### PR TITLE
fix(swift): recover top-level declarations after license headers

### DIFF
--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -65,3 +65,72 @@ func TestSwiftMemberKeywordSelfAfterDotStaysNavigable(t *testing.T) {
 		t.Fatalf("navigation suffix count = %d, want %d; tree: %s", got, want, sexpr)
 	}
 }
+
+func TestSwiftImportThenClassParsesAsTopLevelDeclarations(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("import Foundation\nclass Foo {}\n")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse swift import/class: %v", err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("swift import/class fixture has parse errors: %s", root.SExpr(lang))
+	}
+	if got, want := root.Type(lang), "source_file"; got != want {
+		t.Fatalf("root type = %q, want %q", got, want)
+	}
+	if got, want := root.EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d; tree: %s", got, want, root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	for _, want := range []string{"(import_declaration", "(class_declaration"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("missing %s in tree: %s", want, sexpr)
+		}
+	}
+}
+
+func TestSwiftLicenseHeaderImportThenClassParses(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte(`//
+//  Foo.swift
+//
+//  Copyright (c) 2025 Foo Foundation (http://example.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+
+import Foundation
+class Foo {}
+`)
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse swift license header: %v", err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("swift license header fixture has parse errors: %s", root.SExpr(lang))
+	}
+	if got, want := root.Type(lang), "source_file"; got != want {
+		t.Fatalf("root type = %q, want %q", got, want)
+	}
+	if got, want := root.EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d; tree: %s", got, want, root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	if strings.Count(sexpr, "(comment)") < 7 {
+		t.Fatalf("license header comments were not preserved as comments: %s", sexpr)
+	}
+	for _, want := range []string{"(import_declaration", "(class_declaration"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("missing %s in tree: %s", want, sexpr)
+		}
+	}
+}

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -116,7 +116,7 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) {
 	case "svelte":
 		normalizeSvelteTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
 	case "swift":
-		normalizeSwiftCompatibility(ctx.root, ctx.source, ctx.lang)
+		normalizeSwiftCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
 	case "tsx", "typescript":
 		normalizeTypeScriptTreeCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
 	case "yaml":

--- a/parser_result_swift.go
+++ b/parser_result_swift.go
@@ -9,10 +9,11 @@ import "bytes"
 // _optionally_valueful_control_keyword in a way that loses the anonymous
 // token, leaving either a childless node (bare `return`) or a node whose
 // span starts at the result expression (`return 42`).
-func normalizeSwiftCompatibility(root *Node, source []byte, lang *Language) {
+func normalizeSwiftCompatibility(root *Node, source []byte, p *Parser, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "swift" {
 		return
 	}
+	normalizeSwiftRecoveredTopLevelDeclarations(root, source, p, lang)
 	// Bare keyword case (childCount=0, span covers exactly the keyword).
 	normalizeCollapsedNamedLeafChildrenBySource(
 		root, source, lang,
@@ -22,6 +23,115 @@ func normalizeSwiftCompatibility(root *Node, source []byte, lang *Language) {
 	// `return <expr>` case: existing children present but the keyword leaf is
 	// missing as the first child and the span starts at the result expression.
 	prependSwiftControlTransferKeyword(root, source, lang)
+}
+
+func normalizeSwiftRecoveredTopLevelDeclarations(root *Node, source []byte, p *Parser, lang *Language) {
+	if root == nil || p == nil || p.skipRecoveryReparse || lang == nil || root.ownerArena == nil || len(source) == 0 {
+		return
+	}
+	if root.Type(lang) != "source_file" || len(root.children) == 0 {
+		return
+	}
+	recoveredChildren := make([]*Node, 0, len(root.children))
+	changed := false
+	for i, child := range root.children {
+		if child == nil {
+			continue
+		}
+		if !child.HasError() {
+			recoveredChildren = append(recoveredChildren, child)
+			continue
+		}
+		start := child.startByte
+		end := uint32(len(source))
+		if i+1 < len(root.children) && root.children[i+1] != nil && root.children[i+1].startByte > start {
+			end = root.children[i+1].startByte
+		}
+		if recovered, ok := swiftRecoverTopLevelDeclarationFromRange(source, start, end, p, lang, root.ownerArena); ok {
+			recoveredChildren = append(recoveredChildren, recovered)
+			changed = true
+			continue
+		}
+		recoveredChildren = append(recoveredChildren, child)
+	}
+	if !changed {
+		return
+	}
+	root.children = cloneNodeSliceIfArena(root.ownerArena, recoveredChildren)
+	populateParentNode(root, root.children)
+	if !swiftAnyChildHasError(root) {
+		root.setHasError(false)
+	}
+	if len(root.children) > 0 {
+		last := root.children[len(root.children)-1]
+		if last != nil && last.endByte > root.endByte {
+			root.endByte = last.endByte
+			root.endPoint = last.endPoint
+		}
+	}
+}
+
+func swiftRecoverTopLevelDeclarationFromRange(source []byte, start, end uint32, p *Parser, lang *Language, arena *nodeArena) (*Node, bool) {
+	if p == nil || lang == nil || arena == nil || start >= end || int(end) > len(source) {
+		return nil, false
+	}
+	start, end = swiftTrimSpaceBounds(source, start, end)
+	if start >= end {
+		return nil, false
+	}
+	tree, err := p.parseForRecovery(source[start:end])
+	if err != nil || tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, false
+	}
+	defer tree.Release()
+	startPoint := advancePointByBytes(Point{}, source[:start])
+	offsetRoot := tree.RootNodeWithOffset(start, startPoint)
+	if offsetRoot == nil || offsetRoot.HasError() {
+		return nil, false
+	}
+	for _, child := range offsetRoot.children {
+		if child == nil || child.IsExtra() || child.HasError() {
+			continue
+		}
+		return cloneTreeNodesIntoArena(child, arena), true
+	}
+	return nil, false
+}
+
+func swiftTrimSpaceBounds(source []byte, start, end uint32) (uint32, uint32) {
+	for start < end && int(start) < len(source) {
+		switch source[start] {
+		case ' ', '\t', '\n', '\r':
+			start++
+		default:
+			goto trimRight
+		}
+	}
+trimRight:
+	for end > start && int(end) <= len(source) {
+		switch source[end-1] {
+		case ' ', '\t', '\n', '\r':
+			end--
+		default:
+			return start, end
+		}
+	}
+	return start, end
+}
+
+func swiftAnyChildHasError(root *Node) bool {
+	if root == nil {
+		return false
+	}
+	for _, child := range root.children {
+		if child != nil && child.HasError() {
+			return true
+		}
+	}
+	return false
 }
 
 func prependSwiftControlTransferKeyword(root *Node, source []byte, lang *Language) {


### PR DESCRIPTION
## Summary

Addresses #99.

Current `main` already parses the tiny `// software` comment-only reproducer as comments, but the full license-header fixture from the issue still failed once it reached `import Foundation\nclass Foo {}`. The remaining failure was a top-level declaration recovery gap: the parser accepted the first declaration and wrapped the next top-level declaration in an errored `_global_declaration`.

This PR adds a guarded Swift compatibility recovery pass for errored top-level declaration ranges. It reparses the remaining source slice with `parseForRecovery()` and splices the recovered declaration back into the source file, preserving the existing control-transfer normalization and avoiding recursive recovery.

## Validation

Ran in the bounded Docker harness:

```sh
bash cgo_harness/docker/run_parity_in_docker.sh --label swift-issue99-unit -- "cd /workspace && go test ./grammars -run 'TestSwiftLineCommentsStayExtraComments|TestSwiftImportThenClassParsesAsTopLevelDeclarations|TestSwiftLicenseHeaderImportThenClassParses|TestSwiftMemberKeywordSelfAfterDotStaysNavigable' -count=1"
```

Result: PASS, `oom_killed=false`.

```sh
bash cgo_harness/docker/run_parity_in_docker.sh --no-build --label swift-issue99-parity --run '^TestParityFreshParse/swift$'
```

Result: PASS, `oom_killed=false`, max RSS `1234168 KB`.