### PR TITLE
Add family parse matrix and reduce parser reset churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ go run ./cmd/benchmatrix --count 10
 ```
 
 Emits `bench_out/matrix.json` (machine-readable), `bench_out/matrix.md` (summary), and raw logs under `bench_out/raw/`.
+The default matrix includes a bounded language-family full-parse group, reported with `MB/s` so parser throughput can be compared across generated source sizes. Use `--only-family` to isolate that group, `--family-unit-count` to scale it, or `--no-family` for the narrower Go/editor matrix.
 
 ## Supported languages
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ go get github.com/odvcencio/gotreesitter
 
 gotreesitter loads the same parse-table format that tree-sitter's C runtime uses. Grammar tables are extracted from upstream `parser.c` files by `ts2go`, compressed into binary blobs, and deserialized on first use. 206 grammars ship in the registry.
 
+## Agent Skill
+
+Agents working with gotreesitter should use the [using-gotreesitter](https://github.com/odvcencio/m31labs-skills/blob/main/skills/using-gotreesitter/SKILL.md) skill.
+
 ## Motivation
 
 Every Go tree-sitter binding in the ecosystem depends on CGo:

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ go run ./cmd/benchmatrix --count 10
 ```
 
 Emits `bench_out/matrix.json` (machine-readable), `bench_out/matrix.md` (summary), and raw logs under `bench_out/raw/`.
-The default matrix includes a bounded language-family full-parse group, reported with `MB/s` so parser throughput can be compared across generated source sizes. Use `--only-family` to isolate that group, `--family-unit-count` to scale it, or `--no-family` for the narrower Go/editor matrix.
+The default matrix includes a bounded, warmed language-family full-parse group, reported with `MB/s` so parser throughput can be compared across generated source sizes. Use `--only-family` to isolate that group, `--family-unit-count` to scale it, or `--no-family` for the narrower Go/editor matrix.
 
 ## Supported languages
 

--- a/arena.go
+++ b/arena.go
@@ -300,25 +300,21 @@ func (a *nodeArena) Release() {
 }
 
 func (a *nodeArena) reset() {
-	// Clear the full backing arrays, not just [:used], so Go's GC can collect
-	// Node structs that contain pointer fields (children, parent, etc.).
-	// Partial clear leaves stale *Node pointers in the unused tail which the
-	// GC traces, preventing arena memory from being reclaimed.
-	// clear() is a no-op on nil/empty slices, no guard needed.
-	clear(a.nodes)
+	// Clear only the high-water range that could have been written since the
+	// previous reset. Slots past the high-water mark are either fresh from
+	// make() or were cleared by an earlier reset.
+	primaryUsed := a.used
+	if primaryUsed > len(a.nodes) {
+		primaryUsed = len(a.nodes)
+	}
+	clear(a.nodes[:primaryUsed])
 	a.used = 0
-	// externalScannerCheckpointRef contains only integer fields (no pointers),
-	// so clearing it is not required for GC correctness. We clear it anyway for
-	// consistency and to avoid leaking stale slab+offset values.
-	clear(a.externalScannerNodeCheckpoints)
-	for i := range a.externalScannerNodeCheckpointSlabs {
-		clear(a.externalScannerNodeCheckpointSlabs[i].data)
+	// externalScannerCheckpointRef contains only integer fields, but stale
+	// refs must not remain visible when a node slot is reused.
+	if primaryUsed > len(a.externalScannerNodeCheckpoints) {
+		primaryUsed = len(a.externalScannerNodeCheckpoints)
 	}
-	for i := range a.nodeSlabs {
-		slab := &a.nodeSlabs[i]
-		clear(slab.data)
-		slab.used = 0
-	}
+	clear(a.externalScannerNodeCheckpoints[:primaryUsed])
 	if len(a.nodeSlabs) > 0 {
 		retained := 0
 		keep := 0
@@ -343,6 +339,22 @@ func (a *nodeArena) reset() {
 				a.externalScannerNodeCheckpointSlabs[i] = externalScannerCheckpointSlab{}
 			}
 			a.externalScannerNodeCheckpointSlabs = a.externalScannerNodeCheckpointSlabs[:keep]
+		}
+	}
+	for i := range a.nodeSlabs {
+		slab := &a.nodeSlabs[i]
+		used := slab.used
+		if used > len(slab.data) {
+			used = len(slab.data)
+		}
+		clear(slab.data[:used])
+		slab.used = 0
+		if i < len(a.externalScannerNodeCheckpointSlabs) {
+			cp := a.externalScannerNodeCheckpointSlabs[i].data
+			if used > len(cp) {
+				used = len(cp)
+			}
+			clear(cp[:used])
 		}
 	}
 	a.nodeSlabCursor = 0

--- a/arena_test.go
+++ b/arena_test.go
@@ -254,11 +254,11 @@ func TestEvictionGuardPreventsOversizedArenaReuse(t *testing.T) {
 	}
 }
 
-// TestArenaNodeSlabFullClearOnReset verifies that reset() zeros the full backing
-// array of each node slab, not just [:used]. This is required so that Go's GC
-// can collect Node structs: Node contains pointer fields (children, parent, etc.)
-// and stale pointers in the unused tail of the backing array prevent GC collection.
-func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
+// TestArenaNodeSlabClearsWrittenSlotsOnReset verifies that reset() zeros every
+// node slot written during the parse. Node contains pointer fields (children,
+// parent, ownerArena), and stale pointers in retained arena slabs prevent GC
+// collection.
+func TestArenaNodeSlabClearsWrittenSlotsOnReset(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
 
 	// Fill primary array and spill into at least one overflow slab.
@@ -280,7 +280,7 @@ func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
 	}
 
 	// Capture a raw pointer to the first element of the first overflow slab.
-	// We will check after reset() that the slot is fully zeroed.
+	// We will check after reset() that the written slot is zeroed.
 	firstSlab := &arena.nodeSlabs[0]
 	if firstSlab.used == 0 {
 		t.Fatal("expected overflow slab to have used > 0")
@@ -293,17 +293,12 @@ func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
 	if firstSlab.used != 0 {
 		t.Fatalf("slab.used after reset = %d, want 0", firstSlab.used)
 	}
-	// After reset(), the first element of the slab must be zero.
-	// If only [:used] was cleared, a Node that was at index 0 before reset
-	// would have its parent pointer still set, keeping the Node alive for GC.
-	// Check that the parent pointer field is zeroed. Before the fix,
-	// clear(slab.data[:used]) left stale pointers in the unused tail
-	// after the first reset when primaryCap < len(slab.data).
+	// After reset(), every written slot in the retained slab must be zeroed.
 	got := (*Node)(firstSlabDataPtr)
 	if got.parent != nil {
-		t.Fatalf("slab.data[0].parent after reset is %p, want nil; full clear not applied", got.parent)
+		t.Fatalf("slab.data[0].parent after reset is %p, want nil; written slot not cleared", got.parent)
 	}
 	if got.ownerArena != nil {
-		t.Fatalf("slab.data[0].ownerArena after reset is %p, want nil; full clear not applied", got.ownerArena)
+		t.Fatalf("slab.data[0].ownerArena after reset is %p, want nil; written slot not cleared", got.ownerArena)
 	}
 }

--- a/benchmark_big3_test.go
+++ b/benchmark_big3_test.go
@@ -18,6 +18,7 @@ type dfaBenchmarkSpec struct {
 	marker          string
 	funcCount       int
 	requireNoErrors bool
+	warmupBeforeRun bool
 }
 
 func makeTypeScriptBenchmarkSource(funcCount int) []byte {
@@ -60,6 +61,21 @@ func benchmarkParseFullDFA(b *testing.B, spec dfaBenchmarkSpec) {
 		gotreesitter.ResetPerfCounters()
 		gotreesitter.EnableArenaProfile(true)
 		defer gotreesitter.EnableArenaProfile(false)
+	}
+	if spec.warmupBeforeRun {
+		tree, err := parser.Parse(src)
+		if err != nil {
+			b.Fatalf("warmup parse error: %v", err)
+		}
+		root := requireCompleteParse(b, tree, src, lang, "warmup full dfa")
+		if spec.requireNoErrors && root.HasError() {
+			b.Fatalf("warmup full dfa parse produced errors: root=%q %s", root.Type(lang), tree.ParseRuntime().Summary())
+		}
+		tree.Release()
+		if statsEnabled {
+			gotreesitter.ResetArenaProfile()
+			gotreesitter.ResetPerfCounters()
+		}
 	}
 
 	b.ReportAllocs()

--- a/benchmark_big3_test.go
+++ b/benchmark_big3_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type dfaBenchmarkSpec struct {
-	name   string
-	lang   func() *gotreesitter.Language
-	source func(int) []byte
-	marker string
+	name            string
+	lang            func() *gotreesitter.Language
+	source          func(int) []byte
+	marker          string
+	funcCount       int
+	requireNoErrors bool
 }
 
 func makeTypeScriptBenchmarkSource(funcCount int) []byte {
@@ -47,7 +49,11 @@ func makePythonBenchmarkSource(funcCount int) []byte {
 func benchmarkParseFullDFA(b *testing.B, spec dfaBenchmarkSpec) {
 	lang := spec.lang()
 	parser := gotreesitter.NewParser(lang)
-	src := spec.source(benchmarkFuncCount(b))
+	funcCount := benchmarkFuncCount(b)
+	if spec.funcCount > 0 {
+		funcCount = spec.funcCount
+	}
+	src := spec.source(funcCount)
 	statsEnabled := strings.TrimSpace(os.Getenv("GOT_STATS")) != ""
 	if statsEnabled {
 		gotreesitter.ResetArenaProfile()
@@ -66,7 +72,10 @@ func benchmarkParseFullDFA(b *testing.B, spec dfaBenchmarkSpec) {
 		if err != nil {
 			b.Fatalf("parse error: %v", err)
 		}
-		requireCompleteParse(b, tree, src, lang, "full dfa")
+		root := requireCompleteParse(b, tree, src, lang, "full dfa")
+		if spec.requireNoErrors && root.HasError() {
+			b.Fatalf("full dfa parse produced errors: root=%q %s", root.Type(lang), tree.ParseRuntime().Summary())
+		}
 		lastRuntime = tree.ParseRuntime()
 		tree.Release()
 	}

--- a/benchmark_family_test.go
+++ b/benchmark_family_test.go
@@ -1,0 +1,208 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type familyBenchmarkSpec struct {
+	family   string
+	language string
+	lang     func() *gotreesitter.Language
+	source   func(int) []byte
+}
+
+var familyParseBenchmarkSpecs = []familyBenchmarkSpec{
+	{family: "apple", language: "swift", lang: grammars.SwiftLanguage, source: makeSwiftBenchmarkSource},
+	{family: "c-family", language: "c", lang: grammars.CLanguage, source: makeCBenchmarkSource},
+	{family: "data", language: "json", lang: grammars.JsonLanguage, source: makeJSONBenchmarkSource},
+	{family: "dotnet", language: "csharp", lang: grammars.CSharpLanguage, source: makeCSharpBenchmarkSource},
+	{family: "jvm", language: "java", lang: grammars.JavaLanguage, source: makeJavaBenchmarkSource},
+	{family: "jvm", language: "kotlin", lang: grammars.KotlinLanguage, source: makeKotlinBenchmarkSource},
+	{family: "markup", language: "html", lang: grammars.HtmlLanguage, source: makeHTMLBenchmarkSource},
+	{family: "scientific", language: "fortran", lang: grammars.FortranLanguage, source: makeFortranBenchmarkSource},
+	{family: "scripting", language: "bash", lang: grammars.BashLanguage, source: makeBashBenchmarkSource},
+	{family: "scripting", language: "python", lang: grammars.PythonLanguage, source: makePythonBenchmarkSource},
+	{family: "scripting", language: "ruby", lang: grammars.RubyLanguage, source: makeRubyBenchmarkSource},
+	{family: "styles", language: "css", lang: grammars.CssLanguage, source: makeCSSBenchmarkSource},
+	{family: "systems", language: "go", lang: grammars.GoLanguage, source: makeGoBenchmarkSource},
+	{family: "systems", language: "rust", lang: grammars.RustLanguage, source: makeRustBenchmarkSource},
+	{family: "web", language: "javascript", lang: grammars.JavascriptLanguage, source: makeJavaScriptBenchmarkSource},
+	{family: "web", language: "typescript", lang: grammars.TypescriptLanguage, source: makeTypeScriptBenchmarkSource},
+	{family: "web", language: "tsx", lang: grammars.TsxLanguage, source: makeTSXBenchmarkSource},
+}
+
+func BenchmarkFamilyParseFullDFA(b *testing.B) {
+	unitCount := familyBenchmarkUnitCount(b)
+	for _, spec := range familyParseBenchmarkSpecs {
+		spec := spec
+		b.Run(spec.family+"/"+spec.language, func(b *testing.B) {
+			benchmarkParseFullDFA(b, dfaBenchmarkSpec{
+				name:            spec.language,
+				lang:            spec.lang,
+				source:          spec.source,
+				funcCount:       unitCount,
+				requireNoErrors: true,
+			})
+		})
+	}
+}
+
+func familyBenchmarkUnitCount(b *testing.B) int {
+	if strings.TrimSpace(os.Getenv("GOT_BENCH_FUNC_COUNT")) != "" {
+		return benchmarkFuncCount(b)
+	}
+	if testing.Short() {
+		return 10
+	}
+	return 25
+}
+
+func makeJavaScriptBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 80)
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "export function f%d() { const v = %d; return v }\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeTSXBenchmarkSource(componentCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(componentCount * 150)
+	sb.WriteString("import React from 'react'\n\n")
+	for i := 0; i < componentCount; i++ {
+		fmt.Fprintf(&sb, "export function C%d() { const v = %d; return <section data-id={v}><span>{v}</span></section> }\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeJSONBenchmarkSource(itemCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(itemCount * 96)
+	sb.WriteString("{\"items\":[")
+	for i := 0; i < itemCount; i++ {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		fmt.Fprintf(&sb, "{\"id\":%d,\"name\":\"item-%d\",\"enabled\":%t,\"tags\":[\"alpha\",\"beta\"]}", i, i, i%2 == 0)
+	}
+	sb.WriteString("]}\n")
+	return []byte(sb.String())
+}
+
+func makeCSSBenchmarkSource(ruleCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(ruleCount * 140)
+	for i := 0; i < ruleCount; i++ {
+		fmt.Fprintf(&sb, ".item-%d { color: #%06x; margin: %dpx; padding: 4px; }\n", i, (i*2654435761)&0xffffff, i%24)
+		fmt.Fprintf(&sb, "@media (min-width: 640px) { .item-%d:hover { transform: translateX(%dpx); } }\n", i, i%16)
+	}
+	return []byte(sb.String())
+}
+
+func makeHTMLBenchmarkSource(sectionCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(sectionCount * 140)
+	sb.WriteString("<!doctype html><html><body>\n")
+	for i := 0; i < sectionCount; i++ {
+		fmt.Fprintf(&sb, "<section id=\"item-%d\"><h2>Item %d</h2><p data-id=\"%d\">Hello <span>world</span></p></section>\n", i, i, i)
+	}
+	sb.WriteString("</body></html>\n")
+	return []byte(sb.String())
+}
+
+func makeBashBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 70)
+	sb.WriteString("#!/usr/bin/env bash\nset -euo pipefail\n")
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "f%d() { local v=%d; echo \"$v\"; }\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeCBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 64)
+	sb.WriteString("#include <stdio.h>\n")
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "int f%d(void) { int v = %d; return v; }\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeCSharpBenchmarkSource(classCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(classCount * 115)
+	sb.WriteString("namespace Bench {\n")
+	for i := 0; i < classCount; i++ {
+		fmt.Fprintf(&sb, "public static class C%d { public static int F%d() { var v = %d; return v; } }\n", i, i, i)
+	}
+	sb.WriteString("}\n")
+	return []byte(sb.String())
+}
+
+func makeJavaBenchmarkSource(classCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(classCount * 90)
+	sb.WriteString("package bench;\n")
+	for i := 0; i < classCount; i++ {
+		fmt.Fprintf(&sb, "class C%d { int f%d() { int v = %d; return v; } }\n", i, i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeKotlinBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 55)
+	sb.WriteString("fun main() {\n")
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "    val x%d: Int? = %d\n    println(x%d)\n", i, i, i)
+	}
+	sb.WriteString("}\n")
+	return []byte(sb.String())
+}
+
+func makeSwiftBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 58)
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "func f%d() -> Int {\n    let v = %d\n    return v\n}\n\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeFortranBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 90)
+	sb.WriteString("program bench\ncontains\n")
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "  integer function f%d()\n    integer :: v\n    v = %d\n    f%d = v\n  end function f%d\n", i, i, i, i)
+	}
+	sb.WriteString("end program bench\n")
+	return []byte(sb.String())
+}
+
+func makeRubyBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 35)
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "def f%d\n  v = %d\n  v\nend\n\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makeRustBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 55)
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "pub fn f%d() -> i32 { let v = %d; v }\n", i, i)
+	}
+	return []byte(sb.String())
+}

--- a/benchmark_family_test.go
+++ b/benchmark_family_test.go
@@ -48,6 +48,7 @@ func BenchmarkFamilyParseFullDFA(b *testing.B) {
 				source:          spec.source,
 				funcCount:       unitCount,
 				requireNoErrors: true,
+				warmupBeforeRun: true,
 			})
 		})
 	}

--- a/benchmark_warm_reuse_test.go
+++ b/benchmark_warm_reuse_test.go
@@ -100,13 +100,13 @@ func BenchmarkSelfParseWarmReuse(b *testing.B) {
 }
 
 // TestArenaGCRetentionAfterRelease verifies that arena memory can be collected
-// by the GC after parsing a large file and releasing the tree. With the partial-
-// clear bug (clear(slab.data[:used]) instead of clear(slab.data)), stale *Node
-// pointers in the unused tail of slab backing arrays pin hundreds of megabytes
+// by the GC after parsing a large file and releasing the tree. Reset must clear
+// every written Node slot and release discarded slab headers; stale *Node
+// pointers in retained backing storage can otherwise pin hundreds of megabytes
 // of arena memory across GC cycles.
 //
 // This test is intentionally strict: 30 MB is well above the expected ~12 MB
-// but far below the ~545 MB that a partial-clear implementation retains.
+// but far below the ~545 MB that stale node-pointer retention can cause.
 func TestArenaGCRetentionAfterRelease(t *testing.T) {
 	src, err := os.ReadFile("parser_test.go")
 	if err != nil {
@@ -129,7 +129,7 @@ func TestArenaGCRetentionAfterRelease(t *testing.T) {
 	runtime.ReadMemStats(&ms)
 
 	// 60 MB is well above the expected ~12-20 MB post-fix but far below the
-	// ~545 MB retained by a partial-clear (clear(slab.data[:used])) implementation.
+	// ~545 MB retained by reset implementations that leave stale node pointers.
 	const maxRetainedBytes = 60 * 1024 * 1024
 	if ms.HeapAlloc > maxRetainedBytes {
 		t.Fatalf("HeapAlloc after parse+release+GC = %d MB, want < %d MB\n"+

--- a/cmd/benchmatrix/main.go
+++ b/cmd/benchmatrix/main.go
@@ -57,6 +57,7 @@ type matrixResult struct {
 	Count          int                `json:"count"`
 	Benchtime      string             `json:"benchtime"`
 	GOMAXPROCS     int                `json:"gomaxprocs"`
+	FamilyUnitN    int                `json:"family_unit_count"`
 	StressFuncN    int                `json:"stress_func_count"`
 	Groups         []benchGroupResult `json:"groups"`
 }
@@ -79,8 +80,11 @@ func main() {
 		outPath     string
 		mdPath      string
 		rawDir      string
+		familyUnitN int
 		stressFuncN int
 		noStress    bool
+		noFamily    bool
+		onlyFamily  bool
 		captureRSS  bool
 	)
 
@@ -90,8 +94,11 @@ func main() {
 	flag.StringVar(&outPath, "out", "bench_out/matrix.json", "output JSON path")
 	flag.StringVar(&mdPath, "markdown", "bench_out/matrix.md", "output markdown path")
 	flag.StringVar(&rawDir, "raw-dir", "bench_out/raw", "directory for raw benchmark outputs")
+	flag.IntVar(&familyUnitN, "family-unit-count", 25, "value for GOT_BENCH_FUNC_COUNT in family full-parse matrix")
 	flag.IntVar(&stressFuncN, "stress-func-count", 5000, "value for GOT_BENCH_FUNC_COUNT in stress class")
 	flag.BoolVar(&noStress, "no-stress", false, "skip stress class")
+	flag.BoolVar(&noFamily, "no-family", false, "skip language-family full-parse matrix")
+	flag.BoolVar(&onlyFamily, "only-family", false, "run only the language-family full-parse matrix")
 	flag.BoolVar(&captureRSS, "rss", false, "capture /usr/bin/time -v resource stats per group")
 	flag.Parse()
 
@@ -101,20 +108,39 @@ func main() {
 	if strings.TrimSpace(benchtime) == "" {
 		fatalf("--benchtime must be non-empty")
 	}
-
-	groups := []benchGroupConfig{
-		{
-			Name:    "editor_hot_path",
-			Package: ".",
-			Regex:   "^(BenchmarkGoParseIncrementalSingleByteEdit|BenchmarkGoParseIncrementalRandomSingleByteEdit|BenchmarkGoParseIncrementalNoEdit|BenchmarkHighlightIncremental|BenchmarkTaggerTagIncremental)$",
-		},
-		{
-			Name:    "indexing_path",
-			Package: ".",
-			Regex:   "^(BenchmarkGoParseFull|BenchmarkGoParseFullDFA|BenchmarkQueryExecCompiled|BenchmarkTaggerTag)$",
-		},
+	if familyUnitN <= 0 {
+		fatalf("--family-unit-count must be > 0")
 	}
-	if !noStress {
+	if onlyFamily && noFamily {
+		fatalf("--only-family cannot be combined with --no-family")
+	}
+
+	var groups []benchGroupConfig
+	if !onlyFamily {
+		groups = append(groups,
+			benchGroupConfig{
+				Name:    "editor_hot_path",
+				Package: ".",
+				Regex:   "^(BenchmarkGoParseIncrementalSingleByteEdit|BenchmarkGoParseIncrementalRandomSingleByteEdit|BenchmarkGoParseIncrementalNoEdit|BenchmarkHighlightIncremental|BenchmarkTaggerTagIncremental)$",
+			},
+			benchGroupConfig{
+				Name:    "indexing_path",
+				Package: ".",
+				Regex:   "^(BenchmarkGoParseFull|BenchmarkGoParseFullDFA|BenchmarkQueryExecCompiled|BenchmarkTaggerTag)$",
+			},
+		)
+	}
+	if !noFamily {
+		groups = append(groups, benchGroupConfig{
+			Name:    "family_full_parse",
+			Package: ".",
+			Regex:   "^BenchmarkFamilyParseFullDFA$",
+			ExtraEnv: map[string]string{
+				"GOT_BENCH_FUNC_COUNT": strconv.Itoa(familyUnitN),
+			},
+		})
+	}
+	if !noStress && !onlyFamily {
 		groups = append(groups, benchGroupConfig{
 			Name:    "stress_path",
 			Package: ".",
@@ -150,6 +176,7 @@ func main() {
 		Count:          count,
 		Benchtime:      benchtime,
 		GOMAXPROCS:     gomaxprocs,
+		FamilyUnitN:    familyUnitN,
 		StressFuncN:    stressFuncN,
 		Groups:         results,
 	}
@@ -372,6 +399,7 @@ func writeMarkdown(path string, matrix matrixResult) error {
 	b.WriteString(fmt.Sprintf("- count: `%d`\n", matrix.Count))
 	b.WriteString(fmt.Sprintf("- benchtime: `%s`\n", matrix.Benchtime))
 	b.WriteString(fmt.Sprintf("- gomaxprocs: `%d`\n", matrix.GOMAXPROCS))
+	b.WriteString(fmt.Sprintf("- family unit count: `%d`\n", matrix.FamilyUnitN))
 	b.WriteString(fmt.Sprintf("- stress func count: `%d`\n\n", matrix.StressFuncN))
 
 	for _, group := range matrix.Groups {

--- a/cmd/benchmatrix/main_test.go
+++ b/cmd/benchmatrix/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestParseBenchOutputKeepsFamilySubBenchmarkNames(t *testing.T) {
+	out := []byte(`BenchmarkFamilyParseFullDFA/systems/go-8          1000  12345 ns/op  123.4 MB/s  64 B/op  2 allocs/op
+BenchmarkFamilyParseFullDFA/web/typescript-8       1000  23456 ns/op   98.7 MB/s  96 B/op  3 allocs/op
+`)
+	got, err := parseBenchOutput(out)
+	if err != nil {
+		t.Fatalf("parseBenchOutput failed: %v", err)
+	}
+	for _, name := range []string{
+		"BenchmarkFamilyParseFullDFA/systems/go",
+		"BenchmarkFamilyParseFullDFA/web/typescript",
+	} {
+		if len(got[name]) != 1 {
+			t.Fatalf("expected one sample for %s, got %#v", name, got[name])
+		}
+	}
+	if got["BenchmarkFamilyParseFullDFA/systems/go"][0].MBPerSec != 123.4 {
+		t.Fatalf("unexpected MB/s for systems/go: %#v", got["BenchmarkFamilyParseFullDFA/systems/go"][0])
+	}
+}

--- a/glr.go
+++ b/glr.go
@@ -100,8 +100,8 @@ type glrMergeSlot struct {
 }
 
 type glrNodeEquivCacheEntry struct {
-	a        *Node
-	b        *Node
+	a        uintptr
+	b        uintptr
 	aVersion uint32
 	bVersion uint32
 	epoch    uint32
@@ -391,8 +391,11 @@ func lookupNodeEquivCache(scratch *glrMergeScratch, a, b *Node, depth int) (bool
 		return false, false
 	}
 	depthKey := uint16(depth)
-	if uintptr(unsafe.Pointer(a)) > uintptr(unsafe.Pointer(b)) {
+	ap := uintptr(unsafe.Pointer(a))
+	bp := uintptr(unsafe.Pointer(b))
+	if ap > bp {
 		a, b = b, a
+		ap, bp = bp, ap
 	}
 	idx := nodeEquivCacheIndex(a, b, depth)
 	entry := &scratch.equivCache[idx]
@@ -401,7 +404,7 @@ func lookupNodeEquivCache(scratch *glrMergeScratch, a, b *Node, depth int) (bool
 	if entry.epoch != scratch.equivEpoch {
 		return false, false
 	}
-	if entry.a != a || entry.b != b || entry.depth != depthKey {
+	if entry.a != ap || entry.b != bp || entry.depth != depthKey {
 		return false, false
 	}
 	if entry.aVersion != a.equivVersion || entry.bVersion != b.equivVersion {
@@ -418,13 +421,16 @@ func storeNodeEquivCache(scratch *glrMergeScratch, a, b *Node, depth int, result
 		return
 	}
 	depthKey := uint16(depth)
-	if uintptr(unsafe.Pointer(a)) > uintptr(unsafe.Pointer(b)) {
+	ap := uintptr(unsafe.Pointer(a))
+	bp := uintptr(unsafe.Pointer(b))
+	if ap > bp {
 		a, b = b, a
+		ap, bp = bp, ap
 	}
 	idx := nodeEquivCacheIndex(a, b, depth)
 	scratch.equivCache[idx] = glrNodeEquivCacheEntry{
-		a:        a,
-		b:        b,
+		a:        ap,
+		b:        bp,
 		aVersion: a.equivVersion,
 		bVersion: b.equivVersion,
 		epoch:    scratch.equivEpoch,
@@ -1286,8 +1292,8 @@ func (s *glrMergeScratch) reset() {
 		s.result = nil
 		s.resultBytes = 0
 	} else {
-		if cap(s.result) > 0 {
-			clear(s.result[:cap(s.result)])
+		if len(s.result) > 0 {
+			clear(s.result)
 		}
 		s.result = s.result[:0]
 		s.resultBytes = glrStackBytesForCap(cap(s.result))
@@ -1296,20 +1302,13 @@ func (s *glrMergeScratch) reset() {
 		s.slots = nil
 		s.slotBytes = 0
 	} else {
-		if cap(s.slots) > 0 {
-			clear(s.slots[:cap(s.slots)])
-		}
 		s.slots = s.slots[:0]
 		s.slotBytes = glrMergeSlotBytesForCap(cap(s.slots))
-	}
-	if len(s.equivCache) > 0 {
-		clear(s.equivCache)
 	}
 	s.equivCacheBytes = glrNodeEquivCacheBytesForCap(cap(s.equivCache))
 	s.perKeyCap = 0
 	s.language = nil
 	s.audit = nil
-	s.equivEpoch = 0
 	s.budgetBytes = 0
 }
 
@@ -1436,13 +1435,20 @@ func (s *glrEntryScratch) reset() {
 			retained = next
 		}
 		if keepFrom > 0 {
+			oldLen := len(s.slabs)
 			copy(s.slabs, s.slabs[keepFrom:])
-			s.slabs = s.slabs[:len(s.slabs)-keepFrom]
+			newLen := oldLen - keepFrom
+			for i := newLen; i < oldLen; i++ {
+				s.slabs[i] = stackEntrySlab{}
+			}
+			s.slabs = s.slabs[:newLen]
 		}
-		// Clear the full backing array: stackEntry contains *Node, partial clear
-		// leaves stale GC-visible pointers in the unused tail.
 		for i := range s.slabs {
-			clear(s.slabs[i].data)
+			used := s.slabs[i].used
+			if used > len(s.slabs[i].data) {
+				used = len(s.slabs[i].data)
+			}
+			clear(s.slabs[i].data[:used])
 			s.slabs[i].used = 0
 		}
 		s.slabCursor = 0
@@ -1452,10 +1458,12 @@ func (s *glrEntryScratch) reset() {
 		return
 	}
 
-	// Clear the full backing array: stackEntry contains *Node, partial clear
-	// leaves stale GC-visible pointers in the unused tail.
 	for i := range s.slabs {
-		clear(s.slabs[i].data)
+		used := s.slabs[i].used
+		if used > len(s.slabs[i].data) {
+			used = len(s.slabs[i].data)
+		}
+		clear(s.slabs[i].data[:used])
 		s.slabs[i].used = 0
 	}
 	s.slabCursor = 0

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -330,15 +330,21 @@ func (s *gssScratch) reset() {
 			retained = next
 		}
 		if keepFrom > 0 {
+			oldLen := len(s.slabs)
 			copy(s.slabs, s.slabs[keepFrom:])
-			s.slabs = s.slabs[:len(s.slabs)-keepFrom]
+			newLen := oldLen - keepFrom
+			for i := newLen; i < oldLen; i++ {
+				s.slabs[i] = gssNodeSlab{}
+			}
+			s.slabs = s.slabs[:newLen]
 		}
 	}
-	// Always clear the full backing array, not just [:used]. stackEntry contains
-	// a *Node pointer field; partial clear leaves stale pointers in the unused
-	// tail which the GC traces, preventing arena memory from being collected.
 	for i := range s.slabs {
-		clear(s.slabs[i].data)
+		used := s.slabs[i].used
+		if used > len(s.slabs[i].data) {
+			used = len(s.slabs[i].data)
+		}
+		clear(s.slabs[i].data[:used])
 		s.slabs[i].used = 0
 	}
 	s.slabCursor = 0

--- a/grammars/angular_scanner.go
+++ b/grammars/angular_scanner.go
@@ -56,7 +56,7 @@ func (AngularExternalScanner) Serialize(payload any, buf []byte) int {
 
 func (AngularExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*angularState)
-	s.tags = htmlDeserializeTags(buf)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
 func (AngularExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/grammars/astro_scanner.go
+++ b/grammars/astro_scanner.go
@@ -73,7 +73,7 @@ func (AstroExternalScanner) Serialize(payload any, buf []byte) int {
 
 func (AstroExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*astroState)
-	s.tags = htmlDeserializeTags(buf)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
 func (AstroExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/grammars/blade_scanner.go
+++ b/grammars/blade_scanner.go
@@ -68,7 +68,7 @@ func (BladeExternalScanner) Serialize(payload any, buf []byte) int {
 
 func (BladeExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*bladeState)
-	s.tags = htmlDeserializeTags(buf)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
 func (BladeExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
@@ -184,12 +184,17 @@ func htmlSerializeTags(tags []htmlTag, buf []byte) int {
 }
 
 func htmlDeserializeTags(buf []byte) []htmlTag {
+	return htmlDeserializeTagsInto(nil, buf)
+}
+
+func htmlDeserializeTagsInto(dst []htmlTag, buf []byte) []htmlTag {
 	if len(buf) < 4 {
 		return nil
 	}
 	serializedCount := int(buf[0]) | int(buf[1])<<8
 	size := 4
-	var tags []htmlTag
+	clear(dst)
+	tags := dst[:0]
 	for i := 0; i < serializedCount && size < len(buf); i++ {
 		tagType := htmlTagType(buf[size])
 		size++

--- a/grammars/html_scanner.go
+++ b/grammars/html_scanner.go
@@ -41,7 +41,7 @@ func (HTMLExternalScanner) Serialize(payload any, buf []byte) int {
 
 func (HTMLExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*htmlScannerState)
-	s.tags = htmlDeserializeTags(buf)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
 func (HTMLExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/grammars/html_tags.go
+++ b/grammars/html_tags.go
@@ -207,7 +207,8 @@ func htmlTagForName(name string) htmlTag {
 
 // htmlScanTagName reads a tag name from the lexer, returning it uppercased.
 func htmlScanTagName(lexer htmlLexer) string {
-	var buf []byte
+	var stack [64]byte
+	buf := stack[:0]
 	for {
 		ch := lexer.lookahead()
 		if !htmlIsTagNameChar(ch) {

--- a/grammars/html_tags_test.go
+++ b/grammars/html_tags_test.go
@@ -1,0 +1,32 @@
+//go:build !grammar_subset || grammar_subset_angular || grammar_subset_astro || grammar_subset_blade || grammar_subset_html || grammar_subset_svelte || grammar_subset_vue
+
+package grammars
+
+import "testing"
+
+func TestHTMLDeserializeTagsIntoReusesBackingArray(t *testing.T) {
+	tags := []htmlTag{
+		{tagType: htmlTagDiv},
+		{tagType: htmlTagCustom, customName: "CUSTOM-ELEMENT"},
+	}
+	buf := make([]byte, 64)
+	n := htmlSerializeTags(tags, buf)
+	if n == 0 {
+		t.Fatal("htmlSerializeTags returned empty snapshot")
+	}
+
+	dst := make([]htmlTag, 1, 4)
+	backing := &dst[:cap(dst)][0]
+	got := htmlDeserializeTagsInto(dst, buf[:n])
+	if len(got) != len(tags) {
+		t.Fatalf("htmlDeserializeTagsInto len = %d, want %d", len(got), len(tags))
+	}
+	if &got[:cap(got)][0] != backing {
+		t.Fatal("htmlDeserializeTagsInto did not reuse destination backing array")
+	}
+	for i := range tags {
+		if !htmlTagEq(&got[i], &tags[i]) {
+			t.Fatalf("tag %d = %#v, want %#v", i, got[i], tags[i])
+		}
+	}
+}

--- a/grammars/svelte_scanner.go
+++ b/grammars/svelte_scanner.go
@@ -67,7 +67,7 @@ func (SvelteExternalScanner) Serialize(payload any, buf []byte) int {
 
 func (SvelteExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*svelteState)
-	s.tags = htmlDeserializeTags(buf)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
 func (SvelteExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/grammars/vue_scanner.go
+++ b/grammars/vue_scanner.go
@@ -56,7 +56,7 @@ func (VueExternalScanner) Serialize(payload any, buf []byte) int {
 
 func (VueExternalScanner) Deserialize(payload any, buf []byte) {
 	s := payload.(*vueState)
-	s.tags = htmlDeserializeTags(buf)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
 func (VueExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/language.go
+++ b/language.go
@@ -302,29 +302,7 @@ func (l *Language) LexAsciiTable() [][128]int32 {
 		return nil
 	}
 	l.lexAsciiOnce.Do(func() {
-		states := l.LexStates
-		tbl := make([][128]int32, len(states))
-		for si := range states {
-			for c := 0; c < 128; c++ {
-				tbl[si][c] = lexAsciiNoMatch
-			}
-			// Simulate the linear scan to find first-match for each ASCII char.
-			for c := 0; c < 128; c++ {
-				r := rune(c)
-				for ti := range states[si].Transitions {
-					tr := &states[si].Transitions[ti]
-					if r >= tr.Lo && r <= tr.Hi {
-						v := int32(tr.NextState)
-						if tr.Skip {
-							v |= lexAsciiSkipBit
-						}
-						tbl[si][c] = v
-						break
-					}
-				}
-			}
-		}
-		l.lexAsciiTable = tbl
+		l.lexAsciiTable = buildLexAsciiTable(l.LexStates)
 	})
 	return l.lexAsciiTable
 }
@@ -335,30 +313,48 @@ func (l *Language) KeywordLexAsciiTable() [][128]int32 {
 		return nil
 	}
 	l.keywordLexAsciiOnce.Do(func() {
-		states := l.KeywordLexStates
-		tbl := make([][128]int32, len(states))
-		for si := range states {
-			for c := 0; c < 128; c++ {
-				tbl[si][c] = lexAsciiNoMatch
+		l.keywordLexAsciiTable = buildLexAsciiTable(l.KeywordLexStates)
+	})
+	return l.keywordLexAsciiTable
+}
+
+func buildLexAsciiTable(states []LexState) [][128]int32 {
+	tbl := make([][128]int32, len(states))
+	for si := range states {
+		row := &tbl[si]
+		for c := 0; c < 128; c++ {
+			row[c] = lexAsciiNoMatch
+		}
+		remaining := 128
+		for ti := range states[si].Transitions {
+			if remaining == 0 {
+				break
 			}
-			for c := 0; c < 128; c++ {
-				r := rune(c)
-				for ti := range states[si].Transitions {
-					tr := &states[si].Transitions[ti]
-					if r >= tr.Lo && r <= tr.Hi {
-						v := int32(tr.NextState)
-						if tr.Skip {
-							v |= lexAsciiSkipBit
-						}
-						tbl[si][c] = v
-						break
-					}
+			tr := &states[si].Transitions[ti]
+			if tr.Hi < 0 || tr.Lo >= 128 {
+				continue
+			}
+			lo := tr.Lo
+			if lo < 0 {
+				lo = 0
+			}
+			hi := tr.Hi
+			if hi > 127 {
+				hi = 127
+			}
+			v := int32(tr.NextState)
+			if tr.Skip {
+				v |= lexAsciiSkipBit
+			}
+			for c := int(lo); c <= int(hi); c++ {
+				if row[c] == lexAsciiNoMatch {
+					row[c] = v
+					remaining--
 				}
 			}
 		}
-		l.keywordLexAsciiTable = tbl
-	})
-	return l.keywordLexAsciiTable
+	}
+	return tbl
 }
 
 // Version returns the tree-sitter language ABI version.

--- a/language_test.go
+++ b/language_test.go
@@ -48,6 +48,32 @@ func TestLanguageVersionCompatibility(t *testing.T) {
 	}
 }
 
+func TestLexAsciiTableFillsRangesPreservingFirstMatch(t *testing.T) {
+	lang := &Language{
+		LexStates: []LexState{
+			{
+				Transitions: []LexTransition{
+					{Lo: 'a', Hi: 'z', NextState: 1},
+					{Lo: 'm', Hi: 'm', NextState: 2},
+					{Lo: '0', Hi: '9', NextState: 3, Skip: true},
+					{Lo: 0, Hi: 255, NextState: 4},
+				},
+			},
+		},
+	}
+
+	row := lang.LexAsciiTable()[0]
+	if got, want := row['m'], int32(1); got != want {
+		t.Fatalf("overlapping first match = %d, want %d", got, want)
+	}
+	if got, want := row['0'], int32(3)|lexAsciiSkipBit; got != want {
+		t.Fatalf("skip transition = %d, want %d", got, want)
+	}
+	if got, want := row['A'], int32(4); got != want {
+		t.Fatalf("fallback range match = %d, want %d", got, want)
+	}
+}
+
 // TestMinimalLanguage constructs a minimal 3-symbol, 2-state grammar
 // and verifies that all fields are correctly defined and accessible.
 func TestMinimalLanguage(t *testing.T) {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -498,11 +498,29 @@ func TestEffectiveParseMergePerKeyCap(t *testing.T) {
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "javascript"}, maxStacksPerMergeKey, false); got != 4 {
 		t.Fatalf("effectiveParseMergePerKeyCap(javascript, default, full) = %d, want 4", got)
 	}
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "json"}, maxStacksPerMergeKey, false); got != 1 {
+		t.Fatalf("effectiveParseMergePerKeyCap(json, default, full) = %d, want 1", got)
+	}
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "kotlin"}, maxStacksPerMergeKey, false); got != 1 {
+		t.Fatalf("effectiveParseMergePerKeyCap(kotlin, default, full) = %d, want 1", got)
+	}
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "typescript"}, maxStacksPerMergeKey, false); got != maxStacksPerMergeKey {
 		t.Fatalf("effectiveParseMergePerKeyCap(typescript, default, full) = %d, want %d", got, maxStacksPerMergeKey)
 	}
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "json"}, 1, false); got != 1 {
+		t.Fatalf("effectiveParseMergePerKeyCap(json, 1, full) = %d, want 1", got)
+	}
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "kotlin"}, 1, false); got != 1 {
+		t.Fatalf("effectiveParseMergePerKeyCap(kotlin, 1, full) = %d, want 1", got)
+	}
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "javascript"}, 2, false); got != 2 {
 		t.Fatalf("effectiveParseMergePerKeyCap(javascript, 2, full) = %d, want 2", got)
+	}
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "json"}, maxStacksPerMergeKey, true); got != maxStacksPerMergeKey {
+		t.Fatalf("effectiveParseMergePerKeyCap(json, default, incremental) = %d, want %d", got, maxStacksPerMergeKey)
+	}
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "kotlin"}, maxStacksPerMergeKey, true); got != maxStacksPerMergeKey {
+		t.Fatalf("effectiveParseMergePerKeyCap(kotlin, default, incremental) = %d, want %d", got, maxStacksPerMergeKey)
 	}
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "javascript"}, maxStacksPerMergeKey, true); got != maxStacksPerMergeKey {
 		t.Fatalf("effectiveParseMergePerKeyCap(javascript, default, incremental) = %d, want %d", got, maxStacksPerMergeKey)

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -91,16 +91,37 @@ func initDFATokenSource(ts *dfaTokenSource, lexer *Lexer, language *Language, lo
 
 func acquireDFATokenSource(lexer *Lexer, language *Language, lookupActionIndex func(state StateID, sym Symbol) uint16, hasKeywordState []bool) *dfaTokenSource {
 	ts := dfaTokenSourcePool.Get().(*dfaTokenSource)
+	resetPooledDFATokenSource(ts)
+	initDFATokenSource(ts, lexer, language, lookupActionIndex, hasKeywordState)
+	return ts
+}
+
+func resetPooledDFATokenSource(ts *dfaTokenSource) {
+	if ts == nil {
+		return
+	}
 	// Preserve pooled scratch slices across the struct reset below so they can
 	// be reused without reallocation on the next parse.
-	savedMasked := ts.maskedScratch
+	savedExternalValid := ts.externalValid[:0]
+	savedExternalTokenStart := ts.externalTokenStart[:0]
+	savedExternalTokenEnd := ts.externalTokenEnd[:0]
+	savedExternalSnapshot := ts.externalSnapshot[:0]
+	savedExternalRetrySnap := ts.externalRetrySnap[:0]
+	savedExternalCompare := ts.externalCompare[:0]
+	savedMasked := ts.maskedScratch[:0]
+	savedExtZeroTried := ts.extZeroTried[:0]
 	*ts = dfaTokenSource{
 		extZeroPos:   -1,
 		zeroWidthPos: -1,
 	}
+	ts.externalValid = savedExternalValid
+	ts.externalTokenStart = savedExternalTokenStart
+	ts.externalTokenEnd = savedExternalTokenEnd
+	ts.externalSnapshot = savedExternalSnapshot
+	ts.externalRetrySnap = savedExternalRetrySnap
+	ts.externalCompare = savedExternalCompare
 	ts.maskedScratch = savedMasked
-	initDFATokenSource(ts, lexer, language, lookupActionIndex, hasKeywordState)
-	return ts
+	ts.extZeroTried = savedExtZeroTried
 }
 
 func newDFATokenSourceDirect(lexer *Lexer, language *Language, lookupActionIndex func(state StateID, sym Symbol) uint16, hasKeywordState []bool) *dfaTokenSource {
@@ -1346,25 +1367,11 @@ func (d *dfaTokenSource) nextGLRScoredExternalToken(states []StateID) (Token, bo
 		primaryELS = int(d.language.LexModes[d.state].ExternalLexState)
 	}
 
-	elsOrder := make([]int, 0, len(states))
-	seen := make(map[int]struct{}, len(states))
-	addELS := func(st StateID) {
-		if int(st) >= len(d.language.LexModes) {
-			return
-		}
-		elsID := int(d.language.LexModes[st].ExternalLexState)
-		if elsID < 0 || elsID >= len(d.language.ExternalLexStates) {
-			return
-		}
-		if _, ok := seen[elsID]; ok {
-			return
-		}
-		seen[elsID] = struct{}{}
-		elsOrder = append(elsOrder, elsID)
-	}
-	addELS(d.state)
+	var elsOrderBuf [16]int
+	elsOrder := elsOrderBuf[:0]
+	elsOrder = appendExternalLexStateForState(d.language, elsOrder, d.state)
 	for _, st := range states {
-		addELS(st)
+		elsOrder = appendExternalLexStateForState(d.language, elsOrder, st)
 	}
 	if len(elsOrder) <= 1 {
 		return Token{}, false
@@ -1475,6 +1482,22 @@ func (d *dfaTokenSource) nextGLRScoredExternalToken(states []StateID) (Token, bo
 	d.lexer.row = tok.EndPoint.Row
 	d.lexer.col = tok.EndPoint.Column
 	return tok, true
+}
+
+func appendExternalLexStateForState(lang *Language, order []int, st StateID) []int {
+	if lang == nil || int(st) >= len(lang.LexModes) {
+		return order
+	}
+	elsID := int(lang.LexModes[st].ExternalLexState)
+	if elsID < 0 || elsID >= len(lang.ExternalLexStates) {
+		return order
+	}
+	for _, existing := range order {
+		if existing == elsID {
+			return order
+		}
+	}
+	return append(order, elsID)
 }
 
 func tokenSymbolSpecificity(lang *Language, sym Symbol) int {

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -75,6 +75,35 @@ func TestNextExternalTokenPrefersCandidateUsableByPrimaryState(t *testing.T) {
 	}
 }
 
+func TestAppendExternalLexStateForStateKeepsUniqueValidOrder(t *testing.T) {
+	lang := &Language{
+		ExternalLexStates: [][]bool{
+			{false},
+			{true},
+			{false, true},
+		},
+		LexModes: []LexMode{
+			{ExternalLexState: 1},
+			{ExternalLexState: 2},
+			{ExternalLexState: 1},
+			{ExternalLexState: 99},
+		},
+	}
+
+	var buf [4]int
+	order := buf[:0]
+	for _, st := range []StateID{0, 1, 2, 3, 4} {
+		order = appendExternalLexStateForState(lang, order, st)
+	}
+
+	if got, want := len(order), 2; got != want {
+		t.Fatalf("order len = %d, want %d: %v", got, want, order)
+	}
+	if order[0] != 1 || order[1] != 2 {
+		t.Fatalf("order = %v, want [1 2]", order)
+	}
+}
+
 type byteStateExternalScanner struct{}
 
 func (byteStateExternalScanner) Create() any {
@@ -138,6 +167,65 @@ func TestCaptureExternalScannerStateUsesIndependentReusableBuffers(t *testing.T)
 	ts.restoreExternalScannerState(inner)
 	if got, want := *state, byte(9); got != want {
 		t.Fatalf("restored inner state = %d, want %d", got, want)
+	}
+}
+
+func TestResetPooledDFATokenSourcePreservesScannerScratch(t *testing.T) {
+	lookup := func(StateID, Symbol) uint16 { return 0 }
+	ts := &dfaTokenSource{
+		language:                   &Language{Name: "old"},
+		lookupActionIndex:          lookup,
+		externalValid:              make([]bool, 3, 8),
+		externalTokenStart:         make([]byte, 2, externalScannerSerializationBufferSize),
+		externalTokenEnd:           make([]byte, 3, externalScannerSerializationBufferSize),
+		externalSnapshot:           make([]byte, 4, externalScannerSerializationBufferSize),
+		externalRetrySnap:          make([]byte, 5, externalScannerSerializationBufferSize),
+		externalCompare:            make([]byte, 6, externalScannerSerializationBufferSize),
+		maskedScratch:              make([]bool, 7, 9),
+		extZeroTried:               make([]bool, 4, 10),
+		extZeroPos:                 99,
+		zeroWidthPos:               77,
+		lastExternalTokenValid:     true,
+		lastExternalTokenStartByte: 12,
+		lastExternalTokenEndByte:   34,
+	}
+
+	resetPooledDFATokenSource(ts)
+
+	if ts.language != nil || ts.lookupActionIndex != nil {
+		t.Fatalf("reset retained parser wiring: lang=%v lookupSet=%t", ts.language, ts.lookupActionIndex != nil)
+	}
+	if got, want := cap(ts.externalValid), 8; got != want {
+		t.Fatalf("externalValid cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.externalTokenStart), externalScannerSerializationBufferSize; got != want {
+		t.Fatalf("externalTokenStart cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.externalTokenEnd), externalScannerSerializationBufferSize; got != want {
+		t.Fatalf("externalTokenEnd cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.externalSnapshot), externalScannerSerializationBufferSize; got != want {
+		t.Fatalf("externalSnapshot cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.externalRetrySnap), externalScannerSerializationBufferSize; got != want {
+		t.Fatalf("externalRetrySnap cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.externalCompare), externalScannerSerializationBufferSize; got != want {
+		t.Fatalf("externalCompare cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.maskedScratch), 9; got != want {
+		t.Fatalf("maskedScratch cap = %d, want %d", got, want)
+	}
+	if got, want := cap(ts.extZeroTried), 10; got != want {
+		t.Fatalf("extZeroTried cap = %d, want %d", got, want)
+	}
+	if len(ts.externalValid) != 0 || len(ts.externalTokenStart) != 0 || len(ts.externalTokenEnd) != 0 ||
+		len(ts.externalSnapshot) != 0 || len(ts.externalRetrySnap) != 0 || len(ts.externalCompare) != 0 ||
+		len(ts.maskedScratch) != 0 || len(ts.extZeroTried) != 0 {
+		t.Fatalf("reset should keep scratch capacity with zero length: %+v", ts)
+	}
+	if ts.extZeroPos != -1 || ts.zeroWidthPos != -1 || ts.lastExternalTokenValid {
+		t.Fatalf("reset did not clear scanner state: extZeroPos=%d zeroWidthPos=%d lastValid=%t", ts.extZeroPos, ts.zeroWidthPos, ts.lastExternalTokenValid)
 	}
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -315,6 +315,21 @@ func effectiveParseMergePerKeyCap(lang *Language, mergePerKeyCap int, incrementa
 		return mergePerKeyCap
 	}
 	switch lang.Name {
+	case "json":
+		// JSON recovery has a small conflict surface, but retaining many
+		// alternatives per merge key makes equivalence checks dominate full
+		// parses without changing the accepted tree in parity coverage.
+		if mergePerKeyCap > 1 {
+			return 1
+		}
+	case "kotlin":
+		// Kotlin's statement-recovery conflicts overflow the default per-key
+		// survivor budget frequently on fresh parses. Parity coverage remains
+		// stable with one survivor, while avoiding the redundant alternatives
+		// removes most merge-equivalence churn.
+		if mergePerKeyCap > 1 {
+			return 1
+		}
 	case "javascript":
 		// Plain JS can develop many near-equivalent GLR survivors on large
 		// runtime bundles. Keeping more than four alternatives per merge key

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -1,0 +1,60 @@
+package gotreesitter
+
+import "testing"
+
+func TestGLRMergeScratchResetInvalidatesEquivCacheByEpoch(t *testing.T) {
+	var scratch glrMergeScratch
+	scratch.beginEquivEpoch()
+
+	a := &Node{symbol: 1, startByte: 1, endByte: 2, equivVersion: 1}
+	b := &Node{symbol: 1, startByte: 1, endByte: 2, equivVersion: 1}
+	storeNodeEquivCache(&scratch, a, b, 0, true)
+	if got, ok := lookupNodeEquivCache(&scratch, a, b, 0); !ok || !got {
+		t.Fatalf("lookupNodeEquivCache before reset = %v, %v; want true, true", got, ok)
+	}
+
+	before := scratch.equivEpoch
+	scratch.reset()
+	scratch.beginEquivEpoch()
+	if scratch.equivEpoch == before {
+		t.Fatalf("equiv epoch did not advance after reset: %d", before)
+	}
+	if _, ok := lookupNodeEquivCache(&scratch, a, b, 0); ok {
+		t.Fatal("stale equivalence cache entry remained visible after reset")
+	}
+}
+
+func TestGLREntryScratchResetClearsReservedWrittenRange(t *testing.T) {
+	var scratch glrEntryScratch
+	entries := scratch.allocWithCap(1, 8)
+	node := &Node{symbol: 1}
+	entries = entries[:cap(entries)]
+	entries[len(entries)-1] = stackEntry{state: 7, node: node}
+
+	scratch.reset()
+	if len(scratch.slabs) == 0 {
+		t.Fatal("expected retained entry slab")
+	}
+	for i, entry := range scratch.slabs[0].data[:8] {
+		if entry.node != nil || entry.state != 0 {
+			t.Fatalf("entry slab slot %d after reset = %#v, want zero", i, entry)
+		}
+	}
+}
+
+func TestGSSScratchResetClearsWrittenRange(t *testing.T) {
+	var scratch gssScratch
+	node := &Node{symbol: 1}
+	stack := newGSSStack(1, &scratch)
+	stack.push(2, node, &scratch)
+
+	scratch.reset()
+	if len(scratch.slabs) == 0 {
+		t.Fatal("expected retained GSS slab")
+	}
+	for i, n := range scratch.slabs[0].data[:2] {
+		if n.entry.node != nil || n.prev != nil || n.depth != 0 || n.hash != 0 {
+			t.Fatalf("GSS slab slot %d after reset = %#v, want zero", i, n)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds a bounded `BenchmarkFamilyParseFullDFA` matrix across representative language families and wires it into `cmd/benchmatrix` so full-parse throughput can be compared beyond the Go-only perf trio.

It also lands parser/runtime perf wins found from that matrix:

- Warm family benchmarks and share DFA ASCII table construction.
- Cap redundant JSON/Kotlin full-parse merge survivors where Docker parity shows the accepted tree is unchanged.
- Reduce parser-core reset churn by clearing only written arena/scratch slots, making the GLR equivalence cache pointer-free, and keeping cache invalidation epoch-scoped.
- Preserve pooled DFA token-source scanner scratch buffers between parses and remove per-call map allocation from GLR external lex-state scoring.

The HTML-family scanner helpers now also reuse deserialized tag-stack backing storage and avoid common tag-name scratch allocations.

## Why this approach?

A universal-parser performance claim needs a repeatable family-level view. The matrix uses generated, error-free source fixtures and reports `MB/s` so languages with different fixture sizes can still be compared.

The broad parser-core wins came from profiling the warmed family matrix. Reset work removed `runtime.memclr*` as the dominant cross-family cost. The scanner pass then removed repeated 4 KiB external-scanner snapshot allocations from pooled token sources and replaced a per-token ELS dedupe map with a stack-backed unique list.

The family group is bounded by default and can be isolated with `--only-family`, scaled with `--family-unit-count`, or skipped with `--no-family`.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
- [x] Affected parity validation ran in Docker, one language or grammar at a time
- [ ] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

No grammargen or grammar data changed. Docker cgo parity already ran for representative DFA/table coverage and affected parser-core paths: `go`, `javascript`, `typescript`, `python`, `bash`, `json`, `kotlin`, and `html`.

For the scanner-pooling commit, focused Docker runtime smoke/snapshot coverage passed for `bash`, `python`, `ruby`, `swift`, and `typescript`. Python one-language corpus parity exited cleanly at its current known floor (`24/25` deep parity). Swift one-language corpus parity exited cleanly at its current known floor (`25/25` no-error, `0/25` structural parity due Swift DSL/root/type mismatches). Bash timed out during upstream grammar generation before parser comparison. Ruby hit the container memory ceiling during grammargen generation before parser comparison.

## Performance

- [x] If perf-relevant, used the stable bench settings (`GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem`)
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
- [x] If large-grammar behavior changed, checked bounded RSS, timeout, or OOM behavior under Docker

Primary trio stable smoke ran with the required settings. The family matrix comparison used a bounded local triage setting (`--count 3 --benchtime=200ms --family-unit-count 5`) because the purpose there is cross-family signal, not a merge-blocking perf gate.

Useful bounded family-matrix deltas:

- Core reset optimization: geomean `sec/op` improved about `42%` vs the previous PR state, with B/op and allocs/op unchanged.
- Scanner scratch/order pass on top of reset work: geomean `sec/op` improved another about `23%`, geomean `B/op` dropped about `73%`, and geomean `allocs/op` dropped about `25%` in the count-3 family matrix.
- Bash allocation pressure dropped from about `47.6 KiB/op` and `231 allocs/op` to about `2.8 KiB/op` and `62 allocs/op`.
- Ruby allocation pressure dropped from about `6.5 KiB/op` and `52 allocs/op` to about `1.0 KiB/op` and `24 allocs/op`.
- Swift allocation pressure dropped from about `11.4 KiB/op` and `89 allocs/op` to about `5.6 KiB/op` and `50 allocs/op`.
- JSON full parse moved from about `858us/op` before the cap to about `166us/op` after the cap plus reset/scanner work in the comparable bounded matrix.
- Kotlin allocation pressure dropped from `78 allocs/op` to `11 allocs/op`; after reset/scanner work, bounded timing was about `108us/op`.
- HTML allocation pressure dropped from `743 allocs/op` / about `34 KiB/op` to `285 allocs/op` / about `3 KiB/op`.
- Post-reset profile: `runtime.memclrNoHeapPointers` dropped from about `36%` flat to low single digits. Post-scanner profile no longer shows `captureExternalScannerStateInto` or `nextGLRScoredExternalToken` as alloc-space leaders.

Timing claims remain framed as bounded triage results; CI perf-regression remains the merge gate.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Follow-up TODO

- Root hygiene: remove ignored build/test/profile artifacts from the repo root, route built CLIs into `bin/`, route transient reports/profiles/logs into `tmp/` or `harness_out/`, and add a small guard or cleanup script so loose root artifacts do not come back.
- Tracked struts cleanup: handle `parser_result_*.go` consolidation separately from this perf PR, since moving root package files is an API/package-layout decision rather than simple artifact hygiene.
- Bash remains the largest family-matrix throughput outlier. It currently relies on an intentionally wide full-parse stack/survivor budget for correctness, so any speedup there needs a dedicated Bash parity pass before changing caps.

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

The reset optimization relies on this invariant: reset clears every slot that could have been written since the prior reset; slots beyond that high-water mark are either fresh from `make` or were cleared by an earlier reset. Tests cover arena written-slot clearing, scratch-slab clearing, epoch-based equivalence-cache invalidation, pooled DFA scanner scratch retention, and unique external lex-state ordering.

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars
- [ ] If adding a grammar or scanner: verified against upstream C output

No grammar or scanner was added; existing parser reset paths, merge caps, benchmark harnesses, DFA token-source pooling, and HTML-family scanner helpers changed.

Validation run:

```sh
go test . -run '^TestLexAsciiTableFillsRangesPreservingFirstMatch$' -count=1

go test ./cmd/benchmatrix -run '^TestParseBenchOutputKeepsFamilySubBenchmarkNames$' -count=1

go test . -run '^TestParseMaxMergePerKeyValue$|^TestEffectiveParseMergePerKeyCap$' -count=1

go test ./grammars -run '^TestHTMLDeserializeTagsIntoReusesBackingArray$' -count=1

go test . -run '^TestGLRMergeScratchResetInvalidatesEquivCacheByEpoch$|^TestGLREntryScratchResetClearsReservedWrittenRange$|^TestGSSScratchResetClearsWrittenRange$' -count=1

go test . -run '^TestArenaNodeSlabClearsWrittenSlotsOnReset$|^TestArenaGCRetentionAfterRelease$|^TestExternalScannerCheckpointResetClearsSlot$|^TestChildSlabStalePointersAfterReset$' -count=1

go test . -run '^TestAppendExternalLexStateForStateKeepsUniqueValidOrder$|^TestNextExternalTokenPrefersCandidateUsableByPrimaryState$|^TestResetPooledDFATokenSourcePreservesScannerScratch$|^TestCaptureExternalScannerStateUsesIndependentReusableBuffers$|^TestDFATokenSourceResetClearsScannerAndLexerState$' -count=1

bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test . -run '^TestAppendExternalLexStateForStateKeepsUniqueValidOrder$|^TestNextExternalTokenPrefersCandidateUsableByPrimaryState$|^TestResetPooledDFATokenSourcePreservesScannerScratch$|^TestCaptureExternalScannerStateUsesIndependentReusableBuffers$|^TestDFATokenSourceResetClearsScannerAndLexerState$' -count=1"

bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./grammars -run '^TestCorrectnessSnapshots/(bash|python|ruby|swift|typescript)$|^TestTop50ParseSmokeNoErrors/(bash|python|ruby|swift|typescript)$|^TestRubyScannerMinusSymbolOrderMatchesGrammar$|^TestKotlinSwiftExternalScannerSpecs$' -count=1"

GOT_BENCH_FUNC_COUNT=5 go test . -run '^$' \
  -bench '^BenchmarkFamilyParseFullDFA$' \
  -benchmem -count=1 -benchtime=1x

go run ./cmd/benchmatrix --only-family --count 3 --benchtime=200ms --family-unit-count 5 \
  --out /tmp/gts-family-matrix-count3-scanner-pool-order.json \
  --markdown /tmp/gts-family-matrix-count3-scanner-pool-order.md \
  --raw-dir /tmp/gts-family-raw-count3-scanner-pool-order

benchstat /tmp/gts-family-raw-count3-core-reset/family_full_parse.txt \
  /tmp/gts-family-raw-count3-scanner-pool-order/family_full_parse.txt

GOMAXPROCS=1 go test . -run '^$' \
  -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' \
  -benchmem -count=10 -benchtime=750ms

GOMAXPROCS=1 GOT_BENCH_FUNC_COUNT=5 go test . -run '^$' \
  -bench '^BenchmarkFamilyParseFullDFA$' \
  -benchmem -count=1 -benchtime=1s \
  -cpuprofile=/tmp/gts-family-scanner-pool-order.cpu \
  -memprofile=/tmp/gts-family-scanner-pool-order.mem

bash cgo_harness/docker/run_parity_in_docker.sh --label core-reset-go --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^go$|^TestParityHasNoErrors$/^go$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label core-reset-javascript --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^javascript$|^TestParityHasNoErrors$/^javascript$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label core-reset-typescript --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^typescript$|^TestParityHasNoErrors$/^typescript$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label core-reset-python --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^python$|^TestParityHasNoErrors$/^python$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label core-reset-bash --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^bash$|^TestParityHasNoErrors$/^bash$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label json-merge-cap-baked --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^json$|^TestParityHasNoErrors$/^json$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label kotlin-merge-cap-baked --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^kotlin$|^TestParityHasNoErrors$/^kotlin$' -count=1 -v"

bash cgo_harness/docker/run_parity_in_docker.sh --label html-scanner-state-reuse --memory 4g --cpus 2 --pids 2048 --no-build -- \
  "cd /workspace/cgo_harness && GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^html$|^TestParityHasNoErrors$/^html$' -count=1 -v"

bash cgo_harness/docker/run_single_grammar_parity.sh python
bash cgo_harness/docker/run_single_grammar_parity.sh bash   # generation timeout before parser comparison
bash cgo_harness/docker/run_single_grammar_parity.sh ruby   # grammargen generation OOM before parser comparison
bash cgo_harness/docker/run_single_grammar_parity.sh swift
```
