### PR TITLE
Bind external scanner symbols positionally and bound arena growth

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -45,6 +45,21 @@ const (
 	// a 100+ MB arena in the pool indefinitely, consumed by every subsequent
 	// parse on that goroutine.
 	maxRetainedFullArenaBytes = 128 * 1024 * 1024
+
+	// maxOverflowSlabGrowthBytes bounds geometric overflow-slab growth. Overflow
+	// slabs double for cheap amortization on small/medium parses, but unbounded
+	// doubling makes the final backing slab of a very large parse as large as
+	// everything allocated before it combined: up to ~half of that last slab is
+	// never used. Because the per-parse memory budget is charged against slab
+	// *capacity* (allocatedBytes), not live usage, that speculative doubled tail
+	// could trip the budget hundreds of MB before the live tree actually reached
+	// it — the deterministic asm.js-class arena exhaustion (box2d.js /
+	// lua_binarytrees.js: enormous flat trees whose last doubled node slab is
+	// added in one budget-blowing step). Past this ceiling slabs grow linearly,
+	// so peak capacity — and the budget charge — tracks live usage within one
+	// ceiling-sized slab. This mirrors the fixed-size slab strategy already used
+	// for pendingParent / rawShape / full-parse pendingChildEntry slabs.
+	maxOverflowSlabGrowthBytes = 8 * 1024 * 1024
 )
 
 type arenaClass uint8
@@ -1101,7 +1116,7 @@ func (a *nodeArena) allocNodeSlow() *Node {
 	for i := a.nodeSlabCursor; ; i++ {
 		if i >= len(a.nodeSlabs) {
 			lastCap := len(a.nodeSlabs[len(a.nodeSlabs)-1].data)
-			capacity := max(lastCap*2, minArenaNodeCap)
+			capacity := boundedNextSlabCap(lastCap, minArenaNodeCap, int(unsafe.Sizeof(Node{})))
 			a.nodeSlabs = append(a.nodeSlabs, nodeSlab{data: make([]Node, capacity)})
 			a.allocatedBytes += nodeBytesForCap(capacity)
 		}
@@ -1136,7 +1151,7 @@ func (a *nodeArena) allocNoTreeNode() *noTreeNode {
 	for i := a.noTreeNodeSlabCursor; ; i++ {
 		if i >= len(a.noTreeNodeSlabs) {
 			lastCap := len(a.noTreeNodeSlabs[len(a.noTreeNodeSlabs)-1].data)
-			capacity := max(lastCap*2, minArenaNodeCap)
+			capacity := boundedNextSlabCap(lastCap, minArenaNodeCap, int(unsafe.Sizeof(noTreeNode{})))
 			a.noTreeNodeSlabs = append(a.noTreeNodeSlabs, noTreeNodeSlab{data: make([]noTreeNode, capacity)})
 			a.allocatedBytes += noTreeNodeBytesForCap(capacity)
 		}
@@ -1171,7 +1186,7 @@ func (a *nodeArena) allocCompactFullLeaf() *compactFullLeaf {
 	for i := a.compactFullLeafSlabCursor; ; i++ {
 		if i >= len(a.compactFullLeafSlabs) {
 			lastCap := len(a.compactFullLeafSlabs[len(a.compactFullLeafSlabs)-1].data)
-			capacity := max(lastCap*2, minArenaNodeCap)
+			capacity := boundedNextSlabCap(lastCap, minArenaNodeCap, int(unsafe.Sizeof(compactFullLeaf{})))
 			a.compactFullLeafSlabs = append(a.compactFullLeafSlabs, compactFullLeafSlab{data: make([]compactFullLeaf, capacity)})
 			a.allocatedBytes += compactFullLeafBytesForCap(capacity)
 		}
@@ -1317,7 +1332,7 @@ func (a *nodeArena) allocRawShapeChildren(n int) rawShapeChildRange {
 	for i := a.rawShapeChildSlabCursor; ; i++ {
 		if i >= len(a.rawShapeChildSlabs) {
 			lastCap := len(a.rawShapeChildSlabs[len(a.rawShapeChildSlabs)-1].data)
-			capacity := max(lastCap*2, n)
+			capacity := boundedNextSlabCap(lastCap, n, int(unsafe.Sizeof(rawShapeChild{})))
 			a.rawShapeChildSlabs = append(a.rawShapeChildSlabs, rawShapeChildSlab{data: make([]rawShapeChild, capacity)})
 			a.allocatedBytes += rawShapeChildBytesForCap(capacity)
 		}
@@ -1334,7 +1349,13 @@ func (a *nodeArena) allocRawShapeChildren(n int) rawShapeChildRange {
 
 func nextPendingChildEntrySlabCap(class arenaClass, lastCap, min int) int {
 	if class != arenaClassFull {
-		return max(lastCap*2, min)
+		// Bound the incremental-class geometric tail with the same 8 MB ceiling
+		// as the node/leaf overflow slabs (boundedNextSlabCap): double until the
+		// ceiling, then grow linearly, while still satisfying an oversized single
+		// request (min = slotCount for a wide reduce) via exact-fit. The
+		// arenaClassFull path already uses a fixed default-sized overflow slab
+		// (never doubles) — the strategy that fixed the box2d/asm.js exhaustion.
+		return boundedNextSlabCap(lastCap, min, int(unsafe.Sizeof(pendingChildEntry{})))
 	}
 	return max(defaultPendingChildEntrySlabCap(class), min)
 }
@@ -1355,7 +1376,7 @@ func (a *nodeArena) allocCompactCheckpointLeaf() *compactCheckpointLeaf {
 	for i := a.compactCheckpointLeafSlabCursor; ; i++ {
 		if i >= len(a.compactCheckpointLeafSlabs) {
 			lastCap := len(a.compactCheckpointLeafSlabs[len(a.compactCheckpointLeafSlabs)-1].data)
-			capacity := max(lastCap*2, minArenaNodeCap)
+			capacity := boundedNextSlabCap(lastCap, minArenaNodeCap, int(unsafe.Sizeof(compactCheckpointLeaf{})))
 			a.compactCheckpointLeafSlabs = append(a.compactCheckpointLeafSlabs, compactCheckpointLeafSlab{data: make([]compactCheckpointLeaf, capacity)})
 			a.allocatedBytes += compactCheckpointLeafBytesForCap(capacity)
 		}
@@ -1587,6 +1608,35 @@ func nodeCapacityForClass(class arenaClass) int {
 		return nodeCapacityForBytes(incrementalArenaSlab)
 	}
 	return nodeCapacityForBytes(fullParseArenaSlab)
+}
+
+// boundedNextSlabCap returns the capacity for the next geometric overflow slab
+// of an element type sized elemSize bytes. Slabs double (cheap amortization for
+// small/medium parses) until doubling would exceed maxOverflowSlabGrowthBytes,
+// after which they grow linearly at that ceiling. minReq guarantees room for a
+// single variable-length request (e.g. a wide rawShapeChild range) that is
+// itself larger than the ceiling. Bounding the geometric tail keeps peak slab
+// capacity — and therefore the per-parse memory-budget charge levied against
+// allocatedBytes — tracking live usage within one ceiling-sized slab instead of
+// overshooting by up to ~50% of the largest slab. See maxOverflowSlabGrowthBytes.
+func boundedNextSlabCap(lastCap, minReq, elemSize int) int {
+	next := lastCap * 2
+	if elemSize > 0 {
+		ceiling := maxOverflowSlabGrowthBytes / elemSize
+		if ceiling < minArenaNodeCap {
+			ceiling = minArenaNodeCap
+		}
+		if next > ceiling {
+			next = ceiling
+		}
+	}
+	if next < minReq {
+		next = minReq
+	}
+	if next < minArenaNodeCap {
+		next = minArenaNodeCap
+	}
+	return next
 }
 
 func nodeBytesForCap(n int) int64 {

--- a/arena_overflow_growth_test.go
+++ b/arena_overflow_growth_test.go
@@ -1,0 +1,137 @@
+package gotreesitter
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestArenaOverflowSlabGrowthBounded guards the asm.js-class arena-exhaustion
+// fix: overflow node slabs previously doubled without bound, so a single large
+// flat-tree parse (box2d.js / lua_binarytrees.js) allocated a final backing slab
+// as large as everything before it combined. Up to ~half of that last slab was
+// never used, and because the per-parse memory budget is charged against slab
+// *capacity* (allocatedBytes), that speculative tail tripped the 512 MB budget
+// hundreds of MB before the live tree actually reached it.
+//
+// The invariant: no overflow slab may exceed maxOverflowSlabGrowthBytes, and
+// total node capacity waste (allocated slots minus live slots) stays within one
+// ceiling-sized slab regardless of how many nodes are allocated.
+func TestArenaOverflowSlabGrowthBounded(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	nodeSize := int(unsafe.Sizeof(Node{}))
+	ceiling := maxOverflowSlabGrowthBytes / nodeSize
+
+	// Allocate well into the linear-growth regime: past the primary slab and
+	// several ceiling-sized overflow slabs.
+	primary := len(arena.nodes)
+	total := primary + ceiling*8
+	for i := 0; i < total; i++ {
+		_ = arena.allocNode()
+	}
+
+	if len(arena.nodeSlabs) == 0 {
+		t.Fatal("expected overflow slabs after allocating past primary capacity")
+	}
+
+	// No single overflow slab may exceed the growth ceiling.
+	maxSlab := 0
+	capacity := primary
+	for i := range arena.nodeSlabs {
+		c := len(arena.nodeSlabs[i].data)
+		capacity += c
+		if c > maxSlab {
+			maxSlab = c
+		}
+		if c > ceiling {
+			t.Fatalf("overflow slab %d capacity=%d exceeds growth ceiling=%d (unbounded doubling regressed)", i, c, ceiling)
+		}
+	}
+
+	// Capacity waste must be bounded by a single ceiling slab. Unbounded doubling
+	// produced waste of up to ~50% of total capacity; the bound is one slab.
+	waste := capacity - arena.used
+	if waste > ceiling {
+		t.Fatalf("node capacity waste=%d nodes (%d MB) exceeds one ceiling slab=%d nodes; "+
+			"unbounded overflow doubling has regressed",
+			waste, int64(waste)*int64(nodeSize)/(1<<20), ceiling)
+	}
+
+	// The reported allocatedBytes (what the memory budget is charged) must match
+	// the true slab capacity, and waste beyond live usage must stay minimal.
+	if got, want := arena.allocatedBytes, arena.nodeStructBytesAllocated()+arena.childSliceBytesAllocated()+arena.fieldIDBytesAllocated()+arena.fieldSourceBytesAllocated(); got != want {
+		t.Fatalf("allocatedBytes=%d, recomputed node+slice bytes=%d", got, want)
+	}
+}
+
+// TestBoundedNextSlabCapCapsGrowth checks the growth helper directly across the
+// geometric-then-linear transition for the Node element size.
+func TestBoundedNextSlabCapCapsGrowth(t *testing.T) {
+	nodeSize := int(unsafe.Sizeof(Node{}))
+	ceiling := maxOverflowSlabGrowthBytes / nodeSize
+
+	// Geometric regime: doubles while below the ceiling.
+	if got := boundedNextSlabCap(1000, minArenaNodeCap, nodeSize); got != 2000 {
+		t.Fatalf("boundedNextSlabCap(1000) = %d, want 2000 (doubling below ceiling)", got)
+	}
+	// Transition: doubling past the ceiling is clamped to the ceiling.
+	if got := boundedNextSlabCap(ceiling*3/4, minArenaNodeCap, nodeSize); got != ceiling {
+		t.Fatalf("boundedNextSlabCap(ceiling*3/4) = %d, want ceiling=%d", got, ceiling)
+	}
+	// Linear regime: once at/above the ceiling, stays flat at the ceiling.
+	if got := boundedNextSlabCap(ceiling, minArenaNodeCap, nodeSize); got != ceiling {
+		t.Fatalf("boundedNextSlabCap(ceiling) = %d, want ceiling=%d (flat linear growth)", got, ceiling)
+	}
+	// A single request larger than the ceiling is still satisfied (variable-length
+	// rawShapeChild ranges rely on this).
+	big := ceiling + 5000
+	if got := boundedNextSlabCap(ceiling, big, nodeSize); got != big {
+		t.Fatalf("boundedNextSlabCap(minReq=%d) = %d, want %d", big, got, big)
+	}
+}
+
+// TestArenaCompactFullLeafOverflowBounded extends the overflow-growth guard to
+// one of the compact-leaf allocators (allocCompactFullLeaf). Review A flagged
+// the compact-leaf overflow slabs as still doubling without bound after the
+// node-slab fix, so leaf-heavy parses (leaf-dense flat trees) still carried
+// ~50% capacity overshoot in the final doubled slab — the same budget-tripping
+// tail the node fix removed. The invariant mirrors the node path: no compact
+// leaf overflow slab exceeds maxOverflowSlabGrowthBytes, and total leaf-slab
+// capacity waste stays within one ceiling-sized slab regardless of how many
+// leaves are allocated.
+func TestArenaCompactFullLeafOverflowBounded(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	elemSize := int(unsafe.Sizeof(compactFullLeaf{}))
+	ceiling := maxOverflowSlabGrowthBytes / elemSize
+
+	// Allocate the primary slab plus several ceiling-sized overflow slabs so the
+	// growth is well into the linear regime.
+	primary := defaultCompactFullLeafSlabCap(arenaClassFull)
+	total := primary + ceiling*5
+	for i := 0; i < total; i++ {
+		if arena.allocCompactFullLeaf() == nil {
+			t.Fatal("allocCompactFullLeaf returned nil")
+		}
+	}
+	if len(arena.compactFullLeafSlabs) < 2 {
+		t.Fatalf("expected compact-full-leaf overflow slabs, got %d slab(s)", len(arena.compactFullLeafSlabs))
+	}
+
+	capacity := 0
+	for i := range arena.compactFullLeafSlabs {
+		c := len(arena.compactFullLeafSlabs[i].data)
+		capacity += c
+		if c > ceiling {
+			t.Fatalf("compact-full-leaf overflow slab %d capacity=%d exceeds growth ceiling=%d (unbounded doubling regressed)", i, c, ceiling)
+		}
+	}
+
+	// Every slab but the last is full (we allocated past them), so waste is
+	// bounded by the last, at-most-ceiling-sized slab. Unbounded doubling grew
+	// the final slab as large as everything before it, blowing past this bound.
+	waste := capacity - total
+	if waste > ceiling {
+		t.Fatalf("compact-full-leaf capacity waste=%d leaves (%d MB) exceeds one ceiling slab=%d; "+
+			"unbounded overflow doubling has regressed",
+			waste, int64(waste)*int64(elemSize)/(1<<20), ceiling)
+	}
+}

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -141,6 +141,22 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 	case "r":
 		chosen, ok = rRepetitionShiftConflictChoice(p.language, currentState, actions)
 	case "php":
+		// Stack-scoped error gate: only lineages that never entered the C
+		// error state take the deterministic comma list-repeat fold. The sticky
+		// !cEverErrored bit is the airtight signal; cNodeBaseline==0 is NOT —
+		// cApplyMergedErrorGroupBaseline can write a 0 baseline (error entered at
+		// cumulative count 0), the cNodeCountSinceError clamp can rewrite a
+		// baseline back to 0 after a pop-below-everything, and cRecoverToState
+		// clears cRec on the recovered fork, so a wreckage-carrying lineage could
+		// pass the old baseline==0 gate two tokens later. The !cPaused check is
+		// still required: pausing precedes the cHandleError entry that sets
+		// cEverErrored. See phpCommaListRepeatConflictChoice for why
+		// wreckage-descended lineages must keep the ordinary GLR fork here.
+		if s != nil && s.cRec == nil && !s.cPaused && s.cRecoverMissingGroup == nil && !s.cEverErrored {
+			if next, ok := phpCommaListRepeatConflictChoice(p.language, tok, actions); ok {
+				return next, true
+			}
+		}
 		chosen, ok = phpRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
 	case "perl":
 		chosen, ok = perlRepetitionShiftConflictChoice(p.language, currentState, actions)

--- a/glr.go
+++ b/glr.go
@@ -62,6 +62,21 @@ type glrStack struct {
 	// cumulative visible-node count when the error discontinuity was last
 	// pushed. Zero for stacks that never entered the C error state.
 	cNodeBaseline int
+	// cEverErrored is a sticky per-stack bit: true once this lineage has entered
+	// C's error handling at any point, even if it later recovered to a clean tree
+	// with cRec cleared and cNodeBaseline reset (or clamped) back to zero. Unlike
+	// cRec/cPaused/cNodeBaseline — every one of which a recovered fork can
+	// legitimately reset to its pristine value — this bit never clears, so a gate
+	// that must distinguish "provably never touched recovery" from "recovered
+	// wreckage that now looks pristine" (the php comma-list gate in
+	// conflict_policy.go) can rely on it where cNodeBaseline==0 is not airtight
+	// (a baseline can be written or clamped back to 0). Set at every C-error
+	// entry funnel (cHandleError entry, cApplyMergedErrorGroupBaseline,
+	// cRecoverToState fork creation), propagated by clone()/cloneWithScratch(),
+	// and OR-merged at the two GSS merge choke points (tryGSSMainMergeResult,
+	// tryGSSMainMergeForParser) so a clean survivor cannot shed a merged-in
+	// wreckage lineage's history.
+	cEverErrored bool
 	// cRecoveryUnvalidatedMarker is set on this lineage in exactly one place:
 	// cRecoverToState (parser_recover_c.go), the moment it creates a real
 	// ERROR node wrapping popped content (strategy 1 of ts_parser__recover),
@@ -141,16 +156,20 @@ type glrMergeScratch struct {
 	stackEquivCache   []glrStackEquivCacheEntry
 	frontierHashCache []glrStackFrontierHashCacheEntry
 	cErrorCost        map[*Node]glrCErrorCostEntry
-	shapePrefixCache  []glrShapePrefixCacheEntry
-	shapePrefixEpoch  uint32
-	shapePrefixBytes  int64
-	cleanZeroEpoch    uint32
-	cleanZeroScan     uint32
-	cleanZeroCache    map[*gssNode]gssCleanZeroErrorCacheEntry
-	cleanZeroFront    []glrCleanZeroFrontCacheEntry
-	cleanZeroBytes    int64
-	cleanZeroStack    []*gssNode
-	cleanZeroVisited  []*gssNode
+	// cPrefixPath is the descent scratch for merge-side GSS prefix-aggregate
+	// fills (cStackPrefixCostForMerge, parser_recover_c.go); the aggregates
+	// live on gssNode, validated against gssPrefixAggGen.
+	cPrefixPath      []*gssNode
+	shapePrefixCache []glrShapePrefixCacheEntry
+	shapePrefixEpoch uint32
+	shapePrefixBytes int64
+	cleanZeroEpoch   uint32
+	cleanZeroScan    uint32
+	cleanZeroCache   map[*gssNode]gssCleanZeroErrorCacheEntry
+	cleanZeroFront   []glrCleanZeroFrontCacheEntry
+	cleanZeroBytes   int64
+	cleanZeroStack   []*gssNode
+	cleanZeroVisited []*gssNode
 	// preflight + mergeSeen are pooled per-scratch so the GSS merge can-phase
 	// stops allocating a preflight object plus several maps per merge attempt
 	// (the dominant profile cost on low-stack GLR grammars like json — maps
@@ -371,6 +390,7 @@ func (s *glrStack) clone() glrStack {
 			cRecoverMissingGroup:       s.cRecoverMissingGroup,
 			cNodeBaseline:              s.cNodeBaseline,
 			cRecoveryUnvalidatedMarker: s.cRecoveryUnvalidatedMarker,
+			cEverErrored:               s.cEverErrored,
 		}
 	}
 	s.ensureGSS(nil)
@@ -386,6 +406,7 @@ func (s *glrStack) clone() glrStack {
 		cRecoverMissingGroup:       s.cRecoverMissingGroup,
 		cNodeBaseline:              s.cNodeBaseline,
 		cRecoveryUnvalidatedMarker: s.cRecoveryUnvalidatedMarker,
+		cEverErrored:               s.cEverErrored,
 	}
 }
 
@@ -403,6 +424,7 @@ func (s *glrStack) cloneWithScratch(scratch *gssScratch) glrStack {
 		cRecoverMissingGroup:       s.cRecoverMissingGroup,
 		cNodeBaseline:              s.cNodeBaseline,
 		cRecoveryUnvalidatedMarker: s.cRecoveryUnvalidatedMarker,
+		cEverErrored:               s.cEverErrored,
 	}
 }
 
@@ -2681,13 +2703,20 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 		return false
 	}
 	merged := gssMainMerge(a, b)
-	if merged && p != nil {
-		// Mirror tryGSSMainMergeResult (bumpShapePrefixEpoch above): a successful
-		// main merge rewrites link 0 (setGSSMainLink) of surviving nodes during
-		// dispatch, so every root->head shape prefix cached in the active merge
-		// scratch may now be stale. p.mergeScratch is nil outside a parse and
-		// bumpShapePrefixEpoch is nil-safe.
-		p.mergeScratch.bumpShapePrefixEpoch()
+	if merged {
+		// a survives and absorbs b, so OR the sticky wreckage bit: cEverErrored
+		// is lineage history, not current shape, and a clean survivor must not
+		// shed a merged-in recovered-wreckage lineage's error history (see
+		// glrStack.cEverErrored / tryGSSMainMergeResult).
+		a.cEverErrored = a.cEverErrored || b.cEverErrored
+		if p != nil {
+			// Mirror tryGSSMainMergeResult (bumpShapePrefixEpoch above): a successful
+			// main merge rewrites link 0 (setGSSMainLink) of surviving nodes during
+			// dispatch, so every root->head shape prefix cached in the active merge
+			// scratch may now be stale. p.mergeScratch is nil outside a parse and
+			// bumpShapePrefixEpoch is nil-safe.
+			p.mergeScratch.bumpShapePrefixEpoch()
+		}
 	}
 	return merged
 }
@@ -3011,6 +3040,10 @@ func stackEntryNodesEquivalentIgnoringDynamic(a, b *Node) bool {
 
 func setGSSMainLink(n *gssNode, i int, prev *gssNode, entry stackEntry) {
 	if i == 0 {
+		// Rewriting link 0 changes n's prev chain and payload, so every
+		// cached GSS prefix aggregate at or above n is stale (see
+		// gssPrefixAggGen, parser_recover_c.go).
+		gssPrefixAggGen.Add(1)
 		n.prev = prev
 		n.entry = entry
 		return
@@ -3671,10 +3704,16 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 		return false, true
 	}
 	merged = gssMainMergeWithScratch(scratch, &result[idx], stack)
-	if merged && scratch != nil {
-		// A successful main merge can rewrite link 0 (prev/entry) of surviving
-		// nodes (setGSSMainLink), so every cached spine prefix may be stale.
-		scratch.bumpShapePrefixEpoch()
+	if merged {
+		// result[idx] survives and absorbs stack, so OR the sticky wreckage bit:
+		// a clean survivor that merges a recovered-wreckage lineage must inherit
+		// its error history (see glrStack.cEverErrored / tryGSSMainMergeForParser).
+		result[idx].cEverErrored = result[idx].cEverErrored || stack.cEverErrored
+		if scratch != nil {
+			// A successful main merge can rewrite link 0 (prev/entry) of surviving
+			// nodes (setGSSMainLink), so every cached spine prefix may be stale.
+			scratch.bumpShapePrefixEpoch()
+		}
 	}
 	return merged, true
 }

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -16,6 +16,20 @@ type gssNode struct {
 	// extraLinks holds links 1..k after a gated lossless condense merge. The
 	// inline (prev, entry) pair remains link 0.
 	extraLinks []gssMainLink
+
+	// Prefix aggregates for the C-recovery cost competition: the cumulative
+	// error cost / visible subtree count of the link-0 prev chain root..this
+	// node inclusive — the port of C StackNode.error_cost / node_count
+	// maintained at push (stack.c stack_node_new), read O(1) by
+	// ts_stack_error_cost (stack.c:493). Valid only while the matching gen
+	// field equals gssPrefixAggGen (parser_recover_c.go); allocNode resets the
+	// gens to 0 (never valid — the counter starts at 1). aggCost is filled by
+	// both the parser-side and merge-side walks (identical math); aggVis only
+	// by the parser side, hence the separate gen.
+	aggGen    uint64
+	aggVisGen uint64
+	aggCost   uint32
+	aggVis    int32
 }
 
 type gssMainLink struct {
@@ -375,6 +389,8 @@ func (s *gssScratch) allocNode(entry stackEntry, prev *gssNode, depth int) *gssN
 			n.depth = depth
 			n.hash = hash
 			n.extraLinks = nil
+			n.aggGen = 0
+			n.aggVisGen = 0
 			return n
 		}
 	}
@@ -426,6 +442,8 @@ func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth int, h
 		n.depth = depth
 		n.hash = hash
 		n.extraLinks = nil
+		n.aggGen = 0
+		n.aggVisGen = 0
 		if s.audit != nil {
 			s.audit.recordGSSAlloc(n)
 		}

--- a/grammars/dart_scanner_test.go
+++ b/grammars/dart_scanner_test.go
@@ -3,12 +3,15 @@
 package grammars
 
 import (
+	"slices"
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 )
 
-func TestDartExternalScannerBindsShiftedExternalSymbolsByName(t *testing.T) {
+func TestDartExternalScannerBindsExternalSymbolsPositionally(t *testing.T) {
+	// Positional binding: external index i binds to scanner token i. The Language
+	// names here are a shuffled subset; positional binding maps by position.
 	lang := dartExternalBindingTestLanguage(
 		"_extension_only",
 		"_documentation_block_comment",
@@ -21,33 +24,22 @@ func TestDartExternalScannerBindsShiftedExternalSymbolsByName(t *testing.T) {
 	if !ok {
 		t.Fatalf("DartExternalScanner binding type = %T, want DartExternalScanner", DartExternalScanner{}.ExternalScannerForLanguage(lang))
 	}
-	if got, want := scanner.externalToToken[0], -1; got != want {
-		t.Fatalf("extension-only external mapped to token %d, want %d", got, want)
+	if got, want := scanner.externalToToken, []int{0, 1, 2, 3, 4}; !slices.Equal(got, want) {
+		t.Fatalf("dart externalToToken = %v, want %v", got, want)
 	}
-	if got, want := scanner.externalToToken[1], dartTokDocBlockComment; got != want {
-		t.Fatalf("doc-comment external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.externalToToken[2], dartTokTemplateCharsRawSlash; got != want {
-		t.Fatalf("raw-slash external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.externalToToken[3], dartTokTemplateCharsDouble; got != want {
-		t.Fatalf("template-double external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.symbols[dartTokTemplateCharsDouble], gotreesitter.Symbol(4); got != want {
-		t.Fatalf("template-double result symbol = %d, want %d", got, want)
-	}
-	if got, want := scanner.symbols[dartTokDocBlockComment], gotreesitter.Symbol(2); got != want {
-		t.Fatalf("doc-comment result symbol = %d, want %d", got, want)
+	// External index 3 -> scanner token 3 (single-single template chars), symbol 4.
+	if got, want := scanner.symbols[dartTokTemplateCharsSingleSingle], gotreesitter.Symbol(4); got != want {
+		t.Fatalf("token 3 result symbol = %d, want %d", got, want)
 	}
 
 	validExternal := []bool{false, false, false, true, false}
 	var semanticValid [dartTokenCount]bool
 	validSemantic := scanner.remapValidSymbols(validExternal, &semanticValid)
-	if !validSemantic[dartTokTemplateCharsDouble] {
-		t.Fatalf("shifted template-double external did not become valid semantic token: %v", validSemantic)
+	if !validSemantic[dartTokTemplateCharsSingleSingle] {
+		t.Fatalf("external index 3 did not become valid semantic token 3: %v", validSemantic)
 	}
 	if got, want := dartTemplateResultSymbol(validSemantic, scanner.symbolTable()), gotreesitter.Symbol(4); got != want {
-		t.Fatalf("template scanner result symbol = %d, want shifted symbol %d", got, want)
+		t.Fatalf("template scanner result symbol = %d, want %d", got, want)
 	}
 }
 

--- a/grammars/external_scanner_binding.go
+++ b/grammars/external_scanner_binding.go
@@ -1,11 +1,48 @@
 package grammars
 
-import gotreesitter "github.com/odvcencio/gotreesitter"
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
 
 func bindExternalScannerSpec(lang *gotreesitter.Language, spec ExternalScannerSpec, setSymbol func(int, gotreesitter.Symbol)) []int {
 	return bindExternalScannerSymbolNames(lang, spec.Externals, setSymbol)
 }
 
+// bindExternalScannerSymbolNames binds a hand-written scanner's token slots to a
+// Language's external symbols POSITIONALLY: external index i is scanner spec
+// token i, for every language provenance.
+//
+// Why positional and not by name: a hand-written scanner's spec.Externals array
+// is ordered by scanner token index, and every Language's ExternalSymbols slice
+// is emitted in the same grammar-external order (both the ts2go blobs and the
+// grammargen assembler preserve the upstream `externals: [...]` order). Empirically
+// spec order == grammar-external order at every index for all five name-binding
+// languages (kotlin/python/swift/dart/rust), so positional binding reproduces the
+// previous by-name bindings exactly while ALSO rescuing literal-valued externals
+// whose Language *display* name differs from the spec *rule* name.
+//
+// The old by-name algorithm compared spec rule names (e.g. "safe_nav") against
+// Language symbol names, but SymbolNames stores DISPLAY text for literal-valued
+// tokens (e.g. "\?."), so those externals never matched and were left unbound
+// (externalToToken[i] == -1). An unbound external means the scanner is never told
+// the token is valid, so the corresponding source mislexes: kotlin `?.`, and
+// swift's 18 custom operators (`->`, `.`, `&&`, `||`, `??`, `=`, `==`, `+`, `-`,
+// `as`, `as?`, `as!`, `async`, `#`, `#if`, `#elseif`, `#else`, `#endif`). swift's
+// were previously rescued only by an incidental GeneratedByGrammargen provenance
+// flag; positional binding makes the rescue robust for every provenance.
+//
+// Name comparison is retained as VERIFICATION ONLY: when the Language symbol name
+// at index i disagrees with the spec token name at index i, the binding is still
+// made positionally and a drift event is recorded (see noteExternalBindingDrift)
+// so a genuine spec/grammar ordering skew is observable instead of silent.
+//
+// The returned slice maps external index -> scanner token index (or -1 when an
+// external has no corresponding scanner token). setSymbol(tokenIdx, sym) records
+// the concrete Language Symbol for each bound scanner token.
 func bindExternalScannerSymbolNames(lang *gotreesitter.Language, names []string, setSymbol func(int, gotreesitter.Symbol)) []int {
 	if lang == nil {
 		return nil
@@ -15,42 +52,33 @@ func bindExternalScannerSymbolNames(lang *gotreesitter.Language, names []string,
 	for i := range externalToToken {
 		externalToToken[i] = -1
 	}
-	matched := make([]bool, len(names))
 
-	for externalIdx, sym := range lang.ExternalSymbols {
-		name := externalScannerSymbolName(lang, sym)
-		for tokenIdx, want := range names {
-			if matched[tokenIdx] || name != want {
-				continue
+	// Bind min(externals, specTokens): external index i binds to scanner token i.
+	bindCount := len(externalToToken)
+	if len(names) < bindCount {
+		bindCount = len(names)
+	}
+	for i := 0; i < bindCount; i++ {
+		sym := lang.ExternalSymbols[i]
+		setSymbol(i, sym)
+		externalToToken[i] = i
+
+		// Verification only: flag (but do not act on) a name disagreement between
+		// the Language symbol name and the scanner spec token name at this index.
+		if want := names[i]; want != "" {
+			if got := externalScannerSymbolName(lang, sym); got != "" && got != want {
+				noteExternalBindingDrift(i, got, want)
 			}
-			setSymbol(tokenIdx, sym)
-			externalToToken[externalIdx] = tokenIdx
-			matched[tokenIdx] = true
-			break
 		}
 	}
 
-	// Fall back to positional binding for generated languages, whose external
-	// symbol order is preserved from grammargen SetExternals, and for test
-	// languages that do not carry symbol names. Named mismatches stay unbound for
-	// arbitrary languages so unrelated scanner tokens cannot bind to unrelated
-	// named target externals.
-	unmappedExternalIdx := 0
-	for tokenIdx, wasMatched := range matched {
-		if wasMatched {
-			continue
-		}
-		for unmappedExternalIdx < len(externalToToken) &&
-			(externalToToken[unmappedExternalIdx] != -1 ||
-				(!lang.GeneratedByGrammargen && names[tokenIdx] != "" &&
-					externalScannerSymbolName(lang, lang.ExternalSymbols[unmappedExternalIdx]) != "")) {
-			unmappedExternalIdx++
-		}
-		if unmappedExternalIdx >= len(lang.ExternalSymbols) {
-			break
-		}
-		setSymbol(tokenIdx, lang.ExternalSymbols[unmappedExternalIdx])
-		externalToToken[unmappedExternalIdx] = tokenIdx
+	// Length mismatch preserves the historical structure: externalToToken has one
+	// slot per Language external. When the spec declares more tokens than the
+	// Language exposes externals, the surplus scanner tokens keep their default
+	// symbols (setSymbol is never called for them). When the Language exposes more
+	// externals than the spec declares, the surplus externals stay -1 (no token).
+	if len(names) != len(externalToToken) {
+		noteExternalBindingLengthMismatch(len(names), len(externalToToken), bindCount)
 	}
 
 	return externalToToken
@@ -61,4 +89,85 @@ func externalScannerSymbolName(lang *gotreesitter.Language, sym gotreesitter.Sym
 		return ""
 	}
 	return lang.SymbolNames[sym]
+}
+
+// ---- positional-binding drift diagnostics (verification only) ----
+
+// externalBindingDrift records one external index whose Language symbol name
+// disagreed with the scanner spec token name at the same index. Positional
+// binding is authoritative; drift entries are diagnostic signal only. Benign
+// display-vs-rule-name disagreements (e.g. kotlin safe_nav display "\?." vs spec
+// "safe_nav", swift's 18 custom operators) drift, and so would a genuine
+// spec/grammar ordering skew that warrants investigation.
+type externalBindingDrift struct {
+	Index int
+	Got   string // Language symbol (display/rule) name at this external index
+	Want  string // scanner spec token name at this index
+}
+
+var (
+	externalBindingDriftMu      sync.Mutex
+	externalBindingDriftCount   int
+	externalBindingDriftCapture bool
+	externalBindingDriftLog     []externalBindingDrift
+
+	externalBindingDebugOnce sync.Once
+	externalBindingDebug     bool
+)
+
+// externalBindingDebugEnabled reports whether GOT_DEBUG_EXTERNAL_BINDING=1 is set,
+// matching the repo's env-gated stderr debug idiom (cf. the GOT_DEBUG_* /
+// GOT_EAGER_DEFAULT_REDUCE_DEBUG toggles elsewhere in the tree).
+func externalBindingDebugEnabled() bool {
+	externalBindingDebugOnce.Do(func() {
+		externalBindingDebug = os.Getenv("GOT_DEBUG_EXTERNAL_BINDING") == "1"
+	})
+	return externalBindingDebug
+}
+
+func noteExternalBindingDrift(index int, got, want string) {
+	externalBindingDriftMu.Lock()
+	externalBindingDriftCount++
+	if externalBindingDriftCapture {
+		externalBindingDriftLog = append(externalBindingDriftLog, externalBindingDrift{Index: index, Got: got, Want: want})
+	}
+	externalBindingDriftMu.Unlock()
+
+	if externalBindingDebugEnabled() {
+		fmt.Fprintf(os.Stderr, "GOT-EXTERNAL-BINDING drift index=%d got=%q want=%q (positional binding kept)\n", index, got, want)
+	}
+}
+
+func noteExternalBindingLengthMismatch(specTokens, externals, bound int) {
+	if externalBindingDebugEnabled() {
+		fmt.Fprintf(os.Stderr, "GOT-EXTERNAL-BINDING length-mismatch specTokens=%d externals=%d bound=%d\n", specTokens, externals, bound)
+	}
+}
+
+// externalBindingDriftBeginCapture starts collecting drift entries into a log for
+// inspection and clears any previously captured entries. Test-facing.
+func externalBindingDriftBeginCapture() {
+	externalBindingDriftMu.Lock()
+	externalBindingDriftCapture = true
+	externalBindingDriftLog = nil
+	externalBindingDriftMu.Unlock()
+}
+
+// externalBindingDriftEndCapture stops collecting drift entries and returns those
+// captured since the matching begin. Test-facing.
+func externalBindingDriftEndCapture() []externalBindingDrift {
+	externalBindingDriftMu.Lock()
+	out := externalBindingDriftLog
+	externalBindingDriftLog = nil
+	externalBindingDriftCapture = false
+	externalBindingDriftMu.Unlock()
+	return out
+}
+
+// externalBindingDriftTotal returns the process-wide count of positional bindings
+// that disagreed with their spec token name. Test-facing.
+func externalBindingDriftTotal() int {
+	externalBindingDriftMu.Lock()
+	defer externalBindingDriftMu.Unlock()
+	return externalBindingDriftCount
 }

--- a/grammars/external_scanner_binding_test.go
+++ b/grammars/external_scanner_binding_test.go
@@ -58,7 +58,10 @@ func TestKotlinSwiftExternalScannerSpecs(t *testing.T) {
 	}
 }
 
-func TestLanguageBoundExternalScannersBindBySymbolName(t *testing.T) {
+func TestLanguageBoundExternalScannersBindPositionally(t *testing.T) {
+	// Positional binding: external index i binds to scanner token i for every
+	// provenance. These synthetic languages present a shuffled subset of the real
+	// externals; positional binding maps them by position, not by symbol name.
 	kotlinLang := externalBindingTestLanguage(
 		"_extension_only",
 		"_import_dot",
@@ -69,12 +72,13 @@ func TestLanguageBoundExternalScannersBindBySymbolName(t *testing.T) {
 	if !ok {
 		t.Fatalf("KotlinExternalScanner binding type = %T, want KotlinExternalScanner", KotlinExternalScanner{}.ExternalScannerForLanguage(kotlinLang))
 	}
-	if got, want := kotlinScanner.externalToToken[0], -1; got != want {
-		t.Fatalf("kotlin extension-only external mapped to token %d, want %d", got, want)
+	if got, want := kotlinScanner.externalToToken, []int{0, 1, 2, 3}; !slices.Equal(got, want) {
+		t.Fatalf("kotlin externalToToken = %v, want %v", got, want)
 	}
-	if got, want := kotlinScanner.externalToToken[1], kotlinTokImportDot; got != want {
-		t.Fatalf("kotlin import-dot external mapped to token %d, want %d", got, want)
-	}
+	// safe_nav sits at external index 2 == scanner token index 2, so positional
+	// binding lands it on kotlinTokSafeNav with its real symbol (3 here). By-name
+	// binding dropped this slot for the real grammar because the Language display
+	// name is "\?." rather than the spec rule name "safe_nav".
 	if got, want := kotlinScanner.externalToToken[2], kotlinTokSafeNav; got != want {
 		t.Fatalf("kotlin safe-nav external mapped to token %d, want %d", got, want)
 	}
@@ -91,21 +95,15 @@ func TestLanguageBoundExternalScannersBindBySymbolName(t *testing.T) {
 	if !ok {
 		t.Fatalf("SwiftExternalScanner binding type = %T, want SwiftExternalScanner", SwiftExternalScanner{}.ExternalScannerForLanguage(swiftLang))
 	}
-	if got, want := swiftScanner.externalToToken[0], swtTokFakeTryBang; got != want {
-		t.Fatalf("swift fake-try-bang external mapped to token %d, want %d", got, want)
+	if got, want := swiftScanner.externalToToken, []int{0, 1, 2}; !slices.Equal(got, want) {
+		t.Fatalf("swift externalToToken = %v, want %v", got, want)
 	}
-	if got, want := swiftScanner.externalToToken[1], swtTokElseKeyword; got != want {
-		t.Fatalf("swift else external mapped to token %d, want %d", got, want)
-	}
-	if got, want := swiftScanner.externalToToken[2], swtTokDirectiveElse; got != want {
-		t.Fatalf("swift directive-else external mapped to token %d, want %d", got, want)
-	}
-	if got, want := swiftScanner.symbols[swtTokDirectiveElse], gotreesitter.Symbol(3); got != want {
-		t.Fatalf("swift directive-else result symbol = %d, want %d", got, want)
+	if got, want := swiftScanner.symbols[2], gotreesitter.Symbol(3); got != want {
+		t.Fatalf("swift token-2 result symbol = %d, want %d", got, want)
 	}
 }
 
-func TestExternalScannerBindingFallbackUsesUnmappedExternalSymbols(t *testing.T) {
+func TestExternalScannerBindingBindsPositionally(t *testing.T) {
 	lang := externalBindingTestLanguage(
 		"",
 		"named_two",
@@ -122,21 +120,26 @@ func TestExternalScannerBindingFallbackUsesUnmappedExternalSymbols(t *testing.T)
 		symbols[tokenIdx] = sym
 	})
 
-	if got, want := externalToToken, []int{0, 2, 1}; !slices.Equal(got, want) {
+	// External index i binds to token i; empty and mismatched Language names do
+	// not change the mapping.
+	if got, want := externalToToken, []int{0, 1, 2}; !slices.Equal(got, want) {
 		t.Fatalf("externalToToken = %v, want %v", got, want)
 	}
 	if got, want := symbols[0], gotreesitter.Symbol(1); got != want {
-		t.Fatalf("fallback token 0 symbol = %d, want %d", got, want)
+		t.Fatalf("token 0 symbol = %d, want %d", got, want)
 	}
-	if got, want := symbols[1], gotreesitter.Symbol(3); got != want {
-		t.Fatalf("fallback token 1 symbol = %d, want %d", got, want)
+	if got, want := symbols[1], gotreesitter.Symbol(2); got != want {
+		t.Fatalf("token 1 symbol = %d, want %d", got, want)
 	}
-	if got, want := symbols[2], gotreesitter.Symbol(2); got != want {
-		t.Fatalf("named token 2 symbol = %d, want %d", got, want)
+	if got, want := symbols[2], gotreesitter.Symbol(3); got != want {
+		t.Fatalf("token 2 symbol = %d, want %d", got, want)
 	}
 }
 
-func TestExternalScannerBindingDoesNotFallbackForNamedMismatch(t *testing.T) {
+func TestExternalScannerBindingPositionalRecordsNameDrift(t *testing.T) {
+	// Positional binding ignores name disagreement (the old algorithm left these
+	// unbound as [-1, 2, -1]); every disagreeing index is recorded as drift so a
+	// genuine spec/grammar ordering skew is observable instead of silent.
 	lang := externalBindingTestLanguage(
 		"alias_zero",
 		"named_two",
@@ -149,53 +152,108 @@ func TestExternalScannerBindingDoesNotFallbackForNamedMismatch(t *testing.T) {
 	}
 
 	symbols := make([]gotreesitter.Symbol, len(names))
+	externalBindingDriftBeginCapture()
+	t.Cleanup(func() { externalBindingDriftEndCapture() })
 	externalToToken := bindExternalScannerSymbolNames(lang, names, func(tokenIdx int, sym gotreesitter.Symbol) {
 		symbols[tokenIdx] = sym
 	})
-
-	if got, want := externalToToken, []int{-1, 2, -1}; !slices.Equal(got, want) {
-		t.Fatalf("externalToToken = %v, want %v", got, want)
-	}
-	if got, want := symbols[0], gotreesitter.Symbol(0); got != want {
-		t.Fatalf("unmatched token 0 symbol = %d, want %d", got, want)
-	}
-	if got, want := symbols[1], gotreesitter.Symbol(0); got != want {
-		t.Fatalf("unmatched token 1 symbol = %d, want %d", got, want)
-	}
-	if got, want := symbols[2], gotreesitter.Symbol(2); got != want {
-		t.Fatalf("named token 2 symbol = %d, want %d", got, want)
-	}
-}
-
-func TestExternalScannerBindingFallbackKeepsGeneratedOrderAliases(t *testing.T) {
-	lang := externalBindingTestLanguage(
-		"alias_zero",
-		"alias_one",
-		"alias_two",
-	)
-	lang.GeneratedByGrammargen = true
-	names := []string{
-		"scanner_zero",
-		"scanner_one",
-		"scanner_two",
-	}
-
-	symbols := make([]gotreesitter.Symbol, len(names))
-	externalToToken := bindExternalScannerSymbolNames(lang, names, func(tokenIdx int, sym gotreesitter.Symbol) {
-		symbols[tokenIdx] = sym
-	})
+	drift := externalBindingDriftEndCapture()
 
 	if got, want := externalToToken, []int{0, 1, 2}; !slices.Equal(got, want) {
 		t.Fatalf("externalToToken = %v, want %v", got, want)
 	}
 	if got, want := symbols[0], gotreesitter.Symbol(1); got != want {
-		t.Fatalf("generated alias token 0 symbol = %d, want %d", got, want)
+		t.Fatalf("token 0 symbol = %d, want %d", got, want)
 	}
 	if got, want := symbols[1], gotreesitter.Symbol(2); got != want {
-		t.Fatalf("generated alias token 1 symbol = %d, want %d", got, want)
+		t.Fatalf("token 1 symbol = %d, want %d", got, want)
 	}
 	if got, want := symbols[2], gotreesitter.Symbol(3); got != want {
-		t.Fatalf("generated alias token 2 symbol = %d, want %d", got, want)
+		t.Fatalf("token 2 symbol = %d, want %d", got, want)
+	}
+	if len(drift) != 3 {
+		t.Fatalf("drift entries = %d (%v), want 3 (every index disagrees)", len(drift), drift)
+	}
+}
+
+// TestExternalBindingDriftFiresOnMismatchSilentOnAligned and
+// TestExternalBindingLengthMismatchBindsMin live in this file, rather than in
+// external_scanner_positional_binding_test.go (gated !grammar_subset only),
+// because neither depends on any real language: both exercise
+// bindExternalScannerSymbolNames purely through the synthetic
+// externalBindingTestLanguage fixture below. This file's broader tag keeps them
+// visible to grammar_subset builds that select kotlin+swift.
+
+// TestExternalBindingDriftFiresOnMismatchSilentOnAligned verifies the
+// verification-only drift signal: aligned specs are silent, name disagreements are
+// recorded (with their index), and empty Language names never drift.
+func TestExternalBindingDriftFiresOnMismatchSilentOnAligned(t *testing.T) {
+	totalBefore := externalBindingDriftTotal()
+
+	// Aligned: Language symbol names match spec names at every index -> no drift.
+	aligned := externalBindingTestLanguage("alpha", "beta", "gamma")
+	externalBindingDriftBeginCapture()
+	t.Cleanup(func() { externalBindingDriftEndCapture() })
+	bindExternalScannerSymbolNames(aligned, []string{"alpha", "beta", "gamma"}, func(int, gotreesitter.Symbol) {})
+	if drift := externalBindingDriftEndCapture(); len(drift) != 0 {
+		t.Fatalf("aligned spec produced drift: %v", drift)
+	}
+
+	// Skewed at indices 0 and 2; index 1 matches.
+	skewed := externalBindingTestLanguage("alpha", "beta", "gamma")
+	externalBindingDriftBeginCapture()
+	t.Cleanup(func() { externalBindingDriftEndCapture() })
+	bindExternalScannerSymbolNames(skewed, []string{"ALPHA", "beta", "GAMMA"}, func(int, gotreesitter.Symbol) {})
+	drift := externalBindingDriftEndCapture()
+	if len(drift) != 2 {
+		t.Fatalf("skewed spec drift = %d (%v), want 2", len(drift), drift)
+	}
+	if drift[0].Index != 0 || drift[1].Index != 2 {
+		t.Fatalf("drift indices = %v, want [0 2]", drift)
+	}
+	if drift[0].Got != "alpha" || drift[0].Want != "ALPHA" {
+		t.Fatalf("drift[0] = %+v, want got=alpha want=ALPHA", drift[0])
+	}
+
+	// Empty Language names cannot be verified and never drift.
+	unnamed := externalBindingTestLanguage("", "", "")
+	externalBindingDriftBeginCapture()
+	t.Cleanup(func() { externalBindingDriftEndCapture() })
+	bindExternalScannerSymbolNames(unnamed, []string{"a", "b", "c"}, func(int, gotreesitter.Symbol) {})
+	if drift := externalBindingDriftEndCapture(); len(drift) != 0 {
+		t.Fatalf("empty Language names produced drift: %v", drift)
+	}
+
+	// The process-wide counter tracks every disagreement; only the skewed bind
+	// above contributed (two indices). This test is non-parallel, so no other
+	// binder call overlaps this delta.
+	if got := externalBindingDriftTotal() - totalBefore; got != 2 {
+		t.Fatalf("drift counter delta = %d, want 2", got)
+	}
+}
+
+// TestExternalBindingLengthMismatchBindsMin documents the length-mismatch contract:
+// bind min(externals, specTokens); surplus scanner tokens keep defaults (never
+// bound), surplus externals stay -1.
+func TestExternalBindingLengthMismatchBindsMin(t *testing.T) {
+	// Spec longer than externals: only the first len(externals) tokens are bound.
+	lang := externalBindingTestLanguage("a", "b")
+	var boundTokens []int
+	ett := bindExternalScannerSymbolNames(lang, []string{"a", "b", "c", "d"}, func(tok int, _ gotreesitter.Symbol) {
+		boundTokens = append(boundTokens, tok)
+	})
+	if got, want := ett, []int{0, 1}; !slices.Equal(got, want) {
+		t.Fatalf("spec-longer externalToToken = %v, want %v", got, want)
+	}
+	if got, want := boundTokens, []int{0, 1}; !slices.Equal(got, want) {
+		t.Fatalf("spec-longer bound tokens = %v, want %v", got, want)
+	}
+
+	// Externals longer than spec: surplus externals stay unbound (-1).
+	lang2 := externalBindingTestLanguage("a", "b", "c", "d")
+	ett2 := bindExternalScannerSymbolNames(lang2, []string{"a", "b"}, func(int, gotreesitter.Symbol) {})
+	if got, want := ett2, []int{0, 1, -1, -1}; !slices.Equal(got, want) {
+		t.Fatalf("externals-longer externalToToken = %v, want %v", got, want)
 	}
 }
 

--- a/grammars/external_scanner_positional_binding_test.go
+++ b/grammars/external_scanner_positional_binding_test.go
@@ -1,0 +1,198 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"slices"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// parseHasError parses src with lang and reports whether the resulting tree has
+// any error, returning the s-expression for diagnostics.
+func parseHasError(t *testing.T, lang *gotreesitter.Language, src string) (bool, string) {
+	t.Helper()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("parse returned nil root")
+	}
+	return root.HasError(), root.SExpr(lang)
+}
+
+// TestKotlinSafeNavParsesClean is the audit's regression witness. Under the old
+// by-name binder the kotlin safe-nav external (spec rule "safe_nav") never bound
+// because the Language display name is "\?.", so `?.` mislexed and every use
+// produced a spurious ERROR. Positional binding lands safe_nav on scanner token 2.
+//
+// This test FAILS on main (err on the safe-nav cases) and PASSES with the fix.
+func TestKotlinSafeNavParsesClean(t *testing.T) {
+	lang := KotlinLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"safe_nav", "fun f() { val x = a?.b }"},
+		{"safe_nav_chain", "fun f() { val x = a?.b?.c }"},
+		{"plain_dot_control", "fun f() { val x = a.b }"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hasErr, sexpr := parseHasError(t, lang, tc.src)
+			if hasErr {
+				t.Fatalf("kotlin %q parsed with errors:\n%s", tc.src, sexpr)
+			}
+		})
+	}
+}
+
+// TestSwiftDisplayMismatchedExternalsParseClean guards the 18 swift externals
+// whose Language display name differs from their spec rule name (->, ??, as?,
+// as!, ...). They were previously rescued only by the GeneratedByGrammargen
+// provenance flag; positional binding makes the rescue provenance-independent.
+func TestSwiftDisplayMismatchedExternalsParseClean(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"nil_coalescing", "let x = a ?? b"},
+		{"as_quest", "let y = a as? B"},
+		{"as_bang", "let z = a as! B"},
+		{"arrow", "func f() -> Int { return 0 }"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hasErr, sexpr := parseHasError(t, lang, tc.src)
+			if hasErr {
+				t.Fatalf("swift %q parsed with errors:\n%s", tc.src, sexpr)
+			}
+		})
+	}
+}
+
+// TestDartAndRustScannerWitnessesParseClean closes the audit's lower-confidence
+// edges: dart nestable/doc block comments and rust raw strings + lifetimes all
+// flow through externals whose binding must remain intact under positional.
+func TestDartAndRustScannerWitnessesParseClean(t *testing.T) {
+	dart := DartLanguage()
+	for _, tc := range []struct{ name, src string }{
+		{"doc_block_comment", "/** x */\nvoid main() {}"},
+		{"nested_block_comment", "void main() { /* a /* b */ c */ }"},
+	} {
+		t.Run("dart_"+tc.name, func(t *testing.T) {
+			hasErr, sexpr := parseHasError(t, dart, tc.src)
+			if hasErr {
+				t.Fatalf("dart %q parsed with errors:\n%s", tc.src, sexpr)
+			}
+		})
+	}
+
+	rust := RustLanguage()
+	for _, tc := range []struct{ name, src string }{
+		{"raw_string", `fn main() { let s = r"x"; }`},
+		{"raw_string_hash", `fn main() { let s = r#"x"#; }`},
+		{"lifetimes", "fn f<'a>(x: &'a str) -> &'a str { x }"},
+	} {
+		t.Run("rust_"+tc.name, func(t *testing.T) {
+			hasErr, sexpr := parseHasError(t, rust, tc.src)
+			if hasErr {
+				t.Fatalf("rust %q parsed with errors:\n%s", tc.src, sexpr)
+			}
+		})
+	}
+}
+
+// TestRealLanguageExternalBindingTablesArePositional pins the exact externalToToken
+// table for every name-binding language. python/swift/dart/rust are unchanged from
+// the by-name binder; kotlin gains its previously-dropped safe_nav slot (index 2).
+//
+// Each language block also asserts the scanner's post-bind symbols table equals
+// that scanner's package-level Default*SymTable. For every canonical (checked-in)
+// grammar blob, Language.ExternalSymbols is in the same order as the hand-written
+// scanner's Default*SymTable, so this equality is non-tautological: positional
+// binding sets symbols[i] = lang.ExternalSymbols[i], while Default*SymTable[i] is
+// the scanner author's independently recorded expectation for that same slot. A
+// future external REORDER (two upstream externals swapping positions in a grammar
+// regeneration) would still produce the trivial identity externalToToken
+// ([0,1,2,...]) checked above -- that check never looks at symbol values, so it
+// cannot see a reorder -- but the bound symbols would then disagree with
+// Default*SymTable and this assertion would fail. All five scanners expose their
+// default table as a package-level var (kotlinDefaultSymTable, pyDefaultSymTable,
+// swtDefaultSymTable, dartDefaultSymTable, rustDefaultSymTable), so every language
+// below compares its post-bind symbols directly against that var; none needed the
+// lang.ExternalSymbols[i]-by-index fallback.
+//
+// KNOWN FAILING for python and swift as of this writing, and NOT a positional-
+// binding bug: both python_scanner.go's pyDefaultSymTable and swift_scanner.go's
+// swtDefaultSymTable are stale relative to the currently checked-in python.bin /
+// swift.bin (confirmed pre-existing: both scanner files are untouched in this
+// tree's uncommitted diff, and the drift reproduces in isolation with no other
+// test bodies executed, ruling out cross-test mutation of the cached Language
+// singleton). python: all 12 slots are shifted (e.g. index 0 "_newline" is live
+// symbol 101 vs. pyDefaultSymTable's 102). swift: 32 of 33 slots are shifted by a
+// uniform +10, and index 30 ("_directive_else") carries an unrelated, independent
+// bug: swtSymDirectiveElse = 530, wildly outside the ~180-222 range of every
+// neighboring swift external symbol. kotlin, dart, and rust match their default
+// tables exactly. This assertion is deliberately left strict rather than softened
+// for python/swift: weakening it would defeat its purpose for precisely the two
+// languages where it has already caught real drift. Fixing pySym*/swtSym* lives in
+// python_scanner.go/swift_scanner.go, outside this test file's scope.
+func TestRealLanguageExternalBindingTablesArePositional(t *testing.T) {
+	kotlin := KotlinExternalScanner{}.ExternalScannerForLanguage(KotlinLanguage()).(KotlinExternalScanner)
+	if got, want := kotlin.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8}; !slices.Equal(got, want) {
+		t.Fatalf("kotlin externalToToken = %v, want %v (safe_nav at index 2 must bind)", got, want)
+	}
+	if got, want := kotlin.symbols, kotlinDefaultSymTable; got != want {
+		t.Fatalf("kotlin post-bind symbols = %v, want default table %v (an ExternalSymbols reorder would still pass the externalToToken check above)", got, want)
+	}
+
+	python := PythonExternalScanner{}.ExternalScannerForLanguage(PythonLanguage()).(PythonExternalScanner)
+	if got, want := python.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}; !slices.Equal(got, want) {
+		t.Fatalf("python externalToToken = %v, want %v", got, want)
+	}
+	if got, want := python.symbols, pyDefaultSymTable; got != want {
+		t.Fatalf("python post-bind symbols = %v, want default table %v", got, want)
+	}
+
+	swift := SwiftExternalScanner{}.ExternalScannerForLanguage(SwiftLanguage()).(SwiftExternalScanner)
+	wantSwift := make([]int, swtTokenCount)
+	for i := range wantSwift {
+		wantSwift[i] = i
+	}
+	if got := swift.externalToToken; !slices.Equal(got, wantSwift) {
+		t.Fatalf("swift externalToToken = %v, want %v", got, wantSwift)
+	}
+	if got, want := swift.symbols, swtDefaultSymTable; got != want {
+		t.Fatalf("swift post-bind symbols = %v, want default table %v", got, want)
+	}
+
+	dart := DartExternalScanner{}.ExternalScannerForLanguage(DartLanguage()).(DartExternalScanner)
+	if got, want := dart.externalToToken, []int{0, 1, 2, 3, 4, 5, 6}; !slices.Equal(got, want) {
+		t.Fatalf("dart externalToToken = %v, want %v", got, want)
+	}
+	if got, want := dart.symbols, dartDefaultSymTable; got != want {
+		t.Fatalf("dart post-bind symbols = %v, want default table %v", got, want)
+	}
+
+	rust := RustExternalScanner{}.ExternalScannerForLanguage(RustLanguage()).(RustExternalScanner)
+	if got, want := rust.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}; !slices.Equal(got, want) {
+		t.Fatalf("rust externalToToken = %v, want %v", got, want)
+	}
+	if got, want := rust.symbols, rustDefaultSymTable; got != want {
+		t.Fatalf("rust post-bind symbols = %v, want default table %v", got, want)
+	}
+}
+
+// Note: the pure-unit drift and length-mismatch tests for
+// bindExternalScannerSymbolNames (no real-language dependency) live in
+// external_scanner_binding_test.go, not here. This file is gated !grammar_subset
+// only, so a test with zero real-language dependency has no reason to be invisible
+// to every grammar_subset build; the sibling file's broader tag keeps it visible to
+// grammar_subset builds that select kotlin+swift.

--- a/grammars/php_comma_list_defusal_regression_test.go
+++ b/grammars/php_comma_list_defusal_regression_test.go
@@ -1,0 +1,69 @@
+package grammars
+
+import (
+	"strings"
+	"testing"
+
+	ts "github.com/odvcencio/gotreesitter"
+)
+
+// TestPHPGiantArrayCommaListDefusalStaysLinear pins the quadratic-defusal side
+// of the php comma-list gate (conflict_policy.go). The giant-data-array class
+// this collapse exists for — Symfony emoji/Intl tables — is clean input that
+// never enters C error handling, so the sticky glrStack.cEverErrored bit added
+// for the wreckage-exclusion hardening stays false and the deterministic
+// comma-list-repeat fold must still fire. When it fires the parse is single
+// stack and linear (~9 nodes per element, MaxStacksSeen==1); if the gate ever
+// stops firing on clean input (e.g. the sticky bit over-propagating to a
+// never-errored lineage) the fold is lost and the flat comma spine detonates
+// O(n^2) in allocated nodes and live stacks — the exact defusal this gate
+// exists to prevent, and the emoji-witness regression review A flagged.
+//
+// Deterministic (node/stack counts, not wall clock) so it is CI-safe.
+func TestPHPGiantArrayCommaListDefusalStaysLinear(t *testing.T) {
+	const n = 6000
+	var b strings.Builder
+	b.Grow(n*3 + 32)
+	b.WriteString("<?php $x = [")
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString("1")
+	}
+	b.WriteString("];\n")
+	src := []byte(b.String())
+
+	tree, err := ts.NewParser(PhpLanguage()).Parse(src)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("missing root node")
+	}
+	if tree.ParseStopReason() != ts.ParseStopAccepted {
+		t.Fatalf("stop=%s runtime=%s", tree.ParseStopReason(), tree.ParseRuntime().Summary())
+	}
+	if root.HasError() {
+		t.Fatalf("clean giant array reported an error; the comma-list defusal must keep it clean")
+	}
+	if got := root.EndByte(); got != uint32(len(src)) {
+		t.Fatalf("root end = %d, want %d (giant array not fully parsed)", got, len(src))
+	}
+
+	rt := tree.ParseRuntime()
+	// Fold fired => linear (~9*n nodes). A disabled fold is O(n^2): the 20*n
+	// bound clears the observed 9*n with slack while staying ~n below the
+	// quadratic blow-up (n^2 = 36e6 at n=6000, vs the 120000 bound).
+	if rt.NodesAllocated > 20*n {
+		t.Fatalf("NodesAllocated=%d exceeds linear bound %d — comma-list quadratic defusal regressed (gate stopped folding clean input); runtime=%s",
+			rt.NodesAllocated, 20*n, rt.Summary())
+	}
+	// The fold keeps the parse single-stack; a lost fold forks per element and
+	// MaxStacksSeen climbs with input size.
+	if rt.MaxStacksSeen > 16 {
+		t.Fatalf("MaxStacksSeen=%d — clean giant array must stay effectively single-stack; the defusal regressed; runtime=%s",
+			rt.MaxStacksSeen, rt.Summary())
+	}
+}

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -25,18 +25,18 @@ const (
 
 // Concrete symbol IDs from the checked-in Python grammar ExternalSymbols.
 const (
-	pySymNewline             gotreesitter.Symbol = 102
-	pySymIndent              gotreesitter.Symbol = 103
-	pySymDedent              gotreesitter.Symbol = 104
-	pySymStringStart         gotreesitter.Symbol = 105
-	pySymStringContent       gotreesitter.Symbol = 106
-	pySymEscapeInterpolation gotreesitter.Symbol = 107
-	pySymStringEnd           gotreesitter.Symbol = 108
+	pySymNewline             gotreesitter.Symbol = 101
+	pySymIndent              gotreesitter.Symbol = 102
+	pySymDedent              gotreesitter.Symbol = 103
+	pySymStringStart         gotreesitter.Symbol = 104
+	pySymStringContent       gotreesitter.Symbol = 105
+	pySymEscapeInterpolation gotreesitter.Symbol = 106
+	pySymStringEnd           gotreesitter.Symbol = 107
 	pySymComment             gotreesitter.Symbol = 99
-	pySymCloseBracket        gotreesitter.Symbol = 46
-	pySymCloseParen          gotreesitter.Symbol = 7
-	pySymCloseBrace          gotreesitter.Symbol = 52
-	pySymExcept              gotreesitter.Symbol = 35
+	pySymCloseBracket        gotreesitter.Symbol = 47
+	pySymCloseParen          gotreesitter.Symbol = 8
+	pySymCloseBrace          gotreesitter.Symbol = 53
+	pySymExcept              gotreesitter.Symbol = 33
 )
 
 var pyDefaultSymTable = [pyTokenCount]gotreesitter.Symbol{

--- a/grammars/python_scanner_binding_test.go
+++ b/grammars/python_scanner_binding_test.go
@@ -35,7 +35,9 @@ func TestPythonExternalScannerSpec(t *testing.T) {
 	}
 }
 
-func TestPythonExternalScannerBindsShiftedExternalSymbolsByName(t *testing.T) {
+func TestPythonExternalScannerBindsExternalSymbolsPositionally(t *testing.T) {
+	// Positional binding: external index i binds to scanner token i. The Language
+	// names here are a shuffled subset; positional binding maps by position.
 	lang := pythonExternalBindingTestLanguage(
 		"_extension_only",
 		"escape_interpolation",
@@ -48,30 +50,21 @@ func TestPythonExternalScannerBindsShiftedExternalSymbolsByName(t *testing.T) {
 	if !ok {
 		t.Fatalf("PythonExternalScanner binding type = %T, want PythonExternalScanner", PythonExternalScanner{}.ExternalScannerForLanguage(lang))
 	}
-	if got, want := scanner.externalToToken[0], -1; got != want {
-		t.Fatalf("extension-only external mapped to token %d, want %d", got, want)
+	if got, want := scanner.externalToToken, []int{0, 1, 2, 3, 4}; !slices.Equal(got, want) {
+		t.Fatalf("python externalToToken = %v, want %v", got, want)
 	}
-	if got, want := scanner.externalToToken[1], pyTokEscapeInterpolation; got != want {
-		t.Fatalf("escape-interpolation external mapped to token %d, want %d", got, want)
+	if got, want := scanner.externalToToken[1], pyTokIndent; got != want {
+		t.Fatalf("external index 1 mapped to token %d, want %d", got, want)
 	}
-	if got, want := scanner.externalToToken[2], pyTokIndent; got != want {
-		t.Fatalf("indent external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.externalToToken[3], pyTokStringStart; got != want {
-		t.Fatalf("string-start external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.externalToToken[4], pyTokNewline; got != want {
-		t.Fatalf("newline external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.symbols[pyTokEscapeInterpolation], gotreesitter.Symbol(2); got != want {
-		t.Fatalf("escape-interpolation result symbol = %d, want %d", got, want)
+	if got, want := scanner.symbols[pyTokIndent], gotreesitter.Symbol(2); got != want {
+		t.Fatalf("token 1 result symbol = %d, want %d", got, want)
 	}
 
 	validExternal := []bool{false, true, false, false, false}
 	var semanticValid [pyTokenCount]bool
 	validSemantic := scanner.remapValidSymbols(validExternal, &semanticValid)
-	if !validSemantic[pyTokEscapeInterpolation] {
-		t.Fatalf("shifted escape-interpolation external did not become valid semantic token: %v", validSemantic)
+	if !validSemantic[pyTokIndent] {
+		t.Fatalf("external index 1 did not become valid semantic token 1: %v", validSemantic)
 	}
 }
 

--- a/grammars/rust_scanner_test.go
+++ b/grammars/rust_scanner_test.go
@@ -3,12 +3,16 @@
 package grammars
 
 import (
+	"slices"
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 )
 
-func TestRustExternalScannerBindsGeneratedExternalSymbolsByName(t *testing.T) {
+func TestRustExternalScannerBindsExternalSymbolsPositionally(t *testing.T) {
+	// Positional binding: external index i binds to scanner token i. The duplicate
+	// "string_content" externals (indices 0 and 3) bind to their positional tokens
+	// naturally, with no name-based disambiguation.
 	lang := rustExternalBindingTestLanguage(
 		"string_content",
 		"_raw_string_literal_start",
@@ -21,33 +25,27 @@ func TestRustExternalScannerBindsGeneratedExternalSymbolsByName(t *testing.T) {
 	if !ok {
 		t.Fatalf("RustExternalScanner binding type = %T, want RustExternalScanner", RustExternalScanner{}.ExternalScannerForLanguage(lang))
 	}
-	if got, want := scanner.externalToToken[0], rustTokStringContent; got != want {
-		t.Fatalf("regular string_content external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.externalToToken[1], rustTokRawStringStart; got != want {
-		t.Fatalf("raw-string-start external mapped to token %d, want %d", got, want)
-	}
-	if got, want := scanner.externalToToken[2], rustTokRawStringContent; got != want {
-		t.Fatalf("raw string_content external mapped to token %d, want %d", got, want)
+	if got, want := scanner.externalToToken, []int{0, 1, 2, 3, 4}; !slices.Equal(got, want) {
+		t.Fatalf("rust externalToToken = %v, want %v", got, want)
 	}
 	if got, want := scanner.symbols[rustTokStringContent], gotreesitter.Symbol(1); got != want {
-		t.Fatalf("string_content result symbol = %d, want shifted symbol %d", got, want)
+		t.Fatalf("token 0 (string-content) result symbol = %d, want %d", got, want)
 	}
-	if got, want := scanner.symbols[rustTokRawStringStart], gotreesitter.Symbol(2); got != want {
-		t.Fatalf("raw-string-start result symbol = %d, want shifted symbol %d", got, want)
+	if got, want := scanner.symbols[rustTokRawStringContent], gotreesitter.Symbol(4); got != want {
+		t.Fatalf("token 3 (raw string-content) result symbol = %d, want %d", got, want)
 	}
 
 	validExternal := []bool{false, true, false, false, true}
 	var semanticValid [rustTokenCount]bool
 	validSemantic := scanner.remapValidSymbols(validExternal, &semanticValid)
-	if validSemantic[rustTokStringClose] {
-		t.Fatalf("missing string-close external became valid after remap: %v", validSemantic)
+	if !validSemantic[rustTokStringClose] {
+		t.Fatalf("external index 1 did not map to token 1 (string-close): %v", validSemantic)
 	}
-	if !validSemantic[rustTokRawStringStart] {
-		t.Fatalf("raw-string-start external did not become valid semantic token: %v", validSemantic)
+	if !validSemantic[rustTokRawStringEnd] {
+		t.Fatalf("external index 4 did not map to token 4 (raw-string-end): %v", validSemantic)
 	}
-	if !validSemantic[rustTokFloatLiteral] {
-		t.Fatalf("float external did not become valid semantic token: %v", validSemantic)
+	if validSemantic[rustTokRawStringStart] {
+		t.Fatalf("token 2 (raw-string-start) unexpectedly valid: %v", validSemantic)
 	}
 }
 

--- a/grammars/swift_scanner.go
+++ b/grammars/swift_scanner.go
@@ -48,39 +48,39 @@ const (
 
 // Concrete symbol IDs from the generated Swift grammar ExternalSymbols.
 const (
-	swtSymBlockComment              gotreesitter.Symbol = 180
-	swtSymRawStrPart                gotreesitter.Symbol = 181
-	swtSymRawStrContinuingIndicator gotreesitter.Symbol = 182
-	swtSymRawStrEndPart             gotreesitter.Symbol = 183
-	swtSymImplicitSemi              gotreesitter.Symbol = 184
-	swtSymExplicitSemi              gotreesitter.Symbol = 185
-	swtSymArrowOperator             gotreesitter.Symbol = 186
-	swtSymDotOperator               gotreesitter.Symbol = 187
-	swtSymConjunctionOperator       gotreesitter.Symbol = 188
-	swtSymDisjunctionOperator       gotreesitter.Symbol = 189
-	swtSymNilCoalescingOperator     gotreesitter.Symbol = 190
-	swtSymEqualSign                 gotreesitter.Symbol = 191
-	swtSymEqEq                      gotreesitter.Symbol = 192
-	swtSymPlusThenWs                gotreesitter.Symbol = 193
-	swtSymMinusThenWs               gotreesitter.Symbol = 194
-	swtSymBang                      gotreesitter.Symbol = 195
-	swtSymThrowsKeyword             gotreesitter.Symbol = 196
-	swtSymRethrowsKeyword           gotreesitter.Symbol = 197
-	swtSymDefaultKeyword            gotreesitter.Symbol = 198
-	swtSymWhereKeyword              gotreesitter.Symbol = 199
-	swtSymElseKeyword               gotreesitter.Symbol = 200
-	swtSymCatchKeyword              gotreesitter.Symbol = 201
-	swtSymAsKeyword                 gotreesitter.Symbol = 202
-	swtSymAsQuest                   gotreesitter.Symbol = 203
-	swtSymAsBang                    gotreesitter.Symbol = 204
-	swtSymAsyncKeyword              gotreesitter.Symbol = 205
-	swtSymCustomOperator            gotreesitter.Symbol = 206
-	swtSymHashSymbol                gotreesitter.Symbol = 207
-	swtSymDirectiveIf               gotreesitter.Symbol = 208
-	swtSymDirectiveElseif           gotreesitter.Symbol = 209
-	swtSymDirectiveElse             gotreesitter.Symbol = 530
-	swtSymDirectiveEndif            gotreesitter.Symbol = 211
-	swtSymFakeTryBang               gotreesitter.Symbol = 212
+	swtSymBlockComment              gotreesitter.Symbol = 190
+	swtSymRawStrPart                gotreesitter.Symbol = 191
+	swtSymRawStrContinuingIndicator gotreesitter.Symbol = 192
+	swtSymRawStrEndPart             gotreesitter.Symbol = 193
+	swtSymImplicitSemi              gotreesitter.Symbol = 194
+	swtSymExplicitSemi              gotreesitter.Symbol = 195
+	swtSymArrowOperator             gotreesitter.Symbol = 196
+	swtSymDotOperator               gotreesitter.Symbol = 197
+	swtSymConjunctionOperator       gotreesitter.Symbol = 198
+	swtSymDisjunctionOperator       gotreesitter.Symbol = 199
+	swtSymNilCoalescingOperator     gotreesitter.Symbol = 200
+	swtSymEqualSign                 gotreesitter.Symbol = 201
+	swtSymEqEq                      gotreesitter.Symbol = 202
+	swtSymPlusThenWs                gotreesitter.Symbol = 203
+	swtSymMinusThenWs               gotreesitter.Symbol = 204
+	swtSymBang                      gotreesitter.Symbol = 205
+	swtSymThrowsKeyword             gotreesitter.Symbol = 206
+	swtSymRethrowsKeyword           gotreesitter.Symbol = 207
+	swtSymDefaultKeyword            gotreesitter.Symbol = 208
+	swtSymWhereKeyword              gotreesitter.Symbol = 209
+	swtSymElseKeyword               gotreesitter.Symbol = 210
+	swtSymCatchKeyword              gotreesitter.Symbol = 211
+	swtSymAsKeyword                 gotreesitter.Symbol = 212
+	swtSymAsQuest                   gotreesitter.Symbol = 213
+	swtSymAsBang                    gotreesitter.Symbol = 214
+	swtSymAsyncKeyword              gotreesitter.Symbol = 215
+	swtSymCustomOperator            gotreesitter.Symbol = 216
+	swtSymHashSymbol                gotreesitter.Symbol = 217
+	swtSymDirectiveIf               gotreesitter.Symbol = 218
+	swtSymDirectiveElseif           gotreesitter.Symbol = 219
+	swtSymDirectiveElse             gotreesitter.Symbol = 220
+	swtSymDirectiveEndif            gotreesitter.Symbol = 221
+	swtSymFakeTryBang               gotreesitter.Symbol = 222
 )
 
 // swtDefaultSymTable maps token indexes to concrete ts2go symbol IDs.

--- a/grammars/zzwave2_profile_test.go
+++ b/grammars/zzwave2_profile_test.go
@@ -1,0 +1,48 @@
+package grammars
+
+// Temporary wave-2 profiling harness for the open-error-region quadratic.
+// Gated behind WAVE2_PROFILE so it never runs in normal suites.
+
+import (
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func TestZZWave2ProfileCSharp(t *testing.T) {
+	target := os.Getenv("WAVE2_PROFILE")
+	if target == "" {
+		t.Skip("set WAVE2_PROFILE=<file.cs> to run")
+	}
+	src, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lang := CSharpLanguage()
+	p := gotreesitter.NewParser(lang)
+
+	if prof := os.Getenv("WAVE2_CPUPROFILE"); prof != "" {
+		f, err := os.Create(prof)
+		if err != nil {
+			t.Fatalf("cpuprofile: %v", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			t.Fatalf("start profile: %v", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	start := time.Now()
+	tree, err := p.Parse(src)
+	dur := time.Since(start)
+	if err != nil {
+		t.Fatalf("parse error after %v: %v", dur, err)
+	}
+	root := tree.RootNode()
+	t.Logf("parsed %d bytes in %v; root=%s hasError=%v span=[%d,%d)",
+		len(src), dur, root.Type(lang), root.HasError(), root.StartByte(), root.EndByte())
+}

--- a/grammars/zzwave2_shape_test.go
+++ b/grammars/zzwave2_shape_test.go
@@ -1,0 +1,56 @@
+package grammars
+
+// Wave-2 shape-neutrality harness: parses WAVE2_SHAPE_FILE with the language
+// named by WAVE2_SHAPE_LANG and prints a full-S-expression FNV hash plus node
+// and span stats, for byte-shape comparison across builds.
+
+import (
+	"fmt"
+	"hash/fnv"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func w2DumpSexp(h interface{ Write([]byte) (int, error) }, lang *gotreesitter.Language, n *gotreesitter.Node, depth int) (nodes int) {
+	if n == nil {
+		return 0
+	}
+	fmt.Fprintf(h, "(%s %d %d %v %v", n.Type(lang), n.StartByte(), n.EndByte(), n.IsNamed(), n.IsMissing())
+	nodes = 1
+	for i := 0; i < n.ChildCount(); i++ {
+		nodes += w2DumpSexp(h, lang, n.Child(i), depth+1)
+	}
+	fmt.Fprint(h, ")")
+	return nodes
+}
+
+func TestZZWave2Shape(t *testing.T) {
+	file := os.Getenv("WAVE2_SHAPE_FILE")
+	if file == "" {
+		t.Skip("set WAVE2_SHAPE_FILE")
+	}
+	langName := os.Getenv("WAVE2_SHAPE_LANG")
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lang := loadEmbeddedLanguage(langName + ".bin")
+	if lang == nil {
+		t.Fatalf("lang %q: not found", langName)
+	}
+	p := gotreesitter.NewParser(lang)
+	start := time.Now()
+	tree, err := p.Parse(src)
+	dur := time.Since(start)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	root := tree.RootNode()
+	h := fnv.New64a()
+	nodes := w2DumpSexp(h, lang, root, 0)
+	fmt.Printf("SHAPE %s lang=%s hash=%016x nodes=%d root=%s span=[%d,%d) hasErr=%v dur=%v\n",
+		file, langName, h.Sum64(), nodes, root.Type(lang), root.StartByte(), root.EndByte(), root.HasError(), dur.Round(time.Millisecond))
+}

--- a/language.go
+++ b/language.go
@@ -8,6 +8,7 @@ package gotreesitter
 import (
 	"slices"
 	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -418,6 +419,13 @@ type Language struct {
 	keywordPrefilterOnce sync.Once
 	zeroWidthInfo        languageZeroWidthInfo
 	zeroWidthInfoOnce    sync.Once
+
+	// cRecoveryGateCache memoizes DiagnoseCRecoveryGate (parser_recover_c.go),
+	// which otherwise re-scans the full parse tables on every call. The entry
+	// is keyed by a fingerprint of every input the diagnosis reads, so
+	// post-load mutations (external scanner / ExternalLexStates attach)
+	// invalidate it. See cRecoveryGateCacheKeyFor.
+	cRecoveryGateCache atomic.Pointer[cRecoveryGateCacheEntry]
 }
 
 type symbolNameNamedKey struct {

--- a/parser.go
+++ b/parser.go
@@ -189,7 +189,13 @@ type Parser struct {
 	// analogue of C's SubtreeHeapData.error_cost/visible_descendant_count
 	// computed once in ts_subtree_summarize_children. Cleared at parse start;
 	// nil while the gate is off.
-	cNodeMemo       map[*Node]cNodeMemoEntry
+	cNodeMemo map[*Node]cNodeMemoEntry
+	// cPrefixPath is the reusable descent scratch for GSS prefix-aggregate
+	// fills (cStackPrefixAgg, parser_recover_c.go). The aggregates themselves
+	// live on gssNode (aggGen/aggCost/aggVis), the engine analogue of C
+	// StackNode.error_cost / node_count maintained at push, making
+	// ts_stack_error_cost-equivalent reads O(1) instead of O(stack depth).
+	cPrefixPath     []*gssNode
 	forceRawSpanAll bool
 	// leafInternByLang enables canonical leaf interning for this language even
 	// when the global GOT_PARSE_INTERN_LEAVES_SUBSTITUTE flag is off. Limited to
@@ -4189,6 +4195,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				reconcileStaleHasErrorFlags(root, 0)
 			}
 		}
+		// Env-gated (GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1) one-line summary of the
+		// incremental cost/vis aggregate assertions run this parse; no-op when unset.
+		debugRecoveryIncrementalCostReport()
 		scratch.audit.finishParse(stacks)
 		captureArenaStats()
 		captureScratchStats()
@@ -8136,4 +8145,103 @@ func classifyConflictShape(actions []ParseAction) (rrConflict, rsConflict bool) 
 		return false, true
 	}
 	return reduceCount >= 2, false
+}
+
+// phpCommaListRepeatSymbols lists the php repeat-boundary families whose ONLY
+// conflict lookahead in the generated table is the list separator ",". Each is
+// a comma-separated list closed by a terminator (")", "]", "}", ";", "=>")
+// that carries no repetition-continuation shift. C tree-sitter resolves these
+// entries deterministically by skipping the repetition shift, folding, and
+// re-dispatching (parser.c: `if (action.shift.repetition) break;`), so no GLR
+// fork exists in C. Without the equivalent collapse the GLR loop forks per
+// element: the flat-vs-folded stacks re-fork on every subsequent separator,
+// the conflict-frontier walk refolds O(n) accumulated elements per token, and
+// node materialization goes O(n^2) — Symfony's emoji data tables
+// (~2.4k-element arrays) hit the memory budget at >10s while C parses them in
+// ~28ms.
+// The list is SYMMETRIC across the array-vs-destructuring ambiguity
+// (_array_destructing_repeat1 / _list_destructing_repeat1 are included
+// alongside array_creation_expression_repeat1): a php "[...]" keeps both GLR
+// lineages alive until an "=" does or does not appear, and C folds BOTH
+// lineages at each separator. Collapsing only one side was observed to be
+// non-monotonic on real files (PhpDocExtractor.php: the deterministic
+// array-side lineage outcompeted the forked destructuring lineage in the
+// merge, so `[$a, $b] = ...` lost its list_literal reading and the whole
+// class collapsed to ERROR).
+var phpCommaListRepeatSymbols = []string{
+	"_array_destructing_repeat1",
+	"_class_const_declaration_repeat1",
+	"_list_destructing_repeat1",
+	"anonymous_function_use_clause_repeat1",
+	"arguments_repeat1",
+	"array_creation_expression_repeat1",
+	"attribute_group_repeat1",
+	"base_clause_repeat1",
+	"const_declaration_repeat1",
+	"formal_parameters_repeat1",
+	"function_static_declaration_repeat1",
+	"global_declaration_repeat1",
+	"match_block_repeat1",
+	"match_condition_list_repeat1",
+	"namespace_use_declaration_repeat1",
+	"property_declaration_repeat1",
+	"unset_statement_repeat1",
+}
+
+func phpAllReducesAreCommaListRepeat(lang *Language, actions []ParseAction) bool {
+	found := false
+	for _, act := range actions {
+		if act.Type != ParseActionReduce {
+			continue
+		}
+		matched := false
+		for _, name := range phpCommaListRepeatSymbols {
+			if symbolHasName(lang, act.Symbol, name) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+// phpCommaListRepeatConflictChoice collapses php's comma list-repeat
+// boundaries to the single REDUCE (the eager fold), exactly C's dispatch
+// semantics for these entries (parser.c skips the repetition shift —
+// `if (action.shift.repetition) break;` — performs the reduce, and
+// re-dispatches the same lookahead from the folded state). The fold is
+// lossless: after it, the same "," re-dispatches and either shifts as the
+// list continuation or closes via the outer `optional(',') closer` rule
+// (trailing comma), so BOTH futures survive — unlike choosing the repetition
+// shift, which commits to a following element and breaks trailing commas, or
+// deferring folds, which builds an O(n) flat spine that detonates
+// quadratically at whichever boundary finally forces the fold.
+//
+// The caller must NOT apply this to a stack whose lineage has ever entered the
+// C error state (the sticky glrStack.cEverErrored bit, or a live
+// cRec/cPaused/missing-group marker): inside recovery wreckage the
+// repetition-shift arm of these entries
+// can be the ordinary-resync fork the recovery cost competition keeps
+// (observed on TransportResponseTrait.php / TwigExtensionTest.php at a
+// _array_destructing_repeat1 boundary two tokens after a paused stack), and
+// collapsing it flips recovered-clean parses to ERROR. The gate is
+// deliberately per-stack, not per-parse: a benign sibling dead-end (e.g. the
+// destructuring lineage of an integer-valued array pausing at the first
+// integer value) must not switch the collapse off for the healthy lineage,
+// or integer-keyed data tables re-detonate. Clean lineages — the
+// giant-data-array class this collapse exists for (Symfony emoji/Intl
+// tables) — never enter C error handling, so cEverErrored stays false and the
+// quadratic defusal is unaffected by the gate.
+func phpCommaListRepeatConflictChoice(lang *Language, tok Token, actions []ParseAction) (ParseAction, bool) {
+	if lang == nil {
+		return ParseAction{}, false
+	}
+	if !symbolHasName(lang, tok.Symbol, ",") || !phpAllReducesAreCommaListRepeat(lang, actions) {
+		return ParseAction{}, false
+	}
+	return singleReduceAgainstRepetitionShiftConflictChoice(actions)
 }

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"unicode"
 )
 
@@ -198,9 +199,125 @@ type CRecoveryGateDiagnostics struct {
 	ExternalLexStateMinLen int
 }
 
+// cRecoveryGateCacheKey fingerprints every input DiagnoseCRecoveryGate reads:
+// presence/lengths of the table surface plus the backing-array identity of
+// each slice whose contents feed the validation. Language tables are immutable
+// after decode; the only supported post-load mutations (external scanner and
+// ExternalLexStates attach via AttachLanguageSupport / RegisterExternalScanner)
+// swap whole slices or flip presence, which changes this key. Equal keys
+// therefore imply an identical diagnosis, so the memo is answer-preserving.
+//
+// WARNING (test authors): the fingerprint captures each slice's backing-array
+// identity (&ParseTable[0], &ParseActions[0], ...) plus its length — NOT its
+// contents. An in-place cell/row poke (e.g. lang.ParseTable[i] = v, or mutating
+// a ParseActionEntry's Actions in place) leaves both the base pointer and the
+// length unchanged, so the key is unchanged and DiagnoseCRecoveryGate returns
+// the STALE memoized diagnosis. To force a re-diagnosis, whole-swap the slice
+// (lang.ParseTable = newSlice) or construct a fresh Language. This aliasing was
+// flagged by review A as a memo-staleness footgun for gate tests.
+type cRecoveryGateCacheKey struct {
+	initialState       StateID
+	stateCount         uint32
+	symbolCount        uint32
+	tokenCount         uint32
+	externalTokenCount uint32
+
+	symbolMetadataLen     int
+	symbolNamesLen        int
+	parseActionsLen       int
+	lexModesLen           int
+	lexStatesLen          int
+	parseTableLen         int
+	smallParseTableLen    int
+	smallParseTableMapLen int
+
+	hasExternalScanner     bool
+	externalSymbolsLen     int
+	externalLexStatesLen   int
+	externalLexStateMinLen int
+
+	parseTablePtr         *[]uint16
+	smallParseTablePtr    *uint16
+	smallParseTableMapPtr *uint32
+	parseActionsPtr       *ParseActionEntry
+	lexModesPtr           *LexMode
+	externalSymbolsPtr    *Symbol
+	externalLexStatesPtr  *[]bool
+}
+
+type cRecoveryGateCacheEntry struct {
+	key  cRecoveryGateCacheKey
+	diag CRecoveryGateDiagnostics
+}
+
+func cRecoveryGateCacheKeyFor(lang *Language) cRecoveryGateCacheKey {
+	key := cRecoveryGateCacheKey{
+		initialState:       lang.InitialState,
+		stateCount:         lang.StateCount,
+		symbolCount:        lang.SymbolCount,
+		tokenCount:         lang.TokenCount,
+		externalTokenCount: lang.ExternalTokenCount,
+
+		symbolMetadataLen:     len(lang.SymbolMetadata),
+		symbolNamesLen:        len(lang.SymbolNames),
+		parseActionsLen:       len(lang.ParseActions),
+		lexModesLen:           len(lang.LexModes),
+		lexStatesLen:          len(lang.LexStates),
+		parseTableLen:         len(lang.ParseTable),
+		smallParseTableLen:    len(lang.SmallParseTable),
+		smallParseTableMapLen: len(lang.SmallParseTableMap),
+
+		hasExternalScanner:     lang.ExternalScanner != nil,
+		externalSymbolsLen:     len(lang.ExternalSymbols),
+		externalLexStatesLen:   len(lang.ExternalLexStates),
+		externalLexStateMinLen: externalLexStateMinLen(lang),
+	}
+	if len(lang.ParseTable) > 0 {
+		key.parseTablePtr = &lang.ParseTable[0]
+	}
+	if len(lang.SmallParseTable) > 0 {
+		key.smallParseTablePtr = &lang.SmallParseTable[0]
+	}
+	if len(lang.SmallParseTableMap) > 0 {
+		key.smallParseTableMapPtr = &lang.SmallParseTableMap[0]
+	}
+	if len(lang.ParseActions) > 0 {
+		key.parseActionsPtr = &lang.ParseActions[0]
+	}
+	if len(lang.LexModes) > 0 {
+		key.lexModesPtr = &lang.LexModes[0]
+	}
+	if len(lang.ExternalSymbols) > 0 {
+		key.externalSymbolsPtr = &lang.ExternalSymbols[0]
+	}
+	if len(lang.ExternalLexStates) > 0 {
+		key.externalLexStatesPtr = &lang.ExternalLexStates[0]
+	}
+	return key
+}
+
 // DiagnoseCRecoveryGate validates the runtime table surface required by the
 // faithful C recovery-cost competition path and returns the first failure.
+//
+// The full validation scans every parse-table row, so the result is memoized
+// per Language behind an input fingerprint (cRecoveryGateCacheKey): callers on
+// parse-adjacent paths (errorCostCompetitionLanguage via gap-token replay and
+// token-source construction) would otherwise redo an O(tables) scan per call,
+// which measurably dominated error-heavy parses.
 func DiagnoseCRecoveryGate(lang *Language) CRecoveryGateDiagnostics {
+	if lang == nil {
+		return CRecoveryGateDiagnostics{Reason: "nil language"}
+	}
+	key := cRecoveryGateCacheKeyFor(lang)
+	if e := lang.cRecoveryGateCache.Load(); e != nil && e.key == key {
+		return e.diag
+	}
+	diag := diagnoseCRecoveryGateUncached(lang)
+	lang.cRecoveryGateCache.Store(&cRecoveryGateCacheEntry{key: key, diag: diag})
+	return diag
+}
+
+func diagnoseCRecoveryGateUncached(lang *Language) CRecoveryGateDiagnostics {
 	if lang == nil {
 		return CRecoveryGateDiagnostics{Reason: "nil language"}
 	}
@@ -1008,6 +1125,203 @@ type cNodeMemoEntry struct {
 	hasVis   bool
 }
 
+// ---------------------------------------------------------------------------
+// Open-error-region incremental cost maintenance
+//
+// While an error region is OPEN, every absorb appends children to the same
+// ERROR node and bumps its equivVersion, invalidating the (node, equivVersion)
+// memo entries above. Re-deriving the region's aggregates then costs
+// O(len(children)) per lookup, and the cost competitions / condense keys /
+// merge comparisons look the region up several times per token — O(n^2)
+// across the region (the c_sharp Bicep witness class).
+//
+// C never pays this: stack.c stack_node_new maintains error_cost as a
+// monotonic accumulator on push ("node->error_cost = previous_node->error_cost;
+// ... node->error_cost += ts_subtree_error_cost(subtree);", stack.c:163-172 in
+// the pinned tree-sitter), and ts_stack_error_cost (stack.c:493) reads it in
+// O(1). The helpers below restore that shape for the port: an absorb ADDS its
+// known delta (subtree cost + ERROR_COST_PER_SKIPPED_TREE charges + span
+// growth) to the region's memoized aggregates instead of leaving them stale.
+// Every write is answer-preserving: it stores exactly what a full walk at the
+// new version would compute (assertable under
+// GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1), and any mutation path that does NOT
+// go through these helpers simply leaves the entry stale, falling back to
+// today's full recompute.
+// ---------------------------------------------------------------------------
+
+// debugRecoveryIncrementalCost enables the env-gated incremental-vs-full-walk
+// assertion (GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1), mirroring the
+// GOT_DEBUG_RECOVERY_CYCLES pattern: zero overhead when unset, loud stderr
+// (budgeted) plus counters when a divergence is found.
+var debugRecoveryIncrementalCost = os.Getenv("GOT_DEBUG_RECOVERY_INCREMENTAL_COST") == "1"
+
+var debugRecoveryIncrementalCostReportsLeft = 8
+var debugRecoveryIncrementalCostDivergences uint64
+var debugRecoveryIncrementalCostChecks uint64
+
+// debugRecoveryIncrementalCostReport wires the otherwise write-only
+// checks/divergences counters into observable output: a one-line summary of the
+// env-gated incremental-vs-full aggregate assertions
+// (GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1), covering both the aggCost and the new
+// aggVis walks. Called once at parse end (parseInternal). The counters are
+// process-cumulative (they back a process-global report budget), so a
+// single-parse witness run shows exactly that parse's totals; checks>0 confirms
+// the assertions actually ran and divergences==0 confirms every memoized
+// aggregate matched its full walk. Per-divergence detail (budgeted to
+// debugRecoveryIncrementalCostReportsLeft) is printed at the divergence sites.
+func debugRecoveryIncrementalCostReport() {
+	if !debugRecoveryIncrementalCost || debugRecoveryIncrementalCostChecks == 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"RECOVERY-INCREMENTAL-COST summary: checks=%d divergences=%d\n",
+		debugRecoveryIncrementalCostChecks, debugRecoveryIncrementalCostDivergences)
+}
+
+// cErrRegionSpanCost returns the span-derived portion of an ERROR node's own
+// error cost (the ERROR_COST_PER_SKIPPED_CHAR / _LINE terms), excluding the
+// per-recovery constant and all child-derived terms.
+func cErrRegionSpanCost(n *Node) uint32 {
+	var bytes, rows uint32
+	if n.endByte > n.startByte {
+		bytes = n.endByte - n.startByte
+	}
+	if n.endPoint.Row > n.startPoint.Row {
+		rows = n.endPoint.Row - n.startPoint.Row
+	}
+	return cErrCostPerSkippedChar*bytes + cErrCostPerSkippedLine*rows
+}
+
+// cErrRegionAbsorbPre captures an open ERROR region's memoized aggregates
+// before an absorb mutates it. Capture MUST happen before any children/span
+// mutation; apply cErrRegionPostAbsorb after the mutation and the
+// nodeBumpEquivVersion call.
+type cErrRegionAbsorbPre struct {
+	node     *Node
+	cost     uint32
+	vis      int
+	spanCost uint32
+	valid    bool
+}
+
+func (p *Parser) cErrRegionPreAbsorb(n *Node) cErrRegionAbsorbPre {
+	if p == nil || p.cNodeMemo == nil || p.language == nil || n == nil {
+		return cErrRegionAbsorbPre{}
+	}
+	if n.symbol != errorSymbol || (n.isMissing() && len(n.children) == 0) {
+		return cErrRegionAbsorbPre{}
+	}
+	// Route through the standard memoized walks so the delta base is exactly
+	// the full-walk answer at the pre-absorb version (O(1) once warm).
+	return cErrRegionAbsorbPre{
+		node:     n,
+		cost:     p.cNodeErrorCost(n),
+		vis:      p.cNodeVisibleSubtreeCount(n),
+		spanCost: cErrRegionSpanCost(n),
+		valid:    true,
+	}
+}
+
+// cErrRegionPostAbsorb updates the region's memo entries for its NEW
+// equivVersion from the captured pre-state plus the absorb delta: the span
+// growth and, per appended child, its (finished, memoized) subtree cost, its
+// skipped-tree charge, and its visible-subtree count. The child terms mirror
+// cNodeErrorCostLang's ERROR-node summarization exactly; the primed values are
+// what a full walk at the new version returns.
+func (p *Parser) cErrRegionPostAbsorb(pre cErrRegionAbsorbPre, added ...*Node) {
+	if !pre.valid || p == nil || p.cNodeMemo == nil {
+		return
+	}
+	n := pre.node
+	lang := p.language
+	cost := pre.cost - pre.spanCost + cErrRegionSpanCost(n)
+	vis := pre.vis
+	for _, c := range added {
+		if c == nil {
+			continue
+		}
+		vis += p.cNodeVisibleSubtreeCount(c)
+		if !(c.symbol == errorSymbol && len(c.children) == 0) {
+			// C ERROR leaf children keep subtree error_cost 0 (see
+			// cNodeErrorCostLang); everything else contributes its own cost.
+			cost += p.cNodeErrorCost(c)
+		}
+		if !c.isExtra() {
+			if cSymbolVisibleLang(lang, c.symbol) {
+				cost += cErrCostPerSkippedTree
+			} else if len(c.children) > 0 {
+				cost += cErrCostPerSkippedTree * uint32(cNodeVisibleChildCountLang(lang, c))
+			}
+		}
+	}
+	if debugRecoveryIncrementalCost {
+		p.debugCheckErrRegionIncremental(n, cost, vis)
+	}
+	p.cNodeMemo[n] = cNodeMemoEntry{
+		ver:      n.equivVersion,
+		cost:     cost,
+		visCount: vis,
+		hasCost:  true,
+		hasVis:   true,
+	}
+	if ms := p.mergeScratch; ms != nil {
+		if ms.cErrorCost == nil {
+			ms.cErrorCost = make(map[*Node]glrCErrorCostEntry)
+		}
+		ms.cErrorCost[n] = glrCErrorCostEntry{ver: n.equivVersion, cost: cost}
+	}
+}
+
+// cErrRegionPrime warms both memo families for a freshly created (or freshly
+// bumped) region node via the standard full walks — O(children) once, so the
+// per-token lookups that follow are O(1) until the next absorb re-primes.
+func (p *Parser) cErrRegionPrime(n *Node) {
+	if p == nil || p.cNodeMemo == nil || p.language == nil || n == nil {
+		return
+	}
+	cost := p.cNodeErrorCost(n)
+	p.cNodeVisibleSubtreeCount(n)
+	if ms := p.mergeScratch; ms != nil {
+		if ms.cErrorCost == nil {
+			ms.cErrorCost = make(map[*Node]glrCErrorCostEntry)
+		}
+		ms.cErrorCost[n] = glrCErrorCostEntry{ver: n.equivVersion, cost: cost}
+	}
+}
+
+// cNodeVisibleSubtreeCountUncachedLang is the memo-free mirror of
+// cNodeVisibleSubtreeCount, used only by the debug assertion so a poisoned
+// memo cannot mask itself.
+func cNodeVisibleSubtreeCountUncachedLang(lang *Language, n *Node) int {
+	if n == nil {
+		return 0
+	}
+	count := 0
+	if cSymbolVisibleLang(lang, n.symbol) {
+		count++
+	}
+	for _, c := range n.children {
+		count += cNodeVisibleSubtreeCountUncachedLang(lang, c)
+	}
+	return count
+}
+
+func (p *Parser) debugCheckErrRegionIncremental(n *Node, cost uint32, vis int) {
+	debugRecoveryIncrementalCostChecks++
+	fullCost := cNodeErrorCostLang(p.language, n)
+	fullVis := cNodeVisibleSubtreeCountUncachedLang(p.language, n)
+	if fullCost == cost && fullVis == vis {
+		return
+	}
+	debugRecoveryIncrementalCostDivergences++
+	if debugRecoveryIncrementalCostReportsLeft > 0 {
+		debugRecoveryIncrementalCostReportsLeft--
+		fmt.Fprintf(os.Stderr,
+			"RECOVERY-INCREMENTAL-COST divergence: node=%p sym=%d ver=%d span=[%d,%d) children=%d incremental(cost=%d vis=%d) full(cost=%d vis=%d)\n",
+			n, n.symbol, n.equivVersion, n.startByte, n.endByte, len(n.children), cost, vis, fullCost, fullVis)
+	}
+}
+
 func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 	if p == nil {
 		return 0
@@ -1064,6 +1378,157 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 	return cost
 }
 
+// ---------------------------------------------------------------------------
+// GSS prefix aggregates: O(1) ts_stack_error_cost / node_count reads
+//
+// C maintains error_cost and node_count as monotonic accumulators on each
+// stack node at push time (stack.c stack_node_new: "node->error_cost =
+// previous_node->error_cost; ... += ts_subtree_error_cost(subtree);",
+// stack.c:163-172 pinned), so ts_stack_error_cost (stack.c:493) and
+// ts_stack_node_count_since_error (stack.c:504) are O(1) per call. The port
+// re-summed the whole prev chain per call — O(depth) — and the condense /
+// merge / competition paths issue hundreds of such calls per token, which
+// dominates error-region parses even with warm per-node memos.
+//
+// The on-node aggregates below (gssNode.aggGen/aggCost/aggVisGen/aggVis)
+// restore C's shape: per gssNode, the cumulative aggregates of the prev-chain
+// prefix root..node inclusive. gssNode prev/entry links are write-once at
+// allocation except setGSSMainLink (link-0 rewrite), and node payload
+// contents mutate only through nodeBumpEquivVersion call sites; both choke
+// points bump gssPrefixAggGen, so an aggregate with a matching generation is
+// exactly the full-walk answer. allocNode zeroes the gens on every (possibly
+// slab-recycled) node and the generation counter starts at 1, so stale or
+// fresh nodes can never validate.
+// ---------------------------------------------------------------------------
+
+// gssPrefixAggGen is the global invalidation generation for the GSS prefix
+// aggregates stored on gssNode (aggGen/aggCost/aggVisGen/aggVis). Bumped by
+// nodeBumpEquivVersion (any in-place node content mutation, tree.go) and
+// setGSSMainLink link-0 rewrites (glr.go). Global rather than per-parser
+// because nodeBumpEquivVersion has no parser in scope; cross-parser
+// over-invalidation only costs a rebuild, never staleness. Initialized to 1
+// so the zero value of gssNode.aggGen / aggVisGen (fresh or slab-cleared
+// nodes) can never validate.
+var gssPrefixAggGen atomic.Uint64
+
+func init() {
+	gssPrefixAggGen.Store(1)
+}
+
+// cStackPrefixAgg returns the cumulative (error cost, visible subtree count)
+// of head's prev chain, filling the on-node aggregates bottom-up from the
+// deepest still-valid node — O(new or invalidated suffix), O(1) steady-state.
+func (p *Parser) cStackPrefixAgg(head *gssNode) (uint32, int) {
+	gen := gssPrefixAggGen.Load()
+	var cost uint32
+	var vis int32
+	path := p.cPrefixPath[:0]
+	gn := head
+	for gn != nil {
+		if gn.aggGen == gen && gn.aggVisGen == gen {
+			cost, vis = gn.aggCost, gn.aggVis
+			break
+		}
+		path = append(path, gn)
+		gn = gn.prev
+	}
+	for i := len(path) - 1; i >= 0; i-- {
+		gn := path[i]
+		if n := stackEntryNode(gn.entry); n != nil {
+			cost += p.cNodeErrorCost(n)
+			vis += int32(p.cNodeVisibleSubtreeCount(n))
+		}
+		gn.aggGen = gen
+		gn.aggVisGen = gen
+		gn.aggCost = cost
+		gn.aggVis = vis
+	}
+	p.cPrefixPath = path
+	return cost, int(vis)
+}
+
+// cStackPrefixCostForMerge is the merge-scratch twin of cStackPrefixAgg. It
+// fills cost only (the merge side has no memoized visible-count walk), so it
+// leaves aggVisGen untouched; the cost value is identical to the parser-side
+// fill, letting both sides share aggCost.
+func cStackPrefixCostForMerge(scratch *glrMergeScratch, lang *Language, head *gssNode) uint32 {
+	gen := gssPrefixAggGen.Load()
+	var cost uint32
+	path := scratch.cPrefixPath[:0]
+	gn := head
+	for gn != nil {
+		if gn.aggGen == gen {
+			cost = gn.aggCost
+			break
+		}
+		path = append(path, gn)
+		gn = gn.prev
+	}
+	for i := len(path) - 1; i >= 0; i-- {
+		gn := path[i]
+		if n := stackEntryNode(gn.entry); n != nil {
+			cost += cNodeErrorCostLangWithScratch(scratch, lang, n)
+		}
+		gn.aggGen = gen
+		gn.aggCost = cost
+	}
+	scratch.cPrefixPath = path
+	return cost
+}
+
+// debugCheckStackPrefixCostLang re-derives the chain sum without any cache
+// (GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1 only).
+func debugCheckStackPrefixCostLang(lang *Language, head *gssNode, got uint32, label string) {
+	debugRecoveryIncrementalCostChecks++
+	var want uint32
+	for gn := head; gn != nil; gn = gn.prev {
+		if n := stackEntryNode(gn.entry); n != nil {
+			want += cNodeErrorCostLang(lang, n)
+		}
+	}
+	if want == got {
+		return
+	}
+	debugRecoveryIncrementalCostDivergences++
+	if debugRecoveryIncrementalCostReportsLeft > 0 {
+		debugRecoveryIncrementalCostReportsLeft--
+		fmt.Fprintf(os.Stderr,
+			"RECOVERY-PREFIX-AGG divergence (%s): head=%p cached=%d full=%d\n", label, head, got, want)
+	}
+}
+
+func (p *Parser) debugCheckStackPrefixAgg(head *gssNode, gotCost uint32, gotVis int) {
+	debugCheckStackPrefixCostLang(p.language, head, gotCost, "parser")
+	debugCheckStackPrefixVisLang(p.language, head, gotVis, "parser")
+}
+
+// debugCheckStackPrefixVisLang is the visible-subtree-count twin of
+// debugCheckStackPrefixCostLang: it re-derives the cumulative visible node
+// count of head's prev chain without any cache (via the uncached per-node walk
+// so a poisoned cNodeMemo cannot mask itself) and compares it against the
+// memoized aggVis the same way the cost check guards aggCost. A divergence here
+// means cStackCumulativeNodeCount / cNodeCountSinceError — and thus the php
+// baseline gate — would read a corrupt count.
+// (GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1 only.)
+func debugCheckStackPrefixVisLang(lang *Language, head *gssNode, got int, label string) {
+	debugRecoveryIncrementalCostChecks++
+	var want int
+	for gn := head; gn != nil; gn = gn.prev {
+		if n := stackEntryNode(gn.entry); n != nil {
+			want += cNodeVisibleSubtreeCountUncachedLang(lang, n)
+		}
+	}
+	if want == got {
+		return
+	}
+	debugRecoveryIncrementalCostDivergences++
+	if debugRecoveryIncrementalCostReportsLeft > 0 {
+		debugRecoveryIncrementalCostReportsLeft--
+		fmt.Fprintf(os.Stderr,
+			"RECOVERY-PREFIX-AGG-VIS divergence (%s): head=%p cached=%d full=%d\n", label, head, got, want)
+	}
+}
+
 // cStackErrorCost ports ts_stack_error_cost: the accumulated error cost of
 // every subtree on the stack, plus one open recovery when the version just
 // entered the error state and has not absorbed anything yet (the C
@@ -1073,18 +1538,23 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 		return 0
 	}
 	var cost uint32
-	walk := func(n *Node) {
-		if n != nil {
-			cost += p.cNodeErrorCost(n)
-		}
-	}
 	if len(s.entries) > 0 {
 		for i := range s.entries {
-			walk(stackEntryNode(s.entries[i]))
+			if n := stackEntryNode(s.entries[i]); n != nil {
+				cost += p.cNodeErrorCost(n)
+			}
+		}
+	} else if p != nil && p.cNodeMemo != nil && s.gss.head != nil {
+		var vis int
+		cost, vis = p.cStackPrefixAgg(s.gss.head)
+		if debugRecoveryIncrementalCost {
+			p.debugCheckStackPrefixAgg(s.gss.head, cost, vis)
 		}
 	} else {
 		for gn := s.gss.head; gn != nil; gn = gn.prev {
-			walk(stackEntryNode(gn.entry))
+			if n := stackEntryNode(gn.entry); n != nil {
+				cost += p.cNodeErrorCost(n)
+			}
 		}
 	}
 	if s.cPaused || (s.cRec != nil && s.cRec.openErr == nil) {
@@ -1107,18 +1577,22 @@ func cStackErrorCostForMergeWithScratch(scratch *glrMergeScratch, lang *Language
 		return 0
 	}
 	var cost uint32
-	walk := func(n *Node) {
-		if n != nil {
-			cost += cNodeErrorCostLangWithScratch(scratch, lang, n)
-		}
-	}
 	if len(s.entries) > 0 {
 		for i := range s.entries {
-			walk(stackEntryNode(s.entries[i]))
+			if n := stackEntryNode(s.entries[i]); n != nil {
+				cost += cNodeErrorCostLangWithScratch(scratch, lang, n)
+			}
+		}
+	} else if scratch != nil && s.gss.head != nil {
+		cost = cStackPrefixCostForMerge(scratch, lang, s.gss.head)
+		if debugRecoveryIncrementalCost {
+			debugCheckStackPrefixCostLang(lang, s.gss.head, cost, "merge")
 		}
 	} else {
 		for gn := s.gss.head; gn != nil; gn = gn.prev {
-			walk(stackEntryNode(gn.entry))
+			if n := stackEntryNode(gn.entry); n != nil {
+				cost += cNodeErrorCostLangWithScratch(scratch, lang, n)
+			}
 		}
 	}
 	if s.cPaused || (s.cRec != nil && s.cRec.openErr == nil) {
@@ -1141,19 +1615,28 @@ func (p *Parser) cStackCumulativeNodeCount(s *glrStack) int {
 		return 0
 	}
 	count := 0
-	walk := func(e stackEntry) {
-		if n := stackEntryNode(e); n != nil {
-			count += p.cNodeVisibleSubtreeCount(n)
-		}
-	}
 	if len(s.entries) > 0 {
 		for i := range s.entries {
-			walk(s.entries[i])
+			if n := stackEntryNode(s.entries[i]); n != nil {
+				count += p.cNodeVisibleSubtreeCount(n)
+			}
+		}
+		return count
+	}
+	if p != nil && p.cNodeMemo != nil && s.gss.head != nil {
+		var cost uint32
+		cost, count = p.cStackPrefixAgg(s.gss.head)
+		if debugRecoveryIncrementalCost {
+			// Verify the memoized aggVis (this cumulative-count path is where the
+			// php baseline gate ultimately reads it) against a full uncached walk.
+			p.debugCheckStackPrefixAgg(s.gss.head, cost, count)
 		}
 		return count
 	}
 	for gn := s.gss.head; gn != nil; gn = gn.prev {
-		walk(gn.entry)
+		if n := stackEntryNode(gn.entry); n != nil {
+			count += p.cNodeVisibleSubtreeCount(n)
+		}
 	}
 	return count
 }
@@ -1167,6 +1650,12 @@ func (p *Parser) cApplyMergedErrorGroupBaseline(versions []glrStack) int {
 	}
 	for vi := range versions {
 		versions[vi].cNodeBaseline = groupBaseline
+		// Writing a node-count baseline is definitionally an error-state entry;
+		// set the sticky wreckage bit alongside it so the (untrustworthy — it can
+		// be written as 0 here, or clamped back to 0 by cNodeCountSinceError)
+		// baseline can never be the sole evidence the php gate relies on. See
+		// glrStack.cEverErrored.
+		versions[vi].cEverErrored = true
 	}
 	return groupBaseline
 }
@@ -1723,6 +2212,14 @@ func (p *Parser) cTerminalNextState(state StateID, sym Symbol) (StateID, ParseAc
 func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool) {
 	s := &(*stacks)[si]
 	s.cPaused = false
+	// Sticky per-stack wreckage bit: this lineage is entering C error handling.
+	// Unlike cRec/cPaused/cNodeBaseline (all of which a later recovery resets to
+	// pristine values), cEverErrored never clears, so the php comma-list gate can
+	// tell "recovered wreckage that now looks clean" from "provably never
+	// errored". Setting it at the funnel entry means every downstream version
+	// (s.clone() below, its reduction/missing forks, and *s = versions[0])
+	// inherits it via clone()/cloneWithScratch(). See glrStack.cEverErrored.
+	s.cEverErrored = true
 	// cHandleError running is NOT proof the input is malformed — LALR table
 	// limitations routinely drive well-formed input into a momentary
 	// no-action point that step 1 below (cDoAllPotentialReductions) resolves
@@ -2414,6 +2911,13 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 	fork.cRecoverMissingGroup = nil
 	fork.dead = false
 	fork.shifted = false
+	// This recovered fork clears cRec (above) and may later reset its baseline,
+	// but it still descends from error wreckage and is about to wrap popped
+	// content in a real ERROR node. Keep the sticky bit set so it cannot pass
+	// the php gate two tokens later looking pristine. cloneWithScratch already
+	// copied it from v; this is the belt-and-suspenders entry-funnel site. See
+	// glrStack.cEverErrored.
+	fork.cEverErrored = true
 	keepDepth := len(entries) - cut
 	if !fork.truncate(keepDepth) {
 		return glrStack{}, false
@@ -2521,10 +3025,12 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	if rec != nil && rec.openErr != nil {
 		top := stackEntryNode(v.top())
 		if top == rec.openErr {
+			pre := p.cErrRegionPreAbsorb(rec.openErr)
 			rec.openErr.children = appendLeaf(rec.openErr.children)
 			rec.openErr.endByte = tok.EndByte
 			rec.openErr.endPoint = tok.EndPoint
 			nodeBumpEquivVersion(rec.openErr)
+			p.cErrRegionPostAbsorb(pre, leaf)
 			if debugRecoveryCycleChecks {
 				debugRecoveryCheckNodeAcyclic(p, arena, "absorb-extend-top", rec.openErr)
 			}
@@ -2559,11 +3065,17 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 				extras = p.cAppendVisibleSplice(extras, n)
 			}
 			if found && v.truncate(len(entries)-above) {
+				pre := p.cErrRegionPreAbsorb(rec.openErr)
 				rec.openErr.children = append(rec.openErr.children, extras...)
 				rec.openErr.children = appendLeaf(rec.openErr.children)
 				rec.openErr.endByte = tok.EndByte
 				rec.openErr.endPoint = tok.EndPoint
 				nodeBumpEquivVersion(rec.openErr)
+				added := extras
+				if leaf != nil {
+					added = append(added, leaf)
+				}
+				p.cErrRegionPostAbsorb(pre, added...)
 				if debugRecoveryCycleChecks {
 					debugRecoveryCheckNodeAcyclic(p, arena, "absorb-fold-extras", rec.openErr)
 				}
@@ -2594,6 +3106,7 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	if rec != nil {
 		rec.openErr = errNode
 	}
+	p.cErrRegionPrime(errNode)
 	if debugRecoveryCycleChecks {
 		debugRecoveryCheckNodeAcyclic(p, arena, "absorb-new-region", errNode)
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -869,11 +869,18 @@ func (p *Parser) pushLexErrorRunLeaf(s *glrStack, state StateID, tok Token, node
 			len(top.children) > 0 &&
 			top.parseState == state &&
 			tok.StartByte >= top.endByte {
+			// Incremental open-region cost: an unlexable-run extend is the
+			// same append-only mutation as a recovery absorb, so keep the
+			// (node, equivVersion) memo warm instead of forcing an
+			// O(len(children)) rewalk per skipped token (see
+			// cErrRegionPostAbsorb, parser_recover_c.go).
+			pre := p.cErrRegionPreAbsorb(top)
 			top.children = append(top.children, leaf)
 			top.endByte = tok.EndByte
 			top.endPoint = tok.EndPoint
 			top.setHasError(true)
 			nodeBumpEquivVersion(top)
+			p.cErrRegionPostAbsorb(pre, leaf)
 			if debugRecoveryCycleChecks {
 				debugRecoveryCheckNodeAcyclic(p, arena, "lex-error-run-extend", top)
 			}

--- a/tree.go
+++ b/tree.go
@@ -115,6 +115,12 @@ func nodeBumpEquivVersion(n *Node) {
 	if n.equivVersion == 0 {
 		n.equivVersion = 1
 	}
+	// Any in-place node mutation can change the node's error cost / visible
+	// count, which invalidates every cached GSS prefix aggregate that may sum
+	// over it (see gssPrefixAggGen, parser_recover_c.go). Bumping the global
+	// generation here — the single choke point for content mutations — keeps
+	// those caches exact without enumerating mutation sites.
+	gssPrefixAggGen.Add(1)
 }
 
 func defaultFieldSourcesInArena(arena *nodeArena, fieldIDs []FieldID) []uint8 {

--- a/zz_jsarena_measure_test.go
+++ b/zz_jsarena_measure_test.go
@@ -1,0 +1,144 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// genAsmJS produces an asm.js-style module: one giant flat function whose body
+// is a long sequence of tiny shallow expression statements. This reproduces the
+// "enormous FLAT tree" class (box2d.js / lua_binarytrees.js) without the actual
+// corpus files: a statement_block with numStmts expression_statement children,
+// each a shallow arithmetic/member/call expression.
+func genAsmJS(numStmts int) []byte {
+	var b strings.Builder
+	b.Grow(numStmts * 24)
+	b.WriteString("function asm(global, env, buffer) {\n\"use asm\";\n")
+	b.WriteString("var HEAP32 = new global.Int32Array(buffer);\n")
+	b.WriteString("var HEAPF64 = new global.Float64Array(buffer);\n")
+	b.WriteString("var imul = global.Math.imul;\n")
+	b.WriteString("function f(i1, i2) {\ni1 = i1 | 0;\ni2 = i2 | 0;\n")
+	b.WriteString("var i3 = 0, i4 = 0, i5 = 0, d6 = 0.0, d7 = 0.0;\n")
+	for i := 0; i < numStmts; i++ {
+		switch i % 6 {
+		case 0:
+			b.WriteString("i3 = (i1 + i2) | 0;\n")
+		case 1:
+			b.WriteString("i4 = HEAP32[i3 >> 2] | 0;\n")
+		case 2:
+			b.WriteString("d6 = +HEAPF64[i4 >> 3];\n")
+		case 3:
+			b.WriteString("i5 = imul(i3, i4) | 0;\n")
+		case 4:
+			b.WriteString("d7 = d6 * 2.0 + 1.0;\n")
+		case 5:
+			b.WriteString("HEAP32[i5 >> 2] = i4 + i3 | 0;\n")
+		}
+	}
+	b.WriteString("return i4 | 0;\n}\nreturn { f: f };\n}\n")
+	return []byte(b.String())
+}
+
+func TestZZJsArenaMeasure(t *testing.T) {
+	if os.Getenv("GTS_JS_ARENA_MEASURE") == "" {
+		t.Skip("set GTS_JS_ARENA_MEASURE=1 to run arena measurement")
+	}
+	stmts := 200000
+	if v := os.Getenv("GTS_JS_ARENA_STMTS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			stmts = n
+		}
+	}
+	src := genAsmJS(stmts)
+	t.Logf("asm.js source: %d statements, %d bytes (%.2f MB)", stmts, len(src), float64(len(src))/(1<<20))
+
+	gotreesitter.EnableArenaBreakdown(true)
+	defer gotreesitter.EnableArenaBreakdown(false)
+
+	parser := gotreesitter.NewParser(grammars.JavascriptLanguage())
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	t.Logf("StopReason=%q stoppedEarly=%v", tree.ParseStopReason(), tree.ParseStoppedEarly())
+	t.Logf("LastTokenEndByte=%d of %d (%.1f%% through source)",
+		rt.LastTokenEndByte, len(src), 100*float64(rt.LastTokenEndByte)/float64(len(src)))
+	t.Logf("MemoryBudgetBytes=%d (%.0f MB)", rt.MemoryBudgetBytes, float64(rt.MemoryBudgetBytes)/(1<<20))
+	t.Logf("ArenaBytesAllocated=%d (%.1f MB)", rt.ArenaBytesAllocated, float64(rt.ArenaBytesAllocated)/(1<<20))
+	t.Logf("ScratchBytesAllocated=%d (%.1f MB)", rt.ScratchBytesAllocated, float64(rt.ScratchBytesAllocated)/(1<<20))
+	t.Logf("GSSBytesAllocated=%d (%.1f MB)", rt.GSSBytesAllocated, float64(rt.GSSBytesAllocated)/(1<<20))
+	t.Logf("FinalNodes=%d (leaf=%d parent=%d)", rt.FinalNodes, rt.FinalLeafNodes, rt.FinalParentNodes)
+	t.Logf("LeafNodesConstructed=%d ParentNodesConstructed=%d", rt.LeafNodesConstructed, rt.ParentNodesConstructed)
+	t.Logf("MaxStacksSeen=%d PeakStackDepth=%d", rt.MaxStacksSeen, rt.PeakStackDepth)
+	if rt.FinalNodes > 0 {
+		t.Logf("PER-FINAL-NODE arena bytes = %.1f", float64(rt.ArenaBytesAllocated)/float64(rt.FinalNodes))
+	}
+	if rt.LeafNodesConstructed+rt.ParentNodesConstructed > 0 {
+		t.Logf("PER-CONSTRUCTED-NODE arena bytes = %.1f",
+			float64(rt.ArenaBytesAllocated)/float64(rt.LeafNodesConstructed+rt.ParentNodesConstructed))
+	}
+
+	bd, ok := tree.ArenaBreakdown()
+	if !ok {
+		t.Fatal("ArenaBreakdown unavailable")
+	}
+	type region struct {
+		name  string
+		bytes int64
+	}
+	regions := []region{
+		{"NodeStruct", bd.NodeStructBytesAllocated},
+		{"NoTreeNode", bd.NoTreeNodeBytesAllocated},
+		{"CompactFullLeaf", bd.CompactFullLeafBytesAllocated},
+		{"CompactCheckpointLeaf", bd.CompactCheckpointLeafBytesAllocated},
+		{"PendingParent", bd.PendingParentBytesAllocated},
+		{"PendingChildEntry", bd.PendingChildEntryBytesAllocated},
+		{"RawShape", bd.RawShapeBytesAllocated},
+		{"RawShapeChild", bd.RawShapeChildBytesAllocated},
+		{"FinalChildSidecar", bd.FinalChildSidecarBytesAllocated},
+		{"ChildSlice", bd.ChildSliceBytesAllocated},
+		{"FieldID", bd.FieldIDBytesAllocated},
+		{"FieldSource", bd.FieldSourceBytesAllocated},
+	}
+	sort.Slice(regions, func(i, j int) bool { return regions[i].bytes > regions[j].bytes })
+	t.Logf("ARENA BREAKDOWN (top consumers):")
+	for _, r := range regions {
+		if r.bytes == 0 {
+			continue
+		}
+		pct := 100 * float64(r.bytes) / float64(rt.ArenaBytesAllocated)
+		t.Logf("  %-22s %12d  (%.1f MB, %5.1f%%)", r.name, r.bytes, float64(r.bytes)/(1<<20), pct)
+	}
+	t.Logf("NodeLiveCount=%d NodeCapacityCount=%d NodeCapacityWaste=%d",
+		bd.NodeLiveCount, bd.NodeCapacityCount, bd.NodeCapacityWaste)
+	if bd.NodeLiveCount > 0 {
+		t.Logf("NodeStruct bytes / live node = %.1f", float64(bd.NodeStructBytesAllocated)/float64(bd.NodeLiveCount))
+	}
+	fmt.Fprintf(os.Stderr, "MEASURE_DONE\n")
+}
+
+func BenchmarkZZJsArenaParse(b *testing.B) {
+	if os.Getenv("GTS_JS_ARENA_MEASURE") == "" {
+		b.Skip("set GTS_JS_ARENA_MEASURE=1")
+	}
+	src := genAsmJS(20000)
+	parser := gotreesitter.NewParser(grammars.JavascriptLanguage())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(src)
+		if err != nil {
+			b.Fatal(err)
+		}
+		tree.Release()
+	}
+}


### PR DESCRIPTION
## Summary

This PR shifts external scanner binding to positional indices to unbreak Kotlin safe-nav (`?.`) and Swift custom operators whose display names differ from spec tokens. It also caps arena overflow slab growth at an 8 MB ceiling to eliminate peak memory spikes on large, flat parse trees. Additionally, a sticky `cEverErrored` flag on GLR lineages keeps PHP comma-list folding linear on clean input while excluding recovered wreckage, and `gssNode` gains prefix aggregates for efficient C-recovery cost tracking.

## Changes

- Replace external scanner symbol binding with positional index mapping; added drift diagnostics for name mismatches
- Bound arena overflow slab geometric growth at an 8 MB ceiling, switching to linear growth past the limit to cap peak capacity
- Introduce `cEverErrored` sticky bit on `glrStack` to track lineage error history across GLR merges and recoveries
- Restrict PHP comma-list fold to only error-free lineages to prevent O(n^2) defusal regression on giant arrays
- Add prefix aggregates (`aggCost`, `aggVis`) to `gssNode` for O(1) C-recovery cost competition, invalidating on link changes
- Update Python/Swift scanner symbol constants and add regression tests for parser correctness

## Testing

- Run grammar subset tests for Kotlin, Swift, Dart, Python, and Rust to verify scanner bindings and parse correctness
- Run `TestArenaOverflowSlabGrowthBounded` and `TestArenaCompactFullLeafOverflowBounded` to validate capacity waste limits
- Run `TestPHPGiantArrayCommaListDefusalStaysLinear` to confirm linear parse behavior on large arrays
- Verify Kotlin `?.` and Swift operators parse cleanly without spurious errors

## Review Focus

Focus on the GLR lineage sticky bit logic (`cEverErrored` propagation) and arena slab clamping (`boundedNextSlabCap`) to verify they don't introduce regressions in edge-case parses or memory budgets.