### PR TITLE
release: v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-07-13
+
+Parser recovery, recurring-work, grammar-contract, and browser-runtime release.
+C-recovery elections and retained memo invalidation reduce fixed overhead;
+retry selection and generated-language provenance are stricter; and the browser
+runtime gains persistent incremental documents plus reproducible selected-
+language bundles for Go and TinyGo.
+
+This release supersedes v0.35.0. That tag was published from incomplete
+ancestry; its browser-runtime changes have been reconciled here with every
+change on the current main line. The v0.35.0 tag remains immutable so existing
+Go module downloads continue to identify one source revision.
+
 ### Added
 
 - The browser runtime now supports persistent UTF-16 documents through
@@ -2383,7 +2396,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.36.0...HEAD
+[0.36.0]: https://github.com/odvcencio/gotreesitter/compare/v0.34.0...v0.36.0
 [0.34.0]: https://github.com/odvcencio/gotreesitter/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/odvcencio/gotreesitter/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/odvcencio/gotreesitter/compare/v0.31.0...v0.32.0

--- a/README.md
+++ b/README.md
@@ -661,11 +661,12 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.34.0**. The 206-grammar curated parity milestone is
-banked. v0.34.0 removes discarded automatic forest work for Beancount, Org,
-Vimdoc, Fish, and Racket, and deletes confirmed-dead C, C++, and Rust
-compatibility passes after full-corpus verification. Detailed history lives in
-[CHANGELOG.md](CHANGELOG.md).
+The current release is **v0.36.0**. The 206-grammar curated parity milestone is
+banked. v0.36.0 reduces recurring recovery work, hardens retry selection and
+generated-language provenance, and adds persistent incremental browser
+documents plus reproducible selected-language Go and TinyGo bundles. It
+supersedes the incomplete v0.35.0 release ancestry without rewriting that
+published Go module tag. Detailed history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ### Now — performance and extreme hygiene
 


### PR DESCRIPTION
## Summary

- roll the accumulated parser recovery, recurring-work, grammar-contract, and browser-runtime changes into v0.36.0
- update the current-release documentation and changelog comparison links
- document v0.36.0 as the corrected cumulative successor to the immutable, incomplete v0.35.0 tag

## Validation

- `git diff --check`
- `go test ./cmd/wasmassets ./wasm/runtime`
- all implementation PRs were independently gated before merge
