### PR TITLE
fix: preserve JavaScript trailing comment ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
             --goflags -p=1 \
             --test-parallel 1 \
             --timeout 20m \
-            --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$'
+            --run '^TestParityFreshParse$|^TestParityIncrementalParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityGLRCanaryGo$|^TestParityGLRCanarySet$|^TestParityGLRCapPressureTopLanguages$|^TestParityGateCoverageRatchet$|^TestParityHighlight$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$'
 
   parity-cgo-exhaustive:
     needs: exhaustive_parity_scope
@@ -504,7 +504,7 @@ jobs:
             --goflags -p=1 \
             --test-parallel 1 \
             --timeout 30m \
-            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityKnownDegradedStructuralStillDiverges$'
+            --run '^TestParityFreshParse$|^TestParityHasNoErrors$|^TestParityIssue3Repros$|^TestParityKnownDegradedStructuralStillDiverges$|^TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment$|^TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken$'
 
       - name: CGo Structural Parity Exhaustive (Incremental + GLR)
         run: |

--- a/cgo_harness/parity_gate_ratchet_test.go
+++ b/cgo_harness/parity_gate_ratchet_test.go
@@ -3,7 +3,11 @@
 package cgoharness
 
 import (
+	"bufio"
+	"os"
+	"regexp"
 	"sort"
+	"strings"
 	"testing"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -30,9 +34,16 @@ var allowedKnownDegradedStructural = map[string]struct{}{
 	// exemption, and PR #214 removed it from knownDegradedStructural.
 }
 
+var javascriptParityRegressionCITests = []string{
+	"TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment",
+	"TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken",
+}
+
 // TestParityGateCoverageRatchet prevents silent narrowing of correctness gates.
 // Update these thresholds only when intentionally tightening/loosening policy.
 func TestParityGateCoverageRatchet(t *testing.T) {
+	assertJavaScriptRegressionWorkflowCoverage(t)
+
 	if got := len(curatedStructuralLanguages); got < minCuratedStructuralLanguages {
 		t.Fatalf("curatedStructuralLanguages shrank: got=%d min=%d", got, minCuratedStructuralLanguages)
 	}
@@ -65,6 +76,80 @@ func TestParityGateCoverageRatchet(t *testing.T) {
 	}
 	if got := len(paritySkips); got > maxParitySkips {
 		t.Fatalf("paritySkips grew: got=%d max=%d", got, maxParitySkips)
+	}
+}
+
+func assertJavaScriptRegressionWorkflowCoverage(t *testing.T) {
+	t.Helper()
+
+	workflow, err := os.Open("../.github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("open CI workflow: %v", err)
+	}
+	defer workflow.Close()
+
+	selectors := make(map[string]string)
+	var label string
+	scanner := bufio.NewScanner(workflow)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "--label ") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				label = strings.TrimSuffix(fields[1], "\\")
+			}
+			continue
+		}
+		if label == "" || !strings.HasPrefix(line, "--run ") {
+			continue
+		}
+		selector := strings.TrimSpace(strings.TrimPrefix(line, "--run "))
+		selector = strings.TrimSuffix(selector, "\\")
+		selectors[label] = strings.Trim(strings.TrimSpace(selector), "'")
+		label = ""
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan CI workflow: %v", err)
+	}
+
+	for _, label := range []string{"ci-parity-cgo-smoke", "ci-parity-cgo-exhaustive-fresh"} {
+		selector, ok := selectors[label]
+		if !ok {
+			t.Errorf("CI workflow is missing --run selector for --label %s", label)
+			continue
+		}
+		re, err := regexp.Compile(selector)
+		if err != nil {
+			t.Errorf("CI workflow selector for %s is invalid: %v", label, err)
+			continue
+		}
+		for _, testName := range javascriptParityRegressionCITests {
+			if !re.MatchString(testName) {
+				t.Errorf("CI workflow selector for %s does not run %s", label, testName)
+			}
+		}
+	}
+
+	for _, label := range []string{
+		"ci-parity-cgo-exhaustive-incremental",
+		"ci-parity-cgo-exhaustive-corpus",
+		"ci-parity-cgo-exhaustive-highlight-yaml",
+	} {
+		selector, ok := selectors[label]
+		if !ok {
+			t.Errorf("CI workflow is missing --run selector for --label %s", label)
+			continue
+		}
+		re, err := regexp.Compile(selector)
+		if err != nil {
+			t.Errorf("CI workflow selector for %s is invalid: %v", label, err)
+			continue
+		}
+		for _, testName := range javascriptParityRegressionCITests {
+			if re.MatchString(testName) {
+				t.Errorf("CI workflow selector for %s redundantly runs %s", label, testName)
+			}
+		}
 	}
 }
 

--- a/cgo_harness/parity_javascript_regression_test.go
+++ b/cgo_harness/parity_javascript_regression_test.go
@@ -8,3 +8,8 @@ func TestParityJavaScriptStandaloneBlockBeforeSimpleAssignment(t *testing.T) {
 	src := []byte("{a}b=c")
 	runParityCase(t, parityCase{name: "javascript", source: string(src)}, "issue111", src)
 }
+
+func TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment(t *testing.T) {
+	src := []byte("function f() {\n  if (!size || !pre) { i--; break; } // counter\n  var curr = 1;\n}\n")
+	runParityCase(t, parityCase{name: "javascript", source: string(src)}, "javascript-asi-before-trailing-comment", src)
+}

--- a/cgo_harness/parity_javascript_regression_test.go
+++ b/cgo_harness/parity_javascript_regression_test.go
@@ -13,3 +13,8 @@ func TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment(t *testing.T) {
 	src := []byte("function f() {\n  if (!size || !pre) { i--; break; } // counter\n  var curr = 1;\n}\n")
 	runParityCase(t, parityCase{name: "javascript", source: string(src)}, "javascript-asi-before-trailing-comment", src)
 }
+
+func TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken(t *testing.T) {
+	src := []byte("if (x) {} /* first *//* second */ else {}\n")
+	runParityCase(t, parityCase{name: "javascript", source: string(src)}, "javascript-adjacent-block-comments-before-else", src)
+}

--- a/cgo_harness/tier_scan/external_lex_elections.json
+++ b/cgo_harness/tier_scan/external_lex_elections.json
@@ -1314,17 +1314,17 @@
    "tier_notes": "diagnostic scan 20260621T035630Z-206-inventory-telemetry: 22/40, trunc=0, errTree=0, panics=0; previous CLEAN row was stale: in ratchet; java full-parse stack cap 14"
   },
   {
-   "c_recovery_default_opt_out": false,
-   "default_external_lex_states": false,
+   "c_recovery_default_opt_out": true,
+   "default_external_lex_states": true,
    "extensions": ".cjs,.js,.mjs",
    "grammar": "javascript",
    "has_external_scanner": true,
    "parity": "40/40",
-   "staged_external_lex_states": true,
+   "staged_external_lex_states": false,
    "status": "staged_precise_els",
    "status_label": "staged precise ELS",
    "tier_classification": "CLEAN",
-   "tier_notes": "in ratchet"
+   "tier_notes": "precise ELS promoted for C-equivalent ASI/comment scanner ordering; faithful C recovery remains default-opted-out because it regresses clean large-file performance"
   },
   {
    "c_recovery_default_opt_out": false,

--- a/cgo_harness/tier_scan/external_lex_elections.json
+++ b/cgo_harness/tier_scan/external_lex_elections.json
@@ -2697,9 +2697,9 @@
    "angular/python/yaml clean; scss/wgsl classified recovery/error-shape IV"
   ],
   "staged_precise_els": [
-   "Docker: wave4-javascript-precise-els-staged-test",
-   "TestJavascriptExternalLexStatesRegression (-tags javascript_precise_els)",
-   "TestJavascriptExternalLexStatesRemainStagedByDefault",
+   "Docker: javascript-asi-comment-deep-review",
+   "TestJavascriptExternalLexStatesRegression",
+   "TestJavascriptExternalLexStatesDefaultWithoutRecoveryElection",
    "TestExternalLexStatesRecoveryElectionOptOutInventory"
   ],
   "wave3_inventory": [
@@ -2712,7 +2712,7 @@
   "cgo_harness/tier_scan/exts.tsv",
   "cgo_harness/tier_scan/tier_classification.tsv",
   "grammars/zzz_scanner_attachments.go",
-  "grammars/*_external_lex_states_gen.go",
+  "grammars/*_external_lex_states*.go (excluding tests and staged files)",
   "grammars/*_external_lex_states_staged.go",
   "grammars/z_subset_scanner_register_*.go"
  ],
@@ -2723,11 +2723,11 @@
   "staged_precise_els": "A precise ExternalLexStates table exists behind an opt-in build tag or explicit staging policy; default C recovery election is intentionally disabled."
  },
  "summary": {
-  "c_recovery_default_opt_out_count": 3,
-  "default_external_lex_state_count": 90,
+  "c_recovery_default_opt_out_count": 4,
+  "default_external_lex_state_count": 91,
   "external_scanner_count": 119,
   "grammar_count": 206,
-  "staged_external_lex_state_count": 1
+  "staged_external_lex_state_count": 0
  },
  "wave": "wave4-external-lex-state-elections"
 }

--- a/cgo_harness/tier_scan/external_lex_elections.md
+++ b/cgo_harness/tier_scan/external_lex_elections.md
@@ -12,9 +12,9 @@ scanner.
 | --- | ---: |
 | grammars | 206 |
 | registered external scanners | 119 |
-| default precise ExternalLexStates tables | 90 |
-| staged precise ExternalLexStates tables | 1 |
-| C recovery default opt-outs | 3 |
+| default precise ExternalLexStates tables | 91 |
+| staged precise ExternalLexStates tables | 0 |
+| C recovery default opt-outs | 4 |
 
 | status | count |
 | --- | ---: |
@@ -26,7 +26,7 @@ scanner.
 ## Verification Receipts
 
 - `default_elected`: Docker: wave4-external-lex-election-inventory-test-v2; TestExternalLexStatesDefaultElectionInventory; Docker: wave4-cobol-default-precise-els; TestCobolExternalLexStatesDefaultElection
-- `staged_precise_els`: Docker: wave4-javascript-precise-els-staged-test; TestJavascriptExternalLexStatesRegression (-tags javascript_precise_els); TestJavascriptExternalLexStatesRemainStagedByDefault; TestExternalLexStatesRecoveryElectionOptOutInventory
+- `staged_precise_els`: Docker: javascript-asi-comment-deep-review; TestJavascriptExternalLexStatesRegression; TestJavascriptExternalLexStatesDefaultWithoutRecoveryElection; TestExternalLexStatesRecoveryElectionOptOutInventory
 - `sample_c_oracle_smoke`: Docker: wave4-external-lex-smoke-20260707T1928; angular/python/yaml clean; scss/wgsl classified recovery/error-shape IV
 - `wave3_inventory`: Docker: wave3-tier-plan-206; 206 visited; 202 planned files; 4 planned-empty
 
@@ -130,7 +130,7 @@ scanner.
 | `yaml` | default elected | CLEAN | 40/40 | yes | yes | no | no | `.yaml,.yml` |
 | `cpp` | staged precise ELS | IV-recovery | 9/40 | yes | yes | no | yes | `.cc,.cpp,.cxx,.h,.hh,.hpp,.hxx` |
 | `html` | staged precise ELS | IV-recovery | 0/40 | yes | yes | no | yes | `.htm,.html` |
-| `javascript` | staged precise ELS | CLEAN | 40/40 | yes | no | yes | no | `.cjs,.js,.mjs` |
+| `javascript` | staged precise ELS | CLEAN | 40/40 | yes | yes | no | yes | `.cjs,.js,.mjs` |
 | `julia` | staged precise ELS | IV-recovery | unmeasured | yes | yes | no | yes | `.jl` |
 | `agda` | blocked: missing precise ELS | IV-scanner | 2/40 | yes | no | no | no | `.agda` |
 | `comment` | blocked: missing precise ELS | IV-perf | unmeasured | yes | no | no | no | `.txt` |

--- a/cgo_harness/tier_scan/gen_external_lex_elections.py
+++ b/cgo_harness/tier_scan/gen_external_lex_elections.py
@@ -46,6 +46,7 @@ C_RECOVERY_DEFAULT_OPT_OUT = {
     # accepted trees for these grammars.
     "cpp",
     "html",
+    "javascript",
     "julia",
 }
 
@@ -57,9 +58,9 @@ RECEIPTS = {
         "TestCobolExternalLexStatesDefaultElection",
     ],
     "staged_precise_els": [
-        "Docker: wave4-javascript-precise-els-staged-test",
-        "TestJavascriptExternalLexStatesRegression (-tags javascript_precise_els)",
-        "TestJavascriptExternalLexStatesRemainStagedByDefault",
+        "Docker: javascript-asi-comment-deep-review",
+        "TestJavascriptExternalLexStatesRegression",
+        "TestJavascriptExternalLexStatesDefaultWithoutRecoveryElection",
         "TestExternalLexStatesRecoveryElectionOptOutInventory",
     ],
     "sample_c_oracle_smoke": [
@@ -137,7 +138,9 @@ def extract_go_map_literal(text, marker):
 
 def default_external_lex_states():
     names = set()
-    for path in GRAMMARS_DIR.glob("*_external_lex_states_gen.go"):
+    for path in GRAMMARS_DIR.glob("*_external_lex_states*.go"):
+        if path.name.endswith(("_test.go", "_staged.go")):
+            continue
         text = path.read_text(encoding="utf-8")
         names.update(re.findall(r'RegisterExternalLexStates\("([^"]+)"', text))
 
@@ -293,7 +296,7 @@ def build():
             "cgo_harness/tier_scan/exts.tsv",
             "cgo_harness/tier_scan/tier_classification.tsv",
             "grammars/zzz_scanner_attachments.go",
-            "grammars/*_external_lex_states_gen.go",
+            "grammars/*_external_lex_states*.go (excluding tests and staged files)",
             "grammars/*_external_lex_states_staged.go",
             "grammars/z_subset_scanner_register_*.go",
         ],

--- a/cgo_harness/tier_scan/tier_classification.tsv
+++ b/cgo_harness/tier_scan/tier_classification.tsv
@@ -100,7 +100,7 @@ hyprlang	IV-unknown	1/2	diagnostic scan 20260621T035630Z-206-inventory-telemetry
 ini	IV-unknown	9/11	diagnostic scan 20260621T035630Z-206-inventory-telemetry: 9/11, trunc=1, errTree=1, panics=0; previous CLEAN row was stale: mypy-style continuation recovery normalized for both residual witnesses; bounded cgo oracle parity medianRatio=3.98x, verified 2026-06-12
 janet	CLEAN	40/40	in ratchet
 java	IV-unknown	22/40	diagnostic scan 20260621T035630Z-206-inventory-telemetry: 22/40, trunc=0, errTree=0, panics=0; previous CLEAN row was stale: in ratchet; java full-parse stack cap 14
-javascript	CLEAN	40/40	in ratchet
+javascript	CLEAN	40/40	precise ELS promoted for C-equivalent ASI/comment scanner ordering; faithful C recovery remains default-opted-out because it regresses clean large-file performance
 jinja2	IV-recovery	3/40	faithful C error-cost version competition (see spec)
 jq	IV-unknown	7/8	diagnostic scan 20260621T035630Z-206-inventory-telemetry: 7/8, trunc=1, errTree=0, panics=0; previous CLEAN row was stale: in ratchet
 jsdoc	IV-unknown	13/40	diagnostic scan 20260621T035630Z-206-inventory-telemetry: 13/40, trunc=27, errTree=0, panics=0; previous CLEAN row was stale: in ratchet; C-recovery gate (stage-2 redwood)

--- a/grammars/external_lex_states_election_test.go
+++ b/grammars/external_lex_states_election_test.go
@@ -153,6 +153,7 @@ func TestExternalLexStatesRecoveryElectionOptOutInventory(t *testing.T) {
 	}{
 		{name: "cpp", load: CppLanguage},
 		{name: "html", load: HtmlLanguage},
+		{name: "javascript", load: JavascriptLanguage},
 		{name: "julia", load: JuliaLanguage},
 	}
 

--- a/grammars/javascript_external_lex_states.go
+++ b/grammars/javascript_external_lex_states.go
@@ -1,12 +1,7 @@
-//go:build javascript_precise_els
-
-// STAGED — inactive by default. Build/enable with: -tags javascript_precise_els
-//
 // Verbatim ts_external_scanner_states[10][8] from the pinned
-// tree-sitter-javascript parser.c. Registering it flips DiagnoseCRecoveryGate
-// for javascript (precise ExternalLexStates is the last missing gate input),
-// which ELECTS javascript into the faithful C error-recovery cost competition
-// by default.
+// tree-sitter-javascript parser.c. Ordinary scanner arbitration needs these
+// rows to distinguish ASI-valid states from expression-continuation states;
+// action-table fallback is broader and can reverse ASI/comment ordering.
 //
 // WHY IT IS STAGED (2026-07 cliff campaign measurement)
 // Unlike c_sharp — whose stateful interpolation scanner was actively
@@ -26,11 +21,10 @@
 // The elected path's per-token cost (cRecoveryEnabled lexing via
 // NextWithErrorRuns + acquire-token bookkeeping) is paid on CLEAN parses,
 // and javascript's actual sweep cliffs (asm.js megafunctions dying on
-// memory_budget) are unrelated to external-scanner validity. Enable this
-// only after the javascript memory-budget cliff class is fixed and a sweep
-// re-measurement shows election is at worst neutral. Full test suites
-// (go test . ./grammars) PASS with this table active and javascript elected,
-// so correctness is not the blocker — perf on the cliff slice is.
+// memory_budget) are unrelated to external-scanner validity. JavaScript is
+// therefore explicitly opted out of default C-recovery election even though
+// precise scanner validity is now always enabled. Re-enable recovery only
+// after the memory-budget cliff is fixed and a sweep shows it at worst neutral.
 //
 // Columns are the JavaScript external token indices, in the language's
 // ExternalSymbols order (== C enum order):
@@ -43,7 +37,7 @@
 // Source: https://github.com/tree-sitter/tree-sitter-javascript 58404d8cf191d69f2674a8fd507bd5776f46cb11 src/parser.c
 package grammars
 
-// javascriptExternalLexStates mirrors C tree-sitter ts_external_scanner_states.
+// javascriptExternalLexStates mirrors C tree-sitter's ts_external_scanner_states.
 var javascriptExternalLexStates = [][]bool{
 	/* 0 */ {false, false, false, false, false, false, false, false},
 	/* 1 */ {true, true, true, true, true, true, false, true},

--- a/grammars/javascript_external_lex_states.go
+++ b/grammars/javascript_external_lex_states.go
@@ -3,7 +3,7 @@
 // rows to distinguish ASI-valid states from expression-continuation states;
 // action-table fallback is broader and can reverse ASI/comment ordering.
 //
-// WHY IT IS STAGED (2026-07 cliff campaign measurement)
+// WHY PRECISE ELS IS DEFAULT BUT C RECOVERY IS NOT (2026-07 cliff campaign measurement)
 // Unlike c_sharp — whose stateful interpolation scanner was actively
 // corrupted by the union-mask fallback, so the precise table + election fixed
 // real misparses (DeclaredTypeManager.cs 31 ERROR nodes -> 0) — javascript's

--- a/grammars/javascript_external_lex_states_default_test.go
+++ b/grammars/javascript_external_lex_states_default_test.go
@@ -1,18 +1,16 @@
-//go:build !javascript_precise_els
-
 package grammars
 
 import "testing"
 
-func TestJavascriptExternalLexStatesRemainStagedByDefault(t *testing.T) {
-	if got := len(LookupExternalLexStates("javascript")); got != 0 {
-		t.Fatalf("LookupExternalLexStates(\"javascript\") rows = %d, want 0 without javascript_precise_els", got)
+func TestJavascriptExternalLexStatesDefaultWithoutRecoveryElection(t *testing.T) {
+	if got := len(LookupExternalLexStates("javascript")); got != 10 {
+		t.Fatalf("LookupExternalLexStates(\"javascript\") rows = %d, want 10", got)
 	}
 	lang := JavascriptLanguage()
-	if len(lang.ExternalLexStates) != 0 {
-		t.Fatalf("JavascriptLanguage ExternalLexStates rows = %d, want 0 without javascript_precise_els", len(lang.ExternalLexStates))
+	if got := len(lang.ExternalLexStates); got != 10 {
+		t.Fatalf("JavascriptLanguage ExternalLexStates rows = %d, want 10", got)
 	}
 	if lang.CRecoveryCostCompetitionEnabledByDefault {
-		t.Fatal("javascript C recovery election default-enabled without javascript_precise_els")
+		t.Fatal("javascript C recovery election default-enabled despite performance opt-out")
 	}
 }

--- a/grammars/javascript_external_lex_states_regression_test.go
+++ b/grammars/javascript_external_lex_states_regression_test.go
@@ -1,11 +1,3 @@
-//go:build javascript_precise_els
-
-// STAGED — runs only with -tags javascript_precise_els, alongside
-// javascript_external_lex_states_staged.go. See that file for why the
-// javascript precise-ELS table (and with it C-recovery election) is not
-// default yet: election is a measured perf regression on javascript's worst
-// perf_scan sweep slice while fixing no misparses there.
-
 package grammars
 
 import (
@@ -14,7 +6,7 @@ import (
 	"github.com/odvcencio/gotreesitter"
 )
 
-// TestJavascriptExternalLexStatesRegression guards the staged javascript
+// TestJavascriptExternalLexStatesRegression guards the default javascript
 // ExternalLexStates table against drift from the pinned
 // tree-sitter-javascript parser.c (ts_external_scanner_states[10][8]).
 func TestJavascriptExternalLexStatesRegression(t *testing.T) {
@@ -63,10 +55,13 @@ func TestJavascriptExternalLexStatesRegression(t *testing.T) {
 		t.Fatalf("LexModes reference external_lex_state %d but table only has %d rows", maxELS, len(lang.ExternalLexStates))
 	}
 
-	// With the table registered the C-recovery gate must be satisfiable —
-	// this is the election precondition the staged file documents.
+	// The table makes the C-recovery surface valid, but JavaScript remains an
+	// explicit default opt-out because its clean large-file path regresses.
 	diag := gotreesitter.DiagnoseCRecoveryGate(lang)
 	if !diag.Supported {
 		t.Fatalf("DiagnoseCRecoveryGate not supported with precise ELS: %s", diag.Reason)
+	}
+	if lang.CRecoveryCostCompetitionEnabledByDefault {
+		t.Fatal("javascript C recovery default-enabled despite performance opt-out")
 	}
 }

--- a/grammars/javascript_scanner.go
+++ b/grammars/javascript_scanner.go
@@ -251,6 +251,7 @@ func jsProbeWhitespaceAndComments(lexer *gotreesitter.ExternalLexer, scannedComm
 			*scannedComment = true
 		case '*':
 			lexer.Advance(true)
+		scanBlock:
 			for lexer.Lookahead() != 0 {
 				switch lexer.Lookahead() {
 				case '*':
@@ -264,7 +265,7 @@ func jsProbeWhitespaceAndComments(lexer *gotreesitter.ExternalLexer, scannedComm
 							}
 							return jsWhitespaceNoNewline
 						}
-						break
+						break scanBlock
 					}
 				case '\n', 0x2028, 0x2029:
 					sawBlockNewline = true

--- a/grammars/javascript_scanner.go
+++ b/grammars/javascript_scanner.go
@@ -32,6 +32,14 @@ const (
 // JSX text, ternary question marks, and HTML comments for JavaScript.
 type JavaScriptExternalScanner struct{}
 
+type jsWhitespaceResult uint8
+
+const (
+	jsWhitespaceReject jsWhitespaceResult = iota
+	jsWhitespaceNoNewline
+	jsWhitespaceAccept
+)
+
 func (JavaScriptExternalScanner) Create() any                           { return nil }
 func (JavaScriptExternalScanner) Destroy(payload any)                   {}
 func (JavaScriptExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
@@ -122,6 +130,18 @@ func jsScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool,
 		if ch == 0 {
 			return true
 		}
+		if ch == '/' {
+			result := jsProbeWhitespaceAndComments(lexer, scannedComment, false)
+			if result == jsWhitespaceReject {
+				return false
+			}
+			if result == jsWhitespaceAccept &&
+				!jsValid(validSymbols, jsTokLogicalOr) &&
+				lexer.Lookahead() != ',' && lexer.Lookahead() != '=' {
+				return true
+			}
+			ch = lexer.Lookahead()
+		}
 		if ch == '}' {
 			lexer.Advance(true)
 			for unicode.IsSpace(lexer.Lookahead()) {
@@ -203,6 +223,60 @@ func jsScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool,
 	}
 
 	return true
+}
+
+// jsProbeWhitespaceAndComments mirrors the pinned JavaScript scanner's
+// same-line comment probe. In particular, a valid automatic semicolon is
+// emitted at the scanner's original mark before the comment is shifted as an
+// extra. Keeping that ordering is what lets the parser reduce `} ASI` first and
+// replay the following comment into the surrounding statement list.
+func jsProbeWhitespaceAndComments(lexer *gotreesitter.ExternalLexer, scannedComment *bool, consume bool) jsWhitespaceResult {
+	sawBlockNewline := false
+	for {
+		for unicode.IsSpace(lexer.Lookahead()) {
+			lexer.Advance(true)
+		}
+
+		if lexer.Lookahead() != '/' {
+			return jsWhitespaceAccept
+		}
+		lexer.Advance(true)
+		switch lexer.Lookahead() {
+		case '/':
+			lexer.Advance(true)
+			for lexer.Lookahead() != 0 && lexer.Lookahead() != '\n' &&
+				lexer.Lookahead() != 0x2028 && lexer.Lookahead() != 0x2029 {
+				lexer.Advance(true)
+			}
+			*scannedComment = true
+		case '*':
+			lexer.Advance(true)
+			for lexer.Lookahead() != 0 {
+				switch lexer.Lookahead() {
+				case '*':
+					lexer.Advance(true)
+					if lexer.Lookahead() == '/' {
+						lexer.Advance(true)
+						*scannedComment = true
+						if lexer.Lookahead() != '/' && !consume {
+							if sawBlockNewline {
+								return jsWhitespaceAccept
+							}
+							return jsWhitespaceNoNewline
+						}
+						break
+					}
+				case '\n', 0x2028, 0x2029:
+					sawBlockNewline = true
+					lexer.Advance(true)
+				default:
+					lexer.Advance(true)
+				}
+			}
+		default:
+			return jsWhitespaceReject
+		}
+	}
 }
 
 func jsScanWSAndComments(lexer *gotreesitter.ExternalLexer, scannedComment *bool) bool {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -450,7 +450,7 @@ func generatedCRecoveryDefaultSafe(lang *Language) bool {
 
 func cRecoveryDefaultOptOut(name string) bool {
 	switch name {
-	case "cpp", "html", "julia":
+	case "cpp", "html", "javascript", "julia":
 		return true
 	default:
 		return false

--- a/parser_result_test/parser_result_javascript_block_assignment_regression_test.go
+++ b/parser_result_test/parser_result_javascript_block_assignment_regression_test.go
@@ -41,6 +41,45 @@ func TestJavaScriptStandaloneBlockBeforeSimpleAssignment(t *testing.T) {
 	}
 }
 
+func TestJavaScriptAutomaticSemicolonPrecedesTrailingComment(t *testing.T) {
+	src := "function f() {\n  if (!size || !pre) { i--; break; } // counter\n  var curr = 1;\n}\n"
+	tree, lang := parseByLanguageName(t, "javascript", src)
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("unexpected javascript parse error: %s", root.SExpr(lang))
+	}
+
+	function := root.Child(0)
+	if function == nil || function.ChildCount() != 4 {
+		t.Fatalf("function shape mismatch: %s", root.SExpr(lang))
+	}
+	outer := function.Child(3)
+	if outer == nil || outer.Type(lang) != "statement_block" || outer.ChildCount() != 5 {
+		t.Fatalf("outer statement block mismatch: %s", root.SExpr(lang))
+	}
+	wantTypes := []string{"{", "if_statement", "comment", "variable_declaration", "}"}
+	for i, want := range wantTypes {
+		if got := outer.Child(i).Type(lang); got != want {
+			t.Fatalf("outer child %d type = %q, want %q: %s", i, got, want, root.SExpr(lang))
+		}
+	}
+	comment := outer.Child(2)
+	if !comment.IsExtra() || comment.StartByte() != 52 || comment.EndByte() != 62 {
+		t.Fatalf("outer comment range/flags = [%d:%d] extra=%v, want [52:62] extra: %s",
+			comment.StartByte(), comment.EndByte(), comment.IsExtra(), root.SExpr(lang))
+	}
+	ifStatement := outer.Child(1)
+	consequence := ifStatement.Child(2)
+	if consequence == nil || consequence.Type(lang) != "statement_block" || consequence.EndByte() != 51 {
+		t.Fatalf("if consequence must end at closing brace byte 51: %s", root.SExpr(lang))
+	}
+	for i := 0; i < consequence.ChildCount(); i++ {
+		if consequence.Child(i).Type(lang) == "comment" {
+			t.Fatalf("trailing comment remained inside if consequence: %s", root.SExpr(lang))
+		}
+	}
+}
+
 func TestJavaScriptJSXAttributeAfterExpressionStillParses(t *testing.T) {
 	tests := []string{
 		"<A a={b} c={d} />",


### PR DESCRIPTION
## Summary

- match the pinned JavaScript scanner's same-line comment probe so a zero-width `_automatic_semicolon` is emitted before the comment extra
- promote JavaScript's precise external lex-state table for ordinary scanner validity while keeping default faithful C recovery explicitly opted out for its measured large-file cost
- add focused returned-tree and Docker C-oracle regressions for trailing-comment ownership
- preserve the pinned scanner's block-comment loop boundary across adjacent comments, preventing the following token from being consumed during ASI arbitration

## Why

On Poppler, Go shifted `} -> comment(extra) -> _automatic_semicolon` while C shifted `} -> _automatic_semicolon -> comment(extra)`. The reversed ordering made the comment interior to the inner `statement_block`. This patch fixes scanner arbitration rather than adding a result-tree rewrite or broad reducer heuristic.

A deeper source-to-source review also caught a Go porting trap: `break` inside the probe's `switch` exited only the switch, not the enclosing block-comment loop. A labeled break now matches the C scanner and is pinned by an adjacent-block-comment parity regression.

## Validation

- `go test ./grammars ./parser_result_test -count=1`
- `go test . -run 'CRecoveryGate|CRecoveryCostCompetition' -count=1`
- focused Docker C oracle: `TestParityJavaScriptAutomaticSemicolonBeforeTrailingComment`
- focused Docker C oracle: `TestParityJavaScriptAdjacentBlockCommentsDoNotConsumeFollowingToken`
- JavaScript one-grammar Docker gate: 25/25 no-error, 24/25 deep parity; the prior template ERROR is gone and the remaining generated-grammar comment-ownership residual is separate from the embedded runtime
- Poppler 3,447,275-byte parse-gap run in an 8 GiB container: `no_error=true`, `sexpr=true`, `deep=true`, accepted EOF, no OOM; Go 21.706s vs C 13.087s (1.66x)

## Stack

Stacked on #220 (`codex/poppler-versioned-external-relex`).
