### PR TITLE
Add file exclusion support to performance scan tooling

### DIFF
--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"sort"
 	"strings"
 )
@@ -188,6 +189,13 @@ func validateBudget(b *budgetFile) []evalFinding {
 			out = append(out, evalFinding{Axis: axis, Metric: "measurement_basis.axes", Got: strings.Join(b.MeasurementBasis.Axes, ","), Want: "include " + axis})
 		}
 	}
+	for _, pattern := range normalizedPathList(b.MeasurementBasis.ExcludePaths) {
+		if strings.ContainsAny(pattern, "*?[") {
+			if _, err := path.Match(pattern, "x"); err != nil {
+				out = append(out, evalFinding{Metric: "measurement_basis.exclude_paths", Got: pattern, Want: "valid path.Match pattern"})
+			}
+		}
+	}
 	for _, lang := range sortedBudgetLanguages(b) {
 		entry := b.Languages[lang]
 		if strings.TrimSpace(entry.Status) == "" {
@@ -295,7 +303,7 @@ func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
 	if len(b.ExcludePaths) > 0 || len(s.ExcludePaths) > 0 {
 		got := normalizedPathList(s.ExcludePaths)
 		want := normalizedPathList(b.ExcludePaths)
-		if strings.Join(got, ",") != strings.Join(want, ",") {
+		if !stringSlicesEqual(got, want) {
 			out = append(out, evalFinding{Metric: "config.exclude_paths", Got: strings.Join(got, ","), Want: strings.Join(want, ",")})
 		}
 	}
@@ -431,7 +439,9 @@ func normalizedPathList(items []string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, item := range items {
-		item = strings.Trim(strings.ReplaceAll(strings.TrimSpace(item), "\\", "/"), "/")
+		item = strings.ReplaceAll(strings.TrimSpace(item), "\\", "/")
+		item = strings.TrimPrefix(item, "./")
+		item = strings.TrimPrefix(item, "/")
 		if item == "" || seen[item] {
 			continue
 		}
@@ -440,6 +450,18 @@ func normalizedPathList(items []string) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func contains(items []string, needle string) bool {

--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -32,6 +32,7 @@ type budgetMeasurementBasis struct {
 	MaxFiles     int      `json:"max_files,omitempty"`
 	Order        string   `json:"order,omitempty"`
 	Axes         []string `json:"axes"`
+	ExcludePaths []string `json:"exclude_paths,omitempty"`
 }
 
 type budgetLang struct {
@@ -62,6 +63,7 @@ type scoreboardConfig struct {
 	MaxFiles     int      `json:"max_files"`
 	Order        string   `json:"order"`
 	Axes         []string `json:"axes"`
+	ExcludePaths []string `json:"exclude_paths,omitempty"`
 }
 
 type scoreboardLang struct {
@@ -290,6 +292,13 @@ func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
 			out = append(out, evalFinding{Axis: axis, Metric: "config.axes", Got: strings.Join(s.Axes, ","), Want: "include " + axis})
 		}
 	}
+	if len(b.ExcludePaths) > 0 || len(s.ExcludePaths) > 0 {
+		got := normalizedPathList(s.ExcludePaths)
+		want := normalizedPathList(b.ExcludePaths)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			out = append(out, evalFinding{Metric: "config.exclude_paths", Got: strings.Join(got, ","), Want: strings.Join(want, ",")})
+		}
+	}
 	return out
 }
 
@@ -415,6 +424,21 @@ func parseList(raw string) []string {
 			out = append(out, part)
 		}
 	}
+	return out
+}
+
+func normalizedPathList(items []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, item := range items {
+		item = strings.Trim(strings.ReplaceAll(strings.TrimSpace(item), "\\", "/"), "/")
+		if item == "" || seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -81,6 +81,24 @@ func TestCompareScoreboardReportsStrictConfigMismatch(t *testing.T) {
 	}
 }
 
+func TestCompareScoreboardReportsExcludePathConfigMismatch(t *testing.T) {
+	b := testBudget()
+	b.MeasurementBasis.ExcludePaths = []string{"d/compiler/src/dmd/expressionsem.d"}
+	s := testScoreboard(2.5, 0, 0)
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "::config.exclude_paths") {
+		t.Fatalf("findings %q missing config exclude_paths failure (%#v)", got, findings)
+	}
+
+	s.Config.ExcludePaths = []string{"d/compiler/src/dmd/expressionsem.d"}
+	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	if len(findings) != 0 {
+		t.Fatalf("matching exclude_paths should pass: %#v", findings)
+	}
+}
+
 func TestCompareScoreboardReportsCReferenceFailure(t *testing.T) {
 	b := testBudget()
 	s := testScoreboard(2.5, 0, 0)

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -97,6 +97,25 @@ func TestCompareScoreboardReportsExcludePathConfigMismatch(t *testing.T) {
 	if len(findings) != 0 {
 		t.Fatalf("matching exclude_paths should pass: %#v", findings)
 	}
+
+	b.MeasurementBasis.ExcludePaths = []string{"groovy/subprojects/"}
+	s.Config.ExcludePaths = []string{"groovy/subprojects"}
+	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got = renderFindingKeys(findings)
+	if !strings.Contains(got, "::config.exclude_paths") {
+		t.Fatalf("trailing slash should remain semantically distinct, findings %q (%#v)", got, findings)
+	}
+}
+
+func TestValidateBudgetReportsMalformedExcludePathGlob(t *testing.T) {
+	b := testBudget()
+	b.MeasurementBasis.ExcludePaths = []string{"bad/[glob"}
+
+	findings := validateBudget(b)
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "::measurement_basis.exclude_paths") {
+		t.Fatalf("findings %q missing malformed exclude path glob (%#v)", got, findings)
+	}
 }
 
 func TestCompareScoreboardReportsCReferenceFailure(t *testing.T) {

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -110,7 +110,7 @@ grammar repos, not corpus repos.
 | `GTS_PERF_SCAN_LANG_TIMEOUT_MS` | 600000 | hard subprocess kill per language |
 | `GTS_PERF_SCAN_MAX_FILES` | 16 | files per language (after ordering) |
 | `GTS_PERF_SCAN_MIN_FILE_BYTES` / `_MAX_FILE_BYTES` | 0 / 4MiB | size filters |
-| `GTS_PERF_SCAN_EXCLUDE_PATHS` | — | comma-separated language-relative or `language/path` exact paths/globs to omit from selection; globs use Go `path.Match` semantics (`*` does not cross `/`), and trailing `/` means directory prefix. Intended for named C-oracle cliff witnesses that remain tracked in the ledger |
+| `GTS_PERF_SCAN_EXCLUDE_PATHS` | — | comma-separated language-relative or `language/path` exact paths/globs to omit from selection; globs use Go `path.Match` semantics (`*` does not cross `/`, and `**` is not recursive), while trailing `/` means recursive directory prefix. Intended for named C-oracle cliff witnesses that remain tracked in the ledger |
 | `GTS_PERF_SCAN_ORDER` | `largest` | `largest` / `smallest` / `path` selection order |
 | `GTS_PERF_SCAN_AXES` | `full,noedit` | add `edit` for the incremental-edit axis |
 | `GTS_PERF_SCAN_CONTENDED` | auto (loadavg) | mark run as contended (smoke-only numbers) |

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -110,6 +110,7 @@ grammar repos, not corpus repos.
 | `GTS_PERF_SCAN_LANG_TIMEOUT_MS` | 600000 | hard subprocess kill per language |
 | `GTS_PERF_SCAN_MAX_FILES` | 16 | files per language (after ordering) |
 | `GTS_PERF_SCAN_MIN_FILE_BYTES` / `_MAX_FILE_BYTES` | 0 / 4MiB | size filters |
+| `GTS_PERF_SCAN_EXCLUDE_PATHS` | — | comma-separated language-relative or `language/path` exact paths/globs to omit from selection; intended for named C-oracle cliff witnesses that remain tracked in the ledger |
 | `GTS_PERF_SCAN_ORDER` | `largest` | `largest` / `smallest` / `path` selection order |
 | `GTS_PERF_SCAN_AXES` | `full,noedit` | add `edit` for the incremental-edit axis |
 | `GTS_PERF_SCAN_CONTENDED` | auto (loadavg) | mark run as contended (smoke-only numbers) |

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -110,7 +110,7 @@ grammar repos, not corpus repos.
 | `GTS_PERF_SCAN_LANG_TIMEOUT_MS` | 600000 | hard subprocess kill per language |
 | `GTS_PERF_SCAN_MAX_FILES` | 16 | files per language (after ordering) |
 | `GTS_PERF_SCAN_MIN_FILE_BYTES` / `_MAX_FILE_BYTES` | 0 / 4MiB | size filters |
-| `GTS_PERF_SCAN_EXCLUDE_PATHS` | — | comma-separated language-relative or `language/path` exact paths/globs to omit from selection; intended for named C-oracle cliff witnesses that remain tracked in the ledger |
+| `GTS_PERF_SCAN_EXCLUDE_PATHS` | — | comma-separated language-relative or `language/path` exact paths/globs to omit from selection; globs use Go `path.Match` semantics (`*` does not cross `/`), and trailing `/` means directory prefix. Intended for named C-oracle cliff witnesses that remain tracked in the ledger |
 | `GTS_PERF_SCAN_ORDER` | `largest` | `largest` / `smallest` / `path` selection order |
 | `GTS_PERF_SCAN_AXES` | `full,noedit` | add `edit` for the incremental-edit axis |
 | `GTS_PERF_SCAN_CONTENDED` | auto (loadavg) | mark run as contended (smoke-only numbers) |

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -248,7 +248,7 @@ func perfScanPathList(raw string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, part := range strings.Split(raw, ",") {
-		part = filepath.ToSlash(strings.TrimSpace(part))
+		part = strings.ReplaceAll(strings.TrimSpace(part), "\\", "/")
 		part = strings.TrimPrefix(part, "./")
 		part = strings.TrimPrefix(part, "/")
 		if part == "" || seen[part] {
@@ -276,10 +276,10 @@ func perfScanPathExcluded(lang, rel string, patterns []string) bool {
 }
 
 func perfScanPathPatternMatches(pattern, candidate string) bool {
-	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	pattern = strings.ReplaceAll(strings.TrimSpace(pattern), "\\", "/")
 	pattern = strings.TrimPrefix(pattern, "./")
 	pattern = strings.TrimPrefix(pattern, "/")
-	candidate = filepath.ToSlash(strings.TrimSpace(candidate))
+	candidate = strings.ReplaceAll(strings.TrimSpace(candidate), "\\", "/")
 	candidate = strings.TrimPrefix(candidate, "./")
 	candidate = strings.Trim(candidate, "/")
 	if pattern == "" {
@@ -1803,7 +1803,7 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	if strings.Contains(joined, "LANG=old") || !strings.Contains(joined, "GTS_PERF_SCAN_LANG=go") {
 		t.Fatalf("mergeEnv=%v", env)
 	}
-	paths := perfScanPathList(" ./compiler/src/dmd/expressionsem.d, fsharp/examples/*.fs, groovy/subprojects/ ")
+	paths := perfScanPathList(" .\\compiler\\src\\dmd\\expressionsem.d, fsharp/examples/*.fs, groovy/subprojects/ ")
 	if got, want := strings.Join(paths, ","), "compiler/src/dmd/expressionsem.d,fsharp/examples/*.fs,groovy/subprojects/"; got != want {
 		t.Fatalf("path list = %q, want %q", got, want)
 	}
@@ -1815,6 +1815,7 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 		want     bool
 	}{
 		{name: "exact relative", lang: "d", rel: "compiler/src/dmd/expressionsem.d", patterns: []string{"compiler/src/dmd/expressionsem.d"}, want: true},
+		{name: "backslash relative", lang: "d", rel: "compiler/src/dmd/expressionsem.d", patterns: []string{`compiler\src\dmd\expressionsem.d`}, want: true},
 		{name: "exact language relative", lang: "d", rel: "compiler/src/dmd/expressionsem.d", patterns: []string{"d/compiler/src/dmd/expressionsem.d"}, want: true},
 		{name: "glob", lang: "fsharp", rel: "examples/ProvidedTypes.fs", patterns: []string{"fsharp/examples/*.fs"}, want: true},
 		{name: "directory prefix", lang: "groovy", rel: "subprojects/performance/x.groovy", patterns: []string{"groovy/subprojects/"}, want: true},

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -40,6 +40,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -68,6 +69,7 @@ const (
 	perfScanEnvMaxFiles    = "GTS_PERF_SCAN_MAX_FILES"
 	perfScanEnvMinBytes    = "GTS_PERF_SCAN_MIN_FILE_BYTES"
 	perfScanEnvMaxBytes    = "GTS_PERF_SCAN_MAX_FILE_BYTES"
+	perfScanEnvExclude     = "GTS_PERF_SCAN_EXCLUDE_PATHS"
 	perfScanEnvOrder       = "GTS_PERF_SCAN_ORDER"
 	perfScanEnvAxes        = "GTS_PERF_SCAN_AXES"
 	perfScanEnvContended   = "GTS_PERF_SCAN_CONTENDED"
@@ -98,6 +100,7 @@ type perfScanConfig struct {
 	MaxFiles      int      `json:"max_files"`
 	MinFileBytes  int      `json:"min_file_bytes"`
 	MaxFileBytes  int      `json:"max_file_bytes"`
+	ExcludePaths  []string `json:"exclude_paths,omitempty"`
 	Order         string   `json:"order"`
 	Axes          []string `json:"axes"`
 	Contended     bool     `json:"contended"`
@@ -207,6 +210,7 @@ func perfScanLoadConfig() perfScanConfig {
 		MaxFiles:      perfScanEnvIntDefault(perfScanEnvMaxFiles, 16),
 		MinFileBytes:  perfScanEnvIntDefault(perfScanEnvMinBytes, 0),
 		MaxFileBytes:  perfScanEnvIntDefault(perfScanEnvMaxBytes, 4<<20),
+		ExcludePaths:  perfScanPathList(os.Getenv(perfScanEnvExclude)),
 		Order:         strings.TrimSpace(os.Getenv(perfScanEnvOrder)),
 		Axes:          perfScanAxes(),
 		ChildRSSMB:    perfScanEnvIntDefault(perfScanEnvChildRSSMB, 0),
@@ -238,6 +242,61 @@ func perfScanAxes() []string {
 		return []string{perfScanAxisFull, perfScanAxisNoEdit}
 	}
 	return axes
+}
+
+func perfScanPathList(raw string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		part = filepath.ToSlash(strings.TrimSpace(part))
+		part = strings.TrimPrefix(part, "./")
+		part = strings.TrimPrefix(part, "/")
+		if part == "" || seen[part] {
+			continue
+		}
+		seen[part] = true
+		out = append(out, part)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func perfScanPathExcluded(lang, rel string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+	rel = filepath.ToSlash(strings.TrimPrefix(rel, "./"))
+	langRel := lang + "/" + rel
+	for _, pattern := range patterns {
+		if perfScanPathPatternMatches(pattern, rel) || perfScanPathPatternMatches(pattern, langRel) {
+			return true
+		}
+	}
+	return false
+}
+
+func perfScanPathPatternMatches(pattern, candidate string) bool {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	pattern = strings.TrimPrefix(pattern, "./")
+	pattern = strings.TrimPrefix(pattern, "/")
+	candidate = filepath.ToSlash(strings.TrimSpace(candidate))
+	candidate = strings.TrimPrefix(candidate, "./")
+	candidate = strings.Trim(candidate, "/")
+	if pattern == "" {
+		return false
+	}
+	if pattern == candidate {
+		return true
+	}
+	if strings.HasSuffix(pattern, "/") && strings.HasPrefix(candidate, pattern) {
+		return true
+	}
+	if strings.ContainsAny(pattern, "*?[") {
+		if ok, err := path.Match(pattern, candidate); err == nil && ok {
+			return true
+		}
+	}
+	return false
 }
 
 func perfScanCorpusRoot() string {
@@ -622,7 +681,11 @@ func perfScanSelectFiles(t *testing.T, lang string, cfg perfScanConfig, langRoot
 		if r, err := filepath.Rel(langRoot, path); err == nil {
 			rel = r
 		}
+		rel = filepath.ToSlash(rel)
 		if !realCorpusBenchmarkFileAllowed(rel, filters) {
+			return nil
+		}
+		if perfScanPathExcluded(lang, rel, cfg.ExcludePaths) {
 			return nil
 		}
 		size := info.Size()
@@ -632,7 +695,7 @@ func perfScanSelectFiles(t *testing.T, lang string, cfg perfScanConfig, langRoot
 		if cfg.MaxFileBytes > 0 && size > int64(cfg.MaxFileBytes) {
 			return nil
 		}
-		all = append(all, perfScanCorpusFile{path: path, rel: filepath.ToSlash(rel), size: size})
+		all = append(all, perfScanCorpusFile{path: path, rel: rel, size: size})
 		return nil
 	})
 	if err != nil {
@@ -1739,6 +1802,27 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	joined := strings.Join(env, " ")
 	if strings.Contains(joined, "LANG=old") || !strings.Contains(joined, "GTS_PERF_SCAN_LANG=go") {
 		t.Fatalf("mergeEnv=%v", env)
+	}
+	paths := perfScanPathList(" ./compiler/src/dmd/expressionsem.d, fsharp/examples/*.fs, groovy/subprojects/ ")
+	if got, want := strings.Join(paths, ","), "compiler/src/dmd/expressionsem.d,fsharp/examples/*.fs,groovy/subprojects/"; got != want {
+		t.Fatalf("path list = %q, want %q", got, want)
+	}
+	for _, tc := range []struct {
+		name     string
+		lang     string
+		rel      string
+		patterns []string
+		want     bool
+	}{
+		{name: "exact relative", lang: "d", rel: "compiler/src/dmd/expressionsem.d", patterns: []string{"compiler/src/dmd/expressionsem.d"}, want: true},
+		{name: "exact language relative", lang: "d", rel: "compiler/src/dmd/expressionsem.d", patterns: []string{"d/compiler/src/dmd/expressionsem.d"}, want: true},
+		{name: "glob", lang: "fsharp", rel: "examples/ProvidedTypes.fs", patterns: []string{"fsharp/examples/*.fs"}, want: true},
+		{name: "directory prefix", lang: "groovy", rel: "subprojects/performance/x.groovy", patterns: []string{"groovy/subprojects/"}, want: true},
+		{name: "miss", lang: "go", rel: "src/main.go", patterns: []string{"d/compiler/src/dmd/expressionsem.d"}, want: false},
+	} {
+		if got := perfScanPathExcluded(tc.lang, tc.rel, tc.patterns); got != tc.want {
+			t.Fatalf("%s: excluded=%v want %v", tc.name, got, tc.want)
+		}
 	}
 	rss, ok := perfScanParseStatusRSSBytes("Name:\tperfscan\nVmRSS:\t  1537 kB\n")
 	if !ok || rss != 1537*1024 {


### PR DESCRIPTION
## Summary

Adds `GTS_PERF_SCAN_EXCLUDE_PATHS` so perf-scan runs can omit named language-relative or `language/path` witnesses from corpus selection while still recording the exclusion list in scoreboard config. This gives Wave 3 a reproducible way to seed scoped ratchet rows around known C-oracle cliff files without erasing those witnesses from the gap ledger.

## Changes

- Adds `exclude_paths` to perf-scan scoreboard config and perf-ratio budget measurement basis.
- Filters selected corpus files by exact path, `language/path`, simple `path.Match` globs, and trailing-slash directory prefixes.
- Teaches `perf_scan_budget` strict config comparison to reject mismatched exclusion lists.
- Documents `GTS_PERF_SCAN_EXCLUDE_PATHS` in `cgo_harness/perf_scan/README.md`.

## Testing

- `go test ./cmd/perf_scan_budget -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh --label wave3-perfscan-exclude-helper-r2 -- "cd /workspace/cgo_harness && GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 go test -tags 'treesitter_c_parity treesitter_c_perfscan' -run '^TestPerfScanHelpersUnit$' -count=1 ."`\n- Docker smoke: `GTS_PERF_SCAN_LANGS=json GTS_PERF_SCAN_MAX_FILES=1 GTS_PERF_SCAN_ORDER=path GTS_PERF_SCAN_EXCLUDE_PATHS=json/medium__grammar.json ... TestPerfScanSweep`\n- Smoke scoreboard confirmed `exclude_paths=["json/medium__grammar.json"]` and selected `medium__node-types.json` instead of the excluded file.\n- `git diff --check`