### PR TITLE
optimize(grammargen): memoize skip-extra lex preemption checks

### DIFF
--- a/grammargen/diagnostics.go
+++ b/grammargen/diagnostics.go
@@ -320,11 +320,34 @@ func buildMissingRecoveryTokensFuncWithContext(ctx context.Context, tables *LRTa
 		}
 		return false
 	}
+	// preemptsSkippedTerminalExtra depends only on `lookahead` (patternsBySymbol
+	// and skipExtras are fixed for the lifetime of this closure), so its result
+	// is identical for every state that queries the same lookahead. Without
+	// this cache, addSeen re-invokes preemptsSkippedTerminalExtra (and the NFA
+	// + lex DFA rebuild inside recoveryLookaheadPreemptsDirectTerminal it
+	// performs per skipExtras entry) once per state per lookahead, which
+	// dominates compute_lex_modes on large grammars (e.g. c_sharp: 19564
+	// states x up to tokenCount-1 lookaheads). Memoizing by lookahead alone
+	// mirrors preemptionCache above and is safe here for the same reason:
+	// callers of the returned closure run sequentially within a single
+	// buildMissingRecoveryTokensFuncWithContext invocation (computeLexModes
+	// iterates states in a plain for-loop, no goroutines), and this map is
+	// local to that invocation, so there is no cross-invocation or concurrent
+	// access to guard against.
+	skipExtraPreemptionCache := make(map[int]bool)
+	preemptsSkippedTerminalExtraCached := func(lookahead int) bool {
+		if preempts, ok := skipExtraPreemptionCache[lookahead]; ok {
+			return preempts
+		}
+		preempts := preemptsSkippedTerminalExtra(ctx, patternsBySymbol, skipExtras, lookahead)
+		skipExtraPreemptionCache[lookahead] = preempts
+		return preempts
+	}
 	addSeen := func(state int, seen map[int]bool, lookahead int) {
 		if preemptsDirectTerminalShift(state, lookahead) {
 			return
 		}
-		if preemptsSkippedTerminalExtra(ctx, patternsBySymbol, skipExtras, lookahead) {
+		if preemptsSkippedTerminalExtraCached(lookahead) {
 			return
 		}
 		seen[lookahead] = true

--- a/grammargen/missing_recovery_lexmode_test.go
+++ b/grammargen/missing_recovery_lexmode_test.go
@@ -451,3 +451,82 @@ func TestMissingRecoveryTokensStillAddSameFirstRuneNonPreemptingLookahead(t *tes
 		t.Fatalf("missing recovery tokens for same-first-rune non-preempting lookahead = %v, want %v", got, want)
 	}
 }
+
+// TestMissingRecoveryTokensSkippedExtraPreemptionCacheConsistentAcrossStates
+// guards the skip-extra preemption memoization added to
+// buildMissingRecoveryTokensFuncWithContext (a map in the same closure scope
+// as preemptionCache, keyed by lookahead alone since preemptsSkippedTerminalExtra
+// depends only on lookahead for a fixed patternsBySymbol/skipExtras). The
+// cache is shared across every state queried from the returned closure, so
+// this test builds TWO independent "missing token" origins (state 0 and
+// state 20) that both resolve the SAME two lookaheads — one skip-extra-
+// preempted (newline, shadowed by the whitespace extra exactly like
+// TestMissingRecoveryTokensDoNotAddLookaheadOverSkippedExtra above) and one
+// not preempted (comma) — and checks both origins agree with the correct,
+// uncached answer regardless of which state's query populates the cache
+// first. A cache keyed or scoped incorrectly (e.g. accidentally reused
+// across distinct lookaheads, or not actually shared and silently
+// re-deriving a stale/wrong answer) would make one of the two origins
+// diverge from the other.
+func TestMissingRecoveryTokensSkippedExtraPreemptionCacheConsistentAcrossStates(t *testing.T) {
+	const (
+		tokenCount = 6
+		missingA   = 1
+		missingB   = 2
+		whitespace = 3
+		newline    = 4
+		comma      = 5
+	)
+
+	tables := &LRTables{
+		StateCount: 24,
+		ActionTable: map[int]map[int][]lrAction{
+			// Origin A: state 0 --missingA--> state 1, which directly shifts
+			// both lookaheads.
+			0: {
+				missingA: {{kind: lrShift, state: 1}},
+			},
+			1: {
+				newline: {{kind: lrShift, state: 2}},
+				comma:   {{kind: lrShift, state: 3}},
+			},
+			// Origin B: an independent copy rooted at state 20.
+			20: {
+				missingB: {{kind: lrShift, state: 21}},
+			},
+			21: {
+				newline: {{kind: lrShift, state: 22}},
+				comma:   {{kind: lrShift, state: 23}},
+			},
+		},
+		ExtraChainStateStart: -1,
+	}
+	patterns := []TerminalPattern{
+		{SymbolID: whitespace, Rule: Pat(`\s`), Priority: 2000},
+		{SymbolID: newline, Rule: Pat(`\r?\n`), Priority: -500, Immediate: true},
+		{SymbolID: comma, Rule: Str(",")},
+	}
+	skipExtras := map[int]bool{whitespace: true}
+	want := []int{comma}
+
+	// Populate the shared skip-extra preemption cache from origin A first,
+	// then reuse it from origin B.
+	fnAB := buildMissingRecoveryTokensFunc(tables, tokenCount, patterns, skipExtras)
+	if got := fnAB(0); !reflect.DeepEqual(got, want) {
+		t.Fatalf("origin A (populates cache) missing recovery tokens = %v, want %v", got, want)
+	}
+	if got := fnAB(20); !reflect.DeepEqual(got, want) {
+		t.Fatalf("origin B (reuses cache) missing recovery tokens = %v, want %v", got, want)
+	}
+
+	// Reverse the query order with a fresh function/cache so the memoized
+	// skip-extra preemption result cannot depend on which state populates it
+	// first.
+	fnBA := buildMissingRecoveryTokensFunc(tables, tokenCount, patterns, skipExtras)
+	if got := fnBA(20); !reflect.DeepEqual(got, want) {
+		t.Fatalf("origin B (populates cache) missing recovery tokens = %v, want %v", got, want)
+	}
+	if got := fnBA(0); !reflect.DeepEqual(got, want) {
+		t.Fatalf("origin A (reuses cache) missing recovery tokens = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes the c_sharp grammargen generation-timeout blocker per the RCA at `GEN_COST_RCA.md` (c_sharp section): `preemptsSkippedTerminalExtra` was recomputed (full NFA + lex-DFA rebuild) on every `(state, lookahead)` pair inside `buildMissingRecoveryTokensFuncWithContext`, even though its result depends only on `lookahead`. The sibling direct-preemption path already had this memoization (`preemptionCache`); this mirrors that pattern for the skip-extra path.
- Pure semantics-preserving caching: `skipExtraPreemptionCache` is a closure-local `map[int]bool` keyed by `lookahead`, populated on first use per lookahead within a single `buildMissingRecoveryTokensFuncWithContext` invocation. `computeLexModes` drives this closure from a plain sequential `for state` loop (no goroutines), so no concurrency guard is needed.

## Before / after (wall clock, `grammargen emit -json <grammar.json> -bin out.bin`)
| language | before | after | speedup |
|---|---|---|---|
| c_sharp | **times out (>300s, never completes)** | **21.3s / 20.4s (2 runs)** | unblocked |
| java | 33.9s | 3.3s | 10.3x |
| python | 78.9s | 5.3s | 14.9x |
| javascript | 38.4s | 16.5s | 2.3x |
| sql | 16.2s | 5.4s | 3.0x |
| regex | 5.4s | 1.4s | 3.8x |
| go | 4.1s | 1.1s | 3.9x |

c_sharp and java both speed up as the RCA predicted.

## Byte-identical proof (origin/main vs this branch, single generation run each)
| language | SHA-256 (before == after) |
|---|---|
| java | `49c5c451f0d2ebdb62fd1c8484c84d01dfe67e2938d22180caf3f3a212365a49` |
| javascript | `bcc3495c4905823d0d8d88d9bd7f55ceee1f63f9f6f855b028b6c718d1642a81` |
| python | `1b9de99a1531e3600e2892070d8c1622c8491100f30850095c25f1ca32053848` |
| go | `5a6173436c4217cc047104e23d05f2826aa424c91afa381b76f65dd1ab94fcf1` |
| regex | `d5156a4b08e42baeb11f6b19dcc54326589af3da9de16319c36625689b4d845c` |
| sql | `2e58832d1cbba0ecf4b283aad80fbb35415c4cce69446ed39e2f717ac947e270` |

All six match exactly. c_sharp has no origin/main baseline to diff against (it never completed generation before this fix).

## c_sharp determinism note (read before merging)
Running c_sharp generation twice with this fix produces gzip blobs with **different SHA-256** (byte counts differ by ~13 bytes; the gzip streams diverge more after that). This is **not** a semantic change from this diff. Root-caused via phase-by-phase canonical (order-independent) hashing across two independent in-process generation runs:

- `build_lr` (19564 states), `resolve_conflicts`, `add_nonterminal_extra_chains` (80490 states): byte-identical
- `compute_lex_modes` (882 lex modes) — the exact phase this diff touches: byte-identical
- `build_lex_dfa` (101375 states), `build_keyword_dfa` (586 states): byte-identical
- Decoded `Language.LargeStateGotos` (1694 entries) sorted-canonical content: byte-identical
- Raw gob encoding of `Language` **with** `LargeStateGotos`: **differs** between runs
- Raw gob encoding of `Language` **with `LargeStateGotos` zeroed out**: byte-identical

`Language.LargeStateGotos` is an exported `map[uint64]StateID` gob-encoded directly by `encodeLanguageBlob`. `encoding/gob`'s map encoder (`GOROOT/src/encoding/gob/encode.go: encodeMap`) iterates via plain `mv.MapRange()` with no key sort, so two encodings of an identical map can (and did) differ byte-for-byte. This field is only populated for grammars whose remapped LR state count exceeds `uint16` (65535) — c_sharp is the only grammar in this repo's corpus that crosses that threshold (80,491 states), and until this fix it never reached the encoding step at all, so this was never observable. It does not affect parsing correctness (decoded map lookup behavior is order-independent).

This is a **separate, pre-existing bug**, unrelated to this diff, living in `grammargen/encode.go` / `language.go` (parser-runtime territory, intentionally not touched here). Recommend filing separately — fix is straightforward (sort `LargeStateGotos` keys before gob encoding, or wire it as a sorted slice-of-pairs).

## c_sharp parity note (also pre-existing, also newly visible)
Running the existing `TestCSharp*Parity` suite (`grammargen/csharp_parity_test.go`) against this fix — the first time these tests have ever been able to complete generation (previously always failing on the 90s per-test `generateWithTimeout`) — passes 11/14, with 3 pre-existing grammar-construction gaps newly visible:
- `TestCSharpAttributedTopLevelDeclarationsParity/named_attribute_arguments` — `name = value` attribute args parse as `assignment_expression` instead of the dedicated named-argument shape
- `TestCSharpTopLevelChunkParity/top_level_local_function_switch_patterns` — `case int when ...:` type-pattern switch arms
- `TestCSharpUnicodeIdentifierParity` — a Unicode identifier statement misparses

All three inputs are well-formed, complete C# (no missing/incomplete tokens), so they never exercise the missing-token-recovery widening this diff touches — these look like independent conflict-resolution/lexing gaps elsewhere in c_sharp's grammar construction, not caused by this change. Flagging for a separate follow-up; not fixed here.

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `go test ./grammargen/... -run 'Keyword|Reserved|Recovery|LexMode|Missing' -count=1` — green
- [x] New regression test `TestMissingRecoveryTokensSkippedExtraPreemptionCacheConsistentAcrossStates` — asserts the memoized skip-extra preemption cache gives the same correct answer regardless of which of two independent states populates vs. reuses it
- [x] `go run ./cmd/grammargen emit -json c_sharp/grammar.json -bin out.bin` completes in ~21s, twice, well under the 300s budget
- [x] Byte-identical blobs (java/go/javascript/python/regex/sql) vs origin/main
