### PR TITLE
release: v0.27.0 — layered containment and canonical-parse levers

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -56,6 +56,14 @@ the allocation counts — 9 allocs/op for a fully materialized parse, zero for
 both incremental lanes — and the materialization attribution: full minus
 core ≈ 3.5 ms ≈ 29% of full-parse time on this host.
 
+### v0.27.0 combined receipt
+
+Same host, same pinned core, C baseline re-measured in the same session
+(5.756 ms): full parse median 10.907 ms = **1.895x C** (from 2.142x at the
+prior receipt — single-stack raw-shape elision plus supertype hidden-choice
+collapse, stacked), 9 allocs/op; one-byte edit 1.95 µs and no-edit reparse
+9.8 ns, both zero-alloc.
+
 ### Same-host C calibration (what makes wall-clock comparable)
 
 The C baselines (`BenchmarkCTreeSitterGoParse*`, via the go-tree-sitter cgo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-07-12
+
+Containment and canonical-parse-lever release. Memory-budget enforcement is
+now layered (volume-triggered polling, in-merge checks, and an absolute hard
+ceiling) so runaway parses stop instead of ballooning, while certified
+bounded-overshoot witnesses still complete. Two independent hot-path levers
+land together: single-stack raw-shape elision and supertype hidden-choice
+collapse. Combined same-host receipt on the canonical Go workload: full
+parse 12.25 ms to 10.91 ms — 2.14x to **1.89x** the C runtime measured in
+the same session — with allocations unchanged (9 per full parse, zero on
+both incremental lanes). The compat tier continues shrinking, the field-map
+generation ceiling is lifted (Bash and Dart now carry real-corpus floor
+rows), and parity floors are reproducible against lock-pinned corpora.
+
 ### Added
 
 - Memory-budget containment is now layered: volume-triggered polling


### PR DESCRIPTION
## Summary

Cuts v0.27.0. Release theme: layered memory-budget containment (volume-triggered polling, in-merge checks, hard ceiling — runaway parses stop, certified bounded-overshoot witnesses still complete) plus the first two canonical-ratio perf levers (single-stack raw-shape elision, supertype hidden-choice collapse), the continuing compat-tier retirement, the lifted field-map generation ceiling with first Bash/Dart floor rows, and reproducible lock-pinned parity floors.

Combined quiet-host receipt recorded in BENCH.md: canonical full parse 12.25 → 10.91 ms, **2.14x → 1.89x C** (C baseline re-measured same session), allocations unchanged 9/0/0.

Post-merge: tag `v0.27.0` on the merge commit.