### PR TITLE
[codex] Add grammargen authoring commands

### DIFF
--- a/cmd/grammargen/commands.go
+++ b/cmd/grammargen/commands.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -24,6 +25,14 @@ type sampleFlags struct {
 	samplePath string
 	text       string
 	stdin      bool
+}
+
+type parseOptions struct {
+	format          string
+	runtime         bool
+	strict          bool
+	expectPath      string
+	writeExpectPath string
 }
 
 func isSubcommand(name string) bool {
@@ -53,6 +62,7 @@ func runEmitCommand(args []string) {
 	var binOut string
 	var cOut string
 	var goOut string
+	var jsonOut string
 	var pkgName string
 	var funcName string
 	var highlight bool
@@ -61,6 +71,7 @@ func runEmitCommand(args []string) {
 	fs.StringVar(&binOut, "bin", "", "output path for gotreesitter .bin blob")
 	fs.StringVar(&cOut, "c", "", "output path for tree-sitter parser.c")
 	fs.StringVar(&goOut, "go", "", "output path for grammargen Go DSL source")
+	fs.StringVar(&jsonOut, "json-out", "", "output path for resolved grammar.json")
 	fs.StringVar(&pkgName, "pkg", "grammargen", "package name for -go output")
 	fs.StringVar(&funcName, "func", "", "function name for -go output (default: <GrammarName>Grammar)")
 	fs.BoolVar(&highlight, "highlight", false, "write inferred highlight query to stdout")
@@ -79,19 +90,24 @@ func runEmitCommand(args []string) {
 	if highlight {
 		fmt.Print(grammargen.GenerateHighlightQuery(g))
 	}
-	if binOut == "" && cOut == "" && goOut == "" {
+	if jsonOut != "" {
+		writeGrammarJSONOutput(jsonOut, g)
+	}
+	if binOut == "" && cOut == "" && goOut == "" && jsonOut == "" {
 		if highlight {
 			return
 		}
-		exitf("specify at least one output: -bin <path>, -c <path>, -go <path>, or -highlight")
+		exitf("specify at least one output: -bin <path>, -c <path>, -go <path>, -json-out <path>, or -highlight")
 	}
-	runGenerateMode(cliConfig{
-		binOut:   binOut,
-		cOut:     cOut,
-		goOut:    goOut,
-		pkgName:  pkgName,
-		funcName: funcName,
-	}, g)
+	if binOut != "" || cOut != "" || goOut != "" {
+		runGenerateMode(cliConfig{
+			binOut:   binOut,
+			cOut:     cOut,
+			goOut:    goOut,
+			pkgName:  pkgName,
+			funcName: funcName,
+		}, g)
+	}
 }
 
 func registerSourceFlags(fs *flag.FlagSet, src *sourceFlags) {
@@ -105,6 +121,14 @@ func registerSampleFlags(fs *flag.FlagSet, sample *sampleFlags) {
 	fs.StringVar(&sample.samplePath, "sample", "", "path to source sample to parse")
 	fs.StringVar(&sample.text, "text", "", "inline source sample to parse")
 	fs.BoolVar(&sample.stdin, "stdin", false, "read source sample from stdin")
+}
+
+func registerParseOptionFlags(fs *flag.FlagSet, opts *parseOptions) {
+	fs.StringVar(&opts.format, "format", "text", "output format: text, sexpr, json")
+	fs.BoolVar(&opts.runtime, "runtime", false, "print parser runtime summary")
+	fs.BoolVar(&opts.strict, "strict", false, "exit non-zero if the parse has ERROR nodes or stops early")
+	fs.StringVar(&opts.expectPath, "expect", "", "path to expected S-expression file")
+	fs.StringVar(&opts.writeExpectPath, "write-expect", "", "write actual S-expression to this file")
 }
 
 func loadCommandGrammar(src sourceFlags) (*grammargen.Grammar, string) {
@@ -166,11 +190,11 @@ func readSample(sample sampleFlags, required bool) ([]byte, string, bool) {
 func runParseCommand(args []string) {
 	var src sourceFlags
 	var sample sampleFlags
-	var runtime bool
+	var opts parseOptions
 	fs := flag.NewFlagSet("grammargen parse", flag.ExitOnError)
 	registerSourceFlags(fs, &src)
 	registerSampleFlags(fs, &sample)
-	fs.BoolVar(&runtime, "runtime", false, "print parser runtime summary")
+	registerParseOptionFlags(fs, &opts)
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: grammargen parse [flags] <grammar-name>")
 		fmt.Fprintln(os.Stderr, "       grammargen parse -json <grammar.json> -sample <file>")
@@ -181,6 +205,7 @@ func runParseCommand(args []string) {
 		exitf("%v", err)
 	}
 	src.args = fs.Args()
+	validateParseOptions(opts)
 
 	g, name := loadCommandGrammar(src)
 	input, sampleName, _ := readSample(sample, true)
@@ -189,20 +214,40 @@ func runParseCommand(args []string) {
 		exitf("generation failed: %v", err)
 	}
 	result := parseSample(lang, input)
+	sexpr := resultSExpr(result, lang)
+	golden := applyGoldenOptions(opts, sexpr)
+	failed := golden.failed() || (opts.strict && parseResultFailed(result))
 
-	fmt.Printf("Grammar: %s\n", name)
-	fmt.Printf("Sample:  %s (%d bytes)\n", sampleName, len(input))
-	printParseResult(result, lang, runtime)
+	switch opts.format {
+	case "text":
+		fmt.Printf("Grammar: %s\n", name)
+		fmt.Printf("Sample:  %s (%d bytes)\n", sampleName, len(input))
+		printParseResult(result, lang, opts.runtime)
+		printGoldenResult(golden)
+	case "sexpr":
+		if sexpr != "" {
+			fmt.Println(sexpr)
+		}
+	case "json":
+		writeJSON(parseJSONReport(name, sampleName, len(input), result, lang, opts.runtime, golden))
+	default:
+		exitf("unknown -format %q (want text, sexpr, or json)", opts.format)
+	}
+	if failed {
+		os.Exit(1)
+	}
 }
 
 func runDoctorCommand(args []string) {
 	var src sourceFlags
 	var sample sampleFlags
-	var runtime bool
+	var opts parseOptions
+	var conflictLimit int
 	fs := flag.NewFlagSet("grammargen doctor", flag.ExitOnError)
 	registerSourceFlags(fs, &src)
 	registerSampleFlags(fs, &sample)
-	fs.BoolVar(&runtime, "runtime", false, "print parser runtime summary when parsing a sample")
+	registerParseOptionFlags(fs, &opts)
+	fs.IntVar(&conflictLimit, "conflicts", 0, "print the first N conflict diagnostics")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "usage: grammargen doctor [flags] <grammar-name>")
 		fmt.Fprintln(os.Stderr, "       grammargen doctor -json <grammar.json> [-sample <file>]")
@@ -213,20 +258,16 @@ func runDoctorCommand(args []string) {
 		exitf("%v", err)
 	}
 	src.args = fs.Args()
+	validateParseOptions(opts)
+	if conflictLimit < 0 {
+		exitf("-conflicts must be >= 0")
+	}
 
 	g, name := loadCommandGrammar(src)
 	failed := false
-	fmt.Printf("Grammar: %s\n", name)
-	fmt.Printf("Rules:   %d\n", len(g.Rules))
 
 	warnings := grammargen.Validate(g)
-	if len(warnings) == 0 {
-		fmt.Println("Validate: OK")
-	} else {
-		fmt.Printf("Validate: %d warning(s)\n", len(warnings))
-		for _, w := range warnings {
-			fmt.Printf("  - %s\n", w)
-		}
+	if len(warnings) > 0 {
 		failed = true
 	}
 
@@ -235,40 +276,76 @@ func runDoctorCommand(args []string) {
 		exitf("Generate: failed: %v", err)
 	}
 	glrConflicts := countGLRConflicts(rpt.Conflicts)
-	fmt.Println("Generate: OK")
-	fmt.Printf("Symbols:  %d\n", rpt.SymbolCount)
-	fmt.Printf("States:   %d\n", rpt.StateCount)
-	fmt.Printf("Tokens:   %d\n", rpt.TokenCount)
-	fmt.Printf("Blob:     %d bytes\n", len(rpt.Blob))
-	fmt.Printf("Conflicts: %d resolved", len(rpt.Conflicts))
-	if glrConflicts > 0 {
-		fmt.Printf(" (%d kept for GLR)", glrConflicts)
-	}
-	fmt.Println()
 
+	testStatus := "none"
+	var testError string
 	if len(g.Tests) == 0 {
-		fmt.Println("Embedded tests: none")
+		testStatus = "none"
 	} else if err := grammargen.RunTests(g); err != nil {
-		fmt.Printf("Embedded tests: failed\n")
-		fmt.Printf("%v\n", err)
+		testStatus = "failed"
+		testError = err.Error()
 		failed = true
 	} else {
-		fmt.Printf("Embedded tests: OK (%d)\n", len(g.Tests))
+		testStatus = "ok"
 	}
 
 	input, sampleName, ok := readSample(sample, false)
+	var sampleReport *parseJSON
+	var golden goldenResult
 	if ok {
 		result := parseSample(rpt.Language, input)
-		fmt.Printf("Sample: %s (%d bytes)\n", sampleName, len(input))
-		printParseResult(result, rpt.Language, runtime)
+		sexpr := resultSExpr(result, rpt.Language)
+		golden = applyGoldenOptions(opts, sexpr)
+		sampleReport = parseJSONReport(name, sampleName, len(input), result, rpt.Language, opts.runtime, golden)
 		if parseResultFailed(result) {
 			failed = true
 		}
-	} else {
-		fmt.Println("Sample: not run")
+		if golden.failed() {
+			failed = true
+		}
+	} else if opts.expectPath != "" || opts.writeExpectPath != "" {
+		exitf("-expect and -write-expect require a sample from -sample, -text, or -stdin")
+	} else if opts.format == "sexpr" {
+		exitf("-format sexpr requires a sample from -sample, -text, or -stdin")
 	}
 
-	printDoctorNextSteps(name, src, ok)
+	steps := nextSteps(name, src, ok)
+	switch opts.format {
+	case "text":
+		printDoctorText(name, g, warnings, rpt, glrConflicts, conflictLimit, testStatus, testError, ok, sampleName, len(input), sampleReport, golden, steps, opts.runtime)
+	case "json":
+		writeJSON(doctorJSONReport{
+			Grammar: name,
+			Rules:   len(g.Rules),
+			Validate: validateJSON{
+				OK:       len(warnings) == 0,
+				Warnings: warnings,
+			},
+			Generate: generateJSON{
+				OK:              true,
+				Symbols:         rpt.SymbolCount,
+				States:          rpt.StateCount,
+				Tokens:          rpt.TokenCount,
+				BlobBytes:       len(rpt.Blob),
+				Conflicts:       len(rpt.Conflicts),
+				GLRConflicts:    glrConflicts,
+				ConflictDetails: conflictDetails(rpt.Conflicts, g, conflictLimit),
+			},
+			EmbeddedTests: testsJSON{
+				Status: testStatus,
+				Count:  len(g.Tests),
+				Error:  testError,
+			},
+			Sample: sampleReport,
+			Next:   steps,
+		})
+	case "sexpr":
+		if sampleReport != nil {
+			fmt.Println(sampleReport.Parse.SExpr)
+		}
+	default:
+		exitf("unknown -format %q (want text, sexpr, or json)", opts.format)
+	}
 	if failed {
 		os.Exit(1)
 	}
@@ -299,7 +376,11 @@ func printParseResult(result parseResult, lang *gotreesitter.Language, runtime b
 		fmt.Println("Parse:   failed: nil root")
 		return
 	}
-	fmt.Println("Parse:   OK")
+	if parseResultFailed(result) {
+		fmt.Println("Parse:   completed with errors")
+	} else {
+		fmt.Println("Parse:   OK")
+	}
 	fmt.Printf("Root:    %s [%d:%d]\n", root.Type(lang), root.StartByte(), root.EndByte())
 	fmt.Printf("Error:   %v\n", root.HasError())
 	fmt.Printf("Stop:    %s\n", result.tree.ParseStopReason())
@@ -307,7 +388,7 @@ func printParseResult(result parseResult, lang *gotreesitter.Language, runtime b
 		fmt.Printf("Runtime: %s\n", result.tree.ParseRuntime().Summary())
 	}
 	fmt.Println("S-expression:")
-	fmt.Println(root.SExpr(lang))
+	fmt.Println(resultSExpr(result, lang))
 }
 
 func parseResultFailed(result parseResult) bool {
@@ -315,6 +396,154 @@ func parseResultFailed(result parseResult) bool {
 		return true
 	}
 	return result.root.HasError() || result.tree.ParseStoppedEarly()
+}
+
+func validateParseOptions(opts parseOptions) {
+	switch opts.format {
+	case "text", "sexpr", "json":
+	default:
+		exitf("unknown -format %q (want text, sexpr, or json)", opts.format)
+	}
+	if opts.expectPath != "" && opts.writeExpectPath != "" {
+		exitf("use only one of -expect or -write-expect")
+	}
+}
+
+func resultSExpr(result parseResult, lang *gotreesitter.Language) string {
+	if result.err != nil || result.root == nil {
+		return ""
+	}
+	return result.root.SExpr(lang)
+}
+
+type goldenResult struct {
+	Path     string `json:"path,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	Matched  bool   `json:"matched,omitempty"`
+	Updated  bool   `json:"updated,omitempty"`
+	Expected string `json:"expected,omitempty"`
+	Actual   string `json:"actual,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+func (r goldenResult) failed() bool {
+	return r.Error != "" || (r.Mode == "expect" && !r.Matched)
+}
+
+func applyGoldenOptions(opts parseOptions, sexpr string) goldenResult {
+	switch {
+	case opts.expectPath != "":
+		data, err := os.ReadFile(opts.expectPath)
+		if err != nil {
+			return goldenResult{Path: opts.expectPath, Mode: "expect", Actual: sexpr, Error: err.Error()}
+		}
+		expected := normalizeGoldenSExpr(string(data))
+		actual := normalizeGoldenSExpr(sexpr)
+		return goldenResult{
+			Path:     opts.expectPath,
+			Mode:     "expect",
+			Matched:  expected == actual,
+			Expected: expected,
+			Actual:   actual,
+		}
+	case opts.writeExpectPath != "":
+		err := os.WriteFile(opts.writeExpectPath, []byte(sexpr+"\n"), 0644)
+		out := goldenResult{Path: opts.writeExpectPath, Mode: "write", Updated: err == nil, Actual: sexpr}
+		if err != nil {
+			out.Error = err.Error()
+		}
+		return out
+	default:
+		return goldenResult{}
+	}
+}
+
+func normalizeGoldenSExpr(s string) string {
+	s = strings.TrimSuffix(s, "\n")
+	s = strings.TrimSuffix(s, "\r")
+	return s
+}
+
+func printGoldenResult(result goldenResult) {
+	if result.Mode == "" {
+		return
+	}
+	switch {
+	case result.Error != "":
+		fmt.Printf("Golden: failed: %s\n", result.Error)
+	case result.Mode == "write":
+		fmt.Printf("Golden: wrote %s\n", result.Path)
+	case result.Matched:
+		fmt.Printf("Golden: matched %s\n", result.Path)
+	default:
+		fmt.Printf("Golden: mismatch %s\n", result.Path)
+		fmt.Printf("  expected: %s\n", result.Expected)
+		fmt.Printf("  actual:   %s\n", result.Actual)
+	}
+}
+
+type parseJSON struct {
+	Grammar string        `json:"grammar"`
+	Sample  string        `json:"sample"`
+	Bytes   int           `json:"bytes"`
+	Parse   parseStatus   `json:"parse"`
+	Golden  *goldenResult `json:"golden,omitempty"`
+}
+
+type parseStatus struct {
+	OK           bool   `json:"ok"`
+	Root         string `json:"root,omitempty"`
+	StartByte    uint32 `json:"start_byte"`
+	EndByte      uint32 `json:"end_byte"`
+	HasError     bool   `json:"has_error"`
+	StoppedEarly bool   `json:"stopped_early"`
+	StopReason   string `json:"stop_reason,omitempty"`
+	SExpr        string `json:"sexpr,omitempty"`
+	Runtime      string `json:"runtime,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
+func parseJSONReport(name, sampleName string, sampleBytes int, result parseResult, lang *gotreesitter.Language, runtime bool, golden goldenResult) *parseJSON {
+	out := &parseJSON{
+		Grammar: name,
+		Sample:  sampleName,
+		Bytes:   sampleBytes,
+	}
+	if golden.Mode != "" {
+		out.Golden = &golden
+	}
+	if result.err != nil {
+		out.Parse = parseStatus{OK: false, Error: result.err.Error()}
+		return out
+	}
+	if result.root == nil || result.tree == nil {
+		out.Parse = parseStatus{OK: false, Error: "nil parse tree or root"}
+		return out
+	}
+	root := result.root
+	out.Parse = parseStatus{
+		OK:           !parseResultFailed(result),
+		Root:         root.Type(lang),
+		StartByte:    root.StartByte(),
+		EndByte:      root.EndByte(),
+		HasError:     root.HasError(),
+		StoppedEarly: result.tree.ParseStoppedEarly(),
+		StopReason:   string(result.tree.ParseStopReason()),
+		SExpr:        resultSExpr(result, lang),
+	}
+	if runtime {
+		out.Parse.Runtime = result.tree.ParseRuntime().Summary()
+	}
+	return out
+}
+
+func writeJSON(v interface{}) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		exitf("marshal JSON: %v", err)
+	}
 }
 
 func countGLRConflicts(conflicts []grammargen.ConflictDiag) int {
@@ -327,7 +556,144 @@ func countGLRConflicts(conflicts []grammargen.ConflictDiag) int {
 	return count
 }
 
-func printDoctorNextSteps(name string, src sourceFlags, parsedSample bool) {
+func printDoctorText(
+	name string,
+	g *grammargen.Grammar,
+	warnings []string,
+	rpt *grammargen.GenerateReport,
+	glrConflicts int,
+	conflictLimit int,
+	testStatus string,
+	testError string,
+	hasSample bool,
+	sampleName string,
+	sampleBytes int,
+	sampleReport *parseJSON,
+	golden goldenResult,
+	steps []string,
+	runtime bool,
+) {
+	fmt.Printf("Grammar: %s\n", name)
+	fmt.Printf("Rules:   %d\n", len(g.Rules))
+	if len(warnings) == 0 {
+		fmt.Println("Validate: OK")
+	} else {
+		fmt.Printf("Validate: %d warning(s)\n", len(warnings))
+		for _, w := range warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+	fmt.Println("Generate: OK")
+	fmt.Printf("Symbols:  %d\n", rpt.SymbolCount)
+	fmt.Printf("States:   %d\n", rpt.StateCount)
+	fmt.Printf("Tokens:   %d\n", rpt.TokenCount)
+	fmt.Printf("Blob:     %d bytes\n", len(rpt.Blob))
+	fmt.Printf("Conflicts: %d resolved", len(rpt.Conflicts))
+	if glrConflicts > 0 {
+		fmt.Printf(" (%d kept for GLR)", glrConflicts)
+	}
+	fmt.Println()
+	printConflictDetails(rpt.Conflicts, g, conflictLimit)
+
+	switch testStatus {
+	case "none":
+		fmt.Println("Embedded tests: none")
+	case "ok":
+		fmt.Printf("Embedded tests: OK (%d)\n", len(g.Tests))
+	case "failed":
+		fmt.Println("Embedded tests: failed")
+		fmt.Println(testError)
+	}
+
+	if hasSample && sampleReport != nil {
+		fmt.Printf("Sample: %s (%d bytes)\n", sampleName, sampleBytes)
+		printParseStatus(sampleReport.Parse, runtime)
+		printGoldenResult(golden)
+	} else {
+		fmt.Println("Sample: not run")
+	}
+
+	printNextSteps(steps)
+}
+
+func printParseStatus(status parseStatus, runtime bool) {
+	if status.Error != "" {
+		fmt.Printf("Parse:   failed: %v\n", status.Error)
+		return
+	}
+	if status.OK {
+		fmt.Println("Parse:   OK")
+	} else {
+		fmt.Println("Parse:   completed with errors")
+	}
+	fmt.Printf("Root:    %s [%d:%d]\n", status.Root, status.StartByte, status.EndByte)
+	fmt.Printf("Error:   %v\n", status.HasError)
+	fmt.Printf("Stop:    %s\n", status.StopReason)
+	if runtime && status.Runtime != "" {
+		fmt.Printf("Runtime: %s\n", status.Runtime)
+	}
+	fmt.Println("S-expression:")
+	fmt.Println(status.SExpr)
+}
+
+func printConflictDetails(conflicts []grammargen.ConflictDiag, g *grammargen.Grammar, limit int) {
+	for _, detail := range conflictDetails(conflicts, g, limit) {
+		fmt.Println()
+		fmt.Println(detail)
+	}
+}
+
+func conflictDetails(conflicts []grammargen.ConflictDiag, g *grammargen.Grammar, limit int) []string {
+	if limit <= 0 || len(conflicts) == 0 {
+		return nil
+	}
+	if limit > len(conflicts) {
+		limit = len(conflicts)
+	}
+	ng, err := grammargen.Normalize(g)
+	if err != nil {
+		return []string{"conflict detail unavailable: " + err.Error()}
+	}
+	details := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		details = append(details, fmt.Sprintf("[%d] %s", i+1, conflicts[i].String(ng)))
+	}
+	return details
+}
+
+type doctorJSONReport struct {
+	Grammar       string       `json:"grammar"`
+	Rules         int          `json:"rules"`
+	Validate      validateJSON `json:"validate"`
+	Generate      generateJSON `json:"generate"`
+	EmbeddedTests testsJSON    `json:"embedded_tests"`
+	Sample        *parseJSON   `json:"sample,omitempty"`
+	Next          []string     `json:"next,omitempty"`
+}
+
+type validateJSON struct {
+	OK       bool     `json:"ok"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+type generateJSON struct {
+	OK              bool     `json:"ok"`
+	Symbols         int      `json:"symbols"`
+	States          int      `json:"states"`
+	Tokens          int      `json:"tokens"`
+	BlobBytes       int      `json:"blob_bytes"`
+	Conflicts       int      `json:"conflicts"`
+	GLRConflicts    int      `json:"glr_conflicts"`
+	ConflictDetails []string `json:"conflict_details,omitempty"`
+}
+
+type testsJSON struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+	Error  string `json:"error,omitempty"`
+}
+
+func nextSteps(name string, src sourceFlags, parsedSample bool) []string {
 	var steps []string
 	if !parsedSample {
 		steps = append(steps, "add -sample <file>, -text <source>, or -stdin to inspect a parse tree")
@@ -341,6 +707,10 @@ func printDoctorNextSteps(name string, src sourceFlags, parsedSample bool) {
 	if isKnownParityGrammar(name) {
 		steps = append(steps, fmt.Sprintf("run focused parity in Docker when ready: bash cgo_harness/docker/run_single_grammar_parity.sh %s", canonicalParityName(name)))
 	}
+	return steps
+}
+
+func printNextSteps(steps []string) {
 	if len(steps) == 0 {
 		return
 	}
@@ -348,6 +718,17 @@ func printDoctorNextSteps(name string, src sourceFlags, parsedSample bool) {
 	for _, step := range steps {
 		fmt.Printf("  %s\n", step)
 	}
+}
+
+func writeGrammarJSONOutput(path string, g *grammargen.Grammar) {
+	data, err := grammargen.ExportGrammarJSON(g)
+	if err != nil {
+		exitf("grammar.json generation failed: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		exitf("write %s: %v", path, err)
+	}
+	fmt.Printf("wrote %s (%d bytes)\n", path, len(data))
 }
 
 func sourceSpecifier(name string, src sourceFlags) string {
@@ -405,16 +786,21 @@ func canonicalParityName(name string) string {
 
 func normalizeSubcommandArgs(args []string) []string {
 	valueFlags := map[string]bool{
-		"bin":     true,
-		"c":       true,
-		"func":    true,
-		"go":      true,
-		"js":      true,
-		"json":    true,
-		"grammar": true,
-		"pkg":     true,
-		"sample":  true,
-		"text":    true,
+		"bin":          true,
+		"c":            true,
+		"conflicts":    true,
+		"expect":       true,
+		"format":       true,
+		"func":         true,
+		"go":           true,
+		"js":           true,
+		"json":         true,
+		"json-out":     true,
+		"grammar":      true,
+		"pkg":          true,
+		"sample":       true,
+		"text":         true,
+		"write-expect": true,
 	}
 	var flags []string
 	var positionals []string

--- a/cmd/grammargen/commands.go
+++ b/cmd/grammargen/commands.go
@@ -1,0 +1,448 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammargen"
+)
+
+type sourceFlags struct {
+	jsInput     string
+	jsonInput   string
+	grammarFile string
+	lrSplit     bool
+	args        []string
+}
+
+type sampleFlags struct {
+	samplePath string
+	text       string
+	stdin      bool
+}
+
+func isSubcommand(name string) bool {
+	switch name {
+	case "emit", "parse", "doctor":
+		return true
+	default:
+		return false
+	}
+}
+
+func runSubcommand(name string, args []string) {
+	switch name {
+	case "emit":
+		runEmitCommand(args)
+	case "parse":
+		runParseCommand(args)
+	case "doctor":
+		runDoctorCommand(args)
+	default:
+		exitf("unknown command %q", name)
+	}
+}
+
+func runEmitCommand(args []string) {
+	var src sourceFlags
+	var binOut string
+	var cOut string
+	var goOut string
+	var pkgName string
+	var funcName string
+	var highlight bool
+	fs := flag.NewFlagSet("grammargen emit", flag.ExitOnError)
+	registerSourceFlags(fs, &src)
+	fs.StringVar(&binOut, "bin", "", "output path for gotreesitter .bin blob")
+	fs.StringVar(&cOut, "c", "", "output path for tree-sitter parser.c")
+	fs.StringVar(&goOut, "go", "", "output path for grammargen Go DSL source")
+	fs.StringVar(&pkgName, "pkg", "grammargen", "package name for -go output")
+	fs.StringVar(&funcName, "func", "", "function name for -go output (default: <GrammarName>Grammar)")
+	fs.BoolVar(&highlight, "highlight", false, "write inferred highlight query to stdout")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: grammargen emit [flags] <grammar-name>")
+		fmt.Fprintln(os.Stderr, "       grammargen emit -json <grammar.json> -go <out.go>")
+		fmt.Fprintln(os.Stderr, "       grammargen emit -grammar <file.grammar> -go <out.go>")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeSubcommandArgs(args)); err != nil {
+		exitf("%v", err)
+	}
+	src.args = fs.Args()
+
+	g, _ := loadCommandGrammar(src)
+	if highlight {
+		fmt.Print(grammargen.GenerateHighlightQuery(g))
+	}
+	if binOut == "" && cOut == "" && goOut == "" {
+		if highlight {
+			return
+		}
+		exitf("specify at least one output: -bin <path>, -c <path>, -go <path>, or -highlight")
+	}
+	runGenerateMode(cliConfig{
+		binOut:   binOut,
+		cOut:     cOut,
+		goOut:    goOut,
+		pkgName:  pkgName,
+		funcName: funcName,
+	}, g)
+}
+
+func registerSourceFlags(fs *flag.FlagSet, src *sourceFlags) {
+	fs.StringVar(&src.jsInput, "js", "", "path to a tree-sitter grammar.js file to import")
+	fs.StringVar(&src.jsonInput, "json", "", "path to a resolved tree-sitter grammar.json file to import")
+	fs.StringVar(&src.grammarFile, "grammar", "", "path to a .grammar file to parse")
+	fs.BoolVar(&src.lrSplit, "lr-split", false, "enable LR(1) state splitting before generation")
+}
+
+func registerSampleFlags(fs *flag.FlagSet, sample *sampleFlags) {
+	fs.StringVar(&sample.samplePath, "sample", "", "path to source sample to parse")
+	fs.StringVar(&sample.text, "text", "", "inline source sample to parse")
+	fs.BoolVar(&sample.stdin, "stdin", false, "read source sample from stdin")
+}
+
+func loadCommandGrammar(src sourceFlags) (*grammargen.Grammar, string) {
+	cfg := cliConfig{
+		jsInput:     src.jsInput,
+		jsonInput:   src.jsonInput,
+		grammarFile: src.grammarFile,
+		lrSplit:     src.lrSplit,
+		args:        src.args,
+	}
+	g, name := loadGrammar(cfg)
+	if cfg.lrSplit {
+		g.EnableLRSplitting = true
+	}
+	return g, name
+}
+
+func readSample(sample sampleFlags, required bool) ([]byte, string, bool) {
+	count := 0
+	if sample.samplePath != "" {
+		count++
+	}
+	if sample.text != "" {
+		count++
+	}
+	if sample.stdin {
+		count++
+	}
+	if count > 1 {
+		exitf("use only one of -sample, -text, or -stdin")
+	}
+	if count == 0 {
+		if required {
+			exitf("provide a sample with -sample <path>, -text <source>, or -stdin")
+		}
+		return nil, "", false
+	}
+
+	switch {
+	case sample.samplePath != "":
+		data, err := os.ReadFile(sample.samplePath)
+		if err != nil {
+			exitf("read sample %s: %v", sample.samplePath, err)
+		}
+		return data, sample.samplePath, true
+	case sample.text != "":
+		return []byte(sample.text), "<text>", true
+	case sample.stdin:
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			exitf("read stdin: %v", err)
+		}
+		return data, "<stdin>", true
+	default:
+		return nil, "", false
+	}
+}
+
+func runParseCommand(args []string) {
+	var src sourceFlags
+	var sample sampleFlags
+	var runtime bool
+	fs := flag.NewFlagSet("grammargen parse", flag.ExitOnError)
+	registerSourceFlags(fs, &src)
+	registerSampleFlags(fs, &sample)
+	fs.BoolVar(&runtime, "runtime", false, "print parser runtime summary")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: grammargen parse [flags] <grammar-name>")
+		fmt.Fprintln(os.Stderr, "       grammargen parse -json <grammar.json> -sample <file>")
+		fmt.Fprintln(os.Stderr, "       grammargen parse -grammar <file.grammar> -text <source>")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeSubcommandArgs(args)); err != nil {
+		exitf("%v", err)
+	}
+	src.args = fs.Args()
+
+	g, name := loadCommandGrammar(src)
+	input, sampleName, _ := readSample(sample, true)
+	lang, err := grammargen.GenerateLanguage(g)
+	if err != nil {
+		exitf("generation failed: %v", err)
+	}
+	result := parseSample(lang, input)
+
+	fmt.Printf("Grammar: %s\n", name)
+	fmt.Printf("Sample:  %s (%d bytes)\n", sampleName, len(input))
+	printParseResult(result, lang, runtime)
+}
+
+func runDoctorCommand(args []string) {
+	var src sourceFlags
+	var sample sampleFlags
+	var runtime bool
+	fs := flag.NewFlagSet("grammargen doctor", flag.ExitOnError)
+	registerSourceFlags(fs, &src)
+	registerSampleFlags(fs, &sample)
+	fs.BoolVar(&runtime, "runtime", false, "print parser runtime summary when parsing a sample")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: grammargen doctor [flags] <grammar-name>")
+		fmt.Fprintln(os.Stderr, "       grammargen doctor -json <grammar.json> [-sample <file>]")
+		fmt.Fprintln(os.Stderr, "       grammargen doctor -grammar <file.grammar> [-text <source>]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(normalizeSubcommandArgs(args)); err != nil {
+		exitf("%v", err)
+	}
+	src.args = fs.Args()
+
+	g, name := loadCommandGrammar(src)
+	failed := false
+	fmt.Printf("Grammar: %s\n", name)
+	fmt.Printf("Rules:   %d\n", len(g.Rules))
+
+	warnings := grammargen.Validate(g)
+	if len(warnings) == 0 {
+		fmt.Println("Validate: OK")
+	} else {
+		fmt.Printf("Validate: %d warning(s)\n", len(warnings))
+		for _, w := range warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+		failed = true
+	}
+
+	rpt, err := grammargen.GenerateWithReport(g)
+	if err != nil {
+		exitf("Generate: failed: %v", err)
+	}
+	glrConflicts := countGLRConflicts(rpt.Conflicts)
+	fmt.Println("Generate: OK")
+	fmt.Printf("Symbols:  %d\n", rpt.SymbolCount)
+	fmt.Printf("States:   %d\n", rpt.StateCount)
+	fmt.Printf("Tokens:   %d\n", rpt.TokenCount)
+	fmt.Printf("Blob:     %d bytes\n", len(rpt.Blob))
+	fmt.Printf("Conflicts: %d resolved", len(rpt.Conflicts))
+	if glrConflicts > 0 {
+		fmt.Printf(" (%d kept for GLR)", glrConflicts)
+	}
+	fmt.Println()
+
+	if len(g.Tests) == 0 {
+		fmt.Println("Embedded tests: none")
+	} else if err := grammargen.RunTests(g); err != nil {
+		fmt.Printf("Embedded tests: failed\n")
+		fmt.Printf("%v\n", err)
+		failed = true
+	} else {
+		fmt.Printf("Embedded tests: OK (%d)\n", len(g.Tests))
+	}
+
+	input, sampleName, ok := readSample(sample, false)
+	if ok {
+		result := parseSample(rpt.Language, input)
+		fmt.Printf("Sample: %s (%d bytes)\n", sampleName, len(input))
+		printParseResult(result, rpt.Language, runtime)
+		if parseResultFailed(result) {
+			failed = true
+		}
+	} else {
+		fmt.Println("Sample: not run")
+	}
+
+	printDoctorNextSteps(name, src, ok)
+	if failed {
+		os.Exit(1)
+	}
+}
+
+type parseResult struct {
+	tree *gotreesitter.Tree
+	root *gotreesitter.Node
+	err  error
+}
+
+func parseSample(lang *gotreesitter.Language, input []byte) parseResult {
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(input)
+	if err != nil {
+		return parseResult{err: err}
+	}
+	return parseResult{tree: tree, root: tree.RootNode()}
+}
+
+func printParseResult(result parseResult, lang *gotreesitter.Language, runtime bool) {
+	if result.err != nil {
+		fmt.Printf("Parse:   failed: %v\n", result.err)
+		return
+	}
+	root := result.root
+	if root == nil {
+		fmt.Println("Parse:   failed: nil root")
+		return
+	}
+	fmt.Println("Parse:   OK")
+	fmt.Printf("Root:    %s [%d:%d]\n", root.Type(lang), root.StartByte(), root.EndByte())
+	fmt.Printf("Error:   %v\n", root.HasError())
+	fmt.Printf("Stop:    %s\n", result.tree.ParseStopReason())
+	if runtime {
+		fmt.Printf("Runtime: %s\n", result.tree.ParseRuntime().Summary())
+	}
+	fmt.Println("S-expression:")
+	fmt.Println(root.SExpr(lang))
+}
+
+func parseResultFailed(result parseResult) bool {
+	if result.err != nil || result.tree == nil || result.root == nil {
+		return true
+	}
+	return result.root.HasError() || result.tree.ParseStoppedEarly()
+}
+
+func countGLRConflicts(conflicts []grammargen.ConflictDiag) int {
+	count := 0
+	for _, c := range conflicts {
+		if strings.Contains(c.Resolution, "GLR") {
+			count++
+		}
+	}
+	return count
+}
+
+func printDoctorNextSteps(name string, src sourceFlags, parsedSample bool) {
+	var steps []string
+	if !parsedSample {
+		steps = append(steps, "add -sample <file>, -text <source>, or -stdin to inspect a parse tree")
+	}
+	if source := sourceSpecifier(name, src); source != "" {
+		steps = append(steps,
+			fmt.Sprintf("emit Go DSL with: go run ./cmd/grammargen emit %s -go <path> -pkg grammargen", source),
+			fmt.Sprintf("emit a blob with: go run ./cmd/grammargen emit %s -bin <path>", source),
+		)
+	}
+	if isKnownParityGrammar(name) {
+		steps = append(steps, fmt.Sprintf("run focused parity in Docker when ready: bash cgo_harness/docker/run_single_grammar_parity.sh %s", canonicalParityName(name)))
+	}
+	if len(steps) == 0 {
+		return
+	}
+	fmt.Println("Next:")
+	for _, step := range steps {
+		fmt.Printf("  %s\n", step)
+	}
+}
+
+func sourceSpecifier(name string, src sourceFlags) string {
+	switch {
+	case src.grammarFile != "":
+		return "-grammar " + commandArg(src.grammarFile)
+	case src.jsonInput != "":
+		return "-json " + commandArg(src.jsonInput)
+	case src.jsInput != "":
+		return "-js " + commandArg(src.jsInput)
+	case name != "":
+		return commandArg(name)
+	default:
+		return ""
+	}
+}
+
+func commandArg(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if strings.ContainsAny(s, " \t\n'\"\\$`") {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func isKnownParityGrammar(name string) bool {
+	switch canonicalParityName(name) {
+	case "bash", "c_lang", "comment", "cpon", "css", "csv", "diff", "dockerfile",
+		"dot", "eds", "eex", "elixir", "forth", "git_config", "git_rebase",
+		"gitattributes", "gitcommit", "go_lang", "gomod", "graphql", "haskell",
+		"hcl", "html", "ini", "javascript", "jsdoc", "json", "json5", "lua",
+		"make", "nix", "ocaml", "pem", "php", "promql", "properties", "proto",
+		"python", "regex", "requirements", "ron", "scala", "scheme", "sql",
+		"ssh_config", "swift", "todotxt", "toml", "yaml", "rust", "c_sharp",
+		"java", "ruby", "cpp", "kotlin", "cuda", "typescript", "tsx", "cobol",
+		"fortran", "perl", "erlang", "d":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalParityName(name string) string {
+	switch name {
+	case "go":
+		return "go_lang"
+	case "c":
+		return "c_lang"
+	default:
+		return name
+	}
+}
+
+func normalizeSubcommandArgs(args []string) []string {
+	valueFlags := map[string]bool{
+		"bin":     true,
+		"c":       true,
+		"func":    true,
+		"go":      true,
+		"js":      true,
+		"json":    true,
+		"grammar": true,
+		"pkg":     true,
+		"sample":  true,
+		"text":    true,
+	}
+	var flags []string
+	var positionals []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			positionals = append(positionals, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			positionals = append(positionals, arg)
+			continue
+		}
+
+		flags = append(flags, arg)
+		name, hasValue := splitFlagName(arg)
+		if valueFlags[name] && !hasValue && i+1 < len(args) {
+			i++
+			flags = append(flags, args[i])
+		}
+	}
+	return append(flags, positionals...)
+}
+
+func splitFlagName(arg string) (name string, hasValue bool) {
+	name = strings.TrimLeft(arg, "-")
+	if idx := strings.IndexByte(name, '='); idx >= 0 {
+		return name[:idx], true
+	}
+	return name, false
+}

--- a/cmd/grammargen/commands_test.go
+++ b/cmd/grammargen/commands_test.go
@@ -20,3 +20,25 @@ func TestNormalizeSubcommandArgsKeepsFlagEqualsValues(t *testing.T) {
 		t.Fatalf("normalizeSubcommandArgs() = %#v, want %#v", got, want)
 	}
 }
+
+func TestNormalizeSubcommandArgsHandlesAuthoringValueFlags(t *testing.T) {
+	got := normalizeSubcommandArgs([]string{
+		"calc",
+		"-format", "json",
+		"-expect", "want.sexpr",
+		"-write-expect", "got.sexpr",
+		"-json-out", "grammar.json",
+		"-conflicts", "2",
+	})
+	want := []string{
+		"-format", "json",
+		"-expect", "want.sexpr",
+		"-write-expect", "got.sexpr",
+		"-json-out", "grammar.json",
+		"-conflicts", "2",
+		"calc",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeSubcommandArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/cmd/grammargen/commands_test.go
+++ b/cmd/grammargen/commands_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeSubcommandArgsAllowsGrammarBeforeFlags(t *testing.T) {
+	got := normalizeSubcommandArgs([]string{"calc", "-text", "1+2", "-runtime"})
+	want := []string{"-text", "1+2", "-runtime", "calc"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeSubcommandArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeSubcommandArgsKeepsFlagEqualsValues(t *testing.T) {
+	got := normalizeSubcommandArgs([]string{"calc", "-text=1+2", "-sample", "sample.txt"})
+	want := []string{"-text=1+2", "-sample", "sample.txt", "calc"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeSubcommandArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/cmd/grammargen/main.go
+++ b/cmd/grammargen/main.go
@@ -71,6 +71,11 @@ type cliConfig struct {
 }
 
 func main() {
+	if len(os.Args) > 1 && isSubcommand(os.Args[1]) {
+		runSubcommand(os.Args[1], os.Args[2:])
+		return
+	}
+
 	cfg := parseCLIConfig()
 	if cfg.list {
 		runListMode()
@@ -96,6 +101,10 @@ func main() {
 
 func parseCLIConfig() cliConfig {
 	var cfg cliConfig
+	flag.Usage = func() {
+		printUsageError()
+		flag.PrintDefaults()
+	}
 	flag.StringVar(&cfg.binOut, "bin", "", "output path for gotreesitter .bin blob")
 	flag.StringVar(&cfg.cOut, "c", "", "output path for tree-sitter parser.c")
 	flag.StringVar(&cfg.goOut, "go", "", "output path for grammargen Go DSL source")
@@ -290,6 +299,9 @@ func printUsageError() {
 	fmt.Fprintln(os.Stderr, "       grammargen -js <grammar.js> [flags]")
 	fmt.Fprintln(os.Stderr, "       grammargen -json <grammar.json> [flags]")
 	fmt.Fprintln(os.Stderr, "       grammargen -grammar <file.grammar> [flags]")
+	fmt.Fprintln(os.Stderr, "       grammargen emit [flags] <grammar-name>")
+	fmt.Fprintln(os.Stderr, "       grammargen parse [flags] <grammar-name>")
+	fmt.Fprintln(os.Stderr, "       grammargen doctor [flags] <grammar-name>")
 	fmt.Fprintln(os.Stderr, "run with -list to see available built-in grammars")
 }
 

--- a/cmd/grammargen/main.go
+++ b/cmd/grammargen/main.go
@@ -6,15 +6,22 @@
 //
 // Input sources:
 //
-//	<name>        Built-in grammar (json, calc, glr, go, js, ts, tsx, fortran, etc.)
-//	-js <path>    Import a tree-sitter grammar.js file
-//	-json <path>  Import a resolved tree-sitter grammar.json file
+//	<name>          Built-in grammar (json, calc, glr, go, js, ts, tsx, fortran, etc.)
+//	-js <path>      Import a tree-sitter grammar.js file
+//	-json <path>    Import a resolved tree-sitter grammar.json file
+//	-grammar <path> Parse a portable .grammar file
 //
 // Output formats:
 //
-//	-bin <path>    Write gotreesitter .bin blob
-//	-c <path>      Write tree-sitter parser.c
-//	-go <path>     Write grammargen Go DSL source
+//	-bin <path>      Write gotreesitter .bin blob
+//	-c <path>        Write tree-sitter parser.c
+//	-go <path>       Write grammargen Go DSL source
+//	-json-out <path> Write resolved grammar.json (emit subcommand)
+//
+// Authoring helpers:
+//
+//	parse      Parse a sample and print text, S-expression, or JSON output
+//	doctor     Validate, generate, test, parse samples, and report next steps
 //
 // Other flags:
 //

--- a/grammargen/README.md
+++ b/grammargen/README.md
@@ -1,0 +1,260 @@
+# grammargen
+
+`grammargen` is the pure-Go grammar compiler used by gotreesitter. It turns a
+grammar definition into a `*gotreesitter.Language`, a serialized `.bin` blob, a
+tree-sitter-compatible `parser.c`, or generated Go DSL source.
+
+The authoring surface is intentionally input-neutral:
+
+- Go DSL grammars built with `NewGrammar`, `Define`, `Seq`, `Choice`, `Token`,
+  `Field`, `PrecLeft`, and related constructors.
+- Resolved upstream `grammar.json` files, which are the preferred import format
+  for tree-sitter grammars.
+- `.grammar` files, a compact ecosystem-agnostic grammar format that parses
+  into the same IR and can emit Go DSL.
+
+`grammar.js` import also exists, but `grammar.json` is usually more reliable
+because helper functions, `require()` calls, and JavaScript evaluation have
+already been resolved by tree-sitter.
+
+## Authoring Commands
+
+Use `doctor` when changing a grammar. It validates, generates parser tables,
+runs embedded tests when present, optionally parses a sample, and suggests the
+next command.
+
+```sh
+go run ./cmd/grammargen doctor calc -text '1+2*3'
+go run ./cmd/grammargen doctor -json /tmp/grammar_parity/go/src/grammar.json -sample sample.go
+go run ./cmd/grammargen doctor -grammar ./mini.grammar -text '123'
+```
+
+Use `parse` when you want quick sample-to-tree feedback:
+
+```sh
+go run ./cmd/grammargen parse calc -text '1+2*3'
+go run ./cmd/grammargen parse -grammar ./mini.grammar -stdin
+```
+
+Use `emit` to write artifacts from any supported input:
+
+```sh
+# gotreesitter blob
+go run ./cmd/grammargen emit go -bin grammars/grammar_blobs/go.bin
+
+# Go DSL source from a resolved grammar.json
+go run ./cmd/grammargen emit \
+  -json /tmp/grammar_parity/go/src/grammar.json \
+  -go grammargen/go_grammar.go \
+  -pkg grammargen \
+  -func GoGrammar
+
+# Go DSL source from a .grammar file
+go run ./cmd/grammargen emit -grammar ./mini.grammar -go ./mini_grammar.go -pkg grammargen
+
+# tree-sitter parser.c
+go run ./cmd/grammargen emit calc -c /tmp/parser.c
+
+# inferred highlight query
+go run ./cmd/grammargen emit calc -highlight
+```
+
+The legacy flag surface still works:
+
+```sh
+go run ./cmd/grammargen -validate calc
+go run ./cmd/grammargen -report calc
+go run ./cmd/grammargen -grammar ./mini.grammar -go ./mini_grammar.go
+```
+
+For grammars that benefit from local LR(1) state splitting, pass `-lr-split`:
+
+```sh
+go run ./cmd/grammargen doctor go -lr-split -sample sample.go
+go run ./cmd/grammargen emit go -lr-split -bin grammars/grammar_blobs/go.bin
+```
+
+## Go DSL
+
+The first defined rule is the start rule. Names beginning with `_` are hidden
+rules. String rules create literal tokens, pattern rules create regex terminals,
+and `Token` groups a rule into one lexer token.
+
+```go
+func MiniExprGrammar() *Grammar {
+	g := NewGrammar("mini_expr")
+
+	g.Define("program", Sym("expression"))
+	g.Define("expression", Choice(
+		PrecLeft(1, Seq(
+			Field("left", Sym("expression")),
+			Field("operator", Str("+")),
+			Field("right", Sym("expression")),
+		)),
+		PrecLeft(2, Seq(
+			Field("left", Sym("expression")),
+			Field("operator", Str("*")),
+			Field("right", Sym("expression")),
+		)),
+		Sym("number"),
+		Seq(Str("("), Sym("expression"), Str(")")),
+	))
+	g.Define("number", Token(Repeat1(Pat(`[0-9]`))))
+	g.SetExtras(Pat(`\s`))
+
+	g.Test("precedence", "1 + 2 * 3", "")
+
+	return g
+}
+```
+
+An embedded test with an empty expected S-expression only checks that parsing
+finishes without `ERROR` nodes. Fill in the expected S-expression when a rule's
+exact tree shape should be locked down.
+
+Common grammar-level settings:
+
+- `SetExtras(...)`: whitespace, comments, or other extra tokens.
+- `SetConflicts(...)`: declared ambiguity groups that should keep GLR
+  alternatives.
+- `SetExternals(...)`: external scanner tokens.
+- `SetInline(...)`: rules to inline during normalization.
+- `SetWord(...)`: word token used for keyword extraction.
+- `SetSupertypes(...)`: structural supertypes exposed in metadata.
+- `Precedences`: ordered named and symbol precedence levels imported from
+  `grammar.json`.
+
+Useful DSL helpers live in `grammar.go`: `CommaSep`, `CommaSep1`, `SepBy`,
+`SepBy1`, `Parens`, `Brackets`, `Braces`, `AppendChoice`, and `ExtendGrammar`.
+
+## `.grammar` Files
+
+`.grammar` is the ecosystem-agnostic text format. It is currently line-oriented,
+so keep each rule definition on one line.
+
+```text
+grammar mini
+
+extras = [ /\s/ ]
+
+rule program = number
+rule number = token(repeat1(/[0-9]/))
+```
+
+Run it through the same command surface:
+
+```sh
+go run ./cmd/grammargen doctor -grammar ./mini.grammar -text '123'
+go run ./cmd/grammargen parse -grammar ./mini.grammar -text '123'
+go run ./cmd/grammargen emit -grammar ./mini.grammar -go ./mini_grammar.go -pkg grammargen
+go run ./cmd/grammargen emit -grammar ./mini.grammar -bin /tmp/mini.bin
+```
+
+Supported top-level lines:
+
+```text
+grammar <name>
+extras = [ <rule-expr>, ... ]
+word = <rule_name>
+supertypes = [ <rule_name>, ... ]
+conflicts = [ [<rule>, <rule>], ... ]
+rule <name> = <rule-expr>
+```
+
+Supported expressions:
+
+```text
+"literal"
+/regex/
+identifier
+
+seq(a, b, ...)
+choice(a, b, ...)
+repeat(a)
+repeat1(a)
+optional(a)
+token(a)
+field("name", a)
+prec(1, a)
+prec.left(1, a)
+prec.right(1, a)
+prec.dynamic(1, a)
+alias(a, name)
+alias(a, "anonymous_name")
+```
+
+For large upstream grammars, resolved `grammar.json` remains the most complete
+input. `.grammar` is the portable authoring format and should stay independent
+of any host language syntax.
+
+## Validation Loop
+
+For small package-local checks, keep tests focused:
+
+```sh
+go test ./cmd/grammargen ./grammargen \
+  -run '^TestJSONGenerate$|^TestGenerateWithReportCtxSkipsDiagnosticsWhenNotRequested$' \
+  -count=1
+```
+
+When changing GLR, incremental, import, or parity-sensitive behavior, use the
+Docker parity runners and keep runs to one grammar at a time:
+
+```sh
+# Focused package test inside Docker
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  -- "cd /workspace && go test ./grammargen -run '^TestName$' -count=1"
+
+# Real-corpus parity for one grammar
+bash cgo_harness/docker/run_single_grammar_parity.sh typescript
+
+# Focused grammargen real-corpus lane
+bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs typescript
+
+# Focused grammargen-vs-C lane
+bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs typescript
+```
+
+Do not run repo-wide `go test ./...` or broad race sweeps on the host for
+grammargen work. Heavy correctness, parity, and race coverage belongs in Docker
+or CI, scoped to one language or one regression at a time.
+
+## Reading the Package
+
+- `grammar.go`: public IR and Go DSL constructors.
+- `parse_grammar_file.go`: `.grammar` parser.
+- `import_grammarjson.go`: resolved tree-sitter `grammar.json` import.
+- `import_grammarjs.go`: best-effort `grammar.js` import.
+- `normalize.go`: rule lowering, metadata, fields, terminals, and production
+  construction.
+- `lr.go`: LR/LALR table construction and conflict resolution.
+- `lr_split.go`, `lr_split_oracle.go`: local LR(1) split support.
+- `dfa.go`, `nfa.go`, `regex.go`: lexer construction.
+- `encode.go`, `assemble.go`: `Language` assembly and blob encoding.
+- `diagnostics.go`: validation, embedded tests, and generation reports.
+- `emit_grammar_go.go`, `export_grammarjson.go`, `codegen_c.go`: artifact
+  emitters.
+- `parity_test.go`, `parity_real_corpus_test.go`: generated-vs-reference
+  parity infrastructure.
+
+## Troubleshooting
+
+Start with `doctor`. It reports validation warnings, generation failures, table
+sizes, conflict count, embedded test status, and sample parse status.
+
+Use `parse` when a grammar generates but the tree shape looks wrong. It prints
+the root type, byte range, error flag, stop reason, and named-node
+S-expression.
+
+For upstream imports, prefer `src/grammar.json` from a generated tree-sitter
+repository. If import fails on `grammar.js`, regenerate or locate the resolved
+JSON first.
+
+External-scanner grammars need a compatible Go scanner binding in `grammars/`.
+The generated grammar can expose external tokens, but scanner behavior is still
+hand-written runtime code.
+
+When corpus parity fails, narrow before changing generator behavior: one
+language, one focused test, one sample if possible. Use `GTS_GRAMMARGEN_REAL_CORPUS_ONLY`,
+`GTS_GRAMMARGEN_REAL_CORPUS_MAX_CASES`, and the focused Docker runners to keep
+the workload reproducible and attributable.

--- a/grammargen/README.md
+++ b/grammargen/README.md
@@ -27,6 +27,8 @@ next command.
 go run ./cmd/grammargen doctor calc -text '1+2*3'
 go run ./cmd/grammargen doctor -json /tmp/grammar_parity/go/src/grammar.json -sample sample.go
 go run ./cmd/grammargen doctor -grammar ./mini.grammar -text '123'
+go run ./cmd/grammargen doctor calc -text '1+2*3' -conflicts 3
+go run ./cmd/grammargen doctor calc -text '1+2*3' -format json
 ```
 
 Use `parse` when you want quick sample-to-tree feedback:
@@ -34,6 +36,8 @@ Use `parse` when you want quick sample-to-tree feedback:
 ```sh
 go run ./cmd/grammargen parse calc -text '1+2*3'
 go run ./cmd/grammargen parse -grammar ./mini.grammar -stdin
+go run ./cmd/grammargen parse calc -text '1+2*3' -format sexpr
+go run ./cmd/grammargen parse calc -text '1+2*3' -format json
 ```
 
 Use `emit` to write artifacts from any supported input:
@@ -52,12 +56,27 @@ go run ./cmd/grammargen emit \
 # Go DSL source from a .grammar file
 go run ./cmd/grammargen emit -grammar ./mini.grammar -go ./mini_grammar.go -pkg grammargen
 
+# Resolved grammar.json from any supported input
+go run ./cmd/grammargen emit -grammar ./mini.grammar -json-out ./mini.grammar.json
+
 # tree-sitter parser.c
 go run ./cmd/grammargen emit calc -c /tmp/parser.c
 
 # inferred highlight query
 go run ./cmd/grammargen emit calc -highlight
 ```
+
+For golden parse snapshots, write the current tree once, then compare future
+runs against it:
+
+```sh
+go run ./cmd/grammargen parse calc -text '1+2*3' -write-expect ./calc.sexpr
+go run ./cmd/grammargen parse calc -text '1+2*3' -expect ./calc.sexpr
+```
+
+`parse -strict` exits non-zero when parsing finishes with `ERROR` nodes or an
+early stop condition. `doctor` treats sample parse errors as gate failures by
+default.
 
 The legacy flag surface still works:
 
@@ -147,6 +166,7 @@ Run it through the same command surface:
 go run ./cmd/grammargen doctor -grammar ./mini.grammar -text '123'
 go run ./cmd/grammargen parse -grammar ./mini.grammar -text '123'
 go run ./cmd/grammargen emit -grammar ./mini.grammar -go ./mini_grammar.go -pkg grammargen
+go run ./cmd/grammargen emit -grammar ./mini.grammar -json-out ./mini.grammar.json
 go run ./cmd/grammargen emit -grammar ./mini.grammar -bin /tmp/mini.bin
 ```
 
@@ -240,11 +260,14 @@ or CI, scoped to one language or one regression at a time.
 ## Troubleshooting
 
 Start with `doctor`. It reports validation warnings, generation failures, table
-sizes, conflict count, embedded test status, and sample parse status.
+sizes, conflict count, embedded test status, and sample parse status. Add
+`-conflicts N` when precedence or GLR behavior needs inspection, or
+`-format json` when another tool should consume the report.
 
 Use `parse` when a grammar generates but the tree shape looks wrong. It prints
 the root type, byte range, error flag, stop reason, and named-node
-S-expression.
+S-expression. Use `-format sexpr` or `-expect`/`-write-expect` for golden tree
+snapshots.
 
 For upstream imports, prefer `src/grammar.json` from a generated tree-sitter
 repository. If import fails on `grammar.js`, regenerate or locate the resolved


### PR DESCRIPTION
## Summary

- Add `grammargen emit`, `grammargen parse`, and `grammargen doctor` as an input-neutral authoring surface.
- Support built-in grammars, resolved `grammar.json`, best-effort `grammar.js`, and `.grammar` files through the same subcommand loader.
- Add parser authoring outputs for humans and tools: text, S-expression, and structured JSON.
- Add golden S-expression write/compare flows and strict parse failure handling for reproducible sample checks.
- Add `emit -json-out` so `.grammar`, Go DSL, imported JSON, and built-ins can round-trip to resolved `grammar.json`.
- Add richer doctor reporting, including limited conflict diagnostics, embedded test status, sample parse status, and next-step hints.
- Add package documentation for authoring workflows, `.grammar` usage, Go DSL emission, troubleshooting, and focused validation.

## Validation

- `go test ./cmd/grammargen ./grammargen -run '^TestNormalizeSubcommandArgs|^TestJSONGenerate$|^TestGenerateWithReportCtxSkipsDiagnosticsWhenNotRequested$' -count=1`
- `canopy analyze check ./cmd/grammargen`
- `go run ./cmd/grammargen parse calc -text '1+2*3' -format json`
- `go run ./cmd/grammargen parse calc -text '1+2*3' -format sexpr`
- `go run ./cmd/grammargen parse calc -text '1+2*3' -write-expect <temp.sexpr>`
- `go run ./cmd/grammargen parse calc -text '1+2*3' -expect <temp.sexpr>`
- `go run ./cmd/grammargen doctor calc -text '1+2*3' -conflicts 1`
- `go run ./cmd/grammargen doctor calc -text '1+2*3' -format json -conflicts 1`
- `go run ./cmd/grammargen emit -grammar <temp.grammar> -json-out <temp.json>`

## Notes

Draft PR while we keep iterating on the grammar-authoring surface. `.grammar` remains positioned as the third authoring option behind Go DSL and resolved `grammar.json`, with this PR making the shared command surface nicer first.