### PR TITLE
ci: trigger exhaustive CGo parity on parser-result/recovery PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,49 @@ jobs:
           GOWORK=off go run ./cmd/perf_scan_budget \
             -budget perf_scan/perf_ratio_budgets.json
 
+  exhaustive_parity_scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_exhaustive: ${{ steps.scope.outputs.run_exhaustive }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: scope
+        name: Detect exhaustive parity scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          run_exhaustive=false
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run_exhaustive=true
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            git diff --name-only "${PR_BASE_SHA}...HEAD" > /tmp/changed-files.txt
+            if grep -Eq '^(parser_result_.*\.go|parser_recover_c.*\.go|parser_result_test/.*\.go)$' /tmp/changed-files.txt; then
+              run_exhaustive=true
+              {
+                echo "### Exhaustive parity trigger"
+                echo
+                echo "Running exhaustive CGo parity because this PR touches parser-result or C-recovery files:"
+                echo
+                grep -E '^(parser_result_.*\.go|parser_recover_c.*\.go|parser_result_test/.*\.go)$' /tmp/changed-files.txt | sed 's/^/- `/' | sed 's/$/`/'
+              } >> "$GITHUB_STEP_SUMMARY"
+            else
+              {
+                echo "### Exhaustive parity trigger"
+                echo
+                echo "No parser-result or C-recovery files changed; exhaustive CGo parity is skipped."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+          echo "run_exhaustive=${run_exhaustive}" >> "$GITHUB_OUTPUT"
+
   build:
     needs:
       - compile
@@ -204,6 +247,8 @@ jobs:
       - draft_focused_tests
       - parity_report
       - perf_scan_budget
+      - exhaustive_parity_scope
+      - parity-cgo-exhaustive
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -217,6 +262,9 @@ jobs:
           DRAFT_FOCUSED_RESULT: ${{ needs.draft_focused_tests.result }}
           PARITY_REPORT_RESULT: ${{ needs.parity_report.result }}
           PERF_SCAN_BUDGET_RESULT: ${{ needs.perf_scan_budget.result }}
+          EXHAUSTIVE_PARITY_SCOPE_RESULT: ${{ needs.exhaustive_parity_scope.result }}
+          EXHAUSTIVE_PARITY_SCOPE: ${{ needs.exhaustive_parity_scope.outputs.run_exhaustive }}
+          EXHAUSTIVE_PARITY_RESULT: ${{ needs.parity-cgo-exhaustive.result }}
         run: |
           set -euo pipefail
           failed=0
@@ -233,12 +281,17 @@ jobs:
           require_success "compile" "$COMPILE_RESULT"
           require_success "parity_report" "$PARITY_REPORT_RESULT"
           require_success "perf_scan_budget" "$PERF_SCAN_BUDGET_RESULT"
+          require_success "exhaustive_parity_scope" "$EXHAUSTIVE_PARITY_SCOPE_RESULT"
 
           if [ "$IS_DRAFT" = "true" ]; then
             require_success "draft_focused_tests" "$DRAFT_FOCUSED_RESULT"
           else
             require_success "race_root" "$RACE_ROOT_RESULT"
             require_success "race_packages" "$RACE_PACKAGES_RESULT"
+          fi
+
+          if [ "$EXHAUSTIVE_PARITY_SCOPE" = "true" ]; then
+            require_success "parity-cgo-exhaustive" "$EXHAUSTIVE_PARITY_RESULT"
           fi
 
           if [ "$failed" -ne 0 ]; then
@@ -402,7 +455,8 @@ jobs:
             --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$'
 
   parity-cgo-exhaustive:
-    if: github.event_name == 'workflow_dispatch'
+    needs: exhaustive_parity_scope
+    if: needs.exhaustive_parity_scope.outputs.run_exhaustive == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
## Summary

Previously, the exhaustive CGo parity job only ran on manual `workflow_dispatch` triggers, meaning PRs touching critical parser-result or C-recovery files could merge without full parity validation. This PR introduces an `exhaustive_parity_scope` job that conditionally triggers exhaustive parity on PRs when changed files match parser-result or C-recovery patterns, and wires it into the build gate so those PRs are blocked until parity passes.

## Changes

- Add `exhaustive_parity_scope` job that detects whether exhaustive CGo parity should run — always on `workflow_dispatch`, and on PRs only when changed files match `parser_result_*.go`, `parser_recover_c*.go`, or `parser_result_test/*.go`
- Rework `parity-cgo-exhaustive` to depend on the scope job (`needs: exhaustive_parity_scope`) and gate on `run_exhaustive == 'true'` instead of hardcoding `workflow_dispatch` only
- Update the `build` gate to always wait on and require `exhaustive_parity_scope`, and conditionally require `parity-cgo-exhaustive` only when the scope job signals exhaustive should run
- Add a GITHUB_STEP_SUMMARY block showing which files triggered (or why it skipped) exhaustive parity for PR transparency

## Testing

- Open a PR that modifies a file like `parser_result_tree.go` — verify `exhaustive_parity_scope` outputs `run_exhaustive=true` and `parity-cgo-exhaustive` runs and is required by the `build` gate.
- Open a PR that only touches unrelated files (e.g., a README or a non-parser `.go` file) — verify `exhaustive_parity_scope` outputs `run_exhaustive=false`, `parity-cgo-exhaustive` is skipped, and the `build` gate still passes.
- Trigger the workflow via `workflow_dispatch` — verify `exhaustive_parity_scope` sets `run_exhaustive=true` and `parity-cgo-exhaustive` runs as before.
- Inspect the PR's job summary (GITHUB_STEP_SUMMARY) to confirm the trigger rationale is displayed correctly.

## Review Focus

Pay attention to the grep regex pattern (`^(parser_result_.*\.go|parser_recover_c.*\.go|parser_result_test/.*\.go)$`) — make sure it matches the intended file naming conventions and doesn't accidentally match unrelated files. Also verify that the `build` gate correctly handles the case where `parity-cgo-exhaustive` is skipped (result will be 'skipped', not 'success').