### PR TITLE
harness: load grammar support on demand

### DIFF
--- a/cgo_harness/benchmark_real_corpus_parity_test.go
+++ b/cgo_harness/benchmark_real_corpus_parity_test.go
@@ -273,7 +273,7 @@ func prepareRealCorpusBenchmarkCases(b *testing.B, name string) []realCorpusBenc
 	if !ok {
 		b.Fatalf("missing registry entry for %q", name)
 	}
-	report, ok := paritySupportByName[name]
+	report, ok := paritySupportForName(name)
 	if !ok {
 		b.Fatalf("missing parse support report for %q", name)
 	}

--- a/cgo_harness/benchmark_top50_parity_test.go
+++ b/cgo_harness/benchmark_top50_parity_test.go
@@ -83,7 +83,7 @@ func prepareTop50BenchmarkCase(b *testing.B, name string) (top50BenchmarkCase, b
 	if !ok {
 		b.Fatalf("missing registry entry for %q", name)
 	}
-	report, ok := paritySupportByName[name]
+	report, ok := paritySupportForName(name)
 	if !ok {
 		b.Fatalf("missing parse support report for %q", name)
 	}
@@ -266,7 +266,7 @@ func TestParityTop50ParseSmoke(t *testing.T) {
 		if parityLanguageExcluded(name) {
 			continue
 		}
-		report, ok := paritySupportByName[name]
+		report, ok := paritySupportForName(name)
 		if !ok || report.Backend == grammars.ParseBackendUnsupported || !hasDedicatedSample[name] {
 			continue
 		}
@@ -293,7 +293,7 @@ func TestParityTop50ParseMaterializationTrends(t *testing.T) {
 		if parityLanguageExcluded(name) {
 			continue
 		}
-		report, ok := paritySupportByName[name]
+		report, ok := paritySupportForName(name)
 		if !ok || report.Backend == grammars.ParseBackendUnsupported || !hasDedicatedSample[name] {
 			continue
 		}

--- a/cgo_harness/cmd/corpus_parity/main.go
+++ b/cgo_harness/cmd/corpus_parity/main.go
@@ -130,9 +130,11 @@ func main() {
 	for _, entry := range grammars.AllLanguages() {
 		entriesByName[entry.Name] = entry
 	}
-	supportByName := make(map[string]grammars.ParseSupport)
-	for _, report := range grammars.AuditParseSupport() {
-		supportByName[report.Name] = report
+	supportByName := make(map[string]grammars.ParseSupport, len(langs))
+	for _, name := range langs {
+		if report, ok := grammars.ParseSupportFor(name); ok {
+			supportByName[report.Name] = report
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(outFlag), 0o755); err != nil {

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -675,7 +675,7 @@ func main() {
 		fatalf("zero corpus samples for languages %s", strings.Join(langs, ","))
 	}
 
-	entries, support := registryMaps()
+	entries := registryEntries()
 	runners := make(map[string]*runner)
 	defer func() {
 		for _, r := range runners {
@@ -729,7 +729,7 @@ func main() {
 	unsupportedSamples := 0
 
 	for _, s := range samples {
-		r, err := runnerForLanguage(s.Language, entries, support, runners, hotShapeLimit)
+		r, err := runnerForLanguage(s.Language, entries, runners, hotShapeLimit)
 		if err != nil {
 			unsupportedSamples++
 			row := errorRow(common, s, "setup", countFlag, err)
@@ -866,19 +866,15 @@ func commonRowFields(repoRoot string) commonFields {
 	}
 }
 
-func registryMaps() (map[string]grammars.LangEntry, map[string]grammars.ParseSupport) {
+func registryEntries() map[string]grammars.LangEntry {
 	entries := make(map[string]grammars.LangEntry)
 	for _, entry := range grammars.AllLanguages() {
 		entries[entry.Name] = entry
 	}
-	support := make(map[string]grammars.ParseSupport)
-	for _, report := range grammars.AuditParseSupport() {
-		support[report.Name] = report
-	}
-	return entries, support
+	return entries
 }
 
-func runnerForLanguage(name string, entries map[string]grammars.LangEntry, support map[string]grammars.ParseSupport, cache map[string]*runner, hotShapeLimit int) (*runner, error) {
+func runnerForLanguage(name string, entries map[string]grammars.LangEntry, cache map[string]*runner, hotShapeLimit int) (*runner, error) {
 	if r := cache[name]; r != nil {
 		r.setHotShapeLimit(hotShapeLimit)
 		return r, nil
@@ -887,7 +883,7 @@ func runnerForLanguage(name string, entries map[string]grammars.LangEntry, suppo
 	if !ok {
 		return nil, fmt.Errorf("language %q is not in grammars registry", name)
 	}
-	report, ok := support[name]
+	report, ok := grammars.ParseSupportFor(name)
 	if !ok || report.Backend == grammars.ParseBackendUnsupported {
 		return nil, fmt.Errorf("language %q parse backend is unsupported", name)
 	}

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"testing"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -87,16 +88,16 @@ var hasDedicatedSample = func() map[string]bool {
 }()
 
 // curatedStructuralLanguages is the merge-blocking structural parity set.
-// It includes every language with a dedicated smoke sample and supported parse
-// backend (DFA, partial DFA, or token source).
+// It includes every registered language with a dedicated smoke sample. Parse
+// support is evaluated lazily when a language is exercised so a focused test
+// does not decode the entire grammar fleet during package initialization.
 var curatedStructuralLanguages = func() map[string]bool {
 	out := make(map[string]bool, len(parityCases))
 	for _, tc := range parityCases {
 		if !hasDedicatedSample[tc.name] {
 			continue
 		}
-		report, ok := paritySupportByName[tc.name]
-		if !ok || report.Backend == grammars.ParseBackendUnsupported {
+		if _, ok := parityEntriesByName[tc.name]; !ok {
 			continue
 		}
 		out[tc.name] = true
@@ -104,23 +105,49 @@ var curatedStructuralLanguages = func() map[string]bool {
 	return out
 }()
 
-var parityEntriesByName, paritySupportByName = func() (map[string]grammars.LangEntry, map[string]grammars.ParseSupport) {
+var parityEntriesByName = func() map[string]grammars.LangEntry {
 	entries := make(map[string]grammars.LangEntry)
 	for _, entry := range grammars.AllLanguages() {
 		entries[entry.Name] = entry
 	}
-
-	support := make(map[string]grammars.ParseSupport)
-	for _, report := range grammars.AuditParseSupport() {
-		support[report.Name] = report
-	}
-	return entries, support
+	return entries
 }()
 
+type paritySupportLoad struct {
+	once   sync.Once
+	report grammars.ParseSupport
+	ok     bool
+}
+
+var paritySupportCache sync.Map // map[string]*paritySupportLoad
+
+func paritySupportForName(name string) (grammars.ParseSupport, bool) {
+	value, _ := paritySupportCache.LoadOrStore(name, &paritySupportLoad{})
+	load := value.(*paritySupportLoad)
+	load.once.Do(func() {
+		load.report, load.ok = grammars.ParseSupportFor(name)
+	})
+	return load.report, load.ok
+}
+
+func TestParitySupportForName(t *testing.T) {
+	report, ok := paritySupportForName("groovy")
+	if !ok || report.Name != "groovy" || report.Backend == grammars.ParseBackendUnsupported {
+		t.Fatalf("Groovy support = (%+v, %t), want supported report", report, ok)
+	}
+	if cached, cachedOK := paritySupportForName("groovy"); !cachedOK || cached != report {
+		t.Fatalf("cached Groovy support = (%+v, %t), want (%+v, true)", cached, cachedOK, report)
+	}
+	if report, ok := paritySupportForName("not-a-language"); ok || report != (grammars.ParseSupport{}) {
+		t.Fatalf("missing support = (%+v, %t), want zero report and false", report, ok)
+	}
+}
+
 // curatedHighlightLanguages scales independently of structural parity. Any
-// language with a dedicated smoke sample and shipped highlight query is part of
-// the merge-blocking highlight parity gate, as long as parsing is supported.
-// Divergence thresholds are controlled in parity_highlight_test.go.
+// registered language with a dedicated smoke sample and shipped highlight
+// query is part of the merge-blocking highlight parity gate. Parse support is
+// evaluated lazily when the language is exercised. Divergence thresholds are
+// controlled in parity_highlight_test.go.
 var curatedHighlightLanguages = func() map[string]bool {
 	out := make(map[string]bool, len(parityCases))
 	for _, tc := range parityCases {
@@ -129,9 +156,6 @@ var curatedHighlightLanguages = func() map[string]bool {
 		}
 		entry, ok := parityEntriesByName[tc.name]
 		if !ok || strings.TrimSpace(entry.HighlightQuery) == "" {
-			continue
-		}
-		if report, ok := paritySupportByName[tc.name]; ok && report.Backend == grammars.ParseBackendUnsupported {
 			continue
 		}
 		out[tc.name] = true
@@ -429,7 +453,7 @@ func parseWithGo(tc parityCase, src []byte, oldTree *gotreesitter.Tree) (*gotree
 	if !ok {
 		return nil, nil, fmt.Errorf("missing gotreesitter registry entry for %q", tc.name)
 	}
-	report, ok := paritySupportByName[tc.name]
+	report, ok := paritySupportForName(tc.name)
 	if !ok {
 		return nil, nil, fmt.Errorf("missing parse support report for %q", tc.name)
 	}

--- a/cgo_harness/parity_query_top50_test.go
+++ b/cgo_harness/parity_query_top50_test.go
@@ -24,7 +24,7 @@ func TestParityQueryExactTop50Generated(t *testing.T) {
 		if parityLanguageExcluded(name) {
 			continue
 		}
-		report, ok := paritySupportByName[name]
+		report, ok := paritySupportForName(name)
 		if !ok || report.Backend == grammars.ParseBackendUnsupported {
 			continue
 		}

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -545,7 +545,7 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 	if !ok {
 		return finish("no_registry_entry", "language not present in grammars registry")
 	}
-	report, ok := paritySupportByName[lang]
+	report, ok := paritySupportForName(lang)
 	if !ok || report.Backend == grammars.ParseBackendUnsupported {
 		return finish("unsupported_backend", fmt.Sprintf("parse backend %q", report.Backend))
 	}

--- a/grammars/registry_test.go
+++ b/grammars/registry_test.go
@@ -114,16 +114,33 @@ func TestDetectLanguageByShebang(t *testing.T) {
 // loading only that grammar instead of all 206.
 func parseSupportForLang(t *testing.T, name string) ParseSupport {
 	t.Helper()
-	entries := AllLanguages()
-	for _, entry := range entries {
-		if entry.Name == name {
-			lang := entry.Language()
-			t.Cleanup(func() { UnloadEmbeddedLanguage(entry.Name + ".bin") })
-			return EvaluateParseSupport(entry, lang)
-		}
+	report, ok := ParseSupportFor(name)
+	if !ok {
+		t.Fatalf("language %q not registered", name)
 	}
-	t.Fatalf("language %q not registered", name)
-	return ParseSupport{}
+	t.Cleanup(func() { UnloadEmbeddedLanguage(name + ".bin") })
+	return report
+}
+
+func TestParseSupportForLoadsOnlyRequestedGrammar(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	report, ok := ParseSupportFor("go")
+	if !ok || report.Name != "go" || report.Backend != ParseBackendDFA {
+		t.Fatalf("ParseSupportFor(go) = (%+v, %t), want Go DFA report", report, ok)
+	}
+	loaded, _ := EmbeddedLanguageCacheStats()
+	if loaded != 1 {
+		t.Fatalf("ParseSupportFor(go) loaded %d grammars, want 1", loaded)
+	}
+	if report, ok := ParseSupportFor("not-a-language"); ok || report != (ParseSupport{}) {
+		t.Fatalf("ParseSupportFor(missing) = (%+v, %t), want zero report and false", report, ok)
+	}
+	loaded, _ = EmbeddedLanguageCacheStats()
+	if loaded != 1 {
+		t.Fatalf("ParseSupportFor(missing) changed loaded grammar count to %d, want 1", loaded)
+	}
 }
 
 func TestAuditParseSupportUsesDFAForGo(t *testing.T) {

--- a/grammars/support.go
+++ b/grammars/support.go
@@ -79,6 +79,23 @@ func EvaluateParseSupport(entry LangEntry, lang *gotreesitter.Language) ParseSup
 	return report
 }
 
+// ParseSupportFor evaluates one registered language without loading the rest
+// of the grammar fleet. It returns false when name is not a canonical registry
+// name or the language loader returns nil.
+func ParseSupportFor(name string) (ParseSupport, bool) {
+	for _, entry := range AllLanguages() {
+		if entry.Name != name || entry.Language == nil {
+			continue
+		}
+		lang := entry.Language()
+		if lang == nil {
+			return ParseSupport{}, false
+		}
+		return EvaluateParseSupport(entry, lang), true
+	}
+	return ParseSupport{}, false
+}
+
 // AuditParseSupport evaluates parse support for all registered languages.
 func AuditParseSupport() []ParseSupport {
 	entries := AllLanguages()


### PR DESCRIPTION
## Summary

- evaluate parse support for one selected language without decoding the grammar fleet
- cache support lazily in parity and performance tests
- keep corpus utilities scoped to the languages they actually run

## Validation

- focused grammar support tests, including race coverage
- focused C parity harness tests and Groovy fresh-parse parity in Docker
- corpus command package tests and vet under the C parity build tags
- hard 2 GiB Groovy performance scan: previous harness OOM at 1,647,820 KiB RSS; updated harness passes at 84,084 KiB RSS with no timeout or performance cliff (6.80x C on the measured witness)