### PR TITLE
test(perf): enforce file-level fleet ceilings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
         working-directory: cgo_harness
         run: |
           set -euo pipefail
-          GOWORK=off go test ./cmd/perf_scan_budget -count=1
+          GOWORK=off go test ./cmd/perf_scan_budget ./cmd/perf_scan_status -count=1
           GOWORK=off go run ./cmd/perf_scan_budget \
             -budget perf_scan/perf_ratio_budgets.json
 

--- a/.github/workflows/perf-scan-gate.yml
+++ b/.github/workflows/perf-scan-gate.yml
@@ -124,7 +124,7 @@ jobs:
             GOWORK=off go run ./cmd/perf_scan_budget \
               -budget perf_scan/perf_ratio_budgets.json \
               -scoreboard perf_scan/out/nightly/scoreboard.json \
-              -require-all-budget-langs \
+              -hard-gate-only \
               -out-md perf_scan/out/nightly/budget.md || budget_result=$?
             GOWORK=off go run ./cmd/perf_scan_status \
               -budget perf_scan/perf_ratio_budgets.json \

--- a/.github/workflows/perf-scan-gate.yml
+++ b/.github/workflows/perf-scan-gate.yml
@@ -1,8 +1,6 @@
 name: perf-scan-hard-gate
 
 on:
-  schedule:
-    - cron: "17 6 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -18,7 +16,7 @@ jobs:
     timeout-minutes: 360
     env:
       PERF_CORPUS_DIR: /srv/gotreesitter-perf
-      PERF_OUT: cgo_harness/perf_scan/out/nightly
+      PERF_OUT: cgo_harness/perf_scan/out/hard_gate
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +59,9 @@ jobs:
 
             checkout="$root/$name"
             test -d "$checkout" || fail "missing corpus checkout for $name: $checkout"
+            actual_repo="$(git -C "$checkout" remote get-url origin)" || fail "cannot resolve origin URL for $name"
+            test "${actual_repo%.git}" = "${repo%.git}" || fail "corpus origin drift for $name: got $actual_repo, want $repo"
+            test ! -s "$checkout/.git/objects/info/alternates" || fail "external Git object alternate is not allowed for $name"
             git -C "$checkout" cat-file -e "$commit^{commit}" || fail "locked commit is unavailable for $name: $commit"
             head="$(git -C "$checkout" rev-parse --verify HEAD)" || fail "cannot resolve HEAD for $name"
             test "$head" = "$commit" || fail "corpus HEAD drift for $name: got $head, want $commit"
@@ -106,7 +107,7 @@ jobs:
               GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
               GTS_PERF_SCAN_LANG_TIMEOUT_MS=900000 \
               GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=6144 \
-              GTS_PERF_SCAN_OUT=perf_scan/out/nightly \
+              GTS_PERF_SCAN_OUT=perf_scan/out/hard_gate \
               go test -tags 'treesitter_c_parity treesitter_c_perfscan' \
                 -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 -p 1 ."
 
@@ -119,19 +120,19 @@ jobs:
           GOWORK=off go test ./cmd/perf_scan_budget ./cmd/perf_scan_status -count=1
           GOWORK=off go run ./cmd/perf_scan_budget \
             -budget perf_scan/perf_ratio_budgets.json
-          if test -f perf_scan/out/nightly/scoreboard.json; then
+          if test -f perf_scan/out/hard_gate/scoreboard.json; then
             budget_result=0
             GOWORK=off go run ./cmd/perf_scan_budget \
               -budget perf_scan/perf_ratio_budgets.json \
-              -scoreboard perf_scan/out/nightly/scoreboard.json \
+              -scoreboard perf_scan/out/hard_gate/scoreboard.json \
               -hard-gate-only \
-              -out-md perf_scan/out/nightly/budget.md || budget_result=$?
+              -out-md perf_scan/out/hard_gate/budget.md || budget_result=$?
             GOWORK=off go run ./cmd/perf_scan_status \
               -budget perf_scan/perf_ratio_budgets.json \
               -fleet tier_scan/exts.tsv \
-              -scoreboards perf_scan/out/nightly/scoreboard.json \
-              -out-json perf_scan/out/nightly/status.json \
-              -out-md perf_scan/out/nightly/status.md
+              -scoreboards perf_scan/out/hard_gate/scoreboard.json \
+              -out-json perf_scan/out/hard_gate/status.json \
+              -out-md perf_scan/out/hard_gate/status.md
             exit "$budget_result"
           fi
 
@@ -141,7 +142,7 @@ jobs:
         with:
           name: perf-hard-gate-${{ github.run_id }}
           path: |
-            cgo_harness/perf_scan/out/nightly
+            cgo_harness/perf_scan/out/hard_gate
             harness_out/docker
           if-no-files-found: warn
           retention-days: 90

--- a/.github/workflows/perf-scan-gate.yml
+++ b/.github/workflows/perf-scan-gate.yml
@@ -1,0 +1,147 @@
+name: perf-scan-hard-gate
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: perf-scan-hard-gate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  fleet:
+    runs-on: [self-hosted, perf]
+    timeout-minutes: 360
+    env:
+      PERF_CORPUS_DIR: /srv/gotreesitter-perf
+      PERF_OUT: cgo_harness/perf_scan/out/nightly
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cgo_harness/go.mod
+
+      - name: Authenticate corpus lock
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="$(awk 'NF { print $1; exit }' cgo_harness/perf_scan/corpus_sources.lock.sha256)"
+          actual="$(sha256sum "$PERF_CORPUS_DIR/corpus_sources.lock" | awk '{ print $1 }')"
+          test "$actual" = "$expected"
+          test -d "$PERF_CORPUS_DIR/corpus_sources"
+
+      - name: Verify pinned corpus checkouts
+        shell: bash
+        run: |
+          set -euo pipefail
+          lock="$PERF_CORPUS_DIR/corpus_sources.lock"
+          root="$PERF_CORPUS_DIR/corpus_sources"
+          rows=0
+          declare -A seen=()
+          fail() {
+            echo "::error::$*" >&2
+            exit 1
+          }
+          while read -r name repo commit subdir extensions extra; do
+            if test -z "${name:-}" || [[ "$name" == \#* ]]; then
+              continue
+            fi
+            test -z "${extra:-}" || fail "invalid extra field in corpus lock row for $name"
+            test -n "${repo:-}" || fail "missing repository URL for $name"
+            test -n "${commit:-}" || fail "missing commit for $name"
+            test -n "${extensions:-}" || test "$name" = "gomod" || fail "missing extension filter for $name"
+            test -z "${seen[$name]:-}" || fail "duplicate corpus lock row for $name"
+            seen[$name]=1
+            rows=$((rows + 1))
+
+            checkout="$root/$name"
+            test -d "$checkout" || fail "missing corpus checkout for $name: $checkout"
+            git -C "$checkout" cat-file -e "$commit^{commit}" || fail "locked commit is unavailable for $name: $commit"
+            head="$(git -C "$checkout" rev-parse --verify HEAD)" || fail "cannot resolve HEAD for $name"
+            test "$head" = "$commit" || fail "corpus HEAD drift for $name: got $head, want $commit"
+            git -C "$checkout" diff --quiet --ignore-submodules=none "$commit" -- || fail "tracked worktree drift for $name"
+            git -C "$checkout" diff --cached --quiet --ignore-submodules=none "$commit" -- || fail "index drift for $name"
+
+            if test -n "${subdir:-}" && test "$subdir" != "."; then
+              test -e "$checkout/$subdir" || fail "locked corpus subpath is missing for $name: $subdir"
+            fi
+          done < "$lock"
+          test "$rows" -eq 206 || fail "corpus lock contains $rows language rows, want 206"
+
+      - name: Restore C reference build cache
+        uses: actions/cache@v4
+        with:
+          path: harness_out/parity_c_ref_cache
+          key: perf-c-ref-${{ runner.os }}-${{ hashFiles('grammars/languages.lock') }}
+
+      - name: Run authenticated fleet gate in Docker
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$PERF_OUT"
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label perf-scan-hard-gate \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --mount "$PERF_CORPUS_DIR:/corpus:ro" \
+            -- "cd /workspace/cgo_harness && \
+              GOWORK=off \
+              GTS_PERF_SCAN=1 \
+              GTS_PERF_SCAN_HARD_GATE=1 \
+              GTS_PERF_SCAN_REQUIRE_FLEET=1 \
+              GTS_PERF_SCAN_CORPUS_ROOT=/corpus/corpus_sources \
+              GTS_REAL_CORPUS_BENCH_LOCK=/corpus/corpus_sources.lock \
+              GTS_PERF_SCAN_MAX_FILES=8 \
+              GTS_PERF_SCAN_ORDER=largest \
+              GTS_PERF_SCAN_REPS=5 \
+              GTS_PERF_SCAN_WARMUP=1 \
+              GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
+              GTS_PERF_SCAN_LANG_TIMEOUT_MS=900000 \
+              GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=6144 \
+              GTS_PERF_SCAN_OUT=perf_scan/out/nightly \
+              go test -tags 'treesitter_c_parity treesitter_c_perfscan' \
+                -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 -p 1 ."
+
+      - name: Render gate status
+        if: always()
+        working-directory: cgo_harness
+        shell: bash
+        run: |
+          set -euo pipefail
+          GOWORK=off go test ./cmd/perf_scan_budget ./cmd/perf_scan_status -count=1
+          GOWORK=off go run ./cmd/perf_scan_budget \
+            -budget perf_scan/perf_ratio_budgets.json
+          if test -f perf_scan/out/nightly/scoreboard.json; then
+            budget_result=0
+            GOWORK=off go run ./cmd/perf_scan_budget \
+              -budget perf_scan/perf_ratio_budgets.json \
+              -scoreboard perf_scan/out/nightly/scoreboard.json \
+              -require-all-budget-langs \
+              -out-md perf_scan/out/nightly/budget.md || budget_result=$?
+            GOWORK=off go run ./cmd/perf_scan_status \
+              -budget perf_scan/perf_ratio_budgets.json \
+              -fleet tier_scan/exts.tsv \
+              -scoreboards perf_scan/out/nightly/scoreboard.json \
+              -out-json perf_scan/out/nightly/status.json \
+              -out-md perf_scan/out/nightly/status.md
+            exit "$budget_result"
+          fi
+
+      - name: Upload perf gate evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-hard-gate-${{ github.run_id }}
+          path: |
+            cgo_harness/perf_scan/out/nightly
+            harness_out/docker
+          if-no-files-found: warn
+          retention-days: 90

--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -163,6 +163,7 @@ func main() {
 		langsRaw              string
 		requireAllBudgetLangs bool
 		strictConfig          bool
+		hardGateOnly          bool
 		outMD                 string
 	)
 
@@ -171,6 +172,7 @@ func main() {
 	flag.StringVar(&langsRaw, "langs", "", "optional comma-separated language filter")
 	flag.BoolVar(&requireAllBudgetLangs, "require-all-budget-langs", false, "fail if the scoreboard omits a budgeted language")
 	flag.BoolVar(&strictConfig, "strict-config", true, "require scoreboard measurement knobs to match structured budget metadata")
+	flag.BoolVar(&hardGateOnly, "hard-gate-only", false, "check fail-closed fleet coverage and per-file hard limits without applying historical aggregate ratchets")
 	flag.StringVar(&outMD, "out-md", "", "optional markdown summary output path")
 	flag.Parse()
 
@@ -194,6 +196,7 @@ func main() {
 			Languages:             langs,
 			RequireAllBudgetLangs: requireAllBudgetLangs,
 			StrictConfig:          strictConfig,
+			HardGateOnly:          hardGateOnly,
 		})
 	}
 
@@ -297,6 +300,7 @@ type compareOptions struct {
 	Languages             []string
 	RequireAllBudgetLangs bool
 	StrictConfig          bool
+	HardGateOnly          bool
 }
 
 func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []evalFinding {
@@ -305,7 +309,10 @@ func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []
 		out = append(out, evalFinding{Metric: "scoreboard.schema", Got: s.Schema, Want: scoreboardSchema})
 	}
 	if opts.StrictConfig {
-		out = append(out, compareConfig(b.MeasurementBasis, s.Config)...)
+		out = append(out, compareConfig(b.MeasurementBasis, s.Config, opts.HardGateOnly)...)
+	}
+	if opts.HardGateOnly && !opts.StrictConfig && !s.Config.HardGate {
+		out = append(out, evalFinding{Metric: "config.hard_gate", Got: "false", Want: "true"})
 	}
 	if s.Config.HardGate {
 		out = append(out, compareHardCoverage(s)...)
@@ -321,12 +328,15 @@ func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []
 			continue
 		}
 		scoreboardLangs[row.Language] = row
-		if s.Config.HardGate {
+		if s.Config.HardGate || opts.HardGateOnly {
 			out = append(out, compareHardGate(row)...)
 		}
-		if _, ok := b.Languages[row.Language]; !ok && !(s.Config.HardGate && s.Config.RequireFleet && s.Gate != nil) {
+		if _, ok := b.Languages[row.Language]; !ok && !opts.HardGateOnly && !(s.Config.HardGate && s.Config.RequireFleet && s.Gate != nil) {
 			out = append(out, evalFinding{Language: row.Language, Metric: "budget", Got: "missing", Want: "language budget"})
 		}
+	}
+	if opts.HardGateOnly {
+		return out
 	}
 
 	for _, lang := range sortedBudgetLanguages(b) {
@@ -478,7 +488,7 @@ func hardStopDescription(stop *scoreboardStop, status string) string {
 	return description
 }
 
-func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
+func compareConfig(b budgetMeasurementBasis, s scoreboardConfig, hardGateOnly bool) []evalFinding {
 	var out []evalFinding
 	if b.Reps > 0 && s.Reps != b.Reps {
 		out = append(out, evalFinding{Metric: "config.reps", Got: fmt.Sprint(s.Reps), Want: fmt.Sprint(b.Reps)})
@@ -500,7 +510,11 @@ func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
 			out = append(out, evalFinding{Axis: axis, Metric: "config.axes", Got: strings.Join(s.Axes, ","), Want: "include " + axis})
 		}
 	}
-	if len(b.ExcludePaths) > 0 || len(s.ExcludePaths) > 0 {
+	if hardGateOnly {
+		if got := normalizedPathList(s.ExcludePaths); len(got) > 0 {
+			out = append(out, evalFinding{Metric: "config.exclude_paths", Got: strings.Join(got, ","), Want: "none for the universal hard gate"})
+		}
+	} else if len(b.ExcludePaths) > 0 || len(s.ExcludePaths) > 0 {
 		got := normalizedPathList(s.ExcludePaths)
 		want := normalizedPathList(b.ExcludePaths)
 		if !stringSlicesEqual(got, want) {

--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -17,6 +17,9 @@ const (
 	axisFull   = "full"
 	axisNoEdit = "noedit"
 	statusOK   = "ok"
+
+	hardMaxFullParseRatio = 10.0
+	fastFullParseRatio    = 0.10
 )
 
 type budgetFile struct {
@@ -27,13 +30,16 @@ type budgetFile struct {
 }
 
 type budgetMeasurementBasis struct {
-	Reps         int      `json:"reps"`
-	Warmup       int      `json:"warmup"`
-	FileBudgetMS int      `json:"file_budget_ms"`
-	MaxFiles     int      `json:"max_files,omitempty"`
-	Order        string   `json:"order,omitempty"`
-	Axes         []string `json:"axes"`
-	ExcludePaths []string `json:"exclude_paths,omitempty"`
+	Reps                  int      `json:"reps"`
+	Warmup                int      `json:"warmup"`
+	FileBudgetMS          int      `json:"file_budget_ms"`
+	MaxFiles              int      `json:"max_files,omitempty"`
+	Order                 string   `json:"order,omitempty"`
+	Axes                  []string `json:"axes"`
+	ExcludePaths          []string `json:"exclude_paths,omitempty"`
+	HardMaxFullParseRatio float64  `json:"hard_max_full_parse_ratio"`
+	FastFullParseRatio    float64  `json:"fast_full_parse_ratio"`
+	CorpusLockSHA256      string   `json:"corpus_lock_sha256"`
 }
 
 type budgetLang struct {
@@ -55,23 +61,33 @@ type scoreboardFile struct {
 	Schema    string           `json:"schema"`
 	Config    scoreboardConfig `json:"config"`
 	Languages []scoreboardLang `json:"languages"`
+	Corpus    scoreboardCorpus `json:"corpus_coverage"`
+	Gate      *scoreboardGate  `json:"hard_gate,omitempty"`
 }
 
 type scoreboardConfig struct {
-	Reps         int      `json:"reps"`
-	Warmup       int      `json:"warmup"`
-	FileBudgetMS int      `json:"file_budget_ms"`
-	MaxFiles     int      `json:"max_files"`
-	Order        string   `json:"order"`
-	Axes         []string `json:"axes"`
-	ExcludePaths []string `json:"exclude_paths,omitempty"`
+	Reps             int      `json:"reps"`
+	Warmup           int      `json:"warmup"`
+	FileBudgetMS     int      `json:"file_budget_ms"`
+	MaxFiles         int      `json:"max_files"`
+	Order            string   `json:"order"`
+	Axes             []string `json:"axes"`
+	ExcludePaths     []string `json:"exclude_paths,omitempty"`
+	HardGate         bool     `json:"hard_gate"`
+	RequireFleet     bool     `json:"require_fleet"`
+	CorpusLockSHA256 string   `json:"corpus_lock_sha256,omitempty"`
 }
 
 type scoreboardLang struct {
-	Language string                    `json:"language"`
-	Status   string                    `json:"status"`
-	Axes     map[string]scoreboardAxis `json:"axes"`
-	Files    []scoreboardFileRow       `json:"files"`
+	Language      string                    `json:"language"`
+	Status        string                    `json:"status"`
+	FilesSelected int                       `json:"files_selected"`
+	FilesMeasured int                       `json:"files_measured"`
+	Axes          map[string]scoreboardAxis `json:"axes"`
+	Files         []scoreboardFileRow       `json:"files"`
+	ActiveFile    string                    `json:"active_file,omitempty"`
+	ActiveAxis    string                    `json:"active_axis,omitempty"`
+	Stop          *scoreboardStop           `json:"stop,omitempty"`
 }
 
 type scoreboardAxis struct {
@@ -87,12 +103,53 @@ type scoreboardFileRow struct {
 }
 
 type scoreboardFileAxis struct {
-	Status string `json:"status"`
-	Detail string `json:"detail,omitempty"`
+	Status     string          `json:"status"`
+	Detail     string          `json:"detail,omitempty"`
+	GoMedianNs int64           `json:"go_median_ns,omitempty"`
+	CMedianNs  int64           `json:"c_median_ns,omitempty"`
+	Ratio      float64         `json:"ratio,omitempty"`
+	Stop       *scoreboardStop `json:"stop,omitempty"`
+}
+
+type scoreboardStop struct {
+	Class          string `json:"class"`
+	Reason         string `json:"reason,omitempty"`
+	Implementation string `json:"implementation,omitempty"`
+	Phase          string `json:"phase,omitempty"`
+	Attempt        int    `json:"attempt,omitempty"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+type scoreboardGate struct {
+	Status             string                  `json:"status"`
+	MaxFullParseRatio  float64                 `json:"max_full_parse_ratio"`
+	FastFullParseRatio float64                 `json:"fast_full_parse_ratio"`
+	FilesExpected      int                     `json:"files_expected"`
+	FilesMeasured      int                     `json:"files_measured"`
+	FullFilesEvaluated int                     `json:"full_files_evaluated"`
+	Failures           []scoreboardGateFinding `json:"failures,omitempty"`
+}
+
+type scoreboardCorpus struct {
+	LockSHA256          string   `json:"lock_sha256,omitempty"`
+	LockLanguages       int      `json:"lock_languages"`
+	SelectedLanguages   int      `json:"selected_languages"`
+	MissingFromLock     []string `json:"missing_from_lock,omitempty"`
+	MissingFromRegistry []string `json:"missing_from_registry,omitempty"`
+}
+
+type scoreboardGateFinding struct {
+	Kind     string `json:"kind"`
+	Language string `json:"language,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Axis     string `json:"axis,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Detail   string `json:"detail,omitempty"`
 }
 
 type evalFinding struct {
 	Language string
+	Path     string
 	Axis     string
 	Metric   string
 	Got      string
@@ -189,6 +246,15 @@ func validateBudget(b *budgetFile) []evalFinding {
 			out = append(out, evalFinding{Axis: axis, Metric: "measurement_basis.axes", Got: strings.Join(b.MeasurementBasis.Axes, ","), Want: "include " + axis})
 		}
 	}
+	if b.MeasurementBasis.HardMaxFullParseRatio != hardMaxFullParseRatio {
+		out = append(out, evalFinding{Axis: axisFull, Metric: "measurement_basis.hard_max_full_parse_ratio", Got: fmt.Sprintf("%.6g", b.MeasurementBasis.HardMaxFullParseRatio), Want: fmt.Sprintf("%.1f", hardMaxFullParseRatio)})
+	}
+	if b.MeasurementBasis.FastFullParseRatio != fastFullParseRatio {
+		out = append(out, evalFinding{Axis: axisFull, Metric: "measurement_basis.fast_full_parse_ratio", Got: fmt.Sprintf("%.6g", b.MeasurementBasis.FastFullParseRatio), Want: fmt.Sprintf("%.2f", fastFullParseRatio)})
+	}
+	if !validSHA256(b.MeasurementBasis.CorpusLockSHA256) {
+		out = append(out, evalFinding{Metric: "measurement_basis.corpus_lock_sha256", Got: b.MeasurementBasis.CorpusLockSHA256, Want: "64 lowercase hex characters"})
+	}
 	for _, pattern := range normalizedPathList(b.MeasurementBasis.ExcludePaths) {
 		if strings.ContainsAny(pattern, "*?[") {
 			if _, err := path.Match(pattern, "x"); err != nil {
@@ -241,6 +307,9 @@ func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []
 	if opts.StrictConfig {
 		out = append(out, compareConfig(b.MeasurementBasis, s.Config)...)
 	}
+	if s.Config.HardGate {
+		out = append(out, compareHardCoverage(s)...)
+	}
 
 	filter := map[string]bool{}
 	for _, lang := range opts.Languages {
@@ -252,7 +321,10 @@ func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []
 			continue
 		}
 		scoreboardLangs[row.Language] = row
-		if _, ok := b.Languages[row.Language]; !ok {
+		if s.Config.HardGate {
+			out = append(out, compareHardGate(row)...)
+		}
+		if _, ok := b.Languages[row.Language]; !ok && !(s.Config.HardGate && s.Config.RequireFleet && s.Gate != nil) {
 			out = append(out, evalFinding{Language: row.Language, Metric: "budget", Got: "missing", Want: "language budget"})
 		}
 	}
@@ -276,6 +348,134 @@ func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []
 		out = append(out, compareAxis(lang, axisNoEdit, entry.NoEditAxis, row)...)
 	}
 	return out
+}
+
+func compareHardCoverage(s *scoreboardFile) []evalFinding {
+	var out []evalFinding
+	if s.Gate == nil {
+		return append(out, evalFinding{Metric: "hard_gate_report", Got: "missing", Want: "embedded fail-closed report"})
+	}
+	if s.Gate.Status != "pass" {
+		out = append(out, evalFinding{Metric: "hard_gate_report", Got: s.Gate.Status, Want: "pass"})
+	}
+	if s.Gate.MaxFullParseRatio != hardMaxFullParseRatio {
+		out = append(out, evalFinding{Axis: axisFull, Metric: "hard_gate.max_full_parse_ratio", Got: fmt.Sprintf("%.6g", s.Gate.MaxFullParseRatio), Want: fmt.Sprintf("%.1f", hardMaxFullParseRatio)})
+	}
+	if s.Gate.FastFullParseRatio != fastFullParseRatio {
+		out = append(out, evalFinding{Axis: axisFull, Metric: "hard_gate.fast_full_parse_ratio", Got: fmt.Sprintf("%.6g", s.Gate.FastFullParseRatio), Want: fmt.Sprintf("%.2f", fastFullParseRatio)})
+	}
+	if s.Corpus.LockSHA256 != s.Config.CorpusLockSHA256 {
+		out = append(out, evalFinding{Metric: "hard_fleet_coverage", Got: "coverage lock=" + s.Corpus.LockSHA256, Want: "config lock=" + s.Config.CorpusLockSHA256})
+	}
+	if s.Corpus.LockLanguages <= 0 {
+		out = append(out, evalFinding{Metric: "hard_fleet_coverage", Got: fmt.Sprint(s.Corpus.LockLanguages), Want: "positive authenticated lock language count"})
+	}
+	if !s.Config.RequireFleet {
+		return out
+	}
+	if s.Corpus.SelectedLanguages != s.Corpus.LockLanguages {
+		out = append(out, evalFinding{Metric: "hard_fleet_coverage", Got: fmt.Sprintf("selected=%d lock=%d", s.Corpus.SelectedLanguages, s.Corpus.LockLanguages), Want: "selected=lock"})
+	}
+	if len(s.Languages) != s.Corpus.SelectedLanguages {
+		out = append(out, evalFinding{Metric: "hard_fleet_coverage", Got: fmt.Sprintf("rows=%d selected=%d", len(s.Languages), s.Corpus.SelectedLanguages), Want: "one row per selected language"})
+	}
+	if len(s.Corpus.MissingFromLock) > 0 {
+		out = append(out, evalFinding{Metric: "hard_fleet_coverage", Got: "missing_from_lock=" + strings.Join(s.Corpus.MissingFromLock, ","), Want: "none"})
+	}
+	if len(s.Corpus.MissingFromRegistry) > 0 {
+		out = append(out, evalFinding{Metric: "hard_fleet_coverage", Got: "missing_from_registry=" + strings.Join(s.Corpus.MissingFromRegistry, ","), Want: "none"})
+	}
+	return out
+}
+
+func compareHardGate(row scoreboardLang) []evalFinding {
+	var out []evalFinding
+	if row.Status != statusOK {
+		out = append(out, evalFinding{Language: row.Language, Path: row.ActiveFile, Axis: row.ActiveAxis, Metric: "hard_coverage", Got: row.Status, Want: statusOK})
+	}
+	if row.FilesMeasured != row.FilesSelected || len(row.Files) != row.FilesSelected {
+		out = append(out, evalFinding{
+			Language: row.Language,
+			Metric:   "hard_coverage",
+			Got:      fmt.Sprintf("measured=%d rows=%d selected=%d", row.FilesMeasured, len(row.Files), row.FilesSelected),
+			Want:     "complete selected-file coverage",
+		})
+	}
+	if scoreboardStopIsGo(row.Stop) {
+		out = append(out, evalFinding{
+			Language: row.Language,
+			Path:     row.ActiveFile,
+			Axis:     row.ActiveAxis,
+			Metric:   "hard_go_stop",
+			Got:      hardStopDescription(row.Stop, row.Status),
+			Want:     "no Go timeout, parser-budget, wall, RSS, or OOM stop",
+		})
+	}
+	for _, file := range row.Files {
+		for axis, result := range file.Axes {
+			if scoreboardStopIsGo(result.Stop) || legacyGoStopStatus(result.Status) {
+				out = append(out, evalFinding{
+					Language: row.Language,
+					Path:     file.Path,
+					Axis:     axis,
+					Metric:   "hard_go_stop",
+					Got:      hardStopDescription(result.Stop, result.Status),
+					Want:     "no Go timeout or parser-budget stop",
+				})
+			}
+		}
+		full, ok := file.Axes[axisFull]
+		if !ok {
+			out = append(out, evalFinding{Language: row.Language, Path: file.Path, Axis: axisFull, Metric: "hard_full_measurement", Got: "missing", Want: "exact per-file Go/C ratio"})
+			continue
+		}
+		if full.Status != statusOK || full.GoMedianNs <= 0 || full.CMedianNs <= 0 {
+			if !scoreboardStopIsGo(full.Stop) && !legacyGoStopStatus(full.Status) {
+				got := full.Status
+				if got == "" {
+					got = "missing timing"
+				}
+				out = append(out, evalFinding{Language: row.Language, Path: file.Path, Axis: axisFull, Metric: "hard_full_measurement", Got: got, Want: "status=ok with exact Go/C ratio"})
+			}
+			continue
+		}
+		ratio := float64(full.GoMedianNs) / float64(full.CMedianNs)
+		if ratio > hardMaxFullParseRatio {
+			out = append(out, evalFinding{
+				Language: row.Language,
+				Path:     file.Path,
+				Axis:     axisFull,
+				Metric:   "hard_full_ratio",
+				Got:      fmt.Sprintf("%.4fx", ratio),
+				Want:     fmt.Sprintf("<=%.1fx", hardMaxFullParseRatio),
+			})
+		}
+	}
+	return out
+}
+
+func scoreboardStopIsGo(stop *scoreboardStop) bool {
+	return stop != nil && stop.Implementation == "go"
+}
+
+func legacyGoStopStatus(status string) bool {
+	switch status {
+	case "go_timeout", "go_budget_stop", "go_stopped":
+		return true
+	default:
+		return false
+	}
+}
+
+func hardStopDescription(stop *scoreboardStop, status string) string {
+	if stop == nil {
+		return status
+	}
+	description := stop.Class
+	if stop.Reason != "" {
+		description += ":" + stop.Reason
+	}
+	return description
 }
 
 func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
@@ -307,7 +507,25 @@ func compareConfig(b budgetMeasurementBasis, s scoreboardConfig) []evalFinding {
 			out = append(out, evalFinding{Metric: "config.exclude_paths", Got: strings.Join(got, ","), Want: strings.Join(want, ",")})
 		}
 	}
+	if !s.HardGate {
+		out = append(out, evalFinding{Metric: "config.hard_gate", Got: "false", Want: "true"})
+	}
+	if s.CorpusLockSHA256 != b.CorpusLockSHA256 {
+		out = append(out, evalFinding{Metric: "config.corpus_lock_sha256", Got: s.CorpusLockSHA256, Want: b.CorpusLockSHA256})
+	}
 	return out
+}
+
+func validSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			return false
+		}
+	}
+	return true
 }
 
 func compareAxis(lang, axis string, budget budgetAxis, row scoreboardLang) []evalFinding {
@@ -399,11 +617,11 @@ func renderSummary(b *budgetFile, scoreboardPath string, findings []evalFinding)
 		return sb.String()
 	}
 	fmt.Fprintf(&sb, "- outcome: `FAIL`\n\n")
-	fmt.Fprintf(&sb, "| language | axis | metric | got | want |\n")
-	fmt.Fprintf(&sb, "|---|---|---|---|---|\n")
+	fmt.Fprintf(&sb, "| language | file | axis | metric | got | want |\n")
+	fmt.Fprintf(&sb, "|---|---|---|---|---|---|\n")
 	for _, f := range findings {
-		fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
-			mdCell(f.Language), mdCell(f.Axis), mdCell(f.Metric), mdCell(f.Got), mdCell(f.Want))
+		fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s |\n",
+			mdCell(f.Language), mdCell(f.Path), mdCell(f.Axis), mdCell(f.Metric), mdCell(f.Got), mdCell(f.Want))
 	}
 	return sb.String()
 }
@@ -411,7 +629,7 @@ func renderSummary(b *budgetFile, scoreboardPath string, findings []evalFinding)
 func printFindings(prefix string, findings []evalFinding) {
 	fmt.Fprintln(os.Stderr, prefix)
 	for _, f := range findings {
-		fmt.Fprintf(os.Stderr, "%s\t%s\t%s\tgot=%s\twant=%s\n", f.Language, f.Axis, f.Metric, f.Got, f.Want)
+		fmt.Fprintf(os.Stderr, "%s\t%s\t%s\t%s\tgot=%s\twant=%s\n", f.Language, f.Path, f.Axis, f.Metric, f.Got, f.Want)
 	}
 }
 

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -137,6 +137,26 @@ func TestCompareScoreboardKeepsLegacyRatchetComparisonWithoutHardGate(t *testing
 	}
 }
 
+func TestCompareScoreboardHardGateOnlyUsesUniversalUnexcludedBasis(t *testing.T) {
+	b := testBudget()
+	b.MeasurementBasis.ExcludePaths = []string{"groovy/heldout.groovy"}
+	lang := b.Languages["go"]
+	lang.FullAxis.MaxRatioByTotal = 1
+	b.Languages["go"] = lang
+	s := testScoreboard(2.5, 0, 0)
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true, HardGateOnly: true})
+	if len(findings) != 0 {
+		t.Fatalf("hard-gate-only comparison applied historical basis or ratchet: %#v", findings)
+	}
+
+	s.Config.ExcludePaths = []string{"groovy/heldout.groovy"}
+	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true, HardGateOnly: true})
+	if got := renderFindingKeys(findings); !strings.Contains(got, "::config.exclude_paths") {
+		t.Fatalf("hard-gate-only comparison accepted an exclusion: %q (%#v)", got, findings)
+	}
+}
+
 func TestCompareScoreboardReportsExcludePathConfigMismatch(t *testing.T) {
 	b := testBudget()
 	b.MeasurementBasis.ExcludePaths = []string{"d/compiler/src/dmd/expressionsem.d"}

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -19,7 +19,7 @@ func TestValidateBudgetAcceptsCurrentFile(t *testing.T) {
 
 func TestCompareScoreboardPassesWithinBudget(t *testing.T) {
 	b := testBudget()
-	s := testScoreboard(2.5, 1, 1)
+	s := testScoreboard(2.5, 0, 0)
 
 	findings := compareScoreboard(b, s, compareOptions{
 		RequireAllBudgetLangs: true,
@@ -69,6 +69,45 @@ func TestCompareScoreboardReportsMedianRatioRegression(t *testing.T) {
 	}
 }
 
+func TestCompareScoreboardEnforcesExactPerFileFullRatio(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(1.5, 0, 0)
+	full := s.Languages[0].Files[0].Axes[axisFull]
+	full.GoMedianNs = 10_001
+	full.CMedianNs = 1_000
+	full.Ratio = 10.001
+	s.Languages[0].Files[0].Axes[axisFull] = full
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:hard_full_ratio") {
+		t.Fatalf("findings %q missing per-file >10x failure (%#v)", got, findings)
+	}
+
+	full.GoMedianNs = 10_000
+	full.Ratio = 10
+	s.Languages[0].Files[0].Axes[axisFull] = full
+	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	if got := renderFindingKeys(findings); strings.Contains(got, "hard_full_ratio") {
+		t.Fatalf("exactly 10x must pass the hard ratio boundary: %q (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardRejectsStructuredParserBudgetStop(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(1.5, 0, 0)
+	full := s.Languages[0].Files[0].Axes[axisFull]
+	full.Status = "go_budget_stop"
+	full.Stop = &scoreboardStop{Class: "parser_budget", Reason: "memory_budget", Implementation: "go"}
+	s.Languages[0].Files[0].Axes[axisFull] = full
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:hard_go_stop") {
+		t.Fatalf("findings %q missing structured parser-budget failure (%#v)", got, findings)
+	}
+}
+
 func TestCompareScoreboardReportsStrictConfigMismatch(t *testing.T) {
 	b := testBudget()
 	s := testScoreboard(2.5, 0, 0)
@@ -78,6 +117,23 @@ func TestCompareScoreboardReportsStrictConfigMismatch(t *testing.T) {
 	got := renderFindingKeys(findings)
 	if !strings.Contains(got, "::config.reps") {
 		t.Fatalf("findings %q missing config reps failure (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardKeepsLegacyRatchetComparisonWithoutHardGate(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Config.HardGate = false
+	s.Gate = nil
+	// Legacy v1 rows did not need the exact per-file timing fields now used by
+	// the hard gate. Aggregate ratchets must remain comparable when strict
+	// config is explicitly disabled for historical analysis.
+	s.Languages[0].Files[0].Axes[axisFull] = scoreboardFileAxis{Status: statusOK}
+	s.Languages[0].Files[0].Axes[axisNoEdit] = scoreboardFileAxis{Status: statusOK}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: false})
+	if len(findings) != 0 {
+		t.Fatalf("legacy ratchet comparison unexpectedly applied hard semantics: %#v", findings)
 	}
 }
 
@@ -130,7 +186,7 @@ func TestCompareScoreboardReportsCReferenceFailure(t *testing.T) {
 	}
 }
 
-func TestCompareScoreboardAllowsExplicitCReferenceFailureBudget(t *testing.T) {
+func TestCompareScoreboardRejectsMissingFullRatioDespiteHistoricalCFailureBudget(t *testing.T) {
 	b := testBudget()
 	lang := b.Languages["go"]
 	lang.FullAxis.MaxCReferenceFailures = intPtr(1)
@@ -140,32 +196,37 @@ func TestCompareScoreboardAllowsExplicitCReferenceFailureBudget(t *testing.T) {
 	s.Languages[0].Files[0].Axes[axisFull] = scoreboardFileAxis{Status: "c_timeout"}
 
 	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
-	if len(findings) != 0 {
-		t.Fatalf("explicit C-reference failure budget should pass: %#v", findings)
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:hard_full_measurement") {
+		t.Fatalf("hard gate must reject a missing full ratio despite the historical allowance: %q (%#v)", got, findings)
+	}
+	if strings.Contains(got, "go:full:c_reference_failures") {
+		t.Fatalf("historical C-reference allowance should still suppress the ratchet finding: %q (%#v)", got, findings)
 	}
 }
 
-func TestCompareScoreboardCountsDefensiveTruncationStatus(t *testing.T) {
+func TestCompareScoreboardKeepsCorrectnessFailureSeparateFromRatioGate(t *testing.T) {
 	b := testBudget()
 	s := testScoreboard(2.5, 0, 0)
 	s.Languages[0].Files[0].Axes[axisFull] = scoreboardFileAxis{Status: "go_truncated"}
 
 	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
-	if len(findings) != 0 {
-		t.Fatalf("one truncation should be within the explicit full-axis budget: %#v", findings)
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:hard_full_measurement") {
+		t.Fatalf("findings %q missing fail-closed full measurement (%#v)", got, findings)
 	}
 
 	lang := b.Languages["go"]
 	lang.FullAxis.MaxErrors = intPtr(0)
 	b.Languages["go"] = lang
 	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true})
-	got := renderFindingKeys(findings)
+	got = renderFindingKeys(findings)
 	if !strings.Contains(got, "go:full:go_errors") {
 		t.Fatalf("findings %q missing go_truncated error accounting (%#v)", got, findings)
 	}
 }
 
-func TestCompareScoreboardAllowsAllTimeoutsWithinBudget(t *testing.T) {
+func TestCompareScoreboardRejectsTimeoutsDespiteHistoricalBudget(t *testing.T) {
 	b := testBudget()
 	lang := b.Languages["go"]
 	lang.FullAxis.MaxTimeouts = 2
@@ -187,8 +248,9 @@ func TestCompareScoreboardAllowsAllTimeoutsWithinBudget(t *testing.T) {
 	}
 
 	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
-	if len(findings) != 0 {
-		t.Fatalf("all-timeout budget should pass when timeouts stay within budget: %#v", findings)
+	got := renderFindingKeys(findings)
+	if !strings.Contains(got, "go:full:hard_go_stop") || !strings.Contains(got, "go:noedit:hard_go_stop") {
+		t.Fatalf("hard gate must reject timeout allowances, got %q (%#v)", got, findings)
 	}
 }
 
@@ -212,8 +274,10 @@ func TestCompareScoreboardReportsUnknownBudgetLanguage(t *testing.T) {
 	b := testBudget()
 	s := testScoreboard(2.5, 0, 0)
 	s.Languages = append(s.Languages, scoreboardLang{
-		Language: "unknown",
-		Status:   statusOK,
+		Language:      "unknown",
+		Status:        statusOK,
+		FilesSelected: 1,
+		FilesMeasured: 1,
 		Axes: map[string]scoreboardAxis{
 			axisFull:   {FilesOK: 1, RatioByTotal: 1},
 			axisNoEdit: {FilesOK: 1, RatioByTotal: 1},
@@ -231,6 +295,51 @@ func TestCompareScoreboardReportsUnknownBudgetLanguage(t *testing.T) {
 	}
 }
 
+func TestCompareScoreboardAllowsUnbudgetedLanguageInAuthenticatedFleetGate(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Config.RequireFleet = true
+	s.Corpus = scoreboardCorpus{
+		LockSHA256:        strings.Repeat("a", 64),
+		LockLanguages:     2,
+		SelectedLanguages: 2,
+	}
+	s.Languages = append(s.Languages, scoreboardLang{
+		Language:      "unbudgeted",
+		Status:        statusOK,
+		FilesSelected: 1,
+		FilesMeasured: 1,
+		Axes: map[string]scoreboardAxis{
+			axisFull:   {FilesOK: 1, RatioByTotal: 1},
+			axisNoEdit: {FilesOK: 1, RatioByTotal: 0.1},
+		},
+		Files: []scoreboardFileRow{{Path: "x", Axes: map[string]scoreboardFileAxis{
+			axisFull:   {Status: statusOK, GoMedianNs: 1000, CMedianNs: 1000, Ratio: 1},
+			axisNoEdit: {Status: statusOK, GoMedianNs: 100, CMedianNs: 1000, Ratio: 0.1},
+		}}},
+	})
+	s.Gate.FilesExpected = 2
+	s.Gate.FilesMeasured = 2
+	s.Gate.FullFilesEvaluated = 2
+
+	findings := compareScoreboard(b, s, compareOptions{RequireAllBudgetLangs: true, StrictConfig: true})
+	if got := renderFindingKeys(findings); strings.Contains(got, "unbudgeted::budget") {
+		t.Fatalf("authenticated fleet hard gate must admit languages without historical ratchets: %q (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardRejectsIncompleteFleetCoverage(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(2.5, 0, 0)
+	s.Config.RequireFleet = true
+	s.Corpus = scoreboardCorpus{LockLanguages: 2, SelectedLanguages: 1}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true})
+	if got := renderFindingKeys(findings); !strings.Contains(got, "::hard_fleet_coverage") {
+		t.Fatalf("findings %q missing fail-closed fleet coverage failure (%#v)", got, findings)
+	}
+}
+
 func TestMainWritesMarkdownSummary(t *testing.T) {
 	dir := t.TempDir()
 	budgetPath := filepath.Join(dir, "budget.json")
@@ -239,7 +348,7 @@ func TestMainWritesMarkdownSummary(t *testing.T) {
 
 	writeFile(t, budgetPath, `{
   "schema": "gts-perf-ratio-budgets/v1",
-  "measurement_basis": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"]},
+  "measurement_basis": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"], "hard_max_full_parse_ratio": 10, "fast_full_parse_ratio": 0.1, "corpus_lock_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
   "languages": {
     "go": {
       "status": "green",
@@ -250,15 +359,19 @@ func TestMainWritesMarkdownSummary(t *testing.T) {
 }`)
 	writeFile(t, scoreboardPath, `{
   "schema": "gts-perf-scan/v1",
-  "config": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"]},
+  "config": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"], "hard_gate": true, "corpus_lock_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+  "corpus_coverage": {"lock_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "lock_languages": 1, "selected_languages": 1},
+  "hard_gate": {"status": "pass", "max_full_parse_ratio": 10, "fast_full_parse_ratio": 0.1, "files_expected": 1, "files_measured": 1, "full_files_evaluated": 1},
   "languages": [{
     "language": "go",
     "status": "ok",
+    "files_selected": 1,
+    "files_measured": 1,
     "axes": {
       "full": {"files_ok": 1, "ratio_by_total": 1.5, "ratio_median_of_files": 1.5, "go_timeouts": 0},
       "noedit": {"files_ok": 1, "ratio_by_total": 0.1, "ratio_median_of_files": 0.1, "go_timeouts": 0}
     },
-    "files": [{"path": "x.go", "axes": {"full": {"status": "ok"}, "noedit": {"status": "ok"}}}]
+    "files": [{"path": "x.go", "axes": {"full": {"status": "ok", "go_median_ns": 1500, "c_median_ns": 1000, "ratio": 1.5}, "noedit": {"status": "ok", "go_median_ns": 100, "c_median_ns": 1000, "ratio": 0.1}}}]
   }]
 }`)
 
@@ -290,12 +403,15 @@ func testBudget() *budgetFile {
 	return &budgetFile{
 		Schema: budgetSchema,
 		MeasurementBasis: budgetMeasurementBasis{
-			Reps:         5,
-			Warmup:       1,
-			FileBudgetMS: 10000,
-			MaxFiles:     8,
-			Order:        "largest",
-			Axes:         []string{axisFull, axisNoEdit},
+			Reps:                  5,
+			Warmup:                1,
+			FileBudgetMS:          10000,
+			MaxFiles:              8,
+			Order:                 "largest",
+			Axes:                  []string{axisFull, axisNoEdit},
+			HardMaxFullParseRatio: hardMaxFullParseRatio,
+			FastFullParseRatio:    fastFullParseRatio,
+			CorpusLockSHA256:      strings.Repeat("a", 64),
 		},
 		Languages: map[string]budgetLang{
 			"go": {
@@ -317,8 +433,8 @@ func testBudget() *budgetFile {
 func testScoreboard(fullRatio float64, timeouts, errors int) *scoreboardFile {
 	files := []scoreboardFileRow{
 		{Path: "ok.go", Axes: map[string]scoreboardFileAxis{
-			axisFull:   {Status: statusOK},
-			axisNoEdit: {Status: statusOK},
+			axisFull:   {Status: statusOK, GoMedianNs: int64(fullRatio * 1000), CMedianNs: 1000, Ratio: fullRatio},
+			axisNoEdit: {Status: statusOK, GoMedianNs: 100, CMedianNs: 1000, Ratio: 0.1},
 		}},
 	}
 	for i := 0; i < timeouts; i++ {
@@ -336,16 +452,25 @@ func testScoreboard(fullRatio float64, timeouts, errors int) *scoreboardFile {
 	return &scoreboardFile{
 		Schema: scoreboardSchema,
 		Config: scoreboardConfig{
-			Reps:         5,
-			Warmup:       1,
-			FileBudgetMS: 10000,
-			MaxFiles:     8,
-			Order:        "largest",
-			Axes:         []string{axisFull, axisNoEdit},
+			Reps:             5,
+			Warmup:           1,
+			FileBudgetMS:     10000,
+			MaxFiles:         8,
+			Order:            "largest",
+			Axes:             []string{axisFull, axisNoEdit},
+			HardGate:         true,
+			CorpusLockSHA256: strings.Repeat("a", 64),
+		},
+		Corpus: scoreboardCorpus{
+			LockSHA256:        strings.Repeat("a", 64),
+			LockLanguages:     1,
+			SelectedLanguages: 1,
 		},
 		Languages: []scoreboardLang{{
-			Language: "go",
-			Status:   statusOK,
+			Language:      "go",
+			Status:        statusOK,
+			FilesSelected: len(files),
+			FilesMeasured: len(files),
 			Axes: map[string]scoreboardAxis{
 				axisFull: {
 					FilesOK:            1,
@@ -362,6 +487,14 @@ func testScoreboard(fullRatio float64, timeouts, errors int) *scoreboardFile {
 			},
 			Files: files,
 		}},
+		Gate: &scoreboardGate{
+			Status:             "pass",
+			MaxFullParseRatio:  hardMaxFullParseRatio,
+			FastFullParseRatio: fastFullParseRatio,
+			FilesExpected:      len(files),
+			FilesMeasured:      len(files),
+			FullFilesEvaluated: len(files),
+		},
 	}
 }
 

--- a/cgo_harness/cmd/perf_scan_status/main.go
+++ b/cgo_harness/cmd/perf_scan_status/main.go
@@ -39,13 +39,16 @@ type budgetFile struct {
 }
 
 type measurementBasis struct {
-	Reps         int      `json:"reps"`
-	Warmup       int      `json:"warmup"`
-	FileBudgetMS int      `json:"file_budget_ms"`
-	MaxFiles     int      `json:"max_files,omitempty"`
-	Order        string   `json:"order,omitempty"`
-	Axes         []string `json:"axes"`
-	ExcludePaths []string `json:"exclude_paths,omitempty"`
+	Reps                  int      `json:"reps"`
+	Warmup                int      `json:"warmup"`
+	FileBudgetMS          int      `json:"file_budget_ms"`
+	MaxFiles              int      `json:"max_files,omitempty"`
+	Order                 string   `json:"order,omitempty"`
+	Axes                  []string `json:"axes"`
+	ExcludePaths          []string `json:"exclude_paths,omitempty"`
+	HardMaxFullParseRatio float64  `json:"hard_max_full_parse_ratio,omitempty"`
+	FastFullParseRatio    float64  `json:"fast_full_parse_ratio,omitempty"`
+	CorpusLockSHA256      string   `json:"corpus_lock_sha256,omitempty"`
 }
 
 type knownBudgetGap struct {
@@ -109,20 +112,25 @@ type scoreboardFile struct {
 	Host        scoreboardHost       `json:"host"`
 	Languages   []scoreboardLanguage `json:"languages"`
 	Summary     map[string]int       `json:"summary_verdicts"`
+	Corpus      scoreboardCorpus     `json:"corpus_coverage"`
+	Gate        *scoreboardGate      `json:"hard_gate,omitempty"`
 	SourcePath  string               `json:"-"`
 }
 
 type scoreboardConfig struct {
-	Reps          int      `json:"reps"`
-	Warmup        int      `json:"warmup"`
-	FileBudgetMS  int      `json:"file_budget_ms"`
-	LangTimeoutMS int      `json:"lang_timeout_ms"`
-	MaxFiles      int      `json:"max_files"`
-	Order         string   `json:"order"`
-	Axes          []string `json:"axes"`
-	ExcludePaths  []string `json:"exclude_paths,omitempty"`
-	Contended     bool     `json:"contended"`
-	ContendedNote string   `json:"contended_note,omitempty"`
+	Reps             int      `json:"reps"`
+	Warmup           int      `json:"warmup"`
+	FileBudgetMS     int      `json:"file_budget_ms"`
+	LangTimeoutMS    int      `json:"lang_timeout_ms"`
+	MaxFiles         int      `json:"max_files"`
+	Order            string   `json:"order"`
+	Axes             []string `json:"axes"`
+	ExcludePaths     []string `json:"exclude_paths,omitempty"`
+	Contended        bool     `json:"contended"`
+	ContendedNote    string   `json:"contended_note,omitempty"`
+	HardGate         bool     `json:"hard_gate"`
+	RequireFleet     bool     `json:"require_fleet"`
+	CorpusLockSHA256 string   `json:"corpus_lock_sha256,omitempty"`
 }
 
 type scoreboardHost struct {
@@ -138,35 +146,108 @@ type scoreboardLanguage struct {
 	BytesMeasured int64                     `json:"bytes_measured"`
 	Verdict       string                    `json:"verdict"`
 	Axes          map[string]scoreboardAxis `json:"axes"`
+	Files         []scoreboardFileRow       `json:"files,omitempty"`
+	ActiveFile    string                    `json:"active_file,omitempty"`
+	ActiveAxis    string                    `json:"active_axis,omitempty"`
+	Stop          *scoreboardStop           `json:"stop,omitempty"`
 }
 
 type scoreboardAxis struct {
 	FilesOK            int     `json:"files_ok"`
 	GoTimeouts         int     `json:"go_timeouts"`
+	GoStops            int     `json:"go_stops"`
 	Cliffs             int     `json:"cliffs"`
 	RatioByTotal       float64 `json:"ratio_by_total"`
 	RatioMedianOfFiles float64 `json:"ratio_median_of_files"`
 	Verdict            string  `json:"verdict"`
 }
 
+type scoreboardFileRow struct {
+	Path string                        `json:"path"`
+	Axes map[string]scoreboardFileAxis `json:"axes"`
+}
+
+type scoreboardFileAxis struct {
+	Status     string          `json:"status"`
+	Detail     string          `json:"detail,omitempty"`
+	GoMedianNs int64           `json:"go_median_ns,omitempty"`
+	CMedianNs  int64           `json:"c_median_ns,omitempty"`
+	Ratio      float64         `json:"ratio,omitempty"`
+	Stop       *scoreboardStop `json:"stop,omitempty"`
+}
+
+type scoreboardStop struct {
+	Class          string `json:"class"`
+	Reason         string `json:"reason,omitempty"`
+	Implementation string `json:"implementation,omitempty"`
+	Phase          string `json:"phase,omitempty"`
+	Attempt        int    `json:"attempt,omitempty"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+type scoreboardCorpus struct {
+	LockPath            string   `json:"lock_path,omitempty"`
+	LockSHA256          string   `json:"lock_sha256,omitempty"`
+	LockLanguages       int      `json:"lock_languages"`
+	SelectedLanguages   int      `json:"selected_languages"`
+	MissingFromLock     []string `json:"missing_from_lock,omitempty"`
+	MissingFromRegistry []string `json:"missing_from_registry,omitempty"`
+}
+
+type scoreboardGateFinding struct {
+	Kind     string          `json:"kind"`
+	Language string          `json:"language,omitempty"`
+	Path     string          `json:"path,omitempty"`
+	Axis     string          `json:"axis,omitempty"`
+	Status   string          `json:"status,omitempty"`
+	Ratio    float64         `json:"ratio,omitempty"`
+	Limit    float64         `json:"limit,omitempty"`
+	Stop     *scoreboardStop `json:"stop,omitempty"`
+	Detail   string          `json:"detail,omitempty"`
+}
+
+type scoreboardGate struct {
+	Status             string                  `json:"status"`
+	MaxFullParseRatio  float64                 `json:"max_full_parse_ratio"`
+	FastFullParseRatio float64                 `json:"fast_full_parse_ratio"`
+	FilesExpected      int                     `json:"files_expected"`
+	FilesMeasured      int                     `json:"files_measured"`
+	FullFilesEvaluated int                     `json:"full_files_evaluated"`
+	FastFullFiles      []scoreboardGateFinding `json:"fast_full_files,omitempty"`
+	Failures           []scoreboardGateFinding `json:"failures,omitempty"`
+}
+
 type statusDocument struct {
-	Schema             string              `json:"schema"`
-	GeneratedAt        string              `json:"generated_at"`
-	BudgetPath         string              `json:"budget_path"`
-	FleetPath          string              `json:"fleet_path,omitempty"`
-	BudgetGeneratedAt  string              `json:"budget_generated_at"`
-	BudgetGeneratedBy  string              `json:"budget_generated_by"`
-	MeasurementBasis   measurementBasis    `json:"measurement_basis"`
-	Coverage           coverageSummary     `json:"coverage"`
-	HeldOutLanguages   []string            `json:"held_out_languages"`
-	BudgetStatusCounts map[string]int      `json:"budget_status_counts"`
-	SeedSources        []string            `json:"seed_sources"`
-	KnownGaps          []knownGapSummary   `json:"known_budget_class_gaps"`
-	ScoreboardPatterns []string            `json:"scoreboard_patterns,omitempty"`
-	ScoreboardCoverage *scoreboardCoverage `json:"scoreboard_coverage,omitempty"`
-	Scoreboards        []scoreboardSummary `json:"scoreboards,omitempty"`
-	MeasuredLanguages  []measuredLanguage  `json:"measured_languages,omitempty"`
-	Caveats            []string            `json:"caveats"`
+	Schema             string               `json:"schema"`
+	GeneratedAt        string               `json:"generated_at"`
+	BudgetPath         string               `json:"budget_path"`
+	FleetPath          string               `json:"fleet_path,omitempty"`
+	BudgetGeneratedAt  string               `json:"budget_generated_at"`
+	BudgetGeneratedBy  string               `json:"budget_generated_by"`
+	MeasurementBasis   measurementBasis     `json:"measurement_basis"`
+	Coverage           coverageSummary      `json:"coverage"`
+	HeldOutLanguages   []string             `json:"held_out_languages"`
+	BudgetStatusCounts map[string]int       `json:"budget_status_counts"`
+	SeedSources        []string             `json:"seed_sources"`
+	KnownGaps          []knownGapSummary    `json:"known_budget_class_gaps"`
+	ScoreboardPatterns []string             `json:"scoreboard_patterns,omitempty"`
+	ScoreboardCoverage *scoreboardCoverage  `json:"scoreboard_coverage,omitempty"`
+	Scoreboards        []scoreboardSummary  `json:"scoreboards,omitempty"`
+	MeasuredLanguages  []measuredLanguage   `json:"measured_languages,omitempty"`
+	HardGateFailures   []gateFindingSummary `json:"hard_gate_failures,omitempty"`
+	FastFullFiles      []gateFindingSummary `json:"fast_full_parse_files,omitempty"`
+	Caveats            []string             `json:"caveats"`
+}
+
+type gateFindingSummary struct {
+	SourcePath string  `json:"source_path"`
+	Kind       string  `json:"kind"`
+	Language   string  `json:"language,omitempty"`
+	Path       string  `json:"path,omitempty"`
+	Axis       string  `json:"axis,omitempty"`
+	Status     string  `json:"status,omitempty"`
+	Ratio      float64 `json:"ratio,omitempty"`
+	Detail     string  `json:"detail,omitempty"`
 }
 
 type coverageSummary struct {
@@ -193,6 +274,11 @@ type scoreboardCoverage struct {
 	MeasuredLanguages        int      `json:"measured_languages"`
 	MeasuredBudgetLanguages  int      `json:"measured_budget_languages"`
 	MeasuredHeldOutLanguages []string `json:"measured_held_out_languages,omitempty"`
+	HardGateScoreboards      int      `json:"hard_gate_scoreboards"`
+	HardGatePasses           int      `json:"hard_gate_passes"`
+	HardGateFailures         int      `json:"hard_gate_failures"`
+	LegacyScoreboards        int      `json:"legacy_scoreboards"`
+	FastFullParseFiles       int      `json:"fast_full_parse_files"`
 }
 
 type scoreboardSummary struct {
@@ -207,6 +293,12 @@ type scoreboardSummary struct {
 	LoadAvgStart     string         `json:"loadavg_start,omitempty"`
 	LoadAvgEnd       string         `json:"loadavg_end,omitempty"`
 	SummaryVerdicts  map[string]int `json:"summary_verdicts,omitempty"`
+	HardGateStatus   string         `json:"hard_gate_status"`
+	HardGateFailures int            `json:"hard_gate_failures"`
+	FullFilesChecked int            `json:"full_files_checked"`
+	FastFullFiles    int            `json:"fast_full_files"`
+	RequireFleet     bool           `json:"require_fleet"`
+	CorpusLockSHA256 string         `json:"corpus_lock_sha256,omitempty"`
 }
 
 type measuredLanguage struct {
@@ -226,6 +318,7 @@ type measuredLanguage struct {
 type axisSummary struct {
 	FilesOK            int     `json:"files_ok"`
 	GoTimeouts         int     `json:"go_timeouts"`
+	GoStops            int     `json:"go_stops"`
 	Cliffs             int     `json:"cliffs"`
 	RatioByTotal       float64 `json:"ratio_by_total"`
 	RatioMedianOfFiles float64 `json:"ratio_median_of_files"`
@@ -341,12 +434,15 @@ func buildStatus(opts options) (*statusDocument, error) {
 			return nil, err
 		}
 		doc.ScoreboardPatterns = patterns
-		doc.Scoreboards, doc.MeasuredLanguages, doc.ScoreboardCoverage, err = summarizeScoreboards(paths, budgetSet, setFromList(heldOut))
+		doc.Scoreboards, doc.MeasuredLanguages, doc.ScoreboardCoverage, doc.HardGateFailures, doc.FastFullFiles, err = summarizeScoreboards(paths, budgetSet, setFromList(heldOut))
 		if err != nil {
 			return nil, err
 		}
 		if doc.ScoreboardCoverage.ContendedScoreboards > 0 {
 			doc.Caveats = append(doc.Caveats, "At least one local scoreboard was harness-flagged as contended; treat those ratios as smoke or visibility evidence rather than quiet-box ratchets.")
+		}
+		if doc.ScoreboardCoverage.LegacyScoreboards > 0 {
+			doc.Caveats = append(doc.Caveats, "Legacy scoreboards remain readable, but they predate the structured hard-gate report and are shown as not_evaluated; rerun the harness for a fail-closed verdict.")
 		}
 	}
 
@@ -416,14 +512,15 @@ func expandGlobs(patterns []string) ([]string, error) {
 	return out, nil
 }
 
-func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet map[string]bool) ([]scoreboardSummary, []measuredLanguage, *scoreboardCoverage, error) {
+func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet map[string]bool) ([]scoreboardSummary, []measuredLanguage, *scoreboardCoverage, []gateFindingSummary, []gateFindingSummary, error) {
 	var summaries []scoreboardSummary
 	measured := map[string]measuredLanguage{}
-	var contended int
+	var contended, hardGateBoards, hardGatePasses, hardGateFailures, legacyBoards, fastFiles int
+	var failureFindings, fastFindings []gateFindingSummary
 	for _, path := range paths {
 		board, err := loadScoreboard(path)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, nil, err
 		}
 		budgetLangs := 0
 		var heldOut []string
@@ -451,6 +548,31 @@ func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet 
 		if board.Config.Contended {
 			contended++
 		}
+		gateStatus := "not_evaluated"
+		gateFailureCount := 0
+		fullFilesChecked := 0
+		fastFullFiles := 0
+		if board.Gate == nil {
+			legacyBoards++
+		} else {
+			hardGateBoards++
+			gateStatus = board.Gate.Status
+			gateFailureCount = len(board.Gate.Failures)
+			fullFilesChecked = board.Gate.FullFilesEvaluated
+			fastFullFiles = len(board.Gate.FastFullFiles)
+			fastFiles += fastFullFiles
+			if strings.EqualFold(board.Gate.Status, "pass") {
+				hardGatePasses++
+			} else {
+				hardGateFailures++
+			}
+			for _, finding := range board.Gate.Failures {
+				failureFindings = append(failureFindings, summarizeGateFinding(path, finding))
+			}
+			for _, finding := range board.Gate.FastFullFiles {
+				fastFindings = append(fastFindings, summarizeGateFinding(path, finding))
+			}
+		}
 		summaries = append(summaries, scoreboardSummary{
 			Path:             path,
 			GeneratedAt:      board.GeneratedAt,
@@ -463,6 +585,12 @@ func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet 
 			LoadAvgStart:     board.Host.LoadAvgStart,
 			LoadAvgEnd:       board.Host.LoadAvgEnd,
 			SummaryVerdicts:  board.Summary,
+			HardGateStatus:   gateStatus,
+			HardGateFailures: gateFailureCount,
+			FullFilesChecked: fullFilesChecked,
+			FastFullFiles:    fastFullFiles,
+			RequireFleet:     board.Config.RequireFleet,
+			CorpusLockSHA256: board.Corpus.LockSHA256,
 		})
 	}
 	measuredList := make([]measuredLanguage, 0, len(measured))
@@ -486,8 +614,47 @@ func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet 
 		MeasuredLanguages:        len(measuredList),
 		MeasuredBudgetLanguages:  measuredBudget,
 		MeasuredHeldOutLanguages: sortedKeysBool(measuredHeldOut),
+		HardGateScoreboards:      hardGateBoards,
+		HardGatePasses:           hardGatePasses,
+		HardGateFailures:         hardGateFailures,
+		LegacyScoreboards:        legacyBoards,
+		FastFullParseFiles:       fastFiles,
 	}
-	return summaries, measuredList, coverage, nil
+	sortGateFindings(failureFindings)
+	sortGateFindings(fastFindings)
+	return summaries, measuredList, coverage, failureFindings, fastFindings, nil
+}
+
+func summarizeGateFinding(sourcePath string, finding scoreboardGateFinding) gateFindingSummary {
+	return gateFindingSummary{
+		SourcePath: sourcePath,
+		Kind:       finding.Kind,
+		Language:   finding.Language,
+		Path:       finding.Path,
+		Axis:       finding.Axis,
+		Status:     finding.Status,
+		Ratio:      finding.Ratio,
+		Detail:     finding.Detail,
+	}
+}
+
+func sortGateFindings(findings []gateFindingSummary) {
+	sort.Slice(findings, func(i, j int) bool {
+		a, b := findings[i], findings[j]
+		if a.SourcePath != b.SourcePath {
+			return a.SourcePath < b.SourcePath
+		}
+		if a.Language != b.Language {
+			return a.Language < b.Language
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		if a.Axis != b.Axis {
+			return a.Axis < b.Axis
+		}
+		return a.Kind < b.Kind
+	})
 }
 
 func loadScoreboard(path string) (*scoreboardFile, error) {
@@ -512,6 +679,7 @@ func summarizeAxes(in map[string]scoreboardAxis) map[string]axisSummary {
 		out[axis] = axisSummary{
 			FilesOK:            row.FilesOK,
 			GoTimeouts:         row.GoTimeouts,
+			GoStops:            row.GoStops,
 			Cliffs:             row.Cliffs,
 			RatioByTotal:       row.RatioByTotal,
 			RatioMedianOfFiles: row.RatioMedianOfFiles,
@@ -556,6 +724,12 @@ func renderMarkdown(doc *statusDocument) string {
 		doc.MeasurementBasis.MaxFiles,
 		mdInline(doc.MeasurementBasis.Order),
 		mdInline(strings.Join(doc.MeasurementBasis.Axes, ",")))
+	if doc.MeasurementBasis.HardMaxFullParseRatio > 0 {
+		fmt.Fprintf(&sb, "Hard full-parse ceiling: every measured file must be `<=%.1fx`; full-parse files at `<=%.2fx` are reported separately as 10x-or-better wins. Corpus lock SHA-256: `%s`.\n\n",
+			doc.MeasurementBasis.HardMaxFullParseRatio,
+			doc.MeasurementBasis.FastFullParseRatio,
+			mdInline(doc.MeasurementBasis.CorpusLockSHA256))
+	}
 
 	if len(doc.MeasurementBasis.ExcludePaths) > 0 {
 		fmt.Fprintf(&sb, "Excluded paths: `%s`.\n\n", strings.Join(doc.MeasurementBasis.ExcludePaths, "`, `"))
@@ -614,20 +788,46 @@ func renderScoreboardMarkdown(sb *strings.Builder, doc *statusDocument) {
 	fmt.Fprintf(sb, "| contended scoreboards | %d |\n", doc.ScoreboardCoverage.ContendedScoreboards)
 	fmt.Fprintf(sb, "| measured languages | %d |\n", doc.ScoreboardCoverage.MeasuredLanguages)
 	fmt.Fprintf(sb, "| measured budget languages | %d |\n", doc.ScoreboardCoverage.MeasuredBudgetLanguages)
+	fmt.Fprintf(sb, "| structured hard-gate scoreboards | %d |\n", doc.ScoreboardCoverage.HardGateScoreboards)
+	fmt.Fprintf(sb, "| hard-gate passes | %d |\n", doc.ScoreboardCoverage.HardGatePasses)
+	fmt.Fprintf(sb, "| hard-gate failures | %d |\n", doc.ScoreboardCoverage.HardGateFailures)
+	fmt.Fprintf(sb, "| legacy/not-evaluated scoreboards | %d |\n", doc.ScoreboardCoverage.LegacyScoreboards)
+	fmt.Fprintf(sb, "| full-parse files at least 10x faster than C | %d |\n", doc.ScoreboardCoverage.FastFullParseFiles)
 	fmt.Fprintf(sb, "\n")
 
-	fmt.Fprintf(sb, "| scoreboard | languages | budgeted | contended | loadavg_start | verdicts |\n")
-	fmt.Fprintf(sb, "|---|---:|---:|---|---|---|\n")
+	fmt.Fprintf(sb, "| scoreboard | languages | budgeted | hard gate | failures | full files | fast files | contended | verdicts |\n")
+	fmt.Fprintf(sb, "|---|---:|---:|---|---:|---:|---:|---|---|\n")
 	for _, row := range doc.Scoreboards {
-		fmt.Fprintf(sb, "| `%s` | %d | %d | `%t` | `%s` | %s |\n",
+		fmt.Fprintf(sb, "| `%s` | %d | %d | `%s` | %d | %d | %d | `%t` | %s |\n",
 			mdCell(row.Path),
 			row.Languages,
 			row.BudgetLanguages,
+			mdCell(row.HardGateStatus),
+			row.HardGateFailures,
+			row.FullFilesChecked,
+			row.FastFullFiles,
 			row.Contended,
-			mdCell(row.LoadAvgStart),
 			mdCell(formatIntMap(row.SummaryVerdicts)))
 	}
 	fmt.Fprintf(sb, "\n")
+
+	if len(doc.HardGateFailures) > 0 {
+		fmt.Fprintf(sb, "### Hard-gate failures\n\n")
+		for _, finding := range doc.HardGateFailures {
+			fmt.Fprintf(sb, "- `%s` **%s** `%s` axis=%s kind=%s status=%s ratio=%.4fx — %s\n",
+				mdInline(finding.SourcePath), finding.Language, finding.Path, finding.Axis,
+				finding.Kind, finding.Status, finding.Ratio, finding.Detail)
+		}
+		fmt.Fprintf(sb, "\n")
+	}
+	if len(doc.FastFullFiles) > 0 {
+		fmt.Fprintf(sb, "### Full-parse files at least 10x faster than C\n\n")
+		for _, finding := range doc.FastFullFiles {
+			fmt.Fprintf(sb, "- `%s` **%s** `%s` ratio=%.4fx — %s\n",
+				mdInline(finding.SourcePath), finding.Language, finding.Path, finding.Ratio, finding.Detail)
+		}
+		fmt.Fprintf(sb, "\n")
+	}
 }
 
 func summarizeKnownGaps(gaps map[string]knownBudgetGap) []knownGapSummary {

--- a/cgo_harness/cmd/perf_scan_status/main_test.go
+++ b/cgo_harness/cmd/perf_scan_status/main_test.go
@@ -168,8 +168,81 @@ func TestBuildStatusWithScoreboards(t *testing.T) {
 	if doc.ScoreboardCoverage.ContendedScoreboards != 1 {
 		t.Fatalf("contended scoreboards = %d, want 1", doc.ScoreboardCoverage.ContendedScoreboards)
 	}
+	if doc.ScoreboardCoverage.LegacyScoreboards != 1 || doc.Scoreboards[0].HardGateStatus != "not_evaluated" {
+		t.Fatalf("legacy scoreboard accounting = %+v / %+v", doc.ScoreboardCoverage, doc.Scoreboards[0])
+	}
 	if got := strings.Join(doc.Scoreboards[0].ExcludePaths, ","); got != "groovy/large.groovy" {
 		t.Fatalf("scoreboard exclude paths = %q, want groovy/large.groovy", got)
+	}
+}
+
+func TestBuildStatusReportsStructuredHardGateAndFastFiles(t *testing.T) {
+	dir := t.TempDir()
+	budgetPath := filepath.Join(dir, "budget.json")
+	fleetPath := filepath.Join(dir, "exts.tsv")
+	scoreboardPath := filepath.Join(dir, "scoreboard.json")
+	writeFile(t, fleetPath, "go\t.go\n")
+	writeJSON(t, budgetPath, map[string]any{
+		"schema": budgetSchema,
+		"measurement_basis": map[string]any{
+			"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8,
+			"order": "largest", "axes": []string{"full", "noedit"},
+			"hard_max_full_parse_ratio": 10.0, "fast_full_parse_ratio": 0.10,
+			"corpus_lock_sha256": strings.Repeat("a", 64),
+		},
+		"languages": map[string]any{
+			"go": map[string]any{
+				"status":      "green",
+				"full_axis":   map[string]any{"max_timeouts": 0, "max_ratio_by_total": 2.0},
+				"noedit_axis": map[string]any{"max_timeouts": 0, "max_ratio_by_total": 1.0},
+			},
+		},
+	})
+	writeJSON(t, scoreboardPath, map[string]any{
+		"schema": scoreboardSchema,
+		"config": map[string]any{
+			"hard_gate": true, "require_fleet": true,
+			"corpus_lock_sha256": strings.Repeat("a", 64),
+		},
+		"corpus_coverage": map[string]any{
+			"lock_sha256": strings.Repeat("a", 64), "lock_languages": 1, "selected_languages": 1,
+		},
+		"hard_gate": map[string]any{
+			"status": "pass", "max_full_parse_ratio": 10.0, "fast_full_parse_ratio": 0.10,
+			"files_expected": 1, "files_measured": 1, "full_files_evaluated": 1,
+			"fast_full_files": []any{map[string]any{
+				"kind": "fast", "language": "go", "path": "fast.go", "axis": "full",
+				"status": "ok", "ratio": 0.08, "detail": "full parse is 12.50x faster than C",
+			}},
+		},
+		"languages": []any{map[string]any{
+			"language": "go", "status": "ok", "files_selected": 1, "files_measured": 1,
+			"verdict": "<=0.10x", "axes": map[string]any{
+				"full": map[string]any{"files_ok": 1, "go_stops": 0, "ratio_by_total": 0.08, "verdict": "<=0.10x"},
+			},
+		}},
+	})
+
+	doc, err := buildStatus(options{
+		BudgetPath:         budgetPath,
+		FleetPath:          fleetPath,
+		ScoreboardPatterns: scoreboardPath,
+		GeneratedAt:        "2026-07-11T20:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("buildStatus returned error: %v", err)
+	}
+	if doc.ScoreboardCoverage.HardGatePasses != 1 || doc.ScoreboardCoverage.HardGateFailures != 0 {
+		t.Fatalf("hard gate accounting = %+v", doc.ScoreboardCoverage)
+	}
+	if doc.ScoreboardCoverage.FastFullParseFiles != 1 || len(doc.FastFullFiles) != 1 {
+		t.Fatalf("fast-file accounting = %+v / %+v", doc.ScoreboardCoverage, doc.FastFullFiles)
+	}
+	md := renderMarkdown(doc)
+	for _, needle := range []string{"hard-gate passes", "Full-parse files at least 10x faster than C", "fast.go"} {
+		if !strings.Contains(md, needle) {
+			t.Fatalf("markdown missing %q:\n%s", needle, md)
+		}
 	}
 }
 

--- a/cgo_harness/perf_scan/CI_PROPOSAL.md
+++ b/cgo_harness/perf_scan/CI_PROPOSAL.md
@@ -1,134 +1,76 @@
-# CI proposal: nightly Go-vs-C perf scoreboard (non-blocking)
+# Scheduled hard zero-cliff gate
 
-Status: PROPOSAL ONLY for the expensive nightly sweep. The fast PR lane only
-validates the checked-in budget schema and the checker unit tests; it does not
-run real-corpus timing. The job below is written as a comment block for the
-coordinator to adopt (or adapt) once the corpus-provisioning question is
-settled.
+The authoritative real-corpus run is a nightly and manually dispatchable hard
+gate on a dedicated `[self-hosted, perf]` runner. The job itself is blocking:
+there is no `continue-on-error`, and a single full-parse ratio above `10.0x`,
+Go parser/resource stop, incomplete locked-corpus row, or unauthenticated
+corpus selection makes the run red.
 
-## Job shape
+This is intentionally not a required check on every pull request. A 206-
+language largest-file fleet sweep needs the external corpus, C-reference build
+cache, multiple GiB of isolated memory, and hours of quiet-box time. The normal
+PR lane instead runs the fast budget/status unit tests and validates the
+checked-in contract. Performance-sensitive changes should use a manually
+dispatched focused run before merge; the next nightly run closes fleet-wide
+coverage.
 
-- Nightly schedule, `continue-on-error: true` end to end — the scoreboard is
-  telemetry, not a gate. Regressions become visible in the uploaded artifact
-  and (optionally) a tracking issue, never a red main.
-- Single dedicated runner, no test parallelism inside the job (`-p 1`, one
-  language subprocess at a time) — timing fidelity requires an uncontended
-  box. The scan auto-marks `contended=true` from loadavg if that assumption
-  breaks, so polluted numbers are self-labeling.
-- Reuses the parity container discipline: the suite refuses to run outside a
-  container unless `GTS_PARITY_ALLOW_HOST=1`.
+The executable workflow is `.github/workflows/perf-scan-gate.yml`.
 
-```yaml
-# --- PROPOSED .github/workflows/perf-scan-nightly.yml (do not commit from here) ---
-# name: perf-scan-nightly
-# on:
-#   schedule:
-#     - cron: "17 6 * * *"   # nightly, off-peak UTC
-#   workflow_dispatch: {}     # manual re-runs for quiet-box confirmation
-#
-# jobs:
-#   perf-scan:
-#     runs-on: [self-hosted, perf]   # see "corpus provisioning" below
-#     timeout-minutes: 300
-#     continue-on-error: true        # non-blocking by construction
-#     steps:
-#       - uses: actions/checkout@v4
-#
-#       # Corpus provisioning — pick ONE of the options discussed below.
-#       # Option A (artifact bucket):
-#       # - run: aws s3 sync s3://gts-perf-corpus/corpus_sources /corpus/corpus_sources
-#       # Option B (checked-in minimal subset): nothing to do, corpus ships in-repo.
-#       # Option C (self-hosted runner): corpus pre-provisioned at a fixed path.
-#
-#       - name: Restore C reference build cache
-#         uses: actions/cache@v4
-#         with:
-#           path: harness_out/parity_c_ref_cache
-#           key: parity-c-ref-${{ hashFiles('grammars/languages.lock') }}
-#
-#       - name: Run perf scan sweep
-#         working-directory: cgo_harness
-#         env:
-#           GOWORK: "off"
-#           GTS_PARITY_ALLOW_HOST: "1"        # or run inside the parity container
-#           GTS_PERF_SCAN: "1"
-#           GTS_PERF_SCAN_CORPUS_ROOT: /corpus/corpus_sources
-#           GTS_REAL_CORPUS_BENCH_LOCK: /corpus/corpus_sources.lock
-#           GTS_PERF_SCAN_MAX_FILES: "8"
-#           GTS_PERF_SCAN_ORDER: largest
-#           GTS_PERF_SCAN_REPS: "5"
-#           GTS_PERF_SCAN_FILE_BUDGET_MS: "10000"
-#           GTS_PERF_SCAN_LANG_TIMEOUT_MS: "900000"
-#           GTS_PERF_SCAN_OUT: perf_scan/out/nightly
-#         run: |
-#           go test -tags "treesitter_c_parity treesitter_c_perfscan" \
-#             -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 -p 1 .
-#
-#       - name: Check perf ratio budget
-#         working-directory: cgo_harness
-#         run: |
-#           GOWORK=off go run ./cmd/perf_scan_budget \
-#             -budget perf_scan/perf_ratio_budgets.json \
-#             -scoreboard perf_scan/out/nightly/scoreboard.json \
-#             -require-all-budget-langs \
-#             -out-md perf_scan/out/nightly/budget.md
-#
-#       - name: Upload scoreboard
-#         if: always()
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: perf-scoreboard-${{ github.run_id }}
-#           path: cgo_harness/perf_scan/out/nightly
-#           retention-days: 90
-#
-#       # Optional trend step: diff scoreboard.json against the previous run's
-#       # artifact and open/update a tracking issue when a language's verdict
-#       # bucket regresses (<=1.2x -> <=2x etc.) or a new cliff appears.
-# --- END PROPOSAL ---
-```
+## Runner contract
 
-## The corpus provisioning question (stated honestly)
+The runner must provide:
 
-The real corpus is local-only today: `cgo_harness/corpus_real/` is
-git-ignored (generated onto dev boxes) and the big per-language repo
-checkouts live at `/home/draco/work/gotreesitter-corpora/corpus_sources`
-(~GBs, one full upstream repo per language). CI has neither. Options:
+- labels `self-hosted` and `perf`;
+- Docker and enough disk for C-reference builds;
+- at least 8 GiB available to the isolated parity container;
+- an uncontended CPU allocation;
+- `/srv/gotreesitter-perf/corpus_sources` and
+  `/srv/gotreesitter-perf/corpus_sources.lock`.
 
-**Option A — corpus artifact bucket (recommended).** Snapshot the pinned
-corpus (or a curated per-language slice of it) into an object-store bucket
-(S3/GCS/Harbor OCI artifact), keyed by a corpus lock hash. The job syncs it
-at start (~minutes, cacheable on a self-hosted runner). Pros: real corpus,
-reproducible, no repo bloat, works on any runner with credentials. Cons:
-infra + credentials to maintain; snapshot must be re-cut when the corpus
-profile changes.
+The lock file is authenticated before the container starts. Its SHA-256 must
+match both `perf_scan/corpus_sources.lock.sha256` and the structured budget
+metadata. Before timing, the workflow walks all 206 lock rows and requires a
+corresponding Git checkout, the exact locked `HEAD`, a resolvable commit
+object, no tracked worktree or index changes, and the locked corpus subpath.
+The harness then selects every locked language and checks that all locked
+languages exist in the grammar registry. Corpus or lock drift is a gate
+failure, not an implicit baseline update.
 
-**Option B — checked-in minimal corpus subset.** Commit a small curated
-subset (e.g. the existing small/medium/large triple per language, ~5-10 MB
-total) under a new `cgo_harness/corpus_ci/`. Pros: zero infra, works on
-hosted runners, deterministic. Cons: weak cliff coverage — the known cliffs
-(e.g. bash on ~100 KB git test scripts) only reproduce on files larger than
-what is reasonable to commit; upstream licenses must be vetted before
-vendoring. Usable as a smoke tier, not as the authoritative sweep.
+The checkout check intentionally does not reject every untracked path. The
+current corpus builder uses untracked nested dependency checkouts for several
+languages and deterministic `.gts-extracted/<language>` trees for languages
+whose fixtures are embedded inside another syntax. Some lock rows explicitly
+select those extracted directories, so `git status --porcelain` cleanliness
+would reject the corpus by construction. The scheduled job mounts the whole
+corpus read-only and does require the parent tracked tree and index to be clean.
+Longer term, the supplemental trees should gain their own content manifest so
+their bytes—not only the parent checkout—are independently authenticated.
 
-**Option C — self-hosted runner with pre-provisioned corpus.** Label a quiet
-self-hosted box (`[self-hosted, perf]`), provision `corpus_sources` once at a
-fixed path, point `GTS_PERF_SCAN_CORPUS_ROOT` at it. Pros: zero per-run
-transfer, the same box every night makes ratios comparable across runs; this
-matches how the numbers are produced locally today. Cons: single point of
-failure, box must actually stay quiet (the `contended` auto-flag guards
-this), corpus drift is manual.
+## Gate semantics
 
-Pragmatic recommendation: **C now, A later** — start with the self-hosted
-quiet box (fastest path to nightly trend data, identical to today's manual
-runs), and graduate to the artifact bucket when a second runner or team
-consumers appear. Keep B only if a hosted-runner smoke tier is wanted on PRs.
+For every selected file:
 
-## Non-blocking regression visibility
+- the full axis must produce positive Go and C median timings;
+- `Go median / C median <= 10.0` passes; exactly `10.0` passes;
+- a value above `10.0` fails;
+- every Go parser timeout, parser-budget stop, language wall timeout, RSS
+  stop, or OOM/kill fails on every axis;
+- files at or below `0.10x` are listed separately as 10x-or-better wins.
 
-The implemented `cmd/perf_scan_budget` step compares each nightly
-`scoreboard.json` against the checked-in ratio budget and fails the step for
-new ratio, timeout, truncation, or C-reference failures. The nightly job should
-remain `continue-on-error: true`, so regressions are visible in the job summary
-and uploaded artifact without blocking unrelated PRs. A later trend step can
-still diff consecutive artifacts to flag verdict-bucket movement or open/update
-a pinned tracking issue.
+The sweep remains a timing/resource gate. Structural shape and error-tree
+parity stay in the independent correctness suites, so a timing pass never
+substitutes for the correctness gate.
+
+## Artifacts and failure handling
+
+The harness writes `scoreboard.json`, `scoreboard.md`, per-language fragments,
+and child logs. Artifact upload runs under `if: always()` so a red gate retains
+the exact file, axis, implementation, phase, stop class, and partial progress.
+The workflow also renders the checked-in status reporter against the new
+scoreboard when one exists.
+
+The practical cadence is nightly plus manual dispatch. If the dedicated runner
+is temporarily unavailable, the run should remain queued or fail visibly; it
+must not silently fall back to a shared hosted runner whose corpus, memory, and
+timing characteristics differ. A future artifact-backed corpus can add more
+runners without changing the authenticated lock or gate semantics.

--- a/cgo_harness/perf_scan/CI_PROPOSAL.md
+++ b/cgo_harness/perf_scan/CI_PROPOSAL.md
@@ -1,7 +1,7 @@
-# Scheduled hard zero-cliff gate
+# Hard zero-cliff gate operations
 
-The authoritative real-corpus run is a nightly and manually dispatchable hard
-gate on a dedicated `[self-hosted, perf]` runner. The job itself is blocking:
+The authoritative real-corpus run is a manually dispatchable hard gate on a
+dedicated `[self-hosted, perf]` runner. The job itself is blocking:
 there is no `continue-on-error`, and a single full-parse ratio above `10.0x`,
 Go parser/resource stop, incomplete locked-corpus row, or unauthenticated
 corpus selection makes the run red.
@@ -10,11 +10,16 @@ This is intentionally not a required check on every pull request. A 206-
 language largest-file fleet sweep needs the external corpus, C-reference build
 cache, multiple GiB of isolated memory, and hours of quiet-box time. The normal
 PR lane instead runs the fast budget/status unit tests and validates the
-checked-in contract. Performance-sensitive changes should use a manually
-dispatched focused run before merge; the next nightly run closes fleet-wide
-coverage.
+checked-in contract. Performance-sensitive changes should use a focused local
+Docker run before merge; a full local run closes fleet-wide coverage until the
+dedicated runner is authorized for manual dispatch and a future cadence.
 
-The executable workflow is `.github/workflows/perf-scan-gate.yml`.
+The executable workflow is `.github/workflows/perf-scan-gate.yml`. It is
+manual-only until a runner is explicitly registered and the corpus is
+provisioned at the documented path. The repository currently has no available
+self-hosted runner, so enabling a cron now would only leave jobs queued before
+they fail. Once that infrastructure is authorized and verified, the intended
+steady-state cadence is nightly plus manual dispatch.
 
 ## Runner contract
 
@@ -31,7 +36,8 @@ The lock file is authenticated before the container starts. Its SHA-256 must
 match both `perf_scan/corpus_sources.lock.sha256` and the structured budget
 metadata. Before timing, the workflow walks all 206 lock rows and requires a
 corresponding Git checkout, the exact locked `HEAD`, a resolvable commit
-object, no tracked worktree or index changes, and the locked corpus subpath.
+object, the locked origin URL, no external Git object alternate, no tracked
+worktree or index changes, and the locked corpus subpath.
 The harness then selects every locked language and checks that all locked
 languages exist in the grammar registry. Corpus or lock drift is a gate
 failure, not an implicit baseline update.
@@ -69,8 +75,10 @@ the exact file, axis, implementation, phase, stop class, and partial progress.
 The workflow also renders the checked-in status reporter against the new
 scoreboard when one exists.
 
-The practical cadence is nightly plus manual dispatch. If the dedicated runner
-is temporarily unavailable, the run should remain queued or fail visibly; it
-must not silently fall back to a shared hosted runner whose corpus, memory, and
-timing characteristics differ. A future artifact-backed corpus can add more
-runners without changing the authenticated lock or gate semantics.
+The practical cadence today is local Docker execution plus explicit manual
+dispatch after runner provisioning. The intended steady state is nightly plus
+manual dispatch. If the dedicated runner is temporarily unavailable, a
+requested run should remain queued or fail visibly; it must not silently fall
+back to a shared hosted runner whose corpus, memory, and timing characteristics
+differ. A future artifact-backed corpus can add more runners without changing
+the authenticated lock or gate semantics.

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -104,7 +104,7 @@ subdirectory and extensions. This prevents the unsafe fallback to
 `grammars/languages.lock`, whose `subdir` column describes grammar repos, not
 corpus repos.
 
-The scheduled workflow additionally verifies all 206 corpus checkout `HEAD`s,
+The dedicated workflow additionally verifies all 206 corpus checkout `HEAD`s,
 locked subpaths, and tracked worktree/index cleanliness before mounting the
 corpus read-only. It cannot require a completely empty untracked set because
 the corpus builder deliberately supplies nested dependency checkouts and
@@ -254,7 +254,7 @@ requires `hard_gate=true` and the authenticated corpus-lock digest in addition
 to the measurement knobs (`reps`, `warmup`, `file_budget_ms`, `max_files`,
 `order`, exclusions, and axes).
 
-The universal scheduled scan passes `-hard-gate-only`. That mode requires an
+The universal hard-gate run passes `-hard-gate-only`. That mode requires an
 unexcluded scoreboard and checks authenticated fleet coverage plus the exact
 per-file hard rules without applying historical aggregates whose seeded sample
 basis included an exclusion. Historical ratchets remain available through the

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -25,14 +25,17 @@ median, with min/max recorded. Per-file ratio = Go median / C median. Language
 aggregate = ratio-by-total (sum of Go medians / sum of C medians) plus
 median-of-file-ratios.
 
-Verdict buckets: `<=1.2x`, `<=2x`, `>2x`, `cliff>10x`. Any single file over
-10x — or a file that hits the parse budget — escalates the language to
-`cliff>10x` so cliffs cannot hide behind healthy averages.
+Verdict buckets: `<=0.10x`, `<=1.2x`, `<=2x`, `>2x`, `cliff>10x`. The first
+bucket is reported separately as a 10x-or-better win. The hard gate evaluates
+the exact per-file full-parse ratio: `<=10.0x` passes and `>10.0x` fails. A
+healthy aggregate can never hide a single cliff.
 
 Notes on interpretation:
-- The scan is timing-grade, not correctness-grade: structural parity is owned
-  by the parity suites / tier_scan. Truncated or errored parses are excluded
-  from medians and surfaced as per-file statuses.
+- The scan is a timing/resource gate, not a structural-correctness gate.
+  Structural and error-tree parity remain owned by the parity suites and
+  tier_scan. A missing or non-OK full-parse measurement still fails this gate
+  closed because no exact Go/C ratio was produced; that is coverage, not a
+  claim that this harness proved structural parity.
 - The Go no-edit path may legitimately short-circuit (near-zero ns) when the
   engine returns the old tree for an unchanged reparse; the C side always
   pays its reuse walk. The scoreboard reports honest wall time of the API call.
@@ -41,19 +44,20 @@ Notes on interpretation:
 
 ## Cliff containment (why one 17s file cannot hang the sweep)
 
-Two layers:
+Two layers, both represented by structured stop records in `scoreboard.json`:
 1. Per-attempt budget (`GTS_PERF_SCAN_FILE_BUDGET_MS`, default 5000): Go via
    `Parser.SetTimeoutMicros` (partial tree + `ParseStoppedEarly`), C via
    `ts_parser_set_timeout_micros` (nil tree + parser reset). A timed-out Go
-   file is recorded as `go_timeout` with a **lower-bound ratio**
-   (`budget / C median`, `ratio_is_lower_bound=true`) — the cliff is surfaced,
-   not hung on.
+   file is recorded as `go_timeout`, `go_budget_stop`, or `go_stopped`, with
+   the parser stop reason preserved. Lower-bound ratios remain telemetry, but
+   every Go parser timeout or budget stop fails the hard gate.
 2. Per-language subprocess with a hard wall-clock kill
    (`GTS_PERF_SCAN_LANG_TIMEOUT_MS`, default 10 min): the sweep re-execs the
    test binary per language, so hard hangs, native crashes in a C grammar, or
-   OOMs cost one language row (`lang_timeout` / `error` with log tail), never
-   the sweep. Partial per-file results survive because the child rewrites its
-   fragment after every file.
+   OOMs cost one language row, never the sweep. Wall timeout, RSS watchdog,
+   SIGKILL/OOM, and other process signals are classified separately and retain
+   the active file/axis/implementation when a fragment exists. A Go wall/RSS/
+   OOM stop fails the hard gate; incomplete coverage also fails closed.
 
 ## Running
 
@@ -62,45 +66,59 @@ and a corpus. C reference grammars are built/loaded by the existing parity
 machinery (`ParityCLanguage`, `grammars/languages.lock`, cached under
 `harness_out/parity_c_ref_cache/`).
 
-Smoke (explicit languages, default corpus `corpus_real/`):
+Exploratory smoke (explicit languages, default corpus `corpus_real/`). This
+opts out of the hard gate because it does not use the authenticated fleet lock:
 
 ```sh
 cd cgo_harness
-GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
+GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 GTS_PERF_SCAN_HARD_GATE=0 \
   GTS_PERF_SCAN_LANGS=go,python,bash,json,c_sharp \
   go test -tags "treesitter_c_parity treesitter_c_perfscan" \
   -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 .
 ```
 
-Authoritative full sweep on a QUIET box (all languages that have both a corpus
-dir and a registry entry are auto-discovered from the corpus root):
+Authoritative full sweep on a quiet box. With no `GTS_PERF_SCAN_LANGS`, the
+hard gate selects every language in the authenticated corpus lock and requires
+complete fleet coverage:
 
 ```sh
 cd cgo_harness
 GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
   GTS_PERF_SCAN_CORPUS_ROOT=/home/draco/work/gotreesitter-corpora/corpus_sources \
   GTS_REAL_CORPUS_BENCH_LOCK=/home/draco/work/gotreesitter-corpora/corpus_sources.lock \
-  GTS_PERF_SCAN_MAX_FILES=16 GTS_PERF_SCAN_ORDER=largest \
-  GTS_PERF_SCAN_REPS=7 GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
+  GTS_PERF_SCAN_HARD_GATE=1 GTS_PERF_SCAN_REQUIRE_FLEET=1 \
+  GTS_PERF_SCAN_MAX_FILES=8 GTS_PERF_SCAN_ORDER=largest \
+  GTS_PERF_SCAN_REPS=5 GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
+  GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=6144 \
   GTS_PERF_SCAN_OUT=perf_scan/out/authoritative_$(date -u +%Y%m%dT%H%M%SZ) \
   go test -tags "treesitter_c_parity treesitter_c_perfscan" \
   -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 .
 ```
 
-When the corpus root ends in `corpus_sources`/`corpus-sources` the existing
-lock-filter machinery restricts file selection to each language's subdir and
-extensions from the corpus lock (same rules as the real-corpus parity
-benchmarks). Point `GTS_REAL_CORPUS_BENCH_LOCK` at the corpus lock
-(`corpus_sources.lock` next to the corpus checkouts); without it the filter
-falls back to `grammars/languages.lock`, whose `subdir` column describes
-grammar repos, not corpus repos.
+Hard-gate mode requires `GTS_REAL_CORPUS_BENCH_LOCK`. Its SHA-256 must match
+`perf_scan/corpus_sources.lock.sha256` and the same digest in the budget file;
+a missing, changed, empty, or registry-incomplete lock aborts before timing.
+When the corpus root ends in `corpus_sources`/`corpus-sources`, the existing
+lock-filter machinery restricts file selection to each language's locked
+subdirectory and extensions. This prevents the unsafe fallback to
+`grammars/languages.lock`, whose `subdir` column describes grammar repos, not
+corpus repos.
+
+The scheduled workflow additionally verifies all 206 corpus checkout `HEAD`s,
+locked subpaths, and tracked worktree/index cleanliness before mounting the
+corpus read-only. It cannot require a completely empty untracked set because
+the corpus builder deliberately supplies nested dependency checkouts and
+`.gts-extracted` fixture trees that some lock rows select; see
+`CI_PROPOSAL.md` for that provisioning boundary.
 
 ## Knobs (all env)
 
 | env | default | meaning |
 |---|---|---|
 | `GTS_PERF_SCAN` | — | master gate; `1` to run |
-| `GTS_PERF_SCAN_LANGS` | auto-discover | comma list for the sweep |
+| `GTS_PERF_SCAN_HARD_GATE` | 1 | enforce the fail-closed per-file/full-fleet gate; set `0` only for exploratory telemetry |
+| `GTS_PERF_SCAN_REQUIRE_FLEET` | 1 when `GTS_PERF_SCAN_LANGS` is empty | require the selected language count to equal the authenticated lock |
+| `GTS_PERF_SCAN_LANGS` | locked fleet (hard) / auto-discover (exploratory) | comma list for a targeted sweep |
 | `GTS_PERF_SCAN_LANG` | — | single language (child mode; set by the sweep) |
 | `GTS_PERF_SCAN_OUT` | `perf_scan/out/scan_<UTC>` | output dir |
 | `GTS_PERF_SCAN_CORPUS_ROOT` | `corpus_real` | corpus root (per-language subdirs) |
@@ -117,6 +135,7 @@ grammar repos, not corpus repos.
 | `GTS_PERF_SCAN_INPROCESS` | 0 | debug: run languages in-process (no crash isolation) |
 | `GTS_PERF_SCAN_EDIT_CANDIDATES` | 16 | edit-site candidates tried per file |
 | `GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB` | 0 | optional parent-side RSS watchdog for the per-language child process; when set, kills the child before a container cgroup OOM can kill the sweep parent |
+| `GTS_REAL_CORPUS_BENCH_LOCK` | required by hard gate | authenticated corpus selection lock; digest is checked before any language runs |
 
 Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 `GTS_PARITY_REPO_ROOT`, `GTS_PARITY_REPO_CACHE`,
@@ -132,8 +151,10 @@ Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 ```
 
 `scoreboard.json` carries host metadata (loadavg at start/end), the full
-config, a `contended` flag, per-language per-axis aggregates, and per-file
-medians/ratios/statuses.
+config, authenticated corpus coverage, a `contended` flag, structured stop
+records, per-language per-axis aggregates, per-file medians/ratios/statuses,
+and a `hard_gate` report. The report lists failures and separately lists
+full-parse files at `<=0.10x`.
 
 If a language child process is killed while measuring a file, the latest
 partial fragment includes `active_file`, 1-based `active_file_index`, and
@@ -223,13 +244,20 @@ GOWORK=off go run ./cmd/perf_scan_budget \
   -langs go
 ```
 
-The checker gates `ratio_by_total`, optional `ratio_median_of_files`,
-`go_timeout` counts, and Go-side error/truncation counts. It rejects C
-reference failures by default; a language row can opt into an explicit
-`max_c_reference_failures` allowance when the workload's C oracle itself is
-the known failure being ratcheted. By default, the checker also requires the
-scoreboard's structured measurement knobs (`reps`, `warmup`, `file_budget_ms`,
-`max_files`, `order`, and axes) to match the budget metadata.
+The checker first applies the independent hard rule to every file: each full
+axis must be `ok`, contain positive Go/C timings, and have ratio `<=10.0x`;
+every structured or legacy Go stop fails on every axis. It then applies the
+historical aggregate ratchets (`ratio_by_total`, optional
+`ratio_median_of_files`, timeout/error counts, and C-reference allowances).
+Those historical allowances cannot waive the hard rule. Strict config also
+requires `hard_gate=true` and the authenticated corpus-lock digest in addition
+to the measurement knobs (`reps`, `warmup`, `file_budget_ms`, `max_files`,
+`order`, exclusions, and axes).
+
+Older `gts-perf-scan/v1` scoreboards still decode. They predate structured
+stops, corpus coverage, and the embedded hard-gate report, so use
+`-strict-config=false` only for historical analysis; they cannot establish a
+new hard-gate pass. `cmd/perf_scan_status` labels them `not_evaluated`.
 
 ## Phase 2 (documented, not built)
 

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -254,6 +254,12 @@ requires `hard_gate=true` and the authenticated corpus-lock digest in addition
 to the measurement knobs (`reps`, `warmup`, `file_budget_ms`, `max_files`,
 `order`, exclusions, and axes).
 
+The universal scheduled scan passes `-hard-gate-only`. That mode requires an
+unexcluded scoreboard and checks authenticated fleet coverage plus the exact
+per-file hard rules without applying historical aggregates whose seeded sample
+basis included an exclusion. Historical ratchets remain available through the
+normal comparator on scoreboards produced with their exact recorded basis.
+
 Older `gts-perf-scan/v1` scoreboards still decode. They predate structured
 stops, corpus coverage, and the embedded hard-gate report, so use
 `-strict-config=false` only for historical analysis; they cannot establish a

--- a/cgo_harness/perf_scan/corpus_sources.lock.sha256
+++ b/cgo_harness/perf_scan/corpus_sources.lock.sha256
@@ -1,0 +1,1 @@
+cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2  corpus_sources.lock

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -5,7 +5,7 @@
     "RCA in its description -- i.e. a root-cause explanation of the perf/behavior",
     "change that made the old (tighter) budget unreachable, not just 'CI is flaky'",
     "or 'the new number is fine'. See cgo_harness/perf_scan/CI_PROPOSAL.md for the",
-    "non-blocking visibility job this file is meant to back, and cgo_harness/",
+    "scheduled hard-gate runner contract this file backs, and cgo_harness/",
     "perf_scan/README.md for the measurement protocol (verdict buckets, cliff",
     "containment, ratio_by_total vs ratio_median_of_files) these numbers assume.",
     "Every budget below was seeded from a REAL measurement (see _seed_sources)",
@@ -16,7 +16,8 @@
     "that isn't green today is worse than useless.",
     "Adding measurement_basis.exclude_paths is a budget-loosening operation and",
     "must carry the same mechanism/RCA evidence as loosening a ratio budget;",
-    "removing exclusions is a tightening operation."
+    "removing exclusions is a tightening operation. Historical per-language",
+    "timeout/error allowances do not weaken the independent fail-closed hard gate."
   ],
   "schema": "gts-perf-ratio-budgets/v1",
   "generated_at": "2026-07-11T13:54:40Z",
@@ -32,11 +33,14 @@
     "reps": 5,
     "warmup": 1,
     "file_budget_ms": 10000,
+    "hard_max_full_parse_ratio": 10.0,
+    "fast_full_parse_ratio": 0.10,
+    "corpus_lock_sha256": "cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2",
     "axes": ["full", "noedit"],
     "exclude_paths": [
       "groovy/subprojects/performance/src/files/pleac11_15.groovy"
     ],
-    "ratio_definition": "ratio = Go median ns / C median ns, per file; ratio_by_total = sum(Go medians)/sum(C medians) across completing files; ratio_median_of_files = median of per-file ratios. A file that hits the 10s per-attempt budget (wall-clock timeout or memory_budget stop) is excluded from both aggregates and counted in max_timeouts. A file whose Go tree completes but does not cover the full byte range (root.EndByte != len(source), status go_error/truncated) is counted in max_errors -- this is a DISTINCT failure mode from timeouts (silent-truncation-shaped correctness bugs, e.g. haskell/cpp/scala/crystal/typescript below) and is not caught by max_timeouts alone."
+    "ratio_definition": "ratio = Go median ns / C median ns, per file; ratio_by_total = sum(Go medians)/sum(C medians) across completing files; ratio_median_of_files = median of per-file ratios. The hard gate is independent of historical language ratchets: every locked full-parse file must produce an exact Go/C ratio <=10.0, and every Go parser timeout, parser-budget stop, language wall stop, RSS stop, or OOM/kill fails. Ratchet timeout/error allowances remain historical evidence only. Structural parity remains a separate correctness gate. Full-parse ratios <=0.10 are reported separately as 10x-or-better wins."
   },
   "_seed_sources": {
     "authoritative_20260706T145520Z": "pre-campaign baseline (cgo_harness/perf_scan/out/authoritative_20260706T145520Z)",

--- a/cgo_harness/perf_scan/perf_ratio_budgets.json
+++ b/cgo_harness/perf_scan/perf_ratio_budgets.json
@@ -5,7 +5,7 @@
     "RCA in its description -- i.e. a root-cause explanation of the perf/behavior",
     "change that made the old (tighter) budget unreachable, not just 'CI is flaky'",
     "or 'the new number is fine'. See cgo_harness/perf_scan/CI_PROPOSAL.md for the",
-    "scheduled hard-gate runner contract this file backs, and cgo_harness/",
+    "hard-gate runner contract this file backs, and cgo_harness/",
     "perf_scan/README.md for the measurement protocol (verdict buckets, cliff",
     "containment, ratio_by_total vs ratio_median_of_files) these numbers assume.",
     "Every budget below was seeded from a REAL measurement (see _seed_sources)",

--- a/cgo_harness/perf_scan/wave3_sweep_status.json
+++ b/cgo_harness/perf_scan/wave3_sweep_status.json
@@ -17,7 +17,10 @@
     ],
     "exclude_paths": [
       "groovy/subprojects/performance/src/files/pleac11_15.groovy"
-    ]
+    ],
+    "hard_max_full_parse_ratio": 10,
+    "fast_full_parse_ratio": 0.1,
+    "corpus_lock_sha256": "cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2"
   },
   "coverage": {
     "fleet_languages": 206,

--- a/cgo_harness/perf_scan/wave3_sweep_status.md
+++ b/cgo_harness/perf_scan/wave3_sweep_status.md
@@ -21,6 +21,8 @@
 
 Measurement basis: `reps=5`, `warmup=1`, `file_budget_ms=10000`, `max_files=8`, `order=largest`, `axes=full,noedit`.
 
+Hard full-parse ceiling: every measured file must be `<=10.0x`; full-parse files at `<=0.10x` are reported separately as 10x-or-better wins. Corpus lock SHA-256: `cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2`.
+
 Excluded paths: `groovy/subprojects/performance/src/files/pleac11_15.groovy`.
 
 Held out of the ratchet: `d`, `fsharp`.

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -26,7 +26,8 @@ package cgoharness
 // "treesitter_c_parity treesitter_c_perfscan", the container-or-
 // GTS_PARITY_ALLOW_HOST=1 TestMain guard, and the GTS_PERF_SCAN=1 env gate,
 // so it never burdens normal builds or the fast PR lane. The authenticated
-// fleet gate runs on its dedicated scheduled runner.
+// fleet gate runs on its dedicated runner once that infrastructure is
+// provisioned.
 //
 // Usage (from cgo_harness/):
 //

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -18,17 +18,19 @@ package cgoharness
 // (Go: Parser.SetTimeoutMicros -> ParseStoppedEarly; C: SetTimeoutMicros ->
 // nil tree), and every language runs in its own subprocess with a hard
 // wall-clock kill, so one pathological file or grammar cannot hang or crash
-// the sweep. Timed-out files are surfaced as lower-bound ratios and "cliff"
-// verdicts instead of hanging.
+// the sweep. Structured parser, wall, RSS, OOM/kill, and signal stops retain
+// active-attempt attribution. In hard-gate mode they fail closed instead of
+// being hidden behind language aggregates.
 //
 // Build/run discipline mirrors the parity suites: requires the build tags
 // "treesitter_c_parity treesitter_c_perfscan", the container-or-
 // GTS_PARITY_ALLOW_HOST=1 TestMain guard, and the GTS_PERF_SCAN=1 env gate,
-// so it never burdens normal builds or CI.
+// so it never burdens normal builds or the fast PR lane. The authenticated
+// fleet gate runs on its dedicated scheduled runner.
 //
 // Usage (from cgo_harness/):
 //
-//	GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
+//	GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 GTS_PERF_SCAN_HARD_GATE=0 \
 //	  go test -tags "treesitter_c_parity treesitter_c_perfscan" \
 //	  -run '^TestPerfScanSweep$' -v -timeout 0 .
 //
@@ -36,6 +38,7 @@ package cgoharness
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -46,6 +49,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -57,55 +61,79 @@ import (
 const (
 	perfScanSchema = "gts-perf-scan/v1"
 
-	perfScanEnvGate        = "GTS_PERF_SCAN"
-	perfScanEnvLang        = "GTS_PERF_SCAN_LANG"
-	perfScanEnvLangs       = "GTS_PERF_SCAN_LANGS"
-	perfScanEnvOut         = "GTS_PERF_SCAN_OUT"
-	perfScanEnvCorpusRoot  = "GTS_PERF_SCAN_CORPUS_ROOT"
-	perfScanEnvReps        = "GTS_PERF_SCAN_REPS"
-	perfScanEnvWarmup      = "GTS_PERF_SCAN_WARMUP"
-	perfScanEnvFileBudget  = "GTS_PERF_SCAN_FILE_BUDGET_MS"
-	perfScanEnvLangTimeout = "GTS_PERF_SCAN_LANG_TIMEOUT_MS"
-	perfScanEnvMaxFiles    = "GTS_PERF_SCAN_MAX_FILES"
-	perfScanEnvMinBytes    = "GTS_PERF_SCAN_MIN_FILE_BYTES"
-	perfScanEnvMaxBytes    = "GTS_PERF_SCAN_MAX_FILE_BYTES"
-	perfScanEnvExclude     = "GTS_PERF_SCAN_EXCLUDE_PATHS"
-	perfScanEnvOrder       = "GTS_PERF_SCAN_ORDER"
-	perfScanEnvAxes        = "GTS_PERF_SCAN_AXES"
-	perfScanEnvContended   = "GTS_PERF_SCAN_CONTENDED"
-	perfScanEnvInProcess   = "GTS_PERF_SCAN_INPROCESS"
-	perfScanEnvEditCands   = "GTS_PERF_SCAN_EDIT_CANDIDATES"
-	perfScanEnvChildRSSMB  = "GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB"
+	perfScanEnvGate         = "GTS_PERF_SCAN"
+	perfScanEnvLang         = "GTS_PERF_SCAN_LANG"
+	perfScanEnvLangs        = "GTS_PERF_SCAN_LANGS"
+	perfScanEnvOut          = "GTS_PERF_SCAN_OUT"
+	perfScanEnvCorpusRoot   = "GTS_PERF_SCAN_CORPUS_ROOT"
+	perfScanEnvReps         = "GTS_PERF_SCAN_REPS"
+	perfScanEnvWarmup       = "GTS_PERF_SCAN_WARMUP"
+	perfScanEnvFileBudget   = "GTS_PERF_SCAN_FILE_BUDGET_MS"
+	perfScanEnvLangTimeout  = "GTS_PERF_SCAN_LANG_TIMEOUT_MS"
+	perfScanEnvMaxFiles     = "GTS_PERF_SCAN_MAX_FILES"
+	perfScanEnvMinBytes     = "GTS_PERF_SCAN_MIN_FILE_BYTES"
+	perfScanEnvMaxBytes     = "GTS_PERF_SCAN_MAX_FILE_BYTES"
+	perfScanEnvExclude      = "GTS_PERF_SCAN_EXCLUDE_PATHS"
+	perfScanEnvOrder        = "GTS_PERF_SCAN_ORDER"
+	perfScanEnvAxes         = "GTS_PERF_SCAN_AXES"
+	perfScanEnvContended    = "GTS_PERF_SCAN_CONTENDED"
+	perfScanEnvInProcess    = "GTS_PERF_SCAN_INPROCESS"
+	perfScanEnvEditCands    = "GTS_PERF_SCAN_EDIT_CANDIDATES"
+	perfScanEnvChildRSSMB   = "GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB"
+	perfScanEnvHardGate     = "GTS_PERF_SCAN_HARD_GATE"
+	perfScanEnvRequireFleet = "GTS_PERF_SCAN_REQUIRE_FLEET"
+	perfScanEnvCorpusLock   = "GTS_REAL_CORPUS_BENCH_LOCK"
 
 	perfScanAxisFull   = "full"
 	perfScanAxisNoEdit = "noedit"
 	perfScanAxisEdit   = "edit"
 
-	perfScanBucketLe12   = "<=1.2x"
-	perfScanBucketLe2    = "<=2x"
-	perfScanBucketGt2    = ">2x"
-	perfScanBucketCliff  = "cliff>10x"
-	perfScanBucketNoData = "n/a"
+	perfScanBucketLePoint1 = "<=0.10x"
+	perfScanBucketLe12     = "<=1.2x"
+	perfScanBucketLe2      = "<=2x"
+	perfScanBucketGt2      = ">2x"
+	perfScanBucketCliff    = "cliff>10x"
+	perfScanBucketNoData   = "n/a"
 
 	perfScanStatusOK      = "ok"
 	perfScanStatusRunning = "running"
+
+	perfScanGatePass = "pass"
+	perfScanGateFail = "fail"
+
+	perfScanHardFullRatio = 10.0
+	perfScanFastFullRatio = 0.10
+
+	perfScanStopParserTimeout = "parser_timeout"
+	perfScanStopParserBudget  = "parser_budget"
+	perfScanStopParserStopped = "parser_stopped"
+	perfScanStopCTimeout      = "c_timeout"
+	perfScanStopWallTimeout   = "wall_timeout"
+	perfScanStopRSSLimit      = "rss_limit"
+	perfScanStopOOMOrKill     = "oom_or_kill"
+	perfScanStopProcessSignal = "process_signal"
 )
 
 type perfScanConfig struct {
-	CorpusRoot    string   `json:"corpus_root"`
-	Reps          int      `json:"reps"`
-	Warmup        int      `json:"warmup"`
-	FileBudgetMS  int      `json:"file_budget_ms"`
-	LangTimeoutMS int      `json:"lang_timeout_ms"`
-	MaxFiles      int      `json:"max_files"`
-	MinFileBytes  int      `json:"min_file_bytes"`
-	MaxFileBytes  int      `json:"max_file_bytes"`
-	ExcludePaths  []string `json:"exclude_paths,omitempty"`
-	Order         string   `json:"order"`
-	Axes          []string `json:"axes"`
-	Contended     bool     `json:"contended"`
-	ContendedNote string   `json:"contended_note,omitempty"`
-	ChildRSSMB    int      `json:"child_rss_limit_mb,omitempty"`
+	CorpusRoot          string   `json:"corpus_root"`
+	Reps                int      `json:"reps"`
+	Warmup              int      `json:"warmup"`
+	FileBudgetMS        int      `json:"file_budget_ms"`
+	LangTimeoutMS       int      `json:"lang_timeout_ms"`
+	MaxFiles            int      `json:"max_files"`
+	MinFileBytes        int      `json:"min_file_bytes"`
+	MaxFileBytes        int      `json:"max_file_bytes"`
+	ExcludePaths        []string `json:"exclude_paths,omitempty"`
+	Order               string   `json:"order"`
+	Axes                []string `json:"axes"`
+	Contended           bool     `json:"contended"`
+	ContendedNote       string   `json:"contended_note,omitempty"`
+	ChildRSSMB          int      `json:"child_rss_limit_mb,omitempty"`
+	HardGate            bool     `json:"hard_gate"`
+	RequireFleet        bool     `json:"require_fleet"`
+	CorpusLock          string   `json:"corpus_lock,omitempty"`
+	CorpusLockSHA256    string   `json:"corpus_lock_sha256,omitempty"`
+	CorpusLockLanguages int      `json:"corpus_lock_languages,omitempty"`
 }
 
 type perfScanHost struct {
@@ -119,17 +147,27 @@ type perfScanHost struct {
 }
 
 type perfScanFileAxis struct {
-	Status            string  `json:"status"`
-	Detail            string  `json:"detail,omitempty"`
-	GoMedianNs        int64   `json:"go_median_ns,omitempty"`
-	CMedianNs         int64   `json:"c_median_ns,omitempty"`
-	GoMinNs           int64   `json:"go_min_ns,omitempty"`
-	GoMaxNs           int64   `json:"go_max_ns,omitempty"`
-	CMinNs            int64   `json:"c_min_ns,omitempty"`
-	CMaxNs            int64   `json:"c_max_ns,omitempty"`
-	Ratio             float64 `json:"ratio,omitempty"`
-	RatioIsLowerBound bool    `json:"ratio_is_lower_bound,omitempty"`
-	Verdict           string  `json:"verdict,omitempty"`
+	Status            string        `json:"status"`
+	Detail            string        `json:"detail,omitempty"`
+	GoMedianNs        int64         `json:"go_median_ns,omitempty"`
+	CMedianNs         int64         `json:"c_median_ns,omitempty"`
+	GoMinNs           int64         `json:"go_min_ns,omitempty"`
+	GoMaxNs           int64         `json:"go_max_ns,omitempty"`
+	CMinNs            int64         `json:"c_min_ns,omitempty"`
+	CMaxNs            int64         `json:"c_max_ns,omitempty"`
+	Ratio             float64       `json:"ratio,omitempty"`
+	RatioIsLowerBound bool          `json:"ratio_is_lower_bound,omitempty"`
+	Verdict           string        `json:"verdict,omitempty"`
+	Stop              *perfScanStop `json:"stop,omitempty"`
+}
+
+type perfScanStop struct {
+	Class          string `json:"class"`
+	Reason         string `json:"reason,omitempty"`
+	Implementation string `json:"implementation,omitempty"`
+	Phase          string `json:"phase,omitempty"`
+	Attempt        int    `json:"attempt,omitempty"`
+	Detail         string `json:"detail,omitempty"`
 }
 
 type perfScanFile struct {
@@ -146,6 +184,7 @@ type perfScanLangAxis struct {
 	RatioMedianOfFiles float64 `json:"ratio_median_of_files,omitempty"`
 	Cliffs             int     `json:"cliffs"`
 	GoTimeouts         int     `json:"go_timeouts"`
+	GoStops            int     `json:"go_stops"`
 	Verdict            string  `json:"verdict"`
 }
 
@@ -171,17 +210,52 @@ type perfScanLanguage struct {
 	Axes             map[string]*perfScanLangAxis `json:"axes,omitempty"`
 	Notes            []string                     `json:"notes,omitempty"`
 	Files            []*perfScanFile              `json:"files,omitempty"`
+	Stop             *perfScanStop                `json:"stop,omitempty"`
 	activeFileDetail string
 }
 
+type perfScanCorpusCoverage struct {
+	LockPath            string   `json:"lock_path,omitempty"`
+	LockSHA256          string   `json:"lock_sha256,omitempty"`
+	LockLanguages       int      `json:"lock_languages"`
+	SelectedLanguages   int      `json:"selected_languages"`
+	MissingFromLock     []string `json:"missing_from_lock,omitempty"`
+	MissingFromRegistry []string `json:"missing_from_registry,omitempty"`
+}
+
+type perfScanGateFinding struct {
+	Kind     string        `json:"kind"`
+	Language string        `json:"language,omitempty"`
+	Path     string        `json:"path,omitempty"`
+	Axis     string        `json:"axis,omitempty"`
+	Status   string        `json:"status,omitempty"`
+	Ratio    float64       `json:"ratio,omitempty"`
+	Limit    float64       `json:"limit,omitempty"`
+	Stop     *perfScanStop `json:"stop,omitempty"`
+	Detail   string        `json:"detail,omitempty"`
+}
+
+type perfScanGateReport struct {
+	Status             string                `json:"status"`
+	MaxFullParseRatio  float64               `json:"max_full_parse_ratio"`
+	FastFullParseRatio float64               `json:"fast_full_parse_ratio"`
+	FilesExpected      int                   `json:"files_expected"`
+	FilesMeasured      int                   `json:"files_measured"`
+	FullFilesEvaluated int                   `json:"full_files_evaluated"`
+	FastFullFiles      []perfScanGateFinding `json:"fast_full_files,omitempty"`
+	Failures           []perfScanGateFinding `json:"failures,omitempty"`
+}
+
 type perfScanScoreboard struct {
-	Schema      string              `json:"schema"`
-	GeneratedAt string              `json:"generated_at"`
-	Host        perfScanHost        `json:"host"`
-	Config      perfScanConfig      `json:"config"`
-	Notes       []string            `json:"notes,omitempty"`
-	Summary     map[string]int      `json:"summary_verdicts"`
-	Languages   []*perfScanLanguage `json:"languages"`
+	Schema      string                 `json:"schema"`
+	GeneratedAt string                 `json:"generated_at"`
+	Host        perfScanHost           `json:"host"`
+	Config      perfScanConfig         `json:"config"`
+	Notes       []string               `json:"notes,omitempty"`
+	Summary     map[string]int         `json:"summary_verdicts"`
+	Languages   []*perfScanLanguage    `json:"languages"`
+	Corpus      perfScanCorpusCoverage `json:"corpus_coverage"`
+	Gate        *perfScanGateReport    `json:"hard_gate,omitempty"`
 }
 
 func perfScanGateEnabled() bool {
@@ -201,6 +275,7 @@ func perfScanEnvIntDefault(name string, def int) int {
 }
 
 func perfScanLoadConfig() perfScanConfig {
+	requireFleetDefault := strings.TrimSpace(os.Getenv(perfScanEnvLangs)) == ""
 	cfg := perfScanConfig{
 		CorpusRoot:    perfScanCorpusRoot(),
 		Reps:          perfScanEnvIntDefault(perfScanEnvReps, 5),
@@ -214,6 +289,9 @@ func perfScanLoadConfig() perfScanConfig {
 		Order:         strings.TrimSpace(os.Getenv(perfScanEnvOrder)),
 		Axes:          perfScanAxes(),
 		ChildRSSMB:    perfScanEnvIntDefault(perfScanEnvChildRSSMB, 0),
+		HardGate:      parityEnvBool(perfScanEnvHardGate, true),
+		RequireFleet:  parityEnvBool(perfScanEnvRequireFleet, requireFleetDefault),
+		CorpusLock:    strings.TrimSpace(os.Getenv(perfScanEnvCorpusLock)),
 	}
 	if cfg.Reps < 1 {
 		cfg.Reps = 1
@@ -365,6 +443,8 @@ func perfScanVerdictBucket(ratio float64) string {
 	switch {
 	case ratio <= 0:
 		return perfScanBucketNoData
+	case ratio <= perfScanFastFullRatio:
+		return perfScanBucketLePoint1
 	case ratio <= 1.2:
 		return perfScanBucketLe12
 	case ratio <= 2:
@@ -418,6 +498,198 @@ func perfScanMinMaxNs(samples []int64) (int64, int64) {
 	return minV, maxV
 }
 
+func perfScanPrepareCorpusLock(cfg *perfScanConfig) (map[string]realCorpusBenchmarkLockEntry, perfScanCorpusCoverage, error) {
+	coverage := perfScanCorpusCoverage{}
+	if cfg == nil {
+		return nil, coverage, fmt.Errorf("nil perf scan config")
+	}
+	lockPath := strings.TrimSpace(cfg.CorpusLock)
+	if lockPath == "" {
+		if cfg.HardGate {
+			return nil, coverage, fmt.Errorf("%s must name the authenticated corpus lock in hard-gate mode", perfScanEnvCorpusLock)
+		}
+		return nil, coverage, nil
+	}
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return nil, coverage, fmt.Errorf("read corpus lock %s: %w", lockPath, err)
+	}
+	actualDigest := fmt.Sprintf("%x", sha256.Sum256(data))
+	if cfg.HardGate {
+		expectedDigest, err := perfScanExpectedCorpusLockDigest()
+		if err != nil {
+			return nil, coverage, err
+		}
+		if actualDigest != expectedDigest {
+			return nil, coverage, fmt.Errorf("corpus lock sha256 %s, want %s from perf_scan/corpus_sources.lock.sha256", actualDigest, expectedDigest)
+		}
+	}
+	entries, err := realCorpusBenchmarkLockEntries(lockPath)
+	if err != nil {
+		return nil, coverage, fmt.Errorf("parse corpus lock %s: %w", lockPath, err)
+	}
+	if len(entries) == 0 {
+		return nil, coverage, fmt.Errorf("corpus lock %s contains no languages", lockPath)
+	}
+	cfg.CorpusLockSHA256 = actualDigest
+	cfg.CorpusLockLanguages = len(entries)
+	coverage.LockPath = lockPath
+	coverage.LockSHA256 = actualDigest
+	coverage.LockLanguages = len(entries)
+	for lang := range entries {
+		if _, ok := parityEntriesByName[lang]; !ok {
+			coverage.MissingFromRegistry = append(coverage.MissingFromRegistry, lang)
+		}
+	}
+	sort.Strings(coverage.MissingFromRegistry)
+	return entries, coverage, nil
+}
+
+func perfScanExpectedCorpusLockDigest() (string, error) {
+	var lastErr error
+	for _, candidate := range []string{
+		filepath.Join("perf_scan", "corpus_sources.lock.sha256"),
+		filepath.Join("cgo_harness", "perf_scan", "corpus_sources.lock.sha256"),
+		filepath.Join("..", "cgo_harness", "perf_scan", "corpus_sources.lock.sha256"),
+	} {
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		fields := strings.Fields(string(data))
+		if len(fields) == 0 || len(fields[0]) != sha256.Size*2 {
+			return "", fmt.Errorf("invalid corpus lock digest file %s", candidate)
+		}
+		for _, r := range fields[0] {
+			if !strings.ContainsRune("0123456789abcdef", r) {
+				return "", fmt.Errorf("invalid corpus lock sha256 %q in %s", fields[0], candidate)
+			}
+		}
+		return fields[0], nil
+	}
+	return "", fmt.Errorf("read perf_scan/corpus_sources.lock.sha256: %w", lastErr)
+}
+
+func perfScanFinalizeCorpusCoverage(coverage perfScanCorpusCoverage, entries map[string]realCorpusBenchmarkLockEntry, langs []string) perfScanCorpusCoverage {
+	coverage.SelectedLanguages = len(langs)
+	for _, lang := range langs {
+		if _, ok := entries[lang]; !ok {
+			coverage.MissingFromLock = append(coverage.MissingFromLock, lang)
+		}
+	}
+	sort.Strings(coverage.MissingFromLock)
+	return coverage
+}
+
+func perfScanIsGoStop(stop *perfScanStop) bool {
+	return stop != nil && stop.Implementation == "go"
+}
+
+func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
+	report := perfScanGateReport{
+		Status:             perfScanGatePass,
+		MaxFullParseRatio:  perfScanHardFullRatio,
+		FastFullParseRatio: perfScanFastFullRatio,
+	}
+	addFailure := func(finding perfScanGateFinding) {
+		report.Failures = append(report.Failures, finding)
+		report.Status = perfScanGateFail
+	}
+	if board == nil {
+		addFailure(perfScanGateFinding{Kind: "coverage", Detail: "nil scoreboard"})
+		return report
+	}
+	for _, lang := range board.Corpus.MissingFromLock {
+		addFailure(perfScanGateFinding{Kind: "coverage", Language: lang, Detail: "language missing from authenticated corpus lock"})
+	}
+	for _, lang := range board.Corpus.MissingFromRegistry {
+		addFailure(perfScanGateFinding{Kind: "coverage", Language: lang, Detail: "locked corpus language missing from grammar registry"})
+	}
+	if board.Config.RequireFleet && board.Corpus.SelectedLanguages != board.Corpus.LockLanguages {
+		addFailure(perfScanGateFinding{
+			Kind:   "coverage",
+			Status: "fleet_incomplete",
+			Detail: fmt.Sprintf("selected %d language(s), authenticated lock contains %d", board.Corpus.SelectedLanguages, board.Corpus.LockLanguages),
+		})
+	}
+	if board.Config.RequireFleet && len(board.Languages) != board.Corpus.SelectedLanguages {
+		addFailure(perfScanGateFinding{
+			Kind:   "coverage",
+			Status: "fleet_incomplete",
+			Detail: fmt.Sprintf("scoreboard has %d language row(s), selected %d", len(board.Languages), board.Corpus.SelectedLanguages),
+		})
+	}
+	for _, row := range board.Languages {
+		if row == nil {
+			addFailure(perfScanGateFinding{Kind: "coverage", Detail: "nil language row"})
+			continue
+		}
+		report.FilesExpected += row.FilesSelected
+		report.FilesMeasured += row.FilesMeasured
+		if perfScanIsGoStop(row.Stop) {
+			addFailure(perfScanGateFinding{
+				Kind:     "go_stop",
+				Language: row.Language,
+				Path:     row.ActiveFile,
+				Axis:     row.ActiveAxis,
+				Status:   row.Status,
+				Stop:     row.Stop,
+				Detail:   row.Detail,
+			})
+		}
+		if row.Status != perfScanStatusOK && !perfScanIsGoStop(row.Stop) {
+			addFailure(perfScanGateFinding{Kind: "coverage", Language: row.Language, Path: row.ActiveFile, Axis: row.ActiveAxis, Status: row.Status, Stop: row.Stop, Detail: row.Detail})
+		}
+		if row.FilesMeasured != row.FilesSelected || len(row.Files) != row.FilesSelected {
+			addFailure(perfScanGateFinding{
+				Kind:     "coverage",
+				Language: row.Language,
+				Status:   "files_incomplete",
+				Detail:   fmt.Sprintf("measured=%d rows=%d selected=%d", row.FilesMeasured, len(row.Files), row.FilesSelected),
+			})
+		}
+		for _, file := range row.Files {
+			if file == nil {
+				addFailure(perfScanGateFinding{Kind: "coverage", Language: row.Language, Detail: "nil file row"})
+				continue
+			}
+			for axis, result := range file.Axes {
+				if result != nil && perfScanIsGoStop(result.Stop) {
+					addFailure(perfScanGateFinding{Kind: "go_stop", Language: row.Language, Path: file.Path, Axis: axis, Status: result.Status, Stop: result.Stop, Detail: result.Detail})
+				}
+			}
+			full := file.Axes[perfScanAxisFull]
+			if full == nil {
+				addFailure(perfScanGateFinding{Kind: "coverage", Language: row.Language, Path: file.Path, Axis: perfScanAxisFull, Status: "missing", Detail: "full-parse axis missing"})
+				continue
+			}
+			if full.Status != perfScanStatusOK || full.GoMedianNs <= 0 || full.CMedianNs <= 0 {
+				if !perfScanIsGoStop(full.Stop) {
+					addFailure(perfScanGateFinding{Kind: "coverage", Language: row.Language, Path: file.Path, Axis: perfScanAxisFull, Status: full.Status, Stop: full.Stop, Detail: "full-parse Go/C ratio was not measured: " + full.Detail})
+				}
+				continue
+			}
+			report.FullFilesEvaluated++
+			ratio := float64(full.GoMedianNs) / float64(full.CMedianNs)
+			finding := perfScanGateFinding{Language: row.Language, Path: file.Path, Axis: perfScanAxisFull, Status: full.Status, Ratio: ratio}
+			switch {
+			case ratio > perfScanHardFullRatio:
+				finding.Kind = "ratio"
+				finding.Limit = perfScanHardFullRatio
+				finding.Detail = fmt.Sprintf("full-parse Go/C ratio %.4fx exceeds %.1fx", ratio, perfScanHardFullRatio)
+				addFailure(finding)
+			case ratio <= perfScanFastFullRatio:
+				finding.Kind = "fast"
+				finding.Limit = perfScanFastFullRatio
+				finding.Detail = fmt.Sprintf("full parse is %.2fx faster than C", 1/ratio)
+				report.FastFullFiles = append(report.FastFullFiles, finding)
+			}
+		}
+	}
+	return report
+}
+
 // ---------------------------------------------------------------------------
 // Child: measure one language.
 // ---------------------------------------------------------------------------
@@ -439,6 +711,9 @@ func TestPerfScanLanguage(t *testing.T) {
 		t.Fatalf("%s must be set in child mode", perfScanEnvOut)
 	}
 	cfg := perfScanLoadConfig()
+	if _, _, err := perfScanPrepareCorpusLock(&cfg); err != nil {
+		t.Fatalf("prepare authenticated corpus lock: %v", err)
+	}
 	row := perfScanMeasureLanguage(t, lang, cfg, func(partial *perfScanLanguage) {
 		if err := perfScanWriteLangFragment(outDir, partial); err != nil {
 			t.Logf("write partial fragment: %v", err)
@@ -752,6 +1027,7 @@ type perfScanAttempt struct {
 	ns     int64
 	status string // "" == ok
 	detail string
+	stop   *perfScanStop
 }
 
 func (m *perfScanLangMeasurer) benchCase(src []byte) realCorpusBenchmarkCase {
@@ -836,8 +1112,15 @@ func (m *perfScanLangMeasurer) classifyGoAttempt(tree *gotreesitter.Tree, err er
 		return nil, att
 	}
 	if tree.ParseStoppedEarly() {
-		att.status = "go_timeout"
-		att.detail = fmt.Sprintf("parse stopped early (%v) at file budget %s", tree.ParseStopReason(), m.budget)
+		reason := tree.ParseStopReason()
+		att.stop = perfScanGoParserStop(reason, m.budget)
+		att.status = "go_stopped"
+		if reason == gotreesitter.ParseStopTimeout {
+			att.status = "go_timeout"
+		} else if att.stop.Class == perfScanStopParserBudget {
+			att.status = "go_budget_stop"
+		}
+		att.detail = att.stop.Detail
 		releaseGoTree(tree)
 		return nil, att
 	}
@@ -898,6 +1181,11 @@ func (m *perfScanLangMeasurer) cAttempt(src []byte, oldTree *sitter.Tree, keepTr
 		m.cPsr.Reset()
 		att.status = "c_timeout"
 		att.detail = fmt.Sprintf("nil tree (halted at file budget %s)", m.budget)
+		att.stop = &perfScanStop{
+			Class:          perfScanStopCTimeout,
+			Implementation: "c",
+			Detail:         att.detail,
+		}
 		return nil, att
 	}
 	if !isCompleteRealCorpusCTree(tree, src) {
@@ -911,6 +1199,41 @@ func (m *perfScanLangMeasurer) cAttempt(src []byte, oldTree *sitter.Tree, keepTr
 		return nil, att
 	}
 	return tree, att
+}
+
+func perfScanGoParserStop(reason gotreesitter.ParseStopReason, budget time.Duration) *perfScanStop {
+	class := perfScanStopParserStopped
+	switch reason {
+	case gotreesitter.ParseStopTimeout:
+		class = perfScanStopParserTimeout
+	case gotreesitter.ParseStopMemoryBudget,
+		gotreesitter.ParseStopNodeLimit,
+		gotreesitter.ParseStopIterationLimit,
+		gotreesitter.ParseStopStackDepthLimit:
+		class = perfScanStopParserBudget
+	}
+	return &perfScanStop{
+		Class:          class,
+		Reason:         string(reason),
+		Implementation: "go",
+		Detail:         fmt.Sprintf("parse stopped early (%v) at file budget %s", reason, budget),
+	}
+}
+
+func perfScanRecordAttemptStop(out *perfScanFileAxis, att perfScanAttempt, phase string, attempt int) {
+	if out == nil || att.stop == nil {
+		return
+	}
+	stop := *att.stop
+	stop.Phase = phase
+	stop.Attempt = attempt
+	// Preserve a Go stop if the C side also stops later in the same axis. The
+	// hard gate must retain the causal Go failure instead of letting a
+	// subsequent C timeout overwrite it.
+	if out.Stop != nil && out.Stop.Implementation == "go" && stop.Implementation != "go" {
+		return
+	}
+	out.Stop = &stop
 }
 
 func perfScanRecover(fn func()) (panicked string) {
@@ -948,6 +1271,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 			goOK = false
 			out.Status = att.status
 			goDetail = att.detail
+			perfScanRecordAttemptStop(out, att, "warmup", i+1)
 			break
 		}
 	}
@@ -961,6 +1285,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 				out.Status = att.status
 			}
 			out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+			perfScanRecordAttemptStop(out, att, "warmup", i+1)
 			break
 		}
 	}
@@ -974,6 +1299,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 				goOK = false
 				out.Status = att.status
 				goDetail = att.detail
+				perfScanRecordAttemptStop(out, att, "rep", i+1)
 			} else {
 				goSamples = append(goSamples, att.ns)
 			}
@@ -987,6 +1313,7 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) *perfScanFileAxis {
 					out.Status = att.status
 				}
 				out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+				perfScanRecordAttemptStop(out, att, "rep", i+1)
 			} else {
 				cSamples = append(cSamples, att.ns)
 			}
@@ -1010,6 +1337,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 	if !goOK {
 		out.Status = baseAtt.status
 		out.Detail = "base full parse: " + baseAtt.detail
+		perfScanRecordAttemptStop(out, baseAtt, "base", 1)
 	} else {
 		for i := 0; i < m.cfg.Reps; i++ {
 			m.checkpoint(perfScanAxisNoEdit, "go", "rep", i+1)
@@ -1018,6 +1346,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 				goOK = false
 				out.Status = att.status
 				out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+				perfScanRecordAttemptStop(out, att, "rep", i+1)
 				break
 			}
 			goSamples = append(goSamples, att.ns)
@@ -1039,6 +1368,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 			out.Status = cBaseAtt.status
 		}
 		out.Detail = strings.TrimSpace(out.Detail + " C base: " + cBaseAtt.detail)
+		perfScanRecordAttemptStop(out, cBaseAtt, "base", 1)
 	} else {
 		for i := 0; i < m.cfg.Reps; i++ {
 			m.checkpoint(perfScanAxisNoEdit, "c", "rep", i+1)
@@ -1049,6 +1379,7 @@ func (m *perfScanLangMeasurer) measureNoEdit(src []byte) *perfScanFileAxis {
 					out.Status = att.status
 				}
 				out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+				perfScanRecordAttemptStop(out, att, "rep", i+1)
 				break
 			}
 			cSamples = append(cSamples, att.ns)
@@ -1086,6 +1417,7 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 	if !goOK {
 		out.Status = baseAtt.status
 		out.Detail = "base full parse: " + baseAtt.detail
+		perfScanRecordAttemptStop(out, baseAtt, "base", 1)
 	} else {
 		for i := 0; i < m.cfg.Reps; i++ {
 			m.checkpoint(perfScanAxisEdit, "go", "tree_edit", i+1)
@@ -1097,6 +1429,7 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 				goOK = false
 				out.Status = att.status
 				out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+				perfScanRecordAttemptStop(out, att, "rep", i+1)
 				break
 			}
 			goSamples = append(goSamples, att.ns)
@@ -1119,6 +1452,7 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 			out.Status = cBaseAtt.status
 		}
 		out.Detail = strings.TrimSpace(out.Detail + " C base: " + cBaseAtt.detail)
+		perfScanRecordAttemptStop(out, cBaseAtt, "base", 1)
 	} else {
 		cState := realCorpusCIncrementalState{tc: editCase, src: cSrc, tree: cTree}
 		for i := 0; i < m.cfg.Reps; i++ {
@@ -1133,6 +1467,7 @@ func (m *perfScanLangMeasurer) measureEdit(src []byte) *perfScanFileAxis {
 					out.Status = att.status
 				}
 				out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+				perfScanRecordAttemptStop(out, att, "rep", i+1)
 				break
 			}
 			cSamples = append(cSamples, att.ns)
@@ -1244,7 +1579,10 @@ func perfScanAggregateLanguage(row *perfScanLanguage, cfg perfScanConfig) {
 			if fa.Status == "go_timeout" {
 				agg.GoTimeouts++
 			}
-			if fa.Verdict == perfScanBucketCliff || (fa.RatioIsLowerBound && fa.Ratio > 10) || fa.Status == "go_timeout" {
+			if perfScanIsGoStop(fa.Stop) {
+				agg.GoStops++
+			}
+			if fa.Verdict == perfScanBucketCliff || (fa.RatioIsLowerBound && fa.Ratio > perfScanHardFullRatio) || perfScanIsGoStop(fa.Stop) {
 				agg.Cliffs++
 			}
 			if fa.Status == perfScanStatusOK && fa.GoMedianNs > 0 && fa.CMedianNs > 0 {
@@ -1293,6 +1631,10 @@ func TestPerfScanSweep(t *testing.T) {
 		t.Skipf("%s is set; refusing to sweep inside a child invocation", perfScanEnvLang)
 	}
 	cfg := perfScanLoadConfig()
+	lockEntries, corpusCoverage, err := perfScanPrepareCorpusLock(&cfg)
+	if err != nil {
+		t.Fatalf("prepare authenticated corpus lock: %v", err)
+	}
 
 	outDir := strings.TrimSpace(os.Getenv(perfScanEnvOut))
 	if outDir == "" {
@@ -1309,10 +1651,11 @@ func TestPerfScanSweep(t *testing.T) {
 		t.Fatalf("create log dir: %v", err)
 	}
 
-	langs := perfScanSweepLanguages(t, cfg)
+	langs := perfScanSweepLanguages(t, cfg, lockEntries)
 	if len(langs) == 0 {
 		t.Fatalf("no languages selected: set %s or provide a corpus root with per-language dirs", perfScanEnvLangs)
 	}
+	corpusCoverage = perfScanFinalizeCorpusCoverage(corpusCoverage, lockEntries, langs)
 	t.Logf("perf scan sweep: %d language(s): %s", len(langs), strings.Join(langs, ","))
 	t.Logf("perf scan out dir: %s", absOut)
 
@@ -1320,6 +1663,7 @@ func TestPerfScanSweep(t *testing.T) {
 		Schema:      perfScanSchema,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Config:      cfg,
+		Corpus:      corpusCoverage,
 		Summary:     map[string]int{},
 		Host: perfScanHost{
 			Hostname:     perfScanHostname(),
@@ -1349,23 +1693,40 @@ func TestPerfScanSweep(t *testing.T) {
 			lang, row.Status, row.Verdict, row.FilesMeasured, row.FilesSelected, row.ElapsedMS, row.Detail)
 	}
 	board.Host.LoadavgEnd = perfScanReadLoadavg()
+	gate := perfScanEvaluateHardGate(board)
+	board.Gate = &gate
 
 	if err := perfScanWriteScoreboard(absOut, board); err != nil {
 		t.Fatalf("write scoreboard: %v", err)
 	}
 	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.json"))
 	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.md"))
+	if cfg.HardGate && gate.Status != perfScanGatePass {
+		t.Errorf("hard zero-cliff gate failed: %d finding(s), %d/%d full files evaluated; scoreboard: %s",
+			len(gate.Failures), gate.FullFilesEvaluated, gate.FilesExpected, filepath.Join(absOut, "scoreboard.json"))
+	}
 }
 
-func perfScanSweepLanguages(t *testing.T, cfg perfScanConfig) []string {
+func perfScanSweepLanguages(t *testing.T, cfg perfScanConfig, lockEntries map[string]realCorpusBenchmarkLockEntry) []string {
 	if raw := strings.TrimSpace(os.Getenv(perfScanEnvLangs)); raw != "" {
+		seen := map[string]bool{}
 		var out []string
 		for _, part := range strings.Split(raw, ",") {
 			name := strings.TrimSpace(part)
-			if name != "" {
+			if name != "" && !seen[name] {
+				seen[name] = true
 				out = append(out, name)
 			}
 		}
+		sort.Strings(out)
+		return out
+	}
+	if cfg.RequireFleet && len(lockEntries) > 0 {
+		out := make([]string, 0, len(lockEntries))
+		for lang := range lockEntries {
+			out = append(out, lang)
+		}
+		sort.Strings(out)
 		return out
 	}
 	entries, err := os.ReadDir(cfg.CorpusRoot)
@@ -1429,11 +1790,15 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 	})
 
 	start := time.Now()
-	runErr, rssStop := perfScanRunChild(ctx, cmd, cfg.ChildRSSMB)
+	runErr, childStop := perfScanRunChild(ctx, cmd, cfg.ChildRSSMB)
 	elapsed := time.Since(start)
 
 	fragment, fragErr := perfScanReadLangFragment(absOut, lang)
-	timedOut := ctx.Err() == context.DeadlineExceeded
+	if childStop != nil && fragment != nil {
+		childStop = perfScanStopWithActiveAttempt(childStop, fragment)
+		fragment.Stop = childStop
+	}
+	timedOut := childStop != nil && childStop.Class == perfScanStopWallTimeout
 
 	switch {
 	case fragment != nil && fragment.Status == perfScanStatusOK && runErr == nil:
@@ -1451,14 +1816,14 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 		return fragment
 	case fragment != nil:
 		stopDetail := fmt.Sprintf("%v", runErr)
-		if rssStop != "" {
-			stopDetail = rssStop
+		if childStop != nil {
+			stopDetail = childStop.Detail
 		}
 		if runErr != nil && fragment.Status == perfScanStatusOK {
 			fragment.Notes = append(fragment.Notes, "child exited with error after fragment write: "+stopDetail)
 		}
 		if fragment.Status == perfScanStatusRunning {
-			fragment.Status = "error"
+			fragment.Status = perfScanLanguageStopStatus(childStop)
 			fragment.Detail = strings.TrimSpace(fmt.Sprintf("child exited early (%s); partial results. %s", stopDetail, fragment.Detail))
 			perfScanAggregateLanguage(fragment, cfg)
 		}
@@ -1469,8 +1834,9 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 		if timedOut {
 			status = "lang_timeout"
 			detail = fmt.Sprintf("killed after %s before any file completed", langTimeout)
-		} else if rssStop != "" {
-			detail = rssStop + " before any file completed"
+		} else if childStop != nil {
+			status = perfScanLanguageStopStatus(childStop)
+			detail = childStop.Detail + " before any file completed"
 		} else if fragErr != nil && runErr == nil {
 			detail = fmt.Sprintf("fragment read failed: %v", fragErr)
 		}
@@ -1483,16 +1849,18 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 			Detail:    detail,
 			Verdict:   perfScanBucketNoData,
 			ElapsedMS: elapsed.Milliseconds(),
+			Stop:      childStop,
 		}
 	}
 }
 
-func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error, string) {
+func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error, *perfScanStop) {
 	if rssLimitMB <= 0 {
-		return cmd.Run(), ""
+		err := cmd.Run()
+		return err, perfScanChildExitStop(ctx, err)
 	}
 	if err := cmd.Start(); err != nil {
-		return err, ""
+		return err, nil
 	}
 
 	done := make(chan error, 1)
@@ -1506,37 +1874,100 @@ func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error
 	defer ticker.Stop()
 
 	limitBytes := int64(rssLimitMB) << 20
-	checkRSS := func() (bool, string) {
+	checkRSS := func() (bool, *perfScanStop) {
 		if cmd.Process == nil {
-			return false, ""
+			return false, nil
 		}
 		rssBytes, ok := perfScanProcessRSSBytes(cmd.Process.Pid)
 		if !ok || rssBytes < limitBytes {
-			return false, ""
+			return false, nil
 		}
-		return true, fmt.Sprintf("child rss exceeded %d MiB limit (rss=%d MiB)",
+		detail := fmt.Sprintf("child rss exceeded %d MiB limit (rss=%d MiB)",
 			rssLimitMB, (rssBytes+(1<<20)-1)>>20)
+		return true, &perfScanStop{Class: perfScanStopRSSLimit, Detail: detail}
 	}
 	for {
 		select {
 		case err := <-done:
-			return err, ""
+			return err, perfScanChildExitStop(ctx, err)
 		default:
 		}
-		if kill, detail := checkRSS(); kill {
+		if kill, stop := checkRSS(); kill {
 			_ = cmd.Process.Kill()
-			return <-done, detail
+			return <-done, stop
 		}
 		select {
 		case err := <-done:
-			return err, ""
+			return err, perfScanChildExitStop(ctx, err)
 		case <-ctx.Done():
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
-			return <-done, ""
+			return <-done, &perfScanStop{Class: perfScanStopWallTimeout, Detail: "language subprocess exceeded hard wall timeout"}
 		case <-ticker.C:
 		}
+	}
+}
+
+func perfScanChildExitStop(ctx context.Context, err error) *perfScanStop {
+	if ctx != nil && ctx.Err() == context.DeadlineExceeded {
+		return &perfScanStop{Class: perfScanStopWallTimeout, Detail: "language subprocess exceeded hard wall timeout"}
+	}
+	return perfScanUnexpectedChildStop(err)
+}
+
+func perfScanUnexpectedChildStop(err error) *perfScanStop {
+	if err == nil {
+		return nil
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		return nil
+	}
+	waitStatus, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !waitStatus.Signaled() {
+		return nil
+	}
+	signal := waitStatus.Signal()
+	class := perfScanStopProcessSignal
+	if signal == syscall.SIGKILL {
+		class = perfScanStopOOMOrKill
+	}
+	return &perfScanStop{
+		Class:  class,
+		Reason: signal.String(),
+		Detail: fmt.Sprintf("language subprocess terminated by %s", signal),
+	}
+}
+
+func perfScanStopWithActiveAttempt(stop *perfScanStop, row *perfScanLanguage) *perfScanStop {
+	if stop == nil || row == nil {
+		return stop
+	}
+	out := *stop
+	out.Implementation = row.ActiveImpl
+	out.Phase = row.ActivePhase
+	if row.ActiveAttempt != nil {
+		out.Attempt = *row.ActiveAttempt
+	}
+	return &out
+}
+
+func perfScanLanguageStopStatus(stop *perfScanStop) string {
+	if stop == nil {
+		return "error"
+	}
+	switch stop.Class {
+	case perfScanStopWallTimeout:
+		return "lang_timeout"
+	case perfScanStopRSSLimit:
+		return "rss_limit"
+	case perfScanStopOOMOrKill:
+		return "oom_or_kill"
+	case perfScanStopProcessSignal:
+		return "process_signal"
+	default:
+		return "error"
 	}
 }
 
@@ -1689,6 +2120,12 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 		board.Config.CorpusRoot, board.Config.Order, board.Config.MaxFiles,
 		board.Config.Reps, board.Config.Warmup, board.Config.FileBudgetMS,
 		strings.Join(board.Config.Axes, ","))
+	fmt.Fprintf(&b, "- hard gate: `%t` require_fleet=`%t` max_full_ratio=`%.1fx` fast_full_ratio=`%.2fx`\n",
+		board.Config.HardGate, board.Config.RequireFleet, perfScanHardFullRatio, perfScanFastFullRatio)
+	if board.Corpus.LockSHA256 != "" {
+		fmt.Fprintf(&b, "- corpus lock: `%s` sha256=`%s` languages=%d selected=%d\n",
+			board.Corpus.LockPath, board.Corpus.LockSHA256, board.Corpus.LockLanguages, board.Corpus.SelectedLanguages)
+	}
 	if board.Config.ChildRSSMB > 0 {
 		fmt.Fprintf(&b, "- child RSS limit: `%d MiB`\n", board.Config.ChildRSSMB)
 	}
@@ -1700,9 +2137,32 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 	}
 
 	fmt.Fprintf(&b, "\n## Verdict summary\n\n")
-	for _, bucket := range []string{perfScanBucketLe12, perfScanBucketLe2, perfScanBucketGt2, perfScanBucketCliff, perfScanBucketNoData} {
+	for _, bucket := range []string{perfScanBucketLePoint1, perfScanBucketLe12, perfScanBucketLe2, perfScanBucketGt2, perfScanBucketCliff, perfScanBucketNoData} {
 		if n := board.Summary[bucket]; n > 0 {
 			fmt.Fprintf(&b, "- `%s`: %d\n", bucket, n)
+		}
+	}
+
+	if board.Gate != nil {
+		fmt.Fprintf(&b, "\n## Hard zero-cliff gate\n\n")
+		fmt.Fprintf(&b, "- outcome: `%s`\n", strings.ToUpper(board.Gate.Status))
+		fmt.Fprintf(&b, "- full files evaluated: `%d/%d` (measured rows `%d`)\n",
+			board.Gate.FullFilesEvaluated, board.Gate.FilesExpected, board.Gate.FilesMeasured)
+		fmt.Fprintf(&b, "- failures: `%d`; full files at or below `%.2fx`: `%d`\n",
+			len(board.Gate.Failures), board.Gate.FastFullParseRatio, len(board.Gate.FastFullFiles))
+		fmt.Fprintf(&b, "\nThis is a timing/resource gate. Structural and error-tree parity remain owned by the separate correctness suites.\n")
+		if len(board.Gate.Failures) > 0 {
+			fmt.Fprintf(&b, "\n### Gate failures\n\n")
+			for _, finding := range board.Gate.Failures {
+				fmt.Fprintf(&b, "- **%s** `%s` axis=%s kind=%s status=%s ratio=%.4fx — %s\n",
+					finding.Language, finding.Path, finding.Axis, finding.Kind, finding.Status, finding.Ratio, finding.Detail)
+			}
+		}
+		if len(board.Gate.FastFullFiles) > 0 {
+			fmt.Fprintf(&b, "\n### Full-parse files at least 10x faster than C\n\n")
+			for _, finding := range board.Gate.FastFullFiles {
+				fmt.Fprintf(&b, "- **%s** `%s` ratio=%.4fx — %s\n", finding.Language, finding.Path, finding.Ratio, finding.Detail)
+			}
 		}
 	}
 
@@ -1730,7 +2190,7 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 				if !ok {
 					continue
 				}
-				isCliff := fa.Verdict == perfScanBucketCliff || fa.Status == "go_timeout"
+				isCliff := fa.Verdict == perfScanBucketCliff || perfScanIsGoStop(fa.Stop)
 				if !isCliff {
 					continue
 				}
@@ -1765,8 +2225,8 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 			fmt.Fprintf(&b, "%s\n", line)
 		}
 	}
-	fmt.Fprintf(&b, "\nBuckets: `%s` / `%s` / `%s` / `%s` (ratio = Go median / C median; per-language ratio-by-total = sum of Go file medians / sum of C file medians; `>=` marks a lower bound from a budget timeout).\n",
-		perfScanBucketLe12, perfScanBucketLe2, perfScanBucketGt2, perfScanBucketCliff)
+	fmt.Fprintf(&b, "\nBuckets: `%s` / `%s` / `%s` / `%s` / `%s` (ratio = Go median / C median; per-language ratio-by-total = sum of Go file medians / sum of C file medians; `>=` marks a lower bound from a budget timeout).\n",
+		perfScanBucketLePoint1, perfScanBucketLe12, perfScanBucketLe2, perfScanBucketGt2, perfScanBucketCliff)
 	return b.String()
 }
 
@@ -1775,6 +2235,9 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 // ---------------------------------------------------------------------------
 
 func TestPerfScanHelpersUnit(t *testing.T) {
+	if got := perfScanVerdictBucket(0.10); got != perfScanBucketLePoint1 {
+		t.Fatalf("bucket(0.10)=%s", got)
+	}
 	if got := perfScanVerdictBucket(1.0); got != perfScanBucketLe12 {
 		t.Fatalf("bucket(1.0)=%s", got)
 	}
@@ -1835,6 +2298,21 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	t.Setenv(perfScanEnvChildRSSMB, "321")
 	if got := perfScanLoadConfig().ChildRSSMB; got != 321 {
 		t.Fatalf("ChildRSSMB = %d, want 321", got)
+	}
+	if got := perfScanGoParserStop(gotreesitter.ParseStopMemoryBudget, 5*time.Second); got.Class != perfScanStopParserBudget || got.Reason != string(gotreesitter.ParseStopMemoryBudget) {
+		t.Fatalf("memory stop classification = %+v", got)
+	}
+	if got := perfScanGoParserStop(gotreesitter.ParseStopTimeout, 5*time.Second); got.Class != perfScanStopParserTimeout {
+		t.Fatalf("timeout stop classification = %+v", got)
+	}
+	axisStop := &perfScanFileAxis{}
+	perfScanRecordAttemptStop(axisStop, perfScanAttempt{stop: &perfScanStop{Class: perfScanStopParserBudget, Implementation: "go"}}, "rep", 1)
+	perfScanRecordAttemptStop(axisStop, perfScanAttempt{stop: &perfScanStop{Class: perfScanStopCTimeout, Implementation: "c"}}, "rep", 2)
+	if axisStop.Stop == nil || axisStop.Stop.Implementation != "go" || axisStop.Stop.Class != perfScanStopParserBudget {
+		t.Fatalf("C stop overwrote causal Go stop: %+v", axisStop.Stop)
+	}
+	if got, err := perfScanExpectedCorpusLockDigest(); err != nil || got != "cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2" {
+		t.Fatalf("checked corpus lock digest = %q,%v", got, err)
 	}
 
 	fragDir := t.TempDir()
@@ -1912,5 +2390,58 @@ func TestPerfScanHelpersUnit(t *testing.T) {
 	_, att := (&perfScanLangMeasurer{budget: 5 * time.Second}).classifyGoAttempt(tree, nil, "", src, false, perfScanAttempt{})
 	if att.status != "go_error" || !strings.Contains(att.detail, "truncated[SILENT]") {
 		t.Fatalf("silent prefix tree classified as status=%q detail=%q, want go_error truncated[SILENT]", att.status, att.detail)
+	}
+}
+
+func TestPerfScanHardGateUnit(t *testing.T) {
+	fullAxis := func(ratio float64) *perfScanFileAxis {
+		return &perfScanFileAxis{
+			Status:     perfScanStatusOK,
+			GoMedianNs: int64(ratio * 1000),
+			CMedianNs:  1000,
+			Ratio:      ratio,
+		}
+	}
+	board := &perfScanScoreboard{
+		Config: perfScanConfig{RequireFleet: true},
+		Corpus: perfScanCorpusCoverage{LockLanguages: 1, SelectedLanguages: 1},
+		Languages: []*perfScanLanguage{{
+			Language:      "go",
+			Status:        perfScanStatusOK,
+			FilesSelected: 3,
+			FilesMeasured: 3,
+			Files: []*perfScanFile{
+				{Path: "boundary.go", Axes: map[string]*perfScanFileAxis{perfScanAxisFull: fullAxis(10)}},
+				{Path: "fast.go", Axes: map[string]*perfScanFileAxis{perfScanAxisFull: fullAxis(0.10)}},
+				{Path: "cliff.go", Axes: map[string]*perfScanFileAxis{perfScanAxisFull: fullAxis(10.001)}},
+			},
+		}},
+	}
+
+	report := perfScanEvaluateHardGate(board)
+	if report.Status != perfScanGateFail || len(report.Failures) != 1 || report.Failures[0].Kind != "ratio" {
+		t.Fatalf("cliff gate report = %+v", report)
+	}
+	if report.FullFilesEvaluated != 3 || len(report.FastFullFiles) != 1 || report.FastFullFiles[0].Path != "fast.go" {
+		t.Fatalf("full/fast file accounting = %+v", report)
+	}
+
+	board.Languages[0].Files[2].Axes[perfScanAxisFull] = fullAxis(10)
+	report = perfScanEvaluateHardGate(board)
+	if report.Status != perfScanGatePass || len(report.Failures) != 0 {
+		t.Fatalf("exact 10x boundary must pass: %+v", report)
+	}
+
+	board.Languages[0].Files[0].Axes[perfScanAxisNoEdit] = &perfScanFileAxis{
+		Status: "go_budget_stop",
+		Stop: &perfScanStop{
+			Class:          perfScanStopParserBudget,
+			Reason:         string(gotreesitter.ParseStopMemoryBudget),
+			Implementation: "go",
+		},
+	}
+	report = perfScanEvaluateHardGate(board)
+	if report.Status != perfScanGateFail || len(report.Failures) != 1 || report.Failures[0].Kind != "go_stop" {
+		t.Fatalf("Go parser-budget stop must fail independently of full ratio: %+v", report)
 	}
 }


### PR DESCRIPTION
## Summary

- enforce a per-file full-parse Go/C ceiling of 10.0x across the authenticated fleet
- fail closed on parser timeouts, parser-budget stops, wall limits, RSS limits, and OOM or kill outcomes
- verify the pinned 206-language corpus lock and each exact checkout before measurement
- report full-parse files at or below 0.10x separately as 10x-or-better wins
- keep structural correctness and historical ratio ratchets as independent evidence
- provide a manually dispatchable isolated-runner contract while local Docker remains the executable path

The hard gate is expected to expose current known cliffs; this change makes those failures explicit and reproducible.

## Review corrections

- The universal hard scan has no path exclusions. Its comparator has an explicit hard-gate-only mode so it checks authenticated coverage and exact per-file rules without inheriting the historical Groovy ratchet exclusion or applying aggregates measured on a different sample basis.
- The repository has no registered self-hosted runner, so the workflow is manual-only rather than leaving scheduled jobs queued. No runner was registered as part of this change.
- Corpus preflight now verifies origin URLs and rejects external Git object alternates in addition to exact commits, HEADs, tracked state, and locked subpaths.

## Verification

- focused budget and status tests, repeated 10 times
- focused vet
- tagged Docker helper tests
- budget and JSON validation
- workflow validation with actionlint
- authenticated preflight over all 206 corpus rows
- clean rebased diff against main
- Docker integration smoke on the largest selected Go file: the gate correctly failed closed on a structured memory-budget stop for src/cmd/compile/internal/ssa/opGen.go, retained exact file/axis/attempt attribution, and reported no container OOM
- hard-gate-only comparator reproduced that failure without exclusion or historical aggregate findings