### PR TITLE
feat(perf-scan): add perf ratio budget ratchet + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: cgo_harness/go.mod
 
       - name: Validate perf scan budget ratchet
         working-directory: cgo_harness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,24 @@ jobs:
           name: parity-log
           path: parity.log
 
+  perf_scan_budget:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Validate perf scan budget ratchet
+        working-directory: cgo_harness
+        run: |
+          set -euo pipefail
+          GOWORK=off go test ./cmd/perf_scan_budget -count=1
+          GOWORK=off go run ./cmd/perf_scan_budget \
+            -budget perf_scan/perf_ratio_budgets.json
+
   build:
     needs:
       - compile
@@ -179,6 +197,7 @@ jobs:
       - race_packages
       - draft_focused_tests
       - parity_report
+      - perf_scan_budget
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -191,6 +210,7 @@ jobs:
           RACE_PACKAGES_RESULT: ${{ needs.race_packages.result }}
           DRAFT_FOCUSED_RESULT: ${{ needs.draft_focused_tests.result }}
           PARITY_REPORT_RESULT: ${{ needs.parity_report.result }}
+          PERF_SCAN_BUDGET_RESULT: ${{ needs.perf_scan_budget.result }}
         run: |
           set -euo pipefail
           failed=0
@@ -206,6 +226,7 @@ jobs:
 
           require_success "compile" "$COMPILE_RESULT"
           require_success "parity_report" "$PARITY_REPORT_RESULT"
+          require_success "perf_scan_budget" "$PERF_SCAN_BUDGET_RESULT"
 
           if [ "$IS_DRAFT" = "true" ]; then
             require_success "draft_focused_tests" "$DRAFT_FOCUSED_RESULT"

--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -294,8 +294,8 @@ func compareAxis(lang, axis string, budget budgetAxis, row scoreboardLang) []eva
 	if !ok {
 		return append(out, evalFinding{Language: lang, Axis: axis, Metric: "axis", Got: "missing", Want: "measured"})
 	}
-	if actual.FilesOK == 0 && actual.RatioByTotal <= 0 {
-		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "files_ok", Got: "0", Want: ">0"})
+	if len(row.Files) == 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "files", Got: "0", Want: ">0"})
 	}
 	if actual.GoTimeouts > budget.MaxTimeouts {
 		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "go_timeouts", Got: fmt.Sprint(actual.GoTimeouts), Want: fmt.Sprintf("<=%d", budget.MaxTimeouts)})
@@ -324,11 +324,22 @@ func countGoErrors(row scoreboardLang, axis string) int {
 		if !ok {
 			continue
 		}
-		if fa.Status == "go_error" || fa.Status == "go_panic" {
+		if isGoErrorStatus(fa.Status) {
 			n++
 		}
 	}
 	return n
+}
+
+func isGoErrorStatus(status string) bool {
+	switch status {
+	case "go_error", "go_panic", "go_truncated", "go_partial":
+		return true
+	case "go_timeout", statusOK, "":
+		return false
+	default:
+		return strings.HasPrefix(status, "go_") && strings.Contains(status, "trunc")
+	}
 }
 
 func countCProblems(row scoreboardLang, axis string) int {

--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+const (
+	budgetSchema     = "gts-perf-ratio-budgets/v1"
+	scoreboardSchema = "gts-perf-scan/v1"
+
+	axisFull   = "full"
+	axisNoEdit = "noedit"
+	statusOK   = "ok"
+)
+
+type budgetFile struct {
+	Schema           string                 `json:"schema"`
+	GeneratedAt      string                 `json:"generated_at"`
+	MeasurementBasis budgetMeasurementBasis `json:"measurement_basis"`
+	Languages        map[string]budgetLang  `json:"languages"`
+}
+
+type budgetMeasurementBasis struct {
+	Reps         int      `json:"reps"`
+	Warmup       int      `json:"warmup"`
+	FileBudgetMS int      `json:"file_budget_ms"`
+	MaxFiles     int      `json:"max_files,omitempty"`
+	Order        string   `json:"order,omitempty"`
+	Axes         []string `json:"axes"`
+}
+
+type budgetLang struct {
+	Status     string     `json:"status"`
+	FullAxis   budgetAxis `json:"full_axis"`
+	NoEditAxis budgetAxis `json:"noedit_axis"`
+}
+
+type budgetAxis struct {
+	MaxTimeouts           int     `json:"max_timeouts"`
+	MaxErrors             *int    `json:"max_errors"`
+	MaxRatioByTotal       float64 `json:"max_ratio_by_total"`
+	MaxRatioMedianOfFiles float64 `json:"max_ratio_median_of_files"`
+}
+
+type scoreboardFile struct {
+	Schema    string           `json:"schema"`
+	Config    scoreboardConfig `json:"config"`
+	Languages []scoreboardLang `json:"languages"`
+}
+
+type scoreboardConfig struct {
+	Reps         int      `json:"reps"`
+	Warmup       int      `json:"warmup"`
+	FileBudgetMS int      `json:"file_budget_ms"`
+	MaxFiles     int      `json:"max_files"`
+	Order        string   `json:"order"`
+	Axes         []string `json:"axes"`
+}
+
+type scoreboardLang struct {
+	Language string                    `json:"language"`
+	Status   string                    `json:"status"`
+	Axes     map[string]scoreboardAxis `json:"axes"`
+	Files    []scoreboardFileRow       `json:"files"`
+}
+
+type scoreboardAxis struct {
+	FilesOK            int     `json:"files_ok"`
+	RatioByTotal       float64 `json:"ratio_by_total"`
+	RatioMedianOfFiles float64 `json:"ratio_median_of_files"`
+	GoTimeouts         int     `json:"go_timeouts"`
+}
+
+type scoreboardFileRow struct {
+	Path string                        `json:"path"`
+	Axes map[string]scoreboardFileAxis `json:"axes"`
+}
+
+type scoreboardFileAxis struct {
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type evalFinding struct {
+	Language string
+	Axis     string
+	Metric   string
+	Got      string
+	Want     string
+}
+
+func main() {
+	var (
+		budgetPath            string
+		scoreboardPath        string
+		langsRaw              string
+		requireAllBudgetLangs bool
+		strictConfig          bool
+		outMD                 string
+	)
+
+	flag.StringVar(&budgetPath, "budget", "perf_scan/perf_ratio_budgets.json", "perf ratio budget JSON path")
+	flag.StringVar(&scoreboardPath, "scoreboard", "", "optional perf_scan scoreboard.json path to compare against the budget")
+	flag.StringVar(&langsRaw, "langs", "", "optional comma-separated language filter")
+	flag.BoolVar(&requireAllBudgetLangs, "require-all-budget-langs", false, "fail if the scoreboard omits a budgeted language")
+	flag.BoolVar(&strictConfig, "strict-config", true, "require scoreboard measurement knobs to match structured budget metadata")
+	flag.StringVar(&outMD, "out-md", "", "optional markdown summary output path")
+	flag.Parse()
+
+	budget, err := loadBudget(budgetPath)
+	if err != nil {
+		fatalf("load budget: %v", err)
+	}
+	if findings := validateBudget(budget); len(findings) > 0 {
+		printFindings("budget validation failed", findings)
+		os.Exit(1)
+	}
+
+	var findings []evalFinding
+	if scoreboardPath != "" {
+		board, err := loadScoreboard(scoreboardPath)
+		if err != nil {
+			fatalf("load scoreboard: %v", err)
+		}
+		langs := parseList(langsRaw)
+		findings = compareScoreboard(budget, board, compareOptions{
+			Languages:             langs,
+			RequireAllBudgetLangs: requireAllBudgetLangs,
+			StrictConfig:          strictConfig,
+		})
+	}
+
+	summary := renderSummary(budget, scoreboardPath, findings)
+	fmt.Print(summary)
+	if outMD != "" {
+		if err := os.WriteFile(outMD, []byte(summary), 0o644); err != nil {
+			fatalf("write markdown summary: %v", err)
+		}
+	}
+	if len(findings) > 0 {
+		os.Exit(1)
+	}
+}
+
+func loadBudget(path string) (*budgetFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out budgetFile
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func loadScoreboard(path string) (*scoreboardFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out scoreboardFile
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func validateBudget(b *budgetFile) []evalFinding {
+	var out []evalFinding
+	if b.Schema != budgetSchema {
+		out = append(out, evalFinding{Metric: "schema", Got: b.Schema, Want: budgetSchema})
+	}
+	if len(b.Languages) == 0 {
+		out = append(out, evalFinding{Metric: "languages", Got: "0", Want: ">0"})
+	}
+	for _, axis := range []string{axisFull, axisNoEdit} {
+		if !contains(b.MeasurementBasis.Axes, axis) {
+			out = append(out, evalFinding{Axis: axis, Metric: "measurement_basis.axes", Got: strings.Join(b.MeasurementBasis.Axes, ","), Want: "include " + axis})
+		}
+	}
+	for _, lang := range sortedBudgetLanguages(b) {
+		entry := b.Languages[lang]
+		if strings.TrimSpace(entry.Status) == "" {
+			out = append(out, evalFinding{Language: lang, Metric: "status", Got: "", Want: "non-empty"})
+		}
+		out = append(out, validateBudgetAxis(lang, axisFull, entry.FullAxis)...)
+		out = append(out, validateBudgetAxis(lang, axisNoEdit, entry.NoEditAxis)...)
+	}
+	return out
+}
+
+func validateBudgetAxis(lang, axis string, b budgetAxis) []evalFinding {
+	var out []evalFinding
+	if b.MaxTimeouts < 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "max_timeouts", Got: fmt.Sprint(b.MaxTimeouts), Want: ">=0"})
+	}
+	if b.MaxErrors != nil && *b.MaxErrors < 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "max_errors", Got: fmt.Sprint(*b.MaxErrors), Want: ">=0"})
+	}
+	if b.MaxRatioByTotal <= 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "max_ratio_by_total", Got: fmt.Sprintf("%.6g", b.MaxRatioByTotal), Want: ">0"})
+	}
+	if b.MaxRatioMedianOfFiles < 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "max_ratio_median_of_files", Got: fmt.Sprintf("%.6g", b.MaxRatioMedianOfFiles), Want: ">=0"})
+	}
+	return out
+}
+
+type compareOptions struct {
+	Languages             []string
+	RequireAllBudgetLangs bool
+	StrictConfig          bool
+}
+
+func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []evalFinding {
+	var out []evalFinding
+	if s.Schema != scoreboardSchema {
+		out = append(out, evalFinding{Metric: "scoreboard.schema", Got: s.Schema, Want: scoreboardSchema})
+	}
+	if opts.StrictConfig {
+		out = append(out, compareConfig(b.MeasurementBasis, s.Config)...)
+	}
+
+	filter := map[string]bool{}
+	for _, lang := range opts.Languages {
+		filter[lang] = true
+	}
+	scoreboardLangs := map[string]scoreboardLang{}
+	for _, row := range s.Languages {
+		if len(filter) > 0 && !filter[row.Language] {
+			continue
+		}
+		scoreboardLangs[row.Language] = row
+		if _, ok := b.Languages[row.Language]; !ok {
+			out = append(out, evalFinding{Language: row.Language, Metric: "budget", Got: "missing", Want: "language budget"})
+		}
+	}
+
+	for _, lang := range sortedBudgetLanguages(b) {
+		if len(filter) > 0 && !filter[lang] {
+			continue
+		}
+		row, ok := scoreboardLangs[lang]
+		if !ok {
+			if opts.RequireAllBudgetLangs || len(filter) > 0 {
+				out = append(out, evalFinding{Language: lang, Metric: "scoreboard", Got: "missing", Want: "measured language"})
+			}
+			continue
+		}
+		if row.Status != statusOK {
+			out = append(out, evalFinding{Language: lang, Metric: "language_status", Got: row.Status, Want: statusOK})
+		}
+		entry := b.Languages[lang]
+		out = append(out, compareAxis(lang, axisFull, entry.FullAxis, row)...)
+		out = append(out, compareAxis(lang, axisNoEdit, entry.NoEditAxis, row)...)
+	}
+	return out
+}
+
+func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
+	var out []evalFinding
+	if b.Reps > 0 && s.Reps != b.Reps {
+		out = append(out, evalFinding{Metric: "config.reps", Got: fmt.Sprint(s.Reps), Want: fmt.Sprint(b.Reps)})
+	}
+	if b.Warmup > 0 && s.Warmup != b.Warmup {
+		out = append(out, evalFinding{Metric: "config.warmup", Got: fmt.Sprint(s.Warmup), Want: fmt.Sprint(b.Warmup)})
+	}
+	if b.FileBudgetMS > 0 && s.FileBudgetMS != b.FileBudgetMS {
+		out = append(out, evalFinding{Metric: "config.file_budget_ms", Got: fmt.Sprint(s.FileBudgetMS), Want: fmt.Sprint(b.FileBudgetMS)})
+	}
+	if b.MaxFiles > 0 && s.MaxFiles != b.MaxFiles {
+		out = append(out, evalFinding{Metric: "config.max_files", Got: fmt.Sprint(s.MaxFiles), Want: fmt.Sprint(b.MaxFiles)})
+	}
+	if b.Order != "" && s.Order != b.Order {
+		out = append(out, evalFinding{Metric: "config.order", Got: s.Order, Want: b.Order})
+	}
+	for _, axis := range b.Axes {
+		if !contains(s.Axes, axis) {
+			out = append(out, evalFinding{Axis: axis, Metric: "config.axes", Got: strings.Join(s.Axes, ","), Want: "include " + axis})
+		}
+	}
+	return out
+}
+
+func compareAxis(lang, axis string, budget budgetAxis, row scoreboardLang) []evalFinding {
+	var out []evalFinding
+	actual, ok := row.Axes[axis]
+	if !ok {
+		return append(out, evalFinding{Language: lang, Axis: axis, Metric: "axis", Got: "missing", Want: "measured"})
+	}
+	if actual.FilesOK == 0 && actual.RatioByTotal <= 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "files_ok", Got: "0", Want: ">0"})
+	}
+	if actual.GoTimeouts > budget.MaxTimeouts {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "go_timeouts", Got: fmt.Sprint(actual.GoTimeouts), Want: fmt.Sprintf("<=%d", budget.MaxTimeouts)})
+	}
+	errors := countGoErrors(row, axis)
+	if budget.MaxErrors != nil && errors > *budget.MaxErrors {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "go_errors", Got: fmt.Sprint(errors), Want: fmt.Sprintf("<=%d", *budget.MaxErrors)})
+	}
+	cProblems := countCProblems(row, axis)
+	if cProblems > 0 {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "c_reference_failures", Got: fmt.Sprint(cProblems), Want: "0"})
+	}
+	if budget.MaxRatioByTotal > 0 && actual.RatioByTotal > budget.MaxRatioByTotal {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "ratio_by_total", Got: fmt.Sprintf("%.4fx", actual.RatioByTotal), Want: fmt.Sprintf("<=%.4fx", budget.MaxRatioByTotal)})
+	}
+	if budget.MaxRatioMedianOfFiles > 0 && actual.RatioMedianOfFiles > budget.MaxRatioMedianOfFiles {
+		out = append(out, evalFinding{Language: lang, Axis: axis, Metric: "ratio_median_of_files", Got: fmt.Sprintf("%.4fx", actual.RatioMedianOfFiles), Want: fmt.Sprintf("<=%.4fx", budget.MaxRatioMedianOfFiles)})
+	}
+	return out
+}
+
+func countGoErrors(row scoreboardLang, axis string) int {
+	n := 0
+	for _, file := range row.Files {
+		fa, ok := file.Axes[axis]
+		if !ok {
+			continue
+		}
+		if fa.Status == "go_error" || fa.Status == "go_panic" {
+			n++
+		}
+	}
+	return n
+}
+
+func countCProblems(row scoreboardLang, axis string) int {
+	n := 0
+	for _, file := range row.Files {
+		fa, ok := file.Axes[axis]
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(fa.Status, "c_") {
+			n++
+		}
+	}
+	return n
+}
+
+func renderSummary(b *budgetFile, scoreboardPath string, findings []evalFinding) string {
+	var sb strings.Builder
+	mode := "validate"
+	if scoreboardPath != "" {
+		mode = "compare"
+	}
+	fmt.Fprintf(&sb, "### Perf Scan Budget %s\n\n", titleWord(mode))
+	fmt.Fprintf(&sb, "- budget schema: `%s`\n", b.Schema)
+	fmt.Fprintf(&sb, "- budget languages: `%d`\n", len(b.Languages))
+	if scoreboardPath != "" {
+		fmt.Fprintf(&sb, "- scoreboard: `%s`\n", scoreboardPath)
+	}
+	if len(findings) == 0 {
+		fmt.Fprintf(&sb, "- outcome: `PASS`\n")
+		return sb.String()
+	}
+	fmt.Fprintf(&sb, "- outcome: `FAIL`\n\n")
+	fmt.Fprintf(&sb, "| language | axis | metric | got | want |\n")
+	fmt.Fprintf(&sb, "|---|---|---|---|---|\n")
+	for _, f := range findings {
+		fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
+			mdCell(f.Language), mdCell(f.Axis), mdCell(f.Metric), mdCell(f.Got), mdCell(f.Want))
+	}
+	return sb.String()
+}
+
+func printFindings(prefix string, findings []evalFinding) {
+	fmt.Fprintln(os.Stderr, prefix)
+	for _, f := range findings {
+		fmt.Fprintf(os.Stderr, "%s\t%s\t%s\tgot=%s\twant=%s\n", f.Language, f.Axis, f.Metric, f.Got, f.Want)
+	}
+}
+
+func sortedBudgetLanguages(b *budgetFile) []string {
+	out := make([]string, 0, len(b.Languages))
+	for lang := range b.Languages {
+		out = append(out, lang)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func parseList(raw string) []string {
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func contains(items []string, needle string) bool {
+	for _, item := range items {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func mdCell(s string) string {
+	if s == "" {
+		return "-"
+	}
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
+func titleWord(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(2)
+}

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -50,6 +50,96 @@ func TestCompareScoreboardReportsRegressions(t *testing.T) {
 	}
 }
 
+func TestCompareScoreboardReportsMedianRatioRegression(t *testing.T) {
+	b := testBudget()
+	lang := b.Languages["go"]
+	lang.FullAxis.MaxRatioMedianOfFiles = 2
+	b.Languages["go"] = lang
+	s := testScoreboard(1.5, 0, 0)
+	s.Languages[0].Axes[axisFull] = scoreboardAxis{
+		FilesOK:            1,
+		RatioByTotal:       1.5,
+		RatioMedianOfFiles: 2.5,
+	}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:ratio_median_of_files") {
+		t.Fatalf("findings %q missing median ratio failure (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardReportsStrictConfigMismatch(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Config.Reps = 7
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "::config.reps") {
+		t.Fatalf("findings %q missing config reps failure (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardReportsCReferenceFailure(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Languages[0].Files[0].Axes[axisFull] = scoreboardFileAxis{Status: "c_timeout"}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:c_reference_failures") {
+		t.Fatalf("findings %q missing C reference failure (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardCountsDefensiveTruncationStatus(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Languages[0].Files[0].Axes[axisFull] = scoreboardFileAxis{Status: "go_truncated"}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	if len(findings) != 0 {
+		t.Fatalf("one truncation should be within the explicit full-axis budget: %#v", findings)
+	}
+
+	lang := b.Languages["go"]
+	lang.FullAxis.MaxErrors = intPtr(0)
+	b.Languages["go"] = lang
+	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:go_errors") {
+		t.Fatalf("findings %q missing go_truncated error accounting (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardAllowsAllTimeoutsWithinBudget(t *testing.T) {
+	b := testBudget()
+	lang := b.Languages["go"]
+	lang.FullAxis.MaxTimeouts = 2
+	lang.NoEditAxis.MaxTimeouts = 2
+	b.Languages["go"] = lang
+
+	s := testScoreboard(0, 2, 0)
+	s.Languages[0].Axes[axisFull] = scoreboardAxis{GoTimeouts: 2}
+	s.Languages[0].Axes[axisNoEdit] = scoreboardAxis{GoTimeouts: 2}
+	s.Languages[0].Files = []scoreboardFileRow{
+		{Path: "timeout-a.go", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: "go_timeout"},
+			axisNoEdit: {Status: "go_timeout"},
+		}},
+		{Path: "timeout-b.go", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: "go_timeout"},
+			axisNoEdit: {Status: "go_timeout"},
+		}},
+	}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	if len(findings) != 0 {
+		t.Fatalf("all-timeout budget should pass when timeouts stay within budget: %#v", findings)
+	}
+}
+
 func TestCompareScoreboardRequiresConfiguredLanguage(t *testing.T) {
 	b := testBudget()
 	s := testScoreboard(2.5, 0, 0)
@@ -63,6 +153,29 @@ func TestCompareScoreboardRequiresConfiguredLanguage(t *testing.T) {
 	got := renderFindingKeys(findings)
 	if !strings.Contains(got, "go::scoreboard") {
 		t.Fatalf("findings %q missing missing-language failure", got)
+	}
+}
+
+func TestCompareScoreboardReportsUnknownBudgetLanguage(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Languages = append(s.Languages, scoreboardLang{
+		Language: "unknown",
+		Status:   statusOK,
+		Axes: map[string]scoreboardAxis{
+			axisFull:   {FilesOK: 1, RatioByTotal: 1},
+			axisNoEdit: {FilesOK: 1, RatioByTotal: 1},
+		},
+		Files: []scoreboardFileRow{{Path: "x", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: statusOK},
+			axisNoEdit: {Status: statusOK},
+		}}},
+	})
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "unknown::budget") {
+		t.Fatalf("findings %q missing unknown budget language failure (%#v)", got, findings)
 	}
 }
 

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateBudgetAcceptsCurrentFile(t *testing.T) {
+	b, err := loadBudget(filepath.Join("..", "..", "perf_scan", "perf_ratio_budgets.json"))
+	if err != nil {
+		t.Fatalf("load budget: %v", err)
+	}
+	if findings := validateBudget(b); len(findings) != 0 {
+		t.Fatalf("budget findings: %#v", findings)
+	}
+}
+
+func TestCompareScoreboardPassesWithinBudget(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 1, 1)
+
+	findings := compareScoreboard(b, s, compareOptions{
+		RequireAllBudgetLangs: true,
+		StrictConfig:          true,
+	})
+	if len(findings) != 0 {
+		t.Fatalf("findings: %#v", findings)
+	}
+}
+
+func TestCompareScoreboardReportsRegressions(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(4.1, 2, 2)
+
+	findings := compareScoreboard(b, s, compareOptions{
+		RequireAllBudgetLangs: true,
+		StrictConfig:          true,
+	})
+	got := renderFindingKeys(findings)
+	for _, want := range []string{
+		"go:full:go_timeouts",
+		"go:full:go_errors",
+		"go:full:ratio_by_total",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("findings %q missing %q (%#v)", got, want, findings)
+		}
+	}
+}
+
+func TestCompareScoreboardRequiresConfiguredLanguage(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Languages = nil
+
+	findings := compareScoreboard(b, s, compareOptions{
+		Languages:             []string{"go"},
+		RequireAllBudgetLangs: false,
+		StrictConfig:          true,
+	})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go::scoreboard") {
+		t.Fatalf("findings %q missing missing-language failure", got)
+	}
+}
+
+func TestMainWritesMarkdownSummary(t *testing.T) {
+	dir := t.TempDir()
+	budgetPath := filepath.Join(dir, "budget.json")
+	scoreboardPath := filepath.Join(dir, "scoreboard.json")
+	outPath := filepath.Join(dir, "summary.md")
+
+	writeFile(t, budgetPath, `{
+  "schema": "gts-perf-ratio-budgets/v1",
+  "measurement_basis": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"]},
+  "languages": {
+    "go": {
+      "status": "green",
+      "full_axis": {"max_timeouts": 0, "max_errors": 0, "max_ratio_by_total": 3},
+      "noedit_axis": {"max_timeouts": 0, "max_errors": 0, "max_ratio_by_total": 1}
+    }
+  }
+}`)
+	writeFile(t, scoreboardPath, `{
+  "schema": "gts-perf-scan/v1",
+  "config": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"]},
+  "languages": [{
+    "language": "go",
+    "status": "ok",
+    "axes": {
+      "full": {"files_ok": 1, "ratio_by_total": 1.5, "ratio_median_of_files": 1.5, "go_timeouts": 0},
+      "noedit": {"files_ok": 1, "ratio_by_total": 0.1, "ratio_median_of_files": 0.1, "go_timeouts": 0}
+    },
+    "files": [{"path": "x.go", "axes": {"full": {"status": "ok"}, "noedit": {"status": "ok"}}}]
+  }]
+}`)
+
+	b, err := loadBudget(budgetPath)
+	if err != nil {
+		t.Fatalf("load budget: %v", err)
+	}
+	s, err := loadScoreboard(scoreboardPath)
+	if err != nil {
+		t.Fatalf("load scoreboard: %v", err)
+	}
+	summary := renderSummary(b, scoreboardPath, compareScoreboard(b, s, compareOptions{
+		RequireAllBudgetLangs: true,
+		StrictConfig:          true,
+	}))
+	if err := os.WriteFile(outPath, []byte(summary), 0o644); err != nil {
+		t.Fatalf("write summary: %v", err)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	if !strings.Contains(string(data), "outcome: `PASS`") {
+		t.Fatalf("summary = %s", data)
+	}
+}
+
+func testBudget() *budgetFile {
+	return &budgetFile{
+		Schema: budgetSchema,
+		MeasurementBasis: budgetMeasurementBasis{
+			Reps:         5,
+			Warmup:       1,
+			FileBudgetMS: 10000,
+			MaxFiles:     8,
+			Order:        "largest",
+			Axes:         []string{axisFull, axisNoEdit},
+		},
+		Languages: map[string]budgetLang{
+			"go": {
+				Status: "green",
+				FullAxis: budgetAxis{
+					MaxTimeouts:     1,
+					MaxErrors:       intPtr(1),
+					MaxRatioByTotal: 3,
+				},
+				NoEditAxis: budgetAxis{
+					MaxTimeouts:     1,
+					MaxRatioByTotal: 1,
+				},
+			},
+		},
+	}
+}
+
+func testScoreboard(fullRatio float64, timeouts, errors int) *scoreboardFile {
+	files := []scoreboardFileRow{
+		{Path: "ok.go", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: statusOK},
+			axisNoEdit: {Status: statusOK},
+		}},
+	}
+	for i := 0; i < timeouts; i++ {
+		files = append(files, scoreboardFileRow{Path: "timeout.go", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: "go_timeout"},
+			axisNoEdit: {Status: "go_timeout"},
+		}})
+	}
+	for i := 0; i < errors; i++ {
+		files = append(files, scoreboardFileRow{Path: "truncated.go", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: "go_error"},
+			axisNoEdit: {Status: statusOK},
+		}})
+	}
+	return &scoreboardFile{
+		Schema: scoreboardSchema,
+		Config: scoreboardConfig{
+			Reps:         5,
+			Warmup:       1,
+			FileBudgetMS: 10000,
+			MaxFiles:     8,
+			Order:        "largest",
+			Axes:         []string{axisFull, axisNoEdit},
+		},
+		Languages: []scoreboardLang{{
+			Language: "go",
+			Status:   statusOK,
+			Axes: map[string]scoreboardAxis{
+				axisFull: {
+					FilesOK:            1,
+					RatioByTotal:       fullRatio,
+					RatioMedianOfFiles: fullRatio,
+					GoTimeouts:         timeouts,
+				},
+				axisNoEdit: {
+					FilesOK:            1,
+					RatioByTotal:       0.1,
+					RatioMedianOfFiles: 0.1,
+					GoTimeouts:         timeouts,
+				},
+			},
+			Files: files,
+		}},
+	}
+}
+
+func renderFindingKeys(findings []evalFinding) string {
+	var parts []string
+	for _, f := range findings {
+		parts = append(parts, f.Language+":"+f.Axis+":"+f.Metric)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func intPtr(n int) *int {
+	return &n
+}

--- a/cgo_harness/perf_scan/CI_PROPOSAL.md
+++ b/cgo_harness/perf_scan/CI_PROPOSAL.md
@@ -1,8 +1,10 @@
 # CI proposal: nightly Go-vs-C perf scoreboard (non-blocking)
 
-Status: PROPOSAL ONLY. Nothing in `.github/workflows` is changed by this
-directory. The job below is written as a comment block for the coordinator to
-adopt (or adapt) once the corpus-provisioning question is settled.
+Status: PROPOSAL ONLY for the expensive nightly sweep. The fast PR lane only
+validates the checked-in budget schema and the checker unit tests; it does not
+run real-corpus timing. The job below is written as a comment block for the
+coordinator to adopt (or adapt) once the corpus-provisioning question is
+settled.
 
 ## Job shape
 
@@ -52,15 +54,24 @@ adopt (or adapt) once the corpus-provisioning question is settled.
 #           GTS_PERF_SCAN: "1"
 #           GTS_PERF_SCAN_CORPUS_ROOT: /corpus/corpus_sources
 #           GTS_REAL_CORPUS_BENCH_LOCK: /corpus/corpus_sources.lock
-#           GTS_PERF_SCAN_MAX_FILES: "16"
+#           GTS_PERF_SCAN_MAX_FILES: "8"
 #           GTS_PERF_SCAN_ORDER: largest
-#           GTS_PERF_SCAN_REPS: "7"
+#           GTS_PERF_SCAN_REPS: "5"
 #           GTS_PERF_SCAN_FILE_BUDGET_MS: "10000"
 #           GTS_PERF_SCAN_LANG_TIMEOUT_MS: "900000"
 #           GTS_PERF_SCAN_OUT: perf_scan/out/nightly
 #         run: |
 #           go test -tags "treesitter_c_parity treesitter_c_perfscan" \
 #             -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 -p 1 .
+#
+#       - name: Check perf ratio budget
+#         working-directory: cgo_harness
+#         run: |
+#           GOWORK=off go run ./cmd/perf_scan_budget \
+#             -budget perf_scan/perf_ratio_budgets.json \
+#             -scoreboard perf_scan/out/nightly/scoreboard.json \
+#             -require-all-budget-langs \
+#             -out-md perf_scan/out/nightly/budget.md
 #
 #       - name: Upload scoreboard
 #         if: always()
@@ -70,7 +81,7 @@ adopt (or adapt) once the corpus-provisioning question is settled.
 #           path: cgo_harness/perf_scan/out/nightly
 #           retention-days: 90
 #
-#       # Optional phase 2: diff scoreboard.json against the previous run's
+#       # Optional trend step: diff scoreboard.json against the previous run's
 #       # artifact and open/update a tracking issue when a language's verdict
 #       # bucket regresses (<=1.2x -> <=2x etc.) or a new cliff appears.
 # --- END PROPOSAL ---
@@ -112,11 +123,12 @@ quiet box (fastest path to nightly trend data, identical to today's manual
 runs), and graduate to the artifact bucket when a second runner or team
 consumers appear. Keep B only if a hosted-runner smoke tier is wanted on PRs.
 
-## Non-blocking regression visibility (phase 2)
+## Non-blocking regression visibility
 
-Once two nightly artifacts exist, a small diff step can compare
-`scoreboard.json` runs: flag any language whose verdict bucket worsened, any
-new `cliff>10x`, and any language that flipped to
-`lang_timeout`/`error`. Publish as a job-summary table and (optionally) a
-pinned tracking issue. Still non-blocking; the ratchet decision (if ever)
-belongs to the tier_scan gates, not this job.
+The implemented `cmd/perf_scan_budget` step compares each nightly
+`scoreboard.json` against the checked-in ratio budget and fails the step for
+new ratio, timeout, truncation, or C-reference failures. The nightly job should
+remain `continue-on-error: true`, so regressions are visible in the job summary
+and uploaded artifact without blocking unrelated PRs. A later trend step can
+still diff consecutive artifacts to flag verdict-bucket movement or open/update
+a pinned tracking issue.

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -133,6 +133,73 @@ Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 config, a `contended` flag, per-language per-axis aggregates, and per-file
 medians/ratios/statuses.
 
+## Ratio budget ratchet
+
+Wave 3 seeds a checked-in ratio budget at
+`cgo_harness/perf_scan/perf_ratio_budgets.json`. The file is intentionally a
+ratchet, not an aspirational target list: values may be tightened after better
+measurements or engine fixes, but loosening a budget needs a root-cause note in
+the PR that explains why the old bound is no longer reachable.
+
+Validate the budget file itself:
+
+```sh
+cd cgo_harness
+GOWORK=off go run ./cmd/perf_scan_budget \
+  -budget perf_scan/perf_ratio_budgets.json
+```
+
+Compare an authoritative scoreboard against the ratchet:
+
+```sh
+cd cgo_harness
+GOWORK=off go run ./cmd/perf_scan_budget \
+  -budget perf_scan/perf_ratio_budgets.json \
+  -scoreboard perf_scan/out/authoritative_YYYYMMDDTHHMMSSZ/scoreboard.json \
+  -require-all-budget-langs \
+  -out-md perf_scan/out/authoritative_YYYYMMDDTHHMMSSZ/budget.md
+```
+
+The checked-in budget was seeded with `order=largest`, `max_files=8`,
+`reps=5`, `warmup=1`, `file_budget_ms=10000`, and axes `full,noedit`. Generate
+a strict ratchet scoreboard with those same knobs inside the parity container:
+
+```sh
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --label perf-scan-ratchet \
+  --memory 8g \
+  --cpus 2 \
+  --pids 4096 \
+  --gomemlimit 6GiB \
+  --goflags -p=1 \
+  --mount /home/draco/work/gotreesitter-corpora:/corpus:ro \
+  -- "cd /workspace/cgo_harness && \
+      GOWORK=off GTS_PERF_SCAN=1 \
+      GTS_PERF_SCAN_CORPUS_ROOT=/corpus/corpus_sources \
+      GTS_REAL_CORPUS_BENCH_LOCK=/corpus/corpus_sources.lock \
+      GTS_PERF_SCAN_MAX_FILES=8 GTS_PERF_SCAN_ORDER=largest \
+      GTS_PERF_SCAN_REPS=5 GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
+      GTS_PERF_SCAN_OUT=perf_scan/out/ratchet_\$(date -u +%Y%m%dT%H%M%SZ) \
+      go test -tags 'treesitter_c_parity treesitter_c_perfscan' \
+      -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 ."
+```
+
+For a targeted language refresh, scope the comparison:
+
+```sh
+cd cgo_harness
+GOWORK=off go run ./cmd/perf_scan_budget \
+  -budget perf_scan/perf_ratio_budgets.json \
+  -scoreboard perf_scan/out/go_refresh/scoreboard.json \
+  -langs go
+```
+
+The checker gates `ratio_by_total`, optional `ratio_median_of_files`,
+`go_timeout` counts, and Go-side error/truncation counts. It also rejects C
+reference failures and, by default, requires the scoreboard's structured
+measurement knobs (`reps`, `warmup`, `file_budget_ms`, `max_files`, `order`,
+and axes) to match the budget metadata.
+
 ## Phase 2 (documented, not built)
 
 - Correctness-verified `edit` axis: verify structural parity of the
@@ -142,5 +209,5 @@ medians/ratios/statuses.
 - Multi-site edit sampling (median over K edit sites per file instead of the
   first verified site).
 - Allocation / RSS axes (Go `ReportAllocs` analogue vs C arena growth).
-- Trend storage + ratchet (compare scoreboards across runs, alert on bucket
-  regressions) — see CI_PROPOSAL.md.
+- Trend storage across nightly artifacts and issue updates when a language
+  worsens after budget comparison — see CI_PROPOSAL.md.

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -1,0 +1,424 @@
+{
+  "_ratchet_policy": [
+    "These budgets are RATCHETS, not targets: they may only ever be TIGHTENED.",
+    "A PR that loosens (regresses) any value in this file must carry a mechanism",
+    "RCA in its description -- i.e. a root-cause explanation of the perf/behavior",
+    "change that made the old (tighter) budget unreachable, not just 'CI is flaky'",
+    "or 'the new number is fine'. See cgo_harness/perf_scan/CI_PROPOSAL.md for the",
+    "non-blocking visibility job this file is meant to back, and cgo_harness/",
+    "perf_scan/README.md for the measurement protocol (verdict buckets, cliff",
+    "containment, ratio_by_total vs ratio_median_of_files) these numbers assume.",
+    "Every budget below was seeded from a REAL measurement (see _seed_sources)",
+    "with roughly +25% headroom over the best currently-reproducible number, so",
+    "budgets are comfortably green today while still tight enough to catch a",
+    "cliff regression. Where a language's real, fresh measurement contradicts an",
+    "optimistic prior assumption (bash), the real measurement wins -- a ratchet",
+    "that isn't green today is worse than useless."
+  ],
+  "schema": "gts-perf-ratio-budgets/v1",
+  "generated_at": "2026-07-07T07:05:47Z",
+  "generated_by": "wave-2b ratchet-drafting pass, branch wave2/integration, HEAD 009c55b9 (includes 7c04440c optimize(arena): Bound overflow slab growth -- wave-2a arena fix, -27% arena bytes on the js asm-class witness)",
+  "measurement_basis": {
+    "harness": "cgo_harness/perf_scan (TestPerfScanSweep / TestPerfScanLanguage, tags treesitter_c_parity treesitter_c_perfscan)",
+    "corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources (real upstream per-language checkouts, largest-8-files sampling -- deliberately adversarial, hunts cliffs, NOT representative of typical file size)",
+    "selection": "order=largest max_files=8 min_file_bytes=0 max_file_bytes=4194304",
+    "order": "largest",
+    "max_files": 8,
+    "min_file_bytes": 0,
+    "max_file_bytes": 4194304,
+    "reps": 5,
+    "warmup": 1,
+    "file_budget_ms": 10000,
+    "axes": ["full", "noedit"],
+    "ratio_definition": "ratio = Go median ns / C median ns, per file; ratio_by_total = sum(Go medians)/sum(C medians) across completing files; ratio_median_of_files = median of per-file ratios. A file that hits the 10s per-attempt budget (wall-clock timeout or memory_budget stop) is excluded from both aggregates and counted in max_timeouts. A file whose Go tree completes but does not cover the full byte range (root.EndByte != len(source), status go_error/truncated) is counted in max_errors -- this is a DISTINCT failure mode from timeouts (silent-truncation-shaped correctness bugs, e.g. haskell/cpp/scala/crystal/typescript below) and is not caught by max_timeouts alone."
+  },
+  "_seed_sources": {
+    "authoritative_20260706T145520Z": "pre-campaign baseline (cgo_harness/perf_scan/out/authoritative_20260706T145520Z)",
+    "after_cliffs_20260706T210143Z": "post-wave-1 snapshot (cgo_harness/perf_scan/out/after_cliffs_20260706T210143Z); generated 2026-07-06T21:01:49Z, which is BEFORE commit 7c04440c (wave-2a arena fix, 2026-07-07T06:17:33Z) and before several wave-2a per-language fixes (php-cliff, java-ratio, kotlin-ratio) landed -- treat its numbers for php/c_sharp/java/kotlin/javascript/typescript as STALE lower bounds on today's real state, not current",
+    "wave2b_green_20260707T0100Z": "fresh re-sweep this pass, HEAD 009c55b9, languages bash/python/ruby/tsx/json/go/cpp/haskell/php, same corpus/order/reps/budget as authoritative -- CONTENDED run (loadavg1=5.10, auto-flagged by the harness), so treat ratios as slightly pessimistic vs a quiet box",
+    "wave2b_js_20260707T0000Z": "fresh re-sweep this pass, HEAD 009c55b9, javascript only, same corpus/order/reps/budget -- clean/uncontended run",
+    "webworker_oracle_spotcheck": "fresh cgo_harness oracle check this pass (BenchmarkParityRealCorpusParseFull/typescript + grammars.TestZZWave2Shape), single file src/lib/webworker.generated.d.ts (786262 bytes), sweeping GOT_PARSE_MEMORY_BUDGET_MB -- not part of the perf_scan sweep, see typescript.notes and known_budget_class_gaps below",
+    "pr142_evidence_and_wave2a_closeout_spore": "prior-agent scratch docs from this same campaign (/tmp .../scratchpad/pr142-evidence.md, spore-wave2a.md) documenting per-file wave-2a wins (php 0/8->8/8 @1.66x, c_sharp DeclaredTypeManager 25.08s->3.10s @8.1x 2/8->5/8 ok, kotlin JobSupport 5036ms->74ms, java DLBF 5.19s->521ms) that are NOT yet reflected in a full re-swept aggregate -- cited in notes where relevant, not used to fabricate an aggregate I did not measure"
+  },
+  "languages": {
+    "php": {
+      "status": "green",
+      "wave2b_pending": false,
+      "measured_today": true,
+      "note": "Wave-2a's 'repetition-shift fork cascade' fix (choose-reduce, C-faithful) resolved php's all-timeout class entirely. Fresh re-sweep today: 8/8 ok, 0 timeouts, 0 truncations. Matches pr142-evidence.md's reported 8/8 @1.66x (this run measured 1.91x/1.90x median on a contended box -- same <=2x bucket).",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 2.5,
+        "observed_ratio_by_total": 1.91,
+        "observed_ratio_median_of_files": 1.90
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0116
+      }
+    },
+    "bash": {
+      "status": "green_with_caveat",
+      "wave2b_pending": true,
+      "measured_today": true,
+      "note": "DEVIATION FROM TASK EXAMPLE, evidence-based: the ~12x/<=1 timeout target is NOT reachable today. Fresh re-sweep: git-gui/git-gui.sh (101KB) still hits the 10s budget every run (go_timeout, iteration_limit or memory_budget depending on run) -- this is the named 'install.sh/eof_no_root residuals' wave-2b backlog item (still in flight per spore-wave2a.md: 'Wave 2b (live at close): ... bash eof_no_root + t1300'). Of the 7 completing files, ratio_by_total=110.1x is dominated by two legitimately-slow-but-completing outliers (t9300-fast-import.sh 1.31s/426x, t6423-merge-rename-directories.sh 1.69s/131x); ratio_median_of_files=39.3x is the more robust number. Budget seeded from median*1.25, NOT from the task's illustrative ~12x, because that number is not comfortably green today. Re-tighten toward the aspirational ~12x once git-gui.sh completes.",
+      "full_axis": {
+        "max_timeouts": 1,
+        "max_errors": 0,
+        "max_ratio_by_total": 140,
+        "max_ratio_median_of_files": 50,
+        "observed_ratio_by_total": 110.11,
+        "observed_ratio_median_of_files": 39.30
+      },
+      "noedit_axis": {
+        "max_timeouts": 1,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0000412
+      }
+    },
+    "python": {
+      "status": "green",
+      "wave2b_pending": false,
+      "measured_today": true,
+      "note": "Fresh re-sweep: 8/8 ok, 0 timeouts, 0 truncations, comfortably under the task's ~25x example.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 25,
+        "observed_ratio_by_total": 17.77,
+        "observed_ratio_median_of_files": 10.65
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0000216
+      }
+    },
+    "ruby": {
+      "status": "green",
+      "wave2b_pending": false,
+      "measured_today": true,
+      "note": "Fresh re-sweep: 8/8 ok, 0 timeouts, 0 truncations.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 5,
+        "observed_ratio_by_total": 3.60,
+        "observed_ratio_median_of_files": 2.21
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00038
+      }
+    },
+    "tsx": {
+      "status": "green",
+      "wave2b_pending": false,
+      "measured_today": true,
+      "note": "Fresh re-sweep: 8/8 ok, 0 timeouts, 0 truncations. Healthiest language in the sweep by completion rate across every snapshot measured this campaign.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 4,
+        "observed_ratio_by_total": 2.59,
+        "observed_ratio_median_of_files": 2.15
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00656
+      }
+    },
+    "json": {
+      "status": "green",
+      "wave2b_pending": false,
+      "measured_today": true,
+      "note": "Fresh re-sweep: 8/8 ok, 0 timeouts, 0 truncations.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 8,
+        "observed_ratio_by_total": 6.91,
+        "observed_ratio_median_of_files": 4.32
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.160
+      }
+    },
+    "go": {
+      "status": "green_with_caveat",
+      "wave2b_pending": true,
+      "measured_today": true,
+      "note": "Ratio comfortably under the task's ~8x example, but 2 real timeouts remain (src/cmd/compile/internal/ssa/opGen.go, rewriteAMD64.go -- both memory_budget stops on generated-code giants), unchanged in kind since wave-1 (was 4 pre-campaign, 3 post-wave-1, 2 today). max_timeouts added explicitly since the task's example gave a ratio-only target; without it this budget would implicitly demand 0 timeouts and be red today.",
+      "full_axis": {
+        "max_timeouts": 2,
+        "max_errors": 0,
+        "max_ratio_by_total": 8,
+        "observed_ratio_by_total": 5.84,
+        "observed_ratio_median_of_files": 2.99
+      },
+      "noedit_axis": {
+        "max_timeouts": 2,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00001
+      }
+    },
+    "cpp": {
+      "status": "green_with_caveat",
+      "wave2b_pending": true,
+      "measured_today": true,
+      "note": "Ratio comfortably under the task's ~3x example. 1 timeout (include/fmt/format.h, memory_budget, unchanged since wave-1) AND 1 silent-truncation error (test/format-test.cc completes 'successfully' -- err==nil, ParseStoppedEarly()==false -- but root.EndByte=36806 of 101572, ~36% span). The truncation is a NEW distinct finding from this pass: max_errors added so a regression that turns more files into silent partial-tree accepts (rather than honest timeouts) is caught.",
+      "full_axis": {
+        "max_timeouts": 1,
+        "max_errors": 1,
+        "max_ratio_by_total": 3,
+        "observed_ratio_by_total": 2.02,
+        "observed_ratio_median_of_files": 1.55
+      },
+      "noedit_axis": {
+        "max_timeouts": 1,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0000739
+      }
+    },
+    "haskell": {
+      "status": "green_with_caveat",
+      "wave2b_pending": true,
+      "measured_today": true,
+      "note": "CAUTION: the ~3x ratio is real but only reflects 1 of 8 giant files -- the completion rate, not the ratio, is haskell's actual health signal. 2 files hit go_timeout (memory_budget), and 5 of 8 (!) hit the SAME silent-truncation shape as cpp's format-test.cc: err==nil, ParseStoppedEarly()==false, but root.EndByte stops at 15-30% of the true span (e.g. Cabal/.../Configure.hs: 23548/118011 bytes). This is a distinct, probably-shared-mechanism correctness bug across at least cpp/haskell/scala/crystal/typescript (see max_errors on each) and is a stronger wave-2b candidate than the ratio number suggests.",
+      "full_axis": {
+        "max_timeouts": 2,
+        "max_errors": 5,
+        "max_ratio_by_total": 3,
+        "observed_ratio_by_total": 1.73,
+        "observed_ratio_median_of_files": 1.73,
+        "observed_files_ok": "1/8 -- ratio is not representative, see note"
+      },
+      "noedit_axis": {
+        "max_timeouts": 2,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00787
+      }
+    },
+    "scala": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1, pre-wave-2a; STALE, not re-swept this pass). 1/8 ok; the completing file's 1.24x is not representative (survivorship of a single easy file). 5 go_timeout + 2 go_error/truncated (RefChecks.scala 115487/115488 -- 1 byte short, likely a boundary/trailing-token bug rather than a budget cliff; bridges.scala 11744/701402 -- severe, ~1.7% span). Known pre-existing gap per wave-1 notes: 'scala PathResolver recovery gap (machine-local gitignored fixture; byte-identical failure on main)'. Prime candidate for wave-2b's proposed 'global repetition-skip rule' (repetition-shift fork cascade, same mechanism class as the php fix, called out in spore-wave2a.md as 'wave-2b #0').",
+      "full_axis": {
+        "max_timeouts": 5,
+        "max_errors": 2,
+        "max_ratio_by_total": 2.0,
+        "observed_ratio_by_total": 1.236,
+        "observed_ratio_median_of_files": 1.236
+      },
+      "noedit_axis": {
+        "max_timeouts": 4,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00313
+      }
+    },
+    "kotlin": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1, pre-wave-2a; STALE). 7/8 ok, 1 go_timeout (BufferedChannel.kt). Wave-2a fixed the safe-navigation ('?.') external-scanner mislex (display-name vs rule-name binding bug -> spurious ERROR -> O(n^2)) fleet-generally via positional-primary binding; per pr142-evidence.md this took JobSupport.kt from 5,036ms to 74ms (node-for-node C parity) -- but that is a single-file data point, not a re-swept aggregate, so the budget below is seeded from the stale after_cliffs aggregate (109.3x by-total / 51.0x median) rather than fabricating a post-fix aggregate. Expect this to tighten substantially at the next full re-sweep.",
+      "full_axis": {
+        "max_timeouts": 1,
+        "max_errors": 0,
+        "max_ratio_by_total": 140,
+        "observed_ratio_by_total": 109.275,
+        "observed_ratio_median_of_files": 51.019
+      },
+      "noedit_axis": {
+        "max_timeouts": 1,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0000928
+      }
+    },
+    "java": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1, pre-wave-2a; STALE). 8/8 ok, 0 timeouts already (best completion rate among the 'pending' set). Wave-2a's java-ratio lane took DefaultListableBeanFactory.java from 5.19s to 521ms (14.8x) per pr142-evidence.md, a single-file data point not yet folded into a re-swept aggregate -- budget below seeded from the stale 46.4x by-total / 32.6x median aggregate. Expect substantial tightening at re-sweep given 0 timeouts today.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 60,
+        "observed_ratio_by_total": 46.370,
+        "observed_ratio_median_of_files": 32.613
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0147
+      }
+    },
+    "c_sharp": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1, pre-wave-2a; STALE and KNOWN OUT OF DATE). after_cliffs shows 1/8 ok, 7 go_timeout (all Bicep.* open-region-quadratic files). Wave-2a's c_sharp lane (C-faithful GSS prefix aggregates + incremental open-region deltas + gate-scan memo) is reported in pr142-evidence.md as already reaching 5/8 ok (DeclaredTypeManager.cs 25.08s->3.10s, 8.1x; truncation witness 41.7s->1.55s) -- i.e. today's real timeout count is very likely ~3, not 7. Budget below intentionally kept at the stale, looser 7-timeout ceiling because I have not personally re-measured the full 8-file aggregate this pass (no fabricated ratio_by_total for the 4 newly-completing files); tighten to the re-swept number at the next full pass rather than trusting this note's arithmetic.",
+      "full_axis": {
+        "max_timeouts": 7,
+        "max_errors": 0,
+        "max_ratio_by_total": 5,
+        "observed_ratio_by_total": 3.656,
+        "observed_ratio_median_of_files": 3.656
+      },
+      "noedit_axis": {
+        "max_timeouts": 7,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00688
+      }
+    },
+    "typescript": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": "partial (webworker.generated.d.ts oracle spot-check only; full 8-file sweep documented from after_cliffs, STALE)",
+      "note": "SEE known_budget_class_gaps.webworker_generated_d_ts BELOW -- this is the headline wave-2b-pending finding of this pass. after_cliffs (pre-arena-fix) full-axis aggregate: 5/8 ok, 1 go_timeout (typescript.d.ts, memory_budget), 2 go_error/truncated (checker.ts 53017/3151774 bytes ~1.7% span; dom.generated.d.ts 101054/2348669 ~4.3% span -- both severe silent truncations). ratio_by_total=25.79x is a 'survivorship optics' artifact per pr141-scoreboard.md: it got numerically WORSE than wave-1's baseline (1.5x) purely because a previously-excluded (timed-out) giant, webworker.generated.d.ts, now finishes (slowly, and per this pass's fresh oracle check, INCORRECTLY at the default budget) and drags the sum up; ratio_median_of_files=1.72x is far less distorted and is the more honest per-file signal. Named wave-1/wave-2 backlog item: 'GOT_FAITHFUL_CONDENSE for the webworker 512MB-budget divergence' -- confirmed still open by this pass's direct oracle re-check.",
+      "full_axis": {
+        "max_timeouts": 1,
+        "max_errors": 2,
+        "max_ratio_by_total": 35,
+        "max_ratio_median_of_files": 3,
+        "observed_ratio_by_total": 25.791,
+        "observed_ratio_median_of_files": 1.720
+      },
+      "noedit_axis": {
+        "max_timeouts": 1,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000001
+      }
+    },
+    "cmake": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1; not touched by any named wave-2a lane, so likely still current, but not re-swept this pass). 4/8 ok, 4 go_timeout, 0 truncation.",
+      "full_axis": {
+        "max_timeouts": 4,
+        "max_errors": 0,
+        "max_ratio_by_total": 90,
+        "observed_ratio_by_total": 71.709,
+        "observed_ratio_median_of_files": 29.652
+      },
+      "noedit_axis": {
+        "max_timeouts": 4,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000217
+      }
+    },
+    "lua": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1; not re-swept this pass). 1/8 ok, 7 go_timeout, 0 truncation. Named wave-2b candidate: 'global repetition-skip rule' (spore-wave2a.md flags lua/crystal/scala/swift/cmake as prime suspects for the same repetition-shift fork cascade mechanism the php fix resolved).",
+      "full_axis": {
+        "max_timeouts": 7,
+        "max_errors": 0,
+        "max_ratio_by_total": 70,
+        "observed_ratio_by_total": 55.765,
+        "observed_ratio_median_of_files": 55.765
+      },
+      "noedit_axis": {
+        "max_timeouts": 7,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000002
+      }
+    },
+    "crystal": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1; not re-swept this pass). 1/8 ok, 3 go_timeout, 3 go_error/truncated -- and the truncations here are severe and suspicious (src/string.cr 49/180451 bytes; src/winerror.cr 19/174453 bytes; src/float/printer/ryu_printf_table.cr 53/345473 bytes -- all stop within the first ~50 bytes). Same silent-truncation shape as cpp/haskell/typescript above; likely a shared root cause worth a dedicated wave-2b investigation rather than five separate ones.",
+      "full_axis": {
+        "max_timeouts": 3,
+        "max_errors": 3,
+        "max_ratio_by_total": 20,
+        "observed_ratio_by_total": 15.875,
+        "observed_ratio_median_of_files": 15.875
+      },
+      "noedit_axis": {
+        "max_timeouts": 3,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.01059
+      }
+    },
+    "swift": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1; not re-swept this pass). 1/8 ok, 7 go_timeout (all SwiftSyntax 'generated' giants), 0 truncation. Wave-2a's kotlin '?.' binding fix is reported (pr142-evidence.md) to have 'defused swift's latent 18-token landmine (->, ??, as?, && bound only via an incidental provenance flag)' as a side effect of the fleet-wide positional-primary rebind -- a single corroborated mechanism claim, not a re-swept aggregate, so not applied to the budget below.",
+      "full_axis": {
+        "max_timeouts": 7,
+        "max_errors": 0,
+        "max_ratio_by_total": 10,
+        "observed_ratio_by_total": 7.409,
+        "observed_ratio_median_of_files": 7.409
+      },
+      "noedit_axis": {
+        "max_timeouts": 7,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000464
+      }
+    },
+    "rust": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": false,
+      "note": "Documented from after_cliffs (post-wave-1; not re-swept this pass). 3/8 ok, 5 go_timeout (all library/stdarch/.../generated.rs SIMD-intrinsic giants), 0 truncation. Was 0/8 (all-timeout) pre-campaign; wave-1 already resurrected 3 completions (avx512fp16.rs, lints.rs among them).",
+      "full_axis": {
+        "max_timeouts": 5,
+        "max_errors": 0,
+        "max_ratio_by_total": 20,
+        "observed_ratio_by_total": 9.932,
+        "observed_ratio_median_of_files": 16.343
+      },
+      "noedit_axis": {
+        "max_timeouts": 5,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000002
+      }
+    },
+    "javascript": {
+      "status": "wave2b_pending",
+      "wave2b_pending": true,
+      "measured_today": true,
+      "note": "FRESH re-sweep this pass (clean/uncontended box, post-arena-fix): 3/8 ok, 5 go_timeout, 0 truncation. deps/undici/undici.js (774KB) now reliably completes (18.0x this run) -- a genuine, reproducible transition, unchanged from the wave-1 snapshot. deps/v8/test/mjsunit/{asm,wasm}/embenchen/box2d.js and lua_binarytrees.js STILL hit go_timeout with reason=memory_budget on every rep despite the wave-2a arena fix (-27% arena bytes); deps/v8/test/mjsunit/asm/poppler/poppler.js still hits a raw wall-clock timeout (reason=timeout, not memory) -- C itself takes ~2s on this file, so it is a genuine throughput cliff, not a budget cliff. The wave-2a arena fix's own validation (pr142-evidence.md: 'javascript asm.js memory_budget ... 120k-stmt witness completes at default budget') was against a synthetic stress witness plus jquery, not these specific real-corpus giants -- this pass's finding is that the real-corpus worst files are NOT yet resolved by that fix and remain a distinct wave-2b item.",
+      "full_axis": {
+        "max_timeouts": 5,
+        "max_errors": 0,
+        "max_ratio_by_total": 18,
+        "observed_ratio_by_total": 14.402,
+        "observed_ratio_median_of_files": 12.521
+      },
+      "noedit_axis": {
+        "max_timeouts": 5,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000034
+      }
+    }
+  },
+  "known_budget_class_gaps": {
+    "webworker_generated_d_ts": {
+      "file": "typescript/src/lib/webworker.generated.d.ts (786262 bytes, largest .d.ts in the corpus sample)",
+      "backlog_ref": "named wave-1/wave-2 backlog item 'GOT_FAITHFUL_CONDENSE for the webworker 512MB-budget divergence' (pr141-scoreboard.md) -- CONFIRMED STILL OPEN by this pass",
+      "pre_arena_fix": "reported to pass the cgo_harness byte-shape oracle (root-type + child-count structural match against the C reference) at GOT_PARSE_MEMORY_BUDGET_MB=1024, per the task brief for this pass",
+      "post_arena_fix_today": {
+        "default_512mb": "FAILS the byte-shape oracle: BenchmarkParityRealCorpusParseFull/typescript verify step reports 'structural parity mismatch ... first=/ERROR type go=ERROR c=program, root: ChildCount go=330 c=1484'. Independently reproduced via grammars.TestZZWave2Shape (Go-only, no C compare): root=ERROR, hasErr=true, span=[0,786262) (full byte range covered -- NOT a truncation), dur=24.164s wall time with no timeout set, i.e. this is a genuine memory-budget-exhaustion degradation, not a hang.",
+        "576mb": "FAILS, same root=ERROR shape",
+        "640mb": "PASSES cleanly (root types match, byte-shape oracle green); Go full parse 8.68-9.19s vs C 90-101ms in this pass's runs (~86-102x, single-sample benchtime=1x, not a scoreboard median)",
+        "1024mb": "PASSES cleanly (same as 640MB; arena_B/op metric reports ~695.8MB for a successful parse at this pass's HEAD, down from an implied ~950MB-1GB pre-arena-fix, consistent with wave-2a's claimed -27% arena reduction)",
+        "threshold_bound": "minimum sufficient budget is in (576, 640] MB today, versus needing ~1024MB pre-fix -- real, substantial improvement, but the file remains BROKEN at the shipped 512MB default"
+      },
+      "perf_scan_sweep_caveat": "perf_scan's own scoreboards report 'status=ok' for this file (e.g. after_cliffs: go_median=10.47s, ratio=165.5x, verdict=cliff>10x) at whatever ambient GOT_PARSE_MEMORY_BUDGET_MB was in effect for that run. This is TIMING-GRADE ONLY per the harness's own README ('the scan is timing-grade, not correctness-grade'): perf_scan's status=ok means 'produced a tree spanning the full input inside the wall-clock file budget', not 'structurally correct'. Do not read a perf_scan 'ok' verdict on this file (or its siblings dom.generated.d.ts/checker.ts, which show the identical silent-truncation shape) as a correctness signal -- always cross-check the byte-shape oracle (BenchmarkParityRealCorpusParseFull's pre-benchmark verify step, or forest_oracle_parity_test.go) for giants in this class.",
+      "action": "typescript's full_axis budget above is intentionally NOT tightened to reflect a 'fixed' webworker.generated.d.ts; GOT_FAITHFUL_CONDENSE (or an equivalent default-budget-aware condense path) remains a real wave-2b item."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Introduces a fast perf ratio budget ratchet and CI check to prevent regressions in perf_scan relative to the C reference. A new tool validates the checked-in budget schema and can compare scoreboards, failing on ratio, timeout, truncation/error, or C-reference regressions. This seeds per-language budgets (20 languages) with provenance-backed measurement settings and updates docs for generating and checking scoreboards. CI adds a lightweight job that runs the tool and its unit tests and gates the build on success.

## Changes

- Add cgo_harness/cmd/perf_scan_budget: CLI to validate the checked-in perf ratio budget and compare perf_scan scoreboards against it; exits non-zero on violations and can emit a Markdown summary
- Gate metrics: ratio_by_total, ratio_median_of_files, Go timeouts, Go errors/truncations, and C-reference failures; supports -langs filtering, -require-all-budget-langs, -strict-config, and -out-md
- Seed cgo_harness/perf_scan/perf_ratio_budgets.json with per-language ratchet budgets for 20 languages, including structured measurement_basis metadata (reps=5, warmup=1, file_budget_ms=10000, max_files=8, order=largest, axes=full,noedit)
- Add unit tests for the checker (validation of current budget file, within-budget pass, regression detection, language presence checks, and summary write-out)
- Update .github/workflows/ci.yml: add perf_scan_budget job that runs the checker tests and validates the budget; wire its result into the build aggregator via require_success
- Revise perf_scan/README.md: document the ratio-budget ratchet, usage examples for validation/compare, strict knobs for generating scoreboards, and targeted language refresh
- Revise perf_scan/CI_PROPOSAL.md: clarify fast PR lane vs nightly sweep, add budget-compare step, adjust recommended knobs (max_files=8, reps=5), and note non-blocking nightly behavior

## Testing

- Local quick check: cd cgo_harness && GOWORK=off go test ./cmd/perf_scan_budget -count=1
- Validate budget only: cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json (expect PASS with empty findings)
- Compare against a scoreboard: cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json -scoreboard perf_scan/out/<run>/scoreboard.json -require-all-budget-langs -out-md perf_scan/out/<run>/budget.md (expect non-zero exit on regressions and a Markdown summary)
- Filter to a language: cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json -scoreboard perf_scan/out/<run>/scoreboard.json -langs go
- CI: verify new perf_scan_budget job runs in ~<5m>, and that the build aggregator requires perf_scan_budget to succeed
- Optional: generate a scoreboard with the documented knobs (reps=5, warmup=1, file_budget_ms=10000, max_files=8, order=largest; axes full,noedit) and confirm the tool passes; then intentionally increase a ratio to observe a failing exit

## Review Focus

Focus review on: 1) the budget JSON schema and measurement_basis values; 2) checker logic for how findings are produced and which metrics are gated; 3) the default StrictConfig behavior (scoreboard knobs must match the budget unless explicitly disabled); and 4) the CI wiring (new perf_scan_budget job and its aggregation into the build gate). The large JSON budget file is data-only—spot-check a few representative languages and caveat notes. If your scoreboard generation flow uses different knobs, confirm whether we should keep StrictConfig=true by default or relax it.