### PR TITLE
feat(parser): consumer opt-in forest parsing (Language field, grammargen flag, grammar.json)

### DIFF
--- a/cgo_harness/forest_corpus_parity_test.go
+++ b/cgo_harness/forest_corpus_parity_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TestForestCorpusParity is the correctness gate for promoting a language onto
-// the GSS-forest fast path (Parser.tryForestFastPath / languageWantsForest).
+// the GSS-forest fast path (Parser.tryForestFastPath / builtinForestDefaults).
 //
 // The runtime dispatch falls back to the production parser whenever the forest
 // declines (failure / error node / truncation), so it can never regress those

--- a/forest_incremental_correctness_test.go
+++ b/forest_incremental_correctness_test.go
@@ -85,7 +85,7 @@ func TestForestIncrementalCorrectness(t *testing.T) {
 		file string
 		lang func() *gts.Language
 	}{
-		// These are forest-default languages (languageWantsForest). erlang +
+		// These are forest-default languages (builtinForestDefaults). erlang +
 		// javascript do real forest-incremental reuse (must match fresh); scss,
 		// css, cmake and go are forest for full parses but demoted from the
 		// incremental path, so they reach the same assertion via fresh-parse

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -34,10 +34,11 @@ import (
 //	         dynamic_precedence-then-first-match selection for byte-identical out.
 
 // glrForestEnabled is the master switch for the GSS-forest fast path. ON by
-// default: the byte-range-verified languages in languageWantsForest dispatch to
-// the forest automatically (with production fallback). Set GOT_GLR_FOREST=0 to
-// disable globally; tests/benchmarks toggle via SetGLRForestEnabled. Languages
-// NOT in the allowlist always use production regardless of this switch.
+// default: the byte-range-verified languages in builtinForestDefaults (plus any
+// Language with WantsForest set, see parserWantsForest) dispatch to the forest
+// automatically (with production fallback). Set GOT_GLR_FOREST=0 to disable
+// globally; tests/benchmarks toggle via SetGLRForestEnabled. Languages that
+// want neither always use production regardless of this switch.
 var glrForestEnabled = os.Getenv("GOT_GLR_FOREST") != "0"
 
 // SetGLRForestEnabled toggles the GSS-forest path at runtime (tests/benchmarks).
@@ -117,20 +118,20 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 	p.forestDeclineStates = append(p.forestDeclineStates[:0], states...)
 }
 
-// languageWantsForest reports whether a language dispatches to the GSS-forest
-// GLR fast path by default. Restricted to languages whose production GLR parse
-// suffers the super-linear deep-stack-equivalence blowup AND that are verified
-// byte-identical to production on their real corpus by TestForestCorpusParity
-// (which compares full node BYTE RANGES, not just s-expressions — an s-expr-only
-// gate hid systematic span bugs). Measured byte-range-clean production-vs-forest
-// speedups on the real corpus: bash 803x, erlang 664x, cmake 166x, awk 202x,
-// javascript 36x, css 5x, scss 3x, c_sharp 3x. GraphQL is clean against
-// production here too, but stays out until the production tree is C-oracle-clean
-// on the ring matrix. The forest has no error recovery, so tryForestFastPath
-// falls back to production on any decline (failure / error / truncation); that
-// fallback means a language can never regress the cases it declines, but does
-// NOT catch a clean-but-different tree — so a language joins this list only
-// once its byte-range gate is green.
+// builtinForestDefaults is the curated set of built-in languages that dispatch
+// to the GSS-forest GLR fast path by default. Restricted to languages whose
+// production GLR parse suffers the super-linear deep-stack-equivalence blowup
+// AND that are verified byte-identical to production on their real corpus by
+// TestForestCorpusParity (which compares full node BYTE RANGES, not just
+// s-expressions — an s-expr-only gate hid systematic span bugs). Measured
+// byte-range-clean production-vs-forest speedups on the real corpus: bash
+// 803x, erlang 664x, cmake 166x, awk 202x, javascript 36x, css 5x, scss 3x,
+// c_sharp 3x. GraphQL is clean against production here too, but stays out
+// until the production tree is C-oracle-clean on the ring matrix. The forest
+// has no error recovery, so tryForestFastPath falls back to production on any
+// decline (failure / error / truncation); that fallback means a language can
+// never regress the cases it declines, but does NOT catch a clean-but-different
+// tree — so a language joins this list only once its byte-range gate is green.
 //
 // Verified NOT forest-amenable (2026-06-02 sweep — do NOT re-add as "divergent",
 // the older note was stale): python is forest byte-CLEAN (diverged=0) but ~0.8x
@@ -164,13 +165,33 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 //
 // One pre-existing gotreesitter-vs-C span quirk (off-by-3 on a few files) is
 // SHARED with production (not a forest regression), so it does not block.
-func languageWantsForest(name string) bool {
-	switch name {
-	case "bash", "erlang", "cmake", "css", "scss", "awk", "javascript", "c_sharp", "go":
-		return true
-	default:
-		return false
-	}
+//
+// Non-built-in languages opt in per-Language via Language.WantsForest (see
+// parserWantsForest) instead of joining this map — e.g. a grammargen consumer
+// generating its own grammar (a Pawn grammar, say) sets WantsForest directly
+// (or grammargen.Grammar.WantsForest, plumbed through assemble) without
+// forking this file. That path bypasses the byte-range parity certification
+// this curated set underwent; the decline->production fallback still prevents
+// hard failures, but a clean-but-different tree is the consumer's
+// responsibility.
+var builtinForestDefaults = map[string]bool{
+	"bash":       true,
+	"erlang":     true,
+	"cmake":      true,
+	"css":        true,
+	"scss":       true,
+	"awk":        true,
+	"javascript": true,
+	"c_sharp":    true,
+	"go":         true,
+}
+
+// parserWantsForest reports whether p's language dispatches to the GSS-forest
+// GLR fast path: either the Language opted in directly (WantsForest, set by a
+// grammargen consumer) or it is one of the curated built-ins in
+// builtinForestDefaults.
+func parserWantsForest(p *Parser) bool {
+	return p != nil && p.language != nil && (p.language.WantsForest || builtinForestDefaults[p.language.Name])
 }
 
 // tryForestFastPath attempts a full parse via the GSS-forest path and returns a
@@ -181,7 +202,7 @@ func languageWantsForest(name string) bool {
 // off by default so the production path is unchanged until per-language corpus
 // parity is verified and the gate is lifted.
 func (p *Parser) tryForestFastPath(source []byte) *Tree {
-	if !glrForestEnabled || p == nil || p.language == nil || !languageWantsForest(p.language.Name) {
+	if !glrForestEnabled || !parserWantsForest(p) {
 		return nil
 	}
 	arena := acquireNodeArena(arenaClassFull)

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestForestDispatchParity verifies the (default-on) forest fast path is
-// invisible: for a dispatched language (css ∈ languageWantsForest) the forest
+// invisible: for a dispatched language (css ∈ builtinForestDefaults) the forest
 // tree must be byte-identical to production — same s-expr AND same root byte
 // span — and anything the forest declines (malformed input, non-dispatched
 // languages) must match production because we fall back to it.

--- a/grammargen/diagnostics.go
+++ b/grammargen/diagnostics.go
@@ -670,6 +670,7 @@ func generateWithReportCtx(bgCtx context.Context, g *Grammar, opts reportBuildOp
 		return nil, fmt.Errorf("assemble: %w", err)
 	}
 	lang.Name = g.Name
+	lang.WantsForest = g.WantsForest
 
 	// Set after-whitespace lex states for states that need IMMTOKEN exclusion.
 	for _, entry := range afterWSModes {

--- a/grammargen/export_grammarjson.go
+++ b/grammargen/export_grammarjson.go
@@ -68,6 +68,10 @@ func ExportGrammarJSON(g *Grammar) ([]byte, error) {
 		out.Supertypes = []string{}
 	}
 
+	if g.WantsForest {
+		out.Gotreesitter = &grammarJSONExtensions{WantsForest: g.WantsForest}
+	}
+
 	data, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshal grammar.json: %w", err)
@@ -79,14 +83,15 @@ func ExportGrammarJSON(g *Grammar) ([]byte, error) {
 
 // exportGrammar is the JSON structure for grammar.json output.
 type exportGrammar struct {
-	Name       string        `json:"name"`
-	Word       string        `json:"word,omitempty"`
-	Rules      *orderedRules `json:"rules"`
-	Extras     []interface{} `json:"extras"`
-	Conflicts  [][]string    `json:"conflicts"`
-	Externals  []interface{} `json:"externals"`
-	Inline     []string      `json:"inline"`
-	Supertypes []string      `json:"supertypes"`
+	Name         string                 `json:"name"`
+	Word         string                 `json:"word,omitempty"`
+	Rules        *orderedRules          `json:"rules"`
+	Extras       []interface{}          `json:"extras"`
+	Conflicts    [][]string             `json:"conflicts"`
+	Externals    []interface{}          `json:"externals"`
+	Inline       []string               `json:"inline"`
+	Supertypes   []string               `json:"supertypes"`
+	Gotreesitter *grammarJSONExtensions `json:"gotreesitter,omitempty"`
 }
 
 // orderedRules preserves rule order when marshaling to JSON.

--- a/grammargen/forest_optin_test.go
+++ b/grammargen/forest_optin_test.go
@@ -1,0 +1,51 @@
+package grammargen
+
+import "testing"
+
+// TestGrammarWantsForestBlobRoundTrip verifies that Grammar.WantsForest is
+// plumbed onto the assembled Language and survives gob-blob encode/decode
+// (grammargen.Generate / decodeLanguageBlob) — consumer grammars set this
+// flag to opt a grammargen-generated Language into the GSS-forest fast path
+// without forking gotreesitter's curated builtinForestDefaults allowlist.
+func TestGrammarWantsForestBlobRoundTrip(t *testing.T) {
+	g := CalcGrammar()
+	g.WantsForest = true
+
+	lang, blob, err := GenerateLanguageAndBlob(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguageAndBlob failed: %v", err)
+	}
+	if !lang.WantsForest {
+		t.Errorf("directly generated Language.WantsForest = false, want true")
+	}
+
+	decoded, err := decodeLanguageBlob(blob)
+	if err != nil {
+		t.Fatalf("decodeLanguageBlob failed: %v", err)
+	}
+	if !decoded.WantsForest {
+		t.Errorf("blob round-trip Language.WantsForest = false, want true")
+	}
+}
+
+// TestGrammarWantsForestDefaultFalse verifies the flag defaults to false when
+// unset, so existing consumer grammars are unaffected until they opt in.
+func TestGrammarWantsForestDefaultFalse(t *testing.T) {
+	g := CalcGrammar()
+
+	lang, blob, err := GenerateLanguageAndBlob(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguageAndBlob failed: %v", err)
+	}
+	if lang.WantsForest {
+		t.Errorf("unset Grammar.WantsForest should default to false, got true")
+	}
+
+	decoded, err := decodeLanguageBlob(blob)
+	if err != nil {
+		t.Fatalf("decodeLanguageBlob failed: %v", err)
+	}
+	if decoded.WantsForest {
+		t.Errorf("blob round-trip of unset WantsForest should default to false, got true")
+	}
+}

--- a/grammargen/forest_optin_test.go
+++ b/grammargen/forest_optin_test.go
@@ -1,6 +1,124 @@
 package grammargen
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// minimalForestOptInGrammarJSON is a minimal valid grammar.json body — just
+// enough for ImportGrammarJSON to succeed (a single STRING rule) — used to
+// exercise the declarative "gotreesitter" extension object independent of any
+// other grammar feature.
+const minimalForestOptInGrammarJSON = `{
+	"name": "pawn",
+	"rules": {
+		"source_file": {"type": "STRING", "value": "a"}
+	},
+	"extras": [],
+	"conflicts": [],
+	"externals": [],
+	"inline": [],
+	"supertypes": [],
+	"word": "",
+	"reserved": {},
+	"precedences": [],
+	"gotreesitter": {"wantsForest": true}
+}`
+
+// TestImportGrammarJSONGotreesitterWantsForest verifies that ImportGrammarJSON
+// reads the namespaced "gotreesitter" extension object's "wantsForest" field
+// into Grammar.WantsForest — letting an existing grammar opt into the
+// GSS-forest fast path declaratively via grammar.json, with no Go code or
+// fork required.
+func TestImportGrammarJSONGotreesitterWantsForest(t *testing.T) {
+	g, err := ImportGrammarJSON([]byte(minimalForestOptInGrammarJSON))
+	if err != nil {
+		t.Fatalf("ImportGrammarJSON failed: %v", err)
+	}
+	if !g.WantsForest {
+		t.Errorf("Grammar.WantsForest = false, want true")
+	}
+}
+
+// TestImportGrammarJSONWithoutGotreesitterDefaultsFalse verifies that a
+// standard grammar.json with no "gotreesitter" object leaves WantsForest
+// false — the extension is purely additive and does not affect existing
+// grammars.
+func TestImportGrammarJSONWithoutGotreesitterDefaultsFalse(t *testing.T) {
+	data := []byte(`{
+		"name": "pawn",
+		"rules": {
+			"source_file": {"type": "STRING", "value": "a"}
+		},
+		"extras": [],
+		"conflicts": [],
+		"externals": [],
+		"inline": [],
+		"supertypes": [],
+		"word": "",
+		"reserved": {},
+		"precedences": []
+	}`)
+
+	g, err := ImportGrammarJSON(data)
+	if err != nil {
+		t.Fatalf("ImportGrammarJSON failed: %v", err)
+	}
+	if g.WantsForest {
+		t.Errorf("Grammar.WantsForest = true, want false (no gotreesitter object present)")
+	}
+}
+
+// TestGrammarJSONGotreesitterWantsForestRoundTrip verifies the full
+// Import -> Export -> Import cycle preserves WantsForest, and that
+// ExportGrammarJSON mirrors it back into a "gotreesitter" object.
+func TestGrammarJSONGotreesitterWantsForestRoundTrip(t *testing.T) {
+	g, err := ImportGrammarJSON([]byte(minimalForestOptInGrammarJSON))
+	if err != nil {
+		t.Fatalf("ImportGrammarJSON failed: %v", err)
+	}
+	if !g.WantsForest {
+		t.Fatalf("precondition failed: Grammar.WantsForest = false, want true")
+	}
+
+	data, err := ExportGrammarJSON(g)
+	if err != nil {
+		t.Fatalf("ExportGrammarJSON failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"gotreesitter"`) {
+		t.Errorf("exported grammar.json missing \"gotreesitter\" key: %s", data)
+	}
+	if !strings.Contains(string(data), `"wantsForest": true`) {
+		t.Errorf("exported grammar.json missing wantsForest:true: %s", data)
+	}
+
+	g2, err := ImportGrammarJSON(data)
+	if err != nil {
+		t.Fatalf("re-ImportGrammarJSON failed: %v", err)
+	}
+	if !g2.WantsForest {
+		t.Errorf("round-tripped Grammar.WantsForest = false, want true")
+	}
+}
+
+// TestExportGrammarJSONOmitsGotreesitterWhenUnset verifies that
+// ExportGrammarJSON's "gotreesitter" key is entirely absent (via omitempty)
+// when WantsForest is false, so standard grammars' exported JSON is
+// byte-identical to before this feature existed.
+func TestExportGrammarJSONOmitsGotreesitterWhenUnset(t *testing.T) {
+	g := CalcGrammar()
+	if g.WantsForest {
+		t.Fatalf("precondition failed: CalcGrammar().WantsForest = true, want false")
+	}
+
+	data, err := ExportGrammarJSON(g)
+	if err != nil {
+		t.Fatalf("ExportGrammarJSON failed: %v", err)
+	}
+	if strings.Contains(string(data), `"gotreesitter"`) {
+		t.Errorf("exported grammar.json unexpectedly contains \"gotreesitter\" key (should be omitted when unset): %s", data)
+	}
+}
 
 // TestGrammarWantsForestBlobRoundTrip verifies that Grammar.WantsForest is
 // plumbed onto the assembled Language and survives gob-blob encode/decode

--- a/grammargen/forest_optin_test.go
+++ b/grammargen/forest_optin_test.go
@@ -167,3 +167,23 @@ func TestGrammarWantsForestDefaultFalse(t *testing.T) {
 		t.Errorf("blob round-trip of unset WantsForest should default to false, got true")
 	}
 }
+
+// TestExtendGrammarPreservesWantsForest verifies ExtendGrammar inherits the base
+// grammar's WantsForest opt-in, the same way it carries every other Grammar-level
+// config flag. Without this, extending a forest-enabled base grammar would
+// silently drop the opt-in to false.
+func TestExtendGrammarPreservesWantsForest(t *testing.T) {
+	base := CalcGrammar()
+	base.WantsForest = true
+
+	ext := ExtendGrammar("calc_ext", base, func(g *Grammar) {})
+	if !ext.WantsForest {
+		t.Errorf("ExtendGrammar dropped base.WantsForest; extended grammar should inherit it")
+	}
+
+	// A base without the opt-in stays false.
+	ext2 := ExtendGrammar("calc_ext2", CalcGrammar(), func(g *Grammar) {})
+	if ext2.WantsForest {
+		t.Errorf("ExtendGrammar set WantsForest when base had none")
+	}
+}

--- a/grammargen/grammar.go
+++ b/grammargen/grammar.go
@@ -337,6 +337,7 @@ func ExtendGrammar(name string, base *Grammar, customize func(g *Grammar)) *Gram
 		SuppressEquivalentExternalReduceLookaheads: base.SuppressEquivalentExternalReduceLookaheads,
 		ExternalReduceFollowLookaheads:             append([]string(nil), base.ExternalReduceFollowLookaheads...),
 		PriorityInlinePatterns:                     append([]string(nil), base.PriorityInlinePatterns...),
+		WantsForest:                                base.WantsForest,
 	}
 
 	// Deep copy rules.

--- a/grammargen/grammar.go
+++ b/grammargen/grammar.go
@@ -83,6 +83,7 @@ type Grammar struct {
 	SuppressEquivalentExternalReduceLookaheads bool          // suppress external scanner validity for duplicate reduce-only lookaheads
 	ExternalReduceFollowLookaheads             []string      // external token names that may be valid after reducing in the current state
 	PriorityInlinePatterns                     []string      // anonymous pattern terminals that should win same-length ties against named tokens
+	WantsForest                                bool          // opt this grammar's assembled Language into the GSS-forest GLR fast path (see gotreesitter.Language.WantsForest)
 }
 
 // NewGrammar creates a new grammar with the given name.

--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -102,6 +102,10 @@ func ImportGrammarJSON(data []byte) (*Grammar, error) {
 	g := NewGrammar(raw.Name)
 	applyImportGrammarShapeHints(g)
 
+	if raw.Gotreesitter != nil {
+		g.WantsForest = raw.Gotreesitter.WantsForest
+	}
+
 	// Build named precedence → numeric value mapping from the precedences array.
 	// Each level is an ordered list from highest to lowest precedence.
 	// STRING entries define named precedence values.
@@ -268,6 +272,17 @@ func importPrecedenceLevels(rawLevels []json.RawMessage) [][]PrecEntry {
 	return levels
 }
 
+// grammarJSONExtensions holds gotreesitter-specific settings that extend the
+// standard tree-sitter grammar.json under a "gotreesitter" object. tree-sitter's
+// own tooling ignores this key; gotreesitter reads it during ImportGrammarJSON
+// and writes it back during ExportGrammarJSON (only when set).
+type grammarJSONExtensions struct {
+	// WantsForest opts the assembled Language into the GSS-forest GLR fast path
+	// (see gotreesitter.Language.WantsForest). Lets an existing grammar enable
+	// forest declaratively via grammar.json — no code change, no fork.
+	WantsForest bool `json:"wantsForest,omitempty"`
+}
+
 // jsonGrammar is the top-level structure of a grammar.json file.
 type jsonGrammar struct {
 	Name          string                       `json:"name"`
@@ -280,6 +295,7 @@ type jsonGrammar struct {
 	Word          string                       `json:"word"`
 	Reserved      map[string][]json.RawMessage `json:"reserved"`
 	Precedences   []json.RawMessage            `json:"precedences"`
+	Gotreesitter  *grammarJSONExtensions       `json:"gotreesitter,omitempty"`
 	ruleOrder     []string                     // populated during UnmarshalJSON
 	reservedOrder []string                     // populated during UnmarshalJSON
 }

--- a/language.go
+++ b/language.go
@@ -225,6 +225,15 @@ type Language struct {
 	// runtime rather than decoded from a checked-in ts2go blob.
 	GeneratedByGrammargen bool
 
+	// WantsForest opts this language into the GSS-forest GLR fast path. Built-in
+	// languages are enabled via the curated builtinForestDefaults map instead;
+	// consumers generating a Language via grammargen set this (directly or via
+	// grammargen.Grammar.WantsForest) to enable forest for their own grammar. This
+	// bypasses the byte-range parity certification built-ins undergo — the
+	// decline->production fallback still prevents hard failures on declined inputs,
+	// but a clean-but-different tree is the consumer's responsibility.
+	WantsForest bool
+
 	// LanguageVersion is the tree-sitter language ABI version.
 	// A value of 0 means "unknown/unspecified" and is treated as compatible.
 	LanguageVersion uint32

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -1,0 +1,57 @@
+package gotreesitter
+
+import "testing"
+
+// TestParserWantsForestFieldDrivesDispatch verifies that Language.WantsForest
+// drives the forest dispatch gate independently of the curated
+// builtinForestDefaults allowlist: a synthetic non-built-in language opts in
+// via the field, and a built-in name dispatches even when the field is left
+// false (its default comes from the curated map).
+func TestParserWantsForestFieldDrivesDispatch(t *testing.T) {
+	optedIn := &Parser{language: &Language{Name: "x", WantsForest: true}}
+	if !parserWantsForest(optedIn) {
+		t.Errorf("Language{Name:x, WantsForest:true} should dispatch to forest")
+	}
+
+	notOptedIn := &Parser{language: &Language{Name: "x", WantsForest: false}}
+	if parserWantsForest(notOptedIn) {
+		t.Errorf("Language{Name:x, WantsForest:false} (non-builtin) should NOT dispatch to forest")
+	}
+
+	builtinNoField := &Parser{language: &Language{Name: "bash", WantsForest: false}}
+	if !parserWantsForest(builtinNoField) {
+		t.Errorf("built-in language %q should dispatch to forest via builtinForestDefaults even with WantsForest=false", "bash")
+	}
+
+	if parserWantsForest(nil) {
+		t.Errorf("parserWantsForest(nil) should be false")
+	}
+	if parserWantsForest(&Parser{}) {
+		t.Errorf("parserWantsForest with nil language should be false")
+	}
+}
+
+// TestBuiltinForestDefaultsCuratedSet is a regression test asserting the
+// curated built-in forest allowlist (migrated from the former
+// languageWantsForest name switch) still contains exactly the languages
+// validated by TestForestCorpusParity / TestForestVsCOracleParity, including
+// "go" (promoted 2026-06-03; see the builtinForestDefaults doc comment).
+func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
+	want := []string{"bash", "erlang", "cmake", "css", "scss", "awk", "javascript", "c_sharp", "go"}
+	if len(builtinForestDefaults) != len(want) {
+		t.Fatalf("builtinForestDefaults has %d entries, want %d: %v", len(builtinForestDefaults), len(want), builtinForestDefaults)
+	}
+	for _, name := range want {
+		if !builtinForestDefaults[name] {
+			t.Errorf("builtinForestDefaults missing curated language %q", name)
+		}
+	}
+	// A handful of explicitly-NOT-forest-amenable languages (see the doc
+	// comment) must stay out of the curated set.
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php"}
+	for _, name := range notWanted {
+		if builtinForestDefaults[name] {
+			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Lets downstream consumers that generate a parser table with **grammargen** turn on the GSS-forest GLR fast path for their own grammar — **without forking gotreesitter**. Forest dispatch was previously gated by a hardcoded name switch (`languageWantsForest`), so a niche / out-of-tree grammar could only get full forest parsing by forking the repo and editing that switch.

## Motivation

A real downstream (a pure-Go Pawn toolchain for SA-MP/open.mp) had to fork gotreesitter **and rename the Go module** just to add one line to `languageWantsForest`. This makes forest opt-in a first-class, no-fork capability, reachable three ways.

## Three opt-in surfaces (least → most declarative)

1. **`Language.WantsForest`** (Go field) — set it on any `*Language`. Serialized via `gob`, so it's baked into `GenerateLanguageAndBlob` output and is backward-compatible (pre-existing blobs decode it as `false`).
2. **`grammargen.Grammar.WantsForest`** (Go flag) — set on the grammar IR before `GenerateLanguage`; plumbed onto the assembled `Language`.
3. **`grammar.json` `"gotreesitter": { "wantsForest": true }`** (declarative) — an existing grammar enables forest with a one-line JSON edit, no Go code. `ImportGrammarJSON` reads the namespaced extension into `Grammar.WantsForest`; `ExportGrammarJSON` mirrors it back (with `omitempty`, so standard grammars' output is byte-unchanged). tree-sitter's own tooling ignores the key.

```go
// (1) or (2)
g := myGrammar(); g.WantsForest = true
lang, _ := grammargen.GenerateLanguage(g)   // forest on — no fork
```
```json
// (3) — in grammar.json
{ "name": "pawn", "rules": { ... }, "gotreesitter": { "wantsForest": true } }
```

## Gate change

`languageWantsForest` name switch → `builtinForestDefaults` map (every validation comment preserved verbatim, including `go`). Runtime gate is now `parserWantsForest(p) = p.language.WantsForest || builtinForestDefaults[p.language.Name]`, still `AND`ed with the `glrForestEnabled` (`GOT_GLR_FOREST`) master switch.

## Correctness contract (pure opt-in)

Built-in languages keep their byte-range parity-certified defaults — **behavior is unchanged** (the map has the exact same entries as the old switch, verified by test). A consumer flipping `WantsForest` self-certifies: the forest's decline→production fallback still prevents hard failures on declined inputs, but a *clean-but-different* tree is the consumer's responsibility (documented on the field).

## Scope note

Targets `release/v0.20.8` (built on the `v0.20.7` tag). Forest *recovery* (`WantsForestRecover`) is intentionally omitted — that mechanism doesn't exist at this release; add the recover opt-in when it lands.

## Tests

- `TestParserWantsForestFieldDrivesDispatch` — the field drives dispatch; built-ins still dispatch with the field unset.
- `TestBuiltinForestDefaultsCuratedSet` — the curated set (incl. `go`) is preserved verbatim.
- `TestGrammarWantsForestBlobRoundTrip` / `TestGrammarWantsForestDefaultFalse` — `Grammar.WantsForest` survives `GenerateLanguageAndBlob` → decode (gob baking); defaults off.
- `TestImportGrammarJSONGotreesitterWantsForest` / `...WithoutGotreesitterDefaultsFalse` / `TestGrammarJSONGotreesitterWantsForestRoundTrip` / `TestExportGrammarJSONOmitsGotreesitterWhenUnset` — grammar.json import/export + round-trip, and standard output unchanged.
- Existing forest dispatch / corpus-parity tests unchanged.

`go build ./...`, `go vet`, and the forest + grammargen suites are green; behavior-preserving for every built-in language.
