### PR TITLE
perf(glr): skip recursive frontier descent in stack merge — 8.7x speedup

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -604,14 +604,10 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 		}
 	}
 
-	frontier := -1
 	for i := range a.children {
 		ca := a.children[i]
 		cb := b.children[i]
 		if ca == cb {
-			if ca != nil && !ca.isExtra && (ca.isNamed || len(ca.children) > 0) {
-				frontier = i
-			}
 			continue
 		}
 		if ca == nil || cb == nil {
@@ -636,52 +632,16 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 				return false
 			}
 		}
-		if !ca.isExtra && (ca.isNamed || len(ca.children) > 0) {
-			frontier = i
-		}
 	}
-	if depth == 0 {
-		return true
-	}
-
-	candidates := [8]int{}
-	candidateCount := 0
-	addCandidate := func(idx int) {
-		if idx < 0 {
-			return
-		}
-		for i := 0; i < candidateCount; i++ {
-			if candidates[i] == idx {
-				return
-			}
-		}
-		if candidateCount < len(candidates) {
-			candidates[candidateCount] = idx
-			candidateCount++
-		}
-	}
-	if len(a.children) <= 3 {
-		for i := range a.fieldIDs {
-			if a.fieldIDs[i] == 0 {
-				continue
-			}
-			child := a.children[i]
-			if child == nil || child.isExtra || (!child.isNamed && len(child.children) == 0) {
-				continue
-			}
-			addCandidate(i)
-		}
-	}
-	addCandidate(frontier)
-	if candidateCount == 0 {
-		return true
-	}
-	for i := 0; i < candidateCount; i++ {
-		idx := candidates[i]
-		if !stackEntryNodesEquivalentFrontier(a.children[idx], b.children[idx], depth-1) {
-			return false
-		}
-	}
+	// The shallow comparison above (symbol, byte range, state, productionID,
+	// children count, fieldIDs) is sufficient for merge correctness. The
+	// recursive descent into frontier candidates provided marginally better
+	// deduplication but at enormous cost on grammars with high GLR ambiguity.
+	//
+	// Profiling the Go grammar shows 99.3% multi-stack iterations with up to
+	// 18 parallel stacks. The recursive frontier comparison consumed 82% of
+	// total CPU time due to O(depth^candidates) explosion on every merge check.
+	// Removing it yields an 8.7x speedup with identical parse output.
 	return true
 }
 


### PR DESCRIPTION
## What does this PR do?

Removes the recursive frontier descent in `stackEntryNodesEquivalentFrontier`, keeping only the shallow field comparison. This eliminates the dominant bottleneck for grammars with high GLR ambiguity (Go, and likely others).

## Why this approach?

Profiling the Go grammar on an i5-2400 (6MB L3 cache) revealed that `stackEntryNodesEquivalentFrontier` consumed **82% of total CPU time** during parsing. The Go grammar triggers GLR on 99.3% of parser iterations with up to 18 parallel stacks.

The recursive descent into frontier candidates creates O(depth^candidates) work on every merge check. Since most comparisons are between structurally equivalent stacks (they succeed), the recursion adds cost without rejecting anything — it just confirms what the shallow check already determined.

The shallow comparison already checks: symbol, byte range, parseState, preGotoState, productionID, children count, fieldIDs, and per-child symbol/range/state/flags. This is sufficient for merge correctness.

## Benchmark

Hardware: Intel i5-2400 @ 3.10GHz (4 cores, 6MB L3), Windows 11, Go 1.24

Test file: `lang_go.go` (7.6KB, ~290 lines, functions + methods with pointer receivers)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Per-file parse | 142ms | 16.2ms | **8.7x faster** |
| vs CGo baseline | 25x slower | 2.9x slower | — |
| 152 .go files (serial) | ~40s | 2.4s | **16.7x faster** |
| 152 .go files (4 workers) | ~15s | 1.7s | **8.8x faster** |

### ParseRuntime stats confirming GLR pressure

```
Iterations:              3,169
SingleStackIterations:      23  (0.7%)
MultiStackIterations:    3,146  (99.3%)
MaxStacksSeen:              18
MultiStackGSSNodes:      28,786
```

### CPU profile (before patch)

```
82.35%  stackEntryNodesEquivalentFrontier  (8.82s / 10.71s total)
89.36%  mergeStacksWithScratch
87.58%  gssStacksEqualForLanguage
```

### Note on hardware sensitivity

Your benchmarks show 3.52ms/file (2.0x vs C) on modern hardware for the same grammar. The 25x overhead we measured appears to be cache-sensitive — the recursive tree comparison thrashes L3 cache on smaller/older CPUs. The patch makes the function cache-friendly by eliminating deep pointer chasing.

## Correctness

- [x] All 206 grammar smoke tests pass (`TestSupportedLanguagesParseSmoke`)
- [x] Parse output identical for Go sources (functions, methods with receivers, types, imports, calls, interface embedding)
- [x] Zero parse errors across 152 .go files in a real project
- [x] Query API produces identical results

## Scope

Single function change in `glr.go`: `stackEntryNodesEquivalentFrontier`. No other files modified. 9 lines added, 49 removed.