### PR TITLE
fix(parser): preserve distinct-named children of visible alias targets

### DIFF
--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -43,19 +43,17 @@ var paritySkips = map[string]parityMeta{
 // lane and fails the build if a listed language unexpectedly passes, so this
 // map can only shrink truthfully going forward.
 var knownDegradedStructural = map[string]string{
-	// norg: fresh parse diverges from the C reference by 4 nodes — the Go
-	// parser collapses `_word` hidden wrapper nodes to ChildCount=0 where the
-	// C reference keeps a single child (see TestParityFreshParse/norg for the
-	// live divergence dump). Tracked as a genuine, unfixed scanner/version
-	// structural-shape gap; not yet assigned a fix owner.
-	"norg": "fresh parse structural parity still diverges from C reference (4 node divergences: _word hidden-wrapper ChildCount go=0 c=1)",
+	// Empty: the last known structural divergence (norg's `_word` alias
+	// hidden-wrapper collapse) was fixed by extending
+	// normalizeResultTerminalLeafNodes's visible-terminal guard to also
+	// preserve distinct-named children under reused alias-target symbol IDs
+	// (see parser_result_terminal_leaf.go). Fresh-parse structural parity is
+	// now 206/206 across the curated fleet.
 }
 
 // knownDegradedNoErrorClean preserves no-error coverage for structural backlog
 // entries whose current failure is tree shape, not error-node production.
-var knownDegradedNoErrorClean = map[string]struct{}{
-	"norg": {},
-}
+var knownDegradedNoErrorClean = map[string]struct{}{}
 
 type parityCase struct {
 	name   string

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -14,7 +14,7 @@ const (
 	minCuratedStructuralLanguages = 206
 	minCuratedHighlightLanguages  = 200
 	maxKnownDegradedStructural    = 0
-	maxKnownDegradedNoErrorClean  = 1
+	maxKnownDegradedNoErrorClean  = 0
 	maxKnownDegradedHighlight     = 49
 	maxParitySkips                = 0
 )

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -13,7 +13,7 @@ const (
 	// Ratchets: these should only move in the "stricter" direction over time.
 	minCuratedStructuralLanguages = 206
 	minCuratedHighlightLanguages  = 200
-	maxKnownDegradedStructural    = 1
+	maxKnownDegradedStructural    = 0
 	maxKnownDegradedNoErrorClean  = 1
 	maxKnownDegradedHighlight     = 49
 	maxParitySkips                = 0

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -35,7 +35,7 @@ func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCh
 		if !resultCanCollapseTerminalLeafChild(child, lang, aliasTargets) {
 			return true
 		}
-		if !resultSymbolIsVisibleTerminal(lang, n.symbol) && !resultSymbolNamesEqual(lang, n.symbol, child.symbol) {
+		if (!resultSymbolIsVisibleTerminal(lang, n.symbol) || resultSymbolIsVisibleAliasTarget(lang, n.symbol, aliasTargets)) && !resultSymbolNamesEqual(lang, n.symbol, child.symbol) {
 			// n only qualified via the alias-target set, which just records
 			// "this symbol is SOME production's alias somewhere in the
 			// grammar" -- it is not scoped to this specific reduction. A
@@ -45,6 +45,16 @@ func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCh
 			// splat_parameter wrapping a bare "*" token) is a real, distinct
 			// production whose child C tree-sitter keeps as a visible node --
 			// collapsing it here would silently drop a real AST child.
+			//
+			// Grammars can also reuse a genuine visible-terminal symbol ID as
+			// an alias target elsewhere (e.g. norg's "_word" alias reuses a
+			// symbol ID that also denotes a real terminal). In that case
+			// resultSymbolIsVisibleTerminal(n.symbol) alone is true and used
+			// to short-circuit this guard, even though -- for this specific
+			// reduction -- n is standing in for the alias, not the terminal.
+			// Treat "also a visible alias target" the same as "not a visible
+			// terminal": require matching names before collapsing so a
+			// distinct-named child under a reused ID is preserved too.
 			return true
 		}
 		n.startByte = child.startByte

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -180,6 +180,59 @@ func TestNormalizeResultTerminalLeafNodesCollapsesTerminalAliasTarget(t *testing
 	}
 }
 
+// TestNormalizeResultTerminalLeafNodesPreservesDistinctChildUnderReusedAliasTargetID
+// mirrors norg's "_word" alias: a symbol ID can simultaneously be a genuine
+// visible terminal (ID within TokenCount) AND a visible alias target
+// registered by some other production's AliasSequences entry. When that
+// reused-ID node wraps a DIFFERENT-named visible child (e.g. "_uppercase"),
+// the child is a real, distinct AST node C tree-sitter keeps -- it must not
+// be collapsed away just because the parent's ID happens to also denote a
+// plain terminal. Pre-fix, resultSymbolIsVisibleTerminal(n.symbol) alone
+// short-circuited the name-equality guard and dropped the child.
+func TestNormalizeResultTerminalLeafNodesPreservesDistinctChildUnderReusedAliasTargetID(t *testing.T) {
+	lang := &Language{
+		TokenCount: 3,
+		SymbolNames: []string{
+			"EOF",
+			"_lowercase_word",
+			"_word",
+			"root",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "_lowercase_word", Visible: true, Named: false},
+			{Name: "_word", Visible: true, Named: false},
+			{Name: "root", Visible: true, Named: true},
+		},
+		AliasSequences: [][]Symbol{
+			// Some other production aliases target symbol 2 ("_word"), which
+			// is ALSO a genuine visible terminal ID (< TokenCount) -- the
+			// reused-ID scenario that trips the pre-fix guard.
+			{2},
+		},
+	}
+	arena := newNodeArena(arenaClassFull)
+	child := newLeafNodeInArena(arena, 1, false, 20, 25, Point{Row: 0, Column: 20}, Point{Row: 0, Column: 25})
+	parent := newParentNodeInArena(arena, 2, false, []*Node{child}, nil, 0)
+	parent.startByte = 20
+	parent.endByte = 25
+	parent.startPoint = Point{Row: 0, Column: 20}
+	parent.endPoint = Point{Row: 0, Column: 25}
+	root := newParentNodeInArena(arena, 3, true, []*Node{parent}, nil, 0)
+
+	counters := normalizeResultTerminalLeafNodes(root, lang)
+
+	if got, want := counters.nodesRewritten, uint64(0); got != want {
+		t.Fatalf("nodesRewritten = %d, want %d", got, want)
+	}
+	if got, want := parent.ChildCount(), 1; got != want {
+		t.Fatalf("parent.ChildCount() = %d, want %d", got, want)
+	}
+	if got := parent.Child(0); got != child {
+		t.Fatalf("parent.Child(0) = %p, want original child %p", got, child)
+	}
+}
+
 func TestNormalizeResultTerminalLeafNodesPreservesFieldedTerminal(t *testing.T) {
 	lang := &Language{
 		TokenCount: 3,


### PR DESCRIPTION
## Stacked on #208

This PR is **stacked on #208** (`fix/parity-skip-list-flush`) — it edits the same skip-list region and merges after it. Diff here is scoped to the delta on top of #208's flush.

## Summary

Ships the last fresh-parse structural divergence in the 206-language curated fleet: norg.

**Root cause (extends the 949d9bdb guard class):** `normalizeResultTerminalLeafNodes` (`parser_result_terminal_leaf.go`) collapses a terminal-leaf-like parent into its single child when the parent's symbol is a visible terminal, unless the child has a different name — a guard added in 949d9bdb to stop distinct productions (e.g. Ruby's `splat_parameter` wrapping `*`) from being silently collapsed.

norg's `_word` alias reuses a symbol ID that **also** denotes a genuine visible terminal elsewhere in the grammar. `resultSymbolIsVisibleTerminal(lang, n.symbol)` returns `true` for that reused ID purely because the numeric ID happens to fall in the terminal range — even though, for this specific reduction, the node stands in for the alias, not the terminal. That short-circuited the 949d9bdb name-equality guard and let the pass unconditionally collapse the node, dropping norg's differently-named `_uppercase`/`_lowercase` children (4 node divergences: `ChildCount` go=0 vs c=1).

**Fix:** extend the guard so a different-named child is *also* preserved when the parent symbol is a visible alias target (regardless of whether it's independently also a "real" terminal ID):

```go
if (!resultSymbolIsVisibleTerminal(lang, n.symbol) || resultSymbolIsVisibleAliasTarget(lang, n.symbol, aliasTargets)) && !resultSymbolNamesEqual(lang, n.symbol, child.symbol) {
    return true // preserve, don't collapse
}
```

Genuine non-alias-target visible terminals are unaffected and still collapse unconditionally — `TestNormalizeResultTerminalLeafNodesCollapsesRedundantAnonymousTokenChild` and `TestNormalizeResultTerminalLeafNodesCollapsesTerminalAliasTarget` stay green.

## Changes

- `parser_result_terminal_leaf.go`: extend the visible-terminal guard to also preserve distinct-named children when the parent is a visible alias target (reused-ID case).
- `parser_result_terminal_leaf_test.go`: add `TestNormalizeResultTerminalLeafNodesPreservesDistinctChildUnderReusedAliasTargetID`, a synthetic reused-ID regression case (fails pre-fix with `nodesRewritten=1`, passes post-fix) mirroring norg's `_word` shape; existing collapse/preserve tests unchanged and green.
- `cgo_harness/parity_cgo_test.go`: remove `norg` from `knownDegradedStructural` and `knownDegradedNoErrorClean` — both skip lists are now **empty**.
- `cgo_harness/parity_gate_ratchet_test.go`: tighten `maxKnownDegradedStructural` 1 → 0. `TestParityKnownDegradedStructuralStillDiverges` (the #208 stale-skip ratchet) handles the now-empty list gracefully — zero subtests, trivial pass.

## Milestone: empty structural skip list

`knownDegradedStructural` and `knownDegradedNoErrorClean` are both now empty maps for the first time. Fresh-parse structural parity is **206/206** across the curated fleet with zero skips.

## Verification (exhaustive lane, reproduced on this branch)

Env: `GTS_PARITY_C_REF_BUILD_CACHE=<C reference build cache>`, `GTS_PARITY_ALLOW_HOST=1`, `GTS_PARITY_MODE=exhaustive`, from `cgo_harness/`.

- `TestParityFreshParse/norg` — PASS, 0 divergences.
- `TestParityFreshParse` (full sweep, all curated languages) — **206/206 PASS, 0 skip, 0 fail.**
- `TestParityHasNoErrors` (exhaustive) — 206/206 PASS, 0 skip, 0 fail. No regressions.
- `TestParityIncrementalParse` (exhaustive) — 206/206 PASS, 0 skip, 0 fail. No regressions.
- `TestParityGateCoverageRatchet` — PASS.
- `TestParityKnownDegradedStructuralStillDiverges` — PASS (0 subtests: empty list handled gracefully).
- Spot checks: `TestParityHighlight` (incl. `norg`), `TestParityHighlightAllGrammars`, `TestParityNoSkip`, `TestParityStructuralCorpus` — all PASS.

Standard suite:
- `GOWORK=off go build ./...` — clean.
- `GOWORK=off go test . -count=1 -short` — PASS.
- `GOWORK=off go test ./grammars/... -count=1` — PASS.
- `go vet` on both the root module and the `cgo_harness` module — clean.
- No pre-existing env-sensitive failures encountered.

## Deferred / secondary (not in scope here)

- regex `any_character` latent shape gap noted during the RCA — not a fresh-parse structural divergence today, left for separate follow-up.
- norg's `NonTerminalAliasMap` ts2go blob-generation gap (the alias-target metadata this fix consumes is currently synthesized at parse-normalization time rather than carried end-to-end from ts2go) — tracked as a follow-up, not required for this fix.

## Footprint

`parser_result_terminal_leaf.go` (+ test), `cgo_harness/parity_cgo_test.go` (skip lists), `cgo_harness/parity_gate_ratchet_test.go` (ratchet constant). No other files touched.