### PR TITLE
Skip redundant retries for Haxe, Odin, and SCSS

### DIFF
--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -26,9 +26,25 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                    mustRuntimeProfileSHA256("06bac15a9921a2e6af2810fb37ecb29a358b120e137345b9af5fb5f6c6632f59"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 	},
+	// Haxe's accepted-error retry ladder selects the same tree on every pass.
+	// Keep the first accepted result instead of running either retry ladder.
+	"haxe": {
+		blobSHA256: mustRuntimeProfileSHA256("eb39b273148a394f792b322cd30b5483fd6f8ca915b7e15835de4d6482b5a4a7"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
 	"kotlin": {
 		blobSHA256:                    mustRuntimeProfileSHA256("643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+	},
+	// Odin's accepted-error retry ladder selects the same tree on every pass.
+	// Keep the first accepted result instead of running either retry ladder.
+	"odin": {
+		blobSHA256: mustRuntimeProfileSHA256("9b376bcbbe677780b9031ae84eee4fb59eb37a14fbe169c7c17d35f2b5b776ed"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
 	},
 	"python": {
 		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
@@ -63,6 +79,12 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	},
 	"rego": {
 		blobSHA256: mustRuntimeProfileSHA256("b10816c87dc847492fbbc1fd97c5096ed35d7abe69d0cd2ef5dd7e02aabac25c"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
+	"scss": {
+		blobSHA256: mustRuntimeProfileSHA256("0646d27248a96d865a717a2a020ede70762b8a0542fac32a316b34248af9a50e"),
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -32,7 +32,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 10; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 13; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -104,8 +104,11 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 		{name: "bash", load: BashLanguage},
 		{name: "caddy", load: CaddyLanguage},
 		{name: "cpp", load: CppLanguage},
+		{name: "haxe", load: HaxeLanguage},
 		{name: "kdl", load: KdlLanguage},
+		{name: "odin", load: OdinLanguage},
 		{name: "rego", load: RegoLanguage},
+		{name: "scss", load: ScssLanguage},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -181,7 +184,7 @@ func TestBuiltinJavaAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T)
 }
 
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	for _, name := range []string{"caddy", "kdl", "rego"} {
+	for _, name := range []string{"caddy", "haxe", "kdl", "odin", "rego", "scss"} {
 		t.Run(name, func(t *testing.T) {
 			lang := &gotreesitter.Language{Name: name}
 			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {


### PR DESCRIPTION
## Summary

- attach exact-blob runtime profiles for Haxe, Odin, and SCSS
- keep the first complete accepted-error result when every retry pass selects the same tree
- leave caller-built, adapted, and blob-mismatched languages on the conservative retry path

## Results

| Cohort | Before | After |
|---|---:|---:|
| Odin largest eight | `d3d12.odin` 22.65-25.07x C | 2.33x aggregate, 3.82x worst |
| Haxe largest eight | `TestStrict.hx` 18.68x; `ServerTests.hx` 11.20x | 1.91x aggregate, 3.48x worst |
| SCSS largest eight | `_functions.scss` 16.90x; `_utilities.scss` 31.22x | 1.91x aggregate, 4.42x worst |

All 24 selected files complete with zero timeout/OOM/>10x cases.

## Correctness gates

- compared retry-enabled and certified parses for all 24 files
- exact match on S-expression, node type/flags, fields, spans, parse states, stop reason, and truncation status
- existing Go-vs-C structural mismatches are unchanged; this PR does not claim to fix them
- full Docker unit gates for root and `grammars`
- focused Docker race gate for profile attachment/certification
- standard full, single-byte incremental, and no-edit benchmark trio: statistically unchanged

## Scope

The profiles are pinned to the checked-in grammar blob SHA-256 values. A regenerated or caller-supplied grammar does not inherit these retry decisions.