### PR TITLE
fix(cpp-recovery): normalize fused malformed class+method

### DIFF
--- a/cgo_harness/zz_c_tree_dump_test.go
+++ b/cgo_harness/zz_c_tree_dump_test.go
@@ -92,8 +92,17 @@ func TestCTreeDumpDiag(t *testing.T) {
 	if goLang == nil {
 		t.Fatalf("%s: not in grammars.AllLanguages", name)
 	}
-	gp := gts.NewParser(goLang)
-	gt, _ := gp.Parse(src)
+	var gt *gts.Tree
+	if os.Getenv("REPRO_GO_BACKEND") == "registry" {
+		var parseErr error
+		gt, _, parseErr = parseWithGo(parityCase{name: name, source: string(src)}, src, nil)
+		if parseErr != nil {
+			t.Fatalf("go registry parse failed: %v", parseErr)
+		}
+	} else {
+		gp := gts.NewParser(goLang)
+		gt, _ = gp.Parse(src)
+	}
 	if gt == nil || gt.RootNode() == nil {
 		t.Fatalf("go parse failed")
 	}

--- a/parser_result_c.go
+++ b/parser_result_c.go
@@ -24,6 +24,9 @@ func normalizeCCompatibilityWithParser(root *Node, source []byte, p *Parser, lan
 		run("c_top_level_item_wrappers", func() {
 			normalizeCTopLevelItemWrappers(root, lang)
 		})
+		run("cpp_malformed_class_function_definition", func() {
+			normalizeCppMalformedClassFunctionDefinition(root, source, lang)
+		})
 		run("c_preprocessor_directive_shapes", func() {
 			normalizeCPreprocessorDirectiveShapes(root, source, lang)
 		})
@@ -54,6 +57,7 @@ func normalizeCCompatibilityWithParser(root *Node, source []byte, p *Parser, lan
 	normalizeCTranslationUnitRoot(root, lang)
 	normalizeCRecoveredTopLevelChunks(root, source, p, lang)
 	normalizeCTopLevelItemWrappers(root, lang)
+	normalizeCppMalformedClassFunctionDefinition(root, source, lang)
 	normalizeCPreprocessorDirectiveShapes(root, source, lang)
 	normalizeCFusedDeclVariadicWalk(root, source, lang)
 	normalizeCSizeofUnknownTypeIdentifiers(root, source, lang)

--- a/parser_result_cpp.go
+++ b/parser_result_cpp.go
@@ -1,0 +1,220 @@
+package gotreesitter
+
+import "strings"
+
+func normalizeCppMalformedClassFunctionDefinition(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "cpp" || root.Type(lang) != "translation_unit" || len(root.children) < 2 {
+		return
+	}
+	changed := false
+	out := make([]*Node, 0, len(root.children))
+	for i := 0; i < len(root.children); i++ {
+		if i+1 < len(root.children) {
+			if merged, ok := rewriteCppMalformedClassFunctionDefinition(root.children[i], root.children[i+1], source, lang); ok {
+				out = append(out, merged)
+				i++
+				changed = true
+				continue
+			}
+		}
+		out = append(out, root.children[i])
+	}
+	if changed {
+		replaceNodeChildrenUnfielded(root, cloneNodeSliceIfArena(root.ownerArena, out))
+	}
+}
+
+func rewriteCppMalformedClassFunctionDefinition(left, right *Node, source []byte, lang *Language) (*Node, bool) {
+	if left == nil || right == nil || lang == nil || len(source) == 0 || right.ownerArena == nil {
+		return nil, false
+	}
+	arena := right.ownerArena
+	classSpec := cppMalformedClassSpecifierCarrier(left, lang, arena)
+	if classSpec == nil || right.Type(lang) != "function_definition" || len(right.children) != 3 {
+		return nil, false
+	}
+
+	returnType := right.children[0]
+	declarator := right.children[1]
+	body := right.children[2]
+	if returnType == nil || declarator == nil || body == nil ||
+		returnType.Text(source) != "void" ||
+		declarator.Type(lang) != "function_declarator" ||
+		body.Type(lang) != "compound_statement" ||
+		len(declarator.children) != 2 {
+		return nil, false
+	}
+
+	qualified := declarator.children[0]
+	params := declarator.children[1]
+	if qualified == nil || params == nil ||
+		qualified.Type(lang) != "qualified_identifier" ||
+		params.Type(lang) != "parameter_list" ||
+		len(qualified.children) != 3 {
+		return nil, false
+	}
+
+	namespace := qualified.children[0]
+	separator := qualified.children[1]
+	name := qualified.children[2]
+	if namespace == nil || separator == nil || name == nil ||
+		namespace.Type(lang) != "namespace_identifier" ||
+		separator.Type(lang) != "::" ||
+		name.Type(lang) != "identifier" {
+		return nil, false
+	}
+
+	namespaceSym, ok := symbolByName(lang, "namespace_identifier")
+	if !ok {
+		return nil, false
+	}
+	identifierSym, ok := symbolByName(lang, "identifier")
+	if !ok {
+		return nil, false
+	}
+
+	voidNamespace := cppRetaggedClone(arena, returnType, namespaceSym, symbolIsNamed(lang, namespaceSym))
+	identifier := cppRetaggedClone(arena, namespace, identifierSym, symbolIsNamed(lang, identifierSym))
+	err := cppErrorWrapper(arena, identifier)
+
+	rewrittenQualified := cppCloneParentWithChildren(arena, qualified, []*Node{
+		voidNamespace,
+		err,
+		cloneNodeInArena(arena, separator),
+		cloneNodeInArena(arena, name),
+	})
+	rewrittenDeclarator := cppCloneParentWithChildren(arena, declarator, []*Node{
+		rewrittenQualified,
+		cloneNodeInArena(arena, params),
+	})
+	return cppCloneParentWithChildren(arena, right, []*Node{
+		cloneNodeInArena(arena, classSpec),
+		rewrittenDeclarator,
+		cloneNodeInArena(arena, body),
+	}), true
+}
+
+func cppMalformedClassSpecifierCarrier(n *Node, lang *Language, arena *nodeArena) *Node {
+	if n == nil || lang == nil {
+		return nil
+	}
+	switch n.Type(lang) {
+	case "ERROR":
+		if len(n.children) == 1 && n.children[0] != nil && n.children[0].Type(lang) == "class_specifier" {
+			return n.children[0]
+		}
+		return buildCppMalformedClassSpecifierFromError(n, lang, arena)
+	case "_declaration_specifiers":
+		if n.isExtra() && len(n.children) == 1 && n.children[0] != nil && n.children[0].Type(lang) == "class_specifier" {
+			return n.children[0]
+		}
+	}
+	return nil
+}
+
+func buildCppMalformedClassSpecifierFromError(n *Node, lang *Language, arena *nodeArena) *Node {
+	if n == nil || lang == nil || arena == nil || len(n.children) < 5 {
+		return nil
+	}
+
+	classTok := n.children[0]
+	nameCarrier := n.children[1]
+	baseClause := n.children[2]
+	openBrace := n.children[3]
+	closeBrace := n.children[len(n.children)-1]
+	if classTok == nil || nameCarrier == nil || baseClause == nil || openBrace == nil || closeBrace == nil ||
+		classTok.Type(lang) != "class" ||
+		baseClause.Type(lang) != "base_class_clause" ||
+		openBrace.Type(lang) != "{" ||
+		closeBrace.Type(lang) != "}" {
+		return nil
+	}
+
+	name := nameCarrier
+	if nameCarrier.Type(lang) == "_class_name" && len(nameCarrier.children) == 1 && nameCarrier.children[0] != nil {
+		name = nameCarrier.children[0]
+	}
+	if name == nil || name.Type(lang) != "type_identifier" {
+		return nil
+	}
+
+	classSpecSym, ok := symbolByName(lang, "class_specifier")
+	if !ok {
+		return nil
+	}
+	fieldDeclListSym, ok := symbolByName(lang, "field_declaration_list")
+	if !ok {
+		return nil
+	}
+
+	fieldChildren := make([]*Node, 0, len(n.children))
+	fieldChildren = append(fieldChildren, cloneNodeInArena(arena, openBrace))
+	for _, child := range n.children[4 : len(n.children)-1] {
+		if child == nil {
+			continue
+		}
+		if strings.Contains(child.Type(lang), "field_declaration_list") && strings.Contains(child.Type(lang), "repeat") {
+			for _, repeated := range child.children {
+				if repeated != nil {
+					fieldChildren = append(fieldChildren, cloneNodeInArena(arena, repeated))
+				}
+			}
+			continue
+		}
+		fieldChildren = append(fieldChildren, cloneNodeInArena(arena, child))
+	}
+	fieldChildren = append(fieldChildren, cloneNodeInArena(arena, closeBrace))
+
+	fieldDeclList := cppNewParent(arena, fieldDeclListSym, symbolIsNamed(lang, fieldDeclListSym), fieldChildren)
+	return cppNewParent(arena, classSpecSym, symbolIsNamed(lang, classSpecSym), []*Node{
+		cloneNodeInArena(arena, classTok),
+		cloneNodeInArena(arena, name),
+		cloneNodeInArena(arena, baseClause),
+		fieldDeclList,
+	})
+}
+
+func cppRetaggedClone(arena *nodeArena, n *Node, sym Symbol, named bool) *Node {
+	clone := cloneNodeInArena(arena, n)
+	cppRetagLeaf(clone, sym, named)
+	return clone
+}
+
+func cppRetagLeaf(n *Node, sym Symbol, named bool) {
+	if n == nil {
+		return
+	}
+	n.symbol = sym
+	n.setNamed(named)
+	n.children = nil
+	n.fieldIDs = nil
+	n.fieldSources = nil
+	n.setExtra(false)
+	n.setHasError(false)
+}
+
+func cppErrorWrapper(arena *nodeArena, child *Node) *Node {
+	err := newParentNodeInArena(arena, errorSymbol, true, cloneNodeSliceInArena(arena, []*Node{child}), nil, 0)
+	err.setExtra(true)
+	err.setHasError(true)
+	return err
+}
+
+func cppNewParent(arena *nodeArena, sym Symbol, named bool, children []*Node) *Node {
+	n := newParentNodeInArena(arena, sym, named, cloneNodeSliceInArena(arena, children), nil, 0)
+	n.setExtra(false)
+	n.setHasError(false)
+	populateParentNode(n, n.children)
+	return n
+}
+
+func cppCloneParentWithChildren(arena *nodeArena, template *Node, children []*Node) *Node {
+	n := cloneNodeInArena(arena, template)
+	n.children = cloneNodeSliceInArena(arena, children)
+	n.fieldIDs = nil
+	n.fieldSources = nil
+	n.setExtra(false)
+	n.setHasError(false)
+	populateParentNode(n, n.children)
+	return n
+}

--- a/parser_result_cpp_recovery_test.go
+++ b/parser_result_cpp_recovery_test.go
@@ -57,37 +57,60 @@ void A::b() {
 	if !root.HasError() {
 		t.Fatalf("root.HasError = false, want true")
 	}
-	// The C oracle (tree-sitter's cost-based error-recovery competition,
-	// ts_parser__recover) folds the "void" token following the malformed
-	// class body into the *next* declarator's qualified_identifier, fusing
-	// the malformed class and `void A::b() {}` into a single 2-child
-	// function_definition with a nested ERROR around the misplaced "A".
-	// That fold is an artifact of the faithful C recovery-cost port
-	// (parser_recover_c.go / errorCostCompetitionEnabled). cpp is not
-	// gated on it (its external scanner lacks precise ExternalLexStates —
-	// see DiagnoseCRecoveryGate — and, empirically, broadly enabling that
-	// port for cpp regresses oracle agreement on a 300-file LLVM corpus
-	// walk: 160/300 -> 142/299 with 26 new clean->error false positives,
-	// so it is intentionally NOT gated on here). Without that mechanism,
-	// gotreesitter's generic opportunistic top-level resync
-	// (tryResyncErrorRecoveryMode) instead localizes the damage to a single
-	// ERROR node spanning exactly the malformed class body and correctly
-	// keeps `int main() {...}` and `void A::b() {...}` as clean, separate,
-	// well-formed top-level siblings: 3 children, zero content loss, and
-	// (checked above) HasError=true.
-	if got, want := root.ChildCount(), 3; got != want {
+	// The C oracle folds the malformed class and following `void A::b() {}`
+	// into one recovered function_definition. Keep the cpp compatibility
+	// normalizer scoped to this C shape instead of enabling cpp C-recovery
+	// globally; the latter regressed corpus agreement in earlier A/B runs.
+	if got, want := root.ChildCount(), 2; got != want {
 		t.Fatalf("root child count = %d, want %d\n%s", got, want, root.SExpr(lang))
 	}
-	if errNode := root.Child(1); errNode.Type(lang) != "ERROR" {
-		t.Fatalf("root.Child(1) = %q, want ERROR\n%s", errNode.Type(lang), root.SExpr(lang))
-	} else if got, want := errNode.StartByte(), uint32(234); got != want {
-		t.Fatalf("ERROR node start = %d, want %d (start of malformed class body)", got, want)
-	} else if got, want := errNode.EndByte(), uint32(310); got != want {
-		t.Fatalf("ERROR node end = %d, want %d (end of malformed class body)", got, want)
+	recovered := root.Child(1)
+	if got, want := recovered.Type(lang), "function_definition"; got != want {
+		t.Fatalf("root.Child(1) = %q, want %q\n%s", got, want, root.SExpr(lang))
 	}
-	if got, want := root.Child(2).Type(lang), "function_definition"; got != want {
-		t.Fatalf("root.Child(2) = %q, want %q (clean void A::b() {...})\n%s", got, want, root.SExpr(lang))
-	} else if root.Child(2).HasError() {
-		t.Fatalf("root.Child(2) (void A::b() {...}) unexpectedly has an error\n%s", root.SExpr(lang))
+	if !recovered.HasError() {
+		t.Fatalf("recovered function_definition HasError = false, want true\n%s", recovered.SExpr(lang))
+	}
+	if got, want := recovered.StartByte(), uint32(234); got != want {
+		t.Fatalf("recovered function start = %d, want %d", got, want)
+	}
+	if got, want := recovered.EndByte(), uint32(346); got != want {
+		t.Fatalf("recovered function end = %d, want %d", got, want)
+	}
+	if got, want := recovered.ChildCount(), 3; got != want {
+		t.Fatalf("recovered child count = %d, want %d\n%s", got, want, recovered.SExpr(lang))
+	}
+	if got, want := recovered.Child(0).Type(lang), "class_specifier"; got != want {
+		t.Fatalf("recovered child[0] = %q, want %q\n%s", got, want, recovered.SExpr(lang))
+	}
+	declarator := recovered.Child(1)
+	if got, want := declarator.Type(lang), "function_declarator"; got != want {
+		t.Fatalf("recovered child[1] = %q, want %q\n%s", got, want, recovered.SExpr(lang))
+	}
+	qualified := declarator.Child(0)
+	if got, want := qualified.Type(lang), "qualified_identifier"; got != want {
+		t.Fatalf("declarator child[0] = %q, want %q\n%s", got, want, declarator.SExpr(lang))
+	}
+	if got, want := qualified.ChildCount(), 4; got != want {
+		t.Fatalf("qualified_identifier child count = %d, want %d\n%s", got, want, qualified.SExpr(lang))
+	}
+	if got, want := qualified.Child(0).Type(lang), "namespace_identifier"; got != want {
+		t.Fatalf("qualified child[0] = %q, want %q\n%s", got, want, qualified.SExpr(lang))
+	}
+	if got, want := qualified.Child(0).Text(src), "void"; got != want {
+		t.Fatalf("qualified child[0] text = %q, want %q", got, want)
+	}
+	errNode := qualified.Child(1)
+	if got, want := errNode.Type(lang), "ERROR"; got != want {
+		t.Fatalf("qualified child[1] = %q, want %q\n%s", got, want, qualified.SExpr(lang))
+	}
+	if !errNode.HasError() || !errNode.IsExtra() {
+		t.Fatalf("qualified ERROR flags extra=%v hasError=%v, want both true\n%s", errNode.IsExtra(), errNode.HasError(), qualified.SExpr(lang))
+	}
+	if got, want := errNode.Child(0).Type(lang), "identifier"; got != want {
+		t.Fatalf("qualified ERROR child = %q, want %q\n%s", got, want, errNode.SExpr(lang))
+	}
+	if got, want := errNode.Child(0).Text(src), "A"; got != want {
+		t.Fatalf("qualified ERROR child text = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

This PR closes the focused Wave 5 C++ malformed-class recovery parity case without enabling cpp C-recovery globally. The Go parser already preserves the source content, but the C oracle folds a malformed class body plus the following `void A::b() {}` into one recovered `function_definition`. This adds a narrow cpp result-compatibility normalizer for that exact shape.

## Changes

- Add `normalizeCppMalformedClassFunctionDefinition` in `parser_result_cpp.go` and call it from the existing C/C++ compatibility pipeline.
- Reconstruct the C-compatible recovered shape: `class_specifier`, rewritten `function_declarator`, `void` retagged as `namespace_identifier`, and the original namespace `A` wrapped in an extra `ERROR(identifier)`.
- Keep the rewrite guarded by cpp language, translation-unit sibling shape, concrete node types, child counts, and `void` source text.
- Update the pure-Go C++ recovery regression to assert the C-compatible 2-child root and recovered qualified identifier shape.
- Add `REPRO_GO_BACKEND=registry` to the C tree-dump diagnostic so the registry parser path can reproduce token-source trees.

## Testing

- `git diff --check HEAD~1..HEAD`
- `staticcheck ./...`
- `go test . -run '^(TestCppMalformedClassFunctionDefinitionRecovery|TestNormalizeCppCompatibilityRestoresCollapsedKeywordChildren)$' -count=1`
- `go test ./grammars -run '^TestCppUserTypeTemplateArgumentInParameterListParsesWithoutError$' -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh --label wave5-cpp-focused-cgo-clean-refactor --timeout 20m --no-build --memory 8g --cpus 1 --pids 512 -- "cd /workspace/cgo_harness && go test -tags 'cgo treesitter_c_parity' . -run '^TestCpp(TemplateTypeParameterParity|CollapsedKeywordCompatibilityParity|MalformedClassFunctionDefinitionRecoveryParity)$' -count=1 -timeout 10m -v"`

Docker artifact: `harness_out/docker/20260708T113321Z-wave5-cpp-focused-cgo-clean-refactor`, exit_code=0, oom_killed=false.

## Notes

This intentionally does not claim full cpp corpus parity. The broader single-grammar cpp sweep still reports known corpus mismatches outside this focused recovery fold.

## Review Focus

Please check the rewrite guards, arena-clone helper usage, and the retag/error-wrapper shape against the C-oracle tree for this malformed-class case.