### PR TITLE
feat(wasm): add persistent browser analysis bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Added
+
+- The browser runtime now supports persistent UTF-16 documents through
+  `open`, `update`, `close`, and `queryDocument`. Updates compute a
+  surrogate-safe minimal edit, reuse the prior parse tree, and run highlights,
+  tags, and bounded queries over the same retained tree while leaving the
+  existing stateless parse, query, and highlight APIs intact.
+- `cmd/wasmassets` now emits reproducible single-language browser bundles for
+  either the Go or TinyGo WebAssembly compiler. Bundles contain the external
+  grammar blob, highlight and optional tags queries, the matching compiler
+  bootstrap, and a manifest with compiler identity and SHA-256 digests; the
+  runtime build is restricted to the selected grammar's tables, registry, and
+  scanner support instead of embedding the full grammar fleet.
+
 ### Performance
 
 - Linearized C-recovery strategy-1 elections with reusable cursor and dedupe
@@ -33,6 +47,9 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Browser runtime results are now assembled as explicit JavaScript objects and
+  arrays, avoiding TinyGo's primitive-only `syscall/js.ValueOf` path while
+  preserving the richer structured-tree and bounded-query wire formats.
 - The real-corpus Docker runner now forwards `REAL_CORPUS_ONLY`, allowing a
   reproducible single-language run without switching to a different wrapper.
 - HTML range normalization no longer extends already-closed child elements

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ The repository ships two `GOOS=js GOARCH=wasm` targets: a blob-loading runtime
 and a grammargen build that imports Tree-sitter
 grammar JSON and generates tables in the browser. The runtime exposes parsing,
 queries, and highlighting; structured parse and query results include both
-UTF-8 byte offsets and JavaScript UTF-16 code-unit offsets.
+UTF-8 byte offsets and JavaScript UTF-16 code-unit offsets. It can also retain
+an incrementally updated document tree and reuse it for highlights, tags, and
+queries. `cmd/wasmassets` emits a reproducible, single-language browser bundle
+for either the Go or TinyGo WebAssembly compiler.
 
 See the [WebAssembly guide](wasm/README.md) for build commands, the complete
 JavaScript APIs, node and match limits, and a browser example.

--- a/cmd/wasmassets/main.go
+++ b/cmd/wasmassets/main.go
@@ -66,7 +66,7 @@ func generate(languageName, output, compiler, goBinary, tinygo string) error {
 
 	runtimeName := "gotreesitter.wasm"
 	runtimePath := filepath.Join(output, runtimeName)
-	wasmExec, err := buildRuntime(root, runtimePath, compiler, goBinary, tinygo)
+	wasmExec, err := buildRuntime(root, runtimePath, entry.Name, compiler, goBinary, tinygo)
 	if err != nil {
 		return err
 	}
@@ -105,12 +105,16 @@ func generate(languageName, output, compiler, goBinary, tinygo string) error {
 	return os.WriteFile(filepath.Join(output, "manifest.json"), encoded, 0o644)
 }
 
-func buildRuntime(root, output, compiler, goBinary, tinygo string) ([]byte, error) {
+func buildRuntime(root, output, languageName, compiler, goBinary, tinygo string) ([]byte, error) {
+	buildTags, err := runtimeBuildTags(languageName)
+	if err != nil {
+		return nil, err
+	}
 	var build *exec.Cmd
 	var wasmExecPath string
 	switch compiler {
 	case "go":
-		build = exec.Command(goBinary, "build", "-trimpath", "-o", output, "./wasm/runtime")
+		build = exec.Command(goBinary, "build", "-tags", buildTags, "-trimpath", "-o", output, "./wasm/runtime")
 		build.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 		goRoot, err := commandOutput(goBinary, "env", "GOROOT")
 		if err != nil {
@@ -121,7 +125,7 @@ func buildRuntime(root, output, compiler, goBinary, tinygo string) ([]byte, erro
 			wasmExecPath = filepath.Join(goRoot, "misc", "wasm", "wasm_exec.js")
 		}
 	case "tinygo":
-		build = exec.Command(tinygo, "build", "-target", "wasm", "-no-debug", "-opt=z", "-o", output, "./wasm/runtime")
+		build = exec.Command(tinygo, "build", "-tags", buildTags, "-target", "wasm", "-no-debug", "-opt=z", "-o", output, "./wasm/runtime")
 		tinygoRoot, err := commandOutput(tinygo, "env", "TINYGOROOT")
 		if err != nil {
 			return nil, fmt.Errorf("locate TinyGo runtime: %w", err)
@@ -141,6 +145,21 @@ func buildRuntime(root, output, compiler, goBinary, tinygo string) ([]byte, erro
 		return nil, fmt.Errorf("read %s bootstrap: %w", compiler, err)
 	}
 	return wasmExec, nil
+}
+
+func runtimeBuildTags(languageName string) (string, error) {
+	if languageName == "" {
+		return "", errors.New("language name is required")
+	}
+	for _, char := range languageName {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '_' {
+			return "", fmt.Errorf("language %q cannot be expressed as a grammar subset build tag", languageName)
+		}
+	}
+	return strings.Join([]string{
+		"grammar_subset",
+		"grammar_subset_" + languageName,
+	}, ","), nil
 }
 
 func moduleRoot() (string, error) {

--- a/cmd/wasmassets/main.go
+++ b/cmd/wasmassets/main.go
@@ -21,23 +21,26 @@ import (
 type manifest struct {
 	Version  int               `json:"version"`
 	Language string            `json:"language"`
+	Compiler string            `json:"compiler"`
 	Assets   map[string]string `json:"assets"`
 }
 
 func main() {
 	languageName := flag.String("language", "go", "registered grammar name")
 	output := flag.String("output", "", "output directory")
+	compiler := flag.String("compiler", "go", "WASM compiler: go or tinygo")
+	goBinary := flag.String("go", "go", "Go executable")
 	tinygo := flag.String("tinygo", "tinygo", "TinyGo executable")
 	flag.Parse()
 	if strings.TrimSpace(*output) == "" {
 		fatal(errors.New("-output is required"))
 	}
-	if err := generate(*languageName, *output, *tinygo); err != nil {
+	if err := generate(*languageName, *output, *compiler, *goBinary, *tinygo); err != nil {
 		fatal(err)
 	}
 }
 
-func generate(languageName, output, tinygo string) error {
+func generate(languageName, output, compiler, goBinary, tinygo string) error {
 	entry := grammars.DetectLanguageByName(languageName)
 	if entry == nil {
 		return fmt.Errorf("unknown language %q", languageName)
@@ -63,12 +66,9 @@ func generate(languageName, output, tinygo string) error {
 
 	runtimeName := "gotreesitter.wasm"
 	runtimePath := filepath.Join(output, runtimeName)
-	build := exec.Command(tinygo, "build", "-target", "wasm", "-no-debug", "-opt=z", "-o", runtimePath, "./wasm/runtime")
-	build.Dir = root
-	build.Stdout = os.Stdout
-	build.Stderr = os.Stderr
-	if err := build.Run(); err != nil {
-		return fmt.Errorf("build runtime: %w", err)
+	wasmExec, err := buildRuntime(root, runtimePath, compiler, goBinary, tinygo)
+	if err != nil {
+		return err
 	}
 	runtime, err := os.ReadFile(runtimePath)
 	if err != nil {
@@ -77,14 +77,6 @@ func generate(languageName, output, tinygo string) error {
 	digest := sha256.Sum256(runtime)
 	assets[runtimeName] = "sha256:" + hex.EncodeToString(digest[:])
 
-	tinygoRoot, err := commandOutput(tinygo, "env", "TINYGOROOT")
-	if err != nil {
-		return fmt.Errorf("locate TinyGo runtime: %w", err)
-	}
-	wasmExec, err := os.ReadFile(filepath.Join(tinygoRoot, "targets", "wasm_exec.js"))
-	if err != nil {
-		return err
-	}
 	if err := write("wasm_exec.js", wasmExec, 0o644); err != nil {
 		return err
 	}
@@ -105,12 +97,50 @@ func generate(languageName, output, tinygo string) error {
 		}
 	}
 
-	encoded, err := json.MarshalIndent(manifest{Version: 1, Language: entry.Name, Assets: assets}, "", "  ")
+	encoded, err := json.MarshalIndent(manifest{Version: 1, Language: entry.Name, Compiler: compiler, Assets: assets}, "", "  ")
 	if err != nil {
 		return err
 	}
 	encoded = append(encoded, '\n')
 	return os.WriteFile(filepath.Join(output, "manifest.json"), encoded, 0o644)
+}
+
+func buildRuntime(root, output, compiler, goBinary, tinygo string) ([]byte, error) {
+	var build *exec.Cmd
+	var wasmExecPath string
+	switch compiler {
+	case "go":
+		build = exec.Command(goBinary, "build", "-trimpath", "-o", output, "./wasm/runtime")
+		build.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
+		goRoot, err := commandOutput(goBinary, "env", "GOROOT")
+		if err != nil {
+			return nil, fmt.Errorf("locate Go runtime: %w", err)
+		}
+		wasmExecPath = filepath.Join(goRoot, "lib", "wasm", "wasm_exec.js")
+		if _, err := os.Stat(wasmExecPath); err != nil {
+			wasmExecPath = filepath.Join(goRoot, "misc", "wasm", "wasm_exec.js")
+		}
+	case "tinygo":
+		build = exec.Command(tinygo, "build", "-target", "wasm", "-no-debug", "-opt=z", "-o", output, "./wasm/runtime")
+		tinygoRoot, err := commandOutput(tinygo, "env", "TINYGOROOT")
+		if err != nil {
+			return nil, fmt.Errorf("locate TinyGo runtime: %w", err)
+		}
+		wasmExecPath = filepath.Join(tinygoRoot, "targets", "wasm_exec.js")
+	default:
+		return nil, fmt.Errorf("unsupported compiler %q", compiler)
+	}
+	build.Dir = root
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		return nil, fmt.Errorf("build runtime with %s: %w", compiler, err)
+	}
+	wasmExec, err := os.ReadFile(wasmExecPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s bootstrap: %w", compiler, err)
+	}
+	return wasmExec, nil
 }
 
 func moduleRoot() (string, error) {

--- a/cmd/wasmassets/main.go
+++ b/cmd/wasmassets/main.go
@@ -1,0 +1,164 @@
+// Command wasmassets builds the persistent gotreesitter WASM runtime and emits
+// a self-contained browser asset bundle for one registered language.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type manifest struct {
+	Version  int               `json:"version"`
+	Language string            `json:"language"`
+	Assets   map[string]string `json:"assets"`
+}
+
+func main() {
+	languageName := flag.String("language", "go", "registered grammar name")
+	output := flag.String("output", "", "output directory")
+	tinygo := flag.String("tinygo", "tinygo", "TinyGo executable")
+	flag.Parse()
+	if strings.TrimSpace(*output) == "" {
+		fatal(errors.New("-output is required"))
+	}
+	if err := generate(*languageName, *output, *tinygo); err != nil {
+		fatal(err)
+	}
+}
+
+func generate(languageName, output, tinygo string) error {
+	entry := grammars.DetectLanguageByName(languageName)
+	if entry == nil {
+		return fmt.Errorf("unknown language %q", languageName)
+	}
+	root, err := moduleRoot()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(output, 0o755); err != nil {
+		return err
+	}
+
+	assets := map[string]string{}
+	write := func(name string, data []byte, mode os.FileMode) error {
+		path := filepath.Join(output, name)
+		if err := os.WriteFile(path, data, mode); err != nil {
+			return err
+		}
+		digest := sha256.Sum256(data)
+		assets[name] = "sha256:" + hex.EncodeToString(digest[:])
+		return nil
+	}
+
+	runtimeName := "gotreesitter.wasm"
+	runtimePath := filepath.Join(output, runtimeName)
+	build := exec.Command(tinygo, "build", "-target", "wasm", "-no-debug", "-opt=z", "-o", runtimePath, "./wasm/runtime")
+	build.Dir = root
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		return fmt.Errorf("build runtime: %w", err)
+	}
+	runtime, err := os.ReadFile(runtimePath)
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256(runtime)
+	assets[runtimeName] = "sha256:" + hex.EncodeToString(digest[:])
+
+	tinygoRoot, err := commandOutput(tinygo, "env", "TINYGOROOT")
+	if err != nil {
+		return fmt.Errorf("locate TinyGo runtime: %w", err)
+	}
+	wasmExec, err := os.ReadFile(filepath.Join(tinygoRoot, "targets", "wasm_exec.js"))
+	if err != nil {
+		return err
+	}
+	if err := write("wasm_exec.js", wasmExec, 0o644); err != nil {
+		return err
+	}
+
+	blobName := entry.Name + ".bin"
+	if err := copyAsset(filepath.Join(root, "grammars", "grammar_blobs", blobName), filepath.Join(output, blobName), assets); err != nil {
+		return err
+	}
+	if strings.TrimSpace(entry.HighlightQuery) == "" {
+		return fmt.Errorf("language %q has no highlight query", entry.Name)
+	}
+	if err := write(entry.Name+"-highlights.scm", []byte(entry.HighlightQuery), 0o644); err != nil {
+		return err
+	}
+	if tags := grammars.ResolveTagsQuery(*entry); strings.TrimSpace(tags) != "" {
+		if err := write(entry.Name+"-tags.scm", []byte(tags), 0o644); err != nil {
+			return err
+		}
+	}
+
+	encoded, err := json.MarshalIndent(manifest{Version: 1, Language: entry.Name, Assets: assets}, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	return os.WriteFile(filepath.Join(output, "manifest.json"), encoded, 0o644)
+}
+
+func moduleRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func commandOutput(name string, args ...string) (string, error) {
+	output, err := exec.Command(name, args...).Output()
+	return strings.TrimSpace(string(output)), err
+}
+
+func copyAsset(source, destination string, assets map[string]string) error {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(output, hash), input)
+	closeErr := output.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	assets[filepath.Base(destination)] = "sha256:" + hex.EncodeToString(hash.Sum(nil))
+	return nil
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "wasmassets:", err)
+	os.Exit(1)
+}

--- a/cmd/wasmassets/main_test.go
+++ b/cmd/wasmassets/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestRuntimeBuildTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		want     string
+		wantErr  bool
+	}{
+		{name: "go", language: "go", want: "grammar_subset,grammar_subset_go"},
+		{name: "underscore", language: "c_sharp", want: "grammar_subset,grammar_subset_c_sharp"},
+		{name: "empty", wantErr: true},
+		{name: "comma", language: "go,grammar_subset_python", wantErr: true},
+		{name: "path", language: "../go", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := runtimeBuildTags(test.language)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("runtimeBuildTags(%q) error = %v, wantErr %v", test.language, err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("runtimeBuildTags(%q) = %q, want %q", test.language, got, test.want)
+			}
+		})
+	}
+}

--- a/highlight.go
+++ b/highlight.go
@@ -171,6 +171,16 @@ func (h *Highlighter) HighlightUTF16(source []uint16) []UTF16HighlightRange {
 	return h.highlightTreeUTF16(tree)
 }
 
+// HighlightTreeUTF16 executes the highlighter query against an already parsed
+// UTF-16 tree. It lets editor runtimes share one persistent parse tree across
+// syntax highlighting, tags, and ad-hoc queries.
+func (h *Highlighter) HighlightTreeUTF16(tree *Tree) []UTF16HighlightRange {
+	if tree == nil || tree.RootNode() == nil {
+		return nil
+	}
+	return h.highlightTreeUTF16(tree)
+}
+
 // HighlightUTF16Bytes is like HighlightUTF16 for endian-specific UTF-16 bytes.
 func (h *Highlighter) HighlightUTF16Bytes(source []byte, order UTF16ByteOrder) ([]UTF16HighlightRange, error) {
 	units, err := DecodeUTF16Bytes(source, order)

--- a/utf16_test.go
+++ b/utf16_test.go
@@ -346,6 +346,24 @@ func TestHighlighterUTF16(t *testing.T) {
 	}
 }
 
+func TestHighlighterHighlightTreeUTF16(t *testing.T) {
+	lang := buildArithmeticLanguage()
+	highlighter, err := NewHighlighter(lang, `(NUMBER) @number`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree, err := NewParser(lang).ParseUTF16(utf16Units("1+2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+
+	ranges := highlighter.HighlightTreeUTF16(tree)
+	if len(ranges) != 2 {
+		t.Fatalf("HighlightTreeUTF16 len = %d, want 2: %+v", len(ranges), ranges)
+	}
+}
+
 func TestHighlighterIncrementalUTF16(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	hl, err := NewHighlighter(lang, `(NUMBER) @number`)

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -24,6 +24,17 @@ cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" dist/wasm_exec.js
 cp wasm/loader.js dist/loader.js
 ```
 
+For a deployable single-language bundle, use the asset command instead. It
+selects only the requested language's tables, registry, and scanner support,
+emits the browser-loaded grammar blob as a separate asset, and writes a digest
+manifest alongside the compiler's matching bootstrap:
+
+```sh
+go run ./cmd/wasmassets -language go -output dist/go -compiler go
+# Or use TinyGo and its matching wasm_exec.js:
+go run ./cmd/wasmassets -language go -output dist/go-tiny -compiler tinygo
+```
+
 Serve these files over HTTP. `WebAssembly.instantiateStreaming` normally
 requires the server to send `.wasm` as `application/wasm`; the shared loader
 falls back to fetching an `ArrayBuffer` when streaming instantiation is not
@@ -50,8 +61,8 @@ highlighting. Unknown out-of-tree names fall back to the blob's DFA tables.
 
 ### API
 
-- `loadBlob(name, blobUint8Array, highlightQuery)` loads one grammar blob. Pass
-  an empty string when no highlight query is available.
+- `loadBlob(name, blobUint8Array, highlightQuery, tagsQuery?)` loads one grammar
+  blob. Pass an empty string for either unavailable query.
 - `parse(name, source)` returns `{ok, sexp, hasError, tree}`. `tree` is a JSON
   string containing the structured syntax tree; parse it once with
   `JSON.parse`. Empty source returns an empty S-expression, `hasError: false`,
@@ -62,6 +73,15 @@ highlighting. Unknown out-of-tree names fall back to the blob's DFA tables.
 - `highlight(name, source)` returns `{ok, ranges}` for the highlight query
   supplied to `loadBlob`. Each range contains `startByte`, `endByte`, and
   `capture`.
+- `open(name, documentID, source)` retains a UTF-16 document tree and returns
+  its initial highlights and tags.
+- `update(documentID, source)` computes a surrogate-safe minimal edit,
+  incrementally reparses the document, and returns its new revision,
+  highlights, tags, and edit span.
+- `queryDocument(documentID, queryText)` runs a bounded query over the retained
+  tree without reparsing source.
+- `close(documentID)` releases the retained tree. Reopening an existing ID
+  replaces and releases the prior document.
 
 Tree nodes contain `type`, `named`, optional `missing`, `error`, and `field`
 properties, plus nested `children`. Their `start`/`end` positions are canonical
@@ -106,6 +126,18 @@ the streaming cursor rather than materializing every match first.
 
 To highlight, pass the language's `highlights.scm` contents as the third
 `loadBlob` argument and then call `api.highlight("go", source)`.
+
+Persistent editor clients can share one tree across analysis operations:
+
+```js
+const opened = api.open("go", "editor:main.go", source);
+const updated = api.update("editor:main.go", source.replace("hello", "world"));
+const matches = api.queryDocument(
+  "editor:main.go",
+  "(function_declaration name: (identifier) @name)",
+);
+api.close("editor:main.go");
+```
 
 ## Grammargen build
 

--- a/wasm/runtime/blob_test.go
+++ b/wasm/runtime/blob_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
 )
 
 func TestRuntimeGoBlobSupportsUTF16Analysis(t *testing.T) {
@@ -12,7 +13,7 @@ func TestRuntimeGoBlobSupportsUTF16Analysis(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	language, err := gotreesitter.LoadLanguage(blob)
+	language, err := grammars.LoadLanguage("go", blob)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wasm/runtime/blob_test.go
+++ b/wasm/runtime/blob_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func TestRuntimeGoBlobSupportsUTF16Analysis(t *testing.T) {
+	blob, err := os.ReadFile("../../grammars/grammar_blobs/go.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	language, err := gotreesitter.LoadLanguage(blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser := gotreesitter.NewParser(language)
+	tree, err := parser.ParseUTF16(units("package main\n\nfunc main() {}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	if tree.RootNode() == nil || tree.RootNode().HasError() {
+		t.Fatalf("unexpected parse tree: %v", tree.RootNode())
+	}
+
+	highlighter, err := gotreesitter.NewHighlighter(language, `(identifier) @identifier`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ranges := highlighter.HighlightTreeUTF16(tree); len(ranges) == 0 {
+		t.Fatal("expected at least one identifier highlight")
+	}
+}

--- a/wasm/runtime/bridge.go
+++ b/wasm/runtime/bridge.go
@@ -11,6 +11,8 @@ import (
 type runtimeLanguage struct {
 	language           *gotreesitter.Language
 	tokenSourceFactory func([]byte) gotreesitter.TokenSource
+	highlighter        *gotreesitter.Highlighter
+	tagger             *gotreesitter.Tagger
 }
 
 func newRuntimeLanguage(name string, lang *gotreesitter.Language) runtimeLanguage {
@@ -29,13 +31,26 @@ func newRuntimeLanguage(name string, lang *gotreesitter.Language) runtimeLanguag
 
 func (l runtimeLanguage) parseUTF16(source string) (*gotreesitter.Tree, error) {
 	parser := gotreesitter.NewParser(l.language)
-	units := utf16.Encode([]rune(source))
-	if l.tokenSourceFactory == nil {
-		return parser.ParseUTF16(units)
+	return l.parseUTF16Units(parser, toUTF16(source), nil)
+}
+
+func (l runtimeLanguage) parseUTF16Units(parser *gotreesitter.Parser, source []uint16, oldTree *gotreesitter.Tree) (*gotreesitter.Tree, error) {
+	if parser == nil {
+		parser = gotreesitter.NewParser(l.language)
 	}
-	return parser.ParseUTF16WithTokenSourceFactory(units, func(source []byte) (gotreesitter.TokenSource, error) {
+	if l.tokenSourceFactory == nil {
+		if oldTree != nil {
+			return parser.ParseIncrementalUTF16(source, oldTree)
+		}
+		return parser.ParseUTF16(source)
+	}
+	factory := func(source []byte) (gotreesitter.TokenSource, error) {
 		return l.tokenSourceFactory(source), nil
-	})
+	}
+	if oldTree != nil {
+		return parser.ParseIncrementalUTF16WithTokenSourceFactory(source, oldTree, factory)
+	}
+	return parser.ParseUTF16WithTokenSourceFactory(source, factory)
 }
 
 func (l runtimeLanguage) newHighlighter(query string) (*gotreesitter.Highlighter, error) {
@@ -47,6 +62,21 @@ func (l runtimeLanguage) newHighlighter(query string) (*gotreesitter.Highlighter
 		query,
 		gotreesitter.WithTokenSourceFactory(l.tokenSourceFactory),
 	)
+}
+
+func (l runtimeLanguage) newTagger(query string) (*gotreesitter.Tagger, error) {
+	if l.tokenSourceFactory == nil {
+		return gotreesitter.NewTagger(l.language, query)
+	}
+	return gotreesitter.NewTagger(
+		l.language,
+		query,
+		gotreesitter.WithTaggerTokenSourceFactory(l.tokenSourceFactory),
+	)
+}
+
+func toUTF16(source string) []uint16 {
+	return utf16.Encode([]rune(source))
 }
 
 // jsonNode is the wire shape of one syntax node in the structured tree the

--- a/wasm/runtime/bridge_test.go
+++ b/wasm/runtime/bridge_test.go
@@ -201,6 +201,54 @@ func TestRuntimeLanguageUsesRegisteredTokenSourceFactory(t *testing.T) {
 	}
 }
 
+func TestRuntimeLanguageIncrementalUTF16UsesRegisteredTokenSourceFactory(t *testing.T) {
+	entry := grammars.DetectLanguageByName("json")
+	if entry == nil {
+		t.Skip("JSON is not included in this grammar subset")
+	}
+	loaded := newRuntimeLanguage("json", entry.Language())
+	if loaded.tokenSourceFactory == nil {
+		t.Fatal("JSON runtime language did not retain its registered token-source factory")
+	}
+
+	factory := loaded.tokenSourceFactory
+	calls := 0
+	loaded.tokenSourceFactory = func(source []byte) gotreesitter.TokenSource {
+		calls++
+		return factory(source)
+	}
+	parser := gotreesitter.NewParser(loaded.language)
+	oldSource := units(`{"name":"gotreesitter"}`)
+	newSource := units(`{"name":"treesitter"}`)
+	oldTree, err := loaded.parseUTF16Units(parser, oldSource, nil)
+	if err != nil {
+		t.Fatalf("parse old source: %v", err)
+	}
+	if oldTree == nil {
+		t.Fatal("parse old source returned no tree")
+	}
+	defer oldTree.Release()
+
+	edit, changed := utf16EditBetween(oldSource, newSource)
+	if !changed || !oldTree.EditUTF16(edit, newSource) {
+		t.Fatalf("apply UTF-16 edit: changed=%v edit=%+v", changed, edit)
+	}
+	newTree, err := loaded.parseUTF16Units(parser, newSource, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	if newTree == nil {
+		t.Fatal("incremental parse returned no tree")
+	}
+	defer newTree.Release()
+	if newTree.RootNode() == nil || newTree.RootNode().HasError() {
+		t.Fatalf("incremental parse returned invalid tree: %v", newTree.RootNode())
+	}
+	if calls != 2 {
+		t.Fatalf("full and incremental token-source factory calls = %d, want 2", calls)
+	}
+}
+
 func TestRuntimeLanguageKeepsGoOnDFA(t *testing.T) {
 	entry := grammars.DetectLanguageByName("go")
 	if entry == nil {

--- a/wasm/runtime/incremental.go
+++ b/wasm/runtime/incremental.go
@@ -1,0 +1,56 @@
+package main
+
+import "github.com/odvcencio/gotreesitter"
+
+// utf16EditBetween returns the smallest replacement that transforms oldSource
+// into newSource. Boundaries are widened when necessary so an edit never
+// splits a UTF-16 surrogate pair.
+func utf16EditBetween(oldSource, newSource []uint16) (gotreesitter.UTF16Edit, bool) {
+	prefix := 0
+	for prefix < len(oldSource) && prefix < len(newSource) && oldSource[prefix] == newSource[prefix] {
+		prefix++
+	}
+	if prefix == len(oldSource) && prefix == len(newSource) {
+		return gotreesitter.UTF16Edit{
+			StartCodeUnit:  uint32(prefix),
+			OldEndCodeUnit: uint32(prefix),
+			NewEndCodeUnit: uint32(prefix),
+		}, false
+	}
+	for prefix > 0 && (!utf16Boundary(oldSource, prefix) || !utf16Boundary(newSource, prefix)) {
+		prefix--
+	}
+
+	oldEnd := len(oldSource)
+	newEnd := len(newSource)
+	for oldEnd > prefix && newEnd > prefix && oldSource[oldEnd-1] == newSource[newEnd-1] {
+		oldEnd--
+		newEnd--
+	}
+	for oldEnd < len(oldSource) && newEnd < len(newSource) &&
+		(!utf16Boundary(oldSource, oldEnd) || !utf16Boundary(newSource, newEnd)) {
+		oldEnd++
+		newEnd++
+	}
+
+	return gotreesitter.UTF16Edit{
+		StartCodeUnit:  uint32(prefix),
+		OldEndCodeUnit: uint32(oldEnd),
+		NewEndCodeUnit: uint32(newEnd),
+	}, true
+}
+
+func utf16Boundary(source []uint16, offset int) bool {
+	if offset <= 0 || offset >= len(source) {
+		return true
+	}
+	return !isLeadSurrogate(source[offset-1]) || !isTrailSurrogate(source[offset])
+}
+
+func isLeadSurrogate(unit uint16) bool {
+	return unit >= 0xd800 && unit <= 0xdbff
+}
+
+func isTrailSurrogate(unit uint16) bool {
+	return unit >= 0xdc00 && unit <= 0xdfff
+}

--- a/wasm/runtime/incremental_test.go
+++ b/wasm/runtime/incremental_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+	"unicode/utf16"
+)
+
+func units(value string) []uint16 {
+	return utf16.Encode([]rune(value))
+}
+
+func TestUTF16EditBetween(t *testing.T) {
+	tests := []struct {
+		name                  string
+		oldSource             string
+		newSource             string
+		start, oldEnd, newEnd uint32
+		changed               bool
+	}{
+		{name: "same", oldSource: "hello", newSource: "hello", start: 5, oldEnd: 5, newEnd: 5},
+		{name: "insert", oldSource: "ab", newSource: "aXb", start: 1, oldEnd: 1, newEnd: 2, changed: true},
+		{name: "replace", oldSource: "hello", newSource: "hullo", start: 1, oldEnd: 2, newEnd: 2, changed: true},
+		{name: "delete", oldSource: "abc", newSource: "ac", start: 1, oldEnd: 2, newEnd: 1, changed: true},
+		{name: "emoji", oldSource: "a😀z", newSource: "a😁z", start: 1, oldEnd: 3, newEnd: 3, changed: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			edit, changed := utf16EditBetween(units(test.oldSource), units(test.newSource))
+			if changed != test.changed || edit.StartCodeUnit != test.start || edit.OldEndCodeUnit != test.oldEnd || edit.NewEndCodeUnit != test.newEnd {
+				t.Fatalf("edit = %+v, changed = %v", edit, changed)
+			}
+		})
+	}
+}

--- a/wasm/runtime/main.go
+++ b/wasm/runtime/main.go
@@ -11,28 +11,45 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
+type runtimeDocument struct {
+	runtime  runtimeLanguage
+	source   []uint16
+	parser   *gotreesitter.Parser
+	tree     *gotreesitter.Tree
+	revision uint64
+}
+
 func main() {
 	js.Global().Set("gotreesitter", js.ValueOf(map[string]interface{}{
-		"parse":     js.FuncOf(parse),
-		"query":     js.FuncOf(query),
-		"highlight": js.FuncOf(highlight),
-		"loadBlob":  js.FuncOf(loadBlob),
-		"version":   js.ValueOf("0.1.0-runtime"),
-		"mode":      js.ValueOf("runtime"),
+		"parse":         js.FuncOf(parse),
+		"query":         js.FuncOf(query),
+		"highlight":     js.FuncOf(highlight),
+		"loadBlob":      js.FuncOf(loadBlob),
+		"open":          js.FuncOf(openDocument),
+		"update":        js.FuncOf(updateDocument),
+		"close":         js.FuncOf(closeDocument),
+		"queryDocument": js.FuncOf(queryDocument),
+		"version":       js.ValueOf("0.2.0-runtime"),
+		"mode":          js.ValueOf("runtime"),
 	}))
 	select {}
 }
 
 var languages = map[string]runtimeLanguage{}
 var highlighters = map[string]*gotreesitter.Highlighter{}
+var documents = map[string]*runtimeDocument{}
 
 func loadBlob(this js.Value, args []js.Value) interface{} {
 	if len(args) < 3 {
-		return err("usage: loadBlob(name, blobUint8Array, highlightQuery)")
+		return err("usage: loadBlob(name, blobUint8Array, highlightQuery, [tagsQuery])")
 	}
 	name := args[0].String()
 	jsArr := args[1]
 	queryText := args[2].String()
+	tagsText := ""
+	if len(args) >= 4 && args[3].Type() == js.TypeString {
+		tagsText = args[3].String()
+	}
 
 	length := jsArr.Get("length").Int()
 	blob := make([]byte, length)
@@ -52,6 +69,15 @@ func loadBlob(this js.Value, args []js.Value) interface{} {
 			return err("highlighter: " + hlErr.Error())
 		}
 	}
+	var tagger *gotreesitter.Tagger
+	if tagsText != "" {
+		tagger, langErr = loaded.newTagger(tagsText)
+		if langErr != nil {
+			return err("tagger: " + langErr.Error())
+		}
+	}
+	loaded.highlighter = hl
+	loaded.tagger = tagger
 
 	// Publish the language and its optional highlighter together only after all
 	// validation succeeds. Reloading without a query intentionally clears an
@@ -63,7 +89,11 @@ func loadBlob(this js.Value, args []js.Value) interface{} {
 		delete(highlighters, name)
 	}
 
-	return ok(map[string]interface{}{"name": name})
+	return ok(map[string]interface{}{
+		"name":         name,
+		"highlighting": hl != nil,
+		"tags":         tagger != nil,
+	})
 }
 
 func parse(this js.Value, args []js.Value) interface{} {
@@ -156,6 +186,190 @@ func highlight(this js.Value, args []js.Value) interface{} {
 		}
 	}
 	return ok(map[string]interface{}{"ranges": jsRanges})
+}
+
+func openDocument(this js.Value, args []js.Value) interface{} {
+	if len(args) < 3 {
+		return err("usage: open(name, documentID, source)")
+	}
+	name, documentID := args[0].String(), args[1].String()
+	if documentID == "" {
+		return err("document id is required")
+	}
+	loaded, has := languages[name]
+	if !has {
+		return err("language not loaded: " + name)
+	}
+
+	source := toUTF16(args[2].String())
+	document := &runtimeDocument{
+		runtime:  loaded,
+		source:   source,
+		parser:   gotreesitter.NewParser(loaded.language),
+		revision: 1,
+	}
+	var parseErr error
+	document.tree, parseErr = loaded.parseUTF16Units(document.parser, source, nil)
+	if parseErr != nil {
+		if document.tree != nil {
+			document.tree.Release()
+		}
+		return err(parseErr.Error())
+	}
+	if document.tree == nil {
+		return err("parse returned no tree")
+	}
+	if previous := documents[documentID]; previous != nil {
+		previous.release()
+	}
+	documents[documentID] = document
+	return document.analysis(false, nil)
+}
+
+func updateDocument(this js.Value, args []js.Value) interface{} {
+	if len(args) < 2 {
+		return err("usage: update(documentID, source)")
+	}
+	documentID := args[0].String()
+	document, has := documents[documentID]
+	if !has {
+		return err("document not open: " + documentID)
+	}
+	newSource := toUTF16(args[1].String())
+	edit, changed := utf16EditBetween(document.source, newSource)
+	if !changed {
+		return document.analysis(true, &edit)
+	}
+	if !document.tree.EditUTF16(edit, newSource) {
+		return err("edit does not align to a UTF-16 boundary")
+	}
+	oldTree := document.tree
+	newTree, parseErr := document.runtime.parseUTF16Units(document.parser, newSource, oldTree)
+	if parseErr != nil {
+		if newTree != nil && newTree != oldTree {
+			newTree.Release()
+		}
+		// EditUTF16 already moved the retained tree into the new coordinate
+		// space. Keep the source synchronized so a later update remains valid.
+		document.source = newSource
+		document.revision++
+		return err(parseErr.Error())
+	}
+	if newTree == nil {
+		return err("incremental parse returned no tree")
+	}
+	document.tree = newTree
+	document.source = newSource
+	document.revision++
+	if oldTree != newTree {
+		oldTree.Release()
+	}
+	return document.analysis(true, &edit)
+}
+
+func closeDocument(this js.Value, args []js.Value) interface{} {
+	if len(args) < 1 {
+		return err("usage: close(documentID)")
+	}
+	documentID := args[0].String()
+	document, has := documents[documentID]
+	if has {
+		document.release()
+		delete(documents, documentID)
+	}
+	return ok(map[string]interface{}{"closed": has})
+}
+
+func queryDocument(this js.Value, args []js.Value) interface{} {
+	if len(args) < 2 {
+		return err("usage: queryDocument(documentID, queryText)")
+	}
+	document, has := documents[args[0].String()]
+	if !has {
+		return err("document not open: " + args[0].String())
+	}
+	q, queryErr := gotreesitter.NewQuery(args[1].String(), document.runtime.language)
+	if queryErr != nil {
+		return err(queryErr.Error())
+	}
+	matches, truncated := executeQueryJSON(q, document.tree, document.runtime.language, maxQueryMatches)
+	return ok(map[string]interface{}{
+		"matches":   queryMatchesForJS(matches),
+		"truncated": truncated,
+	})
+}
+
+func (document *runtimeDocument) analysis(incremental bool, edit *gotreesitter.UTF16Edit) interface{} {
+	root := document.tree.RootNode()
+	result := map[string]interface{}{
+		"revision":    document.revision,
+		"incremental": incremental,
+		"hasError":    root != nil && root.HasError(),
+		"highlights":  []interface{}{},
+		"tags":        []interface{}{},
+	}
+	if document.runtime.highlighter != nil {
+		result["highlights"] = highlightRanges(document.runtime.highlighter.HighlightTreeUTF16(document.tree))
+	}
+	if document.runtime.tagger != nil {
+		result["tags"] = tagRanges(document.runtime.tagger.TagTreeUTF16(document.tree))
+	}
+	if edit != nil {
+		result["edit"] = map[string]interface{}{
+			"start16":  edit.StartCodeUnit,
+			"oldEnd16": edit.OldEndCodeUnit,
+			"newEnd16": edit.NewEndCodeUnit,
+		}
+	}
+	return ok(result)
+}
+
+func (document *runtimeDocument) release() {
+	if document != nil && document.tree != nil {
+		document.tree.Release()
+		document.tree = nil
+	}
+}
+
+func highlightRanges(ranges []gotreesitter.UTF16HighlightRange) []interface{} {
+	result := make([]interface{}, 0, len(ranges))
+	for _, highlight := range ranges {
+		result = append(result, map[string]interface{}{
+			"start16":      highlight.StartCodeUnit,
+			"end16":        highlight.EndCodeUnit,
+			"startPoint":   jsPoint(highlight.StartPoint),
+			"endPoint":     jsPoint(highlight.EndPoint),
+			"capture":      highlight.Capture,
+			"patternIndex": highlight.PatternIndex,
+		})
+	}
+	return result
+}
+
+func tagRanges(tags []gotreesitter.UTF16Tag) []interface{} {
+	result := make([]interface{}, 0, len(tags))
+	for _, tag := range tags {
+		result = append(result, map[string]interface{}{
+			"kind":      tag.Kind,
+			"name":      tag.Name,
+			"range":     jsRange(tag.Range),
+			"nameRange": jsRange(tag.NameRange),
+		})
+	}
+	return result
+}
+
+func jsRange(sourceRange gotreesitter.UTF16Range) map[string]interface{} {
+	return map[string]interface{}{
+		"start16":    sourceRange.StartCodeUnit,
+		"end16":      sourceRange.EndCodeUnit,
+		"startPoint": jsPoint(sourceRange.StartPoint),
+		"endPoint":   jsPoint(sourceRange.EndPoint),
+	}
+}
+
+func jsPoint(point gotreesitter.Point) map[string]interface{} {
+	return map[string]interface{}{"row": point.Row, "column": point.Column}
 }
 
 func ok(extra map[string]interface{}) interface{} {

--- a/wasm/runtime/main.go
+++ b/wasm/runtime/main.go
@@ -20,18 +20,18 @@ type runtimeDocument struct {
 }
 
 func main() {
-	js.Global().Set("gotreesitter", js.ValueOf(map[string]interface{}{
-		"parse":         js.FuncOf(parse),
-		"query":         js.FuncOf(query),
-		"highlight":     js.FuncOf(highlight),
-		"loadBlob":      js.FuncOf(loadBlob),
-		"open":          js.FuncOf(openDocument),
-		"update":        js.FuncOf(updateDocument),
-		"close":         js.FuncOf(closeDocument),
-		"queryDocument": js.FuncOf(queryDocument),
-		"version":       js.ValueOf("0.2.0-runtime"),
-		"mode":          js.ValueOf("runtime"),
-	}))
+	runtime := js.Global().Get("Object").New()
+	runtime.Set("parse", js.FuncOf(parse))
+	runtime.Set("query", js.FuncOf(query))
+	runtime.Set("highlight", js.FuncOf(highlight))
+	runtime.Set("loadBlob", js.FuncOf(loadBlob))
+	runtime.Set("open", js.FuncOf(openDocument))
+	runtime.Set("update", js.FuncOf(updateDocument))
+	runtime.Set("close", js.FuncOf(closeDocument))
+	runtime.Set("queryDocument", js.FuncOf(queryDocument))
+	runtime.Set("version", "0.2.0-runtime")
+	runtime.Set("mode", "runtime")
+	js.Global().Set("gotreesitter", runtime)
 	select {}
 }
 
@@ -374,9 +374,57 @@ func jsPoint(point gotreesitter.Point) map[string]interface{} {
 
 func ok(extra map[string]interface{}) interface{} {
 	extra["ok"] = true
-	return extra
+	return jsObject(extra)
 }
 
 func err(msg string) interface{} {
-	return map[string]interface{}{"ok": false, "error": msg}
+	return jsObject(map[string]interface{}{"ok": false, "error": msg})
+}
+
+// TinyGo's syscall/js.ValueOf intentionally accepts only primitive Go values.
+// Build compound values explicitly so the same runtime works under TinyGo and
+// the standard Go js/wasm target.
+func jsObject(fields map[string]interface{}) js.Value {
+	object := js.Global().Get("Object").New()
+	for key, value := range fields {
+		object.Set(key, jsValue(value))
+	}
+	return object
+}
+
+func jsArray(values []interface{}) js.Value {
+	array := js.Global().Get("Array").New(len(values))
+	for index, value := range values {
+		array.SetIndex(index, jsValue(value))
+	}
+	return array
+}
+
+func jsValue(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return jsObject(typed)
+	case []interface{}:
+		return jsArray(typed)
+	case uint:
+		return float64(typed)
+	case uint8:
+		return float64(typed)
+	case uint16:
+		return float64(typed)
+	case uint32:
+		return float64(typed)
+	case uint64:
+		return float64(typed)
+	case int8:
+		return int(typed)
+	case int16:
+		return int(typed)
+	case int32:
+		return int(typed)
+	case int64:
+		return float64(typed)
+	default:
+		return value
+	}
 }

--- a/wasm/runtime/main.go
+++ b/wasm/runtime/main.go
@@ -148,7 +148,7 @@ func query(this js.Value, args []js.Value) interface{} {
 				res["errorOffset"] = off
 			}
 		}
-		return res
+		return jsObject(res)
 	}
 
 	tree, parseErr := loaded.parseUTF16(args[1].String())
@@ -245,18 +245,29 @@ func updateDocument(this js.Value, args []js.Value) interface{} {
 	}
 	oldTree := document.tree
 	newTree, parseErr := document.runtime.parseUTF16Units(document.parser, newSource, oldTree)
-	if parseErr != nil {
+	if parseErr != nil || newTree == nil {
 		if newTree != nil && newTree != oldTree {
 			newTree.Release()
 		}
-		// EditUTF16 already moved the retained tree into the new coordinate
-		// space. Keep the source synchronized so a later update remains valid.
-		document.source = newSource
-		document.revision++
-		return err(parseErr.Error())
-	}
-	if newTree == nil {
-		return err("incremental parse returned no tree")
+		// Tree.EditUTF16 has already mutated oldTree. A full reparse gives the
+		// document a transactional fallback for parser errors and the defensive
+		// nil-tree/no-error edge instead of retaining a half-updated tree.
+		freshParser := gotreesitter.NewParser(document.runtime.language)
+		newTree, parseErr = document.runtime.parseUTF16Units(freshParser, newSource, nil)
+		if parseErr == nil && newTree != nil {
+			document.parser = freshParser
+		} else {
+			if newTree != nil {
+				newTree.Release()
+			}
+			oldTree.Release()
+			document.tree = nil
+			delete(documents, documentID)
+			if parseErr != nil {
+				return err("update failed and the document was closed: " + parseErr.Error())
+			}
+			return err("update returned no tree and the document was closed")
+		}
 	}
 	document.tree = newTree
 	document.source = newSource


### PR DESCRIPTION
## Summary

- add persistent UTF-16 document open, update, query, highlight, tag, and close operations while preserving the stateless browser APIs
- add reproducible selected-language browser bundles for Go and TinyGo with compiler-matched bootstrap assets and verified SHA-256 manifests
- assemble compound JavaScript results explicitly for Go and TinyGo compatibility, and document the browser workflow

## Validation

- `go test ./cmd/wasmassets`
- `go test ./wasm/runtime`
- focused root UTF-16 and tree-highlighting tests
- selected-language `GOOS=js GOARCH=wasm` build and external-blob load proof
- two byte-identical Go bundle generations with verified manifest digests
- TinyGo 0.40.1 selected-language bundle on the isolated host: exit 0, 9:08 wall, 1,563,240 KiB max RSS; all manifest digests verified
