### PR TITLE
cleanup(parser): Remove dead rust collapsed-named-leaf compat walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ for tags and release notes while still in `0.x`.
   `BenchmarkParse_C` show a statistically significant ~13-27% drop in parse
   time and 26-50% drop in allocations per parse from dropping the two
   full-tree walks.
+- Rust's collapsed named-leaf-children compat pass
+  (`parser_result_rust_recovery.go`), a full-tree walk gated on the source
+  containing `true`, `false`, `..`, or `;` — a gate that opens on essentially
+  every real Rust file. A full-corpus re-verification (all 37,127 `.rs` files
+  under the rust corpus, parsed both clean and truncated to 55% on every
+  second file — 55,691 parses total) recorded 130,018 gate fires and zero
+  rewrites. The companion candidate, Rust's dot-range-expressions walk, was
+  re-verified the same way and found live (3,030 real rewrites on the same
+  corpus, the simplest case being a bare `..` full-range slice index such as
+  `s[..]`) and is therefore kept untouched. Net 228 lines removed; verified
+  byte-identical (S-expression and full node-span dumps) on 30 real Rust
+  files spanning size and content (macro-heavy, `..`-heavy), with the Rust
+  parity suite, including the dot-range-motivated weird-expressions fixture,
+  unaffected.
 
 ## [0.33.0] - 2026-07-13
 

--- a/parser_result_rust_recovery.go
+++ b/parser_result_rust_recovery.go
@@ -3,11 +3,10 @@ package gotreesitter
 import "bytes"
 
 type rustCompatibilitySourceFlags struct {
-	collapsedNamedLeafChildren bool
-	dotRangeExpressions        bool
-	docCommentRanges           bool
-	tokenBindingPatterns       bool
-	recoveredFunctionItems     bool
+	dotRangeExpressions    bool
+	docCommentRanges       bool
+	tokenBindingPatterns   bool
+	recoveredFunctionItems bool
 }
 
 func normalizeRustCompatibility(root *Node, source []byte, p *Parser, lang *Language) {
@@ -53,96 +52,16 @@ func normalizeRustCompatibility(root *Node, source []byte, p *Parser, lang *Lang
 	run("rust_doc_comment_ranges", flags.docCommentRanges, func() {
 		normalizeRustDocCommentRanges(root, source, lang)
 	})
-	run("rust_collapsed_named_leaf_children", flags.collapsedNamedLeafChildren, func() {
-		normalizeRustCollapsedNamedLeafChildren(root, source, lang)
-	})
 }
 
 func rustCompatibilitySourceFlagsFor(source []byte) rustCompatibilitySourceFlags {
 	hasDotDot := bytes.Contains(source, []byte(".."))
 	return rustCompatibilitySourceFlags{
-		collapsedNamedLeafChildren: bytes.Contains(source, []byte("true")) ||
-			bytes.Contains(source, []byte("false")) ||
-			hasDotDot ||
-			bytes.IndexByte(source, ';') >= 0,
 		dotRangeExpressions:    hasDotDot,
 		docCommentRanges:       bytes.Contains(source, []byte("///")) || bytes.Contains(source, []byte("//!")),
 		tokenBindingPatterns:   bytes.IndexByte(source, '$') >= 0,
 		recoveredFunctionItems: bytes.Contains(source, []byte("fn")),
 	}
-}
-
-func normalizeRustCollapsedNamedLeafChildren(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "rust" || len(source) == 0 {
-		return
-	}
-	booleanLiteralSym, hasBooleanLiteral := rustResultSymbolByName(lang, "boolean_literal", true)
-	emptyStatementSym, hasEmptyStatement := rustResultSymbolByName(lang, "empty_statement", true)
-	remainingFieldPatternSym, hasRemainingFieldPattern := rustResultSymbolByName(lang, "remaining_field_pattern", true)
-	rangeExpressionSym, hasRangeExpression := rustResultSymbolByName(lang, "range_expression", true)
-	trueSym, hasTrue := rustResultSymbolByName(lang, "true", false)
-	falseSym, hasFalse := rustResultSymbolByName(lang, "false", false)
-	semicolonSym, hasSemicolon := rustResultSymbolByName(lang, ";", false)
-	dotDotSym, hasDotDot := rustResultSymbolByName(lang, "..", false)
-	dotDotEqSym, hasDotDotEq := rustResultSymbolByName(lang, "..=", false)
-	trueNamed := symbolIsNamed(lang, trueSym)
-	falseNamed := symbolIsNamed(lang, falseSym)
-	semicolonNamed := symbolIsNamed(lang, semicolonSym)
-	dotDotNamed := symbolIsNamed(lang, dotDotSym)
-	dotDotEqNamed := symbolIsNamed(lang, dotDotEqSym)
-
-	walkResultTreeSidecarFirst(root, func(n *Node) {
-		if n == nil || resultChildCount(n) != 0 || n.startByte > n.endByte || int(n.endByte) > len(source) {
-			return
-		}
-		start := int(n.startByte)
-		width := int(n.endByte - n.startByte)
-		var childSym Symbol
-		var childNamed bool
-		ok := false
-		switch {
-		case hasBooleanLiteral && n.symbol == booleanLiteralSym:
-			switch {
-			case hasTrue && width == 4 && source[start] == 't' && source[start+1] == 'r' && source[start+2] == 'u' && source[start+3] == 'e':
-				childSym, childNamed, ok = trueSym, trueNamed, true
-			case hasFalse && width == 5 && source[start] == 'f' && source[start+1] == 'a' && source[start+2] == 'l' && source[start+3] == 's' && source[start+4] == 'e':
-				childSym, childNamed, ok = falseSym, falseNamed, true
-			}
-		case hasEmptyStatement && n.symbol == emptyStatementSym:
-			if hasSemicolon && width == 1 && source[start] == ';' {
-				childSym, childNamed, ok = semicolonSym, semicolonNamed, true
-			}
-		case hasRemainingFieldPattern && n.symbol == remainingFieldPatternSym:
-			if hasDotDot && width == 2 && source[start] == '.' && source[start+1] == '.' {
-				childSym, childNamed, ok = dotDotSym, dotDotNamed, true
-			}
-		case hasRangeExpression && n.symbol == rangeExpressionSym:
-			switch {
-			case hasDotDot && width == 2 && source[start] == '.' && source[start+1] == '.':
-				childSym, childNamed, ok = dotDotSym, dotDotNamed, true
-			case hasDotDotEq && width == 3 && source[start] == '.' && source[start+1] == '.' && source[start+2] == '=':
-				childSym, childNamed, ok = dotDotEqSym, dotDotEqNamed, true
-			}
-		}
-		if !ok {
-			return
-		}
-		child := newLeafNodeInArena(n.ownerArena, childSym, childNamed, n.startByte, n.endByte, n.startPoint, n.endPoint)
-		child.parent = n
-		child.childIndex = 0
-		n.children = cloneNodeSliceInArena(n.ownerArena, []*Node{child})
-	})
-}
-
-func rustResultSymbolByName(lang *Language, name string, named bool) (Symbol, bool) {
-	if lang == nil {
-		return 0, false
-	}
-	sym, ok := lang.symbolByNameAndNamed(name, named)
-	if ok {
-		return sym, true
-	}
-	return symbolByName(lang, name)
 }
 
 func normalizeRustDocCommentRanges(root *Node, source []byte, lang *Language) {

--- a/parser_result_rust_test.go
+++ b/parser_result_rust_test.go
@@ -2,150 +2,6 @@ package gotreesitter
 
 import "testing"
 
-func TestNormalizeRustBooleanLiteralRestoresKeywordChild(t *testing.T) {
-	lang := &Language{
-		Name:        "rust",
-		SymbolNames: []string{"", "source_file", "boolean_literal", "true", "false", "empty_statement", ";"},
-		SymbolMetadata: []SymbolMetadata{
-			{},
-			{Name: "source_file", Visible: true, Named: true},
-			{Name: "boolean_literal", Visible: true, Named: true},
-			{Name: "true", Visible: true, Named: false},
-			{Name: "false", Visible: true, Named: false},
-			{Name: "empty_statement", Visible: true, Named: true},
-			{Name: ";", Visible: true, Named: false},
-		},
-	}
-	parser := &Parser{language: lang}
-	arena := acquireNodeArena(arenaClassFull)
-	source := []byte("true")
-	booleanLiteral := newLeafNodeInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
-	root := newParentNodeInArena(arena, 1, true, []*Node{booleanLiteral}, nil, 0)
-
-	normalizeResultCompatibility(root, source, parser)
-
-	if got, want := booleanLiteral.ChildCount(), 1; got != want {
-		t.Fatalf("boolean literal child count = %d, want %d", got, want)
-	}
-	child := booleanLiteral.Child(0)
-	if child == nil {
-		t.Fatal("boolean literal child = nil")
-	}
-	if got, want := child.Type(lang), "true"; got != want {
-		t.Fatalf("boolean literal child type = %q, want %q", got, want)
-	}
-	if child.IsNamed() {
-		t.Fatal("restored true child should be anonymous")
-	}
-}
-
-func TestNormalizeRustEmptyStatementRestoresSemicolonChild(t *testing.T) {
-	lang := &Language{
-		Name:        "rust",
-		SymbolNames: []string{"", "source_file", "empty_statement", ";", "remaining_field_pattern", ".."},
-		SymbolMetadata: []SymbolMetadata{
-			{},
-			{Name: "source_file", Visible: true, Named: true},
-			{Name: "empty_statement", Visible: true, Named: true},
-			{Name: ";", Visible: true, Named: false},
-			{Name: "remaining_field_pattern", Visible: true, Named: true},
-			{Name: "..", Visible: true, Named: false},
-		},
-	}
-	parser := &Parser{language: lang}
-	arena := acquireNodeArena(arenaClassFull)
-	source := []byte(";")
-	emptyStatement := newLeafNodeInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
-	root := newParentNodeInArena(arena, 1, true, []*Node{emptyStatement}, nil, 0)
-
-	normalizeResultCompatibility(root, source, parser)
-
-	if got, want := emptyStatement.ChildCount(), 1; got != want {
-		t.Fatalf("empty statement child count = %d, want %d", got, want)
-	}
-	child := emptyStatement.Child(0)
-	if child == nil {
-		t.Fatal("empty statement child = nil")
-	}
-	if got, want := child.Type(lang), ";"; got != want {
-		t.Fatalf("empty statement child type = %q, want %q", got, want)
-	}
-	if child.IsNamed() {
-		t.Fatal("restored semicolon child should be anonymous")
-	}
-}
-
-func TestNormalizeRustRemainingFieldPatternRestoresDotDotChild(t *testing.T) {
-	lang := &Language{
-		Name:        "rust",
-		SymbolNames: []string{"", "source_file", "remaining_field_pattern", "..", "range_expression", "..="},
-		SymbolMetadata: []SymbolMetadata{
-			{},
-			{Name: "source_file", Visible: true, Named: true},
-			{Name: "remaining_field_pattern", Visible: true, Named: true},
-			{Name: "..", Visible: true, Named: false},
-			{Name: "range_expression", Visible: true, Named: true},
-			{Name: "..=", Visible: true, Named: false},
-		},
-	}
-	parser := &Parser{language: lang}
-	arena := acquireNodeArena(arenaClassFull)
-	source := []byte("..")
-	remaining := newLeafNodeInArena(arena, 2, true, 0, 2, Point{}, Point{Column: 2})
-	root := newParentNodeInArena(arena, 1, true, []*Node{remaining}, nil, 0)
-
-	normalizeResultCompatibility(root, source, parser)
-
-	if got, want := remaining.ChildCount(), 1; got != want {
-		t.Fatalf("remaining field pattern child count = %d, want %d", got, want)
-	}
-	child := remaining.Child(0)
-	if child == nil {
-		t.Fatal("remaining field pattern child = nil")
-	}
-	if got, want := child.Type(lang), ".."; got != want {
-		t.Fatalf("remaining field pattern child type = %q, want %q", got, want)
-	}
-	if child.IsNamed() {
-		t.Fatal("restored .. child should be anonymous")
-	}
-}
-
-func TestNormalizeRustRangeExpressionRestoresOperatorChild(t *testing.T) {
-	lang := &Language{
-		Name:        "rust",
-		SymbolNames: []string{"", "source_file", "range_expression", "..", "..="},
-		SymbolMetadata: []SymbolMetadata{
-			{},
-			{Name: "source_file", Visible: true, Named: true},
-			{Name: "range_expression", Visible: true, Named: true},
-			{Name: "..", Visible: true, Named: false},
-			{Name: "..=", Visible: true, Named: false},
-		},
-	}
-	parser := &Parser{language: lang}
-	arena := acquireNodeArena(arenaClassFull)
-	source := []byte("..=")
-	rangeExpr := newLeafNodeInArena(arena, 2, true, 0, 3, Point{}, Point{Column: 3})
-	root := newParentNodeInArena(arena, 1, true, []*Node{rangeExpr}, nil, 0)
-
-	normalizeResultCompatibility(root, source, parser)
-
-	if got, want := rangeExpr.ChildCount(), 1; got != want {
-		t.Fatalf("range expression child count = %d, want %d", got, want)
-	}
-	child := rangeExpr.Child(0)
-	if child == nil {
-		t.Fatal("range expression child = nil")
-	}
-	if got, want := child.Type(lang), "..="; got != want {
-		t.Fatalf("range expression child type = %q, want %q", got, want)
-	}
-	if child.IsNamed() {
-		t.Fatal("restored ..= child should be anonymous")
-	}
-}
-
 func TestRustExtractRecoveredTopLevelNodesWithOffsetClonesIntoDestinationArena(t *testing.T) {
 	lang := &Language{
 		Name:        "rust",
@@ -628,14 +484,11 @@ func TestRustRetagCleanTopLevelErrorRootKeepsFinalChildRefsLazy(t *testing.T) {
 }
 
 func TestRustCompatibilitySourceFlags(t *testing.T) {
-	if flags := rustCompatibilitySourceFlagsFor([]byte("let x = 1\n")); flags.collapsedNamedLeafChildren || flags.dotRangeExpressions || flags.docCommentRanges || flags.tokenBindingPatterns || flags.recoveredFunctionItems {
+	if flags := rustCompatibilitySourceFlagsFor([]byte("let x = 1\n")); flags.dotRangeExpressions || flags.docCommentRanges || flags.tokenBindingPatterns || flags.recoveredFunctionItems {
 		t.Fatalf("unexpected Rust compatibility flags for plain binding: %+v", flags)
 	}
-	if flags := rustCompatibilitySourceFlagsFor([]byte("let x = true;")); !flags.collapsedNamedLeafChildren {
-		t.Fatalf("expected collapsed leaf flag for true/semicolon source: %+v", flags)
-	}
-	if flags := rustCompatibilitySourceFlagsFor([]byte("let r = 1..=3;")); !flags.dotRangeExpressions || !flags.collapsedNamedLeafChildren {
-		t.Fatalf("expected dot range and collapsed leaf flags for range source: %+v", flags)
+	if flags := rustCompatibilitySourceFlagsFor([]byte("let r = 1..=3;")); !flags.dotRangeExpressions {
+		t.Fatalf("expected dot range flag for range source: %+v", flags)
 	}
 	if flags := rustCompatibilitySourceFlagsFor([]byte("/// docs\nfn f() {}\n")); !flags.docCommentRanges || !flags.recoveredFunctionItems {
 		t.Fatalf("expected doc comment and recovered function flags: %+v", flags)


### PR DESCRIPTION
## Summary

Removes `rust_collapsed_named_leaf_children` — a full-tree compat walk whose gate (source containing `true`/`false`/`..`/`;`) opened on essentially every rust parse while never rewriting anything. The full-corpus pre-cut gate parsed all 37,127 corpus `.rs` files clean plus 18,564 truncated variants: 130,018 gate fires, zero rewrites. Net −228 lines including the pass's synthetic unit tests.

Equally important, the same gate **cancelled** the census's second candidate: `rust_dot_range_expressions` showed 3,030 real rewrites on the full corpus (minimal repro: `&s[..]` — it repairs a genuinely-produced childless `range_expression` for bare `..` slice ranges). The census's sampled fingerprint missed it because `..` is an anonymous token, invisible to named-S-expression diffing. That pass and its helpers are untouched, and the census canon is being corrected accordingly.

## Receipts

- Byte-identity: S-expression + full node-span dumps on 30 real rust files (macro-heavy and `..`-heavy included) — zero diffs.
- Deep-parity suites green after corpus seeding, including `TestRustPatternStatementParity` and `TestRustWeirdExpressionsParity`.
- Benchstat `BenchmarkFamilyParseFullDFA/systems/rust` n=8: neutral (p=0.195) — expected, as this walk's cost was gate-check dominated.

## Gates

`go build ./...`, `go vet ./...`, gofmt clean; root suite plain + `-race`; rust-filtered suites across root, parser_result_test, grammars, and grammargen packages — all green. Changelog bullet under Unreleased.