### PR TITLE
add parent-side RSS watchdog to perf scan harness

### DIFF
--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -115,6 +115,7 @@ grammar repos, not corpus repos.
 | `GTS_PERF_SCAN_CONTENDED` | auto (loadavg) | mark run as contended (smoke-only numbers) |
 | `GTS_PERF_SCAN_INPROCESS` | 0 | debug: run languages in-process (no crash isolation) |
 | `GTS_PERF_SCAN_EDIT_CANDIDATES` | 16 | edit-site candidates tried per file |
+| `GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB` | 0 | optional parent-side RSS watchdog for the per-language child process; when set, kills the child before a container cgroup OOM can kill the sweep parent |
 
 Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 `GTS_PARITY_REPO_ROOT`, `GTS_PARITY_REPO_CACHE`,

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -3973,10 +3973,13 @@
         "partial_progress": "7/8 selected files completed before the same final file reproduced the blowup; completing files still showed severe measured ratios, including one go_timeout lower-bound row",
         "host_gomemlimit_4gib": "killed while climbing past roughly 15GiB RSS",
         "host_gomemlimit_3gib": "killed around roughly 8GiB RSS",
-        "docker_cgroup_6gib": "Docker wrapper reported oom_killed=true"
+        "docker_cgroup_6gib": "Docker wrapper reported oom_killed=true",
+        "post_runtime_budget_docker_2gib": "post-#182, exact-file pleac11_15.groovy probe under Docker 2GiB/GOMEMLIMIT=1536MiB/GOT_PARSE_MEMORY_BUDGET_MB=512 still cgroup-OOMs before a scoreboard fragment can be written without a parent-side RSS watchdog",
+        "post_runtime_budget_docker_4gib": "post-#182, exact-file pleac11_15.groovy probe under Docker 4GiB/GOMEMLIMIT=3GiB completes the perf-scan row without cgroup OOM and reports full-axis go_timeout: parse stopped early (memory_budget), C median 27.67ms, lower-bound ratio >=361.4x",
+        "rss_watchdog_probe": "with GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=512, the same 2GiB container exits cleanly with a written scoreboard row instead of oom_killed=true; the child is stopped at rss=519MiB before any file completes"
       },
       "suspected_class": "candidate severe memory variant of repetition-shift fork cascade or population explosion; distinct from ordinary 10s go_timeout and from clean internal memory_budget stops",
-      "action": "dedicated RCA on pleac11_15.groovy in an isolated hard-bounded container; do not sweep this file again as part of broad fleet runs until containment is understood"
+      "action": "use GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB for future isolated Groovy/F# memory probes so the sweep parent can preserve a scoreboard instead of dying with the container; Groovy remains held out of the ratchet until pleac11_15.groovy is reduced/fixed or a budget row is deliberately scoped around this memory_budget cliff"
     },
     "fsharp_providedtypes_c_reference_memory_blowup": {
       "file": "fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection)",

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,6 +1,6 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T04:59:41Z",
+  "generated_at": "2026-07-09T05:57:37Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
   "budget_generated_at": "2026-07-09T01:17:47Z",
@@ -70,7 +70,7 @@
       "key": "groovy_pleac11_15_memory_blowup",
       "file": "groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass)",
       "backlog_ref": "assisted Wave-3 fleet gap-close pass, reported in /tmp/gts_scratch/FLEET_SCOREBOARD.md; intentionally not added to languages because it is not a ratchetable row",
-      "action": "dedicated RCA on pleac11_15.groovy in an isolated hard-bounded container; do not sweep this file again as part of broad fleet runs until containment is understood"
+      "action": "use GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB for future isolated Groovy/F# memory probes so the sweep parent can preserve a scoreboard instead of dying with the container; Groovy remains held out of the ratchet until pleac11_15.groovy is reduced/fixed or a budget row is deliberately scoped around this memory_budget cliff"
     },
     {
       "key": "webworker_generated_d_ts",

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,6 +1,6 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T04:59:41Z`
+- generated_at: `2026-07-09T05:57:37Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
 - budget_generated_at: `2026-07-09T01:17:47Z`
@@ -36,7 +36,7 @@ Held out of the ratchet: `d`, `fsharp`, `groovy`.
 |---|---|---|
 | `d_docker_oom` | d corpus largest-file selection from wave3_batch6 | dedicated one-language D RCA under a hard disposable memory limit before creating any budget row |
 | `fsharp_providedtypes_c_reference_memory_blowup` | fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection) | dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog |
-| `groovy_pleac11_15_memory_blowup` | groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass) | dedicated RCA on pleac11_15.groovy in an isolated hard-bounded container; do not sweep this file again as part of broad fleet runs until containment is understood |
+| `groovy_pleac11_15_memory_blowup` | groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass) | use GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB for future isolated Groovy/F# memory probes so the sweep parent can preserve a scoreboard instead of dying with the container; Groovy remains held out of the ratchet until pleac11_15.groovy is reduced/fixed or a budget row is deliberately scoped around this memory_budget cliff |
 | `webworker_generated_d_ts` | typescript/src/lib/webworker.generated.d.ts (786262 bytes, largest .d.ts in the corpus sample) | typescript's full_axis budget above is intentionally NOT tightened to reflect a 'fixed' webworker.generated.d.ts; GOT_FAITHFUL_CONDENSE (or an equivalent default-budget-aware condense path) remains a real wave-2b item. |
 
 ## Seed Sources

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -73,6 +73,7 @@ const (
 	perfScanEnvContended   = "GTS_PERF_SCAN_CONTENDED"
 	perfScanEnvInProcess   = "GTS_PERF_SCAN_INPROCESS"
 	perfScanEnvEditCands   = "GTS_PERF_SCAN_EDIT_CANDIDATES"
+	perfScanEnvChildRSSMB  = "GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB"
 
 	perfScanAxisFull   = "full"
 	perfScanAxisNoEdit = "noedit"
@@ -101,6 +102,7 @@ type perfScanConfig struct {
 	Axes          []string `json:"axes"`
 	Contended     bool     `json:"contended"`
 	ContendedNote string   `json:"contended_note,omitempty"`
+	ChildRSSMB    int      `json:"child_rss_limit_mb,omitempty"`
 }
 
 type perfScanHost struct {
@@ -207,6 +209,7 @@ func perfScanLoadConfig() perfScanConfig {
 		MaxFileBytes:  perfScanEnvIntDefault(perfScanEnvMaxBytes, 4<<20),
 		Order:         strings.TrimSpace(os.Getenv(perfScanEnvOrder)),
 		Axes:          perfScanAxes(),
+		ChildRSSMB:    perfScanEnvIntDefault(perfScanEnvChildRSSMB, 0),
 	}
 	if cfg.Reps < 1 {
 		cfg.Reps = 1
@@ -1363,7 +1366,7 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 	})
 
 	start := time.Now()
-	runErr := cmd.Run()
+	runErr, rssStop := perfScanRunChild(ctx, cmd, cfg.ChildRSSMB)
 	elapsed := time.Since(start)
 
 	fragment, fragErr := perfScanReadLangFragment(absOut, lang)
@@ -1384,12 +1387,16 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 		}
 		return fragment
 	case fragment != nil:
+		stopDetail := fmt.Sprintf("%v", runErr)
+		if rssStop != "" {
+			stopDetail = rssStop
+		}
 		if runErr != nil && fragment.Status == perfScanStatusOK {
-			fragment.Notes = append(fragment.Notes, fmt.Sprintf("child exited with error after fragment write: %v", runErr))
+			fragment.Notes = append(fragment.Notes, "child exited with error after fragment write: "+stopDetail)
 		}
 		if fragment.Status == perfScanStatusRunning {
 			fragment.Status = "error"
-			fragment.Detail = strings.TrimSpace(fmt.Sprintf("child exited early (%v); partial results. %s", runErr, fragment.Detail))
+			fragment.Detail = strings.TrimSpace(fmt.Sprintf("child exited early (%s); partial results. %s", stopDetail, fragment.Detail))
 			perfScanAggregateLanguage(fragment, cfg)
 		}
 		return fragment
@@ -1399,6 +1406,8 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 		if timedOut {
 			status = "lang_timeout"
 			detail = fmt.Sprintf("killed after %s before any file completed", langTimeout)
+		} else if rssStop != "" {
+			detail = rssStop + " before any file completed"
 		} else if fragErr != nil && runErr == nil {
 			detail = fmt.Sprintf("fragment read failed: %v", fragErr)
 		}
@@ -1413,6 +1422,79 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 			ElapsedMS: elapsed.Milliseconds(),
 		}
 	}
+}
+
+func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error, string) {
+	if rssLimitMB <= 0 {
+		return cmd.Run(), ""
+	}
+	if err := cmd.Start(); err != nil {
+		return err, ""
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	limitBytes := int64(rssLimitMB) << 20
+	checkRSS := func() (bool, string) {
+		if cmd.Process == nil {
+			return false, ""
+		}
+		rssBytes, ok := perfScanProcessRSSBytes(cmd.Process.Pid)
+		if !ok || rssBytes < limitBytes {
+			return false, ""
+		}
+		return true, fmt.Sprintf("child rss exceeded %d MiB limit (rss=%d MiB)",
+			rssLimitMB, (rssBytes+(1<<20)-1)>>20)
+	}
+	for {
+		if kill, detail := checkRSS(); kill {
+			_ = cmd.Process.Kill()
+			return <-done, detail
+		}
+		select {
+		case err := <-done:
+			return err, ""
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			return <-done, ""
+		case <-ticker.C:
+		}
+	}
+}
+
+func perfScanProcessRSSBytes(pid int) (int64, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0, false
+	}
+	return perfScanParseStatusRSSBytes(string(data))
+}
+
+func perfScanParseStatusRSSBytes(status string) (int64, bool) {
+	for _, line := range strings.Split(status, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "VmRSS:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0, false
+		}
+		kib, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kib < 0 {
+			return 0, false
+		}
+		return kib * 1024, true
+	}
+	return 0, false
 }
 
 func perfScanReadLangFragment(outDir, lang string) (*perfScanLanguage, error) {
@@ -1537,6 +1619,9 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 		board.Config.CorpusRoot, board.Config.Order, board.Config.MaxFiles,
 		board.Config.Reps, board.Config.Warmup, board.Config.FileBudgetMS,
 		strings.Join(board.Config.Axes, ","))
+	if board.Config.ChildRSSMB > 0 {
+		fmt.Fprintf(&b, "- child RSS limit: `%d MiB`\n", board.Config.ChildRSSMB)
+	}
 	if board.Config.Contended {
 		fmt.Fprintf(&b, "\n**WARNING: contended run (%s) — smoke-only numbers, not authoritative.**\n", board.Config.ContendedNote)
 	}
@@ -1647,6 +1732,17 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	joined := strings.Join(env, " ")
 	if strings.Contains(joined, "LANG=old") || !strings.Contains(joined, "GTS_PERF_SCAN_LANG=go") {
 		t.Fatalf("mergeEnv=%v", env)
+	}
+	rss, ok := perfScanParseStatusRSSBytes("Name:\tperfscan\nVmRSS:\t  1537 kB\n")
+	if !ok || rss != 1537*1024 {
+		t.Fatalf("parse VmRSS = %d,%v; want %d,true", rss, ok, 1537*1024)
+	}
+	if _, ok := perfScanParseStatusRSSBytes("Name:\tperfscan\n"); ok {
+		t.Fatal("parse VmRSS succeeded without VmRSS line")
+	}
+	t.Setenv(perfScanEnvChildRSSMB, "321")
+	if got := perfScanLoadConfig().ChildRSSMB; got != 321 {
+		t.Fatalf("ChildRSSMB = %d, want 321", got)
 	}
 
 	fragDir := t.TempDir()

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -1437,6 +1437,8 @@ func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error
 		done <- cmd.Wait()
 	}()
 
+	// This knob is for containment probes, not authoritative timing runs; keep
+	// the poll tight so a fast RSS climb is stopped before the container OOMs.
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -1453,6 +1455,11 @@ func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error
 			rssLimitMB, (rssBytes+(1<<20)-1)>>20)
 	}
 	for {
+		select {
+		case err := <-done:
+			return err, ""
+		default:
+		}
 		if kill, detail := checkRSS(); kill {
 			_ = cmd.Process.Kill()
 			return <-done, detail


### PR DESCRIPTION
## Summary

This PR introduces a configurable parent-side RSS watchdog (GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB) for the perf scan harness. Previously, when a language subprocess exceeded memory limits, the container OOM killer would terminate the parent process, causing loss of intermediate scoreboard data. The new watchdog monitors child process RSS via /proc/<pid>/status and kills it gracefully before a container-level OOM occurs, preserving partial results and preventing parent death.

## Changes

- Added GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB env var and config field
- Implemented perfScanRunChild to spawn subprocesses with RSS monitoring via polling /proc/<pid>/status
- Added perfScanProcessRSSBytes and perfScanParseStatusRSSBytes helper functions
- Updated perfScanRunLanguageSubprocess to pass RSS kill details to scoreboard fragments on early exit
- Updated Markdown board rendering to display the active child RSS limit
- Added unit tests for VmRSS parsing and config loading
- Updated README and sweep status/budget files to reflect the new containment strategy for Groovy/F# memory blowups

## Testing

- Run `go test -run TestPerfScanHelpersUnit ./cgo_harness` to verify RSS parsing and config loading
- Verify that setting `GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=512` correctly kills a memory-heavy child and preserves the scoreboard
- Run a subset of the perf sweep to confirm the dashboard markdown includes the `- child RSS limit: <N> MiB` line
- Confirm existing perf scan behavior remains unchanged when the flag is unset (default 0)