### PR TITLE
fix(csharp): bound namespace recovery sub-parses

### DIFF
--- a/parser_api.go
+++ b/parser_api.go
@@ -135,6 +135,8 @@ func (p *Parser) parseForRecovery(source []byte) (*Tree, error) {
 		p.recoveryParser = parser
 	}
 	parser.skipRecoveryReparse = true
+	parser.timeoutMicros = p.timeoutMicros
+	parser.cancellationFlag = p.cancellationFlag
 	if p.reparseFactory != nil {
 		ts, err := p.reparseFactory(source)
 		if err != nil {

--- a/parser_csharp_boundedness_test.go
+++ b/parser_csharp_boundedness_test.go
@@ -65,6 +65,29 @@ func TestCSharpCJKPartialClassesStayBounded(t *testing.T) {
 	}
 }
 
+func TestCSharpNamespaceRecoveryStaysBoundedDottedBitorArg(t *testing.T) {
+	src := []byte(`namespace N { class C { void M(string n) { F(n, E.A | E.B); } } }`)
+	parser := gotreesitter.NewParser(grammars.CSharpLanguage())
+	parser.SetTimeoutMicros(500_000)
+
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	if got, want := rt.StopReason, gotreesitter.ParseStopAccepted; got != want {
+		t.Fatalf("StopReason = %s, want %s (%s)", got, want, rt.Summary())
+	}
+	if tree.ParseStoppedEarly() {
+		t.Fatalf("ParseStoppedEarly = true (%s)", rt.Summary())
+	}
+	if got, want := tree.RootNode().EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d (%s)", got, want, rt.Summary())
+	}
+}
+
 func csharpSyntheticDesignerSource(fields int) []byte {
 	var b strings.Builder
 	b.WriteString("namespace Station.UI {\n")

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -628,27 +628,19 @@ func csharpFindBlockCommentEnd(source []byte, start, end uint32) uint32 {
 }
 
 func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, p *Parser, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "c_sharp" || len(source) == 0 || root.ownerArena == nil {
+	if root == nil || p == nil || lang == nil || lang.Name != "c_sharp" || len(source) == 0 || root.ownerArena == nil {
 		return
 	}
 	rootType := root.Type(lang)
 	if rootType != "ERROR" && rootType != "compilation_unit" {
 		return
 	}
-	// Inherit the parent parser's per-parse timeout so each snippet sub-parse
-	// the recovery triggers is bounded too. Without this, the snippet pool
-	// resets timeoutMicros to 0 (parser_pool_reset.go) and the inner parses
-	// can run unbounded.
-	var snippetTimeoutMicros uint64
-	if p != nil {
-		snippetTimeoutMicros = p.timeoutMicros
-	}
 	recoveredChildren := make([]*Node, 0, len(root.children))
 	changed := false
 	recoveryCount := 0
 	for i := 0; i < len(root.children); {
 		if recoveryCount < csharpMaxNamespaceRecoveries {
-			if recovered, next, ok := csharpRecoverNamespaceFromChildren(root.children, i, source, lang, root.ownerArena, snippetTimeoutMicros); ok {
+			if recovered, next, ok := csharpRecoverNamespaceFromChildren(root.children, i, source, p, lang, root.ownerArena); ok {
 				recoveredChildren = append(recoveredChildren, recovered)
 				i = next
 				changed = true
@@ -682,8 +674,8 @@ func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, p *Parser, la
 	}
 }
 
-func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source []byte, lang *Language, arena *nodeArena, snippetTimeoutMicros uint64) (*Node, int, bool) {
-	if startIdx < 0 || startIdx >= len(children) || lang == nil || arena == nil {
+func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source []byte, p *Parser, lang *Language, arena *nodeArena) (*Node, int, bool) {
+	if startIdx < 0 || startIdx >= len(children) || p == nil || lang == nil || arena == nil {
 		return nil, startIdx, false
 	}
 	startNode := children[startIdx]
@@ -709,7 +701,7 @@ func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source [
 		return nil, startIdx, false
 	}
 	nsEnd := uint32(closeBrace + 1)
-	recovered, ok := csharpRecoverNamespaceNodeFromRange(source, nsStart, nsEnd, lang, arena, snippetTimeoutMicros)
+	recovered, ok := csharpRecoverNamespaceNodeFromRange(source, nsStart, nsEnd, p, lang, arena)
 	if !ok {
 		return nil, startIdx, false
 	}
@@ -728,11 +720,11 @@ func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source [
 	return recovered, nextIdx, true
 }
 
-func csharpRecoverNamespaceNodeFromRange(source []byte, start, end uint32, lang *Language, arena *nodeArena, snippetTimeoutMicros uint64) (*Node, bool) {
-	if lang == nil || arena == nil || start >= end || int(end) > len(source) {
+func csharpRecoverNamespaceNodeFromRange(source []byte, start, end uint32, p *Parser, lang *Language, arena *nodeArena) (*Node, bool) {
+	if p == nil || lang == nil || arena == nil || start >= end || int(end) > len(source) {
 		return nil, false
 	}
-	tree, err := parseWithSnippetParser(lang, source[start:end], snippetTimeoutMicros)
+	tree, err := p.parseForRecovery(source[start:end])
 	if err != nil || tree == nil || tree.RootNode() == nil {
 		if tree != nil {
 			tree.Release()


### PR DESCRIPTION
## Summary

Fixes #98.

C# namespace recovery now routes namespace snippet parses through `Parser.parseForRecovery()` instead of the generic `parseWithSnippetParser()` path. That reuses the parser's recovery parser and sets `skipRecoveryReparse`, so a recovered namespace snippet cannot recursively re-enter namespace recovery on the same range.

This also propagates the parent parser's timeout and cancellation flag into recovery parses so snippet work observes the same guardrails as the outer parse.

## Validation

Ran in the bounded Docker harness:

```sh
bash cgo_harness/docker/run_parity_in_docker.sh --label csharp-oom-unit -- "cd /workspace && go test . -run 'TestCSharpNamespaceRecoveryStaysBoundedDottedBitorArg|TestCSharpDesignerStyleBlockStaysBounded|TestCSharpCJKPartialClassesStayBounded|TestParseForRecoveryReusesRecoveryParser' -count=1"
```

Result: PASS, `oom_killed=false`.

```sh
bash cgo_harness/docker/run_parity_in_docker.sh --no-build --label csharp-oom-parity --run '^TestParityFreshParse/c_sharp$'
```

Result: PASS, `oom_killed=false`, max RSS `1408056 KB`.