### PR TITLE
Update F# ProvidedTypes memory diagnostics and sweep status

### DIFF
--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -3987,10 +3987,13 @@
       "observed": {
         "activeattempt_fsharp_lock_20260709T023116Z": "Docker 4GiB cgroup, GOMEMLIMIT=3GiB, lock-filtered corpus, largest-8, reps=1, warmup=0, file_budget=2000ms: child exited with signal:killed, docker wrapper reported oom_killed=true, files=0/8, active_axis=full, active_impl=c, active_phase=rep, active_attempt=1",
         "active_file_checkpoint_20260709T022239Z": "earlier active-file-only rerun identified the same first active file but could not distinguish Go vs C attempt",
-        "prior_isolated_attempts": "host GOMEMLIMIT=4GiB and 3GiB plus a Docker 6GiB cgroup reproduced severe memory blowups before attempt-level attribution existed"
+        "prior_isolated_attempts": "host GOMEMLIMIT=4GiB and 3GiB plus a Docker 6GiB cgroup reproduced severe memory blowups before attempt-level attribution existed",
+        "rss_watchdog_1536": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, lock-filtered corpus, largest-8, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=1536: parent exited cleanly with oom_killed=false but no language fragment; child stopped at rss=1540MiB before any file checkpoint",
+        "rss_watchdog_2500": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, lock-filtered corpus, largest-8, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=2500: container cgroup-OOMed before a scoreboard could be written; 2500MiB is too high for this 4GiB envelope",
+        "activeattempt_3000": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, lock-filtered corpus, largest-8, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=3000: scoreboard fragment preserved the same active_file=examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs, active_axis=full, active_impl=c, active_phase=rep, active_attempt=1, but docker still reported oom_killed=true"
       },
       "suspected_class": "C reference parser memory blowup on the active full-parse attempt, not currently evidence of a pure-Go memory blowup; fsharp still cannot be ratcheted because the reference side dies before a C median can be recorded",
-      "action": "dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog"
+      "action": "dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; under a 4GiB cgroup, <=1536MiB RSS caps keep the parent alive but stop before active-file checkpointing, while 2500-3000MiB can still cgroup-OOM, so do not rerun fsharp broad sweeps without a disposable hard memory bound and an explicit cgroup/RSS envelope"
     },
     "d_expressionsem_go_rss_blowup": {
       "file": "d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes)",

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,6 +1,6 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T06:28:40Z",
+  "generated_at": "2026-07-09T06:58:32Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
   "budget_generated_at": "2026-07-09T01:17:47Z",
@@ -64,7 +64,7 @@
       "key": "fsharp_providedtypes_c_reference_memory_blowup",
       "file": "fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection)",
       "backlog_ref": "assisted Wave-3 fleet gap-close pass, reported in /tmp/gts_scratch/FLEET_SCOREBOARD.md; intentionally not added to languages because it is not a ratchetable row",
-      "action": "dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog"
+      "action": "dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; under a 4GiB cgroup, \u003c=1536MiB RSS caps keep the parent alive but stop before active-file checkpointing, while 2500-3000MiB can still cgroup-OOM, so do not rerun fsharp broad sweeps without a disposable hard memory bound and an explicit cgroup/RSS envelope"
     },
     {
       "key": "groovy_pleac11_15_memory_blowup",

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,6 +1,6 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T06:28:40Z`
+- generated_at: `2026-07-09T06:58:32Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
 - budget_generated_at: `2026-07-09T01:17:47Z`
@@ -35,7 +35,7 @@ Held out of the ratchet: `d`, `fsharp`, `groovy`.
 | key | file | action |
 |---|---|---|
 | `d_expressionsem_go_rss_blowup` | d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes) | reduce or contain the expressionsem.d Go full-parse memory blowup before adding D to the ratchet; D remains held out until full/noedit can complete or an explicit budget row is deliberately scoped around this RSS cliff |
-| `fsharp_providedtypes_c_reference_memory_blowup` | fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection) | dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; do not rerun fsharp broad sweeps without a disposable hard memory bound and process-level watchdog |
+| `fsharp_providedtypes_c_reference_memory_blowup` | fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection) | dedicated isolated C-reference containment or corpus-selection RCA on ProvidedTypes.fs; under a 4GiB cgroup, <=1536MiB RSS caps keep the parent alive but stop before active-file checkpointing, while 2500-3000MiB can still cgroup-OOM, so do not rerun fsharp broad sweeps without a disposable hard memory bound and an explicit cgroup/RSS envelope |
 | `groovy_pleac11_15_memory_blowup` | groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass) | use GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB for future isolated Groovy/F# memory probes so the sweep parent can preserve a scoreboard instead of dying with the container; Groovy remains held out of the ratchet until pleac11_15.groovy is reduced/fixed or a budget row is deliberately scoped around this memory_budget cliff |
 | `webworker_generated_d_ts` | typescript/src/lib/webworker.generated.d.ts (786262 bytes, largest .d.ts in the corpus sample) | typescript's full_axis budget above is intentionally NOT tightened to reflect a 'fixed' webworker.generated.d.ts; GOT_FAITHFUL_CONDENSE (or an equivalent default-budget-aware condense path) remains a real wave-2b item. |
 


### PR DESCRIPTION
## Summary

Updates the F# ProvidedTypes memory blowup diagnosis with new RSS watchdog experiments. Shows that <=1536MiB RSS caps keep the parent alive but halt before checkpointing, while 2500-3000MiB caps still cause cgroup OOMs. Adjusts the recommended action to enforce explicit cgroup/RSS envelopes for future F# sweeps.

## Changes

- Add RSS watchdog observations for 1536MiB, 2500MiB, and 3000MiB limits to perf_ratio_budgets.json
- Update action recommendations in wave3_sweep_status.json and wave3_sweep_status.md to reflect new RSS threshold findings
- Refresh generated timestamps in sweep status files

## Testing

- Validate updated JSON structure with `python -m json.tool cgo_harness/perf_scan/*.json`
- Review markdown table rendering in `wave3_sweep_status.md`
- Confirm observations accurately reflect post-#185 Docker runs with lock-filtered corpus

## Review Focus

Focus on the accuracy of the new RSS limit observations and the updated action recommendation regarding cgroup/RSS envelopes for future sweeps.