### PR TITLE
docs(readme): refresh benchmarks and grammar status

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,15 +211,15 @@ cpu: Intel(R) Core(TM) Ultra 9 285
 
 | Runtime | Full parse | Incremental (1-byte edit) | Incremental (no edit) |
 |---|---:|---:|---:|
-| Native C (pure C runtime) | 1.76 ms | 101.7 μs | 100.4 μs |
-| CGo binding (C runtime via cgo) | 1.98 ms | 128.8 μs | 124.5 μs |
-| gotreesitter (pure Go) | 6.77 ms | 2.43 μs | 2.05 ns |
+| Native C (pure C runtime) | 2.42 ms | 140.3 μs | 101.9 μs |
+| CGo binding (C runtime via cgo) | 1.98 ms | 130.0 μs | 202.8 μs |
+| gotreesitter (pure Go) | 6.92 ms | 2.49 μs | 2.08 ns |
 
 On this workload:
 
-- Full parse is ~3.9x slower than native C (~3.4x slower than CGo).
-- Incremental single-byte edits are ~41.9x faster than native C (~53.1x faster than CGo).
-- No-edit reparses are ~49kx faster than native C (~61kx faster than CGo).
+- Full parse is ~2.9x slower than native C (~3.5x slower than CGo).
+- Incremental single-byte edits are ~56.4x faster than native C (~52.3x faster than CGo).
+- No-edit reparses are ~49kx faster than native C (~97.6kx faster than CGo).
 
 <details>
 <summary>Raw benchmark output</summary>
@@ -242,15 +242,15 @@ GOMAXPROCS=1 go test . -run '^$' -tags treesitter_c_bench \
 
 | Benchmark | Median ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| Native C full parse | 1,756,526 | — | — |
-| Native C incremental (1-byte edit) | 101,732 | — | — |
-| Native C incremental (no edit) | 100,385 | — | — |
-| `CTreeSitterGoParseFull` | 1,975,322 | 600 | 6 |
-| `CTreeSitterGoParseIncrementalSingleByteEdit` | 128,830 | 648 | 7 |
-| `CTreeSitterGoParseIncrementalNoEdit` | 124,548 | 600 | 6 |
-| `GoParseFullDFA` | 6,765,290 | 425 | 5 |
-| `GoParseIncrementalSingleByteEditDFA` | 2,426 | 496 | 9 |
-| `GoParseIncrementalNoEditDFA` | 2.045 | 0 | 0 |
+| Native C full parse | 2,416,412 | — | — |
+| Native C incremental (1-byte edit) | 140,266 | — | — |
+| Native C incremental (no edit) | 101,853 | — | — |
+| `CTreeSitterGoParseFull` | 1,984,274 | 600 | 6 |
+| `CTreeSitterGoParseIncrementalSingleByteEdit` | 129,955 | 648 | 7 |
+| `CTreeSitterGoParseIncrementalNoEdit` | 202,811 | 600 | 6 |
+| `GoParseFullDFA` | 6,916,742 | 425 | 5 |
+| `GoParseIncrementalSingleByteEditDFA` | 2,486 | 496 | 9 |
+| `GoParseIncrementalNoEditDFA` | 2.077 | 0 | 0 |
 
 </details>
 
@@ -266,9 +266,9 @@ Emits `bench_out/matrix.json` (machine-readable), `bench_out/matrix.md` (summary
 
 ## Supported languages
 
-206 grammars ship in the registry. 203 currently produce error-free parse trees on smoke samples; 3 are degraded (`disassembly`, `norg`, `vimdoc`). Run `go run ./cmd/parity_report` for current status.
+206 grammars ship in the registry. 205 currently produce error-free parse trees on smoke samples; 1 is degraded (`vimdoc`). Run `go run ./cmd/parity_report` for current status.
 
-- 14 hand-written (😉) Go external scanners (python, elixir, comment, doxygen, foam, nginx, nushell, r, xml, yuck, purescript, typst, html, yaml)
+- 15 hand-written (😉) Go external scanners (python, elixir, comment, doxygen, foam, nginx, nushell, r, xml, yuck, purescript, typst, html, yaml, norg)
 - 8 hand-written Go token sources (authzed, c, go, html, java, json, lua, toml)
 - Remaining languages use the DFA lexer generated from grammar tables
 
@@ -318,9 +318,9 @@ All shipped highlight and tags queries compile (`156/156` highlight, `69/69` tag
 
 ## Known limitations
 
-- **Full-parse throughput**: still slower than the C runtime on cold full parses (currently ~3.9x on the 500-function Go benchmark). Incremental reparsing amortizes this for editor-style workloads.
+- **Full-parse throughput**: still slower than the C runtime on cold full parses (currently ~2.9x on the 500-function Go benchmark). Incremental reparsing amortizes this for editor-style workloads.
 - **GLR safety caps**: The parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity but impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
-- **Degraded grammars**: 3 of 206 grammars are currently degraded: `disassembly`, `norg`, and `vimdoc`. Check `entry.Quality` and `tree.RootNode().HasError()`.
+- **Degraded grammars**: 1 of 206 grammars is currently degraded: `vimdoc`. Check `entry.Quality` and `tree.RootNode().HasError()`.
 
 ## Adding a language
 
@@ -445,7 +445,7 @@ v0.6.0 — 206 grammars, GLR parser, incremental reparsing, query engine, tree c
 Next:
 - Corpus parity testing against C tree-sitter reference output
 - GLR ambiguity overhead reduction for large files
-- Port norg external scanner
+- Stabilize vimdoc parsing to remove final degraded grammar
 - Fuzz coverage expansion
 
 Release history and retroactive notes are tracked in [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
## Summary\n- refresh README benchmark table and ratio bullets using fresh local benchmark runs\n- update supported/degraded grammar counts to current parity report output\n- add norg to the hand-written scanner list\n- update roadmap next-step from norg scanner port to vimdoc stabilization\n\n## Scope\n- docs-only: README.md\n\n## Validation\n- \coverage: parseable=206 total=206 unsupported=0

language	backend	quality	fields	status	notes
ada	dfa		216	ok	
agda	dfa		0	ok	
angular	dfa		137	ok	
apex	dfa		7525	ok	
arduino	dfa		416	ok	
asm	dfa		7	ok	
astro	dfa		0	ok	
authzed	token_source		37	ok	
awk	dfa		66	ok	
bash	dfa		287	ok	
bass	dfa		2	ok	
beancount	dfa		478	ok	
bibtex	dfa		16	ok	
bicep	dfa		29	ok	
bitbake	dfa		195	ok	
blade	dfa		0	ok	
brightscript	dfa		65	ok	
c	token_source		253	ok	
c_sharp	dfa		531	ok	
caddy	dfa		0	ok	
cairo	dfa		177	ok	
capnp	dfa		0	ok	
chatito	dfa		18	ok	
circom	dfa		66	ok	
clojure	dfa		151	ok	
cmake	dfa		0	ok	
cobol	dfa		2066	ok	
comment	dfa		0	ok	
commonlisp	dfa		604	ok	
cooklang	dfa		0	ok	
corn	dfa		0	ok	
cpon	dfa		2	ok	
cpp	dfa		452	ok	
crystal	dfa		566	ok	
css	dfa		0	ok	
csv	dfa		0	ok	
cuda	dfa		418	ok	
cue	dfa		26	ok	
cylc	dfa		58	ok	
d	dfa		82	ok	
dart	dfa		287	ok	
desktop	dfa		5	ok	
devicetree	dfa		90	ok	
dhall	dfa		19	ok	
diff	dfa		3	ok	
disassembly	dfa		0	ok	
djot	dfa		91	ok	
dockerfile	dfa		27	ok	
dot	dfa		9	ok	
doxygen	dfa		17	ok	
dtd	dfa		1	ok	
earthfile	dfa		139	ok	
ebnf	dfa		8	ok	
editorconfig	dfa		7	ok	
eds	dfa		0	ok	
eex	dfa		0	ok	
elisp	dfa		8	ok	
elixir	dfa		47	ok	
elm	dfa		172	ok	
elsa	dfa		4	ok	
embedded_template	dfa		0	ok	
enforce	dfa		233	ok	
erlang	dfa		305	ok	
facility	dfa		5	ok	
faust	dfa		80	ok	
fennel	dfa		277	ok	
fidl	dfa		0	ok	
firrtl	dfa		0	ok	
fish	dfa		26	ok	
foam	dfa		50	ok	
forth	dfa		0	ok	
fortran	dfa		206	ok	
fsharp	dfa		147	ok	
gdscript	dfa		270	ok	
git_config	dfa		1	ok	
git_rebase	dfa		0	ok	
gitattributes	dfa		16	ok	
gitcommit	dfa		1	ok	
gitignore	dfa		27	ok	
gleam	dfa		176	ok	
glsl	dfa		295	ok	
gn	dfa		13	ok	
go	token_source		212	ok	
godot_resource	dfa		0	ok	
gomod	dfa		1	ok	
graphql	dfa		0	ok	
groovy	dfa		197	ok	
hack	dfa		423	ok	
hare	dfa		97	ok	
haskell	dfa		1560	ok	
haxe	dfa		217	ok	
hcl	dfa		2	ok	
heex	dfa		0	ok	
hlsl	dfa		456	ok	
html	token_source		0	ok	
http	dfa		95	ok	
hurl	dfa		8	ok	
hyprlang	dfa		7	ok	
ini	dfa		1	ok	
janet	dfa		0	ok	
java	token_source		565	ok	
javascript	dfa		243	ok	
jinja2	dfa		4	ok	
jq	dfa		47	ok	
jsdoc	dfa		1	ok	
json	token_source		2	ok	
json5	dfa		2	ok	
jsonnet	dfa		23	ok	
julia	dfa		23	ok	
just	dfa		107	ok	
kconfig	dfa		11	ok	
kdl	dfa		6	ok	
kotlin	dfa		17	ok	
ledger	dfa		0	ok	
less	dfa		0	ok	
linkerscript	dfa		95	ok	
liquid	dfa		169	ok	
llvm	dfa		34	ok	
lua	token_source		155	ok	
luau	dfa		145	ok	
make	dfa		144	ok	
markdown	dfa		4	ok	
markdown_inline	dfa		0	ok	
matlab	dfa		45	ok	
mermaid	dfa		0	ok	
meson	dfa		68	ok	
mojo	dfa		308	ok	
move	dfa		74	ok	
nginx	dfa		1	ok	
nickel	dfa		162	ok	
nim	dfa		416	ok	
ninja	dfa		259	ok	
nix	dfa		71	ok	
norg	dfa		146	ok	
nushell	dfa		618	ok	
objc	dfa		288	ok	
ocaml	dfa		254	ok	
odin	dfa		168	ok	
org	dfa		429	ok	
pascal	dfa		730	ok	
pem	dfa		0	ok	
perl	dfa		256	ok	
php	dfa		590	ok	
pkl	dfa		15	ok	
powershell	dfa		36	ok	
prisma	dfa		1	ok	
prolog	dfa		41	ok	
promql	dfa		0	ok	
properties	dfa		2	ok	
proto	dfa		2	ok	
pug	dfa		0	ok	
puppet	dfa		32	ok	
purescript	dfa		108	ok	
python	dfa		342	ok	
ql	dfa		157	ok	
r	dfa		172	ok	
racket	dfa		0	ok	
regex	dfa		0	ok	
rego	dfa		5	ok	
requirements	dfa		3	ok	
rescript	dfa		99	ok	
robot	dfa		35	ok	
ron	dfa		3	ok	
rst	dfa		15	ok	
ruby	dfa		222	ok	
rust	dfa		552	ok	
scala	dfa		601	ok	
scheme	dfa		0	ok	
scss	dfa		14	ok	
smithy	dfa		0	ok	
solidity	dfa		196	ok	
sparql	dfa		38	ok	
sql	dfa		162	ok	
squirrel	dfa		54	ok	
ssh_config	dfa		267	ok	
starlark	dfa		286	ok	
svelte	dfa		9	ok	
swift	dfa		0	ok	
tablegen	dfa		6	ok	
tcl	dfa		61	ok	
teal	dfa		256	ok	
templ	dfa		299	ok	
textproto	dfa		0	ok	
thrift	dfa		45	ok	
tlaplus	dfa		145	ok	
tmux	dfa		4	ok	
todotxt	dfa		0	ok	
toml	token_source		0	ok	
tsx	dfa		830	ok	
turtle	dfa		5	ok	
twig	dfa		0	ok	
typescript	dfa		816	ok	
typst	dfa		28	ok	
uxntal	dfa		6	ok	
v	dfa		435	ok	
verilog	dfa		0	ok	
vhdl	dfa		85	ok	
vimdoc	dfa		3	degraded	DFA cannot parse vimdoc grammar (0 external tokens, root always errors)
vue	dfa		0	ok	
wat	dfa		1	ok	
wgsl	dfa		40	ok	
wolfram	dfa		0	ok	
xml	dfa		4	ok	
yaml	dfa		12	ok	
yuck	dfa		9	ok	
zig	dfa		57	ok	\n- \goos: linux
goarch: amd64
pkg: github.com/odvcencio/gotreesitter
cpu: Intel(R) Core(TM) Ultra 9 285
BenchmarkGoParseFullDFA                      	     142	   6249355 ns/op	   3.09 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     140	   6356486 ns/op	   3.04 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     141	   6343651 ns/op	   3.04 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     139	   6477090 ns/op	   2.98 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     141	   6414492 ns/op	   3.01 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     140	   6325186 ns/op	   3.05 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     139	   6460003 ns/op	   2.99 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     139	   6412512 ns/op	   3.01 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     136	   6828119 ns/op	   2.83 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseFullDFA                      	     130	   6806290 ns/op	   2.83 MB/s	     425 B/op	       5 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  365584	      2368 ns/op	8149.13 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  408386	      2447 ns/op	7885.39 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  403749	      2451 ns/op	7871.42 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  407604	      2431 ns/op	7938.09 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  407782	      2541 ns/op	7593.55 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  379106	      2533 ns/op	7615.60 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  390765	      2516 ns/op	7667.00 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  388928	      2520 ns/op	7655.43 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  387210	      2352 ns/op	8203.43 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalSingleByteEditDFA 	  414608	      2421 ns/op	7968.11 MB/s	     496 B/op	       9 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	449232597	         2.005 ns/op	9620698.87 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	446696464	         1.969 ns/op	9799399.51 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	458113704	         1.938 ns/op	9958153.06 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	466609527	         1.932 ns/op	9986389.70 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	473112256	         1.917 ns/op	10062762.37 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	469122055	         1.923 ns/op	10033445.79 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	460487077	         1.924 ns/op	10025937.30 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	470406216	         1.921 ns/op	10046019.93 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	469980093	         1.870 ns/op	10316903.90 MB/s	       0 B/op	       0 allocs/op
BenchmarkGoParseIncrementalNoEditDFA         	490562824	         1.873 ns/op	10303224.17 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/odvcencio/gotreesitter	38.939s\n- \goos: linux
goarch: amd64
pkg: github.com/odvcencio/gotreesitter/cgo_harness
cpu: Intel(R) Core(TM) Ultra 9 285
BenchmarkCTreeSitterGoParseFull                      	     488	   1839820 ns/op	  10.49 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     496	   1826475 ns/op	  10.56 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     483	   1824534 ns/op	  10.57 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     492	   1828375 ns/op	  10.55 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     478	   1915065 ns/op	  10.07 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     458	   1923303 ns/op	  10.03 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     462	   1926217 ns/op	  10.02 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     466	   1958041 ns/op	   9.85 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     470	   1943593 ns/op	   9.93 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseFull                      	     468	   1916794 ns/op	  10.07 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    7393	    122727 ns/op	 157.21 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    7300	    121627 ns/op	 158.63 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    7302	    124447 ns/op	 155.04 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    6750	    134053 ns/op	 143.93 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    6826	    133119 ns/op	 144.94 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    6872	    133644 ns/op	 144.37 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    7242	    132541 ns/op	 145.57 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    6051	    127990 ns/op	 150.75 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    7226	    122214 ns/op	 157.87 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit 	    6871	    124661 ns/op	 154.77 MB/s	     648 B/op	       7 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7382	    119731 ns/op	 161.14 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7581	    119680 ns/op	 161.21 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    8154	    115665 ns/op	 166.81 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7807	    114922 ns/op	 167.89 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7742	    114982 ns/op	 167.80 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7864	    116024 ns/op	 166.29 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7484	    115446 ns/op	 167.13 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7854	    115840 ns/op	 166.56 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    8049	    115669 ns/op	 166.80 MB/s	     600 B/op	       6 allocs/op
BenchmarkCTreeSitterGoParseIncrementalNoEdit         	    7705	    114939 ns/op	 167.86 MB/s	     600 B/op	       6 allocs/op
PASS
ok  	github.com/odvcencio/gotreesitter/cgo_harness	29.236s\n- \source_bytes=19294
pure_c_full_ns_op=1650358.78
pure_c_inc_edit_ns_op=97458.98
pure_c_inc_noedit_ns_op=99063.18
pure_c_inc_edit_random_ns_op=3295190.57\n