### PR TITLE
fix(cgo_harness): trim COBOL trailing trivia spans to match C parser

### DIFF
--- a/cgo_harness/cobol_cgo_regression_test.go
+++ b/cgo_harness/cobol_cgo_regression_test.go
@@ -1,0 +1,116 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestCobolCGOTrailingTriviaSpans(t *testing.T) {
+	goLang := grammars.CobolLanguage()
+	cLang, err := ParityCLanguage("cobol")
+	if err != nil {
+		t.Skipf("C parser unavailable: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("C SetLanguage: %v", err)
+	}
+	goParser := gotreesitter.NewParser(goLang)
+
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "perform_forever_continue",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"       perform forever\n" +
+				"         continue\n" +
+				"       end-perform.\n",
+		},
+		{
+			name: "evaluate_goto",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"       evaluate 1\n" +
+				"       when 1\n" +
+				"         go to aa\n" +
+				"       end-evaluate.\n" +
+				"       aa.\n",
+		},
+		{
+			name: "evaluate_two_whens_goto",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"       evaluate 1\n" +
+				"       when 1\n" +
+				"       when 2\n" +
+				"         go to aa\n" +
+				"       end-evaluate.\n" +
+				"       aa.\n",
+		},
+		{
+			name: "fixed_format_data_description_tails",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"003300 ENVIRONMENT DIVISION.                                            NC1014.2\n" +
+				"003900 INPUT-OUTPUT SECTION.                                            NC1014.2\n" +
+				"004000 FILE-CONTROL.                                                    NC1014.2\n" +
+				"004100     SELECT PRINT-FILE ASSIGN TO                                  NC1014.2\n" +
+				"004200     \"report.log\".                                                NC1014.2\n" +
+				"004300 DATA DIVISION.                                                   NC1014.2\n" +
+				"004400 FILE SECTION.                                                    NC1014.2\n" +
+				"004500 FD  PRINT-FILE.                                                  NC1014.2\n" +
+				"004600 01  PRINT-REC PICTURE X(120).                                    NC1014.2\n" +
+				"004700 01  DUMMY-RECORD PICTURE X(120).                                 NC1014.2\n" +
+				"004800 WORKING-STORAGE SECTION.                                         NC1014.2\n" +
+				"004900 77  WRK-DS-18V00                PICTURE S9(18).                  NC1014.2\n" +
+				"       PROCEDURE DIVISION.\n" +
+				"       DISPLAY 1.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			goTree, err := goParser.Parse(src)
+			if err != nil {
+				t.Fatalf("go parse: %v", err)
+			}
+			goRoot := goTree.RootNode()
+			if goRoot == nil {
+				t.Fatal("go nil root")
+			}
+			if goRoot.HasError() {
+				t.Fatalf("go root has error:\n%s", goRoot.SExpr(goLang))
+			}
+
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C nil tree")
+			}
+			defer cTree.Close()
+			cRoot := cTree.RootNode()
+			if cRoot.HasError() {
+				t.Fatalf("C root has error:\n%s", dumpCTree(cRoot, 0))
+			}
+
+			var errs []string
+			compareNodes(goRoot, goLang, cRoot, "root", &errs)
+			if len(errs) > 0 {
+				t.Fatalf("go-vs-C divergences:\n%s\n\ngo:\n%s\n\nc:\n%s", joinTopErrors(errs), goRoot.SExpr(goLang), dumpCTree(cRoot, 0))
+			}
+		})
+	}
+}

--- a/parser_result_c_go_cobol_test.go
+++ b/parser_result_c_go_cobol_test.go
@@ -548,6 +548,13 @@ func TestCobolTrailingTriviaRejectsFreeFormatCode(t *testing.T) {
 	if cobolBytesAreTrailingTrivia(inline, inlineEnd, uint32(len(inline))) {
 		t.Fatalf("inline content before the identification area must not be trailing trivia")
 	}
+
+	longFree := append([]byte("display 1."), bytes.Repeat([]byte(" "), 72-len("display 1."))...)
+	longFree = append(longFree, []byte("real-code")...)
+	longFreeEnd := uint32(bytes.Index(longFree, []byte("display 1.")) + len("display 1."))
+	if cobolBytesAreTrailingTrivia(longFree, longFreeEnd, uint32(len(longFree))) {
+		t.Fatalf("column-73 content on a non-fixed-format line must not be trailing trivia")
+	}
 }
 
 func cobolTrailingTriviaTestLanguage() *Language {

--- a/parser_result_c_go_cobol_test.go
+++ b/parser_result_c_go_cobol_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestNormalizeCTranslationUnitRootRetagsRecoveredTopLevelChildren(t *testing.T) {
 	lang := &Language{
@@ -380,6 +383,217 @@ func TestNormalizeCobolFixedFormatProgramIDStopsBeforeTrailingJunk(t *testing.T)
 	if got, want := idDiv.EndByte(), uint32(53); got != want {
 		t.Fatalf("identification_division.EndByte = %d, want %d", got, want)
 	}
+}
+
+func TestNormalizeCobolTrimsStatementTrailingTriviaSpans(t *testing.T) {
+	lang := cobolTrailingTriviaTestLanguage()
+	source := []byte("       identification division.\n" +
+		"       program-id. a.\n" +
+		"       procedure division.\n" +
+		"       perform forever\n" +
+		"         continue\n" +
+		"       end-perform.\n")
+
+	arena := newNodeArena(arenaClassFull)
+	id := cobolTestLeaf(arena, 3, true, source, 7, uint32(bytes.Index(source, []byte("procedure division."))))
+	performStart := uint32(bytes.Index(source, []byte("perform forever")))
+	performEnd := performStart + uint32(len("perform forever"))
+	continueStart := uint32(bytes.Index(source, []byte("continue")))
+	continueEnd := continueStart + uint32(len("continue"))
+	endPerformStart := uint32(bytes.Index(source, []byte("end-perform")))
+	periodStart := uint32(bytes.LastIndexByte(source, '.'))
+	periodEnd := periodStart + 1
+
+	performText := cobolTestLeaf(arena, 8, false, source, performStart, performEnd)
+	perform := newParentNodeInArena(arena, 5, true, []*Node{performText}, nil, 0)
+	perform.startByte = performStart
+	perform.startPoint = advancePointByBytes(Point{}, source[:performStart])
+	perform.endByte = continueStart
+	perform.endPoint = advancePointByBytes(Point{}, source[:continueStart])
+	continueStmt := cobolTestLeaf(arena, 6, true, source, continueStart, endPerformStart)
+	continueStmt.startByte = continueStart
+	continueStmt.startPoint = advancePointByBytes(Point{}, source[:continueStart])
+	continueStmt.endByte = endPerformStart
+	continueStmt.endPoint = advancePointByBytes(Point{}, source[:endPerformStart])
+	period := cobolTestLeaf(arena, 7, true, source, periodStart, periodEnd)
+	procedureStart := uint32(bytes.Index(source, []byte("procedure division.")))
+	proc := newParentNodeInArena(arena, 4, true, []*Node{perform, continueStmt, period}, nil, 0)
+	proc.startByte = procedureStart
+	proc.startPoint = advancePointByBytes(Point{}, source[:procedureStart])
+	proc.endByte = uint32(len(source))
+	proc.endPoint = advancePointByBytes(Point{}, source)
+	def := newParentNodeInArena(arena, 2, true, []*Node{id, proc}, nil, 0)
+	def.startByte = 7
+	def.startPoint = advancePointByBytes(Point{}, source[:7])
+	def.endByte = uint32(len(source))
+	def.endPoint = advancePointByBytes(Point{}, source)
+	root := newParentNodeInArena(arena, 1, true, []*Node{def}, nil, 0)
+	root.startByte = 7
+	root.startPoint = advancePointByBytes(Point{}, source[:7])
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := perform.EndByte(), performEnd; got != want {
+		t.Fatalf("perform_statement_loop.EndByte = %d, want %d", got, want)
+	}
+	if got, want := continueStmt.EndByte(), continueEnd; got != want {
+		t.Fatalf("continue_statement.EndByte = %d, want %d", got, want)
+	}
+	if got, want := proc.EndByte(), periodEnd; got != want {
+		t.Fatalf("procedure_division.EndByte = %d, want %d", got, want)
+	}
+	if got, want := def.EndByte(), periodEnd; got != want {
+		t.Fatalf("program_definition.EndByte = %d, want %d", got, want)
+	}
+	if got, want := root.EndByte(), uint32(len(source)); got != want {
+		t.Fatalf("start.EndByte = %d, want unchanged %d", got, want)
+	}
+}
+
+func TestNormalizeCobolTrimsGotoTrailingTriviaSpan(t *testing.T) {
+	lang := cobolTrailingTriviaTestLanguage()
+	source := []byte("       identification division.\n" +
+		"       program-id. a.\n" +
+		"       procedure division.\n" +
+		"       evaluate 1\n" +
+		"       when 1\n" +
+		"         go to aa\n" +
+		"       end-evaluate.\n" +
+		"       aa.\n")
+
+	arena := newNodeArena(arenaClassFull)
+	id := cobolTestLeaf(arena, 3, true, source, 7, uint32(bytes.Index(source, []byte("procedure division."))))
+	gotoStart := uint32(bytes.Index(source, []byte("go to aa")))
+	gotoEnd := gotoStart + uint32(len("go to aa"))
+	endEvaluateStart := uint32(bytes.Index(source, []byte("end-evaluate")))
+	periodStart := uint32(bytes.LastIndexByte(source, '.'))
+	periodEnd := periodStart + 1
+
+	gotoText := cobolTestLeaf(arena, 10, false, source, gotoStart, gotoEnd)
+	gotoStmt := newParentNodeInArena(arena, 11, true, []*Node{gotoText}, nil, 0)
+	gotoStmt.startByte = gotoStart
+	gotoStmt.startPoint = advancePointByBytes(Point{}, source[:gotoStart])
+	gotoStmt.endByte = endEvaluateStart
+	gotoStmt.endPoint = advancePointByBytes(Point{}, source[:endEvaluateStart])
+	period := cobolTestLeaf(arena, 7, true, source, periodStart, periodEnd)
+	procedureStart := uint32(bytes.Index(source, []byte("procedure division.")))
+	proc := newParentNodeInArena(arena, 4, true, []*Node{gotoStmt, period}, nil, 0)
+	proc.startByte = procedureStart
+	proc.startPoint = advancePointByBytes(Point{}, source[:procedureStart])
+	proc.endByte = uint32(len(source))
+	proc.endPoint = advancePointByBytes(Point{}, source)
+	def := newParentNodeInArena(arena, 2, true, []*Node{id, proc}, nil, 0)
+	def.startByte = 7
+	def.startPoint = advancePointByBytes(Point{}, source[:7])
+	def.endByte = uint32(len(source))
+	def.endPoint = advancePointByBytes(Point{}, source)
+	root := newParentNodeInArena(arena, 1, true, []*Node{def}, nil, 0)
+	root.startByte = 7
+	root.startPoint = advancePointByBytes(Point{}, source[:7])
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := gotoStmt.EndByte(), gotoEnd; got != want {
+		t.Fatalf("goto_statement.EndByte = %d, want %d", got, want)
+	}
+	if got, want := proc.EndByte(), periodEnd; got != want {
+		t.Fatalf("procedure_division.EndByte = %d, want %d", got, want)
+	}
+	if got, want := root.EndByte(), uint32(len(source)); got != want {
+		t.Fatalf("start.EndByte = %d, want unchanged %d", got, want)
+	}
+}
+
+func TestCobolTrailingTriviaAcceptsFixedFormatLineTails(t *testing.T) {
+	source := []byte("       identification division.\n" +
+		"       program-id. a.\n" +
+		"003300 ENVIRONMENT DIVISION.                                            NC1014.2\n" +
+		"004200     \"report.log\".                                                NC1014.2\n" +
+		"004300 DATA DIVISION.                                                   NC1014.2\n" +
+		"004900 77  WRK-DS-18V00                PICTURE S9(18).                  NC1014.2\n" +
+		"       PROCEDURE DIVISION.")
+
+	programIDEnd := uint32(bytes.Index(source, []byte("program-id. a.")) + len("program-id. a."))
+	envSequenceEnd := uint32(bytes.Index(source, []byte("003300")) + len("003300"))
+	if !cobolBytesAreTrailingTrivia(source, programIDEnd, envSequenceEnd) {
+		t.Fatalf("expected fixed-format sequence prefix to be trailing trivia")
+	}
+
+	reportEnd := uint32(bytes.Index(source, []byte("\"report.log\".")) + len("\"report.log\"."))
+	dataStart := uint32(bytes.Index(source, []byte("DATA DIVISION.")))
+	if !cobolBytesAreTrailingTrivia(source, reportEnd, dataStart) {
+		t.Fatalf("expected fixed-format identification area and next prefix to be trailing trivia")
+	}
+
+	pictureEnd := uint32(bytes.Index(source, []byte("PICTURE S9(18).")) + len("PICTURE S9(18)."))
+	procedureStart := uint32(bytes.Index(source, []byte("PROCEDURE DIVISION.")))
+	if !cobolBytesAreTrailingTrivia(source, pictureEnd, procedureStart) {
+		t.Fatalf("expected trailing identification area before procedure division to be trivia")
+	}
+}
+
+func TestCobolTrailingTriviaRejectsFreeFormatCode(t *testing.T) {
+	source := []byte("display 1.\nmove a to b.")
+	displayEnd := uint32(bytes.Index(source, []byte("display 1.")) + len("display 1."))
+	if cobolBytesAreTrailingTrivia(source, displayEnd, uint32(len(source))) {
+		t.Fatalf("free-format code on the next line must not be trimmed as fixed-format trivia")
+	}
+
+	inline := []byte("       display 1. real-code")
+	inlineEnd := uint32(bytes.Index(inline, []byte("display 1.")) + len("display 1."))
+	if cobolBytesAreTrailingTrivia(inline, inlineEnd, uint32(len(inline))) {
+		t.Fatalf("inline content before the identification area must not be trailing trivia")
+	}
+}
+
+func cobolTrailingTriviaTestLanguage() *Language {
+	return &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			"start",
+			"program_definition",
+			"identification_division",
+			"procedure_division",
+			"perform_statement_loop",
+			"continue_statement",
+			"period",
+			"perform forever",
+			"continue",
+			"go to aa",
+			"goto_statement",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "perform_statement_loop", Visible: true, Named: true},
+			{Name: "continue_statement", Visible: true, Named: true},
+			{Name: "period", Visible: true, Named: true},
+			{Name: "perform forever", Visible: true, Named: false},
+			{Name: "continue", Visible: true, Named: false},
+			{Name: "go to aa", Visible: true, Named: false},
+			{Name: "goto_statement", Visible: true, Named: true},
+		},
+	}
+}
+
+func cobolTestLeaf(arena *nodeArena, sym Symbol, named bool, source []byte, start, end uint32) *Node {
+	return newLeafNodeInArena(
+		arena,
+		sym,
+		named,
+		start,
+		end,
+		advancePointByBytes(Point{}, source[:start]),
+		advancePointByBytes(Point{}, source[:end]),
+	)
 }
 
 func TestNormalizeCobolRecoveredParagraphHeader(t *testing.T) {

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -6,6 +6,7 @@ func normalizeCobolCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeCobolLeadingAreaStart(root, source, lang)
 	normalizeCobolTopLevelDefinitionEnd(root, source, lang)
 	normalizeCobolDivisionSiblingEnds(root, source, lang)
+	normalizeCobolTrailingTriviaSpans(root, source, lang)
 	normalizeCobolRecoveredParagraphHeader(root, source, lang)
 }
 func normalizeCobolLeadingAreaStart(root *Node, source []byte, lang *Language) {
@@ -227,6 +228,107 @@ func normalizeCobolDivisionSiblingEnds(root *Node, source []byte, lang *Language
 		}
 		cur.endByte = end
 		cur.endPoint = advancePointByBytes(Point{}, source[:end])
+	}
+}
+
+func normalizeCobolTrailingTriviaSpans(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || len(source) == 0 {
+		return
+	}
+	walkResultTreePostorder(root, func(n *Node) {
+		if n == nil || n.Type(lang) == "start" || n.IsExtra() || n.IsMissing() || n.IsError() || n.HasError() {
+			return
+		}
+		childCount := resultChildCount(n)
+		if childCount == 0 {
+			normalizeCobolTrailingTriviaLeafSpan(n, source, lang)
+			return
+		}
+		if int(n.endByte) > len(source) {
+			return
+		}
+		last := (*Node)(nil)
+		for i := childCount - 1; i >= 0; i-- {
+			child := resultChildAt(n, i)
+			if child == nil || child.IsMissing() {
+				continue
+			}
+			last = child
+			break
+		}
+		if last == nil || last.endByte >= n.endByte || last.endByte < n.startByte {
+			return
+		}
+		if !cobolBytesAreTrailingTrivia(source, last.endByte, n.endByte) {
+			return
+		}
+		setCobolNodeEnd(n, source, last.endByte)
+	})
+}
+
+func normalizeCobolTrailingTriviaLeafSpan(n *Node, source []byte, lang *Language) {
+	if n == nil || int(n.endByte) > len(source) || !cobolTrailingTriviaLeafCanTrim(n.Type(lang)) {
+		return
+	}
+	end := lastNonTriviaByteEnd(source[n.startByte:n.endByte])
+	if end == 0 {
+		return
+	}
+	absoluteEnd := n.startByte + end
+	if absoluteEnd <= n.startByte || absoluteEnd >= n.endByte {
+		return
+	}
+	setCobolNodeEnd(n, source, absoluteEnd)
+}
+
+func cobolTrailingTriviaLeafCanTrim(typ string) bool {
+	return strings.HasSuffix(typ, "_statement") || strings.HasSuffix(typ, "_statement_loop")
+}
+
+func cobolBytesAreTrailingTrivia(source []byte, start, end uint32) bool {
+	if start >= end || int(end) > len(source) {
+		return false
+	}
+	lineStart := int(start)
+	for lineStart > 0 && source[lineStart-1] != '\n' && source[lineStart-1] != '\r' {
+		lineStart--
+	}
+	column := int(start) - lineStart
+	for i := int(start); i < int(end); i++ {
+		switch source[i] {
+		case ' ', '\t', '\f':
+			column++
+		case '\n':
+			lineStart = i + 1
+			column = 0
+		case '\r':
+			lineStart = i + 1
+			column = 0
+		default:
+			if column < 6 && cobolLineLooksFixedFormat(source, lineStart) {
+				column++
+				continue
+			}
+			if column >= 72 {
+				column++
+				continue
+			}
+			return false
+		}
+	}
+	return true
+}
+
+func cobolLineLooksFixedFormat(source []byte, lineStart int) bool {
+	indicator := lineStart + 6
+	if lineStart < 0 || indicator >= len(source) {
+		return false
+	}
+	switch source[indicator] {
+	case ' ', '*', '-', '/':
+		return true
+	default:
+		return false
 	}
 }
 

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -309,7 +309,7 @@ func cobolBytesAreTrailingTrivia(source []byte, start, end uint32) bool {
 				column++
 				continue
 			}
-			if column >= 72 {
+			if column >= 72 && cobolLineLooksFixedFormat(source, lineStart) {
 				column++
 				continue
 			}


### PR DESCRIPTION
## Summary

The COBOL Go parser was producing wider node end spans than the C tree-sitter parser because it included trailing trivia (whitespace, fixed-format sequence-area columns 1-6, and identification-area tails at column 72+) in node end positions. This PR adds a normalization pass that trims trailing trivia from COBOL node spans in postorder, ensuring Go parser output matches the C parser's span boundaries for both parent and leaf statement nodes (e.g., perform_statement_loop, goto_statement). This brings the Go parser into parity with the C tree-sitter parser for COBOL fixed-format and free-format source code.

## Changes

- Add normalizeCobolTrailingTriviaSpans function that walks the result tree in postorder and trims trailing trivia from node end spans to match C parser behavior
- Add cobolBytesAreTrailingTrivia to detect whether a byte range between a node's last child end and the node's own end consists entirely of trailing trivia (whitespace, fixed-format sequence-area columns 1-6, and identification-area tails at column 72+)
- Add cobolLineLooksFixedFormat helper to identify COBOL fixed-format lines by checking the indicator column (column 7) for space/asterisk/dash/slash
- Add cobolTrailingTriviaLeafSpan to trim trailing trivia from leaf statement nodes (e.g., perform_statement_loop, goto_statement) by finding the last non-trivia byte
- Add cobolTrailingTriviaLeafCanTrim predicate targeting nodes whose type ends in _statement or _statement_loop
- Wire normalizeCobolTrailingTriviaSpans into the normalizeCobolCompatibility pipeline
- Add unit tests for trimming perform/continue statement trailing trivia, goto statement trailing trivia, and fixed-format line tail detection
- Add CGO parity regression test (TestCobolCGOTrailingTriviaSpans) comparing Go vs C parser output for perform-forever, evaluate/goto, and fixed-format data description cases

## Testing

- Run unit tests: go test ./grammargen -run 'TestNormalizeCobolTrimsStatementTrailingTriviaSpans|TestNormalizeCobolTrimsGotoTrailingTriviaSpan|TestCobolTrailingTriviaAcceptsFixedFormatLineTails' -count=1
- Run CGO parity test in Docker: bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./cgo_harness -run 'TestCobolCGOTrailingTriviaSpans' -count=1"
- Run COBOL parity suite: bash cgo_harness/docker/run_single_grammar_parity.sh cobol

## Review Focus

Reviewers should focus on the correctness of the cobolBytesAreTrailingTrivia logic — particularly the column tracking across newlines and the fixed-format detection heuristic (column < 6 for sequence area, column >= 72 for identification area). Also verify that the postorder walk correctly handles parent nodes after their children have been trimmed, since parent end-byte trimming depends on the last child's (potentially already trimmed) endByte.