### PR TITLE
Wave 5: support large GOTOs and clean COBOL recovery

### DIFF
--- a/grammargen/assemble.go
+++ b/grammargen/assemble.go
@@ -12,10 +12,11 @@ import (
 // maxUint16Index is the largest value that fits in the uint16 index/ID fields
 // grammargen writes into a Language: parse-action group indices (ParseTable /
 // SmallParseTable values), field-map and supertype-map offsets, reserved-word
-// set IDs, external-lex-state row indices, and parse-table state IDs. A naive
-// uint16(n) conversion of a larger value silently wraps and produces a
-// valid-looking but WRONG table — generation "succeeds" and the corruption only
-// surfaces later as mysterious downstream parse failures. checkUint16Index
+// set IDs, and external-lex-state row indices. Nonterminal GOTO state IDs can
+// exceed this and spill into Language.LargeStateGotos. A naive uint16(n)
+// conversion of a larger value silently wraps and produces a valid-looking but
+// WRONG table — generation "succeeds" and the corruption only surfaces later
+// as mysterious downstream parse failures. checkUint16Index
 // turns that worst-case silent wrap into a hard generation error instead.
 const maxUint16Index = math.MaxUint16 // 65535
 
@@ -576,10 +577,14 @@ func buildParseTables(
 		parseActions = append(parseActions, extraEntry)
 	}
 
-	// Build the raw action table: [state][symbol] → action index.
-	rawTable := make([][]uint16, tables.StateCount)
+	// Build the raw action table: [state][symbol] -> action index or GOTO state.
+	// Keep this intermediate wide: terminal action indices must still fit in
+	// uint16, but large generated grammars can have nonterminal GOTO targets
+	// above 65535. Those spill into Language.LargeStateGotos when the final
+	// runtime tables are emitted.
+	rawTable := make([][]uint32, tables.StateCount)
 	for state := 0; state < tables.StateCount; state++ {
-		row := make([]uint16, symbolCount)
+		row := make([]uint32, symbolCount)
 		rawTable[state] = row
 
 		// Terminal actions.
@@ -592,7 +597,7 @@ func buildParseTables(
 			}
 			sort.Ints(syms)
 			for _, sym := range syms {
-				row[sym] = getOrAddActionGroup(acts[sym])
+				row[sym] = uint32(getOrAddActionGroup(acts[sym]))
 			}
 		}
 
@@ -603,7 +608,7 @@ func buildParseTables(
 				continue // nonterminal extra — handled by LR items/reduce
 			}
 			if row[extraSym] == 0 {
-				row[extraSym] = extraShiftIdx
+				row[extraSym] = uint32(extraShiftIdx)
 			}
 		}
 
@@ -617,7 +622,7 @@ func buildParseTables(
 			}
 			sort.Ints(syms)
 			for _, sym := range syms {
-				row[sym] = uint16(gotos[sym])
+				row[sym] = uint32(gotos[sym])
 			}
 		}
 	}
@@ -686,23 +691,16 @@ func buildParseTables(
 	// Remap: state 0 in our LR construction = initial state = should be state 1.
 	// We need to insert an empty state 0 for error recovery.
 	newStateCount := tables.StateCount + 1 // +1 for error recovery state 0
-	// Gotos and remapped shift targets are stored as uint16 in ParseTable /
-	// SmallParseTable, so the highest state ID (newStateCount-1) must fit.
-	// lr.go bounds states against uint32 for the general builder, which leaves
-	// this narrower table encoding unguarded — close that gap here.
-	if err := checkUint16Index(ng.GrammarName, "parse table state", newStateCount-1); err != nil {
-		return err
-	}
 	stateRemap := make([]int, tables.StateCount)
 	for i := range stateRemap {
 		stateRemap[i] = i + 1 // shift everything up by 1
 	}
 
 	// Rebuild rawTable with remapped states.
-	newRawTable := make([][]uint16, newStateCount)
-	newRawTable[0] = make([]uint16, symbolCount) // state 0 = error recovery (empty)
+	newRawTable := make([][]uint32, newStateCount)
+	newRawTable[0] = make([]uint32, symbolCount) // state 0 = error recovery (empty)
 	for oldState, newState := range stateRemap {
-		row := make([]uint16, symbolCount)
+		row := make([]uint32, symbolCount)
 		for sym, val := range rawTable[oldState] {
 			if val == 0 {
 				continue
@@ -713,7 +711,7 @@ func buildParseTables(
 			// For nonterminals: the value IS a state ID that needs remapping.
 			if sym >= tokenCount {
 				// GOTO: value is a state ID.
-				row[sym] = uint16(stateRemap[int(val)])
+				row[sym] = uint32(stateRemap[int(val)])
 			} else {
 				row[sym] = val
 			}
@@ -756,10 +754,40 @@ func buildParseTables(
 		largeStateCount = newStateCount
 	}
 
+	recordLargeGoto := func(state int, sym int, target uint32) {
+		if lang.LargeStateGotos == nil {
+			lang.LargeStateGotos = make(map[uint64]gotreesitter.StateID)
+		}
+		key := uint64(gotreesitter.StateID(state))<<32 | uint64(gotreesitter.Symbol(sym))
+		lang.LargeStateGotos[key] = gotreesitter.StateID(target)
+	}
+
+	downcastCell := func(state int, sym int, val uint32) (uint16, error) {
+		if val == 0 {
+			return 0, nil
+		}
+		if sym >= tokenCount && val > maxUint16Index {
+			recordLargeGoto(state, sym, val)
+			return 0, nil
+		}
+		if val > maxUint16Index {
+			return 0, checkUint16Index(ng.GrammarName, "parse table action/goto", int(val))
+		}
+		return uint16(val), nil
+	}
+
 	// Build dense parse table (first largeStateCount states).
 	lang.ParseTable = make([][]uint16, largeStateCount)
 	for i := 0; i < largeStateCount; i++ {
-		lang.ParseTable[i] = newRawTable[i]
+		row := make([]uint16, symbolCount)
+		for sym, val := range newRawTable[i] {
+			downcast, err := downcastCell(i, sym, val)
+			if err != nil {
+				return err
+			}
+			row[sym] = downcast
+		}
+		lang.ParseTable[i] = row
 	}
 
 	// Build sparse parse table for remaining states.
@@ -774,7 +802,14 @@ func buildParseTables(
 			groups := make(map[uint16][]uint16)
 			for sym, val := range newRawTable[state] {
 				if val != 0 {
-					groups[val] = append(groups[val], uint16(sym))
+					downcast, err := downcastCell(state, sym, val)
+					if err != nil {
+						return err
+					}
+					if downcast == 0 {
+						continue
+					}
+					groups[downcast] = append(groups[downcast], uint16(sym))
 				}
 			}
 

--- a/grammargen/cobol_corpus_snippet_parity_test.go
+++ b/grammargen/cobol_corpus_snippet_parity_test.go
@@ -132,6 +132,21 @@ func TestCobolCorpusSnippetDeepParity(t *testing.T) {
 				"       end-perform.",
 		},
 		{
+			name: "evaluate_when_other_corpus_block_exact",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"       evaluate 1\n" +
+				"       when 1\n" +
+				"         go to aa\n" +
+				"       when 2\n" +
+				"         go to aa\n" +
+				"       when other\n" +
+				"         go to aa\n" +
+				"       end-evaluate.\n" +
+				"       aa.\n",
+		},
+		{
 			name: "fixed_format_comment_corpus_block_exact",
 			src: "aaaaaa identification division.\n" +
 				"aaaaaa program-id. a.  ,,, ;;;                                          aaaaa\n" +

--- a/grammargen/uint16_index_guard_test.go
+++ b/grammargen/uint16_index_guard_test.go
@@ -8,7 +8,7 @@ import (
 // TestCheckUint16IndexBoundary pins the exact overflow boundary of the guard
 // that protects every uint16-indexed table grammargen writes (parse-action
 // group indices, field/supertype-map offsets, reserved-word-set IDs,
-// external-lex-state rows, parse-table state IDs). Constructing a real
+// external-lex-state rows). Constructing a real
 // >65535-entry grammar is impractical for a unit test, so the bounds check is
 // factored into checkUint16Index and its failure path is exercised directly.
 func TestCheckUint16IndexBoundary(t *testing.T) {

--- a/language.go
+++ b/language.go
@@ -302,6 +302,10 @@ type Language struct {
 	SmallParseTable    []uint16   // compressed sparse table
 	SmallParseTableMap []uint32   // state -> offset into SmallParseTable
 	ParseActions       []ParseActionEntry
+	// LargeStateGotos stores nonterminal GOTO targets that do not fit in the
+	// uint16 parse-table cells used by tree-sitter C tables. Keys are
+	// uint64(state)<<32 | uint64(symbol). Terminal actions must never live here.
+	LargeStateGotos map[uint64]StateID
 
 	// ReduceChainHints are optional generated hot-path hints for deterministic
 	// reduce runs. They are only consumed when reduce-chain hints are enabled.
@@ -671,6 +675,7 @@ func (l *Language) Size() int64 {
 	size += languageSliceSize(l.SmallParseTable)
 	size += languageSliceSize(l.SmallParseTableMap)
 	size += languageParseActionsSize(l.ParseActions)
+	size += languageStateIDMapSize(l.LargeStateGotos)
 	size += languageReduceChainHintsSize(l.ReduceChainHints)
 	size += languageLexStatesSize(l.LexStates)
 	size += languageLexStatesSize(l.KeywordLexStates)
@@ -748,6 +753,10 @@ func languageParseActionsSize(actions []ParseActionEntry) int64 {
 		size += languageSliceSize(entry.Actions)
 	}
 	return size
+}
+
+func languageStateIDMapSize(m map[uint64]StateID) int64 {
+	return int64(len(m)) * int64(unsafe.Sizeof(uint64(0))+unsafe.Sizeof(StateID(0)))
 }
 
 func languageReduceChainHintsSize(hints []ReduceChainHint) int64 {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -230,6 +230,8 @@ type cRecoveryGateCacheKey struct {
 	parseTableLen         int
 	smallParseTableLen    int
 	smallParseTableMapLen int
+	largeStateGotosLen    int
+	largeStateGotosHash   uint64
 
 	hasExternalScanner     bool
 	externalSymbolsLen     int
@@ -266,6 +268,8 @@ func cRecoveryGateCacheKeyFor(lang *Language) cRecoveryGateCacheKey {
 		parseTableLen:         len(lang.ParseTable),
 		smallParseTableLen:    len(lang.SmallParseTable),
 		smallParseTableMapLen: len(lang.SmallParseTableMap),
+		largeStateGotosLen:    len(lang.LargeStateGotos),
+		largeStateGotosHash:   largeStateGotosFingerprint(lang.LargeStateGotos),
 
 		hasExternalScanner:     lang.ExternalScanner != nil,
 		externalSymbolsLen:     len(lang.ExternalSymbols),
@@ -294,6 +298,16 @@ func cRecoveryGateCacheKeyFor(lang *Language) cRecoveryGateCacheKey {
 		key.externalLexStatesPtr = &lang.ExternalLexStates[0]
 	}
 	return key
+}
+
+func largeStateGotosFingerprint(gotos map[uint64]StateID) uint64 {
+	var h uint64
+	for key, target := range gotos {
+		v := uint64(target)
+		h ^= key + 0x9e3779b97f4a7c15 + (v << 6) + (v >> 2)
+		h ^= (key << 17) | (key >> 47)
+	}
+	return h
 }
 
 // DiagnoseCRecoveryGate validates the runtime table surface required by the
@@ -531,6 +545,22 @@ func parseTablesCRecoveryFailure(lang *Language) string {
 			if reason := validateValue(sym, val); reason != "" {
 				return reason
 			}
+		}
+	}
+	for key, target := range lang.LargeStateGotos {
+		state := int(key >> 32)
+		sym := int(uint32(key))
+		if state < 0 || state >= stateCount {
+			return "large-state goto source state is outside StateCount"
+		}
+		if sym < 0 || sym >= symbolCount {
+			return "large-state goto symbol is outside SymbolCount"
+		}
+		if sym < tokenCount {
+			return "large-state goto symbol is terminal"
+		}
+		if target == 0 || target >= StateID(stateCount) {
+			return "large-state goto target state is outside StateCount"
 		}
 	}
 	if len(lang.SmallParseTableMap) == 0 {

--- a/parser_recover_c_gate_test.go
+++ b/parser_recover_c_gate_test.go
@@ -203,6 +203,37 @@ func TestCRecoveryGateValidatesParseTableActionAndGotoBounds(t *testing.T) {
 	}
 }
 
+func TestCRecoveryGateAcceptsLargeStateGotos(t *testing.T) {
+	t.Setenv("GOT_C_RECOVERY", "")
+	lang := cRecoveryGateLanguage()
+	lang.StateCount = 70002
+	lang.LexModes = make([]LexMode, lang.StateCount)
+	for i := range lang.LexModes {
+		lang.LexModes[i].LexState = 0
+	}
+	lang.LargeStateGotos = map[uint64]StateID{
+		largeStateGotoKey(1, 2): 70001,
+	}
+	validHash := largeStateGotosFingerprint(lang.LargeStateGotos)
+	if !errorCostCompetitionLanguage(lang) {
+		t.Fatalf("large-state nonterminal goto rejected: %+v", DiagnoseCRecoveryGate(lang))
+	}
+
+	lang.LargeStateGotos = map[uint64]StateID{
+		largeStateGotoKey(1, 1): 70001,
+	}
+	if invalidHash := largeStateGotosFingerprint(lang.LargeStateGotos); invalidHash == validHash {
+		t.Fatal("large-state goto fingerprint did not change after map contents changed")
+	}
+	diag := DiagnoseCRecoveryGate(lang)
+	if errorCostCompetitionLanguage(lang) {
+		t.Fatalf("terminal symbol accepted in large-state goto table: %+v", diag)
+	}
+	if !strings.Contains(diag.Reason, "large-state goto symbol is terminal") {
+		t.Fatalf("diagnostic reason = %q, want terminal large-state goto reason", diag.Reason)
+	}
+}
+
 func TestCRecoveryGateGrammargenRequiresExplicitCertification(t *testing.T) {
 	t.Setenv("GOT_C_RECOVERY", "")
 	lang := cRecoveryGateLanguage()

--- a/parser_result_c_go_cobol_test.go
+++ b/parser_result_c_go_cobol_test.go
@@ -332,3 +332,138 @@ func TestNormalizeResultCompatibilityDispatchesUppercaseCobol(t *testing.T) {
 		t.Fatalf("program_definition.StartByte = %d, want %d", got, want)
 	}
 }
+
+func TestNormalizeCobolFixedFormatProgramIDStopsBeforeTrailingJunk(t *testing.T) {
+	lang := &Language{
+		Name:        "cobol",
+		SymbolNames: []string{"EOF", "start", "program_definition", "identification_division"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+		},
+	}
+	source := []byte("aaaaaa identification division.\n" +
+		"aaaaaa program-id. a.  ,,, ;;;                                          aaaaa\n" +
+		"      *aaaa\n")
+
+	arena := newNodeArena(arenaClassFull)
+	div := newLeafNodeInArena(arena, 3, true, 6, 116, Point{Column: 6}, Point{Row: 2, Column: 6})
+	def := newParentNodeInArena(arena, 2, true, []*Node{div}, nil, 0)
+	def.startByte = 6
+	def.startPoint = Point{Column: 6}
+	def.endByte = 116
+	def.endPoint = Point{Row: 2, Column: 6}
+	root := newParentNodeInArena(arena, 1, true, []*Node{def}, nil, 0)
+	root.startByte = 6
+	root.startPoint = Point{Column: 6}
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := root.StartByte(), uint32(6); got != want {
+		t.Fatalf("root.StartByte = %d, want %d", got, want)
+	}
+	program := root.Child(0)
+	if got, want := program.StartByte(), uint32(7); got != want {
+		t.Fatalf("program_definition.StartByte = %d, want %d", got, want)
+	}
+	if got, want := program.EndByte(), uint32(53); got != want {
+		t.Fatalf("program_definition.EndByte = %d, want %d", got, want)
+	}
+	idDiv := program.Child(0)
+	if got, want := idDiv.StartByte(), uint32(7); got != want {
+		t.Fatalf("identification_division.StartByte = %d, want %d", got, want)
+	}
+	if got, want := idDiv.EndByte(), uint32(53); got != want {
+		t.Fatalf("identification_division.EndByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolRecoveredParagraphHeader(t *testing.T) {
+	lang := &Language{
+		Name:                  "COBOL",
+		GeneratedByGrammargen: true,
+		SymbolNames:           []string{"EOF", ".", "start", "program_definition", "identification_division", "procedure_division", "END_EVALUATE", "period", "paragraph_header"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "END_EVALUATE", Visible: true, Named: true},
+			{Name: "period", Visible: true, Named: true},
+			{Name: "paragraph_header", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       identification division.\n" +
+		"       program-id. a.\n" +
+		"       procedure division.\n" +
+		"       evaluate 1\n" +
+		"       when 1\n" +
+		"         go to aa\n" +
+		"       when 2\n" +
+		"         go to aa\n" +
+		"       when other\n" +
+		"         go to aa\n" +
+		"       end-evaluate.\n" +
+		"       aa.\n")
+
+	arena := newNodeArena(arenaClassFull)
+	id := newLeafNodeInArena(arena, 4, true, 7, 53, advancePointByBytes(Point{}, source[:7]), advancePointByBytes(Point{}, source[:53]))
+	endEvaluate := newLeafNodeInArena(arena, 6, true, 206, 218, advancePointByBytes(Point{}, source[:206]), advancePointByBytes(Point{}, source[:218]))
+	period := newLeafNodeInArena(arena, 7, true, 218, 219, advancePointByBytes(Point{}, source[:218]), advancePointByBytes(Point{}, source[:219]))
+	proc := newParentNodeInArena(arena, 5, true, []*Node{endEvaluate, period}, nil, 0)
+	proc.startByte = 61
+	proc.startPoint = advancePointByBytes(Point{}, source[:61])
+	proc.endByte = 230
+	proc.endPoint = advancePointByBytes(Point{}, source[:230])
+	def := newParentNodeInArena(arena, 3, true, []*Node{id, proc}, nil, 0)
+	def.startByte = 7
+	def.startPoint = advancePointByBytes(Point{}, source[:7])
+	def.endByte = 230
+	def.endPoint = advancePointByBytes(Point{}, source[:230])
+	errDot := newLeafNodeInArena(arena, 1, false, 229, 230, advancePointByBytes(Point{}, source[:229]), advancePointByBytes(Point{}, source[:230]))
+	errDot.setHasError(true)
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{errDot}, nil, 0)
+	err.setExtra(true)
+	err.setHasError(true)
+	err.startByte = 227
+	err.startPoint = advancePointByBytes(Point{}, source[:227])
+	err.endByte = 230
+	err.endPoint = advancePointByBytes(Point{}, source[:230])
+	root := newParentNodeInArena(arena, 2, true, []*Node{def, err}, nil, 0)
+	root.startByte = 7
+	root.startPoint = advancePointByBytes(Point{}, source[:7])
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if root.HasError() {
+		t.Fatalf("root.HasError = true, want false")
+	}
+	if got, want := root.ChildCount(), 1; got != want {
+		t.Fatalf("root.ChildCount = %d, want %d", got, want)
+	}
+	procedure := root.Child(0).Child(1)
+	if got, want := procedure.EndByte(), uint32(len(source)); got != want {
+		t.Fatalf("procedure_division.EndByte = %d, want %d", got, want)
+	}
+	header := procedure.Child(procedure.ChildCount() - 1)
+	if got, want := header.Type(lang), "paragraph_header"; got != want {
+		t.Fatalf("last procedure child type = %q, want %q", got, want)
+	}
+	if got, want := header.StartByte(), uint32(227); got != want {
+		t.Fatalf("paragraph_header.StartByte = %d, want %d", got, want)
+	}
+	if got, want := header.EndByte(), uint32(230); got != want {
+		t.Fatalf("paragraph_header.EndByte = %d, want %d", got, want)
+	}
+	if header.HasError() {
+		t.Fatalf("paragraph_header.HasError = true, want false")
+	}
+}

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -6,30 +6,25 @@ func normalizeCobolCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeCobolLeadingAreaStart(root, source, lang)
 	normalizeCobolTopLevelDefinitionEnd(root, source, lang)
 	normalizeCobolDivisionSiblingEnds(root, source, lang)
+	normalizeCobolRecoveredParagraphHeader(root, source, lang)
 }
 func normalizeCobolLeadingAreaStart(root *Node, source []byte, lang *Language) {
 	if root == nil || !isCobolLanguage(lang) || len(source) == 0 {
 		return
 	}
-	start := firstNonWhitespaceByte(source)
-	if start == 0 {
-		// COBOL fixed format: columns 1-6 are sequence numbers (non-whitespace).
-		// Detect this pattern and use column 7 (byte 6) as the adjusted start.
-		if len(source) >= 7 && (source[6] == ' ' || source[6] == '*' || source[6] == '-' || source[6] == '/') {
-			start = 6
-		} else {
-			return
-		}
+	rootStart, defStart, ok := cobolLeadingStarts(source)
+	if !ok {
+		return
 	}
-	startPoint := advancePointByBytes(Point{}, source[:start])
-	setNodeStartTo := func(n *Node) {
+	setNodeStartTo := func(n *Node, start uint32) {
 		if n == nil || n.startByte == start {
 			return
 		}
+		startPoint := advancePointByBytes(Point{}, source[:start])
 		n.startByte = start
 		n.startPoint = startPoint
 	}
-	setNodeStartTo(root)
+	setNodeStartTo(root, rootStart)
 	if resultChildCount(root) == 0 {
 		return
 	}
@@ -44,17 +39,54 @@ func normalizeCobolLeadingAreaStart(root *Node, source []byte, lang *Language) {
 	if def == nil {
 		return
 	}
-	setNodeStartTo(def)
+	setNodeStartTo(def, defStart)
 	if resultChildCount(def) == 0 {
 		return
 	}
 	for i := 0; i < resultChildCount(def); i++ {
 		child := resultChildAt(def, i)
 		if child != nil && !child.IsExtra() && child.Type(lang) == "identification_division" {
-			setNodeStartTo(child)
+			setNodeStartTo(child, defStart)
 			break
 		}
 	}
+}
+
+func cobolLeadingStarts(source []byte) (uint32, uint32, bool) {
+	start := firstNonWhitespaceByte(source)
+	if start != 0 {
+		return start, start, true
+	}
+	if len(source) < 7 {
+		return 0, 0, false
+	}
+	switch source[6] {
+	case ' ':
+		contentStart, ok := firstNonWhitespaceByteFrom(source, 7)
+		if !ok {
+			return 0, 0, false
+		}
+		return 6, contentStart, true
+	case '*', '-', '/':
+		return 6, 6, true
+	default:
+		return 0, 0, false
+	}
+}
+
+func firstNonWhitespaceByteFrom(source []byte, start int) (uint32, bool) {
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(source); i++ {
+		switch source[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			return uint32(i), true
+		}
+	}
+	return 0, false
 }
 
 func normalizeCobolTopLevelDefinitionEnd(root *Node, source []byte, lang *Language) {
@@ -72,12 +104,96 @@ func normalizeCobolTopLevelDefinitionEnd(root *Node, source []byte, lang *Langua
 	if def == nil {
 		return
 	}
+	if idDiv := cobolSoleIdentificationDivision(def, lang); idDiv != nil {
+		end := cobolProgramIDStatementEnd(source, def.startByte, def.endByte)
+		if end != 0 && end < def.endByte {
+			setCobolNodeEnd(def, source, end)
+			if end < idDiv.endByte {
+				setCobolNodeEnd(idDiv, source, end)
+			}
+			return
+		}
+	}
 	end := lastNonTriviaByteEnd(source)
 	if end == 0 || end >= def.endByte {
 		return
 	}
-	def.endByte = end
-	def.endPoint = advancePointByBytes(Point{}, source[:end])
+	setCobolNodeEnd(def, source, end)
+}
+
+func cobolSoleIdentificationDivision(def *Node, lang *Language) *Node {
+	var idDiv *Node
+	for i := 0; i < resultChildCount(def); i++ {
+		child := resultChildAt(def, i)
+		if child == nil || child.IsExtra() {
+			continue
+		}
+		if child.Type(lang) != "identification_division" {
+			return nil
+		}
+		if idDiv != nil {
+			return nil
+		}
+		idDiv = child
+	}
+	return idDiv
+}
+
+func cobolProgramIDStatementEnd(source []byte, start, end uint32) uint32 {
+	if start >= end || int(end) > len(source) {
+		return 0
+	}
+	idx := cobolIndexFoldASCII(source, int(start), int(end), "program-id.")
+	if idx < 0 {
+		return 0
+	}
+	for i := idx + len("program-id."); i < int(end); i++ {
+		switch source[i] {
+		case '.':
+			return uint32(i + 1)
+		case '\n', '\r':
+			return 0
+		}
+	}
+	return 0
+}
+
+func cobolIndexFoldASCII(source []byte, start, end int, needle string) int {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(source) {
+		end = len(source)
+	}
+	if len(needle) == 0 || start >= end || end-start < len(needle) {
+		return -1
+	}
+	for i := start; i+len(needle) <= end; i++ {
+		if cobolEqualFoldASCII(source[i:i+len(needle)], needle) {
+			return i
+		}
+	}
+	return -1
+}
+
+func cobolEqualFoldASCII(b []byte, s string) bool {
+	if len(b) != len(s) {
+		return false
+	}
+	for i := range b {
+		if asciiLower(b[i]) != asciiLower(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func setCobolNodeEnd(n *Node, source []byte, end uint32) {
+	if n == nil || n.endByte == end {
+		return
+	}
+	n.endByte = end
+	n.endPoint = advancePointByBytes(Point{}, source[:end])
 }
 
 func normalizeCobolDivisionSiblingEnds(root *Node, source []byte, lang *Language) {
@@ -111,5 +227,129 @@ func normalizeCobolDivisionSiblingEnds(root *Node, source []byte, lang *Language
 		}
 		cur.endByte = end
 		cur.endPoint = advancePointByBytes(Point{}, source[:end])
+	}
+}
+
+func normalizeCobolRecoveredParagraphHeader(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || !lang.GeneratedByGrammargen || root.Type(lang) != "start" || !root.hasError() {
+		return
+	}
+	rootChildren := resultChildSliceForMutation(root)
+	if len(rootChildren) < 2 {
+		return
+	}
+	errNode := rootChildren[len(rootChildren)-1]
+	if errNode == nil || errNode.symbol != errorSymbol || !errNode.hasError() || errNode.startByte >= errNode.endByte || int(errNode.endByte) > len(source) {
+		return
+	}
+	dot := cobolTrailingParagraphErrorDot(errNode, lang)
+	if dot == nil || dot.endByte != errNode.endByte || dot.startByte <= errNode.startByte || int(dot.endByte) > len(source) {
+		return
+	}
+	if !cobolBytesAreParagraphLabel(source[errNode.startByte:dot.startByte]) {
+		return
+	}
+	program := cobolFirstProgramDefinition(root, lang)
+	if program == nil {
+		return
+	}
+	procedure := cobolFirstChildOfType(program, lang, "procedure_division")
+	if procedure == nil {
+		return
+	}
+	paragraphSym, ok := symbolByName(lang, "paragraph_header")
+	if !ok {
+		return
+	}
+
+	rootStart, rootStartPoint := root.startByte, root.startPoint
+	rootEnd, rootEndPoint := root.endByte, root.endPoint
+	procStart, procStartPoint := procedure.startByte, procedure.startPoint
+
+	cobolClearErrorFlags(dot)
+	header := newParentNodeInArena(root.ownerArena, paragraphSym, symbolIsNamed(lang, paragraphSym), []*Node{dot}, nil, 0)
+	header.startByte = errNode.startByte
+	header.startPoint = errNode.startPoint
+	header.endByte = errNode.endByte
+	header.endPoint = errNode.endPoint
+	header.setHasError(false)
+
+	procChildren := append(resultChildSliceForMutation(procedure), header)
+	replaceNodeChildrenUnfielded(procedure, cloneNodeSliceInArena(procedure.ownerArena, procChildren))
+	procedure.startByte = procStart
+	procedure.startPoint = procStartPoint
+	procedure.endByte = rootEnd
+	procedure.endPoint = rootEndPoint
+	procedure.setHasError(false)
+
+	keptRootChildren := cloneNodeSliceInArena(root.ownerArena, rootChildren[:len(rootChildren)-1])
+	replaceNodeChildrenUnfielded(root, keptRootChildren)
+	root.startByte = rootStart
+	root.startPoint = rootStartPoint
+	root.endByte = rootEnd
+	root.endPoint = rootEndPoint
+	root.setHasError(false)
+}
+
+func cobolFirstProgramDefinition(root *Node, lang *Language) *Node {
+	for i := 0; i < resultChildCount(root); i++ {
+		child := resultChildAt(root, i)
+		if child != nil && !child.IsExtra() && child.Type(lang) == "program_definition" {
+			return child
+		}
+	}
+	return nil
+}
+
+func cobolFirstChildOfType(parent *Node, lang *Language, typ string) *Node {
+	for i := 0; i < resultChildCount(parent); i++ {
+		child := resultChildAt(parent, i)
+		if child != nil && !child.IsExtra() && child.Type(lang) == typ {
+			return child
+		}
+	}
+	return nil
+}
+
+func cobolTrailingParagraphErrorDot(errNode *Node, lang *Language) *Node {
+	for i := resultChildCount(errNode) - 1; i >= 0; i-- {
+		child := resultChildAt(errNode, i)
+		if child != nil && child.Type(lang) == "." {
+			return child
+		}
+	}
+	return nil
+}
+
+func cobolBytesAreParagraphLabel(b []byte) bool {
+	seen := false
+	for _, c := range b {
+		switch {
+		case c == ' ' || c == '\t':
+			if seen {
+				return false
+			}
+		case c >= 'a' && c <= 'z':
+			seen = true
+		case c >= 'A' && c <= 'Z':
+			seen = true
+		case c >= '0' && c <= '9':
+			seen = true
+		case c == '-' || c == '_':
+			seen = true
+		default:
+			return false
+		}
+	}
+	return seen
+}
+
+func cobolClearErrorFlags(n *Node) {
+	if n == nil {
+		return
+	}
+	n.setHasError(false)
+	for i := 0; i < resultChildCount(n); i++ {
+		cobolClearErrorFlags(resultChildAt(n, i))
 	}
 }

--- a/parser_tables.go
+++ b/parser_tables.go
@@ -440,8 +440,28 @@ func (p *Parser) lookupActionIndexSmall(state StateID, sym Symbol) uint16 {
 	return 0
 }
 
+func largeStateGotoKey(state StateID, sym Symbol) uint64 {
+	return uint64(state)<<32 | uint64(sym)
+}
+
+func (l *Language) lookupLargeStateGoto(state StateID, sym Symbol) StateID {
+	if l == nil || len(l.LargeStateGotos) == 0 {
+		return 0
+	}
+	return l.LargeStateGotos[largeStateGotoKey(state, sym)]
+}
+
 // lookupGoto returns the GOTO target state for a nonterminal symbol.
 func (p *Parser) lookupGoto(state StateID, sym Symbol) StateID {
+	if p == nil || p.language == nil {
+		return 0
+	}
+	if p.language.TokenCount > 0 && uint32(sym) >= p.language.TokenCount {
+		if target := p.language.lookupLargeStateGoto(state, sym); target != 0 {
+			return target
+		}
+	}
+
 	raw := p.lookupActionIndex(state, sym)
 	if raw == 0 {
 		return 0

--- a/parser_tables_test.go
+++ b/parser_tables_test.go
@@ -138,6 +138,35 @@ func TestLookupActionIndexSmallUsesFullSymbolRowsForGo(t *testing.T) {
 	}
 }
 
+func TestLookupGotoUsesLargeStateGotos(t *testing.T) {
+	const (
+		sourceState = StateID(1)
+		rootSymbol  = Symbol(3)
+		targetState = StateID(70001)
+	)
+	lang := &Language{
+		TokenCount:      2,
+		SymbolCount:     4,
+		StateCount:      70002,
+		InitialState:    1,
+		LargeStateCount: 2,
+		ParseTable: [][]uint16{
+			make([]uint16, 4),
+			make([]uint16, 4),
+		},
+		ParseActions:    []ParseActionEntry{{}},
+		LargeStateGotos: map[uint64]StateID{largeStateGotoKey(sourceState, rootSymbol): targetState},
+	}
+	p := NewParser(lang)
+
+	if got := p.lookupActionIndex(sourceState, rootSymbol); got != 0 {
+		t.Fatalf("lookupActionIndex large goto cell = %d, want 0 legacy-table spill marker", got)
+	}
+	if got := p.lookupGoto(sourceState, rootSymbol); got != targetState {
+		t.Fatalf("lookupGoto large target = %d, want %d", got, targetState)
+	}
+}
+
 func TestBuildExternalValidByStateUsesCompactExternalIndexes(t *testing.T) {
 	lang := &Language{
 		TokenCount:      5,


### PR DESCRIPTION
## Summary

Wave 5 makes Cobol clean against the C oracle without timing out by addressing the large-state table surface and the remaining Cobol compatibility gaps found in the real corpus.

## Changes

- Add `Language.LargeStateGotos` for nonterminal GOTO targets that exceed the uint16 table-cell limit.
- Build grammargen parse-table intermediates as uint32 and spill only oversized nonterminal GOTOs, while preserving uint16 terminal action safety.
- Teach runtime `lookupGoto` and the C recovery gate/cache to validate and consume large-state GOTO entries.
- Tighten Cobol result normalization for fixed-format leading area starts, isolated `program-id.` trailing junk, division sibling ends, and recovered trailing paragraph headers.
- Add focused runtime, recovery gate, grammargen boundary, and Cobol corpus snippet coverage.

## Testing

- `go test . -run '^(TestNormalizeResultCompatibilityDispatchesUppercaseCobol|TestNormalizeCobolFixedFormatProgramIDStopsBeforeTrailingJunk|TestNormalizeCobolRecoveredParagraphHeader|TestLookupGotoUsesLargeStateGotos|TestCRecoveryGateAcceptsLargeStateGotos|TestCRecoveryGateValidatesParseTableActionAndGotoBounds)$' -count=1`
- `go test ./grammargen -run '^(TestCheckUint16IndexBoundary|TestCheckUint16IndexErrorIsActionable|TestMaxUint16IndexValue)$' -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh --memory 8g --cpus 1 --pids 512 --label cobol-evaluate-focused --no-build -- "cd /workspace && GOMAXPROCS=1 GOFLAGS='-p=1' go test ./grammargen -run '^TestCobolCorpusSnippetDeepParity/evaluate_when_other_corpus_block_exact$' -count=1 -v -timeout 15m"`
- `bash cgo_harness/docker/run_parity_in_docker.sh --memory 8g --cpus 1 --pids 512 --label cobol-snippets --no-build -- "cd /workspace && GOMAXPROCS=1 GOFLAGS='-p=1' go test ./grammargen -run '^TestCobolCorpusSnippetDeepParity$' -count=1 -v -timeout 15m"`
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode real-corpus --langs cobol --real-timeout 15m --no-build` -> Cobol 25/25 no-error, sexpr parity, and deep parity; max RSS 3,875,828 KB; no OOM.
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs cobol --cgo-timeout 20 --no-build` -> Cobol 20/20 eligible, no-error, and tree parity; divergences=0. The run logs one upstream blob-vs-C `perform.txt` gap that is not a grammargen-vs-C divergence.
