### PR TITLE
Refine D language RSS blowup details and wave3 status

### DIFF
--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -3992,15 +3992,18 @@
       "suspected_class": "C reference parser memory blowup on the active full-parse attempt, not currently evidence of a pure-Go memory blowup; fsharp still cannot be ratcheted because the reference side dies before a C median can be recorded",
       "action": "dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog"
     },
-    "d_docker_oom": {
-      "file": "d corpus largest-file selection from wave3_batch6",
-      "backlog_ref": "wave3_batch6_20260708T224850Z seed note; intentionally not added to languages because both the batch run and one-language rerun ended with Docker oom_killed=true",
+    "d_expressionsem_go_rss_blowup": {
+      "file": "d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes)",
+      "backlog_ref": "wave3_batch6_20260708T224850Z seed note; intentionally not added to languages because both the batch run and one-language rerun ended with Docker oom_killed=true before #185 added the parent-side RSS watchdog",
       "observed": {
         "wave3_batch6": "child process exited signal:killed with Docker oom_killed=true",
-        "one_language_rerun": "reproduced the Docker OOM"
+        "one_language_rerun": "reproduced the Docker OOM",
+        "rss_watchdog_512": "post-#185 Docker 2GiB, GOMEMLIMIT=1536MiB, largest-8, reps=5, warmup=1, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=512: parent preserved an error row instead of cgroup OOM; child stopped at rss=518MiB before any file checkpoint",
+        "rss_watchdog_1024": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, largest-1, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=1024: child stopped at rss=1025MiB before any file checkpoint",
+        "activeattempt_1536": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, largest-1, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=1536: child stopped at rss=1539MiB with active_file=compiler/src/dmd/expressionsem.d, active_axis=full, active_impl=go, active_phase=rep, active_attempt=1"
       },
-      "suspected_class": "severe memory blowup or containment failure requiring isolated RCA before broad sweeps",
-      "action": "dedicated one-language D RCA under a hard disposable memory limit before creating any budget row"
+      "suspected_class": "pure-Go D full-parse memory blowup during the first timed full/go attempt on expressionsem.d; no longer an unattributed container failure and not currently evidence of a C-reference blowup",
+      "action": "reduce or contain the expressionsem.d Go full-parse memory blowup before adding D to the ratchet; D remains held out until full/noedit can complete or an explicit budget row is deliberately scoped around this RSS cliff"
     }
   }
 }

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,6 +1,6 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T05:57:37Z",
+  "generated_at": "2026-07-09T06:28:40Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
   "budget_generated_at": "2026-07-09T01:17:47Z",
@@ -55,10 +55,10 @@
   ],
   "known_budget_class_gaps": [
     {
-      "key": "d_docker_oom",
-      "file": "d corpus largest-file selection from wave3_batch6",
-      "backlog_ref": "wave3_batch6_20260708T224850Z seed note; intentionally not added to languages because both the batch run and one-language rerun ended with Docker oom_killed=true",
-      "action": "dedicated one-language D RCA under a hard disposable memory limit before creating any budget row"
+      "key": "d_expressionsem_go_rss_blowup",
+      "file": "d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes)",
+      "backlog_ref": "wave3_batch6_20260708T224850Z seed note; intentionally not added to languages because both the batch run and one-language rerun ended with Docker oom_killed=true before #185 added the parent-side RSS watchdog",
+      "action": "reduce or contain the expressionsem.d Go full-parse memory blowup before adding D to the ratchet; D remains held out until full/noedit can complete or an explicit budget row is deliberately scoped around this RSS cliff"
     },
     {
       "key": "fsharp_providedtypes_c_reference_memory_blowup",

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,6 +1,6 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T05:57:37Z`
+- generated_at: `2026-07-09T06:28:40Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
 - budget_generated_at: `2026-07-09T01:17:47Z`
@@ -34,7 +34,7 @@ Held out of the ratchet: `d`, `fsharp`, `groovy`.
 
 | key | file | action |
 |---|---|---|
-| `d_docker_oom` | d corpus largest-file selection from wave3_batch6 | dedicated one-language D RCA under a hard disposable memory limit before creating any budget row |
+| `d_expressionsem_go_rss_blowup` | d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes) | reduce or contain the expressionsem.d Go full-parse memory blowup before adding D to the ratchet; D remains held out until full/noedit can complete or an explicit budget row is deliberately scoped around this RSS cliff |
 | `fsharp_providedtypes_c_reference_memory_blowup` | fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection) | dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog |
 | `groovy_pleac11_15_memory_blowup` | groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass) | use GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB for future isolated Groovy/F# memory probes so the sweep parent can preserve a scoreboard instead of dying with the container; Groovy remains held out of the ratchet until pleac11_15.groovy is reduced/fixed or a budget row is deliberately scoped around this memory_budget cliff |
 | `webworker_generated_d_ts` | typescript/src/lib/webworker.generated.d.ts (786262 bytes, largest .d.ts in the corpus sample) | typescript's full_axis budget above is intentionally NOT tightened to reflect a 'fixed' webworker.generated.d.ts; GOT_FAITHFUL_CONDENSE (or an equivalent default-budget-aware condense path) remains a real wave-2b item. |


### PR DESCRIPTION
## Summary

Reclassifies D's Wave 3 held-out perf gap from a generic Docker OOM into a
concrete Go-side RSS blowup on the largest D corpus file,
`compiler/src/dmd/expressionsem.d`.

## Changes

- Renames `d_docker_oom` to `d_expressionsem_go_rss_blowup` in the perf budget ledger.
- Records three post-#185 RSS watchdog probes:
  - 2GiB container / 512MiB child cap: preserved error row, no cgroup OOM, stopped before file checkpoint at ~518MiB.
  - 4GiB container / 1024MiB child cap: preserved error row, stopped before file checkpoint at ~1025MiB.
  - 4GiB container / 1536MiB child cap: preserved active-attempt attribution: `expressionsem.d`, `full/go/rep`, attempt 1, ~1539MiB.
- Regenerates `wave3_sweep_status.json` and `wave3_sweep_status.md` from the budget file.
- Keeps D held out of the ratchet; this is attribution/RCA evidence, not a performance fix.

## Validation

- Docker D probe: `perf-scan-d-rss-512`, `oom_killed=false`.
- Docker D probe: `perf-scan-d-largest-rss1024`, `oom_killed=false`.
- Docker D probe: `perf-scan-d-largest-rss1536`, `oom_killed=false`, active-attempt attribution captured.
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json`
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_status -budget perf_scan/perf_ratio_budgets.json -fleet tier_scan/exts.tsv -out-json perf_scan/wave3_sweep_status.json -out-md perf_scan/wave3_sweep_status.md`
- `python3 -m json.tool cgo_harness/perf_scan/perf_ratio_budgets.json >/dev/null`
- `git diff --check`
- `cd cgo_harness && GOWORK=off go test ./cmd/perf_scan_status ./cmd/perf_scan_budget -count=1`
- `canopy index build .`

Buckley review: grade A, no blockers.
