### PR TITLE
remove: retire test-only compat wrappers and one dead Go-range normalizer

### DIFF
--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -46,10 +46,10 @@ var paritySkips = map[string]parityMeta{
 var knownDegradedStructural = map[string]string{
 	// Empty: the last known structural divergence (norg's `_word` alias
 	// hidden-wrapper collapse) was fixed by extending
-	// normalizeResultTerminalLeafNodes's visible-terminal guard to also
-	// preserve distinct-named children under reused alias-target symbol IDs
-	// (see parser_result_terminal_leaf.go). Fresh-parse structural parity is
-	// now 206/206 across the curated fleet.
+	// normalizeResultTerminalLeafNodesWithStopAndErrorSummary's
+	// visible-terminal guard to also preserve distinct-named children under
+	// reused alias-target symbol IDs (see parser_result_terminal_leaf.go).
+	// Fresh-parse structural parity is now 206/206 across the curated fleet.
 }
 
 // knownDegradedNoErrorClean preserves no-error coverage for structural backlog

--- a/grammars/clean_regression_pins_test.go
+++ b/grammars/clean_regression_pins_test.go
@@ -186,8 +186,9 @@ func TestCleanRegressionPinGitRebasePick(t *testing.T) {
 // visible) as a child (ChildCount==1). Divergence class:
 // accepted_shape_materialization — a terminal-leaf on a NONTERMINAL wrapper.
 //
-// Root cause: normalizeResultTerminalLeafNodes (parser_result_terminal_leaf.go)
-// only collapses parents that are visible terminals or visible alias targets.
+// Root cause: normalizeResultTerminalLeafNodesWithStopAndErrorSummary
+// (parser_result_terminal_leaf.go) only collapses parents that are visible
+// terminals or visible alias targets.
 // `any_character` is a visible NAMED NONTERMINAL (sym 50) whose sole production
 // is the single anonymous literal '.', which C compiles as a terminal-equiv
 // leaf. Collapsing it safely needs a "token-only nonterminal" signal that is

--- a/parser_result_c.go
+++ b/parser_result_c.go
@@ -2,10 +2,6 @@ package gotreesitter
 
 import "strings"
 
-func normalizeCCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeCCompatibilityWithParser(root, source, nil, lang)
-}
-
 func normalizeCCompatibilityWithParser(root *Node, source []byte, p *Parser, lang *Language) {
 	recordPasses := p != nil && p.currentMaterializationTiming() != nil
 	if recordPasses {

--- a/parser_result_c_go_cobol_test.go
+++ b/parser_result_c_go_cobol_test.go
@@ -50,7 +50,7 @@ func TestNormalizeCCollapsedKeywordChildrenRestoresNull(t *testing.T) {
 	nullNode := newLeafNodeInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
 	root := newParentNodeInArena(arena, 1, true, []*Node{nullNode}, nil, 0)
 
-	normalizeCCompatibility(root, source, lang)
+	normalizeCCompatibilityWithParser(root, source, nil, lang)
 
 	if got, want := nullNode.ChildCount(), 1; got != want {
 		t.Fatalf("null child count = %d, want %d", got, want)
@@ -144,7 +144,7 @@ func TestNormalizeCCollapsedKeywordChildrenRestoresStorageClassSpecifier(t *test
 	storage := newLeafNodeInArena(arena, 2, true, 0, 6, Point{}, Point{Column: 6})
 	root := newParentNodeInArena(arena, 1, true, []*Node{storage}, nil, 0)
 
-	normalizeCCompatibility(root, source, lang)
+	normalizeCCompatibilityWithParser(root, source, nil, lang)
 
 	if got, want := storage.ChildCount(), 1; got != want {
 		t.Fatalf("storage class child count = %d, want %d", got, want)
@@ -177,7 +177,7 @@ func TestNormalizeCCollapsedKeywordChildrenRestoresTypeQualifier(t *testing.T) {
 	qualifier := newLeafNodeInArena(arena, 2, true, 0, 5, Point{}, Point{Column: 5})
 	root := newParentNodeInArena(arena, 1, true, []*Node{qualifier}, nil, 0)
 
-	normalizeCCompatibility(root, source, lang)
+	normalizeCCompatibilityWithParser(root, source, nil, lang)
 
 	if got, want := qualifier.ChildCount(), 1; got != want {
 		t.Fatalf("type qualifier child count = %d, want %d", got, want)

--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -40,10 +40,6 @@ func normalizeGoCompatibilityInRangesWithParser(root *Node, source []byte, lang 
 	return normalizeGoCompatibilityInRangesWithStopAndScratch(root, source, lang, incrementalRanges, stopCheck, frames)
 }
 
-func normalizeGoCompatibilityInRangesWithStop(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck) ParseStopReason {
-	return normalizeGoCompatibilityInRangesWithStopAndScratch(root, source, lang, incrementalRanges, stopCheck, nil)
-}
-
 func normalizeGoCompatibilityInRangesWithStopAndScratch(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck, frames *[]goCompatSubtreeFrame) ParseStopReason {
 	if root == nil || lang == nil || lang.Name != "go" || len(source) == 0 {
 		return ParseStopNone
@@ -309,10 +305,6 @@ func (s goCompatibilitySymbols) isStatementList(sym Symbol) bool {
 type goCompatSubtreeFrame struct {
 	node *Node
 	exit bool
-}
-
-func normalizeGoCompatibilitySubtreeWithStop(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller) ParseStopReason {
-	return normalizeGoCompatibilitySubtreeWithStopAndScratch(n, source, syms, flags, incrementalRanges, poller, nil)
 }
 
 func normalizeGoCompatibilitySubtreeWithStopAndScratch(n *Node, source []byte, syms goCompatibilitySymbols, flags goCompatibilitySourceFlags, incrementalRanges []Range, poller *parseStopPoller, frames *[]goCompatSubtreeFrame) ParseStopReason {

--- a/parser_result_go_compat_pathological_test.go
+++ b/parser_result_go_compat_pathological_test.go
@@ -48,9 +48,9 @@ func TestNormalizeGoCompatibilitySubtreeTerminatesOnCycle(t *testing.T) {
 	syms, _ := goCompatibilitySymbolsForLanguage(lang)
 	root, _ := buildCyclicGoTree()
 	source := []byte(".")
-	runWithin(t, 15*time.Second, "normalizeGoCompatibilitySubtreeWithStop", func() {
+	runWithin(t, 15*time.Second, "normalizeGoCompatibilitySubtreeWithStopAndScratch", func() {
 		poller := parseStopPoller{}
-		normalizeGoCompatibilitySubtreeWithStop(root, source, syms, goCompatibilitySourceFlags{}, nil, &poller)
+		normalizeGoCompatibilitySubtreeWithStopAndScratch(root, source, syms, goCompatibilitySourceFlags{}, nil, &poller, nil)
 	})
 }
 

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -16,10 +16,6 @@ func normalizeJavaScriptCompatibility(root *Node, source []byte, lang *Language)
 	normalizeJavaScriptProgramEnd(root, source, lang)
 }
 
-func normalizeTypeScriptTreeCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeTypeScriptTreeCompatibilityWithParser(root, source, nil, lang)
-}
-
 func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, parser *Parser, lang *Language) {
 	recordPasses := parser != nil && parser.currentMaterializationTiming() != nil
 	if !recordPasses {

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -380,7 +380,7 @@ func TestNormalizeTypeScriptSyntaxPassRestoresExistentialTypeStarChild(t *testin
 	existentialType := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
 	root := newParentNodeInArena(arena, 1, true, []*Node{existentialType}, nil, 0)
 
-	normalizeTypeScriptTreeCompatibility(root, []byte("*"), lang)
+	normalizeTypeScriptTreeCompatibilityWithParser(root, []byte("*"), nil, lang)
 
 	if got, want := resultChildCount(existentialType), 1; got != want {
 		t.Fatalf("existential_type child count = %d, want %d", got, want)

--- a/parser_result_javascript_typescript_test.go
+++ b/parser_result_javascript_typescript_test.go
@@ -29,7 +29,7 @@ func TestNormalizeJavaScriptTopLevelExpressionStatementBoundsAlsoSnapsTypeScript
 	root.children[0].symbol = 0
 	root.children[1].symbol = 0
 
-	normalizeTypeScriptTreeCompatibility(root, nil, lang)
+	normalizeTypeScriptTreeCompatibilityWithParser(root, nil, nil, lang)
 
 	if got, want := stmt.StartByte(), uint32(73); got != want {
 		t.Fatalf("stmt.StartByte = %d, want %d", got, want)
@@ -70,7 +70,7 @@ func TestNormalizeJavaScriptTopLevelExpressionStatementBoundsSnapsFinalRefs(t *t
 		t.Fatalf("root did not retain final child refs")
 	}
 
-	normalizeTypeScriptTreeCompatibility(root, nil, lang)
+	normalizeTypeScriptTreeCompatibilityWithParser(root, nil, nil, lang)
 
 	view := resultMutableChildrenForMutation(root)
 	entry, ok := view.Entry(2)

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -1,21 +1,11 @@
 package gotreesitter
 
-// normalizeResultTerminalLeafNodes removes redundant terminal payload children
-// that can be introduced by generalized reduction/materialization paths. C
-// tree-sitter exposes terminal and terminal-alias symbols as leaves, so a
-// visible leaf-like parent with one visible anonymous terminal child and no
-// semantic decorations should keep the parent's symbol/flags and adopt the
-// child's token span.
-func normalizeResultTerminalLeafNodes(root *Node, lang *Language) normalizationPassCounters {
-	counters, _ := normalizeResultTerminalLeafNodesWithStop(root, lang, nil)
-	return counters
-}
-
-func normalizeResultTerminalLeafNodesWithStop(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason) {
-	counters, stopReason, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, stopCheck)
-	return counters, stopReason
-}
-
+// normalizeResultTerminalLeafNodesWithStopAndErrorSummary removes redundant
+// terminal payload children that can be introduced by generalized
+// reduction/materialization paths. C tree-sitter exposes terminal and
+// terminal-alias symbols as leaves, so a visible leaf-like parent with one
+// visible anonymous terminal child and no semantic decorations should keep
+// the parent's symbol/flags and adopt the child's token span.
 func normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason, resultErrorSummary) {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -27,7 +27,7 @@ func TestNormalizeResultTerminalLeafNodesCollapsesRedundantAnonymousTokenChild(t
 	token.endPoint = Point{Row: 0, Column: 12}
 	root := newParentNodeInArena(arena, 3, true, []*Node{token}, nil, 0)
 
-	counters := normalizeResultTerminalLeafNodes(root, lang)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
 
 	if got, want := counters.nodesRewritten, uint64(1); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -218,7 +218,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesNonterminalWrapper(t *testing.
 	wrapper := newParentNodeInArena(arena, 2, true, []*Node{child}, nil, 0)
 	root := newParentNodeInArena(arena, 3, true, []*Node{wrapper}, nil, 0)
 
-	counters := normalizeResultTerminalLeafNodes(root, lang)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
 
 	if got, want := counters.nodesRewritten, uint64(0); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -259,7 +259,7 @@ func TestNormalizeResultTerminalLeafNodesCollapsesTerminalAliasTarget(t *testing
 	alias.endPoint = Point{Row: 12, Column: 1}
 	root := newParentNodeInArena(arena, 2, true, []*Node{alias}, nil, 0)
 
-	counters := normalizeResultTerminalLeafNodes(root, lang)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
 
 	if got, want := counters.nodesRewritten, uint64(1); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -318,7 +318,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesDistinctChildUnderReusedAliasT
 	parent.endPoint = Point{Row: 0, Column: 25}
 	root := newParentNodeInArena(arena, 3, true, []*Node{parent}, nil, 0)
 
-	counters := normalizeResultTerminalLeafNodes(root, lang)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
 
 	if got, want := counters.nodesRewritten, uint64(0); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -352,7 +352,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesFieldedTerminal(t *testing.T) 
 	token := newParentNodeInArena(arena, 2, true, []*Node{child}, []FieldID{1}, 0)
 	root := newParentNodeInArena(arena, 3, true, []*Node{token}, nil, 0)
 
-	counters := normalizeResultTerminalLeafNodes(root, lang)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
 
 	if got, want := counters.nodesRewritten, uint64(0); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)


### PR DESCRIPTION
## Summary

The next compat-tier retirement cut, following the model of the earlier JS/TS/Java and Python closures. Removes six functions with no production callers, re-verified individually on current HEAD:

- `normalizeGoCompatibilityInRangesWithStop` — fully dead (zero references anywhere).
- `normalizeCCompatibility`, `normalizeGoCompatibilitySubtreeWithStop`, `normalizeTypeScriptTreeCompatibility`, `normalizeResultTerminalLeafNodes`, `normalizeResultTerminalLeafNodesWithStop` — test-only wrappers around the live `WithParser` / `WithStopAndScratch` / `WithStopAndErrorSummary` variants that production dispatch already calls directly.

All test coverage is preserved: call sites redirect to the surviving live variants rather than deleting assertions; two comment-only references updated for accuracy. Net −25 LoC across 11 files.

## Verification

- `go build ./...`, `go vet .` — clean
- `go test . -run 'Compat|TerminalLeaf|Golden|SExpr|ByteIdentity' -count=1` — pass
- Full root package: ok (10.9s)