### PR TITLE
perf(parser): scale fresh entry reservations to source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ for tags and release notes while still in `0.x`.
   reduced the five-byte KDL floor by 11.2% and Java's registered token-source
   path by 14.9%, with unchanged bytes and allocations per operation; the
   standard full/incremental benchmark trio remained neutral.
+- Tiny fresh full parses now reserve a source-scaled logical range from the
+  existing physical entry-scratch slab, avoiding repeated clearing of unused
+  stack entries while preserving incremental and large-source reservations.
 - The exact bundled C# grammar now advertises native result compatibility for
   `notnull` constraints, Unicode identifier spans, scoped-lambda statements and
   blocks, and LINQ query expressions, allowing the runtime to skip the five

--- a/parser.go
+++ b/parser.go
@@ -6183,9 +6183,9 @@ func (p *Parser) ensureFullParseInitialCapacity(source []byte, arena *nodeArena,
 func (p *Parser) newInitialParseStacks(scratch *parserScratch, reuse *reuseCursor, timing *incrementalParseTiming, sourceLen int) ([]glrStack, int) {
 	var stacksBuf [4]glrStack
 	stacks := stacksBuf[:1]
-	initialStackCap := parseFullEntryScratchCapacity(sourceLen)
-	if reuse != nil {
-		initialStackCap = defaultStackEntrySlabCap
+	initialStackCap := defaultStackEntrySlabCap
+	if reuse == nil {
+		initialStackCap = parseFullEntryScratchReservation(sourceLen)
 	}
 	stacks[0] = newGLRStackWithScratchCap(p.language.InitialState, &scratch.entries, initialStackCap)
 	stacks[0].recoverabilityKnown = true

--- a/parser_limits.go
+++ b/parser_limits.go
@@ -739,19 +739,34 @@ func (p *Parser) recordFullGSSUsage(used int) {
 	}
 }
 
-func parseFullEntryScratchCapacity(sourceLen int) int {
+const (
+	fullParseEntryScratchEntriesPerSourceByte = 12
+	maxFullParseEntryScratchEntries           = 64 * 1024
+)
+
+func parseFullEntryScratchEstimate(sourceLen int) int {
 	if sourceLen <= 0 {
-		return defaultStackEntrySlabCap
+		return 0
 	}
-	estimate := sourceLen * 12
+	if sourceLen > maxFullParseEntryScratchEntries/fullParseEntryScratchEntriesPerSourceByte {
+		return maxFullParseEntryScratchEntries
+	}
+	return sourceLen * fullParseEntryScratchEntriesPerSourceByte
+}
+
+func parseFullEntryScratchCapacity(sourceLen int) int {
+	estimate := parseFullEntryScratchEstimate(sourceLen)
 	if estimate < defaultStackEntrySlabCap {
 		estimate = defaultStackEntrySlabCap
 	}
-	// Keep initial scratch growth bounded; larger capacities are still
-	// reached on demand and retained up to maxRetainedStackEntryCap.
-	const maxPreallocEntries = 64 * 1024
-	if estimate > maxPreallocEntries {
-		estimate = maxPreallocEntries
+	return estimate
+}
+
+func parseFullEntryScratchReservation(sourceLen int) int {
+	const minReservedEntries = 8
+	estimate := parseFullEntryScratchEstimate(sourceLen)
+	if estimate < minReservedEntries {
+		return minReservedEntries
 	}
 	return estimate
 }

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestGLRMergeScratchResetInvalidatesEquivCacheByEpoch(t *testing.T) {
 	var scratch glrMergeScratch
@@ -128,12 +131,22 @@ func TestGLREntryScratchResetClearsReservedWrittenRange(t *testing.T) {
 
 func TestInitialParseStackReservationMatchesCurrentFullParseSize(t *testing.T) {
 	var scratch parserScratch
-	scratch.entries.ensureInitialCap(64 * 1024)
+	scratch.entries.ensureInitialCap(maxFullParseEntryScratchEntries)
 	parser := &Parser{language: &Language{InitialState: 1}}
 
-	tinySourceLen := len("{}")
+	tinySourceLen := len("node\n")
+	if got := len(scratch.entries.slabs[0].data); got != maxFullParseEntryScratchEntries {
+		t.Fatalf("retained full-parse physical slab = %d, want %d", got, maxFullParseEntryScratchEntries)
+	}
 	stacks, _ := parser.newInitialParseStacks(&scratch, nil, nil, tinySourceLen)
-	wantTiny := parseFullEntryScratchCapacity(tinySourceLen)
+	wantTiny := parseFullEntryScratchReservation(tinySourceLen)
+	wantTinyScaled := tinySourceLen * fullParseEntryScratchEntriesPerSourceByte
+	if wantTiny != wantTinyScaled {
+		t.Fatalf("tiny full-parse logical reservation = %d, want source-scaled %d", wantTiny, wantTinyScaled)
+	}
+	if wantTiny >= defaultStackEntrySlabCap {
+		t.Fatalf("tiny full-parse logical reservation = %d, want less than physical slab %d", wantTiny, defaultStackEntrySlabCap)
+	}
 	if got := cap(stacks[0].entries); got != wantTiny {
 		t.Fatalf("tiny full-parse reservation = %d, want %d", got, wantTiny)
 	}
@@ -144,7 +157,7 @@ func TestInitialParseStackReservationMatchesCurrentFullParseSize(t *testing.T) {
 	scratch.entries.reset()
 	largeSourceLen := 2 * 1024 * 1024
 	stacks, _ = parser.newInitialParseStacks(&scratch, nil, nil, largeSourceLen)
-	wantLarge := parseFullEntryScratchCapacity(largeSourceLen)
+	wantLarge := parseFullEntryScratchReservation(largeSourceLen)
 	if got := cap(stacks[0].entries); got != wantLarge {
 		t.Fatalf("large full-parse reservation = %d, want %d", got, wantLarge)
 	}
@@ -154,6 +167,74 @@ func TestInitialParseStackReservationMatchesCurrentFullParseSize(t *testing.T) {
 	stacks, _ = parser.newInitialParseStacks(&scratch, reuse, nil, largeSourceLen)
 	if got := cap(stacks[0].entries); got != defaultStackEntrySlabCap {
 		t.Fatalf("incremental reservation = %d, want %d", got, defaultStackEntrySlabCap)
+	}
+}
+
+func TestInitialParseStackTinyReservationGrowsAndResetsSafely(t *testing.T) {
+	var scratch parserScratch
+	parser := &Parser{language: &Language{InitialState: 1}}
+	sourceLen := len("node\n")
+	scratch.entries.ensureInitialCap(parseFullEntryScratchCapacity(sourceLen))
+	if got := len(scratch.entries.slabs[0].data); got != defaultStackEntrySlabCap {
+		t.Fatalf("fresh tiny full-parse physical slab = %d, want %d", got, defaultStackEntrySlabCap)
+	}
+
+	stacks, _ := parser.newInitialParseStacks(&scratch, nil, nil, sourceLen)
+	stack := &stacks[0]
+	reserved := cap(stack.entries)
+	for len(stack.entries) <= reserved {
+		stack.pushEntry(stackEntry{state: StateID(len(stack.entries) + 1)}, &scratch.entries, nil)
+	}
+	if got := len(stack.entries); got != reserved+1 {
+		t.Fatalf("grown stack length = %d, want %d", got, reserved+1)
+	}
+	if got := cap(stack.entries); got < reserved+1 {
+		t.Fatalf("grown stack capacity = %d, want at least %d", got, reserved+1)
+	}
+	for i, entry := range stack.entries {
+		if want := StateID(i + 1); entry.state != want {
+			t.Fatalf("grown stack entry %d state = %d, want %d", i, entry.state, want)
+		}
+	}
+
+	scratch.entries.reset()
+	for slabIndex := range scratch.entries.slabs {
+		for entryIndex, entry := range scratch.entries.slabs[slabIndex].data {
+			if entry != (stackEntry{}) {
+				t.Fatalf("entry scratch slab %d slot %d after reset = %#v, want zero", slabIndex, entryIndex, entry)
+			}
+		}
+	}
+}
+
+func TestFullEntryScratchReservationNeverExceedsPhysicalCapacity(t *testing.T) {
+	threshold := maxFullParseEntryScratchEntries / fullParseEntryScratchEntriesPerSourceByte
+	for _, tc := range []struct {
+		sourceLen    int
+		wantReserved int
+		wantPhysical int
+	}{
+		{sourceLen: -1, wantReserved: 8, wantPhysical: defaultStackEntrySlabCap},
+		{sourceLen: 0, wantReserved: 8, wantPhysical: defaultStackEntrySlabCap},
+		{sourceLen: 1, wantReserved: fullParseEntryScratchEntriesPerSourceByte, wantPhysical: defaultStackEntrySlabCap},
+		{sourceLen: len("node\n"), wantReserved: len("node\n") * fullParseEntryScratchEntriesPerSourceByte, wantPhysical: defaultStackEntrySlabCap},
+		{sourceLen: threshold - 1, wantReserved: (threshold - 1) * fullParseEntryScratchEntriesPerSourceByte, wantPhysical: (threshold - 1) * fullParseEntryScratchEntriesPerSourceByte},
+		{sourceLen: threshold, wantReserved: threshold * fullParseEntryScratchEntriesPerSourceByte, wantPhysical: threshold * fullParseEntryScratchEntriesPerSourceByte},
+		{sourceLen: threshold + 1, wantReserved: maxFullParseEntryScratchEntries, wantPhysical: maxFullParseEntryScratchEntries},
+		{sourceLen: 2 * 1024 * 1024, wantReserved: maxFullParseEntryScratchEntries, wantPhysical: maxFullParseEntryScratchEntries},
+		{sourceLen: math.MaxInt, wantReserved: maxFullParseEntryScratchEntries, wantPhysical: maxFullParseEntryScratchEntries},
+	} {
+		reserved := parseFullEntryScratchReservation(tc.sourceLen)
+		physical := parseFullEntryScratchCapacity(tc.sourceLen)
+		if reserved != tc.wantReserved {
+			t.Fatalf("source length %d reservation = %d, want %d", tc.sourceLen, reserved, tc.wantReserved)
+		}
+		if physical != tc.wantPhysical {
+			t.Fatalf("source length %d physical capacity = %d, want %d", tc.sourceLen, physical, tc.wantPhysical)
+		}
+		if reserved > physical {
+			t.Fatalf("source length %d reservation = %d, exceeds physical capacity %d", tc.sourceLen, reserved, physical)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Keep the existing physical entry-scratch slab sizing while reserving only a source-scaled logical range for fresh full parses.
- Preserve the existing incremental and large-source reservations.
- Saturate before multiplication and cover negative, threshold, large, and max-int boundaries.

## Verification

- Focused scratch, empty-source, growth, reset, and retained-slab invariants passed ten times.
- Exhaustive KDL fresh-parse parity against the C oracle passed ten times in Docker.
- Both candidate blocks improved the recurring tiny KDL target while the standard full, single-byte edit, and no-edit lanes remained neutral; bytes and allocations per operation were unchanged.
- One later baseline block experienced a system-wide slowdown and is intentionally excluded from the performance claim.

## Changelog

- Added under Unreleased.