### PR TITLE
Perf scan: add Wave 3 batch 3 budgets

### DIFF
--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -16,8 +16,8 @@
     "that isn't green today is worse than useless."
   ],
   "schema": "gts-perf-ratio-budgets/v1",
-  "generated_at": "2026-07-08T21:18:48Z",
-  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/fleet-perf-batch2, extending the wave-2b budget with batch-1 and batch-2 measurements through HEAD 3426d5f9",
+  "generated_at": "2026-07-08T21:39:18Z",
+  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/fleet-perf-batch3, extending the wave-2b budget with batch-1 through batch-3 measurements through HEAD 06e2b8e9",
   "measurement_basis": {
     "harness": "cgo_harness/perf_scan (TestPerfScanSweep / TestPerfScanLanguage, tags treesitter_c_parity treesitter_c_perfscan)",
     "corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources (real upstream per-language checkouts, largest-8-files sampling -- deliberately adversarial, hunts cliffs, NOT representative of typical file size)",
@@ -40,7 +40,8 @@
     "webworker_oracle_spotcheck": "fresh cgo_harness oracle check this pass (BenchmarkParityRealCorpusParseFull/typescript + grammars.TestZZWave2Shape), single file src/lib/webworker.generated.d.ts (786262 bytes), sweeping GOT_PARSE_MEMORY_BUDGET_MB -- not part of the perf_scan sweep, see typescript.notes and known_budget_class_gaps below",
     "pr142_evidence_and_wave2a_closeout_spore": "prior-agent scratch docs from this same campaign (/tmp .../scratchpad/pr142-evidence.md, spore-wave2a.md) documenting per-file wave-2a wins (php 0/8->8/8 @1.66x, c_sharp DeclaredTypeManager 25.08s->3.10s @8.1x 2/8->5/8 ok, kotlin JobSupport 5036ms->74ms, java DLBF 5.19s->521ms) that are NOT yet reflected in a full re-swept aggregate -- cited in notes where relevant, not used to fabricate an aggregate I did not measure",
     "wave3_batch1_20260708T202820Z": "first Wave-3 fleet batch on HEAD edf04d84, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit), languages c/css/html/sql/toml/yaml/zig/elixir/graphql/hcl. SQL is intentionally NOT budgeted from this run because its child exited early with signal:killed after 4/8 files and the Docker wrapper reported oom_killed=true; keep it as a measured ledger item until a complete row or an explicit language-status budget policy exists.",
-    "wave3_batch2_20260708T211248Z": "second Wave-3 fleet batch on HEAD 3426d5f9, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit), languages nix/dart/elm/erlang/gomod/ini/json5/julia/make/markdown. All ten language subprocesses completed; dart and julia retain explicit timeout budgets, julia also retains flagged truncation/error budgets, and json5/ini are thin-corpus rows rather than broad coverage claims."
+    "wave3_batch2_20260708T211248Z": "second Wave-3 fleet batch on HEAD 3426d5f9, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit), languages nix/dart/elm/erlang/gomod/ini/json5/julia/make/markdown. All ten language subprocesses completed; dart and julia retain explicit timeout budgets, julia also retains flagged truncation/error budgets, and json5/ini are thin-corpus rows rather than broad coverage claims.",
+    "wave3_batch3_20260708T213644Z": "third Wave-3 fleet batch on HEAD 06e2b8e9, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit), languages ada/agda/angular/apex/arduino/asm/astro/authzed/awk/cobol. All ten language subprocesses completed; angular and asm retain explicit timeout budgets, ada/angular/asm/awk are measured cliff backlog rows, and cobol is now cleanly budgeted at <=2x."
   },
   "languages": {
     "php": {
@@ -775,6 +776,206 @@
         "max_errors": 0,
         "max_ratio_by_total": 1.0,
         "observed_ratio_by_total": 0.000468
+      }
+    },
+    "ada": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8/8 files measured, 0 timeouts, 0 truncations, aggregate full parse 6.17x with two genuine >10x cliffs in si4432 Ada files. This is a measured throughput backlog row.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 8.0,
+        "max_ratio_median_of_files": 3.3,
+        "observed_ratio_by_total": 6.169,
+        "observed_ratio_median_of_files": 2.616
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00542
+      }
+    },
+    "agda": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8 files selected; 5 full-axis files produced ratio aggregates at 3.21x, 0 timeouts, and 3 files returned flagged truncation go_errors (SlowOccurrences2.agda, ReflectionWellScoped.agda, ReflectionWellScopedList.agda). This is both a measured >2x backlog row and a named correctness-gap budget row.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 3,
+        "max_ratio_by_total": 4.1,
+        "max_ratio_median_of_files": 2.7,
+        "observed_ratio_by_total": 3.211,
+        "observed_ratio_median_of_files": 2.098
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 3,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0000276
+      }
+    },
+    "angular": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8 files selected; 7 full-axis files produced ratio aggregates, one home-animation component hit node_limit on full and noedit base parse, and two completing HTML files are genuine >10x cliffs. This is a measured Angular-template throughput and node-budget backlog row.",
+      "full_axis": {
+        "max_timeouts": 1,
+        "max_errors": 0,
+        "max_ratio_by_total": 20,
+        "max_ratio_median_of_files": 2.3,
+        "observed_ratio_by_total": 15.419,
+        "observed_ratio_median_of_files": 1.769
+      },
+      "noedit_axis": {
+        "max_timeouts": 1,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00269
+      }
+    },
+    "apex": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8/8 files measured, 0 timeouts, 0 truncations, aggregate full parse 2.79x. This is a measured >2x backlog row.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 3.6,
+        "max_ratio_median_of_files": 3.1,
+        "observed_ratio_by_total": 2.794,
+        "observed_ratio_median_of_files": 2.443
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00950
+      }
+    },
+    "arduino": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): only 2 files selected by the corpus lock (3948 bytes total), 0 timeouts, 0 truncations, full parse within <=2x. This is a thin-corpus but clean ratchet row.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 2.0,
+        "max_ratio_median_of_files": 2.0,
+        "observed_ratio_by_total": 1.541,
+        "observed_ratio_median_of_files": 1.558
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00490
+      }
+    },
+    "asm": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8 files selected; 7 full-axis files completed but all 8 selected files are cliff-class, and arch/powerpc/cpu/mpc85xx/start.S hit memory_budget on full and noedit base parse. This is a severe measured throughput and memory-budget backlog row.",
+      "full_axis": {
+        "max_timeouts": 1,
+        "max_errors": 0,
+        "max_ratio_by_total": 180,
+        "max_ratio_median_of_files": 185,
+        "observed_ratio_by_total": 140.414,
+        "observed_ratio_median_of_files": 146.091
+      },
+      "noedit_axis": {
+        "max_timeouts": 1,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00000347
+      }
+    },
+    "astro": {
+      "status": "green",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8/8 files measured, 0 timeouts, 0 truncations, full parse within <=2x.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.9,
+        "max_ratio_median_of_files": 1.9,
+        "observed_ratio_by_total": 1.483,
+        "observed_ratio_median_of_files": 1.510
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0111
+      }
+    },
+    "authzed": {
+      "status": "green",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8/8 files measured, 0 timeouts, 0 truncations, full parse within <=2x.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.6,
+        "max_ratio_median_of_files": 2.2,
+        "observed_ratio_by_total": 1.247,
+        "observed_ratio_median_of_files": 1.753
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.411
+      }
+    },
+    "awk": {
+      "status": "green_with_caveat",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8/8 files measured, 0 timeouts, 0 truncations, but aggregate full parse is dominated by one extreme cliff in testdir/funstack.awk (247x). This is a measured throughput backlog row.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 190,
+        "max_ratio_median_of_files": 3.6,
+        "observed_ratio_by_total": 149.805,
+        "observed_ratio_median_of_files": 2.798
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.00133
+      }
+    },
+    "cobol": {
+      "status": "green",
+      "wave3_batch3": true,
+      "measured_today": true,
+      "note": "Wave-3 batch-3 authoritative sweep (wave3_batch3_20260708T213644Z): 8/8 files measured, 0 timeouts, 0 truncations, full parse within <=2x. This closes cobol's perf ratchet row cleanly.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.8,
+        "max_ratio_median_of_files": 1.8,
+        "observed_ratio_by_total": 1.379,
+        "observed_ratio_median_of_files": 1.364
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.0000241
       }
     }
   },


### PR DESCRIPTION
## Summary
- add Wave 3 batch-3 perf budget rows for ada, agda, angular, apex, arduino, asm, astro, authzed, awk, and cobol
- document the batch-3 seed source from Docker run wave3_batch3_20260708T213644Z
- mark agda truncation errors, angular/asm timeout rows, and severe asm/awk throughput cliffs explicitly
- add cobol as a clean <=2x perf ratchet row: 8/8 files, 0 timeouts, 0 truncations

## Validation
- Docker smoke perf scan for the 10-language batch: PASS
- Docker authoritative perf scan for the 10-language batch: PASS, no OOM kill
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json`: PASS
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json -scoreboard perf_scan/out/wave3_batch3_20260708T213644Z/scoreboard.json -langs ada,agda,angular,apex,arduino,asm,astro,authzed,awk,cobol`: PASS
- `cd cgo_harness && GOWORK=off go test ./cmd/perf_scan_budget -count=1`: PASS
- `git diff --check`: PASS

## Notes
- Buckley authored and pushed the commit (`buckley commit -yes`).
- `buckley pr -yes -base main` was attempted first but failed before PR creation with `unmarshal tool call: invalid character ' ' in numeric literal`; this PR was opened with `gh` as the publish fallback.