### PR TITLE
refactor(cgo_harness): remove unused tier-scan helper

### DIFF
--- a/cgo_harness/tier_scan/summarize_scan.py
+++ b/cgo_harness/tier_scan/summarize_scan.py
@@ -702,17 +702,6 @@ def failure_family_entry(
     }
 
 
-def unmeasured_family_entry(name: str, description: str, entries: list[dict[str, Any]]) -> dict[str, Any]:
-    sorted_entries = sorted(entries, key=lambda item: item["grammar"])
-    return {
-        "name": name,
-        "description": description,
-        "count": len(sorted_entries),
-        "grammars": [item["grammar"] for item in sorted_entries],
-        "entries": sorted_entries,
-    }
-
-
 def failure_families(
     measurements: dict[str, dict[str, Any]],
     unmeasured_entries: list[dict[str, Any]],


### PR DESCRIPTION
## Summary

- remove the private unmeasured_family_entry helper
- keep the active failure-family summary path unchanged
- reduce the tier-scan CLI surface by 11 lines with no behavior change

## Evidence

- Canopy references: 0; blast radius: 0
- whole-repository literal search: definition only
- representative before/after CLI output: byte-identical
- Python CLI help and git diff check: pass