### PR TITLE
fix(parser): avoid pool aliasing for recovery token sources

### DIFF
--- a/parser_api.go
+++ b/parser_api.go
@@ -64,7 +64,7 @@ func (p *Parser) dfaReparseFactory() normalizationTokenSourceFactory {
 	}
 	return func(source []byte) (TokenSource, error) {
 		lexer := NewLexer(p.language.LexStates, source)
-		return acquireDFATokenSource(lexer, p.language, p.lookupActionIndex, p.hasKeywordState), nil
+		return newDFATokenSourceDirect(lexer, p.language, p.lookupActionIndex, p.hasKeywordState), nil
 	}
 }
 

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -50,6 +50,10 @@ type dfaTokenSource struct {
 	// emissions so tokenization always makes forward progress.
 	zeroWidthPos   int
 	zeroWidthCount int
+
+	// noPool skips pool return on Close; set for token sources whose lifetime
+	// is nested inside an active parse (e.g. recovery reparsing).
+	noPool bool
 }
 
 const maxConsecutiveZeroWidthTokens = 4
@@ -77,6 +81,28 @@ func acquireDFATokenSource(lexer *Lexer, language *Language, lookupActionIndex f
 		zeroWidthPos: -1,
 	}
 	ts.maskedScratch = savedMasked
+	ts.lexer = lexer
+	ts.language = language
+	ts.state = 0
+	ts.lookupActionIndex = lookupActionIndex
+	ts.hasKeywordState = hasKeywordState
+	if lexer != nil && language != nil {
+		ts.lexer.states = language.LexStates
+		ts.lexer.immediateTokens = language.ImmediateTokens
+		ts.lexer.asciiTable = language.LexAsciiTable()
+	}
+	if language != nil && language.ExternalScanner != nil {
+		ts.externalPayload = language.ExternalScanner.Create()
+	}
+	return ts
+}
+
+func newDFATokenSourceDirect(lexer *Lexer, language *Language, lookupActionIndex func(state StateID, sym Symbol) uint16, hasKeywordState []bool) *dfaTokenSource {
+	ts := &dfaTokenSource{
+		extZeroPos:   -1,
+		zeroWidthPos: -1,
+		noPool:       true,
+	}
 	ts.lexer = lexer
 	ts.language = language
 	ts.state = 0
@@ -134,25 +160,10 @@ func (d *dfaTokenSource) Reset(source []byte) {
 }
 
 func (d *dfaTokenSource) Close() {
-	if d.language == nil || d.language.ExternalScanner == nil || d.externalPayload == nil {
-		// still recycle the token source instance
-		d.lexer = nil
-		d.language = nil
-		d.lookupActionIndex = nil
-		d.hasKeywordState = nil
-		d.glrStates = nil
-		d.extZeroPos = -1
-		d.extZeroState = 0
-		d.zeroWidthPos = -1
-		d.zeroWidthCount = 0
-		d.lastExternalTokenStartByte = 0
-		d.lastExternalTokenEndByte = 0
-		d.lastExternalTokenValid = false
-		dfaTokenSourcePool.Put(d)
-		return
+	if d.language != nil && d.language.ExternalScanner != nil && d.externalPayload != nil {
+		d.language.ExternalScanner.Destroy(d.externalPayload)
+		d.externalPayload = nil
 	}
-	d.language.ExternalScanner.Destroy(d.externalPayload)
-	d.externalPayload = nil
 	d.lexer = nil
 	d.language = nil
 	d.lookupActionIndex = nil
@@ -165,7 +176,9 @@ func (d *dfaTokenSource) Close() {
 	d.lastExternalTokenStartByte = 0
 	d.lastExternalTokenEndByte = 0
 	d.lastExternalTokenValid = false
-	dfaTokenSourcePool.Put(d)
+	if !d.noPool {
+		dfaTokenSourcePool.Put(d)
+	}
 }
 
 // DebugDFA enables trace logging for DFA token production.

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -71,6 +71,22 @@ var dfaTokenSourcePool = sync.Pool{
 	},
 }
 
+func initDFATokenSource(ts *dfaTokenSource, lexer *Lexer, language *Language, lookupActionIndex func(state StateID, sym Symbol) uint16, hasKeywordState []bool) {
+	ts.lexer = lexer
+	ts.language = language
+	ts.state = 0
+	ts.lookupActionIndex = lookupActionIndex
+	ts.hasKeywordState = hasKeywordState
+	if lexer != nil && language != nil {
+		ts.lexer.states = language.LexStates
+		ts.lexer.immediateTokens = language.ImmediateTokens
+		ts.lexer.asciiTable = language.LexAsciiTable()
+	}
+	if language != nil && language.ExternalScanner != nil {
+		ts.externalPayload = language.ExternalScanner.Create()
+	}
+}
+
 func acquireDFATokenSource(lexer *Lexer, language *Language, lookupActionIndex func(state StateID, sym Symbol) uint16, hasKeywordState []bool) *dfaTokenSource {
 	ts := dfaTokenSourcePool.Get().(*dfaTokenSource)
 	// Preserve pooled scratch slices across the struct reset below so they can
@@ -81,19 +97,7 @@ func acquireDFATokenSource(lexer *Lexer, language *Language, lookupActionIndex f
 		zeroWidthPos: -1,
 	}
 	ts.maskedScratch = savedMasked
-	ts.lexer = lexer
-	ts.language = language
-	ts.state = 0
-	ts.lookupActionIndex = lookupActionIndex
-	ts.hasKeywordState = hasKeywordState
-	if lexer != nil && language != nil {
-		ts.lexer.states = language.LexStates
-		ts.lexer.immediateTokens = language.ImmediateTokens
-		ts.lexer.asciiTable = language.LexAsciiTable()
-	}
-	if language != nil && language.ExternalScanner != nil {
-		ts.externalPayload = language.ExternalScanner.Create()
-	}
+	initDFATokenSource(ts, lexer, language, lookupActionIndex, hasKeywordState)
 	return ts
 }
 
@@ -103,19 +107,7 @@ func newDFATokenSourceDirect(lexer *Lexer, language *Language, lookupActionIndex
 		zeroWidthPos: -1,
 		noPool:       true,
 	}
-	ts.lexer = lexer
-	ts.language = language
-	ts.state = 0
-	ts.lookupActionIndex = lookupActionIndex
-	ts.hasKeywordState = hasKeywordState
-	if lexer != nil && language != nil {
-		ts.lexer.states = language.LexStates
-		ts.lexer.immediateTokens = language.ImmediateTokens
-		ts.lexer.asciiTable = language.LexAsciiTable()
-	}
-	if language != nil && language.ExternalScanner != nil {
-		ts.externalPayload = language.ExternalScanner.Create()
-	}
+	initDFATokenSource(ts, lexer, language, lookupActionIndex, hasKeywordState)
 	return ts
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a data race in concurrent Parse calls on Go source files. Recovery token
sources created by dfaReparseFactory were drawn from the global
dfaTokenSourcePool; a token source released at the end of one recovery
iteration could be acquired by another goroutine while the first was still
reading it, causing a race on glrStates and a nil-pointer dereference.

## Why this approach?

Add newDFATokenSourceDirect which allocates a dfaTokenSource directly
(setting noPool: true) instead of drawing from the pool. Close skips
dfaTokenSourcePool.Put when noPool is set. Only the recovery reparse path
uses direct allocation; all other acquisition sites continue to use the pool.

The alternative (a per-parser pool scoped to a single Parse call) avoids
the GC pressure of direct allocation but is more invasive. Since recovery
reparsing is not on the hot path, direct allocation is the simpler fix.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
- [ ] Affected parity validation ran in Docker, one language or grammar at a time
- [ ] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

Verified with a race-detector repro: [rasros/gotreesitter-race-repro](https://github.com/rasros/gotreesitter-race-repro), a concurrent Go-file parser that uses [lx](https://github.com/rasros/lx) to stream source files and hammer Parse from multiple goroutines. go run -race main.go triggered the race reliably before this fix; no race after. Full go test -race ./... passes. Docker parity not run; this change only affects token source lifetime, not parse table logic.

## Performance

- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR

Not a perf change. Recovery reparsing is not on the hot path; the extra allocation per recovery call has negligible impact.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
- [ ] Called out anything I'm unsure about or want a second opinion on

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars
- [ ] If adding a grammar or scanner: verified against upstream C output