### PR TITLE
fix(parity): flush stale known-degraded skips and assert skips still diverge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,7 +503,7 @@ jobs:
             --goflags -p=1 \
             --test-parallel 1 \
             --timeout 30m \
-            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$'
+            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityKnownDegradedStructuralStillDiverges$'
 
       - name: CGo Structural Parity Exhaustive (Incremental + GLR)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,20 +244,21 @@ jobs:
             run_exhaustive=true
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             git diff --name-only "${PR_BASE_SHA}...HEAD" > /tmp/changed-files.txt
-            if grep -Eq '^(parser_result_.*\.go|parser_recover_c.*\.go|parser_result_test/.*\.go)$' /tmp/changed-files.txt; then
+            exhaustive_pattern='^(parser_result_.*\.go|parser_recover_c.*\.go|parser_result_test/.*\.go|cgo_harness/(parity_cgo_test|parity_gate_ratchet_test)\.go)$'
+            if grep -Eq "$exhaustive_pattern" /tmp/changed-files.txt; then
               run_exhaustive=true
               {
                 echo "### Exhaustive parity trigger"
                 echo
-                echo "Running exhaustive CGo parity because this PR touches parser-result or C-recovery files:"
+                echo "Running exhaustive CGo parity because this PR touches parser-result, C-recovery, or parity-degradation gate files:"
                 echo
-                grep -E '^(parser_result_.*\.go|parser_recover_c.*\.go|parser_result_test/.*\.go)$' /tmp/changed-files.txt | sed 's/^/- `/' | sed 's/$/`/'
+                grep -E "$exhaustive_pattern" /tmp/changed-files.txt | sed 's/^/- `/' | sed 's/$/`/'
               } >> "$GITHUB_STEP_SUMMARY"
             else
               {
                 echo "### Exhaustive parity trigger"
                 echo
-                echo "No parser-result or C-recovery files changed; exhaustive CGo parity is skipped."
+                echo "No parser-result, C-recovery, or parity-degradation gate files changed; exhaustive CGo parity is skipped."
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           fi

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -36,14 +36,19 @@ var paritySkips = map[string]parityMeta{
 
 // knownDegradedStructural tracks currently non-parity structural languages
 // within the full-coverage gate. Keep this list shrinking over time.
+//
+// Every entry here MUST still actually diverge from the C reference parser.
+// TestParityKnownDegradedStructuralStillDiverges (parity_gate_ratchet_test.go)
+// re-parses each entry's smoke sample against the C oracle in the exhaustive
+// lane and fails the build if a listed language unexpectedly passes, so this
+// map can only shrink truthfully going forward.
 var knownDegradedStructural = map[string]string{
-	"agda":    "named wrapper/runtime alias shape still diverges from C reference",
-	"apex":    "named wrapper/runtime alias shape still diverges from C reference",
-	"doxygen": "tier row IV-unknown: whole-block comment/error-root compatibility remains non-clean",
-	"hare":    "fresh parse structural parity still diverges from C reference",
-	"jsdoc":   "tier row IV-unknown: C-recovery/default ELS smoke sample still diverges from C reference",
-	"norg":    "tier row IV-scanner: scanner/version structural shape still diverges from C reference",
-	"rst":     "fresh parse structural parity still diverges from C reference",
+	// norg: fresh parse diverges from the C reference by 4 nodes — the Go
+	// parser collapses `_word` hidden wrapper nodes to ChildCount=0 where the
+	// C reference keeps a single child (see TestParityFreshParse/norg for the
+	// live divergence dump). Tracked as a genuine, unfixed scanner/version
+	// structural-shape gap; not yet assigned a fix owner.
+	"norg": "fresh parse structural parity still diverges from C reference (4 node divergences: _word hidden-wrapper ChildCount go=0 c=1)",
 }
 
 // knownDegradedNoErrorClean preserves no-error coverage for structural backlog

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -19,6 +19,16 @@ const (
 	maxParitySkips                = 0
 )
 
+// allowedKnownDegradedStructural is the membership half of the structural
+// skip-list ratchet. The numeric ceiling above prevents growth, while this
+// allow-list prevents replacing an approved exemption with a newly degraded
+// language at the same count. When a verified fix removes an exemption, the
+// same tightening change must remove it here too; additions or renames require
+// an explicit policy change in both places.
+var allowedKnownDegradedStructural = map[string]struct{}{
+	"norg": {},
+}
+
 // TestParityGateCoverageRatchet prevents silent narrowing of correctness gates.
 // Update these thresholds only when intentionally tightening/loosening policy.
 func TestParityGateCoverageRatchet(t *testing.T) {
@@ -30,6 +40,16 @@ func TestParityGateCoverageRatchet(t *testing.T) {
 	}
 	if got := len(knownDegradedStructural); got > maxKnownDegradedStructural {
 		t.Fatalf("knownDegradedStructural grew: got=%d max=%d", got, maxKnownDegradedStructural)
+	}
+	for name := range knownDegradedStructural {
+		if _, ok := allowedKnownDegradedStructural[name]; !ok {
+			t.Fatalf("knownDegradedStructural added or renamed unapproved entry %q; this ratchet permits removals only", name)
+		}
+	}
+	for name := range allowedKnownDegradedStructural {
+		if _, ok := knownDegradedStructural[name]; !ok {
+			t.Fatalf("allowedKnownDegradedStructural contains stale entry %q; remove it with the verified skip-list tightening", name)
+		}
 	}
 	if got := len(knownDegradedNoErrorClean); got > maxKnownDegradedNoErrorClean {
 		t.Fatalf("knownDegradedNoErrorClean grew: got=%d max=%d", got, maxKnownDegradedNoErrorClean)
@@ -130,13 +150,17 @@ func TestParityKnownDegradedStructuralStillDiverges(t *testing.T) {
 				t.Fatalf("[%s] C parser SetLanguage error: %v", tc.name, err)
 			}
 			cTree := cParser.Parse(src, nil)
-			if cTree == nil || cTree.RootNode() == nil {
+			if cTree == nil {
 				t.Fatalf("[%s] C reference parser returned nil tree", tc.name)
 			}
 			defer cTree.Close()
+			cRoot := cTree.RootNode()
+			if cRoot == nil {
+				t.Fatalf("[%s] C reference parser returned nil root node", tc.name)
+			}
 
 			var errs []string
-			compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+			compareNodes(goTree.RootNode(), goLang, cRoot, "root", &errs)
 			if len(errs) == 0 {
 				t.Fatalf("stale skip: %q is listed in knownDegradedStructural but its fresh parse now matches the C reference exactly (0 node divergences) — remove %q from knownDegradedStructural", name, name)
 			}

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -2,13 +2,18 @@
 
 package cgoharness
 
-import "testing"
+import (
+	"sort"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
 
 const (
 	// Ratchets: these should only move in the "stricter" direction over time.
 	minCuratedStructuralLanguages = 206
 	minCuratedHighlightLanguages  = 200
-	maxKnownDegradedStructural    = 14
+	maxKnownDegradedStructural    = 1
 	maxKnownDegradedNoErrorClean  = 1
 	maxKnownDegradedHighlight     = 49
 	maxParitySkips                = 0
@@ -39,5 +44,103 @@ func TestParityGateCoverageRatchet(t *testing.T) {
 	}
 	if got := len(paritySkips); got > maxParitySkips {
 		t.Fatalf("paritySkips grew: got=%d max=%d", got, maxParitySkips)
+	}
+}
+
+// parityCaseByName looks up a parityCases entry by language name. Returns
+// ok=false if the language has no registry/smoke-sample entry at all, which
+// itself indicates a dead knownDegradedStructural entry.
+func parityCaseByName(name string) (parityCase, bool) {
+	for _, tc := range parityCases {
+		if tc.name == name {
+			return tc, true
+		}
+	}
+	return parityCase{}, false
+}
+
+// TestParityKnownDegradedStructuralStillDiverges is the "stale skip" ratchet.
+//
+// TestParityGateCoverageRatchet above only stops knownDegradedStructural from
+// GROWING past its ceiling; it never confirms the entries it already
+// contains still describe a real divergence. That one-directional check is
+// exactly how the list went stale in the first place: agda, apex, doxygen,
+// hare, jsdoc, and rst all sat skipped long after their fresh-parse output
+// matched (or came to match) the C reference exactly, because nothing ever
+// re-verified them.
+//
+// For every remaining knownDegradedStructural entry, this test bypasses the
+// skip and re-parses the language's smoke sample with both gotreesitter and
+// the pinned C reference parser (the same comparison TestParityFreshParse
+// performs), then requires at least one real node divergence. A language
+// that now parses byte-for-byte identically to the C reference must be
+// removed from knownDegradedStructural — this test fails loudly instead of
+// letting the skip rot silently.
+//
+// Requires the C reference toolchain/cache, so — like the rest of the
+// structural gate — it only runs in the exhaustive parity lane:
+//
+//	GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PARITY_MODE=exhaustive \
+//	GTS_PARITY_C_REF_BUILD_CACHE=<cache dir> \
+//	go test . -tags treesitter_c_parity -run TestParityKnownDegradedStructuralStillDiverges -v
+func TestParityKnownDegradedStructuralStillDiverges(t *testing.T) {
+	parityRequireExhaustive(t, "TestParityKnownDegradedStructuralStillDiverges")
+
+	names := make([]string, 0, len(knownDegradedStructural))
+	for name := range knownDegradedStructural {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			if parityLanguageExcluded(name) {
+				t.Skipf("[%s] excluded via GTS_PARITY_SKIP_LANGS", name)
+			}
+			parityMaybeParallel(t)
+			scheduleParityMemoryScavenge(t)
+
+			tc, ok := parityCaseByName(name)
+			if !ok {
+				t.Fatalf("knownDegradedStructural[%q] has no matching language registry entry (dead skip-list entry, remove it)", name)
+			}
+
+			cLang, err := ParityCLanguage(tc.name)
+			if err != nil {
+				if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+					t.Skipf("[%s] skip C reference parser: %s", tc.name, skipReason)
+				}
+				t.Fatalf("[%s] load C parser from languages.lock: %v", tc.name, err)
+			}
+
+			src := normalizedSource(tc.name, tc.source)
+			goTree, goLang, err := parseWithGo(tc, src, nil)
+			if err != nil {
+				t.Fatalf("[%s] gotreesitter parse error: %v", tc.name, err)
+			}
+			defer releaseGoTree(goTree)
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				if skipReason := parityReferenceSkipReason(err); skipReason != "" {
+					t.Skipf("[%s] skip C reference parser SetLanguage: %s", tc.name, skipReason)
+				}
+				t.Fatalf("[%s] C parser SetLanguage error: %v", tc.name, err)
+			}
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatalf("[%s] C reference parser returned nil tree", tc.name)
+			}
+			defer cTree.Close()
+
+			var errs []string
+			compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+			if len(errs) == 0 {
+				t.Fatalf("stale skip: %q is listed in knownDegradedStructural but its fresh parse now matches the C reference exactly (0 node divergences) — remove %q from knownDegradedStructural", name, name)
+			}
+			t.Logf("[%s] confirmed live divergence: %d node mismatch(es)", name, len(errs))
+		})
 	}
 }


### PR DESCRIPTION
Flushes the stale entries from the parity gate's known-degraded skip list and adds an assertion so the list can never silently go stale again. Follow-up noted in #207.

## Verification (exhaustive parity, skips bypassed, current main)
| language | verdict |
|---|---|
| doxygen | PASS (fixed by #207) |
| jsdoc | PASS (fixed by #207) |
| agda / apex / hare / rst | PASS (stale skips) |
| norg | FAIL — 4 node divergences (`_word` hidden-wrapper ChildCount) |

## Changes
- `knownDegradedStructural` flushed to just `norg` (re-annotated with live divergence count).
- New `TestParityKnownDegradedStructuralStillDiverges`: in the exhaustive lane, every remaining skip-listed language is re-parsed against the C oracle and the build fails with `stale skip: remove <lang>` if it unexpectedly passes. Validated by fault-injection (reinserting agda → intended failure).
- `maxKnownDegradedStructural` tightened 14 → 1 (future re-adds are explicit: bump + entry).
- CI wiring: the assertion added to the exhaustive fresh-parse lane's `--run` filter (review follow-up — without this the assertion never executed in CI).

## Result
Full exhaustive sweep: **205 pass / 1 skip (norg) / 0 fail.** All six flushed languages now hard-fail CI on regression across fresh, incremental, and no-errors gates (adversarially verified: no alternate skip path exempts them).