### PR TITLE
fix(go): stop inferred tags from capturing return types

### DIFF
--- a/grammars/registry_test.go
+++ b/grammars/registry_test.go
@@ -1,6 +1,7 @@
 package grammars
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
@@ -278,6 +279,45 @@ func TestInferredTagsQueryCoverage(t *testing.T) {
 	// Core set (9) is explicit. Inference should expand this materially.
 	if withTags < 30 {
 		t.Fatalf("expected inferred tags query coverage to be >=30 languages, got %d", withTags)
+	}
+}
+
+func TestInferredGoTagsQuerySkipsReturnTypes(t *testing.T) {
+	entry := lookupByName("go")
+	if entry == nil {
+		t.Fatal("expected go language entry")
+	}
+	query := ResolveTagsQuery(*entry)
+	if query == "" {
+		t.Fatal("expected inferred Go tags query")
+	}
+	if strings.Contains(query, "(function_declaration (type_identifier)") {
+		t.Fatalf("Go inferred tags query should not capture return type identifiers as functions:\n%s", query)
+	}
+
+	tagger, err := gotreesitter.NewTagger(entry.Language(), query)
+	if err != nil {
+		t.Fatalf("NewTagger: %v", err)
+	}
+	src := []byte(`package p
+
+func levelFromKind(kind string) int {
+	return 2
+}
+
+func InitDB() error {
+	return nil
+}
+`)
+	tags := tagger.Tag(src)
+	var functions []string
+	for _, tag := range tags {
+		if tag.Kind == "definition.function" {
+			functions = append(functions, tag.Name)
+		}
+	}
+	if got, want := strings.Join(functions, ","), "levelFromKind,InitDB"; got != want {
+		t.Fatalf("definition.function names = %q, want %q; tags=%+v", got, want, tags)
 	}
 }
 

--- a/grammars/tags_query_infer.go
+++ b/grammars/tags_query_infer.go
@@ -14,6 +14,15 @@ var (
 	inferredTagsQueryCache sync.Map // map[string]string
 )
 
+var inferredTagsQueryOverrides = map[string]string{
+	"go": strings.Join([]string{
+		"(function_declaration name: (identifier) @name) @definition.function",
+		"(method_declaration name: (field_identifier) @name) @definition.method",
+		"(call_expression function: (identifier) @name) @reference.call",
+		"(call_expression function: (selector_expression field: (field_identifier) @name)) @reference.call",
+	}, "\n"),
+}
+
 var inferredTagsQueryPatterns = []tagsQueryPattern{
 	// Common definitions.
 	{Query: "(function_declaration (identifier) @name) @definition.function", Symbols: []string{"function_declaration", "identifier"}},
@@ -72,6 +81,11 @@ func inferredTagsQuery(entry LangEntry) string {
 
 	if cached, ok := inferredTagsQueryCache.Load(name); ok {
 		return cached.(string)
+	}
+
+	if query := inferredTagsQueryOverrides[name]; strings.TrimSpace(query) != "" {
+		inferredTagsQueryCache.Store(name, query)
+		return query
 	}
 
 	if entry.Language == nil {


### PR DESCRIPTION
## Summary

Fixes #100.

The generic inferred tags query can match descendant identifiers under `function_declaration`, which makes Go return type identifiers such as `int` or `error` appear as `definition.function` tags. This PR adds a Go-specific inferred query override that uses field-constrained captures for function and method names instead of the generic descendant pattern.

## Validation

Ran focused checks locally and in the bounded Docker harness:

```sh
go test ./grammars -run 'TestInferredGoTagsQuerySkipsReturnTypes|TestCoreLanguagesHaveCompilableTagsQuery|TestInferredTagsQueryCoverage' -count=1
```

```sh
bash cgo_harness/docker/run_parity_in_docker.sh --label go-tags-return-types-unit -- "cd /workspace && go test ./grammars -run 'TestInferredGoTagsQuerySkipsReturnTypes|TestCoreLanguagesHaveCompilableTagsQuery|TestInferredTagsQueryCoverage' -count=1"
```

Result: PASS, `oom_killed=false`.