### PR TITLE
perf(parser): reuse missing-shift state chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Performance
+
+- Missing-token recovery now materializes each parser-state chain once per
+  attempt and reuses pointer-free state buffers across candidate simulations,
+  instead of rebuilding and allocating the same deep chain for each fallback.
+  On the pinned 163 KB C++ recovery witness this reduced full-parse time by
+  28.4%, allocated bytes by 79.9%, and allocation count by 41.1%, while
+  preserving the accepted full-span error tree and parser-runtime counters.
+
 ### Changed
 
 - Internal retry and tree-selection decisions now inspect each tree's stored

--- a/parser.go
+++ b/parser.go
@@ -1948,7 +1948,7 @@ func (p *Parser) canFinalizeNoActionEOFAt(s *glrStack, expectedEOFByte uint32, s
 	return true
 }
 
-func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Token, ts TokenSource, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) bool {
+func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Token, ts TokenSource, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, stateScratch *missingShiftStateScratch, trackChildErrors *bool) bool {
 	if p == nil || p.language == nil || s == nil || s.dead || tok.NoLookahead {
 		return false
 	}
@@ -1994,6 +1994,12 @@ func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Tok
 	})
 	var reducePrefix []ParseAction
 	if candidateCnt != 1 {
+		localStateScratch := missingShiftStateScratch{}
+		if stateScratch == nil {
+			stateScratch = &localStateScratch
+		}
+		baseStates := p.collectStackStatesInto(s, stateScratch.baseStates[:0])
+		stateScratch.baseStates = baseStates
 		// Mirror tree-sitter's ts_parser__recover_with_missing: when the strict
 		// single-shift heuristic above did not isolate a unique visible/named
 		// candidate, fall back to the C runtime's exact algorithm. Scan terminal
@@ -2014,10 +2020,10 @@ func (p *Parser) tryInsertMissingSingleShift(source []byte, s *glrStack, tok Tok
 		// lookahead be shifted, so this returns false and the parser falls through
 		// to its established ERROR recovery; for Zig's `struct {}` the missing
 		// `_identifier` reduces up to a state that can shift the closing `}`.
-		if sym, act, ok := p.findRecoverWithMissingShift(s, state, tok.Symbol); ok {
+		if sym, act, ok := p.findRecoverWithMissingShiftAtStatesScratch(baseStates, state, tok.Symbol, &stateScratch.simStates); ok {
 			candidateSym = sym
 			candidateAct = act
-		} else if reduces, sym, act, ok := p.findRecoverWithMissingAfterReductions(s, state, tok.Symbol); ok {
+		} else if reduces, sym, act, ok := p.findRecoverWithMissingAfterReductionsAtStates(baseStates, state, tok.Symbol, &stateScratch.reduceStates, &stateScratch.simStates); ok {
 			// C's ts_parser__handle_error runs do_all_potential_reductions
 			// BEFORE per-version missing insertion, so the missing terminal is
 			// often only insertable after pending reductions land (jq: REDUCE
@@ -2161,6 +2167,10 @@ func (p *Parser) findRecoverWithMissingAfterReductions(s *glrStack, state StateI
 		return nil, 0, ParseAction{}, false
 	}
 	baseStates := p.collectStackStates(s)
+	return p.findRecoverWithMissingAfterReductionsAtStates(baseStates, state, lookahead, nil, nil)
+}
+
+func (p *Parser) findRecoverWithMissingAfterReductionsAtStates(baseStates []StateID, state StateID, lookahead Symbol, reduceScratch, simScratch *[]StateID) ([]ParseAction, Symbol, ParseAction, bool) {
 	if len(baseStates) == 0 {
 		return nil, 0, ParseAction{}, false
 	}
@@ -2169,7 +2179,16 @@ func (p *Parser) findRecoverWithMissingAfterReductions(s *glrStack, state StateI
 	// missing-token insertion — deeper chains find insertions C never takes
 	// (PHP's `static function …` recovery is pinned on NOT inserting).
 	const maxReduceChase = 1
-	states := append([]StateID(nil), baseStates...)
+	var states []StateID
+	if reduceScratch != nil {
+		states = resizeMissingShiftStateScratch((*reduceScratch)[:0], len(baseStates))
+		defer func() {
+			*reduceScratch = states[:0]
+		}()
+	} else {
+		states = make([]StateID, len(baseStates))
+	}
+	copy(states, baseStates)
 	var reduces []ParseAction
 	cur := state
 	for step := 0; step < maxReduceChase; step++ {
@@ -2189,7 +2208,7 @@ func (p *Parser) findRecoverWithMissingAfterReductions(s *glrStack, state StateI
 		states = append(states, gotoState)
 		reduces = append(reduces, reduceAct)
 		cur = gotoState
-		if sym, act, ok := p.findRecoverWithMissingShiftAtStates(states, cur, lookahead); ok {
+		if sym, act, ok := p.findRecoverWithMissingShiftAtStatesScratch(states, cur, lookahead, simScratch); ok {
 			return reduces, sym, act, true
 		}
 	}
@@ -2225,8 +2244,18 @@ func (p *Parser) anyLookaheadReduceAction(state StateID) (ParseAction, bool) {
 // findRecoverWithMissingShiftAtStates is findRecoverWithMissingShift's scan
 // over an explicit (simulated) state chain instead of the live stack.
 func (p *Parser) findRecoverWithMissingShiftAtStates(baseStates []StateID, state StateID, lookahead Symbol) (Symbol, ParseAction, bool) {
+	return p.findRecoverWithMissingShiftAtStatesScratch(baseStates, state, lookahead, nil)
+}
+
+func (p *Parser) findRecoverWithMissingShiftAtStatesScratch(baseStates []StateID, state StateID, lookahead Symbol, simScratch *[]StateID) (Symbol, ParseAction, bool) {
 	tokenCount := Symbol(p.language.TokenCount)
 	var sim []StateID
+	if simScratch != nil {
+		sim = (*simScratch)[:0]
+		defer func() {
+			*simScratch = sim[:0]
+		}()
+	}
 	for ms := Symbol(1); ms < tokenCount; ms++ {
 		if ms == lookahead {
 			continue
@@ -2271,7 +2300,6 @@ func (p *Parser) findRecoverWithMissingShift(s *glrStack, state StateID, lookahe
 	if p == nil || p.language == nil || s == nil {
 		return 0, ParseAction{}, false
 	}
-	tokenCount := Symbol(p.language.TokenCount)
 	// Materialize the current stack's state chain once; the per-candidate
 	// reduction simulation works on a scratch copy so the real stack is never
 	// mutated.
@@ -2279,66 +2307,57 @@ func (p *Parser) findRecoverWithMissingShift(s *glrStack, state StateID, lookahe
 	if len(baseStates) == 0 {
 		return 0, ParseAction{}, false
 	}
-	var sim []StateID
-	for ms := Symbol(1); ms < tokenCount; ms++ {
-		if ms == lookahead {
-			continue
-		}
-		idx := p.lookupActionIndex(state, ms)
-		if idx == 0 || int(idx) >= len(p.language.ParseActions) {
-			continue
-		}
-		actions := p.language.ParseActions[idx].Actions
-		if len(actions) == 0 {
-			continue
-		}
-		// ts_language_next_state uses the LAST action of the entry — for GLR
-		// conflict entries like [REDUCE, SHIFT] the shift is the next-state
-		// candidate (jq's `?` after `if … end` is exactly this shape).
-		act := actions[len(actions)-1]
-		if act.Type != ParseActionShift || act.Extra {
-			continue
-		}
-		nextState := act.State
-		// ts_language_next_state skips when the target is 0 or unchanged.
-		if nextState == 0 || nextState == state {
-			continue
-		}
-		if !p.stateHasLeadingReduceAction(nextState, lookahead) {
-			continue
-		}
-		// Simulate inserting the missing terminal (shift to nextState) followed
-		// by all potential reductions, then check the lookahead can be shifted.
-		sim = append(sim[:0], baseStates...)
-		sim = append(sim, nextState)
-		if p.canShiftAfterReductions(sim, lookahead) {
-			return ms, act, true
-		}
-	}
-	return 0, ParseAction{}, false
+	return p.findRecoverWithMissingShiftAtStates(baseStates, state, lookahead)
 }
 
 // collectStackStates returns the chain of parser states for s, bottom-to-top.
 func (p *Parser) collectStackStates(s *glrStack) []StateID {
+	return p.collectStackStatesInto(s, nil)
+}
+
+func (p *Parser) collectStackStatesInto(s *glrStack, dst []StateID) []StateID {
 	if s == nil {
 		return nil
 	}
 	if s.gss.head == nil && len(s.entries) > 0 {
-		states := make([]StateID, len(s.entries))
+		states := resizeMissingShiftStateScratch(dst, len(s.entries))
 		for i := range s.entries {
 			states[i] = s.entries[i].state
 		}
 		return states
 	}
-	entries := s.gss.materialize(nil)
-	if len(entries) == 0 {
+	n := s.gss.len()
+	if n == 0 {
 		return nil
 	}
-	states := make([]StateID, len(entries))
-	for i := range entries {
-		states[i] = entries[i].state
+	states := resizeMissingShiftStateScratch(dst, n)
+	i := n - 1
+	for node := s.gss.head; node != nil && i >= 0; node = node.prev {
+		states[i] = node.entry.state
+		i--
+	}
+	if i >= 0 {
+		panic("collectStackStatesInto: corrupt GSS depth metadata")
 	}
 	return states
+}
+
+func resizeMissingShiftStateScratch(dst []StateID, n int) []StateID {
+	if n == 0 {
+		return dst[:0]
+	}
+	if cap(dst) < n {
+		capacity := cap(dst) * 2
+		if capacity < 64 {
+			capacity = 64
+		}
+		if capacity < n {
+			capacity = n
+		}
+		dst = make([]StateID, n, capacity)
+		return dst
+	}
+	return dst[:n]
 }
 
 // stateHasLeadingReduceAction mirrors ts_language_has_reduce_action: the first
@@ -6592,11 +6611,28 @@ type parseMissingShiftTracker struct {
 	lastStartByte uint32
 	lastEndByte   uint32
 	consecutive   int
+	stateScratch  missingShiftStateScratch
+}
+
+type missingShiftStateScratch struct {
+	baseStates   []StateID
+	reduceStates []StateID
+	simStates    []StateID
+}
+
+func (s *missingShiftStateScratch) reset() {
+	if s == nil {
+		return
+	}
+	s.baseStates = s.baseStates[:0]
+	s.reduceStates = s.reduceStates[:0]
+	s.simStates = s.simStates[:0]
 }
 
 func (t *parseMissingShiftTracker) resetForToken() {
 	t.lastDepth = -1
 	t.consecutive = 0
+	t.stateScratch.reset()
 }
 
 func (t *parseMissingShiftTracker) tryInsert(p *Parser, source []byte, stackIndex int, s *glrStack, currentState StateID, tok Token, ts TokenSource, nodeCount *int, arena *nodeArena, scratch *parserScratch, trackChildErrors *bool) bool {
@@ -6608,7 +6644,7 @@ func (t *parseMissingShiftTracker) tryInsert(p *Parser, source []byte, stackInde
 		}
 		return false
 	}
-	if !p.tryInsertMissingSingleShift(source, s, tok, ts, nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
+	if !p.tryInsertMissingSingleShift(source, s, tok, ts, nodeCount, arena, &scratch.entries, &scratch.gss, &t.stateScratch, trackChildErrors) {
 		return false
 	}
 	if t.matches(currentState, missingShiftDepth, tok) {

--- a/parser_missing_shift_scratch_test.go
+++ b/parser_missing_shift_scratch_test.go
@@ -1,0 +1,199 @@
+package gotreesitter
+
+import "testing"
+
+func TestCollectStackStatesIntoPreservesDeepEntryAndGSSOrder(t *testing.T) {
+	const depth = 4096
+	entries := make([]stackEntry, depth)
+	want := make([]StateID, depth)
+	for i := range entries {
+		state := StateID(i + 1)
+		entries[i].state = state
+		want[i] = state
+	}
+
+	parser := &Parser{}
+	entryStack := &glrStack{entries: entries}
+	entryStates := parser.collectStackStatesInto(entryStack, make([]StateID, 0, depth))
+	assertStateIDsEqual(t, entryStates, want)
+
+	var gssStorage gssScratch
+	gssStack := &glrStack{gss: buildGSSStack(entries, &gssStorage)}
+	gssStates := parser.collectStackStatesInto(gssStack, make([]StateID, 0, depth))
+	assertStateIDsEqual(t, gssStates, want)
+}
+
+func TestMissingShiftStateScratchReuseOverwritesActiveStateAndResetsLengths(t *testing.T) {
+	parser := &Parser{}
+	deepEntries := make([]stackEntry, 257)
+	for i := range deepEntries {
+		deepEntries[i].state = StateID(i + 100)
+	}
+	shallowEntries := []stackEntry{{state: 7}, {state: 11}, {state: 13}}
+
+	var scratch missingShiftStateScratch
+	scratch.baseStates = parser.collectStackStatesInto(&glrStack{entries: deepEntries}, scratch.baseStates[:0])
+	deepBacking := &scratch.baseStates[0]
+	deepCapacity := cap(scratch.baseStates)
+
+	scratch.reset()
+	if len(scratch.baseStates) != 0 || len(scratch.reduceStates) != 0 || len(scratch.simStates) != 0 {
+		t.Fatalf("reset lengths = base:%d reduce:%d sim:%d, want all zero", len(scratch.baseStates), len(scratch.reduceStates), len(scratch.simStates))
+	}
+	scratch.baseStates = parser.collectStackStatesInto(&glrStack{entries: shallowEntries}, scratch.baseStates[:0])
+	if got := len(scratch.baseStates); got != len(shallowEntries) {
+		t.Fatalf("shallow length = %d, want %d", got, len(shallowEntries))
+	}
+	if &scratch.baseStates[0] != deepBacking || cap(scratch.baseStates) != deepCapacity {
+		t.Fatal("shallow collection did not reuse the retained deep buffer")
+	}
+	assertStateIDsEqual(t, scratch.baseStates, []StateID{7, 11, 13})
+
+	allocs := testing.AllocsPerRun(100, func() {
+		scratch.baseStates = parser.collectStackStatesInto(&glrStack{entries: shallowEntries}, scratch.baseStates[:0])
+	})
+	if allocs != 0 {
+		t.Fatalf("allocations with retained buffer = %v, want 0", allocs)
+	}
+
+	tracker := parseMissingShiftTracker{
+		lastDepth:   9,
+		consecutive: 3,
+		stateScratch: missingShiftStateScratch{
+			baseStates:   make([]StateID, 4, 16),
+			reduceStates: make([]StateID, 3, 16),
+			simStates:    make([]StateID, 2, 16),
+		},
+	}
+	tracker.resetForToken()
+	if tracker.lastDepth != -1 || tracker.consecutive != 0 {
+		t.Fatalf("tracker reset = depth:%d consecutive:%d", tracker.lastDepth, tracker.consecutive)
+	}
+	if len(tracker.stateScratch.baseStates) != 0 || len(tracker.stateScratch.reduceStates) != 0 || len(tracker.stateScratch.simStates) != 0 {
+		t.Fatal("tracker retained stale active StateIDs after token reset")
+	}
+	if cap(tracker.stateScratch.baseStates) != 16 || cap(tracker.stateScratch.reduceStates) != 16 || cap(tracker.stateScratch.simStates) != 16 {
+		t.Fatal("tracker reset discarded reusable capacity")
+	}
+}
+
+func TestMissingShiftScratchSimulationMatchesAllocationBacked(t *testing.T) {
+	parser := NewParser(buildMissingShiftScratchDifferentialLanguage())
+	tests := []struct {
+		name               string
+		baseStates         []StateID
+		state              StateID
+		wantCandidate      bool
+		wantAfterReduction bool
+	}{
+		{
+			name:          "direct candidate",
+			baseStates:    []StateID{0, 5},
+			state:         5,
+			wantCandidate: true,
+		},
+		{
+			name:       "candidate reduction cannot goto",
+			baseStates: []StateID{0, 6},
+			state:      6,
+		},
+		{
+			name:               "candidate after one reduction",
+			baseStates:         []StateID{0, 1},
+			state:              1,
+			wantAfterReduction: true,
+		},
+		{
+			name:       "prelude reduction cannot goto",
+			baseStates: []StateID{4, 1},
+			state:      1,
+		},
+	}
+
+	var scratch missingShiftStateScratch
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allocSym, allocAction, allocOK := parser.findRecoverWithMissingShiftAtStates(tt.baseStates, tt.state, 3)
+			scratchSym, scratchAction, scratchOK := parser.findRecoverWithMissingShiftAtStatesScratch(tt.baseStates, tt.state, 3, &scratch.simStates)
+			assertMissingShiftSimulationEqual(t, nil, allocSym, allocAction, allocOK, nil, scratchSym, scratchAction, scratchOK)
+			if allocOK != tt.wantCandidate {
+				t.Fatalf("direct candidate result = %v, want %v", allocOK, tt.wantCandidate)
+			}
+
+			allocReductions, allocSym, allocAction, allocOK := parser.findRecoverWithMissingAfterReductionsAtStates(tt.baseStates, tt.state, 3, nil, nil)
+			scratchReductions, scratchSym, scratchAction, scratchOK := parser.findRecoverWithMissingAfterReductionsAtStates(tt.baseStates, tt.state, 3, &scratch.reduceStates, &scratch.simStates)
+			assertMissingShiftSimulationEqual(t, allocReductions, allocSym, allocAction, allocOK, scratchReductions, scratchSym, scratchAction, scratchOK)
+			if allocOK != tt.wantAfterReduction {
+				t.Fatalf("after-reduction candidate result = %v, want %v", allocOK, tt.wantAfterReduction)
+			}
+
+			if len(scratch.reduceStates) != 0 || len(scratch.simStates) != 0 {
+				t.Fatalf("scratch lengths after simulation = reduce:%d sim:%d, want zero", len(scratch.reduceStates), len(scratch.simStates))
+			}
+		})
+	}
+}
+
+func buildMissingShiftScratchDifferentialLanguage() *Language {
+	const (
+		missingToken     Symbol = 1
+		reductionTrigger Symbol = 2
+		lookahead        Symbol = 3
+		preludeSymbol    Symbol = 4
+		candidateSymbol  Symbol = 5
+	)
+	return &Language{
+		SymbolCount: 6,
+		TokenCount:  4,
+		StateCount:  7,
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: preludeSymbol, ChildCount: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: candidateSymbol, ChildCount: 1}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},
+		},
+		ParseTable: [][]uint16{
+			{0, 0, 0, 0, 3, 0},
+			{0, 0, 2, 0, 0, 0},
+			{0, 0, 0, 4, 0, 0},
+			{0, 0, 0, 6, 0, 0},
+			{0, 0, 0, 0, 0, 0},
+			{0, 1, 0, 0, 0, 5},
+			{0, 1, 0, 0, 0, 0},
+		},
+		SymbolNames: []string{"end", "missing", "reduce", "lookahead", "prelude", "candidate"},
+		SymbolMetadata: []SymbolMetadata{
+			{}, {}, {}, {}, {}, {},
+		},
+	}
+}
+
+func assertMissingShiftSimulationEqual(t *testing.T, wantReductions []ParseAction, wantSym Symbol, wantAction ParseAction, wantOK bool, gotReductions []ParseAction, gotSym Symbol, gotAction ParseAction, gotOK bool) {
+	t.Helper()
+	if gotOK != wantOK || gotSym != wantSym || gotAction != wantAction {
+		t.Fatalf("scratch result = (sym:%d action:%+v ok:%v), allocation-backed = (sym:%d action:%+v ok:%v)", gotSym, gotAction, gotOK, wantSym, wantAction, wantOK)
+	}
+	if len(gotReductions) != len(wantReductions) {
+		t.Fatalf("scratch reductions = %+v, allocation-backed = %+v", gotReductions, wantReductions)
+	}
+	for i := range wantReductions {
+		if gotReductions[i] != wantReductions[i] {
+			t.Fatalf("scratch reduction[%d] = %+v, allocation-backed = %+v", i, gotReductions[i], wantReductions[i])
+		}
+	}
+}
+
+func assertStateIDsEqual(t *testing.T, got, want []StateID) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("state count = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("state[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## What

- Reuse pointer-free parser-state scratch across missing-token recovery candidate and one-reduction simulations.
- Materialize each live state chain once per recovery attempt while retaining allocation-backed wrappers for differential coverage.
- Add focused state-order, reuse/reset, and scratch-versus-allocation tests.

## Why

Deep recovery rebuilt the same parser-state chain for every fallback candidate, dominating allocation and time on the pinned fmt C++ witness.

## Measured result

On fmtlib `include/fmt/format.h` (163 KB), CPU-pinned B-C-C-B runs improved:

- Full parse: 1113.4 ms to 796.9 ms (-28.4%).
- Allocated bytes: 1563.4 MiB/op to 315.0 MiB/op (-79.9%).
- Allocations: 70.91k/op to 41.74k/op (-41.1%).

The accepted full-span error-tree digest and parser runtime counters were unchanged. The canonical full/incremental/no-edit benchmark trio remained statistically neutral.

## Validation

- Focused host recovery and C++ tests passed.
- Focused Docker root tests passed without OOM.
- Docker C++ fresh, incremental, and no-error parity against C passed.
- Scratch-backed and allocation-backed simulations return identical symbols, actions, reductions, and outcomes.
- The strict generated-grammar C++ corpus lane is delta-neutral to the base commit; no floor changed.