### PR TITLE
add doxygen, jsdoc, norg to known degraded structural list

### DIFF
--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -37,10 +37,13 @@ var paritySkips = map[string]parityMeta{
 // knownDegradedStructural tracks currently non-parity structural languages
 // within the full-coverage gate. Keep this list shrinking over time.
 var knownDegradedStructural = map[string]string{
-	"agda": "named wrapper/runtime alias shape still diverges from C reference",
-	"apex": "named wrapper/runtime alias shape still diverges from C reference",
-	"hare": "fresh parse structural parity still diverges from C reference",
-	"rst":  "fresh parse structural parity still diverges from C reference",
+	"agda":    "named wrapper/runtime alias shape still diverges from C reference",
+	"apex":    "named wrapper/runtime alias shape still diverges from C reference",
+	"doxygen": "tier row IV-unknown: whole-block comment/error-root compatibility remains non-clean",
+	"hare":    "fresh parse structural parity still diverges from C reference",
+	"jsdoc":   "tier row IV-unknown: C-recovery/default ELS smoke sample still diverges from C reference",
+	"norg":    "tier row IV-scanner: scanner/version structural shape still diverges from C reference",
+	"rst":     "fresh parse structural parity still diverges from C reference",
 }
 
 type parityCase struct {

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -296,6 +296,9 @@ func paritySkipReason(name string) string {
 	return ""
 }
 
+// parityNoErrorSkipReason returns a skip reason for the no-error gate. Some
+// structural backlog entries still have useful no-error signal, so keep those
+// running while fresh/incremental structural parity remains skipped.
 func parityNoErrorSkipReason(name string) string {
 	if _, ok := knownDegradedNoErrorClean[name]; ok {
 		return ""

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -46,6 +46,12 @@ var knownDegradedStructural = map[string]string{
 	"rst":     "fresh parse structural parity still diverges from C reference",
 }
 
+// knownDegradedNoErrorClean preserves no-error coverage for structural backlog
+// entries whose current failure is tree shape, not error-node production.
+var knownDegradedNoErrorClean = map[string]struct{}{
+	"norg": {},
+}
+
 type parityCase struct {
 	name   string
 	source string
@@ -288,6 +294,13 @@ func paritySkipReason(name string) string {
 		return meta.skipReason
 	}
 	return ""
+}
+
+func parityNoErrorSkipReason(name string) string {
+	if _, ok := knownDegradedNoErrorClean[name]; ok {
+		return ""
+	}
+	return paritySkipReason(name)
 }
 
 type nodeSnapshot struct {
@@ -978,7 +991,7 @@ func TestParityHasNoErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			parityMaybeParallel(t)
 			scheduleParityMemoryScavenge(t)
-			if reason := paritySkipReason(tc.name); reason != "" {
+			if reason := parityNoErrorSkipReason(tc.name); reason != "" {
 				t.Skipf("known mismatch: %s", reason)
 			}
 			tree, _, err := parseWithGo(tc, normalizedSource(tc.name, tc.source), nil)

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -9,6 +9,7 @@ const (
 	minCuratedStructuralLanguages = 206
 	minCuratedHighlightLanguages  = 200
 	maxKnownDegradedStructural    = 14
+	maxKnownDegradedNoErrorClean  = 1
 	maxKnownDegradedHighlight     = 49
 	maxParitySkips                = 0
 )
@@ -24,6 +25,14 @@ func TestParityGateCoverageRatchet(t *testing.T) {
 	}
 	if got := len(knownDegradedStructural); got > maxKnownDegradedStructural {
 		t.Fatalf("knownDegradedStructural grew: got=%d max=%d", got, maxKnownDegradedStructural)
+	}
+	if got := len(knownDegradedNoErrorClean); got > maxKnownDegradedNoErrorClean {
+		t.Fatalf("knownDegradedNoErrorClean grew: got=%d max=%d", got, maxKnownDegradedNoErrorClean)
+	}
+	for name := range knownDegradedNoErrorClean {
+		if _, ok := knownDegradedStructural[name]; !ok {
+			t.Fatalf("knownDegradedNoErrorClean[%q] is not in knownDegradedStructural", name)
+		}
 	}
 	if got := len(knownDegradedHighlight); got > maxKnownDegradedHighlight {
 		t.Fatalf("knownDegradedHighlight grew: got=%d max=%d", got, maxKnownDegradedHighlight)


### PR DESCRIPTION
## Summary

Adds doxygen, jsdoc, and norg to `knownDegradedStructural` so the exhaustive C-oracle gate reports these current failures as tracked structural backlog instead of unexplained release regressions.

This does not mark the grammars clean. The underlying parser/scanner gaps remain in the backlog and can still be exercised with `GTS_PARITY_IGNORE_KNOWN_SKIPS=1` or the skipped-backlog diagnostic. Norg stays covered by the no-error gate because its current release blocker is tree shape, not error-node production.

## Changes

- Add doxygen, jsdoc, and norg to `knownDegradedStructural` in `cgo_harness/parity_cgo_test.go`
- Record tier-aligned reasons for each language: Doxygen error-root compatibility, jsdoc C-recovery/default ELS smoke divergence, and norg scanner/version shape divergence
- Add a narrow `knownDegradedNoErrorClean` path so `TestParityHasNoErrors/norg` continues to run while structural parity is skipped
- Ratchet the no-error carve-out at one entry and require it to remain a subset of `knownDegradedStructural`
- Let `gofmt` align the map literals

## Testing

- PASS: `bash cgo_harness/docker/run_parity_in_docker.sh --label release-known-degraded-ratchet-guard --timeout 20m --no-build -- "cd /workspace/cgo_harness && env GTS_PARITY_MODE=exhaustive go test . -tags treesitter_c_parity -run '^(TestParityGateCoverageRatchet|TestParityFreshParse|TestParityHasNoErrors)$/^(doxygen|jsdoc|norg)$' -count=1 -v -timeout 20m"`
- Docker artifacts: `harness_out/docker/20260708T031247Z-release-known-degraded-ratchet-guard`
- Result: doxygen/jsdoc/norg fresh parse subtests skip with explicit known-degraded reasons; doxygen/jsdoc no-error subtests skip; `TestParityHasNoErrors/norg` passes; `TestParityGateCoverageRatchet` passes

## Review

- Buckley GLM review was run with `z-ai/glm-5.2` using the PR diff embedded directly. Initial low-severity findings were addressed by documenting the helper and adding the ratchet/subset guard.