### PR TITLE
fix(arena): add DrainArenaPools and release cursor refs to fix memory retention in long-running processes

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -193,6 +193,23 @@ func (p *nodeArenaPool) release(a *nodeArena) {
 	p.mu.Unlock()
 }
 
+func (p *nodeArenaPool) drain() {
+	p.mu.Lock()
+	p.free = p.free[:0]
+	p.mu.Unlock()
+}
+
+// DrainArenaPools releases all cached arenas from both incremental and full-parse
+// pools. Arenas held in the pool are strong Go references and are not collected
+// by the GC until explicitly drained or the process exits.
+//
+// Call this after a large batch scan (e.g. after WalkAndParse returns) to allow
+// the GC to reclaim the arena memory. The next parse will allocate a fresh arena.
+func DrainArenaPools() {
+	incrementalArenaPool.drain()
+	fullArenaPool.drain()
+}
+
 func nodeCapacityForBytes(slabBytes int) int {
 	nodeSize := int(unsafe.Sizeof(Node{}))
 	if nodeSize <= 0 {

--- a/arena.go
+++ b/arena.go
@@ -195,6 +195,7 @@ func (p *nodeArenaPool) release(a *nodeArena) {
 
 func (p *nodeArenaPool) drain() {
 	p.mu.Lock()
+	clear(p.free) // nil all pointers so GC can collect the arenas
 	p.free = p.free[:0]
 	p.mu.Unlock()
 }

--- a/arena.go
+++ b/arena.go
@@ -195,7 +195,7 @@ func (p *nodeArenaPool) release(a *nodeArena) {
 
 func (p *nodeArenaPool) drain() {
 	p.mu.Lock()
-	clear(p.free) // nil all pointers so GC can collect the arenas
+	clear(p.free[:cap(p.free)]) // nil all pointers so GC can collect the arenas
 	p.free = p.free[:0]
 	p.mu.Unlock()
 }

--- a/incremental.go
+++ b/incremental.go
@@ -115,10 +115,7 @@ func (c *reuseCursor) releaseNodeRefs() {
 	c.oldSource = nil
 	c.newSource = nil
 	if cap(c.stack) > 0 {
-		s := c.stack[:cap(c.stack)]
-		for i := range s {
-			s[i].node = nil
-		}
+		clear(c.stack[:cap(c.stack)])
 		c.stack = c.stack[:0]
 	}
 	if cap(c.cached) > 0 {
@@ -130,10 +127,7 @@ func (c *reuseCursor) releaseNodeRefs() {
 // releaseNodeRefs nils *Node pointers in the scratch buffers.
 func (s *reuseScratch) releaseNodeRefs() {
 	if cap(s.stack) > 0 {
-		sl := s.stack[:cap(s.stack)]
-		for i := range sl {
-			sl[i].node = nil
-		}
+		clear(s.stack[:cap(s.stack)])
 		s.stack = s.stack[:0]
 	}
 	if cap(s.cache) > 0 {

--- a/incremental.go
+++ b/incremental.go
@@ -105,6 +105,43 @@ func (c *reuseCursor) commitScratch(scratch *reuseScratch) {
 	scratch.cache = c.cached[:0]
 }
 
+// releaseNodeRefs nils all *Node pointers so the GC can collect the arenas
+// they reference. Call before returning a Parser to a pool to prevent arena
+// retention via reuseCursor holding nodes from the last incremental parse.
+// Backing arrays (stack, cached) are kept to avoid re-allocation next parse.
+func (c *reuseCursor) releaseNodeRefs() {
+	c.next = nil
+	c.topLevel = nil
+	c.oldSource = nil
+	c.newSource = nil
+	if cap(c.stack) > 0 {
+		s := c.stack[:cap(c.stack)]
+		for i := range s {
+			s[i].node = nil
+		}
+		c.stack = c.stack[:0]
+	}
+	if cap(c.cached) > 0 {
+		clear(c.cached[:cap(c.cached)])
+		c.cached = c.cached[:0]
+	}
+}
+
+// releaseNodeRefs nils *Node pointers in the scratch buffers.
+func (s *reuseScratch) releaseNodeRefs() {
+	if cap(s.stack) > 0 {
+		sl := s.stack[:cap(s.stack)]
+		for i := range sl {
+			sl[i].node = nil
+		}
+		s.stack = s.stack[:0]
+	}
+	if cap(s.cache) > 0 {
+		clear(s.cache[:cap(s.cache)])
+		s.cache = s.cache[:0]
+	}
+}
+
 func (c *reuseCursor) candidates(start uint32) []*Node {
 	if c == nil {
 		return nil

--- a/parser.go
+++ b/parser.go
@@ -311,6 +311,11 @@ func resetSnippetParser(parser *Parser) {
 	parser.glrTrace = false
 	parser.timeoutMicros = 0
 	parser.cancellationFlag = nil
+	// Release *Node refs so the arenas from the last incremental parse can be
+	// collected by the GC. Without this, a Parser sitting in a sync.Pool keeps
+	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
+	parser.reuseCursor.releaseNodeRefs()
+	parser.reuseScratch.releaseNodeRefs()
 }
 
 // InferredRootSymbol returns the root symbol inferred during parser

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -123,6 +123,9 @@ func (pp *ParserPool) release(p *Parser) {
 	// Release *Node refs so the last-used arena can be GC'd.
 	p.reuseCursor.releaseNodeRefs()
 	p.reuseScratch.releaseNodeRefs()
+	// Drop the recovery sub-parser so its reuseCursor *Node refs (and the
+	// arena they pin) are released.  It is cheap to recreate on next use.
+	p.recoveryParser = nil
 	pp.pool.Put(p)
 }
 

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -120,6 +120,9 @@ func (pp *ParserPool) release(p *Parser) {
 	}
 	// Keep parser state scrubbed before re-adding to the shared pool.
 	pp.applyDefaults(p)
+	// Release *Node refs so the last-used arena can be GC'd.
+	p.reuseCursor.releaseNodeRefs()
+	p.reuseScratch.releaseNodeRefs()
 	pp.pool.Put(p)
 }
 


### PR DESCRIPTION
## Background

I'm integrating gotreesitter as the parsing backend for an MCP code intelligence server that scans codebases on demand. After each scan the process retained ~1.6 GB of heap indefinitely — making it unsuitable for long-running use. Investigation revealed two independent causes.

## Problem 1: No way to release arena memory after a batch operation

`nodeArenaPool` is a custom mutex pool (not `sync.Pool`), designed to aggressively retain arenas between parses to avoid reallocation on the hot path. This is the right tradeoff for short-lived CLI tools. But for a server or daemon, freed arenas accumulate in `free[]` as strong Go references that `runtime.GC()` cannot collect — up to 4 full-parse arenas x ~300 MB each sit in memory until process exit.

This PR adds `DrainArenaPools()` — an explicit release point intended for use after a batch operation is complete:

```go
// After scanning a full codebase:
gotreesitter.DrainArenaPools()
```

The hot-path behavior is unchanged. The caller decides when it's appropriate to trade retained capacity for reclaimed memory.

Also fixes `drain()` to nil pointers before truncating, so the GC can collect freed arenas immediately rather than waiting for the next sweep to discover the slice is empty.

## Problem 2: `reuseCursor` and `recoveryParser` pin arenas inside `sync.Pool`

When a `Parser` is returned to `ParserPool`, it carries live `*Node` references that keep the last-used arena reachable through `sync.Pool`'s victim cache:

- `reuseCursor` / `reuseScratch` hold node pointers from the last incremental parse
- `recoveryParser` (created lazily by `parseForRecovery`) has its own `reuseCursor` with the same problem

`resetSnippetParser` already nils `recoveryParser` for snippet parsers — but `ParserPool.release()` did not. This PR fixes both.

## Results

Scanning a ~300-file Go codebase, 3x GC after scan:

| Metric | Before | After |
|--------|--------|-------|
| Memory post-scan (3x GC) | ~1 648 MB | **6.5 MB** |
| Memory mid-scan (500 ms snapshot) | 228 MB | **177 MB** (-22%) |
| CPU time | 3.75s | 3.87s (+3%, within noise) |

The mid-scan improvement comes from releasing cursor refs on pool return — GC can collect intermediate arenas faster during active scanning.

## Note on `DrainArenaPools` usage

This is intentionally a manual call, not automatic. It is appropriate once after a batch scan completes — not after each individual parse. Calling it during active parsing would defeat the pool's purpose.