### PR TITLE
perf(kotlin): certify the first scanner retry ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ for tags and release notes while still in `0.x`.
 - Added the explicitly diagnostic `BenchmarkGoParseCoreDFA` lane and withdrew
   the older generated-Go full-parse headline pending a pinned quiet-host rerun
   of the corrected public benchmark.
+- External-scanner full-parse retry suppression now uses explicit certified
+  language-profile metadata instead of parser-core language-name checks.
+  Python and Dart retain their existing behavior, and Kotlin now treats the
+  first retry ladder's selected tree as authoritative.
 
 ### Performance
 
@@ -36,6 +40,10 @@ for tags and release notes while still in `0.x`.
   2.07 GB/op and seconds before the certified row policy. The exact CGo deep
   parity gate and bounded runtime regression both pass; timing is not ratcheted
   until a quiet-host sample is available.
+- Kotlin's pinned eight-file performance set drops from 1.423 seconds to 790
+  milliseconds in a one-CPU Docker A/B after removing the redundant second
+  external-scanner retry ladder. All eight selected trees retain identical
+  S-expression hashes, stop reasons, EOF spans, and error states.
 
 ## [0.24.0] - 2026-07-11
 

--- a/grammars/blob_export_test.go
+++ b/grammars/blob_export_test.go
@@ -63,6 +63,9 @@ func TestLoadLanguageAttachesExternalScannerSupport(t *testing.T) {
 	if len(lang.ExternalLexStates) == 0 {
 		t.Fatal("LoadLanguage(python) did not attach external lex states")
 	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetrySkipRepeat {
+		t.Fatalf("LoadLanguage(python) retry policy = %d, want certified skip-repeat policy", got)
+	}
 }
 
 func TestLoadLanguageAcceptsAliases(t *testing.T) {

--- a/grammars/embedded_loader.go
+++ b/grammars/embedded_loader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"container/list"
+	"crypto/sha256"
 	"encoding/gob"
 	"fmt"
 	"io"
@@ -44,6 +45,7 @@ func RegisterExternalLexStates(name string, states [][]bool) {
 
 type embeddedLanguageCacheEntry struct {
 	blobName   string
+	blobSHA256 [32]byte
 	lruNode    *list.Element
 	lastAccess time.Time
 	once       sync.Once
@@ -118,21 +120,24 @@ func loadEmbeddedLanguage(blobName string) *gotreesitter.Language {
 }
 
 // LoadLanguage deserializes a raw grammar blob and attaches registered
-// gotreesitter/grammars runtime support for name, including external scanners
-// and external lex-state tables. Use this instead of gotreesitter.LoadLanguage
-// when loading blobs that came from BlobByName, grammar_subset, or a remote WASM
-// bundle and the caller knows the language name.
+// gotreesitter/grammars runtime support for name, including external scanners,
+// external lex-state tables, and any runtime profile certified for this exact
+// blob. Use this instead of gotreesitter.LoadLanguage when loading blobs that
+// came from BlobByName, grammar_subset, or a remote WASM bundle and the caller
+// knows the language name.
 func LoadLanguage(name string, data []byte) (*gotreesitter.Language, error) {
 	lang, err := gotreesitter.LoadLanguage(data)
 	if err != nil {
 		return nil, err
 	}
 	AttachLanguageSupport(name, lang)
+	attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256(data), lang)
 	return lang, nil
 }
 
-// AttachLanguageSupport attaches registered scanner support for name to lang.
-// It returns true when scanner or external lex-state support was attached.
+// AttachLanguageSupport attaches registered scanner and external lex-state
+// support for name to lang. Certified runtime profiles require the original
+// blob identity and are attached by LoadLanguage or the embedded loader.
 func AttachLanguageSupport(name string, lang *gotreesitter.Language) bool {
 	if lang == nil {
 		return false
@@ -161,12 +166,14 @@ func canonicalLanguageName(name string) string {
 func loadEmbeddedLanguageBase(blobName string) *gotreesitter.Language {
 	entry := getEmbeddedLanguageCacheEntry(blobName)
 	entry.once.Do(func() {
-		entry.lang, entry.err = decodeEmbeddedLanguage(blobName)
+		entry.lang, entry.blobSHA256, entry.err = decodeEmbeddedLanguage(blobName)
 		if entry.err == nil {
-			// Attach external scanner and lex states if registered.
+			// Attach external scanner, lex states, and certified runtime profile
+			// if registered.
 			name := strings.TrimSuffix(blobName, ".bin")
 			attachExternalScannerForLanguage(name, entry.lang)
 			attachRegisteredExternalLexStates(name, entry.lang)
+			attachBuiltinLanguageRuntimeProfile(name, entry.blobSHA256, entry.lang)
 		}
 	})
 	if entry.err != nil {
@@ -507,14 +514,16 @@ func attachRegisteredExternalLexStates(name string, targetLang *gotreesitter.Lan
 	gotreesitter.CertifyCRecoveryCostCompetition(targetLang)
 }
 
-func decodeEmbeddedLanguage(blobName string) (*gotreesitter.Language, error) {
+func decodeEmbeddedLanguage(blobName string) (*gotreesitter.Language, [32]byte, error) {
 	blob, err := readGrammarBlob(blobName)
 	if err != nil {
-		return nil, fmt.Errorf("read grammar blob %q: %w", blobName, err)
+		return nil, [32]byte{}, fmt.Errorf("read grammar blob %q: %w", blobName, err)
 	}
 	defer blob.close()
 
-	return decodeLanguageBlobData(blobName, blob.data)
+	sum := sha256.Sum256(blob.data)
+	lang, err := decodeLanguageBlobData(blobName, blob.data)
+	return lang, sum, err
 }
 
 func decodeLanguageBlobData(blobName string, data []byte) (*gotreesitter.Language, error) {

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -1,0 +1,58 @@
+package grammars
+
+import (
+	"encoding/hex"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// builtinLanguageRuntimeProfile contains narrow runtime decisions certified
+// against the checked-in grammar/scanner pair. Keep these policies outside the
+// parser core: loading the exact certified blob attaches its profile, while
+// caller-constructed and adapted languages retain conservative zero defaults.
+type builtinLanguageRuntimeProfile struct {
+	blobSHA256                    [32]byte
+	externalScannerFullParseRetry gotreesitter.ExternalScannerFullParseRetryPolicy
+}
+
+var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
+	// These scanner-backed grammars have certified the first retry ladder's
+	// selected accepted-error tree as authoritative. Repeating the whole ladder
+	// does not improve the selected tree and imposes a full additional parse.
+	"dart": {
+		blobSHA256:                    mustRuntimeProfileSHA256("06bac15a9921a2e6af2810fb37ecb29a358b120e137345b9af5fb5f6c6632f59"),
+		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+	},
+	"kotlin": {
+		blobSHA256:                    mustRuntimeProfileSHA256("643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78"),
+		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+	},
+	"python": {
+		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
+		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+	},
+}
+
+func mustRuntimeProfileSHA256(raw string) (sum [32]byte) {
+	decoded, err := hex.DecodeString(raw)
+	if err != nil || len(decoded) != len(sum) {
+		panic("invalid built-in runtime-profile SHA-256")
+	}
+	copy(sum[:], decoded)
+	return sum
+}
+
+func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang *gotreesitter.Language) bool {
+	if lang == nil || lang.ExternalScanner == nil {
+		return false
+	}
+	profile, ok := builtinLanguageRuntimeProfiles[canonicalLanguageName(name)]
+	if !ok || blobSHA256 != profile.blobSHA256 {
+		return false
+	}
+	if lang.ExternalScannerFullParseRetryPolicy == profile.externalScannerFullParseRetry {
+		return false
+	}
+	lang.ExternalScannerFullParseRetryPolicy = profile.externalScannerFullParseRetry
+	return true
+}

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -67,9 +67,12 @@ func TestBuiltinExternalScannerRetryProfilesRequireCertifiedBlob(t *testing.T) {
 
 func TestAttachLanguageSupportDoesNotCertifyWithoutBlobIdentity(t *testing.T) {
 	base := KotlinLanguage()
-	lang := *base
-	lang.ExternalScannerFullParseRetryPolicy = gotreesitter.ExternalScannerFullParseRetryDefault
-	if !AttachLanguageSupport("kotlin", &lang) {
+	lang := &gotreesitter.Language{
+		Name:            base.Name,
+		ExternalSymbols: append([]gotreesitter.Symbol(nil), base.ExternalSymbols...),
+		SymbolNames:     append([]string(nil), base.SymbolNames...),
+	}
+	if !AttachLanguageSupport("kotlin", lang) {
 		t.Fatal("AttachLanguageSupport(kotlin) did not attach scanner support")
 	}
 	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -1,0 +1,78 @@
+package grammars
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	tests := []struct {
+		name string
+		load func() *gotreesitter.Language
+	}{
+		{name: "dart", load: DartLanguage},
+		{name: "kotlin", load: KotlinLanguage},
+		{name: "python", load: PythonLanguage},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := tt.load()
+			if lang.ExternalScanner == nil {
+				t.Fatal("ExternalScanner = nil, want attached scanner")
+			}
+			if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetrySkipRepeat {
+				t.Fatalf("ExternalScannerFullParseRetryPolicy = %d, want certified skip-repeat policy", got)
+			}
+		})
+	}
+}
+
+func TestBuiltinExternalScannerRetryProfilesStayNarrow(t *testing.T) {
+	if got, want := len(builtinLanguageRuntimeProfiles), 3; got != want {
+		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
+	}
+	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
+	if attachBuiltinLanguageRuntimeProfile("ruby", [32]byte{}, lang) {
+		t.Fatal("unknown runtime profile reported an attachment")
+	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {
+		t.Fatalf("unknown runtime profile changed policy to %d", got)
+	}
+}
+
+func TestBuiltinExternalScannerRetryProfilesRequireCertifiedBlob(t *testing.T) {
+	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
+	if attachBuiltinLanguageRuntimeProfile("kotlin", sha256.Sum256([]byte("uncertified")), lang) {
+		t.Fatal("uncertified Kotlin blob reported a runtime-profile attachment")
+	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {
+		t.Fatalf("uncertified Kotlin blob changed policy to %d", got)
+	}
+
+	blob := BlobByName("kotlin")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(kotlin) returned no data")
+	}
+	if !attachBuiltinLanguageRuntimeProfile("kotlin", sha256.Sum256(blob), lang) {
+		t.Fatal("certified Kotlin blob did not attach its runtime profile")
+	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetrySkipRepeat {
+		t.Fatalf("certified Kotlin blob policy = %d, want skip-repeat", got)
+	}
+}
+
+func TestAttachLanguageSupportDoesNotCertifyWithoutBlobIdentity(t *testing.T) {
+	base := KotlinLanguage()
+	lang := *base
+	lang.ExternalScannerFullParseRetryPolicy = gotreesitter.ExternalScannerFullParseRetryDefault
+	if !AttachLanguageSupport("kotlin", &lang) {
+		t.Fatal("AttachLanguageSupport(kotlin) did not attach scanner support")
+	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {
+		t.Fatalf("AttachLanguageSupport certified policy without blob identity: %d", got)
+	}
+}

--- a/language.go
+++ b/language.go
@@ -257,6 +257,24 @@ type ConflictPolicy struct {
 	ReduceSymbols []Symbol
 }
 
+// ExternalScannerFullParseRetryPolicy controls whether a full parse with an
+// external scanner may schedule the generic second retry ladder after the
+// normal retry ladder has already selected its best tree.
+//
+// Keep new values append-only: Language blobs encode these numeric values.
+type ExternalScannerFullParseRetryPolicy uint8
+
+const (
+	// ExternalScannerFullParseRetryDefault preserves the generic behavior: an
+	// accepted error-bearing tree may schedule one more full retry ladder.
+	ExternalScannerFullParseRetryDefault ExternalScannerFullParseRetryPolicy = iota
+
+	// ExternalScannerFullParseRetrySkipRepeat certifies that the tree selected
+	// by the first retry ladder is authoritative. The parser retains that exact
+	// selected tree and does not schedule the extra external-scanner retry.
+	ExternalScannerFullParseRetrySkipRepeat
+)
+
 // Language holds all data needed to parse a specific language.
 // It mirrors tree-sitter's TSLanguage C struct, translated into
 // idiomatic Go types with slice-based tables instead of raw pointers.
@@ -448,9 +466,14 @@ type Language struct {
 	// NonTerminalAliasMap mirrors tree-sitter C's ts_non_terminal_alias_map.
 	// Rows are indexed by nonterminal symbol and contain aliases that require
 	// preserving the wrapper during alias-bearing reductions. This is cold
-	// metadata and intentionally lives at the end of the struct so existing
-	// parser hot-field offsets stay stable.
+	// metadata and intentionally lives in the struct's cold tail so parser hot
+	// field offsets stay stable.
 	NonTerminalAliasMap [][]Symbol
+
+	// ExternalScannerFullParseRetryPolicy is a certified language-level policy
+	// for scheduling the extra external-scanner full-parse retry. Zero preserves
+	// the generic behavior for legacy blobs and caller-constructed languages.
+	ExternalScannerFullParseRetryPolicy ExternalScannerFullParseRetryPolicy
 }
 
 type symbolNameNamedKey struct {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -807,7 +807,7 @@ func TestShouldTakeCleanWideRetryNoStacksAliveRequiresExpectedEOFCoverage(t *tes
 	}
 }
 
-func TestShouldRepeatExternalScannerFullParseSkipsDart(t *testing.T) {
+func TestShouldRepeatExternalScannerFullParseHonorsLanguagePolicy(t *testing.T) {
 	tree := &Tree{
 		root: &Node{
 			flags: nodeFlagHasError,
@@ -818,11 +818,15 @@ func TestShouldRepeatExternalScannerFullParseSkipsDart(t *testing.T) {
 	}
 	scanner := parserTestUnsafeExternalScanner{}
 
-	if shouldRepeatExternalScannerFullParse(&Language{Name: "dart", ExternalScanner: scanner}, tree) {
-		t.Fatal("shouldRepeatExternalScannerFullParse(dart accepted error) = true, want false")
-	}
-	if shouldRepeatExternalScannerFullParse(&Language{Name: "python", ExternalScanner: scanner}, tree) {
-		t.Fatal("shouldRepeatExternalScannerFullParse(python accepted error) = true, want false")
+	for _, name := range []string{"dart", "kotlin", "python"} {
+		lang := &Language{Name: name, ExternalScanner: scanner}
+		if !shouldRepeatExternalScannerFullParse(lang, tree) {
+			t.Fatalf("shouldRepeatExternalScannerFullParse(%s default accepted error) = false, want true", name)
+		}
+		lang.ExternalScannerFullParseRetryPolicy = ExternalScannerFullParseRetrySkipRepeat
+		if shouldRepeatExternalScannerFullParse(lang, tree) {
+			t.Fatalf("shouldRepeatExternalScannerFullParse(%s certified accepted error) = true, want false", name)
+		}
 	}
 	if !shouldRepeatExternalScannerFullParse(&Language{Name: "ruby", ExternalScanner: scanner}, tree) {
 		t.Fatal("shouldRepeatExternalScannerFullParse(ruby accepted error) = false, want true")
@@ -875,6 +879,13 @@ func TestRetryFullParseStopsSchedulingRetriesAfterTimeout(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("runRetry calls = %d, want 1", calls)
+	}
+	lang := &Language{
+		ExternalScanner:                     parserTestUnsafeExternalScanner{},
+		ExternalScannerFullParseRetryPolicy: ExternalScannerFullParseRetrySkipRepeat,
+	}
+	if shouldRepeatExternalScannerFullParse(lang, got) {
+		t.Fatal("certified first-ladder selected tree scheduled a second external-scanner retry")
 	}
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1116,7 +1116,7 @@ func shouldRepeatExternalScannerFullParse(lang *Language, tree *Tree) bool {
 	if lang == nil || lang.ExternalScanner == nil || tree == nil {
 		return false
 	}
-	if lang.Name == "python" || lang.Name == "dart" {
+	if lang.ExternalScannerFullParseRetryPolicy == ExternalScannerFullParseRetrySkipRepeat {
 		return false
 	}
 	// Skip the redundant re-parse when the first attempt already produced a


### PR DESCRIPTION
Moves external-scanner repeat scheduling out of parser-core language-name checks and into an explicit `Language` policy. Built-in Python and Dart retain their existing behavior; Kotlin now certifies the first retry ladder's selected tree as authoritative.

The built-in certifications are fail-closed on the exact checked-in blob SHA-256. Caller-constructed, adapted, and override languages retain the conservative generic retry behavior.

Performance/correctness evidence:

- pinned eight-file Kotlin Docker A/B: 1.423s → 790ms aggregate (~44.5%)
- retry cliffs: `BufferedChannel.kt` 1.126s → 558ms; `Channel.kt` 142ms → 67ms
- all eight files retain identical S-expression SHA-256, stop reason, EOF span, and root error state
- the known pre-existing macro C mismatch (`annotation` vs `prefix_expression`) is unchanged and remains separately correctness-gated

Validation:

- focused policy tests repeated 20×
- exact-blob and fail-closed loader/profile tests
- root and grammars compile checks
- Kotlin grammar-subset build
- Docker focused root/grammar policy gate
- structural reference review and `git diff --check`

A strict generated Kotlin parity attempt reached the existing 90s grammar-generation timeout before selecting any cases; it did not report a parse or parity regression.