### PR TITLE
Prepare v0.16.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ for tags and release notes while still in `0.x`.
 
 - Nothing yet.
 
+## [0.16.0] - 2026-05-06
+
+Grammar extensibility, UTF-16 input, and parser-resilience release.
+
+### Added
+- Native UTF-16 parser/editor APIs, including UTF-16 byte parsing, token source
+  factories, incremental parser variants, edit mapping, injection reuse, and
+  descendant range lookup helpers for editor integrations.
+- `grammargen` DSL sources and extension smoke coverage for Kotlin and Swift.
+- `grammargen` constructors for JavaScript, TypeScript, TSX, and Fortran, plus
+  imported grammar coverage and TypeScript inline-rule filtering documentation.
+- Grammar update guard tooling for scanner-facing grammar refreshes so
+  automation can distinguish safe lock updates from changes that require
+  scanner-port work and focused parity validation.
+
+### Changed
+- Parser-result compatibility shims now route through an explicit strut
+  registry, with language-owned helper files and shared normalization helpers
+  split out of mixed parser-result modules.
+- The cgo harness now runs on Go 1.25.
+
+### Fixed
+- External scanner fallback binding now assigns unmatched tokens to the next
+  available external symbol instead of relying on positional token indexes when
+  name-based binding partially succeeds.
+- Python f-string scanner checkpoints now recompute interpolated-string state
+  from the delimiter stack after deserialize, preserving `DEDENT` behavior for
+  issue #53. Includes Fraser Isbester's fork commit and a follow-up regression
+  hardening pass.
+- C# pathological recovery is bounded, full-parse retries stop after timeout,
+  parser arena budgets are repaired, and C# repetition shift conflicts are
+  handled without unbounded GLR growth.
+- TypeScript parity gaps and GLR merge scratch handling were corrected.
+- Fortran `grammargen` parity gaps were closed.
+
+### Testing
+- Added focused Swift and Kotlin `ExtendGrammar` smoke tests.
+- Added and hardened imported grammar coverage for the new JavaScript,
+  TypeScript, TSX, and Fortran `grammargen` constructors.
+- Kept C#, Fortran, TypeScript, Swift, and Kotlin parity work scoped through
+  Docker grammar-focused lanes and scanner update gating.
+
 ## [0.15.3] - 2026-04-26
 
 Parser stability and harness release.
@@ -419,7 +461,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.15.3...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/odvcencio/gotreesitter/compare/v0.15.3...v0.16.0
 [0.15.3]: https://github.com/odvcencio/gotreesitter/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/odvcencio/gotreesitter/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/odvcencio/gotreesitter/compare/v0.15.0...v0.15.1

--- a/README.md
+++ b/README.md
@@ -542,6 +542,16 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
+v0.16.x — Grammar extensibility and parser-resilience release. Adds native
+UTF-16 parser/editor APIs, `grammargen` DSL constructors and extension smoke
+coverage for Kotlin, Swift, JavaScript, TypeScript/TSX, and Fortran, and
+grammar-update guardrails that block scanner-facing lock refreshes until
+regenerated artifacts and focused parity are handled. C# pathological recovery
+is bounded, TypeScript and Fortran `grammargen` parity advanced, Python
+f-string scanner checkpoints preserve interpolated-string state, and
+parser-result compatibility shims are isolated behind an explicit strut registry
+with language-owned helper files.
+
 v0.15.x — Large-repo consumer safety and parser-maintenance release. `ParsePolicy.ShouldSkipDir` lets gateway callers prune generated/vendor directories before descent, the GLR node-equivalence cache is smaller and checks epoch first for L2-friendly lookups, `Tree.Edit` avoids scanning unchanged right-side siblings when there is no tail shift, and parser-result compatibility normalization now keeps language-specific call sequences beside the relevant `parser_result_*.go` helpers. The v0.15.1 patch also hardens arena release/GC behavior, releases retry loser arenas promptly, and fixes query predicate backtracking for nested Starlark dictionary matches. v0.15.2 folds the drifting `main` and release lines back together, adds a Swift ABI mangling grammar, and ships `grammar_updater` pin verification and manifest-only sync flags. v0.15.3 caps JavaScript/TypeScript full-parse merge survivors, tunes markdown retry and node budgets, tolerates external-scanner symbol-list drift, and adds a scoped Canopy harness runner for bounded repo analysis. This line carries the post-0.14 tier-1 grammar refreshes and reserved-word import fixes.
 
 v0.14.x — Go grammar now shipped as a grammargen-compiled blob (our own pure-Go LR(1) state-splitting compiler), eliminating a dead-end state inherited from tree-sitter-go that wrapped several valid Go files in ERROR. Combined with arena retention/initial-sizing fixes, retry-lifecycle cleanup, and a GLR cap update keyed to the new grammar's conflict profile, warm-reuse heap allocation across a six-file self-parse benchmark dropped ~54% (498 → 229 MB/iter); cold-case dropped ~61%.
@@ -550,8 +560,8 @@ v0.12.x — 206 grammars (all OK), 116 external scanners, pure-Go runtime plus `
 
 Next:
 - Full-parse `grammargen` performance work that keeps the recent incremental wins without regressing the main DFA benchmark
-- Remaining parser-result recovery/parity backlog on high-value C#, Rust, Scala, TypeScript, and Python corpus cases
-- The next highest-value parser/`grammargen` parity language after YAML and C# stabilization
+- Retire parser-result struts by moving C#, Rust, Scala, TypeScript, and Python recovery into runtime or grammar generation paths
+- Grammar refresh automation that moves from lock-only PRs to regenerated artifacts and focused parity for allow-listed `grammargen`-backed languages
 - Table-size and codegen compaction work for Unicode-heavy grammars
 
 Release history and retroactive notes are tracked in [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
## What does this PR do?

Prepares the v0.16.0 release notes by adding the changelog entry for the work merged since v0.15.3 and updating the README roadmap snapshot for the new release line.

## Why this approach?

This is a docs-only release-prep PR so the tag can be cut from `main` after checks pass. The closed lock-only grammar refresh PR #52 is intentionally superseded here because the release notes need to describe the regenerated/parity-backed grammar work that actually landed.

## Correctness

- [ ] Focused package or unit tests ran for the touched behavior
- [ ] Affected parity validation ran in Docker, one language or grammar at a time
- [ ] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

Validation performed:
- `git diff --check`

Intentionally left unvalidated:
- No package, parser, or Docker parity tests ran because this PR only changes `CHANGELOG.md` and `README.md`.
- The release tag and GitHub release should wait until this PR is merged from a green `main`.

## Performance

- [ ] If perf-relevant, used the stable bench settings (`GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem`)
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
- [ ] If large-grammar behavior changed, checked bounded RSS, timeout, or OOM behavior under Docker

Performance is not the goal of this PR; there are no runtime changes.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

Review your own diff before requesting review. Walk through it as if you're seeing it for the first time, and keep any self-review comments concise and focused on the non-obvious parts.

- [x] Reviewed my own diff end to end
- [ ] Left comments on notable sections or the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

No inline comments were needed for this docs-only diff. The only release-order dependency is called out above: merge first, then tag v0.16.0 and publish the GitHub release.

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [ ] If touching the parser or lexer: validated against diverse affected grammars
- [ ] If adding a grammar or scanner: verified against upstream C output

The changed files follow the existing changelog/release-snapshot style, and this PR does not touch parser, lexer, grammar, scanner, generated, or harness code.