### PR TITLE
perf(parser): avoid retry runtime record copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- Internal retry and tree-selection decisions now inspect each tree's stored
+  parse-runtime record in place instead of repeatedly copying the 2,928-byte
+  public snapshot. `Tree.ParseRuntime()` remains a value API with its live
+  final-child-counter overlay unchanged. In pinned recurring benchmarks this
+  reduced the five-byte KDL floor by 11.2% and Java's registered token-source
+  path by 14.9%, with unchanged bytes and allocations per operation; the
+  standard full/incremental benchmark trio remained neutral.
 - The exact bundled C# grammar now advertises native result compatibility for
   `notnull` constraints, Unicode identifier spans, scoped-lambda statements and
   blocks, and LINQ query expressions, allowing the runtime to skip the five

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -117,7 +117,7 @@ func shouldRetryAcceptedErrorParse(tree *Tree, sourceLen int, initialMaxStacks i
 	if !retryTreeHasError(tree) {
 		return false
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if rt.StopReason != ParseStopAccepted || rt.Truncated || rt.TokenSourceEOFEarly {
 		return false
 	}
@@ -141,7 +141,7 @@ func shouldRetryStackPressureCleanFullParse(tree *Tree, sourceLen int, _ int) bo
 	if root == nil || root.HasError() {
 		return false
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if rt.TokenSourceEOFEarly {
 		return false
 	}
@@ -190,7 +190,7 @@ func treeParseClean(tree *Tree) bool {
 	if retryTreeHasError(tree) {
 		return false
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	return rt.StopReason == ParseStopAccepted && !rt.TokenSourceEOFEarly && retryTreeCoversExpectedEOF(tree)
 }
 
@@ -208,7 +208,7 @@ func retryTreeEndByte(tree *Tree) uint32 {
 	if root := rawRootOrNil(tree); root != nil {
 		return root.EndByte()
 	}
-	return tree.ParseRuntime().RootEndByte
+	return tree.parseRuntimeReadOnly().RootEndByte
 }
 
 func retryTreeChildCount(tree *Tree) int {
@@ -263,7 +263,7 @@ func retryTreeCoversExpectedEOF(tree *Tree) bool {
 	if tree == nil {
 		return false
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if rt.ExpectedEOFByte == 0 {
 		return true
 	}
@@ -274,7 +274,7 @@ func retryTreeCoversExpectedEOF(tree *Tree) bool {
 	return endByte >= rt.ExpectedEOFByte || parserTailAllowsCleanAcceptance(tree.Source(), endByte, rt.ExpectedEOFByte, tree.includedRanges)
 }
 
-func retryStopRank(rt ParseRuntime) int {
+func retryStopRank(rt *ParseRuntime) int {
 	switch rt.StopReason {
 	case ParseStopAccepted:
 		return 4
@@ -307,8 +307,8 @@ func preferRetryTree(p *Parser, candidate, incumbent *Tree) bool {
 	if candEnd != incEnd {
 		return candEnd > incEnd
 	}
-	candRT := candidate.ParseRuntime()
-	incRT := incumbent.ParseRuntime()
+	candRT := candidate.parseRuntimeReadOnly()
+	incRT := incumbent.parseRuntimeReadOnly()
 	if candRT.Truncated != incRT.Truncated {
 		return !candRT.Truncated
 	}
@@ -356,7 +356,7 @@ func shouldTakeCleanWideRetry(incumbent, candidate *Tree, sourceLen int, initial
 	if candidate == nil || retryTreeHasError(candidate) {
 		return false
 	}
-	candRT := candidate.ParseRuntime()
+	candRT := candidate.parseRuntimeReadOnly()
 	if candRT.TokenSourceEOFEarly {
 		return false
 	}
@@ -1187,7 +1187,7 @@ func certifiedAcceptedErrorRetryUsesInitialStackCeiling(tree *Tree, sourceLen in
 		parseMaxGLRStacksEnvConfigured() || parseMaxMergePerKeyEnvConfigured() {
 		return false
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	return rt.StopReason == ParseStopAccepted &&
 		!rt.Truncated &&
 		!rt.TokenSourceEOFEarly &&
@@ -1201,7 +1201,7 @@ func certifiedAcceptedErrorRetrySkipsComplete(tree *Tree, sourceLen int) bool {
 		return false
 	}
 	profile := tree.language.FullParseAcceptedErrorRetryProfile
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if profile.SkipCompleteMaxEntryScratchPeak > 0 &&
 		rt.EntryScratchPeak > uint64(profile.SkipCompleteMaxEntryScratchPeak) {
 		return false
@@ -1238,7 +1238,7 @@ func fullParseRetryNodeLimitOverride(tree *Tree, sourceLen int) int {
 	if !shouldRetryNodeLimitParse(tree, sourceLen) {
 		return 0
 	}
-	limit := tree.ParseRuntime().NodeLimit
+	limit := tree.parseRuntimeReadOnly().NodeLimit
 	if limit <= 0 {
 		limit = parseNodeLimit(sourceLen)
 	}
@@ -1249,7 +1249,7 @@ func fullParseRetrySecondaryNodeLimitOverride(tree *Tree, sourceLen int) int {
 	if tree == nil || sourceLen <= 0 || sourceLen > fullParseRetryMaxSourceBytes {
 		return 0
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if rt.StopReason != ParseStopNodeLimit {
 		return 0
 	}
@@ -1267,7 +1267,7 @@ func fullParseRetryMergePerKeyOverride(tree *Tree, sourceLen int, initialMaxStac
 	if treeParseClean(tree) {
 		return 0
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if rt.TokenSourceEOFEarly {
 		return 0
 	}
@@ -1331,7 +1331,7 @@ func fullParseRetryMergePerKeyOverride(tree *Tree, sourceLen int, initialMaxStac
 	return fullParseRetryMaxMergePerKey
 }
 
-func fullParseNoStacksAliveCleanEOFNeedsMergeRetry(tree *Tree, rt ParseRuntime) bool {
+func fullParseNoStacksAliveCleanEOFNeedsMergeRetry(tree *Tree, rt *ParseRuntime) bool {
 	return rt.StopReason == ParseStopNoStacksAlive &&
 		!rt.TokenSourceEOFEarly &&
 		!retryTreeHasError(tree)
@@ -1346,7 +1346,7 @@ func shouldRunInitialFullParseMergeRetry(tree *Tree, sourceLen int, origin fullP
 	// node cap plus a larger merge bucket. Keep merge-per-key retries available
 	// after a widened node-budget pass if the parser still proves ambiguity-
 	// bound, but skip the dead intermediate pass up front.
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	if rt.StopReason == ParseStopNodeLimit {
 		return false
 	}
@@ -1362,7 +1362,7 @@ func certifiedAcceptedErrorRetrySkipsInitialMerge(tree *Tree, sourceLen int, ori
 		parseMaxGLRStacksEnvConfigured() || parseMaxMergePerKeyEnvConfigured() {
 		return false
 	}
-	rt := tree.ParseRuntime()
+	rt := tree.parseRuntimeReadOnly()
 	return rt.StopReason == ParseStopAccepted &&
 		!rt.Truncated &&
 		!rt.TokenSourceEOFEarly &&

--- a/tree.go
+++ b/tree.go
@@ -3391,6 +3391,16 @@ func (t *Tree) ParseRuntime() ParseRuntime {
 	return out
 }
 
+// parseRuntimeReadOnly returns the runtime record stored on the tree without
+// the public accessor's live arena-counter overlay. Internal decision helpers
+// may use it only while the tree is alive and must not mutate the result.
+func (t *Tree) parseRuntimeReadOnly() *ParseRuntime {
+	if t == nil {
+		return nil
+	}
+	return &t.parseRuntime
+}
+
 // ArenaBreakdown returns optional arena/materialization attribution captured
 // when EnableArenaBreakdown(true) was set before parsing.
 func (t *Tree) ArenaBreakdown() (ArenaBreakdown, bool) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -42,6 +42,41 @@ func TestNodeLayoutSizeBudget(t *testing.T) {
 	}
 }
 
+func TestParseRuntimeReadOnlyUsesStoredRecordWithoutArenaOverlay(t *testing.T) {
+	var nilTree *Tree
+	if got := nilTree.parseRuntimeReadOnly(); got != nil {
+		t.Fatalf("nil tree runtime = %p, want nil", got)
+	}
+	if got := nilTree.ParseRuntime().StopReason; got != ParseStopNone {
+		t.Fatalf("nil tree public stop reason = %q, want %q", got, ParseStopNone)
+	}
+
+	tree := &Tree{
+		arena: &nodeArena{
+			finalChildRefsCreated: 23,
+		},
+		parseRuntime: ParseRuntime{
+			StopReason:     ParseStopAccepted,
+			FinalChildRefs: 7,
+			NodeLimit:      41,
+		},
+	}
+	stored := tree.parseRuntimeReadOnly()
+	if stored != &tree.parseRuntime {
+		t.Fatal("internal runtime accessor returned a copy")
+	}
+	if stored.StopReason != ParseStopAccepted || stored.NodeLimit != 41 || stored.FinalChildRefs != 7 {
+		t.Fatalf("stored runtime = {stop:%q node_limit:%d child_refs:%d}", stored.StopReason, stored.NodeLimit, stored.FinalChildRefs)
+	}
+	public := tree.ParseRuntime()
+	if public.FinalChildRefs != 23 {
+		t.Fatalf("public FinalChildRefs = %d, want live arena count 23", public.FinalChildRefs)
+	}
+	if stored.FinalChildRefs != 7 {
+		t.Fatalf("public runtime overlay mutated stored FinalChildRefs to %d", stored.FinalChildRefs)
+	}
+}
+
 func TestLeafNode(t *testing.T) {
 	lang := testLanguage()
 


### PR DESCRIPTION
## Summary

- Read stored parse-runtime state directly in internal retry and tree-selection decisions.
- Preserve the exported value-returning API and its live final-child-counter overlay.
- Remove repeated large stack copies from the recurring parse path.

## Verification

- Focused accessor semantics test passes.
- Java single-language Docker coverage preserved the committed 23/25 no-error, S-expression, and deep-parity ratchet.
- Pinned balanced runs improved recurring KDL by 11.2% and the Java token-source route by 14.9%, with unchanged bytes and allocations per operation.
- The standard full, single-byte edit, and no-edit benchmark trio remained statistically neutral.

## Changelog

- Added under Unreleased.