### PR TITLE
perf(parser): reduce recurring parse overhead

### DIFF
--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1592,8 +1592,8 @@ func (p *Parser) forestEOFRecoveryCouldCompete(idx *gssForestIndex, arena *nodeA
 		p.crecoveryHandleErrorSingleStack = true
 		defer func() { p.crecoveryHandleErrorSingleStack = prevSingleStack }()
 	}
-	for i := range idx.entries {
-		node := idx.entries[i].node
+	for i := 0; i < idx.len(); i++ {
+		node := idx.nodeAt(i)
 		if node == nil || node.byteOffset != eofByte {
 			continue
 		}
@@ -1997,12 +1997,12 @@ func replaceRawShapeChildEntry(arena *nodeArena, parent, oldChild, newChild *Nod
 // grammar's expected root symbol — retagged to errorSymbol when a fragment
 // carries an error (production's synthetic-root rule). Recovery-only.
 func (p *Parser) collectForestErrorRoot(idx *gssForestIndex, arena *nodeArena) *Node {
-	if idx == nil || len(idx.entries) == 0 {
+	if idx == nil || idx.len() == 0 {
 		return nil
 	}
 	var best *gssForestNode
-	for i := range idx.entries {
-		n := idx.entries[i].node
+	for i := 0; i < idx.len(); i++ {
+		n := idx.nodeAt(i)
 		if n == nil {
 			continue
 		}
@@ -2293,18 +2293,26 @@ type gssForestEntry struct {
 }
 
 type gssForestIndex struct {
-	entries   []gssForestEntry
+	inline    [16]gssForestEntry
+	spill     []gssForestEntry
+	inlineLen uint8
 	lastKey   gssForestKey
 	lastNode  *gssForestNode
 	lastValid bool
 }
 
-func newGSSForestIndex(capacity int) gssForestIndex {
-	return gssForestIndex{entries: make([]gssForestEntry, 0, capacity)}
+func (idx *gssForestIndex) init(capacity int) {
+	if capacity > len(idx.inline) {
+		idx.spill = make([]gssForestEntry, 0, capacity)
+	}
 }
 
 func (idx *gssForestIndex) reset() {
-	idx.entries = idx.entries[:0]
+	if idx.spill != nil {
+		idx.spill = idx.spill[:0]
+	} else {
+		idx.inlineLen = 0
+	}
 	idx.lastValid = false
 	idx.lastNode = nil
 }
@@ -2313,29 +2321,56 @@ func (idx *gssForestIndex) len() int {
 	if idx == nil {
 		return 0
 	}
-	return len(idx.entries)
+	if idx.spill != nil {
+		return len(idx.spill)
+	}
+	return int(idx.inlineLen)
 }
 
 func (idx *gssForestIndex) lookup(key gssForestKey) *gssForestNode {
 	if idx.lastValid && idx.lastKey == key {
 		return idx.lastNode
 	}
-	for i := range idx.entries {
-		if idx.entries[i].key == key {
+	entries := idx.spill
+	if entries == nil {
+		entries = idx.inline[:idx.inlineLen]
+	}
+	for i := range entries {
+		if entries[i].key == key {
 			idx.lastKey = key
-			idx.lastNode = idx.entries[i].node
+			idx.lastNode = entries[i].node
 			idx.lastValid = true
-			return idx.entries[i].node
+			return entries[i].node
 		}
 	}
 	return nil
 }
 
 func (idx *gssForestIndex) set(key gssForestKey, node *gssForestNode) {
-	idx.entries = append(idx.entries, gssForestEntry{key: key, node: node})
+	entry := gssForestEntry{key: key, node: node}
+	if idx.spill != nil {
+		idx.spill = append(idx.spill, entry)
+	} else if int(idx.inlineLen) < len(idx.inline) {
+		idx.inline[idx.inlineLen] = entry
+		idx.inlineLen++
+	} else {
+		idx.spill = make([]gssForestEntry, len(idx.inline), len(idx.inline)*2)
+		copy(idx.spill, idx.inline[:])
+		idx.spill = append(idx.spill, entry)
+	}
 	idx.lastKey = key
 	idx.lastNode = node
 	idx.lastValid = true
+}
+
+func (idx *gssForestIndex) nodeAt(i int) *gssForestNode {
+	if idx == nil || i < 0 || i >= idx.len() {
+		return nil
+	}
+	if idx.spill != nil {
+		return idx.spill[i].node
+	}
+	return idx.inline[i].node
 }
 
 const (
@@ -2531,8 +2566,11 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 	// Drive the production token source so keyword promotion, lex-mode
 	// selection, immediate tokens, external scanners and GLR-lexing all match
 	// the production parser. State is set per step from the frontier.
-	lexer := NewLexer(lang.LexStates, source)
-	ts := acquireDFATokenSourceWithCRecovery(lexer, lang, p.lookupActionIndexFunc(), p.hasKeywordState, p.externalValidByState, p.externalValidMaskByState, p.errorCostCompetitionEnabled())
+	ts := p.acquireParserDFATokenSource(source)
+	if ts == nil {
+		return nil, false
+	}
+	defer ts.Close()
 	ts.setExternalScannerCheckpointsEnabled(captureExternalCheckpoints)
 
 	// tree-sitter convention: state 0 is the error state, state 1 is the start.
@@ -2582,8 +2620,9 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 
 	// Per-step scratch reused across every token (cleared, not reallocated): the
 	// allocation/GC of fresh maps+slices each step dominated the profile.
-	curIndex := newGSSForestIndex(16)
-	nextIndex := newGSSForestIndex(16)
+	var curIndex, nextIndex gssForestIndex
+	curIndex.init(16)
+	nextIndex.init(16)
 	var work, nextFrontier, relex []*gssForestNode
 	alternatives := newForestAlternativeIndex(forestAlternativeIndexCapacityForSource(len(source)))
 	processEpoch := int32(0)
@@ -3179,8 +3218,8 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 			// reductions produced — but DROP states that themselves only emit a
 			// no-lookahead reduce, which would re-emit the synthetic EOF and loop.
 			relex = relex[:0]
-			for i := range curIndex.entries {
-				n := curIndex.entries[i].node
+			for i := 0; i < curIndex.len(); i++ {
+				n := curIndex.nodeAt(i)
 				if ts.lexStateForState(n.state) != noLookaheadLexState {
 					relex = append(relex, n)
 				}
@@ -3199,9 +3238,9 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 		}
 		noLookaheadSteps = 0
 		if len(nextFrontier) == 0 {
-			curStates := make([]StateID, 0, len(curIndex.entries))
-			for i := range curIndex.entries {
-				curStates = append(curStates, curIndex.entries[i].node.state)
+			curStates := make([]StateID, 0, curIndex.len())
+			for i := 0; i < curIndex.len(); i++ {
+				curStates = append(curStates, curIndex.nodeAt(i).state)
 			}
 			// No frontier node could shift this token: the production parser would
 			// recover here. EXPERIMENTAL: absorb the token into an error region and

--- a/glr_forest_test.go
+++ b/glr_forest_test.go
@@ -328,7 +328,8 @@ func TestReduceOverForestLinearPrefixForkedWithExtra(t *testing.T) {
 // TestCoalesceForestSharesNode proves coalesceForest dedups by (state,byteOffset)
 // into one node with multiple links — the O(1), no-deep-compare mechanism.
 func TestCoalesceForestSharesNode(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	base := &gssForestNode{state: 0}
 	// Two distinct parses reach (state=5, byteOffset=42).
@@ -356,8 +357,40 @@ func TestCoalesceForestSharesNode(t *testing.T) {
 	}
 }
 
+func TestGSSForestIndexUsesInlineTierAndPreservesEntriesOnSpill(t *testing.T) {
+	var idx gssForestIndex
+	idx.init(len(idx.inline))
+	if idx.spill != nil {
+		t.Fatal("small index allocated spill storage during initialization")
+	}
+	for i := range idx.inline {
+		key := gssForestKey{state: StateID(i + 1), byteOffset: uint32(i)}
+		idx.set(key, &gssForestNode{state: key.state, byteOffset: key.byteOffset})
+	}
+	if got := idx.len(); got != len(idx.inline) {
+		t.Fatalf("inline index length = %d, want %d", got, len(idx.inline))
+	}
+
+	spillKey := gssForestKey{state: 99, byteOffset: 99}
+	spillNode := &gssForestNode{state: spillKey.state, byteOffset: spillKey.byteOffset}
+	idx.set(spillKey, spillNode)
+	if idx.spill == nil {
+		t.Fatal("index did not spill after exhausting inline storage")
+	}
+	for i := range idx.inline {
+		key := gssForestKey{state: StateID(i + 1), byteOffset: uint32(i)}
+		if got := idx.lookup(key); got == nil || got.state != key.state || got.byteOffset != key.byteOffset {
+			t.Fatalf("lookup after spill for %+v = %+v", key, got)
+		}
+	}
+	if got := idx.lookup(spillKey); got != spillNode {
+		t.Fatalf("spill lookup = %p, want %p", got, spillNode)
+	}
+}
+
 func TestCoalesceForestRefreshesMinLinkScoreOnReplacement(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	base := &gssForestNode{state: 0}
 	loser := newStackEntryNode(100, &Node{symbol: 100, startByte: 1, endByte: 4})
@@ -384,7 +417,8 @@ func TestCoalesceForestRefreshesMinLinkScoreOnReplacement(t *testing.T) {
 }
 
 func TestCoalesceForestKeepsEqualScoreRawDistinctLinks(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()
@@ -412,7 +446,8 @@ func TestCoalesceForestKeepsEqualScoreRawDistinctLinks(t *testing.T) {
 }
 
 func TestCoalesceForestKeepsEqualScoreOneSidedRawUnknownLinks(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()
@@ -436,7 +471,8 @@ func TestCoalesceForestKeepsEqualScoreOneSidedRawUnknownLinks(t *testing.T) {
 }
 
 func TestCoalesceForestCapPreservesRawDistinctCandidateOverDuplicateBucket(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()
@@ -485,7 +521,8 @@ func TestCoalesceForestCapPreservesRawDistinctCandidateOverDuplicateBucket(t *te
 }
 
 func TestForestCoalesceWouldDropForCapDefersUntilRawShapeExists(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	node := &gssForestNode{
 		state:        5,
 		byteOffset:   4,
@@ -508,7 +545,8 @@ func TestForestCoalesceWouldDropForCapDefersUntilRawShapeExists(t *testing.T) {
 }
 
 func TestCoalesceForestCapDoesNotLetLowerRankSameRawBucketEvictDistinctBucket(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()
@@ -556,7 +594,8 @@ func TestCollectForestErrorRootUsesResultLinkErrorCost(t *testing.T) {
 			{prev: start, subtree: newStackEntryNode(101, lowScoreLowError), score: 1, errorCost: 2},
 		},
 	}
-	idx := newGSSForestIndex(1)
+	var idx gssForestIndex
+	idx.init(1)
 	idx.set(gssForestKey{state: partial.state, byteOffset: partial.byteOffset}, partial)
 
 	parser := &Parser{rootSymbol: 1}
@@ -636,7 +675,8 @@ func TestForestResultLinkUsesCumulativeDynamicPrecedenceBeforeMaterializedShape(
 }
 
 func TestCoalesceForestMarksDirtyWhenPredecessorChanges(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	slab := &gssForestNodeSlab{}
 	prev := &gssForestNode{state: 1, dirty: 1}
 	entry := newStackEntryNode(2, &Node{symbol: 7, startByte: 10, endByte: 20})
@@ -659,7 +699,8 @@ func TestCoalesceForestMarksDirtyWhenPredecessorChanges(t *testing.T) {
 }
 
 func TestGSSForestIndexLookupCacheClearsOnReset(t *testing.T) {
-	idx := newGSSForestIndex(0)
+	var idx gssForestIndex
+	idx.init(0)
 	key := gssForestKey{state: 7, byteOffset: 11}
 	node := &gssForestNode{state: 7, byteOffset: 11}
 

--- a/parser.go
+++ b/parser.go
@@ -254,6 +254,7 @@ type Parser struct {
 	reduceChainHintByState       []int
 	reduceAliasSeq               [][]Symbol
 	aliasTargetSymbol            []bool
+	visibleAliasTargetSymbol     []bool
 	keepSameNamedAnonChildSymbol []bool
 	sharedAnonymousTokenSymbol   []bool
 	reduceHasFields              []bool
@@ -1352,6 +1353,7 @@ func NewParser(lang *Language) *Parser {
 		p.reduceChainHintByState = buildReduceChainHintIndex(p.reduceChainHints)
 		p.reduceAliasSeq = buildReduceAliasSequences(lang)
 		p.aliasTargetSymbol = buildAliasTargetSymbols(lang)
+		p.visibleAliasTargetSymbol = buildVisibleAliasTargetSymbols(lang)
 		p.keepSameNamedAnonChildSymbol = buildKeepSameNamedAnonChildSymbols(lang)
 		p.sharedAnonymousTokenSymbol = buildSharedAnonymousTokenSymbols(lang)
 		p.reduceHasFields = buildReduceFieldPresence(lang)
@@ -4492,7 +4494,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		return finalizeRecoveredNodes(nodes), true
 	}
 
-	stacks, maxStacksSeen = p.newInitialParseStacks(scratch, reuse, timing)
+	stacks, maxStacksSeen = p.newInitialParseStacks(scratch, reuse, timing, len(source))
 	caps := p.configureParseCaps(source, reuse, arenaClass, scratch, maxStacksOverride, maxNodesOverride, maxMergePerKeyOverride)
 	maxStacks := caps.maxStacks
 	retryPass := caps.retryPass
@@ -6173,10 +6175,10 @@ func (p *Parser) ensureFullParseInitialCapacity(source []byte, arena *nodeArena,
 	scratch.entries.ensureInitialCap(parseFullEntryScratchCapacity(len(source)))
 }
 
-func (p *Parser) newInitialParseStacks(scratch *parserScratch, reuse *reuseCursor, timing *incrementalParseTiming) ([]glrStack, int) {
+func (p *Parser) newInitialParseStacks(scratch *parserScratch, reuse *reuseCursor, timing *incrementalParseTiming, sourceLen int) ([]glrStack, int) {
 	var stacksBuf [4]glrStack
 	stacks := stacksBuf[:1]
-	initialStackCap := 64 * 1024
+	initialStackCap := parseFullEntryScratchCapacity(sourceLen)
 	if reuse != nil {
 		initialStackCap = defaultStackEntrySlabCap
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -248,6 +248,21 @@ func buildAliasTargetSymbols(lang *Language) []bool {
 	return out
 }
 
+func buildVisibleAliasTargetSymbols(lang *Language) []bool {
+	if lang == nil || len(lang.AliasSequences) == 0 {
+		return nil
+	}
+	out := make([]bool, len(lang.SymbolNames))
+	for _, seq := range lang.AliasSequences {
+		for _, sym := range seq {
+			if int(sym) < len(out) && symbolIsVisible(lang, sym) {
+				out[sym] = true
+			}
+		}
+	}
+	return out
+}
+
 func buildReduceFieldPresence(lang *Language) []bool {
 	if lang == nil || len(lang.FieldMapSlices) == 0 {
 		return nil

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -54,7 +54,7 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCo
 	}
 	normalizeRootTrailingExtraTriviaCompatibility(root, source, lang)
 	var terminalReason ParseStopReason
-	_, terminalReason, result.errorSummary = normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, ctx.stopCheck)
+	_, terminalReason, result.errorSummary = normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, p.visibleAliasTargetSymbol, ctx.stopCheck)
 	if parseStopReasonIsActive(terminalReason) {
 		result.stopReason = terminalReason
 		return result

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -7,6 +7,10 @@ package gotreesitter
 // visible anonymous terminal child and no semantic decorations should keep
 // the parent's symbol/flags and adopt the child's token span.
 func normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason, resultErrorSummary) {
+	return normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), stopCheck)
+}
+
+func normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root *Node, lang *Language, aliasTargets []bool, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason, resultErrorSummary) {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {
 		return counters, ParseStopNone, resultErrorSummaryUnknown
@@ -25,7 +29,6 @@ func normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root *Node, lang *L
 		}
 		return counters, reason, errorSummary
 	}
-	aliasTargets := resultVisibleAliasTargetSet(lang)
 	var stopReason ParseStopReason
 	walkResultTreeUntil(root, func(n *Node) bool {
 		if reason := poller.poll(); parseStopReasonIsActive(reason) {
@@ -123,21 +126,6 @@ func resultSymbolIsVisibleAliasTarget(lang *Language, sym Symbol, aliasTargets [
 		return false
 	}
 	return aliasTargets[sym]
-}
-
-func resultVisibleAliasTargetSet(lang *Language) []bool {
-	if lang == nil || len(lang.AliasSequences) == 0 {
-		return nil
-	}
-	aliasTargets := make([]bool, len(lang.SymbolNames))
-	for _, seq := range lang.AliasSequences {
-		for _, alias := range seq {
-			if int(alias) < len(aliasTargets) && symbolIsVisible(lang, alias) {
-				aliasTargets[alias] = true
-			}
-		}
-	}
-	return aliasTargets
 }
 
 // resultSymbolNamesEqual mirrors Parser.sameSymbolName for callers (like this

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -278,6 +278,36 @@ func TestNormalizeResultTerminalLeafNodesCollapsesTerminalAliasTarget(t *testing
 	}
 }
 
+func TestVisibleAliasTargetsExcludeHiddenAliases(t *testing.T) {
+	lang := &Language{
+		TokenCount:  2,
+		SymbolNames: []string{"EOF", "]", "root", "]"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "]", Visible: true},
+			{Name: "root", Visible: true, Named: true},
+			{Name: "]", Visible: false},
+		},
+		AliasSequences: [][]Symbol{{3}},
+	}
+	parser := NewParser(lang)
+	if !parser.aliasTargetSymbol[3] {
+		t.Fatal("general alias-target cache omitted hidden alias")
+	}
+	if parser.visibleAliasTargetSymbol[3] {
+		t.Fatal("visible alias-target cache included hidden alias")
+	}
+
+	arena := newNodeArena(arenaClassFull)
+	child := newLeafNodeInArena(arena, 1, false, 0, 1, Point{}, Point{Column: 1})
+	hiddenAlias := newParentNodeInArena(arena, 3, false, []*Node{child}, nil, 0)
+	root := newParentNodeInArena(arena, 2, true, []*Node{hiddenAlias}, nil, 0)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, parser.visibleAliasTargetSymbol, nil)
+	if counters.nodesRewritten != 0 || hiddenAlias.ChildCount() != 1 {
+		t.Fatalf("hidden alias was normalized as visible: rewritten=%d children=%d", counters.nodesRewritten, hiddenAlias.ChildCount())
+	}
+}
+
 // TestNormalizeResultTerminalLeafNodesPreservesDistinctChildUnderReusedAliasTargetID
 // mirrors norg's "_word" alias: a symbol ID can simultaneously be a genuine
 // visible terminal (ID within TokenCount) AND a visible alias target

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -48,6 +48,54 @@ func TestGLREntryScratchResetClearsReservedWrittenRange(t *testing.T) {
 	}
 }
 
+func TestInitialParseStackReservationMatchesCurrentFullParseSize(t *testing.T) {
+	var scratch parserScratch
+	scratch.entries.ensureInitialCap(64 * 1024)
+	parser := &Parser{language: &Language{InitialState: 1}}
+
+	tinySourceLen := len("{}")
+	stacks, _ := parser.newInitialParseStacks(&scratch, nil, nil, tinySourceLen)
+	wantTiny := parseFullEntryScratchCapacity(tinySourceLen)
+	if got := cap(stacks[0].entries); got != wantTiny {
+		t.Fatalf("tiny full-parse reservation = %d, want %d", got, wantTiny)
+	}
+	if got := scratch.entries.peakEntriesUsed(); got != wantTiny {
+		t.Fatalf("tiny full-parse reserved range = %d, want %d", got, wantTiny)
+	}
+
+	scratch.entries.reset()
+	largeSourceLen := 2 * 1024 * 1024
+	stacks, _ = parser.newInitialParseStacks(&scratch, nil, nil, largeSourceLen)
+	wantLarge := parseFullEntryScratchCapacity(largeSourceLen)
+	if got := cap(stacks[0].entries); got != wantLarge {
+		t.Fatalf("large full-parse reservation = %d, want %d", got, wantLarge)
+	}
+
+	scratch.entries.reset()
+	reuse := &reuseCursor{}
+	stacks, _ = parser.newInitialParseStacks(&scratch, reuse, nil, largeSourceLen)
+	if got := cap(stacks[0].entries); got != defaultStackEntrySlabCap {
+		t.Fatalf("incremental reservation = %d, want %d", got, defaultStackEntrySlabCap)
+	}
+}
+
+func BenchmarkInitialParseStackReservationAfterLarge(b *testing.B) {
+	var scratch parserScratch
+	scratch.entries.ensureInitialCap(64 * 1024)
+	parser := &Parser{language: &Language{InitialState: 1}}
+	tinySourceLen := len("{}")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stacks, _ := parser.newInitialParseStacks(&scratch, nil, nil, tinySourceLen)
+		if len(stacks) != 1 {
+			b.Fatalf("initial stack count = %d, want 1", len(stacks))
+		}
+		scratch.entries.reset()
+	}
+}
+
 func TestGSSScratchResetClearsWrittenRange(t *testing.T) {
 	var scratch gssScratch
 	node := &Node{symbol: 1}

--- a/parser_shift_gap_test.go
+++ b/parser_shift_gap_test.go
@@ -197,7 +197,8 @@ func TestForestRecoveryGapRejectsNonTriviaSource(t *testing.T) {
 		EndByte:   uint32(len(source)),
 	}
 
-	nextIndex := newGSSForestIndex(0)
+	var nextIndex gssForestIndex
+	nextIndex.init(0)
 	var nextFrontier []*gssForestNode
 	parser := &Parser{glrTrace: false}
 	if parser.guardForestRealShiftGap(source, node, tok) {


### PR DESCRIPTION
## Summary

- reuse and close the parser DFA token source in forest parsing
- keep small forest indexes inline and spill only when necessary
- cache visible alias targets and right-size initial entry scratch for each parse

## Results

- recurring C#: 28.78 µs to 18.85 µs; 8,160 B/op to 1,520 B/op
- recurring CSS: 14.29 µs to 9.30 µs; 7,048 B/op to 1,256 B/op
- selected six-language family: 3.18% lower time and 6.81% lower bytes (geomean)
- primary Go benchmark trio remains neutral, with full-parse bytes down 18.68%

## Validation

- focused forest-index, alias, scratch-reset, and recovery tests
- isolated C# and CSS parity suites
- isolated CMake forest incremental lifecycle test
- no OOMs in isolated runs