### PR TITLE
optimize(glr): compact gssNode layout and recycle transient GSS slabs

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -162,6 +162,7 @@ type glrMergeScratch struct {
 	cRecoveryCost     bool
 	audit             *runtimeAudit
 	equivEpoch        uint32
+	gssPointerEpoch   uint32
 	equivCache        []glrNodeEquivCacheEntry
 	stackEquivCache   []glrStackEquivCacheEntry
 	spineEquivCache   []glrSpineEquivCacheEntry
@@ -1015,12 +1016,11 @@ func (s *glrMergeScratch) beginEquivEpoch() {
 	s.beginCleanZeroEpoch()
 	if s.equivEpoch == ^uint32(0) {
 		clear(s.equivCache)
-		clear(s.stackEquivCache)
 		clear(s.spineEquivCache)
-		clear(s.frontierHashCache)
 		s.equivEpoch = 0
 	}
 	s.equivEpoch++
+	s.bumpGSSPointerEpoch()
 	if len(s.cErrorCost) > maxRetainedMergeResultCap {
 		s.cErrorCost = nil
 	} else if len(s.cErrorCost) > 0 {
@@ -1038,6 +1038,57 @@ func (s *glrMergeScratch) beginEquivEpoch() {
 	// empty backing array make that a correct no-memo fallback.
 }
 
+// bumpGSSPointerEpoch invalidates caches whose answer is keyed only by a GSS
+// address. The spine cache is deliberately excluded: it also validates both
+// nodes' complete rolling spine fingerprints, so recycled addresses with new
+// content miss without throwing away still-useful immutable-prefix answers.
+func (s *glrMergeScratch) bumpGSSPointerEpoch() {
+	if s == nil {
+		return
+	}
+	if s.gssPointerEpoch == ^uint32(0) {
+		clear(s.stackEquivCache)
+		clear(s.frontierHashCache)
+		s.gssPointerEpoch = 0
+	}
+	s.gssPointerEpoch++
+}
+
+// invalidateGSSPointersForReuse drops every merge-scratch reference whose
+// identity is tied to a gssNode address, then advances the epochs guarding the
+// uintptr-keyed caches. Callers may recycle GSS slab slots only after this and
+// after clearing any live glrStack slices that used the old graph.
+func (s *glrMergeScratch) invalidateGSSPointersForReuse() {
+	if s == nil {
+		return
+	}
+	s.beginCleanZeroEpoch()
+	s.bumpGSSPointerEpoch()
+	s.bumpShapePrefixEpoch()
+	resetGSSPrefixPath(&s.cPrefixPath)
+	if len(s.cleanZeroCache) > 0 {
+		clear(s.cleanZeroCache)
+	}
+	if cap(s.cleanZeroStack) > 0 {
+		clear(s.cleanZeroStack[:cap(s.cleanZeroStack)])
+		s.cleanZeroStack = s.cleanZeroStack[:0]
+	}
+	if cap(s.cleanZeroVisited) > 0 {
+		clear(s.cleanZeroVisited[:cap(s.cleanZeroVisited)])
+		s.cleanZeroVisited = s.cleanZeroVisited[:0]
+	}
+	if cap(s.spineVisit) > 0 {
+		clear(s.spineVisit[:cap(s.spineVisit)])
+		s.spineVisit = s.spineVisit[:0]
+	}
+	if s.preflight != nil {
+		s.preflight.clearGSSPointersForReuse()
+	}
+	if len(s.mergeSeen) > 0 {
+		clear(s.mergeSeen)
+	}
+}
+
 func stackFrontierHashCacheIndex(p uintptr) int {
 	h := uint64(p)
 	h ^= h >> 33
@@ -1049,17 +1100,17 @@ func stackFrontierHashCacheIndex(p uintptr) int {
 }
 
 func lookupStackFrontierHashCache(scratch *glrMergeScratch, n *gssNode) (uint64, bool) {
-	if scratch == nil || len(scratch.frontierHashCache) == 0 || scratch.equivEpoch == 0 || n == nil {
+	if scratch == nil || len(scratch.frontierHashCache) == 0 || scratch.gssPointerEpoch == 0 || n == nil {
 		return 0, false
 	}
 	p := uintptr(unsafe.Pointer(n))
 	idx := stackFrontierHashCacheIndex(p)
 	primary := &scratch.frontierHashCache[idx]
-	if primary.epoch == scratch.equivEpoch && primary.node == p {
+	if primary.epoch == scratch.gssPointerEpoch && primary.node == p {
 		return primary.hash, true
 	}
 	victim := &scratch.frontierHashCache[idx+1]
-	if victim.epoch == scratch.equivEpoch && victim.node == p {
+	if victim.epoch == scratch.gssPointerEpoch && victim.node == p {
 		scratch.frontierHashCache[idx], scratch.frontierHashCache[idx+1] = scratch.frontierHashCache[idx+1], scratch.frontierHashCache[idx]
 		return scratch.frontierHashCache[idx].hash, true
 	}
@@ -1067,7 +1118,7 @@ func lookupStackFrontierHashCache(scratch *glrMergeScratch, n *gssNode) (uint64,
 }
 
 func storeStackFrontierHashCache(scratch *glrMergeScratch, n *gssNode, hash uint64) {
-	if scratch == nil || scratch.equivEpoch == 0 || n == nil {
+	if scratch == nil || scratch.gssPointerEpoch == 0 || n == nil {
 		return
 	}
 	if len(scratch.frontierHashCache) == 0 {
@@ -1079,7 +1130,7 @@ func storeStackFrontierHashCache(scratch *glrMergeScratch, n *gssNode, hash uint
 	scratch.frontierHashCache[idx+1] = scratch.frontierHashCache[idx]
 	scratch.frontierHashCache[idx] = glrStackFrontierHashCacheEntry{
 		node:  p,
-		epoch: scratch.equivEpoch,
+		epoch: scratch.gssPointerEpoch,
 		hash:  hash,
 	}
 }
@@ -1109,7 +1160,7 @@ func stackEquivCacheIndex(ap, bp uintptr) int {
 }
 
 func lookupGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode) (bool, bool) {
-	if scratch == nil || len(scratch.stackEquivCache) == 0 || scratch.equivEpoch == 0 {
+	if scratch == nil || len(scratch.stackEquivCache) == 0 || scratch.gssPointerEpoch == 0 {
 		return false, false
 	}
 	ap, bp, ok := orderedGSSNodePair(a, b)
@@ -1118,11 +1169,11 @@ func lookupGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode) (bool, bo
 	}
 	idx := stackEquivCacheIndex(ap, bp)
 	primary := &scratch.stackEquivCache[idx]
-	if primary.epoch == scratch.equivEpoch && primary.a == ap && primary.b == bp {
+	if primary.epoch == scratch.gssPointerEpoch && primary.a == ap && primary.b == bp {
 		return primary.result, true
 	}
 	victim := &scratch.stackEquivCache[idx+1]
-	if victim.epoch == scratch.equivEpoch && victim.a == ap && victim.b == bp {
+	if victim.epoch == scratch.gssPointerEpoch && victim.a == ap && victim.b == bp {
 		scratch.stackEquivCache[idx], scratch.stackEquivCache[idx+1] = scratch.stackEquivCache[idx+1], scratch.stackEquivCache[idx]
 		return scratch.stackEquivCache[idx].result, true
 	}
@@ -1130,7 +1181,7 @@ func lookupGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode) (bool, bo
 }
 
 func storeGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode, result bool) {
-	if scratch == nil || scratch.equivEpoch == 0 {
+	if scratch == nil || scratch.gssPointerEpoch == 0 {
 		return
 	}
 	ap, bp, ok := orderedGSSNodePair(a, b)
@@ -1146,7 +1197,7 @@ func storeGSSStackEquivCache(scratch *glrMergeScratch, a, b *gssNode, result boo
 	scratch.stackEquivCache[idx] = glrStackEquivCacheEntry{
 		a:      ap,
 		b:      bp,
-		epoch:  scratch.equivEpoch,
+		epoch:  scratch.gssPointerEpoch,
 		result: result,
 	}
 }
@@ -3460,6 +3511,37 @@ type gssMainPreflight struct {
 	// (cleared per use) so pooled preflights stop allocating two maps per
 	// nodesCanMerge call.
 	offsetSeen map[*gssNode]bool
+}
+
+func (p *gssMainPreflight) clearGSSPointersForReuse() {
+	if p == nil {
+		return
+	}
+	clear(p.seen)
+	clear(p.virtualLink)
+	clear(p.reachCache)
+	clear(p.reachSeen)
+	clear(p.cleanCache)
+	clear(p.cleanSeen)
+	clear(p.offsetSeen)
+	if cap(p.reachStack) > 0 {
+		clear(p.reachStack[:cap(p.reachStack)])
+		p.reachStack = p.reachStack[:0]
+	}
+	if cap(p.reachVisit) > 0 {
+		clear(p.reachVisit[:cap(p.reachVisit)])
+		p.reachVisit = p.reachVisit[:0]
+	}
+	if cap(p.cleanStack) > 0 {
+		clear(p.cleanStack[:cap(p.cleanStack)])
+		p.cleanStack = p.cleanStack[:0]
+	}
+	if cap(p.cleanVisit) > 0 {
+		clear(p.cleanVisit[:cap(p.cleanVisit)])
+		p.cleanVisit = p.cleanVisit[:0]
+	}
+	p.reachStrict = true
+	p.reachEpoch = 1
 }
 
 const maxGSSPreflightReachCacheEntries = 32768

--- a/glr.go
+++ b/glr.go
@@ -3423,7 +3423,7 @@ func setGSSMainLink(n *gssNode, i int, prev *gssNode, entry stackEntry) {
 		n.entry = entry
 		return
 	}
-	n.extraLinks[i-1] = gssMainLink{prev: prev, entry: entry}
+	n.setExtraLink(i-1, gssMainLink{prev: prev, entry: entry})
 }
 
 func gssMainAddLink(n *gssNode, prev *gssNode, entry stackEntry) bool {
@@ -3896,7 +3896,7 @@ func gssMainAddLinkSeenMutate(scratch *glrMergeScratch, n *gssNode, prev *gssNod
 		}
 		return false
 	}
-	n.extraLinks = append(n.extraLinks, gssMainLink{prev: prev, entry: entry})
+	n.appendExtraLink(gssMainLink{prev: prev, entry: entry})
 	n.hash = 0
 	return true
 }

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -12,11 +12,7 @@ const (
 type gssNode struct {
 	entry stackEntry
 	prev  *gssNode
-	depth int
 	hash  uint64
-	// extraLinks holds links 1..k after a gated lossless condense merge. The
-	// inline (prev, entry) pair remains link 0.
-	extraLinks []gssMainLink
 
 	// Prefix aggregates for the C-recovery cost competition: the cumulative
 	// error cost / visible subtree count of the link-0 prev chain root..this
@@ -24,13 +20,22 @@ type gssNode struct {
 	// maintained at push (stack.c stack_node_new), read O(1) by
 	// ts_stack_error_cost (stack.c:493). Valid only while the matching gen
 	// field equals gssPrefixAggGen (parser_recover_c.go); allocNode resets the
-	// gens to 0 (never valid — the counter starts at 1). aggCost is filled by
-	// both the parser-side and merge-side walks (identical math); aggVis only
-	// by the parser side, hence the separate gen.
-	aggGen    uint64
-	aggVisGen uint64
-	aggCost   uint32
-	aggVis    int32
+	// generation to 0 (never valid — the counter starts at 1). aggCost is filled
+	// by both the parser-side and merge-side walks (identical math); aggVis only
+	// by the parser side, hence aggVisValid.
+	aggGen uint64
+
+	// extraLinks points at the backing array for links 1..k after a gated
+	// lossless condense merge. Keeping only a pointer and compact length/capacity
+	// on the overwhelmingly single-link node avoids paying a slice header on
+	// every GSS record. The inline (prev, entry) pair remains link 0.
+	extraLinks     *gssMainLink
+	aggCost        uint32
+	aggVis         int32
+	depth          uint32
+	extraLinkCount uint8
+	extraLinkCap   uint8
+	aggVisValid    bool
 }
 
 type gssMainLink struct {
@@ -44,15 +49,57 @@ func (n *gssNode) linkCount() int {
 	if n == nil {
 		return 0
 	}
-	return 1 + len(n.extraLinks)
+	return 1 + int(n.extraLinkCount)
 }
 
 func (n *gssNode) link(i int) (prev *gssNode, entry stackEntry) {
 	if i == 0 {
 		return n.prev, n.entry
 	}
-	l := n.extraLinks[i-1]
+	l := n.extraLink(i - 1)
 	return l.prev, l.entry
+}
+
+func (n *gssNode) extraLink(i int) gssMainLink {
+	if n == nil || i < 0 || i >= int(n.extraLinkCount) || n.extraLinks == nil {
+		panic("gssNode.extraLink: index out of range")
+	}
+	return unsafe.Slice(n.extraLinks, int(n.extraLinkCount))[i]
+}
+
+func (n *gssNode) setExtraLink(i int, link gssMainLink) {
+	if n == nil || i < 0 || i >= int(n.extraLinkCount) || n.extraLinks == nil {
+		panic("gssNode.setExtraLink: index out of range")
+	}
+	unsafe.Slice(n.extraLinks, int(n.extraLinkCount))[i] = link
+}
+
+func (n *gssNode) appendExtraLink(link gssMainLink) {
+	if n == nil || int(n.extraLinkCount) >= maxMainLinkCount-1 {
+		panic("gssNode.appendExtraLink: link limit exceeded")
+	}
+	count := int(n.extraLinkCount)
+	capacity := int(n.extraLinkCap)
+	if count < capacity && n.extraLinks != nil {
+		unsafe.Slice(n.extraLinks, capacity)[count] = link
+		n.extraLinkCount++
+		return
+	}
+	newCapacity := 1
+	if capacity > 0 {
+		newCapacity = capacity * 2
+	}
+	if max := maxMainLinkCount - 1; newCapacity > max {
+		newCapacity = max
+	}
+	links := make([]gssMainLink, newCapacity)
+	if count > 0 {
+		copy(links, unsafe.Slice(n.extraLinks, count))
+	}
+	links[count] = link
+	n.extraLinks = &links[0]
+	n.extraLinkCount++
+	n.extraLinkCap = uint8(newCapacity)
 }
 
 // gssStack is a shared-prefix stack foundation for future GLR work.
@@ -244,7 +291,7 @@ func gssNodeHash(n *gssNode) uint64 {
 		pending = append(pending, cur)
 	}
 	prevHash := gssHashSeed
-	if len(pending) < n.depth {
+	if len(pending) < int(n.depth) {
 		prev := pending[len(pending)-1].prev
 		if prev != nil {
 			prevHash = prev.hash
@@ -281,7 +328,7 @@ func (s gssStack) len() int {
 	if s.head == nil {
 		return 0
 	}
-	return s.head.depth
+	return int(s.head.depth)
 }
 
 func (s gssStack) top() stackEntry {
@@ -305,11 +352,12 @@ func (s *gssStack) push(state StateID, node *Node, scratch *gssScratch) {
 }
 
 func (s *gssStack) pushEntry(entry stackEntry, scratch *gssScratch) {
-	var depth int
+	depth := uint32(1)
 	if s.head != nil {
+		if s.head.depth == ^uint32(0) {
+			panic("gssStack.pushEntry: stack depth overflow")
+		}
 		depth = s.head.depth + 1
-	} else {
-		depth = 1
 	}
 	n := scratch.allocNode(entry, s.head, depth)
 	s.head = n
@@ -323,14 +371,18 @@ func (s *gssStack) truncate(depth int) bool {
 	if s.head == nil {
 		return depth == 0
 	}
-	if depth > s.head.depth {
+	if uint64(depth) > uint64(^uint32(0)) {
+		return false
+	}
+	depth32 := uint32(depth)
+	if depth32 > s.head.depth {
 		return false
 	}
 	keep := s.head
-	for keep != nil && keep.depth > depth {
+	for keep != nil && keep.depth > depth32 {
 		keep = keep.prev
 	}
-	if keep == nil || keep.depth != depth {
+	if keep == nil || keep.depth != depth32 {
 		return false
 	}
 	s.head = keep
@@ -360,7 +412,7 @@ func (s gssStack) materialize(dst []stackEntry) []stackEntry {
 	return dst
 }
 
-func (s *gssScratch) allocNode(entry stackEntry, prev *gssNode, depth int) *gssNode {
+func (s *gssScratch) allocNode(entry stackEntry, prev *gssNode, depth uint32) *gssNode {
 	hash := uint64(0)
 	if s == nil || !s.singleStackMode {
 		prevHash := gssHashSeed
@@ -395,15 +447,17 @@ func (s *gssScratch) allocNode(entry stackEntry, prev *gssNode, depth int) *gssN
 			n.depth = depth
 			n.hash = hash
 			n.extraLinks = nil
+			n.extraLinkCount = 0
+			n.extraLinkCap = 0
 			n.aggGen = 0
-			n.aggVisGen = 0
+			n.aggVisValid = false
 			return n
 		}
 	}
 	return s.allocNodeSlow(entry, prev, depth, hash)
 }
 
-func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth int, hash uint64) *gssNode {
+func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth uint32, hash uint64) *gssNode {
 	if len(s.slabs) == 0 {
 		capacity := defaultGSSNodeSlabCap
 		if s.initialCap > capacity {
@@ -445,8 +499,10 @@ func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth int, h
 		n.depth = depth
 		n.hash = hash
 		n.extraLinks = nil
+		n.extraLinkCount = 0
+		n.extraLinkCap = 0
 		n.aggGen = 0
-		n.aggVisGen = 0
+		n.aggVisValid = false
 		if s.audit != nil {
 			s.audit.recordGSSAlloc(n)
 		}
@@ -530,7 +586,7 @@ func gssSpanIsLinear(head *gssNode, childCount int) bool {
 	}
 	nonExtraFound := 0
 	for n := head; n != nil; n = n.prev {
-		if len(n.extraLinks) > 0 {
+		if n.extraLinkCount > 0 {
 			return false
 		}
 		if stackEntryHasNode(n.entry) && !stackEntryNodeIsExtra(n.entry) {

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -45,6 +45,11 @@ type gssMainLink struct {
 
 const maxMainLinkCount = maxStacksPerMergeKey
 
+// extraLinkCount/extraLinkCap are uint8; the compacted layout is only valid
+// while every possible link count fits. This conversion fails to compile if
+// maxMainLinkCount ever grows past what uint8 can carry.
+const _ = uint8(maxMainLinkCount - 1)
+
 func (n *gssNode) linkCount() int {
 	if n == nil {
 		return 0

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -114,6 +114,7 @@ type gssScratch struct {
 	initialCap        int
 	skipClear         bool
 	usedTotal         int
+	peakUsed          int
 	allocatedBytes    int64
 	singleStackMode   bool
 	singleStackAllocs uint64
@@ -436,6 +437,9 @@ func (s *gssScratch) allocNode(entry stackEntry, prev *gssNode, depth uint32) *g
 			idx := slab.used
 			slab.used++
 			s.usedTotal++
+			if s.usedTotal > s.peakUsed {
+				s.peakUsed = s.usedTotal
+			}
 			if s.singleStackMode {
 				s.singleStackAllocs++
 			} else {
@@ -487,6 +491,9 @@ func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth uint32
 		idx := slab.used
 		slab.used++
 		s.usedTotal++
+		if s.usedTotal > s.peakUsed {
+			s.peakUsed = s.usedTotal
+		}
 		s.slabCursor = i
 		if s.singleStackMode {
 			s.singleStackAllocs++
@@ -510,6 +517,27 @@ func (s *gssScratch) allocNodeSlow(entry stackEntry, prev *gssNode, depth uint32
 	}
 }
 
+// recycleForParse makes every GSS slab slot available to the current parse.
+// The caller must first prove that no live parse stack points into the slabs
+// and invalidate every pointer-keyed merge/recovery cache. Keeping that proof
+// outside this allocator makes accidental address reuse impossible from lower
+// level allocation call sites.
+func (s *gssScratch) recycleForParse() {
+	if s == nil || s.usedTotal == 0 {
+		return
+	}
+	for i := range s.slabs {
+		used := s.slabs[i].used
+		if used > len(s.slabs[i].data) {
+			used = len(s.slabs[i].data)
+		}
+		clear(s.slabs[i].data[:used])
+		s.slabs[i].used = 0
+	}
+	s.slabCursor = 0
+	s.usedTotal = 0
+}
+
 func (s *gssScratch) reset() {
 	if cap(s.stackEntries) > maxRetainedGSSStackEntries {
 		s.stackEntries = nil
@@ -524,6 +552,7 @@ func (s *gssScratch) reset() {
 		s.demotions = 0
 		s.nodesDemoted = 0
 		s.skipClear = false
+		s.peakUsed = 0
 		s.allocatedBytes = s.frontier.allocatedBytes() + stackEntryBytesForCap(cap(s.stackEntries))
 		s.audit = nil
 		return
@@ -564,6 +593,7 @@ func (s *gssScratch) reset() {
 	s.slabCursor = 0
 	s.skipClear = false
 	s.usedTotal = 0
+	s.peakUsed = 0
 	s.singleStackMode = false
 	s.singleStackAllocs = 0
 	s.multiStackAllocs = 0

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -968,16 +968,17 @@ func TestGSSScratchRecycleForParseReusesClearedSlots(t *testing.T) {
 	var scratch gssScratch
 	payload := &Node{symbol: 7, endByte: 3}
 	first := scratch.allocNode(newStackEntryNode(2, payload), nil, 1)
-	first.extraLinks = append(first.extraLinks, gssMainLink{entry: stackEntry{state: 9}})
+	first.appendExtraLink(gssMainLink{entry: stackEntry{state: 9}})
 	first.aggGen = 12
-	first.aggVisGen = 13
+	first.aggVisValid = true
 
 	scratch.recycleForParse()
 
 	if scratch.usedTotal != 0 {
 		t.Fatalf("used nodes after recycle = %d, want 0", scratch.usedTotal)
 	}
-	if first.prev != nil || first.entry.node != nil || first.extraLinks != nil || first.aggGen != 0 || first.aggVisGen != 0 {
+	if first.prev != nil || first.entry.node != nil || first.extraLinks != nil || first.extraLinkCount != 0 ||
+		first.extraLinkCap != 0 || first.aggGen != 0 || first.aggVisValid {
 		t.Fatalf("recycled slot retained state: %+v", *first)
 	}
 	second := scratch.allocNode(stackEntry{state: 4}, nil, 1)

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -5,6 +5,24 @@ import (
 	"unsafe"
 )
 
+func gssNodeWithExtraLinks(node gssNode, links ...gssMainLink) *gssNode {
+	n := &node
+	for _, link := range links {
+		n.appendExtraLink(link)
+	}
+	return n
+}
+
+func TestGSSNodeLayoutSizeBudget(t *testing.T) {
+	want := uintptr(64)
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		want = 52
+	}
+	if got := unsafe.Sizeof(gssNode{}); got != want {
+		t.Fatalf("gssNode size = %d bytes, want %d", got, want)
+	}
+}
+
 func TestGSSStackPushCloneAndTruncate(t *testing.T) {
 	var scratch gssScratch
 	base := newGSSStack(1, &scratch)
@@ -221,7 +239,7 @@ func TestGSSMainAddLinkAtCapRejectsUnsafeEquivalentReplacement(t *testing.T) {
 		depth: 2,
 	}
 	for i := 1; i < maxMainLinkCount; i++ {
-		head.extraLinks = append(head.extraLinks, gssMainLink{
+		head.appendExtraLink(gssMainLink{
 			prev:  &gssNode{entry: stackEntry{state: StateID(100 + i)}, depth: 1},
 			entry: newStackEntryNode(10, &Node{symbol: 20, startByte: 1, endByte: 2, flags: nodeFlagNamed, dynamicPrecedence: int32(i + 1)}),
 		})
@@ -265,7 +283,7 @@ func TestGSSMainAddLinkAtCapReplacesEquivalentSamePredecessorWithHigherDynamic(t
 		depth: 2,
 	}
 	for i := 1; i < maxMainLinkCount; i++ {
-		head.extraLinks = append(head.extraLinks, gssMainLink{
+		head.appendExtraLink(gssMainLink{
 			prev:  &gssNode{entry: stackEntry{state: StateID(100 + i)}, depth: 1},
 			entry: newStackEntryNode(10, &Node{symbol: Symbol(20 + i), startByte: 1, endByte: 2, flags: nodeFlagNamed, dynamicPrecedence: int32(i + 1)}),
 		})
@@ -302,15 +320,11 @@ func TestGSSMainAddLinkMergesNestedPackedPredecessorLinks(t *testing.T) {
 		return newStackEntryNode(3, &Node{symbol: 31, startByte: 1, endByte: 2, flags: nodeFlagNamed})
 	}
 
-	packedPred := &gssNode{
+	packedPred := gssNodeWithExtraLinks(gssNode{
 		entry: left(),
 		prev:  baseA,
 		depth: 2,
-		extraLinks: []gssMainLink{{
-			prev:  baseB,
-			entry: left(),
-		}},
-	}
+	}, gssMainLink{prev: baseB, entry: left()})
 	head := &gssNode{
 		entry: right(),
 		prev:  packedPred,
@@ -373,12 +387,12 @@ func TestGSSMainMergeFailureLeavesIncumbentPredecessorUnchanged(t *testing.T) {
 		depth: 2,
 	}
 	for i := 1; i < maxMainLinkCount-1; i++ {
-		w.extraLinks = append(w.extraLinks, gssMainLink{
+		w.appendExtraLink(gssMainLink{
 			prev:  base(StateID(1000 + i)),
 			entry: branchEntry(Symbol(100 + i)),
 		})
 	}
-	w.extraLinks = append(w.extraLinks, gssMainLink{
+	w.appendExtraLink(gssMainLink{
 		prev:  base(1999),
 		entry: branchEntry(199),
 	})
@@ -396,24 +410,16 @@ func TestGSSMainMergeFailureLeavesIncumbentPredecessorUnchanged(t *testing.T) {
 		prev:  base(3000),
 		depth: 2,
 	}
-	incumbentHead := &gssNode{
+	incumbentHead := gssNodeWithExtraLinks(gssNode{
 		entry: topEntry(1),
 		prev:  w,
 		depth: 3,
-		extraLinks: []gssMainLink{{
-			prev:  x,
-			entry: topEntry(2),
-		}},
-	}
-	incomingHead := &gssNode{
+	}, gssMainLink{prev: x, entry: topEntry(2)})
+	incomingHead := gssNodeWithExtraLinks(gssNode{
 		entry: topEntry(1),
 		prev:  y,
 		depth: 3,
-		extraLinks: []gssMainLink{{
-			prev:  x,
-			entry: topEntry(1),
-		}},
-	}
+	}, gssMainLink{prev: x, entry: topEntry(1)})
 	beforePred := snapshotGSSMainLinks(w)
 	beforeX := snapshotGSSMainLinks(x)
 	beforeHead := snapshotGSSMainLinks(incumbentHead)
@@ -448,7 +454,7 @@ func TestGSSMainCanMergeNodesEnumeratesVirtualSourceLinks(t *testing.T) {
 		depth: 2,
 	}
 	for i := 1; i < maxMainLinkCount; i++ {
-		dest.extraLinks = append(dest.extraLinks, gssMainLink{
+		dest.appendExtraLink(gssMainLink{
 			prev:  base(StateID(200 + i)),
 			entry: entry(Symbol(20 + i)),
 		})
@@ -518,7 +524,7 @@ func TestGSSMainPreflightCachedReachInvalidatesFalseBeforeCycleCheck(t *testing.
 
 func TestGSSMainPreflightCleanZeroCacheInvalidatesAfterVirtualErrorLink(t *testing.T) {
 	base := func(state StateID, prev *gssNode, depth int) *gssNode {
-		return &gssNode{entry: stackEntry{state: state}, prev: prev, depth: depth}
+		return &gssNode{entry: stackEntry{state: state}, prev: prev, depth: uint32(depth)}
 	}
 
 	tail := base(3, nil, 0)
@@ -565,17 +571,13 @@ func TestGSSMainMergeRejectsVirtualCycleWithoutPartialMutation(t *testing.T) {
 		depth: 2,
 	}
 
-	incumbentHead := &gssNode{
+	incumbentHead := gssNodeWithExtraLinks(gssNode{
 		entry: topEntry(20),
 		prev:  a,
 		depth: 3,
-		extraLinks: []gssMainLink{{
-			prev:  x,
-			entry: topEntry(21),
-		}},
-	}
+	}, gssMainLink{prev: x, entry: topEntry(21)})
 	for i := incumbentHead.linkCount(); i < maxMainLinkCount; i++ {
-		incumbentHead.extraLinks = append(incumbentHead.extraLinks, gssMainLink{
+		incumbentHead.appendExtraLink(gssMainLink{
 			prev:  base(StateID(200 + i)),
 			entry: topEntry(Symbol(30 + i)),
 		})
@@ -584,15 +586,11 @@ func TestGSSMainMergeRejectsVirtualCycleWithoutPartialMutation(t *testing.T) {
 		t.Fatalf("incumbent head link count = %d, want %d", got, maxMainLinkCount)
 	}
 
-	candidate := &gssNode{
+	candidate := gssNodeWithExtraLinks(gssNode{
 		entry: topEntry(21),
 		prev:  y,
 		depth: 3,
-		extraLinks: []gssMainLink{{
-			prev:  x,
-			entry: topEntry(20),
-		}},
-	}
+	}, gssMainLink{prev: x, entry: topEntry(20)})
 
 	beforeHead := snapshotGSSMainLinks(incumbentHead)
 	beforeX := snapshotGSSMainLinks(x)
@@ -623,7 +621,7 @@ func TestGSSMainEquivalentReplacementFailureLeavesWorstPredecessorUnchanged(t *t
 		depth: 2,
 	}
 	for i := 1; i < maxMainLinkCount-1; i++ {
-		worstPrev.extraLinks = append(worstPrev.extraLinks, gssMainLink{
+		worstPrev.appendExtraLink(gssMainLink{
 			prev:  base(StateID(3000 + i)),
 			entry: branchEntry(Symbol(300 + i)),
 		})
@@ -634,21 +632,17 @@ func TestGSSMainEquivalentReplacementFailureLeavesWorstPredecessorUnchanged(t *t
 
 	head := &gssNode{entry: equivEntry(1), prev: worstPrev, depth: 3}
 	for i := 1; i < maxMainLinkCount; i++ {
-		head.extraLinks = append(head.extraLinks, gssMainLink{
+		head.appendExtraLink(gssMainLink{
 			prev:  base(StateID(4000 + i)),
 			entry: equivEntry(int32(10 + i)),
 		})
 	}
 
-	incomingPrev := &gssNode{
+	incomingPrev := gssNodeWithExtraLinks(gssNode{
 		entry: branchEntry(400),
 		prev:  base(5000),
 		depth: 2,
-		extraLinks: []gssMainLink{{
-			prev:  base(5001),
-			entry: branchEntry(401),
-		}},
-	}
+	}, gssMainLink{prev: base(5001), entry: branchEntry(401)})
 	beforeWorst := snapshotGSSMainLinks(worstPrev)
 	beforeHead := snapshotGSSMainLinks(head)
 
@@ -845,7 +839,7 @@ func TestGLRStackDemoteLinearGSSRejectsPackedLinks(t *testing.T) {
 	var scratch gssScratch
 	stack := glrStack{gss: buildGSSStack([]stackEntry{{state: 1}, {state: 2}, {state: 3}}, &scratch)}
 	packed := stack.gss.head.prev
-	packed.extraLinks = append(packed.extraLinks, gssMainLink{entry: stackEntry{state: 4}})
+	packed.appendExtraLink(gssMainLink{entry: stackEntry{state: 4}})
 	originalHead := stack.gss.head
 
 	if stack.demoteLinearGSS(nil) {
@@ -948,7 +942,7 @@ func TestGSSScratchOverflowSlabGrowthBounded(t *testing.T) {
 	total := scratch.initialCap + ceiling*3
 	var prev *gssNode
 	for depth := 1; depth <= total; depth++ {
-		prev = scratch.allocNode(stackEntry{state: 1}, prev, depth)
+		prev = scratch.allocNode(stackEntry{state: 1}, prev, uint32(depth))
 	}
 
 	if len(scratch.slabs) < 3 {

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -963,3 +963,147 @@ func TestGSSScratchOverflowSlabGrowthBounded(t *testing.T) {
 		t.Fatalf("GSS allocatedBytes=%d, want capacity bytes=%d", got, want)
 	}
 }
+
+func TestGSSScratchRecycleForParseReusesClearedSlots(t *testing.T) {
+	var scratch gssScratch
+	payload := &Node{symbol: 7, endByte: 3}
+	first := scratch.allocNode(newStackEntryNode(2, payload), nil, 1)
+	first.extraLinks = append(first.extraLinks, gssMainLink{entry: stackEntry{state: 9}})
+	first.aggGen = 12
+	first.aggVisGen = 13
+
+	scratch.recycleForParse()
+
+	if scratch.usedTotal != 0 {
+		t.Fatalf("used nodes after recycle = %d, want 0", scratch.usedTotal)
+	}
+	if first.prev != nil || first.entry.node != nil || first.extraLinks != nil || first.aggGen != 0 || first.aggVisGen != 0 {
+		t.Fatalf("recycled slot retained state: %+v", *first)
+	}
+	second := scratch.allocNode(stackEntry{state: 4}, nil, 1)
+	if second != first {
+		t.Fatalf("recycled pointer = %p, want %p", second, first)
+	}
+	if scratch.peakUsed != 1 || scratch.usedTotal != 1 {
+		t.Fatalf("allocation high-water peak=%d used=%d", scratch.peakUsed, scratch.usedTotal)
+	}
+}
+
+func TestParserRecycleDemotedGSSInvalidatesPointerHolders(t *testing.T) {
+	var scratch parserScratch
+	payload := &Node{symbol: 11, startByte: 1, endByte: 4}
+	stack := glrStack{
+		gss:          buildGSSStack([]stackEntry{{state: 1}, newStackEntryNode(2, payload)}, &scratch.gss),
+		byteOffset:   4,
+		cRec:         &cRecoverState{summary: []cStackSummaryEntry{{depth: 2, state: 2, posBytes: 4}}},
+		cEntryAggGen: gssPrefixAggGen.Load(),
+	}
+	oldHead := stack.gss.head
+	stale := stack.cloneWithScratch(&scratch.gss)
+
+	scratch.merge.beginEquivEpoch()
+	scratch.merge.result = append(scratch.merge.result, stack, stale)
+	stacks := scratch.merge.result[:1]
+	scratch.merge.cPrefixPath = append(scratch.merge.cPrefixPath, oldHead)
+	scratch.merge.cleanZeroCache = map[*gssNode]gssCleanZeroErrorCacheEntry{oldHead: {clean: true}}
+	scratch.merge.cleanZeroStack = append(scratch.merge.cleanZeroStack, oldHead)
+	scratch.merge.cleanZeroVisited = append(scratch.merge.cleanZeroVisited, oldHead)
+	scratch.merge.spineVisit = append(scratch.merge.spineVisit, spinePairKey{a: oldHead, b: oldHead.prev})
+	scratch.merge.mergeSeen = map[gssMergePair]bool{{a: oldHead, b: oldHead.prev}: true}
+	scratch.merge.preflight = newGSSMainPreflight(nil)
+	scratch.merge.preflight.addVirtualLink(oldHead, oldHead.prev, oldHead.entry)
+	equivEpochBefore := scratch.merge.equivEpoch
+	gssPointerEpochBefore := scratch.merge.gssPointerEpoch
+
+	parser := &Parser{crecoveryEnteredErrorState: true}
+	pending := []glrStack{stale}
+	parser.pendingForkStacks = pending[:0]
+	frontierPending := []glrStack{stale}
+	parser.pendingFrontierForkStacks = frontierPending[:0]
+	parser.cPrefixPath = append(parser.cPrefixPath, oldHead)
+	prefixGenBefore := gssPrefixAggGen.Load()
+
+	if !parser.tryDemoteSingleLinearGSS(stacks, &scratch) {
+		t.Fatal("tryDemoteSingleLinearGSS() = false")
+	}
+	if stacks[0].gss.head != nil || len(stacks[0].entries) != 2 || stackEntryNode(stacks[0].entries[1]) != payload ||
+		stacks[0].cRec == nil || len(stacks[0].cRec.summary) != 1 || stacks[0].cEntryAggGen != 0 {
+		t.Fatalf("live stack changed during recycle: %+v", stacks[0])
+	}
+	if scratch.gss.usedTotal != 0 {
+		t.Fatalf("GSS used nodes after recycle = %d, want 0", scratch.gss.usedTotal)
+	}
+	if got := gssPrefixAggGen.Load(); got == prefixGenBefore {
+		t.Fatalf("GSS prefix aggregate generation did not advance: %d", got)
+	}
+	if scratch.merge.equivEpoch != equivEpochBefore {
+		t.Fatalf("node/spine equivalence epoch = %d, want preserved %d", scratch.merge.equivEpoch, equivEpochBefore)
+	}
+	if scratch.merge.gssPointerEpoch == gssPointerEpochBefore {
+		t.Fatalf("GSS pointer epoch did not advance: %d", scratch.merge.gssPointerEpoch)
+	}
+	if len(scratch.merge.result) != 0 || len(scratch.merge.cPrefixPath) != 0 || len(scratch.merge.cleanZeroCache) != 0 || len(scratch.merge.mergeSeen) != 0 {
+		t.Fatalf("merge pointer holders not reset: result=%d prefix=%d clean=%d seen=%d", len(scratch.merge.result), len(scratch.merge.cPrefixPath), len(scratch.merge.cleanZeroCache), len(scratch.merge.mergeSeen))
+	}
+	if scratch.merge.preflight == nil || len(scratch.merge.preflight.virtualLink) != 0 || len(scratch.merge.preflight.reachCache) != 0 {
+		t.Fatal("preflight pointer holders not reset")
+	}
+	if parser.cPrefixPath != nil && len(parser.cPrefixPath) != 0 {
+		t.Fatalf("parser prefix path len=%d, want 0", len(parser.cPrefixPath))
+	}
+	if got := parser.pendingForkStacks[:cap(parser.pendingForkStacks)][0].gss.head; got != nil {
+		t.Fatalf("pending fork backing retained GSS head %p", got)
+	}
+	if got := parser.pendingFrontierForkStacks[:cap(parser.pendingFrontierForkStacks)][0].gss.head; got != nil {
+		t.Fatalf("frontier pending backing retained GSS head %p", got)
+	}
+	if oldHead.entry.node != nil || oldHead.prev != nil {
+		t.Fatalf("old slab node not cleared: %+v", *oldHead)
+	}
+
+	clone := stacks[0].cloneWithScratch(&scratch.gss)
+	if stacks[0].gss.head == nil || clone.gss.head != stacks[0].gss.head {
+		t.Fatalf("refork after recycle failed: stack=%p clone=%p", stacks[0].gss.head, clone.gss.head)
+	}
+	if got := stacks[0].gss.materialize(nil); len(got) != 2 || stackEntryNode(got[1]) != payload {
+		t.Fatalf("reforked stack entries = %+v", got)
+	}
+}
+
+func TestGSSReuseRetainsOnlyFingerprintedSpineCache(t *testing.T) {
+	var nodes gssScratch
+	a := nodes.allocNode(stackEntry{state: 1}, nil, 1)
+	b := nodes.allocNode(stackEntry{state: 1}, nil, 1)
+	var merge glrMergeScratch
+	merge.beginEquivEpoch()
+	merge.ensureMergeHotCaches()
+	storeSpineEquivCache(&merge, a, b, true)
+	storeGSSStackEquivCache(&merge, a, b, true)
+	storeShapePrefixCache(&merge, a, glrMaterializingShapeHash{hash: 9, count: 1})
+	storeCleanZeroFrontCache(&merge, a, true)
+
+	merge.invalidateGSSPointersForReuse()
+
+	if got, ok := lookupSpineEquivCache(&merge, a, b); !ok || !got {
+		t.Fatalf("fingerprinted spine cache after invalidation = %v, %v; want true, true", got, ok)
+	}
+	if _, ok := lookupGSSStackEquivCache(&merge, a, b); ok {
+		t.Fatal("address-only stack cache survived GSS pointer epoch")
+	}
+	if _, ok := lookupShapePrefixCache(&merge, a); ok {
+		t.Fatal("address-only shape-prefix cache survived GSS reuse invalidation")
+	}
+	if _, ok := lookupCleanZeroFrontCache(&merge, a); ok {
+		t.Fatal("address-only clean-zero cache survived GSS reuse invalidation")
+	}
+
+	nodes.recycleForParse()
+	a2 := nodes.allocNode(stackEntry{state: 2}, nil, 1)
+	b2 := nodes.allocNode(stackEntry{state: 3}, nil, 1)
+	if a2 != a || b2 != b {
+		t.Fatalf("expected recycled addresses a=%p/%p b=%p/%p", a2, a, b2, b)
+	}
+	if _, ok := lookupSpineEquivCache(&merge, a2, b2); ok {
+		t.Fatal("fingerprinted spine cache hit after recycled addresses changed content")
+	}
+}

--- a/glr_test.go
+++ b/glr_test.go
@@ -3770,7 +3770,7 @@ func TestGSSCleanZeroAllLinksHandlesLongCleanChain(t *testing.T) {
 	var head *gssNode
 	const chainLen = 20000
 	for i := 0; i < chainLen; i++ {
-		head = gssScratch.allocNode(stackEntry{state: StateID(i%17 + 1)}, head, i+1)
+		head = gssScratch.allocNode(stackEntry{state: StateID(i%17 + 1)}, head, uint32(i+1))
 	}
 
 	if !gssNodeCleanZeroErrorAllLinksWithScratch(&mergeScratch, head) {
@@ -3791,7 +3791,7 @@ func TestGSSCleanZeroAllLinksRejectsErrorBearingPackedPredecessor(t *testing.T) 
 	head := gssScratch.allocNode(newStackEntryNode(2, NewLeafNode(11, true, 0, 1, Point{}, Point{Column: 1})), base, 2)
 	errorEntry := newStackEntryNode(2, NewLeafNode(99, true, 0, 1, Point{}, Point{Column: 1}))
 	stackEntryNode(errorEntry).setHasError(true)
-	head.extraLinks = append(head.extraLinks, gssMainLink{prev: extraPrev, entry: errorEntry})
+	head.appendExtraLink(gssMainLink{prev: extraPrev, entry: errorEntry})
 
 	if gssNodeCleanZeroErrorAllLinksWithScratch(&mergeScratch, head) {
 		t.Fatal("clean-zero scan accepted an error-bearing packed predecessor link")
@@ -3804,7 +3804,7 @@ func TestGSSNodesCanMergeAllowsCleanPackedPredecessorLinks(t *testing.T) {
 	extraPrev := scratch.allocNode(stackEntry{state: 9}, nil, 1)
 	extraEntry := newStackEntryNode(2, NewLeafNode(99, true, 0, 1, Point{}, Point{Column: 1}))
 	withExtra := scratch.allocNode(newStackEntryNode(2, NewLeafNode(11, true, 0, 1, Point{}, Point{Column: 1})), base, 2)
-	withExtra.extraLinks = append(withExtra.extraLinks, gssMainLink{prev: extraPrev, entry: extraEntry})
+	withExtra.appendExtraLink(gssMainLink{prev: extraPrev, entry: extraEntry})
 	candidate := scratch.allocNode(newStackEntryNode(2, NewLeafNode(11, true, 0, 1, Point{}, Point{Column: 1})), base, 2)
 
 	if !gssNodesCanMerge(withExtra, candidate) {
@@ -3813,7 +3813,7 @@ func TestGSSNodesCanMergeAllowsCleanPackedPredecessorLinks(t *testing.T) {
 
 	errorEntry := newStackEntryNode(2, NewLeafNode(99, true, 0, 1, Point{}, Point{Column: 1}))
 	stackEntryNode(errorEntry).setHasError(true)
-	withExtra.extraLinks[0] = gssMainLink{prev: extraPrev, entry: errorEntry}
+	withExtra.setExtraLink(0, gssMainLink{prev: extraPrev, entry: errorEntry})
 	if gssNodesCanMerge(withExtra, candidate) {
 		t.Fatal("gssNodesCanMerge = true for error-bearing packed predecessor")
 	}
@@ -3933,7 +3933,7 @@ func TestGSSMainMergePreservesCandidateBeyondUnsafeCLinkCap(t *testing.T) {
 	incumbent := buildStack(20)
 	for i := 1; i < maxMainLinkCount; i++ {
 		extraNode := NewLeafNode(Symbol(20+i), true, 0, 5, Point{}, Point{Column: 5})
-		incumbent.gss.head.extraLinks = append(incumbent.gss.head.extraLinks, gssMainLink{
+		incumbent.gss.head.appendExtraLink(gssMainLink{
 			prev:  incumbent.gss.head.prev,
 			entry: newStackEntryNode(7, extraNode),
 		})
@@ -3972,7 +3972,7 @@ func TestMergeStacksGeneralFaithfulGSSPreservesCandidateBeyondUnsafeCLinkCap(t *
 	incumbent := buildStack(7, 30, 0)
 	for i := 1; i < maxMainLinkCount; i++ {
 		extraNode := NewLeafNode(Symbol(30+i), true, 0, 5, Point{}, Point{Column: 5})
-		incumbent.gss.head.extraLinks = append(incumbent.gss.head.extraLinks, gssMainLink{
+		incumbent.gss.head.appendExtraLink(gssMainLink{
 			prev:  incumbent.gss.head.prev,
 			entry: newStackEntryNode(StateID(7+i), extraNode),
 		})
@@ -4027,7 +4027,7 @@ func TestMergeStacksDeferExactFaithfulGSSPreservesCandidateBeyondUnsafeCLinkCap(
 	incumbent := buildStack(7, 50, 0)
 	for i := 1; i < maxMainLinkCount; i++ {
 		extraNode := NewLeafNode(Symbol(50+i), true, 0, 5, Point{}, Point{Column: 5})
-		incumbent.gss.head.extraLinks = append(incumbent.gss.head.extraLinks, gssMainLink{
+		incumbent.gss.head.appendExtraLink(gssMainLink{
 			prev:  incumbent.gss.head.prev,
 			entry: newStackEntryNode(StateID(7+i), extraNode),
 		})
@@ -4079,13 +4079,13 @@ func TestMergeStacksSmallFaithfulGSSSameInlinePreservesCandidateBeyondUnsafeCLin
 	candidateHead := scratchGSS.allocNode(topEntry, prev, 2)
 	for i := 1; i < maxMainLinkCount; i++ {
 		extraNode := NewLeafNode(Symbol(30+i), true, 0, 5, Point{}, Point{Column: 5})
-		incumbentHead.extraLinks = append(incumbentHead.extraLinks, gssMainLink{
+		incumbentHead.appendExtraLink(gssMainLink{
 			prev:  prev,
 			entry: newStackEntryNode(StateID(7+i), extraNode),
 		})
 	}
 	candidateExtra := NewLeafNode(99, true, 0, 5, Point{}, Point{Column: 5})
-	candidateHead.extraLinks = append(candidateHead.extraLinks, gssMainLink{
+	candidateHead.appendExtraLink(gssMainLink{
 		prev:  prev,
 		entry: newStackEntryNode(99, candidateExtra),
 	})

--- a/parser.go
+++ b/parser.go
@@ -3137,7 +3137,7 @@ func captureParseScratchStats(parseRuntime *ParseRuntime, scratch *parserScratch
 	parseRuntime.GSSBytesAllocated = scratch.gss.allocatedBytes
 	parseRuntime.GSSBaselineBytes = scratch.gssBaselineBytes
 	parseRuntime.GSSSlabCount = len(scratch.gss.slabs)
-	parseRuntime.GSSNodesUsed = scratch.gss.usedTotal
+	parseRuntime.GSSNodesUsed = scratch.gss.peakUsed
 	parseRuntime.GSSNodesCapacity = scratch.gss.capacityNodes()
 	parseRuntime.GSSDemotions = scratch.gss.demotions
 	parseRuntime.GSSNodesDemoted = scratch.gss.nodesDemoted
@@ -6088,12 +6088,12 @@ func (p *Parser) recordParseArenaUsageOnReturn(arenaClass arenaClass, arena *nod
 					p.recordFullArenaUsage(arena.used)
 				}
 			}
-			p.recordFullGSSUsage(scratch.gss.usedTotal)
+			p.recordFullGSSUsage(scratch.gss.peakUsed)
 		}
 	}
 	return func() {
 		p.recordIncrementalArenaUsage(arena.used)
-		p.recordIncrementalGSSUsage(scratch.gss.usedTotal)
+		p.recordIncrementalGSSUsage(scratch.gss.peakUsed)
 	}
 }
 
@@ -6340,7 +6340,48 @@ func (p *Parser) tryDemoteSingleLinearGSS(stacks []glrStack, scratch *parserScra
 	}
 	scratch.gss.demotions++
 	scratch.gss.nodesDemoted += uint64(depth)
+	if !scratch.audit.enabled && !scratch.audit.equivEnabled {
+		p.recycleDemotedGSS(stacks, scratch)
+	}
 	return true
+}
+
+// recycleDemotedGSS reclaims GSS slab slots only after the sole live stack has
+// been materialized into entry scratch. The ordering is intentional: first
+// invalidate address-keyed caches and clear stale stack holders, then overwrite
+// the slab nodes. Runtime/equivalence audits stay on the append-only path
+// because their attribution state deliberately retains node identity across
+// token boundaries. C-recovery remains safe because its live version state is
+// carried by glrStack/cRecoverState, while both GSS prefix paths are cleared
+// here and the aggregate generation is advanced before address reuse.
+func (p *Parser) recycleDemotedGSS(stacks []glrStack, scratch *parserScratch) {
+	if p == nil || scratch == nil || len(stacks) != 1 || stacks[0].gss.head != nil ||
+		len(stacks[0].entries) == 0 || len(p.pendingForkStacks) != 0 ||
+		len(p.pendingFrontierForkStacks) != 0 || scratch.gss.usedTotal == 0 {
+		return
+	}
+
+	live := stacks[0]
+	scratch.merge.invalidateGSSPointersForReuse()
+	resetGSSPrefixPath(&p.cPrefixPath)
+	gssPrefixAggGen.Add(1)
+	if cap(scratch.merge.result) > 0 {
+		clear(scratch.merge.result[:cap(scratch.merge.result)])
+		scratch.merge.result = scratch.merge.result[:0]
+	}
+	if cap(stacks) > 0 {
+		clear(stacks[:cap(stacks)])
+		stacks[0] = live
+	}
+	if cap(p.pendingForkStacks) > 0 {
+		clear(p.pendingForkStacks[:cap(p.pendingForkStacks)])
+		p.pendingForkStacks = p.pendingForkStacks[:0]
+	}
+	if cap(p.pendingFrontierForkStacks) > 0 {
+		clear(p.pendingFrontierForkStacks[:cap(p.pendingFrontierForkStacks)])
+		p.pendingFrontierForkStacks = p.pendingFrontierForkStacks[:0]
+	}
+	scratch.gss.recycleForParse()
 }
 
 func (p *Parser) checkpointTransientScratch(stacks []glrStack, scratch *parserScratch, arena *nodeArena) ParseStopReason {

--- a/parser_default_reduce_test.go
+++ b/parser_default_reduce_test.go
@@ -72,7 +72,7 @@ func TestExternalNoActionDefaultReduceDrainsForksBetweenRounds(t *testing.T) {
 	altLeft := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
 	altLeftNode := gssScratch.allocNode(newStackEntryNode(8, altLeft), altBase, 2)
 	altRight := newLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	rightNode.extraLinks = append(rightNode.extraLinks, gssMainLink{
+	rightNode.appendExtraLink(gssMainLink{
 		prev:  altLeftNode,
 		entry: newStackEntryNode(7, altRight),
 	})

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1429,7 +1429,7 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 // merge / competition paths issue hundreds of such calls per token, which
 // dominates error-region parses even with warm per-node memos.
 //
-// The on-node aggregates below (gssNode.aggGen/aggCost/aggVisGen/aggVis)
+// The on-node aggregates below (gssNode.aggGen/aggCost/aggVis/aggVisValid)
 // restore C's shape: per gssNode, the cumulative aggregates of the prev-chain
 // prefix root..node inclusive. gssNode prev/entry links are write-once at
 // allocation except setGSSMainLink (link-0 rewrite), and node payload
@@ -1443,13 +1443,13 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 // ---------------------------------------------------------------------------
 
 // gssPrefixAggGen is the global invalidation generation for the GSS prefix
-// aggregates stored on gssNode (aggGen/aggCost/aggVisGen/aggVis). Bumped by
+// aggregates stored on gssNode (aggGen/aggCost/aggVis/aggVisValid). Bumped by
 // recovery-relevant nodeBumpEquivVersion mutations (tree.go) and link-0
 // rewrites that change the predecessor or full-Node payload (glr.go). Global
 // rather than per-parser because nodeBumpEquivVersion has no parser in scope;
 // cross-parser over-invalidation only costs a rebuild, never staleness.
-// Initialized to 1 so the zero value of gssNode.aggGen / aggVisGen (fresh or
-// slab-cleared nodes) can never validate.
+// Initialized to 1 so the zero value of gssNode.aggGen (fresh or slab-cleared
+// nodes) can never validate.
 var gssPrefixAggGen atomic.Uint64
 
 const maxRetainedGSSPrefixPath = 4 * 1024
@@ -1480,7 +1480,7 @@ func (p *Parser) cStackPrefixAgg(head *gssNode) (uint32, int) {
 	path := p.cPrefixPath[:0]
 	gn := head
 	for gn != nil {
-		if gn.aggGen == gen && gn.aggVisGen == gen {
+		if gn.aggGen == gen && gn.aggVisValid {
 			cost, vis = gn.aggCost, gn.aggVis
 			break
 		}
@@ -1494,7 +1494,7 @@ func (p *Parser) cStackPrefixAgg(head *gssNode) (uint32, int) {
 			vis += int32(p.cNodeVisibleSubtreeCount(n))
 		}
 		gn.aggGen = gen
-		gn.aggVisGen = gen
+		gn.aggVisValid = true
 		gn.aggCost = cost
 		gn.aggVis = vis
 	}
@@ -1504,7 +1504,7 @@ func (p *Parser) cStackPrefixAgg(head *gssNode) (uint32, int) {
 
 // cStackPrefixCostForMerge is the merge-scratch twin of cStackPrefixAgg. It
 // fills cost only (the merge side has no memoized visible-count walk), so it
-// leaves aggVisGen untouched; the cost value is identical to the parser-side
+// marks visibility invalid; the cost value is identical to the parser-side
 // fill, letting both sides share aggCost.
 func cStackPrefixCostForMerge(scratch *glrMergeScratch, lang *Language, head *gssNode) uint32 {
 	gen := gssPrefixAggGen.Load()
@@ -1525,6 +1525,7 @@ func cStackPrefixCostForMerge(scratch *glrMergeScratch, lang *Language, head *gs
 			cost += cNodeErrorCostLangWithScratch(scratch, lang, n)
 		}
 		gn.aggGen = gen
+		gn.aggVisValid = false
 		gn.aggCost = cost
 	}
 	scratch.cPrefixPath = path

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -656,7 +656,7 @@ func TestCDoAllPotentialReductionsCollapsesSamePopTargetSlicesByCParentSelection
 	rightNode := scratch.allocNode(newStackEntryNode(3, right), leftNode, 3)
 	altRight := newLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
 	altRight.dynamicPrecedence = 9
-	rightNode.extraLinks = append(rightNode.extraLinks, gssMainLink{
+	rightNode.appendExtraLink(gssMainLink{
 		prev:  leftNode,
 		entry: newStackEntryNode(3, altRight),
 	})
@@ -722,7 +722,7 @@ func TestCDoAllPotentialReductionsCollapsesSamePopWithTrailingExtra(t *testing.T
 	rightLowNode := scratch.allocNode(newStackEntryNode(3, rightLow), leftNode, 3)
 	rightHighNode := scratch.allocNode(newStackEntryNode(3, rightHigh), leftNode, 3)
 	head := scratch.allocNode(newStackEntryNode(3, extraLow), rightLowNode, 4)
-	head.extraLinks = append(head.extraLinks, gssMainLink{
+	head.appendExtraLink(gssMainLink{
 		prev:  rightHighNode,
 		entry: newStackEntryNode(3, extraHigh),
 	})

--- a/parser_recover_prefix_agg_test.go
+++ b/parser_recover_prefix_agg_test.go
@@ -56,8 +56,8 @@ func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
 		t.Fatalf("initial aggregate = (%d, %d), want (0, 1)", cost, visible)
 	}
 	gen := gssPrefixAggGen.Load()
-	if head.aggGen != gen || head.aggVisGen != gen {
-		t.Fatalf("initial cache generation = (%d, %d), want %d", head.aggGen, head.aggVisGen, gen)
+	if head.aggGen != gen || !head.aggVisValid {
+		t.Fatalf("initial cache generation = %d valid=%v, want %d valid", head.aggGen, head.aggVisValid, gen)
 	}
 
 	payload.parseState = 2
@@ -84,6 +84,35 @@ func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
 	wantCost := uint32(cErrCostPerMissingTree + cErrCostPerRecovery)
 	if cost != wantCost || visible != 1 {
 		t.Fatalf("post-missing aggregate = (%d, %d), want (%d, 1)", cost, visible, wantCost)
+	}
+}
+
+func TestMergeCostFillInvalidatesAndParserRefillsVisibility(t *testing.T) {
+	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
+	p := &Parser{language: lang, cNodeMemo: make(map[*Node]cNodeMemoEntry)}
+	base := &gssNode{entry: newStackEntryNode(1, &Node{symbol: 1, equivVersion: 1}), depth: 1}
+	head := &gssNode{entry: newStackEntryNode(2, &Node{symbol: 1, equivVersion: 1}), prev: base, depth: 2}
+
+	if cost, visible := p.cStackPrefixAgg(head); cost != 0 || visible != 2 {
+		t.Fatalf("initial aggregate = (%d, %d), want (0, 2)", cost, visible)
+	}
+	if !base.aggVisValid || !head.aggVisValid {
+		t.Fatal("parser aggregate did not validate visibility")
+	}
+
+	gssPrefixAggGen.Add(1)
+	merge := glrMergeScratch{language: lang}
+	if cost := cStackPrefixCostForMerge(&merge, lang, head); cost != 0 {
+		t.Fatalf("merge-side cost = %d, want 0", cost)
+	}
+	if base.aggVisValid || head.aggVisValid {
+		t.Fatal("cost-only refill left stale visibility valid")
+	}
+	if cost, visible := p.cStackPrefixAgg(head); cost != 0 || visible != 2 {
+		t.Fatalf("parser refill = (%d, %d), want (0, 2)", cost, visible)
+	}
+	if !base.aggVisValid || !head.aggVisValid {
+		t.Fatal("parser refill did not restore visibility validity")
 	}
 }
 
@@ -163,13 +192,10 @@ func TestExpandedGSSResultPathsKeepIndependentRecoveryAggregates(t *testing.T) {
 		endByte:      1,
 		children:     []*Node{errChild},
 	}
-	head := &gssNode{
+	head := gssNodeWithExtraLinks(gssNode{
 		entry: newStackEntryNode(1, plain),
 		depth: 1,
-		extraLinks: []gssMainLink{{
-			entry: newStackEntryNode(1, errNode),
-		}},
-	}
+	}, gssMainLink{entry: newStackEntryNode(1, errNode)})
 	source := glrStack{
 		gss:  gssStack{head: head},
 		cRec: &cRecoverState{},
@@ -195,11 +221,11 @@ func TestSetGSSMainLinkInvalidatesOnlyChangedRecoveryContribution(t *testing.T) 
 	prev := &gssNode{depth: 1}
 	payload := &Node{symbol: 1, equivVersion: 1}
 	head := &gssNode{
-		prev:      prev,
-		entry:     newStackEntryNode(1, payload),
-		depth:     2,
-		aggGen:    gssPrefixAggGen.Load(),
-		aggVisGen: gssPrefixAggGen.Load(),
+		prev:        prev,
+		entry:       newStackEntryNode(1, payload),
+		depth:       2,
+		aggGen:      gssPrefixAggGen.Load(),
+		aggVisValid: true,
 	}
 
 	gen := gssPrefixAggGen.Load()

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -1340,7 +1340,7 @@ func TestBuildResultFromGLRExpandsPackedGSSAlternateForFinalChoice(t *testing.T)
 	var scratch gssScratch
 	base := scratch.allocNode(stackEntry{state: 1}, nil, 1)
 	head := scratch.allocNode(newStackEntryNode(2, inlineErr), base, 2)
-	head.extraLinks = append(head.extraLinks, gssMainLink{
+	head.appendExtraLink(gssMainLink{
 		prev:  base,
 		entry: newStackEntryNode(2, good),
 	})
@@ -1376,7 +1376,7 @@ func TestBuildResultFromGLRExpandsNestedPackedGSSAlternate(t *testing.T) {
 	var scratch gssScratch
 	base := scratch.allocNode(stackEntry{state: 1}, nil, 1)
 	packedBelowHead := scratch.allocNode(newStackEntryNode(2, inlineErr), base, 2)
-	packedBelowHead.extraLinks = append(packedBelowHead.extraLinks, gssMainLink{
+	packedBelowHead.appendExtraLink(gssMainLink{
 		prev:  base,
 		entry: newStackEntryNode(2, good),
 	})

--- a/parser_reduce_test.go
+++ b/parser_reduce_test.go
@@ -11,7 +11,7 @@ func buildTwoWindowFullGSSReduceCase(t *testing.T, scratch *gssScratch, arena *n
 	leftNode := scratch.allocNode(newStackEntryNode(2, left), base, 2)
 	rightNode := scratch.allocNode(newStackEntryNode(3, right), leftNode, 3)
 	altRight := newLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	rightNode.extraLinks = append(rightNode.extraLinks, gssMainLink{
+	rightNode.appendExtraLink(gssMainLink{
 		prev:  leftNode,
 		entry: newStackEntryNode(3, altRight),
 	})
@@ -80,7 +80,7 @@ func TestFastVisibleReduceFromGSSDeclinesMultiLinkSpan(t *testing.T) {
 	leftNode := scratch.allocNode(newStackEntryNode(2, left), base, 2)
 	rightNode := scratch.allocNode(newStackEntryNode(3, right), leftNode, 3)
 	altRight := NewLeafNode(2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	rightNode.extraLinks = append(rightNode.extraLinks, gssMainLink{
+	rightNode.appendExtraLink(gssMainLink{
 		prev:  leftNode,
 		entry: newStackEntryNode(3, altRight),
 	})
@@ -521,7 +521,7 @@ func TestReduceForkSelectionScansPastCrossProductRawCapForSameGroupWinner(t *tes
 				altLeft.dynamicPrecedence = 99
 				bestLeft = altLeft
 			}
-			leftHub.extraLinks = append(leftHub.extraLinks, gssMainLink{
+			leftHub.appendExtraLink(gssMainLink{
 				prev:  popTo,
 				entry: newStackEntryNode(8, altLeft),
 			})
@@ -535,7 +535,7 @@ func TestReduceForkSelectionScansPastCrossProductRawCapForSameGroupWinner(t *tes
 			head = scratch.allocNode(newStackEntryNode(9, right), leftHub, 3)
 			continue
 		}
-		head.extraLinks = append(head.extraLinks, gssMainLink{
+		head.appendExtraLink(gssMainLink{
 			prev:  leftHub,
 			entry: newStackEntryNode(9, right),
 		})
@@ -636,7 +636,7 @@ func TestReduceForkSelectionCapsDistinctCrossProductGroups(t *testing.T) {
 		for leftIdx := 1; leftIdx < maxMainLinkCount; leftIdx++ {
 			distinctPopTo := scratch.allocNode(stackEntry{state: StateID(20 + rightIdx*maxMainLinkCount + leftIdx)}, nil, 1)
 			altLeft := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
-			leftHub.extraLinks = append(leftHub.extraLinks, gssMainLink{
+			leftHub.appendExtraLink(gssMainLink{
 				prev:  distinctPopTo,
 				entry: newStackEntryNode(8, altLeft),
 			})
@@ -646,7 +646,7 @@ func TestReduceForkSelectionCapsDistinctCrossProductGroups(t *testing.T) {
 			head = scratch.allocNode(newStackEntryNode(9, right), leftHub, 3)
 			continue
 		}
-		head.extraLinks = append(head.extraLinks, gssMainLink{
+		head.appendExtraLink(gssMainLink{
 			prev:  leftHub,
 			entry: newStackEntryNode(9, right),
 		})
@@ -696,10 +696,10 @@ func TestSelectedReduceWindowsFromGSSCapsTraversalWork(t *testing.T) {
 	prev := popTo
 	for depth := 0; depth < childCount; depth++ {
 		leaf := newLeafNodeInArena(arena, Symbol(1+depth), true, uint32(depth), uint32(depth+1), Point{Column: uint32(depth)}, Point{Column: uint32(depth + 1)})
-		layer := scratch.allocNode(newStackEntryNode(StateID(20+depth), leaf), prev, depth+2)
+		layer := scratch.allocNode(newStackEntryNode(StateID(20+depth), leaf), prev, uint32(depth+2))
 		for alt := 1; alt < maxMainLinkCount; alt++ {
 			altLeaf := newLeafNodeInArena(arena, Symbol(1+depth), true, uint32(depth), uint32(depth+1), Point{Column: uint32(depth)}, Point{Column: uint32(depth + 1)})
-			layer.extraLinks = append(layer.extraLinks, gssMainLink{
+			layer.appendExtraLink(gssMainLink{
 				prev:  prev,
 				entry: newStackEntryNode(StateID(20+depth), altLeaf),
 			})
@@ -759,7 +759,7 @@ func TestFaithfulForkReduceTargetMismatchFallsBackToPendingFork(t *testing.T) {
 	altLeft := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
 	altLeftNode := scratch.allocNode(newStackEntryNode(8, altLeft), altBase, 2)
 	altRight := newLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	rightNode.extraLinks = append(rightNode.extraLinks, gssMainLink{
+	rightNode.appendExtraLink(gssMainLink{
 		prev:  altLeftNode,
 		entry: newStackEntryNode(7, altRight),
 	})
@@ -1043,7 +1043,7 @@ func TestNoTreeReduceFromGSSRejectsMultiLinkSpan(t *testing.T) {
 	leftNode := scratch.allocNode(newStackEntryNoTreeNode(2, left), base, 2)
 	rightNode := scratch.allocNode(newStackEntryNoTreeNode(3, right), leftNode, 3)
 	altRight := newNoTreeLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
-	rightNode.extraLinks = append(rightNode.extraLinks, gssMainLink{
+	rightNode.appendExtraLink(gssMainLink{
 		prev:  leftNode,
 		entry: newStackEntryNoTreeNode(3, altRight),
 	})

--- a/parser_scratch_budget_test.go
+++ b/parser_scratch_budget_test.go
@@ -27,7 +27,7 @@ func TestParserScratchMemoryBudgetExhaustedByGSSSlabGrowth(t *testing.T) {
 	scratch.setBudget(1)
 
 	for depth := 2; depth <= defaultGSSNodeSlabCap; depth++ {
-		_ = scratch.gss.allocNode(stackEntry{state: 1}, nil, depth)
+		_ = scratch.gss.allocNode(stackEntry{state: 1}, nil, uint32(depth))
 	}
 	if scratch.budgetExhausted() {
 		t.Fatal("budget exhausted before gss-slab overflow")
@@ -110,7 +110,7 @@ func TestParserScratchResetRecomputesAllocatedBytes(t *testing.T) {
 	_ = scratch.entries.allocWithCap(defaultStackEntrySlabCap, defaultStackEntrySlabCap)
 	_ = scratch.entries.alloc(1)
 	for depth := 1; depth <= defaultGSSNodeSlabCap+1; depth++ {
-		_ = scratch.gss.allocNode(stackEntry{state: 1}, nil, depth)
+		_ = scratch.gss.allocNode(stackEntry{state: 1}, nil, uint32(depth))
 	}
 	_ = ensureMergeResultCap(&scratch.merge, 2)
 	_ = ensureMergeSlotCap(&scratch.merge, 2)


### PR DESCRIPTION
## Summary

Completes and lands two stacked GLR memory optimizations that were left mid-integration on `codex/gss-node-layout`:

- **gssNode layout compaction** (7e63f411): `extraLinks` slice → pointer-backed array with uint8 count/cap (eliminating the slice header on the common single-link node), `depth` int → uint32, `aggVisGen` uint64 → `aggVisValid` bool. `TestGSSNodeLayoutSizeBudget` enforces the 64-byte target on 64-bit (52 on 32-bit). Mutation goes through `setExtraLink`/`appendExtraLink`/`extraLink` helpers.
- **Transient GSS slab recycling** (79f53985): reuses GSS storage after linear demotion. Address-keyed merge/recovery caches are invalidated before reuse (`invalidateGSSPointersForReuse`, prefix-path reset, agg generation bump); fingerprinted spine memoization is preserved.
- **Integration fixup** (9238630e): aligns the recycle tests with the compacted field set.

Semantic audit of the seam between the two: both `recycleForParse()` and `reset()` zero slab slots wholesale via `clear()`, so the compacted fields (`extraLinks` ptr/count/cap, `aggVisValid`) are reset by construction, with explicit re-zeroing on both `allocNode` paths as defense in depth.

## Verification

- `go build ./...`, `go vet .` — clean
- GSS/recycle/demotion suite: 85 subtests PASS (size budget, recycle-reuse, pointer-holder invalidation, fingerprinted-spine retention, merge/reduce/forest)
- Full root package: ok (9.9s)
- `go test -race` over GSS/GLR/recycle machinery: clean
- Quiet-host A/B (pinned core, count=10, vs same-morning main baseline): full parse −0.17%, one-byte edit −1.54%, no-edit +2.07% — timing-neutral within noise, allocs identical (9/0/0). The win is per-node GSS memory on GLR-heavy paths, enforced by the size-budget test; the canonical lanes confirm no common-path regression.