### PR TITLE
cleanup(glr): Remove debug stats helpers and counter instrumentation

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -1092,38 +1092,13 @@ func storeGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode, result boo
 // when unset.
 var debugMergeEquiv = os.Getenv("GOT_DEBUG_MERGE_EQUIV") == "1"
 
-// debugMergeEquivStats, when set (GOT_DEBUG_MERGE_EQUIV_STATS=1), accumulates
-// spine-memo lookup/hit/store counters (single-threaded parse; plain adds).
-var debugMergeEquivStats = os.Getenv("GOT_DEBUG_MERGE_EQUIV_STATS") == "1"
-
 // mergeEquivMemoEnabled gates the spine-equality memo. Default on; set
 // GOT_DISABLE_MERGE_EQUIV_MEMO=1 to fall back to the original memo-free walk
 // (A/B measurement only — the memo is answer-exact, verified by
 // GOT_DEBUG_MERGE_EQUIV).
 var mergeEquivMemoEnabled = os.Getenv("GOT_DISABLE_MERGE_EQUIV_MEMO") != "1"
 
-var (
-	debugSpineMemoLookups    uint64
-	debugSpineMemoHits       uint64
-	debugSpineMemoStores     uint64
-	debugMergeEquivChecks    uint64
-	debugMergeEquivDiverge   uint64
-	debugMergeEquivReportsLt = 20
-)
-
-// DebugSpineMemoStats returns (lookups, hits, stores) for the spine-equality
-// memo since process start. Measurement helper (wave-2b); only populated when
-// GOT_DEBUG_MERGE_EQUIV_STATS=1.
-func DebugSpineMemoStats() (uint64, uint64, uint64) {
-	return debugSpineMemoLookups, debugSpineMemoHits, debugSpineMemoStores
-}
-
-// DebugMergeEquivAssertStats returns (checks, divergences) for the spine-memo
-// correctness assertion. Nonzero divergences mean the memo answer differed from
-// the full walk (a bug). Only populated when GOT_DEBUG_MERGE_EQUIV=1.
-func DebugMergeEquivAssertStats() (uint64, uint64) {
-	return debugMergeEquivChecks, debugMergeEquivDiverge
-}
+var debugMergeEquivReportsLt = 20
 
 func spineEquivCacheIndex(ap, bp uintptr) int {
 	x := uint64(ap)
@@ -1155,25 +1130,16 @@ func lookupSpineEquivCache(scratch *glrMergeScratch, a, b *gssNode) (bool, bool)
 		// orderedGSSNodePair swapped: keep fingerprints paired with pointers.
 		aHash, bHash = b.hash, a.hash
 	}
-	if debugMergeEquivStats {
-		debugSpineMemoLookups++
-	}
 	idx := spineEquivCacheIndex(ap, bp)
 	primary := &scratch.spineEquivCache[idx]
 	if primary.epoch == scratch.equivEpoch && primary.a == ap && primary.b == bp &&
 		primary.aHash == aHash && primary.bHash == bHash {
-		if debugMergeEquivStats {
-			debugSpineMemoHits++
-		}
 		return primary.result, true
 	}
 	victim := &scratch.spineEquivCache[idx+1]
 	if victim.epoch == scratch.equivEpoch && victim.a == ap && victim.b == bp &&
 		victim.aHash == aHash && victim.bHash == bHash {
 		*primary, *victim = *victim, *primary
-		if debugMergeEquivStats {
-			debugSpineMemoHits++
-		}
 		return primary.result, true
 	}
 	return false, false
@@ -1196,9 +1162,6 @@ func storeSpineEquivCache(scratch *glrMergeScratch, a, b *gssNode, result bool) 
 	aHash, bHash := a.hash, b.hash
 	if ap != uintptr(unsafe.Pointer(a)) {
 		aHash, bHash = b.hash, a.hash
-	}
-	if debugMergeEquivStats {
-		debugSpineMemoStores++
 	}
 	idx := spineEquivCacheIndex(ap, bp)
 	scratch.spineEquivCache[idx+1] = scratch.spineEquivCache[idx]
@@ -1667,12 +1630,10 @@ func gssSpineEqualRaw(scratch *glrMergeScratch, lang *Language, headA, headB *gs
 }
 
 func debugCheckSpineEquiv(scratch *glrMergeScratch, lang *Language, headA, headB *gssNode, got bool) {
-	debugMergeEquivChecks++
 	want := gssSpineEqualRaw(scratch, lang, headA, headB)
 	if want == got {
 		return
 	}
-	debugMergeEquivDiverge++
 	if debugMergeEquivReportsLt > 0 {
 		debugMergeEquivReportsLt--
 		fmt.Fprintf(os.Stderr,

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -144,9 +144,6 @@ const forestRecoverCap = 1 << 20
 // not thread-safe; for single-threaded prototyping/measurement).
 var forestLastDeclineReason string
 
-// ForestLastDeclineReason returns the reason parseForest last declined.
-func ForestLastDeclineReason() string { return forestLastDeclineReason }
-
 const forestDeclineEOFRecoveryConflict = "eof-recovery-conflict"
 
 func forestProgressExtra(frontier, work, nextFrontier []*gssForestNode, curIndex, nextIndex gssForestIndex, processEpoch int32, recoverCount int, reducer *forestReducer, accepted *gssForestNode, more string) string {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1449,11 +1449,6 @@ func init() {
 	gssPrefixAggGen.Store(1)
 }
 
-// DebugGSSPrefixAggGen returns the current global GSS prefix-aggregate
-// generation. Monotonic (only Add(1)); the delta across a parse equals the
-// number of choke-point invalidations. Measurement helper (wave-2b).
-func DebugGSSPrefixAggGen() uint64 { return gssPrefixAggGen.Load() }
-
 // cStackPrefixAgg returns the cumulative (error cost, visible subtree count)
 // of head's prev chain, filling the on-node aggregates bottom-up from the
 // deepest still-valid node — O(new or invalidated suffix), O(1) steady-state.


### PR DESCRIPTION
## Summary

This PR removes stale wave-local measurement scaffolding from the GLR spine-equivalence and recovery diagnostic surface. It keeps the actual merge-equivalence memo, the `GOT_DEBUG_MERGE_EQUIV` assertion path, forest decline telemetry, and GSS prefix aggregate invalidation behavior intact.

## Changes

- Remove the unused exported measurement helpers `DebugSpineMemoStats`, `DebugMergeEquivAssertStats`, `DebugGSSPrefixAggGen`, and `ForestLastDeclineReason`.
- Drop the `GOT_DEBUG_MERGE_EQUIV_STATS` flag and the backing spine-memo lookup/hit/store counters it fed.
- Remove no-longer-readable counter increments from `lookupSpineEquivCache`, `storeSpineEquivCache`, and `debugCheckSpineEquiv`.
- Leave the per-parser `ForestDeclineInfo` API in place for forest decline diagnostics.

## Testing

- `git diff --check`
- `staticcheck -checks=U1000 ./...`
- `deadcode -test -f='{{range .Funcs}}{{printf "%s:%d:%d %s %t\\n" .Position.File .Position.Line .Position.Col .Name .Generated}}{{end}}' ./...`
- `go test . -run '^(TestReduceForkSelection|TestSelectReduceForkChildren|TestFastVisibleReduceFromGSS|TestFaithfulForkReduce|TestCRecoveryCostCompetitionDisabledInNoTreeModes|TestCRecoveryZerrorsTruncationAcyclic)$' -count=1 -timeout 20m`
- `go test . -run '^$' -count=1`
- `(cd cgo_harness && go test ./cmd/equiv_audit_oneshot -run '^$' -count=1)`
- `(cd cgo_harness && go test -tags 'cgo treesitter_c_parity' ./cmd/parse_gap_report -run '^$' -count=1)`

## Compatibility

This removes exported but undocumented debug/measurement helpers. Downstream code calling those helpers must drop those calls or use existing runtime diagnostics such as `ForestDeclineInfo` where applicable.

## Review Focus

Confirm this only removes stale counter plumbing and does not change parser decisions, memo correctness assertions, recovery behavior, or cgo-harness audit toggles.
