### PR TITLE
fix(csharp): preserve compatibility for uncertified grammars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,20 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-### Removed
+### Changed
 
-- Five confirmed-dead C# post-parse compat/recovery passes: `notnull`
-  type-constraint keyword unwrap, Unicode identifier span extension, scoped-
-  lambda statement splitting, scoped-lambda block recovery, and LINQ query-
-  expression recovery, plus their exclusively-owned helpers (call-graph
-  verified, not file-size estimated; shared builders such as the query-clause
-  and interpolated-string-expression recovery machinery are unaffected and
-  stay). Grammar-native output now produces `notnull` constraints and full
-  Unicode identifier spans directly, scoped lambdas parse without splitting,
-  and query expressions parse clean, making all five rewrites permanently
-  unreachable. Verified with a corpus sweep (1,700-file real-world C# corpus,
-  clean and truncated-55%-every-2nd phases), each pass's original motivating
-  snippets, and — for the query-expression cut specifically — an 84-program
-  LINQ battery (75 authored programs plus the full upstream tree-sitter-c-sharp
-  query-syntax corpus) covering from/where/select/group/join/let/orderby/
-  into-continuation/nested/degenerate/anonymous-type/method-mixed forms: zero
-  rewrites fired anywhere. Byte-identical (S-expression and spans) on 25
-  representative real-world files and the full LINQ battery. Net ~745 lines
-  removed.
+- The exact bundled C# grammar now advertises native result compatibility for
+  `notnull` constraints, Unicode identifier spans, scoped-lambda statements and
+  blocks, and LINQ query expressions, allowing the runtime to skip the five
+  corresponding post-parse passes for that certified blob. The implementations
+  remain quarantined conservative fallbacks for legacy blobs, grammargen output,
+  caller-built languages, and overrides unless those artifacts explicitly carry
+  the relevant append-only capability bits. Runtime-profile attachment remains
+  pinned to the exact blob SHA; attaching scanner support by name alone does not
+  certify native result shapes. The skip is backed by the 1,700-file C# corpus
+  sweep, the original motivating fixtures, an 84-program LINQ battery, explicit
+  capability round-trip and identity gates, and direct embedded-grammar Unicode,
+  scoped-lambda, and LINQ regressions.
 
 ### Performance
 

--- a/grammars/csharp_native_result_compatibility_test.go
+++ b/grammars/csharp_native_result_compatibility_test.go
@@ -1,0 +1,95 @@
+package grammars
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func TestEmbeddedCSharpNativeUnicodeIdentifier(t *testing.T) {
+	lang := CSharpLanguage()
+	source := []byte("class C { int ග්‍රහලෝකය = 0; }\n")
+	tree := parseEmbeddedCSharpNativeFixture(t, lang, source)
+	defer tree.Release()
+
+	identifier := findFirstNamedDescendantWhere(tree.RootNode(), lang, "identifier", func(node *gotreesitter.Node) bool {
+		return node.Text(source) == "ග්‍රහලෝකය"
+	})
+	if identifier == nil {
+		t.Fatalf("missing full Unicode identifier span: %s", tree.RootNode().SExpr(lang))
+	}
+}
+
+func TestEmbeddedCSharpNativeScopedLambdaBlock(t *testing.T) {
+	lang := CSharpLanguage()
+	source := []byte(`class C {
+    void M() {
+        var first = scoped => null;
+        var second = (scoped value) => value;
+    }
+}
+`)
+	tree := parseEmbeddedCSharpNativeFixture(t, lang, source)
+	defer tree.Release()
+
+	if got := countNamedCSharpNodes(tree.RootNode(), lang, "lambda_expression"); got != 2 {
+		t.Fatalf("lambda_expression count = %d, want 2: %s", got, tree.RootNode().SExpr(lang))
+	}
+	if got := countNamedCSharpNodes(tree.RootNode(), lang, "local_declaration_statement"); got != 2 {
+		t.Fatalf("local_declaration_statement count = %d, want 2: %s", got, tree.RootNode().SExpr(lang))
+	}
+}
+
+func TestEmbeddedCSharpNativeLINQQueryExpression(t *testing.T) {
+	lang := CSharpLanguage()
+	source := []byte(`class C {
+    void M() {
+        var result = from a in sourceA
+                     join b in sourceB on a.ID equals b.ID
+                     where a.Enabled
+                     select new { a, b };
+    }
+}
+`)
+	tree := parseEmbeddedCSharpNativeFixture(t, lang, source)
+	defer tree.Release()
+
+	query := findFirstNamedDescendantWhere(tree.RootNode(), lang, "query_expression", func(node *gotreesitter.Node) bool {
+		return strings.Contains(node.Text(source), "join b in sourceB")
+	})
+	if query == nil {
+		t.Fatalf("missing native query_expression: %s", tree.RootNode().SExpr(lang))
+	}
+}
+
+func parseEmbeddedCSharpNativeFixture(t *testing.T, lang *gotreesitter.Language, source []byte) *gotreesitter.Tree {
+	t.Helper()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse embedded C# fixture: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("parse embedded C# fixture returned nil root")
+	}
+	root := tree.RootNode()
+	if root.HasError() || root.EndByte() != uint32(len(source)) {
+		t.Fatalf("embedded C# fixture was not accepted cleanly to EOF: %s", root.SExpr(lang))
+	}
+	return tree
+}
+
+func countNamedCSharpNodes(node *gotreesitter.Node, lang *gotreesitter.Language, typ string) int {
+	if node == nil {
+		return 0
+	}
+	count := 0
+	if node.IsNamed() && node.Type(lang) == typ {
+		count++
+	}
+	for i := 0; i < node.NamedChildCount(); i++ {
+		count += countNamedCSharpNodes(node.NamedChild(i), lang, typ)
+	}
+	return count
+}

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -15,6 +15,7 @@ type builtinLanguageRuntimeProfile struct {
 	blobSHA256                         [32]byte
 	externalScannerFullParseRetry      gotreesitter.ExternalScannerFullParseRetryPolicy
 	fullParseAcceptedErrorRetryProfile gotreesitter.FullParseAcceptedErrorRetryProfile
+	nativeResultCompatibility          gotreesitter.ResultCompatibilityCapability
 	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
 
@@ -47,6 +48,11 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	"c_sharp": {
 		blobSHA256:                    mustRuntimeProfileSHA256("7ad425e89733339dde94e3c03b762ae478fb453b530493f5d62e1ae7537e1784"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		nativeResultCompatibility: gotreesitter.ResultCompatibilityCSharpNativeNotNull |
+			gotreesitter.ResultCompatibilityCSharpNativeUnicodeIdentifiers |
+			gotreesitter.ResultCompatibilityCSharpNativeScopedLambdaStatements |
+			gotreesitter.ResultCompatibilityCSharpNativeScopedLambdaBlocks |
+			gotreesitter.ResultCompatibilityCSharpNativeQueryExpressions,
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry:             true,
 			SkipCompleteMaxEntryScratchPeak:            csharpAcceptedErrorRetryMaxEntryScratchPeak,
@@ -274,6 +280,10 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	if profile.fullParseAcceptedErrorRetryProfile != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) &&
 		lang.FullParseAcceptedErrorRetryProfile != profile.fullParseAcceptedErrorRetryProfile {
 		lang.FullParseAcceptedErrorRetryProfile = profile.fullParseAcceptedErrorRetryProfile
+		changed = true
+	}
+	if missing := profile.nativeResultCompatibility &^ lang.NativeResultCompatibility; missing != 0 {
+		lang.NativeResultCompatibility |= missing
 		changed = true
 	}
 	for _, policy := range profile.conflictPolicies {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -481,6 +481,51 @@ func TestResidualRetryProfilesRequireExactBlobIdentity(t *testing.T) {
 	}
 }
 
+func TestCSharpNativeResultCompatibilityRequiresExactBlobIdentity(t *testing.T) {
+	want := gotreesitter.ResultCompatibilityCSharpNativeNotNull |
+		gotreesitter.ResultCompatibilityCSharpNativeUnicodeIdentifiers |
+		gotreesitter.ResultCompatibilityCSharpNativeScopedLambdaStatements |
+		gotreesitter.ResultCompatibilityCSharpNativeScopedLambdaBlocks |
+		gotreesitter.ResultCompatibilityCSharpNativeQueryExpressions
+
+	wrongSHA := &gotreesitter.Language{Name: "c_sharp"}
+	if attachBuiltinLanguageRuntimeProfile("c_sharp", sha256.Sum256([]byte("uncertified")), wrongSHA) {
+		t.Fatal("wrong blob SHA reported a runtime-profile attachment")
+	}
+	if got := wrongSHA.NativeResultCompatibility; got != 0 {
+		t.Fatalf("wrong blob SHA attached native result compatibility %#x", got)
+	}
+
+	adapted := &gotreesitter.Language{Name: "c_sharp"}
+	AttachLanguageSupport("c_sharp", adapted)
+	if got := adapted.NativeResultCompatibility; got != 0 {
+		t.Fatalf("AttachLanguageSupport certified native result compatibility without blob identity: %#x", got)
+	}
+
+	blob := BlobByName("c_sharp")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(c_sharp) returned no data")
+	}
+	exact := &gotreesitter.Language{Name: "c_sharp"}
+	if !attachBuiltinLanguageRuntimeProfile("c_sharp", sha256.Sum256(blob), exact) {
+		t.Fatal("exact C# blob did not attach its runtime profile")
+	}
+	if got := exact.NativeResultCompatibility; got != want {
+		t.Fatalf("exact profile NativeResultCompatibility = %#x, want %#x", got, want)
+	}
+
+	loaded, err := LoadLanguage("c_sharp", blob)
+	if err != nil {
+		t.Fatalf("LoadLanguage(c_sharp): %v", err)
+	}
+	if got := loaded.NativeResultCompatibility; got != want {
+		t.Fatalf("LoadLanguage NativeResultCompatibility = %#x, want %#x", got, want)
+	}
+	if got := CSharpLanguage().NativeResultCompatibility; got != want {
+		t.Fatalf("embedded CSharpLanguage NativeResultCompatibility = %#x, want %#x", got, want)
+	}
+}
+
 func TestBuiltinCompleteAcceptedErrorRetryProfileRequiresCertifiedBlob(t *testing.T) {
 	for _, name := range []string{"caddy", "c_sharp", "haxe", "kdl", "odin", "rego", "scss", "swift", "tcl"} {
 		t.Run(name, func(t *testing.T) {

--- a/language.go
+++ b/language.go
@@ -318,6 +318,20 @@ type FullParseAcceptedErrorRetryProfile struct {
 	SkipInitialCompleteAcceptedErrorMergeRetry bool
 }
 
+// ResultCompatibilityCapability records result-tree shapes that a language
+// produces natively and therefore does not need the runtime to repair after
+// parsing. Keep capability values append-only: Language blobs encode these
+// numeric bits, and a zero value deliberately preserves legacy behavior.
+type ResultCompatibilityCapability uint64
+
+const (
+	ResultCompatibilityCSharpNativeNotNull                ResultCompatibilityCapability = 1 << 0
+	ResultCompatibilityCSharpNativeUnicodeIdentifiers     ResultCompatibilityCapability = 1 << 1
+	ResultCompatibilityCSharpNativeScopedLambdaStatements ResultCompatibilityCapability = 1 << 2
+	ResultCompatibilityCSharpNativeScopedLambdaBlocks     ResultCompatibilityCapability = 1 << 3
+	ResultCompatibilityCSharpNativeQueryExpressions       ResultCompatibilityCapability = 1 << 4
+)
+
 // Language holds all data needed to parse a specific language.
 // It mirrors tree-sitter's TSLanguage C struct, translated into
 // idiomatic Go types with slice-based tables instead of raw pointers.
@@ -522,6 +536,12 @@ type Language struct {
 	// blob. Zero preserves widened-stack and no-stacks retries for legacy blobs,
 	// caller-constructed languages, and language overrides.
 	FullParseAcceptedErrorRetryProfile FullParseAcceptedErrorRetryProfile
+
+	// NativeResultCompatibility identifies result-tree shapes produced natively
+	// by this exact language artifact. Zero keeps conservative post-parse
+	// compatibility fallbacks for legacy blobs, generated grammars, caller-built
+	// languages, and overrides whose native behavior has not been certified.
+	NativeResultCompatibility ResultCompatibilityCapability
 }
 
 type symbolNameNamedKey struct {

--- a/language_result_compatibility_test.go
+++ b/language_result_compatibility_test.go
@@ -1,0 +1,330 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestResultCompatibilityCapabilityLanguageBlobRoundTrip(t *testing.T) {
+	wantValues := []ResultCompatibilityCapability{1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4}
+	gotValues := []ResultCompatibilityCapability{
+		ResultCompatibilityCSharpNativeNotNull,
+		ResultCompatibilityCSharpNativeUnicodeIdentifiers,
+		ResultCompatibilityCSharpNativeScopedLambdaStatements,
+		ResultCompatibilityCSharpNativeScopedLambdaBlocks,
+		ResultCompatibilityCSharpNativeQueryExpressions,
+	}
+	for i := range wantValues {
+		if gotValues[i] != wantValues[i] {
+			t.Fatalf("result compatibility capability %d = %#x, want %#x", i, gotValues[i], wantValues[i])
+		}
+	}
+
+	want := ResultCompatibilityCSharpNativeNotNull |
+		ResultCompatibilityCSharpNativeUnicodeIdentifiers |
+		ResultCompatibilityCSharpNativeScopedLambdaStatements |
+		ResultCompatibilityCSharpNativeScopedLambdaBlocks |
+		ResultCompatibilityCSharpNativeQueryExpressions
+	lang := &Language{
+		Name:                      "result_compatibility_round_trip",
+		NativeResultCompatibility: want,
+	}
+
+	blob, err := EncodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("EncodeLanguageBlob: %v", err)
+	}
+	decoded, err := LoadLanguage(blob)
+	if err != nil {
+		t.Fatalf("LoadLanguage: %v", err)
+	}
+	if got := decoded.NativeResultCompatibility; got != want {
+		t.Fatalf("NativeResultCompatibility = %#x, want %#x", got, want)
+	}
+}
+
+func TestCSharpLegacyCompatibilityCapabilityGatesEveryPass(t *testing.T) {
+	tests := []struct {
+		name       string
+		capability ResultCompatibilityCapability
+		unrelated  ResultCompatibilityCapability
+	}{
+		{"notnull", ResultCompatibilityCSharpNativeNotNull, ResultCompatibilityCSharpNativeUnicodeIdentifiers},
+		{"unicode_identifiers", ResultCompatibilityCSharpNativeUnicodeIdentifiers, ResultCompatibilityCSharpNativeScopedLambdaStatements},
+		{"scoped_lambda_statements", ResultCompatibilityCSharpNativeScopedLambdaStatements, ResultCompatibilityCSharpNativeScopedLambdaBlocks},
+		{"scoped_lambda_blocks", ResultCompatibilityCSharpNativeScopedLambdaBlocks, ResultCompatibilityCSharpNativeQueryExpressions},
+		{"query_expressions", ResultCompatibilityCSharpNativeQueryExpressions, ResultCompatibilityCSharpNativeNotNull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			legacy := csharpMissingNativeResultCompatibility(&Language{Name: "c_sharp"})
+			if legacy&tt.capability == 0 {
+				t.Fatal("zero-value language suppressed its conservative fallback")
+			}
+
+			certified := csharpMissingNativeResultCompatibility(&Language{
+				Name:                      "c_sharp",
+				NativeResultCompatibility: tt.capability,
+			})
+			if certified&tt.capability != 0 {
+				t.Fatal("native capability did not suppress its fallback")
+			}
+
+			partiallyCertified := csharpMissingNativeResultCompatibility(&Language{
+				Name:                      "c_sharp",
+				NativeResultCompatibility: tt.unrelated,
+			})
+			if partiallyCertified&tt.capability == 0 {
+				t.Fatal("unrelated capability suppressed the fallback")
+			}
+		})
+	}
+}
+
+func TestCSharpLegacyNotNullRepairHonorsNativeCapability(t *testing.T) {
+	tests := []struct {
+		name       string
+		capability ResultCompatibilityCapability
+		wantType   string
+	}{
+		{"legacy_repairs", 0, "notnull"},
+		{"native_suppresses", ResultCompatibilityCSharpNativeNotNull, "identifier"},
+		{"unrelated_still_repairs", ResultCompatibilityCSharpNativeUnicodeIdentifiers, "notnull"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := &Language{
+				Name:                      "c_sharp",
+				NativeResultCompatibility: tt.capability,
+				SymbolNames:               []string{"EOF", "root", "type_parameter_constraint", "identifier", "notnull"},
+				SymbolMetadata: []SymbolMetadata{
+					{Name: "EOF"},
+					{Name: "root", Visible: true, Named: true},
+					{Name: "type_parameter_constraint", Visible: true, Named: true},
+					{Name: "identifier", Visible: true, Named: true},
+					{Name: "notnull", Visible: true},
+				},
+			}
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			inner := newLeafNodeInArena(arena, 4, false, 0, 7, Point{}, Point{Column: 7})
+			identifier := newParentNodeInArena(arena, 3, true, []*Node{inner}, nil, 0)
+			constraint := newParentNodeInArena(arena, 2, true, []*Node{identifier}, nil, 0)
+			root := newParentNodeInArena(arena, 1, true, []*Node{constraint}, nil, 0)
+
+			normalizeCSharpCompatibility(root, []byte("notnull"), &Parser{skipRecoveryReparse: true}, lang)
+			if got := constraint.Child(0).Type(lang); got != tt.wantType {
+				t.Fatalf("constraint child type = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestCSharpLegacyUnicodeRepairHonorsNativeCapability(t *testing.T) {
+	source := []byte("ග්‍රහලෝකය")
+	_, firstRuneBytes := utf8.DecodeRune(source)
+	tests := []struct {
+		name       string
+		capability ResultCompatibilityCapability
+		wantEnd    uint32
+	}{
+		{"legacy_repairs", 0, uint32(len(source))},
+		{"native_suppresses", ResultCompatibilityCSharpNativeUnicodeIdentifiers, uint32(firstRuneBytes)},
+		{"unrelated_still_repairs", ResultCompatibilityCSharpNativeQueryExpressions, uint32(len(source))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := &Language{
+				Name:                      "c_sharp",
+				NativeResultCompatibility: tt.capability,
+				SymbolNames:               []string{"EOF", "root", "identifier"},
+				SymbolMetadata: []SymbolMetadata{
+					{Name: "EOF"},
+					{Name: "root", Visible: true, Named: true},
+					{Name: "identifier", Visible: true, Named: true},
+				},
+			}
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			identifier := newLeafNodeInArena(arena, 2, true, 0, uint32(firstRuneBytes), Point{}, Point{Column: uint32(firstRuneBytes)})
+			root := newParentNodeInArena(arena, 1, true, []*Node{identifier}, nil, 0)
+
+			normalizeCSharpCompatibility(root, source, &Parser{skipRecoveryReparse: true}, lang)
+			if got := identifier.EndByte(); got != tt.wantEnd {
+				t.Fatalf("identifier end = %d, want %d", got, tt.wantEnd)
+			}
+		})
+	}
+}
+
+func TestCSharpLegacyScopedLambdaStatementRepairHonorsNativeCapability(t *testing.T) {
+	blob := readCSharpLegacyTestBlob(t)
+	source := []byte("var first = scoped => null; var second = scoped => null;")
+	tests := []struct {
+		name       string
+		capability ResultCompatibilityCapability
+		wantCount  int
+	}{
+		{"legacy_repairs", 0, 2},
+		{"native_suppresses", ResultCompatibilityCSharpNativeScopedLambdaStatements, 1},
+		{"unrelated_still_repairs", ResultCompatibilityCSharpNativeQueryExpressions, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := loadCSharpLegacyTestLanguage(t, blob)
+			lang.NativeResultCompatibility = tt.capability
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			badStatement := csharpLegacyTestLeaf(t, arena, lang, "local_declaration_statement", source, 0, uint32(len(source)))
+			block := csharpLegacyTestParent(t, arena, lang, "block", []*Node{badStatement})
+
+			normalizeCSharpCompatibility(block, source, &Parser{skipRecoveryReparse: true}, lang)
+			if got := block.ChildCount(); got != tt.wantCount {
+				t.Fatalf("block child count = %d, want %d: %s", got, tt.wantCount, block.SExpr(lang))
+			}
+		})
+	}
+}
+
+func TestCSharpLegacyScopedLambdaBlockRepairHonorsNativeCapability(t *testing.T) {
+	blob := readCSharpLegacyTestBlob(t)
+	source := []byte("{ var first = scoped => null; var second = scoped => null; }")
+	statementStart := uint32(2)
+	statementEnd := uint32(len(source) - 2)
+	tests := []struct {
+		name       string
+		capability ResultCompatibilityCapability
+		wantSplit  bool
+	}{
+		{
+			"legacy_repairs",
+			// Skip the statement splitter so this fixture isolates block recovery.
+			ResultCompatibilityCSharpNativeScopedLambdaStatements,
+			true,
+		},
+		{
+			"native_suppresses",
+			ResultCompatibilityCSharpNativeScopedLambdaStatements | ResultCompatibilityCSharpNativeScopedLambdaBlocks,
+			false,
+		},
+		{
+			"unrelated_still_repairs",
+			ResultCompatibilityCSharpNativeScopedLambdaStatements | ResultCompatibilityCSharpNativeQueryExpressions,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := loadCSharpLegacyTestLanguage(t, blob)
+			lang.NativeResultCompatibility = tt.capability
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			badStatement := csharpLegacyTestLeaf(t, arena, lang, "local_declaration_statement", source, statementStart, statementEnd)
+			block := csharpLegacyTestParent(t, arena, lang, "block", []*Node{badStatement})
+			block.startByte = 0
+			block.endByte = uint32(len(source))
+			block.startPoint = Point{}
+			block.endPoint = advancePointByBytes(Point{}, source)
+			parser := NewParser(lang)
+
+			normalizeCSharpCompatibility(block, source, parser, lang)
+			gotSplit := block.ChildCount() > 1
+			if gotSplit != tt.wantSplit {
+				t.Fatalf("block split = %v, want %v (children=%d): %s", gotSplit, tt.wantSplit, block.ChildCount(), block.SExpr(lang))
+			}
+		})
+	}
+}
+
+func TestCSharpLegacyQueryExpressionRepairHonorsNativeCapability(t *testing.T) {
+	blob := readCSharpLegacyTestBlob(t)
+	source := []byte("var result = from a in source where a.Enabled select a;\n")
+	// Stay just beyond the general top-level recovery cutoff so this fixture
+	// can only become clean through the query-expression fallback under test.
+	source = append(source, bytes.Repeat([]byte{' '}, csharpMaxTopLevelChunkRecoverySourceBytes)...)
+	tests := []struct {
+		name       string
+		capability ResultCompatibilityCapability
+		wantRepair bool
+	}{
+		{"legacy_repairs", 0, true},
+		{"native_suppresses", ResultCompatibilityCSharpNativeQueryExpressions, false},
+		{"unrelated_still_repairs", ResultCompatibilityCSharpNativeUnicodeIdentifiers, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := loadCSharpLegacyTestLanguage(t, blob)
+			lang.NativeResultCompatibility = tt.capability
+			arena := acquireNodeArena(arenaClassFull)
+			defer arena.Release()
+			root := csharpLegacyTestLeaf(t, arena, lang, "compilation_unit", source, 0, uint32(len(source)))
+			root.setHasError(true)
+			parser := NewParser(lang)
+
+			normalizeCSharpCompatibility(root, source, parser, lang)
+			gotRepair := !root.HasError() && csharpLegacyTreeHasType(root, lang, "query_expression")
+			if gotRepair != tt.wantRepair {
+				t.Fatalf("query repair = %v, want %v: %s", gotRepair, tt.wantRepair, root.SExpr(lang))
+			}
+		})
+	}
+}
+
+func readCSharpLegacyTestBlob(t *testing.T) []byte {
+	t.Helper()
+	blob, err := os.ReadFile("grammars/grammar_blobs/c_sharp.bin")
+	if err != nil {
+		t.Fatalf("read C# grammar blob: %v", err)
+	}
+	return blob
+}
+
+func loadCSharpLegacyTestLanguage(t *testing.T, blob []byte) *Language {
+	t.Helper()
+	lang, err := LoadLanguage(blob)
+	if err != nil {
+		t.Fatalf("load legacy C# grammar: %v", err)
+	}
+	if got := lang.NativeResultCompatibility; got != 0 {
+		t.Fatalf("raw legacy loader unexpectedly attached native compatibility %#x", got)
+	}
+	return lang
+}
+
+func csharpLegacyTestLeaf(t *testing.T, arena *nodeArena, lang *Language, typ string, source []byte, start, end uint32) *Node {
+	t.Helper()
+	sym, ok := lang.SymbolByName(typ)
+	if !ok {
+		t.Fatalf("C# grammar has no %q symbol", typ)
+	}
+	return newLeafNodeInArena(
+		arena,
+		sym,
+		symbolIsNamed(lang, sym),
+		start,
+		end,
+		advancePointByBytes(Point{}, source[:start]),
+		advancePointByBytes(Point{}, source[:end]),
+	)
+}
+
+func csharpLegacyTestParent(t *testing.T, arena *nodeArena, lang *Language, typ string, children []*Node) *Node {
+	t.Helper()
+	sym, ok := lang.SymbolByName(typ)
+	if !ok {
+		t.Fatalf("C# grammar has no %q symbol", typ)
+	}
+	return newParentNodeInArena(arena, sym, symbolIsNamed(lang, sym), children, nil, 0)
+}
+
+func csharpLegacyTreeHasType(root *Node, lang *Language, typ string) bool {
+	found := false
+	walkResultTree(root, func(node *Node) {
+		if node != nil && node.Type(lang) == typ {
+			found = true
+		}
+	})
+	return found
+}

--- a/parser_result_csharp.go
+++ b/parser_result_csharp.go
@@ -60,10 +60,17 @@ const (
 )
 
 func normalizeCSharpCompatibility(root *Node, source []byte, p *Parser, lang *Language) {
+	missing := csharpMissingNativeResultCompatibility(lang)
 	if p != nil && p.skipRecoveryReparse {
+		if missing&ResultCompatibilityCSharpNativeUnicodeIdentifiers != 0 {
+			normalizeCSharpUnicodeIdentifierSpans(root, source, lang)
+		}
 		normalizeCSharpQuotedStringContentIdentifiers(root, source, lang)
 		normalizeCSharpSurfaceCompatibility(root, source, lang)
 		normalizeCSharpMissingAttributedProperties(root, source, lang)
+		if missing&ResultCompatibilityCSharpNativeScopedLambdaStatements != 0 {
+			normalizeCSharpSplitScopedLambdaStatements(root, source, lang)
+		}
 		normalizeCSharpInvocationStatements(root, source, lang)
 		normalizeCSharpDereferenceLogicalAndCasts(root, source, lang)
 		normalizeCSharpConditionalIsPatternInitializers(root, source, lang)
@@ -75,15 +82,30 @@ func normalizeCSharpCompatibility(root *Node, source []byte, p *Parser, lang *La
 		normalizeCSharpImplicitVarTypes(root, source, lang)
 		normalizeCSharpParenthesizedVarPatterns(root, source, lang)
 		normalizeCSharpGenericBaseLists(root, lang)
+		if missing&ResultCompatibilityCSharpNativeNotNull != 0 {
+			normalizeCSharpTypeConstraintKeywords(root, lang)
+		}
 		normalizeCSharpSwitchTupleCasePatterns(root, lang)
 		return
 	}
 	normalizeCSharpRecoveredTopLevelChunks(root, source, p)
 	normalizeCSharpRecoveredNamespaces(root, source, p, lang)
 	normalizeCSharpRecoveredTypeDeclarations(root, source, p, lang)
+	if missing&ResultCompatibilityCSharpNativeUnicodeIdentifiers != 0 {
+		normalizeCSharpUnicodeIdentifierSpans(root, source, lang)
+	}
 	normalizeCSharpQuotedStringContentIdentifiers(root, source, lang)
 	normalizeCSharpSurfaceCompatibility(root, source, lang)
 	normalizeCSharpMissingAttributedProperties(root, source, lang)
+	if missing&ResultCompatibilityCSharpNativeQueryExpressions != 0 {
+		normalizeCSharpQueryExpressions(root, source, p)
+	}
+	if missing&ResultCompatibilityCSharpNativeScopedLambdaStatements != 0 {
+		normalizeCSharpSplitScopedLambdaStatements(root, source, lang)
+	}
+	if missing&ResultCompatibilityCSharpNativeScopedLambdaBlocks != 0 {
+		normalizeCSharpRecoveredScopedLambdaBlocks(root, source, p)
+	}
 	normalizeCSharpRecoveredMethodBlocks(root, source, p)
 	normalizeCSharpInvocationStatements(root, source, lang)
 	normalizeCSharpDereferenceLogicalAndCasts(root, source, lang)
@@ -96,6 +118,9 @@ func normalizeCSharpCompatibility(root *Node, source []byte, p *Parser, lang *La
 	normalizeCSharpImplicitVarTypes(root, source, lang)
 	normalizeCSharpParenthesizedVarPatterns(root, source, lang)
 	normalizeCSharpGenericBaseLists(root, lang)
+	if missing&ResultCompatibilityCSharpNativeNotNull != 0 {
+		normalizeCSharpTypeConstraintKeywords(root, lang)
+	}
 	normalizeCSharpSwitchTupleCasePatterns(root, lang)
 }
 

--- a/parser_result_csharp_legacy.go
+++ b/parser_result_csharp_legacy.go
@@ -1,0 +1,110 @@
+package gotreesitter
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// This file contains conservative compatibility repairs for C# language
+// artifacts that do not certify the corresponding native result shapes.
+// Exact built-in blobs skip these walks through NativeResultCompatibility.
+
+const csharpLegacyResultCompatibility = ResultCompatibilityCSharpNativeNotNull |
+	ResultCompatibilityCSharpNativeUnicodeIdentifiers |
+	ResultCompatibilityCSharpNativeScopedLambdaStatements |
+	ResultCompatibilityCSharpNativeScopedLambdaBlocks |
+	ResultCompatibilityCSharpNativeQueryExpressions
+
+func csharpMissingNativeResultCompatibility(lang *Language) ResultCompatibilityCapability {
+	if lang == nil {
+		return csharpLegacyResultCompatibility
+	}
+	return csharpLegacyResultCompatibility &^ lang.NativeResultCompatibility
+}
+
+func normalizeCSharpUnicodeIdentifierSpans(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "c_sharp" || len(source) == 0 {
+		return
+	}
+	walkResultTree(root, func(n *Node) {
+		if n.Type(lang) == "identifier" && len(n.children) == 0 {
+			if end := csharpUnicodeIdentifierEnd(source, n.startByte); end > n.endByte && csharpCanExtendLeafNodeTo(n, end) {
+				n.endByte = end
+				n.endPoint = advancePointByBytes(Point{}, source[:end])
+			}
+		}
+	})
+}
+
+func csharpUnicodeIdentifierEnd(source []byte, start uint32) uint32 {
+	if int(start) >= len(source) {
+		return start
+	}
+	r, size := utf8.DecodeRune(source[start:])
+	if size == 0 || r == utf8.RuneError && size == 1 || !csharpIdentifierStartRune(r) {
+		return start
+	}
+	pos := start + uint32(size)
+	for int(pos) < len(source) {
+		r, size = utf8.DecodeRune(source[pos:])
+		if size == 0 || r == utf8.RuneError && size == 1 || !csharpIdentifierContinueRune(r) {
+			break
+		}
+		pos += uint32(size)
+	}
+	return pos
+}
+
+func csharpIdentifierStartRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.In(r, unicode.Nl)
+}
+
+func csharpIdentifierContinueRune(r rune) bool {
+	return csharpIdentifierStartRune(r) ||
+		unicode.IsDigit(r) ||
+		unicode.In(r, unicode.Mn, unicode.Mc, unicode.Pc, unicode.Cf)
+}
+
+func csharpCanExtendLeafNodeTo(n *Node, end uint32) bool {
+	if n == nil || end <= n.endByte {
+		return false
+	}
+	if n.parent == nil {
+		return true
+	}
+	for _, sibling := range n.parent.children {
+		if sibling == nil || sibling == n {
+			continue
+		}
+		if sibling.startByte >= n.endByte && sibling.startByte < end {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeCSharpTypeConstraintKeywords(root *Node, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "c_sharp" {
+		return
+	}
+	walkResultTree(root, func(n *Node) {
+		if n.Type(lang) == "type_parameter_constraint" && len(n.children) == 1 {
+			child := n.children[0]
+			if child != nil && child.Type(lang) == "identifier" && len(child.children) == 1 {
+				inner := child.children[0]
+				if inner != nil && inner.Type(lang) == "notnull" && !inner.isNamed() &&
+					child.startByte == inner.startByte && child.endByte == inner.endByte {
+					n.children[0] = inner
+					inner.parent = n
+					inner.childIndex = 0
+					if len(n.fieldIDs()) > 0 {
+						n.fieldIDs()[0] = 0
+					}
+					if len(n.fieldSources()) > 0 {
+						n.fieldSources()[0] = fieldSourceNone
+					}
+				}
+			}
+		}
+	})
+}

--- a/parser_result_csharp_legacy_lambda.go
+++ b/parser_result_csharp_legacy_lambda.go
@@ -1,0 +1,169 @@
+package gotreesitter
+
+import "bytes"
+
+// These scoped-lambda repairs remain conservative fallbacks for legacy,
+// generated, and overridden C# language artifacts without native capability
+// certification.
+
+func normalizeCSharpRecoveredScopedLambdaBlocks(root *Node, source []byte, p *Parser) {
+	if root == nil || p == nil || p.language == nil || p.language.Name != "c_sharp" || len(source) == 0 || len(source) > csharpMaxTopLevelChunkRecoverySourceBytes {
+		return
+	}
+	walkResultTree(root, func(n *Node) {
+		if n.Type(p.language) == "block" && csharpBlockNeedsScopedLambdaRecovery(n, source, p.language) {
+			if recovered, ok := csharpRecoverScopedLambdaBlock(n, source, p); ok {
+				csharpReplaceNodeContents(n, recovered)
+			}
+		}
+	})
+}
+
+func csharpBlockNeedsScopedLambdaRecovery(block *Node, source []byte, lang *Language) bool {
+	if block == nil || lang == nil || block.Type(lang) != "block" || block.startByte >= block.endByte || int(block.endByte) > len(source) {
+		return false
+	}
+	for _, child := range block.children {
+		if child == nil || child.Type(lang) != "local_declaration_statement" || child.startByte >= child.endByte || int(child.endByte) > len(source) {
+			continue
+		}
+		stmtSource := source[child.startByte:child.endByte]
+		if !bytes.Contains(stmtSource, []byte("scoped")) || !bytes.Contains(stmtSource, []byte("=>")) {
+			continue
+		}
+		if end, ok := csharpFirstStatementEndInRange(source, child.startByte, block.endByte); ok && end < child.endByte {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeCSharpSplitScopedLambdaStatements(root *Node, source []byte, lang *Language) {
+	if root == nil || lang == nil || lang.Name != "c_sharp" || len(source) == 0 {
+		return
+	}
+	walkResultTree(root, func(n *Node) {
+		if n.Type(lang) == "block" {
+			csharpSplitScopedLambdaStatementChildren(n, source, lang)
+		}
+	})
+}
+
+func csharpSplitScopedLambdaStatementChildren(block *Node, source []byte, lang *Language) bool {
+	if block == nil || lang == nil || block.ownerArena == nil || len(block.children) == 0 {
+		return false
+	}
+	var rebuilt []*Node
+	var rebuiltFields []FieldID
+	hadFields := len(block.fieldIDs()) > 0
+	changed := false
+	for i, child := range block.children {
+		replacements, ok := csharpSplitScopedLambdaStatementChild(child, source, lang, block.ownerArena)
+		if !ok {
+			rebuilt = append(rebuilt, child)
+			if hadFields {
+				rebuiltFields = append(rebuiltFields, csharpFieldIDAt(block, i))
+			}
+			continue
+		}
+		changed = true
+		rebuilt = append(rebuilt, replacements...)
+		if hadFields {
+			for range replacements {
+				rebuiltFields = append(rebuiltFields, 0)
+			}
+		}
+	}
+	if !changed {
+		return false
+	}
+	children := block.ownerArena.allocNodeSlice(len(rebuilt))
+	copy(children, rebuilt)
+	block.children = children
+	if hadFields {
+		fieldIDs := cloneFieldIDSliceInArena(block.ownerArena, rebuiltFields)
+		block.setFieldMetadata(fieldIDs, defaultFieldSourcesInArena(block.ownerArena, fieldIDs))
+	} else {
+		block.clearFieldMetadata()
+	}
+	block.setHasError(false)
+	populateParentNode(block, block.children)
+	return true
+}
+
+func csharpSplitScopedLambdaStatementChild(child *Node, source []byte, lang *Language, arena *nodeArena) ([]*Node, bool) {
+	if child == nil || lang == nil || arena == nil || child.Type(lang) != "local_declaration_statement" ||
+		child.startByte >= child.endByte || int(child.endByte) > len(source) {
+		return nil, false
+	}
+	stmtSource := source[child.startByte:child.endByte]
+	if !bytes.Contains(stmtSource, []byte("scoped")) || !bytes.Contains(stmtSource, []byte("=>")) {
+		return nil, false
+	}
+	if end, ok := csharpFirstStatementEndInRange(source, child.startByte, child.endByte); !ok || end >= child.endByte {
+		return nil, false
+	}
+	relSpans := csharpTopLevelChunkSpans(stmtSource)
+	if len(relSpans) < 2 {
+		return nil, false
+	}
+	replacements := make([]*Node, 0, len(relSpans))
+	for _, rel := range relSpans {
+		start := child.startByte + rel[0]
+		end := child.startByte + rel[1]
+		stmt, ok := csharpRecoverScopedLambdaLocalDeclarationStatementFromRange(source, start, end, lang, arena)
+		if !ok {
+			return nil, false
+		}
+		replacements = append(replacements, stmt)
+	}
+	return replacements, true
+}
+
+func csharpFieldIDAt(n *Node, index int) FieldID {
+	fieldIDs := n.fieldIDs()
+	if index < 0 || index >= len(fieldIDs) {
+		return 0
+	}
+	return fieldIDs[index]
+}
+
+func csharpRecoverScopedLambdaBlock(block *Node, source []byte, p *Parser) (*Node, bool) {
+	if block == nil || p == nil || p.language == nil || block.startByte >= block.endByte || int(block.endByte) > len(source) || block.ownerArena == nil {
+		return nil, false
+	}
+	openBrace := block.startByte
+	if source[openBrace] != '{' {
+		found := false
+		for i := block.startByte; i < block.endByte && int(i) < len(source); i++ {
+			if source[i] == '{' {
+				openBrace = i
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, false
+		}
+	}
+	if block.endByte == 0 || source[block.endByte-1] != '}' {
+		return nil, false
+	}
+	closeBrace := block.endByte - 1
+	statements, ok := csharpRecoverMethodBlockStatementsFromRange(source, openBrace+1, closeBrace, p, block.ownerArena)
+	if !ok {
+		return nil, false
+	}
+	return csharpBuildRecoveredMethodBlockNode(source, p.language, block.ownerArena, openBrace, closeBrace, statements)
+}
+
+func csharpFirstStatementEndInRange(source []byte, start, end uint32) (uint32, bool) {
+	if start >= end || int(end) > len(source) {
+		return 0, false
+	}
+	spans := csharpTopLevelChunkSpans(source[start:end])
+	if len(spans) == 0 {
+		return 0, false
+	}
+	return start + spans[0][1], true
+}

--- a/parser_result_csharp_legacy_query.go
+++ b/parser_result_csharp_legacy_query.go
@@ -1,0 +1,457 @@
+package gotreesitter
+
+import "bytes"
+
+// These query-expression repairs remain conservative fallbacks for legacy,
+// generated, and overridden C# language artifacts without native capability
+// certification.
+
+func normalizeCSharpQueryExpressions(root *Node, source []byte, p *Parser) {
+	if root == nil || p == nil || p.language == nil || p.language.Name != "c_sharp" || len(source) == 0 {
+		return
+	}
+	if root.ownerArena == nil {
+		return
+	}
+	if !root.HasError() && root.EndByte() >= uint32(len(source)) {
+		return
+	}
+	if recovered, ok := csharpRecoverQueryAssignmentsRoot(source, p, root.ownerArena); ok {
+		*root = *recovered
+		root.parent = nil
+		root.childIndex = -1
+		return
+	}
+	spec, ok := csharpFindSimpleJoinQuerySpec(source)
+	if !ok {
+		return
+	}
+	recovered, ok := csharpRecoverQuerySkeletonRoot(source, p, root.ownerArena, spec)
+	if !ok {
+		return
+	}
+	*root = *recovered
+	root.parent = nil
+	root.childIndex = -1
+}
+
+func csharpRecoverQueryAssignmentsRoot(source []byte, p *Parser, arena *nodeArena) (*Node, bool) {
+	if p == nil || p.language == nil || arena == nil {
+		return nil, false
+	}
+	specs, ok := csharpFindQueryAssignmentSpecs(source)
+	if !ok || len(specs) == 0 {
+		return nil, false
+	}
+	skeleton := append([]byte(nil), source...)
+	for _, spec := range specs {
+		for i := spec.queryStart; i < spec.queryEnd; i++ {
+			skeleton[i] = ' '
+		}
+		if spec.queryStart < uint32(len(skeleton)) {
+			skeleton[spec.queryStart] = '0'
+		}
+	}
+	tree, err := p.parseForRecovery(skeleton)
+	if err != nil || tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, false
+	}
+	defer tree.Release()
+	rt := tree.ParseRuntime()
+	recoveredRoot := tree.RootNode()
+	if rt.StopReason != ParseStopAccepted || rt.Truncated || rt.TokenSourceEOFEarly || recoveredRoot.HasError() {
+		return nil, false
+	}
+	cloned := cloneTreeNodesIntoArena(recoveredRoot, arena)
+	if cloned == nil {
+		return nil, false
+	}
+	for _, spec := range specs {
+		queryExpr, ok := csharpBuildRecoveredQueryExpression(arena, source, p, spec)
+		if !ok {
+			return nil, false
+		}
+		if !csharpReplaceRecoveredQueryExpression(cloned, p.language, spec.queryStart, spec.queryEnd, queryExpr) {
+			return nil, false
+		}
+	}
+	return cloned, true
+}
+
+func csharpFindQueryAssignmentSpecs(source []byte) ([]csharpQueryAssignmentSpec, bool) {
+	var specs []csharpQueryAssignmentSpec
+	cursor := uint32(0)
+	for cursor < uint32(len(source)) {
+		eqRel := bytes.IndexByte(source[cursor:], '=')
+		if eqRel < 0 {
+			break
+		}
+		eqPos := cursor + uint32(eqRel)
+		queryStart := csharpSkipSpaceBytes(source, eqPos+1)
+		if !csharpHasKeywordAt(source, queryStart, "from") {
+			cursor = eqPos + 1
+			continue
+		}
+		spec, ok := csharpParseQueryAssignmentSpec(source, queryStart)
+		if !ok {
+			cursor = eqPos + 1
+			continue
+		}
+		specs = append(specs, spec)
+		cursor = spec.semiPos + 1
+	}
+	return specs, len(specs) > 0
+}
+
+func csharpParseQueryAssignmentSpec(source []byte, queryStart uint32) (csharpQueryAssignmentSpec, bool) {
+	var spec csharpQueryAssignmentSpec
+	spec.queryStart = queryStart
+	semiRel := bytes.IndexByte(source[queryStart:], ';')
+	if semiRel < 0 {
+		return spec, false
+	}
+	spec.semiPos = queryStart + uint32(semiRel)
+	spec.queryEnd = csharpTrimRightSpaceBytes(source, spec.semiPos)
+	return csharpParseQueryExpressionSpec(source, spec)
+}
+
+func csharpBuildRecoveredQueryExpression(arena *nodeArena, source []byte, p *Parser, spec csharpQueryAssignmentSpec) (*Node, bool) {
+	if arena == nil || p == nil || p.language == nil || len(spec.clauses) == 0 {
+		return nil, false
+	}
+	return csharpBuildRecoveredQueryExpressionWithExpr(arena, source, p.language, spec, func(span [2]uint32) (*Node, bool) {
+		return csharpRecoverExpressionNodeFromRange(source, span[0], span[1], p, arena)
+	})
+}
+
+type csharpSimpleJoinQuerySpec struct {
+	queryStart uint32
+	queryEnd   uint32
+	semiPos    uint32
+
+	fromStart uint32
+	fromEnd   uint32
+	rangeName [2]uint32
+	in1Start  uint32
+	in1End    uint32
+	source1   [2]uint32
+
+	joinStart uint32
+	joinEnd   uint32
+	joinName  [2]uint32
+	in2Start  uint32
+	in2End    uint32
+	source2   [2]uint32
+
+	onStart    uint32
+	onEnd      uint32
+	leftObj    [2]uint32
+	leftDotPos uint32
+	leftProp   [2]uint32
+
+	equalsStart uint32
+	equalsEnd   uint32
+	rightObj    [2]uint32
+	rightDotPos uint32
+	rightProp   [2]uint32
+
+	selectStart uint32
+	selectEnd   uint32
+	selectName  [2]uint32
+}
+
+func csharpRecoverQuerySkeletonRoot(source []byte, p *Parser, arena *nodeArena, spec csharpSimpleJoinQuerySpec) (*Node, bool) {
+	if p == nil || p.language == nil || arena == nil {
+		return nil, false
+	}
+	skeleton := append([]byte(nil), source...)
+	for i := spec.queryStart; i < spec.queryEnd; i++ {
+		skeleton[i] = ' '
+	}
+	if spec.queryStart < uint32(len(skeleton)) {
+		skeleton[spec.queryStart] = '0'
+	}
+	tree, err := p.parseForRecovery(skeleton)
+	if err != nil || tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		return nil, false
+	}
+	defer tree.Release()
+	rt := tree.ParseRuntime()
+	recoveredRoot := tree.RootNode()
+	if rt.StopReason != ParseStopAccepted || rt.Truncated || rt.TokenSourceEOFEarly || recoveredRoot.HasError() {
+		return nil, false
+	}
+	cloned := cloneTreeNodesIntoArena(recoveredRoot, arena)
+	if cloned == nil {
+		return nil, false
+	}
+	queryExpr, ok := csharpBuildSimpleJoinQueryExpression(arena, source, p.language, spec)
+	if !ok {
+		return nil, false
+	}
+	if !csharpReplaceRecoveredQueryExpression(cloned, p.language, spec.queryStart, spec.queryEnd, queryExpr) {
+		return nil, false
+	}
+	return cloned, true
+}
+
+func csharpFindSimpleJoinQuerySpec(source []byte) (csharpSimpleJoinQuerySpec, bool) {
+	var spec csharpSimpleJoinQuerySpec
+	if len(source) == 0 {
+		return spec, false
+	}
+	eq := bytes.IndexByte(source, '=')
+	if eq < 0 {
+		return spec, false
+	}
+	spec.queryStart = csharpSkipSpaceBytes(source, uint32(eq+1))
+	spec.fromStart = spec.queryStart
+	if !csharpHasKeywordAt(source, spec.fromStart, "from") {
+		return spec, false
+	}
+	spec.fromEnd = spec.fromStart + 4
+	var ok bool
+	if spec.rangeName[0], spec.rangeName[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.fromEnd)); !ok {
+		return spec, false
+	}
+	spec.in1Start = csharpSkipSpaceBytes(source, spec.rangeName[1])
+	if !csharpHasKeywordAt(source, spec.in1Start, "in") {
+		return spec, false
+	}
+	spec.in1End = spec.in1Start + 2
+	if spec.source1[0], spec.source1[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.in1End)); !ok {
+		return spec, false
+	}
+	spec.joinStart = csharpSkipSpaceBytes(source, spec.source1[1])
+	if !csharpHasKeywordAt(source, spec.joinStart, "join") {
+		return spec, false
+	}
+	spec.joinEnd = spec.joinStart + 4
+	if spec.joinName[0], spec.joinName[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.joinEnd)); !ok {
+		return spec, false
+	}
+	spec.in2Start = csharpSkipSpaceBytes(source, spec.joinName[1])
+	if !csharpHasKeywordAt(source, spec.in2Start, "in") {
+		return spec, false
+	}
+	spec.in2End = spec.in2Start + 2
+	if spec.source2[0], spec.source2[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.in2End)); !ok {
+		return spec, false
+	}
+	spec.onStart = csharpSkipSpaceBytes(source, spec.source2[1])
+	if !csharpHasKeywordAt(source, spec.onStart, "on") {
+		return spec, false
+	}
+	spec.onEnd = spec.onStart + 2
+	if spec.leftObj[0], spec.leftObj[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.onEnd)); !ok {
+		return spec, false
+	}
+	spec.leftDotPos = spec.leftObj[1]
+	if spec.leftDotPos >= uint32(len(source)) || source[spec.leftDotPos] != '.' {
+		return spec, false
+	}
+	if spec.leftProp[0], spec.leftProp[1], ok = csharpScanIdentifierAt(source, spec.leftDotPos+1); !ok {
+		return spec, false
+	}
+	spec.equalsStart = csharpSkipSpaceBytes(source, spec.leftProp[1])
+	if !csharpHasKeywordAt(source, spec.equalsStart, "equals") {
+		return spec, false
+	}
+	spec.equalsEnd = spec.equalsStart + 6
+	if spec.rightObj[0], spec.rightObj[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.equalsEnd)); !ok {
+		return spec, false
+	}
+	spec.rightDotPos = spec.rightObj[1]
+	if spec.rightDotPos >= uint32(len(source)) || source[spec.rightDotPos] != '.' {
+		return spec, false
+	}
+	if spec.rightProp[0], spec.rightProp[1], ok = csharpScanIdentifierAt(source, spec.rightDotPos+1); !ok {
+		return spec, false
+	}
+	spec.selectStart = csharpSkipSpaceBytes(source, spec.rightProp[1])
+	if !csharpHasKeywordAt(source, spec.selectStart, "select") {
+		return spec, false
+	}
+	spec.selectEnd = spec.selectStart + 6
+	if spec.selectName[0], spec.selectName[1], ok = csharpScanIdentifierAt(source, csharpSkipSpaceBytes(source, spec.selectEnd)); !ok {
+		return spec, false
+	}
+	spec.queryEnd = spec.selectName[1]
+	spec.semiPos = csharpSkipSpaceBytes(source, spec.queryEnd)
+	if spec.semiPos >= uint32(len(source)) || source[spec.semiPos] != ';' {
+		return spec, false
+	}
+	return spec, true
+}
+
+func csharpReplaceRecoveredQueryExpression(root *Node, lang *Language, queryStart, queryEnd uint32, queryExpr *Node) bool {
+	if root == nil || lang == nil || queryExpr == nil {
+		return false
+	}
+	var walk func(*Node) bool
+	walk = func(n *Node) bool {
+		if n == nil {
+			return false
+		}
+		if n.Type(lang) == "variable_declarator" && len(n.children) >= 3 {
+			expr := n.children[len(n.children)-1]
+			if expr != nil && expr.startByte <= queryStart && expr.endByte > queryStart && n.startByte <= queryStart {
+				n.children[len(n.children)-1] = queryExpr
+				queryExpr.parent = n
+				queryExpr.childIndex = int32(len(n.children) - 1)
+				for cur := n; cur != nil; cur = cur.parent {
+					populateParentNode(cur, cur.children)
+				}
+				return true
+			}
+		}
+		for _, child := range n.children {
+			if walk(child) {
+				n.setHasError(false)
+				return true
+			}
+		}
+		return false
+	}
+	return walk(root)
+}
+
+func csharpBuildSimpleJoinQueryExpression(arena *nodeArena, source []byte, lang *Language, spec csharpSimpleJoinQuerySpec) (*Node, bool) {
+	if arena == nil || lang == nil {
+		return nil, false
+	}
+	queryExprSym, ok := symbolByName(lang, "query_expression")
+	if !ok {
+		return nil, false
+	}
+	fromClauseSym, ok := symbolByName(lang, "from_clause")
+	if !ok {
+		return nil, false
+	}
+	joinClauseSym, ok := symbolByName(lang, "join_clause")
+	if !ok {
+		return nil, false
+	}
+	selectClauseSym, ok := symbolByName(lang, "select_clause")
+	if !ok {
+		return nil, false
+	}
+	memberAccessSym, ok := symbolByName(lang, "member_access_expression")
+	if !ok {
+		return nil, false
+	}
+	identifierSym, ok := symbolByName(lang, "identifier")
+	if !ok {
+		return nil, false
+	}
+	fromSym, ok := symbolByName(lang, "from")
+	if !ok {
+		return nil, false
+	}
+	inSym, ok := symbolByName(lang, "in")
+	if !ok {
+		return nil, false
+	}
+	joinSym, ok := symbolByName(lang, "join")
+	if !ok {
+		return nil, false
+	}
+	onSym, ok := symbolByName(lang, "on")
+	if !ok {
+		return nil, false
+	}
+	equalsSym, ok := symbolByName(lang, "equals")
+	if !ok {
+		return nil, false
+	}
+	selectSym, ok := symbolByName(lang, "select")
+	if !ok {
+		return nil, false
+	}
+	dotSym, ok := symbolByName(lang, ".")
+	if !ok {
+		return nil, false
+	}
+	nameFieldID, hasNameField := lang.FieldByName("name")
+	expressionFieldID, hasExpressionField := lang.FieldByName("expression")
+	if !hasNameField || !hasExpressionField {
+		return nil, false
+	}
+	identifierNamed := symbolIsNamed(lang, identifierSym)
+	memberAccessNamed := symbolIsNamed(lang, memberAccessSym)
+	fromClauseNamed := symbolIsNamed(lang, fromClauseSym)
+	joinClauseNamed := symbolIsNamed(lang, joinClauseSym)
+	selectClauseNamed := symbolIsNamed(lang, selectClauseSym)
+	queryExprNamed := symbolIsNamed(lang, queryExprSym)
+
+	ident := func(span [2]uint32) *Node {
+		return newLeafNodeInArena(
+			arena,
+			identifierSym,
+			identifierNamed,
+			span[0],
+			span[1],
+			advancePointByBytes(Point{}, source[:span[0]]),
+			advancePointByBytes(Point{}, source[:span[1]]),
+		)
+	}
+	leaf := func(sym Symbol, start, end uint32) *Node {
+		named := symbolIsNamed(lang, sym)
+		return newLeafNodeInArena(
+			arena,
+			sym,
+			named,
+			start,
+			end,
+			advancePointByBytes(Point{}, source[:start]),
+			advancePointByBytes(Point{}, source[:end]),
+		)
+	}
+	memberAccess := func(obj, prop [2]uint32, dotPos uint32) *Node {
+		children := []*Node{
+			ident(obj),
+			leaf(dotSym, dotPos, dotPos+1),
+			ident(prop),
+		}
+		fieldIDs := cloneFieldIDSliceInArena(arena, []FieldID{expressionFieldID, 0, nameFieldID})
+		return newParentNodeInArena(arena, memberAccessSym, memberAccessNamed, children, fieldIDs, 0)
+	}
+
+	fromChildren := []*Node{
+		leaf(fromSym, spec.fromStart, spec.fromEnd),
+		ident(spec.rangeName),
+		leaf(inSym, spec.in1Start, spec.in1End),
+		ident(spec.source1),
+	}
+	fromFields := cloneFieldIDSliceInArena(arena, []FieldID{0, nameFieldID, 0, 0})
+	fromClause := newParentNodeInArena(arena, fromClauseSym, fromClauseNamed, fromChildren, fromFields, 0)
+
+	joinClause := newParentNodeInArena(arena, joinClauseSym, joinClauseNamed, []*Node{
+		leaf(joinSym, spec.joinStart, spec.joinEnd),
+		ident(spec.joinName),
+		leaf(inSym, spec.in2Start, spec.in2End),
+		ident(spec.source2),
+		leaf(onSym, spec.onStart, spec.onEnd),
+		memberAccess(spec.leftObj, spec.leftProp, spec.leftDotPos),
+		leaf(equalsSym, spec.equalsStart, spec.equalsEnd),
+		memberAccess(spec.rightObj, spec.rightProp, spec.rightDotPos),
+	}, nil, 0)
+
+	selectClause := newParentNodeInArena(arena, selectClauseSym, selectClauseNamed, []*Node{
+		leaf(selectSym, spec.selectStart, spec.selectEnd),
+		ident(spec.selectName),
+	}, nil, 0)
+
+	queryExpr := newParentNodeInArena(arena, queryExprSym, queryExprNamed, []*Node{
+		fromClause,
+		joinClause,
+		selectClause,
+	}, nil, 0)
+	return queryExpr, true
+}

--- a/parser_result_csharp_test.go
+++ b/parser_result_csharp_test.go
@@ -2,6 +2,30 @@ package gotreesitter
 
 import "testing"
 
+func TestCSharpFindQueryAssignmentSpecs(t *testing.T) {
+	src := []byte("var x = from a in source\n  where a.B == \"A\"\n  select new { Name = a.B };\n")
+
+	specs, ok := csharpFindQueryAssignmentSpecs(src)
+	if !ok {
+		t.Fatal("expected query assignment spec")
+	}
+	if got := len(specs); got != 1 {
+		t.Fatalf("spec count = %d, want 1", got)
+	}
+	if got := len(specs[0].clauses); got != 3 {
+		t.Fatalf("clause count = %d, want 3", got)
+	}
+	if got := specs[0].clauses[0].kind; got != csharpQueryFromClause {
+		t.Fatalf("first clause kind = %v, want from", got)
+	}
+	if got := specs[0].clauses[1].kind; got != csharpQueryWhereClause {
+		t.Fatalf("second clause kind = %v, want where", got)
+	}
+	if got := specs[0].clauses[2].kind; got != csharpQuerySelectClause {
+		t.Fatalf("third clause kind = %v, want select", got)
+	}
+}
+
 func TestCSharpLargeNamespaceAltStatsCanSkipPrimary(t *testing.T) {
 	child := csharpRecoveredDeclarationStats{total: 103, methods: 93}
 	alt := csharpRecoveredDeclarationStats{total: 126, methods: 116}
@@ -34,6 +58,17 @@ func TestCSharpParseQueryExpressionSpecWithGroupIntoOrder(t *testing.T) {
 	}
 	if got, want := len(spec.clauses), 5; got != want {
 		t.Fatalf("clause count = %d, want %d", got, want)
+	}
+}
+
+func TestCSharpFirstStatementEndHandlesScopedLambda(t *testing.T) {
+	src := []byte("    var l = scoped => null;\n    var l = (scoped i) => null;\n")
+	got, ok := csharpFirstStatementEndInRange(src, 4, uint32(len(src)))
+	if !ok {
+		t.Fatal("expected statement span")
+	}
+	if want := uint32(len("    var l = scoped => null;")); got != want {
+		t.Fatalf("statement end = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- certify native C# result shapes only for the exact bundled grammar blob
- keep the existing result repairs as conservative fallbacks for raw, generated, overridden, and caller-built grammars
- add serialized capability and identity tests for all five gated passes

## Validation

- focused root and grammar tests in Docker
- C# CGo focus: 20/20 eligible files with no errors and exact tree parity
- Docker vet
- independent structural review with Canopy