### PR TITLE
chore(grammargen): add 4 grammars to real-corpus parity floor file

### DIFF
--- a/cgo_harness/docker/run_single_grammar_parity.sh
+++ b/cgo_harness/docker/run_single_grammar_parity.sh
@@ -369,6 +369,7 @@ make_clone_block() {
     [perl]="https://github.com/tree-sitter-perl/tree-sitter-perl.git"
     [erlang]="https://github.com/WhatsApp/tree-sitter-erlang.git"
     [d]="https://github.com/CyberShadow/tree-sitter-d.git"
+    [dart]="https://github.com/UserNobody14/tree-sitter-dart.git"
   )
 
   # Map grammar names to repo directory names (some differ).

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -1,16 +1,16 @@
 {
-  "version": 14,
-  "generated_at": "2026-03-08T08:15:00Z",
-  "commit_sha": "279f617",
+  "version": 15,
+  "generated_at": "2026-04-17T03:20:46Z",
+  "commit_sha": "f5ded69",
   "corpus_root": "/tmp/grammar_parity",
   "profile": "aggressive",
   "max_cases": 25,
   "max_sample_bytes": 524288,
-  "grammar_count": 49,
-  "total_eligible": 915,
-  "total_no_error": 915,
-  "total_sexpr_parity": 685,
-  "total_deep_parity": 682,
+  "grammar_count": 53,
+  "total_eligible": 1019,
+  "total_no_error": 970,
+  "total_sexpr_parity": 745,
+  "total_deep_parity": 740,
   "metrics": {
     "bash": {
       "eligible": 25,
@@ -48,6 +48,12 @@
       "sexpr_parity": 7,
       "deep_parity": 7
     },
+    "dart": {
+      "eligible": 29,
+      "no_error": 9,
+      "sexpr_parity": 7,
+      "deep_parity": 4
+    },
     "diff": {
       "eligible": 14,
       "no_error": 14,
@@ -83,6 +89,12 @@
       "no_error": 25,
       "sexpr_parity": 13,
       "deep_parity": 13
+    },
+    "erlang": {
+      "eligible": 25,
+      "no_error": 24,
+      "sexpr_parity": 20,
+      "deep_parity": 20
     },
     "forth": {
       "eligible": 25,
@@ -180,6 +192,12 @@
       "sexpr_parity": 25,
       "deep_parity": 25
     },
+    "kotlin": {
+      "eligible": 25,
+      "no_error": 14,
+      "sexpr_parity": 11,
+      "deep_parity": 11
+    },
     "lua": {
       "eligible": 25,
       "no_error": 25,
@@ -257,6 +275,12 @@
       "no_error": 16,
       "sexpr_parity": 16,
       "deep_parity": 16
+    },
+    "rust": {
+      "eligible": 25,
+      "no_error": 20,
+      "sexpr_parity": 12,
+      "deep_parity": 12
     },
     "scala": {
       "eligible": 25,


### PR DESCRIPTION
## What does this PR do?

Extends the grammargen real-corpus parity baseline (`grammargen/testdata/real_corpus_parity_floors.json`) to track **dart, erlang, kotlin, rust** — four tier-1 grammars whose lock SHAs were refreshed in #26 but whose grammargen-compiler quality wasn't being measured. Ruby was attempted and deliberately left out (OOM-kill even at 14 g).

Also adds the missing `[dart]` entry to `run_single_grammar_parity.sh`'s REPO_URLS map — without it the runner silently falls through the clone block and the test reports "no grammar repos with corpus samples found", making dart invisible.

## Why this approach?

Follow-up (C) to #26. The grammargen compiler quality metric across all 206 grammars is the real-corpus parity test via `ImportGrammarJSON`. Five tier-1 grammars (dart, erlang, kotlin, ruby, rust) weren't in the floor file, so we had no baseline to detect regressions. Adding them gives us per-grammar telemetry and sets graduation candidates for the future grammargen-ships path (the bar is ~70 % sexpr, Go's was 72 % when we swapped it in #35).

## Correctness

- [x] Focused unit tests ran for the touched behavior — `run_single_grammar_parity.sh --no-build <grammar>` for each, inside Docker
- [x] Affected parity validation ran in Docker, one language at a time
- [x] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated — ruby OOM-kill is documented in the commit message; re-add once memory footprint is addressed

Numbers (origin/main baseline, profile=aggressive, max_cases=25):

| grammar | eligible | no_error | sexpr | deep | sexpr % | graduation-ready? |
|---|---:|---:|---:|---:|---:|---|
| dart | 29 | 9 | 7 | 4 | 24 % | no |
| erlang | 25 | 24 | 20 | 20 | **80 %** | closest |
| kotlin | 25 | 14 | 11 | 11 | 44 % | no |
| rust | 25 | 20 | 12 | 12 | 48 % | no |

Aggregates recomputed: **49 → 53 grammars; 915 → 1019 eligible; 685 → 745 sexpr; 682 → 740 deep.** Version 14 → 15, `generated_at` + `commit_sha` refreshed.

## Performance

Not the goal of this PR — telemetry addition only. No runtime behavior changes.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup — one additional entry in REPO_URLS, four new entries in the floor file, aggregates recomputed
- [x] Generated files touched only because required — floor file is the generated artifact whose content *is* the telemetry; updating it is the point
- [x] No new dependencies

Dart has 29 eligible upstream samples (not 25) because its repo ships extra corpus beyond the typical set. The test honors `max_cases=25` as a ceiling but accepts additional samples if present; the floor entry records the actual eligible count.

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections — commit message captures per-grammar numbers, graduation status, ruby's absence
- [x] Called out anything I'm unsure about — the ruby skip reason. 8 g OOM is a known issue for large grammars; 14 g OOM extends it. Could be a genuine memory leak in the grammargen ruby path or legitimately huge working set. Flagging for a separate investigation before any migration attempt on ruby.

## Due diligence

- [x] Read the code being changed before changing it — confirmed floor file semantic via `parity_real_corpus_test.go` (treats values as minimum thresholds)
- [x] Checked similar patterns across the codebase — the pattern mirrors the existing 49 grammar entries
- [x] N/A parser/lexer change
- [x] N/A grammar/scanner addition (blobs unchanged)

## Graduation candidates (not in scope of this PR)

- **erlang at 80 % sexpr / 24/25 no-error** is the closest to Go's 72 % graduation threshold. If we wanted to follow Go's precedent and swap erlang to grammargen-only (like #35 did), it's the next candidate. Keeping as ts2go for now; recording the number so we can tell if it regresses.
- All others have meaningful gaps before they'd be migration candidates.

## Follow-ups

1. Ruby OOM investigation — both 8 g and 14 g killed during the grammargen build+parse pipeline. Pre-existing skip-list item; now empirically confirmed on current main.
2. Kotlin 14/25 no-error is notable — half the samples fail to parse cleanly via grammargen. Related to the kotlin blob regression flagged in #37 (different path — that was the ts2go ABI blob, this is grammargen JSON-import — but same upstream SHA, so the upstream may have introduced a genuinely harder shape).
3. Post #38 (ImportGrammarJSON reserved-word fix), we should re-measure Go's floor entry (currently 18/25 sexpr, empirically 25/25 now) and raise it to protect against regression. Doing that in a separate PR to keep this one scoped.