### PR TITLE
Correct full-parse benchmark contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,17 +566,13 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DRAFT_PR: ${{ github.event.pull_request.draft }}
           PERF_LEGACY_BASE_SHA: 7a29f591d7fcc54b3d0639b3e38a1bacd8fcb386
-          # Contract rebased for the v0.21.0 engine (second rebase; the first
-          # accepted the forest-default profile move). The generalized
-          # GLR+C-recovery engine deliberately changed the Go full-parse
-          # path (go held out of forest defaults, ASI external scanner,
-          # recovery hooks): B/op −91%, allocs −80%, incremental at parity
-          # with 0 allocs everywhere; full-parse ns is microarchitecture-
-          # dependent vs the old path (−20% on modern cores, +17% on 2-core
-          # CI runners) and the runner-side delta is consciously accepted —
-          # reclaim tracked in the post-v0.21.0 ledger. Gate future PRs
-          # against this engine's profile, not the retired one's.
-          PERF_BENCH_CONTRACT_BASE_SHA: 1e2e96f185d6a1e5261677d3bee4ff2b69731f07
+          # Contract rebased after the 2026-07-11 audit proved the old
+          # BenchmarkGoParseFullDFA silently enabled no-tree mode. This floor
+          # is the first commit where that benchmark calls Parser.Parse and
+          # measures a fully materialized tree; parser-core attribution moved
+          # to BenchmarkGoParseCoreDFA. Never compare the corrected public
+          # full-parse lane with the retired parser-core numbers.
+          PERF_BENCH_CONTRACT_BASE_SHA: 1717ce84179a850501ec86684f80a77e24d661a8
         run: |
           set -euo pipefail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- `BenchmarkGoParseFullDFA` now exercises the public `Parser.Parse` path and a
+  fully materialized tree. The former implementation silently enabled the
+  no-tree diagnostic and was mislabeled as a full parse.
+- `ParseNoResultCompatibilityBenchmarkOnly` now disables only compatibility
+  rewrites. Tree materialization remains enabled, so `parse_gap_report` can
+  finally distinguish compatibility cost from parser-core/no-tree cost.
+
+### Changed
+
+- Added the explicitly diagnostic `BenchmarkGoParseCoreDFA` lane and withdrew
+  the older generated-Go full-parse headline pending a pinned quiet-host rerun
+  of the corrected public benchmark.
+
 ## [0.24.0] - 2026-07-11
 
 JavaScript large-file parity and parser memory-economy release. With an explicit
@@ -69,8 +84,9 @@ focused gate is 25/25 no-error, S-expression, and deep parity. The shipped
   1,729,836 KiB maximum RSS. The separate Go/C deep-parity oracle remains in
   its 8 GiB envelope because it retains both giant trees for comparison.
 - Memory-budget diagnostics are embedded in `Parser` so attribution adds no
-  steady-state parse allocation; the primary benchmark trio remains 978 B and
-  5 allocs for full parse, with both incremental lanes at zero allocation.
+  steady-state parser-core allocation. The v0.24.0 `978 B`/`5 allocs` sample
+  used the then-mislabeled no-tree benchmark and is not a full-parse allocation
+  claim; both incremental lanes remained at zero allocation.
 
 ## [0.23.1] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ for tags and release notes while still in `0.x`.
 - `BenchmarkGoParseFullDFA` now exercises the public `Parser.Parse` path and a
   fully materialized tree. The former implementation silently enabled the
   no-tree diagnostic and was mislabeled as a full parse.
-- `ParseNoResultCompatibilityBenchmarkOnly` now disables only compatibility
-  rewrites. Tree materialization remains enabled, so `parse_gap_report` can
-  finally distinguish compatibility cost from parser-core/no-tree cost.
+- `ParseNoResultCompatibilityBenchmarkOnly` no longer implicitly enables the
+  no-tree path. Its result is materialized, so `parse_gap_report` can separate
+  no-tree parser-core cost from the broader no-compat diagnostic. Some
+  large-input diagnostic materialization strategies still key off this mode,
+  so it is not yet a pure compatibility-only A/B.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -329,58 +329,40 @@ for _, tag := range tags {
 
 ## Benchmarks
 
-All measurements below use the same workload: a generated Go source file with 500 functions (`19294` bytes).
-Numbers are medians from 10 runs on:
+The canonical public full-parse benchmark is `BenchmarkGoParseFullDFA`. It calls
+`Parser.Parse`, requires a complete root, and releases the materialized tree.
+`BenchmarkGoParseCoreDFA` is a separate parser-loop diagnostic that suppresses
+ordinary tree materialization; its numbers are not public full-parse numbers.
 
-```text
-goos: linux
-goarch: amd64
-cpu: Intel(R) Core(TM) Ultra 9 285
-```
+An audit on 2026-07-11 found that older versions of
+`BenchmarkGoParseFullDFA` called `ParseNoResultCompatibilityBenchmarkOnly`,
+which also enabled the no-tree path. The previously published `1.54 ms`,
+`728 B/op`, and `7 allocs/op` figures—and v0.24.0's later `978 B/op` and
+`5 allocs/op` figures—therefore described parser-core diagnostics, not a full
+materialized parse. Those headline comparisons have been withdrawn pending a
+pinned, quiet-host rerun of the corrected benchmark.
 
-| Runtime | Full parse | Incremental (1-byte edit) | Incremental (no edit) |
-|---|---:|---:|---:|
-| Native C (pure C runtime) | 1.76 ms | 102.3 μs | 101.7 μs |
-| CGo binding (C runtime via cgo) | ~2.0 ms | ~130 μs | — |
-| gotreesitter (pure Go) | 1.54 ms | 649 ns | 2.43 ns |
-
-On this workload:
-
-- Full parse is faster than both listed C baselines: ~1.15x faster than native C and ~1.29x faster than the CGo binding.
-- Incremental single-byte edits are ~158x faster than native C (~200x faster than CGo).
-- No-edit reparses are ~41,800x faster than native C, zero allocations.
-
-<details>
-<summary>Raw benchmark output</summary>
+The historical incremental measurements on the same generated 500-function Go
+workload were `649 ns` for a one-byte edit and `2.43 ns` for a no-edit reparse.
+They remain workload-specific; use the real-corpus perf scoreboard for
+per-language Go-vs-C claims.
 
 ```sh
-# Pure Go (this repo):
+# Public full parse plus incremental API lanes:
 GOMAXPROCS=1 go test . -run '^$' \
   -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' \
   -benchmem -count=10 -benchtime=750ms
 
-# CGo binding benchmarks:
-cd cgo_harness
-GOMAXPROCS=1 go test . -run '^$' -tags treesitter_c_bench \
-  -bench 'BenchmarkCTreeSitterGoParseFull|BenchmarkCTreeSitterGoParseIncrementalSingleByteEdit|BenchmarkCTreeSitterGoParseIncrementalNoEdit' \
+# Parser-core attribution only:
+GOMAXPROCS=1 go test . -run '^$' \
+  -bench '^BenchmarkGoParseCoreDFA$' \
   -benchmem -count=10 -benchtime=750ms
-
-# Native C benchmarks (no Go, direct C binary):
-./pure_c/run_go_benchmark.sh 500 2000 20000
 ```
 
-| Benchmark | Median ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| Native C full parse | 1,764,436 | — | — |
-| Native C incremental (1-byte edit) | 102,336 | — | — |
-| Native C incremental (no edit) | 101,740 | — | — |
-| `CTreeSitterGoParseFull` | ~1,990,000 | 600 | 6 |
-| `CTreeSitterGoParseIncrementalSingleByteEdit` | ~130,000 | 648 | 7 |
-| `GoParseFullDFA` | 1,538,089 | 728 | 7 |
-| `GoParseIncrementalSingleByteEditDFA` | 648.9 | 176 | 3 |
-| `GoParseIncrementalNoEditDFA` | 2.432 | 0 | 0 |
-
-</details>
+Correctness and performance are gated separately. For Go-vs-C real-corpus
+timing, see [`cgo_harness/perf_scan`](cgo_harness/perf_scan/README.md); its
+ratchet records caveats, timeouts, and resource gaps instead of extrapolating
+from this generated-Go microbenchmark.
 
 ### Benchmark matrix
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -210,9 +210,8 @@ func BenchmarkGoParseFullDFA(b *testing.B) {
 	b.ResetTimer()
 
 	var lastRuntime gotreesitter.ParseRuntime
-	// The parse-gap harness gates public compatibility; this microbench tracks parser core.
 	for i := 0; i < b.N; i++ {
-		tree, err := parser.ParseNoResultCompatibilityBenchmarkOnly(src)
+		tree, err := parser.Parse(src)
 		if err != nil {
 			b.Fatalf("parse error: %v", err)
 		}
@@ -263,6 +262,27 @@ func BenchmarkGoParseFullDFA(b *testing.B) {
 			lastRuntime.MergeStacksIn, lastRuntime.MergeStacksOut, lastRuntime.MergeSlotsUsed,
 			lastRuntime.GlobalCullStacksIn, lastRuntime.GlobalCullStacksOut,
 		)
+	}
+}
+
+// BenchmarkGoParseCoreDFA isolates the parser loop by suppressing result-tree
+// materialization. It is a diagnostic, not a public full-parse benchmark.
+func BenchmarkGoParseCoreDFA(b *testing.B) {
+	lang := grammars.GoLanguage()
+	parser := gotreesitter.NewParser(lang)
+	src := makeGoBenchmarkSource(benchmarkFuncCount(b))
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.ParseNoTreeBenchmarkOnly(src)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		requireCompleteParse(b, tree, src, lang, "parser core dfa")
+		tree.Release()
 	}
 }
 

--- a/parser_api.go
+++ b/parser_api.go
@@ -1194,22 +1194,17 @@ func (p *Parser) ParseNoTreeWithExternalCheckpointsBenchmarkOnly(source []byte) 
 }
 
 // ParseNoResultCompatibilityBenchmarkOnly parses source while suppressing
-// language-specific result compatibility rewrites. It is intended only for
-// performance attribution; the returned tree is not API-compatible.
+// language-specific result compatibility rewrites while preserving ordinary
+// tree materialization. It is intended only for performance attribution; the
+// returned tree is not API-compatible.
 func (p *Parser) ParseNoResultCompatibilityBenchmarkOnly(source []byte) (*Tree, error) {
 	if p == nil {
 		return nil, ErrNoLanguage
 	}
 	prevNoResult := p.noResultCompatibilityBenchmarkOnly
-	prevNoTree := p.noTreeBenchmarkOnly
-	prevCheckpoints := p.noTreeCheckpointBenchmarkOnly
 	p.noResultCompatibilityBenchmarkOnly = true
-	p.noTreeBenchmarkOnly = true
-	p.noTreeCheckpointBenchmarkOnly = false
 	defer func() {
 		p.noResultCompatibilityBenchmarkOnly = prevNoResult
-		p.noTreeBenchmarkOnly = prevNoTree
-		p.noTreeCheckpointBenchmarkOnly = prevCheckpoints
 	}()
 	return p.Parse(source)
 }

--- a/parser_api.go
+++ b/parser_api.go
@@ -1194,9 +1194,10 @@ func (p *Parser) ParseNoTreeWithExternalCheckpointsBenchmarkOnly(source []byte) 
 }
 
 // ParseNoResultCompatibilityBenchmarkOnly parses source while suppressing
-// language-specific result compatibility rewrites while preserving ordinary
-// tree materialization. It is intended only for performance attribution; the
-// returned tree is not API-compatible.
+// language-specific result compatibility rewrites while preserving result-tree
+// materialization. Other diagnostic materialization strategies may still key
+// off this mode, so it is not a pure compatibility-only A/B. It is intended
+// only for performance attribution; the returned tree is not API-compatible.
 func (p *Parser) ParseNoResultCompatibilityBenchmarkOnly(source []byte) (*Tree, error) {
 	if p == nil {
 		return nil, ErrNoLanguage

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -195,8 +195,9 @@ func (pp *ParserPool) ParseNoTreeWithExternalCheckpointsBenchmarkOnly(source []b
 
 // ParseNoResultCompatibilityBenchmarkOnly delegates to
 // Parser.ParseNoResultCompatibilityBenchmarkOnly. It is intended only for
-// performance attribution of parser/tree construction versus compatibility
-// rewrites; the returned tree is not API-compatible.
+// performance attribution. The result tree is materialized, but other
+// diagnostic materialization strategies may still key off this mode, and the
+// returned tree is not API-compatible.
 func (pp *ParserPool) ParseNoResultCompatibilityBenchmarkOnly(source []byte) (*Tree, error) {
 	p := pp.checkout()
 	if p == nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -112,6 +112,31 @@ func TestParserSimpleExpression(t *testing.T) {
 	}
 }
 
+func TestParseNoResultCompatibilityBenchmarkOnlyMaterializesTree(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	parser := NewParser(lang)
+
+	tree, err := parser.ParseNoResultCompatibilityBenchmarkOnly([]byte("1+2"))
+	if err != nil {
+		t.Fatalf("ParseNoResultCompatibilityBenchmarkOnly: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("parse returned nil tree")
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("parse returned nil root")
+	}
+	if got := root.ChildCount(); got != 3 {
+		t.Fatalf("root child count = %d, want 3; no-compat mode must preserve tree materialization", got)
+	}
+	if parser.noResultCompatibilityBenchmarkOnly || parser.noTreeBenchmarkOnly || parser.noTreeCheckpointBenchmarkOnly {
+		t.Fatal("benchmark-only parser flags were not restored")
+	}
+}
+
 func TestParserChainedExpression(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)


### PR DESCRIPTION
## Outcome

Corrects the canonical full-parse measurement contract before further performance work.

- `BenchmarkGoParseFullDFA` now calls public `Parser.Parse` and materializes a complete tree.
- `BenchmarkGoParseCoreDFA` preserves an explicitly named no-tree parser-core diagnostic.
- `ParseNoResultCompatibilityBenchmarkOnly` no longer implicitly enables no-tree mode. It now returns a materialized diagnostic tree; large-input diagnostic strategies still key off this flag, so this is not claimed as a pure compatibility-only A/B.
- README and changelog withdraw the mislabeled generated-Go headline and identify the v0.24.0 allocation statement as parser-core evidence.
- CI rebases its existing perf contract floor to exact commit `1717ce84179a850501ec86684f80a77e24d661a8`, the first corrected benchmark implementation.

## Evidence

- Focused host tests green.
- Focused Docker gate green: `harness_out/docker/20260711T100932Z-benchmark-contract`.
- Corrected steady-state allocation samples separate public full parse at about 622 KiB / 100 allocs from parser core at about 1 KiB / 6 allocs. Host timing was deliberately not published because load average exceeded 30.
- Canopy blast-radius review: five direct consumers and 34 affected symbols across five files; all are benchmark, harness, or pool delegation paths.
- A broader root sweep hit `TestCSharpDesignerStyleBlockStaysBounded` timeout under host pressure; the same failure reproduces unchanged on the v0.24.0 release worktree, while v0.24.0 hosted CI is green.

Correctness and performance gates remain separate; no production `Parser.Parse` semantics are changed.