### PR TITLE
optimize(parser): set-associative cache for C-recovery node cost memo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ for tags and release notes while still in `0.x`.
   polling at all) and is tracked separately.
 
 ## [0.27.0] - 2026-07-12
+### Performance
+
+- The C-recovery per-subtree error-cost/visible-count memo
+  (`cNodeErrorCost`/`cNodeVisibleSubtreeCount`) is now a fixed-capacity,
+  pointer-keyed 2-way set-associative cache instead of a
+  `map[*Node]cNodeMemoEntry`: warm CPU profiles of error-bearing parses on
+  fleet-tail languages (kdl, uxntal) showed `runtime.mapaccess2_fast64` as
+  the single hottest leaf, driven almost entirely by these two lookups.
+  Every decision made by the recovery cost-competition machinery
+  (`cRecoverStrategy1Election`, `cHandleError`, `cCondenseAndResume`, etc.)
+  is unchanged — a cache miss simply falls back to the same full recompute
+  as before. The cache starts small (matching the old map's practical
+  per-parse footprint) and grows to its full working-set size only the
+  first time a parse actually enters C error handling, so clean parses of
+  recovery-capable grammars are unaffected (measured neutral-to-positive on
+  the canonical Go workload). A synthetic KDL truncated/garbage-suffix
+  recovery benchmark (`BenchmarkKDLRecoveryGarbageSuffix`) improves ~18%
+  (83.2ms to 68.2ms median, p=0.002, n=6).
 
 Containment and canonical-parse-lever release. Memory-budget enforcement is
 now layered (volume-triggered polling, in-merge checks, and an absolute hard

--- a/benchmark_recovery_test.go
+++ b/benchmark_recovery_test.go
@@ -1,0 +1,75 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// makeKDLRecoveryGarbageSource synthesizes a KDL document that reliably
+// drives the C-recovery cost-competition machinery: a valid, node-per-line
+// KDL prefix truncated 70% of the way through, followed by a long run of
+// unterminated-string / mismatched-brace garbage that the parser can never
+// resynchronize against. The whole garbage tail is absorbed into one
+// continuously growing ERROR region, exactly the shape that makes warm CPU
+// profiles of error-bearing parses on fleet-tail languages (kdl, uxntal)
+// dominated by cRecoverStrategy1Election / cNodeErrorCost / cStackPrefixAgg /
+// cHandleError / cCondenseAndResume (parser_recover_c.go).
+func makeKDLRecoveryGarbageSource(nodeCount, garbageRepeats int) []byte {
+	var body strings.Builder
+	for i := 0; i < nodeCount; i++ {
+		fmt.Fprintf(&body, "node%d \"arg%d\" key=%d {\n", i, i, i)
+		fmt.Fprintf(&body, "  child%d \"x\"\n", i)
+		body.WriteString("}\n")
+	}
+	valid := body.String()
+	cut := int(float64(len(valid)) * 0.7)
+
+	var out strings.Builder
+	out.Grow(cut + garbageRepeats*32)
+	out.WriteString(valid[:cut])
+	for i := 0; i < garbageRepeats; i++ {
+		out.WriteString(" }} \"unterminated garbage ][ ")
+		fmt.Fprintf(&out, "%d==%d<<>>", i, i*7)
+	}
+	return []byte(out.String())
+}
+
+// BenchmarkKDLRecoveryGarbageSuffix exercises the C-recovery cost-competition
+// machinery end to end on a representative fleet-tail-class error-bearing
+// parse (see makeKDLRecoveryGarbageSource). This is the recovery-heavy
+// counterpart to the clean-parse canonical trio in BENCH.md: those
+// benchmarks never enter cHandleError, so they cannot see regressions or
+// wins in the recovery cost-competition path (cRecoverStrategy1Election,
+// cNodeErrorCost, cStackPrefixAgg, cHandleError, cCondenseAndResume in
+// parser_recover_c.go / glr.go).
+func BenchmarkKDLRecoveryGarbageSuffix(b *testing.B) {
+	lang := grammars.KdlLanguage()
+	parser := gotreesitter.NewParser(lang)
+	src := makeKDLRecoveryGarbageSource(120, 300)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(src)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		root := tree.RootNode()
+		if root == nil {
+			b.Fatalf("recovery garbage-suffix parse returned nil root")
+		}
+		if !root.HasError() {
+			b.Fatalf("recovery garbage-suffix workload parsed without error: benchmark no longer exercises recovery")
+		}
+		if got, want := root.EndByte(), uint32(len(src)); got != want {
+			b.Fatalf("recovery garbage-suffix parse truncated: root.EndByte=%d want=%d", got, want)
+		}
+		tree.Release()
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -184,12 +184,14 @@ type Parser struct {
 	// active source qualifies for engine-side error-mode substitution (see
 	// cRecoverCustomSourceEligibleFor).
 	cRecoverCustomSourceEligible bool
-	// cNodeMemo caches per-subtree error cost and visible node count for the
-	// gated recovery, keyed on (node pointer, equivVersion) — the engine
+	// cNodeMemoCache caches per-subtree error cost and visible node count for
+	// the gated recovery, keyed on (node pointer, equivVersion) — the engine
 	// analogue of C's SubtreeHeapData.error_cost/visible_descendant_count
-	// computed once in ts_subtree_summarize_children. Cleared at parse start;
-	// nil while the gate is off.
-	cNodeMemo map[*Node]cNodeMemoEntry
+	// computed once in ts_subtree_summarize_children. A fixed-capacity
+	// pointer-keyed 2-way set-associative cache (see cNodeMemoSlot,
+	// parser_recover_c.go) rather than a map: cleared at parse start, empty
+	// (len 0) while the gate is off.
+	cNodeMemoCache []cNodeMemoCacheEntry
 	// cPrefixPath is the reusable descent scratch for GSS prefix-aggregate
 	// fills (cStackPrefixAgg, parser_recover_c.go). The aggregates themselves
 	// live on gssNode (aggGen/aggCost/aggVis), the engine analogue of C
@@ -3902,11 +3904,15 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	if p.errorCostCompetitionEnabled() {
 		// Faithful C recovery port: arena nodes are pooled across parses, so
 		// stale (pointer, version) memo hits from a previous parse must be
-		// impossible.
-		if p.cNodeMemo == nil {
-			p.cNodeMemo = make(map[*Node]cNodeMemoEntry, 256)
+		// impossible. Start at the small per-parse default -- cCompareVersions
+		// cost competition participates in ordinary GLR disambiguation on
+		// well-formed input too, so this path is warm even on clean parses;
+		// growCNodeMemoCache upgrades it to the full working-set size the
+		// first time this parse actually enters C error handling.
+		if len(p.cNodeMemoCache) == 0 {
+			p.cNodeMemoCache = make([]cNodeMemoCacheEntry, cNodeMemoCacheInitialSize)
 		} else {
-			clear(p.cNodeMemo)
+			clear(p.cNodeMemoCache)
 		}
 		p.crecoveryEnteredErrorState = false
 		p.crecoveryDroppedErrorForClean = false
@@ -6453,8 +6459,8 @@ func (p *Parser) checkpointTransientScratch(stacks []glrStack, scratch *parserSc
 	// memo state before slab addresses are reused, so pointer-keyed results from
 	// discarded alternatives cannot alias freshly allocated transient parents.
 	scratch.merge.beginEquivEpoch()
-	if p.cNodeMemo != nil {
-		clear(p.cNodeMemo)
+	if len(p.cNodeMemoCache) != 0 {
+		clear(p.cNodeMemoCache)
 	}
 	if cap(scratch.tmpEntries) > 0 {
 		clear(scratch.tmpEntries[:cap(scratch.tmpEntries)])

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"unicode"
+	"unsafe"
 )
 
 // parser_recover_c.go is the stage-1 faithful port of tree-sitter C's error
@@ -1017,9 +1018,9 @@ func (p *Parser) cNodeVisibleSubtreeCount(n *Node) int {
 	if n == nil {
 		return 0
 	}
-	if p != nil && p.cNodeMemo != nil {
-		if e, ok := p.cNodeMemo[n]; ok && e.hasVis && e.ver == n.equivVersion {
-			return e.visCount
+	if p != nil && len(p.cNodeMemoCache) != 0 {
+		if slot := p.cNodeMemoSlot(n); slot.hasVis && slot.ver == n.equivVersion {
+			return slot.visCount
 		}
 	}
 	count := 0
@@ -1029,14 +1030,16 @@ func (p *Parser) cNodeVisibleSubtreeCount(n *Node) int {
 	for _, c := range n.children {
 		count += p.cNodeVisibleSubtreeCount(c)
 	}
-	if p != nil && p.cNodeMemo != nil {
-		e := p.cNodeMemo[n]
-		if e.ver != n.equivVersion {
-			e = cNodeMemoEntry{ver: n.equivVersion}
+	if p != nil && len(p.cNodeMemoCache) != 0 {
+		// Re-fetch the slot: the recursive calls above may have evicted n's
+		// slot (a child's pointer hashing into the same 2-way set), so the
+		// pointer captured before recursing could now be stale.
+		slot := p.cNodeMemoSlot(n)
+		if slot.ver != n.equivVersion {
+			*slot = cNodeMemoCacheEntry{node: uintptr(unsafe.Pointer(n)), ver: n.equivVersion}
 		}
-		e.visCount = count
-		e.hasVis = true
-		p.cNodeMemo[n] = e
+		slot.visCount = count
+		slot.hasVis = true
 	}
 	return count
 }
@@ -1149,19 +1152,101 @@ func cNodeErrorCostLangWithScratch(scratch *glrMergeScratch, lang *Language, n *
 	return cost
 }
 
-// cNodeMemoEntry caches the gated recovery's per-subtree aggregates, the
+// cNodeMemoCacheEntry caches the gated recovery's per-subtree aggregates, the
 // engine analogue of C SubtreeHeapData.error_cost / node counts computed once
 // per subtree in ts_subtree_summarize_children. Finished subtrees never
 // mutate during a parse; the open error region is bumped (equivVersion) on
 // every absorb, invalidating its entry. Without the memo every
 // condense/competition step rewalks whole accumulated subtrees per token,
 // which is O(n^2) on large gated files.
-type cNodeMemoEntry struct {
+//
+// This is one slot of a pointer-keyed 2-way set-associative cache (same
+// layout discipline as glrShapePrefixCacheEntry / glrNodeEquivCacheEntry in
+// glr.go): profiling error-recovery-heavy parses (kdl/uxntal-class
+// fleet-tail cliffs, see cRecoverStrategy1Election/cHandleError/
+// cCondenseAndResume) showed runtime.mapaccess2_fast64 as the single hottest
+// leaf in the whole parse, driven almost entirely by the two memo lookups
+// below (cNodeErrorCost, cNodeVisibleSubtreeCount) previously backed by a
+// map[*Node]cNodeMemoEntry. A miss here is always safe: every caller falls
+// through to a full recompute over n's children, so an approximate
+// (evictable) cache changes only how often the answer is recomputed, never
+// what the answer is.
+type cNodeMemoCacheEntry struct {
+	node     uintptr
 	ver      uint32
 	cost     uint32
 	visCount int
 	hasCost  bool
 	hasVis   bool
+}
+
+const (
+	// cNodeMemoCacheInitialSize is what every C-recovery-capable parse
+	// allocates up front (parseInternal), matching the previous
+	// map[*Node]cNodeMemoEntry's practical footprint (make(..., 256) measured
+	// ~3.8KiB): cCompareVersions-driven cost competition participates in
+	// ordinary GLR disambiguation on well-formed input too (see the doc
+	// comment above cVersionStatus), so this path is warm on every capable
+	// parse, clean or not, and must stay cheap for the common case.
+	cNodeMemoCacheInitialSize = 128
+	// cNodeMemoCacheSize is what the cache grows to the first time a lineage
+	// actually enters C error handling (cHandleError / cRecoverDispatchInError
+	// setting crecoveryEnteredErrorState), matching the sizing of the
+	// merge-scratch pointer-keyed caches (glrShapePrefixCacheSize et al.):
+	// 8192 sets, 2-way each. Growing loses whatever was cached at the smaller
+	// size, which only costs a recompute (see cNodeMemoSlot) -- never a wrong
+	// answer.
+	cNodeMemoCacheSize = 16384
+)
+
+func cNodeMemoCacheIndex(p uintptr, setCount int) int {
+	h := uint64(p)
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	h *= 0xc4ceb9fe1a85ec53
+	h ^= h >> 33
+	return int(h&uint64(setCount-1)) << 1
+}
+
+// growCNodeMemoCache upgrades the parser's per-subtree cost/vis memo from its
+// small per-parse default (cNodeMemoCacheInitialSize) to the full working-set
+// size (cNodeMemoCacheSize) the first time a lineage actually enters C error
+// handling. Called once per parse from cHandleError's crecoveryEnteredErrorState
+// transition; a no-op once already grown.
+func (p *Parser) growCNodeMemoCache() {
+	if p == nil || len(p.cNodeMemoCache) >= cNodeMemoCacheSize {
+		return
+	}
+	p.cNodeMemoCache = make([]cNodeMemoCacheEntry, cNodeMemoCacheSize)
+}
+
+// cNodeMemoSlot returns the writable 2-way set-associative slot for node n,
+// evicting the current occupant into the victim half of the pair if n is not
+// already resident. This mirrors map[*Node]cNodeMemoEntry lookup semantics:
+// an existing entry for n keeps its stored version/cost/vis fields until the
+// caller explicitly overwrites them; a newly-resident node starts zeroed
+// (matching a fresh map key's zero value). Returns nil only when the cache is
+// unprovisioned (recovery gate off) or n/p is nil.
+func (p *Parser) cNodeMemoSlot(n *Node) *cNodeMemoCacheEntry {
+	if p == nil || n == nil || len(p.cNodeMemoCache) == 0 {
+		return nil
+	}
+	setCount := len(p.cNodeMemoCache) >> 1
+	ptr := uintptr(unsafe.Pointer(n))
+	idx := cNodeMemoCacheIndex(ptr, setCount)
+	primary := &p.cNodeMemoCache[idx]
+	if primary.node == ptr {
+		return primary
+	}
+	victim := &p.cNodeMemoCache[idx+1]
+	if victim.node == ptr {
+		*primary, *victim = *victim, *primary
+		return primary
+	}
+	*victim = *primary
+	*primary = cNodeMemoCacheEntry{node: ptr}
+	return primary
 }
 
 // ---------------------------------------------------------------------------
@@ -1244,7 +1329,7 @@ type cErrRegionAbsorbPre struct {
 }
 
 func (p *Parser) cErrRegionPreAbsorb(n *Node) cErrRegionAbsorbPre {
-	if p == nil || p.cNodeMemo == nil || p.language == nil || n == nil {
+	if p == nil || len(p.cNodeMemoCache) == 0 || p.language == nil || n == nil {
 		return cErrRegionAbsorbPre{}
 	}
 	if n.symbol != errorSymbol || (n.isMissing() && len(n.children) == 0) {
@@ -1268,7 +1353,7 @@ func (p *Parser) cErrRegionPreAbsorb(n *Node) cErrRegionAbsorbPre {
 // cNodeErrorCostLang's ERROR-node summarization exactly; the primed values are
 // what a full walk at the new version returns.
 func (p *Parser) cErrRegionPostAbsorb(pre cErrRegionAbsorbPre, added ...*Node) {
-	if !pre.valid || p == nil || p.cNodeMemo == nil {
+	if !pre.valid || p == nil || len(p.cNodeMemoCache) == 0 {
 		return
 	}
 	n := pre.node
@@ -1296,12 +1381,15 @@ func (p *Parser) cErrRegionPostAbsorb(pre cErrRegionAbsorbPre, added ...*Node) {
 	if debugRecoveryIncrementalCost {
 		p.debugCheckErrRegionIncremental(n, cost, vis)
 	}
-	p.cNodeMemo[n] = cNodeMemoEntry{
-		ver:      n.equivVersion,
-		cost:     cost,
-		visCount: vis,
-		hasCost:  true,
-		hasVis:   true,
+	if slot := p.cNodeMemoSlot(n); slot != nil {
+		*slot = cNodeMemoCacheEntry{
+			node:     uintptr(unsafe.Pointer(n)),
+			ver:      n.equivVersion,
+			cost:     cost,
+			visCount: vis,
+			hasCost:  true,
+			hasVis:   true,
+		}
 	}
 	if ms := p.mergeScratch; ms != nil {
 		if ms.cErrorCost == nil {
@@ -1315,7 +1403,7 @@ func (p *Parser) cErrRegionPostAbsorb(pre cErrRegionAbsorbPre, added ...*Node) {
 // bumped) region node via the standard full walks — O(children) once, so the
 // per-token lookups that follow are O(1) until the next absorb re-primes.
 func (p *Parser) cErrRegionPrime(n *Node) {
-	if p == nil || p.cNodeMemo == nil || p.language == nil || n == nil {
+	if p == nil || len(p.cNodeMemoCache) == 0 || p.language == nil || n == nil {
 		return
 	}
 	cost := p.cNodeErrorCost(n)
@@ -1368,11 +1456,11 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 	if n == nil {
 		return 0
 	}
-	if p.cNodeMemo == nil {
+	if len(p.cNodeMemoCache) == 0 {
 		return cNodeErrorCostLang(p.language, n)
 	}
-	if e, ok := p.cNodeMemo[n]; ok && e.hasCost && e.ver == n.equivVersion {
-		return e.cost
+	if slot := p.cNodeMemoSlot(n); slot.hasCost && slot.ver == n.equivVersion {
+		return slot.cost
 	}
 	if n.isMissing() && len(n.children) == 0 {
 		return cErrCostPerMissingTree + cErrCostPerRecovery
@@ -1407,13 +1495,15 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 		}
 		cost += cErrCostPerRecovery + cErrCostPerSkippedChar*bytes + cErrCostPerSkippedLine*rows
 	}
-	e := p.cNodeMemo[n]
-	if e.ver != n.equivVersion {
-		e = cNodeMemoEntry{ver: n.equivVersion}
+	// Re-fetch the slot: the recursive p.cNodeErrorCost(c) calls above may
+	// have evicted n's slot (a child's pointer hashing into the same 2-way
+	// set), so the pointer captured before recursing could now be stale.
+	slot := p.cNodeMemoSlot(n)
+	if slot.ver != n.equivVersion {
+		*slot = cNodeMemoCacheEntry{node: uintptr(unsafe.Pointer(n)), ver: n.equivVersion}
 	}
-	e.cost = cost
-	e.hasCost = true
-	p.cNodeMemo[n] = e
+	slot.cost = cost
+	slot.hasCost = true
 	return cost
 }
 
@@ -1561,7 +1651,7 @@ func (p *Parser) debugCheckStackPrefixAgg(head *gssNode, gotCost uint32, gotVis 
 // debugCheckStackPrefixVisLang is the visible-subtree-count twin of
 // debugCheckStackPrefixCostLang: it re-derives the cumulative visible node
 // count of head's prev chain without any cache (via the uncached per-node walk
-// so a poisoned cNodeMemo cannot mask itself) and compares it against the
+// so a poisoned cNodeMemoCache cannot mask itself) and compares it against the
 // memoized aggVis the same way the cost check guards aggCost. A divergence here
 // means cStackCumulativeNodeCount / cNodeCountSinceError — and thus the php
 // baseline gate — would read a corrupt count.
@@ -1595,7 +1685,7 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 	}
 	var cost uint32
 	if len(s.entries) > 0 {
-		if p != nil && p.cNodeMemo != nil && s.cRec != nil {
+		if p != nil && len(p.cNodeMemoCache) != 0 && s.cRec != nil {
 			cost, _ = p.cStackEntryAgg(s)
 		} else {
 			for i := range s.entries {
@@ -1604,7 +1694,7 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 				}
 			}
 		}
-	} else if p != nil && p.cNodeMemo != nil && s.gss.head != nil {
+	} else if p != nil && len(p.cNodeMemoCache) != 0 && s.gss.head != nil {
 		var vis int
 		cost, vis = p.cStackPrefixAgg(s.gss.head)
 		if debugRecoveryIncrementalCost {
@@ -1637,7 +1727,7 @@ func (p *Parser) cStackEntryAgg(s *glrStack) (uint32, int) {
 		return 0, 0
 	}
 	gen := gssPrefixAggGen.Load()
-	if p != nil && p.cNodeMemo != nil && s.cRec != nil && s.cEntryAggGen == gen {
+	if p != nil && len(p.cNodeMemoCache) != 0 && s.cRec != nil && s.cEntryAggGen == gen {
 		return s.cEntryAggCost, int(s.cEntryAggVis)
 	}
 	var cost uint32
@@ -1648,7 +1738,7 @@ func (p *Parser) cStackEntryAgg(s *glrStack) (uint32, int) {
 			vis += int32(p.cNodeVisibleSubtreeCount(n))
 		}
 	}
-	if p != nil && p.cNodeMemo != nil && s.cRec != nil {
+	if p != nil && len(p.cNodeMemoCache) != 0 && s.cRec != nil {
 		s.cEntryAggGen = gen
 		s.cEntryAggCost = cost
 		s.cEntryAggVis = vis
@@ -1704,7 +1794,7 @@ func (p *Parser) cStackCumulativeNodeCount(s *glrStack) int {
 	}
 	count := 0
 	if len(s.entries) > 0 {
-		if p != nil && p.cNodeMemo != nil && s.cRec != nil {
+		if p != nil && len(p.cNodeMemoCache) != 0 && s.cRec != nil {
 			_, count = p.cStackEntryAgg(s)
 		} else {
 			for i := range s.entries {
@@ -1715,7 +1805,7 @@ func (p *Parser) cStackCumulativeNodeCount(s *glrStack) int {
 		}
 		return count
 	}
-	if p != nil && p.cNodeMemo != nil && s.gss.head != nil {
+	if p != nil && len(p.cNodeMemoCache) != 0 && s.gss.head != nil {
 		var cost uint32
 		cost, count = p.cStackPrefixAgg(s.gss.head)
 		if debugRecoveryIncrementalCost {
@@ -2412,6 +2502,12 @@ func (p *Parser) cHandleError(stacks *[]glrStack, si int, source []byte, tok Tok
 	// actual suspicion signal is cRecoveryDroppedErrorForClean, scoped to the
 	// selected result's own lineage in buildResultFromGLR.
 	p.crecoveryEnteredErrorState = true
+	// This lineage is now doing real recovery-competition work (as opposed to
+	// the routine per-token GLR cost comparisons every capable parse runs even
+	// when well-formed), so it is worth upgrading the per-subtree memo from its
+	// small per-parse default to its full working-set size (see
+	// growCNodeMemoCache / cNodeMemoCacheInitialSize).
+	p.growCNodeMemoCache()
 	// Recovery machinery is running: stack error costs can now be nonzero, so
 	// the merge cost competition must run its walks from here on (sticky
 	// per-parse gate, see crecoveryCostCompetitionRelevant).

--- a/parser_recover_prefix_agg_test.go
+++ b/parser_recover_prefix_agg_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestBeforePublicationVersionBumpDoesNotInvalidateLivePrefixes(t *testing.T) {
 	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
 	p := &Parser{
-		language:  lang,
-		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+		language:       lang,
+		cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize),
 	}
 	published := &Node{symbol: 1, equivVersion: 1}
 	head := &gssNode{entry: newStackEntryNode(1, published), depth: 1}
@@ -45,8 +45,8 @@ func TestBeforePublicationVersionBumpDoesNotInvalidateLivePrefixes(t *testing.T)
 func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
 	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
 	p := &Parser{
-		language:  lang,
-		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+		language:       lang,
+		cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize),
 	}
 	payload := &Node{symbol: 1, equivVersion: 1, errorRankCache: 3}
 	head := &gssNode{entry: newStackEntryNode(1, payload), depth: 1}
@@ -89,7 +89,7 @@ func TestMetadataVersionBumpKeepsRecoveryPrefixAggregate(t *testing.T) {
 
 func TestMergeCostFillInvalidatesAndParserRefillsVisibility(t *testing.T) {
 	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
-	p := &Parser{language: lang, cNodeMemo: make(map[*Node]cNodeMemoEntry)}
+	p := &Parser{language: lang, cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize)}
 	base := &gssNode{entry: newStackEntryNode(1, &Node{symbol: 1, equivVersion: 1}), depth: 1}
 	head := &gssNode{entry: newStackEntryNode(2, &Node{symbol: 1, equivVersion: 1}), prev: base, depth: 2}
 
@@ -119,8 +119,8 @@ func TestMergeCostFillInvalidatesAndParserRefillsVisibility(t *testing.T) {
 func TestContiguousRecoveryAggregateCacheTracksStackAndNodeMutations(t *testing.T) {
 	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
 	p := &Parser{
-		language:  lang,
-		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+		language:       lang,
+		cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize),
 	}
 	first := &Node{symbol: 1, equivVersion: 1}
 	missing := &Node{symbol: 1, equivVersion: 1}
@@ -181,8 +181,8 @@ func TestContiguousRecoveryAggregateCacheTracksStackAndNodeMutations(t *testing.
 func TestExpandedGSSResultPathsKeepIndependentRecoveryAggregates(t *testing.T) {
 	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
 	p := &Parser{
-		language:  lang,
-		cNodeMemo: make(map[*Node]cNodeMemoEntry),
+		language:       lang,
+		cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize),
 	}
 	plain := &Node{symbol: 1, equivVersion: 1}
 	errChild := &Node{symbol: 1, equivVersion: 1, endByte: 1}

--- a/transient_children_test.go
+++ b/transient_children_test.go
@@ -543,7 +543,7 @@ func TestTransientScratchCheckpointMaterializesLiveStackAndReusesSlabs(t *testin
 	scratch.transientCheckpointBytes = 1
 	scratch.reduce.transientParents = &scratch.transientParents
 	scratch.reduce.transientChildren = &scratch.transientChildren
-	parser := &Parser{cNodeMemo: make(map[*Node]cNodeMemoEntry)}
+	parser := &Parser{cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheSize)}
 
 	leaf := newLeafNodeInArena(arena, Symbol(1), true, 0, 1, Point{}, Point{Column: 1})
 	children := scratch.transientChildren.alloc(1)
@@ -551,7 +551,9 @@ func TestTransientScratchCheckpointMaterializesLiveStackAndReusesSlabs(t *testin
 	parent := scratch.transientParents.allocParent(arena, Symbol(2), true, children, 0, true)
 	parent.dynamicPrecedence = 13
 	parent.rawShape = 17
-	parser.cNodeMemo[parent] = cNodeMemoEntry{hasCost: true}
+	if slot := parser.cNodeMemoSlot(parent); slot != nil {
+		*slot = cNodeMemoCacheEntry{node: uintptr(unsafe.Pointer(parent)), hasCost: true}
+	}
 	stack := glrStack{entries: []stackEntry{newStackEntryNode(7, parent)}, cacheEntries: true, byteOffset: 1}
 	parentCapacityBytes := scratch.transientParents.allocatedBytes
 	childCapacityBytes := scratch.transientChildren.allocatedBytes
@@ -579,8 +581,10 @@ func TestTransientScratchCheckpointMaterializesLiveStackAndReusesSlabs(t *testin
 	if scratch.transientCheckpoints != 1 {
 		t.Fatalf("transient checkpoints = %d, want 1", scratch.transientCheckpoints)
 	}
-	if len(parser.cNodeMemo) != 0 {
-		t.Fatal("recovery node memo retained recycled transient pointers")
+	for i := range parser.cNodeMemoCache {
+		if parser.cNodeMemoCache[i].node != 0 {
+			t.Fatal("recovery node memo retained recycled transient pointers")
+		}
 	}
 
 	reused := scratch.transientParents.allocParent(arena, Symbol(3), true, nil, 0, false)


### PR DESCRIPTION
## Summary

The fleet-tail investigation established that tail-language cost is dominated by error-recovery work (zero parity gaps vs the C oracle across 691 corpus files — every Go error is a C error; the 80-530x tail rows are recovery throughput). Profiling the recovery-heavy path put the single hottest leaf in `p.cNodeMemo` — a `map[*Node]` per-subtree error-cost/visible-count memo hit recursively inside every cost-competition comparison (`mapaccess2_fast64`/`aeshashbody` at the top of the profile).

This replaces the map with a pointer-keyed 2-way set-associative cache (same layout discipline as the existing GLR shape/equiv caches). Decisions are provably unchanged: a cache miss falls through to the identical recompute a map miss ran before — only recomputation frequency changes. Verified no call site ever iterates the old map (no ordering dependence). The cache starts at 128 slots (the cost-competition path is warm on every recovery-capable parse) and grows to 16,384 only when a parse actually enters error recovery — the naive always-large variant regressed canonical B/op +270% and was caught and fixed by this branch's own neutrality gate.

## Verification

- Recovery benchmark (new, committed): −18.0% (p=0.002, n=6, interleaved same-host benchstat); quiet-host median recorded at 116.8 ms.
- Canonical neutrality, quiet-host paired same-session A/B (count=10 each side): **+0.29% — neutral**. (An earlier contended run suggested a canonical improvement; a fresh paired bracket shows that was host drift, and no canonical claim is made.)
- Full root suite: 1,835 pass / 0 fail; recovery suites 135 pass; `-race` clean; cgo recovery-parity smoke (Caddy recovered-repetition, C++ malformed-class recovery, template/keyword parity) pass.
- Changelog bullet included.