### PR TITLE
perf(parser): avoid discarded Beancount forest parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ compatibility code is removed.
 
 ### Changed
 
+- Automatic forest dispatch no longer speculates through Beancount by default.
+  The exact four-file clean corpus produced no forest return, so every parse
+  paid for a discarded forest before production. In matched automatic-parser
+  scans, removing that retry cut the 347 KiB witness from 30.255x to 2.130x C
+  and the corpus aggregate from 27.621x to 2.088x, eliminating the only ratio
+  above 10x while returning the same accepted, full-span, error-free trees.
+  Explicit forest experiments and Beancount's certified recovery policy remain
+  available.
 - Automatic forest dispatch now remembers stable semantic declines for a small,
   bounded set of unchanged sources and routes warm recurring full parses
   directly to the production parser after exact source verification. Explicit

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -450,6 +450,13 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // a corpus gate proves the forest actually returns its tree and produces a net
 // wall-time win instead of paying a failed attempt first.
 //
+// Beancount recovery likewise remains available to explicit forest experiments,
+// but automatic dispatch is held out. The exact four-file clean corpus produced
+// zero forest returns: every attempt reached EOF and conservatively declined
+// with eof-recovery-conflict before repeating the parse in production. On the
+// largest 347 KiB witness that retry raised the Go/C ratio from 1.72x on the
+// production path to 30.26x under automatic dispatch.
+//
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
 // parserWantsForest) instead of joining this map — e.g. a grammargen consumer
 // generating its own grammar (a Pawn grammar, say) sets WantsForest directly
@@ -514,7 +521,6 @@ var builtinForestDefaults = map[string]bool{
 	"fish":      true,
 	"racket":    true,
 	"tlaplus":   true,
-	"beancount": true,
 
 	// Promoted 2026-06-08 against the C ORACLE, not production. gitattributes
 	// is parity-blocked (production diverges from C), but the forest matches

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -110,6 +110,50 @@ func TestForestExperimentalAppliesBashCompatibility(t *testing.T) {
 	}
 }
 
+func TestBeancountDefaultSkipsForestButExplicitRemainsAvailable(t *testing.T) {
+	// This external-package test follows the file's existing non-parallel
+	// convention: no public getter exists for the test/benchmark-only global
+	// switch, so restore its process default rather than expanding the API.
+	gts.SetGLRForestEnabled(true)
+	defer gts.SetGLRForestEnabled(true)
+
+	// The leading comment is the smallest corpus-shaped witness that reaches
+	// the explicit forest's conservative EOF recovery-conflict fallback.
+	src := []byte(";;; comment\n2024-01-01 open Assets:Bank\n")
+	lang := grm.BeancountLanguage()
+	parser := gts.NewParser(lang)
+	automatic, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("automatic Beancount parse: %v", err)
+	}
+	defer automatic.Release()
+	if rt := automatic.ParseRuntime(); rt.ForestFastPath {
+		t.Fatalf("automatic Beancount parse used forest fast path: %s", rt.Summary())
+	}
+	if offset, sym, reason, states := parser.ForestDeclineInfo(); reason != "" {
+		t.Fatalf("automatic Beancount parse attempted forest: offset=%d symbol=%d reason=%q states=%v", offset, sym, reason, states)
+	}
+
+	explicitParser := gts.NewParser(lang)
+	explicit, ok := explicitParser.ParseForestExperimental(src)
+	if !ok || explicit == nil || explicit.RootNode() == nil {
+		t.Fatalf("explicit Beancount forest parse ok=%v tree nil=%v", ok, explicit == nil)
+	}
+	defer explicit.Release()
+	if offset, sym, reason, states := explicitParser.ForestDeclineInfo(); reason != "eof-recovery-conflict" {
+		t.Fatalf("explicit Beancount forest decline: offset=%d symbol=%d reason=%q states=%v, want reason=%q", offset, sym, reason, states, "eof-recovery-conflict")
+	}
+	if got, want := explicit.RootNode().SExpr(lang), automatic.RootNode().SExpr(lang); got != want {
+		t.Fatalf("explicit Beancount forest result mismatch\n got: %s\nwant: %s", got, want)
+	}
+	if got, want := explicit.RootNode().EndByte(), automatic.RootNode().EndByte(); got != want {
+		t.Fatalf("explicit Beancount root endByte = %d, want %d", got, want)
+	}
+	if got, want := explicit.RootNode().HasError(), automatic.RootNode().HasError(); got != want {
+		t.Fatalf("explicit Beancount HasError = %v, want %v", got, want)
+	}
+}
+
 func TestForestDispatchReportsAcceptedRuntime(t *testing.T) {
 	gts.SetGLRForestEnabled(true)
 	defer gts.SetGLRForestEnabled(true)

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -44,7 +44,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 		"bash", "erlang", "cmake", "css", "scss", "awk", "javascript", "c_sharp",
 		"gitignore", "nix", "squirrel", "prisma",
 		"agda", "org", "ledger", "yuck", "json5", "commonlisp", "vimdoc",
-		"bibtex", "faust", "arduino", "authzed", "make", "fish", "racket", "tlaplus", "beancount",
+		"bibtex", "faust", "arduino", "authzed", "make", "fish", "racket", "tlaplus",
 		"gitattributes",
 	}
 	if len(builtinForestDefaults) != len(want) {
@@ -58,7 +58,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// A handful of explicitly-NOT-forest-amenable languages (see the doc
 	// comment) must stay out of the curated set. "go" is intentionally held
 	// out of default dispatch (commit 6894fc9f) even though it is forest-clean.
-	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv"}
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount"}
 	for _, name := range notWanted {
 		if builtinForestDefaults[name] {
 			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
@@ -75,5 +75,16 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	}
 	if !languageWantsForestRecover("csv") {
 		t.Error("CSV forest recovery should remain available to explicit forest runs")
+	}
+
+	// Beancount has the same policy split: the certified built-in no longer
+	// speculates automatically, while explicit callers retain both the forest
+	// entry point and its certified recovery behavior.
+	beancount := &Parser{language: &Language{Name: "beancount", WantsForest: true}}
+	if !parserWantsForest(beancount) {
+		t.Error("explicit Language.WantsForest should still dispatch Beancount to forest")
+	}
+	if !languageWantsForestRecover("beancount") {
+		t.Error("Beancount forest recovery should remain available to explicit forest runs")
 	}
 }


### PR DESCRIPTION
Summary

- Keep automatic Beancount parses on the production parser after the certified corpus returned no forest trees.
- Preserve explicit forest experiments and the existing Beancount recovery policy.
- Add focused dispatch and opt-in regressions plus the Unreleased changelog entry.

Evidence

- Matched four-file scan: largest ratio 30.255x to 2.130x C; aggregate 27.621x to 2.088x.
- Ratios above 10x: 1 to 0.
- All four automatic results remain accepted, full-span, error-free, and digest-identical.

Validation

- Focused dispatch tests, 10 repetitions.
- Local Docker focused dispatch and Beancount smoke tests.
- Local Docker four-file production/explicit and explicit/C structural gates.