### PR TITLE
perf(parser): avoid redundant accepted-error retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Performance
+
+- The exact built-in Meson grammar now skips the redundant accepted-error
+  retry ladder only for sources of at least 2 KiB. A locked 1,549-file corpus
+  certification preserved complete and structural trees across all 28
+  eligible error-bearing files and cut their aggregate one-pass parse time by
+  78.04% (1.410s to 0.310s). Smaller inputs keep the generic retry ladder,
+  including seven witnesses where retrying changes the selected tree.
+- The exact built-in Enforce grammar now reuses a certified complete
+  accepted-error widened result instead of repeating it with recovery enabled
+  on sources of at least 128 KiB. Locked full-tree, structural, and semantic
+  runtime checks remained exact; count-10 runs cut playerbase time by 28.01%
+  and itembase time by 7.31%, with corresponding allocation reductions and an
+  unchanged clean control.
+
 ## [0.34.0] - 2026-07-13
 
 Forest-routing performance and compatibility-hygiene release. Automatic

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -22,6 +22,7 @@ type builtinLanguageRuntimeProfile struct {
 const (
 	csharpAcceptedErrorRetryMaxEntryScratchPeak = 690_365
 	csharpFreshErrorNoStacksRetryMaxStacks      = 16
+	mesonAcceptedErrorRetryMinSourceBytes       = 2 * 1024
 )
 
 var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
@@ -126,10 +127,31 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},
 	},
+	// On the locked large accepted-error witnesses, the non-recovery and
+	// recovery-enabled widened-stack passes produce the same complete tree and
+	// semantic runtime state. Retain the first result instead of parsing it
+	// again; exact blob identity keeps adapted and future grammars conservative.
+	"enforce": {
+		blobSHA256: mustRuntimeProfileSHA256("9ddb5d9b74c06eb3f3f9eba98be968719eff298d86ee9aa046009ed0a868b676"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			ReuseCleanWideForWideRetry:   true,
+			ReuseCleanWideMinSourceBytes: 128 * 1024,
+		},
+	},
 	"kdl": {
 		blobSHA256: mustRuntimeProfileSHA256("ef6d000123c053eddebd200a1cbd44d6df5dcab7c4b3d34ae18acdf2f14989f5"),
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry: true,
+		},
+	},
+	// Meson's retry ladder changes selected trees on small error-bearing files,
+	// but is redundant for complete accepted-error sources at or above this
+	// conservative exact-blob corpus-certified floor.
+	"meson": {
+		blobSHA256: mustRuntimeProfileSHA256("b3b7e74bcd35614419f5359c31eb8a05bd58c0b97529f133f2aea2f40796789d"),
+		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
+			SkipCompleteAcceptedErrorRetry: true,
+			SkipCompleteMinSourceBytes:     mesonAcceptedErrorRetryMinSourceBytes,
 		},
 	},
 	"rego": {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -34,14 +34,15 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	// 21 = the prior 19 plus D and Groovy: their retry ceilings moved out of
+	// 23 = the prior 19 plus D and Groovy, whose retry ceilings moved out of
 	// parser-core name switches and onto exact-blob profiles. The prior gomod
-	// and C additions moved hardcoded compat-tier
+	// and C additions moved hardcoded compat-tier behavior to profiles. Meson
+	// and Enforce add two exact-blob retry policies. The
 	// repetition-conflict helpers were retired in favor of certified
 	// ConflictPolicies rows here. dot's helper was
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry.
-	if got, want := len(builtinLanguageRuntimeProfiles), 21; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 23; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -53,6 +54,39 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
 		t.Fatalf("unknown runtime profile changed accepted-error retry profile to %+v", got)
+	}
+}
+
+func TestEnforceDuplicateWideProfileRequiresExactBlobIdentity(t *testing.T) {
+	want := gotreesitter.FullParseAcceptedErrorRetryProfile{
+		ReuseCleanWideForWideRetry:   true,
+		ReuseCleanWideMinSourceBytes: 128 * 1024,
+	}
+
+	wrongSHA := &gotreesitter.Language{Name: "enforce"}
+	if attachBuiltinLanguageRuntimeProfile("enforce", sha256.Sum256([]byte("uncertified")), wrongSHA) {
+		t.Fatal("wrong Enforce blob SHA reported a runtime-profile attachment")
+	}
+	if got := wrongSHA.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("wrong Enforce blob SHA attached retry profile %+v", got)
+	}
+
+	adapted := &gotreesitter.Language{Name: "enforce"}
+	AttachLanguageSupport("enforce", adapted)
+	if got := adapted.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
+		t.Fatalf("adapted Enforce language attached retry profile %+v", got)
+	}
+
+	blob := BlobByName("enforce")
+	if len(blob) == 0 {
+		t.Fatal("BlobByName(enforce) returned no data")
+	}
+	exact := &gotreesitter.Language{Name: "enforce"}
+	if !attachBuiltinLanguageRuntimeProfile("enforce", sha256.Sum256(blob), exact) {
+		t.Fatal("exact Enforce blob did not attach duplicate-wide profile")
+	}
+	if got := exact.FullParseAcceptedErrorRetryProfile; got != want {
+		t.Fatalf("exact Enforce retry profile = %+v, want %+v", got, want)
 	}
 }
 
@@ -254,6 +288,7 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 		{name: "cpp", load: CppLanguage},
 		{name: "haxe", load: HaxeLanguage},
 		{name: "kdl", load: KdlLanguage},
+		{name: "meson", load: MesonLanguage},
 		{name: "odin", load: OdinLanguage},
 		{name: "rego", load: RegoLanguage},
 		{name: "scss", load: ScssLanguage},
@@ -268,6 +303,9 @@ func TestBuiltinCompleteAcceptedErrorRetryProfilesAttach(t *testing.T) {
 			}
 			if tt.name == "swift" && profile.SkipCompleteMaxEntryScratchPeak != 3*64*1024 {
 				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want first-growth entry-scratch ceiling", profile)
+			}
+			if tt.name == "meson" && profile.SkipCompleteMinSourceBytes != 2*1024 {
+				t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want %d-byte skip minimum", profile, 2*1024)
 			}
 			if tt.name == "c_sharp" && (profile.SkipCompleteMaxEntryScratchPeak != csharpAcceptedErrorRetryMaxEntryScratchPeak ||
 				profile.FreshErrorNoStacksRetryMaxStacks != csharpFreshErrorNoStacksRetryMaxStacks ||
@@ -447,6 +485,13 @@ func TestResidualRetryProfilesRequireExactBlobIdentity(t *testing.T) {
 				SkipCompleteMaxEntryScratchPeak:            csharpAcceptedErrorRetryMaxEntryScratchPeak,
 				FreshErrorNoStacksRetryMaxStacks:           csharpFreshErrorNoStacksRetryMaxStacks,
 				SkipInitialCompleteAcceptedErrorMergeRetry: true,
+			},
+		},
+		{
+			name: "meson",
+			want: gotreesitter.FullParseAcceptedErrorRetryProfile{
+				SkipCompleteAcceptedErrorRetry: true,
+				SkipCompleteMinSourceBytes:     2 * 1024,
 			},
 		},
 	}

--- a/language.go
+++ b/language.go
@@ -316,6 +316,18 @@ type FullParseAcceptedErrorRetryProfile struct {
 	// widened-stack and merge retries remain available. Incremental fallbacks
 	// and explicit stack/merge environment overrides ignore it.
 	SkipInitialCompleteAcceptedErrorMergeRetry bool
+	// SkipCompleteMinSourceBytes limits SkipCompleteAcceptedErrorRetry to
+	// sources at least this large. Zero preserves the legacy unbounded skip.
+	// It has no effect on the profile's other retry policies.
+	SkipCompleteMinSourceBytes uint32
+	// ReuseCleanWideForWideRetry certifies that the complete accepted-error tree
+	// from the non-recovery widened-stack pass is identical to the following
+	// recovery-enabled widened-stack pass. The parser may retain that tree and
+	// substitute it at the recovery-wide slot while preserving retry accounting.
+	ReuseCleanWideForWideRetry bool
+	// ReuseCleanWideMinSourceBytes limits clean-wide reuse to the certified
+	// large-source class. Zero disables the policy even when the boolean is set.
+	ReuseCleanWideMinSourceBytes uint32
 }
 
 // ResultCompatibilityCapability records result-tree shapes that a language

--- a/load_language_test.go
+++ b/load_language_test.go
@@ -7,6 +7,31 @@ import (
 	"testing"
 )
 
+func TestFullParseAcceptedErrorRetryProfileLanguageBlobRoundTrip(t *testing.T) {
+	want := FullParseAcceptedErrorRetryProfile{
+		SkipCompleteAcceptedErrorRetry: true,
+		SkipCompleteMinSourceBytes:     2 * 1024,
+		ReuseCleanWideForWideRetry:     true,
+		ReuseCleanWideMinSourceBytes:   128 * 1024,
+	}
+	lang := &Language{
+		Name:                               "accepted_error_retry_profile_round_trip",
+		FullParseAcceptedErrorRetryProfile: want,
+	}
+
+	blob, err := EncodeLanguageBlob(lang)
+	if err != nil {
+		t.Fatalf("EncodeLanguageBlob: %v", err)
+	}
+	decoded, err := LoadLanguage(blob)
+	if err != nil {
+		t.Fatalf("LoadLanguage: %v", err)
+	}
+	if got := decoded.FullParseAcceptedErrorRetryProfile; got != want {
+		t.Fatalf("FullParseAcceptedErrorRetryProfile = %+v, want %+v", got, want)
+	}
+}
+
 func TestLoadLanguageInfersGeneratedRepeatAuxMetadata(t *testing.T) {
 	var buf bytes.Buffer
 	gzw := gzip.NewWriter(&buf)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -577,6 +577,143 @@ func TestCertifiedInitialMergeRetrySkipKeepsWideningAndTreeSelection(t *testing.
 	}
 }
 
+func duplicateWideRetryTestTree(sourceLen, nodes, maxStacks int, certified bool) *Tree {
+	tree := certifiedAcceptedErrorRetryTestTree(false, sourceLen)
+	tree.language.Name = "synthetic"
+	tree.parseRuntime.NodesAllocated = nodes
+	tree.parseRuntime.MaxStacksSeen = maxStacks
+	if certified {
+		tree.language.FullParseAcceptedErrorRetryProfile = FullParseAcceptedErrorRetryProfile{
+			ReuseCleanWideForWideRetry:   true,
+			ReuseCleanWideMinSourceBytes: 128 * 1024,
+		}
+	}
+	return tree
+}
+
+func TestCertifiedDuplicateWideRetryPreservesPassAccounting(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	t.Setenv("GOT_PARSE_NODE_LIMIT_SCALE", "")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	const sourceLen = 256 * 1024
+	type retryCall struct {
+		stacks int
+		merge  int
+		clean  bool
+	}
+	run := func(certified bool) (calls []retryCall, passes int, got *Tree) {
+		parser := &Parser{}
+		initial := duplicateWideRetryTestTree(sourceLen, 100, 18, certified)
+		got = parser.retryFullParse(make([]byte, sourceLen), 8, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+			calls = append(calls, retryCall{stacks: maxStacks, merge: maxMergePerKeyOverride, clean: parser.forceCleanRetryPass})
+			switch {
+			case maxMergePerKeyOverride != 0 && len(calls) == 1:
+				return duplicateWideRetryTestTree(sourceLen, 90, 36, certified)
+			case parser.forceCleanRetryPass:
+				return duplicateWideRetryTestTree(sourceLen, 80, 54, certified)
+			case maxMergePerKeyOverride != 0:
+				return duplicateWideRetryTestTree(sourceLen, 85, 73, certified)
+			default:
+				return duplicateWideRetryTestTree(sourceLen, 80, 54, certified)
+			}
+		})
+		return calls, parser.fullParseRetryPassesTaken, got
+	}
+
+	genericCalls, genericPasses, genericTree := run(false)
+	certifiedCalls, certifiedPasses, certifiedTree := run(true)
+	if len(genericCalls) != 4 {
+		t.Fatalf("generic retry calls = %+v, want initial-merge, clean-wide, wide, final-merge", genericCalls)
+	}
+	if len(certifiedCalls) != 3 {
+		t.Fatalf("certified retry calls = %+v, want initial-merge, clean-wide, final-merge", certifiedCalls)
+	}
+	if genericPasses != 4 || certifiedPasses != genericPasses {
+		t.Fatalf("retry passes generic=%d certified=%d, want both 4", genericPasses, certifiedPasses)
+	}
+	if genericTree == nil || certifiedTree == nil || genericTree.parseRuntime.NodesAllocated != certifiedTree.parseRuntime.NodesAllocated {
+		t.Fatalf("selected nodes generic=%v certified=%v, want equivalent selected candidate", genericTree, certifiedTree)
+	}
+}
+
+func TestCertifiedDuplicateWideRetryFallbackScope(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	t.Setenv("GOT_PARSE_NODE_LIMIT_SCALE", "")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	const sourceLen = 256 * 1024
+	eligible := func() (*Parser, *Tree) {
+		return &Parser{}, duplicateWideRetryTestTree(sourceLen, 80, 54, true)
+	}
+	parser, tree := eligible()
+	if !certifiedAcceptedErrorRetryReusesCleanWide(parser, tree, sourceLen, fullParseRetryOriginFresh, 0) {
+		t.Fatal("eligible complete accepted-error clean-wide tree did not reuse")
+	}
+
+	assertFallback := func(label string, parser *Parser, tree *Tree, bytes int, origin fullParseRetryOrigin, maxNodes int) {
+		t.Helper()
+		if certifiedAcceptedErrorRetryReusesCleanWide(parser, tree, bytes, origin, maxNodes) {
+			t.Fatalf("%s unexpectedly reused clean-wide tree", label)
+		}
+	}
+
+	parser, tree = eligible()
+	parser.timeoutMicros = 1_000_000
+	if !certifiedAcceptedErrorRetryReusesCleanWide(parser, tree, sourceLen, fullParseRetryOriginFresh, 0) {
+		t.Fatal("configured timeout disabled exact-blob duplicate-wide policy")
+	}
+	parser, tree = eligible()
+	cancelled := uint32(0)
+	parser.cancellationFlag = &cancelled
+	if !certifiedAcceptedErrorRetryReusesCleanWide(parser, tree, sourceLen, fullParseRetryOriginFresh, 0) {
+		t.Fatal("configured cancellation pointer disabled exact-blob duplicate-wide policy")
+	}
+	parser, tree = eligible()
+	assertFallback("incremental origin", parser, tree, sourceLen, fullParseRetryOriginIncremental, 0)
+	parser, tree = eligible()
+	assertFallback("node-limit retry", parser, tree, sourceLen, fullParseRetryOriginFresh, 1)
+	parser, tree = eligible()
+	assertFallback("below certified floor", parser, tree, 129_488, fullParseRetryOriginFresh, 0)
+
+	for _, env := range []string{"GOT_GLR_MAX_STACKS", "GOT_GLR_MAX_MERGE_PER_KEY", "GOT_PARSE_NODE_LIMIT_SCALE"} {
+		t.Run(env, func(t *testing.T) {
+			t.Setenv(env, "2")
+			parser, tree := eligible()
+			assertFallback("explicit "+env, parser, tree, sourceLen, fullParseRetryOriginFresh, 0)
+			t.Setenv(env, "")
+		})
+	}
+}
+
+func TestCertifiedDuplicateWideRetryDoesNotBypassTerminalCancellation(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	t.Setenv("GOT_PARSE_NODE_LIMIT_SCALE", "")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+	const sourceLen = 256 * 1024
+	cancelled := uint32(1)
+	parser := &Parser{cancellationFlag: &cancelled}
+	initial := duplicateWideRetryTestTree(sourceLen, 100, 18, true)
+	calls := 0
+	parser.retryFullParse(make([]byte, sourceLen), 8, initial, func(maxStacks, maxMergePerKeyOverride, maxNodes int) *Tree {
+		calls++
+		return duplicateWideRetryTestTree(sourceLen, 90, 36, true)
+	})
+	if calls != 1 {
+		t.Fatalf("retry calls after terminal cancellation = %d, want only the pre-deadline initial merge", calls)
+	}
+	if parser.fullParseRetryPassesTaken != 1 {
+		t.Fatalf("retry passes after terminal cancellation = %d, want 1", parser.fullParseRetryPassesTaken)
+	}
+}
+
 func TestCSharpAcceptedErrorTreeCanUseNamespaceRecovery(t *testing.T) {
 	source := []byte("using X;\nnamespace N { class C { } }\n")
 	nsStart := uint32(bytes.Index(source, []byte("namespace")))
@@ -954,6 +1091,57 @@ func TestCompleteAcceptedErrorRetrySkipRequiresCertification(t *testing.T) {
 	tree.parseRuntime.EntryScratchPeak = 1024
 	if shouldRetryAcceptedErrorParse(tree, 128, 8) {
 		t.Fatal("accepted-error tree at the certified entry-scratch peak scheduled retry")
+	}
+}
+
+func TestCompleteAcceptedErrorRetrySkipHonorsMinimumSourceBytes(t *testing.T) {
+	const minSourceBytes = 2 * 1024
+	newTree := func(sourceLen int, minSourceBytes uint32) *Tree {
+		return &Tree{
+			language: &Language{
+				Name: "synthetic",
+				FullParseAcceptedErrorRetryProfile: FullParseAcceptedErrorRetryProfile{
+					SkipCompleteAcceptedErrorRetry: true,
+					SkipCompleteMinSourceBytes:     minSourceBytes,
+				},
+			},
+			root: &Node{
+				endByte: uint32(sourceLen),
+				flags:   nodeFlagHasError,
+			},
+			parseRuntime: ParseRuntime{
+				StopReason:       ParseStopAccepted,
+				SourceLen:        uint32(sourceLen),
+				ExpectedEOFByte:  uint32(sourceLen),
+				RootEndByte:      uint32(sourceLen),
+				LastTokenEndByte: uint32(sourceLen),
+				LastTokenWasEOF:  true,
+				MaxStacksSeen:    9,
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		sourceLen       int
+		minSourceBytes  uint32
+		wantRetry       bool
+		wantMergePerKey int
+	}{
+		{name: "legacy zero is unbounded", sourceLen: 128, minSourceBytes: 0, wantMergePerKey: 0},
+		{name: "below threshold keeps retry", sourceLen: minSourceBytes - 1, minSourceBytes: minSourceBytes, wantRetry: true, wantMergePerKey: fullParseRetryMaxMergePerKey},
+		{name: "at threshold skips retry", sourceLen: minSourceBytes, minSourceBytes: minSourceBytes, wantMergePerKey: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := newTree(tt.sourceLen, tt.minSourceBytes)
+			if got := shouldRetryAcceptedErrorParse(tree, tt.sourceLen, 8); got != tt.wantRetry {
+				t.Fatalf("shouldRetryAcceptedErrorParse() = %v, want %v", got, tt.wantRetry)
+			}
+			if got := fullParseRetryMergePerKeyOverride(tree, tt.sourceLen, 8); got != tt.wantMergePerKey {
+				t.Fatalf("fullParseRetryMergePerKeyOverride() = %d, want %d", got, tt.wantMergePerKey)
+			}
+		})
 	}
 }
 

--- a/parser_config.go
+++ b/parser_config.go
@@ -85,6 +85,10 @@ func parseNodeLimitScaleFactor() int {
 	return parseNodeLimitScale
 }
 
+func parseNodeLimitScaleEnvConfigured() bool {
+	return strings.TrimSpace(os.Getenv("GOT_PARSE_NODE_LIMIT_SCALE")) != ""
+}
+
 func parseMaxGLRStacksValue() int {
 	parseMaxGLRStacksOnce.Do(func() {
 		parseMaxGLRStacks = maxGLRStacks

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1201,6 +1201,10 @@ func certifiedAcceptedErrorRetrySkipsComplete(tree *Tree, sourceLen int) bool {
 		return false
 	}
 	profile := tree.language.FullParseAcceptedErrorRetryProfile
+	if profile.SkipCompleteMinSourceBytes > 0 &&
+		uint64(sourceLen) < uint64(profile.SkipCompleteMinSourceBytes) {
+		return false
+	}
 	rt := tree.parseRuntimeReadOnly()
 	if profile.SkipCompleteMaxEntryScratchPeak > 0 &&
 		rt.EntryScratchPeak > uint64(profile.SkipCompleteMaxEntryScratchPeak) {
@@ -1370,6 +1374,25 @@ func certifiedAcceptedErrorRetrySkipsInitialMerge(tree *Tree, sourceLen int, ori
 		retryTreeCoversExpectedEOF(tree)
 }
 
+func certifiedAcceptedErrorRetryReusesCleanWide(p *Parser, tree *Tree, sourceLen int, origin fullParseRetryOrigin, maxNodesOverride int) bool {
+	if p == nil || tree == nil || tree.language == nil || sourceLen <= 0 || origin != fullParseRetryOriginFresh ||
+		maxNodesOverride != 0 ||
+		parseMaxGLRStacksEnvConfigured() || parseMaxMergePerKeyEnvConfigured() || parseNodeLimitScaleEnvConfigured() {
+		return false
+	}
+	profile := tree.language.FullParseAcceptedErrorRetryProfile
+	if !profile.ReuseCleanWideForWideRetry || profile.ReuseCleanWideMinSourceBytes == 0 ||
+		uint64(sourceLen) < uint64(profile.ReuseCleanWideMinSourceBytes) {
+		return false
+	}
+	rt := tree.parseRuntimeReadOnly()
+	return rt.StopReason == ParseStopAccepted &&
+		!rt.Truncated &&
+		!rt.TokenSourceEOFEarly &&
+		retryTreeHasError(tree) &&
+		retryTreeCoversExpectedEOF(tree)
+}
+
 func (p *Parser) retryFullParse(source []byte, initialMaxStacks int, tree *Tree, runRetry fullParseRetryRunner) *Tree {
 	return p.retryFullParseForOrigin(source, initialMaxStacks, tree, fullParseRetryOriginFresh, runRetry)
 }
@@ -1476,6 +1499,10 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 		}
 		release(candidate)
 	}
+	var reusableCleanWideTree *Tree
+	defer func() {
+		release(reusableCleanWideTree)
+	}()
 
 	structuralResyncRetry := shouldRetryFullParse(tree, len(source))
 	retryDebug := os.Getenv("GOT_RETRY_DEBUG") == "1"
@@ -1581,6 +1608,8 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 					return bestTree
 				}
 			}
+		} else if certifiedAcceptedErrorRetryReusesCleanWide(p, cleanRetryTree, len(source), origin, maxNodesOverride) {
+			reusableCleanWideTree = cleanRetryTree
 		} else {
 			release(cleanRetryTree)
 		}
@@ -1589,7 +1618,17 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 		}
 	}
 	if maxStacksOverride > 0 || maxNodesOverride > 0 {
-		retryTree := runRetryAttempt(retryMaxStacks, 0, maxNodesOverride)
+		var retryTree *Tree
+		if reusableCleanWideTree != nil && !retryPassLimitReached() {
+			// Consume the same pass slot as the recovery-enabled widened retry.
+			// Keeping accounting identical preserves the scheduling of any later
+			// secondary-node or merge retry.
+			p.fullParseRetryPassesTaken++
+			retryTree = reusableCleanWideTree
+			reusableCleanWideTree = nil
+		} else {
+			retryTree = runRetryAttempt(retryMaxStacks, 0, maxNodesOverride)
+		}
 		// nodeRetryTree is read below for stop-reason inspection, so we hold
 		// a pointer to it without handing it through replaceBest until the
 		// retry sequence is done. If it doesn't end up bestTree, we release


### PR DESCRIPTION
## Summary

- size-gate complete accepted-error retry skips for the exact built-in Meson grammar
- reuse the certified widened Enforce result instead of repeating an equivalent recovery pass
- preserve conservative behavior for custom blobs, small inputs, incremental parses, and explicit diagnostic overrides
- document both changes under `Unreleased`

## Validation

- focused root and grammar tests
- `go vet . ./grammars`
- Meson fresh, incremental, and no-error C parity in Docker
- Enforce fresh, incremental, and no-error C parity in Docker
- locked corpus tree/runtime equivalence and count-10 performance receipts
