### PR TITLE
docs(changelog): document unreleased work since 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,33 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-Wave-3 perf-fleet coverage and standing correctness gates. This unreleased line
-closes the perf-scan *measurement* gap — the Go-vs-C full-parse ratio ratchet
-now covers 203/206 grammars (up from the handful measured at the v0.22.0
-checkpoint) via batches 1–7 plus an assisted fleet gap-close sweep — and adds
-the structural gates that keep correctness from silently regressing between
-releases. It does not yet claim universal near-C throughput: the ratchet records
-where every grammar stands (many are near-C; a long tail is classified cliffs),
-and optimizing that tail plus a memory-blowup class in a few grammars remains
-tracked for the next waves. Honest-as-of-main.
+Wave-3 perf-fleet coverage and standing correctness checks. This unreleased
+line extends perf-scan measurement coverage: the Go-vs-C full-parse ratio
+ratchet now covers 203/206 grammars (up from the targeted subset measured at
+the v0.22.0 checkpoint) via batches 1–7 plus a fleet gap-close sweep, while
+keeping the three held-out grammars explicit in the ledger. It does not yet
+claim universal near-C throughput: the ratchet records where every grammar
+stands (many are near-C; a long tail is classified cliffs), and optimizing
+that tail plus a memory-blowup class in a few grammars remains tracked for the
+next waves.
 
 ### Added
 
 - Wave-3 fleet perf ratchet: Go-vs-C full-parse ratio budgets extended to
-  203/206 grammars (batches 1–7 plus an assisted fleet gap-close sweep),
-  turning "universal near-C" from an unmeasured claim into a per-language,
-  CI-enforced scoreboard, with a `perf_scan_status` CLI for coverage reporting.
+  203/206 grammars (batches 1–7 plus a fleet gap-close sweep), turning sparse
+  fleet coverage into a per-language CI-tracked scoreboard with a
+  `perf_scan_status` CLI for coverage reporting.
 - Auto-triggered exhaustive CGo parity on `parser_result_*` and recovery-path
-  PRs — a standing gate so masking-normalization or recovery changes cannot
-  merge without byte-exact verification against the tree-sitter v0.25.0 oracle.
+  PRs, so masking-normalization or recovery changes surface byte-exact
+  verification against the tree-sitter v0.25.0 oracle instead of relying only
+  on smoke coverage.
 - Runtime memory budget with unified materialization stop checks, bounding
   worst-case parse memory (with a small-source fast path).
 - perf-scan harness hardening: explicit C-reference failure budget, active-file
   tracking in partial fragments, and a parent-side RSS watchdog.
-- Non-terminal alias maps carried in ts2go blobs (Wave 5), preserving
-  parent-context aliasing across the blob boundary.
+- Non-terminal alias maps carried in ts2go blobs as part of the parallel
+  correctness work, preserving parent-context aliasing across the blob
+  boundary.
 - Grammargen now derives `Language.NonTerminalAliasMap`, with Lua parity,
   shipped-blob inventory coverage, and synthetic edge-case tests for
   self-recursive alias wrappers, singleton aliases, terminal aliases, and
@@ -39,7 +41,8 @@ tracked for the next waves. Honest-as-of-main.
 
 ### Changed
 
-- COBOL promoted to Tier III and marked parity-clean.
+- COBOL promoted to Tier III and marked parity-clean after the `EXEC CICS`
+  parity fix below.
 - CGo parity tests now run inside Docker; grammar race lanes split by test
   range / package group for CI throughput.
 - Groovy and D large-file GLR retry paths now use scoped stack ceilings to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ now covers 203/206 grammars (up from the handful measured at the v0.22.0
 checkpoint) via batches 1–7 plus an assisted fleet gap-close sweep — and adds
 the structural gates that keep correctness from silently regressing between
 releases. It does not yet claim universal near-C throughput: the ratchet records
-where every grammar stands (many are near-C; a long tail are classified cliffs),
-and optimizing that tail plus a memory-blowup class in a few grammars remain
+where every grammar stands (many are near-C; a long tail is classified cliffs),
+and optimizing that tail plus a memory-blowup class in a few grammars remains
 tracked for the next waves. Honest-as-of-main.
 
 ### Added
@@ -32,12 +32,19 @@ tracked for the next waves. Honest-as-of-main.
   tracking in partial fragments, and a parent-side RSS watchdog.
 - Non-terminal alias maps carried in ts2go blobs (Wave 5), preserving
   parent-context aliasing across the blob boundary.
+- Grammargen now derives `Language.NonTerminalAliasMap`, with Lua parity,
+  shipped-blob inventory coverage, and synthetic edge-case tests for
+  self-recursive alias wrappers, singleton aliases, terminal aliases, and
+  deterministic row ordering.
 
 ### Changed
 
 - COBOL promoted to Tier III and marked parity-clean.
 - CGo parity tests now run inside Docker; grammar race lanes split by test
   range / package group for CI throughput.
+- Groovy and D large-file GLR retry paths now use scoped stack ceilings to
+  contain Go-side RSS cliffs; both remain explicitly tracked in the perf ledger
+  until their exact Go-vs-C rows are ratchetable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,24 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-Wave-3 perf-fleet coverage and standing correctness checks. This unreleased
+Wave-3 perf-fleet coverage and ongoing correctness checks. This unreleased
 line extends perf-scan measurement coverage: the Go-vs-C full-parse ratio
 ratchet now covers 203/206 grammars (up from the targeted subset measured at
 the v0.22.0 checkpoint) via batches 1–7 plus a fleet gap-close sweep, while
 keeping the three held-out grammars explicit in the ledger. It does not yet
 claim universal near-C throughput: the ratchet records where every grammar
-stands (many are near-C; a long tail is classified cliffs), and optimizing
-that tail plus a memory-blowup class in a few grammars remains tracked for the
-next waves.
+stands, including held-out rows and known cliffs, and optimizing that tail
+plus a memory-blowup class in a few grammars remains tracked for the next
+waves.
 
 ### Added
 
 - Wave-3 fleet perf ratchet: Go-vs-C full-parse ratio budgets extended to
   203/206 grammars (batches 1–7 plus a fleet gap-close sweep), turning sparse
-  fleet coverage into a per-language CI-tracked scoreboard with a
-  `perf_scan_status` CLI for coverage reporting.
-- Auto-triggered exhaustive CGo parity on `parser_result_*` and recovery-path
-  PRs, so masking-normalization or recovery changes surface byte-exact
+  fleet coverage into a per-language scoreboard with `perf_scan_status`
+  coverage reporting and CI budget validation.
+- Auto-triggered scoped CGo parity on `parser_result_*` and recovery-path PRs,
+  so masking-normalization or recovery changes surface byte-exact
   verification against the tree-sitter v0.25.0 oracle instead of relying only
   on smoke coverage.
 - Runtime memory budget with unified materialization stop checks, bounding
@@ -42,7 +42,8 @@ next waves.
 ### Changed
 
 - COBOL promoted to Tier III and marked parity-clean after the `EXEC CICS`
-  parity fix below.
+  parity fix below, retaining the 25/25 real-corpus and 20/20 direct C-oracle
+  parity gates for this line.
 - CGo parity tests now run inside Docker; grammar race lanes split by test
   range / package group for CI throughput.
 - Groovy and D large-file GLR retry paths now use scoped stack ceilings to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+Wave-3 perf-fleet coverage and standing correctness gates. This unreleased line
+closes the perf-scan *measurement* gap — the Go-vs-C full-parse ratio ratchet
+now covers 203/206 grammars (up from the handful measured at the v0.22.0
+checkpoint) via batches 1–7 plus an assisted fleet gap-close sweep — and adds
+the structural gates that keep correctness from silently regressing between
+releases. It does not yet claim universal near-C throughput: the ratchet records
+where every grammar stands (many are near-C; a long tail are classified cliffs),
+and optimizing that tail plus a memory-blowup class in a few grammars remain
+tracked for the next waves. Honest-as-of-main.
+
+### Added
+
+- Wave-3 fleet perf ratchet: Go-vs-C full-parse ratio budgets extended to
+  203/206 grammars (batches 1–7 plus an assisted fleet gap-close sweep),
+  turning "universal near-C" from an unmeasured claim into a per-language,
+  CI-enforced scoreboard, with a `perf_scan_status` CLI for coverage reporting.
+- Auto-triggered exhaustive CGo parity on `parser_result_*` and recovery-path
+  PRs — a standing gate so masking-normalization or recovery changes cannot
+  merge without byte-exact verification against the tree-sitter v0.25.0 oracle.
+- Runtime memory budget with unified materialization stop checks, bounding
+  worst-case parse memory (with a small-source fast path).
+- perf-scan harness hardening: explicit C-reference failure budget, active-file
+  tracking in partial fragments, and a parent-side RSS watchdog.
+- Non-terminal alias maps carried in ts2go blobs (Wave 5), preserving
+  parent-context aliasing across the blob boundary.
+
+### Changed
+
+- COBOL promoted to Tier III and marked parity-clean.
+- CGo parity tests now run inside Docker; grammar race lanes split by test
+  range / package group for CI throughput.
+
+### Fixed
+
+- COBOL if-header `EXEC CICS` error parity aligned with the C parser.
+
 ## [0.22.0] - 2026-07-08
 
 Roadmap checkpoint release after the v0.21 engine cut. This release lands the


### PR DESCRIPTION
Populates the empty `[Unreleased]` section with the ~30 commits on `main` past the last documented version (`[0.22.0]`).

## What's captured
- **Wave-3 fleet perf ratchet** → 203/206 grammars measured (batches 1–7 + gap-close sweep) + `perf_scan_status` CLI.
- **Auto exhaustive-parity gate** (#174) on `parser_result_*`/recovery PRs.
- **Runtime memory budget** + materialization stop checks (#182); perf-scan RSS watchdog / active-file tracking / C-ref failure budget.
- **COBOL → Tier III** parity-clean (#184); EXEC CICS if-header parity fix (#176).
- **Non-terminal alias maps** in ts2go blobs (Wave 5, `edf04d84`).

Framed honestly: near-C is *measured* across 203/206, not claimed universal.

## Follow-ups (separate)
- `[0.22.1]`/`[0.22.2]`/`[0.22.3]` entries are also missing (the changelog jumps 0.22.0 → main); backfilling needs per-tag archaeology.
- A v0.23.0 cut to *tag* this line is warranted.
