### PR TITLE
chore(release): prepare v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-07-13
+
+Forest-routing performance and compatibility-hygiene release. Automatic
+dispatch now avoids five language paths that consistently discarded their
+forest result, while confirmed-dead C, C++, and Rust compatibility walks are
+removed after full-corpus verification.
+
 ### Changed
 
 - Automatic forest dispatch no longer speculates through Beancount by default.
@@ -2318,7 +2325,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/odvcencio/gotreesitter/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/odvcencio/gotreesitter/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/odvcencio/gotreesitter/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/odvcencio/gotreesitter/compare/v0.30.0...v0.31.0

--- a/README.md
+++ b/README.md
@@ -658,11 +658,11 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.33.0**. The 206-grammar curated parity milestone is
-banked. v0.33.0 reduces recurring parser and failed-forest work, reuses
-missing-shift recovery state, skips certified C# compatibility passes, tightens
-arena and browser-WASM lifetimes, and removes confirmed-dead compatibility
-code. Detailed history lives in [CHANGELOG.md](CHANGELOG.md).
+The current release is **v0.34.0**. The 206-grammar curated parity milestone is
+banked. v0.34.0 removes discarded automatic forest work for Beancount, Org,
+Vimdoc, Fish, and Racket, and deletes confirmed-dead C, C++, and Rust
+compatibility passes after full-corpus verification. Detailed history lives in
+[CHANGELOG.md](CHANGELOG.md).
 
 ### Now — performance and extreme hygiene
 


### PR DESCRIPTION
## Summary

- publish the accumulated forest-routing and compatibility-hygiene work as v0.34.0
- move the complete Unreleased record under the dated release heading
- refresh README release status and changelog comparison links

## Included changes

- avoid discarded automatic forest attempts for Beancount, Org, Vimdoc, Fish, and Racket while retaining explicit and recovery paths
- remove full-corpus-confirmed dead compatibility passes from C, C++, and Rust

## Validation

- root package compile check passes
- git diff --check passes
- every included implementation PR passed its focused parity, performance, and hosted CI gates