### PR TITLE
chore: remove dead unexported code

### DIFF
--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -768,35 +768,6 @@ func unwrapReservedWordRule(rule *Rule) *Rule {
 	return nil
 }
 
-func describeRule(rule *Rule) string {
-	if rule == nil {
-		return "<nil>"
-	}
-	switch rule.Kind {
-	case RuleString:
-		return fmt.Sprintf("STRING(%q)", rule.Value)
-	case RulePattern:
-		return fmt.Sprintf("PATTERN(%q)", rule.Value)
-	case RuleSymbol:
-		return fmt.Sprintf("SYMBOL(%q)", rule.Value)
-	case RuleToken:
-		return fmt.Sprintf("TOKEN(%s)", describeRule(firstRuleChild(rule)))
-	case RuleImmToken:
-		return fmt.Sprintf("IMMEDIATE_TOKEN(%s)", describeRule(firstRuleChild(rule)))
-	case RuleAlias:
-		return fmt.Sprintf("ALIAS(%s, %q)", describeRule(firstRuleChild(rule)), rule.Value)
-	default:
-		return fmt.Sprintf("kind=%d", rule.Kind)
-	}
-}
-
-func firstRuleChild(rule *Rule) *Rule {
-	if rule == nil || len(rule.Children) == 0 {
-		return nil
-	}
-	return rule.Children[0]
-}
-
 // promoteDefaultAliases promotes hidden symbols that always appear with the
 // same alias to be visible under the alias name. Returns a map from the
 // original symbol name to the new (alias) name, so callers can rewrite

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -162,55 +162,6 @@ func cmakeTextInvariantUnquotedByte(b byte) bool {
 		b == '_'
 }
 
-func (p *Parser) tokenInvariantLeafEditCandidate(source []byte, oldTree *Tree) (*Node, InputEdit, bool) {
-	if p == nil || oldTree == nil || oldTree.RootNode() == nil || oldTree.language != p.language {
-		return nil, InputEdit{}, false
-	}
-	if len(oldTree.edits) != 1 {
-		return nil, InputEdit{}, false
-	}
-	edit := oldTree.edits[0]
-	if !inputEditPreservesTokenExtent(edit) {
-		return nil, InputEdit{}, false
-	}
-	if len(source) != len(oldTree.source) {
-		return nil, InputEdit{}, false
-	}
-	return oldTree.RootNode(), edit, true
-}
-
-func inputEditPreservesTokenExtent(edit InputEdit) bool {
-	if edit.NewEndByte-edit.StartByte != edit.OldEndByte-edit.StartByte {
-		return false
-	}
-	return edit.NewEndPoint == edit.OldEndPoint && edit.OldEndByte > edit.StartByte
-}
-
-func tokenInvariantEditedLeaf(root *Node, oldTree *Tree, edit InputEdit) *Node {
-	if root == nil || oldTree == nil {
-		return nil
-	}
-	leaf := oldTree.lastEditedLeaf
-	if leaf == nil || !leaf.containsByteRange(edit.StartByte, edit.OldEndByte) {
-		leaf = root.DescendantForByteRange(edit.StartByte, edit.OldEndByte)
-	}
-	if !tokenInvariantLeafReusable(leaf) {
-		return nil
-	}
-	return leaf
-}
-
-func tokenInvariantLeafReusable(leaf *Node) bool {
-	return leaf != nil && leaf.ChildCount() == 0 && !leaf.hasError() && !leaf.isMissing()
-}
-
-func tokenInvariantReuseStart(timing *incrementalParseTiming) time.Time {
-	if timing != nil {
-		return time.Now()
-	}
-	return time.Time{}
-}
-
 func (p *Parser) scanTokenInvariantEditedLeaf(source []byte, ts TokenSource, leaf *Node) (Token, bool) {
 	tok, ok := scanLeafTokenWithoutMutatingSource(ts, leaf)
 	if ok {
@@ -262,38 +213,6 @@ func skipTokenSourceToLeaf(ts TokenSource, leaf *Node) (Token, bool) {
 		return skipper.SkipToByte(leaf.startByte), true
 	}
 	return Token{}, false
-}
-
-func tokenMatchesLeaf(tok Token, leaf *Node) bool {
-	return leaf != nil && tok.Symbol == leaf.symbol && tok.StartByte == leaf.startByte && tok.EndByte == leaf.endByte
-}
-
-func setTokenInvariantReuseRuntime(tree *Tree, source []byte, tok Token) {
-	tree.setParseRuntime(ParseRuntime{
-		StopReason:       ParseStopAccepted,
-		SourceLen:        uint32(len(source)),
-		TokensConsumed:   1,
-		LastTokenEndByte: tok.EndByte,
-		LastTokenSymbol:  tok.Symbol,
-		ExpectedEOFByte:  uint32(len(source)),
-		RootEndByte:      tree.root.EndByte(),
-		MaxStacksSeen:    1,
-	})
-}
-
-func recordTokenInvariantReuseTiming(timing *incrementalParseTiming, source []byte, tok Token, start time.Time) {
-	if timing != nil {
-		timing.reuseNanos += time.Since(start).Nanoseconds()
-		timing.reusedSubtrees++
-		timing.reusedBytes += uint64(len(source))
-		timing.maxStacksSeen = 1
-		timing.stopReason = ParseStopAccepted
-		timing.tokensConsumed = 1
-		timing.lastTokenEndByte = tok.EndByte
-		timing.expectedEOFByte = uint32(len(source))
-		timing.singleStackIterations = 1
-		timing.singleStackTokens = 1
-	}
 }
 
 func scanLeafTokenWithoutMutatingSource(ts TokenSource, leaf *Node) (Token, bool) {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -423,16 +423,6 @@ func (p *Parser) pushOrExtendErrorNode(s *glrStack, state StateID, tok Token, no
 	}
 }
 
-func reduceChainSignatureFor(state StateID, depth int, act ParseAction) reduceChainSignature {
-	return reduceChainSignature{
-		state:        state,
-		depth:        depth,
-		symbol:       act.Symbol,
-		childCount:   act.ChildCount,
-		productionID: act.ProductionID,
-	}
-}
-
 func noteRepeatedReduceChainSignature(prev reduceChainSignature, prevCount int, next reduceChainSignature) (reduceChainSignature, int, bool) {
 	if prev == next {
 		prevCount++
@@ -3518,19 +3508,6 @@ func reduceChildPathMayDropSpan(path reduceChildPath) bool {
 	default:
 		return true
 	}
-}
-
-func reduceEntriesContainHiddenFieldIDs(entries []stackEntry, start, end int, symbolMeta []SymbolMetadata) bool {
-	for i := start; i < end; i++ {
-		n := stackEntryNode(entries[i])
-		if n == nil || symbolVisibleForPending(n.symbol, symbolMeta) {
-			continue
-		}
-		if hiddenTreeHasFieldIDs(n) {
-			return true
-		}
-	}
-	return false
 }
 
 func (p *Parser) buildReduceChildrenNoAliasNoFieldsPlanned(entries []stackEntry, start, end int, parentSymbol Symbol, symbolMeta []SymbolMetadata, arena *nodeArena) ([]*Node, []FieldID, []uint8, reduceChildPath, bool) {

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -376,35 +376,6 @@ func typeScriptCompatCandidateSymbolsFor(lang *Language) typeScriptCompatCandida
 	return syms
 }
 
-func normalizeJavaScriptTypeScriptStatementKeywordLeaves(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || len(source) == 0 {
-		return
-	}
-	switch lang.Name {
-	case "javascript", "typescript", "tsx":
-	default:
-		return
-	}
-	ifStmtSym, hasIfStmt := symbolByName(lang, "if_statement")
-	whileStmtSym, hasWhileStmt := symbolByName(lang, "while_statement")
-	ifSym, ifNamed, hasIf := symbolMeta(lang, "if")
-	whileSym, whileNamed, hasWhile := symbolMeta(lang, "while")
-	closeBraceSym, hasCloseBrace := symbolByName(lang, "}")
-	if (!hasIfStmt || !hasIf) && (!hasWhileStmt || !hasWhile) {
-		return
-	}
-
-	walkResultTreeDenseFirst(root, func(n *Node) {
-		if hasIfStmt && hasIf && n.symbol == ifStmtSym {
-			normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbol(n, source, "if", ifSym, ifNamed, closeBraceSym, hasCloseBrace)
-			return
-		}
-		if hasWhileStmt && hasWhile && n.symbol == whileStmtSym {
-			normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbol(n, source, "while", whileSym, whileNamed, closeBraceSym, hasCloseBrace)
-		}
-	})
-}
-
 func normalizeJavaScriptTypeScriptStatementKeywordLeavesWithStats(root *Node, source []byte, lang *Language) normalizationPassCounters {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil || len(source) == 0 {
@@ -439,18 +410,6 @@ func normalizeJavaScriptTypeScriptStatementKeywordLeavesWithStats(root *Node, so
 		}
 	})
 	return counters
-}
-
-func normalizeJavaScriptTypeScriptStatementKeywordLeaf(n *Node, source []byte, lang *Language, keyword string) {
-	keywordSym, ok := symbolByName(lang, keyword)
-	if !ok {
-		return
-	}
-	normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbol(n, source, keyword, keywordSym, symbolIsNamed(lang, keywordSym), 0, false)
-}
-
-func normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbol(n *Node, source []byte, keyword string, keywordSym Symbol, keywordNamed bool, closeBraceSym Symbol, hasCloseBrace bool) {
-	_ = normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbolChanged(n, source, keyword, keywordSym, keywordNamed, closeBraceSym, hasCloseBrace)
 }
 
 func normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbolChanged(n *Node, source []byte, keyword string, keywordSym Symbol, keywordNamed bool, closeBraceSym Symbol, hasCloseBrace bool) bool {
@@ -878,28 +837,6 @@ func normalizeJavaScriptTypeScriptOptionalChainLeaves(root *Node, source []byte,
 	})
 }
 
-func normalizeJavaScriptTypeScriptCallPrecedence(root *Node, lang *Language) {
-	if root == nil || lang == nil {
-		return
-	}
-	switch lang.Name {
-	case "javascript", "typescript", "tsx":
-	default:
-		return
-	}
-	callSym, ok := symbolByName(lang, "call_expression")
-	if !ok {
-		return
-	}
-	if lang.Name == "javascript" {
-		_ = normalizeJavaScriptTypeScriptCallPrecedenceFullWalk(root, lang, callSym)
-		return
-	}
-
-	index := buildJavaScriptTypeScriptCallPrecedenceIndex(root, callSym)
-	rewriteJavaScriptTypeScriptCallPrecedenceCandidates(index.candidates, lang, callSym)
-}
-
 func normalizeJavaScriptTypeScriptCallPrecedenceWithStats(root *Node, lang *Language) normalizationPassCounters {
 	return normalizeJavaScriptTypeScriptCallPrecedenceWithDetailedStats(root, lang).normalizationPassCounters
 }
@@ -952,19 +889,6 @@ func normalizeJavaScriptTypeScriptCallPrecedenceFullWalk(root *Node, lang *Langu
 		}
 	})
 	return counters
-}
-
-func normalizeJavaScriptTypeScriptPrecedence(root *Node, lang *Language) {
-	if root == nil || lang == nil {
-		return
-	}
-	if lang.Name == "javascript" {
-		normalizeJavaScriptTypeScriptCallPrecedence(root, lang)
-		normalizeJavaScriptTypeScriptUnaryPrecedence(root, lang)
-		normalizeJavaScriptTypeScriptBinaryPrecedence(root, lang)
-		return
-	}
-	_ = normalizeJavaScriptTypeScriptPrecedenceWithDetailedStats(root, lang)
 }
 
 type javaScriptTypeScriptPrecedenceStats struct {
@@ -1464,14 +1388,6 @@ func replaceJavaScriptTypeScriptPrecedenceCandidate(candidate javaScriptTypeScri
 	return true
 }
 
-func rewriteJavaScriptTypeScriptCallPrecedence(node *Node, lang *Language) *Node {
-	callSym, ok := symbolByName(lang, "call_expression")
-	if !ok {
-		return nil
-	}
-	return rewriteJavaScriptTypeScriptCallPrecedenceWithSymbol(node, lang, callSym)
-}
-
 func rewriteJavaScriptTypeScriptCallPrecedenceWithSymbol(node *Node, lang *Language, callSym Symbol) *Node {
 	if node == nil || lang == nil || node.symbol != callSym || len(node.children) != 2 {
 		return nil
@@ -1587,25 +1503,6 @@ func isJavaScriptTypeScriptCallableShape(node *Node, lang *Language) bool {
 	}
 }
 
-func normalizeJavaScriptTypeScriptUnaryPrecedence(root *Node, lang *Language) {
-	if root == nil || lang == nil {
-		return
-	}
-	switch lang.Name {
-	case "javascript", "typescript", "tsx":
-	default:
-		return
-	}
-	unarySym, ok := symbolByName(lang, "unary_expression")
-	if !ok {
-		return
-	}
-
-	rewriteResultTreeChildrenPostorder(root, func(n *Node) *Node {
-		return rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(n, lang, unarySym)
-	})
-}
-
 func normalizeJavaScriptTypeScriptUnaryPrecedenceWithStats(root *Node, lang *Language) normalizationPassCounters {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {
@@ -1624,53 +1521,6 @@ func normalizeJavaScriptTypeScriptUnaryPrecedenceWithStats(root *Node, lang *Lan
 	return rewriteResultTreeChildrenPostorderWithStats(root, func(n *Node) *Node {
 		return rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(n, lang, unarySym)
 	})
-}
-
-func normalizeJavaScriptTypeScriptUnaryBinaryPrecedence(root *Node, lang *Language) {
-	_ = normalizeJavaScriptTypeScriptUnaryBinaryPrecedenceWithDetailedStats(root, lang)
-}
-
-type javaScriptTypeScriptUnaryBinaryPrecedenceStats struct {
-	unary             normalizationPassCounters
-	binary            normalizationPassCounters
-	indexBuilds       uint64
-	indexNodesVisited uint64
-}
-
-func normalizeJavaScriptTypeScriptUnaryBinaryPrecedenceWithDetailedStats(root *Node, lang *Language) javaScriptTypeScriptUnaryBinaryPrecedenceStats {
-	var stats javaScriptTypeScriptUnaryBinaryPrecedenceStats
-	if root == nil || lang == nil {
-		return stats
-	}
-	switch lang.Name {
-	case "javascript", "typescript", "tsx":
-	default:
-		return stats
-	}
-	unarySym, ok := symbolByName(lang, "unary_expression")
-	if !ok {
-		return stats
-	}
-	binarySym, ok := symbolByName(lang, "binary_expression")
-	if !ok {
-		return stats
-	}
-
-	index := buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root, unarySym, binarySym)
-	stats.indexBuilds += index.builds
-	stats.indexNodesVisited += index.nodesVisited
-	stats.unary = rewriteJavaScriptTypeScriptPrecedenceCandidates(index.unaryCandidates, func(n *Node) *Node {
-		return rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(n, lang, unarySym)
-	})
-	if stats.unary.nodesRewritten != 0 {
-		index = buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root, unarySym, binarySym)
-		stats.indexBuilds += index.builds
-		stats.indexNodesVisited += index.nodesVisited
-	}
-	stats.binary = rewriteJavaScriptTypeScriptPrecedenceCandidates(index.binaryCandidates, func(n *Node) *Node {
-		return rewriteJavaScriptTypeScriptBinaryPrecedenceWithSymbol(n, lang, binarySym)
-	})
-	return stats
 }
 
 type javaScriptTypeScriptUnaryBinaryPrecedenceIndex struct {
@@ -1742,14 +1592,6 @@ func rewriteJavaScriptTypeScriptPrecedenceCandidates(candidates []javaScriptType
 	return counters
 }
 
-func rewriteJavaScriptTypeScriptUnaryPrecedence(node *Node, lang *Language) *Node {
-	unarySym, ok := symbolByName(lang, "unary_expression")
-	if !ok {
-		return nil
-	}
-	return rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(node, lang, unarySym)
-}
-
 func rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(node *Node, lang *Language, unarySym Symbol) *Node {
 	if node == nil || lang == nil || node.symbol != unarySym || len(node.children) < 2 {
 		return nil
@@ -1777,25 +1619,6 @@ func rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(node *Node, lang *Lang
 	return rewrittenBinary
 }
 
-func normalizeJavaScriptTypeScriptBinaryPrecedence(root *Node, lang *Language) {
-	if root == nil || lang == nil {
-		return
-	}
-	switch lang.Name {
-	case "javascript", "typescript", "tsx":
-	default:
-		return
-	}
-	binarySym, ok := symbolByName(lang, "binary_expression")
-	if !ok {
-		return
-	}
-
-	rewriteResultTreeChildrenPostorder(root, func(n *Node) *Node {
-		return rewriteJavaScriptTypeScriptBinaryPrecedenceWithSymbol(n, lang, binarySym)
-	})
-}
-
 func normalizeJavaScriptTypeScriptBinaryPrecedenceWithStats(root *Node, lang *Language) normalizationPassCounters {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {
@@ -1814,14 +1637,6 @@ func normalizeJavaScriptTypeScriptBinaryPrecedenceWithStats(root *Node, lang *La
 	return rewriteResultTreeChildrenPostorderWithStats(root, func(n *Node) *Node {
 		return rewriteJavaScriptTypeScriptBinaryPrecedenceWithSymbol(n, lang, binarySym)
 	})
-}
-
-func rewriteJavaScriptTypeScriptBinaryPrecedence(node *Node, lang *Language) *Node {
-	binarySym, ok := symbolByName(lang, "binary_expression")
-	if !ok {
-		return nil
-	}
-	return rewriteJavaScriptTypeScriptBinaryPrecedenceWithSymbol(node, lang, binarySym)
 }
 
 func rewriteJavaScriptTypeScriptBinaryPrecedenceWithSymbol(node *Node, lang *Language, binarySym Symbol) *Node {

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -368,9 +368,8 @@ func normalizePythonFusedPreorder(root *Node, source []byte, parser *Parser, lan
 	}
 }
 
-// applyCollapsedKeywordRewrite mirrors the inner switch of
-// normalizePythonCollapsedKeywordStatementWithStats for use inside the fused
-// dispatcher. Returns true on rewrite.
+// applyCollapsedKeywordRewrite performs the collapsed-keyword statement rewrite
+// for use inside the fused dispatcher. Returns true on rewrite.
 func applyCollapsedKeywordRewrite(n *Node, lang *Language, ck pythonCollapsedKeywordSetup) bool {
 	switch {
 	case n.symbol == ck.statementSym:
@@ -563,44 +562,6 @@ func normalizePythonStarCollapsedChildrenWithStats(root *Node, source []byte, la
 	return counters
 }
 
-func normalizePythonInlineRaiseBlocksWithStats(root *Node, lang *Language) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if root == nil || lang == nil {
-		return counters
-	}
-	raiseStmtSym, ok := lang.symbolByNameAndNamed("raise_statement", true)
-	if !ok {
-		raiseStmtSym, ok = symbolByName(lang, "raise_statement")
-	}
-	if !ok {
-		return counters
-	}
-	walkResultTree(root, func(n *Node) {
-		counters.nodesVisited++
-		childCount := resultChildCount(n)
-		if childCount < 1 || n.Type(lang) != "block" || n.startPoint.Row != n.endPoint.Row {
-			return
-		}
-		first := resultChildAt(n, 0)
-		last := resultChildAt(n, childCount-1)
-		if first == nil || last == nil || first.Type(lang) != "raise" {
-			return
-		}
-		children := resultChildSliceForMutation(n)
-		stmtChildren := cloneNodeSliceInArena(n.ownerArena, children)
-		stmt := newParentNodeInArena(n.ownerArena, raiseStmtSym, true, stmtChildren, nil, 0)
-		stmt.startByte = first.startByte
-		stmt.endByte = last.endByte
-		stmt.startPoint = first.startPoint
-		stmt.endPoint = last.endPoint
-		stmt.parent = n
-		stmt.childIndex = 0
-		n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{stmt})
-		counters.nodesRewritten++
-	})
-	return counters
-}
-
 func normalizePythonAssignmentRightExpressionListsWithStats(root *Node, lang *Language) normalizationPassCounters {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {
@@ -634,166 +595,6 @@ func normalizePythonAssignmentRightExpressionListsWithStats(root *Node, lang *La
 				counters.nodesRewritten++
 				return
 			}
-		}
-	})
-	return counters
-}
-
-func normalizePythonInlineTupleExpressionBlocksWithStats(root *Node, lang *Language) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if root == nil || lang == nil {
-		return counters
-	}
-	tupleSym, ok := symbolByName(lang, "tuple_expression")
-	if !ok {
-		return counters
-	}
-	tupleNamed := symbolIsNamed(lang, tupleSym)
-	walkResultTree(root, func(n *Node) {
-		counters.nodesVisited++
-		childCount := resultChildCount(n)
-		if childCount < 3 || n.Type(lang) != "block" || n.startPoint.Row != n.endPoint.Row {
-			return
-		}
-		hasComma := false
-		for i := 0; i < childCount; i++ {
-			child := resultChildAt(n, i)
-			if child != nil && child.Type(lang) == "," {
-				hasComma = true
-				break
-			}
-		}
-		if !hasComma {
-			return
-		}
-		children := resultChildSliceForMutation(n)
-		stmtChildren := cloneNodeSliceInArena(n.ownerArena, children)
-		stmt := newParentNodeInArena(n.ownerArena, tupleSym, tupleNamed, stmtChildren, nil, 0)
-		stmt.startByte = children[0].startByte
-		stmt.endByte = children[len(children)-1].endByte
-		stmt.startPoint = children[0].startPoint
-		stmt.endPoint = children[len(children)-1].endPoint
-		stmt.parent = n
-		stmt.childIndex = 0
-		n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{stmt})
-		counters.nodesRewritten++
-	})
-	return counters
-}
-
-func normalizePythonInlineYieldBlocksWithStats(root *Node, lang *Language) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if root == nil || lang == nil {
-		return counters
-	}
-	yieldSym, ok := lang.symbolByNameAndNamed("yield", true)
-	if !ok {
-		return counters
-	}
-	walkResultTree(root, func(n *Node) {
-		counters.nodesVisited++
-		childCount := resultChildCount(n)
-		if childCount < 1 || n.Type(lang) != "block" || n.startPoint.Row != n.endPoint.Row {
-			return
-		}
-		first := resultChildAt(n, 0)
-		last := resultChildAt(n, childCount-1)
-		if first == nil || last == nil || first.Type(lang) != "yield" || first.IsNamed() {
-			return
-		}
-		children := resultChildSliceForMutation(n)
-		stmtChildren := cloneNodeSliceInArena(n.ownerArena, children)
-		stmt := newParentNodeInArena(n.ownerArena, yieldSym, true, stmtChildren, nil, 0)
-		stmt.startByte = first.startByte
-		stmt.endByte = last.endByte
-		stmt.startPoint = first.startPoint
-		stmt.endPoint = last.endPoint
-		stmt.parent = n
-		stmt.childIndex = 0
-		n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{stmt})
-		counters.nodesRewritten++
-	})
-	return counters
-}
-
-func normalizePythonInlineReturnBlocksWithStats(root *Node, source []byte, lang *Language) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if root == nil || lang == nil || len(source) == 0 {
-		return counters
-	}
-	returnStmtSym, ok := lang.symbolByNameAndNamed("return_statement", true)
-	if !ok {
-		returnStmtSym, ok = symbolByName(lang, "return_statement")
-	}
-	if !ok {
-		return counters
-	}
-	walkResultTree(root, func(n *Node) {
-		counters.nodesVisited++
-		childCount := resultChildCount(n)
-		if childCount < 1 || n.Type(lang) != "block" || n.startPoint.Row != n.endPoint.Row {
-			return
-		}
-		first := resultChildAt(n, 0)
-		last := resultChildAt(n, childCount-1)
-		if first == nil || last == nil || first.Type(lang) != "return" {
-			return
-		}
-		children := resultChildSliceForMutation(n)
-		stmtChildren := cloneNodeSliceInArena(n.ownerArena, children)
-		stmt := newParentNodeInArena(n.ownerArena, returnStmtSym, true, stmtChildren, nil, 0)
-		stmt.startByte = first.startByte
-		stmt.endByte = last.endByte
-		stmt.startPoint = first.startPoint
-		stmt.endPoint = last.endPoint
-		stmt.parent = n
-		stmt.childIndex = 0
-		n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{stmt})
-		counters.nodesRewritten++
-	})
-	return counters
-}
-
-func normalizePythonCollapsedKeywordStatementWithStats(root *Node, source []byte, lang *Language, statementName, keywordName string) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if root == nil || lang == nil || len(source) == 0 {
-		return counters
-	}
-	statementSym, statementOK := lang.symbolByNameAndNamed(statementName, true)
-	if !statementOK {
-		statementSym, statementOK = symbolByName(lang, statementName)
-	}
-	keywordSym, keywordOK := lang.symbolByNameAndNamed(keywordName, false)
-	if !keywordOK {
-		keywordSym, keywordOK = symbolByName(lang, keywordName)
-	}
-	if !statementOK || !keywordOK {
-		return counters
-	}
-	keywordNamed := symbolIsNamed(lang, keywordSym)
-	walkResultTree(root, func(n *Node) {
-		counters.nodesVisited++
-		if resultChildCount(n) != 0 || int(n.endByte) > len(source) || n.startByte >= n.endByte || string(source[n.startByte:n.endByte]) != keywordName {
-			return
-		}
-		switch {
-		case n.symbol == statementSym:
-			child := newLeafNodeInArena(n.ownerArena, keywordSym, keywordNamed, n.startByte, n.endByte, n.startPoint, n.endPoint)
-			child.parent = n
-			child.childIndex = 0
-			n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{child})
-			counters.nodesRewritten++
-		case n.Type(lang) == "block":
-			child := newLeafNodeInArena(n.ownerArena, keywordSym, keywordNamed, n.startByte, n.endByte, n.startPoint, n.endPoint)
-			stmt := newParentNodeInArena(n.ownerArena, statementSym, true, []*Node{child}, nil, 0)
-			stmt.startByte = n.startByte
-			stmt.endByte = n.endByte
-			stmt.startPoint = n.startPoint
-			stmt.endPoint = n.endPoint
-			stmt.parent = n
-			stmt.childIndex = 0
-			n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{stmt})
-			counters.nodesRewritten++
 		}
 	})
 	return counters
@@ -947,7 +748,6 @@ func normalizePythonPatternTargetIdentifiers(root *Node, source []byte, lang *La
 	walk(root)
 	return counters
 }
-
 
 func pythonAsPatternTargetLooksLikeTuple(n *Node, lang *Language, childCount int) bool {
 	if n == nil || childCount < 3 {

--- a/parser_result_typescript.go
+++ b/parser_result_typescript.go
@@ -1234,46 +1234,6 @@ func typeScriptAssignMemberFields(node *Node, ctx *typeScriptNormalizationContex
 	node.fieldSources = defaultFieldSourcesInArena(node.ownerArena, fieldIDs)
 }
 
-func scanTypeScriptIdentifierAfter(source []byte, after uint32) (uint32, uint32, bool) {
-	pos := int(after)
-	for pos < len(source) {
-		switch source[pos] {
-		case ' ', '\t', '\n', '\r':
-			pos++
-			continue
-		}
-		break
-	}
-	if pos >= len(source) || !isTypeScriptIdentifierStartByte(source[pos]) {
-		return 0, 0, false
-	}
-	start := pos
-	pos++
-	for pos < len(source) {
-		ch := source[pos]
-		if ch == '_' || ch == '$' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
-			pos++
-			continue
-		}
-		break
-	}
-	return uint32(start), uint32(pos), true
-}
-
-func typeScriptNextNonspaceByte(source []byte, after uint32) byte {
-	pos := int(after)
-	for pos < len(source) {
-		switch source[pos] {
-		case ' ', '\t', '\n', '\r':
-			pos++
-			continue
-		default:
-			return source[pos]
-		}
-	}
-	return 0
-}
-
 func scanTypeScriptMemberPrefixTokens(source []byte, startByte, endByte uint32, startPoint Point) ([]typeScriptMemberToken, bool) {
 	if int(startByte) >= len(source) || startByte >= endByte || int(endByte) > len(source) {
 		return nil, false
@@ -1733,16 +1693,6 @@ func rewriteTypeScriptInstantiatedCall(node *Node, ctx *typeScriptNormalizationC
 	call := newParentNodeInArena(node.ownerArena, ctx.callSym, ctx.callNamed, children, fieldIDs, node.productionID)
 	call.fieldSources = defaultFieldSourcesInArena(node.ownerArena, fieldIDs)
 	return call
-}
-
-func rewriteTypeScriptAsExpressionCompatibility(node *Node, ctx *typeScriptNormalizationContext) *Node {
-	if node == nil || ctx == nil || ctx.lang == nil {
-		return nil
-	}
-	if rewritten := rewriteTypeScriptAsAssignmentOrTernary(node, ctx); rewritten != nil {
-		return rewritten
-	}
-	return rewriteTypeScriptAsTypeChain(node, ctx)
 }
 
 func rewriteTypeScriptAsAssignmentOrTernary(node *Node, ctx *typeScriptNormalizationContext) *Node {

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -97,13 +97,6 @@ func treeParseClean(tree *Tree) bool {
 	return rt.StopReason == ParseStopAccepted && !rt.Truncated && !rt.TokenSourceEOFEarly
 }
 
-func rootOrNil(tree *Tree) *Node {
-	if tree == nil {
-		return nil
-	}
-	return tree.RootNode()
-}
-
 func rawRootOrNil(tree *Tree) *Node {
 	if tree == nil {
 		return nil

--- a/parser_tables.go
+++ b/parser_tables.go
@@ -314,17 +314,6 @@ func (p *Parser) forEachActionIndexInState(state StateID, visit func(sym Symbol,
 	}
 }
 
-func (p *Parser) lookupActionIndexDense(state StateID, sym Symbol) uint16 {
-	if int(state) >= len(p.language.ParseTable) {
-		return 0
-	}
-	row := p.language.ParseTable[state]
-	if int(sym) >= len(row) {
-		return 0
-	}
-	return row[sym]
-}
-
 func (p *Parser) lookupActionIndexSmall(state StateID, sym Symbol) uint16 {
 	// Small (compressed sparse) table lookup.
 	smallIdx := int(state) - p.smallBase

--- a/runtime_audit.go
+++ b/runtime_audit.go
@@ -42,10 +42,6 @@ type runtimeAuditEquivStateInfo struct {
 	stackEquivPairRepeatFalse             uint64
 	stackEquivPairRepeatMismatch          uint64
 	stackEquivPairStores                  uint64
-	mergeHeaderEqTotal                    uint64
-	mergeDeepTrue                         uint64
-	mergeDeepFalse                        uint64
-	mergeHeaderDeepDivergent              uint64
 	equivCacheLookups                     uint64
 	equivCacheHits                        uint64
 	equivCacheStores                      uint64
@@ -651,10 +647,6 @@ func (a *runtimeAudit) recordStackEquivHashMismatch() {
 	}
 }
 
-func (a *runtimeAudit) recordStackEquivStateMismatch() {
-	a.recordStackEquivStateMismatchAt(-1)
-}
-
 func (a *runtimeAudit) recordStackEquivStateMismatchAt(depthFromTop int) {
 	if a == nil || !a.equivEnabled {
 		return
@@ -665,10 +657,6 @@ func (a *runtimeAudit) recordStackEquivStateMismatchAt(depthFromTop int) {
 		state.stackEquivStateMismatch++
 		recordStackEquivMismatchDepth(&state.stackEquivStateMismatchDepthSum, &state.stackEquivStateMismatchMaxDepth, &state.stackEquivStateMismatchDepthBuckets, depthFromTop)
 	}
-}
-
-func (a *runtimeAudit) recordStackEquivPayloadMismatch() {
-	a.recordStackEquivPayloadMismatchAt(-1)
 }
 
 func (a *runtimeAudit) recordStackEquivPayloadMismatchAt(depthFromTop int) {

--- a/tree.go
+++ b/tree.go
@@ -2148,14 +2148,6 @@ func (a *nodeArena) recordReduceChildSliceAllVisible(n int) {
 	a.reduceChildPointersAllVisible += uint64(n)
 }
 
-func (a *nodeArena) recordReduceChildSliceNoAlias(n int) {
-	if a == nil || !a.breakdownEnabled || n <= 0 {
-		return
-	}
-	a.reduceChildSlicesNoAlias++
-	a.reduceChildPointersNoAlias += uint64(n)
-}
-
 func (a *nodeArena) recordReduceChildSliceScratchGeneral(n int) {
 	if a == nil || !a.breakdownEnabled || n <= 0 {
 		return


### PR DESCRIPTION
## Summary

Removes unexported functions, methods, a type, and struct fields that are never referenced anywhere in the module. Each removal was confirmed two ways:

- `staticcheck -checks U1000` (reachability analysis) flags them as unused, and reports **clean** after the change;
- a full-repo grep finds zero references outside each definition, including from `_test.go` files and under all build tags.

No exported/public API is touched, so the library surface is unchanged.

## What's removed

- **incremental_leaf_fastpath.go** — the unused token-invariant leaf-reuse helper cluster (`tokenInvariantLeafEditCandidate`, `inputEditPreservesTokenExtent`, `tokenInvariantEditedLeaf`, `tokenInvariantLeafReusable`, `tokenInvariantReuseStart`, `tokenMatchesLeaf`, `setTokenInvariantReuseRuntime`, `recordTokenInvariantReuseTiming`).
- **parser_result_javascript_typescript.go** — the unused JS/TS precedence-normalization subsystem (`normalize`/`rewrite` `*Precedence` variants, keyword-leaf helpers, and the `javaScriptTypeScriptUnaryBinaryPrecedenceStats` type).
- **parser_result_python.go** — the unused `*WithStats` inline-block normalizers.
- **parser_result_typescript.go** — `scanTypeScriptIdentifierAfter`, `typeScriptNextNonspaceByte`, `rewriteTypeScriptAsExpressionCompatibility`.
- **parser_reduce.go** — `reduceChainSignatureFor`, `reduceEntriesContainHiddenFieldIDs`.
- **parser_retry.go** — `rootOrNil`.
- **parser_tables.go** — `(*Parser).lookupActionIndexDense`.
- **runtime_audit.go** — `(*runtimeAudit).recordStackEquivStateMismatch` / `recordStackEquivPayloadMismatch` and their four now-unused counter fields.
- **tree.go** — `(*nodeArena).recordReduceChildSliceNoAlias`.
- **grammargen/normalize.go** — `describeRule`, `firstRuleChild`.

These are superseded experiments and helpers; if any is wanted again it remains in git history.

## Not removed

The build-tag-gated `perfRecordReduceChildrenNoAlias` stub in `perf_metrics_stub.go` is intentionally left in place — it is one half of a matched `//go:build perf` / `//go:build !perf` stub/impl pair, and staticcheck only sees the inactive side under default tags.

## Verification

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- `staticcheck -checks U1000 ./...` is clean afterwards (aside from the intentionally-retained perf stub).
- The diff is deletion-only (plus a one-line doc-comment reword that referenced a removed function); no unrelated reformatting.