### PR TITLE
perf: reuse recovery stack summaries

### DIFF
--- a/glr_gss.go
+++ b/glr_gss.go
@@ -3,9 +3,10 @@ package gotreesitter
 import "unsafe"
 
 const (
-	defaultGSSNodeSlabCap   = 4 * 1024
-	fullParseGSSNodeSlabCap = 32 * 1024
-	maxRetainedGSSNodes     = 256 * 1024
+	defaultGSSNodeSlabCap      = 4 * 1024
+	fullParseGSSNodeSlabCap    = 32 * 1024
+	maxRetainedGSSNodes        = 256 * 1024
+	maxRetainedGSSStackEntries = 4 * 1024
 )
 
 type gssNode struct {
@@ -74,6 +75,7 @@ type gssScratch struct {
 	nodesDemoted      uint64
 	audit             *runtimeAudit
 	frontier          conflictReduceFrontierScratch
+	stackEntries      []stackEntry
 }
 
 type gssNodeSlab struct {
@@ -453,6 +455,12 @@ func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth int, h
 }
 
 func (s *gssScratch) reset() {
+	if cap(s.stackEntries) > maxRetainedGSSStackEntries {
+		s.stackEntries = nil
+	} else if cap(s.stackEntries) > 0 {
+		clear(s.stackEntries[:cap(s.stackEntries)])
+		s.stackEntries = s.stackEntries[:0]
+	}
 	if len(s.slabs) == 0 {
 		s.singleStackMode = false
 		s.singleStackAllocs = 0
@@ -460,7 +468,7 @@ func (s *gssScratch) reset() {
 		s.demotions = 0
 		s.nodesDemoted = 0
 		s.skipClear = false
-		s.allocatedBytes = s.frontier.allocatedBytes()
+		s.allocatedBytes = s.frontier.allocatedBytes() + stackEntryBytesForCap(cap(s.stackEntries))
 		s.audit = nil
 		return
 	}
@@ -562,5 +570,6 @@ func (s *gssScratch) recomputeAllocatedBytes() {
 		total += gssNodeBytesForCap(len(s.slabs[i].data))
 	}
 	total += s.frontier.allocatedBytes()
+	total += stackEntryBytesForCap(cap(s.stackEntries))
 	s.allocatedBytes = total
 }

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -882,6 +882,58 @@ func TestGSSScratchResetClearsTouchedSlots(t *testing.T) {
 	}
 }
 
+func TestGSSScratchResetClearsRetainedStackEntries(t *testing.T) {
+	var scratch gssScratch
+	scratch.stackEntries = make([]stackEntry, 0, 8)
+	scratch.stackEntries = append(scratch.stackEntries, newStackEntryNode(1, &Node{}))
+	backing := scratch.stackEntries[:cap(scratch.stackEntries)]
+	backing[len(backing)-1] = newStackEntryNode(2, &Node{})
+
+	scratch.reset()
+
+	if len(scratch.stackEntries) != 0 || cap(scratch.stackEntries) != cap(backing) {
+		t.Fatalf("retained stack entries len/cap = %d/%d, want 0/%d", len(scratch.stackEntries), cap(scratch.stackEntries), cap(backing))
+	}
+	if stackEntryHasNode(backing[0]) {
+		t.Fatal("retained stack entry still holds a node after reset")
+	}
+	if stackEntryHasNode(backing[len(backing)-1]) {
+		t.Fatal("retained stack entry beyond slice length still holds a node after reset")
+	}
+	if got, want := scratch.allocatedBytes, stackEntryBytesForCap(cap(backing)); got != want {
+		t.Fatalf("allocated bytes = %d, want %d", got, want)
+	}
+}
+
+func TestGSSScratchResetAccountsForNodesAndStackEntries(t *testing.T) {
+	var scratch gssScratch
+	_ = scratch.allocNode(stackEntry{state: 1}, nil, 1)
+	scratch.stackEntries = make([]stackEntry, 0, 8)
+	scratch.recomputeAllocatedBytes()
+	nodeCapacity := scratch.capacityNodes()
+
+	scratch.reset()
+
+	want := gssNodeBytesForCap(nodeCapacity) + stackEntryBytesForCap(8)
+	if scratch.allocatedBytes != want {
+		t.Fatalf("allocated bytes = %d, want %d", scratch.allocatedBytes, want)
+	}
+}
+
+func TestGSSScratchResetDropsOversizedStackEntries(t *testing.T) {
+	var scratch gssScratch
+	scratch.stackEntries = make([]stackEntry, 0, maxRetainedGSSStackEntries+1)
+
+	scratch.reset()
+
+	if scratch.stackEntries != nil {
+		t.Fatalf("stack entries capacity = %d, want released", cap(scratch.stackEntries))
+	}
+	if scratch.allocatedBytes != 0 {
+		t.Fatalf("allocated bytes = %d, want 0", scratch.allocatedBytes)
+	}
+}
+
 func TestGSSScratchOverflowSlabGrowthBounded(t *testing.T) {
 	elemSize := int(unsafe.Sizeof(gssNode{}))
 	ceiling := maxOverflowSlabGrowthBytes / elemSize

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1860,17 +1860,37 @@ func (p *Parser) cBetterVersionExists(stacks []glrStack, self int, isInError boo
 // Stack walking helpers
 // ---------------------------------------------------------------------------
 
-// cStackEntriesTopFirst materializes the stack spine top-first.
+// cStackEntriesTopFirst materializes the stack spine top-first. With non-nil
+// scratch the returned slice is borrowed and remains valid only until the next
+// call or scratch reset. A nil scratch returns independently owned storage.
 func cStackEntriesTopFirst(s *glrStack, gssScratch *gssScratch) []stackEntry {
 	s.ensureGSS(gssScratch)
 	depth := s.depth()
 	if depth == 0 {
+		if gssScratch != nil {
+			gssScratch.stackEntries = gssScratch.stackEntries[:0]
+		}
 		return nil
 	}
-	entries := make([]stackEntry, 0, depth)
+	if gssScratch == nil {
+		entries := make([]stackEntry, 0, depth)
+		for n := s.gss.head; n != nil; n = n.prev {
+			entries = append(entries, n.entry)
+		}
+		return entries
+	}
+	oldCap := cap(gssScratch.stackEntries)
+	if oldCap < depth {
+		gssScratch.stackEntries = make([]stackEntry, 0, depth)
+		gssScratch.allocatedBytes += stackEntryBytesForCap(depth) - stackEntryBytesForCap(oldCap)
+	} else {
+		gssScratch.stackEntries = gssScratch.stackEntries[:0]
+	}
+	entries := gssScratch.stackEntries
 	for n := s.gss.head; n != nil; n = n.prev {
 		entries = append(entries, n.entry)
 	}
+	gssScratch.stackEntries = entries
 	return entries
 }
 
@@ -1894,20 +1914,6 @@ func cEntryCountsTowardDepth(e stackEntry) bool {
 func (p *Parser) cRecordSummary(entries []stackEntry) []cStackSummaryEntry {
 	summary := make([]cStackSummaryEntry, 0, 8)
 	depth := 0
-	// Position of the node at-or-below each entry: C node positions are the
-	// cumulative input position at that stack node.
-	posBytesAt := make([]uint32, len(entries))
-	posRowAt := make([]uint32, len(entries))
-	var pb uint32
-	var pr uint32
-	for i := len(entries) - 1; i >= 0; i-- {
-		if stackEntryHasNode(entries[i]) {
-			pb = stackEntryNodeEndByte(entries[i])
-			pr = stackEntryNodeEndPoint(entries[i]).Row
-		}
-		posBytesAt[i] = pb
-		posRowAt[i] = pr
-	}
 	record := func(d int, st StateID, posBytes, posRow uint32) {
 		for j := len(summary) - 1; j >= 0; j-- {
 			if summary[j].depth < d {
@@ -1919,9 +1925,32 @@ func (p *Parser) cRecordSummary(entries []stackEntry) []cStackSummaryEntry {
 		}
 		summary = append(summary, cStackSummaryEntry{depth: d, state: st, posBytes: posBytes, posRow: posRow})
 	}
+	// A node-bearing entry owns its position. Node-less discontinuities use the
+	// next payload below them. The cached index advances monotonically, so this
+	// preserves the old bottom-up position table in O(depth) time without two
+	// full-depth allocations.
+	nextPayload := -1
 	for i := 0; i < len(entries); i++ {
-		record(depth, entries[i].state, posBytesAt[i], posRowAt[i])
-		if cEntryCountsTowardDepth(entries[i]) {
+		entry := entries[i]
+		var posBytes uint32
+		var posRow uint32
+		if stackEntryHasNode(entry) {
+			posBytes = stackEntryNodeEndByte(entry)
+			posRow = stackEntryNodeEndPoint(entry).Row
+		} else {
+			if nextPayload <= i {
+				nextPayload = i + 1
+				for nextPayload < len(entries) && !stackEntryHasNode(entries[nextPayload]) {
+					nextPayload++
+				}
+			}
+			if nextPayload < len(entries) {
+				posBytes = stackEntryNodeEndByte(entries[nextPayload])
+				posRow = stackEntryNodeEndPoint(entries[nextPayload]).Row
+			}
+		}
+		record(depth, entry.state, posBytes, posRow)
+		if cEntryCountsTowardDepth(entry) {
 			depth++
 			if depth > cRecoverMaxSummaryDepth {
 				break

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -236,6 +236,174 @@ func TestCRecordSummaryUsesCompactEntryPosition(t *testing.T) {
 	}
 }
 
+func TestCStackEntriesTopFirstReusesScratch(t *testing.T) {
+	const depth = 128
+	entries := make([]stackEntry, depth)
+	for i := range entries {
+		entries[i] = stackEntry{state: StateID(i + 1)}
+	}
+	stack := glrStack{entries: entries}
+	var scratch gssScratch
+
+	got := cStackEntriesTopFirst(&stack, &scratch)
+	if len(got) != depth {
+		t.Fatalf("entry count = %d, want %d", len(got), depth)
+	}
+	if got[0].state != entries[depth-1].state || got[depth-1].state != entries[0].state {
+		t.Fatal("entries are not top-first")
+	}
+
+	if allocs := testing.AllocsPerRun(100, func() {
+		got = cStackEntriesTopFirst(&stack, &scratch)
+	}); allocs != 0 {
+		t.Fatalf("allocs per reused walk = %g, want 0", allocs)
+	}
+	if len(got) != depth {
+		t.Fatalf("reused entry count = %d, want %d", len(got), depth)
+	}
+
+	ownedFirst := cStackEntriesTopFirst(&stack, nil)
+	ownedSecond := cStackEntriesTopFirst(&stack, nil)
+	ownedSecond[0].state++
+	if ownedFirst[0].state == ownedSecond[0].state {
+		t.Fatal("nil-scratch calls reused borrowed storage")
+	}
+	if ownedFirst[0].state != entries[depth-1].state {
+		t.Fatal("later nil-scratch call overwrote the earlier result")
+	}
+}
+
+func TestCRecordSummaryMatchesPositionTableReference(t *testing.T) {
+	parser := &Parser{}
+	const maxEntries = 10
+	nodes := make([]Node, maxEntries)
+	for i := range nodes {
+		nodes[i].endByte = uint32(100 + i)
+		nodes[i].endPoint = Point{Row: uint32(10 + i), Column: uint32(i)}
+	}
+
+	for count := 0; count <= maxEntries; count++ {
+		for mask := 0; mask < 1<<count; mask++ {
+			entries := make([]stackEntry, count)
+			for i := range entries {
+				state := StateID(i%7 + 1)
+				if mask&(1<<i) != 0 {
+					entries[i] = newStackEntryNode(state, &nodes[i])
+				} else {
+					if i%3 == 0 {
+						state = cErrorState
+					}
+					entries[i] = stackEntry{state: state}
+				}
+			}
+
+			got := parser.cRecordSummary(entries)
+			want := cRecordSummaryPositionTableReference(entries)
+			if len(got) != len(want) {
+				t.Fatalf("count=%d mask=%#x summary len = %d, want %d", count, mask, len(got), len(want))
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("count=%d mask=%#x summary[%d] = %+v, want %+v", count, mask, i, got[i], want[i])
+				}
+			}
+		}
+	}
+
+	entries := make([]stackEntry, cRecoverMaxSummaryDepth+4)
+	boundaryNodes := make([]Node, len(entries))
+	for pattern := 0; pattern < 4; pattern++ {
+		for i := range entries {
+			state := StateID((i+pattern)%7 + 1)
+			if (i+pattern)%3 != 0 {
+				boundaryNodes[i].endByte = uint32(200 + i)
+				boundaryNodes[i].endPoint = Point{Row: uint32(20 + i)}
+				entries[i] = newStackEntryNode(state, &boundaryNodes[i])
+			} else {
+				if i%2 == 0 {
+					state = cErrorState
+				}
+				entries[i] = stackEntry{state: state}
+			}
+		}
+		got := parser.cRecordSummary(entries)
+		want := cRecordSummaryPositionTableReference(entries)
+		if len(got) != len(want) {
+			t.Fatalf("boundary pattern=%d summary len = %d, want %d", pattern, len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("boundary pattern=%d summary[%d] = %+v, want %+v", pattern, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestCRecordSummaryAvoidsPositionAllocations(t *testing.T) {
+	parser := &Parser{}
+	entries := make([]stackEntry, 8)
+	nodes := make([]Node, len(entries))
+	for i := range entries {
+		nodes[i].endByte = uint32(i + 1)
+		nodes[i].endPoint = Point{Row: uint32(i)}
+		entries[i] = newStackEntryNode(StateID(i+1), &nodes[i])
+	}
+
+	var summary []cStackSummaryEntry
+	if allocs := testing.AllocsPerRun(100, func() {
+		summary = parser.cRecordSummary(entries)
+	}); allocs != 1 {
+		t.Fatalf("allocs per summary = %g, want 1 persistent result allocation", allocs)
+	}
+	if len(summary) != len(entries) {
+		t.Fatalf("summary len = %d, want %d", len(summary), len(entries))
+	}
+}
+
+func cRecordSummaryPositionTableReference(entries []stackEntry) []cStackSummaryEntry {
+	summary := make([]cStackSummaryEntry, 0, 8)
+	posBytesAt := make([]uint32, len(entries))
+	posRowAt := make([]uint32, len(entries))
+	var posBytes uint32
+	var posRow uint32
+	for i := len(entries) - 1; i >= 0; i-- {
+		if stackEntryHasNode(entries[i]) {
+			posBytes = stackEntryNodeEndByte(entries[i])
+			posRow = stackEntryNodeEndPoint(entries[i]).Row
+		}
+		posBytesAt[i] = posBytes
+		posRowAt[i] = posRow
+	}
+	depth := 0
+	for i := range entries {
+		duplicate := false
+		for j := len(summary) - 1; j >= 0; j-- {
+			if summary[j].depth < depth {
+				break
+			}
+			if summary[j].depth == depth && summary[j].state == entries[i].state {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			summary = append(summary, cStackSummaryEntry{
+				depth:    depth,
+				state:    entries[i].state,
+				posBytes: posBytesAt[i],
+				posRow:   posRowAt[i],
+			})
+		}
+		if cEntryCountsTowardDepth(entries[i]) {
+			depth++
+			if depth > cRecoverMaxSummaryDepth {
+				break
+			}
+		}
+	}
+	return summary
+}
+
 func TestCStackPosRowUsesCompactEntryPoint(t *testing.T) {
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()

--- a/parser_scratch_budget_test.go
+++ b/parser_scratch_budget_test.go
@@ -71,6 +71,23 @@ func TestParserScratchBudgetUsesPerParseGrowth(t *testing.T) {
 	}
 }
 
+func TestParserScratchBudgetCountsRecoveryStackEntryGrowth(t *testing.T) {
+	var scratch parserScratch
+	entries := make([]stackEntry, 8)
+	for i := range entries {
+		entries[i] = stackEntry{state: StateID(i + 1)}
+	}
+	stack := glrStack{entries: entries}
+	stack.ensureGSS(&scratch.gss)
+	scratch.setBudget(1)
+
+	_ = cStackEntriesTopFirst(&stack, &scratch.gss)
+
+	if !scratch.budgetExhausted() {
+		t.Fatal("budget not exhausted by recovery stack-entry growth")
+	}
+}
+
 func TestMergeAliveLimitHonorsScratchBudget(t *testing.T) {
 	var scratch glrMergeScratch
 	perStack := int64(unsafe.Sizeof(glrStack{}) + unsafe.Sizeof(glrMergeSlot{}))


### PR DESCRIPTION
## Summary

- reuse a bounded recovery stack-entry buffer across stack walks
- replace two full-depth position arrays with a monotonic forward scan
- clear retained pointers, drop oversized buffers, and include capacity in scratch budgets

## Results

- standard full parse: 10 to 9 allocs/op and about 1.37 to 1.33 KiB/op
- MATLAB gallery: 25.4% less allocation for one pass and 33.5% less across the full retry flow
- GLSL witness: 7.49% fewer bytes and 15.96% fewer allocations
- SQL information-schema witness: 7.33% fewer bytes and 14.09% fewer mallocs
- incremental edit and no-edit paths remain at zero allocations

Canonical outputs and parser telemetry remain identical across the MATLAB, Objective-C, GLSL, and SQL validation witnesses.

## Verification

- focused recovery, GSS, and parser-scratch tests
- focused Docker race test
- Docker go vet
- allocation-equivalence and retained-pointer regression tests
- standard full/incremental/no-edit benchmark trio