### PR TITLE
refactor: remove retired no_alias attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ for tags and release notes while still in `0.x`.
   pending descendants. Missing arena context and excessive depth fail closed
   instead of allowing a hash collision to collapse distinct alternatives.
 
+### Removed
+
+- Removed the retired direct `no_alias` reduction-attribution lane from
+  `ParseRuntime`, `ArenaBreakdown`, `PerfCounters`, and the Java/Python and
+  parse-gap reports. The path has had no production producer since reductions
+  moved to `all_visible` or `scratch_no_alias`; every exposed value was
+  permanently zero.
+- Removed two unexported transient-materialization wrappers used only by tests;
+  tests now call the stop-aware implementations directly.
+
 ## [0.24.1] - 2026-07-11
 
 Performance-contract and repository-hygiene follow-up to v0.24.0. This patch

--- a/arena.go
+++ b/arena.go
@@ -232,8 +232,6 @@ type nodeArena struct {
 	reduceChildPointersFastGSS           uint64
 	reduceChildSlicesAllVisible          uint64
 	reduceChildPointersAllVisible        uint64
-	reduceChildSlicesNoAlias             uint64
-	reduceChildPointersNoAlias           uint64
 	reduceChildSlicesScratchGeneral      uint64
 	reduceChildPointersScratchGeneral    uint64
 	reduceChildSlicesScratchNoAlias      uint64
@@ -979,8 +977,6 @@ func (a *nodeArena) resetCounters() {
 	a.reduceChildPointersFastGSS = 0
 	a.reduceChildSlicesAllVisible = 0
 	a.reduceChildPointersAllVisible = 0
-	a.reduceChildSlicesNoAlias = 0
-	a.reduceChildPointersNoAlias = 0
 	a.reduceChildSlicesScratchGeneral = 0
 	a.reduceChildPointersScratchGeneral = 0
 	a.reduceChildSlicesScratchNoAlias = 0
@@ -2249,8 +2245,6 @@ func (a *nodeArena) collectArenaBreakdown() *ArenaBreakdown {
 		ReduceChildPointersFastGSS:          a.reduceChildPointersFastGSS,
 		ReduceChildSlicesAllVisible:         a.reduceChildSlicesAllVisible,
 		ReduceChildPointersAllVisible:       a.reduceChildPointersAllVisible,
-		ReduceChildSlicesNoAlias:            a.reduceChildSlicesNoAlias,
-		ReduceChildPointersNoAlias:          a.reduceChildPointersNoAlias,
 		ReduceChildSlicesScratchGeneral:     a.reduceChildSlicesScratchGeneral,
 		ReduceChildPointersScratchGeneral:   a.reduceChildPointersScratchGeneral,
 		ReduceChildSlicesScratchNoAlias:     a.reduceChildSlicesScratchNoAlias,

--- a/cgo_harness/benchmark_java_corpus_test.go
+++ b/cgo_harness/benchmark_java_corpus_test.go
@@ -743,11 +743,10 @@ func formatJavaPerfStats(p gotreesitter.PerfCounters) string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"parent_child_ptrs=%d reduce_fast_gss=%d reduce_all_visible=%d reduce_no_alias=%d reduce_scratch=%d reduce_scratch_no_alias=%d reduce_scratch_general=%d extra_nodes=%d error_nodes=%d merge_calls=%d merge_overflow=%d merge_replacements=%d stackeq_calls=%d stackeq_true=%d stackeq_hash_miss_skips=%d stackcmp_calls=%d conflicts_rr=%d conflicts_rs=%d conflicts_other=%d reduce_chain_steps=%d reduce_chain_max_len=%d reduce_chain_break_multi=%d reduce_chain_break_shift=%d reduce_chain_break_accept=%d forks=%d max_stacks=%d lex_bytes=%d lex_tokens=%d",
+		"parent_child_ptrs=%d reduce_fast_gss=%d reduce_all_visible=%d reduce_scratch=%d reduce_scratch_no_alias=%d reduce_scratch_general=%d extra_nodes=%d error_nodes=%d merge_calls=%d merge_overflow=%d merge_replacements=%d stackeq_calls=%d stackeq_true=%d stackeq_hash_miss_skips=%d stackcmp_calls=%d conflicts_rr=%d conflicts_rs=%d conflicts_other=%d reduce_chain_steps=%d reduce_chain_max_len=%d reduce_chain_break_multi=%d reduce_chain_break_shift=%d reduce_chain_break_accept=%d forks=%d max_stacks=%d lex_bytes=%d lex_tokens=%d",
 		p.ParentChildPointers,
 		p.ReduceChildrenFastGSS,
 		p.ReduceChildrenAllVis,
-		p.ReduceChildrenNoAlias,
 		p.ReduceChildrenScratch,
 		p.ReduceScratchNoAlias,
 		p.ReduceScratchGeneral,

--- a/cgo_harness/benchmark_python_corpus_test.go
+++ b/cgo_harness/benchmark_python_corpus_test.go
@@ -84,7 +84,6 @@ type pythonRuntimeBenchStats struct {
 	childPointersDropped                 uint64
 	reduceChildFastGSS                   pythonReduceChildPathStats
 	reduceChildAllVisible                pythonReduceChildPathStats
-	reduceChildNoAlias                   pythonReduceChildPathStats
 	reduceChildScratchGeneral            pythonReduceChildPathStats
 	reduceChildScratchNoAlias            pythonReduceChildPathStats
 	transientChildSlicesAllocated        uint64
@@ -219,8 +218,6 @@ type pythonRuntimeBenchStats struct {
 	reduceChildPointersFastGSS           uint64
 	reduceChildSlicesAllVisible          uint64
 	reduceChildPointersAllVisible        uint64
-	reduceChildSlicesNoAlias             uint64
-	reduceChildPointersNoAlias           uint64
 	reduceChildSlicesScratchGeneral      uint64
 	reduceChildPointersScratchGeneral    uint64
 	reduceChildSlicesScratchNoAlias      uint64
@@ -401,7 +398,6 @@ func (s *pythonRuntimeBenchStats) add(rt gotreesitter.ParseRuntime, breakdown go
 	s.childPointersDropped += rt.ChildPointersDroppedSameToken
 	s.reduceChildFastGSS.add(rt.ReduceChildFastGSS)
 	s.reduceChildAllVisible.add(rt.ReduceChildAllVisible)
-	s.reduceChildNoAlias.add(rt.ReduceChildNoAlias)
 	s.reduceChildScratchGeneral.add(rt.ReduceChildScratchGeneral)
 	s.reduceChildScratchNoAlias.add(rt.ReduceChildScratchNoAlias)
 	s.transientChildSlicesAllocated += rt.TransientChildSlicesAllocated
@@ -570,8 +566,6 @@ func (s *pythonRuntimeBenchStats) add(rt gotreesitter.ParseRuntime, breakdown go
 		s.reduceChildPointersFastGSS += breakdown.ReduceChildPointersFastGSS
 		s.reduceChildSlicesAllVisible += breakdown.ReduceChildSlicesAllVisible
 		s.reduceChildPointersAllVisible += breakdown.ReduceChildPointersAllVisible
-		s.reduceChildSlicesNoAlias += breakdown.ReduceChildSlicesNoAlias
-		s.reduceChildPointersNoAlias += breakdown.ReduceChildPointersNoAlias
 		s.reduceChildSlicesScratchGeneral += breakdown.ReduceChildSlicesScratchGeneral
 		s.reduceChildPointersScratchGeneral += breakdown.ReduceChildPointersScratchGeneral
 		s.reduceChildSlicesScratchNoAlias += breakdown.ReduceChildSlicesScratchNoAlias
@@ -703,7 +697,6 @@ func (s pythonRuntimeBenchStats) report(b *testing.B) {
 		b.ReportMetric(float64(s.childPointersDropped)/tokens, "child_ptrs_discarded/token")
 		s.reduceChildFastGSS.report(b, tokens, "fast_gss")
 		s.reduceChildAllVisible.report(b, tokens, "all_visible")
-		s.reduceChildNoAlias.report(b, tokens, "no_alias")
 		s.reduceChildScratchGeneral.report(b, tokens, "scratch_general")
 		s.reduceChildScratchNoAlias.report(b, tokens, "scratch_no_alias")
 	}
@@ -785,8 +778,6 @@ func (s pythonRuntimeBenchStats) report(b *testing.B) {
 		b.ReportMetric(float64(s.reduceChildPointersFastGSS)/tokens, "reduce_child_ptrs_fast_gss/token")
 		b.ReportMetric(float64(s.reduceChildSlicesAllVisible)/tokens, "reduce_child_slices_all_visible/token")
 		b.ReportMetric(float64(s.reduceChildPointersAllVisible)/tokens, "reduce_child_ptrs_all_visible/token")
-		b.ReportMetric(float64(s.reduceChildSlicesNoAlias)/tokens, "reduce_child_slices_no_alias/token")
-		b.ReportMetric(float64(s.reduceChildPointersNoAlias)/tokens, "reduce_child_ptrs_no_alias/token")
 		b.ReportMetric(float64(s.reduceChildSlicesScratchGeneral)/tokens, "reduce_child_slices_scratch_general/token")
 		b.ReportMetric(float64(s.reduceChildPointersScratchGeneral)/tokens, "reduce_child_ptrs_scratch_general/token")
 		b.ReportMetric(float64(s.reduceChildSlicesScratchNoAlias)/tokens, "reduce_child_slices_scratch_no_alias/token")

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -330,7 +330,6 @@ type runtimeStats struct {
 	ParentChildPointers                   uint64        `json:"parent_child_pointers,omitempty"`
 	ReduceChildrenFastGSS                 uint64        `json:"reduce_children_fast_gss,omitempty"`
 	ReduceChildrenAllVisible              uint64        `json:"reduce_children_all_visible,omitempty"`
-	ReduceChildrenNoAlias                 uint64        `json:"reduce_children_no_alias,omitempty"`
 	ReduceChildrenScratch                 uint64        `json:"reduce_children_scratch,omitempty"`
 	ReduceScratchNoAlias                  uint64        `json:"reduce_scratch_no_alias,omitempty"`
 	ReduceScratchGeneral                  uint64        `json:"reduce_scratch_general,omitempty"`
@@ -367,7 +366,6 @@ type runtimeStats struct {
 	ForestCoalesceCapReplacements         uint64        `json:"forest_coalesce_cap_replacements,omitempty"`
 	ReduceChildFastGSS                    *pathStats    `json:"reduce_child_fast_gss,omitempty"`
 	ReduceChildAllVisible                 *pathStats    `json:"reduce_child_all_visible,omitempty"`
-	ReduceChildNoAlias                    *pathStats    `json:"reduce_child_no_alias,omitempty"`
 	ReduceChildScratchGeneral             *pathStats    `json:"reduce_child_scratch_general,omitempty"`
 	ReduceChildScratchNoAlias             *pathStats    `json:"reduce_child_scratch_no_alias,omitempty"`
 	NoTreeReduceNodes                     uint64        `json:"notree_reduce_nodes,omitempty"`
@@ -1210,7 +1208,6 @@ func statsFromGoTree(r *runner, tree *gotreesitter.Tree, queryCaptures, cursorNo
 	stats.ParentChildPointers = perf.ParentChildPointers
 	stats.ReduceChildrenFastGSS = perf.ReduceChildrenFastGSS
 	stats.ReduceChildrenAllVisible = perf.ReduceChildrenAllVis
-	stats.ReduceChildrenNoAlias = perf.ReduceChildrenNoAlias
 	stats.ReduceChildrenScratch = perf.ReduceChildrenScratch
 	stats.ReduceScratchNoAlias = perf.ReduceScratchNoAlias
 	stats.ReduceScratchGeneral = perf.ReduceScratchGeneral
@@ -1641,7 +1638,6 @@ func statsFromRuntime(rt gotreesitter.ParseRuntime) runtimeStats {
 		NoTreeLeafNodes:                       rt.NoTreeLeafNodesConstructed,
 		ReduceChildFastGSS:                    pathStatsFromRuntime(rt.ReduceChildFastGSS),
 		ReduceChildAllVisible:                 pathStatsFromRuntime(rt.ReduceChildAllVisible),
-		ReduceChildNoAlias:                    pathStatsFromRuntime(rt.ReduceChildNoAlias),
 		ReduceChildScratchGeneral:             pathStatsFromRuntime(rt.ReduceChildScratchGeneral),
 		ReduceChildScratchNoAlias:             pathStatsFromRuntime(rt.ReduceChildScratchNoAlias),
 	}

--- a/parser.go
+++ b/parser.go
@@ -3191,7 +3191,6 @@ func recordParseRuntimeLoopStats(parseRuntime *ParseRuntime, scratch *parserScra
 	parseRuntime.ChildPointersDroppedSameToken = scratch.audit.totalChildPointersDropped
 	parseRuntime.ReduceChildFastGSS = scratch.audit.reduceChildPathRuntime(reduceChildPathFastGSS)
 	parseRuntime.ReduceChildAllVisible = scratch.audit.reduceChildPathRuntime(reduceChildPathAllVisible)
-	parseRuntime.ReduceChildNoAlias = scratch.audit.reduceChildPathRuntime(reduceChildPathNoAlias)
 	parseRuntime.ReduceChildScratchGeneral = scratch.audit.reduceChildPathRuntime(reduceChildPathScratchGeneral)
 	parseRuntime.ReduceChildScratchNoAlias = scratch.audit.reduceChildPathRuntime(reduceChildPathScratchNoAlias)
 	parseRuntime.MergeStacksIn = scratch.audit.mergeStacksIn

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5892,7 +5892,7 @@ func reduceChildPathForLen(n int, nonEmptyPath reduceChildPath) reduceChildPath 
 
 func reduceChildPathMayDropSpan(path reduceChildPath) bool {
 	switch path {
-	case reduceChildPathAllVisible, reduceChildPathNoAlias, reduceChildPathFastGSS:
+	case reduceChildPathAllVisible, reduceChildPathFastGSS:
 		return false
 	default:
 		return true

--- a/perf_counters.go
+++ b/perf_counters.go
@@ -50,7 +50,6 @@ type PerfCounters struct {
 	ParentChildPointers                  uint64
 	ReduceChildrenFastGSS                uint64
 	ReduceChildrenAllVis                 uint64
-	ReduceChildrenNoAlias                uint64
 	ReduceChildrenScratch                uint64
 	ReduceScratchNoAlias                 uint64
 	ReduceScratchGeneral                 uint64

--- a/perf_metrics_perf.go
+++ b/perf_metrics_perf.go
@@ -60,7 +60,6 @@ type perfCountersData struct {
 	parentChildPointers                  atomic.Uint64
 	reduceChildrenFastGSS                atomic.Uint64
 	reduceChildrenAllVis                 atomic.Uint64
-	reduceChildrenNoAlias                atomic.Uint64
 	reduceChildrenScratch                atomic.Uint64
 	reduceScratchNoAlias                 atomic.Uint64
 	reduceScratchGeneral                 atomic.Uint64
@@ -164,7 +163,6 @@ func ResetPerfCounters() {
 	perfCounters.parentChildPointers.Store(0)
 	perfCounters.reduceChildrenFastGSS.Store(0)
 	perfCounters.reduceChildrenAllVis.Store(0)
-	perfCounters.reduceChildrenNoAlias.Store(0)
 	perfCounters.reduceChildrenScratch.Store(0)
 	perfCounters.reduceScratchNoAlias.Store(0)
 	perfCounters.reduceScratchGeneral.Store(0)
@@ -297,7 +295,6 @@ func PerfCountersSnapshot() PerfCounters {
 	out.ParentChildPointers = perfCounters.parentChildPointers.Load()
 	out.ReduceChildrenFastGSS = perfCounters.reduceChildrenFastGSS.Load()
 	out.ReduceChildrenAllVis = perfCounters.reduceChildrenAllVis.Load()
-	out.ReduceChildrenNoAlias = perfCounters.reduceChildrenNoAlias.Load()
 	out.ReduceChildrenScratch = perfCounters.reduceChildrenScratch.Load()
 	out.ReduceScratchNoAlias = perfCounters.reduceScratchNoAlias.Load()
 	out.ReduceScratchGeneral = perfCounters.reduceScratchGeneral.Load()

--- a/transient_children.go
+++ b/transient_children.go
@@ -67,10 +67,6 @@ func (s *transientChildScratch) owns(children []*Node) bool {
 	return false
 }
 
-func (s *transientChildScratch) materializeNode(root *Node, arena *nodeArena, scratch *[]*Node) {
-	s.materializeNodeUntil(root, arena, scratch, nil)
-}
-
 func (s *transientChildScratch) materializeNodeUntil(root *Node, arena *nodeArena, scratch *[]*Node, p *Parser) ParseStopReason {
 	if s == nil || root == nil || arena == nil {
 		return ParseStopNone

--- a/transient_children_test.go
+++ b/transient_children_test.go
@@ -48,7 +48,7 @@ func TestTransientChildScratchMaterializesReachableNode(t *testing.T) {
 	}
 
 	var stack []*Node
-	scratch.materializeNode(parent, arena, &stack)
+	scratch.materializeNodeUntil(parent, arena, &stack, nil)
 
 	if scratch.owns(parent.children) {
 		t.Fatal("expected parent children to be copied into arena storage")
@@ -88,7 +88,7 @@ func TestTransientParentScratchMaterializesReachableParent(t *testing.T) {
 	}
 
 	entries := []stackEntry{newStackEntryNode(parent.parseState, parent)}
-	parentScratch.materializeEntries(entries, arena, &childScratch)
+	parentScratch.materializeEntriesUntil(entries, arena, &childScratch, nil)
 
 	got := stackEntryNode(entries[0])
 	if got == nil {
@@ -140,7 +140,7 @@ func TestTransientChildScratchMaterializesFieldedArenaParent(t *testing.T) {
 	parent := newParentNodeInArenaNoLinksWithFieldSources(arena, Symbol(3), true, children, fieldIDs, fieldSources, 0, true)
 
 	var stack []*Node
-	scratch.materializeNode(parent, arena, &stack)
+	scratch.materializeNodeUntil(parent, arena, &stack, nil)
 
 	if scratch.owns(parent.children) {
 		t.Fatal("fielded parent still owns transient children")
@@ -436,7 +436,7 @@ func TestTransientParentScratchMaterializesSharedTransientParentOnce(t *testing.
 	root := parentScratch.allocParent(arena, Symbol(5), true, rootChildren, 31, true)
 
 	entries := []stackEntry{newStackEntryNode(root.parseState, root)}
-	parentScratch.materializeEntries(entries, arena, &childScratch)
+	parentScratch.materializeEntriesUntil(entries, arena, &childScratch, nil)
 
 	gotRoot := stackEntryNode(entries[0])
 	if gotRoot == nil || parentScratch.owns(gotRoot) {

--- a/transient_parents.go
+++ b/transient_parents.go
@@ -104,10 +104,6 @@ func (s *transientParentScratch) owns(node *Node) bool {
 	return false
 }
 
-func (s *transientParentScratch) materializeEntries(entries []stackEntry, arena *nodeArena, childScratch *transientChildScratch) {
-	s.materializeEntriesUntil(entries, arena, childScratch, nil)
-}
-
 func (s *transientParentScratch) materializeEntriesUntil(entries []stackEntry, arena *nodeArena, childScratch *transientChildScratch, p *Parser) ParseStopReason {
 	return s.materializeEntriesModeUntil(entries, arena, childScratch, p, false)
 }

--- a/tree.go
+++ b/tree.go
@@ -827,7 +827,6 @@ type ParseRuntime struct {
 	ChildPointersDroppedSameToken                 uint64
 	ReduceChildFastGSS                            ReduceChildPathRuntime
 	ReduceChildAllVisible                         ReduceChildPathRuntime
-	ReduceChildNoAlias                            ReduceChildPathRuntime
 	ReduceChildScratchGeneral                     ReduceChildPathRuntime
 	ReduceChildScratchNoAlias                     ReduceChildPathRuntime
 	TransientChildSlicesAllocated                 uint64
@@ -1061,7 +1060,6 @@ const (
 	reduceChildPathNone reduceChildPath = iota
 	reduceChildPathFastGSS
 	reduceChildPathAllVisible
-	reduceChildPathNoAlias
 	reduceChildPathScratchGeneral
 	reduceChildPathScratchNoAlias
 	reduceChildPathCount
@@ -1139,8 +1137,6 @@ type ArenaBreakdown struct {
 	ReduceChildPointersFastGSS        uint64
 	ReduceChildSlicesAllVisible       uint64
 	ReduceChildPointersAllVisible     uint64
-	ReduceChildSlicesNoAlias          uint64
-	ReduceChildPointersNoAlias        uint64
 	ReduceChildSlicesScratchGeneral   uint64
 	ReduceChildPointersScratchGeneral uint64
 	ReduceChildSlicesScratchNoAlias   uint64


### PR DESCRIPTION
## Summary

- remove the permanently-zero direct no_alias attribution lane end-to-end
- retain active all_visible, scratch_general, and scratch_no_alias measurements
- remove two unexported transient-materialization wrappers used only by tests
- update four tests to call the existing stop-aware implementations directly

This intentionally removes the zero-only exported telemetry fields from ParseRuntime, ArenaBreakdown, and PerfCounters as well as their harness JSON/benchmark consumers. There has been no production producer since commit 42cb88f1; keeping the fields would preserve a false measurement surface.

## Validation

- focused runtime/transient tests repeated 20x
- root vet, compile, and perf-tag compile
- Docker parity+perf harness compile
- Docker cgo-bench+perf harness compile
- Docker parse_gap_report parity+perf compile
- post-edit structural/reference audit and git diff --check

Net result: 43 deletions and 16 additions including release notes; no parser behavior change.