### PR TITLE
fix(grammargen): collapse redundant nested aliases like tree-sitter

### DIFF
--- a/grammargen/keyword_choice_token_test.go
+++ b/grammargen/keyword_choice_token_test.go
@@ -264,6 +264,66 @@ func TestPlainVisibleIdentifierStringRuleWithWordRemainsNonterminal(t *testing.T
 	}
 }
 
+func TestPlainVisiblePunctuationPrefixedStringRuleWithWordBecomesNamedLeafToken(t *testing.T) {
+	g := NewGrammar("plain_visible_punctuation_prefixed_string_rule_with_word_named_leaf_token")
+	g.Define("source_file", Seq(Sym("identifier"), Sym("important")))
+	g.Define("identifier", Pat(`[a-z]+`))
+	g.Define("important", Str("!important"))
+	g.Define("match", Str("match"))
+	g.SetWord("identifier")
+	g.Extras = []*Rule{Pat(`[ \t]+`)}
+
+	ng, err := Normalize(g)
+	if err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	if got := symbolKind(t, ng, "important"); got != SymbolNamedToken {
+		t.Fatalf("important kind = %v, want SymbolNamedToken", got)
+	}
+	foundMatchNonterminal := false
+	for _, sym := range ng.Symbols {
+		if sym.Name != "match" {
+			continue
+		}
+		if sym.Kind == SymbolNamedToken {
+			t.Fatal("match was promoted to SymbolNamedToken")
+		}
+		if sym.Kind == SymbolNonterminal {
+			foundMatchNonterminal = true
+		}
+	}
+	if !foundMatchNonterminal {
+		t.Fatal("match nonterminal not found")
+	}
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte("selector !important"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("parse missing root node")
+	}
+	if root.HasError() || root.ChildCount() != 2 {
+		t.Fatalf("root = %v, child count = %d; tree=%s", root, root.ChildCount(), root.SExpr(lang))
+	}
+	important := root.Child(1)
+	if got := important.Type(lang); got != "important" {
+		t.Fatalf("child type = %q, want important; tree=%s", got, root.SExpr(lang))
+	}
+	if !important.IsNamed() {
+		t.Fatal("important IsNamed = false")
+	}
+	if got := important.ChildCount(); got != 0 {
+		t.Fatalf("important child count = %d, want 0; tree=%s", got, root.SExpr(lang))
+	}
+}
+
 func TestPlainVisiblePunctuationStringRuleBecomesNamedLeafToken(t *testing.T) {
 	g := NewGrammar("plain_visible_punctuation_string_rule_named_leaf_token")
 	g.Define("source_file", Sym("optional_chain"))

--- a/grammargen/nested_alias_materialization_test.go
+++ b/grammargen/nested_alias_materialization_test.go
@@ -18,7 +18,13 @@ import (
 //
 //   - A direct alias-of-alias chain with nothing else in between collapses:
 //     alias(alias(x, "a"), "b") == alias(x, "b") — the outermost name wins,
-//     any intermediate name is discarded.
+//     any intermediate name is discarded. The same collapse applies when the
+//     inner alias() is reachable through nothing but alias-metadata
+//     wrappers — prec/prec_left/prec_right/prec_dynamic/field — which carry
+//     no naming of their own: alias(prec(N, alias(x, "a")), "b") ==
+//     prec(N, alias(x, "b")), and likewise for field(). This does NOT apply
+//     once a seq/choice/repeat/optional sits in between; those introduce
+//     separate production steps, so the per-step rule below applies instead.
 //   - An alias() wrapping a choice/seq collapses PER PRODUCTION STEP: a step
 //     that is already aliased by an explicit nested alias() reachable
 //     through that choice/seq structure keeps its own (inner) alias, and
@@ -198,6 +204,59 @@ func TestDirectAliasChainCollapsesToOutermostName(t *testing.T) {
 	}
 	if types["order"] != 1 {
 		t.Fatalf("expected outermost \"order\" alias to win: %s", root.SExpr(lang))
+	}
+}
+
+// TestAliasChainThroughPrecCollapsesToOutermostName covers a
+// metadata-mediated alias chain: alias(prec(N, alias(x, "ASC")), "order").
+// Unlike the choice/seq-mediated cases above, a prec/prec_left/prec_right/
+// prec_dynamic wrapper carries no naming of its own and never introduces a
+// separate production step -- tree-sitter's compiler merges it together
+// with any alias() it wraps exactly like the direct alias-of-alias chain,
+// so the OUTERMOST alias wins here too, through the prec wrapper.
+func TestAliasChainThroughPrecCollapsesToOutermostName(t *testing.T) {
+	g := NewGrammar("test_alias_chain_through_prec")
+	g.Define("source_file", Seq(
+		Sym("ident"),
+		Optional(Alias(Prec(1, Alias(Pat("[Aa][Ss][Cc]"), "ASC", true)), "order", true)),
+	))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "Foo asc")
+	types := map[string]int{}
+	collectNodeTypes(root, lang, types)
+	if types["ASC"] != 0 {
+		t.Fatalf("expected inner \"ASC\" alias to be fully discarded through the prec wrapper: %s", root.SExpr(lang))
+	}
+	if types["order"] != 1 {
+		t.Fatalf("expected outermost \"order\" alias to win through the prec wrapper: %s", root.SExpr(lang))
+	}
+}
+
+// TestAliasChainThroughFieldCollapsesToOutermostName is the field-wrapper
+// analogue of TestAliasChainThroughPrecCollapsesToOutermostName:
+// alias(field("f", alias(x, "ASC")), "order") also collapses to the
+// outermost alias, through the field wrapper.
+func TestAliasChainThroughFieldCollapsesToOutermostName(t *testing.T) {
+	g := NewGrammar("test_alias_chain_through_field")
+	g.Define("source_file", Seq(
+		Sym("ident"),
+		Optional(Alias(Field("f", Alias(Pat("[Aa][Ss][Cc]"), "ASC", true)), "order", true)),
+	))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "Foo asc")
+	types := map[string]int{}
+	collectNodeTypes(root, lang, types)
+	if types["ASC"] != 0 {
+		t.Fatalf("expected inner \"ASC\" alias to be fully discarded through the field wrapper: %s", root.SExpr(lang))
+	}
+	if types["order"] != 1 {
+		t.Fatalf("expected outermost \"order\" alias to win through the field wrapper: %s", root.SExpr(lang))
 	}
 }
 

--- a/grammargen/nested_alias_materialization_test.go
+++ b/grammargen/nested_alias_materialization_test.go
@@ -1,0 +1,353 @@
+package grammargen
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// These tests cover the alias-materialization bug fixed in
+// enumerateAlternatives's RuleAlias case and substituteInlineRefsDepth
+// (normalize.go), and the visible bare-string token/nonterminal
+// classification fixed in isPlainVisibleNamedLeafStringLiteral
+// (normalize.go).
+//
+// The underlying tree-sitter C compiler rules, confirmed empirically against
+// tree-sitter CLI 0.26.6 and cross-checked against the real, pinned SQL
+// (order/nulls_order) and CSS (!important) grammars:
+//
+//   - A direct alias-of-alias chain with nothing else in between collapses:
+//     alias(alias(x, "a"), "b") == alias(x, "b") — the outermost name wins,
+//     any intermediate name is discarded.
+//   - An alias() wrapping a choice/seq collapses PER PRODUCTION STEP: a step
+//     that is already aliased by an explicit nested alias() reachable
+//     through that choice/seq structure keeps its own (inner) alias, and
+//     the outer alias is dropped for that step entirely (not merged). A
+//     step reached with no alias of its own — including a bare symbol
+//     reference to another (possibly hidden) rule, whose own internal
+//     aliasing lives on its own productions and isn't visible at this
+//     step — still receives the outer alias normally. grammargen's own
+//     SetInline mechanism (unlike real tree-sitter) splices a hidden rule's
+//     body into every call site before alias resolution runs, so
+//     substituteInlineRefsDepth strips any aliases that inlining exposes
+//     under an enclosing alias, keeping inlined content as transparent to
+//     alias resolution as an un-inlined symbol reference would have been.
+//   - A visible (non-hidden) named rule whose entire body is a single bare
+//     string literal collapses into a plain named terminal (no wrapper
+//     node) based on ownership, not shape — unique owner of that exact
+//     string value, and the value never used bare elsewhere in the grammar.
+//     isPlainVisibleNamedLeafStringLiteral only special-cased pure
+//     punctuation and lowercase-identifier-like shapes; it now also
+//     recognizes a run of punctuation immediately followed by a
+//     lowercase-identifier-like tail (CSS's "!important"), without widening
+//     the bar for other shapes (a rule differing from an identifier only by
+//     case, like "True", still keeps its wrapper).
+//
+// The `ident` helper rule in these grammars matches capitalized identifiers
+// only ([A-Z][a-zA-Z0-9]*) so it can never collide with the lowercase
+// keyword-shaped literals under test (asc/desc/nulls/first/to/etc).
+
+var testWhitespaceExtras = []*Rule{Pat(`[ \t]+`)}
+
+func mustGenerate(t *testing.T, g *Grammar) *gotreesitter.Language {
+	t.Helper()
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	return lang
+}
+
+func mustParseClean(t *testing.T, lang *gotreesitter.Language, src string) *gotreesitter.Node {
+	t.Helper()
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse %q: %v", src, err)
+	}
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("parse %q produced ERROR: %s", src, root.SExpr(lang))
+	}
+	return root
+}
+
+func collectNodeTypes(node *gotreesitter.Node, lang *gotreesitter.Language, out map[string]int) {
+	if node == nil {
+		return
+	}
+	out[node.Type(lang)]++
+	for i := 0; i < node.ChildCount(); i++ {
+		collectNodeTypes(node.Child(i), lang, out)
+	}
+}
+
+// TestAliasOfChoiceWithAlreadyAliasedArmsDropsOuterAlias reproduces the SQL
+// grammar bug: alias(choice(alias(A, "ASC"), alias(B, "DESC")), $.order).
+// tree-sitter's C compiler never materializes an "order" wrapper here —
+// both choice arms already name themselves, so the outer alias has nothing
+// left to attach to.
+func TestAliasOfChoiceWithAlreadyAliasedArmsDropsOuterAlias(t *testing.T) {
+	g := NewGrammar("test_alias_choice_dedup")
+	g.Define("source_file", Seq(
+		Sym("ident"),
+		Optional(Alias(Choice(
+			Alias(Pat("[Aa][Ss][Cc]"), "ASC", false),
+			Alias(Pat("[Dd][Ee][Ss][Cc]"), "DESC", false),
+		), "order", true)),
+	))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	for _, src := range []string{"Foo asc", "Foo desc"} {
+		root := mustParseClean(t, lang, src)
+		types := map[string]int{}
+		collectNodeTypes(root, lang, types)
+		if types["order"] != 0 {
+			t.Fatalf("parse %q: spurious \"order\" wrapper node materialized: %s", src, root.SExpr(lang))
+		}
+	}
+}
+
+// TestAliasOfSeqWithAllStepsAlreadyAliasedDropsOuterAlias reproduces the SQL
+// grammar's nulls_order bug: alias(seq(alias(A,"NULLS"),
+// choice(alias(B,"FIRST"), alias(C,"LAST"))), $.nulls_order). Every step
+// under the seq already names itself, so the outer alias is dropped
+// entirely — not even applied to one of the steps.
+func TestAliasOfSeqWithAllStepsAlreadyAliasedDropsOuterAlias(t *testing.T) {
+	g := NewGrammar("test_alias_seq_dedup")
+	g.Define("source_file", Seq(
+		Sym("ident"),
+		Optional(Alias(Seq(
+			Alias(Pat("[Nn][Uu][Ll][Ll][Ss]"), "NULLS", false),
+			Choice(
+				Alias(Pat("[Ff][Ii][Rr][Ss][Tt]"), "FIRST", false),
+				Alias(Pat("[Ll][Aa][Ss][Tt]"), "LAST", false),
+			),
+		), "nulls_order", true)),
+	))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "Foo nulls first")
+	types := map[string]int{}
+	collectNodeTypes(root, lang, types)
+	if types["nulls_order"] != 0 {
+		t.Fatalf("spurious \"nulls_order\" wrapper node materialized: %s", root.SExpr(lang))
+	}
+	if types["NULLS"] != 1 || types["FIRST"] != 1 {
+		t.Fatalf("expected raw NULLS/FIRST anonymous tokens as direct siblings: %s", root.SExpr(lang))
+	}
+}
+
+// TestAliasOfMixedChoiceAppliesOuterOnlyToUnaliasedArm covers a choice where
+// only one arm is already aliased: that arm keeps its own (inner) alias,
+// while the other, unaliased arm still receives the outer alias normally.
+func TestAliasOfMixedChoiceAppliesOuterOnlyToUnaliasedArm(t *testing.T) {
+	g := NewGrammar("test_alias_choice_mixed")
+	g.Define("source_file", Seq(
+		Sym("ident"),
+		Optional(Alias(Choice(
+			Alias(Pat("[Aa][Ss][Cc]"), "ASC", false),
+			Pat("[Dd][Ee][Ss][Cc]"),
+		), "order", true)),
+	))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+
+	ascRoot := mustParseClean(t, lang, "Foo asc")
+	ascTypes := map[string]int{}
+	collectNodeTypes(ascRoot, lang, ascTypes)
+	if ascTypes["order"] != 0 {
+		t.Fatalf("ASC arm: spurious \"order\" wrapper (inner alias should win): %s", ascRoot.SExpr(lang))
+	}
+	if ascTypes["ASC"] != 1 {
+		t.Fatalf("ASC arm: expected raw ASC token: %s", ascRoot.SExpr(lang))
+	}
+
+	descRoot := mustParseClean(t, lang, "Foo desc")
+	descTypes := map[string]int{}
+	collectNodeTypes(descRoot, lang, descTypes)
+	if descTypes["order"] != 1 {
+		t.Fatalf("DESC arm: expected outer \"order\" alias to apply to the unaliased arm: %s", descRoot.SExpr(lang))
+	}
+}
+
+// TestDirectAliasChainCollapsesToOutermostName covers a direct alias-of-alias
+// chain with nothing else in between: alias(alias(x, "a"), "b") == alias(x,
+// "b"). The outer name wins outright and the inner name is fully discarded
+// — unlike the choice/seq-mediated cases above.
+func TestDirectAliasChainCollapsesToOutermostName(t *testing.T) {
+	g := NewGrammar("test_alias_direct_chain")
+	g.Define("source_file", Seq(
+		Sym("ident"),
+		Optional(Alias(Alias(Pat("[Aa][Ss][Cc]"), "ASC", true), "order", true)),
+	))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "Foo asc")
+	types := map[string]int{}
+	collectNodeTypes(root, lang, types)
+	if types["ASC"] != 0 {
+		t.Fatalf("expected inner \"ASC\" alias to be fully discarded: %s", root.SExpr(lang))
+	}
+	if types["order"] != 1 {
+		t.Fatalf("expected outermost \"order\" alias to win: %s", root.SExpr(lang))
+	}
+}
+
+// TestAliasOfHiddenSymbolReferenceStillAppliesUniformly guards the
+// pre-existing case that originally motivated grammargen's (overly broad)
+// "outer always wins" behavior: alias($._hidden, "outer_name") where
+// _hidden is a bare rule/symbol reference (not an inline alias()) whose own
+// body independently aliases each of its choice arms, and _hidden is NOT
+// listed in Grammar.Inline (so it stays a genuine separate nonterminal
+// symbol, exactly like real tree-sitter's hidden rules — see
+// TestAliasOfSetInlineHiddenSymbolReferenceStillAppliesUniformly below for
+// the SetInline-specific variant of this same guarantee). Because content
+// here is a plain Symbol — not a Choice/Seq/Alias reachable through this
+// alias()'s own body — flattening treats it as a single untagged step, so
+// the outer alias must still apply uniformly regardless of which of
+// _hidden's own arms matched.
+func TestAliasOfHiddenSymbolReferenceStillAppliesUniformly(t *testing.T) {
+	g := NewGrammar("test_alias_hidden_symbol_ref")
+	g.Define("source_file", Repeat1(Alias(Sym("_hidden"), "outer_name", true)))
+	g.Define("_hidden", Choice(
+		Alias(Str("a"), "inner_a", true),
+		Alias(Str("b"), "inner_b", true),
+	))
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "ab")
+	types := map[string]int{}
+	collectNodeTypes(root, lang, types)
+	if types["outer_name"] != 2 {
+		t.Fatalf("expected outer_name alias to apply uniformly to both arms of the hidden symbol reference: %s", root.SExpr(lang))
+	}
+}
+
+// TestAliasOfSetInlineHiddenSymbolReferenceStillAppliesUniformly reproduces
+// the real-world regression this fix introduced (and then fixed) via
+// grammargen's own SetInline mechanism, mirroring JavaScript/TSX's actual
+// alias(_jsx_identifier, $.property_identifier) idiom exactly:
+//
+//	_jsx_identifier: choice(alias(jsx_identifier, "identifier"), identifier)
+//	_jsx_attribute_name: alias(_jsx_identifier, "property_identifier")
+//
+// Unlike TestAliasOfHiddenSymbolReferenceStillAppliesUniformly above,
+// "_hidden" here IS listed in Grammar.Inline, so
+// substituteInlineRefsDepth splices _hidden's own body — a choice with one
+// already-aliased arm — directly into the alias()'s content BEFORE
+// enumerateAlternatives ever runs. Structurally that looks exactly like a
+// hand-written alias(choice(alias(...), ...), outer) — which
+// TestAliasOfMixedChoiceAppliesOuterOnlyToUnaliasedArm establishes must let
+// the inner alias win on its arm. But real tree-sitter never inlines hidden
+// rule bodies at this stage (hidden nonterminals stay distinct grammar
+// symbols all the way through table construction), so this is purely a
+// grammargen implementation artifact — the outer alias must still apply
+// uniformly to both arms, regardless of which one the hidden rule's own
+// choice matched. This is what stripAliases (in substituteInlineRefsDepth)
+// restores.
+func TestAliasOfSetInlineHiddenSymbolReferenceStillAppliesUniformly(t *testing.T) {
+	g := NewGrammar("test_alias_setinline_hidden_symbol_ref")
+	g.Define("source_file", Repeat1(Alias(Sym("_hidden"), "outer_name", true)))
+	g.Define("_hidden", Choice(
+		Alias(Str("a"), "inner_a", true),
+		Str("b"),
+	))
+	g.SetInline("_hidden")
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "ab")
+	types := map[string]int{}
+	collectNodeTypes(root, lang, types)
+	if types["inner_a"] != 0 {
+		t.Fatalf("hidden rule's own inner alias leaked through a SetInline substitution under an outer alias: %s", root.SExpr(lang))
+	}
+	if types["outer_name"] != 2 {
+		t.Fatalf("expected outer_name alias to apply uniformly to both arms of the SetInline'd hidden symbol reference: %s", root.SExpr(lang))
+	}
+}
+
+// TestVisibleBareStringRuleCollapsesRegardlessOfShape reproduces CSS's
+// `important: $ => '!important'` bug: a visible named rule whose body is a
+// single, uniquely-owned bare string literal collapses into a plain named
+// leaf terminal (0 children) regardless of whether the string's shape is
+// pure punctuation, a lowercase identifier, or — like "!important" — a
+// punctuation-prefixed, identifier-like mix that falls outside both
+// buckets.
+func TestVisibleBareStringRuleCollapsesRegardlessOfShape(t *testing.T) {
+	g := NewGrammar("test_visible_bare_string_mixed_shape")
+	g.Define("source_file", Seq(Sym("ident"), Optional(Sym("important"))))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Define("important", Str("!important"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "X !important")
+
+	var importantNode *gotreesitter.Node
+	var walk func(n *gotreesitter.Node)
+	walk = func(n *gotreesitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type(lang) == "important" {
+			importantNode = n
+		}
+		for i := 0; i < n.ChildCount(); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	if importantNode == nil {
+		t.Fatalf("no \"important\" node found: %s", root.SExpr(lang))
+	}
+	if importantNode.ChildCount() != 0 {
+		t.Fatalf("\"important\" node = %d children, want 0 (plain named leaf, not a wrapper): %s", importantNode.ChildCount(), root.SExpr(lang))
+	}
+}
+
+// TestVisibleBareStringRuleSharedWithBareLiteralStaysWrapped is a regression
+// guard for the pre-existing, still-required half of the classification
+// rule: when the exact same string value is ALSO used bare (unaliased,
+// un-owned) elsewhere in the grammar, the named rule must keep its
+// nonterminal wrapper — collapsing it would incorrectly rename the other,
+// unrelated bare occurrence too. This must hold regardless of the shape
+// widening above.
+func TestVisibleBareStringRuleSharedWithBareLiteralStaysWrapped(t *testing.T) {
+	g := NewGrammar("test_visible_bare_string_shared")
+	g.Define("source_file", Seq(Sym("to"), Sym("ident"), Optional(Seq(Str("to"), Str("("), Sym("ident"), Str(")")))))
+	g.Define("to", Str("to"))
+	g.Define("ident", Pat("[A-Z][a-zA-Z0-9]*"))
+	g.Extras = testWhitespaceExtras
+
+	lang := mustGenerate(t, g)
+	root := mustParseClean(t, lang, "to Foo to ( Bar )")
+
+	var toNode *gotreesitter.Node
+	var walk func(n *gotreesitter.Node)
+	walk = func(n *gotreesitter.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type(lang) == "to" && n.IsNamed() && toNode == nil {
+			toNode = n
+		}
+		for i := 0; i < n.ChildCount(); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	if toNode == nil {
+		t.Fatalf("no named \"to\" node found: %s", root.SExpr(lang))
+	}
+	if toNode.ChildCount() != 1 {
+		t.Fatalf("named \"to\" node = %d children, want 1 (must stay wrapped: the bare literal \"to\" used elsewhere needs to stay anonymous): %s", toNode.ChildCount(), root.SExpr(lang))
+	}
+}

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -3357,15 +3357,6 @@ func isLowercaseIdentifierLikeKeywordLiteral(s string) bool {
 }
 
 func isPlainVisibleNamedLeafStringLiteral(g *Grammar, s string) bool {
-	if isSafePlainPunctuationLiteral(s) || isBackslashEscapedNamedLeafLiteral(s) {
-		return true
-	}
-	if g != nil && g.Word != "" {
-		return false
-	}
-	if isLowercaseIdentifierLikeKeywordLiteral(s) {
-		return true
-	}
 	// Whether a visible bare-string rule collapses into a plain named
 	// terminal (vs. wrapping the anonymous string token in a nonterminal
 	// production) is actually decided by ownership, not shape: it collapses
@@ -3373,7 +3364,7 @@ func isPlainVisibleNamedLeafStringLiteral(g *Grammar, s string) bool {
 	// and the value never appears bare elsewhere in the grammar (both
 	// already enforced by this function's caller, plainVisibleStringTokenRules,
 	// via candidatesByValue/anonymousSources). The punctuation and
-	// lowercase-identifier buckets above are not the real rule — they only
+	// lowercase-identifier buckets described here are not the real rule — they only
 	// approximate that real, shape-irrelevant ownership rule for the two
 	// shapes most commonly seen in practice. CSS's `!important` (punctuation
 	// prefix + identifier-like tail: neither pure punctuation nor a
@@ -3391,7 +3382,20 @@ func isPlainVisibleNamedLeafStringLiteral(g *Grammar, s string) bool {
 	// pre-existing gap, predating this change and not fixed by it, tracked
 	// separately from the punctuation/identifier shape buckets extended
 	// here.
-	return isPunctuationPrefixedLowercaseIdentifierLiteral(s)
+	if isSafePlainPunctuationLiteral(s) || isBackslashEscapedNamedLeafLiteral(s) {
+		return true
+	}
+	if isPunctuationPrefixedLowercaseIdentifierLiteral(s) {
+		return true
+	}
+	// A pure lowercase identifier literal participates in word-token keyword
+	// handling, so preserve its nonterminal wrapper when a word symbol exists.
+	// Punctuation-prefixed literals cannot be word tokens and must be
+	// classified before this guard.
+	if g != nil && g.Word != "" {
+		return false
+	}
+	return isLowercaseIdentifierLikeKeywordLiteral(s)
 }
 
 // isPunctuationPrefixedLowercaseIdentifierLiteral reports whether s is a

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -3363,7 +3363,64 @@ func isPlainVisibleNamedLeafStringLiteral(g *Grammar, s string) bool {
 	if g != nil && g.Word != "" {
 		return false
 	}
-	return isLowercaseIdentifierLikeKeywordLiteral(s)
+	if isLowercaseIdentifierLikeKeywordLiteral(s) {
+		return true
+	}
+	// Whether a visible bare-string rule collapses into a plain named
+	// terminal (vs. wrapping the anonymous string token in a nonterminal
+	// production) is actually decided by ownership, not shape: it collapses
+	// when this rule is the only named rule with this exact string value
+	// and the value never appears bare elsewhere in the grammar (both
+	// already enforced by this function's caller, plainVisibleStringTokenRules,
+	// via candidatesByValue/anonymousSources). The punctuation and
+	// lowercase-identifier buckets above only special-case the two shapes
+	// most commonly seen in practice. CSS's `!important` (punctuation
+	// prefix + identifier-like tail: neither pure punctuation nor a
+	// lowercase identifier) falls through both but still collapses under
+	// tree-sitter's C compiler — confirmed against the C oracle, where
+	// `important: $ => '!important'` produces a 0-child named leaf, not a
+	// wrapper. Extend eligibility to that specific shape — a run of safe
+	// punctuation immediately followed by a lowercase-identifier-like tail
+	// — without widening the bar for other shapes (e.g. a rule whose value
+	// merely differs from an all-lowercase identifier by case, like "True",
+	// deliberately keeps its wrapper; see
+	// TestCapitalizedPlainStringRuleStaysWrapper).
+	return isPunctuationPrefixedLowercaseIdentifierLiteral(s)
+}
+
+// isPunctuationPrefixedLowercaseIdentifierLiteral reports whether s is a
+// non-empty run of "safe" punctuation runes (see isSafePlainPunctuationLiteral)
+// immediately followed by a non-empty lowercase-identifier-like tail (see
+// isLowercaseIdentifierLikeKeywordLiteral) — e.g. CSS's "!important".
+func isPunctuationPrefixedLowercaseIdentifierLiteral(s string) bool {
+	i := 0
+	for i < len(s) {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size <= 1 {
+			return false
+		}
+		if !isSafePunctuationRune(r) {
+			break
+		}
+		i += size
+	}
+	if i == 0 || i >= len(s) {
+		return false
+	}
+	return isLowercaseIdentifierLikeKeywordLiteral(s[i:])
+}
+
+// isSafePunctuationRune reports whether r is safe to use as (part of) a bare
+// literal name, mirroring isSafePlainPunctuationLiteral's character class.
+func isSafePunctuationRune(r rune) bool {
+	if r > unicode.MaxASCII || unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || unicode.IsSpace(r) || unicode.IsControl(r) {
+		return false
+	}
+	switch r {
+	case '"', '\'', '`', '\\':
+		return false
+	}
+	return true
 }
 
 func isBackslashEscapedNamedLeafLiteral(s string) bool {
@@ -3860,19 +3917,55 @@ func enumerateAlternatives(r *Rule) [][]*rhsElement {
 		if len(r.Children) == 0 {
 			return [][]*rhsElement{{}}
 		}
-		// Enumerate alternatives inside the alias, tagging each with the alias name.
-		// The outer alias must override any inner alias metadata; otherwise nested
-		// alias forms like alias(_jsx_identifier, "property_identifier") let the
-		// inner alias on _jsx_identifier shadow the outer one and lose the
-		// intended surface node type after default-alias cleanup.
+		// A direct chain of alias() wrappers with nothing else in between
+		// collapses to a single alias: the outermost name/named wins and any
+		// intermediate alias name is discarded entirely, exactly like
+		// tree-sitter's C compiler merges consecutive alias-metadata
+		// wrappers rather than representing them as two separate steps.
+		//
+		//   alias(alias(x, "a"), "b")  ==  alias(x, "b")
+		//
+		// Grammars occasionally write this directly. It is also the shape
+		// substituteInlineRefsDepth deliberately normalizes SetInline'd
+		// hidden-rule references down to (via stripAliases) before this
+		// case ever sees them, so alias(_jsx_identifier-style,
+		// "property_identifier") — where _jsx_identifier is itself a bare
+		// rule/symbol reference, not an inline alias() — keeps working via
+		// the generic path below (a symbol reference flattens to a single
+		// untagged element here; its own internal aliasing lives on its own
+		// productions, not on this element).
+		if content := r.Children[0]; content.Kind == RuleAlias {
+			collapsed := &Rule{Kind: RuleAlias, Value: r.Value, Named: r.Named, Children: content.Children}
+			return enumerateAlternatives(collapsed)
+		}
+
+		// Enumerate alternatives inside the content, tagging each resulting
+		// element with this alias's name/named — but only when the element
+		// doesn't already carry an alias of its own. tree-sitter's compiler
+		// attaches alias() to each production step produced by flattening
+		// its content; where flattening reaches a step that's already
+		// aliased by an explicit nested alias() reachable through
+		// choice/seq structure, that inner alias is what actually displays
+		// and the outer alias is dropped for that step entirely (not
+		// merged, not overridden by the outer one) — a single alias() call
+		// cannot rename a step that already names itself without
+		// synthesizing a new hidden wrapper symbol, which tree-sitter does
+		// not do for plain choice/seq content. This is why, for example,
+		// SQL's alias(choice(alias(/asc/i,"ASC"), alias(/desc/i,"DESC")),
+		// $.order) never produces an "order" wrapper node: both choice arms
+		// already name themselves, so "order" has nothing left to attach
+		// to. Steps with no alias of their own still receive this alias
+		// normally.
 		innerAlts := enumerateAlternatives(r.Children[0])
 		var result [][]*rhsElement
 		for _, alt := range innerAlts {
 			tagged := make([]*rhsElement, len(alt))
 			for i, elem := range alt {
 				cp := *elem
-				cp.aliasName = r.Value
-				cp.aliasNamed = r.Named
+				if cp.aliasName == "" {
+					cp.aliasName = r.Value
+					cp.aliasNamed = r.Named
+				}
 				tagged[i] = &cp
 			}
 			result = append(result, tagged)
@@ -5092,12 +5185,37 @@ func choiceWidth(r *Rule) int {
 // prevent Cartesian product explosion in grammars with deep inline chains
 // (e.g. Haskell with 17 nested chains across 51 inline rules).
 func substituteInlineRefs(r *Rule, inlineBodies map[string]*Rule) *Rule {
-	return substituteInlineRefsDepth(r, inlineBodies, 0)
+	return substituteInlineRefsDepth(r, inlineBodies, 0, false)
 }
 
 const maxInlineSubstDepth = 2
 
-func substituteInlineRefsDepth(r *Rule, inlineBodies map[string]*Rule, depth int) *Rule {
+// substituteInlineRefsDepth replaces RuleSymbol references to inline rules
+// with (a clone of) the referenced rule's body.
+//
+// insideAlias tracks whether this call is processing content reachable
+// (through any amount of Choice/Seq/Field/Prec/etc. wrapping) from inside an
+// Alias node's content, within the current rule body. When a symbol
+// reference is substituted in that context, any ALIAS nodes inside the
+// substituted clone are stripped (see stripAliases): grammargen's SetInline
+// mechanism eagerly splices a hidden rule's body into every call site
+// *before* alias resolution runs, but real tree-sitter never does this —
+// hidden nonterminals stay distinct grammar symbols all the way through
+// table construction, so an enclosing alias() cleanly renames that one
+// symbol occurrence regardless of the referenced rule's own internal
+// structure or aliasing (see e.g. real-world
+// alias($._jsx_identifier, $.property_identifier), where _jsx_identifier's
+// own choice aliases one of its two arms to "identifier" — that inner alias
+// must never be allowed to compete with the outer "property_identifier").
+// Without this stripping, inlining artificially recreates the exact
+// "alias(choice(alias(...), ...), outer)" shape that a genuinely
+// hand-written nested alias() would use — and that shape intentionally lets
+// an inner alias win over the outer one (see enumerateAlternatives's
+// RuleAlias case). Stripping keeps the two cases distinguishable: real
+// nested alias() syntax collapses per tree-sitter's own rule, while
+// SetInline-introduced structure stays fully transparent to the enclosing
+// alias, exactly as an un-inlined symbol reference would have been.
+func substituteInlineRefsDepth(r *Rule, inlineBodies map[string]*Rule, depth int, insideAlias bool) *Rule {
 	if r == nil {
 		return nil
 	}
@@ -5107,7 +5225,10 @@ func substituteInlineRefsDepth(r *Rule, inlineBodies map[string]*Rule, depth int
 			// Recursively substitute nested inline refs up to a bounded
 			// depth to avoid exponential production explosion.
 			if depth < maxInlineSubstDepth {
-				return substituteInlineRefsDepth(clone, inlineBodies, depth+1)
+				clone = substituteInlineRefsDepth(clone, inlineBodies, depth+1, insideAlias)
+			}
+			if insideAlias {
+				clone = stripAliases(clone)
 			}
 			return clone
 		}
@@ -5118,8 +5239,36 @@ func substituteInlineRefsDepth(r *Rule, inlineBodies map[string]*Rule, depth int
 	}
 	out := *r
 	out.Children = make([]*Rule, len(r.Children))
+	childInsideAlias := insideAlias || r.Kind == RuleAlias
 	for i, c := range r.Children {
-		out.Children[i] = substituteInlineRefsDepth(c, inlineBodies, depth)
+		out.Children[i] = substituteInlineRefsDepth(c, inlineBodies, depth, childInsideAlias)
+	}
+	return &out
+}
+
+// stripAliases recursively removes ALIAS wrapping from r, keeping the
+// aliased content but discarding the alias name/named annotation. Used when
+// inline-substituting a symbol reference that sits inside an enclosing
+// alias()'s content, so the referenced rule's own internal aliasing can't
+// compete with the enclosing alias for the same production step (see
+// substituteInlineRefsDepth).
+func stripAliases(r *Rule) *Rule {
+	if r == nil {
+		return nil
+	}
+	if r.Kind == RuleAlias {
+		if len(r.Children) == 0 {
+			return r
+		}
+		return stripAliases(r.Children[0])
+	}
+	if len(r.Children) == 0 {
+		return r
+	}
+	out := *r
+	out.Children = make([]*Rule, len(r.Children))
+	for i, c := range r.Children {
+		out.Children[i] = stripAliases(c)
 	}
 	return &out
 }

--- a/grammargen/normalize.go
+++ b/grammargen/normalize.go
@@ -3373,18 +3373,24 @@ func isPlainVisibleNamedLeafStringLiteral(g *Grammar, s string) bool {
 	// and the value never appears bare elsewhere in the grammar (both
 	// already enforced by this function's caller, plainVisibleStringTokenRules,
 	// via candidatesByValue/anonymousSources). The punctuation and
-	// lowercase-identifier buckets above only special-case the two shapes
-	// most commonly seen in practice. CSS's `!important` (punctuation
+	// lowercase-identifier buckets above are not the real rule — they only
+	// approximate that real, shape-irrelevant ownership rule for the two
+	// shapes most commonly seen in practice. CSS's `!important` (punctuation
 	// prefix + identifier-like tail: neither pure punctuation nor a
 	// lowercase identifier) falls through both but still collapses under
 	// tree-sitter's C compiler — confirmed against the C oracle, where
 	// `important: $ => '!important'` produces a 0-child named leaf, not a
 	// wrapper. Extend eligibility to that specific shape — a run of safe
 	// punctuation immediately followed by a lowercase-identifier-like tail
-	// — without widening the bar for other shapes (e.g. a rule whose value
-	// merely differs from an all-lowercase identifier by case, like "True",
-	// deliberately keeps its wrapper; see
-	// TestCapitalizedPlainStringRuleStaysWrapper).
+	// — without widening the bar for other shapes. This is still only a
+	// minimal, targeted extension, not the full ownership rule: a
+	// uniquely-owned rule whose value differs from an identifier only by
+	// case, like "True" (see TestCapitalizedPlainStringRuleStaysWrapper),
+	// would also collapse under real tree-sitter's shape-irrelevant
+	// ownership rule, but grammargen still keeps it wrapped — a
+	// pre-existing gap, predating this change and not fixed by it, tracked
+	// separately from the punctuation/identifier shape buckets extended
+	// here.
 	return isPunctuationPrefixedLowercaseIdentifierLiteral(s)
 }
 
@@ -3917,15 +3923,35 @@ func enumerateAlternatives(r *Rule) [][]*rhsElement {
 		if len(r.Children) == 0 {
 			return [][]*rhsElement{{}}
 		}
-		// A direct chain of alias() wrappers with nothing else in between
-		// collapses to a single alias: the outermost name/named wins and any
-		// intermediate alias name is discarded entirely, exactly like
-		// tree-sitter's C compiler merges consecutive alias-metadata
-		// wrappers rather than representing them as two separate steps.
+		// A direct chain of alias() wrappers -- or an outer alias() whose
+		// content reaches an inner alias() through nothing but
+		// alias-metadata wrappers (prec/prec_left/prec_right/prec_dynamic/
+		// field) -- collapses to a single alias: the outermost name/named
+		// wins and any intermediate alias name is discarded entirely,
+		// exactly like tree-sitter's C compiler merges consecutive
+		// alias-metadata wrappers rather than representing them as separate
+		// production steps.
 		//
-		//   alias(alias(x, "a"), "b")  ==  alias(x, "b")
+		//   alias(alias(x, "a"), "b")             ==  alias(x, "b")
+		//   alias(prec(N, alias(x, "a")), "b")     ==  prec(N, alias(x, "b"))
+		//   alias(field("f", alias(x, "a")), "b")  ==  field("f", alias(x, "b"))
 		//
-		// Grammars occasionally write this directly. It is also the shape
+		// prec/prec_left/prec_right/prec_dynamic/field wrappers carry no
+		// naming of their own and never introduce a separate production
+		// step, so tree-sitter's compiler treats them as transparent when
+		// deciding which alias a production step actually displays --
+		// unlike choice/seq/repeat/optional, which DO introduce separate
+		// steps and so make the inner alias win on its own step instead
+		// (see the generic path below). metadataOnlyAliasChain finds the
+		// terminal alias() reachable through metadata wrappers alone (it
+		// also matches the direct chain above, as the zero-wrapper case);
+		// rewriteAliasChainTarget rebuilds the same wrapper chain with that
+		// terminal alias's name/named replaced by this alias's, so any
+		// prec/field metadata on the intermediate wrappers is preserved on
+		// the resulting element exactly as if this alias had wrapped the
+		// content directly.
+		//
+		// Grammars occasionally write the direct form. It is also the shape
 		// substituteInlineRefsDepth deliberately normalizes SetInline'd
 		// hidden-rule references down to (via stripAliases) before this
 		// case ever sees them, so alias(_jsx_identifier-style,
@@ -3934,9 +3960,11 @@ func enumerateAlternatives(r *Rule) [][]*rhsElement {
 		// the generic path below (a symbol reference flattens to a single
 		// untagged element here; its own internal aliasing lives on its own
 		// productions, not on this element).
-		if content := r.Children[0]; content.Kind == RuleAlias {
-			collapsed := &Rule{Kind: RuleAlias, Value: r.Value, Named: r.Named, Children: content.Children}
-			return enumerateAlternatives(collapsed)
+		if content := r.Children[0]; content != nil {
+			if _, ok := metadataOnlyAliasChain(content); ok {
+				collapsed := rewriteAliasChainTarget(content, r.Value, r.Named)
+				return enumerateAlternatives(collapsed)
+			}
 		}
 
 		// Enumerate alternatives inside the content, tagging each resulting
@@ -4008,6 +4036,52 @@ func enumerateAlternatives(r *Rule) [][]*rhsElement {
 	default:
 		// Leaf node (String, Symbol, etc.) — single element.
 		return [][]*rhsElement{{&rhsElement{rule: r}}}
+	}
+}
+
+// metadataOnlyAliasChain walks a chain of pure alias-metadata wrappers
+// (prec, prec_left, prec_right, prec_dynamic, field) starting at r, looking
+// for a terminal alias() node reachable through metadata alone -- never
+// through seq/choice/repeat/optional, which introduce separate production
+// steps rather than merely annotating the one step beneath them. It reports
+// the terminal alias rule and true if one is found; r itself may already be
+// that terminal alias (the zero-wrapper / direct-chain case).
+func metadataOnlyAliasChain(r *Rule) (*Rule, bool) {
+	for r != nil {
+		switch r.Kind {
+		case RuleAlias:
+			return r, true
+		case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic, RuleField:
+			if len(r.Children) == 0 {
+				return nil, false
+			}
+			r = r.Children[0]
+		default:
+			return nil, false
+		}
+	}
+	return nil, false
+}
+
+// rewriteAliasChainTarget returns a copy of r with the terminal alias()
+// node at the bottom of a metadataOnlyAliasChain renamed to (value, named).
+// Only the wrapper nodes on the path (prec/prec_left/prec_right/
+// prec_dynamic/field) are copied; everything else, including the aliased
+// content itself, is shared with the original tree. Call only when
+// metadataOnlyAliasChain(r) reports true.
+func rewriteAliasChainTarget(r *Rule, value string, named bool) *Rule {
+	switch r.Kind {
+	case RuleAlias:
+		return &Rule{Kind: RuleAlias, Value: value, Named: named, Children: r.Children}
+	case RulePrec, RulePrecLeft, RulePrecRight, RulePrecDynamic, RuleField:
+		if len(r.Children) == 0 {
+			return r
+		}
+		cp := *r
+		cp.Children = []*Rule{rewriteAliasChainTarget(r.Children[0], value, named)}
+		return &cp
+	default:
+		return r
 	}
 }
 


### PR DESCRIPTION
## Summary

grammargen materialized a spurious NAMED wrapper node in two situations where tree-sitter's C compiler collapses one away. This was the blocker for the sql/css wave-7 promotions.

1. `enumerateAlternatives`'s `RuleAlias` case unconditionally let an outer `alias()` overwrite any inner alias tag. Under real tree-sitter, an `alias()` wrapping a choice/seq only applies to production steps that don't already carry their own alias; a step that's already named by a nested `alias()` keeps that name, and the outer alias has nothing left to attach to. This is exactly SQL's `order`/`nulls_order` rules (`alias(choice(alias(/asc/i,"ASC"), alias(/desc/i,"DESC")), $.order)`): grammargen kept materializing an `order`/`nulls_order` wrapper; C collapses it to the bare ASC/DESC token. A chain of `alias()` wrappers with nothing but other alias-metadata (`alias()`, `prec()`, `field()`, etc.) in between is the one case that still collapses to the outermost name, matching tree-sitter's own consecutive alias-metadata merge (see the review follow-up below for a gap in the original scope of that exception).
2. `isPlainVisibleNamedLeafStringLiteral` only recognized pure-punctuation or all-lowercase-identifier string shapes as eligible to collapse a named rule into a plain leaf token. tree-sitter's actual rule is ownership, not shape: a visible rule collapses when it uniquely owns its string value and that value is never used bare elsewhere in the grammar. CSS's `` important: $ => '!important' `` (punctuation prefix + identifier tail) fell through both shape buckets and kept an unwanted wrapper. Extended eligibility to that specific shape only.
3. grammargen's own `SetInline` mechanism splices a hidden rule's body into every call site before alias resolution runs, unlike real tree-sitter, which keeps hidden nonterminals as distinct grammar symbols through table construction. Left unguarded, fix 1 lets a `SetInline`'d rule's own internal aliasing leak through an enclosing alias — the `alias($._jsx_identifier, $.property_identifier)` pattern the old unconditional-overwrite behavior happened to paper over. Inline substitution now strips alias annotations introduced only by inlining when it happens under an enclosing alias.

## The tree-sitter rule

Confirmed empirically against tree-sitter CLI 0.26.6 (isolated synthetic grammars) and cross-checked against the real pinned SQL/CSS grammars and the C oracle:

- `alias(alias(x, "a"), "b")` (direct chain, nothing else in between) collapses to `alias(x, "b")`. The same collapse applies when the inner `alias()` is reachable through nothing but other alias-metadata wrappers — `prec`/`prec_left`/`prec_right`/`prec_dynamic`/`field` — which carry no naming of their own and never introduce a separate production step: `alias(prec(N, alias(x, "a")), "b")` == `prec(N, alias(x, "b"))`, and likewise for `field()`.
- `alias(choice(alias(a,"A"), alias(b,"B")), "outer")` never produces `outer`: each arm already names itself; a single `alias()` can't rename an already-self-naming step without synthesizing a new hidden wrapper symbol, which tree-sitter doesn't do here. This only holds once a `seq`/`choice`/`repeat`/`optional` sits between the two aliases — those introduce genuinely separate production steps, unlike the metadata wrappers above.
- A visible named rule whose entire body is one bare string literal collapses to a plain named leaf (0 children) purely by ownership: unique owner of that string value, never used bare elsewhere in the grammar. Shape is irrelevant.

## Review follow-up (metadata-mediated alias chains)

An adversarial review caught a real regression in the first version of this PR: the direct-chain collapse only fired when the outer alias's content was *literally* another `alias()` node (`r.Children[0].Kind == RuleAlias`). When a `prec()`/`field()`/etc. wrapper sat in between — `alias(prec(N, alias(x, "inner")), "outer")` — the check didn't fire, so the generic per-step path ran instead. That path only assigns the outer name when the step isn't already aliased; since the inner alias had already set it, the outer alias was silently dropped and `"inner"` displayed instead of tree-sitter's `"outer"`.

Fixed by generalizing the collapse: `metadataOnlyAliasChain` walks a chain of pure alias-metadata wrappers (`prec`/`prec_left`/`prec_right`/`prec_dynamic`/`field`) looking for a terminal `alias()` — it also matches the pre-existing direct-chain case as the zero-wrapper case — and `rewriteAliasChainTarget` rebuilds the same wrapper chain with that terminal alias renamed to the outer alias's name, so any `prec`/`field` metadata in between is preserved on the resulting element exactly as before. This does **not** touch the `seq`/`choice`/`repeat`/`optional`-mediated per-step behavior (the sql/css fix) at all — those still make the inner alias win on its own step.

Also closed two nits from the same review:
- A nil-deref: the old direct-chain check dereferenced `r.Children[0].Kind` before any nil check; the new code guards `content != nil` first.
- A misleading code comment that framed grammargen's under-collapse of capitalized bare-string rules (e.g. `'True'`) as tree-sitter "agreeing" the wrapper should stay. It doesn't — real tree-sitter's ownership-based collapse is shape-irrelevant and would also collapse a uniquely-owned `'True'`. grammargen's punctuation+identifier shape-bucket widening in this PR is still a correct, minimal, targeted improvement; the comment now says so without misattributing the pre-existing (out-of-scope, unaffected by this PR) shape-bucket gap to tree-sitter itself.

Two new guard tests (`TestAliasChainThroughPrecCollapsesToOutermostName`, `TestAliasChainThroughFieldCollapsesToOutermostName`) cover the metadata-chain case directly; both were verified to fail against the code as it stood before this follow-up and pass after.

Beyond the unit tests, this was cross-checked directly against the real tree-sitter CLI 0.26.6 with a synthetic grammar covering all four wrapper shapes in one file, including a *double*-nested metadata chain (`prec` wrapping `field` wrapping `alias`) one level deeper than either new unit test exercises on its own:

```js
alias(prec(1, alias($._c, $.inner_c)), $.outer_P),               // prec-mediated
alias(field('fld', alias($._d, $.inner_d)), $.outer_F),          // field-mediated
alias(prec.left(1, alias($._e, $.inner_e)), $.outer_PL),         // prec_left-mediated
alias(prec(1, field('g', alias($._h, $.inner_h))), $.outer_PFA), // double metadata chain
```

Real tree-sitter CLI 0.26.6 on `c d e h`: `(source_file (outer_P) fld: (outer_F) (outer_PL) g: (outer_PFA))` — outer wins in all four, with the `fld`/`g` field annotations correctly hoisted onto the renamed node. grammargen with this fix reproduces that exact shape node-for-node and field-for-field (verified with a throwaway local test against the same grammar, not checked in).

## Test plan

- [x] `grammargen/nested_alias_materialization_test.go`: 10 focused unit tests (8 original + 2 added in the review follow-up above) covering the choice/seq collapse rule, the direct- and metadata-mediated alias-chain collapse, the (un-inlined and `SetInline`'d) hidden-symbol-reference exemption, and both halves of the string-literal classification rule (corrected from the "9" originally claimed here — there are 8 in the original file, not 9; the previous count was simply off by one). Only 4 of the 10 are true bug-repros that fail against pre-PR `main` (`TestAliasOfChoiceWithAlreadyAliasedArmsDropsOuterAlias`, `TestAliasOfSeqWithAllStepsAlreadyAliasedDropsOuterAlias`, `TestAliasOfMixedChoiceAppliesOuterOnlyToUnaliasedArm`, `TestVisibleBareStringRuleCollapsesRegardlessOfShape`) — verified individually by running each test against `main`'s pre-PR `normalize.go`. The other 6, including the 2 new metadata-chain tests, already pass against pre-PR `main` (whose *unconditional* outer-always-wins behavior happens to get those particular shapes right by accident) and are regression guards, not bug repros; they exist to pin the corrected, narrower behavior this PR introduces. The 2 new metadata-chain tests specifically fail against the first version of this PR (commit-as-merged, post sql/css fix, pre review-follow-up) and pass after it — that regression window is exactly what the adversarial review caught. (`TestCapitalizedPlainStringRuleStaysWrapper`, referenced in the review follow-up above, lives in `keyword_choice_token_test.go`, not this file, and predates this PR entirely — it also passes unchanged pre- and post-fix.)
- [x] `GOWORK=off go build ./... && go test ./grammargen/... ./grammars/... -count=1`. `grammars/...` is fully clean. `grammargen/...` has pre-existing, unrelated failures on unmodified `main` too (Markdown block-wrapper divergences, two Dart LR-conflict-resolution tests, one JS template-string escape-sequence test, a documented uint16-table-ceiling limit for `markdown_inline`, and an environment-load-dependent 90s generation-timeout budget that hits large grammars — swift and/or C# depending on machine load — in a handful of pipeline/parity tests) — every one of these was individually confirmed byte-identical before/after this change via direct A/B comparison, including re-confirming the review follow-up's metadata-chain fix in isolation.
- [x] RAW grammargen-vs-C-oracle comparison, bypassing the promotion gate's shared-oracle-gap leniency (self-referential once a language is grammargen-owned, per the wave-7 verification caveat):
  - **sql**: 7/183 samples diverging (the order/nulls_order wrapper) → 0/183. The 2 residual divergences are a pre-existing, unrelated StartByte/whitespace-boundary gap, byte-identical before/after — including after the review follow-up's metadata-chain fix (raw divergence list re-diffed and confirmed byte-for-byte identical).
  - **css**: every `!important` divergence resolved, including 11 occurrences in one real-world stylesheet alone. 2 residual divergences (a pre-existing child-count gap and a pre-existing ERROR mismatch, both in real-world stylesheets) are byte-identical before/after — including after the review follow-up (same re-diff).
  - **go, swift, regex** (the 3 currently-shipping grammargen languages): byte-for-byte IDENTICAL raw divergence lists before/after (regex 38/38 clean both ways; go 13/47 and swift 152/226 raw tree-parity both ways — confirmed via exact diff of every divergence detail, not just matching counts). The review follow-up's metadata-chain fix additionally regenerates SHA-256-identical blobs for all three languages before/after (confirmed blast-radius-0: neither go_grammar.go nor swift_grammar.go nor the regex grammar.json contains the `alias(metadata(...alias(...)))` shape the fix touches — verified with a Go-AST scan of every grammargen source and test fixture, which found exactly 2 matches: the two new guard tests added for this fix).

Note: go and swift are not currently 100% byte-exact against the true C oracle (pre-existing gaps — e.g. Go's trailing-newline/ASI `statement_list` span handling, Swift's `user_type`/`simple_identifier` disambiguation). That predates this change and is out of scope here; flagging because the "byte-exact" framing for these 3 languages elsewhere assumed the self-referential lenient promotion-gate comparison rather than a raw C-oracle diff.

This is a grammargen-core change affecting blob output for every grammargen-generated language — opening for review rather than merging directly.
