### PR TITLE
perf(parser): compact oversized returned-tree arenas

### DIFF
--- a/final_tree_compaction.go
+++ b/final_tree_compaction.go
@@ -1,0 +1,227 @@
+package gotreesitter
+
+import (
+	"math"
+	"unsafe"
+)
+
+const (
+	// Returned-tree compaction is reserved for exceptional full parses. The
+	// final-tree walk is itself O(nodes), so ordinary parses must fail the cheap
+	// retained-arena check before doing any extra work.
+	minFinalTreeCompactionArenaBytes = 512 * 1024 * 1024
+	minFinalTreeCompactionReclaim    = 256 * 1024 * 1024
+	finalTreeCompactionFixedHeadroom = 64 * 1024 * 1024
+)
+
+// maybeCompactReturnedFullTree copies a completed full-parse result into a
+// right-sized arena when discarded GLR alternatives otherwise keep hundreds
+// of megabytes of Node and slice slabs alive with the returned tree.
+//
+// Keep this at the outer Parser.Parse boundary, after retry selection,
+// normalization, and recovery-result replacement. parseInternal results can
+// still be discarded by those stages.
+func (p *Parser) maybeCompactReturnedFullTree(tree *Tree, source []byte) *Tree {
+	return p.maybeCompactReturnedFullTreeWithBudget(tree, source, parseMemoryBudgetForParser(p, len(source)))
+}
+
+func (p *Parser) maybeCompactReturnedFullTreeWithBudget(tree *Tree, source []byte, memoryBudget int64) *Tree {
+	if !eligibleForFinalTreeCompaction(p, tree, source) {
+		return tree
+	}
+
+	arena := tree.arena
+	retainedBytes := arena.allocatedBytes
+	if retainedBytes < minFinalTreeCompactionArenaBytes {
+		return tree
+	}
+
+	stats := collectMaterializedFinalTreeStorageStats(tree.root)
+	estimatedBytes, ok := estimateCompactedFinalTreeBytes(stats)
+	if !ok || !finalTreeCompactionWorthwhile(retainedBytes, estimatedBytes, memoryBudget) {
+		return tree
+	}
+
+	destination := acquireNodeArena(arenaClassFull)
+	if !prepareArenaForFinalTreeClone(destination, stats) {
+		destination.Release()
+		return tree
+	}
+	root := cloneTreeNodesIntoArena(tree.root, destination)
+	if root == nil {
+		destination.Release()
+		return tree
+	}
+
+	// The estimate is deliberately conservative, but keep the old tree if a
+	// pooled destination happened to retain enough backing storage to erase the
+	// expected win.
+	if !finalTreeCompactionWorthwhile(retainedBytes, destination.allocatedBytes, memoryBudget) {
+		destination.Release()
+		return tree
+	}
+
+	tree.root = root
+	tree.arena = destination
+	tree.lastEditedLeaf = nil
+	arena.Release()
+	return tree
+}
+
+func eligibleForFinalTreeCompaction(p *Parser, tree *Tree, source []byte) bool {
+	if p == nil || tree == nil || tree.released || tree.root == nil || tree.arena == nil {
+		return false
+	}
+	if p.noTreeBenchmarkOnly || p.noResultCompatibilityBenchmarkOnly || p.crecoverySwallowedErrorCheckActive {
+		return false
+	}
+	if tree.sourceEncoding != InputEncodingUTF8 || tree.sourceUTF16 != nil || len(source) != len(tree.source) {
+		return false
+	}
+	if tree.ParseStopReason() != ParseStopAccepted || tree.parseRuntime.Truncated || tree.forestFastPath || tree.incrementalReuseDisabled {
+		return false
+	}
+	if tree.resultCompatibilityPending || tree.externalScannerCheckpointsDeferred || len(tree.includedRanges) != 0 || len(tree.edits) != 0 {
+		return false
+	}
+	if len(tree.borrowedArena) != 0 || tree.arena.class != arenaClassFull || tree.arena.refs.Load() != 1 {
+		return false
+	}
+	if tree.root.ownerArena != tree.arena || tree.arena.finalChildRefs {
+		return false
+	}
+	return true
+}
+
+func collectMaterializedFinalTreeStorageStats(root *Node) finalTreeMaterializationStats {
+	var stats finalTreeMaterializationStats
+	if root == nil {
+		return stats
+	}
+	var local [128]*Node
+	stack := local[:0]
+	stack = append(stack, root)
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		if node == nil {
+			continue
+		}
+		stats.nodes++
+		if metadata := node.fieldMetadata; metadata != nil {
+			stats.nodeFieldMetadata++
+			stats.fieldIDElements += uint64(len(metadata.ids))
+			stats.fieldSourceElements += uint64(len(metadata.sources))
+		}
+		childCount := len(node.children)
+		if childCount == 0 {
+			stats.leafNodes++
+			continue
+		}
+		stats.parentNodes++
+		stats.childSlices++
+		stats.childPointers += uint64(childCount)
+		for i := childCount - 1; i >= 0; i-- {
+			stack = append(stack, node.children[i])
+		}
+	}
+	return stats
+}
+
+func prepareArenaForFinalTreeClone(arena *nodeArena, stats finalTreeMaterializationStats) bool {
+	if arena == nil || arena.used != 0 {
+		return false
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	counts := [...]uint64{
+		stats.nodes,
+		stats.childPointers,
+		stats.fieldIDElements,
+		stats.fieldSourceElements,
+		stats.nodeFieldMetadata,
+	}
+	for _, count := range counts {
+		if count > maxInt {
+			return false
+		}
+	}
+
+	arena.ensureExactNodeCapacity(int(stats.nodes))
+	if stats.childPointers > 0 {
+		arena.childSlabs = []childSliceSlab{{data: make([]*Node, int(stats.childPointers))}}
+	} else {
+		arena.childSlabs = nil
+	}
+	if stats.fieldIDElements > 0 {
+		arena.fieldSlabs = []fieldSliceSlab{{data: make([]FieldID, int(stats.fieldIDElements))}}
+	} else {
+		arena.fieldSlabs = nil
+	}
+	if stats.fieldSourceElements > 0 {
+		arena.fieldSourceSlabs = []fieldSourceSliceSlab{{data: make([]uint8, int(stats.fieldSourceElements))}}
+	} else {
+		arena.fieldSourceSlabs = nil
+	}
+	if stats.nodeFieldMetadata > 0 {
+		arena.nodeFieldMetadataSlabs = []nodeFieldMetadataSlab{{data: make([]nodeFieldMetadata, int(stats.nodeFieldMetadata))}}
+	} else {
+		arena.nodeFieldMetadataSlabs = nil
+	}
+	arena.childSlabCursor = 0
+	arena.fieldSlabCursor = 0
+	arena.fieldSourceSlabCursor = 0
+	arena.nodeFieldMetadataSlabCursor = 0
+	arena.recomputeAllocatedBytes()
+	return true
+}
+
+func estimateCompactedFinalTreeBytes(stats finalTreeMaterializationStats) (int64, bool) {
+	total := uint64(finalTreeCompactionFixedHeadroom)
+	parts := [...]struct {
+		count uint64
+		size  uintptr
+	}{
+		{stats.nodes, unsafe.Sizeof(Node{})},
+		{stats.childPointers, unsafe.Sizeof((*Node)(nil))},
+		{stats.nodeFieldMetadata, unsafe.Sizeof(nodeFieldMetadata{})},
+		{stats.fieldIDElements, unsafe.Sizeof(FieldID(0))},
+		{stats.fieldSourceElements, unsafe.Sizeof(uint8(0))},
+	}
+	for _, part := range parts {
+		size := uint64(part.size)
+		if size != 0 && part.count > (math.MaxUint64-total)/size {
+			return 0, false
+		}
+		total += part.count * size
+	}
+	if total > math.MaxInt64 {
+		return 0, false
+	}
+	return int64(total), true
+}
+
+func finalTreeCompactionWorthwhile(retainedBytes, compactedBytes, memoryBudget int64) bool {
+	if retainedBytes <= 0 || compactedBytes <= 0 || memoryBudget <= 0 || compactedBytes >= retainedBytes {
+		return false
+	}
+	reclaim := retainedBytes - compactedBytes
+	if reclaim < minFinalTreeCompactionReclaim {
+		return false
+	}
+	// Require at least 30% retained-arena reduction.
+	if reclaim > math.MaxInt64/10 || retainedBytes > math.MaxInt64/3 {
+		return false
+	}
+	if reclaim*10 < retainedBytes*3 {
+		return false
+	}
+	// Leave one quarter of the parser memory budget for non-arena heap,
+	// scratch still alive at the outer return boundary, and GC pacing while
+	// both arenas coexist.
+	peakAllowance := memoryBudget - memoryBudget/4
+	if retainedBytes > peakAllowance || compactedBytes > peakAllowance-retainedBytes {
+		return false
+	}
+	return true
+}

--- a/final_tree_compaction_test.go
+++ b/final_tree_compaction_test.go
@@ -1,0 +1,268 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+func TestFinalTreeCompactionWorthwhileForMeasuredLargeTree(t *testing.T) {
+	stats := finalTreeMaterializationStats{
+		nodes:               3_321_766,
+		parentNodes:         872_327,
+		leafNodes:           2_449_439,
+		nodeFieldMetadata:   566_534,
+		fieldedParentNodes:  566_534,
+		childPointers:       3_321_765,
+		fieldIDElements:     1_756_684,
+		fieldSourceElements: 1_756_684,
+	}
+	estimated, ok := estimateCompactedFinalTreeBytes(stats)
+	if !ok {
+		t.Fatal("estimateCompactedFinalTreeBytes rejected measured counts")
+	}
+	const retained = int64(834_842_568)
+	if !finalTreeCompactionWorthwhile(retained, estimated, 2<<30) {
+		t.Fatalf("measured large tree should compact: retained=%d estimated=%d", retained, estimated)
+	}
+	if finalTreeCompactionWorthwhile(retained, estimated, 1<<30) {
+		t.Fatal("compaction should be rejected without coexistence headroom")
+	}
+}
+
+func TestFinalTreeCompactionWorthwhileRejectsMarginalSavings(t *testing.T) {
+	tests := []struct {
+		name      string
+		retained  int64
+		compacted int64
+		budget    int64
+	}{
+		{name: "below absolute threshold", retained: 700 << 20, compacted: 500 << 20, budget: 2 << 30},
+		{name: "below fractional threshold", retained: 1 << 30, compacted: 750 << 20, budget: 3 << 30},
+		{name: "no savings", retained: 700 << 20, compacted: 700 << 20, budget: 2 << 30},
+		{name: "no budget", retained: 700 << 20, compacted: 300 << 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if finalTreeCompactionWorthwhile(tt.retained, tt.compacted, tt.budget) {
+				t.Fatal("marginal or unsafe compaction was accepted")
+			}
+		})
+	}
+}
+
+func TestMaybeCompactReturnedFullTreePreservesTreeBehavior(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("ab")
+	arena := acquireNodeArena(arenaClassFull)
+
+	left := newLeafNodeInArena(arena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
+	left.parseState = 7
+	right := newLeafNodeInArena(arena, Symbol(2), true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	right.parseState = 9
+	children := arena.allocNodeSlice(2)
+	children[0], children[1] = left, right
+	fields := arena.allocFieldIDSlice(2)
+	fields[0], fields[1] = FieldID(1), FieldID(2)
+	root := newParentNode(arena, Symbol(7), true, children, fields, 3)
+	root.parseState = 11
+
+	tree := newTreeWithArenas(root, source, lang, arena, nil)
+	tree.setParseRuntime(ParseRuntime{
+		StopReason:      ParseStopAccepted,
+		ExpectedEOFByte: uint32(len(source)),
+		RootEndByte:     uint32(len(source)),
+	})
+	fastStats := collectMaterializedFinalTreeStorageStats(root)
+	fullStats := collectFinalTreeMaterializationStats(root, lang)
+	if fastStats.nodes != fullStats.nodes ||
+		fastStats.parentNodes != fullStats.parentNodes ||
+		fastStats.leafNodes != fullStats.leafNodes ||
+		fastStats.nodeFieldMetadata != fullStats.nodeFieldMetadata ||
+		fastStats.childPointers != fullStats.childPointers ||
+		fastStats.fieldIDElements != fullStats.fieldIDElements ||
+		fastStats.fieldSourceElements != fullStats.fieldSourceElements {
+		t.Fatalf("storage stats differ: fast=%+v full=%+v", fastStats, fullStats)
+	}
+	beforeSExpr := tree.RootNode().SExpr(lang)
+	oldRoot := tree.root
+	oldArena := tree.arena
+
+	// Model a large post-parse arena without allocating hundreds of MiB in a
+	// unit test. The compaction decision uses retained backing, while the clone
+	// itself still exercises real arena storage and ownership.
+	oldArena.allocatedBytes = 800 << 20
+	parser := &Parser{language: lang}
+	got := parser.maybeCompactReturnedFullTreeWithBudget(tree, source, 2<<30)
+	if got != tree {
+		t.Fatal("compaction replaced the Tree wrapper")
+	}
+	if tree.arena == oldArena {
+		t.Fatal("tree retained the oversized arena")
+	}
+	if tree.root == oldRoot {
+		t.Fatal("tree retained the original root node")
+	}
+	if refs := oldArena.refs.Load(); refs != 0 {
+		t.Fatalf("old arena refs = %d, want 0", refs)
+	}
+	defer tree.Release()
+
+	newRoot := tree.RootNode()
+	if got := newRoot.SExpr(lang); got != beforeSExpr {
+		t.Fatalf("S-expression changed: got %q, want %q", got, beforeSExpr)
+	}
+	if got := newRoot.FieldNameForChild(0, lang); got != "name" {
+		t.Fatalf("first child field = %q, want name", got)
+	}
+	if got := newRoot.FieldNameForChild(1, lang); got != "body" {
+		t.Fatalf("second child field = %q, want body", got)
+	}
+	if child := newRoot.Child(0); child == nil || child.Parent() != newRoot || child.parseState != 7 {
+		t.Fatal("first child parent link or parser state changed")
+	}
+
+	cursor := NewTreeCursorFromTree(tree)
+	if !cursor.GotoFirstChild() || cursor.CurrentNode() != newRoot.Child(0) {
+		t.Fatal("cursor could not enter the compacted tree")
+	}
+	query, err := NewQuery(`(identifier) @ident`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery: %v", err)
+	}
+	if matches := query.Execute(tree); len(matches) != 1 {
+		t.Fatalf("query matches = %d, want 1", len(matches))
+	}
+}
+
+func TestFinalTreeCompactionEligibilityIsNarrow(t *testing.T) {
+	lang := testLanguage()
+	source := []byte("x")
+	arena := acquireNodeArena(arenaClassFull)
+	root := newLeafNodeInArena(arena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
+	tree := newTreeWithArenas(root, source, lang, arena, nil)
+	tree.setParseRuntime(ParseRuntime{StopReason: ParseStopAccepted, RootEndByte: 1, ExpectedEOFByte: 1})
+	parser := &Parser{language: lang}
+	if !eligibleForFinalTreeCompaction(parser, tree, source) {
+		t.Fatal("fresh accepted full parse should be eligible")
+	}
+	tree.resultCompatibilityPending = true
+	if eligibleForFinalTreeCompaction(parser, tree, source) {
+		t.Fatal("deferred compatibility tree should be excluded")
+	}
+	tree.resultCompatibilityPending = false
+	tree.externalScannerCheckpointsDeferred = true
+	if eligibleForFinalTreeCompaction(parser, tree, source) {
+		t.Fatal("deferred external checkpoints should be excluded")
+	}
+	tree.externalScannerCheckpointsDeferred = false
+	tree.arena.finalChildRefs = true
+	if eligibleForFinalTreeCompaction(parser, tree, source) {
+		t.Fatal("lazy final-child refs should be excluded")
+	}
+	tree.arena.finalChildRefs = false
+	tree.Release()
+}
+
+func TestIncrementalParseAfterFinalTreeCompactionMatchesFresh(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	parser := NewParser(lang)
+	source := []byte("1+2+3")
+	oldTree := mustParse(t, parser, source)
+	oldArena := oldTree.arena
+	oldArena.allocatedBytes = 800 << 20
+	parser.maybeCompactReturnedFullTreeWithBudget(oldTree, source, 2<<30)
+	if oldTree.arena == oldArena {
+		t.Fatal("test tree was not compacted")
+	}
+	defer oldTree.Release()
+
+	oldTree.Edit(InputEdit{
+		StartByte:   4,
+		OldEndByte:  5,
+		NewEndByte:  5,
+		StartPoint:  Point{Column: 4},
+		OldEndPoint: Point{Column: 5},
+		NewEndPoint: Point{Column: 5},
+	})
+	updated := []byte("1+2+4")
+	incremental := mustParseIncremental(t, parser, updated, oldTree)
+	defer incremental.Release()
+	fresh := mustParse(t, NewParser(lang), updated)
+	defer fresh.Release()
+
+	if got, want := incremental.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang); got != want {
+		t.Fatalf("incremental tree = %s, fresh = %s", got, want)
+	}
+}
+
+func TestConcurrentReadsAfterFinalTreeCompaction(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	source := []byte("1+2+3+4")
+	parser := NewParser(lang)
+	tree := mustParse(t, parser, source)
+	oldArena := tree.arena
+	oldArena.allocatedBytes = 800 << 20
+	parser.maybeCompactReturnedFullTreeWithBudget(tree, source, 2<<30)
+	if tree.arena == oldArena {
+		t.Fatal("test tree was not compacted")
+	}
+	defer tree.Release()
+
+	const readers = 8
+	errors := make(chan string, readers)
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				root := tree.RootNode()
+				first := root.Child(0)
+				if first == nil || first.Parent() != root {
+					errors <- "parent link changed"
+					return
+				}
+				if next := first.NextSibling(); next != nil && next.PrevSibling() != first {
+					errors <- "sibling links changed"
+					return
+				}
+				cursor := NewTreeCursorFromTree(tree)
+				if !cursor.GotoFirstChild() || cursor.CurrentNode() == nil {
+					errors <- "cursor traversal failed"
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for message := range errors {
+		t.Fatal(message)
+	}
+}
+
+func TestCloneTreePreservesRecordedExternalScannerCheckpoint(t *testing.T) {
+	sourceArena := acquireNodeArena(arenaClassIncremental)
+	defer sourceArena.Release()
+	destinationArena := acquireNodeArena(arenaClassIncremental)
+	defer destinationArena.Release()
+
+	leaf := newLeafNodeInArena(sourceArena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
+	startState := []byte{1, 2, 3}
+	endState := []byte{4, 5, 6}
+	if !sourceArena.recordExternalScannerLeafCheckpoint(leaf, startState, endState) {
+		t.Fatal("recordExternalScannerLeafCheckpoint failed")
+	}
+	clone := cloneTreeNodesIntoArena(leaf, destinationArena)
+	cp, ok := externalScannerCheckpointRefForNode(clone)
+	if !ok {
+		t.Fatal("cloned checkpoint not found")
+	}
+	if got := destinationArena.externalScannerSnapshotBytes(cp.start); !bytes.Equal(got, startState) {
+		t.Fatalf("cloned start state = %v, want %v", got, startState)
+	}
+	if got := destinationArena.externalScannerSnapshotBytes(cp.end); !bytes.Equal(got, endState) {
+		t.Fatalf("cloned end state = %v, want %v", got, endState)
+	}
+}

--- a/parser_api.go
+++ b/parser_api.go
@@ -962,6 +962,7 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 		}
 		p.normalizeReturnedTreeForParse(tree, source)
 		tree = p.resolveCRecoverySwallowedError(source, tree)
+		tree = p.maybeCompactReturnedFullTree(tree, source)
 	}
 	return tree, nil
 }

--- a/tree.go
+++ b/tree.go
@@ -1878,6 +1878,7 @@ type finalTreeMaterializationStats struct {
 	nodes                uint64
 	parentNodes          uint64
 	leafNodes            uint64
+	nodeFieldMetadata    uint64
 	fieldedParentNodes   uint64
 	unfieldedParentNodes uint64
 	visibleParentNodes   uint64
@@ -1920,6 +1921,9 @@ func collectFinalNodeStats(n *Node, lang *Language, stats *finalTreeMaterializat
 		return
 	}
 	stats.nodes++
+	if n.fieldMetadata != nil {
+		stats.nodeFieldMetadata++
+	}
 	if childRange, ok := n.ownerArena.finalChildRange(n); ok {
 		childCount := childRange.count()
 		if childCount == 0 {
@@ -2878,7 +2882,7 @@ func cloneTreeNodesIntoArena(root *Node, arena *nodeArena) *Node {
 
 		cloneNodeFieldMetadataInto(newNode, oldNode, arena)
 
-		if cloneFinalChildRefsIntoArena(oldNode, newNode, arena, nil) {
+		if oldNode.ownerArena != nil && oldNode.ownerArena.finalChildRefs && cloneFinalChildRefsIntoArena(oldNode, newNode, arena, nil) {
 			continue
 		}
 		if n := len(oldNode.children); n > 0 {
@@ -2985,6 +2989,9 @@ func cloneNodeHeaderInto(dst, src *Node, arena *nodeArena, offset *cloneOffset) 
 	dst.parent = nil
 	dst.childIndex = -1
 	dst.ownerArena = arena
+	if src.ownerArena == nil || src.ownerArena.externalScannerCheckpointRecords == 0 {
+		return
+	}
 	if cp, ok := externalScannerCheckpointRefForNode(src); ok {
 		if cloned, ok := cloneExternalScannerCheckpointRef(src.ownerArena, arena, cp); ok && arena.setExternalScannerCheckpoint(dst, cloned) {
 			arena.externalScannerCheckpointRecords++
@@ -3010,8 +3017,12 @@ func cloneNodeFieldMetadataInto(dst, src *Node, arena *nodeArena) {
 	if dst == nil || src == nil {
 		return
 	}
-	fieldIDs := cloneFieldIDsIntoArena(arena, src.fieldIDs())
-	fieldSources := cloneFieldSourcesIntoArena(arena, src.fieldSources())
+	if src.fieldMetadata == nil {
+		dst.clearFieldMetadata()
+		return
+	}
+	fieldIDs := cloneFieldIDsIntoArena(arena, src.fieldMetadata.ids)
+	fieldSources := cloneFieldSourcesIntoArena(arena, src.fieldMetadata.sources)
 	dst.setFieldMetadata(fieldIDs, fieldSources)
 }
 


### PR DESCRIPTION
## Summary

- Compact exceptionally large completed UTF-8 DFA parse results into a right-sized arena after retry selection, normalization, and recovery-result resolution.
- Require unique ownership, at least 512 MiB of retained arena storage, at least 256 MiB and 30% projected reclaim, and enough budget headroom for both arenas to coexist.
- Exclude forest, incremental, included-range, borrowed-arena, deferred compatibility/checkpoint, and lazy final-child results.
- Pre-size the destination from the materialized tree and avoid empty scanner-checkpoint lookups during cloning.

## Measured result

On the exact 3,447,275-byte JavaScript Poppler witness under a hard 2 GiB container (`GOMAXPROCS=1`, pinned CPU, `GOMEMLIMIT=1536MiB`, parser budget 2 GiB):

- retained heap after GC: 862,803,056 B → 409,862,040 B (-431.96 MiB, -52.50%)
- parse elapsed: 13.236 s → 14.293 s (+7.98%)
- peak RSS: 1,605,760 KiB → 1,642,716 KiB (+2.30%)
- accepted error-free root at EOF in both runs
- exact Go/C no-error, S-expression, and deep parity: true

Macro timing on this witness is noisy; the controlled benchmark trio remains statistically unchanged:

- full DFA: 8.222 ms → 8.291 ms (p=0.579)
- one-byte incremental: 1.319 µs → 1.363 µs (p=0.127)
- no-edit incremental: 6.130 ns → 6.134 ns (p=0.631)
- full DFA allocation: 38.38 KiB / 30 allocs in both runs

## Validation

- full root-package suite in Docker
- focused race coverage for compacted-tree traversal, incremental reuse, and scanner-checkpoint cloning
- exact Poppler Go/C parity
- compacted-tree fields, parser states, parent/sibling links, cursor, query, and incremental-vs-fresh tests
- `go vet .` in Docker

The existing large mid-file Poppler incremental probe stops at the same byte with the same `no_stacks_alive` reason on v0.26.0 and this branch; this change does not widen that behavior.
