### PR TITLE
fix(grammars): synchronize extension loading and refresh stale pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Extension grammar generation is now synchronized and memoized, including
+  failures, so concurrent first access cannot race or regenerate repeatedly.
+- `ParseFilePooled` replaces a cached parser pool when a same-name registry
+  update supplies a different language instance.
+
 ## [0.25.0] - 2026-07-11
 
 Performance, memory, and runtime-hygiene release following v0.24.1. It makes

--- a/grammars/parse_file.go
+++ b/grammars/parse_file.go
@@ -16,13 +16,13 @@ func getOrCreatePool(name string, lang *gotreesitter.Language) *gotreesitter.Par
 	poolsMu.RLock()
 	pp, ok := pools[name]
 	poolsMu.RUnlock()
-	if ok {
+	if ok && pp.Language() == lang {
 		return pp
 	}
 
 	poolsMu.Lock()
 	defer poolsMu.Unlock()
-	if pp, ok = pools[name]; ok {
+	if pp, ok = pools[name]; ok && pp.Language() == lang {
 		return pp
 	}
 	pp = gotreesitter.NewParserPool(lang)

--- a/grammars/registry.go
+++ b/grammars/registry.go
@@ -134,7 +134,8 @@ func Register(entry LangEntry) {
 // RegisterExtension registers a grammargen-based grammar extension with the
 // language registry. This enables detection by file extension, markdown code
 // fence highlighting, and LSP support. The language is generated lazily on
-// first access.
+// first access. Its result, including a generation error, is cached so the
+// generator is invoked at most once.
 //
 // Usage from an extension package:
 //
@@ -161,17 +162,19 @@ type ExtensionEntry struct {
 // RegisterExtension registers a grammar extension for file detection and
 // markdown code fence highlighting.
 func RegisterExtension(ext ExtensionEntry) {
-	var cached *gotreesitter.Language
+	var (
+		generateOnce sync.Once
+		cached       *gotreesitter.Language
+		cachedErr    error
+	)
 	loader := func() *gotreesitter.Language {
-		if cached != nil {
-			return cached
-		}
-		lang, err := ext.GenerateLanguage()
-		if err != nil {
+		generateOnce.Do(func() {
+			cached, cachedErr = ext.GenerateLanguage()
+		})
+		if cachedErr != nil {
 			return nil
 		}
-		cached = lang
-		return lang
+		return cached
 	}
 
 	Register(LangEntry{

--- a/grammars/registry_lifecycle_test.go
+++ b/grammars/registry_lifecycle_test.go
@@ -1,0 +1,198 @@
+package grammars
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func preserveRegistryState(t *testing.T) {
+	t.Helper()
+	ensureReady()
+
+	registryMu.RLock()
+	savedRegistry := append([]LangEntry(nil), registry...)
+	savedResolved := highlightInheritanceResolved
+	savedAliases := make(map[string]string, len(extensionAliases))
+	for alias, name := range extensionAliases {
+		savedAliases[alias] = name
+	}
+	registryMu.RUnlock()
+
+	t.Cleanup(func() {
+		registryMu.Lock()
+		defer registryMu.Unlock()
+
+		registry = savedRegistry
+		highlightInheritanceResolved = savedResolved
+		extensionAliases = savedAliases
+		buildExtIndex()
+	})
+}
+
+func preserveParserPool(t *testing.T, name string) {
+	t.Helper()
+	poolsMu.Lock()
+	saved, existed := pools[name]
+	delete(pools, name)
+	poolsMu.Unlock()
+
+	t.Cleanup(func() {
+		poolsMu.Lock()
+		defer poolsMu.Unlock()
+		if existed {
+			pools[name] = saved
+		} else {
+			delete(pools, name)
+		}
+	})
+}
+
+func TestRegisterExtensionGeneratesLanguageOnceConcurrently(t *testing.T) {
+	preserveRegistryState(t)
+
+	const workers = 32
+	want := &gotreesitter.Language{Name: "zz_extension_once"}
+	var calls atomic.Int32
+	generatorStarted := make(chan struct{})
+	releaseGenerator := make(chan struct{})
+
+	RegisterExtension(ExtensionEntry{
+		Name:       "zz_extension_once",
+		Extensions: []string{".zz-extension-once"},
+		GenerateLanguage: func() (*gotreesitter.Language, error) {
+			calls.Add(1)
+			close(generatorStarted)
+			<-releaseGenerator
+			return want, nil
+		},
+	})
+
+	entry := DetectLanguage("sample.zz-extension-once")
+	if entry == nil {
+		t.Fatal("expected extension language to be registered")
+	}
+
+	start := make(chan struct{})
+	results := make(chan *gotreesitter.Language, workers)
+	var ready sync.WaitGroup
+	var done sync.WaitGroup
+	ready.Add(workers)
+	done.Add(workers)
+	for range workers {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			<-start
+			results <- entry.Language()
+		}()
+	}
+
+	ready.Wait()
+	close(start)
+	<-generatorStarted
+	close(releaseGenerator)
+	done.Wait()
+	close(results)
+
+	for got := range results {
+		if got != want {
+			t.Errorf("Language() = %p, want %p", got, want)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("GenerateLanguage called %d times, want 1", got)
+	}
+}
+
+func TestRegisterExtensionCachesGenerationError(t *testing.T) {
+	preserveRegistryState(t)
+
+	var calls atomic.Int32
+	wantErr := errors.New("generate failed")
+	RegisterExtension(ExtensionEntry{
+		Name:       "zz_extension_error_once",
+		Extensions: []string{".zz-extension-error"},
+		GenerateLanguage: func() (*gotreesitter.Language, error) {
+			calls.Add(1)
+			return nil, wantErr
+		},
+	})
+
+	entry := DetectLanguage("sample.zz-extension-error")
+	if entry == nil {
+		t.Fatal("expected extension language to be registered")
+	}
+	for i := 0; i < 3; i++ {
+		if got := entry.Language(); got != nil {
+			t.Fatalf("Language() call %d = %p, want nil after generation error", i+1, got)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("GenerateLanguage called %d times after cached error, want 1", got)
+	}
+}
+
+func TestParseFilePooledReplacesPoolForReplacedLanguage(t *testing.T) {
+	preserveRegistryState(t)
+	const name = "zz_pool_language_identity"
+	preserveParserPool(t, name)
+
+	goLang := GoLanguage()
+	pythonLang := PythonLanguage()
+	Register(LangEntry{
+		Name:       name,
+		Extensions: []string{".zz-pool-identity"},
+		Language: func() *gotreesitter.Language {
+			return goLang
+		},
+	})
+
+	first, err := ParseFilePooled("before.zz-pool-identity", []byte("package before\n"))
+	if err != nil {
+		t.Fatalf("first ParseFilePooled: %v", err)
+	}
+	if got := first.Language(); got != goLang {
+		first.Release()
+		t.Fatalf("first tree language = %p, want %p", got, goLang)
+	}
+	first.Release()
+
+	poolsMu.RLock()
+	firstPool := pools[name]
+	poolsMu.RUnlock()
+	if firstPool == nil {
+		t.Fatal("first ParseFilePooled did not cache a parser pool")
+	}
+
+	Register(LangEntry{
+		Name:       name,
+		Extensions: []string{".zz-pool-identity"},
+		Language: func() *gotreesitter.Language {
+			return pythonLang
+		},
+	})
+
+	second, err := ParseFilePooled("after.zz-pool-identity", []byte("value = 1\n"))
+	if err != nil {
+		t.Fatalf("second ParseFilePooled: %v", err)
+	}
+	if got := second.Language(); got != pythonLang {
+		second.Release()
+		t.Fatalf("second tree language = %p, want replacement %p", got, pythonLang)
+	}
+	second.Release()
+
+	poolsMu.RLock()
+	secondPool := pools[name]
+	poolsMu.RUnlock()
+	if secondPool == firstPool {
+		t.Fatal("ParseFilePooled reused the pool built for the replaced Language")
+	}
+	if got := secondPool.Language(); got != pythonLang {
+		t.Fatalf("replacement pool language = %p, want %p", got, pythonLang)
+	}
+}


### PR DESCRIPTION
## Summary

- Memoize extension grammar generation with sync.Once so concurrent first access cannot race or regenerate.
- Cache failed generation deterministically instead of retrying on every access.
- Rebuild a name-keyed ParserPool when registry replacement supplies a different Language pointer.

## Direct validation

- Concurrent success, cached-error, and same-name replacement public-path regressions pass at count 20.
- go vet ./grammars and git diff checks pass.
- Docker race coverage passes without OOM.
- Canopy limits the production blast radius to RegisterExtension and ParseFilePooled.

This intentionally does not add a new error-returning registry API or expand ExtensionEntry.