### PR TITLE
[codex] Fix query parity and top-50 compatibility coverage

### DIFF
--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -42,7 +42,6 @@ var knownDegradedStructural = map[string]string{
 	"cue":  "named wrapper/runtime alias shape still diverges from C reference",
 	"hare": "fresh parse structural parity still diverges from C reference",
 	"rst":  "fresh parse structural parity still diverges from C reference",
-	"toml": "fresh parse structural parity still diverges from C reference",
 }
 
 type parityCase struct {
@@ -149,6 +148,8 @@ func parityMode() string {
 	switch strings.ToLower(raw) {
 	case "", "smoke":
 		return "smoke"
+	case "top50", "tier1":
+		return "top50"
 	case "all", "full", "exhaustive":
 		return "exhaustive"
 	default:
@@ -160,6 +161,11 @@ func parityRunExhaustive() bool {
 	return parityMode() == "exhaustive"
 }
 
+func parityRunTop50() bool {
+	mode := parityMode()
+	return mode == "top50" || mode == "exhaustive"
+}
+
 func parityRequireExhaustive(t *testing.T, suite string) {
 	t.Helper()
 	if parityRunExhaustive() {
@@ -168,12 +174,23 @@ func parityRequireExhaustive(t *testing.T, suite string) {
 	t.Skipf("%s requires GTS_PARITY_MODE=exhaustive", suite)
 }
 
+func parityRequireTop50(t *testing.T, suite string) {
+	t.Helper()
+	if parityRunTop50() {
+		return
+	}
+	t.Skipf("%s requires GTS_PARITY_MODE=top50 or exhaustive", suite)
+}
+
 func parityIncludeStructuralLanguage(name string) bool {
 	if !curatedStructuralLanguages[name] {
 		return false
 	}
 	if parityRunExhaustive() {
 		return true
+	}
+	if parityMode() == "top50" {
+		return top50ParityLanguageSet[name]
 	}
 	return smokeParityLanguages[name]
 }
@@ -184,6 +201,9 @@ func parityIncludeHighlightLanguage(name string) bool {
 	}
 	if parityRunExhaustive() {
 		return true
+	}
+	if parityMode() == "top50" {
+		return top50ParityLanguageSet[name]
 	}
 	return smokeParityLanguages[name]
 }

--- a/cgo_harness/parity_highlight_test.go
+++ b/cgo_harness/parity_highlight_test.go
@@ -4,6 +4,7 @@ package cgoharness
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -132,6 +133,9 @@ func collectCHighlightCaptures(t *testing.T, cLang *sitter.Language, cTree *sitt
 		if m == nil {
 			break
 		}
+		if !cQueryMatchSatisfiesGeneralPredicates(m, cQuery, source) {
+			continue
+		}
 		for _, c := range m.Captures {
 			name := ""
 			if int(c.Index) < len(captureNames) {
@@ -148,6 +152,132 @@ func collectCHighlightCaptures(t *testing.T, cLang *sitter.Language, cTree *sitt
 		}
 	}
 	return deduplicateCaptures(caps)
+}
+
+func cQueryMatchSatisfiesGeneralPredicates(m *sitter.QueryMatch, query *sitter.Query, source []byte) bool {
+	if m == nil || query == nil {
+		return true
+	}
+	for _, pred := range query.GeneralPredicates(m.PatternIndex) {
+		switch pred.Operator {
+		case "lua-match?":
+			if len(pred.Args) != 2 || pred.Args[0].CaptureId == nil || pred.Args[1].String == nil {
+				return false
+			}
+			text, ok := cFirstCaptureTextForID(m, *pred.Args[0].CaptureId, source)
+			if !ok {
+				return false
+			}
+			rx, err := compileHighlightLuaPattern(*pred.Args[1].String)
+			if err != nil || !rx.MatchString(text) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func cFirstCaptureTextForID(m *sitter.QueryMatch, captureID uint, source []byte) (string, bool) {
+	for _, c := range m.Captures {
+		if uint(c.Index) != captureID {
+			continue
+		}
+		start := uint32(c.Node.StartByte())
+		end := uint32(c.Node.EndByte())
+		if start > end || end > uint32(len(source)) {
+			return "", false
+		}
+		return string(source[start:end]), true
+	}
+	return "", false
+}
+
+func compileHighlightLuaPattern(pattern string) (*regexp.Regexp, error) {
+	var out strings.Builder
+	inClass := false
+
+	writeLuaClass := func(ch byte, inClass bool) bool {
+		if inClass {
+			switch ch {
+			case 'a':
+				out.WriteString("A-Za-z")
+			case 'c':
+				out.WriteString("[:cntrl:]")
+			case 'd':
+				out.WriteString("0-9")
+			case 'l':
+				out.WriteString("a-z")
+			case 'p':
+				out.WriteString("[:punct:]")
+			case 's':
+				out.WriteString("\\s")
+			case 'u':
+				out.WriteString("A-Z")
+			case 'w':
+				out.WriteString("A-Za-z0-9")
+			case 'x':
+				out.WriteString("A-Fa-f0-9")
+			case 'z':
+				out.WriteString("\\x00")
+			default:
+				return false
+			}
+			return true
+		}
+
+		switch ch {
+		case 'a':
+			out.WriteString("[A-Za-z]")
+		case 'c':
+			out.WriteString("[[:cntrl:]]")
+		case 'd':
+			out.WriteString("[0-9]")
+		case 'l':
+			out.WriteString("[a-z]")
+		case 'p':
+			out.WriteString("[[:punct:]]")
+		case 's':
+			out.WriteString("\\s")
+		case 'u':
+			out.WriteString("[A-Z]")
+		case 'w':
+			out.WriteString("[A-Za-z0-9]")
+		case 'x':
+			out.WriteString("[A-Fa-f0-9]")
+		case 'z':
+			out.WriteString("\\x00")
+		default:
+			return false
+		}
+		return true
+	}
+
+	for i := 0; i < len(pattern); i++ {
+		ch := pattern[i]
+		switch ch {
+		case '[':
+			inClass = true
+			out.WriteByte(ch)
+		case ']':
+			inClass = false
+			out.WriteByte(ch)
+		case '%':
+			if i+1 >= len(pattern) {
+				out.WriteString("%")
+				continue
+			}
+			i++
+			next := pattern[i]
+			if writeLuaClass(next, inClass) {
+				continue
+			}
+			out.WriteString(regexp.QuoteMeta(string(next)))
+		default:
+			out.WriteByte(ch)
+		}
+	}
+
+	return regexp.Compile(out.String())
 }
 
 // deduplicateCaptures sorts captures by (start, end, name) and removes exact duplicates.

--- a/cgo_harness/parity_highlight_test.go
+++ b/cgo_harness/parity_highlight_test.go
@@ -195,60 +195,108 @@ func cFirstCaptureTextForID(m *sitter.QueryMatch, captureID uint, source []byte)
 func compileHighlightLuaPattern(pattern string) (*regexp.Regexp, error) {
 	var out strings.Builder
 	inClass := false
+	classContentStart := false
 
-	writeLuaClass := func(ch byte, inClass bool) bool {
+	writeLuaClass := func(ch byte, inClass bool, classContentStart bool) bool {
+		inClassText := ""
+		outsideText := ""
 		if inClass {
 			switch ch {
 			case 'a':
-				out.WriteString("A-Za-z")
+				inClassText = "A-Za-z"
+			case 'A':
+				inClassText = "^A-Za-z"
 			case 'c':
-				out.WriteString("[:cntrl:]")
+				inClassText = "[:cntrl:]"
+			case 'C':
+				inClassText = "^[:cntrl:]"
 			case 'd':
-				out.WriteString("0-9")
+				inClassText = "0-9"
+			case 'D':
+				inClassText = "^0-9"
 			case 'l':
-				out.WriteString("a-z")
+				inClassText = "a-z"
+			case 'L':
+				inClassText = "^a-z"
 			case 'p':
-				out.WriteString("[:punct:]")
+				inClassText = "[:punct:]"
+			case 'P':
+				inClassText = "^[:punct:]"
 			case 's':
-				out.WriteString("\\s")
+				inClassText = "\\s"
+			case 'S':
+				inClassText = "^\\s"
 			case 'u':
-				out.WriteString("A-Z")
+				inClassText = "A-Z"
+			case 'U':
+				inClassText = "^A-Z"
 			case 'w':
-				out.WriteString("A-Za-z0-9")
+				inClassText = "A-Za-z0-9"
+			case 'W':
+				inClassText = "^A-Za-z0-9"
 			case 'x':
-				out.WriteString("A-Fa-f0-9")
+				inClassText = "A-Fa-f0-9"
+			case 'X':
+				inClassText = "^A-Fa-f0-9"
 			case 'z':
-				out.WriteString("\\x00")
+				inClassText = "\\x00"
+			case 'Z':
+				inClassText = "^\\x00"
 			default:
 				return false
 			}
+			if strings.HasPrefix(inClassText, "^") && !classContentStart {
+				return false
+			}
+			out.WriteString(inClassText)
 			return true
 		}
 
 		switch ch {
 		case 'a':
-			out.WriteString("[A-Za-z]")
+			outsideText = "[A-Za-z]"
+		case 'A':
+			outsideText = "[^A-Za-z]"
 		case 'c':
-			out.WriteString("[[:cntrl:]]")
+			outsideText = "[[:cntrl:]]"
+		case 'C':
+			outsideText = "[^[:cntrl:]]"
 		case 'd':
-			out.WriteString("[0-9]")
+			outsideText = "[0-9]"
+		case 'D':
+			outsideText = "[^0-9]"
 		case 'l':
-			out.WriteString("[a-z]")
+			outsideText = "[a-z]"
+		case 'L':
+			outsideText = "[^a-z]"
 		case 'p':
-			out.WriteString("[[:punct:]]")
+			outsideText = "[[:punct:]]"
+		case 'P':
+			outsideText = "[^[:punct:]]"
 		case 's':
-			out.WriteString("\\s")
+			outsideText = "\\s"
+		case 'S':
+			outsideText = "\\S"
 		case 'u':
-			out.WriteString("[A-Z]")
+			outsideText = "[A-Z]"
+		case 'U':
+			outsideText = "[^A-Z]"
 		case 'w':
-			out.WriteString("[A-Za-z0-9]")
+			outsideText = "[A-Za-z0-9]"
+		case 'W':
+			outsideText = "[^A-Za-z0-9]"
 		case 'x':
-			out.WriteString("[A-Fa-f0-9]")
+			outsideText = "[A-Fa-f0-9]"
+		case 'X':
+			outsideText = "[^A-Fa-f0-9]"
 		case 'z':
-			out.WriteString("\\x00")
+			outsideText = "\\x00"
+		case 'Z':
+			outsideText = "[^\\x00]"
 		default:
 			return false
 		}
+		out.WriteString(outsideText)
 		return true
 	}
 
@@ -257,9 +305,11 @@ func compileHighlightLuaPattern(pattern string) (*regexp.Regexp, error) {
 		switch ch {
 		case '[':
 			inClass = true
+			classContentStart = true
 			out.WriteByte(ch)
 		case ']':
 			inClass = false
+			classContentStart = false
 			out.WriteByte(ch)
 		case '%':
 			if i+1 >= len(pattern) {
@@ -268,16 +318,92 @@ func compileHighlightLuaPattern(pattern string) (*regexp.Regexp, error) {
 			}
 			i++
 			next := pattern[i]
-			if writeLuaClass(next, inClass) {
+			if writeLuaClass(next, inClass, classContentStart) {
+				if inClass {
+					classContentStart = false
+				}
 				continue
 			}
 			out.WriteString(regexp.QuoteMeta(string(next)))
+			if inClass {
+				classContentStart = false
+			}
+		case '-':
+			if inClass {
+				out.WriteByte(ch)
+				classContentStart = false
+				continue
+			}
+			out.WriteString("*?")
 		default:
 			out.WriteByte(ch)
+			if inClass {
+				classContentStart = false
+			}
 		}
 	}
 
 	return regexp.Compile(out.String())
+}
+
+func TestCompileHighlightLuaPatternUppercaseClassesAndNonGreedy(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   string
+		matches   []string
+		nonMatch  []string
+		findInput string
+		findWant  string
+	}{
+		{
+			name:     "non-digit",
+			pattern:  `^%D+$`,
+			matches:  []string{"abc", "_-"},
+			nonMatch: []string{"123", "abc1"},
+		},
+		{
+			name:     "non-space",
+			pattern:  `^%S+$`,
+			matches:  []string{"abc"},
+			nonMatch: []string{"a b", "\t"},
+		},
+		{
+			name:     "non-word",
+			pattern:  `^%W+$`,
+			matches:  []string{"-!", "_"},
+			nonMatch: []string{"abc", "A1"},
+		},
+		{
+			name:      "non-greedy",
+			pattern:   `a.-b`,
+			findInput: "a123b456b",
+			findWant:  "a123b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rx, err := compileHighlightLuaPattern(tt.pattern)
+			if err != nil {
+				t.Fatalf("compileHighlightLuaPattern(%q): %v", tt.pattern, err)
+			}
+			for _, input := range tt.matches {
+				if !rx.MatchString(input) {
+					t.Fatalf("compileHighlightLuaPattern(%q).MatchString(%q) = false, want true", tt.pattern, input)
+				}
+			}
+			for _, input := range tt.nonMatch {
+				if rx.MatchString(input) {
+					t.Fatalf("compileHighlightLuaPattern(%q).MatchString(%q) = true, want false", tt.pattern, input)
+				}
+			}
+			if tt.findInput != "" {
+				if got := rx.FindString(tt.findInput); got != tt.findWant {
+					t.Fatalf("compileHighlightLuaPattern(%q).FindString(%q) = %q, want %q", tt.pattern, tt.findInput, got, tt.findWant)
+				}
+			}
+		})
+	}
 }
 
 // deduplicateCaptures sorts captures by (start, end, name) and removes exact duplicates.

--- a/cgo_harness/parity_query_exact_test.go
+++ b/cgo_harness/parity_query_exact_test.go
@@ -1,0 +1,368 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type exactQueryCase struct {
+	name   string
+	lang   string
+	source string
+	query  string
+}
+
+type exactQueryMatch struct {
+	PatternIndex int
+	Captures     []exactQueryCapture
+}
+
+type exactQueryCapture struct {
+	Name      string
+	Type      string
+	Named     bool
+	StartByte uint32
+	EndByte   uint32
+	Text      string
+}
+
+func TestParityQueryExactJavaScriptEcosystemPatterns(t *testing.T) {
+	cases := []exactQueryCase{
+		{
+			name: "top_level_comments_are_separate_matches",
+			lang: "javascript",
+			source: `// one
+// two
+const value = 1;
+// three
+`,
+			query: `(program (comment) @comment)`,
+		},
+		{
+			name: "anchor_after_zero_or_more_comments",
+			lang: "javascript",
+			source: `const one = require("one");
+const two = require(
+  // keep this with the dependency
+  "two"
+);
+const three = require(
+  /* leading block */
+  // leading line
+  "three"
+);
+`,
+			query: `
+(call_expression
+  function: (identifier) @fn
+  arguments: (arguments . (comment)* . (string (string_fragment) @from))
+  (#eq? @fn "require"))
+`,
+		},
+		{
+			name:   "repeated_capture_grouping",
+			lang:   "javascript",
+			source: `const values = [alpha, beta, gamma];`,
+			query:  `(array (identifier) @item)`,
+		},
+		{
+			name: "top_level_repetition_groups_adjacent_comments",
+			lang: "javascript",
+			source: `// a
+// b
+// c
+
+call();
+
+// d
+`,
+			query: `(comment)+ @doc`,
+		},
+		{
+			name: "parent_repetition_uses_first_contiguous_comment_run",
+			lang: "javascript",
+			source: `// a
+// b
+// c
+
+call();
+
+// d
+`,
+			query: `(program (comment)+ @doc)`,
+		},
+		{
+			name: "parent_star_repetition_uses_first_contiguous_comment_run",
+			lang: "javascript",
+			source: `// a
+// b
+// c
+
+call();
+
+// d
+`,
+			query: `(program (comment)* @doc)`,
+		},
+		{
+			name:   "parent_star_repetition_without_child",
+			lang:   "javascript",
+			source: `call();`,
+			query:  `(program (comment)* @doc)`,
+		},
+		{
+			name:   "parent_optional_repetition_without_child",
+			lang:   "javascript",
+			source: `call();`,
+			query:  `(program (comment)? @doc)`,
+		},
+		{
+			name: "top_level_star_repetition_groups_adjacent_comments",
+			lang: "javascript",
+			source: `// a
+// b
+// c
+
+call();
+
+// d
+`,
+			query: `(comment)* @doc`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertExactQueryParity(t, tc)
+		})
+	}
+}
+
+func TestParityQueryExactKeywordStringPatterns(t *testing.T) {
+	cases := []exactQueryCase{
+		{
+			name:   "kotlin_val_keyword_alias",
+			lang:   "kotlin",
+			source: grammars.ParseSmokeSample("kotlin"),
+			query:  `"val" @keyword`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertExactQueryParity(t, tc)
+		})
+	}
+}
+
+func assertExactQueryParity(t *testing.T, tc exactQueryCase) {
+	t.Helper()
+
+	src := []byte(tc.source)
+	goTree, goLang, err := parseWithGo(parityCase{name: tc.lang, source: tc.source}, src, nil)
+	if err != nil {
+		t.Fatalf("Go parse error: %v", err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLang, err := ParityCLanguage(tc.lang)
+	if err != nil {
+		if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+			t.Skipf("skip C reference parser: %s", skipReason)
+		}
+		t.Fatalf("load C parser: %v", err)
+	}
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+			t.Skipf("skip C reference parser SetLanguage: %s", skipReason)
+		}
+		t.Fatalf("C SetLanguage: %v", err)
+	}
+	cTree := cParser.Parse(src, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C parser returned nil tree")
+	}
+	defer cTree.Close()
+
+	var structuralErrs []string
+	compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &structuralErrs)
+
+	goMatches := collectGoExactQueryMatches(t, goLang, goTree, tc.query, src)
+	cMatches := collectCExactQueryMatches(t, cLang, cTree, tc.query, src)
+
+	queryMatches := reflect.DeepEqual(goMatches, cMatches)
+	if len(structuralErrs) == 0 && queryMatches {
+		return
+	}
+
+	var structuralReport string
+	if len(structuralErrs) > 0 {
+		structuralReport = fmt.Sprintf("\nStructural divergence:\n%s\nGo root: %s\nC root:  %s\nGo children:\n%s\nC children:\n%s",
+			firstLines(structuralErrs, 12),
+			goTree.RootNode().SExpr(goLang),
+			cTree.RootNode().ToSexp(),
+			formatGoRootChildren(goTree.RootNode(), goLang, src),
+			formatCRootChildren(cTree.RootNode(), src))
+	}
+
+	var queryReport string
+	if !queryMatches {
+		queryReport = fmt.Sprintf("\nQuery divergence:\nGo:\n%s\nC:\n%s",
+			formatExactQueryMatches(goMatches),
+			formatExactQueryMatches(cMatches))
+	}
+
+	t.Fatalf("exact query parity mismatch for %s/%s\nQuery:\n%s%s%s",
+		tc.lang, tc.name,
+		strings.TrimSpace(tc.query),
+		structuralReport,
+		queryReport)
+}
+
+func collectGoExactQueryMatches(t *testing.T, lang *gotreesitter.Language, tree *gotreesitter.Tree, queryStr string, source []byte) []exactQueryMatch {
+	t.Helper()
+
+	q, err := gotreesitter.NewQuery(queryStr, lang)
+	if err != nil {
+		t.Fatalf("Go NewQuery error: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), lang, source)
+	var matches []exactQueryMatch
+	for {
+		m, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		snap := exactQueryMatch{PatternIndex: m.PatternIndex}
+		for _, c := range m.Captures {
+			if c.Node == nil {
+				continue
+			}
+			snap.Captures = append(snap.Captures, exactQueryCapture{
+				Name:      c.Name,
+				Type:      c.Node.Type(lang),
+				Named:     c.Node.IsNamed(),
+				StartByte: c.Node.StartByte(),
+				EndByte:   c.Node.EndByte(),
+				Text:      c.Text(source),
+			})
+		}
+		matches = append(matches, snap)
+	}
+	return matches
+}
+
+func collectCExactQueryMatches(t *testing.T, lang *sitter.Language, tree *sitter.Tree, queryStr string, source []byte) []exactQueryMatch {
+	t.Helper()
+
+	query, err := sitter.NewQuery(lang, queryStr)
+	if err != nil {
+		t.Fatalf("C NewQuery error: %v", err)
+	}
+	defer query.Close()
+
+	cursor := sitter.NewQueryCursor()
+	defer cursor.Close()
+
+	names := query.CaptureNames()
+	iter := cursor.Matches(query, tree.RootNode(), source)
+
+	var matches []exactQueryMatch
+	for {
+		m := iter.Next()
+		if m == nil {
+			break
+		}
+		snap := exactQueryMatch{PatternIndex: int(m.PatternIndex)}
+		for _, c := range m.Captures {
+			name := ""
+			if int(c.Index) < len(names) {
+				name = names[c.Index]
+			}
+			start := uint32(c.Node.StartByte())
+			end := uint32(c.Node.EndByte())
+			snap.Captures = append(snap.Captures, exactQueryCapture{
+				Name:      name,
+				Type:      c.Node.Kind(),
+				Named:     c.Node.IsNamed(),
+				StartByte: start,
+				EndByte:   end,
+				Text:      string(source[start:end]),
+			})
+		}
+		matches = append(matches, snap)
+	}
+	return matches
+}
+
+func formatExactQueryMatches(matches []exactQueryMatch) string {
+	if len(matches) == 0 {
+		return "  <no matches>"
+	}
+	var b strings.Builder
+	for i, m := range matches {
+		fmt.Fprintf(&b, "  match[%d] pattern=%d captures=%d\n", i, m.PatternIndex, len(m.Captures))
+		for j, c := range m.Captures {
+			fmt.Fprintf(&b, "    capture[%d] @%s %s named=%v [%d-%d] %q\n",
+				j, c.Name, c.Type, c.Named, c.StartByte, c.EndByte, c.Text)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func firstLines(lines []string, limit int) string {
+	if len(lines) <= limit {
+		return strings.Join(lines, "\n")
+	}
+	return strings.Join(lines[:limit], "\n") + fmt.Sprintf("\n... and %d more", len(lines)-limit)
+}
+
+func formatGoRootChildren(root *gotreesitter.Node, lang *gotreesitter.Language, source []byte) string {
+	if root == nil {
+		return "  <nil>"
+	}
+	var b strings.Builder
+	for i := 0; i < root.ChildCount(); i++ {
+		child := root.Child(i)
+		if child == nil {
+			fmt.Fprintf(&b, "  [%d] <nil>\n", i)
+			continue
+		}
+		fmt.Fprintf(&b, "  [%d] %s named=%v [%d-%d] %q\n",
+			i, child.Type(lang), child.IsNamed(), child.StartByte(), child.EndByte(), child.Text(source))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func formatCRootChildren(root *sitter.Node, source []byte) string {
+	if root == nil {
+		return "  <nil>"
+	}
+	var b strings.Builder
+	for i := uint(0); i < uint(root.ChildCount()); i++ {
+		child := root.Child(i)
+		if child == nil {
+			fmt.Fprintf(&b, "  [%d] <nil>\n", i)
+			continue
+		}
+		start := uint32(child.StartByte())
+		end := uint32(child.EndByte())
+		fmt.Fprintf(&b, "  [%d] %s named=%v [%d-%d] %q\n",
+			i, child.Kind(), child.IsNamed(), start, end, string(source[start:end]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/cgo_harness/parity_query_top50_test.go
+++ b/cgo_harness/parity_query_top50_test.go
@@ -1,0 +1,224 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type generatedExactQuery struct {
+	name  string
+	query string
+}
+
+func TestParityQueryExactTop50Generated(t *testing.T) {
+	parityRequireTop50(t, "TestParityQueryExactTop50Generated")
+	for _, name := range top50ParityLanguages {
+		if parityLanguageExcluded(name) {
+			continue
+		}
+		report, ok := paritySupportByName[name]
+		if !ok || report.Backend == grammars.ParseBackendUnsupported {
+			continue
+		}
+		if !hasDedicatedSample[name] {
+			continue
+		}
+
+		tc := parityCase{name: name, source: grammars.ParseSmokeSample(name)}
+		t.Run(name, func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+			if reason := paritySkipReason(tc.name); reason != "" {
+				t.Skipf("known mismatch: %s", reason)
+			}
+			queries := generatedExactQueriesForTop50Smoke(t, tc)
+			if len(queries) == 0 {
+				t.Skip("no generated exact query cases")
+			}
+			for _, qc := range queries {
+				qc := qc
+				t.Run(qc.name, func(t *testing.T) {
+					assertExactQueryParity(t, exactQueryCase{
+						name:   qc.name,
+						lang:   tc.name,
+						source: tc.source,
+						query:  qc.query,
+					})
+				})
+			}
+		})
+	}
+}
+
+func generatedExactQueriesForTop50Smoke(t *testing.T, tc parityCase) []generatedExactQuery {
+	t.Helper()
+	src := normalizedSource(tc.name, tc.source)
+	cLang, err := ParityCLanguage(tc.name)
+	if err != nil {
+		if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+			t.Skipf("skip C reference parser: %s", skipReason)
+		}
+		t.Fatalf("load C parser: %v", err)
+	}
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+			t.Skipf("skip C reference parser SetLanguage: %s", skipReason)
+		}
+		t.Fatalf("C SetLanguage: %v", err)
+	}
+	cTree := cParser.Parse(src, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C parser returned nil tree")
+	}
+	defer cTree.Close()
+
+	return generatedExactQueriesFromCTree(cTree.RootNode())
+}
+
+func generatedExactQueriesFromCTree(root *sitter.Node) []generatedExactQuery {
+	if root == nil {
+		return nil
+	}
+
+	var queries []generatedExactQuery
+	add := func(name, query string) {
+		for _, existing := range queries {
+			if existing.query == query {
+				return
+			}
+		}
+		queries = append(queries, generatedExactQuery{name: name, query: query})
+	}
+
+	rootKind := root.Kind()
+	if queryNodeTypeUsable(rootKind) {
+		add("root_capture", fmt.Sprintf("(%s) @root", rootKind))
+	}
+	add("named_wildcard", "(_) @node")
+
+	firstNamed := firstNamedDescendant(root)
+	firstNamedKind := ""
+	if firstNamed != nil && queryNodeTypeUsable(firstNamed.Kind()) {
+		firstNamedKind = firstNamed.Kind()
+		add("first_named_type", fmt.Sprintf("(%s) @node", firstNamedKind))
+		add("first_named_plus", fmt.Sprintf("(%s)+ @node", firstNamedKind))
+		if countCNodes(root) <= 120 {
+			add("first_named_star", fmt.Sprintf("(%s)* @node", firstNamedKind))
+		}
+	}
+
+	firstChild := firstNamedDirectChild(root)
+	if firstChild != nil && queryNodeTypeUsable(rootKind) && queryNodeTypeUsable(firstChild.Kind()) {
+		childKind := firstChild.Kind()
+		add("root_child", fmt.Sprintf("(%s (%s) @child)", rootKind, childKind))
+		add("root_child_plus", fmt.Sprintf("(%s (%s)+ @child)", rootKind, childKind))
+		add("root_child_star", fmt.Sprintf("(%s (%s)* @child)", rootKind, childKind))
+	}
+
+	parent, runKind := firstAdjacentNamedSiblingRun(root)
+	if parent != nil && queryNodeTypeUsable(parent.Kind()) && queryNodeTypeUsable(runKind) {
+		add("adjacent_sibling_run_plus", fmt.Sprintf("(%s (%s)+ @run)", parent.Kind(), runKind))
+		add("adjacent_sibling_run_star", fmt.Sprintf("(%s (%s)* @run)", parent.Kind(), runKind))
+	}
+
+	return queries
+}
+
+func queryNodeTypeUsable(kind string) bool {
+	if kind == "" || kind == "ERROR" {
+		return false
+	}
+	for i, r := range kind {
+		switch {
+		case i == 0 && !(unicode.IsLetter(r) || r == '_'):
+			return false
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '_', r == '.', r == '-', r == '/':
+			continue
+		default:
+			return false
+		}
+	}
+	return !strings.HasPrefix(kind, "MISSING")
+}
+
+func firstNamedDescendant(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.IsNamed() {
+			return child
+		}
+		if found := firstNamedDescendant(child); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func firstNamedDirectChild(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child != nil && child.IsNamed() && queryNodeTypeUsable(child.Kind()) {
+			return child
+		}
+	}
+	return nil
+}
+
+func firstAdjacentNamedSiblingRun(root *sitter.Node) (*sitter.Node, string) {
+	var visit func(*sitter.Node) (*sitter.Node, string)
+	visit = func(node *sitter.Node) (*sitter.Node, string) {
+		if node == nil {
+			return nil, ""
+		}
+		prevKind := ""
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			if child == nil {
+				continue
+			}
+			if child.IsNamed() && queryNodeTypeUsable(child.Kind()) {
+				if child.Kind() == prevKind {
+					return node, child.Kind()
+				}
+				prevKind = child.Kind()
+			}
+		}
+		for i := uint(0); i < node.ChildCount(); i++ {
+			if parent, kind := visit(node.Child(i)); parent != nil {
+				return parent, kind
+			}
+		}
+		return nil, ""
+	}
+	return visit(root)
+}
+
+func countCNodes(root *sitter.Node) int {
+	if root == nil {
+		return 0
+	}
+	total := 1
+	for i := uint(0); i < root.ChildCount(); i++ {
+		total += countCNodes(root.Child(i))
+	}
+	return total
+}

--- a/cgo_harness/parity_top50_materialization_test.go
+++ b/cgo_harness/parity_top50_materialization_test.go
@@ -1,0 +1,123 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestParityTop50ParseMaterializationTrends(t *testing.T) {
+	parityRequireTop50(t, "TestParityTop50ParseMaterializationTrends")
+
+	gotreesitter.EnableRuntimeAudit(true)
+	t.Cleanup(func() {
+		gotreesitter.EnableRuntimeAudit(false)
+	})
+
+	for _, name := range top50ParityLanguages {
+		if parityLanguageExcluded(name) {
+			continue
+		}
+		report, ok := paritySupportByName[name]
+		if !ok || report.Backend == grammars.ParseBackendUnsupported {
+			continue
+		}
+		if !hasDedicatedSample[name] {
+			continue
+		}
+
+		tc := parityCase{name: name, source: grammars.ParseSmokeSample(name)}
+		t.Run(name, func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+
+			src := normalizedSource(tc.name, tc.source)
+			tree, lang, err := parseWithGo(tc, src, nil)
+			if err != nil {
+				t.Fatalf("gotreesitter parse error: %v", err)
+			}
+			defer releaseGoTree(tree)
+
+			root := tree.RootNode()
+			rt := tree.ParseRuntime()
+			divergences, firstDivergence := top50StructuralDivergenceSummary(t, tc, src, tree, lang)
+
+			t.Logf("TOP50_PARSE_MATERIALIZATION language=%s backend=%s bytes=%d root=%q has_error=%v structural_divergences=%d first_divergence=%q stop=%s tokens=%d nodes_alloc=%d final_nodes=%d final_parents=%d final_leaves=%d max_stacks=%d arena_bytes=%d scratch_bytes=%d gss_bytes=%d parent_alloc=%d parent_retained=%d leaf_alloc=%d leaf_retained=%d compact_leaf_created=%d compact_leaf_materialized=%d compact_leaf_final=%d pending_parent_created=%d pending_parent_materialized=%d pending_parent_final=%d transient_parent_alloc=%d transient_parent_materialized=%d transient_child_slices_alloc=%d transient_child_slices_materialized=%d transient_child_ptrs_alloc=%d transient_child_ptrs_materialized=%d normalization_checked=%d normalization_run=%d normalization_rewritten=%d summary=%q",
+				tc.name,
+				report.Backend,
+				len(src),
+				root.Type(lang),
+				root.HasError(),
+				divergences,
+				firstDivergence,
+				rt.StopReason,
+				rt.TokensConsumed,
+				rt.NodesAllocated,
+				rt.FinalNodes,
+				rt.FinalParentNodes,
+				rt.FinalLeafNodes,
+				rt.MaxStacksSeen,
+				rt.ArenaBytesAllocated,
+				rt.ScratchBytesAllocated,
+				rt.GSSBytesAllocated,
+				rt.ParentNodesAllocated,
+				rt.ParentNodesRetained,
+				rt.LeafNodesAllocated,
+				rt.LeafNodesRetained,
+				rt.CompactFullLeafCreated,
+				rt.CompactFullLeafMaterialized,
+				rt.CompactFullLeafMaterializedForFinalTree,
+				rt.PendingParentCreated,
+				rt.PendingParentMaterialized,
+				rt.PendingParentMaterializedForFinalTree,
+				rt.TransientParentNodesAllocated,
+				rt.TransientParentNodesMaterialized,
+				rt.TransientChildSlicesAllocated,
+				rt.TransientChildSlicesMaterialized,
+				rt.TransientChildPointersAllocated,
+				rt.TransientChildPointersMaterialized,
+				rt.NormalizationPassesChecked,
+				rt.NormalizationPassesRun,
+				rt.NormalizationNodesRewritten,
+				rt.Summary(),
+			)
+		})
+	}
+}
+
+func top50StructuralDivergenceSummary(t *testing.T, tc parityCase, src []byte, goTree *gotreesitter.Tree, goLang *gotreesitter.Language) (int, string) {
+	t.Helper()
+
+	cLang, err := ParityCLanguage(tc.name)
+	if err != nil {
+		if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+			return 0, "skip C reference: " + skipReason
+		}
+		return 1, "load C parser: " + err.Error()
+	}
+
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+			return 0, "skip C SetLanguage: " + skipReason
+		}
+		return 1, "C SetLanguage: " + err.Error()
+	}
+	cTree := cParser.Parse(src, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		return 1, "C parser returned nil tree"
+	}
+	defer cTree.Close()
+
+	var errs []string
+	compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+	if len(errs) == 0 {
+		return 0, ""
+	}
+	return len(errs), strings.TrimSpace(errs[0])
+}

--- a/cgo_harness/parity_top50_test.go
+++ b/cgo_harness/parity_top50_test.go
@@ -1,0 +1,66 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+// top50ParityLanguages is the lock-step top-50 correctness surface used by
+// grammars/update_tier1_top50.txt and cgo_harness/testdata/top50_manifest.json.
+var top50ParityLanguages = []string{
+	"bash",
+	"c",
+	"cpp",
+	"c_sharp",
+	"cmake",
+	"css",
+	"dart",
+	"elixir",
+	"elm",
+	"erlang",
+	"go",
+	"gomod",
+	"graphql",
+	"haskell",
+	"hcl",
+	"html",
+	"ini",
+	"java",
+	"javascript",
+	"json",
+	"json5",
+	"julia",
+	"kotlin",
+	"lua",
+	"make",
+	"markdown",
+	"nix",
+	"objc",
+	"ocaml",
+	"perl",
+	"php",
+	"powershell",
+	"python",
+	"r",
+	"ruby",
+	"rust",
+	"scala",
+	"scss",
+	"sql",
+	"svelte",
+	"swift",
+	"toml",
+	"tsx",
+	"typescript",
+	"xml",
+	"yaml",
+	"zig",
+	"awk",
+	"clojure",
+	"d",
+}
+
+var top50ParityLanguageSet = func() map[string]bool {
+	out := make(map[string]bool, len(top50ParityLanguages))
+	for _, name := range top50ParityLanguages {
+		out[name] = true
+	}
+	return out
+}()

--- a/language.go
+++ b/language.go
@@ -496,18 +496,6 @@ func (l *Language) buildSymbolMaps() {
 			if _, exists := l.symbolNameNamedMap[key]; !exists {
 				l.symbolNameNamedMap[key] = sym
 			}
-			// Map each symbol to the canonical (first) symbol with its name.
-			l.publicSymbolMap[i] = l.symbolNameMap[sn]
-			if namedSym, exists := l.symbolNameNamedMap[symbolNameNamedKey{name: sn, named: true}]; exists {
-				l.publicNamedSymbolMap[i] = namedSym
-			} else {
-				l.publicNamedSymbolMap[i] = l.symbolNameMap[sn]
-			}
-			if anonSym, exists := l.symbolNameNamedMap[symbolNameNamedKey{name: sn, named: false}]; exists {
-				l.publicAnonymousSymbolMap[i] = anonSym
-			} else {
-				l.publicAnonymousSymbolMap[i] = l.symbolNameMap[sn]
-			}
 			if i < tokenCount {
 				l.tokenSymbolNameMap[sn] = append(l.tokenSymbolNameMap[sn], sym)
 			}

--- a/language.go
+++ b/language.go
@@ -275,10 +275,13 @@ type Language struct {
 	InitialState StateID
 
 	// Lazily-built lookup maps for O(1) name resolution.
-	symbolNameMap      map[string]Symbol
-	tokenSymbolNameMap map[string][]Symbol
-	publicSymbolMap    []Symbol // internal symbol → canonical public symbol
-	fieldNameMap       map[string]FieldID
+	symbolNameMap            map[string]Symbol
+	symbolNameNamedMap       map[symbolNameNamedKey]Symbol
+	tokenSymbolNameMap       map[string][]Symbol
+	publicSymbolMap          []Symbol // internal symbol → canonical public symbol
+	publicNamedSymbolMap     []Symbol // internal symbol -> canonical public named symbol
+	publicAnonymousSymbolMap []Symbol // internal symbol -> canonical public anonymous symbol
+	fieldNameMap             map[string]FieldID
 
 	symbolMapOnce sync.Once
 	fieldMapOnce  sync.Once
@@ -290,6 +293,11 @@ type Language struct {
 	lexAsciiOnce         sync.Once
 	keywordLexAsciiTable [][128]int32
 	keywordLexAsciiOnce  sync.Once
+}
+
+type symbolNameNamedKey struct {
+	name  string
+	named bool
 }
 
 const lexAsciiNoMatch = int32(0x7FFF_FFFF)
@@ -390,6 +398,22 @@ func (l *Language) SymbolByName(name string) (Symbol, bool) {
 	return sym, ok
 }
 
+func (l *Language) symbolByNameAndNamed(name string, named bool) (Symbol, bool) {
+	if name == "_" {
+		return 0, true
+	}
+	l.buildSymbolMaps()
+	sym, ok := l.symbolNameNamedMap[symbolNameNamedKey{name: name, named: named}]
+	return sym, ok
+}
+
+func (l *Language) symbolByNamePreferNamed(name string) (Symbol, bool) {
+	if sym, ok := l.symbolByNameAndNamed(name, true); ok {
+		return sym, true
+	}
+	return l.SymbolByName(name)
+}
+
 // TokenSymbolsByName returns all terminal token symbols whose display name
 // matches name. The returned symbols are in grammar order.
 func (l *Language) TokenSymbolsByName(name string) []Symbol {
@@ -414,11 +438,38 @@ func (l *Language) PublicSymbol(sym Symbol) Symbol {
 	return sym
 }
 
+// PublicSymbolForNamedness maps an internal symbol to the canonical public
+// symbol with the same display name and requested namedness. This lets query
+// matching distinguish named nodes from anonymous tokens that share text.
+func (l *Language) PublicSymbolForNamedness(sym Symbol, named bool) Symbol {
+	if l == nil {
+		return sym
+	}
+	l.buildSymbolMaps()
+	idx := int(sym)
+	if idx < 0 || idx >= len(l.SymbolNames) {
+		return sym
+	}
+	if named {
+		if idx < len(l.publicNamedSymbolMap) {
+			return l.publicNamedSymbolMap[idx]
+		}
+		return sym
+	}
+	if idx < len(l.publicAnonymousSymbolMap) {
+		return l.publicAnonymousSymbolMap[idx]
+	}
+	return sym
+}
+
 func (l *Language) buildSymbolMaps() {
 	l.symbolMapOnce.Do(func() {
 		l.symbolNameMap = make(map[string]Symbol, len(l.SymbolNames))
+		l.symbolNameNamedMap = make(map[symbolNameNamedKey]Symbol, len(l.SymbolNames))
 		l.tokenSymbolNameMap = make(map[string][]Symbol)
 		l.publicSymbolMap = make([]Symbol, len(l.SymbolNames))
+		l.publicNamedSymbolMap = make([]Symbol, len(l.SymbolNames))
+		l.publicAnonymousSymbolMap = make([]Symbol, len(l.SymbolNames))
 
 		tokenCount := int(l.TokenCount)
 		if tokenCount > len(l.SymbolNames) {
@@ -429,16 +480,56 @@ func (l *Language) buildSymbolMaps() {
 			sym := Symbol(i)
 			if sn == "" {
 				l.publicSymbolMap[i] = sym
+				l.publicNamedSymbolMap[i] = sym
+				l.publicAnonymousSymbolMap[i] = sym
 				continue
 			}
 			// Keep the first match so duplicate names remain deterministic.
 			if _, exists := l.symbolNameMap[sn]; !exists {
 				l.symbolNameMap[sn] = sym
 			}
+			named := false
+			if i < len(l.SymbolMetadata) {
+				named = l.SymbolMetadata[i].Named
+			}
+			key := symbolNameNamedKey{name: sn, named: named}
+			if _, exists := l.symbolNameNamedMap[key]; !exists {
+				l.symbolNameNamedMap[key] = sym
+			}
 			// Map each symbol to the canonical (first) symbol with its name.
 			l.publicSymbolMap[i] = l.symbolNameMap[sn]
+			if namedSym, exists := l.symbolNameNamedMap[symbolNameNamedKey{name: sn, named: true}]; exists {
+				l.publicNamedSymbolMap[i] = namedSym
+			} else {
+				l.publicNamedSymbolMap[i] = l.symbolNameMap[sn]
+			}
+			if anonSym, exists := l.symbolNameNamedMap[symbolNameNamedKey{name: sn, named: false}]; exists {
+				l.publicAnonymousSymbolMap[i] = anonSym
+			} else {
+				l.publicAnonymousSymbolMap[i] = l.symbolNameMap[sn]
+			}
 			if i < tokenCount {
 				l.tokenSymbolNameMap[sn] = append(l.tokenSymbolNameMap[sn], sym)
+			}
+		}
+		for i, sn := range l.SymbolNames {
+			sym := Symbol(i)
+			if sn == "" {
+				l.publicSymbolMap[i] = sym
+				l.publicNamedSymbolMap[i] = sym
+				l.publicAnonymousSymbolMap[i] = sym
+				continue
+			}
+			l.publicSymbolMap[i] = l.symbolNameMap[sn]
+			if namedSym, exists := l.symbolNameNamedMap[symbolNameNamedKey{name: sn, named: true}]; exists {
+				l.publicNamedSymbolMap[i] = namedSym
+			} else {
+				l.publicNamedSymbolMap[i] = l.symbolNameMap[sn]
+			}
+			if anonSym, exists := l.symbolNameNamedMap[symbolNameNamedKey{name: sn, named: false}]; exists {
+				l.publicAnonymousSymbolMap[i] = anonSym
+			} else {
+				l.publicAnonymousSymbolMap[i] = l.symbolNameMap[sn]
 			}
 		}
 	})

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -56,7 +56,7 @@ const (
 
 func newStackEntryNode(state StateID, node *Node) stackEntry {
 	return stackEntry{
-		node:  node,
+		node:  unsafe.Pointer(node),
 		state: state,
 		kind:  stackEntryKindNode,
 	}
@@ -64,7 +64,7 @@ func newStackEntryNode(state StateID, node *Node) stackEntry {
 
 func newStackEntryNoTreeNode(state StateID, node *noTreeNode) stackEntry {
 	return stackEntry{
-		node:  (*Node)(unsafe.Pointer(node)),
+		node:  unsafe.Pointer(node),
 		state: state,
 		kind:  stackEntryKindNoTreeNode,
 	}
@@ -72,7 +72,7 @@ func newStackEntryNoTreeNode(state StateID, node *noTreeNode) stackEntry {
 
 func newStackEntryCompactCheckpointLeaf(state StateID, leaf *compactCheckpointLeaf) stackEntry {
 	return stackEntry{
-		node:  (*Node)(unsafe.Pointer(leaf)),
+		node:  unsafe.Pointer(leaf),
 		state: state,
 		kind:  stackEntryKindNoTreeNode,
 	}
@@ -80,7 +80,7 @@ func newStackEntryCompactCheckpointLeaf(state StateID, leaf *compactCheckpointLe
 
 func newStackEntryCompactFullLeaf(state StateID, leaf *compactFullLeaf) stackEntry {
 	return stackEntry{
-		node:  (*Node)(unsafe.Pointer(leaf)),
+		node:  unsafe.Pointer(leaf),
 		state: state,
 		kind:  stackEntryKindCompactFullLeaf,
 	}
@@ -88,7 +88,7 @@ func newStackEntryCompactFullLeaf(state StateID, leaf *compactFullLeaf) stackEnt
 
 func newStackEntryPendingParent(state StateID, parent *pendingParent) stackEntry {
 	return stackEntry{
-		node:  (*Node)(unsafe.Pointer(parent)),
+		node:  unsafe.Pointer(parent),
 		state: state,
 		kind:  stackEntryKindPendingParent,
 	}
@@ -98,28 +98,39 @@ func stackEntryNode(e stackEntry) *Node {
 	if e.kind != stackEntryKindNode || e.node == nil {
 		return nil
 	}
-	return e.node
+	return (*Node)(e.node)
 }
 
 func stackEntryNoTreeNode(e stackEntry) *noTreeNode {
 	if e.kind != stackEntryKindNoTreeNode || e.node == nil {
 		return nil
 	}
-	return (*noTreeNode)(unsafe.Pointer(e.node))
+	return (*noTreeNode)(e.node)
 }
 
 func stackEntryCompactFullLeaf(e stackEntry) *compactFullLeaf {
 	if e.kind != stackEntryKindCompactFullLeaf || e.node == nil {
 		return nil
 	}
-	return (*compactFullLeaf)(unsafe.Pointer(e.node))
+	return (*compactFullLeaf)(e.node)
 }
 
 func stackEntryPendingParent(e stackEntry) *pendingParent {
 	if e.kind != stackEntryKindPendingParent || e.node == nil {
 		return nil
 	}
-	return (*pendingParent)(unsafe.Pointer(e.node))
+	return (*pendingParent)(e.node)
+}
+
+func setStackEntryNode(entry *stackEntry, node *Node) {
+	if entry == nil {
+		return
+	}
+	entry.node = unsafe.Pointer(node)
+	entry.kind = stackEntryKindNode
+	if node != nil {
+		entry.state = node.parseState
+	}
 }
 
 func (n *noTreeNode) hasFlag(flag nodeFlags) bool {
@@ -541,9 +552,7 @@ func materializeStackEntryCompactFullLeaf(arena *nodeArena, entry *stackEntry, r
 			}
 		}
 	}
-	entry.node = node
-	entry.kind = stackEntryKindNode
-	entry.state = node.parseState
+	setStackEntryNode(entry, node)
 	if arena != nil {
 		arena.compactFullLeafMaterialized++
 		switch reason {

--- a/parser_api.go
+++ b/parser_api.go
@@ -3,6 +3,7 @@ package gotreesitter
 import (
 	"errors"
 	"fmt"
+	"unsafe"
 )
 
 type parseConfig struct {
@@ -394,10 +395,10 @@ type parserStateTokenSource interface {
 }
 
 // stackEntry is a single parser LR-stack entry. The hot path stores real
-// public tree nodes directly; no-tree benchmark reductions can tag the same
-// 16-byte slot as a compact noTreeNode payload.
+// public tree nodes directly; compact parse modes can tag the same 16-byte slot
+// as a noTreeNode, compact leaf, or pending-parent payload.
 type stackEntry struct {
-	node  *Node
+	node  unsafe.Pointer
 	state StateID
 	kind  uint32
 }

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -968,7 +968,7 @@ func computeReduceRange(entries []stackEntry, childCount int) (reduceRange, bool
 	nonExtraFound := 0
 	for nonExtraFound < childCount && start > 1 {
 		start--
-		if entries[start].node != nil && !entries[start].node.isExtra() {
+		if n := stackEntryNode(entries[start]); n != nil && !n.isExtra() {
 			nonExtraFound++
 		}
 	}
@@ -979,7 +979,7 @@ func computeReduceRange(entries []stackEntry, childCount int) (reduceRange, bool
 	actualEnd := len(entries)
 	reducedEnd := actualEnd
 	for i := actualEnd - 1; i >= start; i-- {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil || !n.isExtra() {
 			break
 		}
@@ -1377,7 +1377,7 @@ func computeReduceRawSpan(entries []stackEntry, start, end int) reduceRawSpan {
 
 	foundStart := false
 	for i := start; i < end; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n != nil && !n.isExtra() {
 			span.startByte = n.startByte
 			span.startPoint = n.startPoint
@@ -1388,7 +1388,7 @@ func computeReduceRawSpan(entries []stackEntry, start, end int) reduceRawSpan {
 
 	foundEnd := false
 	for i := end - 1; i >= start; i-- {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n != nil && !n.isExtra() {
 			span.endByte = n.endByte
 			span.endPoint = n.endPoint
@@ -1397,8 +1397,8 @@ func computeReduceRawSpan(entries []stackEntry, start, end int) reduceRawSpan {
 		}
 	}
 
-	firstRaw := entries[start].node
-	lastRaw := entries[end-1].node
+	firstRaw := stackEntryNode(entries[start])
+	lastRaw := stackEntryNode(entries[end-1])
 	if !foundStart && firstRaw != nil {
 		span.startByte = firstRaw.startByte
 		span.startPoint = firstRaw.startPoint
@@ -1415,7 +1415,7 @@ func extendRawSpanToTrailingEntries(span *reduceRawSpan, entries []stackEntry, s
 		return
 	}
 	for i := end - 1; i >= start; i-- {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -1458,7 +1458,7 @@ func shouldUseRawSpanForReduction(sym Symbol, children []*Node, symbolMeta []Sym
 func extendParentSpanToWindow(parent *Node, entries []stackEntry, start, reducedEnd int, symbolMeta []SymbolMetadata, symbolNames []string) {
 	// Leading extras: extend startByte backward until the first structural child.
 	for i := start; i < reducedEnd; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -1480,7 +1480,7 @@ func extendParentSpanToWindow(parent *Node, entries []stackEntry, start, reduced
 	// The same reverse scan is still safe for endByte growth because the
 	// contiguity checks below prevent phantom gaps from inflating the span.
 	for i := reducedEnd - 1; i >= start; i-- {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil || n.isExtra() {
 			continue
 		}
@@ -1514,7 +1514,7 @@ func extendParentSpanToWindow(parent *Node, entries []stackEntry, start, reduced
 	// Follow with a forward pass for endByte growth so contiguous hidden tails
 	// can chain (for example interpolated multiline string middle -> string end).
 	for i := start; i < reducedEnd; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil || n.isExtra() {
 			continue
 		}
@@ -1902,7 +1902,7 @@ func (p *Parser) buildReduceChildrenAllVisible(entries []stackEntry, start, end,
 	visibleCount := 0
 	structuralChildIndex := 0
 	for i := start; i < end; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -1943,7 +1943,7 @@ func (p *Parser) buildReduceChildrenAllVisible(entries []stackEntry, start, end,
 	out := 0
 	structuralChildIndex = 0
 	for i := start; i < end; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -2005,7 +2005,7 @@ func (p *Parser) buildReduceChildrenWithPath(entries []stackEntry, start, end, c
 	preserveHiddenFields := false
 	if parentVisible {
 		for i := start; i < end; i++ {
-			n := entries[i].node
+			n := stackEntryNode(entries[i])
 			if n == nil {
 				continue
 			}
@@ -2045,7 +2045,7 @@ func (p *Parser) buildReduceChildrenWithPath(entries []stackEntry, start, end, c
 
 	structuralChildIndex := 0
 	for i := start; i < end; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -2199,7 +2199,7 @@ func (p *Parser) buildReduceChildrenNoAliasNoFieldsStreaming(entries []stackEntr
 	visibleCount := 0
 	allVisible := true
 	for i := start; i < end; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -2224,7 +2224,7 @@ func (p *Parser) buildReduceChildrenNoAliasNoFieldsStreaming(entries []stackEntr
 		}
 		out := 0
 		for i := start; i < end; i++ {
-			n := entries[i].node
+			n := stackEntryNode(entries[i])
 			if n == nil {
 				continue
 			}
@@ -2247,7 +2247,7 @@ func (p *Parser) buildReduceChildrenNoAliasNoFieldsStreaming(entries []stackEntr
 		parentVisible = symbolMeta[parentSymbol].Visible
 	}
 	for i := start; i < end; i++ {
-		n := entries[i].node
+		n := stackEntryNode(entries[i])
 		if n == nil {
 			continue
 		}
@@ -2814,7 +2814,7 @@ func (p *Parser) applyReduceAction(s *glrStack, act ParseAction, tok Token, anyR
 	parent.parseState = targetState
 	p.pushStackNode(s, targetState, parent, entryScratch, gssScratch)
 	for i := trailingStart; i < trailingEnd; i++ {
-		extra := entries[i].node
+		extra := stackEntryNode(entries[i])
 		if extra == nil {
 			continue
 		}
@@ -2929,7 +2929,7 @@ func (p *Parser) applyReduceActionTransientParents(s *glrStack, act ParseAction,
 	parent.parseState = targetState
 	p.pushStackNode(s, targetState, parent, entryScratch, gssScratch)
 	for i := trailingStart; i < trailingEnd; i++ {
-		extra := entries[i].node
+		extra := stackEntryNode(entries[i])
 		if extra == nil {
 			continue
 		}
@@ -3058,7 +3058,7 @@ func (p *Parser) pushCollapsedUnaryReduceNode(s *glrStack, act ParseAction, tok 
 	nodeBumpEquivVersion(child)
 	p.pushStackNode(s, targetState, child, entryScratch, gssScratch)
 	for i := trailingStart; i < trailingEnd; i++ {
-		extra := entries[i].node
+		extra := stackEntryNode(entries[i])
 		if extra == nil {
 			continue
 		}
@@ -3256,7 +3256,7 @@ func (p *Parser) collapsibleRawUnarySelfReduction(act ParseAction, tok Token, ar
 		}
 		return nil
 	}
-	child := entries[start].node
+	child := stackEntryNode(entries[start])
 	if child == nil || child.ownerArena != arena || child.parent != nil {
 		if diag {
 			arena.collapseRawUnaryMissChild++
@@ -3316,7 +3316,7 @@ func (p *Parser) collapsibleUnarySelfReduction(act ParseAction, tok Token, arena
 		}
 		return nil
 	}
-	if start < 0 || start >= len(entries) || entries[start].node != child {
+	if start < 0 || start >= len(entries) || stackEntryNode(entries[start]) != child {
 		if diag {
 			arena.collapseUnaryMissChild++
 		}

--- a/parser_result_collapsed_helpers.go
+++ b/parser_result_collapsed_helpers.go
@@ -13,13 +13,19 @@ func normalizeCollapsedNamedLeafChildrenWithStats(root *Node, lang *Language, pa
 	if root == nil || lang == nil {
 		return counters
 	}
-	parentSym, ok := symbolByName(lang, parentName)
+	parentSym, ok := lang.symbolByNameAndNamed(parentName, true)
+	if !ok {
+		parentSym, ok = symbolByName(lang, parentName)
+	}
 	if !ok {
 		return counters
 	}
-	childSym, childOk := symbolByName(lang, childName)
+	childSym, childOk := lang.symbolByNameAndNamed(childName, false)
 	if !childOk {
-		return counters
+		childSym, childOk = symbolByName(lang, childName)
+		if !childOk {
+			return counters
+		}
 	}
 	childNamed := false
 	if int(childSym) < len(lang.SymbolMetadata) {
@@ -33,6 +39,8 @@ func normalizeCollapsedNamedLeafChildrenWithStats(root *Node, lang *Language, pa
 		counters.nodesVisited++
 		if n.symbol == parentSym && len(n.children) == 0 {
 			child := newLeafNodeInArena(n.ownerArena, childSym, childNamed, n.startByte, n.endByte, n.startPoint, n.endPoint)
+			child.parent = n
+			child.childIndex = 0
 			n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{child})
 			counters.nodesRewritten++
 		}

--- a/parser_result_collapsed_text.go
+++ b/parser_result_collapsed_text.go
@@ -1,0 +1,29 @@
+package gotreesitter
+
+func normalizeCollapsedTextToken(n *Node, source []byte, lang *Language, accept func(string) bool) bool {
+	if n == nil || lang == nil || n.startByte > n.endByte || n.endByte > uint32(len(source)) {
+		return false
+	}
+	text := string(source[n.startByte:n.endByte])
+	if accept != nil && !accept(text) {
+		return false
+	}
+	sym, ok := lang.symbolByNameAndNamed(text, false)
+	if !ok {
+		sym, ok = symbolByName(lang, text)
+		if !ok {
+			return false
+		}
+	}
+	named := false
+	if idx := int(sym); idx >= 0 && idx < len(lang.SymbolMetadata) {
+		named = lang.SymbolMetadata[idx].Named
+	}
+	child := newLeafNodeInArena(n.ownerArena, sym, named, n.startByte, n.endByte, n.startPoint, n.endPoint)
+	child.parent = n
+	child.childIndex = 0
+	n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{child})
+	n.fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, []FieldID{0})
+	n.fieldSources = nil
+	return true
+}

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -36,7 +36,9 @@ var resultCompatibilityStrutLanguageNames = []string{
 	"hcl",
 	"html",
 	"ini",
+	"java",
 	"javascript",
+	"kotlin",
 	"lua",
 	"make",
 	"nginx",
@@ -95,8 +97,12 @@ func resultCompatibilityStrutForLanguage(name string) resultCompatibilityStrut {
 		return normalizeHTMLResultStrut
 	case "ini":
 		return normalizeIniResultStrut
+	case "java":
+		return normalizeJavaResultStrut
 	case "javascript":
 		return normalizeJavaScriptResultStrut
+	case "kotlin":
+		return normalizeKotlinResultStrut
 	case "lua":
 		return normalizeLuaResultStrut
 	case "make":
@@ -232,8 +238,16 @@ func normalizeIniResultStrut(ctx resultCompatibilityContext) {
 	normalizeIniSectionStarts(ctx.root, ctx.lang)
 }
 
+func normalizeJavaResultStrut(ctx resultCompatibilityContext) {
+	normalizeJavaCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
 func normalizeJavaScriptResultStrut(ctx resultCompatibilityContext) {
 	normalizeJavaScriptCompatibility(ctx.root, ctx.source, ctx.lang)
+}
+
+func normalizeKotlinResultStrut(ctx resultCompatibilityContext) {
+	normalizeKotlinCompatibility(ctx.root, ctx.source, ctx.lang)
 }
 
 func normalizeLuaResultStrut(ctx resultCompatibilityContext) {
@@ -267,6 +281,7 @@ func normalizePHPResultStrut(ctx resultCompatibilityContext) {
 
 func normalizePowerShellResultStrut(ctx resultCompatibilityContext) {
 	normalizePowerShellProgramShape(ctx.root, ctx.source, ctx.lang)
+	normalizePowerShellAssignmentOperatorTokens(ctx.root, ctx.source, ctx.lang)
 }
 
 func normalizePugResultStrut(ctx resultCompatibilityContext) {

--- a/parser_result_java.go
+++ b/parser_result_java.go
@@ -1,0 +1,42 @@
+package gotreesitter
+
+func normalizeJavaCompatibility(root *Node, source []byte, lang *Language) {
+	normalizeJavaPrimitiveTypeTokens(root, source, lang)
+}
+
+func normalizeJavaPrimitiveTypeTokens(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "java" {
+		return
+	}
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if len(n.children) == 0 && javaPrimitiveTypeWrapper(n.Type(lang)) {
+			normalizeCollapsedTextToken(n, source, lang, javaPrimitiveTypeToken)
+		}
+		for _, child := range n.children {
+			walk(child)
+		}
+	}
+	walk(root)
+}
+
+func javaPrimitiveTypeWrapper(name string) bool {
+	switch name {
+	case "boolean_type", "integral_type", "floating_point_type", "void_type":
+		return true
+	default:
+		return false
+	}
+}
+
+func javaPrimitiveTypeToken(text string) bool {
+	switch text {
+	case "boolean", "byte", "short", "int", "long", "char", "float", "double", "void":
+		return true
+	default:
+		return false
+	}
+}

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -10,6 +10,7 @@ func normalizeJavaScriptCompatibility(root *Node, source []byte, lang *Language)
 	normalizeJavaScriptTypeScriptBinaryPrecedence(root, lang)
 	normalizeJavaScriptTrailingContinueComments(root, source, lang)
 	normalizeJavaScriptTopLevelExpressionStatementBounds(root, lang)
+	normalizeJavaScriptTopLevelDeclarationBounds(root, lang)
 	normalizeJavaScriptTopLevelObjectLiterals(root, lang)
 }
 
@@ -19,6 +20,7 @@ func normalizeTypeScriptTreeCompatibility(root *Node, source []byte, lang *Langu
 	normalizeJavaScriptTypeScriptUnaryPrecedence(root, lang)
 	normalizeJavaScriptTypeScriptBinaryPrecedence(root, lang)
 	normalizeTypeScriptRecoveredNamespaceRoot(root, source, lang)
+	normalizeJavaScriptTopLevelDeclarationBounds(root, lang)
 	normalizeTypeScriptCompatibility(root, source, lang)
 	normalizeCollapsedNamedLeafChildren(root, lang, "existential_type", "*")
 }
@@ -74,6 +76,41 @@ func normalizeJavaScriptTopLevelExpressionStatementBounds(root *Node, lang *Lang
 	}
 	for _, child := range root.children {
 		if child == nil || child.Type(lang) != "expression_statement" || len(child.children) == 0 {
+			continue
+		}
+		first, last := firstAndLastNonNilChild(child.children)
+		if first == nil || last == nil {
+			continue
+		}
+		child.startByte = first.startByte
+		child.startPoint = first.startPoint
+		child.endByte = last.endByte
+		child.endPoint = last.endPoint
+	}
+}
+
+func normalizeJavaScriptTopLevelDeclarationBounds(root *Node, lang *Language) {
+	if root == nil || lang == nil || root.Type(lang) != "program" {
+		return
+	}
+	switch lang.Name {
+	case "javascript", "typescript", "tsx":
+	default:
+		return
+	}
+	for _, child := range root.children {
+		if child == nil || len(child.children) == 0 {
+			continue
+		}
+		switch child.Type(lang) {
+		case "lexical_declaration",
+			"variable_declaration",
+			"function_declaration",
+			"generator_function_declaration",
+			"class_declaration",
+			"import_statement",
+			"export_statement":
+		default:
 			continue
 		}
 		first, last := firstAndLastNonNilChild(child.children)

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -94,6 +94,49 @@ func TestNormalizeJavaScriptTopLevelExpressionStatementBoundsSnapToChildren(t *t
 	}
 }
 
+func TestNormalizeJavaScriptTopLevelDeclarationBoundsSnapToChildren(t *testing.T) {
+	lang := &Language{
+		Name:        "javascript",
+		SymbolNames: []string{"EOF", "program", "comment", "lexical_declaration", "const", "variable_declarator", ";"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "program", Visible: true, Named: true},
+			{Name: "comment", Visible: true, Named: true},
+			{Name: "lexical_declaration", Visible: true, Named: true},
+			{Name: "const", Visible: true, Named: false},
+			{Name: "variable_declarator", Visible: true, Named: true},
+			{Name: ";", Visible: true, Named: false},
+		},
+	}
+
+	arena := newNodeArena(arenaClassFull)
+	comment := newLeafNodeInArena(arena, 2, true, 0, 6, Point{}, Point{Column: 6})
+	constTok := newLeafNodeInArena(arena, 4, false, 7, 12, Point{Row: 1}, Point{Row: 1, Column: 5})
+	decl := newLeafNodeInArena(arena, 5, true, 13, 22, Point{Row: 1, Column: 6}, Point{Row: 1, Column: 15})
+	semi := newLeafNodeInArena(arena, 6, false, 22, 23, Point{Row: 1, Column: 15}, Point{Row: 1, Column: 16})
+	lex := newParentNodeInArena(arena, 3, true, []*Node{constTok, decl, semi}, nil, 0)
+	lex.startByte = 0
+	lex.startPoint = Point{}
+	lex.endByte = 23
+	lex.endPoint = Point{Row: 1, Column: 16}
+	root := newParentNodeInArena(arena, 1, true, []*Node{comment, lex}, nil, 0)
+
+	normalizeJavaScriptTopLevelDeclarationBounds(root, lang)
+
+	if got, want := lex.StartByte(), uint32(7); got != want {
+		t.Fatalf("lex.StartByte = %d, want %d", got, want)
+	}
+	if got, want := lex.EndByte(), uint32(23); got != want {
+		t.Fatalf("lex.EndByte = %d, want %d", got, want)
+	}
+	if got, want := lex.StartPoint(), (Point{Row: 1}); got != want {
+		t.Fatalf("lex.StartPoint = %#v, want %#v", got, want)
+	}
+	if got, want := lex.EndPoint(), (Point{Row: 1, Column: 16}); got != want {
+		t.Fatalf("lex.EndPoint = %#v, want %#v", got, want)
+	}
+}
+
 func TestNormalizeTypeScriptRecoveredNamespaceRootRewrapsNamespaceBody(t *testing.T) {
 	lang := &Language{
 		Name:        "typescript",

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -1,0 +1,38 @@
+package gotreesitter
+
+func normalizeKotlinCompatibility(root *Node, source []byte, lang *Language) {
+	normalizeKotlinBindingPatternKindTokens(root, source, lang)
+}
+
+func normalizeKotlinBindingPatternKindTokens(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "kotlin" {
+		return
+	}
+
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if n.Type(lang) == "binding_pattern_kind" && len(n.children) == 0 {
+			normalizeKotlinBindingPatternKindToken(n, source, lang)
+		}
+		for _, child := range n.children {
+			walk(child)
+		}
+	}
+	walk(root)
+}
+
+func normalizeKotlinBindingPatternKindToken(n *Node, source []byte, lang *Language) {
+	if n == nil || n.startByte > n.endByte || n.endByte > uint32(len(source)) {
+		return
+	}
+	text := string(source[n.startByte:n.endByte])
+	if text != "val" && text != "var" {
+		return
+	}
+	normalizeCollapsedTextToken(n, source, lang, func(text string) bool {
+		return text == "val" || text == "var"
+	})
+}

--- a/parser_result_powershell.go
+++ b/parser_result_powershell.go
@@ -163,6 +163,34 @@ func normalizePowerShellProgramShape(root *Node, source []byte, lang *Language) 
 	root.setHasError(true)
 }
 
+func normalizePowerShellAssignmentOperatorTokens(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "powershell" {
+		return
+	}
+	var walk func(*Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if n.Type(lang) == "assignement_operator" && len(n.children) == 0 {
+			normalizeCollapsedTextToken(n, source, lang, powerShellAssignmentOperatorToken)
+		}
+		for _, child := range n.children {
+			walk(child)
+		}
+	}
+	walk(root)
+}
+
+func powerShellAssignmentOperatorToken(text string) bool {
+	switch text {
+	case "=", "+=", "-=", "*=", "/=", "%=":
+		return true
+	default:
+		return false
+	}
+}
+
 func powerShellLooksLikeSpilledFunction(nodes []*Node, lang *Language) bool {
 	if len(nodes) < 4 || lang == nil {
 		return false

--- a/parser_result_yaml.go
+++ b/parser_result_yaml.go
@@ -39,6 +39,7 @@ func normalizeYAMLRecoveredRoot(root *Node, source []byte, lang *Language) {
 		}
 	}
 	yamlNormalizeRecoveredSubtrees(root, source, lang)
+	yamlWrapDocumentBlockCollections(root, lang)
 	yamlExtendExplicitDocumentRangesToLeadingComments(root, lang)
 	yamlUnwrapCommentLedSequenceDocuments(root, lang)
 	root.startByte = 0
@@ -196,6 +197,39 @@ func yamlWrapYAMLCollection(name string, children []*Node, endByte uint32, endPo
 
 func yamlWrapYAMLBlockNode(children []*Node, endByte uint32, endPoint Point, arena *nodeArena, lang *Language) *Node {
 	return yamlWrapYAMLNode("block_node", children, endByte, endPoint, arena, lang)
+}
+
+func yamlWrapDocumentBlockCollections(root *Node, lang *Language) {
+	if root == nil || lang == nil || root.Type(lang) != "stream" {
+		return
+	}
+	for _, doc := range root.children {
+		if doc == nil || doc.Type(lang) != "document" || len(doc.children) != 1 {
+			continue
+		}
+		child := doc.children[0]
+		if child == nil {
+			continue
+		}
+		switch child.Type(lang) {
+		case "block_mapping":
+		default:
+			continue
+		}
+		blockNode := yamlWrapYAMLBlockNode([]*Node{child}, doc.endByte, doc.endPoint, doc.ownerArena, lang)
+		if blockNode == nil {
+			continue
+		}
+		blockNode.startByte = child.startByte
+		blockNode.startPoint = child.startPoint
+		blockNode.endByte = doc.endByte
+		blockNode.endPoint = doc.endPoint
+		doc.children = cloneNodeSliceInArena(doc.ownerArena, []*Node{blockNode})
+		doc.fieldIDs = nil
+		doc.fieldSources = nil
+		doc.setHasError(false)
+		populateParentNode(doc, doc.children)
+	}
 }
 
 func yamlWrapPlainScalarFlowNodes(node *Node, lang *Language) {

--- a/pending_parent.go
+++ b/pending_parent.go
@@ -142,9 +142,7 @@ func materializeStackEntryPendingParent(arena *nodeArena, entry *stackEntry, rea
 	node.endPoint = parent.endPoint
 	node.parseState = parent.parseState
 	node.preGotoState = parent.preGotoState
-	entry.node = node
-	entry.kind = stackEntryKindNode
-	entry.state = node.parseState
+	setStackEntryNode(entry, node)
 	if arena != nil {
 		arena.pendingParentMaterialized++
 		switch reason {

--- a/query.go
+++ b/query.go
@@ -14,9 +14,14 @@ type Query struct {
 	captures []string // capture name by index
 	strings  []string // string literals by index
 
-	rootCandidatesBySymbol map[Symbol][]int
-	rootCandidatesDense    [][]int
-	rootFallbackCandidates []int
+	rootCandidatesBySymbol     map[Symbol][]int
+	rootCandidatesDense        [][]int
+	rootFallbackCandidates     []int
+	postCandidatesBySymbol     map[Symbol][]int
+	postCandidatesDense        [][]int
+	postFallbackCandidates     []int
+	rootZeroOrMorePatterns     []int
+	rootRepetitionPostPatterns []int
 
 	disabledPatternIdx  map[int]struct{}
 	disabledCaptureName map[string]struct{}
@@ -212,12 +217,16 @@ type QueryCursor struct {
 
 	currentNode       *Node
 	currentNodeDepth  uint32
+	currentNodePost   bool
 	currentCandidates []int
 	candidateIdx      int
 
 	// Pending captures from the last match returned by NextMatch.
 	pendingCaptures   []QueryCapture
 	pendingCaptureIdx int
+
+	pendingMatches  []QueryMatch
+	pendingMatchIdx int
 
 	matchLimit        uint32
 	matchCount        uint32
@@ -233,11 +242,11 @@ type QueryCursor struct {
 type queryCursorWorkItem struct {
 	node  *Node
 	depth uint32
+	post  bool
 }
 
 type queryExecBuffer struct {
 	matches  []QueryMatch
-	captures []QueryCapture
 	worklist []queryCursorWorkItem
 }
 
@@ -445,7 +454,6 @@ func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte,
 			return nil
 		}
 		buf.matches = buf.matches[:0]
-		buf.captures = buf.captures[:0]
 		buf.worklist = buf.worklist[:0]
 		return buf.matches
 	}
@@ -457,7 +465,6 @@ func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte,
 	}
 
 	buf.matches = buf.matches[:0]
-	buf.captures = buf.captures[:0]
 	buf.worklist = append(buf.worklist[:0], queryCursorWorkItem{node: root, depth: 0})
 
 	for len(buf.worklist) > 0 {
@@ -468,6 +475,37 @@ func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte,
 		n := item.node
 		if n == nil {
 			continue
+		}
+		if item.post {
+			candidates := q.postorderPatternCandidates(lang.PublicSymbolForNamedness(n.Symbol(), n.IsNamed()))
+			candidates = mergePatternIndexLists(q.rootRepetitionPostPatterns, candidates)
+			for _, pi := range candidates {
+				if q.isPatternDisabled(pi) {
+					continue
+				}
+				pat := q.patterns[pi]
+				var captureSets [][]QueryCapture
+				if pat.steps[0].quantifier == queryQuantifierZeroOrMore || pat.steps[0].quantifier == queryQuantifierOneOrMore {
+					captureSets = q.matchPatternPostorderAll(&pat, n, lang, source)
+				} else {
+					captureSets = q.matchPatternAll(&pat, n, lang, source)
+				}
+				for _, captures := range captureSets {
+					buf.matches = append(buf.matches, QueryMatch{
+						PatternIndex: pi,
+						Captures:     captures,
+					})
+				}
+			}
+			continue
+		}
+
+		if q.hasPostorderPatterns() {
+			buf.worklist = append(buf.worklist, queryCursorWorkItem{
+				node:  n,
+				depth: item.depth,
+				post:  true,
+			})
 		}
 
 		for i := n.ChildCount() - 1; i >= 0; i-- {
@@ -481,22 +519,22 @@ func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte,
 			})
 		}
 
-		candidates := q.rootPatternCandidates(lang.PublicSymbol(n.Symbol()))
+		candidates := q.rootPatternCandidates(lang.PublicSymbolForNamedness(n.Symbol(), n.IsNamed()))
 		for _, pi := range candidates {
 			if q.isPatternDisabled(pi) {
 				continue
 			}
 			pat := q.patterns[pi]
-			nextCaptures, ok := q.matchPatternIntoBuffer(&pat, n, lang, source, buf.captures)
-			if !ok {
+			captureSets := q.matchPatternAll(&pat, n, lang, source)
+			if len(captureSets) == 0 {
 				continue
 			}
-			start := len(buf.captures)
-			buf.captures = nextCaptures
-			buf.matches = append(buf.matches, QueryMatch{
-				PatternIndex: pi,
-				Captures:     buf.captures[start:len(buf.captures):len(buf.captures)],
-			})
+			for _, captures := range captureSets {
+				buf.matches = append(buf.matches, QueryMatch{
+					PatternIndex: pi,
+					Captures:     captures,
+				})
+			}
 		}
 	}
 
@@ -513,6 +551,24 @@ func (q *Query) rootPatternCandidates(sym Symbol) []int {
 		return cands
 	}
 	return q.rootFallbackCandidates
+}
+
+func (q *Query) postorderPatternCandidates(sym Symbol) []int {
+	if int(sym) < len(q.postCandidatesDense) {
+		if cands := q.postCandidatesDense[sym]; cands != nil {
+			return cands
+		}
+	}
+	if cands, ok := q.postCandidatesBySymbol[sym]; ok {
+		return cands
+	}
+	return q.postFallbackCandidates
+}
+
+func (q *Query) hasPostorderPatterns() bool {
+	return len(q.rootRepetitionPostPatterns) > 0 ||
+		len(q.postFallbackCandidates) > 0 ||
+		len(q.postCandidatesBySymbol) > 0
 }
 
 func mergePatternIndexLists(a, b []int) []int {
@@ -567,8 +623,13 @@ func mergePatternIndexLists(a, b []int) []int {
 
 func (q *Query) buildRootPatternIndex() {
 	bySymbolExact := make(map[Symbol][]int)
+	postBySymbolExact := make(map[Symbol][]int)
 	var wildcard []int
 	var complex []int
+	var postWildcard []int
+	var postComplex []int
+	q.rootZeroOrMorePatterns = q.rootZeroOrMorePatterns[:0]
+	q.rootRepetitionPostPatterns = q.rootRepetitionPostPatterns[:0]
 
 	for pi, pat := range q.patterns {
 		if len(pat.steps) == 0 {
@@ -576,40 +637,22 @@ func (q *Query) buildRootPatternIndex() {
 		}
 		step := pat.steps[0]
 
-		if len(step.alternatives) > 0 {
-			complexAlt := false
-			for _, alt := range step.alternatives {
-				if alt.textMatch != "" || alt.symbol == 0 {
-					complexAlt = true
-					break
-				}
-			}
-			if complexAlt {
-				complex = append(complex, pi)
-				continue
-			}
-
-			seen := make(map[Symbol]struct{}, len(step.alternatives))
-			for _, alt := range step.alternatives {
-				if _, ok := seen[alt.symbol]; ok {
-					continue
-				}
-				seen[alt.symbol] = struct{}{}
-				bySymbolExact[alt.symbol] = append(bySymbolExact[alt.symbol], pi)
-			}
-			continue
-		}
-
-		if step.textMatch != "" {
+		if step.quantifier == queryQuantifierZeroOrMore {
 			complex = append(complex, pi)
+			q.rootZeroOrMorePatterns = append(q.rootZeroOrMorePatterns, pi)
+			q.rootRepetitionPostPatterns = append(q.rootRepetitionPostPatterns, pi)
 			continue
 		}
-		if step.symbol == 0 {
-			wildcard = append(wildcard, pi)
+		if step.quantifier == queryQuantifierOneOrMore {
+			q.rootRepetitionPostPatterns = append(q.rootRepetitionPostPatterns, pi)
+		}
+
+		if patternHasPostorderChildRepetition(pat) {
+			addRootPatternCandidate(pi, step, postBySymbolExact, &postWildcard, &postComplex)
 			continue
 		}
 
-		bySymbolExact[step.symbol] = append(bySymbolExact[step.symbol], pi)
+		addRootPatternCandidate(pi, step, bySymbolExact, &wildcard, &complex)
 	}
 
 	fallback := mergePatternIndexLists(wildcard, complex)
@@ -626,6 +669,71 @@ func (q *Query) buildRootPatternIndex() {
 	for sym, candidates := range q.rootCandidatesBySymbol {
 		q.rootCandidatesDense[sym] = candidates
 	}
+
+	postFallback := mergePatternIndexLists(postWildcard, postComplex)
+	q.postFallbackCandidates = postFallback
+	q.postCandidatesBySymbol = make(map[Symbol][]int, len(postBySymbolExact))
+	maxPostSymbol := Symbol(0)
+	for sym, exact := range postBySymbolExact {
+		if sym > maxPostSymbol {
+			maxPostSymbol = sym
+		}
+		q.postCandidatesBySymbol[sym] = mergePatternIndexLists(exact, postFallback)
+	}
+	q.postCandidatesDense = make([][]int, int(maxPostSymbol)+1)
+	for sym, candidates := range q.postCandidatesBySymbol {
+		q.postCandidatesDense[sym] = candidates
+	}
+}
+
+func addRootPatternCandidate(pi int, step QueryStep, bySymbolExact map[Symbol][]int, wildcard *[]int, complex *[]int) {
+	if len(step.alternatives) > 0 {
+		complexAlt := false
+		for _, alt := range step.alternatives {
+			if alt.textMatch != "" || alt.symbol == 0 {
+				complexAlt = true
+				break
+			}
+		}
+		if complexAlt {
+			*complex = append(*complex, pi)
+			return
+		}
+
+		seen := make(map[Symbol]struct{}, len(step.alternatives))
+		for _, alt := range step.alternatives {
+			if _, ok := seen[alt.symbol]; ok {
+				continue
+			}
+			seen[alt.symbol] = struct{}{}
+			bySymbolExact[alt.symbol] = append(bySymbolExact[alt.symbol], pi)
+		}
+		return
+	}
+
+	if step.textMatch != "" {
+		*complex = append(*complex, pi)
+		return
+	}
+	if step.symbol == 0 {
+		*wildcard = append(*wildcard, pi)
+		return
+	}
+
+	bySymbolExact[step.symbol] = append(bySymbolExact[step.symbol], pi)
+}
+
+func patternHasPostorderChildRepetition(pat Pattern) bool {
+	for i := 1; i < len(pat.steps); i++ {
+		step := pat.steps[i]
+		if step.depth == 0 {
+			continue
+		}
+		if step.quantifier == queryQuantifierZeroOrMore || step.quantifier == queryQuantifierOneOrMore {
+			return true
+		}
+	}
+	return false
 }
 
 // NextMatch yields the next query match from the cursor.
@@ -668,6 +776,15 @@ func (c *QueryCursor) nextMatchRaw() (QueryMatch, bool) {
 	if c == nil || c.done || c.query == nil || c.lang == nil {
 		return QueryMatch{}, false
 	}
+	if c.pendingMatchIdx < len(c.pendingMatches) {
+		m := c.pendingMatches[c.pendingMatchIdx]
+		c.pendingMatchIdx++
+		if c.pendingMatchIdx >= len(c.pendingMatches) {
+			c.pendingMatches = nil
+			c.pendingMatchIdx = 0
+		}
+		return m, true
+	}
 	q := c.query
 	if q.rootCandidatesBySymbol == nil && q.rootFallbackCandidates == nil {
 		q.buildRootPatternIndex()
@@ -688,9 +805,26 @@ func (c *QueryCursor) nextMatchRaw() (QueryMatch, bool) {
 			if !c.nodeIntersectsRanges(n) {
 				continue
 			}
+			if item.post {
+				c.currentNode = n
+				c.currentNodeDepth = depth
+				c.currentNodePost = true
+				postCandidates := q.postorderPatternCandidates(c.lang.PublicSymbolForNamedness(n.Symbol(), n.IsNamed()))
+				c.currentCandidates = mergePatternIndexLists(q.rootRepetitionPostPatterns, postCandidates)
+				c.candidateIdx = 0
+				continue
+			}
 
 			if c.hasMaxStartDepth && depth > c.maxStartDepth {
 				continue
+			}
+
+			if q.hasPostorderPatterns() {
+				c.worklist = append(c.worklist, queryCursorWorkItem{
+					node:  n,
+					depth: depth,
+					post:  true,
+				})
 			}
 
 			// Push children in reverse order so leftmost is visited first.
@@ -708,7 +842,8 @@ func (c *QueryCursor) nextMatchRaw() (QueryMatch, bool) {
 
 			c.currentNode = n
 			c.currentNodeDepth = depth
-			c.currentCandidates = q.rootPatternCandidates(c.lang.PublicSymbol(n.Symbol()))
+			c.currentNodePost = false
+			c.currentCandidates = q.rootPatternCandidates(c.lang.PublicSymbolForNamedness(n.Symbol(), n.IsNamed()))
 			c.candidateIdx = 0
 		}
 
@@ -719,17 +854,39 @@ func (c *QueryCursor) nextMatchRaw() (QueryMatch, bool) {
 				continue
 			}
 			pat := q.patterns[pi]
-			if caps, ok := q.matchPattern(&pat, c.currentNode, c.lang, c.source); ok {
-				return QueryMatch{
-					PatternIndex: pi,
-					Captures:     caps,
-				}, true
+			var captureSets [][]QueryCapture
+			if c.currentNodePost {
+				if pat.steps[0].quantifier == queryQuantifierZeroOrMore || pat.steps[0].quantifier == queryQuantifierOneOrMore {
+					captureSets = q.matchPatternPostorderAll(&pat, c.currentNode, c.lang, c.source)
+				} else {
+					captureSets = q.matchPatternAll(&pat, c.currentNode, c.lang, c.source)
+				}
+			} else {
+				captureSets = q.matchPatternAll(&pat, c.currentNode, c.lang, c.source)
 			}
+			if len(captureSets) == 0 {
+				continue
+			}
+			first := QueryMatch{
+				PatternIndex: pi,
+				Captures:     captureSets[0],
+			}
+			if len(captureSets) > 1 {
+				c.pendingMatches = make([]QueryMatch, len(captureSets)-1)
+				for i := 1; i < len(captureSets); i++ {
+					c.pendingMatches[i-1] = QueryMatch{
+						PatternIndex: pi,
+						Captures:     captureSets[i],
+					}
+				}
+			}
+			return first, true
 		}
 
 		// Exhausted candidates for this node; advance to the next node.
 		c.currentNode = nil
 		c.currentNodeDepth = 0
+		c.currentNodePost = false
 		c.currentCandidates = nil
 		c.candidateIdx = 0
 	}
@@ -777,25 +934,6 @@ func (q *Query) matchPattern(pat *Pattern, node *Node, lang *Language, source []
 	}
 	captures = q.applyDirectives(pat.predicates, captures, source)
 	return captures, true
-}
-
-func (q *Query) matchPatternIntoBuffer(pat *Pattern, node *Node, lang *Language, source []byte, captures []QueryCapture) ([]QueryCapture, bool) {
-	if len(pat.steps) == 0 {
-		return captures, false
-	}
-
-	start := len(captures)
-	if !q.matchStepsWithPredicates(pat.steps, 0, node, lang, source, pat.predicates, &captures) {
-		return captures[:start], false
-	}
-
-	matchCaptures := captures[start:]
-	if !q.matchesPredicates(pat.predicates, matchCaptures, lang, source) {
-		return captures[:start], false
-	}
-
-	matchCaptures = q.applyDirectives(pat.predicates, matchCaptures, source)
-	return captures[:start+len(matchCaptures)], true
 }
 
 func (q *Query) matchStepWithRollbackPredicates(steps []QueryStep, stepIdx int, node *Node, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {

--- a/query_compile_helpers.go
+++ b/query_compile_helpers.go
@@ -117,12 +117,12 @@ func (p *queryParser) resolveSymbol(name string) (Symbol, bool, error) {
 		return 0, false, nil
 	}
 
-	sym, ok := p.lang.SymbolByName(name)
+	sym, ok := p.lang.symbolByNamePreferNamed(name)
 	if !ok {
 		// Some highlight queries use supertype-like names such as
 		// "pattern/wildcard". Fall back to the rightmost segment when needed.
 		if idx := strings.LastIndex(name, "/"); idx >= 0 && idx+1 < len(name) {
-			if fallback, fallbackOK := p.lang.SymbolByName(name[idx+1:]); fallbackOK {
+			if fallback, fallbackOK := p.lang.symbolByNamePreferNamed(name[idx+1:]); fallbackOK {
 				sym = fallback
 				ok = true
 			}

--- a/query_compile_predicates.go
+++ b/query_compile_predicates.go
@@ -710,59 +710,107 @@ func (p *queryParser) parsePredicate() (QueryPredicate, error) {
 func compileLuaPattern(pattern string) (*regexp.Regexp, error) {
 	var out strings.Builder
 	inClass := false
+	classContentStart := false
 
-	writeLuaClass := func(ch byte, inClass bool) bool {
+	writeLuaClass := func(ch byte, inClass bool, classContentStart bool) bool {
+		inClassText := ""
+		outsideText := ""
 		if inClass {
 			switch ch {
 			case 'a':
-				out.WriteString("A-Za-z")
+				inClassText = "A-Za-z"
+			case 'A':
+				inClassText = "^A-Za-z"
 			case 'c':
-				out.WriteString("[:cntrl:]")
+				inClassText = "[:cntrl:]"
+			case 'C':
+				inClassText = "^[:cntrl:]"
 			case 'd':
-				out.WriteString("0-9")
+				inClassText = "0-9"
+			case 'D':
+				inClassText = "^0-9"
 			case 'l':
-				out.WriteString("a-z")
+				inClassText = "a-z"
+			case 'L':
+				inClassText = "^a-z"
 			case 'p':
-				out.WriteString("[:punct:]")
+				inClassText = "[:punct:]"
+			case 'P':
+				inClassText = "^[:punct:]"
 			case 's':
-				out.WriteString("\\s")
+				inClassText = "\\s"
+			case 'S':
+				inClassText = "^\\s"
 			case 'u':
-				out.WriteString("A-Z")
+				inClassText = "A-Z"
+			case 'U':
+				inClassText = "^A-Z"
 			case 'w':
-				out.WriteString("A-Za-z0-9")
+				inClassText = "A-Za-z0-9"
+			case 'W':
+				inClassText = "^A-Za-z0-9"
 			case 'x':
-				out.WriteString("A-Fa-f0-9")
+				inClassText = "A-Fa-f0-9"
+			case 'X':
+				inClassText = "^A-Fa-f0-9"
 			case 'z':
-				out.WriteString("\\x00")
+				inClassText = "\\x00"
+			case 'Z':
+				inClassText = "^\\x00"
 			default:
 				return false
 			}
+			if strings.HasPrefix(inClassText, "^") && !classContentStart {
+				return false
+			}
+			out.WriteString(inClassText)
 			return true
 		}
 		switch ch {
 		case 'a':
-			out.WriteString("[A-Za-z]")
+			outsideText = "[A-Za-z]"
+		case 'A':
+			outsideText = "[^A-Za-z]"
 		case 'c':
-			out.WriteString("[[:cntrl:]]")
+			outsideText = "[[:cntrl:]]"
+		case 'C':
+			outsideText = "[^[:cntrl:]]"
 		case 'd':
-			out.WriteString("[0-9]")
+			outsideText = "[0-9]"
+		case 'D':
+			outsideText = "[^0-9]"
 		case 'l':
-			out.WriteString("[a-z]")
+			outsideText = "[a-z]"
+		case 'L':
+			outsideText = "[^a-z]"
 		case 'p':
-			out.WriteString("[[:punct:]]")
+			outsideText = "[[:punct:]]"
+		case 'P':
+			outsideText = "[^[:punct:]]"
 		case 's':
-			out.WriteString("\\s")
+			outsideText = "\\s"
+		case 'S':
+			outsideText = "\\S"
 		case 'u':
-			out.WriteString("[A-Z]")
+			outsideText = "[A-Z]"
+		case 'U':
+			outsideText = "[^A-Z]"
 		case 'w':
-			out.WriteString("[A-Za-z0-9]")
+			outsideText = "[A-Za-z0-9]"
+		case 'W':
+			outsideText = "[^A-Za-z0-9]"
 		case 'x':
-			out.WriteString("[A-Fa-f0-9]")
+			outsideText = "[A-Fa-f0-9]"
+		case 'X':
+			outsideText = "[^A-Fa-f0-9]"
 		case 'z':
-			out.WriteString("\\x00")
+			outsideText = "\\x00"
+		case 'Z':
+			outsideText = "[^\\x00]"
 		default:
 			return false
 		}
+		out.WriteString(outsideText)
 		return true
 	}
 
@@ -771,9 +819,11 @@ func compileLuaPattern(pattern string) (*regexp.Regexp, error) {
 		switch ch {
 		case '[':
 			inClass = true
+			classContentStart = true
 			out.WriteByte(ch)
 		case ']':
 			inClass = false
+			classContentStart = false
 			out.WriteByte(ch)
 		case '%':
 			if i+1 >= len(pattern) {
@@ -782,12 +832,28 @@ func compileLuaPattern(pattern string) (*regexp.Regexp, error) {
 			}
 			i++
 			next := pattern[i]
-			if writeLuaClass(next, inClass) {
+			if writeLuaClass(next, inClass, classContentStart) {
+				if inClass {
+					classContentStart = false
+				}
 				continue
 			}
 			out.WriteString(regexp.QuoteMeta(string(next)))
+			if inClass {
+				classContentStart = false
+			}
+		case '-':
+			if inClass {
+				out.WriteByte(ch)
+				classContentStart = false
+				continue
+			}
+			out.WriteString("*?")
 		default:
 			out.WriteByte(ch)
+			if inClass {
+				classContentStart = false
+			}
 		}
 	}
 

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -111,6 +111,513 @@ func (q *Query) appendCaptureIDs(ids []int, legacyID int, node *Node, captures *
 	}
 }
 
+func cloneQueryCaptures(captures []QueryCapture) []QueryCapture {
+	if len(captures) == 0 {
+		return nil
+	}
+	out := make([]QueryCapture, len(captures))
+	copy(out, captures)
+	return out
+}
+
+func (q *Query) matchPatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
+	if len(pat.steps) == 0 {
+		return nil
+	}
+	if pat.steps[0].quantifier == queryQuantifierZeroOrMore {
+		return q.matchRootRepetitionPatternAll(pat, node, lang, source)
+	}
+	if pat.steps[0].quantifier == queryQuantifierOneOrMore {
+		return nil
+	}
+
+	var matches [][]QueryCapture
+	q.matchStepsAllWithParentPredicates(pat.steps, 0, node, nil, -1, lang, source, pat.predicates, nil, func(captures []QueryCapture) {
+		if !q.matchesPredicates(pat.predicates, captures, lang, source) {
+			return
+		}
+		captures = q.applyDirectives(pat.predicates, captures, source)
+		matches = append(matches, cloneQueryCaptures(captures))
+	})
+	return matches
+}
+
+func (q *Query) matchRootRepetitionPatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
+	if node == nil {
+		return nil
+	}
+	if pat.steps[0].quantifier == queryQuantifierZeroOrMore {
+		return q.matchRootZeroOrMorePatternAll(pat, node, lang, source)
+	}
+
+	parent := node.Parent()
+	childIdx := nodeChildIndexInParent(node, parent)
+	if prev := node.PrevSibling(); prev != nil {
+		prevParent := prev.Parent()
+		prevChildIdx := nodeChildIndexInParent(prev, prevParent)
+		if len(q.matchPatternOnceAll(pat, prev, prevParent, prevChildIdx, lang, source, nil)) > 0 {
+			return nil
+		}
+	}
+
+	partials := [][]QueryCapture{nil}
+	count := 0
+	for current := node; current != nil; current = current.NextSibling() {
+		currentParent := parent
+		currentChildIdx := childIdx
+		if current != node {
+			currentParent = current.Parent()
+			currentChildIdx = nodeChildIndexInParent(current, currentParent)
+		}
+
+		var nextPartials [][]QueryCapture
+		for _, captures := range partials {
+			for _, next := range q.matchPatternOnceAll(pat, current, currentParent, currentChildIdx, lang, source, captures) {
+				nextPartials = append(nextPartials, next)
+			}
+		}
+		if len(nextPartials) == 0 {
+			break
+		}
+		count++
+		partials = nextPartials
+		childIdx++
+	}
+	if count == 0 {
+		return nil
+	}
+
+	var matches [][]QueryCapture
+	for _, captures := range partials {
+		if !q.matchesPredicates(pat.predicates, captures, lang, source) {
+			continue
+		}
+		captures = q.applyDirectives(pat.predicates, captures, source)
+		matches = append(matches, cloneQueryCaptures(captures))
+	}
+	return matches
+}
+
+func (q *Query) matchRootZeroOrMorePatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
+	if q.matchesPredicates(pat.predicates, nil, lang, source) {
+		captures := q.applyDirectives(pat.predicates, nil, source)
+		return [][]QueryCapture{cloneQueryCaptures(captures)}
+	}
+	return nil
+}
+
+func (q *Query) matchPatternPostorderAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
+	if len(pat.steps) == 0 {
+		return nil
+	}
+	switch pat.steps[0].quantifier {
+	case queryQuantifierZeroOrMore, queryQuantifierOneOrMore:
+	default:
+		return nil
+	}
+	parent := node.Parent()
+	childIdx := nodeChildIndexInParent(node, parent)
+	if len(q.matchPatternOnceAll(pat, node, parent, childIdx, lang, source, nil)) == 0 {
+		return nil
+	}
+	if next := node.NextSibling(); next != nil {
+		nextParent := next.Parent()
+		nextChildIdx := nodeChildIndexInParent(next, nextParent)
+		if len(q.matchPatternOnceAll(pat, next, nextParent, nextChildIdx, lang, source, nil)) > 0 {
+			return nil
+		}
+	}
+
+	runStart := node
+	for prev := node.PrevSibling(); prev != nil; prev = prev.PrevSibling() {
+		prevParent := prev.Parent()
+		prevChildIdx := nodeChildIndexInParent(prev, prevParent)
+		if len(q.matchPatternOnceAll(pat, prev, prevParent, prevChildIdx, lang, source, nil)) == 0 {
+			break
+		}
+		runStart = prev
+	}
+
+	partials := [][]QueryCapture{nil}
+	for current := runStart; current != nil; current = current.NextSibling() {
+		currentParent := current.Parent()
+		currentChildIdx := nodeChildIndexInParent(current, currentParent)
+
+		var nextPartials [][]QueryCapture
+		for _, captures := range partials {
+			for _, next := range q.matchPatternOnceAll(pat, current, currentParent, currentChildIdx, lang, source, captures) {
+				nextPartials = append(nextPartials, next)
+			}
+		}
+		if len(nextPartials) == 0 {
+			break
+		}
+		partials = nextPartials
+		if current == node {
+			break
+		}
+	}
+
+	var matches [][]QueryCapture
+	for _, captures := range partials {
+		if !q.matchesPredicates(pat.predicates, captures, lang, source) {
+			continue
+		}
+		captures = q.applyDirectives(pat.predicates, captures, source)
+		matches = append(matches, cloneQueryCaptures(captures))
+	}
+	return matches
+}
+
+func (q *Query) matchPatternOnceAll(
+	pat *Pattern,
+	node *Node,
+	parent *Node,
+	childIdx int,
+	lang *Language,
+	source []byte,
+	captures []QueryCapture,
+) [][]QueryCapture {
+	var matches [][]QueryCapture
+	q.matchStepsAllWithParentPredicates(pat.steps, 0, node, parent, childIdx, lang, source, pat.predicates, captures, func(next []QueryCapture) {
+		matches = append(matches, cloneQueryCaptures(next))
+	})
+	return matches
+}
+
+func nodeChildIndexInParent(node *Node, parent *Node) int {
+	if node == nil || parent == nil {
+		return -1
+	}
+	if idx := int(node.childIndex); idx >= 0 && idx < len(parent.children) && parent.children[idx] == node {
+		return idx
+	}
+	for i, child := range parent.children {
+		if child == node {
+			return i
+		}
+	}
+	return -1
+}
+
+func (q *Query) matchStepsAllWithParentPredicates(
+	steps []QueryStep,
+	stepIdx int,
+	node *Node,
+	parent *Node,
+	childIdx int,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func([]QueryCapture),
+) {
+	if stepIdx >= len(steps) || node == nil {
+		return
+	}
+
+	step := &steps[stepIdx]
+	if len(step.alternatives) > 0 {
+		q.matchAlternationStepAll(step, node, parent, childIdx, lang, source, predicates, captures, func(next []QueryCapture) {
+			q.matchStepChildrenAll(steps, stepIdx, node, lang, source, predicates, next, emit)
+		})
+		return
+	}
+
+	if !q.nodeMatchesStep(step, node, lang) {
+		return
+	}
+	next := cloneQueryCaptures(captures)
+	q.appendCaptureIDs(step.captureIDs, step.captureID, node, &next)
+	if !q.predicatesStillViable(predicates, next, source) {
+		return
+	}
+	q.matchStepChildrenAll(steps, stepIdx, node, lang, source, predicates, next, emit)
+}
+
+func (q *Query) matchStepChildrenAll(
+	steps []QueryStep,
+	stepIdx int,
+	node *Node,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func([]QueryCapture),
+) {
+	step := &steps[stepIdx]
+	childDepth := step.depth + 1
+	childStart := stepIdx + 1
+
+	if childStart >= len(steps) || steps[childStart].depth <= step.depth {
+		emit(captures)
+		return
+	}
+
+	var childStepsBuf [16]queryChildStepInfo
+	childSteps := childStepsBuf[:0]
+	for i := childStart; i < len(steps); i++ {
+		if steps[i].depth <= step.depth {
+			break
+		}
+		if steps[i].depth == childDepth {
+			childSteps = append(childSteps, queryChildStepInfo{
+				stepIdx: i,
+				field:   steps[i].field,
+			})
+		}
+	}
+	q.matchChildStepsAll(node, steps, childSteps, lang, source, predicates, captures, emit)
+}
+
+func (q *Query) matchAlternationStepAll(
+	step *QueryStep,
+	node *Node,
+	parent *Node,
+	childIdx int,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func([]QueryCapture),
+) {
+	hasStepCaptures := len(step.captureIDs) > 0 || step.captureID >= 0
+	nodeNamed := node.IsNamed()
+	nodeSymbol := lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed)
+	var nodeType string
+	nodeTypeLoaded := false
+
+	for i := range step.alternatives {
+		alt := &step.alternatives[i]
+		if !alternativeMatchesNodeCached(*alt, node, lang, nodeSymbol, nodeNamed, &nodeType, &nodeTypeLoaded) {
+			continue
+		}
+		if !q.alternativeFieldMatches(alt, node, parent, childIdx, lang) {
+			continue
+		}
+
+		next := cloneQueryCaptures(captures)
+		if q.matchAlternationBranch(step, alt, node, lang, source, predicates, &next, hasStepCaptures) {
+			emit(next)
+		}
+	}
+}
+
+func (q *Query) matchChildStepsAll(
+	parent *Node,
+	steps []QueryStep,
+	childSteps []queryChildStepInfo,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func([]QueryCapture),
+) {
+	children := parent.Children()
+	var namedPosByIndexBuf [64]int
+	var namedPosByIndex []int
+	if len(children) <= len(namedPosByIndexBuf) {
+		namedPosByIndex = namedPosByIndexBuf[:len(children)]
+	} else {
+		namedPosByIndex = make([]int, len(children))
+	}
+	namedPos := 0
+	for i, child := range children {
+		if child != nil && child.IsNamed() {
+			namedPosByIndex[i] = namedPos
+			namedPos++
+		} else {
+			namedPosByIndex[i] = -1
+		}
+	}
+
+	q.matchChildStepsRecursiveAll(
+		parent, children, namedPosByIndex, namedPos-1,
+		steps, childSteps, 0, 0, false, -1,
+		lang, source, predicates, captures, emit,
+	)
+}
+
+func (q *Query) matchChildStepsRecursiveAll(
+	parent *Node,
+	children []*Node,
+	namedPosByIndex []int,
+	parentLastNamedPos int,
+	steps []QueryStep,
+	childSteps []queryChildStepInfo,
+	childPos int,
+	nextChildIdx int,
+	prevHasNamed bool,
+	prevLastNamedPos int,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func([]QueryCapture),
+) {
+	if childPos >= len(childSteps) {
+		emit(captures)
+		return
+	}
+
+	cs := childSteps[childPos]
+	step := &steps[cs.stepIdx]
+	minCount, maxCount, ok := quantifierBounds(step.quantifier)
+	if !ok {
+		return
+	}
+
+	var candidateIndicesBuf [32]int
+	candidateIndices := candidateIndicesBuf[:0]
+	var candidatesOK bool
+	candidateIndices, candidatesOK = q.collectChildCandidateIndices(parent, children, step, cs.field, nextChildIdx, lang, candidateIndices)
+	if !candidatesOK {
+		return
+	}
+
+	if maxCount < 0 || maxCount > len(candidateIndices) {
+		maxCount = len(candidateIndices)
+	}
+	if minCount > len(candidateIndices) {
+		return
+	}
+
+	for count := maxCount; count >= minCount; count-- {
+		emittedForCount := false
+		emitForCount := emit
+		if step.quantifier != queryQuantifierOne {
+			emitForCount = func(captures []QueryCapture) {
+				emittedForCount = true
+				emit(captures)
+			}
+		}
+
+		var tryCombinations func(
+			candidatePos int,
+			chosen int,
+			nextIdx int,
+			hasNamed bool,
+			firstNamedPos int,
+			lastNamedPos int,
+			current []QueryCapture,
+		)
+
+		tryCombinations = func(
+			candidatePos int,
+			chosen int,
+			nextIdx int,
+			hasNamed bool,
+			firstNamedPos int,
+			lastNamedPos int,
+			current []QueryCapture,
+		) {
+			if chosen == count {
+				if count > 0 && !q.stepAnchorsSatisfied(
+					step, childPos, hasNamed, firstNamedPos, lastNamedPos,
+					prevHasNamed, prevLastNamedPos, parentLastNamedPos,
+				) {
+					return
+				}
+				nextPrevHasNamed := prevHasNamed || hasNamed
+				nextPrevLastNamedPos := prevLastNamedPos
+				if hasNamed {
+					nextPrevLastNamedPos = lastNamedPos
+				}
+				q.matchChildStepsRecursiveAll(
+					parent, children, namedPosByIndex, parentLastNamedPos,
+					steps, childSteps, childPos+1, nextIdx, nextPrevHasNamed, nextPrevLastNamedPos,
+					lang, source, predicates, current, emitForCount,
+				)
+				return
+			}
+
+			remaining := count - chosen
+			limit := len(candidateIndices) - remaining
+			for i := candidatePos; i <= limit; i++ {
+				childIdx := candidateIndices[i]
+				child := children[childIdx]
+
+				nextIdxForChoice := nextIdx
+				if childIdx+1 > nextIdxForChoice {
+					nextIdxForChoice = childIdx + 1
+				}
+
+				hasNamedForChoice := hasNamed
+				firstNamedForChoice := firstNamedPos
+				lastNamedForChoice := lastNamedPos
+				if namedPos := namedPosByIndex[childIdx]; namedPos >= 0 {
+					if !hasNamedForChoice {
+						hasNamedForChoice = true
+						firstNamedForChoice = namedPos
+					}
+					lastNamedForChoice = namedPos
+				}
+
+				q.matchStepsAllWithParentPredicates(
+					steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, current,
+					func(next []QueryCapture) {
+						tryCombinations(
+							i+1, chosen+1, nextIdxForChoice,
+							hasNamedForChoice, firstNamedForChoice, lastNamedForChoice,
+							next,
+						)
+					},
+				)
+			}
+		}
+
+		tryCombinations(0, 0, nextChildIdx, false, -1, -1, captures)
+		if step.quantifier != queryQuantifierOne && emittedForCount {
+			return
+		}
+	}
+}
+
+func (q *Query) collectChildCandidateIndices(
+	parent *Node,
+	children []*Node,
+	step *QueryStep,
+	field FieldID,
+	nextChildIdx int,
+	lang *Language,
+	dst []int,
+) ([]int, bool) {
+	fieldName := ""
+	if field != 0 {
+		if int(field) <= 0 || int(field) >= len(lang.FieldNames) {
+			return dst, false
+		}
+		fieldName = lang.FieldNames[field]
+		if fieldName == "" {
+			return dst, false
+		}
+	}
+
+	contiguousRun := step.quantifier == queryQuantifierZeroOrMore || step.quantifier == queryQuantifierOneOrMore
+	startedRun := false
+	for i := nextChildIdx; i < len(children); i++ {
+		child := children[i]
+		if child == nil {
+			continue
+		}
+
+		fieldMatches := true
+		if fieldName != "" {
+			fieldMatches = parent.FieldNameForChild(i, lang) == fieldName
+		}
+		if fieldMatches && q.nodeMatchesStep(step, child, lang) {
+			dst = append(dst, i)
+			startedRun = true
+			continue
+		}
+
+		if contiguousRun && startedRun {
+			break
+		}
+	}
+	return dst, true
+}
+
 func quantifierBounds(quantifier queryQuantifier) (int, int, bool) {
 	switch quantifier {
 	case queryQuantifierOne:
@@ -231,35 +738,10 @@ func (q *Query) matchChildStepsRecursive(
 
 	var candidateIndicesBuf [32]int
 	candidateIndices := candidateIndicesBuf[:0]
-	if cs.field != 0 {
-		fieldName := ""
-		if int(cs.field) < len(lang.FieldNames) {
-			fieldName = lang.FieldNames[cs.field]
-		}
-		if fieldName == "" {
-			return false
-		}
-		// A parent can have multiple children with the same field name.
-		// Iterate children directly instead of ChildByFieldName (first match only).
-		for i := nextChildIdx; i < len(children); i++ {
-			child := children[i]
-			if child == nil {
-				continue
-			}
-			if parent.FieldNameForChild(i, lang) != fieldName {
-				continue
-			}
-			if q.nodeMatchesStep(step, child, lang) {
-				candidateIndices = append(candidateIndices, i)
-			}
-		}
-	} else {
-		for i := nextChildIdx; i < len(children); i++ {
-			child := children[i]
-			if q.nodeMatchesStep(step, child, lang) {
-				candidateIndices = append(candidateIndices, i)
-			}
-		}
+	var candidatesOK bool
+	candidateIndices, candidatesOK = q.collectChildCandidateIndices(parent, children, step, cs.field, nextChildIdx, lang, candidateIndices)
+	if !candidatesOK {
+		return false
 	}
 
 	if maxCount < 0 || maxCount > len(candidateIndices) {
@@ -398,8 +880,8 @@ func (q *Query) matchChildStepsRecursive(
 
 func (q *Query) matchAlternationStep(step *QueryStep, node *Node, parent *Node, childIdx int, lang *Language, source []byte, predicates []QueryPredicate, captures *[]QueryCapture) bool {
 	hasStepCaptures := len(step.captureIDs) > 0 || step.captureID >= 0
-	nodeSymbol := lang.PublicSymbol(node.Symbol())
 	nodeNamed := node.IsNamed()
+	nodeSymbol := lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed)
 	var nodeType string
 	nodeTypeLoaded := false
 
@@ -578,7 +1060,9 @@ func (q *Query) nodeMatchesStep(step *QueryStep, node *Node, lang *Language) boo
 			if len(idx.wildcard) > 0 {
 				return true
 			}
-			if len(idx.bySymbolNamed[alternationSymbolNamedKey(lang.PublicSymbol(node.Symbol()), node.IsNamed())]) > 0 {
+			nodeNamed := node.IsNamed()
+			nodeSymbol := lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed)
+			if len(idx.bySymbolNamed[alternationSymbolNamedKey(nodeSymbol, nodeNamed)]) > 0 {
 				return true
 			}
 			if !node.IsNamed() && len(idx.byText) > 0 {
@@ -606,15 +1090,14 @@ func (q *Query) nodeMatchesStep(step *QueryStep, node *Node, lang *Language) boo
 		return !step.isNamed || node.IsNamed()
 	}
 
-	// Symbol matching — use public symbol to handle aliases.
-	// Multiple internal symbols may share the same visible name (e.g.
-	// HTML's _start_tag_name and _end_tag_name both aliased to "tag_name").
-	if lang.PublicSymbol(node.Symbol()) != step.symbol {
+	nodeNamed := node.IsNamed()
+	if nodeNamed != step.isNamed {
 		return false
 	}
 
-	// Named check.
-	if step.isNamed && !node.IsNamed() {
+	// Symbol matching uses the public symbol with namedness to handle aliases
+	// without conflating anonymous tokens and named nodes that share text.
+	if lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed) != lang.PublicSymbolForNamedness(step.symbol, step.isNamed) {
 		return false
 	}
 
@@ -646,7 +1129,9 @@ func alternativeMatchesNode(alt alternativeSymbol, node *Node, lang *Language) b
 		return !node.IsNamed() && node.Type(lang) == alt.textMatch
 	}
 
-	return lang.PublicSymbol(node.Symbol()) == alt.symbol && node.IsNamed() == alt.isNamed
+	nodeNamed := node.IsNamed()
+	return nodeNamed == alt.isNamed &&
+		lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed) == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
 }
 
 func alternativeMatchesNodeCached(
@@ -675,5 +1160,5 @@ func alternativeMatchesNodeCached(
 		return *nodeType == alt.textMatch
 	}
 
-	return lang.PublicSymbol(nodeSymbol) == alt.symbol && nodeNamed == alt.isNamed
+	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
 }

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -125,7 +125,7 @@ func (q *Query) matchPatternAll(pat *Pattern, node *Node, lang *Language, source
 		return nil
 	}
 	if pat.steps[0].quantifier == queryQuantifierZeroOrMore {
-		return q.matchRootRepetitionPatternAll(pat, node, lang, source)
+		return q.matchRootZeroOrMorePatternAll(pat, node, lang, source)
 	}
 	if pat.steps[0].quantifier == queryQuantifierOneOrMore {
 		return nil
@@ -142,63 +142,10 @@ func (q *Query) matchPatternAll(pat *Pattern, node *Node, lang *Language, source
 	return matches
 }
 
-func (q *Query) matchRootRepetitionPatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
+func (q *Query) matchRootZeroOrMorePatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
 	if node == nil {
 		return nil
 	}
-	if pat.steps[0].quantifier == queryQuantifierZeroOrMore {
-		return q.matchRootZeroOrMorePatternAll(pat, node, lang, source)
-	}
-
-	parent := node.Parent()
-	childIdx := nodeChildIndexInParent(node, parent)
-	if prev := node.PrevSibling(); prev != nil {
-		prevParent := prev.Parent()
-		prevChildIdx := nodeChildIndexInParent(prev, prevParent)
-		if len(q.matchPatternOnceAll(pat, prev, prevParent, prevChildIdx, lang, source, nil)) > 0 {
-			return nil
-		}
-	}
-
-	partials := [][]QueryCapture{nil}
-	count := 0
-	for current := node; current != nil; current = current.NextSibling() {
-		currentParent := parent
-		currentChildIdx := childIdx
-		if current != node {
-			currentParent = current.Parent()
-			currentChildIdx = nodeChildIndexInParent(current, currentParent)
-		}
-
-		var nextPartials [][]QueryCapture
-		for _, captures := range partials {
-			for _, next := range q.matchPatternOnceAll(pat, current, currentParent, currentChildIdx, lang, source, captures) {
-				nextPartials = append(nextPartials, next)
-			}
-		}
-		if len(nextPartials) == 0 {
-			break
-		}
-		count++
-		partials = nextPartials
-		childIdx++
-	}
-	if count == 0 {
-		return nil
-	}
-
-	var matches [][]QueryCapture
-	for _, captures := range partials {
-		if !q.matchesPredicates(pat.predicates, captures, lang, source) {
-			continue
-		}
-		captures = q.applyDirectives(pat.predicates, captures, source)
-		matches = append(matches, cloneQueryCaptures(captures))
-	}
-	return matches
-}
-
-func (q *Query) matchRootZeroOrMorePatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
 	if q.matchesPredicates(pat.predicates, nil, lang, source) {
 		captures := q.applyDirectives(pat.predicates, nil, source)
 		return [][]QueryCapture{cloneQueryCaptures(captures)}

--- a/query_test.go
+++ b/query_test.go
@@ -1169,15 +1169,16 @@ func TestMatchAlternationFieldShorthandRespectsField(t *testing.T) {
 	}
 
 	matches := q.Execute(tree)
-	if len(matches) != 1 {
-		t.Fatalf("matches: got %d, want 1", len(matches))
-	}
-	if len(matches[0].Captures) != 2 {
-		t.Fatalf("captures: got %d, want 2", len(matches[0].Captures))
+	if len(matches) != 2 {
+		t.Fatalf("matches: got %d, want 2", len(matches))
 	}
 
 	got := map[string]bool{}
-	for _, c := range matches[0].Captures {
+	for _, m := range matches {
+		if len(m.Captures) != 1 {
+			t.Fatalf("captures per match: got %d, want 1", len(m.Captures))
+		}
+		c := m.Captures[0]
 		got[c.Node.Text(tree.Source())] = true
 	}
 
@@ -1919,16 +1920,15 @@ func TestMatchNamedWildcardSkipsAnonymousNodes(t *testing.T) {
 	}
 
 	matches := q.Execute(tree)
-	if len(matches) != 1 || len(matches[0].Captures) == 0 {
-		t.Fatalf("captures: got %d matches / %d captures, want 1/non-zero", len(matches), func() int {
-			if len(matches) == 0 {
-				return 0
-			}
-			return len(matches[0].Captures)
-		}())
+	if len(matches) != 3 {
+		t.Fatalf("matches: got %d, want 3", len(matches))
 	}
 	foundMain := false
-	for _, c := range matches[0].Captures {
+	for _, m := range matches {
+		if len(m.Captures) != 1 {
+			t.Fatalf("captures per match: got %d, want 1", len(m.Captures))
+		}
+		c := m.Captures[0]
 		if got := c.Node.Text(tree.Source()); got == "func" {
 			t.Fatalf("named wildcard matched anonymous token %q", got)
 		}
@@ -2102,6 +2102,201 @@ func TestMatchQuantifierPlusRequiresAtLeastOne(t *testing.T) {
 	matches := q.Execute(tree)
 	if len(matches) != 0 {
 		t.Fatalf("matches: got %d, want 0", len(matches))
+	}
+}
+
+func TestMatchRootQuantifierGroupsAdjacentSiblings(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("a b 1 c")
+	id0 := leaf(Symbol(1), true, 0, 1)
+	id1 := leaf(Symbol(1), true, 2, 3)
+	num := leaf(Symbol(2), true, 4, 5)
+	id2 := leaf(Symbol(1), true, 6, 7)
+	program := parent(Symbol(7), true, []*Node{id0, id1, num, id2}, []FieldID{0, 0, 0, 0})
+	tree := NewTree(program, source, lang)
+
+	q, err := NewQuery(`(identifier)+ @id`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	assertRootQuantifierGroups := func(t *testing.T, matches []QueryMatch) {
+		t.Helper()
+		if len(matches) != 2 {
+			t.Fatalf("matches: got %d, want 2", len(matches))
+		}
+		if len(matches[0].Captures) != 2 {
+			t.Fatalf("match[0] captures: got %d, want 2", len(matches[0].Captures))
+		}
+		if got := matches[0].Captures[0].Node.Text(source); got != "a" {
+			t.Fatalf("match[0] capture[0]: got %q, want %q", got, "a")
+		}
+		if got := matches[0].Captures[1].Node.Text(source); got != "b" {
+			t.Fatalf("match[0] capture[1]: got %q, want %q", got, "b")
+		}
+		if len(matches[1].Captures) != 1 {
+			t.Fatalf("match[1] captures: got %d, want 1", len(matches[1].Captures))
+		}
+		if got := matches[1].Captures[0].Node.Text(source); got != "c" {
+			t.Fatalf("match[1] capture[0]: got %q, want %q", got, "c")
+		}
+	}
+
+	assertRootQuantifierGroups(t, q.Execute(tree))
+	assertRootQuantifierGroups(t, q.executeNodeIntoBuffer(tree.RootNode(), lang, source, &queryExecBuffer{}))
+}
+
+func TestMatchRootStarEmitsEmptyMatchesBeforeRunEnd(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("a b 1 c")
+	id0 := leaf(Symbol(1), true, 0, 1)
+	id1 := leaf(Symbol(1), true, 2, 3)
+	num := leaf(Symbol(2), true, 4, 5)
+	id2 := leaf(Symbol(1), true, 6, 7)
+	program := parent(Symbol(7), true, []*Node{id0, id1, num, id2}, []FieldID{0, 0, 0, 0})
+	tree := NewTree(program, source, lang)
+
+	q, err := NewQuery(`(identifier)* @id`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	assertRootStarMatches := func(t *testing.T, matches []QueryMatch) {
+		t.Helper()
+		want := [][]string{
+			nil,
+			nil,
+			nil,
+			{"a", "b"},
+			nil,
+			nil,
+			{"c"},
+		}
+		if len(matches) != len(want) {
+			t.Fatalf("matches: got %d, want %d", len(matches), len(want))
+		}
+		for i, wantCaptures := range want {
+			if len(matches[i].Captures) != len(wantCaptures) {
+				t.Fatalf("match[%d] captures: got %d, want %d", i, len(matches[i].Captures), len(wantCaptures))
+			}
+			for j, wantText := range wantCaptures {
+				if got := matches[i].Captures[j].Node.Text(source); got != wantText {
+					t.Fatalf("match[%d] capture[%d]: got %q, want %q", i, j, got, wantText)
+				}
+			}
+		}
+	}
+
+	assertRootStarMatches(t, q.Execute(tree))
+	assertRootStarMatches(t, q.executeNodeIntoBuffer(tree.RootNode(), lang, source, &queryExecBuffer{}))
+}
+
+func TestMatchNamedNodeDoesNotMatchAnonymousTokenWithSameName(t *testing.T) {
+	lang := &Language{
+		Name:       "test_query_name_collision",
+		TokenCount: 2,
+		SymbolNames: []string{
+			"",
+			"module",
+			"module",
+			"module_id",
+			"source",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "", Visible: false, Named: false},
+			{Name: "module", Visible: true, Named: false},
+			{Name: "module", Visible: true, Named: true},
+			{Name: "module_id", Visible: true, Named: true},
+			{Name: "source", Visible: true, Named: true},
+		},
+	}
+	source := []byte("module Main")
+	keyword := leaf(Symbol(1), false, 0, 6)
+	moduleID := leaf(Symbol(3), true, 7, 11)
+	moduleNode := parent(Symbol(2), true, []*Node{moduleID}, []FieldID{0})
+	root := parent(Symbol(4), true, []*Node{keyword, moduleNode}, []FieldID{0, 0})
+	tree := NewTree(root, source, lang)
+
+	nodeQuery, err := NewQuery(`(module (module_id) @id)`, lang)
+	if err != nil {
+		t.Fatalf("node query parse error: %v", err)
+	}
+	nodeMatches := nodeQuery.Execute(tree)
+	if len(nodeMatches) != 1 {
+		t.Fatalf("node matches: got %d, want 1", len(nodeMatches))
+	}
+	if got := nodeMatches[0].Captures[0].Node.Text(source); got != "Main" {
+		t.Fatalf("node capture text: got %q, want %q", got, "Main")
+	}
+
+	tokenQuery, err := NewQuery(`"module" @kw`, lang)
+	if err != nil {
+		t.Fatalf("token query parse error: %v", err)
+	}
+	tokenMatches := tokenQuery.Execute(tree)
+	if len(tokenMatches) != 1 {
+		t.Fatalf("token matches: got %d, want 1", len(tokenMatches))
+	}
+	if got := tokenMatches[0].Captures[0].Node.Text(source); got != "module" {
+		t.Fatalf("token capture text: got %q, want %q", got, "module")
+	}
+}
+
+func TestMatchChildQuantifierUsesFirstContiguousNamedRun(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("a b 1 c")
+	id0 := leaf(Symbol(1), true, 0, 1)
+	id1 := leaf(Symbol(1), true, 2, 3)
+	num := leaf(Symbol(2), true, 4, 5)
+	id2 := leaf(Symbol(1), true, 6, 7)
+	program := parent(Symbol(7), true, []*Node{id0, id1, num, id2}, []FieldID{0, 0, 0, 0})
+	tree := NewTree(program, source, lang)
+
+	q, err := NewQuery(`(program (identifier)+ @id)`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	matches := q.Execute(tree)
+	if len(matches) != 1 {
+		t.Fatalf("matches: got %d, want 1", len(matches))
+	}
+	if len(matches[0].Captures) != 2 {
+		t.Fatalf("captures: got %d, want 2", len(matches[0].Captures))
+	}
+	if got := matches[0].Captures[0].Node.Text(source); got != "a" {
+		t.Fatalf("capture[0]: got %q, want %q", got, "a")
+	}
+	if got := matches[0].Captures[1].Node.Text(source); got != "b" {
+		t.Fatalf("capture[1]: got %q, want %q", got, "b")
+	}
+}
+
+func TestMatchChildQuantifierStopsAtAnonymousSiblingAfterRunStarts(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("a,b,c")
+	id0 := leaf(Symbol(1), true, 0, 1)
+	comma0 := leaf(Symbol(11), false, 1, 2)
+	id1 := leaf(Symbol(1), true, 2, 3)
+	comma1 := leaf(Symbol(11), false, 3, 4)
+	id2 := leaf(Symbol(1), true, 4, 5)
+	program := parent(Symbol(7), true, []*Node{id0, comma0, id1, comma1, id2}, []FieldID{0, 0, 0, 0, 0})
+	tree := NewTree(program, source, lang)
+
+	q, err := NewQuery(`(program (identifier)+ @id)`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	matches := q.Execute(tree)
+	if len(matches) != 1 {
+		t.Fatalf("matches: got %d, want 1", len(matches))
+	}
+	if len(matches[0].Captures) != 1 {
+		t.Fatalf("captures: got %d, want 1", len(matches[0].Captures))
+	}
+	if got := matches[0].Captures[0].Node.Text(source); got != "a" {
+		t.Fatalf("capture[0]: got %q, want %q", got, "a")
 	}
 }
 
@@ -2371,6 +2566,40 @@ func TestQueryCursorNextCapture(t *testing.T) {
 	}
 	if got[0] != "main" || got[1] != "42" {
 		t.Fatalf("cursor capture texts: got %v, want [main 42]", got)
+	}
+}
+
+func TestQueryChildRepetitionMatchesPostorder(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("a b c")
+	outerA := leaf(Symbol(1), true, 0, 1)
+	outerB := leaf(Symbol(1), true, 2, 3)
+	innerC := leaf(Symbol(1), true, 4, 5)
+	innerBlock := parent(Symbol(14), true, []*Node{innerC}, []FieldID{0})
+	outerBlock := parent(Symbol(14), true, []*Node{outerA, outerB, innerBlock}, []FieldID{0, 0, 0})
+	program := parent(Symbol(7), true, []*Node{outerBlock}, []FieldID{0})
+	tree := NewTree(program, source, lang)
+
+	q, err := NewQuery(`(block (identifier)+ @id)`, lang)
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	matches := q.Execute(tree)
+	if len(matches) != 2 {
+		t.Fatalf("matches: got %d, want 2", len(matches))
+	}
+
+	got := make([][]string, len(matches))
+	for i, match := range matches {
+		for _, capture := range match.Captures {
+			got[i] = append(got[i], capture.Node.Text(source))
+		}
+	}
+	if got[0][0] != "c" {
+		t.Fatalf("first match captures = %v, want nested [c] first", got)
+	}
+	if len(got[1]) != 2 || got[1][0] != "a" || got[1][1] != "b" {
+		t.Fatalf("second match captures = %v, want outer [a b] second", got)
 	}
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -599,6 +599,66 @@ func TestParsePredicateLuaMatch(t *testing.T) {
 	}
 }
 
+func TestCompileLuaPatternUppercaseClassesAndNonGreedy(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   string
+		matches   []string
+		nonMatch  []string
+		findInput string
+		findWant  string
+	}{
+		{
+			name:     "non-digit",
+			pattern:  `^%D+$`,
+			matches:  []string{"abc", "_-"},
+			nonMatch: []string{"123", "abc1"},
+		},
+		{
+			name:     "non-space",
+			pattern:  `^%S+$`,
+			matches:  []string{"abc"},
+			nonMatch: []string{"a b", "\t"},
+		},
+		{
+			name:     "non-word",
+			pattern:  `^%W+$`,
+			matches:  []string{"-!", "_"},
+			nonMatch: []string{"abc", "A1"},
+		},
+		{
+			name:      "non-greedy",
+			pattern:   `a.-b`,
+			findInput: "a123b456b",
+			findWant:  "a123b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rx, err := compileLuaPattern(tt.pattern)
+			if err != nil {
+				t.Fatalf("compileLuaPattern(%q): %v", tt.pattern, err)
+			}
+			for _, input := range tt.matches {
+				if !rx.MatchString(input) {
+					t.Fatalf("compileLuaPattern(%q).MatchString(%q) = false, want true", tt.pattern, input)
+				}
+			}
+			for _, input := range tt.nonMatch {
+				if rx.MatchString(input) {
+					t.Fatalf("compileLuaPattern(%q).MatchString(%q) = true, want false", tt.pattern, input)
+				}
+			}
+			if tt.findInput != "" {
+				if got := rx.FindString(tt.findInput); got != tt.findWant {
+					t.Fatalf("compileLuaPattern(%q).FindString(%q) = %q, want %q", tt.pattern, tt.findInput, got, tt.findWant)
+				}
+			}
+		})
+	}
+}
+
 func TestParsePredicateAncestorPredicates(t *testing.T) {
 	lang := queryTestLanguage()
 	q, err := NewQuery(`(identifier) @name (#has-ancestor? @name function_declaration)`, lang)

--- a/transient_parents.go
+++ b/transient_parents.go
@@ -121,11 +121,11 @@ func (s *transientParentScratch) materializeEntries(entries []stackEntry, arena 
 			continue
 		}
 		if replacement := s.transientReplacement(node); replacement != nil {
-			entries[i].node = replacement
+			setStackEntryNode(&entries[i], replacement)
 			continue
 		}
 		if replacement, ok := s.seen[node]; ok {
-			entries[i].node = replacement
+			setStackEntryNode(&entries[i], replacement)
 		}
 	}
 	s.clearMaterializeScratch()


### PR DESCRIPTION
## Summary
- Align query matching closer to C tree-sitter semantics for named vs anonymous symbols, repeated captures, quantified child groups, and postorder repetition ordering.
- Add top-50 query, highlight, and materialization parity coverage in the cgo harness.
- Normalize parse/materialization compatibility for Java, Kotlin, JavaScript/TypeScript, PowerShell, and YAML, and tighten the known-degraded list to current non-top50 cases.

## Validation
- `go test . -run 'Test(Query|Match|Highlight|Normalize|Collapsed|SymbolByName)' -count=1`
- `go test ./grammars -run '^TestTop50ParseSmokeNoErrors$/^(java|powershell|yaml|toml|kotlin)$' -count=1`
- Docker structural parity for Java, PowerShell, YAML, and TOML fresh/incremental paths.
- Docker top-50 generated query sweep: `harness_out/docker/20260520T044149Z`
- Docker top-50 highlight sweep: `harness_out/docker/20260520T044647Z`
- Docker top-50 materialization trend sweep: `harness_out/docker/20260520T045142Z`
- TOML no-skip confirmation: `harness_out/docker/20260520T045721Z`

## Notes
- Remaining surfaced trends are performance/materialization pressure rather than parity blockers: CMake and TOML `max_stacks=18`, Clojure `max_stacks=13`, and Python high `scratch_bytes=2949088`.