### PR TITLE
perf: fix GLR parser unusable on large Go files (147KB pb.go: 4+ min → 420ms)

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -426,7 +426,7 @@ func (a *nodeArena) allocNodeFast() *Node {
 	if a.used < len(a.nodes) {
 		n := &a.nodes[a.used]
 		a.used++
-		*n = Node{}
+		// Node is already zeroed: fresh slabs by make(), reused slabs by reset().
 		return n
 	}
 	return a.allocNodeSlow()
@@ -459,7 +459,7 @@ func (a *nodeArena) allocNodeSlow() *Node {
 		a.nodeSlabCursor = i
 		a.used++
 		n := &slab.data[idx]
-		*n = Node{}
+		// Node is already zeroed: fresh slabs by make(), reused slabs by reset().
 		return n
 	}
 }

--- a/glr.go
+++ b/glr.go
@@ -352,7 +352,7 @@ func stackHash(s glrStack) uint64 {
 	return h
 }
 
-const glrNodeEquivCacheSize = 32768
+const glrNodeEquivCacheSize = 131072
 
 func (s *glrMergeScratch) beginEquivEpoch() {
 	if s == nil {
@@ -409,6 +409,8 @@ func nodeEquivCacheIndex(a, b *Node, depth int) int {
 	x := uint64(uintptr(unsafe.Pointer(a)))
 	y := uint64(uintptr(unsafe.Pointer(b)))
 	h := x ^ (y + 0x9e3779b97f4a7c15 + (x << 6) + (x >> 2))
+	// Mix in symbol to improve distribution for arena-sequential pointers.
+	h ^= (uint64(a.symbol) | uint64(b.symbol)<<16) * 0x85ebca6b
 	h ^= uint64(depth) * 0x517cc1b727220a95
 	return int(h & uint64(glrNodeEquivCacheSize-1))
 }
@@ -669,33 +671,30 @@ func stackEntryNodesEquivalentFrontier(a, b *Node, depth int) bool {
 }
 
 func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b *Node, depth int) bool {
-	if a != nil && b != nil {
-		if hit, ok := lookupNodeEquivCache(scratch, a, b, depth); ok {
-			return hit
-		}
-	}
+	// Cheap checks first — skip cache for trivial cases.
 	if a == b {
-		storeNodeEquivCache(scratch, a, b, depth, true)
 		return true
 	}
 	if a == nil || b == nil {
-		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
-	if a.symbol != b.symbol {
-		storeNodeEquivCache(scratch, a, b, depth, false)
-		return false
-	}
-	if a.startByte != b.startByte ||
+	if a.symbol != b.symbol ||
+		a.startByte != b.startByte ||
 		a.endByte != b.endByte ||
-		a.isExtra != b.isExtra ||
+		len(a.children) != len(b.children) {
+		return false
+	}
+	// Cache lookup only for non-trivial comparisons.
+	if hit, ok := lookupNodeEquivCache(scratch, a, b, depth); ok {
+		return hit
+	}
+	if a.isExtra != b.isExtra ||
 		a.isNamed != b.isNamed ||
 		a.isMissing != b.isMissing ||
 		a.hasError != b.hasError ||
 		a.parseState != b.parseState ||
 		a.preGotoState != b.preGotoState ||
-		a.productionID != b.productionID ||
-		len(a.children) != len(b.children) {
+		a.productionID != b.productionID {
 		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}

--- a/glr.go
+++ b/glr.go
@@ -681,22 +681,19 @@ func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b
 	if a.symbol != b.symbol ||
 		a.startByte != b.startByte ||
 		a.endByte != b.endByte ||
-		len(a.children) != len(b.children) {
-		return false
-	}
-	// Cache lookup only for non-trivial comparisons.
-	if hit, ok := lookupNodeEquivCache(scratch, a, b, depth); ok {
-		return hit
-	}
-	if a.isExtra != b.isExtra ||
+		len(a.children) != len(b.children) ||
+		a.isExtra != b.isExtra ||
 		a.isNamed != b.isNamed ||
 		a.isMissing != b.isMissing ||
 		a.hasError != b.hasError ||
 		a.parseState != b.parseState ||
 		a.preGotoState != b.preGotoState ||
 		a.productionID != b.productionID {
-		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
+	}
+	// Cache lookup only for recursive children comparison.
+	if hit, ok := lookupNodeEquivCache(scratch, a, b, depth); ok {
+		return hit
 	}
 	if a.hasError && b.hasError {
 		storeNodeEquivCache(scratch, a, b, depth, true)

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -229,6 +229,31 @@ func (s *gssScratch) allocNode(entry stackEntry, prev *gssNode, depth int) *gssN
 	if s == nil {
 		return &gssNode{entry: entry, prev: prev, depth: depth, hash: hash}
 	}
+
+	// Fast path: current slab has space. Kept small for inlining.
+	if cur := s.slabCursor; cur >= 0 && cur < len(s.slabs) {
+		slab := &s.slabs[cur]
+		if slab.used < len(slab.data) {
+			idx := slab.used
+			slab.used++
+			s.usedTotal++
+			if s.singleStackMode {
+				s.singleStackAllocs++
+			} else {
+				s.multiStackAllocs++
+			}
+			n := &slab.data[idx]
+			n.entry = entry
+			n.prev = prev
+			n.depth = depth
+			n.hash = hash
+			return n
+		}
+	}
+	return s.allocNodeSlow(entry, prev, depth, hash)
+}
+
+func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth int, hash uint64) *gssNode {
 	if len(s.slabs) == 0 {
 		capacity := defaultGSSNodeSlabCap
 		if s.initialCap > capacity {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -340,6 +340,9 @@ func TestEffectiveFullParseInitialMaxStacks(t *testing.T) {
 	if got := effectiveFullParseInitialMaxStacks(&Language{Name: "rust"}, maxGLRStacks); got != 2 {
 		t.Fatalf("effectiveFullParseInitialMaxStacks(rust) = %d, want 2", got)
 	}
+	if got := effectiveFullParseInitialMaxStacks(&Language{Name: "go"}, maxGLRStacks); got != 2 {
+		t.Fatalf("effectiveFullParseInitialMaxStacks(go) = %d, want 2", got)
+	}
 	if got := effectiveFullParseInitialMaxStacks(&Language{Name: "css"}, 16); got != 16 {
 		t.Fatalf("effectiveFullParseInitialMaxStacks(css, explicit override) = %d, want 16", got)
 	}

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -262,6 +262,14 @@ func effectiveFullParseInitialMaxStacks(lang *Language, initialMaxStacks int) in
 		if initialMaxStacks == maxGLRStacks {
 			initialMaxStacks = 2
 		}
+	case "go":
+		// Go's grammar triggers GLR ambiguity on type assertions, composite
+		// literals, and generic-like syntax in generated protobuf files.
+		// The default cap of 8 causes exponential stack blowup on large files.
+		// A tight default keeps parsing fast; retry widening handles edge cases.
+		if initialMaxStacks == maxGLRStacks {
+			initialMaxStacks = 2
+		}
 	case "ruby":
 		// Ruby's ambiguous syntax (optional parentheses, flexible method calls,
 		// complex string/regex literals) requires wider GLR stacks than the


### PR DESCRIPTION
## Problem

In its current state, gotreesitter is **unusable for scanning large files** — parsing a 147KB protobuf-generated Go file (`backoffice.pb.go`, 3420 lines) takes **over 4 minutes** and consumes **9+ GB of RAM**. For comparison, the C tree-sitter reference implementation parses the same file in under 1 second.

According to the README benchmarks, full-parsing a 19KB file costs ~4.2ms, which scales linearly to ~32ms for 147KB. The raw parse itself is not the bottleneck — the problem is in the **GLR stack machinery**. Go's grammar triggers GLR ambiguity on type assertions, composite literals, and generic-like syntax patterns that are extremely common in generated protobuf code. With the default `maxGLRStacks=8`, this creates exponential node allocation blowup (~33M `allocNodeFast` calls) and O(N²) pairwise stack equivalence comparisons.

### CPU profile breakdown (before fix, 3-second sample)

| Hotspot | CPU % | Root cause |
|---|---|---|
| `allocNodeFast` | 59% | Redundant zero-fill — nodes already zeroed by `arena.reset()` or `make()` |
| equiv cache + comparison | 24% | Cache thrashing (32K entries for 33M nodes) + expensive field checks before cheap rejection |
| `gssScratch.allocNode` | 11% | Non-inlineable hot path |

## Fix (4 commits)

### 1. Remove redundant node zeroing in `allocNodeFast`/`allocNodeSlow`
Arena lifecycle guarantees that nodes are zero-valued: fresh slabs from `make()` are zero, reused slabs are cleared by `reset()`. The explicit `*n = Node{}` was a redundant write + write-barrier on every allocation (~33M calls).

### 2. Optimize GLR equivalence cache
- **4× larger cache** (32K → 131K entries) to reduce thrashing under heavy GLR workloads
- **Reorder comparisons**: move cheap field checks (symbol, byte range, children count) *before* cache lookup — trivially-false cases skip the cache entirely
- **Improve hash distribution**: mix in symbol bits for better spread with arena-sequential pointers

### 3. Split `gssScratch.allocNode` into inlineable fast path
The original function exceeded Go's inline budget. Splitting into a small fast path (current slab has space → direct allocation) and a `allocNodeSlow` fallback allows the compiler to inline the hot path.

### 4. Go-specific `maxGLRStacks=2`
Go's grammar has few genuine GLR ambiguities compared to Ruby or C#. The default cap of 8 causes exponential stack blowup on large generated files. Setting the default to 2 — consistent with the approach already used for JS/TS/Python/Rust/CSS — keeps parsing fast while the existing retry-widening mechanism handles edge cases.

## Result

| Metric | Before | After | Improvement |
|---|---|---|---|
| Wall time (147KB pb.go) | 4+ min | 420ms | ~570× |
| Allocations | 9+ GB | 837 MB | ~11× |

All existing tests pass. The fix is backward-compatible — no API changes.