### PR TITLE
perf(parser): pin retry policies to grammar identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- Large D and Groovy accepted-error parses now retain their certified initial
+  stack ceilings through exact-blob runtime profiles, and C# skips its
+  redundant first same-stack merge retry through the same fail-closed profile
+  mechanism. Caller-adapted grammars, incremental fallbacks, and explicit
+  diagnostic overrides retain the conservative retry ladder.
+
 ## [0.29.0] - 2026-07-12
 
 Recurring-parser performance and compatibility-cleanup release. Repeated small

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -48,9 +48,10 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		blobSHA256:                    mustRuntimeProfileSHA256("7ad425e89733339dde94e3c03b762ae478fb453b530493f5d62e1ae7537e1784"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
-			SkipCompleteAcceptedErrorRetry:   true,
-			SkipCompleteMaxEntryScratchPeak:  csharpAcceptedErrorRetryMaxEntryScratchPeak,
-			FreshErrorNoStacksRetryMaxStacks: csharpFreshErrorNoStacksRetryMaxStacks,
+			SkipCompleteAcceptedErrorRetry:             true,
+			SkipCompleteMaxEntryScratchPeak:            csharpAcceptedErrorRetryMaxEntryScratchPeak,
+			FreshErrorNoStacksRetryMaxStacks:           csharpFreshErrorNoStacksRetryMaxStacks,
+			SkipInitialCompleteAcceptedErrorMergeRetry: true,
 		},
 	},
 	// Haxe's accepted-error retry ladder selects the same tree on every pass.
@@ -170,6 +171,25 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			MinSourceBytes:      64 * 1024,
 			InitialStackCeiling: 14,
+		},
+	},
+	// Large Groovy and D accepted-error parses stay inside their certified
+	// initial stack ceilings. Widening does not improve the selected tree and
+	// reintroduces their real-corpus time/RSS cliffs. The generic profile gate
+	// keeps incremental fallbacks and explicit diagnostic overrides
+	// conservative.
+	"groovy": {
+		blobSHA256: mustRuntimeProfileSHA256("a1d1bb30d9971f1c3d645aab456521943a5f0da419b57a0986fc9b2a502a90d9"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			MinSourceBytes:      64 * 1024,
+			InitialStackCeiling: 2,
+		},
+	},
+	"d": {
+		blobSHA256: mustRuntimeProfileSHA256("1e2bf6c9d37193dad050a3e2f35d450973245dbee60550ef6cc24fca2b0e0016"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			MinSourceBytes:      64 * 1024,
+			InitialStackCeiling: 3,
 		},
 	},
 	// NOTE on dot: no certified row here (unlike gomod/dart/c below) — dot's

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -34,12 +34,14 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	// 19 = the prior 17 plus gomod and c: their hardcoded compat-tier
+	// 21 = the prior 19 plus D and Groovy: their retry ceilings moved out of
+	// parser-core name switches and onto exact-blob profiles. The prior gomod
+	// and C additions moved hardcoded compat-tier
 	// repetition-conflict helpers were retired in favor of certified
 	// ConflictPolicies rows here. dot's helper was
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry.
-	if got, want := len(builtinLanguageRuntimeProfiles), 19; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 21; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -268,7 +270,8 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want first-growth entry-scratch ceiling", profile)
 			}
 			if tt.name == "c_sharp" && (profile.SkipCompleteMaxEntryScratchPeak != csharpAcceptedErrorRetryMaxEntryScratchPeak ||
-				profile.FreshErrorNoStacksRetryMaxStacks != csharpFreshErrorNoStacksRetryMaxStacks) {
+				profile.FreshErrorNoStacksRetryMaxStacks != csharpFreshErrorNoStacksRetryMaxStacks ||
+				!profile.SkipInitialCompleteAcceptedErrorMergeRetry) {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want bounded C# retry profile", profile)
 			}
 			if tt.name == "tcl" && profile.FreshErrorNoStacksMaxPasses != 1 {
@@ -304,6 +307,23 @@ func TestBuiltinBoundedAcceptedErrorRetryProfilesAttach(t *testing.T) {
 				InitialStackCeiling: 14,
 			},
 			wantNoScanner: true,
+		},
+		{
+			name: "groovy",
+			load: GroovyLanguage,
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{
+				MinSourceBytes:      64 * 1024,
+				InitialStackCeiling: 2,
+			},
+			wantNoScanner: true,
+		},
+		{
+			name: "d",
+			load: DLanguage,
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{
+				MinSourceBytes:      64 * 1024,
+				InitialStackCeiling: 3,
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -363,9 +383,10 @@ func TestBuiltinCSharpRetryProfileRequiresCertifiedBlob(t *testing.T) {
 		t.Fatalf("certified C# scanner retry policy = %d, want skip-repeat", got)
 	}
 	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
-		SkipCompleteAcceptedErrorRetry:   true,
-		SkipCompleteMaxEntryScratchPeak:  csharpAcceptedErrorRetryMaxEntryScratchPeak,
-		FreshErrorNoStacksRetryMaxStacks: csharpFreshErrorNoStacksRetryMaxStacks,
+		SkipCompleteAcceptedErrorRetry:             true,
+		SkipCompleteMaxEntryScratchPeak:            csharpAcceptedErrorRetryMaxEntryScratchPeak,
+		FreshErrorNoStacksRetryMaxStacks:           csharpFreshErrorNoStacksRetryMaxStacks,
+		SkipInitialCompleteAcceptedErrorMergeRetry: true,
 	}
 	if got := lang.FullParseAcceptedErrorRetryProfile; got != want {
 		t.Fatalf("certified C# retry profile = %+v, want %+v", got, want)
@@ -379,6 +400,8 @@ func TestBuiltinBoundedAcceptedErrorRetryProfilesRequireCertifiedBlob(t *testing
 	}{
 		{name: "asm", want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 11 * 1024, InitialStackCeiling: 8}},
 		{name: "java", want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 64 * 1024, InitialStackCeiling: 14}},
+		{name: "groovy", want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 64 * 1024, InitialStackCeiling: 2}},
+		{name: "d", want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 64 * 1024, InitialStackCeiling: 3}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -399,6 +422,60 @@ func TestBuiltinBoundedAcceptedErrorRetryProfilesRequireCertifiedBlob(t *testing
 			}
 			if got := lang.FullParseAcceptedErrorRetryProfile; got != tt.want {
 				t.Fatalf("certified %s retry profile = %+v, want %+v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResidualRetryProfilesRequireExactBlobIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		want gotreesitter.FullParseAcceptedErrorRetryProfile
+	}{
+		{
+			name: "groovy",
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 64 * 1024, InitialStackCeiling: 2},
+		},
+		{
+			name: "d",
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{MinSourceBytes: 64 * 1024, InitialStackCeiling: 3},
+		},
+		{
+			name: "c_sharp",
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{
+				SkipCompleteAcceptedErrorRetry:             true,
+				SkipCompleteMaxEntryScratchPeak:            csharpAcceptedErrorRetryMaxEntryScratchPeak,
+				FreshErrorNoStacksRetryMaxStacks:           csharpFreshErrorNoStacksRetryMaxStacks,
+				SkipInitialCompleteAcceptedErrorMergeRetry: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrongSHA := &gotreesitter.Language{Name: tt.name}
+			if attachBuiltinLanguageRuntimeProfile(tt.name, sha256.Sum256([]byte("uncertified")), wrongSHA) {
+				t.Fatal("wrong blob SHA reported a runtime-profile attachment")
+			}
+			if got := wrongSHA.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+				t.Fatalf("wrong blob SHA attached retry profile %+v", got)
+			}
+
+			adapted := &gotreesitter.Language{Name: tt.name}
+			AttachLanguageSupport(tt.name, adapted)
+			if got := adapted.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+				t.Fatalf("adapted same-name language attached retry profile %+v", got)
+			}
+
+			blob := BlobByName(tt.name)
+			if len(blob) == 0 {
+				t.Fatal("BlobByName returned no data")
+			}
+			exact := &gotreesitter.Language{Name: tt.name}
+			if !attachBuiltinLanguageRuntimeProfile(tt.name, sha256.Sum256(blob), exact) {
+				t.Fatal("exact blob did not attach its runtime profile")
+			}
+			if got := exact.FullParseAcceptedErrorRetryProfile; got != tt.want {
+				t.Fatalf("exact blob retry profile = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/language.go
+++ b/language.go
@@ -311,6 +311,11 @@ type FullParseAcceptedErrorRetryProfile struct {
 	// target for a fresh error-bearing no-stacks parse. Zero keeps the generic
 	// target. Incremental fallbacks and explicit environment overrides ignore it.
 	FreshErrorNoStacksRetryMaxStacks uint16
+	// SkipInitialCompleteAcceptedErrorMergeRetry skips only the first
+	// same-stack merge retry for a fresh, complete accepted-error parse. Later
+	// widened-stack and merge retries remain available. Incremental fallbacks
+	// and explicit stack/merge environment overrides ignore it.
+	SkipInitialCompleteAcceptedErrorMergeRetry bool
 }
 
 // Language holds all data needed to parse a specific language.

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -471,7 +471,12 @@ func TestFullParseRetrySecondaryNodeLimitOverride(t *testing.T) {
 }
 
 func TestShouldRunInitialFullParseMergeRetry(t *testing.T) {
-	if shouldRunInitialFullParseMergeRetry(nil) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	if shouldRunInitialFullParseMergeRetry(nil, 0, fullParseRetryOriginFresh) {
 		t.Fatal("shouldRunInitialFullParseMergeRetry(nil) = true, want false")
 	}
 	tree := &Tree{
@@ -479,11 +484,11 @@ func TestShouldRunInitialFullParseMergeRetry(t *testing.T) {
 			StopReason: ParseStopNodeLimit,
 		},
 	}
-	if shouldRunInitialFullParseMergeRetry(tree) {
+	if shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginFresh) {
 		t.Fatal("shouldRunInitialFullParseMergeRetry(node_limit) = true, want false")
 	}
 	tree.parseRuntime.StopReason = ParseStopNoStacksAlive
-	if !shouldRunInitialFullParseMergeRetry(tree) {
+	if !shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginFresh) {
 		t.Fatal("shouldRunInitialFullParseMergeRetry(no_stacks_alive) = false, want true")
 	}
 	tree = &Tree{
@@ -499,12 +504,76 @@ func TestShouldRunInitialFullParseMergeRetry(t *testing.T) {
 			MaxStacksSeen:   64,
 		},
 	}
-	if shouldRunInitialFullParseMergeRetry(tree) {
-		t.Fatal("shouldRunInitialFullParseMergeRetry(c_sharp accepted error) = true, want false")
+	if !shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginFresh) {
+		t.Fatal("uncertified same-name C# tree skipped the initial merge retry")
+	}
+	tree.language.FullParseAcceptedErrorRetryProfile.SkipInitialCompleteAcceptedErrorMergeRetry = true
+	if shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginFresh) {
+		t.Fatal("certified complete accepted-error tree scheduled the initial merge retry")
+	}
+	if !shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginIncremental) {
+		t.Fatal("certified incremental fallback skipped the conservative initial merge retry")
 	}
 	tree.parseRuntime.Truncated = true
-	if !shouldRunInitialFullParseMergeRetry(tree) {
-		t.Fatal("shouldRunInitialFullParseMergeRetry(c_sharp truncated accepted error) = false, want true")
+	if !shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginFresh) {
+		t.Fatal("certified truncated accepted-error tree skipped the initial merge retry")
+	}
+}
+
+func TestCertifiedInitialMergeRetrySkipHonorsExplicitOverrides(t *testing.T) {
+	for _, env := range []string{"GOT_GLR_MAX_STACKS", "GOT_GLR_MAX_MERGE_PER_KEY"} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv("GOT_GLR_MAX_STACKS", "")
+			t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+			t.Setenv(env, "8")
+			ResetParseEnvConfigCacheForTests()
+			defer ResetParseEnvConfigCacheForTests()
+
+			tree := certifiedAcceptedErrorRetryTestTree(false, 128)
+			tree.language.Name = "c_sharp"
+			tree.language.FullParseAcceptedErrorRetryProfile.SkipInitialCompleteAcceptedErrorMergeRetry = true
+			if !shouldRunInitialFullParseMergeRetry(tree, 128, fullParseRetryOriginFresh) {
+				t.Fatalf("certified policy ignored explicit %s", env)
+			}
+		})
+	}
+}
+
+func TestCertifiedInitialMergeRetrySkipKeepsWideningAndTreeSelection(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	const sourceLen = 128
+	source := make([]byte, sourceLen)
+	initial := certifiedAcceptedErrorRetryTestTree(false, sourceLen)
+	initial.language.Name = "c_sharp"
+	initial.language.FullParseAcceptedErrorRetryProfile.SkipInitialCompleteAcceptedErrorMergeRetry = true
+	initial.parseRuntime.MaxStacksSeen = 8
+
+	candidate := certifiedAcceptedErrorRetryTestTree(false, sourceLen)
+	candidate.language.Name = "c_sharp"
+	candidate.root.flags = 0
+	candidate.parseRuntime.NodesAllocated = 1
+
+	type retryCall struct {
+		stacks int
+		merge  int
+		nodes  int
+	}
+	var calls []retryCall
+	parser := &Parser{}
+	got := parser.retryFullParse(source, 8, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+		calls = append(calls, retryCall{stacks: maxStacks, merge: maxMergePerKeyOverride, nodes: maxNodes})
+		return candidate
+	})
+	if got != candidate {
+		t.Fatalf("retryFullParse returned %p, want widened clean tree %p", got, candidate)
+	}
+	want := []retryCall{{stacks: fullParseRetryMaxGLRStacks}}
+	if !slices.Equal(calls, want) {
+		t.Fatalf("retry calls = %+v, want widened pass %+v with no initial same-stack merge", calls, want)
 	}
 }
 
@@ -553,63 +622,42 @@ func TestCSharpAcceptedErrorTreeCanUseNamespaceRecovery(t *testing.T) {
 	}
 }
 
-func TestGroovyLargeAcceptedErrorRetryUsesInitialStackCeiling(t *testing.T) {
+func TestCertifiedLargeAcceptedErrorRetryUsesInitialStackCeiling(t *testing.T) {
 	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
 	ResetParseEnvConfigCacheForTests()
 	defer ResetParseEnvConfigCacheForTests()
 
-	const dExpressionsemWitnessBytes = 685384
+	const sourceLen = 96 * 1024
+	for _, tt := range []struct {
+		name string
+		cap  uint16
+	}{
+		{name: "groovy", cap: 2},
+		{name: "d", cap: 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := certifiedAcceptedErrorRetryTestTree(false, sourceLen)
+			tree.language.Name = tt.name
+			tree.language.FullParseAcceptedErrorRetryProfile = FullParseAcceptedErrorRetryProfile{
+				MinSourceBytes:      64 * 1024,
+				InitialStackCeiling: tt.cap,
+			}
+			if got := fullParseRetryMaxStacksOverrideForOrigin(tree, sourceLen, int(tt.cap), fullParseRetryOriginFresh); got != 0 {
+				t.Fatalf("certified fresh stack override = %d, want 0", got)
+			}
+			if got := fullParseRetryMaxStacksOverrideForOrigin(tree, sourceLen, int(tt.cap), fullParseRetryOriginIncremental); got != fullParseRetryMaxGLRStacks {
+				t.Fatalf("incremental stack override = %d, want %d", got, fullParseRetryMaxGLRStacks)
+			}
+			if got := fullParseRetryMaxStacksOverride(tree, 1024, int(tt.cap)); got != fullParseRetryMaxGLRStacks {
+				t.Fatalf("small-source stack override = %d, want %d", got, fullParseRetryMaxGLRStacks)
+			}
 
-	tree := &Tree{
-		language: &Language{Name: "groovy"},
-		root: &Node{
-			endByte: 102960,
-			flags:   nodeFlagHasError,
-		},
-		parseRuntime: ParseRuntime{
-			StopReason:      ParseStopAccepted,
-			ExpectedEOFByte: 102960,
-			RootEndByte:     102960,
-			MaxStacksSeen:   35,
-		},
-	}
-
-	if got := fullParseRetryMaxStacksOverride(tree, 102960, 2); got != 0 {
-		t.Fatalf("fullParseRetryMaxStacksOverride(large groovy) = %d, want 0", got)
-	}
-	if got := fullParseRetryMaxStacksOverride(tree, 1024, 2); got != fullParseRetryMaxGLRStacks {
-		t.Fatalf("fullParseRetryMaxStacksOverride(small groovy) = %d, want %d", got, fullParseRetryMaxGLRStacks)
-	}
-	tree.language = &Language{Name: "d"}
-	tree.root.endByte = dExpressionsemWitnessBytes
-	tree.parseRuntime.ExpectedEOFByte = dExpressionsemWitnessBytes
-	tree.parseRuntime.RootEndByte = dExpressionsemWitnessBytes
-	if got := fullParseRetryMaxStacksOverride(tree, dExpressionsemWitnessBytes, dLargeFileRetryStackCeiling); got != 0 {
-		t.Fatalf("fullParseRetryMaxStacksOverride(large d) = %d, want 0", got)
-	}
-	if got := fullParseRetryMaxStacksOverride(tree, dLargeFileRetryMinBytes-1, dLargeFileRetryStackCeiling); got != fullParseRetryMaxGLRStacks {
-		t.Fatalf("fullParseRetryMaxStacksOverride(small d) = %d, want %d", got, fullParseRetryMaxGLRStacks)
-	}
-	tree.language = &Language{Name: "typescript"}
-	if got := fullParseRetryMaxStacksOverride(tree, 102960, 2); got != fullParseRetryMaxGLRStacks {
-		t.Fatalf("fullParseRetryMaxStacksOverride(typescript) = %d, want %d", got, fullParseRetryMaxGLRStacks)
-	}
-}
-
-func TestDLargeRetryUsesInitialStackCeiling(t *testing.T) {
-	tree := &Tree{language: &Language{Name: "d"}}
-	if !fullParseRetryUsesInitialStackCeiling(tree, dLargeFileRetryMinBytes, dLargeFileRetryStackCeiling) {
-		t.Fatal("fullParseRetryUsesInitialStackCeiling(d large) = false, want true")
-	}
-	if fullParseRetryUsesInitialStackCeiling(tree, dLargeFileRetryMinBytes-1, dLargeFileRetryStackCeiling) {
-		t.Fatal("fullParseRetryUsesInitialStackCeiling(d below threshold) = true, want false")
-	}
-	if fullParseRetryUsesInitialStackCeiling(tree, dLargeFileRetryMinBytes, dLargeFileRetryStackCeiling+1) {
-		t.Fatal("fullParseRetryUsesInitialStackCeiling(d widened cap) = true, want false")
-	}
-	tree.language = &Language{Name: "typescript"}
-	if fullParseRetryUsesInitialStackCeiling(tree, dLargeFileRetryMinBytes, dLargeFileRetryStackCeiling) {
-		t.Fatal("fullParseRetryUsesInitialStackCeiling(typescript) = true, want false")
+			tree.language.FullParseAcceptedErrorRetryProfile = FullParseAcceptedErrorRetryProfile{}
+			if got := fullParseRetryMaxStacksOverride(tree, sourceLen, int(tt.cap)); got != fullParseRetryMaxGLRStacks {
+				t.Fatalf("uncertified same-name stack override = %d, want %d", got, fullParseRetryMaxGLRStacks)
+			}
+		})
 	}
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -23,12 +23,6 @@ const (
 	javaFullParseRetryMaxGLRStacks   = 64
 	javaFullParseRetryMaxMergePerKey = 16
 	javaTightMergeCapSourceLen       = 256 * 1024
-	// D's tuned default starts at cap 2, then fullParseInitialMaxStacks raises
-	// the effective parse cap to this conflict floor. Large D accepted-error
-	// retries must not widen beyond it, or expressionsem.d re-enters the
-	// survivor-population RSS cliff.
-	dLargeFileRetryStackCeiling = 3
-	dLargeFileRetryMinBytes     = 64 * 1024
 	// goAcceptedErrorMergePerKeyRetry widens Go's merge-per-key survivor
 	// budget only on the retry rung, when a fresh full parse at the
 	// steady-state cap (3, see the "go" case in effectiveParseMergePerKeyCap)
@@ -1178,27 +1172,8 @@ func fullParseRetryUsesInitialStackCeilingForOrigin(tree *Tree, sourceLen int, i
 	if tree == nil || tree.language == nil {
 		return false
 	}
-	if origin == fullParseRetryOriginFresh && certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree, sourceLen, initialMaxStacks) {
-		return true
-	}
-	switch tree.language.Name {
-	case "groovy":
-		// The large Groovy corpus cliff accepts at the tuned cap=2 but the
-		// widened retry spends the entire file budget and still returns an
-		// error-bearing tree. Treat the language-tuned cap as the ceiling for
-		// large files. Cap-2 merge retries remain available, and explicit env
-		// overrides are handled above as diagnostic ceilings. This contains the
-		// timeout/OOM class only; the exact witness remains a tracked C-shape gap.
-		return sourceLen >= 64*1024 && initialMaxStacks <= 2
-	case "d":
-		// D's expressionsem.d accepts under the tuned cap (raised to 3 by the
-		// grammar conflict floor) and stays below the prior Go-side RSS cliff.
-		// Widening accepted-error retry stacks reintroduces the survivor
-		// population blowup, so keep large D retries at the initial ceiling.
-		return sourceLen >= dLargeFileRetryMinBytes && initialMaxStacks <= dLargeFileRetryStackCeiling
-	default:
-		return false
-	}
+	return origin == fullParseRetryOriginFresh &&
+		certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree, sourceLen, initialMaxStacks)
 }
 
 func certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree *Tree, sourceLen int, initialMaxStacks int) bool {
@@ -1362,7 +1337,7 @@ func fullParseNoStacksAliveCleanEOFNeedsMergeRetry(tree *Tree, rt ParseRuntime) 
 		!retryTreeHasError(tree)
 }
 
-func shouldRunInitialFullParseMergeRetry(tree *Tree) bool {
+func shouldRunInitialFullParseMergeRetry(tree *Tree, sourceLen int, origin fullParseRetryOrigin) bool {
 	if tree == nil {
 		return false
 	}
@@ -1375,19 +1350,24 @@ func shouldRunInitialFullParseMergeRetry(tree *Tree) bool {
 	if rt.StopReason == ParseStopNodeLimit {
 		return false
 	}
-	if tree.language != nil && tree.language.Name == "c_sharp" &&
-		rt.StopReason == ParseStopAccepted &&
-		retryTreeHasError(tree) &&
-		!rt.Truncated &&
-		!rt.TokenSourceEOFEarly {
-		// Large C# namespace bodies that accept with an error under the narrow
-		// first-pass stack cap have repeatedly spent close to a second in this
-		// same-stack merge retry without clearing the error. The existing clean
-		// widened-stack retry is the next useful pass; keep later merge retries
-		// available if that widened pass still returns an error.
+	if certifiedAcceptedErrorRetrySkipsInitialMerge(tree, sourceLen, origin) {
 		return false
 	}
 	return true
+}
+
+func certifiedAcceptedErrorRetrySkipsInitialMerge(tree *Tree, sourceLen int, origin fullParseRetryOrigin) bool {
+	if tree == nil || tree.language == nil || sourceLen <= 0 || origin != fullParseRetryOriginFresh ||
+		!tree.language.FullParseAcceptedErrorRetryProfile.SkipInitialCompleteAcceptedErrorMergeRetry ||
+		parseMaxGLRStacksEnvConfigured() || parseMaxMergePerKeyEnvConfigured() {
+		return false
+	}
+	rt := tree.ParseRuntime()
+	return rt.StopReason == ParseStopAccepted &&
+		!rt.Truncated &&
+		!rt.TokenSourceEOFEarly &&
+		retryTreeHasError(tree) &&
+		retryTreeCoversExpectedEOF(tree)
 }
 
 func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree, runRetry fullParseRetryRunner) *Tree {
@@ -1548,7 +1528,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	}
 
 	bestTree := tree
-	if shouldRunInitialFullParseMergeRetry(tree) {
+	if shouldRunInitialFullParseMergeRetry(tree, len(source), origin) {
 		if initialMergePerKey := fullParseRetryMergePerKeyOverride(tree, len(source), initialMaxStacks); initialMergePerKey != 0 {
 			mergeRetryTree := runRetryAttempt(initialMaxStacks, initialMergePerKey, 0)
 			replaceBest(&bestTree, mergeRetryTree)


### PR DESCRIPTION
## Summary

- attach the bounded D and Groovy retry ceilings only to the exact checked-in grammar blobs
- express the C# first same-stack merge skip through the same certified runtime profile
- preserve conservative retry behavior for custom grammars, incremental fallbacks, and explicit diagnostic overrides
- add profile-identity and retry-scheduling coverage, plus an Unreleased changelog entry

## Validation

- focused root and `grammars` retry/profile tests
- Docker profile and scheduler gate (no OOM)
- D aggressive corpus candidate/baseline: identical 23/25 error-free and 22/25 structural/deep parity (no OOM)
- C# aggressive corpus candidate/baseline: identical 24/25 error-free and 20/25 structural/deep parity (no OOM)
- Groovy large-file witness: byte-identical candidate/baseline result record (no OOM)

The non-perfect D, C#, and Groovy rows are pre-existing corpus gaps; this change preserves their measured results while removing the remaining retry-policy name checks.