### PR TITLE
fix(csharp): bound recovery on pathological inputs

### DIFF
--- a/parser_api.go
+++ b/parser_api.go
@@ -98,11 +98,22 @@ func (p *Parser) parseForRecovery(source []byte) (*Tree, error) {
 }
 
 func parseWithSnippetParser(lang *Language, source []byte) (*Tree, error) {
+	return parseWithSnippetParserTimed(lang, source, 0)
+}
+
+// parseWithSnippetParserTimed is parseWithSnippetParser with a per-parse
+// timeout. Used by recovery paths (e.g. csharpRecoverNamespaceFromChildren)
+// to inherit the parent parser's timeout — without this, the snippet pool
+// resets timeoutMicros to 0 and recovery sub-parses could run unbounded.
+func parseWithSnippetParserTimed(lang *Language, source []byte, timeoutMicros uint64) (*Tree, error) {
 	parser := acquireSnippetParser(lang)
 	if parser == nil {
 		return nil, ErrNoLanguage
 	}
 	defer releaseSnippetParser(parser)
+	if timeoutMicros > 0 {
+		parser.timeoutMicros = timeoutMicros
+	}
 	return parser.Parse(source)
 }
 

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2,6 +2,7 @@ package gotreesitter
 
 import (
 	"testing"
+	"time"
 )
 
 type parserTestUnsafeExternalScanner struct{}
@@ -129,6 +130,55 @@ func TestShouldRunInitialFullParseMergeRetry(t *testing.T) {
 	tree.parseRuntime.StopReason = ParseStopNoStacksAlive
 	if !shouldRunInitialFullParseMergeRetry(tree) {
 		t.Fatal("shouldRunInitialFullParseMergeRetry(no_stacks_alive) = false, want true")
+	}
+}
+
+func TestRetryFullParseStopsSchedulingRetriesAfterTimeout(t *testing.T) {
+	parser := &Parser{timeoutMicros: 500}
+	source := []byte("1+")
+	initial := &Tree{
+		root: &Node{
+			endByte:  1,
+			hasError: true,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: uint32(len(source)),
+			MaxStacksSeen:   2,
+			NodesAllocated:  20,
+		},
+	}
+	retry := &Tree{
+		root: &Node{
+			endByte:  2,
+			hasError: true,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: uint32(len(source)),
+			MaxStacksSeen:   2,
+			NodesAllocated:  10,
+		},
+	}
+	calls := 0
+
+	got := parser.retryFullParse(source, 2, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+		calls++
+		if calls != 1 {
+			t.Fatalf("runRetry called %d times, want exactly one retry before timeout cutoff", calls)
+		}
+		if maxMergePerKeyOverride == 0 {
+			t.Fatalf("first retry maxMergePerKeyOverride = 0, want initial merge retry")
+		}
+		time.Sleep(2 * time.Millisecond)
+		return retry
+	})
+
+	if got != retry {
+		t.Fatalf("retryFullParse returned %p, want retry tree %p", got, retry)
+	}
+	if calls != 1 {
+		t.Fatalf("runRetry calls = %d, want 1", calls)
 	}
 }
 

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -9,11 +9,18 @@ import (
 const (
 	csharpMaxTopLevelChunkRecoverySourceBytes = 4096
 	csharpMaxTopLevelChunkRecoverySpans       = 128
+
+	// csharpMaxNamespaceRecoveries caps how many top-level error nodes we
+	// re-parse via parseWithSnippetParser. Each recovery is itself a full
+	// snippet parse — on pathological inputs (e.g. C# with CJK identifiers
+	// or many nested partial classes) the recovery loop can be triggered
+	// dozens of times per file, multiplying parse time/memory.
+	csharpMaxNamespaceRecoveries = 32
 )
 
 func normalizeCSharpCompatibility(root *Node, source []byte, p *Parser, lang *Language) {
 	normalizeCSharpRecoveredTopLevelChunks(root, source, p)
-	normalizeCSharpRecoveredNamespaces(root, source, lang)
+	normalizeCSharpRecoveredNamespaces(root, source, p, lang)
 	normalizeCSharpRecoveredTypeDeclarations(root, source, lang)
 	normalizeCollapsedNamedLeafChildren(root, lang, "implicit_type", "var")
 	normalizeCSharpUnicodeIdentifierSpans(root, source, lang)
@@ -355,7 +362,7 @@ func csharpFindBlockCommentEnd(source []byte, start, end uint32) uint32 {
 	return 0
 }
 
-func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, lang *Language) {
+func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, p *Parser, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "c_sharp" || len(source) == 0 || root.ownerArena == nil {
 		return
 	}
@@ -363,14 +370,26 @@ func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, lang *Languag
 	if rootType != "ERROR" && rootType != "compilation_unit" {
 		return
 	}
+	// Inherit the parent parser's per-parse timeout so each snippet sub-parse
+	// the recovery triggers is bounded too. Without this, the snippet pool
+	// resets timeoutMicros to 0 (parser_pool_reset.go) and the inner parses
+	// can run unbounded.
+	var snippetTimeoutMicros uint64
+	if p != nil {
+		snippetTimeoutMicros = p.timeoutMicros
+	}
 	recoveredChildren := make([]*Node, 0, len(root.children))
 	changed := false
+	recoveryCount := 0
 	for i := 0; i < len(root.children); {
-		if recovered, next, ok := csharpRecoverNamespaceFromChildren(root.children, i, source, lang, root.ownerArena); ok {
-			recoveredChildren = append(recoveredChildren, recovered)
-			i = next
-			changed = true
-			continue
+		if recoveryCount < csharpMaxNamespaceRecoveries {
+			if recovered, next, ok := csharpRecoverNamespaceFromChildren(root.children, i, source, lang, root.ownerArena, snippetTimeoutMicros); ok {
+				recoveredChildren = append(recoveredChildren, recovered)
+				i = next
+				changed = true
+				recoveryCount++
+				continue
+			}
 		}
 		if child := root.children[i]; child != nil {
 			if recovered, ok := csharpRecoverWrappedTopLevelDeclaration(child, lang, root.ownerArena); ok {
@@ -403,7 +422,7 @@ func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, lang *Languag
 	}
 }
 
-func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source []byte, lang *Language, arena *nodeArena) (*Node, int, bool) {
+func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source []byte, lang *Language, arena *nodeArena, snippetTimeoutMicros uint64) (*Node, int, bool) {
 	if startIdx < 0 || startIdx >= len(children) || lang == nil || arena == nil {
 		return nil, startIdx, false
 	}
@@ -430,7 +449,7 @@ func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source [
 		return nil, startIdx, false
 	}
 	nsEnd := uint32(closeBrace + 1)
-	recovered, ok := csharpRecoverNamespaceNodeFromRange(source, nsStart, nsEnd, lang, arena)
+	recovered, ok := csharpRecoverNamespaceNodeFromRange(source, nsStart, nsEnd, lang, arena, snippetTimeoutMicros)
 	if !ok {
 		return nil, startIdx, false
 	}
@@ -449,11 +468,11 @@ func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source [
 	return recovered, nextIdx, true
 }
 
-func csharpRecoverNamespaceNodeFromRange(source []byte, start, end uint32, lang *Language, arena *nodeArena) (*Node, bool) {
+func csharpRecoverNamespaceNodeFromRange(source []byte, start, end uint32, lang *Language, arena *nodeArena, snippetTimeoutMicros uint64) (*Node, bool) {
 	if lang == nil || arena == nil || start >= end || int(end) > len(source) {
 		return nil, false
 	}
-	tree, err := parseWithSnippetParser(lang, source[start:end])
+	tree, err := parseWithSnippetParserTimed(lang, source[start:end], snippetTimeoutMicros)
 	if err != nil || tree == nil || tree.RootNode() == nil {
 		if tree != nil {
 			tree.Release()

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1,5 +1,7 @@
 package gotreesitter
 
+import "time"
+
 const (
 	// Retry no-stacks-alive full parses with a wider GLR cap. Large real-world
 	// files (for example this repo's parser.go) can legitimately need >8 stacks
@@ -429,6 +431,21 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 		retryMaxStacks = maxStacksOverride
 	}
 
+	// retryDeadline caps the cumulative wall time spent across retry
+	// iterations. Without it, a pathological input that triggers all four
+	// retry branches (initial-merge, node-limit, secondary-node-limit, final
+	// merge-per-key) can run far longer than the caller's SetTimeoutMicros
+	// budget — the parser polls timeoutMicros inside the parse loop, but
+	// between retries the budget isn't re-checked. We honor the same budget
+	// as a wall-clock deadline shared across retry attempts.
+	retryStart := time.Now()
+	retryDeadlineExceeded := func() bool {
+		if p == nil || p.timeoutMicros == 0 {
+			return false
+		}
+		return time.Since(retryStart) > time.Duration(p.timeoutMicros)*time.Microsecond
+	}
+
 	// Each runRetry() produces a fresh Tree + arena. When a candidate loses
 	// the compare, release its arena back to the pool immediately so later
 	// runRetry() calls in this same retryFullParse can reuse it; otherwise
@@ -465,6 +482,9 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 			}
 		}
 	}
+	if retryDeadlineExceeded() {
+		return bestTree
+	}
 
 	nodeRetryTree := tree
 	if maxStacksOverride == 0 && maxNodesOverride == 0 {
@@ -477,6 +497,10 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 		// retry sequence is done. If it doesn't end up bestTree, we release
 		// it at function exit via the sentinel below.
 		nodeRetryTree = retryTree
+		if retryDeadlineExceeded() {
+			replaceBest(&bestTree, retryTree)
+			return bestTree
+		}
 		if extraNodeLimit := fullParseRetrySecondaryNodeLimitOverride(retryTree, len(source)); extraNodeLimit > 0 {
 			secondaryTree := runRetry(retryMaxStacks, 0, extraNodeLimit)
 			// Fold the primary retry into bestTree before we overwrite
@@ -506,6 +530,12 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 	}
 	maxMergePerKeyOverride := fullParseRetryMergePerKeyOverride(nodeRetryTree, len(source), initialMaxStacks)
 	if maxMergePerKeyOverride == 0 {
+		if nodeRetryTree != nil && nodeRetryTree != bestTree && nodeRetryTree != tree {
+			release(nodeRetryTree)
+		}
+		return bestTree
+	}
+	if retryDeadlineExceeded() {
 		if nodeRetryTree != nil && nodeRetryTree != bestTree && nodeRetryTree != tree {
 			release(nodeRetryTree)
 		}

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -435,9 +435,9 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 	// iterations. Without it, a pathological input that triggers all four
 	// retry branches (initial-merge, node-limit, secondary-node-limit, final
 	// merge-per-key) can run far longer than the caller's SetTimeoutMicros
-	// budget — the parser polls timeoutMicros inside the parse loop, but
-	// between retries the budget isn't re-checked. We honor the same budget
-	// as a wall-clock deadline shared across retry attempts.
+	// budget. The parser polls timeoutMicros inside the parse loop, but between
+	// retries the budget was not re-checked. We honor the same budget as a
+	// wall-clock deadline shared across retry attempts.
 	retryStart := time.Now()
 	retryDeadlineExceeded := func() bool {
 		if p == nil || p.timeoutMicros == 0 {
@@ -536,9 +536,6 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 		return bestTree
 	}
 	if retryDeadlineExceeded() {
-		if nodeRetryTree != nil && nodeRetryTree != bestTree && nodeRetryTree != tree {
-			release(nodeRetryTree)
-		}
 		return bestTree
 	}
 	mergeRetryTree := runRetry(retryMaxStacks, maxMergePerKeyOverride, maxNodesOverride)


### PR DESCRIPTION
## Summary

Three independent bugs in the C# recovery + retry path let a single file containing pathological constructs (e.g. partial classes with CJK identifiers in XML doc comments) blow past `SetTimeoutMicros` and allocate gigabytes of heap. This PR adds bounded loops + propagates the parser timeout into the recovery sub-parses.

## The bugs

### 1. `parseWithSnippetParser` ignored the parent parser's timeout
`acquireSnippetParser` → `resetSnippetParser` (parser.go) sets `timeoutMicros = 0` and `cancellationFlag = nil`. So when `csharpRecoverNamespaceFromChildren` triggers a snippet sub-parse via `parseWithSnippetParser`, the inner parse has no timeout — even if the outer caller configured one via `Parser.SetTimeoutMicros`.

**Fix**: new `parseWithSnippetParserTimed(lang, source, timeoutMicros)` that propagates the parent timeout. The old `parseWithSnippetParser` is preserved as a pass-through so other call sites are untouched.

### 2. C# namespace recovery had no per-file iteration cap
`normalizeCSharpRecoveredNamespaces` walks every top-level `ERROR` / `global_statement` / `statement` node in the root and triggers a fresh snippet sub-parse per match. On files with many error nodes (e.g. a `partial class Logic贴合` whose initial parse failed in multiple places due to mixed-language identifiers), this loop runs dozens of times — each iteration is a full snippet parse.

**Fix**: cap recoveries at `csharpMaxNamespaceRecoveries = 32` per top-level parse. This mirrors the existing `csharpMaxTopLevelChunkRecoverySpans = 128` cap at the top of the same file. Beyond 32 recoveries the parse is so malformed that more recovery rarely helps, but reliably amplifies cost.

### 3. `retryFullParse` didn't honor `SetTimeoutMicros` between iterations
The timeout is checked inside the GLR parse loop, but `retryFullParse` runs up to four sequential retry passes (initial-merge, node-limit-override, secondary-node-limit, final merge-per-key). Each pass is its own `parseInternal` call with its own `parseStart`. So a 10-second `SetTimeoutMicros` budget could spend 40+ seconds before returning.

**Fix**: track wall-clock from the start of `retryFullParse` and bail with the best tree so far once `p.timeoutMicros` is exceeded.

## Verification

- All existing short tests in the root package pass (`go test -count=1 -short -timeout 600s .` → ok).
- A real-world drop of 330 customer C# files (mix of standard code, WinForms designer files, and partial classes with CJK identifiers) that previously OOM-killed the process at 12+ GB RSS now completes with bounded memory after combining these patches with a small per-file timeout on the calling side.
- The library tests for `ParseStopMemoryBudget` and the snippet-parser round-trip continue to pass.

## What this doesn't fix (separate concern)

A single `parseInternal` invocation can still allocate hundreds of MB during one outer iteration on highly ambiguous inputs (the GLR algorithm forks stacks during `mergeStacksWithScratch` and `stackEntryNodesEquivalentFrontierWithScratch`). The existing `parseMemoryBudget` infrastructure is wired up correctly at `parser.go:1241` (`arena.setBudget(parseMemoryBudget(len(source)))`) so each pass is bounded by the configured 512 MB ceiling, but multiple retries × multiple snippet recoveries can multiply this. Filing this as a separate concern — likely needs either a parser-wide cumulative budget or tighter inner-loop allocation checks.

## Diff stats

- `parser_api.go` — new `parseWithSnippetParserTimed` (+11 lines)
- `parser_result_csharp.go` — namespace-recovery cap + timeout propagation (+30 / -11 lines)
- `parser_retry.go` — retry deadline (+30 lines)

Total: 3 files, +71 / -11 lines. No public API changes; existing callers unaffected.