### PR TITLE
fix(glr): replace unsafe frontier skip with versioned equivalence cache

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -62,11 +62,13 @@ const (
 )
 
 type glrMergeScratch struct {
-	result    []glrStack
-	slots     []glrMergeSlot
-	perKeyCap int
-	language  *Language
-	audit     *runtimeAudit
+	result     []glrStack
+	slots      []glrMergeSlot
+	perKeyCap  int
+	language   *Language
+	audit      *runtimeAudit
+	equivEpoch uint32
+	equivCache []glrNodeEquivCacheEntry
 }
 
 type glrMergeKey struct {
@@ -81,6 +83,16 @@ type glrMergeSlot struct {
 	hashMask   uint64
 	count      int
 	worstIndex int
+}
+
+type glrNodeEquivCacheEntry struct {
+	a        *Node
+	b        *Node
+	aVersion uint32
+	bVersion uint32
+	epoch    uint32
+	depth    uint8
+	result   bool
 }
 
 type glrEntryScratch struct {
@@ -294,6 +306,7 @@ func (s *glrStack) recomputeByteOffset() {
 // identical. Distinct parse paths are preserved.
 func mergeStacks(stacks []glrStack) []glrStack {
 	var scratch glrMergeScratch
+	scratch.beginEquivEpoch()
 	return mergeStacksWithScratch(stacks, &scratch)
 }
 
@@ -339,16 +352,81 @@ func stackHash(s glrStack) uint64 {
 	return h
 }
 
+const glrNodeEquivCacheSize = 32768
+
+func (s *glrMergeScratch) beginEquivEpoch() {
+	if s == nil {
+		return
+	}
+	if s.equivEpoch == ^uint32(0) {
+		clear(s.equivCache)
+		s.equivEpoch = 0
+	}
+	s.equivEpoch++
+	if len(s.equivCache) == 0 {
+		s.equivCache = make([]glrNodeEquivCacheEntry, glrNodeEquivCacheSize)
+	}
+}
+
+func lookupNodeEquivCache(scratch *glrMergeScratch, a, b *Node, depth int) (bool, bool) {
+	if scratch == nil || len(scratch.equivCache) == 0 || scratch.equivEpoch == 0 {
+		return false, false
+	}
+	if uintptr(unsafe.Pointer(a)) > uintptr(unsafe.Pointer(b)) {
+		a, b = b, a
+	}
+	idx := nodeEquivCacheIndex(a, b, depth)
+	entry := scratch.equivCache[idx]
+	if entry.epoch != scratch.equivEpoch || entry.a != a || entry.b != b || entry.depth != uint8(depth) {
+		return false, false
+	}
+	if entry.aVersion != a.equivVersion || entry.bVersion != b.equivVersion {
+		return false, false
+	}
+	return entry.result, true
+}
+
+func storeNodeEquivCache(scratch *glrMergeScratch, a, b *Node, depth int, result bool) {
+	if scratch == nil || len(scratch.equivCache) == 0 || scratch.equivEpoch == 0 || a == nil || b == nil {
+		return
+	}
+	if uintptr(unsafe.Pointer(a)) > uintptr(unsafe.Pointer(b)) {
+		a, b = b, a
+	}
+	idx := nodeEquivCacheIndex(a, b, depth)
+	scratch.equivCache[idx] = glrNodeEquivCacheEntry{
+		a:        a,
+		b:        b,
+		aVersion: a.equivVersion,
+		bVersion: b.equivVersion,
+		epoch:    scratch.equivEpoch,
+		depth:    uint8(depth),
+		result:   result,
+	}
+}
+
+func nodeEquivCacheIndex(a, b *Node, depth int) int {
+	x := uint64(uintptr(unsafe.Pointer(a)))
+	y := uint64(uintptr(unsafe.Pointer(b)))
+	h := x ^ (y + 0x9e3779b97f4a7c15 + (x << 6) + (x >> 2))
+	h ^= uint64(depth) * 0x517cc1b727220a95
+	return int(h & uint64(glrNodeEquivCacheSize-1))
+}
+
 func stackEntriesEqual(a, b []stackEntry) bool {
 	return stackEntriesEqualForLanguage(nil, a, b)
 }
 
 func stackEntriesEqualForLanguage(lang *Language, a, b []stackEntry) bool {
+	return stackEntriesEqualForLanguageWithScratch(nil, lang, a, b)
+}
+
+func stackEntriesEqualForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b []stackEntry) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if a[i].state != b[i].state || !stackEntryNodesEquivalentForLanguage(lang, a[i].node, b[i].node) {
+		if a[i].state != b[i].state || !stackEntryNodesEquivalentForLanguageWithScratch(scratch, lang, a[i].node, b[i].node) {
 			return false
 		}
 	}
@@ -360,6 +438,10 @@ func gssStacksEqual(a, b gssStack) bool {
 }
 
 func gssStacksEqualForLanguage(lang *Language, a, b gssStack) bool {
+	return gssStacksEqualForLanguageWithScratch(nil, lang, a, b)
+}
+
+func gssStacksEqualForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b gssStack) bool {
 	if a.head == b.head {
 		return true
 	}
@@ -376,7 +458,7 @@ func gssStacksEqualForLanguage(lang *Language, a, b gssStack) bool {
 		if an == bn {
 			return true
 		}
-		if an.entry.state != bn.entry.state || !stackEntryNodesEquivalentForLanguage(lang, an.entry.node, bn.entry.node) {
+		if an.entry.state != bn.entry.state || !stackEntryNodesEquivalentForLanguageWithScratch(scratch, lang, an.entry.node, bn.entry.node) {
 			return false
 		}
 	}
@@ -388,6 +470,10 @@ func stackEquivalent(a, b glrStack) bool {
 }
 
 func stackEquivalentForLanguage(lang *Language, a, b glrStack) bool {
+	return stackEquivalentForLanguageWithScratch(nil, lang, a, b)
+}
+
+func stackEquivalentForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b glrStack) bool {
 	if perfCountersEnabled {
 		perfRecordStackEquivalentCall()
 	}
@@ -395,27 +481,27 @@ func stackEquivalentForLanguage(lang *Language, a, b glrStack) bool {
 		return false
 	}
 	if a.gss.head != nil && b.gss.head != nil {
-		eq := gssStacksEqualForLanguage(lang, a.gss, b.gss)
+		eq := gssStacksEqualForLanguageWithScratch(scratch, lang, a.gss, b.gss)
 		if eq && perfCountersEnabled {
 			perfRecordStackEquivalentTrue()
 		}
 		return eq
 	}
 	if a.gss.head != nil {
-		eq := gssStackEntriesEqualForLanguage(lang, a.gss, b.entries)
+		eq := gssStackEntriesEqualForLanguageWithScratch(scratch, lang, a.gss, b.entries)
 		if eq && perfCountersEnabled {
 			perfRecordStackEquivalentTrue()
 		}
 		return eq
 	}
 	if b.gss.head != nil {
-		eq := gssStackEntriesEqualForLanguage(lang, b.gss, a.entries)
+		eq := gssStackEntriesEqualForLanguageWithScratch(scratch, lang, b.gss, a.entries)
 		if eq && perfCountersEnabled {
 			perfRecordStackEquivalentTrue()
 		}
 		return eq
 	}
-	eq := stackEntriesEqualForLanguage(lang, a.entries, b.entries)
+	eq := stackEntriesEqualForLanguageWithScratch(scratch, lang, a.entries, b.entries)
 	if eq && perfCountersEnabled {
 		perfRecordStackEquivalentTrue()
 	}
@@ -427,6 +513,10 @@ func gssStackEntriesEqual(gss gssStack, entries []stackEntry) bool {
 }
 
 func gssStackEntriesEqualForLanguage(lang *Language, gss gssStack, entries []stackEntry) bool {
+	return gssStackEntriesEqualForLanguageWithScratch(nil, lang, gss, entries)
+}
+
+func gssStackEntriesEqualForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, gss gssStack, entries []stackEntry) bool {
 	if gss.head == nil {
 		return len(entries) == 0
 	}
@@ -439,7 +529,7 @@ func gssStackEntriesEqualForLanguage(lang *Language, gss gssStack, entries []sta
 			return false
 		}
 		e := entries[i]
-		if n.entry.state != e.state || !stackEntryNodesEquivalentForLanguage(lang, n.entry.node, e.node) {
+		if n.entry.state != e.state || !stackEntryNodesEquivalentForLanguageWithScratch(scratch, lang, n.entry.node, e.node) {
 			return false
 		}
 		i--
@@ -477,7 +567,7 @@ func stackEntryNodesEquivalent(a, b *Node) bool {
 		return true
 	}
 	if stackNodeNeedsDeepEquivalent(a) || stackNodeNeedsDeepEquivalent(b) {
-		return stackEntryNodesEquivalentFrontier(a, b, stackEquivalentGenericFrontierDepthLimit)
+		return stackEntryNodesEquivalentFrontierWithScratch(nil, a, b, stackEquivalentGenericFrontierDepthLimit)
 	}
 	for i := range a.children {
 		ca := a.children[i]
@@ -521,6 +611,10 @@ func stackNodeNeedsDeepEquivalent(n *Node) bool {
 }
 
 func stackEntryNodesEquivalentForLanguage(lang *Language, a, b *Node) bool {
+	return stackEntryNodesEquivalentForLanguageWithScratch(nil, lang, a, b)
+}
+
+func stackEntryNodesEquivalentForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b *Node) bool {
 	if lang != nil && (lang.Name == "c_sharp" || lang.Name == "bash" || len(lang.AliasSequences) > 0) {
 		depthLimit := stackEquivalentFrontierDepthLimit
 		if lang.Name == "bash" {
@@ -530,7 +624,7 @@ func stackEntryNodesEquivalentForLanguage(lang *Language, a, b *Node) bool {
 		} else if depthLimit < 10 {
 			depthLimit = 10
 		}
-		if !stackEntryNodesEquivalentFrontier(a, b, depthLimit) {
+		if !stackEntryNodesEquivalentFrontierWithScratch(scratch, a, b, depthLimit) {
 			return false
 		}
 		if lang.Name == "bash" || lang.Name != "c_sharp" {
@@ -546,7 +640,7 @@ func stackEntryNodesEquivalentForLanguage(lang *Language, a, b *Node) bool {
 				if child == nil || child.isExtra || (!child.isNamed && len(child.children) == 0) {
 					continue
 				}
-				if !stackEntryNodesEquivalentFrontier(child, b.children[i], depthLimit-1) {
+				if !stackEntryNodesEquivalentFrontierWithScratch(scratch, child, b.children[i], depthLimit-1) {
 					return false
 				}
 				compared++
@@ -559,7 +653,7 @@ func stackEntryNodesEquivalentForLanguage(lang *Language, a, b *Node) bool {
 				if child == nil || child.isExtra || (!child.isNamed && len(child.children) == 0) {
 					continue
 				}
-				if !stackEntryNodesEquivalentFrontier(child, b.children[i], depthLimit-1) {
+				if !stackEntryNodesEquivalentFrontierWithScratch(scratch, child, b.children[i], depthLimit-1) {
 					return false
 				}
 				compared++
@@ -571,13 +665,25 @@ func stackEntryNodesEquivalentForLanguage(lang *Language, a, b *Node) bool {
 }
 
 func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
+	return stackEntryNodesEquivalentFrontierWithScratch(nil, a, b, depth)
+}
+
+func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b *Node, depth int) bool {
+	if a != nil && b != nil {
+		if hit, ok := lookupNodeEquivCache(scratch, a, b, depth); ok {
+			return hit
+		}
+	}
 	if a == b {
+		storeNodeEquivCache(scratch, a, b, depth, true)
 		return true
 	}
 	if a == nil || b == nil {
+		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
 	if a.symbol != b.symbol {
+		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
 	if a.startByte != b.startByte ||
@@ -590,27 +696,36 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 		a.preGotoState != b.preGotoState ||
 		a.productionID != b.productionID ||
 		len(a.children) != len(b.children) {
+		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
 	if a.hasError && b.hasError {
+		storeNodeEquivCache(scratch, a, b, depth, true)
 		return true
 	}
 	if len(a.fieldIDs) != len(b.fieldIDs) {
+		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
 	for i := range a.fieldIDs {
 		if a.fieldIDs[i] != b.fieldIDs[i] {
+			storeNodeEquivCache(scratch, a, b, depth, false)
 			return false
 		}
 	}
 
+	frontier := -1
 	for i := range a.children {
 		ca := a.children[i]
 		cb := b.children[i]
 		if ca == cb {
+			if ca != nil && !ca.isExtra && (ca.isNamed || len(ca.children) > 0) {
+				frontier = i
+			}
 			continue
 		}
 		if ca == nil || cb == nil {
+			storeNodeEquivCache(scratch, a, b, depth, false)
 			return false
 		}
 		if ca.symbol != cb.symbol ||
@@ -625,23 +740,65 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 			ca.productionID != cb.productionID ||
 			len(ca.children) != len(cb.children) ||
 			len(ca.fieldIDs) != len(cb.fieldIDs) {
+			storeNodeEquivCache(scratch, a, b, depth, false)
 			return false
 		}
 		for j := range ca.fieldIDs {
 			if ca.fieldIDs[j] != cb.fieldIDs[j] {
+				storeNodeEquivCache(scratch, a, b, depth, false)
 				return false
 			}
 		}
+		if !ca.isExtra && (ca.isNamed || len(ca.children) > 0) {
+			frontier = i
+		}
 	}
-	// The shallow comparison above (symbol, byte range, state, productionID,
-	// children count, fieldIDs) is sufficient for merge correctness. The
-	// recursive descent into frontier candidates provided marginally better
-	// deduplication but at enormous cost on grammars with high GLR ambiguity.
-	//
-	// Profiling the Go grammar shows 99.3% multi-stack iterations with up to
-	// 18 parallel stacks. The recursive frontier comparison consumed 82% of
-	// total CPU time due to O(depth^candidates) explosion on every merge check.
-	// Removing it yields an 8.7x speedup with identical parse output.
+	if depth == 0 {
+		storeNodeEquivCache(scratch, a, b, depth, true)
+		return true
+	}
+
+	candidates := [8]int{}
+	candidateCount := 0
+	addCandidate := func(idx int) {
+		if idx < 0 {
+			return
+		}
+		for i := 0; i < candidateCount; i++ {
+			if candidates[i] == idx {
+				return
+			}
+		}
+		if candidateCount < len(candidates) {
+			candidates[candidateCount] = idx
+			candidateCount++
+		}
+	}
+	if len(a.children) <= 3 {
+		for i := range a.fieldIDs {
+			if a.fieldIDs[i] == 0 {
+				continue
+			}
+			child := a.children[i]
+			if child == nil || child.isExtra || (!child.isNamed && len(child.children) == 0) {
+				continue
+			}
+			addCandidate(i)
+		}
+	}
+	addCandidate(frontier)
+	if candidateCount == 0 {
+		storeNodeEquivCache(scratch, a, b, depth, true)
+		return true
+	}
+	for i := 0; i < candidateCount; i++ {
+		idx := candidates[i]
+		if !stackEntryNodesEquivalentFrontierWithScratch(scratch, a.children[idx], b.children[idx], depth-1) {
+			storeNodeEquivCache(scratch, a, b, depth, false)
+			return false
+		}
+	}
+	storeNodeEquivCache(scratch, a, b, depth, true)
 	return true
 }
 
@@ -783,7 +940,7 @@ func preferOverflowCandidate(candidate, incumbent *glrStack, candidateHash, incu
 	return candidateHash > incumbentHash
 }
 
-func mergeStacksSmallForLanguage(alive []glrStack, lang *Language) []glrStack {
+func mergeStacksSmallForLanguage(alive []glrStack, scratch *glrMergeScratch, lang *Language) []glrStack {
 	if len(alive) <= 1 {
 		return alive
 	}
@@ -796,7 +953,7 @@ func mergeStacksSmallForLanguage(alive []glrStack, lang *Language) []glrStack {
 			if mergeKeyForStack(result[j]) != key {
 				continue
 			}
-			if stackEquivalentForLanguage(lang, result[j], stack) {
+			if stackEquivalentForLanguageWithScratch(scratch, lang, result[j], stack) {
 				duplicateIndex = j
 				break
 			}
@@ -843,10 +1000,11 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 	}
 	if scratch == nil {
 		local := glrMergeScratch{}
+		local.beginEquivEpoch()
 		scratch = &local
 	}
 	if len(alive) <= 4 {
-		result := mergeStacksSmallForLanguage(alive, scratch.language)
+		result := mergeStacksSmallForLanguage(alive, scratch, scratch.language)
 		if perfCountersEnabled {
 			perfRecordMergeOut(len(result))
 		}
@@ -902,7 +1060,7 @@ func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrSt
 				hashMatched = true
 				idx := slot.indices[j]
 				existing := &result[idx]
-				if stackEquivalentForLanguage(scratch.language, *existing, stack) {
+				if stackEquivalentForLanguageWithScratch(scratch, scratch.language, *existing, stack) {
 					duplicateIndex = idx
 					break
 				}

--- a/glr.go
+++ b/glr.go
@@ -604,14 +604,10 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 		}
 	}
 
-	frontier := -1
 	for i := range a.children {
 		ca := a.children[i]
 		cb := b.children[i]
 		if ca == cb {
-			if ca != nil && !ca.isExtra && (ca.isNamed || len(ca.children) > 0) {
-				frontier = i
-			}
 			continue
 		}
 		if ca == nil || cb == nil {
@@ -636,52 +632,16 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 				return false
 			}
 		}
-		if !ca.isExtra && (ca.isNamed || len(ca.children) > 0) {
-			frontier = i
-		}
 	}
-	if depth == 0 {
-		return true
-	}
-
-	candidates := [8]int{}
-	candidateCount := 0
-	addCandidate := func(idx int) {
-		if idx < 0 {
-			return
-		}
-		for i := 0; i < candidateCount; i++ {
-			if candidates[i] == idx {
-				return
-			}
-		}
-		if candidateCount < len(candidates) {
-			candidates[candidateCount] = idx
-			candidateCount++
-		}
-	}
-	if len(a.children) <= 3 {
-		for i := range a.fieldIDs {
-			if a.fieldIDs[i] == 0 {
-				continue
-			}
-			child := a.children[i]
-			if child == nil || child.isExtra || (!child.isNamed && len(child.children) == 0) {
-				continue
-			}
-			addCandidate(i)
-		}
-	}
-	addCandidate(frontier)
-	if candidateCount == 0 {
-		return true
-	}
-	for i := 0; i < candidateCount; i++ {
-		idx := candidates[i]
-		if !stackEntryNodesEquivalentFrontier(a.children[idx], b.children[idx], depth-1) {
-			return false
-		}
-	}
+	// The shallow comparison above (symbol, byte range, state, productionID,
+	// children count, fieldIDs) is sufficient for merge correctness. The
+	// recursive descent into frontier candidates provided marginally better
+	// deduplication but at enormous cost on grammars with high GLR ambiguity.
+	//
+	// Profiling the Go grammar shows 99.3% multi-stack iterations with up to
+	// 18 parallel stacks. The recursive frontier comparison consumed 82% of
+	// total CPU time due to O(depth^candidates) explosion on every merge check.
+	// Removing it yields an 8.7x speedup with identical parse output.
 	return true
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1131,6 +1131,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		defer closer.Close()
 	}
 	scratch := acquireParserScratch()
+	scratch.merge.beginEquivEpoch()
 	if deferParentLinks {
 		scratch.gss.initialCap = p.fullGSSHintCapacity()
 	} else {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -80,6 +80,7 @@ func (p *Parser) pushOrExtendErrorNode(s *glrStack, state StateID, tok Token, no
 			top.endByte = tok.EndByte
 			top.endPoint = tok.EndPoint
 			top.hasError = true
+			nodeBumpEquivVersion(top)
 			if s.byteOffset < top.endByte {
 				s.byteOffset = top.endByte
 			}
@@ -464,6 +465,7 @@ func (p *Parser) applyReduceActionFromGSS(s *glrStack, act ParseAction, tok Toke
 		child.productionID = act.ProductionID
 		child.preGotoState = topState
 		child.parseState = targetState
+		nodeBumpEquivVersion(child)
 		p.pushStackNode(s, targetState, child, entryScratch, gssScratch)
 		for i := reducedEnd; i < actualEnd; i++ {
 			extra := windowEntries[i].node
@@ -471,6 +473,7 @@ func (p *Parser) applyReduceActionFromGSS(s *glrStack, act ParseAction, tok Toke
 				continue
 			}
 			extra.parseState = targetState
+			nodeBumpEquivVersion(extra)
 			p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 		}
 		s.score += int(act.DynamicPrecedence)
@@ -520,6 +523,7 @@ func (p *Parser) applyReduceActionFromGSS(s *glrStack, act ParseAction, tok Toke
 			continue
 		}
 		extra.parseState = targetState
+		nodeBumpEquivVersion(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 
@@ -1899,6 +1903,7 @@ func (p *Parser) applyReduceAction(s *glrStack, act ParseAction, tok Token, anyR
 		child.productionID = act.ProductionID
 		child.preGotoState = window.topState
 		child.parseState = targetState
+		nodeBumpEquivVersion(child)
 		p.pushStackNode(s, targetState, child, entryScratch, gssScratch)
 		for i := trailingStart; i < trailingEnd; i++ {
 			extra := entries[i].node
@@ -1906,6 +1911,7 @@ func (p *Parser) applyReduceAction(s *glrStack, act ParseAction, tok Token, anyR
 				continue
 			}
 			extra.parseState = targetState
+			nodeBumpEquivVersion(extra)
 			p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 		}
 		s.score += int(act.DynamicPrecedence)
@@ -1952,6 +1958,7 @@ func (p *Parser) applyReduceAction(s *glrStack, act ParseAction, tok Token, anyR
 			continue
 		}
 		extra.parseState = targetState
+		nodeBumpEquivVersion(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -35,9 +35,27 @@ type Node struct {
 	hasError     bool
 	dirty        bool // set by Tree.Edit for nodes touched by edits
 	productionID uint16
+	equivVersion uint32
 	parent       *Node
 	childIndex   int
 	ownerArena   *nodeArena
+}
+
+func nodeInitEquivVersion(n *Node) {
+	if n == nil {
+		return
+	}
+	n.equivVersion = 1
+}
+
+func nodeBumpEquivVersion(n *Node) {
+	if n == nil {
+		return
+	}
+	n.equivVersion++
+	if n.equivVersion == 0 {
+		n.equivVersion = 1
+	}
 }
 
 func defaultFieldSources(fieldIDs []FieldID) []uint8 {
@@ -483,7 +501,7 @@ func (n *Node) NamedDescendantForPointRange(startPoint, endPoint Point) *Node {
 
 // NewLeafNode creates a terminal/leaf node.
 func NewLeafNode(sym Symbol, named bool, startByte, endByte uint32, startPoint, endPoint Point) *Node {
-	return &Node{
+	n := &Node{
 		symbol:     sym,
 		isNamed:    named,
 		startByte:  startByte,
@@ -492,6 +510,8 @@ func NewLeafNode(sym Symbol, named bool, startByte, endByte uint32, startPoint, 
 		endPoint:   endPoint,
 		childIndex: -1,
 	}
+	nodeInitEquivVersion(n)
+	return n
 }
 
 func populateParentNode(n *Node, children []*Node) {
@@ -634,6 +654,7 @@ func newParentNode(arena *nodeArena, sym Symbol, named bool, children []*Node, f
 	n.productionID = productionID
 	n.childIndex = -1
 	populateParentNode(n, children)
+	nodeInitEquivVersion(n)
 	return n
 }
 
@@ -666,6 +687,7 @@ func newLeafNodeInArena(arena *nodeArena, sym Symbol, named bool, startByte, end
 	n.endPoint = endPoint
 	n.childIndex = -1
 	n.ownerArena = arena
+	nodeInitEquivVersion(n)
 	if arena.audit != nil {
 		arena.audit.recordNodeAlloc(n, runtimeAuditNodeKindLeaf)
 	}
@@ -697,6 +719,7 @@ func newParentNodeInArenaWithFieldSources(arena *nodeArena, sym Symbol, named bo
 	n.productionID = productionID
 	n.childIndex = -1
 	populateParentNode(n, children)
+	nodeInitEquivVersion(n)
 	if arena.audit != nil {
 		arena.audit.recordNodeAlloc(n, runtimeAuditNodeKindParent)
 	}
@@ -728,6 +751,7 @@ func newParentNodeInArenaNoLinksWithFieldSources(arena *nodeArena, sym Symbol, n
 	n.productionID = productionID
 	n.childIndex = -1
 	populateParentNodeNoLinks(n, children, trackChildErrors)
+	nodeInitEquivVersion(n)
 	if arena.audit != nil {
 		arena.audit.recordNodeAlloc(n, runtimeAuditNodeKindParent)
 	}


### PR DESCRIPTION
## Summary

This follows up on #14 with a correctness-safe version of the same idea.

The original PR proves there is a large win available in GLR stack merge equivalence, but the raw frontier-skip approach is not correct: it fails the existing alias-language tripwire (`TestStackEquivalentForAliasLanguageRejectsDeepAliasMismatch`).

This branch replaces that unsafe shortcut with a parse-scoped, versioned equivalence cache. It keeps the win, but only reuses frontier-comparison results while the compared nodes are still in the same parse epoch and at the same mutation version.

## What Changed

- add a direct-mapped node-equivalence cache to `glrMergeScratch`
- key cache entries by node pair, frontier depth, parse epoch, and node mutation version
- bump node equivalence versions at the parse-time mutation sites that can invalidate cached comparisons
- start a fresh cache epoch for each parse / merge scratch lifetime
- route stack merge equivalence through the scratch-aware cache path

## Why This Instead of #14's Frontier Skip

#14 improves the macro benchmark because recursive frontier descent is dominating merge cost, but it also conflates parse states that still differ in alias-sensitive deep structure.

This version attacks the same hotspot without weakening equivalence semantics:

- no grammar-specific shortcuts
- no alias-language carveouts
- no reuse across parse epochs
- no reuse after in-place node mutation

## Validation

Correctness:

- `TestStackEquivalentForAliasLanguageRejectsDeepAliasMismatch` passes
- `TestMergeStacksSmallPathKeepsDistinctDeepStructures` passes
- Go real-corpus Docker lane: `25/25` no-error, sexpr parity, deep parity
- TypeScript real-corpus Docker lane: `24/25`, which matches `main`
- Bash bounded Docker lane still times out, but `main` times out the same way under the same 8 GiB single-container preset
- C# bounded Docker lane matches `main` exactly: `10/25` no-error, `9/25` sexpr parity, `9/25` deep parity

Performance:

`benchstat` over 5 runs (`GOMAXPROCS=1`, `-benchmem`, `-benchtime=750ms`):

- `BenchmarkGoParseRealworldLargeProcDFA`: `9.871s -> 1.868s` (`-81.08%`, `p=0.008`)
- `BenchmarkGoParseFullDFA`: no meaningful change
- `BenchmarkGoParseIncrementalSingleByteEditDFA`: no meaningful change
- `BenchmarkGoParseIncrementalNoEditDFA`: slight improvement (`-2.29%`)

Profiling:

- `main`: `stackEntryNodesEquivalentFrontier` was ~`78%` flat CPU on the realworld Go case
- this branch: the hotspot shifts to cache lookup/store, and frontier descent itself drops out of the dominant position

## Relationship to #14

This should be read as a replacement / successor to #14, not a rejection of its core observation. The recursive frontier walk really is the hot path. The issue is just that skipping it outright is too aggressive for correctness.
