### PR TITLE
perf(parser): bound forest heap before fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Removed `foldPythonTrailingSelfCallIntoNestedFunction`, a Python
+  compat-normalization heuristic that spuriously folded a same-named trailing
+  call into a preceding nested function's block when that function's body
+  ended in a dangling `;` before a dedent. Raw parser results already matched
+  the reference; only the post-parse fold diverged. Python real-corpus
+  S-expression and deep parity both improve from 20/25 to 25/25.
 - The pooled forest GSS slab now clears outer batch references discarded by
   its 32 MiB retention cap. On the 3,447,275-byte JavaScript Poppler witness
   under the default 512 MiB parser budget, this reduced one-GC live heap from
@@ -163,19 +169,6 @@ benchmark trio remains neutral while full-parse bytes fall 18.68%.
   statement count for no fork-count benefit. C#'s helper is left in place: it
   depends on the literal source text of a contextual keyword (`scoped`),
   which `ConflictPolicies`' state/lookahead-symbol matching cannot express.
-### Fixed
-
-- Removed `foldPythonTrailingSelfCallIntoNestedFunction`, a Python
-  compat-normalization heuristic that spuriously folded a same-named
-  trailing call into a preceding nested function's block whenever that
-  function's own body ended in a dangling `;` before a dedent (e.g. `def
-  foo(): x = 1;` followed by a sibling `foo()` at the outer indent). Raw
-  GLR parse actions and materialized trees were already byte-identical
-  between the trailing-`;` and no-`;` forms and matched the reference
-  parser; only this post-parse fold diverged. Python real-corpus deep
-  parity goes from 20/25 to 25/25 (`python3.8_grammar.py` /
-  `python2-grammar.py` witnesses now match exactly).
-
 ## [0.28.0] - 2026-07-12
 
 Containment closure and measurement-honesty release. The runtime memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ for tags and release notes while still in `0.x`.
   metadata so one-language containers on the same physical benchmark host can
   produce a consistent authenticated host identity.
 
+### Performance
+
+- Forest parsing now applies the parser's existing runtime heap and system
+  memory guard in addition to its node-arena budget, covering GSS slabs and
+  alternative indexes before a failed forest attempt falls back to production
+  parsing. On the default-budget JavaScript Poppler witness, this moved the
+  forest decline from byte 1,147,865 to roughly byte 360,000, cut combined
+  elapsed time from 5.313 s to 2.610 s, total allocation from 2.450 GB to
+  1.289 GB, and maximum RSS from 1,961,948 KiB to 1,012,296 KiB while
+  preserving exact stopped-tree hashes. Final-diff successful-forest B-C-C-B
+  timing remained neutral (+1.4%, p=0.142), with a small measured allocation
+  cost (+0.28% B/op and +0.01% allocs/op). This bounds a failed attempt;
+  Poppler still reports the ordinary 512 MiB production fallback stop and is
+  not claimed to complete within that policy.
+
 ### Fixed
 
 - The pooled forest GSS slab now clears outer batch references discarded by

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2588,11 +2588,15 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 	defer releaseGSSForestNodeSlab(slab)
 	linkCap := forestLinkCapForLanguage(lang.Name)
 
-	// Honor the same per-parse memory budget the production loop enforces
-	// (parser.go: arena.budgetExhausted → ParseStopMemoryBudget). The forest has
-	// no partial-tree/error-recovery path, so on exhaustion it declines (returns
-	// false) and the production parser re-runs and reports ParseStopMemoryBudget.
-	arena.setBudget(parseMemoryBudgetForParser(p, len(source)))
+	// Honor the same per-parse memory budget the production loop enforces.
+	// The arena counter covers tree materialization, while the runtime-wide
+	// guard also covers forest-only heap such as GSS slabs and the alternative
+	// indexes. The forest has no partial-tree/error-recovery path, so on
+	// exhaustion it declines and lets the production parser report the stop.
+	restoreRuntimeMemoryBudget := p.enterForestMemoryBudget(arena, len(source))
+	if restoreRuntimeMemoryBudget.parser != nil {
+		defer restoreRuntimeMemoryBudget.restore()
+	}
 
 	// Honor the same caller-configured timeout/cancellation the production
 	// loop enforces (parser.go's `for iter := ...` checks p.parseStopReasonNow()
@@ -2649,7 +2653,7 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 			progress.beginDetail(time.Now(), "forest_step_begin", "", iter, tokens, Token{}, false, nil, 0, 0, 0, true, 0, 0,
 				forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, nil, ""))
 		}
-		if arena.budgetExhausted() {
+		if p.forestMemoryBudgetExceeded(arena, false) {
 			// Memory budget hit; decline so the production parser re-runs and
 			// reports ParseStopMemoryBudget (the forest has no partial-tree path).
 			p.recordForestDecline("budget", Token{StartByte: frontier[len(frontier)-1].byteOffset}, nil)
@@ -3115,6 +3119,15 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 			progress.endDetail(time.Now(), "forest_reduce_worklist_end", iter, tokens, tok, true, nil, 0, 0, 0, true, 0, 0,
 				forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, accepted, ""))
 		}
+		// A single token's reduce worklist is bounded by the visit/step caps, but
+		// it can still materialize enough nodes to cross the arena budget before
+		// the next outer-token poll. Catch that cheap, exact accounting boundary
+		// here. Forest-only heap is sampled at the next token and unconditionally
+		// before an accepted return below.
+		if arena.budgetExhausted() {
+			p.recordForestDecline("budget", tok, nil)
+			return nil, false
+		}
 
 		if eof {
 			// A genuinely CLEAN forest accept (zero recovery cost, no ERROR/MISSING
@@ -3162,6 +3175,10 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 						if int(eroot.endByte) < len(source) && bytesAreTrivia(source[eroot.endByte:]) {
 							extendNodeEndTo(eroot, uint32(len(source)), source)
 						}
+						if p.forestMemoryBudgetExceeded(arena, true) {
+							p.recordForestDecline("budget", tok, nil)
+							return nil, false
+						}
 						if progress.enabled {
 							progress.endDetail(time.Now(), "forest_collect_error_root_end", iter, tokens, tok, true, nil, 0, 0, 0, false, 0, 0,
 								forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, accepted,
@@ -3208,6 +3225,10 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 					progress.emit(time.Now(), "forest_decline", iter, tokens, tok, true, nil, 0, 0, 0, false, 0, 0,
 						forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, accepted, "decline_reason=noncontiguous_root"))
 				}
+				return nil, false
+			}
+			if p.forestMemoryBudgetExceeded(arena, true) {
+				p.recordForestDecline("budget", tok, nil)
 				return nil, false
 			}
 			if progress.enabled {
@@ -3327,6 +3348,22 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 				forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, accepted, "via=shift"))
 		}
 	}
+}
+
+func (p *Parser) enterForestMemoryBudget(arena *nodeArena, sourceLen int) runtimeMemoryBudgetRestore {
+	memoryBudget := parseMemoryBudgetForParser(p, sourceLen)
+	arena.setBudget(memoryBudget)
+	return p.enterRuntimeMemoryBudget(memoryBudget, sourceLen)
+}
+
+func (p *Parser) forestMemoryBudgetExceeded(arena *nodeArena, final bool) bool {
+	if arena.budgetExhausted() {
+		return true
+	}
+	if final {
+		return p.runtimeMemoryBudgetStopReasonNow() == ParseStopMemoryBudget
+	}
+	return p.runtimeMemoryBudgetStopReason(arenaAllocatedVolume(arena)) == ParseStopMemoryBudget
 }
 
 // maxForestNoLookaheadSteps bounds consecutive no-lookahead re-lex steps at one

--- a/glr_forest_budget_test.go
+++ b/glr_forest_budget_test.go
@@ -1,0 +1,113 @@
+package gotreesitter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnterForestMemoryBudgetArmsAndRestoresState(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "8")
+	t.Setenv("GOT_PARSE_MEMORY_HARD_CEILING_MB", "0")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+	DrainArenaPools()
+
+	parser := NewParser(loadBlobForDecode(t, "json"))
+	parser.parseRuntimeMemoryBudgetBytes = 11
+	parser.parseRuntimeMemoryBaselineBytes = 22
+	parser.parseRuntimeMemoryBaselineSys = 33
+	parser.parseRuntimeMemoryPoll = 44
+	parser.parseRuntimeMemoryVolumeAtPoll = 55
+	parser.parseRuntimeMemoryHardCeilingBytes = 66
+
+	arena := acquireNodeArena(arenaClassFull)
+	restore := parser.enterForestMemoryBudget(arena, parseRuntimeMemoryMinSourceBytes)
+	if restore.parser != parser {
+		t.Fatal("forest runtime memory budget did not arm for a large source")
+	}
+	if got, want := parser.parseRuntimeMemoryBudgetBytes, int64(8<<20); got != want {
+		t.Fatalf("armed runtime budget = %d, want %d", got, want)
+	}
+	if got, want := arena.budgetBytes, int64(8<<20); got != want {
+		t.Fatalf("armed arena budget = %d, want %d", got, want)
+	}
+	if parser.parseRuntimeMemoryHardCeilingBytes != 0 {
+		t.Fatalf("armed hard ceiling = %d, want disabled", parser.parseRuntimeMemoryHardCeilingBytes)
+	}
+	restore.restore()
+	arena.Release()
+
+	if got := parser.parseRuntimeMemoryBudgetBytes; got != 11 {
+		t.Fatalf("runtime budget after parseForest = %d, want 11", got)
+	}
+	if got := parser.parseRuntimeMemoryBaselineBytes; got != 22 {
+		t.Fatalf("runtime heap baseline after parseForest = %d, want 22", got)
+	}
+	if got := parser.parseRuntimeMemoryBaselineSys; got != 33 {
+		t.Fatalf("runtime sys baseline after parseForest = %d, want 33", got)
+	}
+	if got := parser.parseRuntimeMemoryPoll; got != 44 {
+		t.Fatalf("runtime poll after parseForest = %d, want 44", got)
+	}
+	if got := parser.parseRuntimeMemoryVolumeAtPoll; got != 55 {
+		t.Fatalf("runtime volume checkpoint after parseForest = %d, want 55", got)
+	}
+	if got := parser.parseRuntimeMemoryHardCeilingBytes; got != 66 {
+		t.Fatalf("runtime hard ceiling after parseForest = %d, want 66", got)
+	}
+}
+
+func TestParseForestMemoryBudgetDeclines(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "512")
+	t.Setenv("GOT_PARSE_MEMORY_HARD_CEILING_MB", "1")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+	DrainArenaPools()
+
+	parser := NewParser(loadBlobForDecode(t, "json"))
+	parser.parseRuntimeMemoryBudgetBytes = 17
+	parser.parseRuntimeMemoryHardCeilingBytes = 23
+	// Clear the runtime guard's 64 KiB arming floor. The 1 MiB runtime hard
+	// ceiling must decline before the intentionally roomy 512 MiB node arena;
+	// this makes the regression sensitive to the forest's runtime-wide poll.
+	source := []byte("[" + strings.Repeat("0,", 40_000) + "0]")
+	arena := acquireNodeArena(arenaClassFull)
+	root, ok := parser.parseForest(arena, source, false)
+	arenaBudgetExhausted := arena.budgetExhausted()
+	arena.Release()
+	if ok || root != nil {
+		t.Fatal("parseForest accepted despite the 1 MiB runtime hard ceiling")
+	}
+	if _, _, reason, _ := parser.ForestDeclineInfo(); reason != "budget" {
+		t.Fatalf("forest decline reason = %q, want budget", reason)
+	}
+	if arenaBudgetExhausted {
+		t.Fatal("node arena exhausted; test did not isolate the runtime-wide forest budget")
+	}
+	if got := parser.parseRuntimeMemoryBudgetBytes; got != 17 {
+		t.Fatalf("runtime budget after parseForest decline = %d, want 17", got)
+	}
+	if got := parser.parseRuntimeMemoryHardCeilingBytes; got != 23 {
+		t.Fatalf("runtime hard ceiling after parseForest decline = %d, want 23", got)
+	}
+}
+
+func TestForestMemoryBudgetFinalCheckSamplesRuntimeUnmasked(t *testing.T) {
+	parser := &Parser{
+		parseRuntimeMemoryBudgetBytes:   1,
+		parseRuntimeMemoryBaselineBytes: 0,
+	}
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+	arena.setBudget(1 << 30)
+
+	// The ordinary masked poll should skip its first sample. The final check
+	// must bypass that mask so EOF/root materialization cannot return a tree
+	// whose forest-only heap crossed the budget after the last token boundary.
+	if parser.forestMemoryBudgetExceeded(arena, false) {
+		t.Fatal("ordinary masked poll unexpectedly sampled on its first call")
+	}
+	if !parser.forestMemoryBudgetExceeded(arena, true) {
+		t.Fatal("final forest budget check did not sample live runtime memory")
+	}
+}


### PR DESCRIPTION
## Summary

- apply the existing runtime heap and system-memory guard during forest parsing, covering GSS slabs and alternative indexes in addition to the node arena
- check exact arena growth after each reduction worklist and perform an unmasked runtime check before accepted returns
- restore prior parser budget state on every exit and add focused regression coverage
- keep the concurrently merged Python compatibility fix in `[Unreleased]` rather than a prior release section

## Evidence

- Default-budget Poppler forest decline moved from byte 1,147,865 to about 360,000; combined time fell 5.313s to 2.610s, allocation 2.450GB to 1.289GB, and max RSS 1,961,948KiB to 1,012,296KiB. Returned stopped-tree hashes were unchanged.
- At a 2GiB parser budget, Poppler accepted the full 3,447,275-byte input with exact C no-error, S-expression, and deep parity; Docker exited cleanly without OOM.
- JavaScript single-grammar parity passed 25/25 on no-error, S-expression, and deep axes.
- Final-diff successful-forest B-C-C-B timing was neutral: +1.4%, p=0.142, n=20. The guard has a small measured allocation cost: +0.28% B/op and +0.01% allocs/op.
- The stable full, single-edit, and no-edit benchmark trio remained statistically neutral.

## Scope

This bounds an expensive failed forest attempt. Poppler still reports the ordinary 512MiB production fallback stop and is not claimed to complete within that policy.