### PR TITLE
perf(parser): inline small forest alternative indexes

### DIFF
--- a/benchmark_recurring_parse_test.go
+++ b/benchmark_recurring_parse_test.go
@@ -24,9 +24,30 @@ func requireRecurringBenchmarkTree(b *testing.B, tree *gotreesitter.Tree, err er
 // reused parser. The input is intentionally much smaller than the parser's
 // retained scratch caches, making recurring reset work visible.
 func BenchmarkKDLParseRecurringTinyClean(b *testing.B) {
-	lang := grammars.KdlLanguage()
+	benchmarkRecurringTinyClean(b, grammars.KdlLanguage(), []byte("node\n"))
+}
+
+// BenchmarkJavaParseRecurringTinyClean is the fixed-floor witness for the
+// highest clean/parity-passing ratio in the post-refresh fleet sweep.
+func BenchmarkJavaParseRecurringTinyClean(b *testing.B) {
+	benchmarkRecurringTinyClean(b, grammars.JavaLanguage(), []byte("class A {}\n"))
+}
+
+// BenchmarkCSharpParseRecurringTinyClean is a second clean fleet-tail witness
+// with substantially different grammar and conflict behavior from Java.
+func BenchmarkCSharpParseRecurringTinyClean(b *testing.B) {
+	benchmarkRecurringTinyClean(b, grammars.CSharpLanguage(), []byte("class A {}\n"))
+}
+
+// BenchmarkCSSParseRecurringTinyClean covers another clean/parity-passing row
+// from the post-refresh fleet tail at negligible additional benchmark cost.
+func BenchmarkCSSParseRecurringTinyClean(b *testing.B) {
+	benchmarkRecurringTinyClean(b, grammars.CssLanguage(), []byte("a{color:red}\n"))
+}
+
+func benchmarkRecurringTinyClean(b *testing.B, lang *gotreesitter.Language, src []byte) {
+	b.Helper()
 	parser := gotreesitter.NewParser(lang)
-	src := []byte("node\n")
 
 	warm, err := parser.Parse(src)
 	requireRecurringBenchmarkTree(b, warm, err, false)

--- a/benchmark_recurring_parse_test.go
+++ b/benchmark_recurring_parse_test.go
@@ -1,0 +1,106 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func requireRecurringBenchmarkTree(b *testing.B, tree *gotreesitter.Tree, err error, wantError bool) {
+	b.Helper()
+	if err != nil {
+		b.Fatalf("parse error: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		b.Fatal("parse returned nil tree or root")
+	}
+	if got := tree.RootNode().HasError(); got != wantError {
+		b.Fatalf("root.HasError() = %v, want %v", got, wantError)
+	}
+}
+
+// BenchmarkKDLParseRecurringTinyClean isolates the fixed per-Parse floor on a
+// reused parser. The input is intentionally much smaller than the parser's
+// retained scratch caches, making recurring reset work visible.
+func BenchmarkKDLParseRecurringTinyClean(b *testing.B) {
+	lang := grammars.KdlLanguage()
+	parser := gotreesitter.NewParser(lang)
+	src := []byte("node\n")
+
+	warm, err := parser.Parse(src)
+	requireRecurringBenchmarkTree(b, warm, err, false)
+	warm.Release()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(src)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		tree.Release()
+	}
+}
+
+// BenchmarkKDLParseRecurringErrorCleanAlternate exercises an error parse that
+// grows recovery scratch followed by a tiny clean parse on the same Parser.
+// Each operation is one error+clean pair so reset costs cannot hide behind a
+// sub-benchmark boundary or a fresh parser.
+func BenchmarkKDLParseRecurringErrorCleanAlternate(b *testing.B) {
+	lang := grammars.KdlLanguage()
+	parser := gotreesitter.NewParser(lang)
+	errorSrc := makeKDLRecoveryGarbageSource(4, 8)
+	cleanSrc := []byte("node\n")
+
+	errorTree, err := parser.Parse(errorSrc)
+	requireRecurringBenchmarkTree(b, errorTree, err, true)
+	errorTree.Release()
+	cleanTree, err := parser.Parse(cleanSrc)
+	requireRecurringBenchmarkTree(b, cleanTree, err, false)
+	cleanTree.Release()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(errorSrc) + len(cleanSrc)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		errorTree, err := parser.Parse(errorSrc)
+		if err != nil {
+			b.Fatalf("error parse: %v", err)
+		}
+		errorTree.Release()
+
+		cleanTree, err := parser.Parse(cleanSrc)
+		if err != nil {
+			b.Fatalf("clean parse: %v", err)
+		}
+		cleanTree.Release()
+	}
+}
+
+// BenchmarkJSONParseRecurringTinyTokenSourceFactory measures the recurring
+// floor when callers use the public factory route instead of Parser.Parse.
+func BenchmarkJSONParseRecurringTinyTokenSourceFactory(b *testing.B) {
+	lang := grammars.JsonLanguage()
+	parser := gotreesitter.NewParser(lang)
+	src := []byte("{}")
+	factory := func(source []byte) (gotreesitter.TokenSource, error) {
+		return grammars.NewJSONTokenSource(source, lang)
+	}
+
+	warm, err := parser.ParseWithTokenSourceFactory(src, factory)
+	requireRecurringBenchmarkTree(b, warm, err, false)
+	warm.Release()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.ParseWithTokenSourceFactory(src, factory)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		tree.Release()
+	}
+}

--- a/benchmark_recurring_parse_test.go
+++ b/benchmark_recurring_parse_test.go
@@ -27,10 +27,55 @@ func BenchmarkKDLParseRecurringTinyClean(b *testing.B) {
 	benchmarkRecurringTinyClean(b, grammars.KdlLanguage(), []byte("node\n"))
 }
 
-// BenchmarkJavaParseRecurringTinyClean is the fixed-floor witness for the
-// highest clean/parity-passing ratio in the post-refresh fleet sweep.
-func BenchmarkJavaParseRecurringTinyClean(b *testing.B) {
+// BenchmarkJavaParseRecurringTinyCleanDFA isolates the built-in DFA route. The
+// fleet scanner uses Java's registered TokenSourceFactory instead; keep this
+// variant explicit so it cannot be mistaken for the fleet witness below.
+func BenchmarkJavaParseRecurringTinyCleanDFA(b *testing.B) {
 	benchmarkRecurringTinyClean(b, grammars.JavaLanguage(), []byte("class A {}\n"))
+}
+
+// BenchmarkJavaParseRecurringTinyTokenSourceFactory matches perf_scan's Java
+// route: construct the registered custom token source inside the timed
+// operation, then parse it on a reused Parser.
+func BenchmarkJavaParseRecurringTinyTokenSourceFactory(b *testing.B) {
+	lang := grammars.JavaLanguage()
+	parser := gotreesitter.NewParser(lang)
+	src := []byte("class A {}\n")
+
+	warm := grammars.NewJavaTokenSourceOrEOF(src, lang)
+	warmTree, err := parser.ParseWithTokenSource(src, warm)
+	requireRecurringBenchmarkTree(b, warmTree, err, false)
+	warmTree.Release()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ts := grammars.NewJavaTokenSourceOrEOF(src, lang)
+		tree, err := parser.ParseWithTokenSource(src, ts)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		tree.Release()
+	}
+}
+
+// BenchmarkJavaTokenSourceConstructRecurring isolates the per-call factory
+// floor, including immutable token-symbol binding and cached lexer-table
+// attachment, without parser work.
+func BenchmarkJavaTokenSourceConstructRecurring(b *testing.B) {
+	lang := grammars.JavaLanguage()
+	src := []byte("class A {}\n")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ts, err := grammars.NewJavaTokenSource(src, lang)
+		if err != nil {
+			b.Fatalf("token source: %v", err)
+		}
+		_ = ts
+	}
 }
 
 // BenchmarkCSharpParseRecurringTinyClean is a second clean fleet-tail witness

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -694,9 +694,21 @@ func coalesceForestWithRaw(p *Parser, arena *nodeArena, index *gssForestIndex, s
 }
 
 type forestAlternativeIndex struct {
-	nodes   map[*Node]*gssForestNode
-	byStart map[uint32][]*Node
-	slots   map[forestAlternativeSlotKey]forestAlternativeSlot
+	nodes            map[*Node]*gssForestNode
+	byStart          map[uint32][]*Node
+	slots            map[forestAlternativeSlotKey]forestAlternativeSlot
+	targetCapacity   int
+	promoted         bool
+	inlineNodeCount  uint8
+	inlineSlotCount  uint8
+	inlineNodes      [forestAlternativeIndexInlineCapacity]forestAlternativeNodeEntry
+	inlineSlots      [forestAlternativeIndexInlineCapacity]forestAlternativeSlotEntry
+	inlineCandidates [forestAlternativeIndexInlineCapacity]*Node
+}
+
+type forestAlternativeNodeEntry struct {
+	key   *Node
+	value *gssForestNode
 }
 
 type forestAlternativeSlotKey struct {
@@ -707,6 +719,11 @@ type forestAlternativeSlotKey struct {
 type forestAlternativeSlot struct {
 	node *gssForestNode
 	prev *gssForestNode
+}
+
+type forestAlternativeSlotEntry struct {
+	key   forestAlternativeSlotKey
+	value forestAlternativeSlot
 }
 
 // forestAlternativeIndexCapacityForSource sizes the alternative-index maps'
@@ -731,12 +748,119 @@ func forestAlternativeIndexCapacityForSource(sourceLen int) int {
 	return capacity
 }
 
-func newForestAlternativeIndex(capacity int) *forestAlternativeIndex {
-	return &forestAlternativeIndex{
-		nodes:   make(map[*Node]*gssForestNode, capacity),
-		byStart: make(map[uint32][]*Node, max(16, capacity/4)),
-		slots:   make(map[forestAlternativeSlotKey]forestAlternativeSlot, capacity),
+const forestAlternativeIndexInlineCapacity = 16
+
+func newForestAlternativeIndex(targetCapacity int) *forestAlternativeIndex {
+	return &forestAlternativeIndex{targetCapacity: targetCapacity}
+}
+
+func (alternatives *forestAlternativeIndex) promote() bool {
+	if alternatives == nil || alternatives.promoted {
+		return false
 	}
+	targetCapacity := max(forestAlternativeIndexInlineCapacity, alternatives.targetCapacity)
+	nodes := make(map[*Node]*gssForestNode, targetCapacity)
+	byStart := make(map[uint32][]*Node, max(16, targetCapacity/4))
+	for i := 0; i < int(alternatives.inlineNodeCount); i++ {
+		entry := alternatives.inlineNodes[i]
+		nodes[entry.key] = entry.value
+		byStart[entry.key.startByte] = append(byStart[entry.key.startByte], entry.key)
+	}
+	slots := make(map[forestAlternativeSlotKey]forestAlternativeSlot, targetCapacity)
+	for i := 0; i < int(alternatives.inlineSlotCount); i++ {
+		entry := alternatives.inlineSlots[i]
+		slots[entry.key] = entry.value
+	}
+	alternatives.nodes = nodes
+	alternatives.byStart = byStart
+	alternatives.slots = slots
+	clear(alternatives.inlineNodes[:])
+	clear(alternatives.inlineSlots[:])
+	clear(alternatives.inlineCandidates[:])
+	alternatives.inlineNodeCount = 0
+	alternatives.inlineSlotCount = 0
+	alternatives.promoted = true
+	return true
+}
+
+func (alternatives *forestAlternativeIndex) node(key *Node) *gssForestNode {
+	if alternatives == nil || key == nil {
+		return nil
+	}
+	if alternatives.promoted {
+		return alternatives.nodes[key]
+	}
+	for i := 0; i < int(alternatives.inlineNodeCount); i++ {
+		if alternatives.inlineNodes[i].key == key {
+			return alternatives.inlineNodes[i].value
+		}
+	}
+	return nil
+}
+
+func (alternatives *forestAlternativeIndex) setNode(key *Node, value *gssForestNode) {
+	if alternatives == nil || key == nil {
+		return
+	}
+	if alternatives.promoted {
+		if _, exists := alternatives.nodes[key]; !exists {
+			alternatives.byStart[key.startByte] = append(alternatives.byStart[key.startByte], key)
+		}
+		alternatives.nodes[key] = value
+		return
+	}
+	for i := 0; i < int(alternatives.inlineNodeCount); i++ {
+		if alternatives.inlineNodes[i].key == key {
+			alternatives.inlineNodes[i].value = value
+			return
+		}
+	}
+	if int(alternatives.inlineNodeCount) == len(alternatives.inlineNodes) {
+		alternatives.promote()
+		alternatives.setNode(key, value)
+		return
+	}
+	alternatives.inlineNodes[alternatives.inlineNodeCount] = forestAlternativeNodeEntry{key: key, value: value}
+	alternatives.inlineNodeCount++
+}
+
+func (alternatives *forestAlternativeIndex) slot(key forestAlternativeSlotKey) (forestAlternativeSlot, bool) {
+	if alternatives == nil {
+		return forestAlternativeSlot{}, false
+	}
+	if alternatives.promoted {
+		value, ok := alternatives.slots[key]
+		return value, ok
+	}
+	for i := 0; i < int(alternatives.inlineSlotCount); i++ {
+		if alternatives.inlineSlots[i].key == key {
+			return alternatives.inlineSlots[i].value, true
+		}
+	}
+	return forestAlternativeSlot{}, false
+}
+
+func (alternatives *forestAlternativeIndex) setSlot(key forestAlternativeSlotKey, value forestAlternativeSlot) {
+	if alternatives == nil {
+		return
+	}
+	if alternatives.promoted {
+		alternatives.slots[key] = value
+		return
+	}
+	for i := 0; i < int(alternatives.inlineSlotCount); i++ {
+		if alternatives.inlineSlots[i].key == key {
+			alternatives.inlineSlots[i].value = value
+			return
+		}
+	}
+	if int(alternatives.inlineSlotCount) == len(alternatives.inlineSlots) {
+		alternatives.promote()
+		alternatives.setSlot(key, value)
+		return
+	}
+	alternatives.inlineSlots[alternatives.inlineSlotCount] = forestAlternativeSlotEntry{key: key, value: value}
+	alternatives.inlineSlotCount++
 }
 
 func forestRecordAlternative(alternatives *forestAlternativeIndex, entry stackEntry, node *gssForestNode) {
@@ -744,19 +868,25 @@ func forestRecordAlternative(alternatives *forestAlternativeIndex, entry stackEn
 		return
 	}
 	if n := stackEntryNode(entry); n != nil {
-		if _, exists := alternatives.nodes[n]; !exists {
-			if alternatives.byStart == nil {
-				alternatives.byStart = make(map[uint32][]*Node, 16)
-			}
-			alternatives.byStart[n.startByte] = append(alternatives.byStart[n.startByte], n)
-		}
-		alternatives.nodes[n] = node
+		alternatives.setNode(n, node)
 	}
 }
 
 func forestAlternativeCandidatesStartingAt(alternatives *forestAlternativeIndex, startByte uint32) []*Node {
 	if alternatives == nil {
 		return nil
+	}
+	if !alternatives.promoted {
+		clear(alternatives.inlineCandidates[:])
+		count := 0
+		for i := 0; i < int(alternatives.inlineNodeCount); i++ {
+			n := alternatives.inlineNodes[i].key
+			if n != nil && n.startByte == startByte {
+				alternatives.inlineCandidates[count] = n
+				count++
+			}
+		}
+		return alternatives.inlineCandidates[:count]
 	}
 	if len(alternatives.byStart) == 0 && len(alternatives.nodes) > 0 {
 		alternatives.byStart = make(map[uint32][]*Node, max(16, len(alternatives.nodes)/4))
@@ -777,7 +907,7 @@ func forestRecordParentChildAlternatives(alternatives *forestAlternativeIndex, p
 		if child == nil || forestDirectReduceChildIndex(child, rawEntries) < 0 {
 			continue
 		}
-		forestNode := alternatives.nodes[child]
+		forestNode := alternatives.node(child)
 		if forestNode == nil {
 			continue
 		}
@@ -785,10 +915,10 @@ func forestRecordParentChildAlternatives(alternatives *forestAlternativeIndex, p
 		if !ok {
 			continue
 		}
-		alternatives.slots[forestAlternativeSlotKey{parent: parent, childIndex: i}] = forestAlternativeSlot{
+		alternatives.setSlot(forestAlternativeSlotKey{parent: parent, childIndex: i}, forestAlternativeSlot{
 			node: forestNode,
 			prev: prev,
-		}
+		})
 	}
 }
 
@@ -1771,7 +1901,7 @@ func resolveForestChildAlternatives(p *Parser, arena *nodeArena, parent *Node, a
 			continue
 		}
 		chosen := child
-		if slot, ok := alternatives.slots[forestAlternativeSlotKey{parent: parent, childIndex: i}]; ok {
+		if slot, ok := alternatives.slot(forestAlternativeSlotKey{parent: parent, childIndex: i}); ok {
 			if best := slot.node.bestResultLinkForPrev(p, arena, slot.prev); best != nil {
 				if bestNode := stackEntryNode(best.subtree); bestNode != nil && forestAlternativeFitsChildSlot(p, child, bestNode) {
 					chosen = bestNode
@@ -1800,11 +1930,11 @@ func forestRecordedUnaryDirectChildAlternative(p *Parser, arena *nodeArena, alte
 	if p == nil || arena == nil || alternatives == nil || wrapper == nil || depth > maxTreeWalkDepth {
 		return nil
 	}
-	if len(wrapper.children) != 1 || alternatives.nodes[wrapper] == nil {
+	if len(wrapper.children) != 1 || alternatives.node(wrapper) == nil {
 		return nil
 	}
 	direct := wrapper.children[0]
-	if direct == nil || len(direct.children) <= 1 || alternatives.nodes[direct] == nil {
+	if direct == nil || len(direct.children) <= 1 || alternatives.node(direct) == nil {
 		return nil
 	}
 	if !stackEntryUnaryWrapperContains(p, arena, newStackEntryNode(wrapper.parseState, wrapper), newStackEntryNode(direct.parseState, direct), depth+1) {

--- a/glr_forest_test.go
+++ b/glr_forest_test.go
@@ -3,7 +3,100 @@ package gotreesitter
 import (
 	"fmt"
 	"testing"
+	"unsafe"
 )
+
+func TestForestAlternativeIndexCapacityForSource(t *testing.T) {
+	const maxCapacity = 1 << 20
+	tests := []struct {
+		name      string
+		sourceLen int
+		want      int
+	}{
+		{name: "empty", sourceLen: 0, want: 1024},
+		{name: "below floor", sourceLen: 8191, want: 1024},
+		{name: "at floor", sourceLen: 8192, want: 1024},
+		{name: "above floor", sourceLen: 8200, want: 1025},
+		{name: "at ceiling", sourceLen: maxCapacity * 8, want: maxCapacity},
+		{name: "above ceiling", sourceLen: maxCapacity*8 + 8, want: maxCapacity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := forestAlternativeIndexCapacityForSource(tt.sourceLen); got != tt.want {
+				t.Fatalf("forestAlternativeIndexCapacityForSource(%d) = %d, want %d", tt.sourceLen, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForestAlternativeIndexInlineTierBelowCapacity(t *testing.T) {
+	index := newForestAlternativeIndex(1024)
+	for i := 0; i < forestAlternativeIndexInlineCapacity; i++ {
+		node := &Node{startByte: uint32(i % 3)}
+		index.setNode(node, &gssForestNode{state: StateID(i + 1)})
+		index.setSlot(forestAlternativeSlotKey{parent: node, childIndex: i}, forestAlternativeSlot{node: &gssForestNode{state: StateID(i + 2)}})
+	}
+	if index.promoted || index.nodes != nil || index.slots != nil || index.byStart != nil {
+		t.Fatal("inline alternative index allocated maps at capacity")
+	}
+	if got := len(forestAlternativeCandidatesStartingAt(index, 1)); got != 5 {
+		t.Fatalf("inline by-start candidate count = %d, want 5", got)
+	}
+}
+
+func TestForestAlternativeIndexPromotionPreservesEntries(t *testing.T) {
+	index := newForestAlternativeIndex(1024)
+	var first *Node
+	var firstSlotKey forestAlternativeSlotKey
+	var firstSlot forestAlternativeSlot
+	for i := 0; i < forestAlternativeIndexInlineCapacity; i++ {
+		node := &Node{startByte: uint32(i)}
+		value := &gssForestNode{state: StateID(i + 1)}
+		slotKey := forestAlternativeSlotKey{parent: node, childIndex: i}
+		slot := forestAlternativeSlot{node: value, prev: &gssForestNode{state: StateID(i)}}
+		if i == 0 {
+			first, firstSlotKey, firstSlot = node, slotKey, slot
+		}
+		index.setNode(node, value)
+		index.setSlot(slotKey, slot)
+	}
+	extra := &Node{startByte: 99}
+	index.setNode(extra, &gssForestNode{state: 99})
+	if !index.promoted {
+		t.Fatal("alternative index did not promote on entry 17")
+	}
+	if index.node(first) == nil || index.node(extra) == nil {
+		t.Fatal("promotion lost node entries")
+	}
+	if got, ok := index.slot(firstSlotKey); !ok || got != firstSlot {
+		t.Fatalf("promotion lost slot entry: got %#v, %v want %#v", got, ok, firstSlot)
+	}
+	if got := forestAlternativeCandidatesStartingAt(index, first.startByte); len(got) != 1 || got[0] != first {
+		t.Fatalf("promotion lost by-start entry: %#v", got)
+	}
+	if index.inlineNodeCount != 0 || index.inlineSlotCount != 0 {
+		t.Fatalf("promotion retained inline counts: nodes=%d slots=%d", index.inlineNodeCount, index.inlineSlotCount)
+	}
+}
+
+func TestForestAlternativeIndexSlotPromotionRunsOnce(t *testing.T) {
+	index := newForestAlternativeIndex(1024)
+	for i := 0; i <= forestAlternativeIndexInlineCapacity; i++ {
+		index.setSlot(forestAlternativeSlotKey{parent: &Node{}, childIndex: i}, forestAlternativeSlot{node: &gssForestNode{state: StateID(i + 1)}})
+	}
+	if !index.promoted || len(index.slots) != forestAlternativeIndexInlineCapacity+1 {
+		t.Fatalf("slot promotion state: promoted=%v slots=%d", index.promoted, len(index.slots))
+	}
+	if index.promote() {
+		t.Fatal("alternative index promoted more than once")
+	}
+}
+
+func TestForestAlternativeIndexInlineLayoutBounded(t *testing.T) {
+	if got, maxSize := unsafe.Sizeof(forestAlternativeIndex{}), uintptr(1024); got > maxSize {
+		t.Fatalf("forest alternative inline index size = %d, exceeds %d", got, maxSize)
+	}
+}
 
 // pathsOf reduces childCount children over node and returns each visited path as
 // "child-states|popToState" so order and fan-out are easy to assert.

--- a/raw_shape_test.go
+++ b/raw_shape_test.go
@@ -394,8 +394,8 @@ func TestForestChildAlternativeResolutionPreservesVisibleNamedUnaryWrapper(t *te
 	root.rawShape = parser.captureRawShape(nil, arena, rootSym, 0, []stackEntry{newStackEntryNode(0, guard)}, 0, 1)
 
 	alternatives := newForestAlternativeIndex(4)
-	alternatives.nodes[guard] = &gssForestNode{state: 10}
-	alternatives.nodes[call] = &gssForestNode{state: 20}
+	alternatives.setNode(guard, &gssForestNode{state: 10})
+	alternatives.setNode(call, &gssForestNode{state: 20})
 	resolveForestChildAlternatives(parser, arena, root, alternatives, nil, 0)
 	if got := root.children[0]; got != guard {
 		t.Fatalf("resolved child = %v, want visible guard_clause wrapper preserved", got)
@@ -518,7 +518,7 @@ func TestForestRootPreservesVisibleContainerAlternativeOverHiddenRepeatSlice(t *
 	container := newParentNodeInArena(arena, containerSym, true, []*Node{containerHeader, containerA, containerB}, nil, 0)
 
 	alternatives := newForestAlternativeIndex(4)
-	alternatives.nodes[container] = &gssForestNode{state: 10}
+	alternatives.setNode(container, &gssForestNode{state: 10})
 	if !forestPreserveRootVisibleContainerAlternatives(parser, arena, root, alternatives) {
 		t.Fatal("forestPreserveRootVisibleContainerAlternatives = false, want true")
 	}


### PR DESCRIPTION
Summary

- Keep up to 16 forest node and slot alternatives inline.
- Promote once to the existing source-sized maps when the inline tier fills.
- Add recurring lifecycle benchmarks for tiny and custom-token-source parses.

Performance

- Tiny C#: 65.4% faster, 94.4% fewer bytes, 40.0% fewer allocations.
- Tiny CSS: 77.5% faster, 95.1% fewer bytes, 49.0% fewer allocations.
- Default-size C#, Bash, CSS, and JavaScript family: neutral wall time; +0.07% geomean B/op.
- Large C#, Java DFA, and standard Go full/incremental controls: statistically neutral.

Validation

- Focused forest, raw-shape, and visible-container tests pass.
- C# and CSS Docker corpus runs match the base revision counts with no OOM.
- Independent structural and code review found no runtime blocker.