### PR TITLE
perf(parser): skip discarded Org and Vimdoc forest parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- Automatic forest dispatch no longer speculates through Beancount by default.
+  The exact four-file clean corpus produced no forest return, so every parse
+  paid for a discarded forest before production. In matched automatic-parser
+  scans, removing that retry cut the 347 KiB witness from 30.255x to 2.130x C
+  and the corpus aggregate from 27.621x to 2.088x, eliminating the only ratio
+  above 10x while returning the same accepted, full-span, error-free trees.
+  Explicit forest experiments and Beancount's certified recovery policy remain
+  available.
+- Automatic forest dispatch no longer speculates through Org or Vimdoc by
+  default. Representative clean witnesses produced no forest return and
+  returned the exact production tree after declining at EOF. Production-only
+  routing cut fresh parses by about 97%; on reused parsers it also removed the
+  repeated 97% Vimdoc penalty, while Org's bounded decline memo had already
+  made warm parses production-like. Explicit forest experiments and both
+  certified recovery policies remain available.
+
 ### Removed
 
 - Five confirmed-dead C/C++ post-parse compatibility passes, found by a
@@ -72,14 +90,6 @@ compatibility code is removed.
 
 ### Changed
 
-- Automatic forest dispatch no longer speculates through Beancount by default.
-  The exact four-file clean corpus produced no forest return, so every parse
-  paid for a discarded forest before production. In matched automatic-parser
-  scans, removing that retry cut the 347 KiB witness from 30.255x to 2.130x C
-  and the corpus aggregate from 27.621x to 2.088x, eliminating the only ratio
-  above 10x while returning the same accepted, full-span, error-free trees.
-  Explicit forest experiments and Beancount's certified recovery policy remain
-  available.
 - Automatic forest dispatch now remembers stable semantic declines for a small,
   bounded set of unchanged sources and routes warm recurring full parses
   directly to the production parser after exact source verification. Explicit

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -457,6 +457,13 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // largest 347 KiB witness that retry raised the Go/C ratio from 1.72x on the
 // production path to 30.26x under automatic dispatch.
 //
+// Org and Vimdoc retain their certified recovery policies for explicit forest
+// experiments, but automatic dispatch is held out. Representative clean
+// witnesses produced zero forest returns: both reached EOF and declined with
+// eof-recovery-conflict before returning the exact production tree. That retry
+// made fresh parses more than 30x slower; Vimdoc's 227 KiB witness also exceeds
+// the bounded decline-memo ceiling, so reused parsers repeated the same cost.
+//
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
 // parserWantsForest) instead of joining this map — e.g. a grammargen consumer
 // generating its own grammar (a Pawn grammar, say) sets WantsForest directly
@@ -494,16 +501,15 @@ var builtinForestDefaults = map[string]bool{
 	"squirrel":  true,
 	"prisma":    true,
 
-	// Phase 2 promotions 2026-06-08: forest+recovery, introduced=0 vs C, large
-	// net-wall win (agda 0.95x/prod28x, org 1.70x/25x, ledger 2.27x/345x,
-	// yuck 1.28x/14x, json5 1.81x/50x). See languageWantsForestRecover.
+	// Phase 2 promotions 2026-06-08: forest+recovery, introduced=0 vs C and a
+	// large net-wall win. Org and Vimdoc later moved back to explicit-only
+	// routing after current clean witnesses showed only discarded attempts;
+	// their certified recovery profiles remain in languageWantsForestRecover.
 	"agda":       true,
-	"org":        true,
 	"ledger":     true,
 	"yuck":       true,
 	"json5":      true,
 	"commonlisp": true,
-	"vimdoc":     true,
 
 	// Promoted 2026-06-08 via the forest-vs-C sweep (TestForestVsCSources):
 	// the forest introduces ZERO C-divergences (every divergence is inherited
@@ -513,14 +519,14 @@ var builtinForestDefaults = map[string]bool{
 	// arduino 10/19 production-mismatches that are the forest being C-correct).
 	// Held: make (forest=C-clean but net-wall NEUTRAL 1.0x — no lift) and
 	// commonlisp (net-wall unverified; rich corpus times out — revisit).
-	"bibtex":    true,
-	"faust":     true,
-	"arduino":   true,
-	"authzed":   true,
-	"make":      true,
-	"fish":      true,
-	"racket":    true,
-	"tlaplus":   true,
+	"bibtex":  true,
+	"faust":   true,
+	"arduino": true,
+	"authzed": true,
+	"make":    true,
+	"fish":    true,
+	"racket":  true,
+	"tlaplus": true,
 
 	// Promoted 2026-06-08 against the C ORACLE, not production. gitattributes
 	// is parity-blocked (production diverges from C), but the forest matches

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -154,6 +154,56 @@ func TestBeancountDefaultSkipsForestButExplicitRemainsAvailable(t *testing.T) {
 	}
 }
 
+func TestOrgAndVimdocDefaultSkipForestButExplicitRemainAvailable(t *testing.T) {
+	// Follow this file's existing non-parallel convention around the global
+	// test/benchmark forest switch.
+	gts.SetGLRForestEnabled(true)
+	defer gts.SetGLRForestEnabled(true)
+
+	tests := []struct {
+		name string
+		lang func() *gts.Language
+		src  string
+	}{
+		{name: "org", lang: grm.OrgLanguage, src: "# The GNU Free Documentation License.\n#+begin_center\nVersion 1.3, 3 November 2008\n#+end_center\n\n#+begin_verse\nCopyright 2008 Free Software Foundation, Inc.\n#+end_verse\n\n* ADDENDUM: How to use this License for your documents\n:PROPERTIES:\n:UNNUMBERED: notoc\n:END:\n"},
+		{name: "vimdoc", lang: grm.VimdocLanguage, src: "*lua-guide.txt*                        Nvim\n\n                            NVIM REFERENCE MANUAL\n\n==============================================================================\nIntroduction                                                         *lua-guide*\n\nThis guide introduces Lua usage in Nvim.\n\nvim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lang := tt.lang()
+			src := []byte(tt.src)
+			automaticParser := gts.NewParser(lang)
+			automatic, err := automaticParser.Parse(src)
+			if err != nil {
+				t.Fatalf("automatic parse: %v", err)
+			}
+			defer automatic.Release()
+			if rt := automatic.ParseRuntime(); rt.ForestFastPath {
+				t.Fatalf("automatic parse used forest fast path: %s", rt.Summary())
+			}
+			if offset, sym, reason, states := automaticParser.ForestDeclineInfo(); reason != "" {
+				t.Fatalf("automatic parse attempted forest: offset=%d symbol=%d reason=%q states=%v", offset, sym, reason, states)
+			}
+
+			explicitParser := gts.NewParser(lang)
+			explicit, ok := explicitParser.ParseForestExperimental(src)
+			if !ok || explicit == nil || explicit.RootNode() == nil {
+				t.Fatalf("explicit forest parse ok=%v tree nil=%v", ok, explicit == nil)
+			}
+			defer explicit.Release()
+			if got, want := explicit.RootNode().SExpr(lang), automatic.RootNode().SExpr(lang); got != want {
+				t.Fatalf("explicit forest result mismatch\n got: %s\nwant: %s", got, want)
+			}
+			if got, want := explicit.RootNode().EndByte(), automatic.RootNode().EndByte(); got != want {
+				t.Fatalf("explicit forest root endByte = %d, want %d", got, want)
+			}
+			if got, want := explicit.RootNode().HasError(), automatic.RootNode().HasError(); got != want {
+				t.Fatalf("explicit forest HasError = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestForestDispatchReportsAcceptedRuntime(t *testing.T) {
 	gts.SetGLRForestEnabled(true)
 	defer gts.SetGLRForestEnabled(true)

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -43,7 +43,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	want := []string{
 		"bash", "erlang", "cmake", "css", "scss", "awk", "javascript", "c_sharp",
 		"gitignore", "nix", "squirrel", "prisma",
-		"agda", "org", "ledger", "yuck", "json5", "commonlisp", "vimdoc",
+		"agda", "ledger", "yuck", "json5", "commonlisp",
 		"bibtex", "faust", "arduino", "authzed", "make", "fish", "racket", "tlaplus",
 		"gitattributes",
 	}
@@ -58,7 +58,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// A handful of explicitly-NOT-forest-amenable languages (see the doc
 	// comment) must stay out of the curated set. "go" is intentionally held
 	// out of default dispatch (commit 6894fc9f) even though it is forest-clean.
-	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount"}
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc"}
 	for _, name := range notWanted {
 		if builtinForestDefaults[name] {
 			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
@@ -86,5 +86,17 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	}
 	if !languageWantsForestRecover("beancount") {
 		t.Error("Beancount forest recovery should remain available to explicit forest runs")
+	}
+
+	// Org and Vimdoc retain the same explicit-only split without losing their
+	// certified recovery profiles.
+	for _, name := range []string{"org", "vimdoc"} {
+		parser := &Parser{language: &Language{Name: name, WantsForest: true}}
+		if !parserWantsForest(parser) {
+			t.Errorf("explicit Language.WantsForest should still dispatch %s to forest", name)
+		}
+		if !languageWantsForestRecover(name) {
+			t.Errorf("%s forest recovery should remain available to explicit forest runs", name)
+		}
 	}
 }


### PR DESCRIPTION
Summary

- Route automatic Org and Vimdoc parsing directly to the production parser after representative clean witnesses produced no useful forest return.
- Preserve explicit forest experiments and both recovery profiles.
- Move the post-v0.33 Beancount entry into the Unreleased changelog section.

Measured impact

- Org fdl.org: 250.3 ms automatic to 7.89 ms production; the production path measured 1.40x C.
- Vimdoc luaref.txt: 2.538 s automatic to 67.2 ms production; reused automatic parsing remained 2.046 s because the source exceeds the decline-memo ceiling. The production path measured 1.075x C.
- Automatic and production paths returned identical accepted trees, root spans, and error state.

Verification

- Focused forest-default and explicit-opt-in unit tests.
- Isolated Org Docker parity: 1 file, 0 divergences.
- Isolated Vimdoc Docker parity: 1 file, 0 divergences.
- git diff --check.