### PR TITLE
fix(parser): Remove mis-firing python trailing-self-call fold heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,18 @@ benchmark trio remains neutral while full-parse bytes fall 18.68%.
   statement count for no fork-count benefit. C#'s helper is left in place: it
   depends on the literal source text of a contextual keyword (`scoped`),
   which `ConflictPolicies`' state/lookahead-symbol matching cannot express.
+### Fixed
+
+- Removed `foldPythonTrailingSelfCallIntoNestedFunction`, a Python
+  compat-normalization heuristic that spuriously folded a same-named
+  trailing call into a preceding nested function's block whenever that
+  function's own body ended in a dangling `;` before a dedent (e.g. `def
+  foo(): x = 1;` followed by a sibling `foo()` at the outer indent). Raw
+  GLR parse actions and materialized trees were already byte-identical
+  between the trailing-`;` and no-`;` forms and matched the reference
+  parser; only this post-parse fold diverged. Python real-corpus deep
+  parity goes from 20/25 to 25/25 (`python3.8_grammar.py` /
+  `python2-grammar.py` witnesses now match exactly).
 
 ## [0.28.0] - 2026-07-12
 

--- a/grammargen/python_parity_test.go
+++ b/grammargen/python_parity_test.go
@@ -330,6 +330,33 @@ func pythonCorpusFenceForTest(line string, want rune) bool {
 	return true
 }
 
+// TestPythonNestedFunctionDedentTrailingSemicolonParity is the minimal
+// reducer for the E2 python-dedent floor witness (python3.8_grammar.py /
+// python2-grammar.py real-corpus samples): a nested function whose body ends
+// in a dangling ';' immediately before a dedent, followed by a same-named
+// call at the outer indentation. Root cause was NOT a table-construction /
+// reduce-lineage divergence (raw GLR parse actions and raw materialized
+// trees are byte-identical between the trailing-';' and no-';' variants,
+// and identical to the reference for both) — it was
+// foldPythonTrailingSelfCallIntoNestedFunction, a python compat-normalization
+// heuristic (added in 82f90e77, "restore python real-corpus parity") that
+// spuriously folded a same-named trailing call into the preceding function's
+// block whenever that block's raw last child was ';'. See CHANGELOG.
+func TestPythonNestedFunctionDedentTrailingSemicolonParity(t *testing.T) {
+	genLang := loadGeneratedPythonLanguageForParity(t)
+	refLang := grammars.PythonLanguage()
+	adaptExternalScanner(refLang, genLang)
+
+	t.Run("with_trailing_semicolon", func(t *testing.T) {
+		sample := "def m():\n    x=1\n    def foo():\n        x=1;\n    foo()\n"
+		assertPythonParity(t, genLang, refLang, sample)
+	})
+	t.Run("without_trailing_semicolon_control", func(t *testing.T) {
+		sample := "def m():\n    x=1\n    def foo():\n        x=1\n    foo()\n"
+		assertPythonParity(t, genLang, refLang, sample)
+	})
+}
+
 func assertPythonParity(t *testing.T, genLang, refLang *gotreesitter.Language, sample string) {
 	t.Helper()
 

--- a/grammargen/testdata/real_corpus_parity_floors.json
+++ b/grammargen/testdata/real_corpus_parity_floors.json
@@ -8,8 +8,8 @@
  "grammar_count": 55,
  "total_eligible": 1026,
  "total_no_error": 898,
- "total_sexpr_parity": 852,
- "total_deep_parity": 851,
+ "total_sexpr_parity": 857,
+ "total_deep_parity": 856,
  "metrics": {
   "bash": {
    "eligible": 25,
@@ -260,8 +260,8 @@
   "python": {
    "eligible": 25,
    "no_error": 25,
-   "sexpr_parity": 20,
-   "deep_parity": 20
+   "sexpr_parity": 25,
+   "deep_parity": 25
   },
   "regex": {
    "eligible": 25,

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -17,13 +17,6 @@ func normalizePythonCompatibilityWithParser(root *Node, source []byte, parser *P
 		}()
 	}
 	sourceFlags := pythonCompatibilitySourceFlagsFor(source)
-	// Postorder passes: trailingSelfCalls + printChevron. Run separately
-	// because they require a different walk order.
-	parser.runNormalizationPass(func() bool {
-		return sourceFlags.trailingSelfCalls
-	}, func() normalizationPassCounters {
-		return normalizePythonTrailingSelfCallsWithSemicolons(root, source, lang, &sourceFlags.trailingSelfCallSemicolons)
-	})
 	parser.runNormalizationPass(func() bool {
 		return sourceFlags.printChevron
 	}, func() normalizationPassCounters {
@@ -477,7 +470,6 @@ func applyCollapsedKeywordRewrite(n *Node, lang *Language, ck pythonCollapsedKey
 }
 
 type pythonCompatibilitySourceFlags struct {
-	trailingSelfCalls  bool
 	printChevron       bool
 	fStringPattern     bool
 	passWord           bool
@@ -492,42 +484,6 @@ type pythonCompatibilitySourceFlags struct {
 	asPattern          bool
 	casePattern        bool
 	continuationEscape bool
-
-	trailingSelfCallSemicolons pythonTrailingSelfCallSemicolons
-}
-
-const pythonTrailingSelfCallInlineSemicolonLimit = 32
-
-type pythonTrailingSelfCallSemicolons struct {
-	count    int
-	inline   [pythonTrailingSelfCallInlineSemicolonLimit]uint32
-	overflow []uint32
-}
-
-func (s *pythonTrailingSelfCallSemicolons) add(offset uint32) {
-	if s == nil {
-		return
-	}
-	if s.count < len(s.inline) {
-		s.inline[s.count] = offset
-	} else {
-		s.overflow = append(s.overflow, offset)
-	}
-	s.count++
-}
-
-func (s *pythonTrailingSelfCallSemicolons) rangeMayContain(start, end uint32) bool {
-	if s == nil || s.count == 0 || start == end {
-		return true
-	}
-	inlineCount := s.count
-	if inlineCount > len(s.inline) {
-		inlineCount = len(s.inline)
-	}
-	if pythonSortedOffsetsMayIntersectRange(s.inline[:inlineCount], start, end) {
-		return true
-	}
-	return pythonSortedOffsetsMayIntersectRange(s.overflow, start, end)
 }
 
 func pythonCompatibilitySourceFlagsFor(source []byte) pythonCompatibilitySourceFlags {
@@ -565,7 +521,6 @@ func pythonCompatibilitySourceFlagsFor(source []byte) pythonCompatibilitySourceF
 				flags.continuationEscape = true
 			}
 			if !ok {
-				flags.trailingSelfCalls = true
 				flags.printChevron = true
 				flags.fStringPattern = true
 				flags.passWord = true
@@ -580,10 +535,6 @@ func pythonCompatibilitySourceFlagsFor(source []byte) pythonCompatibilitySourceF
 			}
 			i = end
 			continue
-		}
-		if source[i] == ';' {
-			flags.trailingSelfCalls = true
-			flags.trailingSelfCallSemicolons.add(uint32(i))
 		}
 		if !flags.assignmentList && source[i] == '=' && bytes.IndexByte(source[i+1:], ',') >= 0 {
 			flags.assignmentList = true
@@ -893,52 +844,6 @@ func normalizePythonPrintStatements(root *Node, source []byte, lang *Language) n
 	return counters
 }
 
-func normalizePythonTrailingSelfCallsWithSemicolons(root *Node, source []byte, lang *Language, semicolons *pythonTrailingSelfCallSemicolons) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if root == nil || lang == nil || lang.Name != "python" || len(source) == 0 {
-		return counters
-	}
-	blockSym, ok := symbolByName(lang, "block")
-	if !ok {
-		walkResultTreePostorder(root, func(node *Node) {
-			counters.nodesVisited++
-		})
-		return counters
-	}
-	normalizePythonTrailingSelfCallsPostorder(root, source, lang, blockSym, semicolons, &counters)
-	return counters
-}
-
-func normalizePythonTrailingSelfCallsPostorder(node *Node, source []byte, lang *Language, blockSym Symbol, semicolons *pythonTrailingSelfCallSemicolons, counters *normalizationPassCounters) {
-	if node == nil {
-		return
-	}
-	if semicolons != nil && semicolons.count > 0 && !semicolons.rangeMayContain(node.startByte, node.endByte) {
-		return
-	}
-	if node.ownerArena == nil || node.childIndex > finalChildSidecarIndexBase {
-		for _, child := range node.children {
-			normalizePythonTrailingSelfCallsPostorder(child, source, lang, blockSym, semicolons, counters)
-		}
-	} else {
-		childCount := resultChildCount(node)
-		for i := 0; i < childCount; i++ {
-			normalizePythonTrailingSelfCallsPostorder(resultChildAt(node, i), source, lang, blockSym, semicolons, counters)
-		}
-	}
-	counters.nodesVisited++
-	if node.symbol != blockSym {
-		return
-	}
-	children := resultChildSliceForMutation(node)
-	rewritten, changed := foldPythonTrailingSelfCallsInBlock(children, source, lang)
-	if !changed {
-		return
-	}
-	replaceNodeChildrenUnfielded(node, cloneNodeSliceInArena(node.ownerArena, rewritten))
-	counters.nodesRewritten++
-}
-
 func pythonSortedOffsetsMayIntersectRange(offsets []uint32, start, end uint32) bool {
 	if len(offsets) == 0 {
 		return false
@@ -956,74 +861,6 @@ func pythonSortedOffsetsMayIntersectRange(offsets []uint32, start, end uint32) b
 		}
 	}
 	return lo < len(offsets) && offsets[lo] < end
-}
-
-func foldPythonTrailingSelfCallsInBlock(children []*Node, source []byte, lang *Language) ([]*Node, bool) {
-	if len(children) < 2 || lang == nil || lang.Name != "python" || len(source) == 0 {
-		return children, false
-	}
-	var out []*Node
-	for i := 0; i < len(children); i++ {
-		cur := children[i]
-		if i+1 >= len(children) {
-			if out != nil {
-				out = append(out, cur)
-			}
-			continue
-		}
-		next := children[i+1]
-		rewritten, ok := foldPythonTrailingSelfCallIntoNestedFunction(cur, next, source, lang)
-		if !ok {
-			if out != nil {
-				out = append(out, cur)
-			}
-			continue
-		}
-		if out == nil {
-			out = make([]*Node, 0, len(children))
-			out = append(out, children[:i]...)
-		}
-		out = append(out, rewritten)
-		i++
-	}
-	if out == nil {
-		return children, false
-	}
-	return out, true
-}
-
-func foldPythonTrailingSelfCallIntoNestedFunction(fnNode, trailingCall *Node, source []byte, lang *Language) (*Node, bool) {
-	if fnNode == nil || trailingCall == nil || lang == nil || lang.Name != "python" || len(source) == 0 {
-		return nil, false
-	}
-	if fnNode.Type(lang) != "function_definition" || trailingCall.Type(lang) != "call" {
-		return nil, false
-	}
-	if trailingCall.startPoint.Column != fnNode.startPoint.Column {
-		return nil, false
-	}
-	fnName, ok := pythonFunctionDefinitionNameNode(fnNode, lang)
-	if !ok || fnName == nil {
-		return nil, false
-	}
-	callName, ok := pythonCallIdentifierNode(trailingCall, lang)
-	if !ok || callName == nil {
-		return nil, false
-	}
-	if !pythonNodeTextEqual(fnName, callName, source) {
-		return nil, false
-	}
-	bodyIndex := pythonChildIndexByTypeNoMaterialize(fnNode, lang, "block")
-	body := resultChildAt(fnNode, bodyIndex)
-	if bodyIndex < 0 || body == nil || !pythonBlockEndsWithSemicolon(body, lang) {
-		return nil, false
-	}
-
-	bodyClone := cloneNodeInArenaAppendingChildForMutation(body.ownerArena, body, trailingCall)
-	bodyClone.clearFieldMetadata()
-
-	fnClone := cloneNodeInArenaReplacingChildForMutation(fnNode.ownerArena, fnNode, bodyIndex, bodyClone)
-	return fnClone, true
 }
 
 func rewritePythonStatementList(children []*Node, source []byte, lang *Language) ([]*Node, bool) {
@@ -2035,31 +1872,6 @@ func pythonBlockLastChildNode(node *Node) *Node {
 	return nil
 }
 
-func pythonBlockEndsWithSemicolon(node *Node, lang *Language) bool {
-	childCount := resultChildCount(node)
-	if node == nil || lang == nil || childCount == 0 {
-		return false
-	}
-	if semiSym, ok := symbolByName(lang, ";"); ok {
-		if entry, ok := nodeChildEntryAtNoMaterialize(node, childCount-1); ok && stackEntryHasNode(entry) {
-			return stackEntryNodeSymbol(entry) == semiSym
-		}
-	}
-	lastChild := resultChildAt(node, childCount-1)
-	return lastChild != nil && lastChild.Type(lang) == ";"
-}
-
-func pythonFunctionDefinitionNameNode(node *Node, lang *Language) (*Node, bool) {
-	if node == nil || lang == nil || node.Type(lang) != "function_definition" {
-		return nil, false
-	}
-	if index := pythonChildIndexByTypeNoMaterialize(node, lang, "identifier"); index >= 0 {
-		child := resultChildAt(node, index)
-		return child, child != nil
-	}
-	return nil, false
-}
-
 func pythonChildIndexByTypeNoMaterialize(node *Node, lang *Language, typ string) int {
 	if node == nil || lang == nil || typ == "" {
 		return -1
@@ -2088,33 +1900,6 @@ func pythonChildIndexByTypeNoMaterialize(node *Node, lang *Language, typ string)
 		}
 	}
 	return -1
-}
-
-func pythonCallIdentifierNode(node *Node, lang *Language) (*Node, bool) {
-	if node == nil || lang == nil || node.Type(lang) != "call" || resultChildCount(node) == 0 {
-		return nil, false
-	}
-	fn := resultChildAt(node, 0)
-	if fn != nil && fn.Type(lang) == "identifier" {
-		return fn, true
-	}
-	return nil, false
-}
-
-func pythonNodeTextEqual(a, b *Node, source []byte) bool {
-	if a == nil || b == nil || len(source) == 0 {
-		return false
-	}
-	if a.startByte >= a.endByte || b.startByte >= b.endByte {
-		return false
-	}
-	if int(a.endByte) > len(source) || int(b.endByte) > len(source) {
-		return false
-	}
-	if a.endByte-a.startByte != b.endByte-b.startByte {
-		return false
-	}
-	return bytes.Equal(source[a.startByte:a.endByte], source[b.startByte:b.endByte])
 }
 
 func splitPythonOvernestedFunction(node *Node, arena *nodeArena, lang *Language) (*Node, []*Node, bool) {

--- a/parser_result_python_test.go
+++ b/parser_result_python_test.go
@@ -399,19 +399,26 @@ func TestNormalizePythonCompatibilityRecordsRuntimeStats(t *testing.T) {
 		SymbolNames: []string{
 			"",
 			"module",
+			"escape_sequence",
+			"string_content",
 		},
 		SymbolMetadata: []SymbolMetadata{
 			{},
 			{Name: "module", Visible: true, Named: true},
+			{Name: "escape_sequence", Visible: true, Named: true},
+			{Name: "string_content", Visible: true, Named: true},
 		},
 	}
 	parser := &Parser{}
 	root := newParentNodeInArena(nil, 1, true, nil, nil, 0)
 
-	normalizePythonCompatibilityWithParser(root, []byte(";"), parser, lang)
+	// A backslash-newline continuation is the only source-level trigger left
+	// (trailingSelfCalls was removed with foldPythonTrailingSelfCallIntoNestedFunction),
+	// so use it to exercise exactly one gated pass end-to-end.
+	normalizePythonCompatibilityWithParser(root, []byte("\\\n"), parser, lang)
 
 	stats := parser.normalizationStats
-	if got, want := stats.passesChecked, uint64(14); got != want {
+	if got, want := stats.passesChecked, uint64(13); got != want {
 		t.Fatalf("passesChecked = %d, want %d", got, want)
 	}
 	if got, want := stats.passesRun, uint64(1); got != want {
@@ -789,12 +796,6 @@ func TestNormalizePythonCompatibilityWrapsInlineTupleExpressionBlock(t *testing.
 }
 
 func TestPythonCompatibilitySourceGatesPreferCodeTokens(t *testing.T) {
-	if flags := pythonCompatibilitySourceFlagsFor([]byte(`x = ";"; y = 1`)); !flags.trailingSelfCalls {
-		t.Fatal("expected combined flags to detect code semicolon after string literal")
-	}
-	if flags := pythonCompatibilitySourceFlagsFor([]byte("\";\"\n# ;\n")); flags.trailingSelfCalls {
-		t.Fatal("did not expect combined flags to detect semicolon inside string/comment")
-	}
 	if flags := pythonCompatibilitySourceFlagsFor([]byte(`print >>sys.stderr, "x"`)); !flags.printChevron {
 		t.Fatal("expected combined flags to detect print-chevron statement")
 	}
@@ -1007,5 +1008,78 @@ func TestBuildResultFromNodesHoistsPythonClassSiblingsOutOfFunctionBody(t *testi
 	}
 	if block.NamedChild(2) == nil || block.NamedChild(2).Type(lang) != "function_definition" {
 		t.Fatalf("expected hoisted trailing function_definition, got %s", root.SExpr(lang))
+	}
+}
+
+// TestNormalizePythonCompatibilityDoesNotFoldTrailingSelfCallIntoNestedFunction
+// guards against reintroducing foldPythonTrailingSelfCallIntoNestedFunction
+// (removed): a same-named trailing call after a nested function whose body
+// ends in ';' must stay a sibling of that function, not get folded into its
+// block. See TestPythonNestedFunctionDedentTrailingSemicolonParity in
+// grammargen for the end-to-end real-corpus witness (python3.8_grammar.py /
+// python2-grammar.py) this protects.
+func TestNormalizePythonCompatibilityDoesNotFoldTrailingSelfCallIntoNestedFunction(t *testing.T) {
+	lang := &Language{
+		Name: "python",
+		SymbolNames: []string{
+			"",
+			"module",
+			"block",
+			"function_definition",
+			"identifier",
+			"parameters",
+			"comment",
+			"assignment",
+			";",
+			"call",
+			"argument_list",
+		},
+	}
+	arena := acquireNodeArena(arenaClassFull)
+	source := []byte("    def foo():\n        x = 1;\n    foo()\n")
+
+	fnName := newLeafNodeInArena(arena, 4, true, 8, 11, Point{Column: 8}, Point{Column: 11})
+	body := newParentNodeInArena(arena, 2, true, []*Node{
+		newLeafNodeInArena(arena, 7, true, 23, 28, Point{Row: 1, Column: 8}, Point{Row: 1, Column: 13}),
+		newLeafNodeInArena(arena, 8, false, 28, 29, Point{Row: 1, Column: 13}, Point{Row: 1, Column: 14}),
+	}, nil, 0)
+	fn := newParentNodeInArena(arena, 3, true, []*Node{
+		fnName,
+		newParentNodeInArena(arena, 5, true, nil, nil, 0),
+		newLeafNodeInArena(arena, 6, true, 15, 18, Point{Row: 1, Column: 0}, Point{Row: 1, Column: 3}),
+		body,
+	}, nil, 0)
+	fn.startByte = 4
+	fn.startPoint = Point{Column: 4}
+	call := newParentNodeInArena(arena, 9, true, []*Node{
+		newLeafNodeInArena(arena, 4, true, 34, 37, Point{Row: 2, Column: 4}, Point{Row: 2, Column: 7}),
+		newParentNodeInArena(arena, 10, true, nil, nil, 0),
+	}, nil, 0)
+	outerBlock := newParentNodeInArena(arena, 2, true, []*Node{fn, call}, nil, 0)
+	module := newParentNodeInArena(arena, 1, true, []*Node{outerBlock}, nil, 0)
+
+	normalizePythonCompatibilityWithParser(module, source, &Parser{}, lang)
+
+	block := module.Child(0)
+	if block == nil || block.Type(lang) != "block" {
+		t.Fatalf("expected block child, got %#v", block)
+	}
+	if got, want := block.ChildCount(), 2; got != want {
+		t.Fatalf("outer block child count = %d, want %d (call must stay a sibling, not fold into fn's block): %s", got, want, block.SExpr(lang))
+	}
+	gotFn := block.Child(0)
+	if gotFn == nil || gotFn.Type(lang) != "function_definition" {
+		t.Fatalf("expected function_definition child, got %s", block.SExpr(lang))
+	}
+	gotBody := gotFn.Child(gotFn.ChildCount() - 1)
+	if gotBody == nil || gotBody.Type(lang) != "block" {
+		t.Fatalf("expected nested block, got %s", gotFn.SExpr(lang))
+	}
+	if got, want := gotBody.ChildCount(), 2; got != want {
+		t.Fatalf("nested function body child count = %d, want %d (must not absorb trailing call): %s", got, want, gotBody.SExpr(lang))
+	}
+	gotCall := block.Child(1)
+	if gotCall == nil || gotCall.Type(lang) != "call" {
+		t.Fatalf("expected trailing call to remain a sibling of the function_definition, got %s", block.SExpr(lang))
 	}
 }


### PR DESCRIPTION
## Summary

- remove a Python compatibility heuristic that incorrectly folded a same-named trailing call into a preceding nested function block after a dangling semicolon and dedent
- preserve the raw parser result, which already matches the reference parser for both trailing-semicolon and control forms
- remove the heuristic and its exclusively owned helpers, reducing the Python compatibility tier by roughly 215 lines

## Validation

- Python real-corpus no-error, S-expression, and deep parity: 25/25
- focused trailing-semicolon and no-semicolon regression cases match the reference parser
- hosted compile, race, parity, exhaustive CGo parity, freshness, and performance checks passed

The change is limited to post-parse Python normalization; generated parse tables remain unchanged.