### PR TITLE
optimize: memoize spine equality, repetition fold, fix truncation

### DIFF
--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -675,9 +675,42 @@ func (m *perfScanLangMeasurer) classifyGoAttempt(tree *gotreesitter.Tree, err er
 		releaseGoTree(tree)
 		return nil, att
 	}
-	if got, want := tree.RootNode().EndByte(), uint32(len(src)); got != want {
+	// Coverage + internal-consistency verdict (wave2b): status=ok must mean the
+	// result tree COVERS the input AND its runtime error signals are self-
+	// consistent — not merely "finished within wall-clock". No C oracle: these
+	// are pure internal-consistency checks on the returned tree.
+	root := tree.RootNode()
+	rt := tree.ParseRuntime()
+	got, want := root.EndByte(), uint32(len(src))
+	if got != want {
+		// The result tree does not span the input. Always a failure, but flag
+		// whether the truncation is SILENT (the wave2b class: no reliable error
+		// signal at all) vs. honestly flagged. The library contract is that a
+		// truncated returned tree carries Truncated=true OR root.HasError().
+		signal := "flagged"
+		if !rt.Truncated && !root.HasError() {
+			signal = "SILENT"
+		}
 		att.status = "go_error"
-		att.detail = fmt.Sprintf("truncated: root.EndByte=%d want=%d", got, want)
+		att.detail = fmt.Sprintf("truncated[%s]: root.EndByte=%d want=%d hasErr=%v Truncated=%v",
+			signal, got, want, root.HasError(), rt.Truncated)
+		releaseGoTree(tree)
+		return nil, att
+	}
+	// The root spans the input from here on. Enforce consistency so a covered
+	// tree cannot masquerade as clean.
+	if rt.Truncated {
+		// Coverage and the Truncated flag disagree: an internal inconsistency.
+		att.status = "go_error"
+		att.detail = fmt.Sprintf("inconsistent: root covers %d but ParseRuntime.Truncated=true", got)
+		releaseGoTree(tree)
+		return nil, att
+	}
+	if root.IsError() {
+		// A full-span ERROR root is a degenerate parse (whole input recovered as
+		// one ERROR node); 'ok' used to mask this (the webworker case).
+		att.status = "go_error"
+		att.detail = "error_root: root symbol is ERROR spanning the input"
 		releaseGoTree(tree)
 		return nil, att
 	}
@@ -1494,5 +1527,24 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	joined := strings.Join(env, " ")
 	if strings.Contains(joined, "LANG=old") || !strings.Contains(joined, "GTS_PERF_SCAN_LANG=go") {
 		t.Fatalf("mergeEnv=%v", env)
+	}
+
+	lang := &gotreesitter.Language{
+		Name: "perf_scan_synthetic",
+		SymbolNames: []string{
+			"EOF",
+			"source_file",
+		},
+		SymbolMetadata: []gotreesitter.SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "source_file", Visible: true, Named: true},
+		},
+	}
+	src := []byte("abcdef")
+	root := gotreesitter.NewLeafNode(1, true, 0, 3, gotreesitter.Point{}, gotreesitter.Point{Column: 3})
+	tree := gotreesitter.NewTree(root, src, lang)
+	_, att := (&perfScanLangMeasurer{budget: 5 * time.Second}).classifyGoAttempt(tree, nil, "", src, false, perfScanAttempt{})
+	if att.status != "go_error" || !strings.Contains(att.detail, "truncated[SILENT]") {
+		t.Fatalf("silent prefix tree classified as status=%q detail=%q, want go_error truncated[SILENT]", att.status, att.detail)
 	}
 }

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -92,6 +92,86 @@ func singleShiftConflictChoice(actions []ParseAction) (ParseAction, bool) {
 	return shift, true
 }
 
+// cRepetitionSkipOptOut lists languages excluded from the global C
+// repetition-skip fold (cRepetitionSkipConflictChoice). The list starts
+// empty by design: C applies the rule to every grammar, so an entry here
+// requires concrete evidence (a failing shape test or a C-oracle parity
+// divergence), cited in a comment next to the entry.
+var cRepetitionSkipOptOut = map[string]bool{
+	// dart: correctness-cap language whose SELECTED trees are cap-sensitive.
+	// A/B on the dart corpus (wave-2b, 2026-07-07): with the fold on,
+	// dev/a11y_assessments/lib/use_cases/back_button.dart drops from 75/88
+	// C-oracle-matching shape chunks to 62/88 (tree-sitter CLI oracle,
+	// dart-81638dbbdb76) — pre-error fold choices reshape the downstream
+	// recovery wreckage that dart's capped branch selection depends on.
+	// dart's error-free giant-list wins (e.g.
+	// generated_material_localizations.dart 4.4s->0.9s) are forfeited until
+	// dart's selection fidelity is C-clean; re-test before removing.
+	"dart": true,
+	// c: error-dense real corpus (12/15 spot files carry ERROR) whose
+	// recovered shapes are sensitive to pre-error stack layout. A/B
+	// (wave-2b, 2026-07-07): with the fold on, archive.c drops from
+	// 1354/2040 to 1061/2040 C-oracle-matching shape chunks (tree-sitter
+	// CLI oracle, c-ae19b676b13b) even with the legacy c helper restored —
+	// eager folds before the first error leave a different stack for
+	// recovery to chew on. Clean-lineage-only wins don't outweigh the
+	// recovery-shape regression; revisit when c recovery is C-clean.
+	"c": true,
+	// haskell: the engine-wide fold KILLS a previously clean parse — A/B
+	// (wave-2b, 2026-07-07) flips SetupHooks.hs (Cabal-hooks) from
+	// accepted/error-free (151ms) to no_stacks_alive at byte ~17k: at some
+	// haskell state outside the two proven fold states (9609/10984, see
+	// haskellRepeatBoundaryConflictChoice) the repetition-marked shift is
+	// NOT re-reachable after the fold, so the fold's losslessness invariant
+	// does not hold on this table (huge external-scanner grammar; table
+	// fidelity suspect). The scoped 2-state fold helper stays as the proven
+	// subset; the memory_budget wins the global fold showed (LicenseId.hs,
+	// Licenses.hs ~1.9s->~0.1s) are forfeited until the offending state is
+	// isolated.
+	"haskell": true,
+	// c_sharp: the fold flips a clean parse to ERROR — A/B (wave-2b,
+	// 2026-07-07): DeployCommandTests.cs (Bicep) goes from accepted/clean
+	// (5.7s, legacy kind-scoped shift helper) to accepted WITH error
+	// (0.45s) under the fold. Same failure family as haskell: a fold at
+	// some state outside the helper's block/declaration_list kinds is not
+	// lossless on this table. c_sharp keeps its kind-scoped helper
+	// (csharpRepetitionShiftConflictChoice) and the forest fast path it
+	// already dispatches to by default.
+	"c_sharp": true,
+}
+
+// cRepetitionSkipConflictChoice is C tree-sitter's dispatch rule for
+// {repetition SHIFT, REDUCE} conflicts, applied engine-wide. C's action loop
+// (parser-repos/tree-sitter/lib/src/parser.c:1625, ts_parser__advance)
+// executes `if (action.shift.repetition) break;` — the repetition shift is
+// NEVER taken at a conflict entry. Every REDUCE runs (each spawning a stack
+// version), and when there is exactly one REDUCE the surviving version is
+// renumbered onto the current one and the SAME lookahead re-dispatches from
+// the folded state: a deterministic fold, no fork at all. The fold is
+// lossless because a repetition-marked shift is by construction re-reachable
+// from the post-reduce goto state — after folding, the same lookahead either
+// shifts as the list continuation or closes the list, so both futures
+// survive. Forking instead (our previous default) builds an O(n) flat spine
+// plus a per-boundary frontier refold — O(n^2) on any long repeated list.
+//
+// Scope: exactly-1 REDUCE + exactly-1 repetition SHIFT (the shape where C's
+// semantics are a deterministic fold; with 2+ REDUCEs C itself forks the
+// reduce versions, which our GLR fork approximates). Gated per-stack to
+// error-free lineages by the sticky !cEverErrored discipline established by
+// the php comma-list fold (see phpCommaListRepeatConflictChoice's doc for
+// the recovery-wreckage counterexamples): inside recovery wreckage the
+// repetition-shift arm can be the branch the recovery cost competition
+// keeps, so wreckage-descended lineages keep the ordinary GLR fork.
+func (p *Parser) cRepetitionSkipConflictChoice(s *glrStack, actions []ParseAction) (ParseAction, bool) {
+	if p == nil || p.language == nil || cRepetitionSkipOptOut[p.language.Name] {
+		return ParseAction{}, false
+	}
+	if s == nil || s.cRec != nil || s.cPaused || s.cRecoverMissingGroup != nil || s.cEverErrored {
+		return ParseAction{}, false
+	}
+	return singleReduceAgainstRepetitionShiftConflictChoice(actions)
+}
+
 func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrStack, tok Token, currentState StateID, actions []ParseAction, maxStacksSeen int, reuse *reuseCursor) (ParseAction, bool) {
 	if p == nil || p.language == nil {
 		return ParseAction{}, false
@@ -107,84 +187,94 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 	if chosen, ok := conflictPolicyChoice(p.language, tok, currentState, actions); ok {
 		return chosen, true
 	}
+	// C's global repetition-skip fold. Runs after explicit generated
+	// ConflictPolicies (per-state directives outrank the default) but before
+	// the grammargen repeat-boundary veto and the per-language arms: the veto
+	// exists to keep hand-written SHIFT-preferring shortcuts away from
+	// grammars they were never tuned for, whereas this fold is C's own
+	// dispatch semantics and applies to every grammar whose tables carry
+	// repetition-marked shifts.
+	if next, ok := p.cRepetitionSkipConflictChoice(s, actions); ok {
+		return next, true
+	}
 	if generatedRepeatBoundaryConflict(p.language, actions) {
 		return ParseAction{}, false
 	}
 	if p.language.GeneratedByGrammargen {
 		return ParseAction{}, false
 	}
+	// The per-language repetition-boundary arms that used to populate this
+	// switch (java/c_sharp/c/rust/typescript/tsx/javascript/python/r/php/perl/
+	// sql/dart/hcl/haskell/make/d/clojure/awk/scheme/dot) are retired:
+	// cRepetitionSkipConflictChoice above makes the C-faithful choice for the
+	// exact {1 repetition-SHIFT + 1 REDUCE} shape those helpers were scoped
+	// to. Table-shape analysis (cmd/repskip_shapes) shows every state those
+	// helpers covered carries ONLY that exact shape (zero multi-reduce
+	// entries), so on error-free lineages the global fold fully shadows them;
+	// on wreckage lineages (cEverErrored and friends) the C-faithful behavior
+	// is the GLR fork feeding the recovery cost competition — the php
+	// TransportResponseTrait lesson — not a deterministic commitment, so the
+	// helpers' unconditional firing there was a latent recovery-shape hazard,
+	// not coverage worth keeping. The helper functions remain (with their
+	// unit tests) as documentation of the profiled states until integration
+	// deletes them. Arms that survive below are NOT repetition-boundary
+	// policies (or, for gomod above, run where the global fold does not).
 	var chosen ParseAction
 	var ok bool
 	switch p.language.Name {
 	case "java":
-		if next, ok := p.javaSwitchArrowConflictChoice(s, tok, actions); ok {
-			return next, true
-		}
-		chosen, ok = javaRepetitionShiftConflictChoiceForDispatch(p.language, source, tok, currentState, actions)
-	case "c_sharp":
-		chosen, ok = csharpRepetitionShiftConflictChoice(p.language, tok, actions)
-	case "c":
-		chosen, ok = cRepetitionShiftConflictChoice(p.language, actions)
-	case "rust":
-		if p.noTreeBenchmarkOnly {
-			return ParseAction{}, false
-		}
-		chosen, ok = rustRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
-	case "typescript":
-		chosen, ok = typescriptRepetitionShiftConflictChoiceForDispatch(p.language, tok, currentState, actions)
-	case "tsx":
-		chosen, ok = tsxRepetitionReduceConflictChoice(p.language, tok, currentState, actions)
-	case "javascript":
-		chosen, ok = javascriptRepetitionShiftConflictChoiceForDispatch(p.language, tok, currentState, actions)
-	case "python":
-		chosen, ok = pythonRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
-	case "r":
-		chosen, ok = rRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "php":
-		// Stack-scoped error gate: only lineages that never entered the C
-		// error state take the deterministic comma list-repeat fold. The sticky
-		// !cEverErrored bit is the airtight signal; cNodeBaseline==0 is NOT —
-		// cApplyMergedErrorGroupBaseline can write a 0 baseline (error entered at
-		// cumulative count 0), the cNodeCountSinceError clamp can rewrite a
-		// baseline back to 0 after a pop-below-everything, and cRecoverToState
-		// clears cRec on the recovered fork, so a wreckage-carrying lineage could
-		// pass the old baseline==0 gate two tokens later. The !cPaused check is
-		// still required: pausing precedes the cHandleError entry that sets
-		// cEverErrored. See phpCommaListRepeatConflictChoice for why
-		// wreckage-descended lineages must keep the ordinary GLR fork here.
-		if s != nil && s.cRec == nil && !s.cPaused && s.cRecoverMissingGroup == nil && !s.cEverErrored {
-			if next, ok := phpCommaListRepeatConflictChoice(p.language, tok, actions); ok {
-				return next, true
-			}
-		}
-		chosen, ok = phpRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
-	case "perl":
-		chosen, ok = perlRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "sql":
-		chosen, ok = sqlRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
+		// Non-repetition: `case A ->` switch-label disambiguation via a
+		// goto/action-table probe on the reduce's landing state.
+		chosen, ok = p.javaSwitchArrowConflictChoice(s, tok, actions)
 	case "dart":
+		// KEPT, and dart is also in cRepetitionSkipOptOut: dart's capped
+		// branch selection is tuned around this helper's deterministic
+		// repetition shift, INCLUDING on wreckage lineages where the global
+		// fold never applies. A/B evidence (wave-2b, 2026-07-07): removing
+		// the arm alone flips app_bar.dart's recovered tree and pushes
+		// generated_material_localizations.dart from accepted to
+		// memory_budget; the global fold instead of it drops
+		// back_button.dart from 75/88 to 62/88 C-oracle shape chunks. This
+		// is non-C dispatch policy papering over dart's recovery-selection
+		// gaps — revisit when dart is C-recovery-clean.
 		chosen, ok = dartRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "hcl":
-		chosen, ok = hclRepetitionShiftConflictChoice(p.language, currentState, actions)
+	case "c":
+		// KEPT, and c is also in cRepetitionSkipOptOut: the C-language
+		// corpus is error-dense and its recovered shapes depend on this
+		// helper's deterministic translation_unit_repeat1 /
+		// preproc_if_repeat1 shift on all lineages. A/B evidence (wave-2b,
+		// 2026-07-07): retiring the arm dropped archive.c from 1354/2040 to
+		// 1061/2040 C-oracle-matching shape chunks, and the fold alone kept
+		// it there (pre-error folds reshape the stack recovery chews on).
+		// Non-C dispatch policy stabilizing recovery selection; revisit
+		// when c recovery is C-clean.
+		chosen, ok = cRepetitionShiftConflictChoice(p.language, actions)
 	case "haskell":
+		// KEPT, and haskell is also in cRepetitionSkipOptOut: this is the
+		// proven-safe scoped subset of the fold (REDUCE at states
+		// 9609/10984 via singleReduceAgainstRepetitionShiftConflictChoice —
+		// the same choice the global rule would make there). The engine-wide
+		// fold dead-ends SetupHooks.hs (see the opt-out entry), so haskell
+		// keeps only these two certified states.
 		chosen, ok = haskellRepeatBoundaryConflictChoice(p.language, currentState, actions)
-	case "make":
-		chosen, ok = makeRepetitionShiftConflictChoice(p.language, currentState, actions)
+	case "c_sharp":
+		// KEPT, and c_sharp is also in cRepetitionSkipOptOut: the
+		// engine-wide fold flips DeployCommandTests.cs from clean to ERROR
+		// (see the opt-out entry), so c_sharp keeps the kind-scoped
+		// block/declaration_list repetition shift that the designer-block
+		// boundedness tests were built around.
+		chosen, ok = csharpRepetitionShiftConflictChoice(p.language, tok, actions)
 	case "swift":
+		// Non-repetition: brace/type-expression and navigable-type reduce
+		// selection between distinct nonterminal interpretations.
 		chosen, ok = swiftBraceTypeExpressionConflictChoice(p.language, tok, currentState, actions)
-	case "d":
-		chosen, ok = dRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "clojure":
-		chosen, ok = clojureRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "awk":
-		chosen, ok = awkRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "scheme":
-		chosen, ok = schemeRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
-	case "dot":
-		chosen, ok = dotRepetitionShiftConflictChoice(p.language, tok, currentState, actions)
 	case "kotlin":
+		// Non-repetition: suppresses the bundled table's spurious bodiless
+		// object_literal reduction (issue #93).
 		chosen, ok = kotlinObjectLiteralConflictChoice(p.language, actions)
 	case "erlang":
+		// Non-repetition: macro invocation args shift (explicitly excludes
+		// repetition shifts).
 		chosen, ok = erlangMacroCallExprConflictChoice(p.language, actions)
 	}
 	return chosen, ok

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -172,6 +172,13 @@ func (p *Parser) cRepetitionSkipConflictChoice(s *glrStack, actions []ParseActio
 	return singleReduceAgainstRepetitionShiftConflictChoice(actions)
 }
 
+func (p *Parser) cRepetitionSkipForestConflictChoice(recoverActive bool, actions []ParseAction) (ParseAction, bool) {
+	if p == nil || p.language == nil || cRepetitionSkipOptOut[p.language.Name] || recoverActive {
+		return ParseAction{}, false
+	}
+	return singleReduceAgainstRepetitionShiftConflictChoice(actions)
+}
+
 func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrStack, tok Token, currentState StateID, actions []ParseAction, maxStacksSeen int, reuse *reuseCursor) (ParseAction, bool) {
 	if p == nil || p.language == nil {
 		return ParseAction{}, false

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -396,6 +396,31 @@ func TestForestResolveConflictDotLegacyUsesStateAndLookahead(t *testing.T) {
 	}
 }
 
+func TestCRepetitionSkipForestConflictChoiceHonorsOptOutAndRecoveryGate(t *testing.T) {
+	actions := []ParseAction{
+		{Type: ParseActionReduce, Symbol: 3, ChildCount: 2},
+		{Type: ParseActionShift, State: 99, Repetition: true},
+	}
+
+	parser := NewParser(&Language{Name: "bash"})
+	chosen, ok := parser.cRepetitionSkipForestConflictChoice(false, actions)
+	if !ok {
+		t.Fatal("cRepetitionSkipForestConflictChoice = false for non-recover non-opt-out language, want fold")
+	}
+	if chosen.Type != ParseActionReduce || chosen.Symbol != 3 {
+		t.Fatalf("cRepetitionSkipForestConflictChoice picked %+v, want reduce", chosen)
+	}
+
+	if chosen, ok := parser.cRepetitionSkipForestConflictChoice(true, actions); ok {
+		t.Fatalf("cRepetitionSkipForestConflictChoice picked %+v while recovery-active, want GLR fork", chosen)
+	}
+
+	parser = NewParser(&Language{Name: "dart"})
+	if chosen, ok := parser.cRepetitionSkipForestConflictChoice(false, actions); ok {
+		t.Fatalf("cRepetitionSkipForestConflictChoice picked %+v for opt-out language, want GLR fork", chosen)
+	}
+}
+
 func TestConflictPolicyGobRoundTrip(t *testing.T) {
 	lang := &Language{
 		Name:             "synthetic_policy_test",

--- a/glr.go
+++ b/glr.go
@@ -2,6 +2,7 @@ package gotreesitter
 
 import (
 	"fmt"
+	"os"
 	"unsafe"
 )
 
@@ -154,12 +155,17 @@ type glrMergeScratch struct {
 	equivEpoch        uint32
 	equivCache        []glrNodeEquivCacheEntry
 	stackEquivCache   []glrStackEquivCacheEntry
+	spineEquivCache   []glrSpineEquivCacheEntry
 	frontierHashCache []glrStackFrontierHashCacheEntry
 	cErrorCost        map[*Node]glrCErrorCostEntry
 	// cPrefixPath is the descent scratch for merge-side GSS prefix-aggregate
 	// fills (cStackPrefixCostForMerge, parser_recover_c.go); the aggregates
 	// live on gssNode, validated against gssPrefixAggGen.
-	cPrefixPath      []*gssNode
+	cPrefixPath []*gssNode
+	// spineVisit is the reusable descent scratch for the spine-equality memo
+	// (gssSpineEqualMemo): the pairs walked before the deciding position, so the
+	// single computed answer can be back-filled to every shallower spine pair.
+	spineVisit       []spinePairKey
 	shapePrefixCache []glrShapePrefixCacheEntry
 	shapePrefixEpoch uint32
 	shapePrefixBytes int64
@@ -183,6 +189,7 @@ type glrMergeScratch struct {
 	largeSlotBytes    int64
 	equivCacheBytes   int64
 	stackEquivBytes   int64
+	spineEquivBytes   int64
 	frontierHashBytes int64
 }
 
@@ -274,6 +281,22 @@ type glrNodeEquivCacheEntry struct {
 type glrStackEquivCacheEntry struct {
 	a      uintptr
 	b      uintptr
+	epoch  uint32
+	result bool
+}
+
+// glrSpineEquivCacheEntry is one slot of the pointer-keyed 2-way set-
+// associative spine-equality memo. Key: the ordered gssNode pointer pair.
+// Validity: epoch (per-parse) plus both prev-chain prefix fingerprints
+// (gssNode.hash). A hit requires the pointers AND both fingerprints to match,
+// so recycled slab pointers (fresh hash on allocNode) and in-place prefix
+// mutations (hash reset to 0 then recomputed at the mutation sites) both force
+// a miss rather than a stale answer.
+type glrSpineEquivCacheEntry struct {
+	a      uintptr
+	b      uintptr
+	aHash  uint64
+	bHash  uint64
 	epoch  uint32
 	result bool
 }
@@ -889,6 +912,21 @@ const (
 	// GLR-heavy grammars such as Dart.
 	glrStackEquivCacheSize     = 4096
 	glrStackEquivCacheSetCount = glrStackEquivCacheSize / 2
+	// glrSpineEquivCacheSize memoizes per-(node,node) GSS spine-equality — the
+	// answer "are the two sub-stacks rooted at an and bn fully equivalent from
+	// here to the root?" — checked at every spine position during a
+	// gssStacksEqual walk (not just the head pair, which is new every token and
+	// so rarely repeats). Unlike the epoch-only stackEquivCache, each entry
+	// carries the prev-chain prefix fingerprint (gssNode.hash) of both nodes and
+	// is valid only while both fingerprints are unchanged. gssNode.hash is a
+	// Merkle-style prefix hash (hash(prev.hash, entry)), so it captures exactly
+	// the data spine-equality depends on: an entry is the full-walk answer iff
+	// both fingerprints match. This survives the ~2 gssPrefixAggGen bumps/token
+	// (frontier merges) because deep spine nodes are not relinked and keep their
+	// hash — the choke-point invalidation that resets the global gen leaves the
+	// unchanged deep-spine fingerprints intact (wave-2b merge-equiv bucket).
+	glrSpineEquivCacheSize     = 16384
+	glrSpineEquivCacheSetCount = glrSpineEquivCacheSize / 2
 	// glrStackFrontierHashCache memoizes the Perl-only frontier merge hash for
 	// immutable GSS heads. It is intentionally smaller than the node-equivalence
 	// cache: it only covers live stack heads encountered during merge bucketing.
@@ -920,6 +958,7 @@ func (s *glrMergeScratch) beginEquivEpoch() {
 	if s.equivEpoch == ^uint32(0) {
 		clear(s.equivCache)
 		clear(s.stackEquivCache)
+		clear(s.spineEquivCache)
 		clear(s.frontierHashCache)
 		s.equivEpoch = 0
 	}
@@ -934,6 +973,11 @@ func (s *glrMergeScratch) beginEquivEpoch() {
 		s.equivCache = make([]glrNodeEquivCacheEntry, glrNodeEquivCacheSize)
 		s.equivCacheBytes = glrNodeEquivCacheBytesForCap(cap(s.equivCache))
 	}
+	// spineEquivCache is provisioned only for persistent parse scratches
+	// (ensureMergeHotCaches), matching shapePrefixCache: one-shot local scratches
+	// (standalone mergeStacks, diagnostics) skip spine memoization rather than
+	// paying a 640KiB zeroed allocation per call. The lookup/store guards on an
+	// empty backing array make that a correct no-memo fallback.
 }
 
 func stackFrontierHashCacheIndex(p uintptr) int {
@@ -1049,6 +1093,133 @@ func storeGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode, result boo
 	}
 }
 
+// debugMergeEquiv, when set (GOT_DEBUG_MERGE_EQUIV=1), makes gssStacksEqual
+// recompute every answer with the spine memo bypassed and loudly report any
+// divergence — the house env-gated correctness assertion pattern (mirrors
+// GOT_DEBUG_RECOVERY_INCREMENTAL_COST / GOT_DEBUG_RECOVERY_CYCLES). Zero cost
+// when unset.
+var debugMergeEquiv = os.Getenv("GOT_DEBUG_MERGE_EQUIV") == "1"
+
+// debugMergeEquivStats, when set (GOT_DEBUG_MERGE_EQUIV_STATS=1), accumulates
+// spine-memo lookup/hit/store counters (single-threaded parse; plain adds).
+var debugMergeEquivStats = os.Getenv("GOT_DEBUG_MERGE_EQUIV_STATS") == "1"
+
+// mergeEquivMemoEnabled gates the spine-equality memo. Default on; set
+// GOT_DISABLE_MERGE_EQUIV_MEMO=1 to fall back to the original memo-free walk
+// (A/B measurement only — the memo is answer-exact, verified by
+// GOT_DEBUG_MERGE_EQUIV).
+var mergeEquivMemoEnabled = os.Getenv("GOT_DISABLE_MERGE_EQUIV_MEMO") != "1"
+
+var (
+	debugSpineMemoLookups    uint64
+	debugSpineMemoHits       uint64
+	debugSpineMemoStores     uint64
+	debugMergeEquivChecks    uint64
+	debugMergeEquivDiverge   uint64
+	debugMergeEquivReportsLt = 20
+)
+
+// DebugSpineMemoStats returns (lookups, hits, stores) for the spine-equality
+// memo since process start. Measurement helper (wave-2b); only populated when
+// GOT_DEBUG_MERGE_EQUIV_STATS=1.
+func DebugSpineMemoStats() (uint64, uint64, uint64) {
+	return debugSpineMemoLookups, debugSpineMemoHits, debugSpineMemoStores
+}
+
+// DebugMergeEquivAssertStats returns (checks, divergences) for the spine-memo
+// correctness assertion. Nonzero divergences mean the memo answer differed from
+// the full walk (a bug). Only populated when GOT_DEBUG_MERGE_EQUIV=1.
+func DebugMergeEquivAssertStats() (uint64, uint64) {
+	return debugMergeEquivChecks, debugMergeEquivDiverge
+}
+
+func spineEquivCacheIndex(ap, bp uintptr) int {
+	x := uint64(ap)
+	y := uint64(bp)
+	h := x ^ (y + 0x9e3779b97f4a7c15 + (x << 6) + (x >> 2))
+	h ^= (x >> 5) * 0x85ebca6b
+	h ^= (y >> 3) * 0xc2b2ae35
+	return int(h&uint64(glrSpineEquivCacheSetCount-1)) << 1
+}
+
+// lookupSpineEquivCache returns the memoized "spine-from-(a) equals spine-from-
+// (b)" answer when both nodes' prev-chain prefix fingerprints are unchanged
+// since the entry was stored. A hit is exactly the full-walk answer (the
+// fingerprint captures every field the walk compares), so it cannot change a
+// merge decision.
+func lookupSpineEquivCache(scratch *glrMergeScratch, a, b *gssNode) (bool, bool) {
+	if scratch == nil || len(scratch.spineEquivCache) == 0 || scratch.equivEpoch == 0 {
+		return false, false
+	}
+	if a == nil || b == nil || a.hash == 0 || b.hash == 0 {
+		return false, false
+	}
+	ap, bp, ok := orderedGSSNodePair(a, b)
+	if !ok {
+		return false, false
+	}
+	aHash, bHash := a.hash, b.hash
+	if ap != uintptr(unsafe.Pointer(a)) {
+		// orderedGSSNodePair swapped: keep fingerprints paired with pointers.
+		aHash, bHash = b.hash, a.hash
+	}
+	if debugMergeEquivStats {
+		debugSpineMemoLookups++
+	}
+	idx := spineEquivCacheIndex(ap, bp)
+	primary := &scratch.spineEquivCache[idx]
+	if primary.epoch == scratch.equivEpoch && primary.a == ap && primary.b == bp &&
+		primary.aHash == aHash && primary.bHash == bHash {
+		if debugMergeEquivStats {
+			debugSpineMemoHits++
+		}
+		return primary.result, true
+	}
+	victim := &scratch.spineEquivCache[idx+1]
+	if victim.epoch == scratch.equivEpoch && victim.a == ap && victim.b == bp &&
+		victim.aHash == aHash && victim.bHash == bHash {
+		*primary, *victim = *victim, *primary
+		if debugMergeEquivStats {
+			debugSpineMemoHits++
+		}
+		return primary.result, true
+	}
+	return false, false
+}
+
+// storeSpineEquivCache never allocates the backing array (see
+// storeShapePrefixCache); one-shot scratches without provisioned caches simply
+// skip memoization.
+func storeSpineEquivCache(scratch *glrMergeScratch, a, b *gssNode, result bool) {
+	if scratch == nil || scratch.equivEpoch == 0 || len(scratch.spineEquivCache) == 0 {
+		return
+	}
+	if a == nil || b == nil || a.hash == 0 || b.hash == 0 {
+		return
+	}
+	ap, bp, ok := orderedGSSNodePair(a, b)
+	if !ok {
+		return
+	}
+	aHash, bHash := a.hash, b.hash
+	if ap != uintptr(unsafe.Pointer(a)) {
+		aHash, bHash = b.hash, a.hash
+	}
+	if debugMergeEquivStats {
+		debugSpineMemoStores++
+	}
+	idx := spineEquivCacheIndex(ap, bp)
+	scratch.spineEquivCache[idx+1] = scratch.spineEquivCache[idx]
+	scratch.spineEquivCache[idx] = glrSpineEquivCacheEntry{
+		a:      ap,
+		b:      bp,
+		aHash:  aHash,
+		bHash:  bHash,
+		epoch:  scratch.equivEpoch,
+		result: result,
+	}
+}
+
 func (s *glrMergeScratch) beginCleanZeroEpoch() {
 	if s == nil {
 		return
@@ -1075,6 +1246,10 @@ func (s *glrMergeScratch) ensureMergeHotCaches() {
 	if len(s.cleanZeroFront) == 0 {
 		s.cleanZeroFront = make([]glrCleanZeroFrontCacheEntry, glrCleanZeroFrontCacheSize)
 		s.cleanZeroBytes = int64(cap(s.cleanZeroFront)) * int64(unsafe.Sizeof(glrCleanZeroFrontCacheEntry{}))
+	}
+	if len(s.spineEquivCache) == 0 {
+		s.spineEquivCache = make([]glrSpineEquivCacheEntry, glrSpineEquivCacheSize)
+		s.spineEquivBytes = glrSpineEquivCacheBytesForCap(cap(s.spineEquivCache))
 	}
 }
 
@@ -1429,6 +1604,90 @@ func gssStacksEqualForLanguage(lang *Language, a, b gssStack) bool {
 	return gssStacksEqualForLanguageWithScratch(nil, lang, a, b)
 }
 
+type spinePairKey struct {
+	a *gssNode
+	b *gssNode
+}
+
+// gssSpineEqualMemo walks the two spines top-down, consulting the spine-equality
+// memo at every position. On the first memoized pair the whole remaining spine
+// answer is known, so the walk stops. It is the iterative twin of the original
+// gssStacksEqual loop (equal answer for equal inputs) plus back-fill: the walk
+// visits pairs (p0,p1,..,pd) before it decides at depth d (convergence,
+// state/payload mismatch, or a memo hit); every shallower pair shares that same
+// answer because they all carry the identical deciding suffix, so one computed
+// verdict is stored for all of them. Iterative (not recursive) to keep the Go
+// stack O(1) on deep spines.
+func gssSpineEqualMemo(scratch *glrMergeScratch, lang *Language, headA, headB *gssNode) bool {
+	if scratch == nil {
+		return gssSpineEqualRaw(scratch, lang, headA, headB)
+	}
+	visited := scratch.spineVisit[:0]
+	result := true
+	for an, bn := headA, headB; an != nil && bn != nil; an, bn = an.prev, bn.prev {
+		if an == bn {
+			result = true
+			break
+		}
+		if res, ok := lookupSpineEquivCache(scratch, an, bn); ok {
+			storeSpineEquivVisited(scratch, visited, res)
+			scratch.spineVisit = visited
+			return res
+		}
+		if an.entry.state != bn.entry.state {
+			visited = append(visited, spinePairKey{an, bn})
+			result = false
+			break
+		}
+		if !stackEntryPayloadsEquivalentForLanguageWithScratch(scratch, lang, an.entry, bn.entry) {
+			visited = append(visited, spinePairKey{an, bn})
+			result = false
+			break
+		}
+		visited = append(visited, spinePairKey{an, bn})
+	}
+	storeSpineEquivVisited(scratch, visited, result)
+	scratch.spineVisit = visited
+	return result
+}
+
+func storeSpineEquivVisited(scratch *glrMergeScratch, visited []spinePairKey, result bool) {
+	for i := range visited {
+		storeSpineEquivCache(scratch, visited[i].a, visited[i].b, result)
+	}
+}
+
+// gssSpineEqualRaw reproduces the original memo-free spine walk. Used only by
+// the GOT_DEBUG_MERGE_EQUIV assertion to confirm the memo answer is exact.
+func gssSpineEqualRaw(scratch *glrMergeScratch, lang *Language, headA, headB *gssNode) bool {
+	for an, bn := headA, headB; an != nil && bn != nil; an, bn = an.prev, bn.prev {
+		if an == bn {
+			return true
+		}
+		if an.entry.state != bn.entry.state {
+			return false
+		}
+		if !stackEntryPayloadsEquivalentForLanguageWithScratch(scratch, lang, an.entry, bn.entry) {
+			return false
+		}
+	}
+	return true
+}
+
+func debugCheckSpineEquiv(scratch *glrMergeScratch, lang *Language, headA, headB *gssNode, got bool) {
+	debugMergeEquivChecks++
+	want := gssSpineEqualRaw(scratch, lang, headA, headB)
+	if want == got {
+		return
+	}
+	debugMergeEquivDiverge++
+	if debugMergeEquivReportsLt > 0 {
+		debugMergeEquivReportsLt--
+		fmt.Fprintf(os.Stderr,
+			"MERGE-EQUIV divergence: headA=%p headB=%p memo=%v full=%v\n", headA, headB, got, want)
+	}
+}
+
 func gssStacksEqualForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b gssStack) bool {
 	if a.head == b.head {
 		return true
@@ -1453,22 +1712,17 @@ func gssStacksEqualForLanguageWithScratch(scratch *glrMergeScratch, lang *Langua
 	}
 	audit := activeEquivAudit(scratch)
 	if audit == nil {
-		for an, bn := a.head, b.head; an != nil && bn != nil; an, bn = an.prev, bn.prev {
-			if an == bn {
-				storeGSSStackEquivCache(scratch, a.head, b.head, true)
-				return true
-			}
-			if an.entry.state != bn.entry.state {
-				storeGSSStackEquivCache(scratch, a.head, b.head, false)
-				return false
-			}
-			if !stackEntryPayloadsEquivalentForLanguageWithScratch(scratch, lang, an.entry, bn.entry) {
-				storeGSSStackEquivCache(scratch, a.head, b.head, false)
-				return false
-			}
+		if !mergeEquivMemoEnabled {
+			res := gssSpineEqualRaw(scratch, lang, a.head, b.head)
+			storeGSSStackEquivCache(scratch, a.head, b.head, res)
+			return res
 		}
-		storeGSSStackEquivCache(scratch, a.head, b.head, true)
-		return true
+		res := gssSpineEqualMemo(scratch, lang, a.head, b.head)
+		if debugMergeEquiv {
+			debugCheckSpineEquiv(scratch, lang, a.head, b.head, res)
+		}
+		storeGSSStackEquivCache(scratch, a.head, b.head, res)
+		return res
 	}
 	for an, bn, depthFromTop := a.head, b.head, 0; an != nil && bn != nil; an, bn, depthFromTop = an.prev, bn.prev, depthFromTop+1 {
 		if an == bn {
@@ -4685,7 +4939,7 @@ func (s *glrMergeScratch) allocatedBytes() int64 {
 	if s == nil {
 		return 0
 	}
-	return s.resultBytes + s.slotBytes + s.largeSlotBytes + s.equivCacheBytes + s.stackEquivBytes + s.frontierHashBytes + s.shapePrefixBytes + s.cleanZeroBytes
+	return s.resultBytes + s.slotBytes + s.largeSlotBytes + s.equivCacheBytes + s.stackEquivBytes + s.spineEquivBytes + s.frontierHashBytes + s.shapePrefixBytes + s.cleanZeroBytes
 }
 
 func (s *glrMergeScratch) reset() {
@@ -4718,6 +4972,7 @@ func (s *glrMergeScratch) reset() {
 	}
 	s.equivCacheBytes = glrNodeEquivCacheBytesForCap(cap(s.equivCache))
 	s.stackEquivBytes = glrStackEquivCacheBytesForCap(cap(s.stackEquivCache))
+	s.spineEquivBytes = glrSpineEquivCacheBytesForCap(cap(s.spineEquivCache))
 	s.frontierHashBytes = glrStackFrontierHashCacheBytesForCap(cap(s.frontierHashCache))
 	s.frontierMergeHash = false
 	if len(s.cErrorCost) > maxRetainedMergeResultCap {
@@ -4794,6 +5049,13 @@ func glrStackEquivCacheBytesForCap(n int) int64 {
 		return 0
 	}
 	return int64(n) * int64(unsafe.Sizeof(glrStackEquivCacheEntry{}))
+}
+
+func glrSpineEquivCacheBytesForCap(n int) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return int64(n) * int64(unsafe.Sizeof(glrSpineEquivCacheEntry{}))
 }
 
 func glrStackFrontierHashCacheBytesForCap(n int) int64 {

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -694,8 +694,9 @@ func coalesceForestWithRaw(p *Parser, arena *nodeArena, index *gssForestIndex, s
 }
 
 type forestAlternativeIndex struct {
-	nodes map[*Node]*gssForestNode
-	slots map[forestAlternativeSlotKey]forestAlternativeSlot
+	nodes   map[*Node]*gssForestNode
+	byStart map[uint32][]*Node
+	slots   map[forestAlternativeSlotKey]forestAlternativeSlot
 }
 
 type forestAlternativeSlotKey struct {
@@ -732,8 +733,9 @@ func forestAlternativeIndexCapacityForSource(sourceLen int) int {
 
 func newForestAlternativeIndex(capacity int) *forestAlternativeIndex {
 	return &forestAlternativeIndex{
-		nodes: make(map[*Node]*gssForestNode, capacity),
-		slots: make(map[forestAlternativeSlotKey]forestAlternativeSlot, capacity),
+		nodes:   make(map[*Node]*gssForestNode, capacity),
+		byStart: make(map[uint32][]*Node, max(16, capacity/4)),
+		slots:   make(map[forestAlternativeSlotKey]forestAlternativeSlot, capacity),
 	}
 }
 
@@ -742,8 +744,29 @@ func forestRecordAlternative(alternatives *forestAlternativeIndex, entry stackEn
 		return
 	}
 	if n := stackEntryNode(entry); n != nil {
+		if _, exists := alternatives.nodes[n]; !exists {
+			if alternatives.byStart == nil {
+				alternatives.byStart = make(map[uint32][]*Node, 16)
+			}
+			alternatives.byStart[n.startByte] = append(alternatives.byStart[n.startByte], n)
+		}
 		alternatives.nodes[n] = node
 	}
+}
+
+func forestAlternativeCandidatesStartingAt(alternatives *forestAlternativeIndex, startByte uint32) []*Node {
+	if alternatives == nil {
+		return nil
+	}
+	if len(alternatives.byStart) == 0 && len(alternatives.nodes) > 0 {
+		alternatives.byStart = make(map[uint32][]*Node, max(16, len(alternatives.nodes)/4))
+		for n := range alternatives.nodes {
+			if n != nil {
+				alternatives.byStart[n.startByte] = append(alternatives.byStart[n.startByte], n)
+			}
+		}
+	}
+	return alternatives.byStart[startByte]
 }
 
 func forestRecordParentChildAlternatives(alternatives *forestAlternativeIndex, parent *Node, children []*Node, rawEntries []stackEntry) {
@@ -1575,11 +1598,8 @@ func forestRootVisibleContainerAlternativeForSlice(p *Parser, arena *nodeArena, 
 	childCount := resultChildCount(root)
 	var best *Node
 	bestEnd := 0
-	for candidate := range alternatives.nodes {
+	for _, candidate := range forestAlternativeCandidatesStartingAt(alternatives, first.startByte) {
 		if !forestVisibleNamedStructuralContainer(p, candidate) || candidate.isExtra() || candidate.isMissing() {
-			continue
-		}
-		if candidate.startByte != first.startByte {
 			continue
 		}
 		for end := childCount; end > start; end-- {

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2617,8 +2617,8 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 			// arm can be the branch the recovery cost competition keeps (the php
 			// comma-list wreckage lesson in conflict_policy.go), so recover-active
 			// languages keep the ordinary GLR fork.
-			if !recoverActive && len(nodeActions) > 1 {
-				if folded, ok := singleReduceAgainstRepetitionShiftConflictChoice(nodeActions); ok {
+			if len(nodeActions) > 1 {
+				if folded, ok := p.cRepetitionSkipForestConflictChoice(recoverActive, nodeActions); ok {
 					nodeActions = p.forestSingletonActions(folded)
 				}
 			}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2580,6 +2580,28 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 
 			nodeActions := p.actionsForParseState(node.state, tok.Symbol, lang.ParseActions)
 			nodeActions = p.forestResolveConflict(node.state, tok, nodeActions)
+			// C's global repetition-skip fold, mirrored into the forest engine.
+			// Production's deterministicConflictChoiceForDispatch resolves a
+			// {1 repetition-marked SHIFT, 1 REDUCE} conflict by taking the REDUCE
+			// (C's ts_parser__advance runs `if (action.shift.repetition) break;`,
+			// parser.c) — a deterministic, lossless fold of the list spine, not a
+			// fork. forestResolveConflict did NOT carry this fold, so a long
+			// repeated list (a bash `program` is repeat($._statement)) forked at
+			// every statement boundary, building an O(n^2) GSS frontier, and
+			// reached EOF with only mid-list lineages surviving — none in a
+			// list-closed (accept) state — declining eof_no_root
+			// (medium__install.sh: forest reached EOF with 2 non-accepting stacks
+			// while tree-sitter-C parses the file clean). Applying the same fold
+			// lets the forest close the list and accept, byte-matching C. Gated to
+			// non-recover forest lineages: with error recovery the repetition-shift
+			// arm can be the branch the recovery cost competition keeps (the php
+			// comma-list wreckage lesson in conflict_policy.go), so recover-active
+			// languages keep the ordinary GLR fork.
+			if !recoverActive && len(nodeActions) > 1 {
+				if folded, ok := singleReduceAgainstRepetitionShiftConflictChoice(nodeActions); ok {
+					nodeActions = p.forestSingletonActions(folded)
+				}
+			}
 			if progress.enabled {
 				reduceActions, shiftActions, acceptActions := 0, 0, 0
 				for _, act := range nodeActions {

--- a/grammars/bash_forest_repetition_fold_test.go
+++ b/grammars/bash_forest_repetition_fold_test.go
@@ -1,0 +1,39 @@
+package grammars
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	ts "github.com/odvcencio/gotreesitter"
+)
+
+// TestBashForestRepetitionFoldDispatch guards the forest-side mirror of C's
+// repetition-skip fold. Bash program bodies are repeated statement lists; if the
+// forest engine forks {repetition SHIFT, REDUCE} at every statement boundary
+// instead of folding the list spine, it reaches EOF without an accepting
+// closed-list lineage and declines eof_no_root.
+func TestBashForestRepetitionFoldDispatch(t *testing.T) {
+	path := filepath.Join("..", "cgo_harness", "corpus_real", "bash", "medium__install.sh")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("bash corpus fixture unavailable: %v", err)
+	}
+
+	parser := ts.NewParser(BashLanguage())
+	parser.SetTimeoutMicros(30 * 1000 * 1000)
+	tree, ok := parser.ParseForestExperimental(src)
+	if !ok || tree == nil {
+		_, _, reason, _ := parser.ForestDeclineInfo()
+		t.Fatalf("forest declined %s (reason=%q); want dispatch via repetition-skip fold", filepath.Base(path), reason)
+	}
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("forest tree HasError for %s; want clean dispatch", filepath.Base(path))
+	}
+	if got, want := root.ChildCount(), 65; got != want {
+		t.Fatalf("forest root childCount=%d, want %d (C-oracle shape)", got, want)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -5916,7 +5916,7 @@ func (p *Parser) ensureParseInitialCapacity(source []byte, arenaClass arenaClass
 }
 
 func (p *Parser) ensureFullParseInitialCapacity(source []byte, arena *nodeArena, scratch *parserScratch) {
-	target := parseFullArenaNodeCapacity(len(source), p.fullArenaHintCapacity())
+	target := parseFullArenaNodeCapacityForSource(source, p.language, p.fullArenaHintCapacity())
 	checkpointCapacityTarget := target
 	switch {
 	case p.finalChildRefs:

--- a/parser_api.go
+++ b/parser_api.go
@@ -115,6 +115,7 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 		return
 	}
 	if tree.resultCompatibilityPending {
+		finalizeDeferredReturnedTreeTruncation(tree, source)
 		return
 	}
 	if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
@@ -133,6 +134,7 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 		return
 	}
 	if tree.resultCompatibilityPending {
+		finalizeDeferredReturnedTreeTruncation(tree, source)
 		return
 	}
 	if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
@@ -140,6 +142,28 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 		return
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
+}
+
+// finalizeDeferredReturnedTreeTruncation enforces the silent-truncation contract
+// for a returned tree whose result-compatibility normalization is deferred
+// (ini/typescript/tsx via shouldDeferResultCompatibility). finalizeReturnedTreeRootSpan
+// is skipped for these trees, so without this a truncated typescript parse
+// (checker.ts / dom.generated.d.ts) returns a SILENT prefix-only program root
+// (root.HasError()==false, ParseStoppedEarly()==false). The deferred trees
+// already carry a correct rt.Truncated (recordParseRuntimeRootStats computes it,
+// trivia tail included); only the consumer-visible HasError signal is missing.
+// Clean deferred trees (rt.Truncated==false, the common typescript path) are
+// untouched and keep their lazy compat.
+func finalizeDeferredReturnedTreeTruncation(tree *Tree, _ []byte) {
+	if tree == nil || !tree.parseRuntime.Truncated {
+		return
+	}
+	// Flush the deferred compat normalization first (only for the rare truncated
+	// case) so the HasError mark lands on the final normalized root and cannot be
+	// dropped if a normalizer rebuilds the root. ensureResultCompatibility clears
+	// resultCompatibilityPending.
+	tree.ensureResultCompatibility()
+	markTruncatedTreeHasError(tree.parseRuntime, rawRootOrNil(tree))
 }
 
 const forestIncrementalReuseUnsupportedReason = "old tree was built by GSS forest fast path"
@@ -318,7 +342,38 @@ func finalizeReturnedTreeRootSpan(tree *Tree, source []byte) {
 	if rt.Truncated && parserTailAllowsCleanAcceptance(source, tailStart, rt.ExpectedEOFByte, tree.includedRanges) {
 		rt.Truncated = false
 	}
+	markTruncatedTreeHasError(rt, root)
 	tree.setParseRuntime(rt)
+}
+
+// markTruncatedTreeHasError repairs the wave2b SILENT-TRUNCATION contract: a
+// returned tree whose root does not span the input (rt.Truncated, a real
+// non-trivia tail) MUST carry a reliable, consumer-visible error signal. C's
+// recovery guarantees its returned tree always spans the input and reports
+// HasError() for these inputs (the C-oracle confirms every one of the 14 known
+// members has a full-span C root; 7 are ERROR-bearing). When our GLR frontier
+// dies mid-file (ParseStopNoStacksAlive) after the live stack already reduced to
+// a clean start symbol, we return a prefix-only root with hasError=false and
+// ParseStoppedEarly()==false — the swallowed-error class (crystal string.cr,
+// typescript checker.ts / dom.generated.d.ts; the _pydecimal.py family). The
+// tree is definitionally erroneous (real source past root.EndByte was dropped),
+// so surface root.HasError()==true. The tree is left honestly TRUNCATED (root
+// span unchanged, rt.Truncated preserved) — matching the established contract
+// that a non-clean tail is never silently extended
+// (TestFinalizeReturnedTreeRootSpanDoesNotExtendNonCleanTail); making the whole
+// span cover the input is the GLR/dispatch layer's job (siblings), not the
+// result-reporting layer's.
+//
+// Only ever SETS the flag (never clears): a truncated tree that already reports
+// HasError (11 of the 14 members) is untouched. Trivia-only tails already
+// cleared rt.Truncated above, and early-stop trees (node_limit / memory_budget /
+// timeout) never reach this finalizer, so hard budget aborts keep their honest
+// Truncated flag without a synthetic error mark.
+func markTruncatedTreeHasError(rt ParseRuntime, root *Node) {
+	if !rt.Truncated || root == nil || root.hasError() {
+		return
+	}
+	root.setHasError(true)
 }
 
 func extendRootToAcceptedCleanTail(root *Node, source []byte, expectedEOFByte uint32, included []Range) bool {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -280,6 +280,13 @@ func TestGeneratedRepeatBoundaryConflictAllowsMixedReduces(t *testing.T) {
 }
 
 func TestDeterministicConflictChoiceKeepsNonGeneratedShortcut(t *testing.T) {
+	// Wave-2b: the php state-2 SHIFT-preferring shortcut is retired in favor
+	// of the global C repetition-skip fold (cRepetitionSkipConflictChoice,
+	// C parser.c:1625 `if (action.shift.repetition) break;`). The contract
+	// pinned here is the fold's: an error-free lineage takes the single
+	// REDUCE deterministically (C folds and re-dispatches the same
+	// lookahead); without a stack (nil = no lineage evidence) dispatch makes
+	// no deterministic choice and the GLR fork stands.
 	lang := &Language{
 		Name:        "php",
 		SymbolNames: []string{"end", "namespace", "\\", "name", "use", "new", "program_repeat1"},
@@ -298,12 +305,20 @@ func TestDeterministicConflictChoiceKeepsNonGeneratedShortcut(t *testing.T) {
 		{Type: ParseActionShift, State: 1846, Repetition: true},
 	}
 	parser := &Parser{language: lang}
-	chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, nil, Token{Symbol: 1}, 2, actions, 2, nil)
-	if !ok {
-		t.Fatal("deterministicConflictChoiceForDispatch = false, want non-generated PHP shortcut")
+	if chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, nil, Token{Symbol: 1}, 2, actions, 2, nil); ok {
+		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v with nil stack, want GLR fork", chosen)
 	}
-	if chosen.Type != ParseActionShift || chosen.State != 1846 || !chosen.Repetition {
-		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v, want repetition shift", chosen)
+	cleanStack := &glrStack{}
+	chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, cleanStack, Token{Symbol: 1}, 2, actions, 2, nil)
+	if !ok {
+		t.Fatal("deterministicConflictChoiceForDispatch = false for clean lineage, want global repetition-skip fold")
+	}
+	if chosen.Type != ParseActionReduce || chosen.Symbol != 6 {
+		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v, want program_repeat1 reduce (C repetition-skip fold)", chosen)
+	}
+	erroredStack := &glrStack{cEverErrored: true}
+	if chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, erroredStack, Token{Symbol: 1}, 2, actions, 2, nil); ok {
+		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v on wreckage lineage, want GLR fork", chosen)
 	}
 }
 

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1270,6 +1270,50 @@ func TestCppAcceptedErrorRetryPreservesTruncatedMergeRetry(t *testing.T) {
 	}
 }
 
+func TestBashAcceptedErrorRetrySkipsCompleteTree(t *testing.T) {
+	tree := &Tree{
+		language: &Language{Name: "bash"},
+		root: &Node{
+			endByte: 128,
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: 128,
+			RootEndByte:     128,
+			MaxStacksSeen:   18,
+		},
+	}
+
+	if shouldRetryAcceptedErrorParse(tree, 128, 18) {
+		t.Fatal("shouldRetryAcceptedErrorParse(bash complete accepted error) = true, want false")
+	}
+	if got := fullParseRetryMergePerKeyOverride(tree, 128, 18); got != 0 {
+		t.Fatalf("fullParseRetryMergePerKeyOverride(bash complete accepted error) = %d, want 0", got)
+	}
+}
+
+func TestBashAcceptedErrorRetryPreservesTruncatedMergeRetry(t *testing.T) {
+	tree := &Tree{
+		language: &Language{Name: "bash"},
+		root: &Node{
+			endByte: 96,
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: 128,
+			RootEndByte:     96,
+			Truncated:       true,
+			MaxStacksSeen:   18,
+		},
+	}
+
+	if got := fullParseRetryMergePerKeyOverride(tree, 128, 18); got != fullParseRetryMaxMergePerKey {
+		t.Fatalf("fullParseRetryMergePerKeyOverride(bash truncated accepted error) = %d, want %d", got, fullParseRetryMaxMergePerKey)
+	}
+}
+
 func TestJavaAcceptedErrorRetryUsesWideMergeRetry(t *testing.T) {
 	errChild := &Node{
 		symbol: errorSymbol,

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2628,6 +2628,36 @@ func TestParseFullArenaInitialNodeCapacityScalesForLargeSources(t *testing.T) {
 	}
 }
 
+func TestParseFullArenaNodeCapacityCapsLargeTypeScriptFourslashCommentFixture(t *testing.T) {
+	source := []byte("/// <reference path=\"fourslash.ts\" />\n////var route = [")
+	source = append(source, bytes.Repeat([]byte("[51.1,-0.2],"), 1024*1024/12)...)
+	source = append(source, []byte("];\nverify.completions({ marker: \"\", excludes: [\"\"] });\n")...)
+
+	got := parseFullArenaNodeCapacityForSource(source, &Language{Name: "typescript"}, 0)
+	if got != typeScriptFourslashLargeCommentArenaNodeCap {
+		t.Fatalf("parseFullArenaNodeCapacityForSource(fourslash) = %d, want %d", got, typeScriptFourslashLargeCommentArenaNodeCap)
+	}
+}
+
+func TestParseFullArenaNodeCapacityKeepsLargeSourceFloorForNonFourslash(t *testing.T) {
+	source := bytes.Repeat([]byte("let x = 1;\n"), 128*1024)
+	got := parseFullArenaNodeCapacityForSource(source, &Language{Name: "typescript"}, 0)
+	want := parseFullArenaNodeCapacity(len(source), 0)
+	if got != want {
+		t.Fatalf("parseFullArenaNodeCapacityForSource(non-fourslash) = %d, want %d", got, want)
+	}
+}
+
+func TestParseFullArenaNodeCapacityKeepsLargeSourceFloorForOtherLanguages(t *testing.T) {
+	source := []byte("/// <reference path=\"fourslash.ts\" />\n////var route = [")
+	source = append(source, bytes.Repeat([]byte("[51.1,-0.2],"), 1024*1024/12)...)
+	got := parseFullArenaNodeCapacityForSource(source, &Language{Name: "python"}, 0)
+	want := parseFullArenaNodeCapacity(len(source), 0)
+	if got != want {
+		t.Fatalf("parseFullArenaNodeCapacityForSource(other lang) = %d, want %d", got, want)
+	}
+}
+
 func TestParseFullArenaInitialNodeCapacityPreallocatesMediumSources(t *testing.T) {
 	sourceLen := 192 * 1024
 	got := parseFullArenaInitialNodeCapacity(sourceLen)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1224,6 +1224,71 @@ func TestShouldRunInitialFullParseMergeRetry(t *testing.T) {
 	if !shouldRunInitialFullParseMergeRetry(tree) {
 		t.Fatal("shouldRunInitialFullParseMergeRetry(no_stacks_alive) = false, want true")
 	}
+	tree = &Tree{
+		language: &Language{Name: "c_sharp"},
+		root: &Node{
+			endByte: 128,
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: 128,
+			RootEndByte:     128,
+			MaxStacksSeen:   64,
+		},
+	}
+	if shouldRunInitialFullParseMergeRetry(tree) {
+		t.Fatal("shouldRunInitialFullParseMergeRetry(c_sharp accepted error) = true, want false")
+	}
+	tree.parseRuntime.Truncated = true
+	if !shouldRunInitialFullParseMergeRetry(tree) {
+		t.Fatal("shouldRunInitialFullParseMergeRetry(c_sharp truncated accepted error) = false, want true")
+	}
+}
+
+func TestCSharpAcceptedErrorTreeCanUseNamespaceRecovery(t *testing.T) {
+	source := []byte("using X;\nnamespace N { class C { } }\n")
+	nsStart := uint32(bytes.Index(source, []byte("namespace")))
+	nsEnd := uint32(bytes.LastIndexByte(source, '}') + 1)
+	if nsStart == 0 || nsEnd == 0 {
+		t.Fatal("test source does not contain expected namespace span")
+	}
+	lang := &Language{
+		Name:        "c_sharp",
+		SymbolNames: []string{"EOF", "compilation_unit", "namespace_declaration"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "compilation_unit", Visible: true, Named: true},
+			{Name: "namespace_declaration", Visible: true, Named: true},
+		},
+	}
+	arena := newNodeArena(arenaClassFull)
+	namespace := newLeafNodeInArena(arena, 2, true, nsStart, nsEnd, Point{}, Point{})
+	namespace.setHasError(true)
+	root := newParentNodeInArena(arena, 1, true, []*Node{namespace}, nil, 0)
+	tree := &Tree{
+		language: lang,
+		root:     root,
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: uint32(len(source)),
+			RootEndByte:     uint32(len(source)),
+			MaxStacksSeen:   64,
+		},
+	}
+
+	if !csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		t.Fatal("csharpAcceptedErrorTreeCanUseNamespaceRecovery = false, want true")
+	}
+	tree.parseRuntime.Truncated = true
+	if csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		t.Fatal("csharpAcceptedErrorTreeCanUseNamespaceRecovery(truncated) = true, want false")
+	}
+	tree.parseRuntime.Truncated = false
+	root.ownerArena = nil
+	if csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		t.Fatal("csharpAcceptedErrorTreeCanUseNamespaceRecovery(no arena) = true, want false")
+	}
 }
 
 func TestCppAcceptedErrorRetrySkipsCompleteTree(t *testing.T) {

--- a/parser_limits.go
+++ b/parser_limits.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "sync/atomic"
+import (
+	"bytes"
+	"sync/atomic"
+)
 
 func parseIterations(sourceLen int) int {
 	return max(10_000, sourceLen*30)
@@ -102,6 +105,30 @@ func parseFullArenaNodeCapacity(sourceLen, hint int) int {
 		return max(target, limit)
 	}
 	return max(target, hint)
+}
+
+const typeScriptFourslashLargeCommentArenaNodeCap = 64 * 1024
+
+func parseFullArenaNodeCapacityForSource(source []byte, lang *Language, hint int) int {
+	target := parseFullArenaNodeCapacity(len(source), hint)
+	if !typeScriptLargeFourslashSource(source, lang) || target <= typeScriptFourslashLargeCommentArenaNodeCap {
+		return target
+	}
+	return max(nodeCapacityForClass(arenaClassFull), typeScriptFourslashLargeCommentArenaNodeCap)
+}
+
+func typeScriptLargeFourslashSource(source []byte, lang *Language) bool {
+	if lang == nil || len(source) < 1024*1024 {
+		return false
+	}
+	switch lang.Name {
+	case "typescript", "tsx":
+	default:
+		return false
+	}
+	prefixLen := min(len(source), 8192)
+	prefix := source[:prefixLen]
+	return bytes.Contains(prefix, []byte("fourslash.ts")) && bytes.Contains(prefix, []byte("\n////"))
 }
 
 func parseFullArenaHintLimit(sourceLen int) int {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1415,6 +1415,11 @@ func init() {
 	gssPrefixAggGen.Store(1)
 }
 
+// DebugGSSPrefixAggGen returns the current global GSS prefix-aggregate
+// generation. Monotonic (only Add(1)); the delta across a parse equals the
+// number of choke-point invalidations. Measurement helper (wave-2b).
+func DebugGSSPrefixAggGen() uint64 { return gssPrefixAggGen.Load() }
+
 // cStackPrefixAgg returns the cumulative (error cost, visible subtree count)
 // of head's prev chain, filling the on-node aggregates bottom-up from the
 // deepest still-valid node — O(new or invalidated suffix), O(1) steady-state.

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -1142,6 +1142,13 @@ func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, p *Parser, la
 	recoveryCount := 0
 	for i := 0; i < len(root.children); {
 		if recoveryCount < csharpMaxNamespaceRecoveries {
+			if recovered, ok := csharpRecoverErroredNamespaceDeclaration(root.children[i], source, p, lang, root.ownerArena); ok {
+				recoveredChildren = append(recoveredChildren, recovered)
+				i++
+				changed = true
+				recoveryCount++
+				continue
+			}
 			if recovered, next, ok := csharpRecoverNamespaceFromChildren(root.children, i, source, p, lang, root.ownerArena); ok {
 				recoveredChildren = append(recoveredChildren, recovered)
 				i = next
@@ -1174,6 +1181,71 @@ func normalizeCSharpRecoveredNamespaces(root *Node, source []byte, p *Parser, la
 			populateParentNode(root, root.children)
 		}
 	}
+}
+
+func csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree *Tree, source []byte) bool {
+	if tree == nil || len(source) == 0 || tree.language == nil || tree.language.Name != "c_sharp" {
+		return false
+	}
+	rt := tree.ParseRuntime()
+	if rt.StopReason != ParseStopAccepted || rt.Truncated || rt.TokenSourceEOFEarly {
+		return false
+	}
+	if !retryTreeHasError(tree) {
+		return false
+	}
+	root := rawRootOrNil(tree)
+	if root == nil || root.ownerArena == nil {
+		return false
+	}
+	rootType := root.Type(tree.language)
+	if rootType != "ERROR" && rootType != "compilation_unit" {
+		return false
+	}
+	for _, child := range root.children {
+		if _, _, ok := csharpRecoverableErroredNamespaceDeclarationSpan(child, source, tree.language); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func csharpRecoverErroredNamespaceDeclaration(n *Node, source []byte, p *Parser, lang *Language, arena *nodeArena) (*Node, bool) {
+	start, end, ok := csharpRecoverableErroredNamespaceDeclarationSpan(n, source, lang)
+	if !ok {
+		return nil, false
+	}
+	return csharpBuildRecoveredNamespaceDeclarationFromErrorRoot(n, source, start, end, p, lang, arena)
+}
+
+func csharpRecoverableErroredNamespaceDeclarationSpan(n *Node, source []byte, lang *Language) (uint32, uint32, bool) {
+	if n == nil || lang == nil || lang.Name != "c_sharp" || !n.HasError() || n.Type(lang) != "namespace_declaration" {
+		return 0, 0, false
+	}
+	if n.startByte >= n.endByte || int(n.endByte) > len(source) {
+		return 0, 0, false
+	}
+	nsStart := csharpSkipSpaceBytes(source, n.startByte)
+	if nsStart >= n.endByte || !csharpHasKeywordAt(source, nsStart, "namespace") {
+		return 0, 0, false
+	}
+	nameStart := csharpSkipSpaceBytes(source, nsStart+uint32(len("namespace")))
+	if nameStart >= n.endByte {
+		return 0, 0, false
+	}
+	openBrace := csharpFindTopLevelByte(source, nameStart, n.endByte, '{')
+	if openBrace >= n.endByte {
+		return 0, 0, false
+	}
+	closeBrace := csharpFindMatchingBraceByte(source, int(openBrace), int(n.endByte))
+	if closeBrace < 0 {
+		return 0, 0, false
+	}
+	nsEnd := uint32(closeBrace + 1)
+	if nsEnd > n.endByte || !bytesAreTrivia(source[nsEnd:n.endByte]) {
+		return 0, 0, false
+	}
+	return nsStart, nsEnd, true
 }
 
 func csharpRecoverNamespaceFromChildren(children []*Node, startIdx int, source []byte, p *Parser, lang *Language, arena *nodeArena) (*Node, int, bool) {

--- a/parser_result_csharp_namespace.go
+++ b/parser_result_csharp_namespace.go
@@ -46,17 +46,17 @@ func csharpBuildRecoveredNamespaceDeclarationFromErrorRoot(errRoot *Node, source
 	// produce before it died, which for large real-world files can be a small
 	// prefix of the body (or nothing at all — a pure GLR dead end leaves no
 	// children to recover from downstream of that point). Try two purely
-	// source-based, bounded reconstructions of the whole body too — the primary
-	// driver (csharpRecoverNamespaceBodyMembersFromSource, which additionally
-	// covers struct/interface/enum shells and preprocessor-skipped spans) and
-	// the Alt driver (csharpRecoverNamespaceBodyMembersFromSourceAlt, upstream
-	// #138, whose per-member wrapped reparse recovers strictly more methods on
-	// some real-world files) — and keep whichever of all three candidates
-	// recovers the most (csharpChooseRecoveredNamespaceMembers). Remove these
-	// fallbacks once the GLR engine gains real mid-parse error recovery (see
-	// #136).
-	sourceMembers, sourceOK := csharpRecoverNamespaceBodyMembersFromSource(source, openBrace, uint32(closeBrace), p, lang, arena)
+	// source-based, bounded reconstructions of the whole body too. On large
+	// namespace bodies, try the Alt driver first and skip the primary driver only
+	// when Alt clearly beats the children-based recovery; this avoids a second
+	// whole-body member-reparse pass on Bicep-sized files while preserving the
+	// primary driver's extra coverage for smaller or marginal cases.
+	var sourceMembers []*Node
+	sourceOK := false
 	altMembers, altOK := csharpRecoverNamespaceBodyMembersFromSourceAlt(source, openBrace, uint32(closeBrace), p, arena)
+	if !csharpLargeNamespaceAltRecoveryCanSkipPrimary(end-start, members, ok, altMembers, altOK, lang) {
+		sourceMembers, sourceOK = csharpRecoverNamespaceBodyMembersFromSource(source, openBrace, uint32(closeBrace), p, lang, arena)
+	}
 	if best, bestOK := csharpChooseRecoveredNamespaceMembers(lang,
 		csharpRecoveredMembersCandidate{members: members, ok: ok},
 		csharpRecoveredMembersCandidate{members: sourceMembers, ok: sourceOK},
@@ -269,6 +269,35 @@ var csharpRecoveredDeclarationNodeTypes = map[string]bool{
 type csharpRecoveredDeclarationStats struct {
 	total   int
 	methods int
+}
+
+const (
+	csharpLargeNamespaceRecoveryBodyBytes     = 64 * 1024
+	csharpLargeNamespaceAltMethodWinThreshold = 8
+	csharpLargeNamespaceAltTotalWinThreshold  = 16
+)
+
+func csharpLargeNamespaceAltRecoveryCanSkipPrimary(spanBytes uint32, childMembers []*Node, childOK bool, altMembers []*Node, altOK bool, lang *Language) bool {
+	if spanBytes < csharpLargeNamespaceRecoveryBodyBytes || lang == nil || !altOK || len(altMembers) == 0 {
+		return false
+	}
+	childStats := csharpRecoveredDeclarationStats{}
+	if childOK && len(childMembers) > 0 {
+		childStats = csharpCountRecoveredDeclarationNodes(childMembers, lang)
+	}
+	altStats := csharpCountRecoveredDeclarationNodes(altMembers, lang)
+	return csharpLargeNamespaceAltStatsCanSkipPrimary(spanBytes, childStats, altStats)
+}
+
+func csharpLargeNamespaceAltStatsCanSkipPrimary(spanBytes uint32, childStats, altStats csharpRecoveredDeclarationStats) bool {
+	if spanBytes < csharpLargeNamespaceRecoveryBodyBytes {
+		return false
+	}
+	if !csharpPreferRecoveredDeclarations(altStats, childStats) {
+		return false
+	}
+	return altStats.methods >= childStats.methods+csharpLargeNamespaceAltMethodWinThreshold ||
+		altStats.total >= childStats.total+csharpLargeNamespaceAltTotalWinThreshold
 }
 
 // csharpCountRecoveredDeclarationNodes recursively tallies declaration-shaped

--- a/parser_result_csharp_test.go
+++ b/parser_result_csharp_test.go
@@ -26,6 +26,23 @@ func TestCSharpFindQueryAssignmentSpecs(t *testing.T) {
 	}
 }
 
+func TestCSharpLargeNamespaceAltStatsCanSkipPrimary(t *testing.T) {
+	child := csharpRecoveredDeclarationStats{total: 103, methods: 93}
+	alt := csharpRecoveredDeclarationStats{total: 126, methods: 116}
+	if !csharpLargeNamespaceAltStatsCanSkipPrimary(csharpLargeNamespaceRecoveryBodyBytes, child, alt) {
+		t.Fatal("large, clear alt win should skip primary source recovery")
+	}
+	if csharpLargeNamespaceAltStatsCanSkipPrimary(csharpLargeNamespaceRecoveryBodyBytes-1, child, alt) {
+		t.Fatal("small namespace must keep primary source recovery")
+	}
+	if csharpLargeNamespaceAltStatsCanSkipPrimary(csharpLargeNamespaceRecoveryBodyBytes, child, csharpRecoveredDeclarationStats{total: 110, methods: 96}) {
+		t.Fatal("marginal alt win must keep primary source recovery")
+	}
+	if csharpLargeNamespaceAltStatsCanSkipPrimary(csharpLargeNamespaceRecoveryBodyBytes, child, csharpRecoveredDeclarationStats{total: 140, methods: 90}) {
+		t.Fatal("alt with fewer methods must keep primary source recovery")
+	}
+}
+
 func TestCSharpParseQueryExpressionSpecWithGroupIntoOrder(t *testing.T) {
 	src := []byte("from a in sourceA\n" +
 		"        join b in sourceB on a.FK equals b.PK\n" +

--- a/parser_result_root_test.go
+++ b/parser_result_root_test.go
@@ -241,6 +241,61 @@ func TestFinalizeReturnedTreeRootSpanDoesNotExtendNonCleanTail(t *testing.T) {
 	if !tree.ParseRuntime().Truncated {
 		t.Fatal("runtime should still report truncation for non-clean tail")
 	}
+	// wave2b SILENT-TRUNCATION contract: a truncated non-clean tail must carry a
+	// consumer-visible error signal (root.HasError()), not just the internal
+	// Truncated flag. See markTruncatedTreeHasError.
+	if !root.HasError() {
+		t.Fatal("truncated non-clean tail must report root.HasError() (silent-truncation contract)")
+	}
+}
+
+// TestFinalizeReturnedTreeRootSpanFlagsSilentTruncation pins the wave2b fix: a
+// non-early-stop parse (ParseStopNoStacksAlive) whose live stack reduced to a
+// clean start symbol before the frontier died mid-file returns a prefix-only
+// root with hasError=false. finalizeReturnedTreeRootSpan must mark it HasError so
+// the returned tree is never a silent clean-looking prefix (crystal string.cr,
+// typescript checker.ts / dom.generated.d.ts class), while leaving it honestly
+// truncated (span unchanged, Truncated=true).
+func TestFinalizeReturnedTreeRootSpanFlagsSilentTruncation(t *testing.T) {
+	lang := &Language{
+		Name:        "root_silent_trunc",
+		SymbolNames: []string{"EOF", "source_file", "statement"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "source_file", Visible: true, Named: true},
+			{Name: "statement", Visible: true, Named: true},
+		},
+	}
+	// A cleanly-reduced source_file prefix [0,49) over a 100-byte input: the
+	// dropped tail [49,100) is real (non-trivia) source.
+	source := make([]byte, 100)
+	for i := range source {
+		source[i] = 'a'
+	}
+	child := NewLeafNode(2, true, 0, 49, Point{}, Point{Column: 49})
+	root := newParentNode(nil, 1, true, []*Node{child}, nil, 0)
+	tree := NewTree(root, source, lang)
+	t.Cleanup(tree.Release)
+	tree.setParseRuntime(ParseRuntime{
+		StopReason:      ParseStopNoStacksAlive,
+		SourceLen:       uint32(len(source)),
+		ExpectedEOFByte: uint32(len(source)),
+	})
+	if root.HasError() {
+		t.Fatal("precondition: synthetic clean prefix must start without an error")
+	}
+
+	finalizeReturnedTreeRootSpan(tree, source)
+
+	if root.HasError() != true {
+		t.Fatal("silent truncation must be flagged HasError after finalize")
+	}
+	if !tree.ParseRuntime().Truncated {
+		t.Fatal("tree must remain honestly truncated (Truncated=true)")
+	}
+	if got, want := root.EndByte(), uint32(49); got != want {
+		t.Fatalf("root span must be left truncated at %d, got %d (do not silently extend)", want, got)
+	}
 }
 
 func TestFinalizeForestRootReextendsAcceptedCleanTailAfterCompatibility(t *testing.T) {

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -114,6 +114,17 @@ func shouldRetryAcceptedErrorParse(tree *Tree, sourceLen int, initialMaxStacks i
 	if rt.StopReason != ParseStopAccepted || rt.Truncated || rt.TokenSourceEOFEarly {
 		return false
 	}
+	if tree.language != nil && tree.language.Name == "bash" {
+		// Bash uses the forest path for clean large-file parses; if production
+		// accepts a full-span error-bearing tree after the forest declines, the
+		// accepted-error retry has repeatedly proven to be wasted work on real
+		// corpus witnesses (for example git's t9300 fast-import script remains
+		// an error-bearing, C-divergent full-span tree while paying multiple
+		// full reparse passes). Keep structural/no-stack/node-limit retries
+		// available, but do not chase an accepted-error Bash tree that already
+		// reached EOF.
+		return false
+	}
 	if tree.language != nil && tree.language.Name == "cpp" {
 		return false
 	}
@@ -1196,6 +1207,11 @@ func fullParseRetryMergePerKeyOverride(tree *Tree, sourceLen int, initialMaxStac
 		return -4
 	}
 	if tree.language != nil && tree.language.Name == "cpp" &&
+		rt.StopReason == ParseStopAccepted && retryTreeHasError(tree) &&
+		!rt.Truncated && !rt.TokenSourceEOFEarly {
+		return 0
+	}
+	if tree.language != nil && tree.language.Name == "bash" &&
 		rt.StopReason == ParseStopAccepted && retryTreeHasError(tree) &&
 		!rt.Truncated && !rt.TokenSourceEOFEarly {
 		return 0

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1246,7 +1246,23 @@ func shouldRunInitialFullParseMergeRetry(tree *Tree) bool {
 	// node cap plus a larger merge bucket. Keep merge-per-key retries available
 	// after a widened node-budget pass if the parser still proves ambiguity-
 	// bound, but skip the dead intermediate pass up front.
-	return tree.ParseRuntime().StopReason != ParseStopNodeLimit
+	rt := tree.ParseRuntime()
+	if rt.StopReason == ParseStopNodeLimit {
+		return false
+	}
+	if tree.language != nil && tree.language.Name == "c_sharp" &&
+		rt.StopReason == ParseStopAccepted &&
+		retryTreeHasError(tree) &&
+		!rt.Truncated &&
+		!rt.TokenSourceEOFEarly {
+		// Large C# namespace bodies that accept with an error under the narrow
+		// first-pass stack cap have repeatedly spent close to a second in this
+		// same-stack merge retry without clearing the error. The existing clean
+		// widened-stack retry is the next useful pass; keep later merge retries
+		// available if that widened pass still returns an error.
+		return false
+	}
+	return true
 }
 
 func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree, runRetry fullParseRetryRunner) *Tree {
@@ -1351,6 +1367,11 @@ func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree,
 		rt := tree.ParseRuntime()
 		fmt.Fprintf(os.Stderr, "RETRYDBG entry stop=%v truncated=%v hasErr=%v maxStacksSeen=%d stacksOverride=%d nodesOverride=%d structResync=%v\n",
 			rt.StopReason, rt.Truncated, retryTreeHasError(tree), rt.MaxStacksSeen, maxStacksOverride, maxNodesOverride, structuralResyncRetry)
+	}
+	// C# namespace recovery can clear this exact accepted-error shape during
+	// normal result compatibility; avoid paying the full retry ladder first.
+	if csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
+		return tree
 	}
 	runRetryAttempt := func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
 		if p != nil {


### PR DESCRIPTION
## Summary

This PR improves GLR performance and correctness by memoizing spine-equality checks during GSS merges, mirroring C's repetition-skip conflict policy for deterministic folding (preventing O(n^2) forest expansion in Bash), and capping arena allocations for large TypeScript fourslash fixtures. It also fixes a silent-truncation contract bug where truncated trees lacked `HasError()`, and skips redundant retry passes for Bash and large C# namespace error trees.

## Changes

- Memoize GSS spine-equality checks via `spineEquivCache` in `glrMergeScratch`, with `GOT_DEBUG_MERGE_EQUIV` toggles for parity verification.
- Implement global `cRepetitionSkipConflictChoice` in `conflict_policy.go`, retiring most per-language repetition arms and applying the fold engine-wide with an opt-out list (dart, c, haskell, c_sharp).
- Mirror C's repetition-skip fold into the forest engine to prevent O(n^2) frontier expansion in Bash when processing repeated statement lists.
- Cap arena allocation for large TypeScript/TSX fourslash sources in `parser_limits.go` (capped at 64k nodes to prevent OOM on massive comment fixtures).
- Fix silent truncation contract: `finalizeDeferredReturnedTreeTruncation` and `markTruncatedTreeHasError` ensure truncated trees explicitly flag `HasError()` instead of returning clean-looking prefix trees.
- Skip redundant retry passes for Bash (`shouldRetryAcceptedErrorParse`) and large C# namespace error trees (`csharpAcceptedErrorTreeCanUseNamespaceRecovery`).
- Optimize C# namespace recovery by trying the Alt driver first and skipping the primary source-recovery pass on large namespaces when the Alt driver wins by a defined threshold.

## Testing

- Run Docker parity suites for C, C#, Java, and Bash to validate spine memo and repetition-fold correctness.
- Execute `TestBashForestRepetitionFoldDispatch` and `TestFinalizeReturnedTreeRootSpanFlagsSilentTruncation` locally.
- Validate spine memo correctness with `GOT_DEBUG_MERGE_EQUIV=1` on large corpus files.
- Run benchmark trio under stable settings to confirm memory/alloc reductions from spine memoization and arena capping.

## Review Focus

Focus review on `glr.go` spine caching logic and `conflict_policy.go` global repetition-skip fold correctness. The silent truncation fix in `parser_api.go` should be verified against TypeScript and C# corpus regressions. Ensure the bash corpus fixture exists for the new forest test.