### PR TITLE
fix(retry): release original tree when a retry result wins

### DIFF
--- a/parser_retry.go
+++ b/parser_retry.go
@@ -493,7 +493,7 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 }
 
 func (p *Parser) retryFullParseWithDFA(source []byte, initialMaxStacks int, deterministicExternalConflicts bool, tree *Tree) *Tree {
-	return p.retryFullParse(source, initialMaxStacks, tree, func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
+	result := p.retryFullParse(source, initialMaxStacks, tree, func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
 		retryLexer := NewLexer(p.language.LexStates, source)
 		retryTS := acquireDFATokenSource(retryLexer, p.language, p.lookupActionIndex, p.hasKeywordState)
 		defer retryTS.Close()
@@ -510,6 +510,13 @@ func (p *Parser) retryFullParseWithDFA(source []byte, initialMaxStacks int, dete
 			deterministicExternalConflicts,
 		)
 	})
+	// retryFullParse releases losing retry trees internally (#34), but when a
+	// retry winner replaces the original tree, the original's arena is orphaned.
+	// Release it here since the caller will overwrite its tree reference.
+	if result != tree {
+		tree.Release()
+	}
+	return result
 }
 
 func (p *Parser) retryFullParseWithTokenSource(source []byte, ts TokenSource, initialMaxStacks int, deterministicExternalConflicts bool, tree *Tree) *Tree {
@@ -517,7 +524,7 @@ func (p *Parser) retryFullParseWithTokenSource(source []byte, ts TokenSource, in
 	if !ok {
 		return tree
 	}
-	return p.retryFullParse(source, initialMaxStacks, tree, func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
+	result := p.retryFullParse(source, initialMaxStacks, tree, func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
 		resettable.Reset(source)
 		return p.parseInternal(
 			source,
@@ -532,4 +539,9 @@ func (p *Parser) retryFullParseWithTokenSource(source []byte, ts TokenSource, in
 			deterministicExternalConflicts,
 		)
 	})
+	// Same as retryFullParseWithDFA: release the original tree if a retry won.
+	if result != tree {
+		tree.Release()
+	}
+	return result
 }


### PR DESCRIPTION
## Problem

`retryFullParse` (#34) correctly releases **losing intermediate trees** via `replaceBest`. But it does not release the **original tree** passed in by the caller.

When a retry produces a better parse, `retryFullParseWithDFA` and `retryFullParseWithTokenSource` return the new tree — and the original tree's arena is never returned to the pool.

The caller overwrites its `tree` reference with the return value, so there is no other path to release it.

## Fix

Capture the return value, check if a retry won, and release the original:

```go
result := p.retryFullParse(...)
if result != tree {
    tree.Release()
}
return result
```

Applied to both `retryFullParseWithDFA` and `retryFullParseWithTokenSource`.

The `result != tree` guard makes it safe: if no retry ran (or the original was already best), `result == tree` and nothing is released.

## Relation to #34

| | #34 | This PR |
|-|-----|---------|
| Releases losing **retry** trees | yes | — |
| Releases the **original** tree when retry wins | no | yes |

Both fixes are needed for complete arena lifecycle coverage on the retry path.