### PR TITLE
fix(cobol-recovery): absorb zero-width tokens; extend root recovery

### DIFF
--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3177,9 +3177,11 @@ func (p *Parser) cRecoverDispatchInError(stacks *[]glrStack, si int, source []by
 			}
 		}
 		// Zero-width non-EOF tokens are skipped (C's error-mode lexer never
-		// returns empty internal tokens; the Go DFA source can).
+		// returns empty internal tokens; the Go DFA source can). Record them
+		// in the open ERROR when possible; the token source owns cursor
+		// progress for true zero-width tokens.
 		if tok.StartByte == tok.EndByte {
-			if s.byteOffset < tok.EndByte && s.cRec != nil && s.cRec.openErr != nil && arena != nil {
+			if s.cRec != nil && s.cRec.openErr != nil && arena != nil {
 				p.cAbsorbTokenIntoError(s, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			} else if s.byteOffset < tok.EndByte {
 				s.byteOffset = tok.EndByte

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3179,6 +3179,11 @@ func (p *Parser) cRecoverDispatchInError(stacks *[]glrStack, si int, source []by
 		// Zero-width non-EOF tokens are skipped (C's error-mode lexer never
 		// returns empty internal tokens; the Go DFA source can).
 		if tok.StartByte == tok.EndByte {
+			if s.byteOffset < tok.EndByte && s.cRec != nil && s.cRec.openErr != nil && arena != nil {
+				p.cAbsorbTokenIntoError(s, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			} else if s.byteOffset < tok.EndByte {
+				s.byteOffset = tok.EndByte
+			}
 			s.shifted = true
 			return cRecConsumed, false
 		}

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -97,6 +97,55 @@ func TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken(t *testing.T) {
 	}
 }
 
+func TestCRecoverDispatchInErrorAbsorbsZeroWidthSkippedTokenAtCurrentOffset(t *testing.T) {
+	parser := cRecoveryElectionTestParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+
+	group := &cRecGroup{}
+	openErr := newParentNodeInArena(arena, errorSymbol, true, nil, nil, 0)
+	cSetNodeSpan(openErr, 18, 18, Point{Column: 18}, Point{Column: 18})
+	openErr.setHasError(true)
+	openErr.parseState = cErrorState
+	stack := newGLRStack(1)
+	stack.pushEntry(newStackEntryNode(cErrorState, openErr), nil, nil)
+	stack.byteOffset = 18
+	stack.cRec = &cRecoverState{group: group, openErr: openErr}
+	stacks := []glrStack{stack}
+	nodeCount := 0
+
+	outcome, forked := parser.cRecoverDispatchInError(
+		&stacks,
+		0,
+		[]byte("012345678901234567890"),
+		Token{Symbol: 2, StartByte: 18, EndByte: 18, StartPoint: Point{Column: 18}, EndPoint: Point{Column: 18}},
+		&nodeCount,
+		arena,
+		nil,
+		nil,
+		nil,
+	)
+
+	if outcome != cRecConsumed || forked {
+		t.Fatalf("outcome/forked = %v/%t, want %v/false", outcome, forked, cRecConsumed)
+	}
+	if !stacks[0].shifted {
+		t.Fatal("zero-width skipped token did not mark stack shifted")
+	}
+	if got, want := stacks[0].byteOffset, uint32(18); got != want {
+		t.Fatalf("stack byteOffset = %d, want %d", got, want)
+	}
+	if got, want := openErr.ChildCount(), 1; got != want {
+		t.Fatalf("open error ChildCount = %d, want %d", got, want)
+	}
+	if got, want := openErr.Child(0).StartByte(), uint32(18); got != want {
+		t.Fatalf("zero-width child StartByte = %d, want %d", got, want)
+	}
+	if nodeCount == 0 {
+		t.Fatal("zero-width skipped token did not update recovery node count")
+	}
+}
+
 func TestCRecoverSkipTailBetterVersionUsesErrorStatus(t *testing.T) {
 	parser := cRecoveryElectionTestParser()
 	arena := acquireNodeArena(arenaClassFull)

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -51,6 +51,52 @@ func TestCRecoveryCostCompetitionDisabledInNoTreeModes(t *testing.T) {
 	}
 }
 
+func TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken(t *testing.T) {
+	parser := cRecoveryElectionTestParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+
+	group := &cRecGroup{}
+	openErr := newParentNodeInArena(arena, errorSymbol, true, nil, nil, 0)
+	cSetNodeSpan(openErr, 10, 10, Point{Column: 10}, Point{Column: 10})
+	openErr.setHasError(true)
+	openErr.parseState = cErrorState
+	stack := newGLRStack(1)
+	stack.pushEntry(newStackEntryNode(cErrorState, openErr), nil, nil)
+	stack.byteOffset = 10
+	stack.cRec = &cRecoverState{group: group, openErr: openErr}
+	stacks := []glrStack{stack}
+	nodeCount := 0
+
+	outcome, forked := parser.cRecoverDispatchInError(
+		&stacks,
+		0,
+		[]byte("012345678901234567890"),
+		Token{Symbol: 2, StartByte: 18, EndByte: 18, StartPoint: Point{Column: 18}, EndPoint: Point{Column: 18}},
+		&nodeCount,
+		arena,
+		nil,
+		nil,
+		nil,
+	)
+
+	if outcome != cRecConsumed || forked {
+		t.Fatalf("outcome/forked = %v/%t, want %v/false", outcome, forked, cRecConsumed)
+	}
+	if !stacks[0].shifted {
+		t.Fatal("zero-width skipped token did not mark stack shifted")
+	}
+	if got, want := stacks[0].byteOffset, uint32(18); got != want {
+		t.Fatalf("stack byteOffset = %d, want %d", got, want)
+	}
+	if got, want := openErr.EndByte(), uint32(18); got != want {
+		t.Fatalf("open error end = %d, want %d", got, want)
+	}
+	if nodeCount == 0 {
+		t.Fatal("zero-width skipped token did not update recovery node count")
+	}
+}
+
 func TestCRecoverSkipTailBetterVersionUsesErrorStatus(t *testing.T) {
 	parser := cRecoveryElectionTestParser()
 	arena := acquireNodeArena(arenaClassFull)
@@ -217,6 +263,7 @@ func TestCAppendVisibleSpliceRecoveryPreservesExtraErrorCarrier(t *testing.T) {
 		t.Fatal("reduced ERROR carrier hasError was cleared")
 	}
 }
+
 // TestCRecoverStrategy1ElectionDedupesDuplicateEntryAcrossMembers pins the C
 // semantics of the merged-version summary: ts_stack_record_summary dedupes
 // (depth, state) pairs across the merged paths at RECORD time, and

--- a/parser_result_c_go_cobol_test.go
+++ b/parser_result_c_go_cobol_test.go
@@ -702,7 +702,8 @@ func TestNormalizeCobolProcedureRootRecoveryHoistsComments(t *testing.T) {
 	root.startPoint = proc.startPoint
 	root.endByte = err.endByte
 	root.endPoint = err.endPoint
-	root.setHasError(true)
+	// Real recovered COBOL roots can be under-marked even when an adjacent
+	// ERROR child is present; the recovery must key off the child shape.
 
 	normalizeResultCompatibility(root, source, &Parser{language: lang})
 
@@ -1016,6 +1017,813 @@ func TestNormalizeCobolZLiteralDataRootRecovery(t *testing.T) {
 	}
 	if got, want := tail.Child(5).StartByte(), end("PROCEDURE DIVISION."); got != want {
 		t.Fatalf("tail child 5 StartByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolRootProgramDefinitionStopsBeforeCopySibling(t *testing.T) {
+	lang := &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			"start",
+			"program_definition",
+			"identification_division",
+			"data_division",
+			"working_storage_section",
+			"data_description",
+			"copy_statement",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+			{Name: "data_division", Visible: true, Named: true},
+			{Name: "working_storage_section", Visible: true, Named: true},
+			{Name: "data_description", Visible: true, Named: true},
+			{Name: "copy_statement", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. SAMPLE.\n" +
+		"       DATA DIVISION.\n" +
+		"       WORKING-STORAGE SECTION.\n" +
+		"       01  WS-COMMAREA PIC X.\n" +
+		"       COPY CENTRY.\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	id := cobolTestLeaf(arena, 3, true, source, idx("IDENTIFICATION"), end("PROGRAM-ID. SAMPLE."))
+	desc := cobolTestLeaf(arena, 6, true, source, idx("01  WS-COMMAREA"), end("01  WS-COMMAREA PIC X."))
+	working := newParentNodeInArena(arena, 5, true, []*Node{desc}, nil, 0)
+	working.startByte = idx("WORKING-STORAGE SECTION.")
+	working.startPoint = advancePointByBytes(Point{}, source[:working.startByte])
+	working.endByte = uint32(len(source))
+	working.endPoint = advancePointByBytes(Point{}, source)
+	data := newParentNodeInArena(arena, 4, true, []*Node{working}, nil, 0)
+	data.startByte = idx("DATA DIVISION.")
+	data.startPoint = advancePointByBytes(Point{}, source[:data.startByte])
+	data.endByte = uint32(len(source))
+	data.endPoint = advancePointByBytes(Point{}, source)
+	program := newParentNodeInArena(arena, 2, true, []*Node{id, data}, nil, 0)
+	program.startByte = id.startByte
+	program.startPoint = id.startPoint
+	program.endByte = uint32(len(source))
+	program.endPoint = advancePointByBytes(Point{}, source)
+	copyStart := idx("COPY CENTRY.")
+	copyStmt := cobolTestLeaf(arena, 7, true, source, copyStart, end("COPY CENTRY."))
+	copyStmt.setExtra(true)
+	root := newParentNodeInArena(arena, 1, true, []*Node{program, copyStmt}, nil, 0)
+	root.startByte = program.startByte
+	root.startPoint = program.startPoint
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+	root.setHasError(true)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	clampedEnd := end("01  WS-COMMAREA PIC X.")
+	if got, want := program.EndByte(), clampedEnd; got != want {
+		t.Fatalf("program.EndByte = %d, want %d", got, want)
+	}
+	if got, want := data.EndByte(), clampedEnd; got != want {
+		t.Fatalf("data_division.EndByte = %d, want %d", got, want)
+	}
+	if got, want := working.EndByte(), clampedEnd; got != want {
+		t.Fatalf("working_storage_section.EndByte = %d, want %d", got, want)
+	}
+	if got, want := root.Child(1).StartByte(), copyStart; got != want {
+		t.Fatalf("copy_statement.StartByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolRootProcedurePrefixErrorMovesCleanPrefix(t *testing.T) {
+	lang := &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"start",
+			"program_definition",
+			"identification_division",
+			"procedure_division",
+			"comment",
+			"move_statement",
+			"SPACE",
+			"qualified_word",
+			"copy_statement",
+			"if_header",
+			"comment_entry",
+			"expr",
+			"is_class",
+			"WORD",
+			"AND",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "comment", Visible: true, Named: true},
+			{Name: "move_statement", Visible: true, Named: true},
+			{Name: "SPACE", Visible: true, Named: true},
+			{Name: "qualified_word", Visible: true, Named: true},
+			{Name: "copy_statement", Visible: true, Named: true},
+			{Name: "if_header", Visible: true, Named: true},
+			{Name: "comment_entry", Visible: true, Named: true},
+			{Name: "expr", Visible: true, Named: true},
+			{Name: "is_class", Visible: true, Named: true},
+			{Name: "WORD", Visible: true, Named: true},
+			{Name: "AND", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. A.\n" +
+		"       PROCEDURE DIVISION.\n" +
+		"      * Procedure comment\n" +
+		"           MOVE SPACES TO ABEND-REASON\n" +
+		"           COPY CABENDPO.\n" +
+		"           IF BANK-MAP-FUNCTION-GET\n" +
+		"              EXEC CICS LINK PROGRAM(X)\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	id := cobolTestLeaf(arena, 4, true, source, idx("IDENTIFICATION"), end("PROGRAM-ID. A."))
+	dot := cobolTestLeaf(arena, 1, false, source, end("PROCEDURE DIVISION"), end("PROCEDURE DIVISION."))
+	proc := newParentNodeInArena(arena, 5, true, []*Node{dot}, nil, 0)
+	proc.startByte = idx("PROCEDURE DIVISION.")
+	proc.startPoint = advancePointByBytes(Point{}, source[:proc.startByte])
+	proc.endByte = dot.endByte
+	proc.endPoint = dot.endPoint
+	def := newParentNodeInArena(arena, 3, true, []*Node{id, proc}, nil, 0)
+	def.startByte = id.startByte
+	def.startPoint = id.startPoint
+	def.endByte = proc.endByte
+	def.endPoint = proc.endPoint
+
+	comment := cobolTestLeaf(arena, 6, true, source, end("Procedure comment"), end("Procedure comment"))
+	moveStart := idx("MOVE SPACES")
+	moveTargetEnd := end("ABEND-REASON")
+	space := cobolTestLeaf(arena, 8, true, source, idx("SPACES"), end("SPACES"))
+	target := cobolTestLeaf(arena, 9, true, source, idx("ABEND-REASON"), moveTargetEnd)
+	move := newParentNodeInArena(arena, 7, true, []*Node{space, target}, nil, 0)
+	move.startByte = moveStart
+	move.startPoint = advancePointByBytes(Point{}, source[:move.startByte])
+	move.endByte = end("COPY CABENDPO.")
+	move.endPoint = advancePointByBytes(Point{}, source[:move.endByte])
+	copyStmt := cobolTestLeaf(arena, 10, true, source, idx("COPY CABENDPO."), end("COPY CABENDPO."))
+	copyStmt.setExtra(true)
+	execStart := idx("EXEC CICS")
+	execEnd := execStart + uint32(len("EXEC"))
+	cicsStart := execStart + uint32(len("EXEC "))
+	bankWord := cobolTestLeaf(arena, 9, true, source, idx("BANK-MAP-FUNCTION-GET"), end("BANK-MAP-FUNCTION-GET"))
+	execWord := cobolTestLeaf(arena, 15, true, source, execStart, execEnd)
+	isClass := newParentNodeInArena(arena, 14, true, []*Node{bankWord, execWord}, nil, 0)
+	isClass.startByte = bankWord.startByte
+	isClass.startPoint = bankWord.startPoint
+	isClass.endByte = execEnd
+	isClass.endPoint = advancePointByBytes(Point{}, source[:execEnd])
+	innerExpr := newParentNodeInArena(arena, 13, true, []*Node{isClass}, nil, 0)
+	innerExpr.startByte = isClass.startByte
+	innerExpr.startPoint = isClass.startPoint
+	innerExpr.endByte = isClass.endByte
+	innerExpr.endPoint = isClass.endPoint
+	and := cobolTestLeaf(arena, 16, true, source, cicsStart, cicsStart)
+	cicsTail := cobolTestLeaf(arena, 13, true, source, cicsStart, end("CICS LINK"))
+	outerExpr := newParentNodeInArena(arena, 13, true, []*Node{innerExpr, and, cicsTail}, nil, 0)
+	outerExpr.startByte = innerExpr.startByte
+	outerExpr.startPoint = innerExpr.startPoint
+	outerExpr.endByte = cicsTail.endByte
+	outerExpr.endPoint = cicsTail.endPoint
+	ifHeader := newParentNodeInArena(arena, 11, true, []*Node{outerExpr}, nil, 0)
+	ifHeader.startByte = idx("IF BANK-MAP-FUNCTION-GET")
+	ifHeader.startPoint = advancePointByBytes(Point{}, source[:ifHeader.startByte])
+	ifHeader.endByte = cicsTail.endByte
+	ifHeader.endPoint = cicsTail.endPoint
+	execLineEnd := uint32(cobolLineStart(source, int(execStart)))
+	for int(execLineEnd) < len(source) && source[execLineEnd] != '\n' && source[execLineEnd] != '\r' {
+		execLineEnd++
+	}
+	marker := cobolTestLeaf(arena, 12, true, source, execLineEnd, execLineEnd)
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{move, copyStmt, ifHeader, marker}, nil, 0)
+	err.startByte = move.startByte
+	err.startPoint = move.startPoint
+	err.endByte = marker.endByte
+	err.endPoint = marker.endPoint
+	err.setExtra(true)
+	err.setHasError(true)
+	root := newParentNodeInArena(arena, 2, true, []*Node{def, comment, err}, nil, 0)
+	root.startByte = def.startByte
+	root.startPoint = def.startPoint
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+	root.setHasError(true)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := root.ChildCount(), 2; got != want {
+		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	procedure := root.Child(0).Child(1)
+	if got, want := procedure.ChildCount(), 5; got != want {
+		t.Fatalf("procedure_division.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := procedure.Child(1).Type(lang), "comment"; got != want {
+		t.Fatalf("moved child type = %q, want %q", got, want)
+	}
+	if got, want := procedure.Child(2).EndByte(), moveTargetEnd; got != want {
+		t.Fatalf("trimmed move_statement.EndByte = %d, want %d", got, want)
+	}
+	if got, want := procedure.Child(4).EndByte(), execEnd; got != want {
+		t.Fatalf("trimmed if_header.EndByte = %d, want %d", got, want)
+	}
+	if got, want := procedure.Child(4).Child(0).Child(0).Type(lang), "is_class"; got != want {
+		t.Fatalf("trimmed if_header expr child type = %q, want %q", got, want)
+	}
+	if got, want := procedure.StartByte(), idx("PROCEDURE DIVISION."); got != want {
+		t.Fatalf("procedure_division.StartByte = %d, want %d", got, want)
+	}
+	if got, want := procedure.EndByte(), execEnd; got != want {
+		t.Fatalf("procedure_division.EndByte = %d, want %d", got, want)
+	}
+	tail := root.Child(1)
+	if got, want := tail.Type(lang), "ERROR"; got != want {
+		t.Fatalf("tail type = %q, want %q", got, want)
+	}
+	if got, want := tail.StartByte(), cicsStart; got != want {
+		t.Fatalf("tail.StartByte = %d, want %d", got, want)
+	}
+	if got, want := tail.ChildCount(), 1; got != want {
+		t.Fatalf("tail.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := tail.Child(0).Type(lang), "comment_entry"; got != want {
+		t.Fatalf("tail child type = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeCobolRootProcedurePrefixErrorSkipsMoveLedPrefix(t *testing.T) {
+	lang := &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"start",
+			"program_definition",
+			"identification_division",
+			"procedure_division",
+			"comment",
+			"move_statement",
+			"if_header",
+			"comment_entry",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "comment", Visible: true, Named: true},
+			{Name: "move_statement", Visible: true, Named: true},
+			{Name: "if_header", Visible: true, Named: true},
+			{Name: "comment_entry", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. A.\n" +
+		"       PROCEDURE DIVISION.\n" +
+		"      * Procedure comment\n" +
+		"           MOVE A TO B\n" +
+		"           IF FLAG\n" +
+		"              EXEC CICS RETURN\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	id := cobolTestLeaf(arena, 4, true, source, idx("IDENTIFICATION"), end("PROGRAM-ID. A."))
+	dot := cobolTestLeaf(arena, 1, false, source, end("PROCEDURE DIVISION"), end("PROCEDURE DIVISION."))
+	proc := newParentNodeInArena(arena, 5, true, []*Node{dot}, nil, 0)
+	proc.startByte = idx("PROCEDURE DIVISION.")
+	proc.startPoint = advancePointByBytes(Point{}, source[:proc.startByte])
+	proc.endByte = dot.endByte
+	proc.endPoint = dot.endPoint
+	def := newParentNodeInArena(arena, 3, true, []*Node{id, proc}, nil, 0)
+	def.startByte = id.startByte
+	def.startPoint = id.startPoint
+	def.endByte = proc.endByte
+	def.endPoint = proc.endPoint
+
+	comment := cobolTestLeaf(arena, 6, true, source, end("Procedure comment"), end("Procedure comment"))
+	move := cobolTestLeaf(arena, 7, true, source, idx("MOVE A TO B"), end("MOVE A TO B"))
+	execStart := idx("EXEC CICS")
+	ifHeader := cobolTestLeaf(arena, 8, true, source, idx("IF FLAG"), execStart+uint32(len("EXEC")))
+	execLineEnd := uint32(cobolLineEnd(source, int(execStart)))
+	marker := cobolTestLeaf(arena, 9, true, source, execLineEnd, execLineEnd)
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{move, ifHeader, marker}, nil, 0)
+	err.startByte = move.startByte
+	err.startPoint = move.startPoint
+	err.endByte = marker.endByte
+	err.endPoint = marker.endPoint
+	err.setExtra(true)
+	err.setHasError(true)
+	root := newParentNodeInArena(arena, 2, true, []*Node{def, comment, err}, nil, 0)
+	root.startByte = def.startByte
+	root.startPoint = def.startPoint
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+	root.setHasError(true)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := root.ChildCount(), 3; got != want {
+		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := root.Child(0).Child(1).ChildCount(), 1; got != want {
+		t.Fatalf("procedure_division.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	tail := root.Child(2)
+	if got, want := tail.Type(lang), "ERROR"; got != want {
+		t.Fatalf("tail type = %q, want %q", got, want)
+	}
+	if got, want := tail.StartByte(), move.StartByte(); got != want {
+		t.Fatalf("tail.StartByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolRootProcedureEvaluateErrorMovesCleanBody(t *testing.T) {
+	lang := &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"start",
+			"program_definition",
+			"identification_division",
+			"procedure_division",
+			"evaluate_header",
+			"when",
+			"goto_statement",
+			"END_EVALUATE",
+			"period",
+			"paragraph_header",
+			"comment_entry",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "identification_division", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "evaluate_header", Visible: true, Named: true},
+			{Name: "when", Visible: true, Named: true},
+			{Name: "goto_statement", Visible: true, Named: true},
+			{Name: "END_EVALUATE", Visible: true, Named: true},
+			{Name: "period", Visible: true, Named: true},
+			{Name: "paragraph_header", Visible: true, Named: true},
+			{Name: "comment_entry", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       identification division.\n" +
+		"       program-id. a.\n" +
+		"       procedure division.\n" +
+		"       evaluate 1\n" +
+		"       when 1\n" +
+		"         go to aa\n" +
+		"       end-evaluate.\n" +
+		"       aa.\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	id := cobolTestLeaf(arena, 4, true, source, idx("identification"), end("program-id. a."))
+	dot := cobolTestLeaf(arena, 1, false, source, end("procedure division"), end("procedure division."))
+	proc := newParentNodeInArena(arena, 5, true, []*Node{dot}, nil, 0)
+	proc.startByte = dot.startByte
+	proc.startPoint = advancePointByBytes(Point{}, source[:proc.startByte])
+	proc.endByte = dot.endByte
+	proc.endPoint = dot.endPoint
+	def := newParentNodeInArena(arena, 3, true, []*Node{id, proc}, nil, 0)
+	def.startByte = id.startByte
+	def.startPoint = id.startPoint
+	def.endByte = proc.endByte
+	def.endPoint = proc.endPoint
+
+	evaluate := cobolTestLeaf(arena, 6, true, source, idx("evaluate 1"), end("evaluate 1"))
+	when := cobolTestLeaf(arena, 7, true, source, idx("when 1"), end("when 1"))
+	gotoStmt := cobolTestLeaf(arena, 8, true, source, idx("go to aa"), end("go to aa"))
+	endEvaluate := cobolTestLeaf(arena, 9, true, source, idx("end-evaluate"), end("end-evaluate"))
+	period := cobolTestLeaf(arena, 10, true, source, end("end-evaluate"), end("end-evaluate."))
+	paragraphMarker := cobolTestLeaf(arena, 12, true, source, end("aa."), end("aa."))
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{evaluate, when, gotoStmt, endEvaluate, period, paragraphMarker}, nil, 0)
+	err.startByte = evaluate.startByte
+	err.startPoint = evaluate.startPoint
+	err.endByte = paragraphMarker.endByte
+	err.endPoint = paragraphMarker.endPoint
+	err.setExtra(true)
+	err.setHasError(true)
+	root := newParentNodeInArena(arena, 2, true, []*Node{def, err}, nil, 0)
+	root.startByte = def.startByte
+	root.startPoint = def.startPoint
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+	root.setHasError(true)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := root.ChildCount(), 1; got != want {
+		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if root.HasError() {
+		t.Fatalf("root.HasError = true, want false; tree=%s", root.SExpr(lang))
+	}
+	procedure := root.Child(0).Child(1)
+	if got, want := procedure.ChildCount(), 7; got != want {
+		t.Fatalf("procedure_division.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := procedure.StartByte(), idx("procedure division."); got != want {
+		t.Fatalf("procedure_division.StartByte = %d, want %d", got, want)
+	}
+	if got, want := procedure.Child(6).Type(lang), "paragraph_header"; got != want {
+		t.Fatalf("procedure child 6 type = %q, want %q; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := procedure.EndByte(), end("aa."); got != want {
+		t.Fatalf("procedure_division.EndByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolProcedureLooseIfHeader(t *testing.T) {
+	lang := &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"start",
+			"program_definition",
+			"procedure_division",
+			"qualified_word",
+			"ne",
+			"if_header",
+			"expr",
+			"WORD",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "qualified_word", Visible: true, Named: true},
+			{Name: "ne", Visible: true, Named: true},
+			{Name: "if_header", Visible: true, Named: true},
+			{Name: "expr", Visible: true, Named: true},
+			{Name: "WORD", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       PROCEDURE DIVISION.\n" +
+		"              IF EIBAID IS NOT EQUAL TO DFHCLEAR\n" +
+		"                 EXEC CICS RECEIVE MAP('CSGM')\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	dot := cobolTestLeaf(arena, 1, false, source, end("PROCEDURE DIVISION"), end("PROCEDURE DIVISION."))
+	left := cobolTestLeaf(arena, 5, true, source, idx("EIBAID"), end("EIBAID"))
+	op := cobolTestLeaf(arena, 6, true, source, idx("IS NOT EQUAL TO"), end("IS NOT EQUAL TO"))
+	rightWord := cobolTestLeaf(arena, 9, true, source, idx("DFHCLEAR"), end("DFHCLEAR"))
+	execWord := cobolTestLeaf(arena, 9, true, source, idx("EXEC"), end("EXEC"))
+	right := newParentNodeInArena(arena, 5, true, []*Node{rightWord, execWord}, nil, 0)
+	right.startByte = rightWord.startByte
+	right.startPoint = rightWord.startPoint
+	right.endByte = execWord.endByte
+	right.endPoint = execWord.endPoint
+	proc := newParentNodeInArena(arena, 4, true, []*Node{dot, left, op, right}, nil, 0)
+	proc.startByte = idx("PROCEDURE DIVISION.")
+	proc.startPoint = advancePointByBytes(Point{}, source[:proc.startByte])
+	proc.endByte = right.endByte
+	proc.endPoint = right.endPoint
+	def := newParentNodeInArena(arena, 3, true, []*Node{proc}, nil, 0)
+	def.startByte = proc.startByte
+	def.startPoint = proc.startPoint
+	def.endByte = proc.endByte
+	def.endPoint = proc.endPoint
+	root := newParentNodeInArena(arena, 2, true, []*Node{def}, nil, 0)
+	root.startByte = def.startByte
+	root.startPoint = def.startPoint
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+	root.setHasError(true)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	procedure := root.Child(0).Child(0)
+	if got, want := procedure.ChildCount(), 2; got != want {
+		t.Fatalf("procedure_division.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	header := procedure.Child(1)
+	if got, want := header.Type(lang), "if_header"; got != want {
+		t.Fatalf("rebuilt child type = %q, want %q", got, want)
+	}
+	if got, want := header.StartByte(), idx("IF EIBAID"); got != want {
+		t.Fatalf("if_header.StartByte = %d, want %d", got, want)
+	}
+	if got, want := header.EndByte(), end("DFHCLEAR"); got != want {
+		t.Fatalf("if_header.EndByte = %d, want %d", got, want)
+	}
+	if got, want := header.Child(0).Child(2).EndByte(), end("DFHCLEAR"); got != want {
+		t.Fatalf("right operand EndByte = %d, want %d", got, want)
+	}
+	if got, want := procedure.StartByte(), idx("PROCEDURE DIVISION."); got != want {
+		t.Fatalf("procedure_division.StartByte = %d, want %d", got, want)
+	}
+	if got, want := procedure.EndByte(), end("DFHCLEAR"); got != want {
+		t.Fatalf("procedure_division.EndByte = %d, want %d", got, want)
+	}
+	if got, want := root.Child(0).EndByte(), end("DFHCLEAR"); got != want {
+		t.Fatalf("program_definition.EndByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolRootExecCICSErrorMarkers(t *testing.T) {
+	lang := &Language{
+		Name: "cobol",
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"start",
+			"program_definition",
+			"procedure_division",
+			"if_header",
+			"comment",
+			"comment_entry",
+			"qualified_word",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "procedure_division", Visible: true, Named: true},
+			{Name: "if_header", Visible: true, Named: true},
+			{Name: "comment", Visible: true, Named: true},
+			{Name: "comment_entry", Visible: true, Named: true},
+			{Name: "qualified_word", Visible: true, Named: true},
+		},
+	}
+	source := []byte("       PROCEDURE DIVISION.\n" +
+		"              IF EIBAID IS NOT EQUAL TO DFHCLEAR\n" +
+		"                 EXEC CICS RECEIVE MAP('CSGM')\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	dot := cobolTestLeaf(arena, 1, false, source, end("PROCEDURE DIVISION"), end("PROCEDURE DIVISION."))
+	header := cobolTestLeaf(arena, 5, true, source, idx("IF EIBAID"), end("DFHCLEAR"))
+	proc := newParentNodeInArena(arena, 4, true, []*Node{dot, header}, nil, 0)
+	proc.startByte = idx("PROCEDURE DIVISION.")
+	proc.startPoint = advancePointByBytes(Point{}, source[:proc.startByte])
+	proc.endByte = header.endByte
+	proc.endPoint = header.endPoint
+	def := newParentNodeInArena(arena, 3, true, []*Node{proc}, nil, 0)
+	def.startByte = proc.startByte
+	def.startPoint = proc.startPoint
+	def.endByte = proc.endByte
+	def.endPoint = proc.endPoint
+	execStart := idx("EXEC CICS")
+	cicsStart := idx("CICS RECEIVE")
+	lineEnd := uint32(cobolLineEnd(source, int(execStart)))
+	raw := cobolTestLeaf(arena, 8, true, source, cicsStart, end("CICS"))
+	marker := cobolTestLeaf(arena, 7, true, source, lineEnd, lineEnd)
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{raw, marker}, nil, 0)
+	err.startByte = cicsStart
+	err.startPoint = advancePointByBytes(Point{}, source[:cicsStart])
+	err.endByte = lineEnd
+	err.endPoint = advancePointByBytes(Point{}, source[:lineEnd])
+	err.setExtra(true)
+	err.setHasError(true)
+	root := newParentNodeInArena(arena, 2, true, []*Node{def, err}, nil, 0)
+	root.startByte = def.startByte
+	root.startPoint = def.startPoint
+	root.endByte = uint32(len(source))
+	root.endPoint = advancePointByBytes(Point{}, source)
+	root.setHasError(true)
+
+	normalizeCobolRootExecCICSErrorMarkers(root, source, lang)
+
+	var tail *Node
+	for i := 0; i < root.ChildCount(); i++ {
+		if child := root.Child(i); child != nil && child.IsError() {
+			tail = child
+			break
+		}
+	}
+	if tail == nil {
+		t.Fatalf("missing root ERROR; tree=%s", root.SExpr(lang))
+	}
+	if got, want := tail.StartByte(), execStart; got != want {
+		t.Fatalf("tail.StartByte = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := tail.ChildCount(), 1; got != want {
+		t.Fatalf("tail.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := tail.Child(0).Type(lang), "comment_entry"; got != want {
+		t.Fatalf("tail child type = %q, want %q", got, want)
+	}
+	if got, want := tail.Child(0).StartByte(), lineEnd; got != want {
+		t.Fatalf("tail marker StartByte = %d, want %d", got, want)
+	}
+}
+
+func TestNormalizeCobolRecoveredErrorAddsMissingCommentEntryGap(t *testing.T) {
+	lang := &Language{
+		Name:        "cobol",
+		SymbolNames: []string{"EOF", "start", "comment", "comment_entry", "move_statement", "period"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "comment", Visible: true, Named: true},
+			{Name: "comment_entry", Visible: true, Named: true},
+			{Name: "move_statement", Visible: true, Named: true},
+			{Name: "period", Visible: true, Named: true},
+		},
+	}
+	source := []byte("           MOVE A TO B.\n" +
+		"      *COPY CRETURN.\n" +
+		"           EXEC CICS RETURN\n" +
+		"           END-EXEC.\n" +
+		"              MOVE '0001-01-01 00:00:00.000000' TO CD05I-START-ID       \n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	move := cobolTestLeaf(arena, 4, true, source, idx("MOVE A TO B"), end("MOVE A TO B"))
+	period := cobolTestLeaf(arena, 5, true, source, end("MOVE A TO B"), end("MOVE A TO B."))
+	comment := cobolTestLeaf(arena, 2, true, source, end("*COPY CRETURN."), end("*COPY CRETURN."))
+	paddedCarrier := cobolTestLeaf(arena, 3, true, source, end("CD05I-START-ID       "), end("CD05I-START-ID       "))
+	paddedCarrier.setHasError(true)
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{move, period, comment, paddedCarrier}, nil, 0)
+	err.startByte = move.startByte
+	err.startPoint = move.startPoint
+	err.endByte = paddedCarrier.endByte
+	err.endPoint = paddedCarrier.endPoint
+	err.setExtra(true)
+	err.setHasError(true)
+	root := newParentNodeInArena(arena, 1, true, []*Node{err}, nil, 0)
+	root.startByte = err.startByte
+	root.startPoint = err.startPoint
+	root.endByte = err.endByte
+	root.endPoint = err.endPoint
+	root.setHasError(true)
+
+	normalizeResultCompatibility(root, source, &Parser{language: lang})
+
+	if got, want := err.ChildCount(), 6; got != want {
+		t.Fatalf("ERROR ChildCount = %d, want %d; err=%s", got, want, err.SExpr(lang))
+	}
+	if got, want := err.Child(3).Type(lang), "comment_entry"; got != want {
+		t.Fatalf("missing gap marker type = %q, want %q", got, want)
+	}
+	if got, want := err.Child(3).StartByte(), end("EXEC CICS RETURN"); got != want {
+		t.Fatalf("gap marker StartByte = %d, want %d", got, want)
+	}
+	if got, want := err.Child(4).StartByte(), end("END-EXEC."); got != want {
+		t.Fatalf("END-EXEC marker StartByte = %d, want %d", got, want)
+	}
+	paddedLineStart := uint32(cobolLineStart(source, int(idx("MOVE '0001-01-01"))))
+	if got, want := err.Child(5).StartByte(), paddedLineStart+71; got != want {
+		t.Fatalf("padded marker StartByte = %d, want %d", got, want)
+	}
+	if err.Child(3).HasError() || err.Child(4).HasError() || err.Child(5).HasError() {
+		t.Fatal("synthesized comment_entry markers should not carry child error flags")
+	}
+}
+
+func TestNormalizeCobolRootCommentsCoveredByError(t *testing.T) {
+	lang := &Language{
+		Name:        "cobol",
+		SymbolNames: []string{"EOF", "start", "program_definition", "comment", "comment_entry"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "start", Visible: true, Named: true},
+			{Name: "program_definition", Visible: true, Named: true},
+			{Name: "comment", Visible: true, Named: true},
+			{Name: "comment_entry", Visible: true, Named: true},
+		},
+	}
+	source := []byte("PROGRAM.\n       01  X PIC X.\n      * duplicate\n       GOBACK.\n      * trailing\n")
+	idx := func(needle string) uint32 {
+		t.Helper()
+		pos := bytes.Index(source, []byte(needle))
+		if pos < 0 {
+			t.Fatalf("missing %q in test source", needle)
+		}
+		return uint32(pos)
+	}
+	end := func(needle string) uint32 { return idx(needle) + uint32(len(needle)) }
+
+	arena := newNodeArena(arenaClassFull)
+	program := cobolTestLeaf(arena, 2, true, source, idx("PROGRAM."), end("PROGRAM."))
+	coveredComment := cobolTestLeaf(arena, 3, true, source, end("duplicate"), end("duplicate"))
+	entry := cobolTestLeaf(arena, 4, true, source, end("GOBACK."), end("GOBACK."))
+	err := newParentNodeInArena(arena, errorSymbol, true, []*Node{entry}, nil, 0)
+	err.startByte = idx("01  X")
+	err.startPoint = advancePointByBytes(Point{}, source[:err.startByte])
+	err.endByte = entry.endByte
+	err.endPoint = entry.endPoint
+	err.setExtra(true)
+	err.setHasError(true)
+	trailingComment := cobolTestLeaf(arena, 3, true, source, end("trailing"), end("trailing"))
+	root := newParentNodeInArena(arena, 1, true, []*Node{program, coveredComment, err, trailingComment}, nil, 0)
+	root.startByte = program.startByte
+	root.startPoint = program.startPoint
+	root.endByte = trailingComment.endByte
+	root.endPoint = trailingComment.endPoint
+	root.setHasError(true)
+
+	normalizeCobolRootCommentsCoveredByError(root, lang)
+
+	if got, want := root.ChildCount(), 3; got != want {
+		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
+	}
+	if got, want := root.Child(1).Type(lang), "ERROR"; got != want {
+		t.Fatalf("root child 1 type = %q, want %q", got, want)
+	}
+	if got, want := root.Child(2).Type(lang), "comment"; got != want {
+		t.Fatalf("root child 2 type = %q, want %q", got, want)
+	}
+}
+
+func TestCobolAppendCommentEntryMarkersSplitsColumn72Content(t *testing.T) {
+	source := []byte("              MOVE BANK-SCR60-NEW-SEND-EMAIL TO CD02I-CONTACT-SEND-EMAIL\n")
+	line := bytes.TrimSuffix(source, []byte("\n"))
+	if got, want := len(line), 72; got != want {
+		t.Fatalf("test line length = %d, want %d", got, want)
+	}
+
+	arena := newNodeArena(arenaClassFull)
+	out := cobolAppendCommentEntryMarkers(nil, arena, source, 0, uint32(len(source)), 3, true)
+
+	if got, want := len(out), 2; got != want {
+		t.Fatalf("marker count = %d, want %d", got, want)
+	}
+	if got, want := out[0].StartByte(), uint32(71); got != want {
+		t.Fatalf("source-area marker StartByte = %d, want %d", got, want)
+	}
+	if got, want := out[1].StartByte(), uint32(72); got != want {
+		t.Fatalf("physical-end marker StartByte = %d, want %d", got, want)
 	}
 }
 

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -946,9 +946,7 @@ func normalizeCobolProcedureLooseIfHeaders(root *Node, source []byte, lang *Lang
 	if !changed {
 		return
 	}
-	if last := cobolLastChildOfType(program, lang, "procedure_division"); last != nil && last.endByte < program.endByte {
-		setCobolNodeEnd(program, source, last.endByte)
-	}
+	cobolTrimProgramEndToLastProcedure(program, source, lang)
 	cobolRefreshHasErrorFromChildren(program)
 }
 
@@ -1102,9 +1100,7 @@ func normalizeCobolProcedureTrailingExecCICSSpans(root *Node, source []byte, lan
 	if !changed {
 		return
 	}
-	if last := cobolLastChildOfType(program, lang, "procedure_division"); last != nil && last.endByte < program.endByte {
-		setCobolNodeEnd(program, source, last.endByte)
-	}
+	cobolTrimProgramEndToLastProcedure(program, source, lang)
 	cobolRefreshHasErrorFromChildren(program)
 }
 
@@ -1142,16 +1138,7 @@ func normalizeCobolRootExecCICSErrorMarkers(root *Node, source []byte, lang *Lan
 	if !ok {
 		return
 	}
-	programIdx := -1
-	program := (*Node)(nil)
-	for i := 0; i < resultChildCount(root); i++ {
-		child := resultChildAt(root, i)
-		if child != nil && !child.IsExtra() && child.Type(lang) == "program_definition" {
-			programIdx = i
-			program = child
-			break
-		}
-	}
+	programIdx, program := cobolFirstProgramDefinitionIndex(root, lang)
 	if program == nil {
 		return
 	}
@@ -1241,6 +1228,13 @@ func cobolLastChildOfType(parent *Node, lang *Language, typ string) *Node {
 		}
 	}
 	return nil
+}
+
+func cobolTrimProgramEndToLastProcedure(program *Node, source []byte, lang *Language) {
+	last := cobolLastChildOfType(program, lang, "procedure_division")
+	if last != nil && last.endByte < program.endByte {
+		setCobolNodeEnd(program, source, last.endByte)
+	}
 }
 
 func cobolProcedureDivisionHeaderEnd(proc *Node, lang *Language) (int, uint32, bool) {
@@ -1571,16 +1565,6 @@ func cobolCommentEntryMarkerEnd(lineStart, lineEnd int) int {
 		return fixedFormatEnd
 	}
 	return lineEnd
-}
-
-func cobolLineShouldEmitCommentEntry(source []byte, lineStart, lineEnd int) bool {
-	if !cobolLineHasContent(source, lineStart, lineEnd) {
-		return false
-	}
-	if cobolLineLooksFixedFormatComment(source, lineStart) {
-		return false
-	}
-	return true
 }
 
 func firstNonWhitespaceByteFrom(source []byte, start int) (uint32, bool) {
@@ -2066,13 +2050,18 @@ func normalizeCobolProcedureTrailingParagraphCommentEntry(root *Node, source []b
 }
 
 func cobolFirstProgramDefinition(root *Node, lang *Language) *Node {
+	_, child := cobolFirstProgramDefinitionIndex(root, lang)
+	return child
+}
+
+func cobolFirstProgramDefinitionIndex(root *Node, lang *Language) (int, *Node) {
 	for i := 0; i < resultChildCount(root); i++ {
 		child := resultChildAt(root, i)
 		if child != nil && !child.IsExtra() && child.Type(lang) == "program_definition" {
-			return child
+			return i, child
 		}
 	}
-	return nil
+	return -1, nil
 }
 
 func cobolFirstChildOfType(parent *Node, lang *Language, typ string) *Node {

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -6,14 +6,25 @@ func normalizeCobolCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeCobolRecoveredRootProgramDefinition(root, source, lang)
 	normalizeCobolAcceptedRootProgramDefinition(root, source, lang)
 	normalizeCobolZLiteralDataRootRecovery(root, source, lang)
-	normalizeCobolProcedureRootRecovery(root, source, lang)
+	recoveredProcedureRoot := normalizeCobolProcedureRootRecovery(root, source, lang)
 	normalizeCobolRootErrorLeadingComments(root, source, lang)
+	normalizeCobolRootProcedureEvaluateError(root, source, lang)
+	if !recoveredProcedureRoot {
+		normalizeCobolRootProcedurePrefixError(root, source, lang)
+	}
+	normalizeCobolProcedureLooseIfHeaders(root, source, lang)
 	normalizeCobolLeadingAreaStart(root, source, lang)
 	normalizeCobolTopLevelDefinitionEnd(root, source, lang)
+	normalizeCobolRootProgramDefinitionSiblingEnds(root, source, lang)
 	normalizeCobolDivisionSiblingEnds(root, source, lang)
 	normalizeCobolSectionSiblingEnds(root, source, lang)
+	normalizeCobolRecoveredErrorCommentEntries(root, source, lang)
+	normalizeCobolRootCommentsCoveredByError(root, lang)
 	normalizeCobolTrailingTriviaSpans(root, source, lang)
 	normalizeCobolRecoveredParagraphHeader(root, source, lang)
+	normalizeCobolProcedureTrailingParagraphCommentEntry(root, source, lang)
+	normalizeCobolProcedureTrailingExecCICSSpans(root, source, lang)
+	normalizeCobolRootExecCICSErrorMarkers(root, source, lang)
 }
 func normalizeCobolLeadingAreaStart(root *Node, source []byte, lang *Language) {
 	if root == nil || !isCobolLanguage(lang) || len(source) == 0 {
@@ -488,9 +499,9 @@ func cobolAppendRecoveryLineMarkers(out []*Node, arena *nodeArena, source []byte
 	return cobolDeduplicateAdjacentZeroWidthMarkers(out, lang)
 }
 
-func normalizeCobolProcedureRootRecovery(root *Node, source []byte, lang *Language) {
-	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || !root.hasError() {
-		return
+func normalizeCobolProcedureRootRecovery(root *Node, source []byte, lang *Language) bool {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" {
+		return false
 	}
 	children := resultChildSliceForMutation(root)
 	for i := 0; i+1 < len(children); i++ {
@@ -546,8 +557,9 @@ func normalizeCobolProcedureRootRecovery(root *Node, source []byte, lang *Langua
 		rootChildren = append(rootChildren, children[i+2:]...)
 		replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rootChildren))
 		cobolRefreshHasErrorFromChildren(root)
-		return
+		return true
 	}
+	return false
 }
 
 func cobolProcedureRecoveryTailIsHeaderAdjacent(children []*Node, errorStart uint32, lang *Language) bool {
@@ -604,6 +616,583 @@ func normalizeCobolRootErrorLeadingComments(root *Node, source []byte, lang *Lan
 		rootChildren = append(rootChildren, err)
 		rootChildren = append(rootChildren, children[i+1:]...)
 		replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rootChildren))
+		cobolRefreshHasErrorFromChildren(root)
+		return
+	}
+}
+
+func normalizeCobolRootProcedureEvaluateError(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || len(source) == 0 {
+		return
+	}
+	children := resultChildSliceForMutation(root)
+	for i := 0; i < len(children); i++ {
+		def := children[i]
+		if def == nil || def.IsExtra() || def.IsError() || def.IsMissing() || def.Type(lang) != "program_definition" {
+			continue
+		}
+		proc := cobolLastChildOfType(def, lang, "procedure_division")
+		_, headerEnd, ok := cobolProcedureDivisionHeaderEnd(proc, lang)
+		if !ok || proc.endByte > headerEnd {
+			continue
+		}
+		errIdx, ok := cobolRootProcedureErrorIndex(children, i+1, lang)
+		if !ok {
+			continue
+		}
+		err := children[errIdx]
+		if err == nil || err.symbol != errorSymbol || resultChildCount(err) == 0 || int(err.endByte) > len(source) {
+			continue
+		}
+		errChildren := resultChildSliceForMutation(err)
+		firstCode := cobolFirstNonCommentChildType(errChildren, lang)
+		if firstCode != "evaluate_header" || cobolIndexFoldASCII(source, int(err.startByte), int(err.endByte), "exec cics") >= 0 {
+			continue
+		}
+
+		prefix := make([]*Node, 0, errIdx-i-1+len(errChildren))
+		prefix = append(prefix, children[i+1:errIdx]...)
+		prefix = append(prefix, errChildren...)
+		procStart, procStartPoint := proc.startByte, proc.startPoint
+		if headerStart, ok := cobolProcedureDivisionHeaderStart(source, headerEnd); ok {
+			procStart = headerStart
+			procStartPoint = advancePointByBytes(Point{}, source[:headerStart])
+		}
+		procChildren := append(resultChildSliceForMutation(proc), prefix...)
+		replaceNodeChildrenUnfielded(proc, cloneNodeSliceInArena(proc.ownerArena, procChildren))
+		proc.startByte = procStart
+		proc.startPoint = procStartPoint
+		setCobolNodeEnd(proc, source, err.endByte)
+		setCobolNodeEnd(def, source, err.endByte)
+		cobolRefreshHasErrorFromChildren(proc)
+		cobolRefreshHasErrorFromChildren(def)
+
+		rootChildren := make([]*Node, 0, len(children)-(errIdx-i))
+		rootChildren = append(rootChildren, children[:i+1]...)
+		rootChildren = append(rootChildren, children[errIdx+1:]...)
+		replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rootChildren))
+		cobolRefreshHasErrorFromChildren(root)
+		return
+	}
+}
+
+func normalizeCobolRootProcedurePrefixError(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || !root.hasError() || len(source) == 0 {
+		return
+	}
+	children := resultChildSliceForMutation(root)
+	for i := 0; i < len(children); i++ {
+		def := children[i]
+		if def == nil || def.IsExtra() || def.IsError() || def.IsMissing() || def.Type(lang) != "program_definition" {
+			continue
+		}
+		proc := cobolLastChildOfType(def, lang, "procedure_division")
+		_, headerEnd, ok := cobolProcedureDivisionHeaderEnd(proc, lang)
+		if !ok || proc.endByte > headerEnd {
+			continue
+		}
+		errIdx, ok := cobolRootProcedurePrefixErrorIndex(children, i+1, lang)
+		if !ok || errIdx <= i+1 {
+			continue
+		}
+		err := children[errIdx]
+		if err == nil || err.symbol != errorSymbol || resultChildCount(err) == 0 {
+			continue
+		}
+		splitEnd, tailStart, ok := cobolFirstExecCICSTailSplit(source, err.startByte, err.endByte)
+		if !ok || splitEnd <= proc.endByte || tailStart <= splitEnd || tailStart >= err.endByte {
+			continue
+		}
+		errChildren := resultChildSliceForMutation(err)
+		prefixEnd := cobolRecoveredProcedurePrefixEnd(errChildren, splitEnd, tailStart)
+		if prefixEnd <= 0 {
+			continue
+		}
+		prefix := make([]*Node, 0, errIdx-i-1+prefixEnd)
+		prefix = append(prefix, children[i+1:errIdx]...)
+		for j := 0; j < prefixEnd; j++ {
+			child := errChildren[j]
+			if child == nil {
+				continue
+			}
+			if child.endByte > splitEnd {
+				cobolTrimNodeEndForRecovery(child, source, splitEnd)
+			}
+			normalizeCobolRecoveredProcedurePrefixNode(child, source, lang)
+			prefix = append(prefix, child)
+		}
+		if len(prefix) == 0 || !cobolProcedurePrefixCanMove(prefix, lang) {
+			continue
+		}
+
+		procStart, procStartPoint := proc.startByte, proc.startPoint
+		procChildren := append(resultChildSliceForMutation(proc), prefix...)
+		replaceNodeChildrenUnfielded(proc, cloneNodeSliceInArena(proc.ownerArena, procChildren))
+		proc.startByte = procStart
+		proc.startPoint = procStartPoint
+		setCobolNodeEnd(proc, source, splitEnd)
+		setCobolNodeEnd(def, source, splitEnd)
+		cobolRefreshHasErrorFromChildren(proc)
+		cobolRefreshHasErrorFromChildren(def)
+
+		replaceNodeChildrenUnfielded(err, cloneNodeSliceInArena(err.ownerArena, errChildren[prefixEnd:]))
+		err.startByte = tailStart
+		err.startPoint = advancePointByBytes(Point{}, source[:tailStart])
+		err.setExtra(true)
+		err.setHasError(true)
+		normalizeCobolRecoveredTailErrorChildren(err, source, lang)
+
+		rootChildren := make([]*Node, 0, len(children)-(errIdx-i-1))
+		rootChildren = append(rootChildren, children[:i+1]...)
+		rootChildren = append(rootChildren, err)
+		rootChildren = append(rootChildren, children[errIdx+1:]...)
+		replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, rootChildren))
+		cobolRefreshHasErrorFromChildren(root)
+		return
+	}
+}
+
+func cobolProcedurePrefixCanMove(children []*Node, lang *Language) bool {
+	firstCodeType := ""
+	for _, child := range children {
+		if child == nil || child.IsMissing() {
+			continue
+		}
+		typ := child.Type(lang)
+		if typ == "copy_statement" {
+			return true
+		}
+		if firstCodeType == "" && typ != "comment" && typ != "comment_entry" {
+			firstCodeType = typ
+		}
+	}
+	return firstCodeType == "if_header"
+}
+
+func cobolRootProcedureErrorIndex(children []*Node, start int, lang *Language) (int, bool) {
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(children); i++ {
+		child := children[i]
+		if child == nil || child.IsMissing() {
+			continue
+		}
+		if child.symbol == errorSymbol {
+			return i, true
+		}
+		if child.IsExtra() || child.IsError() || child.Type(lang) != "comment" {
+			return -1, false
+		}
+	}
+	return -1, false
+}
+
+func cobolFirstNonCommentChildType(children []*Node, lang *Language) string {
+	for _, child := range children {
+		if child == nil || child.IsMissing() {
+			continue
+		}
+		typ := child.Type(lang)
+		if typ != "comment" && typ != "comment_entry" {
+			return typ
+		}
+	}
+	return ""
+}
+
+func cobolProcedureDivisionHeaderStart(source []byte, headerEnd uint32) (uint32, bool) {
+	if int(headerEnd) > len(source) {
+		return 0, false
+	}
+	pos := int(headerEnd)
+	if pos > 0 {
+		pos--
+	}
+	lineStart := cobolLineStart(source, pos)
+	idx := cobolIndexFoldASCII(source, lineStart, int(headerEnd), "procedure division")
+	if idx < 0 {
+		return 0, false
+	}
+	return uint32(idx), true
+}
+
+func cobolRootProcedurePrefixErrorIndex(children []*Node, start int, lang *Language) (int, bool) {
+	if start < 0 {
+		start = 0
+	}
+	sawComment := false
+	for i := start; i < len(children); i++ {
+		child := children[i]
+		if child == nil || child.IsMissing() {
+			continue
+		}
+		if child.symbol == errorSymbol {
+			return i, sawComment
+		}
+		if child.IsExtra() || child.IsError() || child.Type(lang) != "comment" {
+			return -1, false
+		}
+		sawComment = true
+	}
+	return -1, false
+}
+
+func cobolFirstExecCICSTailSplit(source []byte, start, end uint32) (uint32, uint32, bool) {
+	if start >= end || int(end) > len(source) {
+		return 0, 0, false
+	}
+	for lineStart := cobolLineStart(source, int(start)); lineStart < int(end); {
+		lineEnd := lineStart
+		for lineEnd < len(source) && source[lineEnd] != '\n' && source[lineEnd] != '\r' {
+			lineEnd++
+		}
+		if lineEnd > int(end) {
+			lineEnd = int(end)
+		}
+		scanStart := int(start)
+		if scanStart < lineStart {
+			scanStart = lineStart
+		}
+		if scanStart < lineEnd && !cobolLineLooksFixedFormatComment(source, lineStart) {
+			idx := cobolIndexFoldASCII(source, scanStart, lineEnd, "exec cics")
+			if idx >= 0 {
+				cicsStart := idx + len("exec ")
+				splitEnd := lastNonTriviaByteEnd(source[:cicsStart])
+				tailStart, ok := firstNonWhitespaceByteInRange(source, int(splitEnd), lineEnd)
+				if ok && splitEnd > start && tailStart >= uint32(cicsStart) && splitEnd < tailStart {
+					return splitEnd, tailStart, true
+				}
+			}
+		}
+		next := cobolNextLineStart(source, lineEnd)
+		if next <= lineStart {
+			break
+		}
+		lineStart = next
+	}
+	return 0, 0, false
+}
+
+func cobolRecoveredProcedurePrefixEnd(children []*Node, splitEnd, tailStart uint32) int {
+	for i, child := range children {
+		if child == nil {
+			continue
+		}
+		if child.startByte >= tailStart {
+			return i
+		}
+		if child.endByte > splitEnd {
+			if child.startByte < splitEnd {
+				return i + 1
+			}
+			return i
+		}
+	}
+	return len(children)
+}
+
+func normalizeCobolRecoveredProcedurePrefixNode(n *Node, source []byte, lang *Language) {
+	if n == nil || int(n.endByte) > len(source) {
+		return
+	}
+	for i := 0; i < resultChildCount(n); i++ {
+		normalizeCobolRecoveredProcedurePrefixNode(resultChildAt(n, i), source, lang)
+	}
+	if n.Type(lang) == "expr" && resultChildCount(n) == 1 {
+		child := resultChildAt(n, 0)
+		if child != nil && !child.IsExtra() && !child.IsMissing() && child.Type(lang) == "expr" &&
+			child.startByte == n.startByte && child.endByte == n.endByte {
+			replaceNodeChildrenUnfielded(n, cloneNodeSliceInArena(n.ownerArena, resultChildSliceForMutation(child)))
+		}
+	}
+	if !cobolTrailingTriviaLeafCanTrim(n.Type(lang)) {
+		cobolRefreshHasErrorFromChildren(n)
+		return
+	}
+	last := (*Node)(nil)
+	for i := resultChildCount(n) - 1; i >= 0; i-- {
+		child := resultChildAt(n, i)
+		if child == nil || child.IsMissing() {
+			continue
+		}
+		last = child
+		break
+	}
+	if last != nil && last.endByte > n.startByte && last.endByte < n.endByte {
+		setCobolNodeEnd(n, source, last.endByte)
+	}
+	cobolRefreshHasErrorFromChildren(n)
+}
+
+func normalizeCobolProcedureLooseIfHeaders(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || !root.hasError() || len(source) == 0 {
+		return
+	}
+	program := cobolFirstProgramDefinition(root, lang)
+	if program == nil {
+		return
+	}
+	changed := false
+	for i := 0; i < resultChildCount(program); i++ {
+		child := resultChildAt(program, i)
+		if child == nil || child.IsExtra() || child.IsError() || child.IsMissing() || child.Type(lang) != "procedure_division" {
+			continue
+		}
+		if normalizeCobolProcedureLooseIfHeaderChildren(child, source, lang) {
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+	if last := cobolLastChildOfType(program, lang, "procedure_division"); last != nil && last.endByte < program.endByte {
+		setCobolNodeEnd(program, source, last.endByte)
+	}
+	cobolRefreshHasErrorFromChildren(program)
+}
+
+func normalizeCobolProcedureLooseIfHeaderChildren(proc *Node, source []byte, lang *Language) bool {
+	children := resultChildSliceForMutation(proc)
+	if len(children) < 3 {
+		return false
+	}
+	ifHeaderSym, ok := symbolByName(lang, "if_header")
+	if !ok {
+		return false
+	}
+	exprSym, ok := symbolByName(lang, "expr")
+	if !ok {
+		return false
+	}
+	changed := false
+	for i := 0; i+2 < len(children); i++ {
+		left, op, right := children[i], children[i+1], children[i+2]
+		if !cobolLooseIfHeaderParts(left, op, right, lang) {
+			continue
+		}
+		ifStart, ok := cobolIfKeywordStartBefore(source, left.startByte)
+		if !ok {
+			continue
+		}
+		lineEnd := cobolLineEnd(source, int(left.startByte))
+		conditionEnd := lastNonTriviaByteEnd(source[:lineEnd])
+		if conditionEnd <= right.startByte || conditionEnd > right.endByte {
+			continue
+		}
+		if right.endByte > conditionEnd {
+			cobolTrimNodeEndForRecovery(right, source, conditionEnd)
+		}
+		wasLast := i+3 == len(children)
+		procStart, procStartPoint := proc.startByte, proc.startPoint
+		expr := newParentNodeInArena(proc.ownerArena, exprSym, symbolIsNamed(lang, exprSym), cloneNodeSliceInArena(proc.ownerArena, []*Node{left, op, right}), nil, 0)
+		expr.startByte = left.startByte
+		expr.startPoint = left.startPoint
+		expr.endByte = conditionEnd
+		expr.endPoint = advancePointByBytes(Point{}, source[:conditionEnd])
+		cobolRefreshHasErrorFromChildren(expr)
+		header := newParentNodeInArena(proc.ownerArena, ifHeaderSym, symbolIsNamed(lang, ifHeaderSym), []*Node{expr}, nil, 0)
+		header.startByte = ifStart
+		header.startPoint = advancePointByBytes(Point{}, source[:ifStart])
+		header.endByte = conditionEnd
+		header.endPoint = expr.endPoint
+		cobolRefreshHasErrorFromChildren(header)
+
+		out := make([]*Node, 0, len(children)-2)
+		out = append(out, children[:i]...)
+		out = append(out, header)
+		out = append(out, children[i+3:]...)
+		children = cloneNodeSliceInArena(proc.ownerArena, out)
+		replaceNodeChildrenUnfielded(proc, children)
+		proc.startByte = procStart
+		proc.startPoint = procStartPoint
+		if wasLast {
+			setCobolNodeEnd(proc, source, conditionEnd)
+		}
+		cobolRefreshHasErrorFromChildren(proc)
+		changed = true
+	}
+	if changed {
+		for i := resultChildCount(proc) - 1; i >= 0; i-- {
+			last := resultChildAt(proc, i)
+			if last == nil || last.IsMissing() {
+				continue
+			}
+			if last.endByte < proc.endByte {
+				setCobolNodeEnd(proc, source, last.endByte)
+			}
+			break
+		}
+	}
+	return changed
+}
+
+func cobolLooseIfHeaderParts(left, op, right *Node, lang *Language) bool {
+	if left == nil || op == nil || right == nil {
+		return false
+	}
+	if left.IsExtra() || op.IsExtra() || right.IsExtra() || left.IsMissing() || op.IsMissing() || right.IsMissing() {
+		return false
+	}
+	if left.Type(lang) != "qualified_word" || right.Type(lang) != "qualified_word" {
+		return false
+	}
+	switch op.Type(lang) {
+	case "eq", "ne":
+		return true
+	default:
+		return false
+	}
+}
+
+func cobolIfKeywordStartBefore(source []byte, operandStart uint32) (uint32, bool) {
+	if int(operandStart) > len(source) {
+		return 0, false
+	}
+	lineStart := cobolLineStart(source, int(operandStart))
+	kwStart, ok := firstNonWhitespaceByteInRange(source, lineStart, int(operandStart))
+	if !ok || int(kwStart)+2 > int(operandStart) {
+		return 0, false
+	}
+	if !cobolEqualFoldASCII(source[kwStart:kwStart+2], "if") {
+		return 0, false
+	}
+	for i := int(kwStart) + 2; i < int(operandStart); i++ {
+		if source[i] != ' ' && source[i] != '\t' {
+			return 0, false
+		}
+	}
+	return kwStart, true
+}
+
+func cobolLineEnd(source []byte, pos int) int {
+	if pos > len(source) {
+		pos = len(source)
+	}
+	for pos < len(source) && source[pos] != '\n' && source[pos] != '\r' {
+		pos++
+	}
+	return pos
+}
+
+func normalizeCobolProcedureTrailingExecCICSSpans(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || !root.hasError() || len(source) == 0 {
+		return
+	}
+	program := cobolFirstProgramDefinition(root, lang)
+	if program == nil {
+		return
+	}
+	changed := false
+	for i := 0; i < resultChildCount(program); i++ {
+		proc := resultChildAt(program, i)
+		if proc == nil || proc.IsExtra() || proc.IsError() || proc.IsMissing() || proc.Type(lang) != "procedure_division" {
+			continue
+		}
+		last := cobolLastNonMissingChild(proc)
+		if last == nil || last.Type(lang) != "if_header" || last.endByte >= proc.endByte {
+			continue
+		}
+		if !cobolNextCodeStartsExecCICS(source, last.endByte) {
+			continue
+		}
+		setCobolNodeEnd(proc, source, last.endByte)
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	if last := cobolLastChildOfType(program, lang, "procedure_division"); last != nil && last.endByte < program.endByte {
+		setCobolNodeEnd(program, source, last.endByte)
+	}
+	cobolRefreshHasErrorFromChildren(program)
+}
+
+func cobolLastNonMissingChild(parent *Node) *Node {
+	if parent == nil {
+		return nil
+	}
+	for i := resultChildCount(parent) - 1; i >= 0; i-- {
+		child := resultChildAt(parent, i)
+		if child != nil && !child.IsMissing() {
+			return child
+		}
+	}
+	return nil
+}
+
+func cobolNextCodeStartsExecCICS(source []byte, start uint32) bool {
+	pos, ok := firstNonWhitespaceByteFrom(source, int(start))
+	if !ok || int(pos) >= len(source) {
+		return false
+	}
+	lineEnd := cobolLineEnd(source, int(pos))
+	return cobolIndexFoldASCII(source, int(pos), lineEnd, "exec cics") == int(pos)
+}
+
+func normalizeCobolRootExecCICSErrorMarkers(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || !root.hasError() || len(source) == 0 {
+		return
+	}
+	commentSym, ok := symbolByName(lang, "comment")
+	if !ok {
+		return
+	}
+	commentEntrySym, ok := symbolByName(lang, "comment_entry")
+	if !ok {
+		return
+	}
+	programIdx := -1
+	program := (*Node)(nil)
+	for i := 0; i < resultChildCount(root); i++ {
+		child := resultChildAt(root, i)
+		if child != nil && !child.IsExtra() && child.Type(lang) == "program_definition" {
+			programIdx = i
+			program = child
+			break
+		}
+	}
+	if program == nil {
+		return
+	}
+	proc := cobolLastChildOfType(program, lang, "procedure_division")
+	if proc == nil {
+		return
+	}
+	execStart, ok := firstNonWhitespaceByteFrom(source, int(proc.endByte))
+	if !ok || !cobolNextCodeStartsExecCICS(source, proc.endByte) {
+		return
+	}
+	for i := programIdx + 1; i < resultChildCount(root); i++ {
+		err := resultChildAt(root, i)
+		if err == nil || err.symbol != errorSymbol || err.endByte <= execStart || int(err.endByte) > len(source) {
+			continue
+		}
+		if err.startByte <= execStart {
+			return
+		}
+		out := cobolAppendRecoveryLineMarkers(
+			nil,
+			err.ownerArena,
+			source,
+			execStart,
+			err.endByte,
+			lang,
+			commentSym,
+			symbolIsNamed(lang, commentSym),
+			commentEntrySym,
+			symbolIsNamed(lang, commentEntrySym),
+		)
+		if len(out) == 0 {
+			return
+		}
+		replaceNodeChildrenUnfielded(err, cloneNodeSliceInArena(err.ownerArena, out))
+		err.startByte = execStart
+		err.startPoint = advancePointByBytes(Point{}, source[:execStart])
+		err.endByte = out[len(out)-1].endByte
+		err.endPoint = out[len(out)-1].endPoint
+		err.setExtra(true)
+		err.setHasError(true)
 		cobolRefreshHasErrorFromChildren(root)
 		return
 	}
@@ -855,6 +1444,64 @@ func normalizeCobolRecoveredTailErrorChildren(tail *Node, source []byte, lang *L
 	tail.setHasError(true)
 }
 
+func normalizeCobolRecoveredErrorCommentEntries(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || len(source) == 0 {
+		return
+	}
+	walkResultTreePostorder(root, func(n *Node) {
+		if n == nil || n.symbol != errorSymbol || resultChildCount(n) == 0 || !cobolErrorHasCommentEntryChild(n, lang) {
+			return
+		}
+		normalizeCobolRecoveredTailErrorChildren(n, source, lang)
+	})
+}
+
+func normalizeCobolRootCommentsCoveredByError(root *Node, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" {
+		return
+	}
+	children := resultChildSliceForMutation(root)
+	out := make([]*Node, 0, len(children))
+	changed := false
+	for _, child := range children {
+		if child != nil && child.Type(lang) == "comment" && cobolRootCommentCoveredByError(child, children) {
+			changed = true
+			continue
+		}
+		out = append(out, child)
+	}
+	if !changed {
+		return
+	}
+	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, out))
+	cobolRefreshHasErrorFromChildren(root)
+}
+
+func cobolRootCommentCoveredByError(comment *Node, siblings []*Node) bool {
+	if comment == nil {
+		return false
+	}
+	for _, sibling := range siblings {
+		if sibling == nil || sibling == comment || sibling.symbol != errorSymbol {
+			continue
+		}
+		if comment.startByte >= sibling.startByte && comment.endByte <= sibling.endByte {
+			return true
+		}
+	}
+	return false
+}
+
+func cobolErrorHasCommentEntryChild(n *Node, lang *Language) bool {
+	for i := 0; i < resultChildCount(n); i++ {
+		child := resultChildAt(n, i)
+		if child != nil && child.Type(lang) == "comment_entry" {
+			return true
+		}
+	}
+	return false
+}
+
 func cobolDeduplicateAdjacentZeroWidthMarkers(nodes []*Node, lang *Language) []*Node {
 	if len(nodes) < 2 {
 		return nodes
@@ -889,7 +1536,20 @@ func cobolAppendCommentEntryMarkers(out []*Node, arena *nodeArena, source []byte
 		for lineEnd < len(source) && source[lineEnd] != '\n' && source[lineEnd] != '\r' {
 			lineEnd++
 		}
-		if uint32(lineEnd) > start && uint32(lineEnd) <= end && cobolLineShouldEmitCommentEntry(source, lineStart, lineEnd) {
+		if cobolLineLooksFixedFormatComment(source, lineStart) {
+			next := cobolNextLineStart(source, lineEnd)
+			if next <= lineStart {
+				break
+			}
+			lineStart = next
+			continue
+		}
+		markerEnd := cobolCommentEntryMarkerEnd(lineStart, lineEnd)
+		if uint32(markerEnd) > start && uint32(markerEnd) <= end && cobolLineHasContent(source, lineStart, markerEnd) {
+			point := advancePointByBytes(Point{}, source[:markerEnd])
+			out = append(out, newLeafNodeInArena(arena, sym, named, uint32(markerEnd), uint32(markerEnd), point, point))
+		}
+		if lineEnd > markerEnd && uint32(lineEnd) > start && uint32(lineEnd) <= end && cobolLineHasContent(source, markerEnd, lineEnd) {
 			point := advancePointByBytes(Point{}, source[:lineEnd])
 			out = append(out, newLeafNodeInArena(arena, sym, named, uint32(lineEnd), uint32(lineEnd), point, point))
 		}
@@ -900,6 +1560,17 @@ func cobolAppendCommentEntryMarkers(out []*Node, arena *nodeArena, source []byte
 		lineStart = next
 	}
 	return out
+}
+
+func cobolCommentEntryMarkerEnd(lineStart, lineEnd int) int {
+	if lineEnd <= lineStart {
+		return lineEnd
+	}
+	fixedFormatEnd := lineStart + 71
+	if lineEnd > fixedFormatEnd {
+		return fixedFormatEnd
+	}
+	return lineEnd
 }
 
 func cobolLineShouldEmitCommentEntry(source []byte, lineStart, lineEnd int) bool {
@@ -1033,6 +1704,58 @@ func setCobolNodeEnd(n *Node, source []byte, end uint32) {
 	}
 	n.endByte = end
 	n.endPoint = advancePointByBytes(Point{}, source[:end])
+}
+
+func normalizeCobolRootProgramDefinitionSiblingEnds(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || resultChildCount(root) == 0 {
+		return
+	}
+	childCount := resultChildCount(root)
+	for i := 0; i+1 < childCount; i++ {
+		def := resultChildAt(root, i)
+		if def == nil || def.IsExtra() || def.IsError() || def.IsMissing() || def.Type(lang) != "program_definition" {
+			continue
+		}
+		next := cobolNextDefinitionRootSibling(root, i+1)
+		if next == nil {
+			continue
+		}
+		end := cobolNodeEndBeforeSibling(next, source, lang)
+		if end == 0 || end <= def.startByte || end >= def.endByte {
+			continue
+		}
+		setCobolNodeEnd(def, source, end)
+		normalizeCobolLastDivisionEndToParent(def, source, lang)
+	}
+}
+
+func cobolNextDefinitionRootSibling(root *Node, start int) *Node {
+	for i := start; i < resultChildCount(root); i++ {
+		child := resultChildAt(root, i)
+		if child != nil && !child.IsMissing() {
+			return child
+		}
+	}
+	return nil
+}
+
+func normalizeCobolLastDivisionEndToParent(parent *Node, source []byte, lang *Language) {
+	if parent == nil {
+		return
+	}
+	for i := resultChildCount(parent) - 1; i >= 0; i-- {
+		child := resultChildAt(parent, i)
+		if child == nil || child.IsExtra() || child.IsError() || child.IsMissing() {
+			continue
+		}
+		if !strings.HasSuffix(child.Type(lang), "_division") {
+			return
+		}
+		if parent.endByte > child.startByte && parent.endByte < child.endByte {
+			setCobolNodeEnd(child, source, parent.endByte)
+		}
+		return
+	}
 }
 
 func normalizeCobolDivisionSiblingEnds(root *Node, source []byte, lang *Language) {
@@ -1281,6 +2004,65 @@ func normalizeCobolRecoveredParagraphHeader(root *Node, source []byte, lang *Lan
 	root.endByte = rootEnd
 	root.endPoint = rootEndPoint
 	cobolRefreshHasErrorFromChildren(root)
+}
+
+func normalizeCobolProcedureTrailingParagraphCommentEntry(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || len(source) == 0 {
+		return
+	}
+	paragraphSym, ok := symbolByName(lang, "paragraph_header")
+	if !ok {
+		return
+	}
+	dotSym, ok := symbolByName(lang, ".")
+	if !ok {
+		return
+	}
+	program := cobolFirstProgramDefinition(root, lang)
+	if program == nil {
+		return
+	}
+	changed := false
+	walkResultTreePostorder(program, func(n *Node) {
+		if n == nil || n.Type(lang) != "procedure_division" || resultChildCount(n) == 0 {
+			return
+		}
+		last := resultChildAt(n, resultChildCount(n)-1)
+		if last == nil || last.Type(lang) != "comment_entry" || last.startByte != last.endByte || int(last.startByte) > len(source) {
+			return
+		}
+		lineStart := cobolLineStart(source, int(last.startByte))
+		labelStart, ok := firstNonWhitespaceByteInRange(source, lineStart, int(last.startByte))
+		if !ok {
+			return
+		}
+		labelEnd := lastNonTriviaByteEnd(source[:last.startByte])
+		if labelEnd == 0 || labelEnd <= labelStart || source[labelEnd-1] != '.' {
+			return
+		}
+		dotStart := labelEnd - 1
+		if !cobolBytesAreParagraphLabel(source[labelStart:dotStart]) {
+			return
+		}
+		dot := newLeafNodeInArena(n.ownerArena, dotSym, symbolIsNamed(lang, dotSym), dotStart, labelEnd, advancePointByBytes(Point{}, source[:dotStart]), advancePointByBytes(Point{}, source[:labelEnd]))
+		header := newParentNodeInArena(n.ownerArena, paragraphSym, symbolIsNamed(lang, paragraphSym), []*Node{dot}, nil, 0)
+		header.startByte = labelStart
+		header.startPoint = advancePointByBytes(Point{}, source[:labelStart])
+		header.endByte = labelEnd
+		header.endPoint = advancePointByBytes(Point{}, source[:labelEnd])
+		children := resultChildSliceForMutation(n)
+		children[len(children)-1] = header
+		procStart, procStartPoint := n.startByte, n.startPoint
+		replaceNodeChildrenUnfielded(n, cloneNodeSliceInArena(n.ownerArena, children))
+		n.startByte = procStart
+		n.startPoint = procStartPoint
+		setCobolNodeEnd(n, source, labelEnd)
+		changed = true
+	})
+	if changed {
+		cobolRefreshHasErrorFromChildren(program)
+		cobolRefreshHasErrorFromChildren(root)
+	}
 }
 
 func cobolFirstProgramDefinition(root *Node, lang *Language) *Node {


### PR DESCRIPTION
## Summary

Fixes a recovery hole where zero-width skipped tokens could be silently dropped by the C-recovery dispatch path. Zero-width tokens ahead of the stack offset advance the stack/error span; zero-width tokens at the current offset are now still recorded in the open ERROR region instead of disappearing from recovery accounting. Expands COBOL root recovery to retain more valid statements: evaluate/when/goto bodies are hoisted into `procedure_division` when the header is intact, clean root prefixes can move into the procedure, and EXEC CICS tails remain as trimmed ERROR regions. This reduces false-positive ERROR coverage and stabilizes node spans for downstream tooling.

A cleanup follow-up keeps the COBOL compatibility layer tighter: it removes one staticcheck-proven dead helper and shares repeated program/procedure scan and trim operations.

## Changes

- Absorb zero-width skipped tokens into the open ERROR node during `cRecoverDispatchInError`, including the current-offset case surfaced during review.
- Add COBOL normalization passes for evaluate-root recovery, root procedure prefix recovery, loose IF headers, EXEC CICS tails, covered root comments, missing comment-entry markers, and trailing paragraph labels.
- Let `normalizeCobolProcedureRootRecovery` report whether it restructured the root, so prefix recovery does not double-process the same tree.
- Preserve MOVE-led root ERROR cases while allowing copy-statement and IF-header prefixes to move when the C oracle shape supports it.
- Add focused regression coverage for zero-width recovery and the new COBOL normalization shapes.
- Remove unused `cobolLineShouldEmitCommentEntry` and extract shared COBOL program/procedure helpers.

## Testing

Current head (`0363e0a1`):

- `git diff --check`
- `staticcheck .`
- `go test . -run 'CRecoverDispatchInError|Cobol|COBOL' -count=1`
- `bash cgo_harness/docker/run_single_grammar_parity.sh cobol`
  - `RESULT: cobol — PARITY`
  - real corpus aggressive: `no-error 25/25, sexpr parity 25/25, deep parity 25/25`
  - no OOM; max RSS about 3.47 GB

Earlier on this PR branch before cleanup/review-fix follow-ups:

- COBOL tier-40 real corpus: `parityMatch=40/40(100%) diverge=0 trunc=0 panics=0`
- COBOL cgo focus lane: `eligible=40 no_error=40 tree_parity=40 divergences=0`
- Focused Docker witnesses for `SCHAR00P.cbl`, `SCASH00P.cbl`, `DFHZCSGM.cbl`, and `DFHUAINS.cbl`: no structural divergence

## Review Notes

Buckley review was run against the implementation diff. One actionable finding was confirmed and fixed: zero-width skipped tokens at the current stack offset were previously marked consumed without being recorded in the open ERROR region. Other Buckley items were either already covered by focused tests in this PR or were review-checklist items without a concrete defect.

## Review Focus

Check the zero-width token absorption path for current-offset accounting, byte-offset advancement when the token is ahead of the stack, and ERROR-span progress. For COBOL, focus on the gate conditions around intact procedure headers, EXEC CICS split points, comment/paragraph marker synthesis, and `hasError` propagation after moving nodes. The cleanup commit should be behavior-neutral: one unused helper removed, repeated root/program scans shared, and duplicated procedure-end trimming extracted.
