### PR TITLE
perf(parser): skip discarded Fish and Racket forest parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ for tags and release notes while still in `0.x`.
   repeated 97% Vimdoc penalty, while Org's bounded decline memo had already
   made warm parses production-like. Explicit forest experiments and both
   certified recovery policies remain available.
+- Automatic forest dispatch no longer speculates through Fish or Racket by
+  default. Two locked clean witnesses per language produced no forest return
+  and returned the exact production tree after declining at EOF. Removing the
+  discarded attempt cut fresh Fish parses by 90-95% and fresh Racket parses by
+  94-95%; reused 234-248 KiB witnesses improved by 94-96%, while smaller warm
+  parses were already protected by the bounded decline memo. Explicit forest
+  experiments and both certified recovery policies remain available.
 
 ### Removed
 

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -464,6 +464,14 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // made fresh parses more than 30x slower; Vimdoc's 227 KiB witness also exceeds
 // the bounded decline-memo ceiling, so reused parsers repeated the same cost.
 //
+// Fish and Racket are held out for the same reason. Two locked clean witnesses
+// per language produced zero forest returns: each attempt reached EOF, declined
+// with eof-recovery-conflict, and returned the exact production tree. Fresh
+// automatic parses were 10-22x slower for Fish and 16-19x slower for Racket;
+// their 234-248 KiB witnesses exceed the decline-memo ceiling and repeated the
+// same cost on reused parsers. Their recovery policies remain available to
+// explicit forest experiments.
+//
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
 // parserWantsForest) instead of joining this map — e.g. a grammargen consumer
 // generating its own grammar (a Pawn grammar, say) sets WantsForest directly
@@ -524,8 +532,6 @@ var builtinForestDefaults = map[string]bool{
 	"arduino": true,
 	"authzed": true,
 	"make":    true,
-	"fish":    true,
-	"racket":  true,
 	"tlaplus": true,
 
 	// Promoted 2026-06-08 against the C ORACLE, not production. gitattributes

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -154,7 +154,7 @@ func TestBeancountDefaultSkipsForestButExplicitRemainsAvailable(t *testing.T) {
 	}
 }
 
-func TestOrgAndVimdocDefaultSkipForestButExplicitRemainAvailable(t *testing.T) {
+func TestExplicitOnlyLanguagesSkipDefaultForestButRemainAvailable(t *testing.T) {
 	// Follow this file's existing non-parallel convention around the global
 	// test/benchmark forest switch.
 	gts.SetGLRForestEnabled(true)
@@ -167,6 +167,8 @@ func TestOrgAndVimdocDefaultSkipForestButExplicitRemainAvailable(t *testing.T) {
 	}{
 		{name: "org", lang: grm.OrgLanguage, src: "# The GNU Free Documentation License.\n#+begin_center\nVersion 1.3, 3 November 2008\n#+end_center\n\n#+begin_verse\nCopyright 2008 Free Software Foundation, Inc.\n#+end_verse\n\n* ADDENDUM: How to use this License for your documents\n:PROPERTIES:\n:UNNUMBERED: notoc\n:END:\n"},
 		{name: "vimdoc", lang: grm.VimdocLanguage, src: "*lua-guide.txt*                        Nvim\n\n                            NVIM REFERENCE MANUAL\n\n==============================================================================\nIntroduction                                                         *lua-guide*\n\nThis guide introduces Lua usage in Nvim.\n\nvim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:\n"},
+		{name: "fish", lang: grm.FishLanguage, src: "function greet\n    echo hello\nend\n"},
+		{name: "racket", lang: grm.RacketLanguage, src: "#lang racket\n(define (square x) (* x x))\n(displayln (square 4))\n"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -44,7 +44,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 		"bash", "erlang", "cmake", "css", "scss", "awk", "javascript", "c_sharp",
 		"gitignore", "nix", "squirrel", "prisma",
 		"agda", "ledger", "yuck", "json5", "commonlisp",
-		"bibtex", "faust", "arduino", "authzed", "make", "fish", "racket", "tlaplus",
+		"bibtex", "faust", "arduino", "authzed", "make", "tlaplus",
 		"gitattributes",
 	}
 	if len(builtinForestDefaults) != len(want) {
@@ -58,7 +58,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// A handful of explicitly-NOT-forest-amenable languages (see the doc
 	// comment) must stay out of the curated set. "go" is intentionally held
 	// out of default dispatch (commit 6894fc9f) even though it is forest-clean.
-	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc"}
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc", "fish", "racket"}
 	for _, name := range notWanted {
 		if builtinForestDefaults[name] {
 			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
@@ -91,6 +91,18 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// Org and Vimdoc retain the same explicit-only split without losing their
 	// certified recovery profiles.
 	for _, name := range []string{"org", "vimdoc"} {
+		parser := &Parser{language: &Language{Name: name, WantsForest: true}}
+		if !parserWantsForest(parser) {
+			t.Errorf("explicit Language.WantsForest should still dispatch %s to forest", name)
+		}
+		if !languageWantsForestRecover(name) {
+			t.Errorf("%s forest recovery should remain available to explicit forest runs", name)
+		}
+	}
+
+	// Fish and Racket also keep their certified recovery profiles and direct
+	// opt-in path after automatic routing is removed.
+	for _, name := range []string{"fish", "racket"} {
 		parser := &Parser{language: &Language{Name: name, WantsForest: true}}
 		if !parserWantsForest(parser) {
 			t.Errorf("explicit Language.WantsForest should still dispatch %s to forest", name)


### PR DESCRIPTION
## Summary

- stop automatic forest dispatch for Fish and Racket after two locked clean witnesses per language returned only exact production fallbacks at EOF
- retain explicit forest opt-in and certified recovery policies
- extend routing tests and record the measured change in Unreleased

## Results

- Fish fresh automatic routing was 10.14-22.02x slower than production-only; the larger reused witness was 25.71x slower
- Racket fresh automatic routing was 16.49-19.29x slower; production-only measured 1.21-1.26x C instead of roughly 25-27x C
- all automatic attempts produced zero forest fast-path returns and returned the exact production digest after eof-recovery-conflict

## Validation

- focused root routing tests pass
- isolated Fish Docker parity: 2 files, zero divergence, no OOM
- isolated Racket Docker parity: 2 files, zero divergence, no OOM
- git diff --check passes