### PR TITLE
perf: preserve recovery prefix aggregates across metadata changes

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -161,7 +161,8 @@ type glrMergeScratch struct {
 	cErrorCost        map[*Node]glrCErrorCostEntry
 	// cPrefixPath is the descent scratch for merge-side GSS prefix-aggregate
 	// fills (cStackPrefixCostForMerge, parser_recover_c.go); the aggregates
-	// live on gssNode, validated against gssPrefixAggGen.
+	// live on gssNode, validated against gssPrefixAggGen. reset clears the full
+	// backing capacity so pooled scratch cannot retain GSS slabs.
 	cPrefixPath []*gssNode
 	// spineVisit is the reusable descent scratch for the spine-equality memo
 	// (gssSpineEqualMemo): the pairs walked before the deciding position, so the
@@ -3377,10 +3378,15 @@ func stackEntryNodesEquivalentIgnoringDynamic(a, b *Node) bool {
 
 func setGSSMainLink(n *gssNode, i int, prev *gssNode, entry stackEntry) {
 	if i == 0 {
-		// Rewriting link 0 changes n's prev chain and payload, so every
-		// cached GSS prefix aggregate at or above n is stale (see
-		// gssPrefixAggGen, parser_recover_c.go).
-		gssPrefixAggGen.Add(1)
+		// Recovery-prefix aggregates depend only on the link-0 predecessor and
+		// the full-Node payload's error-cost / visible-count contribution. A
+		// same-predecessor rewrite of the exact same Node (or of two compact
+		// entries, which both contribute zero here) changes parser metadata but
+		// not either aggregate. Keep the cache in that explicit identity case;
+		// every other rewrite remains conservatively globally invalidating.
+		if n.prev != prev || stackEntryNode(n.entry) != stackEntryNode(entry) {
+			gssPrefixAggGen.Add(1)
+		}
 		n.prev = prev
 		n.entry = entry
 		return
@@ -5022,7 +5028,7 @@ func (s *glrMergeScratch) allocatedBytes() int64 {
 	if s == nil {
 		return 0
 	}
-	return s.resultBytes + s.slotBytes + s.largeSlotBytes + s.equivCacheBytes + s.stackEquivBytes + s.spineEquivBytes + s.frontierHashBytes + s.shapePrefixBytes + s.cleanZeroBytes
+	return s.resultBytes + s.slotBytes + s.largeSlotBytes + s.equivCacheBytes + s.stackEquivBytes + s.spineEquivBytes + s.frontierHashBytes + s.shapePrefixBytes + s.cleanZeroBytes + int64(cap(s.cPrefixPath))*int64(unsafe.Sizeof((*gssNode)(nil)))
 }
 
 func (s *glrMergeScratch) reset() {
@@ -5063,6 +5069,7 @@ func (s *glrMergeScratch) reset() {
 	} else if len(s.cErrorCost) > 0 {
 		clear(s.cErrorCost)
 	}
+	resetGSSPrefixPath(&s.cPrefixPath)
 	// shapePrefixEpoch is intentionally NOT reset here: like equivEpoch it
 	// increases monotonically across parses so retained array entries can never
 	// alias into a fresh parse (reset would restart the epoch at 1 and collide

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2843,7 +2843,7 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 						for _, ex := range children[reducedEnd:] {
 							extra := (*Node)(ex.node)
 							extra.parseState = gotoState
-							nodeBumpEquivVersion(extra)
+							nodeBumpEquivVersionMetadata(extra)
 							exEnd := extra.endByte
 							top = coalesceForestWithRawAndAlternatives(p, arena, &curIndex, slab, gotoState, exEnd, top,
 								stackEntry{node: ex.node, state: gotoState, kind: stackEntryKindNode},

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -365,7 +365,7 @@ func stackEntryHasNode(e stackEntry) bool {
 func retargetStackEntryPayload(e stackEntry, state StateID) (stackEntry, bool) {
 	if n := stackEntryNode(e); n != nil {
 		n.parseState = state
-		nodeBumpEquivVersion(n)
+		nodeBumpEquivVersionMetadata(n)
 		e.state = state
 		return e, true
 	}

--- a/parser.go
+++ b/parser.go
@@ -195,6 +195,7 @@ type Parser struct {
 	// live on gssNode (aggGen/aggCost/aggVis), the engine analogue of C
 	// StackNode.error_cost / node_count maintained at push, making
 	// ts_stack_error_cost-equivalent reads O(1) instead of O(stack depth).
+	// Cleared and capacity-bounded at parse end so it cannot retain GSS slabs.
 	cPrefixPath     []*gssNode
 	forceRawSpanAll bool
 	// leafInternByLang enables canonical leaf interning for this language even
@@ -1408,6 +1409,7 @@ func resetSnippetParser(parser *Parser) {
 	if parser == nil {
 		return
 	}
+	resetGSSPrefixPath(&parser.cPrefixPath)
 	parser.reparseFactory = nil
 	parser.recoveryParser = nil
 	parser.skipRecoveryReparse = false
@@ -4380,6 +4382,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		// attribution are all complete. Do this after captureArenaStats so the
 		// returned runtime/breakdown continue to describe parse-time allocation.
 		arena.reclaimRawShapeStorage()
+		resetGSSPrefixPath(&p.cPrefixPath)
 		return tree
 	}
 	finalize := func(treeStacks []glrStack, stopReason ParseStopReason) *Tree {

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1429,24 +1429,40 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 // prefix root..node inclusive. gssNode prev/entry links are write-once at
 // allocation except setGSSMainLink (link-0 rewrite), and node payload
 // contents mutate only through nodeBumpEquivVersion call sites; both choke
-// points bump gssPrefixAggGen, so an aggregate with a matching generation is
-// exactly the full-walk answer. allocNode zeroes the gens on every (possibly
+// points invalidate gssPrefixAggGen whenever recovery contributions can
+// change, so an aggregate with a matching generation is exactly the full-walk
+// answer. Metadata-only node changes and identity-preserving link rewrites do
+// not affect these aggregates. allocNode zeroes the gens on every (possibly
 // slab-recycled) node and the generation counter starts at 1, so stale or
 // fresh nodes can never validate.
 // ---------------------------------------------------------------------------
 
 // gssPrefixAggGen is the global invalidation generation for the GSS prefix
 // aggregates stored on gssNode (aggGen/aggCost/aggVisGen/aggVis). Bumped by
-// nodeBumpEquivVersion (any in-place node content mutation, tree.go) and
-// setGSSMainLink link-0 rewrites (glr.go). Global rather than per-parser
-// because nodeBumpEquivVersion has no parser in scope; cross-parser
-// over-invalidation only costs a rebuild, never staleness. Initialized to 1
-// so the zero value of gssNode.aggGen / aggVisGen (fresh or slab-cleared
-// nodes) can never validate.
+// recovery-relevant nodeBumpEquivVersion mutations (tree.go) and link-0
+// rewrites that change the predecessor or full-Node payload (glr.go). Global
+// rather than per-parser because nodeBumpEquivVersion has no parser in scope;
+// cross-parser over-invalidation only costs a rebuild, never staleness.
+// Initialized to 1 so the zero value of gssNode.aggGen / aggVisGen (fresh or
+// slab-cleared nodes) can never validate.
 var gssPrefixAggGen atomic.Uint64
+
+const maxRetainedGSSPrefixPath = 4 * 1024
 
 func init() {
 	gssPrefixAggGen.Store(1)
+}
+
+func resetGSSPrefixPath(path *[]*gssNode) {
+	if path == nil || cap(*path) == 0 {
+		return
+	}
+	if cap(*path) > maxRetainedGSSPrefixPath {
+		*path = nil
+		return
+	}
+	clear((*path)[:cap(*path)])
+	*path = (*path)[:0]
 }
 
 // cStackPrefixAgg returns the cumulative (error cost, visible subtree count)

--- a/parser_recover_prefix_agg_test.go
+++ b/parser_recover_prefix_agg_test.go
@@ -1,0 +1,151 @@
+package gotreesitter
+
+import "testing"
+
+func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
+	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
+	p := &Parser{
+		language:  lang,
+		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+	}
+	payload := &Node{symbol: 1, equivVersion: 1, errorRankCache: 3}
+	head := &gssNode{entry: newStackEntryNode(1, payload), depth: 1}
+
+	cost, visible := p.cStackPrefixAgg(head)
+	if cost != 0 || visible != 1 {
+		t.Fatalf("initial aggregate = (%d, %d), want (0, 1)", cost, visible)
+	}
+	gen := gssPrefixAggGen.Load()
+	if head.aggGen != gen || head.aggVisGen != gen {
+		t.Fatalf("initial cache generation = (%d, %d), want %d", head.aggGen, head.aggVisGen, gen)
+	}
+
+	payload.parseState = 2
+	nodeBumpEquivVersionMetadata(payload)
+	if payload.equivVersion != 2 {
+		t.Fatalf("equiv version = %d, want 2", payload.equivVersion)
+	}
+	if payload.errorRankCache != 0 {
+		t.Fatalf("error-rank cache = %d, want invalidated", payload.errorRankCache)
+	}
+	if got := gssPrefixAggGen.Load(); got != gen {
+		t.Fatalf("metadata bump changed prefix generation from %d to %d", gen, got)
+	}
+	if cost, visible = p.cStackPrefixAgg(head); cost != 0 || visible != 1 {
+		t.Fatalf("post-metadata aggregate = (%d, %d), want (0, 1)", cost, visible)
+	}
+
+	payload.setMissing(true)
+	nodeBumpEquivVersion(payload)
+	if got := gssPrefixAggGen.Load(); got == gen {
+		t.Fatalf("recovery-relevant bump left prefix generation at %d", got)
+	}
+	cost, visible = p.cStackPrefixAgg(head)
+	wantCost := uint32(cErrCostPerMissingTree + cErrCostPerRecovery)
+	if cost != wantCost || visible != 1 {
+		t.Fatalf("post-missing aggregate = (%d, %d), want (%d, 1)", cost, visible, wantCost)
+	}
+}
+
+func TestSetGSSMainLinkInvalidatesOnlyChangedRecoveryContribution(t *testing.T) {
+	prev := &gssNode{depth: 1}
+	payload := &Node{symbol: 1, equivVersion: 1}
+	head := &gssNode{
+		prev:      prev,
+		entry:     newStackEntryNode(1, payload),
+		depth:     2,
+		aggGen:    gssPrefixAggGen.Load(),
+		aggVisGen: gssPrefixAggGen.Load(),
+	}
+
+	gen := gssPrefixAggGen.Load()
+	setGSSMainLink(head, 0, prev, newStackEntryNode(2, payload))
+	if got := gssPrefixAggGen.Load(); got != gen {
+		t.Fatalf("same contribution changed prefix generation from %d to %d", gen, got)
+	}
+	compactHead := &gssNode{
+		prev:  prev,
+		entry: newStackEntryCompactFullLeaf(1, &compactFullLeaf{noTreeNode: noTreeNode{symbol: 1}}),
+		depth: 2,
+	}
+	setGSSMainLink(compactHead, 0, prev, newStackEntryCompactFullLeaf(2, &compactFullLeaf{noTreeNode: noTreeNode{symbol: 2}}))
+	if got := gssPrefixAggGen.Load(); got != gen {
+		t.Fatalf("zero-contribution compact rewrite changed prefix generation from %d to %d", gen, got)
+	}
+
+	otherPayload := &Node{symbol: 1, equivVersion: 1}
+	setGSSMainLink(head, 0, prev, newStackEntryNode(2, otherPayload))
+	changedPayloadGen := gssPrefixAggGen.Load()
+	if changedPayloadGen == gen {
+		t.Fatalf("changed payload left prefix generation at %d", changedPayloadGen)
+	}
+
+	otherPrev := &gssNode{depth: 1}
+	setGSSMainLink(head, 0, otherPrev, newStackEntryNode(2, otherPayload))
+	if got := gssPrefixAggGen.Load(); got == changedPayloadGen {
+		t.Fatalf("changed predecessor left prefix generation at %d", got)
+	}
+}
+
+func TestResetGSSPrefixPathClearsAndBoundsRetention(t *testing.T) {
+	nodes := []*gssNode{{}, {}, {}, {}, {}}
+	path := nodes[:1]
+	resetGSSPrefixPath(&path)
+	if len(path) != 0 || cap(path) != len(nodes) {
+		t.Fatalf("retained path shape = len %d cap %d, want len 0 cap %d", len(path), cap(path), len(nodes))
+	}
+	for i, node := range path[:cap(path)] {
+		if node != nil {
+			t.Fatalf("retained path[%d] = %p, want nil", i, node)
+		}
+	}
+
+	path = make([]*gssNode, 1, maxRetainedGSSPrefixPath+1)
+	path[0] = &gssNode{}
+	resetGSSPrefixPath(&path)
+	if path != nil {
+		t.Fatalf("oversized path retained len %d cap %d, want nil", len(path), cap(path))
+	}
+}
+
+func TestParseFinalizationClearsPrefixPathPointers(t *testing.T) {
+	parser := NewParser(buildArithmeticLanguage())
+	nodes := []*gssNode{{}, {}, {}}
+	parser.cPrefixPath = nodes[:1]
+
+	tree := mustParse(t, parser, []byte("42"))
+	tree.Release()
+
+	if len(parser.cPrefixPath) != 0 || cap(parser.cPrefixPath) != len(nodes) {
+		t.Fatalf("finalized path shape = len %d cap %d, want len 0 cap %d", len(parser.cPrefixPath), cap(parser.cPrefixPath), len(nodes))
+	}
+	for i, node := range parser.cPrefixPath[:cap(parser.cPrefixPath)] {
+		if node != nil {
+			t.Fatalf("finalized path[%d] = %p, want nil", i, node)
+		}
+	}
+}
+
+func TestGLRMergeScratchResetClearsPrefixPathPointers(t *testing.T) {
+	nodes := []*gssNode{{}, {}, {}}
+	var scratch glrMergeScratch
+	scratch.cPrefixPath = nodes[:1]
+	scratch.reset()
+	if len(scratch.cPrefixPath) != 0 || cap(scratch.cPrefixPath) != len(nodes) {
+		t.Fatalf("reset path shape = len %d cap %d, want len 0 cap %d", len(scratch.cPrefixPath), cap(scratch.cPrefixPath), len(nodes))
+	}
+	for i, node := range scratch.cPrefixPath[:cap(scratch.cPrefixPath)] {
+		if node != nil {
+			t.Fatalf("reset path[%d] = %p, want nil", i, node)
+		}
+	}
+}
+
+func TestParserScratchBudgetIncludesMergePrefixPathGrowth(t *testing.T) {
+	var scratch parserScratch
+	scratch.setBudget(1)
+	scratch.merge.cPrefixPath = make([]*gssNode, 0, 2)
+	if !scratch.budgetExhausted() {
+		t.Fatal("budget not exhausted after merge prefix-path growth")
+	}
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -1387,13 +1387,13 @@ func (p *Parser) tryResyncErrorRecoveryMode(source []byte, s *glrStack, tok Toke
 				}
 				n.preGotoState = pushState
 				n.parseState = next
-				nodeBumpEquivVersion(n)
+				nodeBumpEquivVersionMetadata(n)
 				pushState = next
 				p.pushStackNode(s, next, n, entryScratch, gssScratch)
 			}
 			recovered.preGotoState = pushState
 			recovered.parseState = target
-			nodeBumpEquivVersion(recovered)
+			nodeBumpEquivVersionMetadata(recovered)
 			p.pushStackNode(s, target, recovered, entryScratch, gssScratch)
 			if nodeCount != nil {
 				*nodeCount = *nodeCount + 1
@@ -1452,7 +1452,7 @@ func (p *Parser) tryResyncErrorRecoveryMode(source []byte, s *glrStack, tok Toke
 		}
 		n.preGotoState = pushState
 		n.parseState = next
-		nodeBumpEquivVersion(n)
+		nodeBumpEquivVersionMetadata(n)
 		pushState = next
 		p.pushStackNode(s, next, n, entryScratch, gssScratch)
 	}
@@ -1711,7 +1711,7 @@ func (p *Parser) tryReplayTopLevelRecovery(source []byte, s *glrStack, tok Token
 		next := targets[i]
 		n.preGotoState = state
 		n.parseState = next
-		nodeBumpEquivVersion(n)
+		nodeBumpEquivVersionMetadata(n)
 		state = next
 		p.pushStackNode(s, state, n, entryScratch, gssScratch)
 	}
@@ -3057,7 +3057,7 @@ func addStackEntryDynamicPrecedence(entry *stackEntry, delta int16) {
 	}
 	if n := stackEntryNode(*entry); n != nil {
 		n.dynamicPrecedence += int32(delta)
-		nodeBumpEquivVersion(n)
+		nodeBumpEquivVersionMetadata(n)
 		return
 	}
 	if n := stackEntryNoTreeNode(*entry); n != nil {
@@ -3641,7 +3641,7 @@ func (p *Parser) tryFastUnaryCollapseFromGSS(s *glrStack, act ParseAction, tok T
 	collapsed.productionID = act.ProductionID
 	collapsed.preGotoState = topState
 	collapsed.parseState = targetState
-	nodeBumpEquivVersion(collapsed)
+	nodeBumpEquivVersionMetadata(collapsed)
 	if !s.truncateBeforePush(targetDepth) {
 		s.dead = true
 		if tmpEntries != nil {
@@ -3856,7 +3856,7 @@ func (p *Parser) applyReduceActionFromGSS(source []byte, s *glrStack, act ParseA
 			continue
 		}
 		extra.parseState = targetState
-		nodeBumpEquivVersion(extra)
+		nodeBumpEquivVersionMetadata(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 	if timing != nil {
@@ -3942,7 +3942,7 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 				continue
 			}
 			extra.parseState = targetState
-			nodeBumpEquivVersion(extra)
+			nodeBumpEquivVersionMetadata(extra)
 			p.pushStackNode(target, targetState, extra, entryScratch, gssScratch)
 		}
 		target.byteOffset = target.gss.byteOffset()
@@ -4294,7 +4294,7 @@ func (p *Parser) applyReduceActionFromGSSTransientParents(source []byte, s *glrS
 			continue
 		}
 		extra.parseState = targetState
-		nodeBumpEquivVersion(extra)
+		nodeBumpEquivVersionMetadata(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 	if timing != nil {
@@ -7015,7 +7015,7 @@ func (p *Parser) applyReduceAction(source []byte, s *glrStack, act ParseAction, 
 			continue
 		}
 		extra.parseState = targetState
-		nodeBumpEquivVersion(extra)
+		nodeBumpEquivVersionMetadata(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 	if timing != nil {
@@ -7194,7 +7194,7 @@ func (p *Parser) applyReduceActionTransientParents(source []byte, s *glrStack, a
 			continue
 		}
 		extra.parseState = targetState
-		nodeBumpEquivVersion(extra)
+		nodeBumpEquivVersionMetadata(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 	if timing != nil {
@@ -7351,7 +7351,8 @@ func (p *Parser) pushCollapsedUnaryReduceNode(s *glrStack, act ParseAction, tok 
 	if gotoState != 0 {
 		targetState = gotoState
 	}
-	if tok.NoLookahead && targetState == topState {
+	extra := tok.NoLookahead && targetState == topState
+	if extra {
 		child.setExtra(true)
 	}
 	child.productionID = act.ProductionID
@@ -7359,7 +7360,11 @@ func (p *Parser) pushCollapsedUnaryReduceNode(s *glrStack, act ParseAction, tok 
 	child.parseState = targetState
 	child.rawShape = rawShape
 	child.dynamicPrecedence += int32(act.DynamicPrecedence)
-	nodeBumpEquivVersion(child)
+	if extra {
+		nodeBumpEquivVersion(child)
+	} else {
+		nodeBumpEquivVersionMetadata(child)
+	}
 	p.pushStackNode(s, targetState, child, entryScratch, gssScratch)
 	for i := trailingStart; i < trailingEnd; i++ {
 		extra := stackEntryNode(entries[i])
@@ -7367,7 +7372,7 @@ func (p *Parser) pushCollapsedUnaryReduceNode(s *glrStack, act ParseAction, tok 
 			continue
 		}
 		extra.parseState = targetState
-		nodeBumpEquivVersion(extra)
+		nodeBumpEquivVersionMetadata(extra)
 		p.pushStackNode(s, targetState, extra, entryScratch, gssScratch)
 	}
 }
@@ -7412,7 +7417,11 @@ func setCollapsedUnaryEntryMetadata(entry *stackEntry, act ParseAction, extra bo
 		n.productionID = act.ProductionID
 		n.preGotoState = preGotoState
 		n.parseState = parseState
-		nodeBumpEquivVersion(n)
+		if extra {
+			nodeBumpEquivVersion(n)
+		} else {
+			nodeBumpEquivVersionMetadata(n)
+		}
 		entry.state = parseState
 		return
 	}

--- a/raw_shape.go
+++ b/raw_shape.go
@@ -397,7 +397,7 @@ func setStackEntryRawShapeRef(entry *stackEntry, ref rawShapeRef) {
 	}
 	if n := stackEntryNode(*entry); n != nil {
 		n.rawShape = ref
-		nodeBumpEquivVersion(n)
+		nodeBumpEquivVersionMetadata(n)
 		return
 	}
 	if n := stackEntryNoTreeNode(*entry); n != nil {

--- a/tree.go
+++ b/tree.go
@@ -105,7 +105,13 @@ func nodeInitEquivVersion(n *Node) {
 	n.equivVersion = 1
 }
 
-func nodeBumpEquivVersion(n *Node) {
+// nodeBumpEquivVersionMetadata invalidates caches keyed by the node's complete
+// parser identity without invalidating GSS recovery-prefix aggregates. Use it
+// only for mutations that cannot change cNodeErrorCost or
+// cNodeVisibleSubtreeCount: parser states, production/raw-shape metadata, and
+// dynamic precedence. Symbol, child, missing/extra, and ERROR-span mutations
+// must use nodeBumpEquivVersion instead.
+func nodeBumpEquivVersionMetadata(n *Node) {
 	if n == nil {
 		return
 	}
@@ -117,11 +123,17 @@ func nodeBumpEquivVersion(n *Node) {
 	// mutation choke point that invalidated the former version-keyed arena map
 	// now invalidates the inline cache directly.
 	n.errorRankCache = 0
-	// Any in-place node mutation can change the node's error cost / visible
-	// count, which invalidates every cached GSS prefix aggregate that may sum
-	// over it (see gssPrefixAggGen, parser_recover_c.go). Bumping the global
-	// generation here — the single choke point for content mutations — keeps
-	// those caches exact without enumerating mutation sites.
+}
+
+func nodeBumpEquivVersion(n *Node) {
+	if n == nil {
+		return
+	}
+	nodeBumpEquivVersionMetadata(n)
+	// Recovery-relevant in-place mutations can change the node's error cost /
+	// visible count, which invalidates every cached GSS prefix aggregate that
+	// may sum over it (see gssPrefixAggGen, parser_recover_c.go). Metadata-only
+	// mutations use nodeBumpEquivVersionMetadata above.
 	gssPrefixAggGen.Add(1)
 }
 


### PR DESCRIPTION
## Summary

- separate metadata-only node version changes from recovery-cost and visible-count invalidation
- preserve prefix aggregates for identity-equivalent link-0 rewrites
- clear and cap parser and merge prefix-path scratch across parse reuse
- account retained prefix-path capacity in scratch budgets
- add focused contribution, pointer-retention, and budget regression tests

Symbol, child, missing/extra, and error-span mutations continue to invalidate the global recovery-prefix generation.

## Results

- MATLAB gallery Go median: 5.494s to 5.042s, 8.23% faster
- MATLAB current Go/C ratio: 50.29x; this remains a severe cliff
- GLSL reverse-order C-normalized ratio: 5.30% average improvement
- GLSL latest ratio: 1.7257x
- generic single-byte edit: 757.7ns to 752.7ns, statistically unchanged (p=0.624, n=15), 0 B/op and 0 allocs/op

Exact MATLAB and GLSL tree hashes remain unchanged.

## Verification

- focused invalidation and scratch tests repeated 20 times
- fresh Docker vet and race gate repeated 10 times after rebasing
- reverse-order MATLAB and GLSL A/B measurements
- interleaved pinned generic incremental A/B after moving finalization cleanup off the defer path
- retained-pointer clearing and oversized-capacity release coverage
- parser scratch-budget accounting coverage