### PR TITLE
Fix Python and Swift grammargen parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,11 @@ Other focused correctness/parity commands:
 ```sh
 # Top-50 smoke correctness for the grammars package only
 bash cgo_harness/docker/run_parity_in_docker.sh \
-  -- "cd /workspace && go test ./grammars -run '^TestTop50ParseSmokeNoErrors$' -count=1 -v"
+  -- "cd /workspace && go test ./grammars -run '^TestTop50(ParseSmokeNoErrors|CorrectnessListMatchesLockFile)$' -count=1 -v"
+
+# Top-50 grammargen import/parity registry coverage
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  -- "cd /workspace && go test ./grammargen -run '^TestTop50GrammarImportParityCoverage$' -count=1 -v"
 
 # C-oracle parity suites inside the cgo harness
 bash cgo_harness/docker/run_parity_in_docker.sh \

--- a/arena.go
+++ b/arena.go
@@ -300,12 +300,14 @@ func (a *nodeArena) Release() {
 }
 
 func (a *nodeArena) reset() {
-	// Clear the full backing arrays, not just [:used], so Go's GC can collect
-	// Node structs that contain pointer fields (children, parent, etc.).
-	// Partial clear leaves stale *Node pointers in the unused tail which the
-	// GC traces, preventing arena memory from being reclaimed.
-	// clear() is a no-op on nil/empty slices, no guard needed.
-	clear(a.nodes)
+	// Clear slots touched by this parse. Reset establishes the invariant that
+	// every unused slot is already zero, so clearing [:used] is enough to drop
+	// live pointers without bulk-clearing retained capacity on every parse.
+	primaryUsed := a.used
+	if primaryUsed > len(a.nodes) {
+		primaryUsed = len(a.nodes)
+	}
+	clear(a.nodes[:primaryUsed])
 	a.used = 0
 	// externalScannerCheckpointRef contains only integer fields (no pointers),
 	// so clearing it is not required for GC correctness. We clear it anyway for
@@ -316,7 +318,7 @@ func (a *nodeArena) reset() {
 	}
 	for i := range a.nodeSlabs {
 		slab := &a.nodeSlabs[i]
-		clear(slab.data)
+		clear(slab.data[:slab.used])
 		slab.used = 0
 	}
 	if len(a.nodeSlabs) > 0 {
@@ -526,6 +528,14 @@ func (a *nodeArena) ensureNodeCapacity(min int) {
 }
 
 func (a *nodeArena) allocNodeSlice(n int) []*Node {
+	return a.allocNodeSliceInternal(n, true)
+}
+
+func (a *nodeArena) allocNodeSliceNoClear(n int) []*Node {
+	return a.allocNodeSliceInternal(n, false)
+}
+
+func (a *nodeArena) allocNodeSliceInternal(n int, clearOut bool) []*Node {
 	if n <= 0 {
 		return nil
 	}
@@ -559,7 +569,9 @@ func (a *nodeArena) allocNodeSlice(n int) []*Node {
 		// Full-parse arena reset can skip bulk child-slab clearing to avoid
 		// large memclr work on release. Zero the slice on allocation so reused
 		// child slabs never leak stale child pointers into later parses.
-		clear(out)
+		if clearOut {
+			clear(out)
+		}
 		return out
 	}
 }

--- a/arena_test.go
+++ b/arena_test.go
@@ -254,11 +254,10 @@ func TestEvictionGuardPreventsOversizedArenaReuse(t *testing.T) {
 	}
 }
 
-// TestArenaNodeSlabFullClearOnReset verifies that reset() zeros the full backing
-// array of each node slab, not just [:used]. This is required so that Go's GC
-// can collect Node structs: Node contains pointer fields (children, parent, etc.)
-// and stale pointers in the unused tail of the backing array prevent GC collection.
-func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
+// TestArenaNodeSlabClearsTouchedSlotsOnReset verifies that reset() zeros every
+// slot touched by the just-finished parse. The unused tail is kept zero by the
+// reset invariant, so reset does not need to bulk-clear retained capacity.
+func TestArenaNodeSlabClearsTouchedSlotsOnReset(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
 
 	// Fill primary array and spill into at least one overflow slab.
@@ -278,6 +277,8 @@ func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
 	if len(arena.nodeSlabs) == 0 {
 		t.Fatal("expected at least one overflow slab after allocating past primary capacity")
 	}
+	primaryPtr := unsafe.Pointer(&arena.nodes[0])
+	primaryUsedBeforeReset := len(arena.nodes)
 
 	// Capture a raw pointer to the first element of the first overflow slab.
 	// We will check after reset() that the slot is fully zeroed.
@@ -286,6 +287,7 @@ func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
 		t.Fatal("expected overflow slab to have used > 0")
 	}
 	firstSlabDataPtr := unsafe.Pointer(&firstSlab.data[0])
+	slabUsedBeforeReset := firstSlab.used
 
 	arena.reset()
 
@@ -293,17 +295,22 @@ func TestArenaNodeSlabFullClearOnReset(t *testing.T) {
 	if firstSlab.used != 0 {
 		t.Fatalf("slab.used after reset = %d, want 0", firstSlab.used)
 	}
-	// After reset(), the first element of the slab must be zero.
-	// If only [:used] was cleared, a Node that was at index 0 before reset
-	// would have its parent pointer still set, keeping the Node alive for GC.
-	// Check that the parent pointer field is zeroed. Before the fix,
-	// clear(slab.data[:used]) left stale pointers in the unused tail
-	// after the first reset when primaryCap < len(slab.data).
-	got := (*Node)(firstSlabDataPtr)
-	if got.parent != nil {
-		t.Fatalf("slab.data[0].parent after reset is %p, want nil; full clear not applied", got.parent)
+	for i := 0; i < primaryUsedBeforeReset; i++ {
+		got := (*Node)(unsafe.Add(primaryPtr, uintptr(i)*unsafe.Sizeof(Node{})))
+		if got.parent != nil {
+			t.Fatalf("primary node[%d].parent after reset is %p, want nil", i, got.parent)
+		}
+		if got.ownerArena != nil {
+			t.Fatalf("primary node[%d].ownerArena after reset is %p, want nil", i, got.ownerArena)
+		}
 	}
-	if got.ownerArena != nil {
-		t.Fatalf("slab.data[0].ownerArena after reset is %p, want nil; full clear not applied", got.ownerArena)
+	for i := 0; i < slabUsedBeforeReset; i++ {
+		got := (*Node)(unsafe.Add(firstSlabDataPtr, uintptr(i)*unsafe.Sizeof(Node{})))
+		if got.parent != nil {
+			t.Fatalf("slab.data[%d].parent after reset is %p, want nil", i, got.parent)
+		}
+		if got.ownerArena != nil {
+			t.Fatalf("slab.data[%d].ownerArena after reset is %p, want nil", i, got.ownerArena)
+		}
 	}
 }

--- a/cgo_harness/docker/run_single_grammar_parity.sh
+++ b/cgo_harness/docker/run_single_grammar_parity.sh
@@ -382,7 +382,14 @@ make_clone_block() {
     [tsx]="typescript"
   )
 
+  # Map runner names to languages.lock names.
+  declare -A LOCK_NAMES=(
+    [c_lang]="c"
+    [go_lang]="go"
+  )
+
   local repo_name="${REPO_NAMES[$grammar]:-$grammar}"
+  local lock_name="${LOCK_NAMES[$grammar]:-$grammar}"
   local url="${REPO_URLS[$grammar]:-}"
 
   if [[ -z "$url" ]]; then
@@ -391,7 +398,22 @@ make_clone_block() {
   fi
 
   cat <<CLONE_EOF
-if [[ ! -d "/tmp/grammar_parity/$repo_name" ]]; then
+lock_file="/workspace/grammars/languages.lock"
+lock_url=\$(awk -v target="$lock_name" '\$1 == target && \$1 !~ /^#/ { print \$2; exit }' "\$lock_file")
+lock_commit=\$(awk -v target="$lock_name" '\$1 == target && \$1 !~ /^#/ { print \$3; exit }' "\$lock_file")
+if [[ -n "\$lock_url" && -n "\$lock_commit" ]]; then
+  if [[ -d "/tmp/grammar_parity/$repo_name/.git" ]]; then
+    git -C "/tmp/grammar_parity/$repo_name" remote set-url origin "\$lock_url" >/dev/null 2>&1 || true
+  else
+    rm -rf "/tmp/grammar_parity/$repo_name"
+    git clone --depth=1 "\$lock_url" "/tmp/grammar_parity/$repo_name" || echo "WARN: clone failed for $grammar"
+  fi
+  if [[ -d "/tmp/grammar_parity/$repo_name/.git" ]]; then
+    git config --global --add safe.directory "/tmp/grammar_parity/$repo_name" >/dev/null 2>&1 || true
+    git -C "/tmp/grammar_parity/$repo_name" fetch --depth=1 origin "\$lock_commit" >/dev/null 2>&1 || true
+    git -C "/tmp/grammar_parity/$repo_name" checkout --detach "\$lock_commit" >/dev/null 2>&1 || echo "WARN: checkout failed for $grammar @ \$lock_commit"
+  fi
+elif [[ ! -d "/tmp/grammar_parity/$repo_name" ]]; then
   git clone --depth=1 "$url" "/tmp/grammar_parity/$repo_name" || echo "WARN: clone failed for $grammar"
 fi
 CLONE_EOF

--- a/cgo_harness/parity_grammargen_cgo_test.go
+++ b/cgo_harness/parity_grammargen_cgo_test.go
@@ -115,6 +115,7 @@ var grammargenCGOGrammars = []grammargenCGOGrammar{
 	{name: "scala", jsPath: "/tmp/grammar_parity/scala/grammar.js", blobFunc: grammars.ScalaLanguage, genTimeout: 180 * time.Second},
 	{name: "gomod", jsonPath: "/tmp/grammar_parity/gomod/src/grammar.json", blobFunc: grammars.GomodLanguage},
 	{name: "go", jsonPath: "/tmp/grammar_parity/go/src/grammar.json", blobFunc: grammars.GoLanguage, genTimeout: 45 * time.Second},
+	{name: "python", jsonPath: "/tmp/grammar_parity/python/src/grammar.json", blobFunc: grammars.PythonLanguage, genTimeout: 300 * time.Second},
 	{name: "javascript", jsonPath: "/tmp/grammar_parity/javascript/src/grammar.json", blobFunc: grammars.JavascriptLanguage, genTimeout: 90 * time.Second},
 	{name: "typescript", jsonPath: "/tmp/grammar_parity/typescript/typescript/src/grammar.json", blobFunc: grammars.TypescriptLanguage, genTimeout: 180 * time.Second},
 	{name: "tsx", jsonPath: "/tmp/grammar_parity/typescript/tsx/src/grammar.json", blobFunc: grammars.TsxLanguage, genTimeout: 180 * time.Second},
@@ -153,6 +154,7 @@ var grammargenCGOGrammars = []grammargenCGOGrammar{
 	{name: "properties", jsonPath: "/tmp/grammar_parity/properties/src/grammar.json", blobFunc: grammars.PropertiesLanguage},
 	{name: "requirements", jsonPath: "/tmp/grammar_parity/requirements/src/grammar.json", blobFunc: grammars.RequirementsLanguage},
 	{name: "ssh_config", jsonPath: "/tmp/grammar_parity/ssh_config/src/grammar.json", blobFunc: grammars.SshConfigLanguage, genTimeout: 45 * time.Second},
+	{name: "swift", jsonPath: "/tmp/grammar_parity/swift/src/grammar.json", blobFunc: grammars.SwiftLanguage, genTimeout: 120 * time.Second},
 	{name: "corn", jsonPath: "/tmp/grammar_parity/corn/src/grammar.json", blobFunc: grammars.CornLanguage},
 }
 

--- a/cgo_harness/testdata/grammargen_cgo_parity_floors.json
+++ b/cgo_harness/testdata/grammargen_cgo_parity_floors.json
@@ -4,10 +4,10 @@
   "corpus_root": "/tmp/grammar_parity",
   "max_cases": 20,
   "max_bytes": 262144,
-  "grammar_count": 8,
-  "total_eligible": 126,
-  "total_no_error": 124,
-  "total_tree_parity": 120,
+  "grammar_count": 10,
+  "total_eligible": 166,
+  "total_no_error": 163,
+  "total_tree_parity": 159,
   "metrics": {
     "c": {
       "eligible": 20,
@@ -39,11 +39,23 @@
       "tree_parity": 6,
       "divergences": 0
     },
+    "python": {
+      "eligible": 20,
+      "no_error": 20,
+      "tree_parity": 20,
+      "divergences": 0
+    },
     "scala": {
       "eligible": 10,
       "no_error": 8,
       "tree_parity": 6,
       "divergences": 4
+    },
+    "swift": {
+      "eligible": 20,
+      "no_error": 19,
+      "tree_parity": 19,
+      "divergences": 1
     },
     "tsx": {
       "eligible": 20,

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -334,11 +334,11 @@ func (s *gssScratch) reset() {
 			s.slabs = s.slabs[:len(s.slabs)-keepFrom]
 		}
 	}
-	// Always clear the full backing array, not just [:used]. stackEntry contains
-	// a *Node pointer field; partial clear leaves stale pointers in the unused
-	// tail which the GC traces, preventing arena memory from being collected.
+	// Clear slots touched by this parse. Reset establishes the invariant that
+	// every unused slot is already zero, so clearing [:used] drops live node
+	// pointers without bulk-clearing retained capacity on every parse.
 	for i := range s.slabs {
-		clear(s.slabs[i].data)
+		clear(s.slabs[i].data[:s.slabs[i].used])
 		s.slabs[i].used = 0
 	}
 	s.slabCursor = 0

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -155,3 +155,29 @@ func TestGSSStacksEqualWithLazyHashes(t *testing.T) {
 		t.Fatal("expected equality check to populate lazy hashes")
 	}
 }
+
+func TestGSSScratchResetClearsTouchedSlots(t *testing.T) {
+	var scratch gssScratch
+	node := &Node{endByte: 1}
+	var stack gssStack
+	stack.push(1, node, &scratch)
+	stack.push(2, node, &scratch)
+	if len(scratch.slabs) == 0 || scratch.slabs[0].used != 2 {
+		t.Fatalf("expected two used GSS slots, slabs=%d used=%d", len(scratch.slabs), scratch.slabs[0].used)
+	}
+
+	scratch.reset()
+
+	slab := scratch.slabs[0]
+	if slab.used != 0 {
+		t.Fatalf("slab.used after reset = %d, want 0", slab.used)
+	}
+	for i := 0; i < 2; i++ {
+		if slab.data[i].entry.node != nil {
+			t.Fatalf("slab.data[%d].entry.node after reset = %p, want nil", i, slab.data[i].entry.node)
+		}
+		if slab.data[i].prev != nil {
+			t.Fatalf("slab.data[%d].prev after reset = %p, want nil", i, slab.data[i].prev)
+		}
+	}
+}

--- a/grammargen/assemble.go
+++ b/grammargen/assemble.go
@@ -20,13 +20,14 @@ func assemble(
 	symbolCount := len(ng.Symbols)
 
 	lang := &gotreesitter.Language{
-		SymbolCount:        uint32(symbolCount),
-		TokenCount:         uint32(tokenCount),
-		ExternalTokenCount: uint32(len(ng.ExternalSymbols)),
-		StateCount:         uint32(tables.StateCount),
-		InitialState:       1,
-		LexStates:          lexStates,
-		LanguageVersion:    14,
+		SymbolCount:           uint32(symbolCount),
+		TokenCount:            uint32(tokenCount),
+		ExternalTokenCount:    uint32(len(ng.ExternalSymbols)),
+		StateCount:            uint32(tables.StateCount),
+		InitialState:          1,
+		LexStates:             lexStates,
+		LanguageVersion:       14,
+		GeneratedByGrammargen: true,
 	}
 	if len(lexModeOffsets) > 0 {
 		lang.LayoutFallbackLexState = uint16(lexModeOffsets[0])
@@ -707,6 +708,7 @@ func buildExternalLexStates(lang *gotreesitter.Language, tables *LRTables, ng *N
 	rows := [][]bool{make([]bool, extCount)}
 	rowMap := make(map[string]int) // serialized row → row index
 	rowMap[serializeBoolRow(rows[0])] = 0
+	followTokens := buildFollowTokensFunc(tables, tokenCount)
 
 	// For each parser state (after remapping), compute which external tokens
 	// are valid based on the action table.
@@ -726,6 +728,19 @@ func buildExternalLexStates(lang *gotreesitter.Language, tables *LRTables, ng *N
 		// States 1..N map to LR states 0..N-1.
 		lrState := state - 1
 		if lrState >= 0 {
+			if len(ng.ExternalReduceFollowLookaheads) > 0 && followTokens != nil {
+				for _, symID := range followTokens(lrState) {
+					extIdx, isExt := extSymSet[symID]
+					if !isExt || symID < 0 || symID >= len(ng.Symbols) {
+						continue
+					}
+					if !ng.ExternalReduceFollowLookaheads[ng.Symbols[symID].Name] {
+						continue
+					}
+					row[extIdx] = true
+					anyValid = true
+				}
+			}
 			if acts, ok := tables.ActionTable[lrState]; ok {
 				for symID, extIdx := range extSymSet {
 					actionList, ok := acts[symID]
@@ -750,6 +765,12 @@ func buildExternalLexStates(lang *gotreesitter.Language, tables *LRTables, ng *N
 									break
 								}
 							}
+						}
+					}
+					if !suppressed && shouldSuppressEquivalentExternalReduceLookahead(ng, symID, actionList, acts, extSymSet) {
+						if actionsAreReduceOnly(actionList) &&
+							hasEquivalentNonExternalReduceAction(acts, actionList, extSymSet, tokenCount) {
+							suppressed = true
 						}
 					}
 					if !suppressed {
@@ -806,6 +827,91 @@ func actionsAreReduceOnly(acts []lrAction) bool {
 		}
 	}
 	return true
+}
+
+func hasEquivalentNonExternalReduceAction(
+	acts map[int][]lrAction,
+	actionList []lrAction,
+	extSymSet map[int]int,
+	tokenCount int,
+) bool {
+	for sym := 1; sym < tokenCount; sym++ {
+		if _, isExt := extSymSet[sym]; isExt {
+			continue
+		}
+		cpActs, ok := acts[sym]
+		if !ok || len(cpActs) == 0 || !actionsAreReduceOnly(cpActs) {
+			continue
+		}
+		if actListsEqual(actionList, cpActs) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldSuppressEquivalentExternalReduceLookahead(
+	ng *NormalizedGrammar,
+	symID int,
+	actionList []lrAction,
+	acts map[int][]lrAction,
+	extSymSet map[int]int,
+) bool {
+	if ng == nil || !ng.SuppressEquivalentExternalReduceLookaheads ||
+		symID < 0 || symID >= len(ng.Symbols) || !ng.Symbols[symID].Visible {
+		return false
+	}
+	switch ng.Symbols[symID].Name {
+	case "extglob_pattern", "regex", "variable_name":
+		return true
+	case "]":
+		// Bash's scanner uses this delimiter external to decide when a
+		// zero-width _concat is not valid. Dropping it turns a close bracket
+		// into another word-like concatenation segment.
+		return false
+	case "}":
+		// The analogous "}" token has an extra whitespace-sensitive concat rule
+		// in Bash's scanner. Keep it for normal brace contexts and for
+		// simple_expansion reductions that rely on it to avoid string-content
+		// bleed, but suppress duplicate string-reduction exposure when the same
+		// state also exposes "]". Number reductions need the same treatment:
+		// exposing "}" after a numeric command argument makes Bash's scanner
+		// emit whitespace _concat before the next flag.
+		return hasExternalActionNamed(ng, acts, extSymSet, "]") &&
+			(reduceActionListHasLHSName(ng, actionList, "string") ||
+				reduceActionListHasLHSName(ng, actionList, "number"))
+	default:
+		return false
+	}
+}
+
+func reduceActionListHasLHSName(ng *NormalizedGrammar, actions []lrAction, name string) bool {
+	if ng == nil || name == "" {
+		return false
+	}
+	for _, action := range actions {
+		if action.kind != lrReduce || action.prodIdx < 0 || action.prodIdx >= len(ng.Productions) {
+			continue
+		}
+		lhs := ng.Productions[action.prodIdx].LHS
+		if lhs >= 0 && lhs < len(ng.Symbols) && ng.Symbols[lhs].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExternalActionNamed(ng *NormalizedGrammar, acts map[int][]lrAction, extSymSet map[int]int, name string) bool {
+	if ng == nil || len(acts) == 0 || len(extSymSet) == 0 {
+		return false
+	}
+	for symID := range extSymSet {
+		if symID < 0 || symID >= len(ng.Symbols) || ng.Symbols[symID].Name != name {
+			continue
+		}
+		return len(acts[symID]) > 0
+	}
+	return false
 }
 
 // actListsEqual checks if two LR action lists are structurally identical.

--- a/grammargen/comment_parity_test.go
+++ b/grammargen/comment_parity_test.go
@@ -1,0 +1,17 @@
+package grammargen
+
+import "testing"
+
+func TestCommentSimpleTagOrderParity(t *testing.T) {
+	assertImportedDeepParityCases(t, "comment", []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "simple_uppercase_tags",
+			src: "\nTODO: something\n\nXXX: fix something else.\n\nTODO:    extra white spaces.\n\n" +
+				"NOTAG:missing space\n\n(TODO: I'm inside parentheses)\n\nNOTE:\n\n" +
+				"\"NOTE: this should work!\"\n\nDEBUG: this should work with symbols\n",
+		},
+	})
+}

--- a/grammargen/cpon_parity_test.go
+++ b/grammargen/cpon_parity_test.go
@@ -1,0 +1,12 @@
+package grammargen
+
+import "testing"
+
+func TestCponEscapedBlobDeepParity(t *testing.T) {
+	assertImportedDeepParityCases(t, "cpon", []struct {
+		name string
+		src  string
+	}{
+		{name: "escaped_blob_octal_prefix", src: "[\n  b\"ab\\\\\\3123\" // \"ab\\123\"\n  b\"ab1\"\n  b\"ab\\31\"\n  x\"616231\"\n]\n"},
+	})
+}

--- a/grammargen/default_alias_test.go
+++ b/grammargen/default_alias_test.go
@@ -7,9 +7,10 @@ func TestPromoteDefaultAlias(t *testing.T) {
 		Name: "test_default_alias",
 		Rules: map[string]*Rule{
 			"source_file": Seq(Alias(Sym("_doc"), "document", true)),
-			"_doc":        Choice(Str("a"), Str("b")),
+			"_doc":        Sym("doc_item"),
+			"doc_item":    Choice(Str("a"), Str("b")),
 		},
-		RuleOrder: []string{"source_file", "_doc"},
+		RuleOrder: []string{"source_file", "_doc", "doc_item"},
 	}
 
 	ng, err := Normalize(g)
@@ -69,9 +70,10 @@ func TestDefaultAliasRequiresAllUsesAliased(t *testing.T) {
 				Sym("_doc"),
 				Alias(Sym("_doc"), "document", true),
 			),
-			"_doc": Choice(Str("a"), Str("b")),
+			"_doc":     Sym("doc_item"),
+			"doc_item": Choice(Str("a"), Str("b")),
 		},
-		RuleOrder: []string{"source_file", "_doc"},
+		RuleOrder: []string{"source_file", "_doc", "doc_item"},
 	}
 
 	ng, err := Normalize(g)

--- a/grammargen/dfa.go
+++ b/grammargen/dfa.go
@@ -691,17 +691,23 @@ func subsetConstruction(ctx context.Context, n *nfa, _ ...map[int]bool) ([]dfaSt
 		stateSets = append(stateSets, stored)
 
 		// Determine accept symbol (highest priority = lowest priority number).
-		// On tie, prefer the lower symbol ID — this matches tree-sitter C's
-		// implicit ordering where string terminals (keywords) get lower IDs
-		// than pattern terminals (identifiers).
+		// On same-priority ties in the same DFA state, prefer terminal
+		// extraction order. The runtime still performs longest-match across
+		// later DFA states with the same priority, so this only settles true
+		// same-length ambiguities.
 		accept := 0
 		bestPriority := int(^uint(0) >> 1) // max int
+		bestTieOrder := int(^uint(0) >> 1)
 		for _, s := range stored {
 			if n.states[s].accept > 0 {
 				p := n.states[s].priority
 				sym := n.states[s].accept
-				if p < bestPriority || (p == bestPriority && sym < accept) {
+				tieOrder := n.states[s].tieOrder
+				if p < bestPriority ||
+					(p == bestPriority && tieOrder < bestTieOrder) ||
+					(p == bestPriority && tieOrder == bestTieOrder && (accept == 0 || sym < accept)) {
 					bestPriority = p
+					bestTieOrder = tieOrder
 					accept = sym
 				}
 			}

--- a/grammargen/dfa.go
+++ b/grammargen/dfa.go
@@ -481,6 +481,19 @@ func finiteLineBreakStrings(r *Rule) (map[string]bool, bool) {
 		default:
 			return nil, false
 		}
+	case RulePattern:
+		switch r.Value {
+		case "\\n", "\n":
+			return map[string]bool{"\n": true}, true
+		case "\\r", "\r":
+			return map[string]bool{"\r": true}, true
+		case "\\r?\\n":
+			return map[string]bool{"\n": true, "\r\n": true}, true
+		case "\\r\\n":
+			return map[string]bool{"\r\n": true}, true
+		default:
+			return nil, false
+		}
 	case RuleSeq:
 		out := map[string]bool{"": true}
 		for _, child := range r.Children {

--- a/grammargen/dfa_overlap_test.go
+++ b/grammargen/dfa_overlap_test.go
@@ -37,6 +37,62 @@ func TestBuildLexDFAPrefersLongerStringOverSingleCharPattern(t *testing.T) {
 	}
 }
 
+func TestBuildLexDFAPrefersExtractionOrderForSameLengthTie(t *testing.T) {
+	integer, err := expandPatternRule(`\d+`)
+	if err != nil {
+		t.Fatalf("expand integer: %v", err)
+	}
+	unquoted, err := expandPatternRule(`[^\r\n \t]+`)
+	if err != nil {
+		t.Fatalf("expand unquoted: %v", err)
+	}
+	lexStates, modeOffsets, err := buildLexDFA(
+		context.Background(),
+		[]TerminalPattern{
+			{SymbolID: 2, Rule: integer, Priority: 0},
+			{SymbolID: 1, Rule: unquoted, Priority: 0},
+		},
+		nil,
+		nil,
+		[]lexModeSpec{{
+			validSymbols: map[int]bool{1: true, 2: true},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("buildLexDFA: %v", err)
+	}
+	if len(modeOffsets) != 1 {
+		t.Fatalf("len(modeOffsets) = %d, want 1", len(modeOffsets))
+	}
+
+	lexer := gotreesitter.NewLexer(lexStates, []byte("0"))
+	tok := lexer.Next(uint32(modeOffsets[0]))
+	if got, want := tok.Symbol, gotreesitter.Symbol(2); got != want {
+		t.Fatalf("same-length token symbol = %d, want %d", got, want)
+	}
+	if got, want := tok.EndByte, uint32(1); got != want {
+		t.Fatalf("same-length token end = %d, want %d", got, want)
+	}
+
+	lexer = gotreesitter.NewLexer(lexStates, []byte("3rdparty"))
+	tok = lexer.Next(uint32(modeOffsets[0]))
+	if got, want := tok.Symbol, gotreesitter.Symbol(1); got != want {
+		t.Fatalf("longer token symbol = %d, want %d", got, want)
+	}
+	if got, want := tok.EndByte, uint32(8); got != want {
+		t.Fatalf("longer token end = %d, want %d", got, want)
+	}
+}
+
+func TestKeywordLikeInlinePatternClassification(t *testing.T) {
+	if !isKeywordLikeInlinePattern(`[sS][uU][bB][gG][rR][aA][pP][hH]`) {
+		t.Fatalf("case-insensitive keyword pattern should be keyword-like")
+	}
+	if isKeywordLikeInlinePattern(`[^\r\n \t]+`) {
+		t.Fatalf("broad catch-all pattern should not be keyword-like")
+	}
+}
+
 func TestBuildLexDFAPreservesStringOperatorBeforeLineComment(t *testing.T) {
 	lineComment, err := expandPatternRule(`\/\/.*`)
 	if err != nil {

--- a/grammargen/emit_grammar_go.go
+++ b/grammargen/emit_grammar_go.go
@@ -155,6 +155,10 @@ func EmitGrammarGo(g *Grammar, pkgName, funcName string) ([]byte, error) {
 		fmt.Fprintf(&buf, "\tg.PreserveKeywordIdentifierConflicts = true\n\n")
 	}
 
+	if g.ExactPrefixStates != 0 {
+		fmt.Fprintf(&buf, "\tg.ExactPrefixStates = %d\n\n", g.ExactPrefixStates)
+	}
+
 	if g.ChoiceLiftThreshold != 0 {
 		fmt.Fprintf(&buf, "\tg.ChoiceLiftThreshold = %d\n\n", g.ChoiceLiftThreshold)
 	}

--- a/grammargen/emit_grammar_go.go
+++ b/grammargen/emit_grammar_go.go
@@ -163,6 +163,26 @@ func EmitGrammarGo(g *Grammar, pkgName, funcName string) ([]byte, error) {
 		fmt.Fprintf(&buf, "\tg.ChoiceLiftThreshold = %d\n\n", g.ChoiceLiftThreshold)
 	}
 
+	if g.SuppressEquivalentExternalReduceLookaheads {
+		fmt.Fprintf(&buf, "\tg.SuppressEquivalentExternalReduceLookaheads = true\n\n")
+	}
+
+	if len(g.ExternalReduceFollowLookaheads) > 0 {
+		fmt.Fprintf(&buf, "\tg.ExternalReduceFollowLookaheads = []string{\n")
+		for _, name := range g.ExternalReduceFollowLookaheads {
+			fmt.Fprintf(&buf, "\t\t%s,\n", goString(name))
+		}
+		fmt.Fprintf(&buf, "\t}\n\n")
+	}
+
+	if len(g.PriorityInlinePatterns) > 0 {
+		fmt.Fprintf(&buf, "\tg.PriorityInlinePatterns = []string{\n")
+		for _, pattern := range g.PriorityInlinePatterns {
+			fmt.Fprintf(&buf, "\t\t%s,\n", goString(pattern))
+		}
+		fmt.Fprintf(&buf, "\t}\n\n")
+	}
+
 	if len(g.Tests) > 0 {
 		for _, tc := range g.Tests {
 			if tc.ExpectError {

--- a/grammargen/explicit_prec_test.go
+++ b/grammargen/explicit_prec_test.go
@@ -66,6 +66,32 @@ func TestResolveActionConflictExplicitNegativeShiftBeatsImplicitZeroReduce(t *te
 	}
 }
 
+func TestResolveActionConflictJuliaAssignmentOperatorAliasShift(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: "operator", Kind: SymbolTerminal},
+			{Name: "_expression", Kind: SymbolNonterminal},
+			{Name: "assignment", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 1},
+		},
+	}
+
+	actions := []lrAction{
+		{kind: lrReduce, prodIdx: 0, lhsSym: 1},
+		{kind: lrShift, state: 7, prec: -2, hasPrec: true, assoc: AssocRight, lhsSym: 2},
+	}
+
+	got, err := resolveActionConflict(0, actions, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != lrShift {
+		t.Fatalf("resolved actions = %+v, want single shift", got)
+	}
+}
+
 func TestResolveActionConflictExplicitZeroReduceStillBeatsNegativeShift(t *testing.T) {
 	ng := &NormalizedGrammar{
 		Symbols: []SymbolInfo{

--- a/grammargen/explicit_prec_test.go
+++ b/grammargen/explicit_prec_test.go
@@ -40,6 +40,58 @@ func TestFlattenRulePreservesExplicitZeroPrecedenceInsideSeq(t *testing.T) {
 	}
 }
 
+func TestFlattenRuleOuterSequencePrecedenceBeatsInlinedChildPrecedence(t *testing.T) {
+	st := newSymbolTable()
+	lhs := st.addSymbol("binary_expression", SymbolInfo{Name: "binary_expression", Kind: SymbolNonterminal})
+	st.addSymbol("left", SymbolInfo{Name: "left", Kind: SymbolNonterminal})
+	st.addSymbol("+", SymbolInfo{Name: "+", Kind: SymbolTerminal})
+	st.addSymbol("right", SymbolInfo{Name: "right", Kind: SymbolNonterminal})
+
+	prodID := 0
+	prods := flattenRule2(PrecLeft(13, Seq(
+		Prec(1, Sym("left")),
+		Str("+"),
+		Prec(1, Sym("right")),
+	)), lhs, st, &prodID)
+	if len(prods) != 1 {
+		t.Fatalf("flattenRule2 produced %d productions, want 1", len(prods))
+	}
+	if prods[0].Prec != 13 || prods[0].Assoc != AssocLeft || !prods[0].HasExplicitPrec {
+		t.Fatalf("production precedence = %+v, want outer prec.left(13)", prods[0])
+	}
+}
+
+func TestFlattenRuleChoiceAltPrecedenceBeatsInlinedChildPrecedence(t *testing.T) {
+	st := newSymbolTable()
+	lhs := st.addSymbol("expression", SymbolInfo{Name: "expression", Kind: SymbolNonterminal})
+	st.addSymbol("left", SymbolInfo{Name: "left", Kind: SymbolNonterminal})
+	st.addSymbol("+", SymbolInfo{Name: "+", Kind: SymbolTerminal})
+	st.addSymbol("right", SymbolInfo{Name: "right", Kind: SymbolNonterminal})
+	st.addSymbol("number", SymbolInfo{Name: "number", Kind: SymbolTerminal})
+
+	prodID := 0
+	prods := flattenRule2(Choice(
+		PrecLeft(13, Seq(
+			Prec(1, Sym("left")),
+			Str("+"),
+			Prec(1, Sym("right")),
+		)),
+		Str("number"),
+	), lhs, st, &prodID)
+	if len(prods) != 2 {
+		t.Fatalf("flattenRule2 produced %d productions, want 2", len(prods))
+	}
+	for _, prod := range prods {
+		if len(prod.RHS) == 3 {
+			if prod.Prec != 13 || prod.Assoc != AssocLeft || !prod.HasExplicitPrec {
+				t.Fatalf("choice-alt production precedence = %+v, want outer prec.left(13)", prod)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing binary production: %+v", prods)
+}
+
 func TestResolveActionConflictExplicitNegativeShiftBeatsImplicitZeroReduce(t *testing.T) {
 	ng := &NormalizedGrammar{
 		Symbols: []SymbolInfo{

--- a/grammargen/extra_chain_lexmode_test.go
+++ b/grammargen/extra_chain_lexmode_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/odvcencio/gotreesitter"
 )
 
+func singleExtraShiftTarget(t *testing.T, ng *NormalizedGrammar, acts []lrAction) int {
+	t.Helper()
+	if len(acts) != 1 || acts[0].kind != lrShift || !acts[0].isExtra {
+		t.Fatalf("expected single synthetic extra-chain shift, got %s", diagFormatActions(ng, acts))
+	}
+	return acts[0].state
+}
+
 func TestNonterminalExtraChainLexModesDoNotInheritTerminalExtras(t *testing.T) {
 	g := NewGrammar("extra_chain_lexmode")
 	g.Define("source_file", Repeat1(Sym("item")))
@@ -321,6 +329,102 @@ func TestNonterminalExtraChainSyntheticStatesSkipNestedStartsWithoutStarterOverl
 		if act.kind == lrShift && act.isExtra {
 			t.Fatalf("synthetic state %d should not inject nested #region extra starts: %s", outerState, diagFormatActions(ng, tables.ActionTable[outerState][startSyms[0]]))
 		}
+	}
+}
+
+func TestNonterminalExtraChainSyntheticStatesSkipNestedExternalStarts(t *testing.T) {
+	g := NewGrammar("extra_chain_external_no_nested")
+	g.SetExternals(Sym("_external_extra_start"))
+	g.Define("source_file", Repeat1(Sym("item")))
+	g.Define("item", Pat(`[a-z]+`))
+	g.Define("external_extra", Seq(
+		Sym("_external_extra_start"),
+		Token(Pat(`[a-z]+`)),
+	))
+	g.SetExtras(Pat(`\s`), Sym("external_extra"))
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	tables, ctx, err := buildLRTablesWithProvenance(ng)
+	if err != nil {
+		t.Fatalf("build LR tables: %v", err)
+	}
+	addNonterminalExtraChains(tables, ng, ctx)
+
+	if len(ng.ExternalSymbols) != 1 {
+		t.Fatalf("expected one external symbol, got %v", ng.ExternalSymbols)
+	}
+	startSym := ng.ExternalSymbols[0]
+
+	rootActs := tables.ActionTable[0][startSym]
+	if len(rootActs) != 1 || rootActs[0].kind != lrShift || !rootActs[0].isExtra {
+		t.Fatalf("expected synthetic extra-chain shift on external start from state 0, got %s", diagFormatActions(ng, rootActs))
+	}
+	outerState := rootActs[0].state
+	if outerState < tables.ExtraChainStateStart {
+		t.Fatalf("expected synthetic target >= %d, got %d", tables.ExtraChainStateStart, outerState)
+	}
+
+	for _, act := range tables.ActionTable[outerState][startSym] {
+		if act.kind == lrShift && act.isExtra {
+			t.Fatalf("synthetic state %d should not inject nested external extra starts: %s", outerState, diagFormatActions(ng, tables.ActionTable[outerState][startSym]))
+		}
+	}
+}
+
+func TestNonterminalExtraChainExternalStartsShareEntryChain(t *testing.T) {
+	g := NewGrammar("extra_chain_external_shared")
+	g.SetExternals(Sym("_external_extra_start"))
+	g.Define("source_file", Seq(Sym("first"), Sym("second")))
+	g.Define("first", Str("a"))
+	g.Define("second", Str("b"))
+	g.Define("external_extra", Seq(
+		Sym("_external_extra_start"),
+		Token(Pat(`[a-z]+`)),
+	))
+	g.SetExtras(Pat(`\s`), Sym("external_extra"))
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	tables, ctx, err := buildLRTablesWithProvenance(ng)
+	if err != nil {
+		t.Fatalf("build LR tables: %v", err)
+	}
+	addNonterminalExtraChains(tables, ng, ctx)
+
+	if len(ng.ExternalSymbols) != 1 {
+		t.Fatalf("expected one external symbol, got %v", ng.ExternalSymbols)
+	}
+	startSym := ng.ExternalSymbols[0]
+	bSyms := diagFindAllSymbols(ng, "b")
+	if len(bSyms) != 1 {
+		t.Fatalf("expected one b symbol, got %v", bSyms)
+	}
+
+	bState := -1
+	for state := 0; state < tables.ExtraChainStateStart; state++ {
+		for _, act := range tables.ActionTable[state][bSyms[0]] {
+			if act.kind == lrShift && !act.isExtra {
+				bState = state
+				break
+			}
+		}
+		if bState >= 0 {
+			break
+		}
+	}
+	if bState < 0 {
+		t.Fatal("state with structural b shift not found")
+	}
+
+	rootTarget := singleExtraShiftTarget(t, ng, tables.ActionTable[0][startSym])
+	bTarget := singleExtraShiftTarget(t, ng, tables.ActionTable[bState][startSym])
+	if rootTarget != bTarget {
+		t.Fatalf("external-starting extras should share entry chain across main states, got state0=%d state%d=%d", rootTarget, bState, bTarget)
 	}
 }
 

--- a/grammargen/gates/config.json
+++ b/grammargen/gates/config.json
@@ -12,6 +12,7 @@
   "gate0_compiler_health": {
     "description": "The compiler still works: import, generate, emit, no panics/OOM.",
     "tests": [
+      "TestTop50GrammarImportParityCoverage",
       "TestMultiGrammarImportPipeline",
       "TestParityBuiltinNoErrors",
       "TestParityGenerationDeterministic",

--- a/grammargen/gen_test.go
+++ b/grammargen/gen_test.go
@@ -1326,6 +1326,7 @@ func TestRegexParser(t *testing.T) {
 		{`[\pL\p{Mn}\pN_']*`, false},          // haskell: \pL shorthand
 		{`\p{White_Space}|\\\\\\r?\n`, false}, // perl: White_Space property
 		{`[\p{L}\p{M}\p{N}\p{Emoji}]`, false}, // kdl: Emoji property
+		{`[\U00010400-\U00010427]`, false},    // elm: astral Unicode ranges
 	}
 
 	for _, tt := range tests {

--- a/grammargen/gen_test.go
+++ b/grammargen/gen_test.go
@@ -689,6 +689,49 @@ func TestExtNormalize(t *testing.T) {
 	}
 }
 
+func TestNormalizeExternalStartSymbolDoesNotCollideWithAugmentedStart(t *testing.T) {
+	g := NewGrammar("external_start")
+	g.SetExternals(Sym("_start"))
+	g.Define("program", Seq(Sym("_start"), Sym("item")))
+	g.Define("item", Str("x"))
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+	if len(ng.ExternalSymbols) != 1 {
+		t.Fatalf("len(ExternalSymbols) = %d, want 1", len(ng.ExternalSymbols))
+	}
+	externalStart := ng.ExternalSymbols[0]
+	if got := ng.Symbols[externalStart]; got.Name != "_start" || got.Kind != SymbolExternal {
+		t.Fatalf("external start symbol = %+v, want external _start", got)
+	}
+	if got := ng.Symbols[ng.StartSymbol]; got.Name == "_start" {
+		t.Fatalf("augmented start symbol reused external name: %+v", got)
+	}
+
+	programSym := -1
+	for i, sym := range ng.Symbols {
+		if sym.Name == "program" && sym.Kind == SymbolNonterminal {
+			programSym = i
+			break
+		}
+	}
+	if programSym == -1 {
+		t.Fatal("program symbol not found")
+	}
+	for _, prod := range ng.Productions {
+		if prod.LHS != programSym || len(prod.RHS) == 0 {
+			continue
+		}
+		if prod.RHS[0] != externalStart {
+			t.Fatalf("program first RHS symbol = %d (%+v), want external _start %d", prod.RHS[0], ng.Symbols[prod.RHS[0]], externalStart)
+		}
+		return
+	}
+	t.Fatal("program production not found")
+}
+
 func TestNormalizeCanonicalizesConsistentlyAliasedExternalSymbol(t *testing.T) {
 	g := NewGrammar("ext_alias")
 	g.SetExternals(Sym("_layout_start_explicit"))

--- a/grammargen/git_config_parity_test.go
+++ b/grammargen/git_config_parity_test.go
@@ -1,0 +1,15 @@
+package grammargen
+
+import "testing"
+
+func TestGitConfigIntegerValueParity(t *testing.T) {
+	assertImportedDeepParityCases(t, "git_config", []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "repositoryformatversion_integer_zero",
+			src:  "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n",
+		},
+	})
+}

--- a/grammargen/gomod_parity_test.go
+++ b/grammargen/gomod_parity_test.go
@@ -1,0 +1,15 @@
+package grammargen
+
+import "testing"
+
+func TestGomodGroupedRetractIntervalParity(t *testing.T) {
+	assertImportedDeepParityCases(t, "gomod", []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "bracketed_interval_in_group",
+			src:  "retract (\n    v1.0.0\n    [v1.0.0, v1.9.9]\n)\n",
+		},
+	})
+}

--- a/grammargen/grammar.go
+++ b/grammargen/grammar.go
@@ -61,25 +61,28 @@ type ReservedWordSet struct {
 
 // Grammar is the top-level grammar definition.
 type Grammar struct {
-	Name                               string
-	Rules                              map[string]*Rule
-	RuleOrder                          []string // order rules were defined (first = start rule)
-	Extras                             []*Rule
-	Conflicts                          [][]string
-	Externals                          []*Rule
-	Inline                             []string
-	Word                               string
-	ReservedWordSets                   []ReservedWordSet
-	Supertypes                         []string
-	Tests                              []TestCase    // embedded test cases
-	EnableLRSplitting                  bool          // opt-in: attempt LR(1) state splitting for merge pathology
-	BinaryRepeatMode                   bool          // use tree-sitter's binary repeat helper shape (aux→seq(aux,aux)|inner)
-	FlattenGeneratedRepeatAux          bool          // allow generated repeat helpers to participate in hidden-choice flattening
-	ReuseRepeatAuxForParents           []string      // parent rule names whose repeat helpers may be shared by canonical body
-	PreserveKeywordIdentifierConflicts bool          // keep keyword-as-identifier S/R ambiguity for grammars like Fortran
-	ExactPrefixStates                  int           // keep this many LR(1) states exact before merge compaction
-	Precedences                        [][]PrecEntry // ordered precedence levels (each level: earlier = higher prec)
-	ChoiceLiftThreshold                int           // if >0, lift inline CHOICE nodes with more alternatives than this into auxiliary nonterminals to prevent production explosion
+	Name                                       string
+	Rules                                      map[string]*Rule
+	RuleOrder                                  []string // order rules were defined (first = start rule)
+	Extras                                     []*Rule
+	Conflicts                                  [][]string
+	Externals                                  []*Rule
+	Inline                                     []string
+	Word                                       string
+	ReservedWordSets                           []ReservedWordSet
+	Supertypes                                 []string
+	Tests                                      []TestCase    // embedded test cases
+	EnableLRSplitting                          bool          // opt-in: attempt LR(1) state splitting for merge pathology
+	BinaryRepeatMode                           bool          // use tree-sitter's binary repeat helper shape (aux→seq(aux,aux)|inner)
+	FlattenGeneratedRepeatAux                  bool          // allow generated repeat helpers to participate in hidden-choice flattening
+	ReuseRepeatAuxForParents                   []string      // parent rule names whose repeat helpers may be shared by canonical body
+	PreserveKeywordIdentifierConflicts         bool          // keep keyword-as-identifier S/R ambiguity for grammars like Fortran
+	ExactPrefixStates                          int           // keep this many LR(1) states exact before merge compaction
+	Precedences                                [][]PrecEntry // ordered precedence levels (each level: earlier = higher prec)
+	ChoiceLiftThreshold                        int           // if >0, lift inline CHOICE nodes with more alternatives than this into auxiliary nonterminals to prevent production explosion
+	SuppressEquivalentExternalReduceLookaheads bool          // suppress external scanner validity for duplicate reduce-only lookaheads
+	ExternalReduceFollowLookaheads             []string      // external token names that may be valid after reducing in the current state
+	PriorityInlinePatterns                     []string      // anonymous pattern terminals that should win same-length ties against named tokens
 }
 
 // NewGrammar creates a new grammar with the given name.
@@ -330,6 +333,9 @@ func ExtendGrammar(name string, base *Grammar, customize func(g *Grammar)) *Gram
 		ExactPrefixStates:                  base.ExactPrefixStates,
 		Precedences:                        clonePrecedenceLevels(base.Precedences),
 		ChoiceLiftThreshold:                base.ChoiceLiftThreshold,
+		SuppressEquivalentExternalReduceLookaheads: base.SuppressEquivalentExternalReduceLookaheads,
+		ExternalReduceFollowLookaheads:             append([]string(nil), base.ExternalReduceFollowLookaheads...),
+		PriorityInlinePatterns:                     append([]string(nil), base.PriorityInlinePatterns...),
 	}
 
 	// Deep copy rules.

--- a/grammargen/grammar.go
+++ b/grammargen/grammar.go
@@ -77,6 +77,7 @@ type Grammar struct {
 	FlattenGeneratedRepeatAux          bool          // allow generated repeat helpers to participate in hidden-choice flattening
 	ReuseRepeatAuxForParents           []string      // parent rule names whose repeat helpers may be shared by canonical body
 	PreserveKeywordIdentifierConflicts bool          // keep keyword-as-identifier S/R ambiguity for grammars like Fortran
+	ExactPrefixStates                  int           // keep this many LR(1) states exact before merge compaction
 	Precedences                        [][]PrecEntry // ordered precedence levels (each level: earlier = higher prec)
 	ChoiceLiftThreshold                int           // if >0, lift inline CHOICE nodes with more alternatives than this into auxiliary nonterminals to prevent production explosion
 }
@@ -326,6 +327,7 @@ func ExtendGrammar(name string, base *Grammar, customize func(g *Grammar)) *Gram
 		FlattenGeneratedRepeatAux:          base.FlattenGeneratedRepeatAux,
 		ReuseRepeatAuxForParents:           make([]string, len(base.ReuseRepeatAuxForParents)),
 		PreserveKeywordIdentifierConflicts: base.PreserveKeywordIdentifierConflicts,
+		ExactPrefixStates:                  base.ExactPrefixStates,
 		Precedences:                        clonePrecedenceLevels(base.Precedences),
 		ChoiceLiftThreshold:                base.ChoiceLiftThreshold,
 	}

--- a/grammargen/grammar_source_test.go
+++ b/grammargen/grammar_source_test.go
@@ -27,6 +27,7 @@ func TestExtendGrammarCopiesImportMetadata(t *testing.T) {
 	base.FlattenGeneratedRepeatAux = true
 	base.ReuseRepeatAuxForParents = []string{"program", "statement_list"}
 	base.ChoiceLiftThreshold = 16
+	base.ExactPrefixStates = 2048
 	base.Test("identifier", "abc", "")
 
 	extended := ExtendGrammar("extended", base, func(g *Grammar) {
@@ -51,6 +52,9 @@ func TestExtendGrammarCopiesImportMetadata(t *testing.T) {
 	}
 	if extended.ChoiceLiftThreshold != 16 {
 		t.Fatalf("ChoiceLiftThreshold = %d, want 16", extended.ChoiceLiftThreshold)
+	}
+	if extended.ExactPrefixStates != 2048 {
+		t.Fatalf("ExactPrefixStates = %d, want 2048", extended.ExactPrefixStates)
 	}
 	if got := extended.Word; got != "identifier" {
 		t.Fatalf("Word = %q, want identifier", got)
@@ -97,6 +101,7 @@ func TestEmitGrammarGoIncludesImportMetadata(t *testing.T) {
 	g.FlattenGeneratedRepeatAux = true
 	g.ReuseRepeatAuxForParents = []string{"program"}
 	g.ChoiceLiftThreshold = 8
+	g.ExactPrefixStates = 2048
 	g.Test("valid identifier", "abc", "(program (identifier))")
 	g.TestError("invalid identifier", "123")
 
@@ -115,6 +120,7 @@ func TestEmitGrammarGoIncludesImportMetadata(t *testing.T) {
 		"g.ReuseRepeatAuxForParents = []string{",
 		"\"program\"",
 		"g.ChoiceLiftThreshold = 8",
+		"g.ExactPrefixStates = 2048",
 		"g.Test(\"valid identifier\", \"abc\", \"(program (identifier))\")",
 		"g.TestError(\"invalid identifier\", \"123\")",
 	} {

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -31,7 +31,7 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// retract directives. LALR merge compaction otherwise gives the DFA a
 		// state that skips the close delimiter and truncates the parse.
 		g.ExactPrefixStates = 999999
-	case "javascript", "typescript", "tsx", "sql", "d":
+	case "javascript", "typescript", "tsx", "sql", "d", "objc":
 		// These grammars rely heavily on tree-sitter's binary repeat helper
 		// shape. Keeping the upstream lowering avoids large state blowups and
 		// preserves upstream ambiguity handling for imported grammars.

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -25,6 +25,12 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// compaction can deterministically choose the primary-expression path.
 		g.BinaryRepeatMode = true
 		g.ExactPrefixStates = 999999
+	case "gomod":
+		// Go module's bracketed retract intervals need the `retract_spec`
+		// reduce lookahead kept distinct through the closing `)` of grouped
+		// retract directives. LALR merge compaction otherwise gives the DFA a
+		// state that skips the close delimiter and truncates the parse.
+		g.ExactPrefixStates = 999999
 	case "javascript", "typescript", "tsx", "sql":
 		// These grammars rely heavily on tree-sitter's binary repeat helper
 		// shape. Keeping the upstream lowering avoids large state blowups and

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -18,6 +18,13 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// a callable identifier.
 		g.BinaryRepeatMode = true
 		g.PreserveKeywordIdentifierConflicts = true
+	case "python":
+		// Python benefits from tree-sitter's binary repeat helper shape for
+		// broad corpus parity, but its soft `type` alias syntax needs the early
+		// LR(1) conflict context preserved. Otherwise large-grammar merge
+		// compaction can deterministically choose the primary-expression path.
+		g.BinaryRepeatMode = true
+		g.ExactPrefixStates = 999999
 	case "javascript", "typescript", "tsx", "sql":
 		// These grammars rely heavily on tree-sitter's binary repeat helper
 		// shape. Keeping the upstream lowering avoids large state blowups and

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -40,6 +40,11 @@ func applyImportGrammarShapeHints(g *Grammar) {
 			g.FlattenGeneratedRepeatAux = true
 			g.ReuseRepeatAuxForParents = []string{"jsx_opening_element", "jsx_self_closing_element"}
 		}
+	case "powershell":
+		// PowerShell's string/command repeat helpers carry broad content-token
+		// lookaheads. The upstream binary repeat shape keeps those lookaheads
+		// from leaking into plain variable assignment lex modes.
+		g.BinaryRepeatMode = true
 	}
 }
 

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -31,7 +31,7 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// retract directives. LALR merge compaction otherwise gives the DFA a
 		// state that skips the close delimiter and truncates the parse.
 		g.ExactPrefixStates = 999999
-	case "javascript", "typescript", "tsx", "sql", "d", "objc":
+	case "javascript", "typescript", "tsx", "sql", "d", "objc", "perl":
 		// These grammars rely heavily on tree-sitter's binary repeat helper
 		// shape. Keeping the upstream lowering avoids large state blowups and
 		// preserves upstream ambiguity handling for imported grammars.
@@ -45,6 +45,30 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// lookaheads. The upstream binary repeat shape keeps those lookaheads
 		// from leaking into plain variable assignment lex modes.
 		g.BinaryRepeatMode = true
+	}
+}
+
+func applyImportGrammarPostShapeHints(g *Grammar) {
+	if g == nil {
+		return
+	}
+	switch g.Name {
+	case "perl":
+		if _, ok := g.Rules["heredoc_content"]; ok {
+			// Perl models heredoc bodies as grammar extras that start and end in
+			// the external scanner. Importing the full interpolation grammar into
+			// a nonterminal-extra chain makes table generation unbounded for this
+			// shape; keep the scanner-delimited body path and leave richer heredoc
+			// interpolation structure to a scanner-aware follow-up.
+			g.Rules["heredoc_content"] = Seq(
+				Sym("_heredoc_start"),
+				Repeat(Choice(
+					Sym("_heredoc_middle"),
+					Sym("escape_sequence"),
+				)),
+				Sym("heredoc_end"),
+			)
+		}
 	}
 }
 
@@ -154,6 +178,8 @@ func ImportGrammarJSON(data []byte) (*Grammar, error) {
 	if !conv.sawReservedNode {
 		g.ReservedWordSets = nil
 	}
+
+	applyImportGrammarPostShapeHints(g)
 
 	return g, nil
 }

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -31,7 +31,7 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		// retract directives. LALR merge compaction otherwise gives the DFA a
 		// state that skips the close delimiter and truncates the parse.
 		g.ExactPrefixStates = 999999
-	case "javascript", "typescript", "tsx", "sql":
+	case "javascript", "typescript", "tsx", "sql", "d":
 		// These grammars rely heavily on tree-sitter's binary repeat helper
 		// shape. Keeping the upstream lowering avoids large state blowups and
 		// preserves upstream ambiguity handling for imported grammars.

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -11,6 +11,23 @@ func applyImportGrammarShapeHints(g *Grammar) {
 		return
 	}
 	switch g.Name {
+	case "bash":
+		// Bash's external extglob token is intentionally broad. In merged LALR
+		// states, reduce-only lookaheads can otherwise ask the scanner for
+		// extglob_pattern at command-substitution delimiters and overconsume.
+		g.SuppressEquivalentExternalReduceLookaheads = true
+		// Bash's scanner also classifies whitespace-sensitive command
+		// arguments. Some of those tokens only become valid after reducing the
+		// preceding word, so expose this narrow set to the scanner through the
+		// external lex-state rows without broadening extglob_pattern.
+		g.ExternalReduceFollowLookaheads = []string{"file_descriptor", "test_operator", "$", "{", "(", "<<", "<<-"}
+		// Bash's number literals are anonymous regex leaves inside the visible
+		// number rule. They overlap the broad word token on strings like "-9";
+		// tree-sitter's lexer prefers the number pattern on equal length.
+		g.PriorityInlinePatterns = []string{
+			"-?(0x)?[0-9]+(#[0-9A-Za-z@_]+)?",
+			"-?(0x)?[0-9]+#",
+		}
 	case "fortran":
 		// Fortran has no reserved words. Its grammar routes keyword-shaped
 		// tokens back through identifier and declares conflicts to let parser

--- a/grammargen/import_grammarjson_test.go
+++ b/grammargen/import_grammarjson_test.go
@@ -3,7 +3,7 @@ package grammargen
 import "testing"
 
 func TestApplyImportGrammarShapeHintsPowerShellBinaryRepeat(t *testing.T) {
-	for _, name := range []string{"d", "powershell"} {
+	for _, name := range []string{"d", "objc", "powershell"} {
 		t.Run(name, func(t *testing.T) {
 			g := NewGrammar(name)
 			applyImportGrammarShapeHints(g)

--- a/grammargen/import_grammarjson_test.go
+++ b/grammargen/import_grammarjson_test.go
@@ -1,0 +1,11 @@
+package grammargen
+
+import "testing"
+
+func TestApplyImportGrammarShapeHintsPowerShellBinaryRepeat(t *testing.T) {
+	g := NewGrammar("powershell")
+	applyImportGrammarShapeHints(g)
+	if !g.BinaryRepeatMode {
+		t.Fatal("PowerShell import should use binary repeat mode")
+	}
+}

--- a/grammargen/import_grammarjson_test.go
+++ b/grammargen/import_grammarjson_test.go
@@ -3,9 +3,13 @@ package grammargen
 import "testing"
 
 func TestApplyImportGrammarShapeHintsPowerShellBinaryRepeat(t *testing.T) {
-	g := NewGrammar("powershell")
-	applyImportGrammarShapeHints(g)
-	if !g.BinaryRepeatMode {
-		t.Fatal("PowerShell import should use binary repeat mode")
+	for _, name := range []string{"d", "powershell"} {
+		t.Run(name, func(t *testing.T) {
+			g := NewGrammar(name)
+			applyImportGrammarShapeHints(g)
+			if !g.BinaryRepeatMode {
+				t.Fatalf("%s import should use binary repeat mode", name)
+			}
+		})
 	}
 }

--- a/grammargen/import_grammarjson_test.go
+++ b/grammargen/import_grammarjson_test.go
@@ -3,7 +3,7 @@ package grammargen
 import "testing"
 
 func TestApplyImportGrammarShapeHintsPowerShellBinaryRepeat(t *testing.T) {
-	for _, name := range []string{"d", "objc", "powershell"} {
+	for _, name := range []string{"d", "objc", "perl", "powershell"} {
 		t.Run(name, func(t *testing.T) {
 			g := NewGrammar(name)
 			applyImportGrammarShapeHints(g)
@@ -11,5 +11,37 @@ func TestApplyImportGrammarShapeHintsPowerShellBinaryRepeat(t *testing.T) {
 				t.Fatalf("%s import should use binary repeat mode", name)
 			}
 		})
+	}
+}
+
+func TestApplyImportGrammarPostShapeHintsPerlHeredocContent(t *testing.T) {
+	g := NewGrammar("perl")
+	g.Define("heredoc_content", Seq(
+		Sym("_heredoc_start"),
+		Repeat(Choice(
+			Sym("_heredoc_middle"),
+			Sym("escape_sequence"),
+			Sym("_interpolations"),
+			Sym("_interpolation_fallbacks"),
+		)),
+		Sym("heredoc_end"),
+	))
+
+	applyImportGrammarPostShapeHints(g)
+
+	rule := g.Rules["heredoc_content"]
+	if rule == nil || rule.Kind != RuleSeq || len(rule.Children) != 3 {
+		t.Fatalf("heredoc_content rule = %#v, want compact seq", rule)
+	}
+	repeat := rule.Children[1]
+	if repeat == nil || repeat.Kind != RuleRepeat || len(repeat.Children) != 1 {
+		t.Fatalf("middle rule = %#v, want repeat", repeat)
+	}
+	choice := repeat.Children[0]
+	if choice == nil || choice.Kind != RuleChoice || len(choice.Children) != 2 {
+		t.Fatalf("repeat content = %#v, want compact two-way choice", choice)
+	}
+	if got := []string{choice.Children[0].Value, choice.Children[1].Value}; got[0] != "_heredoc_middle" || got[1] != "escape_sequence" {
+		t.Fatalf("compact heredoc alternatives = %v, want [_heredoc_middle escape_sequence]", got)
 	}
 }

--- a/grammargen/ini_parity_test.go
+++ b/grammargen/ini_parity_test.go
@@ -1,0 +1,32 @@
+package grammargen
+
+import "testing"
+
+func TestIniImportedTextTokenAllowsZeroWidth(t *testing.T) {
+	genLang, _ := loadImportedParityLanguages(t, "ini")
+	var textSyms []int
+	var zeroWidthTextSyms []int
+	for i, name := range genLang.SymbolNames {
+		if name == "text" {
+			textSyms = append(textSyms, i)
+			if i < len(genLang.ZeroWidthTokens) && genLang.ZeroWidthTokens[i] {
+				zeroWidthTextSyms = append(zeroWidthTextSyms, i)
+			}
+		}
+	}
+	if len(textSyms) == 0 {
+		t.Fatalf("text symbol not found in imported INI grammar")
+	}
+	if len(zeroWidthTextSyms) == 0 {
+		t.Fatalf("no text symbol is marked zero-width-capable; text symbols=%v", textSyms)
+	}
+}
+
+func TestIniEmptyCommentTextDeepParity(t *testing.T) {
+	assertImportedDeepParityCases(t, "ini", []struct {
+		name string
+		src  string
+	}{
+		{name: "empty_comment_text", src: "#      \n;\n#\n"},
+	})
+}

--- a/grammargen/keyword_choice_token_test.go
+++ b/grammargen/keyword_choice_token_test.go
@@ -1,6 +1,10 @@
 package grammargen
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
 
 func TestNamedStringChoiceTokenBecomesKeyword(t *testing.T) {
 	g := NewGrammar("named_string_choice_keyword")
@@ -55,5 +59,46 @@ func TestNamedStringChoiceTokenBecomesKeyword(t *testing.T) {
 	}
 	if !foundEntry {
 		t.Fatalf("predefined_type sym %d missing from keyword entries", predefinedTypeSym)
+	}
+}
+
+func TestBareLexicalChoiceBecomesNamedToken(t *testing.T) {
+	g := NewGrammar("bare_lexical_choice_named_token")
+	g.Define("source_file", Sym("builtin_type"))
+	g.Define("builtin_type", Choice(
+		Str("bool"),
+		Pat(`(i|u)[1-9][0-9]*`),
+	))
+	g.Define("identifier", Pat(`[A-Za-z_][A-Za-z0-9_]*`))
+	g.SetWord("identifier")
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	builtinTypeSym := -1
+	for i, sym := range ng.Symbols {
+		if sym.Name == "builtin_type" {
+			builtinTypeSym = i
+			if sym.Kind != SymbolNamedToken {
+				t.Fatalf("builtin_type kind = %v, want SymbolNamedToken", sym.Kind)
+			}
+			break
+		}
+	}
+	if builtinTypeSym < 0 {
+		t.Fatal("builtin_type symbol not found")
+	}
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte("i32"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+	if got := tree.RootNode().SExpr(lang); got != "(source_file (builtin_type))" {
+		t.Fatalf("SExpr = %s, want (source_file (builtin_type))", got)
 	}
 }

--- a/grammargen/keyword_choice_token_test.go
+++ b/grammargen/keyword_choice_token_test.go
@@ -141,3 +141,26 @@ func TestAliasedInlinePatternWinsSameLengthNamedPatternTie(t *testing.T) {
 		t.Fatalf("SExpr = %s, want (source_file (preproc_include (system_lib_string)))", got)
 	}
 }
+
+func TestUppercaseUnicodeEscapeIdentifierDoesNotCaptureDigits(t *testing.T) {
+	g := NewGrammar("unicode_escape_identifier_digit_split")
+	g.Define("source_file", Choice(
+		Sym("upper_case_identifier"),
+		Sym("number_literal"),
+	))
+	g.Define("upper_case_identifier", Pat(`[A-Z\U00010400-\U00010427][A-Z0-9]*`))
+	g.Define("number_literal", Pat(`[0-9]+`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte("1"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+	if got := tree.RootNode().SExpr(lang); got != "(source_file (number_literal))" {
+		t.Fatalf("SExpr = %s, want (source_file (number_literal))", got)
+	}
+}

--- a/grammargen/keyword_choice_token_test.go
+++ b/grammargen/keyword_choice_token_test.go
@@ -102,3 +102,42 @@ func TestBareLexicalChoiceBecomesNamedToken(t *testing.T) {
 		t.Fatalf("SExpr = %s, want (source_file (builtin_type))", got)
 	}
 }
+
+func TestAliasedInlinePatternWinsSameLengthNamedPatternTie(t *testing.T) {
+	g := NewGrammar("aliased_inline_pattern_precedence")
+	g.Define("source_file", Choice(
+		Sym("preproc_include"),
+		Sym("preproc_call"),
+	))
+	g.Define("preproc_include", Seq(
+		Alias(Pat(`#[ \t]*include`), "#include", false),
+		Sym("system_lib_string"),
+		ImmToken(Pat(`\r?\n`)),
+	))
+	g.Define("preproc_call", Seq(
+		Field("directive", Sym("preproc_directive")),
+		Optional(Field("argument", Sym("preproc_arg"))),
+		ImmToken(Pat(`\r?\n`)),
+	))
+	g.Define("preproc_directive", Pat(`#[ \t]*[a-zA-Z0-9]\w*`))
+	g.Define("preproc_arg", Token(Pat(`[^\r\n]+`)))
+	g.Define("system_lib_string", Token(Seq(
+		Str("<"),
+		Repeat(Pat(`[^>\n]`)),
+		Str(">"),
+	)))
+	g.Extras = []*Rule{Pat(`[ \t]+`)}
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte("#include <iostream>\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+	if got := tree.RootNode().SExpr(lang); got != "(source_file (preproc_include (system_lib_string)))" {
+		t.Fatalf("SExpr = %s, want (source_file (preproc_include (system_lib_string)))", got)
+	}
+}

--- a/grammargen/lr.go
+++ b/grammargen/lr.go
@@ -2631,15 +2631,14 @@ func (ctx *lrContext) buildItemSets() []lrItemSet {
 		(len(ctx.ng.ExternalSymbols) > 0 && len(ctx.ng.Productions) <= 2000)
 	useBoundaryMerging := len(ctx.ng.ExternalSymbols) > 0 && len(ctx.ng.Productions) > 2000
 	exactPrefixStates := 0
-	if len(ctx.ng.ExternalSymbols) > 0 {
+	if ctx.ng.ExactPrefixStates > 0 {
+		exactPrefixStates = ctx.ng.ExactPrefixStates
+	} else if len(ctx.ng.ExternalSymbols) > 0 {
 		exactPrefixStates = 1024
-		if ctx.ng.ExactPrefixStates > 0 {
-			exactPrefixStates = ctx.ng.ExactPrefixStates
-		}
-		if v := os.Getenv("GOT_LR_EXACT_PREFIX_STATES"); v != "" {
-			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-				exactPrefixStates = n
-			}
+	}
+	if v := os.Getenv("GOT_LR_EXACT_PREFIX_STATES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			exactPrefixStates = n
 		}
 	}
 	preciseStateBudget := 0

--- a/grammargen/lr.go
+++ b/grammargen/lr.go
@@ -873,6 +873,7 @@ type lrContext struct {
 	gotoAdvancedScratch    []coreEntry
 	lr0KernelScratch       []coreItem
 	lr0ClosureScratch      []lr0CoreEntry
+	lr0Dot0ClosureSeeds    [][]int
 	lr0RetainedChunks      [][]lr0CoreEntry
 	lr0RetainedChunkUsed   int
 	lr0SymbolBucketIdx     []int
@@ -1018,6 +1019,7 @@ func (ctx *lrContext) releaseScratch() {
 	ctx.gotoAdvancedScratch = nil
 	ctx.lr0KernelScratch = nil
 	ctx.lr0ClosureScratch = nil
+	ctx.lr0Dot0ClosureSeeds = nil
 	ctx.lr0RetainedChunks = nil
 	ctx.lr0RetainedChunkUsed = 0
 	ctx.lr0SymbolBucketIdx = nil
@@ -3054,6 +3056,15 @@ func resolveActionConflict(lookaheadSym int, actions []lrAction, ng *NormalizedG
 		if shouldPreferAssignmentExpressionShift(lookaheadSym, shifts, reduces, ng) {
 			return []lrAction{shift}, nil
 		}
+		if preferred, ok := preferredArithmeticExpressionContinuation(lookaheadSym, shifts, reduces, ng); ok {
+			return []lrAction{preferred}, nil
+		}
+		if preferred, ok := preferredArithmeticWrapperShift(lookaheadSym, shifts, reduces, ng); ok {
+			return []lrAction{preferred}, nil
+		}
+		if preferred, ok := preferredArithmeticDelimiterShift(lookaheadSym, shifts, reduces, ng); ok {
+			return []lrAction{preferred}, nil
+		}
 		if preferred, ok := preferredKeywordContinuationShift(lookaheadSym, shifts, reduces, ng); ok {
 			return []lrAction{preferred}, nil
 		}
@@ -3310,6 +3321,154 @@ func shouldPreferAssignmentExpressionShift(lookaheadSym int, shifts, reduces []l
 	return true
 }
 
+func preferredArithmeticWrapperShift(lookaheadSym int, shifts, reduces []lrAction, ng *NormalizedGrammar) (lrAction, bool) {
+	if ng == nil || len(shifts) != 1 || len(reduces) == 0 ||
+		lookaheadSym < 0 || lookaheadSym >= len(ng.Symbols) {
+		return lrAction{}, false
+	}
+	if !isArithmeticOperatorLookaheadName(ng.Symbols[lookaheadSym].Name) {
+		return lrAction{}, false
+	}
+	shift := shifts[0]
+	if shift.lhsSym < 0 || shift.lhsSym >= len(ng.Symbols) ||
+		ng.Symbols[shift.lhsSym].Name != "binary_expression" {
+		return lrAction{}, false
+	}
+	for _, reduce := range reduces {
+		if reduce.kind != lrReduce || reduce.prodIdx < 0 || reduce.prodIdx >= len(ng.Productions) {
+			return lrAction{}, false
+		}
+		prod := &ng.Productions[reduce.prodIdx]
+		if len(prod.RHS) != 1 || prod.LHS < 0 || prod.LHS >= len(ng.Symbols) {
+			return lrAction{}, false
+		}
+		lhsName := ng.Symbols[prod.LHS].Name
+		if lhsName != "_arithmetic_expression" && lhsName != "_arithmetic_literal" {
+			return lrAction{}, false
+		}
+	}
+	return shift, true
+}
+
+func preferredArithmeticExpressionContinuation(lookaheadSym int, shifts, reduces []lrAction, ng *NormalizedGrammar) (lrAction, bool) {
+	if ng == nil || len(shifts) != 1 || len(reduces) == 0 ||
+		lookaheadSym < 0 || lookaheadSym >= len(ng.Symbols) {
+		return lrAction{}, false
+	}
+	if !isArithmeticOperatorLookaheadName(ng.Symbols[lookaheadSym].Name) {
+		return lrAction{}, false
+	}
+	var expressionReduces []lrAction
+	for _, reduce := range reduces {
+		if reduce.kind != lrReduce || reduce.prodIdx < 0 || reduce.prodIdx >= len(ng.Productions) {
+			return lrAction{}, false
+		}
+		prod := &ng.Productions[reduce.prodIdx]
+		if prod.LHS < 0 || prod.LHS >= len(ng.Symbols) {
+			return lrAction{}, false
+		}
+		lhsName := ng.Symbols[prod.LHS].Name
+		switch lhsName {
+		case "_arithmetic_expression", "_arithmetic_literal":
+			continue
+		case "binary_expression", "unary_expression", "ternary_expression", "postfix_expression", "parenthesized_expression":
+			expressionReduces = append(expressionReduces, reduce)
+		default:
+			return lrAction{}, false
+		}
+	}
+	if len(expressionReduces) == 0 {
+		return lrAction{}, false
+	}
+	best := rrPickBest(expressionReduces, ng)[0]
+	bestProd := &ng.Productions[best.prodIdx]
+	shift := shifts[0]
+	if bestProd.Prec > shift.prec {
+		return best, true
+	}
+	if shift.prec > bestProd.Prec {
+		return shift, true
+	}
+	switch bestProd.Assoc {
+	case AssocLeft:
+		return best, true
+	case AssocRight:
+		return shift, true
+	default:
+		return lrAction{}, false
+	}
+}
+
+func isArithmeticOperatorLookaheadName(name string) bool {
+	switch name {
+	case "++", "--",
+		"+=", "-=", "*=", "/=", "%=", "**=", "<<=", ">>=", "&=", "^=", "|=",
+		"=", "=~",
+		"||", "&&", "|", "^", "&",
+		"==", "!=", "<", ">", "<=", ">=",
+		"<<", ">>", "+", "-", "*", "/", "%", "**":
+		return true
+	default:
+		return false
+	}
+}
+
+func preferredArithmeticDelimiterShift(lookaheadSym int, shifts, reduces []lrAction, ng *NormalizedGrammar) (lrAction, bool) {
+	if ng == nil || len(shifts) != 1 || len(reduces) == 0 ||
+		lookaheadSym < 0 || lookaheadSym >= len(ng.Symbols) {
+		return lrAction{}, false
+	}
+	lookaheadName := ng.Symbols[lookaheadSym].Name
+	if !isArithmeticDelimiterLookaheadName(lookaheadName) {
+		return lrAction{}, false
+	}
+	shift := shifts[0]
+	if shift.lhsSym < 0 || shift.lhsSym >= len(ng.Symbols) {
+		return lrAction{}, false
+	}
+	shiftLHSName := ng.Symbols[shift.lhsSym].Name
+	if !isArithmeticDelimiterShiftLHS(shiftLHSName, lookaheadName) {
+		return lrAction{}, false
+	}
+	for _, reduce := range reduces {
+		if reduce.kind != lrReduce || reduce.prodIdx < 0 || reduce.prodIdx >= len(ng.Productions) {
+			return lrAction{}, false
+		}
+		prod := &ng.Productions[reduce.prodIdx]
+		if len(prod.RHS) != 1 || prod.LHS < 0 || prod.LHS >= len(ng.Symbols) {
+			return lrAction{}, false
+		}
+		lhsName := ng.Symbols[prod.LHS].Name
+		if lhsName != "_arithmetic_expression" && lhsName != "_arithmetic_literal" {
+			return lrAction{}, false
+		}
+		if prod.Assoc != AssocNone || prod.Prec != shift.prec {
+			return lrAction{}, false
+		}
+	}
+	return shift, true
+}
+
+func isArithmeticDelimiterLookaheadName(name string) bool {
+	switch name {
+	case "))", "]", ",", ")":
+		return true
+	default:
+		return false
+	}
+}
+
+func isArithmeticDelimiterShiftLHS(lhsName, lookaheadName string) bool {
+	switch lookaheadName {
+	case "))", "]", ",":
+		return lhsName == "arithmetic_expansion"
+	case ")":
+		return lhsName == "parenthesized_expression"
+	default:
+		return false
+	}
+}
+
 func isAssignmentShiftLHS(name string) bool {
 	switch name {
 	case "assignment_expression", "assignment", "_closed_assignment":
@@ -3461,6 +3620,12 @@ func isRepeatHelperReduce(action lrAction, ng *NormalizedGrammar) bool {
 }
 
 func resolveReduceReduceLegacy(lookaheadSym int, reduces []lrAction, ng *NormalizedGrammar, cache *conflictResolutionCache) ([]lrAction, error) {
+	if kept, ok := keepBashStatementBoundaryReduces(lookaheadSym, reduces, ng); ok {
+		return kept, nil
+	}
+	if preferred, ok := preferredBashStatementReduce(lookaheadSym, reduces, ng); ok {
+		return []lrAction{preferred}, nil
+	}
 	if allInDeclaredConflict(reduces, ng, cache) {
 		return reduces, nil
 	}
@@ -3496,6 +3661,83 @@ func resolveReduceReduceLegacy(lookaheadSym int, reduces []lrAction, ng *Normali
 	}
 
 	return rrPickBest(reduces, ng), nil
+}
+
+func keepBashStatementBoundaryReduces(lookaheadSym int, reduces []lrAction, ng *NormalizedGrammar) ([]lrAction, bool) {
+	if !bashStatementBoundaryLookahead(lookaheadSym, ng) {
+		return nil, false
+	}
+	notSubshell, notPipeline, ok := bashStatementReducePair(reduces, ng)
+	if !ok {
+		return nil, false
+	}
+	return []lrAction{notSubshell, notPipeline}, true
+}
+
+func preferredBashStatementReduce(lookaheadSym int, reduces []lrAction, ng *NormalizedGrammar) (lrAction, bool) {
+	notSubshell, notPipeline, ok := bashStatementReducePair(reduces, ng)
+	if !ok {
+		return lrAction{}, false
+	}
+	if lookaheadSym >= 0 && lookaheadSym < len(ng.Symbols) {
+		switch ng.Symbols[lookaheadSym].Name {
+		case "|", "|&":
+			return notPipeline, true
+		}
+	}
+	return notSubshell, true
+}
+
+func bashStatementReducePair(reduces []lrAction, ng *NormalizedGrammar) (lrAction, lrAction, bool) {
+	if len(reduces) < 2 || ng == nil {
+		return lrAction{}, lrAction{}, false
+	}
+	var notSubshell, notPipeline lrAction
+	hasNotSubshell := false
+	hasNotPipeline := false
+	relevant := 0
+	for _, reduce := range reduces {
+		if reduce.kind != lrReduce || reduce.prodIdx < 0 || reduce.prodIdx >= len(ng.Productions) {
+			continue
+		}
+		prod := &ng.Productions[reduce.prodIdx]
+		if prod.LHS < 0 || prod.LHS >= len(ng.Symbols) {
+			continue
+		}
+		switch ng.Symbols[prod.LHS].Name {
+		case "_statement_not_subshell":
+			notSubshell = reduce
+			hasNotSubshell = true
+			relevant++
+		case "_statement_not_pipeline":
+			notPipeline = reduce
+			hasNotPipeline = true
+			relevant++
+		}
+	}
+	return notSubshell, notPipeline, hasNotSubshell && hasNotPipeline && relevant == len(reduces)
+}
+
+func bashStatementBoundaryLookahead(lookaheadSym int, ng *NormalizedGrammar) bool {
+	if ng == nil {
+		return false
+	}
+	if lookaheadSym <= 0 {
+		return true
+	}
+	if lookaheadSym >= len(ng.Symbols) {
+		return false
+	}
+	switch ng.Symbols[lookaheadSym].Name {
+	case "end", "$end", "\x00",
+		"\\n", ";", ";;", "&", "&&", "||",
+		"<", ">", "<<", "<<-", ">>", "<<<", "&>", "&>>", "<&", ">&", "<&-", ">&-", ">|",
+		")", "}", "]",
+		"then", "do", "else", "elif", "fi", "done", "esac":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldKeepTypeValueTokenReduces(lookaheadSym int, reduces []lrAction, ng *NormalizedGrammar) bool {

--- a/grammargen/lr.go
+++ b/grammargen/lr.go
@@ -3246,13 +3246,15 @@ func shouldPreferAssignmentExpressionShift(lookaheadSym int, shifts, reduces []l
 	if shift.lhsSym < 0 || shift.lhsSym >= len(ng.Symbols) {
 		return false
 	}
-	if ng.Symbols[shift.lhsSym].Name != "assignment_expression" {
+	shiftLHSName := ng.Symbols[shift.lhsSym].Name
+	if !isAssignmentShiftLHS(shiftLHSName) {
 		return false
 	}
 	if lookaheadSym < 0 || lookaheadSym >= len(ng.Symbols) {
 		return false
 	}
-	if !isAssignmentOperatorLookahead(ng.Symbols[lookaheadSym].Name) {
+	lookaheadName := ng.Symbols[lookaheadSym].Name
+	if !isAssignmentOperatorLookahead(lookaheadName) && !(lookaheadName == "operator" && isAssignmentShiftLHS(shiftLHSName)) {
 		return false
 	}
 	for _, reduce := range reduces {
@@ -3268,6 +3270,15 @@ func shouldPreferAssignmentExpressionShift(lookaheadSym int, shifts, reduces []l
 		}
 	}
 	return true
+}
+
+func isAssignmentShiftLHS(name string) bool {
+	switch name {
+	case "assignment_expression", "assignment", "_closed_assignment":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldPreserveKeywordIdentifierShiftReduce(lookaheadSym int, reduces []lrAction, ng *NormalizedGrammar) bool {

--- a/grammargen/lr.go
+++ b/grammargen/lr.go
@@ -2633,6 +2633,9 @@ func (ctx *lrContext) buildItemSets() []lrItemSet {
 	exactPrefixStates := 0
 	if len(ctx.ng.ExternalSymbols) > 0 {
 		exactPrefixStates = 1024
+		if ctx.ng.ExactPrefixStates > 0 {
+			exactPrefixStates = ctx.ng.ExactPrefixStates
+		}
 		if v := os.Getenv("GOT_LR_EXACT_PREFIX_STATES"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 				exactPrefixStates = n

--- a/grammargen/lr.go
+++ b/grammargen/lr.go
@@ -1610,15 +1610,26 @@ func addNonterminalExtraChains(tables *LRTables, ng *NormalizedGrammar, ctx *lrC
 			terminalExtras = append(terminalExtras, e)
 		}
 	}
+	externalSymbolSet := make(map[int]struct{}, len(ng.ExternalSymbols))
+	for _, sym := range ng.ExternalSymbols {
+		externalSymbolSet[sym] = struct{}{}
+	}
 
 	extraStartsByFirstSym := make(map[int][]int)
 	var extraFirstSyms []int
+	hasExternalExtraStart := false
+	hasNonExternalExtraStart := false
 	for _, prodIdx := range extraProds {
 		prod := &ng.Productions[prodIdx]
 		if len(prod.RHS) > 0 && prod.RHS[0] < tokenCount {
 			firstSym := prod.RHS[0]
 			if _, ok := extraStartsByFirstSym[firstSym]; !ok {
 				extraFirstSyms = append(extraFirstSyms, firstSym)
+				if _, ok := externalSymbolSet[firstSym]; ok {
+					hasExternalExtraStart = true
+				} else {
+					hasNonExternalExtraStart = true
+				}
 			}
 			extraStartsByFirstSym[firstSym] = append(extraStartsByFirstSym[firstSym], prodIdx)
 		}
@@ -1643,6 +1654,16 @@ func addNonterminalExtraChains(tables *LRTables, ng *NormalizedGrammar, ctx *lrC
 			follow.add(firstSym)
 		}
 		return follow
+	}
+	var externalExtraFollow bitset
+	if hasExternalExtraStart {
+		externalExtraFollow = newBitset(tokenCount)
+		for state := 0; state < mainStateCount; state++ {
+			follow := stateFollowSet(state)
+			follow.forEach(func(sym int) {
+				externalExtraFollow.add(sym)
+			})
+		}
 	}
 	stateHasContinuation := func(state int) bool {
 		if acts, ok := tables.ActionTable[state]; ok {
@@ -1689,6 +1710,14 @@ func addNonterminalExtraChains(tables *LRTables, ng *NormalizedGrammar, ctx *lrC
 		if state < mainStateCount {
 			return true
 		}
+		if _, ok := externalSymbolSet[firstSym]; ok {
+			// External-scanner extras are context sensitive. Recursively
+			// injecting their starts into synthetic extra-chain states can make
+			// scanner-driven extras such as Perl POD/heredocs expand without a
+			// structural bound, while main LR states still receive the extra
+			// entry actions they need.
+			return false
+		}
 		extraMatcher, ok := startMatchers[firstSym]
 		if !ok {
 			return true
@@ -1733,7 +1762,10 @@ func addNonterminalExtraChains(tables *LRTables, ng *NormalizedGrammar, ctx *lrC
 		if state >= mainStateCount && stateOnlyReducesCompletedExtra(state) {
 			continue
 		}
-		follow := stateFollowSet(state)
+		var follow bitset
+		if hasNonExternalExtraStart {
+			follow = stateFollowSet(state)
+		}
 		for _, firstSym := range extraFirstSyms {
 			if !syntheticStateMayInjectExtraStart(state, firstSym) {
 				continue
@@ -1748,8 +1780,14 @@ func addNonterminalExtraChains(tables *LRTables, ng *NormalizedGrammar, ctx *lrC
 			if hasNonExtraAction {
 				continue
 			}
+			entryFollow := follow
+			if _, ok := externalSymbolSet[firstSym]; ok {
+				entryFollow = externalExtraFollow
+			} else if len(entryFollow.words) == 0 {
+				entryFollow = stateFollowSet(state)
+			}
 			prodIdxs := extraStartsByFirstSym[firstSym]
-			entryState := builder.buildEntryState(firstSym, prodIdxs, follow)
+			entryState := builder.buildEntryState(firstSym, prodIdxs, entryFollow)
 			tables.addAction(state, firstSym, lrAction{
 				kind:    lrShift,
 				state:   entryState,

--- a/grammargen/lr_conflict_resolution_test.go
+++ b/grammargen/lr_conflict_resolution_test.go
@@ -55,6 +55,64 @@ func TestResolveReduceReduceKeepsTypeValueSingleTokenAmbiguity(t *testing.T) {
 	}
 }
 
+func TestResolveReduceReduceKeepsBashStatementBoundaryReduces(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: "end", Kind: SymbolTerminal},
+			{Name: "|", Kind: SymbolTerminal},
+			{Name: ">", Kind: SymbolTerminal},
+			{Name: "_statement_not_subshell", Kind: SymbolNonterminal},
+			{Name: "_statement_not_pipeline", Kind: SymbolNonterminal},
+			{Name: "command", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 3, RHS: []int{5}},
+			{LHS: 4, RHS: []int{5}},
+		},
+	}
+	reduces := []lrAction{
+		{kind: lrReduce, prodIdx: 0},
+		{kind: lrReduce, prodIdx: 1},
+	}
+
+	for _, lookahead := range []int{0, 2} {
+		got, err := resolveActionConflict(lookahead, reduces, ng)
+		if err != nil {
+			t.Fatalf("resolveActionConflict(%d): %v", lookahead, err)
+		}
+		if len(got) != 2 || got[0].prodIdx != 0 || got[1].prodIdx != 1 {
+			t.Fatalf("resolveActionConflict(%d) = %+v, want both Bash statement reductions", lookahead, got)
+		}
+	}
+}
+
+func TestResolveReduceReducePrefersBashPipelineContinuationReduce(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: "end", Kind: SymbolTerminal},
+			{Name: "|", Kind: SymbolTerminal},
+			{Name: "_statement_not_subshell", Kind: SymbolNonterminal},
+			{Name: "_statement_not_pipeline", Kind: SymbolNonterminal},
+			{Name: "command", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 2, RHS: []int{4}},
+			{LHS: 3, RHS: []int{4}},
+		},
+	}
+
+	got, err := resolveActionConflict(1, []lrAction{
+		{kind: lrReduce, prodIdx: 0},
+		{kind: lrReduce, prodIdx: 1},
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict: %v", err)
+	}
+	if len(got) != 1 || got[0].prodIdx != 1 {
+		t.Fatalf("resolved actions = %+v, want _statement_not_pipeline reduce", got)
+	}
+}
+
 func TestResolveShiftReduceCanPreserveKeywordIdentifierCallAmbiguity(t *testing.T) {
 	ng := &NormalizedGrammar{
 		Symbols: []SymbolInfo{
@@ -125,6 +183,116 @@ func TestResolveShiftReducePrefersSpecificKeywordContinuation(t *testing.T) {
 				t.Fatalf("resolved actions = %+v, want specific keyword shift", got)
 			}
 		})
+	}
+}
+
+func TestResolveShiftReducePrefersArithmeticCloseDelimiter(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: "))", Kind: SymbolTerminal},
+			{Name: "_arithmetic_expression", Kind: SymbolNonterminal},
+			{Name: "postfix_expression", Kind: SymbolNonterminal},
+			{Name: "arithmetic_expansion", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 1, RHS: []int{2}, Prec: 1},
+		},
+	}
+
+	got, err := resolveActionConflict(0, []lrAction{
+		{kind: lrShift, state: 12, prec: 1, lhsSym: 3},
+		{kind: lrReduce, prodIdx: 0, lhsSym: 1},
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != lrShift {
+		t.Fatalf("resolved actions = %+v, want close-delimiter shift", got)
+	}
+}
+
+func TestResolveShiftReduceUsesArithmeticExpressionReducePrecedence(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: "+", Kind: SymbolTerminal},
+			{Name: "*", Kind: SymbolTerminal},
+			{Name: "||", Kind: SymbolTerminal},
+			{Name: "_arithmetic_expression", Kind: SymbolNonterminal},
+			{Name: "_arithmetic_literal", Kind: SymbolNonterminal},
+			{Name: "binary_expression", Kind: SymbolNonterminal},
+			{Name: "unary_expression", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 3, RHS: []int{4}, Prec: 1},
+			{LHS: 4, RHS: []int{4}, Prec: 1},
+			{LHS: 5, RHS: []int{4, 0, 4}, Prec: 13, Assoc: AssocLeft, HasExplicitPrec: true},
+			{LHS: 6, RHS: []int{0, 4}, Prec: 11, HasExplicitPrec: true},
+		},
+	}
+
+	got, err := resolveActionConflict(0, []lrAction{
+		{kind: lrReduce, prodIdx: 0, lhsSym: 3},
+		{kind: lrReduce, prodIdx: 1, lhsSym: 4},
+		{kind: lrReduce, prodIdx: 2, lhsSym: 5},
+		{kind: lrShift, state: 12, prec: 13, lhsSym: 5},
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict same-precedence: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != lrReduce || got[0].prodIdx != 2 {
+		t.Fatalf("same-precedence actions = %+v, want left-associative binary reduce", got)
+	}
+
+	got, err = resolveActionConflict(1, []lrAction{
+		{kind: lrReduce, prodIdx: 0, lhsSym: 3},
+		{kind: lrReduce, prodIdx: 1, lhsSym: 4},
+		{kind: lrReduce, prodIdx: 2, lhsSym: 5},
+		{kind: lrShift, state: 13, prec: 14, lhsSym: 5},
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict higher-shift: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != lrShift {
+		t.Fatalf("higher-shift actions = %+v, want higher-precedence shift", got)
+	}
+
+	got, err = resolveActionConflict(2, []lrAction{
+		{kind: lrReduce, prodIdx: 0, lhsSym: 3},
+		{kind: lrReduce, prodIdx: 3, lhsSym: 6},
+		{kind: lrShift, state: 14, prec: 3, lhsSym: 5},
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict unary: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != lrReduce || got[0].prodIdx != 3 {
+		t.Fatalf("unary actions = %+v, want high-precedence unary reduce", got)
+	}
+}
+
+func TestResolveShiftReduceShiftsArithmeticAssignmentFromWrapper(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: "=", Kind: SymbolTerminal},
+			{Name: "_arithmetic_expression", Kind: SymbolNonterminal},
+			{Name: "_arithmetic_literal", Kind: SymbolNonterminal},
+			{Name: "binary_expression", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 1, RHS: []int{2}, Prec: 1},
+			{LHS: 2, RHS: []int{2}, Prec: 1},
+		},
+	}
+
+	got, err := resolveActionConflict(0, []lrAction{
+		{kind: lrReduce, prodIdx: 0, lhsSym: 1},
+		{kind: lrReduce, prodIdx: 1, lhsSym: 2},
+		{kind: lrShift, state: 9, prec: 1, lhsSym: 3},
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict: %v", err)
+	}
+	if len(got) != 1 || got[0].kind != lrShift {
+		t.Fatalf("resolved actions = %+v, want arithmetic assignment shift", got)
 	}
 }
 

--- a/grammargen/lr_lalr.go
+++ b/grammargen/lr_lalr.go
@@ -74,6 +74,7 @@ func (ctx *lrContext) buildLR0() {
 	debugLALR := os.Getenv("GOT_DEBUG_LALR") == "1"
 	ctx.ensureLR0SymbolSeenCapacity(len(ng.Symbols))
 	ctx.ensureLR0SymbolBucketCapacity(len(ng.Symbols))
+	ctx.ensureLR0Dot0ClosureSeeds()
 	contextTagsEnabled := os.Getenv("GOT_LR_DISABLE_CONTEXT_TAGS") != "1" && len(ng.Productions) >= 2000
 	if contextTagsEnabled {
 		ctx.ensureRepeatWrapperLHS()
@@ -340,11 +341,50 @@ func (ctx *lrContext) buildLR0() {
 	}
 }
 
+func (ctx *lrContext) ensureLR0Dot0ClosureSeeds() {
+	if len(ctx.lr0Dot0ClosureSeeds) == len(ctx.ng.Symbols) {
+		return
+	}
+	ng := ctx.ng
+	tokenCount := ctx.tokenCount
+	seeds := make([][]int, len(ng.Symbols))
+	for sym := tokenCount; sym < len(ng.Symbols); sym++ {
+		seenSym := make([]bool, len(ng.Symbols))
+		seenProd := make([]bool, len(ng.Productions))
+		queue := []int{sym}
+		var prods []int
+		for len(queue) > 0 {
+			cur := queue[len(queue)-1]
+			queue = queue[:len(queue)-1]
+			if cur < tokenCount || cur < 0 || cur >= len(ng.Symbols) || seenSym[cur] {
+				continue
+			}
+			seenSym[cur] = true
+			for _, prodIdx := range ctx.prodsByLHS[cur] {
+				if !seenProd[prodIdx] {
+					seenProd[prodIdx] = true
+					prods = append(prods, prodIdx)
+				}
+				rhs := ng.Productions[prodIdx].RHS
+				if len(rhs) > 0 && rhs[0] >= tokenCount {
+					queue = append(queue, rhs[0])
+				}
+			}
+		}
+		if len(prods) > 1 {
+			sort.Ints(prods)
+		}
+		seeds[sym] = prods
+	}
+	ctx.lr0Dot0ClosureSeeds = seeds
+}
+
 // lr0Closure computes the LR(0) closure of a set of kernel items.
 // No lookaheads are involved — just expands nonterminals to their productions.
 func (ctx *lrContext) lr0Closure(kernel []coreItem) lr0ItemSet {
 	ng := ctx.ng
 	tokenCount := ctx.tokenCount
+	ctx.ensureLR0Dot0ClosureSeeds()
 
 	for _, prodIdx := range ctx.dot0Dirty {
 		ctx.dot0Index[prodIdx] = -1
@@ -352,8 +392,24 @@ func (ctx *lrContext) lr0Closure(kernel []coreItem) lr0ItemSet {
 	ctx.dot0Dirty = ctx.dot0Dirty[:0]
 
 	cores := ctx.lr0ClosureScratch[:0]
-	if cap(cores) < len(kernel)*2 {
-		cores = make([]lr0CoreEntry, 0, len(kernel)*2)
+	capHint := len(kernel)
+	ctx.ensureLR0SymbolSeenCapacity(len(ng.Symbols))
+	seedSeenEpoch := ctx.nextLR0SymbolSeenEpoch()
+	for _, ki := range kernel {
+		prod := &ng.Productions[ki.prodIdx]
+		if ki.dot >= len(prod.RHS) {
+			continue
+		}
+		nextSym := prod.RHS[ki.dot]
+		if nextSym < tokenCount || nextSym < 0 || nextSym >= len(ctx.lr0Dot0ClosureSeeds) ||
+			ctx.lr0SymbolSeenGen[nextSym] == seedSeenEpoch {
+			continue
+		}
+		ctx.lr0SymbolSeenGen[nextSym] = seedSeenEpoch
+		capHint += len(ctx.lr0Dot0ClosureSeeds[nextSym])
+	}
+	if cap(cores) < capHint {
+		cores = make([]lr0CoreEntry, 0, capHint)
 	}
 
 	// Add kernel items.
@@ -366,24 +422,20 @@ func (ctx *lrContext) lr0Closure(kernel []coreItem) lr0ItemSet {
 		}
 	}
 
-	// Expand: for each item [A → α.Bβ], add [B → .γ] for all B-productions.
-	// Use a worklist but only process each core item once (no re-processing needed
-	// since LR(0) closure doesn't change — there are no lookaheads to propagate).
-	for i := 0; i < len(cores); i++ {
-		ce := &cores[i]
-		prodIdx := int(ce.prodIdx())
-		dot := int(ce.dot())
-		prod := &ng.Productions[prodIdx]
-		if dot >= len(prod.RHS) {
+	// Expand: for each item [A -> alpha . B beta], add the precomputed
+	// recursive dot-0 closure for B. LR(0) closure has no lookahead-dependent
+	// state, so this avoids re-walking the same nonterminal graph for every
+	// successor state in large grammars.
+	for _, ki := range kernel {
+		prod := &ng.Productions[ki.prodIdx]
+		if ki.dot >= len(prod.RHS) {
 			continue
 		}
-
-		nextSym := prod.RHS[dot]
+		nextSym := prod.RHS[ki.dot]
 		if nextSym < tokenCount {
 			continue
 		}
-
-		for _, prodIdx := range ctx.prodsByLHS[nextSym] {
+		for _, prodIdx := range ctx.lr0Dot0ClosureSeeds[nextSym] {
 			if ctx.dot0Index[prodIdx] >= 0 {
 				continue
 			}

--- a/grammargen/nfa.go
+++ b/grammargen/nfa.go
@@ -19,6 +19,7 @@ type nfaState struct {
 	transitions []nfaTransition
 	accept      int // symbol ID if accepting, 0 if not
 	priority    int // for disambiguation: lower = higher priority
+	tieOrder    int // stable terminal order for same-length, same-priority ties
 }
 
 // nfa holds the complete NFA.
@@ -511,7 +512,7 @@ func buildCombinedNFA(patterns []TerminalPattern) (*nfa, error) {
 		}
 	}
 	trieEdges := make(map[int]map[rune]int)
-	addStringPattern := func(lit string, symID, priority int) {
+	addStringPattern := func(lit string, symID, priority, tieOrder int) {
 		cur := start
 		for i := 0; i < len(lit); {
 			r, size := utf8.DecodeRuneInString(lit[i:])
@@ -531,11 +532,12 @@ func buildCombinedNFA(patterns []TerminalPattern) (*nfa, error) {
 		}
 		b.states[cur].accept = symID
 		b.states[cur].priority = priority
+		b.states[cur].tieOrder = tieOrder
 	}
 
-	for _, pat := range patterns {
+	for i, pat := range patterns {
 		if pat.Rule != nil && pat.Rule.Kind == RuleString && stringCounts[pat.Rule.Value] == 1 {
-			addStringPattern(pat.Rule.Value, pat.SymbolID, pat.Priority)
+			addStringPattern(pat.Rule.Value, pat.SymbolID, pat.Priority, i)
 			continue
 		}
 		frag, err := b.buildFromRule(pat.Rule)
@@ -545,6 +547,7 @@ func buildCombinedNFA(patterns []TerminalPattern) (*nfa, error) {
 		b.addEpsilon(start, frag.start)
 		b.states[frag.end].accept = pat.SymbolID
 		b.states[frag.end].priority = pat.Priority
+		b.states[frag.end].tieOrder = i
 	}
 
 	return &nfa{states: b.states, start: start}, nil

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -2017,9 +2017,18 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 		})
 	}
 
-	// Inline patterns (regex appearing directly in non-terminal rules, not in token()).
-	// These have no explicit prec, so priority is 0.
+	var keywordInlinePatterns, broadInlinePatterns []string
 	for _, pat := range inlinePatterns {
+		if isKeywordLikeInlinePattern(pat) {
+			keywordInlinePatterns = append(keywordInlinePatterns, pat)
+		} else {
+			broadInlinePatterns = append(broadInlinePatterns, pat)
+		}
+	}
+
+	// Keyword-shaped inline patterns, such as DOT's case-insensitive
+	// `[sS][uU]...` aliases, must beat identifier tokens on same-length ties.
+	for _, pat := range keywordInlinePatterns {
 		id, ok := st.lookup(inlinePatternSymbolKey(pat))
 		if !ok {
 			continue
@@ -2060,6 +2069,27 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 			Rule:      expanded,
 			Priority:  adjustedPriority,
 			Immediate: imm,
+		})
+	}
+
+	// Inline patterns (regex appearing directly in non-terminal rules, not in token()).
+	// These have no explicit prec, so priority is 0. Keep broad ones after named
+	// tokens in terminal extraction order so same-length ties prefer explicit
+	// named tokens, while same-priority longer inline matches still win through
+	// the runtime's longest-match scan.
+	for _, pat := range broadInlinePatterns {
+		id, ok := st.lookup(inlinePatternSymbolKey(pat))
+		if !ok {
+			continue
+		}
+		expanded, err := expandPatternRule(pat)
+		if err != nil {
+			return nil, fmt.Errorf("expand inline pattern %q: %w", pat, err)
+		}
+		patterns = append(patterns, TerminalPattern{
+			SymbolID: id,
+			Rule:     expanded,
+			Priority: 0,
 		})
 	}
 
@@ -2121,6 +2151,46 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 	}
 
 	return patterns, nil
+}
+
+func isKeywordLikeInlinePattern(pattern string) bool {
+	if pattern == "" {
+		return false
+	}
+	consumed := false
+	for i := 0; i < len(pattern); {
+		ch := pattern[i]
+		switch {
+		case isASCIILetter(rune(ch)) || isASCIIDigit(ch) || ch == '_':
+			consumed = true
+			i++
+		case ch == '[':
+			end := strings.IndexByte(pattern[i+1:], ']')
+			if end < 0 {
+				return false
+			}
+			content := pattern[i+1 : i+1+end]
+			if len(content) == 1 && (isASCIILetter(rune(content[0])) || isASCIIDigit(content[0]) || content[0] == '_') {
+				consumed = true
+				i += end + 2
+				continue
+			}
+			if len(content) == 2 && isASCIILetter(rune(content[0])) && isASCIILetter(rune(content[1])) &&
+				strings.EqualFold(content[:1], content[1:]) {
+				consumed = true
+				i += end + 2
+				continue
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return consumed
+}
+
+func isASCIIDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
 }
 
 func hasLongerStringPrefixPattern(patterns []TerminalPattern, prefix string) bool {

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -1179,6 +1179,16 @@ func isTerminalRule(r *Rule) bool {
 		return true
 	case RuleToken, RuleImmToken:
 		return true
+	case RuleChoice:
+		if len(r.Children) == 0 {
+			return false
+		}
+		for _, child := range r.Children {
+			if !isTerminalRule(child) {
+				return false
+			}
+		}
+		return true
 	case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic:
 		if len(r.Children) > 0 {
 			return isTerminalRule(r.Children[0])
@@ -2594,6 +2604,9 @@ func expandTokenRule(r *Rule) (*Rule, bool, int, error) {
 	case RuleImmToken:
 		inner, prec, err := flattenTokenInnerPrec(r.Children[0])
 		return inner, true, prec, err
+	case RuleChoice:
+		inner, err := flattenTokenInner(r)
+		return inner, false, 0, err
 	case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic:
 		if len(r.Children) > 0 {
 			rule, imm, _, err := expandTokenRule(r.Children[0])

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -100,6 +100,8 @@ type NormalizedGrammar struct {
 	// External scanner support (populated when Grammar.Externals is set).
 	ExternalSymbols []int // external token index → symbol ID
 
+	ExactPrefixStates int
+
 	// PrecedenceOrder stores the symbol-level precedence ordering from the
 	// grammar's precedences table. Maps a rule name to its numeric position
 	// (higher = higher priority) and whether it's a SYMBOL or STRING entry.
@@ -638,6 +640,7 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	ng.KeywordEntries = keywordEntries
 	ng.ReservedWordSets = reservedWordSets
 	ng.ExternalSymbols = externalSymbols
+	ng.ExactPrefixStates = g.ExactPrefixStates
 	ng.PrecedenceOrder = buildPrecOrderTable(g.Precedences, buildNamedPrecMapFromLevels(g.Precedences))
 	ng.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
 
@@ -3336,6 +3339,7 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 	out.BinaryRepeatMode = g.BinaryRepeatMode
 	out.EnableLRSplitting = g.EnableLRSplitting
 	out.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
+	out.ExactPrefixStates = g.ExactPrefixStates
 	out.ChoiceLiftThreshold = g.ChoiceLiftThreshold
 	return out
 }
@@ -3714,6 +3718,7 @@ func expandInlineRules(g *Grammar) *Grammar {
 	out.ReuseRepeatAuxForParents = append(out.ReuseRepeatAuxForParents, g.ReuseRepeatAuxForParents...)
 	out.EnableLRSplitting = g.EnableLRSplitting
 	out.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
+	out.ExactPrefixStates = g.ExactPrefixStates
 	out.ChoiceLiftThreshold = g.ChoiceLiftThreshold
 	// Don't propagate Inline — they've been expanded.
 

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -250,6 +250,21 @@ func (st *symbolTable) fieldID(name string) int {
 	return id
 }
 
+func (st *symbolTable) uniqueInternalSymbolName(base string) string {
+	if st == nil {
+		return base
+	}
+	name := base
+	for i := 1; ; i++ {
+		if _, ok := st.lookup(name); !ok {
+			if _, ok := st.lookupNonterm(name); !ok {
+				return name
+			}
+		}
+		name = fmt.Sprintf("%s_%d", base, i)
+	}
+}
+
 // Normalize transforms a Grammar into a NormalizedGrammar.
 func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	if len(g.RuleOrder) == 0 {
@@ -494,8 +509,9 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	// Add augmented start production: S' → startRule
 	startName := g.RuleOrder[0]
 	startSym, _ := st.lookupNonterm(startName)
-	augStartSym := st.addSymbol("_start", SymbolInfo{
-		Name:    "_start",
+	augStartName := st.uniqueInternalSymbolName("__gotreesitter_augmented_start")
+	augStartSym := st.addSymbol(augStartName, SymbolInfo{
+		Name:    augStartName,
 		Visible: false,
 		Named:   false,
 		Kind:    SymbolNonterminal,

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -477,7 +477,7 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	}
 
 	// Phase 6: Extract terminal patterns for DFA generation.
-	terminals, err := extractTerminals(g, st, stringLiterals, namedTokens, inlinePatterns, inlineTokens, keywordSet)
+	terminals, err := extractTerminals(g, st, stringLiterals, namedTokens, inlinePatterns, inlineTokens, keywordSet, aliasedPatterns)
 	if err != nil {
 		return nil, fmt.Errorf("extract terminals: %w", err)
 	}
@@ -1964,7 +1964,7 @@ func resolveExtras(g *Grammar, st *symbolTable) []int {
 // extractTerminals builds TerminalPattern entries for DFA generation.
 // When keywordSet is non-nil, string terminals that are keywords are excluded
 // from the main DFA (they're handled by the keyword DFA instead).
-func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTokens []string, inlinePatterns []string, inlineTokens []inlineTokenEntry, keywordSet map[int]bool) ([]TerminalPattern, error) {
+func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTokens []string, inlinePatterns []string, inlineTokens []inlineTokenEntry, keywordSet map[int]bool, aliasedPatterns map[string]aliasInfo) ([]TerminalPattern, error) {
 	var patterns []TerminalPattern
 
 	// All non-immediate terminals use prec-based priority: -prec*1000.
@@ -2027,10 +2027,10 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 		})
 	}
 
-	var keywordInlinePatterns, broadInlinePatterns []string
+	var priorityInlinePatterns, broadInlinePatterns []string
 	for _, pat := range inlinePatterns {
-		if isKeywordLikeInlinePattern(pat) {
-			keywordInlinePatterns = append(keywordInlinePatterns, pat)
+		if _, aliased := aliasedPatterns[pat]; aliased || isKeywordLikeInlinePattern(pat) {
+			priorityInlinePatterns = append(priorityInlinePatterns, pat)
 		} else {
 			broadInlinePatterns = append(broadInlinePatterns, pat)
 		}
@@ -2038,7 +2038,10 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 
 	// Keyword-shaped inline patterns, such as DOT's case-insensitive
 	// `[sS][uU]...` aliases, must beat identifier tokens on same-length ties.
-	for _, pat := range keywordInlinePatterns {
+	// Aliased inline patterns also need this extraction order: tree-sitter C
+	// gives alias(PATTERN, "...") terminals concrete auxiliary symbols before
+	// later broad named patterns, e.g. C++ #include before preproc_directive.
+	for _, pat := range priorityInlinePatterns {
 		id, ok := st.lookup(inlinePatternSymbolKey(pat))
 		if !ok {
 			continue

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -109,7 +109,9 @@ type NormalizedGrammar struct {
 	// against the named precedence of a competing shift action.
 	PrecedenceOrder *precOrderTable
 
-	PreserveKeywordIdentifierConflicts bool
+	PreserveKeywordIdentifierConflicts         bool
+	SuppressEquivalentExternalReduceLookaheads bool
+	ExternalReduceFollowLookaheads             map[string]bool
 
 	// conflictCache is built lazily by LR conflict resolution so repeated
 	// resolveActionConflict calls can reuse the same reverse indexes.
@@ -130,6 +132,7 @@ type symbolTable struct {
 	binaryRepeatMode    bool // use tree-sitter binary repeat helper shape
 	flattenRepeatAux    bool
 	choiceLiftThreshold int // if >0, lift inline CHOICE nodes exceeding this width
+	stringTokenPrecs    map[string]int
 }
 
 const inlinePatternSymbolPrefix = "\x00inline_pattern:"
@@ -145,6 +148,7 @@ func newSymbolTable() *symbolTable {
 		namedTokenByName: make(map[string]int),
 		fieldMap:         make(map[string]int),
 		repeatAuxByKey:   make(map[string]string),
+		stringTokenPrecs: make(map[string]int),
 		fields:           []string{""}, // index 0 is always ""
 	}
 	// Symbol 0 = "end" (EOF). Tree-sitter C marks this Named=true.
@@ -659,11 +663,26 @@ func Normalize(g *Grammar) (*NormalizedGrammar, error) {
 	ng.ExactPrefixStates = g.ExactPrefixStates
 	ng.PrecedenceOrder = buildPrecOrderTable(g.Precedences, buildNamedPrecMapFromLevels(g.Precedences))
 	ng.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
+	ng.SuppressEquivalentExternalReduceLookaheads = g.SuppressEquivalentExternalReduceLookaheads
+	ng.ExternalReduceFollowLookaheads = stringSetFromSlice(g.ExternalReduceFollowLookaheads)
 
 	// Set tokenCount boundary on symbols so assembly knows where terminals end.
 	_ = tokenCount
 
 	return ng, nil
+}
+
+func stringSetFromSlice(values []string) map[string]bool {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value != "" {
+			out[value] = true
+		}
+	}
+	return out
 }
 
 func resolveReservedWordSets(sets []ReservedWordSet, st *symbolTable, terminals []TerminalPattern) ([][]int, error) {
@@ -1247,6 +1266,34 @@ func liftInlineTokens(g *Grammar, st *symbolTable) []inlineTokenEntry {
 	return entries
 }
 
+func (st *symbolTable) recordStringTokenPrecedence(value string, prec int) {
+	if st == nil || prec == 0 {
+		return
+	}
+	if existing, ok := st.stringTokenPrecs[value]; !ok || prec > existing {
+		st.stringTokenPrecs[value] = prec
+	}
+}
+
+func tokenRulePrecedence(r *Rule) int {
+	if r == nil {
+		return 0
+	}
+	switch r.Kind {
+	case RuleToken, RuleImmToken:
+		if len(r.Children) > 0 {
+			return tokenRulePrecedence(r.Children[0])
+		}
+	case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic:
+		return r.Prec
+	case RuleField, RuleAlias:
+		if len(r.Children) > 0 {
+			return tokenRulePrecedence(r.Children[0])
+		}
+	}
+	return 0
+}
+
 // canonicalTokenKey computes a canonical string key for an inline token's
 // pattern, used to deduplicate tokens with identical matching behavior.
 // Precedence wrappers are stripped since they affect conflict resolution,
@@ -1351,6 +1398,7 @@ func liftTokensInRule(r *Rule, parentName string, st *symbolTable, entries *[]in
 		if r.Kind == RuleToken {
 			if sv := extractTokenStringValue(r); sv != "" {
 				if _, exists := st.lookup(sv); exists {
+					st.recordStringTokenPrecedence(sv, tokenRulePrecedence(r))
 					key := canonicalTokenKey(r)
 					dedup[key] = sv
 					return Sym(sv)
@@ -1907,9 +1955,15 @@ func registerExternalSymbols(g *Grammar, st *symbolTable) []int {
 			named = false
 		case RulePattern:
 			// Anonymous external patterns are emitted by tree-sitter with
-			// synthetic names like _token1. Keep them in the external-symbol
-			// table so scanner adaptation can preserve external token order.
+			// synthetic names like _token1 unless the same anonymous pattern
+			// already exists as an inline terminal. In that case, reuse the
+			// existing symbol so LR actions on the inline terminal also make the
+			// corresponding external scanner token valid.
 			anonPatternCount++
+			if id, ok := st.lookup(inlinePatternSymbolKey(ext.Value)); ok {
+				extSyms = append(extSyms, id)
+				continue
+			}
 			name = fmt.Sprintf("_token%d", anonPatternCount)
 			named = false
 		default:
@@ -2004,7 +2058,7 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 		patterns = append(patterns, TerminalPattern{
 			SymbolID: id,
 			Rule:     Str(s),
-			Priority: 0,
+			Priority: -st.stringTokenPrecs[s] * 1000,
 		})
 	}
 
@@ -2043,9 +2097,24 @@ func extractTerminals(g *Grammar, st *symbolTable, stringLits []string, namedTok
 		})
 	}
 
+	priorityInlinePatternSet := stringSetFromSlice(g.PriorityInlinePatterns)
+	inlinePatternSet := stringSetFromSlice(inlinePatterns)
+	seenPriorityInlinePattern := make(map[string]bool, len(g.PriorityInlinePatterns))
 	var priorityInlinePatterns, broadInlinePatterns []string
+	for _, pat := range g.PriorityInlinePatterns {
+		if inlinePatternSet[pat] && !seenPriorityInlinePattern[pat] {
+			priorityInlinePatterns = append(priorityInlinePatterns, pat)
+			seenPriorityInlinePattern[pat] = true
+		}
+	}
 	for _, pat := range inlinePatterns {
-		if _, aliased := aliasedPatterns[pat]; aliased || isKeywordLikeInlinePattern(pat) {
+		if seenPriorityInlinePattern[pat] {
+			continue
+		}
+		if priorityInlinePatternSet[pat] {
+			priorityInlinePatterns = append(priorityInlinePatterns, pat)
+			seenPriorityInlinePattern[pat] = true
+		} else if _, aliased := aliasedPatterns[pat]; aliased || isKeywordLikeInlinePattern(pat) {
 			priorityInlinePatterns = append(priorityInlinePatterns, pat)
 		} else {
 			broadInlinePatterns = append(broadInlinePatterns, pat)
@@ -2793,16 +2862,20 @@ func flattenRule2(r *Rule, lhsID int, st *symbolTable, prodIDCounter *int) []Pro
 						suppressExplicitZeroWrapperAssoc = true
 					}
 				}
-				if altProds[i].Prec == 0 {
+				if altHasPrec && altPrec != 0 {
+					altProds[i].Prec = altPrec
+				} else if altProds[i].Prec == 0 {
 					altProds[i].Prec = altPrec
 				}
-				if !suppressExplicitZeroWrapperAssoc && !altProds[i].HasExplicitPrec && altHasPrec {
+				if !suppressExplicitZeroWrapperAssoc && altHasPrec && (altPrec != 0 || !altProds[i].HasExplicitPrec) {
 					altProds[i].HasExplicitPrec = true
 				}
-				if !suppressExplicitZeroWrapperAssoc && altProds[i].Assoc == AssocNone {
+				if !suppressExplicitZeroWrapperAssoc && (altProds[i].Assoc == AssocNone || altPrec != 0) {
 					altProds[i].Assoc = altAssoc
 				}
-				if altProds[i].DynPrec == 0 {
+				if altDyn != 0 {
+					altProds[i].DynPrec = altDyn
+				} else if altProds[i].DynPrec == 0 {
 					altProds[i].DynPrec = altDyn
 				}
 			}
@@ -2858,10 +2931,10 @@ func flattenRule2(r *Rule, lhsID int, st *symbolTable, prodIDCounter *int) []Pro
 		trailingAutoSemiOptional := hasTrailingAutomaticSemicolonOptional(inner)
 		var prods []Production
 		for _, alt := range alternatives {
-			// Compute per-alternative prec: use rightmost element's prec
-			// (matching tree-sitter's behavior where the rightmost prec
-			// wrapper in a production wins). Fall back to the outer prec
-			// from unwrapPrec, then scanInnerPrec as last resort.
+			// Compute per-alternative prec: an explicit wrapper on the whole
+			// production wins. Otherwise use the rightmost element's prec,
+			// matching tree-sitter's behavior where an inline prec wrapper in a
+			// production contributes that production's precedence.
 			altPrec, altAssoc, altDyn, altHasPrec := prec, assoc, dynPrec, hasPrec
 			altIncludesBlankChoice := false
 			altHasInnerPrec := false
@@ -2870,16 +2943,16 @@ func flattenRule2(r *Rule, lhsID int, st *symbolTable, prodIDCounter *int) []Pro
 					altIncludesBlankChoice = true
 					continue
 				}
-				if elem.hasPrec {
+				if elem.hasPrec && !hasPrec {
 					altPrec = elem.prec
 					altHasPrec = true
 					altHasInnerPrec = true
 				}
-				if elem.assoc != AssocNone {
+				if elem.assoc != AssocNone && !hasPrec {
 					altAssoc = elem.assoc
 					altHasInnerPrec = true
 				}
-				if elem.dynPrec != 0 {
+				if elem.dynPrec != 0 && dynPrec == 0 {
 					altDyn = elem.dynPrec
 					altHasInnerPrec = true
 				}
@@ -3443,6 +3516,9 @@ func flattenHiddenChoiceAlts(g *Grammar, generatedHiddenRules map[string]bool) *
 	out.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
 	out.ExactPrefixStates = g.ExactPrefixStates
 	out.ChoiceLiftThreshold = g.ChoiceLiftThreshold
+	out.SuppressEquivalentExternalReduceLookaheads = g.SuppressEquivalentExternalReduceLookaheads
+	out.ExternalReduceFollowLookaheads = append(out.ExternalReduceFollowLookaheads, g.ExternalReduceFollowLookaheads...)
+	out.PriorityInlinePatterns = append(out.PriorityInlinePatterns, g.PriorityInlinePatterns...)
 	return out
 }
 
@@ -3822,6 +3898,9 @@ func expandInlineRules(g *Grammar) *Grammar {
 	out.PreserveKeywordIdentifierConflicts = g.PreserveKeywordIdentifierConflicts
 	out.ExactPrefixStates = g.ExactPrefixStates
 	out.ChoiceLiftThreshold = g.ChoiceLiftThreshold
+	out.SuppressEquivalentExternalReduceLookaheads = g.SuppressEquivalentExternalReduceLookaheads
+	out.ExternalReduceFollowLookaheads = append(out.ExternalReduceFollowLookaheads, g.ExternalReduceFollowLookaheads...)
+	out.PriorityInlinePatterns = append(out.PriorityInlinePatterns, g.PriorityInlinePatterns...)
 	// Don't propagate Inline — they've been expanded.
 
 	return out

--- a/grammargen/normalize_terminal_collision_test.go
+++ b/grammargen/normalize_terminal_collision_test.go
@@ -41,3 +41,61 @@ func TestNormalizeSeparatesAnonymousStringAndPatternTerminals(t *testing.T) {
 		t.Fatalf("expected 2 distinct terminals named %q, got %d", ".*", len(collisionSymIDs))
 	}
 }
+
+func TestPriorityInlinePatternsPrecedeAliasedInlinePatterns(t *testing.T) {
+	g := NewGrammar("priority_inline_patterns")
+	g.PriorityInlinePatterns = []string{`[0-9]+`}
+	g.Define("source_file", Choice(
+		Alias(Pat(`[A-Za-z0-9_]+`), "variable_name", true),
+		Pat(`[0-9]+`),
+	))
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	numberOrder := -1
+	variableOrder := -1
+	for i, term := range ng.Terminals {
+		name := ng.Symbols[term.SymbolID].Name
+		switch name {
+		case `[0-9]+`:
+			numberOrder = i
+		case "variable_name":
+			variableOrder = i
+		}
+	}
+	if numberOrder < 0 {
+		t.Fatal("missing priority inline number terminal")
+	}
+	if variableOrder < 0 {
+		t.Fatal("missing aliased variable terminal")
+	}
+	if numberOrder > variableOrder {
+		t.Fatalf("priority inline terminal order = %d, aliased terminal order = %d; want priority first", numberOrder, variableOrder)
+	}
+}
+
+func TestReusedStringTokenPreservesLexicalPrecedence(t *testing.T) {
+	g := NewGrammar("reused_string_token_precedence")
+	g.Define("source_file", Choice(
+		Str("-"),
+		Seq(Token(Prec(1, Str("-"))), Pat(`[0-9]+`)),
+	))
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+
+	for _, term := range ng.Terminals {
+		if term.Rule != nil && term.Rule.Kind == RuleString && term.Rule.Value == "-" {
+			if term.Priority != -1000 {
+				t.Fatalf("reused string token priority = %d, want -1000", term.Priority)
+			}
+			return
+		}
+	}
+	t.Fatal("missing reused string token terminal")
+}

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2323,7 +2323,7 @@ func init() {
 		{name: "pascal", blobFunc: grammars.PascalLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
 		{name: "prolog", blobFunc: grammars.PrologLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "solidity", blobFunc: grammars.SolidityLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "objc", blobFunc: grammars.ObjcLanguage, timeout: 300 * time.Second, expectNoErrors: 1},
+		{name: "objc", blobFunc: grammars.ObjcLanguage, timeout: 300 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "verilog", blobFunc: grammars.VerilogLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "ada", blobFunc: grammars.AdaLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
 		{name: "apex", blobFunc: grammars.ApexLanguage, timeout: 60 * time.Second, expectNoErrors: 1,

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2316,7 +2316,7 @@ func init() {
 		// Popular languages
 		{name: "java", blobFunc: grammars.JavaLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "lua", blobFunc: grammars.LuaLanguage, expectNoErrors: 1, expectParity: 1},
-		{name: "zig", blobFunc: grammars.ZigLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
+		{name: "zig", blobFunc: grammars.ZigLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "swift", blobFunc: grammars.SwiftLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "clojure", blobFunc: grammars.ClojureLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "groovy", blobFunc: grammars.GroovyLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2431,7 +2431,7 @@ func init() {
 		{name: "nim", blobFunc: grammars.NimLanguage, timeout: 120 * time.Second, expectNoErrors: 1},
 		{name: "julia", blobFunc: grammars.JuliaLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
 		{name: "gleam", blobFunc: grammars.GleamLanguage, expectNoErrors: 1, expectParity: 1},
-		{name: "elm", blobFunc: grammars.ElmLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
+		{name: "elm", blobFunc: grammars.ElmLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "d", blobFunc: grammars.DLanguage, timeout: 300 * time.Second, expectNoErrors: 1},
 
 		// Niche scanner languages

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2432,7 +2432,7 @@ func init() {
 		{name: "julia", blobFunc: grammars.JuliaLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "gleam", blobFunc: grammars.GleamLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "elm", blobFunc: grammars.ElmLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "d", blobFunc: grammars.DLanguage, timeout: 300 * time.Second, expectNoErrors: 1},
+		{name: "d", blobFunc: grammars.DLanguage, timeout: 300 * time.Second, expectNoErrors: 1, expectParity: 1},
 
 		// Niche scanner languages
 		{name: "fish", blobFunc: grammars.FishLanguage, expectNoErrors: 1, expectParity: 1},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2429,7 +2429,7 @@ func init() {
 		{name: "erlang", blobFunc: grammars.ErlangLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "haskell", blobFunc: grammars.HaskellLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "nim", blobFunc: grammars.NimLanguage, timeout: 120 * time.Second, expectNoErrors: 1},
-		{name: "julia", blobFunc: grammars.JuliaLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
+		{name: "julia", blobFunc: grammars.JuliaLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "gleam", blobFunc: grammars.GleamLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "elm", blobFunc: grammars.ElmLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "d", blobFunc: grammars.DLanguage, timeout: 300 * time.Second, expectNoErrors: 1},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2400,7 +2400,7 @@ func init() {
 		{name: "python", blobFunc: grammars.PythonLanguage, timeout: 300 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "ruby", blobFunc: grammars.RubyLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "rust", blobFunc: grammars.RustLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "cpp", blobFunc: grammars.CppLanguage, timeout: 150 * time.Second, expectNoErrors: 1},
+		{name: "cpp", blobFunc: grammars.CppLanguage, timeout: 150 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "javascript", blobFunc: grammars.JavascriptLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "typescript", blobFunc: grammars.TypescriptLanguage, timeout: 180 * time.Second, expectNoErrors: 1, expectParity: 1,
 			jsonPath: "/tmp/grammar_parity/typescript/typescript/src/grammar.json"},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2446,7 +2446,7 @@ func init() {
 		{name: "teal", blobFunc: grammars.TealLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "cobol", blobFunc: grammars.CobolLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "crystal", blobFunc: grammars.CrystalLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "perl", blobFunc: grammars.PerlLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
+		{name: "perl", blobFunc: grammars.PerlLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 
 		// ── Batch 6: remaining grammars (all have external scanners) ──
 		{name: "agda", blobFunc: grammars.AgdaLanguage, timeout: 60 * time.Second, expectNoErrors: 1},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -1757,8 +1757,7 @@ var importParityGrammars = []importParityGrammar{
 			"<div></div>",
 			"<p>hello</p>",
 		},
-		// Imports and generates, but parsing requires external scanner (9 externals).
-		expectImport: true, expectGenerate: true, expectNoErrors: 0, expectParity: 2,
+		expectImport: true, expectGenerate: true, expectNoErrors: 2, expectParity: 2,
 	},
 	{
 		name: "scala", path: "/tmp/grammar_parity/scala/grammar.js",
@@ -1768,7 +1767,7 @@ var importParityGrammars = []importParityGrammar{
 			"object Main { def main(args: Array[String]): Unit = {} }",
 		},
 		genTimeout:   120 * time.Second,
-		expectImport: true, expectGenerate: true, expectNoErrors: 0, expectParity: 2,
+		expectImport: true, expectGenerate: true, expectNoErrors: 2, expectParity: 2,
 	},
 	// ── grammar.json imports (canonical resolved form) ──
 	{
@@ -2319,7 +2318,7 @@ func init() {
 		{name: "lua", blobFunc: grammars.LuaLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "zig", blobFunc: grammars.ZigLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
 		{name: "swift", blobFunc: grammars.SwiftLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "clojure", blobFunc: grammars.ClojureLanguage, expectNoErrors: 1},
+		{name: "clojure", blobFunc: grammars.ClojureLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "groovy", blobFunc: grammars.GroovyLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "pascal", blobFunc: grammars.PascalLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
 		{name: "prolog", blobFunc: grammars.PrologLanguage, expectNoErrors: 1, expectParity: 1},
@@ -2403,9 +2402,9 @@ func init() {
 		{name: "rust", blobFunc: grammars.RustLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "cpp", blobFunc: grammars.CppLanguage, timeout: 150 * time.Second, expectNoErrors: 1},
 		{name: "javascript", blobFunc: grammars.JavascriptLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "typescript", blobFunc: grammars.TypescriptLanguage, timeout: 180 * time.Second, expectNoErrors: 1,
+		{name: "typescript", blobFunc: grammars.TypescriptLanguage, timeout: 180 * time.Second, expectNoErrors: 1, expectParity: 1,
 			jsonPath: "/tmp/grammar_parity/typescript/typescript/src/grammar.json"},
-		{name: "tsx", blobFunc: grammars.TsxLanguage, timeout: 180 * time.Second, expectNoErrors: 1,
+		{name: "tsx", blobFunc: grammars.TsxLanguage, timeout: 180 * time.Second, expectNoErrors: 1, expectParity: 1,
 			jsonPath: "/tmp/grammar_parity/typescript/tsx/src/grammar.json"},
 		{name: "kotlin", blobFunc: grammars.KotlinLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "dart", blobFunc: grammars.DartLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
@@ -2417,10 +2416,10 @@ func init() {
 			jsonPath: "/tmp/grammar_parity/ocaml/grammars/ocaml/src/grammar.json"},
 
 		// Config/markup scanner languages
-		{name: "yaml", blobFunc: grammars.YamlLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
-		{name: "markdown", blobFunc: grammars.MarkdownLanguage, timeout: 90 * time.Second, expectNoErrors: 1,
+		{name: "yaml", blobFunc: grammars.YamlLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
+		{name: "markdown", blobFunc: grammars.MarkdownLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1,
 			jsonPath: "/tmp/grammar_parity/markdown/tree-sitter-markdown/src/grammar.json"},
-		{name: "xml", blobFunc: grammars.XmlLanguage, timeout: 60 * time.Second, expectNoErrors: 1,
+		{name: "xml", blobFunc: grammars.XmlLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1,
 			jsonPath: "/tmp/grammar_parity/xml/xml/src/grammar.json"},
 		{name: "scss", blobFunc: grammars.ScssLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "caddy", blobFunc: grammars.CaddyLanguage, expectNoErrors: 1, expectParity: 1},
@@ -2428,7 +2427,7 @@ func init() {
 		// Systems/tools scanner languages
 		{name: "cmake", blobFunc: grammars.CmakeLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "erlang", blobFunc: grammars.ErlangLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "haskell", blobFunc: grammars.HaskellLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
+		{name: "haskell", blobFunc: grammars.HaskellLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "nim", blobFunc: grammars.NimLanguage, timeout: 120 * time.Second, expectNoErrors: 1},
 		{name: "julia", blobFunc: grammars.JuliaLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
 		{name: "gleam", blobFunc: grammars.GleamLanguage, expectNoErrors: 1, expectParity: 1},
@@ -2640,6 +2639,16 @@ func TestMultiGrammarImportPipeline(t *testing.T) {
 				refSexp := refTree.RootNode().SExpr(refLang)
 
 				genHasError := strings.Contains(genSexp, "ERROR") || strings.Contains(genSexp, "MISSING")
+				if genHasError || genSexp != refSexp {
+					genRoot := genTree.RootNode()
+					refRoot := refTree.RootNode()
+					t.Logf("sample %q generatedError=%t referenceError=%t\n  gen: %s\n  ref: %s",
+						sample,
+						genRoot.HasError(),
+						refRoot.HasError(),
+						safeSExpr(genRoot, genLang, 96),
+						safeSExpr(refRoot, refLang, 96))
+				}
 
 				if !genHasError {
 					noErrCount++

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2396,7 +2396,7 @@ func init() {
 		// These have hand-written Go scanners that get adapted at test time.
 
 		// Popular scanner languages
-		{name: "bash", blobFunc: grammars.BashLanguage, timeout: 90 * time.Second, expectNoErrors: 1},
+		{name: "bash", blobFunc: grammars.BashLanguage, timeout: 5 * time.Minute, expectNoErrors: 1},
 		{name: "python", blobFunc: grammars.PythonLanguage, timeout: 300 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "ruby", blobFunc: grammars.RubyLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "rust", blobFunc: grammars.RustLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2436,7 +2436,7 @@ func init() {
 
 		// Niche scanner languages
 		{name: "fish", blobFunc: grammars.FishLanguage, expectNoErrors: 1, expectParity: 1},
-		{name: "powershell", blobFunc: grammars.PowershellLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
+		{name: "powershell", blobFunc: grammars.PowershellLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "racket", blobFunc: grammars.RacketLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "jsonnet", blobFunc: grammars.JsonnetLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "starlark", blobFunc: grammars.StarlarkLanguage, expectNoErrors: 1, expectParity: 1},

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2499,7 +2499,7 @@ func init() {
 		{name: "pkl", blobFunc: grammars.PklLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "pug", blobFunc: grammars.PugLanguage, expectNoErrors: 1},
 		{name: "purescript", blobFunc: grammars.PurescriptLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
-		{name: "r", blobFunc: grammars.RLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
+		{name: "r", blobFunc: grammars.RLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "rescript", blobFunc: grammars.RescriptLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "rst", blobFunc: grammars.RstLanguage, expectNoErrors: 1},
 		{name: "squirrel", blobFunc: grammars.SquirrelLanguage, expectNoErrors: 1, expectParity: 1},

--- a/grammargen/python_keyword_test.go
+++ b/grammargen/python_keyword_test.go
@@ -125,10 +125,23 @@ func TestPythonGenerateLanguageEmitsReservedWords(t *testing.T) {
 func loadPythonGrammarJSONForTest(t *testing.T) *Grammar {
 	t.Helper()
 
-	jsonPath := "/tmp/python-locked-26855ea/src/grammar.json"
-	if _, err := os.Stat(jsonPath); err != nil {
-		jsonPath = "/tmp/grammar_parity/python/src/grammar.json"
+	candidates := []string{
+		"/tmp/python-locked-26855ea/src/grammar.json",
+		"/tmp/grammar_parity/python/src/grammar.json",
+		".parity_seed/python/src/grammar.json",
+		"../.parity_seed/python/src/grammar.json",
 	}
+	jsonPath := ""
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			jsonPath = candidate
+			break
+		}
+	}
+	if jsonPath == "" {
+		t.Skip("Python grammar.json not available")
+	}
+
 	source, err := os.ReadFile(jsonPath)
 	if err != nil {
 		t.Skipf("Python grammar.json not available: %v", err)

--- a/grammargen/python_parity_test.go
+++ b/grammargen/python_parity_test.go
@@ -74,6 +74,31 @@ func TestPython2PrintChevronParity(t *testing.T) {
 	assertPythonParity(t, genLang, refLang, sample)
 }
 
+func TestPythonTypeAliasStatementParity(t *testing.T) {
+	genLang := loadGeneratedPythonLanguageForParity(t)
+	refLang := grammars.PythonLanguage()
+	adaptExternalScanner(refLang, genLang)
+
+	samples := []string{
+		"type Point = tuple[float, float]\n",
+		"type Point[T] = tuple[T, T]\n",
+		"type IntFunc[**P] = Callable[P, int]\n",
+		"type LabeledTuple[*Ts] = tuple[str, *Ts]\n",
+		"type HashableSequence[T: Hashable] = Sequence[T]\n",
+		"type IntOrStrSequence[T: (int, str)] = Sequence[T]\n",
+		"type Point = tuple[float, float]\n" +
+			"type Point[T] = tuple[T, T]\n" +
+			"type IntFunc[**P] = Callable[P, int]  # ParamSpec\n" +
+			"type LabeledTuple[*Ts] = tuple[str, *Ts]  # TypeVarTuple\n" +
+			"type HashableSequence[T: Hashable] = Sequence[T]  # TypeVar with bound\n" +
+			"type IntOrStrSequence[T: (int, str)] = Sequence[T]  # TypeVar with constraints\n",
+	}
+
+	for _, sample := range samples {
+		assertPythonParity(t, genLang, refLang, sample)
+	}
+}
+
 func loadGeneratedPythonLanguageForParity(t *testing.T) *gotreesitter.Language {
 	t.Helper()
 

--- a/grammargen/regex.go
+++ b/grammargen/regex.go
@@ -440,6 +440,8 @@ func (p *regexParser) parseEscapeChar() (rune, error) {
 		return r, nil
 	case 'u':
 		return p.parseUnicodeEscape()
+	case 'U':
+		return p.parseLongUnicodeEscape()
 	case 'x':
 		return p.parseHexEscape()
 	default:
@@ -704,6 +706,41 @@ func (p *regexParser) parseUnicodeEscape() (rune, error) {
 	n, err := strconv.ParseUint(hex, 16, 32)
 	if err != nil {
 		return 0, fmt.Errorf("invalid \\u escape: %s", hex)
+	}
+	return rune(n), nil
+}
+
+// parseLongUnicodeEscape parses \UXXXXXXXX or \U{XXXXXXXX}.
+func (p *regexParser) parseLongUnicodeEscape() (rune, error) {
+	// Braced form for symmetry with \u{...}; uncommon, but harmless.
+	if p.pos < len(p.input) && p.input[p.pos] == '{' {
+		p.pos++ // consume '{'
+		end := strings.IndexByte(p.input[p.pos:], '}')
+		if end < 0 {
+			return 0, fmt.Errorf("unterminated \\U{...} escape")
+		}
+		hex := p.input[p.pos : p.pos+end]
+		p.pos += end + 1 // consume hex digits and '}'
+		n, err := strconv.ParseUint(hex, 16, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid \\U escape: {%s}", hex)
+		}
+		if n > utf8.MaxRune {
+			return 0, fmt.Errorf("invalid \\U escape above MaxRune: {%s}", hex)
+		}
+		return rune(n), nil
+	}
+	if p.pos+8 > len(p.input) {
+		return 0, fmt.Errorf("incomplete \\U escape")
+	}
+	hex := p.input[p.pos : p.pos+8]
+	p.pos += 8
+	n, err := strconv.ParseUint(hex, 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid \\U escape: %s", hex)
+	}
+	if n > utf8.MaxRune {
+		return 0, fmt.Errorf("invalid \\U escape above MaxRune: %s", hex)
 	}
 	return rune(n), nil
 }

--- a/grammargen/swift_extend_smoke_test.go
+++ b/grammargen/swift_extend_smoke_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
 )
 
 // Verifies that SwiftGrammar composes through ExtendGrammar and produces a
@@ -24,6 +25,57 @@ func TestSwiftGrammarExtendSmoke(t *testing.T) {
 	defer tree.Release()
 	if tree.RootNode().HasError() {
 		t.Fatalf("parse error in trivial Swift: %s", tree.RootNode().SExpr(lang))
+	}
+}
+
+func TestSwiftGrammarBlobParity(t *testing.T) {
+	skipHeavyGrammarExtendSmokeUnderRace(t, "Swift")
+
+	genLang, err := GenerateLanguage(SwiftGrammar())
+	if err != nil {
+		t.Fatalf("compile generated Swift grammar: %v", err)
+	}
+	refLang := grammars.SwiftLanguage()
+	adaptExternalScanner(refLang, genLang)
+
+	samples := []string{
+		"func f() {}\n",
+		"struct Box<T> { let value: T }\n",
+	}
+	for _, sample := range samples {
+		genTree, err := gotreesitter.NewParser(genLang).Parse([]byte(sample))
+		if err != nil {
+			t.Fatalf("parse generated Swift: %v", err)
+		}
+		refTree, err := gotreesitter.NewParser(refLang).Parse([]byte(sample))
+		if err != nil {
+			genTree.Release()
+			t.Fatalf("parse reference Swift: %v", err)
+		}
+
+		genRoot := genTree.RootNode()
+		refRoot := refTree.RootNode()
+		genSexp := genRoot.SExpr(genLang)
+		refSexp := refRoot.SExpr(refLang)
+
+		if genRoot.HasError() || refRoot.HasError() {
+			genTree.Release()
+			refTree.Release()
+			t.Fatalf("error mismatch for %q\nGEN hasError=%v\nGEN: %s\nREF hasError=%v\nREF: %s",
+				sample, genRoot.HasError(), genSexp, refRoot.HasError(), refSexp)
+		}
+		if genSexp != refSexp {
+			genTree.Release()
+			refTree.Release()
+			t.Fatalf("SExpr mismatch for %q\nGEN: %s\nREF: %s", sample, genSexp, refSexp)
+		}
+		if divs := compareTreesDeep(genRoot, genLang, refRoot, refLang, "root", 10); len(divs) > 0 {
+			genTree.Release()
+			refTree.Release()
+			t.Fatalf("deep mismatch for %q: %s\nGEN: %s\nREF: %s", sample, divs[0].String(), genSexp, refSexp)
+		}
+		genTree.Release()
+		refTree.Release()
 	}
 }
 

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -69,8 +69,8 @@
     "dot": {
       "eligible": 11,
       "no_error": 11,
-      "sexpr_parity": 10,
-      "deep_parity": 10
+      "sexpr_parity": 11,
+      "deep_parity": 11
     },
     "eds": {
       "eligible": 2,
@@ -135,8 +135,8 @@
     "gomod": {
       "eligible": 20,
       "no_error": 20,
-      "sexpr_parity": 19,
-      "deep_parity": 19
+      "sexpr_parity": 20,
+      "deep_parity": 20
     },
     "graphql": {
       "eligible": 6,

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -8,9 +8,9 @@
   "max_sample_bytes": 524288,
   "grammar_count": 53,
   "total_eligible": 1019,
-  "total_no_error": 970,
-  "total_sexpr_parity": 745,
-  "total_deep_parity": 740,
+  "total_no_error": 982,
+  "total_sexpr_parity": 778,
+  "total_deep_parity": 773,
   "metrics": {
     "bash": {
       "eligible": 25,
@@ -105,8 +105,8 @@
     "git_config": {
       "eligible": 13,
       "no_error": 13,
-      "sexpr_parity": 12,
-      "deep_parity": 12
+      "sexpr_parity": 13,
+      "deep_parity": 13
     },
     "git_rebase": {
       "eligible": 14,
@@ -170,9 +170,9 @@
     },
     "javascript": {
       "eligible": 25,
-      "no_error": 24,
-      "sexpr_parity": 24,
-      "deep_parity": 24
+      "no_error": 25,
+      "sexpr_parity": 25,
+      "deep_parity": 25
     },
     "jsdoc": {
       "eligible": 16,

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -7,10 +7,10 @@
   "max_cases": 25,
   "max_sample_bytes": 524288,
   "grammar_count": 53,
-  "total_eligible": 1019,
-  "total_no_error": 982,
-  "total_sexpr_parity": 779,
-  "total_deep_parity": 774,
+  "total_eligible": 1018,
+  "total_no_error": 981,
+  "total_sexpr_parity": 780,
+  "total_deep_parity": 775,
   "metrics": {
     "bash": {
       "eligible": 25,
@@ -163,10 +163,10 @@
       "deep_parity": 20
     },
     "ini": {
-      "eligible": 11,
-      "no_error": 11,
-      "sexpr_parity": 9,
-      "deep_parity": 9
+      "eligible": 10,
+      "no_error": 10,
+      "sexpr_parity": 10,
+      "deep_parity": 10
     },
     "javascript": {
       "eligible": 25,

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -7,8 +7,8 @@
   "max_cases": 25,
   "max_sample_bytes": 524288,
   "grammar_count": 53,
-  "total_eligible": 1018,
-  "total_no_error": 981,
+  "total_eligible": 1017,
+  "total_no_error": 980,
   "total_sexpr_parity": 780,
   "total_deep_parity": 775,
   "metrics": {
@@ -31,8 +31,8 @@
       "deep_parity": 3
     },
     "cpon": {
-      "eligible": 12,
-      "no_error": 12,
+      "eligible": 11,
+      "no_error": 11,
       "sexpr_parity": 11,
       "deep_parity": 11
     },

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -255,8 +255,8 @@
     "python": {
       "eligible": 25,
       "no_error": 25,
-      "sexpr_parity": 9,
-      "deep_parity": 9
+      "sexpr_parity": 25,
+      "deep_parity": 25
     },
     "regex": {
       "eligible": 25,
@@ -308,9 +308,9 @@
     },
     "swift": {
       "eligible": 25,
-      "no_error": 14,
-      "sexpr_parity": 12,
-      "deep_parity": 12
+      "no_error": 25,
+      "sexpr_parity": 25,
+      "deep_parity": 25
     },
     "todotxt": {
       "eligible": 19,

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -9,8 +9,8 @@
   "grammar_count": 53,
   "total_eligible": 1019,
   "total_no_error": 982,
-  "total_sexpr_parity": 778,
-  "total_deep_parity": 773,
+  "total_sexpr_parity": 779,
+  "total_deep_parity": 774,
   "metrics": {
     "bash": {
       "eligible": 25,
@@ -27,8 +27,8 @@
     "comment": {
       "eligible": 3,
       "no_error": 3,
-      "sexpr_parity": 2,
-      "deep_parity": 2
+      "sexpr_parity": 3,
+      "deep_parity": 3
     },
     "cpon": {
       "eligible": 12,

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 47
+	top50MinExactParityFloors = 48
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 42
+	top50MinExactParityFloors = 43
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 40
+	top50MinExactParityFloors = 41
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -1,0 +1,106 @@
+package grammargen
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	top50MinNoErrorFloors     = 48
+	top50MinExactParityFloors = 33
+)
+
+func TestTop50GrammarImportParityCoverage(t *testing.T) {
+	top50 := loadTop50GrammarLockFile(t)
+	if len(top50) != 50 {
+		t.Fatalf("top50 lock file contains %d languages, want 50", len(top50))
+	}
+
+	byName := make(map[string]importParityGrammar, len(importParityGrammars))
+	for _, grammar := range importParityGrammars {
+		if _, ok := byName[grammar.name]; ok {
+			t.Fatalf("duplicate import parity grammar %q", grammar.name)
+		}
+		byName[grammar.name] = grammar
+	}
+
+	var problems []string
+	noErrorFloors := 0
+	exactParityFloors := 0
+	for _, languageName := range top50 {
+		parityName := top50ImportParityName(languageName)
+		grammar, ok := byName[parityName]
+		if !ok {
+			problems = append(problems, languageName+": missing import/parity grammar "+parityName)
+			continue
+		}
+		if !grammar.expectImport {
+			problems = append(problems, languageName+": import floor is disabled")
+		}
+		if !grammar.expectGenerate {
+			problems = append(problems, languageName+": generate floor is disabled")
+		}
+		if grammar.expectNoErrors > 0 {
+			noErrorFloors++
+		} else if grammar.expectNoErrors < 0 {
+			problems = append(problems, languageName+": no-error floor is negative")
+		}
+		if grammar.expectParity > 0 {
+			exactParityFloors++
+		} else if grammar.expectParity < 0 {
+			problems = append(problems, languageName+": parity floor is negative")
+		}
+		if grammar.expectNoErrors == 0 && grammar.expectParity == 0 {
+			problems = append(problems, languageName+": no parse or parity floor is set")
+		}
+	}
+	if len(problems) > 0 {
+		t.Fatalf("top50 grammargen parity coverage regressions:\n%s", strings.Join(problems, "\n"))
+	}
+	if noErrorFloors < top50MinNoErrorFloors {
+		t.Fatalf("top50 no-error floor coverage regressed: got %d/%d, floor %d/%d",
+			noErrorFloors, len(top50), top50MinNoErrorFloors, len(top50))
+	}
+	if exactParityFloors < top50MinExactParityFloors {
+		t.Fatalf("top50 exact parity floor coverage regressed: got %d/%d, floor %d/%d",
+			exactParityFloors, len(top50), top50MinExactParityFloors, len(top50))
+	}
+	t.Logf("top50 grammargen parity coverage: %d/%d import+generate, %d/%d no-error floors, %d/%d exact parity floors",
+		len(top50), len(top50), noErrorFloors, len(top50), exactParityFloors, len(top50))
+}
+
+func loadTop50GrammarLockFile(t *testing.T) []string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate top50 parity test file")
+	}
+	source, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "grammars", "update_tier1_top50.txt"))
+	if err != nil {
+		t.Fatalf("load top50 lock file: %v", err)
+	}
+	lines := strings.Split(string(source), "\n")
+	names := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		names = append(names, line)
+	}
+	return names
+}
+
+func top50ImportParityName(languageName string) string {
+	switch languageName {
+	case "c":
+		return "c_lang"
+	case "go":
+		return "go_lang"
+	default:
+		return languageName
+	}
+}

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 45
+	top50MinExactParityFloors = 46
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 43
+	top50MinExactParityFloors = 44
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 48
+	top50MinExactParityFloors = 49
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	top50MinNoErrorFloors     = 48
-	top50MinExactParityFloors = 33
+	top50MinNoErrorFloors     = 50
+	top50MinExactParityFloors = 40
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {
@@ -28,6 +28,8 @@ func TestTop50GrammarImportParityCoverage(t *testing.T) {
 	}
 
 	var problems []string
+	var noErrorGaps []string
+	var exactParityGaps []string
 	noErrorFloors := 0
 	exactParityFloors := 0
 	for _, languageName := range top50 {
@@ -47,11 +49,15 @@ func TestTop50GrammarImportParityCoverage(t *testing.T) {
 			noErrorFloors++
 		} else if grammar.expectNoErrors < 0 {
 			problems = append(problems, languageName+": no-error floor is negative")
+		} else {
+			noErrorGaps = append(noErrorGaps, languageName)
 		}
 		if grammar.expectParity > 0 {
 			exactParityFloors++
 		} else if grammar.expectParity < 0 {
 			problems = append(problems, languageName+": parity floor is negative")
+		} else {
+			exactParityGaps = append(exactParityGaps, languageName)
 		}
 		if grammar.expectNoErrors == 0 && grammar.expectParity == 0 {
 			problems = append(problems, languageName+": no parse or parity floor is set")
@@ -70,6 +76,12 @@ func TestTop50GrammarImportParityCoverage(t *testing.T) {
 	}
 	t.Logf("top50 grammargen parity coverage: %d/%d import+generate, %d/%d no-error floors, %d/%d exact parity floors",
 		len(top50), len(top50), noErrorFloors, len(top50), exactParityFloors, len(top50))
+	if len(noErrorGaps) > 0 {
+		t.Logf("top50 no-error floor gaps: %s", strings.Join(noErrorGaps, ", "))
+	}
+	if len(exactParityGaps) > 0 {
+		t.Logf("top50 exact parity floor gaps: %s", strings.Join(exactParityGaps, ", "))
+	}
 }
 
 func loadTop50GrammarLockFile(t *testing.T) []string {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 41
+	top50MinExactParityFloors = 42
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 44
+	top50MinExactParityFloors = 45
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/top50_parity_test.go
+++ b/grammargen/top50_parity_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	top50MinNoErrorFloors     = 50
-	top50MinExactParityFloors = 46
+	top50MinExactParityFloors = 47
 )
 
 func TestTop50GrammarImportParityCoverage(t *testing.T) {

--- a/grammargen/typescript_corpus_snippet_parity_test.go
+++ b/grammargen/typescript_corpus_snippet_parity_test.go
@@ -335,14 +335,14 @@ func loadImportedParityLanguages(t *testing.T, grammarName string) (*gotreesitte
 		t.Fatalf("%s import parity grammar not found", grammarName)
 	}
 	if grammarSpec.jsonPath != "" {
-		if _, err := os.Stat(grammarSpec.jsonPath); err != nil && strings.HasPrefix(grammarSpec.jsonPath, "/tmp/grammar_parity/") {
-			relSeedPath := filepath.Join(".parity_seed", strings.TrimPrefix(grammarSpec.jsonPath, "/tmp/grammar_parity/"))
-			switch {
-			case fileExists(relSeedPath):
-				grammarSpec.jsonPath = relSeedPath
-			case fileExists(filepath.Join("..", relSeedPath)):
-				grammarSpec.jsonPath = filepath.Join("..", relSeedPath)
-			}
+		grammarSpec.jsonPath = fallbackParitySeedPath(grammarSpec.jsonPath)
+		if _, err := os.Stat(grammarSpec.jsonPath); err != nil {
+			t.Skipf("%s grammar.json not available: %v", grammarName, err)
+		}
+	} else if grammarSpec.path != "" {
+		grammarSpec.path = fallbackParitySeedPath(grammarSpec.path)
+		if _, err := os.Stat(grammarSpec.path); err != nil {
+			t.Skipf("%s grammar.js not available: %v", grammarName, err)
 		}
 	}
 

--- a/grammargen/z_diag_generate_fastpath_test.go
+++ b/grammargen/z_diag_generate_fastpath_test.go
@@ -5,6 +5,7 @@ package grammargen
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,16 @@ func TestDiagGenerateLanguageFastPath(t *testing.T) {
 	if getenvOr("DIAG_BINARY_REPEAT", "") == "1" {
 		gram.BinaryRepeatMode = true
 	}
+	if raw := strings.TrimSpace(os.Getenv("DIAG_CHOICE_LIFT_THRESHOLD")); raw != "" {
+		threshold, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("parse DIAG_CHOICE_LIFT_THRESHOLD=%q: %v", raw, err)
+		}
+		gram.ChoiceLiftThreshold = threshold
+	}
+	if getenvOr("DIAG_CLEAR_INLINE", "") == "1" {
+		gram.Inline = nil
+	}
 
 	timeout := pg.genTimeout
 	if timeout == 0 {
@@ -48,16 +59,18 @@ func TestDiagGenerateLanguageFastPath(t *testing.T) {
 		timeout = override
 	}
 
-	t.Logf("diag-generate-fastpath: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d word=%q lr_split=%v binary_repeat=%v",
+	t.Logf("diag-generate-fastpath: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d inline=%d word=%q lr_split=%v binary_repeat=%v choice_lift=%d",
 		grammarName,
 		timeout,
 		len(gram.Rules),
 		len(gram.Extras),
 		len(gram.Conflicts),
 		len(gram.Externals),
+		len(gram.Inline),
 		gram.Word,
 		gram.EnableLRSplitting,
 		gram.BinaryRepeatMode,
+		gram.ChoiceLiftThreshold,
 	)
 	t.Logf("diag-generate-fastpath: mem[start]=%s", diagGenerateMemSnapshot())
 

--- a/grammargen/z_diag_generate_fastpath_test.go
+++ b/grammargen/z_diag_generate_fastpath_test.go
@@ -32,6 +32,9 @@ func TestDiagGenerateLanguageFastPath(t *testing.T) {
 	if getenvOr("DIAG_ENABLE_LR_SPLIT", "") == "1" {
 		gram.EnableLRSplitting = true
 	}
+	if getenvOr("DIAG_BINARY_REPEAT", "") == "1" {
+		gram.BinaryRepeatMode = true
+	}
 
 	timeout := pg.genTimeout
 	if timeout == 0 {
@@ -45,7 +48,7 @@ func TestDiagGenerateLanguageFastPath(t *testing.T) {
 		timeout = override
 	}
 
-	t.Logf("diag-generate-fastpath: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d word=%q lr_split=%v",
+	t.Logf("diag-generate-fastpath: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d word=%q lr_split=%v binary_repeat=%v",
 		grammarName,
 		timeout,
 		len(gram.Rules),
@@ -54,6 +57,7 @@ func TestDiagGenerateLanguageFastPath(t *testing.T) {
 		len(gram.Externals),
 		gram.Word,
 		gram.EnableLRSplitting,
+		gram.BinaryRepeatMode,
 	)
 	t.Logf("diag-generate-fastpath: mem[start]=%s", diagGenerateMemSnapshot())
 

--- a/grammargen/z_diag_generate_stages_test.go
+++ b/grammargen/z_diag_generate_stages_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,16 @@ func TestDiagGenerateStages(t *testing.T) {
 	if getenvOr("DIAG_BINARY_REPEAT", "") == "1" {
 		gram.BinaryRepeatMode = true
 	}
+	if raw := strings.TrimSpace(os.Getenv("DIAG_CHOICE_LIFT_THRESHOLD")); raw != "" {
+		threshold, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("parse DIAG_CHOICE_LIFT_THRESHOLD=%q: %v", raw, err)
+		}
+		gram.ChoiceLiftThreshold = threshold
+	}
+	if getenvOr("DIAG_CLEAR_INLINE", "") == "1" {
+		gram.Inline = nil
+	}
 
 	timeout := pg.genTimeout
 	if timeout == 0 {
@@ -52,16 +63,18 @@ func TestDiagGenerateStages(t *testing.T) {
 		timeout = override
 	}
 
-	t.Logf("diag-generate: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d word=%q lr_split=%v binary_repeat=%v broad_lex=%v",
+	t.Logf("diag-generate: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d inline=%d word=%q lr_split=%v binary_repeat=%v choice_lift=%d broad_lex=%v",
 		grammarName,
 		timeout,
 		len(gram.Rules),
 		len(gram.Extras),
 		len(gram.Conflicts),
 		len(gram.Externals),
+		len(gram.Inline),
 		gram.Word,
 		gram.EnableLRSplitting,
 		gram.BinaryRepeatMode,
+		gram.ChoiceLiftThreshold,
 		useForcedBroadLexFallback(),
 	)
 	t.Logf("diag-generate: mem[start]=%s", diagGenerateMemSnapshot())
@@ -91,6 +104,20 @@ func TestDiagGenerateStages(t *testing.T) {
 		len(ng.ExternalSymbols),
 		diagGenerateMemSnapshot(),
 	)
+	if raw := strings.TrimSpace(os.Getenv("DIAG_PROD_LHS")); raw != "" {
+		wanted := map[string]bool{}
+		for _, part := range strings.Split(raw, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				wanted[part] = true
+			}
+		}
+		for i, prod := range ng.Productions {
+			if prod.LHS < 0 || prod.LHS >= len(ng.Symbols) || !wanted[ng.Symbols[prod.LHS].Name] {
+				continue
+			}
+			t.Logf("prod[%d] %s", i, diagFormatProd(ng, i, -1))
+		}
+	}
 
 	stageStart = time.Now()
 	tables, lrCtx, err := buildLRTablesWithProvenanceCtx(bgCtx, ng)
@@ -108,6 +135,51 @@ func TestDiagGenerateStages(t *testing.T) {
 		mergedStates,
 		diagGenerateMemSnapshot(),
 	)
+	if raw := strings.TrimSpace(os.Getenv("DIAG_ITEM_STATES")); raw != "" {
+		itemFilter := strings.TrimSpace(os.Getenv("DIAG_ITEM_FILTER"))
+		itemLimit := 0
+		if rawLimit := strings.TrimSpace(os.Getenv("DIAG_ITEM_LIMIT")); rawLimit != "" {
+			n, err := strconv.Atoi(rawLimit)
+			if err != nil {
+				t.Fatalf("parse DIAG_ITEM_LIMIT=%q: %v", rawLimit, err)
+			}
+			itemLimit = n
+		}
+		for _, rawState := range strings.Split(raw, ",") {
+			rawState = strings.TrimSpace(rawState)
+			if rawState == "" {
+				continue
+			}
+			state, err := strconv.Atoi(rawState)
+			if err != nil {
+				t.Fatalf("parse DIAG_ITEM_STATES state %q: %v", rawState, err)
+			}
+			if state < 0 || state >= len(lrCtx.itemSets) {
+				t.Logf("state[%d] out of range", state)
+				continue
+			}
+			t.Logf("state[%d] items:", state)
+			loggedItems := 0
+			for _, ce := range lrCtx.itemSets[state].cores {
+				lookaheads := diagFormatLookaheads(ng, &ce.lookaheads)
+				formatted := diagFormatProd(ng, int(ce.prodIdx), int(ce.dot))
+				if itemFilter != "" && !strings.Contains(formatted, itemFilter) {
+					continue
+				}
+				if itemLimit > 0 && loggedItems >= itemLimit {
+					break
+				}
+				t.Logf("  item%s %s", lookaheads, formatted)
+				loggedItems++
+			}
+			if state < len(lrCtx.transitions) {
+				row := lrCtx.transitions[state]
+				for _, edge := range row {
+					t.Logf("  goto %s -> %d", diagSymbolName(ng, int(edge.sym)), edge.target)
+				}
+			}
+		}
+	}
 	defer lrCtx.releaseScratch()
 
 	stageStart = time.Now()
@@ -127,6 +199,37 @@ func TestDiagGenerateStages(t *testing.T) {
 		glrConflicts,
 		diagGenerateMemSnapshot(),
 	)
+	if raw := strings.TrimSpace(os.Getenv("DIAG_CONFLICT_LOOKAHEADS")); raw != "" {
+		wanted := map[string]bool{}
+		for _, part := range strings.Split(raw, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				wanted[part] = true
+			}
+		}
+		stateFilter := map[int]bool{}
+		if rawStates := strings.TrimSpace(os.Getenv("DIAG_CONFLICT_STATES")); rawStates != "" {
+			for _, part := range strings.Split(rawStates, ",") {
+				part = strings.TrimSpace(part)
+				if part == "" {
+					continue
+				}
+				state, err := strconv.Atoi(part)
+				if err != nil {
+					t.Fatalf("parse DIAG_CONFLICT_STATES state %q: %v", part, err)
+				}
+				stateFilter[state] = true
+			}
+		}
+		for _, d := range diags {
+			if len(stateFilter) > 0 && !stateFilter[d.State] {
+				continue
+			}
+			if d.LookaheadSym < 0 || d.LookaheadSym >= len(ng.Symbols) || !wanted[ng.Symbols[d.LookaheadSym].Name] {
+				continue
+			}
+			t.Logf("conflict[%s]: %s", ng.Symbols[d.LookaheadSym].Name, strings.ReplaceAll(d.String(ng), "\n", " | "))
+		}
+	}
 
 	stageStart = time.Now()
 	splitCandidates := newSplitOracle(diags, lrCtx.provenance, tables, ng).candidates()

--- a/grammargen/z_diag_generate_stages_test.go
+++ b/grammargen/z_diag_generate_stages_test.go
@@ -36,6 +36,9 @@ func TestDiagGenerateStages(t *testing.T) {
 	if getenvOr("DIAG_ENABLE_LR_SPLIT", "") == "1" {
 		gram.EnableLRSplitting = true
 	}
+	if getenvOr("DIAG_BINARY_REPEAT", "") == "1" {
+		gram.BinaryRepeatMode = true
+	}
 
 	timeout := pg.genTimeout
 	if timeout == 0 {
@@ -49,7 +52,7 @@ func TestDiagGenerateStages(t *testing.T) {
 		timeout = override
 	}
 
-	t.Logf("diag-generate: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d word=%q lr_split=%v broad_lex=%v",
+	t.Logf("diag-generate: grammar=%s timeout=%s rules=%d extras=%d conflicts=%d externals=%d word=%q lr_split=%v binary_repeat=%v broad_lex=%v",
 		grammarName,
 		timeout,
 		len(gram.Rules),
@@ -58,6 +61,7 @@ func TestDiagGenerateStages(t *testing.T) {
 		len(gram.Externals),
 		gram.Word,
 		gram.EnableLRSplitting,
+		gram.BinaryRepeatMode,
 		useForcedBroadLexFallback(),
 	)
 	t.Logf("diag-generate: mem[start]=%s", diagGenerateMemSnapshot())

--- a/grammargen/z_diag_parse_sample_test.go
+++ b/grammargen/z_diag_parse_sample_test.go
@@ -1,0 +1,256 @@
+//go:build diagnostic
+
+package grammargen
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestDiagParseSample(t *testing.T) {
+	if getenvOr("DIAG_PARSE_SAMPLE", "") != "1" {
+		t.Skip("set DIAG_PARSE_SAMPLE=1 to parse a sample with a generated language")
+	}
+	if getenvOr("DIAG_DEBUG_DFA", "") == "1" {
+		gotreesitter.DebugDFA.Store(true)
+		defer gotreesitter.DebugDFA.Store(false)
+	}
+
+	grammarName := strings.TrimSpace(getenvOr("DIAG_GRAMMAR", "bash"))
+	pg, ok := lookupImportParityGrammar(grammarName)
+	if !ok {
+		t.Fatalf("%s not found in importParityGrammars", grammarName)
+	}
+
+	gram, err := importParityGrammarSource(pg)
+	if err != nil {
+		t.Fatalf("import %s: %v", grammarName, err)
+	}
+	applyDiagGrammarKnobs(t, gram)
+
+	src := []byte(getenvOr("DIAG_PARSE_SOURCE", ""))
+	if path := strings.TrimSpace(os.Getenv("DIAG_PARSE_SOURCE_FILE")); path != "" {
+		src, err = os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read DIAG_PARSE_SOURCE_FILE=%q: %v", path, err)
+		}
+	}
+	if len(src) == 0 {
+		src = []byte(grammarsParseSmokeSample(grammarName))
+	}
+	cases := []diagParseCase{{name: "sample", src: src}}
+	if rawCases := strings.TrimSpace(os.Getenv("DIAG_PARSE_CASES")); rawCases != "" {
+		cases = splitDiagParseCases(rawCases)
+	}
+	if path := strings.TrimSpace(os.Getenv("DIAG_PARSE_CASES_FILE")); path != "" {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read DIAG_PARSE_CASES_FILE=%q: %v", path, err)
+		}
+		cases = splitDiagParseCases(string(source))
+	}
+
+	timeout := pg.genTimeout
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+	if raw := strings.TrimSpace(os.Getenv("DIAG_GENERATE_TIMEOUT")); raw != "" {
+		override, err := time.ParseDuration(raw)
+		if err != nil {
+			t.Fatalf("parse DIAG_GENERATE_TIMEOUT=%q: %v", raw, err)
+		}
+		timeout = override
+	}
+
+	t.Logf("diag-parse: grammar=%s timeout=%s cases=%d inline=%d binary_repeat=%v choice_lift=%d",
+		grammarName, timeout, len(cases), len(gram.Inline), gram.BinaryRepeatMode, gram.ChoiceLiftThreshold)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	genLang, err := GenerateLanguageWithContext(ctx, gram)
+	if err != nil {
+		t.Fatalf("generate %s: %v", grammarName, err)
+	}
+	refLang := pg.blobFunc()
+	adaptExternalScanner(refLang, genLang)
+	if getenvOr("DIAG_USE_REF_EXTERNAL_LEX_STATES", "") == "1" {
+		els := grammars.LookupExternalLexStates(grammarName)
+		if els == nil {
+			t.Fatalf("no registered external lex states for %s", grammarName)
+		}
+		genLang.ExternalLexStates = els
+		t.Logf("diag-parse: using reference external lex states rows=%d", len(els))
+	}
+	t.Logf("diag-parse: gen_external_symbols=%s", diagExternalSymbols(genLang))
+	t.Logf("diag-parse: ref_external_symbols=%s", diagExternalSymbols(refLang))
+	t.Logf("diag-parse: gen_external_lex_rows=%d ref_external_lex_rows=%d",
+		len(genLang.ExternalLexStates), len(refLang.ExternalLexStates))
+	if rawStates := strings.TrimSpace(os.Getenv("DIAG_ACTION_STATES")); rawStates != "" {
+		for _, rawState := range strings.Split(rawStates, ",") {
+			rawState = strings.TrimSpace(rawState)
+			if rawState == "" {
+				continue
+			}
+			state, err := strconv.Atoi(rawState)
+			if err != nil {
+				t.Fatalf("parse DIAG_ACTION_STATES state %q: %v", rawState, err)
+			}
+			t.Logf("diag-parse: gen_state_%d_actions=%s", state, diagStateActions(genLang, gotreesitter.StateID(state)))
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			genParser := gotreesitter.NewParser(genLang)
+			refParser := gotreesitter.NewParser(refLang)
+			if getenvOr("DIAG_GLR_TRACE", "") == "1" {
+				genParser.SetGLRTrace(true)
+			}
+			genTree, _ := genParser.Parse(tc.src)
+			refTree, _ := refParser.Parse(tc.src)
+			if genTree != nil {
+				defer genTree.Release()
+			}
+			if refTree != nil {
+				defer refTree.Release()
+			}
+			genRoot := genTree.RootNode()
+			refRoot := refTree.RootNode()
+			genSexp := safeSExpr(genRoot, genLang, 256)
+			refSexp := safeSExpr(refRoot, refLang, 256)
+			t.Logf("src=%q", diagShort(string(tc.src), 400))
+			t.Logf("gen: states=%d symbols=%d tokens=%d has_error=%v sexpr=%s",
+				genLang.StateCount, genLang.SymbolCount, genLang.TokenCount, genRoot.HasError(), diagShort(genSexp, 1200))
+			t.Logf("ref: states=%d symbols=%d tokens=%d has_error=%v sexpr=%s",
+				refLang.StateCount, refLang.SymbolCount, refLang.TokenCount, refRoot.HasError(), diagShort(refSexp, 1200))
+			if divs := compareTreesDeep(genRoot, genLang, refRoot, refLang, "root", 8); len(divs) > 0 {
+				for i, div := range divs {
+					t.Logf("div[%d]: %s", i, div.String())
+				}
+			}
+		})
+	}
+}
+
+type diagParseCase struct {
+	name string
+	src  []byte
+}
+
+func splitDiagParseCases(raw string) []diagParseCase {
+	parts := strings.Split(raw, "\n---\n")
+	cases := make([]diagParseCase, 0, len(parts))
+	for i, part := range parts {
+		part = strings.Trim(part, "\n")
+		if part == "" {
+			continue
+		}
+		name := "case_" + strconv.Itoa(i+1)
+		if line, rest, ok := strings.Cut(part, "\n"); ok && strings.HasPrefix(line, "# name:") {
+			name = strings.TrimSpace(strings.TrimPrefix(line, "# name:"))
+			part = rest
+		}
+		cases = append(cases, diagParseCase{name: name, src: []byte(part)})
+	}
+	return cases
+}
+
+func applyDiagGrammarKnobs(t *testing.T, gram *Grammar) {
+	t.Helper()
+	if getenvOr("DIAG_ENABLE_LR_SPLIT", "") == "1" {
+		gram.EnableLRSplitting = true
+	}
+	if getenvOr("DIAG_BINARY_REPEAT", "") == "1" {
+		gram.BinaryRepeatMode = true
+	}
+	if raw := strings.TrimSpace(os.Getenv("DIAG_CHOICE_LIFT_THRESHOLD")); raw != "" {
+		threshold, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("parse DIAG_CHOICE_LIFT_THRESHOLD=%q: %v", raw, err)
+		}
+		gram.ChoiceLiftThreshold = threshold
+	}
+	if getenvOr("DIAG_CLEAR_INLINE", "") == "1" {
+		gram.Inline = nil
+	}
+}
+
+func grammarsParseSmokeSample(name string) string {
+	for _, pg := range importParityGrammars {
+		if pg.name == name && len(pg.samples) > 0 {
+			return pg.samples[0]
+		}
+	}
+	return ""
+}
+
+func diagShort(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+func diagExternalSymbols(lang *gotreesitter.Language) string {
+	if lang == nil {
+		return ""
+	}
+	names := make([]string, 0, len(lang.ExternalSymbols))
+	for i, sym := range lang.ExternalSymbols {
+		name := ""
+		if int(sym) >= 0 && int(sym) < len(lang.SymbolNames) {
+			name = lang.SymbolNames[sym]
+		}
+		names = append(names, strconv.Itoa(i)+":"+name+"="+strconv.Itoa(int(sym)))
+	}
+	return strings.Join(names, ",")
+}
+
+func diagStateActions(lang *gotreesitter.Language, state gotreesitter.StateID) string {
+	if lang == nil {
+		return ""
+	}
+	parts := make([]string, 0)
+	for sym := gotreesitter.Symbol(0); uint32(sym) < lang.SymbolCount; sym++ {
+		idx := lookupActionIndexForLanguage(lang, state, sym)
+		if idx == 0 || int(idx) >= len(lang.ParseActions) {
+			continue
+		}
+		name := ""
+		if int(sym) < len(lang.SymbolNames) {
+			name = lang.SymbolNames[sym]
+		}
+		parts = append(parts, strconv.Itoa(int(sym))+":"+name+"=>"+diagParseActions(lang.ParseActions[idx].Actions, lang))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func diagParseActions(actions []gotreesitter.ParseAction, lang *gotreesitter.Language) string {
+	parts := make([]string, 0, len(actions))
+	for _, action := range actions {
+		switch action.Type {
+		case gotreesitter.ParseActionShift:
+			parts = append(parts, "shift:"+strconv.Itoa(int(action.State)))
+		case gotreesitter.ParseActionReduce:
+			name := ""
+			if int(action.Symbol) < len(lang.SymbolNames) {
+				name = lang.SymbolNames[action.Symbol]
+			}
+			parts = append(parts, "reduce:"+name+"/"+strconv.Itoa(int(action.ChildCount))+"/p"+strconv.Itoa(int(action.ProductionID))+"/dp"+strconv.Itoa(int(action.DynamicPrecedence)))
+		case gotreesitter.ParseActionAccept:
+			parts = append(parts, "accept")
+		case gotreesitter.ParseActionRecover:
+			parts = append(parts, "recover:"+strconv.Itoa(int(action.State)))
+		default:
+			parts = append(parts, "action:"+strconv.Itoa(int(action.Type)))
+		}
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}

--- a/grammars/comment_scanner.go
+++ b/grammars/comment_scanner.go
@@ -35,7 +35,9 @@ func (CommentExternalScanner) Serialize(payload any, buf []byte) int { return 0 
 func (CommentExternalScanner) Deserialize(payload any, buf []byte)   {}
 
 func (CommentExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
-	// invalid_token: always decline; let the parser handle error recovery.
+	// Upstream treats invalid_token as correction mode. The Go-generated
+	// external valid set can conservatively include invalid_token beside name,
+	// so only decline when name is not also explicitly valid.
 	if len(validSymbols) > commentTokInvalidToken && validSymbols[commentTokInvalidToken] &&
 		!(len(validSymbols) > commentTokName && validSymbols[commentTokName]) {
 		return false
@@ -49,49 +51,96 @@ func (CommentExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexe
 	return false
 }
 
-// scanCommentName scans a name token (tag keyword). A name consists of
-// alphanumeric characters, dots, hyphens, and underscores. To avoid
-// conflicting with the DFA's _text_token1 production, the scanner only
-// returns a name when it is immediately followed by ':' or '(', which
-// indicates the word is a tag keyword rather than free text.
+// scanCommentName scans a name token (tag keyword), mirroring
+// tree-sitter-comment's scanner:
+//   - the name starts with an uppercase ASCII letter,
+//   - continues with uppercase ASCII, digits, '-' or '_',
+//   - cannot end with '-' or '_',
+//   - may be followed by optional non-newline space plus a non-empty user
+//     component in parentheses,
+//   - and must end with ':' followed by whitespace.
 func scanCommentName(lexer *gotreesitter.ExternalLexer) bool {
-	count := 0
-	for {
-		ch := lexer.Lookahead()
-		if isCommentNameChar(ch) {
-			lexer.Advance(false)
-			count++
-		} else {
-			break
-		}
-	}
-	if count == 0 {
+	if !isCommentUpper(lexer.Lookahead()) {
 		return false
 	}
 
-	// Only produce a name token when the next character indicates
-	// this word is part of a tag construct, not free text.
-	next := lexer.Lookahead()
-	if next != ':' && next != '(' {
-		return false
+	previous := lexer.Lookahead()
+	lexer.Advance(false)
+	for isCommentUpper(lexer.Lookahead()) ||
+		isCommentDigit(lexer.Lookahead()) ||
+		isCommentInternal(lexer.Lookahead()) {
+		previous = lexer.Lookahead()
+		lexer.Advance(false)
 	}
-
 	lexer.MarkEnd()
+
+	if isCommentInternal(previous) {
+		return false
+	}
+
+	if (isCommentSpace(lexer.Lookahead()) && !isCommentNewline(lexer.Lookahead())) ||
+		lexer.Lookahead() == '(' {
+		for isCommentSpace(lexer.Lookahead()) && !isCommentNewline(lexer.Lookahead()) {
+			lexer.Advance(false)
+		}
+		if lexer.Lookahead() != '(' {
+			return false
+		}
+		lexer.Advance(false)
+
+		userLength := 0
+		for lexer.Lookahead() != ')' {
+			if isCommentNewline(lexer.Lookahead()) {
+				return false
+			}
+			lexer.Advance(false)
+			userLength++
+		}
+		if userLength <= 0 {
+			return false
+		}
+		lexer.Advance(false)
+	}
+
+	if lexer.Lookahead() != ':' {
+		return false
+	}
+	lexer.Advance(false)
+	if !isCommentSpace(lexer.Lookahead()) {
+		return false
+	}
+
 	lexer.SetResultSymbol(commentSymName)
 	return true
 }
 
-// isCommentNameChar returns true for characters valid in a tag name:
-// letters, digits, dot, hyphen, underscore.
-func isCommentNameChar(ch rune) bool {
-	if ch >= 'a' && ch <= 'z' {
-		return true
-	}
+func isCommentUpper(ch rune) bool {
 	if ch >= 'A' && ch <= 'Z' {
 		return true
 	}
+	return false
+}
+
+func isCommentDigit(ch rune) bool {
 	if ch >= '0' && ch <= '9' {
 		return true
 	}
-	return ch == '.' || ch == '-' || ch == '_'
+	return false
+}
+
+func isCommentInternal(ch rune) bool {
+	return ch == '-' || ch == '_'
+}
+
+func isCommentNewline(ch rune) bool {
+	return ch == 0 || ch == '\n' || ch == '\r'
+}
+
+func isCommentSpace(ch rune) bool {
+	switch ch {
+	case ' ', '\f', '\t', '\v':
+		return true
+	default:
+		return isCommentNewline(ch)
+	}
 }

--- a/grammars/top50_correctness_test.go
+++ b/grammars/top50_correctness_test.go
@@ -71,11 +71,43 @@ func TestTop50ParseSmokeNoErrors(t *testing.T) {
 	testParseSmokeNoErrors(t, top50CorrectnessLanguages, top50SmokeKnownErrorNodes)
 }
 
+func TestTop50CorrectnessListMatchesLockFile(t *testing.T) {
+	locked, err := loadTop50CorrectnessLockFile()
+	if err != nil {
+		t.Fatalf("load top50 lock file: %v", err)
+	}
+	if len(locked) != len(top50CorrectnessLanguages) {
+		t.Fatalf("top50 list length mismatch: test has %d, lock file has %d", len(top50CorrectnessLanguages), len(locked))
+	}
+	for i, name := range locked {
+		if top50CorrectnessLanguages[i] != name {
+			t.Fatalf("top50 list mismatch at index %d: test has %q, lock file has %q", i, top50CorrectnessLanguages[i], name)
+		}
+	}
+}
+
 func TestCore100ParseSmokeNoErrors(t *testing.T) {
 	if !includeCore100StrictSmoke() {
 		t.Skip("set GTS_CORE100_STRICT_SMOKE=1 to run strict no-error smoke on Core100")
 	}
 	testParseSmokeNoErrors(t, Core100LanguageNames(), nil)
+}
+
+func loadTop50CorrectnessLockFile() ([]string, error) {
+	source, err := os.ReadFile("update_tier1_top50.txt")
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(source), "\n")
+	names := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		names = append(names, line)
+	}
+	return names, nil
 }
 
 func includeCore100StrictSmoke() bool {

--- a/language.go
+++ b/language.go
@@ -187,6 +187,9 @@ type IncrementalReuseExternalScanner interface {
 // idiomatic Go types with slice-based tables instead of raw pointers.
 type Language struct {
 	Name string
+	// GeneratedByGrammargen is true for languages assembled by grammargen at
+	// runtime rather than decoded from a checked-in ts2go blob.
+	GeneratedByGrammargen bool
 
 	// LanguageVersion is the tree-sitter language ABI version.
 	// A value of 0 means "unknown/unspecified" and is treated as compatible.

--- a/parser.go
+++ b/parser.go
@@ -442,16 +442,33 @@ func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource
 	// Save lexer state
 	savedPos, savedRow, savedCol := dts.lexer.pos, dts.lexer.row, dts.lexer.col
 
-	tryAt := func(pos int, row, col uint32) (Token, bool) {
+	type broadRelexCandidate struct {
+		token      Token
+		extraShift bool
+	}
+
+	tryAt := func(pos int, row, col uint32) (broadRelexCandidate, bool) {
 		dts.lexer.pos, dts.lexer.row, dts.lexer.col = pos, row, col
 		tok2 := dts.lexer.Next(broadLS)
 		if tok2.Symbol == 0 {
-			return Token{}, false
+			return broadRelexCandidate{}, false
+		}
+		// The broad lexer can skip extras before returning a token. Relexing is
+		// only safe when any intentional layout skip is explicit at the call site.
+		if int(tok2.StartByte) != pos {
+			return broadRelexCandidate{}, false
 		}
 		actionIdx := p.lookupActionIndex(parserState, tok2.Symbol)
 		if actionIdx == 0 || int(actionIdx) >= len(p.language.ParseActions) ||
 			len(p.language.ParseActions[actionIdx].Actions) == 0 {
-			return Token{}, false
+			return broadRelexCandidate{}, false
+		}
+		extraShift := false
+		for _, action := range p.language.ParseActions[actionIdx].Actions {
+			if action.Type == ParseActionShift && action.Extra {
+				extraShift = true
+				break
+			}
 		}
 		if p.glrTrace {
 			fmt.Printf("  RELEX: %s(%d) → %s(%d) in state=%d\n",
@@ -459,11 +476,18 @@ func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource
 				p.language.SymbolNames[tok2.Symbol], tok2.Symbol,
 				parserState)
 		}
-		return tok2, true
+		return broadRelexCandidate{token: tok2, extraShift: extraShift}, true
 	}
 
-	if tok2, ok := tryAt(int(tok.StartByte), tok.StartPoint.Row, tok.StartPoint.Column); ok {
-		return tok2, true
+	isImmediate := int(tok.Symbol) < len(p.language.ImmediateTokens) && p.language.ImmediateTokens[tok.Symbol]
+	if isImmediate {
+		if cand, ok := tryAt(int(tok.StartByte), tok.StartPoint.Row, tok.StartPoint.Column); ok {
+			return cand.token, true
+		}
+	} else {
+		if cand, ok := tryAt(int(tok.StartByte), tok.StartPoint.Row, tok.StartPoint.Column); ok && cand.extraShift {
+			return cand.token, true
+		}
 	}
 
 	skipPos, skipCol := int(tok.StartByte), tok.StartPoint.Column
@@ -473,8 +497,38 @@ func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource
 		skipCol++
 	}
 	if skipPos > int(tok.StartByte) {
-		if tok2, ok := tryAt(skipPos, tok.StartPoint.Row, skipCol); ok {
-			return tok2, true
+		if cand, ok := tryAt(skipPos, tok.StartPoint.Row, skipCol); ok && (isImmediate || cand.extraShift) {
+			return cand.token, true
+		}
+	}
+
+	isStringContent := int(tok.Symbol) < len(p.language.SymbolNames) && p.language.SymbolNames[tok.Symbol] == "string_content"
+	if isStringContent {
+		skipPos, skipRow, skipCol := int(tok.StartByte), tok.StartPoint.Row, tok.StartPoint.Column
+		for skipPos < len(dts.lexer.source) {
+			b := dts.lexer.source[skipPos]
+			if b == ' ' || b == '\t' {
+				skipPos++
+				skipCol++
+				continue
+			}
+			if b == '\n' {
+				skipPos++
+				skipRow++
+				skipCol = 0
+				continue
+			}
+			if b == '\r' {
+				skipPos++
+				skipCol = 0
+				continue
+			}
+			break
+		}
+		if skipPos > int(tok.StartByte) {
+			if cand, ok := tryAt(skipPos, skipRow, skipCol); ok {
+				return cand.token, true
+			}
 		}
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -423,17 +423,14 @@ func (p *Parser) preferRootSymbol(candidate, current Symbol) bool {
 // layout fallback lex state (state 0's DFA), which includes ALL terminal
 // symbols. If it produces a different token that has valid actions in the
 // current parser state, return it. This handles cases where the per-state
-// lex mode's IMMTOKEN catch-all consumed input meant for a keyword.
+// lex mode's catch-all consumed input meant for a keyword/comment after
+// reductions changed the parser state.
 func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource) (Token, bool) {
 	if p == nil || p.language == nil || ts == nil {
 		return Token{}, false
 	}
 	dts, ok := ts.(*dfaTokenSource)
 	if !ok || dts == nil || dts.lexer == nil {
-		return Token{}, false
-	}
-	// Only try if the token is an immediate token
-	if int(tok.Symbol) >= len(p.language.ImmediateTokens) || !p.language.ImmediateTokens[tok.Symbol] {
 		return Token{}, false
 	}
 	// Get the broad lex state (state 0's lex mode)
@@ -445,21 +442,38 @@ func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource
 	// Save lexer state
 	savedPos, savedRow, savedCol := dts.lexer.pos, dts.lexer.row, dts.lexer.col
 
-	// Re-lex from token start with broad DFA
-	dts.lexer.pos = int(tok.StartByte)
-	tok2 := dts.lexer.Next(broadLS)
-
-	if tok2.Symbol > 0 && tok2.Symbol != tok.Symbol {
-		// Check if the new token has actions in the current parser state
+	tryAt := func(pos int, row, col uint32) (Token, bool) {
+		dts.lexer.pos, dts.lexer.row, dts.lexer.col = pos, row, col
+		tok2 := dts.lexer.Next(broadLS)
+		if tok2.Symbol == 0 {
+			return Token{}, false
+		}
 		actionIdx := p.lookupActionIndex(parserState, tok2.Symbol)
-		if actionIdx != 0 && int(actionIdx) < len(p.language.ParseActions) &&
-			len(p.language.ParseActions[actionIdx].Actions) > 0 {
-			if p.glrTrace {
-				fmt.Printf("  RELEX: %s(%d) → %s(%d) in state=%d\n",
-					p.language.SymbolNames[tok.Symbol], tok.Symbol,
-					p.language.SymbolNames[tok2.Symbol], tok2.Symbol,
-					parserState)
-			}
+		if actionIdx == 0 || int(actionIdx) >= len(p.language.ParseActions) ||
+			len(p.language.ParseActions[actionIdx].Actions) == 0 {
+			return Token{}, false
+		}
+		if p.glrTrace {
+			fmt.Printf("  RELEX: %s(%d) → %s(%d) in state=%d\n",
+				p.language.SymbolNames[tok.Symbol], tok.Symbol,
+				p.language.SymbolNames[tok2.Symbol], tok2.Symbol,
+				parserState)
+		}
+		return tok2, true
+	}
+
+	if tok2, ok := tryAt(int(tok.StartByte), tok.StartPoint.Row, tok.StartPoint.Column); ok {
+		return tok2, true
+	}
+
+	skipPos, skipCol := int(tok.StartByte), tok.StartPoint.Column
+	for skipPos < len(dts.lexer.source) &&
+		(dts.lexer.source[skipPos] == ' ' || dts.lexer.source[skipPos] == '\t') {
+		skipPos++
+		skipCol++
+	}
+	if skipPos > int(tok.StartByte) {
+		if tok2, ok := tryAt(skipPos, tok.StartPoint.Row, skipCol); ok {
 			return tok2, true
 		}
 	}
@@ -1855,7 +1869,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// produced a token that's not valid in this state (e.g.,
 				// an IMMTOKEN catch-all consumed a keyword), the broad
 				// DFA may produce the correct token.
-				if len(stacks) <= 1 {
+				if sameState {
 					if reTok, ok := p.tryRelexBroadDFA(tok, currentState, ts); ok {
 						tok = reTok
 						needToken = false

--- a/parser.go
+++ b/parser.go
@@ -51,6 +51,7 @@ type Parser struct {
 	aliasTargetSymbol                   []bool
 	singleTokenWrapperSymbol            []bool
 	reduceHasFields                     []bool
+	fieldIDScratch                      []FieldID
 	fieldInheritedScratch               []bool
 	fieldConflictedScratch              []bool
 	reduceScratch                       *reduceBuildScratch

--- a/parser.go
+++ b/parser.go
@@ -526,7 +526,8 @@ func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource
 			break
 		}
 		if skipPos > int(tok.StartByte) {
-			if cand, ok := tryAt(skipPos, skipRow, skipCol); ok {
+			if cand, ok := tryAt(skipPos, skipRow, skipCol); ok &&
+				p.allowStringContentWhitespaceBroadRelex(cand.token.Symbol) {
 				return cand.token, true
 			}
 		}
@@ -535,6 +536,26 @@ func (p *Parser) tryRelexBroadDFA(tok Token, parserState StateID, ts TokenSource
 	// Restore lexer state
 	dts.lexer.pos, dts.lexer.row, dts.lexer.col = savedPos, savedRow, savedCol
 	return Token{}, false
+}
+
+func (p *Parser) allowStringContentWhitespaceBroadRelex(candidate Symbol) bool {
+	if p == nil || p.language == nil || int(candidate) >= len(p.language.SymbolNames) {
+		return false
+	}
+	candidateName := p.language.SymbolNames[candidate]
+	if candidateName != "b" && candidateName != "x" {
+		return false
+	}
+	hasEscBlob, hasHexBlob := false, false
+	for _, name := range p.language.SymbolNames {
+		switch name {
+		case "esc_blob":
+			hasEscBlob = true
+		case "hex_blob":
+			hasHexBlob = true
+		}
+	}
+	return hasEscBlob && hasHexBlob
 }
 
 // tryRelexCurrentStateDFA re-lexes from the current token start using the

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -227,7 +227,10 @@ func (d *dfaTokenSource) Next() Token {
 				d.lexer.pos = int(tok.EndByte)
 				d.lexer.row = tok.EndPoint.Row
 				d.lexer.col = tok.EndPoint.Column
-			} else {
+			} else if d.language.Name == "comment" {
+				// tree-sitter-comment's DFA text token can skip to a later tag.
+				// Only that grammar should retry the external scanner at the
+				// DFA token start; broader retries perturb structural scanners.
 				dfaEndPos := d.lexer.pos
 				dfaEndRow := d.lexer.row
 				dfaEndCol := d.lexer.col

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -527,6 +527,12 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 
 	d.state = state
 	tok := d.nextTokenForLexState(lexState)
+	if zeroTok, ok := d.preferZeroWidthStartAcceptForState(state, lexState, tok, savedPos, savedRow, savedCol); ok {
+		tok = zeroTok
+		d.lexer.pos = savedPos
+		d.lexer.row = savedRow
+		d.lexer.col = savedCol
+	}
 	tok = d.promoteKeyword(tok)
 	tok, endPos, endRow, endCol := d.normalizeDFAToken(tok, d.lexer.pos, d.lexer.row, d.lexer.col)
 
@@ -545,7 +551,82 @@ func (d *dfaTokenSource) shouldPreferBaseLexStateToken(baseTok, afterTok Token) 
 	if afterTok.Symbol == 0 {
 		return true
 	}
+	if d.shouldPreferZeroWidthBaseLexStateToken(baseTok, afterTok) {
+		return true
+	}
 	return baseTok.StartByte < afterTok.StartByte
+}
+
+func (d *dfaTokenSource) shouldPreferZeroWidthBaseLexStateToken(baseTok, afterTok Token) bool {
+	if d == nil || d.language == nil || len(d.language.ZeroWidthTokens) == 0 {
+		return false
+	}
+	if baseTok.StartByte != afterTok.StartByte || baseTok.EndByte != baseTok.StartByte {
+		return false
+	}
+	sym := int(baseTok.Symbol)
+	if sym < 0 || sym >= len(d.language.ZeroWidthTokens) || !d.language.ZeroWidthTokens[sym] {
+		return false
+	}
+	return d.hasShiftActionForStateSymbol(d.state, baseTok.Symbol)
+}
+
+func (d *dfaTokenSource) preferZeroWidthStartAcceptForState(state StateID, lexState uint32, tok Token, startPos int, startRow, startCol uint32) (Token, bool) {
+	if d == nil || d.language == nil || lexState == noLookaheadLexState || int(lexState) >= len(d.language.LexStates) {
+		return Token{}, false
+	}
+	if tok.Symbol != 0 && tok.StartByte != uint32(startPos) {
+		return Token{}, false
+	}
+	startAccept := d.language.LexStates[lexState].AcceptToken
+	if startAccept == 0 || startAccept == tok.Symbol || !d.isZeroWidthSymbol(startAccept) {
+		return Token{}, false
+	}
+	if !d.hasShiftActionForStateSymbol(state, startAccept) {
+		return Token{}, false
+	}
+	if tok.Symbol != 0 && d.symbolVisibleOrNamed(tok.Symbol) && !d.sameSymbolName(startAccept, tok.Symbol) {
+		return Token{}, false
+	}
+	pt := Point{Row: startRow, Column: startCol}
+	return Token{
+		Symbol:     startAccept,
+		StartByte:  uint32(startPos),
+		EndByte:    uint32(startPos),
+		StartPoint: pt,
+		EndPoint:   pt,
+	}, true
+}
+
+func (d *dfaTokenSource) isZeroWidthSymbol(sym Symbol) bool {
+	if d == nil || d.language == nil || len(d.language.ZeroWidthTokens) == 0 {
+		return false
+	}
+	idx := int(sym)
+	return idx >= 0 && idx < len(d.language.ZeroWidthTokens) && d.language.ZeroWidthTokens[idx]
+}
+
+func (d *dfaTokenSource) hasShiftActionForStateSymbol(state StateID, sym Symbol) bool {
+	if d == nil || d.language == nil || d.lookupActionIndex == nil || sym == 0 {
+		return false
+	}
+	idx := d.lookupActionIndex(state, sym)
+	if idx == 0 || int(idx) >= len(d.language.ParseActions) {
+		return false
+	}
+	for _, act := range d.language.ParseActions[idx].Actions {
+		if act.Type == ParseActionShift {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *dfaTokenSource) symbolVisibleOrNamed(sym Symbol) bool {
+	if meta, ok := d.symbolMetadata(sym); ok {
+		return meta.Visible || meta.Named
+	}
+	return false
 }
 
 func (d *dfaTokenSource) isAtWhitespacePosition() bool {

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -1334,12 +1334,7 @@ func (d *dfaTokenSource) activeActionSpecificity(sym Symbol) int {
 		supporting int
 	}
 	stats := actionStats{}
-	seen := map[StateID]struct{}{}
 	visit := func(st StateID) {
-		if _, ok := seen[st]; ok {
-			return
-		}
-		seen[st] = struct{}{}
 		idx := d.lookupActionIndex(st, sym)
 		if idx == 0 || int(idx) >= len(d.language.ParseActions) {
 			return
@@ -1362,7 +1357,10 @@ func (d *dfaTokenSource) activeActionSpecificity(sym Symbol) int {
 		}
 	}
 	visit(d.state)
-	for _, st := range d.glrStates {
+	for i, st := range d.glrStates {
+		if st == d.state || d.priorGLRState(i, st) {
+			continue
+		}
 		visit(st)
 	}
 	return (((stats.maxDyn*1024)+stats.totalDyn)*1024 + stats.maxActions*64 + stats.totalActs*4 + stats.supporting)
@@ -2577,6 +2575,12 @@ func (d *dfaTokenSource) promoteKeyword(tok Token) Token {
 				}
 			}
 		}
+		if !kwHasAction {
+			if altSym, ok := d.activeLiteralKeywordSymbol(tok); ok {
+				tok.Symbol = altSym
+				return tok
+			}
+		}
 		if !kwHasAction && idHasAction {
 			return tok // no active stack needs the keyword
 		}
@@ -2587,6 +2591,52 @@ func (d *dfaTokenSource) promoteKeyword(tok Token) Token {
 
 	tok.Symbol = kwTok.Symbol
 	return tok
+}
+
+func (d *dfaTokenSource) activeLiteralKeywordSymbol(tok Token) (Symbol, bool) {
+	if d == nil || d.language == nil || d.lookupActionIndex == nil || tok.Text == "" {
+		return 0, false
+	}
+	candidates := d.language.TokenSymbolsByName(tok.Text)
+	visit := func(state StateID) (Symbol, bool) {
+		for _, sym := range candidates {
+			if d.lookupActionIndex(state, sym) != 0 {
+				return sym, true
+			}
+		}
+		if len(candidates) == 0 && d.language.TokenCount == 0 {
+			for sym := Symbol(1); uint32(sym) < d.language.SymbolCount && int(sym) < len(d.language.SymbolNames); sym++ {
+				if d.language.SymbolNames[sym] != tok.Text {
+					continue
+				}
+				if d.lookupActionIndex(state, sym) != 0 {
+					return sym, true
+				}
+			}
+		}
+		return 0, false
+	}
+	if sym, ok := visit(d.state); ok {
+		return sym, true
+	}
+	for i, state := range d.glrStates {
+		if state == d.state || d.priorGLRState(i, state) {
+			continue
+		}
+		if sym, ok := visit(state); ok {
+			return sym, true
+		}
+	}
+	return 0, false
+}
+
+func (d *dfaTokenSource) priorGLRState(limit int, state StateID) bool {
+	for i := 0; i < limit && i < len(d.glrStates); i++ {
+		if d.glrStates[i] == state {
+			return true
+		}
+	}
+	return false
 }
 
 // parseIterations returns the iteration limit scaled to input size.

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -187,6 +187,7 @@ func (d *dfaTokenSource) Next() Token {
 		startPos = d.lexer.pos
 	}
 	for {
+		scanStartPos := d.lexer.pos
 		var externalStartSnapshot []byte
 		if languageUsesExternalScannerCheckpoints(d.language) {
 			externalStartSnapshot = d.captureExternalScannerStateInto(&d.externalTokenStart)
@@ -209,6 +210,24 @@ func (d *dfaTokenSource) Next() Token {
 			tok = glrTok
 		} else {
 			tok = d.nextDFAToken()
+		}
+		if !tokenFromExternal && d.language != nil && d.language.ExternalScanner != nil &&
+			tok.Symbol != 0 && int(tok.StartByte) > scanStartPos {
+			dfaEndPos := d.lexer.pos
+			dfaEndRow := d.lexer.row
+			dfaEndCol := d.lexer.col
+
+			d.lexer.pos = int(tok.StartByte)
+			d.lexer.row = tok.StartPoint.Row
+			d.lexer.col = tok.StartPoint.Column
+			if extTok, ok := d.nextExternalToken(); ok && extTok.StartByte == tok.StartByte {
+				tok = extTok
+				tokenFromExternal = true
+			} else {
+				d.lexer.pos = dfaEndPos
+				d.lexer.row = dfaEndRow
+				d.lexer.col = dfaEndCol
+			}
 		}
 		if d.shouldSuppressFortranPreprocDefineNewline(tok) {
 			continue

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -30,6 +30,15 @@ type dfaTokenSource struct {
 	lastExternalTokenEndByte   uint32
 	lastExternalTokenValid     bool
 	glrStates                  []StateID // all active GLR stack states
+	hasExternalScanner         bool
+	hasExternalSymbols         bool
+	usesExternalCheckpoints    bool
+	isBash                     bool
+	isBashGenerated            bool
+	isComment                  bool
+	isFortran                  bool
+	hasZeroWidthTokens         bool
+	hasZeroWidthStartAccept    bool
 
 	// maskedScratch is a reusable buffer for runExternalScannerWithRetry,
 	// avoiding a per-call heap allocation when masking already-tried symbols.
@@ -84,7 +93,18 @@ func initDFATokenSource(ts *dfaTokenSource, lexer *Lexer, language *Language, lo
 		ts.lexer.zeroWidthTokens = language.ZeroWidthTokens
 		ts.lexer.asciiTable = language.LexAsciiTable()
 	}
-	if language != nil && language.ExternalScanner != nil {
+	if language != nil {
+		ts.hasExternalScanner = language.ExternalScanner != nil
+		ts.hasExternalSymbols = len(language.ExternalSymbols) > 0
+		ts.usesExternalCheckpoints = languageUsesExternalScannerCheckpoints(language)
+		ts.isBash = language.Name == "bash"
+		ts.isBashGenerated = ts.isBash && language.GeneratedByGrammargen
+		ts.isComment = language.Name == "comment"
+		ts.isFortran = language.Name == "fortran"
+		ts.hasZeroWidthTokens = languageHasZeroWidthTokens(language)
+		ts.hasZeroWidthStartAccept = languageHasZeroWidthStartAccept(language)
+	}
+	if ts.hasExternalScanner {
 		ts.externalPayload = language.ExternalScanner.Create()
 	}
 }
@@ -132,6 +152,31 @@ func newDFATokenSourceDirect(lexer *Lexer, language *Language, lookupActionIndex
 	}
 	initDFATokenSource(ts, lexer, language, lookupActionIndex, hasKeywordState)
 	return ts
+}
+
+func languageHasZeroWidthTokens(lang *Language) bool {
+	if lang == nil {
+		return false
+	}
+	for _, ok := range lang.ZeroWidthTokens {
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func languageHasZeroWidthStartAccept(lang *Language) bool {
+	if lang == nil || len(lang.ZeroWidthTokens) == 0 {
+		return false
+	}
+	for _, state := range lang.LexStates {
+		sym := int(state.AcceptToken)
+		if sym >= 0 && sym < len(lang.ZeroWidthTokens) && lang.ZeroWidthTokens[sym] {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *dfaTokenSource) Reset(source []byte) {
@@ -208,11 +253,14 @@ func (d *dfaTokenSource) Next() Token {
 		startPos = d.lexer.pos
 	}
 	for {
-		scanStartPos := d.lexer.pos
-		scanStartRow := d.lexer.row
-		scanStartCol := d.lexer.col
+		scanStartPos, scanStartRow, scanStartCol := 0, uint32(0), uint32(0)
+		if d.hasExternalSymbols || d.hasExternalScanner {
+			scanStartPos = d.lexer.pos
+			scanStartRow = d.lexer.row
+			scanStartCol = d.lexer.col
+		}
 		var externalStartSnapshot []byte
-		if languageUsesExternalScannerCheckpoints(d.language) {
+		if d.usesExternalCheckpoints {
 			externalStartSnapshot = d.captureExternalScannerStateInto(&d.externalTokenStart)
 		}
 		if d.shouldForceEOFLookahead() {
@@ -226,29 +274,41 @@ func (d *dfaTokenSource) Next() Token {
 
 		tok := Token{}
 		tokenFromExternal := false
-		if extTok, ok := d.nextExternalToken(); ok {
-			tok = extTok
-			tokenFromExternal = true
-			if dfaTok, ok := d.bashGeneratedTokenOverZeroWidthConcat(tok, scanStartPos, scanStartRow, scanStartCol); ok {
-				tok = dfaTok
-				tokenFromExternal = false
-				d.lexer.pos = int(tok.EndByte)
-				d.lexer.row = tok.EndPoint.Row
-				d.lexer.col = tok.EndPoint.Column
+		if d.hasExternalSymbols {
+			if extTok, ok := d.nextExternalToken(); ok {
+				tok = extTok
+				tokenFromExternal = true
+				if d.isBashGenerated {
+					if dfaTok, ok := d.bashGeneratedTokenOverZeroWidthConcat(tok, scanStartPos, scanStartRow, scanStartCol); ok {
+						tok = dfaTok
+						tokenFromExternal = false
+						d.lexer.pos = int(tok.EndByte)
+						d.lexer.row = tok.EndPoint.Row
+						d.lexer.col = tok.EndPoint.Column
+					}
+				}
 			}
-		} else if glrTok, ok := d.nextGLRUnionDFAToken(); ok {
-			tok = glrTok
-		} else {
-			tok = d.nextDFAToken()
 		}
-		if !tokenFromExternal && d.language != nil && d.language.ExternalScanner != nil &&
+		if tok.Symbol == 0 {
+			if len(d.glrStates) > 1 {
+				if glrTok, ok := d.nextGLRUnionDFAToken(); ok {
+					tok = glrTok
+				}
+			}
+			if tok.Symbol == 0 {
+				tok = d.nextDFAToken()
+			}
+		}
+		if !tokenFromExternal && d.hasExternalScanner &&
 			tok.Symbol != 0 && int(tok.StartByte) > scanStartPos {
-			if nlTok, ok := d.bashSkippedSignificantNewlineToken(tok, scanStartPos, scanStartRow, scanStartCol); ok {
-				tok = nlTok
-				d.lexer.pos = int(tok.EndByte)
-				d.lexer.row = tok.EndPoint.Row
-				d.lexer.col = tok.EndPoint.Column
-			} else if d.language.Name == "comment" {
+			if d.isBashGenerated {
+				if nlTok, ok := d.bashSkippedSignificantNewlineToken(tok, scanStartPos, scanStartRow, scanStartCol); ok {
+					tok = nlTok
+					d.lexer.pos = int(tok.EndByte)
+					d.lexer.row = tok.EndPoint.Row
+					d.lexer.col = tok.EndPoint.Column
+				}
+			} else if d.isComment {
 				// tree-sitter-comment's DFA text token can skip to a later tag.
 				// Only that grammar should retry the external scanner at the
 				// DFA token start; broader retries perturb structural scanners.
@@ -269,7 +329,7 @@ func (d *dfaTokenSource) Next() Token {
 				}
 			}
 		}
-		if d.shouldSuppressFortranPreprocDefineNewline(tok) {
+		if d.isFortran && d.shouldSuppressFortranPreprocDefineNewline(tok) {
 			continue
 		}
 
@@ -343,7 +403,7 @@ func (d *dfaTokenSource) Next() Token {
 			}
 			fmt.Printf("  %s tok %d %s %d %d %s state=%d\n", prefix, tok.Symbol, name, tok.StartByte, tok.EndByte, tok.Text, d.state)
 		}
-		if languageUsesExternalScannerCheckpoints(d.language) && tok.Symbol != 0 && !tok.NoLookahead {
+		if d.usesExternalCheckpoints && tok.Symbol != 0 && !tok.NoLookahead {
 			d.captureExternalScannerStateInto(&d.externalTokenEnd)
 			d.lastExternalTokenStartByte = tok.StartByte
 			d.lastExternalTokenEndByte = tok.EndByte
@@ -567,11 +627,13 @@ func (d *dfaTokenSource) scanDFATokenForState(state StateID, lexState uint32) (T
 
 	d.state = state
 	tok := d.nextTokenForLexState(lexState)
-	if zeroTok, ok := d.preferZeroWidthStartAcceptForState(state, lexState, tok, savedPos, savedRow, savedCol); ok {
-		tok = zeroTok
-		d.lexer.pos = savedPos
-		d.lexer.row = savedRow
-		d.lexer.col = savedCol
+	if d.hasZeroWidthStartAccept {
+		if zeroTok, ok := d.preferZeroWidthStartAcceptForState(state, lexState, tok, savedPos, savedRow, savedCol); ok {
+			tok = zeroTok
+			d.lexer.pos = savedPos
+			d.lexer.row = savedRow
+			d.lexer.col = savedCol
+		}
 	}
 	tok = d.promoteKeyword(tok)
 	tok, endPos, endRow, endCol := d.normalizeDFAToken(tok, d.lexer.pos, d.lexer.row, d.lexer.col)
@@ -591,7 +653,7 @@ func (d *dfaTokenSource) shouldPreferBaseLexStateToken(baseTok, afterTok Token) 
 	if afterTok.Symbol == 0 {
 		return true
 	}
-	if d.shouldPreferZeroWidthBaseLexStateToken(baseTok, afterTok) {
+	if d.hasZeroWidthTokens && d.shouldPreferZeroWidthBaseLexStateToken(baseTok, afterTok) {
 		return true
 	}
 	return baseTok.StartByte < afterTok.StartByte
@@ -689,16 +751,20 @@ func (d *dfaTokenSource) normalizeDFAToken(tok Token, endPos int, endRow, endCol
 	if d == nil || d.language == nil || d.lexer == nil {
 		return tok, endPos, endRow, endCol
 	}
-	if nlTok, nlEndPos, nlEndRow, nlEndCol, ok := d.bashGeneratedDFAOnlyNewlineToken(tok); ok {
-		return nlTok, nlEndPos, nlEndRow, nlEndCol
+	if d.isBashGenerated {
+		if nlTok, nlEndPos, nlEndRow, nlEndCol, ok := d.bashGeneratedDFAOnlyNewlineToken(tok); ok {
+			return nlTok, nlEndPos, nlEndRow, nlEndCol
+		}
 	}
 	if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitCompactCloseAngleToken(tok); ok {
 		return splitTok, splitEndPos, splitEndRow, splitEndCol
 	}
-	if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitBashGeneratedDoubleCloseParenToken(tok); ok {
-		return splitTok, splitEndPos, splitEndRow, splitEndCol
+	if d.isBashGenerated {
+		if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitBashGeneratedDoubleCloseParenToken(tok); ok {
+			return splitTok, splitEndPos, splitEndRow, splitEndCol
+		}
 	}
-	if d.language.Name != "bash" || d.symbolName(tok.Symbol) != "\\n" || tok.EndByte <= tok.StartByte+1 {
+	if !d.isBash || d.symbolName(tok.Symbol) != "\\n" || tok.EndByte <= tok.StartByte+1 {
 		return tok, endPos, endRow, endCol
 	}
 	start := int(tok.StartByte)
@@ -723,8 +789,7 @@ func (d *dfaTokenSource) normalizeDFAToken(tok Token, endPos int, endRow, endCol
 }
 
 func (d *dfaTokenSource) bashGeneratedDFAOnlyNewlineToken(tok Token) (Token, int, uint32, uint32, bool) {
-	if d == nil || d.language == nil || d.lexer == nil ||
-		d.language.Name != "bash" || !d.language.GeneratedByGrammargen ||
+	if d == nil || d.language == nil || d.lexer == nil || !d.isBashGenerated ||
 		d.symbolName(tok.Symbol) == "\\n" || tok.EndByte <= tok.StartByte {
 		return tok, 0, 0, 0, false
 	}
@@ -752,8 +817,7 @@ func (d *dfaTokenSource) bashGeneratedDFAOnlyNewlineToken(tok Token) (Token, int
 }
 
 func (d *dfaTokenSource) splitBashGeneratedDoubleCloseParenToken(tok Token) (Token, int, uint32, uint32, bool) {
-	if d == nil || d.language == nil || d.lexer == nil ||
-		d.language.Name != "bash" || !d.language.GeneratedByGrammargen ||
+	if d == nil || d.language == nil || d.lexer == nil || !d.isBashGenerated ||
 		d.symbolName(tok.Symbol) != "))" || tok.EndByte != tok.StartByte+2 {
 		return tok, 0, 0, 0, false
 	}
@@ -775,8 +839,7 @@ func (d *dfaTokenSource) splitBashGeneratedDoubleCloseParenToken(tok Token) (Tok
 }
 
 func (d *dfaTokenSource) bashSkippedSignificantNewlineToken(tok Token, scanStartPos int, scanStartRow, scanStartCol uint32) (Token, bool) {
-	if d == nil || d.language == nil || d.lexer == nil || d.language.Name != "bash" ||
-		!d.language.GeneratedByGrammargen {
+	if d == nil || d.language == nil || d.lexer == nil || !d.isBashGenerated {
 		return Token{}, false
 	}
 	if tok.Symbol == 0 || int(tok.StartByte) <= scanStartPos || scanStartPos < 0 || scanStartPos >= len(d.lexer.source) {
@@ -800,8 +863,7 @@ func (d *dfaTokenSource) bashSkippedSignificantNewlineToken(tok Token, scanStart
 }
 
 func (d *dfaTokenSource) bashGeneratedTokenOverZeroWidthConcat(tok Token, scanStartPos int, scanStartRow, scanStartCol uint32) (Token, bool) {
-	if d == nil || d.language == nil || d.lexer == nil || d.language.Name != "bash" ||
-		!d.language.GeneratedByGrammargen {
+	if d == nil || d.language == nil || d.lexer == nil || !d.isBashGenerated {
 		return Token{}, false
 	}
 	if d.symbolName(tok.Symbol) != "_concat" || tok.StartByte != tok.EndByte ||
@@ -1577,15 +1639,17 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	el := &d.externalLexer
 	el.reset(d.lexer.source, d.lexer.pos, d.lexer.row, d.lexer.col)
 	if !d.runExternalScannerWithRetry(el, valid) {
-		if tok, ok := d.bashGeneratedSyntheticExternalLiteral(valid); ok {
-			if DebugDFA.Load() {
-				fmt.Printf("  EXT synthetic %s %d %d state=%d\n", d.symbolName(tok.Symbol), tok.StartByte, tok.EndByte, d.state)
+		if d.isBashGenerated {
+			if tok, ok := d.bashGeneratedSyntheticExternalLiteral(valid); ok {
+				if DebugDFA.Load() {
+					fmt.Printf("  EXT synthetic %s %d %d state=%d\n", d.symbolName(tok.Symbol), tok.StartByte, tok.EndByte, d.state)
+				}
+				d.trackZeroWidthExternalToken(tok)
+				d.lexer.pos = int(tok.EndByte)
+				d.lexer.row = tok.EndPoint.Row
+				d.lexer.col = tok.EndPoint.Column
+				return tok, true
 			}
-			d.trackZeroWidthExternalToken(tok)
-			d.lexer.pos = int(tok.EndByte)
-			d.lexer.row = tok.EndPoint.Row
-			d.lexer.col = tok.EndPoint.Column
-			return tok, true
 		}
 		if DebugDFA.Load() {
 			fmt.Printf("  EXT miss pos=%d state=%d valid=%s\n", d.lexer.pos, d.state, d.debugExternalValidNames(valid))
@@ -1613,8 +1677,7 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 }
 
 func (d *dfaTokenSource) bashGeneratedSyntheticExternalLiteral(valid []bool) (Token, bool) {
-	if d == nil || d.language == nil || d.lexer == nil ||
-		d.language.Name != "bash" || !d.language.GeneratedByGrammargen {
+	if d == nil || d.language == nil || d.lexer == nil || !d.isBashGenerated {
 		return Token{}, false
 	}
 	literals := []string{"<<-", "<<", "}", "]", "(", "esac"}

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -188,6 +188,8 @@ func (d *dfaTokenSource) Next() Token {
 	}
 	for {
 		scanStartPos := d.lexer.pos
+		scanStartRow := d.lexer.row
+		scanStartCol := d.lexer.col
 		var externalStartSnapshot []byte
 		if languageUsesExternalScannerCheckpoints(d.language) {
 			externalStartSnapshot = d.captureExternalScannerStateInto(&d.externalTokenStart)
@@ -206,6 +208,13 @@ func (d *dfaTokenSource) Next() Token {
 		if extTok, ok := d.nextExternalToken(); ok {
 			tok = extTok
 			tokenFromExternal = true
+			if dfaTok, ok := d.bashGeneratedTokenOverZeroWidthConcat(tok, scanStartPos, scanStartRow, scanStartCol); ok {
+				tok = dfaTok
+				tokenFromExternal = false
+				d.lexer.pos = int(tok.EndByte)
+				d.lexer.row = tok.EndPoint.Row
+				d.lexer.col = tok.EndPoint.Column
+			}
 		} else if glrTok, ok := d.nextGLRUnionDFAToken(); ok {
 			tok = glrTok
 		} else {
@@ -213,20 +222,27 @@ func (d *dfaTokenSource) Next() Token {
 		}
 		if !tokenFromExternal && d.language != nil && d.language.ExternalScanner != nil &&
 			tok.Symbol != 0 && int(tok.StartByte) > scanStartPos {
-			dfaEndPos := d.lexer.pos
-			dfaEndRow := d.lexer.row
-			dfaEndCol := d.lexer.col
-
-			d.lexer.pos = int(tok.StartByte)
-			d.lexer.row = tok.StartPoint.Row
-			d.lexer.col = tok.StartPoint.Column
-			if extTok, ok := d.nextExternalToken(); ok && extTok.StartByte == tok.StartByte {
-				tok = extTok
-				tokenFromExternal = true
+			if nlTok, ok := d.bashSkippedSignificantNewlineToken(tok, scanStartPos, scanStartRow, scanStartCol); ok {
+				tok = nlTok
+				d.lexer.pos = int(tok.EndByte)
+				d.lexer.row = tok.EndPoint.Row
+				d.lexer.col = tok.EndPoint.Column
 			} else {
-				d.lexer.pos = dfaEndPos
-				d.lexer.row = dfaEndRow
-				d.lexer.col = dfaEndCol
+				dfaEndPos := d.lexer.pos
+				dfaEndRow := d.lexer.row
+				dfaEndCol := d.lexer.col
+
+				d.lexer.pos = int(tok.StartByte)
+				d.lexer.row = tok.StartPoint.Row
+				d.lexer.col = tok.StartPoint.Column
+				if extTok, ok := d.nextExternalToken(); ok && extTok.StartByte == tok.StartByte {
+					tok = extTok
+					tokenFromExternal = true
+				} else {
+					d.lexer.pos = dfaEndPos
+					d.lexer.row = dfaEndRow
+					d.lexer.col = dfaEndCol
+				}
 			}
 		}
 		if d.shouldSuppressFortranPreprocDefineNewline(tok) {
@@ -649,10 +665,16 @@ func (d *dfaTokenSource) normalizeDFAToken(tok Token, endPos int, endRow, endCol
 	if d == nil || d.language == nil || d.lexer == nil {
 		return tok, endPos, endRow, endCol
 	}
+	if nlTok, nlEndPos, nlEndRow, nlEndCol, ok := d.bashGeneratedDFAOnlyNewlineToken(tok); ok {
+		return nlTok, nlEndPos, nlEndRow, nlEndCol
+	}
 	if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitCompactCloseAngleToken(tok); ok {
 		return splitTok, splitEndPos, splitEndRow, splitEndCol
 	}
-	if d.language.Name != "bash" || tok.Symbol != 86 || tok.EndByte <= tok.StartByte+1 {
+	if splitTok, splitEndPos, splitEndRow, splitEndCol, ok := d.splitBashGeneratedDoubleCloseParenToken(tok); ok {
+		return splitTok, splitEndPos, splitEndRow, splitEndCol
+	}
+	if d.language.Name != "bash" || d.symbolName(tok.Symbol) != "\\n" || tok.EndByte <= tok.StartByte+1 {
 		return tok, endPos, endRow, endCol
 	}
 	start := int(tok.StartByte)
@@ -674,6 +696,275 @@ func (d *dfaTokenSource) normalizeDFAToken(tok Token, endPos int, endRow, endCol
 		tok.Text = tok.Text[:1]
 	}
 	return tok, start + 1, tok.StartPoint.Row + 1, 0
+}
+
+func (d *dfaTokenSource) bashGeneratedDFAOnlyNewlineToken(tok Token) (Token, int, uint32, uint32, bool) {
+	if d == nil || d.language == nil || d.lexer == nil ||
+		d.language.Name != "bash" || !d.language.GeneratedByGrammargen ||
+		d.symbolName(tok.Symbol) == "\\n" || tok.EndByte <= tok.StartByte {
+		return tok, 0, 0, 0, false
+	}
+	start := int(tok.StartByte)
+	end := int(tok.EndByte)
+	if start < 0 || end > len(d.lexer.source) {
+		return tok, 0, 0, 0, false
+	}
+	for i := start; i < end; i++ {
+		if d.lexer.source[i] != '\n' {
+			return tok, 0, 0, 0, false
+		}
+	}
+	sym, ok := d.bestActiveSymbolByName("\\n")
+	if !ok || sym == 0 {
+		if sym, ok = symbolByName(d.language, "\\n"); !ok || sym == 0 {
+			return tok, 0, 0, 0, false
+		}
+	}
+	tok.Symbol = sym
+	tok.EndByte = tok.StartByte + 1
+	tok.EndPoint = Point{Row: tok.StartPoint.Row + 1, Column: 0}
+	tok.Text = "\n"
+	return tok, start + 1, tok.StartPoint.Row + 1, 0, true
+}
+
+func (d *dfaTokenSource) splitBashGeneratedDoubleCloseParenToken(tok Token) (Token, int, uint32, uint32, bool) {
+	if d == nil || d.language == nil || d.lexer == nil ||
+		d.language.Name != "bash" || !d.language.GeneratedByGrammargen ||
+		d.symbolName(tok.Symbol) != "))" || tok.EndByte != tok.StartByte+2 {
+		return tok, 0, 0, 0, false
+	}
+	start := int(tok.StartByte)
+	if start < 0 || start+1 >= len(d.lexer.source) ||
+		d.lexer.source[start] != ')' || d.lexer.source[start+1] != ')' ||
+		d.bashGeneratedInArithmeticExpansion(start) {
+		return tok, 0, 0, 0, false
+	}
+	sym, ok := d.bestActiveSymbolByName(")")
+	if !ok || sym == 0 {
+		return tok, 0, 0, 0, false
+	}
+	tok.Symbol = sym
+	tok.EndByte = tok.StartByte + 1
+	tok.EndPoint = Point{Row: tok.StartPoint.Row, Column: tok.StartPoint.Column + 1}
+	tok.Text = ")"
+	return tok, start + 1, tok.EndPoint.Row, tok.EndPoint.Column, true
+}
+
+func (d *dfaTokenSource) bashSkippedSignificantNewlineToken(tok Token, scanStartPos int, scanStartRow, scanStartCol uint32) (Token, bool) {
+	if d == nil || d.language == nil || d.lexer == nil || d.language.Name != "bash" ||
+		!d.language.GeneratedByGrammargen {
+		return Token{}, false
+	}
+	if tok.Symbol == 0 || int(tok.StartByte) <= scanStartPos || scanStartPos < 0 || scanStartPos >= len(d.lexer.source) {
+		return Token{}, false
+	}
+	if d.lexer.source[scanStartPos] != '\n' {
+		return Token{}, false
+	}
+	sym, ok := d.bestActiveSymbolByName("\\n")
+	if !ok || sym == 0 {
+		return Token{}, false
+	}
+	return Token{
+		Symbol:     sym,
+		StartByte:  uint32(scanStartPos),
+		EndByte:    uint32(scanStartPos + 1),
+		StartPoint: Point{Row: scanStartRow, Column: scanStartCol},
+		EndPoint:   Point{Row: scanStartRow + 1, Column: 0},
+		Text:       "\n",
+	}, true
+}
+
+func (d *dfaTokenSource) bashGeneratedTokenOverZeroWidthConcat(tok Token, scanStartPos int, scanStartRow, scanStartCol uint32) (Token, bool) {
+	if d == nil || d.language == nil || d.lexer == nil || d.language.Name != "bash" ||
+		!d.language.GeneratedByGrammargen {
+		return Token{}, false
+	}
+	if d.symbolName(tok.Symbol) != "_concat" || tok.StartByte != tok.EndByte ||
+		int(tok.StartByte) != scanStartPos || scanStartPos < 0 || scanStartPos >= len(d.lexer.source) {
+		return Token{}, false
+	}
+	if d.lexer.source[scanStartPos] == '\n' {
+		sym, ok := d.bestActiveSymbolByName("\\n")
+		if !ok || sym == 0 {
+			return Token{}, false
+		}
+		return Token{
+			Symbol:     sym,
+			StartByte:  uint32(scanStartPos),
+			EndByte:    uint32(scanStartPos + 1),
+			StartPoint: Point{Row: scanStartRow, Column: scanStartCol},
+			EndPoint:   Point{Row: scanStartRow + 1, Column: 0},
+			Text:       "\n",
+		}, true
+	}
+	if opTok, ok := d.bashGeneratedOperatorTokenAt(scanStartPos, scanStartRow, scanStartCol); ok {
+		if DebugDFA.Load() {
+			fmt.Printf("  BASH CONCAT->DFA %s %d %d state=%d\n", d.symbolName(opTok.Symbol), opTok.StartByte, opTok.EndByte, d.state)
+		}
+		return opTok, true
+	}
+	dfaTok, endPos, endRow, endCol := d.scanPreferredTokenForState(d.state)
+	if dfaTok.Symbol == 0 || int(dfaTok.StartByte) != scanStartPos || endPos <= scanStartPos {
+		return Token{}, false
+	}
+	if !d.bashGeneratedShouldPreferDFATokenOverConcat(dfaTok) {
+		return Token{}, false
+	}
+	dfaTok.EndByte = uint32(endPos)
+	dfaTok.EndPoint = Point{Row: endRow, Column: endCol}
+	return dfaTok, true
+}
+
+func (d *dfaTokenSource) bashGeneratedOperatorTokenAt(pos int, row, col uint32) (Token, bool) {
+	if d == nil || d.lexer == nil || pos < 0 || pos >= len(d.lexer.source) {
+		return Token{}, false
+	}
+	for _, lit := range bashGeneratedConcatOperatorLookaheads {
+		if !bytes.HasPrefix(d.lexer.source[pos:], lit.bytes) {
+			continue
+		}
+		name := lit.name
+		if name == "" {
+			name = lit.text
+		}
+		if bashGeneratedOperatorRequiresArithmeticContext(name) && !d.bashGeneratedInArithmeticExpansion(pos) {
+			continue
+		}
+		sym, ok := d.bestActiveSymbolByName(name)
+		if !ok || sym == 0 {
+			continue
+		}
+		endCol := col + uint32(len(lit.text))
+		return Token{
+			Symbol:     sym,
+			StartByte:  uint32(pos),
+			EndByte:    uint32(pos + len(lit.text)),
+			StartPoint: Point{Row: row, Column: col},
+			EndPoint:   Point{Row: row, Column: endCol},
+			Text:       lit.text,
+		}, true
+	}
+	return Token{}, false
+}
+
+func bashGeneratedOperatorRequiresArithmeticContext(name string) bool {
+	switch name {
+	case "++", "--",
+		"+=", "-=", "*=", "/=", "%=", "**=", "<<=", ">>=", "&=", "^=", "|=",
+		"^",
+		"+", "-", "*", "/", "%", "**", "))",
+		"?", ":", ",":
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *dfaTokenSource) bashGeneratedInArithmeticExpansion(pos int) bool {
+	if d == nil || d.lexer == nil || pos <= 0 || pos > len(d.lexer.source) {
+		return false
+	}
+	depth := 0
+	src := d.lexer.source[:pos]
+	for i := 0; i < len(src); {
+		switch {
+		case bytes.HasPrefix(src[i:], []byte("$((")):
+			depth++
+			i += len("$((")
+		case depth > 0 && bytes.HasPrefix(src[i:], []byte("))")):
+			depth--
+			i += len("))")
+		case src[i] == '\\':
+			i += 2
+		default:
+			_, size := utf8.DecodeRune(src[i:])
+			if size <= 0 {
+				size = 1
+			}
+			i += size
+		}
+	}
+	return depth > 0
+}
+
+type bashGeneratedConcatOperatorLookahead struct {
+	text  string
+	name  string
+	bytes []byte
+}
+
+var bashGeneratedConcatOperatorLookaheads = makeBashGeneratedConcatOperatorLookaheads(
+	bashGeneratedConcatOperatorLookahead{text: "<<<"},
+	bashGeneratedConcatOperatorLookahead{text: "&>>"},
+	bashGeneratedConcatOperatorLookahead{text: "<<-"},
+	bashGeneratedConcatOperatorLookahead{text: "<&-"},
+	bashGeneratedConcatOperatorLookahead{text: ">&-"},
+	bashGeneratedConcatOperatorLookahead{text: "**="},
+	bashGeneratedConcatOperatorLookahead{text: "<<="},
+	bashGeneratedConcatOperatorLookahead{text: ">>="},
+	bashGeneratedConcatOperatorLookahead{text: "|&"},
+	bashGeneratedConcatOperatorLookahead{text: "&>"},
+	bashGeneratedConcatOperatorLookahead{text: "<&"},
+	bashGeneratedConcatOperatorLookahead{text: ">&"},
+	bashGeneratedConcatOperatorLookahead{text: ">|"},
+	bashGeneratedConcatOperatorLookahead{text: "++"},
+	bashGeneratedConcatOperatorLookahead{text: "--"},
+	bashGeneratedConcatOperatorLookahead{text: "+="},
+	bashGeneratedConcatOperatorLookahead{text: "-="},
+	bashGeneratedConcatOperatorLookahead{text: "*="},
+	bashGeneratedConcatOperatorLookahead{text: "/="},
+	bashGeneratedConcatOperatorLookahead{text: "%="},
+	bashGeneratedConcatOperatorLookahead{text: "&="},
+	bashGeneratedConcatOperatorLookahead{text: "^="},
+	bashGeneratedConcatOperatorLookahead{text: "|="},
+	bashGeneratedConcatOperatorLookahead{text: "||"},
+	bashGeneratedConcatOperatorLookahead{text: "&&"},
+	bashGeneratedConcatOperatorLookahead{text: "=="},
+	bashGeneratedConcatOperatorLookahead{text: "!="},
+	bashGeneratedConcatOperatorLookahead{text: "<="},
+	bashGeneratedConcatOperatorLookahead{text: ">="},
+	bashGeneratedConcatOperatorLookahead{text: "<<"},
+	bashGeneratedConcatOperatorLookahead{text: ">>"},
+	bashGeneratedConcatOperatorLookahead{text: "**"},
+	bashGeneratedConcatOperatorLookahead{text: "))"},
+	bashGeneratedConcatOperatorLookahead{text: ";;"},
+	bashGeneratedConcatOperatorLookahead{text: "+"},
+	bashGeneratedConcatOperatorLookahead{text: "-"},
+	bashGeneratedConcatOperatorLookahead{text: "*"},
+	bashGeneratedConcatOperatorLookahead{text: "/"},
+	bashGeneratedConcatOperatorLookahead{text: "%"},
+	bashGeneratedConcatOperatorLookahead{text: "|"},
+	bashGeneratedConcatOperatorLookahead{text: "^"},
+	bashGeneratedConcatOperatorLookahead{text: "&"},
+	bashGeneratedConcatOperatorLookahead{text: "<"},
+	bashGeneratedConcatOperatorLookahead{text: ">"},
+	bashGeneratedConcatOperatorLookahead{text: "?", name: "\\?"},
+	bashGeneratedConcatOperatorLookahead{text: ":"},
+	bashGeneratedConcatOperatorLookahead{text: ","},
+	bashGeneratedConcatOperatorLookahead{text: ";"},
+)
+
+func makeBashGeneratedConcatOperatorLookaheads(in ...bashGeneratedConcatOperatorLookahead) []bashGeneratedConcatOperatorLookahead {
+	for i := range in {
+		in[i].bytes = []byte(in[i].text)
+	}
+	return in
+}
+
+func (d *dfaTokenSource) bashGeneratedShouldPreferDFATokenOverConcat(tok Token) bool {
+	switch d.symbolName(tok.Symbol) {
+	case "++", "--",
+		"+=", "-=", "*=", "/=", "%=", "**=", "<<=", ">>=", "&=", "^=", "|=",
+		"||", "&&", "|", "|&", "^", "&",
+		"==", "!=", "<", ">", "<=", ">=",
+		"<<", "<<-", ">>", "<<<", "&>", "&>>", "<&", ">&", "<&-", ">&-", ">|",
+		"+", "-", "*", "/", "%", "**",
+		"?", ":", ",", "))", ";", ";;":
+		return true
+	default:
+		return false
+	}
 }
 
 func (d *dfaTokenSource) splitCompactCloseAngleToken(tok Token) (Token, int, uint32, uint32, bool) {
@@ -1247,6 +1538,10 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	if d.shouldDeferFortranExternalEndOfStatementToDFA(valid, states) {
 		return Token{}, false
 	}
+	if DebugDFA.Load() {
+		fmt.Printf("  EXT valid pos=%d state=%d glr=%v els=%s valid=%s\n",
+			d.lexer.pos, d.state, states, d.debugExternalLexStateIDs(states), d.debugExternalValidNames(valid))
+	}
 
 	if d.language.ExternalScanner == nil {
 		tok, ok := d.syntheticExternalToken(valid)
@@ -1260,6 +1555,19 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	el := &d.externalLexer
 	el.reset(d.lexer.source, d.lexer.pos, d.lexer.row, d.lexer.col)
 	if !d.runExternalScannerWithRetry(el, valid) {
+		if tok, ok := d.bashGeneratedSyntheticExternalLiteral(valid); ok {
+			if DebugDFA.Load() {
+				fmt.Printf("  EXT synthetic %s %d %d state=%d\n", d.symbolName(tok.Symbol), tok.StartByte, tok.EndByte, d.state)
+			}
+			d.trackZeroWidthExternalToken(tok)
+			d.lexer.pos = int(tok.EndByte)
+			d.lexer.row = tok.EndPoint.Row
+			d.lexer.col = tok.EndPoint.Column
+			return tok, true
+		}
+		if DebugDFA.Load() {
+			fmt.Printf("  EXT miss pos=%d state=%d valid=%s\n", d.lexer.pos, d.state, d.debugExternalValidNames(valid))
+		}
 		return Token{}, false
 	}
 	tok, ok := el.token()
@@ -1280,6 +1588,50 @@ func (d *dfaTokenSource) nextExternalToken() (Token, bool) {
 	d.lexer.row = tok.EndPoint.Row
 	d.lexer.col = tok.EndPoint.Column
 	return tok, true
+}
+
+func (d *dfaTokenSource) bashGeneratedSyntheticExternalLiteral(valid []bool) (Token, bool) {
+	if d == nil || d.language == nil || d.lexer == nil ||
+		d.language.Name != "bash" || !d.language.GeneratedByGrammargen {
+		return Token{}, false
+	}
+	literals := []string{"<<-", "<<", "}", "]", "(", "esac"}
+	for _, lit := range literals {
+		if !bytes.HasPrefix(d.lexer.source[d.lexer.pos:], []byte(lit)) {
+			continue
+		}
+		if lit == "<<" && d.bashGeneratedLongerHeredocOperatorAt(d.lexer.pos) {
+			continue
+		}
+		for i, sym := range d.language.ExternalSymbols {
+			if i >= len(valid) || !valid[i] || d.symbolName(sym) != lit {
+				continue
+			}
+			endCol := d.lexer.col + uint32(len(lit))
+			return Token{
+				Symbol:     sym,
+				StartByte:  uint32(d.lexer.pos),
+				EndByte:    uint32(d.lexer.pos + len(lit)),
+				StartPoint: Point{Row: d.lexer.row, Column: d.lexer.col},
+				EndPoint:   Point{Row: d.lexer.row, Column: endCol},
+				Text:       lit,
+			}, true
+		}
+	}
+	return Token{}, false
+}
+
+func (d *dfaTokenSource) bashGeneratedLongerHeredocOperatorAt(pos int) bool {
+	if d == nil || d.lexer == nil || pos < 0 || pos+2 >= len(d.lexer.source) {
+		return false
+	}
+	switch d.lexer.source[pos+2] {
+	case '<', '-':
+		return bytes.HasPrefix(d.lexer.source[pos:], []byte("<<<")) ||
+			bytes.HasPrefix(d.lexer.source[pos:], []byte("<<-"))
+	default:
+		return false
+	}
 }
 
 func (d *dfaTokenSource) preferDFASemicolonOverJSXText(tok Token, states []StateID) (Token, int, uint32, uint32, bool) {
@@ -1593,6 +1945,47 @@ func tokenSymbolSpecificity(lang *Language, sym Symbol) int {
 		return 3
 	}
 	return 2
+}
+
+func (d *dfaTokenSource) debugExternalLexStateIDs(states []StateID) string {
+	if d == nil || d.language == nil || len(d.language.ExternalLexStates) == 0 {
+		return ""
+	}
+	ids := make([]string, 0, len(states))
+	seen := map[uint16]struct{}{}
+	for _, st := range states {
+		if int(st) >= len(d.language.LexModes) {
+			continue
+		}
+		id := d.language.LexModes[st].ExternalLexState
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, fmt.Sprintf("%d", id))
+	}
+	return strings.Join(ids, ",")
+}
+
+func (d *dfaTokenSource) debugExternalValidNames(valid []bool) string {
+	if d == nil || d.language == nil {
+		return ""
+	}
+	names := make([]string, 0, len(valid))
+	for i, ok := range valid {
+		if !ok {
+			continue
+		}
+		name := ""
+		if i >= 0 && i < len(d.language.ExternalSymbols) {
+			sym := d.language.ExternalSymbols[i]
+			if int(sym) >= 0 && int(sym) < len(d.language.SymbolNames) {
+				name = d.language.SymbolNames[sym]
+			}
+		}
+		names = append(names, fmt.Sprintf("%d:%s", i, name))
+	}
+	return strings.Join(names, ",")
 }
 
 func (d *dfaTokenSource) runExternalScannerWithRetry(el *ExternalLexer, valid []bool) bool {

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -390,3 +390,134 @@ func TestNextDFATokenAfterWhitespacePrefersEarlierBaseLexStateToken(t *testing.T
 		t.Fatalf("token text after whitespace = %q, want %q", got, want)
 	}
 }
+
+func TestNextDFATokenPrefersParserValidZeroWidthBaseToken(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"end", "text", "newline"},
+		ZeroWidthTokens: []bool{
+			false,
+			true,
+			false,
+		},
+		LexStates: []LexState{
+			{
+				AcceptToken: 1,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{{Lo: ' ', Hi: ' ', NextState: 1}},
+			},
+			{
+				AcceptToken: 1,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{{Lo: ' ', Hi: ' ', NextState: 1}},
+			},
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: '\n', Hi: '\n', NextState: 3},
+				},
+			},
+			{
+				AcceptToken: 2,
+				Default:     -1,
+				EOF:         -1,
+			},
+		},
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 0, AfterWhitespaceLexState: 2},
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift}}},
+		},
+	}
+
+	d := &dfaTokenSource{
+		lexer:    NewLexer(lang.LexStates, []byte(";\n")),
+		language: lang,
+		state:    1,
+		lookupActionIndex: func(_ StateID, sym Symbol) uint16 {
+			if sym == 1 || sym == 2 {
+				return 1
+			}
+			return 0
+		},
+	}
+	d.lexer.zeroWidthTokens = lang.ZeroWidthTokens
+	d.lexer.pos = 1
+
+	tok := d.nextDFAToken()
+	if got, want := tok.Symbol, Symbol(1); got != want {
+		t.Fatalf("token symbol at whitespace boundary = %d (%q), want %d (%q)", got, lang.SymbolNames[got], want, lang.SymbolNames[want])
+	}
+	if got, want := tok.StartByte, uint32(1); got != want {
+		t.Fatalf("token start = %d, want %d", got, want)
+	}
+	if got, want := tok.EndByte, uint32(1); got != want {
+		t.Fatalf("token end = %d, want %d", got, want)
+	}
+}
+
+func TestNextDFATokenPrefersParserValidZeroWidthStartAccept(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"end", "text", "newline"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end"},
+			{Name: "text", Visible: true, Named: true},
+			{Name: "newline"},
+		},
+		ZeroWidthTokens: []bool{
+			false,
+			true,
+			false,
+		},
+		LexStates: []LexState{
+			{
+				AcceptToken: 1,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{{Lo: '\n', Hi: '\n', NextState: 1}},
+			},
+			{
+				AcceptToken: 2,
+				Default:     -1,
+				EOF:         -1,
+			},
+		},
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 0},
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift}}},
+		},
+	}
+
+	d := &dfaTokenSource{
+		lexer:    NewLexer(lang.LexStates, []byte("\n")),
+		language: lang,
+		state:    1,
+		lookupActionIndex: func(_ StateID, sym Symbol) uint16 {
+			if sym == 1 || sym == 2 {
+				return 1
+			}
+			return 0
+		},
+	}
+	d.lexer.zeroWidthTokens = lang.ZeroWidthTokens
+
+	tok := d.nextDFAToken()
+	if got, want := tok.Symbol, Symbol(1); got != want {
+		t.Fatalf("token symbol at zero-width start accept = %d (%q), want %d (%q)", got, lang.SymbolNames[got], want, lang.SymbolNames[want])
+	}
+	if got, want := tok.StartByte, uint32(0); got != want {
+		t.Fatalf("token start = %d, want %d", got, want)
+	}
+	if got, want := tok.EndByte, uint32(0); got != want {
+		t.Fatalf("token end = %d, want %d", got, want)
+	}
+}

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -98,8 +98,10 @@ func TestBashGeneratedSyntheticExternalLiteralDoesNotConsumeHereStringPrefix(t *
 		ExternalSymbols:       []Symbol{1},
 	}
 	ts := &dfaTokenSource{
-		lexer:    NewLexer(nil, []byte("<<< word")),
-		language: lang,
+		lexer:           NewLexer(nil, []byte("<<< word")),
+		language:        lang,
+		isBash:          true,
+		isBashGenerated: true,
 	}
 	if tok, ok := ts.bashGeneratedSyntheticExternalLiteral([]bool{true}); ok {
 		t.Fatalf("synthetic token = %+v, want DFA to handle here-string prefix", tok)
@@ -113,8 +115,10 @@ func TestNormalizeBashNewlineTokenSplitsBySymbolName(t *testing.T) {
 		SymbolNames:           []string{"end", "\\n"},
 	}
 	ts := &dfaTokenSource{
-		lexer:    NewLexer(nil, []byte("\n\nsed")),
-		language: lang,
+		lexer:           NewLexer(nil, []byte("\n\nsed")),
+		language:        lang,
+		isBash:          true,
+		isBashGenerated: true,
 	}
 	tok := Token{
 		Symbol:     1,
@@ -150,6 +154,8 @@ func TestNormalizeBashGeneratedDFAOnlyNewlineToken(t *testing.T) {
 		lexer:             NewLexer(nil, []byte("\n\nsed")),
 		language:          lang,
 		lookupActionIndex: lookup,
+		isBash:            true,
+		isBashGenerated:   true,
 	}
 	tok := Token{
 		Symbol:     2,
@@ -614,9 +620,11 @@ func TestNextDFATokenPrefersParserValidZeroWidthBaseToken(t *testing.T) {
 	}
 
 	d := &dfaTokenSource{
-		lexer:    NewLexer(lang.LexStates, []byte(";\n")),
-		language: lang,
-		state:    1,
+		lexer:                   NewLexer(lang.LexStates, []byte(";\n")),
+		language:                lang,
+		state:                   1,
+		hasZeroWidthTokens:      true,
+		hasZeroWidthStartAccept: true,
 		lookupActionIndex: func(_ StateID, sym Symbol) uint16 {
 			if sym == 1 || sym == 2 {
 				return 1
@@ -676,9 +684,11 @@ func TestNextDFATokenPrefersParserValidZeroWidthStartAccept(t *testing.T) {
 	}
 
 	d := &dfaTokenSource{
-		lexer:    NewLexer(lang.LexStates, []byte("\n")),
-		language: lang,
-		state:    1,
+		lexer:                   NewLexer(lang.LexStates, []byte("\n")),
+		language:                lang,
+		state:                   1,
+		hasZeroWidthTokens:      true,
+		hasZeroWidthStartAccept: true,
 		lookupActionIndex: func(_ StateID, sym Symbol) uint16 {
 			if sym == 1 || sym == 2 {
 				return 1

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -75,6 +75,96 @@ func TestNextExternalTokenPrefersCandidateUsableByPrimaryState(t *testing.T) {
 	}
 }
 
+func TestBashGeneratedShellOperatorsDoNotRequireArithmeticContext(t *testing.T) {
+	shellOps := []string{"|", "|&", "||", "&&", "<", ">", "<<", "<<-", ">>", "<<<", "&>", "&>>", "<&", ">&", "<&-", ">&-", ">|", ";", ";;"}
+	for _, op := range shellOps {
+		if bashGeneratedOperatorRequiresArithmeticContext(op) {
+			t.Fatalf("operator %q requires arithmetic context, want shell context allowed", op)
+		}
+	}
+	arithmeticOps := []string{"+", "-", "*", "/", "%", "**", "++", "--", "+=", "<<=", ">>=", "?", ":", ","}
+	for _, op := range arithmeticOps {
+		if !bashGeneratedOperatorRequiresArithmeticContext(op) {
+			t.Fatalf("operator %q does not require arithmetic context", op)
+		}
+	}
+}
+
+func TestBashGeneratedSyntheticExternalLiteralDoesNotConsumeHereStringPrefix(t *testing.T) {
+	lang := &Language{
+		Name:                  "bash",
+		GeneratedByGrammargen: true,
+		SymbolNames:           []string{"end", "<<"},
+		ExternalSymbols:       []Symbol{1},
+	}
+	ts := &dfaTokenSource{
+		lexer:    NewLexer(nil, []byte("<<< word")),
+		language: lang,
+	}
+	if tok, ok := ts.bashGeneratedSyntheticExternalLiteral([]bool{true}); ok {
+		t.Fatalf("synthetic token = %+v, want DFA to handle here-string prefix", tok)
+	}
+}
+
+func TestNormalizeBashNewlineTokenSplitsBySymbolName(t *testing.T) {
+	lang := &Language{
+		Name:                  "bash",
+		GeneratedByGrammargen: true,
+		SymbolNames:           []string{"end", "\\n"},
+	}
+	ts := &dfaTokenSource{
+		lexer:    NewLexer(nil, []byte("\n\nsed")),
+		language: lang,
+	}
+	tok := Token{
+		Symbol:     1,
+		StartByte:  0,
+		EndByte:    2,
+		StartPoint: Point{},
+		EndPoint:   Point{Row: 2, Column: 0},
+		Text:       "\n\n",
+	}
+	got, endPos, endRow, endCol := ts.normalizeDFAToken(tok, 2, 2, 0)
+	if got.EndByte != 1 || endPos != 1 || endRow != 1 || endCol != 0 || got.Text != "\n" {
+		t.Fatalf("split newline token = %+v end=(%d,%d,%d), want single newline", got, endPos, endRow, endCol)
+	}
+}
+
+func TestNormalizeBashGeneratedDFAOnlyNewlineToken(t *testing.T) {
+	lang := &Language{
+		Name:                  "bash",
+		GeneratedByGrammargen: true,
+		SymbolNames:           []string{"end", "\\n", "regex"},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+		},
+	}
+	lookup := func(state StateID, sym Symbol) uint16 {
+		if sym == 1 {
+			return 1
+		}
+		return 0
+	}
+	ts := &dfaTokenSource{
+		lexer:             NewLexer(nil, []byte("\n\nsed")),
+		language:          lang,
+		lookupActionIndex: lookup,
+	}
+	tok := Token{
+		Symbol:     2,
+		StartByte:  0,
+		EndByte:    2,
+		StartPoint: Point{},
+		EndPoint:   Point{Row: 2, Column: 0},
+		Text:       "\n\n",
+	}
+	got, endPos, endRow, endCol := ts.normalizeDFAToken(tok, 2, 2, 0)
+	if got.Symbol != 1 || got.EndByte != 1 || endPos != 1 || endRow != 1 || endCol != 0 || got.Text != "\n" {
+		t.Fatalf("normalized DFA newline = %+v end=(%d,%d,%d), want active newline", got, endPos, endRow, endCol)
+	}
+}
+
 type byteStateExternalScanner struct{}
 
 func (byteStateExternalScanner) Create() any {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -433,7 +433,7 @@ func (p *Parser) tryFastVisibleReduceActionFromGSS(s *glrStack, act ParseAction,
 		return false
 	}
 
-	children := arena.allocNodeSlice(childCount)
+	children := arena.allocNodeSliceNoClear(childCount)
 	copy(children, childBuf[:childCount])
 	named := p.isNamedSymbol(act.Symbol)
 	var parent *Node
@@ -1108,7 +1108,7 @@ func materializeReduceChildrenFromScratch(scratch *reduceBuildScratch, arena *no
 	if scratch == nil || len(scratch.nodes) == 0 {
 		return nil, nil, nil
 	}
-	children := arena.allocNodeSlice(len(scratch.nodes))
+	children := arena.allocNodeSliceNoClear(len(scratch.nodes))
 	copy(children, scratch.nodes)
 	if !scratch.trackFields {
 		return children, nil, nil
@@ -1150,7 +1150,7 @@ func (p *Parser) buildReduceChildrenAllVisible(entries []stackEntry, start, end,
 		return nil, nil, nil, true
 	}
 
-	children := arena.allocNodeSlice(visibleCount)
+	children := arena.allocNodeSliceNoClear(visibleCount)
 	var fieldIDs []FieldID
 	var fieldSources []uint8
 	if rawFieldIDs != nil {
@@ -1407,7 +1407,7 @@ func (p *Parser) buildReduceChildrenNoAliasNoFieldsStreaming(entries []stackEntr
 		if visibleCount == 0 {
 			return nil, nil, nil
 		}
-		children := arena.allocNodeSlice(visibleCount)
+		children := arena.allocNodeSliceNoClear(visibleCount)
 		out := 0
 		for i := start; i < end; i++ {
 			n := entries[i].node
@@ -2270,8 +2270,8 @@ func (p *Parser) fieldFlagScratch(childCount int) ([]bool, []bool) {
 	return p.fieldInheritedScratch, p.fieldConflictedScratch
 }
 
-// buildFieldIDs creates the field ID slice for a reduce action.
-func (p *Parser) buildFieldIDs(childCount int, productionID uint16, arena *nodeArena) ([]FieldID, []bool) {
+// buildFieldIDs creates the temporary field ID slice for a reduce action.
+func (p *Parser) buildFieldIDs(childCount int, productionID uint16, _ *nodeArena) ([]FieldID, []bool) {
 	if childCount <= 0 || len(p.language.FieldMapEntries) == 0 {
 		return nil, nil
 	}
@@ -2302,7 +2302,7 @@ func (p *Parser) buildFieldIDs(childCount int, productionID uint16, arena *nodeA
 		entry := p.language.FieldMapEntries[entryIdx]
 		if int(entry.ChildIndex) < childCount {
 			if fieldIDs == nil {
-				fieldIDs = arena.allocFieldIDSlice(childCount)
+				fieldIDs = p.fieldIDScratchFor(childCount)
 			}
 			idx := entry.ChildIndex
 			switch {
@@ -2334,4 +2334,20 @@ func (p *Parser) buildFieldIDs(childCount int, productionID uint16, arena *nodeA
 		return nil, nil
 	}
 	return fieldIDs, inherited
+}
+
+func (p *Parser) fieldIDScratchFor(childCount int) []FieldID {
+	if childCount <= 0 {
+		return nil
+	}
+	if p == nil {
+		return make([]FieldID, childCount)
+	}
+	if cap(p.fieldIDScratch) < childCount {
+		p.fieldIDScratch = make([]FieldID, childCount)
+	} else {
+		p.fieldIDScratch = p.fieldIDScratch[:childCount]
+		clear(p.fieldIDScratch)
+	}
+	return p.fieldIDScratch
 }

--- a/parser_reserved_word_test.go
+++ b/parser_reserved_word_test.go
@@ -158,3 +158,61 @@ func TestReservedWordSetIDZeroDoesNotBlock(t *testing.T) {
 		t.Fatalf("setID=0: got symbol %d, want 2 (KW_IF — promoted)", got.Symbol)
 	}
 }
+
+func TestActiveLiteralKeywordSymbolUsesTokenNameIndex(t *testing.T) {
+	lang := &Language{
+		Name:        "literal_keyword_test",
+		SymbolCount: 6,
+		TokenCount:  5,
+		SymbolNames: []string{
+			"end",
+			"identifier",
+			"static",
+			"static",
+			"requires",
+			"static",
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+		},
+	}
+	lookup := func(state StateID, sym Symbol) uint16 {
+		switch {
+		case state == 1 && sym == 3:
+			return 1
+		case state == 2 && sym == 4:
+			return 1
+		default:
+			return 0
+		}
+	}
+	d := &dfaTokenSource{
+		language:          lang,
+		state:             1,
+		glrStates:         []StateID{1, 1, 2},
+		lookupActionIndex: lookup,
+	}
+
+	// Warm the per-language symbol index; activeLiteralKeywordSymbol should not
+	// allocate while consulting it for repeated token lookups.
+	lang.TokenSymbolsByName("static")
+
+	staticTok := Token{Text: "static"}
+	if got, ok := d.activeLiteralKeywordSymbol(staticTok); !ok || got != 3 {
+		t.Fatalf("active static literal = (%d, %v), want (3, true)", got, ok)
+	}
+	requiresTok := Token{Text: "requires"}
+	if got, ok := d.activeLiteralKeywordSymbol(requiresTok); !ok || got != 4 {
+		t.Fatalf("active requires literal = (%d, %v), want (4, true)", got, ok)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		if _, ok := d.activeLiteralKeywordSymbol(staticTok); !ok {
+			t.Fatal("active static literal not found")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("active literal lookup allocations = %v, want 0", allocs)
+	}
+}

--- a/parser_result_bash.go
+++ b/parser_result_bash.go
@@ -55,6 +55,81 @@ func normalizeBashGeneratedCommandAssignments(root *Node, source []byte, lang *L
 	normalizeBashGeneratedCommandAssignmentsInNode(root, source, lang, ctx)
 }
 
+func normalizeBashCommandNameArguments(root *Node, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "bash" {
+		return
+	}
+	commandSym, ok := symbolByName(lang, "command")
+	if !ok {
+		return
+	}
+	commandNameSym, ok := symbolByName(lang, "command_name")
+	if !ok {
+		return
+	}
+	concatenationSym, ok := symbolByName(lang, "concatenation")
+	if !ok {
+		return
+	}
+	normalizeBashCommandNameArgumentsInNode(root, commandSym, commandNameSym, concatenationSym)
+}
+
+func normalizeBashCommandNameArgumentsInNode(node *Node, commandSym, commandNameSym, concatenationSym Symbol) {
+	if node == nil {
+		return
+	}
+	for _, child := range node.children {
+		normalizeBashCommandNameArgumentsInNode(child, commandSym, commandNameSym, concatenationSym)
+	}
+	splitBashCommandNameArguments(node, commandSym, commandNameSym, concatenationSym)
+}
+
+func splitBashCommandNameArguments(node *Node, commandSym, commandNameSym, concatenationSym Symbol) bool {
+	if node == nil || node.symbol != commandSym || len(node.children) != 1 {
+		return false
+	}
+	commandName := node.children[0]
+	if commandName == nil || commandName.symbol != commandNameSym || len(commandName.children) != 1 {
+		return false
+	}
+	concat := commandName.children[0]
+	if concat == nil || concat.symbol != concatenationSym || len(concat.children) < 2 {
+		return false
+	}
+
+	arena := node.ownerArena
+	parts := concat.children
+	commandWord := parts[0]
+	if commandWord == nil {
+		return false
+	}
+
+	nameChildren := []*Node{commandWord}
+	if arena != nil {
+		nameChildren = cloneNodeSliceInArena(arena, nameChildren)
+	}
+	commandName.children = nameChildren
+	commandName.fieldIDs = nil
+	commandName.fieldSources = nil
+	commandName.startByte = commandWord.startByte
+	commandName.endByte = commandWord.endByte
+	commandName.startPoint = commandWord.startPoint
+	commandName.endPoint = commandWord.endPoint
+	populateParentNode(commandName, nameChildren)
+
+	commandChildren := make([]*Node, 0, len(parts))
+	commandChildren = append(commandChildren, commandName)
+	commandChildren = append(commandChildren, parts[1:]...)
+	if arena != nil {
+		commandChildren = cloneNodeSliceInArena(arena, commandChildren)
+	}
+	node.children = commandChildren
+	node.fieldIDs = nil
+	node.fieldSources = nil
+	populateParentNode(node, commandChildren)
+	return true
+}
+
 type bashGeneratedAssignmentContext struct {
 	commandSym            Symbol
 	commandNameSym        Symbol

--- a/parser_result_bash.go
+++ b/parser_result_bash.go
@@ -44,6 +44,188 @@ func normalizeBashVariableAssignmentsInNode(node *Node, lang *Language) {
 	assignBashIfConditionField(node, lang)
 }
 
+func normalizeBashGeneratedCommandAssignments(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || !lang.GeneratedByGrammargen || lang.Name != "bash" || len(source) == 0 {
+		return
+	}
+	ctx, ok := newBashGeneratedAssignmentContext(lang)
+	if !ok {
+		return
+	}
+	normalizeBashGeneratedCommandAssignmentsInNode(root, source, lang, ctx)
+}
+
+type bashGeneratedAssignmentContext struct {
+	commandSym            Symbol
+	commandNameSym        Symbol
+	concatenationSym      Symbol
+	variableAssignmentSym Symbol
+	variableNameSym       Symbol
+	nameFieldID           FieldID
+	valueFieldID          FieldID
+}
+
+func newBashGeneratedAssignmentContext(lang *Language) (bashGeneratedAssignmentContext, bool) {
+	var ctx bashGeneratedAssignmentContext
+	var ok bool
+	if ctx.commandSym, ok = symbolByName(lang, "command"); !ok {
+		return ctx, false
+	}
+	if ctx.commandNameSym, ok = symbolByName(lang, "command_name"); !ok {
+		return ctx, false
+	}
+	if ctx.concatenationSym, ok = symbolByName(lang, "concatenation"); !ok {
+		return ctx, false
+	}
+	if ctx.variableAssignmentSym, ok = symbolByName(lang, "variable_assignment"); !ok {
+		return ctx, false
+	}
+	if ctx.variableNameSym, ok = symbolByName(lang, "variable_name"); !ok {
+		return ctx, false
+	}
+	ctx.nameFieldID, _ = lang.FieldByName("name")
+	ctx.valueFieldID, _ = lang.FieldByName("value")
+	return ctx, true
+}
+
+func normalizeBashGeneratedCommandAssignmentsInNode(node *Node, source []byte, lang *Language, ctx bashGeneratedAssignmentContext) {
+	if node == nil {
+		return
+	}
+	for _, child := range node.children {
+		normalizeBashGeneratedCommandAssignmentsInNode(child, source, lang, ctx)
+	}
+	rewriteBashGeneratedCommandAssignment(node, source, lang, ctx)
+}
+
+func rewriteBashGeneratedCommandAssignment(node *Node, source []byte, lang *Language, ctx bashGeneratedAssignmentContext) bool {
+	if node == nil || node.symbol != ctx.commandSym || len(node.children) != 1 {
+		return false
+	}
+	commandName := node.children[0]
+	if commandName == nil || commandName.symbol != ctx.commandNameSym {
+		return false
+	}
+	parts := bashGeneratedAssignmentParts(commandName, ctx)
+	if len(parts) == 0 {
+		return false
+	}
+	first := parts[0]
+	if first == nil || int(first.startByte) >= len(source) || first.endByte > uint32(len(source)) {
+		return false
+	}
+	nameEnd, valueStart, ok := bashSimpleAssignmentSplit(source, first.startByte, first.endByte)
+	if !ok || valueStart > commandName.endByte {
+		return false
+	}
+
+	arena := node.ownerArena
+	name := newLeafNodeInArena(arena, ctx.variableNameSym, true, first.startByte, nameEnd, first.startPoint, advancePointByBytes(first.startPoint, source[first.startByte:nameEnd]))
+	valueChildren := make([]*Node, 0, len(parts))
+	if valueStart < first.endByte {
+		valueStartPoint := advancePointByBytes(first.startPoint, source[first.startByte:valueStart])
+		valueChildren = append(valueChildren, newLeafNodeInArena(arena, first.symbol, first.isNamed, valueStart, first.endByte, valueStartPoint, first.endPoint))
+	}
+	valueChildren = append(valueChildren, parts[1:]...)
+	if len(valueChildren) == 0 {
+		return false
+	}
+
+	value := valueChildren[0]
+	if len(valueChildren) > 1 {
+		value = newParentNodeInArena(arena, ctx.concatenationSym, true, cloneNodeSliceInArena(arena, valueChildren), nil, 0)
+	}
+
+	children := []*Node{name, value}
+	if arena != nil {
+		children = cloneNodeSliceInArena(arena, children)
+	}
+	node.symbol = ctx.variableAssignmentSym
+	node.isNamed = true
+	node.children = children
+	node.fieldIDs = bashGeneratedAssignmentFieldIDs(arena, ctx)
+	node.fieldSources = bashGeneratedAssignmentFieldSources(ctx)
+	node.hasError = false
+	populateParentNode(node, children)
+	return true
+}
+
+func bashGeneratedAssignmentParts(commandName *Node, ctx bashGeneratedAssignmentContext) []*Node {
+	if commandName == nil {
+		return nil
+	}
+	if len(commandName.children) != 1 {
+		return nil
+	}
+	child := commandName.children[0]
+	if child == nil {
+		return nil
+	}
+	if child.symbol == ctx.concatenationSym {
+		return child.children
+	}
+	return []*Node{child}
+}
+
+func bashSimpleAssignmentSplit(source []byte, startByte, endByte uint32) (uint32, uint32, bool) {
+	if startByte >= endByte || endByte > uint32(len(source)) {
+		return 0, 0, false
+	}
+	start := int(startByte)
+	end := int(endByte)
+	if !bashAssignmentNameStart(source[start]) {
+		return 0, 0, false
+	}
+	for i := start + 1; i < end; i++ {
+		c := source[i]
+		if c == '=' {
+			nameEnd := i
+			if i > start && source[i-1] == '+' {
+				nameEnd = i - 1
+			}
+			if nameEnd <= start {
+				return 0, 0, false
+			}
+			return uint32(nameEnd), uint32(i + 1), true
+		}
+		if c == '+' && i+1 < end && source[i+1] == '=' {
+			continue
+		}
+		if !bashAssignmentNameContinue(c) {
+			return 0, 0, false
+		}
+	}
+	return 0, 0, false
+}
+
+func bashAssignmentNameStart(c byte) bool {
+	return c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
+func bashAssignmentNameContinue(c byte) bool {
+	return bashAssignmentNameStart(c) || (c >= '0' && c <= '9')
+}
+
+func bashGeneratedAssignmentFieldIDs(arena *nodeArena, ctx bashGeneratedAssignmentContext) []FieldID {
+	if ctx.nameFieldID == 0 && ctx.valueFieldID == 0 {
+		return nil
+	}
+	fields := []FieldID{ctx.nameFieldID, ctx.valueFieldID}
+	if arena == nil {
+		return fields
+	}
+	out := arena.allocFieldIDSlice(len(fields))
+	copy(out, fields)
+	return out
+}
+
+func bashGeneratedAssignmentFieldSources(ctx bashGeneratedAssignmentContext) []uint8 {
+	if ctx.nameFieldID == 0 && ctx.valueFieldID == 0 {
+		return nil
+	}
+	return []uint8{fieldSourceDirect, fieldSourceDirect}
+}
+
 func bashAllVariableAssignments(node *Node, lang *Language) bool {
 	if node == nil || lang == nil || len(node.children) < 2 {
 		return false

--- a/parser_result_bash_perl_test.go
+++ b/parser_result_bash_perl_test.go
@@ -1,6 +1,73 @@
 package gotreesitter
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBashGeneratedCommandAssignmentsRewritesAssignmentShapedCommand(t *testing.T) {
+	lang := &Language{
+		Name:                  "bash",
+		GeneratedByGrammargen: true,
+		SymbolNames:           []string{"program", "command", "command_name", "concatenation", "variable_assignment", "variable_name", "word", "command_substitution"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "program", Visible: true, Named: true},
+			{Name: "command", Visible: true, Named: true},
+			{Name: "command_name", Visible: true, Named: true},
+			{Name: "concatenation", Visible: true, Named: true},
+			{Name: "variable_assignment", Visible: true, Named: true},
+			{Name: "variable_name", Visible: true, Named: true},
+			{Name: "word", Visible: true, Named: true},
+			{Name: "command_substitution", Visible: true, Named: true},
+		},
+		FieldNames: []string{"", "name", "value"},
+	}
+	source := []byte("zipname=npm-$(node ../cli.js -v).zip")
+	subStart := strings.Index(string(source), "$(")
+	subEnd := strings.Index(string(source), ").zip") + 1
+	if subStart < 0 || subEnd <= subStart {
+		t.Fatal("bad test source")
+	}
+
+	arena := newNodeArena(arenaClassFull)
+	word0 := newLeafNodeInArena(arena, 6, true, 0, uint32(subStart), Point{}, Point{Column: uint32(subStart)})
+	sub := newLeafNodeInArena(arena, 7, true, uint32(subStart), uint32(subEnd), Point{Column: uint32(subStart)}, Point{Column: uint32(subEnd)})
+	word1 := newLeafNodeInArena(arena, 6, true, uint32(subEnd), uint32(len(source)), Point{Column: uint32(subEnd)}, Point{Column: uint32(len(source))})
+	concat := newParentNodeInArena(arena, 3, true, []*Node{word0, sub, word1}, nil, 0)
+	commandName := newParentNodeInArena(arena, 2, true, []*Node{concat}, nil, 0)
+	command := newParentNodeInArena(arena, 1, true, []*Node{commandName}, nil, 0)
+
+	normalizeBashGeneratedCommandAssignments(command, source, lang)
+
+	if got, want := command.Type(lang), "variable_assignment"; got != want {
+		t.Fatalf("command.Type = %q, want %q", got, want)
+	}
+	if got, want := len(command.children), 2; got != want {
+		t.Fatalf("len(command.children) = %d, want %d", got, want)
+	}
+	if got, want := command.children[0].Type(lang), "variable_name"; got != want {
+		t.Fatalf("name type = %q, want %q", got, want)
+	}
+	if got, want := command.children[0].Text(source), "zipname"; got != want {
+		t.Fatalf("name text = %q, want %q", got, want)
+	}
+	value := command.children[1]
+	if got, want := value.Type(lang), "concatenation"; got != want {
+		t.Fatalf("value type = %q, want %q", got, want)
+	}
+	if got, want := value.children[0].Text(source), "npm-"; got != want {
+		t.Fatalf("value prefix = %q, want %q", got, want)
+	}
+	if got, want := value.children[2].Text(source), ".zip"; got != want {
+		t.Fatalf("value suffix = %q, want %q", got, want)
+	}
+	if got, want := command.fieldIDs[0], FieldID(1); got != want {
+		t.Fatalf("name field = %d, want %d", got, want)
+	}
+	if got, want := command.fieldIDs[1], FieldID(2); got != want {
+		t.Fatalf("value field = %d, want %d", got, want)
+	}
+}
 
 func TestNormalizeBashProgramVariableAssignmentsSplitsTopLevelWrapper(t *testing.T) {
 	lang := &Language{

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -164,6 +164,7 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) {
 func normalizeBashResultStrut(ctx resultCompatibilityContext) {
 	normalizeBashProgramVariableAssignments(ctx.root, ctx.lang)
 	normalizeBashGeneratedCommandAssignments(ctx.root, ctx.source, ctx.lang)
+	normalizeBashCommandNameArguments(ctx.root, ctx.lang)
 }
 
 func normalizeCResultStrut(ctx resultCompatibilityContext) {

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -163,6 +163,7 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) {
 
 func normalizeBashResultStrut(ctx resultCompatibilityContext) {
 	normalizeBashProgramVariableAssignments(ctx.root, ctx.lang)
+	normalizeBashGeneratedCommandAssignments(ctx.root, ctx.source, ctx.lang)
 }
 
 func normalizeCResultStrut(ctx resultCompatibilityContext) {


### PR DESCRIPTION
## What does this PR do?

Fixes Python imported-grammar parity and Swift grammargen parity validation. Python now reaches 25/25 real-corpus grammargen parity, Swift reaches 25/25 on the normal online runner path, and both are covered by focused regressions and ratcheted floors.

## Why this approach?

Python needs tree-sitter's binary repeat helper shape for broader corpus parity, but that made LR merge compaction choose the expression path over `type_alias_statement` for Python 3.12 type aliases. This adds an explicit `ExactPrefixStates` grammar hint so Python can preserve the early LR(1) context it needs without relying on an environment override.

Swift was also failing in normal Docker parity because the single-grammar runner cloned `tree-sitter/tree-sitter-swift` instead of the pinned `languages.lock` source. The runner now uses `languages.lock` repo URLs and commits, falling back to the old static map only when no lock entry exists.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
- [x] Affected parity validation ran in Docker, one language or grammar at a time
- [x] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

Validation run:

- `bash cgo_harness/docker/run_parity_in_docker.sh --no-build --memory 8g --cpus 4 --pids 4096 --label python-swift-focused -- "cd /workspace && go test ./grammargen -run '^(TestPythonTypeAliasStatementParity|TestPythonPatternMatchingParity|TestPythonFStringLiteralParity|TestPython2PrintChevronParity|TestSwiftGrammarBlobParity|TestEmitGrammarGoIncludesImportMetadata|TestExtendGrammarCopiesImportMetadata)$' -count=1 -v -timeout 10m"`
- `bash cgo_harness/docker/run_parity_in_docker.sh --no-build --memory 8g --cpus 4 --pids 4096 --label python-swift-grammar-tests -- "cd /workspace && go test ./grammargen -run '^(TestPython.*|TestSwift.*|TestImportedKotlinSwift.*|TestEmitGrammarGoIncludesImportMetadata|TestExtendGrammarCopiesImportMetadata)$' -count=1 -v -timeout 10m"`
- `bash cgo_harness/docker/run_single_grammar_parity.sh --no-build --max-cases 25 --timeout 15m python` -> 25/25 no-error, SExpr, and deep parity
- `bash cgo_harness/docker/run_single_grammar_parity.sh --no-build --max-cases 25 --timeout 15m swift` -> 25/25 no-error, SExpr, and deep parity
- `bash cgo_harness/docker/run_parity_in_docker.sh --no-build --memory 8g --cpus 4 --pids 4096 --label python-swift-floor-check -- "... GTS_GRAMMARGEN_REAL_CORPUS_REQUIRE_PARITY=1 GTS_GRAMMARGEN_REAL_CORPUS_ONLY=python,swift go test ./grammargen -run '^TestMultiGrammarImportRealCorpusParity$' ..."` -> 50/50 required parity
- `bash cgo_harness/docker/run_grammargen_c_parity.sh --no-build --seed-dir .parity_seed --offline --langs python,swift --max-cases 20 --max-bytes 262144 --timeout 45 --memory 8g --cpus 1 --pids 512 --gomaxprocs 1 --goflags -p=1 --label python-swift-floor`
- `bash -n cgo_harness/docker/run_single_grammar_parity.sh`
- `jq empty grammargen/testdata/real_corpus_parity_floors.json cgo_harness/testdata/grammargen_cgo_parity_floors.json`
- `git diff --check`

The direct grammargen-vs-C lane is ratcheted at Python 20/20 and Swift 19/20. Swift generated-vs-blob parity is 25/25; the C lane still records one Swift parser-vs-C divergence plus known blob-vs-C gaps, so this PR tracks that separately instead of hiding it.

## Performance

- [x] If perf-relevant, used the stable bench settings (`GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem`)
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
- [x] If large-grammar behavior changed, checked bounded RSS, timeout, or OOM behavior under Docker

Perf is not the goal of this PR. Bounded Docker correctness runs stayed within the 8g envelope: Python real-corpus max RSS was about 350 MB and Swift real-corpus max RSS was about 1.5 GB.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

Review your own diff before requesting review. Walk through it as if you're seeing it for the first time, and keep any self-review comments concise and focused on the non-obvious parts.

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

The main point worth review is the `ExactPrefixStates` escape hatch: it is intentionally grammar metadata, not a hidden env dependency, because Python needs exact early LR context while still retaining binary repeat mode for corpus parity.

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars
- [x] If adding a grammar or scanner: verified against upstream C output
