### PR TITLE
fix(ci): increase markdown_inline test timeout for stability

### DIFF
--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2507,7 +2507,12 @@ func init() {
 		{name: "less", blobFunc: grammars.LessLanguage, expectNoErrors: 1},
 		{name: "liquid", blobFunc: grammars.LiquidLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "luau", blobFunc: grammars.LuauLanguage, timeout: 60 * time.Second, expectNoErrors: 1},
-		{name: "markdown_inline", blobFunc: grammars.MarkdownInlineLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1,
+		// markdown_inline is a cost outlier: grammargen builds ~123k LR states and
+		// peaks ~3.2GB RSS for it. Generation is correct (1/1 parity) and takes
+		// ~20s in isolation on a fast host, but under full-suite CI memory pressure
+		// it can exceed a tight deadline. 300s matches the hlsl outlier budget and
+		// leaves CI margin. Do NOT lower back to 60s without re-measuring on CI.
+		{name: "markdown_inline", blobFunc: grammars.MarkdownInlineLanguage, timeout: 300 * time.Second, expectNoErrors: 1, expectParity: 1,
 			jsonPath: "/tmp/grammar_parity/markdown/tree-sitter-markdown-inline/src/grammar.json"},
 		{name: "matlab", blobFunc: grammars.MatlabLanguage, timeout: 60 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "mojo", blobFunc: grammars.MojoLanguage, timeout: 60 * time.Second, expectNoErrors: 1},


### PR DESCRIPTION
## Summary

Addresses intermittent CI timeouts for the `markdown_inline` parity test by increasing the deadline from 60s to 300s. This grammar is a known resource outlier (~123k LR states, ~3.2GB RSS peak) that struggles under CI memory pressure despite functioning correctly in ~20s locally.

## Changes

- Increased `markdown_inline` timeout in `grammargen/parity_test.go` from 60s to 300s
- Added explanatory comment detailing memory/CPU overhead and justifying the budget allocation

## Testing

- Run CI pipeline and verify `grammargen` parity tests pass without timeout
- Optionally run locally with `go test ./grammargen` to confirm ~20s execution time and baseline behavior

## Review Focus

Stability-only fix. No logic changes. Please verify the timeout justification aligns with CI behavior and that the new 300s budget doesn't mask underlying slowdowns on other grammars.