### PR TITLE
perf(arena): lower retention constants to reduce concurrent RSS

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -22,23 +22,21 @@ const (
 	incrementalFieldSliceCap = 2 * 1024
 	fullFieldSliceCap        = 64 * 1024
 
-	maxRetainedArenaFactor = 4
-	// Full-parse node slabs use a lower factor to reduce peak RSS when many
-	// parsers run concurrently. Each pooled arena can retain up to
-	// factor * defaultNodeCap nodes; at factor=4 this caps warm retention at
-	// ~100 KB per arena vs ~1.6 MB at factor=16.
-	maxRetainedFullNodeArenaFactor  = 4
+	maxRetainedArenaFactor          = 4
 	maxRetainedFullSliceArenaFactor = 4
 
-	// Absolute node-cap retention ceilings. Lower values mean a parser that
-	// parsed a large file does not hold a multi-MB arena warm indefinitely.
-	// Trade-off: very large files will re-grow on the next parse instead of
-	// reusing the retained capacity; the cost is one extra allocation per
-	// large-file parse, which is negligible compared to the parse itself.
-	maxRetainedIncrementalNodeCap  = 256 * 1024
-	maxRetainedFullNodeCap         = 100 * 1024
-	maxRetainedIncrementalSliceCap = 32 * 1024
-	maxRetainedFullSliceCap        = 128 * 1024
+	// Node retention ceilings expressed in bytes. maxRetainedNodeCapacityForClass
+	// converts these to node counts at runtime using sizeof(Node). This ensures
+	// the actual retained memory matches the named byte limit regardless of how
+	// Node's size changes over time.
+	// Trade-off: a parser that handled a large file will reallocate on the next
+	// large parse; one extra allocation is negligible compared to the parse itself.
+	maxRetainedIncrementalNodeBytes = 256 * 1024 // 256 KB per incremental arena
+	maxRetainedFullNodeBytes        = 100 * 1024 // 100 KB per full-parse arena
+
+	// Slice retention ceilings in element counts (not bytes).
+	maxRetainedIncrementalSliceCap = 32 * 1024  // 32 K elements
+	maxRetainedFullSliceCap        = 128 * 1024 // 128 K elements
 
 	// Pool eviction ceiling: arenas that grew beyond this byte budget are not
 	// returned to the pool. Without this guard a single large parse can leave
@@ -197,14 +195,6 @@ func (p *nodeArenaPool) release(a *nodeArena) {
 	if a == nil {
 		return
 	}
-	// Do not return oversized arenas to the pool. An arena that grew past the
-	// eviction ceiling during a large parse would occupy that memory for the
-	// lifetime of the pool. Dropping it here lets the GC reclaim the backing
-	// arrays without affecting correctness: the pool simply allocates a fresh
-	// arena the next time one is needed.
-	if a.class == arenaClassFull && a.allocatedBytes > maxRetainedFullArenaBytes {
-		return
-	}
 	p.mu.Lock()
 	if len(p.free) < p.maxSize {
 		p.free = append(p.free, a)
@@ -289,6 +279,13 @@ func (a *nodeArena) Release() {
 	}
 	if a.refs.Add(-1) != 0 {
 		return
+	}
+	// Eviction guard must fire BEFORE reset(). reset() calls recomputeAllocatedBytes()
+	// which overwrites allocatedBytes with the post-trim retained value (~1-15 MB).
+	// Checking after reset() means an arena that grew to hundreds of MB during a
+	// large parse would report a small retained size and slip back into the pool.
+	if a.class == arenaClassFull && a.allocatedBytes > maxRetainedFullArenaBytes {
+		return // drop; GC collects the backing arrays without reset overhead
 	}
 	a.reset()
 	switch a.class {
@@ -794,13 +791,22 @@ func (a *nodeArena) budgetExhausted() bool {
 }
 
 func maxRetainedNodeCapacityForClass(class arenaClass) int {
-	factor := maxRetainedArenaFactor
-	floor := maxRetainedIncrementalNodeCap
-	if class == arenaClassFull {
-		factor = maxRetainedFullNodeArenaFactor
-		floor = maxRetainedFullNodeCap
+	nodeSize := int(unsafe.Sizeof(Node{}))
+	if nodeSize <= 0 {
+		nodeSize = 1
 	}
-	return max(nodeCapacityForClass(class)*factor, floor)
+	// Full-parse arenas: hard ceiling in bytes. The factor-based path
+	// (2 MB slab * factor) would dwarf the byte limit, so we ignore it and
+	// always return the ceiling. This caps warm retention at ~100 KB per
+	// full-parse arena regardless of how large the slab is.
+	if class == arenaClassFull {
+		return maxRetainedFullNodeBytes / nodeSize
+	}
+	// Incremental arenas: retain at least the byte floor, but also allow the
+	// factor-based path if it is larger (handles workloads that repeatedly
+	// parse files that need more than the floor).
+	floor := maxRetainedIncrementalNodeBytes / nodeSize
+	return max(nodeCapacityForClass(class)*maxRetainedArenaFactor, floor)
 }
 
 func maxRetainedOverflowNodeCapacityForClass(class arenaClass) int {

--- a/arena.go
+++ b/arena.go
@@ -23,17 +23,28 @@ const (
 	fullFieldSliceCap        = 64 * 1024
 
 	maxRetainedArenaFactor = 4
-	// Full-parse node slabs are much larger; keep more headroom so capacity
-	// growth does not thrash between parses.
-	maxRetainedFullNodeArenaFactor  = 16
-	maxRetainedFullSliceArenaFactor = 16
+	// Full-parse node slabs use a lower factor to reduce peak RSS when many
+	// parsers run concurrently. Each pooled arena can retain up to
+	// factor * defaultNodeCap nodes; at factor=4 this caps warm retention at
+	// ~100 KB per arena vs ~1.6 MB at factor=16.
+	maxRetainedFullNodeArenaFactor  = 4
+	maxRetainedFullSliceArenaFactor = 4
 
-	// Absolute node-cap retention ceilings to avoid repeated large reallocation
-	// on warm edit/full-parse workloads.
-	maxRetainedIncrementalNodeCap  = 1 * 1024 * 1024
-	maxRetainedFullNodeCap         = 2 * 1024 * 1024
+	// Absolute node-cap retention ceilings. Lower values mean a parser that
+	// parsed a large file does not hold a multi-MB arena warm indefinitely.
+	// Trade-off: very large files will re-grow on the next parse instead of
+	// reusing the retained capacity; the cost is one extra allocation per
+	// large-file parse, which is negligible compared to the parse itself.
+	maxRetainedIncrementalNodeCap  = 256 * 1024
+	maxRetainedFullNodeCap         = 100 * 1024
 	maxRetainedIncrementalSliceCap = 32 * 1024
-	maxRetainedFullSliceCap        = 1 * 1024 * 1024
+	maxRetainedFullSliceCap        = 128 * 1024
+
+	// Pool eviction ceiling: arenas that grew beyond this byte budget are not
+	// returned to the pool. Without this guard a single large parse can leave
+	// a 100+ MB arena in the pool indefinitely, consumed by every subsequent
+	// parse on that goroutine.
+	maxRetainedFullArenaBytes = 128 * 1024 * 1024
 )
 
 type arenaClass uint8
@@ -184,6 +195,14 @@ func (p *nodeArenaPool) acquire() *nodeArena {
 
 func (p *nodeArenaPool) release(a *nodeArena) {
 	if a == nil {
+		return
+	}
+	// Do not return oversized arenas to the pool. An arena that grew past the
+	// eviction ceiling during a large parse would occupy that memory for the
+	// lifetime of the pool. Dropping it here lets the GC reclaim the backing
+	// arrays without affecting correctness: the pool simply allocates a fresh
+	// arena the next time one is needed.
+	if a.class == arenaClassFull && a.allocatedBytes > maxRetainedFullArenaBytes {
 		return
 	}
 	p.mu.Lock()

--- a/arena.go
+++ b/arena.go
@@ -23,20 +23,22 @@ const (
 	fullFieldSliceCap        = 64 * 1024
 
 	maxRetainedArenaFactor          = 4
-	maxRetainedFullSliceArenaFactor = 4
+	maxRetainedFullSliceArenaFactor = 8
 
 	// Node retention ceilings expressed in bytes. maxRetainedNodeCapacityForClass
 	// converts these to node counts at runtime using sizeof(Node). This ensures
 	// the actual retained memory matches the named byte limit regardless of how
 	// Node's size changes over time.
-	// Trade-off: a parser that handled a large file will reallocate on the next
-	// large parse; one extra allocation is negligible compared to the parse itself.
-	maxRetainedIncrementalNodeBytes = 256 * 1024 // 256 KB per incremental arena
-	maxRetainedFullNodeBytes        = 100 * 1024 // 100 KB per full-parse arena
+	// Full-parse retention keeps enough warm node storage for the standard full
+	// parse benchmark while still capping pathological large-file retention well
+	// below the old multi-hundred-MB node-count ceiling.
+	maxRetainedIncrementalNodeBytes  = 256 * 1024       // 256 KB per incremental arena
+	maxRetainedFullNodeBytes         = 64 * 1024 * 1024 // 64 MB primary node slab
+	maxRetainedFullOverflowNodeBytes = 64 * 1024 * 1024 // 64 MB overflow node slabs
 
 	// Slice retention ceilings in element counts (not bytes).
 	maxRetainedIncrementalSliceCap = 32 * 1024  // 32 K elements
-	maxRetainedFullSliceCap        = 128 * 1024 // 128 K elements
+	maxRetainedFullSliceCap        = 512 * 1024 // 512 K elements
 
 	// Pool eviction ceiling: arenas that grew beyond this byte budget are not
 	// returned to the pool. Without this guard a single large parse can leave
@@ -795,10 +797,9 @@ func maxRetainedNodeCapacityForClass(class arenaClass) int {
 	if nodeSize <= 0 {
 		nodeSize = 1
 	}
-	// Full-parse arenas: hard ceiling in bytes. The factor-based path
-	// (2 MB slab * factor) would dwarf the byte limit, so we ignore it and
-	// always return the ceiling. This caps warm retention at ~100 KB per
-	// full-parse arena regardless of how large the slab is.
+	// Full-parse arenas: hard ceiling in bytes. The factor-based path from the
+	// previous node-count cap could retain hundreds of MB, so use the byte ceiling
+	// directly while keeping enough warm capacity for normal full-parse reuse.
 	if class == arenaClassFull {
 		return maxRetainedFullNodeBytes / nodeSize
 	}
@@ -810,6 +811,9 @@ func maxRetainedNodeCapacityForClass(class arenaClass) int {
 }
 
 func maxRetainedOverflowNodeCapacityForClass(class arenaClass) int {
+	if class == arenaClassFull {
+		return max(nodeCapacityForBytes(maxRetainedFullOverflowNodeBytes), nodeCapacityForClass(class))
+	}
 	return max(maxRetainedNodeCapacityForClass(class)/2, nodeCapacityForClass(class))
 }
 

--- a/arena_test.go
+++ b/arena_test.go
@@ -198,10 +198,10 @@ func TestChildSlabStalePointersAfterReset(t *testing.T) {
 }
 
 // TestNodeRetentionCapRespectsByteLimit checks that the maximum node storage
-// an arena may retain after reset() does not exceed maxRetainedFullNodeBytes.
-// Regression: the old constant was interpreted as node count (102400 nodes =
-// ~15 MB), not bytes (100 KB). The fix stores the ceiling in bytes and converts
-// to node count via sizeof(Node).
+// an arena may retain after reset() does not exceed maxRetainedFullNodeBytes,
+// while still retaining the default full-parse slab for warm reuse.
+// Regression: an earlier PR revision interpreted a byte limit as a node count.
+// The fix stores ceilings in bytes and converts to node counts via sizeof(Node).
 func TestNodeRetentionCapRespectsByteLimit(t *testing.T) {
 	nodeSize := int(unsafe.Sizeof(Node{}))
 	maxNodes := maxRetainedNodeCapacityForClass(arenaClassFull)
@@ -210,6 +210,24 @@ func TestNodeRetentionCapRespectsByteLimit(t *testing.T) {
 		t.Fatalf("maxRetainedNodeCapacityForClass(full) = %d nodes = %d bytes; "+
 			"exceeds intended ceiling %d bytes (%d KB)",
 			maxNodes, actualBytes, maxRetainedFullNodeBytes, maxRetainedFullNodeBytes/1024)
+	}
+	if maxNodes < nodeCapacityForClass(arenaClassFull) {
+		t.Fatalf("maxRetainedNodeCapacityForClass(full) = %d nodes; "+
+			"below default full-parse slab capacity %d nodes",
+			maxNodes, nodeCapacityForClass(arenaClassFull))
+	}
+
+	maxOverflowNodes := maxRetainedOverflowNodeCapacityForClass(arenaClassFull)
+	actualOverflowBytes := maxOverflowNodes * nodeSize
+	if actualOverflowBytes > maxRetainedFullOverflowNodeBytes {
+		t.Fatalf("maxRetainedOverflowNodeCapacityForClass(full) = %d nodes = %d bytes; "+
+			"exceeds intended overflow ceiling %d bytes (%d MB)",
+			maxOverflowNodes, actualOverflowBytes, maxRetainedFullOverflowNodeBytes, maxRetainedFullOverflowNodeBytes/(1024*1024))
+	}
+	if maxOverflowNodes < nodeCapacityForClass(arenaClassFull) {
+		t.Fatalf("maxRetainedOverflowNodeCapacityForClass(full) = %d nodes; "+
+			"below default full-parse slab capacity %d nodes",
+			maxOverflowNodes, nodeCapacityForClass(arenaClassFull))
 	}
 }
 

--- a/arena_test.go
+++ b/arena_test.go
@@ -197,6 +197,45 @@ func TestChildSlabStalePointersAfterReset(t *testing.T) {
 	}
 }
 
+// TestNodeRetentionCapRespectsByteLimit checks that the maximum node storage
+// an arena may retain after reset() does not exceed maxRetainedFullNodeBytes.
+// Regression: the old constant was interpreted as node count (102400 nodes =
+// ~15 MB), not bytes (100 KB). The fix stores the ceiling in bytes and converts
+// to node count via sizeof(Node).
+func TestNodeRetentionCapRespectsByteLimit(t *testing.T) {
+	nodeSize := int(unsafe.Sizeof(Node{}))
+	maxNodes := maxRetainedNodeCapacityForClass(arenaClassFull)
+	actualBytes := maxNodes * nodeSize
+	if actualBytes > maxRetainedFullNodeBytes {
+		t.Fatalf("maxRetainedNodeCapacityForClass(full) = %d nodes = %d bytes; "+
+			"exceeds intended ceiling %d bytes (%d KB)",
+			maxNodes, actualBytes, maxRetainedFullNodeBytes, maxRetainedFullNodeBytes/1024)
+	}
+}
+
+// TestEvictionGuardPreventsOversizedArenaReuse checks that a full-parse arena
+// whose allocatedBytes exceed maxRetainedFullArenaBytes at Release() time is
+// dropped instead of returned to the pool.
+// Regression: the guard was evaluated inside pool.release() AFTER reset() had
+// already called recomputeAllocatedBytes(), overwriting the peak value with the
+// much smaller post-trim value. The guard never fired.
+func TestEvictionGuardPreventsOversizedArenaReuse(t *testing.T) {
+	fullArenaPool.drain()
+
+	a := fullArenaPool.acquire()
+	// Simulate an arena that grew very large during a parse.
+	a.allocatedBytes = maxRetainedFullArenaBytes + 1
+	a.Release()
+
+	fullArenaPool.mu.Lock()
+	poolSize := len(fullArenaPool.free)
+	fullArenaPool.mu.Unlock()
+
+	if poolSize != 0 {
+		t.Fatalf("oversized arena returned to pool (size=%d); eviction guard did not fire", poolSize)
+	}
+}
+
 // TestArenaNodeSlabFullClearOnReset verifies that reset() zeros the full backing
 // array of each node slab, not just [:used]. This is required so that Go's GC
 // can collect Node structs: Node contains pointer fields (children, parent, etc.)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -461,3 +461,32 @@ func TestIncrementalReuseUnavailableReason(t *testing.T) {
 		t.Fatalf("incrementalReuseUnavailableReason(safe external scanner) = %q, want empty", got)
 	}
 }
+
+func TestParseFullArenaNodeCapacityCapsStaleLargeHintBySourceSize(t *testing.T) {
+	sourceLen := 32 * 1024
+	staleLargeHint := parseNodeLimit(2 * 1024 * 1024)
+
+	got := parseFullArenaNodeCapacity(sourceLen, staleLargeHint)
+	limit := parseFullArenaHintLimit(sourceLen)
+	if got != limit {
+		t.Fatalf("parseFullArenaNodeCapacity(%d, stale large hint) = %d, want source-sized limit %d", sourceLen, got, limit)
+	}
+	if got >= staleLargeHint {
+		t.Fatalf("parseFullArenaNodeCapacity kept stale large hint: got %d, stale hint %d", got, staleLargeHint)
+	}
+}
+
+func TestParseFullArenaNodeCapacityKeepsUsefulSameSizeHint(t *testing.T) {
+	sourceLen := 128 * 1024
+	initial := parseFullArenaInitialNodeCapacity(sourceLen)
+	limit := parseFullArenaHintLimit(sourceLen)
+	if initial >= limit {
+		t.Fatalf("test setup invalid: initial=%d limit=%d", initial, limit)
+	}
+	hint := initial + (limit-initial)/2
+
+	got := parseFullArenaNodeCapacity(sourceLen, hint)
+	if got != hint {
+		t.Fatalf("parseFullArenaNodeCapacity(%d, useful hint %d) = %d, want hint", sourceLen, hint, got)
+	}
+}

--- a/parser_limits.go
+++ b/parser_limits.go
@@ -47,20 +47,36 @@ func parseMemoryBudget(sourceLen int) int64 {
 }
 
 func parseFullArenaNodeCapacity(sourceLen, hint int) int {
-	base := nodeCapacityForClass(arenaClassFull)
-	if hint > 0 {
-		if hint < base {
-			return base
-		}
-		limit := parseNodeLimit(sourceLen)
-		if sourceLen <= 0 {
-			return max(base, hint)
-		}
-		if hint > limit {
-			return max(base, limit)
-		}
-		return hint
+	target := parseFullArenaInitialNodeCapacity(sourceLen)
+	if hint <= 0 || hint < target {
+		return target
 	}
+	limit := parseFullArenaHintLimit(sourceLen)
+	if hint > limit {
+		return max(target, limit)
+	}
+	return max(target, hint)
+}
+
+func parseFullArenaHintLimit(sourceLen int) int {
+	base := nodeCapacityForClass(arenaClassFull)
+	if sourceLen <= 0 {
+		return base
+	}
+	// Hints are learned from previous parses on the same Parser. In a ParserPool,
+	// a parser that just handled a large file can later be checked out for a much
+	// smaller file. Cap the reusable hint by the current source size so normal
+	// concurrent full parses do not inherit a stale large-file preallocation.
+	limit := sourceLen
+	retainedFullNodes := nodeCapacityForBytes(maxRetainedFullNodeBytes)
+	if limit > retainedFullNodes {
+		limit = retainedFullNodes
+	}
+	return max(base, limit)
+}
+
+func parseFullArenaInitialNodeCapacity(sourceLen int) int {
+	base := nodeCapacityForClass(arenaClassFull)
 	if sourceLen <= 0 {
 		return base
 	}


### PR DESCRIPTION
## Problem

The dangerous case is not just one oversized arena. A pooled parser can learn a large full-parse arena hint from a big file, then later be checked out for a normal file. Without source-aware bounding, that stale large-file hint can make many normal concurrent full parses allocate much larger arenas than their current source needs.

That is a Go-specific serving concern: we want parser reuse to stay fast, but downstream indexers, language servers, and app servers should be able to run many normal full parses concurrently without each parser inheriting an old large-file footprint.

## Fix

Keep the arena-retention idea, but make reuse bounded by both explicit retention ceilings and the current source size:

- full primary node retention: `64 MB`
- full overflow node retention: `64 MB`
- full child/field/source slice retention: `512 K` elements with factor `8`
- incremental node retention: `256 KB`
- oversized full arenas above `128 MB` are dropped before `reset()` so the peak allocation is still visible to the eviction guard
- full-parse adaptive arena hints are capped by the current source length, up to the retained full-node ceiling, so a parser warmed by a large file cannot over-preallocate a later normal parse

This preserves warm reuse for repeated same-size parses, fixes the corrected byte accounting from review feedback, and keeps many normal concurrent full parses in a different lane from the C runtime model.

Depends on #45 and #46, both now merged.

## Validation

- `go test . -run 'TestParseFullArenaNodeCapacity|TestNodeRetentionCapRespectsByteLimit|TestEvictionGuardPreventsOversizedArenaReuse|TestArena' -count=1`
- Docker focused arena/parser tests: `bash cgo_harness/docker/run_parity_in_docker.sh --repo-root /home/draco/work/gotreesitter/.claude/worktrees/arena-retention-constants --out-root /tmp/gts-open-pr-validate --label pr48-source-sized-hints --memory 2g --cpus 1 --pids 512 --no-build -- "cd /workspace && go test . -run 'TestParseFullArenaNodeCapacity|TestNodeRetentionCapRespectsByteLimit|TestEvictionGuardPreventsOversizedArenaReuse|TestArenaResetRetains|TestArenaNodeSlabFullClearOnReset|TestChildSlabStalePointersAfterReset' -count=1"`
- Local benchgate, `GOMAXPROCS=1`, count=10, benchtime=750ms: full parse, single-byte incremental, no-edit incremental all within gate
- Cached large-file RSS probe: `162400 KB -> 164640 KB`, `+1.38%`, within gate

Artifacts:

- `/tmp/gts-open-pr-validate/20260418T061033Z-pr48-source-sized-hints`
- `/tmp/gts-pr48-bench/base-count10.txt`
- `/tmp/gts-pr48-bench/head-sourcecap-count10.txt`
- `/tmp/gts-pr48-bench/head-sourcecap-rss-time.txt`