### PR TITLE
Clean up shared parser result helpers

### DIFF
--- a/parser_result_erlang_lua_svelte.go
+++ b/parser_result_erlang_lua_svelte.go
@@ -171,26 +171,3 @@ func normalizeSvelteTrailingExtraTrivia(root *Node, source []byte, lang *Languag
 		root.fieldSources = root.fieldSources[:len(root.children)]
 	}
 }
-
-func trimTrailingExtraTriviaRoot(root *Node, source []byte) {
-	if root == nil || len(root.children) == 0 || len(source) == 0 {
-		return
-	}
-	last := root.children[len(root.children)-1]
-	if last == nil || !last.IsExtra() || len(last.children) != 0 {
-		return
-	}
-	if last.startByte >= last.endByte || last.endByte != root.endByte || int(last.endByte) > len(source) {
-		return
-	}
-	if !bytesAreTrivia(source[last.startByte:last.endByte]) {
-		return
-	}
-	root.children = root.children[:len(root.children)-1]
-	if len(root.fieldIDs) > len(root.children) {
-		root.fieldIDs = root.fieldIDs[:len(root.children)]
-	}
-	if len(root.fieldSources) > len(root.children) {
-		root.fieldSources = root.fieldSources[:len(root.children)]
-	}
-}

--- a/parser_result_hcl_yaml.go
+++ b/parser_result_hcl_yaml.go
@@ -49,30 +49,6 @@ func normalizePythonInterpolationPatterns(root *Node, lang *Language) {
 	rewrite(root, false)
 }
 
-func bytesAreTrivia(b []byte) bool {
-	for _, c := range b {
-		switch c {
-		case ' ', '\t', '\n', '\r':
-			continue
-		default:
-			return false
-		}
-	}
-	return true
-}
-
-func lastNonTriviaByteEnd(source []byte) uint32 {
-	for i := len(source); i > 0; i-- {
-		switch source[i-1] {
-		case ' ', '\t', '\n', '\r', '\f':
-			continue
-		default:
-			return uint32(i)
-		}
-	}
-	return 0
-}
-
 func normalizeHCLConfigFileRoot(root *Node, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "hcl" || root.Type(lang) != "config_file" || len(root.children) == 0 {
 		return
@@ -119,25 +95,6 @@ func snapHCLBodyBounds(body *Node) {
 	body.startPoint = first.startPoint
 	body.endByte = last.endByte
 	body.endPoint = last.endPoint
-}
-
-func firstAndLastNonNilChild(children []*Node) (*Node, *Node) {
-	var first *Node
-	for _, child := range children {
-		if child != nil {
-			first = child
-			break
-		}
-	}
-	if first == nil {
-		return nil, nil
-	}
-	for i := len(children) - 1; i >= 0; i-- {
-		if children[i] != nil {
-			return first, children[i]
-		}
-	}
-	return first, first
 }
 
 func normalizeYAMLRecoveredRoot(root *Node, source []byte, lang *Language) {

--- a/parser_result_hcl_yaml.go
+++ b/parser_result_hcl_yaml.go
@@ -5,50 +5,6 @@ import (
 	"strings"
 )
 
-func normalizePythonInterpolationPatterns(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "python" {
-		return
-	}
-	patternListSym, ok := symbolByName(lang, "pattern_list")
-	if !ok {
-		return
-	}
-	listSplatPatternSym, hasListSplatPattern := symbolByName(lang, "list_splat_pattern")
-	expressionListSym, hasExpressionList := symbolByName(lang, "expression_list")
-	listSplatSym, hasListSplat := symbolByName(lang, "list_splat")
-
-	patternListNamed := false
-	if int(patternListSym) < len(lang.SymbolMetadata) {
-		patternListNamed = lang.SymbolMetadata[patternListSym].Named
-	}
-	listSplatPatternNamed := false
-	if hasListSplatPattern && int(listSplatPatternSym) < len(lang.SymbolMetadata) {
-		listSplatPatternNamed = lang.SymbolMetadata[listSplatPatternSym].Named
-	}
-
-	var rewrite func(*Node, bool)
-	rewrite = func(n *Node, inInterpolation bool) {
-		if n == nil {
-			return
-		}
-		here := inInterpolation || n.Type(lang) == "interpolation"
-		if here {
-			if hasExpressionList && n.symbol == expressionListSym {
-				n.symbol = patternListSym
-				n.isNamed = patternListNamed
-			}
-			if hasListSplatPattern && hasListSplat && n.symbol == listSplatSym {
-				n.symbol = listSplatPatternSym
-				n.isNamed = listSplatPatternNamed
-			}
-		}
-		for _, child := range n.children {
-			rewrite(child, here)
-		}
-	}
-	rewrite(root, false)
-}
-
 func normalizeHCLConfigFileRoot(root *Node, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "hcl" || root.Type(lang) != "config_file" || len(root.children) == 0 {
 		return

--- a/parser_result_node_helpers.go
+++ b/parser_result_node_helpers.go
@@ -67,6 +67,26 @@ func replaceChildRangeWithSingleNode(parent *Node, start, end int, replacement *
 		child.childIndex = i
 	}
 }
+
+func firstAndLastNonNilChild(children []*Node) (*Node, *Node) {
+	var first *Node
+	for _, child := range children {
+		if child != nil {
+			first = child
+			break
+		}
+	}
+	if first == nil {
+		return nil, nil
+	}
+	for i := len(children) - 1; i >= 0; i-- {
+		if children[i] != nil {
+			return first, children[i]
+		}
+	}
+	return first, first
+}
+
 func bytesContainLineBreak(b []byte) bool {
 	for _, c := range b {
 		if c == '\n' || c == '\r' {

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -8,6 +8,50 @@ func normalizePythonCompatibility(root *Node, source []byte, lang *Language) {
 	normalizePythonStringContinuationEscapes(root, source, lang)
 }
 
+func normalizePythonInterpolationPatterns(root *Node, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "python" {
+		return
+	}
+	patternListSym, ok := symbolByName(lang, "pattern_list")
+	if !ok {
+		return
+	}
+	listSplatPatternSym, hasListSplatPattern := symbolByName(lang, "list_splat_pattern")
+	expressionListSym, hasExpressionList := symbolByName(lang, "expression_list")
+	listSplatSym, hasListSplat := symbolByName(lang, "list_splat")
+
+	patternListNamed := false
+	if int(patternListSym) < len(lang.SymbolMetadata) {
+		patternListNamed = lang.SymbolMetadata[patternListSym].Named
+	}
+	listSplatPatternNamed := false
+	if hasListSplatPattern && int(listSplatPatternSym) < len(lang.SymbolMetadata) {
+		listSplatPatternNamed = lang.SymbolMetadata[listSplatPatternSym].Named
+	}
+
+	var rewrite func(*Node, bool)
+	rewrite = func(n *Node, inInterpolation bool) {
+		if n == nil {
+			return
+		}
+		here := inInterpolation || n.Type(lang) == "interpolation"
+		if here {
+			if hasExpressionList && n.symbol == expressionListSym {
+				n.symbol = patternListSym
+				n.isNamed = patternListNamed
+			}
+			if hasListSplatPattern && hasListSplat && n.symbol == listSplatSym {
+				n.symbol = listSplatPatternSym
+				n.isNamed = listSplatPatternNamed
+			}
+		}
+		for _, child := range n.children {
+			rewrite(child, here)
+		}
+	}
+	rewrite(root, false)
+}
+
 func normalizePythonPrintStatements(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "python" || len(source) == 0 {
 		return

--- a/parser_result_trivia_helpers.go
+++ b/parser_result_trivia_helpers.go
@@ -1,0 +1,48 @@
+package gotreesitter
+
+func bytesAreTrivia(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func lastNonTriviaByteEnd(source []byte) uint32 {
+	for i := len(source); i > 0; i-- {
+		switch source[i-1] {
+		case ' ', '\t', '\n', '\r', '\f':
+			continue
+		default:
+			return uint32(i)
+		}
+	}
+	return 0
+}
+
+func trimTrailingExtraTriviaRoot(root *Node, source []byte) {
+	if root == nil || len(root.children) == 0 || len(source) == 0 {
+		return
+	}
+	last := root.children[len(root.children)-1]
+	if last == nil || !last.IsExtra() || len(last.children) != 0 {
+		return
+	}
+	if last.startByte >= last.endByte || last.endByte != root.endByte || int(last.endByte) > len(source) {
+		return
+	}
+	if !bytesAreTrivia(source[last.startByte:last.endByte]) {
+		return
+	}
+	root.children = root.children[:len(root.children)-1]
+	if len(root.fieldIDs) > len(root.children) {
+		root.fieldIDs = root.fieldIDs[:len(root.children)]
+	}
+	if len(root.fieldSources) > len(root.children) {
+		root.fieldSources = root.fieldSources[:len(root.children)]
+	}
+}


### PR DESCRIPTION
## Summary
- Move reusable parser-result trivia helpers into a dedicated helper file.
- Move the shared first/last non-nil child helper out of the HCL/YAML strut and into node helpers.
- Move Python interpolation pattern normalization from the HCL/YAML file into the Python result compatibility file.
- Keep behavior unchanged while making the remaining language strut files more focused on language-specific normalization.

## Tests
- `go test . -run '^TestNormalize(SvelteTrailingExtraTriviaDropsTrailingToken|HCLConfigFileRootDropsTopLevelWhitespace|HCLConfigFileRootSnapsBodyToStructuralChildren|JavaScriptTopLevelExpressionStatementBoundsSnapToChildren|JavaScriptTopLevelExpressionStatementBoundsAlsoSnapsTypeScript|JavaScriptProgramStart|CTranslationUnitRootRetagsRecoveredTopLevelChildren)$|^TestResultCompatibilityStrutInventoryResolves$' -count=1 -v`
- `go test . -run '^(TestBuildResultFromNodes.*Python.*|TestRepairPythonRootNodeCollapsesFlatClassFunctionFragments|TestRepairPythonBlockFlattensSimpleStatements|TestNormalizePythonStringContinuationEscapesAddsMissingChildren|TestNormalizePythonTrailingSelfCallsFoldsIntoNestedFunctionBlock|TestNormalizeSvelteTrailingExtraTriviaDropsTrailingToken|TestNormalizeHCLConfigFileRootDropsTopLevelWhitespace|TestNormalizeHCLConfigFileRootSnapsBodyToStructuralChildren|TestNormalizeJavaScriptTopLevelExpressionStatementBoundsSnapToChildren|TestNormalizeJavaScriptTopLevelExpressionStatementBoundsAlsoSnapsTypeScript|TestNormalizeJavaScriptProgramStart|TestNormalizeCTranslationUnitRootRetagsRecoveredTopLevelChildren|TestResultCompatibilityStrutInventoryResolves)$' -count=1 -v`
- `bash cgo_harness/docker/run_parity_in_docker.sh --label result-struts-file-hygiene --memory 4g --cpus 1 --pids 512 -- "cd /workspace && GOMAXPROCS=1 go test . -run '^(TestBuildResultFromNodes.*Python.*|TestRepairPythonRootNodeCollapsesFlatClassFunctionFragments|TestRepairPythonBlockFlattensSimpleStatements|TestNormalizePythonStringContinuationEscapesAddsMissingChildren|TestNormalizePythonTrailingSelfCallsFoldsIntoNestedFunctionBlock|TestNormalizeSvelteTrailingExtraTriviaDropsTrailingToken|TestNormalizeHCLConfigFileRootDropsTopLevelWhitespace|TestNormalizeHCLConfigFileRootSnapsBodyToStructuralChildren|TestNormalizeJavaScriptTopLevelExpressionStatementBoundsSnapToChildren|TestNormalizeJavaScriptTopLevelExpressionStatementBoundsAlsoSnapsTypeScript|TestNormalizeJavaScriptProgramStart|TestNormalizeCTranslationUnitRootRetagsRecoveredTopLevelChildren|TestResultCompatibilityStrutInventoryResolves)$' -count=1 -v"`
- `bash cgo_harness/docker/run_parity_in_docker.sh --label result-struts-python-build-result --memory 4g --cpus 1 --pids 512 -- "cd /workspace && GOMAXPROCS=1 go test . -run '^TestBuildResultFromNodes.*Python.*$' -count=1 -v"`