### PR TITLE
Add runtime memory budget and unify materialization stop checks

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -218,6 +218,10 @@ type Parser struct {
 	parseBudgetDepth                 int
 	parseDeadline                    time.Time
 	parseStoppedReason               ParseStopReason
+	parseRuntimeMemoryBudgetBytes    int64
+	parseRuntimeMemoryBaselineBytes  uint64
+	parseRuntimeMemoryBaselineSys    uint64
+	parseRuntimeMemoryPoll           uint64
 	denseLimit                       int
 	smallBase                        int
 	smallLookup                      [][]smallActionPair
@@ -1421,6 +1425,10 @@ func resetSnippetParser(parser *Parser) {
 	parser.parseBudgetDepth = 0
 	parser.parseDeadline = time.Time{}
 	parser.parseStoppedReason = ParseStopNone
+	parser.parseRuntimeMemoryBudgetBytes = 0
+	parser.parseRuntimeMemoryBaselineBytes = 0
+	parser.parseRuntimeMemoryBaselineSys = 0
+	parser.parseRuntimeMemoryPoll = 0
 	// Release *Node refs so the arenas from the last incremental parse can be
 	// collected by the GC. Without this, a Parser sitting in a sync.Pool keeps
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
@@ -3849,6 +3857,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	memoryBudget := parseMemoryBudgetForParser(p, len(source))
 	arena.setBudget(memoryBudget)
 	scratch.setBudget(memoryBudget)
+	restoreRuntimeMemoryBudget := p.enterRuntimeMemoryBudget(memoryBudget)
+	defer restoreRuntimeMemoryBudget()
 	var reuseState parseReuseState
 	nodeCount := 0
 	iterationsUsed := 0
@@ -4148,13 +4158,13 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if phaseTiming && parserLoopNanos == 0 {
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
-		if !parseStopReasonIsTerminal(stopReason) {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+		if !resultMaterializationShouldStop(stopReason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				stopReason = reason
 			}
 		}
 		if p.transientReduceChildren && tree != nil {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				stopReason = reason
 				tree = replaceWithOwnedErrorTree(tree, reason)
 			} else {
@@ -4162,7 +4172,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if materializationTimingRef != nil {
 					materializeStart = time.Now()
 				}
-				if reason := p.materializeTransientChildrenForReturnedTree(tree, arena, scratch); parseStopReasonIsTerminal(reason) {
+				if reason := p.materializeTransientChildrenForReturnedTree(tree, arena, scratch); resultMaterializationShouldStop(reason) {
 					stopReason = reason
 					tree = replaceWithOwnedErrorTree(tree, reason)
 				}
@@ -4293,13 +4303,13 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if phaseTiming && parserLoopNanos == 0 {
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
-		if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return finalizeTree(errorTreeWithOwnedArena(reason), reason)
 		}
-		if reason := materializeTransientParentNodes(nodes, arena, scratch.reduce.transientParents, scratch.reduce.transientChildren, p); parseStopReasonIsTerminal(reason) {
+		if reason := materializeTransientParentNodes(nodes, arena, scratch.reduce.transientParents, scratch.reduce.transientChildren, p); resultMaterializationShouldStop(reason) {
 			return finalizeTree(errorTreeWithOwnedArena(reason), reason)
 		}
-		if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return finalizeTree(errorTreeWithOwnedArena(reason), reason)
 		}
 		for _, n := range nodes {
@@ -4433,8 +4443,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if nodeCount > maxNodes {
 			return finalize(stacks, ParseStopNodeLimit)
 		}
-		if arena.budgetExhausted() {
-			return finalize(stacks, ParseStopMemoryBudget)
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return finalize(stacks, reason)
 		}
 		if scratch.budgetExhausted() {
 			return finalize(stacks, ParseStopMemoryBudget)
@@ -4770,7 +4780,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			// in the C error state dispatches through ts_parser__recover
 			// instead of the parse table, except for shiftable tokens.
 			if s.cRec != nil && p.errorCostCompetitionEnabled() {
-				outcome, redispatch := p.cRecoverDispatchInError(&stacks, si, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+				outcome, redispatch, reason := p.cRecoverDispatchInError(&stacks, si, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+				if resultMaterializationShouldStop(reason) {
+					return finalize(stacks, reason)
+				}
 				s = &stacks[si]
 				if redispatch {
 					anyReduced = true
@@ -5421,6 +5434,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if progress.enabled {
 			progress.emit(time.Now(), "dispatch_end", iterationsUsed, perfTokensConsumed, tok, true, stacks, maxStacksSeen, nodeCount, peakStackDepth, needToken, singleStackIterations, multiStackIterations, fmt.Sprintf("any_reduced=%t consumed_token=%t", anyReduced, dispatchConsumedCurrentToken))
 		}
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return finalize(stacks, reason)
+		}
+		if scratch.budgetExhausted() {
+			return finalize(stacks, ParseStopMemoryBudget)
+		}
 
 		if numStacks > 1 && retryPass && allParseStacksDead(stacks) {
 			bestIdx := bestRetryRecoveryStack(stacks)
@@ -5479,7 +5498,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if condenseErrorCostEnabled && (!anyReduced || condenseEOFRecovery || condenseShiftedRecovery) {
 			var resumed bool
 			condenseRan = true
-			stacks, resumed, tok = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+			var reason ParseStopReason
+			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+			if resultMaterializationShouldStop(reason) {
+				return finalize(stacks, reason)
+			}
 			condenseResumed = resumed
 			if resumed {
 				anyReduced = true
@@ -5641,7 +5664,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			allLiveUnacceptedStacksShifted(stacks) {
 			var resumed bool
 			condenseRan = true
-			stacks, resumed, tok = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+			var reason ParseStopReason
+			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+			if resultMaterializationShouldStop(reason) {
+				return finalize(stacks, reason)
+			}
 			condenseResumed = resumed
 			if resumed {
 				anyReduced = true
@@ -5805,10 +5832,18 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					accepted = selectable
 				}
 				if p.errorCostCompetitionEnabled() {
+					if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+						return finalize(accepted, reason)
+					}
+					if scratch.budgetExhausted() {
+						return finalize(accepted, ParseStopMemoryBudget)
+					}
 					// Faithful C recovery port: ts_parser__accept rebuilds the
 					// root around trailing extras before the tree competes.
 					for i := range accepted {
-						p.cAcceptRootRebuild(&accepted[i], arena, &scratch.entries, &scratch.gss)
+						if reason := p.cAcceptRootRebuild(&accepted[i], arena, &scratch.entries, &scratch.gss); resultMaterializationShouldStop(reason) {
+							return finalize(accepted, reason)
+						}
 					}
 				}
 				return finalize(accepted, ParseStopAccepted)
@@ -6077,7 +6112,11 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 		clearParseStackEntryCaches(stacks)
 		return result
 	}
-	if arena.budgetExhausted() || scratch.budgetExhausted() {
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+		result.stop(reason, false)
+		return result
+	}
+	if scratch.budgetExhausted() {
 		result.stop(ParseStopMemoryBudget, false)
 		return result
 	}

--- a/parser.go
+++ b/parser.go
@@ -3857,8 +3857,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	memoryBudget := parseMemoryBudgetForParser(p, len(source))
 	arena.setBudget(memoryBudget)
 	scratch.setBudget(memoryBudget)
-	restoreRuntimeMemoryBudget := p.enterRuntimeMemoryBudget(memoryBudget)
-	defer restoreRuntimeMemoryBudget()
+	restoreRuntimeMemoryBudget := p.enterRuntimeMemoryBudget(memoryBudget, len(source))
+	if restoreRuntimeMemoryBudget.parser != nil {
+		defer restoreRuntimeMemoryBudget.restore()
+	}
 	var reuseState parseReuseState
 	nodeCount := 0
 	iterationsUsed := 0

--- a/parser_memory_budget_runtime.go
+++ b/parser_memory_budget_runtime.go
@@ -1,0 +1,60 @@
+package gotreesitter
+
+import "runtime"
+
+const parseRuntimeMemoryPollMask = 15
+
+func (p *Parser) enterRuntimeMemoryBudget(bytes int64) func() {
+	if p == nil || bytes <= 0 {
+		return func() {}
+	}
+	prevBudget := p.parseRuntimeMemoryBudgetBytes
+	prevBaseline := p.parseRuntimeMemoryBaselineBytes
+	prevBaselineSys := p.parseRuntimeMemoryBaselineSys
+	prevPoll := p.parseRuntimeMemoryPoll
+
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	p.parseRuntimeMemoryBudgetBytes = bytes
+	p.parseRuntimeMemoryBaselineBytes = stats.HeapAlloc
+	p.parseRuntimeMemoryBaselineSys = stats.Sys
+	p.parseRuntimeMemoryPoll = 0
+
+	return func() {
+		p.parseRuntimeMemoryBudgetBytes = prevBudget
+		p.parseRuntimeMemoryBaselineBytes = prevBaseline
+		p.parseRuntimeMemoryBaselineSys = prevBaselineSys
+		p.parseRuntimeMemoryPoll = prevPoll
+	}
+}
+
+func (p *Parser) runtimeMemoryBudgetStopReason() ParseStopReason {
+	if p == nil || p.parseRuntimeMemoryBudgetBytes <= 0 {
+		return ParseStopNone
+	}
+	p.parseRuntimeMemoryPoll++
+	if p.parseRuntimeMemoryPoll&parseRuntimeMemoryPollMask != 0 {
+		return ParseStopNone
+	}
+	return p.runtimeMemoryBudgetStopReasonNow()
+}
+
+func (p *Parser) runtimeMemoryBudgetStopReasonNow() ParseStopReason {
+	if p == nil || p.parseRuntimeMemoryBudgetBytes <= 0 {
+		return ParseStopNone
+	}
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	if stats.HeapAlloc <= p.parseRuntimeMemoryBaselineBytes {
+		if stats.Sys <= p.parseRuntimeMemoryBaselineSys {
+			return ParseStopNone
+		}
+	} else if int64(stats.HeapAlloc-p.parseRuntimeMemoryBaselineBytes) >= p.parseRuntimeMemoryBudgetBytes {
+		return ParseStopMemoryBudget
+	}
+	if stats.Sys > p.parseRuntimeMemoryBaselineSys &&
+		int64(stats.Sys-p.parseRuntimeMemoryBaselineSys) >= p.parseRuntimeMemoryBudgetBytes {
+		return ParseStopMemoryBudget
+	}
+	return ParseStopNone
+}

--- a/parser_memory_budget_runtime.go
+++ b/parser_memory_budget_runtime.go
@@ -2,16 +2,34 @@ package gotreesitter
 
 import "runtime"
 
-const parseRuntimeMemoryPollMask = 15
+const (
+	parseRuntimeMemoryPollMask       = 15
+	parseRuntimeMemoryMinSourceBytes = 64 * 1024
+)
 
-func (p *Parser) enterRuntimeMemoryBudget(bytes int64) func() {
-	if p == nil || bytes <= 0 {
-		return func() {}
+type runtimeMemoryBudgetRestore struct {
+	parser      *Parser
+	budget      int64
+	baseline    uint64
+	baselineSys uint64
+	poll        uint64
+}
+
+func runtimeMemoryBudgetEnabled(p *Parser, bytes int64, sourceLen int) bool {
+	return p != nil && bytes > 0 && sourceLen >= parseRuntimeMemoryMinSourceBytes
+}
+
+func (p *Parser) enterRuntimeMemoryBudget(bytes int64, sourceLen int) runtimeMemoryBudgetRestore {
+	if !runtimeMemoryBudgetEnabled(p, bytes, sourceLen) {
+		return runtimeMemoryBudgetRestore{}
 	}
-	prevBudget := p.parseRuntimeMemoryBudgetBytes
-	prevBaseline := p.parseRuntimeMemoryBaselineBytes
-	prevBaselineSys := p.parseRuntimeMemoryBaselineSys
-	prevPoll := p.parseRuntimeMemoryPoll
+	restore := runtimeMemoryBudgetRestore{
+		parser:      p,
+		budget:      p.parseRuntimeMemoryBudgetBytes,
+		baseline:    p.parseRuntimeMemoryBaselineBytes,
+		baselineSys: p.parseRuntimeMemoryBaselineSys,
+		poll:        p.parseRuntimeMemoryPoll,
+	}
 
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
@@ -20,12 +38,17 @@ func (p *Parser) enterRuntimeMemoryBudget(bytes int64) func() {
 	p.parseRuntimeMemoryBaselineSys = stats.Sys
 	p.parseRuntimeMemoryPoll = 0
 
-	return func() {
-		p.parseRuntimeMemoryBudgetBytes = prevBudget
-		p.parseRuntimeMemoryBaselineBytes = prevBaseline
-		p.parseRuntimeMemoryBaselineSys = prevBaselineSys
-		p.parseRuntimeMemoryPoll = prevPoll
+	return restore
+}
+
+func (r runtimeMemoryBudgetRestore) restore() {
+	if r.parser == nil {
+		return
 	}
+	r.parser.parseRuntimeMemoryBudgetBytes = r.budget
+	r.parser.parseRuntimeMemoryBaselineBytes = r.baseline
+	r.parser.parseRuntimeMemoryBaselineSys = r.baselineSys
+	r.parser.parseRuntimeMemoryPoll = r.poll
 }
 
 func (p *Parser) runtimeMemoryBudgetStopReason() ParseStopReason {

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -1,0 +1,14 @@
+package gotreesitter
+
+import "testing"
+
+func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
+	parser := &Parser{
+		parseRuntimeMemoryBudgetBytes:   1,
+		parseRuntimeMemoryBaselineBytes: 0,
+		parseRuntimeMemoryPoll:          parseRuntimeMemoryPollMask,
+	}
+	if got := parser.runtimeMemoryBudgetStopReason(); got != ParseStopMemoryBudget {
+		t.Fatalf("runtimeMemoryBudgetStopReason() = %q, want %q", got, ParseStopMemoryBudget)
+	}
+}

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -12,3 +12,26 @@ func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
 		t.Fatalf("runtimeMemoryBudgetStopReason() = %q, want %q", got, ParseStopMemoryBudget)
 	}
 }
+
+func TestRuntimeMemoryBudgetDisabledForSmallSource(t *testing.T) {
+	parser := &Parser{}
+	restore := parser.enterRuntimeMemoryBudget(1, parseRuntimeMemoryMinSourceBytes-1)
+	if restore.parser != nil {
+		t.Fatal("enterRuntimeMemoryBudget enabled for small source")
+	}
+	if parser.parseRuntimeMemoryBudgetBytes != 0 {
+		t.Fatalf("parseRuntimeMemoryBudgetBytes = %d, want 0", parser.parseRuntimeMemoryBudgetBytes)
+	}
+}
+
+func TestRuntimeMemoryBudgetEnabledForLargeSource(t *testing.T) {
+	parser := &Parser{}
+	restore := parser.enterRuntimeMemoryBudget(1, parseRuntimeMemoryMinSourceBytes)
+	if restore.parser != parser {
+		t.Fatal("enterRuntimeMemoryBudget did not return parser restore state")
+	}
+	defer restore.restore()
+	if parser.parseRuntimeMemoryBudgetBytes != 1 {
+		t.Fatalf("parseRuntimeMemoryBudgetBytes = %d, want 1", parser.parseRuntimeMemoryBudgetBytes)
+	}
+}

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1991,24 +1991,39 @@ func (p *Parser) cCollectPotentialReductions(state StateID, lookaheadSym Symbol,
 // With anyLookahead false, dead-end versions are dropped (C removes them).
 // EOF is symbol 0, so callers must pass anyLookahead explicitly instead of
 // overloading lookaheadSym == 0.
-func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookaheadSym Symbol, anyLookahead bool, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, bool) {
+func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookaheadSym Symbol, anyLookahead bool, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, bool, ParseStopReason) {
 	oldDisablePostReduceForkMerge := p.disablePostReduceForkMerge
 	p.disablePostReduceForkMerge = true
 	defer func() {
 		p.disablePostReduceForkMerge = oldDisablePostReduceForkMerge
 	}()
+	checkStop := func() ParseStopReason {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return reason
+		}
+		return ParseStopNone
+	}
+	if reason := checkStop(); reason != ParseStopNone {
+		return nil, false, reason
+	}
 
 	versions := []glrStack{start}
 	canShift := false
 	var reduces []ParseAction
 	v := 0
 	for iter := 0; ; iter++ {
+		if reason := checkStop(); reason != ParseStopNone {
+			return versions, canShift, reason
+		}
 		if v >= len(versions) {
 			break
 		}
 		// Merge check against earlier versions created in this call.
 		merged := false
 		for j := 0; j < v; j++ {
+			if reason := checkStop(); reason != ParseStopNone {
+				return versions, canShift, reason
+			}
 			if p.cTryMergeReductionVersion(&versions[j], &versions[v]) {
 				versions = append(versions[:v], versions[v+1:]...)
 				merged = true
@@ -2022,7 +2037,13 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 		hasShift := p.cCollectPotentialReductions(state, lookaheadSym, anyLookahead, &reduces)
 		lastReduction := -1
 		for _, act := range reduces {
-			actionCandidates := p.cReductionCandidatesForAction(source, versions[v], act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			if reason := checkStop(); reason != ParseStopNone {
+				return versions, canShift, reason
+			}
+			actionCandidates, reason := p.cReductionCandidatesForAction(source, versions[v], act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			if reason != ParseStopNone {
+				return versions, canShift, reason
+			}
 			actionReductionVersion := -1
 			if len(actionCandidates) > 0 {
 				versions, actionReductionVersion = p.cAppendActionReductionVersions(versions, actionCandidates, v, arena)
@@ -2063,26 +2084,39 @@ func (p *Parser) cDoAllPotentialReductions(source []byte, start glrStack, lookah
 			break
 		}
 	}
-	return versions, canShift
+	return versions, canShift, ParseStopNone
 }
 
-func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) []glrStack {
+func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, ParseStopReason) {
 	p.pendingForkStacks = p.pendingForkStacks[:0]
+	defer func() {
+		p.pendingForkStacks = p.pendingForkStacks[:0]
+	}()
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+		return nil, reason
+	}
 	fork := start.cloneWithScratch(gssScratch)
 	fork.cRec = start.cRec.clone()
 	var dummy bool
 	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+		return nil, reason
+	}
 	candidates := make([]glrStack, 0, 1+len(p.pendingForkStacks))
 	if !fork.dead {
 		candidates = append(candidates, fork)
 	}
 	for i := range p.pendingForkStacks {
+		if i&15 == 0 {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+				return candidates, reason
+			}
+		}
 		if !p.pendingForkStacks[i].dead {
 			candidates = append(candidates, p.pendingForkStacks[i])
 		}
 	}
-	p.pendingForkStacks = p.pendingForkStacks[:0]
-	return candidates
+	return candidates, ParseStopNone
 }
 
 func (p *Parser) cAppendActionReductionVersions(versions []glrStack, candidates []glrStack, originalVersion int, arena *nodeArena) ([]glrStack, int) {
@@ -2243,7 +2277,16 @@ func (p *Parser) cTerminalNextState(state StateID, sym Symbol) (StateID, ParseAc
 // and whether any new version still needs to act on the current token (the
 // missing-token versions and strategy-1 recoveries) — the caller must force a
 // re-dispatch pass for the same token.
-func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool) {
+func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool, ParseStopReason) {
+	checkStop := func() ParseStopReason {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return reason
+		}
+		return ParseStopNone
+	}
+	if reason := checkStop(); reason != ParseStopNone {
+		return cRecHalted, false, reason
+	}
 	s := &(*stacks)[si]
 	s.cPaused = false
 	// Sticky per-stack wreckage bit: this lineage is entering C error handling.
@@ -2288,7 +2331,10 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	p.crecoveryHandleErrorSingleStack = len(*stacks) == 1
 
 	// 1. Close in-progress productions: reductions reachable on any symbol.
-	versions, _ := p.cDoAllPotentialReductions(source, s.clone(), 0, true, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+	versions, _, reason := p.cDoAllPotentialReductions(source, s.clone(), 0, true, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+	if reason != ParseStopNone {
+		return cRecHalted, false, reason
+	}
 	group := &cRecGroup{}
 
 	// 2. Missing-token insertion (once across the version set, in order).
@@ -2297,9 +2343,17 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	var missingVersions []glrStack
 	if !p.isGraphQLRecoveryTripleQuote(tok.Symbol) {
 		for vi := range versions {
+			if reason := checkStop(); reason != ParseStopNone {
+				return cRecHalted, false, reason
+			}
 			state := versions[vi].top().state
 			tokenCount := Symbol(p.language.TokenCount)
 			for ms := Symbol(1); ms < tokenCount; ms++ {
+				if ms&63 == 0 {
+					if reason := checkStop(); reason != ParseStopNone {
+						return cRecHalted, false, reason
+					}
+				}
 				nextState, shiftAct, ok := p.cTerminalNextState(state, ms)
 				if !ok || nextState == 0 || nextState == state {
 					continue
@@ -2326,6 +2380,9 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				}
 				var dummy bool
 				p.applyAction(source, &cand, shiftAct, missingTok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)
+				if reason := checkStop(); reason != ParseStopNone {
+					return cRecHalted, false, reason
+				}
 				if p.rejectUndrainedPendingForkStacks(&cand) {
 					continue
 				}
@@ -2333,7 +2390,10 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				if cand.dead {
 					continue
 				}
-				reduced, canShift := p.cDoAllPotentialReductions(source, cand, tok.Symbol, false, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+				reduced, canShift, reason := p.cDoAllPotentialReductions(source, cand, tok.Symbol, false, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+				if reason != ParseStopNone {
+					return cRecHalted, false, reason
+				}
 				if !canShift || len(reduced) == 0 {
 					continue
 				}
@@ -2353,12 +2413,18 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// cRecGroup — the engine equivalent of C merging them into one version
 	// before ts_stack_record_summary.
 	for vi := range versions {
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, false, reason
+		}
 		v := &versions[vi]
 		v.pushEntry(stackEntry{state: cErrorState}, entryScratch, gssScratch)
 		v.shifted = false
 	}
 	p.cApplyMergedErrorGroupBaseline(versions)
 	for vi := range versions {
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, false, reason
+		}
 		v := &versions[vi]
 		entries := cStackEntriesTopFirst(v, gssScratch)
 		if debugRecoveryCycleChecks {
@@ -2375,6 +2441,9 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// The original stack becomes the first absorbing version.
 	*s = versions[0]
 	for vi := 1; vi < len(versions); vi++ {
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, false, reason
+		}
 		*stacks = append(*stacks, versions[vi])
 	}
 
@@ -2388,6 +2457,9 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// the missing versions before the recover pass for the same visibility.
 	needsRedispatch := false
 	for vi := range missingVersions {
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, false, reason
+		}
 		missingVersions[vi].branchOrder = (*stacks)[si].branchOrder
 		missingVersions[vi].cRecoverMissingGroup = group
 		*stacks = append(*stacks, missingVersions[vi])
@@ -2400,11 +2472,17 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	outcome := cRecoverOutcome(cRecConsumed)
 	first := true
 	for i := 0; i < len(*stacks); i++ {
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, needsRedispatch, reason
+		}
 		v := &(*stacks)[i]
 		if v.dead || v.cRec == nil || v.cRec.group != group {
 			continue
 		}
-		res, forked := p.cRecover(stacks, v, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+		res, forked, reason := p.cRecover(stacks, v, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+		if reason != ParseStopNone {
+			return cRecHalted, needsRedispatch || forked, reason
+		}
 		v = &(*stacks)[i]
 		if forked {
 			needsRedispatch = true
@@ -2416,7 +2494,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 			v.dead = true
 		}
 	}
-	return outcome, needsRedispatch
+	return outcome, needsRedispatch, ParseStopNone
 }
 
 // ---------------------------------------------------------------------------
@@ -2430,13 +2508,27 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 // forked=true: the fork must act on the current token), absorb the token into
 // the open error region (cRecConsumed), accept at EOF (cRecConsumed), or halt
 // the member (cRecHalted).
-func (p *Parser) cRecover(stacks *[]glrStack, v *glrStack, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool) {
+func (p *Parser) cRecover(stacks *[]glrStack, v *glrStack, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool, ParseStopReason) {
+	checkStop := func() ParseStopReason {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return reason
+		}
+		return ParseStopNone
+	}
+	if reason := checkStop(); reason != ParseStopNone {
+		return cRecHalted, false, reason
+	}
 	rec := v.cRec
 	if rec == nil {
-		return cRecFallthrough, false
+		return cRecFallthrough, false, ParseStopNone
 	}
 	vIndex := -1
 	for i := range *stacks {
+		if i&63 == 0 {
+			if reason := checkStop(); reason != ParseStopNone {
+				return cRecHalted, false, reason
+			}
+		}
 		if &(*stacks)[i] == v {
 			vIndex = i
 			break
@@ -2452,7 +2544,11 @@ func (p *Parser) cRecover(stacks *[]glrStack, v *glrStack, source []byte, tok To
 			g.electionDone = true
 			g.electionTokenStart = tok.StartByte
 			g.electionTokenSymbol = tok.Symbol
-			didRecover, forked = p.cRecoverStrategy1Election(stacks, g, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			var reason ParseStopReason
+			didRecover, forked, reason = p.cRecoverStrategy1Election(stacks, g, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			if reason != ParseStopNone {
+				return cRecHalted, forked, reason
+			}
 			// Re-resolve v: the fork append may have reallocated the slice.
 			if vIndex >= 0 {
 				v = &(*stacks)[vIndex]
@@ -2466,13 +2562,19 @@ func (p *Parser) cRecover(stacks *[]glrStack, v *glrStack, source []byte, tok To
 	// absorbing paths inside a single merged version).
 	if didRecover && p.cEffectiveVersionCount(*stacks, rec.group) > cRecoverMaxVersionCount {
 		v.dead = true
-		return cRecHalted, forked
+		return cRecHalted, forked, ParseStopNone
 	}
 
 	// EOF: wrap everything and accept (ts_parser__recover recover_eof).
 	if tok.Symbol == 0 && tok.StartByte == tok.EndByte {
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, forked, reason
+		}
 		p.cRecoverEOFAccept(v, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
-		return cRecConsumed, forked
+		if reason := checkStop(); reason != ParseStopNone {
+			return cRecHalted, forked, reason
+		}
+		return cRecConsumed, forked, ParseStopNone
 	}
 
 	// An unlexable-run lookahead while the region already holds content re-runs
@@ -2505,18 +2607,27 @@ func (p *Parser) cRecover(stacks *[]glrStack, v *glrStack, source []byte, tok To
 	// `static function`: C's absorber survives to EOF and its lineage
 	// provides the final `(program php_tag (ERROR ...) compound_statement)`
 	// shape).
+	if reason := checkStop(); reason != ParseStopNone {
+		return cRecHalted, forked, reason
+	}
 	if vIndex >= 0 && p.cBetterVersionExists(*stacks, vIndex, false, newCost) {
 		v.dead = true
-		return cRecHalted, forked
+		return cRecHalted, forked, ParseStopNone
 	}
 
 	// Wrap the lookahead into the open error region (strategy 2).
 	if !p.guardRealTokenAttachmentGap(source, v, tok, "c-recover") {
-		return cRecHalted, forked
+		return cRecHalted, forked, ParseStopNone
+	}
+	if reason := checkStop(); reason != ParseStopNone {
+		return cRecHalted, forked, reason
 	}
 	p.cAbsorbTokenIntoError(v, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+	if reason := checkStop(); reason != ParseStopNone {
+		return cRecHalted, forked, reason
+	}
 	v.shifted = true
-	return cRecConsumed, forked
+	return cRecConsumed, forked, ParseStopNone
 }
 
 // cEffectiveVersionCount counts live stacks with the absorbing group folded
@@ -2622,7 +2733,16 @@ func (p *Parser) cRecoverElectionLookaheadSymbol(source []byte, member *glrStack
 //     the lookahead would have had no actions in that entry's state;
 //   - entries are deduped on (depth, state) at first encounter, mirroring
 //     ts_stack_record_summary's record-time dedup across the merged paths.
-func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (didRecover, forked bool) {
+func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (didRecover, forked bool, reason ParseStopReason) {
+	checkStop := func() ParseStopReason {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return reason
+		}
+		return ParseStopNone
+	}
+	if reason := checkStop(); reason != ParseStopNone {
+		return false, false, reason
+	}
 	// C runs the summary scan for every non-error lookahead INCLUDING the EOF
 	// token (parser.c ts_parser__recover: `summary && !ts_subtree_is_error`).
 	// EOF election is what lets C pop the open error region to a state where
@@ -2631,22 +2751,27 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 	// this engine's unlexable run (C: error-subtree lookahead) — C skips
 	// strategy 1 for those.
 	if tok.Symbol == errorSymbol {
-		return false, false
+		return false, false, ParseStopNone
 	}
 	if p.isGraphQLRecoveryTripleQuote(tok.Symbol) {
-		return false, false
+		return false, false, ParseStopNone
 	}
 	if tok.Symbol == 0 && tok.StartByte != tok.EndByte {
-		return false, false
+		return false, false, ParseStopNone
 	}
 	var members []int
 	for i := range *stacks {
+		if i&63 == 0 {
+			if reason := checkStop(); reason != ParseStopNone {
+				return false, false, reason
+			}
+		}
 		if !(*stacks)[i].dead && (*stacks)[i].cRec != nil && (*stacks)[i].cRec.group == group {
 			members = append(members, i)
 		}
 	}
 	if len(members) == 0 {
-		return false, false
+		return false, false, ParseStopNone
 	}
 	cSortRecoverMembersByGroupOrder((*stacks), members)
 	// C computes position, error cost and node-count-since-error once for the
@@ -2666,7 +2791,7 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 	electionSym := p.cRecoverElectionLookaheadSymbol(source, &(*stacks)[m0], tok)
 	if electionSym == errorSymbol {
 		// C skips strategy 1 for error-subtree lookaheads.
-		return false, false
+		return false, false, ParseStopNone
 	}
 	type seenKey struct {
 		depth int
@@ -2674,8 +2799,19 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 	}
 	seen := make(map[seenKey]bool, 16)
 	for d := 0; d <= cRecoverMaxSummaryDepth+1; d++ {
+		if reason := checkStop(); reason != ParseStopNone {
+			return false, false, reason
+		}
 		for _, mi := range members {
+			if reason := checkStop(); reason != ParseStopNone {
+				return false, false, reason
+			}
 			for _, entry := range (*stacks)[mi].cRec.summary {
+				if len(seen)&63 == 0 {
+					if reason := checkStop(); reason != ParseStopNone {
+						return false, false, reason
+					}
+				}
 				if entry.depth != d {
 					continue
 				}
@@ -2714,12 +2850,18 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 					(pos-entry.posBytes)*cErrCostPerSkippedChar +
 					(curRow-entry.posRow)*cErrCostPerSkippedLine
 				if p.cBetterVersionExists(*stacks, m0, false, newCost) {
-					return false, false
+					return false, false, ParseStopNone
 				}
 				if p.lookupActionIndex(entry.state, electionSym) == 0 {
 					continue
 				}
+				if reason := checkStop(); reason != ParseStopNone {
+					return false, false, reason
+				}
 				if fork, ok := p.cRecoverToState(&(*stacks)[mi], depth, entry.state, arena, entryScratch, gssScratch, trackChildErrors); ok {
+					if reason := checkStop(); reason != ParseStopNone {
+						return false, false, reason
+					}
 					fork.branchOrder = (*stacks)[mi].branchOrder
 					*stacks = append(*stacks, fork)
 					if nodeCount != nil {
@@ -2728,12 +2870,12 @@ func (p *Parser) cRecoverStrategy1Election(stacks *[]glrStack, group *cRecGroup,
 					if p.glrTrace {
 						traceCRecoverToState(entry.state, depth)
 					}
-					return true, true
+					return true, true, ParseStopNone
 				}
 			}
 		}
 	}
-	return false, false
+	return false, false, ParseStopNone
 }
 
 func cSortRecoverMembersByGroupOrder(stacks []glrStack, members []int) {
@@ -2848,6 +2990,26 @@ func (p *Parser) cAppendVisibleSplice(dst []*Node, n *Node) []*Node {
 		dst = p.cAppendVisibleSplice(dst, c)
 	}
 	return dst
+}
+
+func (p *Parser) cAppendVisibleSpliceUntil(dst []*Node, n *Node, limit int) ([]*Node, bool) {
+	if n == nil {
+		return dst, true
+	}
+	if n.symbol == errorSymbol || n.isMissing() || p.cSymbolVisible(n.symbol) {
+		if limit >= 0 && len(dst) >= limit {
+			return dst, false
+		}
+		return append(dst, n), true
+	}
+	for _, c := range n.children {
+		var ok bool
+		dst, ok = p.cAppendVisibleSpliceUntil(dst, c, limit)
+		if !ok {
+			return dst, false
+		}
+	}
+	return dst, true
 }
 
 // cSetNodeSpan pins a recovery node's span explicitly: C error regions span
@@ -3159,12 +3321,12 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 // error, and non-terminal extras (e.g. requirements' linebreak) enter their
 // sub-parse via a real shift in the state-0 row. Everything else goes through
 // ts_parser__recover.
-func (p *Parser) cRecoverDispatchInError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool) {
+func (p *Parser) cRecoverDispatchInError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool, ParseStopReason) {
 	s := &(*stacks)[si]
 	if s.top().state != cErrorState {
 		// Mid non-terminal-extra parse: the version temporarily left
 		// ERROR_STATE; C dispatches it through the normal table rows.
-		return cRecFallthrough, false
+		return cRecFallthrough, false, ParseStopNone
 	}
 	if tok.Symbol != 0 {
 		if p.isGraphQLRecoveryTripleQuote(tok.Symbol) {
@@ -3173,7 +3335,7 @@ func (p *Parser) cRecoverDispatchInError(stacks *[]glrStack, si int, source []by
 		if idx := p.lookupActionIndex(cErrorState, tok.Symbol); idx != 0 && int(idx) < len(p.language.ParseActions) {
 			if actions := p.language.ParseActions[idx].Actions; len(actions) > 0 &&
 				actions[0].Type == ParseActionShift {
-				return cRecFallthrough, false
+				return cRecFallthrough, false, ParseStopNone
 			}
 		}
 		// Zero-width non-EOF tokens are skipped (C's error-mode lexer never
@@ -3187,7 +3349,7 @@ func (p *Parser) cRecoverDispatchInError(stacks *[]glrStack, si int, source []by
 				s.byteOffset = tok.EndByte
 			}
 			s.shifted = true
-			return cRecConsumed, false
+			return cRecConsumed, false, ParseStopNone
 		}
 	}
 	return p.cRecover(stacks, s, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
@@ -3211,10 +3373,20 @@ func (p *Parser) isGraphQLRecoveryTripleQuote(sym Symbol) bool {
 //
 // Returns the condensed slice, whether new versions need to re-dispatch
 // the current token (strategy-1 forks / missing-token versions created by a
-// resumed handle_error), and the possibly error-mode-relexed current token
+// resumed handle_error), the possibly error-mode-relexed current token
 // (see cRecoverResumeLookahead) which the caller must adopt so redispatched
-// versions act on the same lookahead the resumed group consumed.
-func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, bool, Token) {
+// versions act on the same lookahead the resumed group consumed, and any
+// active budget/timeout stop reason encountered while condensing.
+func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) ([]glrStack, bool, Token, ParseStopReason) {
+	checkStop := func() ParseStopReason {
+		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+			return reason
+		}
+		return ParseStopNone
+	}
+	if reason := checkStop(); reason != ParseStopNone {
+		return stacks, false, tok, reason
+	}
 	relevant := false
 	for i := range stacks {
 		if stacks[i].cPaused || stacks[i].cRec != nil || stacks[i].cRecoverMissingGroup != nil {
@@ -3224,6 +3396,9 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 	}
 	if debugRecoveryCycleChecks && relevant {
 		for i := range stacks {
+			if reason := checkStop(); reason != ParseStopNone {
+				return stacks, false, tok, reason
+			}
 			if stacks[i].dead {
 				continue
 			}
@@ -3232,7 +3407,7 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		}
 	}
 	if !relevant {
-		return stacks, false, tok
+		return stacks, false, tok, ParseStopNone
 	}
 	// Drop dead versions first (C removes halted versions in condense).
 	// Accepted versions have left the pool in C (ts_parser__accept stashes
@@ -3242,6 +3417,9 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 	var acceptedStacks []glrStack
 	alive := stacks[:0]
 	for i := range stacks {
+		if reason := checkStop(); reason != ParseStopNone {
+			return stacks, false, tok, reason
+		}
 		if stacks[i].dead {
 			continue
 		}
@@ -3252,9 +3430,19 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		alive = append(alive, stacks[i])
 	}
 	stacks = alive
+	statusProbe := 0
 	for i := 1; i < len(stacks); i++ {
+		if reason := checkStop(); reason != ParseStopNone {
+			return stacks, false, tok, reason
+		}
 		statusI := p.cVersionStatus(&stacks[i])
 		for j := 0; j < i; j++ {
+			statusProbe++
+			if statusProbe&63 == 0 {
+				if reason := checkStop(); reason != ParseStopNone {
+					return stacks, false, tok, reason
+				}
+			}
 			if cRecoverVersionsSameGroup(stacks[j], stacks[i]) {
 				continue
 			}
@@ -3320,6 +3508,9 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		// discipline.
 		keyRanks := make(map[cCondenseVersionKey]int, len(stacks))
 		for i := 0; i < len(stacks); i++ {
+			if reason := checkStop(); reason != ParseStopNone {
+				return stacks, false, tok, reason
+			}
 			key := p.cCondenseVersionKeyFor(&stacks[i])
 			rank, seen := keyRanks[key]
 			if !seen {
@@ -3359,6 +3550,9 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 	needsRedispatch := false
 	hasUnpaused := false
 	for i := 0; i < len(stacks); i++ {
+		if reason := checkStop(); reason != ParseStopNone {
+			return stacks, false, tok, reason
+		}
 		if !stacks[i].cPaused {
 			hasUnpaused = true
 			continue
@@ -3378,7 +3572,16 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 				}
 				tok = replacement
 			}
-			outcome, redispatch := p.cHandleError(&stacks, i, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			if reason := checkStop(); reason != ParseStopNone {
+				return stacks, false, tok, reason
+			}
+			outcome, redispatch, reason := p.cHandleError(&stacks, i, source, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
+			if reason != ParseStopNone {
+				return stacks, false, tok, reason
+			}
+			if reason := checkStop(); reason != ParseStopNone {
+				return stacks, false, tok, reason
+			}
 			if redispatch {
 				needsRedispatch = true
 			}
@@ -3396,7 +3599,7 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		i--
 	}
 	stacks = append(stacks, acceptedStacks...)
-	return stacks, needsRedispatch, tok
+	return stacks, needsRedispatch, tok, ParseStopNone
 }
 
 func (p *Parser) traceCCondenseDrop(reason string, dropIndex, keepIndex int, drop, keep glrStack, dropStatus, keepStatus cErrorStatus) {
@@ -3513,9 +3716,9 @@ func cRecoverVersionShouldStayBefore(a, b glrStack) bool {
 // The stack becomes [base, rebuiltRoot]. Stacks that already hold a single
 // payload node are left untouched (the no-error fast path and
 // cRecoverEOFAccept results).
-func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch) {
+func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch) ParseStopReason {
 	if p == nil || s == nil || !s.accepted {
-		return
+		return ParseStopNone
 	}
 	entries := cStackEntriesTopFirst(s, gssScratch)
 	payloads := 0
@@ -3525,7 +3728,7 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 		}
 	}
 	if payloads <= 1 {
-		return
+		return ParseStopNone
 	}
 	// Materialize base-most first, mirroring C's popped subtree order.
 	nodes := make([]*Node, 0, payloads)
@@ -3535,7 +3738,7 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 		}
 		n, _ := materializeStackEntryPayloadEntryWithParser(p, arena, entries[i], materializeForRecovery, materializeForRecovery)
 		if n == nil {
-			return
+			return ParseStopNone
 		}
 		nodes = append(nodes, n)
 	}
@@ -3548,17 +3751,41 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 		}
 	}
 	if rootIdx < 0 {
-		return
+		return ParseStopNone
 	}
 	cand := nodes[rootIdx]
-	children := make([]*Node, 0, len(nodes)-1+len(cand.children))
+	childLimit := cAcceptRootRebuildChildLimit(arena)
+	initialCap := min(len(nodes)-1+len(cand.children), 1024)
+	children := make([]*Node, 0, initialCap)
 	for _, n := range nodes[:rootIdx] {
-		children = p.cAppendVisibleSplice(children, n)
+		var ok bool
+		children, ok = p.cAppendVisibleSpliceUntil(children, n, childLimit)
+		if !ok {
+			return ParseStopMemoryBudget
+		}
 	}
-	children = append(children, cand.children...)
+	var ok bool
+	children, ok = cAppendNodeSliceUntil(children, cand.children, childLimit)
+	if !ok {
+		return ParseStopMemoryBudget
+	}
 	for _, n := range nodes[rootIdx+1:] {
-		children = p.cAppendVisibleSplice(children, n)
+		var ok bool
+		children, ok = p.cAppendVisibleSpliceUntil(children, n, childLimit)
+		if !ok {
+			return ParseStopMemoryBudget
+		}
 	}
+	if arena != nil && arena.budgetBytes > 0 {
+		used := arena.allocatedBytes - arena.budgetBaselineBytes
+		if used < 0 {
+			used = 0
+		}
+		if used+childSliceBytesForCap(len(children)) >= arena.budgetBytes {
+			return ParseStopMemoryBudget
+		}
+	}
+	children = cloneNodeSliceInArena(arena, children)
 	root := p.newRecoveryParentNodeInArena(arena, cand.symbol, p.isNamedSymbol(cand.symbol), children, 0)
 	root.rawShape = captureRawShapeForNodeSlice(arena, cand.symbol, cand.productionID, children)
 	root.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
@@ -3576,12 +3803,44 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 	}
 	nodeBumpEquivVersion(root)
 	if !s.truncate(1) {
-		return
+		return ParseStopNone
 	}
 	p.pushStackNode(s, 1, root, entryScratch, gssScratch)
 	if debugRecoveryCycleChecks {
 		debugRecoveryCheckNodeAcyclic(p, arena, "accept-root-rebuild", root)
 	}
+	return ParseStopNone
+}
+
+func cAcceptRootRebuildChildLimit(arena *nodeArena) int {
+	if arena == nil || arena.budgetBytes <= 0 {
+		return -1
+	}
+	used := arena.allocatedBytes - arena.budgetBaselineBytes
+	if used < 0 {
+		used = 0
+	}
+	remaining := arena.budgetBytes - used
+	if remaining <= 0 {
+		return 0
+	}
+	perChildPeakBytes := childSliceBytesForCap(1) * 2
+	if perChildPeakBytes <= 0 {
+		return -1
+	}
+	limit := remaining / perChildPeakBytes
+	maxInt := int64(^uint(0) >> 1)
+	if limit > maxInt {
+		return -1
+	}
+	return int(limit)
+}
+
+func cAppendNodeSliceUntil(dst, src []*Node, limit int) ([]*Node, bool) {
+	if limit >= 0 && len(dst)+len(src) > limit {
+		return dst, false
+	}
+	return append(dst, src...), true
 }
 
 func nodeSliceDynamicPrecedence(children []*Node) int32 {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -68,7 +68,7 @@ func TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken(t *testing.T) {
 	stacks := []glrStack{stack}
 	nodeCount := 0
 
-	outcome, forked := parser.cRecoverDispatchInError(
+	outcome, forked, reason := parser.cRecoverDispatchInError(
 		&stacks,
 		0,
 		[]byte("012345678901234567890"),
@@ -80,6 +80,9 @@ func TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken(t *testing.T) {
 		nil,
 	)
 
+	if reason != ParseStopNone {
+		t.Fatalf("cRecoverDispatchInError stop reason = %v, want none", reason)
+	}
 	if outcome != cRecConsumed || forked {
 		t.Fatalf("outcome/forked = %v/%t, want %v/false", outcome, forked, cRecConsumed)
 	}
@@ -114,7 +117,7 @@ func TestCRecoverDispatchInErrorAbsorbsZeroWidthSkippedTokenAtCurrentOffset(t *t
 	stacks := []glrStack{stack}
 	nodeCount := 0
 
-	outcome, forked := parser.cRecoverDispatchInError(
+	outcome, forked, reason := parser.cRecoverDispatchInError(
 		&stacks,
 		0,
 		[]byte("012345678901234567890"),
@@ -126,6 +129,9 @@ func TestCRecoverDispatchInErrorAbsorbsZeroWidthSkippedTokenAtCurrentOffset(t *t
 		nil,
 	)
 
+	if reason != ParseStopNone {
+		t.Fatalf("cRecoverDispatchInError stop reason = %v, want none", reason)
+	}
 	if outcome != cRecConsumed || forked {
 		t.Fatalf("outcome/forked = %v/%t, want %v/false", outcome, forked, cRecConsumed)
 	}
@@ -338,7 +344,10 @@ func TestCRecoverStrategy1ElectionDedupesDuplicateEntryAcrossMembers(t *testing.
 		cRecoveryElectionStack(arena, 2, 3, 10, group, 1, []cStackSummaryEntry{entry}),
 	}
 	nodeCount := 0
-	didRecover, forked := parser.cRecoverStrategy1Election(&stacks, group, nil, Token{Symbol: 1}, &nodeCount, arena, nil, nil, nil)
+	didRecover, forked, reason := parser.cRecoverStrategy1Election(&stacks, group, nil, Token{Symbol: 1}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cRecoverStrategy1Election stop reason = %v, want none", reason)
+	}
 	if didRecover || forked {
 		t.Fatalf("strategy 1 election = didRecover %v forked %v, want false/false (entry position equals the merged version position; duplicate entries dedupe at first encounter)", didRecover, forked)
 	}
@@ -361,7 +370,10 @@ func TestCRecoverStrategy1ElectionIgnoresBetterVersionForNoActionEntry(t *testin
 		cRecoveryElectionPlainStack(arena, 4, 4, 2500),
 	}
 	nodeCount := 0
-	didRecover, forked := parser.cRecoverStrategy1Election(&stacks, group, nil, Token{Symbol: 1}, &nodeCount, arena, nil, nil, nil)
+	didRecover, forked, reason := parser.cRecoverStrategy1Election(&stacks, group, nil, Token{Symbol: 1}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cRecoverStrategy1Election stop reason = %v, want none", reason)
+	}
 	if !didRecover || !forked {
 		t.Fatalf("strategy 1 election = didRecover %v forked %v, want true/true", didRecover, forked)
 	}
@@ -393,7 +405,10 @@ func TestCRecoverStrategy1ElectionUsesMergedVersionCostBasis(t *testing.T) {
 		cRecoveryElectionPlainStack(arena, 4, 4, 2500),
 	}
 	nodeCount := 0
-	didRecover, forked := parser.cRecoverStrategy1Election(&stacks, group, nil, Token{Symbol: 1}, &nodeCount, arena, nil, nil, nil)
+	didRecover, forked, reason := parser.cRecoverStrategy1Election(&stacks, group, nil, Token{Symbol: 1}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cRecoverStrategy1Election stop reason = %v, want none", reason)
+	}
 	if didRecover || forked {
 		t.Fatalf("strategy 1 election = didRecover %v forked %v, want false/false (merged-version cost makes the entry clearly worse than the clean sibling, aborting the scan)", didRecover, forked)
 	}
@@ -480,7 +495,10 @@ func TestCDoAllPotentialReductionsCollapsesSamePopTargetSlicesByCParentSelection
 	start := glrStack{gss: gssStack{head: rightNode}, byteOffset: 2}
 
 	nodeCount := 0
-	versions, canShift := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
 	if canShift {
 		t.Fatal("canShift = true, want false")
 	}
@@ -543,7 +561,10 @@ func TestCDoAllPotentialReductionsCollapsesSamePopWithTrailingExtra(t *testing.T
 	start := glrStack{gss: gssStack{head: head}, byteOffset: 3}
 
 	nodeCount := 0
-	versions, canShift := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, &scratch, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
 	if canShift {
 		t.Fatal("canShift = true, want false")
 	}
@@ -699,7 +720,10 @@ func TestCDoAllPotentialReductionsKeepsShiftableOriginalWithReductionFork(t *tes
 	start.pushEntry(newStackEntryNode(3, leaf), nil, nil)
 
 	nodeCount := 0
-	versions, canShift := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, start, 0, true, Token{}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
 	if !canShift {
 		t.Fatal("canShift = false, want true from the shiftable original state")
 	}
@@ -742,17 +766,26 @@ func TestCDoAllPotentialReductionsDistinguishesEOFFromAnyLookahead(t *testing.T)
 	defer arena.Release()
 
 	nodeCount := 0
-	versions, canShift := parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, true, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason := parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, true, Token{}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
 	if !canShift || len(versions) != 1 {
 		t.Fatalf("any-lookahead reductions: canShift=%v versions=%d, want true/1", canShift, len(versions))
 	}
 
-	versions, canShift = parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, false, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason = parser.cDoAllPotentialReductions(nil, newGLRStack(1), 0, false, Token{}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
 	if canShift || len(versions) != 0 {
 		t.Fatalf("exact EOF reductions on non-EOF state: canShift=%v versions=%d, want false/0", canShift, len(versions))
 	}
 
-	versions, canShift = parser.cDoAllPotentialReductions(nil, newGLRStack(2), 0, false, Token{}, &nodeCount, arena, nil, nil, nil)
+	versions, canShift, reason = parser.cDoAllPotentialReductions(nil, newGLRStack(2), 0, false, Token{}, &nodeCount, arena, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cDoAllPotentialReductions stop reason = %v, want none", reason)
+	}
 	if !canShift || len(versions) != 1 {
 		t.Fatalf("exact EOF accept reductions: canShift=%v versions=%d, want true/1", canShift, len(versions))
 	}
@@ -850,7 +883,10 @@ func TestCCondenseAndResumeComparesMissingGroupStacks(t *testing.T) {
 	}
 
 	var nodeCount int
-	condensed, resumed, _ := parser.cCondenseAndResume([]glrStack{missing, clean}, nil, Token{Symbol: 1}, &nodeCount, nil, nil, nil, nil)
+	condensed, resumed, _, reason := parser.cCondenseAndResume([]glrStack{missing, clean}, nil, Token{Symbol: 1}, &nodeCount, nil, nil, nil, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("cCondenseAndResume stop reason = %v, want none", reason)
+	}
 	if resumed {
 		t.Fatal("cCondenseAndResume resumed without paused/error-state versions")
 	}

--- a/parser_result.go
+++ b/parser_result.go
@@ -145,6 +145,27 @@ func (p *Parser) currentMaterializationTiming() *parseMaterializationTiming {
 	return p.materializationTiming
 }
 
+func (p *Parser) resultMaterializationStopReason(arena *nodeArena) ParseStopReason {
+	if p != nil {
+		if reason := p.parseStopReasonNow(); parseStopReasonIsActive(reason) {
+			return reason
+		}
+	}
+	if arena != nil && arena.budgetExhausted() {
+		return ParseStopMemoryBudget
+	}
+	if p != nil {
+		if reason := p.runtimeMemoryBudgetStopReason(); reason == ParseStopMemoryBudget {
+			return reason
+		}
+	}
+	return ParseStopNone
+}
+
+func resultMaterializationShouldStop(reason ParseStopReason) bool {
+	return parseStopReasonIsActive(reason) || reason == ParseStopMemoryBudget
+}
+
 // hasCleanSiblingAtSamePosition reports whether some other live (non-dead)
 // stack in stacks, besides self, reaches the same final byte position as
 // stacks[self] without itself carrying an unvalidated C-recovery marker. Used
@@ -183,7 +204,7 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		tree.setParseStopReason(reason)
 		return tree
 	}
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 		return errorTreeWithStopReason(reason)
 	}
 	if len(stacks) == 0 {
@@ -198,7 +219,7 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 	best := 0
 	for i := 1; i < len(stacks); i++ {
 		if i&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return errorTreeWithStopReason(reason)
 			}
 		}
@@ -237,7 +258,7 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 	if p.glrTrace && p.errorCostCompetitionEnabled() {
 		p.traceCResultSelectionSelected(best, &selected, arena)
 	}
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 		return errorTreeWithStopReason(reason)
 	}
 	if len(selected.entries) > 0 {
@@ -245,7 +266,7 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		if materializationTiming != nil {
 			materializeStart = time.Now()
 		}
-		if reason := materializeTransientParentEntries(selected.entries, arena, transientParents, transientChildren, p); parseStopReasonIsTerminal(reason) {
+		if reason := materializeTransientParentEntries(selected.entries, arena, transientParents, transientChildren, p); resultMaterializationShouldStop(reason) {
 			return errorTreeWithStopReason(reason)
 		}
 		if materializationTiming != nil {
@@ -272,12 +293,15 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		}
 		return tree
 	}
-	nodes := nodesFromGSSMaterializingCompactFullLeaves(p, selected.gss, arena)
+	nodes, reason := nodesFromGSSMaterializingCompactFullLeaves(p, selected.gss, arena)
+	if resultMaterializationShouldStop(reason) {
+		return errorTreeWithStopReason(reason)
+	}
 	materializeStart := time.Time{}
 	if materializationTiming != nil {
 		materializeStart = time.Now()
 	}
-	if reason := materializeTransientParentNodes(nodes, arena, transientParents, transientChildren, p); parseStopReasonIsTerminal(reason) {
+	if reason := materializeTransientParentNodes(nodes, arena, transientParents, transientChildren, p); resultMaterializationShouldStop(reason) {
 		return errorTreeWithStopReason(reason)
 	}
 	if materializationTiming != nil {
@@ -1313,9 +1337,9 @@ func nodesFromGSS(stack gssStack) []*Node {
 	return nodes
 }
 
-func nodesFromGSSMaterializingCompactFullLeaves(p *Parser, stack gssStack, arena *nodeArena) []*Node {
+func nodesFromGSSMaterializingCompactFullLeaves(p *Parser, stack gssStack, arena *nodeArena) ([]*Node, ParseStopReason) {
 	if stack.head == nil {
-		return nil
+		return nil, ParseStopNone
 	}
 	count := 0
 	for n := stack.head; n != nil; n = n.prev {
@@ -1324,17 +1348,25 @@ func nodesFromGSSMaterializingCompactFullLeaves(p *Parser, stack gssStack, arena
 		}
 	}
 	if count == 0 {
-		return nil
+		return nil, ParseStopNone
 	}
 	nodes := make([]*Node, count)
 	i := count - 1
 	for n := stack.head; n != nil; n = n.prev {
+		if i&255 == 0 {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+				return nil, reason
+			}
+		}
 		if node := materializeStackEntryPayloadWithParser(p, arena, &n.entry, compactFullLeafMaterializeForFinalTree, pendingParentMaterializeForFinalTree); node != nil {
 			nodes[i] = node
 			i--
 		}
 	}
-	return nodes
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
+		return nil, reason
+	}
+	return nodes, ParseStopNone
 }
 
 func filterZeroWidthExtras(nodes []*Node, arena *nodeArena) []*Node {
@@ -1367,7 +1399,7 @@ func filterZeroWidthExtras(nodes []*Node, arena *nodeArena) []*Node {
 
 // buildResult constructs the final Tree from a stack of entries.
 func (p *Parser) buildResult(stack []stackEntry, source []byte, arena *nodeArena, oldTree *Tree, reuseState *parseReuseState, linkScratch *[]*Node) *Tree {
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 		tree := parseErrorTreeWithArena(source, p.language, arena)
 		tree.setParseStopReason(reason)
 		return tree
@@ -1375,7 +1407,7 @@ func (p *Parser) buildResult(stack []stackEntry, source []byte, arena *nodeArena
 	var nodes []*Node
 	for i := range stack {
 		if i&255 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				tree := parseErrorTreeWithArena(source, p.language, arena)
 				tree.setParseStopReason(reason)
 				return tree
@@ -1389,7 +1421,7 @@ func (p *Parser) buildResult(stack []stackEntry, source []byte, arena *nodeArena
 }
 
 func (p *Parser) buildResultFromNodes(nodes []*Node, source []byte, arena *nodeArena, oldTree *Tree, reuseState *parseReuseState, linkScratch *[]*Node) *Tree {
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 		tree := parseErrorTreeWithArena(source, p.language, arena)
 		tree.setParseStopReason(reason)
 		return tree

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -45,7 +45,12 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCo
 		return result
 	}
 	normalizeRootTrailingExtraTriviaCompatibility(root, source, lang)
-	normalizeResultTerminalLeafNodes(root, lang)
+	var terminalReason ParseStopReason
+	_, terminalReason = normalizeResultTerminalLeafNodesWithStop(root, lang, ctx.stopCheck)
+	if parseStopReasonIsActive(terminalReason) {
+		result.stopReason = terminalReason
+		return result
+	}
 	normalizeResultCollapsedNamedLeafChildren(root, lang)
 	result.stopReason = ctx.stopReason()
 	return result

--- a/parser_result_node_helpers.go
+++ b/parser_result_node_helpers.go
@@ -96,6 +96,36 @@ func walkResultTree(root *Node, visit func(*Node)) {
 	walk(root)
 }
 
+func walkResultTreeUntil(root *Node, visit func(*Node) bool) bool {
+	if visit == nil {
+		return true
+	}
+	var walk func(*Node) bool
+	walk = func(n *Node) bool {
+		if n == nil {
+			return true
+		}
+		if !visit(n) {
+			return false
+		}
+		if n.ownerArena == nil || n.childIndex > finalChildSidecarIndexBase {
+			for _, child := range n.children {
+				if !walk(child) {
+					return false
+				}
+			}
+			return true
+		}
+		for i := 0; i < resultChildCount(n); i++ {
+			if !walk(resultChildAt(n, i)) {
+				return false
+			}
+		}
+		return true
+	}
+	return walk(root)
+}
+
 func walkResultTreeDenseFirst(root *Node, visit func(*Node)) {
 	if visit == nil {
 		return

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -648,7 +648,7 @@ func (b *resultRootBuild) finalizeRoot(root *Node, wireParentLinks, extendTraili
 // trivia. The compatibility guard mirrors finalizeResultRoot exactly.
 func (b *resultRootBuild) finalizeWrappedSubtree(root *Node) {
 	p := b.parser
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return
 	}
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
@@ -817,14 +817,14 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 	timing := p.currentMaterializationTiming()
 	finalizeStart := materializationTimingStart(timing)
 	defer timing.addResultFinalizeRoot(finalizeStart)
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return
 	}
 	if p != nil {
 		root = flattenInvisibleRootChildren(root, root.ownerArena, p.language)
 	}
 	widenNodeSpanToRetainedChildren(root)
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return
 	}
 	if extendTrailing {
@@ -832,13 +832,13 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		extendNodeToTrailingWhitespace(root, source)
 		timing.addResultExtendTrailing(start)
 	}
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return
 	}
 	start := materializationTimingStart(timing)
 	p.normalizeRootSourceStart(root, source)
 	timing.addResultNormalizeRootStart(start)
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return
 	}
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
@@ -856,7 +856,7 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 			extendNodeToTrailingWhitespace(root, source)
 		}
 	}
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return
 	}
 	if wireParentLinks {

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -7,19 +7,33 @@ package gotreesitter
 // semantic decorations should keep the parent's symbol/flags and adopt the
 // child's token span.
 func normalizeResultTerminalLeafNodes(root *Node, lang *Language) normalizationPassCounters {
+	counters, _ := normalizeResultTerminalLeafNodesWithStop(root, lang, nil)
+	return counters
+}
+
+func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason) {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil || root.hasError() {
-		return counters
+		return counters, ParseStopNone
+	}
+	poller := parseStopPoller{check: stopCheck}
+	if reason := poller.pollNow(); parseStopReasonIsActive(reason) {
+		return counters, reason
 	}
 	aliasTargets := resultVisibleAliasTargetSet(lang)
-	walkResultTree(root, func(n *Node) {
+	var stopReason ParseStopReason
+	walkResultTreeUntil(root, func(n *Node) bool {
+		if reason := poller.poll(); parseStopReasonIsActive(reason) {
+			stopReason = reason
+			return false
+		}
 		counters.nodesVisited++
 		if !resultCanCollapseTerminalLeafNode(n, lang, aliasTargets) {
-			return
+			return true
 		}
 		child := resultChildAt(n, 0)
 		if !resultCanCollapseTerminalLeafChild(child, lang, aliasTargets) {
-			return
+			return true
 		}
 		if !resultSymbolIsVisibleTerminal(lang, n.symbol) && !resultSymbolNamesEqual(lang, n.symbol, child.symbol) {
 			// n only qualified via the alias-target set, which just records
@@ -31,7 +45,7 @@ func normalizeResultTerminalLeafNodes(root *Node, lang *Language) normalizationP
 			// splat_parameter wrapping a bare "*" token) is a real, distinct
 			// production whose child C tree-sitter keeps as a visible node --
 			// collapsing it here would silently drop a real AST child.
-			return
+			return true
 		}
 		n.startByte = child.startByte
 		n.endByte = child.endByte
@@ -44,8 +58,12 @@ func normalizeResultTerminalLeafNodes(root *Node, lang *Language) normalizationP
 			n.ownerArena.clearFinalChildRefs(n)
 		}
 		counters.nodesRewritten++
+		return true
 	})
-	return counters
+	if parseStopReasonIsActive(stopReason) {
+		return counters, stopReason
+	}
+	return counters, poller.pollNow()
 }
 
 func resultCanCollapseTerminalLeafNode(n *Node, lang *Language, aliasTargets []bool) bool {

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -49,6 +49,56 @@ func TestNormalizeResultTerminalLeafNodesCollapsesRedundantAnonymousTokenChild(t
 	}
 }
 
+func TestNormalizeResultTerminalLeafNodesStopsOnActiveParseBudget(t *testing.T) {
+	lang := &Language{
+		TokenCount: 3,
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"token",
+			"root",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: ".", Visible: true, Named: false},
+			{Name: "token", Visible: true, Named: true},
+			{Name: "root", Visible: true, Named: true},
+		},
+	}
+	arena := newNodeArena(arenaClassFull)
+	children := make([]*Node, 0, parseStopPollMask*2)
+	for i := 0; i < parseStopPollMask*2; i++ {
+		start := uint32(i)
+		leaf := newLeafNodeInArena(arena, 1, false, start, start+1, Point{Column: start}, Point{Column: start + 1})
+		parent := newParentNodeInArena(arena, 2, true, []*Node{leaf}, nil, 0)
+		children = append(children, parent)
+	}
+	root := newParentNodeInArena(arena, 3, true, children, nil, 0)
+	checks := 0
+	stopCheck := func() ParseStopReason {
+		checks++
+		if checks >= 2 {
+			return ParseStopTimeout
+		}
+		return ParseStopNone
+	}
+
+	counters, reason := normalizeResultTerminalLeafNodesWithStop(root, lang, stopCheck)
+
+	if reason != ParseStopTimeout {
+		t.Fatalf("stop reason = %q, want %q", reason, ParseStopTimeout)
+	}
+	if counters.nodesVisited == 0 {
+		t.Fatal("nodesVisited = 0, want partial traversal before stop")
+	}
+	if counters.nodesVisited >= uint64(len(children)+1) {
+		t.Fatalf("nodesVisited = %d, want traversal to stop before full tree", counters.nodesVisited)
+	}
+	if counters.nodesRewritten >= uint64(len(children)) {
+		t.Fatalf("nodesRewritten = %d, want partial rewrite before stop", counters.nodesRewritten)
+	}
+}
+
 func TestNormalizeResultTerminalLeafNodesPreservesNonterminalWrapper(t *testing.T) {
 	lang := &Language{
 		TokenCount: 2,

--- a/transient_children.go
+++ b/transient_children.go
@@ -91,7 +91,7 @@ func (s *transientChildScratch) materializeNodeUntil(root *Node, arena *nodeAren
 	visited := 0
 	for len(stack) > 0 {
 		if visited&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 		}

--- a/transient_parents.go
+++ b/transient_parents.go
@@ -116,7 +116,7 @@ func (s *transientParentScratch) materializeEntriesUntil(entries []stackEntry, a
 	roots := make([]*Node, 0, len(entries))
 	for i := range entries {
 		if i&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 		}
@@ -124,12 +124,12 @@ func (s *transientParentScratch) materializeEntriesUntil(entries []stackEntry, a
 			roots = append(roots, node)
 		}
 	}
-	if reason := s.materializeNodesUntil(roots, arena, childScratch, p); parseStopReasonIsTerminal(reason) {
+	if reason := s.materializeNodesUntil(roots, arena, childScratch, p); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	for i := range entries {
 		if i&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 		}
@@ -153,12 +153,12 @@ func (s *transientParentScratch) materializeNodeSliceUntil(nodes []*Node, arena 
 		return ParseStopNone
 	}
 	defer s.clearMaterializeScratch()
-	if reason := s.materializeNodesUntil(nodes, arena, childScratch, p); parseStopReasonIsTerminal(reason) {
+	if reason := s.materializeNodesUntil(nodes, arena, childScratch, p); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	for i := range nodes {
 		if i&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 		}
@@ -184,7 +184,7 @@ func (s *transientParentScratch) materializeNodesUntil(nodes []*Node, arena *nod
 	}()
 	for i := range nodes {
 		if i&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 		}
@@ -195,7 +195,7 @@ func (s *transientParentScratch) materializeNodesUntil(nodes []*Node, arena *nod
 	visited := 0
 	for len(frames) > 0 {
 		if visited&63 == 0 {
-			if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 		}
@@ -207,7 +207,7 @@ func (s *transientParentScratch) materializeNodesUntil(nodes []*Node, arena *nod
 			continue
 		}
 		if frame.visited {
-			if reason := s.materializeVisitedNodeUntil(n, arena, childScratch, p); parseStopReasonIsTerminal(reason) {
+			if reason := s.materializeVisitedNodeUntil(n, arena, childScratch, p); resultMaterializationShouldStop(reason) {
 				return reason
 			}
 			continue
@@ -254,7 +254,7 @@ func (s *transientParentScratch) materializeVisitedNodeUntil(n *Node, arena *nod
 		}
 		for i, child := range out {
 			if i&63 == 0 {
-				if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+				if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 					return reason
 				}
 			}


### PR DESCRIPTION
## Summary

Introduce runtime memory budget enforcement by tracking heap and OS-level Sys memory growth against a baseline during cliff-risk parses. Consolidates materialization and recovery stop checks so timeout, arena budget, scratch budget, and runtime memory pressure can all return a bounded stop reason instead of letting recovery/finalization OOM.

## Changes

- Add sampled runtime memory budget tracking for HeapAlloc and Sys growth during large parseInternal runs.
- Keep the runtime sampler out of small-source hot paths and use value restore state instead of a per-parse restore closure, preserving `BenchmarkGoParseFullDFA` allocation/perf shape.
- Centralize stop handling in resultMaterializationStopReason / resultMaterializationShouldStop.
- Propagate stop reasons through C recovery helpers, condense/resume, strategy-1 election, accept-root rebuild, GSS materialization, transient parent/child materialization, and terminal leaf normalization.
- Bound accept-root child collection and arena child-slice copies before allocating large rebuilt roots.
- Add focused tests for runtime memory-budget sampling/gating and terminal-leaf normalization early stop behavior.

## Testing

- Host focused package tests: `go test . -run '^(TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth|TestParserMemoryBudgetStopsParse|TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken|TestCRecoverDispatchInErrorAbsorbsZeroWidthSkippedTokenAtCurrentOffset|TestCRecoverStrategy1ElectionDedupesDuplicateEntryAcrossMembers|TestCRecoverStrategy1ElectionIgnoresBetterVersionForNoActionEntry|TestCRecoverStrategy1ElectionUsesMergedVersionCostBasis|TestCCondenseAndResumeComparesMissingGroupStacks)$' -count=1`
- Host follow-up unit gate: `go test . -run '^(TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth|TestRuntimeMemoryBudgetDisabledForSmallSource|TestRuntimeMemoryBudgetEnabledForLargeSource|TestParserMemoryBudgetStopsParse)$' -count=1`
- Host perf trio: `GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms`; full DFA returned to 5 allocs/op and 977 B/op locally.
- Docker focused unit gate: `harness_out/docker/20260709T035804Z-unit-runtime-sys-budget`, exit 0, oom_killed=false.
- Groovy 102960-byte repro, 2s file budget: `harness_out/docker/20260709T041559Z-perf-groovy-runtime-size-budget-2s`, status=ok, files=1/1, verdict=cliff>10x, oom_killed=false.
- Groovy 102960-byte repro, 10s file budget: `harness_out/docker/20260709T041721Z-perf-groovy-runtime-size-budget-10s`, status=ok, files=1/1, verdict=cliff>10x, stopped by memory_budget, oom_killed=false.
- Single-grammar Docker correctness smoke: `harness_out/docker/20260709T040115Z-diag-go_lang`, real-corpus go_lang no-error 5/5, sexpr parity 5/5, deep parity 5/5, oom_killed=false.

Host-wide `go test ./...` was intentionally not run per repo instructions.

## Review Focus

Check the 64 KiB runtime budget sampling threshold, the new ParseStopReason propagation through C recovery, and whether any recovery path should also include scratch budget in addition to arena/runtime checks.
