### PR TITLE
feat(cgo_harness): Split clean vs error-file ratios in parse gap tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Added
+
+- `parse_gap_report` and `parse_gap_correlate` now split each language's
+  Go/C ratio by corpus-file policy: every sample is classified `clean`
+  (Go tree has no ERROR nodes and did not stop early) or error-bearing, and
+  the per-language ledger reports `clean_ratio`/`error_ratio` plus
+  `clean_file_count`/`error_file_count`/`error_file_share` alongside the
+  existing combined ratio. This keeps an error-dense tail-language corpus
+  from making clean-parse throughput look artificially slow in ratchet
+  decisions.
+
 ### Fixed
 
 - The Go compat-normalization walk now honors the parse memory budget: it

--- a/cgo_harness/cmd/parse_gap_correlate/main.go
+++ b/cgo_harness/cmd/parse_gap_correlate/main.go
@@ -30,6 +30,11 @@ type paritySummary struct {
 	Query     *bool  `json:"query,omitempty"`
 	Deep      bool   `json:"deep"`
 	Error     string `json:"error,omitempty"`
+	// Clean mirrors parse_gap_report's per-sample corpus-policy classification:
+	// true when the Go parse had no ERROR nodes and did not stop early. It
+	// drives the clean/error ratio split below so a language's combined ratio
+	// cannot hide an error-dense corpus behind a healthy-looking aggregate.
+	Clean bool `json:"clean"`
 }
 
 type runtimeStats struct {
@@ -237,30 +242,47 @@ type langAgg struct {
 	queryFailures  int
 	highFailures   int
 	modes          map[string]*modeAgg
+	// cleanModes/errorModes mirror modes but are split by the corpus-policy
+	// classification (paritySummary.Clean) so a language-level ratio can be
+	// reported separately for clean-parsing files versus error-bearing ones.
+	cleanModes   map[string]*modeAgg
+	errorModes   map[string]*modeAgg
+	cleanSamples map[string]struct{}
+	errorSamples map[string]struct{}
 }
 
 type langScore struct {
-	lang                string
-	samples             int
-	parityFailures      int
-	queryFailures       int
-	highlightFailures   int
-	bytes               int64
-	cgoFull             int64
-	goFull              int64
-	goNoTree            int64
-	goQuery             int64
-	goCursor            int64
-	goEdit              int64
-	goNoop              int64
-	goFullRuntime       runtimeStats
-	goNoTreeRuntime     runtimeStats
-	goQueryRuntime      runtimeStats
-	fullRatio           float64
-	noTreeRatio         float64
-	queryRatio          float64
-	queryOverFull       float64
-	fullOverNoTree      float64
+	lang              string
+	samples           int
+	parityFailures    int
+	queryFailures     int
+	highlightFailures int
+	bytes             int64
+	cgoFull           int64
+	goFull            int64
+	goNoTree          int64
+	goQuery           int64
+	goCursor          int64
+	goEdit            int64
+	goNoop            int64
+	goFullRuntime     runtimeStats
+	goNoTreeRuntime   runtimeStats
+	goQueryRuntime    runtimeStats
+	fullRatio         float64
+	noTreeRatio       float64
+	queryRatio        float64
+	queryOverFull     float64
+	fullOverNoTree    float64
+	// cleanRatio/errorRatio are the go_full/cgo_full ratio computed
+	// separately over clean-parsing and error-bearing corpus files, kept
+	// alongside fullRatio (the existing combined ratio) rather than
+	// replacing it. cleanFileCount/errorFileCount/errorFileShare report the
+	// underlying per-language file split driving that distinction.
+	cleanRatio          float64
+	errorRatio          float64
+	cleanFileCount      int
+	errorFileCount      int
+	errorFileShare      float64
 	attrs               map[string]float64
 	hotAmbiguities      []hotGLRState
 	hotReduceChains     []hotGLRState
@@ -329,6 +351,10 @@ func scoreRows(rows []reportRow) []langScore {
 				samples:       map[string]struct{}{},
 				bytesBySample: map[string]int{},
 				modes:         map[string]*modeAgg{},
+				cleanModes:    map[string]*modeAgg{},
+				errorModes:    map[string]*modeAgg{},
+				cleanSamples:  map[string]struct{}{},
+				errorSamples:  map[string]struct{}{},
 			}
 			langs[row.Language] = agg
 		}
@@ -345,13 +371,26 @@ func scoreRows(rows []reportRow) []langScore {
 		if row.Parity.Highlight != nil && !*row.Parity.Highlight {
 			agg.highFailures++
 		}
+		splitModes := agg.errorModes
+		if row.Parity.Clean {
+			agg.cleanSamples[row.Sample] = struct{}{}
+			splitModes = agg.cleanModes
+		} else {
+			agg.errorSamples[row.Sample] = struct{}{}
+		}
 		m := agg.modes[row.Mode]
 		if m == nil {
 			m = &modeAgg{}
 			agg.modes[row.Mode] = m
 		}
+		sm := splitModes[row.Mode]
+		if sm == nil {
+			sm = &modeAgg{}
+			splitModes[row.Mode] = sm
+		}
 		if row.Error != "" {
 			m.errors++
+			sm.errors++
 		}
 		if row.MedianNS > 0 && row.Error == "" {
 			m.rows++
@@ -362,6 +401,15 @@ func scoreRows(rows []reportRow) []langScore {
 			m.runtime.add(row.Runtime)
 			if row.Runtime.MaxStacksSeen > m.maxStacks {
 				m.maxStacks = row.Runtime.MaxStacksSeen
+			}
+			sm.rows++
+			sm.ns += row.MedianNS
+			sm.bytes += int64(row.Bytes)
+			sm.bop += row.BOp
+			sm.allocs += row.AllocsOp
+			sm.runtime.add(row.Runtime)
+			if row.Runtime.MaxStacksSeen > sm.maxStacks {
+				sm.maxStacks = row.Runtime.MaxStacksSeen
 			}
 		}
 	}
@@ -390,6 +438,11 @@ func scoreRows(rows []reportRow) []langScore {
 		s.fullRatio = ratio(s.goFull, s.cgoFull)
 		s.noTreeRatio = ratio(s.goNoTree, s.cgoFull)
 		s.queryRatio = ratio(s.goQuery, s.cgoFull)
+		s.cleanRatio = ratio(modeNSFromMap(agg.cleanModes, "go_full"), modeNSFromMap(agg.cleanModes, "cgo_full"))
+		s.errorRatio = ratio(modeNSFromMap(agg.errorModes, "go_full"), modeNSFromMap(agg.errorModes, "cgo_full"))
+		s.cleanFileCount = len(agg.cleanSamples)
+		s.errorFileCount = len(agg.errorSamples)
+		s.errorFileShare = safeRatioInt(s.errorFileCount, s.cleanFileCount+s.errorFileCount)
 		s.queryOverFull = ratio(s.goQuery, s.goFull)
 		s.fullOverNoTree = ratio(s.goFull, s.goNoTree)
 		if nt := agg.modes["go_no_tree"]; nt != nil {
@@ -567,10 +620,17 @@ func assignHotShapes(s *langScore, r runtimeStats) {
 }
 
 func modeNS(agg *langAgg, mode string) int64 {
-	if agg == nil || agg.modes[mode] == nil {
+	if agg == nil {
 		return 0
 	}
-	return agg.modes[mode].ns
+	return modeNSFromMap(agg.modes, mode)
+}
+
+func modeNSFromMap(modes map[string]*modeAgg, mode string) int64 {
+	if modes == nil || modes[mode] == nil {
+		return 0
+	}
+	return modes[mode].ns
 }
 
 func classify(s langScore) string {
@@ -604,10 +664,12 @@ func render(scores []langScore) {
 	fmt.Println()
 	fmt.Println("Ratios use summed per-sample medians, so large and small files both contribute their measured lane cost. Correlations are directional; top-12 rings are intentionally small.")
 	fmt.Println()
-	fmt.Println("| lang | samples | parity_fail | full/cgo | no_tree/cgo | full/no_tree | query/full | bytes | bucket |")
-	fmt.Println("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |")
+	fmt.Println("Corpus-policy split: `clean/cgo` and `error/cgo` restrict the go_full/cgo_full ratio to samples whose Go parse was clean (no ERROR nodes, no early stop) versus samples that were not, so `full/cgo` (the combined ratio) cannot hide an error-dense corpus behind a healthy-looking aggregate. `clean_n`/`error_n`/`error_share` report the underlying per-language file split.")
+	fmt.Println()
+	fmt.Println("| lang | samples | parity_fail | full/cgo | no_tree/cgo | full/no_tree | query/full | clean/cgo | error/cgo | clean_n | error_n | error_share | bytes | bucket |")
+	fmt.Println("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |")
 	for _, s := range scores {
-		fmt.Printf("| %s | %d | %d | %s | %s | %s | %s | %d | %s |\n",
+		fmt.Printf("| %s | %d | %d | %s | %s | %s | %s | %s | %s | %d | %d | %s | %d | %s |\n",
 			s.lang,
 			s.samples,
 			s.parityFailures,
@@ -615,6 +677,11 @@ func render(scores []langScore) {
 			ratioText(s.noTreeRatio),
 			ratioText(s.fullOverNoTree),
 			ratioText(s.queryOverFull),
+			ratioText(s.cleanRatio),
+			ratioText(s.errorRatio),
+			s.cleanFileCount,
+			s.errorFileCount,
+			fileShareText(s.errorFileCount, s.cleanFileCount+s.errorFileCount),
 			s.bytes,
 			s.bucket,
 		)
@@ -1633,6 +1700,17 @@ func pctText(v float64) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%.1f%%", v*100)
+}
+
+// fileShareText reports what share of a language's corpus files were
+// error-bearing, formatted as a percentage. Unlike pctText, 0% is a valid,
+// meaningful result here (every file was clean), so it only falls back to
+// "n/a" when there is no file count to compute a share from.
+func fileShareText(errorFiles, total int) string {
+	if total <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", 100*float64(errorFiles)/float64(total))
 }
 
 func finite(v float64) bool {

--- a/cgo_harness/cmd/parse_gap_correlate/main_test.go
+++ b/cgo_harness/cmd/parse_gap_correlate/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestScoreRowsSplitsCleanAndErrorRatios(t *testing.T) {
+	rows := []reportRow{
+		{Language: "kdl", Sample: "clean1.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean1.kdl", Mode: "go_full", MedianNS: 15, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean2.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean2.kdl", Mode: "go_full", MedianNS: 17, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: false}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "go_full", MedianNS: 1000, Parity: paritySummary{Clean: false}},
+	}
+
+	scores := scoreRows(rows)
+	if len(scores) != 1 {
+		t.Fatalf("scores length = %d, want 1", len(scores))
+	}
+	s := scores[0]
+
+	// Combined ratio still reflects every sample: (15+17+1000)/(10+10+10) = 34.4x.
+	if got, want := s.fullRatio, 1032.0/30.0; !almostEqual(got, want) {
+		t.Fatalf("fullRatio = %v, want %v", got, want)
+	}
+	// Clean ratio isolates the two well-behaved files: (15+17)/(10+10) = 1.6x.
+	if got, want := s.cleanRatio, 32.0/20.0; !almostEqual(got, want) {
+		t.Fatalf("cleanRatio = %v, want %v", got, want)
+	}
+	// Error ratio isolates the single error-bearing file: 1000/10 = 100x.
+	if got, want := s.errorRatio, 100.0; !almostEqual(got, want) {
+		t.Fatalf("errorRatio = %v, want %v", got, want)
+	}
+	if got, want := s.cleanFileCount, 2; got != want {
+		t.Fatalf("cleanFileCount = %d, want %d", got, want)
+	}
+	if got, want := s.errorFileCount, 1; got != want {
+		t.Fatalf("errorFileCount = %d, want %d", got, want)
+	}
+	if got, want := s.errorFileShare, 1.0/3.0; !almostEqual(got, want) {
+		t.Fatalf("errorFileShare = %v, want %v", got, want)
+	}
+}
+
+func TestScoreRowsCleanRatioZeroWhenNoCleanFiles(t *testing.T) {
+	rows := []reportRow{
+		{Language: "kdl", Sample: "err1.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: false}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "go_full", MedianNS: 1000, Parity: paritySummary{Clean: false}},
+	}
+
+	scores := scoreRows(rows)
+	if len(scores) != 1 {
+		t.Fatalf("scores length = %d, want 1", len(scores))
+	}
+	s := scores[0]
+	if s.cleanRatio != 0 {
+		t.Fatalf("cleanRatio = %v, want 0 (no clean samples measured)", s.cleanRatio)
+	}
+	if s.cleanFileCount != 0 {
+		t.Fatalf("cleanFileCount = %d, want 0", s.cleanFileCount)
+	}
+	if got, want := s.errorFileShare, 1.0; !almostEqual(got, want) {
+		t.Fatalf("errorFileShare = %v, want %v", got, want)
+	}
+}
+
+func TestModeNSFromMap(t *testing.T) {
+	if got := modeNSFromMap(nil, "go_full"); got != 0 {
+		t.Fatalf("modeNSFromMap(nil) = %d, want 0", got)
+	}
+	modes := map[string]*modeAgg{"go_full": {ns: 42}}
+	if got, want := modeNSFromMap(modes, "go_full"), int64(42); got != want {
+		t.Fatalf("modeNSFromMap = %d, want %d", got, want)
+	}
+	if got := modeNSFromMap(modes, "cgo_full"); got != 0 {
+		t.Fatalf("modeNSFromMap(missing mode) = %d, want 0", got)
+	}
+}
+
+func TestFileShareText(t *testing.T) {
+	if got, want := fileShareText(0, 0), "n/a"; got != want {
+		t.Fatalf("fileShareText(0,0) = %q, want %q", got, want)
+	}
+	if got, want := fileShareText(0, 4), "0.0%"; got != want {
+		t.Fatalf("fileShareText(0,4) = %q, want %q", got, want)
+	}
+	if got, want := fileShareText(1, 3), "33.3%"; got != want {
+		t.Fatalf("fileShareText(1,3) = %q, want %q", got, want)
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	const epsilon = 1e-9
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= epsilon
+}

--- a/cgo_harness/cmd/parse_gap_report/main.go
+++ b/cgo_harness/cmd/parse_gap_report/main.go
@@ -127,6 +127,16 @@ type paritySummary struct {
 	Query       *bool  `json:"query,omitempty"`
 	Incremental *bool  `json:"incremental,omitempty"`
 	Error       string `json:"error,omitempty"`
+	// GoHasError, GoStoppedEarly, and Clean classify this corpus sample's Go
+	// parse independently of the C reference, for the corpus-policy split:
+	// a language's combined Go/C ratio conflates clean-parse throughput with
+	// error-recovery throughput unless clean and error-bearing files are
+	// scored separately. Clean is true only when the Go tree has no ERROR
+	// nodes and the parse did not stop early (timeout, node/iteration/stack
+	// limit, memory budget, or token-source EOF).
+	GoHasError     bool `json:"go_has_error,omitempty"`
+	GoStoppedEarly bool `json:"go_stopped_early,omitempty"`
+	Clean          bool `json:"clean"`
 }
 
 type runtimeStats struct {
@@ -961,10 +971,15 @@ func computeParity(r *runner, source []byte, queries []querySpec, parseOnlyGate 
 	noError := !cRoot.HasError() && !goRoot.HasError()
 	diff := cgoharness.FirstDivergenceDumpV1(goRoot, r.goLang, cRoot)
 	deep := diff == nil
+	goHasError := goRoot.HasError()
+	goStoppedEarly := goTree.ParseStoppedEarly()
 	summary := paritySummary{
-		NoError: noError,
-		SExpr:   deep,
-		Deep:    deep,
+		NoError:        noError,
+		SExpr:          deep,
+		Deep:           deep,
+		GoHasError:     goHasError,
+		GoStoppedEarly: goStoppedEarly,
+		Clean:          !goHasError && !goStoppedEarly,
 	}
 	if !noError {
 		if goRoot.HasError() != cRoot.HasError() {
@@ -2440,9 +2455,16 @@ func renderSummary(rows []reportRow, languageOrder []string) string {
 		lang string
 		mode string
 	}
+	type cleanKey struct {
+		lang  string
+		mode  string
+		clean bool
+	}
 	by := make(map[key][]reportRow)
+	byClean := make(map[cleanKey][]reportRow)
 	for _, row := range rows {
 		by[key{row.Language, row.Mode}] = append(by[key{row.Language, row.Mode}], row)
+		byClean[cleanKey{row.Language, row.Mode, row.Parity.Clean}] = append(byClean[cleanKey{row.Language, row.Mode, row.Parity.Clean}], row)
 	}
 	langs := make([]string, 0)
 	seenLang := map[string]struct{}{}
@@ -2460,8 +2482,9 @@ func renderSummary(rows []reportRow, languageOrder []string) string {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "# Parse Gap Report\n\n")
-	fmt.Fprintf(&b, "| lang | samples | parse | highlight | query | go_full/cgo | go_no_tree/cgo | go_query/cgo | go_edit | noop | blocker |\n")
-	fmt.Fprintf(&b, "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	fmt.Fprintf(&b, "Corpus-policy split: `clean_ratio`/`error_ratio` score the same go_full/cgo_full ratio as `go_full/cgo` but restricted to samples whose Go parse was clean (no ERROR nodes, no early stop) versus samples that were not; `clean_files`/`error_files`/`error_share` report the underlying per-language file counts so a language cannot look artificially slow (or fast) from an error-dense corpus without that being visible.\n\n")
+	fmt.Fprintf(&b, "| lang | samples | parse | highlight | query | go_full/cgo | go_no_tree/cgo | go_query/cgo | go_edit | noop | clean_ratio | error_ratio | clean_files | error_files | error_share | blocker |\n")
+	fmt.Fprintf(&b, "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
 	for _, lang := range langs {
 		sampleCount := uniqueSamples(rows, lang)
 		blockers := map[string]struct{}{}
@@ -2479,7 +2502,12 @@ func renderSummary(rows []reportRow, languageOrder []string) string {
 		goQuery := averageMedian(by[key{lang, "go_parse_query"}])
 		goEdit := averageMedian(by[key{lang, "go_edit"}])
 		goNoop := averageMedian(by[key{lang, "go_noop_incremental"}])
-		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+		cleanCgoFull := averageMedian(byClean[cleanKey{lang, "cgo_full", true}])
+		cleanGoFull := averageMedian(byClean[cleanKey{lang, "go_full", true}])
+		errorCgoFull := averageMedian(byClean[cleanKey{lang, "cgo_full", false}])
+		errorGoFull := averageMedian(byClean[cleanKey{lang, "go_full", false}])
+		cleanFileCount, errorFileCount := cleanErrorFileCounts(rows, lang)
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %d | %d | %s | %s |\n",
 			lang,
 			sampleCount,
 			parseGateString(rows, lang),
@@ -2490,10 +2518,50 @@ func renderSummary(rows []reportRow, languageOrder []string) string {
 			ratioString(goQuery, cgoFull),
 			nsString(goEdit),
 			nsString(goNoop),
+			ratioString(cleanGoFull, cleanCgoFull),
+			ratioString(errorGoFull, errorCgoFull),
+			cleanFileCount,
+			errorFileCount,
+			fileShareString(errorFileCount, cleanFileCount+errorFileCount),
 			joinSet(blockers),
 		)
 	}
 	return b.String()
+}
+
+// cleanErrorFileCounts reports how many unique corpus samples for lang were
+// classified clean (Go parse had no ERROR nodes and did not stop early)
+// versus not, per paritySummary.Clean. Each sample is counted once even
+// though it may appear across several timing modes.
+func cleanErrorFileCounts(rows []reportRow, lang string) (clean, errorCount int) {
+	seen := map[string]bool{}
+	for _, row := range rows {
+		if row.Language != lang {
+			continue
+		}
+		if _, ok := seen[row.Sample]; ok {
+			continue
+		}
+		seen[row.Sample] = row.Parity.Clean
+	}
+	for _, isClean := range seen {
+		if isClean {
+			clean++
+		} else {
+			errorCount++
+		}
+	}
+	return clean, errorCount
+}
+
+// fileShareString reports what share of total files were error files,
+// formatted as a percentage; it reports "n/a" only when there is no file
+// count to compute a share from (as opposed to a genuine 0%).
+func fileShareString(errorFiles, total int) string {
+	if total <= 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", 100*float64(errorFiles)/float64(total))
 }
 
 func parseGateString(rows []reportRow, lang string) string {

--- a/cgo_harness/cmd/parse_gap_report/main_test.go
+++ b/cgo_harness/cmd/parse_gap_report/main_test.go
@@ -99,6 +99,71 @@ func TestRenderSummaryUsesRequestedLanguageOrder(t *testing.T) {
 	}
 }
 
+func TestCleanErrorFileCountsSplitsUniqueSamplesByCleanliness(t *testing.T) {
+	rows := []reportRow{
+		{Language: "kdl", Sample: "clean1.kdl", Mode: "cgo_full", Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean1.kdl", Mode: "go_full", Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean2.kdl", Mode: "cgo_full", Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean2.kdl", Mode: "go_full", Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "cgo_full", Parity: paritySummary{Clean: false}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "go_full", Parity: paritySummary{Clean: false}},
+		{Language: "other", Sample: "x.other", Mode: "go_full", Parity: paritySummary{Clean: false}},
+	}
+
+	clean, errorCount := cleanErrorFileCounts(rows, "kdl")
+	if clean != 2 {
+		t.Fatalf("clean = %d, want 2", clean)
+	}
+	if errorCount != 1 {
+		t.Fatalf("errorCount = %d, want 1", errorCount)
+	}
+}
+
+func TestFileShareStringFormatsPercentageOrNA(t *testing.T) {
+	if got, want := fileShareString(0, 0), "n/a"; got != want {
+		t.Fatalf("fileShareString(0,0) = %q, want %q", got, want)
+	}
+	if got, want := fileShareString(0, 3), "0.0%"; got != want {
+		t.Fatalf("fileShareString(0,3) = %q, want %q", got, want)
+	}
+	if got, want := fileShareString(1, 3), "33.3%"; got != want {
+		t.Fatalf("fileShareString(1,3) = %q, want %q", got, want)
+	}
+	if got, want := fileShareString(3, 3), "100.0%"; got != want {
+		t.Fatalf("fileShareString(3,3) = %q, want %q", got, want)
+	}
+}
+
+func TestRenderSummaryReportsCleanAndErrorRatiosSeparately(t *testing.T) {
+	rows := []reportRow{
+		{Language: "kdl", Sample: "clean1.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean1.kdl", Mode: "go_full", MedianNS: 15, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean2.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "clean2.kdl", Mode: "go_full", MedianNS: 17, Parity: paritySummary{Clean: true}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "cgo_full", MedianNS: 10, Parity: paritySummary{Clean: false}},
+		{Language: "kdl", Sample: "err1.kdl", Mode: "go_full", MedianNS: 1000, Parity: paritySummary{Clean: false}},
+	}
+
+	summary := renderSummary(rows, []string{"kdl"})
+
+	// Combined ratio mixes clean and error samples: (15+17+1000)/(10+10+10) = 34.40x.
+	if !strings.Contains(summary, "34.40x") {
+		t.Fatalf("summary missing combined ratio 34.40x:\n%s", summary)
+	}
+	// Clean-only ratio should isolate the two well-behaved files: (15+17)/(10+10) = 1.60x.
+	if !strings.Contains(summary, "1.60x") {
+		t.Fatalf("summary missing clean_ratio 1.60x:\n%s", summary)
+	}
+	// Error-only ratio should isolate the single error-bearing file: 1000/10 = 100.00x.
+	if !strings.Contains(summary, "100.00x") {
+		t.Fatalf("summary missing error_ratio 100.00x:\n%s", summary)
+	}
+	// Two clean files, one error file, so error share is 1/3.
+	if !strings.Contains(summary, "33.3%") {
+		t.Fatalf("summary missing error_share 33.3%%:\n%s", summary)
+	}
+}
+
 func TestStatsFromRuntimeReportsScratchAndTransientMemory(t *testing.T) {
 	stats := statsFromRuntime(gotreesitter.ParseRuntime{
 		StopDiagnosticCaptured:             true,


### PR DESCRIPTION
## Summary

Per-language perf ratios in the parse-gap tooling conflate clean-parse throughput with error-recovery throughput — 42-67% of tail-language corpora parse with errors, so a language can report a catastrophic combined ratio while its clean files are fine. This splits the two populations so ratchet decisions can cite the clean-file ratio as primary with the error-file ratio tracked separately.

- `parse_gap_report`: per-sample `go_has_error`, `go_stopped_early`, and `clean` fields on the parity summary (clean = no error and no early stop); `summary.md` gains `clean_ratio`, `error_ratio`, `clean_files`, `error_files`, `error_share` columns. Existing fields and the combined ratio are untouched for consumer continuity.
- `parse_gap_correlate`: decodes the new field and reports `clean/cgo`, `error/cgo`, sample counts, and `error_share` alongside the existing combined column.
- Notable pre-existing gap fixed in passing: the correlator's duplicated parity struct silently dropped the already-emitted `no_error` signal on decode. A distinct `clean` field is used rather than repurposing `no_error`, which conflated C-side errors and never captured early stops.

## Verification

Synthetic corpus with two clean files (1.5x/1.7x) and one error file (100x): combined column shows the misleading 34.40x; the split reports clean 1.60x, error 100.00x, error_share 33.3%.

## Gates

`go build ./...` / `go vet ./...` clean at root; `cgo_harness` cmd packages build/vet/test green under `-tags "cgo treesitter_c_parity"` (7 new tests across both tools); gofmt clean. The untagged `cgo_harness` build failure in `corpus_structural/go_sample.go` is pre-existing and unrelated (verified via stash). Changelog bullet added under Unreleased.