### PR TITLE
fix(typescript): add dynamic import collapsed-leaf normalization

### DIFF
--- a/parser_result_typescript.go
+++ b/parser_result_typescript.go
@@ -94,6 +94,8 @@ type typeScriptNormalizationContext struct {
 	enumAssignmentSym          Symbol
 	importSym                  Symbol
 	hasImportSym               bool
+	dynamicImportSym           Symbol
+	hasDynamicImportSym        bool
 	typeQuerySym               Symbol
 	nameFieldID                FieldID
 	typeParametersFieldID      FieldID
@@ -117,6 +119,10 @@ func normalizeTypeScriptCompatibility(root *Node, source []byte, lang *Language)
 		case ctx.importSym:
 			if ctx.hasImportSym {
 				normalizeTypeScriptImportKeywordNamedness(n, &ctx)
+			}
+		case ctx.dynamicImportSym:
+			if ctx.hasDynamicImportSym {
+				normalizeTypeScriptDynamicImportLeaf(n, &ctx)
 			}
 		case ctx.methodDefinitionSym, ctx.methodSignatureSym, ctx.abstractMethodSignatureSym, ctx.propertySignatureSym, ctx.publicFieldDefinitionSym:
 			if ctx.accessibilityModSym != 0 {
@@ -187,6 +193,16 @@ func normalizeTypeScriptCompatibilityWithStats(root *Node, source []byte, lang *
 				before := n.isNamed()
 				normalizeTypeScriptImportKeywordNamedness(n, &ctx)
 				if n.isNamed() != before {
+					stats.importKeywords.nodesRewritten++
+					stats.total.nodesRewritten++
+				}
+			}
+		case ctx.dynamicImportSym:
+			if ctx.hasDynamicImportSym {
+				stats.importKeywords.nodesVisited++
+				beforeCC := resultChildCount(n)
+				normalizeTypeScriptDynamicImportLeaf(n, &ctx)
+				if resultChildCount(n) != beforeCC {
 					stats.importKeywords.nodesRewritten++
 					stats.total.nodesRewritten++
 				}
@@ -455,13 +471,27 @@ func normalizeTypeScriptImportKeywordNamedness(node *Node, ctx *typeScriptNormal
 	if node == nil || ctx == nil || !ctx.hasImportSym || node.symbol != ctx.importSym {
 		return
 	}
-	if typeScriptNextNonspaceByte(ctx.source, node.endByte) == '(' {
-		node.setNamed(true)
-		return
-	}
+	// Dynamic import expressions (import(...)) are handled by
+	// normalizeTypeScriptDynamicImportLeaf for the named import symbol
+	// (dynamicImportSym). The anonymous import keyword (importSym)
+	// should stay anonymous — C tree-sitter keeps it as an anonymous
+	// child of the named import node.
 	node.setNamed(false)
 }
 
+// normalizeTypeScriptDynamicImportLeaf adds a collapsed-leaf child to the
+// named import node in dynamic import() expressions. C tree-sitter produces
+// a 1-child structure with an anonymous "import" keyword token.
+func normalizeTypeScriptDynamicImportLeaf(node *Node, ctx *typeScriptNormalizationContext) {
+	if node == nil || ctx == nil || !ctx.hasDynamicImportSym || node.symbol != ctx.dynamicImportSym {
+		return
+	}
+	if resultChildCount(node) == 0 && node.endByte > node.startByte {
+		// Use the anonymous import symbol (ctx.importSym, sym 14) as the child.
+		child := newLeafNodeInArena(node.ownerArena, ctx.importSym, false, node.startByte, node.endByte, node.startPoint, node.endPoint)
+		replaceNodeChildrenUnfielded(node, cloneNodeSliceInArena(node.ownerArena, []*Node{child}))
+	}
+}
 func normalizeTypeScriptRecoveredNamespaceRoot(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil || len(root.children) < 4 {
 		return
@@ -843,6 +873,8 @@ func newTypeScriptNormalizationContext(source []byte, lang *Language) (typeScrip
 		}
 	}
 	ctx.importSym, ctx.hasImportSym = lang.SymbolByName("import")
+	// Dynamic import() uses a separate named 'import' symbol (e.g. sym 173).
+	ctx.dynamicImportSym, ctx.hasDynamicImportSym = lang.symbolByNameAndNamed("import", true)
 	ctx.typeQuerySym, _ = lang.SymbolByName("type_query")
 
 	if syms, ok := visibleLanguageSymbols(lang, true,


### PR DESCRIPTION
## What does this PR do?

Adds a normalization pass for TypeScript/TSX `import()` expressions where the named `import` node is a 0-child collapsed leaf. Injects an anonymous `import` keyword child to match C tree-sitter's 1-child structure.

## Why this approach?

C tree-sitter produces a named `import` node (e.g. symbol 173) containing an anonymous `import` keyword child (symbol 14) for dynamic `import()` expressions. The Go parser emits the named import as a 0-child collapsed leaf.

This follows the existing collapsed-leaf pattern used throughout the codebase (e.g., `normalizeCollapsedNamedLeafChildren`). Key design decisions:

- Uses `symbolByNameAndNamed("import", true)` to distinguish the named import symbol (dynamic import) from the anonymous import keyword (static import).
- Wired into both `normalizeTypeScriptCompatibility` and `normalizeTypeScriptCompatibilityWithStats` dispatch paths.
- The `normalizeTypeScriptImportKeywordNamedness` function is simplified — the old `typeScriptNextNonspaceByte == '('` heuristic incorrectly promoted anonymous `import` to named for dynamic imports. C keeps static import keywords anonymous; the dynamic import is a separate named symbol.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
  - `go test -run 'TestParseTSX' -count=1 .` — PASS
- [x] Affected parity validation ran in Docker, one language or grammar at a time
  - `TestParityFreshParse/typescript` — PASS (Docker, 8 GB, 4 CPU)
  - `TestParityFreshParse/tsx` — PASS (Docker, 8 GB, 4 CPU)
- [x] If grammargen or parity logic changed — N/A (normalization only)
- [x] Documented anything intentionally left unvalidated — None

## Performance

- [ ] If perf-relevant, used the stable bench settings
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
  - **Perf is not the goal.** The new dispatch case fires only on `dynamicImportSym` nodes, which are rare (one per `import()` expression). No measurable impact.
- [ ] If large-grammar behavior changed — N/A

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
  - The distinction between `importSym` (anonymous keyword, symbol 14) and `dynamicImportSym` (named import node, symbol 173) is the crux. `symbolByNameAndNamed` resolves this cleanly.
- [x] Called out anything I'm unsure about or want a second opinion on
  - The simplification of `normalizeTypeScriptImportKeywordNamedness` (removing the `'('` lookahead) is intentional. Wanted to flag that this changes behavior for static import keywords from "named if followed by `(`" to "always anonymous."

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars — typescript, tsx
- [x] If adding a grammar or scanner: verified against upstream C output — N/A

## LOC Summary

| Category | Files | +Lines | −Lines | Net |
|---|---|---|---|---|
| Production code | 1 (`parser_result_typescript.go`) | +36 | −4 | +32 |
| **Total** | **1** | **+36** | **−4** | **+32** |
