### PR TITLE
refactor(parser): pack pending-child field metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- Pending-parent child entries now pack their full 16-bit field ID and field
+  source beside the payload kind. Fielded parents use one 16-byte entry per
+  child instead of a second sidecar entry, and materialization no longer
+  reconstructs direct fields from grammar tables.
+
+### Fixed
+
+- Stack dedupe and GSS link merging now treat pending-parent hashes as coarse
+  prefilters and recursively verify packed fields, field sources, and nested
+  pending descendants. Missing arena context and excessive depth fail closed
+  instead of allowing a hash collision to collapse distinct alternatives.
+
 ## [0.24.1] - 2026-07-11
 
 Performance-contract and repository-hygiene follow-up to v0.24.0. This patch

--- a/arena.go
+++ b/arena.go
@@ -1234,22 +1234,15 @@ func (a *nodeArena) allocPendingParent() *pendingParent {
 }
 
 func (a *nodeArena) allocPendingChildEntries(n int) (pendingChildRange, []pendingChildEntry) {
-	return a.allocPendingChildEntryRange(n, n)
-}
-
-func (a *nodeArena) allocPendingChildEntryRange(logicalCount, slotCount int) (pendingChildRange, []pendingChildEntry) {
-	if logicalCount <= 0 || slotCount <= 0 {
+	if n <= 0 {
 		return 0, nil
-	}
-	if slotCount < logicalCount {
-		panic("pending child entry slot count below logical count")
 	}
 	if a == nil {
 		panic("pending child entry ranges require an arena")
 	}
-	a.pendingChildEntriesAllocated += uint64(slotCount)
+	a.pendingChildEntriesAllocated += uint64(n)
 	if len(a.pendingChildEntrySlabs) == 0 {
-		capacity := max(defaultPendingChildEntrySlabCap(a.class), slotCount)
+		capacity := max(defaultPendingChildEntrySlabCap(a.class), n)
 		a.pendingChildEntrySlabs = append(a.pendingChildEntrySlabs, pendingChildEntrySlab{data: make([]pendingChildEntry, capacity)})
 		a.allocatedBytes += pendingChildEntryBytesForCap(capacity)
 		a.pendingChildEntrySlabCursor = 0
@@ -1260,19 +1253,19 @@ func (a *nodeArena) allocPendingChildEntryRange(logicalCount, slotCount int) (pe
 	for i := a.pendingChildEntrySlabCursor; ; i++ {
 		if i >= len(a.pendingChildEntrySlabs) {
 			lastCap := len(a.pendingChildEntrySlabs[len(a.pendingChildEntrySlabs)-1].data)
-			capacity := nextPendingChildEntrySlabCap(a.class, lastCap, slotCount)
+			capacity := nextPendingChildEntrySlabCap(a.class, lastCap, n)
 			a.pendingChildEntrySlabs = append(a.pendingChildEntrySlabs, pendingChildEntrySlab{data: make([]pendingChildEntry, capacity)})
 			a.allocatedBytes += pendingChildEntryBytesForCap(capacity)
 		}
 
 		slab := &a.pendingChildEntrySlabs[i]
-		if len(slab.data)-slab.used < slotCount {
+		if len(slab.data)-slab.used < n {
 			continue
 		}
 		start := slab.used
-		slab.used += slotCount
+		slab.used += n
 		a.pendingChildEntrySlabCursor = i
-		return newPendingChildRange(i, start, logicalCount), slab.data[start:slab.used]
+		return newPendingChildRange(i, start, n), slab.data[start:slab.used]
 	}
 }
 

--- a/glr.go
+++ b/glr.go
@@ -147,6 +147,7 @@ type glrMergeScratch struct {
 	largeSlots        []glrMergeLargeSlot
 	perKeyCap         int
 	language          *Language
+	arena             *nodeArena
 	deferExactDedupe  bool
 	frontierMergeHash bool
 	trace             bool
@@ -2043,6 +2044,9 @@ const (
 )
 
 func stackEntryPayloadsEquivalentForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b stackEntry) bool {
+	if stackEntryPendingParent(a) != nil || stackEntryPendingParent(b) != nil {
+		return pendingStackEntryPayloadsExactlyEquivalentForLanguageWithScratch(scratch, lang, a, b, 0, false)
+	}
 	an := stackEntryNode(a)
 	bn := stackEntryNode(b)
 	if an != nil && bn != nil {
@@ -2067,6 +2071,109 @@ func stackEntryPayloadsEquivalentForLanguageWithScratch(scratch *glrMergeScratch
 		return false
 	}
 	return true
+}
+
+// pendingStackEntryPayloadsExactlyEquivalentForLanguageWithScratch is the
+// collision-safe verifier behind the coarse GSS hash for pending parents.
+// Pending-parent hashes intentionally cover only the parent header; distinct
+// child graphs can therefore share a hash and must never be merged without
+// this recursive comparison. A missing arena fails closed for distinct
+// pending payloads: that can retain an extra stack, but cannot alter the tree.
+func pendingStackEntryPayloadsExactlyEquivalentForLanguageWithScratch(scratch *glrMergeScratch, lang *Language, a, b stackEntry, depth int, ignoreDynamic bool) bool {
+	if a.node == b.node && a.kind == b.kind {
+		return true
+	}
+	if depth >= maxTreeWalkDepth || !stackEntryHasNode(a) || !stackEntryHasNode(b) {
+		return false
+	}
+	if stackEntryNodeSymbol(a) != stackEntryNodeSymbol(b) ||
+		stackEntryNodeStartByte(a) != stackEntryNodeStartByte(b) ||
+		stackEntryNodeEndByte(a) != stackEntryNodeEndByte(b) ||
+		stackEntryNodeChildCount(a) != stackEntryNodeChildCount(b) ||
+		stackEntryNodeFieldIDCount(a) != stackEntryNodeFieldIDCount(b) ||
+		stackEntryNodeExactFlagBits(a) != stackEntryNodeExactFlagBits(b) ||
+		stackEntryNodeParseState(a) != stackEntryNodeParseState(b) ||
+		stackEntryNodePreGotoState(a) != stackEntryNodePreGotoState(b) ||
+		stackEntryNodeProductionID(a) != stackEntryNodeProductionID(b) {
+		return false
+	}
+	if !ignoreDynamic && stackEntryDynamicPrecedence(a) != stackEntryDynamicPrecedence(b) {
+		return false
+	}
+
+	childCount := stackEntryNodeChildCount(a)
+	if childCount == 0 {
+		return true
+	}
+	if scratch == nil || scratch.arena == nil {
+		return false
+	}
+	for i := 0; i < childCount; i++ {
+		af, as, aok := stackEntryPendingFieldMetadataAt(scratch.arena, a, i)
+		bf, bs, bok := stackEntryPendingFieldMetadataAt(scratch.arena, b, i)
+		if !aok || !bok || af != bf || as != bs {
+			return false
+		}
+		ac, aok := stackEntryPendingChildAt(scratch.arena, a, i)
+		bc, bok := stackEntryPendingChildAt(scratch.arena, b, i)
+		if !aok || !bok {
+			return false
+		}
+		if stackEntryPendingParent(ac) != nil || stackEntryPendingParent(bc) != nil {
+			if !pendingStackEntryPayloadsExactlyEquivalentForLanguageWithScratch(scratch, lang, ac, bc, depth+1, false) {
+				return false
+			}
+			continue
+		}
+		if !stackEntryPayloadsEquivalentForLanguageWithScratch(scratch, lang, ac, bc) {
+			return false
+		}
+	}
+	return true
+}
+
+func stackEntryPendingChildAt(arena *nodeArena, entry stackEntry, i int) (stackEntry, bool) {
+	if parent := stackEntryPendingParent(entry); parent != nil {
+		if arena == nil || i < 0 || i >= parent.childEntryCount() {
+			return stackEntry{}, false
+		}
+		refs := parent.childRefs(arena)
+		if i >= len(refs) {
+			return stackEntry{}, false
+		}
+		return refs[i].stackEntry(), true
+	}
+	if node := stackEntryNode(entry); node != nil {
+		return nodeChildEntryAtNoMaterialize(node, i)
+	}
+	return stackEntry{}, false
+}
+
+func stackEntryPendingFieldMetadataAt(arena *nodeArena, entry stackEntry, i int) (FieldID, uint8, bool) {
+	if parent := stackEntryPendingParent(entry); parent != nil {
+		if arena == nil || i < 0 || i >= parent.childEntryCount() {
+			return 0, fieldSourceNone, false
+		}
+		refs := parent.childRefs(arena)
+		if i >= len(refs) {
+			return 0, fieldSourceNone, false
+		}
+		return refs[i].fieldID(), refs[i].fieldSource(), true
+	}
+	if node := stackEntryNode(entry); node != nil {
+		childCount := nodeChildCountNoMaterialize(node)
+		if i < 0 || i >= childCount {
+			return 0, fieldSourceNone, false
+		}
+		if len(node.fieldIDs) == 0 {
+			return 0, fieldSourceNone, true
+		}
+		if len(node.fieldIDs) != childCount {
+			return 0, fieldSourceNone, false
+		}
+		return node.fieldIDs[i], fieldSourceAt(node.fieldSources, i), true
+	}
+	return 0, fieldSourceNone, false
 }
 
 func stackEntryExactHeaderSignature(e stackEntry) uint64 {
@@ -2930,6 +3037,9 @@ func gssMainCanMergeForParser(p *Parser, a, b *glrStack) bool {
 		}
 		return false
 	}
+	if p != nil {
+		return gssMainCanMergeWithScratch(p.mergeScratch, a, b)
+	}
 	return gssMainCanMergeWithScratch(nil, a, b)
 }
 
@@ -2937,7 +3047,11 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 	if !gssMainCanMergeForParser(p, a, b) {
 		return false
 	}
-	merged := gssMainMerge(a, b)
+	var scratch *glrMergeScratch
+	if p != nil {
+		scratch = p.mergeScratch
+	}
+	merged := gssMainMergeWithScratch(scratch, a, b)
 	if merged {
 		// a survives and absorbs b, so OR the sticky wreckage bit: cEverErrored
 		// is lineage history, not current shape, and a clean survivor must not
@@ -3185,6 +3299,17 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 }
 
 func stackEntryPayloadsEquivalentIgnoringDynamic(a, b stackEntry) bool {
+	return stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(nil, a, b)
+}
+
+func stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch *glrMergeScratch, a, b stackEntry) bool {
+	if stackEntryPendingParent(a) != nil || stackEntryPendingParent(b) != nil {
+		var lang *Language
+		if scratch != nil {
+			lang = scratch.language
+		}
+		return pendingStackEntryPayloadsExactlyEquivalentForLanguageWithScratch(scratch, lang, a, b, 0, true)
+	}
 	an := stackEntryNode(a)
 	bn := stackEntryNode(b)
 	if an != nil && bn != nil {
@@ -3681,7 +3806,7 @@ func (p *gssMainPreflight) canAddLink(n *gssNode, prev *gssNode, entry stackEntr
 	}
 	for i := 0; i < p.linkCount(n); i++ {
 		existingPrev, existingEntry := p.linkAt(n, i)
-		if !stackEntryPayloadsEquivalentIgnoringDynamic(existingEntry, entry) {
+		if !stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(p.scratch, existingEntry, entry) {
 			continue
 		}
 		if existingPrev == prev {
@@ -3702,10 +3827,10 @@ func gssMainAddLinkSeen(n *gssNode, prev *gssNode, entry stackEntry, seen map[gs
 	if !gssMainCanAddLinkSeen(n, prev, entry, seen) {
 		return false
 	}
-	return gssMainAddLinkSeenMutate(n, prev, entry, seen)
+	return gssMainAddLinkSeenMutate(nil, n, prev, entry, seen)
 }
 
-func gssMainAddLinkSeenMutate(n *gssNode, prev *gssNode, entry stackEntry, seen map[gssMergePair]bool) bool {
+func gssMainAddLinkSeenMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNode, entry stackEntry, seen map[gssMergePair]bool) bool {
 	if n == nil {
 		return false
 	}
@@ -3714,7 +3839,7 @@ func gssMainAddLinkSeenMutate(n *gssNode, prev *gssNode, entry stackEntry, seen 
 	}
 	for i := 0; i < n.linkCount(); i++ {
 		existingPrev, existingEntry := n.link(i)
-		if !stackEntryPayloadsEquivalentIgnoringDynamic(existingEntry, entry) {
+		if !stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch, existingEntry, entry) {
 			continue
 		}
 		if existingPrev == prev {
@@ -3724,8 +3849,8 @@ func gssMainAddLinkSeenMutate(n *gssNode, prev *gssNode, entry stackEntry, seen 
 			n.hash = 0
 			return true
 		}
-		if gssNodesCanMerge(existingPrev, prev) {
-			merged := gssMainMergeNodesSeenMutate(existingPrev, prev, seen)
+		if gssNodesCanMergeWithScratch(scratch, existingPrev, prev) {
+			merged := gssMainMergeNodesSeenMutate(scratch, existingPrev, prev, seen)
 			if merged && stackEntryDynamicPrecedence(entry) > stackEntryDynamicPrecedence(existingEntry) {
 				setGSSMainLink(n, i, existingPrev, entry)
 			}
@@ -3734,7 +3859,7 @@ func gssMainAddLinkSeenMutate(n *gssNode, prev *gssNode, entry stackEntry, seen 
 		}
 	}
 	if n.linkCount() >= maxMainLinkCount {
-		if gssMainReplaceWorstEquivalentLinkIfBetterMutate(n, prev, entry, seen) {
+		if gssMainReplaceWorstEquivalentLinkIfBetterMutate(scratch, n, prev, entry, seen) {
 			n.hash = 0
 			return true
 		}
@@ -3755,7 +3880,7 @@ func (p *gssMainPreflight) canReplaceWorstEquivalentLinkIfBetter(n *gssNode, pre
 	var worstPrev *gssNode
 	for i := 0; i < p.linkCount(n); i++ {
 		existingPrev, existingEntry := p.linkAt(n, i)
-		if !stackEntryPayloadsEquivalentIgnoringDynamic(existingEntry, entry) {
+		if !stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(p.scratch, existingEntry, entry) {
 			continue
 		}
 		if existingPrev != prev && !p.nodesCanMerge(existingPrev, prev) {
@@ -3781,19 +3906,19 @@ func gssMainReplaceWorstEquivalentLinkIfBetter(n *gssNode, prev *gssNode, entry 
 	if !gssMainCanReplaceWorstEquivalentLinkIfBetter(n, prev, entry, make(map[gssMergePair]bool)) {
 		return false
 	}
-	return gssMainReplaceWorstEquivalentLinkIfBetterMutate(n, prev, entry, make(map[gssMergePair]bool))
+	return gssMainReplaceWorstEquivalentLinkIfBetterMutate(nil, n, prev, entry, make(map[gssMergePair]bool))
 }
 
-func gssMainReplaceWorstEquivalentLinkIfBetterMutate(n *gssNode, prev *gssNode, entry stackEntry, seen map[gssMergePair]bool) bool {
+func gssMainReplaceWorstEquivalentLinkIfBetterMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNode, entry stackEntry, seen map[gssMergePair]bool) bool {
 	worst := -1
 	worstPrecedence := stackEntryDynamicPrecedence(entry)
 	var worstPrev *gssNode
 	for i := 0; i < n.linkCount(); i++ {
 		existingPrev, existingEntry := n.link(i)
-		if !stackEntryPayloadsEquivalentIgnoringDynamic(existingEntry, entry) {
+		if !stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch, existingEntry, entry) {
 			continue
 		}
-		if existingPrev != prev && !gssNodesCanMerge(existingPrev, prev) {
+		if existingPrev != prev && !gssNodesCanMergeWithScratch(scratch, existingPrev, prev) {
 			continue
 		}
 		existingPrecedence := stackEntryDynamicPrecedence(existingEntry)
@@ -3807,7 +3932,7 @@ func gssMainReplaceWorstEquivalentLinkIfBetterMutate(n *gssNode, prev *gssNode, 
 		return false
 	}
 	if worstPrev != prev {
-		if !gssMainMergeNodesSeenMutate(worstPrev, prev, seen) {
+		if !gssMainMergeNodesSeenMutate(scratch, worstPrev, prev, seen) {
 			return false
 		}
 		prev = worstPrev
@@ -3855,10 +3980,10 @@ func gssMainMergeNodesSeen(a, b *gssNode, seen map[gssMergePair]bool) bool {
 	if !gssMainCanMergeNodesSeen(a, b, seen) {
 		return false
 	}
-	return gssMainMergeNodesSeenMutate(a, b, seen)
+	return gssMainMergeNodesSeenMutate(nil, a, b, seen)
 }
 
-func gssMainMergeNodesSeenMutate(a, b *gssNode, seen map[gssMergePair]bool) bool {
+func gssMainMergeNodesSeenMutate(scratch *glrMergeScratch, a, b *gssNode, seen map[gssMergePair]bool) bool {
 	if a == nil || b == nil || a == b {
 		return true
 	}
@@ -3874,7 +3999,7 @@ func gssMainMergeNodesSeenMutate(a, b *gssNode, seen map[gssMergePair]bool) bool
 	count := b.linkCount()
 	for i := 0; i < count; i++ {
 		prev, entry := b.link(i)
-		if !gssMainAddLinkSeenMutate(a, prev, entry, seen) {
+		if !gssMainAddLinkSeenMutate(scratch, a, prev, entry, seen) {
 			mergedAll = false
 		}
 	}
@@ -3904,7 +4029,7 @@ func gssMainMergeWithScratch(scratch *glrMergeScratch, a, b *glrStack) bool {
 	if !pf.canMergeNodes(ah, bh) {
 		return false
 	}
-	return gssMainMergeNodesSeenMutate(ah, bh, acquireMergeSeenForScratch(scratch))
+	return gssMainMergeNodesSeenMutate(scratch, ah, bh, acquireMergeSeenForScratch(scratch))
 }
 
 func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int, stack *glrStack) (merged bool, attempted bool) {
@@ -4975,6 +5100,7 @@ func (s *glrMergeScratch) reset() {
 	s.cleanZeroScan = 0
 	s.perKeyCap = 0
 	s.language = nil
+	s.arena = nil
 	s.trace = false
 	s.cRecoveryCost = false
 	s.audit = nil

--- a/glr_test.go
+++ b/glr_test.go
@@ -1593,16 +1593,17 @@ func TestResultMutableChildViewSurroundFinalRefsKeepsChildrenLazy(t *testing.T) 
 	}
 }
 
-func TestPendingParentMaterializationPreservesFieldEntries(t *testing.T) {
+func TestPendingParentMaterializationPreservesPackedFieldEntries(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
 	left := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
 	right := newLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	parent := newPendingParentShellWithEntrySlotsInArena(arena, 4, true, 5, 2, 4, 0, 2, Point{}, Point{Column: 2}, false)
-	parent.setHasFieldEntries(true)
+	parent := newPendingParentShellInArena(arena, 4, true, 5, 2, 0, 2, Point{}, Point{Column: 2}, false)
 	parent.setChildEntry(arena, 0, newStackEntryNode(6, left))
 	parent.setChildEntry(arena, 1, newStackEntryNode(7, right))
 	parent.setChildFieldEntry(arena, 1, 9, fieldSourceDirect)
-	parent.flags |= pendingParentFlagFieldEntries
+	if got := arena.pendingChildEntriesAllocated; got != 2 {
+		t.Fatalf("pendingChildEntriesAllocated = %d, want one packed slot per child", got)
+	}
 
 	entry := newStackEntryPendingParent(8, parent)
 	node := materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
@@ -1615,40 +1616,27 @@ func TestPendingParentMaterializationPreservesFieldEntries(t *testing.T) {
 	if len(node.fieldSources) != 2 || node.fieldSources[0] != fieldSourceNone || node.fieldSources[1] != fieldSourceDirect {
 		t.Fatalf("fieldSources = %#v, want [none direct]", node.fieldSources)
 	}
-	if node.flags&pendingParentFlagFieldEntries != 0 {
-		t.Fatalf("internal pending field flag leaked to materialized node flags: %08b", node.flags)
+	if node.flags&(pendingParentFlagFieldEntries|pendingParentFlagDirectFieldEntry) != 0 {
+		t.Fatalf("internal pending field flags leaked to materialized node flags: %08b", node.flags)
 	}
 }
 
-func TestPendingParentMaterializationRecomputesDirectFieldEntries(t *testing.T) {
-	lang := &Language{
-		FieldMapSlices: [][2]uint16{
-			{},
-			{},
-			{},
-			{},
-			{},
-			{0, 2},
-		},
-		FieldMapEntries: []FieldMapEntry{
-			{FieldID: 7, ChildIndex: 0},
-			{FieldID: 9, ChildIndex: 1},
-		},
-	}
-	parser := NewParser(lang)
+func TestPendingParentMaterializationUsesPackedDirectFieldEntriesWithoutParser(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
 	extra := newLeafNodeInArena(arena, 3, false, 0, 1, Point{}, Point{Column: 1})
 	extra.setExtra(true)
 	left := newLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
 	right := newLeafNodeInArena(arena, 2, true, 2, 3, Point{Column: 2}, Point{Column: 3})
-	parent := newPendingParentShellWithEntrySlotsInArena(arena, 4, true, 5, 3, 3, 0, 3, Point{}, Point{Column: 3}, false)
-	parent.setHasDirectFieldEntries(true)
+	parent := newPendingParentShellInArena(arena, 4, true, 5, 3, 0, 3, Point{}, Point{Column: 3}, false)
 	parent.setChildEntry(arena, 0, newStackEntryNode(6, extra))
 	parent.setChildEntry(arena, 1, newStackEntryNode(7, left))
 	parent.setChildEntry(arena, 2, newStackEntryNode(8, right))
+	parent.setHasDirectFieldEntries(true)
+	parent.setChildFieldEntry(arena, 1, 7, fieldSourceDirect)
+	parent.setChildFieldEntry(arena, 2, 9, fieldSourceDirect)
 
 	entry := newStackEntryPendingParent(9, parent)
-	node := materializeStackEntryPendingParentWithParser(parser, arena, &entry, pendingParentMaterializeForFinalTree)
+	node := materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
 	if node == nil {
 		t.Fatal("materialized node = nil")
 	}
@@ -1661,80 +1649,129 @@ func TestPendingParentMaterializationRecomputesDirectFieldEntries(t *testing.T) 
 	if len(node.fieldSources) != 3 || node.fieldSources[0] != fieldSourceNone || node.fieldSources[1] != fieldSourceDirect || node.fieldSources[2] != fieldSourceDirect {
 		t.Fatalf("fieldSources = %#v, want [none direct direct]", node.fieldSources)
 	}
-	if node.flags&pendingParentFlagDirectFieldEntry != 0 {
-		t.Fatalf("internal pending direct-field flag leaked to materialized node flags: %08b", node.flags)
+	if node.flags&(pendingParentFlagFieldEntries|pendingParentFlagDirectFieldEntry) != 0 {
+		t.Fatalf("internal pending field flags leaked to materialized node flags: %08b", node.flags)
 	}
 }
 
-func TestPendingDirectFieldParentFieldsRecomputableWithTrailingHidden(t *testing.T) {
-	parser := &Parser{language: &Language{
-		SymbolMetadata: []SymbolMetadata{
-			{},
-			{Visible: true},
-			{Visible: false},
-		},
-		FieldMapSlices: [][2]uint16{
-			{},
-			{},
-			{},
-			{},
-			{},
-			{0, 2},
-		},
-		FieldMapEntries: []FieldMapEntry{
-			{FieldID: 7, ChildIndex: 0},
-			{FieldID: 9, ChildIndex: 1},
-		},
-	}}
+func TestPendingChildEntryPackedFieldMetadataSurvivesPayloadReplacement(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
-	left := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
-	right := newLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	hidden := newParentNodeInArenaNoLinksWithFieldSources(arena, 2, false, nil, nil, nil, 5, false)
-	entries := []stackEntry{
-		newStackEntryNode(1, left),
-		newStackEntryNode(2, right),
-		newStackEntryNode(3, hidden),
+	first := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	replacement := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
+	parent := newPendingParentShellInArena(arena, 4, true, 5, 1, 0, 1, Point{}, Point{Column: 1}, false)
+	parent.setChildEntry(arena, 0, newStackEntryNode(6, first))
+	parent.setChildFieldEntry(arena, 0, FieldID(^uint16(0)), fieldSourceInherited)
+
+	parent.setChildEntry(arena, 0, newStackEntryNode(7, replacement))
+	entry := parent.childEntry(arena, 0)
+	if stackEntryNode(entry) != replacement {
+		t.Fatalf("replacement payload = %p, want %p", stackEntryNode(entry), replacement)
 	}
-	rawFieldIDs := []FieldID{7, 9, 0}
-	rawInherited := []bool{false, false, false}
-	if !parser.pendingDirectFieldParentFieldsRecomputable(5, 2, entries, 0, len(entries), rawFieldIDs, rawInherited, parser.language.SymbolMetadata) {
-		t.Fatal("pendingDirectFieldParentFieldsRecomputable = false, want true for trailing hidden child")
+	if fid, source := parent.childFieldEntry(arena, 0); fid != FieldID(^uint16(0)) || source != fieldSourceInherited {
+		t.Fatalf("packed field metadata = (%d,%d), want (%d,%d)", fid, source, FieldID(^uint16(0)), fieldSourceInherited)
 	}
 }
 
-func TestPendingDirectFieldParentFieldsRecomputableRejectsShiftedHidden(t *testing.T) {
-	parser := &Parser{language: &Language{
-		SymbolMetadata: []SymbolMetadata{
-			{},
-			{Visible: true},
-			{Visible: false},
-		},
-		FieldMapSlices: [][2]uint16{
-			{},
-			{},
-			{},
-			{},
-			{},
-			{0, 2},
-		},
-		FieldMapEntries: []FieldMapEntry{
-			{FieldID: 7, ChildIndex: 0},
-			{FieldID: 9, ChildIndex: 2},
-		},
-	}}
+func TestPendingPackedDirectFieldsRemainTransparentToHiddenCompaction(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
-	left := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
-	hidden := newParentNodeInArenaNoLinksWithFieldSources(arena, 2, false, nil, nil, nil, 5, false)
-	right := newLeafNodeInArena(arena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	entries := []stackEntry{
-		newStackEntryNode(1, left),
-		newStackEntryNode(2, hidden),
-		newStackEntryNode(3, right),
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	direct := newPendingParentInArena(arena, 4, true, 5, []stackEntry{newStackEntryNode(6, leaf)}, 0, 1, Point{}, Point{Column: 1}, false)
+	direct.setHasDirectFieldEntries(true)
+	direct.setChildFieldEntry(arena, 0, 7, fieldSourceDirect)
+	if direct.hasFieldEntries() || !direct.hasDirectFieldEntries() {
+		t.Fatalf("packed direct-field classification = dense:%t direct:%t", direct.hasFieldEntries(), direct.hasDirectFieldEntries())
 	}
-	rawFieldIDs := []FieldID{7, 0, 9}
-	rawInherited := []bool{false, false, false}
-	if parser.pendingDirectFieldParentFieldsRecomputable(5, 2, entries, 0, len(entries), rawFieldIDs, rawInherited, parser.language.SymbolMetadata) {
-		t.Fatal("pendingDirectFieldParentFieldsRecomputable = true, want false when hidden child shifts field map")
+	if stackEntryTreeHasFieldIDs(newStackEntryPendingParent(7, direct), arena) {
+		t.Fatal("packed direct fields became an opaque hidden-compaction barrier")
+	}
+
+	dense := newPendingParentInArena(arena, 4, true, 5, []stackEntry{newStackEntryNode(6, leaf)}, 0, 1, Point{}, Point{Column: 1}, false)
+	dense.setHasFieldEntries(true)
+	dense.setChildFieldEntry(arena, 0, 7, fieldSourceDirect)
+	if !stackEntryTreeHasFieldIDs(newStackEntryPendingParent(7, dense), arena) {
+		t.Fatal("dense packed fields lost their existing hidden-compaction barrier")
+	}
+}
+
+func TestPendingParentMergeEqualityVerifiesPackedFieldsAndDescendants(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	makeEntry := func(field FieldID, source uint8, leafSymbol Symbol) stackEntry {
+		leaf := newLeafNodeInArena(arena, leafSymbol, true, 0, 1, Point{}, Point{Column: 1})
+		leaf.parseState = 3
+		inner := newPendingParentInArena(arena, 10, true, 2, []stackEntry{newStackEntryNode(3, leaf)}, 0, 1, Point{}, Point{Column: 1}, false)
+		inner.parseState = 4
+		inner.setHasDirectFieldEntries(true)
+		inner.setChildFieldEntry(arena, 0, field, source)
+		outer := newPendingParentInArena(arena, 20, true, 3, []stackEntry{newStackEntryPendingParent(4, inner)}, 0, 1, Point{}, Point{Column: 1}, false)
+		outer.parseState = 5
+		return newStackEntryPendingParent(5, outer)
+	}
+	makeStack := func(entry stackEntry) glrStack {
+		return glrStack{
+			entries:    []stackEntry{{state: 1}, entry},
+			byteOffset: 1,
+		}
+	}
+
+	base := makeEntry(7, fieldSourceDirect, 1)
+	same := makeEntry(7, fieldSourceDirect, 1)
+	fieldCollision := makeEntry(8, fieldSourceDirect, 1)
+	fieldSourceCollision := makeEntry(7, fieldSourceInherited, 1)
+	descendantCollision := makeEntry(7, fieldSourceDirect, 2)
+	for name, candidate := range map[string]stackEntry{
+		"field":        fieldCollision,
+		"field-source": fieldSourceCollision,
+		"descendant":   descendantCollision,
+	} {
+		if got, want := gssEntryHash(gssHashSeed, base), gssEntryHash(gssHashSeed, candidate); got != want {
+			t.Fatalf("%s setup hashes differ: got %x want coarse collision %x", name, got, want)
+		}
+	}
+
+	scratch := glrMergeScratch{arena: arena}
+	scratch.beginEquivEpoch()
+	if !stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(base), makeStack(same)) {
+		t.Fatal("structurally identical pending parents were not equivalent")
+	}
+	materializedSame := same
+	if node := materializeStackEntryPendingParent(arena, &materializedSame, pendingParentMaterializeForFinalTree); node == nil {
+		t.Fatal("materializing equivalent pending parent returned nil")
+	}
+	if !stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(base), makeStack(materializedSame)) {
+		t.Fatal("pending and materialized representations of the same graph were not equivalent")
+	}
+	if stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(base), makeStack(fieldCollision)) {
+		t.Fatal("packed field mismatch survived exact pending-parent equality")
+	}
+	if stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(base), makeStack(fieldSourceCollision)) {
+		t.Fatal("packed field-source mismatch survived exact pending-parent equality")
+	}
+	if stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(base), makeStack(descendantCollision)) {
+		t.Fatal("recursive descendant mismatch survived exact pending-parent equality")
+	}
+
+	stacks := []glrStack{makeStack(base), makeStack(descendantCollision)}
+	if got := len(mergeStacksWithScratch(stacks, &scratch)); got != 2 {
+		t.Fatalf("merge result = %d stacks, want both coarse-hash collision alternatives", got)
+	}
+
+	var gssScratch gssScratch
+	sharedPrev := gssScratch.allocNode(stackEntry{state: 1}, nil, 1)
+	leftHead := gssScratch.allocNode(base, sharedPrev, 2)
+	rightHead := gssScratch.allocNode(descendantCollision, sharedPrev, 2)
+	leftStack := glrStack{gss: gssStack{head: leftHead}, byteOffset: 1}
+	rightStack := glrStack{gss: gssStack{head: rightHead}, byteOffset: 1}
+	if !gssMainMergeWithScratch(&scratch, &leftStack, &rightStack) {
+		t.Fatal("lossless GSS merge rejected distinct pending alternatives")
+	}
+	if got := leftHead.linkCount(); got != 2 {
+		t.Fatalf("GSS pending collision links = %d, want both alternatives", got)
+	}
+
+	noArena := glrMergeScratch{}
+	noArena.beginEquivEpoch()
+	if stackEquivalentForLanguageWithScratch(&noArena, nil, makeStack(base), makeStack(same)) {
+		t.Fatal("distinct pending parents without an arena must fail closed")
 	}
 }
 

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -485,6 +485,9 @@ func stackEntryNodeFieldIDCount(e stackEntry) int {
 	if n := stackEntryNode(e); n != nil {
 		return len(n.fieldIDs)
 	}
+	if n := stackEntryPendingParent(e); n != nil && (n.hasFieldEntries() || n.hasDirectFieldEntries()) {
+		return n.childEntryCount()
+	}
 	return 0
 }
 

--- a/parser.go
+++ b/parser.go
@@ -829,6 +829,12 @@ func (p *Parser) stopFrontierSameHeaderSummary(stacks []glrStack) string {
 	gssWouldMerge := 0
 	pairBudgetHit := false
 	scratch := glrMergeScratch{language: p.language, cRecoveryCost: p.errorCostCompetitionEnabled()}
+	if p.mergeScratch != nil {
+		// stopFrontierSameHeaderSummary runs synchronously inside parseInternal;
+		// borrow the active arena so pending-parent diagnostics use the same exact
+		// equality as production merge decisions instead of failing closed.
+		scratch.arena = p.mergeScratch.arena
+	}
 	for gi := range groups {
 		size := len(groups[gi].indices)
 		if size > maxGroup {
@@ -3891,6 +3897,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	arena.skipChildClear = reuse == nil && oldTree == nil
 	arena.finalChildRefs = p.finalChildRefs
 	arena.audit = nil
+	scratch.merge.arena = arena
 	if scratch.audit.enabled || scratch.audit.equivEnabled {
 		scratch.merge.audit = &scratch.audit
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -4603,13 +4603,12 @@ func (p *Parser) tryPushPendingDirectFieldParent(s *glrStack, act ParseAction, t
 		startPoint = span.startPoint
 		endPoint = span.endPoint
 	}
-	parent := newPendingParentShellWithEntrySlotsInArena(
+	parent := newPendingParentShellInArena(
 		arena,
 		act.Symbol,
 		p.isNamedSymbol(act.Symbol),
 		act.ProductionID,
 		window.childCount,
-		pendingDirectFieldParentEntrySlots(window.childCount, useDenseFieldEntries),
 		startByte,
 		endByte,
 		startPoint,
@@ -4641,7 +4640,7 @@ func (p *Parser) tryPushPendingDirectFieldParent(s *glrStack, act ParseAction, t
 			continue
 		}
 		parent.setChildEntry(arena, out, entry)
-		if useDenseFieldEntries && fid != 0 {
+		if fid != 0 {
 			parent.setChildFieldEntry(arena, out, fid, fieldSourceDirect)
 		}
 		out++
@@ -4743,13 +4742,11 @@ func scanPendingDirectFieldParentWindow(entries []stackEntry, start, reducedEnd 
 	return window, window.childCount != 0
 }
 
-func pendingDirectFieldParentEntrySlots(childCount int, useDenseFieldEntries bool) int {
-	if useDenseFieldEntries {
-		return childCount * 2
-	}
-	return childCount
-}
-
+// pendingDirectFieldParentFieldsRecomputable now classifies hidden-flattening
+// behavior only. Packed child entries always retain the exact field metadata;
+// materialization never rebuilds it from the grammar. Keeping the old
+// classification prevents the representation change from making formerly
+// transparent direct-field parents block nested pending compaction.
 func (p *Parser) pendingDirectFieldParentFieldsRecomputable(productionID uint16, visibleChildCount int, entries []stackEntry, start, reducedEnd int, rawFieldIDs []FieldID, rawInherited []bool, symbolMeta []SymbolMetadata) bool {
 	visibleFieldIDs, visibleInherited := p.fixedFieldIDsForProduction(visibleChildCount, productionID)
 	structuralChildIndex := 0
@@ -4837,44 +4834,6 @@ func (p *Parser) fixedFieldIDsForProduction(childCount int, productionID uint16)
 		}
 	}
 	return fieldIDs, inherited
-}
-
-func (p *Parser) populatePendingDirectFieldEntries(parent *pendingParent, children []*Node, fieldIDs []FieldID, fieldSources []uint8, arena *nodeArena) {
-	if p == nil || parent == nil || len(children) == 0 || len(fieldIDs) == 0 {
-		return
-	}
-	structuralChildCount := 0
-	for _, child := range children {
-		if child != nil && !child.isExtra() {
-			structuralChildCount++
-		}
-	}
-	rawFieldIDs, rawInherited := p.buildFieldIDs(structuralChildCount, parent.productionID, arena)
-	if len(rawFieldIDs) == 0 {
-		return
-	}
-	structuralChildIndex := 0
-	for i, child := range children {
-		if child == nil || child.isExtra() {
-			continue
-		}
-		var fid FieldID
-		inherited := false
-		if structuralChildIndex < len(rawFieldIDs) {
-			fid = rawFieldIDs[structuralChildIndex]
-			if structuralChildIndex < len(rawInherited) {
-				inherited = rawInherited[structuralChildIndex]
-			}
-		}
-		structuralChildIndex++
-		if inherited || fid == 0 || p.shouldSuppressVisibleDirectField(child, fid) {
-			continue
-		}
-		fieldIDs[i] = fid
-		if i < len(fieldSources) {
-			fieldSources[i] = fieldSourceDirect
-		}
-	}
 }
 
 func stackEntryTreeHasFieldIDs(entry stackEntry, arena *nodeArena) bool {

--- a/pending_parent.go
+++ b/pending_parent.go
@@ -30,12 +30,23 @@ type pendingChildEntry struct {
 type pendingChildRange uint64
 
 const (
-	pendingChildRangeCountBits                  = 20
-	pendingChildRangeOffsetBits                 = 24
-	pendingChildRangeCountMask                  = (uint64(1) << pendingChildRangeCountBits) - 1
-	pendingChildRangeOffsetMask                 = (uint64(1) << pendingChildRangeOffsetBits) - 1
-	pendingParentFlagFieldEntries     nodeFlags = 1 << 5
-	pendingParentFlagDirectFieldEntry nodeFlags = 1 << 6
+	pendingChildRangeCountBits                      = 20
+	pendingChildRangeOffsetBits                     = 24
+	pendingChildRangeCountMask                      = (uint64(1) << pendingChildRangeCountBits) - 1
+	pendingChildRangeOffsetMask                     = (uint64(1) << pendingChildRangeOffsetBits) - 1
+	pendingChildEntryKindBits                       = 2
+	pendingChildEntryFieldIDBits                    = 16
+	pendingChildEntryFieldSourceBits                = 2
+	pendingChildEntryFieldIDShift                   = pendingChildEntryKindBits
+	pendingChildEntryFieldSourceShift               = pendingChildEntryFieldIDShift + pendingChildEntryFieldIDBits
+	pendingChildEntryKindMask             uintptr   = (1 << pendingChildEntryKindBits) - 1
+	pendingChildEntryFieldIDValueMask     uintptr   = (1 << pendingChildEntryFieldIDBits) - 1
+	pendingChildEntryFieldSourceValueMask uintptr   = (1 << pendingChildEntryFieldSourceBits) - 1
+	pendingChildEntryFieldIDMask                    = pendingChildEntryFieldIDValueMask << pendingChildEntryFieldIDShift
+	pendingChildEntryFieldSourceMask                = pendingChildEntryFieldSourceValueMask << pendingChildEntryFieldSourceShift
+	pendingChildEntryFieldMetadataMask              = pendingChildEntryFieldIDMask | pendingChildEntryFieldSourceMask
+	pendingParentFlagFieldEntries         nodeFlags = 1 << 5
+	pendingParentFlagDirectFieldEntry     nodeFlags = 1 << 6
 
 	publicPendingParentNodeFlags nodeFlags = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError | nodeFlagDirty
 )
@@ -109,10 +120,6 @@ func newPendingParentInArena(arena *nodeArena, sym Symbol, named bool, productio
 }
 
 func newPendingParentShellInArena(arena *nodeArena, sym Symbol, named bool, productionID uint16, childCount int, startByte, endByte uint32, startPoint, endPoint Point, hasError bool) *pendingParent {
-	return newPendingParentShellWithEntrySlotsInArena(arena, sym, named, productionID, childCount, childCount, startByte, endByte, startPoint, endPoint, hasError)
-}
-
-func newPendingParentShellWithEntrySlotsInArena(arena *nodeArena, sym Symbol, named bool, productionID uint16, childCount, entrySlots int, startByte, endByte uint32, startPoint, endPoint Point, hasError bool) *pendingParent {
 	var p *pendingParent
 	var childRange pendingChildRange
 	if arena == nil {
@@ -122,7 +129,7 @@ func newPendingParentShellWithEntrySlotsInArena(arena *nodeArena, sym Symbol, na
 		p = &pendingParent{}
 	} else {
 		p = arena.allocPendingParent()
-		childRange, _ = arena.allocPendingChildEntryRange(childCount, entrySlots)
+		childRange, _ = arena.allocPendingChildEntries(childCount)
 		arena.pendingParentCreated++
 	}
 	p.setChildEntries(childRange)
@@ -155,18 +162,6 @@ func (p *pendingParent) childRefs(arena *nodeArena) []pendingChildEntry {
 	return p.childRange.refs(arena)
 }
 
-func (p *pendingParent) fieldEntryRefs(arena *nodeArena) []pendingChildEntry {
-	if p == nil || arena == nil || !p.hasFieldEntries() || p.childRange.count() == 0 {
-		return nil
-	}
-	count := p.childRange.count()
-	refs := p.childRange.refsN(arena, count*2)
-	if len(refs) < count*2 {
-		return nil
-	}
-	return refs[count : count*2]
-}
-
 func (p *pendingParent) childEntryCount() int {
 	if p == nil {
 		return 0
@@ -193,7 +188,9 @@ func (p *pendingParent) setChildEntry(arena *nodeArena, i int, entry stackEntry)
 	if i >= len(refs) {
 		return
 	}
-	refs[i] = newPendingChildEntry(entry)
+	next := newPendingChildEntry(entry)
+	next.meta |= refs[i].meta & pendingChildEntryFieldMetadataMask
+	refs[i] = next
 }
 
 func (p *pendingParent) hasFieldEntries() bool {
@@ -204,6 +201,10 @@ func (p *pendingParent) setHasFieldEntries(v bool) {
 	p.setFlag(pendingParentFlagFieldEntries, v)
 }
 
+// hasDirectFieldEntries preserves the old hidden-flattening classification:
+// these direct fields were previously safe to reconstruct from visible
+// children. Their values are now packed and are never recomputed when the
+// pending parent materializes.
 func (p *pendingParent) hasDirectFieldEntries() bool {
 	return p != nil && p.hasFlag(pendingParentFlagDirectFieldEntry)
 }
@@ -216,18 +217,26 @@ func (p *pendingParent) setChildFieldEntry(arena *nodeArena, i int, fid FieldID,
 	if p == nil || i < 0 || i >= p.childEntryCount() {
 		return
 	}
-	refs := p.fieldEntryRefs(arena)
+	if uintptr(source)&^pendingChildEntryFieldSourceValueMask != 0 {
+		panic("pending child field source exceeds tag mask")
+	}
+	refs := p.childRefs(arena)
 	if i >= len(refs) {
 		return
 	}
-	refs[i] = newPendingChildFieldEntry(fid, source)
+	refs[i].meta = (refs[i].meta &^ pendingChildEntryFieldMetadataMask) |
+		uintptr(fid)<<pendingChildEntryFieldIDShift |
+		uintptr(source)<<pendingChildEntryFieldSourceShift
+	if (fid != 0 || source != fieldSourceNone) && !p.hasFieldEntries() && !p.hasDirectFieldEntries() {
+		p.setHasFieldEntries(true)
+	}
 }
 
 func (p *pendingParent) childFieldEntry(arena *nodeArena, i int) (FieldID, uint8) {
 	if p == nil || i < 0 || i >= p.childEntryCount() {
 		return 0, fieldSourceNone
 	}
-	refs := p.fieldEntryRefs(arena)
+	refs := p.childRefs(arena)
 	if i >= len(refs) {
 		return 0, fieldSourceNone
 	}
@@ -262,10 +271,7 @@ func (r pendingChildRange) offset() int {
 }
 
 func (r pendingChildRange) refs(arena *nodeArena) []pendingChildEntry {
-	return r.refsN(arena, r.count())
-}
-
-func (r pendingChildRange) refsN(arena *nodeArena, count int) []pendingChildEntry {
+	count := r.count()
 	if arena == nil || count == 0 {
 		return nil
 	}
@@ -292,19 +298,13 @@ func newPendingChildEntry(entry stackEntry) pendingChildEntry {
 	return pendingChildEntry{node: entry.node, meta: kind}
 }
 
-func newPendingChildFieldEntry(fid FieldID, source uint8) pendingChildEntry {
-	return pendingChildEntry{meta: uintptr(fid) | uintptr(source)<<16}
-}
-
 func (e pendingChildEntry) fieldID() FieldID {
-	return FieldID(e.meta & 0xffff)
+	return FieldID((e.meta & pendingChildEntryFieldIDMask) >> pendingChildEntryFieldIDShift)
 }
 
 func (e pendingChildEntry) fieldSource() uint8 {
-	return uint8((e.meta >> 16) & 0xff)
+	return uint8((e.meta & pendingChildEntryFieldSourceMask) >> pendingChildEntryFieldSourceShift)
 }
-
-const pendingChildEntryKindMask = uintptr(3)
 
 func (entry pendingChildEntry) stackEntry() stackEntry {
 	if entry.node == nil {
@@ -361,9 +361,8 @@ func materializeStackEntryPendingParentEntryWithParser(p *Parser, arena *nodeAre
 	children := arena.allocNodeSliceNoClear(childCount)
 	var fieldIDs []FieldID
 	var fieldSources []uint8
-	hasDenseFieldEntries := parent.hasFieldEntries()
-	hasDirectFieldEntries := parent.hasDirectFieldEntries()
-	if hasDenseFieldEntries || hasDirectFieldEntries {
+	hasFieldEntries := parent.hasFieldEntries() || parent.hasDirectFieldEntries()
+	if hasFieldEntries {
 		fieldIDs = arena.allocFieldIDSlice(childCount)
 		fieldSources = arena.allocFieldSourceSlice(childCount)
 	}
@@ -373,14 +372,11 @@ func materializeStackEntryPendingParentEntryWithParser(p *Parser, arena *nodeAre
 		children[i], updatedChild = materializeStackEntryPayloadEntryWithParser(p, arena, child, compactFullLeafMaterializeReason(reason), reason)
 		child = updatedChild
 		parent.setChildEntry(arena, i, child)
-		if hasDenseFieldEntries {
+		if hasFieldEntries {
 			fid, source := parent.childFieldEntry(arena, i)
 			fieldIDs[i] = fid
 			fieldSources[i] = source
 		}
-	}
-	if hasDirectFieldEntries {
-		p.populatePendingDirectFieldEntries(parent, children, fieldIDs, fieldSources, arena)
 	}
 	if fieldIDs != nil && p != nil {
 		p.suppressReducedChildFields(children, fieldIDs, fieldSources)

--- a/tree.go
+++ b/tree.go
@@ -3185,11 +3185,7 @@ func cloneTreeNodesIntoArenaWithOffset(root *Node, arena *nodeArena, offset *clo
 
 func clonePendingParentIntoArena(srcArena, dstArena *nodeArena, src *pendingParent, offset *cloneOffset, metrics cloneMetricScope) *pendingParent {
 	childCount := src.childEntryCount()
-	entrySlots := childCount
-	if src.hasFieldEntries() {
-		entrySlots = childCount * 2
-	}
-	dst := newPendingParentShellWithEntrySlotsInArena(dstArena, src.symbol, src.isNamed(), src.productionID, childCount, entrySlots, src.startByte, src.endByte, src.startPoint, src.endPoint, src.hasError())
+	dst := newPendingParentShellInArena(dstArena, src.symbol, src.isNamed(), src.productionID, childCount, src.startByte, src.endByte, src.startPoint, src.endPoint, src.hasError())
 	dst.noTreeNode = src.noTreeNode
 	dst.startPoint = src.startPoint
 	dst.endPoint = src.endPoint
@@ -3198,7 +3194,7 @@ func clonePendingParentIntoArena(srcArena, dstArena *nodeArena, src *pendingPare
 	dst.setHasDirectFieldEntries(src.hasDirectFieldEntries())
 	for i := 0; i < childCount; i++ {
 		dst.setChildEntry(dstArena, i, cloneStackEntryIntoArena(srcArena, dstArena, src.childEntry(srcArena, i), offset, metrics))
-		if src.hasFieldEntries() {
+		if src.hasFieldEntries() || src.hasDirectFieldEntries() {
 			fid, source := src.childFieldEntry(srcArena, i)
 			dst.setChildFieldEntry(dstArena, i, fid, source)
 		}


### PR DESCRIPTION
## Outcome

This establishes the correctness and storage prerequisite for the next compact-parent/Poppler memory experiments without enabling any new compact mode.

- pack child kind, full uint16 field ID, and 2-bit field source into the existing 16-byte pending-child entry
- remove the doubled field sidecar and materialization-time grammar reconstruction
- preserve direct-vs-dense classification only where hidden-compaction behavior depends on it
- recursively verify pending fields, sources, and nested descendants after coarse hash matches in stack and GSS merge paths
- fail closed when exact comparison lacks arena context or exceeds the walk bound

## Review findings addressed

Direct root review added field-source collision coverage, wired the active arena into stop-frontier diagnostics, and normalized direct-field header counts so direct, dense, and materialized equivalents do not diverge spuriously.

## Validation

- new focused packing/materialization/equality tests repeated 20x
- focused checkptr suite repeated 5x
- broader pending/GSS/stack-equivalence root tests
- root vet and compile, including perf tag
- one-CPU Docker pending/GSS review gate: harness_out/docker/20260711T131345Z-pending-meta-review
- git diff --check and Canopy GSS link-chain impact review

No production compact-parent feature gate is activated in this PR.