### PR TITLE
optimize: bound certified full-parse retries

### DIFF
--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -50,6 +50,17 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 	},
+	// Swift's low-pressure accepted-error parses select the same tree across
+	// the retry ladder. High-pressure parses still benefit from the first
+	// ladder, while repeating that ladder for the external scanner does not.
+	"swift": {
+		blobSHA256:                    mustRuntimeProfileSHA256("3837a017a16785dbd8daa9661dbd5688393f2c72cf18b568a7957bd35f2cac6d"),
+		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry:  true,
+			SkipCompleteMaxEntryScratchPeak: 3 * 64 * 1024,
+		},
+	},
 	// Large ASM accepted-error parses improve during the same-stack merge
 	// retry, but later widened-stack passes do not advance the selected tree.
 	// Keep that first retry while avoiding the redundant wider passes.

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -17,6 +17,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 		{name: "dart", load: DartLanguage},
 		{name: "kotlin", load: KotlinLanguage},
 		{name: "python", load: PythonLanguage},
+		{name: "swift", load: SwiftLanguage},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -32,7 +33,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 15; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 16; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -109,6 +110,7 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 		{name: "odin", load: OdinLanguage},
 		{name: "rego", load: RegoLanguage},
 		{name: "scss", load: ScssLanguage},
+		{name: "swift", load: SwiftLanguage},
 		{name: "tcl", load: TclLanguage},
 	}
 	for _, tt := range tests {
@@ -116,6 +118,9 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 			profile := tt.load().FullParseAcceptedErrorRetryProfile
 			if !profile.SkipCompleteAcceptedErrorRetry {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want skip-complete certification", profile)
+			}
+			if tt.name == "swift" && profile.SkipCompleteMaxEntryScratchPeak != 3*64*1024 {
+				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want first-growth entry-scratch ceiling", profile)
 			}
 			if tt.name == "tcl" && profile.FreshErrorNoStacksMaxPasses != 1 {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want one fresh no-stacks retry", profile)
@@ -219,7 +224,7 @@ func TestBuiltinBoundedAcceptedErrorRetryProfilesRequireCertifiedBlob(t *testing
 }
 
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	for _, name := range []string{"caddy", "haxe", "kdl", "odin", "rego", "scss", "tcl"} {
+	for _, name := range []string{"caddy", "haxe", "kdl", "odin", "rego", "scss", "swift", "tcl"} {
 		t.Run(name, func(t *testing.T) {
 			lang := &gotreesitter.Language{Name: name}
 			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {

--- a/language.go
+++ b/language.go
@@ -292,6 +292,9 @@ type FullParseAcceptedErrorRetryProfile struct {
 	InitialStackCeiling            uint16
 	SkipCompleteAcceptedErrorRetry bool
 	FreshErrorNoStacksMaxPasses    uint8
+	// SkipCompleteMaxEntryScratchPeak limits the complete-tree skip to a
+	// certified peak number of live GLR scratch entries. Zero is unbounded.
+	SkipCompleteMaxEntryScratchPeak uint32
 }
 
 // Language holds all data needed to parse a specific language.

--- a/parser.go
+++ b/parser.go
@@ -3133,6 +3133,7 @@ func captureParseScratchStats(parseRuntime *ParseRuntime, scratch *parserScratch
 	parseRuntime.ScratchBytesAllocated = scratch.allocatedBytes()
 	parseRuntime.ScratchBaselineBytes = scratch.budgetBaselineBytes
 	parseRuntime.EntryScratchBytesAllocated = scratch.entries.allocatedBytes
+	parseRuntime.EntryScratchPeak = uint64(scratch.entries.peakEntriesUsed())
 	parseRuntime.GSSBytesAllocated = scratch.gss.allocatedBytes
 	parseRuntime.GSSBaselineBytes = scratch.gssBaselineBytes
 	parseRuntime.GSSSlabCount = len(scratch.gss.slabs)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -885,6 +885,16 @@ func TestCompleteAcceptedErrorRetrySkipRequiresCertification(t *testing.T) {
 	if got := fullParseRetryMergePerKeyOverride(tree, 128, 8); got != 0 {
 		t.Fatalf("certified complete accepted-error merge override = %d, want 0", got)
 	}
+
+	tree.language.FullParseAcceptedErrorRetryProfile.SkipCompleteMaxEntryScratchPeak = 1024
+	tree.parseRuntime.EntryScratchPeak = 1025
+	if !shouldRetryAcceptedErrorParse(tree, 128, 8) {
+		t.Fatal("accepted-error tree above the certified entry-scratch peak skipped retry")
+	}
+	tree.parseRuntime.EntryScratchPeak = 1024
+	if shouldRetryAcceptedErrorParse(tree, 128, 8) {
+		t.Fatal("accepted-error tree at the certified entry-scratch peak scheduled retry")
+	}
 }
 
 func certifiedFreshErrorNoStacksTestTree(profile bool, sourceLen int) *Tree {

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1219,7 +1219,12 @@ func certifiedAcceptedErrorRetrySkipsComplete(tree *Tree, sourceLen int) bool {
 		!tree.language.FullParseAcceptedErrorRetryProfile.SkipCompleteAcceptedErrorRetry {
 		return false
 	}
+	profile := tree.language.FullParseAcceptedErrorRetryProfile
 	rt := tree.ParseRuntime()
+	if profile.SkipCompleteMaxEntryScratchPeak > 0 &&
+		rt.EntryScratchPeak > uint64(profile.SkipCompleteMaxEntryScratchPeak) {
+		return false
+	}
 	return rt.StopReason == ParseStopAccepted &&
 		!rt.Truncated &&
 		!rt.TokenSourceEOFEarly &&

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -30,8 +30,14 @@ func TestGLREntryScratchResetClearsReservedWrittenRange(t *testing.T) {
 	node := &Node{symbol: 1}
 	entries = entries[:cap(entries)]
 	entries[len(entries)-1] = newStackEntryNode(7, node)
+	if got := scratch.peakEntriesUsed(); got != 8 {
+		t.Fatalf("peak entries before reset = %d, want 8", got)
+	}
 
 	scratch.reset()
+	if got := scratch.peakEntriesUsed(); got != 0 {
+		t.Fatalf("peak entries after reset = %d, want 0", got)
+	}
 	if len(scratch.slabs) == 0 {
 		t.Fatal("expected retained entry slab")
 	}

--- a/tree.go
+++ b/tree.go
@@ -821,6 +821,7 @@ type ParseRuntime struct {
 	ScratchBytesAllocated                         int64
 	ScratchBaselineBytes                          int64
 	EntryScratchBytesAllocated                    int64
+	EntryScratchPeak                              uint64
 	GSSBytesAllocated                             int64
 	GSSBaselineBytes                              int64
 	GSSSlabCount                                  int


### PR DESCRIPTION
## Summary

- record per-parse peak GLR entry-scratch use
- bound SHA-certified accepted-error retry skips by that peak
- avoid redundant Swift retry replay while preserving high-pressure retry selection

## Validation

- focused root and grammar race tests pass in Docker
- focused built-in Swift fresh-parse and no-error C parity passes
- locked eight-file Swift scan reduces stopped files from seven to three; four files now complete on both full and no-edit axes
- direct baseline/candidate traversal confirms identical selected Go trees for all eight files
- standard full, single-byte incremental, and no-edit benchmark trio shows no statistically significant regression; allocations are unchanged
