### PR TITLE
refactor(parser): Table-drive the trailing-span compat shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- Trailing-span compat shims for Caddy, Comment, Fortran, Nim, Pug, and RST
+  moved onto a single data-driven `trailingSpanRules` table
+  (`normalizeResultTrailingSpanCompatibility`) instead of six separate
+  `runLanguageResultCompatibility` switch arms and four hand-written wrapper
+  functions (`normalizeNimTopLevelCallEnd`, `normalizeCommentTrailingExtraTrivia`,
+  `normalizeRSTTopLevelSectionEnd`, `normalizeFortranStatementLineBreaks`).
+  Each row names the language, the shared primitive it drives (extend the
+  sole top-level child across a trailing line break, trim a trailing
+  invisible extra-trivia child at the root, shrink a top-level child's end
+  off trailing whitespace, or extend a statement across the line break
+  before its next sibling), and that primitive's node-kind parameters, so
+  adding another language to any of these four span shapes is a table row,
+  not a new function. Fortran's statement-vs-sibling pass is generalized
+  from a hardcoded `program`/`program_statement` walk into
+  `extendChildLineBreakBeforeNextSibling`, parameterized the same way.
+  The four wrapper functions being retired were already thin call-throughs
+  into shared primitives from an earlier consolidation, so this pass nets a
+  modest line increase (the switch/wrapper boilerplate shrinks, but the new
+  table and its per-row rationale comments are larger than the code they
+  replace) in exchange for one auditable, greppable rule set instead of six
+  scattered dispatch sites.
+
 ## [0.28.0] - 2026-07-12
 
 Containment closure and measurement-honesty release. The runtime memory

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -115,10 +115,8 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		normalizeCCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
 	case "c_sharp":
 		normalizeCSharpCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
-	case "caddy":
-		normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
-	case "comment":
-		normalizeCommentTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
+	case "caddy", "comment", "fortran", "nim", "pug", "rst":
+		normalizeResultTrailingSpanCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "cooklang":
 		normalizeCooklangCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "corn":
@@ -149,9 +147,6 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		normalizeEDSCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "erlang":
 		normalizeErlangSourceFileForms(ctx.root, ctx.lang)
-	case "fortran":
-		normalizeFortranStatementLineBreaks(ctx.root, ctx.source, ctx.lang)
-		normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
 	case "fsharp":
 		normalizeFSharpCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "forth":
@@ -204,8 +199,6 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		normalizeNginxAttributeLineBreaks(ctx.root, ctx.source, ctx.lang)
 	case "ninja":
 		normalizeNinjaCompatibility(ctx.root, ctx.source, ctx.lang)
-	case "nim":
-		normalizeNimTopLevelCallEnd(ctx.root, ctx.source, ctx.lang)
 	case "ocaml":
 		normalizeOCamlCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "pascal":
@@ -221,16 +214,12 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		normalizePowerShellAssignmentOperatorTokens(ctx.root, ctx.source, ctx.lang)
 		normalizePowerShellPathCommandNameVariables(ctx.root, ctx.source, ctx.lang)
 		normalizePowerShellEnumStatementKeywordSpans(ctx.root, ctx.source, ctx.lang)
-	case "pug":
-		normalizeTopLevelTrailingLineBreakSpan(ctx.root, ctx.source, ctx.lang)
 	case "ql":
 		normalizeQLCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "r":
 		normalizeRCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "python":
 		normalizePythonCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
-	case "rst":
-		normalizeRSTTopLevelSectionEnd(ctx.root, ctx.source, ctx.lang)
 	case "rescript":
 		normalizeRescriptCompatibility(ctx.root, ctx.lang)
 	case "robot":

--- a/parser_result_misc_spans.go
+++ b/parser_result_misc_spans.go
@@ -1,18 +1,7 @@
 package gotreesitter
 
-func normalizeNimTopLevelCallEnd(root *Node, source []byte, lang *Language) {
-	shrinkFirstTopLevelChildEndToLastNonTrivia(root, source, lang, "nim", "source_file", "call", true)
-}
-
 func normalizePascalTopLevelProgramEnd(root *Node, source []byte, lang *Language) {
 	shrinkFirstTopLevelChildEndToLastNonTrivia(root, source, lang, "pascal", "root", "program", false)
-}
-
-func normalizeCommentTrailingExtraTrivia(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "comment" || root.Type(lang) != "source" {
-		return
-	}
-	trimTrailingExtraTriviaRoot(root, source, lang)
 }
 
 func normalizePascalTrailingExtraTrivia(root *Node, source []byte, lang *Language) {
@@ -20,11 +9,6 @@ func normalizePascalTrailingExtraTrivia(root *Node, source []byte, lang *Languag
 		return
 	}
 	trimTrailingExtraTriviaRoot(root, source, lang)
-}
-
-func normalizeRSTTopLevelSectionEnd(root *Node, source []byte, lang *Language) {
-	trimTrailingExtraTriviaRoot(root, source, lang)
-	shrinkFirstTopLevelChildEndToLastNonTrivia(root, source, lang, "rst", "document", "section", false)
 }
 
 func shrinkFirstTopLevelChildEndToLastNonTrivia(root *Node, source []byte, lang *Language, languageName, rootType, childType string, requireSingleChild bool) bool {
@@ -201,25 +185,31 @@ func lineBreakEndAt(source []byte, start, limit uint32) uint32 {
 	}
 }
 
-func normalizeFortranStatementLineBreaks(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "fortran" || len(source) == 0 {
+// extendChildLineBreakBeforeNextSibling walks every parentType node and, for
+// each childType child that stops short of its next sibling, extends that
+// child's end to swallow an immediately following line break (formerly
+// normalizeFortranStatementLineBreaks, generalized for the shared
+// trailingSpanRule table in parser_result_trailing_span_rules.go).
+func extendChildLineBreakBeforeNextSibling(root *Node, source []byte, lang *Language, parentType, childType string) {
+	if root == nil || lang == nil || len(source) == 0 {
 		return
 	}
 	walkResultTreeBounded(root, func(n *Node) {
-		if n.Type(lang) == "program" {
-			childCount := resultChildCount(n)
-			for i := 0; i+1 < childCount; i++ {
-				cur := resultChildAt(n, i)
-				next := resultChildAt(n, i+1)
-				if cur == nil || next == nil || cur.endByte >= next.startByte {
-					continue
-				}
-				if cur.Type(lang) != "program_statement" {
-					continue
-				}
-				if end := lineBreakEndAt(source, cur.endByte, next.startByte); end > cur.endByte {
-					extendNodeEndTo(cur, end, source)
-				}
+		if n.Type(lang) != parentType {
+			return
+		}
+		childCount := resultChildCount(n)
+		for i := 0; i+1 < childCount; i++ {
+			cur := resultChildAt(n, i)
+			next := resultChildAt(n, i+1)
+			if cur == nil || next == nil || cur.endByte >= next.startByte {
+				continue
+			}
+			if cur.Type(lang) != childType {
+				continue
+			}
+			if end := lineBreakEndAt(source, cur.endByte, next.startByte); end > cur.endByte {
+				extendNodeEndTo(cur, end, source)
 			}
 		}
 	})

--- a/parser_result_trailing_span_rules.go
+++ b/parser_result_trailing_span_rules.go
@@ -1,0 +1,90 @@
+package gotreesitter
+
+// trailingSpanRuleKind selects which shared primitive a trailingSpanRule row
+// applies. Every kind is generic (parameterized by the row's fields); no
+// per-language logic lives outside this table -- the same spirit as
+// resultCollapsedNamedLeafRules (parser_result_collapsed_helpers.go) for the
+// collapsed-named-leaf-child compat class.
+type trailingSpanRuleKind int
+
+const (
+	// Extends the root's single child to cover a trailing trivia gap
+	// containing a line break (normalizeTopLevelTrailingLineBreakSpan).
+	trailingSpanExtendSoleChildLineBreak trailingSpanRuleKind = iota
+	// Drops the root's final invisible extra-trivia child, widening the
+	// root's own span to cover it (trimTrailingExtraTriviaRoot). Fires even
+	// on error trees, unlike the shared post-switch pass in
+	// normalizeResultCompatibility, which only trims clean trees. rootType,
+	// if set, additionally gates on the root node's type.
+	trailingSpanTrimRootExtraTrivia
+	// Shrinks the root's first child's end back to the source's last
+	// non-trivia byte when its span over-reaches into trailing whitespace
+	// (shrinkFirstTopLevelChildEndToLastNonTrivia). Requires rootType and
+	// childType; requireSingleChild additionally gates on a single root child.
+	trailingSpanShrinkFirstChildToLastNonTrivia
+	// Extends each childType child of a parentType node to cover an
+	// immediately following line break before its next sibling
+	// (extendChildLineBreakBeforeNextSibling). Requires parentType, childType.
+	trailingSpanExtendStatementSiblingLineBreak
+)
+
+// trailingSpanRule is one row of the shared trailing-trivia/span compat
+// pass: languageName selects the row, kind selects the primitive, and the
+// remaining fields parameterize it. Replaces the former per-language wrapper
+// functions normalizeNimTopLevelCallEnd, normalizeCommentTrailingExtraTrivia,
+// normalizeRSTTopLevelSectionEnd, and normalizeFortranStatementLineBreaks.
+type trailingSpanRule struct {
+	languageName       string
+	kind               trailingSpanRuleKind
+	rootType           string // trim (optional gate) / shrink
+	parentType         string // sibling
+	childType          string // shrink / sibling
+	requireSingleChild bool   // shrink
+}
+
+var trailingSpanRules = []trailingSpanRule{
+	// Caddy/pug: sole top-level construct absorbs a trailing line-break gap.
+	{languageName: "caddy", kind: trailingSpanExtendSoleChildLineBreak},
+	{languageName: "pug", kind: trailingSpanExtendSoleChildLineBreak},
+	// Fortran: a program_statement absorbs the line break before its next
+	// program sibling, then the top-level construct absorbs the trailing gap.
+	{languageName: "fortran", kind: trailingSpanExtendStatementSiblingLineBreak, parentType: "program", childType: "program_statement"},
+	{languageName: "fortran", kind: trailingSpanExtendSoleChildLineBreak},
+	// Comment/RST: trim a trailing invisible extra-trivia child at the root,
+	// unconditionally (including on error trees).
+	{languageName: "comment", kind: trailingSpanTrimRootExtraTrivia, rootType: "source"},
+	{languageName: "rst", kind: trailingSpanTrimRootExtraTrivia},
+	// Nim/RST: shrink a top-level construct's end back off trailing
+	// whitespace that C tree-sitter does not attach.
+	{languageName: "nim", kind: trailingSpanShrinkFirstChildToLastNonTrivia, rootType: "source_file", childType: "call", requireSingleChild: true},
+	{languageName: "rst", kind: trailingSpanShrinkFirstChildToLastNonTrivia, rootType: "document", childType: "section"},
+}
+
+// normalizeResultTrailingSpanCompatibility is the single parameterized pass
+// covering the trailing-span compat shims for caddy, comment, fortran, nim,
+// pug, and rst: it applies every trailingSpanRules row matching lang, in
+// table order (fortran's statement pass must run before its sole-child pass;
+// rst's trim must run before its shrink).
+func normalizeResultTrailingSpanCompatibility(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil {
+		return
+	}
+	for _, rule := range trailingSpanRules {
+		if rule.languageName != lang.Name {
+			continue
+		}
+		switch rule.kind {
+		case trailingSpanExtendSoleChildLineBreak:
+			normalizeTopLevelTrailingLineBreakSpan(root, source, lang)
+		case trailingSpanTrimRootExtraTrivia:
+			if rule.rootType != "" && root.Type(lang) != rule.rootType {
+				continue
+			}
+			trimTrailingExtraTriviaRoot(root, source, lang)
+		case trailingSpanShrinkFirstChildToLastNonTrivia:
+			shrinkFirstTopLevelChildEndToLastNonTrivia(root, source, lang, rule.languageName, rule.rootType, rule.childType, rule.requireSingleChild)
+		case trailingSpanExtendStatementSiblingLineBreak:
+			extendChildLineBreakBeforeNextSibling(root, source, lang, rule.parentType, rule.childType)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Compat sunset tranche T1b: the six trailing-span shims (caddy, comment, fortran, nim, pug, rst) migrate onto one parameterized rule table (`trailingSpanRule`, 8 rows, 4 span-shape kinds) with a single dispatcher, in the same spirit as `resultCollapsedNamedLeafRules`. Six switch arms and four per-language wrapper functions are deleted; fortran's statement-pair walk is generalized into a reusable `extendChildLineBreakBeforeNextSibling` primitive.

Honest metric note: net LoC is +69, not the reduction the sunset schedule projected for this tranche. Earlier consolidation had already folded these languages onto shared primitives, so only scattered dispatch remained; the table plus its rationale comments costs slightly more than the dispatch it replaces. The tranche's value is structural — one greppable rule set, and pascal/just/nginx (same primitives, out of scope here) become table rows when their turn comes.

## Gates

- Trees verified byte-identical on representative inputs for nim/rst/comment (spans and S-expressions) before/after.
- `go build ./...`, `go vet ./...`, gofmt clean on touched files.
- Full root suite green including `-race` (346.8s); caddy/comment/fortran/nim/pug/rst suites, `grammars` package, and `parser_result_test` all pass.
- Changelog bullet under Unreleased.