### PR TITLE
improve(cgo_harness/perf_scan): track active file in partial fragments

### DIFF
--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -133,6 +133,12 @@ Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 config, a `contended` flag, per-language per-axis aggregates, and per-file
 medians/ratios/statuses.
 
+If a language child process is killed while measuring a file, the latest
+partial fragment includes `active_file`, `active_file_index`, and
+`active_file_bytes`. These fields are omitted on completed language rows; they
+exist so OOM and hard-kill rows still identify the file being measured even
+when no per-file result could be checkpointed.
+
 ## Ratio budget ratchet
 
 Wave 3 seeds a checked-in ratio budget at

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -134,10 +134,11 @@ config, a `contended` flag, per-language per-axis aggregates, and per-file
 medians/ratios/statuses.
 
 If a language child process is killed while measuring a file, the latest
-partial fragment includes `active_file`, `active_file_index`, and
-`active_file_bytes`. These fields are omitted on completed language rows; they
-exist so OOM and hard-kill rows still identify the file being measured even
-when no per-file result could be checkpointed.
+partial fragment includes `active_file`, 1-based `active_file_index`, and
+`active_file_bytes`. `active_file` is the canonical active-measurement signal;
+these fields are omitted on completed language rows. They exist so OOM and
+hard-kill rows still identify the file being measured even when no per-file
+result could be checkpointed.
 
 ## Ratio budget ratchet
 

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -145,18 +145,21 @@ type perfScanLangAxis struct {
 }
 
 type perfScanLanguage struct {
-	Language      string                       `json:"language"`
-	Status        string                       `json:"status"`
-	Detail        string                       `json:"detail,omitempty"`
-	Backend       string                       `json:"backend,omitempty"`
-	FilesSelected int                          `json:"files_selected"`
-	FilesMeasured int                          `json:"files_measured"`
-	BytesMeasured int64                        `json:"bytes_measured"`
-	ElapsedMS     int64                        `json:"elapsed_ms"`
-	Verdict       string                       `json:"verdict"`
-	Axes          map[string]*perfScanLangAxis `json:"axes,omitempty"`
-	Notes         []string                     `json:"notes,omitempty"`
-	Files         []*perfScanFile              `json:"files,omitempty"`
+	Language        string                       `json:"language"`
+	Status          string                       `json:"status"`
+	Detail          string                       `json:"detail,omitempty"`
+	Backend         string                       `json:"backend,omitempty"`
+	FilesSelected   int                          `json:"files_selected"`
+	FilesMeasured   int                          `json:"files_measured"`
+	BytesMeasured   int64                        `json:"bytes_measured"`
+	ElapsedMS       int64                        `json:"elapsed_ms"`
+	Verdict         string                       `json:"verdict"`
+	ActiveFile      string                       `json:"active_file,omitempty"`
+	ActiveFileIndex int                          `json:"active_file_index,omitempty"`
+	ActiveFileBytes int64                        `json:"active_file_bytes,omitempty"`
+	Axes            map[string]*perfScanLangAxis `json:"axes,omitempty"`
+	Notes           []string                     `json:"notes,omitempty"`
+	Files           []*perfScanFile              `json:"files,omitempty"`
 }
 
 type perfScanScoreboard struct {
@@ -396,6 +399,13 @@ func perfScanWriteLangFragment(outDir string, row *perfScanLanguage) error {
 	return os.Rename(tmp, final)
 }
 
+func perfScanClearActiveFile(row *perfScanLanguage) {
+	row.ActiveFile = ""
+	row.ActiveFileIndex = 0
+	row.ActiveFileBytes = 0
+	row.Detail = ""
+}
+
 func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flush func(*perfScanLanguage)) *perfScanLanguage {
 	start := time.Now()
 	row := &perfScanLanguage{
@@ -436,6 +446,10 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		return finish("no_corpus_files", err.Error())
 	}
 	row.FilesSelected = len(files)
+	if flush != nil {
+		row.ElapsedMS = time.Since(start).Milliseconds()
+		flush(row)
+	}
 
 	cLang, err := ParityCLanguage(lang)
 	if err != nil {
@@ -471,10 +485,23 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 	m.cPsr = cParser
 	defer cParser.Close()
 
-	for _, file := range files {
+	for i, file := range files {
+		row.ActiveFile = file.rel
+		row.ActiveFileIndex = i + 1
+		row.ActiveFileBytes = file.size
+		row.Detail = fmt.Sprintf("measuring file %d/%d: %s (%d bytes)", i+1, len(files), file.rel, file.size)
+		if flush != nil {
+			row.ElapsedMS = time.Since(start).Milliseconds()
+			flush(row)
+		}
 		src, err := os.ReadFile(file.path)
 		if err != nil {
 			row.Notes = append(row.Notes, fmt.Sprintf("read %s: %v", file.rel, err))
+			perfScanClearActiveFile(row)
+			if flush != nil {
+				row.ElapsedMS = time.Since(start).Milliseconds()
+				flush(row)
+			}
 			continue
 		}
 		fileRow := &perfScanFile{
@@ -488,6 +515,7 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		row.Files = append(row.Files, fileRow)
 		row.FilesMeasured++
 		row.BytesMeasured += int64(len(src))
+		perfScanClearActiveFile(row)
 		if flush != nil {
 			row.ElapsedMS = time.Since(start).Milliseconds()
 			flush(row)
@@ -1527,6 +1555,46 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	joined := strings.Join(env, " ")
 	if strings.Contains(joined, "LANG=old") || !strings.Contains(joined, "GTS_PERF_SCAN_LANG=go") {
 		t.Fatalf("mergeEnv=%v", env)
+	}
+
+	fragDir := t.TempDir()
+	frag := &perfScanLanguage{
+		Language:        "perf_scan_synthetic",
+		Status:          perfScanStatusRunning,
+		Detail:          "measuring synthetic",
+		Verdict:         perfScanBucketNoData,
+		ActiveFile:      "src/synthetic.go",
+		ActiveFileIndex: 2,
+		ActiveFileBytes: 123,
+	}
+	if err := perfScanWriteLangFragment(fragDir, frag); err != nil {
+		t.Fatalf("write active fragment: %v", err)
+	}
+	fragData, err := os.ReadFile(filepath.Join(fragDir, "langs", "perf_scan_synthetic.json"))
+	if err != nil {
+		t.Fatalf("read active fragment: %v", err)
+	}
+	fragText := string(fragData)
+	for _, want := range []string{
+		`"active_file": "src/synthetic.go"`,
+		`"active_file_index": 2`,
+		`"active_file_bytes": 123`,
+	} {
+		if !strings.Contains(fragText, want) {
+			t.Fatalf("active fragment missing %s:\n%s", want, fragText)
+		}
+	}
+	perfScanClearActiveFile(frag)
+	if err := perfScanWriteLangFragment(fragDir, frag); err != nil {
+		t.Fatalf("write cleared fragment: %v", err)
+	}
+	fragData, err = os.ReadFile(filepath.Join(fragDir, "langs", "perf_scan_synthetic.json"))
+	if err != nil {
+		t.Fatalf("read cleared fragment: %v", err)
+	}
+	fragText = string(fragData)
+	if strings.Contains(fragText, "active_file") || strings.Contains(fragText, "measuring synthetic") {
+		t.Fatalf("cleared fragment retained active fields:\n%s", fragText)
 	}
 
 	lang := &gotreesitter.Language{

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -145,18 +145,20 @@ type perfScanLangAxis struct {
 }
 
 type perfScanLanguage struct {
-	Language        string                       `json:"language"`
-	Status          string                       `json:"status"`
-	Detail          string                       `json:"detail,omitempty"`
-	Backend         string                       `json:"backend,omitempty"`
-	FilesSelected   int                          `json:"files_selected"`
-	FilesMeasured   int                          `json:"files_measured"`
-	BytesMeasured   int64                        `json:"bytes_measured"`
-	ElapsedMS       int64                        `json:"elapsed_ms"`
-	Verdict         string                       `json:"verdict"`
+	Language      string `json:"language"`
+	Status        string `json:"status"`
+	Detail        string `json:"detail,omitempty"`
+	Backend       string `json:"backend,omitempty"`
+	FilesSelected int    `json:"files_selected"`
+	FilesMeasured int    `json:"files_measured"`
+	BytesMeasured int64  `json:"bytes_measured"`
+	ElapsedMS     int64  `json:"elapsed_ms"`
+	Verdict       string `json:"verdict"`
+	// ActiveFile is the canonical active-measurement signal. The numeric
+	// fields are pointers so active zero-byte files still serialize bytes=0.
 	ActiveFile      string                       `json:"active_file,omitempty"`
-	ActiveFileIndex int                          `json:"active_file_index,omitempty"`
-	ActiveFileBytes int64                        `json:"active_file_bytes,omitempty"`
+	ActiveFileIndex *int                         `json:"active_file_index,omitempty"`
+	ActiveFileBytes *int64                       `json:"active_file_bytes,omitempty"`
 	Axes            map[string]*perfScanLangAxis `json:"axes,omitempty"`
 	Notes           []string                     `json:"notes,omitempty"`
 	Files           []*perfScanFile              `json:"files,omitempty"`
@@ -399,10 +401,21 @@ func perfScanWriteLangFragment(outDir string, row *perfScanLanguage) error {
 	return os.Rename(tmp, final)
 }
 
+func perfScanSetActiveFile(row *perfScanLanguage, file perfScanCorpusFile, index, total int) {
+	activeFileIndex := index
+	activeFileBytes := file.size
+	row.ActiveFile = file.rel
+	row.ActiveFileIndex = &activeFileIndex
+	row.ActiveFileBytes = &activeFileBytes
+	row.Detail = fmt.Sprintf("measuring file %d/%d: %s (%d bytes)", index, total, file.rel, file.size)
+}
+
+// perfScanClearActiveFile resets active-file tracking and its file-progress
+// detail message.
 func perfScanClearActiveFile(row *perfScanLanguage) {
 	row.ActiveFile = ""
-	row.ActiveFileIndex = 0
-	row.ActiveFileBytes = 0
+	row.ActiveFileIndex = nil
+	row.ActiveFileBytes = nil
 	row.Detail = ""
 }
 
@@ -486,10 +499,7 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 	defer cParser.Close()
 
 	for i, file := range files {
-		row.ActiveFile = file.rel
-		row.ActiveFileIndex = i + 1
-		row.ActiveFileBytes = file.size
-		row.Detail = fmt.Sprintf("measuring file %d/%d: %s (%d bytes)", i+1, len(files), file.rel, file.size)
+		perfScanSetActiveFile(row, file, i+1, len(files))
 		if flush != nil {
 			row.ElapsedMS = time.Since(start).Milliseconds()
 			flush(row)
@@ -498,6 +508,7 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		if err != nil {
 			row.Notes = append(row.Notes, fmt.Sprintf("read %s: %v", file.rel, err))
 			perfScanClearActiveFile(row)
+			row.Detail = fmt.Sprintf("read error on file %d/%d: %s: %v", i+1, len(files), file.rel, err)
 			if flush != nil {
 				row.ElapsedMS = time.Since(start).Milliseconds()
 				flush(row)
@@ -1559,14 +1570,11 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 
 	fragDir := t.TempDir()
 	frag := &perfScanLanguage{
-		Language:        "perf_scan_synthetic",
-		Status:          perfScanStatusRunning,
-		Detail:          "measuring synthetic",
-		Verdict:         perfScanBucketNoData,
-		ActiveFile:      "src/synthetic.go",
-		ActiveFileIndex: 2,
-		ActiveFileBytes: 123,
+		Language: "perf_scan_synthetic",
+		Status:   perfScanStatusRunning,
+		Verdict:  perfScanBucketNoData,
 	}
+	perfScanSetActiveFile(frag, perfScanCorpusFile{rel: "src/synthetic.go", size: 0}, 2, 3)
 	if err := perfScanWriteLangFragment(fragDir, frag); err != nil {
 		t.Fatalf("write active fragment: %v", err)
 	}
@@ -1578,7 +1586,8 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	for _, want := range []string{
 		`"active_file": "src/synthetic.go"`,
 		`"active_file_index": 2`,
-		`"active_file_bytes": 123`,
+		`"active_file_bytes": 0`,
+		`"detail": "measuring file 2/3: src/synthetic.go (0 bytes)"`,
 	} {
 		if !strings.Contains(fragText, want) {
 			t.Fatalf("active fragment missing %s:\n%s", want, fragText)
@@ -1593,7 +1602,7 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 		t.Fatalf("read cleared fragment: %v", err)
 	}
 	fragText = string(fragData)
-	if strings.Contains(fragText, "active_file") || strings.Contains(fragText, "measuring synthetic") {
+	if strings.Contains(fragText, "active_file") || strings.Contains(fragText, `"detail":`) {
 		t.Fatalf("cleared fragment retained active fields:\n%s", fragText)
 	}
 


### PR DESCRIPTION
## Summary

Updates the perf_scan harness to capture the currently measured file in partial fragments. When a language child process is interrupted mid-bench, the emitted language JSON now names the active file so OOM and hard-kill rows identify the workload in progress.

## Changes

- Added `active_file`, 1-based `active_file_index`, and `active_file_bytes` to `perfScanLanguage`.
- Flush a partial language fragment after file selection and before each measured file.
- Keep `active_file` as the canonical active signal while preserving `active_file_bytes: 0` for zero-byte active files.
- Clear and re-flush active-file state after completed files; read-error fragments retain explicit error detail.
- Added a helper self-check that verifies active-file fragment serialization and omission after clearing.
- Documented the new partial-fragment fields in `cgo_harness/perf_scan/README.md`.

## Testing

- `git diff --check`
- `cd cgo_harness && GOWORK=off GTS_PARITY_ALLOW_HOST=1 go test -tags 'treesitter_c_parity treesitter_c_perfscan' -run '^TestPerfScanHelpersUnit$' -count=1 .`

## Notes

This is a diagnostic bucket for the remaining Wave 3 memory-gap RCA. It does not budget `d`, `groovy`, or `fsharp`; it makes the next killed/OOM perf fragments name the active corpus file.
