### PR TITLE
fix: iterative DFS in normalizeGoDotLeafChildren to avoid fatal stack overflow (#110)

### DIFF
--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -82,28 +82,35 @@ func normalizeGoDotLeafChildren(root *Node, source []byte, lang *Language) {
 		return
 	}
 	childNamed := symbolIsNamed(lang, childSym)
-	var walk func(*Node)
-	walk = func(n *Node) {
-		if n == nil {
-			return
+	// Iterative DFS with an explicit stack: source trees can nest or chain
+	// deeply enough that callback recursion overflows the goroutine stack
+	// (fatal, unrecoverable) — see issue #110.
+	stack := []*Node{root}
+	push := func(n *Node) {
+		if n != nil {
+			stack = append(stack, n)
 		}
+	}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
 		childCount := resultChildCount(n)
 		if n.symbol == parentSym && childCount == 0 {
 			normalizeGoDotLeafNode(n, source, childSym, childNamed)
-			return
+			continue
 		}
 		if n.ownerArena == nil || n.childIndex > finalChildSidecarIndexBase {
 			for _, child := range n.children {
-				walk(child)
+				push(child)
 			}
-			return
+			continue
 		}
 		view := resultMutableChildrenForMutation(n)
 		if !view.hasFinalChildRefs() {
 			for i := 0; i < childCount; i++ {
-				walk(resultChildAt(n, i))
+				push(resultChildAt(n, i))
 			}
-			return
+			continue
 		}
 		for i := 0; i < view.Len(); i++ {
 			entry, ok := view.Entry(i)
@@ -113,10 +120,9 @@ func normalizeGoDotLeafChildren(root *Node, source []byte, lang *Language) {
 			if stackEntryNodeSymbol(entry) != parentSym && stackEntryNodeChildCount(entry) == 0 {
 				continue
 			}
-			walk(resultChildAt(n, i))
+			push(resultChildAt(n, i))
 		}
 	}
-	walk(root)
 }
 
 func normalizeGoDotLeafNode(n *Node, source []byte, childSym Symbol, childNamed bool) {


### PR DESCRIPTION
## Problem

`normalizeGoDotLeafChildren` walks the parse tree via callback recursion. On large real-world Go files (observed: a 5,899-line table-driven test file) the recursion exceeds the 1 GB goroutine stack limit — a **fatal, unrecoverable** `stack overflow`, killing the host process mid-parse. This is one concrete instance of #110.

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
github.com/odvcencio/gotreesitter.normalizeGoDotLeafChildren.func1
	parser_result_go_compat.go:97
```

## Fix

Replace the recursive walk with an explicit-stack iterative DFS. Visit logic is unchanged — same node tests, same `normalizeGoDotLeafNode` calls, same sidecar/arena branches; only the traversal mechanism differs.

Full test suite passes. The previously-crashing file now parses to completion.

(Found while building [codegrapher](https://github.com/specscore/codegrapher), a code-intelligence indexer that uses gotreesitter for parsing — thanks for the library!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
