### PR TITLE
test(cgo_harness): preserve failing fleet reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- The authenticated performance-shard reducer now distinguishes reporting from
+  certification. `report` mode publishes a recomputed PASS or FAIL fleet board
+  without turning valid failure evidence into a reducer error; the default
+  `certify` mode publishes the same artifact before blocking on a combined
+  FAIL. Exact stored shard gates may be PASS or FAIL, while missing, stale, or
+  malformed evidence still fails closed.
+- The Docker parity wrapper accepts a fixed `--hostname` and records it in run
+  metadata so one-language containers on the same physical benchmark host can
+  produce a consistent authenticated host identity.
+
 ## [0.30.0] - 2026-07-12
 
 Recurring-parser performance and fleet-measurement integrity release. Reused

--- a/cgo_harness/docker/run_parity_in_docker.sh
+++ b/cgo_harness/docker/run_parity_in_docker.sh
@@ -9,6 +9,7 @@ LABEL=""
 IMAGE_TAG="gotreesitter/cgo-harness:go1.25-local"
 MEMORY_LIMIT="8g"
 CPUS_LIMIT="4"
+CONTAINER_HOSTNAME=""
 # CPUSET_CPUS pins the container to a specific set of physical CPUs via
 # docker's --cpuset-cpus. Pinning matters more than CFS quota for benchmark
 # stability — without it, the kernel scheduler can move the container
@@ -47,6 +48,9 @@ Options:
   --label <name>         Optional run label (used in container/artifact naming)
   --memory <limit>       Container memory limit (default: 8g)
   --cpus <count>         CPU limit passed to Docker (default: 4)
+  --hostname <name>      Fixed container hostname recorded by benchmark shards.
+                         Use one stable name per physical host when a campaign
+                         runs one language per container.
   --cpuset-cpus <list>   Pin container to specific CPUs via --cpuset-cpus
                          (e.g. "18" or "16-19"). Empty = no pinning, but
                          benchmark stability suffers — use this for any
@@ -123,6 +127,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --cpus)
       CPUS_LIMIT="$2"
+      shift 2
+      ;;
+    --hostname)
+      CONTAINER_HOSTNAME="$2"
       shift 2
       ;;
     --cpuset-cpus)
@@ -349,6 +357,11 @@ if [[ -n "$CPUSET_CPUS" ]]; then
   CPUSET_ARGS+=(--cpuset-cpus "$CPUSET_CPUS")
 fi
 
+HOSTNAME_ARGS=()
+if [[ -n "$CONTAINER_HOSTNAME" ]]; then
+  HOSTNAME_ARGS+=(--hostname "$CONTAINER_HOSTNAME")
+fi
+
 RUN_START_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 RUN_START_NS="$(date +%s%N)"
 
@@ -388,6 +401,7 @@ CID="$(docker create \
   --memory-swap "$MEMORY_LIMIT" \
   --cpus "$CPUS_LIMIT" \
   "${CPUSET_ARGS[@]}" \
+  "${HOSTNAME_ARGS[@]}" \
   --pids-limit "$PIDS_LIMIT" \
   --mount "type=bind,src=$REPO_ROOT,dst=/workspace" \
   "${EXTRA_MOUNT_ARGS[@]}" \
@@ -414,6 +428,7 @@ STATE_ERROR="$(docker inspect -f '{{.State.Error}}' "$CID")"
   echo "memory=$MEMORY_LIMIT"
   echo "cpus=$CPUS_LIMIT"
   echo "cpuset_cpus=$CPUSET_CPUS"
+  echo "hostname=$CONTAINER_HOSTNAME"
   echo "pids=$PIDS_LIMIT"
   echo "gomemlimit=$GOMEMLIMIT_VALUE"
   echo "goflags=$GOFLAGS_VALUE"

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -120,7 +120,7 @@ GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
       -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 .
 ```
 
-### Resumable one-language shards and blocking reduction
+### Resumable one-language shards and authenticated reduction
 
 Long fleet refreshes can run as independent one-language scoreboards. Keep the
 measurement knobs identical, set `GTS_PERF_SCAN_REQUIRE_FLEET=0`, and give each
@@ -143,26 +143,40 @@ GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
 Repeat for every language in the authenticated lock. Completed shard
 scoreboards are durable checkpoints; the reducer reads them without invoking a
 parser, so an interrupted campaign resumes from the missing languages rather
-than restarting the fleet. Once every shard exists, run the blocking reducer:
+than restarting the fleet. When each shard runs in its own Docker container,
+pass the same `--hostname` value to `run_parity_in_docker.sh` for every
+container on one physical host (for example `--hostname gts-perf-quiet-01`).
+Container-generated hostnames are unique and therefore cannot authenticate as
+one measurement host. Once every shard exists, run the reducer:
+
+A shard with a measured hard-gate FAIL writes its scoreboard and then returns
+nonzero. The campaign coordinator must validate and retain that scoreboard,
+record the failed gate, and continue with the next language; do not let a bare
+`set -e` stop the fleet at its first valid cliff. Process crashes or missing,
+stale, or unauthenticated scoreboards remain retry conditions.
 
 ```sh
 cd cgo_harness
 GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
   GTS_REAL_CORPUS_BENCH_LOCK=/home/draco/work/gotreesitter-corpora/corpus_sources.lock \
   GTS_PERF_SCAN_REDUCE_INPUTS='perf_scan/out/shards/*/scoreboard.json' \
+  GTS_PERF_SCAN_REDUCE_MODE=report \
   GTS_PERF_SCAN_OUT=perf_scan/out/authoritative_reduced \
   go test -tags "treesitter_c_parity treesitter_c_perfscan" \
   -run '^TestPerfScanReduce$' -v -count=1 -timeout 0 .
 ```
 
-Reduction succeeds only with exactly one scoreboard for every locked language.
-It rejects missing or duplicate languages, schema or measurement-config drift,
+Reduction requires exactly one scoreboard for every locked language. It
+rejects missing or duplicate languages, schema or measurement-config drift,
 corpus-lock drift, path exclusions, contended runs, mixed or absent repository
-revisions, dirty source trees, mixed host/runtime identities, incomplete or
-contradictory file evidence, and absent, stale, or failed shard hard gates. A
-host identity includes hostname, GOOS/GOARCH, CPU count, `GOMAXPROCS`, and Go
-version; both start and end load averages must remain below the contention
-threshold. The
+revisions, dirty source trees, mixed host/runtime identities, contradictory or
+malformed file classifications, and absent or stale shard hard gates. A stored
+shard gate may be either PASS or FAIL, but it must exactly equal the gate
+recomputed from that shard's evidence. Ratio cliffs, parser stops, missing
+ratios, and partial or zero file coverage are valid failure evidence and remain
+visible in the combined FAIL board. A host identity includes hostname,
+GOOS/GOARCH, CPU count, `GOMAXPROCS`, and Go version; both start and end load
+averages must remain below the contention threshold. The
 only permitted per-shard config differences are the one-element `languages`
 selection and `require_fleet=false`; the combined config is rewritten to the
 full lock language list with `require_fleet=true`. The reducer recomputes every
@@ -171,6 +185,12 @@ and the full hard gate before writing authoritative JSON and Markdown. The
 reducer execution is authenticated independently: its checkout/build must be
 clean and at the same revision recorded by every shard, so one runtime version
 cannot silently reinterpret another version's evidence.
+
+`GTS_PERF_SCAN_REDUCE_MODE=report` writes the recomputed PASS or FAIL board and
+returns success after evidence authentication. `certify` is the default; it
+writes the identical board, then fails the test when the combined hard gate is
+FAIL and reports the artifact path and finding count. An unknown mode fails
+before any scoreboard is published.
 
 New scoreboards record the full repository revision and clean-source attestation.
 Revisionless v1 JSON still decodes for existing readers, but is deliberately
@@ -209,6 +229,7 @@ the corpus builder deliberately supplies nested dependency checkouts and
 | `GTS_PERF_SCAN_LANG` | — | single language (child mode; set by the sweep) |
 | `GTS_PERF_SCAN_OUT` | `perf_scan/out/scan_<UTC>` | output dir |
 | `GTS_PERF_SCAN_REDUCE_INPUTS` | — | reducer-only comma list of scoreboard paths/globs; requires exactly one authenticated shard per lock language |
+| `GTS_PERF_SCAN_REDUCE_MODE` | `certify` | `report` always publishes and returns success for authenticated PASS/FAIL evidence; `certify` publishes the same board and then blocks on combined FAIL |
 | `GTS_PERF_SCAN_GIT_REVISION` | auto-discovered | full repository object ID override for metadata-poor build environments |
 | `GTS_PERF_SCAN_GIT_CLEAN` | — | explicit clean-source attestation required with a metadata-poor revision override |
 | `GTS_PERF_SCAN_CORPUS_ROOT` | `corpus_real` | corpus root (per-language subdirs) |

--- a/cgo_harness/zz_perf_scan_reduce_test.go
+++ b/cgo_harness/zz_perf_scan_reduce_test.go
@@ -20,7 +20,13 @@ import (
 	"time"
 )
 
-const perfScanEnvReduceInputs = "GTS_PERF_SCAN_REDUCE_INPUTS"
+const (
+	perfScanEnvReduceInputs = "GTS_PERF_SCAN_REDUCE_INPUTS"
+	perfScanEnvReduceMode   = "GTS_PERF_SCAN_REDUCE_MODE"
+
+	perfScanReduceModeReport  = "report"
+	perfScanReduceModeCertify = "certify"
+)
 
 // TestPerfScanReduce authenticates and merges one completed scoreboard for
 // every language in the corpus lock. It never invokes a parser, so interrupted
@@ -32,6 +38,10 @@ func TestPerfScanReduce(t *testing.T) {
 	}
 	if strings.TrimSpace(os.Getenv(perfScanEnvLang)) != "" {
 		t.Fatalf("%s is set; refusing to reduce inside a language child", perfScanEnvLang)
+	}
+	reduceMode, err := perfScanResolveReduceMode(os.Getenv(perfScanEnvReduceMode))
+	if err != nil {
+		t.Fatal(err)
 	}
 	paths, err := perfScanReduceInputPaths(os.Getenv(perfScanEnvReduceInputs))
 	if err != nil {
@@ -75,15 +85,52 @@ func TestPerfScanReduce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve output directory: %v", err)
 	}
-	if err := os.MkdirAll(absOut, 0o755); err != nil {
-		t.Fatalf("create output directory: %v", err)
-	}
-	if err := perfScanWriteScoreboard(absOut, board); err != nil {
-		t.Fatalf("write reduced scoreboard: %v", err)
+	if err := perfScanPublishReducedScoreboard(absOut, board, reduceMode); err != nil {
+		t.Fatal(err)
 	}
 	t.Logf("reduced %d authenticated shard scoreboards at %s", len(board.Languages), board.GitRevision)
+	t.Logf("reducer mode: %s; hard gate: %s", reduceMode, strings.ToUpper(board.Gate.Status))
 	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.json"))
 	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.md"))
+}
+
+func perfScanResolveReduceMode(raw string) (string, error) {
+	mode := strings.TrimSpace(raw)
+	if mode == "" {
+		return perfScanReduceModeCertify, nil
+	}
+	switch mode {
+	case perfScanReduceModeReport, perfScanReduceModeCertify:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("%s must be %q or %q, got %q", perfScanEnvReduceMode, perfScanReduceModeReport, perfScanReduceModeCertify, raw)
+	}
+}
+
+// perfScanPublishReducedScoreboard publishes the exact same recomputed board
+// in both reducer modes. Report mode preserves a failing gate as evidence;
+// certify mode publishes that evidence first and then returns a blocking error.
+func perfScanPublishReducedScoreboard(absOut string, board *perfScanScoreboard, mode string) error {
+	if mode != perfScanReduceModeReport && mode != perfScanReduceModeCertify {
+		return fmt.Errorf("invalid resolved reducer mode %q", mode)
+	}
+	if board == nil || board.Gate == nil {
+		return fmt.Errorf("cannot publish reduced scoreboard without a recomputed hard gate")
+	}
+	if board.Gate.Status != perfScanGatePass && board.Gate.Status != perfScanGateFail {
+		return fmt.Errorf("cannot publish reduced scoreboard with hard gate status %q", board.Gate.Status)
+	}
+	if err := os.MkdirAll(absOut, 0o755); err != nil {
+		return fmt.Errorf("create reduced scoreboard output directory: %w", err)
+	}
+	if err := perfScanWriteScoreboard(absOut, board); err != nil {
+		return fmt.Errorf("write reduced scoreboard: %w", err)
+	}
+	if mode == perfScanReduceModeCertify && board.Gate.Status == perfScanGateFail {
+		findings := len(board.Gate.Failures)
+		return fmt.Errorf("reduced fleet hard gate failed with %d finding(s); scoreboard: %s", findings, filepath.Join(absOut, "scoreboard.json"))
+	}
+	return nil
 }
 
 func perfScanAuthenticateReducer(board *perfScanScoreboard, provenance perfScanRepositoryState) error {
@@ -231,9 +278,6 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 		if _, exists := rowsByLang[lang]; exists {
 			return nil, fmt.Errorf("duplicate shard language %q", lang)
 		}
-		if row.FilesSelected <= 0 || row.FilesMeasured <= 0 || len(row.Files) <= 0 {
-			return nil, fmt.Errorf("shard %s language %q has no selected, measured, and classified file evidence", shardPath, lang)
-		}
 		seenPaths := map[string]bool{}
 		for _, file := range row.Files {
 			if file == nil || file.Classification == nil {
@@ -264,8 +308,14 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 		}
 
 		recomputedGate := perfScanEvaluateHardGate(shard)
-		if shard.Gate == nil || shard.Gate.Status != perfScanGatePass || recomputedGate.Status != perfScanGatePass || !reflect.DeepEqual(*shard.Gate, recomputedGate) {
-			return nil, fmt.Errorf("shard %s has an absent, failed, stale, or otherwise invalid hard gate", shardPath)
+		if shard.Gate == nil {
+			return nil, fmt.Errorf("shard %s has no stored hard gate", shardPath)
+		}
+		if shard.Gate.Status != perfScanGatePass && shard.Gate.Status != perfScanGateFail {
+			return nil, fmt.Errorf("shard %s stored hard gate has unknown status %q", shardPath, shard.Gate.Status)
+		}
+		if !reflect.DeepEqual(*shard.Gate, recomputedGate) {
+			return nil, fmt.Errorf("shard %s stored hard gate is stale or contradicts its file evidence", shardPath)
 		}
 		rowsByLang[lang] = row
 		if ts, err := time.Parse(time.RFC3339, shard.GeneratedAt); err == nil && ts.After(generatedMax) {
@@ -322,9 +372,6 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
 	gate := perfScanEvaluateHardGate(board)
 	board.Gate = &gate
-	if gate.Status != perfScanGatePass {
-		return nil, fmt.Errorf("reduced fleet hard gate failed with %d finding(s)", len(gate.Failures))
-	}
 	return board, nil
 }
 
@@ -515,6 +562,94 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 		}
 	})
 
+	for _, tc := range []struct {
+		name     string
+		mutate   func(*perfScanScoreboard)
+		wantKind string
+	}{
+		{
+			name: "ratio cliff remains authenticated evidence",
+			mutate: func(shard *perfScanScoreboard) {
+				shard.Languages[0].Files[0].Axes[perfScanAxisFull].GoMedianNs = 11_001
+			},
+			wantKind: "ratio",
+		},
+		{
+			name: "parser stop remains authenticated evidence",
+			mutate: func(shard *perfScanScoreboard) {
+				file := shard.Languages[0].Files[0]
+				file.Classification = &perfScanFileClassification{
+					Class:        perfScanClassStopped,
+					Reason:       "Go parser stopped before accepting the full source",
+					GoStatus:     "go_timeout",
+					StoppedEarly: true,
+					StopReason:   perfScanStopParserTimeout,
+				}
+				file.Axes[perfScanAxisFull] = &perfScanFileAxis{
+					Status: "go_timeout",
+					Detail: "parser timeout",
+					Stop: &perfScanStop{
+						Class:          perfScanStopParserTimeout,
+						Reason:         perfScanStopParserTimeout,
+						Implementation: "go",
+						Phase:          "timed",
+					},
+				}
+			},
+			wantKind: "go_stop",
+		},
+		{
+			name: "missing ratio remains authenticated evidence",
+			mutate: func(shard *perfScanScoreboard) {
+				shard.Languages[0].Files[0].Axes[perfScanAxisFull].GoMedianNs = 0
+			},
+			wantKind: "coverage",
+		},
+		{
+			name: "partial coverage remains authenticated evidence",
+			mutate: func(shard *perfScanScoreboard) {
+				shard.Languages[0].FilesSelected = 2
+			},
+			wantKind: "coverage",
+		},
+		{
+			name: "zero coverage remains authenticated evidence",
+			mutate: func(shard *perfScanScoreboard) {
+				row := shard.Languages[0]
+				row.FilesSelected = 0
+				row.FilesMeasured = 0
+				row.BytesMeasured = 0
+				row.Files = nil
+			},
+			wantKind: "coverage",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := makeInputs(t, func(_ *perfScanScoreboard, pythonShard *perfScanScoreboard) {
+				tc.mutate(pythonShard)
+				gate := perfScanEvaluateHardGate(pythonShard)
+				pythonShard.Gate = &gate
+			})
+			board, err := reduce(paths)
+			if err != nil {
+				t.Fatalf("reduce valid failing evidence: %v", err)
+			}
+			if board.Gate == nil || board.Gate.Status != perfScanGateFail {
+				t.Fatalf("combined gate = %+v, want FAIL", board.Gate)
+			}
+			found := false
+			for _, finding := range board.Gate.Failures {
+				if finding.Language == "python" && finding.Kind == tc.wantKind {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("combined gate did not retain %s finding: %+v", tc.wantKind, board.Gate)
+			}
+		})
+	}
+
 	tests := []struct {
 		name   string
 		paths  func(*testing.T) []string
@@ -629,17 +764,6 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 			want: "incomplete full-parse classification coverage",
 		},
 		{
-			name: "zero file evidence",
-			mutate: func(_, pythonShard *perfScanScoreboard) {
-				row := pythonShard.Languages[0]
-				row.FilesSelected = 0
-				row.FilesMeasured = 0
-				row.BytesMeasured = 0
-				row.Files = nil
-			},
-			want: "no selected, measured, and classified file evidence",
-		},
-		{
 			name: "duplicate file path",
 			mutate: func(_, pythonShard *perfScanScoreboard) {
 				row := pythonShard.Languages[0]
@@ -680,11 +804,36 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 			want: "unknown class",
 		},
 		{
-			name: "invalid shard hard gate",
+			name: "missing shard hard gate",
 			mutate: func(_, pythonShard *perfScanScoreboard) {
-				pythonShard.Gate.Status = perfScanGateFail
+				pythonShard.Gate = nil
 			},
-			want: "invalid hard gate",
+			want: "no stored hard gate",
+		},
+		{
+			name: "stale stored pass for failing evidence",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].Axes[perfScanAxisFull].GoMedianNs = 11_001
+			},
+			want: "stale or contradicts",
+		},
+		{
+			name: "stale stored fail for passing evidence",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				full := pythonShard.Languages[0].Files[0].Axes[perfScanAxisFull]
+				full.GoMedianNs = 11_001
+				gate := perfScanEvaluateHardGate(pythonShard)
+				pythonShard.Gate = &gate
+				full.GoMedianNs = 1_000
+			},
+			want: "stale or contradicts",
+		},
+		{
+			name: "unknown stored hard gate status",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Gate.Status = "unknown"
+			},
+			want: "unknown status",
 		},
 		{
 			name: "multiple language rows",
@@ -801,6 +950,110 @@ func TestPerfScanAuthenticateReducer(t *testing.T) {
 	}
 	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: revision, Clean: false}); err == nil || !strings.Contains(err.Error(), "clean repository") {
 		t.Fatalf("dirty reducer provenance error = %v", err)
+	}
+}
+
+func TestPerfScanReduceModes(t *testing.T) {
+	revision := strings.Repeat("a", 40)
+	passBoard := perfScanTestShard("go", "/corpus.lock", strings.Repeat("b", 64), 1, revision)
+	failBoard := perfScanTestShard("go", "/corpus.lock", strings.Repeat("b", 64), 1, revision)
+	failBoard.Languages[0].Files[0].Axes[perfScanAxisFull].GoMedianNs = 11_001
+	perfScanRefreshLanguageAggregates(failBoard.Languages[0], failBoard.Config)
+	failBoard.Summary = map[string]int{failBoard.Languages[0].Verdict: 1}
+	failBoard.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(failBoard.Languages)
+	failGate := perfScanEvaluateHardGate(failBoard)
+	failBoard.Gate = &failGate
+
+	t.Run("default is certify", func(t *testing.T) {
+		mode, err := perfScanResolveReduceMode("")
+		if err != nil || mode != perfScanReduceModeCertify {
+			t.Fatalf("default reduce mode = %q, %v", mode, err)
+		}
+		out := filepath.Join(t.TempDir(), "default-certify")
+		err = perfScanPublishReducedScoreboard(out, failBoard, mode)
+		assertPerfScanCertificationFailure(t, out, err, 1)
+	})
+
+	t.Run("FAIL artifacts are mode-equivalent while exit behavior differs", func(t *testing.T) {
+		reportOut := filepath.Join(t.TempDir(), "report")
+		certifyOut := filepath.Join(t.TempDir(), "certify")
+		if err := perfScanPublishReducedScoreboard(reportOut, failBoard, perfScanReduceModeReport); err != nil {
+			t.Fatalf("report publication: %v", err)
+		}
+		assertPerfScanPublishedGate(t, reportOut, perfScanGateFail)
+		err := perfScanPublishReducedScoreboard(certifyOut, failBoard, perfScanReduceModeCertify)
+		assertPerfScanCertificationFailure(t, certifyOut, err, 1)
+		assertPerfScanPublishedArtifactsEqual(t, reportOut, certifyOut)
+	})
+
+	t.Run("PASS artifacts are mode-equivalent", func(t *testing.T) {
+		reportOut := filepath.Join(t.TempDir(), "report")
+		certifyOut := filepath.Join(t.TempDir(), "certify")
+		if err := perfScanPublishReducedScoreboard(reportOut, passBoard, perfScanReduceModeReport); err != nil {
+			t.Fatalf("report PASS publication: %v", err)
+		}
+		if err := perfScanPublishReducedScoreboard(certifyOut, passBoard, perfScanReduceModeCertify); err != nil {
+			t.Fatalf("certify PASS publication: %v", err)
+		}
+		assertPerfScanPublishedArtifactsEqual(t, reportOut, certifyOut)
+	})
+
+	t.Run("unknown mode fails before output", func(t *testing.T) {
+		for _, raw := range []string{"observe", "REPORT"} {
+			if _, err := perfScanResolveReduceMode(raw); err == nil || !strings.Contains(err.Error(), perfScanEnvReduceMode) {
+				t.Fatalf("unknown reduce mode %q error = %v", raw, err)
+			}
+		}
+		out := filepath.Join(t.TempDir(), "unknown")
+		if err := perfScanPublishReducedScoreboard(out, passBoard, "observe"); err == nil {
+			t.Fatal("unknown reduce mode unexpectedly published")
+		}
+		if _, err := os.Stat(out); !os.IsNotExist(err) {
+			t.Fatalf("unknown reduce mode created output before failing: %v", err)
+		}
+	})
+}
+
+func assertPerfScanCertificationFailure(t *testing.T, out string, err error, findings int) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("%d finding(s)", findings)) || !strings.Contains(err.Error(), filepath.Join(out, "scoreboard.json")) {
+		t.Fatalf("certification error = %v", err)
+	}
+	assertPerfScanPublishedGate(t, out, perfScanGateFail)
+}
+
+func assertPerfScanPublishedGate(t *testing.T, out, wantStatus string) {
+	t.Helper()
+	board, err := perfScanReadScoreboard(filepath.Join(out, "scoreboard.json"))
+	if err != nil {
+		t.Fatalf("read published JSON: %v", err)
+	}
+	if board.Gate == nil || board.Gate.Status != wantStatus {
+		t.Fatalf("published gate = %+v, want %s", board.Gate, wantStatus)
+	}
+	markdown, err := os.ReadFile(filepath.Join(out, "scoreboard.md"))
+	if err != nil {
+		t.Fatalf("read published Markdown: %v", err)
+	}
+	if !strings.Contains(string(markdown), "outcome: `"+strings.ToUpper(wantStatus)+"`") {
+		t.Fatalf("published Markdown does not render %s gate", wantStatus)
+	}
+}
+
+func assertPerfScanPublishedArtifactsEqual(t *testing.T, reportOut, certifyOut string) {
+	t.Helper()
+	for _, name := range []string{"scoreboard.json", "scoreboard.md"} {
+		reportData, err := os.ReadFile(filepath.Join(reportOut, name))
+		if err != nil {
+			t.Fatalf("read report %s: %v", name, err)
+		}
+		certifyData, err := os.ReadFile(filepath.Join(certifyOut, name))
+		if err != nil {
+			t.Fatalf("read certify %s: %v", name, err)
+		}
+		if !reflect.DeepEqual(reportData, certifyData) {
+			t.Fatalf("%s differs by mode", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- separate authenticated fleet reporting from blocking certification
- preserve complete PASS or FAIL artifacts before deciding process exit
- keep rejecting stale gates and malformed provenance, host, lock, config, or classification evidence
- add fixed Docker hostnames for isolated one-language campaigns

## Validation

- focused reducer protocol and adversarial tests (20x)
- full tagged perf-scan suite
- focused Docker suite (20x) with hostname verified in metadata and inspect
- shell syntax/help checks and `git diff --check`
- Sol review found no P0/P1 issues