### PR TITLE
refactor(tree): Move node field metadata to arena-allocated sidecar

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -123,6 +123,8 @@ type nodeArena struct {
 	compactCheckpointLeafSlabs      []compactCheckpointLeafSlab
 	compactCheckpointLeafSlabCursor int
 	finalChildSidecars              []finalChildSidecar
+	nodeFieldMetadataSlabs          []nodeFieldMetadataSlab
+	nodeFieldMetadataSlabCursor     int
 
 	childSlabs                         []childSliceSlab
 	fieldSlabs                         []fieldSliceSlab
@@ -529,6 +531,7 @@ func (a *nodeArena) reset() {
 	a.resetRawShapeChildSlabs()
 	a.resetFinalChildSidecars()
 	a.resetCompactCheckpointLeafSlabs()
+	a.resetNodeFieldMetadataSlabs()
 	a.resetChildSlabs()
 	a.resetCounters()
 	a.resetFieldSlabs()
@@ -1531,9 +1534,9 @@ func (a *nodeArena) allocFieldIDSlice(n int) []FieldID {
 		slab.used += n
 		a.fieldSlabCursor = i
 		// Cap at len: callers (e.g. parser_result_scala_compilation.go) reslice
-		// then append on parent.fieldIDs. Without the 3-index expression the
-		// spare slab capacity would let those appends silently overwrite the
-		// next parent's fieldIDs. Same defect class as allocNodeSlice.
+		// then append on a parent's field-ID slice. Without the 3-index
+		// expression the append can silently overwrite the next parent's field
+		// IDs. Same defect class as allocNodeSlice.
 		out := slab.data[start:slab.used:slab.used]
 		clear(out)
 		return out
@@ -1829,6 +1832,7 @@ func (a *nodeArena) recomputeAllocatedBytes() {
 		return
 	}
 	total := a.nodeStructBytesAllocated() +
+		a.nodeFieldMetadataBytesAllocated() +
 		a.noTreeNodeBytesAllocated() +
 		a.compactFullLeafBytesAllocated() +
 		a.pendingParentBytesAllocated() +
@@ -2186,6 +2190,7 @@ func (a *nodeArena) collectArenaBreakdown() *ArenaBreakdown {
 	}
 	breakdown := &ArenaBreakdown{
 		NodeStructBytesAllocated:            a.nodeStructBytesAllocated(),
+		NodeFieldMetadataBytesAllocated:     a.nodeFieldMetadataBytesAllocated(),
 		NoTreeNodeBytesAllocated:            a.noTreeNodeBytesAllocated(),
 		CompactFullLeafBytesAllocated:       a.compactFullLeafBytesAllocated(),
 		PendingParentBytesAllocated:         a.pendingParentBytesAllocated(),

--- a/cgo_harness/benchmark_python_corpus_test.go
+++ b/cgo_harness/benchmark_python_corpus_test.go
@@ -117,6 +117,7 @@ type pythonRuntimeBenchStats struct {
 	multiStackGSSNodes                   uint64
 	arenaBytesAllocated                  int64
 	arenaNodeStructBytesAllocated        int64
+	arenaNodeFieldMetadataBytesAllocated int64
 	arenaNoTreeNodeBytesAllocated        int64
 	arenaCompactFullLeafBytesAllocated   int64
 	arenaPendingParentBytesAllocated     int64
@@ -514,6 +515,7 @@ func (s *pythonRuntimeBenchStats) add(rt gotreesitter.ParseRuntime, breakdown go
 	if hasBreakdown {
 		s.arenaBreakdownSamples++
 		s.arenaNodeStructBytesAllocated += breakdown.NodeStructBytesAllocated
+		s.arenaNodeFieldMetadataBytesAllocated += breakdown.NodeFieldMetadataBytesAllocated
 		s.arenaNoTreeNodeBytesAllocated += breakdown.NoTreeNodeBytesAllocated
 		s.arenaCompactFullLeafBytesAllocated += breakdown.CompactFullLeafBytesAllocated
 		s.arenaPendingParentBytesAllocated += breakdown.PendingParentBytesAllocated
@@ -805,6 +807,7 @@ func (s pythonRuntimeBenchStats) report(b *testing.B) {
 		b.ReportMetric(float64(s.errorSymbolNodesConstructed)/tokens, "error_nodes/token")
 		b.ReportMetric(float64(s.hasErrorNodesConstructed)/tokens, "has_error_nodes/token")
 		b.ReportMetric(float64(s.arenaNodeStructBytesAllocated)/tokens, "arena_node_B/token")
+		b.ReportMetric(float64(s.arenaNodeFieldMetadataBytesAllocated)/tokens, "arena_node_field_meta_B/token")
 		b.ReportMetric(float64(s.arenaNoTreeNodeBytesAllocated)/tokens, "arena_notree_node_B/token")
 		b.ReportMetric(float64(s.arenaCompactFullLeafBytesAllocated)/tokens, "arena_compact_full_leaf_B/token")
 		b.ReportMetric(float64(s.arenaPendingParentBytesAllocated)/tokens, "arena_pending_parent_B/token")

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -1169,7 +1169,9 @@ func statsFromGoTree(r *runner, tree *gotreesitter.Tree, queryCaptures, cursorNo
 			breakdown.PendingChildEntryBytesAllocated +
 			breakdown.FinalChildSidecarBytesAllocated
 		stats.ArenaChildB = breakdown.ChildSliceBytesAllocated
-		stats.ArenaFieldB = breakdown.FieldIDBytesAllocated + breakdown.FieldSourceBytesAllocated
+		stats.ArenaFieldB = breakdown.NodeFieldMetadataBytesAllocated +
+			breakdown.FieldIDBytesAllocated +
+			breakdown.FieldSourceBytesAllocated
 		stats.ArenaRawShapeB = breakdown.RawShapeBytesAllocated
 		stats.ArenaRawShapeChildB = breakdown.RawShapeChildBytesAllocated
 		stats.ArenaLiveB = arenaLiveBytes(breakdown, rt.ExternalScannerCheckpointBytesAllocated)
@@ -1268,6 +1270,7 @@ func statsFromGoTree(r *runner, tree *gotreesitter.Tree, queryCaptures, cursorNo
 // bytes. The total must stay equal to ParseRuntime.ArenaBytesAllocated.
 func arenaLiveBytes(b gotreesitter.ArenaBreakdown, externalScannerCheckpointBytes int64) int64 {
 	return b.NodeStructBytesAllocated +
+		b.NodeFieldMetadataBytesAllocated +
 		b.NoTreeNodeBytesAllocated +
 		b.CompactFullLeafBytesAllocated +
 		b.PendingParentBytesAllocated +

--- a/cgo_harness/cmd/parse_gap_report/main_test.go
+++ b/cgo_harness/cmd/parse_gap_report/main_test.go
@@ -245,6 +245,7 @@ func TestStatsFromRuntimeReportsScratchAndTransientMemory(t *testing.T) {
 func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 	breakdown := gotreesitter.ArenaBreakdown{
 		NodeStructBytesAllocated:            1,
+		NodeFieldMetadataBytesAllocated:     14,
 		NoTreeNodeBytesAllocated:            2,
 		CompactFullLeafBytesAllocated:       3,
 		PendingParentBytesAllocated:         4,
@@ -259,7 +260,7 @@ func TestArenaLiveBytesIncludesEveryRuntimeArenaComponent(t *testing.T) {
 	}
 	runtime := gotreesitter.ParseRuntime{
 		ExternalScannerCheckpointBytesAllocated: 13,
-		ArenaBytesAllocated:                     91,
+		ArenaBytesAllocated:                     105,
 	}
 	if got, want := arenaLiveBytes(breakdown, runtime.ExternalScannerCheckpointBytesAllocated), runtime.ArenaBytesAllocated; got != want {
 		t.Fatalf("arenaLiveBytes = %d, runtime arena total = %d", got, want)

--- a/glr.go
+++ b/glr.go
@@ -747,9 +747,10 @@ func stackNodeGenericEquivSignature(n *Node, depth int) uint64 {
 	}
 
 	h = mixStackEquivSignature(h, uint64(n.preGotoState))
-	h = mixStackEquivSignature(h, uint64(len(n.fieldIDs)))
-	for i := range n.fieldIDs {
-		h = mixStackEquivSignature(h, uint64(n.fieldIDs[i]))
+	fieldIDs := n.fieldIDs()
+	h = mixStackEquivSignature(h, uint64(len(fieldIDs)))
+	for _, fieldID := range fieldIDs {
+		h = mixStackEquivSignature(h, uint64(fieldID))
 	}
 
 	frontier := -1
@@ -781,8 +782,8 @@ func stackNodeGenericEquivSignature(n *Node, depth int) uint64 {
 		}
 	}
 	if len(n.children) <= 3 {
-		for i := range n.fieldIDs {
-			if n.fieldIDs[i] == 0 || i >= len(n.children) {
+		for i, fieldID := range fieldIDs {
+			if fieldID == 0 || i >= len(n.children) {
 				continue
 			}
 			child := n.children[i]
@@ -822,14 +823,15 @@ func stackNodeGenericFrontierChildSignature(n *Node) uint64 {
 	h = mixStackEquivSignature(h, uint64(n.symbol))
 	h = mixStackEquivSignature(h, (uint64(n.startByte)<<32)|uint64(n.endByte))
 	h = mixStackEquivSignature(h, uint64(len(n.children)))
-	h = mixStackEquivSignature(h, uint64(len(n.fieldIDs)))
+	fieldIDs := n.fieldIDs()
+	h = mixStackEquivSignature(h, uint64(len(fieldIDs)))
 	h = mixStackEquivSignature(h, uint64(n.flags&nodeStackEquivFlagMask))
 	h = mixStackEquivSignature(h, uint64(n.parseState))
 	h = mixStackEquivSignature(h, uint64(n.preGotoState))
 	h = mixStackEquivSignature(h, uint64(n.productionID))
 	h = mixStackEquivSignature(h, uint64(uint32(n.dynamicPrecedence)))
-	for i := range n.fieldIDs {
-		h = mixStackEquivSignature(h, uint64(n.fieldIDs[i]))
+	for _, fieldID := range fieldIDs {
+		h = mixStackEquivSignature(h, uint64(fieldID))
 	}
 	return h
 }
@@ -2165,13 +2167,14 @@ func stackEntryPendingFieldMetadataAt(arena *nodeArena, entry stackEntry, i int)
 		if i < 0 || i >= childCount {
 			return 0, fieldSourceNone, false
 		}
-		if len(node.fieldIDs) == 0 {
+		fieldIDs := node.fieldIDs()
+		if len(fieldIDs) == 0 {
 			return 0, fieldSourceNone, true
 		}
-		if len(node.fieldIDs) != childCount {
+		if len(fieldIDs) != childCount {
 			return 0, fieldSourceNone, false
 		}
-		return node.fieldIDs[i], fieldSourceAt(node.fieldSources, i), true
+		return fieldIDs[i], fieldSourceAt(node.fieldSources(), i), true
 	}
 	return 0, fieldSourceNone, false
 }
@@ -2201,9 +2204,10 @@ func stackEntryExactShallowSignature(e stackEntry) uint64 {
 	if n == nil {
 		return h
 	}
-	h = mixStackEquivSignature(h, uint64(len(n.fieldIDs)))
-	for i := range n.fieldIDs {
-		h = mixStackEquivSignature(h, uint64(n.fieldIDs[i]))
+	fieldIDs := n.fieldIDs()
+	h = mixStackEquivSignature(h, uint64(len(fieldIDs)))
+	for _, fieldID := range fieldIDs {
+		h = mixStackEquivSignature(h, uint64(fieldID))
 	}
 	h = mixStackEquivSignature(h, uint64(len(n.children)))
 	for i := range n.children {
@@ -2221,7 +2225,7 @@ func stackNodeExactHeaderSignature(n *Node) uint64 {
 	h = mixStackEquivSignature(h, uint64(n.symbol))
 	h = mixStackEquivSignature(h, (uint64(n.startByte)<<32)|uint64(n.endByte))
 	h = mixStackEquivSignature(h, uint64(len(n.children)))
-	h = mixStackEquivSignature(h, uint64(len(n.fieldIDs)))
+	h = mixStackEquivSignature(h, uint64(len(n.fieldIDs())))
 	h = mixStackEquivSignature(h, uint64(n.parseState))
 	h = mixStackEquivSignature(h, uint64(n.preGotoState))
 	h = mixStackEquivSignature(h, uint64(n.productionID))
@@ -2303,7 +2307,7 @@ func stackNodeNeedsDeepEquivalent(n *Node) bool {
 	if n == nil {
 		return false
 	}
-	if n.flags&nodeFlagExtra != 0 || n.preGotoState != 0 || len(n.fieldIDs) != 0 {
+	if n.flags&nodeFlagExtra != 0 || n.preGotoState != 0 || len(n.fieldIDs()) != 0 {
 		return true
 	}
 	for i := range n.children {
@@ -2311,7 +2315,7 @@ func stackNodeNeedsDeepEquivalent(n *Node) bool {
 		if child == nil {
 			continue
 		}
-		if child.flags&nodeFlagExtra != 0 || child.preGotoState != 0 || len(child.fieldIDs) != 0 || len(child.children) > 0 {
+		if child.flags&nodeFlagExtra != 0 || child.preGotoState != 0 || len(child.fieldIDs()) != 0 || len(child.children) > 0 {
 			return true
 		}
 	}
@@ -2408,13 +2412,8 @@ func stackEntryNodesEquivalentPythonShallow(a, b *Node) bool {
 	if a.flags&nodeFlagHasError != 0 {
 		return true
 	}
-	if len(a.fieldIDs) != len(b.fieldIDs) {
+	if !equalFieldIDSlices(a.fieldIDs(), b.fieldIDs()) {
 		return false
-	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			return false
-		}
 	}
 	for i := range a.children {
 		ca := a.children[i]
@@ -2434,13 +2433,8 @@ func stackEntryNodesEquivalentPythonShallow(a, b *Node) bool {
 			ca.productionID != cb.productionID ||
 			ca.dynamicPrecedence != cb.dynamicPrecedence ||
 			len(ca.children) != len(cb.children) ||
-			len(ca.fieldIDs) != len(cb.fieldIDs) {
+			!equalFieldIDSlices(ca.fieldIDs(), cb.fieldIDs()) {
 			return false
-		}
-		for j := range ca.fieldIDs {
-			if ca.fieldIDs[j] != cb.fieldIDs[j] {
-				return false
-			}
 		}
 	}
 	return true
@@ -2503,7 +2497,9 @@ func stackEntryNodesExactlyEquivalentWithAudit(scratch *glrMergeScratch, audit *
 		}
 		return false
 	}
-	if len(a.fieldIDs) != len(b.fieldIDs) {
+	aFieldIDs := a.fieldIDs()
+	bFieldIDs := b.fieldIDs()
+	if len(aFieldIDs) != len(bFieldIDs) {
 		if audit != nil {
 			audit.recordEquivSkipFieldMismatch()
 		}
@@ -2516,13 +2512,11 @@ func stackEntryNodesExactlyEquivalentWithAudit(scratch *glrMergeScratch, audit *
 		}
 		return true
 	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			if audit != nil {
-				audit.recordEquivSkipFieldMismatch()
-			}
-			return false
+	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+		if audit != nil {
+			audit.recordEquivSkipFieldMismatch()
 		}
+		return false
 	}
 	if len(a.children) == 0 {
 		if audit != nil {
@@ -2584,6 +2578,8 @@ func stackEntryNodesExactlyEquivalentNoAudit(scratch *glrMergeScratch, a, b *Nod
 	if hit, ok := lookupExactNodeEquivCacheNoAudit(scratch, a, b); ok {
 		return hit
 	}
+	aFieldIDs := a.fieldIDs()
+	bFieldIDs := b.fieldIDs()
 	if a.symbol != b.symbol ||
 		a.startByte != b.startByte ||
 		a.endByte != b.endByte ||
@@ -2593,16 +2589,14 @@ func stackEntryNodesExactlyEquivalentNoAudit(scratch *glrMergeScratch, a, b *Nod
 		a.preGotoState != b.preGotoState ||
 		a.productionID != b.productionID ||
 		a.dynamicPrecedence != b.dynamicPrecedence ||
-		len(a.fieldIDs) != len(b.fieldIDs) {
+		len(aFieldIDs) != len(bFieldIDs) {
 		return false
 	}
 	if a.flags&nodeFlagHasError != 0 {
 		return true
 	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			return false
-		}
+	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+		return false
 	}
 	if len(a.children) == 0 {
 		return true
@@ -2667,21 +2661,21 @@ func stackEntryNodesExactlyEquivalentTerminal(audit *runtimeAudit, a, b *Node) b
 		}
 		return false
 	}
-	if len(a.fieldIDs) != len(b.fieldIDs) {
+	aFieldIDs := a.fieldIDs()
+	bFieldIDs := b.fieldIDs()
+	if len(aFieldIDs) != len(bFieldIDs) {
 		if audit != nil {
 			audit.recordEquivSkipFieldMismatch()
 			audit.recordEquivExactTerminalFalse()
 		}
 		return false
 	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			if audit != nil {
-				audit.recordEquivSkipFieldMismatch()
-				audit.recordEquivExactTerminalFalse()
-			}
-			return false
+	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+		if audit != nil {
+			audit.recordEquivSkipFieldMismatch()
+			audit.recordEquivExactTerminalFalse()
 		}
+		return false
 	}
 	if a.flags&nodeFlagHasError != 0 {
 		if audit != nil {
@@ -2710,6 +2704,8 @@ func stackEntryNodesExactlyEquivalentTerminalNoAudit(a, b *Node) bool {
 	if a == nil || b == nil {
 		return false
 	}
+	aFieldIDs := a.fieldIDs()
+	bFieldIDs := b.fieldIDs()
 	if a.symbol != b.symbol ||
 		a.startByte != b.startByte ||
 		a.endByte != b.endByte ||
@@ -2719,13 +2715,11 @@ func stackEntryNodesExactlyEquivalentTerminalNoAudit(a, b *Node) bool {
 		a.preGotoState != b.preGotoState ||
 		a.productionID != b.productionID ||
 		a.dynamicPrecedence != b.dynamicPrecedence ||
-		len(a.fieldIDs) != len(b.fieldIDs) {
+		len(aFieldIDs) != len(bFieldIDs) {
 		return false
 	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			return false
-		}
+	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+		return false
 	}
 	return a.flags&nodeFlagHasError != 0 || len(a.children) == 0
 }
@@ -2770,15 +2764,15 @@ func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b
 		}
 		return true
 	}
-	if len(a.fieldIDs) != len(b.fieldIDs) {
+	aFieldIDs := a.fieldIDs()
+	bFieldIDs := b.fieldIDs()
+	if len(aFieldIDs) != len(bFieldIDs) {
 		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			storeNodeEquivCache(scratch, a, b, depth, false)
-			return false
-		}
+	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+		storeNodeEquivCache(scratch, a, b, depth, false)
+		return false
 	}
 
 	frontier := -1
@@ -2807,15 +2801,9 @@ func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b
 			ca.productionID != cb.productionID ||
 			ca.dynamicPrecedence != cb.dynamicPrecedence ||
 			len(ca.children) != len(cb.children) ||
-			len(ca.fieldIDs) != len(cb.fieldIDs) {
+			!equalFieldIDSlices(ca.fieldIDs(), cb.fieldIDs()) {
 			storeNodeEquivCache(scratch, a, b, depth, false)
 			return false
-		}
-		for j := range ca.fieldIDs {
-			if ca.fieldIDs[j] != cb.fieldIDs[j] {
-				storeNodeEquivCache(scratch, a, b, depth, false)
-				return false
-			}
 		}
 		if ca.flags&nodeFlagExtra == 0 && (ca.flags&nodeFlagNamed != 0 || len(ca.children) > 0) {
 			frontier = i
@@ -2847,7 +2835,7 @@ func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b
 	}
 	if len(a.children) <= 3 {
 		for i := range a.children {
-			fielded := i < len(a.fieldIDs) && a.fieldIDs[i] != 0
+			fielded := i < len(aFieldIDs) && aFieldIDs[i] != 0
 			child := a.children[i]
 			if child == nil || child.flags&nodeFlagExtra != 0 {
 				continue
@@ -3339,6 +3327,8 @@ func stackEntryNodesEquivalentIgnoringDynamic(a, b *Node) bool {
 	if a == nil || b == nil {
 		return false
 	}
+	aFieldIDs := a.fieldIDs()
+	bFieldIDs := b.fieldIDs()
 	if a.symbol != b.symbol ||
 		a.startByte != b.startByte ||
 		a.endByte != b.endByte ||
@@ -3346,14 +3336,12 @@ func stackEntryNodesEquivalentIgnoringDynamic(a, b *Node) bool {
 		a.parseState != b.parseState ||
 		a.preGotoState != b.preGotoState ||
 		a.productionID != b.productionID ||
-		len(a.fieldIDs) != len(b.fieldIDs) ||
+		len(aFieldIDs) != len(bFieldIDs) ||
 		len(a.children) != len(b.children) {
 		return false
 	}
-	for i := range a.fieldIDs {
-		if a.fieldIDs[i] != b.fieldIDs[i] {
-			return false
-		}
+	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+		return false
 	}
 	if a.flags&nodeFlagHasError != 0 {
 		return true
@@ -3374,7 +3362,7 @@ func stackEntryNodesEquivalentIgnoringDynamic(a, b *Node) bool {
 			ca.parseState != cb.parseState ||
 			ca.preGotoState != cb.preGotoState ||
 			ca.productionID != cb.productionID ||
-			len(ca.fieldIDs) != len(cb.fieldIDs) ||
+			len(ca.fieldIDs()) != len(cb.fieldIDs()) ||
 			len(ca.children) != len(cb.children) {
 			return false
 		}

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -178,10 +178,11 @@ func gssNodeShallowMergeHash(h uint64, n *Node) uint64 {
 		h *= gssHashPrime
 		return h
 	}
-	h ^= uint64(len(n.fieldIDs))
+	fieldIDs := n.fieldIDs()
+	h ^= uint64(len(fieldIDs))
 	h *= gssHashPrime
-	for i := range n.fieldIDs {
-		h ^= uint64(n.fieldIDs[i])
+	for _, fieldID := range fieldIDs {
+		h ^= uint64(fieldID)
 		h *= gssHashPrime
 	}
 	for i := range n.children {
@@ -199,7 +200,7 @@ func gssNodeShallowMergeHash(h uint64, n *Node) uint64 {
 		h *= gssHashPrime
 		h ^= uint64(nodeChildCountNoMaterialize(child))
 		h *= gssHashPrime
-		h ^= uint64(len(child.fieldIDs))
+		h ^= uint64(len(child.fieldIDs()))
 		h *= gssHashPrime
 		h ^= uint64(uint32(child.dynamicPrecedence))
 		h *= gssHashPrime

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -133,15 +133,15 @@ func TestGSSNodeHashComputedLazilyForSingleStackNodes(t *testing.T) {
 
 func TestGSSEntryHashMatchesAccessorSemantics(t *testing.T) {
 	node := &Node{
-		children:     []*Node{{symbol: 20, startByte: 1, endByte: 2, preGotoState: 8, fieldIDs: []FieldID{3}, flags: nodeFlagNamed}},
-		fieldIDs:     []FieldID{2},
-		symbol:       10,
-		startByte:    1,
-		endByte:      3,
-		parseState:   4,
-		preGotoState: 14,
-		productionID: 5,
-		flags:        nodeFlagNamed | nodeFlagHasError,
+		children:      []*Node{{symbol: 20, startByte: 1, endByte: 2, preGotoState: 8, fieldMetadata: &nodeFieldMetadata{ids: []FieldID{3}}, flags: nodeFlagNamed}},
+		fieldMetadata: &nodeFieldMetadata{ids: []FieldID{2}},
+		symbol:        10,
+		startByte:     1,
+		endByte:       3,
+		parseState:    4,
+		preGotoState:  14,
+		productionID:  5,
+		flags:         nodeFlagNamed | nodeFlagHasError,
 	}
 	noTree := &noTreeNode{
 		symbol:       11,
@@ -733,10 +733,10 @@ func gssNodeShallowMergeHashViaAccessors(h uint64, n *Node) uint64 {
 		h *= gssHashPrime
 		return h
 	}
-	h ^= uint64(len(n.fieldIDs))
+	h ^= uint64(len(n.fieldIDs()))
 	h *= gssHashPrime
-	for i := range n.fieldIDs {
-		h ^= uint64(n.fieldIDs[i])
+	for i := range n.fieldIDs() {
+		h ^= uint64(n.fieldIDs()[i])
 		h *= gssHashPrime
 	}
 	for i := range n.children {
@@ -754,7 +754,7 @@ func gssNodeShallowMergeHashViaAccessors(h uint64, n *Node) uint64 {
 		h *= gssHashPrime
 		h ^= uint64(nodeChildCountNoMaterialize(child))
 		h *= gssHashPrime
-		h ^= uint64(len(child.fieldIDs))
+		h ^= uint64(len(child.fieldIDs()))
 		h *= gssHashPrime
 		h ^= uint64(uint32(child.dynamicPrecedence))
 		h *= gssHashPrime

--- a/glr_test.go
+++ b/glr_test.go
@@ -457,7 +457,7 @@ func TestAlternativeFieldMatchesUsesLazyFinalChildRefs(t *testing.T) {
 	if node == nil {
 		t.Fatal("materialized parent = nil")
 	}
-	node.fieldIDs = []FieldID{0, 1}
+	node.setFieldIDs([]FieldID{0, 1})
 	child := nodeChildAtForReason(node, 1, materializeForQuery)
 	if child == nil {
 		t.Fatal("nodeChildAtForReason = nil")
@@ -1610,11 +1610,11 @@ func TestPendingParentMaterializationPreservesPackedFieldEntries(t *testing.T) {
 	if node == nil {
 		t.Fatal("materialized node = nil")
 	}
-	if len(node.fieldIDs) != 2 || node.fieldIDs[0] != 0 || node.fieldIDs[1] != 9 {
-		t.Fatalf("fieldIDs = %#v, want [0 9]", node.fieldIDs)
+	if len(node.fieldIDs()) != 2 || node.fieldIDs()[0] != 0 || node.fieldIDs()[1] != 9 {
+		t.Fatalf("fieldIDs = %#v, want [0 9]", node.fieldIDs())
 	}
-	if len(node.fieldSources) != 2 || node.fieldSources[0] != fieldSourceNone || node.fieldSources[1] != fieldSourceDirect {
-		t.Fatalf("fieldSources = %#v, want [none direct]", node.fieldSources)
+	if len(node.fieldSources()) != 2 || node.fieldSources()[0] != fieldSourceNone || node.fieldSources()[1] != fieldSourceDirect {
+		t.Fatalf("fieldSources = %#v, want [none direct]", node.fieldSources())
 	}
 	if node.flags&(pendingParentFlagFieldEntries|pendingParentFlagDirectFieldEntry) != 0 {
 		t.Fatalf("internal pending field flags leaked to materialized node flags: %08b", node.flags)
@@ -1643,11 +1643,11 @@ func TestPendingParentMaterializationUsesPackedDirectFieldEntriesWithoutParser(t
 	if got := arena.pendingChildEntriesAllocated; got != 3 {
 		t.Fatalf("pendingChildEntriesAllocated = %d, want direct child slots only", got)
 	}
-	if len(node.fieldIDs) != 3 || node.fieldIDs[0] != 0 || node.fieldIDs[1] != 7 || node.fieldIDs[2] != 9 {
-		t.Fatalf("fieldIDs = %#v, want [0 7 9]", node.fieldIDs)
+	if len(node.fieldIDs()) != 3 || node.fieldIDs()[0] != 0 || node.fieldIDs()[1] != 7 || node.fieldIDs()[2] != 9 {
+		t.Fatalf("fieldIDs = %#v, want [0 7 9]", node.fieldIDs())
 	}
-	if len(node.fieldSources) != 3 || node.fieldSources[0] != fieldSourceNone || node.fieldSources[1] != fieldSourceDirect || node.fieldSources[2] != fieldSourceDirect {
-		t.Fatalf("fieldSources = %#v, want [none direct direct]", node.fieldSources)
+	if len(node.fieldSources()) != 3 || node.fieldSources()[0] != fieldSourceNone || node.fieldSources()[1] != fieldSourceDirect || node.fieldSources()[2] != fieldSourceDirect {
+		t.Fatalf("fieldSources = %#v, want [none direct direct]", node.fieldSources())
 	}
 	if node.flags&(pendingParentFlagFieldEntries|pendingParentFlagDirectFieldEntry) != 0 {
 		t.Fatalf("internal pending field flags leaked to materialized node flags: %08b", node.flags)
@@ -2671,44 +2671,44 @@ func TestPythonShallowEquivalentMatchesFrontierDepthZero(t *testing.T) {
 		{
 			name: "same immediate child",
 			a: &Node{
-				symbol:       10,
-				startByte:    0,
-				endByte:      5,
-				flags:        nodeFlagNamed,
-				parseState:   1,
-				preGotoState: 2,
-				productionID: 3,
-				fieldIDs:     []FieldID{4},
+				symbol:        10,
+				startByte:     0,
+				endByte:       5,
+				flags:         nodeFlagNamed,
+				parseState:    1,
+				preGotoState:  2,
+				productionID:  3,
+				fieldMetadata: &nodeFieldMetadata{ids: []FieldID{4}},
 				children: []*Node{{
-					symbol:    20,
-					startByte: 0,
-					endByte:   5,
-					flags:     nodeFlagNamed,
-					fieldIDs:  []FieldID{6},
+					symbol:        20,
+					startByte:     0,
+					endByte:       5,
+					flags:         nodeFlagNamed,
+					fieldMetadata: &nodeFieldMetadata{ids: []FieldID{6}},
 				}},
 			},
 			b: &Node{
-				symbol:       10,
-				startByte:    0,
-				endByte:      5,
-				flags:        nodeFlagNamed,
-				parseState:   1,
-				preGotoState: 2,
-				productionID: 3,
-				fieldIDs:     []FieldID{4},
+				symbol:        10,
+				startByte:     0,
+				endByte:       5,
+				flags:         nodeFlagNamed,
+				parseState:    1,
+				preGotoState:  2,
+				productionID:  3,
+				fieldMetadata: &nodeFieldMetadata{ids: []FieldID{4}},
 				children: []*Node{{
-					symbol:    20,
-					startByte: 0,
-					endByte:   5,
-					flags:     nodeFlagNamed,
-					fieldIDs:  []FieldID{6},
+					symbol:        20,
+					startByte:     0,
+					endByte:       5,
+					flags:         nodeFlagNamed,
+					fieldMetadata: &nodeFieldMetadata{ids: []FieldID{6}},
 				}},
 			},
 		},
 		{
 			name: "parent field mismatch",
-			a:    &Node{symbol: 10, startByte: 0, endByte: 5, fieldIDs: []FieldID{4}},
-			b:    &Node{symbol: 10, startByte: 0, endByte: 5, fieldIDs: []FieldID{5}},
+			a:    &Node{symbol: 10, startByte: 0, endByte: 5, fieldMetadata: &nodeFieldMetadata{ids: []FieldID{4}}},
+			b:    &Node{symbol: 10, startByte: 0, endByte: 5, fieldMetadata: &nodeFieldMetadata{ids: []FieldID{5}}},
 		},
 		{
 			name: "child symbol mismatch",

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -483,7 +483,7 @@ func stackEntryNodeChildCount(e stackEntry) int {
 
 func stackEntryNodeFieldIDCount(e stackEntry) int {
 	if n := stackEntryNode(e); n != nil {
-		return len(n.fieldIDs)
+		return len(n.fieldIDs())
 	}
 	if n := stackEntryPendingParent(e); n != nil && (n.hasFieldEntries() || n.hasDirectFieldEntries()) {
 		return n.childEntryCount()

--- a/node_field_metadata.go
+++ b/node_field_metadata.go
@@ -1,0 +1,187 @@
+package gotreesitter
+
+import "unsafe"
+
+// nodeFieldMetadata keeps the uncommon child-field slice headers out of Node.
+// The backing slices retain their existing ownership and aliasing semantics;
+// replacing either header allocates a new sidecar so shallow Node copies keep
+// independent headers while continuing to share backing storage.
+type nodeFieldMetadata struct {
+	ids     []FieldID
+	sources []uint8
+}
+
+type nodeFieldMetadataSlab struct {
+	data []nodeFieldMetadata
+	used int
+}
+
+func (n *Node) fieldIDs() []FieldID {
+	if n == nil || n.fieldMetadata == nil {
+		return nil
+	}
+	return n.fieldMetadata.ids
+}
+
+func (n *Node) fieldSources() []uint8 {
+	if n == nil || n.fieldMetadata == nil {
+		return nil
+	}
+	return n.fieldMetadata.sources
+}
+
+func (n *Node) setFieldMetadata(ids []FieldID, sources []uint8) {
+	if n == nil {
+		return
+	}
+	if ids == nil && sources == nil {
+		n.fieldMetadata = nil
+		return
+	}
+	metadata := n.ownerArena.allocNodeFieldMetadata()
+	metadata.ids = ids
+	metadata.sources = sources
+	n.fieldMetadata = metadata
+}
+
+func (n *Node) setFieldIDs(ids []FieldID) {
+	if n == nil {
+		return
+	}
+	n.setFieldMetadata(ids, n.fieldSources())
+}
+
+func (n *Node) setFieldSources(sources []uint8) {
+	if n == nil {
+		return
+	}
+	n.setFieldMetadata(n.fieldIDs(), sources)
+}
+
+func (n *Node) clearFieldMetadata() {
+	if n != nil {
+		n.fieldMetadata = nil
+	}
+}
+
+func equalFieldIDSlices(a, b []FieldID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneNodeFieldMetadataHeaderInto(dst, src *Node, arena *nodeArena) {
+	if dst == nil || src == nil || src.fieldMetadata == nil {
+		if dst != nil {
+			dst.fieldMetadata = nil
+		}
+		return
+	}
+	metadata := arena.allocNodeFieldMetadata()
+	metadata.ids = src.fieldMetadata.ids
+	metadata.sources = src.fieldMetadata.sources
+	dst.fieldMetadata = metadata
+}
+
+func (a *nodeArena) allocNodeFieldMetadata() *nodeFieldMetadata {
+	if a == nil {
+		return &nodeFieldMetadata{}
+	}
+	if len(a.nodeFieldMetadataSlabs) == 0 {
+		capacity := defaultNodeFieldMetadataSlabCap(a.class)
+		a.nodeFieldMetadataSlabs = append(a.nodeFieldMetadataSlabs, nodeFieldMetadataSlab{
+			data: make([]nodeFieldMetadata, capacity),
+		})
+		a.allocatedBytes += nodeFieldMetadataBytesForCap(capacity)
+		a.nodeFieldMetadataSlabCursor = 0
+	}
+	if a.nodeFieldMetadataSlabCursor < 0 || a.nodeFieldMetadataSlabCursor >= len(a.nodeFieldMetadataSlabs) {
+		a.nodeFieldMetadataSlabCursor = 0
+	}
+	for i := a.nodeFieldMetadataSlabCursor; ; i++ {
+		if i >= len(a.nodeFieldMetadataSlabs) {
+			lastCap := len(a.nodeFieldMetadataSlabs[len(a.nodeFieldMetadataSlabs)-1].data)
+			capacity := boundedNextSlabCap(lastCap, minArenaNodeCap, int(unsafe.Sizeof(nodeFieldMetadata{})))
+			a.nodeFieldMetadataSlabs = append(a.nodeFieldMetadataSlabs, nodeFieldMetadataSlab{
+				data: make([]nodeFieldMetadata, capacity),
+			})
+			a.allocatedBytes += nodeFieldMetadataBytesForCap(capacity)
+		}
+
+		slab := &a.nodeFieldMetadataSlabs[i]
+		if slab.used >= len(slab.data) {
+			continue
+		}
+		idx := slab.used
+		slab.used++
+		a.nodeFieldMetadataSlabCursor = i
+		return &slab.data[idx]
+	}
+}
+
+func (a *nodeArena) resetNodeFieldMetadataSlabs() {
+	if len(a.nodeFieldMetadataSlabs) > 0 {
+		retained := 0
+		keep := 0
+		limit := maxRetainedNodeFieldMetadataCapacityForClass(a.class)
+		for i := 0; i < len(a.nodeFieldMetadataSlabs); i++ {
+			capacity := len(a.nodeFieldMetadataSlabs[i].data)
+			if capacity <= 0 || retained+capacity > limit {
+				break
+			}
+			retained += capacity
+			keep = i + 1
+		}
+		for i := keep; i < len(a.nodeFieldMetadataSlabs); i++ {
+			a.nodeFieldMetadataSlabs[i] = nodeFieldMetadataSlab{}
+		}
+		a.nodeFieldMetadataSlabs = a.nodeFieldMetadataSlabs[:keep]
+	}
+	for i := range a.nodeFieldMetadataSlabs {
+		slab := &a.nodeFieldMetadataSlabs[i]
+		used := min(slab.used, len(slab.data))
+		clear(slab.data[:used])
+		slab.used = 0
+	}
+	a.nodeFieldMetadataSlabCursor = 0
+}
+
+func defaultNodeFieldMetadataSlabCap(class arenaClass) int {
+	return max(nodeCapacityForClass(class)/8, minArenaNodeCap)
+}
+
+func maxRetainedNodeFieldMetadataCapacityForClass(class arenaClass) int {
+	size := int(unsafe.Sizeof(nodeFieldMetadata{}))
+	if size <= 0 {
+		size = 1
+	}
+	if class == arenaClassFull {
+		return max(maxRetainedFullNodeBytes/size, defaultNodeFieldMetadataSlabCap(class))
+	}
+	floor := maxRetainedIncrementalNodeBytes / size
+	return max(defaultNodeFieldMetadataSlabCap(class)*maxRetainedArenaFactor, floor)
+}
+
+func nodeFieldMetadataBytesForCap(n int) int64 {
+	if n <= 0 {
+		return 0
+	}
+	return int64(n) * int64(unsafe.Sizeof(nodeFieldMetadata{}))
+}
+
+func (a *nodeArena) nodeFieldMetadataBytesAllocated() int64 {
+	if a == nil {
+		return 0
+	}
+	var total int64
+	for i := range a.nodeFieldMetadataSlabs {
+		total += nodeFieldMetadataBytesForCap(len(a.nodeFieldMetadataSlabs[i].data))
+	}
+	return total
+}

--- a/node_field_metadata_test.go
+++ b/node_field_metadata_test.go
@@ -1,0 +1,268 @@
+package gotreesitter
+
+import "testing"
+
+func TestNodeFieldMetadataStandaloneAndNilReads(t *testing.T) {
+	var node Node
+	if node.fieldIDs() != nil || node.fieldSources() != nil {
+		t.Fatal("zero Node field metadata must read as nil")
+	}
+
+	ids := []FieldID{3, 0}
+	sources := []uint8{fieldSourceDirect, fieldSourceNone}
+	node.setFieldMetadata(ids, sources)
+	if node.fieldMetadata == nil {
+		t.Fatal("standalone Node did not allocate field metadata")
+	}
+	if got := nodeFieldIDAt(&node, 0); got != 3 {
+		t.Fatalf("field ID = %d, want 3", got)
+	}
+	if got := fieldSourceAt(node.fieldSources(), 0); got != fieldSourceDirect {
+		t.Fatalf("field source = %d, want direct", got)
+	}
+
+	node.clearFieldMetadata()
+	if node.fieldMetadata != nil || node.fieldIDs() != nil || node.fieldSources() != nil {
+		t.Fatal("cleared standalone metadata must be nil")
+	}
+}
+
+func TestNodeFieldMetadataShallowCopyHeaderCOW(t *testing.T) {
+	original := Node{}
+	original.setFieldMetadata(
+		[]FieldID{1, 2},
+		[]uint8{fieldSourceDirect, fieldSourceInherited},
+	)
+
+	shared := original
+	shared.fieldIDs()[0] = 9
+	if got := original.fieldIDs()[0]; got != 9 {
+		t.Fatalf("element write no longer shares backing: original ID = %d, want 9", got)
+	}
+
+	shared.setFieldIDs(shared.fieldIDs()[:1])
+	if shared.fieldMetadata == original.fieldMetadata {
+		t.Fatal("field-ID header replacement did not detach sidecar")
+	}
+	if got := len(original.fieldIDs()); got != 2 {
+		t.Fatalf("original field-ID length = %d, want 2", got)
+	}
+	if got := len(shared.fieldSources()); got != 2 {
+		t.Fatalf("one-sided setter changed source length to %d, want 2", got)
+	}
+	shared.fieldIDs()[0] = 7
+	if got := original.fieldIDs()[0]; got != 7 {
+		t.Fatalf("header COW stopped backing alias: original ID = %d, want 7", got)
+	}
+
+	shared.setFieldSources(shared.fieldSources()[:1])
+	if got := len(original.fieldSources()); got != 2 {
+		t.Fatalf("original source length = %d, want 2", got)
+	}
+	if got := len(shared.fieldIDs()); got != 1 {
+		t.Fatalf("one-sided source setter changed ID length to %d, want 1", got)
+	}
+
+	shared.clearFieldMetadata()
+	if shared.fieldMetadata != nil {
+		t.Fatal("cleared shallow copy still has metadata")
+	}
+	if got := len(original.fieldIDs()); got != 2 {
+		t.Fatalf("clearing shallow copy changed original ID length to %d", got)
+	}
+}
+
+func TestNodeFieldMetadataPreservesIndependentNilAndEmptyHeaders(t *testing.T) {
+	node := Node{}
+	node.setFieldMetadata([]FieldID{}, nil)
+	if node.fieldIDs() == nil || node.fieldSources() != nil {
+		t.Fatalf("initial headers: ids=%v sources=%v, want nonnil-empty/nil", node.fieldIDs(), node.fieldSources())
+	}
+
+	node.setFieldSources([]uint8{})
+	if node.fieldIDs() == nil || node.fieldSources() == nil {
+		t.Fatalf("empty headers: ids=%v sources=%v, want both nonnil", node.fieldIDs(), node.fieldSources())
+	}
+
+	node.setFieldIDs(nil)
+	if node.fieldIDs() != nil || node.fieldSources() == nil {
+		t.Fatalf("one-sided nil: ids=%v sources=%v, want nil/nonnil-empty", node.fieldIDs(), node.fieldSources())
+	}
+
+	arena := newNodeArena(arenaClassIncremental)
+	clone := arena.allocNode()
+	clone.ownerArena = arena
+	cloneNodeFieldMetadataInto(clone, &node, arena)
+	if clone.fieldIDs() != nil || clone.fieldSources() == nil {
+		t.Fatalf("cloned headers: ids=%v sources=%v, want nil/nonnil-empty", clone.fieldIDs(), clone.fieldSources())
+	}
+}
+
+func TestEnsureNodeFieldStorageMixedLengths(t *testing.T) {
+	node := Node{children: make([]*Node, 2)}
+	node.setFieldMetadata(
+		[]FieldID{4, 5},
+		[]uint8{fieldSourceInherited},
+	)
+	before := node.fieldMetadata
+	idsBefore := node.fieldIDs()
+
+	ensureNodeFieldStorage(&node, 2)
+	if node.fieldMetadata == before {
+		t.Fatal("mixed-length repair did not detach the metadata header")
+	}
+	if got := node.fieldIDs(); len(got) != 2 || got[0] != 4 || got[1] != 5 {
+		t.Fatalf("field IDs after repair = %v, want [4 5]", got)
+	}
+	if got := node.fieldSources(); len(got) != 2 || got[0] != fieldSourceInherited || got[1] != fieldSourceNone {
+		t.Fatalf("field sources after repair = %v, want [inherited none]", got)
+	}
+	node.fieldIDs()[0] = 8
+	if got := idsBefore[0]; got != 8 {
+		t.Fatalf("unchanged ID backing stopped aliasing: got %d, want 8", got)
+	}
+
+	before = node.fieldMetadata
+	ensureNodeFieldStorage(&node, 2)
+	if node.fieldMetadata != before {
+		t.Fatal("matching field lengths unexpectedly detached metadata")
+	}
+}
+
+func TestNodeFieldMetadataArenaPointerStableAcrossGrowth(t *testing.T) {
+	arena := newNodeArena(arenaClassIncremental)
+	first := arena.allocNodeFieldMetadata()
+	first.ids = []FieldID{11}
+	first.sources = []uint8{fieldSourceDirect}
+	firstCapacity := len(arena.nodeFieldMetadataSlabs[0].data)
+
+	for i := 0; i < firstCapacity+1; i++ {
+		arena.allocNodeFieldMetadata()
+	}
+	if len(arena.nodeFieldMetadataSlabs) < 2 {
+		t.Fatal("field-metadata arena did not grow to a second slab")
+	}
+	if got := first.ids[0]; got != 11 {
+		t.Fatalf("first sidecar moved or changed after growth: ID = %d", got)
+	}
+	if got := first.sources[0]; got != fieldSourceDirect {
+		t.Fatalf("first sidecar source = %d, want direct", got)
+	}
+}
+
+func TestNodeFieldMetadataArenaResetClearsAndReuses(t *testing.T) {
+	arena := newNodeArena(arenaClassIncremental)
+	first := arena.allocNodeFieldMetadata()
+	first.ids = []FieldID{6}
+	first.sources = []uint8{fieldSourceInherited}
+
+	arena.resetNodeFieldMetadataSlabs()
+	if first.ids != nil || first.sources != nil {
+		t.Fatalf("reset retained stale headers: ids=%v sources=%v", first.ids, first.sources)
+	}
+	reused := arena.allocNodeFieldMetadata()
+	if reused != first {
+		t.Fatal("reset did not reuse the first retained sidecar slot")
+	}
+	if reused.ids != nil || reused.sources != nil {
+		t.Fatal("reused sidecar slot was not zeroed")
+	}
+}
+
+func TestNodeFieldMetadataArenaAccountingAndBudget(t *testing.T) {
+	arena := newNodeArena(arenaClassIncremental)
+	wantBytes := nodeFieldMetadataBytesForCap(defaultNodeFieldMetadataSlabCap(arena.class))
+	before := arena.allocatedBytes
+	arena.setBudget(wantBytes)
+	arena.allocNodeFieldMetadata()
+
+	if got := arena.allocatedBytes - before; got != wantBytes {
+		t.Fatalf("sidecar allocation delta = %d, want %d", got, wantBytes)
+	}
+	if !arena.budgetExhausted() {
+		t.Fatal("sidecar slab growth was not charged to the memory budget")
+	}
+	breakdown := arena.collectArenaBreakdown()
+	if got := breakdown.NodeFieldMetadataBytesAllocated; got != wantBytes {
+		t.Fatalf("sidecar breakdown bytes = %d, want %d", got, wantBytes)
+	}
+	wantTotal := arena.allocatedBytes
+	arena.recomputeAllocatedBytes()
+	if got := arena.allocatedBytes; got != wantTotal {
+		t.Fatalf("recomputed arena bytes = %d, want %d", got, wantTotal)
+	}
+}
+
+func TestNodeFieldMetadataDeepCopySurvivesOriginalRelease(t *testing.T) {
+	sourceArena := acquireNodeArena(arenaClassIncremental)
+	child := newLeafNodeInArena(sourceArena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	ids := sourceArena.allocFieldIDSlice(1)
+	ids[0] = 2
+	sources := sourceArena.allocFieldSourceSlice(1)
+	sources[0] = fieldSourceDirect
+	root := newParentNodeInArenaWithFieldSources(sourceArena, 3, true, []*Node{child}, ids, sources, 0)
+	tree := newTreeWithArenas(root, []byte("x"), testLanguage(), sourceArena, nil)
+
+	copyTree := tree.Copy()
+	copyRoot := copyTree.RootNode()
+	if copyRoot.fieldMetadata == root.fieldMetadata {
+		t.Fatal("deep copy shared field-metadata header")
+	}
+	copyRoot.fieldIDs()[0] = 9
+	copyRoot.fieldSources()[0] = fieldSourceInherited
+	if root.fieldIDs()[0] != 2 || root.fieldSources()[0] != fieldSourceDirect {
+		t.Fatal("deep copy shared field backing with original")
+	}
+
+	tree.Release()
+	if got := copyRoot.fieldIDs()[0]; got != 9 {
+		t.Fatalf("copied field ID after original release = %d, want 9", got)
+	}
+	if got := copyRoot.fieldSources()[0]; got != fieldSourceInherited {
+		t.Fatalf("copied field source after original release = %d, want inherited", got)
+	}
+	copyTree.Release()
+}
+
+func TestNodeFieldMetadataShallowCloneCopiesHeaderOnly(t *testing.T) {
+	sourceArena := newNodeArena(arenaClassIncremental)
+	destinationArena := newNodeArena(arenaClassIncremental)
+	source := sourceArena.allocNode()
+	source.ownerArena = sourceArena
+	ids := sourceArena.allocFieldIDSlice(1)
+	ids[0] = 3
+	sources := sourceArena.allocFieldSourceSlice(1)
+	sources[0] = fieldSourceDirect
+	source.setFieldMetadata(ids, sources)
+
+	clone := cloneNodeInArena(destinationArena, source)
+	if clone.fieldMetadata == source.fieldMetadata {
+		t.Fatal("shallow cross-arena clone shared metadata header")
+	}
+	clone.fieldIDs()[0] = 7
+	if got := source.fieldIDs()[0]; got != 7 {
+		t.Fatalf("shallow cross-arena clone stopped backing alias: got %d, want 7", got)
+	}
+
+	sourceArena.resetNodeFieldMetadataSlabs()
+	if got := clone.fieldIDs()[0]; got != 7 {
+		t.Fatalf("destination header depended on source sidecar slab: got %d, want 7", got)
+	}
+}
+
+func TestNodeFieldMetadataOffsetCloneIsIndependent(t *testing.T) {
+	child := NewLeafNode(1, true, 2, 3, Point{Column: 2}, Point{Column: 3})
+	root := NewParentNode(3, true, []*Node{child}, []FieldID{2}, 0)
+	offset := cloneTreeNodesWithOffset(root, 5, Point{Column: 5})
+
+	if offset.fieldMetadata == root.fieldMetadata {
+		t.Fatal("offset clone shared field-metadata header")
+	}
+	offset.fieldIDs()[0] = 8
+	if got := root.fieldIDs()[0]; got != 2 {
+		t.Fatalf("offset clone shared field backing: original ID = %d", got)
+	}
+	if got := offset.startByte; got != root.startByte+5 {
+		t.Fatalf("offset start byte = %d, want %d", got, root.startByte+5)
+	}
+}

--- a/parser_http_blank_section_test.go
+++ b/parser_http_blank_section_test.go
@@ -61,7 +61,7 @@ func TestNormalizeHTTPDocumentSectionsMergesContentUntilNextSeparator(t *testing
 	commentSection := newParentNodeInArena(arena, 2, true, []*Node{comment}, nil, 0)
 	request := newLeafNodeInArena(arena, 5, true, 10, 16, Point{Row: 2}, Point{Row: 3})
 	requestSection := newParentNodeInArena(arena, 2, true, []*Node{request}, []FieldID{1}, 0)
-	requestSection.fieldSources = []uint8{fieldSourceDirect}
+	requestSection.setFieldSources([]uint8{fieldSourceDirect})
 	secondSep := newLeafNodeInArena(arena, 3, true, 16, 22, Point{Row: 3}, Point{Row: 4})
 	secondSection := newParentNodeInArena(arena, 2, true, []*Node{secondSep}, nil, 0)
 	root := newParentNodeInArena(arena, 1, true, []*Node{firstSection, commentSection, requestSection, secondSection}, nil, 0)
@@ -81,7 +81,7 @@ func TestNormalizeHTTPDocumentSectionsMergesContentUntilNextSeparator(t *testing
 	if got, want := nodeFieldIDAt(merged, 2), FieldID(1); got != want {
 		t.Fatalf("request field ID = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(merged.fieldSources, 2), uint8(fieldSourceDirect); got != want {
+	if got, want := fieldSourceAt(merged.fieldSources(), 2), uint8(fieldSourceDirect); got != want {
 		t.Fatalf("request field source = %d, want %d", got, want)
 	}
 	if got, want := resultChildAt(root, 1), secondSection; got != want {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -4404,7 +4404,7 @@ func nodeTreeHasFieldIDs(n *Node) bool {
 	if n == nil {
 		return false
 	}
-	if len(n.fieldIDs) != 0 {
+	if len(n.fieldIDs()) != 0 {
 		return true
 	}
 	for _, child := range n.children {
@@ -5677,23 +5677,25 @@ func appendFlattenedHiddenChildrenWithFieldScratch(scratch *reduceBuildScratch, 
 	paddingStartByte := n.startByte
 	paddingStartPoint := n.startPoint
 	paddingSource := n
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
 	for i, child := range n.children {
 		spanStart := len(scratch.nodes)
 		appendFlattenedHiddenChildrenWithFieldScratch(scratch, child, symbolMeta, preservedHidden)
 		spanEnd := len(scratch.nodes)
 		paddingStartByte, paddingStartPoint = absorbFlattenedHiddenPaddingScratch(scratch, spanStart, paddingStartByte, paddingStartPoint, paddingSource, nil, symbolMeta)
 		paddingSource = child
-		if i >= len(n.fieldIDs) || n.fieldIDs[i] == 0 || spanStart >= spanEnd {
+		if i >= len(fieldIDs) || fieldIDs[i] == 0 || spanStart >= spanEnd {
 			continue
 		}
 		scratch.ensureFieldStorage()
-		source := fieldSourceAt(n.fieldSources, i)
+		source := fieldSourceAt(fieldSources, i)
 		if source == fieldSourceNone {
 			source = fieldSourceDirect
 		}
-		applyFieldToFlattenedSpan(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, spanStart, spanEnd, n.fieldIDs[i], source, false)
+		applyFieldToFlattenedSpan(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, spanStart, spanEnd, fieldIDs[i], source, false)
 		if source == fieldSourceDirect {
-			scratch.recordRepeatedField(repeatEpoch, n.fieldIDs[i], source)
+			scratch.recordRepeatedField(repeatEpoch, fieldIDs[i], source)
 		}
 	}
 	if scratch.trackFields {
@@ -6239,6 +6241,8 @@ func appendFlattenedHiddenChildrenWithFields(dst []*Node, fieldDst []FieldID, fi
 	nodeStart := out
 	paddingStartByte := n.startByte
 	paddingStartPoint := n.startPoint
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
 	type hiddenFieldSpan struct {
 		count  int
 		source uint8
@@ -6248,20 +6252,20 @@ func appendFlattenedHiddenChildrenWithFields(dst []*Node, fieldDst []FieldID, fi
 		spanStart := out
 		out = appendFlattenedHiddenChildrenWithFields(dst, fieldDst, fieldSrcDst, out, child, symbolMeta, preservedHidden)
 		paddingStartByte, paddingStartPoint = absorbFlattenedHiddenPaddingNodes(dst, spanStart, out, paddingStartByte, paddingStartPoint, child, nil, symbolMeta)
-		if fieldDst != nil && i < len(n.fieldIDs) && n.fieldIDs[i] != 0 {
-			source := fieldSourceAt(n.fieldSources, i)
+		if fieldDst != nil && i < len(fieldIDs) && fieldIDs[i] != 0 {
+			source := fieldSourceAt(fieldSources, i)
 			if source == fieldSourceNone {
 				source = fieldSourceDirect
 			}
-			applyFieldToFlattenedSpan(dst, fieldDst, fieldSrcDst, spanStart, out, n.fieldIDs[i], source, false)
+			applyFieldToFlattenedSpan(dst, fieldDst, fieldSrcDst, spanStart, out, fieldIDs[i], source, false)
 			if source == fieldSourceDirect && spanStart < out {
 				if repeated == nil {
 					repeated = make(map[FieldID]hiddenFieldSpan)
 				}
-				span := repeated[n.fieldIDs[i]]
+				span := repeated[fieldIDs[i]]
 				span.count++
 				span.source = source
-				repeated[n.fieldIDs[i]] = span
+				repeated[fieldIDs[i]] = span
 			}
 		}
 	}
@@ -6562,8 +6566,8 @@ func nodeHasDirectFieldID(n *Node, fid FieldID) bool {
 	if n == nil || fid == 0 {
 		return false
 	}
-	for i := range n.fieldIDs {
-		if n.fieldIDs[i] == fid {
+	for _, fieldID := range n.fieldIDs() {
+		if fieldID == fid {
 			return true
 		}
 	}
@@ -6574,8 +6578,10 @@ func nodeHasAnyDirectField(n *Node) bool {
 	if n == nil {
 		return false
 	}
-	for i := range n.fieldIDs {
-		if n.fieldIDs[i] != 0 && fieldSourceAt(n.fieldSources, i) == fieldSourceDirect {
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
+	for i := range fieldIDs {
+		if fieldIDs[i] != 0 && fieldSourceAt(fieldSources, i) == fieldSourceDirect {
 			return true
 		}
 	}
@@ -7951,6 +7957,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 	if arena == nil {
 		cloned := &Node{}
 		*cloned = *n
+		cloneNodeFieldMetadataHeaderInto(cloned, n, nil)
 		cloned.symbol = alias
 		if lang != nil && int(alias) < len(lang.SymbolMetadata) {
 			cloned.setNamed(lang.SymbolMetadata[alias].Named)
@@ -7960,6 +7967,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 
 	cloned := arena.allocNode()
 	*cloned = *n
+	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
 	cloned.symbol = alias
 	if lang != nil && int(alias) < len(lang.SymbolMetadata) {
 		cloned.setNamed(lang.SymbolMetadata[alias].Named)
@@ -8092,6 +8100,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	if arena == nil {
 		cloned := &Node{}
 		*cloned = *n
+		cloneNodeFieldMetadataHeaderInto(cloned, n, nil)
 		if nodeHasFinalChildRefs(n) {
 			childCount := nodeChildCountNoMaterialize(n)
 			if childCount > 0 {
@@ -8107,6 +8116,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	cloned := arena.allocNode()
 	*cloned = *n
 	cloned.ownerArena = arena
+	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
 	if nodeHasFinalChildRefs(n) {
 		childCount := nodeChildCountNoMaterialize(n)
 		if childCount > 0 {
@@ -8130,8 +8140,7 @@ func materializeHiddenNodeForAlias(arena *nodeArena, lang *Language, n *Node) *N
 	if normalizedCount == 0 {
 		cloned := cloneNodeInArena(arena, n)
 		cloned.children = nil
-		cloned.fieldIDs = nil
-		cloned.fieldSources = nil
+		cloned.clearFieldMetadata()
 		return cloned
 	}
 
@@ -8156,15 +8165,12 @@ func materializeHiddenNodeForAlias(arena *nodeArena, lang *Language, n *Node) *N
 			}
 		}
 		if hasField {
-			cloned.fieldIDs = fieldIDs
-			cloned.fieldSources = fieldSources
+			cloned.setFieldMetadata(fieldIDs, fieldSources)
 		} else {
-			cloned.fieldIDs = nil
-			cloned.fieldSources = nil
+			cloned.clearFieldMetadata()
 		}
 	} else {
-		cloned.fieldIDs = nil
-		cloned.fieldSources = nil
+		cloned.clearFieldMetadata()
 	}
 	return cloned
 }
@@ -8181,7 +8187,7 @@ func hiddenTreeHasFieldIDs(n *Node) bool {
 		return n.flags&nodeFlagFieldIDCacheHasFieldIDs != 0
 	}
 	result := false
-	for _, fid := range n.fieldIDs {
+	for _, fid := range n.fieldIDs() {
 		if fid != 0 {
 			result = true
 			break

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -86,8 +86,8 @@ func TestBuildResultFoldExtrasPreservesFieldMappings(t *testing.T) {
 	if fieldChild != valueChild {
 		t.Fatal("field mapping shifted after folding extras")
 	}
-	if len(root.fieldIDs) != 3 || root.fieldIDs[1] != 1 {
-		t.Fatalf("fieldIDs not re-aligned after folding extras: %#v", root.fieldIDs)
+	if len(root.fieldIDs()) != 3 || root.fieldIDs()[1] != 1 {
+		t.Fatalf("fieldIDs not re-aligned after folding extras: %#v", root.fieldIDs())
 	}
 	if leadingExtra.Parent() != root || trailingExtra.Parent() != root {
 		t.Fatal("extra child parent pointers were not updated during fold")
@@ -158,7 +158,7 @@ func TestBuildReduceChildrenInheritedFieldOverridesInheritedInnerFieldOnFlattene
 	withTok := newLeafNodeInArena(arena, 3, false, 13, 17, Point{Row: 0, Column: 13}, Point{Row: 0, Column: 17})
 	right := newLeafNodeInArena(arena, 2, true, 18, 25, Point{Row: 0, Column: 18}, Point{Row: 0, Column: 25})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{left, withTok, right}, []FieldID{2, 2, 2}, 0)
-	hidden.fieldSources = []uint8{fieldSourceInherited, fieldSourceInherited, fieldSourceInherited}
+	hidden.setFieldSources([]uint8{fieldSourceInherited, fieldSourceInherited, fieldSourceInherited})
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 4, 0, arena)
 	if got, want := len(children), 3; got != want {
@@ -197,7 +197,7 @@ func TestBuildReduceChildrenDirectFieldOverridesSingleIndirectNamedChild(t *test
 	arena := newNodeArena(arenaClassFull)
 	typ := newLeafNodeInArena(arena, 2, true, 0, 9, Point{Row: 0, Column: 0}, Point{Row: 0, Column: 9})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{typ}, []FieldID{2}, 0)
-	hidden.fieldSources = []uint8{fieldSourceInherited}
+	hidden.setFieldSources([]uint8{fieldSourceInherited})
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 4, 0, arena)
 	if got, want := len(children), 1; got != want {
@@ -322,7 +322,7 @@ func TestBuildReduceChildrenDirectFieldPrefersNamedTargetsOnFlattenedSpan(t *tes
 	dot1 := newLeafNodeInArena(arena, 2, false, 8, 9, Point{Row: 0, Column: 8}, Point{Row: 0, Column: 9})
 	url := newLeafNodeInArena(arena, 3, true, 9, 12, Point{Row: 0, Column: 9}, Point{Row: 0, Column: 12})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{dot0, net, dot1, url}, []FieldID{0, 1, 0, 1}, 0)
-	hidden.fieldSources = []uint8{fieldSourceNone, fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	hidden.setFieldSources([]uint8{fieldSourceNone, fieldSourceDirect, fieldSourceNone, fieldSourceDirect})
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 4, 0, arena)
 	if got, want := len(children), 4; got != want {
@@ -373,9 +373,9 @@ func TestBuildReduceChildrenRepeatedDirectFieldOnHiddenPathLeavesAnonymousGapUnf
 	url := newLeafNodeInArena(arena, 3, true, 9, 12, Point{Row: 0, Column: 9}, Point{Row: 0, Column: 12})
 
 	tail := newParentNodeInArena(arena, 1, false, []*Node{net, dot1, url}, []FieldID{1, 0, 1}, 0)
-	tail.fieldSources = []uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	tail.setFieldSources([]uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect})
 	outer := newParentNodeInArena(arena, 1, false, []*Node{java, dot0, tail}, []FieldID{1, 0, 1}, 0)
-	outer.fieldSources = []uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	outer.setFieldSources([]uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect})
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, outer)}, 0, 1, 1, 4, 0, arena)
 	if got, want := len(children), 5; got != want {
@@ -425,7 +425,7 @@ func TestBuildReduceChildrenInheritedFieldYieldsToDirectTargetOnHiddenSpan(t *te
 	retType := newLeafNodeInArena(arena, 6, true, 20, 23, Point{Row: 0, Column: 20}, Point{Row: 0, Column: 23})
 
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{modifiers, defTok, name, colon, retType}, []FieldID{1, 0, 2, 0, 1}, 0)
-	hidden.fieldSources = []uint8{fieldSourceInherited, fieldSourceNone, fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	hidden.setFieldSources([]uint8{fieldSourceInherited, fieldSourceNone, fieldSourceDirect, fieldSourceNone, fieldSourceDirect})
 
 	children := arena.allocNodeSlice(5)
 	fieldIDs := arena.allocFieldIDSlice(5)
@@ -504,7 +504,7 @@ func TestAppendFlattenedHiddenChildrenRepeatedDirectFieldSkipsCommaSeparator(t *
 	comma := newLeafNodeInArena(arena, 3, false, 1, 2, Point{Row: 0, Column: 1}, Point{Row: 0, Column: 2})
 	right := newLeafNodeInArena(arena, 2, true, 3, 4, Point{Row: 0, Column: 3}, Point{Row: 0, Column: 4})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{left, comma, right}, []FieldID{1, 0, 1}, 0)
-	hidden.fieldSources = []uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	hidden.setFieldSources([]uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect})
 
 	children := arena.allocNodeSlice(3)
 	fieldIDs := arena.allocFieldIDSlice(3)
@@ -618,7 +618,7 @@ func TestBuildReduceChildrenInheritedFieldSkipsProjectionWhenFlattenedSpanHasDir
 	name := newLeafNodeInArena(arena, 4, true, 14, 15, Point{Row: 0, Column: 14}, Point{Row: 0, Column: 15})
 	params := newLeafNodeInArena(arena, 5, true, 15, 21, Point{Row: 0, Column: 15}, Point{Row: 0, Column: 21})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{modifier, typ, name, params}, []FieldID{0, 1, 2, 3}, 0)
-	hidden.fieldSources = []uint8{fieldSourceNone, fieldSourceDirect, fieldSourceDirect, fieldSourceDirect}
+	hidden.setFieldSources([]uint8{fieldSourceNone, fieldSourceDirect, fieldSourceDirect, fieldSourceDirect})
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 6, 0, arena)
 	if got, want := len(children), 4; got != want {
@@ -665,7 +665,7 @@ func TestBuildReduceChildrenInheritedFieldSkipsProjectionWhenDescendantHasDirect
 	dot := newLeafNodeInArena(arena, 4, false, 8, 9, Point{Row: 0, Column: 8}, Point{Row: 0, Column: 9})
 	exprName := newLeafNodeInArena(arena, 3, true, 9, 11, Point{Row: 0, Column: 9}, Point{Row: 0, Column: 11})
 	access := newParentNodeInArena(arena, 5, true, []*Node{exprBase, dot, exprName}, []FieldID{2, 0, 3}, 0)
-	access.fieldSources = []uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	access.setFieldSources([]uint8{fieldSourceDirect, fieldSourceNone, fieldSourceDirect})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{joinTok, ident, access}, nil, 0)
 
 	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 6, 0, arena)
@@ -708,7 +708,7 @@ func TestBuildReduceChildrenInheritedFieldProjectsSingleHiddenChildWhenDescendan
 	ident := newLeafNodeInArena(arena, 3, true, 0, 7, Point{Row: 0, Column: 0}, Point{Row: 0, Column: 7})
 	callArgs := newLeafNodeInArena(arena, 4, true, 7, 10, Point{Row: 0, Column: 7}, Point{Row: 0, Column: 10})
 	call := newParentNodeInArena(arena, 2, true, []*Node{ident, callArgs}, []FieldID{1, 0}, 0)
-	call.fieldSources = []uint8{fieldSourceDirect, fieldSourceNone}
+	call.setFieldSources([]uint8{fieldSourceDirect, fieldSourceNone})
 	outerArgs := newLeafNodeInArena(arena, 4, true, 10, 13, Point{Row: 0, Column: 10}, Point{Row: 0, Column: 13})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{call, outerArgs}, nil, 0)
 
@@ -810,7 +810,7 @@ func TestBuildReduceChildrenCarriesHiddenChildFieldsThroughFieldlessParent(t *te
 	arena := newNodeArena(arenaClassFull)
 	fn := newLeafNodeInArena(arena, 3, true, 0, 8, Point{Row: 0, Column: 0}, Point{Row: 0, Column: 8})
 	inner := newParentNodeInArena(arena, 1, false, []*Node{fn}, []FieldID{1}, 0)
-	inner.fieldSources = []uint8{fieldSourceDirect}
+	inner.setFieldSources([]uint8{fieldSourceDirect})
 	outer := newParentNodeInArena(arena, 2, false, []*Node{inner}, nil, 0)
 
 	children, fieldIDs, fieldSources := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, outer)}, 0, 1, 1, 4, 0, arena)
@@ -880,7 +880,7 @@ func TestBuildReduceChildrenDirectFieldWinsOverInheritedEntriesOnSameChild(t *te
 	params := newLeafNodeInArena(arena, 3, true, 1, 3, Point{Row: 0, Column: 1}, Point{Row: 0, Column: 3})
 	body := newLeafNodeInArena(arena, 4, true, 4, 7, Point{Row: 0, Column: 4}, Point{Row: 0, Column: 7})
 	decl := newParentNodeInArena(arena, 1, true, []*Node{name, params, body}, []FieldID{3, 4, 1}, 0)
-	decl.fieldSources = []uint8{fieldSourceDirect, fieldSourceDirect, fieldSourceDirect}
+	decl.setFieldSources([]uint8{fieldSourceDirect, fieldSourceDirect, fieldSourceDirect})
 
 	children, fieldIDs, fieldSources := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, decl)}, 0, 1, 1, 5, 0, arena)
 	if got, want := len(children), 1; got != want {
@@ -963,7 +963,7 @@ func TestBuildReduceChildrenDartHiddenConstructorParamDoesNotReceiveNameField(t 
 	name := newLeafNodeInArena(arena, 6, true, 5, 6, Point{Column: 5}, Point{Column: 6})
 	constructorParam := newParentNodeInArena(arena, 3, true, []*Node{thisLeaf, dot, name}, nil, 0)
 	hidden := newParentNodeInArena(arena, 2, false, []*Node{constructorParam}, []FieldID{1}, 0)
-	hidden.fieldSources = []uint8{fieldSourceDirect}
+	hidden.setFieldSources([]uint8{fieldSourceDirect})
 
 	children, fieldIDs, fieldSources := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 1, 0, arena)
 	if got, want := len(children), 1; got != want {
@@ -1557,10 +1557,10 @@ func TestFieldIDsAlignAfterExtrasFold(t *testing.T) {
 	root.children = merged
 
 	// Pad fieldIDs to match: extras get 0.
-	if len(root.fieldIDs) > 0 {
-		padded := make([]FieldID, leadingCount+len(root.fieldIDs))
-		copy(padded[leadingCount:], root.fieldIDs)
-		root.fieldIDs = padded
+	if len(root.fieldIDs()) > 0 {
+		padded := make([]FieldID, leadingCount+len(root.fieldIDs()))
+		copy(padded[leadingCount:], root.fieldIDs())
+		root.setFieldIDs(padded)
 	}
 
 	// Verify field lookups still return correct nodes.

--- a/parser_result_authzed.go
+++ b/parser_result_authzed.go
@@ -56,8 +56,7 @@ func normalizeAuthzedCleanRootShape(root *Node, source []byte, lang *Language) {
 		}
 	}
 	root.children = cloneNodeSliceInArena(root.ownerArena, out)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	root.setHasError(false)
 	root.startByte = 0
@@ -227,8 +226,7 @@ func normalizeAuthzedUnclosedCaveatRecovery(root *Node, source []byte, lang *Lan
 	root.setExtra(false)
 	root.setMissing(false)
 	root.children = cloneNodeSliceInArena(arena, rootChildren)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	root.setHasError(true)
 	root.startByte = 0
@@ -311,8 +309,7 @@ func normalizeAuthzedMissingPermissionExpression(root *Node, source []byte, lang
 	root.setExtra(false)
 	root.setMissing(false)
 	root.children = cloneNodeSliceInArena(arena, rootChildren)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	root.setHasError(true)
 	root.startByte = 0
@@ -451,8 +448,7 @@ func normalizeAuthzedStrayCaveatTailRecovery(root *Node, source []byte, lang *La
 	root.setExtra(false)
 	root.setMissing(false)
 	root.children = cloneNodeSliceInArena(arena, rootChildren)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	root.setHasError(true)
 	root.startByte = 0
@@ -600,8 +596,7 @@ func normalizeAuthzedObjectCaveatRecovery(root *Node, source []byte, lang *Langu
 	root.setExtra(false)
 	root.setMissing(false)
 	root.children = cloneNodeSliceInArena(arena, rootChildren)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	root.setHasError(true)
 	root.startByte = 0
@@ -707,8 +702,7 @@ func normalizeAuthzedSingleQuotedCaveatRecovery(root *Node, source []byte, lang 
 	root.setExtra(false)
 	root.setMissing(false)
 	root.children = cloneNodeSliceInArena(arena, rootChildren)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	root.setHasError(true)
 	root.startByte = 0
@@ -820,8 +814,7 @@ func authzedRebuildSingleQuotedCaveatBlock(caveat *Node, source []byte, lang *La
 	}
 
 	block.children = cloneNodeSliceInArena(arena, []*Node{lbrace, newStmt, errNode, newline, rbrace})
-	block.fieldIDs = nil
-	block.fieldSources = nil
+	block.clearFieldMetadata()
 	populateParentNode(block, block.children)
 	block.setHasError(true)
 	caveat.setHasError(true)
@@ -997,8 +990,7 @@ func authzedNormalizeMalformedDefinitionErrorChild(root *Node, source []byte, la
 		return
 	}
 	errNode.children = cloneNodeSliceInArena(errNode.ownerArena, children)
-	errNode.fieldIDs = nil
-	errNode.fieldSources = nil
+	errNode.clearFieldMetadata()
 	populateParentNode(errNode, errNode.children)
 	errNode.startByte = 0
 	errNode.endByte = uint32(len(source))
@@ -1060,8 +1052,7 @@ func authzedCollapseToSourceFileError(root *Node, source []byte, lang *Language,
 	root.startPoint = Point{}
 	root.endPoint = errNode.endPoint
 	root.children = cloneNodeSliceInArena(arena, []*Node{errNode})
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 }
 
@@ -1090,8 +1081,7 @@ func authzedCollapseToSourceFileWithLeadingError(root *Node, source []byte, lang
 	root.startPoint = Point{}
 	root.endPoint = advancePointByBytes(Point{}, source)
 	root.children = cloneNodeSliceInArena(arena, rootChildren)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 }
 

--- a/parser_result_awk.go
+++ b/parser_result_awk.go
@@ -1167,8 +1167,8 @@ func awkSetStringConcatFields(n *Node, lang *Language) {
 	if n == nil || lang == nil || n.Type(lang) != "string_concat" || len(n.children) == 0 {
 		return
 	}
-	n.fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, awkStringConcatFields(lang, len(n.children)))
-	n.fieldSources = defaultFieldSourcesInArena(n.ownerArena, n.fieldIDs)
+	fieldIDs := cloneFieldIDSliceInArena(n.ownerArena, awkStringConcatFields(lang, len(n.children)))
+	n.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(n.ownerArena, fieldIDs))
 }
 
 func awkLeftmostConcatOperand(n *Node, lang *Language) *Node {

--- a/parser_result_awk_test.go
+++ b/parser_result_awk_test.go
@@ -74,11 +74,11 @@ func TestAwkRecoveredShellQuoteRedirectMatchesCShape(t *testing.T) {
 	if innerAssignment.Child(1).Type(lang) != "ERROR" || !innerAssignment.Child(1).IsExtra() {
 		t.Fatalf("assignment child[1] = %q extra:%v, want extra ERROR", innerAssignment.Child(1).Type(lang), innerAssignment.Child(1).IsExtra())
 	}
-	if got.fieldIDs[0] != FieldID(1) || got.fieldIDs[2] != FieldID(2) || got.fieldIDs[3] != FieldID(3) {
-		t.Fatalf("outer fields = %#v, want left/operator/right at 0/2/3", got.fieldIDs)
+	if got.fieldIDs()[0] != FieldID(1) || got.fieldIDs()[2] != FieldID(2) || got.fieldIDs()[3] != FieldID(3) {
+		t.Fatalf("outer fields = %#v, want left/operator/right at 0/2/3", got.fieldIDs())
 	}
-	if innerAssignment.fieldIDs[2] != 0 {
-		t.Fatalf("assignment '=' field = %d, want 0", innerAssignment.fieldIDs[2])
+	if innerAssignment.fieldIDs()[2] != 0 {
+		t.Fatalf("assignment '=' field = %d, want 0", innerAssignment.fieldIDs()[2])
 	}
 }
 
@@ -107,11 +107,11 @@ func TestAwkRecoveredShellInRedirectMovesOperatorOutOfError(t *testing.T) {
 	if redirectErr.Type(lang) != "ERROR" || !redirectErr.IsExtra() || redirectErr.Child(0).Type(lang) != ">" {
 		t.Fatalf("child[2] = %q extra:%v inner:%q, want extra ERROR wrapping >", redirectErr.Type(lang), redirectErr.IsExtra(), redirectErr.Child(0).Type(lang))
 	}
-	if got.fieldIDs[1] != FieldID(2) {
-		t.Fatalf("operator field = %d, want 2", got.fieldIDs[1])
+	if got.fieldIDs()[1] != FieldID(2) {
+		t.Fatalf("operator field = %d, want 2", got.fieldIDs()[1])
 	}
-	if got.fieldIDs[2] != 0 {
-		t.Fatalf("redirect ERROR field = %d, want 0", got.fieldIDs[2])
+	if got.fieldIDs()[2] != 0 {
+		t.Fatalf("redirect ERROR field = %d, want 0", got.fieldIDs()[2])
 	}
 }
 

--- a/parser_result_bash.go
+++ b/parser_result_bash.go
@@ -39,8 +39,7 @@ func normalizeBashVariableAssignmentsInNode(node *Node, lang *Language) {
 		out = buf
 	}
 	node.children = out
-	node.fieldIDs = nil
-	node.fieldSources = nil
+	node.clearFieldMetadata()
 	assignBashIfConditionField(node, lang)
 }
 
@@ -218,8 +217,7 @@ func rewriteBashGeneratedCommandAssignment(node *Node, source []byte, lang *Lang
 	node.symbol = ctx.variableAssignmentSym
 	node.setNamed(true)
 	node.children = children
-	node.fieldIDs = bashGeneratedAssignmentFieldIDs(arena, ctx)
-	node.fieldSources = bashGeneratedAssignmentFieldSources(ctx)
+	node.setFieldMetadata(bashGeneratedAssignmentFieldIDs(arena, ctx), bashGeneratedAssignmentFieldSources(ctx))
 	node.setHasError(false)
 	populateParentNode(node, children)
 	return true
@@ -341,11 +339,13 @@ func assignBashIfConditionField(node *Node, lang *Language) {
 	if thenIndex < 0 {
 		thenIndex = len(node.children)
 	}
+	fieldIDs := node.fieldIDs()
+	fieldSources := node.fieldSources()
 	for i := 1; i < thenIndex; i++ {
 		if node.children[i] == nil {
 			continue
 		}
-		node.fieldIDs[i] = fid
-		node.fieldSources[i] = fieldSourceDirect
+		fieldIDs[i] = fid
+		fieldSources[i] = fieldSourceDirect
 	}
 }

--- a/parser_result_bash_perl_test.go
+++ b/parser_result_bash_perl_test.go
@@ -61,10 +61,10 @@ func TestNormalizeBashGeneratedCommandAssignmentsRewritesAssignmentShapedCommand
 	if got, want := value.children[2].Text(source), ".zip"; got != want {
 		t.Fatalf("value suffix = %q, want %q", got, want)
 	}
-	if got, want := command.fieldIDs[0], FieldID(1); got != want {
+	if got, want := command.fieldIDs()[0], FieldID(1); got != want {
 		t.Fatalf("name field = %d, want %d", got, want)
 	}
-	if got, want := command.fieldIDs[1], FieldID(2); got != want {
+	if got, want := command.fieldIDs()[1], FieldID(2); got != want {
 		t.Fatalf("value field = %d, want %d", got, want)
 	}
 }
@@ -166,11 +166,11 @@ func TestNormalizeBashProgramVariableAssignmentsAssignsIfConditionField(t *testi
 
 	normalizeBashProgramVariableAssignments(root, lang)
 
-	if got, want := ifStmt.fieldIDs[1], FieldID(1); got != want {
-		t.Fatalf("ifStmt.fieldIDs[1] = %d, want %d", got, want)
+	if got, want := ifStmt.fieldIDs()[1], FieldID(1); got != want {
+		t.Fatalf("ifStmt.fieldIDs()[1] = %d, want %d", got, want)
 	}
-	if got, want := ifStmt.fieldSources[1], fieldSourceDirect; got != want {
-		t.Fatalf("ifStmt.fieldSources[1] = %v, want %v", got, want)
+	if got, want := ifStmt.fieldSources()[1], fieldSourceDirect; got != want {
+		t.Fatalf("ifStmt.fieldSources()[1] = %v, want %v", got, want)
 	}
 }
 
@@ -202,11 +202,11 @@ func TestNormalizeBashProgramVariableAssignmentsExtendsIfConditionFieldToThenBou
 
 	normalizeBashProgramVariableAssignments(root, lang)
 
-	if got, want := ifStmt.fieldIDs[1], FieldID(1); got != want {
-		t.Fatalf("ifStmt.fieldIDs[1] = %d, want %d", got, want)
+	if got, want := ifStmt.fieldIDs()[1], FieldID(1); got != want {
+		t.Fatalf("ifStmt.fieldIDs()[1] = %d, want %d", got, want)
 	}
-	if got, want := ifStmt.fieldIDs[2], FieldID(1); got != want {
-		t.Fatalf("ifStmt.fieldIDs[2] = %d, want %d", got, want)
+	if got, want := ifStmt.fieldIDs()[2], FieldID(1); got != want {
+		t.Fatalf("ifStmt.fieldIDs()[2] = %d, want %d", got, want)
 	}
 }
 

--- a/parser_result_c.go
+++ b/parser_result_c.go
@@ -968,16 +968,18 @@ func normalizeCWhitespaceSeparatedFunctionMacro(node *Node, source []byte, lang 
 	node.setNamed(symbolIsNamed(lang, preprocDefSym))
 	node.children = children
 	ensureNodeFieldStorage(node, len(children))
-	for i := range node.fieldIDs {
-		node.fieldIDs[i] = 0
+	fieldIDs := node.fieldIDs()
+	fieldSources := node.fieldSources()
+	for i := range fieldIDs {
+		fieldIDs[i] = 0
 	}
-	for i := range node.fieldSources {
-		node.fieldSources[i] = fieldSourceNone
+	for i := range fieldSources {
+		fieldSources[i] = fieldSourceNone
 	}
-	node.fieldIDs[1] = nameFieldID
-	node.fieldIDs[2] = valueFieldID
-	node.fieldSources[1] = fieldSourceDirect
-	node.fieldSources[2] = fieldSourceDirect
+	fieldIDs[1] = nameFieldID
+	fieldIDs[2] = valueFieldID
+	fieldSources[1] = fieldSourceDirect
+	fieldSources[2] = fieldSourceDirect
 	populateParentNode(node, node.children)
 	return true
 }
@@ -1181,8 +1183,8 @@ func normalizeCSizeofUnknownTypeIdentifiers(root *Node, source []byte, lang *Lan
 						replaceChildRangeWithSingleNode(n, 1, 4, paren)
 						if hasValueField && len(n.children) > 1 {
 							ensureNodeFieldStorage(n, len(n.children))
-							n.fieldIDs[1] = valueFieldID
-							n.fieldSources[1] = fieldSourceDirect
+							n.fieldIDs()[1] = valueFieldID
+							n.fieldSources()[1] = fieldSourceDirect
 						}
 					}
 				}
@@ -1430,13 +1432,13 @@ func setCRewriteChildren(n *Node, symbol Symbol, named bool, children []*Node, f
 	n.symbol = symbol
 	n.setNamed(named)
 	n.children = children
-	n.fieldIDs = fieldIDs
-	n.fieldSources = make([]uint8, len(children))
+	fieldSources := make([]uint8, len(children))
 	for _, idx := range directFieldIndexes {
-		if idx >= 0 && idx < len(n.fieldSources) {
-			n.fieldSources[idx] = fieldSourceDirect
+		if idx >= 0 && idx < len(fieldSources) {
+			fieldSources[idx] = fieldSourceDirect
 		}
 	}
+	n.setFieldMetadata(fieldIDs, fieldSources)
 	n.productionID = 0
 	populateParentNode(n, n.children)
 }

--- a/parser_result_c_test.go
+++ b/parser_result_c_test.go
@@ -28,19 +28,19 @@ func TestNormalizeCPointerAssignmentPrecedence(t *testing.T) {
 
 	assign := newParentNodeInArena(arena, 2, true, []*Node{ident, opAssign, number}, nil, 0)
 	ensureNodeFieldStorage(assign, 3)
-	assign.fieldIDs[0] = 1
-	assign.fieldIDs[1] = 2
-	assign.fieldIDs[2] = 3
-	assign.fieldSources[0] = fieldSourceDirect
-	assign.fieldSources[1] = fieldSourceDirect
-	assign.fieldSources[2] = fieldSourceDirect
+	assign.fieldIDs()[0] = 1
+	assign.fieldIDs()[1] = 2
+	assign.fieldIDs()[2] = 3
+	assign.fieldSources()[0] = fieldSourceDirect
+	assign.fieldSources()[1] = fieldSourceDirect
+	assign.fieldSources()[2] = fieldSourceDirect
 
 	ptr := newParentNodeInArena(arena, 3, true, []*Node{opStar, assign}, nil, 0)
 	ensureNodeFieldStorage(ptr, 2)
-	ptr.fieldIDs[0] = 2
-	ptr.fieldIDs[1] = 4
-	ptr.fieldSources[0] = fieldSourceDirect
-	ptr.fieldSources[1] = fieldSourceDirect
+	ptr.fieldIDs()[0] = 2
+	ptr.fieldIDs()[1] = 4
+	ptr.fieldSources()[0] = fieldSourceDirect
+	ptr.fieldSources()[1] = fieldSourceDirect
 
 	root := newParentNodeInArena(arena, 1, true, []*Node{ptr}, nil, 0)
 
@@ -103,19 +103,19 @@ func TestNormalizeCPointerCompoundAssignmentPrecedence(t *testing.T) {
 
 	assign := newParentNodeInArena(arena, 2, true, []*Node{ident, opAssign, number}, nil, 0)
 	ensureNodeFieldStorage(assign, 3)
-	assign.fieldIDs[0] = 1
-	assign.fieldIDs[1] = 2
-	assign.fieldIDs[2] = 3
-	assign.fieldSources[0] = fieldSourceDirect
-	assign.fieldSources[1] = fieldSourceDirect
-	assign.fieldSources[2] = fieldSourceDirect
+	assign.fieldIDs()[0] = 1
+	assign.fieldIDs()[1] = 2
+	assign.fieldIDs()[2] = 3
+	assign.fieldSources()[0] = fieldSourceDirect
+	assign.fieldSources()[1] = fieldSourceDirect
+	assign.fieldSources()[2] = fieldSourceDirect
 
 	ptr := newParentNodeInArena(arena, 3, true, []*Node{opStar, assign}, nil, 0)
 	ensureNodeFieldStorage(ptr, 2)
-	ptr.fieldIDs[0] = 2
-	ptr.fieldIDs[1] = 4
-	ptr.fieldSources[0] = fieldSourceDirect
-	ptr.fieldSources[1] = fieldSourceDirect
+	ptr.fieldIDs()[0] = 2
+	ptr.fieldIDs()[1] = 4
+	ptr.fieldSources()[0] = fieldSourceDirect
+	ptr.fieldSources()[1] = fieldSourceDirect
 
 	root := newParentNodeInArena(arena, 1, true, []*Node{ptr}, nil, 0)
 

--- a/parser_result_collapsed_text.go
+++ b/parser_result_collapsed_text.go
@@ -23,7 +23,6 @@ func normalizeCollapsedTextToken(n *Node, source []byte, lang *Language, accept 
 	child.parent = n
 	child.childIndex = 0
 	n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{child})
-	n.fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, []FieldID{0})
-	n.fieldSources = nil
+	n.setFieldMetadata(cloneFieldIDSliceInArena(n.ownerArena, []FieldID{0}), nil)
 	return true
 }

--- a/parser_result_cpon.go
+++ b/parser_result_cpon.go
@@ -48,8 +48,7 @@ func normalizeCPONNullLeafChildren(root *Node, source []byte, lang *Language) {
 			return
 		}
 		n.children = nil
-		n.fieldIDs = nil
-		n.fieldSources = nil
+		n.clearFieldMetadata()
 		if n.ownerArena != nil {
 			n.ownerArena.clearFinalChildRefs(n)
 		}

--- a/parser_result_cpp.go
+++ b/parser_result_cpp.go
@@ -187,8 +187,7 @@ func cppRetagLeaf(n *Node, sym Symbol, named bool) {
 	n.symbol = sym
 	n.setNamed(named)
 	n.children = nil
-	n.fieldIDs = nil
-	n.fieldSources = nil
+	n.clearFieldMetadata()
 	n.setExtra(false)
 	n.setHasError(false)
 }
@@ -211,8 +210,7 @@ func cppNewParent(arena *nodeArena, sym Symbol, named bool, children []*Node) *N
 func cppCloneParentWithChildren(arena *nodeArena, template *Node, children []*Node) *Node {
 	n := cloneNodeInArena(arena, template)
 	n.children = cloneNodeSliceInArena(arena, children)
-	n.fieldIDs = nil
-	n.fieldSources = nil
+	n.clearFieldMetadata()
 	n.setExtra(false)
 	n.setHasError(false)
 	populateParentNode(n, n.children)

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -161,15 +161,15 @@ func normalizeCSharpSurfaceCompatibility(root *Node, source []byte, lang *Langua
 			}
 			return
 		}
-		if hasLambda && hasIdentifier && hasModifier && n.symbol == lambdaSym && childCount > 0 && len(n.fieldIDs) > 0 {
+		if hasLambda && hasIdentifier && hasModifier && n.symbol == lambdaSym && childCount > 0 && len(n.fieldIDs()) > 0 {
 			first := resultChildAt(n, 0)
 			if first != nil && first.symbol == identifierSym && resultChildCount(first) == 0 &&
 				first.startByte < first.endByte && int(first.endByte) <= len(source) &&
 				string(source[first.startByte:first.endByte]) == "async" {
 				retagResultRoot(first, modifierSym, modifierNamed)
-				n.fieldIDs[0] = 0
-				if len(n.fieldSources) > 0 {
-					n.fieldSources[0] = fieldSourceNone
+				n.fieldIDs()[0] = 0
+				if len(n.fieldSources()) > 0 {
+					n.fieldSources()[0] = fieldSourceNone
 				}
 			}
 			return
@@ -354,8 +354,7 @@ func csharpRewriteScopedRefVariableDeclaration(decl *Node, source []byte, lang *
 	children := cloneNodeSliceIfArena(decl.ownerArena, []*Node{scopedType, newDeclarator})
 	fields := cloneFieldIDSliceInArena(decl.ownerArena, []FieldID{typeID, 0})
 	decl.children = children
-	decl.fieldIDs = fields
-	decl.fieldSources = defaultFieldSourcesInArena(decl.ownerArena, fields)
+	decl.setFieldMetadata(fields, defaultFieldSourcesInArena(decl.ownerArena, fields))
 	decl.startByte = typeCandidate.startByte
 	decl.endByte = newDeclarator.endByte
 	recomputeNodePointsFromBytes(decl, source)
@@ -529,8 +528,7 @@ func csharpMergeClassGenericBaseList(classNode *Node, lang *Language, genericNam
 		genericName.setHasError(false)
 		baseChildren := cloneNodeSliceIfArena(classNode.ownerArena, []*Node{colon, genericName})
 		baseList.children = baseChildren
-		baseList.fieldIDs = nil
-		baseList.fieldSources = nil
+		baseList.clearFieldMetadata()
 		if baseList.ownerArena != nil {
 			baseList.ownerArena.clearFinalChildRefs(baseList)
 		}
@@ -550,8 +548,7 @@ func csharpMergeClassGenericBaseList(classNode *Node, lang *Language, genericNam
 		if classNode.ownerArena != nil {
 			classNode.ownerArena.clearFinalChildRefs(classNode)
 		}
-		classNode.fieldIDs = nil
-		classNode.fieldSources = nil
+		classNode.clearFieldMetadata()
 		classNode.setHasError(false)
 		populateParentNode(classNode, classNode.children)
 		return true
@@ -583,8 +580,7 @@ func csharpUnwrapTypeArgumentListParameters(typeArgs *Node, lang *Language) bool
 		return false
 	}
 	typeArgs.children = cloneNodeSliceIfArena(typeArgs.ownerArena, children)
-	typeArgs.fieldIDs = nil
-	typeArgs.fieldSources = nil
+	typeArgs.clearFieldMetadata()
 	if typeArgs.ownerArena != nil {
 		typeArgs.ownerArena.clearFinalChildRefs(typeArgs)
 	}
@@ -1649,11 +1645,11 @@ func normalizeCSharpTypeConstraintKeywords(root *Node, lang *Language) {
 					n.children[0] = inner
 					inner.parent = n
 					inner.childIndex = 0
-					if len(n.fieldIDs) > 0 {
-						n.fieldIDs[0] = 0
+					if len(n.fieldIDs()) > 0 {
+						n.fieldIDs()[0] = 0
 					}
-					if len(n.fieldSources) > 0 {
-						n.fieldSources[0] = fieldSourceNone
+					if len(n.fieldSources()) > 0 {
+						n.fieldSources()[0] = fieldSourceNone
 					}
 				}
 			}

--- a/parser_result_csharp_attribute.go
+++ b/parser_result_csharp_attribute.go
@@ -520,11 +520,12 @@ func csharpPrependAttributeListsToDeclaration(decl *Node, attributeLists []*Node
 		children = buf
 	}
 	decl.children = children
-	if len(decl.fieldIDs) > 0 {
+	declFieldIDs := decl.fieldIDs()
+	if len(declFieldIDs) > 0 {
 		fieldIDs := make([]FieldID, len(children))
-		copy(fieldIDs[len(attributeLists):], decl.fieldIDs)
-		decl.fieldIDs = cloneFieldIDSliceInArena(arena, fieldIDs)
-		decl.fieldSources = defaultFieldSourcesInArena(arena, decl.fieldIDs)
+		copy(fieldIDs[len(attributeLists):], declFieldIDs)
+		fieldIDs = cloneFieldIDSliceInArena(arena, fieldIDs)
+		decl.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(arena, fieldIDs))
 	}
 	populateParentNode(decl, decl.children)
 	return decl

--- a/parser_result_csharp_expr.go
+++ b/parser_result_csharp_expr.go
@@ -104,8 +104,7 @@ func csharpRestoreConditionalExpressionTokens(n *Node, source []byte, lang *Lang
 	alternativeID, _ := lang.FieldByName("alternative")
 	fieldIDs := cloneFieldIDSliceInArena(n.ownerArena, []FieldID{conditionID, 0, consequenceID, 0, alternativeID})
 	n.children = children
-	n.fieldIDs = fieldIDs
-	n.fieldSources = defaultFieldSourcesInArena(n.ownerArena, fieldIDs)
+	n.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(n.ownerArena, fieldIDs))
 	if n.ownerArena != nil {
 		n.ownerArena.clearFinalChildRefs(n)
 	}
@@ -171,8 +170,7 @@ func csharpRewriteConditionalIsPatternExpression(n *Node, source []byte, lang *L
 	n.symbol = isPatternSym
 	n.setNamed(isPatternNamed)
 	n.children = children
-	n.fieldIDs = fieldIDs
-	n.fieldSources = defaultFieldSourcesInArena(n.ownerArena, fieldIDs)
+	n.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(n.ownerArena, fieldIDs))
 	n.productionID = 0
 	n.setHasError(false)
 	populateParentNode(n, n.children)
@@ -289,8 +287,7 @@ func csharpRewriteLogicalAndCastExpression(n *Node, source []byte, lang *Languag
 	n.symbol = castSym
 	n.setNamed(castNamed)
 	n.children = children
-	n.fieldIDs = fieldIDs
-	n.fieldSources = defaultFieldSourcesInArena(n.ownerArena, fieldIDs)
+	n.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(n.ownerArena, fieldIDs))
 	n.productionID = 0
 	n.setHasError(false)
 	populateParentNode(n, n.children)

--- a/parser_result_csharp_invocation.go
+++ b/parser_result_csharp_invocation.go
@@ -85,7 +85,6 @@ func normalizeCSharpInvocationStatements(root *Node, source []byte, lang *Langua
 					if arguments, ok := csharpBuildArgumentListFromTuplePattern(varDecl.children[0], lang, argumentListSym, argumentListNamed, argumentSym, argumentNamed); ok {
 						invocationFields := cloneFieldIDSliceInArena(n.ownerArena, []FieldID{functionFieldID, argumentsFieldID})
 						invocation := newParentNodeInArena(n.ownerArena, invocationSym, invocationNamed, []*Node{function, arguments}, invocationFields, 0)
-						invocation.fieldSources = defaultFieldSourcesInArena(n.ownerArena, invocationFields)
 						n.symbol = exprStmtSym
 						n.setNamed(exprStmtNamed)
 						replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{invocation, semi}))
@@ -199,8 +198,7 @@ func csharpRewriteImplicitObjectCreationInvocation(n *Node, source []byte, lang 
 	retagResultRoot(newNode, newSym, newNamed)
 	n.symbol = implicitObjectCreationSym
 	n.setNamed(implicitObjectCreationNamed)
-	n.fieldIDs = nil
-	n.fieldSources = nil
+	n.clearFieldMetadata()
 	n.productionID = 0
 	n.setHasError(false)
 	return true
@@ -306,8 +304,7 @@ func csharpRewriteQualifiedNameAsMemberAccess(node *Node, lang *Language, member
 	}
 	node.symbol = memberAccessSym
 	node.setNamed(memberAccessNamed)
-	node.fieldIDs = fieldIDs
-	node.fieldSources = defaultFieldSourcesInArena(node.ownerArena, fieldIDs)
+	node.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(node.ownerArena, fieldIDs))
 	node.productionID = 0
 	node.setHasError(false)
 	populateParentNode(node, node.children)

--- a/parser_result_csharp_lambda.go
+++ b/parser_result_csharp_lambda.go
@@ -51,7 +51,7 @@ func csharpSplitScopedLambdaStatementChildren(block *Node, source []byte, lang *
 	}
 	var rebuilt []*Node
 	var rebuiltFields []FieldID
-	hadFields := len(block.fieldIDs) > 0
+	hadFields := len(block.fieldIDs()) > 0
 	changed := false
 	for i, child := range block.children {
 		replacements, ok := csharpSplitScopedLambdaStatementChild(child, source, lang, block.ownerArena)
@@ -77,11 +77,10 @@ func csharpSplitScopedLambdaStatementChildren(block *Node, source []byte, lang *
 	copy(children, rebuilt)
 	block.children = children
 	if hadFields {
-		block.fieldIDs = cloneFieldIDSliceInArena(block.ownerArena, rebuiltFields)
-		block.fieldSources = defaultFieldSourcesInArena(block.ownerArena, block.fieldIDs)
+		fieldIDs := cloneFieldIDSliceInArena(block.ownerArena, rebuiltFields)
+		block.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(block.ownerArena, fieldIDs))
 	} else {
-		block.fieldIDs = nil
-		block.fieldSources = nil
+		block.clearFieldMetadata()
 	}
 	block.setHasError(false)
 	populateParentNode(block, block.children)
@@ -118,10 +117,11 @@ func csharpSplitScopedLambdaStatementChild(child *Node, source []byte, lang *Lan
 }
 
 func csharpFieldIDAt(n *Node, index int) FieldID {
-	if n == nil || index < 0 || index >= len(n.fieldIDs) {
+	fieldIDs := n.fieldIDs()
+	if index < 0 || index >= len(fieldIDs) {
 		return 0
 	}
-	return n.fieldIDs[index]
+	return fieldIDs[index]
 }
 
 func csharpRecoverScopedLambdaBlock(block *Node, source []byte, p *Parser) (*Node, bool) {

--- a/parser_result_csharp_test.go
+++ b/parser_result_csharp_test.go
@@ -171,7 +171,6 @@ func TestNormalizeCSharpCollapsedLeafChildrenRestoresMatrixBlockers(t *testing.T
 	asyncIdent := newLeafNodeInArena(arena, 8, true, 20, 25, Point{Column: 20}, Point{Column: 25})
 	lambdaFields := cloneFieldIDSliceInArena(arena, []FieldID{1})
 	lambda := newParentNodeInArena(arena, 10, true, []*Node{asyncIdent}, lambdaFields, 0)
-	lambda.fieldSources = defaultFieldSourcesInArena(arena, lambdaFields)
 	stringLiteral := newLeafNodeInArena(arena, 12, true, 27, 30, Point{Column: 27}, Point{Column: 30})
 	argument := newParentNodeInArena(arena, 11, true, []*Node{stringLiteral}, nil, 0)
 	argument.startByte = 27

--- a/parser_result_cycle_guard.go
+++ b/parser_result_cycle_guard.go
@@ -128,11 +128,19 @@ func reportResultTreeSelfCycleStripped(parent, child *Node) {
 func removeResultTreeChildAt(n *Node, children []*Node, idx int) []*Node {
 	oldLen := len(children)
 	n.children = append(children[:idx], children[idx+1:]...)
-	if len(n.fieldIDs) == oldLen {
-		n.fieldIDs = append(n.fieldIDs[:idx], n.fieldIDs[idx+1:]...)
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
+	metadataChanged := false
+	if len(fieldIDs) == oldLen {
+		fieldIDs = append(fieldIDs[:idx], fieldIDs[idx+1:]...)
+		metadataChanged = true
 	}
-	if len(n.fieldSources) == oldLen {
-		n.fieldSources = append(n.fieldSources[:idx], n.fieldSources[idx+1:]...)
+	if len(fieldSources) == oldLen {
+		fieldSources = append(fieldSources[:idx], fieldSources[idx+1:]...)
+		metadataChanged = true
+	}
+	if metadataChanged {
+		n.setFieldMetadata(fieldIDs, fieldSources)
 	}
 	return n.children
 }

--- a/parser_result_cycle_guard_test.go
+++ b/parser_result_cycle_guard_test.go
@@ -37,17 +37,19 @@ func TestStripResultTreeSelfCycles(t *testing.T) {
 	y := &Node{}
 	kept := &Node{}
 	y.children = []*Node{y, kept}
-	y.fieldIDs = []FieldID{1, 2}
-	y.fieldSources = []uint8{fieldSourceDirect, fieldSourceInherited}
+	y.setFieldMetadata(
+		[]FieldID{1, 2},
+		[]uint8{fieldSourceDirect, fieldSourceInherited},
+	)
 	stripResultTreeSelfCycles(y)
 	if len(y.children) != 1 || y.children[0] != kept {
 		t.Fatalf("children after cycle strip = %v, want only kept child", y.children)
 	}
-	if len(y.fieldIDs) != 1 || y.fieldIDs[0] != 2 {
-		t.Fatalf("fieldIDs after cycle strip = %v, want [2]", y.fieldIDs)
+	if len(y.fieldIDs()) != 1 || y.fieldIDs()[0] != 2 {
+		t.Fatalf("fieldIDs after cycle strip = %v, want [2]", y.fieldIDs())
 	}
-	if len(y.fieldSources) != 1 || y.fieldSources[0] != fieldSourceInherited {
-		t.Fatalf("fieldSources after cycle strip = %v, want inherited source", y.fieldSources)
+	if len(y.fieldSources()) != 1 || y.fieldSources()[0] != fieldSourceInherited {
+		t.Fatalf("fieldSources after cycle strip = %v, want inherited source", y.fieldSources())
 	}
 }
 

--- a/parser_result_dart.go
+++ b/parser_result_dart.go
@@ -242,8 +242,7 @@ func rewriteDartNestedComplexTypeArgumentRelationalCall(n *Node, lang *Language)
 		cloneTreeNodesIntoArena(greaterOp, arena),
 		cloneTreeNodesIntoArena(paren, arena),
 	})
-	n.fieldIDs = nil
-	n.fieldSources = nil
+	n.clearFieldMetadata()
 	if n.ownerArena != nil {
 		n.ownerArena.clearFinalChildRefs(n)
 	}
@@ -560,13 +559,13 @@ func normalizeDartConstructorSignatureKinds(root *Node, source []byte, lang *Lan
 					}
 					sig.symbol = constructorSym
 					sig.setNamed(constructorNamed)
-					if len(sig.fieldIDs) != len(sig.children) {
+					if len(sig.fieldIDs()) != len(sig.children) {
 						ensureNodeFieldStorage(sig, len(sig.children))
 					}
-					if parametersID != 0 && len(sig.fieldIDs) > 1 {
-						sig.fieldIDs[1] = parametersID
-						if len(sig.fieldSources) == len(sig.children) {
-							sig.fieldSources[1] = fieldSourceDirect
+					if parametersID != 0 && len(sig.fieldIDs()) > 1 {
+						sig.fieldIDs()[1] = parametersID
+						if len(sig.fieldSources()) == len(sig.children) {
+							sig.fieldSources()[1] = fieldSourceDirect
 						}
 					}
 				}
@@ -612,9 +611,11 @@ func normalizeDartSwitchExpressionBodyFields(root *Node, lang *Language) {
 	walkResultTree(root, func(n *Node) {
 		if n.Type(lang) == "switch_expression" && len(n.children) > 0 {
 			ensureNodeFieldStorage(n, len(n.children))
+			fieldIDs := n.fieldIDs()
+			fieldSources := n.fieldSources()
 			start := -1
 			for i := 0; i < len(n.children); i++ {
-				if n.fieldIDs[i] == bodyID {
+				if fieldIDs[i] == bodyID {
 					start = i
 					break
 				}
@@ -624,9 +625,9 @@ func normalizeDartSwitchExpressionBodyFields(root *Node, lang *Language) {
 					if n.children[i] == nil {
 						continue
 					}
-					n.fieldIDs[i] = bodyID
-					if len(n.fieldSources) == len(n.children) {
-						n.fieldSources[i] = fieldSourceDirect
+					fieldIDs[i] = bodyID
+					if len(fieldSources) == len(n.children) {
+						fieldSources[i] = fieldSourceDirect
 					}
 				}
 			}

--- a/parser_result_eds.go
+++ b/parser_result_eds.go
@@ -27,8 +27,7 @@ func normalizeEDSCompatibility(root *Node, source []byte, lang *Language) {
 	}
 	if changed {
 		root.children = cloneNodeSliceInArena(root.ownerArena, out)
-		root.fieldIDs = nil
-		root.fieldSources = nil
+		root.clearFieldMetadata()
 		populateParentNode(root, root.children)
 		nodeInitEquivVersion(root)
 	}
@@ -37,8 +36,7 @@ func normalizeEDSCompatibility(root *Node, source []byte, lang *Language) {
 	}
 	out = resultChildSliceForMutation(root)
 	root.children = cloneNodeSliceInArena(root.ownerArena, out)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 	nodeInitEquivVersion(root)
 }
@@ -185,8 +183,7 @@ func normalizeEDSErrorLine(errNode *Node, source []byte, eqSym Symbol) bool {
 	errNode.endPoint = advancePointByBytes(errNode.startPoint, source[start:end])
 	errNode.setExtra(true)
 	errNode.children = buildEDSErrorLineChildren(errNode.ownerArena, source, start, end, eqSym)
-	errNode.fieldIDs = nil
-	errNode.fieldSources = nil
+	errNode.clearFieldMetadata()
 	populateParentNode(errNode, errNode.children)
 	nodeInitEquivVersion(errNode)
 	return true

--- a/parser_result_elixir.go
+++ b/parser_result_elixir.go
@@ -184,8 +184,9 @@ func normalizeElixirMapContentBinaryOperators(root *Node, lang *Language) {
 		originalChildren := resultChildSliceForMutation(n)
 		children := cloneNodeSliceInArena(n.ownerArena, originalChildren)
 		var fieldIDs []FieldID
-		if len(n.fieldIDs) == len(originalChildren) {
-			fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, n.fieldIDs)
+		nodeFieldIDs := n.fieldIDs()
+		if len(nodeFieldIDs) == len(originalChildren) {
+			fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, nodeFieldIDs)
 		}
 		wrapper := newParentNodeInArena(n.ownerArena, binaryOperatorSym, binaryOperatorNamed, children, fieldIDs, 0)
 		replaceChildRangeWithNodes(n, 0, 3, []*Node{wrapper})

--- a/parser_result_erlang.go
+++ b/parser_result_erlang.go
@@ -11,13 +11,15 @@ func normalizeErlangSourceFileForms(root *Node, lang *Language) {
 	}
 	view := resultMutableChildrenForMutation(root)
 	ensureNodeFieldStorage(root, view.Len())
+	fieldIDs := root.fieldIDs()
+	fieldSources := root.fieldSources()
 	for i := 0; i < view.Len(); i++ {
 		entry, ok := view.Entry(i)
 		if !ok || stackEntryNodeIsExtra(entry) {
 			continue
 		}
-		root.fieldIDs[i] = formsOnlyID
-		root.fieldSources[i] = fieldSourceDirect
+		fieldIDs[i] = formsOnlyID
+		fieldSources[i] = fieldSourceDirect
 		if stackEntryNodeChildCount(entry) > 0 {
 			normalizeErlangTopLevelFormBounds(view.Child(i))
 		}

--- a/parser_result_forth.go
+++ b/parser_result_forth.go
@@ -41,8 +41,7 @@ func normalizeForthUnterminatedDefinitions(root *Node, lang *Language) {
 		n.setNamed(true)
 		n.setExtra(false)
 		n.children = updated
-		n.fieldIDs = nil
-		n.fieldSources = nil
+		n.clearFieldMetadata()
 		n.setHasError(true)
 		populateParentNode(n, updated)
 	})

--- a/parser_result_haskell.go
+++ b/parser_result_haskell.go
@@ -145,8 +145,7 @@ func normalizeHaskellZeroWidthTokens(root *Node, lang *Language) {
 		return
 	}
 	root.children = cloneNodeSliceInArena(root.ownerArena, filtered)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	populateParentNode(root, root.children)
 }
 
@@ -158,7 +157,9 @@ func normalizeHaskellRootImportField(root *Node, lang *Language) {
 		return
 	}
 	view := resultMutableChildrenForMutation(root)
-	fieldStorageReady := len(root.fieldIDs) == view.Len() && len(root.fieldSources) == view.Len()
+	fieldIDs := root.fieldIDs()
+	fieldSources := root.fieldSources()
+	fieldStorageReady := len(fieldIDs) == view.Len() && len(fieldSources) == view.Len()
 	for i := 0; i < view.Len(); i++ {
 		entry, ok := view.Entry(i)
 		if !ok {
@@ -170,10 +171,12 @@ func normalizeHaskellRootImportField(root *Node, lang *Language) {
 		}
 		if !fieldStorageReady {
 			ensureNodeFieldStorage(root, view.Len())
+			fieldIDs = root.fieldIDs()
+			fieldSources = root.fieldSources()
 			fieldStorageReady = true
 		}
-		root.fieldIDs[i] = fid
-		root.fieldSources[i] = fieldSourceInherited
+		fieldIDs[i] = fid
+		fieldSources[i] = fieldSourceInherited
 	}
 }
 

--- a/parser_result_haskell_test.go
+++ b/parser_result_haskell_test.go
@@ -167,19 +167,19 @@ func TestNormalizeHaskellRootImportFieldSetsImportsField(t *testing.T) {
 
 	normalizeHaskellRootImportField(root, lang)
 
-	if got, want := len(root.fieldIDs), len(root.children); got != want {
-		t.Fatalf("len(root.fieldIDs) = %d, want %d", got, want)
+	if got, want := len(root.fieldIDs()), len(root.children); got != want {
+		t.Fatalf("len(root.fieldIDs()) = %d, want %d", got, want)
 	}
-	if got, want := root.fieldIDs[3], FieldID(1); got != want {
+	if got, want := root.fieldIDs()[3], FieldID(1); got != want {
 		t.Fatalf("fieldIDs[3] = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(root.fieldSources, 3), uint8(fieldSourceInherited); got != want {
+	if got, want := fieldSourceAt(root.fieldSources(), 3), uint8(fieldSourceInherited); got != want {
 		t.Fatalf("fieldSources[3] = %d, want %d", got, want)
 	}
-	if got, want := root.fieldIDs[4], FieldID(2); got != want {
+	if got, want := root.fieldIDs()[4], FieldID(2); got != want {
 		t.Fatalf("fieldIDs[4] = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(root.fieldSources, 4), uint8(fieldSourceInherited); got != want {
+	if got, want := fieldSourceAt(root.fieldSources(), 4), uint8(fieldSourceInherited); got != want {
 		t.Fatalf("fieldSources[4] = %d, want %d", got, want)
 	}
 }
@@ -226,16 +226,16 @@ func TestNormalizeHaskellRootImportFieldSetsFinalRefFieldsWithoutDrain(t *testin
 	if !nodeHasFinalChildRefs(root) {
 		t.Fatal("root lost final-child refs")
 	}
-	if got, want := root.fieldIDs[1], FieldID(1); got != want {
+	if got, want := root.fieldIDs()[1], FieldID(1); got != want {
 		t.Fatalf("fieldIDs[1] = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(root.fieldSources, 1), uint8(fieldSourceInherited); got != want {
+	if got, want := fieldSourceAt(root.fieldSources(), 1), uint8(fieldSourceInherited); got != want {
 		t.Fatalf("fieldSources[1] = %d, want %d", got, want)
 	}
-	if got, want := root.fieldIDs[2], FieldID(2); got != want {
+	if got, want := root.fieldIDs()[2], FieldID(2); got != want {
 		t.Fatalf("fieldIDs[2] = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(root.fieldSources, 2), uint8(fieldSourceInherited); got != want {
+	if got, want := fieldSourceAt(root.fieldSources(), 2), uint8(fieldSourceInherited); got != want {
 		t.Fatalf("fieldSources[2] = %d, want %d", got, want)
 	}
 }

--- a/parser_result_helpers.go
+++ b/parser_result_helpers.go
@@ -165,8 +165,7 @@ func (v resultMutableChildView) FilterFinalRefs(keep func(i int, entry stackEntr
 		return false
 	}
 	v.parent.children = nil
-	v.parent.fieldIDs = nil
-	v.parent.fieldSources = nil
+	v.parent.clearFieldMetadata()
 	if len(kept) == 0 {
 		v.arena.clearFinalChildRefs(v.parent)
 		return true
@@ -215,43 +214,51 @@ func (v resultMutableChildView) ReplaceFinalRefRangeWithNode(start, end int, rep
 	sidecar.childRange = childRange
 	v.parent.children = nil
 
-	if len(v.parent.fieldIDs) == oldLen {
+	parentFieldIDs := v.parent.fieldIDs()
+	parentFieldSources := v.parent.fieldSources()
+	metadataChanged := false
+	if len(parentFieldIDs) == oldLen {
 		fieldIDs := make([]FieldID, 0, newLen)
-		fieldIDs = append(fieldIDs, v.parent.fieldIDs[:start]...)
+		fieldIDs = append(fieldIDs, parentFieldIDs[:start]...)
 		mergedField := FieldID(0)
 		for i := start; i < end; i++ {
-			if v.parent.fieldIDs[i] != 0 {
-				mergedField = v.parent.fieldIDs[i]
+			if parentFieldIDs[i] != 0 {
+				mergedField = parentFieldIDs[i]
 				break
 			}
 		}
 		fieldIDs = append(fieldIDs, mergedField)
-		fieldIDs = append(fieldIDs, v.parent.fieldIDs[end:]...)
+		fieldIDs = append(fieldIDs, parentFieldIDs[end:]...)
 		if v.parent.ownerArena != nil {
 			buf := v.parent.ownerArena.allocFieldIDSlice(len(fieldIDs))
 			copy(buf, fieldIDs)
 			fieldIDs = buf
 		}
-		v.parent.fieldIDs = fieldIDs
+		parentFieldIDs = fieldIDs
+		metadataChanged = true
 	}
-	if len(v.parent.fieldSources) == oldLen {
+	if len(parentFieldSources) == oldLen {
 		fieldSources := make([]uint8, 0, newLen)
-		fieldSources = append(fieldSources, v.parent.fieldSources[:start]...)
+		fieldSources = append(fieldSources, parentFieldSources[:start]...)
 		mergedSource := uint8(fieldSourceNone)
 		for i := start; i < end; i++ {
-			if v.parent.fieldSources[i] != fieldSourceNone {
-				mergedSource = v.parent.fieldSources[i]
+			if parentFieldSources[i] != fieldSourceNone {
+				mergedSource = parentFieldSources[i]
 				break
 			}
 		}
 		fieldSources = append(fieldSources, mergedSource)
-		fieldSources = append(fieldSources, v.parent.fieldSources[end:]...)
+		fieldSources = append(fieldSources, parentFieldSources[end:]...)
 		if v.parent.ownerArena != nil {
 			buf := v.parent.ownerArena.allocFieldSourceSlice(len(fieldSources))
 			copy(buf, fieldSources)
 			fieldSources = buf
 		}
-		v.parent.fieldSources = fieldSources
+		parentFieldSources = fieldSources
+		metadataChanged = true
+	}
+	if metadataChanged {
+		v.parent.setFieldMetadata(parentFieldIDs, parentFieldSources)
 	}
 	if perfCountersEnabled {
 		perfRecordMutationChildRefCopyOnWrite(newLen)
@@ -282,27 +289,35 @@ func (v resultMutableChildView) AppendFinalRefNode(child *Node) bool {
 	sidecar.childRange = childRange
 	v.parent.children = nil
 
-	if len(v.parent.fieldIDs) == oldLen {
+	parentFieldIDs := v.parent.fieldIDs()
+	parentFieldSources := v.parent.fieldSources()
+	metadataChanged := false
+	if len(parentFieldIDs) == oldLen {
 		fieldIDs := make([]FieldID, 0, newLen)
-		fieldIDs = append(fieldIDs, v.parent.fieldIDs...)
+		fieldIDs = append(fieldIDs, parentFieldIDs...)
 		fieldIDs = append(fieldIDs, 0)
 		if v.parent.ownerArena != nil {
 			buf := v.parent.ownerArena.allocFieldIDSlice(len(fieldIDs))
 			copy(buf, fieldIDs)
 			fieldIDs = buf
 		}
-		v.parent.fieldIDs = fieldIDs
+		parentFieldIDs = fieldIDs
+		metadataChanged = true
 	}
-	if len(v.parent.fieldSources) == oldLen {
+	if len(parentFieldSources) == oldLen {
 		fieldSources := make([]uint8, 0, newLen)
-		fieldSources = append(fieldSources, v.parent.fieldSources...)
+		fieldSources = append(fieldSources, parentFieldSources...)
 		fieldSources = append(fieldSources, uint8(fieldSourceNone))
 		if v.parent.ownerArena != nil {
 			buf := v.parent.ownerArena.allocFieldSourceSlice(len(fieldSources))
 			copy(buf, fieldSources)
 			fieldSources = buf
 		}
-		v.parent.fieldSources = fieldSources
+		parentFieldSources = fieldSources
+		metadataChanged = true
+	}
+	if metadataChanged {
+		v.parent.setFieldMetadata(parentFieldIDs, parentFieldSources)
 	}
 	if perfCountersEnabled {
 		perfRecordMutationChildRefCopyOnWrite(newLen)
@@ -377,25 +392,33 @@ func (v resultMutableChildView) SurroundFinalRefs(prefix, suffix []*Node) bool {
 	sidecar.childRange = childRange
 	v.parent.children = nil
 
-	if len(v.parent.fieldIDs) > 0 {
+	parentFieldIDs := v.parent.fieldIDs()
+	parentFieldSources := v.parent.fieldSources()
+	metadataChanged := false
+	if len(parentFieldIDs) > 0 {
 		fieldIDs := make([]FieldID, newLen)
-		copy(fieldIDs[leadingCount:], v.parent.fieldIDs)
+		copy(fieldIDs[leadingCount:], parentFieldIDs)
 		if v.parent.ownerArena != nil {
 			buf := v.parent.ownerArena.allocFieldIDSlice(len(fieldIDs))
 			copy(buf, fieldIDs)
 			fieldIDs = buf
 		}
-		v.parent.fieldIDs = fieldIDs
+		parentFieldIDs = fieldIDs
+		metadataChanged = true
 	}
-	if len(v.parent.fieldSources) > 0 {
+	if len(parentFieldSources) > 0 {
 		fieldSources := make([]uint8, newLen)
-		copy(fieldSources[leadingCount:], v.parent.fieldSources)
+		copy(fieldSources[leadingCount:], parentFieldSources)
 		if v.parent.ownerArena != nil {
 			buf := v.parent.ownerArena.allocFieldSourceSlice(len(fieldSources))
 			copy(buf, fieldSources)
 			fieldSources = buf
 		}
-		v.parent.fieldSources = fieldSources
+		parentFieldSources = fieldSources
+		metadataChanged = true
+	}
+	if metadataChanged {
+		v.parent.setFieldMetadata(parentFieldIDs, parentFieldSources)
 	}
 	if perfCountersEnabled {
 		perfRecordMutationChildRefCopyOnWrite(newLen)

--- a/parser_result_html.go
+++ b/parser_result_html.go
@@ -50,8 +50,7 @@ func normalizeHTMLRecoveredNestedCustomTags(root *Node, lang *Language) {
 	outerChildren = cloneNodeSliceIfArena(root.ownerArena, outerChildren)
 	outer := newParentNodeInArena(root.ownerArena, elementSym, symbolIsNamed(lang, elementSym), outerChildren, nil, 0)
 	root.children = cloneNodeSliceIfArena(root.ownerArena, []*Node{outer})
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	retagResultRoot(root, documentSym, symbolIsNamed(lang, documentSym))
 	root.setHasError(outer.HasError())
 }

--- a/parser_result_http.go
+++ b/parser_result_http.go
@@ -84,8 +84,10 @@ func mergeHTTPSectionIntoPrevious(prev, cur *Node, source []byte) {
 
 	fieldIDs, fieldSources := mergeHTTPSectionFieldMetadata(prev, cur, prevLen, curLen)
 	prev.children = cloneNodeSliceIfArena(prev.ownerArena, merged)
-	prev.fieldIDs = cloneFieldIDSliceInArena(prev.ownerArena, fieldIDs)
-	prev.fieldSources = cloneHTTPFieldSourceSliceInArena(prev.ownerArena, fieldSources)
+	prev.setFieldMetadata(
+		cloneFieldIDSliceInArena(prev.ownerArena, fieldIDs),
+		cloneHTTPFieldSourceSliceInArena(prev.ownerArena, fieldSources),
+	)
 	if prev.ownerArena != nil {
 		prev.ownerArena.clearFinalChildRefs(prev)
 	}
@@ -93,8 +95,10 @@ func mergeHTTPSectionIntoPrevious(prev, cur *Node, source []byte) {
 }
 
 func mergeHTTPSectionFieldMetadata(prev, cur *Node, prevLen, curLen int) ([]FieldID, []uint8) {
-	needFields := len(prev.fieldIDs) == prevLen || len(cur.fieldIDs) == curLen
-	needSources := len(prev.fieldSources) == prevLen || len(cur.fieldSources) == curLen
+	prevFieldIDs, curFieldIDs := prev.fieldIDs(), cur.fieldIDs()
+	prevFieldSources, curFieldSources := prev.fieldSources(), cur.fieldSources()
+	needFields := len(prevFieldIDs) == prevLen || len(curFieldIDs) == curLen
+	needSources := len(prevFieldSources) == prevLen || len(curFieldSources) == curLen
 	total := prevLen + curLen
 	var fieldIDs []FieldID
 	if needFields {
@@ -110,10 +114,10 @@ func mergeHTTPSectionFieldMetadata(prev, cur *Node, prevLen, curLen int) ([]Fiel
 	if needSources {
 		fieldSources = make([]uint8, total)
 		for i := 0; i < prevLen; i++ {
-			fieldSources[i] = fieldSourceAt(prev.fieldSources, i)
+			fieldSources[i] = fieldSourceAt(prevFieldSources, i)
 		}
 		for i := 0; i < curLen; i++ {
-			fieldSources[prevLen+i] = fieldSourceAt(cur.fieldSources, i)
+			fieldSources[prevLen+i] = fieldSourceAt(curFieldSources, i)
 		}
 	}
 	return fieldIDs, fieldSources

--- a/parser_result_hyprlang.go
+++ b/parser_result_hyprlang.go
@@ -59,8 +59,7 @@ func normalizeHyprlangBooleanAssignmentValues(root *Node, source []byte, lang *L
 			child.symbol = booleanSym
 			child.setNamed(true)
 			child.children = cloneNodeSliceInArena(child.ownerArena, []*Node{leaf})
-			child.fieldIDs = nil
-			child.fieldSources = nil
+			child.clearFieldMetadata()
 			if child.ownerArena != nil {
 				child.ownerArena.clearFinalChildRefs(child)
 			}

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -462,25 +462,29 @@ func normalizeJavaScriptTypeScriptStatementKeywordLeafWithSymbolChanged(n *Node,
 	for i := 0; i < childCount; i++ {
 		children = append(children, resultChildAt(n, i))
 	}
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
 	if first != nil && hasCloseBrace && first.symbol == closeBraceSym {
 		children[0] = keywordNode
-		if len(n.fieldIDs) == childCount {
-			n.fieldIDs[0] = 0
+		if len(fieldIDs) == childCount {
+			fieldIDs[0] = 0
 		}
-		if len(n.fieldSources) == childCount {
-			n.fieldSources[0] = fieldSourceNone
+		if len(fieldSources) == childCount {
+			fieldSources[0] = fieldSourceNone
 		}
 	} else if first == nil || first.startByte > n.startByte {
 		children = append([]*Node{keywordNode}, children...)
-		n.fieldIDs = prependFieldID(n.ownerArena, n.fieldIDs, childCount)
-		n.fieldSources = prependFieldSource(n.ownerArena, n.fieldSources, childCount)
+		n.setFieldMetadata(
+			prependFieldID(n.ownerArena, fieldIDs, childCount),
+			prependFieldSource(n.ownerArena, fieldSources, childCount),
+		)
 	} else {
 		children[0] = keywordNode
-		if len(n.fieldIDs) == childCount {
-			n.fieldIDs[0] = 0
+		if len(fieldIDs) == childCount {
+			fieldIDs[0] = 0
 		}
-		if len(n.fieldSources) == childCount {
-			n.fieldSources[0] = fieldSourceNone
+		if len(fieldSources) == childCount {
+			fieldSources[0] = fieldSourceNone
 		}
 	}
 	n.children = cloneNodeSliceInArena(n.ownerArena, children)
@@ -798,11 +802,14 @@ func extractJavaScriptTrailingContinueComment(node *Node, source []byte, lang *L
 		return nil, false
 	}
 	node.children = node.children[:len(node.children)-1]
-	if len(node.fieldIDs) > len(node.children) {
-		node.fieldIDs = node.fieldIDs[:len(node.children)]
-		if len(node.fieldSources) > len(node.children) {
-			node.fieldSources = node.fieldSources[:len(node.children)]
+	fieldIDs := node.fieldIDs()
+	fieldSources := node.fieldSources()
+	if len(fieldIDs) > len(node.children) {
+		fieldIDs = fieldIDs[:len(node.children)]
+		if len(fieldSources) > len(node.children) {
+			fieldSources = fieldSources[:len(node.children)]
 		}
+		node.setFieldMetadata(fieldIDs, fieldSources)
 	}
 	node.endByte = prev.endByte
 	node.endPoint = prev.endPoint
@@ -814,16 +821,19 @@ func insertJavaScriptStatementBlockComment(parent *Node, childIdx int, comment *
 		return
 	}
 	parent.children = append(parent.children[:childIdx+1], append([]*Node{comment}, parent.children[childIdx+1:]...)...)
-	if len(parent.fieldIDs) > 0 {
-		fieldIDs := append([]FieldID(nil), parent.fieldIDs[:childIdx+1]...)
+	parentFieldIDs := parent.fieldIDs()
+	if len(parentFieldIDs) > 0 {
+		fieldIDs := append([]FieldID(nil), parentFieldIDs[:childIdx+1]...)
 		fieldIDs = append(fieldIDs, 0)
-		fieldIDs = append(fieldIDs, parent.fieldIDs[childIdx+1:]...)
-		parent.fieldIDs = fieldIDs
-		if len(parent.fieldSources) > 0 {
-			fieldSources := append([]uint8(nil), parent.fieldSources[:childIdx+1]...)
+		fieldIDs = append(fieldIDs, parentFieldIDs[childIdx+1:]...)
+		parentFieldSources := parent.fieldSources()
+		if len(parentFieldSources) > 0 {
+			fieldSources := append([]uint8(nil), parentFieldSources[:childIdx+1]...)
 			fieldSources = append(fieldSources, fieldSourceNone)
-			fieldSources = append(fieldSources, parent.fieldSources[childIdx+1:]...)
-			parent.fieldSources = fieldSources
+			fieldSources = append(fieldSources, parentFieldSources[childIdx+1:]...)
+			parent.setFieldMetadata(fieldIDs, fieldSources)
+		} else {
+			parent.setFieldIDs(fieldIDs)
 		}
 	}
 	populateParentNode(parent, parent.children)
@@ -1858,12 +1868,12 @@ func rewriteJavaScriptTopLevelObjectLiteral(node *Node, lang *Language, arena *n
 		switch fieldName {
 		case "key":
 			ensureNodeFieldStorage(pair, len(pair.children))
-			pair.fieldIDs[0] = FieldID(fieldIdx)
-			pair.fieldSources[0] = fieldSourceDirect
+			pair.fieldIDs()[0] = FieldID(fieldIdx)
+			pair.fieldSources()[0] = fieldSourceDirect
 		case "value":
 			ensureNodeFieldStorage(pair, len(pair.children))
-			pair.fieldIDs[2] = FieldID(fieldIdx)
-			pair.fieldSources[2] = fieldSourceDirect
+			pair.fieldIDs()[2] = FieldID(fieldIdx)
+			pair.fieldSources()[2] = fieldSourceDirect
 		}
 	}
 	object := newParentNodeInArena(arena, objectSym, objectNamed, []*Node{

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -419,7 +419,7 @@ func TestNormalizeTypeScriptCompatibilityCandidatesApplyIndexedDirectRewrites(t 
 	identifier.endPoint = Point{Column: 4}
 	assignment := newLeafNodeInArena(arena, 14, true, 5, 6, Point{Column: 5}, Point{Column: 6})
 	enumBody := newParentNodeInArena(arena, 13, true, []*Node{assignment}, []FieldID{1}, 0)
-	enumBody.fieldSources = []uint8{fieldSourceDirect}
+	enumBody.setFieldSources([]uint8{fieldSourceDirect})
 	root := newParentNodeInArena(arena, 1, true, []*Node{identifier, enumBody}, nil, 0)
 
 	stats := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang)
@@ -435,10 +435,10 @@ func TestNormalizeTypeScriptCompatibilityCandidatesApplyIndexedDirectRewrites(t 
 	if got := identifier.ChildCount(); got != 0 {
 		t.Fatalf("identifier child count after candidate compatibility = %d, want 0", got)
 	}
-	if got := enumBody.fieldIDs[0]; got != 0 {
+	if got := enumBody.fieldIDs()[0]; got != 0 {
 		t.Fatalf("enum_body fieldIDs[0] = %d, want cleared", got)
 	}
-	if got := enumBody.fieldSources[0]; got != fieldSourceNone {
+	if got := enumBody.fieldSources()[0]; got != fieldSourceNone {
 		t.Fatalf("enum_body fieldSources[0] = %d, want none", got)
 	}
 }

--- a/parser_result_julia.go
+++ b/parser_result_julia.go
@@ -496,8 +496,7 @@ func juliaRewriteReturnRange(ret *Node, source []byte, returnSym, rangeSym, quot
 	expr.symbol = binarySym
 	expr.setNamed(true)
 	expr.children = cloneNodeSliceInArena(expr.ownerArena, []*Node{left, err, innerOp, innerRight})
-	expr.fieldIDs = nil
-	expr.fieldSources = nil
+	expr.clearFieldMetadata()
 	expr.productionID = 0
 	expr.endByte = innerRight.endByte
 	expr.endPoint = innerRight.endPoint
@@ -532,15 +531,13 @@ func juliaRewriteBareReturnRange(ret, expr, left, colon, right *Node, source []b
 	expr.startByte = colon.startByte
 	expr.startPoint = colon.startPoint
 	expr.children = cloneNodeSliceInArena(expr.ownerArena, []*Node{colon, right})
-	expr.fieldIDs = nil
-	expr.fieldSources = nil
+	expr.clearFieldMetadata()
 	expr.productionID = 0
 	expr.setHasError(false)
 	populateParentNode(expr, expr.children)
 
 	ret.children = cloneNodeSliceInArena(ret.ownerArena, []*Node{resultChildAt(ret, 0), err, expr})
-	ret.fieldIDs = nil
-	ret.fieldSources = nil
+	ret.clearFieldMetadata()
 	ret.setHasError(true)
 	populateParentNode(ret, ret.children)
 	return true

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -474,13 +474,14 @@ func normalizeKotlinReceiverFunctionNames(root *Node, source []byte, lang *Langu
 		children = append(children, n.children[:idx+1]...)
 		children = append(children, dotTok, nameTok)
 		children = append(children, n.children[idx+2:]...)
-		if len(n.fieldIDs) == cc {
+		nodeFieldIDs := n.fieldIDs()
+		if len(nodeFieldIDs) == cc {
 			fieldIDs := make([]FieldID, 0, cc+1)
-			fieldIDs = append(fieldIDs, n.fieldIDs[:idx+1]...)
+			fieldIDs = append(fieldIDs, nodeFieldIDs[:idx+1]...)
 			fieldIDs = append(fieldIDs, 0, 0)
-			fieldIDs = append(fieldIDs, n.fieldIDs[idx+2:]...)
-			n.fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, fieldIDs)
-			n.fieldSources = defaultFieldSourcesInArena(n.ownerArena, n.fieldIDs)
+			fieldIDs = append(fieldIDs, nodeFieldIDs[idx+2:]...)
+			fieldIDs = cloneFieldIDSliceInArena(n.ownerArena, fieldIDs)
+			n.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(n.ownerArena, fieldIDs))
 		}
 		n.children = cloneNodeSliceInArena(n.ownerArena, children)
 		populateParentNode(n, n.children)
@@ -545,8 +546,7 @@ func normalizeKotlinCallableReferenceNavigations(root *Node, source []byte, lang
 		n.symbol = crSym
 		n.setNamed(true)
 		n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{base, op, target})
-		n.fieldIDs = nil
-		n.fieldSources = nil
+		n.clearFieldMetadata()
 		n.productionID = 0
 		populateParentNode(n, n.children)
 	})
@@ -650,8 +650,7 @@ func normalizeKotlinRawStringTrailingContent(root *Node, source []byte, lang *La
 		startPoint, endPoint := n.startPoint, n.endPoint
 		children = append(append([]*Node{}, children...), content)
 		n.children = cloneNodeSliceInArena(n.ownerArena, children)
-		n.fieldIDs = nil
-		n.fieldSources = nil
+		n.clearFieldMetadata()
 		populateParentNode(n, n.children)
 		n.startByte, n.endByte = startByte, endByte
 		n.startPoint, n.endPoint = startPoint, endPoint

--- a/parser_result_make.go
+++ b/parser_result_make.go
@@ -12,9 +12,11 @@ func normalizeMakeConditionalConsequenceFields(root *Node, lang *Language) {
 		switch n.Type(lang) {
 		case "conditional", "elsif_directive", "else_directive":
 			ensureNodeFieldStorage(n, len(n.children))
+			fieldIDs := n.fieldIDs()
+			fieldSources := n.fieldSources()
 			start, end := -1, -1
 			for i := 0; i < len(n.children); i++ {
-				if n.fieldIDs[i] != consequenceID {
+				if fieldIDs[i] != consequenceID {
 					continue
 				}
 				if start < 0 {
@@ -34,9 +36,9 @@ func normalizeMakeConditionalConsequenceFields(root *Node, lang *Language) {
 					if n.children[i] == nil {
 						continue
 					}
-					n.fieldIDs[i] = consequenceID
-					if len(n.fieldSources) == len(n.children) {
-						n.fieldSources[i] = fieldSourceDirect
+					fieldIDs[i] = consequenceID
+					if len(fieldSources) == len(n.children) {
+						fieldSources[i] = fieldSourceDirect
 					}
 				}
 			}

--- a/parser_result_make_ini_zig_test.go
+++ b/parser_result_make_ini_zig_test.go
@@ -25,17 +25,17 @@ func TestNormalizeMakeConditionalConsequenceFieldsExtendsAcrossLeadingTabs(t *te
 	elseDir := newLeafNodeInArena(arena, 5, true, 12, 16, Point{Column: 12}, Point{Column: 16})
 	endif := newLeafNodeInArena(arena, 6, false, 16, 21, Point{Column: 16}, Point{Column: 21})
 	root := newParentNodeInArena(arena, 1, true, []*Node{directive, tab, recipe, elseDir, endif}, []FieldID{0, 0, 1, 1, 0}, 0)
-	root.fieldSources = []uint8{0, 0, fieldSourceDirect, fieldSourceDirect, 0}
+	root.setFieldSources([]uint8{0, 0, fieldSourceDirect, fieldSourceDirect, 0})
 
 	normalizeMakeConditionalConsequenceFields(root, lang)
 
-	if got, want := root.fieldIDs[1], FieldID(1); got != want {
+	if got, want := root.fieldIDs()[1], FieldID(1); got != want {
 		t.Fatalf("tab field = %d, want %d", got, want)
 	}
-	if got, want := fieldSourceAt(root.fieldSources, 1), uint8(fieldSourceDirect); got != want {
+	if got, want := fieldSourceAt(root.fieldSources(), 1), uint8(fieldSourceDirect); got != want {
 		t.Fatalf("tab field source = %d, want %d", got, want)
 	}
-	if got := root.fieldIDs[4]; got != 0 {
+	if got := root.fieldIDs()[4]; got != 0 {
 		t.Fatalf("endif field = %d, want 0", got)
 	}
 }
@@ -469,14 +469,14 @@ func TestNormalizeZigEmptyInitListFieldConstantCleared(t *testing.T) {
 	close := newLeafNodeInArena(arena, 5, false, 2, 3, Point{Column: 2}, Point{Column: 3})
 	initList := newParentNodeInArena(arena, 3, true, []*Node{open, close}, nil, 0)
 	parent := newParentNodeInArena(arena, 1, true, []*Node{dot, initList}, []FieldID{0, 1}, 0)
-	parent.fieldSources = []uint8{0, fieldSourceDirect}
+	parent.setFieldSources([]uint8{0, fieldSourceDirect})
 
 	normalizeZigEmptyInitListFields(parent, lang)
 
-	if got := parent.fieldIDs[1]; got != 0 {
+	if got := parent.fieldIDs()[1]; got != 0 {
 		t.Fatalf("fieldIDs[1] = %d, want 0", got)
 	}
-	if got := fieldSourceAt(parent.fieldSources, 1); got != 0 {
+	if got := fieldSourceAt(parent.fieldSources(), 1); got != 0 {
 		t.Fatalf("fieldSources[1] = %d, want 0", got)
 	}
 }
@@ -504,14 +504,14 @@ func TestNormalizeZigDottedInitListFieldConstantCleared(t *testing.T) {
 	close := newLeafNodeInArena(arena, 6, false, 6, 7, Point{Column: 6}, Point{Column: 7})
 	initList := newParentNodeInArena(arena, 3, true, []*Node{open, value, close}, nil, 0)
 	parent := newParentNodeInArena(arena, 1, true, []*Node{dot, initList}, []FieldID{0, 1}, 0)
-	parent.fieldSources = []uint8{0, fieldSourceDirect}
+	parent.setFieldSources([]uint8{0, fieldSourceDirect})
 
 	normalizeZigEmptyInitListFields(parent, lang)
 
-	if got := parent.fieldIDs[1]; got != 0 {
+	if got := parent.fieldIDs()[1]; got != 0 {
 		t.Fatalf("fieldIDs[1] = %d, want 0", got)
 	}
-	if got := fieldSourceAt(parent.fieldSources, 1); got != 0 {
+	if got := fieldSourceAt(parent.fieldSources(), 1); got != 0 {
 		t.Fatalf("fieldSources[1] = %d, want 0", got)
 	}
 }

--- a/parser_result_misc_compat_test.go
+++ b/parser_result_misc_compat_test.go
@@ -506,14 +506,14 @@ func TestNormalizeErlangSourceFileFormsSetsFinalRefFieldsWithoutDrain(t *testing
 	if !nodeHasFinalChildRefs(root) {
 		t.Fatal("root lost final-child refs")
 	}
-	if got, want := root.fieldIDs[0], FieldID(0); got != want {
+	if got, want := root.fieldIDs()[0], FieldID(0); got != want {
 		t.Fatalf("fieldIDs[0] = %d, want %d", got, want)
 	}
 	for _, i := range []int{1, 2} {
-		if got, want := root.fieldIDs[i], FieldID(1); got != want {
+		if got, want := root.fieldIDs()[i], FieldID(1); got != want {
 			t.Fatalf("fieldIDs[%d] = %d, want %d", i, got, want)
 		}
-		if got, want := fieldSourceAt(root.fieldSources, i), uint8(fieldSourceDirect); got != want {
+		if got, want := fieldSourceAt(root.fieldSources(), i), uint8(fieldSourceDirect); got != want {
 			t.Fatalf("fieldSources[%d] = %d, want %d", i, got, want)
 		}
 	}

--- a/parser_result_ninja.go
+++ b/parser_result_ninja.go
@@ -52,8 +52,7 @@ func normalizeNinjaRecoveredMetadataManifest(root *Node, source []byte, lang *La
 	}
 	next := []*Node{first, children[2], last}
 	root.children = cloneNodeSliceInArena(root.ownerArena, next)
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	root.setHasError(true)
 	populateParentNode(root, root.children)
 	nodeInitEquivVersion(root)

--- a/parser_result_node_helpers.go
+++ b/parser_result_node_helpers.go
@@ -4,25 +4,33 @@ func ensureNodeFieldStorage(n *Node, childCount int) {
 	if n == nil || childCount <= 0 {
 		return
 	}
-	if len(n.fieldIDs) != childCount {
-		fieldIDs := make([]FieldID, childCount)
-		copy(fieldIDs, n.fieldIDs)
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
+	changed := false
+	if len(fieldIDs) != childCount {
+		rebuilt := make([]FieldID, childCount)
+		copy(rebuilt, fieldIDs)
 		if n.ownerArena != nil {
 			buf := n.ownerArena.allocFieldIDSlice(childCount)
-			copy(buf, fieldIDs)
-			fieldIDs = buf
+			copy(buf, rebuilt)
+			rebuilt = buf
 		}
-		n.fieldIDs = fieldIDs
+		fieldIDs = rebuilt
+		changed = true
 	}
-	if len(n.fieldSources) != childCount {
-		fieldSources := make([]uint8, childCount)
-		copy(fieldSources, n.fieldSources)
+	if len(fieldSources) != childCount {
+		rebuilt := make([]uint8, childCount)
+		copy(rebuilt, fieldSources)
 		if n.ownerArena != nil {
 			buf := n.ownerArena.allocFieldSourceSlice(childCount)
-			copy(buf, fieldSources)
-			fieldSources = buf
+			copy(buf, rebuilt)
+			rebuilt = buf
 		}
-		n.fieldSources = fieldSources
+		fieldSources = rebuilt
+		changed = true
+	}
+	if changed {
+		n.setFieldMetadata(fieldIDs, fieldSources)
 	}
 }
 
@@ -31,11 +39,13 @@ func setNodeChildField(n *Node, childIndex int, fid FieldID, source uint8, overw
 		return false
 	}
 	ensureNodeFieldStorage(n, len(n.children))
-	if !overwrite && n.fieldIDs[childIndex] != 0 {
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
+	if !overwrite && fieldIDs[childIndex] != 0 {
 		return false
 	}
-	n.fieldIDs[childIndex] = fid
-	n.fieldSources[childIndex] = source
+	fieldIDs[childIndex] = fid
+	fieldSources[childIndex] = source
 	return true
 }
 
@@ -51,11 +61,13 @@ func clearNodeChildField(n *Node, childIndex int) bool {
 	if n == nil || childIndex < 0 || childIndex >= len(n.children) {
 		return false
 	}
-	if len(n.fieldIDs) == len(n.children) {
-		n.fieldIDs[childIndex] = 0
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
+	if len(fieldIDs) == len(n.children) {
+		fieldIDs[childIndex] = 0
 	}
-	if len(n.fieldSources) == len(n.children) {
-		n.fieldSources[childIndex] = fieldSourceNone
+	if len(fieldSources) == len(n.children) {
+		fieldSources[childIndex] = fieldSourceNone
 	}
 	return true
 }
@@ -65,8 +77,7 @@ func replaceNodeChildrenUnfielded(n *Node, children []*Node) {
 		return
 	}
 	n.children = children
-	n.fieldIDs = nil
-	n.fieldSources = nil
+	n.clearFieldMetadata()
 	if n.ownerArena != nil {
 		n.ownerArena.clearFinalChildRefs(n)
 	}
@@ -314,33 +325,41 @@ func replaceChildRangeWithSingleNode(parent *Node, start, end int, replacement *
 	newChildren = append(newChildren, children[end:]...)
 	parent.children = newChildren
 
-	if len(parent.fieldIDs) == oldLen {
+	fieldIDs := parent.fieldIDs()
+	fieldSources := parent.fieldSources()
+	metadataChanged := false
+	if len(fieldIDs) == oldLen {
 		newFieldIDs := make([]FieldID, 0, len(newChildren))
-		newFieldIDs = append(newFieldIDs, parent.fieldIDs[:start]...)
+		newFieldIDs = append(newFieldIDs, fieldIDs[:start]...)
 		mergedField := FieldID(0)
 		for i := start; i < end; i++ {
-			if parent.fieldIDs[i] != 0 {
-				mergedField = parent.fieldIDs[i]
+			if fieldIDs[i] != 0 {
+				mergedField = fieldIDs[i]
 				break
 			}
 		}
 		newFieldIDs = append(newFieldIDs, mergedField)
-		newFieldIDs = append(newFieldIDs, parent.fieldIDs[end:]...)
-		parent.fieldIDs = newFieldIDs
+		newFieldIDs = append(newFieldIDs, fieldIDs[end:]...)
+		fieldIDs = newFieldIDs
+		metadataChanged = true
 	}
-	if len(parent.fieldSources) == oldLen {
+	if len(fieldSources) == oldLen {
 		newFieldSources := make([]uint8, 0, len(newChildren))
-		newFieldSources = append(newFieldSources, parent.fieldSources[:start]...)
+		newFieldSources = append(newFieldSources, fieldSources[:start]...)
 		mergedSource := uint8(fieldSourceNone)
 		for i := start; i < end; i++ {
-			if parent.fieldSources[i] != fieldSourceNone {
-				mergedSource = parent.fieldSources[i]
+			if fieldSources[i] != fieldSourceNone {
+				mergedSource = fieldSources[i]
 				break
 			}
 		}
 		newFieldSources = append(newFieldSources, mergedSource)
-		newFieldSources = append(newFieldSources, parent.fieldSources[end:]...)
-		parent.fieldSources = newFieldSources
+		newFieldSources = append(newFieldSources, fieldSources[end:]...)
+		fieldSources = newFieldSources
+		metadataChanged = true
+	}
+	if metadataChanged {
+		parent.setFieldMetadata(fieldIDs, fieldSources)
 	}
 	for i, child := range parent.children {
 		if child == nil {
@@ -370,23 +389,31 @@ func replaceChildRangeWithNodes(parent *Node, start, end int, replacements []*No
 		parent.ownerArena.clearFinalChildRefs(parent)
 	}
 
-	if len(parent.fieldIDs) == oldLen {
+	fieldIDs := parent.fieldIDs()
+	fieldSources := parent.fieldSources()
+	metadataChanged := false
+	if len(fieldIDs) == oldLen {
 		newFieldIDs := make([]FieldID, 0, len(newChildren))
-		newFieldIDs = append(newFieldIDs, parent.fieldIDs[:start]...)
+		newFieldIDs = append(newFieldIDs, fieldIDs[:start]...)
 		for range replacements {
 			newFieldIDs = append(newFieldIDs, 0)
 		}
-		newFieldIDs = append(newFieldIDs, parent.fieldIDs[end:]...)
-		parent.fieldIDs = newFieldIDs
+		newFieldIDs = append(newFieldIDs, fieldIDs[end:]...)
+		fieldIDs = newFieldIDs
+		metadataChanged = true
 	}
-	if len(parent.fieldSources) == oldLen {
+	if len(fieldSources) == oldLen {
 		newFieldSources := make([]uint8, 0, len(newChildren))
-		newFieldSources = append(newFieldSources, parent.fieldSources[:start]...)
+		newFieldSources = append(newFieldSources, fieldSources[:start]...)
 		for range replacements {
 			newFieldSources = append(newFieldSources, fieldSourceNone)
 		}
-		newFieldSources = append(newFieldSources, parent.fieldSources[end:]...)
-		parent.fieldSources = newFieldSources
+		newFieldSources = append(newFieldSources, fieldSources[end:]...)
+		fieldSources = newFieldSources
+		metadataChanged = true
+	}
+	if metadataChanged {
+		parent.setFieldMetadata(fieldIDs, fieldSources)
 	}
 	populateParentNode(parent, parent.children)
 }

--- a/parser_result_objc.go
+++ b/parser_result_objc.go
@@ -106,8 +106,8 @@ func normalizeObjcSizeofTypeIdentifierOperands(root *Node, lang *Language) {
 		replaceChildRangeWithSingleNode(n, 1, 4, paren)
 		if hasValueField && len(n.children) > 1 {
 			ensureNodeFieldStorage(n, len(n.children))
-			n.fieldIDs[1] = valueFieldID
-			n.fieldSources[1] = fieldSourceDirect
+			n.fieldIDs()[1] = valueFieldID
+			n.fieldSources()[1] = fieldSourceDirect
 		}
 	})
 }

--- a/parser_result_perl.go
+++ b/parser_result_perl.go
@@ -45,22 +45,23 @@ func rewritePerlJoinAssignmentList(arena *nodeArena, assign *Node, source []byte
 		return nil
 	}
 
-	callFieldIDs := append([]FieldID(nil), call.fieldIDs...)
+	callFieldIDs := append([]FieldID(nil), call.fieldIDs()...)
 	if len(callFieldIDs) > 2 {
 		callFieldIDs = callFieldIDs[:2]
 	}
 	rewrittenCall := newParentNodeInArena(arena, call.symbol, call.isNamed(), []*Node{fn, firstArg}, callFieldIDs, call.productionID)
-	if len(call.fieldSources) > 0 {
-		rewrittenCall.fieldSources = append([]uint8(nil), call.fieldSources...)
-		if len(rewrittenCall.fieldSources) > 2 {
-			rewrittenCall.fieldSources = rewrittenCall.fieldSources[:2]
+	if callFieldSources := call.fieldSources(); len(callFieldSources) > 0 {
+		rewrittenCallFieldSources := append([]uint8(nil), callFieldSources...)
+		if len(rewrittenCallFieldSources) > 2 {
+			rewrittenCallFieldSources = rewrittenCallFieldSources[:2]
 		}
+		rewrittenCall.setFieldSources(rewrittenCallFieldSources)
 	}
 
-	assignFieldIDs := append([]FieldID(nil), assign.fieldIDs...)
+	assignFieldIDs := append([]FieldID(nil), assign.fieldIDs()...)
 	rewrittenAssign := newParentNodeInArena(arena, assign.symbol, assign.isNamed(), []*Node{assign.children[0], assign.children[1], rewrittenCall}, assignFieldIDs, assign.productionID)
-	if len(assign.fieldSources) > 0 {
-		rewrittenAssign.fieldSources = append([]uint8(nil), assign.fieldSources...)
+	if assignFieldSources := assign.fieldSources(); len(assignFieldSources) > 0 {
+		rewrittenAssign.setFieldSources(append([]uint8(nil), assignFieldSources...))
 	}
 
 	outerChildren := make([]*Node, 0, len(args.children))
@@ -108,16 +109,17 @@ func rewritePerlPushExpressionList(arena *nodeArena, list *Node, source []byte, 
 	argChildren = append(argChildren, list.children[1:]...)
 	rewrittenArgs := newParentNodeInArena(arena, listSym, listNamed, argChildren, nil, list.productionID)
 
-	callFieldIDs := append([]FieldID(nil), call.fieldIDs...)
+	callFieldIDs := append([]FieldID(nil), call.fieldIDs()...)
 	if len(callFieldIDs) > 2 {
 		callFieldIDs = callFieldIDs[:2]
 	}
 	rewrittenCall := newParentNodeInArena(arena, call.symbol, call.isNamed(), []*Node{fn, rewrittenArgs}, callFieldIDs, call.productionID)
-	if len(call.fieldSources) > 0 {
-		rewrittenCall.fieldSources = append([]uint8(nil), call.fieldSources...)
-		if len(rewrittenCall.fieldSources) > 2 {
-			rewrittenCall.fieldSources = rewrittenCall.fieldSources[:2]
+	if callFieldSources := call.fieldSources(); len(callFieldSources) > 0 {
+		rewrittenCallFieldSources := append([]uint8(nil), callFieldSources...)
+		if len(rewrittenCallFieldSources) > 2 {
+			rewrittenCallFieldSources = rewrittenCallFieldSources[:2]
 		}
+		rewrittenCall.setFieldSources(rewrittenCallFieldSources)
 	}
 	return rewrittenCall
 }
@@ -156,16 +158,17 @@ func rewritePerlReturnExpressionList(arena *nodeArena, ret *Node, lang *Language
 		return nil
 	}
 
-	retFieldIDs := append([]FieldID(nil), ret.fieldIDs...)
+	retFieldIDs := append([]FieldID(nil), ret.fieldIDs()...)
 	if len(retFieldIDs) > 2 {
 		retFieldIDs = retFieldIDs[:2]
 	}
 	rewrittenReturn := newParentNodeInArena(arena, ret.symbol, ret.isNamed(), []*Node{ret.children[0], firstItem}, retFieldIDs, ret.productionID)
-	if len(ret.fieldSources) > 0 {
-		rewrittenReturn.fieldSources = append([]uint8(nil), ret.fieldSources...)
-		if len(rewrittenReturn.fieldSources) > 2 {
-			rewrittenReturn.fieldSources = rewrittenReturn.fieldSources[:2]
+	if retFieldSources := ret.fieldSources(); len(retFieldSources) > 0 {
+		rewrittenReturnFieldSources := append([]uint8(nil), retFieldSources...)
+		if len(rewrittenReturnFieldSources) > 2 {
+			rewrittenReturnFieldSources = rewrittenReturnFieldSources[:2]
 		}
+		rewrittenReturn.setFieldSources(rewrittenReturnFieldSources)
 	}
 
 	outerChildren := make([]*Node, 0, len(list.children))

--- a/parser_result_php.go
+++ b/parser_result_php.go
@@ -66,8 +66,9 @@ func phpAssignmentLeft(n *Node, lang *Language) *Node {
 	}
 	count := resultChildCount(n)
 	children := resultChildSliceForMutation(n)
-	for i := 0; i < count && i < len(n.fieldIDs); i++ {
-		if n.fieldIDs[i] == leftField && i < len(children) {
+	fieldIDs := n.fieldIDs()
+	for i := 0; i < count && i < len(fieldIDs); i++ {
+		if fieldIDs[i] == leftField && i < len(children) {
 			return children[i]
 		}
 	}
@@ -248,8 +249,7 @@ func normalizePHPStaticFunctionFragments(root *Node, source []byte, parser *Pars
 	}
 	out = cloneNodeSliceIfArena(arena, out)
 	root.children = out
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	assignPHPTopLevelFragmentFields(root, lang, arena)
 	populateParentNode(root, out)
 	extendNodeToTrailingWhitespace(root, source)
@@ -755,8 +755,7 @@ func assignPHPTopLevelFragmentFields(root *Node, lang *Language, arena *nodeAren
 		}
 	}
 	if fieldIDs != nil {
-		root.fieldIDs = fieldIDs
-		root.fieldSources = fieldSources
+		root.setFieldMetadata(fieldIDs, fieldSources)
 	}
 }
 

--- a/parser_result_powershell.go
+++ b/parser_result_powershell.go
@@ -165,8 +165,7 @@ func normalizePowerShellProgramShape(root *Node, source []byte, lang *Language) 
 	}
 	children = cloneNodeSliceIfArena(root.ownerArena, children)
 	statementList.children = children
-	statementList.fieldIDs = nil
-	statementList.fieldSources = nil
+	statementList.clearFieldMetadata()
 	statementList.symbol = statementListSym
 	statementList.setNamed(symbolIsNamed(lang, statementListSym))
 	statementList.setHasError(true)
@@ -177,8 +176,7 @@ func normalizePowerShellProgramShape(root *Node, source []byte, lang *Language) 
 	out = append(out, statementList)
 	out = cloneNodeSliceIfArena(root.ownerArena, out)
 	root.children = out
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	retagResultRoot(root, programSym, symbolIsNamed(lang, programSym))
 	root.setHasError(true)
 	extendNodeEndTo(root, statementListEnd, source)
@@ -364,8 +362,7 @@ trimmed:
 		}
 		truncated := cloneNodeInArena(arena, child)
 		truncated.children = nil
-		truncated.fieldIDs = nil
-		truncated.fieldSources = nil
+		truncated.clearFieldMetadata()
 		truncated.endByte = uint32(scriptEnd)
 		truncated.endPoint = advancePointByBytes(truncated.startPoint, source[truncated.startByte:uint32(scriptEnd)])
 		scriptChildren = append(scriptChildren, truncated)
@@ -411,8 +408,8 @@ trimmed:
 					continue
 				}
 				ensureNodeFieldStorage(body, len(body.children))
-				body.fieldIDs[0] = FieldID(fieldIdx)
-				body.fieldSources[0] = fieldSourceDirect
+				body.fieldIDs()[0] = FieldID(fieldIdx)
+				body.fieldSources()[0] = fieldSourceDirect
 				break
 			}
 			structured = append(structured, body)
@@ -436,8 +433,8 @@ trimmed:
 				continue
 			}
 			ensureNodeFieldStorage(scriptBlock, len(scriptBlock.children))
-			scriptBlock.fieldIDs[i] = FieldID(fieldIdx)
-			scriptBlock.fieldSources[i] = fieldSourceDirect
+			scriptBlock.fieldIDs()[i] = FieldID(fieldIdx)
+			scriptBlock.fieldSources()[i] = fieldSourceDirect
 			break
 		}
 		break
@@ -681,13 +678,13 @@ func buildPowerShellRecoveredIfStatement(arena *nodeArena, source []byte, lang *
 		switch fieldName {
 		case "condition":
 			ensureNodeFieldStorage(stmt, len(stmt.children))
-			stmt.fieldIDs[2] = FieldID(fieldIdx)
-			stmt.fieldSources[2] = fieldSourceDirect
+			stmt.fieldIDs()[2] = FieldID(fieldIdx)
+			stmt.fieldSources()[2] = fieldSourceDirect
 		case "else_clause":
 			if len(stmt.children) > 5 && stmt.children[5] != nil && stmt.children[5].Type(lang) == "else_clause" {
 				ensureNodeFieldStorage(stmt, len(stmt.children))
-				stmt.fieldIDs[5] = FieldID(fieldIdx)
-				stmt.fieldSources[5] = fieldSourceDirect
+				stmt.fieldIDs()[5] = FieldID(fieldIdx)
+				stmt.fieldSources()[5] = fieldSourceDirect
 			}
 		}
 	}
@@ -747,8 +744,8 @@ func buildPowerShellRecoveredStatementBlock(arena *nodeArena, source []byte, lan
 				continue
 			}
 			ensureNodeFieldStorage(block, len(block.children))
-			block.fieldIDs[i] = FieldID(fieldIdx)
-			block.fieldSources[i] = fieldSourceDirect
+			block.fieldIDs()[i] = FieldID(fieldIdx)
+			block.fieldSources()[i] = fieldSourceDirect
 			break
 		}
 		break
@@ -1043,8 +1040,8 @@ func buildPowerShellRecoveredAssignmentPipeline(arena *nodeArena, source []byte,
 			continue
 		}
 		ensureNodeFieldStorage(assignExpr, len(assignExpr.children))
-		assignExpr.fieldIDs[2] = FieldID(fieldIdx)
-		assignExpr.fieldSources[2] = fieldSourceDirect
+		assignExpr.fieldIDs()[2] = FieldID(fieldIdx)
+		assignExpr.fieldSources()[2] = fieldSourceDirect
 		break
 	}
 	pipelineChildren := []*Node{assignExpr}

--- a/parser_result_powershell_command.go
+++ b/parser_result_powershell_command.go
@@ -248,13 +248,13 @@ func buildPowerShellPipelineFromLine(arena *nodeArena, source []byte, lang *Lang
 		switch fieldName {
 		case "command_name":
 			ensureNodeFieldStorage(command, len(command.children))
-			command.fieldIDs[0] = FieldID(fieldIdx)
-			command.fieldSources[0] = fieldSourceDirect
+			command.fieldIDs()[0] = FieldID(fieldIdx)
+			command.fieldSources()[0] = fieldSourceDirect
 		case "command_elements":
 			if len(command.children) > 1 {
 				ensureNodeFieldStorage(command, len(command.children))
-				command.fieldIDs[1] = FieldID(fieldIdx)
-				command.fieldSources[1] = fieldSourceDirect
+				command.fieldIDs()[1] = FieldID(fieldIdx)
+				command.fieldSources()[1] = fieldSourceDirect
 			}
 		}
 	}

--- a/parser_result_powershell_expr.go
+++ b/parser_result_powershell_expr.go
@@ -583,8 +583,8 @@ func buildPowerShellArgumentList(arena *nodeArena, source []byte, lang *Language
 			continue
 		}
 		ensureNodeFieldStorage(argList, len(argList.children))
-		argList.fieldIDs[1] = FieldID(fieldIdx)
-		argList.fieldSources[1] = fieldSourceDirect
+		argList.fieldIDs()[1] = FieldID(fieldIdx)
+		argList.fieldSources()[1] = fieldSourceDirect
 		break
 	}
 	return argList

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -1204,8 +1204,7 @@ func foldPythonTrailingSelfCallIntoNestedFunction(fnNode, trailingCall *Node, so
 	}
 
 	bodyClone := cloneNodeInArenaAppendingChildForMutation(body.ownerArena, body, trailingCall)
-	bodyClone.fieldIDs = nil
-	bodyClone.fieldSources = nil
+	bodyClone.clearFieldMetadata()
 
 	fnClone := cloneNodeInArenaReplacingChildForMutation(fnNode.ownerArena, fnNode, bodyIndex, bodyClone)
 	return fnClone, true
@@ -1273,15 +1272,13 @@ func rewriteMalformedPythonPrintStatement(node *Node, source []byte, lang *Langu
 	printLeaf.symbol = printSym
 	printLeaf.setNamed(printNamed)
 	printLeaf.children = nil
-	printLeaf.fieldIDs = nil
-	printLeaf.fieldSources = nil
+	printLeaf.clearFieldMetadata()
 
 	chevron := cloneNodeInArena(node.ownerArena, bin)
 	chevron.symbol = chevronSym
 	chevron.setNamed(chevronNamed)
 	chevron.children = cloneNodeSliceInArena(chevron.ownerArena, []*Node{op, dest})
-	chevron.fieldIDs = nil
-	chevron.fieldSources = nil
+	chevron.clearFieldMetadata()
 	chevron.productionID = 0
 	populateParentNode(chevron, chevron.children)
 
@@ -1292,8 +1289,7 @@ func rewriteMalformedPythonPrintStatement(node *Node, source []byte, lang *Langu
 	rewritten.symbol = printStmtSym
 	rewritten.setNamed(printStmtNamed)
 	rewritten.children = cloneNodeSliceInArena(rewritten.ownerArena, children)
-	rewritten.fieldIDs = nil
-	rewritten.fieldSources = nil
+	rewritten.clearFieldMetadata()
 	rewritten.productionID = 0
 	populateParentNode(rewritten, rewritten.children)
 	return rewritten, true
@@ -1465,8 +1461,7 @@ func repairPythonRootNode(root *Node, arena *nodeArena, lang *Language) *Node {
 		repaired = buf
 	}
 	cloned.children = repaired
-	cloned.fieldIDs = nil
-	cloned.fieldSources = nil
+	cloned.clearFieldMetadata()
 	if pythonModuleChildrenLookComplete(repaired, lang) {
 		cloned.setHasError(false)
 	}
@@ -2046,8 +2041,7 @@ func repairPythonBlock(node *Node, arena *nodeArena, lang *Language, allowHoist 
 		out = buf
 	}
 	cloned.children = out
-	cloned.fieldIDs = nil
-	cloned.fieldSources = nil
+	cloned.clearFieldMetadata()
 	firstNamed := pythonBlockStartAnchor(out, lang)
 	lastSpan := pythonBlockEndAnchor(out)
 	if firstNamed != nil {
@@ -2348,8 +2342,7 @@ func splitPythonOvernestedFunction(node *Node, arena *nodeArena, lang *Language)
 		kept = buf
 	}
 	newBody.children = kept
-	newBody.fieldIDs = nil
-	newBody.fieldSources = nil
+	newBody.clearFieldMetadata()
 	lastKept := kept[len(kept)-1]
 	newBody.endByte = lastKept.endByte
 	newBody.endPoint = lastKept.endPoint

--- a/parser_result_python_test.go
+++ b/parser_result_python_test.go
@@ -89,10 +89,10 @@ func TestBuildResultFromNodesCollapsesPythonTerminalIfSuffix(t *testing.T) {
 	if stmt == nil || stmt.Type(lang) != "if_statement" {
 		t.Fatalf("expected trailing if_statement, got %s", root.SExpr(lang))
 	}
-	if got, want := stmt.fieldIDs[1], FieldID(1); got != want {
+	if got, want := stmt.fieldIDs()[1], FieldID(1); got != want {
 		t.Fatalf("if condition field = %d, want %d", got, want)
 	}
-	if got, want := stmt.fieldIDs[3], FieldID(2); got != want {
+	if got, want := stmt.fieldIDs()[3], FieldID(2); got != want {
 		t.Fatalf("if consequence field = %d, want %d", got, want)
 	}
 }
@@ -174,23 +174,23 @@ func TestBuildResultFromNodesCollapsesPythonTerminalClassAndIfSuffix(t *testing.
 	if classDef == nil || classDef.Type(lang) != "class_definition" {
 		t.Fatalf("expected leading class_definition, got %s", root.SExpr(lang))
 	}
-	if got, want := classDef.fieldIDs[1], FieldID(1); got != want {
+	if got, want := classDef.fieldIDs()[1], FieldID(1); got != want {
 		t.Fatalf("class name field = %d, want %d", got, want)
 	}
-	if got, want := classDef.fieldIDs[2], FieldID(2); got != want {
+	if got, want := classDef.fieldIDs()[2], FieldID(2); got != want {
 		t.Fatalf("class superclasses field = %d, want %d", got, want)
 	}
-	if got, want := classDef.fieldIDs[4], FieldID(3); got != want {
+	if got, want := classDef.fieldIDs()[4], FieldID(3); got != want {
 		t.Fatalf("class body field = %d, want %d", got, want)
 	}
 	stmt := root.NamedChild(1)
 	if stmt == nil || stmt.Type(lang) != "if_statement" {
 		t.Fatalf("expected trailing if_statement, got %s", root.SExpr(lang))
 	}
-	if got, want := stmt.fieldIDs[1], FieldID(4); got != want {
+	if got, want := stmt.fieldIDs()[1], FieldID(4); got != want {
 		t.Fatalf("if condition field = %d, want %d", got, want)
 	}
-	if got, want := stmt.fieldIDs[3], FieldID(5); got != want {
+	if got, want := stmt.fieldIDs()[3], FieldID(5); got != want {
 		t.Fatalf("if consequence field = %d, want %d", got, want)
 	}
 }

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -777,16 +777,18 @@ func foldResultRootExtras(root *Node, extras []*Node, arena *nodeArena) {
 	}
 	root.children = merged
 
-	if len(root.fieldIDs) > 0 {
+	rootFieldIDs := root.fieldIDs()
+	if len(rootFieldIDs) > 0 {
 		trailingCount := len(extras) - leadingCount
-		padded := make([]FieldID, leadingCount+len(root.fieldIDs)+trailingCount)
-		copy(padded[leadingCount:], root.fieldIDs)
-		root.fieldIDs = padded
-		if len(root.fieldSources) > 0 {
-			paddedSources := make([]uint8, len(padded))
-			copy(paddedSources[leadingCount:], root.fieldSources)
-			root.fieldSources = paddedSources
+		padded := make([]FieldID, leadingCount+len(rootFieldIDs)+trailingCount)
+		copy(padded[leadingCount:], rootFieldIDs)
+		paddedSources := root.fieldSources()
+		if len(paddedSources) > 0 {
+			rootFieldSources := paddedSources
+			paddedSources = make([]uint8, len(padded))
+			copy(paddedSources[leadingCount:], rootFieldSources)
 		}
+		root.setFieldMetadata(padded, paddedSources)
 	}
 	extendResultRootRangeToExtras(root, extras)
 }

--- a/parser_result_rust_recovery.go
+++ b/parser_result_rust_recovery.go
@@ -197,8 +197,10 @@ func rustNormalizeDocCommentMarkerField(node *Node, source []byte, lang *Languag
 	if childCount == 0 {
 		return
 	}
-	if len(node.fieldIDs) != childCount {
-		node.fieldIDs = cloneFieldIDSliceInArena(node.ownerArena, make([]FieldID, childCount))
+	fieldIDs := node.fieldIDs()
+	if len(fieldIDs) != childCount {
+		fieldIDs = cloneFieldIDSliceInArena(node.ownerArena, make([]FieldID, childCount))
+		node.setFieldIDs(fieldIDs)
 	}
 	for i := 0; i < childCount; i++ {
 		child := resultChildAt(node, i)
@@ -208,11 +210,11 @@ func rustNormalizeDocCommentMarkerField(node *Node, source []byte, lang *Languag
 		childType := child.Type(lang)
 		if childType == "outer_doc_comment_marker" || childType == "inner_doc_comment_marker" {
 			rustEnsureDocCommentMarkerToken(child, source, lang)
-			node.fieldIDs[i] = markerFID
+			fieldIDs[i] = markerFID
 			continue
 		}
 		if childType == "doc_comment" {
-			node.fieldIDs[i] = docFID
+			fieldIDs[i] = docFID
 		}
 	}
 }
@@ -304,8 +306,7 @@ func normalizeRustTokenBindingPatternNode(node *Node, source []byte, tokenTreePa
 		fragClone.symbol = fragmentSpecifierSym
 		fragClone.setNamed(fragmentSpecifierNamed)
 		fragClone.children = nil
-		fragClone.fieldIDs = nil
-		fragClone.fieldSources = nil
+		fragClone.clearFieldMetadata()
 
 		binding := cloneNodeInArena(node.ownerArena, meta)
 		binding.symbol = tokenBindingPatternSym

--- a/parser_result_scala_compilation.go
+++ b/parser_result_scala_compilation.go
@@ -330,14 +330,15 @@ func normalizeScalaImportPathFields(root *Node, lang *Language) {
 				if child == nil || child.Type(lang) != "." {
 					continue
 				}
-				prevHasPath := i > 0 && i-1 < len(n.fieldIDs) && n.fieldIDs[i-1] == pathID
-				nextHasPath := i+1 < len(n.children) && i+1 < len(n.fieldIDs) && n.fieldIDs[i+1] == pathID
+				fieldIDs := n.fieldIDs()
+				prevHasPath := i > 0 && i-1 < len(fieldIDs) && fieldIDs[i-1] == pathID
+				nextHasPath := i+1 < len(n.children) && i+1 < len(fieldIDs) && fieldIDs[i+1] == pathID
 				if !prevHasPath || !nextHasPath {
 					continue
 				}
 				ensureNodeFieldStorage(n, len(n.children))
-				n.fieldIDs[i] = pathID
-				n.fieldSources[i] = fieldSourceDirect
+				n.fieldIDs()[i] = pathID
+				n.fieldSources()[i] = fieldSourceDirect
 			}
 		}
 	})
@@ -403,9 +404,9 @@ func normalizeScalaDefinitionFields(root *Node, source []byte, lang *Language) {
 					continue
 				}
 				ensureNodeFieldStorage(n, len(n.children))
-				if n.fieldIDs[i] == 0 {
-					n.fieldIDs[i] = want
-					n.fieldSources[i] = fieldSourceDirect
+				if n.fieldIDs()[i] == 0 {
+					n.fieldIDs()[i] = want
+					n.fieldSources()[i] = fieldSourceDirect
 				}
 			}
 		case "function_definition":
@@ -428,9 +429,9 @@ func normalizeScalaDefinitionFields(root *Node, source []byte, lang *Language) {
 					continue
 				}
 				ensureNodeFieldStorage(n, len(n.children))
-				if n.fieldIDs[i] == 0 {
-					n.fieldIDs[i] = want
-					n.fieldSources[i] = fieldSourceDirect
+				if n.fieldIDs()[i] == 0 {
+					n.fieldIDs()[i] = want
+					n.fieldSources()[i] = fieldSourceDirect
 				}
 			}
 		case "val_definition", "var_definition":
@@ -471,9 +472,9 @@ func normalizeScalaDefinitionFields(root *Node, source []byte, lang *Language) {
 					continue
 				}
 				ensureNodeFieldStorage(n, len(n.children))
-				if n.fieldIDs[i] == 0 {
-					n.fieldIDs[i] = want
-					n.fieldSources[i] = fieldSourceDirect
+				if n.fieldIDs()[i] == 0 {
+					n.fieldIDs()[i] = want
+					n.fieldSources()[i] = fieldSourceDirect
 				}
 			}
 		case "if_expression":
@@ -506,9 +507,9 @@ func normalizeScalaDefinitionFields(root *Node, source []byte, lang *Language) {
 					continue
 				}
 				ensureNodeFieldStorage(n, len(n.children))
-				if n.fieldIDs[i] == 0 {
-					n.fieldIDs[i] = want
-					n.fieldSources[i] = fieldSourceDirect
+				if n.fieldIDs()[i] == 0 {
+					n.fieldIDs()[i] = want
+					n.fieldSources()[i] = fieldSourceDirect
 				}
 			}
 		case "case_block":
@@ -564,21 +565,29 @@ func normalizeScalaTemplateBodyFunctionAnnotations(root *Node, source []byte, pa
 					newChildren = buf
 				}
 				child.children = newChildren
-				if len(child.fieldIDs) > 0 {
+				childFieldIDs := child.fieldIDs()
+				childFieldSources := child.fieldSources()
+				metadataChanged := false
+				if len(childFieldIDs) > 0 {
 					fieldIDs := make([]FieldID, 0, len(child.children))
 					for range annotations {
 						fieldIDs = append(fieldIDs, 0)
 					}
-					fieldIDs = append(fieldIDs, child.fieldIDs...)
-					child.fieldIDs = fieldIDs
+					fieldIDs = append(fieldIDs, childFieldIDs...)
+					childFieldIDs = fieldIDs
+					metadataChanged = true
 				}
-				if len(child.fieldSources) > 0 {
+				if len(childFieldSources) > 0 {
 					fieldSources := make([]uint8, 0, len(child.children))
 					for range annotations {
 						fieldSources = append(fieldSources, fieldSourceNone)
 					}
-					fieldSources = append(fieldSources, child.fieldSources...)
-					child.fieldSources = fieldSources
+					fieldSources = append(fieldSources, childFieldSources...)
+					childFieldSources = fieldSources
+					metadataChanged = true
+				}
+				if metadataChanged {
+					child.setFieldMetadata(childFieldIDs, childFieldSources)
 				}
 				populateParentNode(child, child.children)
 			}
@@ -749,21 +758,29 @@ func normalizeScalaTrailingCommentSiblings(parent *Node, source []byte, lang *La
 		rebuiltChildren = append(rebuiltChildren, added...)
 		body.children = rebuiltChildren
 
-		if len(body.fieldIDs) > 0 {
-			rebuiltFieldIDs := make([]FieldID, 0, len(body.fieldIDs)+len(added))
-			rebuiltFieldIDs = append(rebuiltFieldIDs, body.fieldIDs...)
+		bodyFieldIDs := body.fieldIDs()
+		bodyFieldSources := body.fieldSources()
+		metadataChanged := false
+		if len(bodyFieldIDs) > 0 {
+			rebuiltFieldIDs := make([]FieldID, 0, len(bodyFieldIDs)+len(added))
+			rebuiltFieldIDs = append(rebuiltFieldIDs, bodyFieldIDs...)
 			for range added {
 				rebuiltFieldIDs = append(rebuiltFieldIDs, 0)
 			}
-			body.fieldIDs = rebuiltFieldIDs
+			bodyFieldIDs = rebuiltFieldIDs
+			metadataChanged = true
 		}
-		if len(body.fieldSources) > 0 {
-			rebuiltFieldSources := make([]uint8, 0, len(body.fieldSources)+len(added))
-			rebuiltFieldSources = append(rebuiltFieldSources, body.fieldSources...)
+		if len(bodyFieldSources) > 0 {
+			rebuiltFieldSources := make([]uint8, 0, len(bodyFieldSources)+len(added))
+			rebuiltFieldSources = append(rebuiltFieldSources, bodyFieldSources...)
 			for range added {
 				rebuiltFieldSources = append(rebuiltFieldSources, 0)
 			}
-			body.fieldSources = rebuiltFieldSources
+			bodyFieldSources = rebuiltFieldSources
+			metadataChanged = true
+		}
+		if metadataChanged {
+			body.setFieldMetadata(bodyFieldIDs, bodyFieldSources)
 		}
 		if targetEndByte > body.endByte {
 			body.endByte = targetEndByte
@@ -775,11 +792,14 @@ func normalizeScalaTrailingCommentSiblings(parent *Node, source []byte, lang *La
 		}
 
 		parent.children = append(parent.children[:i], parent.children[j:]...)
-		if len(parent.fieldIDs) > 0 {
-			parent.fieldIDs = append(parent.fieldIDs[:i], parent.fieldIDs[j:]...)
-			if len(parent.fieldSources) > 0 {
-				parent.fieldSources = append(parent.fieldSources[:i], parent.fieldSources[j:]...)
+		parentFieldIDs := parent.fieldIDs()
+		parentFieldSources := parent.fieldSources()
+		if len(parentFieldIDs) > 0 {
+			parentFieldIDs = append(parentFieldIDs[:i], parentFieldIDs[j:]...)
+			if len(parentFieldSources) > 0 {
+				parentFieldSources = append(parentFieldSources[:i], parentFieldSources[j:]...)
 			}
+			parent.setFieldMetadata(parentFieldIDs, parentFieldSources)
 		}
 	}
 }
@@ -835,10 +855,10 @@ func normalizeScalaFunctionModifierFields(root *Node, lang *Language) {
 				if child == nil || child.Type(lang) != "modifiers" {
 					continue
 				}
-				if i < len(n.fieldIDs) && n.fieldIDs[i] == returnTypeID {
-					n.fieldIDs[i] = 0
-					if i < len(n.fieldSources) {
-						n.fieldSources[i] = fieldSourceNone
+				if i < len(n.fieldIDs()) && n.fieldIDs()[i] == returnTypeID {
+					n.fieldIDs()[i] = 0
+					if i < len(n.fieldSources()) {
+						n.fieldSources()[i] = fieldSourceNone
 					}
 				}
 			}

--- a/parser_result_scala_template.go
+++ b/parser_result_scala_template.go
@@ -45,7 +45,7 @@ func normalizeScalaObjectTemplateBodyFragments(root *Node, source []byte, parser
 		replacementChildren := make([]*Node, 0, len(obj.children)+1)
 		replacementChildren = append(replacementChildren, obj.children...)
 		replacementChildren = append(replacementChildren, newParentNodeInArena(arena, templateBodySym, templateBodyNamed, bodyChildren, nil, 0))
-		replacement := newParentNodeInArena(arena, obj.symbol, obj.isNamed(), replacementChildren, obj.fieldIDs, obj.productionID)
+		replacement := newParentNodeInArena(arena, obj.symbol, obj.isNamed(), replacementChildren, obj.fieldIDs(), obj.productionID)
 		replaceChildRangeWithSingleNode(root, i, closeIdx+1, replacement)
 		changed = true
 	}
@@ -513,23 +513,31 @@ func scalaRecoverTemplateBodyTailMembers(body *Node, start uint32, source []byte
 	newChildren = append(newChildren, recovered...)
 	newChildren = append(newChildren, body.children[closeIdx:]...)
 	body.children = newChildren
-	if len(body.fieldIDs) > 0 {
+	bodyFieldIDs := body.fieldIDs()
+	bodyFieldSources := body.fieldSources()
+	metadataChanged := false
+	if len(bodyFieldIDs) > 0 {
 		fieldIDs := make([]FieldID, 0, len(body.children))
-		fieldIDs = append(fieldIDs, body.fieldIDs[:closeIdx]...)
+		fieldIDs = append(fieldIDs, bodyFieldIDs[:closeIdx]...)
 		for range recovered {
 			fieldIDs = append(fieldIDs, 0)
 		}
-		fieldIDs = append(fieldIDs, body.fieldIDs[closeIdx:]...)
-		body.fieldIDs = fieldIDs
+		fieldIDs = append(fieldIDs, bodyFieldIDs[closeIdx:]...)
+		bodyFieldIDs = fieldIDs
+		metadataChanged = true
 	}
-	if len(body.fieldSources) > 0 {
+	if len(bodyFieldSources) > 0 {
 		fieldSources := make([]uint8, 0, len(body.children))
-		fieldSources = append(fieldSources, body.fieldSources[:closeIdx]...)
+		fieldSources = append(fieldSources, bodyFieldSources[:closeIdx]...)
 		for range recovered {
 			fieldSources = append(fieldSources, fieldSourceNone)
 		}
-		fieldSources = append(fieldSources, body.fieldSources[closeIdx:]...)
-		body.fieldSources = fieldSources
+		fieldSources = append(fieldSources, bodyFieldSources[closeIdx:]...)
+		bodyFieldSources = fieldSources
+		metadataChanged = true
+	}
+	if metadataChanged {
+		body.setFieldMetadata(bodyFieldIDs, bodyFieldSources)
 	}
 	for i, child := range body.children {
 		if child == nil {

--- a/parser_result_sql.go
+++ b/parser_result_sql.go
@@ -37,8 +37,7 @@ func normalizeSQLRecoveredSelectRoot(root *Node, lang *Language) {
 	selectClause := newParentNodeInArena(root.ownerArena, selectClauseSym, symbolIsNamed(lang, selectClauseSym), []*Node{root.children[0], selectClauseBody}, nil, 0)
 	selectStatement := newParentNodeInArena(root.ownerArena, selectStmtSym, symbolIsNamed(lang, selectStmtSym), []*Node{selectClause}, nil, 0)
 	root.children = cloneNodeSliceIfArena(root.ownerArena, []*Node{selectStatement})
-	root.fieldIDs = nil
-	root.fieldSources = nil
+	root.clearFieldMetadata()
 	root.setHasError(selectStatement.HasError())
 }
 

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -78,7 +78,7 @@ func normalizeSwiftRecoveredTrailingClosureConditions(root *Node, source []byte,
 	}
 	root.symbol = newRoot.symbol
 	root.productionID = newRoot.productionID
-	root.fieldIDs = newRoot.fieldIDs
+	root.setFieldIDs(newRoot.fieldIDs())
 	root.children = cloneNodeSliceIfArena(root.ownerArena, newRoot.children)
 	// populateParentNode derives the span from the children; reassert the
 	// source_file bounds afterwards so leading/trailing trivia is covered, then
@@ -678,7 +678,7 @@ func (r *swiftRemap) remap(n *Node) (*Node, bool) {
 		}
 	}
 	kids = cloneNodeSliceInArena(r.arena, kids)
-	fieldIDs := cloneFieldIDSliceInArena(r.arena, n.fieldIDs)
+	fieldIDs := cloneFieldIDSliceInArena(r.arena, n.fieldIDs())
 	node := newParentNodeInArena(r.arena, n.symbol, n.isNamed(), kids, fieldIDs, n.productionID)
 	node.setExtra(n.IsExtra())
 	node.startByte = newStart

--- a/parser_result_swift_ternary.go
+++ b/parser_result_swift_ternary.go
@@ -134,7 +134,7 @@ func normalizeSwiftRecoveredTernaryExpressions(root *Node, source []byte, p *Par
 
 	root.symbol = newRoot.symbol
 	root.productionID = newRoot.productionID
-	root.fieldIDs = newRoot.fieldIDs
+	root.setFieldIDs(newRoot.fieldIDs())
 	root.children = cloneNodeSliceIfArena(arena, newRoot.children)
 	populateParentNode(root, root.children)
 	root.startByte = 0
@@ -198,7 +198,7 @@ func (b *swiftTernaryBuilder) rebuild(n *Node) *Node {
 		kids = append(kids, rc)
 	}
 	kids = cloneNodeSliceInArena(b.arena, kids)
-	fieldIDs := cloneFieldIDSliceInArena(b.arena, n.fieldIDs)
+	fieldIDs := cloneFieldIDSliceInArena(b.arena, n.fieldIDs())
 	node := newParentNodeInArena(b.arena, n.symbol, n.isNamed(), kids, fieldIDs, n.productionID)
 	node.setExtra(n.IsExtra())
 	// Preserve the original span but extend it to cover any child a nested

--- a/parser_result_templ.go
+++ b/parser_result_templ.go
@@ -208,8 +208,7 @@ func templBuildQualifiedComponentImport(importNode, tailNode *Node, source []byt
 	argsView.startByte = tailNode.startByte + uint32(parts.argsStart)
 	argsView.startPoint = Point{Row: tailNode.startPoint.Row, Column: tailNode.startPoint.Column + uint32(parts.argsStart)}
 	argsView.children = nil
-	argsView.fieldIDs = nil
-	argsView.fieldSources = nil
+	argsView.clearFieldMetadata()
 	argList := templBuildSimpleArgumentList(&argsView, source, lang, argListSym, argListNamed)
 	if argList == nil {
 		return nil

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -62,8 +62,7 @@ func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCh
 		n.startPoint = child.startPoint
 		n.endPoint = child.endPoint
 		n.children = nil
-		n.fieldIDs = nil
-		n.fieldSources = nil
+		n.clearFieldMetadata()
 		if n.ownerArena != nil {
 			n.ownerArena.clearFinalChildRefs(n)
 		}
@@ -150,12 +149,12 @@ func resultNodeHasChildFields(n *Node) bool {
 	if n == nil {
 		return false
 	}
-	for _, fid := range n.fieldIDs {
+	for _, fid := range n.fieldIDs() {
 		if fid != 0 {
 			return true
 		}
 	}
-	for _, source := range n.fieldSources {
+	for _, source := range n.fieldSources() {
 		if source != fieldSourceNone {
 			return true
 		}

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -262,7 +262,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesFieldedTerminal(t *testing.T) 
 	if got, want := token.ChildCount(), 1; got != want {
 		t.Fatalf("token.ChildCount() = %d, want %d", got, want)
 	}
-	if got, want := token.fieldIDs[0], FieldID(1); got != want {
-		t.Fatalf("token.fieldIDs[0] = %d, want %d", got, want)
+	if got, want := token.fieldIDs()[0], FieldID(1); got != want {
+		t.Fatalf("token.fieldIDs()[0] = %d, want %d", got, want)
 	}
 }

--- a/parser_result_trivia_helpers.go
+++ b/parser_result_trivia_helpers.go
@@ -115,11 +115,19 @@ func trimTrailingExtraTriviaRoot(root *Node, source []byte, lang *Language) {
 	}
 	children := resultChildSliceForMutation(root)
 	root.children = cloneNodeSliceInArena(root.ownerArena, children[:len(children)-1])
-	if len(root.fieldIDs) > len(root.children) {
-		root.fieldIDs = root.fieldIDs[:len(root.children)]
+	fieldIDs := root.fieldIDs()
+	fieldSources := root.fieldSources()
+	metadataChanged := false
+	if len(fieldIDs) > len(root.children) {
+		fieldIDs = fieldIDs[:len(root.children)]
+		metadataChanged = true
 	}
-	if len(root.fieldSources) > len(root.children) {
-		root.fieldSources = root.fieldSources[:len(root.children)]
+	if len(fieldSources) > len(root.children) {
+		fieldSources = fieldSources[:len(root.children)]
+		metadataChanged = true
+	}
+	if metadataChanged {
+		root.setFieldMetadata(fieldIDs, fieldSources)
 	}
 	populateParentNode(root, root.children)
 }

--- a/parser_result_typescript.go
+++ b/parser_result_typescript.go
@@ -138,7 +138,7 @@ func normalizeTypeScriptCompatibility(root *Node, source []byte, lang *Language)
 				normalizeTypeScriptRecoveredMemberModifiers(n, &ctx)
 			}
 		case ctx.enumBodySym:
-			if ctx.canClearEnumBodyFields && len(n.fieldIDs) > 0 {
+			if ctx.canClearEnumBodyFields && len(n.fieldIDs()) > 0 {
 				normalizeTypeScriptEnumBodyCompatibility(n, &ctx)
 			}
 		}
@@ -629,7 +629,7 @@ func normalizeTypeScriptCompatibilityWithStats(root *Node, source []byte, lang *
 				}
 			}
 		case ctx.enumBodySym:
-			if ctx.canClearEnumBodyFields && len(n.fieldIDs) > 0 {
+			if ctx.canClearEnumBodyFields && len(n.fieldIDs()) > 0 {
 				stats.enumBodies.nodesVisited++
 				beforeCleared := typeScriptEnumBodyClearedFieldCount(n, &ctx)
 				normalizeTypeScriptEnumBodyCompatibility(n, &ctx)
@@ -772,37 +772,40 @@ func typeScriptCompatibilityChildNeedsErrorRefresh(child *Node, ctx *typeScriptN
 }
 
 func normalizeTypeScriptEnumBodyCompatibility(n *Node, ctx *typeScriptNormalizationContext) {
-	if n == nil || ctx == nil || !ctx.canClearEnumBodyFields || n.symbol != ctx.enumBodySym || len(n.fieldIDs) == 0 {
+	if n == nil || ctx == nil || !ctx.canClearEnumBodyFields || n.symbol != ctx.enumBodySym || len(n.fieldIDs()) == 0 {
 		return
 	}
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
 	limit := len(n.children)
-	if len(n.fieldIDs) < limit {
-		limit = len(n.fieldIDs)
+	if len(fieldIDs) < limit {
+		limit = len(fieldIDs)
 	}
 	for i := 0; i < limit; i++ {
 		child := n.children[i]
 		if child == nil || child.symbol != ctx.enumAssignmentSym {
 			continue
 		}
-		n.fieldIDs[i] = 0
-		if len(n.fieldSources) > i {
-			n.fieldSources[i] = fieldSourceNone
+		fieldIDs[i] = 0
+		if len(fieldSources) > i {
+			fieldSources[i] = fieldSourceNone
 		}
 	}
 }
 
 func typeScriptEnumBodyClearedFieldCount(n *Node, ctx *typeScriptNormalizationContext) int {
-	if n == nil || ctx == nil || len(n.fieldIDs) == 0 {
+	if n == nil || ctx == nil || len(n.fieldIDs()) == 0 {
 		return 0
 	}
+	fieldIDs := n.fieldIDs()
 	limit := len(n.children)
-	if len(n.fieldIDs) < limit {
-		limit = len(n.fieldIDs)
+	if len(fieldIDs) < limit {
+		limit = len(fieldIDs)
 	}
 	cleared := 0
 	for i := 0; i < limit; i++ {
 		child := n.children[i]
-		if child != nil && child.symbol == ctx.enumAssignmentSym && n.fieldIDs[i] == 0 {
+		if child != nil && child.symbol == ctx.enumAssignmentSym && fieldIDs[i] == 0 {
 			cleared++
 		}
 	}
@@ -810,16 +813,17 @@ func typeScriptEnumBodyClearedFieldCount(n *Node, ctx *typeScriptNormalizationCo
 }
 
 func typeScriptEnumBodyHasUnclearedAssignmentFields(n *Node, ctx *typeScriptNormalizationContext) bool {
-	if n == nil || ctx == nil || !ctx.canClearEnumBodyFields || n.symbol != ctx.enumBodySym || len(n.fieldIDs) == 0 {
+	if n == nil || ctx == nil || !ctx.canClearEnumBodyFields || n.symbol != ctx.enumBodySym || len(n.fieldIDs()) == 0 {
 		return false
 	}
+	fieldIDs := n.fieldIDs()
 	limit := len(n.children)
-	if len(n.fieldIDs) < limit {
-		limit = len(n.fieldIDs)
+	if len(fieldIDs) < limit {
+		limit = len(fieldIDs)
 	}
 	for i := 0; i < limit; i++ {
 		child := n.children[i]
-		if child != nil && child.symbol == ctx.enumAssignmentSym && n.fieldIDs[i] != 0 {
+		if child != nil && child.symbol == ctx.enumAssignmentSym && fieldIDs[i] != 0 {
 			return true
 		}
 	}
@@ -1022,8 +1026,7 @@ func normalizeTypeScriptIdentifierKeywordAliases(node *Node, ctx *typeScriptNorm
 		return
 	}
 	node.children = nil
-	node.fieldIDs = nil
-	node.fieldSources = nil
+	node.clearFieldMetadata()
 }
 
 func normalizeTypeScriptImportKeywordNamedness(node *Node, ctx *typeScriptNormalizationContext) {
@@ -1385,7 +1388,6 @@ func buildTypeScriptRecoveredCallExpression(arena *nodeArena, ctx *typeScriptNor
 		}
 	}
 	call := newParentNodeInArena(arena, ctx.callSym, ctx.callNamed, children, fieldIDs, 0)
-	call.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
 	return call
 }
 
@@ -2101,8 +2103,7 @@ func typeScriptAssignMemberFields(node *Node, ctx *typeScriptNormalizationContex
 		return
 	}
 	if ctx.nameFieldID == 0 {
-		node.fieldIDs = nil
-		node.fieldSources = nil
+		node.clearFieldMetadata()
 		return
 	}
 	var fieldIDs []FieldID
@@ -2140,8 +2141,7 @@ func typeScriptAssignMemberFields(node *Node, ctx *typeScriptNormalizationContex
 			}
 		}
 	}
-	node.fieldIDs = fieldIDs
-	node.fieldSources = defaultFieldSourcesInArena(node.ownerArena, fieldIDs)
+	node.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(node.ownerArena, fieldIDs))
 }
 
 func scanTypeScriptMemberPrefixTokens(source []byte, startByte, endByte uint32, startPoint Point) ([]typeScriptMemberToken, bool) {
@@ -2276,20 +2276,19 @@ func rewriteTypeScriptGenericArrowTypeAssertion(node *Node, ctx *typeScriptNorma
 	copy(children[1:], arrow.children)
 
 	var fieldIDs []FieldID
-	if ctx.typeParametersFieldID != 0 || len(arrow.fieldIDs) > 0 {
+	if ctx.typeParametersFieldID != 0 || len(arrow.fieldIDs()) > 0 {
 		if arena != nil {
 			fieldIDs = arena.allocFieldIDSlice(len(children))
 		} else {
 			fieldIDs = make([]FieldID, len(children))
 		}
 		fieldIDs[0] = ctx.typeParametersFieldID
-		copy(fieldIDs[1:], arrow.fieldIDs)
+		copy(fieldIDs[1:], arrow.fieldIDs())
 	}
 
 	rewritten := cloneNodeInArena(arena, arrow)
 	rewritten.children = children
-	rewritten.fieldIDs = fieldIDs
-	rewritten.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
+	rewritten.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(arena, fieldIDs))
 	populateParentNode(rewritten, rewritten.children)
 	return rewritten
 }
@@ -2321,7 +2320,6 @@ func convertTypeScriptTypeArgumentsToParameters(typeArgs *Node, ctx *typeScriptN
 			fieldIDs[0] = ctx.nameFieldID
 		}
 		param := newParentNodeInArena(arena, ctx.typeParameterSym, ctx.typeParameterNamed, paramChildren, fieldIDs, child.productionID)
-		param.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
 		children[i] = param
 		convertedNamed++
 	}
@@ -2355,12 +2353,12 @@ func rewriteTypeScriptClassExpressionStatement(node *Node, ctx *typeScriptNormal
 		return nil
 	}
 	children := cloneNodeSliceInArena(classNode.ownerArena, classNode.children)
-	fieldIDs := cloneFieldIDSliceInArena(classNode.ownerArena, classNode.fieldIDs)
-	decl := newParentNodeInArena(classNode.ownerArena, ctx.classDeclarationSym, ctx.classDeclarationNamed, children, fieldIDs, classNode.productionID)
-	decl.fieldSources = cloneFieldSourceSliceInArena(classNode.ownerArena, classNode.fieldSources)
-	if len(decl.fieldSources) == 0 {
-		decl.fieldSources = defaultFieldSourcesInArena(classNode.ownerArena, fieldIDs)
+	fieldIDs := cloneFieldIDSliceInArena(classNode.ownerArena, classNode.fieldIDs())
+	fieldSources := cloneFieldSourceSliceInArena(classNode.ownerArena, classNode.fieldSources())
+	if len(fieldSources) == 0 {
+		fieldSources = defaultFieldSourcesInArena(classNode.ownerArena, fieldIDs)
 	}
+	decl := newParentNodeInArenaWithFieldSources(classNode.ownerArena, ctx.classDeclarationSym, ctx.classDeclarationNamed, children, fieldIDs, fieldSources, classNode.productionID)
 	return decl
 }
 
@@ -2372,7 +2370,7 @@ func typeScriptClassExpressionHasName(node *Node, ctx *typeScriptNormalizationCo
 		if child == nil {
 			continue
 		}
-		if ctx.nameFieldID != 0 && i < len(node.fieldIDs) && node.fieldIDs[i] == ctx.nameFieldID {
+		if ctx.nameFieldID != 0 && i < len(node.fieldIDs()) && node.fieldIDs()[i] == ctx.nameFieldID {
 			return child.symbol == ctx.typeIdentifierSym && child.endByte > child.startByte
 		}
 		if child.symbol == ctx.typeIdentifierSym && child.endByte > child.startByte {
@@ -2446,7 +2444,6 @@ func rewriteTypeScriptPredefinedGenericCall(node *Node, ctx *typeScriptNormaliza
 		fieldIDs[2] = ctx.argumentsFieldID
 	}
 	call := newParentNodeInArena(arena, ctx.callSym, ctx.callNamed, callChildren, fieldIDs, node.productionID)
-	call.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
 	return call
 }
 
@@ -2601,7 +2598,6 @@ func rewriteTypeScriptInstantiatedCall(node *Node, ctx *typeScriptNormalizationC
 		fieldIDs[2] = ctx.argumentsFieldID
 	}
 	call := newParentNodeInArena(node.ownerArena, ctx.callSym, ctx.callNamed, children, fieldIDs, node.productionID)
-	call.fieldSources = defaultFieldSourcesInArena(node.ownerArena, fieldIDs)
 	return call
 }
 

--- a/parser_result_zig.go
+++ b/parser_result_zig.go
@@ -9,9 +9,9 @@ func normalizeZigEmptyInitListFields(root *Node, lang *Language) {
 		return
 	}
 	walkResultTree(root, func(n *Node) {
-		if len(n.fieldIDs) == len(n.children) {
+		if len(n.fieldIDs()) == len(n.children) {
 			for i, child := range n.children {
-				if child == nil || n.fieldIDs[i] != fieldConstantID || child.Type(lang) != "InitList" {
+				if child == nil || n.fieldIDs()[i] != fieldConstantID || child.Type(lang) != "InitList" {
 					continue
 				}
 				if n.Type(lang) != "SuffixExpr" || len(n.children) != 2 || i != 1 || n.children[0] == nil || n.children[0].Type(lang) != "." {

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -1102,6 +1102,7 @@ func assertParseRuntimeArenaBreakdown(t *testing.T, tree *Tree, rt ParseRuntime)
 		t.Fatal("ArenaBreakdown = nil, want populated")
 	}
 	breakdown := arenaBreakdown.NodeStructBytesAllocated +
+		arenaBreakdown.NodeFieldMetadataBytesAllocated +
 		arenaBreakdown.NoTreeNodeBytesAllocated +
 		arenaBreakdown.CompactFullLeafBytesAllocated +
 		arenaBreakdown.PendingParentBytesAllocated +

--- a/raw_shape_test.go
+++ b/raw_shape_test.go
@@ -962,8 +962,8 @@ func TestAcceptedStackTreeOrderDoesNotStripSemanticInvisibleWrappers(t *testing.
 		{
 			name: "direct-field-id",
 			configure: func(lang *Language, arena *nodeArena, wrap *Node) {
-				wrap.fieldIDs = cloneFieldIDSliceInArena(arena, []FieldID{1, 0, 0})
-				wrap.fieldSources = defaultFieldSourcesInArena(arena, wrap.fieldIDs)
+				fieldIDs := cloneFieldIDSliceInArena(arena, []FieldID{1, 0, 0})
+				wrap.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(arena, fieldIDs))
 			},
 		},
 		{

--- a/transient_children_test.go
+++ b/transient_children_test.go
@@ -148,11 +148,11 @@ func TestTransientChildScratchMaterializesFieldedArenaParent(t *testing.T) {
 	if len(parent.children) != 2 || parent.children[0] != first || parent.children[1] != second {
 		t.Fatalf("materialized children = %#v, want [%p %p]", parent.children, first, second)
 	}
-	if len(parent.fieldIDs) != 2 || parent.fieldIDs[0] != 7 {
-		t.Fatalf("field IDs = %#v, want first field 7", parent.fieldIDs)
+	if len(parent.fieldIDs()) != 2 || parent.fieldIDs()[0] != 7 {
+		t.Fatalf("field IDs = %#v, want first field 7", parent.fieldIDs())
 	}
-	if len(parent.fieldSources) != 2 || parent.fieldSources[0] != fieldSourceDirect {
-		t.Fatalf("field sources = %#v, want first direct", parent.fieldSources)
+	if len(parent.fieldSources()) != 2 || parent.fieldSources()[0] != fieldSourceDirect {
+		t.Fatalf("field sources = %#v, want first direct", parent.fieldSources())
 	}
 
 	scratch.reset()

--- a/transient_parents.go
+++ b/transient_parents.go
@@ -53,8 +53,7 @@ func (s *transientParentScratch) allocParent(arena *nodeArena, sym Symbol, named
 		n.symbol = sym
 		n.setNamed(named)
 		n.children = children
-		n.fieldIDs = nil
-		n.fieldSources = nil
+		n.clearFieldMetadata()
 		n.productionID = productionID
 		n.childIndex = -1
 		populateParentNodeNoLinks(n, children, trackChildErrors)
@@ -316,8 +315,7 @@ func (s *transientParentScratch) materializeVisitedNodeUntil(n *Node, arena *nod
 	clone.ownerArena = arena
 	clone.symbol = n.symbol
 	clone.children = n.children
-	clone.fieldIDs = n.fieldIDs
-	clone.fieldSources = n.fieldSources
+	clone.setFieldMetadata(n.fieldIDs(), n.fieldSources())
 	clone.startPoint = n.startPoint
 	clone.endPoint = n.endPoint
 	clone.startByte = n.startByte
@@ -330,7 +328,7 @@ func (s *transientParentScratch) materializeVisitedNodeUntil(n *Node, arena *nod
 	clone.flags = n.flags
 	clone.childIndex = -1
 	nodeInitEquivVersion(clone)
-	arena.recordParentNodeConstructed(len(clone.children), clone.fieldIDs, clone.fieldSources, len(clone.fieldSources) > 0, true, false)
+	arena.recordParentNodeConstructed(len(clone.children), clone.fieldIDs(), clone.fieldSources(), len(clone.fieldSources()) > 0, true, false)
 	s.nodesMaterialized++
 	n.parent = clone
 	return ParseStopNone

--- a/tree.go
+++ b/tree.go
@@ -21,8 +21,7 @@ type Node struct {
 	// Layout is performance-sensitive. Keep TestNodeLayoutSizeBudget updated
 	// when changing field order or adding fields.
 	children          []*Node
-	fieldIDs          []FieldID // parallel to children, 0 = no field
-	fieldSources      []uint8   // parallel to children, 0 = none, 1 = direct, 2 = inherited
+	fieldMetadata     *nodeFieldMetadata
 	parent            *Node
 	ownerArena        *nodeArena
 	startPoint        Point
@@ -540,10 +539,11 @@ func nodeChildrenForReason(n *Node, reason materializeReason) []*Node {
 }
 
 func nodeFieldIDAt(n *Node, i int) FieldID {
-	if n == nil || i < 0 || i >= len(n.fieldIDs) {
+	fieldIDs := n.fieldIDs()
+	if i < 0 || i >= len(fieldIDs) {
 		return 0
 	}
-	return n.fieldIDs[i]
+	return fieldIDs[i]
 }
 
 // ParseStopReason reports why parseInternal terminated.
@@ -1073,6 +1073,7 @@ func (p reduceChildPath) valid() bool {
 // populated only when EnableArenaBreakdown(true) is set before parsing.
 type ArenaBreakdown struct {
 	NodeStructBytesAllocated            int64
+	NodeFieldMetadataBytesAllocated     int64
 	NoTreeNodeBytesAllocated            int64
 	CompactFullLeafBytesAllocated       int64
 	PendingParentBytesAllocated         int64
@@ -1956,13 +1957,15 @@ func collectFinalNodeStats(n *Node, lang *Language, stats *finalTreeMaterializat
 	}
 	stats.childSlices++
 	stats.childPointers += uint64(childCount)
-	if len(n.fieldIDs) > 0 {
-		stats.fieldIDElements += uint64(len(n.fieldIDs))
+	fieldIDs := n.fieldIDs()
+	fieldSources := n.fieldSources()
+	if len(fieldIDs) > 0 {
+		stats.fieldIDElements += uint64(len(fieldIDs))
 	}
-	if len(n.fieldSources) > 0 {
-		stats.fieldSourceElements += uint64(len(n.fieldSources))
+	if len(fieldSources) > 0 {
+		stats.fieldSourceElements += uint64(len(fieldSources))
 	}
-	if hasParentFieldMetadata(n.fieldIDs, n.fieldSources) {
+	if hasParentFieldMetadata(fieldIDs, fieldSources) {
 		stats.fieldedParentNodes++
 	} else {
 		stats.unfieldedParentNodes++
@@ -2163,8 +2166,7 @@ func newParentNode(arena *nodeArena, sym Symbol, named bool, children []*Node, f
 	n.symbol = sym
 	n.setNamed(named)
 	n.children = children
-	n.fieldIDs = fieldIDs
-	n.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
+	n.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(arena, fieldIDs))
 	n.productionID = productionID
 	n.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
 	n.childIndex = -1
@@ -2244,18 +2246,17 @@ func newParentNodeInArenaWithFieldSources(arena *nodeArena, sym Symbol, named bo
 	n.symbol = sym
 	n.setNamed(named)
 	n.children = children
-	n.fieldIDs = fieldIDs
-	if fieldSources != nil {
-		n.fieldSources = fieldSources
-	} else {
-		n.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
+	resolvedFieldSources := fieldSources
+	if resolvedFieldSources == nil {
+		resolvedFieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
 	}
+	n.setFieldMetadata(fieldIDs, resolvedFieldSources)
 	n.productionID = productionID
 	n.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
 	n.childIndex = -1
 	arena.parentNodesConstructed++
 	if arena.breakdownEnabled {
-		arena.recordParentNodeConstructedBreakdown(len(children), fieldIDs, n.fieldSources, fieldSources != nil, false, false)
+		arena.recordParentNodeConstructedBreakdown(len(children), fieldIDs, resolvedFieldSources, fieldSources != nil, false, false)
 	}
 	populateParentNode(n, children)
 	nodeInitEquivVersion(n)
@@ -2277,18 +2278,17 @@ func newParentNodeInArenaNoLinksWithFieldSources(arena *nodeArena, sym Symbol, n
 	n.symbol = sym
 	n.setNamed(named)
 	n.children = children
-	n.fieldIDs = fieldIDs
-	if fieldSources != nil {
-		n.fieldSources = fieldSources
-	} else {
-		n.fieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
+	resolvedFieldSources := fieldSources
+	if resolvedFieldSources == nil {
+		resolvedFieldSources = defaultFieldSourcesInArena(arena, fieldIDs)
 	}
+	n.setFieldMetadata(fieldIDs, resolvedFieldSources)
 	n.productionID = productionID
 	n.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
 	n.childIndex = -1
 	arena.parentNodesConstructed++
 	if arena.breakdownEnabled {
-		arena.recordParentNodeConstructedBreakdown(len(children), fieldIDs, n.fieldSources, fieldSources != nil, true, trackChildErrors)
+		arena.recordParentNodeConstructedBreakdown(len(children), fieldIDs, resolvedFieldSources, fieldSources != nil, true, trackChildErrors)
 	}
 	populateParentNodeNoLinks(n, children, trackChildErrors)
 	nodeInitEquivVersion(n)
@@ -2977,8 +2977,7 @@ func cloneNodeHeaderInto(dst, src *Node, arena *nodeArena, offset *cloneOffset) 
 		dst.endPoint = offset.offsetPoint(src.endPoint)
 	}
 	dst.children = nil
-	dst.fieldIDs = nil
-	dst.fieldSources = nil
+	dst.clearFieldMetadata()
 	dst.parent = nil
 	dst.childIndex = -1
 	dst.ownerArena = arena
@@ -3004,16 +3003,36 @@ func (o *cloneOffset) offsetPoint(p Point) Point {
 }
 
 func cloneNodeFieldMetadataInto(dst, src *Node, arena *nodeArena) {
-	if n := len(src.fieldIDs); n > 0 {
-		fieldIDs := arena.allocFieldIDSlice(n)
-		copy(fieldIDs, src.fieldIDs)
-		dst.fieldIDs = fieldIDs
+	if dst == nil || src == nil {
+		return
 	}
-	if n := len(src.fieldSources); n > 0 {
-		fieldSources := arena.allocFieldSourceSlice(n)
-		copy(fieldSources, src.fieldSources)
-		dst.fieldSources = fieldSources
+	fieldIDs := cloneFieldIDsIntoArena(arena, src.fieldIDs())
+	fieldSources := cloneFieldSourcesIntoArena(arena, src.fieldSources())
+	dst.setFieldMetadata(fieldIDs, fieldSources)
+}
+
+func cloneFieldIDsIntoArena(arena *nodeArena, src []FieldID) []FieldID {
+	if src == nil {
+		return nil
 	}
+	if len(src) == 0 {
+		return []FieldID{}
+	}
+	dst := arena.allocFieldIDSlice(len(src))
+	copy(dst, src)
+	return dst
+}
+
+func cloneFieldSourcesIntoArena(arena *nodeArena, src []uint8) []uint8 {
+	if src == nil {
+		return nil
+	}
+	if len(src) == 0 {
+		return []uint8{}
+	}
+	dst := arena.allocFieldSourceSlice(len(src))
+	copy(dst, src)
+	return dst
 }
 
 type cloneMetricScope uint8

--- a/tree_test.go
+++ b/tree_test.go
@@ -20,10 +20,11 @@ func TestNodeLayoutSizeBudget(t *testing.T) {
 	var n Node
 	got := unsafe.Sizeof(n)
 	t.Logf(
-		"Node size=%d align=%d children=%d parent=%d ownerArena=%d startPoint=%d startByte=%d parseState=%d childIndex=%d symbol=%d rawShape=%d flags=%d dirtyFlag=%d",
+		"Node size=%d align=%d children=%d fieldMetadata=%d parent=%d ownerArena=%d startPoint=%d startByte=%d parseState=%d childIndex=%d symbol=%d rawShape=%d flags=%d dirtyFlag=%d",
 		got,
 		unsafe.Alignof(n),
 		unsafe.Offsetof(n.children),
+		unsafe.Offsetof(n.fieldMetadata),
 		unsafe.Offsetof(n.parent),
 		unsafe.Offsetof(n.ownerArena),
 		unsafe.Offsetof(n.startPoint),
@@ -35,12 +36,9 @@ func TestNodeLayoutSizeBudget(t *testing.T) {
 		unsafe.Offsetof(n.flags),
 		unsafe.Offsetof(n.dirtyFlag),
 	)
-	// Keep the 32-bit rawShape before the 16-bit symbol/production pair. The
-	// same fields occupy 144 bytes in this order; placing symbol first inserts
-	// an otherwise unnecessary 8-byte tail-alignment block on 64-bit targets.
-	const budget = 144
-	if got > budget {
-		t.Fatalf("Node size = %d, want <= %d", got, budget)
+	const want = 104
+	if got != want {
+		t.Fatalf("Node size = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move the uncommon field ID/source slice headers out of `Node` into private arena-backed sidecars.
- Reduce `unsafe.Sizeof(Node{})` from 144 to 104 bytes while preserving field, clone, and mutation semantics.

## Changes

- Add bounded sidecar slabs with reset, retention, parser-budget, and arena-breakdown accounting.
- Route node field reads and header mutations through nil-safe accessors and copy-on-write setters.
- Preserve shared backing-array behavior for shallow copies and isolate deep, offset, and cross-arena clones.
- Include sidecar bytes in parse-gap and corpus benchmark reporting.

## Validation

- Full root-package Docker suite and focused Docker race gate pass.
- JavaScript real-corpus gate passes 25/25 no-error, S-expression, and deep parity.
- The 3,447,275-byte Poppler witness passes exact Go/C no-error, S-expression, and deep parity.
- Poppler arena capacity falls by 245,966,616 bytes; hard-2-GiB RSS repeats at 1,571,008–1,618,388 KiB versus 1,708,712 KiB.
- Poppler Go/C time improves from 3.50x to 2.36x.
- Pinned `benchstat` comparisons find full parse, one-byte incremental edit, no-edit, and compiled-query performance statistically unchanged.