### PR TITLE
Compact hidden reductions and certify retry skips

### DIFF
--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -50,6 +50,11 @@ func conflictPolicyChoiceForPolicy(lang *Language, policy *ConflictPolicy, actio
 			return ParseAction{}, false
 		}
 		return singleShiftConflictChoice(actions)
+	case ConflictPolicyRepetitionReduce:
+		if len(policy.ReduceSymbols) == 0 {
+			return ParseAction{}, false
+		}
+		return singleReduceAgainstRepetitionShiftConflictChoice(actions)
 	default:
 		return ParseAction{}, false
 	}

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -37,6 +37,26 @@ func TestConflictPolicyChoiceRepetitionShift(t *testing.T) {
 	}
 }
 
+func TestConflictPolicyChoiceRepetitionReduce(t *testing.T) {
+	lang := &Language{
+		Name:             "synthetic_policy_test",
+		ConflictPolicies: []ConflictPolicy{{State: 42, Lookahead: 7, Kind: ConflictPolicyRepetitionReduce, ReduceSymbols: []Symbol{3}}},
+	}
+	reduce := ParseAction{Type: ParseActionReduce, Symbol: 3, ChildCount: 2}
+	actions := []ParseAction{
+		reduce,
+		{Type: ParseActionShift, State: 99, Repetition: true},
+	}
+
+	chosen, ok := conflictPolicyChoice(lang, Token{Symbol: 7}, 42, actions)
+	if !ok {
+		t.Fatal("conflictPolicyChoice = false, want reduce policy choice")
+	}
+	if chosen != reduce {
+		t.Fatalf("conflictPolicyChoice picked %+v, want %+v", chosen, reduce)
+	}
+}
+
 func TestConflictPolicyChoiceShift(t *testing.T) {
 	lang := &Language{
 		Name:                  "synthetic_policy_test",

--- a/glr.go
+++ b/glr.go
@@ -749,8 +749,10 @@ func stackNodeGenericEquivSignature(n *Node, depth int) uint64 {
 	h = mixStackEquivSignature(h, uint64(n.preGotoState))
 	fieldIDs := n.fieldIDs()
 	h = mixStackEquivSignature(h, uint64(len(fieldIDs)))
-	for _, fieldID := range fieldIDs {
+	fieldSources := n.fieldSources()
+	for i, fieldID := range fieldIDs {
 		h = mixStackEquivSignature(h, uint64(fieldID))
+		h = mixStackEquivSignature(h, uint64(normalizedFieldSourceForID(fieldIDs, fieldSources, i)))
 	}
 
 	frontier := -1
@@ -2419,7 +2421,7 @@ func stackEntryNodesEquivalentPythonShallow(a, b *Node) bool {
 	if a.flags&nodeFlagHasError != 0 {
 		return true
 	}
-	if !equalFieldIDSlices(a.fieldIDs(), b.fieldIDs()) {
+	if !equalNodeFieldMetadata(a, b) {
 		return false
 	}
 	for i := range a.children {
@@ -2440,7 +2442,7 @@ func stackEntryNodesEquivalentPythonShallow(a, b *Node) bool {
 			ca.productionID != cb.productionID ||
 			ca.dynamicPrecedence != cb.dynamicPrecedence ||
 			len(ca.children) != len(cb.children) ||
-			!equalFieldIDSlices(ca.fieldIDs(), cb.fieldIDs()) {
+			!equalNodeFieldMetadata(ca, cb) {
 			return false
 		}
 	}
@@ -2519,7 +2521,7 @@ func stackEntryNodesExactlyEquivalentWithAudit(scratch *glrMergeScratch, audit *
 		}
 		return true
 	}
-	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+	if !equalNodeFieldMetadata(a, b) {
 		if audit != nil {
 			audit.recordEquivSkipFieldMismatch()
 		}
@@ -2602,7 +2604,7 @@ func stackEntryNodesExactlyEquivalentNoAudit(scratch *glrMergeScratch, a, b *Nod
 	if a.flags&nodeFlagHasError != 0 {
 		return true
 	}
-	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+	if !equalNodeFieldMetadata(a, b) {
 		return false
 	}
 	if len(a.children) == 0 {
@@ -2677,7 +2679,7 @@ func stackEntryNodesExactlyEquivalentTerminal(audit *runtimeAudit, a, b *Node) b
 		}
 		return false
 	}
-	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+	if !equalNodeFieldMetadata(a, b) {
 		if audit != nil {
 			audit.recordEquivSkipFieldMismatch()
 			audit.recordEquivExactTerminalFalse()
@@ -2725,7 +2727,7 @@ func stackEntryNodesExactlyEquivalentTerminalNoAudit(a, b *Node) bool {
 		len(aFieldIDs) != len(bFieldIDs) {
 		return false
 	}
-	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+	if !equalNodeFieldMetadata(a, b) {
 		return false
 	}
 	return a.flags&nodeFlagHasError != 0 || len(a.children) == 0
@@ -2777,7 +2779,7 @@ func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b
 		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
-	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+	if !equalNodeFieldMetadata(a, b) {
 		storeNodeEquivCache(scratch, a, b, depth, false)
 		return false
 	}
@@ -2808,7 +2810,7 @@ func stackEntryNodesEquivalentFrontierWithScratch(scratch *glrMergeScratch, a, b
 			ca.productionID != cb.productionID ||
 			ca.dynamicPrecedence != cb.dynamicPrecedence ||
 			len(ca.children) != len(cb.children) ||
-			!equalFieldIDSlices(ca.fieldIDs(), cb.fieldIDs()) {
+			!equalNodeFieldMetadata(ca, cb) {
 			storeNodeEquivCache(scratch, a, b, depth, false)
 			return false
 		}
@@ -3343,7 +3345,7 @@ func stackEntryNodesEquivalentIgnoringDynamic(a, b *Node) bool {
 		len(a.children) != len(b.children) {
 		return false
 	}
-	if !equalFieldIDSlices(aFieldIDs, bFieldIDs) {
+	if !equalNodeFieldMetadata(a, b) {
 		return false
 	}
 	if a.flags&nodeFlagHasError != 0 {

--- a/glr_test.go
+++ b/glr_test.go
@@ -1776,6 +1776,33 @@ func TestPendingParentMergeEqualityVerifiesPackedFieldsAndDescendants(t *testing
 	}
 }
 
+func TestNodeMergeEqualityDistinguishesDeferredFieldSources(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	direct := newParentNodeInArenaWithFieldSources(
+		arena, 2, false, []*Node{leaf}, []FieldID{7}, []uint8{fieldSourceDirect}, 0,
+	)
+	defaultDirect := newParentNodeInArena(arena, 2, false, []*Node{leaf}, []FieldID{7}, 0)
+	deferred := newParentNodeInArenaWithFieldSources(
+		arena, 2, false, []*Node{leaf}, []FieldID{7}, []uint8{fieldSourceDeferredDirect}, 0,
+	)
+	makeStack := func(node *Node) glrStack {
+		return glrStack{
+			entries:    []stackEntry{{state: 1}, newStackEntryNode(2, node)},
+			byteOffset: 1,
+		}
+	}
+
+	scratch := glrMergeScratch{arena: arena}
+	scratch.beginEquivEpoch()
+	if !stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(direct), makeStack(defaultDirect)) {
+		t.Fatal("implicit and explicit direct field sources were not equivalent")
+	}
+	if stackEquivalentForLanguageWithScratch(&scratch, nil, makeStack(direct), makeStack(deferred)) {
+		t.Fatal("deferred and resolved field sources merged before the visible boundary")
+	}
+}
+
 func TestNoTreeNodeStackEntryKeepsBytesAndDropsPoints(t *testing.T) {
 	leaf := newNoTreeLeafNodeInArena(nil, 7, true, 11, 19, Point{Row: 3, Column: 5}, Point{Row: 3, Column: 13})
 	entry := newStackEntryNoTreeNode(2, leaf)

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -2,6 +2,7 @@ package grammars
 
 import (
 	"encoding/hex"
+	"slices"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 )
@@ -14,6 +15,7 @@ type builtinLanguageRuntimeProfile struct {
 	blobSHA256                         [32]byte
 	externalScannerFullParseRetry      gotreesitter.ExternalScannerFullParseRetryPolicy
 	fullParseAcceptedErrorRetryProfile gotreesitter.FullParseAcceptedErrorRetryProfile
+	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
 
 var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
@@ -41,8 +43,20 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},
 	},
+	"caddy": {
+		blobSHA256: mustRuntimeProfileSHA256("e1af0dcba90bca6949ac1a2756e1a6db2271061b40570b9a7fa2ada29478f6fa"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
 	"cpp": {
 		blobSHA256: mustRuntimeProfileSHA256("d351f902c8f2ca85257a9296d3c9991862d57701ac6e9006e386ae173fd35178"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
+	"kdl": {
+		blobSHA256: mustRuntimeProfileSHA256("ef6d000123c053eddebd200a1cbd44d6df5dcab7c4b3d34ae18acdf2f14989f5"),
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},
@@ -51,6 +65,20 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256: mustRuntimeProfileSHA256("b10816c87dc847492fbbc1fd97c5096ed35d7abe69d0cd2ef5dd7e02aabac25c"),
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
+	// Haskell's expression-list repeat has one exact comma row where C folds
+	// the reduce/repetition-shift pair deterministically. Retaining both arms
+	// grows a new GSS frontier for every list element.
+	"haskell": {
+		blobSHA256: mustRuntimeProfileSHA256("fcfc8794bca4442ebf5688d88e2397c78a22c8f0b585c4e1b868986cfa52dd09"),
+		conflictPolicies: []gotreesitter.ConflictPolicy{
+			{
+				State:         11192,
+				Lookahead:     4,
+				Kind:          gotreesitter.ConflictPolicyRepetitionReduce,
+				ReduceSymbols: []gotreesitter.Symbol{500},
+			},
 		},
 	},
 	// On large accepted-error Java sources, the cap-16 same-stack merge retry
@@ -95,5 +123,28 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 		lang.FullParseAcceptedErrorRetryProfile = profile.fullParseAcceptedErrorRetryProfile
 		changed = true
 	}
+	for _, policy := range profile.conflictPolicies {
+		if languageHasConflictPolicy(lang, policy) {
+			continue
+		}
+		policy.ReduceSymbols = append([]gotreesitter.Symbol(nil), policy.ReduceSymbols...)
+		lang.ConflictPolicies = append(lang.ConflictPolicies, policy)
+		changed = true
+	}
 	return changed
+}
+
+func languageHasConflictPolicy(lang *gotreesitter.Language, want gotreesitter.ConflictPolicy) bool {
+	if lang == nil {
+		return false
+	}
+	for _, policy := range lang.ConflictPolicies {
+		if policy.State == want.State &&
+			policy.Lookahead == want.Lookahead &&
+			policy.Kind == want.Kind &&
+			slices.Equal(policy.ReduceSymbols, want.ReduceSymbols) {
+			return true
+		}
+	}
+	return false
 }

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -32,7 +32,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 7; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 10; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -47,6 +47,52 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 }
 
+func TestBuiltinHaskellConflictPolicyAttaches(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	lang := HaskellLanguage()
+	for _, policy := range lang.ConflictPolicies {
+		if policy.State != 11192 || policy.Lookahead != 4 {
+			continue
+		}
+		if policy.Kind != gotreesitter.ConflictPolicyRepetitionReduce ||
+			len(policy.ReduceSymbols) != 1 || policy.ReduceSymbols[0] != 500 {
+			t.Fatalf("Haskell conflict policy = %+v, want certified expression-list reduce", policy)
+		}
+		return
+	}
+	t.Fatal("Haskell expression-list conflict policy was not attached")
+}
+
+func TestBuiltinHaskellConflictPolicyRequiresCertifiedBlobAndAttachesOnce(t *testing.T) {
+	lang := &gotreesitter.Language{Name: "haskell"}
+	if attachBuiltinLanguageRuntimeProfile("haskell", sha256.Sum256([]byte("uncertified")), lang) {
+		t.Fatal("uncertified Haskell blob reported a runtime-profile attachment")
+	}
+	if len(lang.ConflictPolicies) != 0 {
+		t.Fatalf("uncertified Haskell blob attached %d conflict policies", len(lang.ConflictPolicies))
+	}
+
+	blob := BlobByName("haskell")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(haskell) returned no data")
+	}
+	sum := sha256.Sum256(blob)
+	if !attachBuiltinLanguageRuntimeProfile("haskell", sum, lang) {
+		t.Fatal("certified Haskell blob did not attach its runtime profile")
+	}
+	if got := len(lang.ConflictPolicies); got != 1 {
+		t.Fatalf("certified Haskell conflict policies = %d, want 1", got)
+	}
+	if attachBuiltinLanguageRuntimeProfile("haskell", sum, lang) {
+		t.Fatal("reattaching the same Haskell profile reported a change")
+	}
+	if got := len(lang.ConflictPolicies); got != 1 {
+		t.Fatalf("reattached Haskell conflict policies = %d, want 1", got)
+	}
+}
+
 func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 	PurgeEmbeddedLanguageCache()
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
@@ -56,7 +102,9 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 		load func() *gotreesitter.Language
 	}{
 		{name: "bash", load: BashLanguage},
+		{name: "caddy", load: CaddyLanguage},
 		{name: "cpp", load: CppLanguage},
+		{name: "kdl", load: KdlLanguage},
 		{name: "rego", load: RegoLanguage},
 	}
 	for _, tt := range tests {
@@ -133,23 +181,27 @@ func TestBuiltinJavaAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T)
 }
 
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	lang := &gotreesitter.Language{Name: "rego"}
-	if attachBuiltinLanguageRuntimeProfile("rego", sha256.Sum256([]byte("uncertified")), lang) {
-		t.Fatal("uncertified Rego blob reported a runtime-profile attachment")
-	}
-	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
-		t.Fatalf("uncertified Rego blob changed retry profile to %+v", got)
-	}
+	for _, name := range []string{"caddy", "kdl", "rego"} {
+		t.Run(name, func(t *testing.T) {
+			lang := &gotreesitter.Language{Name: name}
+			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {
+				t.Fatalf("uncertified %s blob reported a runtime-profile attachment", name)
+			}
+			if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+				t.Fatalf("uncertified %s blob changed retry profile to %+v", name, got)
+			}
 
-	blob := BlobByName("rego")
-	if len(blob) == 0 {
-		t.Fatal("BlobByName(rego) returned no data")
-	}
-	if !attachBuiltinLanguageRuntimeProfile("rego", sha256.Sum256(blob), lang) {
-		t.Fatal("certified Rego blob did not attach its runtime profile")
-	}
-	if !lang.FullParseAcceptedErrorRetryProfile.SkipCompleteAcceptedErrorRetry {
-		t.Fatalf("certified Rego retry profile = %+v, want skip-complete certification", lang.FullParseAcceptedErrorRetryProfile)
+			blob := BlobByName(name)
+			if len(blob) == 0 {
+				t.Fatalf("BlobByName(%s) returned no data", name)
+			}
+			if !attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256(blob), lang) {
+				t.Fatalf("certified %s blob did not attach its runtime profile", name)
+			}
+			if !lang.FullParseAcceptedErrorRetryProfile.SkipCompleteAcceptedErrorRetry {
+				t.Fatalf("certified %s retry profile = %+v, want skip-complete certification", name, lang.FullParseAcceptedErrorRetryProfile)
+			}
+		})
 	}
 }
 

--- a/language.go
+++ b/language.go
@@ -242,6 +242,9 @@ const (
 	//
 	// Keep new kinds append-only: Language blobs encode these numeric values.
 	ConflictPolicyRecoveredRepetitionReduce
+	// ConflictPolicyRepetitionReduce is an exact-row certification for the
+	// ordinary C repetition fold: one reduce wins over one repetition shift.
+	ConflictPolicyRepetitionReduce
 )
 
 // ConflictPolicy describes one table row/lookahead conflict that can be

--- a/node_field_metadata.go
+++ b/node_field_metadata.go
@@ -76,6 +76,36 @@ func equalFieldIDSlices(a, b []FieldID) bool {
 	return true
 }
 
+func normalizedFieldSourceForID(fieldIDs []FieldID, fieldSources []uint8, i int) uint8 {
+	if i < 0 || i >= len(fieldIDs) || fieldIDs[i] == 0 {
+		return fieldSourceNone
+	}
+	source := fieldSourceAt(fieldSources, i)
+	if source == fieldSourceNone {
+		return fieldSourceDirect
+	}
+	return source
+}
+
+func equalNodeFieldMetadata(a, b *Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	aIDs := a.fieldIDs()
+	bIDs := b.fieldIDs()
+	if !equalFieldIDSlices(aIDs, bIDs) {
+		return false
+	}
+	aSources := a.fieldSources()
+	bSources := b.fieldSources()
+	for i := range aIDs {
+		if normalizedFieldSourceForID(aIDs, aSources, i) != normalizedFieldSourceForID(bIDs, bSources, i) {
+			return false
+		}
+	}
+	return true
+}
+
 func cloneNodeFieldMetadataHeaderInto(dst, src *Node, arena *nodeArena) {
 	if dst == nil || src == nil || src.fieldMetadata == nil {
 		if dst != nil {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5536,7 +5536,40 @@ const (
 	fieldSourceNone uint8 = iota
 	fieldSourceDirect
 	fieldSourceInherited
+	// Deferred sources retain the raw field edge on a hidden child while its
+	// hidden parent is still being built. The edge is resolved with the same
+	// rules as the eager path when the chain reaches a visible boundary.
+	fieldSourceDeferredDirect
+	fieldSourceDeferredInherited
+	fieldSourceDeferredInheritedLater
 )
+
+func deferredFieldSource(inherited, appearsLater bool) uint8 {
+	if !inherited {
+		return fieldSourceDeferredDirect
+	}
+	if appearsLater {
+		return fieldSourceDeferredInheritedLater
+	}
+	return fieldSourceDeferredInherited
+}
+
+func decodeDeferredFieldSource(source uint8) (inherited, appearsLater, ok bool) {
+	switch source {
+	case fieldSourceDeferredDirect:
+		return false, false, true
+	case fieldSourceDeferredInherited:
+		return true, false, true
+	case fieldSourceDeferredInheritedLater:
+		return true, true, true
+	default:
+		return false, false, false
+	}
+}
+
+func fieldSourceIsDirect(source uint8) bool {
+	return source == fieldSourceDirect || source == fieldSourceDeferredDirect
+}
 
 func fieldSourceAt(fieldSources []uint8, i int) uint8 {
 	if i < 0 || i >= len(fieldSources) {
@@ -5593,7 +5626,7 @@ func flattenedSpanHasFieldID(fieldIDs []FieldID, start, end int, fid FieldID) bo
 
 func flattenedSpanHasAnyDirectField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int) bool {
 	for i := start; i < end; i++ {
-		if i < len(fieldIDs) && fieldIDs[i] != 0 && fieldSourceAt(fieldSources, i) == fieldSourceDirect {
+		if i < len(fieldIDs) && fieldIDs[i] != 0 && fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
 			return true
 		}
 		if i < len(children) && nodeHasAnyDirectField(children[i]) {
@@ -5785,6 +5818,15 @@ func appendFlattenedHiddenChildrenWithFieldScratch(scratch *reduceBuildScratch, 
 		}
 		scratch.ensureFieldStorage()
 		source := fieldSourceAt(fieldSources, i)
+		if direct, deferred := resolveDeferredParentField(
+			scratch.nodes, scratch.fieldIDs, scratch.fieldSources,
+			child, spanStart, spanEnd, fieldIDs[i], source,
+		); deferred {
+			if direct {
+				scratch.recordRepeatedField(repeatEpoch, fieldIDs[i], fieldSourceDirect)
+			}
+			continue
+		}
 		if source == fieldSourceNone {
 			source = fieldSourceDirect
 		}
@@ -6181,6 +6223,21 @@ func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, ite
 	if len(n.children) == 0 {
 		return len(scratch.nodes), len(scratch.nodes)
 	}
+	if !parentVisible {
+		spanStart := len(scratch.nodes)
+		scratch.appendNode(n)
+		if item.fieldID != 0 {
+			if !scratch.trackFields {
+				scratch.ensureFieldStorage()
+			}
+			scratch.fieldIDs[spanStart] = item.fieldID
+			scratch.fieldSources[spanStart] = deferredFieldSource(
+				item.inherited,
+				fieldIDAppearsLater(rawFieldIDs, nextStructuralChildIndex, item.fieldID),
+			)
+		}
+		return spanStart, len(scratch.nodes)
+	}
 
 	spanStart := len(scratch.nodes)
 	if hiddenTreeHasFieldIDs(n) {
@@ -6195,7 +6252,17 @@ func (p *Parser) appendReduceChildItemToScratch(scratch *reduceBuildScratch, ite
 		scratch.ensureFieldStorage()
 	}
 	fieldEnd := len(scratch.fieldIDs)
-	applyParentFieldToFlattenedHiddenSpan(scratch, n, spanStart, fieldEnd, item.fieldID, item.inherited, rawFieldIDs, nextStructuralChildIndex)
+	applyParentFieldToFlattenedHiddenSpan(
+		scratch.nodes,
+		scratch.fieldIDs,
+		scratch.fieldSources,
+		n,
+		spanStart,
+		fieldEnd,
+		item.fieldID,
+		item.inherited,
+		fieldIDAppearsLater(rawFieldIDs, nextStructuralChildIndex, item.fieldID),
+	)
 	return spanStart, len(scratch.nodes)
 }
 
@@ -6211,23 +6278,35 @@ func (p *Parser) appendVisibleReduceChildToScratch(scratch *reduceBuildScratch, 
 	}
 }
 
-func applyParentFieldToFlattenedHiddenSpan(scratch *reduceBuildScratch, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, inherited bool, rawFieldIDs []FieldID, nextStructuralChildIndex int) {
+func applyParentFieldToFlattenedHiddenSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, inherited, appearsLater bool) {
 	source := fieldSourceForInheritance(inherited)
-	hasField := flattenedSpanHasFieldID(scratch.fieldIDs, spanStart, fieldEnd, fid)
+	hasField := flattenedSpanHasFieldID(fieldIDs, spanStart, fieldEnd, fid)
 	if inherited && !hasField {
-		if assignSingleDescendantInheritedField(scratch, spanStart, fieldEnd, fid) {
-			normalizeMixedSourceFieldSpan(scratch.fieldIDs, scratch.fieldSources, spanStart, fieldEnd)
+		if assignSingleDescendantInheritedField(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid) {
+			normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
 			return
 		}
-		if shouldSkipInheritedParentFieldForFlattenedSpan(scratch, hiddenParent, spanStart, fieldEnd, fid) {
+		if shouldSkipInheritedParentFieldForFlattenedSpan(children, fieldIDs, fieldSources, hiddenParent, spanStart, fieldEnd, fid) {
 			return
 		}
 	}
-	if inherited && fieldIDAppearsLater(rawFieldIDs, nextStructuralChildIndex, fid) {
+	if inherited && appearsLater {
 		return
 	}
-	applyFieldToFlattenedSpan(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, spanStart, fieldEnd, fid, source, true)
-	normalizeMixedSourceFieldSpan(scratch.fieldIDs, scratch.fieldSources, spanStart, fieldEnd)
+	applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid, source, true)
+	normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, spanStart, fieldEnd)
+}
+
+func resolveDeferredParentField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID, source uint8) (direct, deferred bool) {
+	inherited, appearsLater, deferred := decodeDeferredFieldSource(source)
+	if !deferred {
+		return false, false
+	}
+	applyParentFieldToFlattenedHiddenSpan(
+		children, fieldIDs, fieldSources, hiddenParent,
+		spanStart, fieldEnd, fid, inherited, appearsLater,
+	)
+	return !inherited, true
 }
 
 func fieldSourceForInheritance(inherited bool) uint8 {
@@ -6237,33 +6316,33 @@ func fieldSourceForInheritance(inherited bool) uint8 {
 	return fieldSourceDirect
 }
 
-func assignSingleDescendantInheritedField(scratch *reduceBuildScratch, spanStart, fieldEnd int, fid FieldID) bool {
-	target, ok := flattenedSpanSingleDescendantFieldTarget(scratch.nodes, spanStart, fieldEnd, fid)
+func assignSingleDescendantInheritedField(children []*Node, fieldIDs []FieldID, fieldSources []uint8, spanStart, fieldEnd int, fid FieldID) bool {
+	target, ok := flattenedSpanSingleDescendantFieldTarget(children, spanStart, fieldEnd, fid)
 	if !ok {
 		return false
 	}
-	scratch.fieldIDs[target] = fid
-	scratch.fieldSources[target] = fieldSourceInherited
+	fieldIDs[target] = fid
+	fieldSources[target] = fieldSourceInherited
 	return true
 }
 
-func shouldSkipInheritedParentFieldForFlattenedSpan(scratch *reduceBuildScratch, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID) bool {
+func shouldSkipInheritedParentFieldForFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, hiddenParent *Node, spanStart, fieldEnd int, fid FieldID) bool {
 	if fieldEnd-spanStart == 1 {
-		child := scratch.nodes[spanStart]
+		child := children[spanStart]
 		if child == nil || nodeHasDirectFieldID(child, fid) || len(child.children) == 0 {
 			return true
 		}
 	}
-	if hiddenParent.isNamed() && countEligibleNamedFieldTargets(scratch.nodes, scratch.fieldIDs, spanStart, fieldEnd) > 1 {
+	if hiddenParent.isNamed() && countEligibleNamedFieldTargets(children, fieldIDs, spanStart, fieldEnd) > 1 {
 		return true
 	}
-	if !flattenedSpanHasAnyDirectField(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, spanStart, fieldEnd) {
+	if !flattenedSpanHasAnyDirectField(children, fieldIDs, fieldSources, spanStart, fieldEnd) {
 		return false
 	}
 	if fieldEnd-spanStart != 1 {
 		return true
 	}
-	child := scratch.nodes[spanStart]
+	child := children[spanStart]
 	return child == nil || !nodeHasDirectFieldID(child, fid)
 }
 
@@ -6349,6 +6428,21 @@ func appendFlattenedHiddenChildrenWithFields(dst []*Node, fieldDst []FieldID, fi
 		paddingStartByte, paddingStartPoint = absorbFlattenedHiddenPaddingNodes(dst, spanStart, out, paddingStartByte, paddingStartPoint, child, nil, symbolMeta)
 		if fieldDst != nil && i < len(fieldIDs) && fieldIDs[i] != 0 {
 			source := fieldSourceAt(fieldSources, i)
+			if direct, deferred := resolveDeferredParentField(
+				dst, fieldDst, fieldSrcDst, child,
+				spanStart, out, fieldIDs[i], source,
+			); deferred {
+				if direct && spanStart < out {
+					if repeated == nil {
+						repeated = make(map[FieldID]hiddenFieldSpan)
+					}
+					span := repeated[fieldIDs[i]]
+					span.count++
+					span.source = fieldSourceDirect
+					repeated[fieldIDs[i]] = span
+				}
+				continue
+			}
 			if source == fieldSourceNone {
 				source = fieldSourceDirect
 			}
@@ -6676,7 +6770,7 @@ func nodeHasAnyDirectField(n *Node) bool {
 	fieldIDs := n.fieldIDs()
 	fieldSources := n.fieldSources()
 	for i := range fieldIDs {
-		if fieldIDs[i] != 0 && fieldSourceAt(fieldSources, i) == fieldSourceDirect {
+		if fieldIDs[i] != 0 && fieldSourceIsDirect(fieldSourceAt(fieldSources, i)) {
 			return true
 		}
 	}

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -118,7 +118,7 @@ func TestBuildReduceChildrenHiddenChildDoesNotDuplicateExistingField(t *testing.
 	rhs := newLeafNodeInArena(arena, 3, true, 3, 4, Point{Row: 0, Column: 3}, Point{Row: 0, Column: 4})
 	hidden := newParentNodeInArena(arena, 1, false, []*Node{operator, rhs}, []FieldID{1, 0}, 0)
 
-	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 0, 0, arena)
+	children, fieldIDs, _ := parser.buildReduceChildren([]stackEntry{newStackEntryNode(0, hidden)}, 0, 1, 1, 3, 0, arena)
 	if got, want := len(children), 2; got != want {
 		t.Fatalf("len(children) = %d, want %d", got, want)
 	}
@@ -131,6 +131,204 @@ func TestBuildReduceChildrenHiddenChildDoesNotDuplicateExistingField(t *testing.
 	if got := fieldIDs[1]; got != 0 {
 		t.Fatalf("fieldIDs[1] = %d, want 0", got)
 	}
+}
+
+func TestBuildReduceChildrenDefersDirectHiddenFieldUntilVisibleBoundary(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"EOF", "_inner", "_outer", ".", "identifier", "visible_parent"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false},
+			{Name: "_inner", Visible: false},
+			{Name: "_outer", Visible: false},
+			{Name: ".", Visible: true},
+			{Name: "identifier", Visible: true, Named: true},
+			{Name: "visible_parent", Visible: true, Named: true},
+		},
+		FieldNames:     []string{"", "path"},
+		FieldMapSlices: [][2]uint16{{0, 1}, {1, 0}},
+		FieldMapEntries: []FieldMapEntry{
+			{FieldID: 1, ChildIndex: 0},
+		},
+	}
+
+	parser := NewParser(lang)
+	arena := newNodeArena(arenaClassFull)
+	dot0 := newLeafNodeInArena(arena, 3, false, 0, 1, Point{}, Point{Column: 1})
+	a := newLeafNodeInArena(arena, 4, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	dot1 := newLeafNodeInArena(arena, 3, false, 2, 3, Point{Column: 2}, Point{Column: 3})
+	b := newLeafNodeInArena(arena, 4, true, 3, 4, Point{Column: 3}, Point{Column: 4})
+	inner := newParentNodeInArena(arena, 1, false, []*Node{dot0, a, dot1, b}, nil, 0)
+
+	children, fieldIDs, fieldSources := parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, inner)}, 0, 1, 1, 2, 0, arena,
+	)
+	if got, want := len(children), 1; got != want {
+		t.Fatalf("deferred len(children) = %d, want %d", got, want)
+	}
+	if children[0] != inner {
+		t.Fatal("deferred child does not retain the hidden subtree")
+	}
+	if got, want := fieldIDs[0], FieldID(1); got != want {
+		t.Fatalf("deferred field ID = %d, want %d", got, want)
+	}
+	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceDeferredDirect); got != want {
+		t.Fatalf("deferred field source = %d, want %d", got, want)
+	}
+
+	outer := newParentNodeInArenaWithFieldSources(arena, 2, false, children, fieldIDs, fieldSources, 0)
+	children, fieldIDs, fieldSources = parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, outer)}, 0, 1, 1, 5, 1, arena,
+	)
+	if got, want := len(children), 4; got != want {
+		t.Fatalf("visible len(children) = %d, want %d", got, want)
+	}
+	wantChildren := []*Node{dot0, a, dot1, b}
+	wantFields := []FieldID{0, 1, 0, 1}
+	wantSources := []uint8{fieldSourceNone, fieldSourceDirect, fieldSourceNone, fieldSourceDirect}
+	for i := range wantChildren {
+		if children[i] != wantChildren[i] {
+			t.Fatalf("children[%d] = %p, want %p", i, children[i], wantChildren[i])
+		}
+		if fieldIDs[i] != wantFields[i] {
+			t.Fatalf("fieldIDs[%d] = %d, want %d", i, fieldIDs[i], wantFields[i])
+		}
+		if got := fieldSourceAt(fieldSources, i); got != wantSources[i] {
+			t.Fatalf("fieldSources[%d] = %d, want %d", i, got, wantSources[i])
+		}
+	}
+}
+
+func TestBuildReduceChildrenDeferredInheritedFieldRespectsLaterDirectField(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"EOF", "_inner", "_outer", "operator", "identifier", "visible_parent"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false},
+			{Name: "_inner", Visible: false},
+			{Name: "_outer", Visible: false},
+			{Name: "operator", Visible: true},
+			{Name: "identifier", Visible: true, Named: true},
+			{Name: "visible_parent", Visible: true, Named: true},
+		},
+		FieldNames:     []string{"", "value"},
+		FieldMapSlices: [][2]uint16{{0, 2}, {2, 0}},
+		FieldMapEntries: []FieldMapEntry{
+			{FieldID: 1, ChildIndex: 0, Inherited: true},
+			{FieldID: 1, ChildIndex: 1},
+		},
+	}
+
+	parser := NewParser(lang)
+	arena := newNodeArena(arenaClassFull)
+	op := newLeafNodeInArena(arena, 3, false, 0, 1, Point{}, Point{Column: 1})
+	value := newLeafNodeInArena(arena, 4, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	inner := newParentNodeInArena(arena, 1, false, []*Node{op, value}, nil, 0)
+	tail := newLeafNodeInArena(arena, 4, true, 2, 3, Point{Column: 2}, Point{Column: 3})
+
+	children, fieldIDs, fieldSources := parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, inner), newStackEntryNode(0, tail)}, 0, 2, 2, 2, 0, arena,
+	)
+	if got, want := len(children), 2; got != want {
+		t.Fatalf("deferred len(children) = %d, want %d", got, want)
+	}
+	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceDeferredInheritedLater); got != want {
+		t.Fatalf("first deferred field source = %d, want %d", got, want)
+	}
+	if got, want := fieldSourceAt(fieldSources, 1), uint8(fieldSourceDirect); got != want {
+		t.Fatalf("later field source = %d, want %d", got, want)
+	}
+
+	outer := newParentNodeInArenaWithFieldSources(arena, 2, false, children, fieldIDs, fieldSources, 0)
+	children, fieldIDs, fieldSources = parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, outer)}, 0, 1, 1, 5, 1, arena,
+	)
+	wantChildren := []*Node{op, value, tail}
+	wantFields := []FieldID{0, 0, 1}
+	wantSources := []uint8{fieldSourceNone, fieldSourceNone, fieldSourceDirect}
+	for i := range wantChildren {
+		if children[i] != wantChildren[i] {
+			t.Fatalf("children[%d] = %p, want %p", i, children[i], wantChildren[i])
+		}
+		if fieldIDs[i] != wantFields[i] {
+			t.Fatalf("fieldIDs[%d] = %d, want %d", i, fieldIDs[i], wantFields[i])
+		}
+		if got := fieldSourceAt(fieldSources, i); got != wantSources[i] {
+			t.Fatalf("fieldSources[%d] = %d, want %d", i, got, wantSources[i])
+		}
+	}
+}
+
+func TestBuildReduceChildrenDeferredDirectCountsAsRepeatedField(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"EOF", "_inner", "_outer", "identifier", "visible_parent"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false},
+			{Name: "_inner", Visible: false},
+			{Name: "_outer", Visible: false},
+			{Name: "identifier", Visible: true, Named: true},
+			{Name: "visible_parent", Visible: true, Named: true},
+		},
+		FieldNames:     []string{"", "path", "other"},
+		FieldMapSlices: [][2]uint16{{0, 2}, {2, 0}},
+		FieldMapEntries: []FieldMapEntry{
+			{FieldID: 1, ChildIndex: 0},
+			{FieldID: 1, ChildIndex: 2},
+		},
+	}
+
+	parser := NewParser(lang)
+	arena := newNodeArena(arenaClassFull)
+	a := newLeafNodeInArena(arena, 3, true, 0, 1, Point{}, Point{Column: 1})
+	b := newLeafNodeInArena(arena, 3, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	c := newLeafNodeInArena(arena, 3, true, 2, 3, Point{Column: 2}, Point{Column: 3})
+	d := newLeafNodeInArena(arena, 3, true, 3, 4, Point{Column: 3}, Point{Column: 4})
+	middle := newParentNodeInArenaWithFieldSources(
+		arena, 1, false, []*Node{b, c}, []FieldID{2, 2}, []uint8{fieldSourceInherited, fieldSourceInherited}, 0,
+	)
+	tail := newParentNodeInArena(arena, 1, false, []*Node{d}, nil, 0)
+
+	compactChildren, compactIDs, compactSources := parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, a), newStackEntryNode(0, middle), newStackEntryNode(0, tail)},
+		0, 3, 3, 2, 0, arena,
+	)
+	if got, want := len(compactChildren), 3; got != want {
+		t.Fatalf("compact len(children) = %d, want %d", got, want)
+	}
+	if got, want := fieldSourceAt(compactSources, 2), uint8(fieldSourceDeferredDirect); got != want {
+		t.Fatalf("tail field source = %d, want %d", got, want)
+	}
+	outer := newParentNodeInArenaWithFieldSources(arena, 2, false, compactChildren, compactIDs, compactSources, 0)
+
+	assertFlattened := func(label string, children []*Node, fieldIDs []FieldID, fieldSources []uint8) {
+		t.Helper()
+		wantChildren := []*Node{a, b, c, d}
+		if got, want := len(children), len(wantChildren); got != want {
+			t.Fatalf("%s len(children) = %d, want %d", label, got, want)
+		}
+		for i := range wantChildren {
+			if children[i] != wantChildren[i] {
+				t.Fatalf("%s children[%d] = %p, want %p", label, i, children[i], wantChildren[i])
+			}
+			if got, want := fieldIDs[i], FieldID(1); got != want {
+				t.Fatalf("%s fieldIDs[%d] = %d, want %d", label, i, got, want)
+			}
+			if got, want := fieldSourceAt(fieldSources, i), uint8(fieldSourceDirect); got != want {
+				t.Fatalf("%s fieldSources[%d] = %d, want %d", label, i, got, want)
+			}
+		}
+	}
+
+	children, fieldIDs, fieldSources := parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, outer)}, 0, 1, 1, 4, 1, arena,
+	)
+	assertFlattened("scratch", children, fieldIDs, fieldSources)
+
+	arrayChildren := make([]*Node, 4)
+	arrayIDs := make([]FieldID, 4)
+	arraySources := make([]uint8, 4)
+	if got, want := appendFlattenedHiddenChildrenWithFields(arrayChildren, arrayIDs, arraySources, 0, outer, lang.SymbolMetadata, nil), 4; got != want {
+		t.Fatalf("array flattened count = %d, want %d", got, want)
+	}
+	assertFlattened("array", arrayChildren, arrayIDs, arraySources)
 }
 
 func TestBuildReduceChildrenInheritedFieldOverridesInheritedInnerFieldOnFlattenedSpan(t *testing.T) {


### PR DESCRIPTION
## Summary

- retain hidden reductions until a visible boundary, then resolve deferred field metadata with the existing field-assignment rules
- include normalized field-source metadata in GLR stack equivalence so unresolved edges cannot merge with resolved edges
- certify one Haskell repetition conflict row and accepted-error retry skips for Caddy and KDL against exact built-in grammar blobs

## Validation

- Docker unit gates: root and `grammars` packages
- focused Docker race coverage for conflict selection, deferred fields, GLR equality, and runtime-profile attachment
- exact S-expression and deep parity on the two large Haskell witnesses; aggregate Go/C time ratio: 0.95x, with the prior memory-budget and GSS stoppages removed
- Caddy cohort: 1.24x aggregate Go/C ratio, no stops; KDL cohort: 1.89x, no stops, 4.08x worst case
- standard benchmark trio: full parse improved 5.09%; incremental single-byte and no-edit paths were statistically unchanged

## Scope note

The broader generated Haskell corpus retains pre-existing parity gaps (21/25 error-free, 19/25 exact); this change does not claim to resolve those cases.