### PR TITLE
fix(cgo_harness): remove stale Norg parity exemption

### DIFF
--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -26,7 +26,8 @@ const (
 // same tightening change must remove it here too; additions or renames require
 // an explicit policy change in both places.
 var allowedKnownDegradedStructural = map[string]struct{}{
-	"norg": {},
+	// Empty: Norg's alias-target divergence was the final approved structural
+	// exemption, and PR #214 removed it from knownDegradedStructural.
 }
 
 // TestParityGateCoverageRatchet prevents silent narrowing of correctness gates.


### PR DESCRIPTION
## Summary

Removes the stale `norg` membership from `allowedKnownDegradedStructural`.

#214 correctly removed Norg from the live degraded map and tightened the ceiling to zero, but its branch predated #208's new membership allowlist. The three-way merge preserved #208's allowlist entry, making the integrated main ratchet self-contradictory.

## Verification

- Exact Docker gate: `TestParityGateCoverageRatchet` passes with `treesitter_c_parity`.
- Artifact: `harness_out/docker/20260710T222657Z-norg-allowlist-ratchet-r2`.
- `git diff --check` passes.

This is the sole failure from main push run 29127397054; all parser parity cases in that job passed.