### PR TITLE
fix(grammars/scala): revert lock pin, make LexModes fixture tail-relative

### DIFF
--- a/grammars/embedded_loader_test.go
+++ b/grammars/embedded_loader_test.go
@@ -9,6 +9,13 @@ import (
 func TestRepairNoLookaheadLexModes(t *testing.T) {
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 
+	// The no-lookahead repair logic writes ^uint16(0) sentinel LexState
+	// values into the last few LexModes entries (one per repaired state).
+	// Use a tail-relative offset so the fixture survives blob regens that
+	// add new states ahead of the sentinels. Negative `state` means
+	// "len(LexModes) + state" — i.e. -4 is the fourth-from-last entry,
+	// which is the first repaired sentinel slot for grammars that repair
+	// four no-lookahead states.
 	tests := []struct {
 		name  string
 		load  func() []gotreesitter.LexMode
@@ -17,7 +24,7 @@ func TestRepairNoLookaheadLexModes(t *testing.T) {
 		{
 			name:  "scala",
 			load:  func() []gotreesitter.LexMode { return ScalaLanguage().LexModes },
-			state: 21248,
+			state: -4,
 		},
 		{
 			name:  "rust",
@@ -29,11 +36,16 @@ func TestRepairNoLookaheadLexModes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			lexModes := tc.load()
-			if tc.state >= len(lexModes) {
-				t.Fatalf("state %d out of range for %s", tc.state, tc.name)
+			idx := tc.state
+			if idx < 0 {
+				idx = len(lexModes) + idx
 			}
-			if got := lexModes[tc.state].LexState; got != ^uint16(0) {
-				t.Fatalf("LexModes[%d].LexState = %d, want %d", tc.state, got, ^uint16(0))
+			if idx < 0 || idx >= len(lexModes) {
+				t.Fatalf("state %d (resolved %d) out of range for %s (len=%d)",
+					tc.state, idx, tc.name, len(lexModes))
+			}
+			if got := lexModes[idx].LexState; got != ^uint16(0) {
+				t.Fatalf("LexModes[%d].LexState = %d, want %d", idx, got, ^uint16(0))
 			}
 		})
 	}

--- a/grammars/languages.lock
+++ b/grammars/languages.lock
@@ -22,7 +22,7 @@ tsx https://github.com/tree-sitter/tree-sitter-typescript 75b3874edb2dc714fb1fd7
 typescript https://github.com/tree-sitter/tree-sitter-typescript 75b3874edb2dc714fb1fd77a32013d0f8699989f typescript/src .ts
 yaml https://github.com/tree-sitter-grammars/tree-sitter-yaml 4463985dfccc640f3d6991e3396a2047610cf5f8 src .yaml,.yml
 zig https://github.com/tree-sitter-grammars/tree-sitter-zig 6479aa13f32f701c383083d8b28360ebd682fb7d src .zig
-scala https://github.com/tree-sitter/tree-sitter-scala d71328b913037efe2e695e9aeb5065839dce335f src .scala
+scala https://github.com/tree-sitter/tree-sitter-scala 97aead18d97708190a51d4f551ea9b05b60641c9 src .scala
 elixir https://github.com/elixir-lang/tree-sitter-elixir 7937d3b4d65fa574163cfa59394515d3c1cf16f4 src .ex,.exs
 graphql https://github.com/bkegley/tree-sitter-graphql 5e66e961eee421786bdda8495ed1db045e06b5fe src .graphql,.gql
 hcl https://github.com/tree-sitter-grammars/tree-sitter-hcl 64ad62785d442eb4d45df3a1764962dafd5bc98b src .hcl,.tf,.tfvars


### PR DESCRIPTION
## What does this PR do?

Two-part scala regression remediation for PR #37's held-back work:

1. Revert `scala` in `grammars/languages.lock` from `d71328b9` (the #26 bump) back to `97aead18`.
2. Make `TestRepairNoLookaheadLexModes` in `grammars/embedded_loader_test.go` tail-relative so future blob regens don't false-alarm the LexModes fixture.

## Why this approach?

Upstream commit `42d2ef9` in tree-sitter/tree-sitter-scala ("fix: issue outdents before commas") added `_comma_outdent` at external index 3, shifting every string-related external and Symbol ID by +1. Our hand-written `grammars/scala_scanner.go` hardcodes the pre-shift IDs (`scaTokSimpleStringStart=3` through `scaTokMultilineStringEnd=12`, `scaSymSimpleStringStart=107` through `scaSymMultilineStringEnd=116`), so every `SetResultSymbol` for a string-related external now targets the wrong symbol.

Minimal repro `object O { def f = f"${x}" }` parses to `(ERROR ...)` on the new blob; clean on the old. Not visible in the CGo smoke sample because it doesn't exercise interpolated strings.

Alternatives considered:
- **Adapter fix (option c)** — shift 10 constants in `scala_scanner.go` + port the `COMMA_OUTDENT` branch from upstream `scanner.c:299-304`. Mechanical but the upstream range also includes a scanner stack-layout refactor (`3fb3931`) and string-escape changes (`ddd2dc0`) that carry additional non-obvious risk. No existing consumer is asking for the Scala 3.4+ niceties in the new pin, so the adapter investment isn't justified right now.
- **Refactor `scala_scanner.go` to resolve externals via `lang.ExternalSymbols[]` name lookup** — the html/yaml pattern referenced in MEMORY.md. Correct long-term shape; same class of work needed on `kotlin_scanner.go` and `rust_scanner.go`. Tracked as a follow-up.

For the LexModes fixture: the old blob had `len(LexModes)=21252` with 4 repaired sentinel states at 21248-21251 (tail). The new blob had `len(LexModes)=25888`, still 4 sentinel states, now at 25884-25887. Repair logic unchanged; the hardcoded `21248` was brittle to blob growth. Tail-relative (`-4`) fixes that forever.

## Correctness

- [x] Focused unit tests ran for the touched behavior — `TestScalaInterpolatedStringCarries*` + `TestRepairNoLookaheadLexModes` pass in Docker
- [x] Affected parity validation ran in Docker, one language at a time
- [x] N/A grammargen/parity logic
- [x] Documented anything intentionally left unvalidated — none

| test | before | after |
|---|---|---|
| `TestScalaInterpolatedStringCarriesTrailingMultilineClose` | FAIL (ERROR root) | PASS |
| `TestScalaInterpolatedStringCarriesTrailingSingleLineTail` | FAIL (ERROR root) | PASS |
| `TestRepairNoLookaheadLexModes/scala` | FAIL (hardcoded index mismatch) | PASS |
| `TestRepairNoLookaheadLexModes/rust` | PASS | PASS (unchanged — rust's fixture index stays absolute) |

## Performance

Not the goal.

## Maintainability

- [x] No unnecessary abstractions — one lock revert, one fixture rewrite
- [x] Generated files touched only because required — `languages.lock` is the target; no blob touched
- [x] No new dependencies

The LexModes fixture now documents the `-4` convention inline (the first repaired sentinel slot from the tail). If future grammars hit the same fixture with more/fewer repaired states, update the `state` field to `-N` for `N` repaired states.

## Self-review

- [x] Reviewed my own diff end to end
- [x] Commit message names upstream commits + exact symbol-ID shift
- [x] Called out anything unsure — the adapter path (option c) is the forward direction once we do the broader hand-written-scanner modernization; this PR chooses the minimum-risk path for today.

## Due diligence

- [x] Read the code being changed before changing it — walked `scala_scanner.go` hardcoded constants + upstream scanner.c diff
- [x] Similar patterns — same class of bug hit kotlin (#17) and rust (#20); rust got the adapter fix in #40, kotlin is in a separate PR
- [x] If touching the parser or lexer: N/A; scanner is untouched, only the lock
- [x] N/A scanner addition

## Related

- PR #37 held scala back pending this investigation.
- Same class of bug on rust (ported scanner in #40) and kotlin (pinning to upstream predecessor, in a separate PR).