### PR TITLE
cleanup(cgo_harness): remove dead code and gate C-bench helpers

### DIFF
--- a/cgo_harness/benchmark_c_helpers_test.go
+++ b/cgo_harness/benchmark_c_helpers_test.go
@@ -1,0 +1,92 @@
+//go:build cgo && treesitter_c_bench
+
+package cgoharness
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func makeGoBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * 48)
+	sb.WriteString("package main\n\n")
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "func f%d() int { v := %d; return v }\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func benchmarkFuncCount(b *testing.B) int {
+	if raw := strings.TrimSpace(os.Getenv("GOT_BENCH_FUNC_COUNT")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err == nil && n > 0 {
+			return n
+		}
+		b.Fatalf("invalid GOT_BENCH_FUNC_COUNT=%q", raw)
+	}
+	if testing.Short() {
+		return 100
+	}
+	return 500
+}
+
+func makeBenchmarkEditSites(src []byte, marker string) []benchmarkEditSite {
+	needle := []byte(marker)
+	sites := make([]benchmarkEditSite, 0, 64)
+	from := 0
+	for from < len(src) {
+		idx := bytes.Index(src[from:], needle)
+		if idx < 0 {
+			break
+		}
+		offset := from + idx + len(marker)
+		if offset >= len(src) {
+			break
+		}
+		sites = append(sites, benchmarkEditSite{
+			offset: offset,
+			start:  pointAtOffset(src, offset),
+			end:    pointAtOffset(src, offset+1),
+		})
+		from = offset + 1
+	}
+	return sites
+}
+
+func makeGoBenchmarkEditSites(src []byte) []benchmarkEditSite {
+	return makeBenchmarkEditSites(src, "v := ")
+}
+
+func makeTypeScriptBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * len("export function f0(): number { const v = 0; return v }\n"))
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "export function f%d(): number { const v = %d; return v }\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func makePythonBenchmarkSource(funcCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(funcCount * len("def f0():\n    v = 0\n    return v\n\n"))
+	for i := 0; i < funcCount; i++ {
+		fmt.Fprintf(&sb, "def f%d():\n    v = %d\n    return v\n\n", i, i)
+	}
+	return []byte(sb.String())
+}
+
+func toggleDigitAt(src []byte, offset int) {
+	if offset < 0 || offset >= len(src) {
+		return
+	}
+	if src[offset] == '0' {
+		src[offset] = '1'
+		return
+	}
+	src[offset] = '0'
+}

--- a/cgo_harness/benchmark_helpers_test.go
+++ b/cgo_harness/benchmark_helpers_test.go
@@ -1,26 +1,10 @@
 package cgoharness
 
 import (
-	"bytes"
-	"fmt"
-	"os"
-	"strconv"
-	"strings"
-	"testing"
 	"unicode/utf8"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 )
-
-func makeGoBenchmarkSource(funcCount int) []byte {
-	var sb strings.Builder
-	sb.Grow(funcCount * 48)
-	sb.WriteString("package main\n\n")
-	for i := 0; i < funcCount; i++ {
-		fmt.Fprintf(&sb, "func f%d() int { v := %d; return v }\n", i, i)
-	}
-	return []byte(sb.String())
-}
 
 func pointAtOffset(src []byte, offset int) gotreesitter.Point {
 	var row uint32
@@ -38,87 +22,8 @@ func pointAtOffset(src []byte, offset int) gotreesitter.Point {
 	return gotreesitter.Point{Row: row, Column: col}
 }
 
-func benchmarkFuncCount(b *testing.B) int {
-	if raw := strings.TrimSpace(os.Getenv("GOT_BENCH_FUNC_COUNT")); raw != "" {
-		n, err := strconv.Atoi(raw)
-		if err == nil && n > 0 {
-			return n
-		}
-		b.Fatalf("invalid GOT_BENCH_FUNC_COUNT=%q", raw)
-	}
-	if testing.Short() {
-		return 100
-	}
-	return 500
-}
-
 type benchmarkEditSite struct {
 	offset int
 	start  gotreesitter.Point
 	end    gotreesitter.Point
-}
-
-func makeBenchmarkEditSites(src []byte, marker string) []benchmarkEditSite {
-	needle := []byte(marker)
-	sites := make([]benchmarkEditSite, 0, 64)
-	from := 0
-	for from < len(src) {
-		idx := bytes.Index(src[from:], needle)
-		if idx < 0 {
-			break
-		}
-		offset := from + idx + len(marker)
-		if offset >= len(src) {
-			break
-		}
-		sites = append(sites, benchmarkEditSite{
-			offset: offset,
-			start:  pointAtOffset(src, offset),
-			end:    pointAtOffset(src, offset+1),
-		})
-		from = offset + 1
-	}
-	return sites
-}
-
-func makeGoBenchmarkEditSites(src []byte) []benchmarkEditSite {
-	return makeBenchmarkEditSites(src, "v := ")
-}
-
-func makeTypeScriptBenchmarkSource(funcCount int) []byte {
-	var sb strings.Builder
-	sb.Grow(funcCount * len("export function f0(): number { const v = 0; return v }\n"))
-	for i := 0; i < funcCount; i++ {
-		fmt.Fprintf(&sb, "export function f%d(): number { const v = %d; return v }\n", i, i)
-	}
-	return []byte(sb.String())
-}
-
-func makePythonBenchmarkSource(funcCount int) []byte {
-	var sb strings.Builder
-	sb.Grow(funcCount * len("def f0():\n    v = 0\n    return v\n\n"))
-	for i := 0; i < funcCount; i++ {
-		fmt.Fprintf(&sb, "def f%d():\n    v = %d\n    return v\n\n", i, i)
-	}
-	return []byte(sb.String())
-}
-
-func toggleDigitAt(src []byte, offset int) {
-	if offset < 0 || offset >= len(src) {
-		return
-	}
-	if src[offset] == '0' {
-		src[offset] = '1'
-		return
-	}
-	src[offset] = '0'
-}
-
-func prepareEditedBenchmarkSource(cur, scratch []byte, offset int) []byte {
-	if len(scratch) != len(cur) {
-		scratch = make([]byte, len(cur))
-	}
-	copy(scratch, cur)
-	toggleDigitAt(scratch, offset)
-	return scratch
 }

--- a/cgo_harness/benchmark_real_corpus_parity_test.go
+++ b/cgo_harness/benchmark_real_corpus_parity_test.go
@@ -1571,20 +1571,6 @@ func tryParseRealCorpusGoFull(tc realCorpusBenchmarkCase, parser *gotreesitter.P
 	return tree, ""
 }
 
-func parseRealCorpusGoIncremental(tb testing.TB, tc realCorpusBenchmarkCase, parser *gotreesitter.Parser, oldTree *gotreesitter.Tree) *gotreesitter.Tree {
-	tb.Helper()
-	return parseRealCorpusGoIncrementalWithPhase(tb, tc, parser, oldTree, "gotreesitter incremental")
-}
-
-func parseRealCorpusGoIncrementalWithPhase(tb testing.TB, tc realCorpusBenchmarkCase, parser *gotreesitter.Parser, oldTree *gotreesitter.Tree, phase string) *gotreesitter.Tree {
-	tb.Helper()
-	tree, ok := tryParseCompleteRealCorpusGoIncrementalWithPhase(tb, tc, parser, oldTree, phase)
-	if !ok {
-		tb.Fatalf("%s %s/%s incomplete parse", phase, tc.name, filepath.Base(tc.path))
-	}
-	return tree
-}
-
 func tryParseCompleteRealCorpusGoIncrementalWithPhase(tb testing.TB, tc realCorpusBenchmarkCase, parser *gotreesitter.Parser, oldTree *gotreesitter.Tree, phase string) (*gotreesitter.Tree, bool) {
 	tb.Helper()
 	var tree *gotreesitter.Tree
@@ -1679,14 +1665,6 @@ func parseRealCorpusCFull(tb testing.TB, parser *sitter.Parser, source []byte) *
 		tb.Fatalf("C full parse %s", failure)
 	}
 	return tree
-}
-
-func tryParseCompleteRealCorpusCFull(parser *sitter.Parser, source []byte) (*sitter.Tree, bool) {
-	tree := parser.Parse(source, nil)
-	if !isCompleteRealCorpusCTree(tree, source) {
-		return nil, false
-	}
-	return tree, true
 }
 
 func parseRealCorpusCIncremental(tb testing.TB, parser *sitter.Parser, source []byte, oldTree *sitter.Tree) *sitter.Tree {

--- a/cgo_harness/cmd/build_real_corpus/main.go
+++ b/cgo_harness/cmd/build_real_corpus/main.go
@@ -737,10 +737,6 @@ func collectCandidatesWithMatchers(repoDir string, exts, names, paths []string, 
 	return collectCandidatesWithMatchersFromRoot(repoDir, repoDir, exts, names, paths, maxBytes, includeFixtures)
 }
 
-func collectCandidatesWithNamesFromRoot(sourceRoot, walkRoot string, exts, names []string, maxBytes int, includeFixtures bool) ([]corpusFile, error) {
-	return collectCandidatesWithMatchersFromRoot(sourceRoot, walkRoot, exts, names, nil, maxBytes, includeFixtures)
-}
-
 func collectCandidatesWithMatchersFromRoot(sourceRoot, walkRoot string, exts, names, paths []string, maxBytes int, includeFixtures bool) ([]corpusFile, error) {
 	seen := map[string]struct{}{}
 	out := make([]corpusFile, 0, 256)

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -589,7 +589,6 @@ func safeEditOffset(src []byte) int {
 			switch src[i] {
 			case '\n', '}', ';', ')', ']', '>', '<':
 				insertAt = i
-				break
 			}
 			if insertAt >= 0 {
 				break
@@ -600,21 +599,6 @@ func safeEditOffset(src []byte) int {
 		insertAt = len(src)
 	}
 	return insertAt
-}
-
-func insertSpaceAt(src []byte, insertAt int) []byte {
-	if insertAt < 0 {
-		insertAt = 0
-	}
-	if insertAt > len(src) {
-		insertAt = len(src)
-	}
-
-	edited := make([]byte, len(src)+1)
-	copy(edited[:insertAt], src[:insertAt])
-	edited[insertAt] = ' '
-	copy(edited[insertAt+1:], src[insertAt:])
-	return edited
 }
 
 type incrementalEditCandidate struct {


### PR DESCRIPTION
## Summary

This PR cleans up dead code in the cgo_harness package and gates C-benchmark helper functions behind a `treesitter_c_bench` build tag so they only compile when C benchmarks are enabled. Several unused helper functions are removed entirely, and a redundant `break` statement in `safeEditOffset` is cleaned up.

## Changes

- Move C-benchmark-only helpers into `benchmark_c_helpers_test.go` with `//go:build cgo && treesitter_c_bench`.
- Keep shared parity/benchmark edit-position helpers in `benchmark_helpers_test.go`.
- Remove unused real-corpus incremental/C helper wrappers.
- Remove unused `collectCandidatesWithNamesFromRoot` from `cmd/build_real_corpus`.
- Remove unused `insertSpaceAt` and a redundant `break` in `safeEditOffset`.

## Testing

- `git diff --check`
- `(cd cgo_harness && staticcheck -tags 'cgo treesitter_c_parity' -checks=U1000,SA4011,S1023 . ./cmd/build_real_corpus)`\n- `(cd cgo_harness && staticcheck -tags 'cgo treesitter_c_bench' -checks=U1000 .)`\n- `(cd cgo_harness && staticcheck -checks=U1000 ./...)` from the root module\n- `(cd cgo_harness && go test ./cmd/build_real_corpus -run '^$' -count=1)`\n- `bash cgo_harness/docker/run_parity_in_docker.sh --label cleanup-cgo-harness-parity-compile --timeout 20m --no-build --memory 8g --cpus 1 --pids 512 -- "cd /workspace/cgo_harness && go test -tags 'cgo treesitter_c_parity' . -run '^$' -count=1 -timeout 10m"`\n- `bash cgo_harness/docker/run_parity_in_docker.sh --label cleanup-cgo-harness-bench-compile --timeout 20m --no-build --memory 8g --cpus 1 --pids 512 -- "cd /workspace/cgo_harness && go test -tags 'cgo treesitter_c_bench' . -run '^$' -count=1 -timeout 10m"`\n\n## Notes\n\nA full harness-wide `staticcheck ./...` from inside `cgo_harness` is not a valid gate because it descends into corpus fixture directories that intentionally contain invalid or partial Go source samples.