### PR TITLE
refactor(parser): migrate repetition conflicts to certified policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ for tags and release notes while still in `0.x`.
   table and its per-row rationale comments are larger than the code they
   replace) in exchange for one auditable, greppable rule set instead of six
   scattered dispatch sites.
+- The go.mod, Dart, and C repetition-conflict compat-tier helpers
+  (`gomodRepetitionShiftConflictChoice`, `dartRepetitionShiftConflictChoice`,
+  `cRepetitionShiftConflictChoice`) are retired in favor of certified,
+  blob-SHA-pinned `ConflictPolicies` rows in `grammars/runtime_profiles.go`.
+  C's rule recurs at thousands of table rows (reduce-symbol identity alone,
+  not table position), so it is the first profile to use two new sentinel
+  values, `ConflictPolicyAnyState`/`ConflictPolicyAnyLookahead`, matching
+  every state/lookahead instead of one exact row. Dot's equivalent helper is
+  retired outright rather than migrated: it was already dead code in the
+  shipped dispatch path (dot never opted out of the engine-wide C
+  repetition-skip fold, which already folds it with a flat parse stack), and
+  reviving it as a live policy grew the LR parse-stack depth O(n) with
+  statement count for no fork-count benefit. C#'s helper is left in place: it
+  depends on the literal source text of a contextual keyword (`scoped`),
+  which `ConflictPolicies`' state/lookahead-symbol matching cannot express.
 
 ## [0.28.0] - 2026-07-12
 

--- a/cgo_harness/parity_c_decl_ambiguity_test.go
+++ b/cgo_harness/parity_c_decl_ambiguity_test.go
@@ -5,9 +5,11 @@ package cgoharness
 import "testing"
 
 // TestParityCTopLevelDeclAmbiguity is the adversarial safety gate for the C
-// translation_unit_repeat1 fork collapse (parser.go cRepetitionShiftConflictChoice,
-// state 43). Collapsing the top-level list-continuation fork must NOT change how
-// the deeper declaration-vs-expression-statement ambiguity resolves — C's
+// translation_unit_repeat1 fork collapse (the certified "c" ConflictPolicy row
+// in grammars/runtime_profiles.go, wave10/compat-t1c; previously parser.go
+// cRepetitionShiftConflictChoice, state 43). Collapsing the top-level
+// list-continuation fork must NOT change how the deeper
+// declaration-vs-expression-statement ambiguity resolves — C's
 // hardest parsing case, declared in tree-sitter-c's conflicts: block. Each
 // snippet is parsed by gotreesitter and the C reference and compared
 // node-by-node by runParityCase; any divergence fails.
@@ -70,7 +72,9 @@ func TestParityCTopLevelDeclAmbiguity(t *testing.T) {
 }
 
 // TestParityCPreprocConditional is the adversarial safety gate for collapsing
-// the preproc_if_repeat1 fork (parser.go cRepetitionShiftConflictChoice). A
+// the preproc_if_repeat1 fork (the certified "c" ConflictPolicy row in
+// grammars/runtime_profiles.go, wave10/compat-t1c; previously parser.go
+// cRepetitionShiftConflictChoice). A
 // preprocessor conditional body continues on every content token and closes
 // only on #endif/#elif/#else (which carry no continuation shift), so collapsing
 // the body's list-continuation fork must not change the parse. Each snippet is

--- a/cgo_harness/parity_c_decl_ambiguity_test.go
+++ b/cgo_harness/parity_c_decl_ambiguity_test.go
@@ -6,7 +6,7 @@ import "testing"
 
 // TestParityCTopLevelDeclAmbiguity is the adversarial safety gate for the C
 // translation_unit_repeat1 fork collapse (the certified "c" ConflictPolicy row
-// in grammars/runtime_profiles.go, wave10/compat-t1c; previously parser.go
+// in grammars/runtime_profiles.go; previously parser.go
 // cRepetitionShiftConflictChoice, state 43). Collapsing the top-level
 // list-continuation fork must NOT change how the deeper
 // declaration-vs-expression-statement ambiguity resolves — C's
@@ -73,7 +73,7 @@ func TestParityCTopLevelDeclAmbiguity(t *testing.T) {
 
 // TestParityCPreprocConditional is the adversarial safety gate for collapsing
 // the preproc_if_repeat1 fork (the certified "c" ConflictPolicy row in
-// grammars/runtime_profiles.go, wave10/compat-t1c; previously parser.go
+// grammars/runtime_profiles.go; previously parser.go
 // cRepetitionShiftConflictChoice). A
 // preprocessor conditional body continues on every content token and closes
 // only on #endif/#elif/#else (which carry no continuation shift), so collapsing

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -230,8 +230,7 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 		// gated off during reuse): go.mod files are small enough that reuse
 		// dispatch still benefits from folding the list continuation, and this
 		// predates the reuse gate below. See grammars/runtime_profiles.go for
-		// the certified rows (wave10/compat-t1c; previously
-		// gomodRepetitionShiftConflictChoice).
+		// the certified rows that replaced gomodRepetitionShiftConflictChoice.
 		if next, ok := conflictPolicyChoice(p.language, tok, currentState, actions); ok {
 			return next, true
 		}
@@ -270,8 +269,8 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 	//
 	// dart and c are also in cRepetitionSkipOptOut (the engine-wide fold is
 	// unsafe for both — see the opt-out entries) but each still has a
-	// certified narrow subset in ConflictPolicies (grammars/runtime_profiles.go,
-	// wave10/compat-t1c), checked above by conflictPolicyChoiceForDispatch
+	// certified narrow subset in ConflictPolicies (grammars/runtime_profiles.go),
+	// checked above by conflictPolicyChoiceForDispatch
 	// before this switch is reached, INCLUDING on wreckage lineages: those
 	// rows carry no recovery gating, matching the retired
 	// dartRepetitionShiftConflictChoice / cRepetitionShiftConflictChoice

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -14,7 +14,10 @@ func conflictPolicyChoiceForContext(lang *Language, stack *glrStack, allowRecove
 	}
 	for i := range lang.ConflictPolicies {
 		policy := &lang.ConflictPolicies[i]
-		if policy.State != currentState || policy.Lookahead != tok.Symbol {
+		if policy.State != currentState && policy.State != ConflictPolicyAnyState {
+			continue
+		}
+		if policy.Lookahead != tok.Symbol && policy.Lookahead != ConflictPolicyAnyLookahead {
 			continue
 		}
 		if policy.Kind == ConflictPolicyRecoveredRepetitionReduce {
@@ -222,7 +225,14 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 		return ParseAction{}, false
 	}
 	if p.language.Name == "gomod" {
-		if next, ok := gomodRepetitionShiftConflictChoice(p.language, currentState, actions); ok {
+		// go.mod's certified require-list rows apply even during incremental
+		// reuse dispatch (unlike the general ConflictPolicies path below,
+		// gated off during reuse): go.mod files are small enough that reuse
+		// dispatch still benefits from folding the list continuation, and this
+		// predates the reuse gate below. See grammars/runtime_profiles.go for
+		// the certified rows (wave10/compat-t1c; previously
+		// gomodRepetitionShiftConflictChoice).
+		if next, ok := conflictPolicyChoice(p.language, tok, currentState, actions); ok {
 			return next, true
 		}
 	}
@@ -257,6 +267,15 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 	// feeding recovery cost competition, not an unconditional deterministic
 	// commitment. Arms that survive below are not retired repetition-boundary
 	// policies (or, for gomod above, run where the global fold does not).
+	//
+	// dart and c are also in cRepetitionSkipOptOut (the engine-wide fold is
+	// unsafe for both — see the opt-out entries) but each still has a
+	// certified narrow subset in ConflictPolicies (grammars/runtime_profiles.go,
+	// wave10/compat-t1c), checked above by conflictPolicyChoiceForDispatch
+	// before this switch is reached, INCLUDING on wreckage lineages: those
+	// rows carry no recovery gating, matching the retired
+	// dartRepetitionShiftConflictChoice / cRepetitionShiftConflictChoice
+	// helpers they replaced.
 	var chosen ParseAction
 	var ok bool
 	switch p.language.Name {
@@ -264,29 +283,6 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 		// Non-repetition: `case A ->` switch-label disambiguation via a
 		// goto/action-table probe on the reduce's landing state.
 		chosen, ok = p.javaSwitchArrowConflictChoice(s, tok, actions)
-	case "dart":
-		// KEPT, and dart is also in cRepetitionSkipOptOut: dart's capped
-		// branch selection is tuned around this helper's deterministic
-		// repetition shift, INCLUDING on wreckage lineages where the global
-		// fold never applies. A/B evidence (wave-2b, 2026-07-07): removing
-		// the arm alone flips app_bar.dart's recovered tree and pushes
-		// generated_material_localizations.dart from accepted to
-		// memory_budget; the global fold instead of it drops
-		// back_button.dart from 75/88 to 62/88 C-oracle shape chunks. This
-		// is non-C dispatch policy papering over dart's recovery-selection
-		// gaps — revisit when dart is C-recovery-clean.
-		chosen, ok = dartRepetitionShiftConflictChoice(p.language, currentState, actions)
-	case "c":
-		// KEPT, and c is also in cRepetitionSkipOptOut: the C-language
-		// corpus is error-dense and its recovered shapes depend on this
-		// helper's deterministic translation_unit_repeat1 /
-		// preproc_if_repeat1 shift on all lineages. A/B evidence (wave-2b,
-		// 2026-07-07): retiring the arm dropped archive.c from 1354/2040 to
-		// 1061/2040 C-oracle-matching shape chunks, and the fold alone kept
-		// it there (pre-error folds reshape the stack recovery chews on).
-		// Non-C dispatch policy stabilizing recovery selection; revisit
-		// when c recovery is C-clean.
-		chosen, ok = cRepetitionShiftConflictChoice(p.language, actions)
 	case "haskell":
 		// KEPT, and haskell is also in cRepetitionSkipOptOut: this is the
 		// proven-safe scoped subset of the fold (REDUCE at states

--- a/conflict_policy_legacy_helpers.go
+++ b/conflict_policy_legacy_helpers.go
@@ -1,29 +1,5 @@
 package gotreesitter
 
-// dartRepetitionShiftConflictChoice resolves known Dart repeat-boundary forks.
-func dartRepetitionShiftConflictChoice(lang *Language, state StateID, actions []ParseAction) (ParseAction, bool) {
-	if lang == nil {
-		return ParseAction{}, false
-	}
-	switch state {
-	case 596:
-		if !allReducesHaveSymbol(lang, actions, "enum_body_repeat2") {
-			return ParseAction{}, false
-		}
-	case 602:
-		if !allReducesHaveSymbol(lang, actions, "extension_body_repeat1") {
-			return ParseAction{}, false
-		}
-	case 479:
-		if !allReducesHaveSymbol(lang, actions, "program_repeat4") {
-			return ParseAction{}, false
-		}
-	default:
-		return ParseAction{}, false
-	}
-	return repetitionShiftConflictChoice(actions)
-}
-
 // erlangMacroCallExprConflictChoice resolves macro invocation forks in favor of the C-faithful args shift.
 func erlangMacroCallExprConflictChoice(lang *Language, actions []ParseAction) (ParseAction, bool) {
 	if lang == nil || len(actions) < 2 {

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -371,7 +371,7 @@ func TestForestResolveConflictGeneratedPolicyMissKeepsActions(t *testing.T) {
 // forestResolveConflict's generic ConflictPolicy check using a synthetic
 // state/lookahead-scoped row shaped like dot's retired
 // dotRepetitionShiftConflictChoice helper. dot itself ships no such policy
-// (see grammars/runtime_profiles.go's "NOTE on dot", wave10/compat-t1c); this
+// (see grammars/runtime_profiles.go's "NOTE on dot"); this
 // only covers the state+lookahead exact-match mechanism the helper's shape
 // would have used had it been certified.
 func TestForestResolveConflictDotLegacyUsesStateAndLookahead(t *testing.T) {

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -367,11 +367,21 @@ func TestForestResolveConflictGeneratedPolicyMissKeepsActions(t *testing.T) {
 	}
 }
 
+// TestForestResolveConflictDotLegacyUsesStateAndLookahead exercises
+// forestResolveConflict's generic ConflictPolicy check using a synthetic
+// state/lookahead-scoped row shaped like dot's retired
+// dotRepetitionShiftConflictChoice helper. dot itself ships no such policy
+// (see grammars/runtime_profiles.go's "NOTE on dot", wave10/compat-t1c); this
+// only covers the state+lookahead exact-match mechanism the helper's shape
+// would have used had it been certified.
 func TestForestResolveConflictDotLegacyUsesStateAndLookahead(t *testing.T) {
 	lang := &Language{
 		Name:           "dot",
 		SymbolNames:    []string{"end", "identifier", "other", "stmt_list_repeat1"},
 		SymbolMetadata: []SymbolMetadata{{Name: "end"}, {Name: "identifier"}, {Name: "other"}, {Name: "stmt_list_repeat1"}},
+		ConflictPolicies: []ConflictPolicy{
+			{State: 4, Lookahead: 1, Kind: ConflictPolicyRepetitionShift, ReduceSymbols: []Symbol{3}},
+		},
 	}
 	actions := []ParseAction{
 		{Type: ParseActionReduce, Symbol: 3, ChildCount: 2},

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -29,19 +29,17 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// does not improve the selected tree and imposes a full additional parse.
 	//
 	// Dart also certifies its three profiled repeat-boundary folds (enum
-	// bodies, extension bodies, and top-level declaration lists): each row is
-	// the exact {1 reduce of the named repeat aux, 1 repetition shift} shape
-	// tree-sitter-dart's bundled table exposes at that state, enumerated
-	// against this exact blob (dart-81638dbbdb76, wave10/compat-t1c). This
-	// replaced the hand-written dartRepetitionShiftConflictChoice helper.
+	// bodies, extension bodies, and top-level declaration lists) against this
+	// exact blob. The state and reduce-symbol checks preserve the retired
+	// helper's scope without a linear scan over every lookahead at each state.
 	"dart": {
 		blobSHA256:                    mustRuntimeProfileSHA256("06bac15a9921a2e6af2810fb37ecb29a358b120e137345b9af5fb5f6c6632f59"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
-		conflictPolicies: concatConflictPolicies(
-			expandRepetitionShiftPolicies(596, 509, dartMemberDeclarationStartTokens),
-			expandRepetitionShiftPolicies(602, 512, dartMemberDeclarationStartTokens),
-			expandRepetitionShiftPolicies(479, 467, []gotreesitter.Symbol{1, 27, 92, 97, 98, 99, 100, 101, 107, 108, 124, 125, 129, 130, 131, 132, 134, 136, 138, 142, 143, 144}),
-		),
+		conflictPolicies: []gotreesitter.ConflictPolicy{
+			{State: 596, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{509}},
+			{State: 602, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{512}},
+			{State: 479, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{467}},
+		},
 	},
 	// C#'s certified low-pressure accepted-error trees are authoritative. A
 	// fresh no-stacks parse instead benefits from a bounded cap-16 retry; the
@@ -180,7 +178,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// already folded its stmt_list_repeat1 boundary (state 4) with a flat
 	// parse stack; the retired helper's only call site was forest-only and
 	// dot isn't in builtinForestDefaults, so it never actually ran for this
-	// blob. A/B (wave10/compat-t1c) found identical accepted trees, but
+	// blob. A/B validation found identical accepted trees, but
 	// reviving the helper's shift preference as a policy grows the LR stack
 	// O(n) with statement count (406 deep on a 400-statement file vs 8 for
 	// the fold already in place) for no fork-count benefit (both already
@@ -188,7 +186,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	//
 	// go.mod's require-list continuation forks at two states: the top-level
 	// source_file list (state 3) and a parenthesized require block (state
-	// 37). Replaces gomodRepetitionShiftConflictChoice (wave10/compat-t1c).
+	// 37). Replaces gomodRepetitionShiftConflictChoice.
 	// Unlike dot, this is not a revival: the retired helper's dispatch call
 	// site (conflict_policy.go's gomod special case, still present) ran
 	// unconditionally ahead of the reuse gate and the engine-wide fold, so
@@ -197,10 +195,10 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// this migration on a synthetic 400-require go.mod.
 	"gomod": {
 		blobSHA256: mustRuntimeProfileSHA256("e7dca79c1b4655caeee59c9bea3befdd199dd568e2e17640e2ff93832839d2c2"),
-		conflictPolicies: concatConflictPolicies(
-			expandRepetitionShiftPolicies(3, 50, []gotreesitter.Symbol{6, 10, 11, 12, 13, 14, 16, 17, 21}),
-			expandRepetitionShiftPolicies(37, 52, []gotreesitter.Symbol{1, 2, 5}),
-		),
+		conflictPolicies: []gotreesitter.ConflictPolicy{
+			{State: 3, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{50}},
+			{State: 37, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{52}},
+		},
 	},
 	// C's top-level declaration list (translation_unit_repeat1) and
 	// preprocessor-conditional body (preproc_if_repeat1) close only on
@@ -213,7 +211,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// profile using the ConflictPolicyAnyState/AnyLookahead wildcards instead
 	// of an enumerated per-row table. case_statement_repeat1 is deliberately
 	// excluded: its list boundary is load-bearing, not a dead-end. Replaces
-	// cRepetitionShiftConflictChoice (wave10/compat-t1c); byte-for-byte C
+	// cRepetitionShiftConflictChoice; byte-for-byte C
 	// parity held by TestParityCTopLevelDeclAmbiguity /
 	// TestParityCPreprocConditional.
 	"c": {
@@ -227,42 +225,6 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			},
 		},
 	},
-}
-
-// dartMemberDeclarationStartTokens is the shared member-declaration-start
-// lookahead set for dart's enum-body (state 596) and extension-body (state
-// 602) repeat-boundary rows: both certify against the identical first set.
-var dartMemberDeclarationStartTokens = []gotreesitter.Symbol{1, 27, 92, 98, 107, 108, 120, 123, 124, 125, 133, 136, 137, 142, 143, 144}
-
-// expandRepetitionShiftPolicies builds one ConflictPolicyRepetitionShift row
-// per lookahead in lookaheads, all sharing the same certified state and
-// reduce symbol. This only avoids repeating identical State/Kind/
-// ReduceSymbols literals per lookahead; the exact-row shape (one reduce of
-// reduceSymbol plus one repetition shift, nothing else) is still validated
-// at dispatch time by conflictPolicyReducesMatch.
-func expandRepetitionShiftPolicies(state gotreesitter.StateID, reduceSymbol gotreesitter.Symbol, lookaheads []gotreesitter.Symbol) []gotreesitter.ConflictPolicy {
-	policies := make([]gotreesitter.ConflictPolicy, len(lookaheads))
-	for i, lookahead := range lookaheads {
-		policies[i] = gotreesitter.ConflictPolicy{
-			State:         state,
-			Lookahead:     lookahead,
-			Kind:          gotreesitter.ConflictPolicyRepetitionShift,
-			ReduceSymbols: []gotreesitter.Symbol{reduceSymbol},
-		}
-	}
-	return policies
-}
-
-func concatConflictPolicies(groups ...[]gotreesitter.ConflictPolicy) []gotreesitter.ConflictPolicy {
-	total := 0
-	for _, g := range groups {
-		total += len(g)
-	}
-	out := make([]gotreesitter.ConflictPolicy, 0, total)
-	for _, g := range groups {
-		out = append(out, g...)
-	}
-	return out
 }
 
 func mustRuntimeProfileSHA256(raw string) (sum [32]byte) {

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -27,9 +27,21 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder
 	// does not improve the selected tree and imposes a full additional parse.
+	//
+	// Dart also certifies its three profiled repeat-boundary folds (enum
+	// bodies, extension bodies, and top-level declaration lists): each row is
+	// the exact {1 reduce of the named repeat aux, 1 repetition shift} shape
+	// tree-sitter-dart's bundled table exposes at that state, enumerated
+	// against this exact blob (dart-81638dbbdb76, wave10/compat-t1c). This
+	// replaced the hand-written dartRepetitionShiftConflictChoice helper.
 	"dart": {
 		blobSHA256:                    mustRuntimeProfileSHA256("06bac15a9921a2e6af2810fb37ecb29a358b120e137345b9af5fb5f6c6632f59"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		conflictPolicies: concatConflictPolicies(
+			expandRepetitionShiftPolicies(596, 509, dartMemberDeclarationStartTokens),
+			expandRepetitionShiftPolicies(602, 512, dartMemberDeclarationStartTokens),
+			expandRepetitionShiftPolicies(479, 467, []gotreesitter.Symbol{1, 27, 92, 97, 98, 99, 100, 101, 107, 108, 124, 125, 129, 130, 131, 132, 134, 136, 138, 142, 143, 144}),
+		),
 	},
 	// C#'s certified low-pressure accepted-error trees are authoritative. A
 	// fresh no-stacks parse instead benefits from a bounded cap-16 retry; the
@@ -162,6 +174,95 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			InitialStackCeiling: 14,
 		},
 	},
+	// NOTE on dot: no certified row here (unlike gomod/dart/c below) — dot's
+	// retired dotRepetitionShiftConflictChoice is NOT migrated. dot isn't in
+	// cRepetitionSkipOptOut, so the engine-wide C repetition-skip fold
+	// already folded its stmt_list_repeat1 boundary (state 4) with a flat
+	// parse stack; the retired helper's only call site was forest-only and
+	// dot isn't in builtinForestDefaults, so it never actually ran for this
+	// blob. A/B (wave10/compat-t1c) found identical accepted trees, but
+	// reviving the helper's shift preference as a policy grows the LR stack
+	// O(n) with statement count (406 deep on a 400-statement file vs 8 for
+	// the fold already in place) for no fork-count benefit (both already
+	// MaxStacksSeen=1). Retired outright instead of migrated.
+	//
+	// go.mod's require-list continuation forks at two states: the top-level
+	// source_file list (state 3) and a parenthesized require block (state
+	// 37). Replaces gomodRepetitionShiftConflictChoice (wave10/compat-t1c).
+	// Unlike dot, this is not a revival: the retired helper's dispatch call
+	// site (conflict_policy.go's gomod special case, still present) ran
+	// unconditionally ahead of the reuse gate and the engine-wide fold, so
+	// this exact preference was already the live, shipped behavior —
+	// confirmed byte-identical MaxStacksSeen/PeakStackDepth before and after
+	// this migration on a synthetic 400-require go.mod.
+	"gomod": {
+		blobSHA256: mustRuntimeProfileSHA256("e7dca79c1b4655caeee59c9bea3befdd199dd568e2e17640e2ff93832839d2c2"),
+		conflictPolicies: concatConflictPolicies(
+			expandRepetitionShiftPolicies(3, 50, []gotreesitter.Symbol{6, 10, 11, 12, 13, 14, 16, 17, 21}),
+			expandRepetitionShiftPolicies(37, 52, []gotreesitter.Symbol{1, 2, 5}),
+		),
+	},
+	// C's top-level declaration list (translation_unit_repeat1) and
+	// preprocessor-conditional body (preproc_if_repeat1) close only on
+	// terminators with no continuation shift (EOF; #endif/#elif/#else), so
+	// any lookahead offering a continuation shift makes the competing reduce
+	// a zero-progress dead end. That C-faithful rule is scoped by reduce
+	// symbol identity alone, not by table position: it recurs at hundreds of
+	// (state, lookahead) rows across the grammar (a scan of this exact blob
+	// found 3242, across 446 states), which is why this is the one certified
+	// profile using the ConflictPolicyAnyState/AnyLookahead wildcards instead
+	// of an enumerated per-row table. case_statement_repeat1 is deliberately
+	// excluded: its list boundary is load-bearing, not a dead-end. Replaces
+	// cRepetitionShiftConflictChoice (wave10/compat-t1c); byte-for-byte C
+	// parity held by TestParityCTopLevelDeclAmbiguity /
+	// TestParityCPreprocConditional.
+	"c": {
+		blobSHA256: mustRuntimeProfileSHA256("9aee42825fd1446ce5b754951db26edadcdba5d2f26b61578a30e87ed2dbbd3c"),
+		conflictPolicies: []gotreesitter.ConflictPolicy{
+			{
+				State:         gotreesitter.ConflictPolicyAnyState,
+				Lookahead:     gotreesitter.ConflictPolicyAnyLookahead,
+				Kind:          gotreesitter.ConflictPolicyRepetitionShift,
+				ReduceSymbols: []gotreesitter.Symbol{324, 326},
+			},
+		},
+	},
+}
+
+// dartMemberDeclarationStartTokens is the shared member-declaration-start
+// lookahead set for dart's enum-body (state 596) and extension-body (state
+// 602) repeat-boundary rows: both certify against the identical first set.
+var dartMemberDeclarationStartTokens = []gotreesitter.Symbol{1, 27, 92, 98, 107, 108, 120, 123, 124, 125, 133, 136, 137, 142, 143, 144}
+
+// expandRepetitionShiftPolicies builds one ConflictPolicyRepetitionShift row
+// per lookahead in lookaheads, all sharing the same certified state and
+// reduce symbol. This only avoids repeating identical State/Kind/
+// ReduceSymbols literals per lookahead; the exact-row shape (one reduce of
+// reduceSymbol plus one repetition shift, nothing else) is still validated
+// at dispatch time by conflictPolicyReducesMatch.
+func expandRepetitionShiftPolicies(state gotreesitter.StateID, reduceSymbol gotreesitter.Symbol, lookaheads []gotreesitter.Symbol) []gotreesitter.ConflictPolicy {
+	policies := make([]gotreesitter.ConflictPolicy, len(lookaheads))
+	for i, lookahead := range lookaheads {
+		policies[i] = gotreesitter.ConflictPolicy{
+			State:         state,
+			Lookahead:     lookahead,
+			Kind:          gotreesitter.ConflictPolicyRepetitionShift,
+			ReduceSymbols: []gotreesitter.Symbol{reduceSymbol},
+		}
+	}
+	return policies
+}
+
+func concatConflictPolicies(groups ...[]gotreesitter.ConflictPolicy) []gotreesitter.ConflictPolicy {
+	total := 0
+	for _, g := range groups {
+		total += len(g)
+	}
+	out := make([]gotreesitter.ConflictPolicy, 0, total)
+	for _, g := range groups {
+		out = append(out, g...)
+	}
+	return out
 }
 
 func mustRuntimeProfileSHA256(raw string) (sum [32]byte) {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -34,7 +34,12 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	if got, want := len(builtinLanguageRuntimeProfiles), 17; got != want {
+	// 19 = the prior 17 plus gomod and c: their hardcoded compat-tier
+	// repetition-conflict helpers were retired in favor of certified
+	// ConflictPolicies rows here (wave10/compat-t1c). dot's helper was
+	// retired outright, not migrated (see the "NOTE on dot" comment above
+	// the gomod entry), so it does not add a map entry.
+	if got, want := len(builtinLanguageRuntimeProfiles), 19; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -92,6 +97,140 @@ func TestBuiltinHaskellConflictPolicyRequiresCertifiedBlobAndAttachesOnce(t *tes
 	}
 	if got := len(lang.ConflictPolicies); got != 1 {
 		t.Fatalf("reattached Haskell conflict policies = %d, want 1", got)
+	}
+}
+
+// TestBuiltinDartConflictPoliciesAttach covers the three certified dart
+// repeat-boundary rows (enum bodies, extension bodies, top-level declaration
+// lists) that replaced the hardcoded dartRepetitionShiftConflictChoice helper
+// (wave10/compat-t1c).
+func TestBuiltinDartConflictPoliciesAttach(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	lang := DartLanguage()
+	wantStates := map[gotreesitter.StateID]gotreesitter.Symbol{596: 509, 602: 512, 479: 467}
+	gotStates := map[gotreesitter.StateID]bool{}
+	for _, policy := range lang.ConflictPolicies {
+		wantReduce, known := wantStates[policy.State]
+		if !known {
+			continue
+		}
+		gotStates[policy.State] = true
+		if policy.Kind != gotreesitter.ConflictPolicyRepetitionShift ||
+			len(policy.ReduceSymbols) != 1 || policy.ReduceSymbols[0] != wantReduce {
+			t.Fatalf("dart conflict policy at state %d = %+v, want repetition-shift over reduce symbol %d", policy.State, policy, wantReduce)
+		}
+	}
+	for state := range wantStates {
+		if !gotStates[state] {
+			t.Fatalf("dart conflict policy for state %d was not attached", state)
+		}
+	}
+	if got, want := len(lang.ConflictPolicies), 54; got != want {
+		t.Fatalf("dart ConflictPolicies = %d rows, want %d", got, want)
+	}
+}
+
+// TestBuiltinGomodConflictPoliciesAttach covers the certified go.mod
+// require-list rows that replaced gomodRepetitionShiftConflictChoice
+// (wave10/compat-t1c).
+func TestBuiltinGomodConflictPoliciesAttach(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	lang := GomodLanguage()
+	var state3, state37 int
+	for _, policy := range lang.ConflictPolicies {
+		if policy.Kind != gotreesitter.ConflictPolicyRepetitionShift {
+			t.Fatalf("gomod conflict policy = %+v, want repetition-shift kind", policy)
+		}
+		switch policy.State {
+		case 3:
+			if len(policy.ReduceSymbols) != 1 || policy.ReduceSymbols[0] != 50 {
+				t.Fatalf("gomod state-3 conflict policy = %+v, want source_file_repeat1 (symbol 50)", policy)
+			}
+			state3++
+		case 37:
+			if len(policy.ReduceSymbols) != 1 || policy.ReduceSymbols[0] != 52 {
+				t.Fatalf("gomod state-37 conflict policy = %+v, want require_directive_repeat1 (symbol 52)", policy)
+			}
+			state37++
+		default:
+			t.Fatalf("unexpected gomod conflict policy state %d", policy.State)
+		}
+	}
+	if state3 != 9 {
+		t.Fatalf("gomod state-3 conflict policies = %d, want 9", state3)
+	}
+	if state37 != 3 {
+		t.Fatalf("gomod state-37 conflict policies = %d, want 3", state37)
+	}
+}
+
+// TestBuiltinDotHasNoConflictPolicies documents that dot's retired
+// compat-tier helper (dotRepetitionShiftConflictChoice) was NOT migrated to a
+// certified ConflictPolicy: dot already relied on the engine-wide C
+// repetition-skip fold (it is not in cRepetitionSkipOptOut), and A/B testing
+// found the helper's repetition-shift preference grows the LR parse-stack
+// depth O(n) with statement count for no behavioral benefit over that
+// already-flat fold (see the "NOTE on dot" comment in runtime_profiles.go).
+func TestBuiltinDotHasNoConflictPolicies(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	if got := len(DotLanguage().ConflictPolicies); got != 0 {
+		t.Fatalf("dot ConflictPolicies = %d rows, want 0 (helper retired, not migrated)", got)
+	}
+}
+
+// TestBuiltinCConflictPolicyAttachesWildcard covers the certified C
+// translation_unit_repeat1/preproc_if_repeat1 fold, the one profile using the
+// ConflictPolicyAnyState/AnyLookahead wildcards because the C-faithful rule
+// is scoped by reduce-symbol identity alone (thousands of real table rows).
+// Replaces cRepetitionShiftConflictChoice (wave10/compat-t1c).
+func TestBuiltinCConflictPolicyAttachesWildcard(t *testing.T) {
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	lang := CLanguage()
+	if got, want := len(lang.ConflictPolicies), 1; got != want {
+		t.Fatalf("c ConflictPolicies = %d rows, want %d", got, want)
+	}
+	policy := lang.ConflictPolicies[0]
+	if policy.State != gotreesitter.ConflictPolicyAnyState || policy.Lookahead != gotreesitter.ConflictPolicyAnyLookahead ||
+		policy.Kind != gotreesitter.ConflictPolicyRepetitionShift || len(policy.ReduceSymbols) != 2 ||
+		policy.ReduceSymbols[0] != 324 || policy.ReduceSymbols[1] != 326 {
+		t.Fatalf("c conflict policy = %+v, want wildcard repetition-shift over translation_unit_repeat1(324)/preproc_if_repeat1(326)", policy)
+	}
+}
+
+// TestBuiltinGomodCConflictPoliciesRequireCertifiedBlob mirrors the Haskell
+// fail-closed coverage for the two new certified profiles: an uncertified
+// blob identity must not attach any ConflictPolicies.
+func TestBuiltinGomodCConflictPoliciesRequireCertifiedBlob(t *testing.T) {
+	for _, name := range []string{"gomod", "c"} {
+		t.Run(name, func(t *testing.T) {
+			lang := &gotreesitter.Language{Name: name}
+			if attachBuiltinLanguageRuntimeProfile(name, sha256.Sum256([]byte("uncertified")), lang) {
+				t.Fatalf("uncertified %s blob reported a runtime-profile attachment", name)
+			}
+			if len(lang.ConflictPolicies) != 0 {
+				t.Fatalf("uncertified %s blob attached %d conflict policies", name, len(lang.ConflictPolicies))
+			}
+
+			blob := BlobByName(name)
+			if len(blob) == 0 {
+				t.Fatalf("BlobByName(%s) returned no data", name)
+			}
+			sum := sha256.Sum256(blob)
+			if !attachBuiltinLanguageRuntimeProfile(name, sum, lang) {
+				t.Fatalf("certified %s blob did not attach its runtime profile", name)
+			}
+			if len(lang.ConflictPolicies) == 0 {
+				t.Fatalf("certified %s blob attached no conflict policies", name)
+			}
+		})
 	}
 }
 

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -36,7 +36,7 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// 19 = the prior 17 plus gomod and c: their hardcoded compat-tier
 	// repetition-conflict helpers were retired in favor of certified
-	// ConflictPolicies rows here (wave10/compat-t1c). dot's helper was
+	// ConflictPolicies rows here. dot's helper was
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry.
 	if got, want := len(builtinLanguageRuntimeProfiles), 19; got != want {
@@ -103,7 +103,7 @@ func TestBuiltinHaskellConflictPolicyRequiresCertifiedBlobAndAttachesOnce(t *tes
 // TestBuiltinDartConflictPoliciesAttach covers the three certified dart
 // repeat-boundary rows (enum bodies, extension bodies, top-level declaration
 // lists) that replaced the hardcoded dartRepetitionShiftConflictChoice helper
-// (wave10/compat-t1c).
+// through the generic policy path.
 func TestBuiltinDartConflictPoliciesAttach(t *testing.T) {
 	PurgeEmbeddedLanguageCache()
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
@@ -117,7 +117,8 @@ func TestBuiltinDartConflictPoliciesAttach(t *testing.T) {
 			continue
 		}
 		gotStates[policy.State] = true
-		if policy.Kind != gotreesitter.ConflictPolicyRepetitionShift ||
+		if policy.Lookahead != gotreesitter.ConflictPolicyAnyLookahead ||
+			policy.Kind != gotreesitter.ConflictPolicyRepetitionShift ||
 			len(policy.ReduceSymbols) != 1 || policy.ReduceSymbols[0] != wantReduce {
 			t.Fatalf("dart conflict policy at state %d = %+v, want repetition-shift over reduce symbol %d", policy.State, policy, wantReduce)
 		}
@@ -127,14 +128,14 @@ func TestBuiltinDartConflictPoliciesAttach(t *testing.T) {
 			t.Fatalf("dart conflict policy for state %d was not attached", state)
 		}
 	}
-	if got, want := len(lang.ConflictPolicies), 54; got != want {
+	if got, want := len(lang.ConflictPolicies), 3; got != want {
 		t.Fatalf("dart ConflictPolicies = %d rows, want %d", got, want)
 	}
 }
 
 // TestBuiltinGomodConflictPoliciesAttach covers the certified go.mod
 // require-list rows that replaced gomodRepetitionShiftConflictChoice
-// (wave10/compat-t1c).
+// through the generic policy path.
 func TestBuiltinGomodConflictPoliciesAttach(t *testing.T) {
 	PurgeEmbeddedLanguageCache()
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
@@ -144,6 +145,9 @@ func TestBuiltinGomodConflictPoliciesAttach(t *testing.T) {
 	for _, policy := range lang.ConflictPolicies {
 		if policy.Kind != gotreesitter.ConflictPolicyRepetitionShift {
 			t.Fatalf("gomod conflict policy = %+v, want repetition-shift kind", policy)
+		}
+		if policy.Lookahead != gotreesitter.ConflictPolicyAnyLookahead {
+			t.Fatalf("gomod conflict policy = %+v, want wildcard lookahead", policy)
 		}
 		switch policy.State {
 		case 3:
@@ -160,11 +164,11 @@ func TestBuiltinGomodConflictPoliciesAttach(t *testing.T) {
 			t.Fatalf("unexpected gomod conflict policy state %d", policy.State)
 		}
 	}
-	if state3 != 9 {
-		t.Fatalf("gomod state-3 conflict policies = %d, want 9", state3)
+	if state3 != 1 {
+		t.Fatalf("gomod state-3 conflict policies = %d, want 1", state3)
 	}
-	if state37 != 3 {
-		t.Fatalf("gomod state-37 conflict policies = %d, want 3", state37)
+	if state37 != 1 {
+		t.Fatalf("gomod state-37 conflict policies = %d, want 1", state37)
 	}
 }
 
@@ -188,7 +192,7 @@ func TestBuiltinDotHasNoConflictPolicies(t *testing.T) {
 // translation_unit_repeat1/preproc_if_repeat1 fold, the one profile using the
 // ConflictPolicyAnyState/AnyLookahead wildcards because the C-faithful rule
 // is scoped by reduce-symbol identity alone (thousands of real table rows).
-// Replaces cRepetitionShiftConflictChoice (wave10/compat-t1c).
+// Replaces cRepetitionShiftConflictChoice.
 func TestBuiltinCConflictPolicyAttachesWildcard(t *testing.T) {
 	PurgeEmbeddedLanguageCache()
 	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })

--- a/language.go
+++ b/language.go
@@ -261,13 +261,12 @@ type ConflictPolicy struct {
 }
 
 // ConflictPolicyAnyState and ConflictPolicyAnyLookahead are sentinel State/
-// Lookahead values matching every state or every lookahead symbol, instead of
-// one exact table row. For certified engine-wide repetition folds whose
-// C-faithful rule is scoped by reduce-symbol identity alone (not table
-// position): enumerating every reachable row for such a rule can run into
-// the thousands, defeating a per-row certified table. Only hand-certified,
-// blob-SHA-pinned profiles (grammars/runtime_profiles.go) use these
-// sentinels, so a wildcard policy never attaches to an uncertified blob.
+// Lookahead values matching every state or every lookahead symbol instead of
+// one exact table row. They support policies scoped by state and/or reduce
+// symbol identity when enumerating every reachable row would add lookup cost
+// without strengthening the action-shape check. Built-in wildcard policies
+// are hand-certified and blob-SHA-pinned; callers supplying ConflictPolicies
+// directly are responsible for scoping their own wildcard policies safely.
 const (
 	ConflictPolicyAnyState     StateID = ^StateID(0)
 	ConflictPolicyAnyLookahead Symbol  = ^Symbol(0)

--- a/language.go
+++ b/language.go
@@ -260,6 +260,19 @@ type ConflictPolicy struct {
 	ReduceSymbols []Symbol
 }
 
+// ConflictPolicyAnyState and ConflictPolicyAnyLookahead are sentinel State/
+// Lookahead values matching every state or every lookahead symbol, instead of
+// one exact table row. For certified engine-wide repetition folds whose
+// C-faithful rule is scoped by reduce-symbol identity alone (not table
+// position): enumerating every reachable row for such a rule can run into
+// the thousands, defeating a per-row certified table. Only hand-certified,
+// blob-SHA-pinned profiles (grammars/runtime_profiles.go) use these
+// sentinels, so a wildcard policy never attaches to an uncertified blob.
+const (
+	ConflictPolicyAnyState     StateID = ^StateID(0)
+	ConflictPolicyAnyLookahead Symbol  = ^Symbol(0)
+)
+
 // ExternalScannerFullParseRetryPolicy controls whether a full parse with an
 // external scanner may schedule the generic second retry ladder after the
 // normal retry ladder has already selected its best tree.

--- a/parser.go
+++ b/parser.go
@@ -6703,7 +6703,7 @@ func (p *Parser) forestResolveConflict(state StateID, tok Token, actions []Parse
 	// stack. Reviving the old helper's repetition-shift preference as a
 	// certified policy instead grew the stack O(n) with statement count for
 	// no behavioral benefit (see the "NOTE on dot" comment in
-	// grammars/runtime_profiles.go, wave10/compat-t1c).
+	// grammars/runtime_profiles.go).
 	if chosen, ok := conflictPolicyChoice(p.language, tok, state, actions); ok {
 		return p.forestSingletonActions(chosen)
 	}

--- a/parser.go
+++ b/parser.go
@@ -6695,6 +6695,15 @@ func (p *Parser) forestResolveConflict(state StateID, tok Token, actions []Parse
 	if p == nil || p.language == nil || len(actions) < 2 {
 		return actions
 	}
+	// The dot-only fallback that used to live here (dotRepetitionShiftConflictChoice)
+	// is retired, not migrated: dot was never opted out of the engine-wide C
+	// repetition-skip fold (cRepetitionSkipForestConflictChoice, applied by
+	// the forest dispatch loop right after this function returns), which
+	// already folds its stmt_list boundary with a flat (non-growing) parse
+	// stack. Reviving the old helper's repetition-shift preference as a
+	// certified policy instead grew the stack O(n) with statement count for
+	// no behavioral benefit (see the "NOTE on dot" comment in
+	// grammars/runtime_profiles.go, wave10/compat-t1c).
 	if chosen, ok := conflictPolicyChoice(p.language, tok, state, actions); ok {
 		return p.forestSingletonActions(chosen)
 	}
@@ -6703,12 +6712,6 @@ func (p *Parser) forestResolveConflict(state StateID, tok Token, actions []Parse
 	}
 	if p.language.GeneratedByGrammargen {
 		return actions
-	}
-	switch p.language.Name {
-	case "dot":
-		if chosen, ok := dotRepetitionShiftConflictChoice(p.language, tok, state, actions); ok {
-			return p.forestSingletonActions(chosen)
-		}
 	}
 	return actions
 }
@@ -7233,28 +7236,6 @@ func kotlinObjectLiteralConflictChoice(lang *Language, actions []ParseAction) (P
 	return ParseAction{}, false
 }
 
-// gomodRepetitionShiftConflictChoice keeps parenthesized require lists on the
-// repetition-shift path. On real go.mod corpora, state 37 forks for every
-// following require_spec starter; C continues the list deterministically.
-func gomodRepetitionShiftConflictChoice(lang *Language, state StateID, actions []ParseAction) (ParseAction, bool) {
-	if lang == nil {
-		return ParseAction{}, false
-	}
-	switch state {
-	case 3:
-		if !allReducesHaveSymbol(lang, actions, "source_file_repeat1") {
-			return ParseAction{}, false
-		}
-	case 37:
-		if !allReducesHaveSymbol(lang, actions, "require_directive_repeat1") {
-			return ParseAction{}, false
-		}
-	default:
-		return ParseAction{}, false
-	}
-	return repetitionShiftConflictChoice(actions)
-}
-
 // haskellRepeatBoundaryConflictChoice collapses the two profiled Haskell
 // repeat-boundary forks that dominate large real-corpus parsing. Layout
 // declaration lists (state 9609) and export lists (state 10984) both offer a
@@ -7346,26 +7327,6 @@ func singleReduceAgainstShiftConflictChoice(lang *Language, actions []ParseActio
 		return ParseAction{}, false
 	}
 	return reduce, true
-}
-
-// dotRepetitionShiftConflictChoice collapses DOT's top-level statement-list
-// continuation fork. Upstream's `stmt_list` repeat closes only on `}`, so an
-// `identifier` after an existing statement is always another statement start;
-// taking the repetition shift matches C tree-sitter and prevents large graph
-// files from keeping both list-boundary interpretations alive.
-func dotRepetitionShiftConflictChoice(lang *Language, tok Token, state StateID, actions []ParseAction) (ParseAction, bool) {
-	if lang == nil || state != 4 {
-		return ParseAction{}, false
-	}
-	if tok.Symbol != 0 && !symbolHasName(lang, tok.Symbol, "identifier") {
-		return ParseAction{}, false
-	}
-	for _, act := range actions {
-		if act.Type == ParseActionReduce && !symbolHasName(lang, act.Symbol, "stmt_list_repeat1") {
-			return ParseAction{}, false
-		}
-	}
-	return repetitionShiftConflictChoice(actions)
 }
 
 func singleReduceAgainstRepetitionShiftConflictChoice(actions []ParseAction) (ParseAction, bool) {
@@ -7493,55 +7454,6 @@ func allReducesHaveSymbol(lang *Language, actions []ParseAction, name string) bo
 			continue
 		}
 		if !symbolHasName(lang, act.Symbol, name) {
-			return false
-		}
-		found = true
-	}
-	return found
-}
-
-// cRepetitionShiftConflictChoice collapses the reduce/shift fork at the
-// top-level item list (translation_unit_repeat1) and the preprocessor
-// conditional body (preproc_if_repeat1). Both lists close only on terminators
-// that carry no continuation shift — EOF for translation_unit; #endif/#elif/
-// #else for preproc_if — so on any token that DOES have a continuation shift,
-// continuing the list is correct and the reduce is a zero-progress dead-end.
-// repetitionShiftConflictChoice enforces the single-repetition-shift shape, so
-// the no-continuation-shift terminators are excluded automatically.
-//
-// case_statement_repeat1 is deliberately NOT collapsible: a switch body's
-// `case`/`default` terminators are themselves shiftable, so reducing the inner
-// statement list on them is load-bearing, not a dead-end.
-//
-// C declares a top-level declaration/expression-statement ambiguity in its
-// conflicts: block, but that ambiguity resolves deeper than these list
-// boundaries — collapsing the continuation fork preserves it. Held to
-// byte-for-byte C parity by the treesitter_c_parity suite, including the
-// adversarial declaration/expression and preprocessor cases in
-// TestParityCTopLevelDeclAmbiguity / TestParityCPreprocConditional. On cluster.c
-// the translation_unit collapse alone cuts ~11.9k GLR forks (−57%, xC 1.30→1.03).
-func cRepetitionShiftConflictChoice(lang *Language, actions []ParseAction) (ParseAction, bool) {
-	if lang == nil {
-		return ParseAction{}, false
-	}
-	if !cReduceIsCollapsibleListRepeat(lang, actions) {
-		return ParseAction{}, false
-	}
-	return repetitionShiftConflictChoice(actions)
-}
-
-// cReduceIsCollapsibleListRepeat reports whether every reduce in the conflict
-// reduces a list repeat whose only terminators carry no continuation shift
-// (translation_unit_repeat1, preproc_if_repeat1), and at least one reduce
-// exists. Any other reduce symbol (e.g. case_statement_repeat1) disqualifies.
-func cReduceIsCollapsibleListRepeat(lang *Language, actions []ParseAction) bool {
-	found := false
-	for _, act := range actions {
-		if act.Type != ParseActionReduce {
-			continue
-		}
-		if !symbolHasName(lang, act.Symbol, "translation_unit_repeat1") &&
-			!symbolHasName(lang, act.Symbol, "preproc_if_repeat1") {
 			return false
 		}
 		found = true

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -235,7 +235,7 @@ func TestDeterministicConflictChoiceUsesCRepetitionFoldOnRecoveryLineages(t *tes
 }
 
 // Dart's repeat-boundary states are now certified ConflictPolicy rows
-// (grammars/runtime_profiles.go, wave10/compat-t1c) instead of the retired
+// (grammars/runtime_profiles.go) instead of the retired
 // dartRepetitionShiftConflictChoice helper; these exercise the same shapes
 // through the generic data-driven path.
 func TestDartConflictPolicyRepetitionShiftCoversHotRepeats(t *testing.T) {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -234,7 +234,11 @@ func TestDeterministicConflictChoiceUsesCRepetitionFoldOnRecoveryLineages(t *tes
 	}
 }
 
-func TestDartRepetitionShiftConflictChoiceAllowsHotRepeats(t *testing.T) {
+// Dart's repeat-boundary states are now certified ConflictPolicy rows
+// (grammars/runtime_profiles.go, wave10/compat-t1c) instead of the retired
+// dartRepetitionShiftConflictChoice helper; these exercise the same shapes
+// through the generic data-driven path.
+func TestDartConflictPolicyRepetitionShiftCoversHotRepeats(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		state        StateID
@@ -244,30 +248,38 @@ func TestDartRepetitionShiftConflictChoiceAllowsHotRepeats(t *testing.T) {
 		{name: "extension_body_repeat1", state: 602, reduceSymbol: 2},
 		{name: "program_repeat4", state: 479, reduceSymbol: 3},
 	} {
-		lang := &Language{SymbolNames: []string{"end", "enum_body_repeat2", "extension_body_repeat1", "program_repeat4"}}
+		lang := &Language{
+			Name:             "dart",
+			SymbolNames:      []string{"end", "enum_body_repeat2", "extension_body_repeat1", "program_repeat4"},
+			ConflictPolicies: []ConflictPolicy{{State: tc.state, Lookahead: 7, Kind: ConflictPolicyRepetitionShift, ReduceSymbols: []Symbol{tc.reduceSymbol}}},
+		}
 		actions := []ParseAction{
 			{Type: ParseActionReduce, Symbol: tc.reduceSymbol, ChildCount: 2},
 			{Type: ParseActionShift, State: 9, Repetition: true},
 		}
 
-		chosen, ok := dartRepetitionShiftConflictChoice(lang, tc.state, actions)
+		chosen, ok := conflictPolicyChoice(lang, Token{Symbol: 7}, tc.state, actions)
 		if !ok {
-			t.Fatalf("dartRepetitionShiftConflictChoice(%s) = false, want true", tc.name)
+			t.Fatalf("conflictPolicyChoice(%s) = false, want true", tc.name)
 		}
 		if chosen.Type != ParseActionShift || chosen.State != 9 || !chosen.Repetition {
-			t.Fatalf("dartRepetitionShiftConflictChoice(%s) picked %+v, want repetition shift", tc.name, chosen)
+			t.Fatalf("conflictPolicyChoice(%s) picked %+v, want repetition shift", tc.name, chosen)
 		}
 	}
 }
 
-func TestDartRepetitionShiftConflictChoiceRejectsOtherRepeat(t *testing.T) {
-	lang := &Language{SymbolNames: []string{"end", "enum_body_repeat2", "other_repeat1"}}
+func TestDartConflictPolicyRepetitionShiftRejectsOtherRepeat(t *testing.T) {
+	lang := &Language{
+		Name:             "dart",
+		SymbolNames:      []string{"end", "enum_body_repeat2", "other_repeat1"},
+		ConflictPolicies: []ConflictPolicy{{State: 596, Lookahead: 7, Kind: ConflictPolicyRepetitionShift, ReduceSymbols: []Symbol{1}}},
+	}
 	actions := []ParseAction{
 		{Type: ParseActionReduce, Symbol: 2, ChildCount: 2},
 		{Type: ParseActionShift, State: 9, Repetition: true},
 	}
-	if _, ok := dartRepetitionShiftConflictChoice(lang, 596, actions); ok {
-		t.Fatal("dartRepetitionShiftConflictChoice = true, want false")
+	if _, ok := conflictPolicyChoice(lang, Token{Symbol: 7}, 596, actions); ok {
+		t.Fatal("conflictPolicyChoice = true, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move the shipped C, Dart, and go.mod repetition-conflict choices from language-specific helpers into blob-SHA-pinned `ConflictPolicies`.
- Use compact wildcard rows where the certified behavior is scoped by state and/or reduce-symbol identity, while retaining action-shape validation at dispatch.
- Retire the inactive dot helper; keep the C# helper because its contextual-keyword guard depends on source text that the policy table cannot express.
- Remove the policy expansion helpers and document caller responsibility for wildcard policies.

## Validation

- `go test . ./grammars -count=1`
- Dart GLR cap-pressure parity in Docker
- C top-level declaration and preprocessor parity gates in Docker
- go.mod aggressive real-corpus gate: 20/20 no-error, S-expression parity, and deep parity
- 400-declaration Dart A/B: approximately 2.83 ms median with compact policies versus 2.95 ms with the retired helper; steady-state allocations unchanged

The change reduces language-specific parser code and keeps the built-in behavior fail-closed on the certified grammar blobs.