### PR TITLE
perf: suppress redundant widened Java retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ for tags and release notes while still in `0.x`.
 - Removed two unexported transient-materialization wrappers used only by tests;
   tests now call the stop-aware implementations directly.
 
+### Performance
+
+- Java's exact built-in grammar profile keeps the initial 14-stack ceiling on
+  large fresh parses whose first result accepts at EOF with an error. The
+  cap-16 same-stack merge retry remains intact; only two proven-redundant
+  cap-64 passes are suppressed, while overrides and incremental paths retain
+  the conservative generic ladder.
+
 ## [0.24.1] - 2026-07-11
 
 Performance-contract and repository-hygiene follow-up to v0.24.0. This patch

--- a/grammars/blob_export_test.go
+++ b/grammars/blob_export_test.go
@@ -68,6 +68,24 @@ func TestLoadLanguageAttachesExternalScannerSupport(t *testing.T) {
 	}
 }
 
+func TestLoadLanguageAttachesCertifiedJavaRetryProfile(t *testing.T) {
+	blob := BlobByName("java")
+	if len(blob) == 0 {
+		t.Fatal("expected java blob")
+	}
+	lang, err := LoadLanguage("java", blob)
+	if err != nil {
+		t.Fatalf("LoadLanguage(java) error = %v", err)
+	}
+	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
+		MinSourceBytes:      64 * 1024,
+		InitialStackCeiling: 14,
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
+		t.Fatalf("LoadLanguage(java) retry profile = %+v, want %+v", got, want)
+	}
+}
+
 func TestLoadLanguageAcceptsAliases(t *testing.T) {
 	blob := BlobByName("golang")
 	if len(blob) == 0 {

--- a/grammars/grammargen_blob_override_test.go
+++ b/grammars/grammargen_blob_override_test.go
@@ -110,6 +110,43 @@ func TestJsonLanguageUsesPreferredGrammargenBlobOverride(t *testing.T) {
 	}
 }
 
+func TestJavaLanguageOverrideDoesNotInheritBuiltinRetryProfile(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	purgePreferredLanguageOverrideCache()
+	t.Cleanup(func() {
+		PurgeEmbeddedLanguageCache()
+		purgePreferredLanguageOverrideCache()
+	})
+
+	original, err := os.ReadFile(filepath.Join("grammar_blobs", "java.bin"))
+	if err != nil {
+		t.Fatalf("read checked-in java blob: %v", err)
+	}
+	lang, err := decodeLanguageBlobData("grammar_blobs/java.bin", original)
+	if err != nil {
+		t.Fatalf("decode checked-in java blob: %v", err)
+	}
+	lang.Name = "java-override"
+
+	overrideDir := t.TempDir()
+	overridePath := filepath.Join(overrideDir, "java.bin")
+	if err := os.WriteFile(overridePath, encodeLanguageBlobForTest(t, lang), 0o644); err != nil {
+		t.Fatalf("write override blob: %v", err)
+	}
+	t.Setenv(grammargenBlobDirEnv, overrideDir)
+
+	loaded := JavaLanguage()
+	if loaded == nil {
+		t.Fatal("JavaLanguage() returned nil with override present")
+	}
+	if loaded.Name != "java-override" {
+		t.Fatalf("JavaLanguage().Name = %q, want %q", loaded.Name, "java-override")
+	}
+	if got := loaded.FullParseAcceptedErrorRetryProfile; got.MinSourceBytes != 0 || got.InitialStackCeiling != 0 {
+		t.Fatalf("Java override inherited built-in retry profile: %+v", got)
+	}
+}
+
 func encodeLanguageBlobForTest(t *testing.T, lang interface{}) []byte {
 	t.Helper()
 

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -11,8 +11,9 @@ import (
 // parser core: loading the exact certified blob attaches its profile, while
 // caller-constructed and adapted languages retain conservative zero defaults.
 type builtinLanguageRuntimeProfile struct {
-	blobSHA256                    [32]byte
-	externalScannerFullParseRetry gotreesitter.ExternalScannerFullParseRetryPolicy
+	blobSHA256                         [32]byte
+	externalScannerFullParseRetry      gotreesitter.ExternalScannerFullParseRetryPolicy
+	fullParseAcceptedErrorRetryProfile gotreesitter.FullParseAcceptedErrorRetryProfile
 }
 
 var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
@@ -31,6 +32,17 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 	},
+	// On large accepted-error Java sources, the cap-16 same-stack merge retry
+	// remains authoritative; the subsequent cap-64 clean/recovery passes do not
+	// improve the selected tree. Keep this bound pinned to the exact built-in
+	// blob so overrides and caller-built languages retain the generic ladder.
+	"java": {
+		blobSHA256: mustRuntimeProfileSHA256("530c7257b13e1ce356edd251cac347b5e41f04f74343473c72f43bf1177ffa9c"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			MinSourceBytes:      64 * 1024,
+			InitialStackCeiling: 14,
+		},
+	},
 }
 
 func mustRuntimeProfileSHA256(raw string) (sum [32]byte) {
@@ -43,16 +55,24 @@ func mustRuntimeProfileSHA256(raw string) (sum [32]byte) {
 }
 
 func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang *gotreesitter.Language) bool {
-	if lang == nil || lang.ExternalScanner == nil {
+	if lang == nil {
 		return false
 	}
 	profile, ok := builtinLanguageRuntimeProfiles[canonicalLanguageName(name)]
 	if !ok || blobSHA256 != profile.blobSHA256 {
 		return false
 	}
-	if lang.ExternalScannerFullParseRetryPolicy == profile.externalScannerFullParseRetry {
-		return false
+	changed := false
+	if profile.externalScannerFullParseRetry != gotreesitter.ExternalScannerFullParseRetryDefault &&
+		lang.ExternalScanner != nil &&
+		lang.ExternalScannerFullParseRetryPolicy != profile.externalScannerFullParseRetry {
+		lang.ExternalScannerFullParseRetryPolicy = profile.externalScannerFullParseRetry
+		changed = true
 	}
-	lang.ExternalScannerFullParseRetryPolicy = profile.externalScannerFullParseRetry
-	return true
+	if profile.fullParseAcceptedErrorRetryProfile != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) &&
+		lang.FullParseAcceptedErrorRetryProfile != profile.fullParseAcceptedErrorRetryProfile {
+		lang.FullParseAcceptedErrorRetryProfile = profile.fullParseAcceptedErrorRetryProfile
+		changed = true
+	}
+	return changed
 }

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -31,8 +31,8 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 	}
 }
 
-func TestBuiltinExternalScannerRetryProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 3; got != want {
+func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
+	if got, want := len(builtinLanguageRuntimeProfiles), 4; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -41,6 +41,26 @@ func TestBuiltinExternalScannerRetryProfilesStayNarrow(t *testing.T) {
 	}
 	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {
 		t.Fatalf("unknown runtime profile changed policy to %d", got)
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("unknown runtime profile changed accepted-error retry profile to %+v", got)
+	}
+}
+
+func TestBuiltinJavaAcceptedErrorRetryProfileAttaches(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	lang := JavaLanguage()
+	if lang.ExternalScanner != nil {
+		t.Fatal("Java ExternalScanner != nil; profile must not depend on scanner attachment")
+	}
+	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
+		MinSourceBytes:      64 * 1024,
+		InitialStackCeiling: 14,
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
+		t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want %+v", got, want)
 	}
 }
 
@@ -65,6 +85,31 @@ func TestBuiltinExternalScannerRetryProfilesRequireCertifiedBlob(t *testing.T) {
 	}
 }
 
+func TestBuiltinJavaAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
+	lang := &gotreesitter.Language{Name: "java"}
+	if attachBuiltinLanguageRuntimeProfile("java", sha256.Sum256([]byte("uncertified")), lang) {
+		t.Fatal("uncertified Java blob reported a runtime-profile attachment")
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("uncertified Java blob changed retry profile to %+v", got)
+	}
+
+	blob := BlobByName("java")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(java) returned no data")
+	}
+	if !attachBuiltinLanguageRuntimeProfile("java", sha256.Sum256(blob), lang) {
+		t.Fatal("certified Java blob did not attach its runtime profile")
+	}
+	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
+		MinSourceBytes:      64 * 1024,
+		InitialStackCeiling: 14,
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
+		t.Fatalf("certified Java retry profile = %+v, want %+v", got, want)
+	}
+}
+
 func TestAttachLanguageSupportDoesNotCertifyWithoutBlobIdentity(t *testing.T) {
 	base := KotlinLanguage()
 	lang := &gotreesitter.Language{
@@ -77,5 +122,11 @@ func TestAttachLanguageSupportDoesNotCertifyWithoutBlobIdentity(t *testing.T) {
 	}
 	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {
 		t.Fatalf("AttachLanguageSupport certified policy without blob identity: %d", got)
+	}
+
+	java := &gotreesitter.Language{Name: "java"}
+	AttachLanguageSupport("java", java)
+	if got := java.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("AttachLanguageSupport certified Java retry profile without blob identity: %+v", got)
 	}
 }

--- a/language.go
+++ b/language.go
@@ -275,6 +275,18 @@ const (
 	ExternalScannerFullParseRetrySkipRepeat
 )
 
+// FullParseAcceptedErrorRetryProfile certifies a narrow full-parse retry
+// policy. When a fresh full parse accepts an error-bearing tree that covers
+// EOF, the parser may keep the initial GLR stack ceiling after the ordinary
+// same-stack merge retry instead of scheduling wider-stack passes. Both fields
+// must be non-zero; the zero value preserves the conservative generic ladder.
+//
+// Keep fields append-only: Language blobs encode this structure.
+type FullParseAcceptedErrorRetryProfile struct {
+	MinSourceBytes      uint32
+	InitialStackCeiling uint16
+}
+
 // Language holds all data needed to parse a specific language.
 // It mirrors tree-sitter's TSLanguage C struct, translated into
 // idiomatic Go types with slice-based tables instead of raw pointers.
@@ -474,6 +486,11 @@ type Language struct {
 	// for scheduling the extra external-scanner full-parse retry. Zero preserves
 	// the generic behavior for legacy blobs and caller-constructed languages.
 	ExternalScannerFullParseRetryPolicy ExternalScannerFullParseRetryPolicy
+
+	// FullParseAcceptedErrorRetryProfile is certified against an exact language
+	// blob. Zero preserves widened-stack retries for legacy blobs,
+	// caller-constructed languages, and language overrides.
+	FullParseAcceptedErrorRetryProfile FullParseAcceptedErrorRetryProfile
 }
 
 type symbolNameNamedKey struct {

--- a/parser.go
+++ b/parser.go
@@ -2761,9 +2761,9 @@ func (p *Parser) parseIncrementalInternal(source []byte, oldTree *Tree, ts Token
 		deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
 		initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
 		tree := p.parseInternal(source, ts, nil, nil, arenaClassFull, timing, initialMaxStacks, 0, 0, deterministicExternalConflicts)
-		tree = p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
+		tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
 		if shouldRepeatExternalScannerFullParse(p.language, tree) {
-			tree = p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
+			tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
 		}
 		return tree
 	}

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2,6 +2,7 @@ package gotreesitter
 
 import (
 	"bytes"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -584,6 +585,164 @@ func TestDLargeRetryUsesInitialStackCeiling(t *testing.T) {
 	tree.language = &Language{Name: "typescript"}
 	if fullParseRetryUsesInitialStackCeiling(tree, dLargeFileRetryMinBytes, dLargeFileRetryStackCeiling) {
 		t.Fatal("fullParseRetryUsesInitialStackCeiling(typescript) = true, want false")
+	}
+}
+
+func certifiedAcceptedErrorRetryTestTree(profile bool, sourceLen int) *Tree {
+	lang := &Language{Name: "java"}
+	if profile {
+		lang.FullParseAcceptedErrorRetryProfile = FullParseAcceptedErrorRetryProfile{
+			MinSourceBytes:      64 * 1024,
+			InitialStackCeiling: 14,
+		}
+	}
+	return &Tree{
+		language: lang,
+		root: &Node{
+			endByte: uint32(sourceLen),
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:       ParseStopAccepted,
+			SourceLen:        uint32(sourceLen),
+			ExpectedEOFByte:  uint32(sourceLen),
+			RootEndByte:      uint32(sourceLen),
+			LastTokenEndByte: uint32(sourceLen),
+			LastTokenWasEOF:  true,
+			MaxStacksSeen:    18,
+			NodesAllocated:   100,
+		},
+	}
+}
+
+func TestCertifiedAcceptedErrorRetryStackCeilingScope(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	const sourceLen = 64 * 1024
+	eligible := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+	if !fullParseRetryUsesInitialStackCeilingForOrigin(eligible, sourceLen, 14, fullParseRetryOriginFresh) {
+		t.Fatal("certified fresh accepted-error parse did not keep its initial stack ceiling")
+	}
+	if got := fullParseRetryMaxStacksOverrideForOrigin(eligible, sourceLen, 14, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("certified fresh max-stack override = %d, want 0", got)
+	}
+	if got := fullParseRetryMergePerKeyOverride(eligible, sourceLen, 14); got != javaFullParseRetryMaxMergePerKey {
+		t.Fatalf("certified same-stack merge override = %d, want %d", got, javaFullParseRetryMaxMergePerKey)
+	}
+
+	assertNotCertified := func(label string, tree *Tree, bytes, stacks int, origin fullParseRetryOrigin) {
+		t.Helper()
+		if fullParseRetryUsesInitialStackCeilingForOrigin(tree, bytes, stacks, origin) {
+			t.Fatalf("%s unexpectedly used the certified stack ceiling", label)
+		}
+	}
+
+	assertNotCertified("uncertified language", certifiedAcceptedErrorRetryTestTree(false, sourceLen), sourceLen, 14, fullParseRetryOriginFresh)
+	assertNotCertified("small source", certifiedAcceptedErrorRetryTestTree(true, sourceLen-1), sourceLen-1, 14, fullParseRetryOriginFresh)
+	assertNotCertified("different initial ceiling", certifiedAcceptedErrorRetryTestTree(true, sourceLen), sourceLen, 13, fullParseRetryOriginFresh)
+	assertNotCertified("incremental origin", certifiedAcceptedErrorRetryTestTree(true, sourceLen), sourceLen, 14, fullParseRetryOriginIncremental)
+
+	clean := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+	clean.root.flags = 0
+	assertNotCertified("clean tree", clean, sourceLen, 14, fullParseRetryOriginFresh)
+
+	otherStop := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+	otherStop.parseRuntime.StopReason = ParseStopNoStacksAlive
+	assertNotCertified("other stop reason", otherStop, sourceLen, 14, fullParseRetryOriginFresh)
+
+	truncated := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+	truncated.parseRuntime.Truncated = true
+	assertNotCertified("truncated result", truncated, sourceLen, 14, fullParseRetryOriginFresh)
+
+	earlyEOF := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+	earlyEOF.parseRuntime.TokenSourceEOFEarly = true
+	assertNotCertified("early token-source EOF", earlyEOF, sourceLen, 14, fullParseRetryOriginFresh)
+
+	shortTree := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+	shortTree.root.endByte--
+	shortTree.parseRuntime.RootEndByte--
+	shortTree.parseRuntime.LastTokenWasEOF = false
+	shortTree.parseRuntime.LastTokenEndByte--
+	assertNotCertified("tree not covering EOF", shortTree, sourceLen, 14, fullParseRetryOriginFresh)
+}
+
+func TestCertifiedAcceptedErrorRetryStackCeilingHonorsExplicitOverrides(t *testing.T) {
+	const sourceLen = 64 * 1024
+	tree := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+
+	for _, env := range []string{"GOT_GLR_MAX_STACKS", "GOT_GLR_MAX_MERGE_PER_KEY"} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("GOT_GLR_MAX_STACKS", "")
+			t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+			t.Setenv(env, "14")
+			if certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree, sourceLen, 14) {
+				t.Fatalf("certified policy ignored explicit %s", env)
+			}
+		})
+	}
+}
+
+func TestCertifiedAcceptedErrorRetrySchedulingKeepsMergeAndSkipsWidening(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	const sourceLen = 64 * 1024
+	source := make([]byte, sourceLen)
+	type retryCall struct {
+		stacks int
+		merge  int
+		nodes  int
+	}
+
+	t.Run("fresh certified", func(t *testing.T) {
+		parser := &Parser{}
+		initial := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+		var calls []retryCall
+		parser.retryFullParse(source, 14, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+			calls = append(calls, retryCall{maxStacks, maxMergePerKeyOverride, maxNodes})
+			candidate := certifiedAcceptedErrorRetryTestTree(true, sourceLen)
+			candidate.parseRuntime.NodesAllocated = 99
+			return candidate
+		})
+		want := []retryCall{{stacks: 14, merge: javaFullParseRetryMaxMergePerKey}}
+		if !slices.Equal(calls, want) {
+			t.Fatalf("retry calls = %+v, want %+v", calls, want)
+		}
+	})
+
+	for _, tt := range []struct {
+		name    string
+		profile bool
+		origin  fullParseRetryOrigin
+	}{
+		{name: "uncertified fresh", profile: false, origin: fullParseRetryOriginFresh},
+		{name: "certified incremental", profile: true, origin: fullParseRetryOriginIncremental},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Parser{}
+			initial := certifiedAcceptedErrorRetryTestTree(tt.profile, sourceLen)
+			var calls []retryCall
+			parser.retryFullParseForOrigin(source, 14, initial, tt.origin, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+				calls = append(calls, retryCall{maxStacks, maxMergePerKeyOverride, maxNodes})
+				if maxStacks == javaFullParseRetryMaxGLRStacks {
+					clean := certifiedAcceptedErrorRetryTestTree(tt.profile, sourceLen)
+					clean.root.flags = 0
+					clean.parseRuntime.NodesAllocated = 1
+					return clean
+				}
+				candidate := certifiedAcceptedErrorRetryTestTree(tt.profile, sourceLen)
+				candidate.parseRuntime.NodesAllocated = 99
+				return candidate
+			})
+			if len(calls) < 2 || calls[0] != (retryCall{stacks: 14, merge: javaFullParseRetryMaxMergePerKey}) || calls[1].stacks != javaFullParseRetryMaxGLRStacks {
+				t.Fatalf("retry calls = %+v, want same-stack merge followed by cap-%d widening", calls, javaFullParseRetryMaxGLRStacks)
+			}
+		})
 	}
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -93,6 +93,13 @@ type resettableTokenSource interface {
 
 type fullParseRetryRunner func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree
 
+type fullParseRetryOrigin uint8
+
+const (
+	fullParseRetryOriginFresh fullParseRetryOrigin = iota
+	fullParseRetryOriginIncremental
+)
+
 func shouldRetryFullParse(tree *Tree, sourceLen int) bool {
 	if tree == nil {
 		return false
@@ -1129,13 +1136,17 @@ func shouldRepeatExternalScannerFullParse(lang *Language, tree *Tree) bool {
 }
 
 func fullParseRetryMaxStacksOverride(tree *Tree, sourceLen int, initialMaxStacks int) int {
+	return fullParseRetryMaxStacksOverrideForOrigin(tree, sourceLen, initialMaxStacks, fullParseRetryOriginFresh)
+}
+
+func fullParseRetryMaxStacksOverrideForOrigin(tree *Tree, sourceLen int, initialMaxStacks int, origin fullParseRetryOrigin) int {
 	// An explicit GOT_GLR_MAX_STACKS is a true ceiling: diagnostics and
 	// experiments depend on the survivor cap actually holding, and the
 	// widening below silently defeated it (2026-07 cliff campaign finding).
 	if parseMaxGLRStacksEnvConfigured() {
 		return 0
 	}
-	if fullParseRetryUsesInitialStackCeiling(tree, sourceLen, initialMaxStacks) {
+	if fullParseRetryUsesInitialStackCeilingForOrigin(tree, sourceLen, initialMaxStacks, origin) {
 		return 0
 	}
 	retryMaxStacks := fullParseRetryMaxGLRStacks
@@ -1157,8 +1168,15 @@ func fullParseRetryMaxStacksOverride(tree *Tree, sourceLen int, initialMaxStacks
 }
 
 func fullParseRetryUsesInitialStackCeiling(tree *Tree, sourceLen int, initialMaxStacks int) bool {
+	return fullParseRetryUsesInitialStackCeilingForOrigin(tree, sourceLen, initialMaxStacks, fullParseRetryOriginFresh)
+}
+
+func fullParseRetryUsesInitialStackCeilingForOrigin(tree *Tree, sourceLen int, initialMaxStacks int, origin fullParseRetryOrigin) bool {
 	if tree == nil || tree.language == nil {
 		return false
+	}
+	if origin == fullParseRetryOriginFresh && certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree, sourceLen, initialMaxStacks) {
+		return true
 	}
 	switch tree.language.Name {
 	case "groovy":
@@ -1178,6 +1196,25 @@ func fullParseRetryUsesInitialStackCeiling(tree *Tree, sourceLen int, initialMax
 	default:
 		return false
 	}
+}
+
+func certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree *Tree, sourceLen int, initialMaxStacks int) bool {
+	if tree == nil || tree.language == nil || sourceLen <= 0 {
+		return false
+	}
+	profile := tree.language.FullParseAcceptedErrorRetryProfile
+	if profile.MinSourceBytes == 0 || profile.InitialStackCeiling == 0 ||
+		uint64(sourceLen) < uint64(profile.MinSourceBytes) ||
+		initialMaxStacks != int(profile.InitialStackCeiling) ||
+		parseMaxGLRStacksEnvConfigured() || parseMaxMergePerKeyEnvConfigured() {
+		return false
+	}
+	rt := tree.ParseRuntime()
+	return rt.StopReason == ParseStopAccepted &&
+		!rt.Truncated &&
+		!rt.TokenSourceEOFEarly &&
+		retryTreeHasError(tree) &&
+		retryTreeCoversExpectedEOF(tree)
 }
 
 func fullParseRetryNodeLimitOverride(tree *Tree, sourceLen int) int {
@@ -1319,7 +1356,11 @@ func shouldRunInitialFullParseMergeRetry(tree *Tree) bool {
 }
 
 func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree, runRetry fullParseRetryRunner) *Tree {
-	maxStacksOverride := fullParseRetryMaxStacksOverride(tree, len(source), initialMaxStacks)
+	return p.retryFullParseForOrigin(source, initialMaxStacks, tree, fullParseRetryOriginFresh, runRetry)
+}
+
+func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tree *Tree, origin fullParseRetryOrigin, runRetry fullParseRetryRunner) *Tree {
+	maxStacksOverride := fullParseRetryMaxStacksOverrideForOrigin(tree, len(source), initialMaxStacks, origin)
 	maxNodesOverride := fullParseRetryNodeLimitOverride(tree, len(source))
 	retryMaxStacks := initialMaxStacks
 	if maxStacksOverride > 0 {
@@ -1610,11 +1651,15 @@ func (p *Parser) retryFullParseWithDFA(source []byte, initialMaxStacks int, dete
 }
 
 func (p *Parser) retryFullParseWithTokenSource(source []byte, ts TokenSource, initialMaxStacks int, deterministicExternalConflicts bool, tree *Tree) *Tree {
+	return p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginFresh)
+}
+
+func (p *Parser) retryFullParseWithTokenSourceForOrigin(source []byte, ts TokenSource, initialMaxStacks int, deterministicExternalConflicts bool, tree *Tree, origin fullParseRetryOrigin) *Tree {
 	resettable, ok := ts.(resettableTokenSource)
 	if !ok {
 		return tree
 	}
-	result := p.retryFullParse(source, initialMaxStacks, tree, func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
+	result := p.retryFullParseForOrigin(source, initialMaxStacks, tree, origin, func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
 		resettable.Reset(source)
 		return p.parseInternal(
 			source,
@@ -1642,7 +1687,7 @@ func (p *Parser) retryIncrementalParseAsFullWithTokenSource(source []byte, ts To
 	}
 	deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
 	retryStart := time.Now()
-	result := p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
+	result := p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
 	if result == tree {
 		return tree
 	}


### PR DESCRIPTION
## Summary

- Attach a fail-closed accepted-error retry profile only to the exact built-in Java grammar blob.
- Keep the initial cap-14 parse and cap-16 same-stack merge retry, while suppressing the two cap-64 passes proven redundant on the large Java witness.
- Preserve the generic ladder for incremental parses, small/clean/incomplete results, caller-built or overridden languages, and explicit stack or merge settings.

## Direct validation

Current-main f407985a versus head 3b3c1593:

- Exact DLBF Go dumps are byte-identical: f6449acb039e64ba56d9be88093b27b9db6106180f0466ba3574b9446d7ef9cc.
- Count-10 user time improves 10.12s to 7.90s (-21.94%); wall improves 10.50s to 8.26s (-21.33%).
- Three realistic single-ParserPool count-30 rounds improve mean wall time by 26.1% and reduce allocation volume by about 13%; mean max RSS differs by 0.93% with overlapping variance.
- Count-1 RSS improves 5.87%; both revisions complete a reused-pool count-30 run under GOMEMLIMIT=384MiB.
- Focused retry-policy and grammar-profile Docker tests pass at count 20; local root/grammars vet and perf-tag compile pass.

The witness retains its pre-existing Go/C shape difference. Base and head C dumps are also byte-identical, and this change does not claim to resolve that separate parity item.