### PR TITLE
fix(query): backtrack predicate-invalid child matches

### DIFF
--- a/query.go
+++ b/query.go
@@ -739,7 +739,7 @@ func (q *Query) matchPattern(pat *Pattern, node *Node, lang *Language, source []
 	}
 
 	var captures []QueryCapture
-	ok := q.matchSteps(pat.steps, 0, node, lang, source, &captures)
+	ok := q.matchStepsWithPredicates(pat.steps, 0, node, lang, source, pat.predicates, &captures)
 	if !ok {
 		return nil, false
 	}
@@ -756,7 +756,7 @@ func (q *Query) matchPatternIntoBuffer(pat *Pattern, node *Node, lang *Language,
 	}
 
 	start := len(captures)
-	if !q.matchSteps(pat.steps, 0, node, lang, source, &captures) {
+	if !q.matchStepsWithPredicates(pat.steps, 0, node, lang, source, pat.predicates, &captures) {
 		return captures[:start], false
 	}
 
@@ -770,12 +770,20 @@ func (q *Query) matchPatternIntoBuffer(pat *Pattern, node *Node, lang *Language,
 }
 
 func (q *Query) matchStepWithRollback(steps []QueryStep, stepIdx int, node *Node, lang *Language, source []byte, captures *[]QueryCapture) bool {
-	return q.matchStepWithRollbackAtParent(steps, stepIdx, node, nil, -1, lang, source, captures)
+	return q.matchStepWithRollbackPredicates(steps, stepIdx, node, lang, source, nil, captures)
+}
+
+func (q *Query) matchStepWithRollbackPredicates(steps []QueryStep, stepIdx int, node *Node, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {
+	return q.matchStepWithRollbackAtParentPredicates(steps, stepIdx, node, nil, -1, lang, source, predicates, captures)
 }
 
 func (q *Query) matchStepWithRollbackAtParent(steps []QueryStep, stepIdx int, node *Node, parent *Node, childIdx int, lang *Language, source []byte, captures *[]QueryCapture) bool {
+	return q.matchStepWithRollbackAtParentPredicates(steps, stepIdx, node, parent, childIdx, lang, source, nil, captures)
+}
+
+func (q *Query) matchStepWithRollbackAtParentPredicates(steps []QueryStep, stepIdx int, node *Node, parent *Node, childIdx int, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {
 	checkpoint := len(*captures)
-	if q.matchStepsWithParent(steps, stepIdx, node, parent, childIdx, lang, source, captures) {
+	if q.matchStepsWithParentPredicates(steps, stepIdx, node, parent, childIdx, lang, source, predicates, captures) {
 		return true
 	}
 	*captures = (*captures)[:checkpoint]

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -364,7 +364,6 @@ func (q *Query) matchChildStepsRecursive(
 
 				childCheckpoint := len(*captures)
 				if !q.matchStepWithRollbackAtParentPredicates(steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, captures) {
-					*captures = (*captures)[:childCheckpoint]
 					continue
 				}
 

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -279,6 +279,44 @@ func (q *Query) matchChildStepsRecursive(
 		return false
 	}
 
+	// Final child steps without match predicates intentionally aggregate
+	// structurally matching siblings into one match; predicate-bearing patterns
+	// need normal backtracking so invalid candidates do not leak captures or
+	// block later ones.
+	if !predicatesCanRejectMatch(predicates) && childPos == len(childSteps)-1 && minCount == 1 && maxCount == 1 && !step.anchorBefore && !step.anchorAfter {
+		any := false
+		checkpoint := len(*captures)
+		for _, childIdx := range candidateIndices {
+			child := children[childIdx]
+			childCheckpoint := len(*captures)
+			if !q.matchStepWithRollbackAtParentPredicates(steps, cs.stepIdx, child, parent, childIdx, lang, source, nil, captures) {
+				*captures = (*captures)[:childCheckpoint]
+				continue
+			}
+			hasNamed := false
+			firstNamedPos := -1
+			lastNamedPos := -1
+			if namedPos := namedPosByIndex[childIdx]; namedPos >= 0 {
+				hasNamed = true
+				firstNamedPos = namedPos
+				lastNamedPos = namedPos
+			}
+			if !q.stepAnchorsSatisfied(
+				step, childPos, hasNamed, firstNamedPos, lastNamedPos,
+				prevHasNamed, prevLastNamedPos, parentLastNamedPos,
+			) {
+				*captures = (*captures)[:childCheckpoint]
+				continue
+			}
+			any = true
+		}
+		if any {
+			return true
+		}
+		*captures = (*captures)[:checkpoint]
+		return false
+	}
+
 	// Greedy-first for consistency with prior quantifier behavior; backtrack as needed.
 	for count := maxCount; count >= minCount; count-- {
 		checkpoint := len(*captures)

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -10,10 +10,18 @@ type queryChildStepInfo struct {
 // matchSteps matches a contiguous slice of steps starting at stepIdx
 // against the given node at the expected depth.
 func (q *Query) matchSteps(steps []QueryStep, stepIdx int, node *Node, lang *Language, source []byte, captures *[]QueryCapture) bool {
-	return q.matchStepsWithParent(steps, stepIdx, node, nil, -1, lang, source, captures)
+	return q.matchStepsWithPredicates(steps, stepIdx, node, lang, source, nil, captures)
 }
 
 func (q *Query) matchStepsWithParent(steps []QueryStep, stepIdx int, node *Node, parent *Node, childIdx int, lang *Language, source []byte, captures *[]QueryCapture) bool {
+	return q.matchStepsWithParentPredicates(steps, stepIdx, node, parent, childIdx, lang, source, nil, captures)
+}
+
+func (q *Query) matchStepsWithPredicates(steps []QueryStep, stepIdx int, node *Node, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {
+	return q.matchStepsWithParentPredicates(steps, stepIdx, node, nil, -1, lang, source, predicates, captures)
+}
+
+func (q *Query) matchStepsWithParentPredicates(steps []QueryStep, stepIdx int, node *Node, parent *Node, childIdx int, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {
 	if stepIdx >= len(steps) {
 		return false
 	}
@@ -21,7 +29,7 @@ func (q *Query) matchStepsWithParent(steps []QueryStep, stepIdx int, node *Node,
 	step := &steps[stepIdx]
 
 	if len(step.alternatives) > 0 {
-		if !q.matchAlternationStep(step, node, parent, childIdx, lang, source, captures) {
+		if !q.matchAlternationStep(step, node, parent, childIdx, lang, source, predicates, captures) {
 			return false
 		}
 	} else {
@@ -30,6 +38,9 @@ func (q *Query) matchStepsWithParent(steps []QueryStep, stepIdx int, node *Node,
 			return false
 		}
 		q.appendCaptureIDs(step.captureIDs, step.captureID, node, captures)
+		if !q.predicatesStillViable(predicates, *captures, source) {
+			return false
+		}
 	}
 
 	// Find child steps (steps at depth = step.depth + 1) that are direct
@@ -63,7 +74,7 @@ func (q *Query) matchStepsWithParent(steps []QueryStep, stepIdx int, node *Node,
 			})
 		}
 	}
-	return q.matchChildSteps(node, steps, childSteps, lang, source, captures)
+	return q.matchChildSteps(node, steps, childSteps, lang, source, predicates, captures)
 }
 
 func (q *Query) appendCaptureIDs(ids []int, legacyID int, node *Node, captures *[]QueryCapture) {
@@ -172,6 +183,7 @@ func (q *Query) matchChildSteps(
 	childSteps []queryChildStepInfo,
 	lang *Language,
 	source []byte,
+	predicates []QueryPredicate,
 	captures *[]QueryCapture,
 ) bool {
 	children := parent.Children()
@@ -196,7 +208,7 @@ func (q *Query) matchChildSteps(
 	return q.matchChildStepsRecursive(
 		parent, children, namedPosByIndex, parentLastNamedPos,
 		steps, childSteps, 0, 0, false, -1,
-		lang, source, captures,
+		lang, source, predicates, captures,
 	)
 }
 
@@ -213,6 +225,7 @@ func (q *Query) matchChildStepsRecursive(
 	prevLastNamedPos int,
 	lang *Language,
 	source []byte,
+	predicates []QueryPredicate,
 	captures *[]QueryCapture,
 ) bool {
 	if childPos >= len(childSteps) {
@@ -266,45 +279,6 @@ func (q *Query) matchChildStepsRecursive(
 		return false
 	}
 
-	// When this is the final child step and it requires exactly one match,
-	// accumulate captures from all matching sibling candidates. This matches
-	// tree-sitter query behavior for patterns like:
-	//   (flow_mapping (_ key: (...) @property))
-	// where each sibling pair should contribute captures.
-	if childPos == len(childSteps)-1 && minCount == 1 && maxCount == 1 && !step.anchorBefore && !step.anchorAfter {
-		any := false
-		checkpoint := len(*captures)
-		for _, childIdx := range candidateIndices {
-			child := children[childIdx]
-			childCheckpoint := len(*captures)
-			if !q.matchStepWithRollbackAtParent(steps, cs.stepIdx, child, parent, childIdx, lang, source, captures) {
-				*captures = (*captures)[:childCheckpoint]
-				continue
-			}
-			hasNamed := false
-			firstNamedPos := -1
-			lastNamedPos := -1
-			if namedPos := namedPosByIndex[childIdx]; namedPos >= 0 {
-				hasNamed = true
-				firstNamedPos = namedPos
-				lastNamedPos = namedPos
-			}
-			if !q.stepAnchorsSatisfied(
-				step, childPos, hasNamed, firstNamedPos, lastNamedPos,
-				prevHasNamed, prevLastNamedPos, parentLastNamedPos,
-			) {
-				*captures = (*captures)[:childCheckpoint]
-				continue
-			}
-			any = true
-		}
-		if any {
-			return true
-		}
-		*captures = (*captures)[:checkpoint]
-		return false
-	}
-
 	// Greedy-first for consistency with prior quantifier behavior; backtrack as needed.
 	for count := maxCount; count >= minCount; count-- {
 		checkpoint := len(*captures)
@@ -340,7 +314,7 @@ func (q *Query) matchChildStepsRecursive(
 				return q.matchChildStepsRecursive(
 					parent, children, namedPosByIndex, parentLastNamedPos,
 					steps, childSteps, childPos+1, nextIdx, nextPrevHasNamed, nextPrevLastNamedPos,
-					lang, source, captures,
+					lang, source, predicates, captures,
 				)
 			}
 
@@ -351,7 +325,7 @@ func (q *Query) matchChildStepsRecursive(
 				child := children[childIdx]
 
 				childCheckpoint := len(*captures)
-				if !q.matchStepWithRollbackAtParent(steps, cs.stepIdx, child, parent, childIdx, lang, source, captures) {
+				if !q.matchStepWithRollbackAtParentPredicates(steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, captures) {
 					*captures = (*captures)[:childCheckpoint]
 					continue
 				}
@@ -395,7 +369,7 @@ func (q *Query) matchChildStepsRecursive(
 	return false
 }
 
-func (q *Query) matchAlternationStep(step *QueryStep, node *Node, parent *Node, childIdx int, lang *Language, source []byte, captures *[]QueryCapture) bool {
+func (q *Query) matchAlternationStep(step *QueryStep, node *Node, parent *Node, childIdx int, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {
 	hasStepCaptures := len(step.captureIDs) > 0 || step.captureID >= 0
 	nodeSymbol := lang.PublicSymbol(node.Symbol())
 	nodeNamed := node.IsNamed()
@@ -449,7 +423,7 @@ func (q *Query) matchAlternationStep(step *QueryStep, node *Node, parent *Node, 
 				continue
 			}
 
-			if q.matchAlternationBranch(step, alt, node, lang, source, captures, hasStepCaptures) {
+			if q.matchAlternationBranch(step, alt, node, lang, source, predicates, captures, hasStepCaptures) {
 				return true
 			}
 
@@ -472,7 +446,7 @@ func (q *Query) matchAlternationStep(step *QueryStep, node *Node, parent *Node, 
 		if !q.alternativeFieldMatches(&alt, node, parent, childIdx, lang) {
 			continue
 		}
-		if q.matchAlternationBranch(step, &alt, node, lang, source, captures, hasStepCaptures) {
+		if q.matchAlternationBranch(step, &alt, node, lang, source, predicates, captures, hasStepCaptures) {
 			return true
 		}
 	}
@@ -518,6 +492,7 @@ func (q *Query) matchAlternationBranch(
 	node *Node,
 	lang *Language,
 	source []byte,
+	predicates []QueryPredicate,
 	captures *[]QueryCapture,
 	hasStepCaptures bool,
 ) bool {
@@ -525,15 +500,19 @@ func (q *Query) matchAlternationBranch(
 		// Fast path: no alternation-level captures and no branch predicates.
 		// matchStepWithRollback already protects captures from failed branches.
 		if !hasStepCaptures && len(alt.predicates) == 0 {
-			return q.matchStepWithRollback(alt.steps, 0, node, lang, source, captures)
+			return q.matchStepWithRollbackPredicates(alt.steps, 0, node, lang, source, predicates, captures)
 		}
 
 		checkpoint := len(*captures)
 		if hasStepCaptures {
 			// Captures on the alternation itself apply regardless of chosen branch.
 			q.appendCaptureIDs(step.captureIDs, step.captureID, node, captures)
+			if !q.predicatesStillViable(predicates, *captures, source) {
+				*captures = (*captures)[:checkpoint]
+				return false
+			}
 		}
-		if !q.matchStepWithRollback(alt.steps, 0, node, lang, source, captures) {
+		if !q.matchStepWithRollbackPredicates(alt.steps, 0, node, lang, source, predicates, captures) {
 			*captures = (*captures)[:checkpoint]
 			return false
 		}
@@ -548,10 +527,19 @@ func (q *Query) matchAlternationBranch(
 	if !hasStepCaptures && len(alt.captureIDs) == 0 && alt.captureID < 0 {
 		return true
 	}
+	checkpoint := len(*captures)
 	if hasStepCaptures {
 		q.appendCaptureIDs(step.captureIDs, step.captureID, node, captures)
+		if !q.predicatesStillViable(predicates, *captures, source) {
+			*captures = (*captures)[:checkpoint]
+			return false
+		}
 	}
 	q.appendCaptureIDs(alt.captureIDs, alt.captureID, node, captures)
+	if !q.predicatesStillViable(predicates, *captures, source) {
+		*captures = (*captures)[:checkpoint]
+		return false
+	}
 	return true
 }
 

--- a/query_predicates.go
+++ b/query_predicates.go
@@ -284,6 +284,96 @@ func (q *Query) matchesPredicates(predicates []QueryPredicate, captures []QueryC
 	return true
 }
 
+func (q *Query) predicatesStillViable(predicates []QueryPredicate, captures []QueryCapture, source []byte) bool {
+	if len(predicates) == 0 {
+		return true
+	}
+
+	for _, pred := range predicates {
+		switch pred.kind {
+		case predicateEq, predicateNotEq:
+			left, ok := captureText(pred.leftCapture, captures, source)
+			if !ok {
+				continue
+			}
+			right := pred.literal
+			if pred.rightCapture != "" {
+				var okRight bool
+				right, okRight = captureText(pred.rightCapture, captures, source)
+				if !okRight {
+					continue
+				}
+			}
+			if pred.kind == predicateEq && left != right {
+				return false
+			}
+			if pred.kind == predicateNotEq && left == right {
+				return false
+			}
+
+		case predicateMatch, predicateLuaMatch:
+			left, ok := captureText(pred.leftCapture, captures, source)
+			if !ok {
+				continue
+			}
+			if pred.regex == nil || !pred.regex.MatchString(left) {
+				return false
+			}
+
+		case predicateNotMatch:
+			left, ok := captureText(pred.leftCapture, captures, source)
+			if !ok {
+				continue
+			}
+			if pred.regex != nil && pred.regex.MatchString(left) {
+				return false
+			}
+
+		case predicateAnyOf:
+			left, ok := captureText(pred.leftCapture, captures, source)
+			if !ok {
+				continue
+			}
+			matched := false
+			for _, v := range pred.values {
+				if left == v {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+
+		case predicateNotAnyOf:
+			left, ok := captureText(pred.leftCapture, captures, source)
+			if !ok {
+				continue
+			}
+			for _, v := range pred.values {
+				if left == v {
+					return false
+				}
+			}
+
+		case predicateIsExported:
+			text, ok := captureText(pred.leftCapture, captures, source)
+			if !ok {
+				continue
+			}
+			if text == "" {
+				return false
+			}
+			r, _ := utf8.DecodeRuneInString(text)
+			if r == utf8.RuneError || !unicode.IsUpper(r) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 // applyDirectives applies capture-modifying directives (#select-adjacent!,
 // #strip!) to the captures list after a match has been accepted.
 func (q *Query) applyDirectives(predicates []QueryPredicate, captures []QueryCapture, source []byte) []QueryCapture {

--- a/query_predicates.go
+++ b/query_predicates.go
@@ -374,6 +374,18 @@ func (q *Query) predicatesStillViable(predicates []QueryPredicate, captures []Qu
 	return true
 }
 
+func predicatesCanRejectMatch(predicates []QueryPredicate) bool {
+	for _, pred := range predicates {
+		switch pred.kind {
+		case predicateSet, predicateOffset, predicateSelectAdjacent, predicateStrip:
+			continue
+		default:
+			return true
+		}
+	}
+	return false
+}
+
 // applyDirectives applies capture-modifying directives (#select-adjacent!,
 // #strip!) to the captures list after a match has been accepted.
 func (q *Query) applyDirectives(predicates []QueryPredicate, captures []QueryCapture, source []byte) []QueryCapture {

--- a/query_starlark_issue44_test.go
+++ b/query_starlark_issue44_test.go
@@ -1,0 +1,100 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const issue44StarlarkQuery = `
+(expression_statement
+ (assignment (identifier) @a (#eq? @a "a")
+             (dictionary (pair (string (string_content) @b (#eq? @b "b"))
+                           (dictionary
+                            (pair (string (string_content) @c_key (#eq? @c_key "c"))
+                                  (string) @c)
+                            (pair (string (string_content) @d_key (#eq? @d_key "d"))
+                                  (string) @d))))))
+`
+
+func TestQueryStarlarkNestedDictionaryPredicates(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "first_matching_pair",
+			source: `a = {
+    "b": {
+        "c": "a1",
+        "d": "a2",
+    },
+    "m": {
+        "c": "a1",
+        "d": "a2",
+    },
+}
+`,
+		},
+		{
+			name: "matching_pair_after_nonmatching_sibling",
+			source: `a = {
+    "b": {
+        "n": "p",
+        "c": "a1",
+        "d": "a2",
+    },
+    "m": {
+        "c": "a1",
+        "d": "a2",
+    },
+}
+`,
+		},
+	}
+
+	lang := grammars.StarlarkLanguage()
+	query, err := gotreesitter.NewQuery(issue44StarlarkQuery, lang)
+	if err != nil {
+		t.Fatalf("NewQuery: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte(tc.source)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			defer tree.Release()
+
+			matches := query.Execute(tree)
+			if len(matches) != 1 {
+				t.Fatalf("matches: got %d, want 1", len(matches))
+			}
+
+			got := make([]string, 0, len(matches[0].Captures))
+			for _, capture := range matches[0].Captures {
+				got = append(got, capture.Name+"="+capture.Node.Text(source))
+			}
+			want := []string{
+				"a=a",
+				"b=b",
+				"c_key=c",
+				"c=\"a1\"",
+				"d_key=d",
+				"d=\"a2\"",
+			}
+			if len(got) != len(want) {
+				t.Fatalf("captures: got %d %v, want %d %v", len(got), got, len(want), want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("capture[%d]: got %q, want %q; all captures %v", i, got[i], want[i], got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #44 by making query matching backtrack when a structurally valid child candidate fails predicates. This brings the Starlark nested-dictionary query behavior in line with C tree-sitter for both reported cases:

- exact-one child steps no longer aggregate predicate-invalid siblings into one capture set
- predicate-invalid candidates are pruned early so later valid siblings can be tried
- predicate-free final child steps still preserve the existing sibling aggregation behavior used by structural alternation field shorthand

## Root Cause

The query matcher had a final-child exact-one special case that accumulated captures from every structurally matching sibling. Predicates then evaluated against the first capture for a name, so a later nonmatching sibling could ride along in the same match. Separately, predicate failures were only checked after the full structural match, which prevented backtracking to later sibling candidates.

The CI fix preserves the old aggregation path when a pattern has no match-rejecting predicates, so existing structural alternation queries still collect all expected sibling captures.

## Validation

- `go test . -run 'TestQueryStarlarkNestedDictionaryPredicates|Test(Query|ParsePredicate|MatchPredicate|Any|ExecuteNodePredicate|Injection|Highlight|Tagger)' -count=1`
- `go test . -race -run '^TestMatchAlternationFieldShorthandRespectsField$' -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh --repo-root /home/draco/work/gotreesitter/.claude/worktrees/issue-44-query --out-root /tmp/gts-open-pr-validate --label issue47-ci-fix --memory 2g --cpus 1 --pids 512 --no-build -- "cd /workspace && go test . -race -run 'TestMatchAlternationFieldShorthandRespectsField|TestMatchRootAlternationFieldShorthandRespectsParentField|TestQueryStarlarkNestedDictionaryPredicates' -count=1"`

Docker artifacts:

- `/tmp/gts-open-pr-validate/20260417T221038Z-issue44-query-mainbase`
- `/tmp/gts-open-pr-validate/20260417T221940Z-issue47-ci-fix`

CI rerun on `965e299` passed: build, freshness, parity-cgo, and perf-regression.