### PR TITLE
Add exclude_paths to perf status and budget Groovy

### DIFF
--- a/cgo_harness/cmd/perf_scan_status/main.go
+++ b/cgo_harness/cmd/perf_scan_status/main.go
@@ -55,11 +55,12 @@ type knownBudgetGap struct {
 }
 
 type budgetLanguage struct {
-	Status        string     `json:"status"`
-	Wave2BPending ledgerFlag `json:"wave2b_pending,omitempty"`
-	MeasuredToday ledgerFlag `json:"measured_today,omitempty"`
-	FullAxis      budgetAxis `json:"full_axis"`
-	NoEditAxis    budgetAxis `json:"noedit_axis"`
+	Status             string     `json:"status"`
+	Wave2BPending      ledgerFlag `json:"wave2b_pending,omitempty"`
+	Wave3ScopedHeldout ledgerFlag `json:"wave3_scoped_heldout,omitempty"`
+	MeasuredToday      ledgerFlag `json:"measured_today,omitempty"`
+	FullAxis           budgetAxis `json:"full_axis"`
+	NoEditAxis         budgetAxis `json:"noedit_axis"`
 }
 
 type ledgerFlag struct {
@@ -119,6 +120,7 @@ type scoreboardConfig struct {
 	MaxFiles      int      `json:"max_files"`
 	Order         string   `json:"order"`
 	Axes          []string `json:"axes"`
+	ExcludePaths  []string `json:"exclude_paths,omitempty"`
 	Contended     bool     `json:"contended"`
 	ContendedNote string   `json:"contended_note,omitempty"`
 }
@@ -173,6 +175,7 @@ type coverageSummary struct {
 	HeldOutLanguages            int `json:"held_out_languages"`
 	KnownBudgetClassGaps        int `json:"known_budget_class_gaps"`
 	Wave2BPendingBudgets        int `json:"wave2b_pending_budgets"`
+	ScopedHeldoutBudgets        int `json:"scoped_heldout_budgets,omitempty"`
 	MeasuredTodayBudgets        int `json:"measured_today_budgets"`
 	PartialMeasuredTodayBudgets int `json:"partial_measured_today_budgets"`
 }
@@ -198,6 +201,7 @@ type scoreboardSummary struct {
 	Languages        int            `json:"languages"`
 	BudgetLanguages  int            `json:"budget_languages"`
 	HeldOutLanguages []string       `json:"held_out_languages,omitempty"`
+	ExcludePaths     []string       `json:"exclude_paths,omitempty"`
 	Contended        bool           `json:"contended"`
 	ContendedNote    string         `json:"contended_note,omitempty"`
 	LoadAvgStart     string         `json:"loadavg_start,omitempty"`
@@ -282,12 +286,15 @@ func buildStatus(opts options) (*statusDocument, error) {
 
 	budgetSet := map[string]bool{}
 	statusCounts := map[string]int{}
-	var pending, measuredToday, partialMeasuredToday int
+	var pending, scopedHeldout, measuredToday, partialMeasuredToday int
 	for lang, row := range budget.Languages {
 		budgetSet[lang] = true
 		statusCounts[row.Status]++
 		if row.Wave2BPending.IsTrue() {
 			pending++
+		}
+		if row.Wave3ScopedHeldout.IsTrue() {
+			scopedHeldout++
 		}
 		if row.MeasuredToday.IsTrue() {
 			measuredToday++
@@ -316,6 +323,7 @@ func buildStatus(opts options) (*statusDocument, error) {
 			HeldOutLanguages:            len(heldOut),
 			KnownBudgetClassGaps:        len(budget.KnownGaps),
 			Wave2BPendingBudgets:        pending,
+			ScopedHeldoutBudgets:        scopedHeldout,
 			MeasuredTodayBudgets:        measuredToday,
 			PartialMeasuredTodayBudgets: partialMeasuredToday,
 		},
@@ -323,7 +331,7 @@ func buildStatus(opts options) (*statusDocument, error) {
 		BudgetStatusCounts: statusCounts,
 		SeedSources:        sortedKeys(budget.SeedSources),
 		KnownGaps:          summarizeKnownGaps(budget.KnownGaps),
-		Caveats:            baseCaveats(heldOut, budget.KnownGaps),
+		Caveats:            baseCaveats(heldOut, scopedHeldout, budget.KnownGaps),
 	}
 
 	if opts.ScoreboardPatterns != "" {
@@ -449,6 +457,7 @@ func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet 
 			Languages:        len(board.Languages),
 			BudgetLanguages:  budgetLangs,
 			HeldOutLanguages: heldOut,
+			ExcludePaths:     board.Config.ExcludePaths,
 			Contended:        board.Config.Contended,
 			ContendedNote:    board.Config.ContendedNote,
 			LoadAvgStart:     board.Host.LoadAvgStart,
@@ -531,6 +540,9 @@ func renderMarkdown(doc *statusDocument) string {
 	fmt.Fprintf(&sb, "| held out languages | %d |\n", doc.Coverage.HeldOutLanguages)
 	fmt.Fprintf(&sb, "| known budget class gaps | %d |\n", doc.Coverage.KnownBudgetClassGaps)
 	fmt.Fprintf(&sb, "| wave2b pending budget rows | %d |\n", doc.Coverage.Wave2BPendingBudgets)
+	if doc.Coverage.ScopedHeldoutBudgets > 0 {
+		fmt.Fprintf(&sb, "| scoped heldout budget rows | %d |\n", doc.Coverage.ScopedHeldoutBudgets)
+	}
 	fmt.Fprintf(&sb, "| measured-today budget rows | %d |\n", doc.Coverage.MeasuredTodayBudgets)
 	if doc.Coverage.PartialMeasuredTodayBudgets > 0 {
 		fmt.Fprintf(&sb, "| partial measured-today notes | %d |\n", doc.Coverage.PartialMeasuredTodayBudgets)
@@ -633,11 +645,14 @@ func summarizeKnownGaps(gaps map[string]knownBudgetGap) []knownGapSummary {
 	return out
 }
 
-func baseCaveats(heldOut []string, gaps map[string]knownBudgetGap) []string {
+func baseCaveats(heldOut []string, scopedHeldout int, gaps map[string]knownBudgetGap) []string {
 	var caveats []string
 	caveats = append(caveats, "The perf ratio budget is a ratchet and evidence ledger, not a universal near-C claim; >2x and cliff rows remain explicit backlog.")
 	if len(heldOut) > 0 {
 		caveats = append(caveats, fmt.Sprintf("%s are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved.", strings.Join(heldOut, ", ")))
+	}
+	if scopedHeldout > 0 {
+		caveats = append(caveats, fmt.Sprintf("%d budget row(s) use scoped heldout exclusions; see measurement_basis.exclude_paths and the known-gap ledger before treating those rows as whole-language claims.", scopedHeldout))
 	}
 	if _, ok := gaps["webworker_generated_d_ts"]; ok {
 		caveats = append(caveats, "The TypeScript webworker generated-file entry remains a correctness cross-check caveat even though TypeScript has a timing budget row.")

--- a/cgo_harness/cmd/perf_scan_status/main.go
+++ b/cgo_harness/cmd/perf_scan_status/main.go
@@ -45,6 +45,7 @@ type measurementBasis struct {
 	MaxFiles     int      `json:"max_files,omitempty"`
 	Order        string   `json:"order,omitempty"`
 	Axes         []string `json:"axes"`
+	ExcludePaths []string `json:"exclude_paths,omitempty"`
 }
 
 type knownBudgetGap struct {
@@ -543,6 +544,10 @@ func renderMarkdown(doc *statusDocument) string {
 		doc.MeasurementBasis.MaxFiles,
 		mdInline(doc.MeasurementBasis.Order),
 		mdInline(strings.Join(doc.MeasurementBasis.Axes, ",")))
+
+	if len(doc.MeasurementBasis.ExcludePaths) > 0 {
+		fmt.Fprintf(&sb, "Excluded paths: `%s`.\n\n", strings.Join(doc.MeasurementBasis.ExcludePaths, "`, `"))
+	}
 
 	if len(doc.HeldOutLanguages) > 0 {
 		fmt.Fprintf(&sb, "Held out of the ratchet: `%s`.\n\n", strings.Join(doc.HeldOutLanguages, "`, `"))

--- a/cgo_harness/cmd/perf_scan_status/main_test.go
+++ b/cgo_harness/cmd/perf_scan_status/main_test.go
@@ -32,10 +32,11 @@ func TestBuildStatusFromTrackedInputs(t *testing.T) {
 		},
 		"languages": map[string]any{
 			"go": map[string]any{
-				"status":         "green_with_caveat",
-				"measured_today": true,
-				"full_axis":      map[string]any{"max_timeouts": 0, "max_ratio_by_total": 2.0},
-				"noedit_axis":    map[string]any{"max_timeouts": 0, "max_ratio_by_total": 1.0},
+				"status":               "green_with_caveat",
+				"wave3_scoped_heldout": true,
+				"measured_today":       true,
+				"full_axis":            map[string]any{"max_timeouts": 0, "max_ratio_by_total": 2.0},
+				"noedit_axis":          map[string]any{"max_timeouts": 0, "max_ratio_by_total": 1.0},
 			},
 			"python": map[string]any{
 				"status":         "wave2b_pending",
@@ -78,11 +79,14 @@ func TestBuildStatusFromTrackedInputs(t *testing.T) {
 	if doc.Coverage.PartialMeasuredTodayBudgets != 1 {
 		t.Fatalf("partial measured today = %d, want 1", doc.Coverage.PartialMeasuredTodayBudgets)
 	}
+	if doc.Coverage.ScopedHeldoutBudgets != 1 {
+		t.Fatalf("scoped heldout budgets = %d, want 1", doc.Coverage.ScopedHeldoutBudgets)
+	}
 	if got := strings.Join(doc.MeasurementBasis.ExcludePaths, ","); got != "groovy/large.groovy" {
 		t.Fatalf("exclude paths = %q, want groovy/large.groovy", got)
 	}
 	md := renderMarkdown(doc)
-	for _, needle := range []string{"budgeted languages", "Excluded paths", "Held out of the ratchet", "groovy_gap", "wave3_batch1"} {
+	for _, needle := range []string{"budgeted languages", "scoped heldout budget rows", "Excluded paths", "Held out of the ratchet", "groovy_gap", "wave3_batch1"} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("markdown missing %q:\n%s", needle, md)
 		}
@@ -118,7 +122,8 @@ func TestBuildStatusWithScoreboards(t *testing.T) {
 		"config": map[string]any{
 			"reps": 5, "warmup": 1, "file_budget_ms": 10000, "lang_timeout_ms": 900000,
 			"max_files": 8, "order": "largest", "axes": []string{"full", "noedit"},
-			"contended": true, "contended_note": "test contention",
+			"exclude_paths": []string{"groovy/large.groovy"},
+			"contended":     true, "contended_note": "test contention",
 		},
 		"host":             map[string]any{"loadavg_start": "7.00 5.00 4.00", "loadavg_end": "6.00 5.00 4.00"},
 		"summary_verdicts": map[string]int{"<=2x": 1, "cliff>10x": 1},
@@ -162,6 +167,9 @@ func TestBuildStatusWithScoreboards(t *testing.T) {
 	}
 	if doc.ScoreboardCoverage.ContendedScoreboards != 1 {
 		t.Fatalf("contended scoreboards = %d, want 1", doc.ScoreboardCoverage.ContendedScoreboards)
+	}
+	if got := strings.Join(doc.Scoreboards[0].ExcludePaths, ","); got != "groovy/large.groovy" {
+		t.Fatalf("scoreboard exclude paths = %q, want groovy/large.groovy", got)
 	}
 }
 

--- a/cgo_harness/cmd/perf_scan_status/main_test.go
+++ b/cgo_harness/cmd/perf_scan_status/main_test.go
@@ -20,6 +20,7 @@ func TestBuildStatusFromTrackedInputs(t *testing.T) {
 		"measurement_basis": map[string]any{
 			"reps": 5, "warmup": 1, "file_budget_ms": 10000,
 			"max_files": 8, "order": "largest", "axes": []string{"full", "noedit"},
+			"exclude_paths": []string{"groovy/large.groovy"},
 		},
 		"_seed_sources": map[string]string{
 			"wave3_batch1": "first batch",
@@ -77,8 +78,11 @@ func TestBuildStatusFromTrackedInputs(t *testing.T) {
 	if doc.Coverage.PartialMeasuredTodayBudgets != 1 {
 		t.Fatalf("partial measured today = %d, want 1", doc.Coverage.PartialMeasuredTodayBudgets)
 	}
+	if got := strings.Join(doc.MeasurementBasis.ExcludePaths, ","); got != "groovy/large.groovy" {
+		t.Fatalf("exclude paths = %q, want groovy/large.groovy", got)
+	}
 	md := renderMarkdown(doc)
-	for _, needle := range []string{"budgeted languages", "Held out of the ratchet", "groovy_gap", "wave3_batch1"} {
+	for _, needle := range []string{"budgeted languages", "Excluded paths", "Held out of the ratchet", "groovy_gap", "wave3_batch1"} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("markdown missing %q:\n%s", needle, md)
 		}

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -16,8 +16,8 @@
     "that isn't green today is worse than useless."
   ],
   "schema": "gts-perf-ratio-budgets/v1",
-  "generated_at": "2026-07-09T09:53:11Z",
-  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/perf-assisted-ratchets, extending the wave-2b budget with batch-1 through batch-7 plus the assisted fleet gap-close measurements and held-out exact-file RCA probes",
+  "generated_at": "2026-07-09T10:38:34Z",
+  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/scoped-heldout-ratchets, extending the wave-2b budget with batch-1 through batch-7, assisted fleet gap-close measurements, held-out exact-file RCA probes, and the scoped Groovy heldout ratchet",
   "measurement_basis": {
     "harness": "cgo_harness/perf_scan (TestPerfScanSweep / TestPerfScanLanguage, tags treesitter_c_parity treesitter_c_perfscan)",
     "corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources (real upstream per-language checkouts, largest-8-files sampling -- deliberately adversarial, hunts cliffs, NOT representative of typical file size)",
@@ -30,6 +30,9 @@
     "warmup": 1,
     "file_budget_ms": 10000,
     "axes": ["full", "noedit"],
+    "exclude_paths": [
+      "groovy/subprojects/performance/src/files/pleac11_15.groovy"
+    ],
     "ratio_definition": "ratio = Go median ns / C median ns, per file; ratio_by_total = sum(Go medians)/sum(C medians) across completing files; ratio_median_of_files = median of per-file ratios. A file that hits the 10s per-attempt budget (wall-clock timeout or memory_budget stop) is excluded from both aggregates and counted in max_timeouts. A file whose Go tree completes but does not cover the full byte range (root.EndByte != len(source), status go_error/truncated) is counted in max_errors -- this is a DISTINCT failure mode from timeouts (silent-truncation-shaped correctness bugs, e.g. haskell/cpp/scala/crystal/typescript below) and is not caught by max_timeouts alone."
   },
   "_seed_sources": {
@@ -53,7 +56,10 @@
     "d_expressionsem_default_20260709T083649Z": "post-containment exact-file D probe on branch wave3/d-rss-containment, Docker 8GiB/GOMEMLIMIT=6GiB, lock-filtered largest-1 expressionsem.d (685384 bytes), axes full/noedit, reps=1,warmup=0,file_budget=10000ms. The default parser policy now completes the Go full parse without timeout or Go-side OOM (Go full median 6.68s, noedit 996ns), but C returns nil at the 10s file budget and a 30s follow-up crossed a 6144MiB RSS watchdog during C noedit base. This is Go-cliff containment evidence, not a ratchet seed; D stays held out because the exact C oracle row cannot produce a normal budgeted ratio.",
     "fsharp_providedtypes_exact_default_20260709T094157Z": "exact-file F# ProvidedTypes probe on branch wave3/fsharp-c-reference-rca, Docker 8GiB/GOMEMLIMIT=6GiB, byte-window selected only ProvidedTypes.fs (755275 bytes), axes full/noedit, reps=1,warmup=0,file_budget=10000ms,RSS watchdog 4096. Container completed with oom_killed=false and files=1/1, but both axes were n/a: default Go parse returned truncated[flagged] at root.EndByte=5339 while C returned nil at the 10s budget. This is non-ratchetable RCA evidence, not a budget seed.",
     "fsharp_providedtypes_exact_full30s_20260709T094341Z": "same exact F# ProvidedTypes row, full axis only, Docker 8GiB/GOMEMLIMIT=6GiB, file_budget=30000ms,RSS watchdog 4096. Default policy still returned Go truncated[flagged] at root.EndByte=5339 and C nil at the 30s budget, showing the normal-policy row cannot produce a C ratio.",
-    "fsharp_providedtypes_exact_scale3_rss4096_20260709T094500Z": "same exact F# ProvidedTypes row with GOT_PARSE_NODE_LIMIT_SCALE=3, full axis only, Docker 8GiB/GOMEMLIMIT=6GiB, file_budget=30000ms,RSS watchdog 4096. The child stopped cleanly before cgroup OOM at rss=4101MiB while active_file was ProvidedTypes.fs and active_axis=full active_impl=c active_phase=rep active_attempt=1. This isolates a separate C-reference RSS cliff once the Go diagnostic node budget is raised."
+    "fsharp_providedtypes_exact_scale3_rss4096_20260709T094500Z": "same exact F# ProvidedTypes row with GOT_PARSE_NODE_LIMIT_SCALE=3, full axis only, Docker 8GiB/GOMEMLIMIT=6GiB, file_budget=30000ms,RSS watchdog 4096. The child stopped cleanly before cgroup OOM at rss=4101MiB while active_file was ProvidedTypes.fs and active_axis=full active_impl=c active_phase=rep active_attempt=1. This isolates a separate C-reference RSS cliff once the Go diagnostic node budget is raised.",
+    "wave3_scoped_d_exclude_expressionsem_20260709T103336Z": "scoped D heldout probe on branch wave3/scoped-heldout-ratchets, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis, GTS_PERF_SCAN_EXCLUDE_PATHS=d/compiler/src/dmd/expressionsem.d, RSS watchdog 6144. Result stayed non-ratchetable: two files completed only as C-reference timeouts, then compiler/src/dmd/dsymbolsem.d crossed the RSS watchdog during noedit/c/base attempt 1.",
+    "wave3_scoped_groovy_exclude_pleac11_20260709T103612Z": "scoped Groovy heldout ratchet on branch wave3/scoped-heldout-ratchets, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis, GTS_PERF_SCAN_EXCLUDE_PATHS=groovy/subprojects/performance/src/files/pleac11_15.groovy, RSS watchdog 6144. Completed 8/8 with no timeouts/errors; full axis remained a measured cliff backlog row at ratio_by_total=22.01x and median=25.81x, noedit ratio_by_total=0.000275x. The run was harness-flagged contended (loadavg1=6.68), so the row is a visibility/scoped ratchet rather than a near-C claim.",
+    "wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z": "scoped F# heldout probe on branch wave3/scoped-heldout-ratchets, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis, GTS_PERF_SCAN_EXCLUDE_PATHS=fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs, RSS watchdog 6144. Result stayed non-ratchetable: the first selected file, examples/FSharp.Compiler/tests/FSharp.Core.UnitTests/FSharp.Core/ComparersRegression.fs (3,587,873 bytes), crossed the RSS watchdog during full/c/warmup attempt 1 before any file completed."
   },
   "languages": {
     "php": {
@@ -569,6 +575,27 @@
         "max_timeouts": 0,
         "max_ratio_by_total": 1.0,
         "observed_ratio_by_total": 0.000153
+      }
+    },
+    "groovy": {
+      "status": "green_with_caveat",
+      "wave3_scoped_heldout": true,
+      "measured_today": true,
+      "note": "Scoped Wave-3 heldout ratchet (wave3_scoped_groovy_exclude_pleac11_20260709T103612Z): with the named error-bearing witness subprojects/performance/src/files/pleac11_15.groovy excluded via GTS_PERF_SCAN_EXCLUDE_PATHS, the largest-8 Groovy row completed 8/8 under Docker 8GiB/GOMEMLIMIT=6GiB/RSS watchdog 6144 with 0 timeouts, 0 truncations, and 0 C-reference failures. Full parse remains a measured throughput backlog row (22.01x aggregate, 25.81x median, five cliff files), not a near-C claim. The run was harness-flagged contended (loadavg1=6.68), so keep the budget intentionally loose until a quiet-box refresh tightens it.",
+      "full_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 30,
+        "max_ratio_median_of_files": 35,
+        "observed_ratio_by_total": 22.01,
+        "observed_ratio_median_of_files": 25.81
+      },
+      "noedit_axis": {
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 1.0,
+        "observed_ratio_by_total": 0.000275,
+        "observed_ratio_median_of_files": 0.0159
       }
     },
     "hcl": {
@@ -3983,10 +4010,11 @@
         "post_runtime_budget_docker_4gib": "post-#182, exact-file pleac11_15.groovy probe under Docker 4GiB/GOMEMLIMIT=3GiB completes the perf-scan row without cgroup OOM and reports full-axis go_timeout: parse stopped early (memory_budget), C median 27.67ms, lower-bound ratio >=361.4x",
         "rss_watchdog_probe": "with GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=512, the same 2GiB container exits cleanly with a written scoreboard row instead of oom_killed=true; the child is stopped at rss=519MiB before any file completes",
         "post_stack_ceiling_default_exact": "post Groovy cap-2 + large-file retry-ceiling policy, exact-file Docker 4GiB/GOMEMLIMIT=3GiB/GOT_PARSE_MEMORY_BUDGET_MB=512 completes without timeout or OOM: full Go 1.66s vs C 27.23ms (60.9x cliff), noedit ratio 0.00012x, perf_scan out groovy_ceiling_full_noedit_20260709T075435Z",
+        "scoped_exclude_pleac11_ratchet": "wave3_scoped_groovy_exclude_pleac11_20260709T103612Z, Docker 8GiB/GOMEMLIMIT=6GiB/RSS watchdog 6144, largest-8 ratchet basis with GTS_PERF_SCAN_EXCLUDE_PATHS=groovy/subprojects/performance/src/files/pleac11_15.groovy: completed 8/8 with 0 timeouts/errors/C-reference failures, full ratio_by_total=22.01x, median=25.81x, five full-axis cliff files, noedit ratio_by_total=0.000275x. Harness marked the run contended (loadavg1=6.68), so this is a scoped backlog ratchet rather than a near-C claim.",
         "corpus_parity_exact": "cgo_harness/cmd/corpus_parity on the same exact file completes under Docker 4GiB without OOM but remains structurally divergent: both roots are source_file with HasError=true; first divergence is root child count Go=788 vs C=1264"
       },
       "suspected_class": "retry-widening population explosion on an error-bearing large Groovy file; contained by treating Groovy's tuned cap-2 full-parse policy as a large-file retry ceiling, but still a correctness/perf backlog because the bounded tree is not C-shape-identical and full parse remains ~60x C on the exact witness",
-      "action": "Groovy remains held out of the ratchet. The prior timeout/OOM class is contained for pleac11_15.groovy under default settings, but a ratchetable row needs either C-shape parity on the exact witness or an explicit scoped budget decision that accepts the error-bearing child-count divergence plus cliff full-parse ratio."
+      "action": "Groovy is now budgeted only under a scoped measurement basis that excludes the named pleac11_15.groovy witness. The exact witness remains a tracked correctness/perf gap: default policy contains the OOM, but the file is still C-shape divergent and ~60x C on full parse."
     },
     "fsharp_providedtypes_c_reference_memory_blowup": {
       "file": "fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection)",
@@ -4000,10 +4028,11 @@
         "activeattempt_3000": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, lock-filtered corpus, largest-8, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=3000: scoreboard fragment preserved the same active_file=examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs, active_axis=full, active_impl=c, active_phase=rep, active_attempt=1, but docker still reported oom_killed=true",
         "exact_default_10s": "post-v0.22.4 exact byte-window probe under Docker 8GiB/GOMEMLIMIT=6GiB, reps=1, warmup=0, axes full/noedit, file_budget=10000ms, RSS watchdog 4096: parent preserved a complete language fragment (files=1/1, oom_killed=false), but full and noedit were n/a because default Go returned truncated[flagged] at root.EndByte=5339 and C returned nil at the 10s budget",
         "exact_default_full_30s": "same exact byte-window row under Docker 8GiB/GOMEMLIMIT=6GiB, full axis only, file_budget=30000ms, RSS watchdog 4096: default Go still returned truncated[flagged] at root.EndByte=5339 and C still returned nil at the 30s budget",
-        "exact_scale3_full_rss4096": "same exact byte-window row with GOT_PARSE_NODE_LIMIT_SCALE=3, full axis only, file_budget=30000ms, RSS watchdog 4096: child stopped at rss=4101MiB with active_file=examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs, active_axis=full, active_impl=c, active_phase=rep, active_attempt=1, oom_killed=false"
+        "exact_scale3_full_rss4096": "same exact byte-window row with GOT_PARSE_NODE_LIMIT_SCALE=3, full axis only, file_budget=30000ms, RSS watchdog 4096: child stopped at rss=4101MiB with active_file=examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs, active_axis=full, active_impl=c, active_phase=rep, active_attempt=1, oom_killed=false",
+        "scoped_exclude_providedtypes_rss6144": "wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z, Docker 8GiB/GOMEMLIMIT=6GiB/RSS watchdog 6144, largest-8 ratchet basis with GTS_PERF_SCAN_EXCLUDE_PATHS=fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs: still non-ratchetable. The first selected file, examples/FSharp.Compiler/tests/FSharp.Core.UnitTests/FSharp.Core/ComparersRegression.fs (3,587,873 bytes), crossed the watchdog during full/c/warmup attempt 1 before any file completed."
       },
-      "suspected_class": "Default F# exact ProvidedTypes is a dual non-ratchetable blocker: Go returns an honestly flagged truncated tree at byte 5339 under the normal node budget while C returns nil at 10s/30s. With GOT_PARSE_NODE_LIMIT_SCALE=3, the same exact row advances to the C full-parse attempt and crosses a 4096MiB RSS watchdog, evidencing a separate C-reference RSS cliff after the Go diagnostic node-budget cap is lifted.",
-      "action": "F# remains held out. Do not rerun broad F# sweeps without a disposable hard RSS envelope. Next step is either a scoped corpus-selection/budget decision excluding ProvidedTypes-class files, or a parser-side/default-budget investigation for the Go truncation before any C-reference ratio can be ratcheted; exact ProvidedTypes also needs an explicit C high-RSS witness decision."
+      "suspected_class": "Default F# exact ProvidedTypes is a dual non-ratchetable blocker: Go returns an honestly flagged truncated tree at byte 5339 under the normal node budget while C returns nil at 10s/30s. With GOT_PARSE_NODE_LIMIT_SCALE=3, the same exact row advances to the C full-parse attempt and crosses a 4096MiB RSS watchdog; excluding ProvidedTypes exposes another C-reference high-RSS giant, ComparersRegression.fs.",
+      "action": "F# remains held out. Do not rerun broad F# sweeps without a disposable hard RSS envelope. A ratchetable row needs either a principled corpus-selection policy for multi-MiB F# fixtures plus a default-budget truncation fix, or an explicit decision that these C-reference high-RSS giants are excluded workload witnesses rather than normal ratio samples."
     },
     "d_expressionsem_go_rss_blowup": {
       "file": "d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes)",
@@ -4016,10 +4045,11 @@
         "activeattempt_1536": "post-#185 Docker 4GiB, GOMEMLIMIT=3GiB, largest-1, reps=1, warmup=0, file_budget=10000ms, GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=1536: child stopped at rss=1539MiB with active_file=compiler/src/dmd/expressionsem.d, active_axis=full, active_impl=go, active_phase=rep, active_attempt=1",
         "post_default_go_only": "post D cap-2 + large-file retry-ceiling policy, exact-file Docker 4GiB/GOMEMLIMIT=3GiB/GOT_PARSE_MEMORY_BUDGET_MB=512/TIMEOUT_US=10000000 with no GOT_GLR_MAX_STACKS override: production Parse completed accepted in 6.05s without timeout or OOM; command max RSS 817MiB; runtime root spans 685384 bytes with HasError=true",
         "post_default_perfscan_10s": "post-containment exact-file perf_scan Docker 8GiB/GOMEMLIMIT=6GiB, lock-filtered largest-1, reps=1,warmup=0,file_budget=10000ms,RSS watchdog 6144: parent preserved status=ok files=1/1, Go full median 6.68s and noedit 996ns, but full/noedit verdict remained n/a because C full returned nil at the 10s file budget",
-        "post_cap2_perfscan_30s": "30s-budget follow-up under the same 8GiB/6144MiB RSS envelope crossed the RSS watchdog during C noedit base (rss=6145MiB), confirming the remaining exact-row blocker is C-reference high-RSS/timeout rather than a pure-Go D full-parse OOM"
+        "post_cap2_perfscan_30s": "30s-budget follow-up under the same 8GiB/6144MiB RSS envelope crossed the RSS watchdog during C noedit base (rss=6145MiB), confirming the remaining exact-row blocker is C-reference high-RSS/timeout rather than a pure-Go D full-parse OOM",
+        "scoped_exclude_expressionsem_rss6144": "wave3_scoped_d_exclude_expressionsem_20260709T103336Z, Docker 8GiB/GOMEMLIMIT=6GiB/RSS watchdog 6144, largest-8 ratchet basis with GTS_PERF_SCAN_EXCLUDE_PATHS=d/compiler/src/dmd/expressionsem.d: still non-ratchetable. compiler/src/dmd/backend/x86/cod3.d and compiler/src/dmd/dinterpret.d completed only as C-reference timeouts, then compiler/src/dmd/dsymbolsem.d crossed the watchdog during noedit/c/base attempt 1."
       },
-      "suspected_class": "historical pure-Go D full-parse RSS blowup on expressionsem.d is contained by the D cap-2/default retry-ceiling policy; the remaining exact largest-file blocker is C-reference timeout/high-RSS before a normal ratio can be recorded",
-      "action": "D remains held out of the ratchet. The prior Go timeout/OOM class is contained under default settings, but a ratchetable row needs either a smaller scoped D corpus selection or an explicit budget decision that treats expressionsem.d as a C-reference high-RSS witness instead of a normal Go-vs-C ratio sample."
+      "suspected_class": "historical pure-Go D full-parse RSS blowup on expressionsem.d is contained by the D cap-2/default retry-ceiling policy; the largest-order workload now exposes multiple C-reference timeout/high-RSS blockers before a normal ratio can be recorded",
+      "action": "D remains held out of the ratchet. The prior Go timeout/OOM class is contained under default settings, but excluding expressionsem.d is not enough: largest-order D next hits C timeouts and a dsymbolsem.d C noedit-base RSS watchdog. A ratchetable row needs a principled smaller-workload policy or an explicit D C-reference high-RSS witness exclusion set."
     }
   }
 }

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -13,7 +13,10 @@
     "budgets are comfortably green today while still tight enough to catch a",
     "cliff regression. Where a language's real, fresh measurement contradicts an",
     "optimistic prior assumption (bash), the real measurement wins -- a ratchet",
-    "that isn't green today is worse than useless."
+    "that isn't green today is worse than useless.",
+    "Adding measurement_basis.exclude_paths is a budget-loosening operation and",
+    "must carry the same mechanism/RCA evidence as loosening a ratio budget;",
+    "removing exclusions is a tightening operation."
   ],
   "schema": "gts-perf-ratio-budgets/v1",
   "generated_at": "2026-07-09T10:38:34Z",

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,10 +1,10 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T09:53:11Z",
+  "generated_at": "2026-07-09T10:41:25Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
-  "budget_generated_at": "2026-07-09T09:53:11Z",
-  "budget_generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/perf-assisted-ratchets, extending the wave-2b budget with batch-1 through batch-7 plus the assisted fleet gap-close measurements and held-out exact-file RCA probes",
+  "budget_generated_at": "2026-07-09T10:38:34Z",
+  "budget_generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/scoped-heldout-ratchets, extending the wave-2b budget with batch-1 through batch-7, assisted fleet gap-close measurements, held-out exact-file RCA probes, and the scoped Groovy heldout ratchet",
   "measurement_basis": {
     "reps": 5,
     "warmup": 1,
@@ -14,31 +14,37 @@
     "axes": [
       "full",
       "noedit"
+    ],
+    "exclude_paths": [
+      "groovy/subprojects/performance/src/files/pleac11_15.groovy"
     ]
   },
   "coverage": {
     "fleet_languages": 206,
-    "budgeted_languages": 203,
-    "held_out_languages": 3,
+    "budgeted_languages": 204,
+    "held_out_languages": 2,
     "known_budget_class_gaps": 4,
     "wave2b_pending_budgets": 15,
-    "measured_today_budgets": 193,
+    "measured_today_budgets": 194,
     "partial_measured_today_budgets": 1
   },
   "held_out_languages": [
     "d",
-    "fsharp",
-    "groovy"
+    "fsharp"
   ],
   "budget_status_counts": {
     "green": 50,
-    "green_with_caveat": 142,
+    "green_with_caveat": 143,
     "wave2b_pending": 11
   },
   "seed_sources": [
     "after_cliffs_20260706T210143Z",
     "authoritative_20260706T145520Z",
+    "d_expressionsem_default_20260709T083649Z",
     "fleet_gap_close_assist_20260708T232019Z_to_20260709T003453Z",
+    "fsharp_providedtypes_exact_default_20260709T094157Z",
+    "fsharp_providedtypes_exact_full30s_20260709T094341Z",
+    "fsharp_providedtypes_exact_scale3_rss4096_20260709T094500Z",
     "groovy_ceiling_exact_20260709T075435Z",
     "pr142_evidence_and_wave2a_closeout_spore",
     "wave2b_green_20260707T0100Z",
@@ -52,10 +58,9 @@
     "wave3_batch6_dot_20260708T225933Z",
     "wave3_batch6_doxygen_20260708T230104Z",
     "wave3_batch7_20260708T232544Z",
-    "d_expressionsem_default_20260709T083649Z",
-    "fsharp_providedtypes_exact_default_20260709T094157Z",
-    "fsharp_providedtypes_exact_full30s_20260709T094341Z",
-    "fsharp_providedtypes_exact_scale3_rss4096_20260709T094500Z",
+    "wave3_scoped_d_exclude_expressionsem_20260709T103336Z",
+    "wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z",
+    "wave3_scoped_groovy_exclude_pleac11_20260709T103612Z",
     "webworker_oracle_spotcheck"
   ],
   "known_budget_class_gaps": [
@@ -63,19 +68,19 @@
       "key": "d_expressionsem_go_rss_blowup",
       "file": "d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes)",
       "backlog_ref": "wave3_batch6_20260708T224850Z seed note; intentionally not added to languages because both the batch run and one-language rerun ended with Docker oom_killed=true before #185 added the parent-side RSS watchdog",
-      "action": "D remains held out of the ratchet. The prior Go timeout/OOM class is contained under default settings, but a ratchetable row needs either a smaller scoped D corpus selection or an explicit budget decision that treats expressionsem.d as a C-reference high-RSS witness instead of a normal Go-vs-C ratio sample."
+      "action": "D remains held out of the ratchet. The prior Go timeout/OOM class is contained under default settings, but excluding expressionsem.d is not enough: largest-order D next hits C timeouts and a dsymbolsem.d C noedit-base RSS watchdog. A ratchetable row needs a principled smaller-workload policy or an explicit D C-reference high-RSS witness exclusion set."
     },
     {
       "key": "fsharp_providedtypes_c_reference_memory_blowup",
       "file": "fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection)",
       "backlog_ref": "assisted Wave-3 fleet gap-close pass, reported in /tmp/gts_scratch/FLEET_SCOREBOARD.md; intentionally not added to languages because it is not a ratchetable row",
-      "action": "F# remains held out. Exact ProvidedTypes is a dual blocker under the normal policy: Go returns an honestly flagged truncated tree at byte 5339 and C returns nil at 10s/30s; with GOT_PARSE_NODE_LIMIT_SCALE=3, the same row reaches full/c/rep and crosses a 4096MiB RSS watchdog. Next step is scoped corpus selection or a default-budget truncation fix before any C-reference ratio can be ratcheted, plus an explicit C high-RSS witness decision for ProvidedTypes-class files."
+      "action": "F# remains held out. Do not rerun broad F# sweeps without a disposable hard RSS envelope. A ratchetable row needs either a principled corpus-selection policy for multi-MiB F# fixtures plus a default-budget truncation fix, or an explicit decision that these C-reference high-RSS giants are excluded workload witnesses rather than normal ratio samples."
     },
     {
       "key": "groovy_pleac11_15_memory_blowup",
       "file": "groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass)",
       "backlog_ref": "assisted Wave-3 fleet gap-close pass, reported in /tmp/gts_scratch/FLEET_SCOREBOARD.md; intentionally not added to languages because it is not a ratchetable row",
-      "action": "Groovy remains held out of the ratchet. The prior timeout/OOM class is contained for pleac11_15.groovy under default settings, but a ratchetable row needs either C-shape parity on the exact witness or an explicit scoped budget decision that accepts the error-bearing child-count divergence plus cliff full-parse ratio."
+      "action": "Groovy is now budgeted only under a scoped measurement basis that excludes the named pleac11_15.groovy witness. The exact witness remains a tracked correctness/perf gap: default policy contains the OOM, but the file is still C-shape divergent and ~60x C on full parse."
     },
     {
       "key": "webworker_generated_d_ts",
@@ -86,7 +91,7 @@
   ],
   "caveats": [
     "The perf ratio budget is a ratchet and evidence ledger, not a universal near-C claim; \u003e2x and cliff rows remain explicit backlog.",
-    "d, fsharp, groovy are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved. D's Go-side expressionsem.d cliff is contained, while F# exact ProvidedTypes now has a named default Go truncation plus C high-RSS/timeout blocker.",
+    "d, fsharp are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved.",
     "The TypeScript webworker generated-file entry remains a correctness cross-check caveat even though TypeScript has a timing budget row."
   ]
 }

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,6 +1,6 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T10:41:25Z",
+  "generated_at": "2026-07-09T10:50:28Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
   "budget_generated_at": "2026-07-09T10:38:34Z",
@@ -25,6 +25,7 @@
     "held_out_languages": 2,
     "known_budget_class_gaps": 4,
     "wave2b_pending_budgets": 15,
+    "scoped_heldout_budgets": 1,
     "measured_today_budgets": 194,
     "partial_measured_today_budgets": 1
   },
@@ -92,6 +93,7 @@
   "caveats": [
     "The perf ratio budget is a ratchet and evidence ledger, not a universal near-C claim; \u003e2x and cliff rows remain explicit backlog.",
     "d, fsharp are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved.",
+    "1 budget row(s) use scoped heldout exclusions; see measurement_basis.exclude_paths and the known-gap ledger before treating those rows as whole-language claims.",
     "The TypeScript webworker generated-file entry remains a correctness cross-check caveat even though TypeScript has a timing budget row."
   ]
 }

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,6 +1,6 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T10:41:25Z`
+- generated_at: `2026-07-09T10:50:28Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
 - budget_generated_at: `2026-07-09T10:38:34Z`
@@ -15,6 +15,7 @@
 | held out languages | 2 |
 | known budget class gaps | 4 |
 | wave2b pending budget rows | 15 |
+| scoped heldout budget rows | 1 |
 | measured-today budget rows | 194 |
 | partial measured-today notes | 1 |
 
@@ -72,4 +73,5 @@ Held out of the ratchet: `d`, `fsharp`.
 
 - The perf ratio budget is a ratchet and evidence ledger, not a universal near-C claim; >2x and cliff rows remain explicit backlog.
 - d, fsharp are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved.
+- 1 budget row(s) use scoped heldout exclusions; see measurement_basis.exclude_paths and the known-gap ledger before treating those rows as whole-language claims.
 - The TypeScript webworker generated-file entry remains a correctness cross-check caveat even though TypeScript has a timing budget row.

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,49 +1,55 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T09:53:11Z`
+- generated_at: `2026-07-09T10:41:25Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
-- budget_generated_at: `2026-07-09T09:53:11Z`
-- budget_generated_by: `wave-3 fleet perf sweep ratchet pass, branch wave3/perf-assisted-ratchets, extending the wave-2b budget with batch-1 through batch-7 plus the assisted fleet gap-close measurements and held-out exact-file RCA probes`
+- budget_generated_at: `2026-07-09T10:38:34Z`
+- budget_generated_by: `wave-3 fleet perf sweep ratchet pass, branch wave3/scoped-heldout-ratchets, extending the wave-2b budget with batch-1 through batch-7, assisted fleet gap-close measurements, held-out exact-file RCA probes, and the scoped Groovy heldout ratchet`
 
 ## Coverage
 
 | metric | value |
 |---|---:|
 | fleet languages | 206 |
-| budgeted languages | 203 |
-| held out languages | 3 |
+| budgeted languages | 204 |
+| held out languages | 2 |
 | known budget class gaps | 4 |
 | wave2b pending budget rows | 15 |
-| measured-today budget rows | 193 |
+| measured-today budget rows | 194 |
 | partial measured-today notes | 1 |
 
 Measurement basis: `reps=5`, `warmup=1`, `file_budget_ms=10000`, `max_files=8`, `order=largest`, `axes=full,noedit`.
 
-Held out of the ratchet: `d`, `fsharp`, `groovy`.
+Excluded paths: `groovy/subprojects/performance/src/files/pleac11_15.groovy`.
+
+Held out of the ratchet: `d`, `fsharp`.
 
 ## Budget Status Counts
 
 | status | languages |
 |---|---:|
 | `green` | 50 |
-| `green_with_caveat` | 142 |
+| `green_with_caveat` | 143 |
 | `wave2b_pending` | 11 |
 
 ## Known Gap Ledger
 
 | key | file | action |
 |---|---|---|
-| `d_expressionsem_go_rss_blowup` | d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes) | D remains held out of the ratchet. The prior Go timeout/OOM class is contained under default settings, but a ratchetable row needs either a smaller scoped D corpus selection or an explicit budget decision that treats expressionsem.d as a C-reference high-RSS witness instead of a normal Go-vs-C ratio sample. |
-| `fsharp_providedtypes_c_reference_memory_blowup` | fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection) | F# remains held out. Exact ProvidedTypes is a dual blocker under the normal policy: Go returns an honestly flagged truncated tree at byte 5339 and C returns nil at 10s/30s; with GOT_PARSE_NODE_LIMIT_SCALE=3, the same row reaches full/c/rep and crosses a 4096MiB RSS watchdog. Next step is scoped corpus selection or a default-budget truncation fix before any C-reference ratio can be ratcheted, plus an explicit C high-RSS witness decision for ProvidedTypes-class files. |
-| `groovy_pleac11_15_memory_blowup` | groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass) | Groovy remains held out of the ratchet. The prior timeout/OOM class is contained for pleac11_15.groovy under default settings, but a ratchetable row needs either C-shape parity on the exact witness or an explicit scoped budget decision that accepts the error-bearing child-count divergence plus cliff full-parse ratio. |
+| `d_expressionsem_go_rss_blowup` | d/compiler/src/dmd/expressionsem.d (685384 bytes; largest D corpus file, first selected file under largest-order probes) | D remains held out of the ratchet. The prior Go timeout/OOM class is contained under default settings, but excluding expressionsem.d is not enough: largest-order D next hits C timeouts and a dsymbolsem.d C noedit-base RSS watchdog. A ratchetable row needs a principled smaller-workload policy or an explicit D C-reference high-RSS witness exclusion set. |
+| `fsharp_providedtypes_c_reference_memory_blowup` | fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs (755275 bytes; first active selected file after largest-8 selection) | F# remains held out. Do not rerun broad F# sweeps without a disposable hard RSS envelope. A ratchetable row needs either a principled corpus-selection policy for multi-MiB F# fixtures plus a default-budget truncation fix, or an explicit decision that these C-reference high-RSS giants are excluded workload witnesses rather than normal ratio samples. |
+| `groovy_pleac11_15_memory_blowup` | groovy/subprojects/performance/src/files/pleac11_15.groovy (102960 bytes, largest-file selection hit during the assisted fleet pass) | Groovy is now budgeted only under a scoped measurement basis that excludes the named pleac11_15.groovy witness. The exact witness remains a tracked correctness/perf gap: default policy contains the OOM, but the file is still C-shape divergent and ~60x C on full parse. |
 | `webworker_generated_d_ts` | typescript/src/lib/webworker.generated.d.ts (786262 bytes, largest .d.ts in the corpus sample) | typescript's full_axis budget above is intentionally NOT tightened to reflect a 'fixed' webworker.generated.d.ts; GOT_FAITHFUL_CONDENSE (or an equivalent default-budget-aware condense path) remains a real wave-2b item. |
 
 ## Seed Sources
 
 - `after_cliffs_20260706T210143Z`
 - `authoritative_20260706T145520Z`
+- `d_expressionsem_default_20260709T083649Z`
 - `fleet_gap_close_assist_20260708T232019Z_to_20260709T003453Z`
+- `fsharp_providedtypes_exact_default_20260709T094157Z`
+- `fsharp_providedtypes_exact_full30s_20260709T094341Z`
+- `fsharp_providedtypes_exact_scale3_rss4096_20260709T094500Z`
 - `groovy_ceiling_exact_20260709T075435Z`
 - `pr142_evidence_and_wave2a_closeout_spore`
 - `wave2b_green_20260707T0100Z`
@@ -57,14 +63,13 @@ Held out of the ratchet: `d`, `fsharp`, `groovy`.
 - `wave3_batch6_dot_20260708T225933Z`
 - `wave3_batch6_doxygen_20260708T230104Z`
 - `wave3_batch7_20260708T232544Z`
-- `d_expressionsem_default_20260709T083649Z`
-- `fsharp_providedtypes_exact_default_20260709T094157Z`
-- `fsharp_providedtypes_exact_full30s_20260709T094341Z`
-- `fsharp_providedtypes_exact_scale3_rss4096_20260709T094500Z`
+- `wave3_scoped_d_exclude_expressionsem_20260709T103336Z`
+- `wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z`
+- `wave3_scoped_groovy_exclude_pleac11_20260709T103612Z`
 - `webworker_oracle_spotcheck`
 
 ## Caveats
 
 - The perf ratio budget is a ratchet and evidence ledger, not a universal near-C claim; >2x and cliff rows remain explicit backlog.
-- d, fsharp, groovy are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved. D's Go-side expressionsem.d cliff is contained, while F# exact ProvidedTypes now has a named default Go truncation plus C high-RSS/timeout blocker.
+- d, fsharp are intentionally held out of the language ratchet until their memory/C-reference RCA rows are resolved.
 - The TypeScript webworker generated-file entry remains a correctness cross-check caveat even though TypeScript has a timing budget row.


### PR DESCRIPTION
## Summary

Introduce an `exclude_paths` field to the perf-scan measurement basis, allowing the ratchet to explicitly exclude known problematic or overly large files from the largest-file selection. This enables Groovy to be moved into the budget with a scoped exclusion (`pleac11_15.groovy`), rather than being fully held out.

## Changes

- Add `exclude_paths` field to `measurementBasis` struct and deserialize it from JSON
- Render excluded paths in the markdown status report
- Update test suite to cover `exclude_paths` parsing and output
- Configure Groovy budget to exclude `pleac11_15.groovy`, moving it from held-out to budgeted
- Update wave3 sweep status, seed sources, and coverage counts to reflect the scoped exclusion
- Adjust known gap ledger actions to reflect the new scoped measurement basis

## Testing

- Run `go test ./cgo_harness/cmd/perf_scan_status/...` to verify the new `exclude_paths` parsing and markdown rendering
- Verify `wave3_sweep_status.md` and `perf_ratio_budgets.json` correctly reflect the excluded Groovy path and updated counts
- Check that perf-scan harness respects `GTS_PERF_SCAN_EXCLUDE_PATHS` environment variable in practice (manual/Docker run if needed)

## Review Focus

Pay attention to the JSON schema updates in `perf_ratio_budgets.json` and the status count changes in `wave3_sweep_status.*`. The Go code changes are minimal, but the budget logic shift (Groovy moving from held-out to budgeted via scoped exclusion) is the main behavioral change.