### PR TITLE
fix(grammars): guard F# scanner dedent fallback

### DIFF
--- a/grammars/fsharp_scanner.go
+++ b/grammars/fsharp_scanner.go
@@ -517,11 +517,8 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 						lexer.MarkEnd()
 						lexer.SetResultSymbol(fsSymEnd)
 						return true
-					} else if isValid(fsTokDedent) && len(s.indents) > 0 {
-						s.indents = s.indents[:len(s.indents)-1]
-						lexer.SetResultSymbol(fsSymDedent)
-						return true
 					}
+					return fsEmitDedent(s, lexer)
 				}
 			}
 		}

--- a/grammars/fsharp_scanner.go
+++ b/grammars/fsharp_scanner.go
@@ -57,6 +57,15 @@ type fsState struct {
 	preprocessorIndents []uint16
 }
 
+func fsEmitDedent(s *fsState, lexer *gotreesitter.ExternalLexer) bool {
+	if len(s.indents) <= 1 {
+		return false
+	}
+	s.indents = s.indents[:len(s.indents)-1]
+	lexer.SetResultSymbol(fsSymDedent)
+	return true
+}
+
 // FsharpExternalScanner handles indent/dedent, keywords, preprocessor directives, and comments for F#.
 type FsharpExternalScanner struct{}
 
@@ -405,9 +414,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 						lexer.SetResultSymbol(fsSymThen)
 						return true
 					}
-					s.indents = s.indents[:len(s.indents)-1]
-					lexer.SetResultSymbol(fsSymDedent)
-					return true
+					return fsEmitDedent(s, lexer)
 				}
 			}
 		}
@@ -423,9 +430,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 						lexer.SetResultSymbol(fsSymAnd)
 						return true
 					}
-					s.indents = s.indents[:len(s.indents)-1]
-					lexer.SetResultSymbol(fsSymDedent)
-					return true
+					return fsEmitDedent(s, lexer)
 				}
 			}
 		}
@@ -443,9 +448,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 							lexer.SetResultSymbol(fsSymWith)
 							return true
 						}
-						s.indents = s.indents[:len(s.indents)-1]
-						lexer.SetResultSymbol(fsSymDedent)
-						return true
+						return fsEmitDedent(s, lexer)
 					}
 				}
 			}
@@ -486,9 +489,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 						lexer.SetResultSymbol(fsSymElse)
 						return true
 					}
-					s.indents = s.indents[:len(s.indents)-1]
-					lexer.SetResultSymbol(fsSymDedent)
-					return true
+					return fsEmitDedent(s, lexer)
 				}
 			} else if lexer.Lookahead() == 'i' && (isValid(fsTokElif) || isValid(fsTokDedent)) {
 				lexer.Advance(false)
@@ -504,9 +505,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 						lexer.SetResultSymbol(fsSymElif)
 						return true
 					}
-					s.indents = s.indents[:len(s.indents)-1]
-					lexer.SetResultSymbol(fsSymDedent)
-					return true
+					return fsEmitDedent(s, lexer)
 				}
 			}
 		} else if lexer.Lookahead() == 'n' && (isValid(fsTokEnd) || isValid(fsTokDedent)) {

--- a/grammars/fsharp_scanner_test.go
+++ b/grammars/fsharp_scanner_test.go
@@ -1,0 +1,57 @@
+//go:build !grammar_subset || grammar_subset_fsharp
+
+package grammars
+
+import (
+	"reflect"
+	"testing"
+	_ "unsafe"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func TestFsharpKeywordDedentFallbackIgnoresEmptyIndentStack(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "then", src: "then"},
+		{name: "and", src: "and "},
+		{name: "with", src: "with "},
+		{name: "else", src: "else"},
+		{name: "elif", src: "elif"},
+	}
+
+	scanner := FsharpExternalScanner{}
+	valid := make([]bool, fsTokErrorSentinel+1)
+	valid[fsTokDedent] = true
+	initialIndents := [][]uint16{nil, []uint16{0}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, initial := range initialIndents {
+				want := append([]uint16(nil), initial...)
+				if initial == nil {
+					want = nil
+				}
+				state := &fsState{indents: initial}
+				lexer := newFsharpExternalLexer([]byte(tt.src), 0, 0, 0)
+				if scanner.Scan(state, lexer, valid) {
+					t.Fatalf("Scan() emitted DEDENT with indent stack %#v", initial)
+				}
+				if tok, ok := fsharpExternalLexerToken(lexer); ok {
+					t.Fatalf("Scan() returned false but produced token %+v", tok)
+				}
+				if !reflect.DeepEqual(state.indents, want) {
+					t.Fatalf("indents = %#v, want %#v", state.indents, want)
+				}
+			}
+		})
+	}
+}
+
+//go:linkname newFsharpExternalLexer github.com/odvcencio/gotreesitter.newExternalLexer
+func newFsharpExternalLexer(source []byte, pos int, row, col uint32) *gotreesitter.ExternalLexer
+
+//go:linkname fsharpExternalLexerToken github.com/odvcencio/gotreesitter.(*ExternalLexer).token
+func fsharpExternalLexerToken(*gotreesitter.ExternalLexer) (gotreesitter.Token, bool)

--- a/grammars/fsharp_scanner_test.go
+++ b/grammars/fsharp_scanner_test.go
@@ -20,6 +20,7 @@ func TestFsharpKeywordDedentFallbackIgnoresEmptyIndentStack(t *testing.T) {
 		{name: "with", src: "with "},
 		{name: "else", src: "else"},
 		{name: "elif", src: "elif"},
+		{name: "end", src: "end"},
 	}
 
 	scanner := FsharpExternalScanner{}


### PR DESCRIPTION
## Summary
- Guard F# scanner keyword dedent fallbacks so empty indent stacks cannot panic while emitting `DEDENT`.
- Add focused scanner regression coverage for `then`, `and`, `with`, `else`, and `elif` fallbacks.

## Verification
- `go test ./grammars -run 'TestFsharp' -count=1`
- Re-ran the reported `dotnet/fsharp` `docs/fcs-samples/FsiExe/fsimain.fs` panic repro; `Parse(src)` returned without panic.

Fixes #129.