### PR TITLE
optimize(parser): skip unary-collapse checks on multi-child reduces

### DIFF
--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -7455,6 +7455,13 @@ func (p *Parser) collapsibleRawUnarySelfReductionEntry(act ParseAction, tok Toke
 	if p == nil || arena == nil {
 		return stackEntry{}, false
 	}
+	// See the identical act.ChildCount guard and comment in
+	// collapsibleUnarySelfReduction: only a genuine arity-1 production can
+	// ever collapse here, so multi-child reduces are skipped before any
+	// other work.
+	if act.ChildCount != 1 {
+		return stackEntry{}, false
+	}
 	diag := arena.breakdownEnabled
 	if diag {
 		arena.collapseRawUnaryAttempts++
@@ -7692,6 +7699,13 @@ func (p *Parser) collapsibleRawUnarySelfReduction(act ParseAction, tok Token, ar
 	if p == nil || arena == nil {
 		return nil
 	}
+	// See the identical act.ChildCount guard and comment in
+	// collapsibleUnarySelfReduction: only a genuine arity-1 production can
+	// ever collapse here, so multi-child reduces are skipped before any
+	// other work.
+	if act.ChildCount != 1 {
+		return nil
+	}
 	diag := arena.breakdownEnabled
 	if diag {
 		arena.collapseRawUnaryAttempts++
@@ -7743,6 +7757,22 @@ func (p *Parser) collapsibleRawUnarySelfReduction(act ParseAction, tok Token, ar
 
 func (p *Parser) collapsibleUnarySelfReduction(act ParseAction, tok Token, arena *nodeArena, entries []stackEntry, start, reducedEnd int, children []*Node, fieldIDs []FieldID) *Node {
 	if p == nil || arena == nil {
+		return nil
+	}
+	// A unary self-reduction (rename-through of the sole popped child) can
+	// only ever apply when the production's own arity is 1: the reduce
+	// window always contains at least act.ChildCount non-extra entries
+	// (computeReduceRange/computeReduceRangePayload/reduceWindowFromGSS all
+	// stop as soon as that many non-extra entries are found, so any window
+	// with reducedEnd-start==1 implies ChildCount==1 and vice versa; extra
+	// entries only ever add to the window, never shrink it below
+	// ChildCount). Checking act.ChildCount first — mirroring the identical
+	// fast-exit already used by tryFastUnaryCollapseFromGSS — skips the
+	// shape/child/grammar/rule checks and their arena breakdown bookkeeping
+	// entirely for the structurally-ineligible multi-child reduces, which
+	// can never collapse. This is a pure dead-path skip: no behavior change
+	// for any reduce that could have collapsed before.
+	if act.ChildCount != 1 {
 		return nil
 	}
 	diag := arena.breakdownEnabled


### PR DESCRIPTION
## Summary

Instrumented investigation of the reduce-chain hot path (21% of canonical full-parse CPU) found the unary hidden/unfielded/unaliased collapse is already fully implemented (`collapseUnaryChildForReductionWithRule` + the pending-parent machinery above 256KiB) — but the three entries-array collapse-check helpers ran their shape/child/grammar-lookup preambles on every reduce regardless of child count. This adds the `act.ChildCount != 1` early-out that the GSS-path twin (`tryFastUnaryCollapseFromGSS`) already has, making the entries path consistent and skipping thousands of provably-no-op checks per parse.

Measured context banked for the campaign (quiet-host follow-ups tracked separately): of 8,502 reduce-constructed parents on the canonical workload, 5,000 are structurally unary; ~2,500–3,000 fail to collapse only because `_expression`/`_statement`-class named-hidden wrappers are not in the grammar-precomputed `HiddenChoicePassthroughSymbols` table — widening that table is grammargen certification work (blob regen + oracle re-verification per language), deliberately not attempted here.

## Verification

- `go build ./...`, `go vet .` — clean
- Full root package: ok (10.3s)
- `go test . -run 'Reduce|Chain|Compat|ByteIdentity|Golden|SExpr' -count=1` — pass
- Provably behavior-neutral: all reduce-window constructors size windows to at least `act.ChildCount` non-extra entries, so no previously-collapsible case is affected
- Contended-host directional A/B: no regression (p=0.485 at n=6; ~3% favorable trend at n=10, not significant — not claimed)