### PR TITLE
test(grammargen): cover bounded Crystal heredoc generation

### DIFF
--- a/cgo_harness/docker/run_single_grammar_parity.sh
+++ b/cgo_harness/docker/run_single_grammar_parity.sh
@@ -71,7 +71,7 @@ ALL_GRAMMARS=(
   properties proto python regex requirements ron scala scheme sql ssh_config
   swift todotxt toml yaml
   # Large grammars (previously skipped):
-  rust c_sharp java ruby cpp kotlin cuda
+  rust c_sharp java ruby crystal cpp kotlin cuda
   # TypeScript family:
   typescript tsx
   # Legacy/enterprise languages:
@@ -85,7 +85,7 @@ FAILING_GRAMMARS=(
   jsdoc lua make nix ocaml php promql python regex requirements scala
   sql swift yaml
   # Large grammars (no baseline yet):
-  rust c_sharp java ruby cpp kotlin
+  rust c_sharp java ruby crystal cpp kotlin
 )
 
 usage() {

--- a/cgo_harness/parity_grammargen_cgo_test.go
+++ b/cgo_harness/parity_grammargen_cgo_test.go
@@ -121,6 +121,7 @@ var grammargenCGOGrammars = []grammargenCGOGrammar{
 	{name: "java", jsonPath: "/tmp/grammar_parity/java/src/grammar.json", blobFunc: grammars.JavaLanguage, genTimeout: 180 * time.Second},
 	{name: "python", jsonPath: "/tmp/grammar_parity/python/src/grammar.json", blobFunc: grammars.PythonLanguage, genTimeout: 300 * time.Second},
 	{name: "ruby", jsonPath: "/tmp/grammar_parity/ruby/src/grammar.json", blobFunc: grammars.RubyLanguage, genTimeout: 300 * time.Second},
+	{name: "crystal", jsonPath: "/tmp/grammar_parity/crystal/src/grammar.json", blobFunc: grammars.CrystalLanguage, genTimeout: 300 * time.Second},
 	{name: "javascript", jsonPath: "/tmp/grammar_parity/javascript/src/grammar.json", blobFunc: grammars.JavascriptLanguage, genTimeout: 90 * time.Second},
 	{name: "typescript", jsonPath: "/tmp/grammar_parity/typescript/typescript/src/grammar.json", blobFunc: grammars.TypescriptLanguage, genTimeout: 180 * time.Second},
 	{name: "tsx", jsonPath: "/tmp/grammar_parity/typescript/tsx/src/grammar.json", blobFunc: grammars.TsxLanguage, genTimeout: 180 * time.Second},

--- a/grammargen/extra_chain_state_budget_test.go
+++ b/grammargen/extra_chain_state_budget_test.go
@@ -85,6 +85,29 @@ func TestUseLALRNonterminalExtraStatesDispatch(t *testing.T) {
 		}
 	})
 
+	t.Run("crystal heredoc interpolation uses bounded item sets", func(t *testing.T) {
+		ng := &NormalizedGrammar{
+			GrammarName: "crystal",
+			Symbols: []SymbolInfo{
+				{Name: "end", Kind: SymbolTerminal},
+				{Name: "heredoc_start", Kind: SymbolTerminal},
+				{Name: "heredoc_body", Kind: SymbolNonterminal, IsExtra: true},
+				{Name: "heredoc_parts", Kind: SymbolNonterminal},
+				{Name: "interpolation", Kind: SymbolNonterminal},
+				{Name: "_expression", Kind: SymbolNonterminal},
+			},
+			ExtraSymbols: []int{2},
+			Productions: []Production{
+				{LHS: 2, RHS: []int{1, 3}, IsExtra: true},
+				{LHS: 3, RHS: []int{4}},
+				{LHS: 4, RHS: []int{5}},
+			},
+		}
+		if !useLALRNonterminalExtraStates(ng) {
+			t.Fatal("crystal heredoc_body -> interpolation -> _expression must use bounded LALR item sets")
+		}
+	})
+
 	t.Run("unrelated directive extra keeps legacy builder", func(t *testing.T) {
 		ng := &NormalizedGrammar{
 			Symbols: []SymbolInfo{

--- a/grammargen/import_grammarjson_test.go
+++ b/grammargen/import_grammarjson_test.go
@@ -138,3 +138,87 @@ func TestImportGrammarJSONRubyHeredocBodyPreservesInterpolation(t *testing.T) {
 		t.Fatalf("generated state count = %d, want a bounded non-zero automaton", lang.StateCount)
 	}
 }
+
+// TestImportGrammarJSONCrystalHeredocBodyPreservesInterpolation protects the
+// Crystal import path from the semantic shortcut that the original #213 used:
+// deleting interpolation from heredoc_body. The bounded LALR extra-state
+// builder must make the original grammar shape finite without changing it.
+func TestImportGrammarJSONCrystalHeredocBodyPreservesInterpolation(t *testing.T) {
+	data := []byte(`{
+		"name": "crystal",
+		"rules": {
+			"source_file": {"type": "SYMBOL", "name": "heredoc_body"},
+			"_expression": {"type": "CHOICE", "members": [
+				{"type": "SYMBOL", "name": "identifier"},
+				{"type": "SEQ", "members": [
+					{"type": "SYMBOL", "name": "identifier"},
+					{"type": "STRING", "value": "+"},
+					{"type": "SYMBOL", "name": "_expression"}
+				]}
+			]},
+			"identifier": {"type": "PATTERN", "value": "[a-z]+"},
+			"interpolation": {"type": "SEQ", "members": [
+				{"type": "STRING", "value": "#{"},
+				{"type": "SYMBOL", "name": "_expression"},
+				{"type": "STRING", "value": "}"}
+			]},
+			"heredoc_body": {"type": "SEQ", "members": [
+				{"type": "SYMBOL", "name": "_heredoc_body_start"},
+				{"type": "REPEAT", "content": {"type": "CHOICE", "members": [
+					{"type": "SYMBOL", "name": "heredoc_content"},
+					{"type": "SYMBOL", "name": "interpolation"},
+					{"type": "SYMBOL", "name": "string_escape_sequence"},
+					{"type": "SYMBOL", "name": "ignored_backslash"}
+				]}},
+				{"type": "SYMBOL", "name": "heredoc_end"}
+			]},
+			"_heredoc_body_start": {"type": "STRING", "value": "<<X"},
+			"heredoc_content": {"type": "PATTERN", "value": "[^#\\\\]+"},
+			"string_escape_sequence": {"type": "TOKEN", "content": {"type": "PATTERN", "value": "\\\\\\\\."}},
+			"ignored_backslash": {"type": "STRING", "value": "\\\\"},
+			"heredoc_end": {"type": "STRING", "value": "X"}
+		},
+		"extras": [{"type": "SYMBOL", "name": "heredoc_body"}],
+		"conflicts": [],
+		"externals": [],
+		"inline": [],
+		"supertypes": [],
+		"precedences": []
+	}`)
+
+	g, err := ImportGrammarJSON(data)
+	if err != nil {
+		t.Fatalf("ImportGrammarJSON: %v", err)
+	}
+
+	rule := g.Rules["heredoc_body"]
+	if rule == nil || rule.Kind != RuleSeq || len(rule.Children) != 3 {
+		t.Fatalf("heredoc_body rule = %#v, want original three-part sequence", rule)
+	}
+	repeat := rule.Children[1]
+	if repeat == nil || repeat.Kind != RuleRepeat || len(repeat.Children) != 1 {
+		t.Fatalf("heredoc_body middle = %#v, want repeat", repeat)
+	}
+	choice := repeat.Children[0]
+	if choice == nil || choice.Kind != RuleChoice || len(choice.Children) != 4 {
+		t.Fatalf("heredoc_body content = %#v, want original four-way choice", choice)
+	}
+	got := []string{choice.Children[0].Value, choice.Children[1].Value, choice.Children[2].Value, choice.Children[3].Value}
+	want := []string{"heredoc_content", "interpolation", "string_escape_sequence", "ignored_backslash"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("heredoc alternatives = %v, want %v", got, want)
+	}
+
+	interpolation := g.Rules["interpolation"]
+	if interpolation == nil || interpolation.Kind != RuleSeq || len(interpolation.Children) != 3 || interpolation.Children[1].Value != "_expression" {
+		t.Fatalf("interpolation rule = %#v, want path through _expression", interpolation)
+	}
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage(imported Crystal heredoc grammar): %v", err)
+	}
+	if lang.StateCount == 0 || lang.StateCount > 1000 {
+		t.Fatalf("generated state count = %d, want a bounded non-zero automaton", lang.StateCount)
+	}
+}

--- a/grammargen/parity_test.go
+++ b/grammargen/parity_test.go
@@ -2468,7 +2468,10 @@ func init() {
 		{name: "fennel", blobFunc: grammars.FennelLanguage, expectNoErrors: 1},
 		{name: "teal", blobFunc: grammars.TealLanguage, expectNoErrors: 1, expectParity: 1},
 		{name: "cobol", blobFunc: grammars.CobolLanguage, timeout: 300 * time.Second, expectNoErrors: 1, expectParity: 1},
-		{name: "crystal", blobFunc: grammars.CrystalLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
+		// Crystal's recursive heredoc interpolation now uses the bounded LALR
+		// extra-state builder. The locked grammar converges in roughly two
+		// minutes in the isolated parity container, so retain CI headroom.
+		{name: "crystal", blobFunc: grammars.CrystalLanguage, timeout: 180 * time.Second, expectNoErrors: 1, expectParity: 1},
 		{name: "perl", blobFunc: grammars.PerlLanguage, timeout: 90 * time.Second, expectNoErrors: 1, expectParity: 1},
 
 		// ── Batch 6: remaining grammars (all have external scanners) ──


### PR DESCRIPTION
## Summary

Supersedes the closed/conflicting #213 without carrying forward its grammar rewrite.

PR #212 already made recursive nonterminal-extra construction structural: a `heredoc_body` extra that reaches `interpolation` uses bounded LALR item sets. That detector covers Crystal as well as Ruby, so this follow-up adds Crystal-specific regression coverage and parity visibility instead of deleting Crystal heredoc interpolation.

- prove Crystal's `heredoc_body -> interpolation -> _expression` shape selects the bounded item-set path
- prove JSON import preserves all four Crystal heredoc alternatives and the interpolation path
- raise the locked Crystal generation allowance from 90s to 180s; the exact locked grammar currently completes in about 108s in Docker
- enroll Crystal in the isolated single-grammar/failing lists and direct grammargen-vs-C visibility lane

## Validation

- focused Docker tests: pass
- locked Crystal import pipeline: 14,471 states; 1/1 no-error; 1/1 exact parity
- direct grammargen-vs-C Docker run: pass as a visibility lane; 20 eligible, 16 no-error, 11 tree-parity
- independent exact-delta review: no actionable findings

## Known gaps

This does **not** claim full Crystal grammargen parity. The aggressive real-corpus sweep currently reports 11/26 no-error and 10/26 exact/deep parity, and the single-grammar wrapper correctly classifies that result as a mismatch. The direct-C lane has no Crystal ratchet floor yet, so it is visibility-only until a floor is established.

Buckley routed the requested Codex Terra-high review correctly, but the Codex CLI hit its usage limit before emitting an artifact. A separate exact-delta review completed with no actionable findings and independently reran the focused Docker tests green.
