### PR TITLE
fix(parser): honor the memory budget in the Go compat-normalization walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- The Go compat-normalization walk now honors the parse memory budget: it
+  is skipped when the parse already carries a budget stop, polls the
+  runtime budget at its existing walk stride, and surfaces the stop reason
+  on the final tree via a sticky trip flag. Previously the walk ran
+  budget-blind at result finalization and could balloon on recovered
+  trees after the parse loop had stopped cleanly. Clean-parse trees are
+  byte-identical. The JS/TS fused walk has the same blind spot (no stop
+  polling at all) and is tracked separately.
+
 ## [0.27.0] - 2026-07-12
 
 Containment and canonical-parse-lever release. Memory-budget enforcement is

--- a/parser.go
+++ b/parser.go
@@ -227,26 +227,37 @@ type Parser struct {
 	parseRuntimeMemoryHardCeilingBytes int64
 	parseMemoryBudgetDiag              parseMemoryBudgetDiagnostic
 	parseMemoryBudgetDiagActive        bool
-	denseLimit                         int
-	smallBase                          int
-	smallLookup                        [][]smallActionPair
-	smallTokenLookup                   [][]uint16
-	externalValidByState               [][]uint16
-	externalValidMaskByState           []uint64
-	hasExtraChainActions               bool
-	classifiedActions                  []classifiedParseAction
-	reduceChainHints                   []reduceChainHint
-	reduceChainHintByState             []int
-	reduceAliasSeq                     [][]Symbol
-	aliasTargetSymbol                  []bool
-	keepSameNamedAnonChildSymbol       []bool
-	sharedAnonymousTokenSymbol         []bool
-	reduceHasFields                    []bool
-	reduceFieldPlans                   []reduceFieldPlan
-	fieldIDScratch                     []FieldID
-	fieldInheritedScratch              []bool
-	fieldConflictedScratch             []bool
-	reduceScratch                      *reduceBuildScratch
+	// compatMemoryBudgetTripped latches true the moment Go compat
+	// normalization (normalizeGoReturnedTreeCompatibility /
+	// walkGoCompatSubtree's poller) observes a runtime memory-budget trip.
+	// The runtime heap/sys budget check is inherently non-monotonic (GC can
+	// make heap growth appear to recede), unlike arena.budgetExhausted(),
+	// which stays true for the rest of the parse once tripped — so without
+	// this sticky flag, a later, throttled resultMaterializationStopReason
+	// recheck (finalizeTree, after Go compat returns) could miss the trip
+	// entirely and stamp the tree with ParseStopAccepted despite Go compat
+	// having already bailed out mid-walk. See resultMaterializationStopReason.
+	compatMemoryBudgetTripped    bool
+	denseLimit                   int
+	smallBase                    int
+	smallLookup                  [][]smallActionPair
+	smallTokenLookup             [][]uint16
+	externalValidByState         [][]uint16
+	externalValidMaskByState     []uint64
+	hasExtraChainActions         bool
+	classifiedActions            []classifiedParseAction
+	reduceChainHints             []reduceChainHint
+	reduceChainHintByState       []int
+	reduceAliasSeq               [][]Symbol
+	aliasTargetSymbol            []bool
+	keepSameNamedAnonChildSymbol []bool
+	sharedAnonymousTokenSymbol   []bool
+	reduceHasFields              []bool
+	reduceFieldPlans             []reduceFieldPlan
+	fieldIDScratch               []FieldID
+	fieldInheritedScratch        []bool
+	fieldConflictedScratch       []bool
+	reduceScratch                *reduceBuildScratch
 	// mergeScratch points at the active parse's scratch.merge for the duration
 	// of parseInternal (set alongside reduceScratch, cleared on return). It lets
 	// dispatch-time helpers that only carry *Parser — tryGSSMainMergeForParser
@@ -1448,6 +1459,7 @@ func resetSnippetParser(parser *Parser) {
 	parser.parseRuntimeMemoryHardCeilingBytes = 0
 	parser.parseMemoryBudgetDiag = parseMemoryBudgetDiagnostic{}
 	parser.parseMemoryBudgetDiagActive = false
+	parser.compatMemoryBudgetTripped = false
 	// Release *Node refs so the arenas from the last incremental parse can be
 	// collected by the GC. Without this, a Parser sitting in a sync.Pool keeps
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.
@@ -3847,12 +3859,15 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	parseStart := time.Now()
 	previousMemoryBudgetDiag := p.parseMemoryBudgetDiag
 	previousMemoryBudgetDiagActive := p.parseMemoryBudgetDiagActive
+	previousCompatMemoryBudgetTripped := p.compatMemoryBudgetTripped
 	p.parseMemoryBudgetDiag = parseMemoryBudgetDiagnostic{}
 	p.parseMemoryBudgetDiagActive = true
+	p.compatMemoryBudgetTripped = false
 	memoryBudgetDiag := &p.parseMemoryBudgetDiag
 	defer func() {
 		p.parseMemoryBudgetDiag = previousMemoryBudgetDiag
 		p.parseMemoryBudgetDiagActive = previousMemoryBudgetDiagActive
+		p.compatMemoryBudgetTripped = previousCompatMemoryBudgetTripped
 	}()
 	endParseBudget := p.enterParseBudgetAt(parseStart)
 	defer endParseBudget()

--- a/parser_result.go
+++ b/parser_result.go
@@ -150,6 +150,17 @@ func (p *Parser) resultMaterializationStopReason(arena *nodeArena) ParseStopReas
 		if reason := p.parseStopReasonNow(); parseStopReasonIsActive(reason) {
 			return reason
 		}
+		// compatMemoryBudgetTripped is Go compat normalization's own sticky
+		// latch (see (*Parser).goCompatRuntimeMemoryBudgetStopReason): unlike
+		// arena.budgetExhausted() below, which stays true for the rest of the
+		// parse once tripped, a runtime heap/sys budget trip is inherently
+		// non-monotonic (GC can make heap growth appear to recede), so without
+		// this latch a later caller re-checking here (e.g. finalizeTree, right
+		// after Go compat normalization returns) could miss a trip Go compat
+		// already acted on and stamp the tree with the wrong stop reason.
+		if p.compatMemoryBudgetTripped {
+			return ParseStopMemoryBudget
+		}
 	}
 	if arena != nil && arena.budgetExhausted() {
 		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -38,7 +38,14 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCo
 		return resultCompatibilityResult{stopReason: reason}
 	}
 	result := runLanguageResultCompatibility(ctx)
-	if parseStopReasonIsActive(result.stopReason) {
+	// resultMaterializationShouldStop (not parseStopReasonIsActive) here: Go's
+	// normalizer (the only one that can produce it — see
+	// normalizeGoReturnedTreeCompatibility) may now report ParseStopMemoryBudget,
+	// which parseStopReasonIsActive deliberately excludes (many callers rely on
+	// its narrower Timeout/Cancelled-only semantics). Without this, a
+	// budget-stopped Go result would still fall through into the generic
+	// trailing-trivia/terminal-leaf passes below.
+	if resultMaterializationShouldStop(result.stopReason) {
 		return result
 	}
 	if reason := ctx.stopReason(); parseStopReasonIsActive(reason) {

--- a/parser_result_go.go
+++ b/parser_result_go.go
@@ -2,22 +2,65 @@ package gotreesitter
 
 import "bytes"
 
+// normalizeGoReturnedTreeCompatibility drives Go's post-build compatibility
+// pipeline. Every stage boundary already re-checked p.activeParseStopReason()
+// (Timeout/Cancelled); it now also re-checks the memory budget via
+// goCompatMemoryBudgetStopReason so a parse that is already over budget (the
+// parse loop stopped, or the arena/runtime heap grew past budget during an
+// earlier stage) skips the remaining Go compat work entirely instead of
+// normalizing a partial tree that carries no C-faithful normalization
+// guarantee. This mirrors the existing timeout/cancellation semantics at the
+// same call sites (see the 2026-07-12 gocompat-walk-containment-gap finding).
 func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, lang *Language) ParseStopReason {
+	var arena *nodeArena
+	if root != nil {
+		arena = root.ownerArena
+	}
 	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := p.goCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
 		return reason
 	}
 	normalizeGoSourceFileRoot(root, source, p)
 	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
 		return reason
 	}
-	if reason := normalizeGoCompatibilityWithParser(root, source, lang, p); parseStopReasonIsActive(reason) {
+	if reason := p.goCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
+		return reason
+	}
+	if reason := normalizeGoCompatibilityWithParser(root, source, lang, p); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
 		return reason
 	}
+	if reason := p.goCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
+		return reason
+	}
 	normalizeRootEOFNewlineSpan(root, source, lang)
-	return p.activeParseStopReason()
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	return p.goCompatMemoryBudgetStopReason(arena)
+}
+
+// goCompatMemoryBudgetStopReason forces a real (unmasked) memory-budget check
+// for the Go compat pipeline's stage boundaries in
+// normalizeGoReturnedTreeCompatibility. It is called a small, fixed number of
+// times per parse (never per node), so — unlike the walk-internal poll, which
+// intentionally samples at a coarse stride to stay cheap — it always reads
+// current arena/runtime state directly rather than relying on
+// resultMaterializationStopReason's shared, throttled poll counter, which can
+// otherwise miss an already-tripped budget at these infrequent checkpoints.
+func (p *Parser) goCompatMemoryBudgetStopReason(arena *nodeArena) ParseStopReason {
+	if p == nil {
+		return ParseStopNone
+	}
+	if arena != nil && arena.budgetExhausted() {
+		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)
+	}
+	return p.goCompatRuntimeMemoryBudgetStopReason()
 }
 
 func normalizeGoSourceFileRoot(root *Node, source []byte, p *Parser) {

--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -26,6 +26,26 @@ type goCompatibilitySourceFlags struct {
 	trailingBoundary bool
 }
 
+// goCompatRuntimeMemoryBudgetStopReason forces a real runtime memory-budget
+// check and, when it trips, latches p.compatMemoryBudgetTripped. Every Go
+// compat call site that needs memory-budget awareness (the walk-internal
+// poller's memoryBudgetParser hook, and goCompatMemoryBudgetStopReason's
+// per-stage boundary check) goes through this instead of calling
+// runtimeMemoryBudgetStopReasonNow directly, so a trip detected anywhere in
+// the Go compat pipeline is reliably surfaced later by
+// resultMaterializationStopReason (see compatMemoryBudgetTripped's doc
+// comment on the Parser struct for why a plain re-check is not enough).
+func (p *Parser) goCompatRuntimeMemoryBudgetStopReason() ParseStopReason {
+	if p == nil {
+		return ParseStopNone
+	}
+	if reason := p.runtimeMemoryBudgetStopReasonNow(); reason == ParseStopMemoryBudget {
+		p.compatMemoryBudgetTripped = true
+		return reason
+	}
+	return ParseStopNone
+}
+
 func normalizeGoCompatibilityWithParser(root *Node, source []byte, lang *Language, p *Parser) ParseStopReason {
 	return normalizeGoCompatibilityInRangesWithParser(root, source, lang, nil, p)
 }
@@ -37,20 +57,31 @@ func normalizeGoCompatibilityInRangesWithParser(root *Node, source []byte, lang 
 		frames = p.goCompatFrames
 		stopCheck = p.activeParseStopCheck()
 	}
-	return normalizeGoCompatibilityInRangesWithStopAndScratch(root, source, lang, incrementalRanges, stopCheck, frames)
+	return normalizeGoCompatibilityInRangesWithStopAndScratch(root, source, lang, incrementalRanges, stopCheck, frames, p)
 }
 
-func normalizeGoCompatibilityInRangesWithStopAndScratch(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck, frames *[]goCompatSubtreeFrame) ParseStopReason {
+// normalizeGoCompatibilityInRangesWithStopAndScratch drives the Go compat
+// walk. memBudgetParser, when non-nil, is wired into the poller so the walk
+// itself polls the runtime memory budget (see parseStopPoller.pollNow and
+// walkGoCompatSubtree/walkGoDotLeaves) instead of only ever reacting to
+// timeout/cancellation: a C-recovery-widened Go tree can make the walk's own
+// per-node work (semicolon-container filtering, sibling-boundary rewrites)
+// balloon heap growth independent of whatever the parse loop itself already
+// enforced (see the 2026-07-12 gocompat-walk-containment-gap finding).
+// resultMaterializationShouldStop (not parseStopReasonIsActive) gates every
+// bail-out below so a ParseStopMemoryBudget the poller reports is honored the
+// same way Timeout/Cancelled already are.
+func normalizeGoCompatibilityInRangesWithStopAndScratch(root *Node, source []byte, lang *Language, incrementalRanges []Range, stopCheck parseStopCheck, frames *[]goCompatSubtreeFrame, memBudgetParser *Parser) ParseStopReason {
 	if root == nil || lang == nil || lang.Name != "go" || len(source) == 0 {
 		return ParseStopNone
 	}
-	poller := parseStopPoller{check: stopCheck}
-	if reason := poller.pollNow(); parseStopReasonIsActive(reason) {
+	poller := parseStopPoller{check: stopCheck, memoryBudgetParser: memBudgetParser}
+	if reason := poller.pollNow(); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	flags := goCompatibilitySourceFlagsFor(source)
 	if flags.dot {
-		if reason := normalizeGoDotLeafChildrenWithStop(root, source, lang, &poller); parseStopReasonIsActive(reason) {
+		if reason := normalizeGoDotLeafChildrenWithStop(root, source, lang, &poller); resultMaterializationShouldStop(reason) {
 			return reason
 		}
 	}
@@ -58,7 +89,7 @@ func normalizeGoCompatibilityInRangesWithStopAndScratch(root *Node, source []byt
 	if !ok {
 		return poller.pollNow()
 	}
-	if reason := normalizeGoCompatibilitySubtreeWithStopAndScratch(root, source, syms, flags, incrementalRanges, &poller, frames); parseStopReasonIsActive(reason) {
+	if reason := normalizeGoCompatibilitySubtreeWithStopAndScratch(root, source, syms, flags, incrementalRanges, &poller, frames); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	return poller.pollNow()
@@ -90,7 +121,7 @@ func normalizeGoDotLeafChildrenWithStop(root *Node, source []byte, lang *Languag
 	if root == nil || lang == nil || len(source) == 0 {
 		return ParseStopNone
 	}
-	if reason := poller.pollNow(); parseStopReasonIsActive(reason) {
+	if reason := poller.pollNow(); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	parentSym, ok := lang.symbolByNameAndNamed("dot", true)
@@ -156,7 +187,7 @@ func walkGoDotLeaves(root *Node, source []byte, poller *parseStopPoller, parentS
 		stack = append(stack, n)
 	}
 	for len(stack) > 0 {
-		if reason := poller.poll(); parseStopReasonIsActive(reason) {
+		if reason := poller.poll(); resultMaterializationShouldStop(reason) {
 			return reason, true
 		}
 		n := stack[len(stack)-1]
@@ -352,7 +383,7 @@ func walkGoCompatSubtree(root *Node, source []byte, syms goCompatibilitySymbols,
 		stack = append(stack, goCompatSubtreeFrame{node: c})
 	}
 	for len(stack) > 0 {
-		if reason := poller.poll(); parseStopReasonIsActive(reason) {
+		if reason := poller.poll(); resultMaterializationShouldStop(reason) {
 			return reason, true, stack
 		}
 		top := stack[len(stack)-1]

--- a/parser_result_go_compat_memory_budget_clean_test.go
+++ b/parser_result_go_compat_memory_budget_clean_test.go
@@ -1,0 +1,74 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// goCompatCleanParseGoldenSExpr pins the exact normalized shape of
+// testGoCompatCleanParseSource (const-block semicolon drop + switch/case
+// sibling-boundary normalization), captured before the memory-budget fix and
+// re-verified identical after.
+const goCompatCleanParseGoldenSExpr = "(source_file (package_clause (package_identifier)) (const_declaration (const_spec (identifier) (expression_list (int_literal))) (const_spec (identifier) (expression_list (int_literal)))) (function_declaration (identifier) (parameter_list) (type_identifier) (block (statement_list (expression_switch_statement (expression_case (expression_list (true)) (statement_list (return_statement (expression_list (int_literal))))) (default_case (statement_list (return_statement (expression_list (int_literal))))))))))"
+
+const testGoCompatCleanParseSource = "package p\n\nconst (\n\tA = 1\n\tB = 2\n)\n\nfunc F() int {\n\tswitch {\n\tcase true:\n\t\treturn 1\n\tdefault:\n\t\treturn 0\n\t}\n}\n"
+
+// TestGoCompatCleanParseUnaffectedByMemoryBudgetFix is an explicit
+// byte-identity check for the 2026-07-12 gocompat-walk-containment-gap fix
+// (parseStopPoller.memoryBudgetParser / (*Parser).goCompatMemoryBudgetStopReason
+// / compatMemoryBudgetTripped): a clean, comfortably-within-any-reasonable-budget
+// Go parse must produce the exact same normalized tree shape as before the fix
+// — the new code paths only ever change behavior when a memory budget is
+// actually configured AND actually trips, which never happens here. This
+// complements TestGoZerrorsNormalizerByteIdentity (parser_result_go_compat_byte_identity_test.go),
+// which pins a large real-corpus golden; this one is a small, self-contained
+// pin exercising the const-block semicolon-drop and switch-statement
+// sibling-boundary normalizers directly.
+func TestGoCompatCleanParseUnaffectedByMemoryBudgetFix(t *testing.T) {
+	src := []byte(testGoCompatCleanParseSource)
+	lang := grammars.GoLanguage()
+
+	// Two parses of the identical clean source: the default configuration,
+	// and one with an explicit, generously large memory budget (env-gated,
+	// like GOT_PARSE_MEMORY_BUDGET_MB in TestParserMemoryBudgetStopsParse).
+	// Both must produce byte-identical normalized trees — the new
+	// memory-budget polling in the Go compat walk (parseStopPoller.memoryBudgetParser)
+	// and stage-boundary checks (goCompatMemoryBudgetStopReason) are additive
+	// and must never fire, let alone alter output, on a parse this small.
+	for _, label := range []string{"default", "budget=4096MB"} {
+		t.Run(label, func(t *testing.T) {
+			if label == "budget=4096MB" {
+				t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "4096")
+				gotreesitter.ResetParseEnvConfigCacheForTests()
+				defer gotreesitter.ResetParseEnvConfigCacheForTests()
+			}
+			tree, err := gotreesitter.NewParser(lang).Parse(src)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			defer tree.Release()
+
+			if got, want := tree.ParseStopReason(), gotreesitter.ParseStopAccepted; got != want {
+				t.Fatalf("ParseStopReason() = %q, want %q", got, want)
+			}
+			if tree.ParseStoppedEarly() {
+				t.Fatal("ParseStoppedEarly() = true, want false for a clean small parse")
+			}
+			root := tree.RootNode()
+			if root == nil {
+				t.Fatal("RootNode() = nil")
+			}
+			if root.HasError() {
+				t.Fatalf("clean Go source reported an error: %s", root.SExpr(lang))
+			}
+			if got := root.EndByte(); got != uint32(len(src)) {
+				t.Fatalf("root.EndByte() = %d, want %d (full source coverage)", got, len(src))
+			}
+			if got := root.SExpr(lang); got != goCompatCleanParseGoldenSExpr {
+				t.Fatalf("SExpr drift:\n got:  %s\n want: %s", got, goCompatCleanParseGoldenSExpr)
+			}
+		})
+	}
+}

--- a/parser_result_go_compat_memory_budget_test.go
+++ b/parser_result_go_compat_memory_budget_test.go
@@ -1,0 +1,246 @@
+package gotreesitter
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+)
+
+// This file regression-tests the 2026-07-12 gocompat-walk-containment-gap
+// fix: walkGoCompatSubtree (and normalizeGoDotLeafChildrenWithStop) used to
+// poll only for timeout/cancellation (parseStopReasonIsActive explicitly
+// excludes ParseStopMemoryBudget), so a C-recovery-widened Go tree's compat
+// walk could balloon heap growth during result finalization independent of
+// whatever the parse loop itself already enforced. The fix threads
+// (*Parser).goCompatRuntimeMemoryBudgetStopReason into the walk's poller
+// (parseStopPoller.memoryBudgetParser) and into per-stage boundary checks in
+// normalizeGoReturnedTreeCompatibility (parser_result_go.go), and latches
+// compatMemoryBudgetTripped so a trip detected there is reliably surfaced by
+// resultMaterializationStopReason afterward (parser_result.go).
+//
+// buildGoCompatWideContainerTree below models the trigger shape without an
+// end-to-end multi-hundred-MB reproduction: a wide, flat, C-recovery-shaped
+// tree (many real, distinct semicolon-container nodes, e.g. what a truncated
+// giant const/table-literal input widens into) whose compat-walk cost is
+// genuinely proportional to tree size, calibrated so unbounded work is
+// clearly (10x+) larger than a small configured budget while staying well
+// under ~1-2GiB for test safety.
+
+const (
+	testGoCompatIdentSym Symbol = 100
+	testGoCompatSemiSym  Symbol = 101
+	testGoCompatDeclSym  Symbol = 102
+	testGoCompatRootSym  Symbol = 103
+)
+
+// buildGoCompatWideContainerTree builds a root with numContainers distinct
+// semicolon-container ("const_declaration"-shaped) children, each holding
+// containerWidth alternating ident/droppable-semicolon leaves. Every
+// container is visited exactly once by the walk (there is no node sharing
+// here — unlike the historical DAG/cycle defect, this is an ordinary tree),
+// so its per-container work (normalizeGoSemicolonContainer's kept-slice
+// filter, sized to the container's real width) is real, non-idempotent,
+// unavoidable work: exactly the shape a legitimately huge recovered tree
+// produces, just made large enough here to make the containment gap
+// observable without needing multi-hundred-MB inputs.
+func buildGoCompatWideContainerTree(numContainers, containerWidth int) (*Node, []byte, goCompatibilitySymbols) {
+	arena := newNodeArena(arenaClassFull)
+	source := make([]byte, numContainers*containerWidth)
+	containers := make([]*Node, numContainers)
+	for c := 0; c < numContainers; c++ {
+		base := c * containerWidth
+		children := make([]*Node, containerWidth)
+		for i := 0; i < containerWidth; i++ {
+			off := uint32(base + i)
+			if i%2 == 0 {
+				source[base+i] = 'x'
+				children[i] = newLeafNodeInArena(arena, testGoCompatIdentSym, true, off, off+1, Point{}, Point{})
+			} else {
+				source[base+i] = '\n'
+				children[i] = newLeafNodeInArena(arena, testGoCompatSemiSym, false, off, off+1, Point{}, Point{})
+			}
+		}
+		containers[c] = newParentNodeInArena(arena, testGoCompatDeclSym, true, cloneNodeSliceInArena(arena, children), nil, 0)
+	}
+	root := newParentNodeInArena(arena, testGoCompatRootSym, true, cloneNodeSliceInArena(arena, containers), nil, 0)
+
+	syms := goCompatibilitySymbols{semicolon: testGoCompatSemiSym}
+	syms.semiContainers[0] = testGoCompatDeclSym
+	syms.semiContainerLen = 1
+	return root, source, syms
+}
+
+// containerStillHasSemicolon reports whether container c of root (as built by
+// buildGoCompatWideContainerTree) still carries its droppable semicolon leaf
+// — i.e. normalizeGoSemicolonContainer has not (yet) run on it.
+func containerStillHasSemicolon(root *Node, c int) bool {
+	container := resultChildAt(root, c)
+	if container == nil {
+		return false
+	}
+	for i := 0; i < resultChildCount(container); i++ {
+		if child := resultChildAt(container, i); child != nil && child.symbol == testGoCompatSemiSym {
+			return true
+		}
+	}
+	return false
+}
+
+// newGoCompatBudgetTestParser returns a *Parser configured with a runtime
+// memory budget baselined at the current live heap, mirroring how
+// (*Parser).enterRuntimeMemoryBudget configures a real parse.
+func newGoCompatBudgetTestParser(budgetBytes int64) *Parser {
+	debug.FreeOSMemory()
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return &Parser{
+		parseRuntimeMemoryBudgetBytes:   budgetBytes,
+		parseRuntimeMemoryBaselineBytes: stats.HeapAlloc,
+		parseRuntimeMemoryBaselineSys:   stats.Sys,
+		parseMemoryBudgetDiagActive:     true,
+	}
+}
+
+// TestWalkGoCompatSubtreeUnboundedBaselineCompletes establishes the baseline:
+// with no memory-budget parser wired into the poller (the pre-fix shape —
+// parseStopPoller{} carries no way to express memory-budget awareness at
+// all), the walk runs to completion over every container regardless of size.
+// This is the control for TestWalkGoCompatSubtreeStopsOnMemoryBudget below.
+func TestWalkGoCompatSubtreeUnboundedBaselineCompletes(t *testing.T) {
+	const numContainers, containerWidth = 400, 2000
+	root, source, syms := buildGoCompatWideContainerTree(numContainers, containerWidth)
+
+	poller := parseStopPoller{}
+	reason := normalizeGoCompatibilitySubtreeWithStopAndScratch(root, source, syms, goCompatibilitySourceFlags{}, nil, &poller, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("reason = %q, want %q (unbounded walk must not stop)", reason, ParseStopNone)
+	}
+	for c := 0; c < numContainers; c++ {
+		if containerStillHasSemicolon(root, c) {
+			t.Fatalf("container %d still has a droppable semicolon after an unbounded walk", c)
+		}
+	}
+}
+
+// TestWalkGoCompatSubtreeStopsOnMemoryBudget is the core regression: wiring a
+// tiny-budget *Parser into the poller (parseStopPoller.memoryBudgetParser,
+// the walkGoCompatSubtree-side fix) must make the walk (a) return
+// ParseStopMemoryBudget, (b) stop well before the last container is reached
+// (proving it bailed out mid-walk rather than finishing then reporting the
+// budget as an afterthought), and (c) keep total heap growth within a small
+// multiple of the configured budget — even though an unbounded walk over the
+// identical tree (see the baseline test above) would keep going regardless.
+func TestWalkGoCompatSubtreeStopsOnMemoryBudget(t *testing.T) {
+	const numContainers, containerWidth = 400, 2000
+	root, source, syms := buildGoCompatWideContainerTree(numContainers, containerWidth)
+
+	const budgetBytes = 1 << 20 // 1MiB: far smaller than the ~400*2000*8B = 6.4MB
+	// this walk would allocate (in kept-slice filtering alone) if it ran to
+	// completion, so the trip must land partway through, not at the end.
+	parser := newGoCompatBudgetTestParser(budgetBytes)
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	poller := parseStopPoller{memoryBudgetParser: parser}
+	reason := normalizeGoCompatibilitySubtreeWithStopAndScratch(root, source, syms, goCompatibilitySourceFlags{}, nil, &poller, nil)
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("reason = %q, want %q", reason, ParseStopMemoryBudget)
+	}
+	if !parser.compatMemoryBudgetTripped {
+		t.Fatal("compatMemoryBudgetTripped = false, want true (sticky latch for resultMaterializationStopReason's later recheck)")
+	}
+
+	processed, unprocessed := 0, 0
+	for c := 0; c < numContainers; c++ {
+		if containerStillHasSemicolon(root, c) {
+			unprocessed++
+		} else {
+			processed++
+		}
+	}
+	if unprocessed == 0 {
+		t.Fatalf("all %d containers were processed before the budget trip fired; want a partial walk (processed=%d unprocessed=%d)", numContainers, processed, unprocessed)
+	}
+	if processed == 0 {
+		t.Fatalf("no containers were processed at all; want some real work done before the trip (processed=%d unprocessed=%d)", processed, unprocessed)
+	}
+	// The last container must still be untouched: pushChild processes root's
+	// children in original order (0..numContainers-1), so if the walk had run
+	// to completion the final container would already be normalized.
+	if !containerStillHasSemicolon(root, numContainers-1) {
+		t.Fatal("last container was processed; want the walk to have stopped before reaching it")
+	}
+
+	growth := int64(0)
+	if after.HeapAlloc > before.HeapAlloc {
+		growth = int64(after.HeapAlloc - before.HeapAlloc)
+	}
+	const maxOvershoot = 6 * budgetBytes
+	t.Logf("processed=%d/%d unprocessed=%d heap growth=%d bytes (budget=%d, %.2fx)",
+		processed, numContainers, unprocessed, growth, int64(budgetBytes), float64(growth)/float64(budgetBytes))
+	if growth > maxOvershoot {
+		t.Fatalf("heap growth = %d bytes, want <= %d (6x budget=%d)", growth, maxOvershoot, int64(budgetBytes))
+	}
+}
+
+// TestNormalizeGoCompatibilityWithParserPropagatesMemoryBudgetStop exercises
+// the full production entry point (normalizeGoCompatibilityWithParser, the
+// exact function normalizeGoReturnedTreeCompatibility calls) instead of
+// walkGoCompatSubtree directly, confirming the poller wiring done in
+// normalizeGoCompatibilityInRangesWithStopAndScratch (parser_result_go_compat.go)
+// reaches all the way from a *Parser's configured budget to the returned
+// ParseStopReason.
+func TestNormalizeGoCompatibilityWithParserPropagatesMemoryBudgetStop(t *testing.T) {
+	const numContainers, containerWidth = 400, 2000
+	root, source, _ := buildGoCompatWideContainerTree(numContainers, containerWidth)
+	lang := goCompatMemoryBudgetTestLanguage()
+
+	const budgetBytes = 1 << 20
+	parser := newGoCompatBudgetTestParser(budgetBytes)
+	parser.language = lang
+
+	reason := normalizeGoCompatibilityWithParser(root, source, lang, parser)
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("normalizeGoCompatibilityWithParser reason = %q, want %q", reason, ParseStopMemoryBudget)
+	}
+	if !parser.compatMemoryBudgetTripped {
+		t.Fatal("compatMemoryBudgetTripped = false, want true")
+	}
+	// resultMaterializationStopReason is what finalizeTree (parser.go) and
+	// finalizeResultRoot (parser_result_root_build.go) consult afterward; the
+	// sticky latch must make it report the trip reliably, matching how the
+	// parse loop's own arena/scratch budget checks are surfaced.
+	if got := parser.resultMaterializationStopReason(nil); got != ParseStopMemoryBudget {
+		t.Fatalf("resultMaterializationStopReason() = %q, want %q after a Go compat memory-budget trip", got, ParseStopMemoryBudget)
+	}
+}
+
+// goCompatMemoryBudgetTestLanguage is a minimal "go" Language whose symbol
+// names match the ones goCompatibilitySymbolsForLanguage looks up by name, so
+// normalizeGoCompatibilityWithParser resolves testGoCompatSemiSym /
+// testGoCompatDeclSym the same way it would for a real grammar.
+func goCompatMemoryBudgetTestLanguage() *Language {
+	names := make([]string, 104)
+	meta := make([]SymbolMetadata, 104)
+	for i := range names {
+		names[i] = ""
+	}
+	names[testGoCompatIdentSym] = "identifier"
+	meta[testGoCompatIdentSym] = SymbolMetadata{Name: "identifier", Visible: true, Named: true}
+	names[testGoCompatSemiSym] = ";"
+	meta[testGoCompatSemiSym] = SymbolMetadata{Name: ";", Visible: true, Named: false}
+	names[testGoCompatDeclSym] = "const_declaration"
+	meta[testGoCompatDeclSym] = SymbolMetadata{Name: "const_declaration", Visible: true, Named: true}
+	names[testGoCompatRootSym] = "source_file"
+	meta[testGoCompatRootSym] = SymbolMetadata{Name: "source_file", Visible: true, Named: true}
+	return &Language{
+		Name:           "go",
+		SymbolNames:    names,
+		SymbolMetadata: meta,
+	}
+}

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -975,7 +975,13 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		start = materializationTimingStart(timing)
 		compat := normalizeResultCompatibility(root, source, p)
 		errorSummary = compat.errorSummary
-		compatibilityApplied = p != nil && p.language != nil && !parseStopReasonIsActive(compat.stopReason)
+		// resultMaterializationShouldStop (not parseStopReasonIsActive): Go's
+		// normalizer can now report ParseStopMemoryBudget (see
+		// normalizeGoReturnedTreeCompatibility), which parseStopReasonIsActive
+		// deliberately excludes. A budget-stopped compat pass did not apply
+		// cleanly and must not be treated as "compatibility applied" any more
+		// than a timeout/cancellation-stopped one is.
+		compatibilityApplied = p != nil && p.language != nil && !resultMaterializationShouldStop(compat.stopReason)
 		if parseStopReasonIsActive(compat.stopReason) && p != nil {
 			p.markActiveParseStopped(compat.stopReason)
 		}

--- a/parser_timeout.go
+++ b/parser_timeout.go
@@ -10,12 +10,27 @@ type parseStopCheck func() ParseStopReason
 type parseStopPoller struct {
 	check parseStopCheck
 	count uint64
+	// memoryBudgetParser, when non-nil, makes poll/pollNow also force a
+	// runtime memory-budget check (see (*Parser).goCompatRuntimeMemoryBudgetStopReason)
+	// at the same coarse cadence as check, in addition to whatever check
+	// reports. check alone only ever reports Timeout/Cancelled (see
+	// parseStopReasonIsActive) — some long tree walks (the Go compat walk;
+	// see normalizeGoCompatibilityInRangesWithStopAndScratch) need to also
+	// bound their own runtime heap growth even when the parse loop itself
+	// never tripped the budget, so they opt in by setting this field. nil by
+	// default: every existing caller that only sets check keeps its exact
+	// current behavior, byte-for-byte, since the branches below are additive
+	// and only ever taken when this field is non-nil.
+	memoryBudgetParser *Parser
 }
 
 const parseStopPollMask = 1023
 
 func (p *parseStopPoller) poll() ParseStopReason {
-	if p == nil || p.check == nil {
+	if p == nil {
+		return ParseStopNone
+	}
+	if p.check == nil && p.memoryBudgetParser == nil {
 		return ParseStopNone
 	}
 	p.count++
@@ -26,14 +41,26 @@ func (p *parseStopPoller) poll() ParseStopReason {
 }
 
 func (p *parseStopPoller) pollNow() ParseStopReason {
-	if p == nil || p.check == nil {
+	if p == nil {
 		return ParseStopNone
 	}
-	reason := p.check()
-	if reason == "" {
-		return ParseStopNone
+	if p.check != nil {
+		// check() (always (*Parser).activeParseStopReason) never returns a Go
+		// empty string; its "nothing happened" sentinel is the ParseStopNone
+		// constant ("none"). Comparing against "" here would make this branch
+		// always return early — including the "none" case — and starve the
+		// memoryBudgetParser check below of ever running when check is set,
+		// which every Go compat caller does.
+		if reason := p.check(); reason != ParseStopNone && reason != "" {
+			return reason
+		}
 	}
-	return reason
+	if p.memoryBudgetParser != nil {
+		if reason := p.memoryBudgetParser.goCompatRuntimeMemoryBudgetStopReason(); reason == ParseStopMemoryBudget {
+			return reason
+		}
+	}
+	return ParseStopNone
 }
 
 func parseStopReasonIsActive(reason ParseStopReason) bool {


### PR DESCRIPTION
## Summary

Closes the second containment lane flagged during the wave-5 budget work: `walkGoCompatSubtree` ran unconditionally at result finalization with no memory-budget awareness — only timeout/cancellation polling — so a recovered Go tree could balloon in the compat walk even after the parse loop stopped cleanly on budget.

Two layers, mirroring the parse-loop containment design: Go compat normalization bails at every existing checkpoint when the parse carries a budget stop, and the compat stop-poller gains a budget check at the existing 1024-pop stride, with all bail-outs gating on the materialization stop check (which honors `ParseStopMemoryBudget`). A sticky trip flag guarantees the stop reason surfaces on the final tree even when the throttled poll counter would miss it (runtime heap checks are non-monotonic under GC, unlike arena exhaustion).

Also fixed en route: the poller's original-reason guard compared against the empty string instead of `ParseStopNone` (a non-empty sentinel) — the budget branch would have been dead code on every real parse; caught by this branch's own propagation test.

Rebased over the merged parse-loop containment (#272); the Parser-struct field union and cross-suite interaction verified post-rebase.

## Verification

- Calibrated direct-construction witness (wide recovery-shaped container tree, zero parse-loop involvement): unbudgeted walk completes; 1 MiB budget stops after 34/400 containers at 1.09x budget heap growth.
- Clean-parse byte-identity: existing large-corpus golden unchanged; new explicit SExpr golden pinned at default and explicit-budget configs.
- Post-rebase: `Budget|Containment|Recover` and `-race` `GoCompat|Budget` suites green over the combined state with #272's volume-poll/hard-ceiling layers; targeted suite 233 pass; full root suite green.
- Canonical benchmark neutral under interleaved A/B (p=0.31).

## Follow-up (tracked)

The JS/TS fused normalization walk has the same blind spot and worse — no stop polling of any kind and no pop-budget protection. Queued as its own lane.