### PR TITLE
Extract parser result strut boundary

### DIFF
--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -1,5 +1,103 @@
 package gotreesitter
 
+// resultCompatibilityStrut is a language-specific post-build tree rewrite.
+//
+// These are deliberately named as struts: they hold up parity while the parser,
+// scanner, or grammargen output is not yet producing the final C tree-sitter
+// shape directly. New parser work should prefer fixing the underlying runtime
+// or grammar generation path. When that happens, remove the corresponding strut
+// and its regression tests instead of letting this registry become permanent
+// architecture.
+type resultCompatibilityStrut func(resultCompatibilityContext)
+
+type resultCompatibilityContext struct {
+	root   *Node
+	source []byte
+	parser *Parser
+	lang   *Language
+}
+
+func resultCompatibilityStrutForLanguage(name string) resultCompatibilityStrut {
+	switch name {
+	case "bash":
+		return normalizeBashResultStrut
+	case "c":
+		return normalizeCResultStrut
+	case "c_sharp":
+		return normalizeCSharpResultStrut
+	case "caddy":
+		return normalizeCaddyResultStrut
+	case "cobol", "COBOL":
+		return normalizeCobolResultStrut
+	case "comment":
+		return normalizeCommentResultStrut
+	case "cooklang":
+		return normalizeCooklangResultStrut
+	case "d":
+		return normalizeDResultStrut
+	case "dart":
+		return normalizeDartResultStrut
+	case "elixir":
+		return normalizeElixirResultStrut
+	case "erlang":
+		return normalizeErlangResultStrut
+	case "fortran":
+		return normalizeFortranResultStrut
+	case "go":
+		return normalizeGoResultStrut
+	case "haskell":
+		return normalizeHaskellResultStrut
+	case "hcl":
+		return normalizeHCLResultStrut
+	case "html":
+		return normalizeHTMLResultStrut
+	case "ini":
+		return normalizeIniResultStrut
+	case "javascript":
+		return normalizeJavaScriptResultStrut
+	case "lua":
+		return normalizeLuaResultStrut
+	case "make":
+		return normalizeMakeResultStrut
+	case "nginx":
+		return normalizeNginxResultStrut
+	case "nim":
+		return normalizeNimResultStrut
+	case "pascal":
+		return normalizePascalResultStrut
+	case "perl":
+		return normalizePerlResultStrut
+	case "php":
+		return normalizePHPResultStrut
+	case "powershell":
+		return normalizePowerShellResultStrut
+	case "pug":
+		return normalizePugResultStrut
+	case "python":
+		return normalizePythonResultStrut
+	case "rst":
+		return normalizeRSTResultStrut
+	case "rust":
+		return normalizeRustResultStrut
+	case "ruby":
+		return normalizeRubyResultStrut
+	case "scala":
+		return normalizeScalaResultStrut
+	case "sql":
+		return normalizeSQLResultStrut
+	case "svelte":
+		return normalizeSvelteResultStrut
+	case "tsx", "typescript":
+		return normalizeTypeScriptResultStrut
+	case "yaml":
+		return normalizeYAMLResultStrut
+	case "zig":
+		return normalizeZigResultStrut
+	default:
+		return nil
+	}
+}
+
 // normalizeResultCompatibility applies narrow post-build tree rewrites that
 // keep gotreesitter output aligned with C tree-sitter and existing recovery
 // expectations for grammars with known normalization gaps.
@@ -11,84 +109,163 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) {
 	if root == nil || lang == nil {
 		return
 	}
-
-	switch lang.Name {
-	case "bash":
-		normalizeBashProgramVariableAssignments(root, lang)
-	case "c":
-		normalizeCCompatibility(root, source, lang)
-	case "c_sharp":
-		normalizeCSharpCompatibility(root, source, p, lang)
-	case "caddy":
-		normalizeTopLevelTrailingLineBreakSpan(root, source, lang)
-	case "cobol", "COBOL":
-		normalizeCobolCompatibility(root, source, lang)
-	case "comment":
-		normalizeCommentTrailingExtraTrivia(root, source, lang)
-	case "cooklang":
-		normalizeCooklangTrailingStepTail(root, source, lang)
-	case "d":
-		normalizeDCompatibility(root, source, lang)
-	case "dart":
-		normalizeDartCompatibility(root, source, lang)
-	case "elixir":
-		normalizeElixirNestedCallTargetFields(root, lang)
-	case "erlang":
-		normalizeErlangSourceFileForms(root, lang)
-	case "fortran":
-		normalizeFortranStatementLineBreaks(root, source, lang)
-		normalizeTopLevelTrailingLineBreakSpan(root, source, lang)
-	case "go":
-		normalizeGoReturnedTreeCompatibility(root, source, p, lang)
-	case "haskell":
-		normalizeHaskellCompatibility(root, source, lang)
-	case "hcl":
-		normalizeHCLConfigFileRoot(root, lang)
-	case "html":
-		normalizeHTMLCompatibility(root, source, lang)
-	case "ini":
-		normalizeIniSectionStarts(root, lang)
-	case "javascript":
-		normalizeJavaScriptCompatibility(root, source, lang)
-	case "lua":
-		normalizeLuaChunkLocalDeclarationFields(root, source, lang)
-	case "make":
-		normalizeMakeConditionalConsequenceFields(root, lang)
-	case "nginx":
-		normalizeNginxAttributeLineBreaks(root, source, lang)
-	case "nim":
-		normalizeNimTopLevelCallEnd(root, source, lang)
-	case "pascal":
-		normalizePascalTopLevelProgramEnd(root, source, lang)
-		normalizePascalTrailingExtraTrivia(root, source, lang)
-	case "perl":
-		normalizePerlCompatibility(root, source, lang)
-	case "php":
-		normalizePHPCompatibility(root, source, lang)
-	case "powershell":
-		normalizePowerShellProgramShape(root, source, lang)
-	case "pug":
-		normalizeTopLevelTrailingLineBreakSpan(root, source, lang)
-	case "python":
-		normalizePythonCompatibility(root, source, lang)
-	case "rst":
-		normalizeRSTTopLevelSectionEnd(root, source, lang)
-	case "rust":
-		normalizeRustCompatibility(root, source, p, lang)
-	case "ruby":
-		normalizeRubyThenStarts(root, lang)
-		normalizeRubyTopLevelModuleBounds(root, source, lang)
-	case "scala":
-		normalizeScalaCompatibility(root, source, lang)
-	case "sql":
-		normalizeSQLRecoveredSelectRoot(root, lang)
-	case "svelte":
-		normalizeSvelteTrailingExtraTrivia(root, source, lang)
-	case "tsx", "typescript":
-		normalizeTypeScriptTreeCompatibility(root, source, lang)
-	case "yaml":
-		normalizeYAMLRecoveredRoot(root, source, lang)
-	case "zig":
-		normalizeZigEmptyInitListFields(root, lang)
+	if strut := resultCompatibilityStrutForLanguage(lang.Name); strut != nil {
+		strut(resultCompatibilityContext{
+			root:   root,
+			source: source,
+			parser: p,
+			lang:   lang,
+		})
 	}
+}
+
+func normalizeBashResultStrut(ctx resultCompatibilityContext) {
+	normalizeBashProgramVariableAssignments(ctx.root, ctx.lang)
+}
+
+func normalizeCResultStrut(ctx resultCompatibilityContext) {
+	normalizeCCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeCSharpResultStrut(ctx resultCompatibilityContext) {
+	normalizeCSharpCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+}
+
+func normalizeCaddyResultStrut(ctx resultCompatibilityContext) {
+	normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeCobolResultStrut(ctx resultCompatibilityContext) {
+	normalizeCobolCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeCommentResultStrut(ctx resultCompatibilityContext) {
+	normalizeCommentTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeCooklangResultStrut(ctx resultCompatibilityContext) {
+	normalizeCooklangTrailingStepTail(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeDResultStrut(ctx resultCompatibilityContext) {
+	normalizeDCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeDartResultStrut(ctx resultCompatibilityContext) {
+	normalizeDartCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeElixirResultStrut(ctx resultCompatibilityContext) {
+	normalizeElixirNestedCallTargetFields(ctx.root, ctx.lang)
+}
+
+func normalizeErlangResultStrut(ctx resultCompatibilityContext) {
+	normalizeErlangSourceFileForms(ctx.root, ctx.lang)
+}
+
+func normalizeFortranResultStrut(ctx resultCompatibilityContext) {
+	normalizeFortranStatementLineBreaks(ctx.root, ctx.source, ctx.lang)
+	normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeGoResultStrut(ctx resultCompatibilityContext) {
+	normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+}
+
+func normalizeHaskellResultStrut(ctx resultCompatibilityContext) {
+	normalizeHaskellCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeHCLResultStrut(ctx resultCompatibilityContext) {
+	normalizeHCLConfigFileRoot(ctx.root, ctx.lang)
+}
+
+func normalizeHTMLResultStrut(ctx resultCompatibilityContext) {
+	normalizeHTMLCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeIniResultStrut(ctx resultCompatibilityContext) {
+	normalizeIniSectionStarts(ctx.root, ctx.lang)
+}
+
+func normalizeJavaScriptResultStrut(ctx resultCompatibilityContext) {
+	normalizeJavaScriptCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeLuaResultStrut(ctx resultCompatibilityContext) {
+	normalizeLuaChunkLocalDeclarationFields(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeMakeResultStrut(ctx resultCompatibilityContext) {
+	normalizeMakeConditionalConsequenceFields(ctx.root, ctx.lang)
+}
+
+func normalizeNginxResultStrut(ctx resultCompatibilityContext) {
+	normalizeNginxAttributeLineBreaks(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeNimResultStrut(ctx resultCompatibilityContext) {
+	normalizeNimTopLevelCallEnd(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizePascalResultStrut(ctx resultCompatibilityContext) {
+	normalizePascalTopLevelProgramEnd(ctx.root, ctx.source, ctx.lang)
+	normalizePascalTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizePerlResultStrut(ctx resultCompatibilityContext) {
+	normalizePerlCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizePHPResultStrut(ctx resultCompatibilityContext) {
+	normalizePHPCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizePowerShellResultStrut(ctx resultCompatibilityContext) {
+	normalizePowerShellProgramShape(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizePugResultStrut(ctx resultCompatibilityContext) {
+	normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizePythonResultStrut(ctx resultCompatibilityContext) {
+	normalizePythonCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeRSTResultStrut(ctx resultCompatibilityContext) {
+	normalizeRSTTopLevelSectionEnd(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeRustResultStrut(ctx resultCompatibilityContext) {
+	normalizeRustCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+}
+
+func normalizeRubyResultStrut(ctx resultCompatibilityContext) {
+	normalizeRubyThenStarts(ctx.root, ctx.lang)
+	normalizeRubyTopLevelModuleBounds(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeScalaResultStrut(ctx resultCompatibilityContext) {
+	normalizeScalaCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeSQLResultStrut(ctx resultCompatibilityContext) {
+	normalizeSQLRecoveredSelectRoot(ctx.root, ctx.lang)
+}
+
+func normalizeSvelteResultStrut(ctx resultCompatibilityContext) {
+	normalizeSvelteTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeTypeScriptResultStrut(ctx resultCompatibilityContext) {
+	normalizeTypeScriptTreeCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeYAMLResultStrut(ctx resultCompatibilityContext) {
+	normalizeYAMLRecoveredRoot(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeZigResultStrut(ctx resultCompatibilityContext) {
+	normalizeZigEmptyInitListFields(ctx.root, ctx.lang)
 }

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -17,6 +17,48 @@ type resultCompatibilityContext struct {
 	lang   *Language
 }
 
+var resultCompatibilityStrutLanguageNames = []string{
+	"bash",
+	"c",
+	"c_sharp",
+	"caddy",
+	"cobol",
+	"COBOL",
+	"comment",
+	"cooklang",
+	"d",
+	"dart",
+	"elixir",
+	"erlang",
+	"fortran",
+	"go",
+	"haskell",
+	"hcl",
+	"html",
+	"ini",
+	"javascript",
+	"lua",
+	"make",
+	"nginx",
+	"nim",
+	"pascal",
+	"perl",
+	"php",
+	"powershell",
+	"pug",
+	"python",
+	"rst",
+	"rust",
+	"ruby",
+	"scala",
+	"sql",
+	"svelte",
+	"tsx",
+	"typescript",
+	"yaml",
+	"zig",
+}
+
 func resultCompatibilityStrutForLanguage(name string) resultCompatibilityStrut {
 	switch name {
 	case "bash":

--- a/parser_result_compat_test.go
+++ b/parser_result_compat_test.go
@@ -1,0 +1,19 @@
+package gotreesitter
+
+import "testing"
+
+func TestResultCompatibilityStrutInventoryResolves(t *testing.T) {
+	seen := make(map[string]struct{}, len(resultCompatibilityStrutLanguageNames))
+	for _, name := range resultCompatibilityStrutLanguageNames {
+		if _, ok := seen[name]; ok {
+			t.Fatalf("duplicate result compatibility strut language %q", name)
+		}
+		seen[name] = struct{}{}
+		if got := resultCompatibilityStrutForLanguage(name); got == nil {
+			t.Fatalf("resultCompatibilityStrutForLanguage(%q) = nil, want strut", name)
+		}
+	}
+	if got := resultCompatibilityStrutForLanguage("definitely_not_a_language"); got != nil {
+		t.Fatal("resultCompatibilityStrutForLanguage returned a strut for unknown language")
+	}
+}


### PR DESCRIPTION
## Summary

Starts the parser-result "struts" cleanup by making the language-specific result compatibility rewrites an explicit internal boundary and inventory.

- Introduces `resultCompatibilityStrut` and `resultCompatibilityContext`.
- Routes language-specific result rewrites through `resultCompatibilityStrutForLanguage` instead of embedding every shim directly in `normalizeResultCompatibility`.
- Documents these rewrites as temporary parity scaffolding that should be retired when parser, scanner, or grammargen fixes make them unnecessary.
- Adds an explicit supported-language inventory and a regression test that every listed strut resolves while unknown languages stay unsupported.

This is intentionally behavior-preserving. The goal is to make the accumulated parser-result shims visible, auditable, and retireable before we start removing or replacing them.

## Testing

- PASS: `go test . -run '^TestResultCompatibilityStrutInventoryResolves$|^TestNormalize(ResultCompatibilityDispatchesUppercaseCobol|CTranslationUnitRootRetagsRecoveredTopLevelChildren|GoSourceFileRootRetagsRecoveredTopLevelChildren|BashProgramVariableAssignmentsSplitsTopLevelWrapper|SQLRecoveredSelectRootWrapsFlatSelectClause|JavaScriptTopLevelExpressionStatementBoundsAlsoSnapsTypeScript|RustTokenBindingPatterns|DModuleDefinitionBoundsSnapToStructuralChildren)$|^TestCSharpFindQueryAssignmentSpecs$' -count=1 -v`
- PASS: `bash cgo_harness/docker/run_parity_in_docker.sh --label result-struts-boundary-inventory --memory 4g --cpus 1 --pids 512 -- "cd /workspace && GOMAXPROCS=1 go test . -run '^TestResultCompatibilityStrutInventoryResolves$|^TestNormalize(ResultCompatibilityDispatchesUppercaseCobol|CTranslationUnitRootRetagsRecoveredTopLevelChildren|GoSourceFileRootRetagsRecoveredTopLevelChildren|BashProgramVariableAssignmentsSplitsTopLevelWrapper|SQLRecoveredSelectRootWrapsFlatSelectClause|JavaScriptTopLevelExpressionStatementBoundsAlsoSnapsTypeScript|RustTokenBindingPatterns|DModuleDefinitionBoundsSnapToStructuralChildren)$|^TestCSharpFindQueryAssignmentSpecs$' -count=1 -v"`
- PASS: `git diff --check`
