### PR TITLE
Refresh wave3 perf sweep metadata for Lua and C# rows

### DIFF
--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -19,8 +19,8 @@
     "removing exclusions is a tightening operation."
   ],
   "schema": "gts-perf-ratio-budgets/v1",
-  "generated_at": "2026-07-09T12:14:40Z",
-  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/pending-perf-resweep, extending the scoped-heldout ratchet with strict-basis cmake/java/kotlin pending-row refreshes",
+  "generated_at": "2026-07-09T12:32:58Z",
+  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/lua-csharp-pending-resweep, extending pending-row refreshes with strict-basis lua and c_sharp measurements",
   "measurement_basis": {
     "harness": "cgo_harness/perf_scan (TestPerfScanSweep / TestPerfScanLanguage, tags treesitter_c_parity treesitter_c_perfscan)",
     "corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources (real upstream per-language checkouts, largest-8-files sampling -- deliberately adversarial, hunts cliffs, NOT representative of typical file size)",
@@ -65,7 +65,9 @@
     "wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z": "scoped F# heldout probe on branch wave3/scoped-heldout-ratchets, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis, GTS_PERF_SCAN_EXCLUDE_PATHS=fsharp/examples/FSharp.Compiler/tests/EndToEndBuildTests/ProvidedTypes/ProvidedTypes.fs, RSS watchdog 6144. Result stayed non-ratchetable: the first selected file, examples/FSharp.Compiler/tests/FSharp.Core.UnitTests/FSharp.Core/ComparersRegression.fs (3,587,873 bytes), crossed the RSS watchdog during full/c/warmup attempt 1 before any file completed.",
     "wave3_pending_cmake_strict_20260709T121109Z": "pending-row refresh on branch wave3/pending-perf-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 with 0 timeouts/errors; full parse is a measured >2x backlog row (ratio_by_total=3.09x, median=2.85x), noedit ratio_by_total=0.00134x. Harness marked the run contended (loadavg1=10.19), so this is a visibility ratchet rather than a quiet-box near-C claim.",
     "wave3_pending_java_strict_20260709T121147Z": "pending-row refresh on branch wave3/pending-perf-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 with 0 timeouts/errors; full parse remains a measured cliff throughput row (ratio_by_total=21.56x, median=17.66x, 8 cliff files), noedit ratio_by_total=0.122x. Harness marked the run contended (loadavg1=8.49), so this tightens stale completion evidence without making a quiet-box near-C claim.",
-    "wave3_pending_kotlin_strict_20260709T121258Z": "pending-row refresh on branch wave3/pending-perf-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 with 0 timeouts/errors; full parse remains a measured cliff throughput row (ratio_by_total=31.26x, median=4.89x, 3 cliff files), noedit ratio_by_total=0.00145x. Harness marked the run contended (loadavg1=8.74), so this tightens stale completion evidence without making a quiet-box near-C claim."
+    "wave3_pending_kotlin_strict_20260709T121258Z": "pending-row refresh on branch wave3/pending-perf-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 with 0 timeouts/errors; full parse remains a measured cliff throughput row (ratio_by_total=31.26x, median=4.89x, 3 cliff files), noedit ratio_by_total=0.00145x. Harness marked the run contended (loadavg1=8.74), so this tightens stale completion evidence without making a quiet-box near-C claim.",
+    "wave3_pending_lua_strict_20260709T122826Z": "pending-row refresh on branch wave3/lua-csharp-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 with 0 timeouts/errors, replacing the stale after_cliffs row that had 7 timeouts. Full parse remains a measured cliff row (ratio_by_total=9.51x, median=9.12x, 3 cliff files), noedit ratio_by_total=0.000168x. Harness marked the run contended (loadavg1=6.72), so this is a visibility ratchet rather than a quiet-box near-C claim.",
+    "wave3_pending_csharp_strict_20260709T122931Z": "pending-row refresh on branch wave3/lua-csharp-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. This replaces the stale after_cliffs C# survivor row: full-axis timeouts improved from 7 to 4, but the ratio budget must loosen because the old 3.66x aggregate represented a single completing survivor while the fresh aggregate includes four completing Bicep files at 56.20x/57.11x median plus four explicit timeout cliffs. This is completion evidence plus a named open-region throughput backlog, not a near-C claim. Harness marked the run contended (loadavg1=6.20)."
   },
   "languages": {
     "php": {
@@ -289,21 +291,22 @@
       }
     },
     "c_sharp": {
-      "status": "wave2b_pending",
+      "status": "green_with_caveat",
       "wave2b_pending": true,
-      "measured_today": false,
-      "note": "Documented from after_cliffs (post-wave-1, pre-wave-2a; STALE and KNOWN OUT OF DATE). after_cliffs shows 1/8 ok, 7 go_timeout (all Bicep.* open-region-quadratic files). Wave-2a's c_sharp lane (C-faithful GSS prefix aggregates + incremental open-region deltas + gate-scan memo) is reported in pr142-evidence.md as already reaching 5/8 ok (DeclaredTypeManager.cs 25.08s->3.10s, 8.1x; truncation witness 41.7s->1.55s) -- i.e. today's real timeout count is very likely ~3, not 7. Budget below intentionally kept at the stale, looser 7-timeout ceiling because I have not personally re-measured the full 8-file aggregate this pass (no fabricated ratio_by_total for the 4 newly-completing files); tighten to the re-swept number at the next full pass rather than trusting this note's arithmetic.",
+      "measured_today": true,
+      "note": "Pending-row refresh (wave3_pending_csharp_strict_20260709T122931Z): replaces the stale after_cliffs survivor row. Full-axis timeouts tightened from 7 to 4, with 4/8 files producing ratios and 4 Bicep files still hitting the 10s budget. RCA for the apparent ratio loosening: the old 3.66x aggregate represented one completing survivor and excluded timeout files; the fresh 56.20x aggregate includes four completing Bicep files, three of which are real >10x cliffs, while the remaining four stay explicit timeout cliffs. This is a measured open-region throughput backlog row, not a near-C claim. Harness marked the run contended (loadavg1=6.20), so keep the budget loose until a quiet-box refresh tightens it.",
       "full_axis": {
-        "max_timeouts": 7,
+        "max_timeouts": 4,
         "max_errors": 0,
-        "max_ratio_by_total": 5,
-        "observed_ratio_by_total": 3.656,
-        "observed_ratio_median_of_files": 3.656
+        "max_ratio_by_total": 75,
+        "max_ratio_median_of_files": 75,
+        "observed_ratio_by_total": 56.197,
+        "observed_ratio_median_of_files": 57.108
       },
       "noedit_axis": {
-        "max_timeouts": 7,
+        "max_timeouts": 4,
         "max_ratio_by_total": 1.0,
-        "observed_ratio_by_total": 0.00688
+        "observed_ratio_by_total": 0.0211
       }
     },
     "typescript": {
@@ -345,21 +348,22 @@
       }
     },
     "lua": {
-      "status": "wave2b_pending",
-      "wave2b_pending": true,
-      "measured_today": false,
-      "note": "Documented from after_cliffs (post-wave-1; not re-swept this pass). 1/8 ok, 7 go_timeout, 0 truncation. Named wave-2b candidate: 'global repetition-skip rule' (spore-wave2a.md flags lua/crystal/scala/swift/cmake as prime suspects for the same repetition-shift fork cascade mechanism the php fix resolved).",
+      "status": "green_with_caveat",
+      "wave2b_pending": false,
+      "measured_today": true,
+      "note": "Pending-row refresh (wave3_pending_lua_strict_20260709T122826Z): 8/8 files completed with 0 timeouts and 0 truncations under the checked-in ratchet basis, replacing the stale after_cliffs row that had 7 timeouts. Full parse remains a measured throughput cliff (9.51x aggregate, 9.12x median, 3 cliff files), so this is a perf-backlog ratchet, not a near-C claim. Harness marked the run contended (loadavg1=6.72), so keep the budget loose until a quiet-box refresh tightens it.",
       "full_axis": {
-        "max_timeouts": 7,
+        "max_timeouts": 0,
         "max_errors": 0,
-        "max_ratio_by_total": 70,
-        "observed_ratio_by_total": 55.765,
-        "observed_ratio_median_of_files": 55.765
+        "max_ratio_by_total": 12,
+        "max_ratio_median_of_files": 12,
+        "observed_ratio_by_total": 9.510,
+        "observed_ratio_median_of_files": 9.123
       },
       "noedit_axis": {
-        "max_timeouts": 7,
+        "max_timeouts": 0,
         "max_ratio_by_total": 1.0,
-        "observed_ratio_by_total": 0.000002
+        "observed_ratio_by_total": 0.000168
       }
     },
     "crystal": {

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,10 +1,10 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T12:16:49Z",
+  "generated_at": "2026-07-09T12:34:02Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
-  "budget_generated_at": "2026-07-09T12:14:40Z",
-  "budget_generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/pending-perf-resweep, extending the scoped-heldout ratchet with strict-basis cmake/java/kotlin pending-row refreshes",
+  "budget_generated_at": "2026-07-09T12:32:58Z",
+  "budget_generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/lua-csharp-pending-resweep, extending pending-row refreshes with strict-basis lua and c_sharp measurements",
   "measurement_basis": {
     "reps": 5,
     "warmup": 1,
@@ -24,9 +24,9 @@
     "budgeted_languages": 204,
     "held_out_languages": 2,
     "known_budget_class_gaps": 4,
-    "wave2b_pending_budgets": 12,
+    "wave2b_pending_budgets": 11,
     "scoped_heldout_budgets": 1,
-    "measured_today_budgets": 197,
+    "measured_today_budgets": 199,
     "partial_measured_today_budgets": 1
   },
   "held_out_languages": [
@@ -35,8 +35,8 @@
   ],
   "budget_status_counts": {
     "green": 50,
-    "green_with_caveat": 146,
-    "wave2b_pending": 8
+    "green_with_caveat": 148,
+    "wave2b_pending": 6
   },
   "seed_sources": [
     "after_cliffs_20260706T210143Z",
@@ -60,8 +60,10 @@
     "wave3_batch6_doxygen_20260708T230104Z",
     "wave3_batch7_20260708T232544Z",
     "wave3_pending_cmake_strict_20260709T121109Z",
+    "wave3_pending_csharp_strict_20260709T122931Z",
     "wave3_pending_java_strict_20260709T121147Z",
     "wave3_pending_kotlin_strict_20260709T121258Z",
+    "wave3_pending_lua_strict_20260709T122826Z",
     "wave3_scoped_d_exclude_expressionsem_20260709T103336Z",
     "wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z",
     "wave3_scoped_groovy_exclude_pleac11_20260709T103612Z",

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,10 +1,10 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T12:16:49Z`
+- generated_at: `2026-07-09T12:34:02Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
-- budget_generated_at: `2026-07-09T12:14:40Z`
-- budget_generated_by: `wave-3 fleet perf sweep ratchet pass, branch wave3/pending-perf-resweep, extending the scoped-heldout ratchet with strict-basis cmake/java/kotlin pending-row refreshes`
+- budget_generated_at: `2026-07-09T12:32:58Z`
+- budget_generated_by: `wave-3 fleet perf sweep ratchet pass, branch wave3/lua-csharp-pending-resweep, extending pending-row refreshes with strict-basis lua and c_sharp measurements`
 
 ## Coverage
 
@@ -14,9 +14,9 @@
 | budgeted languages | 204 |
 | held out languages | 2 |
 | known budget class gaps | 4 |
-| wave2b pending budget rows | 12 |
+| wave2b pending budget rows | 11 |
 | scoped heldout budget rows | 1 |
-| measured-today budget rows | 197 |
+| measured-today budget rows | 199 |
 | partial measured-today notes | 1 |
 
 Measurement basis: `reps=5`, `warmup=1`, `file_budget_ms=10000`, `max_files=8`, `order=largest`, `axes=full,noedit`.
@@ -30,8 +30,8 @@ Held out of the ratchet: `d`, `fsharp`.
 | status | languages |
 |---|---:|
 | `green` | 50 |
-| `green_with_caveat` | 146 |
-| `wave2b_pending` | 8 |
+| `green_with_caveat` | 148 |
+| `wave2b_pending` | 6 |
 
 ## Known Gap Ledger
 
@@ -65,8 +65,10 @@ Held out of the ratchet: `d`, `fsharp`.
 - `wave3_batch6_doxygen_20260708T230104Z`
 - `wave3_batch7_20260708T232544Z`
 - `wave3_pending_cmake_strict_20260709T121109Z`
+- `wave3_pending_csharp_strict_20260709T122931Z`
 - `wave3_pending_java_strict_20260709T121147Z`
 - `wave3_pending_kotlin_strict_20260709T121258Z`
+- `wave3_pending_lua_strict_20260709T122826Z`
 - `wave3_scoped_d_exclude_expressionsem_20260709T103336Z`
 - `wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z`
 - `wave3_scoped_groovy_exclude_pleac11_20260709T103612Z`


### PR DESCRIPTION
## Summary

Refresh the wave 3 perf sweep ratchet metadata for the next pending-row bucket: `lua` and `c_sharp`. This is ledger/status bookkeeping only; no runtime parser code changed.

## What changed

- Added strict-basis seed sources for:
  - `wave3_pending_lua_strict_20260709T122826Z`
  - `wave3_pending_csharp_strict_20260709T122931Z`
- Updated `cgo_harness/perf_scan/perf_ratio_budgets.json` with the latest Lua/C# measurements.
- Regenerated `wave3_sweep_status.json` and `wave3_sweep_status.md`.
- Moved Wave 3 coverage from 197 to 199 measured-today rows.
- Reduced status `wave2b_pending` rows from 8 to 6, and pending budget rows from 12 to 11.

## Results

`lua` is now a measured `green_with_caveat` row:

- 8/8 files completed.
- Timeouts tightened from stale pending data to 0.
- Full-parse ratio: 9.51x aggregate, 9.12x median.
- No-edit incremental ratio: 0.000168x aggregate.
- Caveat: still a full-parse cliff row, measured under contended host load (`loadavg1=6.72`).

`c_sharp` remains pending but is now more honestly bounded:

- 8 files selected, 4 completed and 4 Go timeouts.
- Timeout allowance tightened from 7 to 4.
- Full-parse ratio: 56.20x aggregate, 57.11x median across completed survivors.
- No-edit incremental ratio: 0.0211x aggregate.
- Caveat: the full-parse ratio ceiling was loosened from 5 to 75 because the stale 5x ceiling came from one-survivor data. The new row admits four completed files plus four explicit timeout cliffs, so the ledger now records the actual shape instead of survivor bias. This is not a near-C claim for C#.

## Evidence

Docker strict perf scans:

- `harness_out/docker/20260709T122825Z-wave3-pending-lua-strict-ratchet`
- `harness_out/docker/20260709T122931Z-wave3-pending-csharp-strict-ratchet`

Validation commands run locally:

```bash
git diff --check
cd cgo_harness && GOWORK=off go test ./cmd/perf_scan_budget ./cmd/perf_scan_status -count=1
cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json
cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json -scoreboard perf_scan/out/wave3_pending_lua_strict_20260709T122826Z/scoreboard.json -langs lua
cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json -scoreboard perf_scan/out/wave3_pending_csharp_strict_20260709T122931Z/scoreboard.json -langs c_sharp
```

## Review focus

- The Lua timeout cleanup and 12x full-parse ratchet ceiling.
- The C# survivor-bias correction: fewer timeouts, but looser ratio budget because more real completed files now enter the aggregate.
- JSON/status/Markdown consistency.
