### PR TITLE
fix(arena): release oversized arenas from pool backing slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Oversized full arenas rejected by `Release` now clear every matching stale
+  checkout reference from the pool's unused backing slots instead of remaining
+  reachable after rejection. Ordinary checkout and successful repooling remain
+  unchanged.
 - The browser runtime now releases every parse tree returned by both the
   runtime and grammargen WASM bridges. Runtime queries stream through a
   500-match cursor limit instead of materializing an unbounded result before

--- a/arena.go
+++ b/arena.go
@@ -403,6 +403,32 @@ func (p *nodeArenaPool) release(a *nodeArena) {
 	p.mu.Unlock()
 }
 
+// discard clears a stale checkout reference when an arena is rejected instead
+// of returned to the pool. Ordinary checkout and successful repooling stay on
+// their original hot path. Match the exact arena so concurrent checkouts in
+// other unused backing slots retain their own lifecycle bookkeeping.
+func (p *nodeArenaPool) discard(a *nodeArena) {
+	if a == nil {
+		return
+	}
+	p.mu.Lock()
+	all := p.free[:cap(p.free)]
+	for i := len(p.free); i < len(all); i++ {
+		if all[i] == a {
+			all[i] = nil
+		}
+	}
+	p.mu.Unlock()
+}
+
+// discardRejectedFullArena keeps oversized-arena eviction bookkeeping out of
+// the ordinary nodeArena.Release instruction path.
+//
+//go:noinline
+func discardRejectedFullArena(a *nodeArena) {
+	fullArenaPool.discard(a)
+}
+
 func (p *nodeArenaPool) drain() {
 	p.mu.Lock()
 	clear(p.free[:cap(p.free)]) // nil all pointers so GC can collect the arenas
@@ -488,6 +514,7 @@ func (a *nodeArena) Release() {
 	// Checking after reset() means an arena that grew to hundreds of MB during a
 	// large parse would report a small retained size and slip back into the pool.
 	if a.class == arenaClassFull && a.allocatedBytes > maxRetainedFullArenaBytes {
+		discardRejectedFullArena(a)
 		return // drop; GC collects the backing arrays without reset overhead
 	}
 	a.reset()

--- a/arena_pool_lifecycle_test.go
+++ b/arena_pool_lifecycle_test.go
@@ -1,0 +1,59 @@
+package gotreesitter
+
+import "testing"
+
+func TestOversizedFullArenaReleaseClearsAllDuplicateCheckoutSlots(t *testing.T) {
+	DrainArenaPools()
+	t.Cleanup(DrainArenaPools)
+
+	arenaA := newNodeArena(arenaClassFull)
+	arenaB := newNodeArena(arenaClassFull)
+	unrelated := newNodeArena(arenaClassFull)
+	backing := []*nodeArena{arenaB, arenaA, unrelated}
+	fullArenaPool.mu.Lock()
+	fullArenaPool.free = backing[:2]
+	fullArenaPool.mu.Unlock()
+
+	checkedOutA := acquireNodeArena(arenaClassFull)
+	checkedOutB := acquireNodeArena(arenaClassFull)
+	if checkedOutA != arenaA || checkedOutB != arenaB {
+		t.Fatal("test setup did not preserve LIFO checkout order")
+	}
+	t.Cleanup(func() {
+		if checkedOutB.refs.Load() > 0 {
+			checkedOutB.Release()
+		}
+	})
+
+	checkedOutA.Release()
+	checkedOutA = acquireNodeArena(arenaClassFull)
+	if checkedOutA != arenaA {
+		t.Fatal("repooling did not return arena A on the next checkout")
+	}
+
+	fullArenaPool.mu.Lock()
+	before := fullArenaPool.free[:cap(fullArenaPool.free)]
+	duplicateA := before[0] == arenaA && before[1] == arenaA
+	unrelatedBefore := before[2]
+	fullArenaPool.mu.Unlock()
+	if !duplicateA {
+		t.Fatal("test setup did not create duplicate inactive references to arena A")
+	}
+	if unrelatedBefore != unrelated {
+		t.Fatal("test setup lost the unrelated inactive slot")
+	}
+
+	checkedOutA.allocatedBytes = maxRetainedFullArenaBytes + 1
+	checkedOutA.Release()
+
+	fullArenaPool.mu.Lock()
+	after := fullArenaPool.free[:cap(fullArenaPool.free)]
+	firstA, secondA, unrelatedAfter := after[0], after[1], after[2]
+	fullArenaPool.mu.Unlock()
+	if firstA != nil || secondA != nil {
+		t.Fatal("oversized rejected arena remains reachable through duplicate inactive slots")
+	}
+	if unrelatedAfter != unrelated {
+		t.Fatal("discard cleared an unrelated inactive slot")
+	}
+}


### PR DESCRIPTION
## Summary

- clear every stale inactive pool reference when an oversized full arena is rejected
- leave ordinary checkout and successful repooling on their existing paths
- cover the duplicate-slot interleaving that can otherwise retain a rejected arena

## Validation

- focused host test, 10 repetitions
- focused Docker test: harness_out/docker/20260713T115951Z-arena-cold-discard-rebased
- standard full, incremental-edit, and no-edit B-C-C-B benchmark: statistically neutral with unchanged bytes and allocations
- independent Tiller review and git diff check