### PR TITLE
fix(csharp): recover declarations from namespaces with internal errors (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-- Nothing yet.
+### Fixed
+
+- C# files whose namespace body does not parse cleanly no longer collapse into
+  a single top-level `ERROR` node with zero recoverable declarations. Namespace
+  recovery now falls back to a best-effort `namespace_declaration` built from
+  the existing sub-parse, surfacing the type declarations (and the members that
+  parsed) instead of discarding the whole file. C# brace matching used during
+  recovery is now trivia-aware, so braces inside char literals, strings and
+  comments no longer truncate a recovered declaration's span (#115).
 
 ## [0.20.2] - 2026-06-06
 

--- a/parser_csharp_namespace_recovery_test.go
+++ b/parser_csharp_namespace_recovery_test.go
@@ -1,0 +1,139 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// countCSharpDecls walks the tree and counts class/method declaration nodes.
+func countCSharpDecls(t *testing.T, lang *gotreesitter.Language, root *gotreesitter.Node) (classes, methods int) {
+	t.Helper()
+	var walk func(n *gotreesitter.Node)
+	walk = func(n *gotreesitter.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type(lang) {
+		case "class_declaration":
+			classes++
+		case "method_declaration":
+			methods++
+		}
+		for i := 0; i < n.ChildCount(); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return classes, methods
+}
+
+// TestCSharpNamespaceWithInternalErrorRecoversDeclarations is the regression
+// test for issue #115: a namespace whose body has an internal parse error used
+// to collapse the whole file into a single ERROR node with zero recoverable
+// declarations. Recovery should now surface the namespace's type declarations.
+func TestCSharpNamespaceWithInternalErrorRecoversDeclarations(t *testing.T) {
+	lang := grammars.CSharpLanguage()
+
+	// A namespace containing a class with a deliberately broken member among
+	// well-formed ones. The braces are balanced so the namespace span resolves,
+	// but the body does not parse cleanly end-to-end.
+	src := []byte(`namespace N
+{
+    public class C
+    {
+        public void A() {}
+        public int @@@ Broken {}
+        public int B() { return 0; }
+    }
+}`)
+
+	tree, err := gotreesitter.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	classes, methods := countCSharpDecls(t, lang, root)
+	if classes < 1 {
+		t.Fatalf("recovered classes = %d, want >= 1 (root type %s)", classes, root.Type(lang))
+	}
+	if methods < 1 {
+		t.Fatalf("recovered methods = %d, want >= 1 (root type %s)", methods, root.Type(lang))
+	}
+}
+
+// TestCSharpNamespaceWithCharLiteralBracesRecovers exercises the trivia-aware
+// brace matcher: char-literal braces ('{' / '}') in a member body must not
+// truncate the namespace span during recovery.
+func TestCSharpNamespaceWithCharLiteralBracesRecovers(t *testing.T) {
+	lang := grammars.CSharpLanguage()
+
+	src := []byte(`namespace N
+{
+    public class C
+    {
+        char Open = '{';
+        char Close = '}';
+        public int @@@ Broken {}
+        public bool IsBrace(char c) { return c == '{' || c == '}'; }
+    }
+}`)
+
+	tree, err := gotreesitter.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if got, want := root.EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d (span truncated by char-literal braces)", got, want)
+	}
+	classes, _ := countCSharpDecls(t, lang, root)
+	if classes < 1 {
+		t.Fatalf("recovered classes = %d, want >= 1 (root type %s)", classes, root.Type(lang))
+	}
+}
+
+// TestCSharpCleanNamespaceUnaffected guards against the recovery path altering a
+// namespace that already parses cleanly.
+func TestCSharpCleanNamespaceUnaffected(t *testing.T) {
+	lang := grammars.CSharpLanguage()
+
+	src := []byte(`namespace N
+{
+    public class C
+    {
+        public void A() {}
+        public int B() { return 0; }
+    }
+    public class D
+    {
+        public void E() {}
+    }
+}`)
+
+	tree, err := gotreesitter.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("clean namespace reported an error")
+	}
+	if got, want := root.Type(lang), "compilation_unit"; got != want {
+		t.Fatalf("root type = %s, want %s", got, want)
+	}
+	classes, methods := countCSharpDecls(t, lang, root)
+	if classes != 2 {
+		t.Fatalf("classes = %d, want 2", classes)
+	}
+	if methods != 3 {
+		t.Fatalf("methods = %d, want 3", methods)
+	}
+}

--- a/parser_csharp_namespace_recovery_test.go
+++ b/parser_csharp_namespace_recovery_test.go
@@ -98,6 +98,42 @@ func TestCSharpNamespaceWithCharLiteralBracesRecovers(t *testing.T) {
 	}
 }
 
+// TestCSharpNamespaceWithVerbatimStringBracesRecovers ensures a verbatim string
+// (@"...") containing braces and "" escapes does not throw off the trivia-aware
+// brace matcher during recovery: the braces inside the string must be ignored so
+// the namespace/class span is not truncated.
+func TestCSharpNamespaceWithVerbatimStringBracesRecovers(t *testing.T) {
+	lang := grammars.CSharpLanguage()
+
+	src := []byte(`namespace N
+{
+    public class C
+    {
+        string S = @"obj }} with ""q"" and { brace";
+        public int @@@ Broken {}
+        public int B() { return 0; }
+    }
+}`)
+
+	tree, err := gotreesitter.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if got, want := root.EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d (span truncated by verbatim-string braces)", got, want)
+	}
+	classes, methods := countCSharpDecls(t, lang, root)
+	if classes < 1 {
+		t.Fatalf("recovered classes = %d, want >= 1 (root type %s)", classes, root.Type(lang))
+	}
+	if methods < 1 {
+		t.Fatalf("recovered methods = %d, want >= 1 (root type %s)", methods, root.Type(lang))
+	}
+}
+
 // TestCSharpCleanNamespaceUnaffected guards against the recovery path altering a
 // namespace that already parses cleanly.
 func TestCSharpCleanNamespaceUnaffected(t *testing.T) {

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -696,7 +696,7 @@ func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source [
 		return nil, startIdx, false
 	}
 	openBrace := int(nsStart) + openRel
-	closeBrace := findMatchingBraceByte(source, openBrace, len(source))
+	closeBrace := csharpFindMatchingBraceByte(source, openBrace, len(source))
 	if closeBrace < 0 {
 		return nil, startIdx, false
 	}
@@ -737,7 +737,13 @@ func csharpRecoverNamespaceNodeFromRange(source []byte, start, end uint32, p *Pa
 	if offsetRoot == nil {
 		return nil, false
 	}
-	return csharpExtractRecoveredTopLevelNode(offsetRoot, lang, arena, end, "namespace_declaration")
+	if node, ok := csharpExtractRecoveredTopLevelNode(offsetRoot, lang, arena, end, "namespace_declaration"); ok {
+		return node, true
+	}
+	// The namespace body did not parse cleanly. Reuse the same sub-parse to
+	// recover a best-effort namespace_declaration containing the declarations
+	// that did parse (issue #115).
+	return csharpBuildRecoveredNamespaceDeclarationFromErrorRoot(offsetRoot, source, start, end, p, lang, arena)
 }
 
 func csharpRecoverWrappedTopLevelDeclaration(n *Node, lang *Language, arena *nodeArena) (*Node, bool) {
@@ -875,7 +881,7 @@ func normalizeCSharpRecoveredTypeDeclarations(root *Node, source []byte, p *Pars
 			i = next
 			continue
 		}
-		if recovered, next, ok := csharpRecoverNonEmptyTopLevelTypeDeclarationFromChildren(root.children, i, source, p, lang, root.ownerArena); ok {
+		if recovered, next, ok := csharpRecoverNonEmptyTopLevelTypeDeclarationFromChildren(root.children, i, source, p, lang, root.ownerArena, false); ok {
 			recoveredChildren = append(recoveredChildren, recovered)
 			i = next
 			continue
@@ -891,7 +897,7 @@ func normalizeCSharpRecoveredTypeDeclarations(root *Node, source []byte, p *Pars
 			i++
 			continue
 		}
-		nonEmpty, ok := csharpRecoverNonEmptyTypeDeclarationFromError(child, source, p, lang, root.ownerArena)
+		nonEmpty, ok := csharpRecoverNonEmptyTypeDeclarationFromError(child, source, p, lang, root.ownerArena, false)
 		if ok {
 			recoveredChildren = append(recoveredChildren, nonEmpty)
 			i++
@@ -936,7 +942,8 @@ func csharpIsRecoveredTopLevelDeclaration(n *Node, lang *Language) bool {
 		return false
 	}
 	switch n.Type(lang) {
-	case "class_declaration", "struct_declaration", "record_declaration", "interface_declaration", "enum_declaration", "delegate_declaration", "namespace_declaration", "file_scoped_namespace_declaration", "using_directive", "extern_alias_directive", "global_statement", "comment":
+	case "class_declaration", "struct_declaration", "record_declaration", "interface_declaration", "enum_declaration", "delegate_declaration", "namespace_declaration", "file_scoped_namespace_declaration", "using_directive", "extern_alias_directive", "global_statement", "comment",
+		"preproc_region", "preproc_endregion", "preproc_if", "preproc_define", "preproc_undef", "preproc_pragma", "preproc_nullable":
 		return true
 	default:
 		return false
@@ -976,7 +983,7 @@ func csharpBuildRecoveredEmptyTypeDeclaration(errNode, initNode *Node, source []
 		return nil, false
 	}
 	openBrace := int(initNode.endByte) + openRel
-	closeBrace := findMatchingBraceByte(source, openBrace, int(errNode.endByte))
+	closeBrace := csharpFindMatchingBraceByte(source, openBrace, int(errNode.endByte))
 	if closeBrace < 0 || closeBrace <= openBrace || !bytesAreTrivia(source[openBrace+1:closeBrace]) {
 		return nil, false
 	}

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -424,7 +424,11 @@ func csharpTopLevelChunkSpans(source []byte) [][2]uint32 {
 		switch b {
 		case '"':
 			inString = true
-			verbatimString = i > 0 && source[i-1] == '@'
+			// Verbatim strings (@"...") and verbatim interpolated strings in
+			// either order (@$"... or $@"...) use "" as the escaped quote rather
+			// than backslash escapes.
+			verbatimString = (i > 0 && source[i-1] == '@') ||
+				(i > 1 && source[i-1] == '$' && source[i-2] == '@')
 			escape = false
 		case '\'':
 			inChar = true

--- a/parser_result_csharp_helpers.go
+++ b/parser_result_csharp_helpers.go
@@ -796,7 +796,12 @@ func csharpFindMatchingBraceByte(source []byte, openPos, limit int) int {
 		switch b {
 		case '"':
 			inString = true
-			verbatimString = i > 0 && source[i-1] == '@'
+			// Verbatim strings (@"...") and verbatim interpolated strings, in
+			// either order (@$"..." since C# 8, or $@"..."), terminate on a lone
+			// '"' with "" as the escaped quote rather than using backslash
+			// escapes. Detect '@' immediately before the quote, or '@$' before it.
+			verbatimString = (i > 0 && source[i-1] == '@') ||
+				(i > 1 && source[i-1] == '$' && source[i-2] == '@')
 			escape = false
 		case '\'':
 			inChar = true

--- a/parser_result_csharp_helpers.go
+++ b/parser_result_csharp_helpers.go
@@ -710,6 +710,109 @@ func csharpBuildSimpleJoinQueryExpression(arena *nodeArena, source []byte, lang 
 	return queryExpr, true
 }
 
+// csharpFindMatchingBraceByte finds the byte offset of the '}' that closes the
+// '{' at openPos, scanning [openPos, limit) while skipping braces that appear
+// inside line/block comments, regular and verbatim strings, and char literals.
+// The plain findMatchingBraceByte miscounts braces embedded in C# char literals
+// (e.g. '{' / '}') and string content, which truncates declaration spans on
+// real-world files (issue #115). Returns the index of the matching '}', or -1.
+func csharpFindMatchingBraceByte(source []byte, openPos, limit int) int {
+	if openPos < 0 || openPos >= len(source) || source[openPos] != '{' {
+		return -1
+	}
+	if limit > len(source) {
+		limit = len(source)
+	}
+	depth := 0
+	inLineComment := false
+	inBlockComment := false
+	inString := false
+	inChar := false
+	verbatimString := false
+	escape := false
+	for i := openPos; i < limit; i++ {
+		b := source[i]
+		switch {
+		case inLineComment:
+			if b == '\n' {
+				inLineComment = false
+			}
+			continue
+		case inBlockComment:
+			if i > 0 && source[i-1] == '*' && b == '/' {
+				inBlockComment = false
+			}
+			continue
+		case inString:
+			if verbatimString {
+				if b == '"' {
+					if i+1 < limit && source[i+1] == '"' {
+						i++
+						continue
+					}
+					inString = false
+					verbatimString = false
+				}
+				continue
+			}
+			if escape {
+				escape = false
+				continue
+			}
+			if b == '\\' {
+				escape = true
+				continue
+			}
+			if b == '"' {
+				inString = false
+			}
+			continue
+		case inChar:
+			if escape {
+				escape = false
+				continue
+			}
+			if b == '\\' {
+				escape = true
+				continue
+			}
+			if b == '\'' {
+				inChar = false
+			}
+			continue
+		}
+		if b == '/' && i+1 < limit {
+			switch source[i+1] {
+			case '/':
+				inLineComment = true
+				i++
+				continue
+			case '*':
+				inBlockComment = true
+				i++
+				continue
+			}
+		}
+		switch b {
+		case '"':
+			inString = true
+			verbatimString = i > 0 && source[i-1] == '@'
+			escape = false
+		case '\'':
+			inChar = true
+			escape = false
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
 func csharpHasKeywordAt(source []byte, start uint32, kw string) bool {
 	if int(start)+len(kw) > len(source) {
 		return false

--- a/parser_result_csharp_namespace.go
+++ b/parser_result_csharp_namespace.go
@@ -1,0 +1,125 @@
+package gotreesitter
+
+// csharpBuildRecoveredNamespaceDeclarationFromErrorRoot synthesises a
+// namespace_declaration from the ERROR root of a namespace sub-parse whose body
+// could not be parsed cleanly. The keyword, name and braces are read directly
+// from source (mirroring csharpRecoverNamespaceFromChildren), and the body
+// declarations are recovered leniently from the already-parsed children of
+// errRoot — so no additional reparse is performed. This is the partial-recovery
+// fallback for issue #115, where large real-world files collapse to a single
+// ERROR node and the strict whole-namespace extraction finds no clean
+// namespace_declaration.
+func csharpBuildRecoveredNamespaceDeclarationFromErrorRoot(errRoot *Node, source []byte, start, end uint32, p *Parser, lang *Language, arena *nodeArena) (*Node, bool) {
+	if errRoot == nil || lang == nil || arena == nil || start >= end || int(end) > len(source) {
+		return nil, false
+	}
+	nsKwStart := csharpSkipSpaceBytes(source, start)
+	if !csharpHasKeywordAt(source, nsKwStart, "namespace") {
+		return nil, false
+	}
+	nsKwEnd := nsKwStart + uint32(len("namespace"))
+	nameStart := csharpSkipSpaceBytes(source, nsKwEnd)
+	openBrace := csharpFindTopLevelByte(source, nameStart, end, '{')
+	if openBrace >= end {
+		return nil, false
+	}
+	nameEnd := csharpTrimRightSpaceBytes(source, openBrace)
+	if nameStart >= nameEnd {
+		return nil, false
+	}
+	closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(end))
+	if closeBrace < 0 || uint32(closeBrace+1) != end {
+		return nil, false
+	}
+
+	keywordTok, ok := csharpBuildLeafNodeByName(arena, source, lang, "namespace", nsKwStart, nsKwEnd)
+	if !ok {
+		return nil, false
+	}
+	nameNode, ok := csharpNamespaceNameNodeFromErrorRoot(errRoot, source, nameStart, openBrace, lang, arena)
+	if !ok {
+		return nil, false
+	}
+	members, ok := csharpRecoverNamespaceBodyMembersFromErrorRoot(errRoot, source, openBrace, uint32(closeBrace), p, lang, arena)
+	if !ok || len(members) == 0 {
+		return nil, false
+	}
+	declList, ok := csharpBuildSourceDeclarationListNode(source, openBrace, uint32(closeBrace), members, lang, arena)
+	if !ok {
+		return nil, false
+	}
+
+	declSym, ok := symbolByName(lang, "namespace_declaration")
+	if !ok {
+		return nil, false
+	}
+	nameFieldID, _ := lang.FieldByName("name")
+	bodyFieldID, _ := lang.FieldByName("body")
+	children := arena.allocNodeSlice(3)
+	children[0] = keywordTok
+	children[1] = nameNode
+	children[2] = declList
+	fieldIDs := cloneFieldIDSliceInArena(arena, []FieldID{0, nameFieldID, bodyFieldID})
+	decl := newParentNodeInArena(arena, declSym, symbolIsNamed(lang, declSym), children, fieldIDs, 0)
+	decl.setHasError(false)
+	extendNodeEndTo(decl, end, source)
+	return decl, true
+}
+
+// csharpNamespaceNameNodeFromErrorRoot returns the namespace name node, reusing
+// the already-parsed qualified_name/identifier from the sub-parse children when
+// available (it is offset-adjusted to the original source) and falling back to
+// rebuilding it from source.
+func csharpNamespaceNameNodeFromErrorRoot(errRoot *Node, source []byte, nameStart, openBrace uint32, lang *Language, arena *nodeArena) (*Node, bool) {
+	for _, c := range errRoot.children {
+		if c == nil || c.HasError() {
+			continue
+		}
+		switch c.Type(lang) {
+		case "qualified_name", "identifier":
+			if c.startByte >= nameStart && c.endByte <= openBrace {
+				return cloneTreeNodesIntoArena(c, arena), true
+			}
+		}
+	}
+	nameEnd := csharpTrimRightSpaceBytes(source, openBrace)
+	if nameStart >= nameEnd {
+		return nil, false
+	}
+	return csharpBuildQualifiedNameNode(source, nameStart, nameEnd, lang, arena)
+}
+
+// csharpRecoverNamespaceBodyMembersFromErrorRoot recovers the declarations that
+// live inside a namespace body from the (offset-adjusted) children of the
+// namespace sub-parse ERROR root. It performs a single O(children) pass: each
+// step either consumes a recovered type declaration (advancing past all of its
+// children) or skips an unrecoverable fragment. Type bodies are recovered in
+// lenient mode so internal ERROR fragments do not abort the enclosing type.
+func csharpRecoverNamespaceBodyMembersFromErrorRoot(errRoot *Node, source []byte, openBrace, closeBrace uint32, p *Parser, lang *Language, arena *nodeArena) ([]*Node, bool) {
+	if errRoot == nil || lang == nil || arena == nil || openBrace >= closeBrace {
+		return nil, false
+	}
+	children := errRoot.children
+	members := make([]*Node, 0, len(children))
+	for i := 0; i < len(children); {
+		child := children[i]
+		if child == nil || child.endByte <= openBrace+1 || child.startByte >= closeBrace {
+			i++
+			continue
+		}
+		if recovered, next, ok := csharpRecoverNonEmptyTopLevelTypeDeclarationFromChildren(children, i, source, p, lang, arena, true); ok {
+			members = append(members, recovered)
+			i = next
+			continue
+		}
+		if member, ok := csharpRecoverTypeDeclarationBodyChild(child, lang, arena); ok {
+			members = append(members, member)
+			i++
+			continue
+		}
+		// Unrecoverable fragment (e.g. an ERROR span or namespace header token):
+		// skip it so the declarations that did parse still surface (issue #115).
+		i++
+	}
+	return members, len(members) > 0
+}

--- a/parser_result_csharp_property.go
+++ b/parser_result_csharp_property.go
@@ -147,7 +147,7 @@ func csharpRecoverAttributedAutoPropertyFromRange(source []byte, start, end uint
 	if accessorStart >= end || source[accessorStart] != '{' {
 		return nil, false
 	}
-	accessorEnd := findMatchingBraceByte(source, int(accessorStart), int(end))
+	accessorEnd := csharpFindMatchingBraceByte(source, int(accessorStart), int(end))
 	if accessorEnd < 0 || uint32(accessorEnd+1) != end {
 		return nil, false
 	}
@@ -213,7 +213,7 @@ func csharpRecoverAttributedMethodDeclarationFromRange(source []byte, start, end
 	if blockStart >= end || source[blockStart] != '{' {
 		return nil, false
 	}
-	blockEnd := findMatchingBraceByte(source, int(blockStart), int(end))
+	blockEnd := csharpFindMatchingBraceByte(source, int(blockStart), int(end))
 	if blockEnd < 0 || uint32(blockEnd+1) != end {
 		return nil, false
 	}

--- a/parser_result_csharp_statement.go
+++ b/parser_result_csharp_statement.go
@@ -454,7 +454,7 @@ func csharpRecoverTopLevelLocalFunctionStatementFromRange(source []byte, start, 
 		return nil, false
 	}
 	openBrace := start + uint32(openRel)
-	closeBrace := findMatchingBraceByte(source, int(openBrace), int(end))
+	closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(end))
 	if closeBrace < 0 || uint32(closeBrace+1) != end {
 		return nil, false
 	}
@@ -556,7 +556,7 @@ func csharpRecoverSimpleTypePatternSwitchStatementFromRange(source []byte, start
 	if openBrace >= end || source[openBrace] != '{' {
 		return nil, false
 	}
-	closeBrace := findMatchingBraceByte(source, int(openBrace), int(end))
+	closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(end))
 	if closeBrace < 0 || uint32(closeBrace+1) != end {
 		return nil, false
 	}
@@ -806,7 +806,7 @@ func csharpRecoverUsingStatementFromRange(source []byte, start, end uint32, p *P
 	if blockStart >= end || source[blockStart] != '{' {
 		return nil, false
 	}
-	blockEnd := findMatchingBraceByte(source, int(blockStart), int(end))
+	blockEnd := csharpFindMatchingBraceByte(source, int(blockStart), int(end))
 	if blockEnd < 0 || uint32(blockEnd+1) != end {
 		return nil, false
 	}

--- a/parser_result_csharp_type_body.go
+++ b/parser_result_csharp_type_body.go
@@ -48,7 +48,7 @@ func csharpRecoverSourceTopLevelTypeDeclarationFromRange(source []byte, start, e
 	bodyEnd := uint32(0)
 	headerEnd := end
 	if openBrace := csharpFindTopLevelByte(source, cursor, end, '{'); openBrace < end {
-		closeBrace := findMatchingBraceByte(source, int(openBrace), int(end))
+		closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(end))
 		if closeBrace < 0 || uint32(closeBrace+1) > end {
 			return nil, false
 		}
@@ -266,7 +266,7 @@ func csharpRecoverClassMethodDeclarationFromRange(source []byte, start, end uint
 	if openBrace >= end {
 		return nil, false
 	}
-	closeBrace := findMatchingBraceByte(source, int(openBrace), int(end))
+	closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(end))
 	if closeBrace < 0 || uint32(closeBrace+1) != end {
 		return nil, false
 	}
@@ -337,18 +337,18 @@ func csharpBuildSourceDeclarationListNode(source []byte, openBrace, closeBrace u
 	return newParentNodeInArena(arena, sym, named, buf, nil, 0), true
 }
 
-func csharpRecoverNonEmptyTypeDeclarationFromError(n *Node, source []byte, p *Parser, lang *Language, arena *nodeArena) (*Node, bool) {
+func csharpRecoverNonEmptyTypeDeclarationFromError(n *Node, source []byte, p *Parser, lang *Language, arena *nodeArena, lenient bool) (*Node, bool) {
 	if n == nil || lang == nil || arena == nil || n.Type(lang) != "ERROR" || len(n.children) == 0 {
 		return nil, false
 	}
-	return csharpRecoverNonEmptyTypeDeclarationFromChildSlice(n.children, 0, source, p, lang, arena)
+	return csharpRecoverNonEmptyTypeDeclarationFromChildSlice(n.children, 0, source, p, lang, arena, lenient)
 }
 
-func csharpRecoverNonEmptyTopLevelTypeDeclarationFromChildren(children []*Node, startIdx int, source []byte, p *Parser, lang *Language, arena *nodeArena) (*Node, int, bool) {
+func csharpRecoverNonEmptyTopLevelTypeDeclarationFromChildren(children []*Node, startIdx int, source []byte, p *Parser, lang *Language, arena *nodeArena, lenient bool) (*Node, int, bool) {
 	if startIdx < 0 || startIdx >= len(children) || lang == nil || arena == nil {
 		return nil, startIdx, false
 	}
-	recovered, ok := csharpRecoverNonEmptyTypeDeclarationFromChildSlice(children[startIdx:], 0, source, p, lang, arena)
+	recovered, ok := csharpRecoverNonEmptyTypeDeclarationFromChildSlice(children[startIdx:], 0, source, p, lang, arena, lenient)
 	if !ok || recovered == nil {
 		return nil, startIdx, false
 	}
@@ -367,7 +367,7 @@ func csharpRecoverNonEmptyTopLevelTypeDeclarationFromChildren(children []*Node, 
 	return recovered, nextIdx, true
 }
 
-func csharpRecoverNonEmptyTypeDeclarationFromChildSlice(children []*Node, startIdx int, source []byte, p *Parser, lang *Language, arena *nodeArena) (*Node, bool) {
+func csharpRecoverNonEmptyTypeDeclarationFromChildSlice(children []*Node, startIdx int, source []byte, p *Parser, lang *Language, arena *nodeArena, lenient bool) (*Node, bool) {
 	if startIdx < 0 || startIdx >= len(children) || lang == nil || arena == nil {
 		return nil, false
 	}
@@ -385,7 +385,7 @@ func csharpRecoverNonEmptyTypeDeclarationFromChildSlice(children []*Node, startI
 			if child == nil || child.Type(lang) != spec.initName {
 				continue
 			}
-			if recovered, ok := csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children[startIdx:], child, source, p, lang, arena, spec.declName); ok {
+			if recovered, ok := csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children[startIdx:], child, source, p, lang, arena, spec.declName, lenient); ok {
 				return recovered, true
 			}
 		}
@@ -393,7 +393,7 @@ func csharpRecoverNonEmptyTypeDeclarationFromChildSlice(children []*Node, startI
 	return nil, false
 }
 
-func csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children []*Node, initNode *Node, source []byte, p *Parser, lang *Language, arena *nodeArena, declName string) (*Node, bool) {
+func csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children []*Node, initNode *Node, source []byte, p *Parser, lang *Language, arena *nodeArena, declName string, lenient bool) (*Node, bool) {
 	if initNode == nil || lang == nil || arena == nil || int(initNode.endByte) > len(source) {
 		return nil, false
 	}
@@ -402,7 +402,7 @@ func csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children []*Node, i
 		return nil, false
 	}
 	openBrace := int(initNode.endByte) + openRel
-	closeBrace := findMatchingBraceByte(source, openBrace, len(source))
+	closeBrace := csharpFindMatchingBraceByte(source, openBrace, len(source))
 	if closeBrace < 0 || closeBrace <= openBrace {
 		return nil, false
 	}
@@ -414,7 +414,7 @@ func csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children []*Node, i
 	if !ok {
 		return nil, false
 	}
-	members, ok := csharpRecoverTypeDeclarationBodyMembers(children, initNode, source, p, lang, arena, uint32(openBrace), uint32(closeBrace))
+	members, ok := csharpRecoverTypeDeclarationBodyMembers(children, initNode, source, p, lang, arena, uint32(openBrace), uint32(closeBrace), lenient)
 	if !ok || len(members) == 0 {
 		return nil, false
 	}
@@ -456,7 +456,7 @@ func csharpBuildRecoveredTypeDeclarationWithBodyFromChildren(children []*Node, i
 	return recovered, true
 }
 
-func csharpRecoverTypeDeclarationBodyMembers(children []*Node, initNode *Node, source []byte, p *Parser, lang *Language, arena *nodeArena, openBrace, closeBrace uint32) ([]*Node, bool) {
+func csharpRecoverTypeDeclarationBodyMembers(children []*Node, initNode *Node, source []byte, p *Parser, lang *Language, arena *nodeArena, openBrace, closeBrace uint32, lenient bool) ([]*Node, bool) {
 	if lang == nil || arena == nil || openBrace >= closeBrace {
 		return nil, false
 	}
@@ -477,10 +477,22 @@ func csharpRecoverTypeDeclarationBodyMembers(children []*Node, initNode *Node, s
 				i++
 				continue
 			}
+			// In lenient mode (namespace-with-internal-errors recovery), an
+			// unrecoverable ERROR fragment is skipped rather than failing the
+			// whole type declaration, so the surrounding class_declaration and
+			// the members that did parse remain in the tree (issue #115).
+			if lenient {
+				i++
+				continue
+			}
 			return nil, false
 		}
 		member, ok := csharpRecoverTypeDeclarationBodyChild(child, lang, arena)
 		if !ok {
+			if lenient {
+				i++
+				continue
+			}
 			return nil, false
 		}
 		members = append(members, member)
@@ -503,6 +515,8 @@ func csharpRecoverTypeDeclarationBodyChild(n *Node, lang *Language, arena *nodeA
 		"interface_declaration",
 		"enum_declaration",
 		"delegate_declaration",
+		"namespace_declaration",
+		"file_scoped_namespace_declaration",
 		"constructor_declaration",
 		"destructor_declaration",
 		"field_declaration",
@@ -532,7 +546,7 @@ func csharpRecoverMethodDeclarationFromChildren(children []*Node, startIdx int, 
 	if openBracePos >= int(enclosingClose) || source[openBracePos] != '{' {
 		return nil, startIdx, false
 	}
-	closeBracePos := findMatchingBraceByte(source, openBracePos, int(enclosingClose))
+	closeBracePos := csharpFindMatchingBraceByte(source, openBracePos, int(enclosingClose))
 	if closeBracePos < 0 || closeBracePos <= openBracePos {
 		return nil, startIdx, false
 	}


### PR DESCRIPTION
## Summary

Fixes #115. Large real-world C# files (e.g. Newtonsoft.Json's `JsonReader.cs`) could parse into a single top-level `ERROR` node, so a tree walk found **0** `class_declaration` / `method_declaration` nodes. Every individual construct parses fine in isolation — it's a cumulative GLR parse failure — so the fix is in the C# recovery normalizers, not the grammar blob.

## Root cause

- `normalizeCSharpRecoveredNamespaces` was all-or-nothing: `csharpRecoverNamespaceNodeFromRange` only succeeded when the whole namespace body re-parsed cleanly. With any internal error it gave up.
- The subsequent `normalizeCSharpRecoveredTypeDeclarations` pass then bailed on the leading `preproc_region` child.
- The brace matcher used during recovery ignored char/string/comment content, truncating spans on files with braces inside char literals (`'{'` / `'}'`).

## Changes

- **Namespace fallback** (`parser_result_csharp_namespace.go`): when the clean extraction fails, synthesise a `namespace_declaration` from the sub-parse that was *already produced* (no extra reparse) and recover its body declarations leniently, so the type declarations and the members that parsed still surface.
- **Lenient member recovery** (`parser_result_csharp_type_body.go`): thread a `lenient` flag so an unrecoverable `ERROR` fragment is skipped instead of failing the whole enclosing type; keep nested namespaces as body children.
- **Trivia-aware brace matching** (`parser_result_csharp_helpers.go`): `csharpFindMatchingBraceByte` skips braces inside line/block comments, regular/verbatim strings, and char literals. Existing C# recovery call sites now use it.
- **Top-level allow-list** (`parser_result_csharp.go`): permit preprocessor directive nodes so a recovered root can retag to `compilation_unit`.

## Bounding

Respects the prior recovery-cost work (#64, #98, #106): the fallback reuses the sub-parse already produced (no new namespace reparse), does a single `O(children)` pass, and leaves the 4096-byte method-body reparse gate and the `csharpMaxNamespaceRecoveries` cap in place. The existing boundedness tests stay green.

## Result

| File | Before | After |
|---|---|---|
| `JsonReader.cs` | single `ERROR`, 0 decls | `compilation_unit`, class + 13 properties |
| `JsonTextWriter.cs` | single `ERROR`, 0 decls | `compilation_unit`, class + 11 methods |
| `JsonTextReader.cs` | single `ERROR`, 0 decls | `compilation_unit`, namespace recovered |

Recovery is best-effort: declarations whose header is shredded into `ERROR` fragments by the GLR failure (e.g. `JsonTextReader`'s class) are not fully reconstructed — that would need source-based reconstruction and is intentionally out of scope here to keep the change bounded. The catastrophic whole-file collapse is gone in all cases.

## Tests

- New regression tests in `parser_csharp_namespace_recovery_test.go` (namespace-with-internal-error recovers declarations; char-literal braces don't truncate the span; clean namespaces are unaffected).
- `go test ./...` is green, including the C# boundedness suite.