### PR TITLE
perf: reuse result finalization state

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -250,7 +250,10 @@ type Parser struct {
 	// and the retargetStackEntryPayload reduce sites — invalidate the
 	// materializing-shape prefix cache when they rewrite a spine node's
 	// root->head prefix. nil outside a parse; bumpShapePrefixEpoch is nil-safe.
-	mergeScratch                        *glrMergeScratch
+	mergeScratch *glrMergeScratch
+	// goCompatFrames points at the active parser scratch's reusable result-tree
+	// traversal stack. It is nil outside parseInternal.
+	goCompatFrames                      *[]goCompatSubtreeFrame
 	noTreeBenchmarkOnly                 bool
 	noTreeCheckpointBenchmarkOnly       bool
 	compactNoTreeShiftLeaves            bool
@@ -3860,6 +3863,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer releaseParserScratch(scratch, deferParentLinks)
 	p.reduceScratch = &scratch.reduce
 	p.mergeScratch = &scratch.merge
+	p.goCompatFrames = &scratch.goCompatFrames
 	if transientReduceParents {
 		p.reduceScratch.transientParents = &scratch.transientParents
 		p.reduceScratch.transientChildren = &scratch.transientChildren
@@ -3867,6 +3871,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	defer func() {
 		p.reduceScratch = nil
 		p.mergeScratch = nil
+		p.goCompatFrames = nil
 	}()
 	scratch.audit.beginParse()
 	scratch.merge.audit = nil
@@ -4308,7 +4313,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		// hasError=false is definitionally C-correct.
 		if tree != nil && p.crecoveryEnteredErrorState && stopReason == ParseStopAccepted {
 			if root := tree.root; root != nil && root.hasError() && root.endByte >= expectedEOFByte {
-				reconcileStaleHasErrorFlags(root, 0)
+				if reconcileStaleHasErrorFlags(root, 0) {
+					tree.resultErrorSummary = resultErrorSummaryPresent
+				} else {
+					tree.resultErrorSummary = resultErrorSummaryClean
+				}
 			}
 		}
 		// Env-gated (GOT_DEBUG_RECOVERY_INCREMENTAL_COST=1) one-line summary of the

--- a/parser_api.go
+++ b/parser_api.go
@@ -118,9 +118,12 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 		finalizeDeferredReturnedTreeTruncation(tree, source)
 		return
 	}
-	if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
-		tree.setParseStopReason(reason)
-		return
+	if !tree.resultCompatibilityApplied {
+		if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
+			tree.setParseStopReason(reason)
+			return
+		}
+		tree.resultCompatibilityApplied = true
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }
@@ -137,9 +140,12 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 		finalizeDeferredReturnedTreeTruncation(tree, source)
 		return
 	}
-	if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
-		tree.setParseStopReason(reason)
-		return
+	if !tree.resultCompatibilityApplied {
+		if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
+			tree.setParseStopReason(reason)
+			return
+		}
+		tree.resultCompatibilityApplied = true
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }

--- a/parser_api.go
+++ b/parser_api.go
@@ -125,6 +125,10 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 		}
 		tree.resultCompatibilityApplied = true
 	}
+	if reason := p.normalizePostFinalizationReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
+		tree.setParseStopReason(reason)
+		return
+	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }
 
@@ -146,6 +150,10 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 			return
 		}
 		tree.resultCompatibilityApplied = true
+	}
+	if reason := p.normalizePostFinalizationReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
+		tree.setParseStopReason(reason)
+		return
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }
@@ -324,6 +332,17 @@ func (p *Parser) normalizeReturnedTree(root *Node, source []byte) ParseStopReaso
 		return reason
 	}
 	normalizeResultCompatibility(root, source, p)
+	return p.parseStopReasonNow()
+}
+
+func (p *Parser) normalizePostFinalizationReturnedTree(root *Node, source []byte) ParseStopReason {
+	if p == nil || p.language == nil || root == nil || p.noResultCompatibilityBenchmarkOnly {
+		return ParseStopNone
+	}
+	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+		return reason
+	}
+	normalizeReturnedTree(root, source, p.language)
 	return p.parseStopReasonNow()
 }
 

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -13,6 +13,7 @@ type resultCompatibilityResult struct {
 	iniMypyEnableErrorContinuation bool
 	iniContinuationStart           uint32
 	iniContinuationEnd             uint32
+	errorSummary                   resultErrorSummary
 }
 
 // normalizeResultCompatibility applies narrow post-build tree rewrites that
@@ -46,7 +47,7 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCo
 	}
 	normalizeRootTrailingExtraTriviaCompatibility(root, source, lang)
 	var terminalReason ParseStopReason
-	_, terminalReason = normalizeResultTerminalLeafNodesWithStop(root, lang, ctx.stopCheck)
+	_, terminalReason, result.errorSummary = normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, ctx.stopCheck)
 	if parseStopReasonIsActive(terminalReason) {
 		result.stopReason = terminalReason
 		return result

--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -31,10 +31,20 @@ func normalizeGoCompatibilityWithParser(root *Node, source []byte, lang *Languag
 }
 
 func normalizeGoCompatibilityInRangesWithParser(root *Node, source []byte, lang *Language, incrementalRanges []Range, p *Parser) ParseStopReason {
-	return normalizeGoCompatibilityInRangesWithStop(root, source, lang, incrementalRanges, p.activeParseStopCheck())
+	var frames *[]goCompatSubtreeFrame
+	var stopCheck parseStopCheck
+	if p != nil {
+		frames = p.goCompatFrames
+		stopCheck = p.activeParseStopCheck()
+	}
+	return normalizeGoCompatibilityInRangesWithStopAndScratch(root, source, lang, incrementalRanges, stopCheck, frames)
 }
 
 func normalizeGoCompatibilityInRangesWithStop(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck) ParseStopReason {
+	return normalizeGoCompatibilityInRangesWithStopAndScratch(root, source, lang, incrementalRanges, stopCheck, nil)
+}
+
+func normalizeGoCompatibilityInRangesWithStopAndScratch(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck, frames *[]goCompatSubtreeFrame) ParseStopReason {
 	if root == nil || lang == nil || lang.Name != "go" || len(source) == 0 {
 		return ParseStopNone
 	}
@@ -52,7 +62,7 @@ func normalizeGoCompatibilityInRangesWithStop(root *Node, source []byte, lang *L
 	if !ok {
 		return poller.pollNow()
 	}
-	if reason := normalizeGoCompatibilitySubtreeWithStop(root, source, syms, flags, incrementalRanges, &poller); parseStopReasonIsActive(reason) {
+	if reason := normalizeGoCompatibilitySubtreeWithStopAndScratch(root, source, syms, flags, incrementalRanges, &poller, frames); parseStopReasonIsActive(reason) {
 		return reason
 	}
 	return poller.pollNow()
@@ -302,6 +312,10 @@ type goCompatSubtreeFrame struct {
 }
 
 func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller) ParseStopReason {
+	return normalizeGoCompatibilitySubtreeWithStopAndScratch(n, source, syms, flags, incrementalRanges, poller, nil)
+}
+
+func normalizeGoCompatibilitySubtreeWithStopAndScratch(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller, frames *[]goCompatSubtreeFrame) ParseStopReason {
 	if n == nil {
 		return ParseStopNone
 	}
@@ -310,17 +324,24 @@ func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goComp
 	// mutation here (semicolon-drop, sibling-boundary and trailing-extra span
 	// adjustment) is idempotent and keyed on node identity, so descending each
 	// distinct node once matches the well-formed fast path byte-for-byte.
-	reason, completed := walkGoCompatSubtree(n, source, syms, flags, incrementalRanges, poller, nil)
-	if completed {
-		return reason
+	var stack []goCompatSubtreeFrame
+	if frames != nil {
+		stack = (*frames)[:0]
 	}
-	return firstReturnReason(walkGoCompatSubtree(n, source, syms, flags, incrementalRanges, poller, make(map[*Node]struct{})))
+	reason, completed, stack := walkGoCompatSubtree(n, source, syms, flags, incrementalRanges, poller, nil, stack)
+	if !completed {
+		reason, _, stack = walkGoCompatSubtree(n, source, syms, flags, incrementalRanges, poller, make(map[*Node]struct{}), stack[:0])
+	}
+	if frames != nil {
+		*frames = stack[:0]
+	}
+	return reason
 }
 
-func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller, seen map[*Node]struct{}) (ParseStopReason, bool) {
+func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller, seen map[*Node]struct{}, stack []goCompatSubtreeFrame) (ParseStopReason, bool, []goCompatSubtreeFrame) {
 	budget := goNormalizerPopBudget(len(source))
 	pops := 0
-	stack := []goCompatSubtreeFrame{{node: root}}
+	stack = append(stack[:0], goCompatSubtreeFrame{node: root})
 	if seen != nil {
 		seen[root] = struct{}{}
 	}
@@ -340,7 +361,7 @@ func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols,
 	}
 	for len(stack) > 0 {
 		if reason := poller.poll(); parseStopReasonIsActive(reason) {
-			return reason, true
+			return reason, true, stack
 		}
 		top := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -357,7 +378,7 @@ func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols,
 		if seen == nil {
 			pops++
 			if pops > budget {
-				return ParseStopNone, false
+				return ParseStopNone, false, stack
 			}
 		}
 		if !goNodeOverlapsAnyRange(n, incrementalRanges) {
@@ -392,7 +413,7 @@ func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols,
 			}
 		}
 	}
-	return poller.pollNow(), true
+	return poller.pollNow(), true, stack
 }
 
 func goNodeOverlapsAnyRange(n *Node, ranges []Range) bool {

--- a/parser_result_html_test.go
+++ b/parser_result_html_test.go
@@ -65,7 +65,7 @@ func TestNormalizeHTMLRecoveredNestedCustomTagsWrapsStartTagPrefix(t *testing.T)
 	}
 }
 
-func TestNormalizeHTMLRecoveredNestedCustomTagRangesExtendsInnerChain(t *testing.T) {
+func TestNormalizeReturnedTreeForParseExtendsHTMLInnerChain(t *testing.T) {
 	lang := &Language{
 		Name:        "html",
 		SymbolNames: []string{"EOF", "document", "element", "start_tag", "end_tag", "</", "tag_name", ">"},
@@ -100,7 +100,8 @@ func TestNormalizeHTMLRecoveredNestedCustomTagRangesExtendsInnerChain(t *testing
 
 	source := bytes.Repeat([]byte{'x'}, 27)
 	source[20] = '\n'
-	normalizeHTMLRecoveredNestedCustomTagRanges(root, source, lang)
+	tree := &Tree{root: root, source: source, language: lang, resultCompatibilityApplied: true}
+	(&Parser{language: lang}).normalizeReturnedTreeForParse(tree, source)
 
 	if got, want := inner.endByte, uint32(21); got != want {
 		t.Fatalf("inner.endByte = %d, want %d", got, want)

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -266,6 +266,12 @@ func TestTreeRootNodeRecordsDeferredTypeScriptCompatibilityTiming(t *testing.T) 
 	if tree.resultCompatibilityPending {
 		t.Fatal("resultCompatibilityPending = true after deferred compatibility ran")
 	}
+	if tree.resultErrorSummary != resultErrorSummaryClean {
+		t.Fatalf("resultErrorSummary = %d, want clean", tree.resultErrorSummary)
+	}
+	if !tree.resultCompatibilityApplied {
+		t.Fatal("resultCompatibilityApplied = false after deferred compatibility ran")
+	}
 	rt := tree.ParseRuntime()
 	if rt.NormalizationPassesRun == 0 {
 		t.Fatal("NormalizationPassesRun = 0, want deferred compatibility pass attribution")
@@ -277,6 +283,12 @@ func TestTreeRootNodeRecordsDeferredTypeScriptCompatibilityTiming(t *testing.T) 
 	_ = tree.RootNode()
 	if got := tree.ParseRuntime().NormalizationPassesRun; got != before {
 		t.Fatalf("NormalizationPassesRun after second RootNode = %d, want %d", got, before)
+	}
+
+	clone := tree.Copy()
+	defer clone.Release()
+	if clone.resultErrorSummary != tree.resultErrorSummary || clone.resultCompatibilityApplied != tree.resultCompatibilityApplied {
+		t.Fatal("Tree.Copy did not preserve finalized compatibility state")
 	}
 }
 

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -624,20 +624,22 @@ func (b *resultRootBuild) singleChildSlice(child *Node) []*Node {
 }
 
 func (b *resultRootBuild) finishTree(root *Node, wireParentLinks, extendTrailing bool) *Tree {
-	b.finalizeRoot(root, wireParentLinks, extendTrailing)
+	errorSummary, compatibilityApplied := b.finalizeRoot(root, wireParentLinks, extendTrailing)
 	borrowed := b.borrowedArenas()
 	if b.parser != nil {
 		borrowed = append(borrowed, b.parser.takeCompatibilityBorrowedArenas()...)
 	}
 	tree := newTreeWithArenas(root, b.source, b.lang, b.arena, borrowed)
+	tree.resultErrorSummary = errorSummary
+	tree.resultCompatibilityApplied = compatibilityApplied
 	if b.parser.shouldDeferResultCompatibility(root) {
 		tree.deferResultCompatibility()
 	}
 	return tree
 }
 
-func (b *resultRootBuild) finalizeRoot(root *Node, wireParentLinks, extendTrailing bool) {
-	b.parser.finalizeResultRoot(root, b.source, b.linkScratch, wireParentLinks, extendTrailing)
+func (b *resultRootBuild) finalizeRoot(root *Node, wireParentLinks, extendTrailing bool) (resultErrorSummary, bool) {
+	return b.parser.finalizeResultRoot(root, b.source, b.linkScratch, wireParentLinks, extendTrailing)
 }
 
 // finalizeWrappedSubtree applies subtree compatibility normalization to a node
@@ -812,22 +814,24 @@ func extendResultRootRangeToExtras(root *Node, extras []*Node) {
 	}
 }
 
-func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*Node, wireParentLinks, extendTrailing bool) {
+func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*Node, wireParentLinks, extendTrailing bool) (resultErrorSummary, bool) {
+	errorSummary := resultErrorSummaryUnknown
+	compatibilityApplied := false
 	if root == nil {
-		return
+		return errorSummary, compatibilityApplied
 	}
 	timing := p.currentMaterializationTiming()
 	finalizeStart := materializationTimingStart(timing)
 	defer timing.addResultFinalizeRoot(finalizeStart)
 	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
-		return
+		return errorSummary, compatibilityApplied
 	}
 	if p != nil {
 		root = flattenInvisibleRootChildren(root, root.ownerArena, p.language)
 	}
 	widenNodeSpanToRetainedChildren(root)
 	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
-		return
+		return errorSummary, compatibilityApplied
 	}
 	if extendTrailing {
 		start := materializationTimingStart(timing)
@@ -835,17 +839,20 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		timing.addResultExtendTrailing(start)
 	}
 	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
-		return
+		return errorSummary, compatibilityApplied
 	}
 	start := materializationTimingStart(timing)
 	p.normalizeRootSourceStart(root, source)
 	timing.addResultNormalizeRootStart(start)
 	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
-		return
+		return errorSummary, compatibilityApplied
 	}
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
 		start = materializationTimingStart(timing)
-		if compat := normalizeResultCompatibility(root, source, p); parseStopReasonIsActive(compat.stopReason) && p != nil {
+		compat := normalizeResultCompatibility(root, source, p)
+		errorSummary = compat.errorSummary
+		compatibilityApplied = p != nil && p.language != nil && !parseStopReasonIsActive(compat.stopReason)
+		if parseStopReasonIsActive(compat.stopReason) && p != nil {
 			p.markActiveParseStopped(compat.stopReason)
 		}
 		timing.addResultCompatibility(start)
@@ -859,7 +866,7 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		}
 	}
 	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
-		return
+		return errorSummary, compatibilityApplied
 	}
 	if wireParentLinks {
 		start = materializationTimingStart(timing)
@@ -872,6 +879,7 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		}
 		timing.addResultParentLink(start)
 	}
+	return errorSummary, compatibilityApplied
 }
 
 func (p *Parser) shouldDeferResultCompatibility(root *Node) bool {

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -12,13 +12,28 @@ func normalizeResultTerminalLeafNodes(root *Node, lang *Language) normalizationP
 }
 
 func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason) {
+	counters, stopReason, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, stopCheck)
+	return counters, stopReason
+}
+
+func normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason, resultErrorSummary) {
 	var counters normalizationPassCounters
-	if root == nil || lang == nil || root.hasError() {
-		return counters, ParseStopNone
+	if root == nil || lang == nil {
+		return counters, ParseStopNone, resultErrorSummaryUnknown
+	}
+	if root.hasError() {
+		return counters, ParseStopNone, resultErrorSummaryPresent
+	}
+	errorSummary := resultErrorSummaryClean
+	if root.IsError() {
+		errorSummary = resultErrorSummaryPresent
 	}
 	poller := parseStopPoller{check: stopCheck}
 	if reason := poller.pollNow(); parseStopReasonIsActive(reason) {
-		return counters, reason
+		if errorSummary != resultErrorSummaryPresent {
+			errorSummary = resultErrorSummaryUnknown
+		}
+		return counters, reason, errorSummary
 	}
 	aliasTargets := resultVisibleAliasTargetSet(lang)
 	var stopReason ParseStopReason
@@ -28,6 +43,9 @@ func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCh
 			return false
 		}
 		counters.nodesVisited++
+		if n.IsError() || n.hasError() {
+			errorSummary = resultErrorSummaryPresent
+		}
 		if !resultCanCollapseTerminalLeafNode(n, lang, aliasTargets) {
 			return true
 		}
@@ -70,9 +88,16 @@ func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCh
 		return true
 	})
 	if parseStopReasonIsActive(stopReason) {
-		return counters, stopReason
+		if errorSummary != resultErrorSummaryPresent {
+			errorSummary = resultErrorSummaryUnknown
+		}
+		return counters, stopReason, errorSummary
 	}
-	return counters, poller.pollNow()
+	stopReason = poller.pollNow()
+	if parseStopReasonIsActive(stopReason) && errorSummary != resultErrorSummaryPresent {
+		errorSummary = resultErrorSummaryUnknown
+	}
+	return counters, stopReason, errorSummary
 }
 
 func resultCanCollapseTerminalLeafNode(n *Node, lang *Language, aliasTargets []bool) bool {

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -83,7 +83,7 @@ func TestNormalizeResultTerminalLeafNodesStopsOnActiveParseBudget(t *testing.T) 
 		return ParseStopNone
 	}
 
-	counters, reason := normalizeResultTerminalLeafNodesWithStop(root, lang, stopCheck)
+	counters, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, stopCheck)
 
 	if reason != ParseStopTimeout {
 		t.Fatalf("stop reason = %q, want %q", reason, ParseStopTimeout)
@@ -96,6 +96,104 @@ func TestNormalizeResultTerminalLeafNodesStopsOnActiveParseBudget(t *testing.T) 
 	}
 	if counters.nodesRewritten >= uint64(len(children)) {
 		t.Fatalf("nodesRewritten = %d, want partial rewrite before stop", counters.nodesRewritten)
+	}
+	if errorSummary != resultErrorSummaryUnknown {
+		t.Fatalf("error summary = %d, want unknown after interrupted traversal", errorSummary)
+	}
+}
+
+func TestNormalizeResultTerminalLeafNodesSummarizesCleanTree(t *testing.T) {
+	lang := &Language{
+		TokenCount: 2,
+		SymbolNames: []string{
+			"EOF",
+			"token",
+			"root",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "token", Visible: true},
+			{Name: "root", Visible: true, Named: true},
+		},
+	}
+	arena := newNodeArena(arenaClassFull)
+	leaf := newLeafNodeInArena(arena, 1, false, 0, 1, Point{}, Point{Column: 1})
+	root := newParentNodeInArena(arena, 2, true, []*Node{leaf}, nil, 0)
+
+	_, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+
+	if reason != ParseStopNone {
+		t.Fatalf("stop reason = %q, want none", reason)
+	}
+	if errorSummary != resultErrorSummaryClean {
+		t.Fatalf("error summary = %d, want clean", errorSummary)
+	}
+}
+
+func TestNormalizeResultTerminalLeafNodesFindsUnderFlaggedErrorDescendant(t *testing.T) {
+	lang := &Language{
+		TokenCount: 1,
+		SymbolNames: []string{
+			"EOF",
+			"root",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "root", Visible: true, Named: true},
+		},
+	}
+	arena := newNodeArena(arenaClassFull)
+	errNode := newLeafNodeInArena(arena, errorSymbol, true, 0, 1, Point{}, Point{Column: 1})
+	errNode.setHasError(true)
+	root := newParentNodeInArena(arena, 1, true, []*Node{errNode}, nil, 0)
+	root.setHasError(false)
+
+	_, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+
+	if reason != ParseStopNone {
+		t.Fatalf("stop reason = %q, want none", reason)
+	}
+	if root.HasError() {
+		t.Fatal("test setup changed root HasError to true")
+	}
+	if errorSummary != resultErrorSummaryPresent {
+		t.Fatalf("error summary = %d, want present", errorSummary)
+	}
+}
+
+func TestNormalizeResultTerminalLeafNodesWalksUnderFlaggedErrorRoot(t *testing.T) {
+	lang := &Language{
+		TokenCount: 3,
+		SymbolNames: []string{
+			"EOF",
+			".",
+			"token",
+		},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: ".", Visible: true},
+			{Name: "token", Visible: true, Named: true},
+		},
+	}
+	arena := newNodeArena(arenaClassFull)
+	leaf := newLeafNodeInArena(arena, 1, false, 0, 1, Point{}, Point{Column: 1})
+	token := newParentNodeInArena(arena, 2, true, []*Node{leaf}, nil, 0)
+	root := newParentNodeInArena(arena, errorSymbol, true, []*Node{token}, nil, 0)
+	root.setHasError(false)
+
+	counters, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+
+	if reason != ParseStopNone {
+		t.Fatalf("stop reason = %q, want none", reason)
+	}
+	if got, want := counters.nodesRewritten, uint64(1); got != want {
+		t.Fatalf("nodesRewritten = %d, want %d", got, want)
+	}
+	if got := token.ChildCount(); got != 0 {
+		t.Fatalf("token.ChildCount() = %d, want 0", got)
+	}
+	if errorSummary != resultErrorSummaryPresent {
+		t.Fatalf("error summary = %d, want present", errorSummary)
 	}
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -193,8 +193,7 @@ func treeParseClean(tree *Tree) bool {
 	if tree == nil {
 		return false
 	}
-	root := rawRootOrNil(tree)
-	if root == nil || retryNodeSubtreeHasError(root, 0) {
+	if retryTreeHasError(tree) {
 		return false
 	}
 	rt := tree.ParseRuntime()
@@ -234,6 +233,15 @@ func retryTreeHasError(tree *Tree) bool {
 	}
 	root := rawRootOrNil(tree)
 	if root == nil {
+		return true
+	}
+	if root.IsError() || root.HasError() {
+		return true
+	}
+	switch tree.resultErrorSummary {
+	case resultErrorSummaryClean:
+		return false
+	case resultErrorSummaryPresent:
 		return true
 	}
 	return retryNodeSubtreeHasError(root, 0)

--- a/parser_retry_summary_test.go
+++ b/parser_retry_summary_test.go
@@ -1,0 +1,49 @@
+package gotreesitter
+
+import "testing"
+
+func TestRetryTreeHasErrorUsesKnownSummaryAndUnknownFallback(t *testing.T) {
+	root := newLeafNodeInArena(nil, 1, true, 0, 1, Point{}, Point{Column: 1})
+	tree := NewTree(root, []byte("x"), nil)
+
+	tree.resultErrorSummary = resultErrorSummaryClean
+	if retryTreeHasError(tree) {
+		t.Fatal("known-clean tree reported an error")
+	}
+
+	tree.resultErrorSummary = resultErrorSummaryPresent
+	if !retryTreeHasError(tree) {
+		t.Fatal("known-error tree reported clean")
+	}
+
+	errNode := newLeafNodeInArena(nil, errorSymbol, true, 0, 1, Point{}, Point{Column: 1})
+	errNode.setHasError(true)
+	root.children = []*Node{errNode}
+	root.setHasError(false)
+	tree.resultErrorSummary = resultErrorSummaryUnknown
+	if !retryTreeHasError(tree) {
+		t.Fatal("unknown tree did not find descendant error through fallback walk")
+	}
+}
+
+func TestParseRecordsCleanRetryErrorSummary(t *testing.T) {
+	parser := NewParser(buildArithmeticLanguage())
+	tree, err := parser.Parse([]byte("1+2"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	if tree.resultErrorSummary != resultErrorSummaryClean {
+		t.Fatalf("result error summary = %d, want clean", tree.resultErrorSummary)
+	}
+	if !tree.resultCompatibilityApplied {
+		t.Fatal("result compatibility was not recorded as applied")
+	}
+	if retryTreeHasError(tree) {
+		t.Fatal("clean parsed tree reported an error")
+	}
+	if parser.goCompatFrames != nil {
+		t.Fatal("parser retained active Go compatibility scratch after Parse")
+	}
+}

--- a/parser_scratch.go
+++ b/parser_scratch.go
@@ -2,6 +2,10 @@ package gotreesitter
 
 import "sync"
 
+// Keep enough compatibility traversal storage for ordinary generated files
+// without retaining multi-megabyte backing arrays after unusually wide trees.
+const maxRetainedGoCompatFrames = 16 * 1024
+
 type parserScratch struct {
 	merge                    glrMergeScratch
 	entries                  glrEntryScratch
@@ -13,6 +17,7 @@ type parserScratch struct {
 	stackPick                []int
 	stackKeep                []bool
 	stackCull                []stackCullKey
+	goCompatFrames           []goCompatSubtreeFrame
 	reduce                   reduceBuildScratch
 	transientChildren        transientChildScratch
 	transientParents         transientParentScratch
@@ -115,6 +120,12 @@ func releaseParserScratch(s *parserScratch, skipGSSClear bool) {
 		s.stackCull = nil
 	} else if len(s.stackCull) > 0 {
 		s.stackCull = s.stackCull[:0]
+	}
+	if cap(s.goCompatFrames) > maxRetainedGoCompatFrames {
+		s.goCompatFrames = nil
+	} else if cap(s.goCompatFrames) > 0 {
+		clear(s.goCompatFrames[:cap(s.goCompatFrames)])
+		s.goCompatFrames = s.goCompatFrames[:0]
 	}
 	const maxRetainedReduceBuildScratch = 256 * 1024
 	if cap(s.reduce.nodes) > maxRetainedReduceBuildScratch {

--- a/parser_scratch_budget_test.go
+++ b/parser_scratch_budget_test.go
@@ -186,3 +186,14 @@ func TestNodeLinksCapClearedOnRelease(t *testing.T) {
 			"clear(nodeLinks[:cap]) not applied")
 	}
 }
+
+func TestGoCompatFramesReleasedAboveRetentionCap(t *testing.T) {
+	var scratch parserScratch
+	scratch.goCompatFrames = make([]goCompatSubtreeFrame, 0, maxRetainedGoCompatFrames+1)
+
+	releaseParserScratch(&scratch, false)
+
+	if scratch.goCompatFrames != nil {
+		t.Fatalf("goCompatFrames capacity = %d, want released", cap(scratch.goCompatFrames))
+	}
+}

--- a/tree.go
+++ b/tree.go
@@ -2132,6 +2132,8 @@ func (t *Tree) ensureResultCompatibility() {
 		}
 		if !parsePhaseTimingEnabled() {
 			result := normalizeResultCompatibility(t.root, t.source, &Parser{language: t.language})
+			t.resultErrorSummary = result.errorSummary
+			t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
 			t.finishDeferredResultCompatibility(result)
 			return
 		}
@@ -2142,6 +2144,8 @@ func (t *Tree) ensureResultCompatibility() {
 		}
 		start := materializationTimingStart(timing)
 		result := normalizeResultCompatibility(t.root, t.source, parser)
+		t.resultErrorSummary = result.errorSummary
+		t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
 		timing.addResultCompatibility(start)
 		t.parseRuntime.ResultCompatibilityNanos += timing.resultCompatibilityNanos
 		parser.copyNormalizationStats(&t.parseRuntime)
@@ -2467,6 +2471,14 @@ func hasParentFieldMetadata(fieldIDs []FieldID, fieldSources []uint8) bool {
 	return false
 }
 
+type resultErrorSummary uint8
+
+const (
+	resultErrorSummaryUnknown resultErrorSummary = iota
+	resultErrorSummaryClean
+	resultErrorSummaryPresent
+)
+
 // Tree holds a complete syntax tree along with its source text and language.
 // Tree is safe for concurrent reads after construction. Edit and Release are
 // not safe for concurrent use.
@@ -2487,9 +2499,13 @@ type Tree struct {
 	externalScannerCheckpointsDeferred bool
 	forestFastPath                     bool
 	incrementalReuseDisabled           bool
-	resultCompatibilityPending         bool
-	resultCompatibilityOnce            sync.Once
-	released                           bool
+	// Finalization state avoids repeated retry scans and compatibility passes.
+	// The error summary is not a persistent invariant of a caller-edited tree.
+	resultErrorSummary         resultErrorSummary
+	resultCompatibilityApplied bool
+	resultCompatibilityPending bool
+	resultCompatibilityOnce    sync.Once
+	released                   bool
 }
 
 const maxRetainedTreeEditCap = 8
@@ -2820,12 +2836,14 @@ func (t *Tree) Copy() *Tree {
 	t.ensureResultCompatibility()
 
 	out := &Tree{
-		source:         t.source,
-		sourceEncoding: t.sourceEncoding,
-		sourceUTF16:    t.sourceUTF16,
-		utf16Map:       t.utf16Map,
-		language:       t.language,
-		parseRuntime:   t.parseRuntime,
+		source:                     t.source,
+		sourceEncoding:             t.sourceEncoding,
+		sourceUTF16:                t.sourceUTF16,
+		utf16Map:                   t.utf16Map,
+		language:                   t.language,
+		parseRuntime:               t.parseRuntime,
+		resultErrorSummary:         t.resultErrorSummary,
+		resultCompatibilityApplied: t.resultCompatibilityApplied,
 	}
 	if len(t.edits) > 0 {
 		out.edits = make([]InputEdit, len(t.edits))


### PR DESCRIPTION
## Summary

- record a tri-state error summary during the existing terminal-leaf finalization walk
- skip the duplicate returned-tree compatibility pass when finalization already completed it
- reuse bounded parser scratch for Go compatibility traversal frames
- preserve finalized state through deferred compatibility and tree copies

## Performance

Stable pinned A/B measurements for `BenchmarkGoParseFullDFA`:

- time: 4.325 ms -> 3.774 ms (-12.72%, p=0.001)
- bytes: 38.3 KiB/op -> 1.34 KiB/op (-96.50%)
- allocations: 30 -> 10 allocs/op (-66.67%)

Reverse-order incremental A/B measurements remained statistically unchanged, with zero allocations for both single-byte edit and no-edit paths.

## Validation

- focused Docker race tests for summary, deferred compatibility, copy, and scratch lifecycle
- Docker `go vet .`
- aggressive Go parity: 25/25
- C# and Kotlin gates reproduced their baseline results exactly
- Dart exact C parity smoke
- exact C fresh-parse parity across the top-50 fleet
- standard full, single-byte edit, and no-edit benchmark trio