### PR TITLE
Remove redundant wrapper for GLR stack-entry check

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -3286,10 +3286,6 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 	return true
 }
 
-func stackEntryPayloadsEquivalentIgnoringDynamic(a, b stackEntry) bool {
-	return stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(nil, a, b)
-}
-
 func stackEntryPayloadsEquivalentIgnoringDynamicWithScratch(scratch *glrMergeScratch, a, b stackEntry) bool {
 	if stackEntryPendingParent(a) != nil || stackEntryPendingParent(b) != nil {
 		var lang *Language


### PR DESCRIPTION
## Summary

Removes an unused GLR wrapper that only forwarded to the scratch-aware stack-entry equivalence helper. The scratch-aware helper remains the single implementation, with no behavior change.

## Validation

- Canopy and exact source search confirmed the wrapper had no references.
- Root-package compilation passed.
- Focused merge and equivalence tests passed.
- `go vet .` passed.