### PR TITLE
add(parser): layered memory-budget containment — volume polling, in-merge checks, hard ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ for tags and release notes while still in `0.x`.
 
 ### Added
 
+- Memory-budget containment is now layered: volume-triggered polling
+  forces a real budget check whenever tracked arena growth exceeds 64 MiB
+  since the last check (bypassing the iteration-count poll mask), the GLR
+  stack-merge survivor loop polls the budget mid-grind, and a decoupled
+  absolute hard ceiling (`GOT_PARSE_MEMORY_HARD_CEILING_MB`, default
+  2048, 0 = off) stops runaway growth regardless of soft-budget
+  overshoot tolerance. A bare-`Parse` giant-table witness now stops with
+  `ParseStopMemoryBudget` at 2.6-4x budget instead of ballooning; the
+  Poppler witness still completes full-span under its certified 2 GiB
+  budget.
+
 - A hard zero-cliff gate for nightly fleet perf sweeps, with a
   hard-gate-only mode on the perf-scan budget checker; the scheduled
   perf-scan gate is disabled in favor of the nightly hard gate.

--- a/glr.go
+++ b/glr.go
@@ -147,6 +147,17 @@ const (
 	// per-key survivor arrays.
 	maxRetainedMergeResultCap = 4096
 	maxRetainedMergeSlotCap   = 1024
+	// mergeBudgetPollStride is the coarse comparison stride at which
+	// mergeStacksWithScratchLargeCap's survivor loop polls the runtime memory
+	// budget directly (see runtimeMemoryBudgetStopReasonNow). The large-cap
+	// merge path widens perKeyCap up to maxStacksPerMergeKeyCeiling, so a
+	// single call can perform on the order of maxMergeAliveStacks *
+	// maxStacksPerMergeKeyCeiling comparisons -- an O(survivors^2) grind that
+	// can allocate multiple GB (deep stack-equivalence walks) without ever
+	// returning to a normal materialization-boundary poll site. Polling every
+	// 4096 comparisons keeps overhead negligible in the ordinary case while
+	// bounding how far a pathological grind can run before it is stopped.
+	mergeBudgetPollStride = 4096
 )
 
 type glrMergeScratch struct {
@@ -202,6 +213,19 @@ type glrMergeScratch struct {
 	stackEquivBytes   int64
 	spineEquivBytes   int64
 	frontierHashBytes int64
+	// parser backs the in-merge memory-budget poll
+	// (mergeStacksWithScratchLargeCap's survivor loop): the O(survivors^2)
+	// merge-equivalence grind can allocate multiple GB without ever returning
+	// to a normal materialization-boundary poll site, so the large-cap merge
+	// polls the runtime budget itself at a coarse comparison stride. nil
+	// (e.g. the mergeStacks test helper) disables that poll, not the merge.
+	parser *Parser
+	// mergeBudgetStopReason is set by the large-cap merge loop's in-merge poll
+	// when it bails out early because the runtime memory budget (soft budget
+	// or the decoupled hard ceiling) tripped mid-grind. Reset to ParseStopNone
+	// at the top of every mergeStacksWithScratch call so a stale flag from a
+	// previous merge in the same pooled scratch can never leak forward.
+	mergeBudgetStopReason ParseStopReason
 }
 
 type glrCErrorCostEntry struct {
@@ -4457,6 +4481,9 @@ func mergeStacksSmallDeferExact(alive []glrStack, scratch *glrMergeScratch, lang
 //  3. within each key keep exact-equivalent dedupes plus at most N survivors
 //     chosen by stackCompareMerge (with hash prefilter before deep equivalence)
 func mergeStacksWithScratch(stacks []glrStack, scratch *glrMergeScratch) []glrStack {
+	if scratch != nil {
+		scratch.mergeBudgetStopReason = ParseStopNone
+	}
 	if len(stacks) == 0 {
 		return stacks
 	}
@@ -4904,13 +4931,37 @@ func mergeStacksWithScratchLargeCap(alive []glrStack, scratch *glrMergeScratch, 
 	result := ensureMergeResultCap(scratch, len(alive))
 	slots := ensureMergeLargeSlotCap(scratch, len(alive))
 	slotCount := 0
+	// comparisons is the running count of O(slot.count) inner-loop trips since
+	// the last budget poll. This is the coarse-stride in-merge poll (see
+	// mergeBudgetPollStride): the large-cap merge's O(survivors^2)
+	// deep-equivalence grind can otherwise allocate multiple GB without ever
+	// returning to a normal materialization-boundary poll site.
+	var comparisons uint64
 	for i := range alive {
+		if comparisons >= mergeBudgetPollStride {
+			comparisons = 0
+			if scratch != nil && scratch.parser != nil {
+				if reason := scratch.parser.runtimeMemoryBudgetStopReasonNow(); reason == ParseStopMemoryBudget {
+					scratch.mergeBudgetStopReason = reason
+					if perfCountersEnabled {
+						perfRecordMergeOut(len(result))
+					}
+					if scratch.audit != nil {
+						scratch.audit.recordMerge(len(alive), len(result), slotCount)
+					}
+					scratch.result = result
+					scratch.largeSlots = slots[:slotCount]
+					return result
+				}
+			}
+		}
 		stack := alive[i]
 		hash := stackHashForMerge(scratch, scratch.language, stack)
 		key := mergeKeyForStack(stack)
 
 		slotIndex := -1
 		for si := 0; si < slotCount; si++ {
+			comparisons++
 			if slots[si].key == key {
 				slotIndex = si
 				break
@@ -4929,6 +4980,7 @@ func mergeStacksWithScratchLargeCap(alive []glrStack, scratch *glrMergeScratch, 
 		if slot.count > 0 {
 			mergedByGSS := false
 			for j := 0; j < slot.count; j++ {
+				comparisons++
 				idx := slot.indices[j]
 				merged, attempted := tryGSSMainMergeResult(scratch, result, idx, &stack)
 				if attempted && merged {
@@ -4945,6 +4997,7 @@ func mergeStacksWithScratchLargeCap(alive []glrStack, scratch *glrMergeScratch, 
 		hashMatched := false
 		if slot.count > 0 && (slot.hashMask&mergeHashBit(hash)) != 0 {
 			for j := 0; j < slot.count; j++ {
+				comparisons++
 				if slot.hashes[j] != hash {
 					continue
 				}
@@ -5000,6 +5053,7 @@ func mergeStacksWithScratchLargeCap(alive []glrStack, scratch *glrMergeScratch, 
 		if slot.worstIndex >= 0 {
 			replacedSlot := -1
 			for j := 0; j < slot.count; j++ {
+				comparisons++
 				if slot.indices[j] == slot.worstIndex {
 					replacedSlot = j
 					break
@@ -5219,6 +5273,10 @@ func (s *glrMergeScratch) reset() {
 	s.cRecoveryCost = false
 	s.audit = nil
 	s.budgetBytes = 0
+	// Pooled scratch must not retain a live *Parser across parses (GC
+	// retention) or leak a stale in-merge budget-stop flag forward.
+	s.parser = nil
+	s.mergeBudgetStopReason = ParseStopNone
 }
 
 func glrStackBytesForCap(n int) int64 {

--- a/parser.go
+++ b/parser.go
@@ -204,47 +204,49 @@ type Parser struct {
 	// where the deep stack-equivalence merge dominates and shared-leaf pointer
 	// identity short-circuits it (measured: swift 4.0x, bash 1.9x). Net-neutral
 	// or slightly negative on fast languages (go +4.9%), so it stays per-language.
-	leafInternByLang                 bool
-	forceRawSpanTable                []bool
-	spanExtendingInvisibleSymbols    []bool
-	nonSpanExtendingInvisibleSymbols []bool
-	aliasPreservedWrapperSymbols     []bool
-	included                         []Range
-	logger                           ParserLogger
-	glrTrace                         bool // verbose GLR stack tracing
-	ambiguityProfile                 *AmbiguityProfile
-	maxConflictWidth                 int // widest N-way conflict in the parse table
-	timeoutMicros                    uint64
-	cancellationFlag                 *uint32
-	parseBudgetDepth                 int
-	parseDeadline                    time.Time
-	parseStoppedReason               ParseStopReason
-	parseRuntimeMemoryBudgetBytes    int64
-	parseRuntimeMemoryBaselineBytes  uint64
-	parseRuntimeMemoryBaselineSys    uint64
-	parseRuntimeMemoryPoll           uint64
-	parseMemoryBudgetDiag            parseMemoryBudgetDiagnostic
-	parseMemoryBudgetDiagActive      bool
-	denseLimit                       int
-	smallBase                        int
-	smallLookup                      [][]smallActionPair
-	smallTokenLookup                 [][]uint16
-	externalValidByState             [][]uint16
-	externalValidMaskByState         []uint64
-	hasExtraChainActions             bool
-	classifiedActions                []classifiedParseAction
-	reduceChainHints                 []reduceChainHint
-	reduceChainHintByState           []int
-	reduceAliasSeq                   [][]Symbol
-	aliasTargetSymbol                []bool
-	keepSameNamedAnonChildSymbol     []bool
-	sharedAnonymousTokenSymbol       []bool
-	reduceHasFields                  []bool
-	reduceFieldPlans                 []reduceFieldPlan
-	fieldIDScratch                   []FieldID
-	fieldInheritedScratch            []bool
-	fieldConflictedScratch           []bool
-	reduceScratch                    *reduceBuildScratch
+	leafInternByLang                   bool
+	forceRawSpanTable                  []bool
+	spanExtendingInvisibleSymbols      []bool
+	nonSpanExtendingInvisibleSymbols   []bool
+	aliasPreservedWrapperSymbols       []bool
+	included                           []Range
+	logger                             ParserLogger
+	glrTrace                           bool // verbose GLR stack tracing
+	ambiguityProfile                   *AmbiguityProfile
+	maxConflictWidth                   int // widest N-way conflict in the parse table
+	timeoutMicros                      uint64
+	cancellationFlag                   *uint32
+	parseBudgetDepth                   int
+	parseDeadline                      time.Time
+	parseStoppedReason                 ParseStopReason
+	parseRuntimeMemoryBudgetBytes      int64
+	parseRuntimeMemoryBaselineBytes    uint64
+	parseRuntimeMemoryBaselineSys      uint64
+	parseRuntimeMemoryPoll             uint64
+	parseRuntimeMemoryVolumeAtPoll     uint64
+	parseRuntimeMemoryHardCeilingBytes int64
+	parseMemoryBudgetDiag              parseMemoryBudgetDiagnostic
+	parseMemoryBudgetDiagActive        bool
+	denseLimit                         int
+	smallBase                          int
+	smallLookup                        [][]smallActionPair
+	smallTokenLookup                   [][]uint16
+	externalValidByState               [][]uint16
+	externalValidMaskByState           []uint64
+	hasExtraChainActions               bool
+	classifiedActions                  []classifiedParseAction
+	reduceChainHints                   []reduceChainHint
+	reduceChainHintByState             []int
+	reduceAliasSeq                     [][]Symbol
+	aliasTargetSymbol                  []bool
+	keepSameNamedAnonChildSymbol       []bool
+	sharedAnonymousTokenSymbol         []bool
+	reduceHasFields                    []bool
+	reduceFieldPlans                   []reduceFieldPlan
+	fieldIDScratch                     []FieldID
+	fieldInheritedScratch              []bool
+	fieldConflictedScratch             []bool
+	reduceScratch                      *reduceBuildScratch
 	// mergeScratch points at the active parse's scratch.merge for the duration
 	// of parseInternal (set alongside reduceScratch, cleared on return). It lets
 	// dispatch-time helpers that only carry *Parser — tryGSSMainMergeForParser
@@ -1442,6 +1444,8 @@ func resetSnippetParser(parser *Parser) {
 	parser.parseRuntimeMemoryBaselineBytes = 0
 	parser.parseRuntimeMemoryBaselineSys = 0
 	parser.parseRuntimeMemoryPoll = 0
+	parser.parseRuntimeMemoryVolumeAtPoll = 0
+	parser.parseRuntimeMemoryHardCeilingBytes = 0
 	parser.parseMemoryBudgetDiag = parseMemoryBudgetDiagnostic{}
 	parser.parseMemoryBudgetDiagActive = false
 	// Release *Node refs so the arenas from the last incremental parse can be
@@ -3906,6 +3910,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	arena.finalChildRefs = p.finalChildRefs
 	arena.audit = nil
 	scratch.merge.arena = arena
+	scratch.merge.parser = p
 	if scratch.audit.enabled || scratch.audit.equivEnabled {
 		scratch.merge.audit = &scratch.audit
 	}
@@ -6304,6 +6309,15 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 		*glrMergeNanos += time.Since(mergeStart).Nanoseconds()
 	} else {
 		result.stacks = mergeStacksWithScratch(stacks, &scratch.merge)
+	}
+	// The large-cap merge path (mergeStacksWithScratchLargeCap) polls the
+	// runtime memory budget itself at a coarse comparison stride, because its
+	// O(survivors^2) grind can allocate multiple GB without returning to any
+	// other poll site. Honor a stop it detected before doing anything further
+	// with the (possibly partial) merge result.
+	if scratch.merge.mergeBudgetStopReason == ParseStopMemoryBudget {
+		result.stop(scratch.merge.mergeBudgetStopReason, false)
+		return result
 	}
 	if p.glrTrace {
 		p.traceCRecoverPrepareStacks("post-merge", result.stacks)

--- a/parser_config.go
+++ b/parser_config.go
@@ -8,30 +8,32 @@ import (
 )
 
 var (
-	parseNodeLimitScaleOnce    sync.Once
-	parseNodeLimitScale        int
-	parseMemoryBudgetOnce      sync.Once
-	parseMemoryBudgetMBVal     int
-	parseMaxGLRStacksOnce      sync.Once
-	parseMaxGLRStacks          int
-	parseMaxMergePerKeyOnce    sync.Once
-	parseMaxMergePerKey        int
-	preMaterializationDiagOnce sync.Once
-	preMaterializationDiag     bool
-	parsePhaseTimingOnce       sync.Once
-	parsePhaseTiming           bool
-	parseReduceTimingOnce      sync.Once
-	parseReduceTiming          bool
-	parseActionTimingOnce      sync.Once
-	parseActionTiming          bool
-	parseReduceChainHintsOnce  sync.Once
-	parseReduceChainHints      bool
-	parseTSLazyCompatOnce      sync.Once
-	parseTSLazyCompat          bool
-	parseEagerDefaultOnce      sync.Once
-	parseEagerDefault          bool
-	parseEagerDefaultDebugOnce sync.Once
-	parseEagerDefaultDebug     bool
+	parseNodeLimitScaleOnce     sync.Once
+	parseNodeLimitScale         int
+	parseMemoryBudgetOnce       sync.Once
+	parseMemoryBudgetMBVal      int
+	parseMemoryHardCeilingOnce  sync.Once
+	parseMemoryHardCeilingMBVal int
+	parseMaxGLRStacksOnce       sync.Once
+	parseMaxGLRStacks           int
+	parseMaxMergePerKeyOnce     sync.Once
+	parseMaxMergePerKey         int
+	preMaterializationDiagOnce  sync.Once
+	preMaterializationDiag      bool
+	parsePhaseTimingOnce        sync.Once
+	parsePhaseTiming            bool
+	parseReduceTimingOnce       sync.Once
+	parseReduceTiming           bool
+	parseActionTimingOnce       sync.Once
+	parseActionTiming           bool
+	parseReduceChainHintsOnce   sync.Once
+	parseReduceChainHints       bool
+	parseTSLazyCompatOnce       sync.Once
+	parseTSLazyCompat           bool
+	parseEagerDefaultOnce       sync.Once
+	parseEagerDefault           bool
+	parseEagerDefaultDebugOnce  sync.Once
+	parseEagerDefaultDebug      bool
 )
 
 // ResetParseEnvConfigCacheForTests clears memoized parser env config.
@@ -43,6 +45,8 @@ func ResetParseEnvConfigCacheForTests() {
 	parseNodeLimitScale = 0
 	parseMemoryBudgetOnce = sync.Once{}
 	parseMemoryBudgetMBVal = 0
+	parseMemoryHardCeilingOnce = sync.Once{}
+	parseMemoryHardCeilingMBVal = 0
 	parseMaxGLRStacksOnce = sync.Once{}
 	parseMaxGLRStacks = 0
 	parseMaxMergePerKeyOnce = sync.Once{}
@@ -315,4 +319,36 @@ func parseMemoryBudgetMB() int {
 		}
 	})
 	return parseMemoryBudgetMBVal
+}
+
+// parseMemoryHardCeilingMB returns the absolute, decoupled heap-growth stop
+// that fires regardless of the soft per-parse budget's poll-mask overshoot
+// tolerance (see the 2026-07-12 budget-containment RCA). The default (2GiB)
+// sits comfortably above the known-good Poppler JS witness completion point
+// (~1.67GiB heap growth at the default soft budget), so legitimate large
+// parses that rely on bounded overshoot to finish are unaffected; it exists
+// to catch pathological lanes (e.g. the GLR merge survivor grind) that can
+// otherwise balloon to multiple GB before any soft-budget poll site is
+// reached. Set GOT_PARSE_MEMORY_HARD_CEILING_MB=0 to disable it entirely.
+func parseMemoryHardCeilingMB() int {
+	parseMemoryHardCeilingOnce.Do(func() {
+		parseMemoryHardCeilingMBVal = 2048
+		raw := strings.TrimSpace(os.Getenv("GOT_PARSE_MEMORY_HARD_CEILING_MB"))
+		if raw == "" {
+			return
+		}
+		n, err := strconv.Atoi(raw)
+		if err == nil && n >= 0 {
+			parseMemoryHardCeilingMBVal = n
+		}
+	})
+	return parseMemoryHardCeilingMBVal
+}
+
+func parseMemoryHardCeilingBytes() int64 {
+	mb := parseMemoryHardCeilingMB()
+	if mb <= 0 {
+		return 0
+	}
+	return int64(mb) * 1024 * 1024
 }

--- a/parser_memory_budget_merge_test.go
+++ b/parser_memory_budget_merge_test.go
@@ -1,0 +1,106 @@
+package gotreesitter
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+)
+
+// TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind exercises the
+// coarse-stride in-merge poll added to mergeStacksWithScratchLargeCap (2026-07-12
+// budget-containment RCA, item 2). Before that fix, the large-cap merge's
+// O(survivors^2) deep-equivalence grind could allocate multiple GB without ever
+// returning to a materialization-boundary poll site, so no memory-budget stop
+// was structurally reachable during the grind. This test constructs many
+// pairwise-distinct stacks that all share a single merge key (same top state,
+// same byte offset), forcing the large-cap path to compare each new candidate
+// against every retained survivor up to perKeyCap -- the same O(n^2) shape the
+// RCA identified -- and arms a 1-byte runtime memory budget so any real check
+// trips immediately. The assertion is that the merge stops early (partial
+// result, far short of the full input) with mergeBudgetStopReason set, proving
+// the stride poll actually fires mid-grind rather than only at entry/exit.
+func TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind(t *testing.T) {
+	// Disable GC for the duration of the measured window. This package's full
+	// test binary allocates heavily elsewhere (including deliberately huge,
+	// short-lived allocations in nearby memory-budget tests); a concurrent GC
+	// cycle reclaiming that unrelated garbage can otherwise make this test's
+	// own net HeapAlloc delta read as flat or negative at the exact instant
+	// the poll samples it, even though real, live growth occurred. Disabling
+	// GC makes HeapAlloc monotonically non-decreasing for the test's duration.
+	oldGC := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGC)
+
+	const n = 4000
+	stacks := make([]glrStack, n)
+	for i := range stacks {
+		stacks[i] = glrStack{
+			entries: []stackEntry{
+				// Distinct bottom entry -> distinct hash -> distinct hash bucket,
+				// so equivalence never short-circuits into a cheap duplicate merge.
+				{state: StateID(1000 + i)},
+				// Shared top state -> every stack maps to the same merge key,
+				// forcing genuine per-key survivor-list growth and O(slot.count)
+				// comparisons per candidate once the key's slot is populated.
+				{state: StateID(42)},
+			},
+		}
+	}
+
+	parser := &Parser{}
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	// Arm the runtime budget directly (bypassing enterRuntimeMemoryBudget's
+	// min-source-length gate, irrelevant when calling the merge function
+	// directly): baseline "now", budget of 1 byte so any further heap growth
+	// trips the very first real check the stride poll performs.
+	parser.parseRuntimeMemoryBudgetBytes = 1
+	parser.parseRuntimeMemoryBaselineBytes = stats.HeapAlloc
+	parser.parseRuntimeMemoryBaselineSys = stats.Sys
+	parser.parseMemoryBudgetDiagActive = true
+
+	scratch := &glrMergeScratch{
+		perKeyCap: maxStacksPerMergeKeyCeiling,
+		parser:    parser,
+	}
+	scratch.beginEquivEpoch()
+
+	result := mergeStacksWithScratchLargeCap(stacks, scratch, maxStacksPerMergeKeyCeiling)
+
+	if scratch.mergeBudgetStopReason != ParseStopMemoryBudget {
+		t.Fatalf("mergeBudgetStopReason = %v, want %v", scratch.mergeBudgetStopReason, ParseStopMemoryBudget)
+	}
+	if len(result) >= n {
+		t.Fatalf("merge processed all %d survivors (len(result)=%d), want an early partial stop far short of n", n, len(result))
+	}
+	if parser.parseMemoryBudgetDiag.source == "" {
+		t.Fatal("expected a diagnostic source to be recorded for the in-merge budget stop")
+	}
+}
+
+// TestMergeStacksWithScratchLargeCapNoParserNeverPolls confirms the in-merge
+// poll is a strict no-op (never touches scratch.mergeBudgetStopReason, never
+// short-circuits) when scratch.parser is nil, e.g. the package-internal
+// mergeStacks() test helper. This guards against the stride poll silently
+// changing behavior for callers that were never wired to a live Parser.
+func TestMergeStacksWithScratchLargeCapNoParserNeverPolls(t *testing.T) {
+	const n = 64
+	stacks := make([]glrStack, n)
+	for i := range stacks {
+		stacks[i] = glrStack{
+			entries: []stackEntry{
+				{state: StateID(2000 + i)},
+				{state: StateID(7)},
+			},
+		}
+	}
+	scratch := &glrMergeScratch{perKeyCap: maxStacksPerMergeKeyCeiling, mergeBudgetStopReason: ParseStopNone}
+	scratch.beginEquivEpoch()
+
+	result := mergeStacksWithScratchLargeCap(stacks, scratch, maxStacksPerMergeKeyCeiling)
+	if scratch.mergeBudgetStopReason != ParseStopNone {
+		t.Fatalf("mergeBudgetStopReason = %v, want %v when scratch.parser is nil", scratch.mergeBudgetStopReason, ParseStopNone)
+	}
+	if len(result) != n {
+		t.Fatalf("len(result) = %d, want %d (no early stop expected without a parser)", len(result), n)
+	}
+}

--- a/parser_memory_budget_runtime.go
+++ b/parser_memory_budget_runtime.go
@@ -4,18 +4,34 @@ import "runtime"
 
 const (
 	// Arena and parser scratch enforce their budgets at every materialization
-	// boundary. The runtime-wide guard covers untracked Go heap growth, so a
-	// coarser poll avoids repeatedly stopping the world on recovery-heavy
-	// parses while keeping the maximum default-budget overshoot small.
+	// boundary. The runtime-wide guard covers untracked Go heap growth, but the
+	// coarse iteration-count poll mask alone lets overshoot balloon 16-26x past
+	// the configured budget on lanes that allocate multiple GB across only a
+	// few poll-site calls (see the 2026-07-12 budget-containment RCA). Two
+	// additional layers close that gap without tightening the mask globally
+	// (some legitimate parses, e.g. the Poppler JS witness, rely on bounded
+	// overshoot at the default budget to complete): a volume-triggered forced
+	// poll (parseRuntimeMemoryVolumePollThresholdBytes) and an absolute,
+	// decoupled hard ceiling (parseMemoryHardCeilingMB) checked every time a
+	// real poll fires.
 	parseRuntimeMemoryPollMask       = 255
 	parseRuntimeMemoryTightPollMask  = 15
 	parseRuntimeMemoryTightBudget    = 64 << 20
 	parseRuntimeMemoryMinSourceBytes = 64 * 1024
 
+	// parseRuntimeMemoryVolumePollThresholdBytes forces a real runtime memory
+	// check (bypassing the iteration-count mask) once tracked allocation
+	// volume has grown by at least this much since the last real check. This
+	// catches lanes that allocate gigabytes across very few poll-site calls,
+	// where the mask alone would let many multiples of the budget pass
+	// unnoticed before the next sampled check.
+	parseRuntimeMemoryVolumePollThresholdBytes = 64 << 20
+
 	parseMemoryBudgetStopSourceArena       = "arena"
 	parseMemoryBudgetStopSourceScratch     = "scratch"
 	parseMemoryBudgetStopSourceRuntimeHeap = "runtime_heap"
 	parseMemoryBudgetStopSourceRuntimeSys  = "runtime_sys"
+	parseMemoryBudgetStopSourceHardCeiling = "hard_ceiling"
 )
 
 type parseMemoryBudgetDiagnostic struct {
@@ -25,35 +41,62 @@ type parseMemoryBudgetDiagnostic struct {
 }
 
 type runtimeMemoryBudgetRestore struct {
-	parser      *Parser
-	budget      int64
-	baseline    uint64
-	baselineSys uint64
-	poll        uint64
+	parser       *Parser
+	budget       int64
+	baseline     uint64
+	baselineSys  uint64
+	poll         uint64
+	volumeAtPoll uint64
+	hardCeiling  int64
 }
 
 func runtimeMemoryBudgetEnabled(p *Parser, bytes int64, sourceLen int) bool {
 	return p != nil && bytes > 0 && sourceLen >= parseRuntimeMemoryMinSourceBytes
 }
 
+// runtimeMemoryHardCeilingEnabled reports whether the absolute hard ceiling
+// should arm for this parse. It shares the same trivial-source floor as the
+// soft budget (no point instrumenting parses too small to plausibly balloon
+// to GB scale) but is otherwise independent of whether the soft budget itself
+// is enabled, so it keeps working even if a caller explicitly disables the
+// soft budget (GOT_PARSE_MEMORY_BUDGET_MB=0).
+func runtimeMemoryHardCeilingEnabled(p *Parser, sourceLen int) bool {
+	return p != nil && sourceLen >= parseRuntimeMemoryMinSourceBytes && parseMemoryHardCeilingBytes() > 0
+}
+
+// enterRuntimeMemoryBudget arms the runtime-wide poll for the current parse.
 func (p *Parser) enterRuntimeMemoryBudget(bytes int64, sourceLen int) runtimeMemoryBudgetRestore {
-	if !runtimeMemoryBudgetEnabled(p, bytes, sourceLen) {
+	softEnabled := runtimeMemoryBudgetEnabled(p, bytes, sourceLen)
+	hardEnabled := runtimeMemoryHardCeilingEnabled(p, sourceLen)
+	if p == nil || (!softEnabled && !hardEnabled) {
 		return runtimeMemoryBudgetRestore{}
 	}
+	hardCeiling := int64(0)
+	if hardEnabled {
+		hardCeiling = parseMemoryHardCeilingBytes()
+	}
 	restore := runtimeMemoryBudgetRestore{
-		parser:      p,
-		budget:      p.parseRuntimeMemoryBudgetBytes,
-		baseline:    p.parseRuntimeMemoryBaselineBytes,
-		baselineSys: p.parseRuntimeMemoryBaselineSys,
-		poll:        p.parseRuntimeMemoryPoll,
+		parser:       p,
+		budget:       p.parseRuntimeMemoryBudgetBytes,
+		baseline:     p.parseRuntimeMemoryBaselineBytes,
+		baselineSys:  p.parseRuntimeMemoryBaselineSys,
+		poll:         p.parseRuntimeMemoryPoll,
+		volumeAtPoll: p.parseRuntimeMemoryVolumeAtPoll,
+		hardCeiling:  p.parseRuntimeMemoryHardCeilingBytes,
 	}
 
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
-	p.parseRuntimeMemoryBudgetBytes = bytes
+	if softEnabled {
+		p.parseRuntimeMemoryBudgetBytes = bytes
+	} else {
+		p.parseRuntimeMemoryBudgetBytes = 0
+	}
 	p.parseRuntimeMemoryBaselineBytes = stats.HeapAlloc
 	p.parseRuntimeMemoryBaselineSys = stats.Sys
 	p.parseRuntimeMemoryPoll = 0
+	p.parseRuntimeMemoryVolumeAtPoll = 0
+	p.parseRuntimeMemoryHardCeilingBytes = hardCeiling
 
 	return restore
 }
@@ -66,17 +109,40 @@ func (r runtimeMemoryBudgetRestore) restore() {
 	r.parser.parseRuntimeMemoryBaselineBytes = r.baseline
 	r.parser.parseRuntimeMemoryBaselineSys = r.baselineSys
 	r.parser.parseRuntimeMemoryPoll = r.poll
+	r.parser.parseRuntimeMemoryVolumeAtPoll = r.volumeAtPoll
+	r.parser.parseRuntimeMemoryHardCeilingBytes = r.hardCeiling
 }
 
-func (p *Parser) runtimeMemoryBudgetStopReason() ParseStopReason {
-	if p == nil || p.parseRuntimeMemoryBudgetBytes <= 0 {
+// runtimeMemoryBudgetStopReason is the mask-gated poll called from the many
+// materialization-boundary sites throughout the parse loop. volumeBytes is a
+// cheap, already-tracked allocation-volume signal (e.g. arena.allocatedBytes)
+// sampled at the call site with no extra syscalls. When that signal has grown
+// by at least parseRuntimeMemoryVolumePollThresholdBytes since the last real
+// check, the poll is forced through regardless of the iteration-count mask --
+// this is what catches a lane that allocates gigabytes across only a handful
+// of poll-site calls (mask undersampling), without lowering the mask (and
+// therefore the tolerated overshoot) for every parse.
+func (p *Parser) runtimeMemoryBudgetStopReason(volumeBytes uint64) ParseStopReason {
+	if p == nil || (p.parseRuntimeMemoryBudgetBytes <= 0 && p.parseRuntimeMemoryHardCeilingBytes <= 0) {
 		return ParseStopNone
 	}
 	p.parseRuntimeMemoryPoll++
-	if p.parseRuntimeMemoryPoll&runtimeMemoryPollMask(p.parseRuntimeMemoryBudgetBytes) != 0 {
+	forced := runtimeMemoryVolumeForcesPoll(volumeBytes, p.parseRuntimeMemoryVolumeAtPoll)
+	if !forced && p.parseRuntimeMemoryPoll&runtimeMemoryPollMask(p.parseRuntimeMemoryBudgetBytes) != 0 {
 		return ParseStopNone
 	}
+	p.parseRuntimeMemoryVolumeAtPoll = volumeBytes
 	return p.runtimeMemoryBudgetStopReasonNow()
+}
+
+// runtimeMemoryVolumeForcesPoll reports whether tracked allocation volume has
+// grown enough since the last real check to force one now, bypassing the
+// iteration-count mask.
+func runtimeMemoryVolumeForcesPoll(current, last uint64) bool {
+	if current <= last {
+		return false
+	}
+	return current-last >= parseRuntimeMemoryVolumePollThresholdBytes
 }
 
 func runtimeMemoryPollMask(budgetBytes int64) uint64 {
@@ -86,20 +152,34 @@ func runtimeMemoryPollMask(budgetBytes int64) uint64 {
 	return parseRuntimeMemoryPollMask
 }
 
+// runtimeMemoryBudgetStopReasonNow performs the actual runtime.ReadMemStats
+// sample and comparison, unconditionally (no mask, no volume gating). It is
+// used both by the masked poll above once it decides to fire, and directly by
+// the GLR merge survivor loop's coarse-stride poll (mergeStacksWithScratchLargeCap),
+// which has no other route back to a materialization-boundary poll site
+// during its O(survivors^2) grind. The hard ceiling is checked first and is
+// intentionally decoupled from the soft per-parse budget's overshoot
+// tolerance: it fires at a fixed absolute heap-growth regardless of how loose
+// the soft budget's poll cadence is for this parse.
 func (p *Parser) runtimeMemoryBudgetStopReasonNow() ParseStopReason {
-	if p == nil || p.parseRuntimeMemoryBudgetBytes <= 0 {
+	if p == nil || (p.parseRuntimeMemoryBudgetBytes <= 0 && p.parseRuntimeMemoryHardCeilingBytes <= 0) {
 		return ParseStopNone
 	}
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
 	heapGrowth := runtimeMemoryGrowth(stats.HeapAlloc, p.parseRuntimeMemoryBaselineBytes)
 	sysGrowth := runtimeMemoryGrowth(stats.Sys, p.parseRuntimeMemoryBaselineSys)
-	budget := uint64(p.parseRuntimeMemoryBudgetBytes)
-	if heapGrowth >= budget {
-		return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceRuntimeHeap, heapGrowth, sysGrowth)
+	if ceiling := p.parseRuntimeMemoryHardCeilingBytes; ceiling > 0 && heapGrowth >= uint64(ceiling) {
+		return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceHardCeiling, heapGrowth, sysGrowth)
 	}
-	if sysGrowth >= budget {
-		return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceRuntimeSys, heapGrowth, sysGrowth)
+	if p.parseRuntimeMemoryBudgetBytes > 0 {
+		budget := uint64(p.parseRuntimeMemoryBudgetBytes)
+		if heapGrowth >= budget {
+			return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceRuntimeHeap, heapGrowth, sysGrowth)
+		}
+		if sysGrowth >= budget {
+			return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceRuntimeSys, heapGrowth, sysGrowth)
+		}
 	}
 	return ParseStopNone
 }

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -1,6 +1,10 @@
 package gotreesitter
 
-import "testing"
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+)
 
 func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
 	parser := &Parser{
@@ -9,8 +13,8 @@ func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
 		parseRuntimeMemoryPoll:          parseRuntimeMemoryTightPollMask,
 		parseMemoryBudgetDiagActive:     true,
 	}
-	if got := parser.runtimeMemoryBudgetStopReason(); got != ParseStopMemoryBudget {
-		t.Fatalf("runtimeMemoryBudgetStopReason() = %q, want %q", got, ParseStopMemoryBudget)
+	if got := parser.runtimeMemoryBudgetStopReason(0); got != ParseStopMemoryBudget {
+		t.Fatalf("runtimeMemoryBudgetStopReason(0) = %q, want %q", got, ParseStopMemoryBudget)
 	}
 	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceRuntimeHeap; got != want {
 		t.Fatalf("memory budget stop source = %q, want %q", got, want)
@@ -97,5 +101,127 @@ func TestRuntimeMemoryBudgetEnabledForLargeSource(t *testing.T) {
 	defer restore.restore()
 	if parser.parseRuntimeMemoryBudgetBytes != 1 {
 		t.Fatalf("parseRuntimeMemoryBudgetBytes = %d, want 1", parser.parseRuntimeMemoryBudgetBytes)
+	}
+}
+
+// TestRuntimeMemoryVolumeTriggerBypassesPollMask exercises the volume-triggered
+// forced poll (2026-07-12 budget-containment RCA, item 1). A budget above the
+// tight-budget threshold uses poll mask 255, so an ordinary poll call is
+// skipped roughly 255 times out of 256. This test picks a poll count the mask
+// would normally skip and shows that a large enough tracked-allocation-volume
+// delta since the last real check forces the check through anyway.
+func TestRuntimeMemoryVolumeTriggerBypassesPollMask(t *testing.T) {
+	const skippedPollCount = 1 // 1 & parseRuntimeMemoryPollMask(255) == 1 != 0 -> mask alone would skip.
+	if skippedPollCount&parseRuntimeMemoryPollMask == 0 {
+		t.Fatalf("test setup invariant broken: poll count %d not actually masked", skippedPollCount)
+	}
+
+	// Disable GC for the measured window: this package's full test binary
+	// allocates heavily elsewhere, and a concurrent GC cycle reclaiming that
+	// unrelated garbage can otherwise offset this test's own ballast growth
+	// enough that HeapAlloc undercounts it relative to Sys, flipping which
+	// source (runtime_heap vs runtime_sys) the check attributes the stop to.
+	oldGC := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGC)
+
+	// A loose-mask-selecting budget (255 mask, > parseRuntimeMemoryTightBudget)
+	// is itself at least ~64MiB, so proving "heapGrowth >= budget" needs a real
+	// allocation of that scale rather than relying on ambient process heap
+	// size. Capture a real baseline, then deliberately grow the live heap past
+	// the budget so runtimeMemoryBudgetStopReasonNow's comparison is genuine.
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	const budget = parseRuntimeMemoryTightBudget + 8<<20 // ~72MiB: > tight threshold, selects mask 255
+	ballast := make([]byte, budget+(16<<20))             // guarantee >= budget bytes of real growth
+	for i := range ballast {
+		ballast[i] = byte(i)
+	}
+	t.Cleanup(func() { runtime.KeepAlive(ballast) })
+
+	parser := &Parser{
+		parseRuntimeMemoryBudgetBytes:   budget,
+		parseRuntimeMemoryBaselineBytes: before.HeapAlloc,
+		parseRuntimeMemoryPoll:          skippedPollCount - 1,
+		parseRuntimeMemoryVolumeAtPoll:  0,
+		parseMemoryBudgetDiagActive:     true,
+	}
+
+	// Below the volume threshold: the mask governs and the poll is skipped.
+	if got := parser.runtimeMemoryBudgetStopReason(parseRuntimeMemoryVolumePollThresholdBytes - 1); got != ParseStopNone {
+		t.Fatalf("runtimeMemoryBudgetStopReason(small volume delta) = %q, want %q (mask should still gate)", got, ParseStopNone)
+	}
+
+	parser.parseRuntimeMemoryPoll = skippedPollCount - 1 // restore the masked poll count
+	// At/above the volume threshold: forces a real check regardless of the mask.
+	if got := parser.runtimeMemoryBudgetStopReason(parseRuntimeMemoryVolumePollThresholdBytes); got != ParseStopMemoryBudget {
+		t.Fatalf("runtimeMemoryBudgetStopReason(volume >= threshold) = %q, want %q (volume trigger should bypass the mask)", got, ParseStopMemoryBudget)
+	}
+	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceRuntimeHeap; got != want {
+		t.Fatalf("memory budget stop source = %q, want %q", got, want)
+	}
+	runtime.KeepAlive(ballast)
+}
+
+// TestParseMemoryHardCeilingStopsIndependentlyOfSoftBudget exercises the
+// decoupled hard ceiling (item 3): it fires at its own fixed heap-growth
+// threshold even when the soft per-parse budget has plenty of headroom left
+// (i.e. it is not simply reusing the soft budget's overshoot tolerance).
+func TestParseMemoryHardCeilingStopsIndependentlyOfSoftBudget(t *testing.T) {
+	parser := &Parser{
+		parseRuntimeMemoryBudgetBytes:      1 << 30, // 1GiB soft budget: nowhere near tripped
+		parseRuntimeMemoryBaselineBytes:    0,
+		parseRuntimeMemoryHardCeilingBytes: 1, // 1-byte hard ceiling: trips immediately
+		parseMemoryBudgetDiagActive:        true,
+	}
+	got := parser.runtimeMemoryBudgetStopReasonNow()
+	if got != ParseStopMemoryBudget {
+		t.Fatalf("runtimeMemoryBudgetStopReasonNow() = %q, want %q", got, ParseStopMemoryBudget)
+	}
+	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceHardCeiling; got != want {
+		t.Fatalf("memory budget stop source = %q, want %q (soft budget should not have fired first)", got, want)
+	}
+}
+
+// TestParseMemoryHardCeilingDefaultClearsPopplerMargin locks in the property
+// the RCA's fix explicitly requires: the default hard ceiling must sit above
+// the known-good Poppler JS witness completion point (~1.67GiB heap growth at
+// the default soft budget) with real margin, so it never interferes with a
+// legitimate large parse that relies on bounded soft-budget overshoot to
+// finish. If this test ever needs to change, the Poppler docker perf lane
+// witness must be re-verified before merge.
+func TestParseMemoryHardCeilingDefaultClearsPopplerMargin(t *testing.T) {
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	// 1.67GiB expressed in whole bytes: 1.67 * 1024 * 1024 * 1024, rounded down.
+	const popplerWitnessGrowthBytes = int64(1793147207)
+	ceiling := parseMemoryHardCeilingBytes()
+	if ceiling <= popplerWitnessGrowthBytes {
+		t.Fatalf("default hard ceiling %d bytes does not clear the Poppler witness growth %d bytes", ceiling, popplerWitnessGrowthBytes)
+	}
+	margin := ceiling - popplerWitnessGrowthBytes
+	const minMargin = 256 << 20 // at least 256MiB of headroom
+	if margin < minMargin {
+		t.Fatalf("hard ceiling margin over the Poppler witness = %d bytes, want >= %d bytes", margin, minMargin)
+	}
+}
+
+// TestParseMemoryHardCeilingEnvOverride confirms GOT_PARSE_MEMORY_HARD_CEILING_MB
+// is honored, including the documented 0=off escape hatch.
+func TestParseMemoryHardCeilingEnvOverride(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_HARD_CEILING_MB", "5")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+	if got, want := parseMemoryHardCeilingBytes(), int64(5)*1024*1024; got != want {
+		t.Fatalf("parseMemoryHardCeilingBytes() = %d, want %d", got, want)
+	}
+
+	t.Setenv("GOT_PARSE_MEMORY_HARD_CEILING_MB", "0")
+	ResetParseEnvConfigCacheForTests()
+	if got := parseMemoryHardCeilingBytes(); got != 0 {
+		t.Fatalf("parseMemoryHardCeilingBytes() with 0 override = %d, want 0 (disabled)", got)
+	}
+	if runtimeMemoryHardCeilingEnabled(&Parser{}, parseRuntimeMemoryMinSourceBytes) {
+		t.Fatal("runtimeMemoryHardCeilingEnabled() = true with hard ceiling disabled via env, want false")
 	}
 }

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -16,8 +16,12 @@ func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
 	if got := parser.runtimeMemoryBudgetStopReason(0); got != ParseStopMemoryBudget {
 		t.Fatalf("runtimeMemoryBudgetStopReason(0) = %q, want %q", got, ParseStopMemoryBudget)
 	}
-	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceRuntimeHeap; got != want {
-		t.Fatalf("memory budget stop source = %q, want %q", got, want)
+	// Either runtime source proves the volume trigger reached a real
+	// ReadMemStats check. Under -race the detector's shadow memory inflates
+	// MemStats.Sys, so the sys guard can legitimately fire before the heap
+	// guard; pinning "runtime_heap" alone made this test race-mode-flaky.
+	if got := parser.parseMemoryBudgetDiag.source; got != parseMemoryBudgetStopSourceRuntimeHeap && got != parseMemoryBudgetStopSourceRuntimeSys {
+		t.Fatalf("memory budget stop source = %q, want %q or %q", got, parseMemoryBudgetStopSourceRuntimeHeap, parseMemoryBudgetStopSourceRuntimeSys)
 	}
 	if parser.parseMemoryBudgetDiag.runtimeHeapGrowthBytes < 1 {
 		t.Fatalf("runtime heap growth = %d, want >= 1", parser.parseMemoryBudgetDiag.runtimeHeapGrowthBytes)
@@ -156,8 +160,12 @@ func TestRuntimeMemoryVolumeTriggerBypassesPollMask(t *testing.T) {
 	if got := parser.runtimeMemoryBudgetStopReason(parseRuntimeMemoryVolumePollThresholdBytes); got != ParseStopMemoryBudget {
 		t.Fatalf("runtimeMemoryBudgetStopReason(volume >= threshold) = %q, want %q (volume trigger should bypass the mask)", got, ParseStopMemoryBudget)
 	}
-	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceRuntimeHeap; got != want {
-		t.Fatalf("memory budget stop source = %q, want %q", got, want)
+	// Either runtime source proves the volume trigger reached a real
+	// ReadMemStats check. Under -race the detector's shadow memory inflates
+	// MemStats.Sys, so the sys guard can legitimately fire before the heap
+	// guard; pinning "runtime_heap" alone made this test race-mode-flaky.
+	if got := parser.parseMemoryBudgetDiag.source; got != parseMemoryBudgetStopSourceRuntimeHeap && got != parseMemoryBudgetStopSourceRuntimeSys {
+		t.Fatalf("memory budget stop source = %q, want %q or %q", got, parseMemoryBudgetStopSourceRuntimeHeap, parseMemoryBudgetStopSourceRuntimeSys)
 	}
 	runtime.KeepAlive(ballast)
 }

--- a/parser_memory_budget_test.go
+++ b/parser_memory_budget_test.go
@@ -2,6 +2,10 @@ package gotreesitter_test
 
 import (
 	"bytes"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strconv"
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
@@ -56,4 +60,105 @@ func TestParserMemoryBudgetStopsParse(t *testing.T) {
 	default:
 		t.Fatalf("MemoryBudgetStopSource = %q, want exact attribution (runtime=%s)", rt.MemoryBudgetStopSource, rt.Summary())
 	}
+}
+
+// TestGoParseGiantTableLiteralStopsWithinMemoryBudget is the RCA's bare-Parse
+// witness (2026-07-12 budget-containment RCA), adapted to a SYNTHETIC
+// generated input rather than depending on any repo source file's content
+// (the RCA's own witness was a 70KiB prefix of query_test.go, which is not
+// used here). It constructs a large slice-of-struct-literal table -- a
+// "giant table literal", generated at test time -- sized to require real
+// arena/scratch allocation well past a small memory budget, and asserts bare
+// NewParser(...).Parse stops with ParseStopMemoryBudget while process heap
+// growth stays bounded rather than ballooning many multiples of the budget
+// past it (the RCA measured 16-26x overshoot before this fix).
+//
+// This validates the general containment path end-to-end: the hardened
+// runtime poll (parser_memory_budget_runtime.go), including its
+// volume-triggered forced check, and the decoupled hard ceiling, all wired
+// through bare Parse with the DFA lexer (the routing the RCA identified as
+// the asymmetric path -- the gateway token source for .go files keeps
+// survivor sets bounded and rarely needs this containment at all).
+//
+// It does NOT specifically exercise mergeStacksWithScratchLargeCap's
+// coarse-stride in-merge poll: Go's steady-state full-parse merge per-key
+// cap (3) never widens past maxStacksPerMergeKey (6) for well-formed input,
+// so the large-cap merge path is not reached by this witness. That path is
+// covered directly and deterministically by
+// TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind in the
+// internal package (parser_memory_budget_merge_test.go), which constructs
+// the O(survivors^2) shape directly instead of relying on a natural-language
+// trigger.
+//
+// A malformed/truncated variant of this input (mirroring the RCA's
+// query_test.go-prefix witness more literally -- balanced braces up to a
+// dangling partial identifier at EOF) was investigated while building this
+// fix but is intentionally NOT used here: truncating mid-token reliably drove
+// the parser into pathological C-recovery, and the resulting tree tripped a
+// SEPARATE, pre-existing bug in Go-specific post-parse compatibility
+// normalization (walkGoCompatSubtree, parser_result_go_compat.go) that has no
+// memory-budget awareness at all -- it only polls for ParseStopTimeout /
+// ParseStopCancelled -- and runs unconditionally while finalizing the result
+// tree, even for a GLR loop that already stopped early on budget. That is a
+// distinct, out-of-scope escape vector (it OOMed a throwaway repro at
+// several GiB regardless of this change) and is being raised separately
+// rather than folded into this fix; a truncated input here would crash
+// unpredictably for a reason unrelated to what this change addresses.
+func TestGoParseGiantTableLiteralStopsWithinMemoryBudget(t *testing.T) {
+	// budgetMB must be strictly above the tight-poll-mask threshold (64MiB,
+	// parseRuntimeMemoryTightBudget) so this witness exercises the loose (255)
+	// poll mask this fix's volume-triggered bypass targets, not the
+	// already-responsive tight (15) mask a small budget would select.
+	const budgetMB = 96
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", strconv.Itoa(budgetMB))
+	gotreesitter.ResetParseEnvConfigCacheForTests()
+	defer gotreesitter.ResetParseEnvConfigCacheForTests()
+
+	var src bytes.Buffer
+	src.WriteString("package p\n\ntype kv struct {\n\tName    string\n\tVisible bool\n\tNamed   bool\n}\n\nvar t = []kv{\n")
+	// entries is deliberately large (well beyond what's needed to cross the
+	// budget in an isolated run) so the stop is robust to ambient allocator/GC
+	// state from whatever else ran earlier in the same test binary, rather
+	// than depending on a razor-thin margin over the budget.
+	const entries = 300000
+	for i := 0; i < entries; i++ {
+		fmt.Fprintf(&src, "\t{Name: %q, Visible: true, Named: true}, // %d\n", fmt.Sprintf("identifier%d", i), i)
+	}
+	src.WriteString("}\n")
+
+	// Disable GC during the measured window so heap growth reflects true
+	// allocation volume rather than being masked by a GC cycle landing
+	// mid-parse; restore the default afterward.
+	debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(100)
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	tree, err := parser.Parse(src.Bytes())
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	defer tree.Release()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	heapGrowth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+
+	if got, want := tree.ParseStopReason(), gotreesitter.ParseStopMemoryBudget; got != want {
+		t.Fatalf("ParseStopReason() = %q, want %q (runtime=%s)", got, want, tree.ParseRuntime().Summary())
+	}
+	if !tree.ParseStoppedEarly() {
+		t.Fatal("ParseStoppedEarly() = false, want true")
+	}
+
+	budgetBytes := int64(budgetMB) * 1024 * 1024
+	const maxOvershootFactor = 6
+	if heapGrowth > budgetBytes*maxOvershootFactor {
+		t.Fatalf(
+			"process heap growth = %d bytes (%.2fx budget), want < %dx budget %d bytes -- containment escape (runtime=%s)",
+			heapGrowth, float64(heapGrowth)/float64(budgetBytes), maxOvershootFactor, budgetBytes, tree.ParseRuntime().Summary(),
+		)
+	}
+	t.Logf("heap growth = %d bytes (%.2fx budget %d bytes), stop=%s", heapGrowth, float64(heapGrowth)/float64(budgetBytes), budgetBytes, tree.ParseRuntime().Summary())
 }

--- a/parser_result.go
+++ b/parser_result.go
@@ -155,11 +155,22 @@ func (p *Parser) resultMaterializationStopReason(arena *nodeArena) ParseStopReas
 		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)
 	}
 	if p != nil {
-		if reason := p.runtimeMemoryBudgetStopReason(); reason == ParseStopMemoryBudget {
+		if reason := p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena)); reason == ParseStopMemoryBudget {
 			return reason
 		}
 	}
 	return ParseStopNone
+}
+
+// arenaAllocatedVolume returns the arena's cheap, already-tracked allocated-bytes
+// counter as the volume signal for the runtime memory poll's volume-triggered
+// bypass (see runtimeMemoryBudgetStopReason). It costs no syscalls: allocatedBytes
+// is updated incrementally at every arena materialization boundary.
+func arenaAllocatedVolume(arena *nodeArena) uint64 {
+	if arena == nil || arena.allocatedBytes <= 0 {
+		return 0
+	}
+	return uint64(arena.allocatedBytes)
 }
 
 func resultMaterializationShouldStop(reason ParseStopReason) bool {

--- a/tree.go
+++ b/tree.go
@@ -811,7 +811,7 @@ type ParseRuntime struct {
 	StackDepthLimit                               int
 	NodeLimit                                     int
 	MemoryBudgetBytes                             int64
-	MemoryBudgetStopSource                        string // First budget guard: arena, scratch, runtime_heap, or runtime_sys.
+	MemoryBudgetStopSource                        string // First budget guard: arena, scratch, runtime_heap, runtime_sys, or hard_ceiling.
 	RuntimeHeapGrowthBytes                        uint64
 	RuntimeSysGrowthBytes                         uint64
 	Iterations                                    int


### PR DESCRIPTION
## Summary

Closes the containment escape root-caused in the budget RCA: the runtime budget was armed on every path but sampled only by iteration count (mask 255 above 64 MiB budgets — measured 16-26x overshoot), and the GLR stack-merge lane could allocate multi-GB and grind O(survivors²) without ever reaching a poll site. Three layers, per the RCA's fix shape (deliberately not a mask tighten, which would truncate legitimate bounded-overshoot parses):

1. **Volume-triggered polling** — a real `ReadMemStats` check fires whenever tracked arena growth exceeds 64 MiB since the last check, bypassing the poll mask; lanes that allocate GBs in few iterations get checked regardless of iteration count.
2. **In-merge polling** — `mergeStacksWithScratchLargeCap`'s survivor loop checks the budget every 4096 comparison trips and stops early with `ParseStopMemoryBudget`, converting the previously unpollable fatal window.
3. **Absolute hard ceiling** — `GOT_PARSE_MEMORY_HARD_CEILING_MB` (default 2048, 0 = off), decoupled from soft-budget overshoot tolerance; margin over the Poppler completion point locked in by test (≥256 MiB asserted).

Also corrects the stale "overshoot stays small" comment.

## Verification

- Budget/scratch/arena suite: **115 pass, 0 fail**; race clean over Budget/Merge/GSS; full root suite stable across repeated runs.
- End-to-end witness: bare `NewParser().Parse` of a synthetic 300k-entry Go table literal at a 96 MiB budget now stops with `ParseStopMemoryBudget` at 2.6-4.0x budget heap growth (previously ballooned unbounded).
- **Poppler ledger gate (quiet-host A/B, exact 3,447,275-byte witness, certified 2 GiB budget):** branch and main identical — both complete full-span, `hasError=false`, 15.89 s vs 15.58 s, peak RSS within 0.03%. The certified bounded-overshoot behavior is preserved.
- Canonical benchmark neutral (p=0.589, allocs unchanged).

## Follow-up flagged (separate lane)

`walkGoCompatSubtree` runs budget-blind at result finalization on recovered Go trees and can OOM independently of the parse loop (reproduced at 11-16 GiB pre- and post-fix); tracked as its own containment item.