### PR TITLE
fix(parser): harden recovery selection and generated grammar contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ for tags and release notes while still in `0.x`.
 - HTML range normalization no longer extends already-closed child elements
   across trailing trivia to an enclosing end tag; genuinely unclosed recovered
   element chains retain their C-compatible range extension.
+- Full-parse retry selection now preserves an accepted error tree when a later
+  retry stops early, instead of replacing it with a farther provisional tree.
 - Fleet scoreboard reduction now canonicalizes hard-gate finding order and
   records clean reducer provenance separately from immutable measurement
   provenance, allowing later reducer fixes to authenticate historical shards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The real-corpus Docker runner now forwards `REAL_CORPUS_ONLY`, allowing a
+  reproducible single-language run without switching to a different wrapper.
 - HTML range normalization no longer extends already-closed child elements
   across trailing trivia to an enclosing end tag; genuinely unclosed recovered
   element chains retain their C-compatible range extension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- HTML range normalization no longer extends already-closed child elements
+  across trailing trivia to an enclosing end tag; genuinely unclosed recovered
+  element chains retain their C-compatible range extension.
 - Fleet scoreboard reduction now canonicalizes hard-gate finding order and
   records clean reducer provenance separately from immutable measurement
   provenance, allowing later reducer fixes to authenticate historical shards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ for tags and release notes while still in `0.x`.
   element chains retain their C-compatible range extension.
 - Full-parse retry selection now preserves an accepted error tree when a later
   retry stops early, instead of replacing it with a farther provisional tree.
+- Grammargen-owned Go, Regex, and Swift blobs now share one registry
+  provenance contract, and ts2go's Go regeneration hint uses the safe
+  `grammargen emit go` command without LR splitting.
 - Fleet scoreboard reduction now canonicalizes hard-gate finding order and
   records clean reducer provenance separately from immutable measurement
   provenance, allowing later reducer fixes to authenticate historical shards

--- a/cgo_harness/docker/run_grammargen_real_corpus_in_docker.sh
+++ b/cgo_harness/docker/run_grammargen_real_corpus_in_docker.sh
@@ -26,6 +26,7 @@ RATCHET_REBASE="${RATCHET_REBASE:-0}"
 # Grammars skipped by default: ocaml's "attribute" nonterminal-extra chain
 # exceeds the synthetic-state budget (generation-fatal; see GEN_COST_RCA).
 REAL_CORPUS_SKIP="${REAL_CORPUS_SKIP:-ocaml}"
+REAL_CORPUS_ONLY="${REAL_CORPUS_ONLY:-}"
 SEED_DIR=""
 CONTAINER_SEED_DIR=""
 OFFLINE=0
@@ -314,6 +315,7 @@ cd /workspace
   GTS_GRAMMARGEN_REAL_CORPUS_RATCHET_REBASE="$RATCHET_REBASE" \
   GTS_GRAMMARGEN_REAL_CORPUS_FLOORS_PATH="/workspace/tmp_floors/real_corpus_parity_floors.json" \
   GTS_GRAMMARGEN_REAL_CORPUS_SKIP="$REAL_CORPUS_SKIP" \
+  GTS_GRAMMARGEN_REAL_CORPUS_ONLY="$REAL_CORPUS_ONLY" \
   GOGC=50 GOMEMLIMIT=10GiB \
   go test ./grammargen -run '^TestMultiGrammarImportRealCorpusParity$' -count=1 -v -timeout 90m
 EOF2

--- a/cmd/ts2go/batch_run.go
+++ b/cmd/ts2go/batch_run.go
@@ -237,7 +237,7 @@ func loadHighlightQuery(repoDir string) (string, bool) {
 }
 
 // grammargenOwnedBlobs lists languages whose checked-in grammar_blobs/*.bin
-// is compiled by grammargen (go run ./cmd/grammargen -lr-split -bin ...)
+// is compiled by grammargen (go run ./cmd/grammargen emit ...)
 // instead of the ts2go C-table extraction pipeline. Batch regeneration must
 // not clobber these blobs or relabel their registry entries: they advertise
 // GrammarSourceGrammargenBlob in grammars/registry_builtin_gen.go.
@@ -251,21 +251,24 @@ var grammargenOwnedBlobs = map[string]bool{
 // grammargen-owned blob, with a regeneration hint accurate for how that
 // specific language is actually built. "go" and "swift" are grammargen
 // builtin grammar names (see builtinGrammars in cmd/grammargen/main.go) and
-// regenerate via the positional-arg form below. "regex" is NOT a grammargen
+// regenerate via the emit subcommand below. "regex" is NOT a grammargen
 // builtin name — its blob is built ad hoc by importing a resolved
 // tree-sitter grammar.json (grammargen's -json flag), not from a builtin Go
 // DSL grammar, so the builtin-name regen command would fail if run verbatim.
 // See grammargen/regex_import_parity_test.go for the import path this blob
 // must stay parity-checked against.
 func grammargenOwnedBlobSkipMessage(name string) string {
+	if name == "go" {
+		return "skipped go (grammargen-owned blob; regenerate with: go run ./cmd/grammargen emit go -bin grammars/grammar_blobs/go.bin)"
+	}
 	if name == "regex" {
 		return fmt.Sprintf("skipped %s (grammargen-owned blob; regex.bin is grammargen-built via a "+
 			"tree-sitter grammar.json import, not a grammargen builtin grammar name — "+
 			"see grammargen/regex_import_parity_test.go for the import/parity path; "+
 			"do not regenerate it through this batch pipeline or clobber it here)", name)
 	}
-	return fmt.Sprintf("skipped %s (grammargen-owned blob; regenerate with: go run ./cmd/grammargen -lr-split -bin grammars/grammar_blobs/%s.bin %s)",
-		name, safeFileBase(name), name)
+	return fmt.Sprintf("skipped %s (grammargen-owned blob; regenerate with: go run ./cmd/grammargen emit %s -lr-split -bin grammars/grammar_blobs/%s.bin)",
+		name, name, safeFileBase(name))
 }
 
 func writeRegisterStub(outDir string, entry ManifestEntry, highlightQuery string) error {

--- a/cmd/ts2go/batch_test.go
+++ b/cmd/ts2go/batch_test.go
@@ -70,6 +70,16 @@ func TestSafeFileBase(t *testing.T) {
 	}
 }
 
+func TestGrammargenOwnedBlobSkipMessageUsesSafeGoCommand(t *testing.T) {
+	message := grammargenOwnedBlobSkipMessage("go")
+	if want := "go run ./cmd/grammargen emit go -bin grammars/grammar_blobs/go.bin"; !strings.Contains(message, want) {
+		t.Fatalf("skip message = %q, want command %q", message, want)
+	}
+	if strings.Contains(message, "-lr-split") {
+		t.Fatalf("skip message contains unsafe Go -lr-split guidance: %q", message)
+	}
+}
+
 func TestLanguageFuncNameSanitize(t *testing.T) {
 	if got := languageFuncName("c-sharp"); got != "CSharpLanguage" {
 		t.Fatalf("languageFuncName = %q, want %q", got, "CSharpLanguage")

--- a/grammars/html_parse_regression_test.go
+++ b/grammars/html_parse_regression_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/odvcencio/gotreesitter"
 )
 
+func findHTMLElementStartingAt(root *gotreesitter.Node, lang *gotreesitter.Language, start uint32) *gotreesitter.Node {
+	if root == nil {
+		return nil
+	}
+	if root.Type(lang) == "element" && root.StartByte() == start {
+		return root
+	}
+	for i := 0; i < root.ChildCount(); i++ {
+		if found := findHTMLElementStartingAt(root.Child(i), lang, start); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
 func TestParseHTMLDeeplyNestedCustomKeepsRecoveredInnerRange(t *testing.T) {
 	lang := HtmlLanguage()
 	src := []byte("<div>\n" + strings.Repeat("<abc>", 900) + "\n</div>\n")
@@ -45,5 +60,64 @@ func TestParseHTMLDeeplyNestedCustomKeepsRecoveredInnerRange(t *testing.T) {
 	}
 	if got, want := inner.EndPoint(), closeTok.StartPoint(); got != want {
 		t.Fatalf("inner.EndPoint = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseHTMLRecoveredRangeOnlyExtendsUnclosedChain(t *testing.T) {
+	lang := HtmlLanguage()
+	tests := []struct {
+		name      string
+		source    string
+		element   string
+		wantEndAt string
+	}{
+		{
+			name:      "unclosed nested custom chain reaches enclosing close",
+			source:    "<div><abc><def>\n</div>",
+			element:   "<abc>",
+			wantEndAt: "</div>",
+		},
+		{
+			name:      "closed child keeps its own range before trailing trivia",
+			source:    "<div><span>x</span>\n</div>",
+			element:   "<span>",
+			wantEndAt: "\n",
+		},
+		{
+			name:      "closed last sibling keeps its own range before trailing trivia",
+			source:    "<div><span>x</span>\n<em>y</em>\n</div>",
+			element:   "<em>",
+			wantEndAt: "\n</div>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.source)
+			tree, err := gotreesitter.NewParser(lang).Parse(src)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if tree == nil || tree.RootNode() == nil {
+				t.Fatal("Parse() returned nil root")
+			}
+			t.Cleanup(tree.Release)
+
+			start := strings.Index(tc.source, tc.element)
+			if start < 0 {
+				t.Fatalf("source does not contain element marker %q", tc.element)
+			}
+			element := findHTMLElementStartingAt(tree.RootNode(), lang, uint32(start))
+			if element == nil {
+				t.Fatalf("element starting at %d not found: %s", start, tree.RootNode().SExpr(lang))
+			}
+			wantEnd := strings.Index(tc.source, tc.wantEndAt)
+			if wantEnd < 0 {
+				t.Fatalf("source does not contain end marker %q", tc.wantEndAt)
+			}
+			if got := element.EndByte(); got != uint32(wantEnd) {
+				t.Fatalf("element %q EndByte() = %d, want %d; text=%q tree=%s", tc.element, got, wantEnd, element.Text(src), tree.RootNode().SExpr(lang))
+			}
+		})
 	}
 }

--- a/grammars/registry_test.go
+++ b/grammars/registry_test.go
@@ -11,24 +11,30 @@ func isRegisteredLanguage(name string) bool {
 	return lookupByName(name) != nil
 }
 
-// TestGoBlobIsGrammargenGenerated pins the contract invariant that the shipping
-// go.bin is a grammargen-compiled blob (GeneratedByGrammargen == true). The
-// runtime relies on this flag to bypass every per-language conflict-resolution
-// hack: deterministicConflictChoiceForDispatch returns early on
-// GeneratedByGrammargen before reaching its switch p.language.Name block, so a
-// grammargen blob resolves conflicts purely via the general ConflictPolicies +
-// structural generated-repeat detection. If a future blob regeneration silently
-// flipped this flag to false, those general paths would be bypassed and retired
-// per-language resolvers could resurrect. This test is the tripwire — and the
-// template the contract guard for every future ts2go->grammargen migration
-// should follow.
-func TestGoBlobIsGrammargenGenerated(t *testing.T) {
-	lang := GoLanguage()
-	if lang == nil {
-		t.Fatal("GoLanguage() returned nil")
-	}
-	if !lang.GeneratedByGrammargen {
-		t.Fatal("go.bin GeneratedByGrammargen = false, want true; the shipping go blob must be grammargen-compiled so the runtime's per-language conflict hacks stay bypassed")
+func TestGrammargenBlobProvenance(t *testing.T) {
+	for _, name := range []string{"go", "regex", "swift"} {
+		t.Run(name, func(t *testing.T) {
+			entry := DetectLanguageByName(name)
+			if entry == nil {
+				t.Fatalf("DetectLanguageByName(%q) returned nil", name)
+			}
+			if entry.GrammarSource != GrammarSourceGrammargenBlob {
+				t.Fatalf("GrammarSource = %q, want %q", entry.GrammarSource, GrammarSourceGrammargenBlob)
+			}
+			if blob := BlobByName(name); len(blob) == 0 {
+				t.Fatalf("BlobByName(%q) returned empty", name)
+			}
+			if entry.Language == nil {
+				t.Fatal("registry language loader is nil")
+			}
+			lang := entry.Language()
+			if lang == nil {
+				t.Fatal("registry language loader returned nil")
+			}
+			if !lang.GeneratedByGrammargen {
+				t.Fatal("decoded blob is not marked GeneratedByGrammargen")
+			}
+		})
 	}
 }
 
@@ -234,22 +240,6 @@ func TestBuiltinLanguagesAdvertiseTS2GoBlobSource(t *testing.T) {
 	}
 	if entry.GrammarSource != GrammarSourceTS2GoBlob {
 		t.Fatalf("Python GrammarSource = %q, want %q", entry.GrammarSource, GrammarSourceTS2GoBlob)
-	}
-}
-
-func TestGoAdvertisesGrammargenBlobSource(t *testing.T) {
-	// go.bin is grammargen-compiled (cmd/grammargen -lr-split -bin ...), the
-	// only builtin migrated off ts2go so far. It still ships an embedded
-	// blob, so BlobByName must keep serving it.
-	entry := DetectLanguage("main.go")
-	if entry == nil {
-		t.Fatal("expected Go language for main.go")
-	}
-	if entry.GrammarSource != GrammarSourceGrammargenBlob {
-		t.Fatalf("Go GrammarSource = %q, want %q", entry.GrammarSource, GrammarSourceGrammargenBlob)
-	}
-	if blob := BlobByName("go"); len(blob) == 0 {
-		t.Fatal("BlobByName(go) returned empty; grammargen-blob languages must stay blob-served")
 	}
 }
 

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1816,6 +1816,88 @@ func TestPreferRetryTreePrefersFewerChildrenOnEqualErrorTrees(t *testing.T) {
 	}
 }
 
+func TestPreferRetryTreeKeepsAcceptedIncumbentOverStoppedCandidate(t *testing.T) {
+	tests := []struct {
+		name         string
+		incumbentEnd uint32
+	}{
+		{name: "equal span with fewer children", incumbentEnd: 200},
+		{name: "farther provisional progress", incumbentEnd: 180},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			incumbent := &Tree{
+				root: &Node{
+					endByte:  tt.incumbentEnd,
+					flags:    nodeFlagHasError,
+					children: make([]*Node, 12),
+				},
+				parseRuntime: ParseRuntime{
+					StopReason:      ParseStopAccepted,
+					ExpectedEOFByte: 200,
+				},
+			}
+			candidate := &Tree{
+				root: &Node{
+					endByte:  200,
+					flags:    nodeFlagHasError,
+					children: make([]*Node, 2),
+				},
+				parseRuntime: ParseRuntime{
+					StopReason:      ParseStopTimeout,
+					ExpectedEOFByte: 200,
+				},
+			}
+
+			if preferRetryTree(nil, candidate, incumbent) {
+				t.Fatal("preferRetryTree = true, want false for interrupted retry against accepted incumbent")
+			}
+		})
+	}
+}
+
+func TestPreferRetryTreeStoppedCandidateCanBeatStoppedIncumbent(t *testing.T) {
+	incumbent := &Tree{
+		root: &Node{endByte: 180, flags: nodeFlagHasError},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopMemoryBudget,
+			ExpectedEOFByte: 200,
+		},
+	}
+	candidate := &Tree{
+		root: &Node{endByte: 200, flags: nodeFlagHasError},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopTimeout,
+			ExpectedEOFByte: 200,
+		},
+	}
+
+	if !preferRetryTree(nil, candidate, incumbent) {
+		t.Fatal("preferRetryTree = false, want farther stopped candidate over stopped incumbent")
+	}
+}
+
+func TestPreferRetryTreeAcceptedCandidateCanBeatStoppedIncumbent(t *testing.T) {
+	incumbent := &Tree{
+		root: &Node{endByte: 200, flags: nodeFlagHasError},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopTimeout,
+			ExpectedEOFByte: 200,
+		},
+	}
+	candidate := &Tree{
+		root: &Node{endByte: 200, flags: nodeFlagHasError},
+		parseRuntime: ParseRuntime{
+			StopReason:      ParseStopAccepted,
+			ExpectedEOFByte: 200,
+		},
+	}
+
+	if !preferRetryTree(nil, candidate, incumbent) {
+		t.Fatal("preferRetryTree = false, want accepted candidate over stopped incumbent")
+	}
+}
+
 func TestGLRStackCullTrigger(t *testing.T) {
 	if got := glrStackCullTrigger(8, arenaClassFull, "go"); got != 12 {
 		t.Fatalf("glrStackCullTrigger(full, go) = %d, want 12", got)

--- a/parser_result_html.go
+++ b/parser_result_html.go
@@ -111,7 +111,16 @@ func htmlExtendOpenElementChain(node *Node, endByte uint32, endPoint Point, lang
 }
 
 func htmlExtendLeadingElementChain(node *Node, endByte uint32, endPoint Point, lang *Language) {
+	// Validate the complete chain before changing any range. Doing this once
+	// also keeps deeply recovered HTML chains linear rather than re-walking the
+	// remaining suffix for every element.
+	if !htmlElementIsUnclosedChain(node, lang) {
+		return
+	}
 	for cur := node; cur != nil && lang != nil && cur.Type(lang) == "element"; {
+		// Only recovered chains of unclosed start tags should grow to the
+		// enclosing close token. Closed or self-closing elements and elements
+		// ending in concrete content already have an authoritative range.
 		cur.endByte = endByte
 		cur.endPoint = endPoint
 		child := resultChildAt(cur, 1)
@@ -120,6 +129,28 @@ func htmlExtendLeadingElementChain(node *Node, endByte uint32, endPoint Point, l
 		}
 		cur = child
 	}
+}
+
+func htmlElementIsUnclosedChain(node *Node, lang *Language) bool {
+	for cur := node; cur != nil && lang != nil && cur.Type(lang) == "element"; {
+		childCount := resultChildCount(cur)
+		if childCount == 0 {
+			return false
+		}
+		last := resultChildAt(cur, childCount-1)
+		if last == nil {
+			return false
+		}
+		switch last.Type(lang) {
+		case "start_tag":
+			return true
+		case "element":
+			cur = last
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 func normalizeHTMLRecoveredNestedCustomTagRanges(root *Node, source []byte, lang *Language) {

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -302,13 +302,19 @@ func preferRetryTree(p *Parser, candidate, incumbent *Tree) bool {
 	if treeParseClean(incumbent) {
 		return false
 	}
+	incRT := incumbent.parseRuntimeReadOnly()
+	if incRT.StopReason == ParseStopAccepted && candidate.ParseStoppedEarly() {
+		// A retry that stopped before acceptance is not a complete C-style
+		// selection candidate. Keep the accepted incumbent even when the
+		// provisional retry reached farther or reports a lower error cost.
+		return false
+	}
 	candEnd := retryTreeEndByte(candidate)
 	incEnd := retryTreeEndByte(incumbent)
 	if candEnd != incEnd {
 		return candEnd > incEnd
 	}
 	candRT := candidate.parseRuntimeReadOnly()
-	incRT := incumbent.parseRuntimeReadOnly()
 	if candRT.Truncated != incRT.Truncated {
 		return !candRT.Truncated
 	}


### PR DESCRIPTION
## Summary

- preserve accepted retry results when later attempts stop provisionally
- keep closed HTML element ranges from absorbing enclosing trailing trivia
- consolidate generated-blob provenance coverage and correct regeneration guidance
- forward the real-corpus single-language filter through the Docker runner

## Validation

- focused retry-selection tests
- focused HTML parse regressions
- HTML single-grammar Docker parity gate (known 24/25 structural baseline unchanged)
- Go/Regex/Swift registry provenance test
- focused ts2go regeneration-hint test
- shell syntax and diff checks