### PR TITLE
optimize(parser): elide raw-shape capture on single-stack parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ for tags and release notes while still in `0.x`.
   maps, alias and supertype query tables are byte-identical, and supertype
   query predicates match by concrete descendant so observable trees and
   captures are unchanged. Canonical quiet-host full parse improves ~3.4%.
+- Raw-shape capture and content hashing are elided while a parse has only
+  ever had a single GLR stack and has not entered error recovery; capture
+  resumes permanently at the first fork or recovery event. Shape-dependent
+  tie-breaks are unaffected: elided prefix nodes are only ever compared to
+  themselves (structural pointer-sharing), evidenced by forced-descent and
+  recovery differential tests. Canonical quiet-host full parse improves
+  ~4.8% with allocations unchanged (9/0/0 preserved).
 
 - gssNode layout compacted to a 64-byte budget on 64-bit targets
   (pointer-backed extra links with uint8 count/cap, uint32 depth,

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2822,7 +2822,12 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 							parent.setExtra(true)
 						}
 						parent.dynamicPrecedence = int32(score)
-						parent.rawShape = p.captureRawShape(arena, act.Symbol, act.ProductionID, children, 0, reducedEnd)
+						// The forest engine is a separate parsing path from the
+						// production GLR loop's scratch.gss bookkeeping (it does
+						// not thread a *gssScratch here), and it is out of scope
+						// for the single-stack raw-shape elision: nil never
+						// elides, preserving this lane's existing behavior.
+						parent.rawShape = p.captureRawShape(nil, arena, act.Symbol, act.ProductionID, children, 0, reducedEnd)
 						if len(childNodes) > 0 {
 							forestRecordParentChildAlternatives(alternatives, parent, childNodes, children[:reducedEnd])
 						}

--- a/glr_forest_test.go
+++ b/glr_forest_test.go
@@ -302,8 +302,8 @@ func TestCoalesceForestKeepsEqualScoreRawDistinctLinks(t *testing.T) {
 	rightChild := newLeafNodeInArena(arena, 10, true, 1, 2, Point{}, Point{})
 	left := newParentNodeInArena(arena, 100, true, []*Node{leftChild}, nil, 0)
 	right := newParentNodeInArena(arena, 100, true, []*Node{rightChild}, nil, 0)
-	left.rawShape = p.captureRawShape(arena, 100, 1, []stackEntry{newStackEntryNode(11, leftChild)}, 0, 1)
-	right.rawShape = p.captureRawShape(arena, 100, 2, []stackEntry{newStackEntryNode(10, rightChild)}, 0, 1)
+	left.rawShape = p.captureRawShape(nil, arena, 100, 1, []stackEntry{newStackEntryNode(11, leftChild)}, 0, 1)
+	right.rawShape = p.captureRawShape(nil, arena, 100, 2, []stackEntry{newStackEntryNode(10, rightChild)}, 0, 1)
 
 	node := coalesceForestWithRaw(p, arena, &idx, slab, 5, 4, base, newStackEntryNode(100, left), 3, 0)
 	again := coalesceForestWithRaw(p, arena, &idx, slab, 5, 4, base, newStackEntryNode(100, right), 3, 0)
@@ -330,7 +330,7 @@ func TestCoalesceForestKeepsEqualScoreOneSidedRawUnknownLinks(t *testing.T) {
 	rightChild := newLeafNodeInArena(arena, 11, true, 1, 2, Point{}, Point{})
 	left := newParentNodeInArena(arena, 100, true, []*Node{leftChild}, nil, 0)
 	right := newParentNodeInArena(arena, 100, true, []*Node{rightChild}, nil, 0)
-	left.rawShape = p.captureRawShape(arena, 100, 1, []stackEntry{newStackEntryNode(11, leftChild)}, 0, 1)
+	left.rawShape = p.captureRawShape(nil, arena, 100, 1, []stackEntry{newStackEntryNode(11, leftChild)}, 0, 1)
 
 	node := coalesceForestWithRaw(p, arena, &idx, slab, 5, 4, base, newStackEntryNode(100, left), 3, 0)
 	again := coalesceForestWithRaw(p, arena, &idx, slab, 5, 4, base, newStackEntryNode(100, right), 3, 0)
@@ -352,7 +352,7 @@ func TestCoalesceForestCapPreservesRawDistinctCandidateOverDuplicateBucket(t *te
 	makeEntry := func(childSym Symbol, prod uint16) stackEntry {
 		child := newLeafNodeInArena(arena, childSym, true, 1, 2, Point{}, Point{})
 		parent := newParentNodeInArena(arena, 100, true, []*Node{child}, nil, 0)
-		parent.rawShape = p.captureRawShape(arena, 100, prod, []stackEntry{newStackEntryNode(StateID(childSym), child)}, 0, 1)
+		parent.rawShape = p.captureRawShape(nil, arena, 100, prod, []stackEntry{newStackEntryNode(StateID(childSym), child)}, 0, 1)
 		return newStackEntryNode(100, parent)
 	}
 
@@ -424,7 +424,7 @@ func TestCoalesceForestCapDoesNotLetLowerRankSameRawBucketEvictDistinctBucket(t 
 	makeEntry := func(childSym Symbol, prod uint16) stackEntry {
 		child := newLeafNodeInArena(arena, childSym, true, 1, 2, Point{}, Point{})
 		parent := newParentNodeInArena(arena, 100, true, []*Node{child}, nil, 0)
-		parent.rawShape = p.captureRawShape(arena, 100, prod, []stackEntry{newStackEntryNode(StateID(childSym), child)}, 0, 1)
+		parent.rawShape = p.captureRawShape(nil, arena, 100, prod, []stackEntry{newStackEntryNode(StateID(childSym), child)}, 0, 1)
 		return newStackEntryNode(100, parent)
 	}
 
@@ -515,7 +515,7 @@ func TestForestResultLinkUsesCumulativeDynamicPrecedenceBeforeMaterializedShape(
 	varNode := newLeafNodeInArena(arena, 4, true, 0, 3, Point{}, Point{Column: 3})
 	stringNode := newLeafNodeInArena(arena, 5, true, 4, 9, Point{Column: 4}, Point{Column: 9})
 	direct := newParentNodeInArena(arena, 3, true, []*Node{varNode, stringNode}, nil, 0)
-	direct.rawShape = parser.captureRawShape(arena, 3, 1, []stackEntry{
+	direct.rawShape = parser.captureRawShape(nil, arena, 3, 1, []stackEntry{
 		newStackEntryNode(4, varNode),
 		newStackEntryNode(5, stringNode),
 	}, 0, 2)
@@ -525,7 +525,7 @@ func TestForestResultLinkUsesCumulativeDynamicPrecedenceBeforeMaterializedShape(
 	wrappedConcat := newParentNodeInArena(arena, 3, true, []*Node{wrappedVar, wrappedString}, nil, 0)
 	wrapper := newParentNodeInArena(arena, 2, true, []*Node{wrappedConcat}, nil, 0)
 	wrapper.dynamicPrecedence = 4
-	wrapper.rawShape = parser.captureRawShape(arena, 2, 2, []stackEntry{newStackEntryNode(3, wrappedConcat)}, 0, 1)
+	wrapper.rawShape = parser.captureRawShape(nil, arena, 2, 2, []stackEntry{newStackEntryNode(3, wrappedConcat)}, 0, 1)
 
 	node := &gssForestNode{
 		state:      7,

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -132,12 +132,23 @@ type gssScratch struct {
 	// everForked latches true the first time this parse observes more than
 	// one live GLR stack (see the singleStackMode writers in parser.go, and
 	// the explicit early latch at the "len(actions) > 1" conflict-fork
-	// decision point). It is intentionally sticky for the rest of the parse:
-	// once a parse has forked, raw-shape capture must resume for every later
-	// reduction even if the stack count later collapses back to one, because
-	// a subsequent fork's tie-break comparisons (compareRawStackEntries) may
-	// need shapes for nodes built during that "back to one stack" interval.
-	// See spore.2026-07-12.hazel.rawshape-elision-rca.
+	// decision point), OR enters the faithful C-recovery port (latched at
+	// cHandleError's entry in parser_recover_c.go, before it can build or
+	// compare a single node — recovery's version-spawning and its raw-shape
+	// reads, e.g. cSelectReplacementParentEntry, are not visible to the
+	// ordinary singleStackMode bookkeeping since recovery mutates *stacks
+	// directly). It is intentionally sticky for the rest of the parse: once
+	// true, every later reduction captures its raw shape normally, even if
+	// the live stack count later collapses back to one.
+	//
+	// IMPORTANT: this latch is NOT retroactive. It does not, and cannot, add
+	// shapes to nodes that were already built (and left shapeless) before it
+	// flipped true. Behavior preservation for those earlier, still-shapeless
+	// nodes does not come from this field — it comes from a structural
+	// property of GSS/C-recovery sharing (every subsequent stack shares such
+	// a node by pointer, so it is only ever compared against itself). See
+	// captureRawShape's doc comment (raw_shape.go) for the full argument, and
+	// spore.2026-07-12.hazel.rawshape-elision-rca for the originating RCA.
 	everForked bool
 }
 

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -129,6 +129,55 @@ type gssScratch struct {
 	audit             *runtimeAudit
 	frontier          conflictReduceFrontierScratch
 	stackEntries      []stackEntry
+	// everForked latches true the first time this parse observes more than
+	// one live GLR stack (see the singleStackMode writers in parser.go, and
+	// the explicit early latch at the "len(actions) > 1" conflict-fork
+	// decision point). It is intentionally sticky for the rest of the parse:
+	// once a parse has forked, raw-shape capture must resume for every later
+	// reduction even if the stack count later collapses back to one, because
+	// a subsequent fork's tie-break comparisons (compareRawStackEntries) may
+	// need shapes for nodes built during that "back to one stack" interval.
+	// See spore.2026-07-12.hazel.rawshape-elision-rca.
+	everForked bool
+}
+
+// rawShapeElisionDisabledForDiagnostics forces every reduction to capture its
+// raw shape, even on the pure single-stack happy path, matching parser
+// behavior before the single-stack capture elision optimization. It exists so
+// differential tests (and offline profiling harnesses) can A/B the
+// optimization directly against otherwise-identical parses. It is not
+// concurrency-safe and is intended for single-threaded test/benchmark use
+// only; normal parser paths leave it disabled.
+var rawShapeElisionDisabledForDiagnostics bool
+
+// SetRawShapeElisionDisabledForDiagnostics toggles rawShapeElisionDisabledForDiagnostics.
+// See its doc comment: this is a diagnostics-only hook, not part of the
+// parser's production behavior contract.
+func SetRawShapeElisionDisabledForDiagnostics(disabled bool) {
+	rawShapeElisionDisabledForDiagnostics = disabled
+}
+
+// mayElideRawShape reports whether it is safe to skip captureRawShape for the
+// reduction currently in flight. This is true only on the pure single-stack
+// happy path: exactly one GLR stack is live right now, and this parse has
+// never forked before. Once a parse forks even once, this permanently
+// returns false for the remainder of the parse (see everForked).
+func (s *gssScratch) mayElideRawShape() bool {
+	return s != nil && s.singleStackMode && !s.everForked && !rawShapeElisionDisabledForDiagnostics
+}
+
+// setSingleStackMode updates singleStackMode and latches everForked the
+// moment the parse is observed leaving single-stack mode. everForked is
+// sticky for the rest of the parse (cleared only by reset()), even if the
+// stack count later collapses back to one.
+func (s *gssScratch) setSingleStackMode(v bool) {
+	if s == nil {
+		return
+	}
+	s.singleStackMode = v
+	if !v {
+		s.everForked = true
+	}
 }
 
 type gssNodeSlab struct {
@@ -552,6 +601,7 @@ func (s *gssScratch) reset() {
 	}
 	if len(s.slabs) == 0 {
 		s.singleStackMode = false
+		s.everForked = false
 		s.singleStackAllocs = 0
 		s.multiStackAllocs = 0
 		s.demotions = 0
@@ -600,6 +650,7 @@ func (s *gssScratch) reset() {
 	s.usedTotal = 0
 	s.peakUsed = 0
 	s.singleStackMode = false
+	s.everForked = false
 	s.singleStackAllocs = 0
 	s.multiStackAllocs = 0
 	s.demotions = 0

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "unsafe"
+import (
+	"sync/atomic"
+	"unsafe"
+)
 
 const (
 	defaultGSSNodeSlabCap      = 4 * 1024
@@ -156,16 +159,16 @@ type gssScratch struct {
 // raw shape, even on the pure single-stack happy path, matching parser
 // behavior before the single-stack capture elision optimization. It exists so
 // differential tests (and offline profiling harnesses) can A/B the
-// optimization directly against otherwise-identical parses. It is not
-// concurrency-safe and is intended for single-threaded test/benchmark use
-// only; normal parser paths leave it disabled.
-var rawShapeElisionDisabledForDiagnostics bool
+// optimization directly against otherwise-identical parses. Stored as an
+// atomic so concurrent parsers observe a consistent value; it remains a
+// diagnostics-only hook and normal parser paths leave it disabled.
+var rawShapeElisionDisabledForDiagnostics atomic.Bool
 
 // SetRawShapeElisionDisabledForDiagnostics toggles rawShapeElisionDisabledForDiagnostics.
 // See its doc comment: this is a diagnostics-only hook, not part of the
 // parser's production behavior contract.
 func SetRawShapeElisionDisabledForDiagnostics(disabled bool) {
-	rawShapeElisionDisabledForDiagnostics = disabled
+	rawShapeElisionDisabledForDiagnostics.Store(disabled)
 }
 
 // mayElideRawShape reports whether it is safe to skip captureRawShape for the
@@ -174,7 +177,7 @@ func SetRawShapeElisionDisabledForDiagnostics(disabled bool) {
 // never forked before. Once a parse forks even once, this permanently
 // returns false for the remainder of the parse (see everForked).
 func (s *gssScratch) mayElideRawShape() bool {
-	return s != nil && s.singleStackMode && !s.everForked && !rawShapeElisionDisabledForDiagnostics
+	return s != nil && s.singleStackMode && !s.everForked && !rawShapeElisionDisabledForDiagnostics.Load()
 }
 
 // setSingleStackMode updates singleStackMode and latches everForked the

--- a/parser.go
+++ b/parser.go
@@ -4536,7 +4536,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				return finalize(stacks, ParseStopNoStacksAlive)
 			}
 			p.tryDemoteSingleLinearGSS(stacks, scratch)
-			scratch.gss.singleStackMode = true
+			scratch.gss.setSingleStackMode(true)
 			clearParseStackEntryCaches(stacks)
 		} else {
 			if progress.enabled {
@@ -5291,6 +5291,15 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				continue
 			}
 			if len(actions) > 1 {
+				// A real grammar conflict can grow the live stack count (a
+				// literal clone below, or a frontier/gated fork queued by
+				// completeConflictReduceFrontier) before the top-of-loop
+				// singleStackMode recompute runs on the next iteration. Latch
+				// everForked here, at the earliest possible point, so raw-shape
+				// capture resumes for every reduction from this token onward —
+				// including the actions[0] continuation applied to the
+				// original stack later in this same iteration.
+				scratch.gss.everForked = true
 				conflictStart := time.Time{}
 				if actionTiming != nil {
 					conflictStart = time.Now()
@@ -6266,7 +6275,7 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 			result.stop(ParseStopNoStacksAlive, false)
 			return result
 		}
-		scratch.gss.singleStackMode = true
+		scratch.gss.setSingleStackMode(true)
 		p.tryDemoteSingleLinearGSS(stacks, scratch)
 		clearParseStackEntryCaches(stacks)
 		return result
@@ -6324,7 +6333,7 @@ func (p *Parser) prepareParseStacksForIteration(stacks []glrStack, scratch *pars
 	} else {
 		p.tryDemoteSingleLinearGSS(result.stacks, scratch)
 	}
-	scratch.gss.singleStackMode = len(result.stacks) == 1
+	scratch.gss.setSingleStackMode(len(result.stacks) == 1)
 	clearParseStackEntryCaches(result.stacks)
 	return result
 }

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -2365,6 +2365,26 @@ func (p *Parser) cTerminalNextState(state StateID, sym Symbol) (StateID, ParseAc
 // missing-token versions and strategy-1 recoveries) — the caller must force a
 // re-dispatch pass for the same token.
 func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) (cRecoverOutcome, bool, ParseStopReason) {
+	// C-recovery reads raw shapes unconditionally once it runs (see
+	// cSelectReplacementParentEntry / compareRawStackEntries), and its
+	// version-spawning (cRecoverToState and friends) creates multi-stack
+	// exploration windows that the ordinary singleStackMode/everForked
+	// bookkeeping in parser.go never observes, because recovery mutates
+	// *stacks directly rather than going through the normal fork dispatch at
+	// "len(actions) > 1". Latch everForked here, at the single funnel entry
+	// for all C-recovery error handling, before cDoAllPotentialReductions (or
+	// anything else recovery does) can build a single node: this guarantees
+	// every reduction recovery performs from this point captures its raw
+	// shape, and — because everForked is sticky for the rest of the parse —
+	// also covers every later recovery version-spawn window and blocks a
+	// later setSingleStackMode(true) re-collapse from re-enabling elision.
+	// This does not retroactively add shapes to nodes already built before
+	// recovery started — see raw_shape.go captureRawShape's doc comment for
+	// why that is still safe (a structural pointer-sharing argument, not
+	// retroactive backfill).
+	if gssScratch != nil {
+		gssScratch.everForked = true
+	}
 	checkStop := func() ParseStopReason {
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return reason

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3958,7 +3958,11 @@ func captureRawShapeForEntries(arena *nodeArena, symbol Symbol, productionID uin
 		return 0
 	}
 	var p Parser
-	return p.captureRawShape(arena, symbol, productionID, entries, 0, len(entries))
+	// C-recovery error-path shape construction is out of scope for the
+	// single-stack elision (the RCA's reader inventory already gates every
+	// consumer on recovery among other things): nil never elides, preserving
+	// this lane's existing unconditional-capture behavior.
+	return p.captureRawShape(nil, arena, symbol, productionID, entries, 0, len(entries))
 }
 
 // cStackResultErrorCost is the result-selection cost: the error cost of the

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -2913,7 +2913,12 @@ func (p *Parser) reduceForkTemporaryParent(arena *nodeArena, act ParseAction, en
 	if parent == nil {
 		return nil
 	}
-	parent.rawShape = p.captureRawShape(arena, act.Symbol, act.ProductionID, entries, 0, len(entries))
+	// No gssScratch in scope here: this helper builds a throwaway temporary
+	// parent purely to compare two in-flight reduce-fork alternatives
+	// (reduceForkWindowPreference), which only runs once len(forks) >= 2 --
+	// i.e. only after the parse has already forked, so unconditional capture
+	// here is always correct (mayElideRawShape would be false anyway).
+	parent.rawShape = p.captureRawShape(nil, arena, act.Symbol, act.ProductionID, entries, 0, len(entries))
 	setReduceNodeDynamicPrecedence(parent, entries, 0, len(entries), act)
 	return parent
 }
@@ -3555,7 +3560,7 @@ func (p *Parser) tryFastVisibleReduceActionFromGSS(s *glrStack, act ParseAction,
 	for i := 0; i < childCount; i++ {
 		rawWindow = append(rawWindow, newStackEntryNode(0, children[i]))
 	}
-	rawShape := p.captureRawShape(arena, act.Symbol, act.ProductionID, rawWindow, 0, len(rawWindow))
+	rawShape := p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, rawWindow, 0, len(rawWindow))
 	named := p.isNamedSymbol(act.Symbol)
 	var parent *Node
 	parentStart := time.Time{}
@@ -3780,7 +3785,7 @@ func (p *Parser) applyReduceActionFromGSS(source []byte, s *glrStack, act ParseA
 	if timing != nil {
 		childStart = time.Now()
 	}
-	rawShape := p.captureRawShape(arena, act.Symbol, act.ProductionID, windowEntries, window.start, window.reducedEnd)
+	rawShape := p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, windowEntries, window.start, window.reducedEnd)
 	children, fieldIDs, fieldSources, childPath := p.buildReduceChildrenWithPath(windowEntries, window.start, window.reducedEnd, childCount, act.Symbol, act.ProductionID, arena)
 	if timing != nil {
 		timing.reduceChildBuildNanos += time.Since(childStart).Nanoseconds()
@@ -3889,7 +3894,7 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 		actualEnd := len(window)
 		childCount := int(act.ChildCount)
 
-		rawShape := p.captureRawShape(arena, act.Symbol, act.ProductionID, window, 0, reducedEnd)
+		rawShape := p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, window, 0, reducedEnd)
 		children, fieldIDs, fieldSources, childPath := p.buildReduceChildrenWithPath(window, 0, reducedEnd, childCount, act.Symbol, act.ProductionID, arena)
 
 		target.gss.head = fork.popTo
@@ -4218,7 +4223,7 @@ func (p *Parser) applyReduceActionFromGSSTransientParents(source []byte, s *glrS
 	if timing != nil {
 		childStart = time.Now()
 	}
-	rawShape := p.captureRawShape(arena, act.Symbol, act.ProductionID, windowEntries, 0, reducedEnd)
+	rawShape := p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, windowEntries, 0, reducedEnd)
 	children, fieldIDs, fieldSources, childPath := p.buildReduceChildrenWithPath(windowEntries, 0, reducedEnd, childCount, act.Symbol, act.ProductionID, arena)
 	if timing != nil {
 		timing.reduceChildBuildNanos += time.Since(childStart).Nanoseconds()
@@ -4613,7 +4618,7 @@ func (p *Parser) tryPushPendingNoFieldParent(s *glrStack, act ParseAction, tok T
 		endPoint,
 		hasError,
 	)
-	parent.rawShape = p.captureRawShape(arena, act.Symbol, act.ProductionID, entries, start, reducedEnd)
+	parent.rawShape = p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, entries, start, reducedEnd)
 	parent.dynamicPrecedence = reduceWindowDynamicPrecedence(entries, start, reducedEnd, act)
 	out := 0
 	flattenedParents := 0
@@ -4715,7 +4720,7 @@ func (p *Parser) tryPushPendingDirectFieldParent(s *glrStack, act ParseAction, t
 		endPoint,
 		window.hasError,
 	)
-	parent.rawShape = p.captureRawShape(arena, act.Symbol, act.ProductionID, entries, start, reducedEnd)
+	parent.rawShape = p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, entries, start, reducedEnd)
 	parent.dynamicPrecedence = reduceWindowDynamicPrecedence(entries, start, reducedEnd, act)
 	if useDenseFieldEntries {
 		parent.setHasFieldEntries(true)
@@ -6936,7 +6941,7 @@ func (p *Parser) applyReduceAction(source []byte, s *glrStack, act ParseAction, 
 	if timing != nil {
 		childStart = time.Now()
 	}
-	rawShape := p.captureRawShape(arena, act.Symbol, act.ProductionID, entries, window.start, window.reducedEnd)
+	rawShape := p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, entries, window.start, window.reducedEnd)
 	children, fieldIDs, fieldSources, childPath := p.buildReduceChildrenWithPath(entries, window.start, window.reducedEnd, childCount, act.Symbol, act.ProductionID, arena)
 	if timing != nil {
 		timing.reduceChildBuildNanos += time.Since(childStart).Nanoseconds()
@@ -7122,7 +7127,7 @@ func (p *Parser) applyReduceActionTransientParents(source []byte, s *glrStack, a
 	if timing != nil {
 		childStart = time.Now()
 	}
-	rawShape := p.captureRawShape(arena, act.Symbol, act.ProductionID, entries, window.start, window.reducedEnd)
+	rawShape := p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, entries, window.start, window.reducedEnd)
 	children, fieldIDs, fieldSources, childPath := p.buildReduceChildrenWithPath(entries, window.start, window.reducedEnd, childCount, act.Symbol, act.ProductionID, arena)
 	if timing != nil {
 		timing.reduceChildBuildNanos += time.Since(childStart).Nanoseconds()
@@ -7290,7 +7295,11 @@ func newNoTreeReduceNodeInArenaWithRawShape(arena *nodeArena, act ParseAction, n
 	n.preGotoState = 0
 	n.productionID = act.ProductionID
 	if captureRawShape {
-		n.rawShape = captureRawShapeInArena(arena, act, entries, start, reducedEnd)
+		// No gssScratch threaded into this benchmark-only ("noTreeBenchmarkOnly")
+		// lane: it is not part of the canonical parse path the single-stack
+		// elision targets, so it keeps its pre-existing unconditional-capture
+		// behavior (nil never elides; see gssScratch.mayElideRawShape).
+		n.rawShape = captureRawShapeInArena(nil, arena, act, entries, start, reducedEnd)
 	} else {
 		n.rawShape = 0
 	}
@@ -7337,20 +7346,20 @@ func newNoTreeReduceNodeInArenaWithRawShape(arena *nodeArena, act ParseAction, n
 	return n
 }
 
-func captureRawShapeInArena(arena *nodeArena, act ParseAction, entries []stackEntry, start, end int) rawShapeRef {
+func captureRawShapeInArena(gssScratch *gssScratch, arena *nodeArena, act ParseAction, entries []stackEntry, start, end int) rawShapeRef {
 	if arena == nil {
 		return 0
 	}
 	var p Parser
-	return p.captureRawShape(arena, act.Symbol, act.ProductionID, entries, start, end)
+	return p.captureRawShape(gssScratch, arena, act.Symbol, act.ProductionID, entries, start, end)
 }
 
-func captureCollapsedUnaryRawShape(arena *nodeArena, act ParseAction, entries []stackEntry, reducedEnd int) rawShapeRef {
-	return captureRawShapeInArena(arena, act, entries, reducedEnd-1, reducedEnd)
+func captureCollapsedUnaryRawShape(gssScratch *gssScratch, arena *nodeArena, act ParseAction, entries []stackEntry, reducedEnd int) rawShapeRef {
+	return captureRawShapeInArena(gssScratch, arena, act, entries, reducedEnd-1, reducedEnd)
 }
 
 func (p *Parser) pushCollapsedUnaryReduceNode(s *glrStack, act ParseAction, tok Token, child *Node, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, entries []stackEntry, trailingStart, trailingEnd int, topState StateID) {
-	rawShape := captureCollapsedUnaryRawShape(arena, act, entries, trailingStart)
+	rawShape := captureCollapsedUnaryRawShape(gssScratch, arena, act, entries, trailingStart)
 	gotoState := p.lookupGoto(topState, act.Symbol)
 	targetState := topState
 	if gotoState != 0 {
@@ -7383,7 +7392,7 @@ func (p *Parser) pushCollapsedUnaryReduceNode(s *glrStack, act ParseAction, tok 
 }
 
 func (p *Parser) pushCollapsedUnaryReduceEntry(s *glrStack, act ParseAction, tok Token, child stackEntry, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, entries []stackEntry, trailingStart, trailingEnd int, topState StateID) {
-	rawShape := captureCollapsedUnaryRawShape(arena, act, entries, trailingStart)
+	rawShape := captureCollapsedUnaryRawShape(gssScratch, arena, act, entries, trailingStart)
 	gotoState := p.lookupGoto(topState, act.Symbol)
 	targetState := topState
 	if gotoState != 0 {

--- a/raw_shape.go
+++ b/raw_shape.go
@@ -296,16 +296,45 @@ func (a *nodeArena) rawShapeChildrenForNode(node *Node) []rawShapeChild {
 // every reader of the resulting ref is nil-guarded with an explicit fallback
 // (memory-safe unconditionally — see rawShapeForStackEntry and callers), so
 // skipping the capture entirely while gssScratch.mayElideRawShape() is true
-// is always safe. It is NOT always behavior-neutral across a prefix-then-fork
-// transition (later tie-break comparisons, e.g. compareRawStackEntriesRec,
-// can consult a shape's pre-flattening structure), which is why
-// mayElideRawShape latches permanently false for the rest of a parse the
-// first time it ever forks (see gssScratch.everForked). Pass nil for
-// gssScratch from call sites that are already proven fork-only/reachable
-// only outside the pure single-stack path (e.g. reduceForkTemporaryParent) or
-// that are out of scope for this optimization (e.g. the noTreeBenchmarkOnly
-// lane): nil never elides, matching the pre-optimization behavior. See
-// spore.2026-07-12.hazel.rawshape-elision-rca.
+// is always safe.
+//
+// Behavior preservation is a separate, more careful argument. everForked
+// (see gssScratch.everForked) latches permanently once a parse has forked or
+// entered C-recovery — but that latch is NOT retroactive: it only stops
+// FUTURE captures from being elided. A node built earlier, while elision was
+// still active, stays shapeless forever; everForked cannot and does not go
+// back and backfill it.
+//
+// What actually makes that safe is structural, not the latch: any node built
+// while mayElideRawShape() was true predates this parse's first fork/
+// recovery event, and every subsequent stack (GLR fork clones, C-recovery
+// version-spawns) shares that node by pointer — clone()/cloneWithScratch()
+// and recovery's *stacks mutation never deep-copy prior GSS structure. So a
+// shapeless node is only ever compared against ITSELF (compareRawStackEntriesRec
+// recursing to the identical object on both sides, trivially symmetric),
+// never against a different object at the same tree position. The
+// comparison's one-sided-shape fallback (parser_reduce.go
+// compareRawStackEntriesRec, the aHasShape != bHasShape branch, falling back
+// to materialized childCount/symbol) is NOT proven sign-preserving in
+// isolation — TestRawShapeElisionAbstractComparisonFallbackCanFlipSign
+// constructs an artificial asymmetric pair where it does flip sign — but a
+// real parse under this gate can never feed it that asymmetric pair, for the
+// pointer-sharing reason above. That structural argument, not "the fallback
+// happens to agree", is the actual safety basis, and it is what
+// TestRawShapeElisionDifferentialPrefixThenForkSharedRootSymbol and
+// TestRawShapeElisionDifferentialRecoveryFromSingleStackPrefix (both
+// raw_shape_elision_test.go / raw_shape_elision_recovery_test.go) exist to
+// exercise empirically: same-root-symbol fork alternatives and a genuine
+// C-recovery episode, both with a shared single-stack prefix that has a
+// pre/post-flatten childCount mismatch, both pass tree-identical gate-on vs
+// gate-off.
+//
+// Pass nil for gssScratch from call sites that are already proven fork-only/
+// reachable only outside the pure single-stack path (e.g.
+// reduceForkTemporaryParent) or that are out of scope for this optimization
+// (e.g. the noTreeBenchmarkOnly lane, the forest engine, C-recovery's own
+// shape helpers): nil never elides, matching the pre-optimization behavior.
+// See spore.2026-07-12.hazel.rawshape-elision-rca.
 func (p *Parser) captureRawShape(gssScratch *gssScratch, arena *nodeArena, symbol Symbol, productionID uint16, entries []stackEntry, start, end int) rawShapeRef {
 	if arena == nil || start < 0 || end < start || end > len(entries) {
 		return 0

--- a/raw_shape.go
+++ b/raw_shape.go
@@ -291,8 +291,26 @@ func (a *nodeArena) rawShapeChildrenForNode(node *Node) []rawShapeChild {
 	return a.rawShapeChildren(shape)
 }
 
-func (p *Parser) captureRawShape(arena *nodeArena, symbol Symbol, productionID uint16, entries []stackEntry, start, end int) rawShapeRef {
+// captureRawShape captures the reduction-shape sidecar documented on rawShape
+// (raw_shape.go). gssScratch gates a single-stack happy-path optimization:
+// every reader of the resulting ref is nil-guarded with an explicit fallback
+// (memory-safe unconditionally — see rawShapeForStackEntry and callers), so
+// skipping the capture entirely while gssScratch.mayElideRawShape() is true
+// is always safe. It is NOT always behavior-neutral across a prefix-then-fork
+// transition (later tie-break comparisons, e.g. compareRawStackEntriesRec,
+// can consult a shape's pre-flattening structure), which is why
+// mayElideRawShape latches permanently false for the rest of a parse the
+// first time it ever forks (see gssScratch.everForked). Pass nil for
+// gssScratch from call sites that are already proven fork-only/reachable
+// only outside the pure single-stack path (e.g. reduceForkTemporaryParent) or
+// that are out of scope for this optimization (e.g. the noTreeBenchmarkOnly
+// lane): nil never elides, matching the pre-optimization behavior. See
+// spore.2026-07-12.hazel.rawshape-elision-rca.
+func (p *Parser) captureRawShape(gssScratch *gssScratch, arena *nodeArena, symbol Symbol, productionID uint16, entries []stackEntry, start, end int) rawShapeRef {
 	if arena == nil || start < 0 || end < start || end > len(entries) {
+		return 0
+	}
+	if gssScratch.mayElideRawShape() {
 		return 0
 	}
 	count := 0

--- a/raw_shape_elision_recovery_test.go
+++ b/raw_shape_elision_recovery_test.go
@@ -1,0 +1,150 @@
+package gotreesitter
+
+import "testing"
+
+// buildArithmeticRecoveryGarbageLanguage is a small, C-recovery-eligible
+// grammar (ts2go convention: InitialState=1, nonterminal GOTO columns hold
+// raw state IDs, CertifyCRecoveryCostCompetition run at construction) used
+// to validate the recovery elision fix (see cHandleError's everForked latch
+// in parser_recover_c.go). It parses "NUMBER (+ NUMBER)*" and additionally
+// lexes a garbage "#" token (symbol HASH) that has NO parse action anywhere
+// in the table, including the initial state — so no opportunistic/legal
+// top-level resync heuristic can short-circuit the error, and the faithful
+// C-recovery port (cHandleError) is what actually handles it.
+//
+//	expression -> NUMBER                    (production 0, 1 child)
+//	expression -> expression + NUMBER        (production 1, 3 children)
+//
+// Feeding "1 #" shifts and reduces NUMBER -> expression deterministically
+// while singleStackMode is true (a genuine single-stack prefix, a candidate
+// for elision), then hits a true no-action dead end on "#" that only
+// cHandleError's version-spawning recovery machinery resolves.
+func buildArithmeticRecoveryGarbageLanguage() *Language {
+	lang := &Language{
+		Name:               "arithmetic_recovery_garbage",
+		SymbolCount:        5,
+		TokenCount:         4,
+		ExternalTokenCount: 0,
+		StateCount:         6,
+		LargeStateCount:    0,
+		FieldCount:         0,
+		ProductionIDCount:  2,
+		InitialState:       1,
+
+		// Terminals first (ts2go convention: TokenCount counts leading
+		// terminal symbols; nonterminal GOTO columns hold raw state IDs).
+		SymbolNames: []string{"EOF", "NUMBER", "+", "HASH", "expression"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "NUMBER", Visible: true, Named: true},
+			{Name: "+", Visible: true, Named: false},
+			{Name: "HASH", Visible: true, Named: true},
+			{Name: "expression", Visible: true, Named: true},
+		},
+		FieldNames: []string{""},
+
+		ParseActions: []ParseActionEntry{
+			{Actions: nil},                                                                                  // 0
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},                                    // 1: S1 col NUMBER
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 4, ChildCount: 1, ProductionID: 0}}}, // 2: S2 reduce expr->NUMBER
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},                                             // 3: S3 col EOF
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},                                    // 4: S3 col +
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},                                    // 5: S4 col NUMBER
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 4, ChildCount: 3, ProductionID: 1}}}, // 6: S5 reduce expr->expr+NUMBER
+		},
+
+		// Columns: EOF(0), NUMBER(1), +(2), HASH(3), expression(4, GOTO=raw state)
+		ParseTable: [][]uint16{
+			{0, 0, 0, 0, 0}, // state 0: unused placeholder
+			{0, 1, 0, 0, 3}, // state 1: start; NUMBER->shift(idx1); expression->goto state 3
+			{2, 2, 2, 2, 0}, // state 2: reduce regardless of lookahead
+			{3, 0, 4, 0, 0}, // state 3: accept at EOF, shift + ; NO action for HASH (real no-action dead end)
+			{0, 5, 0, 0, 0}, // state 4
+			{6, 6, 6, 6, 0}, // state 5
+		},
+
+		LexModes: []LexMode{
+			{LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0},
+		},
+
+		LexStates: []LexState{
+			{
+				AcceptToken: 0,
+				Skip:        false,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{
+					{Lo: '0', Hi: '9', NextState: 1},
+					{Lo: '+', Hi: '+', NextState: 2},
+					{Lo: '#', Hi: '#', NextState: 4},
+					{Lo: ' ', Hi: ' ', NextState: 3},
+				},
+			},
+			{AcceptToken: 1, Skip: false, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: '0', Hi: '9', NextState: 1}}},
+			{AcceptToken: 2, Skip: false, Default: -1, EOF: -1},
+			{AcceptToken: 0, Skip: true, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: ' ', Hi: ' ', NextState: 3}}},
+			{AcceptToken: 3, Skip: false, Default: -1, EOF: -1},
+		},
+	}
+	CertifyCRecoveryCostCompetition(lang)
+	return lang
+}
+
+// TestArithmeticRecoveryGarbageLanguageActuallyEntersCRecovery instruments
+// that "1 #" genuinely reaches the faithful C-recovery port (cHandleError),
+// not some earlier heuristic (opportunistic top-level resync, plain
+// absorb-into-error-leaf, etc.) that would make the recovery differential
+// below pass vacuously.
+func TestArithmeticRecoveryGarbageLanguageActuallyEntersCRecovery(t *testing.T) {
+	lang := buildArithmeticRecoveryGarbageLanguage()
+	if !lang.CRecoveryCostCompetitionCapable || !lang.CRecoveryCostCompetitionEnabledByDefault {
+		t.Fatalf("language is not C-recovery eligible: capable=%v enabledByDefault=%v (DiagnoseCRecoveryGate=%+v)",
+			lang.CRecoveryCostCompetitionCapable, lang.CRecoveryCostCompetitionEnabledByDefault, DiagnoseCRecoveryGate(lang))
+	}
+	tree := mustParse(t, NewParser(lang), []byte("1 #"))
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	if !rt.CRecoveryEnteredErrorState {
+		t.Fatal("CRecoveryEnteredErrorState = false, want true (test input must actually reach cHandleError)")
+	}
+	if !tree.RootNode().HasError() {
+		t.Fatal("HasError() = false, want true (garbage HASH token must surface as an error)")
+	}
+}
+
+// TestRawShapeElisionDifferentialRecoveryFromSingleStackPrefix is the
+// recovery-path differential that validates the cHandleError everForked
+// latch (parser_recover_c.go): a single-stack prefix ("1" shifts and reduces
+// to "expression" deterministically, a candidate for elision) followed by a
+// malformed "#" that drives the parse into the faithful C-recovery port,
+// including its version-spawning (MaxStacksSeen > 1, confirmed below). The
+// selected tree must be identical whether the elision gate is on or forced
+// off.
+func TestRawShapeElisionDifferentialRecoveryFromSingleStackPrefix(t *testing.T) {
+	lang := buildArithmeticRecoveryGarbageLanguage()
+	source := []byte("1 #")
+
+	SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOn := mustParse(t, NewParser(lang), source)
+	defer gateOn.Release()
+	gateOnRuntime := gateOn.ParseRuntime()
+
+	SetRawShapeElisionDisabledForDiagnostics(true)
+	defer SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOff := mustParse(t, NewParser(lang), source)
+	defer gateOff.Release()
+	gateOffRuntime := gateOff.ParseRuntime()
+
+	if !gateOnRuntime.CRecoveryEnteredErrorState || !gateOffRuntime.CRecoveryEnteredErrorState {
+		t.Fatalf("CRecoveryEnteredErrorState gate-on=%v gate-off=%v, want both true (recovery precondition)",
+			gateOnRuntime.CRecoveryEnteredErrorState, gateOffRuntime.CRecoveryEnteredErrorState)
+	}
+	if gateOnRuntime.MaxStacksSeen <= 1 || gateOffRuntime.MaxStacksSeen <= 1 {
+		t.Fatalf("MaxStacksSeen gate-on=%d gate-off=%d, want both > 1 (recovery version-spawn precondition)",
+			gateOnRuntime.MaxStacksSeen, gateOffRuntime.MaxStacksSeen)
+	}
+	if got, want := gateOn.RootNode().SExpr(lang), gateOff.RootNode().SExpr(lang); got != want {
+		t.Fatalf("gate-on tree = %s, gate-off (elision disabled) tree = %s, want identical", got, want)
+	}
+}

--- a/raw_shape_elision_test.go
+++ b/raw_shape_elision_test.go
@@ -1,0 +1,234 @@
+package gotreesitter
+
+import "testing"
+
+// buildPrefixForkLanguage constructs a hand-built LR grammar with a genuine
+// single-stack prefix reduce, followed by a real GLR reduce/reduce conflict
+// (fork). It exists to differentially test the single-stack raw-shape
+// capture elision (see gssScratch.mayElideRawShape /
+// spore.2026-07-12.hazel.rawshape-elision-rca): the "pre" node is reduced
+// while exactly one GLR stack is live (a candidate for elision), and it is
+// then embedded as a child of both fork alternatives, so the fork's
+// tie-break comparison (compareRawStackEntriesRec, via
+// compareAcceptedStackRawShapePreference) walks back through it.
+//
+//	pre  -> x            (production 0, 1 child)   -- single-stack, deterministic
+//	A    -> pre x         (production 1, 2 children) DynamicPrecedence 0
+//	B    -> pre x         (production 2, 2 children) DynamicPrecedence 0
+//
+// Symbols: 0 EOF, 1 x (terminal), 2 pre, 3 A, 4 B, 5 y (terminal).
+//
+// States:
+//
+//	State 0 (start):        x -> shift(1); pre -> goto(2); A -> goto(4); B -> goto(4)
+//	State 1 (saw x):        any -> reduce pre -> x (1 child)
+//	State 2 (saw pre):      x -> shift(3)
+//	State 3 (saw pre, x):   y -> FORK: reduce A->pre x (prod 1) OR reduce B->pre x (prod 2)
+//	State 4 (saw A or B):   y -> shift(5)
+//	State 5 (saw A/B, y):   EOF -> accept
+//
+// Feeding "x x y" shifts once, reduces "pre" deterministically while
+// singleStackMode is true (never having forked yet), shifts the second x,
+// and only then hits the reduce/reduce conflict that forks the stack on the
+// still-pending "y" lookahead. The trailing "y" is deliberate: reduces do not
+// consume the lookahead token, so without it the fork and both alternatives'
+// accept would resolve within the single iteration that detects the
+// conflict, and the peak stack count (sampled only at each outer loop
+// iteration's top, see maxStacksSeen in parser.go) would never observe the
+// fork. Requiring both alternatives to independently shift "y" forces a real
+// iteration boundary (a fresh token acquisition) while 2 stacks are alive.
+func buildPrefixForkLanguage() *Language {
+	return &Language{
+		Name:               "prefix_fork",
+		SymbolCount:        6,
+		TokenCount:         3,
+		ExternalTokenCount: 0,
+		StateCount:         6,
+		LargeStateCount:    0,
+		FieldCount:         0,
+		ProductionIDCount:  3,
+
+		SymbolNames: []string{"EOF", "x", "pre", "A", "B", "y"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "x", Visible: true, Named: true},
+			{Name: "pre", Visible: true, Named: true},
+			{Name: "A", Visible: true, Named: true},
+			{Name: "B", Visible: true, Named: true},
+			{Name: "y", Visible: true, Named: true},
+		},
+		FieldNames: []string{""},
+
+		ParseActions: []ParseActionEntry{
+			// 0: error / no action
+			{Actions: nil},
+			// 1: state0, col x: shift to state 1
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+			// 2: state1, cols EOF/x/y: reduce pre -> x
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 2, ChildCount: 1, ProductionID: 0}}},
+			// 3: state0, col pre: goto state 2
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},
+			// 4: state2, col x: shift to state 3 (second x)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+			// 5: state0, col A: goto state 4
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},
+			// 6: state0, col B: goto state 4
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},
+			// 7: state3, col y: TWO actions -- GLR reduce/reduce fork
+			{Actions: []ParseAction{
+				{Type: ParseActionReduce, Symbol: 3, ChildCount: 2, ProductionID: 1, DynamicPrecedence: 0},
+				{Type: ParseActionReduce, Symbol: 4, ChildCount: 2, ProductionID: 2, DynamicPrecedence: 0},
+			}},
+			// 8: state4, col y: shift to state 5
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},
+			// 9: state5, col EOF: accept
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},
+		},
+
+		// Columns: EOF(0), x(1), pre(2), A(3), B(4), y(5)
+		ParseTable: [][]uint16{
+			// State 0
+			{0, 1, 3, 5, 6, 0},
+			// State 1: reduce pre->x regardless of lookahead
+			{2, 2, 0, 0, 0, 2},
+			// State 2: shift second x
+			{0, 4, 0, 0, 0, 0},
+			// State 3: fork on y
+			{0, 0, 0, 0, 0, 7},
+			// State 4: shift y
+			{0, 0, 0, 0, 0, 8},
+			// State 5: accept on EOF
+			{9, 0, 0, 0, 0, 0},
+		},
+
+		LexModes: []LexMode{
+			{LexState: 0},
+			{LexState: 0},
+			{LexState: 0},
+			{LexState: 0},
+			{LexState: 0},
+			{LexState: 0},
+		},
+
+		LexStates: []LexState{
+			// State 0: start
+			{
+				AcceptToken: 0,
+				Skip:        false,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+					{Lo: 'y', Hi: 'y', NextState: 3},
+					{Lo: ' ', Hi: ' ', NextState: 2},
+				},
+			},
+			// State 1: accept x (symbol 1)
+			{
+				AcceptToken: 1,
+				Skip:        false,
+				Default:     -1,
+				EOF:         -1,
+			},
+			// State 2: whitespace (skip)
+			{
+				AcceptToken: 0,
+				Skip:        true,
+				Default:     -1,
+				EOF:         -1,
+			},
+			// State 3: accept y (symbol 5)
+			{
+				AcceptToken: 5,
+				Skip:        false,
+				Default:     -1,
+				EOF:         -1,
+			},
+		},
+	}
+}
+
+// TestPrefixForkLanguageActuallyForks instruments (via ParseRuntime, which
+// this hand-built language reaches through the normal parseInternal loop,
+// not any forest fast path) that "x x" genuinely drives more than one live
+// GLR stack. This is the precondition the differential tests below depend
+// on: without a real fork, they would pass vacuously.
+func TestPrefixForkLanguageActuallyForks(t *testing.T) {
+	lang := buildPrefixForkLanguage()
+	tree := mustParse(t, NewParser(lang), []byte("x x y"))
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	if rt.StopReason != ParseStopAccepted {
+		t.Fatalf("StopReason = %v, want accepted", rt.StopReason)
+	}
+	if rt.MaxStacksSeen <= 1 {
+		t.Fatalf("MaxStacksSeen = %d, want > 1 (test input must actually fork)", rt.MaxStacksSeen)
+	}
+	if rt.MultiStackIterations == 0 {
+		t.Fatal("MultiStackIterations = 0, want > 0 (test input must actually fork)")
+	}
+}
+
+// The zero-bytes-on-pure-single-stack and nonzero-bytes-on-forking
+// counterparts live alongside the reclaim/accounting invariant in
+// raw_shape_reclaim_test.go
+// (TestParseReclaimsRawShapeStorageAccountsForZeroOnSingleStackParse and
+// TestParseReclaimsRawShapeStorageAfterAccounting), which is the revision the
+// RCA asked for of the pre-existing reclaim test. This file focuses on the
+// gate-on-vs-gate-off differential, which is the load-bearing safety gate.
+
+// TestRawShapeElisionDifferentialPureSingleStack is the gate-on-vs-gate-off
+// differential for scenario (a): a pure single-stack parse must produce an
+// identical tree whether or not the elision optimization is active.
+func TestRawShapeElisionDifferentialPureSingleStack(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	source := []byte("1+2+3+4")
+
+	SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOn := mustParse(t, NewParser(lang), source)
+	defer gateOn.Release()
+
+	SetRawShapeElisionDisabledForDiagnostics(true)
+	defer SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOff := mustParse(t, NewParser(lang), source)
+	defer gateOff.Release()
+
+	if got, want := gateOn.RootNode().SExpr(lang), gateOff.RootNode().SExpr(lang); got != want {
+		t.Fatalf("gate-on tree = %s, gate-off (elision disabled) tree = %s, want identical", got, want)
+	}
+}
+
+// TestRawShapeElisionDifferentialPrefixThenFork is the load-bearing
+// differential gate the RCA asked for: a parse with a genuine single-stack
+// prefix (the "pre" reduce, elided under the gate) followed by a real GLR
+// fork (proven by TestPrefixForkLanguageActuallyForks) whose tie-break
+// (compareAcceptedStackRawShapePreference / compareRawStackEntriesRec) walks
+// back through that prefix node. The selected tree and the winning
+// alternative (A vs B) must be identical whether the elision gate is on or
+// forced off.
+func TestRawShapeElisionDifferentialPrefixThenFork(t *testing.T) {
+	lang := buildPrefixForkLanguage()
+	source := []byte("x x y")
+
+	SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOn := mustParse(t, NewParser(lang), source)
+	defer gateOn.Release()
+	gateOnRuntime := gateOn.ParseRuntime()
+
+	SetRawShapeElisionDisabledForDiagnostics(true)
+	defer SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOff := mustParse(t, NewParser(lang), source)
+	defer gateOff.Release()
+	gateOffRuntime := gateOff.ParseRuntime()
+
+	if gateOnRuntime.MaxStacksSeen <= 1 || gateOffRuntime.MaxStacksSeen <= 1 {
+		t.Fatalf("MaxStacksSeen gate-on=%d gate-off=%d, want both > 1 (fork precondition)", gateOnRuntime.MaxStacksSeen, gateOffRuntime.MaxStacksSeen)
+	}
+	if got, want := gateOn.RootNode().Symbol(), gateOff.RootNode().Symbol(); got != want {
+		t.Fatalf("gate-on winning symbol = %d, gate-off winning symbol = %d, want identical tie-break selection", got, want)
+	}
+	if got, want := gateOn.RootNode().SExpr(lang), gateOff.RootNode().SExpr(lang); got != want {
+		t.Fatalf("gate-on tree = %s, gate-off (elision disabled) tree = %s, want identical", got, want)
+	}
+}

--- a/raw_shape_elision_test.go
+++ b/raw_shape_elision_test.go
@@ -232,3 +232,277 @@ func TestRawShapeElisionDifferentialPrefixThenFork(t *testing.T) {
 		t.Fatalf("gate-on tree = %s, gate-off (elision disabled) tree = %s, want identical", got, want)
 	}
 }
+
+// buildPrefixForkHiddenChildLanguage strengthens the prefix-then-fork
+// differential per an adversarial review of the initial cut: that cut's fork
+// alternatives (A, B) had distinct root symbols, so
+// compareRawStackEntriesRec's very first check (`as != bs`,
+// parser_reduce.go's compareRawStackEntriesRec) decided the comparison before
+// ever descending into the elided "pre" node — the differential passed
+// regardless of whether elision was active.
+//
+// This grammar closes that gap as far as it can be closed with a real,
+// reachable parse:
+//
+//   - the shared single-stack prefix ("pre") is built through an invisible
+//     child ("_hidden -> x x"), so pre's RAW shape (if captured) has
+//     childCount 1 (one child: _hidden) while its MATERIALIZED view has
+//     childCount 2 (buildReduceChildrenWithPath flattens the invisible
+//     _hidden's own two children into pre's materialized child list) —
+//     exactly the pre/post-flatten mismatch compareRawStackEntriesRec's
+//     one-sided-shape fallback (parser_reduce.go's aHasShape != bHasShape
+//     branch) has to resolve without inventing an answer.
+//   - the two fork alternatives (A, B) are wrapped by two separate unary
+//     productions into the SAME shared root symbol "Top", so the two
+//     accepted stacks being compared for final result selection literally
+//     share a root symbol and childCount, forcing
+//     compareAcceptedStackRawShapePreference to descend at least one level
+//     instead of returning at depth 0.
+//
+//	_hidden -> x x        (production 0, 2 children, invisible)
+//	pre     -> _hidden     (production 1, 1 child)   -- single-stack, elided
+//	A       -> pre x        (production 2, 2 children)
+//	B       -> pre x        (production 3, 2 children)
+//	Top     -> A y  |  Top -> B y   (production 4, 2 children each, same symbol)
+//
+// Feeding "x x x y" builds "pre" deterministically while singleStackMode is
+// true (two x's fold into _hidden, then pre wraps _hidden), consumes a third
+// x, and only then forks on the pending "y" lookahead (reduce/reduce
+// conflict on symbol A vs symbol B). Both alternatives shift the same "y"
+// and reduce into the shared "Top" symbol before accepting.
+//
+// Empirically (see TestRawShapeElisionDifferentialPrefixThenForkSharedRootSymbol),
+// even with the shared "Top" root, the recursive comparison still resolves
+// one level down (A's own symbol vs B's own symbol necessarily differ — that
+// difference IS the fork) before it would ever reach "pre" a second time from
+// a non-identical object. See that test's doc comment for why: this is not a
+// property of this specific grammar, it is structural (raw_shape.go
+// captureRawShape's doc comment states the argument plainly).
+func buildPrefixForkHiddenChildLanguage() *Language {
+	return &Language{
+		Name:               "prefix_fork_hidden",
+		SymbolCount:        8,
+		TokenCount:         3,
+		ExternalTokenCount: 0,
+		StateCount:         10,
+		LargeStateCount:    0,
+		FieldCount:         0,
+		ProductionIDCount:  5,
+
+		SymbolNames: []string{"EOF", "x", "y", "_hidden", "pre", "A", "B", "Top"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "x", Visible: true, Named: true},
+			{Name: "y", Visible: true, Named: true},
+			{Name: "_hidden", Visible: false, Named: false},
+			{Name: "pre", Visible: true, Named: true},
+			{Name: "A", Visible: true, Named: true},
+			{Name: "B", Visible: true, Named: true},
+			{Name: "Top", Visible: true, Named: true},
+		},
+		FieldNames: []string{""},
+
+		ParseActions: []ParseActionEntry{
+			{Actions: nil},                                                                                  // 0: error
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},                                    // 1: S0 col x
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},                                    // 2: S0 col _hidden (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},                                    // 3: S0 col pre (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 6}}},                                    // 4: S0 col A (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 7}}},                                    // 5: S0 col B (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 9}}},                                    // 6: S0 col Top (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},                                    // 7: S1 col x (second x)
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 3, ChildCount: 2, ProductionID: 0}}}, // 8: S2 reduce _hidden -> x x
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 4, ChildCount: 1, ProductionID: 1}}}, // 9: S3 reduce pre -> _hidden
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},                                    // 10: S4 col x (third x)
+			{Actions: []ParseAction{ // 11: S5 col y -- GLR reduce/reduce fork
+				{Type: ParseActionReduce, Symbol: 5, ChildCount: 2, ProductionID: 2, DynamicPrecedence: 0},
+				{Type: ParseActionReduce, Symbol: 6, ChildCount: 2, ProductionID: 3, DynamicPrecedence: 0},
+			}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 8}}},                                    // 12: S6/S7 col y
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 7, ChildCount: 2, ProductionID: 4}}}, // 13: S8 reduce Top -> (A|B) y
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},                                             // 14: S9 accept
+		},
+
+		// Columns: EOF(0), x(1), y(2), _hidden(3), pre(4), A(5), B(6), Top(7)
+		ParseTable: [][]uint16{
+			{0, 1, 0, 2, 3, 4, 5, 6},  // S0 start
+			{0, 7, 0, 0, 0, 0, 0, 0},  // S1 saw x1
+			{8, 8, 8, 0, 0, 0, 0, 0},  // S2 saw x1 x2 -> reduce _hidden
+			{9, 9, 9, 0, 0, 0, 0, 0},  // S3 saw _hidden -> reduce pre
+			{0, 10, 0, 0, 0, 0, 0, 0}, // S4 saw pre
+			{0, 0, 11, 0, 0, 0, 0, 0}, // S5 saw pre,x3 -> FORK on y
+			{0, 0, 12, 0, 0, 0, 0, 0}, // S6 saw A
+			{0, 0, 12, 0, 0, 0, 0, 0}, // S7 saw B
+			{13, 0, 0, 0, 0, 0, 0, 0}, // S8 saw A|B,y -> reduce Top
+			{14, 0, 0, 0, 0, 0, 0, 0}, // S9 saw Top -> accept
+		},
+
+		LexModes: []LexMode{
+			{LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0},
+			{LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0}, {LexState: 0},
+		},
+
+		LexStates: []LexState{
+			{
+				AcceptToken: 0, Skip: false, Default: -1, EOF: -1,
+				Transitions: []LexTransition{
+					{Lo: 'x', Hi: 'x', NextState: 1},
+					{Lo: 'y', Hi: 'y', NextState: 2},
+					{Lo: ' ', Hi: ' ', NextState: 3},
+				},
+			},
+			{AcceptToken: 1, Skip: false, Default: -1, EOF: -1},
+			{AcceptToken: 2, Skip: false, Default: -1, EOF: -1},
+			{AcceptToken: 0, Skip: true, Default: -1, EOF: -1, Transitions: []LexTransition{{Lo: ' ', Hi: ' ', NextState: 3}}},
+		},
+	}
+}
+
+// TestPrefixForkHiddenChildLanguageActuallyForks instruments (via
+// ParseRuntime) that "x x x y" genuinely drives more than one live GLR
+// stack, and that the winning tree still shows the materialized (flattened)
+// view of "pre" — proving the hidden-child construction actually took
+// effect (2 materialized children under "pre", not 1).
+func TestPrefixForkHiddenChildLanguageActuallyForks(t *testing.T) {
+	lang := buildPrefixForkHiddenChildLanguage()
+	tree := mustParse(t, NewParser(lang), []byte("x x x y"))
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	if rt.StopReason != ParseStopAccepted {
+		t.Fatalf("StopReason = %v, want accepted", rt.StopReason)
+	}
+	if rt.MaxStacksSeen <= 1 {
+		t.Fatalf("MaxStacksSeen = %d, want > 1 (test input must actually fork)", rt.MaxStacksSeen)
+	}
+	root := tree.RootNode()
+	if got, want := root.Symbol(), Symbol(7); got != want {
+		t.Fatalf("root symbol = %d, want Top(7)", got)
+	}
+	// The winning alternative's "pre" child must show 2 MATERIALIZED
+	// children (the flattened _hidden pair), proving the pre/post-flatten
+	// mismatch is real: pre's own raw shape (if captured) has exactly 1
+	// child (_hidden, unflattened).
+	winner := root.Child(0) // A or B
+	pre := winner.Child(0)
+	if got, want := pre.Symbol(), Symbol(4); got != want {
+		t.Fatalf("winner's first child symbol = %d, want pre(4)", got)
+	}
+	if got, want := int(pre.ChildCount()), 2; got != want {
+		t.Fatalf("pre materialized child count = %d, want %d (flattened _hidden pair)", got, want)
+	}
+}
+
+// TestRawShapeElisionDifferentialPrefixThenForkSharedRootSymbol is the
+// strengthened load-bearing differential an adversarial review asked for
+// (see buildPrefixForkHiddenChildLanguage's doc comment for the full
+// construction and rationale). It passes: the selected tree is identical
+// gate-on vs gate-off, for a fork whose alternatives share a root symbol and
+// whose shared single-stack prefix has a genuine pre/post-flatten childCount
+// mismatch.
+//
+// This does NOT mean the mismatch is invisible to the comparison in every
+// case: TestRawShapeElisionAbstractComparisonFallbackCanFlipSign proves the
+// one-sided-shape fallback branch itself is not universally sign-preserving
+// when fed an artificially asymmetric pair. What this test (and the
+// structural argument in captureRawShape's doc comment) shows is that a real
+// parse under this gate can never actually construct that asymmetric pair:
+// compareRawStackEntriesRec, walking from the shared "Top" root, still
+// resolves via A's vs B's own (necessarily different, that difference IS
+// the fork) symbol one level up from "pre" — so "pre" is only ever compared
+// against itself (symmetric hasShape, safe), never against a different
+// object.
+func TestRawShapeElisionDifferentialPrefixThenForkSharedRootSymbol(t *testing.T) {
+	lang := buildPrefixForkHiddenChildLanguage()
+	source := []byte("x x x y")
+
+	SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOn := mustParse(t, NewParser(lang), source)
+	defer gateOn.Release()
+	gateOnRuntime := gateOn.ParseRuntime()
+
+	SetRawShapeElisionDisabledForDiagnostics(true)
+	defer SetRawShapeElisionDisabledForDiagnostics(false)
+	gateOff := mustParse(t, NewParser(lang), source)
+	defer gateOff.Release()
+	gateOffRuntime := gateOff.ParseRuntime()
+
+	if gateOnRuntime.MaxStacksSeen <= 1 || gateOffRuntime.MaxStacksSeen <= 1 {
+		t.Fatalf("MaxStacksSeen gate-on=%d gate-off=%d, want both > 1 (fork precondition)", gateOnRuntime.MaxStacksSeen, gateOffRuntime.MaxStacksSeen)
+	}
+	if got, want := gateOn.RootNode().SExpr(lang), gateOff.RootNode().SExpr(lang); got != want {
+		t.Fatalf("gate-on tree = %s, gate-off (elision disabled) tree = %s, want identical", got, want)
+	}
+}
+
+// TestRawShapeElisionAbstractComparisonFallbackCanFlipSign directly exercises
+// compareRawStackEntriesRec's one-sided-shape fallback (parser_reduce.go,
+// the `aHasShape != bHasShape` branch) with a hand-constructed, artificially
+// asymmetric pair: "preElided" and "preCaptured" model the SAME logical node
+// in the two counterfactual worlds (elision on: no raw shape at all; elision
+// off: the raw shape it would have captured, 1 child = the still-unflattened
+// hidden wrapper), both compared against the same "D" (a different node,
+// same symbol, always captured normally).
+//
+// This proves the fallback branch is NOT universally sign-preserving in
+// isolation: feeding it an asymmetric pair can and does flip the comparison
+// sign here. That is exactly why this optimization does not rely on "the
+// fallback always preserves sign" as its safety argument. The actual
+// argument (see captureRawShape's doc comment and
+// TestRawShapeElisionDifferentialPrefixThenForkSharedRootSymbol) is that a
+// real parse under this gate can never feed compareRawStackEntriesRec this
+// exact shape of input: an elided node is always compared against ITSELF
+// (same object, symmetric hasShape), never against a different object like
+// "D" here — this test's "preElided vs D" pairing is a deliberately
+// unreachable construction, included to answer "could the sign flip"
+// directly rather than leaving it as an open question.
+func TestRawShapeElisionAbstractComparisonFallbackCanFlipSign(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	parser := testRawShapeParser()
+
+	const (
+		hiddenSym Symbol = 2
+		childASym Symbol = 3
+		childCSym Symbol = 4
+		childBSym Symbol = 5 // deliberately > childCSym
+		preSym    Symbol = 1
+	)
+
+	childA := newLeafNodeInArena(arena, childASym, true, 0, 1, Point{}, Point{Column: 1})
+	childB := newLeafNodeInArena(arena, childBSym, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	childC := newLeafNodeInArena(arena, childCSym, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	hiddenWrap := newParentNodeInArena(arena, hiddenSym, false, []*Node{childA, childB}, nil, 0)
+
+	// preElided: materialized children flattened to [childA, childB] (mirrors
+	// buildReduceChildrenWithPath splicing an invisible child's own children
+	// into the parent), no raw shape at all -- simulating single-stack
+	// elision.
+	preElided := newParentNodeInArena(arena, preSym, true, []*Node{childA, childB}, nil, 0)
+
+	// preCaptured: the SAME logical node in the counterfactual gate-off
+	// world: identical materialized children, but WITH the raw shape it
+	// would have captured (1 child: the still-unflattened hiddenWrap).
+	preCaptured := newParentNodeInArena(arena, preSym, true, []*Node{childA, childB}, nil, 0)
+	preCaptured.rawShape = parser.captureRawShape(nil, arena, preSym, 0, []stackEntry{newStackEntryNode(0, hiddenWrap)}, 0, 1)
+
+	// d: the OTHER side of the comparison -- same symbol as pre, different
+	// materialized children [childA, childC], captured normally (as any
+	// node built after the parse's first fork always is).
+	d := newParentNodeInArena(arena, preSym, true, []*Node{childA, childC}, nil, 0)
+	d.rawShape = parser.captureRawShape(nil, arena, preSym, 0, []stackEntry{
+		newStackEntryNode(0, childA),
+		newStackEntryNode(0, childC),
+	}, 0, 2)
+
+	dEntry := newStackEntryNode(0, d)
+	cmpOn := parser.compareRawStackEntries(arena, newStackEntryNode(0, preElided), dEntry)
+	cmpOff := parser.compareRawStackEntries(arena, newStackEntryNode(0, preCaptured), dEntry)
+
+	if cmpOn == 0 || cmpOff == 0 {
+		t.Fatalf("expected nonzero comparisons on both sides, got cmpOn=%d cmpOff=%d", cmpOn, cmpOff)
+	}
+	if (cmpOn < 0) == (cmpOff < 0) {
+		t.Fatalf("expected a sign flip between the elided and captured counterfactuals, got cmpOn=%d cmpOff=%d (same sign)", cmpOn, cmpOff)
+	}
+}

--- a/raw_shape_reclaim_test.go
+++ b/raw_shape_reclaim_test.go
@@ -83,7 +83,48 @@ func TestReclaimRawShapeStorageClearsArenaPayloadRefs(t *testing.T) {
 	}
 }
 
+// TestParseReclaimsRawShapeStorageAfterAccounting exercises the reclaim/
+// accounting invariant on a genuinely forking parse (buildPrefixForkLanguage,
+// proven to fork by TestPrefixForkLanguageActuallyForks in
+// raw_shape_elision_test.go). A single-stack input like "1+2+3+4" no longer
+// captures any raw shapes at all under the single-stack capture elision (see
+// gssScratch.mayElideRawShape / spore.2026-07-12.hazel.rawshape-elision-rca),
+// so it can no longer exercise "nonzero captured, then reclaimed" here; see
+// TestParseReclaimsRawShapeStorageAccountsForZeroOnSingleStackParse below for
+// that (now-zero) single-stack case.
 func TestParseReclaimsRawShapeStorageAfterAccounting(t *testing.T) {
+	EnableArenaBreakdown(true)
+	defer EnableArenaBreakdown(false)
+
+	lang := buildPrefixForkLanguage()
+	tree := mustParse(t, NewParser(lang), []byte("x x y"))
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	if rt.MaxStacksSeen <= 1 {
+		t.Fatalf("MaxStacksSeen = %d, want > 1 (this test requires a genuinely forking parse)", rt.MaxStacksSeen)
+	}
+	breakdown := assertParseRuntimeArenaBreakdown(t, tree, rt)
+	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
+	if parseRawBytes == 0 {
+		t.Fatal("parse-time raw-shape bytes = 0, want captured allocation once the parse has forked")
+	}
+	assertTreeRawShapeStorageReclaimed(t, tree)
+	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()
+	if got, want := tree.ParseRuntime().ArenaBytesAllocated-tree.arena.allocatedBytes, parseRawBytes-retainedRawBytes; got != want {
+		t.Fatalf("retained arena reduction = %d, want reclaimed raw-shape allocation %d", got, want)
+	}
+	assertReachableRawShapeRefsCleared(t, tree.RootNode())
+}
+
+// TestParseReclaimsRawShapeStorageAccountsForZeroOnSingleStackParse is the
+// single-stack counterpart the RCA asked for: a pure single-stack parse
+// (buildArithmeticLanguage has no GLR conflicts) now elides every
+// captureRawShape call, so the arena-breakdown accounting invariant must hold
+// with parse-time raw-shape bytes at zero, not just at some captured-then-
+// reclaimed nonzero value.
+func TestParseReclaimsRawShapeStorageAccountsForZeroOnSingleStackParse(t *testing.T) {
+	DrainArenaPools()
 	EnableArenaBreakdown(true)
 	defer EnableArenaBreakdown(false)
 
@@ -91,10 +132,14 @@ func TestParseReclaimsRawShapeStorageAfterAccounting(t *testing.T) {
 	tree := mustParse(t, NewParser(lang), []byte("1+2+3+4"))
 	defer tree.Release()
 
-	breakdown := assertParseRuntimeArenaBreakdown(t, tree, tree.ParseRuntime())
+	rt := tree.ParseRuntime()
+	if rt.MaxStacksSeen > 1 {
+		t.Fatalf("MaxStacksSeen = %d, want <= 1 (arithmetic grammar has no GLR conflicts)", rt.MaxStacksSeen)
+	}
+	breakdown := assertParseRuntimeArenaBreakdown(t, tree, rt)
 	parseRawBytes := breakdown.RawShapeBytesAllocated + breakdown.RawShapeChildBytesAllocated
-	if parseRawBytes == 0 {
-		t.Fatal("parse-time raw-shape bytes = 0, want captured allocation")
+	if parseRawBytes != 0 {
+		t.Fatalf("parse-time raw-shape bytes = %d, want 0 on a pure single-stack parse (elision should skip every capture)", parseRawBytes)
 	}
 	assertTreeRawShapeStorageReclaimed(t, tree)
 	retainedRawBytes := tree.arena.rawShapeBytesAllocated() + tree.arena.rawShapeChildBytesAllocated()

--- a/raw_shape_test.go
+++ b/raw_shape_test.go
@@ -65,8 +65,8 @@ func TestRawShapeCompareDistinguishesHiddenFlattenedPublicShape(t *testing.T) {
 	flatParent := newParentNodeInArena(arena, 1, true, []*Node{leaf}, nil, 0)
 	hiddenParent := newParentNodeInArena(arena, 1, true, []*Node{leaf}, nil, 0)
 
-	flatParent.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, leaf)}, 0, 1)
-	hiddenParent.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, hidden)}, 0, 1)
+	flatParent.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, leaf)}, 0, 1)
+	hiddenParent.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, hidden)}, 0, 1)
 
 	flatEntry := newStackEntryNode(1, flatParent)
 	hiddenEntry := newStackEntryNode(1, hiddenParent)
@@ -87,8 +87,8 @@ func TestAcceptedStackSelectionUsesRawShapeBeforeBranchOrder(t *testing.T) {
 	leafB := newLeafNodeInArena(arena, 4, true, 0, 1, Point{}, Point{Column: 1})
 	rootA := newParentNodeInArena(arena, 1, true, []*Node{leafA}, nil, 0)
 	rootB := newParentNodeInArena(arena, 1, true, []*Node{leafA}, nil, 0)
-	rootA.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, leafA)}, 0, 1)
-	rootB.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, leafB)}, 0, 1)
+	rootA.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, leafA)}, 0, 1)
+	rootB.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, leafB)}, 0, 1)
 
 	laterBetter := glrStack{
 		accepted:    true,
@@ -137,7 +137,7 @@ func TestAcceptedStackRawShapeDoesNotOverrideDistinctMaterializedRoot(t *testing
 	varName := newLeafNodeInArena(arena, varSym, true, 1, 7, Point{Column: 1}, Point{Column: 7})
 	macroArgs := newLeafNodeInArena(arena, argsSym, true, 7, 22, Point{Column: 7}, Point{Column: 22})
 	macro := newParentNodeInArena(arena, macroCallSym, true, []*Node{qmark, varName, macroArgs}, nil, 0)
-	macro.rawShape = parser.captureRawShape(arena, replacementSym, 0, []stackEntry{
+	macro.rawShape = parser.captureRawShape(nil, arena, replacementSym, 0, []stackEntry{
 		newStackEntryNode(0, qmark),
 		newStackEntryNode(0, varName),
 		newStackEntryNode(0, macroArgs),
@@ -146,7 +146,7 @@ func TestAcceptedStackRawShapeDoesNotOverrideDistinctMaterializedRoot(t *testing
 	macroName := newLeafNodeInArena(arena, macroCallSym, true, 0, 7, Point{}, Point{Column: 7})
 	callArgs := newLeafNodeInArena(arena, argsSym, true, 7, 22, Point{Column: 7}, Point{Column: 22})
 	call := newParentNodeInArena(arena, callSym, true, []*Node{macroName, callArgs}, nil, 0)
-	call.rawShape = parser.captureRawShape(arena, replacementSym, 0, []stackEntry{
+	call.rawShape = parser.captureRawShape(nil, arena, replacementSym, 0, []stackEntry{
 		newStackEntryNode(0, macroName),
 		newStackEntryNode(0, callArgs),
 	}, 0, 2)
@@ -229,7 +229,7 @@ func TestForestChildAlternativeResolutionUsesLocalSameSpanBest(t *testing.T) {
 	macroA := newLeafNodeInArena(arena, partASym, true, 0, 2, Point{}, Point{Column: 2})
 	macroB := newLeafNodeInArena(arena, partBSym, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	macro := newParentNodeInArena(arena, macroCallSym, true, []*Node{macroA, macroB}, nil, 0)
-	macro.rawShape = parser.captureRawShape(arena, replacementSym, 0, []stackEntry{
+	macro.rawShape = parser.captureRawShape(nil, arena, replacementSym, 0, []stackEntry{
 		newStackEntryNode(0, macroA),
 		newStackEntryNode(0, macroB),
 	}, 0, 2)
@@ -238,14 +238,14 @@ func TestForestChildAlternativeResolutionUsesLocalSameSpanBest(t *testing.T) {
 	callB := newLeafNodeInArena(arena, partBSym, true, 1, 2, Point{Column: 1}, Point{Column: 2})
 	callC := newLeafNodeInArena(arena, partCSym, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	call := newParentNodeInArena(arena, callSym, true, []*Node{callA, callB, callC}, nil, 0)
-	call.rawShape = parser.captureRawShape(arena, replacementSym, 0, []stackEntry{
+	call.rawShape = parser.captureRawShape(nil, arena, replacementSym, 0, []stackEntry{
 		newStackEntryNode(0, callA),
 		newStackEntryNode(0, callB),
 		newStackEntryNode(0, callC),
 	}, 0, 3)
 
 	root := newParentNodeInArena(arena, rootSym, true, []*Node{call}, nil, 0)
-	root.rawShape = parser.captureRawShape(arena, rootSym, 0, []stackEntry{newStackEntryNode(0, call)}, 0, 1)
+	root.rawShape = parser.captureRawShape(nil, arena, rootSym, 0, []stackEntry{newStackEntryNode(0, call)}, 0, 1)
 
 	local := &gssForestNode{
 		state:      42,
@@ -310,7 +310,7 @@ func TestForestChildAlternativeResolutionRejectsIncompatibleSiblingPath(t *testi
 	macroA := newLeafNodeInArena(arena, partASym, true, 0, 1, Point{}, Point{Column: 1})
 	macroB := newLeafNodeInArena(arena, partBSym, true, 1, 2, Point{Column: 1}, Point{Column: 2})
 	macro := newParentNodeInArena(arena, macroCallSym, true, []*Node{macroA, macroB}, nil, 0)
-	macro.rawShape = parser.captureRawShape(arena, replacementSym, 0, []stackEntry{
+	macro.rawShape = parser.captureRawShape(nil, arena, replacementSym, 0, []stackEntry{
 		newStackEntryNode(0, macroA),
 		newStackEntryNode(0, macroB),
 	}, 0, 2)
@@ -318,14 +318,14 @@ func TestForestChildAlternativeResolutionRejectsIncompatibleSiblingPath(t *testi
 	callA := newLeafNodeInArena(arena, partASym, true, 0, 1, Point{}, Point{Column: 1})
 	callC := newLeafNodeInArena(arena, partCSym, true, 1, 2, Point{Column: 1}, Point{Column: 2})
 	call := newParentNodeInArena(arena, callSym, true, []*Node{callA, callC}, nil, 0)
-	call.rawShape = parser.captureRawShape(arena, replacementSym, 0, []stackEntry{
+	call.rawShape = parser.captureRawShape(nil, arena, replacementSym, 0, []stackEntry{
 		newStackEntryNode(0, callA),
 		newStackEntryNode(0, callC),
 	}, 0, 2)
 
 	sibling := newLeafNodeInArena(arena, siblingSym, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	root := newParentNodeInArena(arena, rootSym, true, []*Node{call, sibling}, nil, 0)
-	root.rawShape = parser.captureRawShape(arena, rootSym, 0, []stackEntry{
+	root.rawShape = parser.captureRawShape(nil, arena, rootSym, 0, []stackEntry{
 		newStackEntryNode(0, call),
 		newStackEntryNode(0, sibling),
 	}, 0, 2)
@@ -391,7 +391,7 @@ func TestForestChildAlternativeResolutionPreservesVisibleNamedUnaryWrapper(t *te
 	call := newParentNodeInArena(arena, callSym, true, []*Node{target}, nil, 0)
 	guard := newParentNodeInArena(arena, guardSym, true, []*Node{call}, nil, 0)
 	root := newParentNodeInArena(arena, rootSym, true, []*Node{guard}, nil, 0)
-	root.rawShape = parser.captureRawShape(arena, rootSym, 0, []stackEntry{newStackEntryNode(0, guard)}, 0, 1)
+	root.rawShape = parser.captureRawShape(nil, arena, rootSym, 0, []stackEntry{newStackEntryNode(0, guard)}, 0, 1)
 
 	alternatives := newForestAlternativeIndex(4)
 	alternatives.nodes[guard] = &gssForestNode{state: 10}
@@ -430,7 +430,7 @@ func TestForestChildAlternativeResolutionPreservesVisibleContainerOverHiddenFlat
 	groupA := newLeafNodeInArena(arena, partASym, true, 0, 2, Point{}, Point{Column: 2})
 	groupB := newLeafNodeInArena(arena, partBSym, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	group := newParentNodeInArena(arena, groupSym, true, []*Node{groupA, groupB}, nil, 0)
-	group.rawShape = parser.captureRawShape(arena, groupSym, 0, []stackEntry{
+	group.rawShape = parser.captureRawShape(nil, arena, groupSym, 0, []stackEntry{
 		newStackEntryNode(0, groupA),
 		newStackEntryNode(0, groupB),
 	}, 0, 2)
@@ -438,13 +438,13 @@ func TestForestChildAlternativeResolutionPreservesVisibleContainerOverHiddenFlat
 	repeatA := newLeafNodeInArena(arena, partASym, true, 0, 2, Point{}, Point{Column: 2})
 	repeatB := newLeafNodeInArena(arena, partBSym, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	flatRepeat := newParentNodeInArena(arena, repeatSym, false, []*Node{repeatA, repeatB}, nil, 0)
-	flatRepeat.rawShape = parser.captureRawShape(arena, repeatSym, 0, []stackEntry{
+	flatRepeat.rawShape = parser.captureRawShape(nil, arena, repeatSym, 0, []stackEntry{
 		newStackEntryNode(0, repeatA),
 		newStackEntryNode(0, repeatB),
 	}, 0, 2)
 
 	root := newParentNodeInArena(arena, rootSym, true, []*Node{group}, nil, 0)
-	root.rawShape = parser.captureRawShape(arena, rootSym, 0, []stackEntry{newStackEntryNode(42, group)}, 0, 1)
+	root.rawShape = parser.captureRawShape(nil, arena, rootSym, 0, []stackEntry{newStackEntryNode(42, group)}, 0, 1)
 
 	prev := &gssForestNode{state: 7}
 	local := &gssForestNode{
@@ -539,8 +539,8 @@ func TestAcceptedStackSelectionUsesDynamicPrecedenceBeforeRawShape(t *testing.T)
 	rawWorseLeaf := newLeafNodeInArena(arena, 4, true, 0, 1, Point{}, Point{Column: 1})
 	rawPreferredRoot := newParentNodeInArena(arena, 1, true, []*Node{rawPreferredLeaf}, nil, 0)
 	dynamicPreferredRoot := newParentNodeInArena(arena, 1, true, []*Node{rawWorseLeaf}, nil, 0)
-	rawPreferredRoot.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, rawPreferredLeaf)}, 0, 1)
-	dynamicPreferredRoot.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, rawWorseLeaf)}, 0, 1)
+	rawPreferredRoot.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, rawPreferredLeaf)}, 0, 1)
+	dynamicPreferredRoot.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, rawWorseLeaf)}, 0, 1)
 	dynamicPreferredRoot.dynamicPrecedence = 7
 
 	dynamicPreferred := glrStack{
@@ -603,13 +603,13 @@ func testGeneratedRepeatBoundaryStacks(t *testing.T, generated bool) (*Parser, *
 	tail := newLeafNodeInArena(arena, 3, true, 900, 1005, Point{Row: 20}, Point{Row: 24})
 
 	shortRepeat := newParentNodeInArena(arena, 2, false, []*Node{first, second}, nil, 0)
-	shortRepeat.rawShape = parser.captureRawShape(arena, 2, 0, []stackEntry{
+	shortRepeat.rawShape = parser.captureRawShape(nil, arena, 2, 0, []stackEntry{
 		newStackEntryNode(0, first),
 		newStackEntryNode(0, second),
 	}, 0, 2)
 
 	wideRepeat := newParentNodeInArena(arena, 2, false, []*Node{shortRepeat, tail}, nil, 0)
-	wideRepeat.rawShape = parser.captureRawShape(arena, 2, 0, []stackEntry{
+	wideRepeat.rawShape = parser.captureRawShape(nil, arena, 2, 0, []stackEntry{
 		newStackEntryNode(0, shortRepeat),
 		newStackEntryNode(0, tail),
 	}, 0, 2)
@@ -619,14 +619,14 @@ func testGeneratedRepeatBoundaryStacks(t *testing.T, generated bool) (*Parser, *
 	shortRoot.endByte = 1005
 	shortRoot.startPoint = Point{}
 	shortRoot.endPoint = Point{Row: 24}
-	shortRoot.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, shortRepeat)}, 0, 1)
+	shortRoot.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, shortRepeat)}, 0, 1)
 
 	wideRoot := newParentNodeInArena(arena, 1, true, []*Node{wideRepeat}, nil, 0)
 	wideRoot.startByte = 0
 	wideRoot.endByte = 1005
 	wideRoot.startPoint = Point{}
 	wideRoot.endPoint = Point{Row: 24}
-	wideRoot.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, wideRepeat)}, 0, 1)
+	wideRoot.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, wideRepeat)}, 0, 1)
 
 	shorter := glrStack{
 		accepted:    true,
@@ -673,13 +673,13 @@ func TestAcceptedStackSelectionPrefersSharedPrefixSpliceBeforeRawShape(t *testin
 	splicedC := newLeafNodeInArena(arena, 6, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	splicedRoot := newParentNodeInArena(arena, 1, true, []*Node{splicedA, splicedB, splicedC}, nil, 0)
 
-	wrap.rawShape = parser.captureRawShape(arena, 2, 0, []stackEntry{
+	wrap.rawShape = parser.captureRawShape(nil, arena, 2, 0, []stackEntry{
 		newStackEntryNode(0, wrappedA),
 		newStackEntryNode(0, wrappedB),
 		newStackEntryNode(0, wrappedC),
 	}, 0, 3)
-	wrappedRoot.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(0, wrap)}, 0, 1)
-	splicedRoot.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{
+	wrappedRoot.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(0, wrap)}, 0, 1)
+	splicedRoot.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{
 		newStackEntryNode(0, splicedA),
 		newStackEntryNode(0, splicedB),
 		newStackEntryNode(0, splicedC),
@@ -1041,13 +1041,13 @@ func testSemanticInvisibleWrapperRawShapeStacks(t *testing.T, arena *nodeArena, 
 	splicedC := newLeafNodeInArena(arena, rawShapeSemanticCSplice, true, 2, 4, Point{Column: 2}, Point{Column: 4})
 	splicedRoot := newParentNodeInArena(arena, rawShapeSemanticRootSym, true, []*Node{splicedA, splicedB, splicedC}, nil, 0)
 
-	wrap.rawShape = parser.captureRawShape(arena, rawShapeSemanticWrapSym, rawShapeSemanticWrapPID, []stackEntry{
+	wrap.rawShape = parser.captureRawShape(nil, arena, rawShapeSemanticWrapSym, rawShapeSemanticWrapPID, []stackEntry{
 		newStackEntryNode(0, wrappedA),
 		newStackEntryNode(0, wrappedB),
 		newStackEntryNode(0, wrappedC),
 	}, 0, 3)
-	wrappedRoot.rawShape = parser.captureRawShape(arena, rawShapeSemanticRootSym, 0, []stackEntry{newStackEntryNode(0, wrap)}, 0, 1)
-	splicedRoot.rawShape = parser.captureRawShape(arena, rawShapeSemanticRootSym, 0, []stackEntry{
+	wrappedRoot.rawShape = parser.captureRawShape(nil, arena, rawShapeSemanticRootSym, 0, []stackEntry{newStackEntryNode(0, wrap)}, 0, 1)
+	splicedRoot.rawShape = parser.captureRawShape(nil, arena, rawShapeSemanticRootSym, 0, []stackEntry{
 		newStackEntryNode(0, splicedA),
 		newStackEntryNode(0, splicedB),
 		newStackEntryNode(0, splicedC),
@@ -1074,7 +1074,7 @@ func TestDynamicPrecedencePropagatesThroughCompactMaterialization(t *testing.T) 
 	parser := testRawShapeParser()
 
 	leaf := newCompactFullLeafInArena(arena, 3, true, 0, 1, Point{}, Point{Column: 1})
-	leaf.rawShape = parser.captureRawShape(arena, 3, 0, []stackEntry{newStackEntryNode(0, newLeafNodeInArena(arena, 4, true, 0, 1, Point{}, Point{Column: 1}))}, 0, 1)
+	leaf.rawShape = parser.captureRawShape(nil, arena, 3, 0, []stackEntry{newStackEntryNode(0, newLeafNodeInArena(arena, 4, true, 0, 1, Point{}, Point{Column: 1}))}, 0, 1)
 	leaf.dynamicPrecedence = 11
 	leafEntry := newStackEntryCompactFullLeaf(1, leaf)
 	leafNode := materializeStackEntryCompactFullLeaf(arena, &leafEntry, compactFullLeafMaterializeForFinalTree)
@@ -1089,7 +1089,7 @@ func TestDynamicPrecedencePropagatesThroughCompactMaterialization(t *testing.T) 
 	}
 
 	parent := newPendingParentInArena(arena, 1, true, 0, []stackEntry{leafEntry}, 0, 1, Point{}, Point{Column: 1}, false)
-	parent.rawShape = parser.captureRawShape(arena, 1, 0, []stackEntry{leafEntry}, 0, 1)
+	parent.rawShape = parser.captureRawShape(nil, arena, 1, 0, []stackEntry{leafEntry}, 0, 1)
 	parent.dynamicPrecedence = 13
 	parentEntry := newStackEntryPendingParent(1, parent)
 	parentNode := materializeStackEntryPendingParent(arena, &parentEntry, pendingParentMaterializeForFinalTree)
@@ -1111,7 +1111,7 @@ func TestDynamicPrecedencePropagatesThroughPendingFinalChildRefs(t *testing.T) {
 
 	child := newLeafNodeInArena(arena, 3, true, 0, 1, Point{}, Point{Column: 1})
 	parent := newPendingParentInArena(arena, 1, true, 0, []stackEntry{newStackEntryNode(1, child)}, 0, 1, Point{}, Point{Column: 1}, false)
-	parent.rawShape = testRawShapeParser().captureRawShape(arena, 1, 0, []stackEntry{newStackEntryNode(1, child)}, 0, 1)
+	parent.rawShape = testRawShapeParser().captureRawShape(nil, arena, 1, 0, []stackEntry{newStackEntryNode(1, child)}, 0, 1)
 	parent.dynamicPrecedence = 17
 	parentEntry := newStackEntryPendingParent(1, parent)
 	parentNode := materializeStackEntryPendingParent(arena, &parentEntry, pendingParentMaterializeForFinalTree)
@@ -1240,7 +1240,7 @@ func TestRawShapePropagatesThroughNoTreeAndCollapsedUnary(t *testing.T) {
 	}
 
 	entry := entries[0]
-	raw := captureCollapsedUnaryRawShape(arena, ParseAction{Symbol: 2, ProductionID: 9}, entries, 1)
+	raw := captureCollapsedUnaryRawShape(nil, arena, ParseAction{Symbol: 2, ProductionID: 9}, entries, 1)
 	setStackEntryRawShapeRef(&entry, raw)
 	shape, ok = rawShapeForStackEntry(arena, entry)
 	if !ok {

--- a/transient_children_test.go
+++ b/transient_children_test.go
@@ -629,17 +629,17 @@ func TestTransientScratchCheckpointRetargetsNestedRawShapeNodesBeforeSlabReuse(t
 
 	leaf := newLeafNodeInArena(arena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
 	rawGrandchild := scratch.transientParents.allocParent(arena, Symbol(2), true, nil, 0, false)
-	rawGrandchild.rawShape = parser.captureRawShape(arena, Symbol(2), 0, []stackEntry{
+	rawGrandchild.rawShape = parser.captureRawShape(nil, arena, Symbol(2), 0, []stackEntry{
 		newStackEntryNode(1, leaf),
 	}, 0, 1)
 	rawChild := scratch.transientParents.allocParent(arena, Symbol(3), true, nil, 0, false)
-	rawChild.rawShape = parser.captureRawShape(arena, Symbol(3), 0, []stackEntry{
+	rawChild.rawShape = parser.captureRawShape(nil, arena, Symbol(3), 0, []stackEntry{
 		newStackEntryNode(2, rawGrandchild),
 	}, 0, 1)
 	semanticChildren := scratch.transientChildren.alloc(1)
 	semanticChildren[0] = leaf
 	liveParent := scratch.transientParents.allocParent(arena, Symbol(4), true, semanticChildren, 0, false)
-	liveParent.rawShape = parser.captureRawShape(arena, Symbol(4), 0, []stackEntry{
+	liveParent.rawShape = parser.captureRawShape(nil, arena, Symbol(4), 0, []stackEntry{
 		newStackEntryNode(3, rawChild),
 	}, 0, 1)
 	wantRootChildShape := rawChild.rawShape


### PR DESCRIPTION
## Summary

Raw-shape capture and content hashing (~8% of canonical full-parse CPU per the pinned quiet-host profile) are pure write-only work on parses that never fork: every raw-shape reader is gated on fork, forest, recovery, checkpoint-recycle, or diagnostics. This elides capture while a parse has only ever had a single GLR stack and has not entered error recovery.

Mechanism: `captureRawShape` takes the GSS scratch and skips as its first line when `singleStackMode && !everForked` — one choke point covering all production call sites. `everForked` is a sticky per-parse latch set at every single-stack-mode writer, explicitly at the conflict-fork decision point (fork stacks can reduce within the deciding iteration), and at the `cHandleError` recovery funnel (recovery both spawns versions and reads shapes; latching at entry protects the entire episode including later re-collapse).

Safety story, adversarially reviewed and then strengthened: memory safety was confirmed on all six review angles (readers nil-guarded, all-or-nothing per node). Behavior preservation does **not** rest on the materialized comparison fallback being sign-preserving — an included abstract test proves it is not in isolation. It rests on structural pointer-sharing: any node built while elision is active predates the parse's first fork/recovery event and is therefore only ever compared to itself. Evidenced by:
- a forced-descent differential (shared root symbol, hidden-child pre/post-flatten count mismatch, comparison descends into the elided prefix): identical trees gate-on vs gate-off;
- a recovery differential (C-recovery entered from a single-stack prefix): identical trees;
- the original pure-single-stack and prefix-then-fork differentials.

A diagnostics toggle (`SetRawShapeElisionDisabledForDiagnostics`, matching existing plain-bool toggle precedent) forces pre-change capture for A/B work.

## Verification

- `go build ./...`, `go vet ./...` — clean; full root suite ok; RawShape/Forest/Recover/Incremental focused suites pass; `-race` over Recover/RawShape/GSS clean.
- Reclaim accounting gates updated: nonzero raw-shape bytes now asserted on a genuinely forking grammar; new zero-bytes assertion for single-stack parses; breakdown-sum invariant balanced.
- Quiet-host receipt (pinned core, count=10): full parse 12.246 → 11.654 ms, **2.142x → 2.039x C**, allocations unchanged (9/0/0); incremental lanes neutral. Toggle-isolated contended A/B: −7.46% (p=0.015) post-recovery-gate, consistent with −7.90% pre-gate.