### PR TITLE
optimize: cache contiguous recovery aggregates

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -54,15 +54,23 @@ type glrStack struct {
 	// lockstep token loop uses this to avoid letting an already-advanced
 	// sibling suppress that group's Strategy 1 recovery.
 	cRecoverMissingGroup *cRecGroup
+	// cEntryAgg* caches the recovery-cost and visible-node aggregates of this
+	// stack's contiguous entries representation. It lives on the stack value,
+	// not the shared cRecoverState pointer, so distinct materialized GSS paths
+	// cannot reuse one another's aggregate after a by-value stack copy.
+	cEntryAggGen  uint64
+	cEntryAggCost uint32
+	cEntryAggVis  int32
+	// cNodeBaseline mirrors C StackHead.node_count_at_last_error: the stack's
+	// cumulative visible-node count when the error discontinuity was last
+	// pushed. C stores this as uint32_t; keeping that width also leaves the
+	// recovery aggregates inside glrStack's existing 104-byte layout.
+	cNodeBaseline uint32
 	// cPaused mirrors C StackStatusPaused: the stack hit a no-action point
 	// under the gated recovery port and waits for the condense step to either
 	// resume it (ts_parser__handle_error) or remove it. Only ever set when
 	// errorCostCompetitionLanguage gates the grammar.
 	cPaused bool
-	// cNodeBaseline mirrors C StackHead.node_count_at_last_error: the stack's
-	// cumulative visible-node count when the error discontinuity was last
-	// pushed. Zero for stacks that never entered the C error state.
-	cNodeBaseline int
 	// cEverErrored is a sticky per-stack bit: true once this lineage has entered
 	// C's error handling at any point, even if it later recovered to a clean tree
 	// with cRec cleared and cNodeBaseline reset (or clamped) back to zero. Unlike
@@ -414,6 +422,9 @@ func (s *glrStack) clone() glrStack {
 			cRec:                       s.cRec.clone(),
 			cRecoverMissingGroup:       s.cRecoverMissingGroup,
 			cNodeBaseline:              s.cNodeBaseline,
+			cEntryAggGen:               s.cEntryAggGen,
+			cEntryAggCost:              s.cEntryAggCost,
+			cEntryAggVis:               s.cEntryAggVis,
 			cRecoveryUnvalidatedMarker: s.cRecoveryUnvalidatedMarker,
 			cEverErrored:               s.cEverErrored,
 		}
@@ -430,6 +441,9 @@ func (s *glrStack) clone() glrStack {
 		cRec:                       s.cRec.clone(),
 		cRecoverMissingGroup:       s.cRecoverMissingGroup,
 		cNodeBaseline:              s.cNodeBaseline,
+		cEntryAggGen:               s.cEntryAggGen,
+		cEntryAggCost:              s.cEntryAggCost,
+		cEntryAggVis:               s.cEntryAggVis,
 		cRecoveryUnvalidatedMarker: s.cRecoveryUnvalidatedMarker,
 		cEverErrored:               s.cEverErrored,
 	}
@@ -448,6 +462,9 @@ func (s *glrStack) cloneWithScratch(scratch *gssScratch) glrStack {
 		cRec:                       s.cRec.clone(),
 		cRecoverMissingGroup:       s.cRecoverMissingGroup,
 		cNodeBaseline:              s.cNodeBaseline,
+		cEntryAggGen:               s.cEntryAggGen,
+		cEntryAggCost:              s.cEntryAggCost,
+		cEntryAggVis:               s.cEntryAggVis,
 		cRecoveryUnvalidatedMarker: s.cRecoveryUnvalidatedMarker,
 		cEverErrored:               s.cEverErrored,
 	}
@@ -467,11 +484,20 @@ func (s *glrStack) ensureEntries(entryScratch *glrEntryScratch) []stackEntry {
 	if entryScratch != nil {
 		dst := entryScratch.allocWithCap(depth, depth+1)
 		s.entries = s.gss.materialize(dst)
+		s.invalidateCEntryAgg()
 		return s.entries
 	}
 	entries := make([]stackEntry, depth)
 	s.entries = s.gss.materialize(entries)
+	s.invalidateCEntryAgg()
 	return s.entries
+}
+
+func (s *glrStack) invalidateCEntryAgg() {
+	if s == nil {
+		return
+	}
+	s.cEntryAggGen = 0
 }
 
 // demoteLinearGSS switches a lone stack back to the contiguous entries path
@@ -498,6 +524,7 @@ func (s *glrStack) demoteLinearGSS(entryScratch *glrEntryScratch) bool {
 	s.gss = gssStack{}
 	s.entries = entries
 	s.cacheEntries = true
+	s.invalidateCEntryAgg()
 	s.byteOffset = stackByteOffset(entries)
 	return true
 }
@@ -517,6 +544,7 @@ func (s *glrStack) push(state StateID, node *Node, entryScratch *glrEntryScratch
 }
 
 func (s *glrStack) pushEntry(entry stackEntry, entryScratch *glrEntryScratch, gssScratch *gssScratch) {
+	s.invalidateCEntryAgg()
 	if s.gss.head != nil {
 		s.gss.pushEntry(entry, gssScratch)
 	}
@@ -552,6 +580,7 @@ func (s *glrStack) truncate(depth int) bool {
 			}
 		}
 		s.byteOffset = s.gss.byteOffset()
+		s.invalidateCEntryAgg()
 		return true
 	}
 	if depth < 0 || depth > len(s.entries) {
@@ -559,6 +588,7 @@ func (s *glrStack) truncate(depth int) bool {
 	}
 	s.entries = s.entries[:depth]
 	s.byteOffset = stackByteOffset(s.entries)
+	s.invalidateCEntryAgg()
 	return true
 }
 
@@ -574,12 +604,14 @@ func (s *glrStack) truncateBeforePush(depth int) bool {
 				s.entries = s.gss.materialize(s.entries[:0])
 			}
 		}
+		s.invalidateCEntryAgg()
 		return true
 	}
 	if depth < 0 || depth > len(s.entries) {
 		return false
 	}
 	s.entries = s.entries[:depth]
+	s.invalidateCEntryAgg()
 	return true
 }
 

--- a/glr_test.go
+++ b/glr_test.go
@@ -12,6 +12,18 @@ func TestStackEntrySizeBudget(t *testing.T) {
 	}
 }
 
+func TestCRecoverStateSizeBudget(t *testing.T) {
+	if got := unsafe.Sizeof(cRecoverState{}); got != 48 {
+		t.Fatalf("cRecoverState size = %d, want 48", got)
+	}
+}
+
+func TestGLRStackSizeBudget(t *testing.T) {
+	if got := unsafe.Sizeof(glrStack{}); got != 104 {
+		t.Fatalf("glrStack size = %d, want 104", got)
+	}
+}
+
 func TestNoTreeNodeSizeBudget(t *testing.T) {
 	// Ratchet: e70dd873 ("Add raw shape tracking, GLR recovery flags, and
 	// refactor parser APIs") intentionally added rawShape (rawShapeRef,

--- a/parser.go
+++ b/parser.go
@@ -2104,6 +2104,7 @@ func (p *Parser) tryRecoverPreviousShiftAsError(s *glrStack, tok Token, nodeCoun
 	s.entries = entries
 	s.gss = gssStack{}
 	s.cacheEntries = true
+	s.invalidateCEntryAgg()
 	s.byteOffset = stackByteOffset(entries)
 	s.shifted = false
 	if s.recoverabilityKnown && !s.mayRecover && p.stateCanRecover(prevState) {
@@ -6484,6 +6485,7 @@ func clearParseStackEntryCaches(stacks []glrStack) {
 		stacks[i].cacheEntries = false
 		if stacks[i].gss.head != nil {
 			stacks[i].entries = nil
+			stacks[i].invalidateCEntryAgg()
 		}
 	}
 }

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -913,15 +913,15 @@ type cRecoverState struct {
 	summary []cStackSummaryEntry
 	// group ties the absorbing stacks that represent the same C version.
 	group *cRecGroup
-	// groupOrder preserves the path order inside the C merged error-state
-	// version. Later Go stack ordering can move members around, but C's
-	// strategy-1 summary scan still walks the merged paths in record order.
-	groupOrder int
 	// openErr is the open error region node on the stack top (the C
 	// error_repeat being accumulated). nil right after entering the error
 	// state — the C "ERROR_STATE head with NULL subtree" shape, which costs an
 	// extra ERROR_COST_PER_RECOVERY in ts_stack_error_cost.
 	openErr *Node
+	// groupOrder preserves the path order inside the C merged error-state
+	// version. Later Go stack ordering can move members around, but C's
+	// strategy-1 summary scan still walks the merged paths in record order.
+	groupOrder uint32
 	// extraRecoveries counts the additional error segments C opens while this
 	// version keeps absorbing: an unlexable-run (ERROR-token) lookahead has no
 	// action in the ERROR_STATE table row, so C pauses AGAIN mid-absorption,
@@ -934,14 +934,19 @@ type cRecoverState struct {
 	// engine's single flat open region charges its 500 once, so the extra
 	// per-segment recoveries are tracked here; forks drop cRec and with it
 	// these charges, exactly like C.
-	extraRecoveries int
+	extraRecoveries uint32
 }
 
 func (r *cRecoverState) clone() *cRecoverState {
 	if r == nil {
 		return nil
 	}
-	cp := &cRecoverState{openErr: r.openErr, group: r.group, groupOrder: r.groupOrder, extraRecoveries: r.extraRecoveries}
+	cp := &cRecoverState{
+		openErr:         r.openErr,
+		group:           r.group,
+		groupOrder:      r.groupOrder,
+		extraRecoveries: r.extraRecoveries,
+	}
 	if len(r.summary) > 0 {
 		cp.summary = append([]cStackSummaryEntry(nil), r.summary...)
 	}
@@ -1589,9 +1594,13 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 	}
 	var cost uint32
 	if len(s.entries) > 0 {
-		for i := range s.entries {
-			if n := stackEntryNode(s.entries[i]); n != nil {
-				cost += p.cNodeErrorCost(n)
+		if p != nil && p.cNodeMemo != nil && s.cRec != nil {
+			cost, _ = p.cStackEntryAgg(s)
+		} else {
+			for i := range s.entries {
+				if n := stackEntryNode(s.entries[i]); n != nil {
+					cost += p.cNodeErrorCost(n)
+				}
 			}
 		}
 	} else if p != nil && p.cNodeMemo != nil && s.gss.head != nil {
@@ -1616,6 +1625,34 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 		cost += cErrCostPerRecovery * uint32(s.cRec.extraRecoveries)
 	}
 	return cost
+}
+
+// cStackEntryAgg is the contiguous-stack counterpart of cStackPrefixAgg. It
+// computes both C recovery aggregates in one walk and keeps the answer on the
+// stack until either a recovery-relevant node mutation bumps gssPrefixAggGen
+// or a stack push/truncate/materialization explicitly invalidates it.
+func (p *Parser) cStackEntryAgg(s *glrStack) (uint32, int) {
+	if s == nil {
+		return 0, 0
+	}
+	gen := gssPrefixAggGen.Load()
+	if p != nil && p.cNodeMemo != nil && s.cRec != nil && s.cEntryAggGen == gen {
+		return s.cEntryAggCost, int(s.cEntryAggVis)
+	}
+	var cost uint32
+	var vis int32
+	for i := range s.entries {
+		if n := stackEntryNode(s.entries[i]); n != nil {
+			cost += p.cNodeErrorCost(n)
+			vis += int32(p.cNodeVisibleSubtreeCount(n))
+		}
+	}
+	if p != nil && p.cNodeMemo != nil && s.cRec != nil {
+		s.cEntryAggGen = gen
+		s.cEntryAggCost = cost
+		s.cEntryAggVis = vis
+	}
+	return cost, int(vis)
 }
 
 func cStackErrorCostForMerge(lang *Language, s *glrStack) uint32 {
@@ -1666,9 +1703,13 @@ func (p *Parser) cStackCumulativeNodeCount(s *glrStack) int {
 	}
 	count := 0
 	if len(s.entries) > 0 {
-		for i := range s.entries {
-			if n := stackEntryNode(s.entries[i]); n != nil {
-				count += p.cNodeVisibleSubtreeCount(n)
+		if p != nil && p.cNodeMemo != nil && s.cRec != nil {
+			_, count = p.cStackEntryAgg(s)
+		} else {
+			for i := range s.entries {
+				if n := stackEntryNode(s.entries[i]); n != nil {
+					count += p.cNodeVisibleSubtreeCount(n)
+				}
 			}
 		}
 		return count
@@ -1699,7 +1740,7 @@ func (p *Parser) cApplyMergedErrorGroupBaseline(versions []glrStack) int {
 		}
 	}
 	for vi := range versions {
-		versions[vi].cNodeBaseline = groupBaseline
+		versions[vi].cNodeBaseline = uint32(groupBaseline)
 		// Writing a node-count baseline is definitionally an error-state entry;
 		// set the sticky wreckage bit alongside it so the (untrustworthy — it can
 		// be written as 0 here, or clamped back to 0 by cNodeCountSinceError)
@@ -1718,10 +1759,10 @@ func (p *Parser) cNodeCountSinceError(s *glrStack) int {
 	if s == nil {
 		return 0
 	}
-	count := p.cStackCumulativeNodeCount(s) - s.cNodeBaseline
+	count := p.cStackCumulativeNodeCount(s) - int(s.cNodeBaseline)
 	if count < 0 {
 		// C clamps (and writes back) when the stack popped below the baseline.
-		s.cNodeBaseline = p.cStackCumulativeNodeCount(s)
+		s.cNodeBaseline = uint32(p.cStackCumulativeNodeCount(s))
 		return 0
 	}
 	return count
@@ -2479,7 +2520,7 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 				}
 			}
 		}
-		v.cRec = &cRecoverState{summary: p.cRecordSummary(entries), group: group, groupOrder: vi}
+		v.cRec = &cRecoverState{summary: p.cRecordSummary(entries), group: group, groupOrder: uint32(vi)}
 		v.cRecoverMissingGroup = nil
 	}
 
@@ -2979,7 +3020,7 @@ func (p *Parser) cRecoverEOFAccept(v *glrStack, tok Token, nodeCount *int, arena
 		cSetNodeSpan(root, tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
 	}
 	root.setHasError(true)
-	nodeBumpEquivVersion(root)
+	nodeBumpEquivVersionBeforePublication(root)
 	if perfCountersEnabled {
 		perfRecordErrorNode()
 	}
@@ -3183,7 +3224,7 @@ func (p *Parser) cRecoverToState(v *glrStack, depth int, goal StateID, arena *no
 		errNode.setExtra(true)
 		errNode.preGotoState = goal
 		errNode.parseState = goal
-		nodeBumpEquivVersion(errNode)
+		nodeBumpEquivVersionBeforePublication(errNode)
 		if perfCountersEnabled {
 			perfRecordErrorNode()
 		}
@@ -3339,7 +3380,7 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	cSetNodeSpan(errNode, tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
 	errNode.setHasError(true)
 	errNode.parseState = cErrorState
-	nodeBumpEquivVersion(errNode)
+	nodeBumpEquivVersionBeforePublication(errNode)
 	if perfCountersEnabled {
 		perfRecordErrorNode()
 	}
@@ -3846,7 +3887,7 @@ func (p *Parser) cAcceptRootRebuild(s *glrStack, arena *nodeArena, entryScratch 
 	if hasErr || cand.hasError() {
 		root.setHasError(true)
 	}
-	nodeBumpEquivVersion(root)
+	nodeBumpEquivVersionBeforePublication(root)
 	if !s.truncate(1) {
 		return ParseStopNone
 	}

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -199,7 +199,7 @@ func TestCApplyMergedErrorGroupBaselineUsesMaxHeadNodeCount(t *testing.T) {
 		t.Fatalf("merged baseline = %d, want max cumulative node count 3", baseline)
 	}
 	for i := range versions {
-		if got := versions[i].cNodeBaseline; got != baseline {
+		if got := versions[i].cNodeBaseline; got != uint32(baseline) {
 			t.Fatalf("version %d baseline = %d, want shared %d", i, got, baseline)
 		}
 	}
@@ -212,7 +212,7 @@ func TestCApplyMergedErrorGroupBaselineUsesMaxHeadNodeCount(t *testing.T) {
 	if got := parser.cNodeCountSinceError(&versions[1]); got != 0 {
 		t.Fatalf("long version node count since error = %d, want 0", got)
 	}
-	if got := versions[1].cNodeBaseline; got != baseline {
+	if got := versions[1].cNodeBaseline; got != uint32(baseline) {
 		t.Fatalf("long version baseline after node count = %d, want shared %d", got, baseline)
 	}
 }
@@ -614,7 +614,7 @@ func cRecoveryElectionStack(arena *nodeArena, base, top StateID, endByte uint32,
 	s := cRecoveryElectionPlainStack(arena, base, top, endByte)
 	s.cRec = &cRecoverState{
 		group:      group,
-		groupOrder: groupOrder,
+		groupOrder: uint32(groupOrder),
 		summary:    summary,
 	}
 	s.cNodeBaseline = 1

--- a/parser_recover_prefix_agg_test.go
+++ b/parser_recover_prefix_agg_test.go
@@ -2,6 +2,46 @@ package gotreesitter
 
 import "testing"
 
+func TestBeforePublicationVersionBumpDoesNotInvalidateLivePrefixes(t *testing.T) {
+	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
+	p := &Parser{
+		language:  lang,
+		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+	}
+	published := &Node{symbol: 1, equivVersion: 1}
+	head := &gssNode{entry: newStackEntryNode(1, published), depth: 1}
+	if cost, visible := p.cStackPrefixAgg(head); cost != 0 || visible != 1 {
+		t.Fatalf("initial published aggregate = (%d, %d), want (0, 1)", cost, visible)
+	}
+	gen := gssPrefixAggGen.Load()
+
+	fresh := &Node{symbol: 1, equivVersion: 1, errorRankCache: 3}
+	fresh.setMissing(true) // Recovery-relevant, but the node is not published.
+	nodeBumpEquivVersionBeforePublication(fresh)
+	if fresh.equivVersion != 2 {
+		t.Fatalf("fresh equiv version = %d, want 2", fresh.equivVersion)
+	}
+	if fresh.errorRankCache != 0 {
+		t.Fatalf("fresh error-rank cache = %d, want invalidated", fresh.errorRankCache)
+	}
+	if got := gssPrefixAggGen.Load(); got != gen {
+		t.Fatalf("before-publication bump changed prefix generation from %d to %d", gen, got)
+	}
+	if cost, visible := p.cStackPrefixAgg(head); cost != 0 || visible != 1 {
+		t.Fatalf("aggregate after fresh bump = (%d, %d), want (0, 1)", cost, visible)
+	}
+
+	published.setMissing(true)
+	nodeBumpEquivVersion(published)
+	if got := gssPrefixAggGen.Load(); got == gen {
+		t.Fatalf("published recovery mutation left prefix generation at %d", got)
+	}
+	wantCost := uint32(cErrCostPerMissingTree + cErrCostPerRecovery)
+	if cost, visible := p.cStackPrefixAgg(head); cost != wantCost || visible != 1 {
+		t.Fatalf("aggregate after published bump = (%d, %d), want (%d, 1)", cost, visible, wantCost)
+	}
+}
+
 func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
 	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
 	p := &Parser{
@@ -44,6 +84,110 @@ func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
 	wantCost := uint32(cErrCostPerMissingTree + cErrCostPerRecovery)
 	if cost != wantCost || visible != 1 {
 		t.Fatalf("post-missing aggregate = (%d, %d), want (%d, 1)", cost, visible, wantCost)
+	}
+}
+
+func TestContiguousRecoveryAggregateCacheTracksStackAndNodeMutations(t *testing.T) {
+	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
+	p := &Parser{
+		language:  lang,
+		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+	}
+	first := &Node{symbol: 1, equivVersion: 1}
+	missing := &Node{symbol: 1, equivVersion: 1}
+	missing.setMissing(true)
+	stack := glrStack{
+		entries: []stackEntry{newStackEntryNode(1, first)},
+		cRec:    &cRecoverState{},
+	}
+
+	if cost, visible := p.cStackEntryAgg(&stack); cost != 0 || visible != 1 {
+		t.Fatalf("initial aggregate = (%d, %d), want (0, 1)", cost, visible)
+	}
+	if got, want := stack.cEntryAggGen, gssPrefixAggGen.Load(); got != want {
+		t.Fatalf("initial cache generation = %d, want %d", got, want)
+	}
+
+	stack.push(2, missing, nil, nil)
+	if stack.cEntryAggGen != 0 {
+		t.Fatalf("push left cache generation at %d, want invalid", stack.cEntryAggGen)
+	}
+	wantMissingCost := uint32(cErrCostPerMissingTree + cErrCostPerRecovery)
+	if cost, visible := p.cStackEntryAgg(&stack); cost != wantMissingCost || visible != 2 {
+		t.Fatalf("post-push aggregate = (%d, %d), want (%d, 2)", cost, visible, wantMissingCost)
+	}
+
+	if !stack.truncate(1) {
+		t.Fatal("truncate failed")
+	}
+	if stack.cEntryAggGen != 0 {
+		t.Fatalf("truncate left cache generation at %d, want invalid", stack.cEntryAggGen)
+	}
+	if cost, visible := p.cStackEntryAgg(&stack); cost != 0 || visible != 1 {
+		t.Fatalf("post-truncate aggregate = (%d, %d), want (0, 1)", cost, visible)
+	}
+
+	child := &Node{symbol: 1, equivVersion: 1}
+	first.children = append(first.children, child)
+	oldGen := gssPrefixAggGen.Load()
+	nodeBumpEquivVersion(first)
+	if got := gssPrefixAggGen.Load(); got == oldGen {
+		t.Fatalf("recovery-relevant mutation left generation at %d", got)
+	}
+	if cost, visible := p.cStackEntryAgg(&stack); cost != 0 || visible != 2 {
+		t.Fatalf("post-node-mutation aggregate = (%d, %d), want (0, 2)", cost, visible)
+	}
+
+	cachedGen := stack.cEntryAggGen
+	first.parseState++
+	nodeBumpEquivVersionMetadata(first)
+	if got := gssPrefixAggGen.Load(); got != cachedGen {
+		t.Fatalf("metadata-only mutation changed generation from %d to %d", cachedGen, got)
+	}
+	if cost, visible := p.cStackEntryAgg(&stack); cost != 0 || visible != 2 {
+		t.Fatalf("post-metadata aggregate = (%d, %d), want (0, 2)", cost, visible)
+	}
+}
+
+func TestExpandedGSSResultPathsKeepIndependentRecoveryAggregates(t *testing.T) {
+	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
+	p := &Parser{
+		language:  lang,
+		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+	}
+	plain := &Node{symbol: 1, equivVersion: 1}
+	errChild := &Node{symbol: 1, equivVersion: 1, endByte: 1}
+	errNode := &Node{
+		symbol:       errorSymbol,
+		equivVersion: 1,
+		endByte:      1,
+		children:     []*Node{errChild},
+	}
+	head := &gssNode{
+		entry: newStackEntryNode(1, plain),
+		depth: 1,
+		extraLinks: []gssMainLink{{
+			entry: newStackEntryNode(1, errNode),
+		}},
+	}
+	source := glrStack{
+		gss:  gssStack{head: head},
+		cRec: &cRecoverState{},
+	}
+
+	paths := appendExpandedGSSResultPaths(nil, source, 2)
+	if len(paths) != 2 {
+		t.Fatalf("expanded path count = %d, want 2", len(paths))
+	}
+	if cost, visible := p.cStackEntryAgg(&paths[0]); cost != 0 || visible != 1 {
+		t.Fatalf("plain path aggregate = (%d, %d), want (0, 1)", cost, visible)
+	}
+	wantErrorCost := uint32(cErrCostPerRecovery + cErrCostPerSkippedTree + cErrCostPerSkippedChar)
+	if cost, visible := p.cStackEntryAgg(&paths[1]); cost != wantErrorCost || visible != 2 {
+		t.Fatalf("error path aggregate = (%d, %d), want (%d, 2)", cost, visible, wantErrorCost)
+	}
+	if paths[0].cEntryAggCost != 0 || paths[0].cEntryAggVis != 1 {
+		t.Fatalf("plain path cache changed to (%d, %d)", paths[0].cEntryAggCost, paths[0].cEntryAggVis)
 	}
 }
 

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -1120,7 +1120,7 @@ func (p *Parser) tryNearestActionStateRecovery(s *glrStack, tok Token, nodeCount
 	errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, errChildren, 0)
 	errNode.setHasError(true)
 	errNode.setExtra(true)
-	nodeBumpEquivVersion(errNode)
+	nodeBumpEquivVersionBeforePublication(errNode)
 	if perfCountersEnabled {
 		perfRecordErrorNode()
 	}
@@ -1424,7 +1424,7 @@ func (p *Parser) tryResyncErrorRecoveryMode(source []byte, s *glrStack, tok Toke
 	// map; eager link wiring here would link this ERROR under itself.
 	errNode := p.newRecoveryParentNodeInArena(arena, errorSymbol, true, errChildren, 0)
 	errNode.setHasError(true)
-	nodeBumpEquivVersion(errNode)
+	nodeBumpEquivVersionBeforePublication(errNode)
 	if perfCountersEnabled {
 		perfRecordErrorNode()
 	}
@@ -1502,7 +1502,7 @@ func (p *Parser) rebuildAliasPrefixedRecoveredSuffix(source []byte, state StateI
 	if shiftTarget, ok := p.shiftTargetForStateSymbol(state, alt); ok {
 		aliasLeaf.parseState = shiftTarget
 	}
-	nodeBumpEquivVersion(aliasLeaf)
+	nodeBumpEquivVersionBeforePublication(aliasLeaf)
 	children = append(children, aliasLeaf)
 	for i := 0; i < childCount; i++ {
 		child := nodeChildAtForReason(recovered, i, materializeForRecovery)
@@ -1528,6 +1528,8 @@ func (p *Parser) rebuildAliasPrefixedRecoveredSuffix(source []byte, state StateI
 	return rebuilt, target, true
 }
 
+// materializeAnonymousChildrenForRecoveredError operates only on a fresh
+// recovery node before its first attachment to a stack or returned tree.
 func (p *Parser) materializeAnonymousChildrenForRecoveredError(source []byte, n *Node, arena *nodeArena) {
 	if p == nil || p.language == nil || n == nil || n.symbol != errorSymbol || nodeChildCountNoMaterialize(n) != 0 {
 		return
@@ -1563,9 +1565,11 @@ func (p *Parser) materializeAnonymousChildrenForRecoveredError(source []byte, n 
 	n.children = children
 	n.setNamed(true)
 	n.setHasError(true)
-	nodeBumpEquivVersion(n)
+	nodeBumpEquivVersionBeforePublication(n)
 }
 
+// restoreAnonymousTokenForRecoveredTail operates only on a fresh clone before
+// it is attached to the rebuilt recovery suffix.
 func (p *Parser) restoreAnonymousTokenForRecoveredTail(source []byte, n *Node) {
 	if p == nil || p.language == nil || n == nil || nodeChildCountNoMaterialize(n) != 0 {
 		return
@@ -1588,7 +1592,7 @@ func (p *Parser) restoreAnonymousTokenForRecoveredTail(source []byte, n *Node) {
 		if symMeta.Visible && !symMeta.Named {
 			n.symbol = sym
 			n.setNamed(false)
-			nodeBumpEquivVersion(n)
+			nodeBumpEquivVersionBeforePublication(n)
 			return
 		}
 	}
@@ -3891,6 +3895,7 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 		target.gss.head = fork.popTo
 		if target.entries != nil {
 			target.entries = nil
+			target.invalidateCEntryAgg()
 		}
 
 		if child := p.collapsibleUnarySelfReduction(act, tok, arena, window, 0, reducedEnd, children, fieldIDs); child != nil {

--- a/parser_result.go
+++ b/parser_result.go
@@ -400,6 +400,9 @@ func appendExpandedGSSResultPaths(dst []glrStack, source glrStack, capPerStack i
 			candidate := source
 			candidate.gss = gssStack{}
 			candidate.entries = entries
+			// The source aggregate describes its original contiguous path (if
+			// any), not this newly materialized packed-link alternative.
+			candidate.invalidateCEntryAgg()
 			dst = append(dst, candidate)
 			capPerStack--
 			return

--- a/tree.go
+++ b/tree.go
@@ -106,11 +106,12 @@ func nodeInitEquivVersion(n *Node) {
 }
 
 // nodeBumpEquivVersionMetadata invalidates caches keyed by the node's complete
-// parser identity without invalidating GSS recovery-prefix aggregates. Use it
-// only for mutations that cannot change cNodeErrorCost or
+// parser identity without invalidating GSS recovery-prefix aggregates. Call it
+// directly only for mutations that cannot change cNodeErrorCost or
 // cNodeVisibleSubtreeCount: parser states, production/raw-shape metadata, and
-// dynamic precedence. Symbol, child, missing/extra, and ERROR-span mutations
-// must use nodeBumpEquivVersion instead.
+// dynamic precedence. On published nodes, symbol, child, missing/extra, and
+// ERROR-span mutations must use nodeBumpEquivVersion instead; fresh nodes use
+// nodeBumpEquivVersionBeforePublication.
 func nodeBumpEquivVersionMetadata(n *Node) {
 	if n == nil {
 		return
@@ -123,6 +124,17 @@ func nodeBumpEquivVersionMetadata(n *Node) {
 	// mutation choke point that invalidated the former version-keyed arena map
 	// now invalidates the inline cache directly.
 	n.errorRankCache = 0
+}
+
+// nodeBumpEquivVersionBeforePublication invalidates node-local caches after a
+// recovery-relevant mutation to a fresh node that is provably not reachable
+// from any GSS stack or returned tree yet. Because no cached GSS prefix can
+// include an unpublished node, changing its error-cost or visible-count
+// contribution must not invalidate every live prefix process-wide.
+//
+// Published nodes must use nodeBumpEquivVersion instead.
+func nodeBumpEquivVersionBeforePublication(n *Node) {
+	nodeBumpEquivVersionMetadata(n)
 }
 
 func nodeBumpEquivVersion(n *Node) {


### PR DESCRIPTION
## Summary\n\n- cache contiguous recovery-stack cost and visible-node aggregates\n- invalidate cached values at stack mutation and packed-path materialization boundaries\n- preserve live prefix aggregates when mutating recovery nodes before publication\n- retain existing stack and recovery-state size budgets\n\n## Validation\n\n- focused recovery tests pass repeatedly\n- focused race coverage passes in Docker\n- SQL real-corpus parity: 25/25 no-error, S-expression, and deep parity\n- SQL largest-eight Go timings improve by about 6–47 percent; numeric_big.sql drops from 1.416 s to 0.865 s\n- MATLAB largest-eight Go timings improve by about 7–24 percent; gallery.m drops from 5.158 s to 3.906 s\n- the standard full, single-byte incremental, and no-edit benchmark trio shows no regression\n