### PR TITLE
perfscan: make fleet reduction deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ for tags and release notes while still in `0.x`.
   and itembase time by 7.31%, with corresponding allocation reductions and an
   unchanged clean control.
 
+### Fixed
+
+- Fleet scoreboard reduction now canonicalizes hard-gate finding order and
+  records clean reducer provenance separately from immutable measurement
+  provenance, allowing later reducer fixes to authenticate historical shards
+  without weakening tamper checks.
+
 ## [0.34.0] - 2026-07-13
 
 Forest-routing performance and compatibility-hygiene release. Automatic

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -170,11 +170,15 @@ Reduction requires exactly one scoreboard for every locked language. It
 rejects missing or duplicate languages, schema or measurement-config drift,
 corpus-lock drift, path exclusions, contended runs, mixed or absent repository
 revisions, dirty source trees, mixed host/runtime identities, contradictory or
-malformed file classifications, and absent or stale shard hard gates. A stored
-shard gate may be either PASS or FAIL, but it must exactly equal the gate
-recomputed from that shard's evidence. Ratio cliffs, parser stops, missing
-ratios, and partial or zero file coverage are valid failure evidence and remain
-visible in the combined FAIL board. A host identity includes hostname,
+malformed file classifications, pre-existing reduction provenance, and absent
+or stale shard hard gates. Raw one-language measurement shards must not contain
+a `reduction` object. A stored shard gate may be either PASS or FAIL, but it
+must exactly equal the gate recomputed from that shard's evidence after
+canonical ordering. Published `failures` and `fast_full_files` are sorted by
+their complete finding and stop attribution, so Go map iteration order cannot
+change an authenticated gate or combined artifact. Ratio cliffs, parser stops,
+missing ratios, and partial or zero file coverage are valid failure evidence
+and remain visible in the combined FAIL board. A host identity includes hostname,
 GOOS/GOARCH, CPU count, `GOMAXPROCS`, and Go version; both start and end load
 averages must remain below the contention threshold. The
 only permitted per-shard config differences are the one-element `languages`
@@ -183,8 +187,11 @@ full lock language list with `require_fleet=true`. The reducer recomputes every
 language aggregate, verdict summary, fleet clean/error split, coverage record,
 and the full hard gate before writing authoritative JSON and Markdown. The
 reducer execution is authenticated independently: its checkout/build must be
-clean and at the same revision recorded by every shard, so one runtime version
-cannot silently reinterpret another version's evidence.
+clean, but it may be a later revision than the immutable measurement revision
+recorded by every shard. The combined board preserves the shard
+`git_revision`/`git_clean` fields as measurement provenance and adds a
+`reduction` object containing the reducer's `git_revision` and `git_clean`
+attestation; Markdown renders both revisions explicitly.
 
 `GTS_PERF_SCAN_REDUCE_MODE=report` writes the recomputed PASS or FAIL board and
 returns success after evidence authentication. `certify` is the default; it
@@ -380,11 +387,11 @@ Older `gts-perf-scan/v1` scoreboards still decode. They predate structured
 stops, corpus coverage, and the embedded hard-gate report, so use
 `-strict-config=false` only for historical analysis; they cannot establish a
 new hard-gate pass. `cmd/perf_scan_status` labels them `not_evaluated`.
-The clean/error and repository-revision fields are optional additions to the
-same v1 schema: readers must continue to accept rows without `classification`,
-`full_parse_split`, or `git_revision`, and current Go decoders do so. The
-authoritative shard reducer applies a stronger provenance policy after decoding
-and rejects revisionless inputs.
+The clean/error, repository-revision, and reduction-provenance fields are
+optional additions to the same v1 schema: readers must continue to accept rows
+without `classification`, `full_parse_split`, `git_revision`, or `reduction`,
+and current Go decoders do so. The authoritative shard reducer applies a
+stronger provenance policy after decoding and rejects revisionless inputs.
 
 ## Phase 2 (documented, not built)
 

--- a/cgo_harness/zz_perf_scan_reduce_test.go
+++ b/cgo_harness/zz_perf_scan_reduce_test.go
@@ -4,8 +4,9 @@ package cgoharness
 
 // This file contains the merge-only fleet reducer for independently produced
 // one-language perf-scan scoreboards. It intentionally lives beside the scan
-// harness so reduction uses the exact scoreboard, aggregation, rendering, and
-// hard-gate implementation that produced the shards.
+// harness so reduction shares its scoreboard, aggregation, rendering, and
+// hard-gate implementation. Measurement and clean reducer revisions are
+// authenticated separately so historical shards can be reduced by a later fix.
 
 import (
 	"encoding/json"
@@ -88,7 +89,7 @@ func TestPerfScanReduce(t *testing.T) {
 	if err := perfScanPublishReducedScoreboard(absOut, board, reduceMode); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("reduced %d authenticated shard scoreboards at %s", len(board.Languages), board.GitRevision)
+	t.Logf("reduced %d authenticated shard scoreboards measured at %s with reducer %s", len(board.Languages), board.GitRevision, board.Reduction.GitRevision)
 	t.Logf("reducer mode: %s; hard gate: %s", reduceMode, strings.ToUpper(board.Gate.Status))
 	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.json"))
 	t.Logf("scoreboard: %s", filepath.Join(absOut, "scoreboard.md"))
@@ -144,9 +145,7 @@ func perfScanAuthenticateReducer(board *perfScanScoreboard, provenance perfScanR
 	if err != nil {
 		return fmt.Errorf("reducer execution revision: %w", err)
 	}
-	if revision != board.GitRevision {
-		return fmt.Errorf("reducer execution revision %s differs from shard revision %s", revision, board.GitRevision)
-	}
+	board.Reduction = &perfScanReductionProvenance{GitRevision: revision, GitClean: true}
 	return nil
 }
 
@@ -228,6 +227,9 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 		if shard.Schema != perfScanSchema {
 			return nil, fmt.Errorf("shard %s schema %q, want %q", shardPath, shard.Schema, perfScanSchema)
 		}
+		if shard.Reduction != nil {
+			return nil, fmt.Errorf("shard %s contains reduction provenance; expected raw one-language measurement evidence", shardPath)
+		}
 		shardRevision, err := perfScanNormalizeRevision(shard.GitRevision)
 		if err != nil {
 			return nil, fmt.Errorf("shard %s git revision: %w", shardPath, err)
@@ -307,14 +309,15 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 			return nil, fmt.Errorf("shard %s host identity differs from earlier shards", shardPath)
 		}
 
-		recomputedGate := perfScanEvaluateHardGate(shard)
+		recomputedGate := perfScanCanonicalizeGateReport(perfScanEvaluateHardGate(shard))
 		if shard.Gate == nil {
 			return nil, fmt.Errorf("shard %s has no stored hard gate", shardPath)
 		}
 		if shard.Gate.Status != perfScanGatePass && shard.Gate.Status != perfScanGateFail {
 			return nil, fmt.Errorf("shard %s stored hard gate has unknown status %q", shardPath, shard.Gate.Status)
 		}
-		if !reflect.DeepEqual(*shard.Gate, recomputedGate) {
+		storedGate := perfScanCanonicalizeGateReport(*shard.Gate)
+		if !reflect.DeepEqual(storedGate, recomputedGate) {
 			return nil, fmt.Errorf("shard %s stored hard gate is stale or contradicts its file evidence", shardPath)
 		}
 		rowsByLang[lang] = row
@@ -554,11 +557,92 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 		if board.Gate == nil || board.Gate.Status != perfScanGatePass || board.Gate.FullFilesEvaluated != 2 {
 			t.Fatalf("gate = %+v", board.Gate)
 		}
+		if board.Reduction != nil {
+			t.Fatalf("pure reduction unexpectedly recorded execution provenance: %+v", board.Reduction)
+		}
 		markdown := perfScanRenderMarkdown(board)
 		for _, want := range []string{"git revision", "Fleet full-parse clean/error split", "2/2"} {
 			if !strings.Contains(markdown, want) {
 				t.Fatalf("markdown missing %q:\n%s", want, markdown)
 			}
+		}
+	})
+
+	t.Run("gate evidence is independent of axis insertion order", func(t *testing.T) {
+		setStoppedAxes := func(shard *perfScanScoreboard, order []string) {
+			file := shard.Languages[0].Files[0]
+			file.Classification = &perfScanFileClassification{
+				Class:        perfScanClassStopped,
+				Reason:       "Go parser stopped before accepting the full source",
+				GoStatus:     "go_timeout",
+				StoppedEarly: true,
+				StopReason:   perfScanStopParserTimeout,
+			}
+			file.Axes = make(map[string]*perfScanFileAxis, len(order))
+			for _, axis := range order {
+				file.Axes[axis] = &perfScanFileAxis{
+					Status: "go_timeout",
+					Detail: "parser timeout on " + axis,
+					Stop: &perfScanStop{
+						Class:          perfScanStopParserTimeout,
+						Reason:         perfScanStopParserTimeout,
+						Implementation: "go",
+						Phase:          "timed",
+					},
+				}
+			}
+		}
+
+		forward := perfScanTestShard("python", lockPath, lockSHA, len(lockLanguages), revision)
+		reverse := perfScanTestShard("python", lockPath, lockSHA, len(lockLanguages), revision)
+		setStoppedAxes(forward, []string{perfScanAxisFull, perfScanAxisNoEdit})
+		setStoppedAxes(reverse, []string{perfScanAxisNoEdit, perfScanAxisFull})
+		forwardGate := perfScanEvaluateHardGate(forward)
+		reverseGate := perfScanEvaluateHardGate(reverse)
+		if !reflect.DeepEqual(forwardGate, reverseGate) {
+			t.Fatalf("opposite axis insertion orders differ:\nforward=%+v\nreverse=%+v", forwardGate, reverseGate)
+		}
+
+		makeFastBoard := func(order []string) *perfScanScoreboard {
+			board := &perfScanScoreboard{}
+			for _, lang := range order {
+				row := perfScanTestShard(lang, lockPath, lockSHA, len(lockLanguages), revision).Languages[0]
+				full := row.Files[0].Axes[perfScanAxisFull]
+				full.GoMedianNs = 100
+				full.CMedianNs = 1_000
+				board.Languages = append(board.Languages, row)
+			}
+			return board
+		}
+		forwardFast := perfScanEvaluateHardGate(makeFastBoard([]string{"go", "python"}))
+		reverseFast := perfScanEvaluateHardGate(makeFastBoard([]string{"python", "go"}))
+		if !reflect.DeepEqual(forwardFast, reverseFast) {
+			t.Fatalf("opposite language orders differ:\nforward=%+v\nreverse=%+v", forwardFast, reverseFast)
+		}
+		if got := []string{forwardFast.FastFullFiles[0].Language, forwardFast.FastFullFiles[1].Language}; !reflect.DeepEqual(got, lockLanguages) {
+			t.Fatalf("canonical fast languages = %v, want %v", got, lockLanguages)
+		}
+
+		paths := makeInputs(t, func(_ *perfScanScoreboard, pythonShard *perfScanScoreboard) {
+			setStoppedAxes(pythonShard, []string{perfScanAxisNoEdit, perfScanAxisFull})
+			gate := perfScanEvaluateHardGate(pythonShard)
+			for left, right := 0, len(gate.Failures)-1; left < right; left, right = left+1, right-1 {
+				gate.Failures[left], gate.Failures[right] = gate.Failures[right], gate.Failures[left]
+			}
+			pythonShard.Gate = &gate
+		})
+		board, err := reduce(paths)
+		if err != nil {
+			t.Fatalf("reduce semantically identical gate evidence: %v", err)
+		}
+		var axes []string
+		for _, finding := range board.Gate.Failures {
+			if finding.Language == "python" && finding.Kind == "go_stop" {
+				axes = append(axes, finding.Axis)
+			}
+		}
+		if want := []string{perfScanAxisFull, perfScanAxisNoEdit}; !reflect.DeepEqual(axes, want) {
+			t.Fatalf("canonical stopped axes = %v, want %v", axes, want)
 		}
 	})
 
@@ -677,6 +761,16 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 				pythonShard.Schema = "gts-perf-scan/v0"
 			},
 			want: "schema",
+		},
+		{
+			name: "chained reduction provenance",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Reduction = &perfScanReductionProvenance{
+					GitRevision: strings.Repeat("b", 40),
+					GitClean:    true,
+				}
+			},
+			want: "contains reduction provenance",
 		},
 		{
 			name: "config mismatch",
@@ -940,16 +1034,49 @@ func TestPerfScanRepositoryProvenancePolicy(t *testing.T) {
 }
 
 func TestPerfScanAuthenticateReducer(t *testing.T) {
-	revision := strings.Repeat("a", 40)
-	board := &perfScanScoreboard{GitRevision: revision, GitClean: true}
-	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: revision, Clean: true}); err != nil {
+	measurementRevision := strings.Repeat("a", 40)
+	reducerRevision := strings.Repeat("b", 40)
+	board := &perfScanScoreboard{GitRevision: measurementRevision, GitClean: true}
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: reducerRevision, Clean: true}); err != nil {
+		t.Fatalf("different clean reducer provenance: %v", err)
+	}
+	if board.GitRevision != measurementRevision || !board.GitClean {
+		t.Fatalf("measurement provenance changed: %+v", board)
+	}
+	if board.Reduction == nil || board.Reduction.GitRevision != reducerRevision || !board.Reduction.GitClean {
+		t.Fatalf("recorded reducer provenance = %+v", board.Reduction)
+	}
+	markdown := perfScanRenderMarkdown(board)
+	for _, want := range []string{
+		"measurement git revision: `" + measurementRevision + "`",
+		"reducer git revision: `" + reducerRevision + "`",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Fatalf("reduced markdown missing %q:\n%s", want, markdown)
+		}
+	}
+
+	board = &perfScanScoreboard{GitRevision: measurementRevision, GitClean: true}
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: measurementRevision, Clean: true}); err != nil {
 		t.Fatalf("matching reducer provenance: %v", err)
 	}
-	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: strings.Repeat("b", 40), Clean: true}); err == nil || !strings.Contains(err.Error(), "differs from shard") {
-		t.Fatalf("mismatched reducer provenance error = %v", err)
+	if board.Reduction == nil || board.Reduction.GitRevision != measurementRevision || !board.Reduction.GitClean {
+		t.Fatalf("matching recorded reducer provenance = %+v", board.Reduction)
 	}
-	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: revision, Clean: false}); err == nil || !strings.Contains(err.Error(), "clean repository") {
+
+	board = &perfScanScoreboard{GitRevision: measurementRevision, GitClean: true}
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: reducerRevision, Clean: false}); err == nil || !strings.Contains(err.Error(), "clean repository") {
 		t.Fatalf("dirty reducer provenance error = %v", err)
+	}
+	if board.Reduction != nil {
+		t.Fatalf("dirty reducer recorded provenance: %+v", board.Reduction)
+	}
+
+	if err := perfScanAuthenticateReducer(board, perfScanRepositoryState{Revision: "not-a-revision", Clean: true}); err == nil || !strings.Contains(err.Error(), "reducer execution revision") {
+		t.Fatalf("invalid reducer provenance error = %v", err)
+	}
+	if board.Reduction != nil {
+		t.Fatalf("invalid reducer recorded provenance: %+v", board.Reduction)
 	}
 }
 
@@ -1070,6 +1197,13 @@ func TestPerfScanScoreboardAtomicWrite(t *testing.T) {
 	}
 	if decoded.GitRevision != revision || !decoded.GitClean || len(decoded.Languages) != 1 {
 		t.Fatalf("round-trip scoreboard = %+v", decoded)
+	}
+	if decoded.Reduction != nil {
+		t.Fatalf("unreduced shard recorded reducer provenance: %+v", decoded.Reduction)
+	}
+	jsonData, err := os.ReadFile(filepath.Join(outDir, "scoreboard.json"))
+	if err != nil || strings.Contains(string(jsonData), `"reduction"`) {
+		t.Fatalf("unreduced shard JSON contains reduction provenance: %v %s", err, jsonData)
 	}
 	markdown, err := os.ReadFile(filepath.Join(outDir, "scoreboard.md"))
 	if err != nil || !strings.Contains(string(markdown), revision) {

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -38,6 +38,7 @@ package cgoharness
 // See perf_scan/README.md for the full knob reference.
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -293,19 +294,25 @@ type perfScanGateReport struct {
 	Failures           []perfScanGateFinding `json:"failures,omitempty"`
 }
 
+type perfScanReductionProvenance struct {
+	GitRevision string `json:"git_revision"`
+	GitClean    bool   `json:"git_clean"`
+}
+
 type perfScanScoreboard struct {
-	Schema         string                   `json:"schema"`
-	GeneratedAt    string                   `json:"generated_at"`
-	GitRevision    string                   `json:"git_revision,omitempty"`
-	GitClean       bool                     `json:"git_clean"`
-	Host           perfScanHost             `json:"host"`
-	Config         perfScanConfig           `json:"config"`
-	Notes          []string                 `json:"notes,omitempty"`
-	Summary        map[string]int           `json:"summary_verdicts"`
-	Languages      []*perfScanLanguage      `json:"languages"`
-	FullParseSplit *perfScanCleanErrorSplit `json:"full_parse_split,omitempty"`
-	Corpus         perfScanCorpusCoverage   `json:"corpus_coverage"`
-	Gate           *perfScanGateReport      `json:"hard_gate,omitempty"`
+	Schema         string                       `json:"schema"`
+	GeneratedAt    string                       `json:"generated_at"`
+	GitRevision    string                       `json:"git_revision,omitempty"`
+	GitClean       bool                         `json:"git_clean"`
+	Host           perfScanHost                 `json:"host"`
+	Config         perfScanConfig               `json:"config"`
+	Notes          []string                     `json:"notes,omitempty"`
+	Summary        map[string]int               `json:"summary_verdicts"`
+	Languages      []*perfScanLanguage          `json:"languages"`
+	FullParseSplit *perfScanCleanErrorSplit     `json:"full_parse_split,omitempty"`
+	Corpus         perfScanCorpusCoverage       `json:"corpus_coverage"`
+	Gate           *perfScanGateReport          `json:"hard_gate,omitempty"`
+	Reduction      *perfScanReductionProvenance `json:"reduction,omitempty"`
 }
 
 func perfScanGateEnabled() bool {
@@ -790,6 +797,68 @@ func perfScanIsGoStop(stop *perfScanStop) bool {
 	return stop != nil && stop.Implementation == "go"
 }
 
+func perfScanCanonicalizeGateReport(report perfScanGateReport) perfScanGateReport {
+	report.FastFullFiles = append([]perfScanGateFinding(nil), report.FastFullFiles...)
+	report.Failures = append([]perfScanGateFinding(nil), report.Failures...)
+	sort.Slice(report.FastFullFiles, func(i, j int) bool {
+		return perfScanCompareGateFinding(report.FastFullFiles[i], report.FastFullFiles[j]) < 0
+	})
+	sort.Slice(report.Failures, func(i, j int) bool {
+		return perfScanCompareGateFinding(report.Failures[i], report.Failures[j]) < 0
+	})
+	return report
+}
+
+func perfScanCompareGateFinding(a, b perfScanGateFinding) int {
+	for _, pair := range [][2]string{
+		{a.Kind, b.Kind},
+		{a.Language, b.Language},
+		{a.Path, b.Path},
+		{a.Axis, b.Axis},
+		{a.Status, b.Status},
+	} {
+		if order := cmp.Compare(pair[0], pair[1]); order != 0 {
+			return order
+		}
+	}
+	if order := cmp.Compare(a.Ratio, b.Ratio); order != 0 {
+		return order
+	}
+	if order := cmp.Compare(a.Limit, b.Limit); order != 0 {
+		return order
+	}
+	if order := perfScanCompareGateStop(a.Stop, b.Stop); order != 0 {
+		return order
+	}
+	return cmp.Compare(a.Detail, b.Detail)
+}
+
+func perfScanCompareGateStop(a, b *perfScanStop) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	for _, pair := range [][2]string{
+		{a.Class, b.Class},
+		{a.Reason, b.Reason},
+		{a.Implementation, b.Implementation},
+		{a.Phase, b.Phase},
+	} {
+		if order := cmp.Compare(pair[0], pair[1]); order != 0 {
+			return order
+		}
+	}
+	if order := cmp.Compare(a.Attempt, b.Attempt); order != 0 {
+		return order
+	}
+	return cmp.Compare(a.Detail, b.Detail)
+}
+
 func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 	report := perfScanGateReport{
 		Status:             perfScanGatePass,
@@ -802,7 +871,7 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 	}
 	if board == nil {
 		addFailure(perfScanGateFinding{Kind: "coverage", Detail: "nil scoreboard"})
-		return report
+		return perfScanCanonicalizeGateReport(report)
 	}
 	if len(board.Languages) == 0 {
 		addFailure(perfScanGateFinding{Kind: "coverage", Status: "no_evidence", Detail: "scoreboard contains no language rows"})
@@ -900,7 +969,7 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 	if report.FullFilesEvaluated == 0 {
 		addFailure(perfScanGateFinding{Kind: "coverage", Status: "no_evidence", Detail: "scoreboard contains no evaluated full-parse file ratios"})
 	}
-	return report
+	return perfScanCanonicalizeGateReport(report)
 }
 
 // ---------------------------------------------------------------------------
@@ -2672,8 +2741,12 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 	fmt.Fprintf(&b, "# Go-vs-C real-corpus perf scoreboard\n\n")
 	fmt.Fprintf(&b, "- schema: `%s` generated: %s\n", board.Schema, board.GeneratedAt)
 	if board.GitRevision != "" {
-		fmt.Fprintf(&b, "- git revision: `%s`\n", board.GitRevision)
-		fmt.Fprintf(&b, "- git worktree clean: `%t`\n", board.GitClean)
+		fmt.Fprintf(&b, "- measurement git revision: `%s`\n", board.GitRevision)
+		fmt.Fprintf(&b, "- measurement git worktree clean: `%t`\n", board.GitClean)
+	}
+	if board.Reduction != nil {
+		fmt.Fprintf(&b, "- reducer git revision: `%s`\n", board.Reduction.GitRevision)
+		fmt.Fprintf(&b, "- reducer git worktree clean: `%t`\n", board.Reduction.GitClean)
 	}
 	fmt.Fprintf(&b, "- host: %s %s/%s cpus=%d gomaxprocs=%d %s\n",
 		board.Host.Hostname, board.Host.GOOS, board.Host.GOARCH, board.Host.NumCPU, board.Host.GOMAXPROCS, board.Host.GoVersion)


### PR DESCRIPTION
## Summary

- canonicalize hard-gate findings before publishing and authenticating shards
- record clean reducer provenance separately from immutable measurement provenance
- reject chained reduction metadata on raw one-language shards
- document the additive scoreboard provenance contract and record the fix in Unreleased

## Verification

- focused Docker reducer, provenance, publication, and tamper tests
- 100 repeated opposite-order regression runs
- reducer-only replay over 206 authenticated immutable shards
- git diff and formatting checks