### PR TITLE
fix(js/ts): correct optional_chain normalization to strip child

### DIFF
--- a/parser_leaf_token_regression_test.go
+++ b/parser_leaf_token_regression_test.go
@@ -346,7 +346,7 @@ func TestParseTSXGenericCallUnionTypeArgument(t *testing.T) {
 	}
 }
 
-func TestParseTSXOptionalChainKeepsTokenChild(t *testing.T) {
+func TestParseTSXOptionalChainIsLeaf(t *testing.T) {
 	src := "const value = elements?.concat(wildcards);\n"
 	tree, lang := parseLanguageSample(t, "tsx", src)
 	t.Cleanup(tree.Release)
@@ -365,14 +365,10 @@ func TestParseTSXOptionalChainKeepsTokenChild(t *testing.T) {
 	if node == nil {
 		t.Fatalf("missing optional_chain node: %s", tree.RootNode().SExpr(lang))
 	}
-	if got, want := node.ChildCount(), 1; got != want {
+	// C tree-sitter emits optional_chain as a 0-child leaf; the Go parser
+	// should match after normalization strips any materialized "?." child.
+	if got, want := node.ChildCount(), 0; got != want {
 		t.Fatalf("optional_chain child count = %d, want %d; root=%s", got, want, tree.RootNode().SExpr(lang))
-	}
-	if child := node.Child(0); child == nil || child.Type(lang) != "?." {
-		if child == nil {
-			t.Fatal("optional_chain token child is nil")
-		}
-		t.Fatalf("optional_chain token child type = %q, want ?.", child.Type(lang))
 	}
 }
 

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -854,28 +854,27 @@ func normalizeJavaScriptTypeScriptOptionalChainLeaves(root *Node, source []byte,
 	if !ok {
 		return
 	}
-	optionalChainTokenSym, ok := symbolByName(lang, "?.")
-	if !ok {
-		return
-	}
 
 	walkResultTreeDenseFirst(root, func(n *Node) {
-		if n.symbol != optionalChainSym || len(n.children) != 0 {
+		if n.symbol != optionalChainSym || len(n.children) != 1 {
 			return
 		}
-		if n.endByte <= n.startByte || int(n.endByte) > len(source) || !bytes.Equal(source[n.startByte:n.endByte], []byte("?.")) {
+		// The C reference parser emits optional_chain as a 0-child leaf.
+		// The Go parser sometimes materializes a "?." anonymous token as
+		// a child. Strip it to match C's structure.
+		child := n.children[0]
+		if child == nil {
 			return
 		}
-		child := newLeafNodeInArena(n.ownerArena, optionalChainTokenSym, symbolIsNamed(lang, optionalChainTokenSym), n.startByte, n.endByte, n.startPoint, n.endPoint)
-		children := phpAllocChildren(n.ownerArena, 1)
-		children[0] = child
-		n.children = children
+		if child.endByte <= child.startByte || int(child.endByte) > len(source) || !bytes.Equal(source[child.startByte:child.endByte], []byte("?.")) {
+			return
+		}
+		n.children = nil
 		n.fieldIDs = nil
 		n.fieldSources = nil
 		if n.ownerArena != nil {
 			n.ownerArena.clearFinalChildRefs(n)
 		}
-		populateParentNode(n, n.children)
 	})
 }
 
@@ -1188,18 +1187,17 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 			if normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbolChanged(n, source, "while", whileSym, whileNamed, closeBraceSym, hasCloseBrace) {
 				index.statementKeyword.nodesRewritten++
 			}
-		} else if enableOptionalChain && n.symbol == optionalChainSym && len(n.children) == 0 {
-			if n.endByte > n.startByte && int(n.endByte) <= len(source) && bytes.Equal(source[n.startByte:n.endByte], []byte("?.")) {
-				child := newLeafNodeInArena(n.ownerArena, optionalChainTokenSym, optionalChainTokenNamed, n.startByte, n.endByte, n.startPoint, n.endPoint)
-				children := phpAllocChildren(n.ownerArena, 1)
-				children[0] = child
-				n.children = children
+		} else if enableOptionalChain && n.symbol == optionalChainSym && len(n.children) == 1 {
+			// The C reference parser emits optional_chain as a 0-child leaf.
+			// Strip the materialized "?." child to match C.
+			child := n.children[0]
+			if child != nil && child.endByte > child.startByte && int(child.endByte) <= len(source) && bytes.Equal(source[child.startByte:child.endByte], []byte("?.")) {
+				n.children = nil
 				n.fieldIDs = nil
 				n.fieldSources = nil
 				if n.ownerArena != nil {
 					n.ownerArena.clearFinalChildRefs(n)
 				}
-				populateParentNode(n, n.children)
 			}
 		}
 


### PR DESCRIPTION
## What does this PR do?

Reverses the optional_chain normalization direction so the Go parser produces 0-child leaf nodes — matching C tree-sitter's structure.

## Why this approach?

The existing normalization was adding a `?.` anonymous child to 0-child optional_chain nodes. However, the C reference parser emits optional_chain as a 0-child leaf. The Go parser sometimes materializes a `?.` token as a child, producing a 1-child node. This PR strips that materialized child instead of adding one, aligning with the C oracle.

The test `TestParseTSXOptionalChainKeepsTokenChild` was asserting the incorrect (pre-fix) behavior. It is renamed to `TestParseTSXOptionalChainIsLeaf` and updated to assert `ChildCount()==0`.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
  - `go test -run 'TestParseTSXOptionalChain' -count=1 .` — PASS
- [x] Affected parity validation ran in Docker, one language or grammar at a time
  - `TestParityFreshParse/javascript` — PASS (Docker, 8 GB, 4 CPU)
  - `TestParityFreshParse/typescript` — PASS (Docker, 8 GB, 4 CPU)
  - `TestParityFreshParse/tsx` — PASS (Docker, 8 GB, 4 CPU)
- [x] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker — N/A (normalization only)
- [x] Documented anything intentionally left unvalidated in this PR — None

## Performance

- [ ] If perf-relevant, used the stable bench settings
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
  - **Perf is not the goal.** This is a correctness fix. The change replaces one conditional branch (`len(n.children) != 0` → `len(n.children) != 1`) and removes a `newLeafNodeInArena` + `populateParentNode` call, so if anything it is marginally faster (fewer allocations on affected nodes).
- [ ] If large-grammar behavior changed, checked bounded RSS — N/A

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
  - The key insight: the normalization was going the **wrong direction**. C produces 0-child leaves; Go was adding children to match a misunderstanding of C's structure.
- [x] Called out anything I'm unsure about or want a second opinion on
  - `n.children = nil` (vs `n.children[:0]`): `len(nil)==0` is safe in Go and `nodeChildCountNoMaterialize` handles nil, but flagging in case the project prefers a different convention for "no children."

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars — javascript, typescript, tsx
- [x] If adding a grammar or scanner: verified against upstream C output — N/A

## LOC Summary

| Category | Files | +Lines | −Lines | Net |
|---|---|---|---|---|
| Production code | 1 (`parser_result_javascript_typescript.go`) | +16 | −18 | −2 |
| Tests | 1 (`parser_leaf_token_regression_test.go`) | +4 | −8 | −4 |
| **Total** | **2** | **+20** | **−26** | **−6** |
