### PR TITLE
fix(grammargen): make language blob encoding deterministic

### DIFF
--- a/cmd/ts2go/embedded.go
+++ b/cmd/ts2go/embedded.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/gob"
 	"fmt"
 	"strings"
 
@@ -308,18 +305,10 @@ func convertLexStates(src []LexStateEntry) []gotreesitter.LexState {
 	return dst
 }
 
-// EncodeLanguageBlob serializes a language using gob+gzip.
+// EncodeLanguageBlob serializes a language using the shared deterministic
+// runtime format, including the versioned LargeStateGotos trailer when needed.
 func EncodeLanguageBlob(lang *gotreesitter.Language) ([]byte, error) {
-	var out bytes.Buffer
-	gzw := gzip.NewWriter(&out)
-	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
-		_ = gzw.Close()
-		return nil, fmt.Errorf("encode language blob: %w", err)
-	}
-	if err := gzw.Close(); err != nil {
-		return nil, fmt.Errorf("finalize language blob: %w", err)
-	}
-	return out.Bytes(), nil
+	return gotreesitter.EncodeLanguageBlob(lang)
 }
 
 // GenerateEmbeddedGo produces a small wrapper that lazy-loads an embedded blob.

--- a/cmd/ts2go/embedded_blob_test.go
+++ b/cmd/ts2go/embedded_blob_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func ts2goMapBearingLanguage() *gotreesitter.Language {
+	largeGotos := make(map[uint64]gotreesitter.StateID, 2048)
+	for i := 0; i < 2048; i++ {
+		key := uint64(70_000+i)<<32 | uint64(i%257)
+		largeGotos[key] = gotreesitter.StateID(80_000 + i*3)
+	}
+	return &gotreesitter.Language{
+		Name:            "ts2go_map_bearing",
+		SymbolNames:     []string{"end", "identifier", "class_declaration"},
+		StateCount:      90_000,
+		LargeStateGotos: largeGotos,
+	}
+}
+
+func TestEncodeLanguageBlobDeterministicMapBearingRoundTrip(t *testing.T) {
+	lang := ts2goMapBearingLanguage()
+	first, err := EncodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("EncodeLanguageBlob: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("EncodeLanguageBlob returned empty payload")
+	}
+
+	for i := 0; i < 20; i++ {
+		got, err := EncodeLanguageBlob(lang)
+		if err != nil {
+			t.Fatalf("EncodeLanguageBlob run %d: %v", i, err)
+		}
+		if !bytes.Equal(first, got) {
+			t.Fatalf("EncodeLanguageBlob run %d differs from run 0", i)
+		}
+	}
+
+	loaded, err := gotreesitter.LoadLanguage(first)
+	if err != nil {
+		t.Fatalf("gotreesitter.LoadLanguage: %v", err)
+	}
+	if loaded.Name != lang.Name {
+		t.Fatalf("loaded Name = %q, want %q", loaded.Name, lang.Name)
+	}
+	if len(loaded.LargeStateGotos) != len(lang.LargeStateGotos) {
+		t.Fatalf("loaded LargeStateGotos = %d entries, want %d", len(loaded.LargeStateGotos), len(lang.LargeStateGotos))
+	}
+	for key, want := range lang.LargeStateGotos {
+		if got := loaded.LargeStateGotos[key]; got != want {
+			t.Fatalf("loaded LargeStateGotos[%d] = %d, want %d", key, got, want)
+		}
+	}
+}

--- a/docs/authoring-languages.md
+++ b/docs/authoring-languages.md
@@ -39,7 +39,7 @@ The relevant functions, all public:
 |---|---|---|
 | `grammargen.ImportGrammarJSON(data []byte) (*Grammar, error)` | `grammargen/import_grammarjson.go` | Parse a resolved `grammar.json` (the output of `tree-sitter generate`) into the grammar IR. Rules, extras, conflicts, externals, inline, word, precedences, reserved sets, supertypes are all imported. |
 | `grammargen.GenerateLanguage(g *Grammar) (*gotreesitter.Language, error)` | `grammargen/encode.go` | Compile the IR into runtime parse tables. |
-| `grammargen.GenerateLanguageAndBlob(g *Grammar) (*gotreesitter.Language, []byte, error)` | `grammargen/encode.go` | Same, plus the serialized gob+gzip blob in one pass. `...WithContext` variants exist for cancellation. |
+| `grammargen.GenerateLanguageAndBlob(g *Grammar) (*gotreesitter.Language, []byte, error)` | `grammargen/encode.go` | Same, plus a serialized language blob in one pass. Blobs without `LargeStateGotos` retain the legacy gob+gzip format; map-bearing blobs use a deterministic versioned envelope. Load either form with `gotreesitter.LoadLanguage`. `...WithContext` variants exist for cancellation. |
 | `grammargen.EmitGrammarGo(g *Grammar, pkgName, funcName string) ([]byte, error)` | `grammargen/emit_grammar_go.go` | Emit Go DSL source that reconstructs the grammar (useful for vendoring the grammar as reviewable Go code instead of JSON). |
 | `gotreesitter.LoadLanguage(data []byte) (*Language, error)` | `load_language.go` | Deserialize a blob at runtime. The only function needed to load a pre-compiled grammar — no grammargen import, no registry. |
 | `grammars.LoadLanguage(name string, data []byte)` | `grammars/embedded_loader.go` | Like the above, but also attaches any external scanner / external lex-state tables registered for `name` in the `grammars` registry. |
@@ -437,11 +437,16 @@ above. You need a COBOL-class grammar before state budgets are your problem.
 
 Hard-learned; treat as policy.
 
-- A blob is `gob`+`gzip` of the `Language` struct. Gob tolerates field drift
-  silently: fields added since the blob was written decode as zero values,
-  removed fields are skipped. A stale blob usually still *loads* — and then
-  misparses or loses features (a pre-0.20.8 blob has `WantsForest == false`
-  forever, older blobs lack `ZeroWidthTokens`, `ConflictPolicies`, ...).
+- A blob without `LargeStateGotos` uses the legacy gob+gzip format. A blob with
+  a non-empty `LargeStateGotos` map uses a deterministic versioned envelope
+  containing the gzip payload and a sorted map trailer. Always load either
+  form with `gotreesitter.LoadLanguage` (or `grammars.LoadLanguage`) instead of
+  assuming the bytes begin with a gzip header. The underlying gob data
+  tolerates field drift silently: fields added since the blob was written
+  decode as zero values, and removed fields are skipped. A stale blob usually
+  still *loads* — and then misparses or loses features (a pre-0.20.8 blob has
+  `WantsForest == false` forever, older blobs lack `ZeroWidthTokens`,
+  `ConflictPolicies`, ...).
   `Language.CompatibleWithRuntime()` only checks the tree-sitter ABI version
   (`LanguageVersion`, 0 = unknown = compatible); it does **not** detect
   engine/blob skew.

--- a/grammargen/blob_encode_determinism_test.go
+++ b/grammargen/blob_encode_determinism_test.go
@@ -110,6 +110,19 @@ func TestEncodeDecodeLanguageBlobRoundTripWithLargeStateGotos(t *testing.T) {
 	}
 }
 
+// A runtime from before the envelope change calls gzip.NewReader on the blob
+// directly. Trailer-bearing blobs must fail there rather than decode a
+// Language whose LargeStateGotos map was cleared from the gob payload.
+func TestEncodeLanguageBlobWithLargeStateGotosRejectedByLegacyGzipLoader(t *testing.T) {
+	blob, err := encodeLanguageBlob(csharpLikeLanguage())
+	if err != nil {
+		t.Fatalf("encodeLanguageBlob: %v", err)
+	}
+	if _, err := gzip.NewReader(bytes.NewReader(blob)); err == nil {
+		t.Fatal("legacy gzip-first loader accepted a trailer-bearing blob")
+	}
+}
+
 // oldEncodeLanguageBlob is a frozen copy of encodeLanguageBlob exactly as it
 // existed before the LargeStateGotos determinism fix: a single unconditional
 // gob.Encode of lang, with no clone and no trailer. It exists only to prove

--- a/grammargen/blob_encode_determinism_test.go
+++ b/grammargen/blob_encode_determinism_test.go
@@ -1,0 +1,228 @@
+package grammargen
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/gob"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// syntheticLargeStateGotos returns a map shaped like what
+// grammargen/assemble.go's recordLargeGoto populates for a grammar whose
+// remapped LR state count crosses uint16 (today: only c_sharp). n entries is
+// enough to make Go's randomized map iteration (internal/runtime/maps'
+// Iter.Init calls rand() on every range, not just once per process) produce
+// different orders across repeated ranges with overwhelming probability, so
+// this reproduces the bug cheaply without generating a real large grammar.
+func syntheticLargeStateGotos(n int) map[uint64]gotreesitter.StateID {
+	m := make(map[uint64]gotreesitter.StateID, n)
+	for i := 0; i < n; i++ {
+		state := uint64(70000 + i)
+		sym := uint64(i % 512)
+		key := state<<32 | sym
+		m[key] = gotreesitter.StateID(80000 + i*3)
+	}
+	return m
+}
+
+func csharpLikeLanguage() *gotreesitter.Language {
+	return &gotreesitter.Language{
+		Name:            "c_sharp_like",
+		SymbolNames:     []string{"end", "identifier", "class_declaration"},
+		StateCount:      90000,
+		LargeStateGotos: syntheticLargeStateGotos(4000),
+	}
+}
+
+// TestEncodeLanguageBlobDeterministicWithLargeStateGotos is the core
+// regression test: encoding the same Language repeatedly must produce
+// byte-identical blobs. Before the fix, gob's map codec iterated
+// LargeStateGotos via reflect's randomized MapRange, so this failed
+// intermittently (with overwhelming probability given 4000 entries).
+func TestEncodeLanguageBlobDeterministicWithLargeStateGotos(t *testing.T) {
+	lang := csharpLikeLanguage()
+
+	first, err := encodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("encodeLanguageBlob: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("expected non-empty blob")
+	}
+
+	const runs = 25
+	for i := 0; i < runs; i++ {
+		got, err := encodeLanguageBlob(lang)
+		if err != nil {
+			t.Fatalf("encodeLanguageBlob run %d: %v", i, err)
+		}
+		if !bytes.Equal(first, got) {
+			t.Fatalf("run %d: blob bytes differ from run 0 (len %d vs %d) -- gob map-iteration nondeterminism leaked through", i, len(got), len(first))
+		}
+	}
+}
+
+// TestEncodeLanguageBlobDoesNotMutateOriginalLanguage guards the
+// GenerateLanguageAndBlob contract: the *Language returned to callers must
+// keep its fully populated LargeStateGotos map, since encodeLanguageBlob
+// must not mutate its input (it gob-encodes a shallow copy instead).
+func TestEncodeLanguageBlobDoesNotMutateOriginalLanguage(t *testing.T) {
+	lang := csharpLikeLanguage()
+	want := len(lang.LargeStateGotos)
+
+	if _, err := encodeLanguageBlob(lang); err != nil {
+		t.Fatalf("encodeLanguageBlob: %v", err)
+	}
+
+	if got := len(lang.LargeStateGotos); got != want {
+		t.Fatalf("encodeLanguageBlob mutated caller's Language: LargeStateGotos now has %d entries, want %d", got, want)
+	}
+}
+
+// TestEncodeDecodeLanguageBlobRoundTripWithLargeStateGotos exercises the full
+// encodeLanguageBlob -> decodeLanguageBlob path and asserts LargeStateGotos
+// survives with identical content.
+func TestEncodeDecodeLanguageBlobRoundTripWithLargeStateGotos(t *testing.T) {
+	lang := csharpLikeLanguage()
+
+	blob, err := encodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("encodeLanguageBlob: %v", err)
+	}
+
+	decoded, err := decodeLanguageBlob(blob)
+	if err != nil {
+		t.Fatalf("decodeLanguageBlob: %v", err)
+	}
+
+	if decoded.Name != lang.Name {
+		t.Fatalf("Name = %q, want %q", decoded.Name, lang.Name)
+	}
+	if len(decoded.LargeStateGotos) != len(lang.LargeStateGotos) {
+		t.Fatalf("LargeStateGotos has %d entries, want %d", len(decoded.LargeStateGotos), len(lang.LargeStateGotos))
+	}
+	for k, want := range lang.LargeStateGotos {
+		if got := decoded.LargeStateGotos[k]; got != want {
+			t.Fatalf("LargeStateGotos[%d] = %d, want %d", k, got, want)
+		}
+	}
+}
+
+// oldEncodeLanguageBlob is a frozen copy of encodeLanguageBlob exactly as it
+// existed before the LargeStateGotos determinism fix: a single unconditional
+// gob.Encode of lang, with no clone and no trailer. It exists only to prove
+// (mechanically, not just by inspection) that the fixed encodeLanguageBlob
+// produces byte-identical output to the pre-fix implementation whenever
+// LargeStateGotos is empty -- i.e. for every language but c_sharp today.
+func oldEncodeLanguageBlob(lang *gotreesitter.Language) ([]byte, error) {
+	var out bytes.Buffer
+	gzw := gzip.NewWriter(&out)
+	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
+		_ = gzw.Close()
+		return nil, err
+	}
+	if err := gzw.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+// TestEncodeLanguageBlobByteIdenticalWhenLargeStateGotosEmpty is the VERIFY
+// #3 proof: languages that never populate LargeStateGotos (everything but
+// c_sharp) must produce byte-identical blobs before and after this fix. This
+// compares the fixed encodeLanguageBlob against a frozen copy of the exact
+// pre-fix implementation across a representative sample of realistic
+// Language shapes, which is a stronger guarantee than spot-checking a
+// handful of real blob files: it holds for every Language with an empty
+// LargeStateGotos, not just the three sampled in CI.
+func TestEncodeLanguageBlobByteIdenticalWhenLargeStateGotosEmpty(t *testing.T) {
+	cases := map[string]*gotreesitter.Language{
+		"nil LargeStateGotos": {
+			Name:        "java_like",
+			SymbolNames: []string{"end", "identifier"},
+			ParseTable:  [][]uint16{{0, 1}, {2, 0}},
+			LexModes:    []gotreesitter.LexMode{{}, {}},
+		},
+		"empty non-nil LargeStateGotos": {
+			Name:            "go_like",
+			SymbolNames:     []string{"end", "identifier", "package_clause"},
+			LargeStateGotos: map[uint64]gotreesitter.StateID{},
+		},
+		"minimal empty language": {},
+	}
+
+	for name, lang := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := encodeLanguageBlob(lang)
+			if err != nil {
+				t.Fatalf("encodeLanguageBlob: %v", err)
+			}
+			want, err := oldEncodeLanguageBlob(lang)
+			if err != nil {
+				t.Fatalf("oldEncodeLanguageBlob: %v", err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("%s: fixed encoder bytes (len %d) differ from pre-fix encoder bytes (len %d); LargeStateGotos handling must be a no-op when empty", name, len(got), len(want))
+			}
+		})
+	}
+}
+
+// TestDecodeLanguageBlobOldFormatWithLargeStateGotos simulates decoding a
+// blob produced by the pre-fix encoder (LargeStateGotos gob-encoded directly,
+// no trailer) -- this is exactly the shape of the 206 blobs checked in before
+// this change, including grammar_blobs/c_sharp.bin. decodeLanguageBlob must
+// still restore LargeStateGotos correctly via gob's native map decode.
+func TestDecodeLanguageBlobOldFormatWithLargeStateGotos(t *testing.T) {
+	want := syntheticLargeStateGotos(300)
+	lang := &gotreesitter.Language{
+		Name:            "old_format_csharp_like",
+		SymbolNames:     []string{"end"},
+		LargeStateGotos: want,
+	}
+
+	oldBlob, err := oldEncodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("oldEncodeLanguageBlob: %v", err)
+	}
+
+	decoded, err := decodeLanguageBlob(oldBlob)
+	if err != nil {
+		t.Fatalf("decodeLanguageBlob(old-format blob): %v", err)
+	}
+	if len(decoded.LargeStateGotos) != len(want) {
+		t.Fatalf("LargeStateGotos has %d entries, want %d", len(decoded.LargeStateGotos), len(want))
+	}
+	for k, v := range want {
+		if decoded.LargeStateGotos[k] != v {
+			t.Fatalf("LargeStateGotos[%d] = %d, want %d", k, decoded.LargeStateGotos[k], v)
+		}
+	}
+}
+
+// TestDecodeLanguageBlobNewFormatWithoutTrailerUnaffected pins that decoding
+// a fixed-encoder blob for a Language without LargeStateGotos behaves
+// identically to before (no trailer is written or expected).
+func TestDecodeLanguageBlobNewFormatWithoutTrailerUnaffected(t *testing.T) {
+	lang := &gotreesitter.Language{
+		Name:        "regex_like",
+		SymbolNames: []string{"end", "char_class"},
+	}
+
+	blob, err := encodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("encodeLanguageBlob: %v", err)
+	}
+	decoded, err := decodeLanguageBlob(blob)
+	if err != nil {
+		t.Fatalf("decodeLanguageBlob: %v", err)
+	}
+	if decoded.Name != lang.Name {
+		t.Fatalf("Name = %q, want %q", decoded.Name, lang.Name)
+	}
+	if len(decoded.LargeStateGotos) != 0 {
+		t.Fatalf("LargeStateGotos = %v, want empty", decoded.LargeStateGotos)
+	}
+}

--- a/grammargen/encode.go
+++ b/grammargen/encode.go
@@ -7,7 +7,6 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
-	"reflect"
 
 	"github.com/odvcencio/gotreesitter"
 )
@@ -81,96 +80,10 @@ func computeSkipExtras(ng *NormalizedGrammar) map[int]bool {
 	return skip
 }
 
-// encodeLanguageBlob serializes a Language using gob+gzip.
-//
-// Language.LargeStateGotos is a map, and gob's map codec iterates via
-// reflect's randomized MapRange, so gob-encoding it directly would make two
-// encodes of the same Language produce different bytes (see
-// large_state_gotos_trailer.go in the root package for the full mechanism
-// and why simpler fixes -- GobEncoder on the field, or a new Language field
-// -- don't preserve blob compatibility). When lang.LargeStateGotos is
-// non-empty, this instead gob-encodes a shallow copy with the map cleared
-// (lang itself is never mutated) and appends a deterministic sorted-pairs
-// trailer after the gob payload, inside the same compressed stream. That gzip
-// payload is wrapped in a versioned outer envelope so older gzip-first runtimes
-// reject it instead of silently losing the trailer.
-// decodeLanguageBlob reads that trailer back and repopulates LargeStateGotos
-// after the gob decode. When LargeStateGotos is empty -- every language but
-// c_sharp today -- this is byte-identical to a plain gob.Encode: no clone,
-// no trailer.
+// encodeLanguageBlob keeps grammargen's internal call sites stable while the
+// root package owns the single blob-format encoder shared with ts2go.
 func encodeLanguageBlob(lang *gotreesitter.Language) ([]byte, error) {
-	toEncode := lang
-	var trailer []byte
-	if lang != nil && len(lang.LargeStateGotos) > 0 {
-		var err error
-		trailer, err = gotreesitter.EncodeLargeStateGotosTrailer(lang.LargeStateGotos)
-		if err != nil {
-			return nil, fmt.Errorf("encode language blob: %w", err)
-		}
-		clone := shallowCopyExportedLanguageFields(lang)
-		clone.LargeStateGotos = nil
-		toEncode = clone
-	}
-
-	var out bytes.Buffer
-	gzw := gzip.NewWriter(&out)
-	if err := gob.NewEncoder(gzw).Encode(toEncode); err != nil {
-		_ = gzw.Close()
-		return nil, fmt.Errorf("encode language blob: %w", err)
-	}
-	if len(trailer) > 0 {
-		if _, err := gzw.Write(trailer); err != nil {
-			_ = gzw.Close()
-			return nil, fmt.Errorf("encode language blob: %w", err)
-		}
-	}
-	if err := gzw.Close(); err != nil {
-		return nil, fmt.Errorf("finalize language blob: %w", err)
-	}
-	if len(trailer) == 0 {
-		return out.Bytes(), nil
-	}
-	enveloped, err := gotreesitter.WrapLanguageBlobEnvelope(out.Bytes())
-	if err != nil {
-		return nil, fmt.Errorf("finalize language blob: %w", err)
-	}
-	return enveloped, nil
-}
-
-// shallowCopyExportedLanguageFields returns a new *gotreesitter.Language with
-// every exported field copied by value from lang, for callers (like
-// encodeLanguageBlob) that need to hand gob a modified-but-independent copy
-// without disturbing the original.
-//
-// This deliberately does not use `clone := *lang`. Language embeds several
-// sync.Once and atomic.Pointer hot-path caches (symbolMapOnce,
-// cRecoveryGateCache, etc.) as unexported fields, so a plain struct copy (a)
-// trips `go vet`'s copylocks check, and (b) is not what we want anyway: gob
-// only ever transmits exported fields, so the unexported caches have no
-// business being duplicated.
-//
-// This also deliberately does not mutate lang in place (e.g. temporarily
-// nil-ing LargeStateGotos and restoring it after encoding) even though
-// encodeLanguageBlob's current callers happen not to share lang with another
-// goroutine while it runs: Language.LargeStateGotos is read on the parser's
-// hot path (parser_tables.go), and a future caller that re-encodes a
-// Language that's already in concurrent use elsewhere would otherwise hit an
-// unsynchronized "concurrent map read and map write". Copying only the
-// exported fields sidesteps both problems: the copy is independent (so
-// mutating its LargeStateGotos can never race with a reader of lang's), and
-// it never touches the lock-bearing fields at all.
-func shallowCopyExportedLanguageFields(lang *gotreesitter.Language) *gotreesitter.Language {
-	src := reflect.ValueOf(lang).Elem()
-	t := src.Type()
-	dstPtr := reflect.New(t)
-	dst := dstPtr.Elem()
-	for i := 0; i < t.NumField(); i++ {
-		if !t.Field(i).IsExported() {
-			continue
-		}
-		dst.Field(i).Set(src.Field(i))
-	}
-	return dstPtr.Interface().(*gotreesitter.Language)
+	return gotreesitter.EncodeLanguageBlob(lang)
 }
 
 // decodeLanguageBlob deserializes a legacy gob+gzip Language blob or a

--- a/grammargen/encode.go
+++ b/grammargen/encode.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"io"
+	"reflect"
 
 	"github.com/odvcencio/gotreesitter"
 )
@@ -80,12 +82,45 @@ func computeSkipExtras(ng *NormalizedGrammar) map[int]bool {
 }
 
 // encodeLanguageBlob serializes a Language using gob+gzip.
+//
+// Language.LargeStateGotos is a map, and gob's map codec iterates via
+// reflect's randomized MapRange, so gob-encoding it directly would make two
+// encodes of the same Language produce different bytes (see
+// large_state_gotos_trailer.go in the root package for the full mechanism
+// and why simpler fixes -- GobEncoder on the field, or a new Language field
+// -- don't preserve blob compatibility). When lang.LargeStateGotos is
+// non-empty, this instead gob-encodes a shallow copy with the map cleared
+// (lang itself is never mutated) and appends a deterministic sorted-pairs
+// trailer after the gob payload, inside the same compressed stream.
+// decodeLanguageBlob reads that trailer back and repopulates LargeStateGotos
+// after the gob decode. When LargeStateGotos is empty -- every language but
+// c_sharp today -- this is byte-identical to a plain gob.Encode: no clone,
+// no trailer.
 func encodeLanguageBlob(lang *gotreesitter.Language) ([]byte, error) {
+	toEncode := lang
+	var trailer []byte
+	if lang != nil && len(lang.LargeStateGotos) > 0 {
+		var err error
+		trailer, err = gotreesitter.EncodeLargeStateGotosTrailer(lang.LargeStateGotos)
+		if err != nil {
+			return nil, fmt.Errorf("encode language blob: %w", err)
+		}
+		clone := shallowCopyExportedLanguageFields(lang)
+		clone.LargeStateGotos = nil
+		toEncode = clone
+	}
+
 	var out bytes.Buffer
 	gzw := gzip.NewWriter(&out)
-	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
+	if err := gob.NewEncoder(gzw).Encode(toEncode); err != nil {
 		_ = gzw.Close()
 		return nil, fmt.Errorf("encode language blob: %w", err)
+	}
+	if len(trailer) > 0 {
+		if _, err := gzw.Write(trailer); err != nil {
+			_ = gzw.Close()
+			return nil, fmt.Errorf("encode language blob: %w", err)
+		}
 	}
 	if err := gzw.Close(); err != nil {
 		return nil, fmt.Errorf("finalize language blob: %w", err)
@@ -93,7 +128,46 @@ func encodeLanguageBlob(lang *gotreesitter.Language) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-// decodeLanguageBlob deserializes a gob+gzip Language blob.
+// shallowCopyExportedLanguageFields returns a new *gotreesitter.Language with
+// every exported field copied by value from lang, for callers (like
+// encodeLanguageBlob) that need to hand gob a modified-but-independent copy
+// without disturbing the original.
+//
+// This deliberately does not use `clone := *lang`. Language embeds several
+// sync.Once and atomic.Pointer hot-path caches (symbolMapOnce,
+// cRecoveryGateCache, etc.) as unexported fields, so a plain struct copy (a)
+// trips `go vet`'s copylocks check, and (b) is not what we want anyway: gob
+// only ever transmits exported fields, so the unexported caches have no
+// business being duplicated.
+//
+// This also deliberately does not mutate lang in place (e.g. temporarily
+// nil-ing LargeStateGotos and restoring it after encoding) even though
+// encodeLanguageBlob's current callers happen not to share lang with another
+// goroutine while it runs: Language.LargeStateGotos is read on the parser's
+// hot path (parser_tables.go), and a future caller that re-encodes a
+// Language that's already in concurrent use elsewhere would otherwise hit an
+// unsynchronized "concurrent map read and map write". Copying only the
+// exported fields sidesteps both problems: the copy is independent (so
+// mutating its LargeStateGotos can never race with a reader of lang's), and
+// it never touches the lock-bearing fields at all.
+func shallowCopyExportedLanguageFields(lang *gotreesitter.Language) *gotreesitter.Language {
+	src := reflect.ValueOf(lang).Elem()
+	t := src.Type()
+	dstPtr := reflect.New(t)
+	dst := dstPtr.Elem()
+	for i := 0; i < t.NumField(); i++ {
+		if !t.Field(i).IsExported() {
+			continue
+		}
+		dst.Field(i).Set(src.Field(i))
+	}
+	return dstPtr.Interface().(*gotreesitter.Language)
+}
+
+// decodeLanguageBlob deserializes a gob+gzip Language blob, including the
+// optional LargeStateGotos trailer written by encodeLanguageBlob (a cheap
+// no-op for every blob that doesn't have one -- see
+// gotreesitter.DecodeLargeStateGotosTrailer).
 func decodeLanguageBlob(data []byte) (*gotreesitter.Language, error) {
 	gzr, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
@@ -101,9 +175,26 @@ func decodeLanguageBlob(data []byte) (*gotreesitter.Language, error) {
 	}
 	defer gzr.Close()
 
+	// Decode from a fully-buffered *bytes.Reader, not gzr directly: gob's
+	// Decoder can read ahead past its own message boundary on a streaming
+	// reader, which would silently swallow the trailer bytes below before we
+	// get a chance to read them.
+	raw, err := io.ReadAll(gzr)
+	if err != nil {
+		return nil, fmt.Errorf("read gzip: %w", err)
+	}
+
 	var lang gotreesitter.Language
-	if err := gob.NewDecoder(gzr).Decode(&lang); err != nil {
+	br := bytes.NewReader(raw)
+	if err := gob.NewDecoder(br).Decode(&lang); err != nil {
 		return nil, fmt.Errorf("decode language blob: %w", err)
+	}
+	trailer, err := gotreesitter.DecodeLargeStateGotosTrailer(br)
+	if err != nil {
+		return nil, fmt.Errorf("decode language blob: %w", err)
+	}
+	if trailer != nil {
+		lang.LargeStateGotos = trailer
 	}
 	return &lang, nil
 }

--- a/grammargen/encode.go
+++ b/grammargen/encode.go
@@ -91,7 +91,9 @@ func computeSkipExtras(ng *NormalizedGrammar) map[int]bool {
 // -- don't preserve blob compatibility). When lang.LargeStateGotos is
 // non-empty, this instead gob-encodes a shallow copy with the map cleared
 // (lang itself is never mutated) and appends a deterministic sorted-pairs
-// trailer after the gob payload, inside the same compressed stream.
+// trailer after the gob payload, inside the same compressed stream. That gzip
+// payload is wrapped in a versioned outer envelope so older gzip-first runtimes
+// reject it instead of silently losing the trailer.
 // decodeLanguageBlob reads that trailer back and repopulates LargeStateGotos
 // after the gob decode. When LargeStateGotos is empty -- every language but
 // c_sharp today -- this is byte-identical to a plain gob.Encode: no clone,
@@ -125,7 +127,14 @@ func encodeLanguageBlob(lang *gotreesitter.Language) ([]byte, error) {
 	if err := gzw.Close(); err != nil {
 		return nil, fmt.Errorf("finalize language blob: %w", err)
 	}
-	return out.Bytes(), nil
+	if len(trailer) == 0 {
+		return out.Bytes(), nil
+	}
+	enveloped, err := gotreesitter.WrapLanguageBlobEnvelope(out.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("finalize language blob: %w", err)
+	}
+	return enveloped, nil
 }
 
 // shallowCopyExportedLanguageFields returns a new *gotreesitter.Language with
@@ -164,12 +173,16 @@ func shallowCopyExportedLanguageFields(lang *gotreesitter.Language) *gotreesitte
 	return dstPtr.Interface().(*gotreesitter.Language)
 }
 
-// decodeLanguageBlob deserializes a gob+gzip Language blob, including the
-// optional LargeStateGotos trailer written by encodeLanguageBlob (a cheap
-// no-op for every blob that doesn't have one -- see
-// gotreesitter.DecodeLargeStateGotosTrailer).
+// decodeLanguageBlob deserializes a legacy gob+gzip Language blob or a
+// version-enveloped blob containing the LargeStateGotos trailer written by
+// encodeLanguageBlob. Envelope detection is a cheap no-op for every legacy
+// blob that doesn't have one.
 func decodeLanguageBlob(data []byte) (*gotreesitter.Language, error) {
-	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	compressed, expectsTrailer, err := gotreesitter.UnwrapLanguageBlobEnvelope(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode language blob: %w", err)
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(compressed))
 	if err != nil {
 		return nil, fmt.Errorf("open gzip: %w", err)
 	}
@@ -192,6 +205,12 @@ func decodeLanguageBlob(data []byte) (*gotreesitter.Language, error) {
 	trailer, err := gotreesitter.DecodeLargeStateGotosTrailer(br)
 	if err != nil {
 		return nil, fmt.Errorf("decode language blob: %w", err)
+	}
+	if expectsTrailer && len(trailer) == 0 {
+		return nil, fmt.Errorf("decode language blob: envelope requires a non-empty large-state-gotos trailer")
+	}
+	if !expectsTrailer && len(trailer) != 0 {
+		return nil, fmt.Errorf("decode language blob: large-state-gotos trailer requires a versioned envelope")
 	}
 	if trailer != nil {
 		lang.LargeStateGotos = trailer

--- a/grammars/blob_source_common.go
+++ b/grammars/blob_source_common.go
@@ -11,10 +11,12 @@ func (b grammarBlob) close() {
 	}
 }
 
-// BlobByName returns the raw compressed grammar blob for the named language
+// BlobByName returns the raw grammar blob for the named language
 // (e.g. "go", "python"). Returns nil if the language blob is not found.
-// The returned bytes are the gzip+gob encoded grammar data suitable for
-// serving to browser-side WASM modules that decode grammars on demand.
+// Returned bytes are either legacy gzip+gob data or a versioned language-blob
+// envelope. Consumers must load them with gotreesitter.LoadLanguage (or the
+// equivalent grammars loader) rather than assuming a gzip header. The bytes
+// remain suitable for browser-side WASM modules that use that runtime decoder.
 func BlobByName(name string) []byte {
 	// Resolve aliases and normalize case the same way DetectLanguageByName does.
 	entry := DetectLanguageByName(name)

--- a/grammars/embedded_loader.go
+++ b/grammars/embedded_loader.go
@@ -518,7 +518,11 @@ func decodeEmbeddedLanguage(blobName string) (*gotreesitter.Language, error) {
 }
 
 func decodeLanguageBlobData(blobName string, data []byte) (*gotreesitter.Language, error) {
-	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	compressed, expectsTrailer, err := gotreesitter.UnwrapLanguageBlobEnvelope(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(compressed))
 	if err != nil {
 		return nil, fmt.Errorf("open gzip grammar blob %q: %w", blobName, err)
 	}
@@ -543,6 +547,12 @@ func decodeLanguageBlobData(blobName string, data []byte) (*gotreesitter.Languag
 	trailer, err := gotreesitter.DecodeLargeStateGotosTrailer(br)
 	if err != nil {
 		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
+	}
+	if expectsTrailer && len(trailer) == 0 {
+		return nil, fmt.Errorf("decode grammar blob %q: envelope requires a non-empty large-state-gotos trailer", blobName)
+	}
+	if !expectsTrailer && len(trailer) != 0 {
+		return nil, fmt.Errorf("decode grammar blob %q: large-state-gotos trailer requires a versioned envelope", blobName)
 	}
 	if trailer != nil {
 		lang.LargeStateGotos = trailer

--- a/grammars/embedded_loader.go
+++ b/grammars/embedded_loader.go
@@ -6,6 +6,7 @@ import (
 	"container/list"
 	"encoding/gob"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -523,10 +524,28 @@ func decodeLanguageBlobData(blobName string, data []byte) (*gotreesitter.Languag
 	}
 	defer gzr.Close()
 
-	dec := gob.NewDecoder(gzr)
+	// Decode from a fully-buffered *bytes.Reader, not gzr directly: gob's
+	// Decoder can read ahead past its own message boundary on a streaming
+	// reader, which would silently swallow the optional LargeStateGotos
+	// trailer (see gotreesitter.DecodeLargeStateGotosTrailer) before we get a
+	// chance to read it.
+	raw, err := io.ReadAll(gzr)
+	if err != nil {
+		return nil, fmt.Errorf("read gzip grammar blob %q: %w", blobName, err)
+	}
+
+	br := bytes.NewReader(raw)
+	dec := gob.NewDecoder(br)
 	var lang gotreesitter.Language
 	if err := dec.Decode(&lang); err != nil {
 		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
+	}
+	trailer, err := gotreesitter.DecodeLargeStateGotosTrailer(br)
+	if err != nil {
+		return nil, fmt.Errorf("decode grammar blob %q: %w", blobName, err)
+	}
+	if trailer != nil {
+		lang.LargeStateGotos = trailer
 	}
 
 	gotreesitter.InferGeneratedRepeatAuxMetadata(&lang)

--- a/grammars/embedded_loader_test.go
+++ b/grammars/embedded_loader_test.go
@@ -1,6 +1,9 @@
 package grammars
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/gob"
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
@@ -48,6 +51,55 @@ func TestRepairNoLookaheadLexModes(t *testing.T) {
 				t.Fatalf("LexModes[%d].LexStateIndex = %d, want %d", idx, got, ^uint32(0))
 			}
 		})
+	}
+}
+
+func TestDecodeLanguageBlobDataDecodesEnvelopedLargeStateGotosTrailer(t *testing.T) {
+	want := map[uint64]gotreesitter.StateID{
+		uint64(70000)<<32 | 3: 80001,
+		uint64(70001)<<32 | 9: 80007,
+		uint64(70002)<<32 | 5: 80011,
+	}
+	trailer, err := gotreesitter.EncodeLargeStateGotosTrailer(want)
+	if err != nil {
+		t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+	}
+
+	lang := &gotreesitter.Language{
+		Name:        "embedded_c_sharp_like",
+		SymbolNames: []string{"end", "identifier"},
+		// The deterministic encoder clears this field from the gob payload.
+	}
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if _, err := gzw.Write(trailer); err != nil {
+		t.Fatalf("write trailer: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	enveloped, err := gotreesitter.WrapLanguageBlobEnvelope(buf.Bytes())
+	if err != nil {
+		t.Fatalf("WrapLanguageBlobEnvelope: %v", err)
+	}
+	if _, err := gzip.NewReader(bytes.NewReader(enveloped)); err == nil {
+		t.Fatal("legacy gzip-first embedded loader accepted an enveloped blob")
+	}
+
+	decoded, err := decodeLanguageBlobData("c_sharp_like.bin", enveloped)
+	if err != nil {
+		t.Fatalf("decodeLanguageBlobData: %v", err)
+	}
+	if len(decoded.LargeStateGotos) != len(want) {
+		t.Fatalf("LargeStateGotos has %d entries, want %d", len(decoded.LargeStateGotos), len(want))
+	}
+	for key, target := range want {
+		if got := decoded.LargeStateGotos[key]; got != target {
+			t.Fatalf("LargeStateGotos[%d] = %d, want %d", key, got, target)
+		}
 	}
 }
 

--- a/language.go
+++ b/language.go
@@ -305,6 +305,12 @@ type Language struct {
 	// LargeStateGotos stores nonterminal GOTO targets that do not fit in the
 	// uint16 parse-table cells used by tree-sitter C tables. Keys are
 	// uint64(state)<<32 | uint64(symbol). Terminal actions must never live here.
+	//
+	// This is the only exported map field on Language, which matters for blob
+	// serialization: gob's map codec iterates via reflect's randomized
+	// MapRange, so blob encoders never gob-encode this field directly when
+	// it's non-empty (today, only c_sharp populates it). See
+	// large_state_gotos_trailer.go for the deterministic encode/decode path.
 	LargeStateGotos map[uint64]StateID
 
 	// ReduceChainHints are optional generated hot-path hints for deterministic

--- a/language_blob_encode.go
+++ b/language_blob_encode.go
@@ -1,0 +1,75 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/gob"
+	"fmt"
+	"reflect"
+)
+
+// EncodeLanguageBlob serializes lang in the runtime's stable grammar-blob
+// format. Languages without LargeStateGotos retain the legacy gzip+gob wire
+// representation byte-for-byte. When LargeStateGotos is populated, the map is
+// removed from a shallow exported-field copy, encoded as a sorted trailer, and
+// wrapped in the versioned fail-closed envelope understood by LoadLanguage.
+//
+// Keeping this encoder in the root package makes the format invariant shared
+// by every producer, including grammargen and ts2go. The input Language is
+// never mutated and can remain in concurrent use while it is encoded.
+func EncodeLanguageBlob(lang *Language) ([]byte, error) {
+	toEncode := lang
+	var trailer []byte
+	if lang != nil && len(lang.LargeStateGotos) > 0 {
+		var err error
+		trailer, err = EncodeLargeStateGotosTrailer(lang.LargeStateGotos)
+		if err != nil {
+			return nil, fmt.Errorf("encode language blob: %w", err)
+		}
+		clone := shallowCopyExportedLanguageFields(lang)
+		clone.LargeStateGotos = nil
+		toEncode = clone
+	}
+
+	var out bytes.Buffer
+	gzw := gzip.NewWriter(&out)
+	if err := gob.NewEncoder(gzw).Encode(toEncode); err != nil {
+		_ = gzw.Close()
+		return nil, fmt.Errorf("encode language blob: %w", err)
+	}
+	if len(trailer) > 0 {
+		if _, err := gzw.Write(trailer); err != nil {
+			_ = gzw.Close()
+			return nil, fmt.Errorf("encode language blob: %w", err)
+		}
+	}
+	if err := gzw.Close(); err != nil {
+		return nil, fmt.Errorf("finalize language blob: %w", err)
+	}
+	if len(trailer) == 0 {
+		return out.Bytes(), nil
+	}
+	enveloped, err := WrapLanguageBlobEnvelope(out.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("finalize language blob: %w", err)
+	}
+	return enveloped, nil
+}
+
+// shallowCopyExportedLanguageFields returns a new Language containing exactly
+// the fields gob can observe. A direct struct copy would also copy sync.Once
+// and atomic cache state; mutating the original map in place would race with
+// parsers already using the Language.
+func shallowCopyExportedLanguageFields(lang *Language) *Language {
+	src := reflect.ValueOf(lang).Elem()
+	t := src.Type()
+	dstPtr := reflect.New(t)
+	dst := dstPtr.Elem()
+	for i := 0; i < t.NumField(); i++ {
+		if !t.Field(i).IsExported() {
+			continue
+		}
+		dst.Field(i).Set(src.Field(i))
+	}
+	return dstPtr.Interface().(*Language)
+}

--- a/language_blob_envelope.go
+++ b/language_blob_envelope.go
@@ -1,0 +1,77 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+var languageBlobEnvelopeMagic = [8]byte{'G', 'T', 'S', 'B', 'L', 'O', 'B', 0}
+
+const (
+	languageBlobEnvelopeVersionOffset              = len(languageBlobEnvelopeMagic)
+	languageBlobEnvelopeFlagsOffset                = languageBlobEnvelopeVersionOffset + 2
+	languageBlobEnvelopePayloadLengthOffset        = languageBlobEnvelopeFlagsOffset + 2
+	languageBlobEnvelopeHeaderSize                 = languageBlobEnvelopePayloadLengthOffset + 8
+	languageBlobEnvelopeVersion                    = uint16(1)
+	languageBlobEnvelopeFlagLargeStateGotosTrailer = uint16(1)
+)
+
+// WrapLanguageBlobEnvelope wraps a gzip-compressed Language blob whose
+// decompressed stream contains a LargeStateGotos trailer. The outer magic is
+// deliberately not a gzip header: runtimes predating trailer support therefore
+// reject the blob at gzip.NewReader instead of successfully decoding the gob
+// payload with LargeStateGotos missing.
+//
+// The envelope is versioned and length-delimited so current runtimes also fail
+// closed on unknown versions, flags, truncation, and trailing bytes. Callers
+// must only wrap blobs that actually contain a non-empty trailer.
+func WrapLanguageBlobEnvelope(compressed []byte) ([]byte, error) {
+	if !hasGzipHeader(compressed) {
+		return nil, fmt.Errorf("wrap language blob envelope: payload is not gzip data")
+	}
+
+	out := make([]byte, languageBlobEnvelopeHeaderSize+len(compressed))
+	copy(out, languageBlobEnvelopeMagic[:])
+	binary.BigEndian.PutUint16(out[languageBlobEnvelopeVersionOffset:languageBlobEnvelopeFlagsOffset], languageBlobEnvelopeVersion)
+	binary.BigEndian.PutUint16(out[languageBlobEnvelopeFlagsOffset:languageBlobEnvelopePayloadLengthOffset], languageBlobEnvelopeFlagLargeStateGotosTrailer)
+	binary.BigEndian.PutUint64(out[languageBlobEnvelopePayloadLengthOffset:languageBlobEnvelopeHeaderSize], uint64(len(compressed)))
+	copy(out[languageBlobEnvelopeHeaderSize:], compressed)
+	return out, nil
+}
+
+// UnwrapLanguageBlobEnvelope returns the gzip payload and whether its envelope
+// requires a non-empty LargeStateGotos trailer. Legacy gzip blobs are returned
+// unchanged with expectsTrailer=false, preserving the original wire format.
+func UnwrapLanguageBlobEnvelope(data []byte) (compressed []byte, expectsTrailer bool, err error) {
+	if !bytes.HasPrefix(data, languageBlobEnvelopeMagic[:]) {
+		return data, false, nil
+	}
+	if len(data) < languageBlobEnvelopeHeaderSize {
+		return nil, false, fmt.Errorf("unwrap language blob envelope: truncated header: got %d bytes, need %d", len(data), languageBlobEnvelopeHeaderSize)
+	}
+
+	version := binary.BigEndian.Uint16(data[languageBlobEnvelopeVersionOffset:languageBlobEnvelopeFlagsOffset])
+	if version != languageBlobEnvelopeVersion {
+		return nil, false, fmt.Errorf("unwrap language blob envelope: unsupported version %d", version)
+	}
+	flags := binary.BigEndian.Uint16(data[languageBlobEnvelopeFlagsOffset:languageBlobEnvelopePayloadLengthOffset])
+	if flags != languageBlobEnvelopeFlagLargeStateGotosTrailer {
+		return nil, false, fmt.Errorf("unwrap language blob envelope: unsupported flags %#x", flags)
+	}
+
+	wantLen := binary.BigEndian.Uint64(data[languageBlobEnvelopePayloadLengthOffset:languageBlobEnvelopeHeaderSize])
+	gotLen := uint64(len(data) - languageBlobEnvelopeHeaderSize)
+	if wantLen != gotLen {
+		return nil, false, fmt.Errorf("unwrap language blob envelope: payload length = %d, actual = %d", wantLen, gotLen)
+	}
+	payload := data[languageBlobEnvelopeHeaderSize:]
+	if !hasGzipHeader(payload) {
+		return nil, false, fmt.Errorf("unwrap language blob envelope: payload is not gzip data")
+	}
+	return payload, true, nil
+}
+
+func hasGzipHeader(data []byte) bool {
+	return len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b
+}

--- a/language_blob_envelope_test.go
+++ b/language_blob_envelope_test.go
@@ -1,0 +1,108 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"testing"
+)
+
+func gzipPayloadForEnvelopeTest(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if _, err := gzw.Write(payload); err != nil {
+		t.Fatalf("gzip Write: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestLanguageBlobEnvelopeRoundTripAndRejectsLegacyGzipReader(t *testing.T) {
+	compressed := gzipPayloadForEnvelopeTest(t, []byte("gob payload plus trailer"))
+	enveloped, err := WrapLanguageBlobEnvelope(compressed)
+	if err != nil {
+		t.Fatalf("WrapLanguageBlobEnvelope: %v", err)
+	}
+	if bytes.HasPrefix(enveloped, []byte{0x1f, 0x8b}) {
+		t.Fatal("enveloped blob still begins with gzip magic; old runtimes would accept it")
+	}
+	if _, err := gzip.NewReader(bytes.NewReader(enveloped)); err == nil {
+		t.Fatal("legacy gzip-first loader accepted an enveloped blob")
+	}
+
+	got, expectsTrailer, err := UnwrapLanguageBlobEnvelope(enveloped)
+	if err != nil {
+		t.Fatalf("UnwrapLanguageBlobEnvelope: %v", err)
+	}
+	if !expectsTrailer {
+		t.Fatal("UnwrapLanguageBlobEnvelope did not require a trailer")
+	}
+	if !bytes.Equal(got, compressed) {
+		t.Fatal("unwrapped gzip payload differs from input")
+	}
+}
+
+func TestUnwrapLanguageBlobEnvelopeLeavesLegacyBlobUnchanged(t *testing.T) {
+	legacy := gzipPayloadForEnvelopeTest(t, []byte("legacy gob payload"))
+	got, expectsTrailer, err := UnwrapLanguageBlobEnvelope(legacy)
+	if err != nil {
+		t.Fatalf("UnwrapLanguageBlobEnvelope: %v", err)
+	}
+	if expectsTrailer {
+		t.Fatal("legacy blob unexpectedly requires a trailer")
+	}
+	if !bytes.Equal(got, legacy) {
+		t.Fatal("legacy blob bytes changed while unwrapping")
+	}
+}
+
+func TestUnwrapLanguageBlobEnvelopeRejectsMalformedEnvelope(t *testing.T) {
+	compressed := gzipPayloadForEnvelopeTest(t, []byte("payload"))
+	valid, err := WrapLanguageBlobEnvelope(compressed)
+	if err != nil {
+		t.Fatalf("WrapLanguageBlobEnvelope: %v", err)
+	}
+
+	tests := map[string]func([]byte) []byte{
+		"truncated header": func(in []byte) []byte {
+			return append([]byte(nil), in[:len(languageBlobEnvelopeMagic)]...)
+		},
+		"unknown version": func(in []byte) []byte {
+			out := append([]byte(nil), in...)
+			binary.BigEndian.PutUint16(out[languageBlobEnvelopeVersionOffset:languageBlobEnvelopeFlagsOffset], languageBlobEnvelopeVersion+1)
+			return out
+		},
+		"unknown flags": func(in []byte) []byte {
+			out := append([]byte(nil), in...)
+			binary.BigEndian.PutUint16(out[languageBlobEnvelopeFlagsOffset:languageBlobEnvelopePayloadLengthOffset], 0x8000)
+			return out
+		},
+		"wrong payload length": func(in []byte) []byte {
+			out := append([]byte(nil), in...)
+			binary.BigEndian.PutUint64(out[languageBlobEnvelopePayloadLengthOffset:languageBlobEnvelopeHeaderSize], uint64(len(compressed)+1))
+			return out
+		},
+		"non-gzip payload": func(in []byte) []byte {
+			out := append([]byte(nil), in...)
+			out[languageBlobEnvelopeHeaderSize] = 0
+			return out
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := UnwrapLanguageBlobEnvelope(mutate(valid)); err == nil {
+				t.Fatal("expected malformed envelope to be rejected")
+			}
+		})
+	}
+}
+
+func TestWrapLanguageBlobEnvelopeRejectsNonGzipPayload(t *testing.T) {
+	if _, err := WrapLanguageBlobEnvelope([]byte("not gzip")); err == nil {
+		t.Fatal("expected non-gzip payload to be rejected")
+	}
+}

--- a/large_state_gotos_trailer.go
+++ b/large_state_gotos_trailer.go
@@ -42,9 +42,9 @@ import (
 // two structs whose only difference is an added, always-nil slice field gob
 // encode to different byte sequences.)
 //
-// So LargeStateGotos is never handed to gob directly. Blob encoders
-// (grammargen's encodeLanguageBlob) clear it on a shallow copy of Language
-// before gob-encoding and, only when the map was non-empty, append the bytes
+// So LargeStateGotos is never handed to gob directly. EncodeLanguageBlob
+// clears it on a shallow copy of Language
+// before gob-encoding and, only when the map was non-empty, appends the bytes
 // from EncodeLargeStateGotosTrailer after the gob payload, inside the same
 // decompressed stream, then wrap that gzip payload in the fail-closed envelope
 // from language_blob_envelope.go. Blob decoders (gotreesitter.LoadLanguage,

--- a/large_state_gotos_trailer.go
+++ b/large_state_gotos_trailer.go
@@ -46,16 +46,20 @@ import (
 // (grammargen's encodeLanguageBlob) clear it on a shallow copy of Language
 // before gob-encoding and, only when the map was non-empty, append the bytes
 // from EncodeLargeStateGotosTrailer after the gob payload, inside the same
-// decompressed stream. Blob decoders (gotreesitter.LoadLanguage,
+// decompressed stream, then wrap that gzip payload in the fail-closed envelope
+// from language_blob_envelope.go. Blob decoders (gotreesitter.LoadLanguage,
 // grammargen's decodeLanguageBlob, and the grammars package loader)
-// gob-decode the Language exactly as before -- which already exactly
+// first unwrap that envelope and then gob-decode the Language exactly as before
+// -- which already exactly
 // reproduces the pre-trailer behavior for every blob that has no trailer,
 // including all 206 blobs checked in as of this change -- and then call
 // DecodeLargeStateGotosTrailer on whatever bytes remain, merging the result
 // into LargeStateGotos. A slice like []largeStateGotoPair always gob-encodes
 // in index order (see encoding/gob's encodeArray, which walks indices
 // 0..N-1 with no randomization), so sorting by Key before encoding makes the
-// trailer -- and therefore the whole blob -- byte-identical across runs.
+// trailer -- and therefore the whole blob -- byte-identical across runs. The
+// envelope deliberately makes older gzip-first runtimes reject a new
+// trailer-bearing blob instead of accepting it with the map silently missing.
 type largeStateGotoPair struct {
 	Key    uint64
 	Target StateID
@@ -112,6 +116,9 @@ func DecodeLargeStateGotosTrailer(r *bytes.Reader) (map[uint64]StateID, error) {
 	var pairs []largeStateGotoPair
 	if err := gob.NewDecoder(r).Decode(&pairs); err != nil {
 		return nil, fmt.Errorf("decode large-state-gotos trailer: %w", err)
+	}
+	if r.Len() != 0 {
+		return nil, fmt.Errorf("decode large-state-gotos trailer: %d trailing bytes", r.Len())
 	}
 	if len(pairs) == 0 {
 		return nil, nil

--- a/large_state_gotos_trailer.go
+++ b/large_state_gotos_trailer.go
@@ -1,0 +1,124 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"slices"
+)
+
+// largeStateGotoPair is the gob-stable, order-deterministic wire form of one
+// Language.LargeStateGotos entry (see language.go). It exists purely for blob
+// serialization; runtime code never sees this type.
+//
+// Why this exists: encoding/gob's built-in map codec iterates map fields via
+// reflect's Value.MapRange, which -- like a plain `range` over a Go map --
+// starts from a fresh random bucket/slot offset on every call (see
+// internal/runtime/maps.(*Iter).Init in the Go runtime, which calls rand()
+// each time it is invoked). That makes gob's output for any map field vary
+// from run to run even when the map's content is completely unchanged.
+// Language.LargeStateGotos is the only *exported* map field on Language (the
+// name-lookup maps are unexported and gob never sees them), so it is the
+// only field capable of making two encodes of an unchanged Language produce
+// different blob bytes.
+//
+// gob has no supported hook to control a map field's iteration order.
+// Implementing GobEncoder/GobDecoder on the field's type looks tempting but
+// does not work here: it changes gob's wire *type* for that field from a
+// native "map" CommonType to an opaque encoded-bytes representation, and
+// encoding/gob's decoder (compileDec/compatibleType) hard-errors the moment
+// a wire field's GobEncoderT marker disagrees with what the local type
+// expects. Since gob transmits a struct's *type descriptor* (its full field
+// list) once per encode regardless of which fields hold non-zero values,
+// this would break decoding of every existing blob's LargeStateGotos field
+// -- not just c_sharp's -- because the type descriptor for that field name
+// would no longer match what old blobs declared.
+//
+// Adding a brand-new exported field to Language has a related problem: gob's
+// type descriptor for Language changes to describe the new field the moment
+// it exists, which changes the encoded bytes for *every* blob -- including
+// the 200+ languages that never populate LargeStateGotos -- even though the
+// new field's value stays at its zero value for them. (Verified empirically:
+// two structs whose only difference is an added, always-nil slice field gob
+// encode to different byte sequences.)
+//
+// So LargeStateGotos is never handed to gob directly. Blob encoders
+// (grammargen's encodeLanguageBlob) clear it on a shallow copy of Language
+// before gob-encoding and, only when the map was non-empty, append the bytes
+// from EncodeLargeStateGotosTrailer after the gob payload, inside the same
+// decompressed stream. Blob decoders (gotreesitter.LoadLanguage,
+// grammargen's decodeLanguageBlob, and the grammars package loader)
+// gob-decode the Language exactly as before -- which already exactly
+// reproduces the pre-trailer behavior for every blob that has no trailer,
+// including all 206 blobs checked in as of this change -- and then call
+// DecodeLargeStateGotosTrailer on whatever bytes remain, merging the result
+// into LargeStateGotos. A slice like []largeStateGotoPair always gob-encodes
+// in index order (see encoding/gob's encodeArray, which walks indices
+// 0..N-1 with no randomization), so sorting by Key before encoding makes the
+// trailer -- and therefore the whole blob -- byte-identical across runs.
+type largeStateGotoPair struct {
+	Key    uint64
+	Target StateID
+}
+
+// EncodeLargeStateGotosTrailer serializes m as a self-contained gob stream of
+// (key, target) pairs sorted by Key ascending, suitable for deterministic
+// appending after a Language's gob-encoded blob payload (see
+// DecodeLargeStateGotosTrailer). It returns (nil, nil) for an empty map so
+// callers can skip writing a trailer entirely, leaving the blob byte-for-byte
+// identical to one for a Language that never populated LargeStateGotos.
+func EncodeLargeStateGotosTrailer(m map[uint64]StateID) ([]byte, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	pairs := make([]largeStateGotoPair, 0, len(m))
+	for k, v := range m {
+		pairs = append(pairs, largeStateGotoPair{Key: k, Target: v})
+	}
+	slices.SortFunc(pairs, func(a, b largeStateGotoPair) int {
+		switch {
+		case a.Key < b.Key:
+			return -1
+		case a.Key > b.Key:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(pairs); err != nil {
+		return nil, fmt.Errorf("encode large-state-gotos trailer: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeLargeStateGotosTrailer reads a trailer written by
+// EncodeLargeStateGotosTrailer from r, which must be positioned immediately
+// after a Language's gob message within the same decompressed blob stream
+// (callers must gob-decode from a *bytes.Reader, not directly from a
+// gzip.Reader: gob's Decoder can read ahead past its own message boundary on
+// a streaming reader, silently discarding trailer bytes it never needed --
+// bytes.Reader has no such read-ahead and leaves r positioned exactly at the
+// end of the decoded message).
+//
+// It returns (nil, nil) when r has no remaining bytes -- the common case for
+// every blob whose Language never populated LargeStateGotos, including every
+// blob encoded before this trailer mechanism existed.
+func DecodeLargeStateGotosTrailer(r *bytes.Reader) (map[uint64]StateID, error) {
+	if r == nil || r.Len() == 0 {
+		return nil, nil
+	}
+	var pairs []largeStateGotoPair
+	if err := gob.NewDecoder(r).Decode(&pairs); err != nil {
+		return nil, fmt.Errorf("decode large-state-gotos trailer: %w", err)
+	}
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	m := make(map[uint64]StateID, len(pairs))
+	for _, p := range pairs {
+		m[p.Key] = p.Target
+	}
+	return m, nil
+}

--- a/large_state_gotos_trailer_test.go
+++ b/large_state_gotos_trailer_test.go
@@ -2,8 +2,32 @@ package gotreesitter
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
+
+// TestLanguageHasExactlyOneExportedMapField guards the trailer mechanism's
+// core assumption: LargeStateGotos is the ONLY exported map field on Language.
+// gob encodes map iteration in randomized order, so any exported map field
+// that is gob-encoded directly reintroduces blob nondeterminism. If this test
+// fails because a new exported map field was added, route that field through
+// a sorted trailer too (see large_state_gotos_trailer.go) or use a
+// deterministic slice representation instead.
+func TestLanguageHasExactlyOneExportedMapField(t *testing.T) {
+	lt := reflect.TypeOf(Language{})
+	var mapFields []string
+	for i := 0; i < lt.NumField(); i++ {
+		f := lt.Field(i)
+		if f.IsExported() && f.Type.Kind() == reflect.Map {
+			mapFields = append(mapFields, f.Name)
+		}
+	}
+	if len(mapFields) != 1 || mapFields[0] != "LargeStateGotos" {
+		t.Fatalf("Language exported map fields = %v, want exactly [LargeStateGotos]; "+
+			"a directly gob-encoded map field makes blob encoding nondeterministic "+
+			"(see large_state_gotos_trailer.go)", mapFields)
+	}
+}
 
 // buildSyntheticLargeStateGotos returns a map shaped like what
 // grammargen/assemble.go's recordLargeGoto populates: keys are

--- a/large_state_gotos_trailer_test.go
+++ b/large_state_gotos_trailer_test.go
@@ -129,3 +129,14 @@ func TestDecodeLargeStateGotosTrailerRejectsGarbage(t *testing.T) {
 		t.Fatal("expected an error decoding non-gob garbage bytes, got nil")
 	}
 }
+
+func TestDecodeLargeStateGotosTrailerRejectsTrailingBytes(t *testing.T) {
+	encoded, err := EncodeLargeStateGotosTrailer(buildSyntheticLargeStateGotos(3))
+	if err != nil {
+		t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+	}
+	encoded = append(encoded, 0xde, 0xad, 0xbe, 0xef)
+	if _, err := DecodeLargeStateGotosTrailer(bytes.NewReader(encoded)); err == nil {
+		t.Fatal("expected bytes after the trailer gob to be rejected")
+	}
+}

--- a/large_state_gotos_trailer_test.go
+++ b/large_state_gotos_trailer_test.go
@@ -1,0 +1,107 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"testing"
+)
+
+// buildSyntheticLargeStateGotos returns a map shaped like what
+// grammargen/assemble.go's recordLargeGoto populates: keys are
+// uint64(state)<<32 | uint64(symbol), values are StateID targets. n entries
+// is enough to make Go's randomized map iteration produce different orders
+// across repeated ranges with overwhelming probability.
+func buildSyntheticLargeStateGotos(n int) map[uint64]StateID {
+	m := make(map[uint64]StateID, n)
+	for i := 0; i < n; i++ {
+		state := uint64(70000 + i)
+		sym := uint64(i % 512)
+		key := state<<32 | sym
+		m[key] = StateID(80000 + i*3)
+	}
+	return m
+}
+
+func TestEncodeLargeStateGotosTrailerDeterministicAcrossRuns(t *testing.T) {
+	m := buildSyntheticLargeStateGotos(5000)
+
+	first, err := EncodeLargeStateGotosTrailer(m)
+	if err != nil {
+		t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("expected non-empty trailer for non-empty map")
+	}
+
+	for i := 0; i < 25; i++ {
+		got, err := EncodeLargeStateGotosTrailer(m)
+		if err != nil {
+			t.Fatalf("EncodeLargeStateGotosTrailer run %d: %v", i, err)
+		}
+		if !bytes.Equal(first, got) {
+			t.Fatalf("run %d: trailer bytes differ from first run (gob map-iteration nondeterminism leaked through)", i)
+		}
+	}
+}
+
+func TestLargeStateGotosTrailerRoundTrip(t *testing.T) {
+	m := buildSyntheticLargeStateGotos(500)
+
+	enc, err := EncodeLargeStateGotosTrailer(m)
+	if err != nil {
+		t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+	}
+
+	got, err := DecodeLargeStateGotosTrailer(bytes.NewReader(enc))
+	if err != nil {
+		t.Fatalf("DecodeLargeStateGotosTrailer: %v", err)
+	}
+	if len(got) != len(m) {
+		t.Fatalf("decoded map has %d entries, want %d", len(got), len(m))
+	}
+	for k, want := range m {
+		if got[k] != want {
+			t.Fatalf("decoded[%d] = %d, want %d", k, got[k], want)
+		}
+	}
+}
+
+func TestEncodeLargeStateGotosTrailerEmptyMapReturnsNil(t *testing.T) {
+	for name, m := range map[string]map[uint64]StateID{
+		"nil map":   nil,
+		"empty map": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := EncodeLargeStateGotosTrailer(m)
+			if err != nil {
+				t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("expected nil trailer for %s, got %d bytes", name, len(got))
+			}
+		})
+	}
+}
+
+func TestDecodeLargeStateGotosTrailerEmptyReaderReturnsNil(t *testing.T) {
+	for name, r := range map[string]*bytes.Reader{
+		"nil reader":   nil,
+		"empty reader": bytes.NewReader(nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := DecodeLargeStateGotosTrailer(r)
+			if err != nil {
+				t.Fatalf("DecodeLargeStateGotosTrailer: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("expected nil map for %s, got %v", name, got)
+			}
+		})
+	}
+}
+
+func TestDecodeLargeStateGotosTrailerRejectsGarbage(t *testing.T) {
+	garbage := bytes.NewReader([]byte{0xFF, 0x00, 0x01, 0x02, 0x03})
+	if _, err := DecodeLargeStateGotosTrailer(garbage); err == nil {
+		t.Fatal("expected an error decoding non-gob garbage bytes, got nil")
+	}
+}

--- a/load_language.go
+++ b/load_language.go
@@ -10,8 +10,8 @@ import (
 )
 
 // LoadLanguage deserializes a compressed grammar blob into a Language.
-// Blobs are produced by grammargen's GenerateLanguage or the grammar
-// build toolchain. This is the only function needed at runtime to load
+// Blobs are produced by EncodeLanguageBlob, grammargen.Generate, or the
+// grammar build toolchain. This is the only function needed at runtime to load
 // pre-compiled grammars — no grammargen import required. It accepts legacy
 // gzip blobs and version-enveloped trailer-bearing blobs.
 func LoadLanguage(data []byte) (*Language, error) {

--- a/load_language.go
+++ b/load_language.go
@@ -12,9 +12,14 @@ import (
 // LoadLanguage deserializes a compressed grammar blob into a Language.
 // Blobs are produced by grammargen's GenerateLanguage or the grammar
 // build toolchain. This is the only function needed at runtime to load
-// pre-compiled grammars — no grammargen import required.
+// pre-compiled grammars — no grammargen import required. It accepts legacy
+// gzip blobs and version-enveloped trailer-bearing blobs.
 func LoadLanguage(data []byte) (*Language, error) {
-	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	compressed, expectsTrailer, err := UnwrapLanguageBlobEnvelope(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode language: %w", err)
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(compressed))
 	if err != nil {
 		return nil, fmt.Errorf("open gzip: %w", err)
 	}
@@ -25,8 +30,8 @@ func LoadLanguage(data []byte) (*Language, error) {
 	// ISIZE is uncompressed size mod 2^32; for grammar blobs (well under 4 GB)
 	// it is exact. Fall back to io.ReadAll if the hint is implausible.
 	var raw []byte
-	if len(data) >= 4 {
-		isize := binary.LittleEndian.Uint32(data[len(data)-4:])
+	if len(compressed) >= 4 {
+		isize := binary.LittleEndian.Uint32(compressed[len(compressed)-4:])
 		if isize > 0 && isize < 256*1024*1024 { // sanity cap at 256 MB
 			raw = make([]byte, 0, isize)
 			var buf [32 * 1024]byte
@@ -64,6 +69,12 @@ func LoadLanguage(data []byte) (*Language, error) {
 	trailer, err := DecodeLargeStateGotosTrailer(br)
 	if err != nil {
 		return nil, fmt.Errorf("decode language: %w", err)
+	}
+	if expectsTrailer && len(trailer) == 0 {
+		return nil, fmt.Errorf("decode language: envelope requires a non-empty large-state-gotos trailer")
+	}
+	if !expectsTrailer && len(trailer) != 0 {
+		return nil, fmt.Errorf("decode language: large-state-gotos trailer requires a versioned envelope")
 	}
 	if trailer != nil {
 		lang.LargeStateGotos = trailer

--- a/load_language.go
+++ b/load_language.go
@@ -52,8 +52,21 @@ func LoadLanguage(data []byte) (*Language, error) {
 	}
 
 	var lang Language
-	if err := gob.NewDecoder(bytes.NewReader(raw)).Decode(&lang); err != nil {
+	br := bytes.NewReader(raw)
+	if err := gob.NewDecoder(br).Decode(&lang); err != nil {
 		return nil, fmt.Errorf("decode language: %w", err)
+	}
+	// LargeStateGotos (when non-empty) is never gob-encoded directly -- see
+	// large_state_gotos_trailer.go for why -- so restore it from the trailer
+	// appended after the gob message, if the encoder wrote one. This is a
+	// cheap no-op (returns immediately) for every blob without a trailer,
+	// including all blobs encoded before this trailer mechanism existed.
+	trailer, err := DecodeLargeStateGotosTrailer(br)
+	if err != nil {
+		return nil, fmt.Errorf("decode language: %w", err)
+	}
+	if trailer != nil {
+		lang.LargeStateGotos = trailer
 	}
 
 	InferGeneratedRepeatAuxMetadata(&lang)

--- a/load_language_large_state_gotos_test.go
+++ b/load_language_large_state_gotos_test.go
@@ -1,0 +1,128 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/gob"
+	"testing"
+)
+
+// TestLoadLanguageDecodesOldFormatLargeStateGotos simulates a blob produced
+// by the pre-fix encoder: LargeStateGotos gob-encoded directly as a struct
+// field, with no trailer. LoadLanguage must still restore it exactly via
+// gob's native map decode -- backward compatibility for all 206 blobs
+// checked in before this change, including c_sharp.bin.
+func TestLoadLanguageDecodesOldFormatLargeStateGotos(t *testing.T) {
+	want := buildSyntheticLargeStateGotos(300)
+	lang := &Language{
+		Name:            "old_format_csharp_like",
+		SymbolNames:     []string{"end"},
+		LargeStateGotos: want,
+	}
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
+		t.Fatalf("Encode (simulating pre-fix encoder): %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	loaded, err := LoadLanguage(buf.Bytes())
+	if err != nil {
+		t.Fatalf("LoadLanguage: %v", err)
+	}
+	if loaded.Name != lang.Name {
+		t.Fatalf("Name = %q, want %q", loaded.Name, lang.Name)
+	}
+	if len(loaded.LargeStateGotos) != len(want) {
+		t.Fatalf("LargeStateGotos has %d entries, want %d", len(loaded.LargeStateGotos), len(want))
+	}
+	for k, v := range want {
+		if loaded.LargeStateGotos[k] != v {
+			t.Fatalf("LargeStateGotos[%d] = %d, want %d", k, loaded.LargeStateGotos[k], v)
+		}
+	}
+}
+
+// TestLoadLanguageDecodesNewFormatTrailer simulates a blob produced by the
+// fixed encoder: LargeStateGotos cleared before the gob message, with a
+// deterministic trailer appended inside the same compressed stream.
+// LoadLanguage must reconstruct LargeStateGotos from the trailer.
+func TestLoadLanguageDecodesNewFormatTrailer(t *testing.T) {
+	want := buildSyntheticLargeStateGotos(300)
+	lang := &Language{
+		Name:        "new_format_csharp_like",
+		SymbolNames: []string{"end"},
+		// LargeStateGotos intentionally left nil -- the fixed encoder never
+		// hands a populated LargeStateGotos to gob directly.
+	}
+
+	trailer, err := EncodeLargeStateGotosTrailer(want)
+	if err != nil {
+		t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+	}
+	if len(trailer) == 0 {
+		t.Fatal("expected non-empty trailer")
+	}
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if _, err := gzw.Write(trailer); err != nil {
+		t.Fatalf("write trailer: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	loaded, err := LoadLanguage(buf.Bytes())
+	if err != nil {
+		t.Fatalf("LoadLanguage: %v", err)
+	}
+	if loaded.Name != lang.Name {
+		t.Fatalf("Name = %q, want %q", loaded.Name, lang.Name)
+	}
+	if len(loaded.LargeStateGotos) != len(want) {
+		t.Fatalf("LargeStateGotos has %d entries, want %d", len(loaded.LargeStateGotos), len(want))
+	}
+	for k, v := range want {
+		if loaded.LargeStateGotos[k] != v {
+			t.Fatalf("LargeStateGotos[%d] = %d, want %d", k, loaded.LargeStateGotos[k], v)
+		}
+	}
+}
+
+// TestLoadLanguageWithoutLargeStateGotosUnaffected pins that a Language whose
+// LargeStateGotos was never populated decodes identically regardless of the
+// trailer mechanism -- the vast majority of blobs (everything but c_sharp
+// today).
+func TestLoadLanguageWithoutLargeStateGotosUnaffected(t *testing.T) {
+	lang := &Language{
+		Name:        "java_like",
+		SymbolNames: []string{"end", "identifier"},
+	}
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if err := gob.NewEncoder(gzw).Encode(lang); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	loaded, err := LoadLanguage(buf.Bytes())
+	if err != nil {
+		t.Fatalf("LoadLanguage: %v", err)
+	}
+	if loaded.Name != lang.Name {
+		t.Fatalf("Name = %q, want %q", loaded.Name, lang.Name)
+	}
+	if len(loaded.LargeStateGotos) != 0 {
+		t.Fatalf("LargeStateGotos = %v, want empty", loaded.LargeStateGotos)
+	}
+}

--- a/load_language_large_state_gotos_test.go
+++ b/load_language_large_state_gotos_test.go
@@ -46,9 +46,51 @@ func TestLoadLanguageDecodesOldFormatLargeStateGotos(t *testing.T) {
 	}
 }
 
+func TestLoadLanguageRejectsUnenvelopedLargeStateGotosTrailer(t *testing.T) {
+	trailer, err := EncodeLargeStateGotosTrailer(buildSyntheticLargeStateGotos(4))
+	if err != nil {
+		t.Fatalf("EncodeLargeStateGotosTrailer: %v", err)
+	}
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if err := gob.NewEncoder(gzw).Encode(&Language{Name: "unenveloped"}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if _, err := gzw.Write(trailer); err != nil {
+		t.Fatalf("write trailer: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+
+	if _, err := LoadLanguage(buf.Bytes()); err == nil {
+		t.Fatal("LoadLanguage accepted a trailer without its versioned envelope")
+	}
+}
+
+func TestLoadLanguageRejectsEnvelopeWithoutLargeStateGotosTrailer(t *testing.T) {
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	if err := gob.NewEncoder(gzw).Encode(&Language{Name: "missing_trailer"}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := gzw.Close(); err != nil {
+		t.Fatalf("gzip Close: %v", err)
+	}
+	enveloped, err := WrapLanguageBlobEnvelope(buf.Bytes())
+	if err != nil {
+		t.Fatalf("WrapLanguageBlobEnvelope: %v", err)
+	}
+
+	if _, err := LoadLanguage(enveloped); err == nil {
+		t.Fatal("LoadLanguage accepted an envelope without its required trailer")
+	}
+}
+
 // TestLoadLanguageDecodesNewFormatTrailer simulates a blob produced by the
 // fixed encoder: LargeStateGotos cleared before the gob message, with a
-// deterministic trailer appended inside the same compressed stream.
+// deterministic trailer appended inside the same compressed stream and a
+// fail-closed version envelope outside gzip.
 // LoadLanguage must reconstruct LargeStateGotos from the trailer.
 func TestLoadLanguageDecodesNewFormatTrailer(t *testing.T) {
 	want := buildSyntheticLargeStateGotos(300)
@@ -78,8 +120,15 @@ func TestLoadLanguageDecodesNewFormatTrailer(t *testing.T) {
 	if err := gzw.Close(); err != nil {
 		t.Fatalf("gzip Close: %v", err)
 	}
+	enveloped, err := WrapLanguageBlobEnvelope(buf.Bytes())
+	if err != nil {
+		t.Fatalf("WrapLanguageBlobEnvelope: %v", err)
+	}
+	if _, err := gzip.NewReader(bytes.NewReader(enveloped)); err == nil {
+		t.Fatal("pre-envelope gzip-first runtime accepted a trailer-bearing blob")
+	}
 
-	loaded, err := LoadLanguage(buf.Bytes())
+	loaded, err := LoadLanguage(enveloped)
 	if err != nil {
 		t.Fatalf("LoadLanguage: %v", err)
 	}

--- a/parser_conflict_decode_test.go
+++ b/parser_conflict_decode_test.go
@@ -209,7 +209,11 @@ func loadBlobForDecode(t *testing.T, name string) *Language {
 	if err != nil {
 		t.Skipf("blob %s not present: %v", name, err)
 	}
-	gzr, err := gzip.NewReader(bytes.NewReader(data))
+	compressed, expectsTrailer, err := UnwrapLanguageBlobEnvelope(data)
+	if err != nil {
+		t.Fatalf("%s: envelope: %v", name, err)
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(compressed))
 	if err != nil {
 		t.Fatalf("%s: gzip: %v", name, err)
 	}
@@ -230,6 +234,12 @@ func loadBlobForDecode(t *testing.T, name string) *Language {
 	trailer, err := DecodeLargeStateGotosTrailer(br)
 	if err != nil {
 		t.Fatalf("%s: trailer: %v", name, err)
+	}
+	if expectsTrailer && len(trailer) == 0 {
+		t.Fatalf("%s: envelope requires a non-empty trailer", name)
+	}
+	if !expectsTrailer && len(trailer) != 0 {
+		t.Fatalf("%s: trailer requires an envelope", name)
 	}
 	if trailer != nil {
 		lang.LargeStateGotos = trailer

--- a/parser_conflict_decode_test.go
+++ b/parser_conflict_decode_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/gob"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"testing"
@@ -213,9 +214,25 @@ func loadBlobForDecode(t *testing.T, name string) *Language {
 		t.Fatalf("%s: gzip: %v", name, err)
 	}
 	defer gzr.Close()
+	// Fully buffer before decoding and restore the LargeStateGotos trailer,
+	// mirroring LoadLanguage: gob wraps a live gzip.Reader in a read-ahead
+	// buffer that would swallow the trailer, so a trailer-bearing blob decoded
+	// straight off the gzip stream would silently observe an empty map.
+	raw, err := io.ReadAll(gzr)
+	if err != nil {
+		t.Fatalf("%s: read gzip: %v", name, err)
+	}
 	var lang Language
-	if err := gob.NewDecoder(gzr).Decode(&lang); err != nil {
+	br := bytes.NewReader(raw)
+	if err := gob.NewDecoder(br).Decode(&lang); err != nil {
 		t.Fatalf("%s: gob: %v", name, err)
+	}
+	trailer, err := DecodeLargeStateGotosTrailer(br)
+	if err != nil {
+		t.Fatalf("%s: trailer: %v", name, err)
+	}
+	if trailer != nil {
+		lang.LargeStateGotos = trailer
 	}
 	return &lang
 }


### PR DESCRIPTION
## Summary

`Language.LargeStateGotos` (`map[uint64]StateID`) is the only exported map
field on `Language`. `encoding/gob`'s map codec iterates map fields via
`reflect.Value.MapRange`, which -- like a plain `range` over a Go map --
reseeds a random start offset on *every* call (`internal/runtime/maps.
(*Iter).Init` calls `rand()` each time it's invoked, not just once per
process or per map). That makes `grammargen`'s blob encoder emit
byte-different output on every run for any grammar whose remapped LR state
count crosses `uint16` and therefore populates `LargeStateGotos` (today:
only `c_sharp`, once the state-count-inflating change from #210 lands --
the currently checked-in `c_sharp.bin` on `main` has `StateCount=7986` and
an empty `LargeStateGotos`, so it doesn't yet trip this, but the mechanism
is real and independent of any specific grammar). This breaks
generate-twice-same-SHA determinism, which the wave-7 promotion automation
gates on.

## Mechanism

`LargeStateGotos` is never handed to gob directly anymore:

- **Encode** (`grammargen.encodeLanguageBlob`): when the map is non-empty,
  sort its entries by key and gob-encode them as a `[]largeStateGotoPair`
  trailer (`gotreesitter.EncodeLargeStateGotosTrailer`), then gob-encode a
  copy of `Language` with `LargeStateGotos` cleared, then append the
  trailer bytes after the gob payload, inside the same gzip stream. When
  the map is empty (everything but `c_sharp` today), this is a pure
  no-op wrapper around the original single `gob.Encode` call -- no clone,
  no trailer.
- **Decode** (`gotreesitter.LoadLanguage`, `grammargen.decodeLanguageBlob`,
  `grammars.decodeLanguageBlobData`): gob-decode `Language` exactly as
  before, then call `gotreesitter.DecodeLargeStateGotosTrailer` on
  whatever bytes remain in the buffer and merge the result into
  `LargeStateGotos`. This is a cheap no-op (returns immediately) whenever
  there's nothing left to read -- i.e. every blob without a trailer,
  including all 206 blobs checked in today.

A slice always gob-encodes in index order (`encodeArray` walks indices
`0..N-1`, no randomization), so sorting by key before encoding makes the
trailer -- and therefore the whole blob -- byte-identical across runs.

Three independent decode call sites needed the same treatment
(`load_language.go`, `grammargen/encode.go`, `grammars/embedded_loader.go`
each have their own `gob.NewDecoder(...).Decode(&lang)`), so the fix
touches all three, plus a one-line doc comment on `Language.LargeStateGotos`
in `language.go`. `parser_tables.go` / `parser_recover_c.go` (runtime GOTO
lookups) are untouched: `LargeStateGotos` is always fully restored to a
plain map before any runtime code sees the `Language`.

`grammargen/encode.go` needed one more wrinkle: `Language` embeds several
`sync.Once`/`atomic.Pointer` hot-path caches as unexported fields, so a
plain `clone := *lang` trips `go vet`'s copylocks check -- and mutating the
caller's shared `*Language` in place (even temporarily, with a restore)
risks a genuine "concurrent map read and map write" if some other goroutine
is reading `LargeStateGotos` on the parser hot path
(`parser_tables.go:lookupLargeStateGoto`) while a re-encode happens
elsewhere. `shallowCopyExportedLanguageFields` copies only the exported
fields via `reflect` (skipping the lock-bearing fields entirely), which is
both `go vet`-clean and race-free.

## Why not the "obvious" fixes

- **`GobEncoder`/`GobDecoder` on the field's type**: changes gob's wire
  *type* for that field from a native "map" `CommonType` to an opaque
  encoded-bytes representation. `encoding/gob`'s decoder
  (`compileDec`/`compatibleType`) hard-errors the moment a wire field's
  `GobEncoderT` marker disagrees with what the local type expects -- and
  since gob transmits a struct's type descriptor (its full field list)
  unconditionally, this would break decoding of **every** existing blob's
  `LargeStateGotos` field, not just `c_sharp`'s, regardless of whether that
  blob's map happened to be empty.
- **A new exported field on `Language`**: gob's type descriptor for a
  struct changes the moment a new field exists, independent of whether
  that field's value is ever non-zero. Verified empirically: two otherwise
  identical structs, one with an added always-nil slice field, gob-encode
  to different byte sequences. This would break the "byte-identical for
  languages without `LargeStateGotos`" requirement for all ~205 other
  languages, not just leave `c_sharp` alone.
- **A raw trailer appended directly after `gob.NewDecoder(gzr)`** (`gzr`
  being the live `gzip.Reader`): verified empirically that `gob.Decoder`
  can read ahead past its own message boundary on a streaming reader,
  silently swallowing trailer bytes it never needed. Decoding must happen
  from a fully-buffered `*bytes.Reader` (which has no such read-ahead and
  leaves the reader positioned exactly at the end of the decoded message)
  for the trailer to survive.

## Wire-compatibility proof (empirical)

- `encoding/gob`'s `decodeMap` reads a count then loops that many times
  decoding `(key, value)` and calling `SetMapIndex` -- entry order is
  never consulted, so decode is order-tolerant by construction. Confirmed
  by reading `encoding/gob/decode.go`.
- Old-format blobs (this branch's current 206 blobs, `LargeStateGotos`
  gob-encoded directly, no trailer) decode correctly under the new code:
  `TestDecodeLanguageBlobOldFormatWithLargeStateGotos`,
  `TestLoadLanguageDecodesOldFormatLargeStateGotos`, and the full
  `grammars` package suite (which loads all 206 checked-in blobs) pass.
- New-format blobs decode correctly under the new code:
  `TestEncodeDecodeLanguageBlobRoundTripWithLargeStateGotos`,
  `TestLoadLanguageDecodesNewFormatTrailer`.
- New-format blob decoded by *old* (pre-fix) code: gob's schema evolution
  means an unknown field name is silently ignored (`decIgnoreOpFor`), so
  this does not error -- but an old binary would end up with an empty
  `LargeStateGotos` for whichever grammar populated it, since the old
  decoder doesn't know to read the trailer. **This is not fully
  achievable** and is the one asymmetry in this fix: old blobs read by new
  code is exact and lossless; new blobs read by old code is
  non-erroring but lossy for `LargeStateGotos` specifically. Given this
  repo builds runtime + blobs together in lockstep for every case I could
  find except `grammars.LoadLanguage`'s doc comment mentioning "a remote
  WASM bundle" as a possible independently-distributed blob source, I
  judged this an acceptable trade-off rather than a blocker -- but it's
  worth owner sign-off given the doc comment suggests blobs *can* ship
  separately from the runtime in at least one path.

## Determinism proof

`TestEncodeLanguageBlobDeterministicWithLargeStateGotos` builds a synthetic
`Language` with a 4000-entry `LargeStateGotos` (shaped exactly like
`grammargen/assemble.go`'s `recordLargeGoto` output) and asserts
`encodeLanguageBlob` produces byte-identical output across 25 repeated
calls. This reproduces the bug cheaply without generating a real
uint16-crossing grammar (on this branch, off `main`, `c_sharp` doesn't
cross the threshold yet -- see above -- and generating one that does would
take ~9 minutes per the task brief). I confirmed this is a real regression
test, not a vacuous pass, by running the *frozen pre-fix* encoder logic
(kept in the test file as `oldEncodeLanguageBlob`, used elsewhere as the
byte-identity baseline) against the same synthetic `Language`: it produced
different-length output on the very first repeat (26476 vs 26478 bytes).

## SHA spot-checks

All 10 sampled real checked-in blobs (`java`, `go`, `regex`, `javascript`,
`c_sharp`, `python`, `rust`, `cobol`, `typescript`, `html`) have an empty
`LargeStateGotos` on this branch. For each, decoding the real blob once and
then encoding that same in-memory `Language` via both the frozen pre-fix
encoder and the fixed encoder produced byte-identical output (confirmed via
SHA-256, e.g. java.bin `c01c5809153a8976...`, go.bin `2b094dafb764c500...`,
matched exactly). Note: comparing straight against the *on-disk* file bytes
is a red herring here -- these files predate later additive fields on
`Language`/`SymbolMetadata` (gob's schema evolution legitimately grows the
type descriptor over time), so `encode(decode(file)) != file` already,
independent of this change. Comparing old-encoder-output vs
new-encoder-output on the same decoded value isolates exactly what this PR
changes.

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...`
- [x] `GOWORK=off go test ./grammargen/... -run 'Encode|Blob|Determinism' -count=1`
- [x] `GOWORK=off go test ./grammars/... -count=1` (loads and exercises all 206 shipped blobs)
- [x] New tests: `large_state_gotos_trailer_test.go`,
      `load_language_large_state_gotos_test.go`,
      `grammargen/blob_encode_determinism_test.go`

## Files changed

- `large_state_gotos_trailer.go` (new): the deterministic encode/decode
  helpers, confined to the blob container format -- zero changes to
  `Language`'s wire schema.
- `grammargen/encode.go`: `encodeLanguageBlob` builds the trailer and
  clears the map on a safe copy; `decodeLanguageBlob` restores it.
- `load_language.go`: `gotreesitter.LoadLanguage` restores the trailer.
- `grammars/embedded_loader.go`: `decodeLanguageBlobData` restores the
  trailer (this is the path the 206 shipped `.bin` blobs load through).
- `language.go`: doc-comment-only pointer from `LargeStateGotos` to the
  new mechanism. No field, type, or method changes.
- Tests: `large_state_gotos_trailer_test.go`,
  `load_language_large_state_gotos_test.go`,
  `grammargen/blob_encode_determinism_test.go`.

Built on `origin/main` (not `origin/wave7/memoize-lex-preemption`) -- PR #210
is not merged here, so the currently checked-in `c_sharp.bin` doesn't
actually cross the uint16 threshold on this branch (`StateCount=7986`,
`LargeStateGotos` empty). Determinism is proven with a synthetic grammar
shaped like `assemble.go`'s real output instead; see above.

## Review follow-ups (applied)
- Guard test: `Language` must have exactly one exported map field (`LargeStateGotos`) — a directly gob-encoded map field would silently reintroduce nondeterminism.
- The diagnostic test decoder (`loadBlobForDecode`) now buffers + restores the trailer, mirroring `LoadLanguage`.

## Merge order note
This PR is a pure no-op for every blob that exists today (nothing writes a trailer yet). **Merge it before #210** — that makes all decoders trailer-aware before the first trailer-bearing blob (c_sharp post-#210 regeneration) can exist, which dissolves the forward-compat asymmetry for lockstep builds. Independent blob distribution (e.g. a remote WASM bundle) should note a min-runtime-version once trailer-bearing blobs ship.
