### PR TITLE
[codex] keep Go recovery roots as source_file

### DIFF
--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -122,6 +122,9 @@ func (b *resultRootBuild) syntheticRootSymbol(originalNodes, rootChildren []*Nod
 	if b.isLanguage("dart") && dartProgramChildrenLookComplete(originalNodes, b.lang) {
 		return b.expectedRootSymbol
 	}
+	if b.isLanguage("go") {
+		return b.expectedRootSymbol
+	}
 	if b.isLanguage("sql") {
 		return b.expectedRootSymbol
 	}

--- a/parser_result_root_test.go
+++ b/parser_result_root_test.go
@@ -207,3 +207,49 @@ func TestBuildResultFromNodesKeepsSwiftSourceFileRootWhenChildrenHaveErrors(t *t
 		t.Fatalf("root end = %d, want %d", got, want)
 	}
 }
+
+func TestBuildResultFromNodesKeepsGoSourceFileRootWhenChildrenHaveErrors(t *testing.T) {
+	lang := &Language{
+		Name: "go",
+		SymbolNames: []string{
+			"EOF",
+			"ERROR",
+			"source_file",
+			"package_clause",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "ERROR", Visible: true, Named: true},
+			{Name: "source_file", Visible: true, Named: true},
+			{Name: "package_clause", Visible: true, Named: true},
+		},
+	}
+	parser := &Parser{
+		language:      lang,
+		rootSymbol:    2,
+		hasRootSymbol: true,
+	}
+	arena := acquireNodeArena(arenaClassFull)
+	source := []byte("package main\nfunc broken")
+
+	pkg := newLeafNodeInArena(arena, 3, true, 0, 12, Point{}, Point{Column: 12})
+	errNode := newLeafNodeInArena(arena, errorSymbol, true, 13, 24, Point{Row: 1}, Point{Row: 1, Column: 11})
+	errNode.setHasError(true)
+
+	tree := parser.buildResultFromNodes([]*Node{pkg, errNode}, source, arena, nil, nil, nil)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("buildResultFromNodes returned nil root")
+	}
+	if got, want := root.Type(lang), "source_file"; got != want {
+		t.Fatalf("root type = %q, want %q", got, want)
+	}
+	if !root.HasError() {
+		t.Fatal("expected source_file root to retain HasError=true")
+	}
+	if got, want := root.EndByte(), uint32(len(source)); got != want {
+		t.Fatalf("root end = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add Go to the synthetic-root path that keeps the grammar root symbol when children contain parse errors.
- Add a focused unit test for Go `source_file` root retention and `HasError` propagation.

## Why

Narrow replacement branch for #112, matching the maintainer request to keep only the Go recovery-root behavior and avoid the broader conflicted PR diff.

## Validation

- `go test . -run 'TestBuildResultFromNodesKeepsGoSourceFileRootWhenChildrenHaveErrors|TestBuildResultFromNodesKeepsSQLSourceFileRootWhenChildrenHaveErrors|TestBuildResultFromNodesKeepsSwiftSourceFileRootWhenChildrenHaveErrors|TestNormalizeGoSourceFileRootRetagsRecoveredTopLevelChildren' -count=1`
- `go test . -run 'TestBuildResult|TestRoot|TestNormalizeGo' -count=1`
