### PR TITLE
fix(recovery): restore doxygen and jsdoc byte-exact parity via scoped normalizers

### DIFF
--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -127,6 +127,8 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		normalizeDartCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "doxygen":
 		normalizeDoxygenCompatibility(ctx.root, ctx.source, ctx.lang)
+	case "jsdoc":
+		normalizeJsdocCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "dtd":
 		normalizeDTDCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "elixir":

--- a/parser_result_doxygen.go
+++ b/parser_result_doxygen.go
@@ -46,6 +46,7 @@ func normalizeDoxygenWholeBlockCommentError(root *Node, source []byte, lang *Lan
 		return
 	}
 	if doxygenErrorTreeHasRecoveredStructure(root, lang) {
+		retypeDoxygenRecoveredErrorRoot(root, source, lang)
 		return
 	}
 	replaceNodeChildrenUnfielded(root, nil)
@@ -65,4 +66,44 @@ func doxygenErrorTreeHasRecoveredStructure(root *Node, lang *Language) bool {
 		}
 	})
 	return found
+}
+
+// retypeDoxygenRecoveredErrorRoot mirrors C tree-sitter's shape for a
+// whole-input doxygen comment whose GLR recovery pass reconstructed real
+// structure (tags, descriptions, ...) but left it wrapped in a top-level
+// ERROR node instead of the `document` root C produces: C retypes that
+// wrapper to `document` and keeps only the recovered content, discarding the
+// leading ERROR-wrapped comment-open delimiter noise (a lexer hiccup around
+// `/**`/`/*!` that gets cleaned up once recovery locks onto the real grammar).
+// Only direct children that are themselves bare delimiter wrappers (ERROR,
+// _multiline_begin, _multiline_end, _singleline_begin) with no recovered
+// structure of their own are dropped; anything else — including an ERROR
+// child that happens to carry recovered structure nested inside it — is kept,
+// so real content is never silently discarded.
+func retypeDoxygenRecoveredErrorRoot(root *Node, source []byte, lang *Language) {
+	documentSym, ok := symbolByName(lang, "document")
+	if !ok {
+		return
+	}
+	total := resultChildCount(root)
+	kept := make([]*Node, 0, total)
+	for i := 0; i < total; i++ {
+		child := resultChildAt(root, i)
+		if child == nil {
+			continue
+		}
+		if doxygenStructuralDelimiterNodeTypes[child.Type(lang)] && !doxygenErrorTreeHasRecoveredStructure(child, lang) {
+			continue
+		}
+		kept = append(kept, child)
+	}
+	if len(kept) == 0 {
+		return
+	}
+	retagResultRoot(root, documentSym, symbolIsNamed(lang, documentSym))
+	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, kept))
+	root.startByte = 0
+	root.startPoint = Point{}
+	setNodeEndTo(root, uint32(len(source)), source)
+	refreshResultRootError(root)
 }

--- a/parser_result_jsdoc.go
+++ b/parser_result_jsdoc.go
@@ -1,0 +1,95 @@
+package gotreesitter
+
+// normalizeJsdocCompatibility applies narrow post-build tree rewrites that
+// keep gotreesitter's jsdoc output aligned with C tree-sitter.
+func normalizeJsdocCompatibility(root *Node, source []byte, lang *Language) {
+	normalizeJsdocNestedDocumentRecovery(root, source, lang)
+}
+
+// normalizeJsdocNestedDocumentRecovery mirrors C tree-sitter's shape for a
+// whole-input jsdoc comment (e.g. multiple `@tag` lines) whose GLR recovery
+// pass wraps the recovered tag structure in a *nested* `document` node —
+// with interstitial ERROR nodes around the inter-tag whitespace, and a
+// trailing zero-width MISSING `/` left dangling on the outer root — instead
+// of reducing everything flat into the root `document`, which is what C
+// tree-sitter (and gotreesitter itself, for the single-tag case that never
+// hits this recovery path) produces.
+//
+// It hoists the nested document's non-ERROR children in place of the nested
+// document (dropping the interstitial ERROR wrappers), then drops the
+// trailing zero-width MISSING `/` that is now redundant with the nested
+// document's own closing `/`, which was just promoted to the root.
+//
+// This is narrowly gated on the exact defect shape — a whole-input `document`
+// root flagged hasError with a nested `document` child — so ordinary jsdoc
+// comments (the common case: at most one `@tag`, never hitting this recovery
+// path) are left completely untouched.
+func normalizeJsdocNestedDocumentRecovery(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "jsdoc" || len(source) == 0 {
+		return
+	}
+	if root.Type(lang) != "document" || root.startByte != 0 || root.endByte != uint32(len(source)) || !root.HasError() {
+		return
+	}
+	total := resultChildCount(root)
+	if total == 0 {
+		return
+	}
+	nestedIndex := -1
+	for i := 0; i < total; i++ {
+		child := resultChildAt(root, i)
+		if child != nil && child.Type(lang) == "document" {
+			nestedIndex = i
+			break
+		}
+	}
+	if nestedIndex < 0 {
+		return
+	}
+	nested := resultChildAt(root, nestedIndex)
+	nestedTotal := resultChildCount(nested)
+
+	flattened := make([]*Node, 0, total-1+nestedTotal)
+	for i := 0; i < total; i++ {
+		if i == nestedIndex {
+			for j := 0; j < nestedTotal; j++ {
+				grandchild := resultChildAt(nested, j)
+				if grandchild == nil || grandchild.Type(lang) == "ERROR" {
+					continue
+				}
+				flattened = append(flattened, grandchild)
+			}
+			continue
+		}
+		if child := resultChildAt(root, i); child != nil {
+			flattened = append(flattened, child)
+		}
+	}
+
+	flattened = jsdocDropTrailingZeroWidthMissing(flattened)
+	if len(flattened) == 0 {
+		return
+	}
+
+	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(root.ownerArena, flattened))
+	root.startByte = 0
+	root.startPoint = Point{}
+	setNodeEndTo(root, uint32(len(source)), source)
+	refreshResultRootError(root)
+}
+
+// jsdocDropTrailingZeroWidthMissing drops a trailing synthetic MISSING token
+// (zero-width, unnamed) that GLR recovery appended after the outer document
+// ran out of real input to attach it to. Once the nested document is
+// unwrapped in place, its own closing `/` already occupies that structural
+// role, so the outer placeholder is redundant relative to C's flat shape.
+func jsdocDropTrailingZeroWidthMissing(nodes []*Node) []*Node {
+	for len(nodes) > 0 {
+		last := nodes[len(nodes)-1]
+		if last == nil || !last.IsMissing() || last.IsNamed() || last.startByte != last.endByte {
+			break
+		}
+		nodes = nodes[:len(nodes)-1]
+	}
+	return nodes
+}


### PR DESCRIPTION
## Summary

Bounded, language-scoped FALLBACK fix for two latent byte-exact parity regressions against the tree-sitter v0.25.0 C oracle: `doxygen` and `jsdoc`. Both were byte-exact at v0.20.8/v0.20.9; a shared GLR-recovery/root-framing regression in the rebased window `051c59e6..e29cbd70` broke whole-input comment recovery for both grammars independently of each other's ELS/normalizer changes.

- `doxygen` (`parser_result_doxygen.go`): when GLR recovery reconstructs real doxygen structure (tags, descriptions, ...) but leaves it wrapped in a whole-input `ERROR` root, retype the root `ERROR` → `document` and keep the recovered content, dropping only the leading `ERROR`-wrapped comment-open delimiter noise. Reuses the existing `doxygenErrorTreeHasRecoveredStructure` / `doxygenStructuralDelimiterNodeTypes` / `replaceNodeChildrenUnfielded` helpers. Result matches C exactly: `document`/2 `[tag[7-17], /[19-21]]`.
- `jsdoc` (new `parser_result_jsdoc.go`, dispatched from `parser_result_compat.go` with one additive line beside the existing doxygen case): when recovery wraps recovered tag structure in a nested `document` node (interstitial `ERROR` nodes around inter-tag whitespace, trailing zero-width MISSING `/`), hoist the nested document's real children into the root in place, drop the interstitial `ERROR` nodes, and drop the now-redundant trailing zero-width `/`. Result matches C exactly: `document`/7, flat.

Both normalizers are gated strictly on `lang.Name`, so they cannot affect any other grammar.

## Parity evidence

C oracle: tree-sitter v0.25.0, skip list bypassed (`GTS_PARITY_IGNORE_KNOWN_SKIPS=1`).

```
GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PARITY_MODE=exhaustive GTS_PARITY_IGNORE_KNOWN_SKIPS=1 \
GTS_PARITY_C_REF_BUILD_CACHE=<c-ref-cache> \
go test . -tags treesitter_c_parity -run '^TestParityFreshParse$/^(doxygen|jsdoc)$' -v -count=1
```
```
--- PASS: TestParityFreshParse (0.08s)
    --- PASS: TestParityFreshParse/doxygen (0.05s)
    --- PASS: TestParityFreshParse/jsdoc (0.03s)
```
0 node divergences for both (previously: doxygen root `Type`/`ChildCount` mismatch `ERROR` vs `document`; jsdoc root `ChildCount` 6 vs 7). `TestParityIncrementalParse` also passes clean for both.

**No-other-language-regression proof**: ran the full exhaustive `TestParityFreshParse` sweep (206 languages, skip list bypassed) on the base commit and again after this change, then diffed the PASS/FAIL verdict list. The *only* two lines that differ are:

```
< doxygen FAIL
> doxygen PASS
< jsdoc FAIL
> jsdoc PASS
```

Every other language's verdict is byte-identical before and after, including `norg`, which remains its own separate, already-known, unrelated failure (unaffected by this change either way).

## Build/test status

- `GOWORK=off go build ./...` — clean.
- `go test . -count=1 -short` — passes, modulo one pre-existing, unrelated, environment-speed-sensitive flake (`TestCSharpDesignerStyleBlockStaysBounded`, a 500ms wall-clock parse budget test) confirmed to fail identically on the base commit with none of this PR's changes applied — not caused by or related to this change.
- `go test ./grammars/... -count=1` — clean.

## Scope / follow-ups

This is the **bounded, language-scoped FALLBACK** fix. The primary fix — repairing the shared GLR-recovery/root-framing regression itself (bisected window `051c59e6..e29cbd70`) — is tracked separately and supersedes this once landed.

Follow-up once merged: remove `doxygen`/`jsdoc` from `knownDegradedStructural` in `cgo_harness/parity_cgo_test.go`. That file is intentionally left untouched in this PR to keep the diff scoped to the language-specific normalizers (`parser_result_doxygen.go`, new `parser_result_jsdoc.go`, one additive dispatch line in `parser_result_compat.go`).