### PR TITLE
fix(swift): recover functions when a for…in iterable is a range or call expression (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Swift functions that iterate a `for…in` loop over a range (`0..<n`, `0...n`)
+  or a call expression (`stride(from:to:by:)`) no longer silently collapse to
+  `_modifierless_function_declaration_no_body` with the loop body spilled out as
+  file-level siblings. As with the `if`/`while` case, the loop body brace was
+  being consumed as a trailing closure of the iterable; recovery now re-parses
+  the affected `for…in` headers with synthetic parentheses around the iterable
+  and maps the result back to byte-faithful original coordinates. Because this
+  misparse produced no `ERROR` node, the recovery pass now runs whenever the
+  detection walk finds a collapsed header rather than only on errored trees
+  (#123).
+
 ## [0.20.5] - 2026-06-24
 
 ### Changed

--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -223,6 +223,82 @@ func TestSwiftComparisonConditionTreeIsFaithful(t *testing.T) {
 	}
 }
 
+// issue #123: a `for…in` loop whose iterable is a range (`0..<n`, `0...n`) or a
+// call expression (`stride(from:to:by:)`) used to make the loop body brace be
+// consumed as a trailing closure, silently collapsing the enclosing function to
+// _modifierless_function_declaration_no_body (with no ERROR node) and spilling
+// the body statements out as siblings.
+func TestSwiftForRangeIterableRecoversFunction(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"half-open-range", "func f(n: Int) -> Int {\n  var t = 0\n  for i in 0..<n { t += i }\n  return t\n}"},
+		{"closed-range", "func f(n: Int) -> Int {\n  var t = 0\n  for i in 0...n { t += i }\n  return t\n}"},
+		{"spaced-range", "func f(n: Int) -> Int {\n  var t = 0\n  for i in 0 ..< n { t += i }\n  return t\n}"},
+		{"stride-call", "func f(n: Int) -> Int {\n  var t = 0\n  for i in stride(from: 0, to: n, by: 1) { t += i }\n  return t\n}"},
+		{"class-method", "class C {\n  func f(n: Int) -> Int {\n    var t = 0\n    for i in 0..<n { t += i }\n    return t\n  }\n}"},
+		{"struct-method", "struct S {\n  func f(n: Int) {\n    for i in 0...n { print(i) }\n  }\n}"},
+		{"destructuring", "func f() { for (a, b) in zip(xs, ys) { print(a, b) } }"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("recovered tree still reports error: %s", root.SExpr(lang))
+			}
+			if got, want := root.EndByte(), uint32(len(src)); got != want {
+				t.Fatalf("root end = %d, want %d (span not byte-faithful): %s", got, want, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "function_declaration"); got < 1 {
+				t.Fatalf("function_declaration count = %d, want >= 1: %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "for_statement"); got < 1 {
+				t.Fatalf("for_statement count = %d, want >= 1: %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "_modifierless_function_declaration_no_body"); got != 0 {
+				t.Fatalf("function collapsed to _modifierless_function_declaration_no_body: %s", root.SExpr(lang))
+			}
+			// The synthetic parenthesis used during recovery must be unwrapped, not
+			// left as a tuple_expression iterable.
+			if countSwiftNodeType(lang, root, "tuple_expression") != 0 {
+				t.Fatalf("synthetic parenthesis leaked as tuple_expression: %s", root.SExpr(lang))
+			}
+		})
+	}
+}
+
+// TestSwiftForBareIdentifierUnaffected guards against the recovery pass disturbing
+// a for…in over a bare identifier, which already parses correctly.
+func TestSwiftForBareIdentifierUnaffected(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("func f(xs: [Int]) -> Int {\n  var t = 0\n  for x in xs { t += x }\n  return t\n}")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("clean for…in source reported error: %s", root.SExpr(lang))
+	}
+	if countSwiftNodeType(lang, root, "for_statement") != 1 {
+		t.Fatalf("expected exactly one for_statement: %s", root.SExpr(lang))
+	}
+	if countSwiftNodeType(lang, root, "tuple_expression") != 0 {
+		t.Fatalf("recovery pass wrapped a clean iterable in tuple_expression: %s", root.SExpr(lang))
+	}
+}
+
 // TestSwiftNormalTrailingClosureUnaffected guards against the recovery pass
 // disturbing a legitimate trailing closure (which must stay a lambda_literal).
 func TestSwiftNormalTrailingClosureUnaffected(t *testing.T) {

--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -241,6 +241,10 @@ func TestSwiftForRangeIterableRecoversFunction(t *testing.T) {
 		{"class-method", "class C {\n  func f(n: Int) -> Int {\n    var t = 0\n    for i in 0..<n { t += i }\n    return t\n  }\n}"},
 		{"struct-method", "struct S {\n  func f(n: Int) {\n    for i in 0...n { print(i) }\n  }\n}"},
 		{"destructuring", "func f() { for (a, b) in zip(xs, ys) { print(a, b) } }"},
+		// The loop variable is a backtick-escaped keyword, not the `in` separator.
+		{"backtick-var", "func f(n: Int) { for `in` in 0..<n { print(`in`) } }"},
+		// A Unicode loop variable must not be split at the `in` substring boundary.
+		{"unicode-var", "func f(n: Int) { for π in 0..<n { print(π) } }"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -221,11 +221,14 @@ func swiftFindForInKeywordEnd(source []byte, start uint32) (uint32, bool) {
 			}
 		}
 		// The loop separator is the first word-boundaried `in` at depth zero.
+		// Skip a backtick-escaped identifier `` `in` ``, which is a loop variable
+		// name and not the keyword.
 		if depth == 0 && b == 'i' && i+1 < n && source[i+1] == 'n' {
+			backticked := i > 0 && source[i-1] == '`' && i+2 < n && source[i+2] == '`'
 			beforeOK := i == 0 || !isSwiftWordByte(source[i-1])
 			after := i + 2
 			afterOK := after >= n || !isSwiftWordByte(source[after])
-			if beforeOK && afterOK {
+			if !backticked && beforeOK && afterOK {
 				return after, true
 			}
 		}
@@ -234,8 +237,12 @@ func swiftFindForInKeywordEnd(source []byte, start uint32) (uint32, bool) {
 	return 0, false
 }
 
+// isSwiftWordByte reports whether b can be part of a Swift identifier. Any UTF-8
+// continuation/lead byte (>= 0x80) counts, since Swift identifiers admit Unicode
+// characters (e.g. Greek letters, emoji) — so `inπ`/`πin` is not mistaken for a
+// bare `in` keyword.
 func isSwiftWordByte(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b >= 0x80
 }
 
 // swiftConditionParenPositions returns the byte offsets at which to insert the

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -1,18 +1,25 @@
 package gotreesitter
 
-// Swift control-flow conditions: trailing-closure ambiguity recovery (issue #118).
+// Swift control-flow trailing-closure ambiguity recovery (issues #118, #123).
 //
-// The Swift grammar misparses a binary/comparison operator in an if/while
-// condition, e.g. `if x > 0 { foo() }`. The body `{ foo() }` is greedily
-// consumed as a *trailing closure* of the last operand (`0 { foo() }` →
-// call_expression(0, lambda_literal{...})), so the control-flow statement loses
-// its body and the surrounding function/type collapses into ERROR nodes — no
-// function_declaration survives and symbol extraction yields nothing.
+// The Swift grammar misparses a control-flow header whose expression ends in a
+// value that can take a trailing closure, because the following statement body
+// brace is greedily consumed as that trailing closure:
 //
-// Swift's real grammar forbids trailing closures in a control-flow condition;
-// wrapping the condition in parentheses removes the ambiguity (`if (x > 0) {…}`
-// parses cleanly). This pass detects each affected condition, reparses the
-// source with synthetic parentheses around those conditions, then maps the
+//   - if/while condition with a comparison operator (#118): `if x > 0 { foo() }`
+//     parses as `... 0 { foo() }` → call_expression(0, lambda_literal{...}), so
+//     the body is lost and the function collapses into ERROR nodes.
+//   - for…in with a range or call iterable (#123): `for i in 0..<n { t += i }`
+//     parses as `0..<n { ... }` → range_expression(..., call_expression(n,
+//     lambda_literal{...})), so the loop body is swallowed and the enclosing
+//     function silently collapses to _modifierless_function_declaration_no_body
+//     with the body statements re-homed as siblings — and *without* an ERROR
+//     node, so it can't even be detected as a parse failure.
+//
+// Swift's real grammar forbids trailing closures in both positions; wrapping the
+// condition / iterable in parentheses removes the ambiguity (`if (x > 0) {…}`,
+// `for i in (0..<n) {…}` parse cleanly). This pass detects each affected header,
+// reparses the source with synthetic parentheses around it, then maps the
 // recovered tree back to the original byte coordinates — dropping the synthetic
 // parens and unwrapping the synthetic parenthesised expression so the result is
 // byte-faithful to the original source.
@@ -26,7 +33,10 @@ func normalizeSwiftRecoveredTrailingClosureConditions(root *Node, source []byte,
 	if root == nil || p == nil || p.skipRecoveryReparse || lang == nil || root.ownerArena == nil || len(source) == 0 {
 		return
 	}
-	if root.Type(lang) != "source_file" || !root.HasError() {
+	// Note: unlike the if/while case (#118), the for…in collapse (#123) leaves no
+	// ERROR node, so we cannot gate on root.HasError(). Instead we always run the
+	// (cheap) detection walk and bail when it finds nothing to rewrite.
+	if root.Type(lang) != "source_file" {
 		return
 	}
 	inserts := swiftCollectConditionParenInserts(root, source, lang)
@@ -79,30 +89,44 @@ func normalizeSwiftRecoveredTrailingClosureConditions(root *Node, source []byte,
 }
 
 // swiftCollectConditionParenInserts walks the (broken) tree with explicit parent
-// tracking and, for every `if`/`while` keyword token that failed to form its
-// statement, computes a `(`/`)` insertion pair around its condition. The body
-// brace is located by scanning the source forward to the first top-level `{`,
-// skipping comments, strings and bracketed/parenthesised groups.
+// tracking and, for every `if`/`while` keyword that failed to form its statement
+// (#118) and every `for` keyword whose loop failed to form a for_statement
+// (#123), computes a `(`/`)` insertion pair around the trailing-closure-ambiguous
+// expression (the condition, or the for…in iterable). The body brace is located
+// by scanning the source forward to the first top-level `{`, skipping comments,
+// strings and bracketed/parenthesised groups.
 func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language) []swiftParenInsert {
 	var inserts []swiftParenInsert
 	seen := make(map[uint32]bool)
+	add := func(lp, rp uint32, ok bool) {
+		if ok && !seen[lp] {
+			seen[lp] = true
+			inserts = append(inserts, swiftParenInsert{pos: lp, ch: '('})
+			inserts = append(inserts, swiftParenInsert{pos: rp, ch: ')'})
+		}
+	}
 	var walk func(n, parent *Node)
 	walk = func(n, parent *Node) {
 		if n == nil {
 			return
 		}
 		typ := n.Type(lang)
-		if (typ == "if" || typ == "while") && resultChildCount(n) == 0 {
-			parentType := ""
-			if parent != nil {
-				parentType = parent.Type(lang)
-			}
+		parentType := ""
+		if parent != nil {
+			parentType = parent.Type(lang)
+		}
+		switch {
+		case (typ == "if" || typ == "while") && resultChildCount(n) == 0:
 			if parentType != "if_statement" && parentType != "while_statement" {
-				if lp, rp, ok := swiftConditionParenPositions(source, n.endByte); ok && !seen[lp] {
-					seen[lp] = true
-					inserts = append(inserts, swiftParenInsert{pos: lp, ch: '('})
-					inserts = append(inserts, swiftParenInsert{pos: rp, ch: ')'})
-				}
+				lp, rp, ok := swiftConditionParenPositions(source, n.endByte)
+				add(lp, rp, ok)
+			}
+		case typ == "for" && resultChildCount(n) == 0:
+			// A well-formed loop nests the `for` token inside a for_statement;
+			// a collapsed one leaves it dangling under source_file/ERROR/etc.
+			if parentType != "for_statement" {
+				lp, rp, ok := swiftForIterableParenPositions(source, n.endByte)
+				add(lp, rp, ok)
 			}
 		}
 		for i := 0; i < resultChildCount(n); i++ {
@@ -111,6 +135,107 @@ func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language
 	}
 	walk(root, nil)
 	return inserts
+}
+
+// swiftForIterableParenPositions locates the `in` keyword that follows a `for`
+// keyword ending at forKeywordEnd, then reuses the condition logic to bracket the
+// iterable expression between `in` and the loop body brace.
+func swiftForIterableParenPositions(source []byte, forKeywordEnd uint32) (lParen, rParen uint32, ok bool) {
+	inEnd, found := swiftFindForInKeywordEnd(source, forKeywordEnd)
+	if !found {
+		return 0, 0, false
+	}
+	return swiftConditionParenPositions(source, inEnd)
+}
+
+// swiftFindForInKeywordEnd scans forward from start to the loop's `in` keyword at
+// bracket depth zero, skipping line/block comments, string literals and ()/[]
+// nesting (so a destructuring pattern like `for (a, b) in …` is handled). Returns
+// the byte offset just past `in`, or ok=false if a `{`/`}`/`;` at depth zero is
+// reached first (no `in` keyword → not a recoverable for…in header).
+func swiftFindForInKeywordEnd(source []byte, start uint32) (uint32, bool) {
+	depth := 0
+	i := start
+	n := uint32(len(source))
+	for i < n {
+		b := source[i]
+		// Comments.
+		if b == '/' && i+1 < n {
+			if source[i+1] == '/' {
+				i += 2
+				for i < n && source[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			if source[i+1] == '*' {
+				i += 2
+				depthC := 1
+				for i+1 < n && depthC > 0 {
+					if source[i] == '/' && source[i+1] == '*' {
+						depthC++
+						i += 2
+					} else if source[i] == '*' && source[i+1] == '/' {
+						depthC--
+						i += 2
+					} else {
+						i++
+					}
+				}
+				continue
+			}
+		}
+		// Strings.
+		if b == '"' {
+			if i+2 < n && source[i+1] == '"' && source[i+2] == '"' {
+				i += 3
+				for i+2 < n && !(source[i] == '"' && source[i+1] == '"' && source[i+2] == '"') {
+					if source[i] == '\\' {
+						i++
+					}
+					i++
+				}
+				i += 3
+				continue
+			}
+			i++
+			for i < n && source[i] != '"' {
+				if source[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+			continue
+		}
+		switch b {
+		case '(', '[':
+			depth++
+		case ')', ']':
+			if depth > 0 {
+				depth--
+			}
+		case '{', '}', ';':
+			if depth == 0 {
+				return 0, false
+			}
+		}
+		// The loop separator is the first word-boundaried `in` at depth zero.
+		if depth == 0 && b == 'i' && i+1 < n && source[i+1] == 'n' {
+			beforeOK := i == 0 || !isSwiftWordByte(source[i-1])
+			after := i + 2
+			afterOK := after >= n || !isSwiftWordByte(source[after])
+			if beforeOK && afterOK {
+				return after, true
+			}
+		}
+		i++
+	}
+	return 0, false
+}
+
+func isSwiftWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
 }
 
 // swiftConditionParenPositions returns the byte offsets at which to insert the


### PR DESCRIPTION
## Summary

Fixes #123. A Swift `for…in` loop whose iterable is a **range expression** (`0..<n`, `0...n`) or a **call expression** (`stride(from:to:by:)`) had its loop body brace `{ … }` greedily consumed as a *trailing closure* of the iterable. This silently collapsed the enclosing `function_declaration` to `_modifierless_function_declaration_no_body` and re-homed the body statements as `source_file`-level siblings — and crucially produced **no `ERROR` node**, so downstream consumers could not even detect the parse failure.

A `for…in` over a bare identifier (`for x in xs`) already parsed correctly, so the problem was specific to a non-trivial iterable in the `for…in` position.

## Approach

This generalizes the existing trailing-closure **condition** recovery from #118. Swift forbids trailing closures in this grammatical position, and wrapping the iterable in parentheses (`for i in (0..<n) { … }`) removes the ambiguity and parses cleanly.

The recovery pass now also:

- detects a `for` keyword token that failed to nest inside a `for_statement`,
- locates the loop's `in` keyword (bracket/comment/string-aware, so `for (a, b) in …` works),
- inserts synthetic parentheses around the iterable between `in` and the body brace, re-parses, and maps the recovered tree back to byte-faithful original coordinates. The synthetic `tuple_expression` wrapper is unwrapped during remap, so the iterable keeps its original `range_expression` / `call_expression` shape.

Because this misparse leaves **no `ERROR` node**, the pass no longer gates on `root.HasError()`; it always runs the (cheap) detection walk and bails when nothing needs rewriting. The reparse-must-be-clean safety check is retained, so files with unrelated parse errors are left untouched.

## Tests

- `TestSwiftForRangeIterableRecoversFunction` — half-open/closed/spaced ranges, `stride(...)` calls, class/struct methods, and destructuring patterns. Asserts a recovered `function_declaration` + `for_statement`, no `_modifierless_function_declaration_no_body`, no leaked `tuple_expression`, and byte-faithful root span.
- `TestSwiftForBareIdentifierUnaffected` — guards that a clean `for x in xs` is not disturbed.

Existing Swift recovery tests (#118 condition cases, trailing-closure guard) and the full root + grammars suites pass.