### PR TITLE
v0.24.0 — JavaScript parity and memory economy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ for tags and release notes while still in `0.x`.
 
 JavaScript large-file parity and parser memory-economy release. The 3,447,275-
 byte Poppler witness now reaches exact EOF with no error and exact structural
-parity, while its default Go full parse remains within the roadmap's 2x C
-target and uses materially less allocation and arena capacity. JavaScript's
-broader focused gate is 25/25 no-error, S-expression, and deep parity.
+parity. Its controlled release benchmark recorded a 1.63x Go/C ratio with
+materially less allocation and arena capacity, and a separate single-pass
+runtime gate completes inside a hard 2 GiB container. JavaScript's broader
+focused gate is 25/25 no-error, S-expression, and deep parity.
 
 ### Added
 
@@ -46,6 +47,9 @@ broader focused gate is 25/25 no-error, S-expression, and deep parity.
 - The JavaScript block-comment probe uses a labeled loop break; adjacent block
   comments can no longer consume the following token during speculative ASI
   scanning.
+- Transient checkpoint recycling now follows raw-shape-only sidecar edges and
+  retargets them to arena clones before slab addresses are reused, preventing
+  later ambiguity decisions from observing overwritten reductions.
 
 ### Performance
 
@@ -53,6 +57,10 @@ broader focused gate is 25/25 no-error, S-expression, and deep parity.
   to 3.328 GB/op in the same 8 GiB, 1-CPU diagnostic envelope. Arena capacity
   fell 9.8%, exact deep parity stayed green, and the measured Go/C ratio was
   1.63x.
+- A prebuilt single-pass Poppler runtime probe accepts the exact 3,447,275-byte
+  witness under a hard 2 GiB cgroup at 1,729,836 KiB maximum RSS. The separate
+  Go/C deep-parity oracle remains in its 8 GiB envelope because it retains both
+  giant trees for comparison.
 - Memory-budget diagnostics are embedded in `Parser` so attribution adds no
   steady-state parse allocation; the primary benchmark trio remains 978 B and
   5 allocs for full parse, with both incremental lanes at zero allocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ for tags and release notes while still in `0.x`.
 
 ## [0.24.0] - 2026-07-11
 
-JavaScript large-file parity and parser memory-economy release. The 3,447,275-
-byte Poppler witness now reaches exact EOF with no error and exact structural
-parity. Its controlled release benchmark recorded a 1.63x Go/C ratio with
-materially less allocation and arena capacity, and a separate single-pass
+JavaScript large-file parity and parser memory-economy release. With an explicit
+2 GiB parser budget, the 3,447,275-byte Poppler witness now reaches exact EOF
+with no error and exact structural parity. Its allocation and arena-capacity
+reductions reproduced in a same-day base/head audit, and a separate single-pass
 runtime gate completes inside a hard 2 GiB container. JavaScript's broader
-focused gate is 25/25 no-error, S-expression, and deep parity.
+focused gate is 25/25 no-error, S-expression, and deep parity. The shipped
+512 MiB Poppler budget gap remains open and tracked in the performance ledger.
 
 ### Added
 
@@ -50,17 +51,23 @@ focused gate is 25/25 no-error, S-expression, and deep parity.
 - Transient checkpoint recycling now follows raw-shape-only sidecar edges and
   retargets them to arena clones before slab addresses are reused, preventing
   later ambiguity decisions from observing overwritten reductions.
+- Transient checkpoints defer when pending-parent compaction is active; pending
+  payloads can retain nodes outside the semantic/raw-shape graph and must not
+  observe recycled transient slabs.
 
 ### Performance
 
-- Full Poppler parsing improved from 21.706 s to 11.754 s and from 4.150 GB/op
-  to 3.328 GB/op in the same 8 GiB, 1-CPU diagnostic envelope. Arena capacity
-  fell 9.8%, exact deep parity stayed green, and the measured Go/C ratio was
-  1.63x.
+- A same-day #221/#222 audit reproduced the Poppler memory gains: 4.150 GB/op
+  fell to 3.329 GB/op (-19.8%) and arena capacity fell from 1.422 GB to
+  1.282 GB (-9.8%) while exact deep parity stayed green. Go wall time moved
+  -2.1% in that sequential sample. An earlier sample recorded 11.754 s and a
+  1.63x Go/C ratio, but later loaded-host samples ranged from 2.92x to 3.46x;
+  v0.24.0 therefore does not ratchet Poppler timing until a pinned quiet-host
+  sweep replaces the variable measurements.
 - A prebuilt single-pass Poppler runtime probe accepts the exact 3,447,275-byte
-  witness under a hard 2 GiB cgroup at 1,729,836 KiB maximum RSS. The separate
-  Go/C deep-parity oracle remains in its 8 GiB envelope because it retains both
-  giant trees for comparison.
+  witness with the explicit 2 GiB parser budget under a hard 2 GiB cgroup at
+  1,729,836 KiB maximum RSS. The separate Go/C deep-parity oracle remains in
+  its 8 GiB envelope because it retains both giant trees for comparison.
 - Memory-budget diagnostics are embedded in `Parser` so attribution adds no
   steady-state parse allocation; the primary benchmark trio remains 978 B and
   5 allocs for full parse, with both incremental lanes at zero allocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-## [0.24.0] - 2026-07-10
+## [0.24.0] - 2026-07-11
 
 JavaScript large-file parity and parser memory-economy release. The 3,447,275-
 byte Poppler witness now reaches exact EOF with no error and exact structural
@@ -46,6 +46,9 @@ broader focused gate is 25/25 no-error, S-expression, and deep parity.
 - The JavaScript block-comment probe uses a labeled loop break; adjacent block
   comments can no longer consume the following token during speculative ASI
   scanning.
+
+### Performance
+
 - Full Poppler parsing improved from 21.706 s to 11.754 s and from 4.150 GB/op
   to 3.328 GB/op in the same 8 GiB, 1-CPU diagnostic envelope. Arena capacity
   fell 9.8%, exact deep parity stayed green, and the measured Go/C ratio was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-10
+
+JavaScript large-file parity and parser memory-economy release. The 3,447,275-
+byte Poppler witness now reaches exact EOF with no error and exact structural
+parity, while its default Go full parse remains within the roadmap's 2x C
+target and uses materially less allocation and arena capacity. JavaScript's
+broader focused gate is 25/25 no-error, S-expression, and deep parity.
+
+### Added
+
+- Version-aware zero-width external-token relex probes for stateless scanners,
+  including transactional token-source rollback when a speculative relex is
+  rejected.
+- Parse-runtime memory attribution for arena, scratch, GSS, runtime heap, and
+  runtime sys budget stops, plus detailed arena/raw-shape/transient counters in
+  parse-gap reports.
+- An opt-in `GOT_TRANSIENT_REDUCE_CHECKPOINT_MB` path that materializes the
+  live linear stack and reuses transient slabs once a configured threshold is
+  crossed.
+
+### Changed
+
+- JavaScript's precise external lex-state table is now enabled for ordinary
+  scanner arbitration. Faithful C-recovery competition remains explicitly
+  default-opted-out because it still regresses clean large-file throughput.
+- Resolved single-path GSS stacks demote back to contiguous entries, and GSS,
+  transient-child, and transient-parent overflow slabs use bounded growth.
+- `Node`, `rawShape`, and `rawShapeChild` layouts remove alignment waste and
+  pack raw-shape edge metadata, shrinking the records from 152 to 144 bytes,
+  32 to 24 bytes, and 24 to 16 bytes respectively.
+
+### Fixed
+
+- JavaScript automatic-semicolon arbitration now probes same-line comments in
+  the pinned C-scanner order, so the zero-width ASI precedes a trailing comment
+  extra and the comment remains owned by the surrounding statement list.
+- The JavaScript block-comment probe uses a labeled loop break; adjacent block
+  comments can no longer consume the following token during speculative ASI
+  scanning.
+- Full Poppler parsing improved from 21.706 s to 11.754 s and from 4.150 GB/op
+  to 3.328 GB/op in the same 8 GiB, 1-CPU diagnostic envelope. Arena capacity
+  fell 9.8%, exact deep parity stayed green, and the measured Go/C ratio was
+  1.63x.
+- Memory-budget diagnostics are embedded in `Parser` so attribution adds no
+  steady-state parse allocation; the primary benchmark trio remains 978 B and
+  5 allocs for full parse, with both incremental lanes at zero allocation.
+
 ## [0.23.1] - 2026-07-10
 
 Generator throughput and certification follow-up. This cut banks the shared,
@@ -1445,7 +1492,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/odvcencio/gotreesitter/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/odvcencio/gotreesitter/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/odvcencio/gotreesitter/compare/v0.22.5...v0.23.0
 [0.22.5]: https://github.com/odvcencio/gotreesitter/compare/v0.22.4...v0.22.5


### PR DESCRIPTION
## Summary

This PR records the v0.24.0 JavaScript parity and parser memory-economy release. It separates what is proven from what remains open: Poppler reaches exact deep parity with an explicit 2 GiB parser budget, a single Go runtime fits a hard 2 GiB cgroup, the allocation/layout gains reproduce, and the shipped 512 MiB Poppler budget plus stable timing ratchet remain follow-up work.

## Changes

- added v0.24.0 release notes for JavaScript scanner parity, GSS demotion, bounded slab growth, compact node/raw-shape layouts, memory attribution, and transient checkpoint safety
- recorded the exact 25/25 JavaScript no-error/S-expression/deep-parity gate
- recorded reproduced Poppler reductions of 19.8% B/op and 9.8% arena capacity
- documented the hard-2GiB single-runtime result separately from the 8GiB dual-tree Go/C oracle
- removed the invalid attribution that treated a variable-host 21.706s-to-11.754s sample as a 45.9% engine speedup; later audits showed the C baseline moved similarly
- left Poppler timing unratcheted pending a pinned quiet-host sweep and left the shipped 512 MiB parser-budget gap explicit
- updated `[Unreleased]` and `[0.24.0]` comparison links

The machine-readable source hash, exact heads/settings/results, raw-artifact hashes, and release interpretation are committed in `cgo_harness/perf_scan/evidence/v0.24.0_poppler.json` by #222.

## Validation

- changelog diff reviewed against the exact #220-#222 stack and checked-in evidence receipt
- version date/title/comparison links verified
- `git diff --check`
- no code changes in this PR

## Stack

Stacked on #222; retarget to `main` after #222 merges.
