### PR TITLE
perf(parser): invalidate recovery memos by generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Reused C-recovery node memos now use generation invalidation instead of
+  clearing a retained 16K-entry cache on every parse. On the pinned quiet
+  host, recovery-primed KDL tiny-clean parses fell from 31.98 microseconds to
+  13.46 microseconds (57.93%), while alternating error/clean parses improved
+  by 3.06%, with unchanged bytes and allocations per operation.
 - The exact built-in Meson grammar now skips the redundant accepted-error
   retry ladder only for sources of at least 2 KiB. A locked 1,549-file corpus
   certification preserved complete and structural trees across all 28

--- a/benchmark_recurring_parse_test.go
+++ b/benchmark_recurring_parse_test.go
@@ -1,6 +1,7 @@
 package gotreesitter_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
@@ -25,6 +26,44 @@ func requireRecurringBenchmarkTree(b *testing.B, tree *gotreesitter.Tree, err er
 // retained scratch caches, making recurring reset work visible.
 func BenchmarkKDLParseRecurringTinyClean(b *testing.B) {
 	benchmarkRecurringTinyClean(b, grammars.KdlLanguage(), []byte("node\n"))
+}
+
+// BenchmarkKDLParseRecurringTinyCleanAfterRecovery isolates the retained
+// recovery-memo invalidation floor. Keep it opt-in because the priming parse is
+// intentionally much larger than the timed tiny-clean workload.
+func BenchmarkKDLParseRecurringTinyCleanAfterRecovery(b *testing.B) {
+	if os.Getenv("GOT_BENCH_CNODE_MEMO_EPOCH") != "1" {
+		b.Skip("set GOT_BENCH_CNODE_MEMO_EPOCH=1 to run the recovery-primed probe")
+	}
+	lang := grammars.KdlLanguage()
+	parser := gotreesitter.NewParser(lang)
+	primeSrc := makeKDLRecoveryGarbageSource(120, 300)
+	cleanSrc := []byte("node\n")
+
+	prime, err := parser.Parse(primeSrc)
+	requireRecurringBenchmarkTree(b, prime, err, true)
+	if rt := prime.ParseRuntime(); !rt.CRecoveryEnteredErrorState {
+		b.Fatalf("priming parse did not enter C recovery: %s", rt.Summary())
+	}
+	if got, want := prime.RootNode().EndByte(), uint32(len(primeSrc)); got != want {
+		b.Fatalf("priming parse truncated: root.EndByte=%d want=%d", got, want)
+	}
+	prime.Release()
+
+	warm, err := parser.Parse(cleanSrc)
+	requireRecurringBenchmarkTree(b, warm, err, false)
+	warm.Release()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(cleanSrc)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(cleanSrc)
+		if err != nil {
+			b.Fatalf("parse: %v", err)
+		}
+		tree.Release()
+	}
 }
 
 // BenchmarkJavaParseRecurringTinyCleanDFA isolates the built-in DFA route. The
@@ -142,6 +181,47 @@ func BenchmarkKDLParseRecurringErrorCleanAlternate(b *testing.B) {
 			b.Fatalf("clean parse: %v", err)
 		}
 		cleanTree.Release()
+	}
+}
+
+func parseKDLSExpr(t *testing.T, parser *gotreesitter.Parser, lang *gotreesitter.Language, src []byte, wantError bool) string {
+	t.Helper()
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("parse returned nil root")
+	}
+	if got := root.HasError(); got != wantError {
+		t.Fatalf("root.HasError() = %v, want %v: %s", got, wantError, root.SExpr(lang))
+	}
+	return root.SExpr(lang)
+}
+
+func TestKDLRecoveryMemoEpochPreservesExactTreesAcrossReusedParses(t *testing.T) {
+	lang := grammars.KdlLanguage()
+	errorSrc := makeKDLRecoveryGarbageSource(4, 8)
+	cleanSrc := []byte("node\n")
+	reused := gotreesitter.NewParser(lang)
+
+	gotError := parseKDLSExpr(t, reused, lang, errorSrc, true)
+	wantError := parseKDLSExpr(t, gotreesitter.NewParser(lang), lang, errorSrc, true)
+	if gotError != wantError {
+		t.Fatalf("reused-parser error tree drift:\n got:  %s\n want: %s", gotError, wantError)
+	}
+
+	gotClean := parseKDLSExpr(t, reused, lang, cleanSrc, false)
+	wantClean := parseKDLSExpr(t, gotreesitter.NewParser(lang), lang, cleanSrc, false)
+	if gotClean != wantClean {
+		t.Fatalf("post-recovery clean tree drift:\n got:  %s\n want: %s", gotClean, wantClean)
+	}
+
+	gotErrorAgain := parseKDLSExpr(t, reused, lang, errorSrc, true)
+	if gotErrorAgain != wantError {
+		t.Fatalf("post-clean error tree drift:\n got:  %s\n want: %s", gotErrorAgain, wantError)
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -184,13 +184,19 @@ type Parser struct {
 	// active source qualifies for engine-side error-mode substitution (see
 	// cRecoverCustomSourceEligibleFor).
 	cRecoverCustomSourceEligible bool
+	// cNodeMemoEpoch makes pointer-keyed recovery memo invalidation O(1). Node
+	// arenas and transient-parent slabs reuse addresses, so an entry is valid
+	// only when its epoch matches this parser-owned generation. The generation
+	// remains monotonic across parses and is cleared safely on uint16 wrap.
+	cNodeMemoEpoch uint16
 	// cNodeMemoCache caches per-subtree error cost and visible node count for
 	// the gated recovery, keyed on (node pointer, equivVersion) — the engine
 	// analogue of C's SubtreeHeapData.error_cost/visible_descendant_count
 	// computed once in ts_subtree_summarize_children. A fixed-capacity
 	// pointer-keyed 2-way set-associative cache (see cNodeMemoSlot,
-	// parser_recover_c.go) rather than a map: cleared at parse start, empty
-	// (len 0) while the gate is off.
+	// parser_recover_c.go) rather than a map: invalidated by cNodeMemoEpoch at
+	// parse start and transient-scratch checkpoints, empty (len 0) while the
+	// gate is off.
 	cNodeMemoCache []cNodeMemoCacheEntry
 	// cPrefixPath is the reusable descent scratch for GSS prefix-aggregate
 	// fills (cStackPrefixAgg, parser_recover_c.go). The aggregates themselves
@@ -3933,16 +3939,17 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	if p.errorCostCompetitionEnabled() {
 		// Faithful C recovery port: arena nodes are pooled across parses, so
 		// stale (pointer, version) memo hits from a previous parse must be
-		// impossible. Start at the small per-parse default -- cCompareVersions
+		// impossible. Advance the parser-owned memo epoch instead of clearing a
+		// cache that may have grown to 16K entries. Start at the small default --
+		// cCompareVersions
 		// cost competition participates in ordinary GLR disambiguation on
 		// well-formed input too, so this path is warm even on clean parses;
 		// growCNodeMemoCache upgrades it to the full working-set size the
 		// first time this parse actually enters C error handling.
 		if len(p.cNodeMemoCache) == 0 {
 			p.cNodeMemoCache = make([]cNodeMemoCacheEntry, cNodeMemoCacheInitialSize)
-		} else {
-			clear(p.cNodeMemoCache)
 		}
+		p.beginCNodeMemoEpoch()
 		p.crecoveryEnteredErrorState = false
 		p.crecoveryDroppedErrorForClean = false
 		// Cost walks stay gated off until this pass proves costs can be
@@ -6489,13 +6496,11 @@ func (p *Parser) checkpointTransientScratch(stacks []glrStack, scratch *parserSc
 		return reason
 	}
 	// The materialized live stack, including its raw-shape-only sidecar graph,
-	// no longer references transient slabs. Bump merge epochs and clear recovery
-	// memo state before slab addresses are reused, so pointer-keyed results from
-	// discarded alternatives cannot alias freshly allocated transient parents.
+	// no longer references transient slabs. Bump merge and recovery-memo epochs
+	// before slab addresses are reused, so pointer-keyed results from discarded
+	// alternatives cannot alias freshly allocated transient parents.
 	scratch.merge.beginEquivEpoch()
-	if len(p.cNodeMemoCache) != 0 {
-		clear(p.cNodeMemoCache)
-	}
+	p.beginCNodeMemoEpoch()
 	if cap(scratch.tmpEntries) > 0 {
 		clear(scratch.tmpEntries[:cap(scratch.tmpEntries)])
 		scratch.tmpEntries = scratch.tmpEntries[:0]

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1036,7 +1036,11 @@ func (p *Parser) cNodeVisibleSubtreeCount(n *Node) int {
 		// pointer captured before recursing could now be stale.
 		slot := p.cNodeMemoSlot(n)
 		if slot.ver != n.equivVersion {
-			*slot = cNodeMemoCacheEntry{node: uintptr(unsafe.Pointer(n)), ver: n.equivVersion}
+			*slot = cNodeMemoCacheEntry{
+				node:  uintptr(unsafe.Pointer(n)),
+				ver:   n.equivVersion,
+				epoch: p.cNodeMemoEpoch,
+			}
 		}
 		slot.visCount = count
 		slot.hasVis = true
@@ -1178,6 +1182,9 @@ type cNodeMemoCacheEntry struct {
 	visCount int
 	hasCost  bool
 	hasVis   bool
+	// epoch occupies existing tail padding on 32- and 64-bit platforms,
+	// keeping each cache entry at 20 and 32 bytes respectively.
+	epoch uint16
 }
 
 const (
@@ -1221,31 +1228,51 @@ func (p *Parser) growCNodeMemoCache() {
 	p.cNodeMemoCache = make([]cNodeMemoCacheEntry, cNodeMemoCacheSize)
 }
 
-// cNodeMemoSlot returns the writable 2-way set-associative slot for node n,
-// evicting the current occupant into the victim half of the pair if n is not
-// already resident. This mirrors map[*Node]cNodeMemoEntry lookup semantics:
-// an existing entry for n keeps its stored version/cost/vis fields until the
-// caller explicitly overwrites them; a newly-resident node starts zeroed
-// (matching a fresh map key's zero value). Returns nil only when the cache is
-// unprovisioned (recovery gate off) or n/p is nil.
+// beginCNodeMemoEpoch invalidates every recovery memo entry in O(1). Epoch
+// zero is reserved for never-valid entries. On uint16 wrap, clear the cache
+// once before reusing epoch 1 so no surviving entry can alias the new epoch.
+func (p *Parser) beginCNodeMemoEpoch() {
+	if p == nil || len(p.cNodeMemoCache) == 0 {
+		return
+	}
+	if p.cNodeMemoEpoch == ^uint16(0) {
+		clear(p.cNodeMemoCache)
+		p.cNodeMemoEpoch = 0
+	}
+	p.cNodeMemoEpoch++
+}
+
+// cNodeMemoSlot returns the writable 2-way set-associative slot for node n.
+// A current-epoch miss evicts the primary into the victim half; stale-epoch
+// occupants are ignored. This mirrors map[*Node]cNodeMemoEntry lookup
+// semantics within an epoch: an existing entry for n keeps its stored
+// version/cost/vis fields until the caller explicitly overwrites them; a
+// newly-resident node starts zeroed (matching a fresh map key's zero value).
+// Returns nil only when the cache is unprovisioned (recovery gate off) or n/p
+// is nil.
 func (p *Parser) cNodeMemoSlot(n *Node) *cNodeMemoCacheEntry {
 	if p == nil || n == nil || len(p.cNodeMemoCache) == 0 {
 		return nil
+	}
+	if p.cNodeMemoEpoch == 0 {
+		p.beginCNodeMemoEpoch()
 	}
 	setCount := len(p.cNodeMemoCache) >> 1
 	ptr := uintptr(unsafe.Pointer(n))
 	idx := cNodeMemoCacheIndex(ptr, setCount)
 	primary := &p.cNodeMemoCache[idx]
-	if primary.node == ptr {
+	if primary.epoch == p.cNodeMemoEpoch && primary.node == ptr {
 		return primary
 	}
 	victim := &p.cNodeMemoCache[idx+1]
-	if victim.node == ptr {
+	if victim.epoch == p.cNodeMemoEpoch && victim.node == ptr {
 		*primary, *victim = *victim, *primary
 		return primary
 	}
-	*victim = *primary
-	*primary = cNodeMemoCacheEntry{node: ptr}
+	if primary.epoch == p.cNodeMemoEpoch {
+		*victim = *primary
+	}
+	*primary = cNodeMemoCacheEntry{node: ptr, epoch: p.cNodeMemoEpoch}
 	return primary
 }
 
@@ -1389,6 +1416,7 @@ func (p *Parser) cErrRegionPostAbsorb(pre cErrRegionAbsorbPre, added ...*Node) {
 			visCount: vis,
 			hasCost:  true,
 			hasVis:   true,
+			epoch:    p.cNodeMemoEpoch,
 		}
 	}
 	if ms := p.mergeScratch; ms != nil {
@@ -1500,7 +1528,11 @@ func (p *Parser) cNodeErrorCost(n *Node) uint32 {
 	// set), so the pointer captured before recursing could now be stale.
 	slot := p.cNodeMemoSlot(n)
 	if slot.ver != n.equivVersion {
-		*slot = cNodeMemoCacheEntry{node: uintptr(unsafe.Pointer(n)), ver: n.equivVersion}
+		*slot = cNodeMemoCacheEntry{
+			node:  uintptr(unsafe.Pointer(n)),
+			ver:   n.equivVersion,
+			epoch: p.cNodeMemoEpoch,
+		}
 	}
 	slot.cost = cost
 	slot.hasCost = true

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"testing"
+	"unsafe"
+)
 
 func TestCVersionStatusAddsPausedSkippedTreeCost(t *testing.T) {
 	parser := &Parser{}
@@ -1158,5 +1161,125 @@ func TestCCondenseAndResumeComparesMissingGroupStacks(t *testing.T) {
 	}
 	if condensed[0].cRecoverMissingGroup != nil {
 		t.Fatal("condense kept missing-group stack; want lower-cost clean stack")
+	}
+}
+
+func collidingCNodeMemoNodes(t *testing.T, setCount int) (*Node, *Node, *Node) {
+	t.Helper()
+	nodes := make([]Node, setCount*2+1)
+	seen := make(map[int][]*Node, setCount)
+	for i := range nodes {
+		n := &nodes[i]
+		n.equivVersion = 1
+		idx := cNodeMemoCacheIndex(uintptr(unsafe.Pointer(n)), setCount)
+		seen[idx] = append(seen[idx], n)
+		if len(seen[idx]) == 3 {
+			return seen[idx][0], seen[idx][1], seen[idx][2]
+		}
+	}
+	t.Fatal("failed to find three nodes in one recovery memo set")
+	return nil, nil, nil
+}
+
+func TestCNodeMemoEpochAdvancesAcrossParserParses(t *testing.T) {
+	p := NewParser(buildArithmeticLanguage())
+	p.errorCostCompetition = true
+
+	first, err := p.Parse([]byte("1"))
+	if err != nil {
+		t.Fatalf("first parse: %v", err)
+	}
+	first.Release()
+	firstEpoch := p.cNodeMemoEpoch
+	if firstEpoch == 0 {
+		t.Fatal("first parse left recovery memo epoch at zero")
+	}
+
+	second, err := p.Parse([]byte("1"))
+	if err != nil {
+		t.Fatalf("second parse: %v", err)
+	}
+	second.Release()
+	if got, want := p.cNodeMemoEpoch, firstEpoch+1; got != want {
+		t.Fatalf("second parse recovery memo epoch = %d, want %d", got, want)
+	}
+}
+
+func TestCNodeMemoSlotPreservesVictimPromotionAndEviction(t *testing.T) {
+	p := &Parser{cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheInitialSize)}
+	p.beginCNodeMemoEpoch()
+	a, b, c := collidingCNodeMemoNodes(t, len(p.cNodeMemoCache)>>1)
+
+	store := func(n *Node, cost uint32) {
+		slot := p.cNodeMemoSlot(n)
+		*slot = cNodeMemoCacheEntry{
+			node:    uintptr(unsafe.Pointer(n)),
+			ver:     n.equivVersion,
+			cost:    cost,
+			hasCost: true,
+			epoch:   p.cNodeMemoEpoch,
+		}
+	}
+	store(a, 11)
+	store(b, 22)
+
+	idx := cNodeMemoCacheIndex(uintptr(unsafe.Pointer(a)), len(p.cNodeMemoCache)>>1)
+	if got := p.cNodeMemoCache[idx].node; got != uintptr(unsafe.Pointer(b)) {
+		t.Fatalf("primary after collision = %#x, want b %#x", got, uintptr(unsafe.Pointer(b)))
+	}
+	if got := p.cNodeMemoCache[idx+1].node; got != uintptr(unsafe.Pointer(a)) {
+		t.Fatalf("victim after collision = %#x, want a %#x", got, uintptr(unsafe.Pointer(a)))
+	}
+
+	promoted := p.cNodeMemoSlot(a)
+	if promoted.cost != 11 || !promoted.hasCost {
+		t.Fatalf("promoted victim payload = %#v, want cached cost 11", *promoted)
+	}
+	if got := p.cNodeMemoCache[idx+1].node; got != uintptr(unsafe.Pointer(b)) {
+		t.Fatalf("victim after promotion = %#x, want b %#x", got, uintptr(unsafe.Pointer(b)))
+	}
+
+	store(c, 33)
+	if got := p.cNodeMemoCache[idx].node; got != uintptr(unsafe.Pointer(c)) {
+		t.Fatalf("primary after miss = %#x, want c %#x", got, uintptr(unsafe.Pointer(c)))
+	}
+	if got := p.cNodeMemoCache[idx+1].node; got != uintptr(unsafe.Pointer(a)) {
+		t.Fatalf("victim after miss = %#x, want prior primary a %#x", got, uintptr(unsafe.Pointer(a)))
+	}
+}
+
+func TestCNodeMemoEpochWrapClearsBeforeEpochReuse(t *testing.T) {
+	p := &Parser{
+		cNodeMemoCache: make([]cNodeMemoCacheEntry, cNodeMemoCacheInitialSize),
+		cNodeMemoEpoch: ^uint16(0),
+	}
+	n := &Node{equivVersion: 1}
+	idx := cNodeMemoCacheIndex(uintptr(unsafe.Pointer(n)), len(p.cNodeMemoCache)>>1)
+	p.cNodeMemoCache[idx] = cNodeMemoCacheEntry{
+		node:    uintptr(unsafe.Pointer(n)),
+		ver:     n.equivVersion,
+		cost:    41,
+		hasCost: true,
+		epoch:   p.cNodeMemoEpoch,
+	}
+
+	p.beginCNodeMemoEpoch()
+	if p.cNodeMemoEpoch != 1 {
+		t.Fatalf("memo epoch after wrap = %d, want 1", p.cNodeMemoEpoch)
+	}
+	for i, entry := range p.cNodeMemoCache {
+		if entry != (cNodeMemoCacheEntry{}) {
+			t.Fatalf("cache slot %d after epoch wrap = %#v, want zero", i, entry)
+		}
+	}
+}
+
+func TestCNodeMemoCacheEntrySize(t *testing.T) {
+	want := uintptr(20)
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		want = 32
+	}
+	if got := unsafe.Sizeof(cNodeMemoCacheEntry{}); got != want {
+		t.Fatalf("cNodeMemoCacheEntry size = %d, want %d", got, want)
 	}
 }

--- a/transient_children_test.go
+++ b/transient_children_test.go
@@ -558,8 +558,14 @@ func TestTransientScratchCheckpointMaterializesLiveStackAndReusesSlabs(t *testin
 	parent.dynamicPrecedence = 13
 	parent.rawShape = 17
 	if slot := parser.cNodeMemoSlot(parent); slot != nil {
-		*slot = cNodeMemoCacheEntry{node: uintptr(unsafe.Pointer(parent)), hasCost: true}
+		*slot = cNodeMemoCacheEntry{
+			node:    uintptr(unsafe.Pointer(parent)),
+			hasCost: true,
+			epoch:   parser.cNodeMemoEpoch,
+		}
 	}
+	epochBefore := parser.cNodeMemoEpoch
+	memoIdx := cNodeMemoCacheIndex(uintptr(unsafe.Pointer(parent)), len(parser.cNodeMemoCache)>>1)
 	stack := glrStack{entries: []stackEntry{newStackEntryNode(7, parent)}, cacheEntries: true, byteOffset: 1}
 	parentCapacityBytes := scratch.transientParents.allocatedBytes
 	childCapacityBytes := scratch.transientChildren.allocatedBytes
@@ -587,10 +593,14 @@ func TestTransientScratchCheckpointMaterializesLiveStackAndReusesSlabs(t *testin
 	if scratch.transientCheckpoints != 1 {
 		t.Fatalf("transient checkpoints = %d, want 1", scratch.transientCheckpoints)
 	}
-	for i := range parser.cNodeMemoCache {
-		if parser.cNodeMemoCache[i].node != 0 {
-			t.Fatal("recovery node memo retained recycled transient pointers")
-		}
+	if parser.cNodeMemoEpoch != epochBefore+1 {
+		t.Fatalf("recovery memo epoch = %d, want %d", parser.cNodeMemoEpoch, epochBefore+1)
+	}
+	if stale := parser.cNodeMemoCache[memoIdx]; stale.node != uintptr(unsafe.Pointer(parent)) || stale.epoch != epochBefore || !stale.hasCost {
+		t.Fatalf("checkpoint physically cleared recovery memo instead of invalidating by epoch: %#v", stale)
+	}
+	if slot := parser.cNodeMemoSlot(parent); slot.hasCost {
+		t.Fatal("recovery node memo retained recycled transient pointer in the new epoch")
 	}
 
 	reused := scratch.transientParents.allocParent(arena, Symbol(3), true, nil, 0, false)


### PR DESCRIPTION
## Summary

- replace per-parse clearing of the retained C-recovery memo cache with parser-owned generation invalidation
- preserve cache entry size by using existing padding and clear only on generation wrap
- invalidate memo generations when transient slabs are recycled
- add focused cache, layout, reused-parser, checkpoint, and benchmark coverage
- record the measured improvement in Unreleased

## Performance

Pinned quiet-host count-10 runs:

- recovery-primed tiny clean: 31.98us to 13.46us, 57.93% faster
- ordinary tiny clean: 13.61us to 13.27us, 2.51% faster
- alternating error/clean: 2.129ms to 2.064ms, 3.06% faster
- bytes and allocations per operation unchanged

## Verification

- focused cache, recovery, checkpoint, exact-tree, and layout tests
- selected linux/386 layout and behavior tests
- focused Docker root/cache/KDL regression gate
- strict-contamination quiet-host benchmark receipts
- formatting and diff checks