### PR TITLE
Inline node error-rank caching in parser result path

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -264,31 +264,13 @@ type nodeArena struct {
 	pendingParentRejectedFieldsHiddenChildPlainMany  uint64
 	pendingParentRejectedFieldsHiddenChildWithFields uint64
 
-	// nodeErrorRankMemo/pendingParentErrorRankMemo memoize
-	// computeStackEntryErrorRank (parser_result.go) per node identity: an
-	// exact cache (never a heuristic — a miss always falls back to the same
-	// recursive computation the uncached path would run), so it cannot change
-	// any result, only avoid re-deriving it. Node entries are additionally
-	// keyed by equivVersion because a Node CAN mutate while it is still the
-	// top of a live stack (pushOrExtendErrorNode/pushLexErrorRunLeaf extend an
-	// open ERROR run and bump equivVersion each time — the same invalidation
-	// signal parser_recover_c.go's cNodeMemo already relies on); a version
-	// mismatch is a cache miss, never a stale hit. pendingParent has no
-	// equivVersion field and, once its child entries are filled at
-	// construction, is never mutated again, so pointer identity alone is
-	// enough there. Both maps are per-arena rather than per-Parser because
-	// nodeArena is already threaded through every caller that needs this
-	// (stackEntryResultErrorRank/stackCompareForResultSelectionWithRawShape/
-	// forestResultLinkCompareWithRawShape), avoiding a Parser struct change.
-	// Cleared in reset() because arena node slabs — and therefore these
-	// pointers — are reused across parses on the same arena.
-	nodeErrorRankMemo          map[*Node]nodeErrorRankMemoEntry
+	// pendingParentErrorRankMemo is the pending-parent counterpart to Node's
+	// inline error-rank cache. pendingParent has no spare cache byte and, once
+	// its child entries are filled at construction, is never mutated, so
+	// pointer identity is sufficient. The map is per-arena because nodeArena
+	// is already threaded through every result-rank caller. It is dropped in
+	// reset() because pending-parent slabs reuse their pointers across parses.
 	pendingParentErrorRankMemo map[*pendingParent]int8
-}
-
-type nodeErrorRankMemoEntry struct {
-	ver  uint32
-	rank int8
 }
 
 type nodeSlab struct {
@@ -547,15 +529,9 @@ func (a *nodeArena) reset() {
 	a.internLeaves.reset()
 	a.internLeavesFull.reset()
 	a.internShiftLeafObserved = 0
-	// Node/pendingParent slab memory is reused across parses on this arena
-	// (only `used`/slab cursors reset above, not the backing storage), so a
-	// stale entry from a previous parse could otherwise alias a
-	// structurally-different node at the same address in the next parse. Drop
-	// both maps rather than clear-in-place: they are allocated lazily on
-	// first use (see cachedStackEntryErrorRank, parser_result.go) and most
-	// parses never populate them at all (only reached via the
-	// !skipErrorRank / forest link-cap comparison paths).
-	a.nodeErrorRankMemo = nil
+	// pendingParent slab memory is reused across parses on this arena, so a
+	// stale entry could otherwise alias a structurally different parent at the
+	// same address. Drop the lazily allocated map rather than clear it in place.
 	a.pendingParentErrorRankMemo = nil
 }
 

--- a/arena_test.go
+++ b/arena_test.go
@@ -471,7 +471,7 @@ func TestArenaNodeSlabClearsWrittenSlotsOnReset(t *testing.T) {
 		// Write a non-zero pointer into the node to make stale data detectable.
 		n.parent = n
 		n.flags = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError
-		n.dirtyFlag = true
+		n.errorRankCache = 3
 	}
 	if len(arena.nodeSlabs) == 0 {
 		t.Fatal("expected at least one overflow slab after allocating past primary capacity")
@@ -505,8 +505,8 @@ func TestArenaNodeSlabClearsWrittenSlotsOnReset(t *testing.T) {
 		if got.flags != 0 {
 			t.Fatalf("primary node[%d].flags after reset = %d, want 0", i, got.flags)
 		}
-		if got.dirtyFlag {
-			t.Fatalf("primary node[%d].dirtyFlag after reset = true, want false", i)
+		if got.errorRankCache != 0 {
+			t.Fatalf("primary node[%d].errorRankCache after reset = %d, want 0", i, got.errorRankCache)
 		}
 	}
 	for i := 0; i < slabUsedBeforeReset; i++ {
@@ -520,8 +520,8 @@ func TestArenaNodeSlabClearsWrittenSlotsOnReset(t *testing.T) {
 		if got.flags != 0 {
 			t.Fatalf("slab.data[%d].flags after reset = %d, want 0", i, got.flags)
 		}
-		if got.dirtyFlag {
-			t.Fatalf("slab.data[%d].dirtyFlag after reset = true, want false", i)
+		if got.errorRankCache != 0 {
+			t.Fatalf("slab.data[%d].errorRankCache after reset = %d, want 0", i, got.errorRankCache)
 		}
 	}
 }

--- a/glr_test.go
+++ b/glr_test.go
@@ -1,6 +1,7 @@
 package gotreesitter
 
 import (
+	"sync"
 	"testing"
 	"unsafe"
 )
@@ -2182,6 +2183,124 @@ func TestStackResultErrorRankIncludesCompactRefs(t *testing.T) {
 	parentStack := &glrStack{entries: []stackEntry{newStackEntryPendingParent(4, parent)}}
 	if got := stackResultErrorRank(parentStack, arena); got != 2 {
 		t.Fatalf("pending parent child error rank = %d, want 2", got)
+	}
+}
+
+func TestCachedStackEntryErrorRankUsesInlineNodeCache(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	entry := newStackEntryNode(2, leaf)
+
+	if got := cachedStackEntryErrorRank(entry, arena); got != 0 {
+		t.Fatalf("clean leaf rank = %d, want 0", got)
+	}
+	if got := leaf.errorRankCache; got != 1 {
+		t.Fatalf("clean leaf cache = %d, want encoded rank 1", got)
+	}
+	if got := cachedStackEntryErrorRank(entry, arena); got != 0 {
+		t.Fatalf("cached clean leaf rank = %d, want 0", got)
+	}
+
+	leaf.setHasError(true)
+	nodeBumpEquivVersion(leaf)
+	if leaf.errorRankCache != 0 {
+		t.Fatalf("cache after mutation = %d, want unknown", leaf.errorRankCache)
+	}
+	if got := cachedStackEntryErrorRank(entry, arena); got != 1 {
+		t.Fatalf("has-error leaf rank = %d, want 1", got)
+	}
+	if got := leaf.errorRankCache; got != 2 {
+		t.Fatalf("has-error leaf cache = %d, want encoded rank 2", got)
+	}
+
+	leaf.symbol = errorSymbol
+	nodeBumpEquivVersion(leaf)
+	if got := cachedStackEntryErrorRank(entry, arena); got != 2 {
+		t.Fatalf("ERROR leaf rank = %d, want 2", got)
+	}
+	if got := leaf.errorRankCache; got != 3 {
+		t.Fatalf("ERROR leaf cache = %d, want encoded rank 3", got)
+	}
+
+	cloned := cloneNodeInArena(arena, leaf)
+	if got := cloned.errorRankCache; got != 0 {
+		t.Fatalf("cloned leaf cache = %d, want unknown", got)
+	}
+	treeClone := cloneTreeNodesIntoArena(leaf, newNodeArena(arenaClassFull))
+	if got := treeClone.errorRankCache; got != 0 {
+		t.Fatalf("tree-cloned leaf cache = %d, want unknown", got)
+	}
+	aliased := aliasedNodeInArena(arena, nil, leaf, 2)
+	if got := aliased.errorRankCache; got != 0 {
+		t.Fatalf("aliased leaf cache = %d, want unknown", got)
+	}
+}
+
+func TestCachedStackEntryErrorRankCachesNestedNode(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	errorLeaf := newLeafNodeInArena(arena, errorSymbol, false, 0, 1, Point{}, Point{Column: 1})
+	parent := newParentNodeInArena(arena, 10, true, cloneNodeSliceInArena(arena, []*Node{errorLeaf}), nil, 0)
+
+	if got := cachedStackEntryErrorRank(newStackEntryNode(3, parent), arena); got != 2 {
+		t.Fatalf("parent rank = %d, want 2", got)
+	}
+	if got := parent.errorRankCache; got != 3 {
+		t.Fatalf("parent cache = %d, want encoded rank 3", got)
+	}
+	if got := errorLeaf.errorRankCache; got != 3 {
+		t.Fatalf("child cache = %d, want encoded rank 3", got)
+	}
+}
+
+func TestCachedStackEntryErrorRankDoesNotCacheForeignNode(t *testing.T) {
+	currentArena := newNodeArena(arenaClassIncremental)
+	oldTreeArena := newNodeArena(arenaClassFull)
+	errorLeaf := newLeafNodeInArena(oldTreeArena, errorSymbol, false, 0, 1, Point{}, Point{Column: 1})
+	parent := newParentNodeInArena(oldTreeArena, 10, true, cloneNodeSliceInArena(oldTreeArena, []*Node{errorLeaf}), nil, 0)
+	errorLeaf.errorRankCache = 1 // stale parse-time values from the old tree
+	parent.errorRankCache = 1
+
+	if got := cachedStackEntryErrorRank(newStackEntryNode(2, parent), currentArena); got != 2 {
+		t.Fatalf("foreign nested rank = %d, want 2", got)
+	}
+	if got := parent.errorRankCache; got != 1 {
+		t.Fatalf("foreign parent cache changed to %d, want untouched value 1", got)
+	}
+	if got := errorLeaf.errorRankCache; got != 1 {
+		t.Fatalf("foreign child cache changed to %d, want untouched value 1", got)
+	}
+}
+
+func TestCachedStackEntryErrorRankForeignNodeConcurrentReads(t *testing.T) {
+	oldTreeArena := newNodeArena(arenaClassFull)
+	errorLeaf := newLeafNodeInArena(oldTreeArena, errorSymbol, false, 0, 1, Point{}, Point{Column: 1})
+	parent := newParentNodeInArena(oldTreeArena, 10, true, cloneNodeSliceInArena(oldTreeArena, []*Node{errorLeaf}), nil, 0)
+	parent.errorRankCache = 1
+	entry := newStackEntryNode(2, parent)
+
+	const workers = 8
+	errCh := make(chan int, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			arena := newNodeArena(arenaClassIncremental)
+			for j := 0; j < 100; j++ {
+				if got := cachedStackEntryErrorRank(entry, arena); got != 2 {
+					errCh <- got
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for got := range errCh {
+		t.Fatalf("foreign concurrent rank = %d, want 2", got)
+	}
+	if got := parent.errorRankCache; got != 1 {
+		t.Fatalf("foreign parent cache changed to %d, want untouched value 1", got)
 	}
 }
 

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -7957,6 +7957,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 	if arena == nil {
 		cloned := &Node{}
 		*cloned = *n
+		cloned.errorRankCache = 0
 		cloneNodeFieldMetadataHeaderInto(cloned, n, nil)
 		cloned.symbol = alias
 		if lang != nil && int(alias) < len(lang.SymbolMetadata) {
@@ -7967,6 +7968,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 
 	cloned := arena.allocNode()
 	*cloned = *n
+	cloned.errorRankCache = 0
 	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
 	cloned.symbol = alias
 	if lang != nil && int(alias) < len(lang.SymbolMetadata) {
@@ -8100,6 +8102,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	if arena == nil {
 		cloned := &Node{}
 		*cloned = *n
+		cloned.errorRankCache = 0
 		cloneNodeFieldMetadataHeaderInto(cloned, n, nil)
 		if nodeHasFinalChildRefs(n) {
 			childCount := nodeChildCountNoMaterialize(n)
@@ -8115,6 +8118,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	}
 	cloned := arena.allocNode()
 	*cloned = *n
+	cloned.errorRankCache = 0
 	cloned.ownerArena = arena
 	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
 	if nodeHasFinalChildRefs(n) {

--- a/parser_result.go
+++ b/parser_result.go
@@ -905,29 +905,30 @@ func stackEntryResultErrorRank(entry stackEntry, arena *nodeArena, rank *int) {
 //
 // Node and pendingParent entries are the only kinds that can have children
 // (stackEntryNodeChildCount is 0 for every other kind), so they are the only
-// ones memoized — on the arena, not a heuristic gate: a cache miss always
-// falls back to computeStackEntryErrorRank, the same recursive walk that ran
-// unconditionally before this cache existed. This is what keeps forest
+// ones memoized. Nodes use a spare inline byte; pending parents use an arena
+// map. A cache miss always falls back to computeStackEntryErrorRank, the same
+// recursive walk that ran unconditionally before this cache existed. This is
+// what keeps forest
 // link-cap eviction scoring (glr_forest.go forestCapReplacementIndex) from
 // re-walking whole shared-prefix subtrees per comparison on shapes with many
 // raw-distinct alternatives (e.g. C# designer-style repeated-statement
-// blocks): once a given (sub)tree's rank is known, every later comparison
-// that references the same node reuses it in O(1). See
-// nodeErrorRankMemo/pendingParentErrorRankMemo's doc comment (arena.go) for
-// why Node needs equivVersion-keying and pendingParent does not.
+// blocks): once a current-arena (sub)tree's rank is known, later comparisons
+// reuse it in O(1). Foreign nodes stay read-only and recompute. See
+// Node.errorRankCache and pendingParentErrorRankMemo's doc comment (arena.go)
+// for their respective invalidation guarantees.
 func cachedStackEntryErrorRank(entry stackEntry, arena *nodeArena) int {
 	if n := stackEntryNode(entry); n != nil {
-		if arena != nil {
-			if e, ok := arena.nodeErrorRankMemo[n]; ok && e.ver == n.equivVersion {
-				return int(e.rank)
-			}
+		// Reused nodes belong to an older tree arena and may be read by more
+		// than one incremental parser. Keep their immutable read path free of
+		// cache writes, and never trust parse-time cache state after result
+		// normalization may have rewritten the returned tree.
+		cacheInline := arena != nil && n.ownerArena == arena
+		if cacheInline && n.errorRankCache != 0 {
+			return int(n.errorRankCache - 1)
 		}
 		rank := computeStackEntryErrorRank(entry, arena)
-		if arena != nil {
-			if arena.nodeErrorRankMemo == nil {
-				arena.nodeErrorRankMemo = make(map[*Node]nodeErrorRankMemoEntry, 256)
-			}
-			arena.nodeErrorRankMemo[n] = nodeErrorRankMemoEntry{ver: n.equivVersion, rank: int8(rank)}
+		if cacheInline {
+			n.errorRankCache = uint8(rank + 1)
 		}
 		return rank
 	}
@@ -955,7 +956,7 @@ func cachedStackEntryErrorRank(entry stackEntry, arena *nodeArena) int {
 // computeStackEntryErrorRank is the recursive computation
 // cachedStackEntryErrorRank memoizes: unchanged in substance from the
 // original uncached stackEntryResultErrorRank body, so every cache miss (and
-// every leaf, which is never cached) still runs exactly this logic.
+// every non-Node compact leaf, which is never cached) still runs this logic.
 func computeStackEntryErrorRank(entry stackEntry, arena *nodeArena) int {
 	if !stackEntryMaterializesForResult(entry) {
 		return 0

--- a/tree.go
+++ b/tree.go
@@ -37,7 +37,7 @@ type Node struct {
 	symbol            Symbol
 	productionID      uint16
 	flags             nodeFlags
-	dirtyFlag         bool
+	errorRankCache    uint8 // current parse arena only; 0 = unknown, rank + 1
 	subtreeHeight     uint8 // forest dedup tie-break cache (0 = uncomputed); see nodeCachedHeight
 }
 
@@ -86,14 +86,13 @@ func (n *Node) isExternalScannerToken() bool {
 }
 func (n *Node) setExternalScannerToken(v bool) { n.setFlag(nodeFlagExternalScannerToken, v) }
 func (n *Node) dirty() bool {
-	return n != nil && (n.dirtyFlag || n.hasFlag(nodeFlagDirty))
+	return n != nil && n.hasFlag(nodeFlagDirty)
 }
 
 func (n *Node) setDirty(v bool) {
 	if n == nil {
 		return
 	}
-	n.dirtyFlag = v
 	n.setFlag(nodeFlagDirty, v)
 }
 
@@ -114,6 +113,10 @@ func nodeBumpEquivVersion(n *Node) {
 	if n.equivVersion == 0 {
 		n.equivVersion = 1
 	}
+	// Error rank is a pure function of the node's current subtree. The same
+	// mutation choke point that invalidated the former version-keyed arena map
+	// now invalidates the inline cache directly.
+	n.errorRankCache = 0
 	// Any in-place node mutation can change the node's error cost / visible
 	// count, which invalidates every cached GSS prefix aggregate that may sum
 	// over it (see gssPrefixAggGen, parser_recover_c.go). Bumping the global
@@ -2970,6 +2973,7 @@ func cloneTreeNodesWithOffset(root *Node, offsetBytes uint32, offsetExtent Point
 
 func cloneNodeHeaderInto(dst, src *Node, arena *nodeArena, offset *cloneOffset) {
 	*dst = *src
+	dst.errorRankCache = 0
 	if offset != nil {
 		dst.startByte = addUint32Delta(src.startByte, int64(offset.byteDelta))
 		dst.endByte = addUint32Delta(src.endByte, int64(offset.byteDelta))

--- a/tree_test.go
+++ b/tree_test.go
@@ -20,7 +20,7 @@ func TestNodeLayoutSizeBudget(t *testing.T) {
 	var n Node
 	got := unsafe.Sizeof(n)
 	t.Logf(
-		"Node size=%d align=%d children=%d fieldMetadata=%d parent=%d ownerArena=%d startPoint=%d startByte=%d parseState=%d childIndex=%d symbol=%d rawShape=%d flags=%d dirtyFlag=%d",
+		"Node size=%d align=%d children=%d fieldMetadata=%d parent=%d ownerArena=%d startPoint=%d startByte=%d parseState=%d childIndex=%d symbol=%d rawShape=%d flags=%d errorRankCache=%d",
 		got,
 		unsafe.Alignof(n),
 		unsafe.Offsetof(n.children),
@@ -34,7 +34,7 @@ func TestNodeLayoutSizeBudget(t *testing.T) {
 		unsafe.Offsetof(n.symbol),
 		unsafe.Offsetof(n.rawShape),
 		unsafe.Offsetof(n.flags),
-		unsafe.Offsetof(n.dirtyFlag),
+		unsafe.Offsetof(n.errorRankCache),
 	)
 	const want = 104
 	if got != want {


### PR DESCRIPTION
## Summary

This replaces the arena-wide node error-rank memo with an inline per-node cache, removing a shared-map lookup and its retained allocations from the result-ranking path. The cache is populated only for nodes owned by the current parse arena; reused or foreign-tree nodes remain read-only and ignore stale parse-time values.

## Changes

- Reuse the byte formerly occupied by redundant `Node.dirtyFlag` for an encoded error-rank cache while keeping dirty state in `nodeFlags`.
- Remove `nodeErrorRankMemo` and retain the pending-parent arena memo.
- Invalidate cached ranks through the existing mutation-version hook and every parser-relevant clone/alias path.
- Add coverage for cache hits, mutation invalidation, clone/reset behavior, stale foreign nodes, and concurrent foreign-node reads.

## Validation

- Full root-package Docker suite and focused Docker race gates pass.
- JavaScript aggressive real-corpus parity passes 25/25 no-error, S-expression, and deep parity.
- The 3,447,275-byte Poppler witness passes exact Go/C no-error, S-expression, and deep parity at accepted EOF.
- Pinned count-10 full DFA improves from 7.813 ms to 6.750 ms (-13.61%), 606.93 KiB/op to 38.34 KiB/op (-93.68%), and 100 to 30 allocs/op (-70%). Incremental edit, no-edit, and compiled-query benchmarks are statistically unchanged.
- The C# designer-style n=300 benchmark improves from 289.8 ms to 258.2 ms (-10.91%); strict C# corpus results match `main` exactly.
- Poppler improves from 2.36x to 2.16x the C time and allocates about 152 MB less. Hard-2-GiB runs remain no-OOM and retain about 152 MB less heap after parsing; sampled peak RSS is 47–52 MiB higher under the changed GC schedule, so this does not claim a peak-RSS improvement.
