### PR TITLE
improve(cgo_harness): Track active measurement attempt in perf scan output

### DIFF
--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -135,9 +135,11 @@ medians/ratios/statuses.
 
 If a language child process is killed while measuring a file, the latest
 partial fragment includes `active_file`, 1-based `active_file_index`, and
-`active_file_bytes`. `active_file` is the canonical active-measurement signal;
-these fields are omitted on completed language rows. They exist so OOM and
-hard-kill rows still identify the file being measured even when no per-file
+`active_file_bytes`. Once measurement starts, it also includes `active_axis`,
+`active_impl`, `active_phase`, and 1-based `active_attempt` when an attempt
+number applies. `active_file` is the canonical active-measurement signal; these
+fields are omitted on completed language rows. They exist so OOM and hard-kill
+rows still identify the exact file and measurement phase even when no per-file
 result could be checkpointed.
 
 ## Ratio budget ratchet

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -48,7 +48,7 @@
     "wave3_batch6_dot_20260708T225933Z": "supplemental Wave-3 batch-6 dot run on HEAD 42aa02f9, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit). Added as a clean replacement row after d reproduced a one-language Docker OOM.",
     "wave3_batch6_doxygen_20260708T230104Z": "supplemental Wave-3 batch-6 doxygen run on HEAD 42aa02f9, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit). Added as a replacement row after bicep repeated a C-reference timeout; doxygen retains explicit go_error budgets.",
     "wave3_batch7_20260708T232544Z": "seventh Wave-3 fleet batch, Docker-isolated with the ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit), languages dtd/earthfile/ebnf/editorconfig/eds/eex/elisp/elsa/embedded_template/enforce. This run was harness-flagged as contended (loadavg1=7.95), so these rows are visibility ratchets with pessimistic caveats rather than authoritative near-C claims; dtd/editorconfig/eds are thin-corpus rows and enforce retains explicit timeout budgets.",
-    "fleet_gap_close_assist_20260708T232019Z_to_20260709T003453Z": "assisted Wave-3 fleet gap-close pass from a detached non-colliding worktree, using the same ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit). Adds 113 ratchetable rows across fleet_tier1_20260708T232019Z, fleet_objc_isolated_20260708T233134Z, fleet_tier1_remaining_20260708T233530Z, fleet_tier2_20260708T234810Z, fleet_tier3_20260709T002002Z, fleet_tier4_20260709T002535Z, fleet_tier5_20260709T002902Z, and fleet_tier6_20260709T003453Z. groovy and fsharp are intentionally not budgeted because repeated isolated attempts reproduced severe memory blowups; they are recorded under known_budget_class_gaps instead."
+    "fleet_gap_close_assist_20260708T232019Z_to_20260709T003453Z": "assisted Wave-3 fleet gap-close pass from a detached non-colliding worktree, using the same ratchet basis (largest-8, reps=5, warmup=1, file_budget=10000ms, axes full/noedit). Adds 113 ratchetable rows across fleet_tier1_20260708T232019Z, fleet_objc_isolated_20260708T233134Z, fleet_tier1_remaining_20260708T233530Z, fleet_tier2_20260708T234810Z, fleet_tier3_20260709T002002Z, fleet_tier4_20260709T002535Z, fleet_tier5_20260709T002902Z, and fleet_tier6_20260709T003453Z. groovy and fsharp are intentionally not budgeted because repeated isolated attempts reproduced severe memory blowups; fsharp is now attributed to a C-reference full-parse OOM on ProvidedTypes.fs by active-attempt checkpointing. They are recorded under known_budget_class_gaps instead."
   },
   "languages": {
     "php": {
@@ -3978,17 +3978,16 @@
       "suspected_class": "candidate severe memory variant of repetition-shift fork cascade or population explosion; distinct from ordinary 10s go_timeout and from clean internal memory_budget stops",
       "action": "dedicated RCA on pleac11_15.groovy in an isolated hard-bounded container; do not sweep this file again as part of broad fleet runs until containment is understood"
     },
-    "fsharp_comparers_regression_memory_blowup": {
-      "file": "fsharp/ComparersRegression.fs candidate largest-file selection from the assisted fleet pass",
+    "fsharp_providedtypes_c_reference_memory_blowup": {
+      "file": "fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection)",
       "backlog_ref": "assisted Wave-3 fleet gap-close pass, reported in /tmp/gts_scratch/FLEET_SCOREBOARD.md; intentionally not added to languages because it is not a ratchetable row",
       "observed": {
-        "partial_progress": "0/8 selected files completed; blowup occurred on the first attempted file before a per-file fragment checkpoint could be written",
-        "host_gomemlimit_4gib": "reproduced severe memory blowup",
-        "host_gomemlimit_3gib": "reproduced severe memory blowup",
-        "docker_cgroup_6gib": "Docker wrapper reported oom_killed=true"
+        "activeattempt_fsharp_lock_20260709T023116Z": "Docker 4GiB cgroup, GOMEMLIMIT=3GiB, lock-filtered corpus, largest-8, reps=1, warmup=0, file_budget=2000ms: child exited with signal:killed, docker wrapper reported oom_killed=true, files=0/8, active_axis=full, active_impl=c, active_phase=rep, active_attempt=1",
+        "active_file_checkpoint_20260709T022239Z": "earlier active-file-only rerun identified the same first active file but could not distinguish Go vs C attempt",
+        "prior_isolated_attempts": "host GOMEMLIMIT=4GiB and 3GiB plus a Docker 6GiB cgroup reproduced severe memory blowups before attempt-level attribution existed"
       },
-      "suspected_class": "candidate severe memory variant of population explosion or repetition-shift fork cascade; severity is higher than ordinary timeout backlog because it escapes a 6GiB hard cgroup",
-      "action": "dedicated isolated single-file RCA, first confirming the exact selected file; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog"
+      "suspected_class": "C reference parser memory blowup on the active full-parse attempt, not currently evidence of a pure-Go memory blowup; fsharp still cannot be ratcheted because the reference side dies before a C median can be recorded",
+      "action": "dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog"
     },
     "d_docker_oom": {
       "file": "d corpus largest-file selection from wave3_batch6",

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -156,12 +156,17 @@ type perfScanLanguage struct {
 	Verdict       string `json:"verdict"`
 	// ActiveFile is the canonical active-measurement signal. The numeric
 	// fields are pointers so active zero-byte files still serialize bytes=0.
-	ActiveFile      string                       `json:"active_file,omitempty"`
-	ActiveFileIndex *int                         `json:"active_file_index,omitempty"`
-	ActiveFileBytes *int64                       `json:"active_file_bytes,omitempty"`
-	Axes            map[string]*perfScanLangAxis `json:"axes,omitempty"`
-	Notes           []string                     `json:"notes,omitempty"`
-	Files           []*perfScanFile              `json:"files,omitempty"`
+	ActiveFile       string                       `json:"active_file,omitempty"`
+	ActiveFileIndex  *int                         `json:"active_file_index,omitempty"`
+	ActiveFileBytes  *int64                       `json:"active_file_bytes,omitempty"`
+	ActiveAxis       string                       `json:"active_axis,omitempty"`
+	ActiveImpl       string                       `json:"active_impl,omitempty"`
+	ActivePhase      string                       `json:"active_phase,omitempty"`
+	ActiveAttempt    *int                         `json:"active_attempt,omitempty"`
+	Axes             map[string]*perfScanLangAxis `json:"axes,omitempty"`
+	Notes            []string                     `json:"notes,omitempty"`
+	Files            []*perfScanFile              `json:"files,omitempty"`
+	activeFileDetail string
 }
 
 type perfScanScoreboard struct {
@@ -407,15 +412,52 @@ func perfScanSetActiveFile(row *perfScanLanguage, file perfScanCorpusFile, index
 	row.ActiveFile = file.rel
 	row.ActiveFileIndex = &activeFileIndex
 	row.ActiveFileBytes = &activeFileBytes
-	row.Detail = fmt.Sprintf("measuring file %d/%d: %s (%d bytes)", index, total, file.rel, file.size)
+	row.activeFileDetail = fmt.Sprintf("measuring file %d/%d: %s (%d bytes)", index, total, file.rel, file.size)
+	row.Detail = row.activeFileDetail
+}
+
+func perfScanSetActiveAttempt(row *perfScanLanguage, axis, impl, phase string, attempt int) {
+	row.ActiveAxis = axis
+	row.ActiveImpl = impl
+	row.ActivePhase = phase
+	if attempt > 0 {
+		activeAttempt := attempt
+		row.ActiveAttempt = &activeAttempt
+	} else {
+		row.ActiveAttempt = nil
+	}
+
+	attemptDetail := fmt.Sprintf("%s/%s/%s", axis, impl, phase)
+	if attempt > 0 {
+		attemptDetail = fmt.Sprintf("%s attempt %d", attemptDetail, attempt)
+	}
+	if row.activeFileDetail != "" {
+		row.Detail = row.activeFileDetail + "; " + attemptDetail
+	} else if row.Detail != "" {
+		row.Detail += "; " + attemptDetail
+	} else {
+		row.Detail = "measuring " + attemptDetail
+	}
+}
+
+func perfScanClearActiveAttempt(row *perfScanLanguage) {
+	row.ActiveAxis = ""
+	row.ActiveImpl = ""
+	row.ActivePhase = ""
+	row.ActiveAttempt = nil
+	if row.activeFileDetail != "" {
+		row.Detail = row.activeFileDetail
+	}
 }
 
 // perfScanClearActiveFile resets active-file tracking and its file-progress
 // detail message.
 func perfScanClearActiveFile(row *perfScanLanguage) {
+	perfScanClearActiveAttempt(row)
 	row.ActiveFile = ""
 	row.ActiveFileIndex = nil
 	row.ActiveFileBytes = nil
+	row.activeFileDetail = ""
 	row.Detail = ""
 }
 
@@ -520,6 +562,18 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 			Bytes: len(src),
 			Axes:  map[string]*perfScanFileAxis{},
 		}
+		m.progress = nil
+		if flush != nil {
+			fileIndex := i + 1
+			fileTotal := len(files)
+			activeFile := file
+			m.progress = func(axis, impl, phase string, attempt int) {
+				perfScanSetActiveFile(row, activeFile, fileIndex, fileTotal)
+				perfScanSetActiveAttempt(row, axis, impl, phase, attempt)
+				row.ElapsedMS = time.Since(start).Milliseconds()
+				flush(row)
+			}
+		}
 		for _, axis := range cfg.Axes {
 			fileRow.Axes[axis] = m.measureFileAxis(axis, src)
 		}
@@ -615,16 +669,17 @@ func perfScanSelectFiles(t *testing.T, lang string, cfg perfScanConfig, langRoot
 // ---------------------------------------------------------------------------
 
 type perfScanLangMeasurer struct {
-	cfg     perfScanConfig
-	lang    string
-	entry   grammars.LangEntry
-	report  grammars.ParseSupport
-	goLang  *gotreesitter.Language
-	cLang   *sitter.Language
-	goPsr   *gotreesitter.Parser
-	cPsr    *sitter.Parser
-	budget  time.Duration
-	editMax int
+	cfg      perfScanConfig
+	lang     string
+	entry    grammars.LangEntry
+	report   grammars.ParseSupport
+	goLang   *gotreesitter.Language
+	cLang    *sitter.Language
+	goPsr    *gotreesitter.Parser
+	cPsr     *sitter.Parser
+	budget   time.Duration
+	editMax  int
+	progress func(axis, impl, phase string, attempt int)
 }
 
 type perfScanAttempt struct {
@@ -642,6 +697,12 @@ func (m *perfScanLangMeasurer) benchCase(src []byte) realCorpusBenchmarkCase {
 		report: m.report,
 		goLang: m.goLang,
 		cLang:  m.cLang,
+	}
+}
+
+func (m *perfScanLangMeasurer) checkpoint(axis, impl, phase string, attempt int) {
+	if m.progress != nil {
+		m.progress(axis, impl, phase, attempt)
 	}
 }
 
@@ -815,6 +876,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 	goOK := true
 	var goDetail string
 	for i := 0; i < m.cfg.Warmup; i++ {
+		m.checkpoint(perfScanAxisFull, "go", "warmup", i+1)
 		_, att := m.goAttemptFull(src, false)
 		if att.status != "" {
 			goOK = false
@@ -825,6 +887,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 	}
 	cOK := true
 	for i := 0; i < m.cfg.Warmup; i++ {
+		m.checkpoint(perfScanAxisFull, "c", "warmup", i+1)
 		_, att := m.cAttempt(src, nil, false)
 		if att.status != "" {
 			cOK = false
@@ -839,6 +902,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 	var goSamples, cSamples []int64
 	for i := 0; i < m.cfg.Reps; i++ {
 		if goOK {
+			m.checkpoint(perfScanAxisFull, "go", "rep", i+1)
 			_, att := m.goAttemptFull(src, false)
 			if att.status != "" {
 				goOK = false
@@ -849,6 +913,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 			}
 		}
 		if cOK {
+			m.checkpoint(perfScanAxisFull, "c", "rep", i+1)
 			_, att := m.cAttempt(src, nil, false)
 			if att.status != "" {
 				cOK = false
@@ -872,6 +937,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 	out := &perfScanFileAxis{Status: perfScanStatusOK}
 
 	// Go side: base full parse (untimed sample), then timed no-edit reparses.
+	m.checkpoint(perfScanAxisNoEdit, "go", "base", 1)
 	goTree, baseAtt := m.goAttemptFull(src, true)
 	goOK := baseAtt.status == ""
 	var goSamples []int64
@@ -880,6 +946,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 		out.Detail = "base full parse: " + baseAtt.detail
 	} else {
 		for i := 0; i < m.cfg.Reps; i++ {
+			m.checkpoint(perfScanAxisNoEdit, "go", "rep", i+1)
 			newTree, att := m.goAttemptIncremental(src, goTree, true)
 			if att.status != "" {
 				goOK = false
@@ -897,6 +964,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 	releaseGoTree(goTree)
 
 	// C side: base full parse, then timed no-edit reparses with the old tree.
+	m.checkpoint(perfScanAxisNoEdit, "c", "base", 1)
 	cTree, cBaseAtt := m.cAttempt(src, nil, true)
 	cOK := cBaseAtt.status == ""
 	var cSamples []int64
@@ -907,6 +975,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 		out.Detail = strings.TrimSpace(out.Detail + " C base: " + cBaseAtt.detail)
 	} else {
 		for i := 0; i < m.cfg.Reps; i++ {
+			m.checkpoint(perfScanAxisNoEdit, "c", "rep", i+1)
 			newTree, att := m.cAttempt(src, cTree, true)
 			if att.status != "" {
 				cOK = false
@@ -944,6 +1013,7 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 
 	// Go side.
 	goSrc := append([]byte(nil), src...)
+	m.checkpoint(perfScanAxisEdit, "go", "base", 1)
 	goTree, baseAtt := m.goAttemptFull(goSrc, true)
 	goOK := baseAtt.status == ""
 	var goSamples []int64
@@ -952,8 +1022,10 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 		out.Detail = "base full parse: " + baseAtt.detail
 	} else {
 		for i := 0; i < m.cfg.Reps; i++ {
+			m.checkpoint(perfScanAxisEdit, "go", "tree_edit", i+1)
 			toggleRealCorpusEditByte(goSrc, editCase)
 			goTree.Edit(editCase.goEdit)
+			m.checkpoint(perfScanAxisEdit, "go", "rep", i+1)
 			newTree, att := m.goAttemptIncremental(goSrc, goTree, true)
 			if att.status != "" {
 				goOK = false
@@ -972,6 +1044,7 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 
 	// C side.
 	cSrc := append([]byte(nil), src...)
+	m.checkpoint(perfScanAxisEdit, "c", "base", 1)
 	cTree, cBaseAtt := m.cAttempt(cSrc, nil, true)
 	cOK := cBaseAtt.status == ""
 	var cSamples []int64
@@ -983,8 +1056,10 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 	} else {
 		cState := realCorpusCIncrementalState{tc: editCase, src: cSrc, tree: cTree}
 		for i := 0; i < m.cfg.Reps; i++ {
+			m.checkpoint(perfScanAxisEdit, "c", "tree_edit", i+1)
 			toggleRealCorpusEditByte(cState.src, cState.tc)
 			cState.tree.Edit(&cState.tc.cEdit)
+			m.checkpoint(perfScanAxisEdit, "c", "rep", i+1)
 			newTree, att := m.cAttempt(cState.src, cState.tree, true)
 			if att.status != "" {
 				cOK = false
@@ -1030,21 +1105,27 @@ func (m *perfScanLangMeasurer) findEditCase(tc realCorpusBenchmarkCase) (realCor
 		editCase := makeRealCorpusIncrementalCase(tc, candidate)
 		edited := applyEditCandidate(tc.source, candidate)
 
+		m.checkpoint(perfScanAxisEdit, "go", "select_base", tried)
 		goTree, baseAtt := m.goAttemptFull(tc.source, true)
 		if baseAtt.status != "" {
 			return realCorpusIncrementalCase{}, false
 		}
+		m.checkpoint(perfScanAxisEdit, "go", "select_tree_edit", tried)
 		goTree.Edit(editCase.goEdit)
+		m.checkpoint(perfScanAxisEdit, "go", "select_incremental", tried)
 		goIncr, goAtt := m.goAttemptIncremental(edited, goTree, true)
 		releaseGoTree(goTree)
 		goOK := goAtt.status == ""
 		releaseGoTree(goIncr)
 
+		m.checkpoint(perfScanAxisEdit, "c", "select_base", tried)
 		cTree, cBaseAtt := m.cAttempt(tc.source, nil, true)
 		if cBaseAtt.status != "" {
 			return realCorpusIncrementalCase{}, false
 		}
+		m.checkpoint(perfScanAxisEdit, "c", "select_tree_edit", tried)
 		cTree.Edit(&editCase.cEdit)
+		m.checkpoint(perfScanAxisEdit, "c", "select_incremental", tried)
 		cIncr, cAtt := m.cAttempt(edited, cTree, true)
 		cTree.Close()
 		cOK := cAtt.status == ""
@@ -1593,6 +1674,26 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 			t.Fatalf("active fragment missing %s:\n%s", want, fragText)
 		}
 	}
+	perfScanSetActiveAttempt(frag, perfScanAxisFull, "go", "rep", 1)
+	if err := perfScanWriteLangFragment(fragDir, frag); err != nil {
+		t.Fatalf("write active attempt fragment: %v", err)
+	}
+	fragData, err = os.ReadFile(filepath.Join(fragDir, "langs", "perf_scan_synthetic.json"))
+	if err != nil {
+		t.Fatalf("read active attempt fragment: %v", err)
+	}
+	fragText = string(fragData)
+	for _, want := range []string{
+		`"active_axis": "full"`,
+		`"active_impl": "go"`,
+		`"active_phase": "rep"`,
+		`"active_attempt": 1`,
+		`"detail": "measuring file 2/3: src/synthetic.go (0 bytes); full/go/rep attempt 1"`,
+	} {
+		if !strings.Contains(fragText, want) {
+			t.Fatalf("active attempt fragment missing %s:\n%s", want, fragText)
+		}
+	}
 	perfScanClearActiveFile(frag)
 	if err := perfScanWriteLangFragment(fragDir, frag); err != nil {
 		t.Fatalf("write cleared fragment: %v", err)
@@ -1602,7 +1703,7 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 		t.Fatalf("read cleared fragment: %v", err)
 	}
 	fragText = string(fragData)
-	if strings.Contains(fragText, "active_file") || strings.Contains(fragText, `"detail":`) {
+	if strings.Contains(fragText, "active_") || strings.Contains(fragText, `"detail":`) {
 		t.Fatalf("cleared fragment retained active fields:\n%s", fragText)
 	}
 


### PR DESCRIPTION
## Summary

Adds attempt-level checkpoints to `cgo_harness/perf_scan` partial fragments. Killed language children now report the active file plus axis, implementation, phase, and 1-based attempt number, so OOM/hard-kill RCA can distinguish `full/go/rep` from `full/c/rep`, no-edit base parses, and edit-axis `Tree.Edit` phases.

The immediate Wave 3 RCA payoff is fsharp: the locked, hard-bounded repro now identifies `examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs` as dying on `full/c/rep attempt 1`, so the checked-in budget ledger no longer blames the stale `ComparersRegression.fs` candidate or treats the evidence as a pure-Go memory blowup.

## Changes

- Adds `active_axis`, `active_impl`, `active_phase`, and `active_attempt` to perf-scan language fragments.
- Threads a progress callback through `perfScanLangMeasurer` and checkpoints before full, no-edit, and edit parse attempts.
- Covers edit-axis selection and `tree_edit` phases as separate checkpoint phases.
- Extends the helper test for active-attempt serialization and clearing.
- Documents the partial-fragment contract in `cgo_harness/perf_scan/README.md`.
- Updates `perf_ratio_budgets.json` with the exact fsharp active-attempt evidence.

## Validation

- `git diff --check`
- `cd cgo_harness && GOWORK=off GTS_PARITY_ALLOW_HOST=1 go test -tags 'treesitter_c_parity treesitter_c_perfscan' -run '^TestPerfScanHelpersUnit$' -count=1 .`
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json`
- Docker isolated fsharp repro, lock-filtered, 4GiB cgroup / `GOMEMLIMIT=3GiB`, largest-8, reps=1, warmup=0, file budget 2000ms, language timeout 30000ms:
  - output: `cgo_harness/perf_scan/out/activeattempt_fsharp_lock_20260709T023116Z`
  - result: wrapper exit `0`, `oom_killed=true`, child `signal:killed`
  - partial fragment: `active_file=examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs`, `active_axis=full`, `active_impl=c`, `active_phase=rep`, `active_attempt=1`
