### PR TITLE
test(parser): update normalization expectations after parity fixes

### DIFF
--- a/parser_result_javascript_typescript_test.go
+++ b/parser_result_javascript_typescript_test.go
@@ -277,7 +277,7 @@ func TestNormalizeJavaScriptTrailingContinueCommentSiblingsDirectContinue(t *tes
 	}
 }
 
-func TestNormalizeJavaScriptTypeScriptOptionalChainKeepsTokenChild(t *testing.T) {
+func TestNormalizeJavaScriptTypeScriptOptionalChainStripsTokenChild(t *testing.T) {
 	lang := &Language{
 		Name:        "javascript",
 		SymbolNames: []string{"EOF", "program", "expression_statement", "call_expression", "identifier", "optional_chain", "?.", "arguments"},
@@ -306,9 +306,9 @@ func TestNormalizeJavaScriptTypeScriptOptionalChainKeepsTokenChild(t *testing.T)
 	stmt := newParentNodeInArena(arena, 2, true, []*Node{call}, nil, 0)
 	root := newParentNodeInArena(arena, 1, true, []*Node{stmt}, nil, 0)
 
-	normalizeJavaScriptTypeScriptOptionalChainLeaves(root, []byte("?."), lang)
+	normalizeJavaScriptTypeScriptOptionalChainLeaves(root, []byte("x?."), lang)
 
-	if got, want := chain.ChildCount(), 1; got != want {
+	if got, want := chain.ChildCount(), 0; got != want {
 		t.Fatalf("optional_chain child count = %d, want %d", got, want)
 	}
 	if got, want := chain.StartByte(), uint32(1); got != want {
@@ -321,13 +321,7 @@ func TestNormalizeJavaScriptTypeScriptOptionalChainKeepsTokenChild(t *testing.T)
 	collapsed := newLeafNodeInArena(arena, 5, true, 0, 2, Point{}, Point{Column: 2})
 	root = newParentNodeInArena(arena, 1, true, []*Node{collapsed}, nil, 0)
 	normalizeJavaScriptTypeScriptOptionalChainLeaves(root, []byte("?."), lang)
-	if got, want := collapsed.ChildCount(), 1; got != want {
+	if got, want := collapsed.ChildCount(), 0; got != want {
 		t.Fatalf("collapsed optional_chain child count = %d, want %d", got, want)
-	}
-	if child := collapsed.Child(0); child == nil || child.Type(lang) != "?." {
-		if child == nil {
-			t.Fatal("collapsed optional_chain child is nil")
-		}
-		t.Fatalf("collapsed optional_chain child type = %q, want ?.", child.Type(lang))
 	}
 }

--- a/parser_result_python_test.go
+++ b/parser_result_python_test.go
@@ -262,7 +262,7 @@ func TestBuildResultFromNodesRepairsPythonIfWrappers(t *testing.T) {
 	if call == nil || call.Type(lang) != "call" {
 		t.Fatalf("expected block child to unwrap to call, got %s", root.SExpr(lang))
 	}
-	if got, want := block.startByte, call.startByte; got != want {
+	if got, want := block.startByte, uint32(26); got != want {
 		t.Fatalf("block startByte = %d, want %d", got, want)
 	}
 }
@@ -315,7 +315,7 @@ func TestBuildResultFromNodesRepairsPythonBlockRangeWithoutWrapperChanges(t *tes
 	if got, want := block.ChildCount(), 1; got != want {
 		t.Fatalf("block child count = %d, want %d", got, want)
 	}
-	if got, want := block.startByte, callLeaf.startByte; got != want {
+	if got, want := block.startByte, uint32(26); got != want {
 		t.Fatalf("block startByte = %d, want %d", got, want)
 	}
 }
@@ -517,10 +517,10 @@ func TestNormalizePythonCompatibilityRecordsRuntimeStats(t *testing.T) {
 	normalizePythonCompatibilityWithParser(root, []byte(";"), parser, lang)
 
 	stats := parser.normalizationStats
-	if got, want := stats.passesChecked, uint64(14); got != want {
+	if got, want := stats.passesChecked, uint64(15); got != want {
 		t.Fatalf("passesChecked = %d, want %d", got, want)
 	}
-	if got, want := stats.passesRun, uint64(1); got != want {
+	if got, want := stats.passesRun, uint64(2); got != want {
 		t.Fatalf("passesRun = %d, want %d", got, want)
 	}
 	if got, want := stats.nodesVisited, uint64(1); got != want {


### PR DESCRIPTION
## Summary

Updates stale package-level test expectations after the focused C-parity fixes from #101 and #103 landed.

- Optional-chain normalization tests now expect `optional_chain` to be a 0-child leaf, matching C tree-sitter and #101.
- Python block span tests now expect the block to start at the preceding colon's end byte, matching #103.
- Python normalization stats now include the added block-start pass.

## Validation

Ran focused tests locally and in the bounded Docker harness:

```sh
go test . -run 'TestNormalizeJavaScriptTypeScriptOptionalChainStripsTokenChild|TestBuildResultFromNodesRepairsPythonIfWrappers|TestBuildResultFromNodesRepairsPythonBlockRangeWithoutWrapperChanges|TestNormalizePythonCompatibilityRecordsRuntimeStats' -count=1
```

```sh
bash cgo_harness/docker/run_parity_in_docker.sh --label post-parity-test-expectations -- "cd /workspace && go test . -run 'TestNormalizeJavaScriptTypeScriptOptionalChainStripsTokenChild|TestBuildResultFromNodesRepairsPythonIfWrappers|TestBuildResultFromNodesRepairsPythonBlockRangeWithoutWrapperChanges|TestNormalizePythonCompatibilityRecordsRuntimeStats' -count=1"
```

Result: PASS, `oom_killed=false`.