### PR TITLE
fix(cobol): Trim EXEC CICS error spans to last material child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- COBOL `EXEC CICS` error normalization now trims recovered
+  `procedure_division`/`program_definition` spans to the last material child
+  when C stops before trailing trivia, while preserving C's zero-width EOF
+  recovery shape. A cgo-backed adversarial fixture now guards the recovered
+  error signal and byte spans against the C oracle.
+
 ## [0.22.5] - 2026-07-09
 
 Scoped held-out perf-ratchet release. This release follows the fleet coverage

--- a/cgo_harness/cobol_cgo_regression_test.go
+++ b/cgo_harness/cobol_cgo_regression_test.go
@@ -163,6 +163,16 @@ func TestCobolCGOErrorOracleParity(t *testing.T) {
 				"      * banner\n" +
 				"       procedure division.\n",
 		},
+		{
+			name: "exec_cics_error_preserves_has_error_after_paragraph_recovery",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"           MOVE A TO B\n" +
+				"           IF FLAG\n" +
+				"              EXEC CICS RETURN\n" +
+				"       aa.\n",
+		},
 	}
 
 	for _, tc := range cases {

--- a/cgo_harness/cobol_cgo_regression_test.go
+++ b/cgo_harness/cobol_cgo_regression_test.go
@@ -173,6 +173,17 @@ func TestCobolCGOErrorOracleParity(t *testing.T) {
 				"              EXEC CICS RETURN\n" +
 				"       aa.\n",
 		},
+		{
+			name: "exec_cics_error_trims_before_trailing_recovered_comment",
+			src: "       identification division.\n" +
+				"       program-id. a.\n" +
+				"       procedure division.\n" +
+				"           MOVE A TO B\n" +
+				"           IF FLAG\n" +
+				"              EXEC CICS RETURN\n" +
+				"       aa.\n" +
+				"      * trailing banner\n",
+		},
 	}
 
 	for _, tc := range cases {

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -1086,8 +1086,12 @@ func normalizeCobolIfHeaderExecCICSClassErrors(root *Node, source []byte, lang *
 	if !changed {
 		return
 	}
-	if proc := cobolLastChildOfType(program, lang, "procedure_division"); proc != nil && proc.endByte > program.endByte {
-		setCobolNodeEnd(program, source, proc.endByte)
+	if proc := cobolLastChildOfType(program, lang, "procedure_division"); proc != nil {
+		cobolTrimNodeEndToLastNonMissingChild(proc, source)
+		if proc.endByte > program.endByte {
+			setCobolNodeEnd(program, source, proc.endByte)
+		}
+		cobolTrimProgramEndToLastProcedure(program, source, lang)
 	}
 	cobolRefreshHasErrorFromChildren(program)
 	cobolRefreshHasErrorFromChildren(root)
@@ -1105,6 +1109,7 @@ func normalizeCobolIfHeaderExecCICSProgramEnd(root *Node, source []byte, lang *L
 	if proc == nil || proc.endByte <= program.endByte || !cobolProcedureHasIfHeaderExecCICSClassError(proc, source, lang) {
 		return
 	}
+	cobolTrimNodeEndToLastNonMissingChild(proc, source)
 	setCobolNodeEnd(program, source, proc.endByte)
 	cobolRefreshHasErrorFromChildren(program)
 	cobolRefreshHasErrorFromChildren(root)
@@ -1395,6 +1400,16 @@ func cobolTrimProgramEndToLastProcedure(program *Node, source []byte, lang *Lang
 	last := cobolLastChildOfType(program, lang, "procedure_division")
 	if last != nil && last.endByte < program.endByte {
 		setCobolNodeEnd(program, source, last.endByte)
+	}
+}
+
+func cobolTrimNodeEndToLastNonMissingChild(n *Node, source []byte) {
+	if n == nil || n.endByte <= n.startByte || int(n.endByte) > len(source) {
+		return
+	}
+	last := cobolLastNonMissingChild(n)
+	if last != nil && last.endByte > n.startByte && last.endByte < n.endByte {
+		setCobolNodeEnd(n, source, last.endByte)
 	}
 }
 

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -1087,7 +1087,7 @@ func normalizeCobolIfHeaderExecCICSClassErrors(root *Node, source []byte, lang *
 		return
 	}
 	if proc := cobolLastChildOfType(program, lang, "procedure_division"); proc != nil {
-		cobolTrimNodeEndToLastNonMissingChild(proc, source)
+		cobolTrimNodeEndToLastRecoveredSpanChild(proc, source, lang)
 		if proc.endByte > program.endByte {
 			setCobolNodeEnd(program, source, proc.endByte)
 		}
@@ -1109,7 +1109,7 @@ func normalizeCobolIfHeaderExecCICSProgramEnd(root *Node, source []byte, lang *L
 	if proc == nil || proc.endByte <= program.endByte || !cobolProcedureHasIfHeaderExecCICSClassError(proc, source, lang) {
 		return
 	}
-	cobolTrimNodeEndToLastNonMissingChild(proc, source)
+	cobolTrimNodeEndToLastRecoveredSpanChild(proc, source, lang)
 	setCobolNodeEnd(program, source, proc.endByte)
 	cobolRefreshHasErrorFromChildren(program)
 	cobolRefreshHasErrorFromChildren(root)
@@ -1403,14 +1403,31 @@ func cobolTrimProgramEndToLastProcedure(program *Node, source []byte, lang *Lang
 	}
 }
 
-func cobolTrimNodeEndToLastNonMissingChild(n *Node, source []byte) {
-	if n == nil || n.endByte <= n.startByte || int(n.endByte) > len(source) {
+func cobolTrimNodeEndToLastRecoveredSpanChild(n *Node, source []byte, lang *Language) {
+	if n == nil || lang == nil || n.endByte <= n.startByte || int(n.endByte) > len(source) {
 		return
 	}
-	last := cobolLastNonMissingChild(n)
+	last := cobolLastRecoveredSpanChild(n, lang)
 	if last != nil && last.endByte > n.startByte && last.endByte < n.endByte {
 		setCobolNodeEnd(n, source, last.endByte)
 	}
+}
+
+func cobolLastRecoveredSpanChild(parent *Node, lang *Language) *Node {
+	if parent == nil {
+		return nil
+	}
+	for i := resultChildCount(parent) - 1; i >= 0; i-- {
+		child := resultChildAt(parent, i)
+		if child == nil || child.IsMissing() {
+			continue
+		}
+		if child.IsExtra() && !child.IsError() && !child.HasError() {
+			continue
+		}
+		return child
+	}
+	return nil
 }
 
 func cobolProcedureDivisionHeaderEnd(proc *Node, lang *Language) (int, uint32, bool) {

--- a/parser_result_cobol.go
+++ b/parser_result_cobol.go
@@ -1087,7 +1087,7 @@ func normalizeCobolIfHeaderExecCICSClassErrors(root *Node, source []byte, lang *
 		return
 	}
 	if proc := cobolLastChildOfType(program, lang, "procedure_division"); proc != nil {
-		cobolTrimNodeEndToLastRecoveredSpanChild(proc, source, lang)
+		cobolTrimNodeEndToLastRecoveredSpanChild(proc, source)
 		if proc.endByte > program.endByte {
 			setCobolNodeEnd(program, source, proc.endByte)
 		}
@@ -1109,7 +1109,7 @@ func normalizeCobolIfHeaderExecCICSProgramEnd(root *Node, source []byte, lang *L
 	if proc == nil || proc.endByte <= program.endByte || !cobolProcedureHasIfHeaderExecCICSClassError(proc, source, lang) {
 		return
 	}
-	cobolTrimNodeEndToLastRecoveredSpanChild(proc, source, lang)
+	cobolTrimNodeEndToLastRecoveredSpanChild(proc, source)
 	setCobolNodeEnd(program, source, proc.endByte)
 	cobolRefreshHasErrorFromChildren(program)
 	cobolRefreshHasErrorFromChildren(root)
@@ -1403,17 +1403,17 @@ func cobolTrimProgramEndToLastProcedure(program *Node, source []byte, lang *Lang
 	}
 }
 
-func cobolTrimNodeEndToLastRecoveredSpanChild(n *Node, source []byte, lang *Language) {
-	if n == nil || lang == nil || n.endByte <= n.startByte || int(n.endByte) > len(source) {
+func cobolTrimNodeEndToLastRecoveredSpanChild(n *Node, source []byte) {
+	if n == nil || n.endByte <= n.startByte || int(n.endByte) > len(source) {
 		return
 	}
-	last := cobolLastRecoveredSpanChild(n, lang)
+	last := cobolLastRecoveredSpanChild(n)
 	if last != nil && last.endByte > n.startByte && last.endByte < n.endByte {
 		setCobolNodeEnd(n, source, last.endByte)
 	}
 }
 
-func cobolLastRecoveredSpanChild(parent *Node, lang *Language) *Node {
+func cobolLastRecoveredSpanChild(parent *Node) *Node {
 	if parent == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Fix COBOL `EXEC CICS` error span normalization by trimming recovered `procedure_division`/`program_definition` nodes to their last material child. This aligns the Go parser's span boundaries with the C backend when trailing trivia is present, while preserving the C parser's zero-width EOF recovery shape. Includes a new adversarial fixture to guard against regressions in both the error signal and byte spans.

## Changes

- - Update `normalizeCobolIfHeaderExecCICSClassErrors` to trim `procedure_division` spans to the last non-missing child before adjusting program ends.
- - Update `normalizeCobolIfHeaderExecCICSProgramEnd` with the same trimming logic.
- - Add `cobolTrimNodeEndToLastNonMissingChild` helper function to safely clamp node end bytes to their last material child.
- - Integrate `cobolTrimProgramEndToLastProcedure` into the CICS error normalization flow.
- - Add `exec_cics_error_preserves_has_error_after_paragraph_recovery` regression test to the CGO parity suite.

## Testing

- - Run COBOL CGO parity regression suite: `bash cgo_harness/docker/run_single_grammar_parity.sh cobol`
- - Run specific error oracle parity test: `go test ./cgo_harness -run 'TestCobolCGOErrorOracleParity' -v`
- - Inspect the new `exec_cics_error_preserves_has_error_after_paragraph_recovery` fixture to verify trailing paragraph handling matches the C oracle.