### PR TITLE
optimize(parser/glr): merge cache precision, fix grammargen uint16 overflow

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -141,12 +141,22 @@ type glrMergeScratch struct {
 	stackEquivCache   []glrStackEquivCacheEntry
 	frontierHashCache []glrStackFrontierHashCacheEntry
 	cErrorCost        map[*Node]glrCErrorCostEntry
-	materializing     map[*gssNode]glrMaterializingShapeHash
+	shapePrefixCache  []glrShapePrefixCacheEntry
+	shapePrefixEpoch  uint32
+	shapePrefixBytes  int64
 	cleanZeroEpoch    uint32
 	cleanZeroScan     uint32
 	cleanZeroCache    map[*gssNode]gssCleanZeroErrorCacheEntry
+	cleanZeroFront    []glrCleanZeroFrontCacheEntry
+	cleanZeroBytes    int64
 	cleanZeroStack    []*gssNode
 	cleanZeroVisited  []*gssNode
+	// preflight + mergeSeen are pooled per-scratch so the GSS merge can-phase
+	// stops allocating a preflight object plus several maps per merge attempt
+	// (the dominant profile cost on low-stack GLR grammars like json — maps
+	// were rebuilt every canMergeNodes call).
+	preflight         *gssMainPreflight
+	mergeSeen         map[gssMergePair]bool
 	pythonShallow     bool
 	budgetBytes       int64
 	resultBytes       int64
@@ -162,9 +172,49 @@ type glrCErrorCostEntry struct {
 	cost uint32
 }
 
+// glrMaterializingShapeHash is, per GSS node, the rolling materializing
+// shape hash of the spine prefix root..node (inclusive) plus the number of
+// materializing entries in that prefix. Cached in the set-associative
+// glrMergeScratch.shapePrefixCache, keyed by (node pointer, shapePrefixEpoch).
+// An entry stays valid until the epoch is bumped (bumpShapePrefixEpoch). The
+// epoch is bumped on every mutation that can change a live node's root->head
+// prefix hash:
+//   - the start of each parse epoch (beginEquivEpoch);
+//   - a successful GSS main merge that rewrites link 0 of surviving nodes, both
+//     the collapse-phase merge (tryGSSMainMergeResult) and the dispatch-time
+//     merge (tryGSSMainMergeForParser via gssMainMerge -> setGSSMainLink);
+//   - retargetStackEntryPayload rewriting a spine node's parseState in place at
+//     its reduce call sites (parseState feeds gssEntryHash, which the prefix
+//     rolls in).
+//
+// Prefix caching makes the per-head shape hash O(new entries) instead of
+// O(full spine), which is what made the merge attempt loop super-linear on
+// large clean files (python cliff RCA 2026-07).
 type glrMaterializingShapeHash struct {
-	hash uint64
-	ok   bool
+	hash  uint64
+	count uint32
+}
+
+// glrShapePrefixCacheEntry is one slot of the pointer-keyed 2-way
+// set-associative materializing-shape prefix cache (same layout discipline as
+// frontierHashCache — a Go map here was the top profile cost on wide-GLR
+// python inputs).
+type glrShapePrefixCacheEntry struct {
+	node   uintptr
+	epoch  uint32
+	prefix glrMaterializingShapeHash
+}
+
+// glrCleanZeroFrontCacheEntry is one slot of the pointer-keyed 2-way
+// set-associative front cache for gssNodeCleanZeroErrorAllLinksWithScratch
+// results. The map cache (cleanZeroCache) stays authoritative — it also holds
+// DFS scan bookkeeping — but the hot repeated lookups (cost fast path +
+// gssMainCanMergeWithScratch, several per merge attempt) hit this array
+// first. clean is only valid when epoch matches the scratch cleanZeroEpoch.
+type glrCleanZeroFrontCacheEntry struct {
+	node  uintptr
+	epoch uint32
+	clean bool
 }
 
 type glrMergeKey struct {
@@ -715,52 +765,72 @@ func stackMaterializingShapeHash(s glrStack) (uint64, bool) {
 }
 
 func stackMaterializingShapeHashWithScratch(scratch *glrMergeScratch, s glrStack) (uint64, bool) {
-	if len(s.entries) == 0 && s.gss.head != nil && scratch != nil {
-		if cached, ok := scratch.materializing[s.gss.head]; ok {
-			return cached.hash, cached.ok
+	if len(s.entries) == 0 {
+		if s.gss.head == nil {
+			return 0, false
 		}
+		prefix := gssMaterializingShapePrefix(scratch, s.gss.head)
+		return finalizeMaterializingShapeHash(prefix)
 	}
 
 	h := gssHashSeed
-	count := 0
-	if len(s.entries) > 0 {
-		for i := range s.entries {
-			if !stackEntryMaterializesForResult(s.entries[i]) {
-				continue
-			}
-			h = gssEntryHash(h, s.entries[i])
-			count++
+	count := uint32(0)
+	for i := range s.entries {
+		if !stackEntryMaterializesForResult(s.entries[i]) {
+			continue
 		}
-	} else {
-		for n := s.gss.head; n != nil; n = n.prev {
-			if !stackEntryMaterializesForResult(n.entry) {
-				continue
-			}
-			h = gssEntryHash(h, n.entry)
-			count++
-		}
+		h = gssEntryHash(h, s.entries[i])
+		count++
 	}
-	if count == 0 {
-		if len(s.entries) == 0 && s.gss.head != nil && scratch != nil {
-			if scratch.materializing == nil {
-				scratch.materializing = make(map[*gssNode]glrMaterializingShapeHash)
-			}
-			scratch.materializing[s.gss.head] = glrMaterializingShapeHash{}
-		}
+	return finalizeMaterializingShapeHash(glrMaterializingShapeHash{hash: h, count: count})
+}
+
+func finalizeMaterializingShapeHash(prefix glrMaterializingShapeHash) (uint64, bool) {
+	if prefix.count == 0 {
 		return 0, false
 	}
-	h ^= uint64(count)
+	h := prefix.hash
+	h ^= uint64(prefix.count)
 	h *= gssHashPrime
 	if h == 0 {
 		h = 1
 	}
-	if len(s.entries) == 0 && s.gss.head != nil && scratch != nil {
-		if scratch.materializing == nil {
-			scratch.materializing = make(map[*gssNode]glrMaterializingShapeHash)
-		}
-		scratch.materializing[s.gss.head] = glrMaterializingShapeHash{hash: h, ok: true}
-	}
 	return h, true
+}
+
+// gssMaterializingShapePrefix returns the rolling materializing shape hash of
+// the spine root..n along the primary (link 0) chain, memoizing every prefix
+// in scratch.shapePrefixCache so a fresh head only pays for its own new
+// entries. The rolling direction is root->head (matching the s.entries path
+// and gssNodeHash) so shared prefixes are reusable across heads and tokens.
+func gssMaterializingShapePrefix(scratch *glrMergeScratch, n *gssNode) glrMaterializingShapeHash {
+	if n == nil {
+		return glrMaterializingShapeHash{hash: gssHashSeed}
+	}
+	if cached, ok := lookupShapePrefixCache(scratch, n); ok {
+		return cached
+	}
+	var local [32]*gssNode
+	pending := local[:0]
+	prefix := glrMaterializingShapeHash{hash: gssHashSeed}
+	for cur := n; cur != nil; cur = cur.prev {
+		if cached, ok := lookupShapePrefixCache(scratch, cur); ok {
+			prefix = cached
+			break
+		}
+		pending = append(pending, cur)
+	}
+	for i := len(pending) - 1; i >= 0; i-- {
+		cur := pending[i]
+		if stackEntryMaterializesForResult(cur.entry) {
+			prefix = glrMaterializingShapeHash{
+				hash:  gssEntryHash(prefix.hash, cur.entry),
+				count: prefix.count + 1,
+			}
+		}
+		storeShapePrefixCache(scratch, cur, prefix)
+	}
+	return prefix
 }
 
 func gssStacksHaveDistinctMaterializingShapes(a, b *glrStack) bool {
@@ -802,6 +872,15 @@ const (
 	// cache: it only covers live stack heads encountered during merge bucketing.
 	glrStackFrontierHashCacheSize     = 4096
 	glrStackFrontierHashCacheSetCount = glrStackFrontierHashCacheSize / 2
+	// glrShapePrefixCache covers every live spine node of every live stack (not
+	// just heads): wide-GLR python inputs keep ~1.5K stacks × ~12 spine nodes
+	// live at once, so this is sized like the node-equivalence cache.
+	glrShapePrefixCacheSize     = 16384
+	glrShapePrefixCacheSetCount = glrShapePrefixCacheSize / 2
+	// glrCleanZeroFrontCache fronts the map-based cleanZeroCache for the
+	// merge-attempt hot path (see glrCleanZeroFrontCacheEntry).
+	glrCleanZeroFrontCacheSize     = 16384
+	glrCleanZeroFrontCacheSetCount = glrCleanZeroFrontCacheSize / 2
 	// Depth is part of the cache key. Keep it bounded so large recursive
 	// comparisons cannot alias through a narrowing conversion.
 	glrNodeEquivCacheMaxDepth = 1<<16 - 1
@@ -828,11 +907,7 @@ func (s *glrMergeScratch) beginEquivEpoch() {
 	} else if len(s.cErrorCost) > 0 {
 		clear(s.cErrorCost)
 	}
-	if len(s.materializing) > maxRetainedMergeResultCap {
-		s.materializing = nil
-	} else if len(s.materializing) > 0 {
-		clear(s.materializing)
-	}
+	s.bumpShapePrefixEpoch()
 	if len(s.equivCache) == 0 {
 		s.equivCache = make([]glrNodeEquivCacheEntry, glrNodeEquivCacheSize)
 		s.equivCacheBytes = glrNodeEquivCacheBytesForCap(cap(s.equivCache))
@@ -958,9 +1033,131 @@ func (s *glrMergeScratch) beginCleanZeroEpoch() {
 	}
 	if s.cleanZeroEpoch == ^uint32(0) {
 		clear(s.cleanZeroCache)
+		clear(s.cleanZeroFront)
 		s.cleanZeroEpoch = 0
 	}
 	s.cleanZeroEpoch++
+}
+
+// ensureMergeHotCaches provisions the fixed-size merge-attempt caches. Called
+// only for persistent (pooled, per-parse) scratches so their cost amortizes
+// across the whole parse; one-shot local scratches never allocate these.
+func (s *glrMergeScratch) ensureMergeHotCaches() {
+	if s == nil {
+		return
+	}
+	if len(s.shapePrefixCache) == 0 {
+		s.shapePrefixCache = make([]glrShapePrefixCacheEntry, glrShapePrefixCacheSize)
+		s.shapePrefixBytes = int64(cap(s.shapePrefixCache)) * int64(unsafe.Sizeof(glrShapePrefixCacheEntry{}))
+	}
+	if len(s.cleanZeroFront) == 0 {
+		s.cleanZeroFront = make([]glrCleanZeroFrontCacheEntry, glrCleanZeroFrontCacheSize)
+		s.cleanZeroBytes = int64(cap(s.cleanZeroFront)) * int64(unsafe.Sizeof(glrCleanZeroFrontCacheEntry{}))
+	}
+}
+
+// bumpShapePrefixEpoch invalidates every cached materializing-shape prefix in
+// O(1). Called when a GSS main merge rewrites links (stale prefixes) and at
+// the start of each parse epoch.
+func (s *glrMergeScratch) bumpShapePrefixEpoch() {
+	if s == nil {
+		return
+	}
+	if s.shapePrefixEpoch == ^uint32(0) {
+		clear(s.shapePrefixCache)
+		s.shapePrefixEpoch = 0
+	}
+	s.shapePrefixEpoch++
+}
+
+func lookupShapePrefixCache(scratch *glrMergeScratch, n *gssNode) (glrMaterializingShapeHash, bool) {
+	if scratch == nil || len(scratch.shapePrefixCache) == 0 || scratch.shapePrefixEpoch == 0 || n == nil {
+		return glrMaterializingShapeHash{}, false
+	}
+	p := uintptr(unsafe.Pointer(n))
+	idx := shapePrefixCacheIndex(p)
+	primary := &scratch.shapePrefixCache[idx]
+	if primary.epoch == scratch.shapePrefixEpoch && primary.node == p {
+		return primary.prefix, true
+	}
+	victim := &scratch.shapePrefixCache[idx+1]
+	if victim.epoch == scratch.shapePrefixEpoch && victim.node == p {
+		*primary, *victim = *victim, *primary
+		return primary.prefix, true
+	}
+	return glrMaterializingShapeHash{}, false
+}
+
+// storeShapePrefixCache never allocates: the backing array is provisioned only
+// for persistent parse scratches (ensureMergeHotCaches). One-shot local
+// scratches (mergeStacks, diagnostics) skip caching rather than paying a
+// 384KiB zeroed allocation per call — that allocation pattern showed up as a
+// GC/memclr storm on the C# per-member recovery path.
+func storeShapePrefixCache(scratch *glrMergeScratch, n *gssNode, prefix glrMaterializingShapeHash) {
+	if scratch == nil || scratch.shapePrefixEpoch == 0 || n == nil || len(scratch.shapePrefixCache) == 0 {
+		return
+	}
+	p := uintptr(unsafe.Pointer(n))
+	idx := shapePrefixCacheIndex(p)
+	scratch.shapePrefixCache[idx+1] = scratch.shapePrefixCache[idx]
+	scratch.shapePrefixCache[idx] = glrShapePrefixCacheEntry{
+		node:   p,
+		epoch:  scratch.shapePrefixEpoch,
+		prefix: prefix,
+	}
+}
+
+func shapePrefixCacheIndex(p uintptr) int {
+	h := uint64(p)
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	h *= 0xc4ceb9fe1a85ec53
+	h ^= h >> 33
+	return int(h&uint64(glrShapePrefixCacheSetCount-1)) << 1
+}
+
+func lookupCleanZeroFrontCache(scratch *glrMergeScratch, n *gssNode) (bool, bool) {
+	if scratch == nil || len(scratch.cleanZeroFront) == 0 || scratch.cleanZeroEpoch == 0 || n == nil {
+		return false, false
+	}
+	p := uintptr(unsafe.Pointer(n))
+	idx := cleanZeroFrontCacheIndex(p)
+	primary := &scratch.cleanZeroFront[idx]
+	if primary.epoch == scratch.cleanZeroEpoch && primary.node == p {
+		return primary.clean, true
+	}
+	victim := &scratch.cleanZeroFront[idx+1]
+	if victim.epoch == scratch.cleanZeroEpoch && victim.node == p {
+		*primary, *victim = *victim, *primary
+		return primary.clean, true
+	}
+	return false, false
+}
+
+// storeCleanZeroFrontCache never allocates (see storeShapePrefixCache).
+func storeCleanZeroFrontCache(scratch *glrMergeScratch, n *gssNode, clean bool) {
+	if scratch == nil || scratch.cleanZeroEpoch == 0 || n == nil || len(scratch.cleanZeroFront) == 0 {
+		return
+	}
+	p := uintptr(unsafe.Pointer(n))
+	idx := cleanZeroFrontCacheIndex(p)
+	scratch.cleanZeroFront[idx+1] = scratch.cleanZeroFront[idx]
+	scratch.cleanZeroFront[idx] = glrCleanZeroFrontCacheEntry{
+		node:  p,
+		epoch: scratch.cleanZeroEpoch,
+		clean: clean,
+	}
+}
+
+func cleanZeroFrontCacheIndex(p uintptr) int {
+	h := uint64(p)
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	h *= 0xc4ceb9fe1a85ec53
+	h ^= h >> 33
+	return int(h&uint64(glrCleanZeroFrontCacheSetCount-1)) << 1
 }
 
 func lookupNodeEquivCache(scratch *glrMergeScratch, a, b *Node, depth int) (bool, bool) {
@@ -1381,6 +1578,50 @@ func cRecoverTraceInteresting(a, b glrStack) bool {
 	return a.cRec != nil || b.cRec != nil || a.cRecoverMissingGroup != nil || b.cRecoverMissingGroup != nil
 }
 
+// cStackCleanZeroErrorCostForMerge is an exact fast path for
+// cStackErrorCostForMergeWithScratch (parser_recover_c.go). When every subtree
+// reachable from the stack head is provably error/missing-free — via the same
+// epoch-managed all-links clean-zero cache gssMainCanMergeWithScratch already
+// trusts for real merges — the walked per-subtree sum is exactly zero (every
+// cost source in cNodeErrorCostLang requires an errorSymbol node, a missing
+// node, or a hasError subtree, all of which force the entry's clean-zero check
+// false). Only the per-stack aux terms remain; they MUST mirror the tail of
+// cStackErrorCostForMergeWithScratch. ok=false means "not provably clean":
+// callers fall back to the full walk, so this can never change a cost value.
+//
+// This matters because on clean parses of large real files the full walk is
+// O(spine length) map lookups per call and runs ~100x per token from the merge
+// attempt loop, which made the cost competition super-linear in file size
+// (python cliff RCA 2026-07).
+func cStackCleanZeroErrorCostForMerge(scratch *glrMergeScratch, s *glrStack) (uint32, bool) {
+	if s == nil {
+		return 0, true
+	}
+	if scratch == nil || len(s.entries) != 0 || s.gss.head == nil {
+		return 0, false
+	}
+	if !gssNodeCleanZeroErrorAllLinksWithScratch(scratch, s.gss.head) {
+		return 0, false
+	}
+	var cost uint32
+	if s.cPaused || (s.cRec != nil && s.cRec.openErr == nil) {
+		cost += cErrCostPerRecovery
+	}
+	if s.cRec != nil && s.cRec.extraRecoveries > 0 {
+		cost += cErrCostPerRecovery * uint32(s.cRec.extraRecoveries)
+	}
+	return cost, true
+}
+
+// cStackErrorCostForMergeCached returns cStackErrorCostForMergeWithScratch's
+// value, preferring the exact clean-zero fast path.
+func cStackErrorCostForMergeCached(scratch *glrMergeScratch, lang *Language, s *glrStack) uint32 {
+	if cost, ok := cStackCleanZeroErrorCostForMerge(scratch, s); ok {
+		return cost
+	}
+	return cStackErrorCostForMergeWithScratch(scratch, lang, s)
+}
+
 func cRecoveryMergeCostsDiffer(scratch *glrMergeScratch, a, b *glrStack) bool {
 	if scratch == nil || !scratch.cRecoveryCost || a == nil || b == nil {
 		return false
@@ -1388,11 +1629,22 @@ func cRecoveryMergeCostsDiffer(scratch *glrMergeScratch, a, b *glrStack) bool {
 	if !stacksHeaderEquivalent(*a, *b) {
 		return false
 	}
-	return cStackErrorCostForMergeWithScratch(scratch, scratch.language, a) != cStackErrorCostForMergeWithScratch(scratch, scratch.language, b)
+	return cStackErrorCostForMergeCached(scratch, scratch.language, a) != cStackErrorCostForMergeCached(scratch, scratch.language, b)
 }
 
 func cRecoveryMergeCostsDifferForParser(p *Parser, a, b *glrStack) bool {
 	if p == nil || !p.errorCostCompetitionEnabled() {
+		return false
+	}
+	// Sticky per-parse gate: before anything cost-relevant has happened this
+	// pass every stack's error cost is provably zero, so the costs cannot
+	// differ (see crecoveryCostCompetitionRelevant). The pair-local recovery
+	// state check keeps this function sound for callers that construct
+	// paused/recovering stacks directly (unit tests, future call sites)
+	// without having gone through the dispatch flip sites.
+	if !p.crecoveryCostCompetitionRelevant &&
+		!(a != nil && (a.cPaused || a.cRec != nil)) &&
+		!(b != nil && (b.cPaused || b.cRec != nil)) {
 		return false
 	}
 	scratch := glrMergeScratch{
@@ -2428,7 +2680,16 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 	if !gssMainCanMergeForParser(p, a, b) {
 		return false
 	}
-	return gssMainMerge(a, b)
+	merged := gssMainMerge(a, b)
+	if merged && p != nil {
+		// Mirror tryGSSMainMergeResult (bumpShapePrefixEpoch above): a successful
+		// main merge rewrites link 0 (setGSSMainLink) of surviving nodes during
+		// dispatch, so every root->head shape prefix cached in the active merge
+		// scratch may now be stale. p.mergeScratch is nil outside a parse and
+		// bumpShapePrefixEpoch is nil-safe.
+		p.mergeScratch.bumpShapePrefixEpoch()
+	}
+	return merged
 }
 
 func gssMainCanMergeWithScratch(scratch *glrMergeScratch, a, b *glrStack) bool {
@@ -2487,28 +2748,61 @@ func gssNodeCanReach(from, target *gssNode) bool {
 	if from == nil || target == nil {
 		return false
 	}
-	seen := make(map[*gssNode]bool)
-	var walk func(*gssNode) bool
-	walk = func(cur *gssNode) bool {
-		if cur == nil {
-			return false
+	if from == target {
+		return true
+	}
+	// Iterative DFS with a small linear visited set: these walks are almost
+	// always tiny, and the per-call map this used to allocate was a top
+	// profile cost on merge-heavy grammars (rust). Falls back to a map only
+	// for pathologically large link graphs.
+	var stackLocal [64]*gssNode
+	var visitedLocal [64]*gssNode
+	stack := stackLocal[:0]
+	visited := visitedLocal[:0]
+	var visitedMap map[*gssNode]bool
+	isVisited := func(n *gssNode) bool {
+		if visitedMap != nil {
+			return visitedMap[n]
 		}
-		if cur == target {
-			return true
-		}
-		if seen[cur] {
-			return false
-		}
-		seen[cur] = true
-		for i := 0; i < cur.linkCount(); i++ {
-			prev, _ := cur.link(i)
-			if walk(prev) {
+		for _, v := range visited {
+			if v == n {
 				return true
 			}
 		}
 		return false
 	}
-	return walk(from)
+	markVisited := func(n *gssNode) {
+		if visitedMap != nil {
+			visitedMap[n] = true
+			return
+		}
+		if len(visited) == cap(visited) && len(visited) >= len(visitedLocal) {
+			visitedMap = make(map[*gssNode]bool, 2*len(visited))
+			for _, v := range visited {
+				visitedMap[v] = true
+			}
+			visitedMap[n] = true
+			return
+		}
+		visited = append(visited, n)
+	}
+	stack = append(stack, from)
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur == nil || isVisited(cur) {
+			continue
+		}
+		if cur == target {
+			return true
+		}
+		markVisited(cur)
+		for i := 0; i < cur.linkCount(); i++ {
+			prev, _ := cur.link(i)
+			stack = append(stack, prev)
+		}
+	}
+	return false
 }
 
 func gssNodeUniformByteOffset(n *gssNode, seen map[*gssNode]bool) (uint32, bool) {
@@ -2561,7 +2855,11 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 	if scratch.cleanZeroEpoch == 0 {
 		scratch.beginCleanZeroEpoch()
 	}
+	if clean, ok := lookupCleanZeroFrontCache(scratch, n); ok {
+		return clean
+	}
 	if entry, ok := scratch.cleanZeroCache[n]; ok && entry.resultEpoch == scratch.cleanZeroEpoch {
+		storeCleanZeroFrontCache(scratch, n, entry.clean)
 		return entry.clean
 	}
 	if scratch.cleanZeroCache == nil {
@@ -2590,6 +2888,7 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 		if ok && entry.resultEpoch == scratch.cleanZeroEpoch {
 			if !entry.clean {
 				scratch.cleanZeroCache[n] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: false}
+				storeCleanZeroFrontCache(scratch, n, false)
 				scratch.cleanZeroStack = stack[:0]
 				scratch.cleanZeroVisited = visited[:0]
 				return false
@@ -2608,6 +2907,7 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 				(stackEntryNodeHasError(linkEntry) || stackEntryNodeIsMissing(linkEntry) || stackEntryNodeSymbol(linkEntry) == errorSymbol) {
 				scratch.cleanZeroCache[cur] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: false}
 				scratch.cleanZeroCache[n] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: false}
+				storeCleanZeroFrontCache(scratch, n, false)
 				scratch.cleanZeroStack = stack[:0]
 				scratch.cleanZeroVisited = visited[:0]
 				return false
@@ -2618,6 +2918,7 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 	for _, node := range visited {
 		scratch.cleanZeroCache[node] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: true}
 	}
+	storeCleanZeroFrontCache(scratch, n, true)
 	scratch.cleanZeroStack = stack[:0]
 	scratch.cleanZeroVisited = visited[:0]
 	return true
@@ -2742,6 +3043,15 @@ type gssMainPreflight struct {
 	cleanSeen   map[*gssNode]bool
 	cleanStack  []*gssNode
 	cleanVisit  []*gssNode
+	// scratch, when non-nil, lets the preflight consult the parse-long
+	// clean-zero caches instead of rebuilding a private verdict map per
+	// preflight (valid only while no virtual links exist — virtual links can
+	// change a node's all-links cleanliness mid-simulation).
+	scratch *glrMergeScratch
+	// offsetSeen is a reusable scratch map for uniformByteOffset walks
+	// (cleared per use) so pooled preflights stop allocating two maps per
+	// nodesCanMerge call.
+	offsetSeen map[*gssNode]bool
 }
 
 const maxGSSPreflightReachCacheEntries = 32768
@@ -2770,7 +3080,72 @@ func newGSSMainPreflight(seen map[gssMergePair]bool) *gssMainPreflight {
 	}
 }
 
+// acquirePreflightForScratch returns the scratch's pooled preflight, reset to
+// the same observable state a fresh newGSSMainPreflight(seen) would have for
+// an EMPTY seen map: all simulation caches invalidated (cleared), no virtual
+// links, strict reachability. The pooled instance additionally carries
+// scratch so cleanZeroErrorAllLinks can use the parse-long clean-zero caches
+// while no virtual links exist. Callers must not retain the returned
+// preflight beyond the current can-phase.
+func acquirePreflightForScratch(scratch *glrMergeScratch) *gssMainPreflight {
+	if scratch == nil {
+		return newGSSMainPreflight(nil)
+	}
+	pf := scratch.preflight
+	if pf == nil {
+		pf = &gssMainPreflight{
+			virtualLink: make(map[*gssNode][]gssMainLink),
+			reachStrict: true,
+			reachEpoch:  1,
+		}
+		scratch.preflight = pf
+	}
+	if pf.seen == nil {
+		pf.seen = make(map[gssMergePair]bool, 16)
+	} else if len(pf.seen) > 0 {
+		clear(pf.seen)
+	}
+	if len(pf.virtualLink) > 0 {
+		clear(pf.virtualLink)
+	}
+	if len(pf.reachCache) > 0 {
+		clear(pf.reachCache)
+	}
+	if len(pf.reachSeen) > 0 {
+		clear(pf.reachSeen)
+	}
+	if len(pf.cleanCache) > 0 {
+		clear(pf.cleanCache)
+	}
+	if len(pf.cleanSeen) > 0 {
+		clear(pf.cleanSeen)
+	}
+	pf.reachStrict = true
+	pf.reachEpoch = 1
+	pf.scratch = scratch
+	return pf
+}
+
+// acquireMergeSeenForScratch returns the scratch's pooled (cleared) seen map
+// for the GSS merge mutate phase, matching a fresh make(map[gssMergePair]bool).
+func acquireMergeSeenForScratch(scratch *glrMergeScratch) map[gssMergePair]bool {
+	if scratch == nil {
+		return make(map[gssMergePair]bool)
+	}
+	if scratch.mergeSeen == nil {
+		scratch.mergeSeen = make(map[gssMergePair]bool, 16)
+	} else if len(scratch.mergeSeen) > 0 {
+		clear(scratch.mergeSeen)
+	}
+	return scratch.mergeSeen
+}
+
 func (p *gssMainPreflight) linkCount(n *gssNode) int {
+	if len(p.virtualLink) == 0 {
+		// Fast path: no virtual links anywhere, skip the per-node map lookup
+		// (this runs once per node visit in every preflight DFS).
+		return n.linkCount()
+	}
 	return n.linkCount() + len(p.virtualLink[n])
 }
 
@@ -2899,6 +3274,13 @@ func (p *gssMainPreflight) cleanZeroErrorAllLinks(n *gssNode) bool {
 	if n == nil {
 		return true
 	}
+	if p.scratch != nil && len(p.virtualLink) == 0 {
+		// With no virtual links the preflight's link view is exactly the real
+		// graph, so the parse-long clean-zero caches give the same verdict the
+		// private DFS below would compute — without rebuilding a per-preflight
+		// verdict map every merge attempt.
+		return gssNodeCleanZeroErrorAllLinksWithScratch(p.scratch, n)
+	}
 	if p.cleanCache != nil {
 		if entry, ok := p.cleanCache[n]; ok {
 			if !entry.clean {
@@ -3017,9 +3399,21 @@ func (p *gssMainPreflight) nodesCanMerge(a, b *gssNode) bool {
 	if !p.cleanZeroErrorAllLinks(a) || !p.cleanZeroErrorAllLinks(b) {
 		return false
 	}
-	aOffset, aOK := p.uniformByteOffset(a, make(map[*gssNode]bool))
-	bOffset, bOK := p.uniformByteOffset(b, make(map[*gssNode]bool))
+	aOffset, aOK := p.uniformByteOffset(a, p.acquireOffsetSeen())
+	bOffset, bOK := p.uniformByteOffset(b, p.acquireOffsetSeen())
 	return aOK && bOK && aOffset == bOffset
+}
+
+// acquireOffsetSeen returns the preflight's reusable (cleared) cycle-guard map
+// for a single uniformByteOffset walk. Both walks in nodesCanMerge complete
+// before any re-entrant preflight call, so one map suffices.
+func (p *gssMainPreflight) acquireOffsetSeen() map[*gssNode]bool {
+	if p.offsetSeen == nil {
+		p.offsetSeen = make(map[*gssNode]bool, 16)
+	} else if len(p.offsetSeen) > 0 {
+		clear(p.offsetSeen)
+	}
+	return p.offsetSeen
 }
 
 func gssMainCanAddLinkSeen(n *gssNode, prev *gssNode, entry stackEntry, seen map[gssMergePair]bool) bool {
@@ -3236,6 +3630,14 @@ func gssMainMergeNodesSeenMutate(a, b *gssNode, seen map[gssMergePair]bool) bool
 }
 
 func gssMainMerge(a, b *glrStack) bool {
+	return gssMainMergeWithScratch(nil, a, b)
+}
+
+// gssMainMergeWithScratch is gssMainMerge with a pooled preflight + seen map
+// when scratch is non-nil: the can-phase and mutate-phase each get a cleared
+// reusable map instead of freshly allocated ones (identical observable
+// semantics — gssMainMergeNodes always started both phases with empty maps).
+func gssMainMergeWithScratch(scratch *glrMergeScratch, a, b *glrStack) bool {
 	ah, bh := a.gss.head, b.gss.head
 	if ah == nil || bh == nil {
 		return false
@@ -3243,7 +3645,14 @@ func gssMainMerge(a, b *glrStack) bool {
 	if ah == bh {
 		return true
 	}
-	return gssMainMergeNodes(ah, bh)
+	if scratch == nil {
+		return gssMainMergeNodes(ah, bh)
+	}
+	pf := acquirePreflightForScratch(scratch)
+	if !pf.canMergeNodes(ah, bh) {
+		return false
+	}
+	return gssMainMergeNodesSeenMutate(ah, bh, acquireMergeSeenForScratch(scratch))
 }
 
 func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int, stack *glrStack) (merged bool, attempted bool) {
@@ -3261,9 +3670,11 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 		gssStacksHaveDistinctMaterializingShapesWithScratch(scratch, &result[idx], stack) {
 		return false, true
 	}
-	merged = gssMainMerge(&result[idx], stack)
-	if merged && scratch != nil && len(scratch.materializing) > 0 {
-		clear(scratch.materializing)
+	merged = gssMainMergeWithScratch(scratch, &result[idx], stack)
+	if merged && scratch != nil {
+		// A successful main merge can rewrite link 0 (prev/entry) of surviving
+		// nodes (setGSSMainLink), so every cached spine prefix may be stale.
+		scratch.bumpShapePrefixEpoch()
 	}
 	return merged, true
 }
@@ -3343,14 +3754,14 @@ func cRecoveryCostClassForSlot(scratch *glrMergeScratch, result []glrStack, slot
 	if scratch == nil || !scratch.cRecoveryCost || slot == nil || stack == nil || mergeSlotTrackedCount(slot) == 0 {
 		return -1, false
 	}
-	candidateCost := cStackErrorCostForMergeWithScratch(scratch, scratch.language, stack)
+	candidateCost := cStackErrorCostForMergeCached(scratch, scratch.language, stack)
 	sawDifferentCost := false
 	for j, n := 0, mergeSlotTrackedCount(slot); j < n; j++ {
 		idx := mergeSlotIndexAt(slot, j)
 		if idx < 0 || idx >= len(result) || !stacksHeaderEquivalent(result[idx], *stack) {
 			continue
 		}
-		if cStackErrorCostForMergeWithScratch(scratch, scratch.language, &result[idx]) == candidateCost {
+		if cStackErrorCostForMergeCached(scratch, scratch.language, &result[idx]) == candidateCost {
 			return idx, false
 		}
 		sawDifferentCost = true
@@ -3362,13 +3773,13 @@ func cRecoveryCostClassForSlice(scratch *glrMergeScratch, result []glrStack, key
 	if scratch == nil || !scratch.cRecoveryCost || stack == nil {
 		return -1, false
 	}
-	candidateCost := cStackErrorCostForMergeWithScratch(scratch, scratch.language, stack)
+	candidateCost := cStackErrorCostForMergeCached(scratch, scratch.language, stack)
 	sawDifferentCost := false
 	for j := range result {
 		if mergeKeyForStack(result[j]) != key || !stacksHeaderEquivalent(result[j], *stack) {
 			continue
 		}
-		if cStackErrorCostForMergeWithScratch(scratch, scratch.language, &result[j]) == candidateCost {
+		if cStackErrorCostForMergeCached(scratch, scratch.language, &result[j]) == candidateCost {
 			return j, false
 		}
 		sawDifferentCost = true
@@ -4235,7 +4646,7 @@ func (s *glrMergeScratch) allocatedBytes() int64 {
 	if s == nil {
 		return 0
 	}
-	return s.resultBytes + s.slotBytes + s.largeSlotBytes + s.equivCacheBytes + s.stackEquivBytes + s.frontierHashBytes
+	return s.resultBytes + s.slotBytes + s.largeSlotBytes + s.equivCacheBytes + s.stackEquivBytes + s.frontierHashBytes + s.shapePrefixBytes + s.cleanZeroBytes
 }
 
 func (s *glrMergeScratch) reset() {
@@ -4275,11 +4686,17 @@ func (s *glrMergeScratch) reset() {
 	} else if len(s.cErrorCost) > 0 {
 		clear(s.cErrorCost)
 	}
-	if len(s.materializing) > maxRetainedMergeResultCap {
-		s.materializing = nil
-	} else if len(s.materializing) > 0 {
-		clear(s.materializing)
+	// shapePrefixEpoch is intentionally NOT reset here: like equivEpoch it
+	// increases monotonically across parses so retained array entries can never
+	// alias into a fresh parse (reset would restart the epoch at 1 and collide
+	// with surviving epoch-1 entries once gss slab pointers get reused).
+	s.shapePrefixBytes = int64(cap(s.shapePrefixCache)) * int64(unsafe.Sizeof(glrShapePrefixCacheEntry{}))
+	// cleanZeroEpoch (below) restarts at 0 per reset, so the epoch-validated
+	// front array MUST be cleared or stale entries could match a future epoch.
+	if len(s.cleanZeroFront) > 0 {
+		clear(s.cleanZeroFront)
 	}
+	s.cleanZeroBytes = int64(cap(s.cleanZeroFront)) * int64(unsafe.Sizeof(glrCleanZeroFrontCacheEntry{}))
 	if len(s.cleanZeroCache) > 0 {
 		clear(s.cleanZeroCache)
 	}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1470,6 +1470,74 @@ func (p *Parser) forestEOFRecoveryCouldCompete(idx *gssForestIndex, arena *nodeA
 	return false
 }
 
+// forestAcceptedIsCleanCompleteParse reports whether the forest's chosen accept
+// candidate is a genuinely CLEAN, complete parse of the whole input — the case
+// for which the EOF-recovery-competition probe (forestEOFRecoveryCouldCompete)
+// is provably unnecessary. It verifies three cheap, independent conditions:
+//
+//  1. Zero recovery cost along the accept path (accepted.errorCost == 0). Forest
+//     errorCost is a PATH cost: a reduce carries its predecessor's errorCost
+//     (coalesce ... popTo.errorCost) and only a recovery step ever raises it (by
+//     at least a skipped-token width; ERROR_COST_PER_RECOVERY at the stack
+//     level). Zero therefore means no recovery happened anywhere on the path —
+//     no skipped input, no error region, no missing insertion.
+//  2. No ERROR/MISSING nodes: the materialized start-symbol root (built eagerly
+//     at reduce time; reached here by the same walk collectForestRootAndExtras
+//     uses, skipping trailing extras) has its has-error flag clear.
+//     populateParentNode ORs every child's flag up and every ERROR/MISSING leaf
+//     sets it, so a clear root flag proves the whole subtree is error-free.
+//  3. Full input span: the accept (chosen for MAX coverage, with trailing extras
+//     coalesced above it) reaches the last non-whitespace byte. Trailing
+//     whitespace/newlines are inter-token trivia outside any node span, so they
+//     are excluded from the bound — the same end rule tryForestFastPath applies.
+//
+// For such a tree the C finished_tree comparison is decisive and needs no probe:
+// ts_parser selects the finished version with the LOWEST error_cost, and every
+// recovery costs at least ERROR_COST_PER_RECOVERY (cErrCostPerRecovery = 500),
+// so a cost-0 accept is unbeatable — the probe's question ("could some EOF
+// recovery have competed?") is definitionally "no". Callers gate the probe on
+// !this so a clean accept dispatches straight through instead of declining.
+func (p *Parser) forestAcceptedIsCleanCompleteParse(arena *nodeArena, accepted *gssForestNode, source []byte) bool {
+	// (1) zero recovery cost — the C-model master signal.
+	if accepted == nil || accepted.errorCost != 0 {
+		return false
+	}
+	// (3) full input span up to the last non-whitespace byte.
+	end := len(source)
+	for end > 0 {
+		switch source[end-1] {
+		case ' ', '\t', '\r', '\n':
+			end--
+			continue
+		}
+		break
+	}
+	if accepted.byteOffset < uint32(end) {
+		return false
+	}
+	// (2) no ERROR/MISSING nodes: walk to the start-symbol root (skipping any
+	// trailing extras stacked above the accept, as collectForestRootAndExtras
+	// does) and require its propagated has-error flag to be clear.
+	var root *Node
+	for cur := accepted; cur != nil; {
+		link := cur.bestAcceptedRootResultLink(p, arena)
+		if link == nil {
+			return false
+		}
+		n := (*Node)(link.subtree.node)
+		if n.isExtra() {
+			cur = link.prev
+			continue
+		}
+		root = n
+		break
+	}
+	if root == nil || root.hasError() {
+		return false
+	}
+	return true
+}
+
 func forestPreserveRootVisibleContainerAlternatives(p *Parser, arena *nodeArena, root *Node, alternatives *forestAlternativeIndex) bool {
 	if p == nil || p.language == nil || root == nil || alternatives == nil || resultChildCount(root) == 0 {
 		return false
@@ -1828,6 +1896,18 @@ func (p *Parser) collectForestErrorRoot(idx *gssForestIndex, arena *nodeArena) *
 		// forest recovery selection.
 		rootSym = errorSymbol
 	}
+	// Eager parent-link wiring is safe here (unlike the C-recovery ERROR wrappers
+	// fixed via newRecoveryParentNodeInArena): the forest path cannot corrupt the
+	// transient-parent sentinel because it never allocates transient parents.
+	// parseForest swaps p.reduceScratch to a zero-valued forestReduceScratch for
+	// the whole forest parse (glr_forest.go ~:2366-2368, transientParents left
+	// nil), and newReduceParentNode only routes to transientParents.allocParent
+	// (the slab node whose .parent doubles as the materializer sentinel) when
+	// transientParents != nil (parser_reduce.go ~:6660). So every `frags` node
+	// built during this forest parse is an ordinary arena/leaf node with a real
+	// parent link — there is no {nil/self/other} sentinel to clobber. This
+	// collectForestErrorRoot site is the only production caller and runs inside
+	// that swap's dynamic extent (glr_forest.go ~:2927).
 	root := newParentNodeInArena(arena, rootSym, true, frags, nil, 0)
 	if hasErr {
 		root.setHasError(true)
@@ -2816,7 +2896,23 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 		}
 
 		if eof {
-			if accepted != nil && (recoverActive || p.errorCostCompetitionEnabled()) && p.forestEOFRecoveryCouldCompete(&curIndex, arena, tok.StartByte, !recoverActive) {
+			// A genuinely CLEAN forest accept (zero recovery cost, no ERROR/MISSING
+			// nodes, full input span) is unbeatable in C's finished_tree selection:
+			// ts_parser picks the lowest-error_cost finished version and every
+			// recovery costs at least ERROR_COST_PER_RECOVERY (500), so no EOF
+			// recovery could compete with a cost-0 accept — forestEOFRecoveryCould-
+			// Compete would always answer "no". Skip that probe for such accepts on
+			// the !recoverActive languages (bash/c_sharp/cmake/... — every forest
+			// language whose accept is required to be error-free), whose outer
+			// tryForestFastPath still declines on any root.HasError() as a safety
+			// net. recoverActive languages keep the conservative probe: their outer
+			// path intentionally accepts error-bearing roots (that HasError net is
+			// disabled for them) and forest-vs-production materialization parity on
+			// their newly forest-routed clean files is not covered by the local
+			// corpus here — the C argument is airtight, but we stay conservative.
+			cleanAcceptBeatsRecovery := !recoverActive &&
+				p.forestAcceptedIsCleanCompleteParse(arena, accepted, source)
+			if accepted != nil && !cleanAcceptBeatsRecovery && (recoverActive || p.errorCostCompetitionEnabled()) && p.forestEOFRecoveryCouldCompete(&curIndex, arena, tok.StartByte, !recoverActive) {
 				p.recordForestDecline(forestDeclineEOFRecoveryConflict, tok, nil)
 				if progress.enabled {
 					progress.emit(time.Now(), "forest_decline", iter, tokens, tok, true, nil, 0, 0, 0, false, 0, 0,

--- a/glr_test.go
+++ b/glr_test.go
@@ -2928,11 +2928,16 @@ func TestTryGSSMainMergeResultClearsMaterializingCache(t *testing.T) {
 
 	var scratch glrMergeScratch
 	scratch.beginEquivEpoch()
+	scratch.ensureMergeHotCaches()
 	if gssStacksHaveDistinctMaterializingShapesWithScratch(&scratch, &left, &right) {
 		t.Fatalf("test setup produced distinct materializing shapes")
 	}
-	if len(scratch.materializing) == 0 {
-		t.Fatalf("test setup did not populate materializing cache")
+	if len(scratch.shapePrefixCache) == 0 {
+		t.Fatalf("test setup did not populate materializing shape prefix cache")
+	}
+	epochBefore := scratch.shapePrefixEpoch
+	if _, hit := lookupShapePrefixCache(&scratch, left.gss.head); !hit {
+		t.Fatalf("test setup did not cache the left head's shape prefix")
 	}
 
 	result := []glrStack{left}
@@ -2940,8 +2945,111 @@ func TestTryGSSMainMergeResultClearsMaterializingCache(t *testing.T) {
 	if !attempted || !merged {
 		t.Fatalf("GSS merge attempted=%v merged=%v, want true/true", attempted, merged)
 	}
-	if len(scratch.materializing) != 0 {
-		t.Fatalf("materializing cache entries after successful merge = %d, want 0", len(scratch.materializing))
+	if scratch.shapePrefixEpoch == epochBefore {
+		t.Fatalf("shape prefix epoch not bumped after successful merge (still %d): stale spine prefixes would survive link rewrites", epochBefore)
+	}
+	if _, hit := lookupShapePrefixCache(&scratch, left.gss.head); hit {
+		t.Fatalf("stale shape prefix still readable after successful merge")
+	}
+}
+
+func TestTryGSSMainMergeForParserBumpsShapePrefixEpoch(t *testing.T) {
+	// Cross-token invalidation guard for the DISPATCH-time GSS main merge
+	// (reached through tryGSSMainMergeForParser from parser_reduce /
+	// parser_recover_c). Like the collapse-phase tryGSSMainMergeResult, a
+	// successful merge rewrites link 0 of surviving nodes (setGSSMainLink), so
+	// cached root->head shape prefixes in the active merge scratch must be
+	// invalidated or the materializing-shape gate compares stale hashes on the
+	// next token.
+	var gssScratch gssScratch
+	node := NewLeafNode(11, true, 0, 5, Point{}, Point{Column: 5})
+	entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+	left := glrStack{
+		gss:        buildGSSStack(entries, &gssScratch),
+		byteOffset: 5,
+	}
+	right := glrStack{
+		gss:        buildGSSStack(entries, &gssScratch),
+		byteOffset: 5,
+	}
+
+	var scratch glrMergeScratch
+	scratch.beginEquivEpoch()
+	scratch.ensureMergeHotCaches()
+	if gssStacksHaveDistinctMaterializingShapesWithScratch(&scratch, &left, &right) {
+		t.Fatalf("test setup produced distinct materializing shapes")
+	}
+	epochBefore := scratch.shapePrefixEpoch
+	if _, hit := lookupShapePrefixCache(&scratch, left.gss.head); !hit {
+		t.Fatalf("test setup did not cache the left head's shape prefix")
+	}
+
+	// tryGSSMainMergeForParser only carries *Parser; the fix reaches the active
+	// scratch through p.mergeScratch, exactly as parseInternal wires it.
+	p := &Parser{mergeScratch: &scratch}
+	if !tryGSSMainMergeForParser(p, &left, &right) {
+		t.Fatalf("dispatch-time GSS main merge did not merge")
+	}
+	if scratch.shapePrefixEpoch == epochBefore {
+		t.Fatalf("shape prefix epoch not bumped after dispatch-time merge (still %d): stale spine prefixes would survive link rewrites", epochBefore)
+	}
+	if _, hit := lookupShapePrefixCache(&scratch, left.gss.head); hit {
+		t.Fatalf("stale shape prefix still readable after dispatch-time merge")
+	}
+}
+
+func TestRetargetStackEntryPayloadParseStateFeedsShapePrefixCache(t *testing.T) {
+	// Locks the invariant behind the retargetStackEntryPayload reduce-site epoch
+	// bumps: parseState feeds gssEntryHash, which the root->head shape prefix
+	// rolls in, so the pointer-keyed prefix cache keeps serving the pre-retarget
+	// hash until the epoch is bumped. Without the reduce-site bump the
+	// materializing-shape gate would read the stale prefix on the next token.
+	var gssScratch gssScratch
+	node := NewLeafNode(11, true, 0, 5, Point{}, Point{Column: 5})
+	node.parseState = 7
+	entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+	stack := glrStack{
+		gss:        buildGSSStack(entries, &gssScratch),
+		byteOffset: 5,
+	}
+
+	var scratch glrMergeScratch
+	scratch.beginEquivEpoch()
+	scratch.ensureMergeHotCaches()
+
+	hashBefore, ok := stackMaterializingShapeHashWithScratch(&scratch, stack)
+	if !ok {
+		t.Fatalf("could not compute initial materializing shape hash")
+	}
+	head := stack.gss.head
+	if _, hit := lookupShapePrefixCache(&scratch, head); !hit {
+		t.Fatalf("test setup did not cache the head's shape prefix")
+	}
+
+	// Retarget the head payload in place, exactly as the reduce sites do.
+	got, ok := retargetStackEntryPayload(head.entry, 99)
+	if !ok {
+		t.Fatalf("retarget of head payload failed")
+	}
+	head.entry = got
+	if node.parseState != 99 {
+		t.Fatalf("retarget did not rewrite the shared node's parseState: got %d", node.parseState)
+	}
+
+	// Same epoch: the cache still serves the pre-retarget hash.
+	if staleHash, ok := stackMaterializingShapeHashWithScratch(&scratch, stack); !ok || staleHash != hashBefore {
+		t.Fatalf("expected stale cached hash %d before invalidation, got %d (ok=%v)", hashBefore, staleHash, ok)
+	}
+
+	// The reduce-site fix bumps the epoch; the gate must then observe the fresh
+	// parseState.
+	scratch.bumpShapePrefixEpoch()
+	freshHash, ok := stackMaterializingShapeHashWithScratch(&scratch, stack)
+	if !ok {
+		t.Fatalf("could not recompute materializing shape hash")
+	}
+	if freshHash == hashBefore {
+		t.Fatalf("shape hash unchanged after parseState retarget + epoch bump (%d): stale prefix survived", hashBefore)
 	}
 }
 

--- a/grammars/c_sharp_external_lex_states_gen.go
+++ b/grammars/c_sharp_external_lex_states_gen.go
@@ -1,0 +1,64 @@
+//go:build !grammar_subset || grammar_subset_c_sharp
+
+// c_sharp precise ExternalLexStates — DEFAULT since the 2026-07 cliff
+// campaign (previously staged behind -tags csharp_precise_els).
+//
+// The embedded c_sharp grammar blob preserves LexModes[state].ExternalLexState
+// (histogram matches C exactly: 10 distinct states) but shipped an EMPTY
+// ExternalLexStates validity table (ts2go dropped it). With the table empty,
+// dfaTokenSource (parser_dfa_token_source.go) cannot use its precise per-state
+// external path and instead unions externalValidMaskByState across all active
+// GLR stacks. Under multi-stack pressure that union over-approximates
+// external-token validity and corrupts the STATEFUL interpolated-string
+// scanner (grammars/csharp_scanner.go): at an interpolation hole's close it
+// reported external-lex-state 2 (expression start) instead of 5 (string
+// content), the scanner's interpolation stack never popped (measured: 27
+// pushes, 0 pops), and pass-1 on DeclaredTypeManager.cs died no_stacks_alive
+// at byte 31888 behind a ~1,000-pass retry cascade.
+//
+// The table below is copied VERBATIM from tree-sitter-c-sharp src/parser.c
+// (ts_external_scanner_states[10][12], pinned commit in languages.lock).
+// Registering it (a) restores the precise per-state external path, and
+// (b) satisfies the C-recovery election gate (DiagnoseCRecoveryGate), so
+// c_sharp runs the faithful C error-recovery cost competition by default.
+//
+// The two engine blockers that kept this staged were fixed in the same
+// campaign:
+//   - parser_recover_c.go cCondenseAndResume: the C MAX_VERSION_COUNT window
+//     now bounds DISTINCT merge keys (C merges same-key versions via
+//     ts_stack_merge before its cap; the old raw positional trim dropped
+//     whole grammar interpretations).
+//   - parser.go usesPrimaryExternalScannerStateForGLR: the c_sharp
+//     primary-stack-only pin now applies only while ExternalLexStates is
+//     empty; with the precise table the scored per-row path sees all stack
+//     states, so interpolation-hole stacks receive interpolation_close_brace.
+//
+// Validation: grammars/csharp_external_lex_states_regression_test.go.
+package grammars
+
+// cSharpExternalLexStates mirrors tree-sitter-c-sharp src/parser.c
+// ts_external_scanner_states[10][12]. Columns are the C# external token indices,
+// in the language's ExternalSymbols order:
+//
+//	 0 _optional_semi              6 interpolation_open_brace
+//	 1 interpolation_regular_start 7 interpolation_close_brace
+//	 2 interpolation_verbatim_start 8 interpolation_string_content
+//	 3 interpolation_raw_start     9 raw_string_start
+//	 4 interpolation_start_quote  10 raw_string_end
+//	 5 interpolation_end_quote    11 raw_string_content
+var cSharpExternalLexStates = [][]bool{
+	/*  0 */ {false, false, false, false, false, false, false, false, false, false, false, false},
+	/*  1 */ {true, true, true, true, true, true, true, true, true, true, true, true},
+	/*  2 */ {false, true, true, true, false, false, false, false, false, true, false, false},
+	/*  3 */ {false, true, true, true, false, false, false, true, false, true, false, false},
+	/*  4 */ {false, false, false, false, false, false, false, true, false, false, false, false},
+	/*  5 */ {false, false, false, false, false, true, true, false, true, false, false, false},
+	/*  6 */ {false, false, false, false, false, false, false, false, false, false, true, false},
+	/*  7 */ {true, false, false, false, false, false, false, false, false, false, false, false},
+	/*  8 */ {false, false, false, false, true, false, false, false, false, false, false, false},
+	/*  9 */ {false, false, false, false, false, false, false, false, false, false, false, true},
+}
+
+func init() {
+	RegisterExternalLexStates("c_sharp", cSharpExternalLexStates)
+}

--- a/grammars/csharp_external_lex_states_regression_test.go
+++ b/grammars/csharp_external_lex_states_regression_test.go
@@ -1,0 +1,113 @@
+//go:build !grammar_subset || grammar_subset_c_sharp
+
+package grammars
+
+import (
+	"os"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestCSharpExternalLexStatesRegression guards the c_sharp ExternalLexStates
+// table. The embedded c_sharp grammar blob preserves LexModes[state].ExternalLexState
+// but ships an EMPTY ExternalLexStates validity table. Without the table, the GLR
+// token source falls back to a union-of-active-stacks external-validity mask, which
+// over-approximates valid external tokens and corrupts the stateful interpolated-
+// string external scanner (the interpolation stack never pops, so pass-1 diverges
+// at an interpolated string and ends no_stacks_alive, driving a ~1000x retry
+// cascade). The sidecar (c_sharp_external_lex_states_gen.go) restores the precise
+// table extracted verbatim from tree-sitter-c-sharp src/parser.c
+// (ts_external_scanner_states[10][12]).
+func TestCSharpExternalLexStatesRegression(t *testing.T) {
+	lang := CSharpLanguage()
+
+	// External token indices, matching lang.ExternalSymbols order (== C enum order):
+	//  0 _optional_semi              6 interpolation_open_brace
+	//  1 interpolation_regular_start 7 interpolation_close_brace
+	//  2 interpolation_verbatim_start 8 interpolation_string_content
+	//  3 interpolation_raw_start     9 raw_string_start
+	//  4 interpolation_start_quote  10 raw_string_end
+	//  5 interpolation_end_quote    11 raw_string_content
+	want := [][]bool{
+		/* 0 */ {false, false, false, false, false, false, false, false, false, false, false, false},
+		/* 1 */ {true, true, true, true, true, true, true, true, true, true, true, true},
+		/* 2 */ {false, true, true, true, false, false, false, false, false, true, false, false},
+		/* 3 */ {false, true, true, true, false, false, false, true, false, true, false, false},
+		/* 4 */ {false, false, false, false, false, false, false, true, false, false, false, false},
+		/* 5 */ {false, false, false, false, false, true, true, false, true, false, false, false},
+		/* 6 */ {false, false, false, false, false, false, false, false, false, false, true, false},
+		/* 7 */ {true, false, false, false, false, false, false, false, false, false, false, false},
+		/* 8 */ {false, false, false, false, true, false, false, false, false, false, false, false},
+		/* 9 */ {false, false, false, false, false, false, false, false, false, false, false, true},
+	}
+
+	if got := len(lang.ExternalLexStates); got != len(want) {
+		t.Fatalf("c_sharp ExternalLexStates rows = %d, want %d (missing sidecar => union-mask fallback corrupts interpolation scanner)", got, len(want))
+	}
+	for i, wantRow := range want {
+		gotRow := lang.ExternalLexStates[i]
+		if len(gotRow) != len(wantRow) {
+			t.Fatalf("ExternalLexStates[%d] len = %d, want %d", i, len(gotRow), len(wantRow))
+		}
+		for j := range wantRow {
+			if gotRow[j] != wantRow[j] {
+				t.Fatalf("ExternalLexStates[%d][%d] = %v, want %v (row must match tree-sitter-c-sharp ts_external_scanner_states)", i, j, gotRow[j], wantRow[j])
+			}
+		}
+	}
+
+	// LexModes must still reference the table (external_lex_state indices 0..9).
+	maxELS := 0
+	for _, lm := range lang.LexModes {
+		if int(lm.ExternalLexState) > maxELS {
+			maxELS = int(lm.ExternalLexState)
+		}
+	}
+	if maxELS >= len(lang.ExternalLexStates) {
+		t.Fatalf("LexModes reference external_lex_state %d but table only has %d rows", maxELS, len(lang.ExternalLexStates))
+	}
+
+	// The precise table is also the C-recovery election gate for c_sharp:
+	// with it registered (plus the attached scanner), the faithful C
+	// error-recovery cost competition must be ELECTED by default.
+	diag := gotreesitter.DiagnoseCRecoveryGate(lang)
+	if !diag.Supported {
+		t.Fatalf("DiagnoseCRecoveryGate not supported: %s", diag.Reason)
+	}
+	if !lang.CRecoveryCostCompetitionCapable || !lang.CRecoveryCostCompetitionEnabledByDefault {
+		t.Fatalf("c_sharp not elected for C recovery: capable=%v default=%v",
+			lang.CRecoveryCostCompetitionCapable, lang.CRecoveryCostCompetitionEnabledByDefault)
+	}
+}
+
+// TestCSharpInterpolatedStringFirstPassNoStacksAlive is the end-to-end regression
+// guard for the interpolated-string first-pass failure. It parses the corpus file
+// DeclaredTypeManager.cs (skipped when unavailable) and asserts pass-1 reaches EOF
+// without ending no_stacks_alive. Before the ExternalLexStates fix, pass-1 died at
+// the file's second interpolated string (byte 31888) with StopReason=no_stacks_alive
+// and Truncated=true, feeding a 1,076-pass retry cascade.
+func TestCSharpInterpolatedStringFirstPassNoStacksAlive(t *testing.T) {
+	const corpusPath = "/home/draco/work/gotreesitter-corpora/corpus_sources/c_sharp/src/Bicep.Core/TypeSystem/DeclaredTypeManager.cs"
+	src, err := os.ReadFile(corpusPath)
+	if err != nil {
+		t.Skipf("corpus file unavailable: %v", err)
+	}
+
+	lang := CSharpLanguage()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	rt := tree.ParseRuntime()
+	if rt.StopReason == gotreesitter.ParseStopNoStacksAlive {
+		t.Fatalf("pass-1 ended no_stacks_alive (interpolation-scanner corruption regressed): %s", rt.Summary())
+	}
+	if rt.Truncated {
+		t.Fatalf("pass-1 truncated before EOF: %s", rt.Summary())
+	}
+	if got, want := tree.RootNode().EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("root end = %d, want %d (%s)", got, want, rt.Summary())
+	}
+}

--- a/grammars/javascript_external_lex_states_regression_test.go
+++ b/grammars/javascript_external_lex_states_regression_test.go
@@ -1,0 +1,72 @@
+//go:build javascript_precise_els
+
+// STAGED — runs only with -tags javascript_precise_els, alongside
+// javascript_external_lex_states_staged.go. See that file for why the
+// javascript precise-ELS table (and with it C-recovery election) is not
+// default yet: election is a measured perf regression on javascript's worst
+// perf_scan sweep slice while fixing no misparses there.
+
+package grammars
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestJavascriptExternalLexStatesRegression guards the staged javascript
+// ExternalLexStates table against drift from the pinned
+// tree-sitter-javascript parser.c (ts_external_scanner_states[10][8]).
+func TestJavascriptExternalLexStatesRegression(t *testing.T) {
+	lang := JavascriptLanguage()
+
+	// External token indices, matching lang.ExternalSymbols order (== C enum order):
+	//	0 _automatic_semicolon  4 ||
+	//	1 _template_chars       5 escape_sequence
+	//	2 _ternary_qmark        6 regex_pattern
+	//	3 html_comment          7 jsx_text
+	want := [][]bool{
+		/* 0 */ {false, false, false, false, false, false, false, false},
+		/* 1 */ {true, true, true, true, true, true, false, true},
+		/* 2 */ {false, false, false, true, false, false, false, false},
+		/* 3 */ {true, false, true, true, true, false, false, false},
+		/* 4 */ {false, false, true, true, true, false, false, false},
+		/* 5 */ {true, false, false, true, false, false, false, false},
+		/* 6 */ {false, false, false, true, false, false, false, true},
+		/* 7 */ {false, true, false, true, false, true, false, false},
+		/* 8 */ {false, false, false, true, false, true, false, false},
+		/* 9 */ {false, false, false, true, false, false, true, false},
+	}
+
+	if got := len(lang.ExternalLexStates); got != len(want) {
+		t.Fatalf("javascript ExternalLexStates rows = %d, want %d", got, len(want))
+	}
+	for i, wantRow := range want {
+		gotRow := lang.ExternalLexStates[i]
+		if len(gotRow) != len(wantRow) {
+			t.Fatalf("ExternalLexStates[%d] len = %d, want %d", i, len(gotRow), len(wantRow))
+		}
+		for j := range wantRow {
+			if gotRow[j] != wantRow[j] {
+				t.Fatalf("ExternalLexStates[%d][%d] = %v, want %v (row must match tree-sitter-javascript ts_external_scanner_states)", i, j, gotRow[j], wantRow[j])
+			}
+		}
+	}
+
+	maxELS := 0
+	for _, lm := range lang.LexModes {
+		if int(lm.ExternalLexState) > maxELS {
+			maxELS = int(lm.ExternalLexState)
+		}
+	}
+	if maxELS >= len(lang.ExternalLexStates) {
+		t.Fatalf("LexModes reference external_lex_state %d but table only has %d rows", maxELS, len(lang.ExternalLexStates))
+	}
+
+	// With the table registered the C-recovery gate must be satisfiable —
+	// this is the election precondition the staged file documents.
+	diag := gotreesitter.DiagnoseCRecoveryGate(lang)
+	if !diag.Supported {
+		t.Fatalf("DiagnoseCRecoveryGate not supported with precise ELS: %s", diag.Reason)
+	}
+}

--- a/grammars/javascript_external_lex_states_staged.go
+++ b/grammars/javascript_external_lex_states_staged.go
@@ -1,0 +1,62 @@
+//go:build javascript_precise_els
+
+// STAGED — inactive by default. Build/enable with: -tags javascript_precise_els
+//
+// Verbatim ts_external_scanner_states[10][8] from the pinned
+// tree-sitter-javascript parser.c. Registering it flips DiagnoseCRecoveryGate
+// for javascript (precise ExternalLexStates is the last missing gate input),
+// which ELECTS javascript into the faithful C error-recovery cost competition
+// by default.
+//
+// WHY IT IS STAGED (2026-07 cliff campaign measurement)
+// Unlike c_sharp — whose stateful interpolation scanner was actively
+// corrupted by the union-mask fallback, so the precise table + election fixed
+// real misparses (DeclaredTypeManager.cs 31 ERROR nodes -> 0) — javascript's
+// worst perf_scan sweep files parse with ZERO error nodes either way, so the
+// table has nothing to fix there today, and ELECTION is a measured
+// regression on that slice (loaded-box interleaved A/B, elected vs
+// GOT_C_RECOVERY=0, live engine with both campaign engine fixes):
+//
+//	deps/undici/undici.js               2.2-2.4s -> ~5.1s   (accepted both)
+//	deps/v8/.../unicode-test.js         ~370ms   -> ~600ms  (median of 4+4)
+//	deps/v8/.../box2d.js                memory_budget @49543 either way
+//	deps/v8/.../lua_binarytrees.js      memory_budget @6745 either way
+//	deps/amaro/dist/index.js            ~100-135ms either way
+//
+// The elected path's per-token cost (cRecoveryEnabled lexing via
+// NextWithErrorRuns + acquire-token bookkeeping) is paid on CLEAN parses,
+// and javascript's actual sweep cliffs (asm.js megafunctions dying on
+// memory_budget) are unrelated to external-scanner validity. Enable this
+// only after the javascript memory-budget cliff class is fixed and a sweep
+// re-measurement shows election is at worst neutral. Full test suites
+// (go test . ./grammars) PASS with this table active and javascript elected,
+// so correctness is not the blocker — perf on the cliff slice is.
+//
+// Columns are the JavaScript external token indices, in the language's
+// ExternalSymbols order (== C enum order):
+//
+//	0 _automatic_semicolon  4 ||
+//	1 _template_chars       5 escape_sequence
+//	2 _ternary_qmark        6 regex_pattern
+//	3 html_comment          7 jsx_text
+//
+// Source: https://github.com/tree-sitter/tree-sitter-javascript 58404d8cf191d69f2674a8fd507bd5776f46cb11 src/parser.c
+package grammars
+
+// javascriptExternalLexStates mirrors C tree-sitter ts_external_scanner_states.
+var javascriptExternalLexStates = [][]bool{
+	/* 0 */ {false, false, false, false, false, false, false, false},
+	/* 1 */ {true, true, true, true, true, true, false, true},
+	/* 2 */ {false, false, false, true, false, false, false, false},
+	/* 3 */ {true, false, true, true, true, false, false, false},
+	/* 4 */ {false, false, true, true, true, false, false, false},
+	/* 5 */ {true, false, false, true, false, false, false, false},
+	/* 6 */ {false, false, false, true, false, false, false, true},
+	/* 7 */ {false, true, false, true, false, true, false, false},
+	/* 8 */ {false, false, false, true, false, true, false, false},
+	/* 9 */ {false, false, false, true, false, false, true, false},
+}
+
+func init() {
+	RegisterExternalLexStates("javascript", javascriptExternalLexStates)
+}

--- a/grammars/zz_bash_cliff_debug_test.go
+++ b/grammars/zz_bash_cliff_debug_test.go
@@ -1,0 +1,132 @@
+package grammars
+
+// Debug harness for the bash perf-cliff campaign (Phase 1 target #1).
+// Not a regression test: everything is gated behind GTS_BASH_CLIFF_DEBUG=1.
+//
+// Usage:
+//   GOWORK=off GTS_BASH_CLIFF_DEBUG=1 go test ./grammars -run TestBashCliffDebug -v -count=1 -timeout 0
+// Optional:
+//   GTS_BASH_CLIFF_FILE=<path>        input file (default corpus small__release.sh)
+//   GTS_BASH_CLIFF_CPUPROFILE=<path>  write CPU profile
+//   GOT_C_RECOVERY=0                  disable C-recovery gate
+//   GOT_GLR_MAX_STACKS=N              override stack cap
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestBashCliffDebug(t *testing.T) {
+	if os.Getenv("GTS_BASH_CLIFF_DEBUG") != "1" {
+		t.Skip("set GTS_BASH_CLIFF_DEBUG=1 to run")
+	}
+	path := os.Getenv("GTS_BASH_CLIFF_FILE")
+	if path == "" {
+		path = "../cgo_harness/corpus_real/bash/small__release.sh"
+	}
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lang := BashLanguage()
+	if lang == nil {
+		t.Fatal("nil bash language")
+	}
+
+	if prof := os.Getenv("GTS_BASH_CLIFF_CPUPROFILE"); prof != "" {
+		f, err := os.Create(prof)
+		if err != nil {
+			t.Fatalf("create profile: %v", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			t.Fatalf("start profile: %v", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	p := gotreesitter.NewParser(lang)
+	if v := os.Getenv("GTS_BASH_CLIFF_TIMEOUT_MS"); v != "" {
+		var ms int
+		fmt.Sscanf(v, "%d", &ms)
+		p.SetTimeoutMicros(uint64(ms) * 1000)
+	}
+	if os.Getenv("GTS_BASH_CLIFF_GLRTRACE") == "1" {
+		p.SetGLRTrace(true)
+	}
+	start := time.Now()
+	tree, err := p.Parse(src)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	root := tree.RootNode()
+	rt := tree.ParseRuntime()
+	fmt.Printf("BASHCLIFF file=%s bytes=%d elapsed=%v\n", path, len(src), elapsed)
+	fmt.Printf("BASHCLIFF hasError=%v rootType=%s rootSpan=[%d,%d) truncated=%v stopReason=%v\n",
+		root.HasError(), root.Type(lang), root.StartByte(), root.EndByte(), rt.Truncated, rt.StopReason)
+	fmt.Printf("BASHCLIFF maxStacksSeen=%d tokensConsumed=%d mergeIn=%d mergeOut=%d\n",
+		rt.MaxStacksSeen, rt.TokensConsumed, rt.MergeStacksIn, rt.MergeStacksOut)
+	fmt.Printf("BASHCLIFF singleIter=%d multiIter=%d singleTok=%d multiTok=%d\n",
+		rt.SingleStackIterations, rt.MultiStackIterations, rt.SingleStackTokens, rt.MultiStackTokens)
+	fmt.Printf("BASHCLIFF loopNs=%d mergeNs=%d cullNs=%d dispatchNs=%d tokenNs=%d\n",
+		rt.ParserLoopNanos, rt.GLRMergeNanos, rt.GLRCullNanos, rt.ActionDispatchNanos, rt.TokenNextNanos)
+	fmt.Printf("BASHCLIFF arenaBytes=%d gssNodes=%d\n", rt.ArenaBytesAllocated, rt.GSSNodesAllocated)
+
+	// Walk for ERROR/MISSING nodes and print their spans plus source context.
+	var walk func(n *gotreesitter.Node, depth int)
+	errCount := 0
+	walk = func(n *gotreesitter.Node, depth int) {
+		if n == nil || errCount > 20 {
+			return
+		}
+		t := n.Type(lang)
+		if t == "ERROR" || n.IsMissing() {
+			errCount++
+			s, e := n.StartByte(), n.EndByte()
+			ctxStart := int(s) - 30
+			if ctxStart < 0 {
+				ctxStart = 0
+			}
+			ctxEnd := int(e) + 30
+			if ctxEnd > len(src) {
+				ctxEnd = len(src)
+			}
+			fmt.Printf("BASHCLIFF ERRNODE type=%s missing=%v span=[%d,%d) ctx=%q\n", t, n.IsMissing(), s, e, string(src[ctxStart:ctxEnd]))
+		}
+		for i := 0; i < n.ChildCount(); i++ {
+			walk(n.Child(i), depth+1)
+		}
+	}
+	walk(root, 0)
+	fmt.Printf("BASHCLIFF totalErrNodes=%d\n", errCount)
+	if os.Getenv("GTS_BASH_CLIFF_SEXPR") == "1" {
+		fmt.Printf("BASHCLIFF SEXPR %s\n", root.SExpr(lang))
+	}
+	// Find deepest node with hasError set.
+	var findErr func(n *gotreesitter.Node, depth int)
+	findErr = func(n *gotreesitter.Node, depth int) {
+		if n == nil || !n.HasError() {
+			return
+		}
+		anyChildErr := false
+		for i := 0; i < n.ChildCount(); i++ {
+			c := n.Child(i)
+			if c != nil && c.HasError() {
+				anyChildErr = true
+				findErr(c, depth+1)
+			}
+		}
+		if !anyChildErr {
+			s, e := n.StartByte(), n.EndByte()
+			fmt.Printf("BASHCLIFF DEEPEST-HASERR type=%s span=[%d,%d) depth=%d childCount=%d src=%q\n",
+				n.Type(lang), s, e, depth, n.ChildCount(), string(src[s:min(int(e), len(src))]))
+		}
+	}
+	findErr(root, 0)
+}

--- a/grammars/zz_ts_detonator_debug_test.go
+++ b/grammars/zz_ts_detonator_debug_test.go
@@ -1,0 +1,69 @@
+package grammars
+
+// Intra-token population explosion debug harness (gated; not CI).
+// GTS_TS_DET=1 go test ./grammars -run TestTSDetonatorSeries -v
+// Parses the union-type detonator files at several sizes and reports
+// stop reason, max stacks, node counts.
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestTSDetonatorSeries(t *testing.T) {
+	if os.Getenv("GTS_TS_DET") != "1" {
+		t.Skip("set GTS_TS_DET=1")
+	}
+	type target struct {
+		lang string
+		path string
+	}
+	targets := []target{
+		{"typescript", "/tmp/det800.d.ts"},
+		{"typescript", "/tmp/det1000.d.ts"},
+		{"typescript", "/tmp/det1300.d.ts"},
+		{"typescript", "/tmp/det2000.d.ts"},
+	}
+	if only := os.Getenv("GTS_TS_DET_ONLY"); only != "" {
+		lang := os.Getenv("GTS_TS_DET_LANG")
+		if lang == "" {
+			lang = "typescript"
+		}
+		targets = []target{{lang, only}}
+	}
+	for _, tg := range targets {
+		path := tg.path
+		src, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Printf("DET %s READ-ERR %v\n", path, err)
+			continue
+		}
+		var lang *gotreesitter.Language
+		switch tg.lang {
+		case "typescript":
+			lang = TypescriptLanguage()
+		case "rust":
+			lang = RustLanguage()
+		case "python":
+			lang = PythonLanguage()
+		}
+		p := gotreesitter.NewParser(lang)
+		p.SetTimeoutMicros(120_000_000)
+		start := time.Now()
+		tree, err := p.Parse(src)
+		elapsed := time.Since(start)
+		if err != nil || tree == nil {
+			fmt.Printf("DET %s bytes=%d PARSE-ERR %v took=%v\n", path, len(src), err, elapsed)
+			continue
+		}
+		root := tree.RootNode()
+		rt := tree.ParseRuntime()
+		fmt.Printf("DET %s bytes=%-7d took=%-12v hasErr=%-5v stop=%-14v maxStacks=%-6d nodes=%-9d nodeLimit=%-9d iter=%-9d lastTokEnd=%-7d rootEnd=%-7d truncated=%v\n",
+			path, len(src), elapsed.Round(time.Millisecond), root.HasError(), rt.StopReason, rt.MaxStacksSeen,
+			rt.NodesAllocated, rt.NodeLimit, rt.Iterations, rt.LastTokenEndByte, rt.RootEndByte, rt.Truncated)
+	}
+}

--- a/grammars/zz_ww_error_locate_test.go
+++ b/grammars/zz_ww_error_locate_test.go
@@ -1,0 +1,68 @@
+package grammars
+
+// Locates ERROR/MISSING nodes in a TypeScript parse (gated; not CI).
+// GTS_WW_ERR=1 GTS_WW_FILE=<path> go test ./grammars -run TestLocateTSErrors -v
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestLocateTSErrors(t *testing.T) {
+	if os.Getenv("GTS_WW_ERR") != "1" {
+		t.Skip("set GTS_WW_ERR=1")
+	}
+	path := os.Getenv("GTS_WW_FILE")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lang := TypescriptLanguage()
+	p := gotreesitter.NewParser(lang)
+	tree, err := p.Parse(src)
+	if err != nil || tree == nil {
+		t.Fatalf("parse: %v", err)
+	}
+	root := tree.RootNode()
+	rt := tree.ParseRuntime()
+	fmt.Printf("WW hasErr=%v stop=%v maxStacks=%d nodes=%d rootEnd=%d srcLen=%d\n",
+		root.HasError(), rt.StopReason, rt.MaxStacksSeen, rt.NodesAllocated, rt.RootEndByte, len(src))
+	found := 0
+	var walk func(n *gotreesitter.Node, depth int)
+	walk = func(n *gotreesitter.Node, depth int) {
+		if found >= 12 {
+			return
+		}
+		if n.IsError() || n.IsMissing() {
+			found++
+			s := int(n.StartByte())
+			e := int(n.EndByte())
+			ctxLo := s - 80
+			if ctxLo < 0 {
+				ctxLo = 0
+			}
+			ctxHi := e + 80
+			if ctxHi > len(src) {
+				ctxHi = len(src)
+			}
+			snip := e
+			if snip > s+120 {
+				snip = s + 120
+			}
+			fmt.Printf("ERRNODE kind=%s missing=%v bytes=%d-%d text=%q context=%q\n",
+				n.Type(lang), n.IsMissing(), s, e, string(src[s:snip]), string(src[ctxLo:ctxHi]))
+			return
+		}
+		if !n.HasError() {
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), depth+1)
+		}
+	}
+	walk(root, 0)
+	fmt.Printf("WW total error nodes shown=%d\n", found)
+}

--- a/parser.go
+++ b/parser.go
@@ -51,21 +51,21 @@ type Parser struct {
 	// burndown can triage dead-ends without re-instrumenting. Set on the parser
 	// (not package globals) so concurrent parsers don't race. Cleared at the
 	// start of each forest parse.
-	forestDeclineByte                   uint32
-	forestDeclineSym                    Symbol
-	forestDeclineReason                 string
-	forestDeclineStates                 []StateID
-	hasRecoverState                     []bool
-	hasRecoverSymbol                    []bool
-	recoverByState                      [][]recoverSymbolAction
-	hasKeywordState                     []bool
+	forestDeclineByte   uint32
+	forestDeclineSym    Symbol
+	forestDeclineReason string
+	forestDeclineStates []StateID
+	hasRecoverState     []bool
+	hasRecoverSymbol    []bool
+	recoverByState      [][]recoverSymbolAction
+	hasKeywordState     []bool
 	// lookupActionIndexFn caches the bound-method closure for
 	// lookupActionIndex. Passing p.lookupActionIndex directly at token-source
 	// construction sites allocates a fresh 16-byte closure per parse; the
 	// bound method only captures p (tables are re-read at call time), so one
 	// closure stays valid for the parser's whole lifetime, including language
 	// changes. See lookupActionIndexFunc (parser_tables.go).
-	lookupActionIndexFn func(state StateID, sym Symbol) uint16
+	lookupActionIndexFn                 func(state StateID, sym Symbol) uint16
 	typeScriptPropertyIdentifierSymbol  Symbol
 	typeScriptIdentifierSymbol          Symbol
 	typeScriptHasPropertyIdentifier     bool
@@ -145,6 +145,26 @@ type Parser struct {
 	// candidates routinely settles back to a legitimately clean tree without
 	// ever being "re-validated", so it must not be treated as suspicious.
 	crecoveryHandleErrorSingleStack bool
+	// crecoveryCostCompetitionRelevant gates the C-recovery merge cost walks
+	// (cRecoveryMergeCostsDiffer / cRecoveryCostClassForSlot/Slice via
+	// scratch.merge.cRecoveryCost): until something cost-relevant happens in
+	// THIS parse pass, every stack's error cost is provably zero, so the cost
+	// competition cannot change any merge outcome and the O(spine) cost walks
+	// per merge candidate are pure tax. It starts false for a fresh full parse
+	// and flips sticky-true on the first event that can make costs nonzero or
+	// unequal: a stack pausing (cPaused), cHandleError running, an
+	// error/missing node being pushed, or — conservatively — any parse that
+	// can REUSE subtrees from an old tree (reused subtrees may already carry
+	// error nodes without any new pause this pass). Reset alongside
+	// crecoveryEnteredErrorState in parseInternal.
+	crecoveryCostCompetitionRelevant bool
+	// fullParseRetryPassesTaken counts retry-ladder passes run during the
+	// current top-level parse operation (reset at the public parse entry
+	// funnels). retryFullParse stops launching passes once it reaches
+	// fullParseRetryMaxTotalPasses — a hard bound that, unlike the ladder's
+	// wall-clock deadline, holds even when the caller never configured
+	// SetTimeoutMicros.
+	fullParseRetryPassesTaken int
 	// cRecoverSharedTokenErrorModeLexed records whether the CURRENT shared
 	// token was produced by C-equivalent error-mode lexing (the DFA token
 	// source lexing with the ERROR-state primary because every live stack is
@@ -177,41 +197,48 @@ type Parser struct {
 	// where the deep stack-equivalence merge dominates and shared-leaf pointer
 	// identity short-circuits it (measured: swift 4.0x, bash 1.9x). Net-neutral
 	// or slightly negative on fast languages (go +4.9%), so it stays per-language.
-	leafInternByLang                    bool
-	forceRawSpanTable                   []bool
-	spanExtendingInvisibleSymbols       []bool
-	nonSpanExtendingInvisibleSymbols    []bool
-	aliasPreservedWrapperSymbols        []bool
-	included                            []Range
-	logger                              ParserLogger
-	glrTrace                            bool // verbose GLR stack tracing
-	ambiguityProfile                    *AmbiguityProfile
-	maxConflictWidth                    int // widest N-way conflict in the parse table
-	timeoutMicros                       uint64
-	cancellationFlag                    *uint32
-	parseBudgetDepth                    int
-	parseDeadline                       time.Time
-	parseStoppedReason                  ParseStopReason
-	denseLimit                          int
-	smallBase                           int
-	smallLookup                         [][]smallActionPair
-	smallTokenLookup                    [][]uint16
-	externalValidByState                [][]uint16
-	externalValidMaskByState            []uint64
-	hasExtraChainActions                bool
-	classifiedActions                   []classifiedParseAction
-	reduceChainHints                    []reduceChainHint
-	reduceChainHintByState              []int
-	reduceAliasSeq                      [][]Symbol
-	aliasTargetSymbol                   []bool
-	keepSameNamedAnonChildSymbol        []bool
-	sharedAnonymousTokenSymbol          []bool
-	reduceHasFields                     []bool
-	reduceFieldPlans                    []reduceFieldPlan
-	fieldIDScratch                      []FieldID
-	fieldInheritedScratch               []bool
-	fieldConflictedScratch              []bool
-	reduceScratch                       *reduceBuildScratch
+	leafInternByLang                 bool
+	forceRawSpanTable                []bool
+	spanExtendingInvisibleSymbols    []bool
+	nonSpanExtendingInvisibleSymbols []bool
+	aliasPreservedWrapperSymbols     []bool
+	included                         []Range
+	logger                           ParserLogger
+	glrTrace                         bool // verbose GLR stack tracing
+	ambiguityProfile                 *AmbiguityProfile
+	maxConflictWidth                 int // widest N-way conflict in the parse table
+	timeoutMicros                    uint64
+	cancellationFlag                 *uint32
+	parseBudgetDepth                 int
+	parseDeadline                    time.Time
+	parseStoppedReason               ParseStopReason
+	denseLimit                       int
+	smallBase                        int
+	smallLookup                      [][]smallActionPair
+	smallTokenLookup                 [][]uint16
+	externalValidByState             [][]uint16
+	externalValidMaskByState         []uint64
+	hasExtraChainActions             bool
+	classifiedActions                []classifiedParseAction
+	reduceChainHints                 []reduceChainHint
+	reduceChainHintByState           []int
+	reduceAliasSeq                   [][]Symbol
+	aliasTargetSymbol                []bool
+	keepSameNamedAnonChildSymbol     []bool
+	sharedAnonymousTokenSymbol       []bool
+	reduceHasFields                  []bool
+	reduceFieldPlans                 []reduceFieldPlan
+	fieldIDScratch                   []FieldID
+	fieldInheritedScratch            []bool
+	fieldConflictedScratch           []bool
+	reduceScratch                    *reduceBuildScratch
+	// mergeScratch points at the active parse's scratch.merge for the duration
+	// of parseInternal (set alongside reduceScratch, cleared on return). It lets
+	// dispatch-time helpers that only carry *Parser — tryGSSMainMergeForParser
+	// and the retargetStackEntryPayload reduce sites — invalidate the
+	// materializing-shape prefix cache when they rewrite a spine node's
+	// root->head prefix. nil outside a parse; bumpShapePrefixEpoch is nil-safe.
+	mergeScratch                        *glrMergeScratch
 	noTreeBenchmarkOnly                 bool
 	noTreeCheckpointBenchmarkOnly       bool
 	compactNoTreeShiftLeaves            bool
@@ -1896,6 +1923,7 @@ func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Tok
 		}
 	}
 
+	p.crecoveryCostCompetitionRelevant = true // missing-token insertion makes costs relevant
 	missingTok := Token{
 		Symbol:     candidateSym,
 		StartByte:  tok.StartByte,
@@ -2438,6 +2466,7 @@ func (p *Parser) tryInsertMissingSingleShiftAtEOF(s *glrStack, tok Token, nodeCo
 		return false
 	}
 
+	p.crecoveryCostCompetitionRelevant = true // missing-token insertion makes costs relevant
 	missingTok := Token{
 		Symbol:     candidateSym,
 		StartByte:  tok.StartByte,
@@ -2502,7 +2531,7 @@ func (p *Parser) tryRecoverTrailingEOFSuffix(s *glrStack, tok Token, nodeCount *
 					trimRecoveryWhitespaceTail(n, source)
 				}
 			}
-			nodes, recovered := appendTrailingEOFRecoveryNodes(nodes, entries, cut, tok, arena, nodeCount)
+			nodes, recovered := p.appendTrailingEOFRecoveryNodes(nodes, entries, cut, tok, arena, nodeCount)
 			if recovered || insertedMissing || cut > firstDrop {
 				return nodes, true
 			}
@@ -2569,7 +2598,21 @@ func (p *Parser) trailingEOFNodesFromPrefix(prefix glrStack) []*Node {
 	return nodes
 }
 
-func appendTrailingEOFRecoveryNodes(nodes []*Node, entries []stackEntry, cut int, tok Token, arena *nodeArena, nodeCount *int) ([]*Node, bool) {
+// appendTrailingEOFRecoveryNodes wraps the first dropped non-extra trailing
+// stack payload in an ERROR node during trailing-EOF suffix recovery. This is
+// issue #110's actual construction path: on a fresh parse `trailing` can be a
+// TRANSIENT reduce parent (a transientParentScratch slab node), whose .parent
+// field doubles as the result-time materializer's {nil: unvisited, self:
+// in-progress, other: arena clone} sentinel. The old eager-link-wiring
+// constructor (newParentNodeInArena → populateParentNode → setNodeParentLink)
+// corrupted that sentinel, so materializeTransientParentNodes then linked this
+// ERROR wrapper under itself — the cyclic-transient-tree defect that
+// stripResultTreeSelfCycles was left to mask. Route through
+// newRecoveryParentNodeInArena, which skips eager wiring while transient parents
+// are active (finalizeResultRoot wires links from the root anyway) and keeps the
+// eager-wiring constructor for incremental parses. See parser_recover_c.go and
+// parser_recover_cycle_internal_test.go for the mechanism and pins.
+func (p *Parser) appendTrailingEOFRecoveryNodes(nodes []*Node, entries []stackEntry, cut int, tok Token, arena *nodeArena, nodeCount *int) ([]*Node, bool) {
 	recovered := false
 	for i := cut; i < len(entries); i++ {
 		trailing := stackEntryNode(entries[i])
@@ -2580,7 +2623,7 @@ func appendTrailingEOFRecoveryNodes(nodes []*Node, entries []stackEntry, cut int
 			continue
 		}
 		if !recovered && !trailing.isExtra() {
-			errNode := newParentNodeInArena(arena, errorSymbol, true, []*Node{trailing}, nil, 0)
+			errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, []*Node{trailing}, 0)
 			errNode.setHasError(true)
 			errNode.setExtra(true)
 			nodes = append(nodes, errNode)
@@ -3699,12 +3742,14 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	transientReduceParents := p.configureParseScratch(scratch, source, reuse, oldTree, arenaClass, deferParentLinks)
 	defer releaseParserScratch(scratch, deferParentLinks)
 	p.reduceScratch = &scratch.reduce
+	p.mergeScratch = &scratch.merge
 	if transientReduceParents {
 		p.reduceScratch.transientParents = &scratch.transientParents
 		p.reduceScratch.transientChildren = &scratch.transientChildren
 	}
 	defer func() {
 		p.reduceScratch = nil
+		p.mergeScratch = nil
 	}()
 	scratch.audit.beginParse()
 	scratch.merge.audit = nil
@@ -3720,6 +3765,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		}
 		p.crecoveryEnteredErrorState = false
 		p.crecoveryDroppedErrorForClean = false
+		// Cost walks stay gated off until this pass proves costs can be
+		// nonzero; parses that may reuse old-tree subtrees start relevant
+		// because reused subtrees can already carry error nodes.
+		p.crecoveryCostCompetitionRelevant = reuse != nil || oldTree != nil
 		p.cRecoverSharedTokenErrorModeLexed = false
 		p.cRecoverCustomResyncActive = false
 		p.cRecoverCustomResyncByte = 0
@@ -4120,6 +4169,26 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			stopReason = ParseStopNoStacksAlive
 			tree = replaceWithOwnedErrorTree(tree, stopReason)
 		}
+		// C-recovery wrap/unwrap cycles can leave stale hasError bits on
+		// ancestors whose error content resolved losslessly (see
+		// reconcileStaleHasErrorFlags). Repair before the runtime is stamped so
+		// the retry ladder and callers see C-derived truth. Gated to passes
+		// where the recovery machinery actually ran; the walk itself only
+		// happens when the root still claims an error.
+		//
+		// SAFETY: only for ACCEPTED, EOF-covering trees. On a truncated or
+		// stopped-early tree "no ERROR node inside" does not mean "no error"
+		// — the error can be exactly the reason the parse stopped (the
+		// _pydecimal.py swallowed-error class: Go truncates at 64K with
+		// hasError=false where C reports hasError=true). Clearing there
+		// would widen that class; an accepted tree spanning expected EOF
+		// with zero ERROR/MISSING descendants is the only case where
+		// hasError=false is definitionally C-correct.
+		if tree != nil && p.crecoveryEnteredErrorState && stopReason == ParseStopAccepted {
+			if root := tree.root; root != nil && root.hasError() && root.endByte >= expectedEOFByte {
+				reconcileStaleHasErrorFlags(root, 0)
+			}
+		}
 		scratch.audit.finishParse(stacks)
 		captureArenaStats()
 		captureScratchStats()
@@ -4257,6 +4326,16 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	maxIter := caps.maxIter
 	maxDepth := caps.maxDepth
 	maxNodes := caps.maxNodes
+	// Population cap for transient conflict-frontier fork admission
+	// (completeConflictReduceFrontier): active exactly where the boundary
+	// cull's overflow window exists (full parses outside c_sharp, where
+	// glrStackCullTrigger returns maxStacks+fullParseGLRStackOverflow).
+	// Zero disables the gate so incremental and c_sharp behavior is
+	// unchanged.
+	frontierForkPopulationCap := 0
+	if maxStackCullTrigger > maxStacks {
+		frontierForkPopulationCap = maxStackCullTrigger
+	}
 	parseRuntime.IterationLimit = maxIter
 	parseRuntime.StackDepthLimit = maxDepth
 	parseRuntime.NodeLimit = maxNodes
@@ -4767,6 +4846,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					// condense step decides (ts_parser__handle_error skips the
 					// strategy-1 scan for error lookaheads and absorbs it).
 					s.cPaused = true
+					p.crecoveryCostCompetitionRelevant = true
 					if actionTiming != nil {
 						ns := recordNoActionTiming()
 						actionTiming.actionNoActionErrorNanos += ns
@@ -4819,6 +4899,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						// the condense step resumes via ts_parser__handle_error
 						// whose recover_eof wraps the stack in an ERROR root.
 						s.cPaused = true
+						p.crecoveryCostCompetitionRelevant = true
 						if actionTiming != nil {
 							ns := recordNoActionTiming()
 							actionTiming.actionNoActionErrorNanos += ns
@@ -4922,6 +5003,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						fmt.Printf("  stack[%d] C-PAUSED: no action for sym=%d in state=%d\n", si, tok.Symbol, currentState)
 					}
 					s.cPaused = true
+					p.crecoveryCostCompetitionRelevant = true
 					if actionTiming != nil {
 						ns := recordNoActionTiming()
 						actionTiming.actionNoActionErrorNanos += ns
@@ -5079,7 +5161,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							afterState:  actionAfterState,
 							afterByte:   actionAfterByte,
 							afterDepth:  actionAfterDepth,
-						}, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
 						traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 					}
 					drainPendingForkStacks()
@@ -5133,7 +5215,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							afterState:  actionAfterState,
 							afterByte:   actionAfterByte,
 							afterDepth:  actionAfterDepth,
-						}, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
 						traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 					}
 					drainPendingForkStacks()
@@ -5169,7 +5251,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 									afterState:  actionAfterState,
 									afterByte:   actionAfterByte,
 									afterDepth:  actionAfterDepth,
-								}, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+								}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
 								frontier := traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, &fork)
 								traceAppend("conflict-fork", si, ai, len(actions), actions[ai], &fork, frontier)
 							} else {
@@ -5218,7 +5300,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						afterState:  actionAfterState,
 						afterByte:   actionAfterByte,
 						afterDepth:  actionAfterDepth,
-					}, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
 					traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 				}
 				if p.glrTrace {
@@ -5777,6 +5859,7 @@ func (p *Parser) configureParseScratch(scratch *parserScratch, source []byte, re
 		p.transientChildren = nil
 	}
 	scratch.merge.beginEquivEpoch()
+	scratch.merge.ensureMergeHotCaches()
 	transientReduceParents := p.shouldUseTransientReduceParents(source, reuse, oldTree, arenaClass)
 	p.transientReduceScratchNoAlias = p.transientReduceChildren && transientReduceParents && parseShouldUseTransientReduceScratchNoAlias(len(source))
 	scratch.merge.pythonShallow = p.language != nil && p.language.Name == "python" && len(source) <= 512*1024
@@ -5929,14 +6012,6 @@ func javaFullParseNeedsAnnotationDeclarationMergeWidth(lang *Language, source []
 }
 
 func (p *Parser) tuneParseGLRCaps(maxStacks, mergePerKeyCap int, reuse *reuseCursor) (int, int) {
-	if reuse == nil && p.language != nil && p.language.Name == "bash" {
-		if maxStacks < 256 {
-			maxStacks = 256
-		}
-		if mergePerKeyCap < 256 {
-			mergePerKeyCap = 256
-		}
-	}
 	if reuse == nil && p.language != nil && p.language.Name == "c_sharp" && mergePerKeyCap < 16 {
 		mergePerKeyCap = 16
 	}
@@ -6003,7 +6078,11 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 	}
 	scratch.merge.language = p.language
 	scratch.merge.trace = p.glrTrace
-	scratch.merge.cRecoveryCost = p.errorCostCompetitionEnabled()
+	// Sticky per-parse gate: before anything cost-relevant has happened this
+	// pass (see crecoveryCostCompetitionRelevant), every stack's error cost is
+	// provably zero and the merge cost competition cannot change any outcome,
+	// so skip its O(spine) walks entirely on the clean prefix of the parse.
+	scratch.merge.cRecoveryCost = p.errorCostCompetitionEnabled() && p.crecoveryCostCompetitionRelevant
 	scratch.merge.deferExactDedupe = languageDefersExactDedupe(p.language, p.noTreeBenchmarkOnly)
 	scratch.merge.frontierMergeHash = p.usesGenericFrontierMergeHash()
 	if p.ambiguityProfile != nil {
@@ -6465,10 +6544,26 @@ func currentRelexStateStackEligible(s *glrStack) bool {
 }
 
 func (p *Parser) usesPrimaryExternalScannerStateForGLR() bool {
-	return p != nil &&
-		p.language != nil &&
-		(p.language.Name == "yaml" || p.language.Name == "c_sharp") &&
-		p.language.ExternalScanner != nil
+	if p == nil || p.language == nil || p.language.ExternalScanner == nil {
+		return false
+	}
+	switch p.language.Name {
+	case "yaml":
+		return true
+	case "c_sharp":
+		// Pin to the primary stack only while the blob lacks a precise
+		// ExternalLexStates table: the union path over-approximates external
+		// validity and corrupts the stateful interpolation scanner. With the
+		// precise table registered, the per-row scored path
+		// (nextGLRScoredExternalToken) lexes each distinct external lex state
+		// like C does per version, and MUST see all stack states — pinning
+		// here starves interpolation-hole stacks of interpolation_close_brace
+		// whenever the primary stack is a competing non-hole interpretation
+		// (observed: DeclaredTypeManager.cs `{nameof(...)}` hole close at
+		// byte 30694 arriving as a plain `}` and detonating recovery).
+		return len(p.language.ExternalLexStates) == 0
+	}
+	return false
 }
 
 func clearGLRStateTokenSource(stateful parserStateTokenSource, scratch *parserScratch) {
@@ -7775,7 +7870,7 @@ func compareStackCullKeys(lang *Language, a, b stackCullKey) int {
 		}
 	}
 	if a.depth != b.depth {
-		if lang != nil && (lang.Name == "bash" || lang.Name == "python") {
+		if lang != nil && lang.Name == "python" {
 			if a.depth < b.depth {
 				return 1
 			}

--- a/parser_api.go
+++ b/parser_api.go
@@ -520,6 +520,7 @@ func (p *Parser) parseWithTokenSource(source []byte, ts TokenSource, reparseFact
 	}
 	endBudget := p.beginParseOperationBudget()
 	defer endBudget()
+	p.fullParseRetryPassesTaken = 0
 	p.releaseCompatibilityBorrowedArenas()
 	p.clearRecoveryParser()
 	defer p.clearRecoveryParser()
@@ -563,6 +564,7 @@ func (p *Parser) parseIncrementalWithTokenSource(source []byte, oldTree *Tree, t
 func (p *Parser) parseIncrementalWithTokenSourceChanged(source []byte, oldTree *Tree, ts TokenSource, reparseFactory TokenSourceFactory) (*Tree, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
+	p.fullParseRetryPassesTaken = 0
 	prevFactory := p.reparseFactory
 	p.reparseFactory = reparseFactory
 	defer func() {
@@ -833,6 +835,7 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	}
 	endBudget := p.beginParseOperationBudget()
 	defer endBudget()
+	p.fullParseRetryPassesTaken = 0
 	progress := newParseProgressTelemetry(p, len(source), uint32(len(source)), time.Now())
 	if progress.enabled {
 		progress.emit(time.Now(), "parse_entry", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")
@@ -1257,6 +1260,7 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
+	p.fullParseRetryPassesTaken = 0
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, nil); ok {
 			return tree, nil
@@ -1392,6 +1396,7 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (*Tree, IncrementalParseProfile, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
+	p.fullParseRetryPassesTaken = 0
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		timing := &incrementalParseTiming{}
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, timing); ok {
@@ -1436,6 +1441,7 @@ func (p *Parser) ParseIncrementalWithTokenSourceProfiled(source []byte, oldTree 
 func (p *Parser) parseIncrementalWithTokenSourceChangedProfiled(source []byte, oldTree *Tree, ts TokenSource) (*Tree, IncrementalParseProfile, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
+	p.fullParseRetryPassesTaken = 0
 	prevFactory := p.reparseFactory
 	p.reparseFactory = p.tokenSourceReparseFactory(ts)
 	defer func() {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1759,8 +1759,15 @@ func TestResolveParseMaxStacks(t *testing.T) {
 }
 
 func TestEffectiveFullParseInitialMaxStacks(t *testing.T) {
-	if got := effectiveFullParseInitialMaxStacks(&Language{Name: "bash"}, maxGLRStacks); got != 256 {
-		t.Fatalf("effectiveFullParseInitialMaxStacks(bash) = %d, want 256", got)
+	// bash's historical 256 floor was removed by the 2026-07 cliff campaign:
+	// it papered over the shallow-depth cull ordering evicting the accept
+	// lineage (see compareStackCullKeys), cost every bash full parse 256
+	// survivors x 256 merge-per-key, and did not even prevent the defect
+	// (first pass still error-wrapped at caps 2..256). With the cull fix the
+	// global default parses the bash corpus clean and byte-shape-identical to
+	// the pinned C oracle.
+	if got := effectiveFullParseInitialMaxStacks(&Language{Name: "bash"}, maxGLRStacks); got != maxGLRStacks {
+		t.Fatalf("effectiveFullParseInitialMaxStacks(bash) = %d, want %d (global default)", got, maxGLRStacks)
 	}
 	if got := effectiveFullParseInitialMaxStacks(&Language{Name: "css"}, maxGLRStacks); got != 2 {
 		t.Fatalf("effectiveFullParseInitialMaxStacks(css) = %d, want 2", got)
@@ -1908,14 +1915,18 @@ func TestEffectiveParseMergePerKeyCap(t *testing.T) {
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "typescript"}, maxStacksPerMergeKey, false); got != 1 {
 		t.Fatalf("effectiveParseMergePerKeyCap(typescript, default, full) = %d, want 1", got)
 	}
-	if got := effectiveParseMergePerKeyCap(&Language{Name: "typescript"}, maxStacksPerMergeKey, false, 128*1024); got != maxStacksPerMergeKey {
-		t.Fatalf("effectiveParseMergePerKeyCap(typescript, large default, full) = %d, want %d", got, maxStacksPerMergeKey)
+	// The tight TypeScript cap applies uniformly regardless of source size:
+	// the former >64KB disengagement retained redundant unreduced-spine
+	// survivors whose frontier walks exploded transient stack population on
+	// large union-list .d.ts sources (intra-token population explosion).
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "typescript"}, maxStacksPerMergeKey, false, 128*1024); got != 1 {
+		t.Fatalf("effectiveParseMergePerKeyCap(typescript, large default, full) = %d, want 1", got)
 	}
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "tsx"}, maxStacksPerMergeKey, false); got != 1 {
 		t.Fatalf("effectiveParseMergePerKeyCap(tsx, default, full) = %d, want 1", got)
 	}
-	if got := effectiveParseMergePerKeyCap(&Language{Name: "tsx"}, maxStacksPerMergeKey, false, 128*1024); got != maxStacksPerMergeKey {
-		t.Fatalf("effectiveParseMergePerKeyCap(tsx, large default, full) = %d, want %d", got, maxStacksPerMergeKey)
+	if got := effectiveParseMergePerKeyCap(&Language{Name: "tsx"}, maxStacksPerMergeKey, false, 128*1024); got != 1 {
+		t.Fatalf("effectiveParseMergePerKeyCap(tsx, large default, full) = %d, want 1", got)
 	}
 	if got := effectiveParseMergePerKeyCap(&Language{Name: "java"}, maxStacksPerMergeKey, false); got != 1 {
 		t.Fatalf("effectiveParseMergePerKeyCap(java, default, full) = %d, want 1", got)
@@ -2124,18 +2135,24 @@ func TestEffectiveParseMergePerKeyCapGoFaithfulCondense(t *testing.T) {
 	}
 }
 
-func TestConfigureParseCapsTypedArrowDoesNotLowerLargeTypeScriptCap(t *testing.T) {
+func TestConfigureParseCapsTypedArrowKeepsTypedArrowWidthOnLargeTypeScript(t *testing.T) {
 	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
 	ResetParseEnvConfigCacheForTests()
 	defer ResetParseEnvConfigCacheForTests()
 
+	// TypeScript's tight full-parse merge cap now applies uniformly regardless
+	// of source size (the former >64KB disengagement caused the intra-token
+	// population explosion on large union-list sources). A large typed-arrow
+	// source therefore gets the same typed-arrow minimum width (2) that small
+	// typed-arrow sources have always used, rather than the former wide
+	// default of maxStacksPerMergeKey.
 	source := []byte(strings.Repeat("const filler = 1;\n", 8192) + "const f = (str: string) => str;\n")
 	parser := &Parser{language: &Language{Name: "typescript"}}
 	var scratch parserScratch
 
 	caps := parser.configureParseCaps(source, nil, arenaClassFull, &scratch, 0, 0, 0)
-	if caps.mergePerKeyCap != maxStacksPerMergeKey {
-		t.Fatalf("configureParseCaps(large TypeScript typed arrow) merge cap = %d, want %d", caps.mergePerKeyCap, maxStacksPerMergeKey)
+	if caps.mergePerKeyCap != 2 {
+		t.Fatalf("configureParseCaps(large TypeScript typed arrow) merge cap = %d, want 2", caps.mergePerKeyCap)
 	}
 
 	caps = parser.configureParseCaps(source, nil, arenaClassFull, &scratch, 0, 0, -4)

--- a/parser_config.go
+++ b/parser_config.go
@@ -115,6 +115,14 @@ func parseMaxMergePerKeyEnvConfigured() bool {
 	return strings.TrimSpace(os.Getenv("GOT_GLR_MAX_MERGE_PER_KEY")) != ""
 }
 
+// parseMaxGLRStacksEnvConfigured reports whether GOT_GLR_MAX_STACKS was set
+// explicitly. An explicit survivor cap is a diagnostic/experiment contract:
+// the retry ladder must treat it as a true ceiling instead of silently
+// widening past it (fullParseRetryMaxStacksOverride).
+func parseMaxGLRStacksEnvConfigured() bool {
+	return strings.TrimSpace(os.Getenv("GOT_GLR_MAX_STACKS")) != ""
+}
+
 // glrFaithfulCapOneMerge (GOT_FAITHFUL_CONDENSE=1) makes cap-one condense
 // preserve same-key tie readings through multi-link GSS nodes. It defaults off
 // while the faithful GLR path is validated.

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1731,6 +1731,10 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// actual suspicion signal is cRecoveryDroppedErrorForClean, scoped to the
 	// selected result's own lineage in buildResultFromGLR.
 	p.crecoveryEnteredErrorState = true
+	// Recovery machinery is running: stack error costs can now be nonzero, so
+	// the merge cost competition must run its walks from here on (sticky
+	// per-parse gate, see crecoveryCostCompetitionRelevant).
+	p.crecoveryCostCompetitionRelevant = true
 	// s is re-entering recovery, so whatever marker content it may already
 	// carry from an earlier cRecoverToState fork or condense-drop win (see
 	// cRecoveryUnvalidatedMarker) is about to be re-accounted for by this
@@ -1826,6 +1830,13 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	for vi := range versions {
 		v := &versions[vi]
 		entries := cStackEntriesTopFirst(v, gssScratch)
+		if debugRecoveryCycleChecks {
+			for ei := range entries {
+				if entries[ei].node != nil {
+					debugRecoveryCheckAcyclic(p, arena, fmt.Sprintf("handle-error-version-%d-spine-%d", vi, ei), entries[ei])
+				}
+			}
+		}
 		v.cRec = &cRecoverState{summary: p.cRecordSummary(entries), group: group, groupOrder: vi}
 		v.cRecoverMissingGroup = nil
 	}
@@ -2243,7 +2254,7 @@ func (p *Parser) cRecoverEOFAccept(v *glrStack, tok Token, nodeCount *int, arena
 		// only invisible (hidden-symbol) subtrees flatten.
 		children = p.cAppendVisibleSplice(children, n)
 	}
-	root := newParentNodeInArena(arena, errorSymbol, true, children, nil, 0)
+	root := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, children, 0)
 	if rawFirst != nil {
 		cSetNodeSpan(root, rawFirst.startByte, rawLast.endByte, rawFirst.startPoint, rawLast.endPoint)
 	} else {
@@ -2264,6 +2275,9 @@ func (p *Parser) cRecoverEOFAccept(v *glrStack, tok Token, nodeCount *int, arena
 	v.cRec = nil
 	v.cRecoverMissingGroup = nil
 	p.pushStackNode(v, 1, root, entryScratch, gssScratch)
+	if debugRecoveryCycleChecks {
+		debugRecoveryCheckNodeAcyclic(p, arena, "recover-eof-accept-root", root)
+	}
 	v.accepted = true
 	v.shifted = true
 }
@@ -2418,7 +2432,7 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 	}
 
 	if rawFirst != nil {
-		errNode := newParentNodeInArena(arena, errorSymbol, true, children, nil, 0)
+		errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, children, 0)
 		cSetNodeSpan(errNode, rawFirst.startByte, rawLast.endByte, rawFirst.startPoint, rawLast.endPoint)
 		errNode.setHasError(true)
 		errNode.setExtra(true)
@@ -2459,6 +2473,9 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 			fork.cRecoveryUnvalidatedMarker = true
 		}
 		p.pushStackNode(&fork, goal, errNode, entryScratch, gssScratch)
+		if debugRecoveryCycleChecks {
+			debugRecoveryCheckNodeAcyclic(p, arena, "recover-to-state-wrap", errNode)
+		}
 	}
 	for _, ex := range trailing {
 		p.pushStackNode(&fork, goal, ex, entryScratch, gssScratch)
@@ -2508,6 +2525,9 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 			rec.openErr.endByte = tok.EndByte
 			rec.openErr.endPoint = tok.EndPoint
 			nodeBumpEquivVersion(rec.openErr)
+			if debugRecoveryCycleChecks {
+				debugRecoveryCheckNodeAcyclic(p, arena, "absorb-extend-top", rec.openErr)
+			}
 			if v.byteOffset < tok.EndByte {
 				v.byteOffset = tok.EndByte
 			}
@@ -2544,6 +2564,9 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 				rec.openErr.endByte = tok.EndByte
 				rec.openErr.endPoint = tok.EndPoint
 				nodeBumpEquivVersion(rec.openErr)
+				if debugRecoveryCycleChecks {
+					debugRecoveryCheckNodeAcyclic(p, arena, "absorb-fold-extras", rec.openErr)
+				}
 				if v.byteOffset < tok.EndByte {
 					v.byteOffset = tok.EndByte
 				}
@@ -2559,7 +2582,7 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	if leaf != nil {
 		errChildren = []*Node{leaf}
 	}
-	errNode := newParentNodeInArena(arena, errorSymbol, true, errChildren, nil, 0)
+	errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, errChildren, 0)
 	cSetNodeSpan(errNode, tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
 	errNode.setHasError(true)
 	errNode.parseState = cErrorState
@@ -2570,6 +2593,9 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	p.pushStackNode(v, cErrorState, errNode, entryScratch, gssScratch)
 	if rec != nil {
 		rec.openErr = errNode
+	}
+	if debugRecoveryCycleChecks {
+		debugRecoveryCheckNodeAcyclic(p, arena, "absorb-new-region", errNode)
 	}
 	if nodeCount != nil {
 		*nodeCount = *nodeCount + 2
@@ -2642,6 +2668,15 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 			break
 		}
 	}
+	if debugRecoveryCycleChecks && relevant {
+		for i := range stacks {
+			if stacks[i].dead {
+				continue
+			}
+			entries := cStackEntriesTopFirst(&stacks[i], gssScratch)
+			debugRecoveryCheckSpineAcyclic(p, arena, fmt.Sprintf("condense-stack-%d-byte-%d", i, stacks[i].byteOffset), entries)
+		}
+	}
 	if !relevant {
 		return stacks, false, tok
 	}
@@ -2707,12 +2742,45 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		}
 	}
 	if len(stacks) > cRecoverMaxVersionCount {
-		if p.glrTrace {
-			for i := cRecoverMaxVersionCount; i < len(stacks); i++ {
+		// C's ts_parser__condense_stack MERGES merge-equivalent versions
+		// (ts_stack_merge: same head state, byte position, error cost, and
+		// external scanner state) during the pairwise loop, BEFORE the
+		// MAX_VERSION_COUNT truncation — the surviving histories live on as
+		// extra links of the merged GSS head. So C's cap only ever counts
+		// DISTINCT (state, position, cost) versions. This port keeps
+		// merge-equivalent stacks as separate versions (each carrying one of
+		// the histories C would fold into links), so a raw positional
+		// truncation at cRecoverMaxVersionCount can kill every copy of a
+		// distinct grammar interpretation while retaining redundant
+		// duplicates of another. Observed on c_sharp (precise-ELS election,
+		// DeclaredTypeManager.cs): six merge-equivalent missing-group stacks
+		// + a 2-way `.` shift conflict forked 6->12, and the positional trim
+		// kept the six duplicates of one interpretation while dropping all
+		// six copies of the other — misparsing a switch-expression arm
+		// (`DeclaredSymbol declaredSymbol => ErrorType.Create(...)`, line
+		// 578) that the C oracle parses clean. Enforce the version window
+		// the way C effectively does: bound the number of DISTINCT merge
+		// keys at cRecoverMaxVersionCount (dropping all stacks of the
+		// least-promising excess keys), and leave same-key duplicates — C's
+		// merged links — to the engine's own boundary merge/cull population
+		// discipline.
+		keyRanks := make(map[cCondenseVersionKey]int, len(stacks))
+		for i := 0; i < len(stacks); i++ {
+			key := p.cCondenseVersionKeyFor(&stacks[i])
+			rank, seen := keyRanks[key]
+			if !seen {
+				rank = len(keyRanks)
+				keyRanks[key] = rank
+			}
+			if rank < cRecoverMaxVersionCount {
+				continue
+			}
+			if p.glrTrace {
 				p.traceCCondenseTrim(i, stacks[i])
 			}
+			stacks = append(stacks[:i], stacks[i+1:]...)
+			i--
 		}
-		stacks = stacks[:cRecoverMaxVersionCount]
 	}
 
 	// Resume the best paused version; remove the rest (C condense tail).
@@ -2832,6 +2900,42 @@ func cRecoverVersionsSameGroup(a, b glrStack) bool {
 		a.cRec.group == b.cRec.group
 }
 
+// cCondenseVersionKey identifies a stack version group under C's
+// ts_stack_can_merge (stack.c): active status, head state, byte position,
+// and error cost. C additionally requires equal external scanner state; this
+// port's lockstep token loop keeps all live stacks on the same lookahead, so
+// same-byte heads share the token source's external state by construction.
+// Port-conservative extras C does not key on: dynamic-precedence score
+// (score breaks final-selection ties here, so unequal-score stacks are not
+// interchangeable), shifted phase, and recovery-group identity (cRec.group /
+// cRecoverMissingGroup pointers).
+type cCondenseVersionKey struct {
+	state        StateID
+	byteOffset   uint32
+	cost         uint32
+	score        int
+	shifted      bool
+	paused       bool
+	recGroup     *cRecGroup
+	missingGroup *cRecGroup
+}
+
+func (p *Parser) cCondenseVersionKeyFor(s *glrStack) cCondenseVersionKey {
+	key := cCondenseVersionKey{
+		state:        s.top().state,
+		byteOffset:   s.byteOffset,
+		cost:         p.cStackErrorCost(s),
+		score:        s.score,
+		shifted:      s.shifted,
+		paused:       s.cPaused,
+		missingGroup: s.cRecoverMissingGroup,
+	}
+	if s.cRec != nil {
+		key.recGroup = s.cRec.group
+	}
+	return key
+}
+
 func cRecoverVersionShouldStayBefore(a, b glrStack) bool {
 	if a.dead || b.dead || a.accepted || b.accepted {
 		return false
@@ -2901,7 +3005,7 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 	for _, n := range nodes[rootIdx+1:] {
 		children = p.cAppendVisibleSplice(children, n)
 	}
-	root := newParentNodeInArena(arena, cand.symbol, p.isNamedSymbol(cand.symbol), children, nil, 0)
+	root := p.newRecoveryParentNodeInArena(arena, cand.symbol, p.isNamedSymbol(cand.symbol), children, 0)
 	root.rawShape = captureRawShapeForNodeSlice(arena, cand.symbol, cand.productionID, children)
 	root.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
 	first, last := nodes[0], nodes[len(nodes)-1]
@@ -2921,6 +3025,9 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 		return
 	}
 	p.pushStackNode(s, 1, root, entryScratch, gssScratch)
+	if debugRecoveryCycleChecks {
+		debugRecoveryCheckNodeAcyclic(p, arena, "accept-root-rebuild", root)
+	}
 }
 
 func nodeSliceDynamicPrecedence(children []*Node) int32 {
@@ -2972,4 +3079,35 @@ func (p *Parser) cTreeErrorCost(t *Tree) uint32 {
 
 func traceCRecoverToState(state StateID, depth int) {
 	fmt.Printf("      -> C-RECOVER-TO-STATE state=%d depth=%d\n", state, depth)
+}
+
+// newRecoveryParentNodeInArena builds a recovery-construction parent node
+// (ERROR wrappers, recover_to_state splice wrappers, EOF-accept and
+// accept-rebuild roots) without corrupting the transient-parent sentinel.
+//
+// Recovery parents wrap children materialized straight off stack entries. In
+// the fresh-parse regime those children can be TRANSIENT reduce parents
+// (transientParentScratch slab nodes), whose .parent field doubles as the
+// result-time materializer's {nil: unvisited, self: in-progress, other: arena
+// clone} map (transient_parents.go materializeNodesUntil /
+// transientReplacement). Wiring eager parent links into such a child — what
+// newParentNodeInArena's populateParentNode does — corrupts that map:
+// materializeNodesUntil then skips the child as "already cloned", and
+// transientReplacement substitutes the child's TREE PARENT for the child,
+// linking the new parent under itself. That self back-edge is the
+// cyclic-transient-tree defect: every subsequent full-tree walk
+// (wireParentLinksWithScratchUntil, the walkResultTree normalizer family)
+// hangs or stack-overflows (go zerrors_windows.go truncations with recovery
+// engaged; the trailing-EOF shape of issue #110).
+//
+// Transient parents only exist on fresh parses (shouldUseTransientReduceParents
+// requires reuse == nil && oldTree == nil), and exactly those parses wire
+// parent links from the root in finalizeResultRoot — so skipping eager wiring
+// there loses nothing. Incremental parses never allocate transient parents and
+// skip the finalize wiring; they keep the eager-wiring constructor.
+func (p *Parser) newRecoveryParentNodeInArena(arena *nodeArena, sym Symbol, named bool, children []*Node, productionID uint16) *Node {
+	if p != nil && p.reduceScratch != nil && p.reduceScratch.transientParents != nil {
+		return newParentNodeInArenaNoLinksWithFieldSources(arena, sym, named, children, nil, nil, productionID, true)
+	}
+	return newParentNodeInArena(arena, sym, named, children, nil, productionID)
 }

--- a/parser_recover_cycle_debug.go
+++ b/parser_recover_cycle_debug.go
@@ -1,0 +1,222 @@
+package gotreesitter
+
+// parser_recover_cycle_debug.go — construction-time back-edge (cycle) tracing
+// for the error-recovery engine, env-gated via GOT_DEBUG_RECOVERY_CYCLES=1.
+//
+// The fundamental tree invariant is that no node is reachable from its own
+// descendants. Recovery-path construction historically violated it (issue
+// #110; the go zerrors_windows.go truncation hang): wiring eager parent links
+// into TRANSIENT reduce-parent children corrupted the result-time
+// materializer's parent-field sentinel, and transientReplacement() then linked
+// a recovery wrapper under itself. The mechanism fix is
+// newRecoveryParentNodeInArena (parser_recover_c.go); the checks here remain
+// as the debug-mode acyclicity sweep: with the env var set, every recovery
+// construction and every condense pass re-verifies the transient child view
+// (dense children, arena final child refs, pending parent shells) WITHOUT
+// materializing anything, so running them cannot perturb the parse.
+//
+// Zero overhead when the env var is unset beyond one package-var bool check
+// per recovery construction site.
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+// The package-level debug state below is single-parse/sequential-use-only.
+// GOT_DEBUG_RECOVERY_CYCLES is a debug-mode tracing aid, not a
+// concurrency-safe facility: debugRecoveryCheckSitesSeen is a plain map and
+// the counters are plain (non-atomic) integers. Running multiple *Parser
+// instances concurrently under this flag can race the site map and undercount
+// or corrupt these values. No mutex is added here deliberately — this path is
+// debug-only and opt-in (zero cost when the flag is unset), and documenting
+// the single-parse constraint is sufficient; callers who need concurrent
+// debug tracing must serialize their own parses.
+var debugRecoveryCycleChecks = os.Getenv("GOT_DEBUG_RECOVERY_CYCLES") == "1"
+
+// debugRecoveryCycleReportsLeft caps the loud per-cycle output;
+// debugRecoveryCyclesFound keeps counting past the cap.
+var debugRecoveryCycleReportsLeft = 8
+var debugRecoveryCyclesFound uint64
+var debugRecoveryCheckCalls uint64
+var debugRecoveryCheckSitesSeen = map[string]bool{}
+
+// debugRecoveryTraceSite prints one line per static site the first time it is
+// checked, so a sweep run proves which recovery paths actually engaged.
+// Per-call variability (indices, byte offsets) is trimmed at the first digit.
+func debugRecoveryTraceSite(site string) {
+	if !debugRecoveryCycleChecks {
+		// Direct detector calls (unit tests) stay quiet; only env-gated sweep
+		// runs report site coverage.
+		return
+	}
+	key := site
+	for j := 0; j < len(key); j++ {
+		if key[j] >= '0' && key[j] <= '9' {
+			key = key[:j]
+			break
+		}
+	}
+	if !debugRecoveryCheckSitesSeen[key] {
+		debugRecoveryCheckSitesSeen[key] = true
+		fmt.Fprintf(os.Stderr, "RECOVERY-CYCLE-TRACE first check at site=%s\n", key)
+	}
+}
+
+// debugRecoveryChildEntries appends e's child payload entries (transient view,
+// no materialization) to out and returns it. Field-only pending entries have a
+// nil payload pointer and are skipped.
+func debugRecoveryChildEntries(arena *nodeArena, e stackEntry, out []stackEntry) []stackEntry {
+	switch e.kind {
+	case stackEntryKindNode:
+		n := (*Node)(e.node)
+		if n == nil {
+			return out
+		}
+		if n.ownerArena != nil {
+			if cr, ok := n.ownerArena.finalChildRange(n); ok {
+				for _, ref := range cr.refs(n.ownerArena) {
+					se := ref.stackEntry()
+					if se.node != nil {
+						out = append(out, se)
+					}
+				}
+				return out
+			}
+		}
+		for _, c := range n.children {
+			if c != nil {
+				out = append(out, newStackEntryNode(c.parseState, c))
+			}
+		}
+	case stackEntryKindPendingParent:
+		pp := (*pendingParent)(e.node)
+		if pp == nil || arena == nil {
+			return out
+		}
+		for _, ref := range pp.childRange.refs(arena) {
+			se := ref.stackEntry()
+			if se.node != nil {
+				out = append(out, se)
+			}
+		}
+	}
+	// noTreeNode / compactFullLeaf payloads are leaves.
+	return out
+}
+
+func debugRecoveryEntryDesc(p *Parser, e stackEntry) string {
+	kind := "?"
+	sym := Symbol(0)
+	var start, end uint32
+	switch e.kind {
+	case stackEntryKindNode:
+		n := (*Node)(e.node)
+		kind = "node"
+		if n != nil {
+			sym = n.symbol
+			start, end = n.startByte, n.endByte
+		}
+	case stackEntryKindPendingParent:
+		pp := (*pendingParent)(e.node)
+		kind = "pending"
+		if pp != nil {
+			sym = pp.symbol
+			start, end = pp.startByte, pp.endByte
+		}
+	case stackEntryKindNoTreeNode:
+		kind = "notree"
+	case stackEntryKindCompactFullLeaf:
+		kind = "leaf"
+	}
+	name := ""
+	if p != nil && p.language != nil && int(sym) < len(p.language.SymbolNames) {
+		name = p.language.SymbolNames[sym]
+	}
+	return fmt.Sprintf("%s@%p sym=%d(%s) [%d-%d]", kind, e.node, sym, name, start, end)
+}
+
+// debugRecoveryCheckAcyclic runs an iterative 3-color DFS from root over the
+// transient child view. On finding a back-edge it prints the enclosing cycle
+// path (up to the report budget) and bumps debugRecoveryCyclesFound. Returns
+// true when the reachable graph is acyclic.
+func debugRecoveryCheckAcyclic(p *Parser, arena *nodeArena, site string, root stackEntry) bool {
+	return debugRecoveryCheckAcyclicShared(p, arena, site, root, make(map[unsafe.Pointer]int, 64))
+}
+
+func debugRecoveryCheckAcyclicShared(p *Parser, arena *nodeArena, site string, root stackEntry, color map[unsafe.Pointer]int) bool {
+	if root.node == nil {
+		return true
+	}
+	debugRecoveryCheckCalls++
+	debugRecoveryTraceSite(site)
+	const (
+		colorGray  = 1
+		colorBlack = 2
+	)
+	if color[root.node] == colorBlack {
+		return true
+	}
+	type frame struct {
+		e        stackEntry
+		children []stackEntry
+		idx      int
+	}
+	stack := []frame{{e: root, children: debugRecoveryChildEntries(arena, root, nil)}}
+	color[root.node] = colorGray
+	for len(stack) > 0 {
+		f := &stack[len(stack)-1]
+		if f.idx >= len(f.children) {
+			color[f.e.node] = colorBlack
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		child := f.children[f.idx]
+		f.idx++
+		switch color[child.node] {
+		case colorGray:
+			// Back-edge: child is an ancestor on the current DFS path.
+			debugRecoveryCyclesFound++
+			if debugRecoveryCycleReportsLeft > 0 {
+				debugRecoveryCycleReportsLeft--
+				fmt.Fprintf(os.Stderr, "RECOVERY-CYCLE site=%s back-edge from %s to ancestor %s\n",
+					site, debugRecoveryEntryDesc(p, f.e), debugRecoveryEntryDesc(p, child))
+				for i := range stack {
+					fmt.Fprintf(os.Stderr, "  path[%d] %s\n", i, debugRecoveryEntryDesc(p, stack[i].e))
+				}
+			}
+			return false
+		case colorBlack:
+			continue
+		default:
+			color[child.node] = colorGray
+			stack = append(stack, frame{e: child, children: debugRecoveryChildEntries(arena, child, nil)})
+		}
+	}
+	return true
+}
+
+// debugRecoveryCheckNodeAcyclic is the *Node convenience wrapper.
+func debugRecoveryCheckNodeAcyclic(p *Parser, arena *nodeArena, site string, n *Node) bool {
+	if n == nil {
+		return true
+	}
+	return debugRecoveryCheckAcyclic(p, arena, site, newStackEntryNode(n.parseState, n))
+}
+
+// debugRecoveryCheckSpineAcyclic checks every payload entry of a stack spine
+// with one shared color map, so shared subtrees are only walked once.
+func debugRecoveryCheckSpineAcyclic(p *Parser, arena *nodeArena, site string, entries []stackEntry) bool {
+	color := make(map[unsafe.Pointer]int, 256)
+	ok := true
+	for ei := range entries {
+		if entries[ei].node == nil {
+			continue
+		}
+		if !debugRecoveryCheckAcyclicShared(p, arena, fmt.Sprintf("%s-spine-%d", site, ei), entries[ei], color) {
+			ok = false
+		}
+	}
+	return ok
+}

--- a/parser_recover_cycle_internal_test.go
+++ b/parser_recover_cycle_internal_test.go
@@ -1,0 +1,201 @@
+package gotreesitter
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// These tests pin the mechanism behind the C-recovery cyclic-transient-tree
+// defect (go zerrors_windows.go truncations; the trailing-EOF shape of issue
+// #110) and its fix.
+//
+// Transient reduce parents (transientParentScratch slab nodes) use their
+// .parent field as the result-time materializer's {nil: unvisited, self:
+// in-progress, other: arena clone} map. Recovery constructions that wrapped
+// such nodes with the eager-link-wiring constructor (newParentNodeInArena →
+// populateParentNode → setNodeParentLink) corrupted that map:
+// materializeNodesUntil skipped the child as "already cloned" and
+// transientReplacement() substituted the child's TREE PARENT for the child —
+// linking the wrapper under itself. newRecoveryParentNodeInArena must never
+// do that while transient parents are active.
+
+func newTransientSentinelFixture(t *testing.T) (*nodeArena, *transientParentScratch, *Node) {
+	t.Helper()
+	arena := newNodeArena(arenaClassFull)
+	scratch := &transientParentScratch{}
+	leaf := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
+	transient := scratch.allocParent(arena, 3, true, []*Node{leaf}, 0, true)
+	if !scratch.owns(transient) {
+		t.Fatal("fixture: allocParent result is not slab-owned")
+	}
+	if transient.parent != nil {
+		t.Fatal("fixture: fresh transient parent must carry the nil sentinel")
+	}
+	return arena, scratch, transient
+}
+
+// TestRecoveryParentPreservesTransientSentinel: with transient parents active,
+// recovery construction must leave transient children's .parent nil, and the
+// result-time materializer must then replace them with arena clones — never
+// with the wrapper itself.
+func TestRecoveryParentPreservesTransientSentinel(t *testing.T) {
+	arena, scratch, transient := newTransientSentinelFixture(t)
+	p := &Parser{reduceScratch: &reduceBuildScratch{transientParents: scratch}}
+
+	wrapper := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, []*Node{transient}, 0)
+	if transient.parent != nil {
+		t.Fatalf("recovery construction corrupted the transient sentinel: parent=%p", transient.parent)
+	}
+
+	nodes := []*Node{wrapper}
+	scratch.materializeNodeSliceUntil(nodes, arena, nil, nil)
+	if len(wrapper.children) != 1 {
+		t.Fatalf("wrapper child count = %d, want 1", len(wrapper.children))
+	}
+	got := wrapper.children[0]
+	if got == wrapper {
+		t.Fatal("wrapper became its own child (cyclic transient tree)")
+	}
+	if scratch.owns(got) {
+		t.Fatal("transient child was not materialized into the arena")
+	}
+	if got.symbol != 3 {
+		t.Fatalf("materialized child symbol = %d, want 3", got.symbol)
+	}
+	if !debugRecoveryCheckNodeAcyclic(p, arena, "test-sentinel-preserved", wrapper) {
+		t.Fatal("cycle detector found a back-edge after the fixed construction")
+	}
+}
+
+// TestEagerWiringOnTransientChildYieldsSelfLoop documents the pre-fix defect
+// mechanism end-to-end and pins the debug detector on it: eager parent-link
+// wiring into a transient child makes the materializer link the wrapper under
+// itself.
+func TestEagerWiringOnTransientChildYieldsSelfLoop(t *testing.T) {
+	arena, scratch, transient := newTransientSentinelFixture(t)
+
+	// The pre-fix construction: populateParentNode wires transient.parent.
+	wrapper := newParentNodeInArena(arena, errorSymbol, true, []*Node{transient}, nil, 0)
+	if transient.parent != wrapper {
+		t.Fatal("simulation expects eager wiring to set the transient child's parent")
+	}
+
+	nodes := []*Node{wrapper}
+	scratch.materializeNodeSliceUntil(nodes, arena, nil, nil)
+	if len(wrapper.children) != 1 || wrapper.children[0] != wrapper {
+		t.Fatalf("expected the corrupted sentinel to produce the self-loop; children=%v", wrapper.children)
+	}
+
+	savedReports := debugRecoveryCycleReportsLeft
+	savedFound := debugRecoveryCyclesFound
+	debugRecoveryCycleReportsLeft = 0
+	defer func() {
+		debugRecoveryCycleReportsLeft = savedReports
+		debugRecoveryCyclesFound = savedFound
+	}()
+	if debugRecoveryCheckNodeAcyclic(nil, arena, "test-self-loop", wrapper) {
+		t.Fatal("cycle detector missed the self-loop")
+	}
+	if debugRecoveryCyclesFound == savedFound {
+		t.Fatal("cycle counter did not advance on a detected back-edge")
+	}
+}
+
+// TestRecoveryParentWiresLinksWithoutTransientParents: incremental parses
+// (reuse/oldTree) never allocate transient parents and skip the finalize-time
+// parent wiring, so recovery constructions there must keep the eager-wiring
+// behavior.
+func TestRecoveryParentWiresLinksWithoutTransientParents(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	leaf := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
+	p := &Parser{}
+	wrapper := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, []*Node{leaf}, 0)
+	if leaf.parent != wrapper {
+		t.Fatal("eager parent wiring expected when transient parents are inactive")
+	}
+}
+
+// TestTrailingEOFRecoveryPreservesTransientSentinel pins the fix on issue #110's
+// actual path: appendTrailingEOFRecoveryNodes wraps a dropped trailing stack
+// payload — here a transient reduce parent — in an ERROR node. With transient
+// parents active it must leave the child's .parent sentinel nil so the
+// result-time materializer replaces the child with an arena clone rather than
+// with the wrapper itself.
+func TestTrailingEOFRecoveryPreservesTransientSentinel(t *testing.T) {
+	arena, scratch, transient := newTransientSentinelFixture(t)
+	p := &Parser{reduceScratch: &reduceBuildScratch{transientParents: scratch}}
+
+	entries := []stackEntry{newStackEntryNode(transient.parseState, transient)}
+	nodeCount := 0
+	nodes, recovered := p.appendTrailingEOFRecoveryNodes(nil, entries, 0, Token{}, arena, &nodeCount)
+	if !recovered {
+		t.Fatal("trailing-EOF recovery did not wrap the dropped payload in an ERROR node")
+	}
+	if nodeCount != 1 {
+		t.Fatalf("nodeCount = %d, want 1", nodeCount)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("recovery nodes = %d, want 1", len(nodes))
+	}
+	wrapper := nodes[0]
+	if wrapper.symbol != errorSymbol {
+		t.Fatalf("wrapper symbol = %d, want errorSymbol", wrapper.symbol)
+	}
+	if transient.parent != nil {
+		t.Fatalf("trailing-EOF construction corrupted the transient sentinel: parent=%p", transient.parent)
+	}
+
+	if reason := scratch.materializeNodeSliceUntil(nodes, arena, nil, nil); reason != ParseStopNone {
+		t.Fatalf("materialize stop reason = %v, want none", reason)
+	}
+	if len(wrapper.children) != 1 {
+		t.Fatalf("wrapper child count = %d, want 1", len(wrapper.children))
+	}
+	got := wrapper.children[0]
+	if got == wrapper {
+		t.Fatal("ERROR wrapper became its own child (cyclic transient tree)")
+	}
+	if scratch.owns(got) {
+		t.Fatal("transient child was not materialized into the arena")
+	}
+	if got.symbol != 3 {
+		t.Fatalf("materialized child symbol = %d, want 3", got.symbol)
+	}
+	if !debugRecoveryCheckNodeAcyclic(p, arena, "test-trailing-eof-fixed", wrapper) {
+		t.Fatal("cycle detector found a back-edge after the fixed trailing-EOF construction")
+	}
+}
+
+// TestTrailingEOFEagerWiringSelfLoopWasMaskedByStrip documents the pre-fix
+// corruption shape on the trailing-EOF path and its interaction with the #110
+// band-aid: the old eager-wiring construction of the ERROR wrapper over a
+// transient child self-loops after materialization, and stripResultTreeSelfCycles
+// removed that edge silently. After the band-aid conversion the strip still
+// happens (defense in depth) but now bumps the observable counter, so the masked
+// construction bug can no longer hide.
+func TestTrailingEOFEagerWiringSelfLoopWasMaskedByStrip(t *testing.T) {
+	arena, scratch, transient := newTransientSentinelFixture(t)
+
+	// Pre-fix appendTrailingEOFRecoveryNodes body: wrap the dropped trailing stack
+	// payload with the eager-link constructor, corrupting transient.parent.
+	trailing := stackEntryNode(newStackEntryNode(transient.parseState, transient))
+	wrapper := newParentNodeInArena(arena, errorSymbol, true, []*Node{trailing}, nil, 0)
+	if transient.parent != wrapper {
+		t.Fatal("pre-fix simulation expects eager wiring to set the transient child's parent")
+	}
+
+	nodes := []*Node{wrapper}
+	scratch.materializeNodeSliceUntil(nodes, arena, nil, nil)
+	if len(wrapper.children) != 1 || wrapper.children[0] != wrapper {
+		t.Fatalf("expected the corrupted sentinel to self-loop the ERROR wrapper; children=%v", wrapper.children)
+	}
+
+	before := atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
+	stripResultTreeSelfCycles(wrapper)
+	if len(wrapper.children) != 0 {
+		t.Fatalf("band-aid did not strip the self-edge; children=%v", wrapper.children)
+	}
+	if got := atomic.LoadUint64(&debugResultTreeSelfCyclesStripped); got != before+1 {
+		t.Fatalf("self-cycle strip counter = %d, want %d — the #110 mask is still silent", got, before+1)
+	}
+}

--- a/parser_recover_cycle_sweep_test.go
+++ b/parser_recover_cycle_sweep_test.go
@@ -1,0 +1,246 @@
+package gotreesitter_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Acyclicity sweep + regression pins for the C-recovery cyclic-transient-tree
+// defect: recovery constructions that wrapped transient reduce parents with
+// the eager-link-wiring constructor corrupted the result-time materializer's
+// parent-field sentinel, and the materializer then linked a recovery wrapper
+// under itself (a back-edge). Every full-tree walk afterwards hung
+// (wireParentLinksWithScratchUntil has no visited set) or overflowed the
+// stack (the recursive walkResultTree normalizer family). See
+// newRecoveryParentNodeInArena (parser_recover_c.go) for the mechanism fix
+// and parser_recover_cycle_internal_test.go for the unit-level pins.
+//
+// Optionally run with GOT_DEBUG_RECOVERY_CYCLES=1 to also engage the
+// construction-time detector inside the recovery engine itself.
+
+const recoveryCycleCorporaRoot = "/home/draco/work/gotreesitter-corpora/corpus_sources"
+
+// parseRecoveryWithGuard parses src and converts a hang regression into a
+// deterministic failure.
+func parseRecoveryWithGuard(t *testing.T, lang *gotreesitter.Language, src []byte, d time.Duration, label string) *gotreesitter.Tree {
+	t.Helper()
+	type res struct {
+		tree *gotreesitter.Tree
+		err  error
+	}
+	done := make(chan res, 1)
+	go func() {
+		tree, err := gotreesitter.NewParser(lang).Parse(src)
+		done <- res{tree, err}
+	}()
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("%s: parse error: %v", label, r.err)
+		}
+		return r.tree
+	case <-time.After(d):
+		t.Fatalf("%s: parse did not complete within %v (cyclic-transient-tree hang regressed)", label, d)
+	}
+	return nil
+}
+
+// assertPublicTreeAcyclic walks the returned tree through the public child
+// API with an on-path set and fails on any back-edge. Returns the node count.
+func assertPublicTreeAcyclic(t *testing.T, lang *gotreesitter.Language, root *gotreesitter.Node, label string) int {
+	t.Helper()
+	if root == nil {
+		t.Fatalf("%s: nil root", label)
+	}
+	type frame struct {
+		n   *gotreesitter.Node
+		idx int
+	}
+	onPath := map[*gotreesitter.Node]struct{}{root: {}}
+	stack := []frame{{n: root}}
+	count := 1
+	for len(stack) > 0 {
+		f := &stack[len(stack)-1]
+		if f.idx >= f.n.ChildCount() {
+			delete(onPath, f.n)
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		c := f.n.Child(f.idx)
+		f.idx++
+		if c == nil {
+			continue
+		}
+		if _, cyc := onPath[c]; cyc {
+			t.Fatalf("%s: back-edge: %s [%d-%d] reachable from its own descendant",
+				label, c.Type(lang), c.StartByte(), c.EndByte())
+		}
+		count++
+		onPath[c] = struct{}{}
+		stack = append(stack, frame{n: c})
+	}
+	return count
+}
+
+func truncateToLines(src []byte, lines int) []byte {
+	idx := 0
+	for i := 0; i < lines; i++ {
+		next := bytes.IndexByte(src[idx:], '\n')
+		if next < 0 {
+			return src
+		}
+		idx += next + 1
+	}
+	return src[:idx]
+}
+
+// TestCRecoveryZerrorsTruncationAcyclic is the direct regression for the
+// zerrors_windows.go defect: an 800-line truncation cuts the giant const
+// block mid-declaration, engaging the full gated recovery (handle_error →
+// strategy-1 recover_to_state → EOF accept). Pre-fix this hung forever in the
+// first full-tree walk; the 600-line truncation stayed fast (the original
+// cliff). Both must now terminate quickly with acyclic trees.
+func TestCRecoveryZerrorsTruncationAcyclic(t *testing.T) {
+	var src []byte
+	var err error
+	for _, p := range zerrorsCandidatePaths {
+		if src, err = os.ReadFile(p); err == nil {
+			break
+		}
+	}
+	if src == nil {
+		t.Skipf("zerrors_windows.go corpus not found: %v", err)
+	}
+	t.Setenv("GOT_C_RECOVERY", "all")
+	lang := grammars.GoLanguage()
+
+	for _, lines := range []int{600, 800} {
+		trunc := truncateToLines(src, lines)
+		label := fmt.Sprintf("zerrors@%dlines", lines)
+		start := time.Now()
+		tree := parseRecoveryWithGuard(t, lang, trunc, 120*time.Second, label)
+		root := tree.RootNode()
+		nodes := assertPublicTreeAcyclic(t, lang, root, label)
+		if root.EndByte() != uint32(len(trunc)) {
+			t.Fatalf("%s: root.EndByte=%d want %d", label, root.EndByte(), len(trunc))
+		}
+		t.Logf("%s: %v, %d nodes, hasError=%v", label, time.Since(start), nodes, root.HasError())
+	}
+}
+
+// TestCRecoveryZerrorsFullFileAcyclic pins the two verification points on the
+// full (syntactically valid) file: it parses without hang/overflow with the
+// gate forced AND under the default env, and recovery never turns the clean
+// parse erroneous.
+func TestCRecoveryZerrorsFullFileAcyclic(t *testing.T) {
+	var src []byte
+	var err error
+	for _, p := range zerrorsCandidatePaths {
+		if src, err = os.ReadFile(p); err == nil {
+			break
+		}
+	}
+	if src == nil {
+		t.Skipf("zerrors_windows.go corpus not found: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	for _, env := range []string{"", "all"} {
+		t.Setenv("GOT_C_RECOVERY", env)
+		label := fmt.Sprintf("zerrors-full env=%q", env)
+		start := time.Now()
+		tree := parseRecoveryWithGuard(t, lang, src, 180*time.Second, label)
+		root := tree.RootNode()
+		assertPublicTreeAcyclic(t, lang, root, label)
+		if root.HasError() {
+			t.Fatalf("%s: clean corpus parse reported an error", label)
+		}
+		t.Logf("%s: %v", label, time.Since(start))
+	}
+}
+
+// recoveryCycleSweepCase names one elected language's worst corpus files
+// (cgo_harness/perf_scan authoritative scoreboard order).
+type recoveryCycleSweepCase struct {
+	lang  string
+	load  func() *gotreesitter.Language
+	files []string
+}
+
+var recoveryCycleSweepCases = []recoveryCycleSweepCase{
+	{"bash", grammars.BashLanguage, []string{"git-gui/git-gui.sh", "t/t1092-sparse-checkout-compatibility.sh"}},
+	{"c_sharp", grammars.CSharpLanguage, []string{"src/Bicep.Core.IntegrationTests/ScenarioTests.cs", "src/Bicep.Core.UnitTests/Mock/FakeResourceTypes.cs"}},
+	{"cmake", grammars.CmakeLanguage, []string{"Modules/ExternalProject.cmake", "Modules/FetchContent.cmake"}},
+	{"cpp", grammars.CppLanguage, []string{"include/fmt/base.h", "include/fmt/chrono.h"}},
+	{"crystal", grammars.CrystalLanguage, []string{"spec/compiler/parser/parser_spec.cr", "spec/std/float_printer/ryu_printf_test_cases.cr"}},
+	{"go", grammars.GoLanguage, []string{"src/cmd/compile/internal/ssa/opGen.go", "src/cmd/compile/internal/ssa/rewriteAMD64.go"}},
+	{"haskell", grammars.HaskellLanguage, []string{"Cabal-syntax/src/Distribution/SPDX/LicenseId.hs", "Cabal/src/Distribution/Simple/Configure.hs"}},
+	{"java", grammars.JavaLanguage, []string{"spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java", "spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java"}},
+	{"javascript", grammars.JavascriptLanguage, []string{"deps/amaro/dist/index.js", "deps/undici/undici.js"}},
+	{"json", grammars.JsonLanguage, []string{"src/api/json/catalog.json", "src/schemas/json/cloudify.json"}},
+	{"kotlin", grammars.KotlinLanguage, []string{"kotlinx-coroutines-core/common/src/CoroutineScope.kt", "kotlinx-coroutines-core/common/src/Job.kt"}},
+	{"lua", grammars.LuaLanguage, []string{"runtime/lua/vim/_meta/options.gen.lua", "runtime/lua/vim/_meta/vimfn.gen.lua"}},
+	{"php", grammars.PhpLanguage, []string{"src/Symfony/Component/Emoji/Resources/data/emoji-as.php", "src/Symfony/Component/Emoji/Resources/data/emoji-bn.php"}},
+	{"python", grammars.PythonLanguage, []string{"Lib/pydoc_data/topics.py", "Lib/test/_test_multiprocessing.py"}},
+	{"ruby", grammars.RubyLanguage, []string{"actionpack/lib/action_dispatch/routing/mapper.rb", "actionpack/test/dispatch/routing_test.rb"}},
+	{"rust", grammars.RustLanguage, []string{"library/stdarch/crates/core_arch/src/aarch64/neon/generated.rs", "library/stdarch/crates/core_arch/src/aarch64/sve/generated.rs"}},
+	{"scala", grammars.ScalaLanguage, []string{"src/compiler/scala/tools/nsc/ast/parser/Parsers.scala", "src/compiler/scala/tools/nsc/typechecker/Implicits.scala"}},
+	{"swift", grammars.SwiftLanguage, []string{"Sources/SwiftSyntax/generated/RenamedChildrenCompatibility.swift", "Sources/SwiftSyntax/generated/SyntaxRewriter.swift"}},
+	{"tsx", grammars.TsxLanguage, []string{"cli/template/extras/src/app/page/with-better-auth-trpc-tw.tsx", "cli/template/extras/src/pages/index/with-better-auth-trpc-tw.tsx"}},
+	{"typescript", grammars.TypescriptLanguage, []string{"src/compiler/checker.ts", "src/lib/dom.generated.d.ts"}},
+}
+
+// TestCRecoveryCorpusTruncationSweepAcyclic truncates the elected languages'
+// worst corpus files mid-construct (forcing error recovery on real-world
+// structure), parses with the recovery gate forced, and asserts every
+// resulting tree is acyclic. -short keeps a fast trio; the full sweep runs the
+// whole elected set.
+func TestCRecoveryCorpusTruncationSweepAcyclic(t *testing.T) {
+	if os.Getenv("GOT_RECOVERY_SWEEP") != "1" {
+		t.Skip("set GOT_RECOVERY_SWEEP=1 to run the corpus truncation acyclicity sweep (slow; multi-language corpora)")
+	}
+	if _, err := os.Stat(recoveryCycleCorporaRoot); err != nil {
+		t.Skipf("corpora not found: %v", err)
+	}
+	os.Setenv("GOT_C_RECOVERY", "all")
+	defer os.Unsetenv("GOT_C_RECOVERY")
+
+	const truncateBytes = 48 * 1024
+	shortSet := map[string]bool{"go": true, "bash": true, "java": true}
+	for _, tc := range recoveryCycleSweepCases {
+		if testing.Short() && !shortSet[tc.lang] {
+			continue
+		}
+		tc := tc
+		t.Run(tc.lang, func(t *testing.T) {
+			lang := tc.load()
+			if lang == nil {
+				t.Skipf("grammar %s unavailable", tc.lang)
+			}
+			for _, rel := range tc.files {
+				path := filepath.Join(recoveryCycleCorporaRoot, tc.lang, rel)
+				src, err := os.ReadFile(path)
+				if err != nil {
+					t.Logf("skip %s: %v", rel, err)
+					continue
+				}
+				if len(src) > truncateBytes {
+					src = src[:truncateBytes]
+				}
+				label := tc.lang + "/" + filepath.Base(rel)
+				start := time.Now()
+				tree := parseRecoveryWithGuard(t, lang, src, 120*time.Second, label)
+				root := tree.RootNode()
+				nodes := assertPublicTreeAcyclic(t, lang, root, label)
+				t.Logf("%s: %d bytes, %v, %d nodes, hasError=%v",
+					label, len(src), time.Since(start), nodes, root.HasError())
+			}
+		})
+	}
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -595,9 +595,32 @@ type conflictReduceFrontierSeed struct {
 	afterDepth  int
 }
 
-func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok Token, seed conflictReduceFrontierSeed, allocBranchOrder func() uint64, anyReduced *bool, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, deferParentLinks bool, trackChildErrors *bool) {
+func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok Token, seed conflictReduceFrontierSeed, liveStacks, maxLiveStacks int, allocBranchOrder func() uint64, anyReduced *bool, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, deferParentLinks bool, trackChildErrors *bool) {
 	if p == nil || p.language == nil || tok.NoLookahead || s == nil || s.dead || s.accepted || s.shifted || s.cPaused {
 		return
+	}
+	// Mirror of the C runtime's version-window discipline
+	// (MAX_VERSION_COUNT + MAX_VERSION_COUNT_OVERFLOW): C never creates a new
+	// stack version once the version pool is saturated — the current version
+	// simply keeps reducing without forking. This port's boundary merge/cull
+	// enforces the same window (maxStacks + fullParseGLRStackOverflow) only
+	// BETWEEN iterations, so a single token's conflict-reduce frontier walk
+	// could admit one transient shifted fork per pending spine frame with no
+	// population bound at all (observed: 6 survivors x 258-step walks = 1548
+	// transient stacks and O(n^2) node allocation on union-list-shaped
+	// sources). Once the live population (dispatch stacks plus already-queued
+	// pending forks) has reached the same cull-engagement threshold the
+	// boundary discipline uses, stop CREATING new frontier forks; the walk
+	// itself continues reducing in place, and the stacks such forks would
+	// have duplicated are exactly the ones the next boundary cull retains.
+	// maxLiveStacks <= 0 disables the gate (incremental and c_sharp arenas,
+	// where glrStackCullTrigger returns maxStacks with no overflow window and
+	// culling historically engages immediately).
+	frontierForkAdmissible := func() bool {
+		if maxLiveStacks <= 0 {
+			return true
+		}
+		return liveStacks+len(p.pendingFrontierForkStacks)+len(p.pendingForkStacks) < maxLiveStacks
 	}
 	if seed.action.Type != ParseActionReduce || seed.beforeDepth == 0 || seed.afterDepth == 0 {
 		return
@@ -680,7 +703,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 		}
 		terminalAppended := false
 		_, terminalAlreadyForked := terminalForkedReduces[currentReduceKey]
-		if !terminalAlreadyForked {
+		if !terminalAlreadyForked && frontierForkAdmissible() {
 			switch terminal.Type {
 			case ParseActionShift:
 				fork := s.cloneWithScratch(gssScratch)
@@ -780,6 +803,11 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 }
 
 func (p *Parser) pushOrExtendErrorNode(s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) {
+	if p != nil {
+		// An ERROR node is entering a stack: costs can be nonzero from here on
+		// (sticky per-parse gate, see crecoveryCostCompetitionRelevant).
+		p.crecoveryCostCompetitionRelevant = true
+	}
 	if s != nil {
 		top := stackEntryNode(s.top())
 		if top != nil &&
@@ -824,6 +852,10 @@ func (p *Parser) pushOrExtendErrorNode(s *glrStack, state StateID, tok Token, no
 // the run becomes an ERROR leaf that is EXTRA — present in the tree but
 // transparent to production arity — and parsing resumes in the same state.
 func (p *Parser) pushLexErrorRunLeaf(s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) {
+	if p != nil {
+		// See pushOrExtendErrorNode: error content makes costs relevant.
+		p.crecoveryCostCompetitionRelevant = true
+	}
 	leaf := newLeafNodeInArena(arena, errorSymbol, true,
 		tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
 	leaf.setHasError(true)
@@ -842,6 +874,9 @@ func (p *Parser) pushLexErrorRunLeaf(s *glrStack, state StateID, tok Token, node
 			top.endPoint = tok.EndPoint
 			top.setHasError(true)
 			nodeBumpEquivVersion(top)
+			if debugRecoveryCycleChecks {
+				debugRecoveryCheckNodeAcyclic(p, arena, "lex-error-run-extend", top)
+			}
 			if s.byteOffset < top.endByte {
 				s.byteOffset = top.endByte
 			}
@@ -977,7 +1012,10 @@ func (p *Parser) tryNearestActionStateRecovery(s *glrStack, tok Token, nodeCount
 	if !s.truncate(depth - recoverIdx) {
 		return false
 	}
-	errNode := newParentNodeInArena(arena, errorSymbol, true, errChildren, nil, 0)
+	// See newRecoveryParentNodeInArena: popped fragments can be transient
+	// reduce parents whose .parent field is the result-time materializer's
+	// map; eager link wiring here would link this ERROR under itself.
+	errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, errChildren, 0)
 	errNode.setHasError(true)
 	errNode.setExtra(true)
 	nodeBumpEquivVersion(errNode)
@@ -1279,7 +1317,10 @@ func (p *Parser) tryResyncErrorRecoveryMode(source []byte, s *glrStack, tok Toke
 		tokLeaf.setExternalScannerToken(tok.ExternalScannerToken)
 		errChildren = append(errChildren, tokLeaf)
 	}
-	errNode := newParentNodeInArena(arena, errorSymbol, true, errChildren, nil, 0)
+	// See newRecoveryParentNodeInArena: popped fragments can be transient
+	// reduce parents whose .parent field is the result-time materializer's
+	// map; eager link wiring here would link this ERROR under itself.
+	errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, errChildren, 0)
 	errNode.setHasError(true)
 	nodeBumpEquivVersion(errNode)
 	if perfCountersEnabled {
@@ -4529,12 +4570,21 @@ func (p *Parser) tryPushPendingNoFieldParent(s *glrStack, act ParseAction, tok T
 		return true
 	}
 	p.pushStackPendingParent(s, targetState, parent, entryScratch, gssScratch)
+	retargeted := false
 	for i := reducedEnd; i < trailingEnd; i++ {
 		extra, ok := retargetStackEntryPayload(entries[i], targetState)
 		if !ok {
 			continue
 		}
+		retargeted = true
 		p.pushStackEntry(s, extra, entryScratch, gssScratch)
+	}
+	if retargeted {
+		// retargetStackEntryPayload rewrote a spine node's parseState in place,
+		// which feeds gssEntryHash and thus every cached root->head shape prefix
+		// rolling through that node; invalidate the prefix cache (see glr.go
+		// glrMaterializingShapeHash doc). p.mergeScratch is nil-safe.
+		p.mergeScratch.bumpShapePrefixEpoch()
 	}
 	if nodeCount != nil {
 		*nodeCount = *nodeCount + 1
@@ -4637,12 +4687,21 @@ func (p *Parser) tryPushPendingDirectFieldParent(s *glrStack, act ParseAction, t
 		return true
 	}
 	p.pushStackPendingParent(s, targetState, parent, entryScratch, gssScratch)
+	retargeted := false
 	for i := reducedEnd; i < trailingEnd; i++ {
 		extra, ok := retargetStackEntryPayload(entries[i], targetState)
 		if !ok {
 			continue
 		}
+		retargeted = true
 		p.pushStackEntry(s, extra, entryScratch, gssScratch)
+	}
+	if retargeted {
+		// retargetStackEntryPayload rewrote a spine node's parseState in place,
+		// which feeds gssEntryHash and thus every cached root->head shape prefix
+		// rolling through that node; invalidate the prefix cache (see glr.go
+		// glrMaterializingShapeHash doc). p.mergeScratch is nil-safe.
+		p.mergeScratch.bumpShapePrefixEpoch()
 	}
 	if nodeCount != nil {
 		*nodeCount = *nodeCount + 1
@@ -7022,12 +7081,21 @@ func (p *Parser) pushNoTreeReduceNode(s *glrStack, act ParseAction, tok Token, a
 	parent.preGotoState = topState
 	parent.parseState = targetState
 	p.pushStackNoTreeNode(s, targetState, parent, entryScratch, gssScratch)
+	retargeted := false
 	for i := trailingStart; i < trailingEnd; i++ {
 		extra, ok := retargetStackEntryPayload(entries[i], targetState)
 		if !ok {
 			continue
 		}
+		retargeted = true
 		p.pushStackEntry(s, extra, entryScratch, gssScratch)
+	}
+	if retargeted {
+		// retargetStackEntryPayload rewrote a spine node's parseState in place,
+		// which feeds gssEntryHash and thus every cached root->head shape prefix
+		// rolling through that node; invalidate the prefix cache (see glr.go
+		// glrMaterializingShapeHash doc). p.mergeScratch is nil-safe.
+		p.mergeScratch.bumpShapePrefixEpoch()
 	}
 	if nodeCount != nil {
 		*nodeCount = *nodeCount + 1
@@ -7177,12 +7245,21 @@ func (p *Parser) pushCollapsedUnaryReduceEntry(s *glrStack, act ParseAction, tok
 	setStackEntryRawShapeRef(&child, rawShape)
 	addStackEntryDynamicPrecedence(&child, act.DynamicPrecedence)
 	p.pushStackEntry(s, child, entryScratch, gssScratch)
+	retargeted := false
 	for i := trailingStart; i < trailingEnd; i++ {
 		extra, ok := retargetStackEntryPayload(entries[i], targetState)
 		if !ok {
 			continue
 		}
+		retargeted = true
 		p.pushStackEntry(s, extra, entryScratch, gssScratch)
+	}
+	if retargeted {
+		// retargetStackEntryPayload rewrote a spine node's parseState in place,
+		// which feeds gssEntryHash and thus every cached root->head shape prefix
+		// rolling through that node; invalidate the prefix cache (see glr.go
+		// glrMaterializingShapeHash doc). p.mergeScratch is nil-safe.
+		p.mergeScratch.bumpShapePrefixEpoch()
 	}
 }
 

--- a/parser_result.go
+++ b/parser_result.go
@@ -11,6 +11,50 @@ import (
 // and nodeArena state directly. Public-API parser-result regressions live in
 // parser_result_test, while source fixtures belong under testdata.
 
+// reconcileStaleHasErrorFlags repairs hasError bits that no longer match the
+// subtree contents after C-recovery wrap/unwrap cycles. During recovery a
+// stack's nodes legitimately carry hasError while an open ERROR region exists;
+// when the region later resolves losslessly (the absorbed content re-reduces
+// into ordinary productions and the ERROR wrapper is spliced away), ancestor
+// flags set during the wrapped phase can be left behind. C cannot represent
+// this state: ts_subtree_has_error is DERIVED (error_cost > 0, which only
+// ERROR and MISSING subtrees contribute), so a tree with no ERROR/MISSING
+// descendant is definitionally HasError=false. A stale root flag is not
+// cosmetic — the retry ladder's treeParseClean/shouldRetryAcceptedErrorParse
+// read it and will run every widened retry pass on an already-clean parse
+// (bash cliff RCA 2026-07: 46s for a 657-byte file, ~7 wasted full passes).
+//
+// Clear-only by design: a node whose flag is set but whose subtree carries no
+// ERROR/MISSING is repaired; under-set flags are left alone (some language
+// normalizers deliberately leave repaired regions unflagged). Subtrees deeper
+// than maxTreeWalkDepth keep their existing claim (never cleared unverified).
+// Returns whether the subtree truly contains an error.
+func reconcileStaleHasErrorFlags(n *Node, depth int) bool {
+	if n == nil {
+		return false
+	}
+	if n.symbol == errorSymbol || n.isMissing() {
+		return true
+	}
+	if depth >= maxTreeWalkDepth {
+		return n.hasError()
+	}
+	has := false
+	// Materializing accessors: recovery-produced spines can still hold
+	// unmaterialized child forms here, and a no-materialize count would skip
+	// exactly the subtrees this repair exists for.
+	for i, count := 0, nodeChildCount(n); i < count; i++ {
+		// No early exit: every stale sibling flag gets repaired.
+		if reconcileStaleHasErrorFlags(resultChildAt(n, i), depth+1) {
+			has = true
+		}
+	}
+	if !has && n.hasError() {
+		n.setHasError(false)
+	}
+	return has
+}
+
 type parseMaterializationTiming struct {
 	resultSelectionNanos               int64
 	transientParentMaterializeNanos    int64

--- a/parser_result_cycle_guard.go
+++ b/parser_result_cycle_guard.go
@@ -1,24 +1,43 @@
 package gotreesitter
 
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+)
+
 // stripResultTreeSelfCycles enforces that no node is its own descendant.
 //
-// The trailing-EOF error recovery clones the GSS (sharing node payload
-// pointers) and re-reduces, which can leave a recovered node, e.g. a
-// `source_file`, referencing itself as a child. The raw .children slice can
-// look fine while the materialized child view is cyclic, so every later full
-// tree walk (parent-link wiring, the compat normalizers, recovery trimming)
-// recurses or loops without end: a fatal stack overflow or an indefinite hang.
+// ROOT CAUSE (now fixed at construction time): trailing-EOF error recovery
+// clones the GSS (sharing node payload pointers), re-reduces, and wraps a
+// dropped stack payload in an ERROR node. On a fresh parse that payload can be a
+// TRANSIENT reduce parent whose .parent field doubles as the result-time
+// materializer's {nil: unvisited, self: in-progress, other: arena clone}
+// sentinel. Wrapping it with the eager-link-wiring constructor corrupted that
+// sentinel, so materializeTransientParentNodes then substituted the child's tree
+// parent for the child and linked the ERROR wrapper under itself. The raw
+// .children slice looked fine while the materialized child view was cyclic, so
+// every later full-tree walk (parent-link wiring, the compat normalizers,
+// recovery trimming) recursed or looped without end: a fatal stack overflow or
+// an indefinite hang (issue #110; the go zerrors_windows.go truncation hang).
 //
-// This pass walks the tree once with an explicit stack and a visited set, so it
-// terminates even on an already-cyclic graph. For each node it materializes the
-// children (clearing the arena refs so .children becomes authoritative) and
-// drops any child edge that points at the node itself or an ancestor on the
-// current path. It runs only on recovered node trees, so normal parses are
-// untouched.
+// The construction hazard is now fixed: appendTrailingEOFRecoveryNodes (parser.go)
+// routes through newRecoveryParentNodeInArena (parser_recover_c.go), which skips
+// eager wiring while transient parents are active. The GLR-forest fragment-root
+// sibling site (glr_forest.go collectForestErrorRoot) is proven safe because the
+// forest parse never allocates transient parents. See
+// parser_recover_cycle_internal_test.go for the pins.
 //
-// The underlying cycle should ideally be prevented in the recovery clone/reduce
-// itself; this guard keeps the returned tree well-formed in the meantime. See
-// issue #110.
+// This pass remains as DEFENSE IN DEPTH. It walks the tree once with an explicit
+// stack and a visited set (so it terminates even on an already-cyclic graph),
+// materializes each node's children (clearing the arena refs so .children
+// becomes authoritative), and drops any child edge that points at the node
+// itself or an ancestor on the current path. It runs only on recovered node
+// trees, so normal parses are untouched. Every dropped edge is now COUNTED (and,
+// under GOT_DEBUG_RECOVERY_CYCLES=1, loudly reported) via
+// reportResultTreeSelfCycleStripped: with the root cause fixed the count must
+// stay zero, so any future construction bug that corrupts the sentinel again
+// surfaces here instead of being silently masked.
 func stripResultTreeSelfCycles(root *Node) {
 	if root == nil {
 		return
@@ -44,6 +63,7 @@ func stripResultTreeSelfCycles(root *Node) {
 				continue
 			}
 			if _, ancestor := onPath[c]; ancestor {
+				reportResultTreeSelfCycleStripped(n, c)
 				children = removeResultTreeChildAt(n, children, stack[i].idx)
 				continue
 			}
@@ -64,6 +84,45 @@ func stripResultTreeSelfCycles(root *Node) {
 		black[n] = struct{}{}
 		stack = stack[:len(stack)-1]
 	}
+}
+
+// debugResultTreeSelfCyclesStripped counts back-edges removed by
+// stripResultTreeSelfCycles across the process. With the sentinel-corruption
+// root cause fixed at construction time it must stay zero; a nonzero value is
+// proof that a recovery construction site is corrupting the transient-parent
+// sentinel again (defense-in-depth kept the tree well-formed, but the bug is
+// real and must be traced, not masked).
+//
+// Parses can run concurrently (multiple *Parser instances across goroutines),
+// so every access goes through sync/atomic: increments use atomic.AddUint64
+// and readers (tests, diagnostics) must use atomic.LoadUint64 rather than a
+// plain read.
+var debugResultTreeSelfCyclesStripped uint64
+
+// reportResultTreeSelfCycleStripped records that the #110 defense-in-depth guard
+// had to drop a self/ancestor back-edge. It always bumps the observable counter;
+// under GOT_DEBUG_RECOVERY_CYCLES=1 it also emits a loud, budgeted stderr line so
+// an env-gated recovery sweep proves the count is zero (or pinpoints the
+// offending node span when it is not). Distinct tag from the construction-time
+// detector (RECOVERY-CYCLE) so the reporting stage is unambiguous.
+func reportResultTreeSelfCycleStripped(parent, child *Node) {
+	atomic.AddUint64(&debugResultTreeSelfCyclesStripped, 1)
+	if !debugRecoveryCycleChecks || debugRecoveryCycleReportsLeft <= 0 {
+		return
+	}
+	debugRecoveryCycleReportsLeft--
+	var psym, csym Symbol
+	var ps, pe, cs, ce uint32
+	if parent != nil {
+		psym, ps, pe = parent.symbol, parent.startByte, parent.endByte
+	}
+	if child != nil {
+		csym, cs, ce = child.symbol, child.startByte, child.endByte
+	}
+	fmt.Fprintf(os.Stderr,
+		"RESULT-TREE-SELF-CYCLE-STRIP #110 guard dropped back-edge: parent sym=%d [%d-%d] -> descendant/self sym=%d [%d-%d] "+
+			"(transient-parent sentinel corruption regressed at a recovery construction site)\n",
+		psym, ps, pe, csym, cs, ce)
 }
 
 func removeResultTreeChildAt(n *Node, children []*Node, idx int) []*Node {

--- a/parser_result_cycle_guard_test.go
+++ b/parser_result_cycle_guard_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"sync/atomic"
+	"testing"
+)
 
 func TestStripResultTreeSelfCycles(t *testing.T) {
 	x := &Node{}
@@ -45,6 +48,42 @@ func TestStripResultTreeSelfCycles(t *testing.T) {
 	}
 	if len(y.fieldSources) != 1 || y.fieldSources[0] != fieldSourceInherited {
 		t.Fatalf("fieldSources after cycle strip = %v, want inherited source", y.fieldSources)
+	}
+}
+
+// TestStripResultTreeSelfCyclesIsObservable pins the #110 band-aid conversion:
+// the strip is no longer silent. A clean tree leaves the counter untouched;
+// every dropped self/ancestor back-edge bumps debugResultTreeSelfCyclesStripped
+// so a future sentinel-corruption regression surfaces instead of being masked.
+func TestStripResultTreeSelfCyclesIsObservable(t *testing.T) {
+	leaf := &Node{}
+	mid := &Node{children: []*Node{leaf}}
+	root := &Node{children: []*Node{mid}}
+	before := atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
+	stripResultTreeSelfCycles(root)
+	if atomic.LoadUint64(&debugResultTreeSelfCyclesStripped) != before {
+		t.Fatalf("clean tree bumped the strip counter: %d -> %d", before, atomic.LoadUint64(&debugResultTreeSelfCyclesStripped))
+	}
+
+	self := &Node{}
+	self.children = []*Node{self}
+	before = atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
+	stripResultTreeSelfCycles(self)
+	if len(self.children) != 0 {
+		t.Fatalf("self-edge not stripped; children=%v", self.children)
+	}
+	if atomic.LoadUint64(&debugResultTreeSelfCyclesStripped) != before+1 {
+		t.Fatalf("self-cycle strip counter = %d, want %d", atomic.LoadUint64(&debugResultTreeSelfCyclesStripped), before+1)
+	}
+
+	a := &Node{}
+	b := &Node{}
+	a.children = []*Node{b}
+	b.children = []*Node{a}
+	before = atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
+	stripResultTreeSelfCycles(a)
+	if atomic.LoadUint64(&debugResultTreeSelfCyclesStripped) != before+1 {
+		t.Fatalf("ancestor back-edge strip counter = %d, want %d", atomic.LoadUint64(&debugResultTreeSelfCyclesStripped), before+1)
 	}
 }
 

--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "bytes"
+import (
+	"bytes"
+	"math"
+)
 
 const goSemicolonContainerSymbolCount = 11
 
@@ -99,23 +102,76 @@ func normalizeGoDotLeafChildrenWithStop(root *Node, source []byte, lang *Languag
 		return ParseStopNone
 	}
 	childNamed := symbolIsNamed(lang, childSym)
+	// Fast path: descend with no per-node dedup bookkeeping. A well-formed tree
+	// never re-pushes a node, so this terminates in O(nodes) and is byte-for-byte
+	// the original walk. A pop budget guards against a recovery-mode transient
+	// tree that is a DAG/cycle (the same *Node reachable via many parents or a
+	// back-edge), which would otherwise re-push shared nodes along every path —
+	// a ~6.5k-node recovered const block was observed re-pushing the same nodes
+	// ~200M times (17B child-count calls). Exceeding the budget triggers a single
+	// deduped retry that bounds the walk to distinct nodes.
+	reason, completed := walkGoDotLeaves(root, source, poller, parentSym, childSym, childNamed, nil)
+	if completed {
+		return reason
+	}
+	return firstReturnReason(walkGoDotLeaves(root, source, poller, parentSym, childSym, childNamed, make(map[*Node]struct{})))
+}
+
+// firstReturnReason adapts a (ParseStopReason, bool) result to a single reason.
+func firstReturnReason(reason ParseStopReason, _ bool) ParseStopReason { return reason }
+
+// walkGoDotLeaves performs the dot-leaf DFS. seen == nil selects the zero-
+// overhead fast path guarded by a pop budget (returns completed=false if the
+// budget is exceeded, signalling a pathological transient graph); a non-nil seen
+// map deduplicates pushes so every distinct node is descended exactly once,
+// which always terminates and — because the rewrite and descent depend only on
+// node identity — is idempotent, yielding output identical to the well-formed
+// fast path.
+func walkGoDotLeaves(root *Node, source []byte, poller *parseStopPoller, parentSym, childSym Symbol, childNamed bool, seen map[*Node]struct{}) (ParseStopReason, bool) {
 	// Iterative DFS with an explicit stack: source trees can nest or chain
 	// deeply enough that callback recursion overflows the goroutine stack
 	// (fatal, unrecoverable) — see issue #110.
+	budget := goNormalizerPopBudget(len(source))
+	pops := 0
 	stack := []*Node{root}
+	if seen != nil {
+		seen[root] = struct{}{}
+	}
 	push := func(n *Node) {
-		if n != nil {
-			stack = append(stack, n)
+		if n == nil {
+			return
 		}
+		if seen != nil {
+			if _, ok := seen[n]; ok {
+				return
+			}
+			seen[n] = struct{}{}
+		}
+		stack = append(stack, n)
 	}
 	for len(stack) > 0 {
 		if reason := poller.poll(); parseStopReasonIsActive(reason) {
-			return reason
+			return reason, true
 		}
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		childCount := resultChildCount(n)
-		if n.symbol == parentSym && childCount == 0 {
+		if seen == nil {
+			pops++
+			if pops > budget {
+				return ParseStopNone, false
+			}
+		}
+		// Only a childless "dot" parent is ever rewritten, so the child count
+		// is only needed for that check (and for the cold non-final-refs push
+		// below). Deriving it lazily keeps the common case — any non-dot node,
+		// which is the overwhelming majority on wide flat sibling lists such as
+		// a giant const block — off the per-node resultChildCount /
+		// nodeChildCountNoMaterialize path entirely; those nodes go straight to
+		// pushing children via the representation-appropriate fast path. The
+		// walk output is unchanged: the dense branch already iterates
+		// n.children directly and the final-refs branch already uses
+		// view.Len(); neither consumed the hoisted count.
+		if n.symbol == parentSym && resultChildCount(n) == 0 {
 			normalizeGoDotLeafNode(n, source, childSym, childNamed)
 			continue
 		}
@@ -127,6 +183,7 @@ func normalizeGoDotLeafChildrenWithStop(root *Node, source []byte, lang *Languag
 		}
 		view := resultMutableChildrenForMutation(n)
 		if !view.hasFinalChildRefs() {
+			childCount := resultChildCount(n)
 			for i := 0; i < childCount; i++ {
 				push(resultChildAt(n, i))
 			}
@@ -143,7 +200,29 @@ func normalizeGoDotLeafChildrenWithStop(root *Node, source []byte, lang *Languag
 			push(resultChildAt(n, i))
 		}
 	}
-	return poller.pollNow()
+	return poller.pollNow(), true
+}
+
+// goNormalizerPopBudget bounds the fast-path DFS pop count. A well-formed go
+// tree has far fewer than this many nodes (the node count is a small multiple of
+// the token count, itself bounded by the source length), so the budget is never
+// reached on legitimate input; it only trips on a cyclic/DAG transient tree,
+// where it caps wasted work at O(len(source)) before the deduped retry.
+//
+// The arithmetic runs in int64 and clamps to math.MaxInt before narrowing back
+// to int: on a 32-bit platform (int is 32 bits) a >33MB source would otherwise
+// overflow 64*(sourceLen+1) past math.MaxInt32 and wrap negative, making every
+// pops > budget check trivially true (or false, depending on the wrapped
+// sign) instead of acting as an actual budget. Clamping preserves the intended
+// "practically unbounded for legitimate input" semantics on both platforms;
+// on 64-bit the clamp is unreachable for any realistic source length, so the
+// constant's behavior there is unchanged.
+func goNormalizerPopBudget(sourceLen int) int {
+	budget := 64*(int64(sourceLen)+1) + 1<<16
+	if budget > int64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(budget)
 }
 
 func normalizeGoDotLeafNode(n *Node, source []byte, childSym Symbol, childNamed bool) {
@@ -217,18 +296,51 @@ func (s goCompatibilitySymbols) isStatementList(sym Symbol) bool {
 	return (s.statementList != 0 && sym == s.statementList) || (s.statementListTail != 0 && sym == s.statementListTail)
 }
 
+type goCompatSubtreeFrame struct {
+	node *Node
+	exit bool
+}
+
 func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller) ParseStopReason {
-	type frame struct {
-		node *Node
-		exit bool
-	}
 	if n == nil {
 		return ParseStopNone
 	}
-	stack := []frame{{node: n}}
+	// Fast path (no dedup) with a pop budget, then a deduped retry if the budget
+	// trips — same rationale as normalizeGoDotLeafChildrenWithStop. Every per-node
+	// mutation here (semicolon-drop, sibling-boundary and trailing-extra span
+	// adjustment) is idempotent and keyed on node identity, so descending each
+	// distinct node once matches the well-formed fast path byte-for-byte.
+	reason, completed := walkGoCompatSubtree(n, source, syms, flags, incrementalRanges, poller, nil)
+	if completed {
+		return reason
+	}
+	return firstReturnReason(walkGoCompatSubtree(n, source, syms, flags, incrementalRanges, poller, make(map[*Node]struct{})))
+}
+
+func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller, seen map[*Node]struct{}) (ParseStopReason, bool) {
+	budget := goNormalizerPopBudget(len(source))
+	pops := 0
+	stack := []goCompatSubtreeFrame{{node: root}}
+	if seen != nil {
+		seen[root] = struct{}{}
+	}
+	// Exit frames re-enqueue an already-seen node deliberately and are never
+	// deduped; only child entry frames consult seen.
+	pushChild := func(c *Node) {
+		if c == nil {
+			return
+		}
+		if seen != nil {
+			if _, ok := seen[c]; ok {
+				return
+			}
+			seen[c] = struct{}{}
+		}
+		stack = append(stack, goCompatSubtreeFrame{node: c})
+	}
 	for len(stack) > 0 {
 		if reason := poller.poll(); parseStopReasonIsActive(reason) {
-			return reason
+			return reason, true
 		}
 		top := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -242,6 +354,12 @@ func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goComp
 			}
 			continue
 		}
+		if seen == nil {
+			pops++
+			if pops > budget {
+				return ParseStopNone, false
+			}
+		}
 		if !goNodeOverlapsAnyRange(n, incrementalRanges) {
 			continue
 		}
@@ -252,10 +370,10 @@ func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goComp
 				normalizeGoAdjacentSiblingBoundaries(n, source, syms)
 			}
 		}
-		stack = append(stack, frame{node: n, exit: true})
+		stack = append(stack, goCompatSubtreeFrame{node: n, exit: true})
 		if n.ownerArena == nil || n.childIndex > finalChildSidecarIndexBase {
 			for i := len(n.children) - 1; i >= 0; i-- {
-				stack = append(stack, frame{node: n.children[i]})
+				pushChild(n.children[i])
 			}
 			continue
 		}
@@ -266,15 +384,15 @@ func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goComp
 				if !ok || stackEntryNodeChildCount(entry) == 0 {
 					continue
 				}
-				stack = append(stack, frame{node: resultChildAt(n, i)})
+				pushChild(resultChildAt(n, i))
 			}
 		} else {
 			for i := childCount - 1; i >= 0; i-- {
-				stack = append(stack, frame{node: resultChildAt(n, i)})
+				pushChild(resultChildAt(n, i))
 			}
 		}
 	}
-	return poller.pollNow()
+	return poller.pollNow(), true
 }
 
 func goNodeOverlapsAnyRange(n *Node, ranges []Range) bool {

--- a/parser_result_go_compat_byte_identity_test.go
+++ b/parser_result_go_compat_byte_identity_test.go
@@ -1,0 +1,100 @@
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Golden hashes of golang.org/x/sys/windows/zerrors_windows.go (a 945KB single
+// giant const block) parsed with GOT_C_RECOVERY=0. They pin the exact tree the
+// go result normalizer produces so the O(n^2) hardening in
+// parser_result_go_compat.go (lazy child-count + deduped cyclic-descent
+// fallback) stays byte-for-byte output-preserving. Captured before the change;
+// re-verified identical after.
+//
+// zerrorsGoldenSpans was regenerated when goNodeSpansHash started folding each
+// child's field name into the hash (review C finding #5): the produced TREE is
+// unchanged — zerrorsGoldenSExpr, which is independent of goNodeSpansHash, was
+// re-verified identical across that change — only the hash function gained an
+// extra `field=%q` line per child edge, which changes the digest.
+const (
+	zerrorsGoldenSExpr = "e32b333c4b72bd386018f54468c9ad0353409060186e66d308903c1ba745174f"
+	zerrorsGoldenSpans = "a8c6810c0da9415dcece890ee67b3b3bfe85f6f0c6455f2de4e04f5134b2c153"
+)
+
+var zerrorsCandidatePaths = []string{
+	"/home/draco/work/gotreesitter-corpora/corpus_sources/go/src/cmd/vendor/golang.org/x/sys/windows/zerrors_windows.go",
+	"/home/draco/work/gotreesitter-corpora/corpus_sources/fidl/third_party/golibs/vendor/golang.org/x/sys/windows/zerrors_windows.go",
+}
+
+// goNodeSpansHash hashes the tree shape by type/named/span AND, per child
+// edge, the field name assigned to that child (via FieldNameForChild). Folding
+// field assignment into the hash means field drift (a child silently gaining,
+// losing, or changing its field) changes the golden hash instead of passing
+// silently — the prior span-only hash could not detect that class of
+// regression.
+func goNodeSpansHash(lang *gotreesitter.Language, root *gotreesitter.Node) string {
+	h := sha256.New()
+	var walk func(n *gotreesitter.Node)
+	walk = func(n *gotreesitter.Node) {
+		if n == nil {
+			return
+		}
+		named := byte(0)
+		if n.IsNamed() {
+			named = 1
+		}
+		sp, ep := n.StartPoint(), n.EndPoint()
+		fmt.Fprintf(h, "%s|%d|%d|%d|%d:%d|%d:%d\n", n.Type(lang), named,
+			n.StartByte(), n.EndByte(), sp.Row, sp.Column, ep.Row, ep.Column)
+		for i := 0; i < n.ChildCount(); i++ {
+			fmt.Fprintf(h, "field=%q\n", n.FieldNameForChild(i, lang))
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// TestGoZerrorsNormalizerByteIdentity re-parses the giant-const-block corpus with
+// recovery off and fails if the normalizer output drifts from the pinned golden.
+func TestGoZerrorsNormalizerByteIdentity(t *testing.T) {
+	t.Setenv("GOT_C_RECOVERY", "0")
+
+	var src []byte
+	var err error
+	for _, p := range zerrorsCandidatePaths {
+		if src, err = os.ReadFile(p); err == nil {
+			break
+		}
+	}
+	if src == nil {
+		t.Skipf("zerrors_windows.go corpus not found: %v", err)
+	}
+
+	lang := grammars.GoLanguage()
+	tree, perr := gotreesitter.NewParser(lang).Parse(src)
+	if perr != nil {
+		t.Fatalf("parse: %v", perr)
+	}
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("nil root")
+	}
+	if got := uint32(len(src)); root.EndByte() != got {
+		t.Fatalf("root.EndByte=%d want %d (truncated parse)", root.EndByte(), got)
+	}
+	sx := sha256.Sum256([]byte(root.SExpr(lang)))
+	if gotS := hex.EncodeToString(sx[:]); gotS != zerrorsGoldenSExpr {
+		t.Fatalf("SExpr drift: got %s want %s", gotS, zerrorsGoldenSExpr)
+	}
+	if gotS := goNodeSpansHash(lang, root); gotS != zerrorsGoldenSpans {
+		t.Fatalf("spans drift: got %s want %s", gotS, zerrorsGoldenSpans)
+	}
+}

--- a/parser_result_go_compat_pathological_test.go
+++ b/parser_result_go_compat_pathological_test.go
@@ -1,0 +1,106 @@
+package gotreesitter
+
+import (
+	"testing"
+	"time"
+)
+
+// runWithin runs fn and fails if it does not return within d. A regression that
+// reintroduces the un-deduped descent would loop forever on the cyclic trees
+// below, so this converts a hang into a deterministic failure.
+func runWithin(t *testing.T, d time.Duration, name string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("%s did not terminate within %v (cyclic-descent guard regressed)", name, d)
+	}
+}
+
+// buildCyclicGoTree builds source_file -> dot -> (back to source_file). A
+// recovery-mode transient go tree can contain exactly this kind of back-edge;
+// the normalizer must terminate on it rather than re-descend the cycle forever.
+func buildCyclicGoTree() (*Node, *nodeArena) {
+	arena := newNodeArena(arenaClassFull)
+	dot := newLeafNodeInArena(arena, 2 /* dot */, true, 0, 1, Point{}, Point{Column: 1})
+	root := newParentNodeInArena(arena, 3 /* source_file */, true, []*Node{dot}, nil, 0)
+	dot.children = cloneNodeSliceInArena(arena, []*Node{root}) // back-edge -> cycle
+	return root, arena
+}
+
+func TestNormalizeGoDotLeafChildrenTerminatesOnCycle(t *testing.T) {
+	lang := goDotCompatibilityTestLanguage()
+	root, _ := buildCyclicGoTree()
+	source := []byte(".")
+	runWithin(t, 15*time.Second, "normalizeGoDotLeafChildrenWithStop", func() {
+		poller := parseStopPoller{}
+		normalizeGoDotLeafChildrenWithStop(root, source, lang, &poller)
+	})
+}
+
+func TestNormalizeGoCompatibilitySubtreeTerminatesOnCycle(t *testing.T) {
+	lang := goDotCompatibilityTestLanguage()
+	syms, _ := goCompatibilitySymbolsForLanguage(lang)
+	root, _ := buildCyclicGoTree()
+	source := []byte(".")
+	runWithin(t, 15*time.Second, "normalizeGoCompatibilitySubtreeWithStop", func() {
+		poller := parseStopPoller{}
+		normalizeGoCompatibilitySubtreeWithStop(root, source, syms, goCompatibilitySourceFlags{}, nil, &poller)
+	})
+}
+
+// buildWideDotFinalRefsTree builds a source_file whose n "dot" leaf children are
+// stored as final child refs — the transient form the dot walker traverses via
+// resultChildAt / view — so the scaling test exercises the real hot path.
+func buildWideDotFinalRefsTree(n int) *Node {
+	arena := newNodeArena(arenaClassFull)
+	childRange, entries := arena.allocPendingChildEntries(n)
+	for i := 0; i < n; i++ {
+		leaf := newLeafNodeInArena(arena, 2 /* dot */, true, 0, 1, Point{}, Point{Column: 1})
+		entries[i] = newPendingChildEntry(newStackEntryNode(leaf.parseState, leaf))
+	}
+	return newParentNodeInArenaWithFinalChildRefs(arena, 3 /* source_file */, true, childRange, 0, false)
+}
+
+func timeDotNormalizerMin(lang *Language, n, runs int) time.Duration {
+	// Size the source so the fast-path pop budget (a small multiple of the
+	// source length, mirroring the O(len(source)) node-count bound of a real
+	// parse) comfortably exceeds the synthetic node count; otherwise a tiny
+	// source would falsely trip the cyclic-descent fallback. Leaves span [0,1];
+	// only byte 0 is read (the "." check), so the padding is never inspected.
+	source := make([]byte, n+64)
+	source[0] = '.'
+	var best time.Duration
+	for r := 0; r < runs; r++ {
+		root := buildWideDotFinalRefsTree(n)
+		poller := parseStopPoller{}
+		start := time.Now()
+		normalizeGoDotLeafChildrenWithStop(root, source, lang, &poller)
+		d := time.Since(start)
+		if r == 0 || d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// TestNormalizeGoDotLeafChildrenScalesLinearly asserts the dot walker is linear
+// (not quadratic) in the width of a flat sibling list. A 4x width increase costs
+// ~4x for a linear walk and ~16x for a quadratic one; the < 8x bound cleanly
+// separates the two while tolerating allocator/GC noise.
+func TestNormalizeGoDotLeafChildrenScalesLinearly(t *testing.T) {
+	lang := goDotCompatibilityTestLanguage()
+	const nSmall, nLarge = 20000, 80000
+	small := timeDotNormalizerMin(lang, nSmall, 6)
+	large := timeDotNormalizerMin(lang, nLarge, 6)
+	ratio := float64(large) / float64(small)
+	t.Logf("n=%d %v  n=%d %v  4x-width ratio=%.2f", nSmall, small, nLarge, large, ratio)
+	if small > 0 && ratio > 8.0 {
+		t.Fatalf("dot normalizer scaling looks super-linear: 4x width -> %.2fx time (want < 8x)", ratio)
+	}
+}

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -393,7 +393,20 @@ func (b *resultRootBuild) syntheticRootReplayLexGapToken(frame syntheticRootRepl
 		return Token{}, false
 	}
 	lexer := NewLexer(b.lang.LexStates, b.source)
-	ts := newDFATokenSourceDirect(lexer, b.lang, b.parser.lookupActionIndex, b.parser.hasKeywordState, b.parser.externalValidByState, b.parser.externalValidMaskByState)
+	// Gate this gap-token lexer on the language-level C-recovery answer rather
+	// than the live b.parser.errorCostCompetition flag. resolveCRecoverySwallowedError
+	// (parser_api.go) temporarily forces p.errorCostCompetition = false around its
+	// fallback comparison re-parse, so reading the parser flag here would flip the
+	// gap-token error-mode lexing inside that window. b.lang is always
+	// b.parser.language (see newResultRootBuild) and errorCostCompetitionLanguage is
+	// a pure function of the language (p.errorCostCompetition is initialized from it
+	// at NewParser), so it is the stable constant this replay needs — identical to
+	// the parser flag outside the fallback window, and exactly the behavior this
+	// path had before it was switched to read the mutable cached flag. Gap-token
+	// replay only runs during synthetic-root reconstruction, off the steady-state
+	// token loop, so the DiagnoseCRecoveryGate scan behind it stays out of the hot
+	// path.
+	ts := newDFATokenSourceDirectWithCRecovery(lexer, b.lang, b.parser.lookupActionIndex, b.parser.hasKeywordState, b.parser.externalValidByState, b.parser.externalValidMaskByState, errorCostCompetitionLanguage(b.lang))
 	defer ts.Close()
 	ts.SetParserState(frame.states[len(frame.states)-1])
 	ts.SeekTokenFrontier(startByte, startPoint)

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -2,6 +2,8 @@ package gotreesitter
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"time"
 )
 
@@ -65,6 +67,18 @@ const (
 	// Keep retry widening bounded to avoid runaway memory growth on very large
 	// malformed inputs. Callers can still override via GOT_GLR_MAX_STACKS.
 	fullParseRetryMaxSourceBytes = 1 << 20 // 1 MiB
+	// fullParseRetryMaxTotalPasses hard-bounds the number of retry passes a
+	// single top-level parse operation may run, independent of any wall-clock
+	// budget (the retryDeadline in retryFullParse is a no-op when the caller
+	// never sets SetTimeoutMicros — the common case). The deepest legitimate
+	// ladder is ~5 passes per retryFullParse invocation and at most a few
+	// invocations per operation (main round + external-scanner repeat +
+	// incremental->full fallback), so 24 leaves >2x headroom while making
+	// runaway repetition (c_sharp was observed running 1076 passes on a
+	// pass-1 parse failure, 2026-07 cliff campaign) structurally impossible.
+	// Retries are best-effort improvements: when the budget is exhausted the
+	// incumbent best tree is returned, never a worse result.
+	fullParseRetryMaxTotalPasses = 24
 )
 
 type resettableTokenSource interface {
@@ -109,7 +123,7 @@ func shouldRetryAcceptedErrorParse(tree *Tree, sourceLen int, initialMaxStacks i
 	return rt.MaxStacksSeen >= initialMaxStacks
 }
 
-func shouldRetryStackPressureCleanFullParse(tree *Tree, sourceLen int, initialMaxStacks int) bool {
+func shouldRetryStackPressureCleanFullParse(tree *Tree, sourceLen int, _ int) bool {
 	if tree == nil {
 		return false
 	}
@@ -130,13 +144,17 @@ func shouldRetryStackPressureCleanFullParse(tree *Tree, sourceLen int, initialMa
 	if rt.Truncated && rt.StopReason != ParseStopAccepted {
 		return false
 	}
-	if initialMaxStacks <= 0 {
-		initialMaxStacks = maxGLRStacks
-	}
-	if rt.GlobalCullStacksIn > rt.GlobalCullStacksOut {
-		return true
-	}
-	return rt.MaxStacksSeen >= initialMaxStacks+fullParseGLRStackOverflow
+	// Only ACTUAL eviction justifies a clean-tree re-parse: the global cap
+	// cull dropped live stacks, so the C-correct interpretation may have
+	// been discarded. The old second arm (MaxStacksSeen >= cap+overflow)
+	// fired on mere transient pre-merge bloom — python's clean parses hit
+	// it on essentially every real file (MaxStacksSeen >= 12 always),
+	// buying a guaranteed second full pass (universal ~2x clean-parse tax,
+	// 2026-07 cliff campaign) for a tree that was never at risk: when the
+	// cull never dropped anything, no lineage was lost and the first clean
+	// tree is already the parse's honest answer (also closer to C's
+	// single-pass semantics).
+	return rt.GlobalCullStacksIn > rt.GlobalCullStacksOut
 }
 
 func shouldRetryNodeLimitParse(tree *Tree, sourceLen int) bool {
@@ -369,9 +387,17 @@ func effectiveFullParseInitialMaxStacks(lang *Language, initialMaxStacks int) in
 	}
 	switch lang.Name {
 	case "bash":
-		if initialMaxStacks < 256 {
-			initialMaxStacks = 256
-		}
+		// bash's historical 256 floor (arrived 2026-03-07 in a C#-focused
+		// commit, no bash rationale recorded) was removed by the 2026-07
+		// cliff campaign. It papered over the real defect — the bash branch
+		// of compareStackCullKeys preferred SHALLOWER stacks, so under cull
+		// pressure the deeper accept-capable lineage was evicted at ANY cap
+		// (2..256 all ended in an EOF mass-pause + whole-file recovery wrap;
+		// only 512 survived) — while multiplying every survivor-count cost
+		// by 32x. With the cull ordering fixed, the global default parses
+		// the bash corpus clean and byte-shape-identical to the pinned C
+		// oracle (small__release.sh 46s -> well under 1s; medium__clean-old.sh
+		// 17-20s -> ~50ms), and all bash regression tests pass unwidened.
 	case "css", "scss":
 		// Large stylesheet corpora spend most of their time churning on the
 		// same RS conflicts without needing a wide steady-state stack budget.
@@ -902,7 +928,22 @@ func effectiveParseMergePerKeyCap(lang *Language, mergePerKeyCap int, incrementa
 }
 
 func typescriptFullParseCanUseTightMergeCap(sourceLen ...int) bool {
-	return len(sourceLen) == 0 || sourceLen[0] <= 64*1024
+	// The tight cap applies uniformly regardless of file size. This function
+	// previously disengaged the cap above 64KB ("large parser.ts-class sources
+	// need the wider default to avoid expensive recovery/result paths",
+	// 719cbe90), which created a size-threshold discontinuity: the wide
+	// six-survivor budget retains redundant unreduced-spine survivors whose
+	// conflict-reduce frontier walk re-forks their entire pending spine at
+	// every statement boundary (O(n) transient forks per token, O(n^2) node
+	// allocation over the file). Union-type-list-shaped .d.ts sources crossed
+	// from "parses in milliseconds" at 64KB-epsilon to "memory_budget with
+	// 1548 transient stacks" at 64KB+epsilon. The tight cap is what prevents
+	// those survivors from being retained in the first place; typed-arrow and
+	// destructured-arrow sources still widen through the dedicated gates in
+	// configureParseCaps, and accepted-error retries still widen through
+	// fullParseRetryMergePerKeyOverride.
+	_ = sourceLen
+	return true
 }
 
 func dartIncrementalFallbackCanUseTightMergeCap(sourceLen ...int) bool {
@@ -1028,7 +1069,6 @@ func typeScriptSourceHasDestructuredArrowReturnType(source []byte) bool {
 	}
 }
 
-
 func fullParseUsesDeterministicExternalConflicts(lang *Language) bool {
 	return lang != nil &&
 		lang.ExternalScanner != nil &&
@@ -1052,6 +1092,12 @@ func shouldRepeatExternalScannerFullParse(lang *Language, tree *Tree) bool {
 }
 
 func fullParseRetryMaxStacksOverride(tree *Tree, sourceLen int, initialMaxStacks int) int {
+	// An explicit GOT_GLR_MAX_STACKS is a true ceiling: diagnostics and
+	// experiments depend on the survivor cap actually holding, and the
+	// widening below silently defeated it (2026-07 cliff campaign finding).
+	if parseMaxGLRStacksEnvConfigured() {
+		return 0
+	}
 	retryMaxStacks := fullParseRetryMaxGLRStacks
 	if tree != nil && tree.language != nil && tree.language.Name == "java" {
 		retryMaxStacks = javaFullParseRetryMaxGLRStacks
@@ -1207,6 +1253,13 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 		if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
 			return true
 		}
+		// Hard pass-count bound, independent of any wall-clock budget (which
+		// is a no-op without SetTimeoutMicros — see the KNOWN GAP below).
+		// Counted per top-level parse operation across every retryFullParse
+		// invocation; see fullParseRetryMaxTotalPasses.
+		if p != nil && p.fullParseRetryPassesTaken >= fullParseRetryMaxTotalPasses {
+			return true
+		}
 		// KNOWN GAP (tracked, not fixed here): when the caller never
 		// configures a timeout (p.timeoutMicros == 0, the default for a
 		// freshly constructed Parser and for every test/benchmark helper in
@@ -1277,16 +1330,48 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 	}
 
 	structuralResyncRetry := shouldRetryFullParse(tree, len(source))
+	retryDebug := os.Getenv("GOT_RETRY_DEBUG") == "1"
+	if retryDebug {
+		rt := tree.ParseRuntime()
+		fmt.Fprintf(os.Stderr, "RETRYDBG entry stop=%v truncated=%v hasErr=%v maxStacksSeen=%d stacksOverride=%d nodesOverride=%d structResync=%v\n",
+			rt.StopReason, rt.Truncated, retryTreeHasError(tree), rt.MaxStacksSeen, maxStacksOverride, maxNodesOverride, structuralResyncRetry)
+	}
 	runRetryAttempt := func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
-		if !structuralResyncRetry || p == nil || p.forceCleanRetryPass {
-			return runRetry(maxStacks, maxMergePerKeyOverride, maxNodes)
+		if p != nil {
+			if p.fullParseRetryPassesTaken >= fullParseRetryMaxTotalPasses {
+				// Budget exhausted: a nil candidate is a no-op for every
+				// caller (replaceBest ignores nil), so the incumbent best
+				// tree flows through unchanged.
+				return nil
+			}
+			p.fullParseRetryPassesTaken++
 		}
-		prev := p.retryStructuralTopLevelResync
-		p.retryStructuralTopLevelResync = true
-		defer func() {
-			p.retryStructuralTopLevelResync = prev
-		}()
-		return runRetry(maxStacks, maxMergePerKeyOverride, maxNodes)
+		var t0 time.Time
+		if retryDebug {
+			t0 = time.Now()
+		}
+		var result *Tree
+		if !structuralResyncRetry || p == nil || p.forceCleanRetryPass {
+			result = runRetry(maxStacks, maxMergePerKeyOverride, maxNodes)
+		} else {
+			prev := p.retryStructuralTopLevelResync
+			p.retryStructuralTopLevelResync = true
+			defer func() {
+				p.retryStructuralTopLevelResync = prev
+			}()
+			result = runRetry(maxStacks, maxMergePerKeyOverride, maxNodes)
+		}
+		if retryDebug {
+			stop := ParseStopNone
+			hasErr := true
+			if result != nil {
+				stop = result.ParseRuntime().StopReason
+				hasErr = retryTreeHasError(result)
+			}
+			fmt.Fprintf(os.Stderr, "RETRYDBG pass maxStacks=%d mergePerKey=%d maxNodes=%d took=%v stop=%v hasErr=%v forceClean=%v\n",
+				maxStacks, maxMergePerKeyOverride, maxNodes, time.Since(t0), stop, hasErr, p != nil && p.forceCleanRetryPass)
+		}
+		return result
 	}
 
 	bestTree := tree

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -281,7 +281,7 @@ func TestConflictReduceFrontierCompletesSingleShift(t *testing.T) {
 	}
 
 	nextBranchOrder := uint64(99)
-	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, func() uint64 {
+	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, 1, 0, func() uint64 {
 		order := nextBranchOrder
 		nextBranchOrder++
 		return order
@@ -331,7 +331,7 @@ func TestConflictReduceFrontierDegenerateSameReduceShiftCompletes(t *testing.T) 
 	seed := applyConflictFrontierReduceForTest(parser, &stack, reduce, tok, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, &trackChildErrors)
 
 	nextBranchOrder := uint64(99)
-	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, func() uint64 {
+	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, 1, 0, func() uint64 {
 		order := nextBranchOrder
 		nextBranchOrder++
 		return order
@@ -421,7 +421,7 @@ func TestConflictReduceFrontierSameHeaderFirstReduceStaysLive(t *testing.T) {
 		afterDepth:  2,
 	}
 
-	parser.completeConflictReduceFrontier([]byte("xxb"), &stack, tok, seed, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
+	parser.completeConflictReduceFrontier([]byte("xxb"), &stack, tok, seed, 1, 0, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
 	if stack.dead {
 		t.Fatal("same-header first reduce killed original branch")
 	}
@@ -505,7 +505,7 @@ func TestConflictReduceFrontierDepthChangingSameReduceDoesNotFakeDuplicate(t *te
 		t.Fatalf("after seed reduce state = %d, want %d", got, want)
 	}
 
-	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
+	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, 1, 0, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
 	if stack.dead {
 		t.Fatal("depth-changing frontier reduce killed stack")
 	}
@@ -627,7 +627,7 @@ func TestConflictReduceFrontierDoesNotCollapseOtherReduceShift(t *testing.T) {
 	reduce := lang.ParseActions[6].Actions[0]
 	seed := applyConflictFrontierReduceForTest(parser, &stack, reduce, tok, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, &trackChildErrors)
 
-	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
+	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, 1, 0, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
 	if stack.dead {
 		t.Fatal("frontier completion killed stack")
 	}
@@ -658,7 +658,7 @@ func TestConflictReduceFrontierRecoverMarksTokenConsumed(t *testing.T) {
 	reduce := lang.ParseActions[6].Actions[0]
 	seed := applyConflictFrontierReduceForTest(parser, &stack, reduce, tok, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, &trackChildErrors)
 
-	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
+	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, 1, 0, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
 	if !stack.dead {
 		t.Fatal("frontier recover same-reduce cycle left original branch live")
 	}


### PR DESCRIPTION
## Summary

This PR optimizes GLR merge paths by replacing map-based caches with fixed-size set-associative arrays for shape prefixes and clean-zero error tracking, eliminating allocation storms and super-linear merge costs on wide-GLR inputs. It patches a silent uint16 wrap-around in grammargen table generation to prevent corrupted language tables, registers precise ExternalLexStates for c_sharp (default) and javascript (staged) to fix scanner stack corruption, and introduces a new perf_scan harness for nightly Go-vs-C performance scoreboarding.

## Changes

- Replace map[*gssNode] lookups in glrMergeScratch with 2-way set-associative arrays (shapePrefixCache, cleanZeroFrontCache) to eliminate per-merge allocations and GC overhead.
- Fix GLR prefix invariant by bumping shapePrefixEpoch on GSS main merges, dispatch-time merges, and retarget sites to prevent stale hash reads across tokens.
- Add forestAcceptedIsCleanCompleteParse to skip unnecessary EOF-recovery competition probes when the forest accept path has zero error cost and full input span.
- Add checkUint16Index validation in grammargen/assemble.go for parse-action groups, field/supertype maps, reserved words, and lex states to hard-fail generation instead of silently wrapping at 65535.
- Register precise ExternalLexStates table for c_sharp (moves from staged to default) and javascript (staged behind -tags javascript_precise_els) to fix interpolated-string scanner stack corruption and enable C-recovery election.
- Introduce cgo_harness/perf_scan/ harness with CLI proposal, README, and zz_perf_scan_test.go for nightly Go-vs-C timing scoreboards and cliff containment.
- Add debug harnesses and regression tests for bash cliff, TypeScript detonator, and error locate scenarios.

## Testing

- Run `go test ./grammargen` to verify uint16 overflow guards and assembly logic.
- Run `go test ./parser -run TestGLR` and scoped parity tests for c_sharp and javascript to validate ExternalLexStates fixes and GLR cache invalidation.
- Execute perf_scan locally: `GTS_PERF_SCAN=1 go test -tags 'treesitter_c_parity treesitter_c_perfscan' -run '^TestPerfScanSweep$'` to verify scoreboard JSON/markdown output.
- Profile `BenchmarkGoParseFullDFA` and `BenchmarkGoParseIncrementalSingleByteEditDFA` on large clean inputs to confirm sub-linear merge costs and reduced allocations.

## Review Focus

Pay special attention to glr.go shape epoch invalidation logic and storeShapePrefixCache/storesCleanZeroFrontCache to ensure no stale cache reads occur during GSS link rewrites.