### PR TITLE
perf(parser): make clean condense summaries demand-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Performance
+
+- Clean full parses now make C-recovery condense summaries demand-driven.
+  Before any error-bearing payload exists, condense charges only the exact
+  open-recovery costs instead of recursively re-summing clean subtrees; visible
+  node counts are evaluated only by the unequal-cost comparison branch that
+  consumes them. On a 4,096-entry generated Go composite witness this reduces
+  a full accepted parse from 18.72 s to 93 ms and one-shot maximum RSS from
+  1,388,988 KiB to 498,240 KiB, with the same full, error-free S-expression.
+  The exact 726,532-byte Go manifest witness now completes in 0.39 s with full
+  span and no error. The standard full/incremental/no-edit benchmark trio and
+  KDL recovery benchmark retain unchanged allocations and show no candidate
+  regression.
+
+### Fixed
+
+- Missing extra shifts, including the C-family zero-width missing-token case,
+  and alias-prefixed recovered-suffix resyncs now mark error-bearing content
+  before the next condense pass. This keeps the clean-subtree proof exact
+  without adding node metadata, parser caches, or language-specific fast paths.
+
 ## [0.31.0] - 2026-07-13
 
 Memory containment, Python parity, and authenticated fleet-reporting release.

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -29,6 +29,20 @@ func makeGoBenchmarkSource(funcCount int) []byte {
 	return []byte(sb.String())
 }
 
+// makeGoLargeCompositeBenchmarkSource exercises the Go grammar's recurring
+// paused-clean version comparisons without introducing recovery or malformed
+// input. It guards the scaling behavior of large generated declarations.
+func makeGoLargeCompositeBenchmarkSource(entryCount int) []byte {
+	var sb strings.Builder
+	sb.Grow(128 + entryCount*32)
+	sb.WriteString("package p\n\ntype S struct { A string; B int; C int; D string }\nconst Method = 1\nvar X = map[string][]S{\"k\": {\n")
+	for i := 0; i < entryCount; i++ {
+		fmt.Fprintf(&sb, "{\"x%d\", Method, 1, \"\"},\n", i)
+	}
+	sb.WriteString("}}\n")
+	return []byte(sb.String())
+}
+
 func pointAtOffset(src []byte, offset int) gotreesitter.Point {
 	var row uint32
 	var col uint32
@@ -262,6 +276,28 @@ func BenchmarkGoParseFullDFA(b *testing.B) {
 			lastRuntime.MergeStacksIn, lastRuntime.MergeStacksOut, lastRuntime.MergeSlotsUsed,
 			lastRuntime.GlobalCullStacksIn, lastRuntime.GlobalCullStacksOut,
 		)
+	}
+}
+
+func BenchmarkGoParseLargeCompositeDFA(b *testing.B) {
+	lang := grammars.GoLanguage()
+	parser := gotreesitter.NewParser(lang)
+	src := makeGoLargeCompositeBenchmarkSource(4096)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(src)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		root := requireCompleteParse(b, tree, src, lang, "large composite dfa")
+		if root.HasError() {
+			b.Fatal("large composite parse returned an error-bearing tree")
+		}
+		tree.Release()
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -3928,6 +3928,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		p.cRecoverCustomResyncActive = false
 		p.cRecoverCustomResyncByte = 0
 	}
+	// Fresh full parses defer parent links and start with no error-bearing
+	// payload. Besides controlling parent metadata propagation, this is a
+	// sticky proof consumed by C-recovery condense: every path that inserts an
+	// ERROR or MISSING payload must flip it before the next condense pass.
+	// Incremental/reuse parses start true because old subtrees may carry errors.
 	trackChildErrors := !deferParentLinks
 
 	arena := acquireNodeArena(arenaClass)
@@ -4998,7 +5003,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					continue
 				}
 				traceVisit(si, s, "extra-shift", 0, len(actions), actions[0])
-				p.applyExtraShiftAction(s, currentState, actions[0], tok, arena, scratch)
+				p.applyExtraShiftAction(s, currentState, actions[0], tok, arena, scratch, &trackChildErrors)
 				nodeCount++
 				traceAfterPrimary(si, s)
 				consumeCurrentToken(s)
@@ -6981,17 +6986,21 @@ func clearGLRStateTokenSource(stateful parserStateTokenSource, scratch *parserSc
 	stateful.SetGLRStates(nil)
 }
 
-func (p *Parser) applyExtraShiftAction(s *glrStack, currentState StateID, act ParseAction, tok Token, arena *nodeArena, scratch *parserScratch) {
+func (p *Parser) applyExtraShiftAction(s *glrStack, currentState StateID, act ParseAction, tok Token, arena *nodeArena, scratch *parserScratch, trackChildErrors *bool) {
 	named := p.isNamedSymbol(tok.Symbol)
 	targetState := extraShiftTargetState(currentState, act)
-	if p.useCompactNoTreeShiftLeaf() && !p.shiftTokenIsMissingError(tok) {
+	isMissing := p.shiftTokenIsMissingError(tok)
+	if p.useCompactNoTreeShiftLeaf() && !isMissing {
 		p.applyCompactExtraShiftAction(s, currentState, targetState, tok, named, arena, scratch)
 		return
 	}
 	leaf := newLeafNodeInArena(arena, tok.Symbol, named, tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
-	if tok.Missing {
+	if isMissing {
 		leaf.setMissing(true)
 		leaf.setHasError(true)
+		if trackChildErrors != nil {
+			*trackChildErrors = true
+		}
 	}
 	leaf.setExtra(true)
 	leaf.setExternalScannerToken(tok.ExternalScannerToken)

--- a/parser_extra_shift_test.go
+++ b/parser_extra_shift_test.go
@@ -67,6 +67,46 @@ func TestApplyActionNonterminalExtraShiftUsesActionState(t *testing.T) {
 	}
 }
 
+func TestApplyExtraShiftMissingMarksChildErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		language string
+		explicit bool
+	}{
+		{name: "explicit missing", explicit: true},
+		{name: "C zero-width missing", language: "c"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := buildArithmeticLanguage()
+			lang.Name = tc.language
+			parser := NewParser(lang)
+			arena := newNodeArena(arenaClassFull)
+			stack := newGLRStack(lang.InitialState)
+			scratch := &parserScratch{}
+			trackChildErrors := false
+			tok := Token{
+				Symbol:    1,
+				StartByte: 4,
+				EndByte:   4,
+				Missing:   tc.explicit,
+			}
+
+			parser.applyExtraShiftAction(&stack, lang.InitialState, ParseAction{
+				Type:  ParseActionShift,
+				Extra: true,
+			}, tok, arena, scratch, &trackChildErrors)
+
+			if !trackChildErrors {
+				t.Fatal("missing extra shift did not mark child-error tracking")
+			}
+			leaf := stackEntryNode(stack.top())
+			if leaf == nil || !leaf.isMissing() || !leaf.hasError() {
+				t.Fatalf("missing extra leaf = %#v", leaf)
+			}
+		})
+	}
+}
+
 func TestApplyActionNonExtraShiftUsesActionState(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1707,6 +1707,17 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 			}
 		}
 	}
+	return cost + cStackOpenRecoveryCost(s)
+}
+
+// cStackOpenRecoveryCost is the part of ts_stack_error_cost that does not
+// come from materialized subtrees. Keeping it separate lets the condense path
+// skip a provably-zero subtree walk without duplicating recovery semantics.
+func cStackOpenRecoveryCost(s *glrStack) uint32 {
+	if s == nil {
+		return 0
+	}
+	var cost uint32
 	if s.cPaused || (s.cRec != nil && s.cRec.openErr == nil) {
 		cost += cErrCostPerRecovery
 	}
@@ -1892,6 +1903,52 @@ func (p *Parser) cVersionStatus(s *glrStack) cErrorStatus {
 		// C ts_parser__version_status: in error when paused or at ERROR_STATE.
 		isInError: s.cPaused || s.cRec != nil,
 	}
+}
+
+func (p *Parser) cCondenseVersionStatus(s *glrStack, subtreeCostRelevant bool) cErrorStatus {
+	var cost uint32
+	if subtreeCostRelevant {
+		cost = p.cStackErrorCost(s)
+	} else {
+		// trackChildErrors is false only on a fresh full parse before any ERROR
+		// or MISSING subtree has been inserted. The recursive subtree component
+		// is therefore exactly zero, but paused/open-recovery costs still apply.
+		cost = cStackOpenRecoveryCost(s)
+	}
+	if s.cPaused {
+		cost += cErrCostPerSkippedTree
+	}
+	status := cErrorStatus{
+		cost:      cost,
+		dynPrec:   s.score,
+		isInError: s.cPaused || s.cRec != nil,
+	}
+	// cNodeCountSinceError clamps a baseline that has moved above the current
+	// stack count. Preserve that eager side effect for recovery lineages even
+	// when this comparison branch will not read nodeCount.
+	if s.cNodeBaseline != 0 {
+		status.nodeCount = p.cNodeCountSinceError(s)
+	}
+	return status
+}
+
+// cCompareCondenseVersions preserves cCompareVersions' literal C semantics
+// while deferring the fresh-lineage visible-node walk until the one
+// unequal-cost branch that actually reads the cheaper side's count.
+func (p *Parser) cCompareCondenseVersions(a, b cErrorStatus, aStack, bStack *glrStack) cErrorComparison {
+	if a.isInError == b.isInError {
+		if a.cost < b.cost {
+			a.nodeCount = p.cNodeCountSinceError(aStack)
+		} else if b.cost < a.cost {
+			b.nodeCount = p.cNodeCountSinceError(bStack)
+		}
+	}
+	return cCompareVersions(a, b)
+}
+
+func (p *Parser) cVersionStatusForTrace(s *glrStack, status cErrorStatus) cErrorStatus {
+	status.nodeCount = p.cNodeCountSinceError(s)
+	return status
 }
 
 // A condense-step drop of a recovery-owning version in favor of a marker-free
@@ -3633,12 +3690,15 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 		alive = append(alive, stacks[i])
 	}
 	stacks = alive
+	// No stack payloads are inserted during the pairwise phase, so the sticky
+	// construction proof cannot change until the resume phase below.
+	subtreeCostRelevant := trackChildErrors == nil || *trackChildErrors
 	statusProbe := 0
 	for i := 1; i < len(stacks); i++ {
 		if reason := checkStop(); reason != ParseStopNone {
 			return stacks, false, tok, reason
 		}
-		statusI := p.cVersionStatus(&stacks[i])
+		statusI := p.cCondenseVersionStatus(&stacks[i], subtreeCostRelevant)
 		for j := 0; j < i; j++ {
 			statusProbe++
 			if statusProbe&63 == 0 {
@@ -3654,32 +3714,38 @@ func (p *Parser) cCondenseAndResume(stacks []glrStack, source []byte, tok Token,
 			}
 			if cRecoverVersionShouldStayBefore(stacks[i], stacks[j]) {
 				stacks[i], stacks[j] = stacks[j], stacks[i]
-				statusI = p.cVersionStatus(&stacks[i])
+				statusI = p.cCondenseVersionStatus(&stacks[i], subtreeCostRelevant)
 				continue
 			}
-			statusJ := p.cVersionStatus(&stacks[j])
-			switch cCompareVersions(statusJ, statusI) {
+			statusJ := p.cCondenseVersionStatus(&stacks[j], subtreeCostRelevant)
+			switch p.cCompareCondenseVersions(statusJ, statusI, &stacks[j], &stacks[i]) {
 			case cErrorComparisonTakeLeft:
 				if p.glrTrace {
-					p.traceCCondenseDrop("take-left", i, j, stacks[i], stacks[j], statusI, statusJ)
+					p.traceCCondenseDrop("take-left", i, j, stacks[i], stacks[j],
+						p.cVersionStatusForTrace(&stacks[i], statusI),
+						p.cVersionStatusForTrace(&stacks[j], statusJ))
 				}
 				stacks = append(stacks[:i], stacks[i+1:]...)
 				i--
 				j = i
 			case cErrorComparisonPreferRight:
 				if p.glrTrace {
-					p.traceCCondenseSwap("prefer-right", i, j, stacks[i], stacks[j], statusI, statusJ)
+					p.traceCCondenseSwap("prefer-right", i, j, stacks[i], stacks[j],
+						p.cVersionStatusForTrace(&stacks[i], statusI),
+						p.cVersionStatusForTrace(&stacks[j], statusJ))
 				}
 				stacks[i], stacks[j] = stacks[j], stacks[i]
-				statusI = p.cVersionStatus(&stacks[i])
+				statusI = p.cCondenseVersionStatus(&stacks[i], subtreeCostRelevant)
 			case cErrorComparisonTakeRight:
 				if p.glrTrace {
-					p.traceCCondenseDrop("take-right", j, i, stacks[j], stacks[i], statusJ, statusI)
+					p.traceCCondenseDrop("take-right", j, i, stacks[j], stacks[i],
+						p.cVersionStatusForTrace(&stacks[j], statusJ),
+						p.cVersionStatusForTrace(&stacks[i], statusI))
 				}
 				stacks = append(stacks[:j], stacks[j+1:]...)
 				i--
 				j--
-				statusI = p.cVersionStatus(&stacks[i])
+				statusI = p.cCondenseVersionStatus(&stacks[i], subtreeCostRelevant)
 			}
 			if i < 1 {
 				break

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -33,6 +33,101 @@ func TestCVersionStatusAddsPausedSkippedTreeCost(t *testing.T) {
 	}
 }
 
+func TestCCondenseFreshTreeGatePreservesOpenRecoveryCosts(t *testing.T) {
+	parser := &Parser{language: &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}}
+	open := &Node{symbol: errorSymbol}
+	for _, tc := range []struct {
+		name  string
+		stack glrStack
+	}{
+		{name: "clean"},
+		{name: "paused", stack: glrStack{cPaused: true}},
+		{name: "open recovery", stack: glrStack{cRec: &cRecoverState{}}},
+		{name: "open recovery segments", stack: glrStack{cRec: &cRecoverState{extraRecoveries: 2}}},
+		{name: "materialized recovery", stack: glrStack{cRec: &cRecoverState{openErr: open, extraRecoveries: 2}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parser.cCondenseVersionStatus(&tc.stack, false)
+			want := parser.cVersionStatus(&tc.stack)
+			if got != want {
+				t.Fatalf("fresh-tree status = %+v, want eager %+v", got, want)
+			}
+		})
+	}
+
+	missing := &Node{symbol: 1}
+	missing.setMissing(true)
+	stack := glrStack{entries: []stackEntry{newStackEntryNode(1, missing)}}
+	got := parser.cCondenseVersionStatus(&stack, true)
+	want := parser.cVersionStatus(&stack)
+	if got.cost != want.cost || got.dynPrec != want.dynPrec || got.isInError != want.isInError {
+		t.Fatalf("error-bearing status = %+v, want eager cost/category %+v", got, want)
+	}
+}
+
+func TestCCondenseVersionStatusPreservesBaselineClamp(t *testing.T) {
+	parser := &Parser{language: &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}}
+	stack := glrStack{
+		entries:       []stackEntry{newStackEntryNode(1, &Node{symbol: 1})},
+		cNodeBaseline: 2,
+	}
+	status := parser.cCondenseVersionStatus(&stack, false)
+	if status.nodeCount != 0 {
+		t.Fatalf("node count = %d, want 0 after clamp", status.nodeCount)
+	}
+	if stack.cNodeBaseline != 1 {
+		t.Fatalf("baseline = %d, want clamped 1", stack.cNodeBaseline)
+	}
+}
+
+func TestCCompareCondenseVersionsEvaluatesOnlyReadNodeCount(t *testing.T) {
+	parser := &Parser{language: &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}}
+	leaf := &Node{symbol: 1}
+	baselineStack := glrStack{
+		entries:       []stackEntry{newStackEntryNode(1, leaf)},
+		cNodeBaseline: 2,
+	}
+	parser.cCondenseVersionStatus(&baselineStack, false)
+	if baselineStack.cNodeBaseline != 1 {
+		t.Fatalf("condense status did not preserve baseline clamp: baseline = %d, want 1", baselineStack.cNodeBaseline)
+	}
+
+	stack := glrStack{
+		entries:       []stackEntry{newStackEntryNode(1, leaf)},
+		cNodeBaseline: 2,
+	}
+
+	clean := cErrorStatus{cost: 1}
+	inError := cErrorStatus{cost: 2, isInError: true}
+	if got := parser.cCompareCondenseVersions(clean, inError, &stack, &stack); got != cCompareVersions(clean, inError) {
+		t.Fatalf("category comparison = %v, want %v", got, cCompareVersions(clean, inError))
+	}
+	if stack.cNodeBaseline != 2 {
+		t.Fatalf("category comparison evaluated node count: baseline = %d, want 2", stack.cNodeBaseline)
+	}
+
+	equalA := cErrorStatus{cost: 3, dynPrec: 1}
+	equalB := cErrorStatus{cost: 3}
+	if got := parser.cCompareCondenseVersions(equalA, equalB, &stack, &stack); got != cCompareVersions(equalA, equalB) {
+		t.Fatalf("equal-cost comparison = %v, want %v", got, cCompareVersions(equalA, equalB))
+	}
+	if stack.cNodeBaseline != 2 {
+		t.Fatalf("equal-cost comparison evaluated node count: baseline = %d, want 2", stack.cNodeBaseline)
+	}
+
+	cheaper := cErrorStatus{cost: 1}
+	dearer := cErrorStatus{cost: 2}
+	eagerCheaper := cheaper
+	stackForWant := stack
+	eagerCheaper.nodeCount = parser.cNodeCountSinceError(&stackForWant)
+	if got, want := parser.cCompareCondenseVersions(cheaper, dearer, &stack, &stack), cCompareVersions(eagerCheaper, dearer); got != want {
+		t.Fatalf("unequal-cost comparison = %v, want %v", got, want)
+	}
+	if stack.cNodeBaseline != 1 {
+		t.Fatalf("unequal-cost comparison did not evaluate cheaper node count: baseline = %d, want 1", stack.cNodeBaseline)
+	}
+}
+
 func TestCRecoveryCostCompetitionDisabledInNoTreeModes(t *testing.T) {
 	parser := &Parser{errorCostCompetition: true}
 	if !parser.errorCostCompetitionEnabled() {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -1389,6 +1389,9 @@ func (p *Parser) tryResyncErrorRecoveryMode(source []byte, s *glrStack, tok Toke
 	}
 	if status == resyncRetry {
 		if recovered, target, ok := p.rebuildAliasPrefixedRecoveredSuffix(source, gotoState, poppedNodes[preservedEnd:], tok.Symbol, arena); ok {
+			if trackChildErrors != nil {
+				*trackChildErrors = true
+			}
 			keepDepth := len(entries) - recoverIdx
 			if !s.truncate(keepDepth) {
 				return resyncNone
@@ -2528,7 +2531,8 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 	named := p.isNamedSymbol(tok.Symbol)
 	currentState := s.top().state
 	targetState := extraShiftTargetState(currentState, act)
-	if p.useCompactNoTreeShiftLeaf() && !p.shiftTokenIsMissingError(tok) {
+	isMissing := p.shiftTokenIsMissingError(tok)
+	if p.useCompactNoTreeShiftLeaf() && !isMissing {
 		extra := act.Extra
 		if cp, ok := p.currentExternalNoTreeLeafCheckpointRef(arena, tok); ok {
 			leaf := newCompactCheckpointLeafInArena(arena, tok.Symbol, named, tok.StartByte, tok.EndByte, cp)
@@ -2566,7 +2570,6 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 		// allocation entirely on hit. The previous post-allocation
 		// variant paid hash+lookup overhead per shift without saving
 		// the allocation, which net-regressed wall time on JS.
-		isMissing := p.shiftTokenIsMissingError(tok)
 		var flags nodeFlags
 		if named {
 			flags |= nodeFlagNamed


### PR DESCRIPTION
## Summary

- skip recursive clean-subtree error-cost walks during C-recovery condense using the existing sticky error-content construction state
- defer visible-node counting until the unequal-cost comparison branch that consumes it, while preserving recovery-baseline clamping and GLR trace output
- mark missing extra shifts and alias-prefixed recovered suffixes before the next condense pass
- add focused invariant coverage and a permanent large-composite materialized-tree benchmark
- record the change under `Unreleased`

## Results

- 4,096-entry generated Go composite: 18.72 s -> 93 ms (201x), with the same full, error-free S-expression
- one-shot maximum RSS on that witness: 1,388,988 KiB -> 498,240 KiB
- exact 726,532-byte Go manifest: accepted at full span with no error in 0.39 s
- standard full/incremental/no-edit trio: no candidate regression; allocations unchanged
- KDL recovery benchmark: statistically neutral; bytes and allocations unchanged

## Validation

- focused invariant tests in Docker
- full root package in Docker
- Go real-corpus parity: 25/25 no-error, 25/25 S-expression, 25/25 deep parity
- C real-corpus comparison: candidate and v0.31 baseline both 22/25 no-error, 20/25 S-expression, 20/25 deep parity
- B-C-C-B benchmark runs for the standard trio and KDL recovery
