### PR TITLE
grammars: prune unused functions

### DIFF
--- a/grammars/norg_scanner.go
+++ b/grammars/norg_scanner.go
@@ -146,14 +146,14 @@ const (
 
 // norgState is the persistent scanner state.
 type norgState struct {
-	previous         rune
-	current          rune
-	tagContext       norgTagType
-	tagLevel         int
-	inLinkLocation   bool
-	lastToken        int
-	parsedChars      int
-	activeModifiers  uint16 // bitset for (BOLD..INLINE_MACRO) open/close pairs
+	previous        rune
+	current         rune
+	tagContext      norgTagType
+	tagLevel        int
+	inLinkLocation  bool
+	lastToken       int
+	parsedChars     int
+	activeModifiers uint16 // bitset for (BOLD..INLINE_MACRO) open/close pairs
 }
 
 const norgSymBase gotreesitter.Symbol = 3
@@ -179,7 +179,7 @@ func (s *norgState) resetMods() { s.activeModifiers = 0 }
 // NorgExternalScanner handles norg markup disambiguation.
 type NorgExternalScanner struct{}
 
-func (NorgExternalScanner) Create() any  { return &norgState{tagContext: norgTagNone} }
+func (NorgExternalScanner) Create() any   { return &norgState{tagContext: norgTagNone} }
 func (NorgExternalScanner) Destroy(_ any) {}
 
 func (NorgExternalScanner) Serialize(payload any, buf []byte) int {
@@ -237,10 +237,6 @@ func (NorgExternalScanner) Deserialize(payload any, buf []byte) {
 func (NorgExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	s := payload.(*norgState)
 	return norgScan(s, lexer, validSymbols)
-}
-
-func norgIsValid(valid []bool, tok int) bool {
-	return tok < len(valid) && valid[tok]
 }
 
 func norgIsNewline(ch rune) bool { return ch == 0 || ch == '\n' || ch == '\r' }

--- a/grammars/support.go
+++ b/grammars/support.go
@@ -15,18 +15,6 @@ const (
 	ParseQualityNone    ParseQuality = "none"    // cannot parse
 )
 
-// qualityFromBackend maps a ParseBackend to a ParseQuality.
-func qualityFromBackend(b ParseBackend) ParseQuality {
-	switch b {
-	case ParseBackendTokenSource, ParseBackendDFA:
-		return ParseQualityFull
-	case ParseBackendDFAPartial:
-		return ParseQualityPartial
-	default:
-		return ParseQualityNone
-	}
-}
-
 // ParseBackend describes how a language can be parsed in this runtime.
 type ParseBackend string
 


### PR DESCRIPTION
This removes two unused functions from the `grammars` package.