### PR TITLE
Optimize incremental leaf reuse and ratchet web parity

### DIFF
--- a/cgo_harness/parity_grammargen_cgo_floor_test.go
+++ b/cgo_harness/parity_grammargen_cgo_floor_test.go
@@ -21,6 +21,12 @@ func TestMergeGrammargenCGOFloorsPreservesRatchetDirection(t *testing.T) {
 			TreeParity:  0,
 			Divergences: 25,
 		},
+		"javascript": {
+			Eligible:    10,
+			NoError:     10,
+			TreeParity:  10,
+			Divergences: 5,
+		},
 	}
 	observed := map[string]grammargenCGOFloorEntry{
 		"c": {
@@ -30,6 +36,12 @@ func TestMergeGrammargenCGOFloorsPreservesRatchetDirection(t *testing.T) {
 			Divergences: 14,
 		},
 		"json": {
+			Eligible:    10,
+			NoError:     10,
+			TreeParity:  10,
+			Divergences: 0,
+		},
+		"javascript": {
 			Eligible:    10,
 			NoError:     10,
 			TreeParity:  10,
@@ -50,6 +62,9 @@ func TestMergeGrammargenCGOFloorsPreservesRatchetDirection(t *testing.T) {
 	}
 	if got, want := merged["c"].Divergences, 11; got != want {
 		t.Fatalf("c divergences = %d, want %d", got, want)
+	}
+	if got, want := merged["javascript"].Divergences, 0; got != want {
+		t.Fatalf("javascript divergences = %d, want %d", got, want)
 	}
 	if got, want := merged["scala"], existing["scala"]; got != want {
 		t.Fatalf("scala entry = %+v, want %+v", got, want)
@@ -80,5 +95,23 @@ func TestGrammargenCGORatchetRegressionsIncludesDivergences(t *testing.T) {
 	}
 	if !strings.Contains(msgs[0], "divergences") {
 		t.Fatalf("regression message %q does not mention divergences", msgs[0])
+	}
+
+	msgs = grammargenCGORatchetRegressions("json",
+		grammargenCGOFloorEntry{
+			Eligible:    10,
+			NoError:     10,
+			TreeParity:  10,
+			Divergences: 0,
+		},
+		grammargenCGOFloorEntry{
+			Eligible:    10,
+			NoError:     10,
+			TreeParity:  10,
+			Divergences: 1,
+		},
+	)
+	if len(msgs) != 1 {
+		t.Fatalf("zero-floor regressions = %v, want one divergence regression", msgs)
 	}
 }

--- a/cgo_harness/parity_grammargen_cgo_test.go
+++ b/cgo_harness/parity_grammargen_cgo_test.go
@@ -868,7 +868,7 @@ func grammargenCGORatchetRegressions(name string, floor, cur grammargenCGOFloorE
 	if cur.TreeParity < floor.TreeParity {
 		out = append(out, fmt.Sprintf("ratchet regression [%s] tree_parity: %d < floor %d", name, cur.TreeParity, floor.TreeParity))
 	}
-	if floor.Divergences > 0 && cur.Divergences > floor.Divergences {
+	if cur.Divergences > floor.Divergences {
 		out = append(out, fmt.Sprintf("ratchet regression [%s] divergences: %d > floor %d", name, cur.Divergences, floor.Divergences))
 	}
 	return out
@@ -934,7 +934,7 @@ func mergeGrammargenCGOFloors(existing, observed map[string]grammargenCGOFloorEn
 			if cur.TreeParity < prev.TreeParity {
 				cur.TreeParity = prev.TreeParity
 			}
-			if prev.Divergences > 0 && (cur.Divergences == 0 || prev.Divergences < cur.Divergences) {
+			if cur.Divergences > prev.Divergences {
 				cur.Divergences = prev.Divergences
 			}
 		}

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "generated_at": "2026-05-07T02:23:13Z",
+  "generated_at": "2026-05-07T02:56:21Z",
   "corpus_root": "/tmp/grammar_parity",
   "max_cases": 20,
   "max_bytes": 262144,
   "grammar_count": 7,
-  "total_eligible": 85,
-  "total_no_error": 77,
-  "total_tree_parity": 70,
+  "total_eligible": 100,
+  "total_no_error": 97,
+  "total_tree_parity": 90,
   "metrics": {
     "c": {
       "eligible": 10,
@@ -16,9 +16,9 @@
       "divergences": 2
     },
     "c_sharp": {
-      "eligible": 5,
-      "no_error": 0,
-      "tree_parity": 0,
+      "eligible": 20,
+      "no_error": 20,
+      "tree_parity": 20,
       "divergences": 5
     },
     "cobol": {

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "generated_at": "2026-05-07T02:59:02Z",
+  "generated_at": "2026-05-07T03:23:52Z",
   "corpus_root": "/tmp/grammar_parity",
   "max_cases": 20,
   "max_bytes": 262144,
   "grammar_count": 7,
-  "total_eligible": 110,
-  "total_no_error": 108,
-  "total_tree_parity": 102,
+  "total_eligible": 120,
+  "total_no_error": 118,
+  "total_tree_parity": 114,
   "metrics": {
     "c": {
       "eligible": 20,
@@ -28,9 +28,9 @@
       "divergences": 3
     },
     "javascript": {
-      "eligible": 10,
-      "no_error": 10,
-      "tree_parity": 8,
+      "eligible": 20,
+      "no_error": 20,
+      "tree_parity": 20,
       "divergences": 2
     },
     "scala": {

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "generated_at": "2026-05-07T03:23:52Z",
+  "generated_at": "2026-05-07T03:29:04Z",
   "corpus_root": "/tmp/grammar_parity",
   "max_cases": 20,
   "max_bytes": 262144,
-  "grammar_count": 7,
-  "total_eligible": 120,
-  "total_no_error": 118,
-  "total_tree_parity": 114,
+  "grammar_count": 8,
+  "total_eligible": 126,
+  "total_no_error": 124,
+  "total_tree_parity": 120,
   "metrics": {
     "c": {
       "eligible": 20,
@@ -32,6 +32,12 @@
       "no_error": 20,
       "tree_parity": 20,
       "divergences": 2
+    },
+    "json": {
+      "eligible": 6,
+      "no_error": 6,
+      "tree_parity": 6,
+      "divergences": 0
     },
     "scala": {
       "eligible": 10,

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "generated_at": "2026-03-21T08:42:17Z",
+  "generated_at": "2026-05-07T02:23:13Z",
   "corpus_root": "/tmp/grammar_parity",
-  "max_cases": 10,
+  "max_cases": 20,
   "max_bytes": 262144,
   "grammar_count": 7,
-  "total_eligible": 65,
-  "total_no_error": 56,
-  "total_tree_parity": 41,
+  "total_eligible": 85,
+  "total_no_error": 77,
+  "total_tree_parity": 70,
   "metrics": {
     "c": {
       "eligible": 10,
@@ -40,15 +40,15 @@
       "divergences": 4
     },
     "tsx": {
-      "eligible": 10,
-      "no_error": 10,
-      "tree_parity": 6,
+      "eligible": 20,
+      "no_error": 20,
+      "tree_parity": 20,
       "divergences": 5
     },
     "typescript": {
-      "eligible": 10,
-      "no_error": 9,
-      "tree_parity": 5,
+      "eligible": 20,
+      "no_error": 20,
+      "tree_parity": 20,
       "divergences": 6
     }
   }

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -1,18 +1,18 @@
 {
   "version": 1,
-  "generated_at": "2026-05-07T02:56:21Z",
+  "generated_at": "2026-05-07T02:59:02Z",
   "corpus_root": "/tmp/grammar_parity",
   "max_cases": 20,
   "max_bytes": 262144,
   "grammar_count": 7,
-  "total_eligible": 100,
-  "total_no_error": 97,
-  "total_tree_parity": 90,
+  "total_eligible": 110,
+  "total_no_error": 108,
+  "total_tree_parity": 102,
   "metrics": {
     "c": {
-      "eligible": 10,
-      "no_error": 9,
-      "tree_parity": 8,
+      "eligible": 20,
+      "no_error": 20,
+      "tree_parity": 20,
       "divergences": 2
     },
     "c_sharp": {

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -13,13 +13,13 @@
       "eligible": 20,
       "no_error": 20,
       "tree_parity": 20,
-      "divergences": 2
+      "divergences": 0
     },
     "c_sharp": {
       "eligible": 20,
       "no_error": 20,
       "tree_parity": 20,
-      "divergences": 5
+      "divergences": 0
     },
     "cobol": {
       "eligible": 10,
@@ -31,7 +31,7 @@
       "eligible": 20,
       "no_error": 20,
       "tree_parity": 20,
-      "divergences": 2
+      "divergences": 0
     },
     "json": {
       "eligible": 6,
@@ -49,13 +49,13 @@
       "eligible": 20,
       "no_error": 20,
       "tree_parity": 20,
-      "divergences": 5
+      "divergences": 0
     },
     "typescript": {
       "eligible": 20,
       "no_error": 20,
       "tree_parity": 20,
-      "divergences": 6
+      "divergences": 0
     }
   }
 }

--- a/grammargen/emit_grammar_go.go
+++ b/grammargen/emit_grammar_go.go
@@ -139,6 +139,18 @@ func EmitGrammarGo(g *Grammar, pkgName, funcName string) ([]byte, error) {
 		fmt.Fprintf(&buf, "\tg.BinaryRepeatMode = true\n\n")
 	}
 
+	if g.FlattenGeneratedRepeatAux {
+		fmt.Fprintf(&buf, "\tg.FlattenGeneratedRepeatAux = true\n\n")
+	}
+
+	if len(g.ReuseRepeatAuxForParents) > 0 {
+		fmt.Fprintf(&buf, "\tg.ReuseRepeatAuxForParents = []string{\n")
+		for _, name := range g.ReuseRepeatAuxForParents {
+			fmt.Fprintf(&buf, "\t\t%s,\n", goString(name))
+		}
+		fmt.Fprintf(&buf, "\t}\n\n")
+	}
+
 	if g.PreserveKeywordIdentifierConflicts {
 		fmt.Fprintf(&buf, "\tg.PreserveKeywordIdentifierConflicts = true\n\n")
 	}

--- a/grammargen/gen_test.go
+++ b/grammargen/gen_test.go
@@ -105,6 +105,8 @@ func TestJSONParseRoundTrip(t *testing.T) {
 		{"simple array", `[1, 2, 3]`},
 		{"nested", `{"a": [1, true, null]}`},
 		{"complex", `{"key": [1, true, null]}`},
+		{"line comment", "{\n// comment\n\"key\": \"value\"\n}"},
+		{"block comment", `{"key": /* comment */ "value"}`},
 	}
 
 	for _, tt := range tests {

--- a/grammargen/grammar.go
+++ b/grammargen/grammar.go
@@ -74,6 +74,8 @@ type Grammar struct {
 	Tests                              []TestCase    // embedded test cases
 	EnableLRSplitting                  bool          // opt-in: attempt LR(1) state splitting for merge pathology
 	BinaryRepeatMode                   bool          // use tree-sitter's binary repeat helper shape (aux→seq(aux,aux)|inner)
+	FlattenGeneratedRepeatAux          bool          // allow generated repeat helpers to participate in hidden-choice flattening
+	ReuseRepeatAuxForParents           []string      // parent rule names whose repeat helpers may be shared by canonical body
 	PreserveKeywordIdentifierConflicts bool          // keep keyword-as-identifier S/R ambiguity for grammars like Fortran
 	Precedences                        [][]PrecEntry // ordered precedence levels (each level: earlier = higher prec)
 	ChoiceLiftThreshold                int           // if >0, lift inline CHOICE nodes with more alternatives than this into auxiliary nonterminals to prevent production explosion
@@ -321,6 +323,8 @@ func ExtendGrammar(name string, base *Grammar, customize func(g *Grammar)) *Gram
 		Tests:                              make([]TestCase, len(base.Tests)),
 		EnableLRSplitting:                  base.EnableLRSplitting,
 		BinaryRepeatMode:                   base.BinaryRepeatMode,
+		FlattenGeneratedRepeatAux:          base.FlattenGeneratedRepeatAux,
+		ReuseRepeatAuxForParents:           make([]string, len(base.ReuseRepeatAuxForParents)),
 		PreserveKeywordIdentifierConflicts: base.PreserveKeywordIdentifierConflicts,
 		Precedences:                        clonePrecedenceLevels(base.Precedences),
 		ChoiceLiftThreshold:                base.ChoiceLiftThreshold,
@@ -344,6 +348,7 @@ func ExtendGrammar(name string, base *Grammar, customize func(g *Grammar)) *Gram
 	copy(g.Inline, base.Inline)
 	copy(g.Supertypes, base.Supertypes)
 	copy(g.Tests, base.Tests)
+	copy(g.ReuseRepeatAuxForParents, base.ReuseRepeatAuxForParents)
 
 	// Let the caller customize.
 	customize(g)

--- a/grammargen/grammar_source_test.go
+++ b/grammargen/grammar_source_test.go
@@ -24,6 +24,8 @@ func TestExtendGrammarCopiesImportMetadata(t *testing.T) {
 	}
 	base.EnableLRSplitting = true
 	base.BinaryRepeatMode = true
+	base.FlattenGeneratedRepeatAux = true
+	base.ReuseRepeatAuxForParents = []string{"program", "statement_list"}
 	base.ChoiceLiftThreshold = 16
 	base.Test("identifier", "abc", "")
 
@@ -40,6 +42,12 @@ func TestExtendGrammarCopiesImportMetadata(t *testing.T) {
 	}
 	if !extended.EnableLRSplitting || !extended.BinaryRepeatMode {
 		t.Fatalf("extension did not inherit generator mode flags")
+	}
+	if !extended.FlattenGeneratedRepeatAux {
+		t.Fatalf("extension did not inherit generated repeat flattening flag")
+	}
+	if !slices.Equal(extended.ReuseRepeatAuxForParents, []string{"program", "statement_list"}) {
+		t.Fatalf("ReuseRepeatAuxForParents = %v, want [program statement_list]", extended.ReuseRepeatAuxForParents)
 	}
 	if extended.ChoiceLiftThreshold != 16 {
 		t.Fatalf("ChoiceLiftThreshold = %d, want 16", extended.ChoiceLiftThreshold)
@@ -86,6 +94,8 @@ func TestEmitGrammarGoIncludesImportMetadata(t *testing.T) {
 	}
 	g.EnableLRSplitting = true
 	g.BinaryRepeatMode = true
+	g.FlattenGeneratedRepeatAux = true
+	g.ReuseRepeatAuxForParents = []string{"program"}
 	g.ChoiceLiftThreshold = 8
 	g.Test("valid identifier", "abc", "(program (identifier))")
 	g.TestError("invalid identifier", "123")
@@ -101,6 +111,9 @@ func TestEmitGrammarGoIncludesImportMetadata(t *testing.T) {
 		"{IsSymbol: true, Name: \"program\"}",
 		"g.EnableLRSplitting = true",
 		"g.BinaryRepeatMode = true",
+		"g.FlattenGeneratedRepeatAux = true",
+		"g.ReuseRepeatAuxForParents = []string{",
+		"\"program\"",
 		"g.ChoiceLiftThreshold = 8",
 		"g.Test(\"valid identifier\", \"abc\", \"(program (identifier))\")",
 		"g.TestError(\"invalid identifier\", \"123\")",
@@ -310,6 +323,12 @@ func TestImportedJavaScriptTypeScriptTSXFortranGrammarConstructors(t *testing.T)
 	}
 	if JSGrammar().Name != "javascript" || JavascriptGrammar().Name != "javascript" {
 		t.Fatalf("JavaScript aliases did not return javascript grammar")
+	}
+	if !JavaScriptGrammar().FlattenGeneratedRepeatAux {
+		t.Fatalf("JavaScriptGrammar did not enable generated repeat aux flattening")
+	}
+	if !slices.Equal(JavaScriptGrammar().ReuseRepeatAuxForParents, []string{"jsx_opening_element", "jsx_self_closing_element"}) {
+		t.Fatalf("JavaScriptGrammar repeat aux reuse parents = %v", JavaScriptGrammar().ReuseRepeatAuxForParents)
 	}
 	if TSGrammar().Name != "typescript" || TypescriptGrammar().Name != "typescript" {
 		t.Fatalf("TypeScript aliases did not return typescript grammar")

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -23,6 +23,10 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// shape. Keeping the upstream lowering avoids large state blowups and
 		// preserves upstream ambiguity handling for imported grammars.
 		g.BinaryRepeatMode = true
+		if g.Name == "javascript" {
+			g.FlattenGeneratedRepeatAux = true
+			g.ReuseRepeatAuxForParents = []string{"jsx_opening_element", "jsx_self_closing_element"}
+		}
 	}
 }
 

--- a/grammargen/javascript_corpus_snippet_parity_test.go
+++ b/grammargen/javascript_corpus_snippet_parity_test.go
@@ -21,6 +21,62 @@ func TestJavaScriptCorpusSnippetParity(t *testing.T) {
 			src:  "var a = <Foo></Foo>\nb = <Foo.Bar></Foo.Bar>\n",
 		},
 		{
+			name: "jsx_corpus_block_exact",
+			src: "var a = <Foo></Foo>\n" +
+				"b = <Foo.Bar></Foo.Bar>\n" +
+				"c = <> <Foo /> </>\n" +
+				"d = <Bar> <Foo /> </Bar>\n" +
+				"e = <Foo bar/>\n" +
+				"f = <Foo bar=\"string\" baz={2} data-i8n=\"dialogs.welcome.heading\" bam />\n" +
+				"g = <Avatar userId={foo.creatorId} />\n" +
+				"h = <input checked={this.state.selectedNewStreetType === 'new-street-default' || !this.state.selectedNewStreetType}> </input>\n" +
+				"i = <Foo:Bar bar={}>{...children}</Foo:Bar>\n",
+		},
+		{
+			name: "jsx_self_closing_multiple_attributes",
+			src:  "f = <Foo bar=\"string\" baz={2} data-i8n=\"dialogs.welcome.heading\" bam />\n",
+		},
+		{
+			name: "jsx_self_closing_string_attribute",
+			src:  "f = <Foo bar=\"string\" />\n",
+		},
+		{
+			name: "jsx_self_closing_expression_attribute",
+			src:  "f = <Foo baz={2} />\n",
+		},
+		{
+			name: "jsx_self_closing_hyphen_string_attribute",
+			src:  "f = <Foo data-i8n=\"dialogs.welcome.heading\" />\n",
+		},
+		{
+			name: "jsx_self_closing_multiple_bare_attributes",
+			src:  "f = <Foo bar baz bam />\n",
+		},
+		{
+			name: "jsx_self_closing_member_expression_attribute",
+			src:  "g = <Avatar userId={foo.creatorId} />\n",
+		},
+		{
+			name: "jsx_logical_expression_attribute_with_children",
+			src:  "h = <input checked={this.state.selectedNewStreetType === 'new-street-default' || !this.state.selectedNewStreetType}> </input>\n",
+		},
+		{
+			name: "jsx_namespace_name_empty_attribute_expression",
+			src:  "i = <Foo:Bar bar={}>{...children}</Foo:Bar>\n",
+		},
+		{
+			name: "jsx_empty_fragment_corpus_block_exact",
+			src:  "a = <></>;\na = <E><></></E>;\n",
+		},
+		{
+			name: "jsx_named_element_with_semicolon",
+			src:  "a = <Foo></Foo>;\n",
+		},
+		{
+			name: "jsx_empty_fragment_without_semicolon",
+			src:  "a = <></>\n",
+		},
+		{
 			name: "template_strings_from_corpus",
 			src:  "`one line`;\n`multi\\n  line`;\n`$${'$'}$$${'$'}$$$$`;\n",
 		},
@@ -43,6 +99,20 @@ func TestJavaScriptCorpusSnippetParity(t *testing.T) {
 				"`The command \\`git ${args.join(' ')}\\` exited with an unexpected code: ${exitCode}. The caller should either handle this error, or expect that exit code.`;\n\n" +
 				"`\\\\`;\n\n" +
 				"`//`;\n",
+		},
+		{
+			name: "function_expression_array_corpus_block_exact",
+			src: "[\n" +
+				"  function() {},\n" +
+				"  function(arg1, ...arg2) {\n" +
+				"    arg2;\n" +
+				"  },\n" +
+				"  function stuff() {},\n" +
+				"  function trailing(a,) {},\n" +
+				"  function trailing(a,b,) {},\n" +
+				"  function reserved(async) {},\n" +
+				"  function rest(...[_ = x]) {}\n" +
+				"]\n",
 		},
 	}
 

--- a/grammargen/javascript_grammar.go
+++ b/grammargen/javascript_grammar.go
@@ -2855,5 +2855,12 @@ func JavaScriptGrammar() *Grammar {
 
 	g.BinaryRepeatMode = true
 
+	g.FlattenGeneratedRepeatAux = true
+
+	g.ReuseRepeatAuxForParents = []string{
+		"jsx_opening_element",
+		"jsx_self_closing_element",
+	}
+
 	return g
 }

--- a/grammargen/json_grammar.go
+++ b/grammargen/json_grammar.go
@@ -27,9 +27,9 @@ func JSONGrammar() *Grammar {
 		Str("}"),
 	))
 
-	// pair: seq(field("key", choice(string, number)), ":", field("value", _value))
+	// pair: seq(field("key", string), ":", field("value", _value))
 	g.Define("pair", Seq(
-		Field("key", Choice(Sym("string"), Sym("number"))),
+		Field("key", Sym("string")),
 		Str(":"),
 		Field("value", Sym("_value")),
 	))
@@ -41,18 +41,21 @@ func JSONGrammar() *Grammar {
 		Str("]"),
 	))
 
-	// string: seq('"', repeat(choice(string_content, escape_sequence)), '"')
+	// string: seq('"', optional(_string_content), '"')
 	g.Define("string", Seq(
 		Str("\""),
-		Repeat(Choice(
-			Sym("string_content"),
-			Sym("escape_sequence"),
-		)),
+		Optional(Sym("_string_content")),
 		Str("\""),
 	))
 
-	// string_content: token.immediate(prec(1, /[^\\"]+/))
-	g.Define("string_content", ImmToken(Prec(1, Pat(`[^\\\"]+`))))
+	// _string_content: repeat1(choice(string_content, escape_sequence))
+	g.Define("_string_content", Repeat1(Choice(
+		Sym("string_content"),
+		Sym("escape_sequence"),
+	)))
+
+	// string_content: token.immediate(prec(1, /[^\\\"\n]+/))
+	g.Define("string_content", ImmToken(Prec(1, Pat(`[^\\\"\n]+`))))
 
 	// escape_sequence: token.immediate(seq("\\", choice(/["\\/bfnrt]/, /u[0-9a-fA-F]{4}/)))
 	g.Define("escape_sequence", ImmToken(Seq(
@@ -84,8 +87,14 @@ func JSONGrammar() *Grammar {
 	g.Define("false", Str("false"))
 	g.Define("null", Str("null"))
 
-	// Extras: whitespace.
-	g.SetExtras(Pat(`\s`))
+	// comment: token(choice(seq("//", /.*/), seq("/*", /[^*]*\*+([^/*][^*]*\*+)*/, "/")))
+	g.Define("comment", Token(Choice(
+		Seq(Str("//"), Pat(`.*`)),
+		Seq(Str("/*"), Pat(`[^*]*\*+([^/*][^*]*\*+)*`), Str("/")),
+	)))
+
+	// Extras: whitespace and comments.
+	g.SetExtras(Pat(`\s`), Sym("comment"))
 
 	// _value is a supertype.
 	g.SetSupertypes("_value")

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -123,8 +124,10 @@ type symbolTable struct {
 	fieldMap            map[string]int
 	fields              []string
 	repeatAuxByKey      map[string]string // canonical repeat body key → generated aux rule
-	binaryRepeatMode    bool              // use tree-sitter binary repeat helper shape
-	choiceLiftThreshold int               // if >0, lift inline CHOICE nodes exceeding this width
+	repeatAuxReuseRules map[string]bool
+	binaryRepeatMode    bool // use tree-sitter binary repeat helper shape
+	flattenRepeatAux    bool
+	choiceLiftThreshold int // if >0, lift inline CHOICE nodes exceeding this width
 }
 
 const inlinePatternSymbolPrefix = "\x00inline_pattern:"
@@ -270,6 +273,13 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	st := newSymbolTable()
 	st.grammarName = g.Name
 	st.binaryRepeatMode = g.BinaryRepeatMode
+	st.flattenRepeatAux = g.FlattenGeneratedRepeatAux
+	if len(g.ReuseRepeatAuxForParents) > 0 {
+		st.repeatAuxReuseRules = make(map[string]bool, len(g.ReuseRepeatAuxForParents))
+		for _, name := range g.ReuseRepeatAuxForParents {
+			st.repeatAuxReuseRules[name] = true
+		}
+	}
 	st.choiceLiftThreshold = g.ChoiceLiftThreshold
 	ng := &NormalizedGrammar{}
 
@@ -443,7 +453,7 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	// alternatives. Running this after prepareRule lets us flatten the cc=1
 	// branches introduced by repeat lowering, especially for hidden repeat
 	// helpers and top-level hidden repeat1 rules.
-	processedRules, auxRules = flattenPreparedRules(g.Name, nonterminals, processedRules, auxRules, g.Supertypes)
+	processedRules, auxRules = flattenPreparedRules(g.Name, nonterminals, processedRules, auxRules, g.Supertypes, st.flattenRepeatAux)
 
 	// Phase 5: Mark extra symbols.
 	extraSymbols := resolveExtras(g, st)
@@ -1630,7 +1640,7 @@ func liftLargeSeqChoices(seq *Rule, parentName string, st *symbolTable, auxRules
 
 func ensureRepeatAuxLinear(parentName string, inner *Rule, st *symbolTable, auxRules map[string]*Rule, counter *int) string {
 	key := ""
-	if shouldReuseRepeatAux(st.grammarName, parentName) {
+	if shouldReuseRepeatAux(st, parentName) {
 		key = "linear:" + canonicalRuleKey(inner)
 		if auxName, ok := st.repeatAuxByKey[key]; ok {
 			return auxName
@@ -1655,7 +1665,7 @@ func ensureRepeatAuxLinear(parentName string, inner *Rule, st *symbolTable, auxR
 
 func ensureRepeatAuxBinary(parentName string, inner *Rule, st *symbolTable, auxRules map[string]*Rule, counter *int) string {
 	key := ""
-	if shouldReuseRepeatAux(st.grammarName, parentName) {
+	if shouldReuseRepeatAux(st, parentName) {
 		key = "binary:" + canonicalRuleKey(inner)
 		if auxName, ok := st.repeatAuxByKey[key]; ok {
 			return auxName
@@ -1678,19 +1688,8 @@ func ensureRepeatAuxBinary(parentName string, inner *Rule, st *symbolTable, auxR
 	return auxName
 }
 
-func shouldReuseRepeatAux(grammarName, parentName string) bool {
-	if grammarName != "javascript" {
-		return false
-	}
-	// Upstream JavaScript reuses the opening-element attribute repeat helper
-	// for self-closing JSX tags. Without that shared helper, attribute lists
-	// can reduce into the opening-tag path and leave no valid "/>" action.
-	switch parentName {
-	case "jsx_opening_element", "jsx_self_closing_element":
-		return true
-	default:
-		return false
-	}
+func shouldReuseRepeatAux(st *symbolTable, parentName string) bool {
+	return st != nil && st.repeatAuxReuseRules[parentName]
 }
 
 func recordAuxOrigin(auxOrigins map[string]map[string]bool, auxName, origin string) {
@@ -1726,7 +1725,14 @@ func writeRuleKey(r *Rule, sb *strings.Builder) {
 		sb.WriteString("nil")
 		return
 	}
-	fmt.Fprintf(sb, "%d:%q:%d:%t[", r.Kind, r.Value, r.Prec, r.Named)
+	sb.WriteString(strconv.Itoa(int(r.Kind)))
+	sb.WriteByte(':')
+	sb.WriteString(strconv.Quote(r.Value))
+	sb.WriteByte(':')
+	sb.WriteString(strconv.Itoa(r.Prec))
+	sb.WriteByte(':')
+	sb.WriteString(strconv.FormatBool(r.Named))
+	sb.WriteByte('[')
 	for i, c := range r.Children {
 		if i > 0 {
 			sb.WriteByte(',')
@@ -1791,9 +1797,10 @@ func expandTopLevelRepeat(r *Rule, ruleName string, binaryMode bool) *Rule {
 	return expanded
 }
 
-func flattenPreparedRules(grammarName string, nonterminals []string, processedRules, auxRules map[string]*Rule, supertypes []string) (map[string]*Rule, map[string]*Rule) {
+func flattenPreparedRules(grammarName string, nonterminals []string, processedRules, auxRules map[string]*Rule, supertypes []string, flattenGeneratedRepeatAux bool) (map[string]*Rule, map[string]*Rule) {
 	tmp := NewGrammar(grammarName)
 	tmp.Supertypes = append(tmp.Supertypes, supertypes...)
+	tmp.FlattenGeneratedRepeatAux = flattenGeneratedRepeatAux
 
 	for _, name := range nonterminals {
 		if rule := processedRules[name]; rule != nil {
@@ -3117,11 +3124,7 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 	flattenMap := make(map[string]*flattenInfo)
 
 	for _, name := range g.RuleOrder {
-		// JavaScript's generated repeat helpers participate in upstream
-		// flattening even when their parent rule is visible (for example
-		// program_repeat1 and JSX attribute repeats). Keep this scoped until
-		// the same shape is validated for TSX's JSX-vs-generic ambiguity.
-		isGeneratedHidden := generatedHiddenRules[name] && g.Name == "javascript"
+		isGeneratedHidden := generatedHiddenRules[name] && g.FlattenGeneratedRepeatAux
 		if !strings.HasPrefix(name, "_") && !isGeneratedHidden {
 			continue // only hidden rules
 		}
@@ -3328,6 +3331,12 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 	out.ReservedWordSets = cloneReservedWordSets(g.ReservedWordSets)
 	out.Supertypes = g.Supertypes
 	out.Inline = g.Inline
+	out.FlattenGeneratedRepeatAux = g.FlattenGeneratedRepeatAux
+	out.ReuseRepeatAuxForParents = append(out.ReuseRepeatAuxForParents, g.ReuseRepeatAuxForParents...)
+	out.BinaryRepeatMode = g.BinaryRepeatMode
+	out.EnableLRSplitting = g.EnableLRSplitting
+	out.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
+	out.ChoiceLiftThreshold = g.ChoiceLiftThreshold
 	return out
 }
 
@@ -3701,6 +3710,8 @@ func expandInlineRules(g *Grammar) *Grammar {
 	out.Supertypes = g.Supertypes
 	out.Precedences = g.Precedences
 	out.BinaryRepeatMode = g.BinaryRepeatMode
+	out.FlattenGeneratedRepeatAux = g.FlattenGeneratedRepeatAux
+	out.ReuseRepeatAuxForParents = append(out.ReuseRepeatAuxForParents, g.ReuseRepeatAuxForParents...)
 	out.EnableLRSplitting = g.EnableLRSplitting
 	out.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
 	out.ChoiceLiftThreshold = g.ChoiceLiftThreshold

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -115,14 +115,16 @@ type NormalizedGrammar struct {
 
 // symbolTable is used during normalization.
 type symbolTable struct {
+	grammarName         string
 	byName              map[string]int // terminal name → symbol ID
 	nontermByName       map[string]int // nonterminal name → symbol ID
 	namedTokenByName    map[string]int // named token name → symbol ID (when distinct from anonymous)
 	symbols             []SymbolInfo
 	fieldMap            map[string]int
 	fields              []string
-	binaryRepeatMode    bool // use tree-sitter binary repeat helper shape
-	choiceLiftThreshold int  // if >0, lift inline CHOICE nodes exceeding this width
+	repeatAuxByKey      map[string]string // canonical repeat body key → generated aux rule
+	binaryRepeatMode    bool              // use tree-sitter binary repeat helper shape
+	choiceLiftThreshold int               // if >0, lift inline CHOICE nodes exceeding this width
 }
 
 const inlinePatternSymbolPrefix = "\x00inline_pattern:"
@@ -137,6 +139,7 @@ func newSymbolTable() *symbolTable {
 		nontermByName:    make(map[string]int),
 		namedTokenByName: make(map[string]int),
 		fieldMap:         make(map[string]int),
+		repeatAuxByKey:   make(map[string]string),
 		fields:           []string{""}, // index 0 is always ""
 	}
 	// Symbol 0 = "end" (EOF). Tree-sitter C marks this Named=true.
@@ -265,6 +268,7 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	}
 
 	st := newSymbolTable()
+	st.grammarName = g.Name
 	st.binaryRepeatMode = g.BinaryRepeatMode
 	st.choiceLiftThreshold = g.ChoiceLiftThreshold
 	ng := &NormalizedGrammar{}
@@ -420,7 +424,7 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	auxCounter := 0
 	processedRules := make(map[string]*Rule)
 	auxRules := make(map[string]*Rule)
-	auxOrigin := make(map[string]string) // aux rule name → originating grammar rule name
+	auxOrigins := make(map[string]map[string]bool) // aux rule name → originating grammar rule names
 
 	for _, name := range nonterminals {
 		rule := g.Rules[name]
@@ -431,17 +435,8 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 		// the rule itself into the repetition binary tree instead of
 		// introducing another auxiliary rule.
 		rule = expandTopLevelRepeat(cloneRule(rule), name, st.binaryRepeatMode)
-		prevAuxCount := len(auxRules)
-		processed := prepareRule(rule, name, st, auxRules, &auxCounter)
+		processed := prepareRule(rule, name, st, auxRules, auxOrigins, &auxCounter)
 		processedRules[name] = processed
-		// Track which grammar rule each new auxiliary rule originates from.
-		if len(auxRules) > prevAuxCount {
-			for auxName := range auxRules {
-				if _, tracked := auxOrigin[auxName]; !tracked {
-					auxOrigin[auxName] = name
-				}
-			}
-		}
 	}
 
 	// Tree-sitter expands repeats before flattening hidden pass-through
@@ -526,8 +521,8 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 		auxNames = append(auxNames, name)
 	}
 	sort.Slice(auxNames, func(i, j int) bool {
-		oi := ruleOrderIdx[auxOrigin[auxNames[i]]]
-		oj := ruleOrderIdx[auxOrigin[auxNames[j]]]
+		oi := earliestAuxOriginOrder(auxOrigins[auxNames[i]], ruleOrderIdx)
+		oj := earliestAuxOriginOrder(auxOrigins[auxNames[j]], ruleOrderIdx)
 		if oi != oj {
 			return oi < oj
 		}
@@ -574,18 +569,20 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 		}
 		// For each auxiliary rule, check if its originating rule is in any
 		// conflict group. If so, add the auxiliary's symbol ID to that group.
-		for auxName, originName := range auxOrigin {
-			gis := conflictGroupsByName[originName]
-			if len(gis) == 0 {
-				continue
-			}
+		for auxName, origins := range auxOrigins {
 			auxID, ok := st.lookupNonterm(auxName)
 			if !ok {
 				continue
 			}
-			for _, gi := range gis {
-				if gi < len(conflicts) {
-					conflicts[gi] = append(conflicts[gi], auxID)
+			for originName := range origins {
+				gis := conflictGroupsByName[originName]
+				if len(gis) == 0 {
+					continue
+				}
+				for _, gi := range gis {
+					if gi < len(conflicts) {
+						conflicts[gi] = append(conflicts[gi], auxID)
+					}
 				}
 			}
 		}
@@ -1438,7 +1435,7 @@ func escapeAnonymousName(s string) string {
 // - Expands Optional(x) → Choice(x, Blank())
 // - Replaces Repeat(x) and Repeat1(x) with auxiliary nonterminal symbols
 // This handles repeat/repeat1 at ALL levels including the root.
-func prepareRule(r *Rule, parentName string, st *symbolTable, auxRules map[string]*Rule, counter *int) *Rule {
+func prepareRule(r *Rule, parentName string, st *symbolTable, auxRules map[string]*Rule, auxOrigins map[string]map[string]bool, counter *int) *Rule {
 	if r == nil {
 		return r
 	}
@@ -1450,38 +1447,42 @@ func prepareRule(r *Rule, parentName string, st *symbolTable, auxRules map[strin
 	// Handle the current node.
 	switch r.Kind {
 	case RuleRepeat:
-		preparedInner := prepareRule(cloneRule(r.Children[0]), parentName, st, auxRules, counter)
+		preparedInner := prepareRule(cloneRule(r.Children[0]), parentName, st, auxRules, auxOrigins, counter)
 		// If the inner rule is a wide CHOICE and we have a lift threshold,
 		// extract it into an auxiliary nonterminal to prevent the repeat
 		// helper from creating N² productions (where N = choice width).
-		preparedInner = maybeExtractWideChoice(preparedInner, parentName, st, auxRules, counter)
+		preparedInner = maybeExtractWideChoice(preparedInner, parentName, st, auxRules, auxOrigins, counter)
 		if st.binaryRepeatMode {
 			auxName := ensureRepeatAuxBinary(parentName, preparedInner, st, auxRules, counter)
+			recordAuxOrigin(auxOrigins, auxName, parentName)
 			return Choice(Sym(auxName), Blank())
 		}
 		auxName := ensureRepeatAuxLinear(parentName, preparedInner, st, auxRules, counter)
+		recordAuxOrigin(auxOrigins, auxName, parentName)
 		return Choice(Blank(), cloneRule(preparedInner), Sym(auxName))
 
 	case RuleRepeat1:
-		preparedInner := prepareRule(cloneRule(r.Children[0]), parentName, st, auxRules, counter)
-		preparedInner = maybeExtractWideChoice(preparedInner, parentName, st, auxRules, counter)
+		preparedInner := prepareRule(cloneRule(r.Children[0]), parentName, st, auxRules, auxOrigins, counter)
+		preparedInner = maybeExtractWideChoice(preparedInner, parentName, st, auxRules, auxOrigins, counter)
 		if st.binaryRepeatMode {
 			auxName := ensureRepeatAuxBinary(parentName, preparedInner, st, auxRules, counter)
+			recordAuxOrigin(auxOrigins, auxName, parentName)
 			return Sym(auxName)
 		}
 		auxName := ensureRepeatAuxLinear(parentName, preparedInner, st, auxRules, counter)
+		recordAuxOrigin(auxOrigins, auxName, parentName)
 		return Choice(cloneRule(preparedInner), Sym(auxName))
 
 	case RuleOptional:
 		// optional(x) → choice(x, blank)
-		inner := prepareRule(r.Children[0], parentName, st, auxRules, counter)
+		inner := prepareRule(r.Children[0], parentName, st, auxRules, auxOrigins, counter)
 		return Choice(inner, Blank())
 
 	}
 
 	// Recurse into children.
 	for i, c := range r.Children {
-		r.Children[i] = prepareRule(c, parentName, st, auxRules, counter)
+		r.Children[i] = prepareRule(c, parentName, st, auxRules, auxOrigins, counter)
 	}
 
 	// For SEQ nodes in grammars with ChoiceLiftThreshold: lift inline CHOICE
@@ -1489,7 +1490,7 @@ func prepareRule(r *Rule, parentName string, st *symbolTable, auxRules map[strin
 	// This prevents Cartesian product explosion in production extraction.
 	// Only enabled for grammars that explicitly opt in (e.g. COBOL with 1071 rules).
 	if r.Kind == RuleSeq && st.choiceLiftThreshold > 0 {
-		r = liftLargeSeqChoices(r, parentName, st, auxRules, counter)
+		r = liftLargeSeqChoices(r, parentName, st, auxRules, auxOrigins, counter)
 	}
 
 	return r
@@ -1504,7 +1505,7 @@ func prepareRule(r *Rule, parentName string, st *symbolTable, auxRules map[strin
 // choiceLiftThreshold. If so, it extracts the CHOICE into an auxiliary
 // nonterminal and returns a symbol reference. This prevents repeat helpers
 // from creating N² productions when their body is a wide CHOICE.
-func maybeExtractWideChoice(r *Rule, parentName string, st *symbolTable, auxRules map[string]*Rule, counter *int) *Rule {
+func maybeExtractWideChoice(r *Rule, parentName string, st *symbolTable, auxRules map[string]*Rule, auxOrigins map[string]map[string]bool, counter *int) *Rule {
 	if st.choiceLiftThreshold <= 0 || r == nil || r.Kind != RuleChoice {
 		return r
 	}
@@ -1519,6 +1520,7 @@ func maybeExtractWideChoice(r *Rule, parentName string, st *symbolTable, auxRule
 		})
 		auxRules[auxName] = r
 	}
+	recordAuxOrigin(auxOrigins, auxName, parentName)
 	return Sym(auxName)
 }
 
@@ -1562,7 +1564,7 @@ func estimateAlternativeCount(r *Rule) int {
 // liftLargeSeqChoices examines a SEQ node and lifts CHOICE children into
 // auxiliary nonterminals when the total Cartesian product exceeds the
 // choiceLiftThreshold. Only active when st.choiceLiftThreshold > 0.
-func liftLargeSeqChoices(seq *Rule, parentName string, st *symbolTable, auxRules map[string]*Rule, counter *int) *Rule {
+func liftLargeSeqChoices(seq *Rule, parentName string, st *symbolTable, auxRules map[string]*Rule, auxOrigins map[string]map[string]bool, counter *int) *Rule {
 	threshold := st.choiceLiftThreshold
 	if threshold <= 0 {
 		return seq
@@ -1614,6 +1616,7 @@ func liftLargeSeqChoices(seq *Rule, parentName string, st *symbolTable, auxRules
 			})
 			auxRules[auxName] = cloneRule(newChildren[bestIdx])
 		}
+		recordAuxOrigin(auxOrigins, auxName, parentName)
 		newChildren[bestIdx] = Sym(auxName)
 
 		newSeq := &Rule{Kind: RuleSeq, Children: newChildren}
@@ -1626,6 +1629,13 @@ func liftLargeSeqChoices(seq *Rule, parentName string, st *symbolTable, auxRules
 }
 
 func ensureRepeatAuxLinear(parentName string, inner *Rule, st *symbolTable, auxRules map[string]*Rule, counter *int) string {
+	key := ""
+	if shouldReuseRepeatAux(st.grammarName, parentName) {
+		key = "linear:" + canonicalRuleKey(inner)
+		if auxName, ok := st.repeatAuxByKey[key]; ok {
+			return auxName
+		}
+	}
 	*counter++
 	auxName := fmt.Sprintf("%s_repeat%d", parentName, *counter)
 	if _, exists := st.lookupNonterm(auxName); !exists {
@@ -1637,10 +1647,20 @@ func ensureRepeatAuxLinear(parentName string, inner *Rule, st *symbolTable, auxR
 			Seq(cloneRule(inner), cloneRule(inner)),
 		)
 	}
+	if key != "" {
+		st.repeatAuxByKey[key] = auxName
+	}
 	return auxName
 }
 
 func ensureRepeatAuxBinary(parentName string, inner *Rule, st *symbolTable, auxRules map[string]*Rule, counter *int) string {
+	key := ""
+	if shouldReuseRepeatAux(st.grammarName, parentName) {
+		key = "binary:" + canonicalRuleKey(inner)
+		if auxName, ok := st.repeatAuxByKey[key]; ok {
+			return auxName
+		}
+	}
 	*counter++
 	auxName := fmt.Sprintf("%s_repeat%d", parentName, *counter)
 	if _, exists := st.lookupNonterm(auxName); !exists {
@@ -1652,7 +1672,68 @@ func ensureRepeatAuxBinary(parentName string, inner *Rule, st *symbolTable, auxR
 			cloneRule(inner),
 		)
 	}
+	if key != "" {
+		st.repeatAuxByKey[key] = auxName
+	}
 	return auxName
+}
+
+func shouldReuseRepeatAux(grammarName, parentName string) bool {
+	if grammarName != "javascript" {
+		return false
+	}
+	// Upstream JavaScript reuses the opening-element attribute repeat helper
+	// for self-closing JSX tags. Without that shared helper, attribute lists
+	// can reduce into the opening-tag path and leave no valid "/>" action.
+	switch parentName {
+	case "jsx_opening_element", "jsx_self_closing_element":
+		return true
+	default:
+		return false
+	}
+}
+
+func recordAuxOrigin(auxOrigins map[string]map[string]bool, auxName, origin string) {
+	if auxName == "" || origin == "" {
+		return
+	}
+	origins := auxOrigins[auxName]
+	if origins == nil {
+		origins = make(map[string]bool)
+		auxOrigins[auxName] = origins
+	}
+	origins[origin] = true
+}
+
+func earliestAuxOriginOrder(origins map[string]bool, ruleOrderIdx map[string]int) int {
+	best := len(ruleOrderIdx)
+	for origin := range origins {
+		if idx, ok := ruleOrderIdx[origin]; ok && idx < best {
+			best = idx
+		}
+	}
+	return best
+}
+
+func canonicalRuleKey(r *Rule) string {
+	var sb strings.Builder
+	writeRuleKey(r, &sb)
+	return sb.String()
+}
+
+func writeRuleKey(r *Rule, sb *strings.Builder) {
+	if r == nil {
+		sb.WriteString("nil")
+		return
+	}
+	fmt.Fprintf(sb, "%d:%q:%d:%t[", r.Kind, r.Value, r.Prec, r.Named)
+	for i, c := range r.Children {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		writeRuleKey(c, sb)
+	}
+	sb.WriteByte(']')
 }
 
 // expandTopLevelRepeat expands repeat1 at the top level of a hidden rule into
@@ -1721,8 +1802,10 @@ func flattenPreparedRules(grammarName string, nonterminals []string, processedRu
 	}
 
 	auxNames := make([]string, 0, len(auxRules))
+	generatedHiddenRules := make(map[string]bool, len(auxRules))
 	for name := range auxRules {
 		auxNames = append(auxNames, name)
+		generatedHiddenRules[name] = true
 	}
 	sort.Strings(auxNames)
 	for _, name := range auxNames {
@@ -1731,7 +1814,7 @@ func flattenPreparedRules(grammarName string, nonterminals []string, processedRu
 		}
 	}
 
-	flattened := flattenHiddenChoiceAlts(tmp)
+	flattened := flattenHiddenChoiceAlts(tmp, generatedHiddenRules)
 	if flattened == nil {
 		return processedRules, auxRules
 	}
@@ -3029,12 +3112,17 @@ func deduplicateProductions(prods []Production) []Production {
 //	A → Choice(_H, X, Y, Z)          (pass-through alts inlined)
 //
 // This matches tree-sitter C's flatten_grammar.cc behavior.
-func flattenHiddenChoiceAlts(g *Grammar) *Grammar {
+func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *Grammar {
 	// 1. Identify hidden nonterminals with mixed pass-through and compound alts.
 	flattenMap := make(map[string]*flattenInfo)
 
 	for _, name := range g.RuleOrder {
-		if !strings.HasPrefix(name, "_") {
+		// JavaScript's generated repeat helpers participate in upstream
+		// flattening even when their parent rule is visible (for example
+		// program_repeat1 and JSX attribute repeats). Keep this scoped until
+		// the same shape is validated for TSX's JSX-vs-generic ambiguity.
+		isGeneratedHidden := generatedHiddenRules[name] && g.Name == "javascript"
+		if !strings.HasPrefix(name, "_") && !isGeneratedHidden {
 			continue // only hidden rules
 		}
 		// Skip supertypes.
@@ -3100,6 +3188,8 @@ func flattenHiddenChoiceAlts(g *Grammar) *Grammar {
 			continue
 		}
 
+		generatedRepeatHelper := isGeneratedHidden && isGeneratedRepeatAuxName(name)
+
 		// Skip arbitrary self-recursive flattening, but allow the exact
 		// repetition shape introduced by repeat lowering:
 		//   choice(seq(self, inner), seq(inner, inner), passthrough...)
@@ -3128,7 +3218,7 @@ func flattenHiddenChoiceAlts(g *Grammar) *Grammar {
 		// would leave the rule unreachable — it can only reduce from
 		// itself, with no way to create a base instance. Skip flattening
 		// for these rules to preserve their base cases.
-		if allCompoundsAreSelfRecursive {
+		if allCompoundsAreSelfRecursive && !generatedRepeatHelper {
 			continue
 		}
 
@@ -3186,9 +3276,10 @@ func flattenHiddenChoiceAlts(g *Grammar) *Grammar {
 		}
 
 		flattenMap[name] = &flattenInfo{
-			passThrough: pt,
-			compound:    compound,
-			replaceRule: true,
+			passThrough:    pt,
+			compound:       compound,
+			replaceRule:    true,
+			inlineCompound: generatedRepeatHelper && allCompoundsAreSelfRecursive,
 		}
 	}
 
@@ -3211,6 +3302,9 @@ func flattenHiddenChoiceAlts(g *Grammar) *Grammar {
 				newRule = fi.compound[0]
 			} else {
 				newRule = Choice(fi.compound...)
+			}
+			if fi.inlineCompound {
+				newRule = inlinePassthroughRefs(newRule, flattenMap)
 			}
 			out.Define(name, newRule)
 			continue
@@ -3328,6 +3422,23 @@ func isRepeatSelfRef(r *Rule, name string) bool {
 		return true
 	}
 	return false
+}
+
+func isGeneratedRepeatAuxName(name string) bool {
+	idx := strings.LastIndex(name, "_repeat")
+	if idx < 0 {
+		return false
+	}
+	suffix := name[idx+len("_repeat"):]
+	if suffix == "" {
+		return false
+	}
+	for _, r := range suffix {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
 }
 
 func isDirectSelfRef(r *Rule, name string) bool {
@@ -3468,9 +3579,10 @@ func stripTopAlias(r *Rule) *Rule {
 }
 
 type flattenInfo struct {
-	passThrough []*Rule
-	compound    []*Rule
-	replaceRule bool
+	passThrough    []*Rule
+	compound       []*Rule
+	replaceRule    bool
+	inlineCompound bool
 }
 
 // expandInlineRules returns a copy of the grammar with all inline rule

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -1064,6 +1064,8 @@ var jsonParityInputs = []struct {
 	{"number key", `{"key": 42}`},
 	{"bool values", `{"t": true, "f": false}`},
 	{"null value", `{"n": null}`},
+	{"line comment extra", "{\n// comment\n\"a\": 1\n}"},
+	{"block comment extra", `{"a": /* comment */ 1}`},
 
 	// Arrays.
 	{"empty array", `[]`},
@@ -1156,6 +1158,34 @@ func TestParityJSONNoErrors(t *testing.T) {
 				t.Errorf("generated parser produced MISSING: %s", sexp)
 			}
 		})
+	}
+}
+
+func TestParityJSONRejectsNumberKeysLikeReference(t *testing.T) {
+	refLang := grammars.JsonLanguage()
+	if refLang == nil {
+		t.Fatal("reference JSON language not available")
+	}
+	genLang, err := GenerateLanguage(JSONGrammar())
+	if err != nil {
+		t.Fatalf("GenerateLanguage failed: %v", err)
+	}
+
+	src := []byte(`{1: "value"}`)
+	refTree, err := gotreesitter.NewParser(refLang).Parse(src)
+	if err != nil {
+		t.Fatalf("reference parse failed: %v", err)
+	}
+	genTree, err := gotreesitter.NewParser(genLang).Parse(src)
+	if err != nil {
+		t.Fatalf("generated parse failed: %v", err)
+	}
+
+	if !refTree.RootNode().HasError() {
+		t.Fatalf("reference JSON unexpectedly accepted a numeric object key: %s", refTree.RootNode().SExpr(refLang))
+	}
+	if !genTree.RootNode().HasError() {
+		t.Fatalf("generated JSON accepted a numeric object key: %s", genTree.RootNode().SExpr(genLang))
 	}
 }
 
@@ -1516,12 +1546,7 @@ func TestParityJSONProperties(t *testing.T) {
 		}
 	}
 
-	// Symbols that the reference has but grammargen intentionally omits.
-	// tree-sitter adds a "comment" symbol to all grammars by default;
-	// grammargen only includes it if the grammar declares a comment rule.
-	refOnlyExpected := map[string]bool{
-		"comment": true,
-	}
+	refOnlyExpected := map[string]bool{}
 
 	// Every visible symbol in the reference should exist in generated
 	// (modulo intentional omissions).

--- a/grammargen/production_diag_test.go
+++ b/grammargen/production_diag_test.go
@@ -30,7 +30,7 @@ func TestProductionChildCountDiag(t *testing.T) {
 	// Grammars and symbols flagged by logReduceActionDiff as having
 	// gen-cc ≠ ref-cc (missing shorter variants).
 	type diagCase struct {
-		grammar string // grammar dir name
+		grammar string   // grammar dir name
 		symbols []string // symbols to check
 	}
 
@@ -652,6 +652,95 @@ func TestProductionRepeatInSeq(t *testing.T) {
 				t.Errorf("repeat aux %q missing cc=2 production", info.Name)
 			}
 		}
+	}
+}
+
+func TestProductionBinaryRepeatAuxForVisibleParentFlattensBaseCase(t *testing.T) {
+	g := &Grammar{
+		Name:             "javascript",
+		BinaryRepeatMode: true,
+		Rules: map[string]*Rule{
+			"program":    Repeat(Sym("statement")),
+			"statement":  Sym("identifier"),
+			"identifier": Pat(`[a-z]+`),
+		},
+		RuleOrder: []string{"program", "statement", "identifier"},
+	}
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	auxID := -1
+	for i, info := range ng.Symbols {
+		if info.Name == "program_repeat1" {
+			auxID = i
+			break
+		}
+	}
+	if auxID < 0 {
+		t.Fatal("program_repeat1 symbol not found")
+	}
+
+	var auxCCs []int
+	for _, p := range ng.Productions {
+		if p.LHS == auxID {
+			auxCCs = append(auxCCs, len(p.RHS))
+		}
+	}
+	t.Logf("program_repeat1 cc values = %v", auxCCs)
+	if len(auxCCs) == 0 {
+		t.Fatal("program_repeat1 has no productions")
+	}
+	hasTwo := false
+	for _, cc := range auxCCs {
+		if cc == 2 {
+			hasTwo = true
+			continue
+		}
+		t.Fatalf("program_repeat1 has non-tree-sitter child count %d (ccs=%v)", cc, auxCCs)
+	}
+	if !hasTwo {
+		t.Fatalf("program_repeat1 missing cc=2 production (ccs=%v)", auxCCs)
+	}
+}
+
+func TestJavaScriptJSXAttributeRepeatHelpersFlattenBaseCases(t *testing.T) {
+	ng, err := Normalize(JavaScriptGrammar())
+	if err != nil {
+		t.Fatalf("normalize javascript: %v", err)
+	}
+
+	checked := 0
+	selfClosingHelpers := 0
+	for i, info := range ng.Symbols {
+		if strings.HasPrefix(info.Name, "jsx_self_closing_element_repeat") {
+			selfClosingHelpers++
+		}
+		if !strings.HasPrefix(info.Name, "jsx_self_closing_element_repeat") &&
+			!strings.HasPrefix(info.Name, "jsx_opening_element_repeat") {
+			continue
+		}
+		checked++
+		var auxCCs []int
+		for _, p := range ng.Productions {
+			if p.LHS == i {
+				auxCCs = append(auxCCs, len(p.RHS))
+			}
+		}
+		t.Logf("%s cc values = %v", info.Name, auxCCs)
+		for _, cc := range auxCCs {
+			if cc != 2 {
+				t.Fatalf("%s has non-tree-sitter child count %d (ccs=%v)", info.Name, cc, auxCCs)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no JSX attribute repeat helpers found")
+	}
+	if selfClosingHelpers != 0 {
+		t.Fatalf("self-closing JSX attributes should reuse the opening-element repeat helper, found %d separate helpers", selfClosingHelpers)
 	}
 }
 

--- a/grammargen/production_diag_test.go
+++ b/grammargen/production_diag_test.go
@@ -657,8 +657,9 @@ func TestProductionRepeatInSeq(t *testing.T) {
 
 func TestProductionBinaryRepeatAuxForVisibleParentFlattensBaseCase(t *testing.T) {
 	g := &Grammar{
-		Name:             "javascript",
-		BinaryRepeatMode: true,
+		Name:                      "javascript",
+		BinaryRepeatMode:          true,
+		FlattenGeneratedRepeatAux: true,
 		Rules: map[string]*Rule{
 			"program":    Repeat(Sym("statement")),
 			"statement":  Sym("identifier"),

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -19,11 +19,6 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 	if len(source) != len(oldTree.source) {
 		return nil, false
 	}
-	restoreState, ok := snapshotTokenSourceState(ts)
-	if !ok {
-		return nil, false
-	}
-	defer restoreState()
 	root := oldTree.RootNode()
 	leaf := oldTree.lastEditedLeaf
 	if leaf == nil || !leaf.containsByteRange(edit.StartByte, edit.OldEndByte) {
@@ -32,23 +27,30 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 	if leaf == nil || leaf.ChildCount() != 0 || leaf.hasError || leaf.isMissing || leaf.isExtra {
 		return nil, false
 	}
-	stateful, ok := ts.(parserStateTokenSource)
-	if !ok {
-		return nil, false
-	}
 	start := time.Time{}
 	if timing != nil {
 		start = time.Now()
 	}
-	stateful.SetParserState(leaf.preGotoState)
-	stateful.SetGLRStates(nil)
-	var tok Token
-	if skipper, ok := ts.(PointSkippableTokenSource); ok {
-		tok = skipper.SkipToByteWithPoint(leaf.startByte, leaf.startPoint)
-	} else if skipper, ok := ts.(ByteSkippableTokenSource); ok {
-		tok = skipper.SkipToByte(leaf.startByte)
-	} else {
-		return nil, false
+	tok, ok := scanLeafTokenWithoutMutatingSource(ts, leaf)
+	if !ok {
+		restoreState, ok := snapshotTokenSourceState(ts)
+		if !ok {
+			return nil, false
+		}
+		defer restoreState()
+		stateful, ok := ts.(parserStateTokenSource)
+		if !ok {
+			return nil, false
+		}
+		stateful.SetParserState(leaf.preGotoState)
+		stateful.SetGLRStates(nil)
+		if skipper, ok := ts.(PointSkippableTokenSource); ok {
+			tok = skipper.SkipToByteWithPoint(leaf.startByte, leaf.startPoint)
+		} else if skipper, ok := ts.(ByteSkippableTokenSource); ok {
+			tok = skipper.SkipToByte(leaf.startByte)
+		} else {
+			return nil, false
+		}
 	}
 	if tok.Symbol != leaf.symbol || tok.StartByte != leaf.startByte || tok.EndByte != leaf.endByte {
 		return nil, false
@@ -80,6 +82,95 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 		timing.singleStackTokens = 1
 	}
 	return tree, true
+}
+
+func scanLeafTokenWithoutMutatingSource(ts TokenSource, leaf *Node) (Token, bool) {
+	if leaf == nil {
+		return Token{}, false
+	}
+	switch typed := ts.(type) {
+	case *dfaTokenSource:
+		return scanDFALeafTokenWithoutMutatingSource(typed, leaf)
+	case *includedRangeTokenSource:
+		if typed == nil {
+			return Token{}, false
+		}
+		base, ok := typed.base.(*dfaTokenSource)
+		if !ok {
+			return Token{}, false
+		}
+		snapshot, ok := prepareDFALeafScan(base, leaf)
+		if !ok {
+			return Token{}, false
+		}
+		idx := typed.idx
+		tok := typed.SkipToByteWithPoint(leaf.startByte, leaf.startPoint)
+		restoreDFALeafScan(base, snapshot)
+		typed.idx = idx
+		return tok, true
+	default:
+		return Token{}, false
+	}
+}
+
+func scanDFALeafTokenWithoutMutatingSource(dts *dfaTokenSource, leaf *Node) (Token, bool) {
+	snapshot, ok := prepareDFALeafScan(dts, leaf)
+	if !ok {
+		return Token{}, false
+	}
+	tok := dts.SkipToByteWithPoint(leaf.startByte, leaf.startPoint)
+	restoreDFALeafScan(dts, snapshot)
+	return tok, true
+}
+
+type dfaLeafScanSnapshot struct {
+	state                  StateID
+	glrStates              []StateID
+	lexer                  Lexer
+	lastExternalTokenStart uint32
+	lastExternalTokenEnd   uint32
+	lastExternalTokenValid bool
+	extZeroPos             int
+	extZeroState           StateID
+	zeroWidthPos           int
+	zeroWidthCount         int
+}
+
+func prepareDFALeafScan(dts *dfaTokenSource, leaf *Node) (dfaLeafScanSnapshot, bool) {
+	if dts == nil || dts.lexer == nil || dts.language == nil || leaf == nil {
+		return dfaLeafScanSnapshot{}, false
+	}
+	if dts.language.ExternalScanner != nil || len(dts.language.ExternalSymbols) != 0 {
+		return dfaLeafScanSnapshot{}, false
+	}
+	snapshot := dfaLeafScanSnapshot{
+		state:                  dts.state,
+		glrStates:              dts.glrStates,
+		lexer:                  *dts.lexer,
+		lastExternalTokenStart: dts.lastExternalTokenStartByte,
+		lastExternalTokenEnd:   dts.lastExternalTokenEndByte,
+		lastExternalTokenValid: dts.lastExternalTokenValid,
+		extZeroPos:             dts.extZeroPos,
+		extZeroState:           dts.extZeroState,
+		zeroWidthPos:           dts.zeroWidthPos,
+		zeroWidthCount:         dts.zeroWidthCount,
+	}
+	dts.state = leaf.preGotoState
+	dts.glrStates = nil
+	return snapshot, true
+}
+
+func restoreDFALeafScan(dts *dfaTokenSource, snapshot dfaLeafScanSnapshot) {
+	dts.state = snapshot.state
+	dts.glrStates = snapshot.glrStates
+	*dts.lexer = snapshot.lexer
+	dts.lastExternalTokenStartByte = snapshot.lastExternalTokenStart
+	dts.lastExternalTokenEndByte = snapshot.lastExternalTokenEnd
+	dts.lastExternalTokenValid = snapshot.lastExternalTokenValid
+	dts.extZeroPos = snapshot.extZeroPos
+	dts.extZeroState = snapshot.extZeroState
+	dts.zeroWidthPos = snapshot.zeroWidthPos
+	dts.zeroWidthCount = snapshot.zeroWidthCount
 }
 
 type dfaTokenSourceStateSnapshot struct {

--- a/incremental_leaf_fastpath_test.go
+++ b/incremental_leaf_fastpath_test.go
@@ -145,3 +145,147 @@ func TestSnapshotTokenSourceStateSupportsIncludedRangeWrapper(t *testing.T) {
 		t.Fatalf("underlying lexer.pos = %d, want %d", underlying.lexer.pos, 3)
 	}
 }
+
+func TestScanLeafTokenWithoutMutatingDFATokenSource(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	parser := NewParser(lang)
+	oldSource := []byte("1+2")
+	newSource := []byte("1+3")
+	tree := mustParse(t, parser, oldSource)
+	tree.Edit(InputEdit{
+		StartByte:   2,
+		OldEndByte:  3,
+		NewEndByte:  3,
+		StartPoint:  Point{Row: 0, Column: 2},
+		OldEndPoint: Point{Row: 0, Column: 3},
+		NewEndPoint: Point{Row: 0, Column: 3},
+	})
+	leaf := tree.lastEditedLeaf
+	if leaf == nil {
+		t.Fatal("expected edited leaf to be tracked")
+	}
+
+	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, newSource), lang, parser.lookupActionIndex, parser.hasKeywordState)
+	ts.state = 88
+	ts.glrStates = []StateID{1, 3, 5}
+	ts.zeroWidthPos = 7
+	ts.zeroWidthCount = 9
+	beforeLexer := *ts.lexer
+	beforeGLR := append([]StateID(nil), ts.glrStates...)
+
+	tok, ok := scanLeafTokenWithoutMutatingSource(ts, leaf)
+	if !ok {
+		t.Fatal("scanLeafTokenWithoutMutatingSource returned false for DFA token source")
+	}
+	if tok.Symbol != 1 || tok.StartByte != 2 || tok.EndByte != 3 {
+		t.Fatalf("token = %+v, want NUMBER at [2,3)", tok)
+	}
+	if ts.state != 88 {
+		t.Fatalf("source parser state mutated to %d, want 88", ts.state)
+	}
+	if !reflect.DeepEqual(ts.glrStates, beforeGLR) {
+		t.Fatalf("source GLR states mutated to %v, want %v", ts.glrStates, beforeGLR)
+	}
+	if ts.zeroWidthPos != 7 || ts.zeroWidthCount != 9 {
+		t.Fatalf("zero-width guard mutated to pos=%d count=%d, want 7/9", ts.zeroWidthPos, ts.zeroWidthCount)
+	}
+	if !reflect.DeepEqual(*ts.lexer, beforeLexer) {
+		t.Fatalf("source lexer mutated to %#v, want %#v", *ts.lexer, beforeLexer)
+	}
+}
+
+func TestScanLeafTokenWithoutMutatingIncludedRangeTokenSource(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	parser := NewParser(lang)
+	oldSource := []byte("1+2")
+	newSource := []byte("1+3")
+	tree := mustParse(t, parser, oldSource)
+	tree.Edit(InputEdit{
+		StartByte:   2,
+		OldEndByte:  3,
+		NewEndByte:  3,
+		StartPoint:  Point{Row: 0, Column: 2},
+		OldEndPoint: Point{Row: 0, Column: 3},
+		NewEndPoint: Point{Row: 0, Column: 3},
+	})
+	leaf := tree.lastEditedLeaf
+	if leaf == nil {
+		t.Fatal("expected edited leaf to be tracked")
+	}
+
+	base := newDFATokenSourceDirect(NewLexer(lang.LexStates, newSource), lang, parser.lookupActionIndex, parser.hasKeywordState)
+	wrapped := &includedRangeTokenSource{
+		base: base,
+		ranges: []Range{
+			{StartByte: 0, EndByte: 1},
+			{StartByte: 2, EndByte: 3},
+		},
+	}
+	beforeBaseLexer := *base.lexer
+
+	tok, ok := scanLeafTokenWithoutMutatingSource(wrapped, leaf)
+	if !ok {
+		t.Fatal("scanLeafTokenWithoutMutatingSource returned false for included range token source")
+	}
+	if tok.Symbol != 1 || tok.StartByte != 2 || tok.EndByte != 3 {
+		t.Fatalf("token = %+v, want NUMBER at [2,3)", tok)
+	}
+	if wrapped.idx != 0 {
+		t.Fatalf("included range idx mutated to %d, want 0", wrapped.idx)
+	}
+	if !reflect.DeepEqual(*base.lexer, beforeBaseLexer) {
+		t.Fatalf("base lexer mutated to %#v, want %#v", *base.lexer, beforeBaseLexer)
+	}
+}
+
+func TestScanLeafTokenWithoutMutatingRejectsExternalScanner(t *testing.T) {
+	lang := *buildArithmeticLanguage()
+	lang.ExternalScanner = parserTestUnsafeExternalScanner{}
+	parser := NewParser(&lang)
+	oldSource := []byte("1+2")
+	newSource := []byte("1+3")
+	tree := mustParse(t, parser, oldSource)
+	tree.Edit(InputEdit{
+		StartByte:   2,
+		OldEndByte:  3,
+		NewEndByte:  3,
+		StartPoint:  Point{Row: 0, Column: 2},
+		OldEndPoint: Point{Row: 0, Column: 3},
+		NewEndPoint: Point{Row: 0, Column: 3},
+	})
+	leaf := tree.lastEditedLeaf
+	if leaf == nil {
+		t.Fatal("expected edited leaf to be tracked")
+	}
+
+	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, newSource), &lang, parser.lookupActionIndex, parser.hasKeywordState)
+	if tok, ok := scanLeafTokenWithoutMutatingSource(ts, leaf); ok {
+		t.Fatalf("scanLeafTokenWithoutMutatingSource succeeded for external-scanner language: %+v", tok)
+	}
+}
+
+func TestScanLeafTokenWithoutMutatingRejectsSyntheticExternalSymbols(t *testing.T) {
+	lang := *buildArithmeticLanguage()
+	lang.ExternalSymbols = []Symbol{1}
+	parser := NewParser(&lang)
+	oldSource := []byte("1+2")
+	newSource := []byte("1+3")
+	tree := mustParse(t, parser, oldSource)
+	tree.Edit(InputEdit{
+		StartByte:   2,
+		OldEndByte:  3,
+		NewEndByte:  3,
+		StartPoint:  Point{Row: 0, Column: 2},
+		OldEndPoint: Point{Row: 0, Column: 3},
+		NewEndPoint: Point{Row: 0, Column: 3},
+	})
+	leaf := tree.lastEditedLeaf
+	if leaf == nil {
+		t.Fatal("expected edited leaf to be tracked")
+	}
+
+	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, newSource), &lang, parser.lookupActionIndex, parser.hasKeywordState)
+	if tok, ok := scanLeafTokenWithoutMutatingSource(ts, leaf); ok {
+		t.Fatalf("scanLeafTokenWithoutMutatingSource succeeded for synthetic-external language: %+v", tok)
+	}
+}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -1167,12 +1167,50 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 		return Token{}, false
 	}
 
+	if dfaTok, endPos, endRow, endCol, ok := d.preferDFASemicolonOverJSXText(tok, states); ok {
+		d.lexer.pos = endPos
+		d.lexer.row = endRow
+		d.lexer.col = endCol
+		return dfaTok, true
+	}
+
 	d.trackZeroWidthExternalToken(tok)
 
 	d.lexer.pos = int(tok.EndByte)
 	d.lexer.row = tok.EndPoint.Row
 	d.lexer.col = tok.EndPoint.Column
 	return tok, true
+}
+
+func (d *dfaTokenSource) preferDFASemicolonOverJSXText(tok Token, states []StateID) (Token, int, uint32, uint32, bool) {
+	if d == nil || d.lexer == nil || d.language == nil || d.lookupActionIndex == nil {
+		return Token{}, 0, 0, 0, false
+	}
+	sym := int(tok.Symbol)
+	if sym < 0 || sym >= len(d.language.SymbolNames) || d.language.SymbolNames[sym] != extNameJSXText {
+		return Token{}, 0, 0, 0, false
+	}
+	start := int(tok.StartByte)
+	if start < 0 || start >= len(d.lexer.source) || d.lexer.source[start] != ';' {
+		return Token{}, 0, 0, 0, false
+	}
+
+	for _, st := range states {
+		cand, endPos, endRow, endCol := d.scanPreferredTokenForState(st)
+		candSym := int(cand.Symbol)
+		if int(cand.StartByte) != start || candSym < 0 || candSym >= len(d.language.SymbolNames) {
+			continue
+		}
+		if d.language.SymbolNames[candSym] != ";" {
+			continue
+		}
+		if d.lookupActionIndex(st, cand.Symbol) == 0 {
+			continue
+		}
+		return cand, endPos, endRow, endCol, true
+	}
+
+	return Token{}, 0, 0, 0, false
 }
 
 func (d *dfaTokenSource) shouldDeferFortranExternalEndOfStatementToDFA(valid []bool, states []StateID) bool {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,3 +11,7 @@ point built-in grammar loaders at local grammargen `.bin` overrides.
 `test_race_serial.sh` is a legacy host-side race wrapper. Prefer CI or a
 dedicated container first; if you ever fall back to it, keep it scoped to one
 package and one target at a time.
+
+`prune_harness_artifacts.sh` reports generated harness artifact directories by
+size and removes them only when run with `--delete`. It intentionally excludes
+private notes and defaults to a dry run.

--- a/scripts/prune_harness_artifacts.sh
+++ b/scripts/prune_harness_artifacts.sh
@@ -39,7 +39,8 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$script_dir/.." && pwd))"
 cd "$repo_root"
 
 targets=(

--- a/scripts/prune_harness_artifacts.sh
+++ b/scripts/prune_harness_artifacts.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/prune_harness_artifacts.sh [--delete] [--include-golden]
+
+Lists repo-local generated harness artifacts by size. With --delete, removes
+the listed paths. The default is a dry run.
+
+Options:
+  --delete          Remove matching artifact paths.
+  --include-golden  Also include .golden/ generated golden corpus artifacts.
+  -h, --help        Show this help.
+USAGE
+}
+
+delete=0
+include_golden=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --delete)
+      delete=1
+      ;;
+    --include-golden)
+      include_golden=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+
+targets=(
+  "harness_out"
+  "parity_out"
+  "cgo_harness/parity_out"
+  "cgo_harness/reports"
+  "cgo_harness/corpus_real"
+  "cgo_harness/grammar_seed"
+  ".parity_seed"
+)
+
+if [[ "$include_golden" -eq 1 ]]; then
+  targets+=(".golden")
+fi
+
+found=0
+for target in "${targets[@]}"; do
+  if [[ ! -e "$target" ]]; then
+    continue
+  fi
+  found=1
+  size="$(du -sh -- "$target" | awk '{print $1}')"
+  if [[ "$delete" -eq 1 ]]; then
+    printf 'removing %8s %s\n' "$size" "$target"
+    rm -rf -- "$target"
+  else
+    printf '%8s %s\n' "$size" "$target"
+  fi
+done
+
+if [[ "$found" -eq 0 ]]; then
+  echo "no generated harness artifacts found"
+elif [[ "$delete" -eq 0 ]]; then
+  echo
+  echo "dry run only; rerun with --delete to remove these paths"
+fi


### PR DESCRIPTION
## What does this PR do?

Optimizes the DFA-backed incremental leaf fast path so token-invariant single-byte edits avoid the heavy token-source snapshot path when the language has no external scanner or synthetic external symbols. It also adds a dry-run harness artifact pruning helper and raises the TypeScript/TSX direct C parity ratchets to the current 20/20 result.

## Why this approach?

The hot path only needs to rescan one edited leaf, so for plain DFA token sources it can save and restore the small mutable parser/lexer state around that scan instead of allocating snapshot closures and copied scratch slices. Scanner-backed and external-symbol languages keep the existing conservative snapshot fallback.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
- [x] Affected parity validation ran in Docker, one language or grammar at a time
- [x] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

Validation:

- `go test . -run 'TestSnapshotTokenSourceState|TestScanLeafTokenWithoutMutating|TestParseIncremental$|TestParseIncrementalReuses' -count=1`
- `(cd cgo_harness && go test . -tags treesitter_c_parity -run 'TestMergeGrammargenCGOFloorsPreservesRatchetDirection|TestGrammargenCGORatchetRegressionsIncludesDivergences' -count=1)`
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs typescript --real-max-cases 25 --real-timeout 15m`
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs typescript --cgo-max-cases 20 --cgo-timeout 45`
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs tsx --real-max-cases 25 --real-timeout 15m`
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs tsx --cgo-max-cases 20 --cgo-timeout 45`

Intentionally not run: host-side repo-wide `go test ./...` per AGENTS.md.

## Performance

- [x] If perf-relevant, used the stable bench settings (`GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem`)
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
- [x] If large-grammar behavior changed, checked bounded RSS, timeout, or OOM behavior under Docker

Primary after-run:

- `BenchmarkGoParseFullDFA`: ~1.89-1.98 ms/op, 4280 B/op, 5 allocs/op
- `BenchmarkGoParseIncrementalSingleByteEditDFA`: ~635-658 ns/op, 232 B/op, 5 allocs/op
- `BenchmarkGoParseIncrementalNoEditDFA`: ~2.37-2.44 ns/op, 0 B/op, 0 allocs/op

Earlier baseline for the changed benchmark was ~846-956 ns/op, 896 B/op, 7 allocs/op.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

The key tradeoff is intentionally limiting the zero-allocation path to plain DFA languages. That keeps the scanner/external-token behavior on the existing conservative path.

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars
- [x] If adding a grammar or scanner: verified against upstream C output