### PR TITLE
perf(parser): reduce recovery guard and retry overhead

### DIFF
--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -32,6 +32,27 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 	},
+	// These grammars have error-bearing real-corpus witnesses that legitimately
+	// reach EOF. Re-running the accepted-error ladder does not improve their
+	// selected trees, so the exact certified blobs keep the first result.
+	"bash": {
+		blobSHA256: mustRuntimeProfileSHA256("a3e898c88f6ad918d4d619dff2a4e74d613bda93c90e4a3f9fb7587c1952f3fb"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
+	"cpp": {
+		blobSHA256: mustRuntimeProfileSHA256("d351f902c8f2ca85257a9296d3c9991862d57701ac6e9006e386ae173fd35178"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
+	"rego": {
+		blobSHA256: mustRuntimeProfileSHA256("b10816c87dc847492fbbc1fd97c5096ed35d7abe69d0cd2ef5dd7e02aabac25c"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
 	// On large accepted-error Java sources, the cap-16 same-stack merge retry
 	// remains authoritative; the subsequent cap-64 clean/recovery passes do not
 	// improve the selected tree. Keep this bound pinned to the exact built-in

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -32,7 +32,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 4; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 7; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -44,6 +44,28 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
 		t.Fatalf("unknown runtime profile changed accepted-error retry profile to %+v", got)
+	}
+}
+
+func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	tests := []struct {
+		name string
+		load func() *gotreesitter.Language
+	}{
+		{name: "bash", load: BashLanguage},
+		{name: "cpp", load: CppLanguage},
+		{name: "rego", load: RegoLanguage},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := tt.load().FullParseAcceptedErrorRetryProfile
+			if !profile.SkipCompleteAcceptedErrorRetry {
+				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want skip-complete certification", profile)
+			}
+		})
 	}
 }
 
@@ -110,6 +132,27 @@ func TestBuiltinJavaAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T)
 	}
 }
 
+func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
+	lang := &gotreesitter.Language{Name: "rego"}
+	if attachBuiltinLanguageRuntimeProfile("rego", sha256.Sum256([]byte("uncertified")), lang) {
+		t.Fatal("uncertified Rego blob reported a runtime-profile attachment")
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("uncertified Rego blob changed retry profile to %+v", got)
+	}
+
+	blob := BlobByName("rego")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(rego) returned no data")
+	}
+	if !attachBuiltinLanguageRuntimeProfile("rego", sha256.Sum256(blob), lang) {
+		t.Fatal("certified Rego blob did not attach its runtime profile")
+	}
+	if !lang.FullParseAcceptedErrorRetryProfile.SkipCompleteAcceptedErrorRetry {
+		t.Fatalf("certified Rego retry profile = %+v, want skip-complete certification", lang.FullParseAcceptedErrorRetryProfile)
+	}
+}
+
 func TestAttachLanguageSupportDoesNotCertifyWithoutBlobIdentity(t *testing.T) {
 	base := KotlinLanguage()
 	lang := &gotreesitter.Language{
@@ -128,5 +171,11 @@ func TestAttachLanguageSupportDoesNotCertifyWithoutBlobIdentity(t *testing.T) {
 	AttachLanguageSupport("java", java)
 	if got := java.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
 		t.Fatalf("AttachLanguageSupport certified Java retry profile without blob identity: %+v", got)
+	}
+
+	rego := &gotreesitter.Language{Name: "rego"}
+	AttachLanguageSupport("rego", rego)
+	if got := rego.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("AttachLanguageSupport certified Rego retry profile without blob identity: %+v", got)
 	}
 }

--- a/language.go
+++ b/language.go
@@ -278,13 +278,16 @@ const (
 // FullParseAcceptedErrorRetryProfile certifies a narrow full-parse retry
 // policy. When a fresh full parse accepts an error-bearing tree that covers
 // EOF, the parser may keep the initial GLR stack ceiling after the ordinary
-// same-stack merge retry instead of scheduling wider-stack passes. Both fields
-// must be non-zero; the zero value preserves the conservative generic ladder.
+// same-stack merge retry instead of scheduling wider-stack passes. A grammar
+// may instead certify that a complete accepted-error tree is authoritative and
+// skip that retry ladder entirely. The zero value preserves the conservative
+// generic ladder.
 //
 // Keep fields append-only: Language blobs encode this structure.
 type FullParseAcceptedErrorRetryProfile struct {
-	MinSourceBytes      uint32
-	InitialStackCeiling uint16
+	MinSourceBytes                 uint32
+	InitialStackCeiling            uint16
+	SkipCompleteAcceptedErrorRetry bool
 }
 
 // Language holds all data needed to parse a specific language.

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -761,7 +761,12 @@ func TestCertifiedAcceptedErrorRetrySchedulingKeepsMergeAndSkipsWidening(t *test
 
 func TestCppAcceptedErrorRetrySkipsCompleteTree(t *testing.T) {
 	tree := &Tree{
-		language: &Language{Name: "cpp"},
+		language: &Language{
+			Name: "cpp",
+			FullParseAcceptedErrorRetryProfile: FullParseAcceptedErrorRetryProfile{
+				SkipCompleteAcceptedErrorRetry: true,
+			},
+		},
 		root: &Node{
 			endByte: 128,
 			flags:   nodeFlagHasError,
@@ -805,7 +810,12 @@ func TestCppAcceptedErrorRetryPreservesTruncatedMergeRetry(t *testing.T) {
 
 func TestBashAcceptedErrorRetrySkipsCompleteTree(t *testing.T) {
 	tree := &Tree{
-		language: &Language{Name: "bash"},
+		language: &Language{
+			Name: "bash",
+			FullParseAcceptedErrorRetryProfile: FullParseAcceptedErrorRetryProfile{
+				SkipCompleteAcceptedErrorRetry: true,
+			},
+		},
 		root: &Node{
 			endByte: 128,
 			flags:   nodeFlagHasError,
@@ -844,6 +854,36 @@ func TestBashAcceptedErrorRetryPreservesTruncatedMergeRetry(t *testing.T) {
 
 	if got := fullParseRetryMergePerKeyOverride(tree, 128, 18); got != fullParseRetryMaxMergePerKey {
 		t.Fatalf("fullParseRetryMergePerKeyOverride(bash truncated accepted error) = %d, want %d", got, fullParseRetryMaxMergePerKey)
+	}
+}
+
+func TestCompleteAcceptedErrorRetrySkipRequiresCertification(t *testing.T) {
+	tree := &Tree{
+		language: &Language{Name: "rego"},
+		root: &Node{
+			endByte: 128,
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:       ParseStopAccepted,
+			SourceLen:        128,
+			ExpectedEOFByte:  128,
+			RootEndByte:      128,
+			LastTokenEndByte: 128,
+			LastTokenWasEOF:  true,
+			MaxStacksSeen:    9,
+		},
+	}
+	if !shouldRetryAcceptedErrorParse(tree, 128, 8) {
+		t.Fatal("uncertified language name suppressed accepted-error retry")
+	}
+
+	tree.language.FullParseAcceptedErrorRetryProfile.SkipCompleteAcceptedErrorRetry = true
+	if shouldRetryAcceptedErrorParse(tree, 128, 8) {
+		t.Fatal("certified complete accepted-error tree scheduled a stack retry")
+	}
+	if got := fullParseRetryMergePerKeyOverride(tree, 128, 8); got != 0 {
+		t.Fatalf("certified complete accepted-error merge override = %d, want 0", got)
 	}
 }
 

--- a/parser_memory_budget_runtime.go
+++ b/parser_memory_budget_runtime.go
@@ -3,7 +3,13 @@ package gotreesitter
 import "runtime"
 
 const (
-	parseRuntimeMemoryPollMask       = 15
+	// Arena and parser scratch enforce their budgets at every materialization
+	// boundary. The runtime-wide guard covers untracked Go heap growth, so a
+	// coarser poll avoids repeatedly stopping the world on recovery-heavy
+	// parses while keeping the maximum default-budget overshoot small.
+	parseRuntimeMemoryPollMask       = 255
+	parseRuntimeMemoryTightPollMask  = 15
+	parseRuntimeMemoryTightBudget    = 64 << 20
 	parseRuntimeMemoryMinSourceBytes = 64 * 1024
 
 	parseMemoryBudgetStopSourceArena       = "arena"
@@ -67,10 +73,17 @@ func (p *Parser) runtimeMemoryBudgetStopReason() ParseStopReason {
 		return ParseStopNone
 	}
 	p.parseRuntimeMemoryPoll++
-	if p.parseRuntimeMemoryPoll&parseRuntimeMemoryPollMask != 0 {
+	if p.parseRuntimeMemoryPoll&runtimeMemoryPollMask(p.parseRuntimeMemoryBudgetBytes) != 0 {
 		return ParseStopNone
 	}
 	return p.runtimeMemoryBudgetStopReasonNow()
+}
+
+func runtimeMemoryPollMask(budgetBytes int64) uint64 {
+	if budgetBytes <= parseRuntimeMemoryTightBudget {
+		return parseRuntimeMemoryTightPollMask
+	}
+	return parseRuntimeMemoryPollMask
 }
 
 func (p *Parser) runtimeMemoryBudgetStopReasonNow() ParseStopReason {

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -6,7 +6,7 @@ func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
 	parser := &Parser{
 		parseRuntimeMemoryBudgetBytes:   1,
 		parseRuntimeMemoryBaselineBytes: 0,
-		parseRuntimeMemoryPoll:          parseRuntimeMemoryPollMask,
+		parseRuntimeMemoryPoll:          parseRuntimeMemoryTightPollMask,
 		parseMemoryBudgetDiagActive:     true,
 	}
 	if got := parser.runtimeMemoryBudgetStopReason(); got != ParseStopMemoryBudget {
@@ -17,6 +17,27 @@ func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
 	}
 	if parser.parseMemoryBudgetDiag.runtimeHeapGrowthBytes < 1 {
 		t.Fatalf("runtime heap growth = %d, want >= 1", parser.parseMemoryBudgetDiag.runtimeHeapGrowthBytes)
+	}
+}
+
+func TestRuntimeMemoryPollMaskKeepsTightBudgetsResponsive(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		budget int64
+		want   uint64
+	}{
+		{name: "tight", budget: parseRuntimeMemoryTightBudget - 1, want: parseRuntimeMemoryTightPollMask},
+		{name: "tight-boundary", budget: parseRuntimeMemoryTightBudget, want: parseRuntimeMemoryTightPollMask},
+		{name: "default-sized", budget: parseRuntimeMemoryTightBudget + 1, want: parseRuntimeMemoryPollMask},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runtimeMemoryPollMask(tt.budget); got != tt.want {
+				t.Fatalf("runtimeMemoryPollMask(%d) = %d, want %d", tt.budget, got, tt.want)
+			}
+			if tt.want&(tt.want+1) != 0 {
+				t.Fatalf("poll mask %d is not a power-of-two interval minus one", tt.want)
+			}
+		})
 	}
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -127,18 +127,7 @@ func shouldRetryAcceptedErrorParse(tree *Tree, sourceLen int, initialMaxStacks i
 	if rt.StopReason != ParseStopAccepted || rt.Truncated || rt.TokenSourceEOFEarly {
 		return false
 	}
-	if tree.language != nil && tree.language.Name == "bash" {
-		// Bash uses the forest path for clean large-file parses; if production
-		// accepts a full-span error-bearing tree after the forest declines, the
-		// accepted-error retry has repeatedly proven to be wasted work on real
-		// corpus witnesses (for example git's t9300 fast-import script remains
-		// an error-bearing, C-divergent full-span tree while paying multiple
-		// full reparse passes). Keep structural/no-stack/node-limit retries
-		// available, but do not chase an accepted-error Bash tree that already
-		// reached EOF.
-		return false
-	}
-	if tree.language != nil && tree.language.Name == "cpp" {
+	if certifiedAcceptedErrorRetrySkipsComplete(tree, sourceLen) {
 		return false
 	}
 	if initialMaxStacks <= 0 {
@@ -1217,6 +1206,19 @@ func certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree *Tree, sourceLen in
 		retryTreeCoversExpectedEOF(tree)
 }
 
+func certifiedAcceptedErrorRetrySkipsComplete(tree *Tree, sourceLen int) bool {
+	if tree == nil || tree.language == nil || sourceLen <= 0 ||
+		!tree.language.FullParseAcceptedErrorRetryProfile.SkipCompleteAcceptedErrorRetry {
+		return false
+	}
+	rt := tree.ParseRuntime()
+	return rt.StopReason == ParseStopAccepted &&
+		!rt.Truncated &&
+		!rt.TokenSourceEOFEarly &&
+		retryTreeHasError(tree) &&
+		retryTreeCoversExpectedEOF(tree)
+}
+
 func fullParseRetryNodeLimitOverride(tree *Tree, sourceLen int) int {
 	if !shouldRetryNodeLimitParse(tree, sourceLen) {
 		return 0
@@ -1259,6 +1261,9 @@ func fullParseRetryMergePerKeyOverride(tree *Tree, sourceLen int, initialMaxStac
 	default:
 		return 0
 	}
+	if certifiedAcceptedErrorRetrySkipsComplete(tree, sourceLen) {
+		return 0
+	}
 	if tree.language != nil && tree.language.Name == "java" && rt.StopReason == ParseStopAccepted && retryTreeHasError(tree) {
 		return javaFullParseRetryMaxMergePerKey
 	}
@@ -1295,16 +1300,6 @@ func fullParseRetryMergePerKeyOverride(tree *Tree, sourceLen int, initialMaxStac
 		// same-key survivors are pruned. Use a negative override as an exact
 		// cap for this retry; positive retry overrides still only widen caps.
 		return -4
-	}
-	if tree.language != nil && tree.language.Name == "cpp" &&
-		rt.StopReason == ParseStopAccepted && retryTreeHasError(tree) &&
-		!rt.Truncated && !rt.TokenSourceEOFEarly {
-		return 0
-	}
-	if tree.language != nil && tree.language.Name == "bash" &&
-		rt.StopReason == ParseStopAccepted && retryTreeHasError(tree) &&
-		!rt.Truncated && !rt.TokenSourceEOFEarly {
-		return 0
 	}
 	if initialMaxStacks <= 0 {
 		initialMaxStacks = maxGLRStacks


### PR DESCRIPTION
## Summary

- Poll the runtime-wide heap guard every 256 materialization checks for budgets above 64 MiB while retaining the 16-check cadence for tight budgets. Arena and parser scratch limits remain checked at every materialization boundary.
- Move complete accepted-error retry suppression from parser language-name checks into exact blob-certified runtime profiles.
- Certify the existing Bash and C++ behavior and the measured Rego behavior without changing caller-built or overridden languages.

## Performance

- Scheme largest-eight full parse: 4.00x to 2.87x C, zero cliffs and zero timeouts. The Unicode witness moved from 6.20x to 3.70x; direct single-core runs fell from roughly 658-724 MB allocated to roughly 172 MB and now reach EOF instead of the memory guard.
- Rego largest-eight full parse: 3.53x to 1.78x C, zero cliffs and zero timeouts.
- The standard full, one-byte incremental, and no-edit benchmarks are statistically unchanged in the reversed pinned A/B run.

## Correctness

- Rego selected-eight C-oracle signatures are unchanged from the pre-trim baseline; the policy witness remains exact.
- Full root and grammar package tests pass in isolated Docker.
- Focused parser and grammar profile tests pass under the race detector in isolated Docker.
- Tight-budget polling and exact-blob certification boundaries have dedicated regression coverage.