### PR TITLE
Refresh Wave 3 TypeScript perf sweep metadata

### DIFF
--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -19,8 +19,8 @@
     "removing exclusions is a tightening operation."
   ],
   "schema": "gts-perf-ratio-budgets/v1",
-  "generated_at": "2026-07-09T14:03:03Z",
-  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/crystal-scala-pending-resweep, extending pending-row refreshes with strict-basis crystal evidence and scoped scala OOM attribution",
+  "generated_at": "2026-07-09T14:20:11Z",
+  "generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/typescript-pending-resweep, extending pending-row refreshes with strict-basis typescript timing evidence while preserving the known webworker oracle caveat",
   "measurement_basis": {
     "harness": "cgo_harness/perf_scan (TestPerfScanSweep / TestPerfScanLanguage, tags treesitter_c_parity treesitter_c_perfscan)",
     "corpus_root": "/home/draco/work/gotreesitter-corpora/corpus_sources (real upstream per-language checkouts, largest-8-files sampling -- deliberately adversarial, hunts cliffs, NOT representative of typical file size)",
@@ -72,7 +72,8 @@
     "wave3_pending_swift_strict_20260709T133944Z": "pending-row refresh on branch wave3/rust-swift-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 selected files but remains 1/8 full-axis completions and 7/8 timeouts on SwiftSyntax generated files. RCA for the apparent ratio loosening: the old 7.41x aggregate came from the stale after_cliffs survivor row, while the fresh strict survivor measures 10.69x under a harness-flagged contended run (loadavg1=5.31). This row remains a timeout-dominated generated-code backlog, not a near-C claim.",
     "wave3_pending_crystal_strict_20260709T135653Z": "pending-row refresh on branch wave3/crystal-scala-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 selected files and did not reproduce the stale after_cliffs silent-truncation row: max_errors tightens from 3 to 0. Full axis remains a severe timeout/throughput backlog with 5/8 timeouts and 3 completing files at ratio_by_total=66.37x, median=7.90x; src/string.cr alone completed at 193.6x. Harness marked the run contended (loadavg1=4.75 start, 5.64 end), so this is a visibility ratchet, not a quiet-box near-C claim.",
     "wave3_pending_scala_strict_20260709T135935Z": "scoped pending-row probe on branch wave3/crystal-scala-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion. The full 8-file Scala row remains non-ratchetable: the child was killed after 1/8 files while measuring src/compiler/scala/tools/nsc/typechecker/Implicits.scala full/c/warmup attempt 1; Docker reported oom_killed=true. Preserve the old after_cliffs budget row until a complete basis or explicit scoped-exclusion policy exists.",
-    "wave3_pending_scala_implicits_strict_20260709T140125Z": "narrowed Scala attribution probe on branch wave3/crystal-scala-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, max_files=1/max_file_bytes=103233 to select src/compiler/scala/tools/nsc/typechecker/Implicits.scala. The isolated witness completed without cgroup OOM but both axes hit Go timeout/memory-budget stops (full C median ~1.01s, full lower-bound ratio >=9.94x; noedit lower-bound ratio >=150770x). This points at cumulative pressure across the largest-8 Scala row plus per-file Go timeout cliffs, not an isolated C-reference OOM."
+    "wave3_pending_scala_implicits_strict_20260709T140125Z": "narrowed Scala attribution probe on branch wave3/crystal-scala-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, max_files=1/max_file_bytes=103233 to select src/compiler/scala/tools/nsc/typechecker/Implicits.scala. The isolated witness completed without cgroup OOM but both axes hit Go timeout/memory-budget stops (full C median ~1.01s, full lower-bound ratio >=9.94x; noedit lower-bound ratio >=150770x). This points at cumulative pressure across the largest-8 Scala row plus per-file Go timeout cliffs, not an isolated C-reference OOM.",
+    "wave3_pending_typescript_strict_20260709T141748Z": "pending-row refresh on branch wave3/typescript-pending-resweep, Docker 8GiB/GOMEMLIMIT=6GiB, largest-8 ratchet basis with the checked-in Groovy heldout exclusion in GTS_PERF_SCAN_EXCLUDE_PATHS. Completed 8/8 timing-grade perf_scan files with 0 timeouts and 0 truncation/status errors; full parse remains a measured cliff row at ratio_by_total=7.63x, median=6.21x, with one >10x file (reallyLargeFile.ts). Noedit ratio_by_total=0.0000248x. This replaces the stale after_cliffs timing row, but it does NOT close known_budget_class_gaps.webworker_generated_d_ts because perf_scan 'ok' is timing-grade only and the default-budget oracle mismatch remains tracked separately."
   },
   "languages": {
     "php": {
@@ -315,22 +316,22 @@
       }
     },
     "typescript": {
-      "status": "wave2b_pending",
+      "status": "green_with_caveat",
       "wave2b_pending": true,
-      "measured_today": "partial (webworker.generated.d.ts oracle spot-check only; full 8-file sweep documented from after_cliffs, STALE)",
-      "note": "SEE known_budget_class_gaps.webworker_generated_d_ts BELOW -- this is the headline wave-2b-pending finding of this pass. after_cliffs (pre-arena-fix) full-axis aggregate: 5/8 ok, 1 go_timeout (typescript.d.ts, memory_budget), 2 go_error/truncated (checker.ts 53017/3151774 bytes ~1.7% span; dom.generated.d.ts 101054/2348669 ~4.3% span -- both severe silent truncations). ratio_by_total=25.79x is a 'survivorship optics' artifact per pr141-scoreboard.md: it got numerically WORSE than wave-1's baseline (1.5x) purely because a previously-excluded (timed-out) giant, webworker.generated.d.ts, now finishes (slowly, and per this pass's fresh oracle check, INCORRECTLY at the default budget) and drags the sum up; ratio_median_of_files=1.72x is far less distorted and is the more honest per-file signal. Named wave-1/wave-2 backlog item: 'GOT_FAITHFUL_CONDENSE for the webworker 512MB-budget divergence' -- confirmed still open by this pass's direct oracle re-check.",
+      "measured_today": true,
+      "note": "Pending-row refresh (wave3_pending_typescript_strict_20260709T141748Z): replaces the stale after_cliffs timing row. The strict largest-8 perf_scan run completed 8/8 selected files with 0 timeouts and 0 perf_scan truncation/status errors; full parse remains a measured throughput backlog row (7.63x aggregate, 6.21x median, one >10x cliff file: reallyLargeFile.ts), and noedit is comfortably below C on aggregate. This is a timing-grade ratchet only: SEE known_budget_class_gaps.webworker_generated_d_ts BELOW. perf_scan 'ok' means a full-span tree was produced inside the timing budget, not that the byte-shape oracle matches C. The default-budget webworker.generated.d.ts oracle mismatch remains open, so wave2b_pending stays true.",
       "full_axis": {
-        "max_timeouts": 1,
-        "max_errors": 2,
-        "max_ratio_by_total": 35,
-        "max_ratio_median_of_files": 3,
-        "observed_ratio_by_total": 25.791,
-        "observed_ratio_median_of_files": 1.720
+        "max_timeouts": 0,
+        "max_errors": 0,
+        "max_ratio_by_total": 10,
+        "max_ratio_median_of_files": 8,
+        "observed_ratio_by_total": 7.634,
+        "observed_ratio_median_of_files": 6.210
       },
       "noedit_axis": {
-        "max_timeouts": 1,
+        "max_timeouts": 0,
         "max_ratio_by_total": 1.0,
-        "observed_ratio_by_total": 0.000001
+        "observed_ratio_by_total": 0.0000248
       }
     },
     "cmake": {

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -1,10 +1,10 @@
 {
   "schema": "gts-wave3-perf-sweep-status/v1",
-  "generated_at": "2026-07-09T14:04:01Z",
+  "generated_at": "2026-07-09T14:21:00Z",
   "budget_path": "perf_scan/perf_ratio_budgets.json",
   "fleet_path": "tier_scan/exts.tsv",
-  "budget_generated_at": "2026-07-09T14:03:03Z",
-  "budget_generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/crystal-scala-pending-resweep, extending pending-row refreshes with strict-basis crystal evidence and scoped scala OOM attribution",
+  "budget_generated_at": "2026-07-09T14:20:11Z",
+  "budget_generated_by": "wave-3 fleet perf sweep ratchet pass, branch wave3/typescript-pending-resweep, extending pending-row refreshes with strict-basis typescript timing evidence while preserving the known webworker oracle caveat",
   "measurement_basis": {
     "reps": 5,
     "warmup": 1,
@@ -26,8 +26,8 @@
     "known_budget_class_gaps": 4,
     "wave2b_pending_budgets": 11,
     "scoped_heldout_budgets": 1,
-    "measured_today_budgets": 202,
-    "partial_measured_today_budgets": 2
+    "measured_today_budgets": 203,
+    "partial_measured_today_budgets": 1
   },
   "held_out_languages": [
     "d",
@@ -35,8 +35,8 @@
   ],
   "budget_status_counts": {
     "green": 50,
-    "green_with_caveat": 148,
-    "wave2b_pending": 6
+    "green_with_caveat": 149,
+    "wave2b_pending": 5
   },
   "seed_sources": [
     "after_cliffs_20260706T210143Z",
@@ -69,6 +69,7 @@
     "wave3_pending_scala_implicits_strict_20260709T140125Z",
     "wave3_pending_scala_strict_20260709T135935Z",
     "wave3_pending_swift_strict_20260709T133944Z",
+    "wave3_pending_typescript_strict_20260709T141748Z",
     "wave3_scoped_d_exclude_expressionsem_20260709T103336Z",
     "wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z",
     "wave3_scoped_groovy_exclude_pleac11_20260709T103612Z",

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -1,10 +1,10 @@
 # Wave 3 Perf Sweep Status
 
-- generated_at: `2026-07-09T14:04:01Z`
+- generated_at: `2026-07-09T14:21:00Z`
 - budget: `perf_scan/perf_ratio_budgets.json`
 - fleet catalog: `tier_scan/exts.tsv`
-- budget_generated_at: `2026-07-09T14:03:03Z`
-- budget_generated_by: `wave-3 fleet perf sweep ratchet pass, branch wave3/crystal-scala-pending-resweep, extending pending-row refreshes with strict-basis crystal evidence and scoped scala OOM attribution`
+- budget_generated_at: `2026-07-09T14:20:11Z`
+- budget_generated_by: `wave-3 fleet perf sweep ratchet pass, branch wave3/typescript-pending-resweep, extending pending-row refreshes with strict-basis typescript timing evidence while preserving the known webworker oracle caveat`
 
 ## Coverage
 
@@ -16,8 +16,8 @@
 | known budget class gaps | 4 |
 | wave2b pending budget rows | 11 |
 | scoped heldout budget rows | 1 |
-| measured-today budget rows | 202 |
-| partial measured-today notes | 2 |
+| measured-today budget rows | 203 |
+| partial measured-today notes | 1 |
 
 Measurement basis: `reps=5`, `warmup=1`, `file_budget_ms=10000`, `max_files=8`, `order=largest`, `axes=full,noedit`.
 
@@ -30,8 +30,8 @@ Held out of the ratchet: `d`, `fsharp`.
 | status | languages |
 |---|---:|
 | `green` | 50 |
-| `green_with_caveat` | 148 |
-| `wave2b_pending` | 6 |
+| `green_with_caveat` | 149 |
+| `wave2b_pending` | 5 |
 
 ## Known Gap Ledger
 
@@ -74,6 +74,7 @@ Held out of the ratchet: `d`, `fsharp`.
 - `wave3_pending_scala_implicits_strict_20260709T140125Z`
 - `wave3_pending_scala_strict_20260709T135935Z`
 - `wave3_pending_swift_strict_20260709T133944Z`
+- `wave3_pending_typescript_strict_20260709T141748Z`
 - `wave3_scoped_d_exclude_expressionsem_20260709T103336Z`
 - `wave3_scoped_fsharp_exclude_providedtypes_20260709T103723Z`
 - `wave3_scoped_groovy_exclude_pleac11_20260709T103612Z`


### PR DESCRIPTION
## Summary

Refreshes the Wave 3 TypeScript timing-grade perf row from a stale/partial entry to a fresh strict-basis measurement, while keeping the known correctness caveat open.

- Adds `wave3_pending_typescript_strict_20260709T141748Z` as the fresh largest-8 TypeScript perf_scan source.
- Moves TypeScript status from `wave2b_pending` to `green_with_caveat`, because the timing-grade sweep completed 8/8 with no perf_scan timeouts or truncation/status errors.
- Keeps `wave2b_pending: true` because `known_budget_class_gaps.webworker_generated_d_ts` remains an oracle/shape mismatch at the default budget. perf_scan `ok` is timing-grade only.
- Regenerates `wave3_sweep_status.{json,md}` so measured counts, status counts, and seed sources match the budget file.

## Evidence

- TypeScript strict scan: `cgo_harness/perf_scan/out/wave3_pending_typescript_strict_20260709T141748Z/scoreboard.json`
  - Docker artifact: `harness_out/docker/20260709T141751Z-wave3-pending-typescript-strict-ratchet`
  - Result: status `ok`, files `8/8`, Docker `oom_killed=false`.
  - Full axis: `8/8` ok, `0` Go timeouts, ratio_by_total `7.63x`, median `6.21x`, one >10x cliff (`tests/cases/fourslash/reallyLargeFile.ts`).
  - Noedit axis: `8/8` ok, `0` Go timeouts, ratio_by_total `0.0000248x`.

## Validation

- `jq empty cgo_harness/perf_scan/perf_ratio_budgets.json`
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_status -out-json perf_scan/wave3_sweep_status.json -out-md perf_scan/wave3_sweep_status.md`
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json -scoreboard perf_scan/out/wave3_pending_typescript_strict_20260709T141748Z/scoreboard.json -langs typescript`
- `cd cgo_harness && GOWORK=off go test ./cmd/perf_scan_budget ./cmd/perf_scan_status -count=1`
- `cd cgo_harness && GOWORK=off go run ./cmd/perf_scan_budget -budget perf_scan/perf_ratio_budgets.json`
- `git diff --check`

## Risk / Follow-up

This is metadata only. It explicitly does not close the TypeScript oracle gap: `webworker.generated.d.ts` still needs the default-budget byte-shape/correctness work tracked in the known-gap ledger.
