### PR TITLE
fix(parser): resolve Kotlin top-level object declaration misparse

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2512,6 +2512,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						if next, ok := javascriptRepetitionShiftConflictChoice(p.language, tok, currentState, actions); ok {
 							chosen, choice = next, true
 						}
+					case "kotlin":
+						if next, ok := kotlinObjectLiteralConflictChoice(p.language, actions); ok {
+							chosen, choice = next, true
+						}
 					}
 				}
 				if !choice && deterministicExternalConflicts && p.language != nil && p.language.Name == "yaml" && p.language.ExternalScanner != nil {
@@ -3499,6 +3503,59 @@ func typescriptRepetitionShiftConflictChoice(lang *Language, tok Token, state St
 		return ParseAction{}, false
 	}
 	return repetitionShiftConflictChoice(actions)
+}
+
+// kotlinObjectLiteralConflictChoice resolves issue #93: the bundled Kotlin
+// table admits a spurious bodiless `object_literal -> object` reduction
+// (ChildCount==1, no class_body) that canonical tree-sitter-kotlin does not
+// have. Completing it lets a top-level `object Foo { ... }` parse as
+// infix_expression(object_literal, simple_identifier, lambda_literal) — the
+// bare `object` becomes an anonymous-object expression, `Foo` an infix
+// operator, and the body a trailing lambda — instead of object_declaration.
+//
+// At a shift/reduce conflict that offers that bodiless object_literal reduce
+// alongside a shift, prefer the shift. Shifting keeps the parser on the
+// declaration path (`object Foo { ... }` -> object_declaration) or, in value
+// position, on the object_literal-plus-class_body path (`val x = object { }`
+// -> object_literal(class_body)). It never completes a bodiless object_literal,
+// so the infix misparse can't form. The anonymous-with-supertype and named
+// forms already parse correctly and are unaffected, because this only fires
+// when a ChildCount==1 object_literal reduce competes with a shift.
+func kotlinObjectLiteralConflictChoice(lang *Language, actions []ParseAction) (ParseAction, bool) {
+	if lang == nil {
+		return ParseAction{}, false
+	}
+	// Cheap pre-filter (no symbol lookup): need both a ChildCount==1 reduce and
+	// a shift in this conflict before it's worth resolving object_literal.
+	var shift ParseAction
+	haveShift := false
+	haveBodilessReduce := false
+	for _, a := range actions {
+		switch a.Type {
+		case ParseActionShift:
+			if !haveShift {
+				shift = a
+				haveShift = true
+			}
+		case ParseActionReduce:
+			if a.ChildCount == 1 {
+				haveBodilessReduce = true
+			}
+		}
+	}
+	if !haveShift || !haveBodilessReduce {
+		return ParseAction{}, false
+	}
+	olSym, ok := symbolByName(lang, "object_literal")
+	if !ok {
+		return ParseAction{}, false
+	}
+	for _, a := range actions {
+		if a.Type == ParseActionReduce && a.ChildCount == 1 && a.Symbol == olSym {
+			return shift, true
+		}
+	}
+	return ParseAction{}, false
 }
 
 // javascriptRepetitionShiftConflictChoice resolves the statement/member-list

--- a/query_kotlin_object_declaration_test.go
+++ b/query_kotlin_object_declaration_test.go
@@ -1,0 +1,82 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Regression coverage for issue #93: the bundled Kotlin grammar misparses a
+// top-level `object Foo { ... }` declaration as an infix_expression
+// (object_literal + simple_identifier + lambda_literal) instead of an
+// object_declaration, hiding the singleton from declaration walkers. The
+// grammar DOES define object_declaration — the parser was resolving the
+// object-at-declaration-position ambiguity toward the expression reading.
+//
+// The fix must NOT flip the *anonymous* object form (`object : Iface { }`),
+// which is genuinely an expression and must stay object_literal.
+
+func kotlinParseTree(t *testing.T, src string) (*gotreesitter.Tree, *gotreesitter.Language) {
+	t.Helper()
+	lang := grammars.KotlinLanguage()
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	return tree, lang
+}
+
+func kotlinHasNodeType(n *gotreesitter.Node, lang *gotreesitter.Language, typ string) bool {
+	if n == nil {
+		return false
+	}
+	if n.Type(lang) == typ {
+		return true
+	}
+	for i := 0; i < n.NamedChildCount(); i++ {
+		if kotlinHasNodeType(n.NamedChild(i), lang, typ) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestKotlinTopLevelObjectParsesAsDeclaration(t *testing.T) {
+	src := "package demo\n\nobject Singleton {\n    fun work() = Unit\n}\n"
+	tree, lang := kotlinParseTree(t, src)
+	defer tree.Release()
+	root := tree.RootNode()
+
+	if kotlinHasNodeType(root, lang, "infix_expression") {
+		t.Errorf("#93: named top-level object misparsed as infix_expression:\n%s", root.SExpr(lang))
+	}
+	if !kotlinHasNodeType(root, lang, "object_declaration") {
+		t.Errorf("#93: named top-level object did not produce object_declaration:\n%s", root.SExpr(lang))
+	}
+}
+
+func TestKotlinObjectWithSupertypeParsesAsDeclaration(t *testing.T) {
+	src := "package demo\n\nobject Singleton : Runnable {\n    override fun run() = Unit\n}\n"
+	tree, lang := kotlinParseTree(t, src)
+	defer tree.Release()
+	if !kotlinHasNodeType(tree.RootNode(), lang, "object_declaration") {
+		t.Errorf("#93: object-with-supertype did not produce object_declaration:\n%s", tree.RootNode().SExpr(lang))
+	}
+}
+
+func TestKotlinAnonymousObjectStaysExpression(t *testing.T) {
+	src := "package demo\n\nval listener = object : Runnable {\n    override fun run() = Unit\n}\n"
+	tree, lang := kotlinParseTree(t, src)
+	defer tree.Release()
+	root := tree.RootNode()
+
+	// The anonymous form is an expression value, not a declaration. It must NOT
+	// be promoted to object_declaration by the #93 fix.
+	if kotlinHasNodeType(root, lang, "object_declaration") {
+		t.Errorf("anonymous object must NOT become object_declaration:\n%s", root.SExpr(lang))
+	}
+	if !kotlinHasNodeType(root, lang, "object_literal") {
+		t.Errorf("anonymous object should parse as an object_literal expression:\n%s", root.SExpr(lang))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes issue #93 where the bundled Kotlin grammar misparses a top-level `object Foo { ... }` declaration as an `infix_expression` instead of `object_declaration`. The fix adds a targeted conflict resolution in the GLR parser to prefer shifting over a spurious bodiless `object_literal` reduction, preserving correct parsing for named objects, objects with supertypes, and anonymous object expressions.

## Changes

- Add `kotlinObjectLiteralConflictChoice` resolver in `parser.go` to prefer shifting over a spurious `object_literal` reduction at shift/reduce conflicts.
- Update GLR conflict dispatch to invoke the Kotlin resolver when processing `kotlin` grammar conflicts.
- Add `query_kotlin_object_declaration_test.go` with regression tests covering top-level named objects, objects with supertypes, and anonymous object expressions.

## Testing

- Run the new Kotlin regression tests: `go test -run 'TestKotlinTopLevelObjectParsesAsDeclaration|TestKotlinObjectWithSupertypeParsesAsDeclaration|TestKotlinAnonymousObjectStaysExpression' .`
- Verify parity with cgo/tree-sitter-kotlin for Kotlin files using top-level `object` declarations using the parity harness.

## Related Issues

- Addresses #93

---

**Root cause (issue #93):** our Kotlin table admitted a spurious bodiless `object_literal → object` production (ChildCount==1, no `class_body`) that canonical tree-sitter-kotlin lacks — proven by `val x = object` parsing to a bare `(object_literal)`. Completing it let `object Foo { … }` parse as `infix_expression(object_literal, simple_identifier, lambda_literal)`.

**Fix:** `kotlinObjectLiteralConflictChoice` (the #90 per-language conflict-resolver pattern, Kotlin-gated) prefers the shift over the bodiless `object_literal` reduce, keeping the parser on the `object_declaration` path (named) or `object_literal`+`class_body` path (anonymous). It never completes a bodiless literal, so the infix misparse can't form.

**Verification:**
- Regression tests (named→`object_declaration`, supertype→`object_declaration`, anonymous→stays `object_literal`) — all green; #86 Kotlin tests still green.
- **Ring-matrix (Docker, `GTS_PARITY_MODE=exhaustive`):** failure set **byte-identical to the pre-existing main baseline (zero new failures)**; `TestParityFreshParse/kotlin` + Incremental + HasNoErrors all PASS. Kotlin-gated → non-Kotlin languages provably unaffected.

Addresses #93 (left open for maintainer reply to the reporter).