### PR TITLE
fix(cobol): Align if-header EXEC CICS error parity with C parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,39 +493,59 @@ jobs:
 
       - name: CGo Structural Parity Exhaustive (Fresh + No Errors + Issue3)
         run: |
-          cd cgo_harness
           GTS_PARITY_MODE=exhaustive \
-          go test . -tags treesitter_c_parity \
-            -run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$' \
-            -timeout=30m \
-            -count=1 -v
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-parity-cgo-exhaustive-fresh \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --timeout 30m \
+            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$'
 
       - name: CGo Structural Parity Exhaustive (Incremental + GLR)
         run: |
-          cd cgo_harness
           GTS_PARITY_MODE=exhaustive \
-          go test . -tags treesitter_c_parity \
-            -run '^TestParityIncrementalParse$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$' \
-            -timeout=30m \
-            -count=1 -v
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-parity-cgo-exhaustive-incremental \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --timeout 30m \
+            --run '^TestParityIncrementalParse$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$'
 
       - name: CGo Structural Parity Exhaustive (Corpus)
         run: |
-          cd cgo_harness
           GTS_PARITY_MODE=exhaustive \
-          go test . -tags treesitter_c_parity \
-            -run '^TestParityCorpusFreshParse$' \
-            -timeout=30m \
-            -count=1 -v
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-parity-cgo-exhaustive-corpus \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --timeout 30m \
+            --run '^TestParityCorpusFreshParse$'
 
       - name: CGo Highlight + YAML Parity Exhaustive
         run: |
-          cd cgo_harness
           GTS_PARITY_MODE=exhaustive \
-          go test . -tags treesitter_c_parity \
-            -run '^TestParityHighlight$|^TestParityHighlightAllGrammars$|^TestParityYAMLCorpus$|^TestParityYAMLCorpusStructural$|^TestParityYAMLCorpusSummary$' \
-            -timeout=30m \
-            -count=1 -v
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-parity-cgo-exhaustive-highlight-yaml \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --timeout 30m \
+            --run '^TestParityHighlight$|^TestParityHighlightAllGrammars$|^TestParityYAMLCorpus$|^TestParityYAMLCorpusStructural$|^TestParityYAMLCorpusSummary$'
 
   perf-regression:
     if: github.event_name == 'pull_request'

--- a/cgo_harness/cobol_cgo_regression_test.go
+++ b/cgo_harness/cobol_cgo_regression_test.go
@@ -109,7 +109,91 @@ func TestCobolCGOTrailingTriviaSpans(t *testing.T) {
 			var errs []string
 			compareNodes(goRoot, goLang, cRoot, "root", &errs)
 			if len(errs) > 0 {
-				t.Fatalf("go-vs-C divergences:\n%s\n\ngo:\n%s\n\nc:\n%s", joinTopErrors(errs), goRoot.SExpr(goLang), dumpCTree(cRoot, 0))
+				t.Fatalf("go-vs-C divergences:\n%s\n\ngo:\n%s\n\ngo spans:\n%s\n\nc:\n%s", joinTopErrors(errs), goRoot.SExpr(goLang), dumpGoTree(goRoot, goLang, 0), dumpCTree(cRoot, 0))
+			}
+		})
+	}
+}
+
+func TestCobolCGOErrorOracleParity(t *testing.T) {
+	goLang := grammars.CobolLanguage()
+	cLang, err := ParityCLanguage("cobol")
+	if err != nil {
+		t.Skipf("C parser unavailable: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("C SetLanguage: %v", err)
+	}
+	goParser := gotreesitter.NewParser(goLang)
+
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "exec_cics_tail_after_clean_prefix",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"      * Procedure comment\n" +
+				"           MOVE SPACES TO ABEND-REASON\n" +
+				"           COPY CABENDPO.\n" +
+				"           IF BANK-MAP-FUNCTION-GET\n" +
+				"              EXEC CICS LINK PROGRAM(X)\n",
+		},
+		{
+			name: "move_led_exec_tail_retains_error",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"      * Procedure comment\n" +
+				"           MOVE A TO B\n" +
+				"           IF FLAG\n" +
+				"              EXEC CICS RETURN\n",
+		},
+		{
+			name: "z_literal_data_root_recovery_retains_error",
+			src: "       data division.\n" +
+				"       working-storage section.\n" +
+				"       01  OK PIC X.\n" +
+				"       01  BAD PIC X(120)\n" +
+				"           VALUE Z'HELLO'.\n" +
+				"      * banner\n" +
+				"       procedure division.\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			goTree, err := goParser.Parse(src)
+			if err != nil {
+				t.Fatalf("go parse: %v", err)
+			}
+			goRoot := goTree.RootNode()
+			if goRoot == nil {
+				t.Fatal("go nil root")
+			}
+
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C nil tree")
+			}
+			defer cTree.Close()
+			cRoot := cTree.RootNode()
+			if !cRoot.HasError() {
+				t.Fatalf("C root has no error; adversarial fixture no longer exercises error parity:\n%s", dumpCTree(cRoot, 0))
+			}
+			if !goRoot.HasError() {
+				t.Fatalf("go root swallowed C error signal:\n\ngo:\n%s\n\nc:\n%s", goRoot.SExpr(goLang), dumpCTree(cRoot, 0))
+			}
+
+			var errs []string
+			compareNodes(goRoot, goLang, cRoot, "root", &errs)
+			if len(errs) > 0 {
+				t.Fatalf("go-vs-C divergences:\n%s\n\ngo:\n%s\n\ngo spans:\n%s\n\nc:\n%s", joinTopErrors(errs), goRoot.SExpr(goLang), dumpGoTree(goRoot, goLang, 0), dumpCTree(cRoot, 0))
 			}
 		})
 	}

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -15,6 +15,7 @@ func normalizeCobolCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeCobolProcedureLooseIfHeaders(root, source, lang)
 	normalizeCobolLeadingAreaStart(root, source, lang)
 	normalizeCobolTopLevelDefinitionEnd(root, source, lang)
+	normalizeCobolIfHeaderExecCICSClassErrors(root, source, lang)
 	normalizeCobolRootProgramDefinitionSiblingEnds(root, source, lang)
 	normalizeCobolDivisionSiblingEnds(root, source, lang)
 	normalizeCobolSectionSiblingEnds(root, source, lang)
@@ -25,6 +26,7 @@ func normalizeCobolCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeCobolProcedureTrailingParagraphCommentEntry(root, source, lang)
 	normalizeCobolProcedureTrailingExecCICSSpans(root, source, lang)
 	normalizeCobolRootExecCICSErrorMarkers(root, source, lang)
+	normalizeCobolIfHeaderExecCICSProgramEnd(root, source, lang)
 }
 func normalizeCobolLeadingAreaStart(root *Node, source []byte, lang *Language) {
 	if root == nil || !isCobolLanguage(lang) || len(source) == 0 {
@@ -1061,6 +1063,165 @@ func cobolIfKeywordStartBefore(source []byte, operandStart uint32) (uint32, bool
 		}
 	}
 	return kwStart, true
+}
+
+func normalizeCobolIfHeaderExecCICSClassErrors(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || len(source) == 0 {
+		return
+	}
+	program := cobolFirstProgramDefinition(root, lang)
+	if program == nil {
+		return
+	}
+	changed := false
+	for i := 0; i < resultChildCount(program); i++ {
+		child := resultChildAt(program, i)
+		if child == nil || child.IsExtra() || child.IsError() || child.IsMissing() || child.Type(lang) != "procedure_division" {
+			continue
+		}
+		if normalizeCobolProcedureIfHeaderExecCICSClassErrors(child, source, lang) {
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+	if proc := cobolLastChildOfType(program, lang, "procedure_division"); proc != nil && proc.endByte > program.endByte {
+		setCobolNodeEnd(program, source, proc.endByte)
+	}
+	cobolRefreshHasErrorFromChildren(program)
+	cobolRefreshHasErrorFromChildren(root)
+}
+
+func normalizeCobolIfHeaderExecCICSProgramEnd(root *Node, source []byte, lang *Language) {
+	if root == nil || !isCobolLanguage(lang) || root.Type(lang) != "start" || len(source) == 0 {
+		return
+	}
+	program := cobolFirstProgramDefinition(root, lang)
+	if program == nil {
+		return
+	}
+	proc := cobolLastChildOfType(program, lang, "procedure_division")
+	if proc == nil || proc.endByte <= program.endByte || !cobolProcedureHasIfHeaderExecCICSClassError(proc, source, lang) {
+		return
+	}
+	setCobolNodeEnd(program, source, proc.endByte)
+	cobolRefreshHasErrorFromChildren(program)
+	cobolRefreshHasErrorFromChildren(root)
+}
+
+func cobolProcedureHasIfHeaderExecCICSClassError(proc *Node, source []byte, lang *Language) bool {
+	for i := 0; i < resultChildCount(proc); i++ {
+		child := resultChildAt(proc, i)
+		if child == nil || child.IsExtra() || child.IsMissing() || child.Type(lang) != "if_header" || !child.hasError() {
+			continue
+		}
+		if _, _, _, ok := cobolIfHeaderExecCICSBounds(child, source); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeCobolProcedureIfHeaderExecCICSClassErrors(proc *Node, source []byte, lang *Language) bool {
+	changed := false
+	for i := 0; i < resultChildCount(proc); i++ {
+		child := resultChildAt(proc, i)
+		if child == nil || child.IsExtra() || child.IsError() || child.IsMissing() || child.Type(lang) != "if_header" {
+			continue
+		}
+		if normalizeCobolIfHeaderExecCICSClassError(child, source, lang) {
+			changed = true
+		}
+	}
+	if changed {
+		cobolRefreshHasErrorFromChildren(proc)
+	}
+	return changed
+}
+
+func normalizeCobolIfHeaderExecCICSClassError(header *Node, source []byte, lang *Language) bool {
+	if header == nil || header.hasError() || int(header.endByte) > len(source) {
+		return false
+	}
+	execStart, cicsStart, cicsEnd, ok := cobolIfHeaderExecCICSBounds(header, source)
+	if !ok {
+		return false
+	}
+	condition := cobolFirstDescendantOfTypeBefore(header, lang, "qualified_word", execStart)
+	if condition == nil {
+		return false
+	}
+	exprSym, ok := symbolByName(lang, "expr")
+	if !ok {
+		return false
+	}
+	isClassSym, ok := symbolByName(lang, "is_class")
+	if !ok {
+		return false
+	}
+	wordSym, ok := symbolByName(lang, "WORD")
+	if !ok {
+		return false
+	}
+
+	execEnd := execStart + uint32(len("EXEC"))
+	err := newLeafNodeInArena(header.ownerArena, errorSymbol, true, execStart, execEnd, advancePointByBytes(Point{}, source[:execStart]), advancePointByBytes(Point{}, source[:execEnd]))
+	err.setHasError(true)
+	cicsWord := newLeafNodeInArena(header.ownerArena, wordSym, symbolIsNamed(lang, wordSym), cicsStart, cicsEnd, advancePointByBytes(Point{}, source[:cicsStart]), advancePointByBytes(Point{}, source[:cicsEnd]))
+	isClass := newParentNodeInArena(header.ownerArena, isClassSym, symbolIsNamed(lang, isClassSym), []*Node{condition, err, cicsWord}, nil, 0)
+	expr := newParentNodeInArena(header.ownerArena, exprSym, symbolIsNamed(lang, exprSym), []*Node{isClass}, nil, 0)
+
+	ifStart := header.startByte
+	if int(ifStart) <= len(source) {
+		if kwStart, ok := cobolIfKeywordStartBefore(source, condition.startByte); ok {
+			ifStart = kwStart
+		}
+	}
+	replaceNodeChildrenUnfielded(header, cloneNodeSliceInArena(header.ownerArena, []*Node{expr}))
+	header.startByte = ifStart
+	header.startPoint = advancePointByBytes(Point{}, source[:ifStart])
+	header.endByte = cicsEnd
+	header.endPoint = advancePointByBytes(Point{}, source[:cicsEnd])
+	cobolRefreshHasErrorFromChildren(header)
+	return true
+}
+
+func cobolIfHeaderExecCICSBounds(header *Node, source []byte) (uint32, uint32, uint32, bool) {
+	if header == nil || int(header.startByte) >= len(source) || int(header.endByte) > len(source) || header.startByte >= header.endByte {
+		return 0, 0, 0, false
+	}
+	exec := cobolIndexFoldASCII(source, int(header.startByte), int(header.endByte), "exec cics")
+	if exec < 0 {
+		return 0, 0, 0, false
+	}
+	lineStart := cobolLineStart(source, exec)
+	codeStart, ok := firstNonWhitespaceByteInRange(source, lineStart, exec+len("EXEC"))
+	if !ok || int(codeStart) != exec {
+		return 0, 0, 0, false
+	}
+	execStart := uint32(exec)
+	cicsStart := execStart + uint32(len("EXEC "))
+	cicsEnd := cicsStart + uint32(len("CICS"))
+	if int(cicsEnd) > len(source) || cicsEnd > header.endByte {
+		return 0, 0, 0, false
+	}
+	return execStart, cicsStart, cicsEnd, true
+}
+
+func cobolFirstDescendantOfTypeBefore(n *Node, lang *Language, typ string, before uint32) *Node {
+	if n == nil || n.startByte >= before {
+		return nil
+	}
+	if !n.IsExtra() && !n.IsMissing() && !n.IsError() && n.endByte <= before && n.Type(lang) == typ {
+		return n
+	}
+	for i := 0; i < resultChildCount(n); i++ {
+		if found := cobolFirstDescendantOfTypeBefore(resultChildAt(n, i), lang, typ, before); found != nil {
+			return found
+		}
+	}
+	return nil
 }
 
 func cobolLineEnd(source []byte, pos int) int {


### PR DESCRIPTION
## Summary

Fixes a COBOL C parity gap where an `if_header` containing `EXEC CICS` could normalize to a clean Go tree even though C reports an inner `ERROR`.

## Changes

- Detect `if_header` nodes that contain a line-start `EXEC CICS` sequence and rebuild that header into the C-shaped `expr -> is_class` form with an inner `ERROR` leaf.
- Propagate `HasError` through the rebuilt header/procedure/program/root and restore the recovered program span after later trailing-trivia normalization.
- Add adversarial CGo oracle coverage for the swallowed-error class, including the `MOVE ... IF FLAG ... EXEC CICS RETURN` fixture.
- Include Go span dumps in COBOL CGo divergence failures to make future oracle mismatches easier to diagnose.
- Route the exhaustive CGo parity CI job through the Docker harness instead of host-side `go test`, matching the harness contract and repo workflow policy.

## Testing

- `git diff --check`
- YAML parse for `.github/workflows/ci.yml`
- `actionlint .github/workflows/ci.yml`
- `go test . -run 'TestNormalizeCobol|TestCobol' -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh --label cobol-error-oracle --memory 6g --cpus 2 --pids 1024 --gomemlimit 4GiB --goflags -p=1 --no-build -- "cd /workspace/cgo_harness && GOWORK=off go test -tags treesitter_c_parity -run '^TestCobolCGOErrorOracleParity$' -v -count=1 -timeout 10m ."`
- `bash cgo_harness/docker/run_single_grammar_parity.sh cobol`
- `bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs cobol --cgo-max-cases 40`

## Review Notes

The first CGo focus run with default `--cgo-max-cases 20` had zero divergences but failed the ratchet because COBOL's floor is 40. The rerun at 40 cases passed.
