### PR TITLE
fix(parser): Bound JS/TS compat walks under the runtime memory budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ for tags and release notes while still in `0.x`.
   trees after the parse loop had stopped cleanly. Clean-parse trees are
   byte-identical. The JS/TS fused walk has the same blind spot (no stop
   polling at all) and is tracked separately.
+- The JS/TS fused compat walk (and its unary/binary candidate-index
+  rebuild) now carries the same containment as the Go compat walk above:
+  it is skipped when the parse already carries a budget stop, polls
+  timeout/cancellation/memory-budget at the same coarse, ~1024-node
+  stride, and surfaces the stop reason via the same sticky trip flag.
+  Previously this walk polled nothing at all — no timeout, cancellation,
+  or memory-budget check of any kind — and could run to completion
+  budget-blind regardless of tree size. Clean-parse JS/TS trees are
+  byte-identical; no measurable regression on the canonical Go benchmark.
 
 ## [0.27.0] - 2026-07-12
 

--- a/parser.go
+++ b/parser.go
@@ -227,15 +227,17 @@ type Parser struct {
 	parseRuntimeMemoryHardCeilingBytes int64
 	parseMemoryBudgetDiag              parseMemoryBudgetDiagnostic
 	parseMemoryBudgetDiagActive        bool
-	// compatMemoryBudgetTripped latches true the moment Go compat
-	// normalization (normalizeGoReturnedTreeCompatibility /
-	// walkGoCompatSubtree's poller) observes a runtime memory-budget trip.
-	// The runtime heap/sys budget check is inherently non-monotonic (GC can
-	// make heap growth appear to recede), unlike arena.budgetExhausted(),
-	// which stays true for the rest of the parse once tripped — so without
-	// this sticky flag, a later, throttled resultMaterializationStopReason
-	// recheck (finalizeTree, after Go compat returns) could miss the trip
-	// entirely and stamp the tree with ParseStopAccepted despite Go compat
+	// compatMemoryBudgetTripped latches true the moment compat normalization
+	// — Go's (normalizeGoReturnedTreeCompatibility / walkGoCompatSubtree's
+	// poller) or JS/TS's fused walk (normalizeJavaScriptCompatibility /
+	// normalizeTypeScriptTreeCompatibilityWithParser / rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex's
+	// poller) — observes a runtime memory-budget trip. The runtime heap/sys
+	// budget check is inherently non-monotonic (GC can make heap growth
+	// appear to recede), unlike arena.budgetExhausted(), which stays true for
+	// the rest of the parse once tripped — so without this sticky flag, a
+	// later, throttled resultMaterializationStopReason recheck (finalizeTree,
+	// after compat normalization returns) could miss the trip entirely and
+	// stamp the tree with ParseStopAccepted despite compat normalization
 	// having already bailed out mid-walk. See resultMaterializationStopReason.
 	compatMemoryBudgetTripped    bool
 	denseLimit                   int

--- a/parser_result.go
+++ b/parser_result.go
@@ -150,8 +150,9 @@ func (p *Parser) resultMaterializationStopReason(arena *nodeArena) ParseStopReas
 		if reason := p.parseStopReasonNow(); parseStopReasonIsActive(reason) {
 			return reason
 		}
-		// compatMemoryBudgetTripped is Go compat normalization's own sticky
-		// latch (see (*Parser).goCompatRuntimeMemoryBudgetStopReason): unlike
+		// compatMemoryBudgetTripped is compat normalization's own sticky
+		// latch, shared by the Go and JS/TS fused compat walks (see
+		// (*Parser).compatRuntimeMemoryBudgetStopReason): unlike
 		// arena.budgetExhausted() below, which stays true for the rest of the
 		// parse once tripped, a runtime heap/sys budget trip is inherently
 		// non-monotonic (GC can make heap growth appear to recede), so without

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -181,7 +181,7 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 	case "java":
 		normalizeJavaCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "javascript":
-		normalizeJavaScriptCompatibility(ctx.root, ctx.source, ctx.lang)
+		return resultCompatibilityResult{stopReason: normalizeJavaScriptCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)}
 	case "julia":
 		normalizeJuliaCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "just":
@@ -265,7 +265,7 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 	case "wolfram":
 		normalizeWolframCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "tsx", "typescript":
-		normalizeTypeScriptTreeCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		return resultCompatibilityResult{stopReason: normalizeTypeScriptTreeCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)}
 	case "typst":
 		normalizeTypstCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "yaml":

--- a/parser_result_go.go
+++ b/parser_result_go.go
@@ -60,7 +60,7 @@ func (p *Parser) goCompatMemoryBudgetStopReason(arena *nodeArena) ParseStopReaso
 	if arena != nil && arena.budgetExhausted() {
 		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)
 	}
-	return p.goCompatRuntimeMemoryBudgetStopReason()
+	return p.compatRuntimeMemoryBudgetStopReason()
 }
 
 func normalizeGoSourceFileRoot(root *Node, source []byte, p *Parser) {

--- a/parser_result_go_compat.go
+++ b/parser_result_go_compat.go
@@ -26,16 +26,19 @@ type goCompatibilitySourceFlags struct {
 	trailingBoundary bool
 }
 
-// goCompatRuntimeMemoryBudgetStopReason forces a real runtime memory-budget
-// check and, when it trips, latches p.compatMemoryBudgetTripped. Every Go
-// compat call site that needs memory-budget awareness (the walk-internal
-// poller's memoryBudgetParser hook, and goCompatMemoryBudgetStopReason's
-// per-stage boundary check) goes through this instead of calling
+// compatRuntimeMemoryBudgetStopReason forces a real runtime memory-budget
+// check and, when it trips, latches p.compatMemoryBudgetTripped. Every
+// compat call site that needs memory-budget awareness — the Go compat
+// walk-internal poller's memoryBudgetParser hook and goCompatMemoryBudgetStopReason's
+// per-stage boundary check (this file / parser_result_go.go), and their JS/TS
+// fused-walk counterparts (javaScriptTypeScriptCompatMemoryBudgetStopReason
+// and the fused walk's own poller.memoryBudgetParser hook, parser_result_javascript_typescript.go)
+// — goes through this shared helper instead of calling
 // runtimeMemoryBudgetStopReasonNow directly, so a trip detected anywhere in
-// the Go compat pipeline is reliably surfaced later by
+// either compat pipeline is reliably surfaced later by
 // resultMaterializationStopReason (see compatMemoryBudgetTripped's doc
 // comment on the Parser struct for why a plain re-check is not enough).
-func (p *Parser) goCompatRuntimeMemoryBudgetStopReason() ParseStopReason {
+func (p *Parser) compatRuntimeMemoryBudgetStopReason() ParseStopReason {
 	if p == nil {
 		return ParseStopNone
 	}

--- a/parser_result_go_compat_memory_budget_test.go
+++ b/parser_result_go_compat_memory_budget_test.go
@@ -12,7 +12,10 @@ import (
 // excludes ParseStopMemoryBudget), so a C-recovery-widened Go tree's compat
 // walk could balloon heap growth during result finalization independent of
 // whatever the parse loop itself already enforced. The fix threads
-// (*Parser).goCompatRuntimeMemoryBudgetStopReason into the walk's poller
+// (*Parser).compatRuntimeMemoryBudgetStopReason (renamed from
+// goCompatRuntimeMemoryBudgetStopReason once the JS/TS fused walk started
+// sharing it — see parser_result_javascript_typescript_memory_budget_test.go)
+// into the walk's poller
 // (parseStopPoller.memoryBudgetParser) and into per-stage boundary checks in
 // normalizeGoReturnedTreeCompatibility (parser_result_go.go), and latches
 // compatMemoryBudgetTripped so a trip detected there is reliably surfaced by

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -2,25 +2,104 @@ package gotreesitter
 
 import "bytes"
 
-func normalizeJavaScriptCompatibility(root *Node, source []byte, lang *Language) {
+// javaScriptTypeScriptCompatMemoryBudgetStopReason forces a real (unmasked)
+// memory-budget check for the JS/TS fused compat pipeline's stage boundaries
+// in normalizeJavaScriptCompatibility / normalizeTypeScriptTreeCompatibilityWithParser.
+// Mirrors (*Parser).goCompatMemoryBudgetStopReason (parser_result_go.go): the
+// JS/TS fused walk shared the identical containment gap the Go compat walk
+// had before the 2026-07-12 gocompat-walk-containment-gap fix — no stop
+// polling of any kind (no timeout, cancellation, or memory-budget check) —
+// so a parse that is already over budget (the parse loop stopped, or the
+// arena/runtime heap grew past budget during an earlier stage) would
+// otherwise normalize a partial tree with no guarantee of a consistent,
+// budget-honoring result.
+func (p *Parser) javaScriptTypeScriptCompatMemoryBudgetStopReason(arena *nodeArena) ParseStopReason {
+	if p == nil {
+		return ParseStopNone
+	}
+	if arena != nil && arena.budgetExhausted() {
+		return p.noteMemoryBudgetStop(parseMemoryBudgetStopSourceArena)
+	}
+	return p.compatRuntimeMemoryBudgetStopReason()
+}
+
+// normalizeJavaScriptCompatibility drives JavaScript's post-build
+// compatibility pipeline. It mirrors normalizeGoReturnedTreeCompatibility's
+// containment discipline (parser_result_go.go): it is skipped entirely when
+// the parse already carries an active stop (timeout/cancellation) or an
+// already-tripped memory budget, and the fused walk plus the other
+// whole-tree passes below are wired with a parseStopPoller (timeout +
+// cancellation + runtime memory budget) at the same coarse, ~1024-node
+// stride the Go compat walk uses (parseStopPollMask), so a runaway tree can
+// no longer balloon heap growth budget-blind during result finalization.
+func normalizeJavaScriptCompatibility(root *Node, source []byte, p *Parser, lang *Language) ParseStopReason {
+	var arena *nodeArena
+	if root != nil {
+		arena = root.ownerArena
+	}
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := p.javaScriptTypeScriptCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
+		return reason
+	}
 	normalizeJavaScriptProgramStart(root, lang)
+
+	poller := parseStopPoller{check: p.activeParseStopCheck(), memoryBudgetParser: p}
 	// Fused walk handles empty_statement, statement keywords (if/while),
 	// optional-chain leaves, call_expression precedence, and builds unary/
 	// binary candidate indexes — six separate full-tree walks collapsed into
 	// one walk + indexed rewrites.
-	normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedence(root, source, lang)
-	normalizeJavaScriptTrailingContinueComments(root, source, lang)
+	if _, reason := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, &poller); resultMaterializationShouldStop(reason) {
+		return reason
+	}
+	if reason := normalizeJavaScriptTrailingContinueComments(root, source, lang, &poller); resultMaterializationShouldStop(reason) {
+		return reason
+	}
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := p.javaScriptTypeScriptCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
+		return reason
+	}
 	normalizeJavaScriptTopLevelExpressionStatementBounds(root, lang)
 	normalizeJavaScriptTopLevelDeclarationBounds(root, lang)
 	normalizeJavaScriptTopLevelObjectLiterals(root, lang)
 	normalizeJavaScriptProgramEnd(root, source, lang)
+	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	return p.javaScriptTypeScriptCompatMemoryBudgetStopReason(arena)
 }
 
-func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, parser *Parser, lang *Language) {
+// normalizeTypeScriptTreeCompatibilityWithParser drives TypeScript/TSX's
+// post-build compatibility pipeline. It shares normalizeJavaScriptCompatibility's
+// containment discipline (see its doc comment above): skipped entirely when
+// the parse already carries an active stop or an already-tripped memory
+// budget, and the fused walk is wired with a parseStopPoller at the same
+// coarse ~1024-node stride the Go compat walk uses. Both the fast (default)
+// path and the metrics-recording path below share the same fused walk and
+// poller, so containment applies identically regardless of which path is
+// taken.
+func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, parser *Parser, lang *Language) ParseStopReason {
+	var arena *nodeArena
+	if root != nil {
+		arena = root.ownerArena
+	}
+	if reason := parser.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	if reason := parser.javaScriptTypeScriptCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
+		return reason
+	}
+	poller := parseStopPoller{check: parser.activeParseStopCheck(), memoryBudgetParser: parser}
 	recordPasses := parser != nil && parser.currentMaterializationTiming() != nil
 	if !recordPasses {
 		// Statement keyword and precedence normalizers share one indexed walk.
-		syntaxStats := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang)
+		syntaxStats, reason := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, &poller)
+		if resultMaterializationShouldStop(reason) {
+			return reason
+		}
 		normalizeTypeScriptRecoveredTernaryGenericCallRoot(root, source, lang)
 		normalizeTypeScriptRecoveredNamespaceRoot(root, source, lang)
 		normalizeJavaScriptTopLevelDeclarationBounds(root, lang)
@@ -30,7 +109,10 @@ func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, p
 			normalizeTypeScriptCompatibility(root, source, lang)
 		}
 		normalizeJavaScriptTopLevelExpressionStatementBounds(root, lang)
-		return
+		if reason := parser.activeParseStopReason(); parseStopReasonIsActive(reason) {
+			return reason
+		}
+		return parser.javaScriptTypeScriptCompatMemoryBudgetStopReason(arena)
 	}
 	run := func(name string, fn func() normalizationPassCounters) {
 		parser.runNamedNormalizationPass(name, func() bool { return true }, fn)
@@ -43,11 +125,14 @@ func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, p
 	}
 	recordTypeScriptCompatSourceFlagMetrics(parser, typeScriptCompatSourceFlagsFor(source))
 
-	recordTypeScriptCompatCandidateMetrics(parser, root, lang)
+	if reason := recordTypeScriptCompatCandidateMetrics(parser, root, lang, &poller); resultMaterializationShouldStop(reason) {
+		return reason
+	}
 	var syntaxStats javaScriptTypeScriptSyntaxNormalizationStats
 	var haveSyntaxStats bool
+	var syntaxStopReason ParseStopReason
 	run("ts_statement_keyword_leaves", func() normalizationPassCounters {
-		syntaxStats = normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang)
+		syntaxStats, syntaxStopReason = normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, &poller)
 		haveSyntaxStats = true
 		parser.recordNormalizationMetric("ts_syntax_precedence_index", 1, syntaxStats.indexBuilds, syntaxStats.indexNodesVisited, 0)
 		parser.recordNormalizationMetric("ts_empty_statement_candidates", 1, 1, syntaxStats.emptyStatement.nodesVisited, syntaxStats.emptyStatement.nodesRewritten)
@@ -58,6 +143,15 @@ func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, p
 		parser.recordNormalizationMetric("ts_binary_precedence_candidates", 1, 1, syntaxStats.binary.nodesVisited, syntaxStats.binary.nodesRewritten)
 		return syntaxStats.statementKeyword
 	})
+	// resultMaterializationShouldStop (not parseStopReasonIsActive): the fused
+	// walk above may report ParseStopMemoryBudget, which parseStopReasonIsActive
+	// deliberately excludes. Skip every remaining metrics pass below once the
+	// walk itself has already bailed out — mirroring normalizeGoReturnedTreeCompatibility's
+	// per-stage bail-out discipline (parser_result_go.go) — rather than running
+	// more passes over a tree the walk stopped partway through.
+	if resultMaterializationShouldStop(syntaxStopReason) {
+		return syntaxStopReason
+	}
 	run("ts_empty_statement", func() normalizationPassCounters {
 		if haveSyntaxStats {
 			return syntaxStats.emptyStatement
@@ -121,6 +215,10 @@ func normalizeTypeScriptTreeCompatibilityWithParser(root *Node, source []byte, p
 	runVoid("ts_top_level_expression_bounds", func() {
 		normalizeJavaScriptTopLevelExpressionStatementBounds(root, lang)
 	})
+	if reason := parser.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return reason
+	}
+	return parser.javaScriptTypeScriptCompatMemoryBudgetStopReason(arena)
 }
 
 type typeScriptCompatSourceFlags struct {
@@ -292,11 +390,17 @@ type typeScriptCompatCandidateMetrics struct {
 	namespaceNodes    uint64
 }
 
-func recordTypeScriptCompatCandidateMetrics(parser *Parser, root *Node, lang *Language) {
+// recordTypeScriptCompatCandidateMetrics is diagnostic-only (only reached
+// when parser.currentMaterializationTiming() != nil): it does its own
+// separate full-tree walk purely to record per-category candidate counts
+// before the fused walk runs. Threading poller through it (like every other
+// whole-tree pass in this file) means enabling detailed normalization
+// metrics can never itself create an unbounded, budget-blind walk.
+func recordTypeScriptCompatCandidateMetrics(parser *Parser, root *Node, lang *Language, poller *parseStopPoller) ParseStopReason {
 	if parser == nil || root == nil || lang == nil {
-		return
+		return ParseStopNone
 	}
-	metrics := typeScriptCompatCandidateMetricsFor(root, lang)
+	metrics, reason := typeScriptCompatCandidateMetricsFor(root, lang, poller)
 	parser.recordNormalizationMetric("ts_candidates_index", 1, 1, metrics.nodesVisited, 0)
 	parser.recordNormalizationMetric("ts_candidates_call_expression", 1, 1, metrics.callExpressions, 0)
 	parser.recordNormalizationMetric("ts_candidates_unary_expression", 1, 1, metrics.unaryExpressions, 0)
@@ -305,12 +409,20 @@ func recordTypeScriptCompatCandidateMetrics(parser *Parser, root *Node, lang *La
 	parser.recordNormalizationMetric("ts_candidates_import_nodes", 1, 1, metrics.importNodes, 0)
 	parser.recordNormalizationMetric("ts_candidates_member_nodes", 1, 1, metrics.memberNodes, 0)
 	parser.recordNormalizationMetric("ts_candidates_namespace_nodes", 1, 1, metrics.namespaceNodes, 0)
+	return reason
 }
 
-func typeScriptCompatCandidateMetricsFor(root *Node, lang *Language) typeScriptCompatCandidateMetrics {
+func typeScriptCompatCandidateMetricsFor(root *Node, lang *Language, poller *parseStopPoller) (typeScriptCompatCandidateMetrics, ParseStopReason) {
 	var metrics typeScriptCompatCandidateMetrics
+	var stopReason ParseStopReason
 	syms := typeScriptCompatCandidateSymbolsFor(lang)
-	walkResultTreeDenseFirst(root, func(n *Node) {
+	walkResultTreeUntil(root, func(n *Node) bool {
+		if poller != nil {
+			if reason := poller.poll(); resultMaterializationShouldStop(reason) {
+				stopReason = reason
+				return false
+			}
+		}
 		metrics.nodesVisited++
 		switch {
 		case syms.hasCallExpression && n.symbol == syms.callExpression:
@@ -338,8 +450,9 @@ func typeScriptCompatCandidateMetricsFor(root *Node, lang *Language) typeScriptC
 			(syms.hasIndexedAccessType && n.symbol == syms.indexedAccessType):
 			metrics.typeNodes++
 		}
+		return true
 	})
-	return metrics
+	return metrics, stopReason
 }
 
 type typeScriptCompatCandidateSymbols struct {
@@ -741,19 +854,28 @@ func setStackEntryStart(entry stackEntry, startByte uint32, startPoint Point) {
 	}
 }
 
-func normalizeJavaScriptTrailingContinueComments(root *Node, source []byte, lang *Language) {
+func normalizeJavaScriptTrailingContinueComments(root *Node, source []byte, lang *Language, poller *parseStopPoller) ParseStopReason {
 	if root == nil || lang == nil || lang.Name != "javascript" || len(source) == 0 {
-		return
+		return ParseStopNone
 	}
 	// Source-level gate: this pass only acts on continue_statement nodes
 	// with trailing comments. If source has neither "continue" nor "//",
 	// no candidate exists and the walk is wasted on large files like jquery.
 	if !bytes.Contains(source, []byte("continue")) || !bytes.Contains(source, []byte("//")) {
-		return
+		return ParseStopNone
 	}
-	walkResultTreeDenseFirst(root, func(n *Node) {
+	var stopReason ParseStopReason
+	walkResultTreeUntil(root, func(n *Node) bool {
+		if poller != nil {
+			if reason := poller.poll(); resultMaterializationShouldStop(reason) {
+				stopReason = reason
+				return false
+			}
+		}
 		normalizeJavaScriptTrailingContinueCommentSiblings(n, source, lang)
+		return true
 	})
+	return stopReason
 }
 
 func normalizeJavaScriptTrailingContinueCommentSiblings(parent *Node, source []byte, lang *Language) {
@@ -910,13 +1032,23 @@ type javaScriptTypeScriptSyntaxNormalizationStats struct {
 }
 
 func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedence(root *Node, source []byte, lang *Language) {
-	_ = normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang)
+	_, _ = normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, nil)
 }
 
-func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root *Node, source []byte, lang *Language) javaScriptTypeScriptSyntaxNormalizationStats {
+// normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats
+// drives the fused walk (rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex)
+// and its follow-on candidate rewrites. poller, when non-nil, is threaded
+// through the fused walk and the unary-rewrite-triggered index rebuild
+// (buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex) — both real
+// whole-tree passes — so a timeout, cancellation, or runtime memory-budget
+// trip anywhere in this call chain aborts the remaining work instead of
+// running unbounded to completion. poller == nil (every caller other than
+// normalizeJavaScriptCompatibility / normalizeTypeScriptTreeCompatibilityWithParser)
+// preserves the exact prior unbounded behavior.
+func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root *Node, source []byte, lang *Language, poller *parseStopPoller) (javaScriptTypeScriptSyntaxNormalizationStats, ParseStopReason) {
 	var stats javaScriptTypeScriptSyntaxNormalizationStats
 	if root == nil || lang == nil {
-		return stats
+		return stats, ParseStopNone
 	}
 	switch lang.Name {
 	case "javascript", "typescript", "tsx":
@@ -928,7 +1060,7 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 		stats.binary = precedence.binary
 		stats.indexBuilds = precedence.indexBuilds
 		stats.indexNodesVisited = precedence.indexNodesVisited
-		return stats
+		return stats, ParseStopNone
 	}
 	callSym, hasCallSym := symbolByName(lang, "call_expression")
 	unarySym, hasUnarySym := symbolByName(lang, "unary_expression")
@@ -962,7 +1094,7 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 		}
 	}
 
-	index := rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex(
+	index, reason := rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex(
 		root, source, lang,
 		callSym, hasCallSym, unarySym, hasUnarySym, binarySym, hasBinarySym,
 		emptyStatementSym, hasEmptyStatement, semicolonSym, semicolonNamed, hasSemicolon,
@@ -973,6 +1105,7 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 		optionalChainSym, optionalChainTokenSym, optionalChainTokenNamed, enableOptionalChain,
 		dynamicImportSym, importKeywordSym, enableDynamicImport,
 		typeScriptCtx,
+		poller,
 	)
 	stats.emptyStatement = index.emptyStatement
 	stats.existentialType = index.existentialType
@@ -981,15 +1114,26 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 	stats.typeScriptCompatibility = index.typeScriptCompatibility
 	stats.indexBuilds += index.builds
 	stats.indexNodesVisited += index.nodesVisited
+	// resultMaterializationShouldStop (not a plain != ParseStopNone check, for
+	// clarity/consistency with every other bail-out in this file): the fused
+	// walk stopped mid-traversal, so unaryCandidates/binaryCandidates only
+	// cover a prefix of the tree — stop here rather than rewriting a partial,
+	// possibly misleading candidate list.
+	if resultMaterializationShouldStop(reason) {
+		return stats, reason
+	}
 	if hasUnarySym {
 		stats.unary = rewriteJavaScriptTypeScriptPrecedenceCandidates(index.unaryCandidates, func(n *Node) *Node {
 			return rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(n, lang, unarySym)
 		})
 		if stats.unary.nodesRewritten != 0 && hasBinarySym {
-			rebuild := buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root, unarySym, binarySym)
+			rebuild, rebuildReason := buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root, unarySym, binarySym, poller)
 			stats.indexBuilds += rebuild.builds
 			stats.indexNodesVisited += rebuild.nodesVisited
 			index.binaryCandidates = rebuild.binaryCandidates
+			if resultMaterializationShouldStop(rebuildReason) {
+				return stats, rebuildReason
+			}
 		}
 	}
 	if hasBinarySym {
@@ -997,7 +1141,7 @@ func normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStat
 			return rewriteJavaScriptTypeScriptBinaryPrecedenceWithSymbol(n, lang, binarySym)
 		})
 	}
-	return stats
+	return stats, ParseStopNone
 }
 
 func normalizeJavaScriptTypeScriptPrecedenceWithDetailedStats(root *Node, lang *Language) javaScriptTypeScriptPrecedenceStats {
@@ -1034,7 +1178,7 @@ func normalizeJavaScriptTypeScriptPrecedenceWithDetailedStats(root *Node, lang *
 		return rewriteJavaScriptTypeScriptUnaryPrecedenceWithSymbol(n, lang, unarySym)
 	})
 	if stats.unary.nodesRewritten != 0 {
-		rebuild := buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root, unarySym, binarySym)
+		rebuild, _ := buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root, unarySym, binarySym, nil)
 		stats.indexBuilds += rebuild.builds
 		stats.indexNodesVisited += rebuild.nodesVisited
 		index.binaryCandidates = rebuild.binaryCandidates
@@ -1085,10 +1229,11 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 	importKeywordSym Symbol,
 	enableDynamicImport bool,
 	typeScriptCtx *typeScriptNormalizationContext,
-) javaScriptTypeScriptUnaryBinaryPrecedenceIndex {
+	poller *parseStopPoller,
+) (javaScriptTypeScriptUnaryBinaryPrecedenceIndex, ParseStopReason) {
 	var index javaScriptTypeScriptUnaryBinaryPrecedenceIndex
 	if root == nil {
-		return index
+		return index, ParseStopNone
 	}
 	// If none of the symbols this walk targets exists in the language, there
 	// is nothing to do; returning early avoids materializing final-ref
@@ -1098,7 +1243,7 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 		!hasEmptyStatement && !hasExistentialType &&
 		!hasIfStmt && !hasWhileStmt && !enableDynamicImport &&
 		typeScriptCtx == nil {
-		return index
+		return index, ParseStopNone
 	}
 	index.builds = 1
 	if typeScriptCtx != nil {
@@ -1118,10 +1263,31 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 			typeScriptCtx.canRewriteGenericArrows ||
 			typeScriptCtx.canRewriteClassDeclarations ||
 			typeScriptCtx.canRewriteDestructuring)
+	// stopReason/stopped let this walk bail out mid-traversal — checked once
+	// per node visited, at the coarse, poller-throttled cadence poll() applies
+	// (parseStopPollMask, the same ~1024-node stride walkGoCompatSubtree uses,
+	// see parser_result_go_compat.go) — on timeout, cancellation, or a runtime
+	// memory-budget trip. Every loop below re-checks the cheap `stopped` flag
+	// before doing further per-child rewrite work, so a trip anywhere in the
+	// recursion unwinds the whole walk immediately instead of continuing to
+	// materialize partial candidate lists (see the 2026-07-12
+	// gocompat-walk-containment-gap finding, which flagged this fused walk as
+	// sharing the Go compat walk's containment gap: before this, this walk
+	// polled nothing at all — no timeout, cancellation, or memory-budget
+	// check of any kind).
+	var stopReason ParseStopReason
+	stopped := false
 	var walk func(*Node)
 	walk = func(n *Node) {
-		if n == nil {
+		if n == nil || stopped {
 			return
+		}
+		if poller != nil {
+			if reason := poller.poll(); resultMaterializationShouldStop(reason) {
+				stopReason = reason
+				stopped = true
+				return
+			}
 		}
 		index.nodesVisited++
 		switch n.symbol {
@@ -1163,6 +1329,9 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 		if n.childIndex <= finalChildSidecarIndexBase && n.ownerArena != nil {
 			childCount := resultChildCount(n)
 			for i := 0; i < childCount; i++ {
+				if stopped {
+					break
+				}
 				child := resultChildAt(n, i)
 				if child == nil {
 					continue
@@ -1177,6 +1346,9 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 					}
 				}
 				walk(child)
+				if stopped {
+					break
+				}
 				switch child.symbol {
 				case unarySym:
 					if hasUnarySym {
@@ -1199,6 +1371,9 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 
 		children := n.children
 		for i, child := range children {
+			if stopped {
+				break
+			}
 			if child == nil {
 				continue
 			}
@@ -1277,6 +1452,9 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 				}
 			}
 			walk(child)
+			if stopped {
+				break
+			}
 			switch child.symbol {
 			case unarySym:
 				if hasUnarySym {
@@ -1296,7 +1474,7 @@ func rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBina
 		}
 	}
 	walk(root)
-	return index
+	return index, stopReason
 }
 
 func normalizeJavaScriptTypeScriptEmptyStatementLeafWithSymbolChanged(node *Node, source []byte, semicolonSym Symbol, semicolonNamed bool) bool {
@@ -1646,13 +1824,30 @@ type javaScriptTypeScriptUnaryBinaryPrecedenceIndex struct {
 	nodesVisited            uint64
 }
 
-func buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root *Node, unarySym, binarySym Symbol) javaScriptTypeScriptUnaryBinaryPrecedenceIndex {
+// buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex re-scans the whole tree
+// for unary/binary candidates after a unary rewrite has changed the tree
+// shape (see its call site above): a real, reachable whole-tree pass, not
+// just a diagnostic one, so poller is threaded through it exactly like the
+// fused walk it follows — a timeout, cancellation, or runtime memory-budget
+// trip aborts the rescan immediately rather than completing it budget-blind.
+// poller == nil preserves the exact prior unbounded behavior.
+func buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root *Node, unarySym, binarySym Symbol, poller *parseStopPoller) (javaScriptTypeScriptUnaryBinaryPrecedenceIndex, ParseStopReason) {
 	var index javaScriptTypeScriptUnaryBinaryPrecedenceIndex
 	if root == nil {
-		return index
+		return index, ParseStopNone
 	}
 	index.builds = 1
-	walkResultTreePostorder(root, func(n *Node) {
+	var stopReason ParseStopReason
+	walkResultTreePostorderUntil(root, func() bool {
+		if poller == nil {
+			return false
+		}
+		if reason := poller.poll(); resultMaterializationShouldStop(reason) {
+			stopReason = reason
+			return true
+		}
+		return false
+	}, func(n *Node) {
 		index.nodesVisited++
 		if n == nil {
 			return
@@ -1679,7 +1874,7 @@ func buildJavaScriptTypeScriptUnaryBinaryPrecedenceIndex(root *Node, unarySym, b
 			}
 		}
 	})
-	return index
+	return index, stopReason
 }
 
 func rewriteJavaScriptTypeScriptPrecedenceCandidates(candidates []javaScriptTypeScriptPrecedenceCandidate, rewrite func(*Node) *Node) normalizationPassCounters {

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -110,7 +110,7 @@ func TestNormalizeJavaScriptEmptyStatementRestoresSemicolonChild(t *testing.T) {
 	stmt := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
 	root := newParentNodeInArena(arena, 1, true, []*Node{stmt}, nil, 0)
 
-	normalizeJavaScriptCompatibility(root, []byte(";"), lang)
+	normalizeJavaScriptCompatibility(root, []byte(";"), nil, lang)
 
 	if got, want := resultChildCount(stmt), 1; got != want {
 		t.Fatalf("empty_statement child count = %d, want %d", got, want)
@@ -434,7 +434,7 @@ func TestNormalizeTypeScriptCompatibilityCandidatesApplyIndexedDirectRewrites(t 
 	enumBody.setFieldSources([]uint8{fieldSourceDirect})
 	root := newParentNodeInArena(arena, 1, true, []*Node{identifier, enumBody}, nil, 0)
 
-	stats := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang)
+	stats, _ := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, nil)
 	if !stats.typeScriptCompatibility.built {
 		t.Fatal("typeScriptCompatibility candidate index was not built")
 	}
@@ -577,7 +577,7 @@ func TestNormalizeJavaScriptStatementKeywordRestoresWhileLeaf(t *testing.T) {
 	stmt.endPoint = Point{Column: 12}
 	root := newParentNodeInArena(arena, 1, true, []*Node{stmt}, nil, 0)
 
-	normalizeJavaScriptCompatibility(root, source, lang)
+	normalizeJavaScriptCompatibility(root, source, nil, lang)
 
 	first := resultChildAt(stmt, 0)
 	if first == nil {
@@ -623,7 +623,7 @@ func TestNormalizeJavaScriptStatementKeywordRestoresFinalRefWhileLeaf(t *testing
 	rootEntry := newStackEntryPendingParent(rootParent.parseState, rootParent)
 	root := materializeStackEntryPendingParent(arena, &rootEntry, pendingParentMaterializeForFinalTree)
 
-	normalizeJavaScriptCompatibility(root, source, lang)
+	normalizeJavaScriptCompatibility(root, source, nil, lang)
 
 	child := root.Child(0)
 	if child == nil {

--- a/parser_result_javascript_typescript_memory_budget_clean_test.go
+++ b/parser_result_javascript_typescript_memory_budget_clean_test.go
@@ -1,0 +1,70 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// jstsCompatCleanParseGoldenSExprJS / jstsCompatCleanParseGoldenSExprTS pin
+// the exact normalized shape of testJSTSCompatCleanParseSourceJS/TS (if/while
+// statement-keyword normalization, empty_statement semicolon drop, and
+// call/unary/binary precedence rewrites — everything the fused walk
+// touches), captured before the 2026-07-13 jstswalk-containment-gap fix and
+// re-verified identical after.
+const jstsCompatCleanParseGoldenSExprJS = "(program (if_statement (parenthesized_expression (identifier)) (statement_block (expression_statement (call_expression (identifier) (arguments)))) (else_clause (statement_block (expression_statement (call_expression (identifier) (arguments)))))) (while_statement (parenthesized_expression (identifier)) (statement_block (expression_statement (call_expression (identifier) (arguments))))) (lexical_declaration (variable_declarator (identifier) (binary_expression (unary_expression (identifier)) (binary_expression (unary_expression (identifier)) (identifier))))) (empty_statement) (expression_statement (call_expression (identifier) (arguments (call_expression (identifier) (arguments (identifier)))))))"
+const jstsCompatCleanParseGoldenSExprTS = "(program (if_statement (parenthesized_expression (identifier)) (statement_block (expression_statement (call_expression (identifier) (arguments)))) (else_clause (statement_block (expression_statement (call_expression (identifier) (arguments)))))) (while_statement (parenthesized_expression (identifier)) (statement_block (expression_statement (call_expression (identifier) (arguments))))) (lexical_declaration (variable_declarator (identifier) (type_annotation (predefined_type)) (binary_expression (unary_expression (identifier)) (binary_expression (unary_expression (identifier)) (identifier))))) (empty_statement) (expression_statement (call_expression (identifier) (type_arguments (predefined_type)) (arguments (call_expression (identifier) (arguments (identifier)))))))"
+
+const testJSTSCompatCleanParseSourceJS = "if (a) { b(); } else { c(); }\nwhile (x) { y(); }\nlet z = !a + -b * c;\n;\nfoo(bar(baz));\n"
+const testJSTSCompatCleanParseSourceTS = "if (a) { b(); } else { c(); }\nwhile (x) { y(); }\nlet z: number = !a + -b * c;\n;\nfoo<string>(bar(baz));\n"
+
+// TestJSTSCompatCleanParseUnaffectedByMemoryBudgetFix is an explicit
+// byte-identity check for the 2026-07-13 jstswalk-containment-gap fix
+// (parseStopPoller.memoryBudgetParser / javaScriptTypeScriptCompatMemoryBudgetStopReason
+// / the shared compatMemoryBudgetTripped sticky latch): a clean,
+// comfortably-within-any-reasonable-budget JS/TS parse must produce the
+// exact same normalized tree shape as before the fix — the new code paths
+// only ever change behavior when a memory budget is actually configured AND
+// actually trips, which never happens here.
+func TestJSTSCompatCleanParseUnaffectedByMemoryBudgetFix(t *testing.T) {
+	cases := []struct {
+		lang   string
+		src    string
+		golden string
+	}{
+		{lang: "javascript", src: testJSTSCompatCleanParseSourceJS, golden: jstsCompatCleanParseGoldenSExprJS},
+		{lang: "typescript", src: testJSTSCompatCleanParseSourceTS, golden: jstsCompatCleanParseGoldenSExprTS},
+	}
+	for _, tc := range cases {
+		t.Run(tc.lang, func(t *testing.T) {
+			for _, label := range []string{"default", "budget=4096MB"} {
+				t.Run(label, func(t *testing.T) {
+					if label == "budget=4096MB" {
+						t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "4096")
+						gotreesitter.ResetParseEnvConfigCacheForTests()
+						defer gotreesitter.ResetParseEnvConfigCacheForTests()
+					}
+					tree, lang := parseLanguageSample(t, tc.lang, tc.src)
+					t.Cleanup(tree.Release)
+
+					if got, want := tree.ParseStopReason(), gotreesitter.ParseStopAccepted; got != want {
+						t.Fatalf("ParseStopReason() = %q, want %q", got, want)
+					}
+					if tree.ParseStoppedEarly() {
+						t.Fatal("ParseStoppedEarly() = true, want false for a clean small parse")
+					}
+					root := tree.RootNode()
+					if root == nil {
+						t.Fatal("RootNode() = nil")
+					}
+					if root.HasError() {
+						t.Fatalf("clean %s source reported an error: %s", tc.lang, root.SExpr(lang))
+					}
+					if got := root.SExpr(lang); got != tc.golden {
+						t.Fatalf("SExpr drift:\n got:  %s\n want: %s", got, tc.golden)
+					}
+				})
+			}
+		})
+	}
+}

--- a/parser_result_javascript_typescript_memory_budget_test.go
+++ b/parser_result_javascript_typescript_memory_budget_test.go
@@ -1,0 +1,191 @@
+package gotreesitter
+
+import (
+	"runtime"
+	"testing"
+)
+
+// This file regression-tests the 2026-07-13 jstswalk-containment-gap fix,
+// the JS/TS analogue of the 2026-07-12 gocompat-walk-containment-gap fix
+// (see parser_result_go_compat_memory_budget_test.go): the JS/TS fused
+// compat walk (rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex,
+// driven by normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats)
+// had ZERO stop polling of any kind before this fix — no timeout,
+// cancellation, or memory-budget check — so it ran to completion (ballooning
+// heap growth via its own candidate-index bookkeeping) regardless of the
+// parse's configured runtime memory budget. The fix wires a *parseStopPoller
+// with memoryBudgetParser set into the walk (mirroring the Go compat walk's
+// poller.memoryBudgetParser hook, parser_result_go_compat.go) and checks the
+// poller once per node visited, throttled to the same ~1024-node stride
+// (parseStopPollMask) walkGoCompatSubtree uses.
+//
+// buildJSTSCompatWideUnaryTree below models the trigger shape without an
+// end-to-end multi-hundred-MB reproduction: a wide, flat tree of many real,
+// distinct unary_expression leaf children whose fused-walk cost (the
+// index.unaryCandidates slice growing by one entry per child, genuinely
+// proportional to tree size) is real, unavoidable, non-idempotent work —
+// calibrated so unbounded work is clearly larger than a small configured
+// budget while staying well under ~1GiB for test safety.
+
+const (
+	testJSTSCompatProgramSym         Symbol = 1
+	testJSTSCompatUnaryExpressionSym Symbol = 2
+)
+
+// buildJSTSCompatWideUnaryTree builds a "program" root with numUnary distinct
+// unary_expression leaf children (no node sharing — an ordinary tree, unlike
+// the historical Go DAG/cycle defect) and a minimal *Language whose symbol
+// table matches, so rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex
+// (via normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats)
+// resolves "unary_expression" the same way it would for a real grammar.
+func buildJSTSCompatWideUnaryTree(numUnary int) (*Node, *Language) {
+	arena := newNodeArena(arenaClassFull)
+	children := make([]*Node, numUnary)
+	for i := 0; i < numUnary; i++ {
+		off := uint32(i)
+		children[i] = newLeafNodeInArena(arena, testJSTSCompatUnaryExpressionSym, true, off, off+1, Point{}, Point{})
+	}
+	root := newParentNodeInArena(arena, testJSTSCompatProgramSym, true, cloneNodeSliceInArena(arena, children), nil, 0)
+
+	lang := &Language{
+		Name:        "javascript",
+		SymbolNames: []string{"EOF", "program", "unary_expression"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "program", Visible: true, Named: true},
+			{Name: "unary_expression", Visible: true, Named: true},
+		},
+	}
+	return root, lang
+}
+
+// TestJSTSFusedWalkUnboundedBaselineCompletes establishes the baseline: with
+// no memory-budget parser wired into the poller (poller == nil — the pre-fix
+// shape, since the fused walk previously had no poller parameter at all), the
+// walk runs to completion and visits every child regardless of tree size.
+// This is the control for TestJSTSFusedWalkStopsOnMemoryBudget below.
+func TestJSTSFusedWalkUnboundedBaselineCompletes(t *testing.T) {
+	const numUnary = 2000000
+	root, lang := buildJSTSCompatWideUnaryTree(numUnary)
+	source := make([]byte, numUnary)
+
+	stats, reason := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, nil)
+	if reason != ParseStopNone {
+		t.Fatalf("reason = %q, want %q (unbounded walk must not stop)", reason, ParseStopNone)
+	}
+	// indexNodesVisited counts every node the fused walk visited (root plus
+	// every child); an unbounded walk must visit all of them.
+	if got, want := stats.indexNodesVisited, uint64(numUnary+1); got != want {
+		t.Fatalf("indexNodesVisited = %d, want %d (unbounded walk must visit every node)", got, want)
+	}
+}
+
+// TestJSTSFusedWalkStopsOnMemoryBudget is the core regression: wiring a
+// tiny-budget *Parser into the poller (parseStopPoller.memoryBudgetParser,
+// the fused-walk-side fix) must make the walk (a) return
+// ParseStopMemoryBudget, (b) stop well before the last child is reached
+// (proving it bailed out mid-walk rather than finishing then reporting the
+// budget as an afterthought), and (c) keep total heap growth within a
+// generous multiple of the configured budget — even though an unbounded walk
+// over the identical tree (see the baseline test above) would keep going
+// regardless.
+func TestJSTSFusedWalkStopsOnMemoryBudget(t *testing.T) {
+	const numUnary = 2000000
+	root, lang := buildJSTSCompatWideUnaryTree(numUnary)
+	source := make([]byte, numUnary)
+
+	const budgetBytes = 1 << 20 // 1MiB: comfortably smaller than the growth
+	// this walk's own index.unaryCandidates bookkeeping allocates (~16 bytes
+	// per candidate = ~32MB across all numUnary children) if it ran to
+	// completion, so the trip must land partway through, not at the end.
+	parser := newGoCompatBudgetTestParser(budgetBytes)
+	parser.language = lang
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	poller := parseStopPoller{memoryBudgetParser: parser}
+	stats, reason := normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats(root, source, lang, &poller)
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("reason = %q, want %q", reason, ParseStopMemoryBudget)
+	}
+	if !parser.compatMemoryBudgetTripped {
+		t.Fatal("compatMemoryBudgetTripped = false, want true (sticky latch for resultMaterializationStopReason's later recheck)")
+	}
+	if stats.indexNodesVisited == 0 {
+		t.Fatal("indexNodesVisited = 0, want some real work done before the trip")
+	}
+	if stats.indexNodesVisited >= uint64(numUnary+1) {
+		t.Fatalf("indexNodesVisited = %d, want a partial prefix < %d (walk must have stopped before reaching the end)", stats.indexNodesVisited, numUnary+1)
+	}
+
+	growth := int64(0)
+	if after.HeapAlloc > before.HeapAlloc {
+		growth = int64(after.HeapAlloc - before.HeapAlloc)
+	}
+	const maxOvershoot = 20 * budgetBytes
+	t.Logf("nodesVisited=%d/%d heap growth=%d bytes (budget=%d, %.2fx)",
+		stats.indexNodesVisited, numUnary+1, growth, int64(budgetBytes), float64(growth)/float64(budgetBytes))
+	if growth > maxOvershoot {
+		t.Fatalf("heap growth = %d bytes, want <= %d (20x budget=%d)", growth, maxOvershoot, int64(budgetBytes))
+	}
+}
+
+// TestNormalizeJavaScriptCompatibilityPropagatesMemoryBudgetStop exercises the
+// full production entry point (normalizeJavaScriptCompatibility) instead of
+// normalizeJavaScriptTypeScriptStatementKeywordsAndPrecedenceWithDetailedStats
+// directly, confirming the poller wiring done inside normalizeJavaScriptCompatibility
+// reaches all the way from a *Parser's configured budget to the returned
+// ParseStopReason, and that resultMaterializationStopReason (what
+// finalizeResultRoot consults afterward) reliably reports the trip via the
+// shared compatMemoryBudgetTripped sticky latch.
+func TestNormalizeJavaScriptCompatibilityPropagatesMemoryBudgetStop(t *testing.T) {
+	const numUnary = 2000000
+	root, lang := buildJSTSCompatWideUnaryTree(numUnary)
+	source := make([]byte, numUnary)
+
+	const budgetBytes = 1 << 20
+	parser := newGoCompatBudgetTestParser(budgetBytes)
+	parser.language = lang
+
+	reason := normalizeJavaScriptCompatibility(root, source, parser, lang)
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("normalizeJavaScriptCompatibility reason = %q, want %q", reason, ParseStopMemoryBudget)
+	}
+	if !parser.compatMemoryBudgetTripped {
+		t.Fatal("compatMemoryBudgetTripped = false, want true")
+	}
+	if got := parser.resultMaterializationStopReason(nil); got != ParseStopMemoryBudget {
+		t.Fatalf("resultMaterializationStopReason() = %q, want %q after a JS/TS compat memory-budget trip", got, ParseStopMemoryBudget)
+	}
+}
+
+// TestNormalizeTypeScriptTreeCompatibilityPropagatesMemoryBudgetStop is the
+// TypeScript-side counterpart of the JavaScript test above, exercising
+// normalizeTypeScriptTreeCompatibilityWithParser's fast (non-metrics) path —
+// the one every real TypeScript/TSX parse takes.
+func TestNormalizeTypeScriptTreeCompatibilityPropagatesMemoryBudgetStop(t *testing.T) {
+	const numUnary = 2000000
+	root, lang := buildJSTSCompatWideUnaryTree(numUnary)
+	lang.Name = "typescript"
+	source := make([]byte, numUnary)
+
+	const budgetBytes = 1 << 20
+	parser := newGoCompatBudgetTestParser(budgetBytes)
+	parser.language = lang
+
+	reason := normalizeTypeScriptTreeCompatibilityWithParser(root, source, parser, lang)
+	if reason != ParseStopMemoryBudget {
+		t.Fatalf("normalizeTypeScriptTreeCompatibilityWithParser reason = %q, want %q", reason, ParseStopMemoryBudget)
+	}
+	if !parser.compatMemoryBudgetTripped {
+		t.Fatal("compatMemoryBudgetTripped = false, want true")
+	}
+	if got := parser.resultMaterializationStopReason(nil); got != ParseStopMemoryBudget {
+		t.Fatalf("resultMaterializationStopReason() = %q, want %q after a JS/TS compat memory-budget trip", got, ParseStopMemoryBudget)
+	}
+}

--- a/parser_result_javascript_typescript_test.go
+++ b/parser_result_javascript_typescript_test.go
@@ -213,7 +213,7 @@ func TestNormalizeJavaScriptTrailingContinueCommentSiblings(t *testing.T) {
 	close := newLeafNodeInArena(arena, 3, false, 86, 87, Point{Row: 1, Column: 24}, Point{Row: 1, Column: 25})
 	block := newParentNodeInArena(arena, 1, true, []*Node{open, ifStmt, lex, close}, nil, 0)
 
-	normalizeJavaScriptTrailingContinueComments(block, []byte(src), lang)
+	normalizeJavaScriptTrailingContinueComments(block, []byte(src), lang, nil)
 
 	if got, want := len(block.children), 5; got != want {
 		t.Fatalf("len(block.children) = %d, want %d", got, want)
@@ -261,7 +261,7 @@ func TestNormalizeJavaScriptTrailingContinueCommentSiblingsDirectContinue(t *tes
 	close := newLeafNodeInArena(arena, 3, false, 79, 80, Point{Row: 1, Column: 24}, Point{Row: 1, Column: 25})
 	block := newParentNodeInArena(arena, 1, true, []*Node{open, cont, lex, close}, nil, 0)
 
-	normalizeJavaScriptTrailingContinueComments(block, []byte(src), lang)
+	normalizeJavaScriptTrailingContinueComments(block, []byte(src), lang, nil)
 
 	if got, want := len(block.children), 5; got != want {
 		t.Fatalf("len(block.children) = %d, want %d", got, want)

--- a/parser_result_node_helpers.go
+++ b/parser_result_node_helpers.go
@@ -184,6 +184,46 @@ func walkResultTreePostorder(root *Node, visit func(*Node)) {
 	walk(root)
 }
 
+// walkResultTreePostorderUntil performs a postorder traversal like
+// walkResultTreePostorder, but calls shouldStop before descending into each
+// node's children — not after, since a postorder visit callback only runs
+// once a node's children are already done, which would be too late to avoid
+// doing that work — and aborts the entire walk (propagating the abort up
+// through every recursion level immediately) the moment shouldStop reports
+// true. shouldStop == nil disables the check entirely (equivalent to
+// walkResultTreePostorder). Returns false iff the walk was aborted early
+// rather than completed.
+func walkResultTreePostorderUntil(root *Node, shouldStop func() bool, visit func(*Node)) bool {
+	if visit == nil {
+		return true
+	}
+	var walk func(*Node) bool
+	walk = func(n *Node) bool {
+		if n == nil {
+			return true
+		}
+		if shouldStop != nil && shouldStop() {
+			return false
+		}
+		if n.ownerArena == nil || n.childIndex > finalChildSidecarIndexBase {
+			for _, child := range n.children {
+				if !walk(child) {
+					return false
+				}
+			}
+		} else {
+			for i := 0; i < resultChildCount(n); i++ {
+				if !walk(resultChildAt(n, i)) {
+					return false
+				}
+			}
+		}
+		visit(n)
+		return true
+	}
+	return walk(root)
+}
+
 func walkResultTreeSidecarFirst(root *Node, visit func(*Node)) {
 	if visit == nil {
 		return

--- a/parser_timeout.go
+++ b/parser_timeout.go
@@ -11,16 +11,17 @@ type parseStopPoller struct {
 	check parseStopCheck
 	count uint64
 	// memoryBudgetParser, when non-nil, makes poll/pollNow also force a
-	// runtime memory-budget check (see (*Parser).goCompatRuntimeMemoryBudgetStopReason)
+	// runtime memory-budget check (see (*Parser).compatRuntimeMemoryBudgetStopReason)
 	// at the same coarse cadence as check, in addition to whatever check
 	// reports. check alone only ever reports Timeout/Cancelled (see
-	// parseStopReasonIsActive) — some long tree walks (the Go compat walk;
-	// see normalizeGoCompatibilityInRangesWithStopAndScratch) need to also
-	// bound their own runtime heap growth even when the parse loop itself
-	// never tripped the budget, so they opt in by setting this field. nil by
-	// default: every existing caller that only sets check keeps its exact
-	// current behavior, byte-for-byte, since the branches below are additive
-	// and only ever taken when this field is non-nil.
+	// parseStopReasonIsActive) — some long tree walks (the Go compat walk,
+	// see normalizeGoCompatibilityInRangesWithStopAndScratch; and the JS/TS
+	// fused compat walk, see rewriteJavaScriptTypeScriptStatementKeywordsCallPrecedenceAndBuildUnaryBinaryIndex)
+	// need to also bound their own runtime heap growth even when the parse
+	// loop itself never tripped the budget, so they opt in by setting this
+	// field. nil by default: every existing caller that only sets check
+	// keeps its exact current behavior, byte-for-byte, since the branches
+	// below are additive and only ever taken when this field is non-nil.
 	memoryBudgetParser *Parser
 }
 
@@ -56,7 +57,7 @@ func (p *parseStopPoller) pollNow() ParseStopReason {
 		}
 	}
 	if p.memoryBudgetParser != nil {
-		if reason := p.memoryBudgetParser.goCompatRuntimeMemoryBudgetStopReason(); reason == ParseStopMemoryBudget {
+		if reason := p.memoryBudgetParser.compatRuntimeMemoryBudgetStopReason(); reason == ParseStopMemoryBudget {
 			return reason
 		}
 	}


### PR DESCRIPTION
## Summary

Completes memory-budget path uniformity for the compat normalization walks: the JS/TS fused compat walk now polls the parse stop poller and honors the runtime memory budget, mirroring the Go compat-walk containment design (#277). The parse loop (#272), the Go walk (#277), and the JS/TS walk (this PR) now all stop under one budget.

- `normalizeJavaScriptCompatibility` / `normalizeTypeScriptTreeCompatibilityWithParser` take the parser, return a `ParseStopReason`, and skip when a stop is already active or the budget latch is tripped.
- The fused statement-keyword/call-precedence walk, the unary/binary index rebuild, the diagnostic candidate-metrics walk, and the JS trailing-comment walk all poll on the shared `parseStopPollMask` stride and unwind immediately on trip (new `walkResultTreePostorderUntil` helper).
- `goCompatRuntimeMemoryBudgetStopReason` renamed to `compatRuntimeMemoryBudgetStopReason` — it is shared infrastructure for both languages now; the sticky `compatMemoryBudgetTripped` latch is reused rather than duplicated.
- Compat dispatch for `javascript`/`typescript`/`tsx` propagates the stop reason instead of discarding it.

## Receipts

- Canonical TS lane `BenchmarkTypeScriptParseFullDFA`: 8.907ms → 9.111ms, p=0.240 (neutral); allocs/op unchanged (18). Cross-process interleaved confirmation p=0.485.
- Canonical Go lane `BenchmarkGoParseFullDFA`: p=0.180 (neutral); allocs/op unchanged (9).
- Budget-stop tests: unbounded control, budget-trip with partial-processing and heap-growth-bound assertions, propagation through both entry points; SExpr byte-identity goldens for clean JS/TS parses under default and large budgets.

## Gates

`go build ./...`, `go vet ./...` clean; root suite PASS including `-race` (119s); 148 targeted JS/TS/compat/budget tests PASS. Changelog bullet added under Unreleased.