### PR TITLE
[codex] fix grammargen precedence string-choice rules

### DIFF
--- a/grammargen/keyword_choice_token_test.go
+++ b/grammargen/keyword_choice_token_test.go
@@ -103,6 +103,79 @@ func TestBareLexicalChoiceBecomesNamedToken(t *testing.T) {
 	}
 }
 
+func TestExplicitPrecStringChoiceBecomesNonterminal(t *testing.T) {
+	g := NewGrammar("explicit_prec_string_choice_nonterminal")
+	g.Define("source_file", Sym("initializer"))
+	g.Define("initializer", Seq(Sym("init_class"), Sym("identifier")))
+	g.Define("init_class", PrecRight(0, Choice(Str("="), Str("+="), Str("-="))))
+	g.Define("identifier", Pat(`[a-z]+`))
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+
+	initClassSym := -1
+	for i, sym := range ng.Symbols {
+		if sym.Name == "init_class" {
+			initClassSym = i
+			if sym.Kind != SymbolNonterminal {
+				t.Fatalf("init_class kind = %v, want SymbolNonterminal", sym.Kind)
+			}
+			if !sym.Visible || !sym.Named {
+				t.Fatalf("init_class metadata = visible:%v named:%v, want visible/named", sym.Visible, sym.Named)
+			}
+			break
+		}
+	}
+	if initClassSym < 0 {
+		t.Fatal("init_class symbol not found")
+	}
+
+	for _, term := range ng.Terminals {
+		if term.SymbolID == initClassSym {
+			t.Fatalf("init_class sym %d was emitted as a terminal", initClassSym)
+		}
+	}
+
+	wantAlts := map[string]bool{"=": false, "+=": false, "-=": false}
+	for _, prod := range ng.Productions {
+		if prod.LHS != initClassSym || len(prod.RHS) != 1 {
+			continue
+		}
+		rhs := prod.RHS[0]
+		if rhs < 0 || rhs >= len(ng.Symbols) {
+			continue
+		}
+		name := ng.Symbols[rhs].Name
+		if _, ok := wantAlts[name]; ok {
+			wantAlts[name] = true
+		}
+	}
+	for name, found := range wantAlts {
+		if !found {
+			t.Fatalf("missing init_class -> %q production", name)
+		}
+	}
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte("+=abc"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("parse has error: %s", root.SExpr(lang))
+	}
+	if got := root.SExpr(lang); got != "(source_file (initializer (init_class) (identifier)))" {
+		t.Fatalf("SExpr = %s, want init_class wrapper", got)
+	}
+}
+
 func TestAliasedInlinePatternWinsSameLengthNamedPatternTie(t *testing.T) {
 	g := NewGrammar("aliased_inline_pattern_precedence")
 	g.Define("source_file", Choice(

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -1158,6 +1158,11 @@ func collectAliasedPatterns(g *Grammar) map[string]aliasInfo {
 //     (if multiple named rules define the same STRING, or the STRING is used
 //     inline in nonterminal rules, the named rule becomes a nonterminal
 //     wrapping the shared anonymous terminal — matching tree-sitter C behavior).
+//
+// Rules like prec.right(choice("=", "+=", "-=")) are not token wrappers:
+// their precedence participates in LR conflict resolution only if the rule is
+// reduced as a nonterminal. Collapsing them into a named DFA token bypasses
+// that conflict and drops the visible wrapper node.
 func classifyRules(g *Grammar) (tokens, nonterms []string) {
 	// Count how many distinct sources each STRING value has.
 	// Sources: named bare-STRING rules + inline STRING usage in nonterminal rules.
@@ -1174,7 +1179,8 @@ func classifyRules(g *Grammar) (tokens, nonterms []string) {
 			// because actions are on the named token symbol that the DFA never emits.
 			isVisible := !strings.HasPrefix(name, "_")
 			isBareString := terminalStringValue(rule) != ""
-			if (isVisible && isBareString) || (isBareString && sharedStrings[terminalStringValue(rule)]) {
+			if (isVisible && isBareString) || (isBareString && sharedStrings[terminalStringValue(rule)]) ||
+				isExplicitPrecedenceStringChoice(rule) {
 				nonterms = append(nonterms, name)
 			} else {
 				tokens = append(tokens, name)
@@ -1255,6 +1261,35 @@ func terminalStringValue(r *Rule) string {
 		}
 	}
 	return ""
+}
+
+func isExplicitPrecedenceStringChoice(r *Rule) bool {
+	sawPrec := false
+	for r != nil {
+		switch r.Kind {
+		case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic:
+			sawPrec = true
+			if len(r.Children) == 0 {
+				return false
+			}
+			r = r.Children[0]
+		default:
+			return sawPrec && isStringChoiceRule(r)
+		}
+	}
+	return false
+}
+
+func isStringChoiceRule(r *Rule) bool {
+	if r == nil || r.Kind != RuleChoice || len(r.Children) == 0 {
+		return false
+	}
+	for _, child := range r.Children {
+		if child == nil || child.Kind != RuleString {
+			return false
+		}
+	}
+	return true
 }
 
 // isTerminalRule returns true if the rule defines a terminal token.


### PR DESCRIPTION
## Summary

- Treat explicit precedence wrappers around finite string choices, such as `prec.right(choice("=", "+=", "-="))`, as reducible nonterminals instead of named DFA tokens.
- Preserve existing behavior for `token(choice(...))` and plain lexical choices that should remain named tokens.
- Add a regression test that verifies the wrapper symbol is a nonterminal, emits productions for each string alternative, is absent from DFA terminals, and parses with the wrapper node intact.

## Why

Addresses #122. The prior classification collapsed precedence-wrapped string-choice rules into lexer tokens, which bypassed LR conflict resolution and dropped the visible wrapper node.

Credit: root-cause report and fix direction by @bmayfi3ld in #122. The commit includes a `Co-authored-by` trailer for Brandon Mayfield.

## Validation

- `go test ./grammargen -run 'TestNamedStringChoiceTokenBecomesKeyword|TestBareLexicalChoiceBecomesNamedToken|TestExplicitPrecStringChoiceBecomesNonterminal|TestAliasedInlinePatternWinsSameLengthNamedPatternTie' -count=1`
- `go test ./grammargen -run 'Test.*(Choice|Prec|Keyword|Alias|Provenance|TerminalCollision)' -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./grammargen -run 'TestExplicitPrecStringChoiceBecomesNonterminal|TestBareLexicalChoiceBecomesNamedToken|TestNamedStringChoiceTokenBecomesKeyword' -count=1"`
