### PR TITLE
fix: no node is its own descendant (golang) -> replaced by #121

### DIFF
--- a/parser_result_cycle_guard.go
+++ b/parser_result_cycle_guard.go
@@ -1,0 +1,66 @@
+package gotreesitter
+
+// stripResultTreeSelfCycles enforces the structural invariant that no node is
+// its own descendant.
+//
+// On recovered input the GLR start-symbol reduce can encode a final-child-ref
+// that points back at the parent node itself — e.g. a `source_file` whose
+// materialized child at some index is the same `source_file` pointer. The raw
+// .children slice looks fine, but the materialized child view is cyclic, so
+// every subsequent full tree walk (parent-link wiring, the go-compat
+// normalizers, recovery whitespace trimming, …) recurses or loops without end,
+// producing a fatal stack overflow or an indefinite hang.
+//
+// This pass walks the tree once with an explicit stack and a visited set, so it
+// terminates even on an already-cyclic graph. For every node it materializes
+// the children (which clears the arena refs and makes .children authoritative),
+// then drops any child edge that points at the node itself or at an ancestor on
+// the current path. The result is an acyclic tree the rest of the pipeline can
+// safely traverse. See issue #110.
+func stripResultTreeSelfCycles(root *Node) {
+	if root == nil {
+		return
+	}
+	type frame struct {
+		n   *Node
+		idx int
+	}
+	black := make(map[*Node]struct{})
+	onPath := map[*Node]struct{}{root: {}}
+	stack := []frame{{root, 0}}
+
+	for len(stack) > 0 {
+		i := len(stack) - 1
+		n := stack[i].n
+		children := nodeChildrenForReason(n, materializeForNormalization)
+
+		descended := false
+		for stack[i].idx < len(children) {
+			c := children[stack[i].idx]
+			if c == nil {
+				stack[i].idx++
+				continue
+			}
+			if _, ancestor := onPath[c]; c == n || ancestor {
+				n.children = append(children[:stack[i].idx], children[stack[i].idx+1:]...)
+				children = n.children
+				continue
+			}
+			if _, done := black[c]; done {
+				stack[i].idx++
+				continue
+			}
+			stack[i].idx++
+			onPath[c] = struct{}{}
+			stack = append(stack, frame{c, 0})
+			descended = true
+			break
+		}
+		if descended {
+			continue
+		}
+		delete(onPath, n)
+		black[n] = struct{}{}
+		stack = stack[:len(stack)-1]
+	}
+}

--- a/parser_result_cycle_guard_test.go
+++ b/parser_result_cycle_guard_test.go
@@ -1,0 +1,36 @@
+package gotreesitter
+
+import "testing"
+
+func TestStripResultTreeSelfCycles(t *testing.T) {
+	// direct self-reference: x is its own child
+	x := &Node{}
+	x.children = []*Node{x}
+	stripResultTreeSelfCycles(x)
+	for _, c := range x.children {
+		if c == x {
+			t.Fatal("self-reference not removed")
+		}
+	}
+
+	// ancestor back-edge: a -> b -> a
+	a := &Node{}
+	b := &Node{}
+	a.children = []*Node{b}
+	b.children = []*Node{a}
+	stripResultTreeSelfCycles(a)
+	for _, c := range b.children {
+		if c == a {
+			t.Fatal("ancestor back-edge not removed")
+		}
+	}
+
+	// clean tree must be left untouched
+	leaf := &Node{}
+	mid := &Node{children: []*Node{leaf}}
+	root := &Node{children: []*Node{mid}}
+	stripResultTreeSelfCycles(root)
+	if len(root.children) != 1 || root.children[0] != mid || len(mid.children) != 1 || mid.children[0] != leaf {
+		t.Fatal("clean tree was mutated")
+	}
+}

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -128,6 +128,9 @@ func (b *resultRootBuild) syntheticRootSymbol(originalNodes, rootChildren []*Nod
 	if b.isLanguage("swift") {
 		return b.expectedRootSymbol
 	}
+	if b.isLanguage("go") {
+		return b.expectedRootSymbol
+	}
 	return errorSymbol
 }
 
@@ -353,6 +356,9 @@ func extendResultRootRangeToExtras(root *Node, extras []*Node) {
 func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*Node, wireParentLinks, extendTrailing bool) {
 	if root == nil {
 		return
+	}
+	if root.hasError() {
+		stripResultTreeSelfCycles(root)
 	}
 	timing := p.currentMaterializationTiming()
 	finalizeStart := materializationTimingStart(timing)


### PR DESCRIPTION
Fix hang/stack overflow on some Go files (#110 )
  
Some Go files (e.g. the stdlib's cmd/compile/internal/noder/reader.go, and packages like net/encoding/runtime) hang forever on main, or stack-overflow on v0.20.2.

Cause: on recovered input, the Go start-symbol reduce can leave a source_file node that has itself as a materialized child (node.children[i] == node). Raw .children looks fine, but the materialized view is cyclic, so every full tree walk loops — wireParentLinksWithScratch first, then the compat normalizers, etc. That's why it surfaces in different functions.

Fix: stripResultTreeSelfCycles, run at the top of finalizeResultRoot before anything walks the tree. It's a bounded DFS that drops any child edge pointing back at the node itself or an ancestor. Gated on root.hasError(), so clean parses are unaffected.

Verified: those files now parse with no hang/crash, full suite passes, added a unit test.
Complements #112 (which gives the proper source_file root); this is the part that stops the hang.