### PR TITLE
CI: split slow grammar race lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,11 @@ jobs:
           - name: cmd
             package_filter: '/cmd/'
           - name: grammars
-            package_filter: '/grammars$|/grammargen/|/parser_result_test$'
+            package_filter: '/grammars$'
+          - name: grammargen-support
+            package_filter: '/grammargen/'
+          - name: parser-result
+            package_filter: '/parser_result_test$'
           - name: support
             package_filter: '/grep$|/taproot($|/)'
     steps:
@@ -83,7 +87,9 @@ jobs:
         # Keep each lane serialized under -race so timing-sensitive tests do
         # not contend with each other on 2-core hosted runners, but split the
         # former all-non-root sweep into package groups so the wall clock stays
-        # near the target 10-minute envelope.
+        # near the target 10-minute envelope. Keep parser-result and grammargen
+        # support out of the grammar registry lane; together they made the
+        # aggregate race shard sit near the timeout cap even for data-only PRs.
         # ./grammargen stays visibility-only until its enumerated backlog is
         # burned down and folded back into the blocking suite.
         run: |
@@ -106,7 +112,7 @@ jobs:
   grammargen_visibility:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
 
@@ -121,7 +127,7 @@ jobs:
         # check rollup while the blocking build gate has already passed.
         run: |
           set +e
-          go test ./grammargen -race -count=1 -timeout 10m
+          go test ./grammargen -race -count=1 -timeout 6m
           status=$?
           set -e
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             {
               echo "### Grammargen Visibility"
               echo
-              echo "\`go test ./grammargen -race -count=1 -timeout 10m\` exited with status \`${status}\`."
+              echo "\`go test ./grammargen -race -count=1 -timeout 6m\` exited with status \`${status}\`."
               echo
               echo "This job is informational until the known grammargen backlog is zeroed."
             } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- split the slow `race_packages` grammar shard into separate `grammars`, `grammargen-support`, and `parser-result` lanes
- keep the same package-selection script and coverage, but let those lanes run independently in the existing matrix
- cap the non-blocking `grammargen_visibility` job at 8 minutes with a 6-minute Go test timeout so it cannot hold the rollup open past the target window

## Why
PR #167 showed the grammar race shard and grammargen visibility job both taking about 11 minutes (`race_packages (grammars)` 11m13s, `grammargen_visibility` 11m16s). That is acceptable but too close to the stated ~10-minute PR loop target.

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- simulated the workflow package selection for all matrix lanes with `go list ./...` and the same awk exclusions

## Notes
- Buckley commit succeeded: `bef194e6`
- `buckley pr -yes -base main` was attempted first, but failed before PR creation with `unmarshal tool call: invalid character ' ' in numeric literal`; this PR was opened with `gh` as fallback.\n