### PR TITLE
fix(parser): re-lex JavaScript zero-width externals per GLR version

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1754,13 +1754,16 @@ func (p *Parser) tryRelexCurrentStateDFA(tok Token, parserState StateID, ts Toke
 }
 
 // peekZeroWidthExternalShiftForState asks an external scanner whether one
-// parser version needs a zero-width token before the already-lexed shared
-// lookahead. The scanner and token-source state are restored before return;
-// callers apply the returned shift only to that version, then retry the real
-// lookahead. This mirrors tree-sitter C's per-version lexing without replacing
-// a real token that another live version may still consume.
+// JavaScript parser version needs a zero-width token before the already-lexed
+// shared lookahead. JavaScript's external scanner has no serialized state, so
+// the scanner and token-source state can be restored before return; callers
+// apply the returned shift only to that version, then retry the real lookahead.
+// This mirrors tree-sitter C's per-version lexing without replacing a real
+// token that another live version may still consume. Keep this JavaScript-only
+// until stateful scanners can transfer the probed post-scan checkpoint onto
+// the shifted version instead of restoring it.
 func (p *Parser) peekZeroWidthExternalShiftForState(tok Token, state StateID, ts TokenSource) (Token, ParseAction, bool) {
-	if p == nil || p.language == nil || tok.NoLookahead || tok.StartByte == tok.EndByte || p.language.ExternalScanner == nil {
+	if p == nil || p.language == nil || p.language.Name != "javascript" || tok.NoLookahead || tok.StartByte == tok.EndByte || p.language.ExternalScanner == nil {
 		return Token{}, ParseAction{}, false
 	}
 	dts, ok := ts.(*dfaTokenSource)

--- a/parser.go
+++ b/parser.go
@@ -6706,6 +6706,9 @@ func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSou
 		restoreRejectedProbe()
 		return Token{}, false
 	}
+	// The returned token and committed scanner checkpoint belong to this parser
+	// state. Keep the source isolated through dispatch; the outer loop refreshes
+	// the live frontier before its next read, and same-pass re-lex paths set it.
 	return next, true
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1766,8 +1766,10 @@ func (p *Parser) peekZeroWidthExternalShiftForState(tok Token, state StateID, ts
 	if p == nil || p.language == nil || p.language.Name != "javascript" || tok.NoLookahead || tok.StartByte == tok.EndByte || p.language.ExternalScanner == nil {
 		return Token{}, ParseAction{}, false
 	}
-	dts, ok := ts.(*dfaTokenSource)
-	if !ok || dts == nil || !dts.CanRelexFromTokenStart(tok) {
+	stateful, statefulOK := ts.(parserStateTokenSource)
+	relexer, relexerOK := ts.(tokenSourceRelexer)
+	dts := underlyingDFATokenSource(ts)
+	if !statefulOK || !relexerOK || dts == nil || !relexer.CanRelexFromTokenStart(tok) {
 		return Token{}, ParseAction{}, false
 	}
 
@@ -1793,13 +1795,13 @@ func (p *Parser) peekZeroWidthExternalShiftForState(tok Token, state StateID, ts
 
 	snapshot := dts.snapshotRelexState()
 	savedState := dts.state
-	savedGLRStates := append([]StateID(nil), dts.glrStates...)
-	dts.state = state
-	dts.glrStates = nil
-	next, relexed := dts.RelexFromTokenStart(tok)
+	savedGLRStates := dts.glrStates
+	stateful.SetParserState(state)
+	stateful.SetGLRStates(nil)
+	next, relexed := relexer.RelexFromTokenStart(tok)
 	snapshot.restore(dts)
 	dts.state = savedState
-	dts.glrStates = append(dts.glrStates[:0], savedGLRStates...)
+	dts.glrStates = savedGLRStates
 
 	if !relexed || !next.ExternalScannerToken || next.StartByte != tok.StartByte || next.EndByte != next.StartByte {
 		return Token{}, ParseAction{}, false
@@ -6684,11 +6686,11 @@ func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSou
 	}
 	snapshot := dts.snapshotRelexState()
 	savedState := dts.state
-	savedGLRStates := append([]StateID(nil), dts.glrStates...)
+	savedGLRStates := dts.glrStates
 	restoreRejectedProbe := func() {
 		snapshot.restore(dts)
 		dts.state = savedState
-		dts.glrStates = append(dts.glrStates[:0], savedGLRStates...)
+		dts.glrStates = savedGLRStates
 		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
 	}
 	stateful.SetParserState(state)

--- a/parser.go
+++ b/parser.go
@@ -1753,6 +1753,69 @@ func (p *Parser) tryRelexCurrentStateDFA(tok Token, parserState StateID, ts Toke
 	return tok2, true
 }
 
+// peekZeroWidthExternalShiftForState asks an external scanner whether one
+// parser version needs a zero-width token before the already-lexed shared
+// lookahead. The scanner and token-source state are restored before return;
+// callers apply the returned shift only to that version, then retry the real
+// lookahead. This mirrors tree-sitter C's per-version lexing without replacing
+// a real token that another live version may still consume.
+func (p *Parser) peekZeroWidthExternalShiftForState(tok Token, state StateID, ts TokenSource) (Token, ParseAction, bool) {
+	if p == nil || p.language == nil || tok.NoLookahead || tok.StartByte == tok.EndByte || p.language.ExternalScanner == nil {
+		return Token{}, ParseAction{}, false
+	}
+	dts, ok := ts.(*dfaTokenSource)
+	if !ok || dts == nil || !dts.CanRelexFromTokenStart(tok) {
+		return Token{}, ParseAction{}, false
+	}
+
+	hasZeroWidthShiftCandidate := false
+	for _, symbol := range p.language.ExternalSymbols {
+		actionIndex := p.lookupActionIndex(state, symbol)
+		if actionIndex == 0 || int(actionIndex) >= len(p.language.ParseActions) {
+			continue
+		}
+		actions := p.language.ParseActions[actionIndex].Actions
+		if len(actions) != 1 {
+			continue
+		}
+		action := actions[0]
+		if action.Type == ParseActionShift && !action.Extra && action.State != 0 && action.State != state {
+			hasZeroWidthShiftCandidate = true
+			break
+		}
+	}
+	if !hasZeroWidthShiftCandidate {
+		return Token{}, ParseAction{}, false
+	}
+
+	snapshot := dts.snapshotRelexState()
+	savedState := dts.state
+	savedGLRStates := append([]StateID(nil), dts.glrStates...)
+	dts.state = state
+	dts.glrStates = nil
+	next, relexed := dts.RelexFromTokenStart(tok)
+	snapshot.restore(dts)
+	dts.state = savedState
+	dts.glrStates = append(dts.glrStates[:0], savedGLRStates...)
+
+	if !relexed || !next.ExternalScannerToken || next.StartByte != tok.StartByte || next.EndByte != next.StartByte {
+		return Token{}, ParseAction{}, false
+	}
+	actionIndex := p.lookupActionIndex(state, next.Symbol)
+	if actionIndex == 0 || int(actionIndex) >= len(p.language.ParseActions) {
+		return Token{}, ParseAction{}, false
+	}
+	actions := p.language.ParseActions[actionIndex].Actions
+	if len(actions) != 1 {
+		return Token{}, ParseAction{}, false
+	}
+	action := actions[0]
+	if action.Type != ParseActionShift || action.Extra || action.State == 0 || action.State == state {
+		return Token{}, ParseAction{}, false
+	}
+	return next, action, true
+}
+
 func (p *Parser) canRelexExternalTokenWithCurrentStateDFA(tok Token) bool {
 	if p == nil || p.language == nil || int(tok.Symbol) >= len(p.language.SymbolNames) {
 		return false
@@ -1843,7 +1906,7 @@ func (p *Parser) canFinalizeNoActionEOFAt(s *glrStack, expectedEOFByte uint32, s
 	return true
 }
 
-func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) bool {
+func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Token, ts TokenSource, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) bool {
 	if p == nil || p.language == nil || s == nil || s.dead || tok.NoLookahead {
 		return false
 	}
@@ -1935,6 +1998,14 @@ func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Tok
 		if s.dead {
 			return false
 		}
+	}
+	if externalTok, externalAct, ok := p.peekZeroWidthExternalShiftForState(tok, s.top().state, ts); ok {
+		p.applyAction(source, s, externalAct, externalTok, new(bool), nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)
+		if p.rejectUndrainedPendingForkStacks(s) {
+			return false
+		}
+		s.shifted = false
+		return true
 	}
 
 	p.crecoveryCostCompetitionRelevant = true // missing-token insertion makes costs relevant
@@ -4379,7 +4450,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	noTokenProgressHaveLast := false
 	missingShift := parseMissingShiftTracker{lastDepth: -1}
 	tryMissingSingleShift := func(stackIndex int, s *glrStack, currentState StateID) bool {
-		return missingShift.tryInsert(p, source, stackIndex, s, currentState, tok, &nodeCount, arena, scratch, &trackChildErrors)
+		return missingShift.tryInsert(p, source, stackIndex, s, currentState, tok, ts, &nodeCount, arena, scratch, &trackChildErrors)
 	}
 
 	for iter := 0; iter < maxIter; iter++ {
@@ -4864,6 +4935,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					return ns
 				}
 				sameState := parseStacksShareState(stacks, currentState)
+				canRelexNoLiveAction := !sameState && p.language != nil && p.language.Name == "javascript" && p.noLiveStackCanAcceptLookahead(stacks, tok)
 				if tok.Symbol == errorSymbol && tok.StartByte != tok.EndByte && p.errorCostCompetitionEnabled() {
 					// Faithful C recovery port: an unlexable-run lookahead has
 					// no table actions in C either; the version pauses and the
@@ -4963,6 +5035,17 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						recordNoActionTiming()
 					}
 					continue
+				}
+				if canRelexNoLiveAction {
+					if reTok, ok := p.tryRelexSingleParserState(tok, currentState, ts, stacks, scratch); ok {
+						tok = reTok
+						needToken = false
+						if actionTiming != nil {
+							ns := recordNoActionTiming()
+							actionTiming.actionNoActionRelexNanos += ns
+						}
+						goto retryAction
+					}
 				}
 				if sameState {
 					if reTok, ok := p.tryRelexCurrentStateDFA(tok, currentState, ts); ok {
@@ -6287,7 +6370,7 @@ func (t *parseMissingShiftTracker) resetForToken() {
 	t.consecutive = 0
 }
 
-func (t *parseMissingShiftTracker) tryInsert(p *Parser, source []byte, stackIndex int, s *glrStack, currentState StateID, tok Token, nodeCount *int, arena *nodeArena, scratch *parserScratch, trackChildErrors *bool) bool {
+func (t *parseMissingShiftTracker) tryInsert(p *Parser, source []byte, stackIndex int, s *glrStack, currentState StateID, tok Token, ts TokenSource, nodeCount *int, arena *nodeArena, scratch *parserScratch, trackChildErrors *bool) bool {
 	missingShiftDepth := s.depth()
 	if t.matches(currentState, missingShiftDepth, tok) && t.consecutive >= maxConsecutiveMissingSingleShifts {
 		if p.glrTrace {
@@ -6296,7 +6379,7 @@ func (t *parseMissingShiftTracker) tryInsert(p *Parser, source []byte, stackInde
 		}
 		return false
 	}
-	if !p.tryInsertMissingSingleShift(source, s, tok, nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
+	if !p.tryInsertMissingSingleShift(source, s, tok, ts, nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 		return false
 	}
 	if t.matches(currentState, missingShiftDepth, tok) {
@@ -6586,6 +6669,41 @@ func (p *Parser) updateCurrentRelexParserStateTokenSource(ts TokenSource, stacks
 		return true
 	}
 	stateful.SetGLRStates(glrBuf)
+	return true
+}
+
+func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSource, stacks []glrStack, scratch *parserScratch) (Token, bool) {
+	stateful, statefulOK := ts.(parserStateTokenSource)
+	relexer, relexerOK := ts.(tokenSourceRelexer)
+	if !statefulOK || !relexerOK || !relexer.CanRelexFromTokenStart(tok) {
+		return Token{}, false
+	}
+	stateful.SetParserState(state)
+	clearGLRStateTokenSource(stateful, scratch)
+	next, ok := relexer.RelexFromTokenStart(tok)
+	actionIndex := p.lookupActionIndex(state, next.Symbol)
+	if !ok || !next.ExternalScannerToken || next.StartByte != tok.StartByte || next.EndByte != next.StartByte || (next.Symbol == tok.Symbol && next.StartByte == tok.StartByte && next.EndByte == tok.EndByte) || actionIndex == 0 || int(actionIndex) >= len(p.language.ParseActions) {
+		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
+		return Token{}, false
+	}
+	actions := p.language.ParseActions[actionIndex].Actions
+	if len(actions) != 1 || actions[0].Type != ParseActionShift || actions[0].Extra || actions[0].State == 0 || actions[0].State == state {
+		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
+		return Token{}, false
+	}
+	return next, true
+}
+
+func (p *Parser) noLiveStackCanAcceptLookahead(stacks []glrStack, tok Token) bool {
+	for stackIndex := range stacks {
+		candidate := &stacks[stackIndex]
+		if candidate.dead || candidate.accepted || candidate.shifted || candidate.cPaused || candidate.depth() == 0 {
+			continue
+		}
+		if p.lookupActionIndex(candidate.top().state, tok.Symbol) != 0 {
+			return false
+		}
+	}
 	return true
 }
 

--- a/parser.go
+++ b/parser.go
@@ -6678,20 +6678,30 @@ func (p *Parser) updateCurrentRelexParserStateTokenSource(ts TokenSource, stacks
 func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSource, stacks []glrStack, scratch *parserScratch) (Token, bool) {
 	stateful, statefulOK := ts.(parserStateTokenSource)
 	relexer, relexerOK := ts.(tokenSourceRelexer)
-	if !statefulOK || !relexerOK || !relexer.CanRelexFromTokenStart(tok) {
+	dts := underlyingDFATokenSource(ts)
+	if !statefulOK || !relexerOK || dts == nil || !relexer.CanRelexFromTokenStart(tok) {
 		return Token{}, false
+	}
+	snapshot := dts.snapshotRelexState()
+	savedState := dts.state
+	savedGLRStates := append([]StateID(nil), dts.glrStates...)
+	restoreRejectedProbe := func() {
+		snapshot.restore(dts)
+		dts.state = savedState
+		dts.glrStates = append(dts.glrStates[:0], savedGLRStates...)
+		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
 	}
 	stateful.SetParserState(state)
 	clearGLRStateTokenSource(stateful, scratch)
 	next, ok := relexer.RelexFromTokenStart(tok)
 	actionIndex := p.lookupActionIndex(state, next.Symbol)
 	if !ok || !next.ExternalScannerToken || next.StartByte != tok.StartByte || next.EndByte != next.StartByte || (next.Symbol == tok.Symbol && next.StartByte == tok.StartByte && next.EndByte == tok.EndByte) || actionIndex == 0 || int(actionIndex) >= len(p.language.ParseActions) {
-		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
+		restoreRejectedProbe()
 		return Token{}, false
 	}
 	actions := p.language.ParseActions[actionIndex].Actions
 	if len(actions) != 1 || actions[0].Type != ParseActionShift || actions[0].Extra || actions[0].State == 0 || actions[0].State == state {
-		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
+		restoreRejectedProbe()
 		return Token{}, false
 	}
 	return next, true

--- a/parser_relex_frontier_lifecycle_test.go
+++ b/parser_relex_frontier_lifecycle_test.go
@@ -1,0 +1,91 @@
+package gotreesitter
+
+import "testing"
+
+type frontierRefreshScanner struct{ calls []uint8 }
+
+func (*frontierRefreshScanner) Create() any                    { return nil }
+func (*frontierRefreshScanner) Destroy(any)                    {}
+func (*frontierRefreshScanner) Serialize(any, []byte) int      { return 0 }
+func (*frontierRefreshScanner) Deserialize(any, []byte)        {}
+func (*frontierRefreshScanner) SupportsIncrementalReuse() bool { return true }
+func (s *frontierRefreshScanner) Scan(_ any, lexer *ExternalLexer, valid []bool) bool {
+	var mask uint8
+	for i, ok := range valid {
+		if ok {
+			mask |= 1 << i
+		}
+	}
+	s.calls = append(s.calls, mask)
+	if mask&1 != 0 {
+		lexer.SetResultSymbol(3)
+		lexer.MarkEnd()
+		return true
+	}
+	if mask&2 != 0 && lexer.Lookahead() == 'x' {
+		lexer.Advance(false)
+		lexer.MarkEnd()
+		lexer.SetResultSymbol(4)
+		return true
+	}
+	return false
+}
+
+// The next token is a sibling-only external. It proves that the parser keeps
+// the successful ASI re-lex isolated for dispatch, then restores the live GLR
+// frontier before the following token-source read.
+func TestSingleStateRelexRefreshesFrontierBeforeNextToken(t *testing.T) {
+	scanner := &frontierRefreshScanner{}
+	lang := &Language{
+		Name: "javascript", SymbolCount: 7, TokenCount: 5, ExternalTokenCount: 2,
+		StateCount: 7, ProductionIDCount: 2,
+		SymbolNames:     []string{"end", "a", "x", "_automatic_semicolon", "witness", "left", "right"},
+		SymbolMetadata:  make([]SymbolMetadata, 7),
+		ExternalSymbols: []Symbol{3, 4},
+		ExternalScanner: scanner,
+		LexStates: []LexState{
+			{Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: 'a', Hi: 'a', NextState: 1}, {Lo: 'x', Hi: 'x', NextState: 2}}},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+		LexModes: make([]LexMode, 7),
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}, {Type: ParseActionShift, State: 2}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 5, ChildCount: 1, ProductionID: 0}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 6, ChildCount: 1, ProductionID: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 6}}},
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},
+		},
+		ParseTable: [][]uint16{
+			{0, 1, 0, 0, 0, 4, 5},
+			{0, 0, 2, 0, 0, 0, 0},
+			{0, 0, 3, 0, 0, 0, 0},
+			{0, 0, 0, 6, 0, 0, 0},
+			{0, 0, 0, 0, 0, 0, 0},
+			{0, 0, 0, 0, 7, 0, 0},
+			{8, 0, 0, 0, 0, 0, 0},
+		},
+	}
+	p := NewParser(lang)
+	valid := make([][]uint16, lang.StateCount)
+	valid[3], valid[4] = []uint16{0}, []uint16{1}
+	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, []byte("ax")), lang, p.lookupActionIndex, nil, valid, nil)
+	tree := p.parseInternal([]byte("ax"), ts, nil, nil, arenaClassFull, nil, 0, 0, 0, false)
+	if tree == nil {
+		t.Fatal("parse returned nil tree")
+	}
+	defer tree.Release()
+	if got := tree.ParseStopReason(); got != ParseStopAccepted {
+		t.Fatalf("stop reason = %s, want %s; scanner calls = %v", got, ParseStopAccepted, scanner.calls)
+	}
+	for i := 0; i+1 < len(scanner.calls); i++ {
+		if scanner.calls[i] == 1 && scanner.calls[i+1] == 2 {
+			return
+		}
+	}
+	t.Fatalf("scanner calls = %v, want isolated ASI (1) then refreshed sibling witness (2)", scanner.calls)
+}

--- a/parser_relex_state_test.go
+++ b/parser_relex_state_test.go
@@ -186,6 +186,83 @@ func TestTryRelexSingleParserStateAcceptsOnlyZeroWidthExternalShift(t *testing.T
 	}
 }
 
+func TestPeekZeroWidthExternalShiftForStateWorksThroughSetIncludedRanges(t *testing.T) {
+	lang := &Language{
+		Name:            "javascript",
+		StateCount:      4,
+		SymbolCount:     4,
+		TokenCount:      4,
+		SymbolNames:     []string{"end", "original", "candidate", "_automatic_semicolon"},
+		ExternalSymbols: []Symbol{3},
+		ExternalScanner: zeroWidthRelexExternalScanner{},
+		LexStates: []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+				},
+			},
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{{LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}},
+		ParseTable: [][]uint16{
+			make([]uint16, 4),
+			make([]uint16, 4),
+			make([]uint16, 4),
+			make([]uint16, 4),
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+		},
+	}
+	lang.ParseTable[1][3] = 1
+	p := NewParser(lang)
+	p.SetIncludedRanges([]Range{{StartByte: 0, EndByte: 2, EndPoint: Point{Column: 2}}})
+	externalValidByState := make([][]uint16, 4)
+	externalValidByState[1] = []uint16{0}
+	dts := newDFATokenSourceDirect(NewLexer(lang.LexStates, []byte("xx")), lang, p.lookupActionIndex, nil, externalValidByState, nil)
+	dts.lexer.pos = 2
+	dts.lexer.col = 2
+	dts.state = 2
+	dts.glrStates = []StateID{1, 2}
+	ts := p.wrapIncludedRanges(dts)
+	original := Token{
+		Symbol:     1,
+		StartByte:  1,
+		EndByte:    2,
+		StartPoint: Point{Column: 1},
+		EndPoint:   Point{Column: 2},
+	}
+
+	got, action, ok := p.peekZeroWidthExternalShiftForState(original, 1, ts)
+	if !ok {
+		t.Fatal("zero-width external shift was rejected through the included-range wrapper")
+	}
+	if got.Symbol != 3 || got.StartByte != 1 || got.EndByte != 1 {
+		t.Fatalf("relexed token = %+v, want zero-width external symbol 3 at byte 1", got)
+	}
+	if action.Type != ParseActionShift || action.State != 3 {
+		t.Fatalf("action = %+v, want shift to state 3", action)
+	}
+	if dts.state != 2 || len(dts.glrStates) != 2 || dts.glrStates[0] != 1 || dts.glrStates[1] != 2 {
+		t.Fatalf("parser/GLR states = %d/%v, want restored 2/[1 2]", dts.state, dts.glrStates)
+	}
+	if dts.lexer.pos != 2 || dts.lexer.col != 2 {
+		t.Fatalf("lexer = pos %d col %d, want restored 2/2", dts.lexer.pos, dts.lexer.col)
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		p.peekZeroWidthExternalShiftForState(original, 1, ts)
+	})
+	// Scanner snapshot/relex setup currently accounts for two allocations. The
+	// saved GLR frontier must remain a slice-header restore, not add save and
+	// restore copies to this per-version probe.
+	if allocs > 2 {
+		t.Fatalf("included-range zero-width probe allocations = %.1f, want at most 2", allocs)
+	}
+}
+
 func TestTryRelexSingleParserStateRejectedCandidateRestoresDFATransaction(t *testing.T) {
 	lang := &Language{
 		Name:            "javascript",

--- a/parser_relex_state_test.go
+++ b/parser_relex_state_test.go
@@ -7,26 +7,20 @@ type recordingParserStateTokenSource struct {
 	glrStates    [][]StateID
 }
 
-type zeroWidthExternalRelexTokenSource struct {
-	relexed      Token
-	parserStates []StateID
-	glrStates    [][]StateID
-}
+type zeroWidthRelexExternalScanner struct{}
 
-func (s *zeroWidthExternalRelexTokenSource) Next() Token { return Token{} }
-
-func (s *zeroWidthExternalRelexTokenSource) SetParserState(state StateID) {
-	s.parserStates = append(s.parserStates, state)
-}
-
-func (s *zeroWidthExternalRelexTokenSource) SetGLRStates(states []StateID) {
-	s.glrStates = append(s.glrStates, append([]StateID(nil), states...))
-}
-
-func (s *zeroWidthExternalRelexTokenSource) CanRelexFromTokenStart(Token) bool { return true }
-
-func (s *zeroWidthExternalRelexTokenSource) RelexFromTokenStart(Token) (Token, bool) {
-	return s.relexed, true
+func (zeroWidthRelexExternalScanner) Create() any                    { return nil }
+func (zeroWidthRelexExternalScanner) Destroy(any)                    {}
+func (zeroWidthRelexExternalScanner) Serialize(any, []byte) int      { return 0 }
+func (zeroWidthRelexExternalScanner) Deserialize(any, []byte)        {}
+func (zeroWidthRelexExternalScanner) SupportsIncrementalReuse() bool { return true }
+func (zeroWidthRelexExternalScanner) Scan(_ any, lexer *ExternalLexer, valid []bool) bool {
+	if len(valid) == 0 || !valid[0] {
+		return false
+	}
+	lexer.SetResultSymbol(3)
+	lexer.MarkEnd()
+	return true
 }
 
 func (s *recordingParserStateTokenSource) Next() Token { return Token{} }
@@ -130,13 +124,101 @@ func TestNoLiveStackCanAcceptLookaheadRequiresEveryEligibleVersionToReject(t *te
 
 func TestTryRelexSingleParserStateAcceptsOnlyZeroWidthExternalShift(t *testing.T) {
 	lang := &Language{
-		StateCount:  4,
-		SymbolCount: 3,
+		Name:            "javascript",
+		StateCount:      4,
+		SymbolCount:     4,
+		TokenCount:      4,
+		SymbolNames:     []string{"end", "original", "candidate", "_automatic_semicolon"},
+		ExternalSymbols: []Symbol{3},
+		ExternalScanner: zeroWidthRelexExternalScanner{},
+		LexStates: []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+				},
+			},
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{{LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}},
 		ParseTable: [][]uint16{
-			make([]uint16, 3),
-			make([]uint16, 3),
-			make([]uint16, 3),
-			make([]uint16, 3),
+			make([]uint16, 4),
+			make([]uint16, 4),
+			make([]uint16, 4),
+			make([]uint16, 4),
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+		},
+	}
+	lang.ParseTable[1][3] = 1
+	p := NewParser(lang)
+	stacks := []glrStack{
+		{entries: []stackEntry{{state: 1}}},
+		{entries: []stackEntry{{state: 2}}},
+	}
+	original := Token{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}}
+	externalValidByState := make([][]uint16, 4)
+	externalValidByState[1] = []uint16{0}
+	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, []byte("x")), lang, p.lookupActionIndex, nil, externalValidByState, nil)
+	ts.lexer.pos = 1
+	ts.lexer.col = 1
+	ts.state = 2
+	ts.glrStates = []StateID{1, 2}
+
+	got, ok := p.tryRelexSingleParserState(original, 1, ts, stacks, &parserScratch{})
+	if !ok {
+		t.Fatal("zero-width external shift was rejected")
+	}
+	if got.Symbol != 3 || got.StartByte != 0 || got.EndByte != 0 {
+		t.Fatalf("relexed token = %+v, want zero-width external symbol 3 at byte 0", got)
+	}
+	if ts.state != 1 {
+		t.Fatalf("parser state = %d, want isolated state 1", ts.state)
+	}
+	if len(ts.glrStates) != 0 {
+		t.Fatalf("GLR states = %v, want cleared frontier", ts.glrStates)
+	}
+	if ts.lexer.pos != 0 {
+		t.Fatalf("lexer position = %d, want committed zero-width position 0", ts.lexer.pos)
+	}
+}
+
+func TestTryRelexSingleParserStateRejectedCandidateRestoresDFATransaction(t *testing.T) {
+	lang := &Language{
+		Name:            "javascript",
+		StateCount:      4,
+		SymbolCount:     4,
+		TokenCount:      4,
+		SymbolNames:     []string{"end", "original", "candidate", "external"},
+		ExternalSymbols: []Symbol{3},
+		ExternalScanner: byteStateExternalScanner{},
+		LexStates: []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+				},
+			},
+			{
+				AcceptToken: 2,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{
+					{Lo: 'y', Hi: 'y', NextState: 2},
+				},
+			},
+			{AcceptToken: 2, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{{LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}},
+		ParseTable: [][]uint16{
+			make([]uint16, 4),
+			make([]uint16, 4),
+			make([]uint16, 4),
+			make([]uint16, 4),
 		},
 		ParseActions: []ParseActionEntry{
 			{},
@@ -149,33 +231,51 @@ func TestTryRelexSingleParserStateAcceptsOnlyZeroWidthExternalShift(t *testing.T
 		{entries: []stackEntry{{state: 1}}},
 		{entries: []stackEntry{{state: 2}}},
 	}
-	original := Token{Symbol: 1, StartByte: 10, EndByte: 11}
-	ts := &zeroWidthExternalRelexTokenSource{relexed: Token{
-		Symbol:               2,
-		StartByte:            10,
-		EndByte:              10,
-		ExternalScannerToken: true,
-	}}
+	original := Token{Symbol: 1, StartByte: 0, EndByte: 1, EndPoint: Point{Column: 1}}
+	ts := newDFATokenSourceDirect(NewLexer(lang.LexStates, []byte("xy")), lang, p.lookupActionIndex, nil, nil, nil)
+	ts.usesExternalCheckpoints = true
+	ts.lastExternalTokenStartByte = 0
+	ts.lastExternalTokenEndByte = 1
+	ts.lastExternalTokenValid = true
+	ts.externalTokenStart = append(ts.externalTokenStart[:0], 2)
+	ts.externalTokenEnd = append(ts.externalTokenEnd[:0], 9)
+	*ts.externalPayload.(*byte) = 9
+	ts.lexer.pos = 1
+	ts.lexer.row = 4
+	ts.lexer.col = 7
+	ts.state = 2
+	ts.glrStates = []StateID{1, 2}
+	ts.extZeroPos = 11
+	ts.extZeroState = 2
+	ts.extZeroTried = append(ts.extZeroTried[:0], true)
+	ts.zeroWidthPos = 13
+	ts.zeroWidthCount = 3
 
-	got, ok := p.tryRelexSingleParserState(original, 1, ts, stacks, &parserScratch{})
-	if !ok {
-		t.Fatal("zero-width external shift was rejected")
-	}
-	if got.Symbol != 2 || got.StartByte != 10 || got.EndByte != 10 {
-		t.Fatalf("relexed token = %+v, want zero-width external symbol 2 at byte 10", got)
-	}
-	if len(ts.parserStates) != 1 || ts.parserStates[0] != 1 {
-		t.Fatalf("parser state calls = %v, want [1]", ts.parserStates)
-	}
-	if len(ts.glrStates) != 1 || len(ts.glrStates[0]) != 0 {
-		t.Fatalf("GLR state calls = %v, want one cleared frontier", ts.glrStates)
-	}
-
-	ts.relexed.EndByte = 11
 	if _, ok := p.tryRelexSingleParserState(original, 1, ts, stacks, &parserScratch{}); ok {
 		t.Fatal("non-zero-width replacement was accepted")
 	}
-	if got := ts.glrStates[len(ts.glrStates)-1]; len(got) != 2 || got[0] != 1 || got[1] != 2 {
-		t.Fatalf("failed relex restored GLR states = %v, want [1 2]", got)
+	if ts.lexer.pos != 1 || ts.lexer.row != 4 || ts.lexer.col != 7 {
+		t.Fatalf("lexer = pos %d row %d col %d, want restored 1/4/7", ts.lexer.pos, ts.lexer.row, ts.lexer.col)
+	}
+	if got := *ts.externalPayload.(*byte); got != 9 {
+		t.Fatalf("external scanner state = %d, want restored 9", got)
+	}
+	if !ts.lastExternalTokenValid || ts.lastExternalTokenStartByte != 0 || ts.lastExternalTokenEndByte != 1 {
+		t.Fatalf("last external token = valid %t start %d end %d, want true/0/1", ts.lastExternalTokenValid, ts.lastExternalTokenStartByte, ts.lastExternalTokenEndByte)
+	}
+	if got := ts.externalTokenStart; len(got) != 1 || got[0] != 2 {
+		t.Fatalf("external token start checkpoint = %v, want [2]", got)
+	}
+	if got := ts.externalTokenEnd; len(got) != 1 || got[0] != 9 {
+		t.Fatalf("external token end checkpoint = %v, want [9]", got)
+	}
+	if ts.extZeroPos != 11 || ts.extZeroState != 2 || len(ts.extZeroTried) != 1 || !ts.extZeroTried[0] {
+		t.Fatalf("external zero-width guard = pos %d state %d tried %v, want 11/2/[true]", ts.extZeroPos, ts.extZeroState, ts.extZeroTried)
+	}
+	if ts.zeroWidthPos != 13 || ts.zeroWidthCount != 3 {
+		t.Fatalf("zero-width guard = pos %d count %d, want 13/3", ts.zeroWidthPos, ts.zeroWidthCount)
+	}
+	if ts.state != 1 || len(ts.glrStates) != 2 || ts.glrStates[0] != 1 || ts.glrStates[1] != 2 {
+		t.Fatalf("parser/GLR states = %d/%v, want current frontier 1/[1 2]", ts.state, ts.glrStates)
 	}
 }

--- a/parser_relex_state_test.go
+++ b/parser_relex_state_test.go
@@ -7,6 +7,28 @@ type recordingParserStateTokenSource struct {
 	glrStates    [][]StateID
 }
 
+type zeroWidthExternalRelexTokenSource struct {
+	relexed      Token
+	parserStates []StateID
+	glrStates    [][]StateID
+}
+
+func (s *zeroWidthExternalRelexTokenSource) Next() Token { return Token{} }
+
+func (s *zeroWidthExternalRelexTokenSource) SetParserState(state StateID) {
+	s.parserStates = append(s.parserStates, state)
+}
+
+func (s *zeroWidthExternalRelexTokenSource) SetGLRStates(states []StateID) {
+	s.glrStates = append(s.glrStates, append([]StateID(nil), states...))
+}
+
+func (s *zeroWidthExternalRelexTokenSource) CanRelexFromTokenStart(Token) bool { return true }
+
+func (s *zeroWidthExternalRelexTokenSource) RelexFromTokenStart(Token) (Token, bool) {
+	return s.relexed, true
+}
+
 func (s *recordingParserStateTokenSource) Next() Token { return Token{} }
 
 func (s *recordingParserStateTokenSource) SetParserState(state StateID) {
@@ -71,5 +93,89 @@ func TestSameSurfaceRelexTokenRequiresSameSpanAndSurface(t *testing.T) {
 	}
 	if p.sameSurfaceRelexToken(original, Token{Symbol: 3, StartByte: 10, EndByte: 11}) {
 		t.Fatal("different-surface token was accepted")
+	}
+}
+
+func TestNoLiveStackCanAcceptLookaheadRequiresEveryEligibleVersionToReject(t *testing.T) {
+	lang := &Language{
+		StateCount:  4,
+		SymbolCount: 3,
+		ParseTable: [][]uint16{
+			make([]uint16, 3),
+			make([]uint16, 3),
+			make([]uint16, 3),
+			make([]uint16, 3),
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+		},
+	}
+	lang.ParseTable[2][1] = 1
+	p := NewParser(lang)
+	stacks := []glrStack{
+		{entries: []stackEntry{{state: 1}}},
+		{entries: []stackEntry{{state: 2}}},
+	}
+	tok := Token{Symbol: 1, StartByte: 10, EndByte: 11}
+
+	if p.noLiveStackCanAcceptLookahead(stacks, tok) {
+		t.Fatal("mixed frontier accepted replacement even though state 2 can consume the real lookahead")
+	}
+	stacks[1].shifted = true
+	if !p.noLiveStackCanAcceptLookahead(stacks, tok) {
+		t.Fatal("shifted versions should not block replacement for the remaining rejecting frontier")
+	}
+}
+
+func TestTryRelexSingleParserStateAcceptsOnlyZeroWidthExternalShift(t *testing.T) {
+	lang := &Language{
+		StateCount:  4,
+		SymbolCount: 3,
+		ParseTable: [][]uint16{
+			make([]uint16, 3),
+			make([]uint16, 3),
+			make([]uint16, 3),
+			make([]uint16, 3),
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+		},
+	}
+	lang.ParseTable[1][2] = 1
+	p := NewParser(lang)
+	stacks := []glrStack{
+		{entries: []stackEntry{{state: 1}}},
+		{entries: []stackEntry{{state: 2}}},
+	}
+	original := Token{Symbol: 1, StartByte: 10, EndByte: 11}
+	ts := &zeroWidthExternalRelexTokenSource{relexed: Token{
+		Symbol:               2,
+		StartByte:            10,
+		EndByte:              10,
+		ExternalScannerToken: true,
+	}}
+
+	got, ok := p.tryRelexSingleParserState(original, 1, ts, stacks, &parserScratch{})
+	if !ok {
+		t.Fatal("zero-width external shift was rejected")
+	}
+	if got.Symbol != 2 || got.StartByte != 10 || got.EndByte != 10 {
+		t.Fatalf("relexed token = %+v, want zero-width external symbol 2 at byte 10", got)
+	}
+	if len(ts.parserStates) != 1 || ts.parserStates[0] != 1 {
+		t.Fatalf("parser state calls = %v, want [1]", ts.parserStates)
+	}
+	if len(ts.glrStates) != 1 || len(ts.glrStates[0]) != 0 {
+		t.Fatalf("GLR state calls = %v, want one cleared frontier", ts.glrStates)
+	}
+
+	ts.relexed.EndByte = 11
+	if _, ok := p.tryRelexSingleParserState(original, 1, ts, stacks, &parserScratch{}); ok {
+		t.Fatal("non-zero-width replacement was accepted")
+	}
+	if got := ts.glrStates[len(ts.glrStates)-1]; len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("failed relex restored GLR states = %v, want [1 2]", got)
 	}
 }


### PR DESCRIPTION
## Summary

Tree-sitter lexes each GLR version with that version's parser state. gotreesitter normally shares one lookahead across the frontier, which can hide JavaScript's zero-width `_automatic_semicolon` from a version that needs it after reductions.

This change adds two narrow correction paths:

- Before materializing a selected single-token recovery insertion as `MISSING`, ask the external scanner whether that parser version has a real zero-width shift at the same byte. If so, shift the scanner token and retry the original lookahead.
- When JavaScript GLR states diverge and every eligible live version rejects the shared real lookahead, re-lex one parser state. The replacement is accepted only when it is a zero-width external-scanner token with exactly one non-extra shift action. If any live version can consume the original token, the shared token is preserved.

The token source's lexer, scanner checkpoint, parser-state, and GLR-state snapshots are restored on probe/failure paths.

## Poppler result

On V8's 3,447,275-byte Emscripten Poppler corpus, the previous v0.23.1 parser stopped at byte 3,385,180 with `no_stacks_alive` on the second closing brace. This head now reaches EOF and returns:

- root: `program [0:3447275]`
- `HasError=false`
- stop reason: `accepted`
- no truncation or early EOF
- last token: EOF at byte 3,447,275

The direct-C run still reports a separate deep-shape mismatch at byte 44,043: a trailing JavaScript comment is owned by the inner `statement_block` in Go but is a sibling in C (`go=children=11`, `c=children=12`). Exact tree parity is therefore not claimed by this PR.

The hard 2 GiB container is also still OOM-killed. Memory reduction remains a separate follow-up; this PR is the scoped late-file correctness fix.

## Validation

- Focused Docker parser/re-lex gate passed:
  `TestNoLiveStackCanAcceptLookaheadRequiresEveryEligibleVersionToReject`,
  `TestTryRelexSingleParserStateAcceptsOnlyZeroWidthExternalShift`,
  `TestUpdateCurrentRelexParserStateTokenSourceExcludesShiftedStacks`, and
  `TestHighlightParserGoRealFile`.
- Final one-file Docker Go/C run completed without OOM in the established 8 GiB correctness envelope and preserved the isolated trailing-comment mismatch as the first divergence.
- `git diff --check` is clean.

## Scope and risk

- The all-versions-dead fallback is gated to `Language.Name == "javascript"`.
- Non-zero-width, non-external, ambiguous, extra, self-loop, and missing-action replacements fail closed.
- Mixed frontiers never replace a real token that another live version accepts.
