### PR TITLE
improve(cgo_harness): harden ParseCtx helpers + gate builds

### DIFF
--- a/cgo_harness/benchmark_c_baseline_test.go
+++ b/cgo_harness/benchmark_c_baseline_test.go
@@ -4,7 +4,6 @@ package cgoharness
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -31,15 +30,6 @@ func requireCompleteCTree(tb testing.TB, tree *sitter.Tree, src []byte, phase st
 		tb.Fatalf("%s parse truncated: root.EndByte=%d want=%d type=%q hasError=%v", phase, got, want, root.Type(), root.HasError())
 	}
 	return root
-}
-
-func parseCTree(tb testing.TB, parser *sitter.Parser, oldTree *sitter.Tree, src []byte, phase string) *sitter.Tree {
-	tb.Helper()
-	tree, err := parser.ParseCtx(context.Background(), oldTree, src)
-	if err != nil {
-		tb.Fatalf("%s parse error: %v", phase, err)
-	}
-	return tree
 }
 
 func newCTreeSitterParser(tb testing.TB) *sitter.Parser {

--- a/cgo_harness/benchmark_c_baseline_test.go
+++ b/cgo_harness/benchmark_c_baseline_test.go
@@ -4,6 +4,7 @@ package cgoharness
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -19,10 +20,12 @@ func requireCompleteCTree(tb testing.TB, tree *sitter.Tree, src []byte, phase st
 	tb.Helper()
 	if tree == nil {
 		tb.Fatalf("%s parse returned nil tree", phase)
+		return nil
 	}
 	root := tree.RootNode()
 	if root == nil {
 		tb.Fatalf("%s parse returned nil root", phase)
+		return nil
 	}
 	if got, want := uint32(root.EndByte()), uint32(len(src)); got != want {
 		tb.Fatalf("%s parse truncated: root.EndByte=%d want=%d type=%q hasError=%v", phase, got, want, root.Type(), root.HasError())
@@ -30,9 +33,22 @@ func requireCompleteCTree(tb testing.TB, tree *sitter.Tree, src []byte, phase st
 	return root
 }
 
+func parseCTree(tb testing.TB, parser *sitter.Parser, oldTree *sitter.Tree, src []byte, phase string) *sitter.Tree {
+	tb.Helper()
+	tree, err := parser.ParseCtx(context.Background(), oldTree, src)
+	if err != nil {
+		tb.Fatalf("%s parse error: %v", phase, err)
+	}
+	return tree
+}
+
 func newCTreeSitterParser(tb testing.TB) *sitter.Parser {
 	tb.Helper()
 	parser := sitter.NewParser()
+	if parser == nil {
+		tb.Fatal("sitter.NewParser returned nil")
+		return nil
+	}
 	parser.SetLanguage(sittergo.GetLanguage())
 	return parser
 }
@@ -50,7 +66,7 @@ func BenchmarkCTreeSitterGoParseFull(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		tree := parser.Parse(nil, src)
+		tree := parseCTree(b, parser, nil, src, "c full")
 		requireCompleteCTree(b, tree, src, "c full")
 		tree.Close()
 	}
@@ -70,7 +86,7 @@ func BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit(b *testing.B) {
 	start := cTreeSitterPointAtOffset(src, editAt)
 	end := cTreeSitterPointAtOffset(src, editAt+1)
 
-	tree := parser.Parse(nil, src)
+	tree := parseCTree(b, parser, nil, src, "initial")
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
@@ -97,7 +113,7 @@ func BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit(b *testing.B) {
 		}
 
 		tree.Edit(edit)
-		newTree := parser.Parse(tree, src)
+		newTree := parseCTree(b, parser, tree, src, "incremental")
 		if newTree == nil || newTree.RootNode() == nil {
 			b.Fatal("incremental parse returned nil root")
 		}
@@ -111,7 +127,7 @@ func BenchmarkCTreeSitterGoParseIncrementalNoEdit(b *testing.B) {
 	defer parser.Close()
 
 	src := makeGoBenchmarkSource(benchmarkFuncCount(b))
-	tree := parser.Parse(nil, src)
+	tree := parseCTree(b, parser, nil, src, "initial")
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
@@ -122,7 +138,7 @@ func BenchmarkCTreeSitterGoParseIncrementalNoEdit(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		newTree := parser.Parse(tree, src)
+		newTree := parseCTree(b, parser, tree, src, "incremental")
 		if newTree == nil || newTree.RootNode() == nil {
 			b.Fatal("incremental parse returned nil root")
 		}
@@ -141,7 +157,7 @@ func BenchmarkCTreeSitterGoParseIncrementalRandomSingleByteEdit(b *testing.B) {
 		b.Fatal("could not find random edit sites")
 	}
 
-	tree := parser.Parse(nil, src)
+	tree := parseCTree(b, parser, nil, src, "initial")
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
@@ -167,7 +183,7 @@ func BenchmarkCTreeSitterGoParseIncrementalRandomSingleByteEdit(b *testing.B) {
 		}
 
 		tree.Edit(edit)
-		newTree := parser.Parse(tree, src)
+		newTree := parseCTree(b, parser, tree, src, "incremental")
 		if newTree == nil || newTree.RootNode() == nil {
 			b.Fatal("incremental parse returned nil root")
 		}

--- a/cgo_harness/benchmark_c_big3_baseline_test.go
+++ b/cgo_harness/benchmark_c_big3_baseline_test.go
@@ -19,6 +19,10 @@ type cTreeSitterBenchmarkSpec struct {
 func newCTreeSitterParserWithLanguage(tb testing.TB, language func() *sitter.Language) *sitter.Parser {
 	tb.Helper()
 	parser := sitter.NewParser()
+	if parser == nil {
+		tb.Fatal("sitter.NewParser returned nil")
+		return nil
+	}
 	parser.SetLanguage(language())
 	return parser
 }
@@ -34,7 +38,7 @@ func benchmarkCTreeSitterParseFull(b *testing.B, spec cTreeSitterBenchmarkSpec) 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		tree := parser.Parse(nil, src)
+		tree := parseCTree(b, parser, nil, src, "c full")
 		requireCompleteCTree(b, tree, src, "c full")
 		tree.Close()
 	}
@@ -51,7 +55,7 @@ func benchmarkCTreeSitterParseIncrementalSingleByteEdit(b *testing.B, spec cTree
 	}
 	site := sites[0]
 
-	tree := parser.Parse(nil, src)
+	tree := parseCTree(b, parser, nil, src, "initial")
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
@@ -73,7 +77,7 @@ func benchmarkCTreeSitterParseIncrementalSingleByteEdit(b *testing.B, spec cTree
 	for i := 0; i < b.N; i++ {
 		toggleDigitAt(src, site.offset)
 		tree.Edit(edit)
-		newTree := parser.Parse(tree, src)
+		newTree := parseCTree(b, parser, tree, src, "incremental")
 		if newTree == nil || newTree.RootNode() == nil {
 			b.Fatal("incremental parse returned nil root")
 		}
@@ -87,7 +91,7 @@ func benchmarkCTreeSitterParseIncrementalNoEdit(b *testing.B, spec cTreeSitterBe
 	defer parser.Close()
 
 	src := spec.source(benchmarkFuncCount(b))
-	tree := parser.Parse(nil, src)
+	tree := parseCTree(b, parser, nil, src, "initial")
 	if tree == nil || tree.RootNode() == nil {
 		b.Fatal("initial parse returned nil root")
 	}
@@ -98,7 +102,7 @@ func benchmarkCTreeSitterParseIncrementalNoEdit(b *testing.B, spec cTreeSitterBe
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		newTree := parser.Parse(tree, src)
+		newTree := parseCTree(b, parser, tree, src, "incremental")
 		if newTree == nil || newTree.RootNode() == nil {
 			b.Fatal("incremental parse returned nil root")
 		}

--- a/cgo_harness/benchmark_c_helpers_test.go
+++ b/cgo_harness/benchmark_c_helpers_test.go
@@ -4,11 +4,14 @@ package cgoharness
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
 )
 
 func makeGoBenchmarkSource(funcCount int) []byte {
@@ -33,6 +36,15 @@ func benchmarkFuncCount(b *testing.B) int {
 		return 100
 	}
 	return 500
+}
+
+func parseCTree(tb testing.TB, parser *sitter.Parser, oldTree *sitter.Tree, src []byte, phase string) *sitter.Tree {
+	tb.Helper()
+	tree, err := parser.ParseCtx(context.Background(), oldTree, src)
+	if err != nil {
+		tb.Fatalf("%s parse error: %v", phase, err)
+	}
+	return tree
 }
 
 func makeBenchmarkEditSites(src []byte, marker string) []benchmarkEditSite {

--- a/cgo_harness/benchmark_helpers_test.go
+++ b/cgo_harness/benchmark_helpers_test.go
@@ -1,3 +1,5 @@
+//go:build cgo && (treesitter_c_parity || treesitter_c_bench)
+
 package cgoharness
 
 import (

--- a/cgo_harness/benchmark_java_corpus_test.go
+++ b/cgo_harness/benchmark_java_corpus_test.go
@@ -1491,7 +1491,7 @@ func BenchmarkJavaCorpusCTreeSitterParseFull(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for _, file := range files {
-			tree := parser.Parse(nil, file.source)
+			tree := parseCTree(b, parser, nil, file.source, file.path)
 			root := requireCompleteCTree(b, tree, file.source, file.path)
 			if root.HasError() {
 				tree.Close()

--- a/cgo_harness/benchmark_python_corpus_test.go
+++ b/cgo_harness/benchmark_python_corpus_test.go
@@ -1166,7 +1166,7 @@ func BenchmarkPythonCorpusCTreeSitterParseFull(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		tree := parser.Parse(nil, file.source)
+		tree := parseCTree(b, parser, nil, file.source, file.path)
 		root := requireCompleteCTree(b, tree, file.source, file.path)
 		if root.HasError() {
 			tree.Close()

--- a/cgo_harness/cmd/build_real_corpus/main.go
+++ b/cgo_harness/cmd/build_real_corpus/main.go
@@ -530,9 +530,7 @@ func loadLanguageListFile(path string) ([]string, error) {
 		if idx := strings.IndexByte(line, '#'); idx >= 0 {
 			line = strings.TrimSpace(line[:idx])
 		}
-		for _, field := range strings.Fields(line) {
-			out = append(out, field)
-		}
+		out = append(out, strings.Fields(line)...)
 	}
 	out = dedupe(out)
 	if len(out) == 0 {

--- a/cgo_harness/cmd/import_replay/main.go
+++ b/cgo_harness/cmd/import_replay/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -465,7 +466,10 @@ func parseWithCGo(file replayFile) error {
 		return err
 	}
 	defer parser.Close()
-	tree := parser.Parse(nil, file.Source)
+	tree, err := parser.ParseCtx(context.Background(), nil, file.Source)
+	if err != nil {
+		return fmt.Errorf("cgo parse error: %w", err)
+	}
 	if tree == nil {
 		return fmt.Errorf("cgo parse returned nil tree")
 	}
@@ -484,8 +488,11 @@ func parseAndExtractWithCGo(file replayFile) cgoExtractResult {
 	}
 	defer parser.Close()
 	parseStart := time.Now()
-	tree := parser.Parse(nil, file.Source)
+	tree, err := parser.ParseCtx(context.Background(), nil, file.Source)
 	parseNanos := time.Since(parseStart).Nanoseconds()
+	if err != nil {
+		return cgoExtractResult{parseNanos: parseNanos, err: fmt.Errorf("cgo parse error: %w", err)}
+	}
 	if tree == nil {
 		return cgoExtractResult{parseNanos: parseNanos, err: fmt.Errorf("cgo parse returned nil tree")}
 	}

--- a/cgo_harness/parity_highlight_test.go
+++ b/cgo_harness/parity_highlight_test.go
@@ -623,27 +623,22 @@ func textSlice(src []byte, c highlightCapture) string {
 
 // diffCaptures returns captures only in Go and only in C.
 func diffCaptures(goCaps, cCaps []highlightCapture) (onlyGo, onlyC []highlightCapture) {
-	type capKey struct {
-		Name      string
-		StartByte uint32
-		EndByte   uint32
-	}
-	goSet := make(map[capKey]bool, len(goCaps))
+	goSet := make(map[highlightCapture]struct{}, len(goCaps))
 	for _, c := range goCaps {
-		goSet[capKey{c.Name, c.StartByte, c.EndByte}] = true
+		goSet[c] = struct{}{}
 	}
-	cSet := make(map[capKey]bool, len(cCaps))
+	cSet := make(map[highlightCapture]struct{}, len(cCaps))
 	for _, c := range cCaps {
-		cSet[capKey{c.Name, c.StartByte, c.EndByte}] = true
+		cSet[c] = struct{}{}
 	}
 
 	for _, c := range goCaps {
-		if !cSet[capKey{c.Name, c.StartByte, c.EndByte}] {
+		if _, ok := cSet[c]; !ok {
 			onlyGo = append(onlyGo, c)
 		}
 	}
 	for _, c := range cCaps {
-		if !goSet[capKey{c.Name, c.StartByte, c.EndByte}] {
+		if _, ok := goSet[c]; !ok {
 			onlyC = append(onlyC, c)
 		}
 	}

--- a/cgo_harness/parity_highlight_test.go
+++ b/cgo_harness/parity_highlight_test.go
@@ -623,22 +623,35 @@ func textSlice(src []byte, c highlightCapture) string {
 
 // diffCaptures returns captures only in Go and only in C.
 func diffCaptures(goCaps, cCaps []highlightCapture) (onlyGo, onlyC []highlightCapture) {
-	goSet := make(map[highlightCapture]struct{}, len(goCaps))
-	for _, c := range goCaps {
-		goSet[c] = struct{}{}
+	type captureKey struct {
+		name      string
+		startByte uint32
+		endByte   uint32
 	}
-	cSet := make(map[highlightCapture]struct{}, len(cCaps))
+	key := func(c highlightCapture) captureKey {
+		return captureKey{
+			name:      c.Name,
+			startByte: c.StartByte,
+			endByte:   c.EndByte,
+		}
+	}
+
+	goSet := make(map[captureKey]struct{}, len(goCaps))
+	for _, c := range goCaps {
+		goSet[key(c)] = struct{}{}
+	}
+	cSet := make(map[captureKey]struct{}, len(cCaps))
 	for _, c := range cCaps {
-		cSet[c] = struct{}{}
+		cSet[key(c)] = struct{}{}
 	}
 
 	for _, c := range goCaps {
-		if _, ok := cSet[c]; !ok {
+		if _, ok := cSet[key(c)]; !ok {
 			onlyGo = append(onlyGo, c)
 		}
 	}
 	for _, c := range cCaps {
-		if _, ok := goSet[c]; !ok {
+		if _, ok := goSet[key(c)]; !ok {
 			onlyC = append(onlyC, c)
 		}
 	}


### PR DESCRIPTION
## Summary

Hardens cgo harness benchmark/parity helper hygiene and removes staticcheck debt found in the harness root, cgo tag surfaces, and harness commands. The behavioral intent is unchanged: cgo benchmarks and replay tooling still parse the same inputs, but now propagate explicit ParseCtx errors instead of collapsing failures into nil-tree/truncation diagnostics.

## Changes

- Gate shared benchmark edit helpers behind `cgo && (treesitter_c_parity || treesitter_c_bench)` so default harness builds do not include cgo-only helper code.
- Switch smacker C parser benchmark/replay calls from deprecated `Parse` to `ParseCtx` and report parse errors directly.
- Add a shared `parseCTree` helper for C benchmark parses and defensive nil checks around parser/tree/root creation.
- Simplify `build_real_corpus` language-list parsing with direct `strings.Fields` append.
- Keep highlight parity capture diffing keyed explicitly by capture name plus byte span while using map-set membership.

## Verification

- `git diff --check`
- `staticcheck ./cmd/...` from repo root
- `staticcheck . ./grammargen ./grammargen/grammarjs ./grammars ./grep ./parser_result_test ./taproot ./taproot/diag ./taproot/walk` from repo root
- `go test ./cmd/... -run '^$' -count=1` from repo root
- `go test -c -run '^$'` from `cgo_harness/`
- `staticcheck .` from `cgo_harness/`
- `staticcheck -tags treesitter_c_parity .` from `cgo_harness/`
- `staticcheck -tags treesitter_c_bench .` from `cgo_harness/`
- `GTS_PARITY_ALLOW_HOST=1 go test -tags treesitter_c_parity -run '^$' -count=1` from `cgo_harness/` (no-test typecheck only; full cgo parity remains Docker-only)
- `go test -tags treesitter_c_bench -run '^$' -count=1` from `cgo_harness/`
- `go test ./cmd/... -run '^$' -count=1` from `cgo_harness/`
- Canopy review against `main`: changed_files=9, blast_radius=44
- Buckley diff review pass found capture-key and helper-placement risks; both were addressed in follow-up commit `7716747d`.

## Review Focus

Confirm this remains harness hygiene only: build-tag behavior for shared cgo helpers, ParseCtx error propagation in benchmark/replay code, and no parser/runtime behavior changes.
