### PR TITLE
optimize: bound certified full-parse retries

### DIFF
--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -18,6 +18,11 @@ type builtinLanguageRuntimeProfile struct {
 	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
 
+const (
+	csharpAcceptedErrorRetryMaxEntryScratchPeak = 690_365
+	csharpFreshErrorNoStacksRetryMaxStacks      = 16
+)
+
 var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder
@@ -25,6 +30,18 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	"dart": {
 		blobSHA256:                    mustRuntimeProfileSHA256("06bac15a9921a2e6af2810fb37ecb29a358b120e137345b9af5fb5f6c6632f59"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+	},
+	// C#'s certified low-pressure accepted-error trees are authoritative. A
+	// fresh no-stacks parse instead benefits from a bounded cap-16 retry; the
+	// generic cap-48 ladder exceeds the large-file memory and time budgets.
+	"c_sharp": {
+		blobSHA256:                    mustRuntimeProfileSHA256("7ad425e89733339dde94e3c03b762ae478fb453b530493f5d62e1ae7537e1784"),
+		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry:   true,
+			SkipCompleteMaxEntryScratchPeak:  csharpAcceptedErrorRetryMaxEntryScratchPeak,
+			FreshErrorNoStacksRetryMaxStacks: csharpFreshErrorNoStacksRetryMaxStacks,
+		},
 	},
 	// Haxe's accepted-error retry ladder selects the same tree on every pass.
 	// Keep the first accepted result instead of running either retry ladder.

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -14,6 +14,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 		name string
 		load func() *gotreesitter.Language
 	}{
+		{name: "c_sharp", load: CSharpLanguage},
 		{name: "dart", load: DartLanguage},
 		{name: "kotlin", load: KotlinLanguage},
 		{name: "python", load: PythonLanguage},
@@ -33,7 +34,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 16; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 17; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -104,6 +105,7 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 	}{
 		{name: "bash", load: BashLanguage},
 		{name: "caddy", load: CaddyLanguage},
+		{name: "c_sharp", load: CSharpLanguage},
 		{name: "cpp", load: CppLanguage},
 		{name: "haxe", load: HaxeLanguage},
 		{name: "kdl", load: KdlLanguage},
@@ -121,6 +123,10 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 			}
 			if tt.name == "swift" && profile.SkipCompleteMaxEntryScratchPeak != 3*64*1024 {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want first-growth entry-scratch ceiling", profile)
+			}
+			if tt.name == "c_sharp" && (profile.SkipCompleteMaxEntryScratchPeak != csharpAcceptedErrorRetryMaxEntryScratchPeak ||
+				profile.FreshErrorNoStacksRetryMaxStacks != csharpFreshErrorNoStacksRetryMaxStacks) {
+				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want bounded C# retry profile", profile)
 			}
 			if tt.name == "tcl" && profile.FreshErrorNoStacksMaxPasses != 1 {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want one fresh no-stacks retry", profile)
@@ -191,6 +197,38 @@ func TestBuiltinExternalScannerRetryProfilesRequireCertifiedBlob(t *testing.T) {
 	}
 }
 
+func TestBuiltinCSharpRetryProfileRequiresCertifiedBlob(t *testing.T) {
+	lang := &gotreesitter.Language{ExternalScanner: CSharpExternalScanner{}}
+	if attachBuiltinLanguageRuntimeProfile("c_sharp", sha256.Sum256([]byte("uncertified")), lang) {
+		t.Fatal("uncertified C# blob reported a runtime-profile attachment")
+	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetryDefault {
+		t.Fatalf("uncertified C# blob changed scanner retry policy to %d", got)
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("uncertified C# blob changed retry profile to %+v", got)
+	}
+
+	blob := BlobByName("c_sharp")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(c_sharp) returned no data")
+	}
+	if !attachBuiltinLanguageRuntimeProfile("c_sharp", sha256.Sum256(blob), lang) {
+		t.Fatal("certified C# blob did not attach its runtime profile")
+	}
+	if got := lang.ExternalScannerFullParseRetryPolicy; got != gotreesitter.ExternalScannerFullParseRetrySkipRepeat {
+		t.Fatalf("certified C# scanner retry policy = %d, want skip-repeat", got)
+	}
+	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
+		SkipCompleteAcceptedErrorRetry:   true,
+		SkipCompleteMaxEntryScratchPeak:  csharpAcceptedErrorRetryMaxEntryScratchPeak,
+		FreshErrorNoStacksRetryMaxStacks: csharpFreshErrorNoStacksRetryMaxStacks,
+	}
+	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
+		t.Fatalf("certified C# retry profile = %+v, want %+v", got, want)
+	}
+}
+
 func TestBuiltinBoundedAcceptedErrorRetryProfilesRequireCertifiedBlob(t *testing.T) {
 	tests := []struct {
 		name string
@@ -224,7 +262,7 @@ func TestBuiltinBoundedAcceptedErrorRetryProfilesRequireCertifiedBlob(t *testing
 }
 
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
-	for _, name := range []string{"caddy", "haxe", "kdl", "odin", "rego", "scss", "swift", "tcl"} {
+	for _, name := range []string{"caddy", "c_sharp", "haxe", "kdl", "odin", "rego", "scss", "swift", "tcl"} {
 		t.Run(name, func(t *testing.T) {
 			lang := &gotreesitter.Language{Name: name}
 			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {

--- a/language.go
+++ b/language.go
@@ -282,9 +282,9 @@ const (
 // policies. When a fresh full parse accepts an error-bearing tree that covers
 // EOF, the parser may keep the initial GLR stack ceiling after the ordinary
 // same-stack merge retry or skip that ladder entirely. A grammar may also cap
-// retries for a fresh, error-bearing no-stacks result after proving that later
-// passes do not improve the selected tree. The zero value preserves the
-// conservative generic ladder.
+// retries or select a narrower widening target for a fresh, error-bearing
+// no-stacks result after proving the generic ladder does not improve the
+// selected tree. The zero value preserves the conservative generic ladder.
 //
 // Keep fields append-only: Language blobs encode this structure.
 type FullParseAcceptedErrorRetryProfile struct {
@@ -295,6 +295,10 @@ type FullParseAcceptedErrorRetryProfile struct {
 	// SkipCompleteMaxEntryScratchPeak limits the complete-tree skip to a
 	// certified peak number of live GLR scratch entries. Zero is unbounded.
 	SkipCompleteMaxEntryScratchPeak uint32
+	// FreshErrorNoStacksRetryMaxStacks replaces the generic widened-stack
+	// target for a fresh error-bearing no-stacks parse. Zero keeps the generic
+	// target. Incremental fallbacks and explicit environment overrides ignore it.
+	FreshErrorNoStacksRetryMaxStacks uint16
 }
 
 // Language holds all data needed to parse a specific language.

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -982,6 +982,109 @@ func TestCertifiedFreshErrorNoStacksRetryPassLimitScheduling(t *testing.T) {
 	}
 }
 
+func certifiedFreshErrorNoStacksRetryTargetTestTree(target uint16, sourceLen int) *Tree {
+	tree := certifiedFreshErrorNoStacksTestTree(false, sourceLen)
+	tree.language.FullParseAcceptedErrorRetryProfile = FullParseAcceptedErrorRetryProfile{
+		SkipCompleteAcceptedErrorRetry:   true,
+		FreshErrorNoStacksRetryMaxStacks: target,
+	}
+	return tree
+}
+
+func TestCertifiedFreshErrorNoStacksRetryMaxStacksScope(t *testing.T) {
+	const sourceLen = 128
+	eligible := certifiedFreshErrorNoStacksRetryTargetTestTree(16, sourceLen)
+	if got := certifiedFreshErrorNoStacksRetryMaxStacks(eligible, sourceLen, fullParseRetryOriginFresh); got != 16 {
+		t.Fatalf("fresh certified retry target = %d, want 16", got)
+	}
+	if got := certifiedFreshErrorNoStacksRetryMaxStacks(eligible, sourceLen, fullParseRetryOriginIncremental); got != 0 {
+		t.Fatalf("incremental certified retry target = %d, want 0", got)
+	}
+	if got := certifiedFreshErrorNoStacksRetryMaxStacks(certifiedFreshErrorNoStacksRetryTargetTestTree(0, sourceLen), sourceLen, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("uncertified retry target = %d, want 0", got)
+	}
+	clean := certifiedFreshErrorNoStacksRetryTargetTestTree(16, sourceLen)
+	clean.root.flags = 0
+	if got := certifiedFreshErrorNoStacksRetryMaxStacks(clean, sourceLen, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("clean no-stacks retry target = %d, want 0", got)
+	}
+	accepted := certifiedFreshErrorNoStacksRetryTargetTestTree(16, sourceLen)
+	accepted.parseRuntime.StopReason = ParseStopAccepted
+	if got := certifiedFreshErrorNoStacksRetryMaxStacks(accepted, sourceLen, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("accepted retry target = %d, want 0", got)
+	}
+	if got := certifiedFreshErrorNoStacksRetryMaxStacks(eligible, fullParseRetryMaxSourceBytes+1, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("oversize retry target = %d, want 0", got)
+	}
+}
+
+func TestCertifiedFreshErrorNoStacksRetryMaxStacksScheduling(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	const sourceLen = 128
+	initial := certifiedFreshErrorNoStacksRetryTargetTestTree(16, sourceLen)
+	if got := fullParseRetryMaxStacksOverrideForOrigin(initial, sourceLen, 8, fullParseRetryOriginFresh); got != 16 {
+		t.Fatalf("fresh certified max-stacks override = %d, want 16", got)
+	}
+	if got := fullParseRetryMaxStacksOverrideForOrigin(initial, sourceLen, 16, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("already-at-target max-stacks override = %d, want 0", got)
+	}
+	if got := fullParseRetryMaxStacksOverrideForOrigin(initial, sourceLen, 8, fullParseRetryOriginIncremental); got != fullParseRetryMaxGLRStacks {
+		t.Fatalf("incremental max-stacks override = %d, want generic %d", got, fullParseRetryMaxGLRStacks)
+	}
+
+	t.Setenv("GOT_GLR_MAX_STACKS", "12")
+	ResetParseEnvConfigCacheForTests()
+	if got := fullParseRetryMaxStacksOverrideForOrigin(initial, sourceLen, 8, fullParseRetryOriginFresh); got != 0 {
+		t.Fatalf("explicit max-stacks override scheduled certified retry target %d", got)
+	}
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	ResetParseEnvConfigCacheForTests()
+	if got := fullParseRetryMaxStacksOverrideForOrigin(initial, sourceLen, 8, fullParseRetryOriginFresh); got != 16 {
+		t.Fatalf("reset certified max-stacks override = %d, want 16", got)
+	}
+}
+
+func TestCertifiedFreshErrorNoStacksRetryMaxStacksFlowsThroughLadder(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	const sourceLen = 128
+	source := make([]byte, sourceLen)
+	initial := certifiedFreshErrorNoStacksRetryTargetTestTree(16, sourceLen)
+	type retryCall struct {
+		stacks int
+		merge  int
+	}
+	var calls []retryCall
+	parser := &Parser{}
+	result := parser.retryFullParse(source, 8, initial, func(maxStacks, maxMergePerKeyOverride, _ int) *Tree {
+		calls = append(calls, retryCall{stacks: maxStacks, merge: maxMergePerKeyOverride})
+		candidate := certifiedFreshErrorNoStacksRetryTargetTestTree(16, sourceLen)
+		if maxStacks == 16 {
+			candidate.root.endByte = sourceLen
+			candidate.parseRuntime.StopReason = ParseStopAccepted
+			candidate.parseRuntime.Truncated = false
+			candidate.parseRuntime.RootEndByte = sourceLen
+			candidate.parseRuntime.LastTokenEndByte = sourceLen
+			candidate.parseRuntime.LastTokenWasEOF = true
+		}
+		return candidate
+	})
+	want := []retryCall{{stacks: 8, merge: fullParseRetryMaxMergePerKey}, {stacks: 16}, {stacks: 16}}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("retry calls = %+v, want %+v", calls, want)
+	}
+	if result == nil || result.ParseStopReason() != ParseStopAccepted {
+		t.Fatalf("retry result = %v, want accepted tree", result)
+	}
+}
+
 func TestJavaAcceptedErrorRetryUsesWideMergeRetry(t *testing.T) {
 	errChild := &Node{
 		symbol: errorSymbol,

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1146,12 +1146,18 @@ func fullParseRetryMaxStacksOverrideForOrigin(tree *Tree, sourceLen int, initial
 	if fullParseRetryUsesInitialStackCeilingForOrigin(tree, sourceLen, initialMaxStacks, origin) {
 		return 0
 	}
-	retryMaxStacks := fullParseRetryMaxGLRStacks
-	if tree != nil && tree.language != nil && tree.language.Name == "java" {
-		retryMaxStacks = javaFullParseRetryMaxGLRStacks
-	}
-	if initialMaxStacks > retryMaxStacks {
-		retryMaxStacks = initialMaxStacks * 2
+	certifiedRetryMaxStacks := certifiedFreshErrorNoStacksRetryMaxStacks(tree, sourceLen, origin)
+	retryMaxStacks := certifiedRetryMaxStacks
+	if certifiedRetryMaxStacks == 0 {
+		retryMaxStacks = fullParseRetryMaxGLRStacks
+		if tree != nil && tree.language != nil && tree.language.Name == "java" {
+			retryMaxStacks = javaFullParseRetryMaxGLRStacks
+		}
+		if initialMaxStacks > retryMaxStacks {
+			retryMaxStacks = initialMaxStacks * 2
+		}
+	} else if retryMaxStacks <= initialMaxStacks {
+		return 0
 	}
 	if parseMaxGLRStacksValue() >= retryMaxStacks {
 		return 0
@@ -1242,6 +1248,15 @@ func certifiedFreshErrorNoStacksRetryPassLimit(tree *Tree, sourceLen int, origin
 		return 0
 	}
 	return int(limit)
+}
+
+func certifiedFreshErrorNoStacksRetryMaxStacks(tree *Tree, sourceLen int, origin fullParseRetryOrigin) int {
+	if tree == nil || tree.language == nil || origin != fullParseRetryOriginFresh ||
+		sourceLen <= 0 || sourceLen > fullParseRetryMaxSourceBytes ||
+		tree.ParseStopReason() != ParseStopNoStacksAlive || !retryTreeHasError(tree) {
+		return 0
+	}
+	return int(tree.language.FullParseAcceptedErrorRetryProfile.FreshErrorNoStacksRetryMaxStacks)
 }
 
 func fullParseRetryNodeLimitOverride(tree *Tree, sourceLen int) int {


### PR DESCRIPTION
## Summary

- add a certified fresh no-stacks retry ceiling
- attach the C# retry policy to the exact built-in blob
- skip redundant scanner and accepted-error retries only within the certified pressure bound

## Validation

- focused root and grammar tests, including race coverage
- focused built-in C# fresh/no-error C parity
- locked eight-file scan: stopped axes 4 to 0
- standard full/single-byte/no-edit trio: no significant regression