### PR TITLE
test(cgo_harness): reduce resumable perf scan shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- The real-corpus performance scan now supports resumable one-language shard
+  campaigns with a blocking merge-only reducer. New scoreboards record their
+  repository revision and clean-source state; reduction requires exactly one
+  quiet, unexcluded, hard-gate-clean shard per authenticated lock language at
+  one revision, host/runtime identity, and measurement configuration, then
+  recomputes the fleet aggregates,
+  clean/error split, coverage, and hard gate before emitting authoritative
+  JSON and Markdown.
 - The real-corpus Go/C performance scoreboard now classifies each full parse
   as clean, error-bearing, or stopped outside the timed path, and reports
   per-language clean/error counts, timing totals, ratios, stopped subsets, and

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -117,8 +117,70 @@ GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
   GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB=6144 \
   GTS_PERF_SCAN_OUT=perf_scan/out/authoritative_$(date -u +%Y%m%dT%H%M%SZ) \
   go test -tags "treesitter_c_parity treesitter_c_perfscan" \
+      -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 .
+```
+
+### Resumable one-language shards and blocking reduction
+
+Long fleet refreshes can run as independent one-language scoreboards. Keep the
+measurement knobs identical, set `GTS_PERF_SCAN_REQUIRE_FLEET=0`, and give each
+language its own output directory:
+
+```sh
+cd cgo_harness
+GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
+  GTS_PERF_SCAN_CORPUS_ROOT=/home/draco/work/gotreesitter-corpora/corpus_sources \
+  GTS_REAL_CORPUS_BENCH_LOCK=/home/draco/work/gotreesitter-corpora/corpus_sources.lock \
+  GTS_PERF_SCAN_HARD_GATE=1 GTS_PERF_SCAN_REQUIRE_FLEET=0 \
+  GTS_PERF_SCAN_LANGS=go GTS_PERF_SCAN_MAX_FILES=8 \
+  GTS_PERF_SCAN_ORDER=largest GTS_PERF_SCAN_REPS=5 \
+  GTS_PERF_SCAN_FILE_BUDGET_MS=10000 \
+  GTS_PERF_SCAN_OUT=perf_scan/out/shards/go \
+  go test -tags "treesitter_c_parity treesitter_c_perfscan" \
   -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 .
 ```
+
+Repeat for every language in the authenticated lock. Completed shard
+scoreboards are durable checkpoints; the reducer reads them without invoking a
+parser, so an interrupted campaign resumes from the missing languages rather
+than restarting the fleet. Once every shard exists, run the blocking reducer:
+
+```sh
+cd cgo_harness
+GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
+  GTS_REAL_CORPUS_BENCH_LOCK=/home/draco/work/gotreesitter-corpora/corpus_sources.lock \
+  GTS_PERF_SCAN_REDUCE_INPUTS='perf_scan/out/shards/*/scoreboard.json' \
+  GTS_PERF_SCAN_OUT=perf_scan/out/authoritative_reduced \
+  go test -tags "treesitter_c_parity treesitter_c_perfscan" \
+  -run '^TestPerfScanReduce$' -v -count=1 -timeout 0 .
+```
+
+Reduction succeeds only with exactly one scoreboard for every locked language.
+It rejects missing or duplicate languages, schema or measurement-config drift,
+corpus-lock drift, path exclusions, contended runs, mixed or absent repository
+revisions, dirty source trees, mixed host/runtime identities, incomplete or
+contradictory file evidence, and absent, stale, or failed shard hard gates. A
+host identity includes hostname, GOOS/GOARCH, CPU count, `GOMAXPROCS`, and Go
+version; both start and end load averages must remain below the contention
+threshold. The
+only permitted per-shard config differences are the one-element `languages`
+selection and `require_fleet=false`; the combined config is rewritten to the
+full lock language list with `require_fleet=true`. The reducer recomputes every
+language aggregate, verdict summary, fleet clean/error split, coverage record,
+and the full hard gate before writing authoritative JSON and Markdown. The
+reducer execution is authenticated independently: its checkout/build must be
+clean and at the same revision recorded by every shard, so one runtime version
+cannot silently reinterpret another version's evidence.
+
+New scoreboards record the full repository revision and clean-source attestation.
+Revisionless v1 JSON still decodes for existing readers, but is deliberately
+ineligible for authoritative reduction. Git and Go build VCS metadata must
+agree and neither may report modification. `GTS_PERF_SCAN_GIT_REVISION` cannot
+override discovered metadata; it accepts a full 40- or 64-hex revision only
+when neither source is available, together with explicit
+`GTS_PERF_SCAN_GIT_CLEAN=1`. Exploratory `GTS_PERF_SCAN_HARD_GATE=0` runs may
+record `git_clean=false` so uncommitted candidates remain benchmarkable, but
+those scoreboards cannot enter authoritative reduction.
 
 Hard-gate mode requires `GTS_REAL_CORPUS_BENCH_LOCK`. Its SHA-256 must match
 `perf_scan/corpus_sources.lock.sha256` and the same digest in the budget file;
@@ -146,6 +208,9 @@ the corpus builder deliberately supplies nested dependency checkouts and
 | `GTS_PERF_SCAN_LANGS` | locked fleet (hard) / auto-discover (exploratory) | comma list for a targeted sweep |
 | `GTS_PERF_SCAN_LANG` | — | single language (child mode; set by the sweep) |
 | `GTS_PERF_SCAN_OUT` | `perf_scan/out/scan_<UTC>` | output dir |
+| `GTS_PERF_SCAN_REDUCE_INPUTS` | — | reducer-only comma list of scoreboard paths/globs; requires exactly one authenticated shard per lock language |
+| `GTS_PERF_SCAN_GIT_REVISION` | auto-discovered | full repository object ID override for metadata-poor build environments |
+| `GTS_PERF_SCAN_GIT_CLEAN` | — | explicit clean-source attestation required with a metadata-poor revision override |
 | `GTS_PERF_SCAN_CORPUS_ROOT` | `corpus_real` | corpus root (per-language subdirs) |
 | `GTS_PERF_SCAN_REPS` | 5 | timed reps per file/axis/impl |
 | `GTS_PERF_SCAN_WARMUP` | 1 | untimed warmup attempts |
@@ -175,13 +240,16 @@ Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 <out>/logs/<lang>.log   child stdout/stderr per language
 ```
 
-`scoreboard.json` carries host metadata (loadavg at start/end), the full
-config, authenticated corpus coverage, a `contended` flag, structured stop
-records, per-language per-axis aggregates, per-file medians/ratios/statuses,
+`scoreboard.json` carries the repository revision, host metadata (loadavg at
+start/end), the full config, authenticated corpus coverage, a `contended` flag,
+structured stop records, per-language per-axis aggregates, per-file medians/ratios/statuses,
 optional per-file full-parse classifications, per-language clean/error timing
-splits, and a `hard_gate` report. The markdown renders the same class totals
-and lists each non-clean file with its reason. The report lists failures and
-separately lists full-parse files at `<=0.10x`.
+splits, a fleet clean/error timing split, and a `hard_gate` report. The markdown
+renders the same class totals and lists each non-clean file with its reason.
+The report lists failures and separately lists full-parse files at `<=0.10x`.
+Both files are staged and synced before publication; Markdown is published
+first and `scoreboard.json` is the final commit marker. A failed JSON publish
+rolls Markdown back, and temporary checkpoint files are removed on failure.
 
 If a language child process is killed while measuring a file, the latest
 partial fragment includes `active_file`, 1-based `active_file_index`, and
@@ -291,9 +359,11 @@ Older `gts-perf-scan/v1` scoreboards still decode. They predate structured
 stops, corpus coverage, and the embedded hard-gate report, so use
 `-strict-config=false` only for historical analysis; they cannot establish a
 new hard-gate pass. `cmd/perf_scan_status` labels them `not_evaluated`.
-The clean/error fields are optional additions to the same v1 schema: readers
-must continue to accept rows without `classification` or `full_parse_split`,
-and current Go decoders do so.
+The clean/error and repository-revision fields are optional additions to the
+same v1 schema: readers must continue to accept rows without `classification`,
+`full_parse_split`, or `git_revision`, and current Go decoders do so. The
+authoritative shard reducer applies a stronger provenance policy after decoding
+and rejects revisionless inputs.
 
 ## Phase 2 (documented, not built)
 

--- a/cgo_harness/zz_perf_scan_reduce_test.go
+++ b/cgo_harness/zz_perf_scan_reduce_test.go
@@ -1,0 +1,997 @@
+//go:build cgo && treesitter_c_parity && treesitter_c_perfscan
+
+package cgoharness
+
+// This file contains the merge-only fleet reducer for independently produced
+// one-language perf-scan scoreboards. It intentionally lives beside the scan
+// harness so reduction uses the exact scoreboard, aggregation, rendering, and
+// hard-gate implementation that produced the shards.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const perfScanEnvReduceInputs = "GTS_PERF_SCAN_REDUCE_INPUTS"
+
+// TestPerfScanReduce authenticates and merges one completed scoreboard for
+// every language in the corpus lock. It never invokes a parser, so interrupted
+// campaigns can resume by retaining their completed shard scoreboards and
+// supplying the full set here once the last language finishes.
+func TestPerfScanReduce(t *testing.T) {
+	if !perfScanGateEnabled() {
+		t.Skipf("set %s=1 to run the perf scan reducer", perfScanEnvGate)
+	}
+	if strings.TrimSpace(os.Getenv(perfScanEnvLang)) != "" {
+		t.Fatalf("%s is set; refusing to reduce inside a language child", perfScanEnvLang)
+	}
+	paths, err := perfScanReduceInputPaths(os.Getenv(perfScanEnvReduceInputs))
+	if err != nil {
+		t.Fatalf("resolve shard scoreboards: %v", err)
+	}
+	reducerProvenance, err := perfScanRepositoryProvenance(true)
+	if err != nil {
+		t.Fatalf("authenticate reducer repository provenance: %v", err)
+	}
+
+	lockCfg := perfScanConfig{
+		CorpusLock:   strings.TrimSpace(os.Getenv(perfScanEnvCorpusLock)),
+		HardGate:     true,
+		RequireFleet: true,
+	}
+	lockEntries, coverage, err := perfScanPrepareCorpusLock(&lockCfg)
+	if err != nil {
+		t.Fatalf("prepare authenticated corpus lock: %v", err)
+	}
+	if len(coverage.MissingFromRegistry) > 0 {
+		t.Fatalf("authenticated lock has registry gaps: %s", strings.Join(coverage.MissingFromRegistry, ","))
+	}
+	lockLanguages := make([]string, 0, len(lockEntries))
+	for lang := range lockEntries {
+		lockLanguages = append(lockLanguages, lang)
+	}
+	sort.Strings(lockLanguages)
+
+	board, err := perfScanReduceScoreboards(paths, coverage.LockPath, coverage.LockSHA256, lockLanguages, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("reduce shard scoreboards: %v", err)
+	}
+	if err := perfScanAuthenticateReducer(board, reducerProvenance); err != nil {
+		t.Fatalf("authenticate reducer against shards: %v", err)
+	}
+	outDir := strings.TrimSpace(os.Getenv(perfScanEnvOut))
+	if outDir == "" {
+		outDir = filepath.Join("perf_scan", "out", "reduced_"+time.Now().UTC().Format("20060102T150405Z"))
+	}
+	absOut, err := filepath.Abs(outDir)
+	if err != nil {
+		t.Fatalf("resolve output directory: %v", err)
+	}
+	if err := os.MkdirAll(absOut, 0o755); err != nil {
+		t.Fatalf("create output directory: %v", err)
+	}
+	if err := perfScanWriteScoreboard(absOut, board); err != nil {
+		t.Fatalf("write reduced scoreboard: %v", err)
+	}
+	t.Logf("reduced %d authenticated shard scoreboards at %s", len(board.Languages), board.GitRevision)
+	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.json"))
+	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.md"))
+}
+
+func perfScanAuthenticateReducer(board *perfScanScoreboard, provenance perfScanRepositoryState) error {
+	if board == nil {
+		return fmt.Errorf("nil reduced scoreboard")
+	}
+	if !provenance.Clean {
+		return fmt.Errorf("reducer execution does not attest a clean repository")
+	}
+	revision, err := perfScanNormalizeRevision(provenance.Revision)
+	if err != nil {
+		return fmt.Errorf("reducer execution revision: %w", err)
+	}
+	if revision != board.GitRevision {
+		return fmt.Errorf("reducer execution revision %s differs from shard revision %s", revision, board.GitRevision)
+	}
+	return nil
+}
+
+func perfScanReduceInputPaths(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	var paths []string
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		matches, err := filepath.Glob(part)
+		if err != nil {
+			return nil, fmt.Errorf("glob %q: %w", part, err)
+		}
+		if len(matches) == 0 {
+			if _, err := os.Stat(part); err != nil {
+				return nil, fmt.Errorf("input %q matched no scoreboard: %w", part, err)
+			}
+			matches = []string{part}
+		}
+		paths = append(paths, matches...)
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("%s must name one or more scoreboard paths or glob patterns", perfScanEnvReduceInputs)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func perfScanReadScoreboard(path string) (*perfScanScoreboard, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var board perfScanScoreboard
+	// Plain Unmarshal deliberately keeps v1's backward-compatible decoding.
+	// Authoritative reduction applies its stronger provenance requirements
+	// after decoding and therefore rejects old revisionless shards.
+	if err := json.Unmarshal(data, &board); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return &board, nil
+}
+
+func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLanguages []string, generatedAt time.Time) (*perfScanScoreboard, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no shard scoreboards")
+	}
+	lockSHA = strings.ToLower(strings.TrimSpace(lockSHA))
+	if lockSHA == "" {
+		return nil, fmt.Errorf("authenticated corpus lock SHA-256 is empty")
+	}
+	wantLanguages := append([]string(nil), lockLanguages...)
+	sort.Strings(wantLanguages)
+	if len(wantLanguages) == 0 {
+		return nil, fmt.Errorf("authenticated corpus lock has no languages")
+	}
+	wantSet := make(map[string]bool, len(wantLanguages))
+	for _, lang := range wantLanguages {
+		if lang == "" || wantSet[lang] {
+			return nil, fmt.Errorf("authenticated corpus lock contains duplicate or empty language %q", lang)
+		}
+		wantSet[lang] = true
+	}
+
+	var (
+		baseConfig   *perfScanConfig
+		baseHost     perfScanHost
+		revision     string
+		rowsByLang   = make(map[string]*perfScanLanguage, len(wantLanguages))
+		generatedMax time.Time
+	)
+	for _, shardPath := range paths {
+		shard, err := perfScanReadScoreboard(shardPath)
+		if err != nil {
+			return nil, err
+		}
+		if shard.Schema != perfScanSchema {
+			return nil, fmt.Errorf("shard %s schema %q, want %q", shardPath, shard.Schema, perfScanSchema)
+		}
+		shardRevision, err := perfScanNormalizeRevision(shard.GitRevision)
+		if err != nil {
+			return nil, fmt.Errorf("shard %s git revision: %w", shardPath, err)
+		}
+		if revision == "" {
+			revision = shardRevision
+		} else if shardRevision != revision {
+			return nil, fmt.Errorf("shard %s git revision %s differs from %s", shardPath, shardRevision, revision)
+		}
+		if !shard.GitClean {
+			return nil, fmt.Errorf("shard %s does not attest a clean tracked and untracked repository", shardPath)
+		}
+		if shard.Config.Contended {
+			return nil, fmt.Errorf("shard %s is contended: %s", shardPath, shard.Config.ContendedNote)
+		}
+		if strings.HasPrefix(shard.Config.ContendedNote, "explicit ") {
+			return nil, fmt.Errorf("shard %s used an explicit contention override: %s", shardPath, shard.Config.ContendedNote)
+		}
+		if len(shard.Config.ExcludePaths) != 0 {
+			return nil, fmt.Errorf("shard %s has excluded paths: %s", shardPath, strings.Join(shard.Config.ExcludePaths, ","))
+		}
+		if !shard.Config.HardGate {
+			return nil, fmt.Errorf("shard %s did not run with the hard gate enabled", shardPath)
+		}
+		if shard.Config.RequireFleet {
+			return nil, fmt.Errorf("shard %s has require_fleet=true; one-language shards must set it false", shardPath)
+		}
+		if shard.Config.CorpusLockSHA256 != lockSHA || shard.Corpus.LockSHA256 != lockSHA {
+			return nil, fmt.Errorf("shard %s corpus lock SHA mismatch: config=%q coverage=%q want=%q", shardPath, shard.Config.CorpusLockSHA256, shard.Corpus.LockSHA256, lockSHA)
+		}
+		if shard.Config.CorpusLockLanguages != len(wantLanguages) || shard.Corpus.LockLanguages != len(wantLanguages) {
+			return nil, fmt.Errorf("shard %s corpus lock language count mismatch: config=%d coverage=%d want=%d", shardPath, shard.Config.CorpusLockLanguages, shard.Corpus.LockLanguages, len(wantLanguages))
+		}
+		if shard.Corpus.SelectedLanguages != 1 || len(shard.Corpus.MissingFromLock) != 0 || len(shard.Corpus.MissingFromRegistry) != 0 {
+			return nil, fmt.Errorf("shard %s has incomplete corpus coverage: selected=%d missing_lock=%v missing_registry=%v", shardPath, shard.Corpus.SelectedLanguages, shard.Corpus.MissingFromLock, shard.Corpus.MissingFromRegistry)
+		}
+		if len(shard.Config.Languages) != 1 || len(shard.Languages) != 1 || shard.Languages[0] == nil {
+			return nil, fmt.Errorf("shard %s must contain exactly one configured language and one language row", shardPath)
+		}
+		lang := shard.Languages[0].Language
+		row := shard.Languages[0]
+		if shard.Config.Languages[0] != lang {
+			return nil, fmt.Errorf("shard %s configured language %q does not match row %q", shardPath, shard.Config.Languages[0], lang)
+		}
+		if !wantSet[lang] {
+			return nil, fmt.Errorf("shard %s language %q is not in the authenticated corpus lock", shardPath, lang)
+		}
+		if _, exists := rowsByLang[lang]; exists {
+			return nil, fmt.Errorf("duplicate shard language %q", lang)
+		}
+		if row.FilesSelected <= 0 || row.FilesMeasured <= 0 || len(row.Files) <= 0 {
+			return nil, fmt.Errorf("shard %s language %q has no selected, measured, and classified file evidence", shardPath, lang)
+		}
+		seenPaths := map[string]bool{}
+		for _, file := range row.Files {
+			if file == nil || file.Classification == nil {
+				return nil, fmt.Errorf("shard %s language %q has incomplete full-parse classification coverage", shardPath, lang)
+			}
+			if file.Path == "" || seenPaths[file.Path] {
+				return nil, fmt.Errorf("shard %s language %q has empty or duplicate file path %q", shardPath, lang, file.Path)
+			}
+			seenPaths[file.Path] = true
+			if err := perfScanValidateClassification(file.Classification); err != nil {
+				return nil, fmt.Errorf("shard %s language %q file %q classification: %w", shardPath, lang, file.Path, err)
+			}
+		}
+
+		comparable := perfScanComparableShardConfig(shard.Config)
+		if baseConfig == nil {
+			copyConfig := comparable
+			baseConfig = &copyConfig
+			baseHost = shard.Host
+		} else if !reflect.DeepEqual(*baseConfig, comparable) {
+			return nil, fmt.Errorf("shard %s measurement config differs from earlier shards (only languages and require_fleet may differ)", shardPath)
+		}
+		if err := perfScanValidateHostIdentity(shard.Host); err != nil {
+			return nil, fmt.Errorf("shard %s host identity: %w", shardPath, err)
+		}
+		if !reflect.DeepEqual(perfScanComparableHost(baseHost), perfScanComparableHost(shard.Host)) {
+			return nil, fmt.Errorf("shard %s host identity differs from earlier shards", shardPath)
+		}
+
+		recomputedGate := perfScanEvaluateHardGate(shard)
+		if shard.Gate == nil || shard.Gate.Status != perfScanGatePass || recomputedGate.Status != perfScanGatePass || !reflect.DeepEqual(*shard.Gate, recomputedGate) {
+			return nil, fmt.Errorf("shard %s has an absent, failed, stale, or otherwise invalid hard gate", shardPath)
+		}
+		rowsByLang[lang] = row
+		if ts, err := time.Parse(time.RFC3339, shard.GeneratedAt); err == nil && ts.After(generatedMax) {
+			generatedMax = ts
+		}
+	}
+
+	var missing []string
+	for _, lang := range wantLanguages {
+		if rowsByLang[lang] == nil {
+			missing = append(missing, lang)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("missing shard languages: %s", strings.Join(missing, ","))
+	}
+	if len(rowsByLang) != len(wantLanguages) {
+		return nil, fmt.Errorf("reduced %d unique languages, authenticated lock contains %d", len(rowsByLang), len(wantLanguages))
+	}
+
+	outputConfig := *baseConfig
+	outputConfig.Languages = append([]string(nil), wantLanguages...)
+	outputConfig.RequireFleet = true
+	outputConfig.HardGate = true
+	outputConfig.ExcludePaths = nil
+	outputConfig.CorpusLock = lockPath
+	outputConfig.CorpusLockSHA256 = lockSHA
+	outputConfig.CorpusLockLanguages = len(wantLanguages)
+	board := &perfScanScoreboard{
+		Schema:      perfScanSchema,
+		GeneratedAt: generatedAt.UTC().Format(time.RFC3339),
+		GitRevision: revision,
+		GitClean:    true,
+		Host:        baseHost,
+		Config:      outputConfig,
+		Summary:     map[string]int{},
+		Corpus: perfScanCorpusCoverage{
+			LockPath:          lockPath,
+			LockSHA256:        lockSHA,
+			LockLanguages:     len(wantLanguages),
+			SelectedLanguages: len(wantLanguages),
+		},
+		Notes: []string{fmt.Sprintf("Reduced from %d authenticated one-language shard scoreboards without rerunning parses.", len(paths))},
+	}
+	if !generatedMax.IsZero() {
+		board.Notes = append(board.Notes, "Latest source shard generated at "+generatedMax.UTC().Format(time.RFC3339)+".")
+	}
+	for _, lang := range wantLanguages {
+		row := rowsByLang[lang]
+		perfScanRefreshLanguageAggregates(row, outputConfig)
+		board.Languages = append(board.Languages, row)
+		board.Summary[row.Verdict]++
+	}
+	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
+	gate := perfScanEvaluateHardGate(board)
+	board.Gate = &gate
+	if gate.Status != perfScanGatePass {
+		return nil, fmt.Errorf("reduced fleet hard gate failed with %d finding(s)", len(gate.Failures))
+	}
+	return board, nil
+}
+
+func perfScanComparableShardConfig(cfg perfScanConfig) perfScanConfig {
+	cfg.Languages = nil
+	cfg.RequireFleet = false
+	return cfg
+}
+
+func perfScanComparableHost(host perfScanHost) perfScanHost {
+	host.LoadavgStart = ""
+	host.LoadavgEnd = ""
+	return host
+}
+
+func perfScanValidateHostIdentity(host perfScanHost) error {
+	if strings.TrimSpace(host.Hostname) == "" || strings.TrimSpace(host.GOOS) == "" || strings.TrimSpace(host.GOARCH) == "" || strings.TrimSpace(host.GoVersion) == "" {
+		return fmt.Errorf("hostname, GOOS, GOARCH, and Go version must be recorded")
+	}
+	if host.NumCPU <= 0 || host.GOMAXPROCS <= 0 {
+		return fmt.Errorf("num_cpu=%d and gomaxprocs=%d must both be positive", host.NumCPU, host.GOMAXPROCS)
+	}
+	threshold := float64(host.NumCPU) / 4
+	if threshold < 2 {
+		threshold = 2
+	}
+	for label, raw := range map[string]string{"start": host.LoadavgStart, "end": host.LoadavgEnd} {
+		fields := strings.Fields(raw)
+		if len(fields) == 0 {
+			return fmt.Errorf("loadavg %s must be recorded", label)
+		}
+		load1, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			return fmt.Errorf("loadavg %s %q is invalid: %w", label, raw, err)
+		}
+		if load1 >= threshold {
+			return fmt.Errorf("loadavg %s %.2f meets contention threshold %.2f", label, load1, threshold)
+		}
+	}
+	return nil
+}
+
+func perfScanValidateClassification(classification *perfScanFileClassification) error {
+	if classification == nil {
+		return fmt.Errorf("missing classification")
+	}
+	if strings.TrimSpace(classification.Reason) == "" || strings.TrimSpace(classification.GoStatus) == "" {
+		return fmt.Errorf("reason and go_status must be recorded")
+	}
+	switch classification.Class {
+	case perfScanClassClean:
+		if classification.GoStatus != perfScanStatusOK || !classification.FullSpan || classification.RootHasError || classification.StoppedEarly || classification.StopReason != "" {
+			return fmt.Errorf("clean class contradicts status/span/error/stop facts")
+		}
+	case perfScanClassError:
+		if classification.StoppedEarly || classification.StopReason != "" {
+			return fmt.Errorf("error class contradicts stopped facts")
+		}
+		if perfScanClassificationStatusIsStopped(classification.GoStatus) {
+			return fmt.Errorf("error class uses stopped go_status %q", classification.GoStatus)
+		}
+		if classification.GoStatus == perfScanStatusOK && classification.FullSpan && !classification.RootHasError {
+			return fmt.Errorf("error class has all clean acceptance facts")
+		}
+	case perfScanClassStopped:
+		if !classification.StoppedEarly || classification.StopReason == "" || !perfScanClassificationStatusIsStopped(classification.GoStatus) {
+			return fmt.Errorf("stopped class lacks stopped status and reason facts")
+		}
+	default:
+		return fmt.Errorf("unknown class %q", classification.Class)
+	}
+	return nil
+}
+
+func perfScanClassificationStatusIsStopped(status string) bool {
+	return status == "go_timeout" || status == "go_budget_stop" || status == "go_stopped"
+}
+
+func perfScanRefreshLanguageAggregates(row *perfScanLanguage, cfg perfScanConfig) {
+	row.FilesMeasured = len(row.Files)
+	row.BytesMeasured = 0
+	for _, file := range row.Files {
+		if file == nil {
+			continue
+		}
+		row.BytesMeasured += int64(file.Bytes)
+		for _, result := range file.Axes {
+			if result == nil {
+				continue
+			}
+			result.Ratio = 0
+			result.RatioIsLowerBound = false
+			result.Verdict = perfScanBucketNoData
+			switch {
+			case result.Status == perfScanStatusOK && result.GoMedianNs > 0 && result.CMedianNs > 0:
+				result.Ratio = float64(result.GoMedianNs) / float64(result.CMedianNs)
+				result.Verdict = perfScanVerdictBucket(result.Ratio)
+			case result.Status == "go_timeout" && result.CMedianNs > 0:
+				result.Ratio = float64(time.Duration(cfg.FileBudgetMS)*time.Millisecond) / float64(result.CMedianNs)
+				result.RatioIsLowerBound = true
+				result.Verdict = perfScanVerdictBucket(result.Ratio)
+			}
+		}
+	}
+	row.Axes = map[string]*perfScanLangAxis{}
+	row.FullParseSplit = nil
+	perfScanAggregateLanguage(row, cfg)
+}
+
+func perfScanAggregateFleetCleanErrorSplit(rows []*perfScanLanguage) *perfScanCleanErrorSplit {
+	var files []*perfScanFile
+	for _, row := range rows {
+		if row != nil {
+			files = append(files, row.Files...)
+		}
+	}
+	if len(files) == 0 {
+		return nil
+	}
+	synthetic := &perfScanLanguage{Files: files}
+	perfScanAggregateCleanErrorSplit(synthetic)
+	return synthetic.FullParseSplit
+}
+
+func TestPerfScanReduceScoreboards(t *testing.T) {
+	const (
+		lockPath = "/corpus/corpus_sources.lock"
+		lockSHA  = "cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2"
+		revision = "7b797554397b814f981e9a3fb462b84a3d0f1837"
+	)
+	lockLanguages := []string{"go", "python"}
+	makeInputs := func(t *testing.T, mutate func(goShard, pythonShard *perfScanScoreboard)) []string {
+		t.Helper()
+		goShard := perfScanTestShard("go", lockPath, lockSHA, len(lockLanguages), revision)
+		pythonShard := perfScanTestShard("python", lockPath, lockSHA, len(lockLanguages), revision)
+		if mutate != nil {
+			mutate(goShard, pythonShard)
+		}
+		dir := t.TempDir()
+		return []string{
+			perfScanWriteTestScoreboard(t, dir, "go.json", goShard),
+			perfScanWriteTestScoreboard(t, dir, "python.json", pythonShard),
+		}
+	}
+	reduce := func(paths []string) (*perfScanScoreboard, error) {
+		return perfScanReduceScoreboards(paths, lockPath, lockSHA, lockLanguages, time.Unix(1_752_400_000, 0))
+	}
+
+	t.Run("happy merge recomputes authoritative fleet", func(t *testing.T) {
+		board, err := reduce(makeInputs(t, func(goShard, _ *perfScanScoreboard) {
+			goShard.Summary = map[string]int{perfScanBucketNoData: 99}
+			goShard.Languages[0].Axes[perfScanAxisFull].RatioByTotal = 99
+			goShard.Languages[0].Files[0].Axes[perfScanAxisFull].Ratio = 99
+			goShard.FullParseSplit = nil
+		}))
+		if err != nil {
+			t.Fatalf("reduce: %v", err)
+		}
+		if board.GitRevision != revision || board.Schema != perfScanSchema {
+			t.Fatalf("provenance = schema=%q revision=%q", board.Schema, board.GitRevision)
+		}
+		if !board.Config.RequireFleet || !board.Config.HardGate || !reflect.DeepEqual(board.Config.Languages, lockLanguages) {
+			t.Fatalf("fleet config = %+v", board.Config)
+		}
+		if board.Corpus.SelectedLanguages != len(lockLanguages) || board.Corpus.LockLanguages != len(lockLanguages) {
+			t.Fatalf("coverage = %+v", board.Corpus)
+		}
+		if len(board.Languages) != 2 || board.Languages[0].Language != "go" || board.Languages[1].Language != "python" {
+			t.Fatalf("languages = %+v", board.Languages)
+		}
+		if board.Summary[perfScanBucketLe12] != 2 {
+			t.Fatalf("summary = %+v", board.Summary)
+		}
+		if board.Languages[0].Axes[perfScanAxisFull].RatioByTotal != 1 || board.Languages[0].Files[0].Axes[perfScanAxisFull].Ratio != 1 {
+			t.Fatalf("language aggregates were not recomputed: %+v", board.Languages[0])
+		}
+		if board.FullParseSplit == nil || board.FullParseSplit.ClassifiedFiles != 2 || board.FullParseSplit.Clean.Files != 2 || board.FullParseSplit.Clean.RatioByTotal != 1 {
+			t.Fatalf("fleet split = %+v", board.FullParseSplit)
+		}
+		if board.Gate == nil || board.Gate.Status != perfScanGatePass || board.Gate.FullFilesEvaluated != 2 {
+			t.Fatalf("gate = %+v", board.Gate)
+		}
+		markdown := perfScanRenderMarkdown(board)
+		for _, want := range []string{"git revision", "Fleet full-parse clean/error split", "2/2"} {
+			if !strings.Contains(markdown, want) {
+				t.Fatalf("markdown missing %q:\n%s", want, markdown)
+			}
+		}
+	})
+
+	tests := []struct {
+		name   string
+		paths  func(*testing.T) []string
+		mutate func(*perfScanScoreboard, *perfScanScoreboard)
+		want   string
+	}{
+		{
+			name: "missing language",
+			paths: func(t *testing.T) []string {
+				return makeInputs(t, nil)[:1]
+			},
+			want: "missing shard languages: python",
+		},
+		{
+			name: "duplicate language",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.Languages = []string{"go"}
+				pythonShard.Languages[0].Language = "go"
+			},
+			want: "duplicate shard language",
+		},
+		{
+			name: "schema mismatch",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Schema = "gts-perf-scan/v0"
+			},
+			want: "schema",
+		},
+		{
+			name: "config mismatch",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.Reps++
+			},
+			want: "measurement config differs",
+		},
+		{
+			name: "corpus lock SHA mismatch",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.CorpusLockSHA256 = strings.Repeat("0", 64)
+			},
+			want: "corpus lock SHA mismatch",
+		},
+		{
+			name: "excluded paths",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.ExcludePaths = []string{"generated/**"}
+			},
+			want: "excluded paths",
+		},
+		{
+			name: "contended shard",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.Contended = true
+				pythonShard.Config.ContendedNote = "loadavg 8"
+			},
+			want: "is contended",
+		},
+		{
+			name: "forced contention override",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.ContendedNote = "explicit GTS_PERF_SCAN_CONTENDED=0"
+			},
+			want: "contention override",
+		},
+		{
+			name: "contended end load",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Host.LoadavgEnd = "8.0 1.0 1.0"
+			},
+			want: "contention threshold",
+		},
+		{
+			name: "dirty repository",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.GitClean = false
+			},
+			want: "does not attest a clean",
+		},
+		{
+			name: "mixed host identity",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Host.Hostname = "another-box"
+			},
+			want: "host identity differs",
+		},
+		{
+			name: "mixed revisions",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.GitRevision = strings.Repeat("a", 40)
+			},
+			want: "differs from",
+		},
+		{
+			name: "absent revision",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.GitRevision = ""
+			},
+			want: "git revision",
+		},
+		{
+			name: "incomplete coverage",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Corpus.SelectedLanguages = 0
+			},
+			want: "incomplete corpus coverage",
+		},
+		{
+			name: "incomplete classification coverage",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].Classification = nil
+			},
+			want: "incomplete full-parse classification coverage",
+		},
+		{
+			name: "zero file evidence",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				row := pythonShard.Languages[0]
+				row.FilesSelected = 0
+				row.FilesMeasured = 0
+				row.BytesMeasured = 0
+				row.Files = nil
+			},
+			want: "no selected, measured, and classified file evidence",
+		},
+		{
+			name: "duplicate file path",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				row := pythonShard.Languages[0]
+				row.Files = append(row.Files, row.Files[0])
+				row.FilesSelected = 2
+				row.FilesMeasured = 2
+			},
+			want: "duplicate file path",
+		},
+		{
+			name: "contradictory clean classification",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].Classification.RootHasError = true
+			},
+			want: "clean class contradicts",
+		},
+		{
+			name: "contradictory error classification",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].Classification.Class = perfScanClassError
+			},
+			want: "error class has all clean acceptance facts",
+		},
+		{
+			name: "contradictory stopped classification",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				classification := pythonShard.Languages[0].Files[0].Classification
+				classification.Class = perfScanClassStopped
+				classification.GoStatus = "go_timeout"
+			},
+			want: "stopped class lacks stopped status and reason facts",
+		},
+		{
+			name: "unknown classification",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].Classification.Class = "mystery"
+			},
+			want: "unknown class",
+		},
+		{
+			name: "invalid shard hard gate",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Gate.Status = perfScanGateFail
+			},
+			want: "invalid hard gate",
+		},
+		{
+			name: "multiple language rows",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages = append(pythonShard.Languages, perfScanTestShard("go", lockPath, lockSHA, len(lockLanguages), revision).Languages[0])
+			},
+			want: "exactly one configured language and one language row",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var paths []string
+			if tc.paths != nil {
+				paths = tc.paths(t)
+			} else {
+				paths = makeInputs(t, tc.mutate)
+			}
+			if _, err := reduce(paths); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("reduce error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPerfScanRefreshLanguageAggregatesClearsStaleAxes(t *testing.T) {
+	const revision = "7b797554397b814f981e9a3fb462b84a3d0f1837"
+	board := perfScanTestShard("go", "/corpus.lock", strings.Repeat("a", 64), 1, revision)
+	row := board.Languages[0]
+	row.Files[0].Axes[perfScanAxisNoEdit] = &perfScanFileAxis{
+		Status:            "c_timeout",
+		CMedianNs:         1_000,
+		Ratio:             999,
+		RatioIsLowerBound: true,
+		Verdict:           perfScanBucketCliff,
+	}
+	row.Files[0].Axes[perfScanAxisEdit] = &perfScanFileAxis{
+		Status:            perfScanStatusOK,
+		CMedianNs:         1_000,
+		Ratio:             999,
+		RatioIsLowerBound: true,
+		Verdict:           perfScanBucketCliff,
+	}
+	row.Files[0].Axes["timeout_probe"] = &perfScanFileAxis{
+		Status:            "go_timeout",
+		CMedianNs:         int64(time.Second),
+		Ratio:             999,
+		RatioIsLowerBound: false,
+		Verdict:           perfScanBucketCliff,
+	}
+	cfg := board.Config
+	cfg.FileBudgetMS = 1_000
+	cfg.Axes = []string{perfScanAxisFull, perfScanAxisNoEdit, perfScanAxisEdit, "timeout_probe"}
+	perfScanRefreshLanguageAggregates(row, cfg)
+
+	for _, axis := range []string{perfScanAxisNoEdit, perfScanAxisEdit} {
+		result := row.Files[0].Axes[axis]
+		if result.Ratio != 0 || result.RatioIsLowerBound || result.Verdict != perfScanBucketNoData {
+			t.Fatalf("axis %s retained stale derived fields: %+v", axis, result)
+		}
+	}
+	timeout := row.Files[0].Axes["timeout_probe"]
+	if timeout.Ratio != 1 || !timeout.RatioIsLowerBound || timeout.Verdict != perfScanBucketLe12 {
+		t.Fatalf("timeout lower bound was not recomputed: %+v", timeout)
+	}
+}
+
+func TestPerfScanRepositoryProvenancePolicy(t *testing.T) {
+	revA := strings.Repeat("a", 40)
+	revB := strings.Repeat("b", 40)
+	cleanGit := perfScanVCSCandidate{Revision: revA, Known: true, CleanKnown: true}
+	for _, tc := range []struct {
+		name          string
+		git           perfScanVCSCandidate
+		build         perfScanVCSCandidate
+		override      string
+		assertedClean bool
+		wantErr       string
+	}{
+		{name: "dirty git", git: perfScanVCSCandidate{Revision: revA, Known: true, CleanKnown: true, Modified: true}, wantErr: "dirty or modified"},
+		{name: "modified build", build: perfScanVCSCandidate{Revision: revA, Known: true, CleanKnown: true, Modified: true}, wantErr: "dirty or modified"},
+		{name: "build cleanliness unknown", build: perfScanVCSCandidate{Revision: revA, Known: true}, wantErr: perfScanEnvGitClean},
+		{name: "git build mismatch", git: cleanGit, build: perfScanVCSCandidate{Revision: revB, Known: true, CleanKnown: true}, wantErr: "revisions disagree"},
+		{name: "override cannot replace git", git: cleanGit, override: revB, wantErr: "cannot supersede"},
+		{name: "metadata poor needs clean assertion", override: revA, wantErr: perfScanEnvGitClean},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := perfScanSelectRepositoryProvenance(tc.git, tc.build, tc.override, tc.assertedClean, true)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("provenance error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+	state, err := perfScanSelectRepositoryProvenance(perfScanVCSCandidate{}, perfScanVCSCandidate{}, revA, true, true)
+	if err != nil || state.Revision != revA || !state.Clean {
+		t.Fatalf("explicit metadata-poor provenance = %+v, %v", state, err)
+	}
+	dirty, err := perfScanSelectRepositoryProvenance(
+		perfScanVCSCandidate{Revision: revA, Known: true, CleanKnown: true, Modified: true},
+		perfScanVCSCandidate{}, "", false, false,
+	)
+	if err != nil || dirty.Revision != revA || dirty.Clean {
+		t.Fatalf("dirty exploratory provenance = %+v, %v", dirty, err)
+	}
+}
+
+func TestPerfScanAuthenticateReducer(t *testing.T) {
+	revision := strings.Repeat("a", 40)
+	board := &perfScanScoreboard{GitRevision: revision, GitClean: true}
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: revision, Clean: true}); err != nil {
+		t.Fatalf("matching reducer provenance: %v", err)
+	}
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: strings.Repeat("b", 40), Clean: true}); err == nil || !strings.Contains(err.Error(), "differs from shard") {
+		t.Fatalf("mismatched reducer provenance error = %v", err)
+	}
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: revision, Clean: false}); err == nil || !strings.Contains(err.Error(), "clean repository") {
+		t.Fatalf("dirty reducer provenance error = %v", err)
+	}
+}
+
+func TestPerfScanScoreboardAtomicWrite(t *testing.T) {
+	const revision = "7b797554397b814f981e9a3fb462b84a3d0f1837"
+	board := perfScanTestShard("go", "/corpus.lock", strings.Repeat("a", 64), 1, revision)
+	outDir := t.TempDir()
+	if err := perfScanWriteScoreboard(outDir, board); err != nil {
+		t.Fatalf("write scoreboard: %v", err)
+	}
+	decoded, err := perfScanReadScoreboard(filepath.Join(outDir, "scoreboard.json"))
+	if err != nil {
+		t.Fatalf("read scoreboard: %v", err)
+	}
+	if decoded.GitRevision != revision || !decoded.GitClean || len(decoded.Languages) != 1 {
+		t.Fatalf("round-trip scoreboard = %+v", decoded)
+	}
+	markdown, err := os.ReadFile(filepath.Join(outDir, "scoreboard.md"))
+	if err != nil || !strings.Contains(string(markdown), revision) {
+		t.Fatalf("read markdown = %v; contents=%q", err, markdown)
+	}
+	assertNoTemps := func(dir string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir: %v", err)
+		}
+		for _, entry := range entries {
+			if strings.Contains(entry.Name(), ".tmp-") {
+				t.Fatalf("temporary scoreboard survived: %s", entry.Name())
+			}
+		}
+	}
+	assertNoTemps(outDir)
+
+	failureDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(failureDir, "scoreboard.md"), 0o755); err != nil {
+		t.Fatalf("create rename blocker: %v", err)
+	}
+	if err := perfScanWriteScoreboard(failureDir, board); err == nil {
+		t.Fatal("scoreboard write unexpectedly succeeded through rename blocker")
+	}
+	assertNoTemps(failureDir)
+	if _, err := os.Stat(filepath.Join(failureDir, "scoreboard.json")); !os.IsNotExist(err) {
+		t.Fatalf("JSON commit marker exists after failed publication: %v", err)
+	}
+
+	jsonFailureDir := t.TempDir()
+	renames := 0
+	failJSONRename := func(oldPath, newPath string) error {
+		renames++
+		if renames == 2 {
+			return fmt.Errorf("injected JSON rename failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	if err := perfScanWriteScoreboardWithRename(jsonFailureDir, board, failJSONRename); err == nil || !strings.Contains(err.Error(), "injected JSON") {
+		t.Fatalf("JSON rename failure = %v", err)
+	}
+	assertNoTemps(jsonFailureDir)
+	for _, name := range []string{"scoreboard.md", "scoreboard.json"} {
+		if _, err := os.Stat(filepath.Join(jsonFailureDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s exposed after failed JSON commit: %v", name, err)
+		}
+	}
+
+	rollbackDir := t.TempDir()
+	if err := perfScanWriteScoreboard(rollbackDir, board); err != nil {
+		t.Fatalf("write prior checkpoint: %v", err)
+	}
+	newRevision := strings.Repeat("b", 40)
+	newBoard := perfScanTestShard("go", "/corpus.lock", strings.Repeat("a", 64), 1, newRevision)
+	failJSONCommit := func(oldPath, newPath string) error {
+		if filepath.Base(newPath) == "scoreboard.json" {
+			return fmt.Errorf("injected JSON commit failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	if err := perfScanWriteScoreboardWithRename(rollbackDir, newBoard, failJSONCommit); err == nil {
+		t.Fatal("replacement checkpoint unexpectedly succeeded")
+	}
+	prior, err := perfScanReadScoreboard(filepath.Join(rollbackDir, "scoreboard.json"))
+	if err != nil || prior.GitRevision != revision {
+		t.Fatalf("prior JSON checkpoint was not preserved: %+v, %v", prior, err)
+	}
+	priorMarkdown, err := os.ReadFile(filepath.Join(rollbackDir, "scoreboard.md"))
+	if err != nil || !strings.Contains(string(priorMarkdown), revision) || strings.Contains(string(priorMarkdown), newRevision) {
+		t.Fatalf("prior Markdown checkpoint was not restored: %v %q", err, priorMarkdown)
+	}
+	assertNoTemps(rollbackDir)
+}
+
+func TestPerfScanHardGateRequiresEvidence(t *testing.T) {
+	if report := perfScanEvaluateHardGate(&perfScanScoreboard{}); report.Status != perfScanGateFail || len(report.Failures) == 0 {
+		t.Fatalf("empty scoreboard passed hard gate: %+v", report)
+	}
+	row := &perfScanLanguage{Language: "go", Status: perfScanStatusOK}
+	board := &perfScanScoreboard{
+		Config:    perfScanConfig{RequireFleet: true},
+		Corpus:    perfScanCorpusCoverage{LockLanguages: 1, SelectedLanguages: 1},
+		Languages: []*perfScanLanguage{row},
+	}
+	if report := perfScanEvaluateHardGate(board); report.Status != perfScanGateFail || report.FullFilesEvaluated != 0 {
+		t.Fatalf("zero-file language passed hard gate: %+v", report)
+	}
+}
+
+func perfScanTestShard(lang, lockPath, lockSHA string, lockLanguages int, revision string) *perfScanScoreboard {
+	full := &perfScanFileAxis{
+		Status:     perfScanStatusOK,
+		GoMedianNs: 1_000,
+		CMedianNs:  1_000,
+		Ratio:      1,
+		Verdict:    perfScanBucketLe12,
+	}
+	row := &perfScanLanguage{
+		Language:      lang,
+		Status:        perfScanStatusOK,
+		FilesSelected: 1,
+		FilesMeasured: 1,
+		BytesMeasured: 64,
+		Axes:          map[string]*perfScanLangAxis{},
+		Files: []*perfScanFile{{
+			Path:  "fixture." + lang,
+			Bytes: 64,
+			Classification: &perfScanFileClassification{
+				Class:    perfScanClassClean,
+				Reason:   "accepted full-span tree without ERROR nodes",
+				GoStatus: perfScanStatusOK,
+				FullSpan: true,
+			},
+			Axes: map[string]*perfScanFileAxis{perfScanAxisFull: full},
+		}},
+	}
+	cfg := perfScanConfig{
+		CorpusRoot:          "/corpus/corpus_sources",
+		Reps:                5,
+		Warmup:              1,
+		FileBudgetMS:        10_000,
+		LangTimeoutMS:       600_000,
+		MaxFiles:            8,
+		MaxFileBytes:        4 << 20,
+		Order:               "largest",
+		Axes:                []string{perfScanAxisFull},
+		HardGate:            true,
+		RequireFleet:        false,
+		CorpusLock:          lockPath,
+		CorpusLockSHA256:    lockSHA,
+		CorpusLockLanguages: lockLanguages,
+		Languages:           []string{lang},
+	}
+	perfScanAggregateLanguage(row, cfg)
+	board := &perfScanScoreboard{
+		Schema:      perfScanSchema,
+		GeneratedAt: time.Unix(1_752_300_000, 0).UTC().Format(time.RFC3339),
+		GitRevision: revision,
+		GitClean:    true,
+		Host: perfScanHost{
+			Hostname:     "quiet-box",
+			GOOS:         "linux",
+			GOARCH:       "amd64",
+			NumCPU:       16,
+			GOMAXPROCS:   1,
+			GoVersion:    "go1.test",
+			LoadavgStart: "0.10 0.10 0.10",
+			LoadavgEnd:   "0.20 0.10 0.10",
+		},
+		Config:    cfg,
+		Summary:   map[string]int{row.Verdict: 1},
+		Languages: []*perfScanLanguage{row},
+		Corpus: perfScanCorpusCoverage{
+			LockPath:          lockPath,
+			LockSHA256:        lockSHA,
+			LockLanguages:     lockLanguages,
+			SelectedLanguages: 1,
+		},
+	}
+	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
+	gate := perfScanEvaluateHardGate(board)
+	board.Gate = &gate
+	return board
+}
+
+func perfScanWriteTestScoreboard(t *testing.T, dir, name string, board *perfScanScoreboard) string {
+	t.Helper()
+	data, err := json.MarshalIndent(board, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal shard: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write shard: %v", err)
+	}
+	return path
+}

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -40,6 +40,7 @@ package cgoharness
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -47,6 +48,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -84,6 +86,8 @@ const (
 	perfScanEnvHardGate     = "GTS_PERF_SCAN_HARD_GATE"
 	perfScanEnvRequireFleet = "GTS_PERF_SCAN_REQUIRE_FLEET"
 	perfScanEnvCorpusLock   = "GTS_REAL_CORPUS_BENCH_LOCK"
+	perfScanEnvRevision     = "GTS_PERF_SCAN_GIT_REVISION"
+	perfScanEnvGitClean     = "GTS_PERF_SCAN_GIT_CLEAN"
 
 	perfScanAxisFull   = "full"
 	perfScanAxisNoEdit = "noedit"
@@ -139,6 +143,7 @@ type perfScanConfig struct {
 	CorpusLock          string   `json:"corpus_lock,omitempty"`
 	CorpusLockSHA256    string   `json:"corpus_lock_sha256,omitempty"`
 	CorpusLockLanguages int      `json:"corpus_lock_languages,omitempty"`
+	Languages           []string `json:"languages,omitempty"`
 }
 
 type perfScanHost struct {
@@ -146,6 +151,7 @@ type perfScanHost struct {
 	GOOS         string `json:"goos"`
 	GOARCH       string `json:"goarch"`
 	NumCPU       int    `json:"num_cpu"`
+	GOMAXPROCS   int    `json:"gomaxprocs"`
 	GoVersion    string `json:"go_version"`
 	LoadavgStart string `json:"loadavg_start,omitempty"`
 	LoadavgEnd   string `json:"loadavg_end,omitempty"`
@@ -288,15 +294,18 @@ type perfScanGateReport struct {
 }
 
 type perfScanScoreboard struct {
-	Schema      string                 `json:"schema"`
-	GeneratedAt string                 `json:"generated_at"`
-	Host        perfScanHost           `json:"host"`
-	Config      perfScanConfig         `json:"config"`
-	Notes       []string               `json:"notes,omitempty"`
-	Summary     map[string]int         `json:"summary_verdicts"`
-	Languages   []*perfScanLanguage    `json:"languages"`
-	Corpus      perfScanCorpusCoverage `json:"corpus_coverage"`
-	Gate        *perfScanGateReport    `json:"hard_gate,omitempty"`
+	Schema         string                   `json:"schema"`
+	GeneratedAt    string                   `json:"generated_at"`
+	GitRevision    string                   `json:"git_revision,omitempty"`
+	GitClean       bool                     `json:"git_clean"`
+	Host           perfScanHost             `json:"host"`
+	Config         perfScanConfig           `json:"config"`
+	Notes          []string                 `json:"notes,omitempty"`
+	Summary        map[string]int           `json:"summary_verdicts"`
+	Languages      []*perfScanLanguage      `json:"languages"`
+	FullParseSplit *perfScanCleanErrorSplit `json:"full_parse_split,omitempty"`
+	Corpus         perfScanCorpusCoverage   `json:"corpus_coverage"`
+	Gate           *perfScanGateReport      `json:"hard_gate,omitempty"`
 }
 
 func perfScanGateEnabled() bool {
@@ -333,6 +342,7 @@ func perfScanLoadConfig() perfScanConfig {
 		HardGate:      parityEnvBool(perfScanEnvHardGate, true),
 		RequireFleet:  parityEnvBool(perfScanEnvRequireFleet, requireFleetDefault),
 		CorpusLock:    strings.TrimSpace(os.Getenv(perfScanEnvCorpusLock)),
+		Languages:     perfScanLanguageList(os.Getenv(perfScanEnvLangs)),
 	}
 	if cfg.Reps < 1 {
 		cfg.Reps = 1
@@ -342,6 +352,159 @@ func perfScanLoadConfig() perfScanConfig {
 	}
 	cfg.Contended, cfg.ContendedNote = perfScanContended()
 	return cfg
+}
+
+func perfScanLanguageList(raw string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+type perfScanVCSCandidate struct {
+	Revision   string
+	Known      bool
+	CleanKnown bool
+	Modified   bool
+}
+
+type perfScanRepositoryState struct {
+	Revision string
+	Clean    bool
+}
+
+func perfScanRepositoryProvenance(requireClean bool) (perfScanRepositoryState, error) {
+	git, err := perfScanGitCandidate()
+	if err != nil {
+		return perfScanRepositoryState{}, err
+	}
+	build := perfScanBuildCandidate()
+	return perfScanSelectRepositoryProvenance(
+		git,
+		build,
+		strings.TrimSpace(os.Getenv(perfScanEnvRevision)),
+		parityEnvBool(perfScanEnvGitClean, false),
+		requireClean,
+	)
+}
+
+func perfScanGitCandidate() (perfScanVCSCandidate, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
+	data, err := cmd.Output()
+	if err != nil {
+		return perfScanVCSCandidate{}, nil
+	}
+	revision, err := perfScanNormalizeRevision(string(data))
+	if err != nil {
+		return perfScanVCSCandidate{}, fmt.Errorf("git HEAD: %w", err)
+	}
+	status, err := exec.Command("git", "status", "--porcelain=v1", "--untracked-files=all").Output()
+	if err != nil {
+		return perfScanVCSCandidate{}, fmt.Errorf("inspect git worktree: %w", err)
+	}
+	return perfScanVCSCandidate{Revision: revision, Known: true, CleanKnown: true, Modified: strings.TrimSpace(string(status)) != ""}, nil
+}
+
+func perfScanBuildCandidate() perfScanVCSCandidate {
+	var candidate perfScanVCSCandidate
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				candidate.Revision = strings.TrimSpace(setting.Value)
+				candidate.Known = candidate.Revision != ""
+			case "vcs.modified":
+				value := strings.TrimSpace(setting.Value)
+				candidate.CleanKnown = strings.EqualFold(value, "true") || strings.EqualFold(value, "false")
+				candidate.Modified = strings.EqualFold(value, "true")
+			}
+		}
+	}
+	return candidate
+}
+
+func perfScanSelectRepositoryProvenance(git, build perfScanVCSCandidate, override string, assertedClean, requireClean bool) (perfScanRepositoryState, error) {
+	override = strings.TrimSpace(override)
+	validateOverride := func(revision string) error {
+		if override == "" {
+			return nil
+		}
+		normalized, err := perfScanNormalizeRevision(override)
+		if err != nil {
+			return fmt.Errorf("%s: %w", perfScanEnvRevision, err)
+		}
+		if normalized != revision {
+			return fmt.Errorf("%s=%s cannot supersede discovered repository revision %s", perfScanEnvRevision, normalized, revision)
+		}
+		return nil
+	}
+	var discoveredRevision string
+	clean := true
+	for _, source := range []struct {
+		name      string
+		candidate perfScanVCSCandidate
+	}{{"git", git}, {"Go build", build}} {
+		if !source.candidate.Known {
+			continue
+		}
+		revision, err := perfScanNormalizeRevision(source.candidate.Revision)
+		if err != nil {
+			return perfScanRepositoryState{}, fmt.Errorf("%s repository revision: %w", source.name, err)
+		}
+		if source.candidate.Modified {
+			clean = false
+			if requireClean {
+				return perfScanRepositoryState{}, fmt.Errorf("%s reports a dirty or modified repository; authoritative scoreboards require tracked and untracked cleanliness", source.name)
+			}
+		}
+		if !source.candidate.CleanKnown && !assertedClean {
+			clean = false
+			if requireClean {
+				return perfScanRepositoryState{}, fmt.Errorf("%s does not report repository cleanliness; explicit %s=1 is required", source.name, perfScanEnvGitClean)
+			}
+		}
+		if discoveredRevision == "" {
+			discoveredRevision = revision
+		} else if discoveredRevision != revision {
+			return perfScanRepositoryState{}, fmt.Errorf("Git and Go build repository revisions disagree: %s != %s", discoveredRevision, revision)
+		}
+	}
+	if discoveredRevision != "" {
+		if err := validateOverride(discoveredRevision); err != nil {
+			return perfScanRepositoryState{}, err
+		}
+		return perfScanRepositoryState{Revision: discoveredRevision, Clean: clean}, nil
+	}
+	if override == "" {
+		return perfScanRepositoryState{}, fmt.Errorf("determine repository revision (set %s and %s=1 only when git and Go VCS metadata are unavailable)", perfScanEnvRevision, perfScanEnvGitClean)
+	}
+	revision, err := perfScanNormalizeRevision(override)
+	if err != nil {
+		return perfScanRepositoryState{}, fmt.Errorf("%s: %w", perfScanEnvRevision, err)
+	}
+	if !assertedClean && requireClean {
+		return perfScanRepositoryState{}, fmt.Errorf("metadata-poor revision override requires explicit %s=1", perfScanEnvGitClean)
+	}
+	return perfScanRepositoryState{Revision: revision, Clean: assertedClean}, nil
+}
+
+func perfScanNormalizeRevision(raw string) (string, error) {
+	revision := strings.ToLower(strings.TrimSpace(raw))
+	if len(revision) != 40 && len(revision) != 64 {
+		return "", fmt.Errorf("repository revision %q must be a full 40- or 64-hex object ID", raw)
+	}
+	if _, err := hex.DecodeString(revision); err != nil {
+		return "", fmt.Errorf("repository revision %q is not hexadecimal: %w", raw, err)
+	}
+	return revision, nil
 }
 
 func perfScanAxes() []string {
@@ -641,6 +804,9 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 		addFailure(perfScanGateFinding{Kind: "coverage", Detail: "nil scoreboard"})
 		return report
 	}
+	if len(board.Languages) == 0 {
+		addFailure(perfScanGateFinding{Kind: "coverage", Status: "no_evidence", Detail: "scoreboard contains no language rows"})
+	}
 	for _, lang := range board.Corpus.MissingFromLock {
 		addFailure(perfScanGateFinding{Kind: "coverage", Language: lang, Detail: "language missing from authenticated corpus lock"})
 	}
@@ -665,6 +831,9 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 		if row == nil {
 			addFailure(perfScanGateFinding{Kind: "coverage", Detail: "nil language row"})
 			continue
+		}
+		if row.FilesSelected <= 0 || row.FilesMeasured <= 0 || len(row.Files) <= 0 {
+			addFailure(perfScanGateFinding{Kind: "coverage", Language: row.Language, Status: "no_evidence", Detail: "language has no selected and measured file evidence"})
 		}
 		report.FilesExpected += row.FilesSelected
 		report.FilesMeasured += row.FilesMeasured
@@ -727,6 +896,9 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 				report.FastFullFiles = append(report.FastFullFiles, finding)
 			}
 		}
+	}
+	if report.FullFilesEvaluated == 0 {
+		addFailure(perfScanGateFinding{Kind: "coverage", Status: "no_evidence", Detail: "scoreboard contains no evaluated full-parse file ratios"})
 	}
 	return report
 }
@@ -1845,6 +2017,10 @@ func TestPerfScanSweep(t *testing.T) {
 		t.Skipf("%s is set; refusing to sweep inside a child invocation", perfScanEnvLang)
 	}
 	cfg := perfScanLoadConfig()
+	provenance, err := perfScanRepositoryProvenance(cfg.HardGate)
+	if err != nil {
+		t.Fatalf("repository provenance: %v", err)
+	}
 	lockEntries, corpusCoverage, err := perfScanPrepareCorpusLock(&cfg)
 	if err != nil {
 		t.Fatalf("prepare authenticated corpus lock: %v", err)
@@ -1876,6 +2052,8 @@ func TestPerfScanSweep(t *testing.T) {
 	board := &perfScanScoreboard{
 		Schema:      perfScanSchema,
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		GitRevision: provenance.Revision,
+		GitClean:    provenance.Clean,
 		Config:      cfg,
 		Corpus:      corpusCoverage,
 		Summary:     map[string]int{},
@@ -1884,6 +2062,7 @@ func TestPerfScanSweep(t *testing.T) {
 			GOOS:         runtime.GOOS,
 			GOARCH:       runtime.GOARCH,
 			NumCPU:       runtime.NumCPU(),
+			GOMAXPROCS:   runtime.GOMAXPROCS(0),
 			GoVersion:    runtime.Version(),
 			LoadavgStart: perfScanReadLoadavg(),
 		},
@@ -1906,7 +2085,17 @@ func TestPerfScanSweep(t *testing.T) {
 		t.Logf("  %-14s status=%-14s verdict=%-9s files=%d/%d elapsed=%dms %s",
 			lang, row.Status, row.Verdict, row.FilesMeasured, row.FilesSelected, row.ElapsedMS, row.Detail)
 	}
+	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
 	board.Host.LoadavgEnd = perfScanReadLoadavg()
+	if contended, note := perfScanContended(); contended {
+		board.Config.Contended = true
+		if board.Config.ContendedNote == "" {
+			board.Config.ContendedNote = "end of run: " + note
+		} else {
+			board.Config.ContendedNote += "; end of run: " + note
+		}
+		board.Notes = append(board.Notes, "CONTENDED END OF RUN — measurements are not authoritative ("+note+").")
+	}
 	gate := perfScanEvaluateHardGate(board)
 	board.Gate = &gate
 
@@ -1922,18 +2111,8 @@ func TestPerfScanSweep(t *testing.T) {
 }
 
 func perfScanSweepLanguages(t *testing.T, cfg perfScanConfig, lockEntries map[string]realCorpusBenchmarkLockEntry) []string {
-	if raw := strings.TrimSpace(os.Getenv(perfScanEnvLangs)); raw != "" {
-		seen := map[string]bool{}
-		var out []string
-		for _, part := range strings.Split(raw, ",") {
-			name := strings.TrimSpace(part)
-			if name != "" && !seen[name] {
-				seen[name] = true
-				out = append(out, name)
-			}
-		}
-		sort.Strings(out)
-		return out
+	if len(cfg.Languages) > 0 {
+		return append([]string(nil), cfg.Languages...)
 	}
 	if cfg.RequireFleet && len(lockEntries) > 0 {
 		out := make([]string, 0, len(lockEntries))
@@ -2280,14 +2459,118 @@ func perfScanHostname() string {
 // ---------------------------------------------------------------------------
 
 func perfScanWriteScoreboard(outDir string, board *perfScanScoreboard) error {
+	return perfScanWriteScoreboardWithRename(outDir, board, os.Rename)
+}
+
+func perfScanWriteScoreboardWithRename(outDir string, board *perfScanScoreboard, rename func(string, string) error) error {
 	data, err := json.MarshalIndent(board, "", "  ")
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(outDir, "scoreboard.json"), append(data, '\n'), 0o644); err != nil {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(outDir, "scoreboard.md"), []byte(perfScanRenderMarkdown(board)), 0o644)
+	markdownTemp, err := perfScanStageScoreboardFile(outDir, "scoreboard.md", []byte(perfScanRenderMarkdown(board)))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(markdownTemp)
+	jsonTemp, err := perfScanStageScoreboardFile(outDir, "scoreboard.json", append(data, '\n'))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(jsonTemp)
+
+	markdownPath := filepath.Join(outDir, "scoreboard.md")
+	jsonPath := filepath.Join(outDir, "scoreboard.json")
+	var markdownBackup string
+	if info, statErr := os.Stat(markdownPath); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("existing %s is not a regular file", markdownPath)
+		}
+		backup, createErr := os.CreateTemp(outDir, ".scoreboard.md.backup-")
+		if createErr != nil {
+			return createErr
+		}
+		markdownBackup = backup.Name()
+		if closeErr := backup.Close(); closeErr != nil {
+			_ = os.Remove(markdownBackup)
+			return closeErr
+		}
+		if removeErr := os.Remove(markdownBackup); removeErr != nil {
+			return removeErr
+		}
+		if err := rename(markdownPath, markdownBackup); err != nil {
+			return err
+		}
+		defer os.Remove(markdownBackup)
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+	restoreMarkdown := func() error {
+		_ = os.Remove(markdownPath)
+		if markdownBackup != "" {
+			return rename(markdownBackup, markdownPath)
+		}
+		return nil
+	}
+
+	// Publish Markdown first and JSON last. scoreboard.json is the commit
+	// marker; if that final rename fails, roll Markdown back before returning.
+	if err := rename(markdownTemp, markdownPath); err != nil {
+		if restoreErr := restoreMarkdown(); restoreErr != nil {
+			return fmt.Errorf("publish markdown: %v (restore: %v)", err, restoreErr)
+		}
+		return err
+	}
+	if err := rename(jsonTemp, jsonPath); err != nil {
+		if restoreErr := restoreMarkdown(); restoreErr != nil {
+			return fmt.Errorf("publish JSON: %v (restore markdown: %v)", err, restoreErr)
+		}
+		return err
+	}
+	if markdownBackup != "" {
+		_ = os.Remove(markdownBackup)
+		markdownBackup = ""
+	}
+	dir, err := os.Open(outDir)
+	if err != nil {
+		return err
+	}
+	syncErr := dir.Sync()
+	closeErr := dir.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+func perfScanStageScoreboardFile(outDir, name string, data []byte) (tempPath string, err error) {
+	file, err := os.CreateTemp(outDir, "."+name+".tmp-")
+	if err != nil {
+		return "", err
+	}
+	tempPath = file.Name()
+	cleanupPath := tempPath
+	defer func() {
+		if err != nil {
+			_ = file.Close()
+			_ = os.Remove(cleanupPath)
+		}
+	}()
+	if err = file.Chmod(0o644); err != nil {
+		return "", err
+	}
+	if _, err = file.Write(data); err != nil {
+		return "", err
+	}
+	if err = file.Sync(); err != nil {
+		return "", err
+	}
+	if err = file.Close(); err != nil {
+		return "", err
+	}
+	return tempPath, nil
 }
 
 func perfScanFmtNs(ns int64) string {
@@ -2388,8 +2671,12 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# Go-vs-C real-corpus perf scoreboard\n\n")
 	fmt.Fprintf(&b, "- schema: `%s` generated: %s\n", board.Schema, board.GeneratedAt)
-	fmt.Fprintf(&b, "- host: %s %s/%s cpus=%d %s\n",
-		board.Host.Hostname, board.Host.GOOS, board.Host.GOARCH, board.Host.NumCPU, board.Host.GoVersion)
+	if board.GitRevision != "" {
+		fmt.Fprintf(&b, "- git revision: `%s`\n", board.GitRevision)
+		fmt.Fprintf(&b, "- git worktree clean: `%t`\n", board.GitClean)
+	}
+	fmt.Fprintf(&b, "- host: %s %s/%s cpus=%d gomaxprocs=%d %s\n",
+		board.Host.Hostname, board.Host.GOOS, board.Host.GOARCH, board.Host.NumCPU, board.Host.GOMAXPROCS, board.Host.GoVersion)
 	fmt.Fprintf(&b, "- loadavg start `%s` end `%s`\n", board.Host.LoadavgStart, board.Host.LoadavgEnd)
 	fmt.Fprintf(&b, "- corpus: `%s` order=%s max_files=%d reps=%d warmup=%d file_budget=%dms axes=%s\n",
 		board.Config.CorpusRoot, board.Config.Order, board.Config.MaxFiles,
@@ -2439,6 +2726,18 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 				fmt.Fprintf(&b, "- **%s** `%s` ratio=%.4fx — %s\n", finding.Language, finding.Path, finding.Ratio, finding.Detail)
 			}
 		}
+	}
+
+	if split := board.FullParseSplit; split != nil {
+		fmt.Fprintf(&b, "\n## Fleet full-parse clean/error split\n\n")
+		fmt.Fprintf(&b, "- classified files: `%d`; stopped subset: `%d`; error share: `%s`\n",
+			split.ClassifiedFiles, split.StoppedFiles, perfScanFmtShare(split.ErrorShare))
+		fmt.Fprintf(&b, "- clean: `%d/%d` timed, Go `%s`, C `%s`, ratio `%s`\n",
+			split.Clean.FilesOK, split.Clean.Files, perfScanFmtNs(split.Clean.GoTotalNs),
+			perfScanFmtNs(split.Clean.CTotalNs), perfScanFmtClassRatio(split.Clean))
+		fmt.Fprintf(&b, "- error/non-clean: `%d/%d` timed, Go `%s`, C `%s`, ratio `%s`\n",
+			split.Error.FilesOK, split.Error.Files, perfScanFmtNs(split.Error.GoTotalNs),
+			perfScanFmtNs(split.Error.CTotalNs), perfScanFmtClassRatio(split.Error))
 	}
 
 	fmt.Fprintf(&b, "\n## Per-language scoreboard\n\n")


### PR DESCRIPTION
## Summary

- record clean repository and runtime provenance in perf-scan scoreboards
- reduce one-language checkpoints into one authenticated fleet artifact without rerunning parsers
- require identical revision, host, runtime, config, lock, coverage, classification, and gate evidence
- recompute language/fleet aggregates and publish checkpoint-safe JSON and Markdown

## Validation

- adversarial reducer, provenance, host, classification, aggregation, atomic-write, and no-evidence cases (20x)
- perf-scan budget/status command tests
- focused Docker suite (20x)
- Canopy changed-code gate
- two Sol scrutiny passes; no P0/P1 findings