### PR TITLE
refactor(parser_result): migrate collapsed-named-leaf adapters to the rules table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,30 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- Collapsed-named-leaf compat adapters for Kotlin, Hack, Dart, and Elixir
+  moved onto the data-driven `resultCollapsedNamedLeafRules` table
+  (previously data-driven for Ruby and Apex only): Kotlin's
+  `identifier -> simple_identifier`, Hack's `true`/`false`/`null` literal
+  wrappers, Dart's `super`/`this`, and Elixir's `nil` are now table rows
+  instead of hand-written adapter functions. The table gained a `bySource`
+  column so a row can pick the source-text-verified matcher
+  (`normalizeCollapsedNamedLeafChildrenBySource`, needed when the
+  collapsed span must be confirmed before a child is attached) instead of
+  the plain structural one. Hack's dedicated compat file and switch arm
+  are retired entirely (all three of its rules were table-eligible); Dart
+  and Elixir keep their compat functions for unrelated rewrites but lose
+  the adapter that only fired these rules. Net ~37 lines of per-language
+  adapter code retired in favor of ~7 declarative table rows. Haskell's
+  `wildcard -> "_"` was evaluated for the same migration but left
+  in place: the anonymous token name `"_"` collides with the special
+  query-wildcard sentinel in `Language.symbolByNameAndNamed`/`SymbolByName`
+  (both short-circuit to `(0, true)` for `name == "_"`), so migrating it
+  through the shared table resolves the child to `Symbol(0)` (EOF) instead
+  of the real anonymous `_` token; OCaml, HCL, and Rust were left
+  unmigrated too (OCaml's and most of HCL's rules need multi-candidate
+  source disambiguation the one-parent/one-child schema doesn't represent,
+  and HCL/Rust also fold their collapse checks into a single perf-tuned
+  tree walk that per-rule table entries would fragment).
 - Real-corpus parity floors regenerated against lock-pinned corpora:
   55 grammars, 851/1026 deep parity, including first-ever bash and dart
   rows; the docker wrapper's default skip list shrinks to OCaml only.

--- a/parser_result_collapsed_helpers.go
+++ b/parser_result_collapsed_helpers.go
@@ -16,6 +16,14 @@ type collapsedNamedLeafRule struct {
 	languageName string
 	parentName   string
 	childName    string
+	// bySource selects the source-verified matcher
+	// (normalizeCollapsedNamedLeafChildrenBySource) instead of the plain
+	// structural matcher (normalizeCollapsedNamedLeafChildren). Use this when
+	// the parent's collapsed span must be confirmed to actually read as
+	// childName before the child is attached (e.g. the parent symbol is
+	// shared with unrelated collapsed shapes, or the rule was ported from a
+	// language-specific adapter that verified source text).
+	bySource bool
 }
 
 var resultCollapsedNamedLeafRules = []collapsedNamedLeafRule{
@@ -44,14 +52,33 @@ var resultCollapsedNamedLeafRules = []collapsedNamedLeafRule{
 	{languageName: "apex", parentName: "undelete", childName: "undelete"},
 	{languageName: "apex", parentName: "upsert", childName: "upsert"},
 	{languageName: "apex", parentName: "user", childName: "user"},
+	// Kotlin's `identifier` is sep1 of `simple_identifier` by "."; a
+	// single-element identifier (e.g. `import benchmarks.*`) collapses to a
+	// leaf in Go but C always materializes the simple_identifier child.
+	{languageName: "kotlin", parentName: "identifier", childName: "simple_identifier"},
+	// Hack's true/false/null literals wrap the identically-named anonymous
+	// keyword token (`true -> 'true'`, etc.); Go collapses the lone child.
+	{languageName: "hack", parentName: "true", childName: "true", bySource: true},
+	{languageName: "hack", parentName: "false", childName: "false", bySource: true},
+	{languageName: "hack", parentName: "null", childName: "null", bySource: true},
+	// Dart's `super`/`this` wrap the identically-named anonymous keyword
+	// token; Go collapses the lone child, C keeps it.
+	{languageName: "dart", parentName: "super", childName: "super", bySource: true},
+	{languageName: "dart", parentName: "this", childName: "this", bySource: true},
+	// Elixir's `nil` wraps the identically-named anonymous keyword token.
+	{languageName: "elixir", parentName: "nil", childName: "nil", bySource: true},
 }
 
-func normalizeResultCollapsedNamedLeafChildren(root *Node, lang *Language) {
+func normalizeResultCollapsedNamedLeafChildren(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil {
 		return
 	}
 	for _, rule := range resultCollapsedNamedLeafRules {
 		if rule.languageName != lang.Name {
+			continue
+		}
+		if rule.bySource {
+			normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, rule.parentName, rule.childName)
 			continue
 		}
 		normalizeCollapsedNamedLeafChildren(root, lang, rule.parentName, rule.childName)

--- a/parser_result_collapsed_helpers_test.go
+++ b/parser_result_collapsed_helpers_test.go
@@ -103,7 +103,7 @@ func TestNormalizeResultCollapsedNamedLeafChildrenApexKeywordWrapper(t *testing.
 	superNode := newLeafNodeInArena(arena, 2, true, 621, 626, Point{Row: 0, Column: 621}, Point{Row: 0, Column: 626})
 	root := newParentNodeInArena(arena, 1, true, []*Node{superNode}, nil, 0)
 
-	normalizeResultCollapsedNamedLeafChildren(root, lang)
+	normalizeResultCollapsedNamedLeafChildren(root, nil, lang)
 
 	if got, want := superNode.ChildCount(), 1; got != want {
 		t.Fatalf("super.ChildCount() = %d, want %d", got, want)

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -52,7 +52,7 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCo
 		result.stopReason = terminalReason
 		return result
 	}
-	normalizeResultCollapsedNamedLeafChildren(root, lang)
+	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
 	result.stopReason = ctx.stopReason()
 	return result
 }
@@ -155,8 +155,6 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		return resultCompatibilityResult{stopReason: normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)}
 	case "gitcommit":
 		normalizeGitcommitCompatibility(ctx.root, ctx.source, ctx.lang)
-	case "hack":
-		normalizeHackCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "haskell":
 		normalizeHaskellCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "hcl":

--- a/parser_result_dart.go
+++ b/parser_result_dart.go
@@ -5,17 +5,8 @@ func normalizeDartCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeDartSingleTypeArgumentFreeCalls(root, lang)
 	normalizeDartComplexTypeArgumentRelationalFreeCalls(root, lang)
 	normalizeDartSwitchExpressionBodyFields(root, lang)
-	normalizeDartCollapsedLeafChildren(root, source, lang)
 	normalizeDartNestedComplexTypeArgumentRelationalCalls(root, lang)
 	normalizeDartComplexTypeArgumentFreeCalls(root, source, lang)
-}
-
-func normalizeDartCollapsedLeafChildren(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "dart" || len(source) == 0 {
-		return
-	}
-	normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, "super", "super")
-	normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, "this", "this")
 }
 
 func normalizeDartSingleTypeArgumentFreeCalls(root *Node, lang *Language) {

--- a/parser_result_dart_test.go
+++ b/parser_result_dart_test.go
@@ -76,6 +76,15 @@ func TestNormalizeDartCollapsedLeafChildrenRestoresDartWrappers(t *testing.T) {
 	// TestDartNullableTypeAndNullLiteralRestoreAnonymousChildren in grammars/),
 	// so finalNode/negationNode/relOpNode/gtNode/nullableNode/nullNode above
 	// stay untouched by this call.
+	//
+	// "super"/"this" are also NOT asserted via normalizeDartCompatibility
+	// anymore: the former normalizeDartCollapsedLeafChildren adapter was
+	// removed and its two rules moved into resultCollapsedNamedLeafRules
+	// (parser_result_collapsed_helpers.go), applied by
+	// normalizeResultCollapsedNamedLeafChildren for every language rather than
+	// from inside normalizeDartCompatibility. Exercise that shared entry point
+	// directly here to keep the coverage.
+	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
 	assertCollapsedKeywordChild(t, superNode, lang, "super")
 	assertCollapsedKeywordChild(t, thisNode, lang, "this")
 }

--- a/parser_result_elixir.go
+++ b/parser_result_elixir.go
@@ -6,7 +6,6 @@ func normalizeElixirCompatibility(root *Node, source []byte, lang *Language) {
 	}
 	normalizeElixirNewlineBeforeCommentExtras(root, lang)
 	normalizeElixirNestedCallTargetFields(root, lang)
-	normalizeElixirCollapsedLiteralChildren(root, source, lang)
 	normalizeElixirMapContentKeywordPairs(root, lang)
 	normalizeElixirMapContentBinaryOperators(root, lang)
 }
@@ -79,10 +78,6 @@ func normalizeElixirNestedCallTargetFields(root *Node, lang *Language) {
 			}
 		}
 	})
-}
-
-func normalizeElixirCollapsedLiteralChildren(root *Node, source []byte, lang *Language) {
-	normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, "nil", "nil")
 }
 
 func normalizeElixirMapContentKeywordPairs(root *Node, lang *Language) {

--- a/parser_result_elixir_test.go
+++ b/parser_result_elixir_test.go
@@ -47,6 +47,14 @@ func TestNormalizeElixirCollapsedLiteralChildren(t *testing.T) {
 	// unconditionally on real parses (see
 	// TestElixirBooleanKeepsTrueTokenChildViaEngine in grammars/), so
 	// falseNode/trueNode above stay untouched by this call.
+	//
+	// "nil" is also NOT restored by normalizeElixirCompatibility anymore: the
+	// normalizeElixirCollapsedLiteralChildren adapter was removed and its rule
+	// moved into resultCollapsedNamedLeafRules
+	// (parser_result_collapsed_helpers.go), applied by
+	// normalizeResultCollapsedNamedLeafChildren for every language. Exercise
+	// that shared entry point directly to keep the coverage.
+	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
 	assertCollapsedKeywordChild(t, nilNode, lang, "nil")
 }
 

--- a/parser_result_hack.go
+++ b/parser_result_hack.go
@@ -1,7 +1,0 @@
-package gotreesitter
-
-func normalizeHackCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, "true", "true")
-	normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, "false", "false")
-	normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, "null", "null")
-}

--- a/parser_result_hack_test.go
+++ b/parser_result_hack_test.go
@@ -2,6 +2,13 @@ package gotreesitter
 
 import "testing"
 
+// Hack's true/false/null literal-wrapper rules used to live in a dedicated
+// normalizeHackCompatibility adapter (parser_result_hack.go, now removed).
+// They are data-driven now: see the "hack" entries in
+// resultCollapsedNamedLeafRules (parser_result_collapsed_helpers.go), applied
+// by normalizeResultCollapsedNamedLeafChildren for every language. The tests
+// below exercise that shared entry point directly.
+
 func TestNormalizeHackBooleanLiteralsRestoreTokenChildren(t *testing.T) {
 	lang := &Language{
 		Name:        "hack",
@@ -21,7 +28,7 @@ func TestNormalizeHackBooleanLiteralsRestoreTokenChildren(t *testing.T) {
 	falseNode := newLeafNodeInArena(arena, 3, true, 5, 10, Point{Column: 5}, Point{Column: 10})
 	root := newParentNodeInArena(arena, 1, true, []*Node{trueNode, falseNode}, nil, 0)
 
-	normalizeHackCompatibility(root, source, lang)
+	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
 
 	if got, want := trueNode.ChildCount(), 1; got != want {
 		t.Fatalf("true child count = %d, want %d", got, want)
@@ -59,7 +66,7 @@ func TestNormalizeHackNullLiteralRestoresTokenChild(t *testing.T) {
 	nullNode := newLeafNodeInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
 	root := newParentNodeInArena(arena, 1, true, []*Node{nullNode}, nil, 0)
 
-	normalizeHackCompatibility(root, source, lang)
+	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
 
 	if got, want := nullNode.ChildCount(), 1; got != want {
 		t.Fatalf("null child count = %d, want %d", got, want)

--- a/parser_result_haskell.go
+++ b/parser_result_haskell.go
@@ -34,6 +34,18 @@ func normalizeHaskellCollapsedNamedLeafChildren(root *Node, source []byte, lang 
 	})
 }
 
+// haskellCollapsedNamedLeafChildren cannot fully migrate to
+// resultCollapsedNamedLeafRules (parser_result_collapsed_helpers.go):
+// "deriving_strategy" has 3 candidate children (stock/anyclass/via), which
+// the plain one-parent-one-child table schema doesn't represent. "wildcard"
+// does reduce to a single-candidate name-pair ("_"), but the anonymous token
+// name "_" collides with the special-cased query wildcard sentinel baked
+// into Language.symbolByNameAndNamed/SymbolByName (both return (0, true) for
+// name == "_" unconditionally, for tree-sitter query "any node" matching)
+// which the shared normalizeCollapsedNamedLeafChildren(BySource) helpers use
+// for symbol lookup. Migrating "wildcard" through the generic mechanism
+// resolves its child to Symbol(0) (EOF) instead of the real anonymous "_"
+// token, so it stays here where symbol lookup walks SymbolMetadata directly.
 var haskellCollapsedNamedLeafChildren = map[string][]string{
 	"deriving_strategy": {"stock", "anyclass", "via"},
 	"wildcard":          {"_"},

--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -8,7 +8,6 @@ func normalizeKotlinCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeKotlinGenericCallTypeArguments(root, source, lang)
 	normalizeKotlinPrefixComparisonExpressions(root, source, lang)
 	normalizeKotlinRawStringTrailingContent(root, source, lang)
-	normalizeKotlinCollapsedIdentifierChildren(root, source, lang)
 	normalizeKotlinCallableReferenceNavigations(root, source, lang)
 	normalizeKotlinReceiverFunctionNames(root, source, lang)
 	normalizeKotlinSourceFileLeadingTriviaStart(root, source, lang)
@@ -550,18 +549,6 @@ func normalizeKotlinCallableReferenceNavigations(root *Node, source []byte, lang
 		n.productionID = 0
 		populateParentNode(n, n.children)
 	})
-}
-
-// normalizeKotlinCollapsedIdentifierChildren restores the simple_identifier
-// child of a single-element `identifier` node (identifier is sep1 of
-// simple_identifier by "."): C tree-sitter always materializes the child
-// (e.g. in `import benchmarks.*` the identifier wraps one simple_identifier),
-// while the Go collapse logic strips lone children.
-func normalizeKotlinCollapsedIdentifierChildren(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "kotlin" || len(source) == 0 {
-		return
-	}
-	normalizeCollapsedNamedLeafChildren(root, lang, "identifier", "simple_identifier")
 }
 
 // normalizeKotlinSourceFileLeadingTriviaStart restores the C-aligned root

--- a/parser_result_kotlin_test.go
+++ b/parser_result_kotlin_test.go
@@ -81,13 +81,17 @@ func kotlinLeadingTriviaTestLanguage() *Language {
 func TestNormalizeKotlinCollapsedIdentifierChildren(t *testing.T) {
 	lang := kotlinLeadingTriviaTestLanguage()
 	// Mirrors `import benchmarks.*`: a single-element identifier must wrap a
-	// simple_identifier child, as in C tree-sitter.
+	// simple_identifier child, as in C tree-sitter. This rule now lives in
+	// resultCollapsedNamedLeafRules (parser_result_collapsed_helpers.go) and
+	// runs via normalizeResultCollapsedNamedLeafChildren for every language;
+	// the former normalizeKotlinCollapsedIdentifierChildren adapter (called
+	// from normalizeKotlinCompatibility) was removed.
 	source := []byte("import benchmarks.*")
 	arena := newNodeArena(arenaClassFull)
 	identifier := newLeafNodeInArena(arena, 3, true, 7, 17, Point{Column: 7}, Point{Column: 17})
 	root := newParentNodeInArena(arena, 1, true, []*Node{identifier}, nil, 0)
 
-	normalizeKotlinCompatibility(root, source, lang)
+	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
 
 	if got, want := identifier.ChildCount(), 1; got != want {
 		t.Fatalf("identifier child count = %d, want %d", got, want)


### PR DESCRIPTION
## Summary

First T1 cut of the compat-tier sunset plan: the collapsed-named-leaf mechanism already had a data-driven rules table (`resultCollapsedNamedLeafRules`, previously used by ruby and apex only); this migrates four more languages onto it and extends the schema with a `bySource` variant for rules that verify source text before reattaching the anonymous child.

- **Migrated fully:** kotlin (plain row), hack (3 bySource rows — `parser_result_hack.go` deleted entirely along with its dispatch arm), dart (2 rows), elixir (1 row). ~37 lines of per-language adapter code replaced by 8 declarative rows.
- **Left hand-written, with reasons documented in-code:** haskell — `SymbolByName("_")` is special-cased as the query engine's any-node wildcard sentinel, so the shared helper resolves the anonymous `_` token to Symbol(0)/EOF (caught by a real test failure; noteworthy trap for any future "_"-token migration); ocaml — all rules need multi-candidate source disambiguation the schema doesn't hold; hcl — rules share one root-type-guarded combined walk; rust — pass is gated by zero-allocation substring-presence flags the generic mechanism would defeat.

## Verification

- `go build ./...`, `go vet ./...` — clean
- Focused languages + mechanism: 81 tests pass, 0 fail
- Full root suite ok (10.1s); full grammars package incl. byte-identity/golden snapshots and the engine-level keyword-child regression tests ok (45.7s)
- Changelog entry included under Unreleased