### PR TITLE
fix(grammargen): rewrite crystal heredoc shape to bound generation

### DIFF
--- a/grammargen/import_grammarjson.go
+++ b/grammargen/import_grammarjson.go
@@ -148,6 +148,37 @@ func applyImportGrammarPostShapeHints(g *Grammar) {
 				Sym("heredoc_end"),
 			)
 		}
+	case "crystal":
+		if _, ok := g.Rules["heredoc_body"]; ok {
+			// Crystal has the same pathology as ruby's heredoc_body above (see
+			// SHAPE_RCA_CRYSTAL_TLAPLUS_RESCRIPT: "crystal | heredoc_body ->
+			// interpolation -> _expression (173304 >= cap 173304)"): heredoc_body
+			// is a grammar extra shaped SEQ(_heredoc_body_start,
+			// REPEAT(CHOICE(heredoc_content, interpolation,
+			// string_escape_sequence, ignored_backslash)), heredoc_end), and
+			// `interpolation` pulls in `_expression` - the entire expression
+			// grammar - as a nonterminal extra chain, tripping the synthetic-state
+			// budget guard (and, absent the guard, never converging) the same way
+			// ruby's heredoc_body did. Crystal's scanner-delimited alternatives
+			// differ from ruby's - string_escape_sequence and ignored_backslash,
+			// not escape_sequence - so this is not a byte-for-byte copy of the
+			// ruby rewrite, but the shape and the fix are identical: drop the
+			// recursive `interpolation` alternative and keep only the
+			// scanner-delimited content/escape path, so heredoc bodies stay a
+			// bounded extra. `interpolation` itself is untouched and still
+			// reachable from regular string literals; only heredoc bodies lose
+			// real interpolation-node structure - the same parity trade ruby and
+			// perl already accepted, pending a scanner-aware follow-up.
+			g.Rules["heredoc_body"] = Seq(
+				Sym("_heredoc_body_start"),
+				Repeat(Choice(
+					Sym("heredoc_content"),
+					Sym("string_escape_sequence"),
+					Sym("ignored_backslash"),
+				)),
+				Sym("heredoc_end"),
+			)
+		}
 	}
 }
 

--- a/grammargen/import_grammarjson_test.go
+++ b/grammargen/import_grammarjson_test.go
@@ -115,26 +115,20 @@ func TestApplyImportGrammarPostShapeHintsRubyHeredocBody(t *testing.T) {
 }
 
 // TestApplyImportGrammarPostShapeHintsRubyHeredocBodyIsGatedToRuby confirms
-// the rewrite is scoped to lang name "ruby" only, as required. crystal
-// shares the same pathology class as ruby's pre-rewrite heredoc_body (a
-// nonterminal-extra heredoc_body whose CHOICE includes an `interpolation`
-// alternative that re-enters the recursive statement/expression grammar),
-// but not the same concrete shape: per tree-sitter-crystal's grammar.json,
-// crystal's real heredoc_body is a 4-way
-// CHOICE(heredoc_content, interpolation, string_escape_sequence,
-// ignored_backslash), not ruby's 3-way
-// CHOICE(heredoc_content, interpolation, escape_sequence).
-//
-// The fixture below deliberately reuses ruby's exact shape under the grammar
-// name "crystal" rather than reproducing crystal's real 4-way shape: the
-// rewrite's gate (applyImportGrammarPostShapeHints, g.Name == "ruby") is
-// name-based, not shape-based, so shape is irrelevant to what this test is
-// proving - applying ruby's identical shape under a different grammar name
-// and confirming it is left untouched is precisely how to prove the gate
-// keys off the name, and that conclusion holds regardless of what crystal's
-// actual shape is. crystal is out of scope for this change and remains
-// protected only by the defense-in-depth synthetic-state budget guard in
-// addNonterminalExtraChains.
+// the ruby rewrite is scoped to lang name "ruby" only, as required, and that
+// crystal's own (distinct) heredoc_body rewrite - see
+// TestApplyImportGrammarPostShapeHintsCrystalHeredocBody - does not bleed
+// into ruby's gate or vice versa. elixir shares the same pathology class as
+// ruby's and crystal's pre-rewrite heredoc_body (a nonterminal-extra body
+// whose CHOICE includes an `interpolation` alternative that re-enters the
+// recursive statement/expression grammar) but has no heredoc_body rule at
+// all in its real grammar; the fixture below deliberately reuses ruby's
+// exact shape under the grammar name "elixir" to prove the rewrite's gate
+// (applyImportGrammarPostShapeHints, g.Name == "ruby") is name-based, not
+// shape-based - applying ruby's identical shape under a third, unrelated
+// grammar name and confirming it is left untouched is precisely how to
+// prove the gate keys off the name, and that conclusion holds regardless of
+// elixir's actual grammar shape. elixir is out of scope for this change.
 func TestApplyImportGrammarPostShapeHintsRubyHeredocBodyIsGatedToRuby(t *testing.T) {
 	original := Seq(
 		Sym("_heredoc_body_start"),
@@ -146,7 +140,7 @@ func TestApplyImportGrammarPostShapeHintsRubyHeredocBodyIsGatedToRuby(t *testing
 		Sym("heredoc_end"),
 	)
 
-	g := NewGrammar("crystal")
+	g := NewGrammar("elixir")
 	g.Define("heredoc_body", cloneRule(original))
 
 	applyImportGrammarPostShapeHints(g)
@@ -155,7 +149,7 @@ func TestApplyImportGrammarPostShapeHintsRubyHeredocBodyIsGatedToRuby(t *testing
 	repeat := rule.Children[1]
 	choice := repeat.Children[0]
 	if len(choice.Children) != 3 {
-		t.Fatalf("crystal's heredoc_body should be left untouched (3-way choice), got %#v", choice)
+		t.Fatalf("elixir's heredoc_body should be left untouched (3-way choice), got %#v", choice)
 	}
 	found := false
 	for _, child := range choice.Children {
@@ -164,6 +158,114 @@ func TestApplyImportGrammarPostShapeHintsRubyHeredocBodyIsGatedToRuby(t *testing
 		}
 	}
 	if !found {
-		t.Fatalf("crystal's heredoc_body should still reference interpolation, got %#v", choice)
+		t.Fatalf("elixir's heredoc_body should still reference interpolation, got %#v", choice)
+	}
+}
+
+// TestApplyImportGrammarPostShapeHintsCrystalHeredocBody mirrors
+// TestApplyImportGrammarPostShapeHintsRubyHeredocBody for crystal's
+// heredoc_body, which has the identical pathology (a nonterminal grammar
+// extra whose REPEAT(CHOICE(...)) body includes a visible `interpolation`
+// alternative that re-enters `_expression`) but a different concrete shape:
+// crystal's real heredoc_body is a 4-way CHOICE(heredoc_content,
+// interpolation, string_escape_sequence, ignored_backslash) - it does not
+// use ruby's `escape_sequence` symbol name. See
+// SHAPE_RCA_CRYSTAL_TLAPLUS_RESCRIPT ("crystal | heredoc_body ->
+// interpolation -> _expression (173304 >= cap 173304) | REWRITABLE-LIKE-RUBY
+// ... validated: drop `interpolation` from heredoc_body ... generates a
+// 217KB blob cleanly").
+func TestApplyImportGrammarPostShapeHintsCrystalHeredocBody(t *testing.T) {
+	g := NewGrammar("crystal")
+	g.Define("heredoc_body", Seq(
+		Sym("_heredoc_body_start"),
+		Repeat(Choice(
+			Sym("heredoc_content"),
+			Sym("interpolation"),
+			Sym("string_escape_sequence"),
+			Sym("ignored_backslash"),
+		)),
+		Sym("heredoc_end"),
+	))
+
+	applyImportGrammarPostShapeHints(g)
+
+	rule := g.Rules["heredoc_body"]
+	if rule == nil || rule.Kind != RuleSeq || len(rule.Children) != 3 {
+		t.Fatalf("heredoc_body rule = %#v, want compact seq", rule)
+	}
+	if rule.Children[0].Value != "_heredoc_body_start" {
+		t.Fatalf("heredoc_body start = %#v, want _heredoc_body_start", rule.Children[0])
+	}
+	if rule.Children[2].Value != "heredoc_end" {
+		t.Fatalf("heredoc_body end = %#v, want heredoc_end", rule.Children[2])
+	}
+	repeat := rule.Children[1]
+	if repeat == nil || repeat.Kind != RuleRepeat || len(repeat.Children) != 1 {
+		t.Fatalf("middle rule = %#v, want repeat", repeat)
+	}
+	choice := repeat.Children[0]
+	if choice == nil || choice.Kind != RuleChoice || len(choice.Children) != 3 {
+		t.Fatalf("repeat content = %#v, want compact three-way choice", choice)
+	}
+	if got := []string{choice.Children[0].Value, choice.Children[1].Value, choice.Children[2].Value}; got[0] != "heredoc_content" || got[1] != "string_escape_sequence" || got[2] != "ignored_backslash" {
+		t.Fatalf("compact heredoc alternatives = %v, want [heredoc_content string_escape_sequence ignored_backslash]", got)
+	}
+	// ignored_backslash must survive the rewrite: unlike ruby, crystal keeps
+	// two scanner-delimited alternatives alongside heredoc_content.
+	found := false
+	for _, child := range choice.Children {
+		if child.Value == "ignored_backslash" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("rewritten crystal heredoc_body must keep ignored_backslash, got %#v", choice)
+	}
+	// The recursive interpolation -> _expression path must be gone: it is
+	// the nonterminal-extra chain that never converges (SHAPE_RCA).
+	for _, child := range choice.Children {
+		if child.Value == "interpolation" {
+			t.Fatalf("rewritten heredoc_body must not reference interpolation, got %#v", rule)
+		}
+	}
+}
+
+// TestApplyImportGrammarPostShapeHintsCrystalHeredocBodyIsGatedFromRuby
+// confirms the crystal rewrite does not touch ruby's heredoc_body (and thus
+// does not accidentally require crystal's string_escape_sequence /
+// ignored_backslash symbol names to be present in ruby's grammar): ruby
+// keeps its own 3-way CHOICE(heredoc_content, interpolation,
+// escape_sequence) input, and only ruby's escape_sequence-shaped rewrite
+// applies to it, exactly as TestApplyImportGrammarPostShapeHintsRubyHeredocBody
+// already verifies. This test instead proves the converse direction: running
+// the switch against ruby's exact original (pre-rewrite) shape under grammar
+// name "crystal" produces crystal's rewrite (string_escape_sequence /
+// ignored_backslash), not ruby's (escape_sequence) - the two cases are
+// independent rewrites keyed strictly on g.Name, not on which symbols the
+// input happens to contain.
+func TestApplyImportGrammarPostShapeHintsCrystalHeredocBodyIsGatedFromRuby(t *testing.T) {
+	g := NewGrammar("ruby")
+	g.Define("heredoc_body", Seq(
+		Sym("_heredoc_body_start"),
+		Repeat(Choice(
+			Sym("heredoc_content"),
+			Sym("interpolation"),
+			Sym("escape_sequence"),
+		)),
+		Sym("heredoc_end"),
+	))
+
+	applyImportGrammarPostShapeHints(g)
+
+	rule := g.Rules["heredoc_body"]
+	repeat := rule.Children[1]
+	choice := repeat.Children[0]
+	if got := []string{choice.Children[0].Value, choice.Children[1].Value}; got[0] != "heredoc_content" || got[1] != "escape_sequence" {
+		t.Fatalf("ruby's heredoc_body should keep escape_sequence (ruby's rewrite, not crystal's), got %v", got)
+	}
+	for _, child := range choice.Children {
+		if child.Value == "string_escape_sequence" || child.Value == "ignored_backslash" {
+			t.Fatalf("ruby's heredoc_body should not pick up crystal's symbol names, got %#v", choice)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Stacked on #212 (`wave7/ruby-heredoc-genfix`) — merges after that PR. This
extends the same `applyImportGrammarPostShapeHints` switch that carries the
ruby heredoc rewrite (#212) with the analogous fix for crystal.

Per `SHAPE_RCA_CRYSTAL_TLAPLUS_RESCRIPT.md` (read-only investigation at
`wave7/ruby-heredoc-genfix @ dfff7fc5`), crystal's `heredoc_body` has the
identical pathology ruby had: a nonterminal grammar extra shaped
`SEQ(_heredoc_body_start, REPEAT(CHOICE(heredoc_content, interpolation,
string_escape_sequence, ignored_backslash)), heredoc_end)`, where
`interpolation` pulls in `_expression` — the entire expression grammar — as
a nonterminal-extra chain. That trips the synthetic-state budget guard
(173304 >= cap 173304) and, absent the guard, never converges.

The RCA verdict: **REWRITABLE-LIKE-RUBY** — validated fix is to drop the
recursive `interpolation` alternative and keep only the scanner-delimited
path:

```
heredoc_body = SEQ(_heredoc_body_start,
                    REPEAT(CHOICE(heredoc_content, string_escape_sequence, ignored_backslash)),
                    heredoc_end)
```

Note crystal's scanner-delimited alternatives (`string_escape_sequence`,
`ignored_backslash`) differ from ruby's (`escape_sequence`) — this is not a
byte-for-byte copy of the ruby case, but the same shape and the same fix.

**Parity trade** (same one ruby and perl already accepted): heredoc
interpolation is flattened out of `heredoc_body`'s visible structure.
`interpolation` itself is untouched and still reachable from regular string
literals — only heredoc bodies lose real interpolation-node structure,
pending a scanner-aware follow-up.

## Validated numbers

Generation, run twice, bounded (`GOMEMLIMIT=3GiB`, `timeout 5m`):

| Run | Wall time | Output | SHA-256 |
|---|---|---|---|
| crystal run 1 | ~32s | 217504 bytes (~217KB) | `14ee5233e72686dc3fc5bed2966bda9554be298a4b9cdcb99feb2c499532dd5b` |
| crystal run 2 | ~37s | 217504 bytes (~217KB) | `14ee5233e72686dc3fc5bed2966bda9554be298a4b9cdcb99feb2c499532dd5b` (identical) |

No `ExtraChainSyntheticStateBudgetError` trip; matches the RCA's "generates
a 217KB blob cleanly" prediction.

## SHA stability (unaffected languages)

| Grammar | Before | After | Match |
|---|---|---|---|
| ruby | `59d28601fab11cc669e9dd86bb2c1714857b8840d68371f676761847370d1974` | `59d28601fab11cc669e9dd86bb2c1714857b8840d68371f676761847370d1974` | identical |
| java | `49c5c451f0d2ebdb62fd1c8484c84d01dfe67e2938d22180caf3f3a212365a49` | `49c5c451f0d2ebdb62fd1c8484c84d01dfe67e2938d22180caf3f3a212365a49` | byte-identical |

## Changes

- `grammargen/import_grammarjson.go`: add a `case "crystal"` beside the
  existing ruby case in `applyImportGrammarPostShapeHints`, gated strictly
  on `g.Name == "crystal"`, with the RCA pointer, the pathology, and the
  parity trade documented inline.
- `grammargen/import_grammarjson_test.go`: mirrors the ruby tests —
  - crystal's rewrite applies and produces the expected 3-way
    `CHOICE(heredoc_content, string_escape_sequence, ignored_backslash)`
    shape, with `interpolation` gone.
  - crystal's rewrite doesn't bleed into ruby's (ruby-named input keeps
    `escape_sequence`, never picks up crystal's symbol names).
  - the existing "gated to ruby" test's premise changed now that crystal
    *is* legitimately rewritten by its own case, so it was reworked to use
    `elixir` (a third, unrelated grammar name) as the fixture proving the
    gate is name-based, not shape-based.
- `grammargen/lr.go`: no change needed — checked for the RCA's noted stale
  "multiplier=12" comment; the live code already documents
  `multiplier=24` correctly (with an accurate "(multiplier was 12 ... until
  ...)" historical note), so there was nothing stale left to fix.

## Smoke test (crystal, with the new blob)

Parsed real heredoc-bearing crystal source (from
`tree-sitter-crystal`'s own `test/corpus/literals.txt`, including an
interpolated heredoc body) through `cmd/grammargen doctor -json
.../crystal/src/grammar.json -sample ...`. Table generation itself is
unaffected by runtime scanning concerns (7340 states, 217504-byte blob,
100656 conflicts resolved / 3175 kept for GLR — in line with a grammar this
size). The parse attempt terminates fast and bounded (`iterations=9/10000`,
`nodes=11/300000`, `maxStacks=1`) rather than exploding — no runaway
GLR growth.

Honest caveat: `cmd/grammargen`'s `-json` import path has no external
scanner wired for *any* grammar (verified true for both crystal and ruby
through this same tool — even non-heredoc crystal snippets misparse without
Crystal's real unary/binary-operator scanner tokens), so this CLI can't
exercise genuine heredoc-content recognition for either language. That's
orthogonal to this change: crystal's shipped, production parsing uses the
ts2go blob + the real `CrystalExternalScanner` (`grammars/crystal_scanner.go`),
which this PR does not touch. What this PR fixes is table generation
convergence for the native grammargen path; interpolation-in-heredoc
structure is honestly flattened per the parity trade above, same as ruby.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./grammargen/ -run 'Heredoc|ShapeHint|ExtraChain|Budget' -count=1` — green
- [x] crystal generates twice, bounded, identical SHA-256
- [x] ruby SHA-256 unchanged vs branch
- [x] java byte-identical before/after
- [x] crystal smoke parse: no runaway/explosion, bounded diagnostics