### PR TITLE
Reclaim raw-shape storage after parse to release arena memory

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -208,7 +208,9 @@ func (p *Parser) ParseForestExperimental(source []byte) (*Tree, bool) {
 		return nil, false
 	}
 	p.finalizeForestRoot(root, source)
-	return newTreeWithArenas(root, source, p.language, arena, nil), true
+	tree := newTreeWithArenas(root, source, p.language, arena, nil)
+	arena.reclaimRawShapeStorage()
+	return tree, true
 }
 
 // ForestDeclineInfo returns where/why the forest fast path last declined (fell
@@ -453,6 +455,7 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		progress.endDetail(time.Now(), "forest_normalize_end", 0, 0, Token{}, false, nil, 0, 0, 0, false, 0, 0, fmt.Sprintf("root_end=%d", root.EndByte()))
 		progress.emit(time.Now(), "forest_try_success", 0, 0, Token{}, false, nil, 0, 0, 0, false, 0, 0, fmt.Sprintf("root_end=%d", root.EndByte()))
 	}
+	arena.reclaimRawShapeStorage()
 	return tree
 }
 

--- a/parser.go
+++ b/parser.go
@@ -4366,6 +4366,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				fmt.Sprintf("stop_reason=%s last_token_symbol=%d last_token_end=%d last_token_eof=%t", parseRuntime.StopReason, lastTokenSymbol, lastTokenEndByte, lastTokenWasEOF),
 			)
 		}
+		// Raw reduction shapes have served their final consumers by this point:
+		// result selection, transient materialization, diagnostics, and arena
+		// attribution are all complete. Do this after captureArenaStats so the
+		// returned runtime/breakdown continue to describe parse-time allocation.
+		arena.reclaimRawShapeStorage()
 		return tree
 	}
 	finalize := func(treeStacks []glrStack, stopReason ParseStopReason) *Tree {

--- a/raw_shape.go
+++ b/raw_shape.go
@@ -104,6 +104,91 @@ type rawShapeChildSlab struct {
 
 type rawShapeChildRange uint64
 
+// reclaimRawShapeStorage releases parser-only reduction-shape sidecars after
+// the returned result has been selected and fully materialized. Raw shapes are
+// not part of the public tree: queries, cursors, edits, and incremental reuse
+// read the materialized node structure instead.
+//
+// Clear every arena-owned payload's ref before resetting and trimming the
+// slabs. Returned trees can lazily materialize compact leaves and pending
+// parents after parse finalization, so clearing only the currently materialized
+// Node values would let a stale arena-relative ref escape through that later
+// materialization. Clearing all payload forms also prevents a reused subtree
+// from carrying a ref into a different parse arena, where the same numeric ref
+// could name an unrelated shape.
+func (a *nodeArena) reclaimRawShapeStorage() {
+	if a == nil {
+		return
+	}
+	clearNodeRawShapeRefs := func(nodes []Node, used int) {
+		if used > len(nodes) {
+			used = len(nodes)
+		}
+		for i := 0; i < used; i++ {
+			nodes[i].rawShape = 0
+		}
+	}
+	clearNoTreeRawShapeRefs := func(nodes []noTreeNode, used int) {
+		if used > len(nodes) {
+			used = len(nodes)
+		}
+		for i := 0; i < used; i++ {
+			nodes[i].rawShape = 0
+		}
+	}
+
+	primaryUsed := a.used
+	if primaryUsed > len(a.nodes) {
+		primaryUsed = len(a.nodes)
+	}
+	clearNodeRawShapeRefs(a.nodes, primaryUsed)
+	for i := range a.nodeSlabs {
+		clearNodeRawShapeRefs(a.nodeSlabs[i].data, a.nodeSlabs[i].used)
+	}
+	for i := range a.noTreeNodeSlabs {
+		clearNoTreeRawShapeRefs(a.noTreeNodeSlabs[i].data, a.noTreeNodeSlabs[i].used)
+	}
+	for i := range a.compactFullLeafSlabs {
+		slab := &a.compactFullLeafSlabs[i]
+		used := slab.used
+		if used > len(slab.data) {
+			used = len(slab.data)
+		}
+		for j := 0; j < used; j++ {
+			slab.data[j].rawShape = 0
+		}
+	}
+	for i := range a.pendingParentSlabs {
+		slab := &a.pendingParentSlabs[i]
+		used := slab.used
+		if used > len(slab.data) {
+			used = len(slab.data)
+		}
+		for j := 0; j < used; j++ {
+			slab.data[j].rawShape = 0
+		}
+	}
+	for i := range a.compactCheckpointLeafSlabs {
+		slab := &a.compactCheckpointLeafSlabs[i]
+		used := slab.used
+		if used > len(slab.data) {
+			used = len(slab.data)
+		}
+		for j := 0; j < used; j++ {
+			slab.data[j].rawShape = 0
+		}
+	}
+
+	// Reuse the arena's existing bounded reset policy: it drops pathological
+	// overflow while retaining a small warm prefix for the next parse. Nil'ing
+	// every slab here would force the 2 MiB full-parse base slabs to be allocated
+	// again on each pooled parse, turning reclamation into an allocation
+	// regression on ordinary files.
+	a.resetRawShapeSlabs()
+	a.resetRawShapeChildSlabs()
+	a.recomputeAllocatedBytes()
+}
+
 func rawShapeBytesForCap(n int) int64 {
 	if n <= 0 {
 		return 0

--- a/raw_shape_reclaim_test.go
+++ b/raw_shape_reclaim_test.go
@@ -1,0 +1,267 @@
+package gotreesitter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReclaimRawShapeStorageClearsArenaPayloadRefs(t *testing.T) {
+	arena := acquireNodeArena(arenaClassIncremental)
+	defer arena.Release()
+
+	node := arena.allocNodeFast()
+	noTree := arena.allocNoTreeNode()
+	compact := arena.allocCompactFullLeaf()
+	pending := arena.allocPendingParent()
+	checkpoint := arena.allocCompactCheckpointLeaf()
+
+	ref, shape := arena.allocRawShape()
+	if ref == 0 || shape == nil {
+		t.Fatal("allocRawShape returned no shape")
+	}
+	shape.childRange = arena.allocRawShapeChildren(1)
+	shape.childCount = 1
+	shapeLimit := maxRetainedRawShapeCapacityForClass(arena.class)
+	for i := 1; i < shapeLimit+defaultRawShapeSlabCap(arena.class); i++ {
+		if _, allocated := arena.allocRawShape(); allocated == nil {
+			t.Fatalf("allocRawShape failed at %d", i)
+		}
+	}
+	childLimit := maxRetainedRawShapeChildCapacityForClass(arena.class)
+	arena.allocRawShapeChildren(childLimit + 1)
+	for _, raw := range []*rawShapeRef{
+		&node.rawShape,
+		&noTree.rawShape,
+		&compact.rawShape,
+		&pending.rawShape,
+		&checkpoint.rawShape,
+	} {
+		*raw = ref
+	}
+
+	rawBytes := arena.rawShapeBytesAllocated() + arena.rawShapeChildBytesAllocated()
+	if rawBytes == 0 {
+		t.Fatal("raw-shape allocation = 0 before reclamation")
+	}
+	allocatedBefore := arena.allocatedBytes
+	arena.reclaimRawShapeStorage()
+
+	retainedRawBytes := arena.rawShapeBytesAllocated() + arena.rawShapeChildBytesAllocated()
+	maxRetainedRawBytes := rawShapeBytesForCap(shapeLimit) + rawShapeChildBytesForCap(childLimit)
+	if retainedRawBytes > maxRetainedRawBytes {
+		t.Fatalf("retained raw-shape bytes = %d, bounded maximum %d", retainedRawBytes, maxRetainedRawBytes)
+	}
+	if retainedRawBytes >= rawBytes {
+		t.Fatalf("retained raw-shape bytes = %d, want less than parse allocation %d", retainedRawBytes, rawBytes)
+	}
+	if arena.rawShapeSlabCursor != 0 || arena.rawShapeChildSlabCursor != 0 {
+		t.Fatalf("raw-shape cursors = (%d,%d), want zeroes", arena.rawShapeSlabCursor, arena.rawShapeChildSlabCursor)
+	}
+	for i, slab := range arena.rawShapeSlabs {
+		if slab.used != 0 {
+			t.Fatalf("raw-shape slab %d used = %d, want 0", i, slab.used)
+		}
+	}
+	for i, slab := range arena.rawShapeChildSlabs {
+		if slab.used != 0 {
+			t.Fatalf("raw-shape child slab %d used = %d, want 0", i, slab.used)
+		}
+	}
+	if got, want := arena.allocatedBytes, allocatedBefore-(rawBytes-retainedRawBytes); got != want {
+		t.Fatalf("allocated bytes after reclamation = %d, want %d", got, want)
+	}
+	for name, raw := range map[string]rawShapeRef{
+		"node":               node.rawShape,
+		"no-tree":            noTree.rawShape,
+		"compact-full-leaf":  compact.rawShape,
+		"pending-parent":     pending.rawShape,
+		"checkpoint-compact": checkpoint.rawShape,
+	} {
+		if raw != 0 {
+			t.Fatalf("%s raw-shape ref = %d, want 0", name, raw)
+		}
+	}
+}
+
+func TestParseReclaimsRawShapeStorageAfterAccounting(t *testing.T) {
+	EnableArenaBreakdown(true)
+	defer EnableArenaBreakdown(false)
+
+	lang := buildArithmeticLanguage()
+	tree := mustParse(t, NewParser(lang), []byte("1+2+3+4"))
+	defer tree.Release()
+
+	breakdown := assertParseRuntimeArenaBreakdown(t, tree, tree.ParseRuntime())
+	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
+	if parseRawBytes == 0 {
+		t.Fatal("parse-time raw-shape bytes = 0, want captured allocation")
+	}
+	assertTreeRawShapeStorageReclaimed(t, tree)
+	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+	if got, want := tree.ParseRuntime().ArenaBytesAllocated-tree.arena.allocatedBytes, parseRawBytes-retainedRawBytes; got != want {
+		t.Fatalf("retained arena reduction = %d, want reclaimed raw-shape allocation %d", got, want)
+	}
+	assertReachableRawShapeRefsCleared(t, tree.RootNode())
+}
+
+func TestIncrementalParseAfterRawShapeReclamationMatchesFresh(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	parser := NewParser(lang)
+	oldTree := mustParse(t, parser, []byte("1+2+3"))
+	defer oldTree.Release()
+	assertTreeRawShapeStorageReclaimed(t, oldTree)
+	root := oldTree.RootNode()
+	if child := root.Child(0); child == nil || child.Parent() != root {
+		t.Fatal("parent access failed after raw-shape reclamation")
+	}
+	cursor := NewTreeCursorFromTree(oldTree)
+	if !cursor.GotoFirstChild() || cursor.CurrentNode() == nil {
+		t.Fatal("cursor access failed after raw-shape reclamation")
+	}
+	query, err := NewQuery(`(expression) @expr`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery: %v", err)
+	}
+	if matches := query.Execute(oldTree); len(matches) == 0 {
+		t.Fatal("query access failed after raw-shape reclamation")
+	}
+
+	oldTree.Edit(InputEdit{
+		StartByte:   4,
+		OldEndByte:  5,
+		NewEndByte:  5,
+		StartPoint:  Point{Column: 4},
+		OldEndPoint: Point{Column: 5},
+		NewEndPoint: Point{Column: 5},
+	})
+	source := []byte("1+2+4")
+	incremental := mustParseIncremental(t, parser, source, oldTree)
+	defer incremental.Release()
+	fresh := mustParse(t, NewParser(lang), source)
+	defer fresh.Release()
+
+	if got, want := incremental.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang); got != want {
+		t.Fatalf("incremental tree = %s, fresh = %s", got, want)
+	}
+	assertTreeRawShapeStorageReclaimed(t, incremental)
+	assertReachableRawShapeRefsCleared(t, incremental.RootNode())
+	assertTreeRawShapeStorageReclaimed(t, fresh)
+}
+
+func TestParseForestExperimentalReclaimsRawShapeStorage(t *testing.T) {
+	lang := loadBlobForDecode(t, "json")
+	tree, ok := NewParser(lang).ParseForestExperimental([]byte(`[1, 2, 3]`))
+	if !ok || tree == nil {
+		t.Fatal("ParseForestExperimental failed")
+	}
+	defer tree.Release()
+
+	assertTreeRawShapeStorageReclaimed(t, tree)
+	assertReachableRawShapeRefsCleared(t, tree.RootNode())
+}
+
+func TestTryForestFastPathReclaimsRawShapeStorage(t *testing.T) {
+	lang := loadBlobForDecode(t, "json")
+	lang.WantsForest = true
+	previous := glrForestEnabled
+	glrForestEnabled = true
+	defer func() { glrForestEnabled = previous }()
+
+	tree := NewParser(lang).tryForestFastPath([]byte(`[1, 2, 3]`))
+	if tree == nil {
+		t.Fatal("tryForestFastPath declined")
+	}
+	defer tree.Release()
+	if !tree.forestFastPath {
+		t.Fatal("returned tree is not marked as forest fast path")
+	}
+	assertTreeRawShapeStorageReclaimed(t, tree)
+	assertReachableRawShapeRefsCleared(t, tree.RootNode())
+}
+
+func BenchmarkReturnedTreeRawShapeRetention(b *testing.B) {
+	EnableArenaBreakdown(true)
+	defer EnableArenaBreakdown(false)
+	lang := buildArithmeticLanguage()
+	source := []byte("1" + strings.Repeat("+1", 127))
+	parser := NewParser(lang)
+	var parseRawBytes int64
+	var retainedRawBytes int64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if breakdown, ok := tree.ArenaBreakdown(); ok {
+			parseRawBytes += breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
+		}
+		if tree.arena != nil {
+			retainedRawBytes += tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+		}
+		tree.Release()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(parseRawBytes)/float64(b.N), "parse-raw-shape-B/op")
+	b.ReportMetric(float64(retainedRawBytes)/float64(b.N), "retained-raw-shape-B/op")
+}
+
+func BenchmarkReclaimRawShapeStorageScan(b *testing.B) {
+	const nodeCount = 64 * 1024
+	b.ReportAllocs()
+	b.ReportMetric(nodeCount, "nodes/op")
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		arena := acquireNodeArena(arenaClassFull)
+		arena.ensureNodeCapacity(nodeCount)
+		for j := 0; j < nodeCount; j++ {
+			node := arena.allocNodeFast()
+			node.ownerArena = arena
+			node.rawShape = 1
+		}
+		if ref, shape := arena.allocRawShape(); ref == 0 || shape == nil {
+			b.Fatal("allocRawShape returned no shape")
+		}
+		arena.allocRawShapeChildren(nodeCount)
+		b.StartTimer()
+		arena.reclaimRawShapeStorage()
+		b.StopTimer()
+		arena.Release()
+	}
+}
+
+func assertTreeRawShapeStorageReclaimed(t *testing.T, tree *Tree) {
+	t.Helper()
+	if tree == nil || tree.arena == nil {
+		t.Fatal("tree has no owned arena")
+	}
+	retained := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+	maximum := rawShapeBytesForCap(maxRetainedRawShapeCapacityForClass(tree.arena.class)) +
+		rawShapeChildBytesForCap(maxRetainedRawShapeChildCapacityForClass(tree.arena.class))
+	if retained > maximum {
+		t.Fatalf("returned arena retains %d raw-shape bytes, bounded maximum %d", retained, maximum)
+	}
+	for i, slab := range tree.arena.rawShapeSlabs {
+		if slab.used != 0 {
+			t.Fatalf("returned raw-shape slab %d used = %d, want 0", i, slab.used)
+		}
+	}
+	for i, slab := range tree.arena.rawShapeChildSlabs {
+		if slab.used != 0 {
+			t.Fatalf("returned raw-shape child slab %d used = %d, want 0", i, slab.used)
+		}
+	}
+}
+
+func assertReachableRawShapeRefsCleared(t *testing.T, root *Node) {
+	t.Helper()
+	Walk(root, func(node *Node, _ int) WalkAction {
+		if node.rawShape != 0 {
+			t.Errorf("reachable node %d retains raw-shape ref %d", node.symbol, node.rawShape)
+			return WalkStop
+		}
+		return WalkContinue
+	})
+}


### PR DESCRIPTION
## Summary

Reclaims parser-only raw-shape storage after tree finalization so returned trees do not retain large reduction-shape buffers. Arena-relative references are cleared before the existing bounded slab reset preserves a small warm prefix for reuse.

## Changes

- Clear raw-shape references from arena nodes, no-tree payloads, compact leaves, pending parents, and checkpoint leaves.
- Reclaim storage after normal parsing and both forest result paths, after parse-time accounting is captured.
- Add focused coverage for bounded retention, incremental reuse, tree access, and forest parsing, plus retention and scan benchmarks.

## Validation

- Full root-package Docker suite and focused Docker race suite passed.
- Exact JavaScript Poppler comparison passed no-error, S-expression, and deep C parity.
- C# aggressive results were baseline-identical: 24/25 no-error and 20/25 exact S-expression/deep parity.
- Pinned primary benchstat was unchanged: full parse 6.916 ms vs 7.176 ms (`p=0.247`); both incremental paths and allocations were unchanged; full-parse bytes were 38.33 vs 38.34 KiB/op.
- Hard-2-GiB retained-tree probes reduced post-GC heap by exactly 192 MiB, from about 1.064 GB to 862.8 MB. Peak RSS remained noisy and is not claimed as an improvement.
- The bounded warm-parse design measured about 18.8 KiB/op; an all-slab-drop variant was rejected after measuring about 4.21 MiB/op.

## Review focus

Please focus on finalization ordering, stale arena-relative reference clearing, and the bounded slab/accounting reset.