### PR TITLE
refactor(grammars): clean up scanner code per staticcheck findings

### DIFF
--- a/grammars/bash_retry_regression_test.go
+++ b/grammars/bash_retry_regression_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBashRetryFullParseOnChainedIfs(t *testing.T) {
-	src := []byte(`a=1
+	src := []byte(strings.ReplaceAll(`a=1
 if foo; then
   :
 fi
@@ -19,17 +19,12 @@ if [ -z "$tar" ]; then
   tar=x
 fi
 if [ -z "$tar" ]; then
-  tar=foo
+  tar=\x06foo\x06
 fi
 if [ 1 -eq 0 ] && [ -x "$tar" ]; then
   :
 fi
-`)
-	for i := range src {
-		if src[i] == 0x06 {
-			src[i] = '`'
-		}
-	}
+	`, `\x06`, "`"))
 	p := ts.NewParser(BashLanguage())
 	tree, err := p.Parse(src)
 	if err != nil {

--- a/grammars/bash_scanner.go
+++ b/grammars/bash_scanner.go
@@ -477,7 +477,7 @@ func bshScanHeredocContent(
 				}
 				continue
 			}
-			if middleTok == bshTokHeredocBodyBeginning && lexer.GetColumn() == 0 {
+			if middleTok == bshTokHeredocBodyBeginning && lexer.Column() == 0 {
 				lexer.SetResultSymbol(middleSym)
 				heredoc.started = true
 				return true
@@ -518,7 +518,7 @@ func bshScanHeredocContent(
 			}
 
 		default:
-			if lexer.GetColumn() == 0 {
+			if lexer.Column() == 0 {
 				for bshIsSpace(lexer.Lookahead()) {
 					if didAdvance {
 						bshAdvance(lexer)
@@ -1135,10 +1135,7 @@ func bshScan(s *bshState, lexer *gotreesitter.ExternalLexer, validSymbols []bool
 			for bshIsSpace(lexer.Lookahead()) {
 				bshSkip(lexer)
 			}
-			if lexer.Lookahead() == '}' {
-				return true
-			}
-			return false
+			return lexer.Lookahead() == '}'
 		}
 	}
 

--- a/grammars/blob_export_test.go
+++ b/grammars/blob_export_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestBlobByName_Go(t *testing.T) {
 	blob := BlobByName("go")
-	if blob == nil || len(blob) == 0 {
+	if len(blob) == 0 {
 		t.Fatal("expected non-empty blob for go")
 	}
 }
@@ -18,14 +18,14 @@ func TestBlobByName_Unknown(t *testing.T) {
 
 func TestBlobByName_Alias(t *testing.T) {
 	blob := BlobByName("golang")
-	if blob == nil || len(blob) == 0 {
+	if len(blob) == 0 {
 		t.Fatal("expected non-empty blob for golang alias")
 	}
 }
 
 func TestBlobByName_CaseInsensitive(t *testing.T) {
 	blob := BlobByName("Go")
-	if blob == nil || len(blob) == 0 {
+	if len(blob) == 0 {
 		t.Fatal("expected non-empty blob for Go (capitalized)")
 	}
 }

--- a/grammars/caddy_scanner.go
+++ b/grammars/caddy_scanner.go
@@ -64,7 +64,7 @@ func (CaddyExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 		return false
 	}
 
-	if lexer.Lookahead() != 0 && lexer.GetColumn() == 0 {
+	if lexer.Lookahead() != 0 && lexer.Column() == 0 {
 		var indentLen uint16
 
 		lexer.MarkEnd()

--- a/grammars/cobol_scanner.go
+++ b/grammars/cobol_scanner.go
@@ -83,8 +83,8 @@ func (CobolExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 	}
 
 	// LINE_PREFIX_COMMENT: columns 1-6 (0-5)
-	if cobolValid(validSymbols, cobolTokLinePrefixComment) && lexer.GetColumn() <= 5 {
-		for lexer.GetColumn() <= 5 && lexer.Lookahead() != 0 && lexer.Lookahead() != '\n' {
+	if cobolValid(validSymbols, cobolTokLinePrefixComment) && lexer.Column() <= 5 {
+		for lexer.Column() <= 5 && lexer.Lookahead() != 0 && lexer.Lookahead() != '\n' {
 			lexer.Advance(true)
 		}
 		lexer.MarkEnd()
@@ -94,7 +94,7 @@ func (CobolExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 
 	// LINE_COMMENT: column 7 (index 6) with * or /
 	if cobolValid(validSymbols, cobolTokLineComment) {
-		if lexer.GetColumn() == 6 {
+		if lexer.Column() == 6 {
 			if lexer.Lookahead() == '*' || lexer.Lookahead() == '/' {
 				for lexer.Lookahead() != '\n' && lexer.Lookahead() != 0 {
 					lexer.Advance(true)
@@ -111,7 +111,7 @@ func (CobolExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 
 	// LINE_SUFFIX_COMMENT: column 73+ (index 72+)
 	if cobolValid(validSymbols, cobolTokLineSuffixComment) {
-		if lexer.GetColumn() >= 72 {
+		if lexer.Column() >= 72 {
 			for lexer.Lookahead() != '\n' && lexer.Lookahead() != 0 {
 				lexer.Advance(true)
 			}
@@ -129,7 +129,7 @@ func (CobolExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 			if lexer.Lookahead() == 0 || lexer.Lookahead() == '\n' {
 				return false
 			}
-			for lexer.Lookahead() != '\n' && lexer.Lookahead() != 0 && lexer.GetColumn() < 72 {
+			for lexer.Lookahead() != '\n' && lexer.Lookahead() != 0 && lexer.Column() < 72 {
 				lexer.Advance(true)
 			}
 			lexer.MarkEnd()
@@ -146,7 +146,7 @@ func (CobolExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 				return false
 			}
 			lexer.Advance(false)
-			for lexer.Lookahead() != '"' && lexer.Lookahead() != 0 && lexer.GetColumn() < 72 {
+			for lexer.Lookahead() != '"' && lexer.Lookahead() != 0 && lexer.Column() < 72 {
 				lexer.Advance(false)
 			}
 			if lexer.Lookahead() == '"' {
@@ -176,7 +176,7 @@ func (CobolExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 			}
 			lexer.Advance(true)
 			// Skip spaces to the continuation quote
-			for lexer.Lookahead() == ' ' && lexer.GetColumn() < 72 {
+			for lexer.Lookahead() == ' ' && lexer.Column() < 72 {
 				lexer.Advance(true)
 			}
 		}
@@ -208,7 +208,7 @@ func cobolStartsWithKeyword(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	for {
-		if lexer.GetColumn() > 71 || lexer.Lookahead() == '\n' || lexer.Lookahead() == 0 {
+		if lexer.Column() > 71 || lexer.Lookahead() == '\n' || lexer.Lookahead() == 0 {
 			return false
 		}
 
@@ -221,7 +221,7 @@ func cobolStartsWithKeyword(lexer *gotreesitter.ExternalLexer) bool {
 		}
 		if !anyActive {
 			// Skip rest of line
-			for lexer.GetColumn() < 71 && lexer.Lookahead() != '\n' && lexer.Lookahead() != 0 {
+			for lexer.Column() < 71 && lexer.Lookahead() != '\n' && lexer.Lookahead() != 0 {
 				lexer.Advance(true)
 			}
 			return false

--- a/grammars/crystal_scanner.go
+++ b/grammars/crystal_scanner.go
@@ -581,7 +581,7 @@ func cryCheckForHeredocStart(s *cryScannerState, lexer *gotreesitter.ExternalLex
 		cryHasUnstartedHeredoc(s) &&
 		!s.previousLineContinued &&
 		!cryIsEOF(lexer) &&
-		lexer.GetColumn() == 0 {
+		lexer.Column() == 0 {
 
 		s.heredocs[0].started = true
 		crySetResult(lexer, cryTokHeredocBodyStart)
@@ -801,7 +801,7 @@ func cryScanHeredocContents(s *cryScannerState, lexer *gotreesitter.ExternalLexe
 			return true
 		}
 
-		if cryIsValid(validSymbols, cryTokHeredocEnd) && !cryIsEOF(lexer) && lexer.GetColumn() == 0 {
+		if cryIsValid(validSymbols, cryTokHeredocEnd) && !cryIsEOF(lexer) && lexer.Column() == 0 {
 			if foundContent {
 				lexer.MarkEnd()
 				for lexer.Lookahead() == '\t' || lexer.Lookahead() == ' ' {

--- a/grammars/djot_scanner.go
+++ b/grammars/djot_scanner.go
@@ -823,10 +823,7 @@ func djotTryCloseDifferentTypedList(s *djotScannerState, lexer *gotreesitter.Ext
 		return true
 	}
 	otherListMarker := djotScanUnorderedListMarkerToken(s, lexer)
-	if djotCloseDifferentListIfNeeded(s, lexer, list, otherListMarker) {
-		return true
-	}
-	return false
+	return djotCloseDifferentListIfNeeded(s, lexer, list, otherListMarker)
 }
 
 // ---------------------------------------------------------------------------
@@ -2347,7 +2344,7 @@ func djotParseNewline(s *djotScannerState, lexer *gotreesitter.ExternalLexer, vs
 	if djotDisallowNewline(top) {
 		return false
 	}
-	newlineColumn := lexer.GetColumn()
+	newlineColumn := lexer.Column()
 	if lexer.Lookahead() == '\n' {
 		djotAdvance(s, lexer)
 	}
@@ -2707,7 +2704,7 @@ func djotScan(s *djotScannerState, lexer *gotreesitter.ExternalLexer, vs []bool)
 	}
 
 	// At column 0, consume leading whitespace and track indentation.
-	if lexer.GetColumn() == 0 {
+	if lexer.Column() == 0 {
 		s.indent = djotConsumeWhitespace(s, lexer)
 	}
 	isNewline := lexer.Lookahead() == '\n'

--- a/grammars/earthfile_scanner.go
+++ b/grammars/earthfile_scanner.go
@@ -77,7 +77,7 @@ func (EarthfileExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLe
 			return earthfileHandleEof(lexer, s, validSymbols)
 		}
 
-		indent := lexer.GetColumn()
+		indent := lexer.Column()
 		if indent > s.prevIndent && earthfileValid(validSymbols, earthfileTokIndent) && s.prevIndent == 0 {
 			lexer.SetResultSymbol(earthfileSymIndent)
 			s.prevIndent = indent

--- a/grammars/elm_scanner.go
+++ b/grammars/elm_scanner.go
@@ -190,7 +190,7 @@ func (ElmExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, v
 			for lexer.Lookahead() == ' ' {
 				lexer.Advance(true)
 			}
-			s.indentLength = lexer.GetColumn()
+			s.indentLength = lexer.Column()
 		} else if !isValid(elmTokBlockCommentBody) && ch == '-' {
 			lexer.Advance(false)
 			la := lexer.Lookahead()
@@ -268,7 +268,7 @@ func (ElmExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, v
 		if len(s.indents) >= 256 {
 			return false
 		}
-		s.indents = append(s.indents, uint8(lexer.GetColumn()))
+		s.indents = append(s.indents, uint8(lexer.Column()))
 		lexer.SetResultSymbol(elmSymVirtualOpenSect)
 		return true
 	}
@@ -473,7 +473,7 @@ func elmSkipWhitespaceAndRemeasure(lexer *gotreesitter.ExternalLexer, s *elmStat
 			for lexer.Lookahead() == ' ' {
 				lexer.Advance(false)
 			}
-			s.indentLength = lexer.GetColumn()
+			s.indentLength = lexer.Column()
 		} else {
 			lexer.Advance(false)
 		}

--- a/grammars/fsharp_scanner.go
+++ b/grammars/fsharp_scanner.go
@@ -182,7 +182,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 	foundPreprocessorEnd := false
 	foundPreprocIf := false
 	foundCommentStart := false
-	indentLength := uint16(lexer.GetColumn())
+	indentLength := uint16(lexer.Column())
 
 	// Whitespace / preprocessor scanning loop
 	for {
@@ -311,7 +311,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 	// Keyword: class
 	if isValid(fsTokClass) && lexer.Lookahead() == 'c' {
 		lexer.MarkEnd()
-		indentLength = uint16(lexer.GetColumn())
+		indentLength = uint16(lexer.Column())
 		lexer.Advance(false)
 		if lexer.Lookahead() == 'l' {
 			lexer.Advance(false)
@@ -330,7 +330,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 		}
 	} else if isValid(fsTokStruct) && lexer.Lookahead() == 's' {
 		lexer.MarkEnd()
-		indentLength = uint16(lexer.GetColumn())
+		indentLength = uint16(lexer.Column())
 		lexer.Advance(false)
 		if lexer.Lookahead() == 't' {
 			lexer.Advance(false)
@@ -352,7 +352,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 		}
 	} else if isValid(fsTokInterface) && lexer.Lookahead() == 'i' {
 		lexer.MarkEnd()
-		indentLength = uint16(lexer.GetColumn())
+		indentLength = uint16(lexer.Column())
 		lexer.Advance(false)
 		if lexer.Lookahead() == 'n' {
 			lexer.Advance(false)
@@ -456,7 +456,7 @@ func (FsharpExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 	} else if lexer.Lookahead() == 'e' &&
 		(isValid(fsTokElse) || isValid(fsTokElif) || isValid(fsTokEnd) || isValid(fsTokDedent)) {
 		lexer.Advance(false)
-		tokenIndentLevel := int16(lexer.GetColumn())
+		tokenIndentLevel := int16(lexer.Column())
 		if lexer.Lookahead() == 'l' {
 			lexer.Advance(false)
 			if lexer.Lookahead() == 's' && (isValid(fsTokElse) || isValid(fsTokDedent)) {

--- a/grammars/haskell_scanner.go
+++ b/grammars/haskell_scanner.go
@@ -409,7 +409,7 @@ func (env *hsEnv) column() uint32 {
 	if env.isEof() {
 		return 0
 	}
-	return env.lexer.GetColumn()
+	return env.lexer.Column()
 }
 
 func (env *hsEnv) advance() {

--- a/grammars/javascript_scanner.go
+++ b/grammars/javascript_scanner.go
@@ -268,10 +268,7 @@ func jsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 
 	if lexer.Lookahead() == '.' {
 		lexer.Advance(false)
-		if unicode.IsDigit(lexer.Lookahead()) {
-			return true
-		}
-		return false
+		return unicode.IsDigit(lexer.Lookahead())
 	}
 	return true
 }

--- a/grammars/just_scanner.go
+++ b/grammars/just_scanner.go
@@ -136,7 +136,7 @@ func (JustExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 			return justHandleEof(lexer, s, validSymbols)
 		}
 
-		indent := lexer.GetColumn()
+		indent := lexer.Column()
 
 		if indent > s.prevIndent && justValid(validSymbols, justTokIndent) && s.prevIndent == 0 {
 			lexer.MarkEnd()
@@ -155,7 +155,7 @@ func (JustExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 	// TEXT
 	if justValid(validSymbols, justTokText) {
 		// Don't start text at column == prevIndent for certain chars
-		if lexer.GetColumn() == s.prevIndent &&
+		if lexer.Column() == s.prevIndent &&
 			(lexer.Lookahead() == '\n' || lexer.Lookahead() == '@' || lexer.Lookahead() == '-') {
 			return false
 		}

--- a/grammars/lua_scanner.go
+++ b/grammars/lua_scanner.go
@@ -97,6 +97,15 @@ func luaConsumeChar(c rune, lexer *gotreesitter.ExternalLexer) bool {
 	return true
 }
 
+func luaConsumeString(s string, lexer *gotreesitter.ExternalLexer) bool {
+	for _, c := range s {
+		if !luaConsumeChar(c, lexer) {
+			return false
+		}
+	}
+	return true
+}
+
 func luaConsumeAndCountChar(c rune, lexer *gotreesitter.ExternalLexer) uint8 {
 	var count uint8
 	for lexer.Lookahead() == c {
@@ -142,7 +151,7 @@ func luaScanBlockContent(s *luaScannerState, lexer *gotreesitter.ExternalLexer) 
 }
 
 func luaScanCommentStart(s *luaScannerState, lexer *gotreesitter.ExternalLexer) bool {
-	if luaConsumeChar('-', lexer) && luaConsumeChar('-', lexer) {
+	if luaConsumeString("--", lexer) {
 		lexer.MarkEnd()
 		if luaScanBlockStart(s, lexer) {
 			lexer.MarkEnd()

--- a/grammars/matlab_scanner.go
+++ b/grammars/matlab_scanner.go
@@ -216,6 +216,15 @@ func matConsumeChar(chr rune, lexer *gotreesitter.ExternalLexer) bool {
 	return true
 }
 
+func matConsumeLineContinuation(lexer *gotreesitter.ExternalLexer) bool {
+	for i := 0; i < 3; i++ {
+		if !matConsumeChar('.', lexer) {
+			return false
+		}
+	}
+	return true
+}
+
 func matConsumeIdentifier(lexer *gotreesitter.ExternalLexer) string {
 	var buf []byte
 	if matIsIdentifierChar(lexer.Lookahead(), true) {
@@ -305,8 +314,7 @@ func matScanComment(
 	lexer.MarkEnd()
 
 	percent := lexer.Lookahead() == '%'
-	lineContinuation := lexer.Lookahead() == '.' && matConsumeChar('.', lexer) &&
-		matConsumeChar('.', lexer) && matConsumeChar('.', lexer)
+	lineContinuation := matConsumeLineContinuation(lexer)
 	block := percent && matConsumeChar('%', lexer) && matConsumeChar('{', lexer)
 
 	// Handle the case where '.' is followed by a digit inside matrices/cells.
@@ -476,7 +484,7 @@ func matScanCommand(scanner *matlabState, lexer *gotreesitter.ExternalLexer, val
 				return false
 			}
 			// Check for line continuation
-			if matConsumeChar('.', lexer) && matConsumeChar('.', lexer) && matConsumeChar('.', lexer) {
+			if matConsumeLineContinuation(lexer) {
 				// If it is a keyword, yield to the internal scanner
 				for _, kw := range matKeywords {
 					if kw == buffer {
@@ -557,8 +565,7 @@ skipCommandCheck:
 		lexer.SetResultSymbol(matSymCommandName)
 		return true
 	}
-	if lexer.Lookahead() == '.' && matConsumeChar('.', lexer) && matConsumeChar('.', lexer) &&
-		matConsumeChar('.', lexer) {
+	if matConsumeLineContinuation(lexer) {
 		lexer.SetResultSymbol(matSymIdentifier)
 		return true
 	}
@@ -993,7 +1000,7 @@ func matScanMultioutputVarStart(lexer *gotreesitter.ExternalLexer) bool {
 	var sbCount uint32
 
 	for lexer.Lookahead() != 0 {
-		if matConsumeChar('.', lexer) && matConsumeChar('.', lexer) && matConsumeChar('.', lexer) {
+		if matConsumeLineContinuation(lexer) {
 			matConsumeCommentLine(lexer)
 			lexer.Advance(false)
 		}
@@ -1020,7 +1027,7 @@ func matScanMultioutputVarStart(lexer *gotreesitter.ExternalLexer) bool {
 	lexer.Advance(false)
 
 	for lexer.Lookahead() != 0 {
-		if matConsumeChar('.', lexer) && matConsumeChar('.', lexer) && matConsumeChar('.', lexer) {
+		if matConsumeLineContinuation(lexer) {
 			matConsumeCommentLine(lexer)
 			lexer.Advance(false)
 		} else if matIsWspaceMatlab(lexer.Lookahead()) {

--- a/grammars/nginx_scanner.go
+++ b/grammars/nginx_scanner.go
@@ -82,7 +82,7 @@ func (NginxExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 	}
 
 	// At column 0, measure indentation and emit INDENT/DEDENT.
-	if lexer.Lookahead() != 0 && lexer.GetColumn() == 0 {
+	if lexer.Lookahead() != 0 && lexer.Column() == 0 {
 		var indentLen uint16
 
 		// Indent tokens are zero width.

--- a/grammars/ocaml_scanner.go
+++ b/grammars/ocaml_scanner.go
@@ -146,7 +146,7 @@ func (OcamlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 
 	// Line number directive: # <digits> "filename"
 	if !s.inString && ocamlValid(validSymbols, ocamlTokLineNumberDirective) &&
-		lexer.Lookahead() == '#' && lexer.GetColumn() == 0 {
+		lexer.Lookahead() == '#' && lexer.Column() == 0 {
 		return ocamlScanLineNumberDirective(lexer)
 	}
 

--- a/grammars/perl_scanner.go
+++ b/grammars/perl_scanner.go
@@ -459,7 +459,7 @@ func (PerlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 			var line plTSPString
 			for lexer.Lookahead() != 0 {
 				line.reset()
-				isValidStartPos := st.heredocState == plHeredocEnd || lexer.GetColumn() == 0
+				isValidStartPos := st.heredocState == plHeredocEnd || lexer.Column() == 0
 				sawEscape := false
 				if isValidStartPos && st.heredocIndents {
 					plSkipWhitespace(lexer)
@@ -538,7 +538,7 @@ func (PerlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 
 	// Heredoc start: heredocs override everything
 	if valid(plTokHeredocStart) {
-		if st.heredocState == plHeredocStart && lexer.GetColumn() == 0 {
+		if st.heredocState == plHeredocStart && lexer.Column() == 0 {
 			st.heredocState = plHeredocUnknown
 			return token(plTokHeredocStart)
 		}
@@ -557,7 +557,6 @@ func (PerlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 		for lexer.Lookahead() != 0 {
 			if c == '\\' {
 				lexer.Advance(false)
-				c = lexer.Lookahead()
 				// ignore the next char
 			} else if c == '(' {
 				delimcount++
@@ -687,7 +686,7 @@ func (PerlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 
 	// POD
 	if valid(plTokPod) {
-		column := lexer.GetColumn()
+		column := lexer.Column()
 		if column == 0 && c == '=' {
 			cutMarker := "=cut"
 			stage := -1
@@ -812,7 +811,6 @@ func (PerlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 		}
 		lexer.MarkEnd()
 		lexer.Advance(false)
-		c = lexer.Lookahead()
 
 		// Guard against brace end in autoquote context
 		if valid(plTokBraceEndZW) && delim == '}' {
@@ -989,7 +987,7 @@ func (PerlExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, 
 			if c == '#' {
 				lexer.Advance(false)
 				c = lexer.Lookahead()
-				for lexer.GetColumn() != 0 {
+				for lexer.Column() != 0 {
 					lexer.Advance(false)
 					c = lexer.Lookahead()
 				}

--- a/grammars/purescript_scanner.go
+++ b/grammars/purescript_scanner.go
@@ -159,7 +159,7 @@ func (st *psState) markEnd() {
 }
 
 func (st *psState) column() uint32 {
-	return st.lexer.GetColumn()
+	return st.lexer.Column()
 }
 
 func (st *psState) isEOF() bool {

--- a/grammars/rst_scanner.go
+++ b/grammars/rst_scanner.go
@@ -992,10 +992,7 @@ func (r *rstCtx) parseExplicitMarkupStart() bool {
 		return false
 	}
 	r.advance()
-	if r.parseInnerListElement(2, rstTokExplicitMarkup) {
-		return true
-	}
-	return false
+	return r.parseInnerListElement(2, rstTokExplicitMarkup)
 }
 
 func (r *rstCtx) parseInnerListElement(consumedChars int, tokenType int) bool {

--- a/grammars/ruby_scanner.go
+++ b/grammars/ruby_scanner.go
@@ -312,7 +312,7 @@ func rbyIsIdenChar(c rune) bool {
 	if c == 0 {
 		return false
 	}
-	return strings.IndexRune(rbyNonIdentifierChars, c) < 0
+	return !strings.ContainsRune(rbyNonIdentifierChars, c)
 }
 
 func rbySetResult(lexer *gotreesitter.ExternalLexer, tok int) {

--- a/grammars/scala_scanner.go
+++ b/grammars/scala_scanner.go
@@ -177,7 +177,7 @@ func (ScalaExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 		if lexer.Lookahead() == 0 {
 			s.lastColumn = -1
 		} else {
-			s.lastColumn = int16(lexer.GetColumn())
+			s.lastColumn = int16(lexer.Column())
 		}
 		return true
 	}
@@ -185,7 +185,7 @@ func (ScalaExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 	// Recover newline_count from outdent reset
 	isEOF := lexer.Lookahead() == 0
 	if (s.lastNewlineCount > 0 && isEOF && s.lastColumn == -1) ||
-		(!isEOF && int16(lexer.GetColumn()) == s.lastColumn) {
+		(!isEOF && int16(lexer.Column()) == s.lastColumn) {
 		newlineCount += s.lastNewlineCount
 	}
 	s.lastNewlineCount = 0

--- a/grammars/tlaplus_scanner.go
+++ b/grammars/tlaplus_scanner.go
@@ -702,7 +702,7 @@ func tlaLexLookahead(
 				state = lsConsumeLeadingSpace
 				continue
 			}
-			col = int16(lexer.GetColumn())
+			col = int16(lexer.Column())
 			lexer.MarkEnd()
 			if !tlaHasNext(lexer) {
 				tlaAdvance(lexer)

--- a/grammars/tsx_scanner.go
+++ b/grammars/tsx_scanner.go
@@ -273,10 +273,7 @@ func tsxScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 
 	if lexer.Lookahead() == '.' {
 		lexer.Advance(false)
-		if unicode.IsDigit(lexer.Lookahead()) {
-			return true
-		}
-		return false
+		return unicode.IsDigit(lexer.Lookahead())
 	}
 	return true
 }

--- a/grammars/typescript_scanner.go
+++ b/grammars/typescript_scanner.go
@@ -273,10 +273,7 @@ func tsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 
 	if lexer.Lookahead() == '.' {
 		lexer.Advance(false)
-		if unicode.IsDigit(lexer.Lookahead()) {
-			return true
-		}
-		return false
+		return unicode.IsDigit(lexer.Lookahead())
 	}
 	return true
 }

--- a/grammars/typst_scanner.go
+++ b/grammars/typst_scanner.go
@@ -838,7 +838,7 @@ func (TypstExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 
 	// COMMENT via '/' prefix
 	if lexer.Lookahead() == '/' {
-		column := lexer.GetColumn()
+		column := lexer.Column()
 
 		// COMMENT
 		if typstParseComment(s, lexer) {
@@ -1044,7 +1044,7 @@ func (TypstExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 	// ITEM (- or + or 1.)
 	if s.lineStart && typstValid(validSymbols, typstTokItem) {
 		if lexer.Lookahead() == '-' || lexer.Lookahead() == '+' {
-			column := lexer.GetColumn()
+			column := lexer.Column()
 			lexer.Advance(false)
 			if typstIsSP(lexer.Lookahead()) || typstIsLB(lexer.Lookahead()) || lexer.Lookahead() == 0 {
 				s.lineStart = false
@@ -1056,7 +1056,7 @@ func (TypstExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 			return false
 		}
 		if lexer.Lookahead() >= '0' && lexer.Lookahead() <= '9' {
-			column := lexer.GetColumn()
+			column := lexer.Column()
 			lexer.Advance(false)
 			for lexer.Lookahead() >= '0' && lexer.Lookahead() <= '9' {
 				lexer.Advance(false)
@@ -1254,7 +1254,7 @@ func (TypstExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer,
 			return false
 		}
 
-		column := lexer.GetColumn()
+		column := lexer.Column()
 		if len(s.indentation) == 0 {
 			return false
 		}

--- a/grammars/yaml_scanner.go
+++ b/grammars/yaml_scanner.go
@@ -1388,8 +1388,6 @@ func (e *yamlEnv) scnBlkStrCnt(resultSymbol int) bool {
 }
 
 func (e *yamlEnv) scnPlnCnt(isPlainSafe func(int32) bool) int8 {
-	isCurWsp := yIsWsp(e.curChr)
-	_ = isCurWsp
 	isCurSaf := isPlainSafe(e.curChr)
 	isLkaWsp := yIsWsp(e.lka())
 	isLkaSaf := isPlainSafe(e.lka())
@@ -1412,7 +1410,6 @@ func (e *yamlEnv) scnPlnCnt(isPlainSafe func(int32) bool) int8 {
 				break
 			}
 
-			isCurWsp = isLkaWsp
 			isCurSaf = isLkaSaf
 			isLkaWsp = yIsWsp(e.lka())
 			isLkaSaf = isPlainSafe(e.lka())


### PR DESCRIPTION
## Summary

This PR pays down the scanner-side staticcheck backlog that was intentionally kept out of #150. It keeps the scope to `grammars/`: deprecated `GetColumn()` calls, redundant boolean returns, unused scanner assignments, nil-length checks, and a couple of small helper extractions that make sequential token consumption explicit.

## Changes

- Replace deprecated `lexer.GetColumn()` calls with `lexer.Column()` across scanner files.
- Simplify redundant boolean-return patterns in bash, djot, javascript, rst, tsx, and typescript scanners.
- Remove unused assignments in perl and yaml scanners.
- Add `luaConsumeString` and `matConsumeLineContinuation` helpers for intentional sequential token consumption.
- Clean up blob export tests and the Bash retry regression placeholder string.

## Validation

- `go vet ./grammars`
- `go test ./grammars -run . -count=1 -timeout 10m`
- `go test . -run '^(TestYAMLIncrementalEditScalarTokenInvariantLeafReuseIsCorrect|TestYAMLPlainScalarKind|TestYAMLPlainScalarStableEditRejectsKindChange|TestYAMLPlainScalarStableEditAllowsStringAndNumberScalars|TestNormalizeLuaChunkLocalDeclarationFields)$' -count=1 -timeout 10m`\n- `go test ./grammars -run '^(TestLuaBlockScannerMatchesC|TestLuaExternalSymbolConstants|TestYAMLNewlineBlTokens|TestLuaNoNewlineTokens|TestAuditParseSupportLuaUsesDFAExternalScanner|TestExternalLexStatesDefaultElectionInventory|TestLeadingCommentSpanTightness)$' -count=1 -timeout 10m`\n- `git diff --check`\n- `staticcheck ./grammars` now leaves only `grammars/generic_lexer.go:680` from main; that is already fixed in #150 and this PR avoids duplicating that edit.\n\nDocker diagnostics:\n\n- `bash cgo_harness/docker/run_single_grammar_parity.sh lua` reports `MISMATCH` with `23/25`; the same command on untouched `origin/main` reports the same `23/25` and same string-escape samples.\n- `bash cgo_harness/docker/run_single_grammar_parity.sh yaml` reports `MISMATCH` with `25/25` no-error and `24/25` parity; the same command on untouched `origin/main` reports the same result and same range-divergence sample.\n- `bash cgo_harness/docker/run_single_grammar_parity.sh perl` does not reach parsing: grammar generation times out after `1m30s`. Retrying with `GTS_GRAMMARGEN_REAL_CORPUS_GENERATE_TIMEOUT=15m` did not affect the wrapper-propagated timeout.\n- `bash cgo_harness/docker/run_single_grammar_parity.sh matlab` is not available in the harness (`unknown grammar: matlab`).\n\n## Review Focus\n\nThe only non-mechanical scanner logic worth scrutinizing is the Lua/MATLAB helper extraction. The helpers preserve the old partial-consumption behavior while making the repeated-character intent explicit.