### PR TITLE
feat(grammars): export DecodeLanguageBlob for out-of-tree grammar registration

### DIFF
--- a/grammars/blob_decode.go
+++ b/grammars/blob_decode.go
@@ -1,0 +1,31 @@
+package grammars
+
+import (
+	"errors"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// DecodeLanguageBlob decodes a gzip+gob encoded grammar blob (as produced by
+// the ts2go pipeline and stored under grammars/grammar_blobs/*.bin) into a
+// ready-to-use *gotreesitter.Language.
+//
+// This is the public entry point for consumer packages that ship their own
+// grammar blobs via go:embed rather than having the grammar absorbed into
+// gotreesitter's built-in registry. The expected usage pattern is to pair
+// DecodeLanguageBlob with [Register] or [RegisterExternalScanner] from an
+// init() function in the consumer package, so the grammar becomes available
+// through [DetectLanguage], [DetectLanguageByName], and [AllLanguages] without
+// modifying gotreesitter itself.
+//
+// The input bytes are consumed once; the returned Language is safe to cache
+// and reuse across parsers. Returns an error if the input is empty or cannot
+// be decoded (wrong format, truncated data, incompatible schema).
+//
+// See the package example for an end-to-end consumer integration.
+func DecodeLanguageBlob(data []byte) (*gotreesitter.Language, error) {
+	if len(data) == 0 {
+		return nil, errors.New("gotreesitter: DecodeLanguageBlob called with empty data")
+	}
+	return decodeLanguageBlobData("<external>", data)
+}

--- a/grammars/blob_decode_test.go
+++ b/grammars/blob_decode_test.go
@@ -1,0 +1,69 @@
+package grammars_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestDecodeLanguageBlob_Roundtrip exercises the public pathway a consumer
+// package uses: fetch blob bytes (here from the built-in store, but in prod
+// typically from the consumer's own go:embed), decode into a *Language, and
+// verify the result is usable.
+func TestDecodeLanguageBlob_Roundtrip(t *testing.T) {
+	blob := grammars.BlobByName("go")
+	if len(blob) == 0 {
+		t.Fatal("precondition: BlobByName(go) returned empty blob")
+	}
+
+	lang, err := grammars.DecodeLanguageBlob(blob)
+	if err != nil {
+		t.Fatalf("DecodeLanguageBlob: unexpected error: %v", err)
+	}
+	if lang == nil {
+		t.Fatal("DecodeLanguageBlob: returned nil language without error")
+	}
+	if lang.SymbolCount == 0 {
+		t.Error("decoded language has zero SymbolCount; blob decode did not populate grammar tables")
+	}
+	if lang.TokenCount == 0 {
+		t.Error("decoded language has zero TokenCount; blob decode did not populate grammar tables")
+	}
+
+	// The decoded Language must be usable for parsing through the public API.
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse([]byte("package main\n"))
+	if err != nil {
+		t.Fatalf("parser.Parse returned error: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("parser produced no tree for minimal go source")
+	}
+	if tree.RootNode().HasError() {
+		t.Errorf("parser reported error on minimal go source: %s", tree.RootNode().SExpr(lang))
+	}
+}
+
+// TestDecodeLanguageBlob_Garbage ensures the decoder rejects non-blob input
+// with an error instead of panicking — consumers need a predictable failure
+// mode for shipping their own embedded blobs.
+func TestDecodeLanguageBlob_Garbage(t *testing.T) {
+	lang, err := grammars.DecodeLanguageBlob([]byte("not a grammar blob"))
+	if err == nil {
+		t.Fatalf("DecodeLanguageBlob(garbage): expected error, got lang=%v", lang)
+	}
+	if lang != nil {
+		t.Errorf("DecodeLanguageBlob(garbage): expected nil language on error, got non-nil")
+	}
+}
+
+// TestDecodeLanguageBlob_Empty verifies nil/empty input is rejected cleanly.
+func TestDecodeLanguageBlob_Empty(t *testing.T) {
+	if _, err := grammars.DecodeLanguageBlob(nil); err == nil {
+		t.Error("DecodeLanguageBlob(nil): expected error, got nil")
+	}
+	if _, err := grammars.DecodeLanguageBlob([]byte{}); err == nil {
+		t.Error("DecodeLanguageBlob(empty): expected error, got nil")
+	}
+}

--- a/grammars/example_external_grammar_test.go
+++ b/grammars/example_external_grammar_test.go
@@ -1,0 +1,71 @@
+package grammars_test
+
+import (
+	"fmt"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// ExampleDecodeLanguageBlob_externalGrammar demonstrates the full pattern for
+// adding a grammar to gotreesitter from a consumer package, without modifying
+// gotreesitter itself. A language-server or application package ships its own
+// precompiled grammar blob via go:embed and registers it at init() time.
+//
+// This is the recommended path for niche grammars (language servers, DSLs,
+// in-house tooling) that don't belong in gotreesitter's built-in registry.
+//
+// A real consumer would replace the BlobByName call below with an embedded blob:
+//
+//	import _ "embed"
+//
+//	//go:embed qmljs.bin
+//	var qmljsBlob []byte
+//
+//	func init() {
+//	    // 1. Register the hand-ported Go external scanner first so it is
+//	    //    attached when the Language is decoded on first access.
+//	    grammars.RegisterExternalScanner("qmljs", newQMLScanner())
+//
+//	    // 2. Register the language with a lazy loader that decodes the
+//	    //    embedded blob on demand. Consumers own the blob bytes; gotreesitter
+//	    //    just decodes them.
+//	    grammars.Register(grammars.LangEntry{
+//	        Name:           "qmljs",
+//	        Extensions:     []string{".qml"},
+//	        Language:       loadQMLJS,
+//	        GrammarSource:  grammars.GrammarSourceTS2GoBlob,
+//	        HighlightQuery: qmljsHighlights,
+//	    })
+//	}
+//
+//	var loadQMLJS = sync.OnceValue(func() *gotreesitter.Language {
+//	    lang, err := grammars.DecodeLanguageBlob(qmljsBlob)
+//	    if err != nil {
+//	        panic("qmljs grammar blob is corrupt: " + err.Error())
+//	    }
+//	    return lang
+//	})
+//
+// After this init() runs, the grammar is indistinguishable from a built-in:
+// grammars.DetectLanguage("foo.qml") returns the entry, AllLanguages() enumerates
+// it, and syntax highlighting / code fences resolve normally.
+func ExampleDecodeLanguageBlob_externalGrammar() {
+	// Pretend this came from a consumer-side go:embed directive.
+	blob := grammars.BlobByName("go")
+
+	lang, err := grammars.DecodeLanguageBlob(blob)
+	if err != nil {
+		fmt.Println("decode failed:", err)
+		return
+	}
+
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse([]byte("package main\n"))
+	if err != nil {
+		fmt.Println("parse failed:", err)
+		return
+	}
+	fmt.Println("parsed:", !tree.RootNode().HasError())
+	// Output: parsed: true
+}


### PR DESCRIPTION
## Summary

Exports a single new public function, `grammars.DecodeLanguageBlob([]byte) (*gotreesitter.Language, error)`, so consumer packages can ship their own precompiled grammar blobs via `go:embed` and wire them into the registry without modifying gotreesitter itself.

This closes the one API gap preventing fully out-of-tree grammar registration. `Register`, `RegisterExternalScanner`, `RegisterExtension`, and `LangEntry.Language` were already public — the only missing piece was a public "decode these bytes into a `*Language`" entry point. All the plumbing already exists (`decodeLanguageBlobData`), it just wasn't exported.

## Why

Every niche grammar (language servers, in-house DSLs, experimental grammars) currently has to be absorbed into `grammars/` to work: blob committed under `grammar_blobs/`, scanner ported into the package, registration file added, manifest and linguist entries touched. That bloats gotreesitter, couples grammar release cadence to the runtime's release cadence, and forces every consumer to carry every grammar.

With this export, a language-server author can:

1. Commit their `.bin` blob in **their own** repo.
2. Hand-port the external scanner to Go in **their own** package.
3. Call `grammars.Register` + `grammars.RegisterExternalScanner` from an `init()` in **their own** package.
4. Import for side effects and the grammar is live — `DetectLanguage(\"foo.qml\")`, `AllLanguages()`, and highlight-query resolution all see it exactly as if it were built in.

No changes to gotreesitter, no waiting for a release, full control of their own grammar.

## What's in the PR

- `grammars/blob_decode.go` — the exported wrapper (~30 lines, including doc comment). Thin delegate to the existing internal `decodeLanguageBlobData` with empty-input guard.
- `grammars/blob_decode_test.go` — TDD-authored tests:
  - `TestDecodeLanguageBlob_Roundtrip` — decodes a real blob via `BlobByName`, verifies `SymbolCount`/`TokenCount` populated, then actually parses Go source through `gotreesitter.NewParser` to confirm the result is end-to-end usable.
  - `TestDecodeLanguageBlob_Garbage` — rejects non-blob bytes cleanly (error, nil language, no panic).
  - `TestDecodeLanguageBlob_Empty` — rejects nil and empty input.
- `grammars/example_external_grammar_test.go` — executable godoc example (`ExampleDecodeLanguageBlob_externalGrammar`) showing the full consumer pattern end-to-end. Has `// Output:` so `go test` runs it, which keeps the documented pattern verified in CI and makes sure it never rots.

## How it works in prod

The example file documents the full recommended shape for a consumer package (e.g. a QML language server):

\`\`\`go
package qmlgrammar

import (
    _ \"embed\"
    \"sync\"

    \"github.com/odvcencio/gotreesitter\"
    \"github.com/odvcencio/gotreesitter/grammars\"
)

//go:embed qmljs.bin
var qmljsBlob []byte

func init() {
    // 1. Register the hand-ported Go external scanner first so it is
    //    attached when the Language is decoded on first access.
    grammars.RegisterExternalScanner(\"qmljs\", newQMLScanner())

    // 2. Register the language with a lazy loader that decodes the
    //    embedded blob on demand.
    grammars.Register(grammars.LangEntry{
        Name:           \"qmljs\",
        Extensions:     []string{\".qml\"},
        Language:       loadQMLJS,
        GrammarSource:  grammars.GrammarSourceTS2GoBlob,
        HighlightQuery: qmljsHighlights,
    })
}

var loadQMLJS = sync.OnceValue(func() *gotreesitter.Language {
    lang, err := grammars.DecodeLanguageBlob(qmljsBlob)
    if err != nil {
        panic(\"qmljs grammar blob is corrupt: \" + err.Error())
    }
    return lang
})
\`\`\`

Any binary that imports `qmlgrammar` for side effects now has full QML support — detection, parsing, highlighting — with zero gotreesitter-side code.

## Relationship to #27

This is the alternative to PR #27 (\"feat(grammars): add QML support via tree-sitter-qmljs\"). Rather than absorbing a 407-line scanner + blob + registration + manifest/linguist touches into gotreesitter, this exposes the one missing API and lets the QML work live in [cushycush/qml-language-server](https://github.com/cushycush/qml-language-server) where it belongs. Plan is to close #27 with a link to this PR and thanks to the author for surfacing the gap.

## Parser-lane safety

Additive-only. Zero changes to parser, lexer, scanner runtime, existing registered grammars, or any blob. New file, three tests, one example. Cannot regress parser correctness or any existing parity gate.

## Test plan

- [x] `go test ./grammars/ -run TestDecodeLanguageBlob -count=1 -v` — all pass
- [x] `go test ./grammars/ -run ExampleDecodeLanguageBlob -count=1` — executable example passes (prints \"parsed: true\")
- [x] `go build ./grammars/...` — clean
- [x] `go vet ./grammars/` — clean (no new issues)