### PR TITLE
feat(c_lexer): support `#embed` directive (C23 and C++26 features)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-- Nothing yet.
+### Added
+- C/C++ lexer bridge now accepts `#embed` directive lines and
+  `__has_embed(...)` conditional feature-test forms (including parameter
+  variants) without parse errors.
 
 ## [0.15.2] - 2026-04-21
 

--- a/grammars/c_lexer.go
+++ b/grammars/c_lexer.go
@@ -1291,7 +1291,8 @@ func (ts *CTokenSource) scanOpaqueQuoted(delim byte) {
 
 func isPreprocOpaqueBuiltin(text string) bool {
 	switch text {
-	case "__has_include", "__has_include_next", "__has_embed":
+	case "__has_include", "__has_include_next", "__has_embed",
+		"__has_cpp_attribute", "__has_c_attribute":
 		return true
 	default:
 		return false

--- a/grammars/c_lexer.go
+++ b/grammars/c_lexer.go
@@ -38,11 +38,13 @@ type CTokenSource struct {
 	rBraceSymbol           gotreesitter.Symbol
 
 	// Preprocessor state tracking
-	preprocState         int
-	parserState          gotreesitter.StateID
-	glrStates            []gotreesitter.StateID
-	lastSyntheticOffset  int
-	preprocDefineNameEnd int
+	preprocState            int
+	parserState             gotreesitter.StateID
+	glrStates               []gotreesitter.StateID
+	lastSyntheticOffset     int
+	preprocDefineNameEnd    int
+	preprocOpaqueArgPending bool
+	preprocOpaqueArgActive  bool
 
 	keywordSymbols    map[string]gotreesitter.Symbol
 	literalSymbols    map[string]gotreesitter.Symbol
@@ -173,6 +175,8 @@ func (ts *CTokenSource) Reset(src []byte) {
 	ts.glrStates = ts.glrStates[:0]
 	ts.lastSyntheticOffset = -1
 	ts.preprocDefineNameEnd = -1
+	ts.preprocOpaqueArgPending = false
+	ts.preprocOpaqueArgActive = false
 }
 
 // Close clears parser-owned state and returns this token source to the pool.
@@ -208,6 +212,8 @@ func (ts *CTokenSource) Close() {
 	ts.glrStates = ts.glrStates[:0]
 	ts.lastSyntheticOffset = -1
 	ts.preprocDefineNameEnd = -1
+	ts.preprocOpaqueArgPending = false
+	ts.preprocOpaqueArgActive = false
 	ts.keywordSymbols = nil
 	ts.literalSymbols = nil
 	ts.literalAlternates = nil
@@ -260,6 +266,8 @@ func (ts *CTokenSource) Next() gotreesitter.Token {
 
 		// Newline handling: in preprocessor context, emit as directive terminator
 		if b == '\n' {
+			ts.preprocOpaqueArgPending = false
+			ts.preprocOpaqueArgActive = false
 			if ts.preprocState == cPreprocConditionalExpr && ts.newlineSymbol != 0 {
 				ts.preprocState = cPreprocNormal
 				return ts.lineEndToken(ts.newlineSymbol)
@@ -297,6 +305,11 @@ func (ts *CTokenSource) Next() gotreesitter.Token {
 		}
 		if ts.preprocState == cPreprocAfterName && ts.preprocArgSymbol != 0 {
 			if tok, ok := ts.preprocArgToken(); ok {
+				return tok
+			}
+		}
+		if ts.preprocOpaqueArgActive {
+			if tok, ok := ts.opaquePreprocArgToken(); ok {
 				return tok
 			}
 		}
@@ -361,6 +374,8 @@ func (ts *CTokenSource) SkipToByte(offset uint32) gotreesitter.Token {
 	ts.glrStates = ts.glrStates[:0]
 	ts.lastSyntheticOffset = -1
 	ts.preprocDefineNameEnd = -1
+	ts.preprocOpaqueArgPending = false
+	ts.preprocOpaqueArgActive = false
 
 	if target < ts.cur.offset {
 		ts.cur = newSourceCursor(ts.src)
@@ -724,6 +739,13 @@ func (ts *CTokenSource) identifierOrKeywordToken() gotreesitter.Token {
 	} else if ts.primitiveTypeSymbol != 0 && isCPrimitiveType(text) {
 		sym = ts.primitiveTypeSymbol
 	}
+	if ts.preprocState == cPreprocConditionalExpr {
+		if isPreprocOpaqueBuiltin(text) {
+			ts.preprocOpaqueArgPending = true
+		} else {
+			ts.preprocOpaqueArgPending = false
+		}
+	}
 	return makeToken(sym, ts.src, start, ts.cur.offset, startPt, ts.cur.point())
 }
 
@@ -825,9 +847,14 @@ func (ts *CTokenSource) directiveToken() (gotreesitter.Token, bool) {
 	ts.cur.advanceBytes(end - start)
 	ts.preprocState = cPreprocNormal
 	ts.lastSyntheticOffset = -1
+	ts.preprocOpaqueArgPending = false
+	ts.preprocOpaqueArgActive = false
 
 	tok := makeToken(specificSym, ts.src, start, ts.cur.offset, startPt, ts.cur.point())
 	ts.updatePreprocStateForLiteral(canonical)
+	if specificSym == ts.preprocDirectiveSymbol && canonical != "#if" && canonical != "#elif" {
+		ts.preprocState = cPreprocAfterName
+	}
 	return tok, true
 }
 
@@ -912,6 +939,8 @@ func (ts *CTokenSource) emitGenericDirectiveLine(directiveEnd int) gotreesitter.
 	ts.cur = argProbe
 	ts.preprocState = cPreprocNormal
 	ts.lastSyntheticOffset = -1
+	ts.preprocOpaqueArgPending = false
+	ts.preprocOpaqueArgActive = false
 	return dirTok
 }
 
@@ -954,21 +983,6 @@ func (ts *CTokenSource) nextLineStartsWithBraceThenDirective(want string) bool {
 	i = skipCSpacesAndTabs(ts.src, i)
 	_, canonical, _, ok := ts.scanDirective(i)
 	return ok && canonical == want
-}
-
-func (ts *CTokenSource) preprocDirectiveState(text string) int {
-	switch text {
-	case "#define":
-		return cPreprocAfterDefine
-	case "#include":
-		return cPreprocAfterInclude
-	case "#if", "#elif":
-		return cPreprocConditionalExpr
-	case "#pragma", "#undef", "#error", "#warning":
-		return cPreprocAfterName
-	default:
-		return cPreprocNormal
-	}
 }
 
 func (ts *CTokenSource) matchLiteral() (gotreesitter.Symbol, int) {
@@ -1029,11 +1043,6 @@ func (ts *CTokenSource) eofToken() gotreesitter.Token {
 	}
 }
 
-// preprocEndToken emits a preprocessor line terminator token for \n.
-// The C grammar uses preproc_include_token2 as the directive delimiter.
-func (ts *CTokenSource) preprocEndToken() gotreesitter.Token {
-	return ts.lineEndToken(ts.preprocEndSymbol)
-}
 func (ts *CTokenSource) lineEndToken(sym gotreesitter.Symbol) gotreesitter.Token {
 	start := ts.cur.offset
 	startPt := ts.cur.point()
@@ -1081,8 +1090,19 @@ func (ts *CTokenSource) preprocArgToken() (gotreesitter.Token, bool) {
 		}
 		if b == '/' && ts.cur.offset+1 < len(ts.src) {
 			next := ts.src[ts.cur.offset+1]
-			if next == '/' || next == '*' {
+			if next == '/' {
 				break
+			}
+			if next == '*' {
+				commentStart := ts.cur
+				ts.consumeBlockComment()
+				afterComment := ts.cur
+				afterComment.skipSpacesAndTabs()
+				if afterComment.eof() || afterComment.peekByte() == '\n' {
+					ts.cur = commentStart
+					break
+				}
+				continue
 			}
 		}
 		if b == '\\' && ts.cur.offset+1 < len(ts.src) && ts.src[ts.cur.offset+1] == '\n' {
@@ -1099,6 +1119,22 @@ func (ts *CTokenSource) preprocArgToken() (gotreesitter.Token, bool) {
 
 	// Leave preprocState > 0 so the following \n is emitted as a token
 	return makeToken(ts.preprocArgSymbol, ts.src, start, ts.cur.offset, startPt, ts.cur.point()), true
+}
+
+func (ts *CTokenSource) consumeBlockComment() {
+	if ts.cur.offset+1 >= len(ts.src) || ts.src[ts.cur.offset] != '/' || ts.src[ts.cur.offset+1] != '*' {
+		return
+	}
+	ts.cur.advanceByte()
+	ts.cur.advanceByte()
+	for !ts.cur.eof() {
+		if ts.cur.peekByte() == '*' && ts.cur.offset+1 < len(ts.src) && ts.src[ts.cur.offset+1] == '/' {
+			ts.cur.advanceByte()
+			ts.cur.advanceByte()
+			return
+		}
+		ts.cur.advanceRune()
+	}
 }
 
 func (ts *CTokenSource) systemLibStringToken() (gotreesitter.Token, bool) {
@@ -1126,6 +1162,14 @@ func (ts *CTokenSource) systemLibStringToken() (gotreesitter.Token, bool) {
 // preproc_include_token2, while #if/#elif condition lines tokenize their
 // expression normally and terminate with the literal newline token.
 func (ts *CTokenSource) updatePreprocStateForLiteral(text string) {
+	if ts.preprocState == cPreprocConditionalExpr && ts.preprocOpaqueArgPending {
+		if text == "(" {
+			ts.preprocOpaqueArgPending = false
+			ts.preprocOpaqueArgActive = true
+		} else if text != "" {
+			ts.preprocOpaqueArgPending = false
+		}
+	}
 	if ts.preprocState == cPreprocAfterDefineParams {
 		if text == ")" {
 			ts.preprocState = cPreprocAfterName
@@ -1139,8 +1183,118 @@ func (ts *CTokenSource) updatePreprocStateForLiteral(text string) {
 		ts.preprocState = cPreprocAfterInclude
 	case "#if", "#elif":
 		ts.preprocState = cPreprocConditionalExpr
-	case "#pragma", "#undef", "#error", "#warning":
+	case "#pragma", "#undef", "#error", "#warning", "#line", "#embed":
 		ts.preprocState = cPreprocAfterName
+	}
+}
+
+// opaquePreprocArgToken collapses feature-test arguments like __has_include(...)
+// and __has_embed(...) into one identifier token so legacy C/C++ grammars can
+// accept modern preprocessor argument forms.
+func (ts *CTokenSource) opaquePreprocArgToken() (gotreesitter.Token, bool) {
+	if !ts.preprocOpaqueArgActive || ts.identifierSymbol == 0 {
+		ts.preprocOpaqueArgActive = false
+		return gotreesitter.Token{}, false
+	}
+
+	ts.cur.skipSpacesAndTabs()
+	if ts.cur.eof() || ts.cur.peekByte() == '\n' || ts.cur.peekByte() == ')' {
+		ts.preprocOpaqueArgActive = false
+		return gotreesitter.Token{}, false
+	}
+
+	start := ts.cur.offset
+	startPt := ts.cur.point()
+	depth := 0
+	for !ts.cur.eof() {
+		b := ts.cur.peekByte()
+		if b == '\n' {
+			break
+		}
+		if b == '/' && ts.cur.offset+1 < len(ts.src) {
+			next := ts.src[ts.cur.offset+1]
+			if next == '/' {
+				break
+			}
+			if next == '*' {
+				ts.consumeBlockComment()
+				continue
+			}
+		}
+		if b == '"' || b == '\'' {
+			ts.scanOpaqueQuoted(b)
+			continue
+		}
+		if b == '\\' && ts.cur.offset+1 < len(ts.src) {
+			next := ts.src[ts.cur.offset+1]
+			if next == '\n' {
+				ts.cur.advanceByte()
+				ts.cur.advanceByte()
+				continue
+			}
+			if next == '\r' {
+				ts.cur.advanceByte()
+				ts.cur.advanceByte()
+				if !ts.cur.eof() && ts.cur.peekByte() == '\n' {
+					ts.cur.advanceByte()
+				}
+				continue
+			}
+		}
+		if b == '(' {
+			depth++
+			ts.cur.advanceByte()
+			continue
+		}
+		if b == ')' {
+			if depth == 0 {
+				ts.preprocOpaqueArgActive = false
+				if ts.cur.offset <= start {
+					return gotreesitter.Token{}, false
+				}
+				return makeToken(ts.identifierSymbol, ts.src, start, ts.cur.offset, startPt, ts.cur.point()), true
+			}
+			depth--
+			ts.cur.advanceByte()
+			continue
+		}
+		ts.cur.advanceRune()
+	}
+
+	ts.preprocOpaqueArgActive = false
+	if ts.cur.offset <= start {
+		return gotreesitter.Token{}, false
+	}
+	return makeToken(ts.identifierSymbol, ts.src, start, ts.cur.offset, startPt, ts.cur.point()), true
+}
+
+func (ts *CTokenSource) scanOpaqueQuoted(delim byte) {
+	ts.cur.advanceByte()
+	for !ts.cur.eof() {
+		b := ts.cur.peekByte()
+		if b == '\n' {
+			return
+		}
+		if b == '\\' {
+			ts.cur.advanceByte()
+			if !ts.cur.eof() {
+				ts.cur.advanceRune()
+			}
+			continue
+		}
+		ts.cur.advanceRune()
+		if b == delim {
+			return
+		}
+	}
+}
+
+func isPreprocOpaqueBuiltin(text string) bool {
+	switch text {
+	case "__has_include", "__has_include_next", "__has_embed":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/grammars/c_lexer_test.go
+++ b/grammars/c_lexer_test.go
@@ -252,6 +252,211 @@ func TestParseCMultilineFunctionLikeMacro(t *testing.T) {
 	}
 }
 
+func TestCTokenSourceEmbedDirectiveTokenSequence(t *testing.T) {
+	lang := CLanguage()
+	src := []byte(`#embed "payload.bin" limit(4) prefix(0x) suffix(,) if_empty(0)
+`)
+	ts, err := NewCTokenSource(src, lang)
+	if err != nil {
+		t.Fatalf("NewCTokenSource failed: %v", err)
+	}
+
+	var got []string
+	for {
+		tok := ts.Next()
+		if tok.Symbol == 0 {
+			break
+		}
+		got = append(got, lang.SymbolNames[tok.Symbol])
+	}
+
+	want := []string{"preproc_directive", "preproc_arg", "preproc_include_token2"}
+	if len(got) != len(want) {
+		t.Fatalf("token count = %d, want %d; got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d = %q, want %q; got=%v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestCTokenSourceEmbedDirectiveWithBlockCommentTokenSequence(t *testing.T) {
+	lang := CLanguage()
+	src := []byte(`#embed "payload.bin" /* keep */ limit(4)
+`)
+	ts, err := NewCTokenSource(src, lang)
+	if err != nil {
+		t.Fatalf("NewCTokenSource failed: %v", err)
+	}
+
+	var got []string
+	for {
+		tok := ts.Next()
+		if tok.Symbol == 0 {
+			break
+		}
+		got = append(got, lang.SymbolNames[tok.Symbol])
+	}
+
+	want := []string{"preproc_directive", "preproc_arg", "preproc_include_token2"}
+	if len(got) != len(want) {
+		t.Fatalf("token count = %d, want %d; got=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("token %d = %q, want %q; got=%v", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestParseCAndCppEmbedDirectiveParsesAsPreprocCall(t *testing.T) {
+	src := []byte(`#embed "payload.bin" limit(4) prefix(0x) suffix(,) if_empty(0)
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppEmbedDirectiveAngleHeaderParsesAsPreprocCall(t *testing.T) {
+	src := []byte(`#embed <payload.bin> limit(16) suffix(,)
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppHasEmbedFeatureTestParsesAsConditional(t *testing.T) {
+	src := []byte(`#if __has_embed("payload.bin" limit(4) prefix(0x) if_empty(0))
+int payload_enabled = 1;
+#endif
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppHasEmbedFeatureTestAngleHeaderParsesAsConditional(t *testing.T) {
+	src := []byte(`#if __has_embed(<payload.bin> suffix(,))
+int payload_enabled = 1;
+#endif
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppHasIncludeFeatureTestParsesAsConditional(t *testing.T) {
+	src := []byte(`#if __has_include("payload.h")
+int include_available = 1;
+#endif
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppHasEmbedFeatureTestWithBlockCommentsParsesAsConditional(t *testing.T) {
+	src := []byte(`#if __has_embed(/* lead */ "payload.bin" /* middle */ limit(4) /* tail */)
+int payload_enabled = 1;
+#endif
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppHasIncludeFeatureTestWithBlockCommentParsesAsConditional(t *testing.T) {
+	src := []byte(`#if __has_include(/* lead */ "payload.h")
+int include_available = 1;
+#endif
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func TestParseCAndCppEmbedDirectiveParameterVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		src  []byte
+	}{
+		{
+			name: "c23 alternate parameter spellings",
+			src: []byte(`#embed "payload.bin" __limit__(4) __prefix__(0x,) __suffix__(,) __if_empty__(0)
+`),
+		},
+		{
+			name: "cpp26 non-standard namespaced parameters",
+			src: []byte(`#embed "payload.bin" vendor::x vendor::y(1, 2)
+`),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testParseCAndCppNoError(t, tc.src)
+		})
+	}
+}
+
+func TestParseCAndCppHasEmbedAndHasIncludeVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		src  []byte
+	}{
+		{
+			name: "has_embed with alternate parameter spellings",
+			src: []byte(`#if __has_embed(<payload.bin> __limit__(4) __prefix__(0x,) __suffix__(,) __if_empty__(0))
+int payload_enabled = 1;
+#endif
+`),
+		},
+		{
+			name: "has_embed with namespaced parameters",
+			src: []byte(`#if __has_embed("payload.bin" vendor::x vendor::y(1, 2))
+int payload_enabled = 1;
+#endif
+`),
+		},
+		{
+			name: "has_include_next",
+			src: []byte(`#if __has_include_next(<payload.h>)
+int include_next_available = 1;
+#endif
+`),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testParseCAndCppNoError(t, tc.src)
+		})
+	}
+}
+
+func TestParseCAndCppLineDirectiveParsesAsPreprocCall(t *testing.T) {
+	src := []byte(`#line 123 "source.c"
+int line_adjusted = 0;
+`)
+	testParseCAndCppNoError(t, src)
+}
+
+func testParseCAndCppNoError(t *testing.T, src []byte) {
+	t.Helper()
+	tests := []struct {
+		name string
+		lang *gotreesitter.Language
+	}{
+		{name: "c", lang: CLanguage()},
+		{name: "cpp", lang: CppLanguage()},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parser := gotreesitter.NewParser(tc.lang)
+			ts, err := NewCTokenSource(src, tc.lang)
+			if err != nil {
+				t.Fatalf("NewCTokenSource failed: %v", err)
+			}
+			tree, err := parser.ParseWithTokenSource(src, ts)
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			root := tree.RootNode()
+			if root == nil {
+				t.Fatal("nil root")
+			}
+			if root.HasError() {
+				t.Fatalf("parse has errors: %s", root.SExpr(tc.lang))
+			}
+		})
+	}
+}
+
 func TestParseCppUsingDeclarationKeepsScopeFieldOffSeparator(t *testing.T) {
 	lang := CppLanguage()
 	parser := gotreesitter.NewParser(lang)

--- a/grammars/c_lexer_test.go
+++ b/grammars/c_lexer_test.go
@@ -411,6 +411,20 @@ int include_next_available = 1;
 #endif
 `),
 		},
+		{
+			name: "has_cpp_attribute with namespaced name",
+			src: []byte(`#if __has_cpp_attribute(vendor::likely)
+int vendor_likely_available = 1;
+#endif
+`),
+		},
+		{
+			name: "has_c_attribute with namespaced name",
+			src: []byte(`#if __has_c_attribute(clang::musttail)
+int clang_musttail_available = 1;
+#endif
+`),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

C/C++ lexer bridge now accepts `#embed` directive lines and `__has_embed(...)` conditional feature-test forms (including  parameter variants) without parse errors.

NOTE: The `#embed` directive is not yet supported in the original `tree-sitter`. This PR implements it ahead of upstream to support modern C23/C++26 codebases in Go. Please note that if upstream introduces a different AST structure in the future, this implementation may need to be adjusted for continued parity.

## Why this approach?

The previous C/C++ lexer was unable to process the `#embed` directive correctly.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
- [x] Affected parity validation ran in Docker, one language or grammar at a time
- [x] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

<!-- Keep correctness gating separate from performance gating. -->
<!-- Do not use host-side repo-wide sweeps. -->
<!-- Examples:
- bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./grammargen -run '^TestName$' -count=1"
- bash cgo_harness/docker/run_single_grammar_parity.sh <grammar>
- bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs <language>
- bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs <language>
-->

Although `bash cgo_harness/docker/run_single_grammar_parity.sh cpp` shows failures, I've verified that the error count and specific failure points remain identical to the `main` branch.

## Performance

- [x] If perf-relevant, used the stable bench settings (`GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem`)
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
- [x] If large-grammar behavior changed, checked bounded RSS, timeout, or OOM behavior under Docker

<!-- Benchmark after correctness passes. Prefer the primary bench trio in AGENTS.md. -->

Performance is not goal of this PR.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

Review your own diff before requesting review. Walk through it as if you're seeing it for the first time, and keep any self-review comments concise and focused on the non-obvious parts.

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars
- [x] If adding a grammar or scanner: verified against upstream C output