### PR TITLE
perf(parser): memoize stable forest declines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ for tags and release notes while still in `0.x`.
   18 KiB parse and the 129 KiB
   error-bearing parse by about 90% while preserving the returned production
   trees and runtime status.
+- Automatic forest dispatch no longer speculates through CSV by default. An
+  all-23-file corpus census produced no forest fast-path returns: the two
+  largest files exhausted the forest budget and the other 21 conservatively
+  declined at EOF before repeating the parse in production. Explicit forest
+  experiments and CSV's certified recovery policy remain available.
 - Internal retry and tree-selection decisions now inspect each tree's stored
   parse-runtime record in place instead of repeatedly copying the 2,928-byte
   public snapshot. `Tree.ParseRuntime()` remains a value API with its live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- Automatic forest dispatch now remembers stable semantic declines for a small,
+  bounded set of unchanged sources and routes warm recurring full parses
+  directly to the production parser after exact source verification. Explicit
+  forest experiments remain uncached; resource-, timeout-, cancellation-, and
+  work-cap-driven declines are never remembered. On the pinned Make witnesses
+  this removed repeated discarded forest construction, cutting both a clean
+  18 KiB parse and the 129 KiB
+  error-bearing parse by about 90% while preserving the returned production
+  trees and runtime status.
 - Internal retry and tree-selection decisions now inspect each tree's stored
   parse-runtime record in place instead of repeatedly copying the 2,928-byte
   public snapshot. `Tree.ParseRuntime()` remains a value API with its live

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1,6 +1,7 @@
 package gotreesitter
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"sync"
@@ -145,6 +146,173 @@ const forestRecoverCap = 1 << 20
 var forestLastDeclineReason string
 
 const forestDeclineEOFRecoveryConflict = "eof-recovery-conflict"
+const forestDeclineErrorRoot = "error_root"
+const forestDeclineRootHasError = "root_has_error"
+
+// The automatic forest path is speculative: a decline always falls back to
+// the production parser. Repeating the same deterministic decline for an
+// unchanged source can cost far more than the production parse itself. Keep a
+// small, lazy parser-local memo for stable semantic declines: EOF recovery
+// competition, a root ERROR, or an error-bearing root on a language that has
+// not certified forest recovery. These are pure functions of the language
+// tables, exact source bytes, and forest/recovery mode. Resource-budget,
+// timeout, cancellation, dead-end, and work-cap declines deliberately remain
+// uncached.
+const (
+	forestDeclineMemoSlots                  = 8
+	forestDeclineMemoMaxSourceBytes         = 128 << 10
+	forestDeclineMemoMaxRetainedSourceBytes = 256 << 10
+)
+
+const (
+	forestDeclineModeRecoverEnabled uint8 = 1 << iota
+	forestDeclineModeRecoverCertified
+	forestDeclineModeCRecovery
+	forestDeclineModeNoTree
+	forestDeclineModeNoTreeCheckpoints
+)
+
+type forestDeclineMemoEntry struct {
+	source     []byte
+	sourceHash uint64
+	mode       uint8
+}
+
+type forestDeclineMemoState struct {
+	entries             [forestDeclineMemoSlots]forestDeclineMemoEntry
+	head                uint8
+	count               uint8
+	retainedSourceBytes int
+}
+
+// forestDeclineReasonIsMemoizable is intentionally a closed allowlist. Adding
+// a reason requires proof that it is a deterministic semantic outcome for the
+// same language, exact source bytes, and mode. Transient resource and control
+// outcomes must remain absent from this function.
+func forestDeclineReasonIsMemoizable(reason string) bool {
+	switch reason {
+	case forestDeclineEOFRecoveryConflict, forestDeclineErrorRoot, forestDeclineRootHasError:
+		return true
+	default:
+		return false
+	}
+}
+
+func forestDeclineSourceHash(source []byte) uint64 {
+	// FNV-1a is only a prefilter. A hit also requires bytes.Equal against the
+	// memo's defensive source copy, so collisions cannot skip forest dispatch.
+	const (
+		offset64 = uint64(14695981039346656037)
+		prime64  = uint64(1099511628211)
+	)
+	h := offset64
+	for _, b := range source {
+		h ^= uint64(b)
+		h *= prime64
+	}
+	return h
+}
+
+func (p *Parser) forestDeclineMemoMode() uint8 {
+	if p == nil || p.language == nil {
+		return 0
+	}
+	var mode uint8
+	if glrForestRecover {
+		mode |= forestDeclineModeRecoverEnabled
+	}
+	if languageWantsForestRecover(p.language.Name) {
+		mode |= forestDeclineModeRecoverCertified
+	}
+	if p.errorCostCompetitionEnabled() {
+		mode |= forestDeclineModeCRecovery
+	}
+	if p.noTreeBenchmarkOnly {
+		mode |= forestDeclineModeNoTree
+	}
+	if p.noTreeCheckpointBenchmarkOnly {
+		mode |= forestDeclineModeNoTreeCheckpoints
+	}
+	return mode
+}
+
+func (p *Parser) forestDeclineMemoHit(source []byte) bool {
+	if p == nil || p.forestDeclineMemo == nil || len(source) > forestDeclineMemoMaxSourceBytes {
+		return false
+	}
+	mode := p.forestDeclineMemoMode()
+	memo := p.forestDeclineMemo
+	needHash := false
+	for offset := 0; offset < int(memo.count); offset++ {
+		index := (int(memo.head) + offset) % forestDeclineMemoSlots
+		entry := &memo.entries[index]
+		if len(entry.source) == len(source) && entry.mode == mode {
+			needHash = true
+			break
+		}
+	}
+	if !needHash {
+		return false
+	}
+	hash := forestDeclineSourceHash(source)
+	for offset := 0; offset < int(memo.count); offset++ {
+		index := (int(memo.head) + offset) % forestDeclineMemoSlots
+		entry := &memo.entries[index]
+		if len(entry.source) == len(source) && entry.mode == mode && entry.sourceHash == hash && bytes.Equal(entry.source, source) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *forestDeclineMemoState) evictOldest() {
+	if m == nil || m.count == 0 {
+		return
+	}
+	index := int(m.head)
+	m.retainedSourceBytes -= len(m.entries[index].source)
+	m.entries[index] = forestDeclineMemoEntry{}
+	m.head = uint8((index + 1) % forestDeclineMemoSlots)
+	m.count--
+}
+
+func (p *Parser) rememberForestDecline(source []byte, reason string) {
+	if p == nil ||
+		!forestDeclineReasonIsMemoizable(reason) ||
+		len(source) > forestDeclineMemoMaxSourceBytes ||
+		len(source) > forestDeclineMemoMaxRetainedSourceBytes {
+		return
+	}
+	mode := p.forestDeclineMemoMode()
+	hash := forestDeclineSourceHash(source)
+	if p.forestDeclineMemo == nil {
+		p.forestDeclineMemo = new(forestDeclineMemoState)
+	}
+	memo := p.forestDeclineMemo
+	for offset := 0; offset < int(memo.count); offset++ {
+		index := (int(memo.head) + offset) % forestDeclineMemoSlots
+		entry := &memo.entries[index]
+		if len(entry.source) == len(source) && entry.mode == mode && entry.sourceHash == hash && bytes.Equal(entry.source, source) {
+			return
+		}
+	}
+	for memo.count > 0 && (memo.count >= forestDeclineMemoSlots || memo.retainedSourceBytes+len(source) > forestDeclineMemoMaxRetainedSourceBytes) {
+		memo.evictOldest()
+	}
+	if memo.count >= forestDeclineMemoSlots || memo.retainedSourceBytes+len(source) > forestDeclineMemoMaxRetainedSourceBytes {
+		return
+	}
+	sourceCopy := make([]byte, len(source))
+	copy(sourceCopy, source)
+	index := (int(memo.head) + int(memo.count)) % forestDeclineMemoSlots
+	memo.entries[index] = forestDeclineMemoEntry{
+		source:     sourceCopy,
+		sourceHash: hash,
+		mode:       mode,
+	}
+	memo.count++
+	memo.retainedSourceBytes += len(sourceCopy)
+}
 
 func forestProgressExtra(frontier, work, nextFrontier []*gssForestNode, curIndex, nextIndex gssForestIndex, processEpoch int32, recoverCount int, reducer *forestReducer, accepted *gssForestNode, more string) string {
 	curLen := curIndex.len()
@@ -379,6 +547,9 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		}
 		return nil
 	}
+	if p.forestDeclineMemoHit(source) {
+		return nil
+	}
 	progress := newParseProgressTelemetry(p, len(source), uint32(len(source)), time.Now())
 	if progress.enabled {
 		progress.emit(time.Now(), "forest_try_begin", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")
@@ -395,6 +566,9 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		progress.endDetail(time.Now(), "forest_parse_call_end", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, fmt.Sprintf("ok=%t root_present=%t decline_reason=%s", ok, root != nil, forestLastDeclineReason))
 	}
 	if !ok || root == nil {
+		if p.forestDeclineReason == forestDeclineEOFRecoveryConflict {
+			p.rememberForestDecline(source, p.forestDeclineReason)
+		}
 		if progress.enabled {
 			progress.emit(time.Now(), "forest_try_decline", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, fmt.Sprintf("reason=parse_forest_failed ok=%t root_present=%t decline_reason=%s", ok, root != nil, forestLastDeclineReason))
 		}
@@ -402,6 +576,8 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		return nil
 	}
 	if forestRootMustDecline(root) {
+		p.recordForestDecline(forestDeclineErrorRoot, Token{StartByte: root.EndByte()}, nil)
+		p.rememberForestDecline(source, p.forestDeclineReason)
 		if progress.enabled {
 			progress.emit(time.Now(), "forest_try_decline", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "reason=error_root")
 		}
@@ -409,6 +585,8 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		return nil
 	}
 	if root.HasError() && !languageWantsForestRecover(p.language.Name) {
+		p.recordForestDecline(forestDeclineRootHasError, Token{StartByte: root.EndByte()}, nil)
+		p.rememberForestDecline(source, p.forestDeclineReason)
 		if progress.enabled {
 			progress.emit(time.Now(), "forest_try_decline", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "reason=root_has_error")
 		}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -441,6 +441,15 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // both parity-clean and perf-clean for default Go parsing (commit 6894fc9f;
 // that decision stands).
 //
+// CSV recovery remains available to explicit forest experiments, but CSV is
+// intentionally held out of default dispatch. An all-23-file corpus census
+// produced zero forest fast-path returns: the two largest inputs exhausted the
+// forest budget, while the other 21 reached EOF and conservatively declined
+// with eof-recovery-conflict before repeating the parse in production. The
+// accepted production parses were full-span and error-free; keep CSV out until
+// a corpus gate proves the forest actually returns its tree and produces a net
+// wall-time win instead of paying a failed attempt first.
+//
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
 // parserWantsForest) instead of joining this map — e.g. a grammargen consumer
 // generating its own grammar (a Pawn grammar, say) sets WantsForest directly
@@ -502,7 +511,6 @@ var builtinForestDefaults = map[string]bool{
 	"arduino":   true,
 	"authzed":   true,
 	"make":      true,
-	"csv":       true,
 	"fish":      true,
 	"racket":    true,
 	"tlaplus":   true,

--- a/glr_forest_decline_memo_test.go
+++ b/glr_forest_decline_memo_test.go
@@ -1,0 +1,273 @@
+package gotreesitter
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func TestForestDeclineMemoExactSourceAndDefensiveCopy(t *testing.T) {
+	parser := &Parser{language: &Language{Name: "memo-test"}}
+	source := []byte("same-length source A")
+	original := bytes.Clone(source)
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("memo sidecar allocated before the first cacheable decline")
+	}
+	parser.rememberForestDecline(source, forestDeclineEOFRecoveryConflict)
+	if parser.forestDeclineMemo == nil {
+		t.Fatal("memo sidecar was not allocated for a cacheable decline")
+	}
+	if !parser.forestDeclineMemoHit(source) || !parser.forestDeclineMemoHit(original) {
+		t.Fatal("memo missed exact source content")
+	}
+
+	source[0] ^= 0xff
+	if parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo followed an in-place caller mutation")
+	}
+	if !parser.forestDeclineMemoHit(original) {
+		t.Fatal("memo did not retain a defensive copy of the original source")
+	}
+	if bytes.Equal(parser.forestDeclineMemo.entries[0].source, source) {
+		t.Fatal("memo retained the caller's source slice")
+	}
+}
+
+func TestForestDeclineMemoHashIsOnlyPrefilter(t *testing.T) {
+	parser := &Parser{language: &Language{Name: "memo-test"}}
+	stored := []byte("same-length source A")
+	collision := []byte("same-length source B")
+	parser.rememberForestDecline(stored, forestDeclineEOFRecoveryConflict)
+	parser.forestDeclineMemo.entries[0].sourceHash = forestDeclineSourceHash(collision)
+	if parser.forestDeclineMemoHit(collision) {
+		t.Fatal("equal length and forced equal hash bypassed exact source comparison")
+	}
+}
+
+func TestForestDeclineMemoSeparatesSemanticModes(t *testing.T) {
+	parser := &Parser{language: &Language{Name: "memo-test"}}
+	source := []byte("mode source")
+	previousRecover := glrForestRecover
+	defer func() { glrForestRecover = previousRecover }()
+	glrForestRecover = false
+	parser.rememberForestDecline(source, forestDeclineEOFRecoveryConflict)
+
+	glrForestRecover = true
+	if parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo matched after forest recovery mode changed")
+	}
+	glrForestRecover = false
+	if !parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo missed after forest recovery mode was restored")
+	}
+
+	parser.errorCostCompetition = true
+	if parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo matched after C-recovery cost competition was enabled")
+	}
+	parser.errorCostCompetition = false
+	if !parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo missed after C-recovery mode was restored")
+	}
+
+	parser.noTreeBenchmarkOnly = true
+	if parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo matched in no-tree mode")
+	}
+	parser.noTreeBenchmarkOnly = false
+	parser.noTreeCheckpointBenchmarkOnly = true
+	if parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo matched in no-tree checkpoint mode")
+	}
+	parser.noTreeCheckpointBenchmarkOnly = false
+	if !parser.forestDeclineMemoHit(source) {
+		t.Fatal("memo missed after no-tree modes were restored")
+	}
+}
+
+func TestForestDeclineMemoBoundsAndFIFO(t *testing.T) {
+	if forestDeclineMemoMaxSourceBytes > forestDeclineMemoMaxRetainedSourceBytes {
+		t.Fatalf("maximum source bytes = %d, exceeds total retained-source bound %d", forestDeclineMemoMaxSourceBytes, forestDeclineMemoMaxRetainedSourceBytes)
+	}
+	if forestDeclineMemoMaxSourceBytes < 129612 {
+		t.Fatalf("maximum source bytes = %d, does not cover the 129,612-byte Make witness", forestDeclineMemoMaxSourceBytes)
+	}
+	if forestDeclineMemoMaxRetainedSourceBytes < 129612+18407 {
+		t.Fatalf("retained source bytes = %d, do not cover both exact Make witnesses", forestDeclineMemoMaxRetainedSourceBytes)
+	}
+
+	parser := &Parser{language: &Language{Name: "memo-test"}}
+	oversized := make([]byte, forestDeclineMemoMaxSourceBytes+1)
+	parser.rememberForestDecline(oversized, forestDeclineEOFRecoveryConflict)
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("oversized source allocated or populated the lazy memo")
+	}
+	parser.rememberForestDecline(make([]byte, forestDeclineMemoMaxRetainedSourceBytes+1), forestDeclineEOFRecoveryConflict)
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("source larger than total retention allocated or populated the lazy memo")
+	}
+
+	parser.forestDeclineMemo = &forestDeclineMemoState{
+		retainedSourceBytes: forestDeclineMemoMaxRetainedSourceBytes,
+	}
+	parser.rememberForestDecline([]byte("cannot fit"), forestDeclineEOFRecoveryConflict)
+	if parser.forestDeclineMemo.count != 0 || parser.forestDeclineMemo.retainedSourceBytes != forestDeclineMemoMaxRetainedSourceBytes {
+		t.Fatalf("unsatisfiable empty memo changed during rejected insert: count=%d retained=%d", parser.forestDeclineMemo.count, parser.forestDeclineMemo.retainedSourceBytes)
+	}
+
+	parser = &Parser{language: &Language{Name: "memo-test"}}
+	sources := make([][]byte, forestDeclineMemoSlots+1)
+	for i := range sources {
+		sources[i] = []byte{byte(i), byte(i + 1), byte(i + 2)}
+		parser.rememberForestDecline(sources[i], forestDeclineEOFRecoveryConflict)
+	}
+	if parser.forestDeclineMemoHit(sources[0]) {
+		t.Fatal("slot bound did not evict the oldest source")
+	}
+	for i, source := range sources[1:] {
+		if !parser.forestDeclineMemoHit(source) {
+			t.Fatalf("slot-bound FIFO missed retained source %d", i+1)
+		}
+	}
+	if got := parser.forestDeclineMemo.count; got != forestDeclineMemoSlots {
+		t.Fatalf("slot-bound count = %d, want %d", got, forestDeclineMemoSlots)
+	}
+
+	parser = &Parser{language: &Language{Name: "memo-test"}}
+	chunkSize := forestDeclineMemoMaxRetainedSourceBytes / 3
+	large := make([][]byte, 4)
+	for i := range large {
+		large[i] = make([]byte, chunkSize)
+		large[i][0] = byte(i + 1)
+		parser.rememberForestDecline(large[i], forestDeclineEOFRecoveryConflict)
+		if parser.forestDeclineMemo.retainedSourceBytes > forestDeclineMemoMaxRetainedSourceBytes {
+			t.Fatalf("retained bytes = %d, cap %d", parser.forestDeclineMemo.retainedSourceBytes, forestDeclineMemoMaxRetainedSourceBytes)
+		}
+		retainedCapacity := 0
+		for offset := 0; offset < int(parser.forestDeclineMemo.count); offset++ {
+			index := (int(parser.forestDeclineMemo.head) + offset) % forestDeclineMemoSlots
+			retainedCapacity += cap(parser.forestDeclineMemo.entries[index].source)
+		}
+		if retainedCapacity != parser.forestDeclineMemo.retainedSourceBytes {
+			t.Fatalf("retained source capacity = %d, accounted bytes %d", retainedCapacity, parser.forestDeclineMemo.retainedSourceBytes)
+		}
+	}
+	if parser.forestDeclineMemoHit(large[0]) {
+		t.Fatal("byte bound did not evict the oldest source")
+	}
+	for i, source := range large[1:] {
+		if !parser.forestDeclineMemoHit(source) {
+			t.Fatalf("byte-bound FIFO missed retained source %d", i+1)
+		}
+	}
+	if got := parser.forestDeclineMemo.count; got != 3 {
+		t.Fatalf("byte-bound count = %d, want 3", got)
+	}
+	if got, want := parser.forestDeclineMemo.retainedSourceBytes, 3*chunkSize; got != want {
+		t.Fatalf("retained bytes = %d, want %d", got, want)
+	}
+}
+
+func TestForestDeclineMemoRejectsTransientReasons(t *testing.T) {
+	parser := &Parser{language: &Language{Name: "memo-test"}}
+	source := []byte("transient source")
+	for _, reason := range []string{
+		"budget",
+		"timeout",
+		"cancelled",
+		"dead_end",
+		"worklist-cap",
+		"eof_no_root",
+		"noncontiguous_root",
+		"nolook_runaway",
+	} {
+		if forestDeclineReasonIsMemoizable(reason) {
+			t.Fatalf("transient reason %q is allowlisted", reason)
+		}
+		parser.rememberForestDecline(source, reason)
+	}
+	if parser.forestDeclineMemo != nil {
+		t.Fatal("transient reasons allocated or populated the lazy memo")
+	}
+}
+
+func TestForestDeclineMemoDoesNotBypassExplicitForest(t *testing.T) {
+	lang := loadBlobForDecode(t, "json")
+	parser := NewParser(lang)
+	source := []byte(`[1, 2, 3]`)
+	parser.rememberForestDecline(source, forestDeclineEOFRecoveryConflict)
+	if !parser.forestDeclineMemoHit(source) {
+		t.Fatal("test setup did not populate automatic-dispatch memo")
+	}
+	tree, ok := parser.ParseForestExperimental(source)
+	if !ok || tree == nil || tree.RootNode() == nil {
+		t.Fatalf("explicit forest was bypassed by memo: ok=%t tree_nil=%t", ok, tree == nil)
+	}
+	tree.Release()
+}
+
+func TestForestDeclineMemoWarmSemanticDeclineMatchesProduction(t *testing.T) {
+	previousEnabled, previousRecover := glrForestEnabled, glrForestRecover
+	defer func() {
+		glrForestEnabled = previousEnabled
+		glrForestRecover = previousRecover
+	}()
+	glrForestRecover = false
+	lang := loadBlobForDecode(t, "make")
+	source := []byte("all:\n\t@echo hi\n")
+
+	glrForestEnabled = false
+	production, err := NewParser(lang).Parse(source)
+	if err != nil || production == nil || production.RootNode() == nil {
+		t.Fatalf("production parse: tree_nil=%t err=%v", production == nil, err)
+	}
+	defer production.Release()
+	wantSExpr := production.RootNode().SExpr(lang)
+	wantRuntime := production.ParseRuntime()
+
+	glrForestEnabled = true
+	parser := NewParser(lang)
+	first, err := parser.Parse(source)
+	if err != nil || first == nil || first.RootNode() == nil {
+		t.Fatalf("first automatic parse: tree_nil=%t err=%v", first == nil, err)
+	}
+	defer first.Release()
+	if parser.forestDeclineReason != forestDeclineEOFRecoveryConflict {
+		t.Fatalf("first automatic decline reason = %q, want %q", parser.forestDeclineReason, forestDeclineEOFRecoveryConflict)
+	}
+	if !parser.forestDeclineMemoHit(source) {
+		t.Fatal("first semantic decline did not populate the memo")
+	}
+
+	parser.forestDeclineReason = ""
+	forestLastDeclineReason = ""
+	warm, err := parser.Parse(bytes.Clone(source))
+	if err != nil || warm == nil || warm.RootNode() == nil {
+		t.Fatalf("warm automatic parse: tree_nil=%t err=%v", warm == nil, err)
+	}
+	defer warm.Release()
+	if parser.forestDeclineReason != "" || forestLastDeclineReason != "" {
+		t.Fatalf("warm parse entered forest: parser_reason=%q global_reason=%q", parser.forestDeclineReason, forestLastDeclineReason)
+	}
+	if got := warm.RootNode().SExpr(lang); got != wantSExpr {
+		t.Fatalf("warm tree differs from production\n got: %s\nwant: %s", got, wantSExpr)
+	}
+	// ArenaBytesAllocated includes capacity retained by the process-global arena
+	// pool before this parser existed, so it can vary with test order despite
+	// identical parse work. ArenaBaselineBytes reports the same pooled capacity
+	// at entry. Compare every other runtime field exactly.
+	wantRuntime.ArenaBytesAllocated = 0
+	wantRuntime.ArenaBaselineBytes = 0
+	gotRuntime := warm.ParseRuntime()
+	gotRuntime.ArenaBytesAllocated = 0
+	gotRuntime.ArenaBaselineBytes = 0
+	if !reflect.DeepEqual(gotRuntime, wantRuntime) {
+		gotValue, wantValue := reflect.ValueOf(gotRuntime), reflect.ValueOf(wantRuntime)
+		for i := 0; i < gotValue.NumField(); i++ {
+			if !reflect.DeepEqual(gotValue.Field(i).Interface(), wantValue.Field(i).Interface()) {
+				t.Errorf("warm runtime field %s = %v, production = %v", gotValue.Type().Field(i).Name, gotValue.Field(i).Interface(), wantValue.Field(i).Interface())
+			}
+		}
+		t.FailNow()
+	}
+}

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -44,7 +44,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 		"bash", "erlang", "cmake", "css", "scss", "awk", "javascript", "c_sharp",
 		"gitignore", "nix", "squirrel", "prisma",
 		"agda", "org", "ledger", "yuck", "json5", "commonlisp", "vimdoc",
-		"bibtex", "faust", "arduino", "authzed", "make", "csv", "fish", "racket", "tlaplus", "beancount",
+		"bibtex", "faust", "arduino", "authzed", "make", "fish", "racket", "tlaplus", "beancount",
 		"gitattributes",
 	}
 	if len(builtinForestDefaults) != len(want) {
@@ -58,10 +58,22 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// A handful of explicitly-NOT-forest-amenable languages (see the doc
 	// comment) must stay out of the curated set. "go" is intentionally held
 	// out of default dispatch (commit 6894fc9f) even though it is forest-clean.
-	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go"}
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv"}
 	for _, name := range notWanted {
 		if builtinForestDefaults[name] {
 			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
 		}
+	}
+
+	// CSV is a default-dispatch demotion, not removal of the experimental
+	// mechanisms. Callers can still opt a CSV language into the forest path
+	// explicitly, and its certified forest-recovery policy remains available
+	// to that path.
+	csv := &Parser{language: &Language{Name: "csv", WantsForest: true}}
+	if !parserWantsForest(csv) {
+		t.Error("explicit Language.WantsForest should still dispatch CSV to forest")
+	}
+	if !languageWantsForestRecover("csv") {
+		t.Error("CSV forest recovery should remain available to explicit forest runs")
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -303,6 +303,12 @@ type Parser struct {
 	pendingFrontierForkStacks  []glrStack
 	disablePostReduceForkMerge bool
 	stopActionDiag             *parseStopActionDiagnostic
+	// forestDeclineMemo lazily remembers a small, strictly bounded set of
+	// deterministic automatic-forest declines for exact source bytes. Keep the
+	// pointer at the end so parsers that never cache a decline pay no sidecar
+	// allocation and the established hot Parser fields retain their layout.
+	// Explicit ParseForestExperimental calls intentionally ignore this memo.
+	forestDeclineMemo *forestDeclineMemoState
 }
 
 var snippetParserPools sync.Map


### PR DESCRIPTION
## Summary

- Remember three stable automatic-forest decline outcomes in a lazy parser-local sidecar, letting warm recurring parses route directly to the canonical production parser.
- Require exact defensive source-byte equality after a hash prefilter and match forest recovery, recovery certification, C-recovery, and no-tree modes.
- Bound retention to eight FIFO entries, 128 KiB per source, and 256 KiB total. Explicit forest experiments and transient/resource declines remain uncached.

## Measurements

- Clean recurring Make parse: 22.413 ms to 1.944 ms (-91.3%); 6,649.7 KiB/op to 8.9 KiB/op and 19,744 to 20 allocs/op.
- Error-bearing recurring Make parse: 109.23 ms to 10.25 ms (-90.6%); 25,032.2 KiB/op to 112.3 KiB/op and 81,520 to 240 allocs/op.
- Both elected Make witnesses retain full-span acceptance, identical production S-expression hashes, and matching production runtime counters.
- The canonical full/edit/no-edit trio is neutral against the settled closing baseline with unchanged allocation floors.
- BibTeX’s exact eight-file clean sample is neutral and does not use this seam: those files succeed through the forest and never populate the decline memo.

## Validation

- Focused host tests, 5 repetitions
- Focused Docker tests, no OOM
- Make one-language Docker gate: established non-strict 19/25 S-expression and deep-parity floor passed, no OOM
- `gofmt` and `git diff --check` clean