### PR TITLE
chore(changelog): update for v0.22.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.22.5] - 2026-07-09
+
+Scoped held-out perf-ratchet release. This release follows the fleet coverage
+cut with the exclusion machinery and ledger language needed to keep Wave 3
+honest: Groovy is now budgeted under a named scoped basis, while D and F#
+remain explicit held-outs because their current large-file witnesses fail in
+the C-reference side or hit the harness RSS watchdog before a stable Go-vs-C
+ratio can be ratcheted.
+
+### Added
+
+- perf-scan file exclusion support for reproducible scoped reruns, including
+  `GTS_PERF_SCAN_EXCLUDE_PATHS`, persisted scoreboard config, and status
+  reporting for measurement-basis exclusions.
+- `perf_scan_status` coverage accounting for scoped held-out budget rows, so
+  budgeted-with-caveat languages are visible separately from ordinary green
+  rows and hard held-outs.
+- Groovy Wave-3 scoped held-out budget row excluding
+  `groovy/subprojects/performance/src/files/pleac11_15.groovy`, with observed
+  full-parse and no-edit ratios recorded from the Docker perf sweep.
+
+### Changed
+
+- The perf-ratchet policy now treats expansion of
+  `measurement_basis.exclude_paths` as budget loosening that requires the same
+  RCA evidence as loosening a ratio threshold.
+- F# and D Wave-3 ledger entries now carry the exact C-reference timeout/RSS
+  witnesses found by the scoped reruns instead of presenting them as ordinary
+  unmeasured gaps.
+
 ## [0.22.4] - 2026-07-09
 
 Wave-3 perf-fleet coverage and ongoing correctness checks. This release
@@ -1333,7 +1363,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.22.4...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.22.5...HEAD
+[0.22.5]: https://github.com/odvcencio/gotreesitter/compare/v0.22.4...v0.22.5
 [0.22.4]: https://github.com/odvcencio/gotreesitter/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/odvcencio/gotreesitter/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/odvcencio/gotreesitter/compare/v0.22.1...v0.22.2


### PR DESCRIPTION
## Summary

Update the CHANGELOG.md to document the v0.22.5 release. This release scopes the perf-ratchet strategy to held-out languages (D, F#), adds support for reproducible scoped perf-scan reruns, introduces `perf_scan_status` coverage accounting, and updates Groovy Wave-3 budget rows. The diff also updates the version comparison links at the end of the file to point to the new tag.

## Changes

- - Add v0.22.5 release notes detailing scoped held-out perf-ratchet strategy for Wave 3
- - Document new `GTS_PERF_SCAN_EXCLUDE_PATHS` and persisted scoreboard config for reproducible scoped reruns
- - Introduce `perf_scan_status` coverage accounting to separate budgeted-with-caveat languages from held-outs
- - Record Groovy Wave-3 scoped held-out budget row and update F#/D ledger entries with exact failure witnesses
- - Update changelog comparison links to reflect the new version tag

## Testing

- Verify CHANGELOG.md contains the [0.22.5] section with correct formatting and date
- Ensure `[Unreleased]` and `[0.22.5]` comparison links at the bottom reflect the correct commit range
- Confirm only CHANGELOG.md was modified, matching standard documentation-only PR expectations

## Review Focus

Verify the release notes accurately reflect the scoped perf-ratchet exclusions and that the comparison links at the bottom align correctly with v0.22.5.