### PR TITLE
[codex] fix recovered result tree self-cycles

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2130,6 +2130,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
 		materializeTransientParentNodes(nodes, arena, scratch.reduce.transientParents, scratch.reduce.transientChildren)
+		for _, n := range nodes {
+			stripResultTreeSelfCycles(n)
+		}
 		tree := p.buildResultFromNodes(nodes, source, arena, oldTree, &reuseState, &scratch.nodeLinks)
 		if root := tree.RootNode(); root != nil {
 			normalizeSQLRecoveredMissingNull(root, arena, p.language)

--- a/parser_result_cycle_guard.go
+++ b/parser_result_cycle_guard.go
@@ -1,0 +1,79 @@
+package gotreesitter
+
+// stripResultTreeSelfCycles enforces that no node is its own descendant.
+//
+// The trailing-EOF error recovery clones the GSS (sharing node payload
+// pointers) and re-reduces, which can leave a recovered node, e.g. a
+// `source_file`, referencing itself as a child. The raw .children slice can
+// look fine while the materialized child view is cyclic, so every later full
+// tree walk (parent-link wiring, the compat normalizers, recovery trimming)
+// recurses or loops without end: a fatal stack overflow or an indefinite hang.
+//
+// This pass walks the tree once with an explicit stack and a visited set, so it
+// terminates even on an already-cyclic graph. For each node it materializes the
+// children (clearing the arena refs so .children becomes authoritative) and
+// drops any child edge that points at the node itself or an ancestor on the
+// current path. It runs only on recovered node trees, so normal parses are
+// untouched.
+//
+// The underlying cycle should ideally be prevented in the recovery clone/reduce
+// itself; this guard keeps the returned tree well-formed in the meantime. See
+// issue #110.
+func stripResultTreeSelfCycles(root *Node) {
+	if root == nil {
+		return
+	}
+	type frame struct {
+		n   *Node
+		idx int
+	}
+	black := make(map[*Node]struct{})
+	onPath := map[*Node]struct{}{root: {}}
+	stack := []frame{{root, 0}}
+
+	for len(stack) > 0 {
+		i := len(stack) - 1
+		n := stack[i].n
+		children := nodeChildrenForReason(n, materializeForNormalization)
+
+		descended := false
+		for stack[i].idx < len(children) {
+			c := children[stack[i].idx]
+			if c == nil {
+				stack[i].idx++
+				continue
+			}
+			if _, ancestor := onPath[c]; ancestor {
+				children = removeResultTreeChildAt(n, children, stack[i].idx)
+				continue
+			}
+			if _, done := black[c]; done {
+				stack[i].idx++
+				continue
+			}
+			stack[i].idx++
+			onPath[c] = struct{}{}
+			stack = append(stack, frame{c, 0})
+			descended = true
+			break
+		}
+		if descended {
+			continue
+		}
+		delete(onPath, n)
+		black[n] = struct{}{}
+		stack = stack[:len(stack)-1]
+	}
+}
+
+func removeResultTreeChildAt(n *Node, children []*Node, idx int) []*Node {
+	oldLen := len(children)
+	n.children = append(children[:idx], children[idx+1:]...)
+	if len(n.fieldIDs) == oldLen {
+		n.fieldIDs = append(n.fieldIDs[:idx], n.fieldIDs[idx+1:]...)
+	}
+	if len(n.fieldSources) == oldLen {
+		n.fieldSources = append(n.fieldSources[:idx], n.fieldSources[idx+1:]...)
+	}
+	return n.children
+}

--- a/parser_result_cycle_guard_test.go
+++ b/parser_result_cycle_guard_test.go
@@ -1,0 +1,49 @@
+package gotreesitter
+
+import "testing"
+
+func TestStripResultTreeSelfCycles(t *testing.T) {
+	x := &Node{}
+	x.children = []*Node{x}
+	stripResultTreeSelfCycles(x)
+	for _, c := range x.children {
+		if c == x {
+			t.Fatal("self-reference not removed")
+		}
+	}
+
+	a := &Node{}
+	b := &Node{}
+	a.children = []*Node{b}
+	b.children = []*Node{a}
+	stripResultTreeSelfCycles(a)
+	for _, c := range b.children {
+		if c == a {
+			t.Fatal("ancestor back-edge not removed")
+		}
+	}
+
+	leaf := &Node{}
+	mid := &Node{children: []*Node{leaf}}
+	root := &Node{children: []*Node{mid}}
+	stripResultTreeSelfCycles(root)
+	if len(root.children) != 1 || root.children[0] != mid || len(mid.children) != 1 || mid.children[0] != leaf {
+		t.Fatal("clean tree was mutated")
+	}
+
+	y := &Node{}
+	kept := &Node{}
+	y.children = []*Node{y, kept}
+	y.fieldIDs = []FieldID{1, 2}
+	y.fieldSources = []uint8{fieldSourceDirect, fieldSourceInherited}
+	stripResultTreeSelfCycles(y)
+	if len(y.children) != 1 || y.children[0] != kept {
+		t.Fatalf("children after cycle strip = %v, want only kept child", y.children)
+	}
+	if len(y.fieldIDs) != 1 || y.fieldIDs[0] != 2 {
+		t.Fatalf("fieldIDs after cycle strip = %v, want [2]", y.fieldIDs)
+	}
+	if len(y.fieldSources) != 1 || y.fieldSources[0] != fieldSourceInherited {
+		t.Fatalf("fieldSources after cycle strip = %v, want inherited source", y.fieldSources)
+	}
+}


### PR DESCRIPTION
## Summary

- Add a recovered-tree guard that strips self-references and ancestor back-edges before result-tree construction.
- Keep `children`, `fieldIDs`, and `fieldSources` aligned when a cyclic child edge is removed.
- Add unit coverage for self-cycle removal, ancestor back-edge removal, clean-tree preservation, and field metadata alignment.

## Why

Maintainer follow-up / replacement branch for #121. It preserves the useful cycle-guard behavior from the contributor PR and incorporates the unresolved review feedback about parallel field metadata. Refs #110.

## Validation

- `go test . -run '^TestStripResultTreeSelfCycles$' -count=1`
- `go test . -run 'TestStripResultTreeSelfCycles|TestParser|TestTree|TestRootNode|TestResult|TestBuildResult' -count=1`
