### PR TITLE
Honor parser timeouts during Go result normalization

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -214,7 +214,7 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 	if !allowIncremental {
 		tree.incrementalReuseDisabled = true
 	}
-	p.normalizeReturnedTree(rawRootOrNil(tree), source)
+	p.normalizeReturnedParseTree(tree, source)
 	return tree
 }
 

--- a/parser.go
+++ b/parser.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -72,6 +71,9 @@ type Parser struct {
 	maxConflictWidth                    int // widest N-way conflict in the parse table
 	timeoutMicros                       uint64
 	cancellationFlag                    *uint32
+	parseBudgetDepth                    int
+	parseDeadline                       time.Time
+	parseStoppedReason                  ParseStopReason
 	denseLimit                          int
 	smallBase                           int
 	smallLookup                         [][]smallActionPair
@@ -475,6 +477,9 @@ func resetSnippetParser(parser *Parser) {
 	parser.noResultCompatibilityBenchmarkOnly = false
 	parser.timeoutMicros = 0
 	parser.cancellationFlag = nil
+	parser.parseBudgetDepth = 0
+	parser.parseDeadline = time.Time{}
+	parser.parseStoppedReason = ParseStopNone
 	// Release *Node refs so the arenas from the last incremental parse can be
 	// collected by the GC. Without this, a Parser sitting in a sync.Pool keeps
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
@@ -2043,6 +2048,8 @@ func copyParseRuntimeToTiming(timing *incrementalParseTiming, parseRuntime Parse
 // merged; distinct alternatives are preserved.
 func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor, oldTree *Tree, arenaClass arenaClass, timing *incrementalParseTiming, maxStacksOverride int, maxNodesOverride int, maxMergePerKeyOverride int, deterministicExternalConflicts bool) *Tree {
 	parseStart := time.Now()
+	endParseBudget := p.enterParseBudgetAt(parseStart)
+	defer endParseBudget()
 	parseFlags := p.applyParseModeFlags(source, reuse, oldTree, arenaClass)
 	defer p.restoreParseModeFlags(parseFlags)
 	p.clearCurrentExternalTokenCheckpoint()
@@ -2182,6 +2189,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if phaseTiming && parserLoopNanos == 0 {
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
+		if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) && (stopReason == ParseStopAccepted || stopReason == ParseStopNone) {
+			stopReason = reason
+		}
 		if p.transientReduceChildren && tree != nil {
 			materializeStart := time.Time{}
 			if materializationTimingRef != nil {
@@ -2314,15 +2324,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	}
 
 	for iter := 0; iter < maxIter; iter++ {
-		if p.timeoutMicros > 0 {
-			// Timeout is checked inside the parse loop so long-running parses
-			// can terminate predictably under caller-configured limits.
-			if time.Since(parseStart) > time.Duration(p.timeoutMicros)*time.Microsecond {
-				return finalize(stacks, ParseStopTimeout)
-			}
-		}
-		if flag := p.cancellationFlag; flag != nil && atomic.LoadUint32(flag) != 0 {
-			return finalize(stacks, ParseStopCancelled)
+		if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+			return finalize(stacks, reason)
 		}
 		iterationsUsed = iter + 1
 		if perfCountersEnabled {

--- a/parser.go
+++ b/parser.go
@@ -2324,8 +2324,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	}
 
 	for iter := 0; iter < maxIter; iter++ {
-		if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
-			return finalize(stacks, reason)
+		if p.parseBudgetDepth > 0 {
+			if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+				return finalize(stacks, reason)
+			}
 		}
 		iterationsUsed = iter + 1
 		if perfCountersEnabled {

--- a/parser_api.go
+++ b/parser_api.go
@@ -148,7 +148,7 @@ func (p *Parser) tryTokenInvariantReuseForDisabledOldTree(source []byte, oldTree
 	if !ok {
 		return nil, false
 	}
-	normalizeReturnedIncrementalTree(tree, oldTree, source, p.language)
+	p.normalizeReturnedIncrementalTree(tree, oldTree, source)
 	return tree, true
 }
 
@@ -266,7 +266,25 @@ func (p *Parser) normalizeReturnedTree(root *Node, source []byte) {
 	if p != nil && p.noResultCompatibilityBenchmarkOnly {
 		return
 	}
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return
+	}
 	normalizeReturnedTree(root, source, p.language)
+}
+
+func (p *Parser) normalizeReturnedParseTree(tree *Tree, source []byte) {
+	if tree == nil || tree.ParseStoppedEarly() {
+		return
+	}
+	p.normalizeReturnedTree(rawRootOrNil(tree), source)
+	p.applyActiveStopReasonToTree(tree)
+}
+
+func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []byte) {
+	if !shouldNormalizeIncrementalReturnedTree(tree, oldTree) {
+		return
+	}
+	p.normalizeReturnedParseTree(tree, source)
 }
 
 func (p *Parser) dfaReparseFactory() TokenSourceFactory {
@@ -292,6 +310,9 @@ func (p *Parser) parseForRecovery(source []byte) (*Tree, error) {
 	if p == nil || p.language == nil {
 		return nil, ErrNoLanguage
 	}
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return nil, &ParseStoppedEarlyError{Reason: reason}
+	}
 	parser := p.recoveryParser
 	if parser == nil || parser.language != p.language {
 		if parser != nil {
@@ -304,16 +325,23 @@ func (p *Parser) parseForRecovery(source []byte) (*Tree, error) {
 		p.recoveryParser = parser
 	}
 	parser.skipRecoveryReparse = true
-	parser.timeoutMicros = p.timeoutMicros
+	parser.timeoutMicros = p.remainingTimeoutMicros()
 	parser.cancellationFlag = p.cancellationFlag
+	var tree *Tree
+	var err error
 	if p.reparseFactory != nil {
 		ts, err := p.reparseFactory(source)
 		if err != nil {
 			return nil, err
 		}
-		return parser.ParseWithTokenSource(source, ts)
+		tree, err = parser.ParseWithTokenSource(source, ts)
+	} else {
+		tree, err = parser.Parse(source)
 	}
-	return parser.Parse(source)
+	if tree != nil && parseStopReasonIsActive(tree.ParseStopReason()) {
+		p.markActiveParseStopped(tree.ParseStopReason())
+	}
+	return tree, err
 }
 
 func (p *Parser) clearRecoveryParser() {
@@ -402,6 +430,8 @@ func (p *Parser) parseWithTokenSource(source []byte, ts TokenSource, reparseFact
 	if ts == nil {
 		return nil, ErrNoTokenSource
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	p.releaseCompatibilityBorrowedArenas()
 	p.clearRecoveryParser()
 	defer p.clearRecoveryParser()
@@ -415,11 +445,13 @@ func (p *Parser) parseWithTokenSource(source []byte, ts TokenSource, reparseFact
 	deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
 	initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
 	tree := p.parseInternal(source, p.wrapIncludedRanges(ts), nil, nil, arenaClassFull, nil, initialMaxStacks, 0, 0, deterministicExternalConflicts)
-	tree = p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
-	if shouldRepeatExternalScannerFullParse(p.language, tree) {
+	if tree != nil && !tree.ParseStoppedEarly() && !parseStopReasonIsActive(p.activeParseStopReason()) {
 		tree = p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
+		if tree != nil && !tree.ParseStoppedEarly() && !parseStopReasonIsActive(p.activeParseStopReason()) && shouldRepeatExternalScannerFullParse(p.language, tree) {
+			tree = p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
+		}
 	}
-	p.normalizeReturnedTree(rawRootOrNil(tree), source)
+	p.normalizeReturnedParseTree(tree, source)
 	return tree, nil
 }
 
@@ -435,13 +467,15 @@ func (p *Parser) parseIncrementalWithTokenSource(source []byte, oldTree *Tree, t
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, nil
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	prevFactory := p.reparseFactory
 	p.reparseFactory = reparseFactory
 	defer func() {
 		p.reparseFactory = prevFactory
 	}()
 	tree := p.parseIncrementalInternal(source, oldTree, p.wrapIncludedRanges(ts), nil)
-	normalizeReturnedIncrementalTree(tree, oldTree, source, p.language)
+	p.normalizeReturnedIncrementalTree(tree, oldTree, source)
 	return tree, nil
 }
 
@@ -681,6 +715,8 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	if err := p.checkDFALexer(); err != nil {
 		return nil, err
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	// GSS-forest fast path for languages whose production GLR parse blows up on
 	// deep stack-equivalence (e.g. bash). Returns nil to fall back to the
 	// production parser on any failure, error, or truncation. Off unless
@@ -706,11 +742,13 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
 	tree := p.parseInternal(source, p.wrapIncludedRanges(ts), nil, nil, arenaClassFull, nil, initialMaxStacks, 0, 0, deterministicExternalConflicts)
 	if !p.noTreeBenchmarkOnly {
-		tree = p.retryFullParseWithDFA(source, initialMaxStacks, deterministicExternalConflicts, tree)
-		if shouldRepeatExternalScannerFullParse(p.language, tree) {
+		if tree != nil && !tree.ParseStoppedEarly() && !parseStopReasonIsActive(p.activeParseStopReason()) {
 			tree = p.retryFullParseWithDFA(source, initialMaxStacks, deterministicExternalConflicts, tree)
+			if tree != nil && !tree.ParseStoppedEarly() && !parseStopReasonIsActive(p.activeParseStopReason()) && shouldRepeatExternalScannerFullParse(p.language, tree) {
+				tree = p.retryFullParseWithDFA(source, initialMaxStacks, deterministicExternalConflicts, tree)
+			}
 		}
-		p.normalizeReturnedTree(rawRootOrNil(tree), source)
+		p.normalizeReturnedParseTree(tree, source)
 	}
 	return tree, nil
 }
@@ -863,6 +901,8 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, nil
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, nil); ok {
 			return tree, nil
@@ -881,7 +921,7 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 	ts := acquireDFATokenSource(lexer, p.language, p.lookupActionIndex, p.hasKeywordState, p.externalValidByState, p.externalValidMaskByState)
 	defer ts.Close()
 	tree := p.parseIncrementalInternal(source, oldTree, p.wrapIncludedRanges(ts), nil)
-	normalizeReturnedIncrementalTree(tree, oldTree, source, p.language)
+	p.normalizeReturnedIncrementalTree(tree, oldTree, source)
 	return tree, nil
 }
 
@@ -986,6 +1026,8 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, IncrementalParseProfile{}, nil
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		timing := &incrementalParseTiming{}
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, timing); ok {
@@ -1008,7 +1050,7 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 	defer ts.Close()
 	timing := &incrementalParseTiming{}
 	tree := p.parseIncrementalInternal(source, oldTree, p.wrapIncludedRanges(ts), timing)
-	normalizeReturnedIncrementalTree(tree, oldTree, source, p.language)
+	p.normalizeReturnedIncrementalTree(tree, oldTree, source)
 	return tree, timing.toProfile(), nil
 }
 
@@ -1023,6 +1065,8 @@ func (p *Parser) ParseIncrementalWithTokenSourceProfiled(source []byte, oldTree 
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, IncrementalParseProfile{}, nil
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	prevFactory := p.reparseFactory
 	p.reparseFactory = p.tokenSourceReparseFactory(ts)
 	defer func() {
@@ -1030,7 +1074,7 @@ func (p *Parser) ParseIncrementalWithTokenSourceProfiled(source []byte, oldTree 
 	}()
 	timing := &incrementalParseTiming{}
 	tree := p.parseIncrementalInternal(source, oldTree, p.wrapIncludedRanges(ts), timing)
-	normalizeReturnedIncrementalTree(tree, oldTree, source, p.language)
+	p.normalizeReturnedIncrementalTree(tree, oldTree, source)
 	return tree, timing.toProfile(), nil
 }
 

--- a/parser_api.go
+++ b/parser_api.go
@@ -467,6 +467,10 @@ func (p *Parser) parseIncrementalWithTokenSource(source []byte, oldTree *Tree, t
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, nil
 	}
+	return p.parseIncrementalWithTokenSourceChanged(source, oldTree, ts, reparseFactory)
+}
+
+func (p *Parser) parseIncrementalWithTokenSourceChanged(source []byte, oldTree *Tree, ts TokenSource, reparseFactory TokenSourceFactory) (*Tree, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
 	prevFactory := p.reparseFactory
@@ -901,6 +905,10 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, nil
 	}
+	return p.parseIncrementalChanged(source, oldTree)
+}
+
+func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
 	if oldTreeDisablesIncrementalReuse(oldTree) {
@@ -1026,6 +1034,10 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, IncrementalParseProfile{}, nil
 	}
+	return p.parseIncrementalChangedProfiled(source, oldTree)
+}
+
+func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (*Tree, IncrementalParseProfile, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
 	if oldTreeDisablesIncrementalReuse(oldTree) {
@@ -1065,6 +1077,10 @@ func (p *Parser) ParseIncrementalWithTokenSourceProfiled(source []byte, oldTree 
 	if canReuseUnchangedTree(source, oldTree, p.language) {
 		return oldTree, IncrementalParseProfile{}, nil
 	}
+	return p.parseIncrementalWithTokenSourceChangedProfiled(source, oldTree, ts)
+}
+
+func (p *Parser) parseIncrementalWithTokenSourceChangedProfiled(source []byte, oldTree *Tree, ts TokenSource) (*Tree, IncrementalParseProfile, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
 	prevFactory := p.reparseFactory

--- a/parser_api.go
+++ b/parser_api.go
@@ -719,8 +719,6 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	if err := p.checkDFALexer(); err != nil {
 		return nil, err
 	}
-	endParseBudget := p.enterParseBudget()
-	defer endParseBudget()
 	// GSS-forest fast path for languages whose production GLR parse blows up on
 	// deep stack-equivalence (e.g. bash). Returns nil to fall back to the
 	// production parser on any failure, error, or truncation. Off unless
@@ -728,6 +726,8 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	if tree := p.tryForestFastPath(source); tree != nil {
 		return tree, nil
 	}
+	endParseBudget := p.enterParseBudget()
+	defer endParseBudget()
 	p.releaseCompatibilityBorrowedArenas()
 	p.clearRecoveryParser()
 	defer p.clearRecoveryParser()

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1166,6 +1166,9 @@ func TestResetSnippetParserClearsTransientState(t *testing.T) {
 	parser.timeoutMicros = 99
 	flag := uint32(1)
 	parser.cancellationFlag = &flag
+	parser.parseBudgetDepth = 1
+	parser.parseDeadline = time.Now()
+	parser.parseStoppedReason = ParseStopTimeout
 
 	resetSnippetParser(parser)
 
@@ -1198,6 +1201,15 @@ func TestResetSnippetParserClearsTransientState(t *testing.T) {
 	}
 	if parser.cancellationFlag != nil {
 		t.Fatal("resetSnippetParser did not clear cancellationFlag")
+	}
+	if parser.parseBudgetDepth != 0 {
+		t.Fatal("resetSnippetParser did not clear parseBudgetDepth")
+	}
+	if !parser.parseDeadline.IsZero() {
+		t.Fatal("resetSnippetParser did not clear parseDeadline")
+	}
+	if parser.parseStoppedReason != ParseStopNone {
+		t.Fatal("resetSnippetParser did not clear parseStoppedReason")
 	}
 }
 

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -1,36 +1,59 @@
 package gotreesitter
 
 type resultCompatibilityContext struct {
-	root   *Node
-	source []byte
-	parser *Parser
-	lang   *Language
+	root      *Node
+	source    []byte
+	parser    *Parser
+	lang      *Language
+	stopCheck parseStopCheck
 }
 
 // normalizeResultCompatibility applies narrow post-build tree rewrites that
 // keep gotreesitter output aligned with C tree-sitter and existing recovery
 // expectations for grammars with known normalization gaps.
-func normalizeResultCompatibility(root *Node, source []byte, p *Parser) {
+func normalizeResultCompatibility(root *Node, source []byte, p *Parser) ParseStopReason {
 	var lang *Language
 	if p != nil {
 		lang = p.language
 	}
 	if root == nil || lang == nil {
-		return
+		return ParseStopNone
 	}
-	runLanguageResultCompatibility(resultCompatibilityContext{
-		root:   root,
-		source: source,
-		parser: p,
-		lang:   lang,
-	})
+	ctx := resultCompatibilityContext{
+		root:      root,
+		source:    source,
+		parser:    p,
+		lang:      lang,
+		stopCheck: p.activeParseStopCheck(),
+	}
+	if reason := ctx.stopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := runLanguageResultCompatibility(ctx); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := ctx.stopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
 	normalizeResultCollapsedNamedLeafChildren(root, lang)
+	return ctx.stopReason()
 }
 
-func runLanguageResultCompatibility(ctx resultCompatibilityContext) {
+func (ctx resultCompatibilityContext) stopReason() ParseStopReason {
+	if ctx.stopCheck == nil {
+		return ParseStopNone
+	}
+	reason := ctx.stopCheck()
+	if reason == "" {
+		return ParseStopNone
+	}
+	return reason
+}
+
+func runLanguageResultCompatibility(ctx resultCompatibilityContext) ParseStopReason {
 	if isCobolLanguage(ctx.lang) {
 		normalizeCobolCompatibility(ctx.root, ctx.source, ctx.lang)
-		return
+		return ctx.stopReason()
 	}
 
 	switch ctx.lang.Name {
@@ -60,7 +83,7 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) {
 		normalizeFortranStatementLineBreaks(ctx.root, ctx.source, ctx.lang)
 		normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
 	case "go":
-		normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		return normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
 	case "graphql":
 		normalizeGraphQLCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "haskell":
@@ -131,4 +154,5 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) {
 	case "zig":
 		normalizeZigEmptyInitListFields(ctx.root, ctx.lang)
 	}
+	return ctx.stopReason()
 }

--- a/parser_result_go.go
+++ b/parser_result_go.go
@@ -2,10 +2,22 @@ package gotreesitter
 
 import "bytes"
 
-func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, lang *Language) {
+func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, lang *Language) ParseStopReason {
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
 	normalizeGoSourceFileRoot(root, source, p)
-	normalizeGoCompatibility(root, source, lang)
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := normalizeGoCompatibilityWithStop(root, source, lang, p.activeParseStopCheck()); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
 	normalizeRootEOFNewlineSpan(root, source, lang)
+	return p.activeParseStopReason()
 }
 
 func normalizeGoSourceFileRoot(root *Node, source []byte, p *Parser) {

--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -23,22 +23,39 @@ type goCompatibilitySourceFlags struct {
 }
 
 func normalizeGoCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeGoCompatibilityInRanges(root, source, lang, nil)
+	_ = normalizeGoCompatibilityInRanges(root, source, lang, nil)
 }
 
-func normalizeGoCompatibilityInRanges(root *Node, source []byte, lang *Language, incrementalRanges []Range) {
+func normalizeGoCompatibilityInRanges(root *Node, source []byte, lang *Language, incrementalRanges []Range) ParseStopReason {
+	return normalizeGoCompatibilityInRangesWithStop(root, source, lang, incrementalRanges, nil)
+}
+
+func normalizeGoCompatibilityWithStop(root *Node, source []byte, lang *Language, stopCheck parseStopCheck) ParseStopReason {
+	return normalizeGoCompatibilityInRangesWithStop(root, source, lang, nil, stopCheck)
+}
+
+func normalizeGoCompatibilityInRangesWithStop(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck) ParseStopReason {
 	if root == nil || lang == nil || lang.Name != "go" || len(source) == 0 {
-		return
+		return ParseStopNone
+	}
+	poller := parseStopPoller{check: stopCheck}
+	if reason := poller.pollNow(); parseStopReasonIsActive(reason) {
+		return reason
 	}
 	flags := goCompatibilitySourceFlagsFor(source)
 	if flags.dot {
-		normalizeGoDotLeafChildren(root, source, lang)
+		if reason := normalizeGoDotLeafChildrenWithStop(root, source, lang, &poller); parseStopReasonIsActive(reason) {
+			return reason
+		}
 	}
 	syms, ok := goCompatibilitySymbolsForLanguage(lang)
 	if !ok {
-		return
+		return poller.pollNow()
 	}
-	normalizeGoCompatibilitySubtree(root, source, syms, flags, incrementalRanges)
+	if reason := normalizeGoCompatibilitySubtreeWithStop(root, source, syms, flags, incrementalRanges, &poller); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	return poller.pollNow()
 }
 
 func goCompatibilitySourceFlagsFor(source []byte) goCompatibilitySourceFlags {
@@ -64,22 +81,29 @@ func goSourceMayNeedTrailingBoundaryCompatibility(source []byte) bool {
 }
 
 func normalizeGoDotLeafChildren(root *Node, source []byte, lang *Language) {
+	_ = normalizeGoDotLeafChildrenWithStop(root, source, lang, nil)
+}
+
+func normalizeGoDotLeafChildrenWithStop(root *Node, source []byte, lang *Language, poller *parseStopPoller) ParseStopReason {
 	if root == nil || lang == nil || len(source) == 0 {
-		return
+		return ParseStopNone
+	}
+	if reason := poller.pollNow(); parseStopReasonIsActive(reason) {
+		return reason
 	}
 	parentSym, ok := lang.symbolByNameAndNamed("dot", true)
 	if !ok {
 		parentSym, ok = symbolByName(lang, "dot")
 	}
 	if !ok {
-		return
+		return ParseStopNone
 	}
 	childSym, ok := lang.symbolByNameAndNamed(".", false)
 	if !ok {
 		childSym, ok = symbolByName(lang, ".")
 	}
 	if !ok {
-		return
+		return ParseStopNone
 	}
 	childNamed := symbolIsNamed(lang, childSym)
 	// Iterative DFS with an explicit stack: source trees can nest or chain
@@ -92,6 +116,9 @@ func normalizeGoDotLeafChildren(root *Node, source []byte, lang *Language) {
 		}
 	}
 	for len(stack) > 0 {
+		if reason := poller.poll(); parseStopReasonIsActive(reason) {
+			return reason
+		}
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
 		childCount := resultChildCount(n)
@@ -123,6 +150,7 @@ func normalizeGoDotLeafChildren(root *Node, source []byte, lang *Language) {
 			push(resultChildAt(n, i))
 		}
 	}
+	return poller.pollNow()
 }
 
 func normalizeGoDotLeafNode(n *Node, source []byte, childSym Symbol, childNamed bool) {
@@ -196,8 +224,15 @@ func (s goCompatibilitySymbols) isStatementList(sym Symbol) bool {
 }
 
 func normalizeGoCompatibilitySubtree(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range) {
+	_ = normalizeGoCompatibilitySubtreeWithStop(n, source, syms, flags, incrementalRanges, nil)
+}
+
+func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller) ParseStopReason {
+	if reason := poller.poll(); parseStopReasonIsActive(reason) {
+		return reason
+	}
 	if n == nil || !goNodeOverlapsAnyRange(n, incrementalRanges) {
-		return
+		return ParseStopNone
 	}
 	childCount := resultChildCount(n)
 	if childCount > 0 {
@@ -208,7 +243,9 @@ func normalizeGoCompatibilitySubtree(n *Node, source []byte, syms goCompatibilit
 	}
 	if n.ownerArena == nil || n.childIndex > finalChildSidecarIndexBase {
 		for _, child := range n.children {
-			normalizeGoCompatibilitySubtree(child, source, syms, flags, incrementalRanges)
+			if reason := normalizeGoCompatibilitySubtreeWithStop(child, source, syms, flags, incrementalRanges, poller); parseStopReasonIsActive(reason) {
+				return reason
+			}
 		}
 	} else {
 		view := resultMutableChildrenForMutation(n)
@@ -218,17 +255,22 @@ func normalizeGoCompatibilitySubtree(n *Node, source []byte, syms goCompatibilit
 				if !ok || stackEntryNodeChildCount(entry) == 0 {
 					continue
 				}
-				normalizeGoCompatibilitySubtree(resultChildAt(n, i), source, syms, flags, incrementalRanges)
+				if reason := normalizeGoCompatibilitySubtreeWithStop(resultChildAt(n, i), source, syms, flags, incrementalRanges, poller); parseStopReasonIsActive(reason) {
+					return reason
+				}
 			}
 		} else {
 			for i := 0; i < childCount; i++ {
-				normalizeGoCompatibilitySubtree(resultChildAt(n, i), source, syms, flags, incrementalRanges)
+				if reason := normalizeGoCompatibilitySubtreeWithStop(resultChildAt(n, i), source, syms, flags, incrementalRanges, poller); parseStopReasonIsActive(reason) {
+					return reason
+				}
 			}
 		}
 	}
 	if flags.trailingBoundary {
 		normalizeGoStatementListTrailingExtras(n, source, syms)
 	}
+	return ParseStopNone
 }
 
 func goNodeOverlapsAnyRange(n *Node, ranges []Range) bool {

--- a/parser_result_go_timeout_test.go
+++ b/parser_result_go_timeout_test.go
@@ -1,0 +1,89 @@
+package gotreesitter
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func goDotCompatibilityTestLanguage() *Language {
+	return &Language{
+		Name:       "go",
+		TokenCount: 2,
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"dot",
+			"source_file",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "dot", Visible: true, Named: true},
+			{Name: "source_file", Visible: true, Named: true},
+		},
+	}
+}
+
+func TestNormalizeGoDotLeafChildrenHonorsStopCheck(t *testing.T) {
+	lang := goDotCompatibilityTestLanguage()
+	arena := newNodeArena(arenaClassFull)
+	const dotLeaves = 4096
+	children := make([]*Node, 0, dotLeaves)
+	for i := 0; i < dotLeaves; i++ {
+		children = append(children, newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1}))
+	}
+	root := newParentNodeInArena(arena, 3, true, children, nil, 0)
+	source := []byte(".")
+	checks := 0
+	poller := parseStopPoller{
+		check: func() ParseStopReason {
+			checks++
+			if checks < 2 {
+				return ParseStopNone
+			}
+			return ParseStopTimeout
+		},
+	}
+
+	reason := normalizeGoDotLeafChildrenWithStop(root, source, lang, &poller)
+
+	if reason != ParseStopTimeout {
+		t.Fatalf("normalizeGoDotLeafChildrenWithStop reason = %q, want %q", reason, ParseStopTimeout)
+	}
+	var rewritten int
+	for i := 0; i < resultChildCount(root); i++ {
+		if resultChildCount(resultChildAt(root, i)) > 0 {
+			rewritten++
+		}
+	}
+	if rewritten == 0 || rewritten >= dotLeaves {
+		t.Fatalf("rewritten dot leaves = %d, want partial rewrite before timeout", rewritten)
+	}
+}
+
+func TestParseForRecoveryHonorsExpiredActiveBudget(t *testing.T) {
+	parser := NewParser(buildArithmeticLanguage())
+	parser.SetTimeoutMicros(1)
+	endBudget := parser.enterParseBudgetAt(time.Now().Add(-time.Millisecond))
+	defer endBudget()
+
+	tree, err := parser.parseForRecovery([]byte("1+2"))
+
+	if tree != nil {
+		t.Fatalf("parseForRecovery returned tree %p, want nil", tree)
+	}
+	if !errors.Is(err, ErrParseStoppedEarly) {
+		t.Fatalf("parseForRecovery error = %v, want ErrParseStoppedEarly", err)
+	}
+	var stopped *ParseStoppedEarlyError
+	if !errors.As(err, &stopped) {
+		t.Fatalf("parseForRecovery error type = %T, want *ParseStoppedEarlyError", err)
+	}
+	if stopped.Reason != ParseStopTimeout {
+		t.Fatalf("stopped reason = %q, want %q", stopped.Reason, ParseStopTimeout)
+	}
+	if got := parser.activeParseStopReason(); got != ParseStopTimeout {
+		t.Fatalf("activeParseStopReason = %q, want %q", got, ParseStopTimeout)
+	}
+}

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -200,7 +200,9 @@ func (b *resultRootBuild) finalizeRoot(root *Node, wireParentLinks, extendTraili
 func (b *resultRootBuild) finalizeWrappedSubtree(root *Node) {
 	p := b.parser
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
-		normalizeResultCompatibility(root, b.source, p)
+		if reason := normalizeResultCompatibility(root, b.source, p); parseStopReasonIsActive(reason) && p != nil {
+			p.markActiveParseStopped(reason)
+		}
 	}
 }
 
@@ -373,7 +375,9 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 	timing.addResultNormalizeRootStart(start)
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
 		start = materializationTimingStart(timing)
-		normalizeResultCompatibility(root, source, p)
+		if reason := normalizeResultCompatibility(root, source, p); parseStopReasonIsActive(reason) && p != nil {
+			p.markActiveParseStopped(reason)
+		}
 		timing.addResultCompatibility(start)
 		// Per-language compatibility passes can filter trailing trivia children
 		// (e.g. HCL drops _whitespace from config_file), which may shrink the root
@@ -383,6 +387,9 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		if extendTrailing {
 			extendNodeToTrailingWhitespace(root, source)
 		}
+	}
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return
 	}
 	if wireParentLinks {
 		start = materializationTimingStart(timing)

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -794,6 +794,12 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 		if p == nil || p.timeoutMicros == 0 {
 			return false
 		}
+		if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+			return true
+		}
+		if p.parseBudgetDepth > 0 {
+			return false
+		}
 		return time.Since(retryStart) > time.Duration(p.timeoutMicros)*time.Microsecond
 	}
 

--- a/parser_timeout.go
+++ b/parser_timeout.go
@@ -46,11 +46,17 @@ func parseStopReasonIsActive(reason ParseStopReason) bool {
 }
 
 func (p *Parser) enterParseBudget() func() {
+	if !p.needsParseBudget() {
+		return func() {}
+	}
 	return p.enterParseBudgetAt(time.Now())
 }
 
 func (p *Parser) enterParseBudgetAt(start time.Time) func() {
 	if p == nil {
+		return func() {}
+	}
+	if !p.needsParseBudget() {
 		return func() {}
 	}
 	prevDepth := p.parseBudgetDepth
@@ -74,6 +80,10 @@ func (p *Parser) enterParseBudgetAt(start time.Time) func() {
 	}
 }
 
+func (p *Parser) needsParseBudget() bool {
+	return p != nil && (p.parseBudgetDepth > 0 || p.timeoutMicros > 0 || p.cancellationFlag != nil)
+}
+
 func (p *Parser) activeParseStopCheck() parseStopCheck {
 	if p == nil {
 		return nil
@@ -83,6 +93,9 @@ func (p *Parser) activeParseStopCheck() parseStopCheck {
 
 func (p *Parser) activeParseStopReason() ParseStopReason {
 	if p == nil {
+		return ParseStopNone
+	}
+	if !p.needsParseBudget() {
 		return ParseStopNone
 	}
 	if parseStopReasonIsActive(p.parseStoppedReason) {

--- a/parser_timeout.go
+++ b/parser_timeout.go
@@ -1,0 +1,143 @@
+package gotreesitter
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type parseStopCheck func() ParseStopReason
+
+type parseStopPoller struct {
+	check parseStopCheck
+	count uint64
+}
+
+const parseStopPollMask = 1023
+
+func (p *parseStopPoller) poll() ParseStopReason {
+	if p == nil || p.check == nil {
+		return ParseStopNone
+	}
+	p.count++
+	if p.count&parseStopPollMask != 0 {
+		return ParseStopNone
+	}
+	return p.pollNow()
+}
+
+func (p *parseStopPoller) pollNow() ParseStopReason {
+	if p == nil || p.check == nil {
+		return ParseStopNone
+	}
+	reason := p.check()
+	if reason == "" {
+		return ParseStopNone
+	}
+	return reason
+}
+
+func parseStopReasonIsActive(reason ParseStopReason) bool {
+	switch reason {
+	case ParseStopTimeout, ParseStopCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Parser) enterParseBudget() func() {
+	return p.enterParseBudgetAt(time.Now())
+}
+
+func (p *Parser) enterParseBudgetAt(start time.Time) func() {
+	if p == nil {
+		return func() {}
+	}
+	prevDepth := p.parseBudgetDepth
+	prevDeadline := p.parseDeadline
+	prevStopped := p.parseStoppedReason
+
+	if prevDepth == 0 {
+		p.parseStoppedReason = ParseStopNone
+		if p.timeoutMicros > 0 {
+			p.parseDeadline = start.Add(time.Duration(p.timeoutMicros) * time.Microsecond)
+		} else {
+			p.parseDeadline = time.Time{}
+		}
+	}
+	p.parseBudgetDepth = prevDepth + 1
+
+	return func() {
+		p.parseBudgetDepth = prevDepth
+		p.parseDeadline = prevDeadline
+		p.parseStoppedReason = prevStopped
+	}
+}
+
+func (p *Parser) activeParseStopCheck() parseStopCheck {
+	if p == nil {
+		return nil
+	}
+	return p.activeParseStopReason
+}
+
+func (p *Parser) activeParseStopReason() ParseStopReason {
+	if p == nil {
+		return ParseStopNone
+	}
+	if parseStopReasonIsActive(p.parseStoppedReason) {
+		return p.parseStoppedReason
+	}
+	if flag := p.cancellationFlag; flag != nil && atomic.LoadUint32(flag) != 0 {
+		return p.markActiveParseStopped(ParseStopCancelled)
+	}
+	if !p.parseDeadline.IsZero() && !time.Now().Before(p.parseDeadline) {
+		return p.markActiveParseStopped(ParseStopTimeout)
+	}
+	return ParseStopNone
+}
+
+func (p *Parser) markActiveParseStopped(reason ParseStopReason) ParseStopReason {
+	if p == nil || !parseStopReasonIsActive(reason) {
+		return ParseStopNone
+	}
+	if !parseStopReasonIsActive(p.parseStoppedReason) {
+		p.parseStoppedReason = reason
+	}
+	return p.parseStoppedReason
+}
+
+func (p *Parser) remainingTimeoutMicros() uint64 {
+	if p == nil || p.timeoutMicros == 0 {
+		return 0
+	}
+	if p.parseBudgetDepth == 0 || p.parseDeadline.IsZero() {
+		return p.timeoutMicros
+	}
+	remaining := time.Until(p.parseDeadline)
+	if remaining <= 0 {
+		p.markActiveParseStopped(ParseStopTimeout)
+		return 1
+	}
+	micros := remaining / time.Microsecond
+	if micros <= 0 {
+		return 1
+	}
+	return uint64(micros)
+}
+
+func (p *Parser) applyActiveStopReasonToTree(tree *Tree) {
+	if p == nil || tree == nil {
+		return
+	}
+	reason := p.activeParseStopReason()
+	if !parseStopReasonIsActive(reason) {
+		return
+	}
+	rt := tree.ParseRuntime()
+	if parseStopReasonIsActive(rt.StopReason) {
+		return
+	}
+	rt.StopReason = reason
+	tree.setParseRuntime(rt)
+}


### PR DESCRIPTION
## Summary
- add an active parse budget shared across parser loop, retries, recovery reparses, finalization, and returned-tree normalization
- propagate timeout/cancellation stop checks through result compatibility and Go dot/semicolon normalization walks
- return timeout/cancelled stop reasons on trees when post-parse compatibility aborts
- add focused tests for Go normalization polling and recovery parse budget expiry

Fixes #114.

This PR addresses the reported timeout/cancellation failure path by applying the active parse budget through parser loop checks, retry/recovery reparses, result finalization, and Go result normalization.

## Verification
- `go test . -run 'TestNormalizeGoDotLeafChildrenHonorsStopCheck|TestParseForRecoveryHonorsExpiredActiveBudget|TestResetSnippetParserClearsTransientState|TestParserTimeoutMicrosStopsParse|TestParserCancellationFlagStopsParse|TestParseStrictReturnsStoppedEarlyError|TestParseWithTokenSourceStrictReturnsTimeoutError|TestParseGoTokenSource|TestNormalizeGo|TestNormalizeResultCompatibilityDispatchesUppercaseCobol|TestNormalizeCppCompatibilityRestoresCollapsedKeywordChildren|TestNormalizeResultCompatibilityRestores' -count=1`
- `go test . -run '^$' -count=1`
- `bash cgo_harness/docker/run_single_grammar_parity.sh go`