### PR TITLE
fix(csharp): recover methods from large shredded namespaces (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Large C# files whose class body is shredded by a cumulative GLR failure (e.g.
+  Newtonsoft.Json's `JsonTextReader.cs` / `JsonReader.cs`) now recover their
+  `method_declaration` nodes instead of yielding only a comment-filled namespace
+  shell. Follow-up to #115/#116: the source-based type/method reconstruction was
+  gated off above 4096 bytes, so nothing rebuilt the members of a large collapsed
+  class. Namespace recovery now falls back, when the child-based pass surfaces no
+  method, to a **per-member bounded** source reconstruction — the type shell's
+  header is reparsed for its modifiers/name/base list, and each member is
+  recovered on its own (a method via signature-shell + lenient block, other
+  members by a single small wrapped reparse), skipping any that still won't parse.
+  Each reparse is a single small snippet capped by size and count and honors the
+  parser timeout, so the anti-OOM guarantees from #64/#98/#106 are preserved and
+  the whole-file 4096-byte gate is unchanged. `JsonTextReader.cs` now recovers 68
+  methods (was 0) and `JsonReader.cs` 41 (was 0) (#136).
+
 ## [0.20.8] - 2026-07-01
 
 Adds consumer-controllable forest parsing.

--- a/parser_csharp_namespace_recovery_test.go
+++ b/parser_csharp_namespace_recovery_test.go
@@ -1,6 +1,7 @@
 package gotreesitter_test
 
 import (
+	"os"
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
@@ -171,5 +172,47 @@ func TestCSharpCleanNamespaceUnaffected(t *testing.T) {
 	}
 	if methods != 3 {
 		t.Fatalf("methods = %d, want 3", methods)
+	}
+}
+
+// TestCSharpLargeShreddedNamespaceRecoversMethods is the regression test for
+// issue #136. A large real-world file (a trimmed Newtonsoft.Json JsonTextReader
+// excerpt) whose class body is shredded by a cumulative GLR failure used to
+// recover the namespace/class shell but zero method_declaration nodes, because
+// the source-based method reconstruction was gated off above 4096 bytes. The
+// per-member bounded source recovery should now surface the methods.
+func TestCSharpLargeShreddedNamespaceRecoversMethods(t *testing.T) {
+	lang := grammars.CSharpLanguage()
+	src, err := os.ReadFile("testdata/parser_result/csharp/jsontextreader_excerpt.cs")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if len(src) <= 4096 {
+		t.Fatalf("fixture must exceed the 4096-byte gate to exercise #136, got %d bytes", len(src))
+	}
+
+	parser := gotreesitter.NewParser(lang)
+	// Generous budget: the recovery is bounded per member and must finish well
+	// within this, so the parse must not stop early.
+	parser.SetTimeoutMicros(5_000_000)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	if tree.ParseStoppedEarly() {
+		t.Fatalf("parse stopped early: %s", tree.ParseRuntime().Summary())
+	}
+	root := tree.RootNode()
+	if got, want := root.EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d (span not byte-faithful)", got, want)
+	}
+	classes, methods := countCSharpDecls(t, lang, root)
+	if classes < 1 {
+		t.Fatalf("class_declaration count = %d, want >= 1", classes)
+	}
+	if methods < 8 {
+		t.Fatalf("method_declaration count = %d, want >= 8 (was 0 before #136)", methods)
 	}
 }

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -16,6 +16,16 @@ const (
 	// or many nested partial classes) the recovery loop can be triggered
 	// dozens of times per file, multiplying parse time/memory.
 	csharpMaxNamespaceRecoveries = 32
+
+	// Bounds for the lenient source-based type/member recovery (#136). Unlike the
+	// whole-file gate above, these are PER declaration: a large real file is
+	// recovered as many small, independently-bounded member reparses rather than
+	// one giant reparse, so the anti-OOM guarantees from #64/#98/#106 still hold.
+	// csharpMaxMemberRecoverySourceBytes caps the size of a single member snippet
+	// that will be reparsed; csharpMaxTypeMemberRecoveries caps how many members
+	// one type recovery will reparse.
+	csharpMaxMemberRecoverySourceBytes = 32768
+	csharpMaxTypeMemberRecoveries      = 4096
 )
 
 func normalizeCSharpCompatibility(root *Node, source []byte, p *Parser, lang *Language) {

--- a/parser_result_csharp_method_recovery.go
+++ b/parser_result_csharp_method_recovery.go
@@ -26,7 +26,7 @@ package gotreesitter
 // record/interface with per-member reparse), or — for small chunks such as enums
 // — a whole-chunk reparse. Unrecoverable chunks are skipped.
 func csharpRecoverNamespaceBodyMembersFromSource(source []byte, openBrace, closeBrace uint32, p *Parser, arena *nodeArena) ([]*Node, bool) {
-	if p == nil || p.language == nil || arena == nil || openBrace >= closeBrace || int(closeBrace) > len(source) {
+	if p == nil || p.language == nil || arena == nil || openBrace >= closeBrace || closeBrace > uint32(len(source)) {
 		return nil, false
 	}
 	bodyStart := openBrace + 1
@@ -89,7 +89,7 @@ func csharpRecoverNamespaceTypeMemberFromSource(source []byte, start, end uint32
 // recovered members. Returns ok=false for other keywords so the caller can fall
 // back to a whole-chunk reparse.
 func csharpRecoverSourceTypeDeclarationLenient(source []byte, start, end uint32, p *Parser, arena *nodeArena) (*Node, bool) {
-	if p == nil || p.language == nil || arena == nil || start >= end || int(end) > len(source) {
+	if p == nil || p.language == nil || arena == nil || start >= end || end > uint32(len(source)) {
 		return nil, false
 	}
 	lang := p.language
@@ -135,7 +135,7 @@ func csharpRecoverSourceTypeDeclarationLenient(source []byte, start, end uint32,
 // returns the recovered type-declaration node (with an empty declaration_list),
 // shifted to original coordinates. The synthetic body is replaced by the caller.
 func csharpRecoverTypeDeclarationShell(source []byte, start, openBrace uint32, p *Parser, arena *nodeArena) *Node {
-	if start >= openBrace || int(openBrace) > len(source) {
+	if start >= openBrace || openBrace > uint32(len(source)) {
 		return nil
 	}
 	header := source[start:openBrace]
@@ -174,6 +174,9 @@ func csharpRecoverTypeDeclarationShell(source []byte, start, openBrace uint32, p
 // csharpReplaceDeclarationList swaps the (synthetic, empty) declaration_list
 // child of a type declaration for the supplied one.
 func csharpReplaceDeclarationList(decl *Node, lang *Language, declList *Node) bool {
+	if decl == nil || declList == nil {
+		return false
+	}
 	for i, c := range decl.children {
 		if c != nil && c.Type(lang) == "declaration_list" {
 			decl.children[i] = declList

--- a/parser_result_csharp_method_recovery.go
+++ b/parser_result_csharp_method_recovery.go
@@ -177,6 +177,11 @@ func csharpReplaceDeclarationList(decl *Node, lang *Language, declList *Node) bo
 	for i, c := range decl.children {
 		if c != nil && c.Type(lang) == "declaration_list" {
 			decl.children[i] = declList
+			declList.parent = decl
+			declList.childIndex = int32(i)
+			// Re-wire parent pointers and child indices so upward navigation
+			// (method → class) stays consistent, matching csharpReplaceMethodBlock.
+			populateParentNode(decl, decl.children)
 			return true
 		}
 	}

--- a/parser_result_csharp_method_recovery.go
+++ b/parser_result_csharp_method_recovery.go
@@ -1,0 +1,468 @@
+package gotreesitter
+
+// Lenient source-based C# type/member recovery (issue #136).
+//
+// #115/#116 gave large real-world files (e.g. Newtonsoft.Json's JsonReader.cs /
+// JsonTextReader.cs) a recovered namespace_declaration shell, but its body still
+// held only comments — every class, and therefore every method_declaration, was
+// lost. Those files exceed the whole-file recovery gate
+// (csharpMaxTopLevelChunkRecoverySourceBytes), so the source-based type/method
+// reconstruction was never reached; and the child-based reconstruction needs a
+// clean sibling sequence the GLR failure destroys.
+//
+// This pass reconstructs a type declaration and its members directly from source
+// with PER-MEMBER bounds instead of a whole-file bound: the type shell (keyword,
+// name, base list, braces) is read from source, and each top-level member chunk
+// is reparsed on its own inside a minimal `class __Q { … }` wrapper. Because the
+// #115 failure is cumulative — every construct parses in isolation — reparsing
+// members one at a time recovers them, while a member that still won't parse is
+// skipped rather than failing the whole type. Every reparse is a single small
+// member snippet, capped by size and count, so the anti-OOM guarantees from
+// #64/#98/#106 hold on pathological input.
+
+// csharpRecoverNamespaceBodyMembersFromSource recovers the declarations inside a
+// namespace body [openBrace+1, closeBrace) directly from source: each top-level
+// chunk is recovered as a comment, a lenient type declaration (class/struct/
+// record/interface with per-member reparse), or — for small chunks such as enums
+// — a whole-chunk reparse. Unrecoverable chunks are skipped.
+func csharpRecoverNamespaceBodyMembersFromSource(source []byte, openBrace, closeBrace uint32, p *Parser, arena *nodeArena) ([]*Node, bool) {
+	if p == nil || p.language == nil || arena == nil || openBrace >= closeBrace || int(closeBrace) > len(source) {
+		return nil, false
+	}
+	bodyStart := openBrace + 1
+	if bodyStart >= closeBrace || bytesAreTrivia(source[bodyStart:closeBrace]) {
+		return nil, false
+	}
+	var members []*Node
+	relSpans := csharpTopLevelChunkSpans(source[bodyStart:closeBrace])
+	for _, rel := range relSpans {
+		spanStart := bodyStart + rel[0]
+		spanEnd := bodyStart + rel[1]
+		for _, part := range csharpSplitLeadingTopLevelCommentSpans(source, spanStart, spanEnd) {
+			if comment, ok := csharpRecoverTopLevelCommentNodeFromRange(source, part[0], part[1], p.language, arena); ok {
+				members = append(members, comment)
+				continue
+			}
+			if decl, ok := csharpRecoverNamespaceTypeMemberFromSource(source, part[0], part[1], p, arena); ok {
+				members = append(members, decl)
+			}
+			// else: unrecoverable chunk — skip it leniently.
+		}
+	}
+	// Only claim success when at least one real declaration (not just comments)
+	// was recovered.
+	for _, m := range members {
+		if m != nil && m.Type(p.language) != "comment" {
+			return members, true
+		}
+	}
+	return nil, false
+}
+
+// csharpRecoverNamespaceTypeMemberFromSource recovers a single namespace member
+// (a type declaration) from source[start:end). Large class/struct/record/
+// interface declarations are reconstructed shell + lenient members; other or
+// small declarations (e.g. enum, delegate) are reparsed whole when they fit.
+func csharpRecoverNamespaceTypeMemberFromSource(source []byte, start, end uint32, p *Parser, arena *nodeArena) (*Node, bool) {
+	start, end = csharpTrimSpaceBounds(source, start, end)
+	if start >= end {
+		return nil, false
+	}
+	if decl, ok := csharpRecoverSourceTypeDeclarationLenient(source, start, end, p, arena); ok {
+		return decl, true
+	}
+	// Fall back to reparsing the whole chunk (bounded) — handles enum/delegate and
+	// any type the lenient path doesn't reconstruct.
+	if end-start <= csharpMaxMemberRecoverySourceBytes {
+		if node, ok := csharpReparseWrappedNamespaceMember(source, start, end, p, arena); ok {
+			return node, true
+		}
+	}
+	return nil, false
+}
+
+// csharpRecoverSourceTypeDeclarationLenient reconstructs a class/struct/record/
+// interface declaration from source, recovering its body members one at a time
+// and skipping any that will not parse. Its header (modifiers, attributes, name,
+// type parameters and base list) is reparsed with a synthetic empty body so the
+// parser handles all header shapes, then the empty body is swapped for the real
+// recovered members. Returns ok=false for other keywords so the caller can fall
+// back to a whole-chunk reparse.
+func csharpRecoverSourceTypeDeclarationLenient(source []byte, start, end uint32, p *Parser, arena *nodeArena) (*Node, bool) {
+	if p == nil || p.language == nil || arena == nil || start >= end || int(end) > len(source) {
+		return nil, false
+	}
+	lang := p.language
+	kwStart := csharpSkipModifiersAndAttributes(source, start, end)
+	if !(csharpHasKeywordAt(source, kwStart, "class") ||
+		csharpHasKeywordAt(source, kwStart, "struct") ||
+		csharpHasKeywordAt(source, kwStart, "record") ||
+		csharpHasKeywordAt(source, kwStart, "interface")) {
+		return nil, false
+	}
+	openBrace := csharpFindTopLevelByte(source, kwStart, end, '{')
+	if openBrace >= end {
+		return nil, false
+	}
+	closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(end))
+	if closeBrace < 0 || uint32(closeBrace+1) > end {
+		return nil, false
+	}
+	members, ok := csharpRecoverClassBodyMembersLenient(source, uint32(openBrace), uint32(closeBrace), p, arena)
+	if !ok || len(members) == 0 {
+		return nil, false
+	}
+	// Reparse the header (up to and including `{`) with a synthetic `}` so the
+	// parser produces the type-declaration shell with modifiers/name/base parsed.
+	shell := csharpRecoverTypeDeclarationShell(source, start, uint32(openBrace), p, arena)
+	if shell == nil {
+		return nil, false
+	}
+	declList, ok := csharpBuildSourceDeclarationListNode(source, uint32(openBrace), uint32(closeBrace), members, lang, arena)
+	if !ok {
+		return nil, false
+	}
+	if !csharpReplaceDeclarationList(shell, lang, declList) {
+		return nil, false
+	}
+	shell.setHasError(false)
+	extendNodeEndTo(shell, uint32(closeBrace+1), source)
+	recomputeNodePointsFromBytes(shell, source)
+	return shell, true
+}
+
+// csharpRecoverTypeDeclarationShell reparses source[start:openBrace] + " {}" and
+// returns the recovered type-declaration node (with an empty declaration_list),
+// shifted to original coordinates. The synthetic body is replaced by the caller.
+func csharpRecoverTypeDeclarationShell(source []byte, start, openBrace uint32, p *Parser, arena *nodeArena) *Node {
+	if start >= openBrace || int(openBrace) > len(source) {
+		return nil
+	}
+	header := source[start:openBrace]
+	snippet := make([]byte, 0, len(header)+3)
+	snippet = append(snippet, header...)
+	snippet = append(snippet, " {}"...)
+	tree, err := p.parseForRecovery(snippet)
+	if err != nil || tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil
+	}
+	root := tree.RootNode()
+	if root.HasError() {
+		tree.Release()
+		return nil
+	}
+	var shell *Node
+	for _, name := range []string{"class_declaration", "struct_declaration", "record_declaration", "record_struct_declaration", "interface_declaration"} {
+		if n := csharpFindFirstNamedDescendantOfType(root, p.language, name); n != nil {
+			shell = cloneTreeNodesIntoArena(n, arena)
+			break
+		}
+	}
+	tree.Release()
+	if shell == nil {
+		return nil
+	}
+	if !shiftNodeBytes(shell, int64(start)) {
+		return nil
+	}
+	return shell
+}
+
+// csharpReplaceDeclarationList swaps the (synthetic, empty) declaration_list
+// child of a type declaration for the supplied one.
+func csharpReplaceDeclarationList(decl *Node, lang *Language, declList *Node) bool {
+	for i, c := range decl.children {
+		if c != nil && c.Type(lang) == "declaration_list" {
+			decl.children[i] = declList
+			return true
+		}
+	}
+	return false
+}
+
+// csharpSkipModifiersAndAttributes advances past leading attribute groups
+// (`[...]`) and modifier keywords to the start of the type keyword.
+func csharpSkipModifiersAndAttributes(source []byte, start, end uint32) uint32 {
+	i := csharpSkipSpaceBytes(source, start)
+	for i < end {
+		if source[i] == '[' {
+			close, ok := csharpFindMatchingParenLikeBracket(source, i, end)
+			if !ok {
+				return i
+			}
+			i = csharpSkipSpaceBytes(source, close+1)
+			continue
+		}
+		wordStart, wordEnd, ok := csharpScanIdentifierAt(source, i)
+		if !ok || wordStart != i {
+			return i
+		}
+		if !csharpIsTypeModifierWord(source[wordStart:wordEnd]) {
+			return i
+		}
+		i = csharpSkipSpaceBytes(source, wordEnd)
+	}
+	return i
+}
+
+// csharpFindMatchingParenLikeBracket returns the index of the `]` matching the
+// `[` at openPos, honoring nesting.
+func csharpFindMatchingParenLikeBracket(source []byte, openPos, end uint32) (uint32, bool) {
+	depth := 0
+	for i := openPos; i < end; i++ {
+		switch source[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// csharpIsTypeModifierWord reports whether word is a C# type-declaration modifier.
+func csharpIsTypeModifierWord(word []byte) bool {
+	switch string(word) {
+	case "public", "private", "protected", "internal", "static", "sealed",
+		"abstract", "partial", "readonly", "unsafe", "new", "file", "ref", "required":
+		return true
+	}
+	return false
+}
+
+// csharpRecoverClassBodyMembersLenient recovers the members inside a type body
+// [openBrace+1, closeBrace) one chunk at a time, reparsing each member in a
+// minimal class wrapper and skipping any that will not parse cleanly. Bounded by
+// csharpMaxMemberRecoverySourceBytes per member and csharpMaxTypeMemberRecoveries
+// members in total.
+func csharpRecoverClassBodyMembersLenient(source []byte, openBrace, closeBrace uint32, p *Parser, arena *nodeArena) ([]*Node, bool) {
+	if p == nil || p.language == nil || arena == nil || openBrace >= closeBrace {
+		return nil, false
+	}
+	bodyStart := openBrace + 1
+	if bodyStart >= closeBrace {
+		return nil, false
+	}
+	if bytesAreTrivia(source[bodyStart:closeBrace]) {
+		return nil, true
+	}
+	var members []*Node
+	reparses := 0
+	relSpans := csharpTopLevelChunkSpans(source[bodyStart:closeBrace])
+	for _, rel := range relSpans {
+		spanStart := bodyStart + rel[0]
+		spanEnd := bodyStart + rel[1]
+		for _, part := range csharpSplitLeadingTopLevelCommentSpans(source, spanStart, spanEnd) {
+			if comment, ok := csharpRecoverTopLevelCommentNodeFromRange(source, part[0], part[1], p.language, arena); ok {
+				members = append(members, comment)
+				continue
+			}
+			ps, pe := csharpTrimSpaceBounds(source, part[0], part[1])
+			if ps >= pe {
+				continue
+			}
+			// A nested type declaration recurses through the lenient path so its
+			// own members are recovered too.
+			if nested, ok := csharpRecoverSourceTypeDeclarationLenient(source, ps, pe, p, arena); ok {
+				members = append(members, nested)
+				continue
+			}
+			if reparses >= csharpMaxTypeMemberRecoveries || pe-ps > csharpMaxMemberRecoverySourceBytes {
+				continue
+			}
+			reparses++
+			// Reparse the whole member first — fast, and yields a complete body when
+			// it parses. If it doesn't (a method body with a construct that still
+			// fails in isolation), fall back for method-shaped members to the
+			// signature shell + lenient block path, which tolerates the bad body.
+			if member, ok := csharpReparseWrappedClassMember(source, ps, pe, p, arena); ok {
+				members = append(members, member)
+				continue
+			}
+			if source[pe-1] == '}' {
+				if method, ok := csharpRecoverClassMethodDeclarationFromRange(source, ps, pe, p, arena); ok {
+					members = append(members, method)
+					continue
+				}
+			}
+		}
+	}
+	return members, len(members) > 0
+}
+
+// csharpReparseWrappedClassMember reparses source[start:end) as a single member
+// inside `class __Q { … }` and returns the recovered member node shifted to
+// original coordinates, or ok=false if it does not parse cleanly to a single
+// recognised member.
+func csharpReparseWrappedClassMember(source []byte, start, end uint32, p *Parser, arena *nodeArena) (*Node, bool) {
+	const prefix = "class __Q {\n"
+	const suffix = "\n}\n"
+	wrapped := make([]byte, 0, len(prefix)+int(end-start)+len(suffix))
+	wrapped = append(wrapped, prefix...)
+	wrapped = append(wrapped, source[start:end]...)
+	wrapped = append(wrapped, suffix...)
+	tree, err := p.parseForRecovery(wrapped)
+	if err != nil || tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, false
+	}
+	root := tree.RootNode()
+	if root.HasError() {
+		tree.Release()
+		return nil, false
+	}
+	member := csharpExtractSingleWrappedClassMember(root, p.language, arena)
+	tree.Release()
+	if member == nil {
+		return nil, false
+	}
+	if !shiftNodeBytes(member, int64(start)-int64(len(prefix))) {
+		return nil, false
+	}
+	recomputeNodePointsFromBytes(member, source)
+	if member.startByte < start || member.endByte > end {
+		return nil, false
+	}
+	return member, true
+}
+
+// csharpReparseWrappedNamespaceMember reparses source[start:end) as a standalone
+// top-level declaration (e.g. an enum) and returns the single recovered
+// declaration node shifted to original coordinates.
+func csharpReparseWrappedNamespaceMember(source []byte, start, end uint32, p *Parser, arena *nodeArena) (*Node, bool) {
+	tree, err := p.parseForRecovery(source[start:end])
+	if err != nil || tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, false
+	}
+	startPoint := advancePointByBytes(Point{}, source[:start])
+	offsetRoot := tree.RootNodeWithOffset(start, startPoint)
+	if offsetRoot == nil || offsetRoot.HasError() {
+		tree.Release()
+		return nil, false
+	}
+	var found *Node
+	for _, child := range offsetRoot.children {
+		if child == nil || child.IsExtra() || child.HasError() {
+			continue
+		}
+		c := child
+		if c.Type(p.language) == "declaration" && len(c.children) == 1 && c.children[0] != nil {
+			c = c.children[0]
+		}
+		if !csharpIsRecoverableMemberType(c.Type(p.language)) {
+			continue
+		}
+		if found != nil {
+			tree.Release()
+			return nil, false // more than one declaration
+		}
+		found = cloneTreeNodesIntoArena(c, arena)
+	}
+	tree.Release()
+	return found, found != nil
+}
+
+// csharpExtractSingleWrappedClassMember returns the single member declaration
+// found inside the wrapper class's declaration_list, or nil if the wrapper did
+// not yield exactly one recognised member.
+func csharpExtractSingleWrappedClassMember(root *Node, lang *Language, arena *nodeArena) *Node {
+	if root == nil || lang == nil {
+		return nil
+	}
+	classDecl := csharpFindFirstNamedDescendantOfType(root, lang, "class_declaration")
+	if classDecl == nil {
+		return nil
+	}
+	var declList *Node
+	for _, c := range classDecl.children {
+		if c != nil && c.Type(lang) == "declaration_list" {
+			declList = c
+			break
+		}
+	}
+	if declList == nil {
+		return nil
+	}
+	var member *Node
+	for _, c := range declList.children {
+		if c == nil || !c.IsNamed() {
+			continue
+		}
+		n := c
+		if n.Type(lang) == "declaration" && len(n.children) == 1 && n.children[0] != nil {
+			n = n.children[0]
+		}
+		if n.Type(lang) == "comment" {
+			continue
+		}
+		if !csharpIsRecoverableMemberType(n.Type(lang)) {
+			return nil
+		}
+		if member != nil {
+			return nil // more than one member — chunk wasn't a single declaration
+		}
+		member = cloneTreeNodesIntoArena(n, arena)
+	}
+	return member
+}
+
+// csharpCountMethodDeclarations counts method_declaration nodes anywhere within
+// the given members (a type body's members are nested under its declaration_list).
+func csharpCountMethodDeclarations(members []*Node, lang *Language) int {
+	total := 0
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if n.Type(lang) == "method_declaration" {
+			total++
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	for _, m := range members {
+		walk(m)
+	}
+	return total
+}
+
+// csharpIsRecoverableMemberType reports whether typ is a C# member/type
+// declaration this recovery is willing to surface.
+func csharpIsRecoverableMemberType(typ string) bool {
+	switch typ {
+	case "class_declaration",
+		"struct_declaration",
+		"record_declaration",
+		"record_struct_declaration",
+		"interface_declaration",
+		"enum_declaration",
+		"delegate_declaration",
+		"namespace_declaration",
+		"file_scoped_namespace_declaration",
+		"constructor_declaration",
+		"destructor_declaration",
+		"field_declaration",
+		"method_declaration",
+		"property_declaration",
+		"event_declaration",
+		"event_field_declaration",
+		"indexer_declaration",
+		"operator_declaration",
+		"conversion_operator_declaration":
+		return true
+	}
+	return false
+}

--- a/parser_result_csharp_namespace.go
+++ b/parser_result_csharp_namespace.go
@@ -41,6 +41,18 @@ func csharpBuildRecoveredNamespaceDeclarationFromErrorRoot(errRoot *Node, source
 		return nil, false
 	}
 	members, ok := csharpRecoverNamespaceBodyMembersFromErrorRoot(errRoot, source, openBrace, uint32(closeBrace), p, lang, arena)
+	// The child-based pass recovers a type shell but, on the shredded bodies of
+	// large files (issue #136), none of its methods — and sometimes not even the
+	// class. When it yields no recoverable method, reconstruct the body's type
+	// declarations and their members directly from source (bounded per member),
+	// keeping it only if it surfaces at least as many methods.
+	if !ok || csharpCountMethodDeclarations(members, lang) == 0 {
+		if sourceMembers, sok := csharpRecoverNamespaceBodyMembersFromSource(source, openBrace, uint32(closeBrace), p, arena); sok {
+			if !ok || csharpCountMethodDeclarations(sourceMembers, lang) >= csharpCountMethodDeclarations(members, lang) {
+				members, ok = sourceMembers, true
+			}
+		}
+	}
 	if !ok || len(members) == 0 {
 		return nil, false
 	}

--- a/parser_result_csharp_namespace.go
+++ b/parser_result_csharp_namespace.go
@@ -44,11 +44,13 @@ func csharpBuildRecoveredNamespaceDeclarationFromErrorRoot(errRoot *Node, source
 	// The child-based pass recovers a type shell but, on the shredded bodies of
 	// large files (issue #136), none of its methods — and sometimes not even the
 	// class. When it yields no recoverable method, reconstruct the body's type
-	// declarations and their members directly from source (bounded per member),
-	// keeping it only if it surfaces at least as many methods.
+	// declarations and their members directly from source (bounded per member).
+	// Keep the source-based pass only when it surfaces strictly more methods (or
+	// the child-based pass failed outright): if neither finds a method, the
+	// child-based members are structurally more accurate for non-method members.
 	if !ok || csharpCountMethodDeclarations(members, lang) == 0 {
 		if sourceMembers, sok := csharpRecoverNamespaceBodyMembersFromSource(source, openBrace, uint32(closeBrace), p, arena); sok {
-			if !ok || csharpCountMethodDeclarations(sourceMembers, lang) >= csharpCountMethodDeclarations(members, lang) {
+			if !ok || csharpCountMethodDeclarations(sourceMembers, lang) > csharpCountMethodDeclarations(members, lang) {
 				members, ok = sourceMembers, true
 			}
 		}

--- a/testdata/parser_result/csharp/jsontextreader_excerpt.cs
+++ b/testdata/parser_result/csharp/jsontextreader_excerpt.cs
@@ -1,0 +1,377 @@
+// Trimmed excerpt of Newtonsoft.Json JsonTextReader.cs, pinned commit
+// 4f73e74372445108d2c1bda37b36e6f5e43402e0. Copyright (c) 2007 James
+// Newton-King, MIT License. Used only as a gotreesitter parse-recovery
+// regression fixture for issue #136 (see JamesNK/Newtonsoft.Json).
+namespace Newtonsoft.Json
+{
+    internal enum ReadType
+    {
+        Read,
+        ReadAsInt32,
+        ReadAsInt64,
+        ReadAsBytes,
+        ReadAsString,
+        ReadAsDecimal,
+        ReadAsDateTime,
+#if HAVE_DATE_TIME_OFFSET
+        ReadAsDateTimeOffset,
+#endif
+        ReadAsDouble,
+        ReadAsBoolean
+    }
+
+    /// <summary>
+    /// Represents a reader that provides fast, non-cached, forward-only access to JSON text data.
+    /// </summary>
+    public partial class JsonTextReader : JsonReader, IJsonLineInfo
+    {
+        private const char UnicodeReplacementChar = '\uFFFD';
+#if HAVE_BIG_INTEGER
+        private const int MaximumJavascriptIntegerCharacterLength = 380;
+#endif
+#if DEBUG
+        internal int LargeBufferLength { get; set; } = int.MaxValue / 2;
+#else
+        private const int LargeBufferLength = int.MaxValue / 2;
+#endif
+
+        private readonly TextReader _reader;
+        private char[]? _chars;
+        private int _charsUsed;
+        private int _charPos;
+        private int _lineStartPos;
+        private int _lineNumber;
+        private bool _isEndOfFile;
+        private StringBuffer _stringBuffer;
+        private StringReference _stringReference;
+        private IArrayPool<char>? _arrayPool;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonTextReader"/> class with the specified <see cref="TextReader"/>.
+        /// </summary>
+        /// <param name="reader">The <see cref="TextReader"/> containing the JSON data to read.</param>
+        public JsonTextReader(TextReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException(nameof(reader));
+            }
+
+            _reader = reader;
+            _lineNumber = 1;
+
+#if HAVE_ASYNC
+            _safeAsync = GetType() == typeof(JsonTextReader);
+#endif
+        }
+
+#if DEBUG
+        internal char[]? CharBuffer
+        {
+            get => _chars;
+            set => _chars = value;
+        }
+
+        internal int CharPos => _charPos;
+#endif
+
+        /// <summary>
+        /// Gets or sets the reader's property name table.
+        /// </summary>
+        public JsonNameTable? PropertyNameTable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reader's character buffer pool.
+        /// </summary>
+        public IArrayPool<char>? ArrayPool
+        {
+            get => _arrayPool;
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                _arrayPool = value;
+            }
+        }
+
+        private void EnsureBufferNotEmpty()
+        {
+            if (_stringBuffer.IsEmpty)
+            {
+                _stringBuffer = new StringBuffer(_arrayPool, 1024);
+            }
+        }
+
+        private void SetNewLine(bool hasNextChar)
+        {
+            MiscellaneousUtils.Assert(_chars != null);
+
+            if (hasNextChar && _chars[_charPos] == StringUtils.LineFeed)
+            {
+                _charPos++;
+            }
+
+            OnNewLine(_charPos);
+        }
+
+        private void OnNewLine(int pos)
+        {
+            _lineNumber++;
+            _lineStartPos = pos;
+        }
+
+        private void ParseString(char quote, ReadType readType)
+        {
+            _charPos++;
+
+            ShiftBufferIfNeeded();
+            ReadStringIntoBuffer(quote);
+            ParseReadString(quote, readType);
+        }
+
+        private void ParseReadString(char quote, ReadType readType)
+        { 
+            SetPostValueState(true);
+
+            switch (readType)
+            {
+                case ReadType.ReadAsBytes:
+                    Guid g;
+                    byte[] data;
+                    if (_stringReference.Length == 0)
+                    {
+                        data = CollectionUtils.ArrayEmpty<byte>();
+                    }
+                    else if (_stringReference.Length == 36 && ConvertUtils.TryConvertGuid(_stringReference.ToString(), out g))
+                    {
+                        data = g.ToByteArray();
+                    }
+                    else
+                    {
+                        data = Convert.FromBase64CharArray(_stringReference.Chars, _stringReference.StartIndex, _stringReference.Length);
+                    }
+
+                    SetToken(JsonToken.Bytes, data, false);
+                    break;
+                case ReadType.ReadAsString:
+                    string text = _stringReference.ToString();
+
+                    SetToken(JsonToken.String, text, false);
+                    _quoteChar = quote;
+                    break;
+                case ReadType.ReadAsInt32:
+                case ReadType.ReadAsDecimal:
+                case ReadType.ReadAsBoolean:
+                    // caller will convert result
+                    break;
+                default:
+                    if (_dateParseHandling != DateParseHandling.None)
+                    {
+                        DateParseHandling dateParseHandling;
+                        if (readType == ReadType.ReadAsDateTime)
+                        {
+                            dateParseHandling = DateParseHandling.DateTime;
+                        }
+#if HAVE_DATE_TIME_OFFSET
+                        else if (readType == ReadType.ReadAsDateTimeOffset)
+                        {
+                            dateParseHandling = DateParseHandling.DateTimeOffset;
+                        }
+#endif
+                        else
+                        {
+                            dateParseHandling = _dateParseHandling;
+                        }
+
+                        if (dateParseHandling == DateParseHandling.DateTime)
+                        {
+                            if (DateTimeUtils.TryParseDateTime(_stringReference, DateTimeZoneHandling, DateFormatString, Culture, out DateTime dt))
+                            {
+                                SetToken(JsonToken.Date, dt, false);
+                                return;
+                            }
+                        }
+#if HAVE_DATE_TIME_OFFSET
+                        else
+                        {
+                            if (DateTimeUtils.TryParseDateTimeOffset(_stringReference, DateFormatString, Culture, out DateTimeOffset dt))
+                            {
+                                SetToken(JsonToken.Date, dt, false);
+                                return;
+                            }
+                        }
+#endif
+                    }
+
+                    SetToken(JsonToken.String, _stringReference.ToString(), false);
+                    _quoteChar = quote;
+                    break;
+            }
+        }
+
+        private static void BlockCopyChars(char[] src, int srcOffset, char[] dst, int dstOffset, int count)
+        {
+            const int charByteCount = 2;
+
+            Buffer.BlockCopy(src, srcOffset * charByteCount, dst, dstOffset * charByteCount, count * charByteCount);
+        }
+
+        private void ShiftBufferIfNeeded()
+        {
+            MiscellaneousUtils.Assert(_chars != null);
+
+            // once in the last 10% of the buffer, or buffer is already very large then
+            // shift the remaining content to the start to avoid unnecessarily increasing
+            // the buffer size when reading numbers/strings
+            int length = _chars.Length;
+            if (length - _charPos <= length * 0.1 || length >= LargeBufferLength)
+            {
+                int count = _charsUsed - _charPos;
+                if (count > 0)
+                {
+                    BlockCopyChars(_chars, _charPos, _chars, 0, count);
+                }
+
+                _lineStartPos -= _charPos;
+                _charPos = 0;
+                _charsUsed = count;
+                _chars[_charsUsed] = '\0';
+            }
+        }
+
+        private int ReadData(bool append)
+        {
+            return ReadData(append, 0);
+        }
+
+        private void PrepareBufferForReadData(bool append, int charsRequired)
+        {
+            MiscellaneousUtils.Assert(_chars != null);
+
+            // char buffer is full
+            if (_charsUsed + charsRequired >= _chars.Length - 1)
+            {
+                if (append)
+                {
+                    int doubledArrayLength = _chars.Length * 2;
+
+                    // copy to new array either double the size of the current or big enough to fit required content
+                    int newArrayLength = Math.Max(
+                        doubledArrayLength < 0 ? int.MaxValue : doubledArrayLength, // handle overflow
+                        _charsUsed + charsRequired + 1);
+
+                    // increase the size of the buffer
+                    char[] dst = BufferUtils.RentBuffer(_arrayPool, newArrayLength);
+
+                    BlockCopyChars(_chars, 0, dst, 0, _chars.Length);
+
+                    BufferUtils.ReturnBuffer(_arrayPool, _chars);
+
+                    _chars = dst;
+                }
+                else
+                {
+                    int remainingCharCount = _charsUsed - _charPos;
+
+                    if (remainingCharCount + charsRequired + 1 >= _chars.Length)
+                    {
+                        // the remaining count plus the required is bigger than the current buffer size
+                        char[] dst = BufferUtils.RentBuffer(_arrayPool, remainingCharCount + charsRequired + 1);
+
+                        if (remainingCharCount > 0)
+                        {
+                            BlockCopyChars(_chars, _charPos, dst, 0, remainingCharCount);
+                        }
+
+                        BufferUtils.ReturnBuffer(_arrayPool, _chars);
+
+                        _chars = dst;
+                    }
+                    else
+                    {
+                        // copy any remaining data to the beginning of the buffer if needed and reset positions
+                        if (remainingCharCount > 0)
+                        {
+                            BlockCopyChars(_chars, _charPos, _chars, 0, remainingCharCount);
+                        }
+                    }
+
+                    _lineStartPos -= _charPos;
+                    _charPos = 0;
+                    _charsUsed = remainingCharCount;
+                }
+            }
+        }
+
+        private int ReadData(bool append, int charsRequired)
+        {
+            if (_isEndOfFile)
+            {
+                return 0;
+            }
+
+            PrepareBufferForReadData(append, charsRequired);
+            MiscellaneousUtils.Assert(_chars != null);
+
+            int attemptCharReadCount = _chars.Length - _charsUsed - 1;
+
+            int charsRead = _reader.Read(_chars, _charsUsed, attemptCharReadCount);
+
+            _charsUsed += charsRead;
+
+            if (charsRead == 0)
+            {
+                _isEndOfFile = true;
+            }
+
+            _chars[_charsUsed] = '\0';
+            return charsRead;
+        }
+
+        private bool EnsureChars(int relativePosition, bool append)
+        {
+            if (_charPos + relativePosition >= _charsUsed)
+            {
+                return ReadChars(relativePosition, append);
+            }
+
+            return true;
+        }
+
+        private bool ReadChars(int relativePosition, bool append)
+        {
+            if (_isEndOfFile)
+            {
+                return false;
+            }
+
+            int charsRequired = _charPos + relativePosition - _charsUsed + 1;
+
+            int totalCharsRead = 0;
+
+            // it is possible that the TextReader doesn't return all data at once
+            // repeat read until the required text is returned or the reader is out of content
+            do
+            {
+                int charsRead = ReadData(append, charsRequired - totalCharsRead);
+
+                // no more content
+                if (charsRead == 0)
+                {
+                    break;
+                }
+
+                totalCharsRead += charsRead;
+            } while (totalCharsRead < charsRequired);
+
+            if (totalCharsRead < charsRequired)
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #136. Follow-up to #115/#116.

## Problem

Large real-world C# files whose class body is shredded by a cumulative GLR failure (e.g. `Newtonsoft.Json`'s `JsonTextReader.cs` / `JsonReader.cs`) recovered a `namespace_declaration` shell (per #115) but its body held **only comments** — every class, and therefore every `method_declaration`, was lost. Downstream symbol/complexity extraction got 0 methods.

The source-based type/method reconstruction was hard-gated to files ≤ `csharpMaxTopLevelChunkRecoverySourceBytes` (4096 bytes), so on a large collapsed class nothing rebuilt the members; and the child-based reconstruction needs a clean `modifier* type identifier parameter_list` sibling sequence that the cumulative GLR failure destroys.

## Approach

When the child-based namespace pass surfaces **no method**, fall back to a **per-member bounded** source reconstruction (`parser_result_csharp_method_recovery.go`):

- The type shell (modifiers, name, type parameters, base list) is reparsed from the header with a synthetic empty body, so the parser handles all header shapes; the empty body is then swapped for the recovered members.
- Each body member is recovered on its own: a method via the existing signature-shell + lenient-block path (`csharpRecoverClassMethodDeclarationFromRange`, which blanks the body for the signature reparse and tolerates an unparseable body), other members (fields, properties, events, nested types) via a single small wrapped reparse. Members that still won't parse are skipped rather than failing the whole type.

## Boundedness

The bounds are **per declaration, not per file** — the key difference from the whole-file 4096 gate (kept unchanged):

- each reparse is a single small member snippet, capped by `csharpMaxMemberRecoverySourceBytes` and `csharpMaxTypeMemberRecoveries`;
- every reparse goes through `parseForRecovery`, which honors the parser timeout/cancellation, so a tight budget degrades gracefully to partial/zero recovery rather than running unbounded.

This preserves the anti-OOM guarantees from #64/#98/#106.

## Results

| File | Methods before | Methods after |
|---|---|---|
| `JsonTextReader.cs` | 0 | 68 |
| `JsonReader.cs` | 0 | 41 |

Members guarded by interspersed `#if`/`#endif` preprocessor directives remain out of scope (a handful of the ~72).

## Testing

- New `TestCSharpLargeShreddedNamespaceRecoversMethods` over a trimmed, MIT-attributed `JsonTextReader` excerpt fixture (>4096 bytes) — asserts `class_declaration >= 1`, `method_declaration >= 8` (was 0), byte-faithful root, and not stopped early.
- All existing `#115`/`#116` C# recovery tests and the C# boundedness suite (`TestCSharp*StaysBounded`) still pass, as do `TestTop50ParseSmokeNoErrors` / `TestSupportedLanguagesParseSmoke`.

Docker parity harness was unavailable in this environment; validation used the real Newtonsoft files plus the scoped Go tests above.