### PR TITLE
parser: bound certified retry ladders

### DIFF
--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -89,6 +89,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},
 	},
+	// Tcl's complete accepted-error trees and first error-bearing no-stacks
+	// retry are authoritative for the certified corpus. Later widened passes
+	// repeat the same failure without advancing the selected tree.
+	"tcl": {
+		blobSHA256: mustRuntimeProfileSHA256("4c331e38860001c18b737f6be508f4b09f230c4b9ff95f4b4d12bdb00c176ad7"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+			FreshErrorNoStacksMaxPasses:    1,
+		},
+	},
 	// Haskell's expression-list repeat has one exact comma row where C folds
 	// the reduce/repetition-shift pair deterministically. Retaining both arms
 	// grows a new GSS frontier for every list element.

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -50,6 +50,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 	},
+	// Large ASM accepted-error parses improve during the same-stack merge
+	// retry, but later widened-stack passes do not advance the selected tree.
+	// Keep that first retry while avoiding the redundant wider passes.
+	"asm": {
+		blobSHA256: mustRuntimeProfileSHA256("7001e89cc1c597efce3143c011d39a40855067fb06863b738d2c4d7e595fb71d"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			MinSourceBytes:      11 * 1024,
+			InitialStackCeiling: 8,
+		},
+	},
 	// These grammars have error-bearing real-corpus witnesses that legitimately
 	// reach EOF. Re-running the accepted-error ladder does not improve their
 	// selected trees, so the exact certified blobs keep the first result.

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -32,7 +32,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 14; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 15; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -124,20 +124,44 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 	}
 }
 
-func TestBuiltinJavaAcceptedErrorRetryProfileAttaches(t *testing.T) {
+func TestBuiltinBoundedAcceptedErrorRetryProfilesAttach(t *testing.T) {
 	PurgeEmbeddedLanguageCache()
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
 
-	lang := JavaLanguage()
-	if lang.ExternalScanner != nil {
-		t.Fatal("Java ExternalScanner != nil; profile must not depend on scanner attachment")
+	tests := []struct {
+		name          string
+		load          func() *gotreesitter.Language
+		want          gotreesitter.FullParseAcceptedErrorRetryProfile
+		wantNoScanner bool
+	}{
+		{
+			name: "asm",
+			load: AsmLanguage,
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{
+				MinSourceBytes:      11 * 1024,
+				InitialStackCeiling: 8,
+			},
+		},
+		{
+			name: "java",
+			load: JavaLanguage,
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{
+				MinSourceBytes:      64 * 1024,
+				InitialStackCeiling: 14,
+			},
+			wantNoScanner: true,
+		},
 	}
-	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
-		MinSourceBytes:      64 * 1024,
-		InitialStackCeiling: 14,
-	}
-	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
-		t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want %+v", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := tt.load()
+			if tt.wantNoScanner && lang.ExternalScanner != nil {
+				t.Fatalf("%s ExternalScanner != nil; profile must not depend on scanner attachment", tt.name)
+			}
+			if got := lang.FullParseAcceptedErrorRetryProfile; got != tt.want {
+				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want %+v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -162,28 +186,35 @@ func TestBuiltinExternalScannerRetryProfilesRequireCertifiedBlob(t *testing.T) {
 	}
 }
 
-func TestBuiltinJavaAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	lang := &gotreesitter.Language{Name: "java"}
-	if attachBuiltinLanguageRuntimeProfile("java", sha256.Sum256([]byte("uncertified")), lang) {
-		t.Fatal("uncertified Java blob reported a runtime-profile attachment")
+func TestBuiltinBoundedAcceptedErrorRetryProfilesRequireCertifiedBlob(t *testing.T) {
+	tests := []struct {
+		name string
+		want gotreesitter.FullParseAcceptedErrorRetryProfile
+	}{
+		{name: "asm", want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 11 * 1024, InitialStackCeiling: 8}},
+		{name: "java", want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 64 * 1024, InitialStackCeiling: 14}},
 	}
-	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
-		t.Fatalf("uncertified Java blob changed retry profile to %+v", got)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := &gotreesitter.Language{Name: tt.name}
+			if attachBuiltinLanguageRuntimeProfile(tt.name, sha256.Sum256([]byte("uncertified")), lang) {
+				t.Fatalf("uncertified %s blob reported a runtime-profile attachment", tt.name)
+			}
+			if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+				t.Fatalf("uncertified %s blob changed retry profile to %+v", tt.name, got)
+			}
 
-	blob := BlobByName("java")
-	if len(blob) == 0 {
-		t.Fatal("BlobByName(java) returned no data")
-	}
-	if !attachBuiltinLanguageRuntimeProfile("java", sha256.Sum256(blob), lang) {
-		t.Fatal("certified Java blob did not attach its runtime profile")
-	}
-	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
-		MinSourceBytes:      64 * 1024,
-		InitialStackCeiling: 14,
-	}
-	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
-		t.Fatalf("certified Java retry profile = %+v, want %+v", got, want)
+			blob := BlobByName(tt.name)
+			if len(blob) == 0 {
+				t.Fatalf("BlobByName(%s) returned no data", tt.name)
+			}
+			if !attachBuiltinLanguageRuntimeProfile(tt.name, sha256.Sum256(blob), lang) {
+				t.Fatalf("certified %s blob did not attach its runtime profile", tt.name)
+			}
+			if got := lang.FullParseAcceptedErrorRetryProfile; got != tt.want {
+				t.Fatalf("certified %s retry profile = %+v, want %+v", tt.name, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -32,7 +32,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 13; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 14; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -109,12 +109,16 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 		{name: "odin", load: OdinLanguage},
 		{name: "rego", load: RegoLanguage},
 		{name: "scss", load: ScssLanguage},
+		{name: "tcl", load: TclLanguage},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			profile := tt.load().FullParseAcceptedErrorRetryProfile
 			if !profile.SkipCompleteAcceptedErrorRetry {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want skip-complete certification", profile)
+			}
+			if tt.name == "tcl" && profile.FreshErrorNoStacksMaxPasses != 1 {
+				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want one fresh no-stacks retry", profile)
 			}
 		})
 	}
@@ -184,7 +188,7 @@ func TestBuiltinJavaAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T)
 }
 
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	for _, name := range []string{"caddy", "haxe", "kdl", "odin", "rego", "scss"} {
+	for _, name := range []string{"caddy", "haxe", "kdl", "odin", "rego", "scss", "tcl"} {
 		t.Run(name, func(t *testing.T) {
 			lang := &gotreesitter.Language{Name: name}
 			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {

--- a/language.go
+++ b/language.go
@@ -278,19 +278,20 @@ const (
 	ExternalScannerFullParseRetrySkipRepeat
 )
 
-// FullParseAcceptedErrorRetryProfile certifies a narrow full-parse retry
-// policy. When a fresh full parse accepts an error-bearing tree that covers
+// FullParseAcceptedErrorRetryProfile certifies narrow full-parse retry
+// policies. When a fresh full parse accepts an error-bearing tree that covers
 // EOF, the parser may keep the initial GLR stack ceiling after the ordinary
-// same-stack merge retry instead of scheduling wider-stack passes. A grammar
-// may instead certify that a complete accepted-error tree is authoritative and
-// skip that retry ladder entirely. The zero value preserves the conservative
-// generic ladder.
+// same-stack merge retry or skip that ladder entirely. A grammar may also cap
+// retries for a fresh, error-bearing no-stacks result after proving that later
+// passes do not improve the selected tree. The zero value preserves the
+// conservative generic ladder.
 //
 // Keep fields append-only: Language blobs encode this structure.
 type FullParseAcceptedErrorRetryProfile struct {
 	MinSourceBytes                 uint32
 	InitialStackCeiling            uint16
 	SkipCompleteAcceptedErrorRetry bool
+	FreshErrorNoStacksMaxPasses    uint8
 }
 
 // Language holds all data needed to parse a specific language.
@@ -494,7 +495,7 @@ type Language struct {
 	ExternalScannerFullParseRetryPolicy ExternalScannerFullParseRetryPolicy
 
 	// FullParseAcceptedErrorRetryProfile is certified against an exact language
-	// blob. Zero preserves widened-stack retries for legacy blobs,
+	// blob. Zero preserves widened-stack and no-stacks retries for legacy blobs,
 	// caller-constructed languages, and language overrides.
 	FullParseAcceptedErrorRetryProfile FullParseAcceptedErrorRetryProfile
 }

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -887,6 +887,91 @@ func TestCompleteAcceptedErrorRetrySkipRequiresCertification(t *testing.T) {
 	}
 }
 
+func certifiedFreshErrorNoStacksTestTree(profile bool, sourceLen int) *Tree {
+	lang := &Language{Name: "synthetic"}
+	if profile {
+		lang.FullParseAcceptedErrorRetryProfile.FreshErrorNoStacksMaxPasses = 1
+	}
+	return &Tree{
+		language: lang,
+		root: &Node{
+			endByte: uint32(sourceLen / 2),
+			flags:   nodeFlagHasError,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:       ParseStopNoStacksAlive,
+			Truncated:        true,
+			SourceLen:        uint32(sourceLen),
+			ExpectedEOFByte:  uint32(sourceLen),
+			RootEndByte:      uint32(sourceLen / 2),
+			LastTokenEndByte: uint32(sourceLen/2 + 1),
+			MaxStacksSeen:    8,
+			NodesAllocated:   100,
+		},
+	}
+}
+
+func TestCertifiedFreshErrorNoStacksRetryPassLimitScope(t *testing.T) {
+	const sourceLen = 128
+	eligible := certifiedFreshErrorNoStacksTestTree(true, sourceLen)
+	if got := certifiedFreshErrorNoStacksRetryPassLimit(eligible, sourceLen, fullParseRetryOriginFresh); got != 1 {
+		t.Fatalf("fresh certified retry limit = %d, want 1", got)
+	}
+	if got := certifiedFreshErrorNoStacksRetryPassLimit(eligible, sourceLen, fullParseRetryOriginIncremental); got != 0 {
+		t.Fatalf("incremental certified retry limit = %d, want 0", got)
+	}
+	if got := certifiedFreshErrorNoStacksRetryPassLimit(certifiedFreshErrorNoStacksTestTree(false, sourceLen), sourceLen, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("uncertified retry limit = %d, want 0", got)
+	}
+	clean := certifiedFreshErrorNoStacksTestTree(true, sourceLen)
+	clean.root.flags = 0
+	if got := certifiedFreshErrorNoStacksRetryPassLimit(clean, sourceLen, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("clean no-stacks retry limit = %d, want 0", got)
+	}
+	accepted := certifiedFreshErrorNoStacksTestTree(true, sourceLen)
+	accepted.parseRuntime.StopReason = ParseStopAccepted
+	if got := certifiedFreshErrorNoStacksRetryPassLimit(accepted, sourceLen, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("accepted retry limit = %d, want 0", got)
+	}
+}
+
+func TestCertifiedFreshErrorNoStacksRetryPassLimitScheduling(t *testing.T) {
+	const sourceLen = 128
+	source := make([]byte, sourceLen)
+	parser := &Parser{}
+	initial := certifiedFreshErrorNoStacksTestTree(true, sourceLen)
+	var calls int
+	result := parser.retryFullParse(source, 8, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+		calls++
+		return certifiedFreshErrorNoStacksTestTree(true, sourceLen)
+	})
+	if calls != 1 {
+		t.Fatalf("certified retry calls = %d, want 1", calls)
+	}
+	if result == nil {
+		t.Fatal("certified retry returned nil tree")
+	}
+	calls = 0
+	parser.retryFullParse(source, 8, certifiedFreshErrorNoStacksTestTree(true, sourceLen), func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+		calls++
+		return certifiedFreshErrorNoStacksTestTree(true, sourceLen)
+	})
+	if calls != 0 {
+		t.Fatalf("second certified retry calls = %d, want shared per-operation limit", calls)
+	}
+
+	parser = &Parser{}
+	initial = certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+	calls = 0
+	parser.retryFullParse(source, 8, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+		calls++
+		return certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+	})
+	if calls <= 1 {
+		t.Fatalf("uncertified retry calls = %d, want conservative ladder", calls)
+	}
+}
+
 func TestJavaAcceptedErrorRetryUsesWideMergeRetry(t *testing.T) {
 	errChild := &Node{
 		symbol: errorSymbol,

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1219,6 +1219,18 @@ func certifiedAcceptedErrorRetrySkipsComplete(tree *Tree, sourceLen int) bool {
 		retryTreeCoversExpectedEOF(tree)
 }
 
+func certifiedFreshErrorNoStacksRetryPassLimit(tree *Tree, sourceLen int, origin fullParseRetryOrigin) int {
+	if tree == nil || tree.language == nil || origin != fullParseRetryOriginFresh ||
+		sourceLen <= 0 || sourceLen > fullParseRetryMaxSourceBytes {
+		return 0
+	}
+	limit := tree.language.FullParseAcceptedErrorRetryProfile.FreshErrorNoStacksMaxPasses
+	if limit == 0 || tree.ParseStopReason() != ParseStopNoStacksAlive || !retryTreeHasError(tree) {
+		return 0
+	}
+	return int(limit)
+}
+
 func fullParseRetryNodeLimitOverride(tree *Tree, sourceLen int) int {
 	if !shouldRetryNodeLimitParse(tree, sourceLen) {
 		return 0
@@ -1370,6 +1382,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	// retries the budget was not re-checked. We honor the same budget as a
 	// wall-clock deadline shared across retry attempts.
 	retryStart := time.Now()
+	retryPassLimit := fullParseRetryMaxTotalPasses
+	if certifiedLimit := certifiedFreshErrorNoStacksRetryPassLimit(tree, len(source), origin); certifiedLimit > 0 && certifiedLimit < retryPassLimit {
+		retryPassLimit = certifiedLimit
+	}
+	retryPassLimitReached := func() bool {
+		return p != nil && p.fullParseRetryPassesTaken >= retryPassLimit
+	}
 	retryDeadlineExceeded := func() bool {
 		if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
 			return true
@@ -1378,7 +1397,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 		// is a no-op without SetTimeoutMicros — see the KNOWN GAP below).
 		// Counted per top-level parse operation across every retryFullParse
 		// invocation; see fullParseRetryMaxTotalPasses.
-		if p != nil && p.fullParseRetryPassesTaken >= fullParseRetryMaxTotalPasses {
+		if retryPassLimitReached() {
 			return true
 		}
 		// KNOWN GAP (tracked, not fixed here): when the caller never
@@ -1464,7 +1483,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	}
 	runRetryAttempt := func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
 		if p != nil {
-			if p.fullParseRetryPassesTaken >= fullParseRetryMaxTotalPasses {
+			if retryPassLimitReached() {
 				// Budget exhausted: a nil candidate is a no-op for every
 				// caller (replaceBest ignores nil), so the incumbent best
 				// tree flows through unchanged.


### PR DESCRIPTION
## Summary

- add an append-only runtime-profile limit for fresh, error-bearing `no_stacks_alive` full-parse retries
- certify the checked-in Tcl grammar blob to keep one useful retry and skip redundant complete accepted-error retries
- certify large ASM parses to retain the useful same-stack merge retry while avoiding later widened passes
- retain conservative retry behavior for uncertified blobs, caller-built languages, incremental fallback, and out-of-scope inputs

## Validation

- all 77 Tcl corpus files preserve selected tree structure, parse states, fields, spans, stop reason, and truncation with the profile enabled
- isolated eight-file Tcl gate: no timeout, OOM, or >10x case; comparable files aggregate at 1.69x C
- all 242 ASM corpus files preserve detailed trees and runtime outcome; the two prior >10x witnesses now measure 5.28x and 5.59x C
- stable benchmark trio shows no reproducible regression: full parse and both incremental paths are statistically unchanged; allocation counts are unchanged
- focused parser/profile unit tests and race tests pass in Docker

Existing Tcl and ASM structural mismatches against C remain unchanged and are not hidden by the performance gates.
