### PR TITLE
Split HCL and YAML parser result helpers

### DIFF
--- a/parser_result_hcl.go
+++ b/parser_result_hcl.go
@@ -1,0 +1,49 @@
+package gotreesitter
+
+func normalizeHCLConfigFileRoot(root *Node, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "hcl" || root.Type(lang) != "config_file" || len(root.children) == 0 {
+		return
+	}
+	filtered := make([]*Node, 0, len(root.children))
+	filteredChanged := false
+	for _, child := range root.children {
+		if child == nil {
+			continue
+		}
+		if child.Type(lang) == "_whitespace" {
+			filteredChanged = true
+			continue
+		}
+		filtered = append(filtered, child)
+	}
+	if filteredChanged {
+		if root.ownerArena != nil {
+			buf := root.ownerArena.allocNodeSlice(len(filtered))
+			copy(buf, filtered)
+			filtered = buf
+		}
+		root.children = filtered
+		root.fieldIDs = nil
+		root.fieldSources = nil
+	}
+	for _, child := range root.children {
+		if child == nil || child.Type(lang) != "body" {
+			continue
+		}
+		snapHCLBodyBounds(child)
+	}
+}
+
+func snapHCLBodyBounds(body *Node) {
+	if body == nil || len(body.children) == 0 {
+		return
+	}
+	first, last := firstAndLastNonNilChild(body.children)
+	if first == nil || last == nil {
+		return
+	}
+	body.startByte = first.startByte
+	body.startPoint = first.startPoint
+	body.endByte = last.endByte
+	body.endPoint = last.endPoint
+}

--- a/parser_result_yaml.go
+++ b/parser_result_yaml.go
@@ -5,54 +5,6 @@ import (
 	"strings"
 )
 
-func normalizeHCLConfigFileRoot(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "hcl" || root.Type(lang) != "config_file" || len(root.children) == 0 {
-		return
-	}
-	filtered := make([]*Node, 0, len(root.children))
-	filteredChanged := false
-	for _, child := range root.children {
-		if child == nil {
-			continue
-		}
-		if child.Type(lang) == "_whitespace" {
-			filteredChanged = true
-			continue
-		}
-		filtered = append(filtered, child)
-	}
-	if filteredChanged {
-		if root.ownerArena != nil {
-			buf := root.ownerArena.allocNodeSlice(len(filtered))
-			copy(buf, filtered)
-			filtered = buf
-		}
-		root.children = filtered
-		root.fieldIDs = nil
-		root.fieldSources = nil
-	}
-	for _, child := range root.children {
-		if child == nil || child.Type(lang) != "body" {
-			continue
-		}
-		snapHCLBodyBounds(child)
-	}
-}
-
-func snapHCLBodyBounds(body *Node) {
-	if body == nil || len(body.children) == 0 {
-		return
-	}
-	first, last := firstAndLastNonNilChild(body.children)
-	if first == nil || last == nil {
-		return
-	}
-	body.startByte = first.startByte
-	body.startPoint = first.startPoint
-	body.endByte = last.endByte
-	body.endPoint = last.endPoint
-}
-
 func normalizeYAMLRecoveredRoot(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "yaml" || len(root.children) == 0 {
 		return


### PR DESCRIPTION
## Summary
- Move HCL config-file result normalization into `parser_result_hcl.go`.
- Rename the remaining HCL/YAML file to `parser_result_yaml.go` now that it only contains YAML recovery helpers.
- Keep normalization behavior unchanged while reducing mixed-language strut files.

## Tests
- `go test . -run '^(TestNormalizeHCLConfigFileRoot.*|TestResultCompatibilityStrutInventoryResolves)$' -count=1 -v`
- `bash cgo_harness/docker/run_parity_in_docker.sh --label result-struts-hcl-yaml-split --memory 4g --cpus 1 --pids 512 -- "cd /workspace && GOMAXPROCS=1 go test . -run '^(TestNormalizeHCLConfigFileRoot.*|TestResultCompatibilityStrutInventoryResolves)$' -count=1 -v"`