### PR TITLE
perf(parser): reduce recurring parse reset cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ for tags and release notes while still in `0.x`.
   mechanism. Caller-adapted grammars, incremental fallbacks, and explicit
   diagnostic overrides retain the conservative retry ladder.
 
+### Performance
+
+- Reused parsers now invalidate the pointer-free clean-zero front cache by
+  advancing its epoch instead of clearing all 16,384 entries between parses.
+  On recurring one-byte KDL and JSON witnesses this reduces wall time by
+  33.10% and 35.67%, respectively, with unchanged allocation counts; the
+  materialized full-parse, single-byte incremental, and no-edit benchmark trio
+  remains neutral.
+
 ### Fixed
 
 - `real_corpus_inventory --require-corpus-sources` now rejects pinned corpus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ for tags and release notes while still in `0.x`.
   mechanism. Caller-adapted grammars, incremental fallbacks, and explicit
   diagnostic overrides retain the conservative retry ladder.
 
+### Fixed
+
+- `real_corpus_inventory --require-corpus-sources` now rejects pinned corpus
+  checkouts that contain no benchmark-eligible regular files matching the
+  language's source policy. Inventory and benchmarks share traversal and
+  subdirectory validation, so invalid paths and scan failures are reported
+  instead of allowing an empty language sweep to appear complete.
+
 ## [0.29.0] - 2026-07-12
 
 Recurring-parser performance and compatibility-cleanup release. Repeated small

--- a/cgo_harness/benchmark_real_corpus_parity_test.go
+++ b/cgo_harness/benchmark_real_corpus_parity_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/cgo_harness/internal/realcorpus"
 	"github.com/odvcencio/gotreesitter/grammars"
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
@@ -370,7 +371,7 @@ func realCorpusBenchmarkLanguageRoot(tb testing.TB, root string, language string
 	if !ok || strings.TrimSpace(entry.Subdir) == "" || strings.TrimSpace(entry.Subdir) == "." {
 		return langRoot
 	}
-	subdir, ok := realCorpusBenchmarkCleanLockSubdir(entry.Subdir)
+	subdir, ok := realcorpus.CleanSubdir(entry.Subdir)
 	if !ok {
 		tb.Fatalf("invalid real corpus lock subdir for %s: %q", language, entry.Subdir)
 	}
@@ -382,32 +383,10 @@ func loadRealCorpusBenchmarkFiles(tb testing.TB, root string, filters realCorpus
 	minBytes := realCorpusBenchmarkEnvInt(tb, "GTS_REAL_CORPUS_BENCH_MIN_BYTES", 0)
 	maxFileBytes := realCorpusBenchmarkEnvInt(tb, "GTS_REAL_CORPUS_BENCH_MAX_FILE_BYTES", 0)
 	var files []realCorpusBenchmarkFile
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			switch d.Name() {
-			case ".git", ".gradle", "bazel-bin", "bazel-out", "bazel-testlogs", "build", "node_modules", "target":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-		relPath := path
-		if rel, err := filepath.Rel(root, path); err == nil {
-			relPath = rel
-		}
-		if !realCorpusBenchmarkFileAllowed(relPath, filters) {
-			return nil
-		}
-		src, err := os.ReadFile(path)
+	err := realcorpus.WalkMatchingFiles(root, func(relPath string) bool {
+		return realCorpusBenchmarkFileAllowed(relPath, filters)
+	}, func(file realcorpus.File) error {
+		src, err := os.ReadFile(file.Path)
 		if err != nil {
 			return err
 		}
@@ -417,7 +396,7 @@ func loadRealCorpusBenchmarkFiles(tb testing.TB, root string, filters realCorpus
 		if maxFileBytes > 0 && len(src) > maxFileBytes {
 			return nil
 		}
-		files = append(files, realCorpusBenchmarkFile{path: path, source: src})
+		files = append(files, realCorpusBenchmarkFile{path: file.Path, source: src})
 		return nil
 	})
 	if err != nil {
@@ -962,18 +941,6 @@ func realCorpusBenchmarkLockEntries(path string) (map[string]realCorpusBenchmark
 		return nil, err
 	}
 	return out, nil
-}
-
-func realCorpusBenchmarkCleanLockSubdir(raw string) (string, bool) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "." {
-		return "", true
-	}
-	clean := filepath.Clean(filepath.FromSlash(raw))
-	if clean == "." || clean == "" || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return "", false
-	}
-	return clean, true
 }
 
 func sortRealCorpusBenchmarkFiles(tb testing.TB, files []realCorpusBenchmarkFile) {

--- a/cgo_harness/cmd/real_corpus_inventory/main.go
+++ b/cgo_harness/cmd/real_corpus_inventory/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/odvcencio/gotreesitter/cgo_harness/internal/realcorpus"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
@@ -198,7 +198,7 @@ func main() {
 	flag.StringVar(&outLangs, "out-langs", "", "optional newline-separated selected language output path")
 	flag.StringVar(&selector, "select", "all", "language selector for -print-langs/-out-langs")
 	flag.BoolVar(&printLangs, "print-langs", false, "print selected languages and suppress default JSON stdout")
-	flag.BoolVar(&requireCorpusSources, "require-corpus-sources", false, "fail if any language is missing a pinned external corpus source checkout")
+	flag.BoolVar(&requireCorpusSources, "require-corpus-sources", false, "fail if any language lacks a pinned external corpus source checkout with matching files")
 	flag.Parse()
 
 	resolvedGrammarDir, err := resolvePath(grammarDir, []string{
@@ -239,9 +239,10 @@ func main() {
 	if err != nil {
 		fatalf("build inventory: %v", err)
 	}
-	if requireCorpusSources && inv.Summary.WithPinnedCorpusSource < inv.Summary.TotalLanguages {
-		missingPinned := inv.Summary.TotalLanguages - inv.Summary.WithPinnedCorpusSource
-		fatalf("missing pinned corpus source checkouts for %d/%d languages", missingPinned, inv.Summary.TotalLanguages)
+	if requireCorpusSources {
+		if err := validateRequiredCorpusSources(inv); err != nil {
+			fatalf("%v", err)
+		}
 	}
 	selectedLangs, err := selectLanguageNames(inv.Languages, selector)
 	if err != nil {
@@ -272,6 +273,24 @@ func main() {
 			fatalf("write stdout: %v", err)
 		}
 	}
+}
+
+func validateRequiredCorpusSources(inv inventory) error {
+	if inv.Summary.WithPinnedCorpusSource < inv.Summary.TotalLanguages {
+		missingPinned := inv.Summary.TotalLanguages - inv.Summary.WithPinnedCorpusSource
+		return fmt.Errorf("missing pinned corpus source checkouts for %d/%d languages", missingPinned, inv.Summary.TotalLanguages)
+	}
+
+	empty := make([]string, 0, inv.Summary.MissingCorpusSourceFiles)
+	for _, status := range inv.Languages {
+		if status.Corpus.Source.Pinned && status.Corpus.Source.MatchingFiles == 0 {
+			empty = append(empty, status.Language)
+		}
+	}
+	if len(empty) > 0 {
+		return fmt.Errorf("pinned corpus source checkouts with no matching files for %d/%d languages: %s", len(empty), inv.Summary.TotalLanguages, strings.Join(empty, ", "))
+	}
+	return nil
 }
 
 type inventoryOptions struct {
@@ -352,7 +371,10 @@ func buildInventoryWithOptions(grammarDir, lockPath string, manifestPaths []stri
 		if corpus, ok := corpusByLanguage[name]; ok {
 			status.Corpus = corpus
 		}
-		status.Corpus.Source = resolveSourceStatus(opts.CorpusSourceRoot, name, sourceLockForLanguage(name, status.Lock, sourceLockEntries, hasCorpusSourceLock))
+		status.Corpus.Source, err = resolveSourceStatus(opts.CorpusSourceRoot, name, sourceLockForLanguage(name, status.Lock, sourceLockEntries, hasCorpusSourceLock))
+		if err != nil {
+			return inventory{}, fmt.Errorf("resolve corpus source for %s: %w", name, err)
+		}
 		if bench, ok := benchByLanguage[name]; ok {
 			status.Benchmark = bench
 		}
@@ -505,9 +527,9 @@ func loadCorpusStatuses(paths []string) (map[string]corpusStatus, error) {
 	return out, nil
 }
 
-func resolveSourceStatus(root, language string, lock lockStatus) sourceStatus {
+func resolveSourceStatus(root, language string, lock lockStatus) (sourceStatus, error) {
 	if strings.TrimSpace(root) == "" {
-		return sourceStatus{}
+		return sourceStatus{}, nil
 	}
 	expectedPath := filepath.Clean(filepath.Join(root, language))
 	status := sourceStatus{
@@ -515,36 +537,37 @@ func resolveSourceStatus(root, language string, lock lockStatus) sourceStatus {
 		RepoURL:        lock.RepoURL,
 		ExpectedCommit: lock.Commit,
 	}
-	if st, err := os.Stat(expectedPath); err == nil && st.IsDir() {
-		status.CheckedOut = true
-		status.ActualCommit = gitHead(expectedPath)
-		status.RemoteURL = gitRemoteURL(expectedPath)
-		status.RemoteMatches = sameGitRemote(status.RemoteURL, lock.RepoURL)
-		status.Pinned = lock.Commit != "" && status.ActualCommit == lock.Commit && status.RemoteMatches
-		status.MatchExtensions, status.MatchBasenames, status.MatchPaths = sourceMatchersForLanguage(language, lock.Exts)
-		scanPath := expectedPath
-		if subdir := cleanSourceSubdir(lock.Subdir); subdir != "" {
-			status.Subdir = filepath.ToSlash(subdir)
-			scanPath = filepath.Join(expectedPath, subdir)
-			status.ScanPath = scanPath
+	subdir, ok := realcorpus.CleanSubdir(lock.Subdir)
+	if !ok {
+		return status, fmt.Errorf("invalid corpus source lock subdir %q", lock.Subdir)
+	}
+	st, err := os.Stat(expectedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return status, nil
 		}
-		if st, err := os.Stat(scanPath); err == nil && st.IsDir() {
-			status.MatchingFiles, status.MatchingBytes = countMatchingSourceFiles(scanPath, status.MatchExtensions, status.MatchBasenames, status.MatchPaths)
-		}
+		return status, fmt.Errorf("stat %s: %w", expectedPath, err)
 	}
-	return status
-}
-
-func cleanSourceSubdir(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" || raw == "." {
-		return ""
+	if !st.IsDir() {
+		return status, fmt.Errorf("corpus source checkout is not a directory: %s", expectedPath)
 	}
-	clean := filepath.Clean(filepath.FromSlash(raw))
-	if clean == "." || clean == "" || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return ""
+	status.CheckedOut = true
+	status.ActualCommit = gitHead(expectedPath)
+	status.RemoteURL = gitRemoteURL(expectedPath)
+	status.RemoteMatches = sameGitRemote(status.RemoteURL, lock.RepoURL)
+	status.Pinned = lock.Commit != "" && status.ActualCommit == lock.Commit && status.RemoteMatches
+	status.MatchExtensions, status.MatchBasenames, status.MatchPaths = sourceMatchersForLanguage(language, lock.Exts)
+	scanPath := expectedPath
+	if subdir != "" {
+		status.Subdir = filepath.ToSlash(subdir)
+		scanPath = filepath.Join(expectedPath, subdir)
+		status.ScanPath = scanPath
 	}
-	return clean
+	status.MatchingFiles, status.MatchingBytes, err = countMatchingSourceFiles(scanPath, status.MatchExtensions, status.MatchBasenames, status.MatchPaths)
+	if err != nil {
+		return status, fmt.Errorf("scan %s: %w", scanPath, err)
+	}
+	return status, nil
 }
 
 func sameGitRemote(actual, expected string) bool {
@@ -661,43 +684,23 @@ func registryExtensionsForLanguage(language string) []string {
 	return nil
 }
 
-func countMatchingSourceFiles(root string, exts []string, basenames []string, paths []string) (int, int64) {
-	if len(exts) == 0 && len(basenames) == 0 && len(paths) == 0 {
-		return 0, 0
-	}
+func countMatchingSourceFiles(root string, exts []string, basenames []string, paths []string) (int, int64, error) {
 	extSet := stringSet(exts)
 	baseSet := stringSet(basenames)
 	pathSet := stringSet(paths)
 	var count int
 	var bytes int64
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			switch strings.ToLower(d.Name()) {
-			case ".git", ".gradle", "bazel-bin", "bazel-out", "bazel-testlogs", "build", "dist", "node_modules", "target", "vendor":
-				return filepath.SkipDir
-			default:
-				return nil
-			}
-		}
-		relPath := path
-		if rel, err := filepath.Rel(root, path); err == nil {
-			relPath = rel
-		}
-		if !sourcePathMatches(relPath, extSet, baseSet, pathSet) {
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return nil
-		}
+	err := realcorpus.WalkMatchingFiles(root, func(relPath string) bool {
+		return sourcePathMatches(relPath, extSet, baseSet, pathSet)
+	}, func(file realcorpus.File) error {
 		count++
-		bytes += info.Size()
+		bytes += file.Size
 		return nil
 	})
-	return count, bytes
+	if err != nil {
+		return 0, 0, err
+	}
+	return count, bytes, nil
 }
 
 func stringSet(values []string) map[string]struct{} {

--- a/cgo_harness/cmd/real_corpus_inventory/main_test.go
+++ b/cgo_harness/cmd/real_corpus_inventory/main_test.go
@@ -378,6 +378,205 @@ func TestBuildInventoryTracksCorpusSourceCheckouts(t *testing.T) {
 	}
 }
 
+func TestValidateRequiredCorpusSources(t *testing.T) {
+	tests := []struct {
+		name    string
+		inv     inventory
+		wantErr string
+	}{
+		{
+			name: "valid",
+			inv: inventory{
+				Summary: inventorySummary{TotalLanguages: 2, WithPinnedCorpusSource: 2, WithCorpusSourceFiles: 2},
+				Languages: []languageStatus{
+					{Language: "git_rebase", Corpus: corpusStatus{Source: sourceStatus{Pinned: true, MatchingFiles: 1}}},
+					{Language: "go", Corpus: corpusStatus{Source: sourceStatus{Pinned: true, MatchingFiles: 2}}},
+				},
+			},
+		},
+		{
+			name: "missing checkout preserves pinning failure",
+			inv: inventory{
+				Summary: inventorySummary{TotalLanguages: 2, WithPinnedCorpusSource: 1, WithCorpusSourceFiles: 1, MissingCorpusSource: 1},
+				Languages: []languageStatus{
+					{Language: "git_rebase"},
+					{Language: "go", Corpus: corpusStatus{Source: sourceStatus{Pinned: true, MatchingFiles: 2}}},
+				},
+			},
+			wantErr: "missing pinned corpus source checkouts for 1/2 languages",
+		},
+		{
+			name: "pinned checkout has no policy matches",
+			inv: inventory{
+				Summary: inventorySummary{TotalLanguages: 2, WithPinnedCorpusSource: 2, WithCorpusSourceFiles: 1, MissingCorpusSourceFiles: 1},
+				Languages: []languageStatus{
+					{Language: "git_rebase", Corpus: corpusStatus{Source: sourceStatus{CheckedOut: true, Pinned: true}}},
+					{Language: "go", Corpus: corpusStatus{Source: sourceStatus{CheckedOut: true, Pinned: true, MatchingFiles: 2}}},
+				},
+			},
+			wantErr: "pinned corpus source checkouts with no matching files for 1/2 languages: git_rebase",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRequiredCorpusSources(tt.inv)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateRequiredCorpusSources: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("validateRequiredCorpusSources error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRequiredCorpusSourcesRejectsPinnedCheckoutWithoutMatchingFiles(t *testing.T) {
+	dir := t.TempDir()
+	grammarDir := filepath.Join(dir, "grammar_blobs")
+	mustMkdir(t, grammarDir)
+	mustWrite(t, filepath.Join(grammarDir, "git_rebase.bin"), "git_rebase")
+
+	root := filepath.Join(dir, "corpus_sources")
+	checkout := filepath.Join(root, "git_rebase")
+	commit := initGitRepo(t, checkout, "https://example.invalid/git-rebase-corpus")
+	lockPath := filepath.Join(dir, "languages.lock")
+	mustWrite(t, lockPath, "git_rebase https://example.invalid/git-rebase-corpus "+commit+" . .git-rebase-todo\n")
+
+	inv, err := buildInventoryWithOptions(grammarDir, lockPath, nil, "", inventoryOptions{CorpusSourceRoot: root})
+	if err != nil {
+		t.Fatalf("buildInventoryWithOptions: %v", err)
+	}
+	source := languageStatusesByName(inv.Languages)["git_rebase"].Corpus.Source
+	if !source.Pinned || source.MatchingFiles != 0 {
+		t.Fatalf("expected pinned source with no policy matches: %+v", source)
+	}
+	if err := validateRequiredCorpusSources(inv); err == nil || !strings.Contains(err.Error(), "git_rebase") {
+		t.Fatalf("validateRequiredCorpusSources error = %v, want git_rebase empty-source failure", err)
+	}
+}
+
+func TestBuildInventoryDoesNotCountSymlinkOnlyCorpusMatches(t *testing.T) {
+	dir := t.TempDir()
+	grammarDir := filepath.Join(dir, "grammar_blobs")
+	mustMkdir(t, grammarDir)
+	mustWrite(t, filepath.Join(grammarDir, "go.bin"), "go")
+
+	root := filepath.Join(dir, "corpus_sources")
+	checkout := filepath.Join(root, "go")
+	initGitRepo(t, checkout, "https://example.invalid/go-corpus")
+	if err := os.Symlink("sample.txt", filepath.Join(checkout, "main.go")); err != nil {
+		t.Skipf("create symlink: %v", err)
+	}
+	runGitTest(t, checkout, "add", "main.go")
+	runGitTest(t, checkout, "-c", "user.name=gotreesitter-test", "-c", "user.email=test@example.invalid", "commit", "-m", "add symlink")
+	commit := strings.TrimSpace(runGitTest(t, checkout, "rev-parse", "HEAD"))
+	lockPath := filepath.Join(dir, "languages.lock")
+	mustWrite(t, lockPath, "go https://example.invalid/go-corpus "+commit+" . .go\n")
+
+	inv, err := buildInventoryWithOptions(grammarDir, lockPath, nil, "", inventoryOptions{CorpusSourceRoot: root})
+	if err != nil {
+		t.Fatalf("buildInventoryWithOptions: %v", err)
+	}
+	source := languageStatusesByName(inv.Languages)["go"].Corpus.Source
+	if !source.Pinned || source.MatchingFiles != 0 {
+		t.Fatalf("symlink must not count as a benchmark-eligible regular file: %+v", source)
+	}
+	if err := validateRequiredCorpusSources(inv); err == nil {
+		t.Fatal("expected symlink-only corpus source to fail required-source validation")
+	}
+}
+
+func TestBuildInventoryIncludesVendorAndDistCorpusMatches(t *testing.T) {
+	dir := t.TempDir()
+	grammarDir := filepath.Join(dir, "grammar_blobs")
+	mustMkdir(t, grammarDir)
+	mustWrite(t, filepath.Join(grammarDir, "go.bin"), "go")
+
+	root := filepath.Join(dir, "corpus_sources")
+	checkout := filepath.Join(root, "go")
+	initGitRepo(t, checkout, "https://example.invalid/go-corpus")
+	mustMkdir(t, filepath.Join(checkout, "vendor"))
+	mustMkdir(t, filepath.Join(checkout, "dist"))
+	mustWrite(t, filepath.Join(checkout, "vendor", "dependency.go"), "package dependency\n")
+	mustWrite(t, filepath.Join(checkout, "dist", "generated.go"), "package generated\n")
+	runGitTest(t, checkout, "add", "vendor/dependency.go", "dist/generated.go")
+	runGitTest(t, checkout, "-c", "user.name=gotreesitter-test", "-c", "user.email=test@example.invalid", "commit", "-m", "add generated sources")
+	commit := strings.TrimSpace(runGitTest(t, checkout, "rev-parse", "HEAD"))
+	lockPath := filepath.Join(dir, "languages.lock")
+	mustWrite(t, lockPath, "go https://example.invalid/go-corpus "+commit+" . .go\n")
+
+	inv, err := buildInventoryWithOptions(grammarDir, lockPath, nil, "", inventoryOptions{CorpusSourceRoot: root})
+	if err != nil {
+		t.Fatalf("buildInventoryWithOptions: %v", err)
+	}
+	source := languageStatusesByName(inv.Languages)["go"].Corpus.Source
+	if source.MatchingFiles != 2 || source.MatchingBytes == 0 {
+		t.Fatalf("vendor and dist files should follow benchmark eligibility: %+v", source)
+	}
+}
+
+func TestBuildInventoryRejectsInvalidCorpusSourceSubdir(t *testing.T) {
+	dir := t.TempDir()
+	grammarDir := filepath.Join(dir, "grammar_blobs")
+	mustMkdir(t, grammarDir)
+	mustWrite(t, filepath.Join(grammarDir, "go.bin"), "go")
+	grammarLockPath := filepath.Join(dir, "languages.lock")
+	mustWrite(t, grammarLockPath, "go https://example.invalid/go-grammar grammarcommit src .go\n")
+	sourceLockPath := filepath.Join(dir, "corpus_sources.lock")
+	mustWrite(t, sourceLockPath, "go https://example.invalid/go-corpus corpuscommit ../escape .go\n")
+
+	_, err := buildInventoryWithOptions(grammarDir, grammarLockPath, nil, "", inventoryOptions{
+		CorpusSourceRoot:     filepath.Join(dir, "corpus_sources"),
+		CorpusSourceLockPath: sourceLockPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), `resolve corpus source for go: invalid corpus source lock subdir "../escape"`) {
+		t.Fatalf("buildInventoryWithOptions error = %v, want invalid subdir", err)
+	}
+}
+
+func TestBuildInventoryReportsCorpusSourceScanErrors(t *testing.T) {
+	dir := t.TempDir()
+	grammarDir := filepath.Join(dir, "grammar_blobs")
+	mustMkdir(t, grammarDir)
+	mustWrite(t, filepath.Join(grammarDir, "go.bin"), "go")
+
+	root := filepath.Join(dir, "corpus_sources")
+	checkout := filepath.Join(root, "go")
+	commit := initGitRepo(t, checkout, "https://example.invalid/go-corpus")
+	grammarLockPath := filepath.Join(dir, "languages.lock")
+	mustWrite(t, grammarLockPath, "go https://example.invalid/go-grammar grammarcommit src .go\n")
+	sourceLockPath := filepath.Join(dir, "corpus_sources.lock")
+	mustWrite(t, sourceLockPath, "go https://example.invalid/go-corpus "+commit+" missing .go\n")
+
+	_, err := buildInventoryWithOptions(grammarDir, grammarLockPath, nil, "", inventoryOptions{
+		CorpusSourceRoot:     root,
+		CorpusSourceLockPath: sourceLockPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "resolve corpus source for go: scan") || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("buildInventoryWithOptions error = %v, want actionable missing-subdir scan error", err)
+	}
+}
+
+func TestBuildInventoryReportsNonDirectoryCorpusSource(t *testing.T) {
+	dir := t.TempDir()
+	grammarDir := filepath.Join(dir, "grammar_blobs")
+	mustMkdir(t, grammarDir)
+	mustWrite(t, filepath.Join(grammarDir, "go.bin"), "go")
+	root := filepath.Join(dir, "corpus_sources")
+	mustMkdir(t, root)
+	mustWrite(t, filepath.Join(root, "go"), "not a checkout\n")
+	lockPath := filepath.Join(dir, "languages.lock")
+	mustWrite(t, lockPath, "go https://example.invalid/go-corpus commit . .go\n")
+
+	_, err := buildInventoryWithOptions(grammarDir, lockPath, nil, "", inventoryOptions{CorpusSourceRoot: root})
+	if err == nil || !strings.Contains(err.Error(), "corpus source checkout is not a directory") {
+		t.Fatalf("buildInventoryWithOptions error = %v, want non-directory source error", err)
+	}
+}
+
 func TestBuildInventoryCanUseSeparateCorpusSourceLock(t *testing.T) {
 	dir := t.TempDir()
 	grammarDir := filepath.Join(dir, "grammar_blobs")

--- a/cgo_harness/internal/realcorpus/files.go
+++ b/cgo_harness/internal/realcorpus/files.go
@@ -1,0 +1,60 @@
+package realcorpus
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// File describes a regular file accepted by the real-corpus traversal policy.
+type File struct {
+	Path string
+	Size int64
+}
+
+// CleanSubdir validates and normalizes a lock-file subdirectory.
+func CleanSubdir(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "." {
+		return "", true
+	}
+	clean := filepath.Clean(filepath.FromSlash(raw))
+	if clean == "." || clean == "" || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return clean, true
+}
+
+// WalkMatchingFiles walks root using the benchmark's directory and file policy.
+// vendor and dist are intentionally eligible because generated and vendored
+// sources are valid performance witnesses.
+func WalkMatchingFiles(root string, matches func(relativePath string) bool, visit func(File) error) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".gradle", "bazel-bin", "bazel-out", "bazel-testlogs", "build", "node_modules", "target":
+				return filepath.SkipDir
+			default:
+				return nil
+			}
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		relPath := path
+		if rel, err := filepath.Rel(root, path); err == nil {
+			relPath = rel
+		}
+		if !matches(relPath) {
+			return nil
+		}
+		return visit(File{Path: path, Size: info.Size()})
+	})
+}

--- a/glr.go
+++ b/glr.go
@@ -5243,11 +5243,11 @@ func (s *glrMergeScratch) reset() {
 	// alias into a fresh parse (reset would restart the epoch at 1 and collide
 	// with surviving epoch-1 entries once gss slab pointers get reused).
 	s.shapePrefixBytes = int64(cap(s.shapePrefixCache)) * int64(unsafe.Sizeof(glrShapePrefixCacheEntry{}))
-	// cleanZeroEpoch (below) restarts at 0 per reset, so the epoch-validated
-	// front array MUST be cleared or stale entries could match a future epoch.
-	if len(s.cleanZeroFront) > 0 {
-		clear(s.cleanZeroFront)
-	}
+	// cleanZeroEpoch, like shapePrefixEpoch above, remains monotonic across
+	// pooled parses. The front stores uintptr values rather than Go pointers,
+	// so advancing the epoch at parse acquisition invalidates its entries in
+	// O(1) without retaining a GSS slab. beginCleanZeroEpoch clears the array
+	// when the uint32 epoch wraps, before epoch values can alias.
 	s.cleanZeroBytes = int64(cap(s.cleanZeroFront)) * int64(unsafe.Sizeof(glrCleanZeroFrontCacheEntry{}))
 	if len(s.cleanZeroCache) > 0 {
 		clear(s.cleanZeroCache)
@@ -5264,7 +5264,6 @@ func (s *glrMergeScratch) reset() {
 		clear(s.cleanZeroVisited[:cap(s.cleanZeroVisited)])
 		s.cleanZeroVisited = s.cleanZeroVisited[:0]
 	}
-	s.cleanZeroEpoch = 0
 	s.cleanZeroScan = 0
 	s.perKeyCap = 0
 	s.language = nil

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -24,6 +24,84 @@ func TestGLRMergeScratchResetInvalidatesEquivCacheByEpoch(t *testing.T) {
 	}
 }
 
+func TestGLRMergeScratchResetPreservesCleanZeroEpochAndRejectsReusedAddress(t *testing.T) {
+	var nodes gssScratch
+	old := nodes.allocNode(stackEntry{state: 1}, nil, 1)
+	var pooled parserScratch
+	scratch := &pooled.merge
+	scratch.ensureMergeHotCaches()
+	scratch.beginCleanZeroEpoch()
+	storeCleanZeroFrontCache(scratch, old, true)
+	scratch.cleanZeroCache = map[*gssNode]gssCleanZeroErrorCacheEntry{
+		old: {resultEpoch: scratch.cleanZeroEpoch, clean: true},
+	}
+	scratch.cleanZeroStack = append(scratch.cleanZeroStack, old)
+	scratch.cleanZeroVisited = append(scratch.cleanZeroVisited, old)
+
+	epochBefore := scratch.cleanZeroEpoch
+	scratch.reset()
+	if scratch.cleanZeroEpoch != epochBefore {
+		t.Fatalf("clean-zero epoch after reset = %d, want preserved %d", scratch.cleanZeroEpoch, epochBefore)
+	}
+	if got, ok := lookupCleanZeroFrontCache(scratch, old); !ok || !got {
+		t.Fatalf("clean-zero front after reset = %v, %v; want retained true, true", got, ok)
+	}
+	if len(scratch.cleanZeroCache) != 0 {
+		t.Fatalf("clean-zero map retained %d GSS pointers", len(scratch.cleanZeroCache))
+	}
+	if len(scratch.cleanZeroStack) != 0 || len(scratch.cleanZeroVisited) != 0 {
+		t.Fatalf("clean-zero traversal scratch not reset: stack=%d visited=%d", len(scratch.cleanZeroStack), len(scratch.cleanZeroVisited))
+	}
+	if cap(scratch.cleanZeroStack) > 0 && scratch.cleanZeroStack[:cap(scratch.cleanZeroStack)][0] != nil {
+		t.Fatal("clean-zero stack backing retained a GSS pointer")
+	}
+	if cap(scratch.cleanZeroVisited) > 0 && scratch.cleanZeroVisited[:cap(scratch.cleanZeroVisited)][0] != nil {
+		t.Fatal("clean-zero visited backing retained a GSS pointer")
+	}
+
+	nodes.recycleForParse()
+	reused := nodes.allocNode(stackEntry{state: 2}, nil, 1)
+	if reused != old {
+		t.Fatalf("recycled GSS address = %p, want %p", reused, old)
+	}
+	parser := NewParser(buildArithmeticLanguage())
+	parser.configureParseScratch(&pooled, nil, nil, nil, arenaClassFull, true)
+	if scratch.cleanZeroEpoch != epochBefore+1 {
+		t.Fatalf("clean-zero epoch after acquisition = %d, want %d", scratch.cleanZeroEpoch, epochBefore+1)
+	}
+	if _, ok := lookupCleanZeroFrontCache(scratch, reused); ok {
+		t.Fatal("clean-zero front hit after a GSS address was reused in a new parse epoch")
+	}
+}
+
+func TestGLRMergeScratchCleanZeroEpochWrapClearsFront(t *testing.T) {
+	var nodes gssScratch
+	node := nodes.allocNode(stackEntry{state: 1}, nil, 1)
+	var scratch glrMergeScratch
+	scratch.ensureMergeHotCaches()
+	scratch.cleanZeroEpoch = ^uint32(0)
+	storeCleanZeroFrontCache(&scratch, node, true)
+	scratch.cleanZeroCache = map[*gssNode]gssCleanZeroErrorCacheEntry{
+		node: {resultEpoch: scratch.cleanZeroEpoch, clean: true},
+	}
+
+	scratch.beginCleanZeroEpoch()
+	if scratch.cleanZeroEpoch != 1 {
+		t.Fatalf("clean-zero epoch after wrap = %d, want 1", scratch.cleanZeroEpoch)
+	}
+	if len(scratch.cleanZeroCache) != 0 {
+		t.Fatalf("clean-zero map retained %d entries across wrap", len(scratch.cleanZeroCache))
+	}
+	if _, ok := lookupCleanZeroFrontCache(&scratch, node); ok {
+		t.Fatal("clean-zero front entry survived epoch wrap")
+	}
+	for i, entry := range scratch.cleanZeroFront {
+		if entry != (glrCleanZeroFrontCacheEntry{}) {
+			t.Fatalf("clean-zero front slot %d after wrap = %#v, want zero", i, entry)
+		}
+	}
+}
+
 func TestGLREntryScratchResetClearsReservedWrittenRange(t *testing.T) {
 	var scratch glrEntryScratch
 	entries := scratch.allocWithCap(1, 8)


### PR DESCRIPTION
## Summary

- invalidate the clean-zero front cache by epoch across pooled parses
- preserve pointer-retention and wraparound safety with focused regression coverage
- make corpus inventory reject pinned checkouts with no benchmark-eligible files and share traversal policy with the benchmark

## Results

- recurring one-byte KDL: 11.018 µs to 7.371 µs (-33.10%)
- recurring JSON: 10.444 µs to 6.719 µs (-35.67%)
- allocation counts unchanged; materialized full, single-edit, and no-edit trio neutral
- isolated KDL C-oracle run passed with no OOM

## Validation

- focused GLR reset tests, 20x on host and in Docker
- corpus inventory focused tests
- paired B-C-C-B benchmarks, n=20 per side
- isolated one-language KDL parity benchmark