### PR TITLE
fix(swift): recover if/else-if chains from trailing-closure collapse (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Swift `if … else if …` chains no longer collapse the enclosing function to
+  `_modifierless_function_declaration_no_body` (#131). The trailing-closure
+  ambiguity recovery now follows the whole if/else-if chain — the chained `if`
+  keyword is swallowed into an ERROR node, so it is discovered by scanning from
+  the body's matching close brace — and requires a byte-faithful reparse so a
+  partially-bracketed chain (which silently truncates without an ERROR node) is
+  rejected rather than accepted.
+
 ## [0.20.6] - 2026-06-28
 
 Patch release for parser recovery correctness, grammargen parity, and the

--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -322,3 +322,61 @@ func TestSwiftNormalTrailingClosureUnaffected(t *testing.T) {
 		t.Fatalf("expected exactly one lambda_literal: %s", root.SExpr(lang))
 	}
 }
+
+// issue #131: an `if … else if …` chain used to collapse the enclosing function
+// to _modifierless_function_declaration_no_body (with no ERROR node, like #123).
+// The trailing-closure ambiguity recovery only found the first `if` token — the
+// chained `if` keyword is swallowed into an ERROR node — so it bracketed only the
+// first condition, leaving the else-if's body brace absorbed as a trailing closure
+// and the function silently truncated. Following the chain through the source and
+// requiring a byte-faithful reparse recovers every condition.
+func TestSwiftElseIfChainRecoversFunction(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"else-if-trailing-return", "func f(_ x: Int) -> Int {\n    if x > 0 {\n        return 1\n    } else if x < 0 {\n        return 2\n    }\n    return 3\n}\n"},
+		{"else-if-else", "func f(_ x: Int) -> Int {\n    if x > 0 {\n        return 1\n    } else if x < 0 {\n        return 2\n    } else {\n        return 3\n    }\n}\n"},
+		{"three-way-chain", "func f(_ x: Int) -> Int {\n    if x > 0 {\n        return 1\n    } else if x < 0 {\n        return 2\n    } else if x == 5 {\n        return 5\n    } else {\n        return 3\n    }\n}\n"},
+		{"oneline-chain", "func f(_ x: Int) -> Int { if x > 0 { return 1 } else if x < 0 { return 2 } else { return 3 } }"},
+		{"else-if-no-return", "func f(_ x: Int) {\n    if x > 0 {\n        a()\n    } else if x < 0 {\n        b()\n    }\n}\n"},
+		{"class-method-chain", "class C {\n  func f(_ x: Int) -> Int {\n    if x > 0 { return 1 } else if x < 0 { return 2 }\n    return 3\n  }\n}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("recovered tree still reports error: %s", root.SExpr(lang))
+			}
+			if got, want := root.EndByte(), uint32(len(src)); got != want {
+				t.Fatalf("root end = %d, want %d (span not byte-faithful): %s", got, want, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "function_declaration"); got < 1 {
+				t.Fatalf("function_declaration count = %d, want >= 1: %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "_modifierless_function_declaration_no_body"); got != 0 {
+				t.Fatalf("function collapsed to _modifierless_function_declaration_no_body: %s", root.SExpr(lang))
+			}
+			// Each `else if` continuation must form a nested if_statement, not be
+			// absorbed as a trailing-closure lambda_literal.
+			if got := countSwiftNodeType(lang, root, "if_statement"); got < 2 {
+				t.Fatalf("if_statement count = %d, want >= 2 (chain not nested): %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "lambda_literal"); got != 0 {
+				t.Fatalf("else-if body misparsed as trailing-closure lambda_literal: %s", root.SExpr(lang))
+			}
+			// The synthetic parens injected during recovery must be unwrapped.
+			if got := countSwiftNodeType(lang, root, "tuple_expression"); got != 0 {
+				t.Fatalf("synthetic parenthesis leaked as tuple_expression: %s", root.SExpr(lang))
+			}
+		})
+	}
+}

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -56,7 +56,11 @@ func normalizeSwiftRecoveredTrailingClosureConditions(root *Node, source []byte,
 	// Apply only when removing the trailing-closure ambiguity makes the reparse
 	// fully clean. This keeps the rewrite trivially safe — a file with other,
 	// unrelated parse errors is left untouched rather than partially rewritten.
-	if tRoot.HasError() || tRoot.Type(lang) != "source_file" {
+	// The byte-faithfulness check is essential: an incompletely-bracketed chain
+	// still collapses to _modifierless_function_declaration_no_body and silently
+	// drops trailing statements *without* an ERROR node (#131), so HasError alone
+	// would accept a truncated, still-broken reparse.
+	if tRoot.HasError() || tRoot.Type(lang) != "source_file" || tRoot.endByte != uint32(len(transformed)) {
 		return
 	}
 	rm := &swiftRemap{
@@ -118,8 +122,12 @@ func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language
 		switch {
 		case (typ == "if" || typ == "while") && resultChildCount(n) == 0:
 			if parentType != "if_statement" && parentType != "while_statement" {
-				lp, rp, ok := swiftConditionParenPositions(source, n.endByte)
-				add(lp, rp, ok)
+				// Bracket this header's condition, then follow any `else if`
+				// continuation (#131): the chained `if` keyword is swallowed into
+				// an ERROR node, so it never surfaces as its own `if` token for the
+				// walk to find — we have to discover it by scanning the source from
+				// the body's matching close brace.
+				swiftCollectIfChainParens(source, n.endByte, add)
 			}
 		case typ == "for" && resultChildCount(n) == 0:
 			// A well-formed loop nests the `for` token inside a for_statement;
@@ -135,6 +143,194 @@ func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language
 	}
 	walk(root, nil)
 	return inserts
+}
+
+// swiftCollectIfChainParens brackets the condition of an `if`/`while` header that
+// begins right after a control-flow keyword ending at keywordEnd, then walks the
+// whole `if … else if …` chain bracketing each subsequent condition. The `else if`
+// continuation (#131) is found by source-scanning: when the chained `if`'s body
+// brace is greedily consumed as a trailing closure, the function collapses to
+// _modifierless_function_declaration_no_body and the chained `if` keyword is buried
+// in an ERROR node, so it never surfaces as its own token for the tree walk to find.
+// Anchoring on the first (surviving) `if` token and following the chain through the
+// source recovers every condition.
+func swiftCollectIfChainParens(source []byte, keywordEnd uint32, add func(lp, rp uint32, ok bool)) {
+	for {
+		condStart := swiftSkipHorizontalAndNewlineSpace(source, keywordEnd)
+		bodyOpen, found := swiftFindConditionBodyBrace(source, condStart)
+		if !found {
+			return
+		}
+		rp := bodyOpen
+		for rp > condStart {
+			switch source[rp-1] {
+			case ' ', '\t', '\n', '\r':
+				rp--
+				continue
+			}
+			break
+		}
+		// Skip the insertion when the span is empty or already parenthesised
+		// (`if (cond) {`); swiftConditionParenPositions applies the same guard.
+		if condStart < rp && !(source[condStart] == '(' && source[rp-1] == ')') {
+			add(condStart, rp, true)
+		}
+		// Follow an `else if` continuation: find the body's matching close brace,
+		// then look for `else if`. Anything else (a plain `else {` block, or the end
+		// of the chain) terminates the walk.
+		closeBrace, ok := swiftFindMatchingCloseBrace(source, bodyOpen)
+		if !ok {
+			return
+		}
+		nextKeywordEnd, isElseIf := swiftFindElseIfKeywordEnd(source, closeBrace+1)
+		if !isElseIf {
+			return
+		}
+		keywordEnd = nextKeywordEnd
+	}
+}
+
+// swiftFindMatchingCloseBrace scans forward from openPos (which must point at a
+// `{`) to its matching `}` at the same brace depth, skipping line/block comments,
+// string literals and ()/[] groups. Returns the index of the matching `}`, or
+// ok=false if none is found.
+func swiftFindMatchingCloseBrace(source []byte, openPos uint32) (uint32, bool) {
+	n := uint32(len(source))
+	if openPos >= n || source[openPos] != '{' {
+		return 0, false
+	}
+	depth := 0
+	i := openPos
+	for i < n {
+		b := source[i]
+		// Comments.
+		if b == '/' && i+1 < n {
+			if source[i+1] == '/' {
+				i += 2
+				for i < n && source[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			if source[i+1] == '*' {
+				i += 2
+				depthC := 1
+				for i+1 < n && depthC > 0 {
+					if source[i] == '/' && source[i+1] == '*' {
+						depthC++
+						i += 2
+					} else if source[i] == '*' && source[i+1] == '/' {
+						depthC--
+						i += 2
+					} else {
+						i++
+					}
+				}
+				continue
+			}
+		}
+		// Strings.
+		if b == '"' {
+			if i+2 < n && source[i+1] == '"' && source[i+2] == '"' {
+				i += 3
+				for i+2 < n && !(source[i] == '"' && source[i+1] == '"' && source[i+2] == '"') {
+					if source[i] == '\\' {
+						i++
+					}
+					i++
+				}
+				i += 3
+				continue
+			}
+			i++
+			for i < n && source[i] != '"' {
+				if source[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+			continue
+		}
+		switch b {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+		i++
+	}
+	return 0, false
+}
+
+// swiftFindElseIfKeywordEnd skips whitespace and comments from start and reports
+// whether an `else if` continuation begins there. On a match it returns the byte
+// offset just past the chained `if` keyword (the position swiftConditionParenPositions
+// expects). A plain `else {` block, or any other token, returns ok=false.
+func swiftFindElseIfKeywordEnd(source []byte, start uint32) (uint32, bool) {
+	i := swiftSkipSpaceAndComments(source, start)
+	n := uint32(len(source))
+	const elseKw = "else"
+	if i+uint32(len(elseKw)) > n || string(source[i:i+uint32(len(elseKw))]) != elseKw {
+		return 0, false
+	}
+	after := i + uint32(len(elseKw))
+	if after < n && isSwiftWordByte(source[after]) {
+		return 0, false // `elsewhere`, not the `else` keyword.
+	}
+	i = swiftSkipSpaceAndComments(source, after)
+	const ifKw = "if"
+	if i+uint32(len(ifKw)) > n || string(source[i:i+uint32(len(ifKw))]) != ifKw {
+		return 0, false // plain `else { … }`, no further condition.
+	}
+	end := i + uint32(len(ifKw))
+	if end < n && isSwiftWordByte(source[end]) {
+		return 0, false // `iffy`, not the `if` keyword.
+	}
+	return end, true
+}
+
+// swiftSkipSpaceAndComments advances past horizontal/newline whitespace and
+// line/block comments starting at i.
+func swiftSkipSpaceAndComments(source []byte, i uint32) uint32 {
+	n := uint32(len(source))
+	for i < n {
+		switch source[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+			continue
+		}
+		if source[i] == '/' && i+1 < n {
+			if source[i+1] == '/' {
+				i += 2
+				for i < n && source[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			if source[i+1] == '*' {
+				i += 2
+				depthC := 1
+				for i+1 < n && depthC > 0 {
+					if source[i] == '/' && source[i+1] == '*' {
+						depthC++
+						i += 2
+					} else if source[i] == '*' && source[i+1] == '/' {
+						depthC--
+						i += 2
+					} else {
+						i++
+					}
+				}
+				continue
+			}
+		}
+		break
+	}
+	return i
 }
 
 // swiftForIterableParenPositions locates the `in` keyword that follows a `for`

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -226,6 +226,10 @@ func swiftFindMatchingCloseBrace(source []byte, openPos uint32) (uint32, bool) {
 						i++
 					}
 				}
+				if depthC > 0 {
+					// Unclosed comment runs to EOF; don't treat its last byte as code.
+					i = n
+				}
 				continue
 			}
 		}
@@ -273,20 +277,19 @@ func swiftFindMatchingCloseBrace(source []byte, openPos uint32) (uint32, bool) {
 func swiftFindElseIfKeywordEnd(source []byte, start uint32) (uint32, bool) {
 	i := swiftSkipSpaceAndComments(source, start)
 	n := uint32(len(source))
-	const elseKw = "else"
-	if i+uint32(len(elseKw)) > n || string(source[i:i+uint32(len(elseKw))]) != elseKw {
+	// Byte-by-byte keyword matching keeps this allocation-free on the recovery path.
+	if i+4 > n || source[i] != 'e' || source[i+1] != 'l' || source[i+2] != 's' || source[i+3] != 'e' {
 		return 0, false
 	}
-	after := i + uint32(len(elseKw))
+	after := i + 4
 	if after < n && isSwiftWordByte(source[after]) {
 		return 0, false // `elsewhere`, not the `else` keyword.
 	}
 	i = swiftSkipSpaceAndComments(source, after)
-	const ifKw = "if"
-	if i+uint32(len(ifKw)) > n || string(source[i:i+uint32(len(ifKw))]) != ifKw {
+	if i+2 > n || source[i] != 'i' || source[i+1] != 'f' {
 		return 0, false // plain `else { … }`, no further condition.
 	}
-	end := i + uint32(len(ifKw))
+	end := i + 2
 	if end < n && isSwiftWordByte(source[end]) {
 		return 0, false // `iffy`, not the `if` keyword.
 	}
@@ -324,6 +327,10 @@ func swiftSkipSpaceAndComments(source []byte, i uint32) uint32 {
 					} else {
 						i++
 					}
+				}
+				if depthC > 0 {
+					// Unclosed comment runs to EOF.
+					i = n
 				}
 				continue
 			}


### PR DESCRIPTION
Fixes #131.

## Problem

With the bundled tree-sitter-swift grammar, an idiomatic `if … else if …` chain misparses. The else-if's body brace is greedily consumed as a trailing closure on its condition, so the enclosing `function_declaration` degrades to `_modifierless_function_declaration_no_body` and trailing statements are silently dropped — all **without** an `ERROR` node, so `HasError()` reports `false` and the failure escapes detection.

```swift
func f(_ x: Int) -> Int {
    if x > 0 {
        return 1
    } else if x < 0 {
        return 2
    }
    return 3
}
```

Before this change the raw parse truncates at `[0-102]`, with the else-if condition `x < 0 { return 2 }` absorbed as `call_expression(0, lambda_literal{…})`.

This is the same trailing-closure ambiguity already handled for plain `if`/`while` conditions (#118) and `for…in` iterables (#123) — only the `else if` continuation was missing.

## Root cause

The existing #118 recovery keys off `if`/`while` keyword **tokens** in the broken tree. In an else-if chain the chained `if` keyword is swallowed into an `ERROR` node, so it never surfaces as its own token — the recovery only ever bracketed the *first* condition. Worse, the acceptance gate checked `HasError()` alone, so the partially-bracketed reparse (still collapsed and truncated, but ERROR-free) was accepted, producing a still-broken tree.

## Fix

- **Follow the chain through the source.** From a detected `if`/`while` header, after locating the condition's body brace, scan to its matching close brace and look for an `else if` continuation; bracket that condition too, and repeat. This is anchored on the first (surviving) `if` token and is robust to the chained keyword being buried in an `ERROR` node. A plain `else { … }` block (or end of chain) terminates the walk, so clean parses are never disturbed.
- **Require a byte-faithful reparse.** The acceptance gate now also checks `tRoot.endByte == len(transformed)`, rejecting a partially-bracketed chain that still truncates the source without an `ERROR` node.

The recovery only runs on already-broken trees, the synthetic parens are unwrapped on remap (no `tuple_expression` leaks), and the result is byte-faithful.

## Tests

Added `TestSwiftElseIfChainRecoversFunction` covering else-if with a trailing return, else-if/else, three-way chains, one-liners, no-return bodies, and a class method. Each asserts: no error, byte-faithful span, a recovered `function_declaration`, no `_modifierless_function_declaration_no_body`, a nested `if_statement` chain (not an absorbed `lambda_literal`), and no leaked `tuple_expression`.

The existing #118/#123 Swift regression tests and the full suite remain green; `go vet` and `gofmt` are clean.