### PR TITLE
Merge v0.19.1 release back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+- Nothing yet.
+
+## [0.19.0] - 2026-05-23
+
+GLR materialization, query parity, and parser hot-path release.
+
+### Added
+- Reduce-chain hint metadata is now attached to embedded grammars and used by
+  the parser to classify hot reduction chains without re-deriving them at run
+  time. Rust carries a targeted reduce-chain hint in this release.
+- Parser and harness attribution now expose reduce-chain timing, action
+  dispatch/apply/lookup timing, GLR merge and cull timing, result-tree
+  materialization timing, lazy-child materialization cost, and GLR equivalence
+  hot-spot counters.
+- Real-corpus benchmark and parse-gap reporting tools now surface top parse
+  gaps, parser phase timing, result attribution, symbol names, active
+  reduce-chain hints, and compiled-test-binary RSS lanes for CI.
+
+### Changed
+- Final tree construction now keeps compact/lazy final child references deeper
+  into parser result assembly, tree traversal, cursor movement, query matching,
+  descendant lookup, sibling scans, and edit paths. Public nodes are
+  materialized on demand instead of eagerly for every reduction result.
+- Parser hot paths cache action classes, lex-mode rows, visible symbol lookups,
+  JS/TS normalization traits, reduce-chain signatures, and language metadata
+  needed for full parses.
+- Full-parse scratch allocation is capped and tuned for medium sources so large
+  files do not preallocate excessive entry storage.
+- JavaScript, TypeScript, TSX, Python, Rust, Go, C, and Java compatibility
+  normalization now routes more work through dense/lazy child accessors and
+  source-gated fast paths.
+- The default reduce-chain hint path is enabled while the explicit reduce-chain
+  experiment knob was removed.
+
+### Fixed
+- Query matching now preserves tree-sitter-compatible behavior for nested
+  repeated children, namedness-sensitive candidates, field matching through
+  parent links, and lazy final child refs. This fixes downstream public queries
+  such as nested Kotlin `source_file -> import_list -> import_header` patterns
+  without requiring query rewrites.
+- `#lua-match?` predicate parity and query predicate stack storage now match
+  expected tree-sitter semantics more closely.
+- GLR materialization preserves pending direct fields, hidden-child field
+  metadata, compact leaf parents, lazy final child refs through edits, and
+  sidecar child counts across tree operations.
+- Incremental reuse handles lazy child refs, no-op edits, top-level reuse, and
+  external-scanner checkpoint rebuilds without forcing broad materialization.
+- Parser compatibility repairs restore or preserve tree shapes for Go,
+  JavaScript/TypeScript optional chains, Python collapsed keyword leaves, Rust
+  recovery/doc comments/repetition conflicts, C parity recovery, Java unary
+  wrappers and annotation parses, and TypeScript repetition conflicts.
+- Large GLR merge caps, terminal-node stack equivalence, zero-width sidecar
+  traversal, and C merge survivor caps now fail boundedly instead of corrupting
+  branch selection or retaining excessive alternatives.
+
+### Removed
 - Removed legacy generated grammar register stubs that were hidden behind the
   obsolete `legacy_generated_register_stubs` build tag; the generated registry
   is now the single checked-in grammar registration surface.
@@ -21,6 +77,26 @@ for tags and release notes while still in `0.x`.
   dependencies from the root module.
 - Collapsed stale internal aliases/helpers around token-source reparsing,
   snippet parsing, COBOL dispatch, and perf counter structs.
+
+### Performance
+- Standard Go/editor benchmark median on the release cut:
+  full DFA parse `~1.54 ms`, incremental single-byte edit `~649 ns`, no-edit
+  incremental reparse `~2.43 ns`. Full parse now reports `728 B/op` and
+  `7 allocs/op` on this workload.
+- Lazy final-child refs and deferred parent-link materialization reduce full
+  parse result-tree construction work while preserving query, cursor, edit, and
+  traversal behavior.
+- GLR stack equivalence checks short-circuit earlier, cache more relevant
+  frontier state, and expose true-share metrics for remaining ambiguity hot
+  spots.
+
+### Testing
+- Focused release benchmark command:
+  `GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms`.
+- Query parity was checked against the original nested Kotlin queries used by
+  downstream Aspect/Gazelle Orion plugins.
+- CI and harness work now prefer compiled test binaries for RSS benchmarks and
+  keep heavy parity/perf runs language-scoped.
 
 ## [0.18.0] - 2026-05-19
 
@@ -654,7 +730,10 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.17.3...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/odvcencio/gotreesitter/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/odvcencio/gotreesitter/compare/v0.17.4...v0.18.0
+[0.17.4]: https://github.com/odvcencio/gotreesitter/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/odvcencio/gotreesitter/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/odvcencio/gotreesitter/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/odvcencio/gotreesitter/compare/v0.17.0...v0.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ Kotlin source-file query compatibility patch.
   nodes are now returned as `source_file` roots instead of `ERROR` roots, while
   preserving child error state for diagnostics.
 - Fragmented top-level Kotlin `fun` declarations recovered under an error root
-  now expose enough `function_declaration` shape for existing
-  `source_file -> function_declaration -> simple_identifier` queries to keep
-  matching. This preserves downstream Aspect/Gazelle Orion queries without AXL
-  rewrites on files with recoverable syntax errors.
+  now expose `function_declaration` shape with the `fun` keyword, name, and
+  parameter list, while retaining error state. This preserves downstream
+  Aspect/Gazelle Orion queries without AXL rewrites on files with recoverable
+  syntax errors.
 
 ## [0.19.0] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ for tags and release notes while still in `0.x`.
 
 - Nothing yet.
 
+## [0.19.1] - 2026-05-23
+
+Kotlin source-file query compatibility patch.
+
+### Fixed
+- Kotlin recovered parse roots that contain top-level package/import/class
+  nodes are now returned as `source_file` roots instead of `ERROR` roots, while
+  preserving child error state for diagnostics.
+- Fragmented top-level Kotlin `fun` declarations recovered under an error root
+  now expose enough `function_declaration` shape for existing
+  `source_file -> function_declaration -> simple_identifier` queries to keep
+  matching. This preserves downstream Aspect/Gazelle Orion queries without AXL
+  rewrites on files with recoverable syntax errors.
+
 ## [0.19.0] - 2026-05-23
 
 GLR materialization, query parity, and parser hot-path release.
@@ -730,7 +744,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.19.1...HEAD
+[0.19.1]: https://github.com/odvcencio/gotreesitter/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/odvcencio/gotreesitter/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/odvcencio/gotreesitter/compare/v0.17.4...v0.18.0
 [0.17.4]: https://github.com/odvcencio/gotreesitter/compare/v0.17.3...v0.17.4

--- a/README.md
+++ b/README.md
@@ -272,13 +272,13 @@ cpu: Intel(R) Core(TM) Ultra 9 285
 |---|---:|---:|---:|
 | Native C (pure C runtime) | 1.76 ms | 102.3 μs | 101.7 μs |
 | CGo binding (C runtime via cgo) | ~2.0 ms | ~130 μs | — |
-| gotreesitter (pure Go) | 1.98 ms | 666 ns | 2.84 ns |
+| gotreesitter (pure Go) | 1.54 ms | 649 ns | 2.43 ns |
 
 On this workload:
 
-- Full parse is roughly at CGo binding speed and ~1.1x slower than native C.
-- Incremental single-byte edits are ~154x faster than native C (~195x faster than CGo).
-- No-edit reparses are ~35,900x faster than native C, zero allocations.
+- Full parse is faster than both listed C baselines: ~1.15x faster than native C and ~1.29x faster than the CGo binding.
+- Incremental single-byte edits are ~158x faster than native C (~200x faster than CGo).
+- No-edit reparses are ~41,800x faster than native C, zero allocations.
 
 <details>
 <summary>Raw benchmark output</summary>
@@ -306,9 +306,9 @@ GOMAXPROCS=1 go test . -run '^$' -tags treesitter_c_bench \
 | Native C incremental (no edit) | 101,740 | — | — |
 | `CTreeSitterGoParseFull` | ~1,990,000 | 600 | 6 |
 | `CTreeSitterGoParseIncrementalSingleByteEdit` | ~130,000 | 648 | 7 |
-| `GoParseFullDFA` | 1,975,154 | 4,281 | 5 |
-| `GoParseIncrementalSingleByteEditDFA` | 666.5 | 176 | 3 |
-| `GoParseIncrementalNoEditDFA` | 2.837 | 0 | 0 |
+| `GoParseFullDFA` | 1,538,089 | 728 | 7 |
+| `GoParseIncrementalSingleByteEditDFA` | 648.9 | 176 | 3 |
+| `GoParseIncrementalNoEditDFA` | 2.432 | 0 | 0 |
 
 </details>
 
@@ -364,7 +364,7 @@ Each `LangEntry` carries a `Quality` field:
 | `#any-of?` / `#not-any-of?` | supported |
 | `#lua-match?` | supported |
 | `#has-ancestor?` / `#not-has-ancestor?` | supported |
-| `#not-has-parent?` | supported |
+| `#has-parent?` / `#not-has-parent?` | supported |
 | `#is?` / `#is-not?` | supported |
 | `#any-eq?` / `#any-not-eq?` | supported |
 | `#any-match?` / `#any-not-match?` | supported |
@@ -377,7 +377,7 @@ All shipped highlight and tags queries compile (`156/156` highlight, `69/69` tag
 
 ## Known limitations
 
-- **Full-parse throughput**: ~2.4x slower than the C runtime on cold full parses (the 500-function Go benchmark). Incremental reparsing — the dominant operation in editor workloads — is 69x faster.
+- **Full-parse throughput**: the 500-function Go benchmark is now faster than the listed C baselines, but full-parse throughput still varies by grammar and corpus shape. Highly ambiguous languages and very large generated files remain the main parity/performance frontier.
 - **GLR safety caps**: The parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity but impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
 
 ## Adding a language
@@ -551,6 +551,24 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
+v0.19.x — GLR materialization, query parity, and parser hot-path release.
+Compact/lazy final child refs now survive parser result assembly and public tree
+operations, so queries, cursors, edits, descendant lookup, and traversal can
+avoid broad eager materialization. Nested repeated query patterns now preserve
+tree-sitter-compatible match rows, including downstream Kotlin Orion queries
+such as `source_file -> import_list -> import_header`. The release also adds
+reduce-chain hints, GLR/action/result timing attribution, parse-gap reporting,
+and full-parse scratch tuning while restoring compatibility shapes for Go,
+JavaScript/TypeScript, Python, Rust, C, and Java edge cases.
+
+v0.18.x — Cold dependency extraction and parser materialization diagnostics
+release. Adds language-neutral import extraction APIs, source-vs-tree import
+parity fixtures, `cgo_harness/cmd/import_replay`, Python materialization
+benchmarks, and parser runtime attribution for arena usage, checkpoint storage,
+reduction/transient storage, final tree materialization, normalization timing,
+and GLR collapse behavior. Hybrid source extraction now gives downstream
+dependency scanners a fast path with structured fallback reporting.
+
 v0.17.x — Java corpus parity and parser-performance release. Java now has
 bounded Docker corpus lanes for Apache Lucene, including largest-file, random,
 timeout-sweep, cgo comparison, no-tree diagnostic, UAX generated-file,
@@ -578,8 +596,6 @@ v0.14.x — Go grammar now shipped as a grammargen-compiled blob (our own pure-G
 v0.12.x — 206 grammars (all OK), 116 external scanners, pure-Go runtime plus `grammargen`, ABI 15 support including reserved-word sets, GLR parser, incremental reparsing with external scanner checkpoints, query engine, tree cursor, highlighting, tagging, injection parser, typed query codegen, CST rewriter, parser pool, arena memory budgets, and structural parity against 100+ curated C reference grammars.
 
 Next:
-- Compact/lazy internal tree materialization so Java full parses keep more of
-  the no-tree diagnostic win without moving excessive cost into query/traversal
 - Retire parser-result struts by moving C#, Rust, Scala, TypeScript, and Python recovery into runtime or grammar generation paths
 - Grammar refresh automation that moves from lock-only PRs to regenerated artifacts and focused parity for allow-listed `grammargen`-backed languages
 - Table-size and codegen compaction work for Unicode-heavy grammars

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -1,7 +1,99 @@
 package gotreesitter
 
+import "strings"
+
 func normalizeKotlinCompatibility(root *Node, source []byte, lang *Language) {
+	normalizeKotlinRecoveredSourceFileRoot(root, source, lang)
 	normalizeKotlinBindingPatternKindTokens(root, source, lang)
+}
+
+func normalizeKotlinRecoveredSourceFileRoot(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "kotlin" || root.Type(lang) != "ERROR" {
+		return
+	}
+	if !kotlinRootLooksRecoverableSourceFile(root, lang) {
+		return
+	}
+	normalizeKotlinTopLevelFunctionFragments(root, source, lang)
+	sym, ok := symbolByName(lang, "source_file")
+	if !ok {
+		return
+	}
+	retagResultRootAndRefreshError(root, sym, symbolIsNamed(lang, sym))
+}
+
+func kotlinRootLooksRecoverableSourceFile(root *Node, lang *Language) bool {
+	if root == nil || lang == nil || resultChildCount(root) == 0 {
+		return false
+	}
+	for i := 0; i < resultChildCount(root); i++ {
+		child := resultChildAt(root, i)
+		if child == nil {
+			continue
+		}
+		switch child.Type(lang) {
+		case "package_header",
+			"import_list",
+			"class_declaration",
+			"function_declaration",
+			"object_declaration",
+			"property_declaration",
+			"typealias_declaration",
+			"multiline_comment",
+			"line_comment":
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *Language) {
+	fnSym, ok := symbolByName(lang, "function_declaration")
+	if !ok {
+		return
+	}
+	children := resultChildSliceForMutation(root)
+	if len(children) < 3 {
+		return
+	}
+	var rebuilt []*Node
+	changed := false
+	for i := 0; i < len(children); i++ {
+		if fn, ok := kotlinRecoveredTopLevelFunction(children, i, source, lang, fnSym); ok {
+			rebuilt = append(rebuilt, fn)
+			i += 2
+			changed = true
+			continue
+		}
+		rebuilt = append(rebuilt, children[i])
+	}
+	if !changed {
+		return
+	}
+	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rebuilt))
+}
+
+func kotlinRecoveredTopLevelFunction(children []*Node, idx int, source []byte, lang *Language, fnSym Symbol) (*Node, bool) {
+	if idx+2 >= len(children) {
+		return nil, false
+	}
+	funKeyword := children[idx]
+	name := children[idx+1]
+	params := children[idx+2]
+	if funKeyword == nil || name == nil || params == nil {
+		return nil, false
+	}
+	if funKeyword.Type(lang) != "ERROR" || strings.TrimSpace(funKeyword.Text(source)) != "fun" {
+		return nil, false
+	}
+	if name.Type(lang) != "simple_identifier" || params.Type(lang) != "function_value_parameters" {
+		return nil, false
+	}
+	fnChildren := cloneNodeSliceInArena(funKeyword.ownerArena, []*Node{name, params})
+	fn := newParentNodeInArena(funKeyword.ownerArena, fnSym, symbolIsNamed(lang, fnSym), fnChildren, nil, 0)
+	fn.startByte = funKeyword.startByte
+	fn.startPoint = funKeyword.startPoint
+	return fn, true
 }
 
 func normalizeKotlinBindingPatternKindTokens(root *Node, source []byte, lang *Language) {

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -52,6 +52,10 @@ func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *L
 	if !ok {
 		return
 	}
+	funSym, ok := symbolByName(lang, "fun")
+	if !ok {
+		return
+	}
 	children := resultChildSliceForMutation(root)
 	if len(children) < 3 {
 		return
@@ -59,7 +63,7 @@ func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *L
 	var rebuilt []*Node
 	changed := false
 	for i := 0; i < len(children); i++ {
-		if fn, ok := kotlinRecoveredTopLevelFunction(children, i, source, lang, fnSym); ok {
+		if fn, ok := kotlinRecoveredTopLevelFunction(children, i, source, lang, fnSym, funSym); ok {
 			rebuilt = append(rebuilt, fn)
 			i += 2
 			changed = true
@@ -73,7 +77,7 @@ func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *L
 	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rebuilt))
 }
 
-func kotlinRecoveredTopLevelFunction(children []*Node, idx int, source []byte, lang *Language, fnSym Symbol) (*Node, bool) {
+func kotlinRecoveredTopLevelFunction(children []*Node, idx int, source []byte, lang *Language, fnSym, funSym Symbol) (*Node, bool) {
 	if idx+2 >= len(children) {
 		return nil, false
 	}
@@ -89,10 +93,11 @@ func kotlinRecoveredTopLevelFunction(children []*Node, idx int, source []byte, l
 	if name.Type(lang) != "simple_identifier" || params.Type(lang) != "function_value_parameters" {
 		return nil, false
 	}
-	fnChildren := cloneNodeSliceInArena(funKeyword.ownerArena, []*Node{name, params})
+	retagResultRoot(funKeyword, funSym, symbolIsNamed(lang, funSym))
+	funKeyword.setHasError(false)
+	fnChildren := cloneNodeSliceInArena(funKeyword.ownerArena, []*Node{funKeyword, name, params})
 	fn := newParentNodeInArena(funKeyword.ownerArena, fnSym, symbolIsNamed(lang, fnSym), fnChildren, nil, 0)
-	fn.startByte = funKeyword.startByte
-	fn.startPoint = funKeyword.startPoint
+	fn.setHasError(true)
 	return fn, true
 }
 

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -60,10 +60,14 @@ func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *L
 	if len(children) < 3 {
 		return
 	}
-	var rebuilt []*Node
+	arena := root.ownerArena
+	if arena == nil {
+		return
+	}
+	rebuilt := make([]*Node, 0, len(children))
 	changed := false
 	for i := 0; i < len(children); i++ {
-		if fn, ok := kotlinRecoveredTopLevelFunction(children, i, source, lang, fnSym, funSym); ok {
+		if fn, ok := kotlinRecoveredTopLevelFunction(arena, children, i, source, lang, fnSym, funSym); ok {
 			rebuilt = append(rebuilt, fn)
 			i += 2
 			changed = true
@@ -74,10 +78,10 @@ func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *L
 	if !changed {
 		return
 	}
-	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rebuilt))
+	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(arena, rebuilt))
 }
 
-func kotlinRecoveredTopLevelFunction(children []*Node, idx int, source []byte, lang *Language, fnSym, funSym Symbol) (*Node, bool) {
+func kotlinRecoveredTopLevelFunction(arena *nodeArena, children []*Node, idx int, source []byte, lang *Language, fnSym, funSym Symbol) (*Node, bool) {
 	if idx+2 >= len(children) {
 		return nil, false
 	}

--- a/query_kotlin_regression_test.go
+++ b/query_kotlin_regression_test.go
@@ -1,0 +1,64 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestKotlinNestedImportQueryMatchesRepeatedHeaders(t *testing.T) {
+	src := []byte("package com.example\n\nimport foo.bar.Baz\nimport foo.qux.*\nfun main() {}\n")
+	lang := grammars.KotlinLanguage()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	defer tree.Release()
+	if tree.RootNode().HasError() {
+		t.Fatalf("root has error:\n%s", tree.RootNode().SExpr(lang))
+	}
+
+	q, err := gotreesitter.NewQuery(`
+		(source_file
+			(import_list
+				(import_header (identifier) @imp (wildcard_import)? @is_star)
+			)
+		)
+	`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery failed: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), lang, src)
+	var got []string
+	var wildcard bool
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		for _, capture := range match.Captures {
+			switch capture.Name {
+			case "imp":
+				got = append(got, capture.Text(src))
+			case "is_star":
+				wildcard = true
+			}
+		}
+	}
+
+	want := []string{"foo.bar.Baz", "foo.qux"}
+	if len(got) != len(want) {
+		t.Fatalf("captures = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("captures = %v, want %v", got, want)
+		}
+	}
+	if !wildcard {
+		t.Fatal("expected wildcard_import capture")
+	}
+}

--- a/query_kotlin_regression_test.go
+++ b/query_kotlin_regression_test.go
@@ -62,3 +62,81 @@ func TestKotlinNestedImportQueryMatchesRepeatedHeaders(t *testing.T) {
 		t.Fatal("expected wildcard_import capture")
 	}
 }
+
+func TestKotlinRecoveredRootPreservesSourceFileQueries(t *testing.T) {
+	src := []byte(`package com.example.deepimport
+
+import com.google.common.base.pretend.deep.Thing
+import com.google.common.base.pretend.deep.Things as ThingsHelper
+
+class DeepCompare() {}
+
+fun main(vararg args: string) {
+    var app = new DeepCompare();
+    System.out.println("Success: " + app.compare(Thing(1), Thing(2)));
+}
+`)
+	lang := grammars.KotlinLanguage()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	defer tree.Release()
+
+	if got := tree.RootNode().Type(lang); got != "source_file" {
+		t.Fatalf("root type = %q, want source_file:\n%s", got, tree.RootNode().SExpr(lang))
+	}
+
+	q, err := gotreesitter.NewQuery(`
+		(source_file
+			(import_list
+				(import_header (identifier) @imp)
+			)
+		)
+
+		(source_file
+			(function_declaration
+				(simple_identifier) @fn
+				(#eq? @fn "main")
+			)
+		)
+	`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery failed: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), lang, src)
+	var imports []string
+	var hasMain bool
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		for _, capture := range match.Captures {
+			switch capture.Name {
+			case "imp":
+				imports = append(imports, capture.Text(src))
+			case "fn":
+				hasMain = true
+			}
+		}
+	}
+
+	wantImports := []string{
+		"com.google.common.base.pretend.deep.Thing",
+		"com.google.common.base.pretend.deep.Things",
+	}
+	if len(imports) != len(wantImports) {
+		t.Fatalf("imports = %v, want %v", imports, wantImports)
+	}
+	for i := range wantImports {
+		if imports[i] != wantImports[i] {
+			t.Fatalf("imports = %v, want %v", imports, wantImports)
+		}
+	}
+	if !hasMain {
+		t.Fatal("expected recovered main function to match source_file-rooted query")
+	}
+}

--- a/query_kotlin_regression_test.go
+++ b/query_kotlin_regression_test.go
@@ -97,6 +97,7 @@ fun main(vararg args: string) {
 
 		(source_file
 			(function_declaration
+				"fun" @fn_keyword
 				(simple_identifier) @fn
 				(#eq? @fn "main")
 			)
@@ -109,6 +110,7 @@ fun main(vararg args: string) {
 	cursor := q.Exec(tree.RootNode(), lang, src)
 	var imports []string
 	var hasMain bool
+	var hasFunKeyword bool
 	for {
 		match, ok := cursor.NextMatch()
 		if !ok {
@@ -120,6 +122,8 @@ fun main(vararg args: string) {
 				imports = append(imports, capture.Text(src))
 			case "fn":
 				hasMain = true
+			case "fn_keyword":
+				hasFunKeyword = capture.Text(src) == "fun"
 			}
 		}
 	}
@@ -138,5 +142,8 @@ fun main(vararg args: string) {
 	}
 	if !hasMain {
 		t.Fatal("expected recovered main function to match source_file-rooted query")
+	}
+	if !hasFunKeyword {
+		t.Fatal("expected recovered function declaration to expose fun keyword")
 	}
 }


### PR DESCRIPTION
The v0.19.1 tag (released 2026-05-23) was cut from `release/v0.19.1` but those commits never landed on `main`. This PR reconciles main with what is actually released.

Contents:
- 8507cb2  update: Document v0.19.0 and add query regression
- 01860f3  fix(kotlin): Preserve recovered Kotlin source_file roots
- 8f875c1  fix(kotlin): Preserve recovered Kotlin function query shape

After merge, `release/v0.19.1` branch + worktree can be deleted.