### PR TITLE
refactor(ci): split build gate into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  compile:
     runs-on: ubuntu-latest
-    # 60m: the full -race suite (non-draft PRs) needs ~30-40m on 2-core
-    # runners with -p 1; see the Test step's comment.
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -42,38 +40,95 @@ jobs:
       - name: Test Compile
         run: go test ./... -run '^$' -count=1
 
-      - name: Test
-        if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+  race_root:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Root Package Race Tests
         # -timeout 35m: the root package alone needs ~11m under -race on a
         # fast box and more on 2-core runners; Go's default 10m per-package
         # timeout panics the test binary mid-run (dumping in-flight tests as
-        # spurious FAILs). -p 1: package binaries otherwise run concurrently,
-        # and on 2 cores under ~10x race instrumentation that contention
-        # flips wall-clock-sensitive tests; sequential packages keep timing
-        # honest at the cost of wall time (covered by the 60m job budget).
-        #
-        # ./grammargen is excluded from the BLOCKING run (next step covers it
-        # non-blocking): this step never executed before 2026-07-06 (the
-        # branch lived in draft), and its first run surfaced a pre-existing
-        # grammargen backlog — a stale bundled markdown blob vs a since-fixed
-        # generator (~40 CommonMark parity subtests; regen tracked), two Dart
-        # generated-grammar parity gaps, and lrd_basic. Same ratchet strategy
-        # as draft-correctness: enumerate → burn down → then fold grammargen
-        # back into this blocking step.
-        run: go test $(go list ./... | grep -v '/grammargen$') -race -count=1 -timeout 35m -p 1
+        # spurious FAILs).
+        run: go test . -race -count=1 -timeout 35m
+
+  race_packages:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Non-root Race Tests
+        # Keep non-root packages serialized under -race so timing-sensitive
+        # tests do not contend with each other on 2-core hosted runners.
+        # ./grammargen stays visibility-only until its enumerated backlog is
+        # burned down and folded back into the blocking suite.
+        run: |
+          set -euo pipefail
+          root="$(go list -m)"
+          pkgs="$(
+            go list ./... |
+              awk -v root="$root" '$0 != root && $0 !~ /\/grammargen$/ { print }'
+          )"
+          if [ -z "$pkgs" ]; then
+            echo "No non-root packages to test"
+            exit 0
+          fi
+          go test $pkgs -race -count=1 -timeout 35m -p 1
+
+  grammargen_visibility:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Test grammargen (non-blocking visibility)
-        if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-        continue-on-error: true
-        # Visibility-only until the enumerated pre-existing backlog above is
-        # zeroed; failures here are SEEN but do not block. Heavy generation
-        # tests get the same -p 1/-timeout discipline.
+        # Visibility-only until the enumerated pre-existing backlog is zeroed;
+        # failures here are SEEN but do not block. Heavy generation tests keep
+        # the same timeout discipline.
         run: go test ./grammargen -race -count=1 -timeout 35m
 
+  draft_focused_tests:
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Draft PR Focused Tests
-        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
         run: |
           go test . -run '^(TestLookupActionIndexSmallUsesDenseTokenRows|TestLookupActionIndexSmallUsesFullTokenRowsForOtherLanguages|TestLookupActionIndexSmallUsesFullSymbolRowsForGo|TestRawShapePropagatesThroughNoTreeAndCollapsedUnary|TestParseRuntimeReportsNoTreeNodeVolume|TestParseRuntimeReportsNoTreeCheckpointLeavesRemainNodes|TestParseNoTreeBenchmarkDropsRetainedExternalCheckpointCapacity|TestSetLexerErrorRunLexStateUsesCRecoveryGate|TestErrorCostCompetitionLanguageRequiresCapabilityByDefault)$' -count=1
+
+  parity_report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Run Parity Report (External Blob Mode)
         run: |
@@ -86,12 +141,60 @@ jobs:
           name: parity-log
           path: parity.log
 
+  build:
+    needs:
+      - compile
+      - race_root
+      - race_packages
+      - draft_focused_tests
+      - parity_report
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check Required Build Gate
+        env:
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
+          COMPILE_RESULT: ${{ needs.compile.result }}
+          RACE_ROOT_RESULT: ${{ needs.race_root.result }}
+          RACE_PACKAGES_RESULT: ${{ needs.race_packages.result }}
+          DRAFT_FOCUSED_RESULT: ${{ needs.draft_focused_tests.result }}
+          PARITY_REPORT_RESULT: ${{ needs.parity_report.result }}
+        run: |
+          set -euo pipefail
+          failed=0
+
+          require_success() {
+            local name="$1"
+            local result="$2"
+            if [ "$result" != "success" ]; then
+              echo "::error::${name} finished with result=${result}"
+              failed=1
+            fi
+          }
+
+          require_success "compile" "$COMPILE_RESULT"
+          require_success "parity_report" "$PARITY_REPORT_RESULT"
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            require_success "draft_focused_tests" "$DRAFT_FOCUSED_RESULT"
+          else
+            require_success "race_root" "$RACE_ROOT_RESULT"
+            require_success "race_packages" "$RACE_PACKAGES_RESULT"
+          fi
+
+          if [ "$failed" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "Required build gate passed"
+
   # Draft PR correctness visibility (NOT a required check).
   #
-  # Background: the `build` job's full-suite step ("Test", above) is
-  # intentionally skipped while a PR is a draft (see that step's `if:`), so
-  # draft PRs only ever ran a small hand-picked focused test list ("Draft PR
-  # Focused Tests", above) instead of the real suite.
+  # Background: the blocking `race_root` / `race_packages` jobs are
+  # intentionally skipped while a PR is a draft, so draft PRs only run the
+  # small hand-picked `draft_focused_tests` required-check input instead of
+  # the real race suite.
   #
   # That blind spot let a real regression go unseen for weeks: on the
   # codex/glr-parity-buckets campaign PR (#133), root-package RealParser
@@ -113,8 +216,8 @@ jobs:
   # pre-existing failure count is driven to zero, promote this job to
   # required to turn it into a ratchet.
   draft-correctness:
-    # Only meaningful for draft PRs: non-draft PRs already get the full
-    # `go test ./... -race` suite from the build job's "Test" step above.
+    # Only meaningful for draft PRs: non-draft PRs already get the blocking
+    # race suite through `race_root` and `race_packages`.
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -130,16 +233,15 @@ jobs:
         run: |
           # No -race: trades race detection for speed so this is cheap
           # enough to run on every draft push. The full -race suite still
-          # runs once the PR leaves draft (build job's "Test" step, above).
+          # runs once the PR leaves draft (`race_root` / `race_packages`).
           #
           # -timeout 25m: the root package alone contains two known
           # C#-boundedness tests (TestCSharpDesignerStyleBlockStaysBounded,
           # TestCSharpCJKPartialClassesStayBounded) that currently run
           # ~130-150s each before hitting their internal parser-level
-          # timeout and failing. The build job has no existing skip/-short
-          # handling for them (they just run to their failure inside its
-          # 20-minute job budget), so we mirror that by not special-casing
-          # them either — just give the whole run a generous budget.
+          # timeout and failing. The non-draft race suite does not
+          # special-case them either, so mirror that behavior here and give
+          # the whole draft visibility run a generous budget.
           go test . ./grammars -count=1 -timeout 25m
 
   freshness:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 35
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -101,9 +100,24 @@ jobs:
 
       - name: Test grammargen (non-blocking visibility)
         # Visibility-only until the enumerated pre-existing backlog is zeroed;
-        # failures here are SEEN but do not block. Heavy generation tests keep
-        # the same timeout discipline.
-        run: go test ./grammargen -race -count=1 -timeout 35m
+        # known test failures here are SEEN but do not make the PR red. Heavy
+        # generation tests keep the same timeout discipline.
+        run: |
+          set +e
+          go test ./grammargen -race -count=1 -timeout 35m
+          status=$?
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::grammargen visibility suite exited with status ${status}; this is informational until the known backlog is burned down."
+            {
+              echo "### Grammargen Visibility"
+              echo
+              echo "\`go test ./grammargen -race -count=1 -timeout 35m\` exited with status \`${status}\`."
+              echo
+              echo "This job is informational until the known grammargen backlog is zeroed."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   draft_focused_tests:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == true


### PR DESCRIPTION
## Summary

The CI build gate previously ran all build, race, and parity steps serially in a single 60-minute job. This created unnecessary bottleneck time since compile, root race tests, non-root race tests, grammargen visibility, and parity report could all run in parallel. This PR splits the monolithic `build` job into parallel jobs while keeping a lightweight aggregator `build` job as the required check, preserving the same blocking semantics for non-draft PRs (race tests + parity) and draft PRs (focused tests).

## Changes

- Split the monolithic `build` job into 6 independent jobs: `compile`, `race_root`, `race_packages`, `grammargen_visibility`, `draft_focused_tests`, and `parity_report`
- Separated root-package race tests (`race_root`) from non-root package race tests (`race_packages`), both running in parallel with 35m timeouts instead of serially under a single 60m budget
- Moved `grammargen_visibility` and `parity_report` into their own jobs so the serial grammargen/parity tail no longer blocks the build gate timeline
- Added a new `build` aggregator job with `if: always()` that enforces required checks: compile + parity always required; race_root + race_packages required for non-draft PRs; draft_focused_tests required for draft PRs
- Reduced compile timeout from 60m to 15m since it no longer includes the full race suite
- Preserved the non-blocking `continue-on-error: true` semantics for grammargen visibility
- Updated the draft-correctness comment block to reference the new parallel job names instead of the old monolithic step structure

## Testing

- Open a non-draft PR and confirm that `compile`, `race_root`, `race_packages`, `parity_report`, and `grammargen_visibility` all run in parallel rather than serially
- Verify the `build` aggregator job fails if any of `compile`, `race_root`, `race_packages`, or `parity_report` fails on a non-draft PR
- Verify the `build` aggregator job fails if `compile`, `draft_focused_tests`, or `parity_report` fails on a draft PR, while `race_root`/`race_packages` are skipped
- Confirm `grammargen_visibility` failures do NOT fail the `build` gate (continue-on-error)
- Check that the total wall-clock time for the pipeline is roughly the max of the individual jobs rather than their sum
- Validate that the parity report artifact (`parity-log`) is still uploaded correctly

## Review Focus

Focus on the `build` aggregator job's logic: verify that the IS_DRAFT conditional correctly maps to the right required jobs, and that no previously-blocking check was accidentally made non-blocking (or vice versa). Also confirm that the parallel `race_root` and `race_packages` jobs cover exactly the same test surface as the old single `go test` command (root package + non-root non-grammargen packages).
