### PR TITLE
fix(tree): fix race in deferred parent-link wiring

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -70,7 +70,7 @@ type nodeArena struct {
 	allocatedBytes      int64
 	parentLinkMu        sync.Mutex
 	deferredParentRoot  *Node
-	parentLinksDeferred bool
+	parentLinksDeferred atomic.Bool
 	finalChildRefs      bool
 	// skipChildClear allows reset() to skip child-slab pointer clearing when
 	// a parse did not borrow any external nodes (full parse without reuse).
@@ -513,7 +513,7 @@ func (a *nodeArena) resetPrimaryNodes() {
 func (a *nodeArena) resetParentLinks() {
 	a.parentLinkMu.Lock()
 	a.deferredParentRoot = nil
-	a.parentLinksDeferred = false
+	a.parentLinksDeferred.Store(false)
 	a.parentLinkMu.Unlock()
 }
 

--- a/parent_link_race_test.go
+++ b/parent_link_race_test.go
@@ -1,0 +1,74 @@
+package gotreesitter_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestParentLinkConcurrentAccessNoRace reproduces the HEAD-only data race in
+// lazy parent-link wiring: on a fresh full-parse tree, parent links are
+// deferred (parser.go deferParentLinks gate), and Node.Parent() wires them on
+// first access via wireDeferredParentPathToNode -> setNodeParentLink, which
+// writes child.parent OUTSIDE parentLinkMu. Two goroutines calling Parent() on
+// the same returned tree therefore race on n.parent (concurrent writes to
+// shared ancestors, plus unsynchronized reads).
+//
+// Run with the race detector — it must be clean:
+//
+//	go test . -race -run TestParentLinkConcurrentAccessNoRace
+//
+// Before the fix this fails under -race; after, it passes.
+func TestParentLinkConcurrentAccessNoRace(t *testing.T) {
+	// Python is one of the languages (java/python/typescript/tsx) that take the
+	// DEFERRED parent-link path by default (shouldDeferResultParentLinks); other
+	// languages wire eagerly and are race-free. Deeply nested so parent chains
+	// overlap (shared ancestors maximize the write/write + read/write window).
+	src := []byte(`def outer():
+    if a:
+        for i in xs:
+            with ctx:
+                try:
+                    return deep(value(here(inner(x))))
+                except Exception:
+                    while cond:
+                        nested(again(more(stuff)))
+`)
+	lang := grammars.PythonLanguage()
+	tree, err := gotreesitter.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	defer tree.Release()
+
+	// Each goroutine independently descends the SAME fresh tree and calls
+	// Parent() on every node — so the first deferred parent-link wiring happens
+	// CONCURRENTLY (no single-threaded pre-walk that would wire links first).
+	// This is the realistic "parse, then fan out goroutines over the tree"
+	// consumer pattern. Overlapping chains write shared ancestors' .parent.
+	const goroutines = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	var walk func(n *gotreesitter.Node)
+	walk = func(n *gotreesitter.Node) {
+		if n == nil {
+			return
+		}
+		_ = n.Parent()
+		for i := 0; i < n.NamedChildCount(); i++ {
+			walk(n.NamedChild(i))
+		}
+	}
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			walk(tree.RootNode())
+		}()
+	}
+	close(start)
+	wg.Wait()
+}

--- a/tree.go
+++ b/tree.go
@@ -248,6 +248,12 @@ func nodeMaterializedChildAtNoMaterialize(n *Node, i int) *Node {
 	return stackEntryNode(entry)
 }
 
+// wireParentPathToNodeNoMaterialize wires the parent links along the single path
+// from root to target (and leaves untouched subtrees unwired). It is used only by
+// the single-threaded incremental-edit path (nodeEditRoot) to keep edit-time
+// finalChildRefs materialization lazy. It must NOT be used from the concurrent
+// public read paths (Parent/NextSibling/PrevSibling) — those write parent links
+// under parentLinkMu via ensureParentLinks instead (issue #93 race fix).
 func wireParentPathToNodeNoMaterialize(root, target *Node) bool {
 	if root == nil || target == nil {
 		return false
@@ -299,7 +305,7 @@ func nodeDeferredParentRoot(n *Node) (*Node, bool) {
 	arena := n.ownerArena
 	arena.parentLinkMu.Lock()
 	deferredRoot := arena.deferredParentRoot
-	parentLinksDeferred := arena.parentLinksDeferred
+	parentLinksDeferred := arena.parentLinksDeferred.Load()
 	arena.parentLinkMu.Unlock()
 	if !parentLinksDeferred || deferredRoot == nil {
 		return nil, false
@@ -307,6 +313,9 @@ func nodeDeferredParentRoot(n *Node) (*Node, bool) {
 	return deferredRoot, true
 }
 
+// wireDeferredParentPathToNode performs single-path parent wiring for the
+// incremental-edit path only (single-threaded). Concurrent read traversal goes
+// through ensureParentLinks (wire-all-once under parentLinkMu).
 func wireDeferredParentPathToNode(n *Node) (*Node, bool) {
 	deferredRoot, ok := nodeDeferredParentRoot(n)
 	if !ok {
@@ -1101,13 +1110,6 @@ func (n *Node) Parent() *Node {
 	if n == nil {
 		return nil
 	}
-	if parent, _, ok := nodeParentLink(n); ok || parent != nil {
-		return parent
-	}
-	if _, ok := wireDeferredParentPathToNode(n); ok {
-		parent, _, _ := nodeParentLink(n)
-		return parent
-	}
 	n.ensureParentLinks()
 	parent, _, _ := nodeParentLink(n)
 	return parent
@@ -1127,15 +1129,10 @@ func (n *Node) NextSibling() *Node {
 	if n == nil {
 		return nil
 	}
+	n.ensureParentLinks()
 	parent, index, ok := nodeParentLink(n)
 	if parent == nil {
-		if _, wired := wireDeferredParentPathToNode(n); !wired {
-			n.ensureParentLinks()
-		}
-		parent, index, ok = nodeParentLink(n)
-		if parent == nil {
-			return nil
-		}
+		return nil
 	}
 	childCount := nodeChildCountNoMaterialize(parent)
 	if ok && index >= 0 && index < childCount && nodeChildAtForReason(parent, index, materializeForParentAPI) == n {
@@ -1162,15 +1159,10 @@ func (n *Node) PrevSibling() *Node {
 	if n == nil {
 		return nil
 	}
+	n.ensureParentLinks()
 	parent, index, ok := nodeParentLink(n)
 	if parent == nil {
-		if _, wired := wireDeferredParentPathToNode(n); !wired {
-			n.ensureParentLinks()
-		}
-		parent, index, ok = nodeParentLink(n)
-		if parent == nil {
-			return nil
-		}
+		return nil
 	}
 	childCount := nodeChildCountNoMaterialize(parent)
 	if ok && index >= 0 && index < childCount && nodeChildAtForReason(parent, index, materializeForParentAPI) == n {
@@ -1793,21 +1785,33 @@ func (a *nodeArena) deferParentLinks(root *Node) {
 	}
 	a.parentLinkMu.Lock()
 	a.deferredParentRoot = root
-	a.parentLinksDeferred = true
+	a.parentLinksDeferred.Store(true)
 	setNodeRootLink(root)
 	a.parentLinkMu.Unlock()
 }
 
+// ensureParentLinks wires the arena's deferred parent links exactly once, under
+// parentLinkMu, and is safe for concurrent callers. The atomic parentLinksDeferred
+// flag pairs a release store (after wiring) with the lock-free Load fast path:
+// once a caller observes the flag false, every parent-link field written during
+// wiring is visible to it without holding the lock, so subsequent reads via
+// nodeParentLink are race-free. This replaces the previous lazy per-path wiring
+// (wireDeferredParentPathToNode), which wrote parent pointers outside the lock and
+// raced with concurrent Parent()/sibling reads on a freshly parsed tree (the
+// java/python/typescript/tsx deferred path).
 func (a *nodeArena) ensureParentLinks() {
 	if a == nil {
 		return
 	}
+	if !a.parentLinksDeferred.Load() {
+		return
+	}
 	a.parentLinkMu.Lock()
 	root := a.deferredParentRoot
-	if a.parentLinksDeferred && root != nil {
+	if a.parentLinksDeferred.Load() && root != nil {
 		wireParentLinksWithScratch(root, nil)
-		a.parentLinksDeferred = false
 		a.deferredParentRoot = nil
+		a.parentLinksDeferred.Store(false)
 	}
 	a.parentLinkMu.Unlock()
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -301,14 +301,17 @@ func TestDeferredParentLinksWireOnAccess(t *testing.T) {
 	if got := first.Parent(); got != parent {
 		t.Fatalf("first.Parent() = %p, want %p", got, parent)
 	}
-	if second.parent != nil {
-		t.Fatal("first.Parent should not wire untouched sibling")
+	// First parent access now wires ALL deferred links once, under parentLinkMu
+	// (so the sibling is wired too). This replaced the previous per-path lazy
+	// wiring, which wrote parent pointers outside the lock and raced with
+	// concurrent Parent()/sibling reads on a freshly parsed java/python/ts/tsx
+	// tree (issue #93 parser-core sweep). The defer-until-first-access property
+	// is preserved (links stay unwired until the first access above).
+	if second.parent != parent {
+		t.Fatalf("expected first access to wire all links once; second.parent = %p, want %p", second.parent, parent)
 	}
 	if got := first.NextSibling(); got != second {
 		t.Fatalf("first.NextSibling() = %p, want %p", got, second)
-	}
-	if second.parent != nil {
-		t.Fatal("first.NextSibling should not wire returned sibling")
 	}
 	if got := second.PrevSibling(); got != first {
 		t.Fatalf("second.PrevSibling() = %p, want %p", got, first)
@@ -332,7 +335,7 @@ func TestFinalizeResultRootDefersSelectedLanguageParentLinks(t *testing.T) {
 
 			parser.finalizeResultRoot(root, []byte("x"), nil, true, false)
 
-			if !arena.parentLinksDeferred {
+			if !arena.parentLinksDeferred.Load() {
 				t.Fatalf("expected %s finalization to defer parent links", name)
 			}
 			if child.parent != nil {
@@ -341,8 +344,15 @@ func TestFinalizeResultRootDefersSelectedLanguageParentLinks(t *testing.T) {
 			if got := child.Parent(); got != root {
 				t.Fatalf("child.Parent() = %p, want %p", got, root)
 			}
-			if !arena.parentLinksDeferred {
-				t.Fatal("expected targeted parent access to keep deferred flag")
+			// First parent access wires ALL deferred links once (under
+			// parentLinkMu) and clears the flag — this replaced the previous
+			// lazy per-path wiring, which wrote parent pointers outside the lock
+			// and raced with concurrent Parent()/sibling reads (issue #93 sweep).
+			if arena.parentLinksDeferred.Load() {
+				t.Fatal("expected first parent access to wire all links once and clear the deferred flag")
+			}
+			if child.parent != root {
+				t.Fatalf("expected child parent link wired to root after access; got %p", child.parent)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes a data race in deferred parent-link wiring that occurred when multiple goroutines accessed Node.Parent() on a freshly parsed tree. Replaces unsafe lazy per-path wiring with ensureParentLinks(), which wires all deferred links exactly once under a mutex. Adds a dedicated race test to prevent regression.

## Changes

- Switch parentLinksDeferred from bool to atomic.Bool for lock-free fast-path checks.
- Introduce ensureParentLinks() to wire all deferred parent links exactly once under parentLinkMu.
- Simplify Parent(), NextSibling(), and PrevSibling() to always call ensureParentLinks() before reading, removing previously unsafe per-path wiring.
- Add TestParentLinkConcurrentAccessNoRace to reproduce and validate the race fix under -race.
- Update existing tests to reflect the new wire-all-once behavior and use .Load()/.Store() for the atomic flag.

## Testing

- go test . -race -run TestParentLinkConcurrentAccessNoRace
- go test . -run TestDeferredParentLinksWireOnAccess
- go test . -race -run TestFinalizeResultRootDefersSelectedLanguageParentLinks

## Related Issues

- Closes #93

## Review Focus

Focus on the new ensureParentLinks() logic and the updated Parent/Next/Prev sibling paths. Verify that the atomic flag fast-path correctly pairs with the mutex release store for visibility across goroutines.

---

**Bug (parser-core sweep finding):** on a freshly parsed tree for the deferred-parent-link languages (java/python/typescript/tsx), `Node.Parent()`/`NextSibling()`/`PrevSibling()` wired parent links lazily per-path via `wireDeferredParentPathToNode` → `setNodeParentLink`, writing `child.parent` **outside `parentLinkMu`**. Two goroutines traversing the same returned tree raced on `n.parent` (confirmed under `-race`: read in `nodeParentLink` vs write in `wireParentPathToNodeNoMaterialize`).

**Fix (wire-all-once on read paths):** `parentLinksDeferred` is now an `atomic.Bool`; `ensureParentLinks()` wires the whole tree once under `parentLinkMu` and does a release-store of the flag, so once a caller observes it false, all wired fields are visible lock-free. `Parent`/`NextSibling`/`PrevSibling` delegate to it before reading. The **single-threaded incremental-edit path** (`nodeEditRoot`) keeps per-path lazy wiring (not concurrent; preserves edit-time `finalChildRefs` laziness).

**Design tradeoff (approved):** the concurrent read paths trade per-path *partial* wiring for wire-all-once. The **primary** deferred optimization — zero wiring when `Parent()` is never called — is fully preserved; only the marginal "touch one node of a huge tree, wire only that path" micro-opt is dropped on the read paths. Cheap alternatives were rejected: atomic parent pointers blow the 136B Node budget; locking every read costs traversal perf.

**Verification:**
- New `TestParentLinkConcurrentAccessNoRace` (python, the deferred path) — fails under `-race` before, clean after. `-race` also clean across the deferred/edit/GLR tests.
- Full root package suite green; build + vet clean.
- **Ring-matrix (Docker, `GTS_PARITY_MODE=exhaustive`):** failure set byte-identical to the pre-existing main baseline (zero new failures); all 9 key languages incl. python/java/typescript/tsx pass FreshParse/Incremental/HasNoErrors.
- Updated `tree_test.go`/`glr_test.go` per-path-laziness assertions to the new wire-all-once read-path semantics (edit-path laziness assertions unchanged).