### PR TITLE
perf: eliminate recovered repetition blowups

### DIFF
--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -159,6 +159,17 @@ var cRepetitionSkipOptOut = map[string]bool{
 	"c_sharp": true,
 }
 
+// cRecoveredRepetitionSkipOptOut lists languages whose current recovery
+// selection still depends on retaining the repetition-shift arm during or
+// after recovery. Clean lineages continue to use C's repetition fold.
+var cRecoveredRepetitionSkipOptOut = map[string]bool{
+	// PHP's recovered Symfony TransportResponseTrait and TwigExtensionTest
+	// witnesses change from their C-matching clean result to ERROR when the
+	// fold is applied after recovery. Keep the exception recovery-scoped so
+	// clean PHP lists retain the linear C path.
+	"php": true,
+}
+
 // cRepetitionSkipConflictChoice is C tree-sitter's dispatch rule for
 // {repetition SHIFT, REDUCE} conflicts, applied engine-wide. C's action loop
 // (parser-repos/tree-sitter/lib/src/parser.c:1625, ts_parser__advance)
@@ -175,18 +186,20 @@ var cRepetitionSkipOptOut = map[string]bool{
 //
 // Scope: exactly-1 REDUCE + exactly-1 repetition SHIFT (the shape where C's
 // semantics are a deterministic fold; with 2+ REDUCEs C itself forks the
-// reduce versions, which our GLR fork approximates). Gated per-stack to
-// error-free lineages by the sticky !cEverErrored discipline established by
-// the recovery-wreckage counterexamples from the original php comma-list fold:
-// inside recovery wreckage the repetition-shift arm can be the branch the
-// recovery cost competition keeps, so wreckage-descended lineages keep the
-// ordinary GLR fork. Exact recovered-lineage exceptions are handled by
+// reduce versions, which our GLR fork approximates). The C rule also applies
+// while a version is recovering. Languages with a confirmed Go recovery-
+// selection counterexample are held out by cRecoveredRepetitionSkipOptOut;
+// exact recovered-lineage exceptions are handled by
 // conflictPolicyChoiceForDispatch before this global rule.
 func (p *Parser) cRepetitionSkipConflictChoice(s *glrStack, actions []ParseAction) (ParseAction, bool) {
 	if p == nil || p.language == nil || cRepetitionSkipOptOut[p.language.Name] {
 		return ParseAction{}, false
 	}
-	if s == nil || s.cRec != nil || s.cPaused || s.cRecoverMissingGroup != nil || s.cEverErrored {
+	if s == nil {
+		return ParseAction{}, false
+	}
+	if cRecoveredRepetitionSkipOptOut[p.language.Name] &&
+		(s.cRec != nil || s.cPaused || s.cRecoverMissingGroup != nil || s.cEverErrored) {
 		return ParseAction{}, false
 	}
 	return singleReduceAgainstRepetitionShiftConflictChoice(actions)

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -457,7 +457,6 @@ func TestRecoveredRepetitionReducePolicyRequiresExactRowAndShape(t *testing.T) {
 			ReduceSymbols: []Symbol{68},
 		}},
 	}
-	parser := NewParser(lang)
 	stack := &glrStack{cEverErrored: true}
 	valid := []ParseAction{
 		{Type: ParseActionReduce, Symbol: 68, ChildCount: 2},
@@ -477,8 +476,8 @@ func TestRecoveredRepetitionReducePolicyRequiresExactRowAndShape(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, stack, Token{Symbol: tc.token}, tc.state, tc.actions, 2, nil); ok {
-				t.Fatalf("picked %+v, want ordinary GLR fork", chosen)
+			if chosen, ok := conflictPolicyChoiceForDispatch(lang, stack, Token{Symbol: tc.token}, tc.state, tc.actions); ok {
+				t.Fatalf("picked recovered policy %+v, want policy miss", chosen)
 			}
 		})
 	}

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -441,8 +441,8 @@ func TestRecoveredRepetitionReducePolicyAppliesOnlyToIdleRecoveredLineage(t *tes
 		{cEverErrored: true, cRecoverMissingGroup: &cRecGroup{}},
 	}
 	for i, stack := range activeRecovery {
-		if chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, stack, tok, 86, actions, 2, nil); ok {
-			t.Fatalf("active recovery case %d picked %+v, want GLR fork", i, chosen)
+		if chosen, ok := conflictPolicyChoiceForDispatch(lang, stack, tok, 86, actions); ok {
+			t.Fatalf("active recovery case %d picked recovered policy %+v, want policy miss", i, chosen)
 		}
 	}
 }

--- a/glr.go
+++ b/glr.go
@@ -1907,12 +1907,19 @@ func cRecoveryMergeCostsDifferForParser(p *Parser, a, b *glrStack) bool {
 		!(b != nil && (b.cPaused || b.cRec != nil)) {
 		return false
 	}
-	scratch := glrMergeScratch{
-		language:      p.language,
-		trace:         p.glrTrace,
-		cRecoveryCost: true,
+	scratch := p.mergeScratch
+	if scratch == nil {
+		local := glrMergeScratch{
+			language:      p.language,
+			trace:         p.glrTrace,
+			cRecoveryCost: true,
+		}
+		return cRecoveryMergeCostsDiffer(&local, a, b)
 	}
-	return cRecoveryMergeCostsDiffer(&scratch, a, b)
+	scratch.language = p.language
+	scratch.trace = p.glrTrace
+	scratch.cRecoveryCost = true
+	return cRecoveryMergeCostsDiffer(scratch, a, b)
 }
 
 func traceCRecoverMergeDecision(scratch *glrMergeScratch, phase, decision string, incumbent, candidate glrStack) {

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -73,6 +73,7 @@ type gssScratch struct {
 	demotions         uint64
 	nodesDemoted      uint64
 	audit             *runtimeAudit
+	frontier          conflictReduceFrontierScratch
 }
 
 type gssNodeSlab struct {
@@ -459,7 +460,7 @@ func (s *gssScratch) reset() {
 		s.demotions = 0
 		s.nodesDemoted = 0
 		s.skipClear = false
-		s.allocatedBytes = 0
+		s.allocatedBytes = s.frontier.allocatedBytes()
 		s.audit = nil
 		return
 	}
@@ -560,5 +561,6 @@ func (s *gssScratch) recomputeAllocatedBytes() {
 	for i := range s.slabs {
 		total += gssNodeBytesForCap(len(s.slabs[i].data))
 	}
+	total += s.frontier.allocatedBytes()
 	s.allocatedBytes = total
 }

--- a/glr_test.go
+++ b/glr_test.go
@@ -3047,6 +3047,40 @@ func TestMergeStacksCRecoveryCostBlocksGSSMerge(t *testing.T) {
 	}
 }
 
+func TestCRecoveryMergeCostComparisonReusesParserScratch(t *testing.T) {
+	var gssScratch gssScratch
+	node := NewLeafNode(11, true, 0, 5, Point{}, Point{Column: 5})
+	entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+	clean := glrStack{
+		gss:        buildGSSStack(entries, &gssScratch),
+		byteOffset: 5,
+	}
+	paused := clean
+	paused.cPaused = true
+
+	var mergeScratch glrMergeScratch
+	mergeScratch.beginEquivEpoch()
+	mergeScratch.ensureMergeHotCaches()
+	parser := &Parser{
+		language:                         &Language{},
+		errorCostCompetition:             true,
+		crecoveryCostCompetitionRelevant: true,
+		mergeScratch:                     &mergeScratch,
+	}
+	if !cRecoveryMergeCostsDifferForParser(parser, &clean, &paused) {
+		t.Fatal("cost comparison treated clean and paused stacks as equal")
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if !cRecoveryMergeCostsDifferForParser(parser, &clean, &paused) {
+			panic("cost comparison changed after warmup")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("warm recovery cost comparison allocations = %g, want 0", allocs)
+	}
+}
+
 func TestCNodeErrorCostScratchTracksEquivVersion(t *testing.T) {
 	lang := &Language{SymbolMetadata: make([]SymbolMetadata, 12)}
 	lang.SymbolMetadata[11].Visible = true

--- a/grammars/uxntal_scanner.go
+++ b/grammars/uxntal_scanner.go
@@ -2,11 +2,10 @@
 
 package grammars
 
-import gotreesitter "github.com/odvcencio/gotreesitter"
+import (
+	"unicode"
 
-// External token indexes for the uxntal grammar.
-const (
-	uxntalTokComment = 0
+	gotreesitter "github.com/odvcencio/gotreesitter"
 )
 
 const (
@@ -21,9 +20,9 @@ func (UxntalExternalScanner) Destroy(payload any)                   {}
 func (UxntalExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (UxntalExternalScanner) Deserialize(payload any, buf []byte)   {}
 
-func (UxntalExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
-	if !uxntalValid(validSymbols, uxntalTokComment) {
-		return false
+func (UxntalExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, _ []bool) bool {
+	for unicode.IsSpace(lexer.Lookahead()) {
+		lexer.Advance(false)
 	}
 	if lexer.Lookahead() != '(' {
 		return false
@@ -34,7 +33,7 @@ func (UxntalExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 	for depth > 0 {
 		ch := lexer.Lookahead()
 		if ch == 0 {
-			break
+			return false
 		}
 		if ch == '(' {
 			depth++
@@ -48,5 +47,3 @@ func (UxntalExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer
 	lexer.SetResultSymbol(uxntalSymComment)
 	return true
 }
-
-func uxntalValid(vs []bool, i int) bool { return i < len(vs) && vs[i] }

--- a/grammars/uxntal_scanner_test.go
+++ b/grammars/uxntal_scanner_test.go
@@ -1,0 +1,77 @@
+//go:build !grammar_subset || grammar_subset_uxntal
+
+package grammars
+
+import (
+	"testing"
+	_ "unsafe"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func TestUxntalScannerConsumesWhitespaceAndNestedComment(t *testing.T) {
+	source := []byte("\n\t( outer (inner) tail )next")
+	lexer := newUxntalExternalLexer(source, 0, 0, 0)
+	if !((UxntalExternalScanner{}).Scan(nil, lexer, nil)) {
+		t.Fatal("Scan returned false for a nested comment")
+	}
+	tok, ok := uxntalExternalLexerToken(lexer)
+	if !ok {
+		t.Fatal("Scan returned true without a token")
+	}
+	if got, want := tok.Symbol, uxntalSymComment; got != want {
+		t.Fatalf("token symbol = %d, want %d", got, want)
+	}
+	if got, want := tok.StartByte, uint32(0); got != want {
+		t.Fatalf("token start = %d, want %d", got, want)
+	}
+	if got, want := tok.EndByte, uint32(len("\n\t( outer (inner) tail )")); got != want {
+		t.Fatalf("token end = %d, want %d", got, want)
+	}
+	if got, want := lexer.Lookahead(), 'n'; got != want {
+		t.Fatalf("lookahead = %q, want %q", got, want)
+	}
+}
+
+func TestUxntalScannerRejectsUnterminatedComment(t *testing.T) {
+	lexer := newUxntalExternalLexer([]byte(" (unterminated"), 0, 0, 0)
+	if (UxntalExternalScanner{}).Scan(nil, lexer, []bool{true}) {
+		t.Fatal("Scan returned true for an unterminated comment")
+	}
+	if tok, ok := uxntalExternalLexerToken(lexer); ok {
+		t.Fatalf("Scan returned false but produced token %+v", tok)
+	}
+}
+
+func TestParseUxntalConsecutiveCommentsStaysCleanAndSingleStacked(t *testing.T) {
+	source := []byte("( first )\n( second ( nested ) )\n|00 @System &vector $2\n")
+	lang := UxntalLanguage()
+	tree, err := gotreesitter.NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("Parse returned nil root")
+	}
+	if root.HasError() {
+		t.Fatalf("root.HasError = true: %s", root.SExpr(lang))
+	}
+	if got, want := root.EndByte(), uint32(len(source)); got != want {
+		t.Fatalf("root.EndByte = %d, want %d", got, want)
+	}
+	if got := tree.ParseRuntime().MaxStacksSeen; got > 1 {
+		t.Fatalf("MaxStacksSeen = %d, want <= 1", got)
+	}
+}
+
+//go:linkname newUxntalExternalLexer github.com/odvcencio/gotreesitter.newExternalLexer
+func newUxntalExternalLexer(source []byte, pos int, row, col uint32) *gotreesitter.ExternalLexer
+
+//go:linkname uxntalExternalLexerToken github.com/odvcencio/gotreesitter.(*ExternalLexer).token
+func uxntalExternalLexerToken(*gotreesitter.ExternalLexer) (gotreesitter.Token, bool)

--- a/parser.go
+++ b/parser.go
@@ -5290,6 +5290,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					chosen, choice = deterministicExternalConflictAction(actions), true
 				}
 				if choice {
+					skipRepetitionShift := false
+					if chosen.Type == ParseActionReduce {
+						if cReduce, ok := singleReduceAgainstRepetitionShiftConflictChoice(actions); ok && cReduce == chosen {
+							skipRepetitionShift = true
+						}
+					}
 					if chosen.Type == ParseActionShift && !p.guardRealShiftGap(source, s, tok) {
 						continue
 					}
@@ -5306,13 +5312,14 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					traceAfterPrimary(si, s)
 					if chosen.Type == ParseActionReduce {
 						p.completeConflictReduceFrontier(source, s, tok, conflictReduceFrontierSeed{
-							action:      chosen,
-							beforeState: actionBeforeState,
-							beforeByte:  actionBeforeByte,
-							beforeDepth: actionBeforeDepth,
-							afterState:  actionAfterState,
-							afterByte:   actionAfterByte,
-							afterDepth:  actionAfterDepth,
+							action:              chosen,
+							beforeState:         actionBeforeState,
+							beforeByte:          actionBeforeByte,
+							beforeDepth:         actionBeforeDepth,
+							afterState:          actionAfterState,
+							afterByte:           actionAfterByte,
+							afterDepth:          actionAfterDepth,
+							skipRepetitionShift: skipRepetitionShift,
 						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
 						traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 					}
@@ -6032,6 +6039,8 @@ func (p *Parser) configureParseScratch(scratch *parserScratch, source []byte, re
 	} else {
 		p.transientChildren = nil
 	}
+	scratch.merge.language = p.language
+	scratch.merge.trace = p.glrTrace
 	scratch.merge.beginEquivEpoch()
 	scratch.merge.ensureMergeHotCaches()
 	transientReduceParents := p.shouldUseTransientReduceParents(source, reuse, oldTree, arenaClass)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -178,16 +178,13 @@ func TestGeneratedRepeatBoundaryConflictAllowsMixedReduces(t *testing.T) {
 	}
 }
 
-func TestDeterministicConflictChoiceUsesCRepetitionFoldOnCleanLineage(t *testing.T) {
-	// Wave-2b: the php state-2 SHIFT-preferring shortcut is retired in favor
-	// of the global C repetition-skip fold (cRepetitionSkipConflictChoice,
-	// C parser.c:1625 `if (action.shift.repetition) break;`). The contract
-	// pinned here is the fold's: an error-free lineage takes the single
-	// REDUCE deterministically (C folds and re-dispatches the same
-	// lookahead); without a stack (nil = no lineage evidence) dispatch makes
-	// no deterministic choice and the GLR fork stands.
+func TestDeterministicConflictChoiceUsesCRepetitionFoldOnRecoveryLineages(t *testing.T) {
+	// C parser.c:1625 (`if (action.shift.repetition) break;`) takes the single
+	// REDUCE and redispatches the same lookahead on both clean and previously
+	// recovered idle lineages. Without a stack (nil = no lineage evidence),
+	// dispatch makes no deterministic choice and the GLR fork stands.
 	lang := &Language{
-		Name:        "php",
+		Name:        "bash",
 		SymbolNames: []string{"end", "namespace", "\\", "name", "use", "new", "program_repeat1"},
 		SymbolMetadata: []SymbolMetadata{
 			{Name: "end"},
@@ -216,8 +213,24 @@ func TestDeterministicConflictChoiceUsesCRepetitionFoldOnCleanLineage(t *testing
 		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v, want program_repeat1 reduce (C repetition-skip fold)", chosen)
 	}
 	erroredStack := &glrStack{cEverErrored: true}
+	chosen, ok = parser.deterministicConflictChoiceForDispatch(nil, erroredStack, Token{Symbol: 1}, 2, actions, 2, nil)
+	if !ok || chosen.Type != ParseActionReduce || chosen.Symbol != 6 {
+		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v on recovered lineage, want C repetition reduce", chosen)
+	}
+	parser.language.Name = "php"
 	if chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, erroredStack, Token{Symbol: 1}, 2, actions, 2, nil); ok {
-		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v on wreckage lineage, want GLR fork", chosen)
+		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v for recovered PHP lineage, want certified exception", chosen)
+	}
+	parser.language.Name = "bash"
+	for i, stack := range []*glrStack{
+		{cEverErrored: true, cRec: &cRecoverState{}},
+		{cEverErrored: true, cPaused: true},
+		{cEverErrored: true, cRecoverMissingGroup: &cRecGroup{}},
+	} {
+		chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, stack, Token{Symbol: 1}, 2, actions, 2, nil)
+		if !ok || chosen.Type != ParseActionReduce || chosen.Symbol != 6 {
+			t.Fatalf("active recovery case %d picked %+v, want C repetition reduce", i, chosen)
+		}
 	}
 }
 

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unsafe"
 )
 
 type reduceChainSignature struct {
@@ -586,13 +587,109 @@ func (p *Parser) applyActionWithReduceChain(source []byte, s *glrStack, act Pars
 }
 
 type conflictReduceFrontierSeed struct {
-	action      ParseAction
-	beforeState StateID
-	beforeByte  uint32
-	beforeDepth int
-	afterState  StateID
-	afterByte   uint32
-	afterDepth  int
+	action              ParseAction
+	beforeState         StateID
+	beforeByte          uint32
+	beforeDepth         int
+	afterState          StateID
+	afterByte           uint32
+	afterDepth          int
+	skipRepetitionShift bool
+}
+
+const (
+	maxConflictReduceFrontierActions = 256
+	conflictReduceFrontierTableSize  = 512
+)
+
+const (
+	conflictReduceFrontierSeen = uint8(1 << iota)
+	conflictReduceFrontierForked
+)
+
+type frontierReduceKey struct {
+	state             StateID
+	byteOffset        uint32
+	depth             int
+	symbol            Symbol
+	childCount        uint8
+	productionID      uint16
+	dynamicPrecedence int16
+	actionState       StateID
+}
+
+type conflictReduceFrontierEntry struct {
+	key        frontierReduceKey
+	generation uint32
+	flags      uint8
+}
+
+type conflictReduceFrontierScratch struct {
+	entries    []conflictReduceFrontierEntry
+	generation uint32
+}
+
+func (s *conflictReduceFrontierScratch) begin() {
+	if len(s.entries) != conflictReduceFrontierTableSize {
+		s.entries = make([]conflictReduceFrontierEntry, conflictReduceFrontierTableSize)
+	}
+	if s.generation == ^uint32(0) {
+		clear(s.entries)
+		s.generation = 0
+	}
+	s.generation++
+}
+
+func (s *conflictReduceFrontierScratch) allocatedBytes() int64 {
+	return int64(cap(s.entries)) * int64(unsafe.Sizeof(conflictReduceFrontierEntry{}))
+}
+
+func frontierReduceKeyHash(key frontierReduceKey) uint64 {
+	h := uint64(key.state) ^ uint64(key.byteOffset)<<16
+	h ^= uint64(uint32(key.depth)) * 0x9e3779b185ebca87
+	h ^= uint64(key.symbol)<<32 | uint64(key.childCount)
+	h ^= uint64(key.productionID)<<17 | uint64(uint16(key.dynamicPrecedence))
+	h ^= uint64(key.actionState) * 0xc2b2ae3d27d4eb4f
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	return h
+}
+
+func (s *conflictReduceFrontierScratch) entry(key frontierReduceKey, create bool) *conflictReduceFrontierEntry {
+	if s == nil || len(s.entries) == 0 || s.generation == 0 {
+		return nil
+	}
+	mask := len(s.entries) - 1
+	index := int(frontierReduceKeyHash(key)) & mask
+	for probes := 0; probes < len(s.entries); probes++ {
+		entry := &s.entries[index]
+		if entry.generation != s.generation {
+			if !create {
+				return nil
+			}
+			entry.key = key
+			entry.generation = s.generation
+			entry.flags = 0
+			return entry
+		}
+		if entry.key == key {
+			return entry
+		}
+		index = (index + 1) & mask
+	}
+	return nil
+}
+
+func (s *conflictReduceFrontierScratch) has(key frontierReduceKey, flag uint8) bool {
+	entry := s.entry(key, false)
+	return entry != nil && entry.flags&flag != 0
+}
+
+func (s *conflictReduceFrontierScratch) add(key frontierReduceKey, flag uint8) {
+	if entry := s.entry(key, true); entry != nil {
+		entry.flags |= flag
+	}
 }
 
 func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok Token, seed conflictReduceFrontierSeed, liveStacks, maxLiveStacks int, allocBranchOrder func() uint64, anyReduced *bool, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, deferParentLinks bool, trackChildErrors *bool) {
@@ -628,19 +725,16 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 	if seed.afterState != s.top().state || seed.afterByte != s.byteOffset || seed.afterDepth != s.depth() {
 		return
 	}
-	const maxConflictFrontierActions = 256
-	type frontierReduceKey struct {
-		state             StateID
-		byteOffset        uint32
-		depth             int
-		symbol            Symbol
-		childCount        uint8
-		productionID      uint16
-		dynamicPrecedence int16
-		actionState       StateID
+	var localFrontier conflictReduceFrontierScratch
+	frontier := &localFrontier
+	if gssScratch != nil {
+		frontier = &gssScratch.frontier
 	}
-	seenReduces := make(map[frontierReduceKey]struct{}, 4)
-	terminalForkedReduces := make(map[frontierReduceKey]struct{}, 4)
+	beforeFrontierBytes := frontier.allocatedBytes()
+	frontier.begin()
+	if gssScratch != nil {
+		gssScratch.allocatedBytes += frontier.allocatedBytes() - beforeFrontierBytes
+	}
 	seedKey := frontierReduceKey{
 		state:             seed.beforeState,
 		byteOffset:        seed.beforeByte,
@@ -663,7 +757,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			actionState:       act.State,
 		}
 	}
-	seenReduces[seedKey] = struct{}{}
+	frontier.add(seedKey, conflictReduceFrontierSeen)
 	completeMultiActionFrontier := func(actions []ParseAction, step int) bool {
 		if len(actions) != 2 {
 			return false
@@ -699,11 +793,12 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 				fork.branchOrder = allocBranchOrder()
 			}
 			p.pendingFrontierForkStacks = append(p.pendingFrontierForkStacks, fork)
-			terminalForkedReduces[currentReduceKey] = struct{}{}
+			frontier.add(currentReduceKey, conflictReduceFrontierForked)
 		}
 		terminalAppended := false
-		_, terminalAlreadyForked := terminalForkedReduces[currentReduceKey]
-		if !terminalAlreadyForked && frontierForkAdmissible() {
+		terminalAlreadyForked := frontier.has(currentReduceKey, conflictReduceFrontierForked)
+		skipTerminalFork := seed.skipRepetitionShift && terminal.Type == ParseActionShift && terminal.Repetition
+		if !skipTerminalFork && !terminalAlreadyForked && frontierForkAdmissible() {
 			switch terminal.Type {
 			case ParseActionShift:
 				fork := s.cloneWithScratch(gssScratch)
@@ -735,20 +830,20 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 				return false
 			}
 		}
-		if _, ok := seenReduces[currentReduceKey]; ok {
+		if frontier.has(currentReduceKey, conflictReduceFrontierSeen) {
 			if terminalAppended || terminalAlreadyForked {
 				s.dead = true
 				return true
 			}
 			return false
 		}
-		seenReduces[currentReduceKey] = struct{}{}
+		frontier.add(currentReduceKey, conflictReduceFrontierSeen)
 		p.noteStopActionDiagnostic("conflict-frontier-fork-reduce", s, tok, reduce, len(actions), true, step, 0, false)
 		p.applyReduceActionDispatch(source, s, reduce, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 		p.noteStopActionResult(s)
 		return true
 	}
-	for step := 1; step <= maxConflictFrontierActions; step++ {
+	for step := 1; step <= maxConflictReduceFrontierActions; step++ {
 		if s.dead || s.accepted || s.shifted || s.cPaused || s.depth() == 0 {
 			return
 		}
@@ -767,10 +862,10 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 		switch act.Type {
 		case ParseActionReduce:
 			key := makeReduceKey(act)
-			if _, ok := seenReduces[key]; ok {
+			if frontier.has(key, conflictReduceFrontierSeen) {
 				return
 			}
-			seenReduces[key] = struct{}{}
+			frontier.add(key, conflictReduceFrontierSeen)
 			p.noteStopActionDiagnostic("conflict-frontier-reduce", s, tok, act, 1, true, step, 0, false)
 			p.applyReduceActionDispatch(source, s, act, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -251,6 +251,68 @@ func applyConflictFrontierReduceForTest(parser *Parser, stack *glrStack, reduce 
 	}
 }
 
+func TestConflictReduceFrontierScratchRetainsExactFlags(t *testing.T) {
+	if conflictReduceFrontierTableSize&(conflictReduceFrontierTableSize-1) != 0 {
+		t.Fatalf("table size %d is not a power of two", conflictReduceFrontierTableSize)
+	}
+	if conflictReduceFrontierTableSize < maxConflictReduceFrontierActions+1 {
+		t.Fatalf("table size %d cannot hold the %d-action frontier plus its seed", conflictReduceFrontierTableSize, maxConflictReduceFrontierActions)
+	}
+	var scratch conflictReduceFrontierScratch
+	scratch.begin()
+	if got, want := len(scratch.entries), conflictReduceFrontierTableSize; got != want {
+		t.Fatalf("entries = %d, want %d", got, want)
+	}
+
+	keys := make([]frontierReduceKey, maxConflictReduceFrontierActions+1)
+	for i := range keys {
+		keys[i] = frontierReduceKey{
+			state:             StateID(i),
+			byteOffset:        uint32(i * 7),
+			depth:             i + 1,
+			symbol:            Symbol(i * 3),
+			childCount:        uint8(i),
+			productionID:      uint16(i * 5),
+			dynamicPrecedence: int16(i - 128),
+			actionState:       StateID(i * 11),
+		}
+		scratch.add(keys[i], conflictReduceFrontierSeen)
+		if i%2 == 0 {
+			scratch.add(keys[i], conflictReduceFrontierForked)
+		}
+	}
+	for i, key := range keys {
+		if !scratch.has(key, conflictReduceFrontierSeen) {
+			t.Fatalf("key %d lost seen flag", i)
+		}
+		if got, want := scratch.has(key, conflictReduceFrontierForked), i%2 == 0; got != want {
+			t.Fatalf("key %d forked flag = %t, want %t", i, got, want)
+		}
+	}
+
+	oldGeneration := scratch.generation
+	scratch.begin()
+	if scratch.generation == oldGeneration {
+		t.Fatal("begin did not advance generation")
+	}
+	for i, key := range keys {
+		if scratch.has(key, conflictReduceFrontierSeen) || scratch.has(key, conflictReduceFrontierForked) {
+			t.Fatalf("key %d survived generation reset", i)
+		}
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		scratch.begin()
+		scratch.add(keys[0], conflictReduceFrontierSeen)
+		if !scratch.has(keys[0], conflictReduceFrontierSeen) {
+			panic("frontier scratch lost warm entry")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("warm frontier scratch allocations = %g, want 0", allocs)
+	}
+}
+
 func TestConflictReduceFrontierCompletesSingleShift(t *testing.T) {
 	lang := buildConflictReduceFrontierLanguage(4, []ParseAction{
 		{Type: ParseActionReduce, Symbol: 3, ChildCount: 1},
@@ -354,6 +416,35 @@ func TestConflictReduceFrontierDegenerateSameReduceShiftCompletes(t *testing.T) 
 	}
 	if got, want := nextBranchOrder, uint64(100); got != want {
 		t.Fatalf("next branch order = %d, want %d", got, want)
+	}
+}
+
+func TestConflictReduceFrontierSkipsRepetitionShiftAfterCFold(t *testing.T) {
+	lang := buildConflictReduceFrontierLanguage(6, []ParseAction{
+		{Type: ParseActionReduce, Symbol: 3, ChildCount: 1},
+		{Type: ParseActionShift, State: 3, Repetition: true},
+	})
+	parser := NewParser(lang)
+	arena := newNodeArena(arenaClassFull)
+	var entries glrEntryScratch
+	var gss gssScratch
+	var tmp []stackEntry
+	nodeCount := 0
+	anyReduced := false
+	trackChildErrors := false
+
+	stack := newConflictReduceFrontierStackForTest(parser, arena, &entries, &gss)
+	tok := Token{Symbol: 2, StartByte: 1, EndByte: 2, StartPoint: Point{Column: 1}, EndPoint: Point{Column: 2}}
+	reduce := lang.ParseActions[6].Actions[0]
+	seed := applyConflictFrontierReduceForTest(parser, &stack, reduce, tok, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, &trackChildErrors)
+	seed.skipRepetitionShift = true
+
+	parser.completeConflictReduceFrontier(nil, &stack, tok, seed, 1, 0, nil, &anyReduced, &nodeCount, arena, &entries, &gss, &tmp, false, &trackChildErrors)
+	if stack.dead || stack.shifted {
+		t.Fatalf("C repetition fold branch dead=%t shifted=%t, want live reduce branch", stack.dead, stack.shifted)
+	}
+	if got := len(parser.pendingFrontierForkStacks); got != 0 {
+		t.Fatalf("pending frontier forks = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Apply Tree-sitter C's repetition-shift fold to recovered parser lineages, while retaining the certified PHP recovery exception.
- Keep conflict-frontier bookkeeping and recovery-cost comparisons in reusable parser scratch instead of allocating maps per dispatch.
- Match the upstream Uxntal scanner's leading-whitespace, nested-comment, and unterminated-comment behavior.

## Impact

- Uxntal's largest-eight full-parse aggregate improves from 563.69x C with eight cliffs and two timeouts to 1.78x C with no cliffs or timeouts.
- The Drum Rack witness improves from hundreds of times slower with gigabyte-scale allocation to 1.45x C and about 3 MB/op.
- The stable full/incremental benchmark trio is statistically unchanged; allocations remain unchanged on those paths.

## Correctness

- The Uxntal scanner regression now parses its clean witness exactly and single-stacked.
- Both PHP recovery counterexamples remain exact against the C oracle.
- Representative Scheme and Bash witnesses remain exact; pre-existing Fennel and Rego corpus disagreements do not move earlier.

## Validation

- Focused root and grammar unit tests in Docker.
- One-language-at-a-time C-oracle checks for Uxntal, PHP, Fennel, Scheme, Bash, and Rego.
- Largest-eight perf scans for Uxntal, Fennel, Scheme, Bash, and Rego.
- `GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem` on the full parse, single-byte incremental, and no-edit benchmarks.