### PR TITLE
fix(glr): release discarded forest batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ for tags and release notes while still in `0.x`.
   metadata so one-language containers on the same physical benchmark host can
   produce a consistent authenticated host identity.
 
+### Fixed
+
+- The pooled forest GSS slab now clears outer batch references discarded by
+  its 32 MiB retention cap. On the 3,447,275-byte JavaScript Poppler witness
+  under the default 512 MiB parser budget, this reduced one-GC live heap from
+  1,475,142,360 to 608,167,688 bytes and eliminated all 866,975,744 bytes of
+  hidden tail references while preserving the 33,488,896-byte warm prefix and
+  identical parse output. Peak RSS remained effectively unchanged because the
+  batches are still allocated before release; a recurring successful-forest
+  benchmark was neutral (2.627 ms to 2.636 ms, p=0.947, n=20) with unchanged
+  bytes and allocations.
+
 ## [0.30.0] - 2026-07-12
 
 Recurring-parser performance and fleet-measurement integrity release. Reused

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2424,19 +2424,25 @@ func releaseGSSForestNodeSlab(s *gssForestNodeSlab) {
 // of batches lets them be reused (acquire resets linkBatch/nodeBatch to 0), so a
 // large parse re-allocates only the overflow, at the SAME 32 MiB memory bound.
 func (s *gssForestNodeSlab) trimToRetentionCap() {
+	s.trimToRetentionLimit(maxRetainedGSSForestScratchBytes)
+}
+
+func (s *gssForestNodeSlab) trimToRetentionLimit(maxRetainedBytes int) {
 	nodeSize := int(unsafe.Sizeof(gssForestNode{}))
 	linkSize := int(unsafe.Sizeof(gssLink{}))
 	total := s.retainedBytes()
 	// Link batches dominate; trim them first, then node batches. Always keep at
 	// least one batch of each so the slab stays warm.
-	for total > maxRetainedGSSForestScratchBytes && len(s.linkBatches) > 1 {
+	for total > maxRetainedBytes && len(s.linkBatches) > 1 {
 		last := len(s.linkBatches) - 1
 		total -= cap(s.linkBatches[last]) * linkSize
+		s.linkBatches[last] = nil
 		s.linkBatches = s.linkBatches[:last]
 	}
-	for total > maxRetainedGSSForestScratchBytes && len(s.nodeBatches) > 1 {
+	for total > maxRetainedBytes && len(s.nodeBatches) > 1 {
 		last := len(s.nodeBatches) - 1
 		total -= cap(s.nodeBatches[last]) * nodeSize
+		s.nodeBatches[last] = nil
 		s.nodeBatches = s.nodeBatches[:last]
 	}
 }

--- a/glr_forest_test.go
+++ b/glr_forest_test.go
@@ -739,6 +739,119 @@ func TestGSSForestNodeSlabReleaseClearsPointers(t *testing.T) {
 	}
 }
 
+func TestGSSForestNodeSlabTrimClearsDiscardedBatchReferences(t *testing.T) {
+	nodeBatches := [][]gssForestNode{
+		make([]gssForestNode, 1),
+		make([]gssForestNode, 1),
+		make([]gssForestNode, 1),
+	}
+	linkBatches := [][]gssLink{
+		make([]gssLink, forestMaxLinksPerNode),
+		make([]gssLink, forestMaxLinksPerNode),
+		make([]gssLink, forestMaxLinksPerNode),
+	}
+	slab := &gssForestNodeSlab{
+		nodeBatches: nodeBatches,
+		linkBatches: linkBatches,
+	}
+	retainedNode := &nodeBatches[0][0]
+	retainedLink := &linkBatches[0][0]
+	limit := cap(nodeBatches[0])*int(unsafe.Sizeof(gssForestNode{})) +
+		cap(linkBatches[0])*int(unsafe.Sizeof(gssLink{}))
+
+	slab.trimToRetentionLimit(limit)
+	if got := len(slab.nodeBatches); got != 1 {
+		t.Fatalf("retained node batches = %d, want 1", got)
+	}
+	if got := len(slab.linkBatches); got != 1 {
+		t.Fatalf("retained link batches = %d, want 1", got)
+	}
+	if got := slab.retainedBytes(); got != limit {
+		t.Fatalf("retained bytes = %d, want %d", got, limit)
+	}
+	if got := &slab.nodeBatches[0][0]; got != retainedNode {
+		t.Fatalf("retained node batch moved: got %p, want %p", got, retainedNode)
+	}
+	if got := &slab.linkBatches[0][0]; got != retainedLink {
+		t.Fatalf("retained link batch moved: got %p, want %p", got, retainedLink)
+	}
+	for i, batch := range slab.nodeBatches[:cap(slab.nodeBatches)] {
+		if i >= len(slab.nodeBatches) && batch != nil {
+			t.Fatalf("discarded node batch %d remains reachable", i)
+		}
+	}
+	for i, batch := range slab.linkBatches[:cap(slab.linkBatches)] {
+		if i >= len(slab.linkBatches) && batch != nil {
+			t.Fatalf("discarded link batch %d remains reachable", i)
+		}
+	}
+
+	if got := slab.alloc(7, 11, 0, 0); got != retainedNode {
+		t.Fatalf("first allocation after trim = %p, want retained node %p", got, retainedNode)
+	}
+	if got := &slab.linkBatches[0][0]; got != retainedLink {
+		t.Fatalf("first link allocation after trim moved: got %p, want %p", got, retainedLink)
+	}
+
+	// Exhaust the retained prefix once, then prove append reuses the cleared
+	// outer slots and a second release can clear those references again.
+	slab.nodeIdx = len(slab.nodeBatches[0])
+	slab.linkIdx = len(slab.linkBatches[0])
+	slab.alloc(8, 12, 0, 0)
+	if len(slab.nodeBatches) != 2 {
+		t.Fatalf("node batch count after reuse = %d, want 2", len(slab.nodeBatches))
+	}
+	if slab.nodeBatches[1] == nil {
+		t.Fatal("node batch append did not reuse a cleared outer slot")
+	}
+	if len(slab.linkBatches) != 2 {
+		t.Fatalf("link batch count after reuse = %d, want 2", len(slab.linkBatches))
+	}
+	if slab.linkBatches[1] == nil {
+		t.Fatal("link batch append did not reuse a cleared outer slot")
+	}
+	slab.resetForRelease()
+	slab.trimToRetentionLimit(limit)
+	if slab.nodeBatches[:cap(slab.nodeBatches)][1] != nil {
+		t.Fatal("reused node batch remains reachable after second trim")
+	}
+	if slab.linkBatches[:cap(slab.linkBatches)][1] != nil {
+		t.Fatal("reused link batch remains reachable after second trim")
+	}
+}
+
+func TestGSSForestNodeSlabTrimLimitBoundaries(t *testing.T) {
+	var empty gssForestNodeSlab
+	empty.trimToRetentionLimit(0)
+	if len(empty.nodeBatches) != 0 || len(empty.linkBatches) != 0 {
+		t.Fatalf("empty trim created batches: nodes=%d links=%d", len(empty.nodeBatches), len(empty.linkBatches))
+	}
+
+	slab := &gssForestNodeSlab{
+		nodeBatches: [][]gssForestNode{
+			make([]gssForestNode, 1),
+			make([]gssForestNode, 1),
+		},
+		linkBatches: [][]gssLink{
+			make([]gssLink, 1),
+			make([]gssLink, 1),
+		},
+	}
+	exact := slab.retainedBytes()
+	slab.trimToRetentionLimit(exact)
+	if len(slab.nodeBatches) != 2 || len(slab.linkBatches) != 2 {
+		t.Fatalf("exact-limit trim changed batches: nodes=%d links=%d", len(slab.nodeBatches), len(slab.linkBatches))
+	}
+
+	slab.trimToRetentionLimit(exact - 1)
+	if len(slab.nodeBatches) != 2 || len(slab.linkBatches) != 1 {
+		t.Fatalf("over-limit trim removed wrong suffix: nodes=%d links=%d", len(slab.nodeBatches), len(slab.linkBatches))
+	}
+	if slab.linkBatches[:cap(slab.linkBatches)][1] != nil {
+		t.Fatal("over-limit link suffix remains reachable")
+	}
+}
+
 func TestForestRootMustDeclineErrorRoot(t *testing.T) {
 	if forestRootMustDecline(nil) {
 		t.Fatal("nil root should not decline")


### PR DESCRIPTION
## Summary

- clear discarded forest GSS slab references before shrinking retention slices
- preserve retained slab identity and append reuse
- add focused regression coverage for exact, empty, over-limit, and repeated trim cycles
- record the change under Unreleased

## Evidence

- post-GC hidden forest retention: 866,975,744 B -> 0 B
- retained forest backing: 33,488,896 B, within the 32 MiB cap plus slab granularity
- peak RSS: neutral within run noise
- default-budget stop point and parser counters: unchanged
- JavaScript Docker structural parity: 25/25
- successful-forest canary: 3/3 dispatch with no fallback or divergence
- focused host and Docker regression runs: green
- successful-forest benchmark: statistically neutral for time, bytes, and allocations