### PR TITLE
test(grammars): dedicated alias-map parity coverage for go, swift, caddy

### DIFF
--- a/grammargen/nonterminal_alias_map_parity_test.go
+++ b/grammargen/nonterminal_alias_map_parity_test.go
@@ -22,18 +22,30 @@ const shippedGrammarBlobsDir = "../grammars/grammar_blobs"
 // nonTerminalAliasMapExpectedNonEmptyLanguages lists every language whose
 // SHIPPING ts2go blob is known (per the Wave-7 audit, cross-checked by
 // TestShippedBlobsNonTerminalAliasMapInventory below) to carry a non-empty
-// Language.NonTerminalAliasMap. Lua is the only one today: its
-// _doublequote_string_content / _singlequote_string_content aux wrappers are
-// each referenced both unaliased (within their own repeat1 self-recursion)
-// and aliased to string_content (from _quote_string), so their possible
-// display genuinely varies by occurrence and can't be folded into a single
-// static entry the way single-target aliases can.
+// Language.NonTerminalAliasMap, each backed by its own dedicated parity test:
+//
+//   - lua (TestLuaNonTerminalAliasMapParity): _doublequote_string_content /
+//     _singlequote_string_content aux wrappers are each referenced both
+//     unaliased (within their own repeat1 self-recursion) and aliased to
+//     string_content (from _quote_string).
+//   - go (TestGoNonTerminalAliasMapParity): type_elem is referenced both
+//     unaliased (interface type-sets, type_arguments) and aliased to
+//     type_constraint (a generic type-parameter's constraint).
+//   - swift (TestSwiftNonTerminalAliasMapParity): several rules similarly
+//     vary by occurrence, e.g. simple_identifier (plain identifier vs.
+//     aliased to type_identifier in type-name position).
+//   - caddy (TestCaddyNonTerminalAliasMapParity): directive is referenced
+//     both unaliased (server address blocks) and aliased to option (global
+//     options / sub-option blocks).
 //
 // If this set ever needs to grow, add a dedicated parity test mirroring
 // TestLuaNonTerminalAliasMapParity for the new language before adding it
 // here — this map is a deliberate gate, not just documentation.
 var nonTerminalAliasMapExpectedNonEmptyLanguages = map[string]bool{
-	"lua": true,
+	"lua":   true,
+	"go":    true,
+	"swift": true,
+	"caddy": true,
 }
 
 // loadShippedBlob reads and decodes a shipped grammar blob by language name
@@ -370,6 +382,213 @@ func TestLuaNonTerminalAliasMapParity(t *testing.T) {
 			}
 		}
 	}
+}
+
+// goGrammarJSONPathForTest locates the pinned tree-sitter-go grammar.json (see
+// grammars/languages.lock for the pinned commit), following the same
+// candidate-path convention as rustGrammarJSONPathForTest / lua's. Seed it
+// locally with:
+//
+//	cgo_harness/seed_parity_repos.sh --langs go
+func goGrammarJSONPathForTest(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		"/tmp/grammar_parity/go/src/grammar.json",
+		".parity_seed/go/src/grammar.json",
+		"../.parity_seed/go/src/grammar.json",
+	}
+	globs := []string{
+		"/tmp/gotreesitter-parity-*/repos/go/src/grammar.json",
+	}
+	for _, pattern := range globs {
+		matches, err := filepath.Glob(pattern)
+		if err == nil && len(matches) > 0 {
+			candidates = append(candidates, matches...)
+		}
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	t.Skip("go grammar.json not available (run cgo_harness/seed_parity_repos.sh --langs go)")
+	return ""
+}
+
+// swiftGrammarJSONPathForTest locates the pinned tree-sitter-swift
+// grammar.json (see grammars/languages.lock and grammars/swift_scanner.go's
+// UpstreamCommit for the pinned commit — both agree on
+// 41d6e5fe811ec94229ee71771174a8cce558dfee), following the same
+// candidate-path convention as rustGrammarJSONPathForTest / lua's. Seed it
+// locally with:
+//
+//	cgo_harness/seed_parity_repos.sh --langs swift
+func swiftGrammarJSONPathForTest(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		"/tmp/grammar_parity/swift/src/grammar.json",
+		".parity_seed/swift/src/grammar.json",
+		"../.parity_seed/swift/src/grammar.json",
+	}
+	globs := []string{
+		"/tmp/gotreesitter-parity-*/repos/swift/src/grammar.json",
+	}
+	for _, pattern := range globs {
+		matches, err := filepath.Glob(pattern)
+		if err == nil && len(matches) > 0 {
+			candidates = append(candidates, matches...)
+		}
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	t.Skip("swift grammar.json not available (run cgo_harness/seed_parity_repos.sh --langs swift)")
+	return ""
+}
+
+// caddyGrammarJSONPathForTest locates the pinned tree-sitter-caddy
+// grammar.json (see grammars/languages.lock for the pinned commit), following
+// the same candidate-path convention as rustGrammarJSONPathForTest / lua's.
+// Seed it locally with:
+//
+//	cgo_harness/seed_parity_repos.sh --langs caddy
+func caddyGrammarJSONPathForTest(t *testing.T) string {
+	t.Helper()
+
+	candidates := []string{
+		"/tmp/grammar_parity/caddy/src/grammar.json",
+		".parity_seed/caddy/src/grammar.json",
+		"../.parity_seed/caddy/src/grammar.json",
+	}
+	globs := []string{
+		"/tmp/gotreesitter-parity-*/repos/caddy/src/grammar.json",
+	}
+	for _, pattern := range globs {
+		matches, err := filepath.Glob(pattern)
+		if err == nil && len(matches) > 0 {
+			candidates = append(candidates, matches...)
+		}
+	}
+	for _, path := range candidates {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	t.Skip("caddy grammar.json not available (run cgo_harness/seed_parity_repos.sh --langs caddy)")
+	return ""
+}
+
+// nonTerminalAliasMapParityCheck is the shared body of every per-language
+// NonTerminalAliasMap parity gate (TestLuaNonTerminalAliasMapParity,
+// TestGoNonTerminalAliasMapParity, TestSwiftNonTerminalAliasMapParity,
+// TestCaddyNonTerminalAliasMapParity): import the exact pinned upstream
+// grammar.json, generate a Language through grammargen's own LR pipeline, and
+// assert the derived NonTerminalAliasMap is semantically identical (same
+// symbol-name -> alias-target-name-set entries; see nonTerminalAliasMapByName
+// for why correlation is name-based) to the map ts2go extracted from
+// tree-sitter's real generated parser.c and shipped in
+// grammars/grammar_blobs/<lang>.bin.
+//
+// A wrong alias map corrupts parse trees (see parser_reduce.go's
+// buildAliasPreservedWrapperSymbols), so this check is intentionally strict:
+// any row present on only one side, or any per-row alias-set mismatch, fails
+// with a full diagnostic rather than silently passing on a coincidental
+// partial match.
+func nonTerminalAliasMapParityCheck(t *testing.T, lang string, jsonPath string, genTimeout time.Duration) {
+	t.Helper()
+
+	refLang := loadShippedBlob(t, lang)
+	refEntries := nonTerminalAliasMapByName(refLang)
+	if len(refEntries) == 0 {
+		t.Fatalf("shipped %s blob unexpectedly has an empty NonTerminalAliasMap; nothing to verify parity against (has %s.bin regressed?)", lang, lang)
+	}
+
+	source, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Skipf("%s grammar.json not available: %v", lang, err)
+	}
+	gram, err := ImportGrammarJSON(source)
+	if err != nil {
+		t.Fatalf("import %s grammar.json: %v", lang, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), genTimeout)
+	defer cancel()
+	genLang, err := GenerateLanguageWithContext(ctx, gram)
+	if err != nil {
+		t.Fatalf("generate %s language via grammargen: %v", lang, err)
+	}
+	genEntries := nonTerminalAliasMapByName(genLang)
+	if len(genEntries) == 0 {
+		t.Fatalf("grammargen-derived %s NonTerminalAliasMap is empty; expected it to match the shipped ts2go blob's non-empty map", lang)
+	}
+
+	if diffs := diffNonTerminalAliasMapEntries(refEntries, genEntries); len(diffs) > 0 {
+		t.Fatalf("grammargen-derived NonTerminalAliasMap diverges from the shipped ts2go %s blob (%d row(s) in ts2go's map, %d in grammargen's):\n%s",
+			lang, len(refEntries), len(genEntries), strings.Join(diffs, "\n"))
+	}
+
+	// Non-fatal diagnostic: report (but do not fail on) any row-symbol or
+	// alias-target Named/Visible metadata differences between the two sides.
+	// See nonTerminalAliasMapByName's doc comment for why this is scoped out.
+	for name, refRow := range refEntries {
+		genRow, ok := genEntries[name]
+		if !ok {
+			continue
+		}
+		if refRow.symbol.named != genRow.symbol.named || refRow.symbol.visible != genRow.symbol.visible {
+			t.Logf("NOTE (non-fatal, pre-existing, out of scope): row symbol %q metadata differs: ts2go=%s grammargen=%s", name, refRow.symbol, genRow.symbol)
+		}
+		refAliasByName := make(map[string]symIdentity, len(refRow.aliases))
+		for _, v := range refRow.aliases {
+			refAliasByName[v.name] = v
+		}
+		for _, gv := range genRow.aliases {
+			if rv, ok := refAliasByName[gv.name]; ok && (rv.named != gv.named || rv.visible != gv.visible) {
+				t.Logf("NOTE (non-fatal, pre-existing, out of scope): alias-target %q metadata differs: ts2go=%s grammargen=%s", gv.name, rv, gv)
+			}
+		}
+	}
+}
+
+// TestGoNonTerminalAliasMapParity is THE GATE for grammargen's
+// NonTerminalAliasMap derivation for Go: shipped go.bin carries a non-empty
+// row for type_elem (unaliased when used directly inside interface type-sets
+// and type_arguments, aliased to type_constraint when used as a generic
+// type-parameter constraint in type_parameter_declaration) — see
+// nonTerminalAliasMapParityCheck's doc comment for what this asserts.
+func TestGoNonTerminalAliasMapParity(t *testing.T) {
+	nonTerminalAliasMapParityCheck(t, "go", goGrammarJSONPathForTest(t), 60*time.Second)
+}
+
+// TestSwiftNonTerminalAliasMapParity is THE GATE for grammargen's
+// NonTerminalAliasMap derivation for Swift: shipped swift.bin carries several
+// non-empty rows (e.g. simple_identifier unaliased as a plain identifier
+// expression vs. aliased to type_identifier in type-name position; the
+// analogous split for _parenthesized_type/tuple_type_item,
+// value_argument/interpolated_expression (string-interpolation arguments),
+// _three_dot_operator/fully_open_range, _bodyless_function_declaration and
+// function_body both folding into protocol_function_declaration inside
+// protocol bodies, and the pattern-binding trio
+// _binding_pattern_no_expr/_no_expr_pattern_already_bound/
+// _binding_kind_and_pattern all folding into pattern) — see
+// nonTerminalAliasMapParityCheck's doc comment for what this asserts.
+func TestSwiftNonTerminalAliasMapParity(t *testing.T) {
+	nonTerminalAliasMapParityCheck(t, "swift", swiftGrammarJSONPathForTest(t), 150*time.Second)
+}
+
+// TestCaddyNonTerminalAliasMapParity is THE GATE for grammargen's
+// NonTerminalAliasMap derivation for Caddy: shipped caddy.bin carries a
+// non-empty row for directive (unaliased when it's a top-level directive,
+// aliased to option when the same rule is nested as an option/sub-directive
+// inside a directive block) — see nonTerminalAliasMapParityCheck's doc
+// comment for what this asserts.
+func TestCaddyNonTerminalAliasMapParity(t *testing.T) {
+	nonTerminalAliasMapParityCheck(t, "caddy", caddyGrammarJSONPathForTest(t), 60*time.Second)
 }
 
 // TestNonTerminalAliasMapSyntheticSelfAndAlias is a fast, offline (no

--- a/grammars/caddy_directive_option_alias_regression_test.go
+++ b/grammars/caddy_directive_option_alias_regression_test.go
@@ -1,0 +1,68 @@
+package grammars
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestCaddyDirectiveAliasedAsOption pins the runtime behavior backing
+// caddy.bin's NonTerminalAliasMap row for directive: tree-sitter-caddy's
+// global_options rule aliases $.directive to $.option (grammar.js:
+// `repeat1(alias($.directive, $.option))` inside the top-level `{ ... }`
+// global options block), so a line inside a global options block must
+// display as option, while the SAME directive production reached unaliased
+// (a line inside an ordinary server address block) must display as plain
+// directive.
+//
+// This is the "real" behavioral half of TestCaddyNonTerminalAliasMapParity in
+// grammargen: that test only checks the derived NonTerminalAliasMap table is
+// structurally identical between grammargen and ts2go; this test checks the
+// shipped grammars.CaddyLanguage() blob actually PRODUCES the two distinct
+// shapes on live input.
+func TestCaddyDirectiveAliasedAsOption(t *testing.T) {
+	lang := CaddyLanguage()
+
+	t.Run("global-options-block-aliased", func(t *testing.T) {
+		src := []byte("{\n\tadmin off\n\tdebug\n}\n")
+		parser := gotreesitter.NewParser(lang)
+		tree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		root := tree.RootNode()
+		if root.HasError() {
+			t.Fatalf("global options block produced parse errors: %s", root.SExpr(lang))
+		}
+		sexpr := root.SExpr(lang)
+		if !strings.Contains(sexpr, "(option") {
+			t.Fatalf("expected option (aliased directive) inside a global_options block: %s", sexpr)
+		}
+		if strings.Contains(sexpr, "(directive") {
+			t.Fatalf("did not expect unaliased directive inside a global_options block: %s", sexpr)
+		}
+	})
+
+	t.Run("server-block-unaliased", func(t *testing.T) {
+		src := []byte("example.com {\n\treverse_proxy localhost:9000\n}\n")
+		parser := gotreesitter.NewParser(lang)
+		tree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		root := tree.RootNode()
+		if root.HasError() {
+			t.Fatalf("server block produced parse errors: %s", root.SExpr(lang))
+		}
+		sexpr := root.SExpr(lang)
+		if !strings.Contains(sexpr, "(directive") {
+			t.Fatalf("expected unaliased directive inside a server address block: %s", sexpr)
+		}
+		if strings.Contains(sexpr, "(option") {
+			t.Fatalf("did not expect option alias outside a global_options block: %s", sexpr)
+		}
+	})
+}

--- a/grammars/go_type_constraint_alias_regression_test.go
+++ b/grammars/go_type_constraint_alias_regression_test.go
@@ -1,0 +1,93 @@
+package grammars
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestGoTypeElemAliasedAsTypeConstraint pins the runtime behavior backing
+// go.bin's NonTerminalAliasMap row for type_elem: tree-sitter-go's
+// type_parameter_declaration rule aliases $.type_elem to $.type_constraint
+// (see tree-sitter-go's grammar.js: `field('type', alias($.type_elem,
+// $.type_constraint))`), so a generic type parameter's constraint set
+// ("int | string") must display as a type_constraint node, while the SAME
+// type_elem production reached unaliased (e.g. a type set inside an
+// interface body) must display as plain type_elem.
+//
+// This is the "real" behavioral half of TestGoNonTerminalAliasMapParity in
+// grammargen: that test only checks the derived NonTerminalAliasMap table is
+// structurally identical between grammargen and ts2go; this test checks the
+// shipped grammars.GoLanguage() blob actually PRODUCES the two distinct
+// shapes on live input, i.e. that the alias map is not just structurally
+// present but semantically wired up in the parser.
+func TestGoTypeElemAliasedAsTypeConstraint(t *testing.T) {
+	lang := GoLanguage()
+
+	t.Run("generic-type-parameter-constraint", func(t *testing.T) {
+		src := []byte("package main\n\nfunc F[T int | string](x T) {}\n")
+		parser := gotreesitter.NewParser(lang)
+		tree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		root := tree.RootNode()
+		if root.HasError() {
+			t.Fatalf("generic type parameter constraint produced parse errors: %s", root.SExpr(lang))
+		}
+		sexpr := root.SExpr(lang)
+		if !strings.Contains(sexpr, "(type_constraint") {
+			t.Fatalf("expected type_constraint (aliased type_elem) in tree: %s", sexpr)
+		}
+		if strings.Contains(sexpr, "(type_elem") {
+			t.Fatalf("did not expect unaliased type_elem when only the constraint-position occurrence is present: %s", sexpr)
+		}
+	})
+
+	t.Run("interface-type-set-unaliased", func(t *testing.T) {
+		src := []byte("package main\n\ntype Number interface {\n\tint | string\n}\n")
+		parser := gotreesitter.NewParser(lang)
+		tree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		root := tree.RootNode()
+		if root.HasError() {
+			t.Fatalf("interface type set produced parse errors: %s", root.SExpr(lang))
+		}
+		sexpr := root.SExpr(lang)
+		if !strings.Contains(sexpr, "(type_elem") {
+			t.Fatalf("expected unaliased type_elem for an interface type-set: %s", sexpr)
+		}
+		if strings.Contains(sexpr, "(type_constraint") {
+			t.Fatalf("did not expect type_constraint alias outside a type-parameter-declaration constraint position: %s", sexpr)
+		}
+	})
+
+	t.Run("both-occurrences-in-one-source", func(t *testing.T) {
+		// Both shapes present in the same parse: confirms the alias display
+		// genuinely varies per-occurrence within a single compiled grammar,
+		// not merely across separately-parsed sources.
+		src := []byte("package main\n\ntype Number interface {\n\tint | string\n}\n\nfunc F[T int | string](x T) {}\n")
+		parser := gotreesitter.NewParser(lang)
+		tree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		root := tree.RootNode()
+		if root.HasError() {
+			t.Fatalf("combined source produced parse errors: %s", root.SExpr(lang))
+		}
+		sexpr := root.SExpr(lang)
+		if !strings.Contains(sexpr, "(type_elem") {
+			t.Fatalf("expected unaliased type_elem from the interface type-set: %s", sexpr)
+		}
+		if !strings.Contains(sexpr, "(type_constraint") {
+			t.Fatalf("expected type_constraint alias from the generic function's constraint: %s", sexpr)
+		}
+	})
+}

--- a/grammars/swift_alias_map_regression_test.go
+++ b/grammars/swift_alias_map_regression_test.go
@@ -1,0 +1,73 @@
+package grammars
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestSwiftSimpleIdentifierAliasedAsTypeIdentifier pins the runtime behavior
+// backing one row of swift.bin's NonTerminalAliasMap: tree-sitter-swift's
+// _simple_user_type rule aliases $.simple_identifier to $.type_identifier
+// (grammar.js: `alias($.simple_identifier, $.type_identifier)`), so an
+// identifier used in type-name position must display as type_identifier,
+// while the SAME simple_identifier production reached unaliased (an
+// ordinary identifier expression) must display as plain simple_identifier.
+//
+// This is the "real" behavioral half of TestSwiftNonTerminalAliasMapParity in
+// grammargen: that test only checks the derived NonTerminalAliasMap table is
+// structurally identical between grammargen and ts2go; this test checks the
+// shipped grammars.SwiftLanguage() blob actually PRODUCES the two distinct
+// shapes on live input.
+func TestSwiftSimpleIdentifierAliasedAsTypeIdentifier(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("let x: Int = 1\nlet y = x\n")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("produced parse errors: %s", root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	if !strings.Contains(sexpr, "(type_identifier") {
+		t.Fatalf("expected type_identifier (aliased simple_identifier) for the `Int` type annotation: %s", sexpr)
+	}
+	if !strings.Contains(sexpr, "(simple_identifier") {
+		t.Fatalf("expected an unaliased simple_identifier for the `x` reference expression: %s", sexpr)
+	}
+}
+
+// TestSwiftValueArgumentAliasedAsInterpolatedExpression pins the runtime
+// behavior backing another row of swift.bin's NonTerminalAliasMap:
+// tree-sitter-swift's _interpolation_contents rule aliases $.value_argument
+// to $.interpolated_expression (grammar.js: `alias($.value_argument,
+// $.interpolated_expression)`), so a value inside a string interpolation
+// (`"\(bar)"`) must display as interpolated_expression, while the SAME
+// value_argument production reached unaliased (an ordinary call argument)
+// must display as plain value_argument.
+func TestSwiftValueArgumentAliasedAsInterpolatedExpression(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("let bar = 1\nfoo(bar)\nlet s = \"\\(bar)\"\n")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root.HasError() {
+		t.Fatalf("produced parse errors: %s", root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	if !strings.Contains(sexpr, "(interpolated_expression") {
+		t.Fatalf("expected interpolated_expression (aliased value_argument) inside the string literal: %s", sexpr)
+	}
+	if !strings.Contains(sexpr, "(value_argument") {
+		t.Fatalf("expected an unaliased value_argument for the `foo(bar)` call: %s", sexpr)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #264. Regenerating go.bin/swift.bin at HEAD made them carry `NonTerminalAliasMap` data, and `TestShippedBlobsNonTerminalAliasMapInventory` correctly demanded dedicated parity coverage before registration. This adds the real coverage rather than an allowlist expansion:

- Refactored the Lua alias-map derivation gate into a shared `nonTerminalAliasMapParityCheck` helper; added `TestGoNonTerminalAliasMapParity`, `TestSwiftNonTerminalAliasMapParity`, and `TestCaddyNonTerminalAliasMapParity` (caddy was the pre-existing uncovered entry — now covered too). Each imports the lock-pinned grammar.json, derives the alias map through grammargen's own pipeline, and asserts semantic equality with the shipped blob's map.
- Live-parse regression tests for the alias behaviors themselves: go `type_elem`→`type_constraint` in generic constraints, swift `simple_identifier`→`type_identifier` and `value_argument`→`interpolated_expression`, caddy `directive`→`option` in global-options blocks.
- Registered go/swift/caddy in `nonTerminalAliasMapExpectedNonEmptyLanguages` with the rule inventory documented.

## Verification

- `go build ./...`, `go vet ./grammargen/... ./grammars/...` — clean
- `go test ./grammargen/ -run 'AliasMap|NonTerminalAlias' -count=1` — pass (inventory now green with `[caddy go lua swift]`)
- `go test ./grammars/ -run 'Swift|Go|Caddy' -count=1` — pass

## Note for a follow-up

`grammars/grammar_updates.json` claims swift `applied: true` at ref `64f26c3a…` while `languages.lock` and `swift_scanner.go`'s `UpstreamCommit` agree on `41d6e5fe…` (which matches the shipped blob). The updates ledger looks stale for swift; not changed here.