### PR TITLE
add(grammargen): combined language/blob generation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project are documented in this file.
 This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 for tags and release notes while still in `0.x`.
 
+## [Unreleased]
+
+### Added
+- `grammargen.GenerateLanguageAndBlob` and `GenerateLanguageAndBlobWithContext` to expose the compiled language and serialized blob from one generation pass without coupling callers to diagnostic reports.
+
 ## [0.7.3] - 2026-03-16
 
 ### Added

--- a/grammargen/encode.go
+++ b/grammargen/encode.go
@@ -29,6 +29,12 @@ func GenerateLanguage(g *Grammar) (*gotreesitter.Language, error) {
 	return GenerateLanguageWithContext(context.Background(), g)
 }
 
+// GenerateLanguageAndBlob compiles a Grammar into both a Language struct and
+// its serialized blob form in a single generation pass.
+func GenerateLanguageAndBlob(g *Grammar) (*gotreesitter.Language, []byte, error) {
+	return GenerateLanguageAndBlobWithContext(context.Background(), g)
+}
+
 // GenerateLanguageWithContext is like GenerateLanguage but accepts a context
 // for cancellation. When the context is cancelled, LR table construction and
 // DFA building abort promptly, allowing the caller to reclaim memory that
@@ -39,6 +45,19 @@ func GenerateLanguageWithContext(ctx context.Context, g *Grammar) (*gotreesitter
 		return nil, err
 	}
 	return report.Language, nil
+}
+
+// GenerateLanguageAndBlobWithContext is like GenerateLanguageAndBlob but
+// accepts a context for cancellation.
+func GenerateLanguageAndBlobWithContext(ctx context.Context, g *Grammar) (*gotreesitter.Language, []byte, error) {
+	report, err := generateWithReportCtx(ctx, g, reportBuildOptions{
+		includeLanguage: true,
+		includeBlob:     true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return report.Language, report.Blob, nil
 }
 
 // allSymbolsSet returns a set containing all symbol IDs from the patterns.


### PR DESCRIPTION
## What does this PR do?

Adds `grammargen.GenerateLanguageAndBlob` and `grammargen.GenerateLanguageAndBlobWithContext` so callers can get both the compiled `Language` and the serialized blob from one generation pass, without having to depend on the diagnostic report API.

This is intended to unblock downstream callers like `danmuji` that want to cache the blob but still need the live `Language` object immediately.

## Why this approach?

The combined generation path already exists internally via `generateWithReportCtx(..., includeLanguage: true, includeBlob: true)` and is exposed indirectly through `GenerateWithReport`. The gap is that callers who only need the operational outputs have to opt into a diagnostics-oriented API.

A small public wrapper keeps the common case direct, preserves the existing `GenerateLanguage` / `GenerateLanguageWithContext` shape, and avoids forcing downstream code to couple to report internals.

## Correctness

- [ ] All existing tests pass (`go test ./...`)
- [ ] New tests added for new behavior
- [ ] 206/206 grammars still smoke-parse (`go test ./grammars/ -run TestSupportedLanguagesParseSmoke`)
- [ ] Correctness snapshots still match (`go test ./grammars/ -run TestCorrectness`)
- [ ] CGo parity holds for affected languages (`go test -tags 'cgo treesitter_c_parity' ./cgo_harness/`)

Notes:
- I have not run the validation matrix on this branch yet.
- I did not add a dedicated test because this is a thin wrapper over the existing combined-generation path rather than new generation logic.

## Performance

- [ ] Ran benchmarks before and after (`go test -bench=. -benchmem -count=5`)
- [ ] No regressions in ns/op, B/op, or allocs/op beyond noise
- [ ] If this is a hot path change, included benchmark numbers in the PR

Notes:
- I have not run benchmarks on this branch yet.
- The purpose of this API is to let downstream callers avoid paying for a second generation pass when they need both outputs.

## Maintainability

- [x] No unnecessary abstractions — code does what it needs to and nothing more
- [x] No speculative features or "while I'm here" cleanup outside the PR's scope
- [x] Scanner ports follow existing conventions (MarkEnd before SetResultSymbol, symbol resolution via ExternalSymbols)
- [x] No new dependencies without justification

Notes:
- The scanner-port item is effectively N/A here because this PR does not touch scanners.

## Self-review

Review your own diff before requesting review from others. Walk through it as if you're seeing it for the first time. Leave comments on your own PR pointing out the notable parts — the tricky bits, the non-obvious decisions, anything a reviewer's eye would naturally land on. Comment on what you think the crux of the solution is and why.

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections and the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

Notes:
- The main thing I would want a second opinion on is whether maintainers want a focused API-level test here, even though the implementation is just exposing an already-used internal path.

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [ ] If touching the parser or lexer: tested with at least 3 diverse grammars
- [ ] If adding a grammar or scanner: verified against upstream C output

Notes:
- The parser/lexer and grammar/scanner-specific items are N/A for this PR. This change only exposes an existing combined-generation path through a narrower public API.
