### PR TITLE
perf(parser): bound speculative JavaScript forest memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Performance
+
+- Automatic forest dispatch for the exact built-in JavaScript grammar now
+  limits the speculative forest phase to 128 MiB while preserving the caller's
+  full budget for the production fallback and for explicit forest parsing. A
+  20,784-file locked-corpus comparison preserved every tree, byte range, span,
+  error, and stop outcome while reducing aggregate parse time by 3.09%,
+  allocated bytes by 2.96%, and peak RSS by 19.02%. Caller-provided, modified,
+  and same-name grammars retain the existing full-budget behavior.
+
 ## [0.36.0] - 2026-07-13
 
 Parser recovery, recurring-work, grammar-contract, and browser-runtime release.

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -363,7 +363,7 @@ func (p *Parser) ParseForestExperimental(source []byte) (*Tree, bool) {
 	endBudget := p.enterParseBudget()
 	defer endBudget()
 	arena := acquireNodeArena(arenaClassFull)
-	root, ok := p.parseForest(arena, source, true)
+	root, ok := p.parseForest(arena, source, true, parseMemoryBudgetForParser(p, len(source)))
 	if !ok || root == nil {
 		arena.Release()
 		if forestLastDeclineReason == forestDeclineEOFRecoveryConflict {
@@ -555,6 +555,20 @@ func parserWantsForest(p *Parser) bool {
 	return p != nil && p.language != nil && (p.language.WantsForest || builtinForestDefaults[p.language.Name])
 }
 
+func automaticForestMemoryBudget(p *Parser, operationBudget int64) int64 {
+	if p == nil || p.language == nil || operationBudget <= 0 {
+		return operationBudget
+	}
+	allowance := p.language.AutomaticForestMemoryAllowanceBytes
+	if allowance <= 0 {
+		return operationBudget
+	}
+	if allowance > operationBudget {
+		allowance = operationBudget
+	}
+	return allowance
+}
+
 // tryForestFastPath attempts a full parse via the GSS-forest path and returns a
 // Tree on success, or nil to tell the caller to fall back to the production
 // parser. It declines (nil) whenever the forest cannot produce a clean,
@@ -587,7 +601,9 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		progress.endDetail(time.Now(), "forest_arena_acquire_end", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")
 		progress.beginDetail(time.Now(), "forest_parse_call_begin", "forest_parse_call_end", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")
 	}
-	root, ok := p.parseForest(arena, source, allowIncremental)
+	operationBudget := parseMemoryBudgetForParser(p, len(source))
+	forestBudget := automaticForestMemoryBudget(p, operationBudget)
+	root, ok := p.parseForest(arena, source, allowIncremental, forestBudget)
 	if progress.enabled {
 		progress.endDetail(time.Now(), "forest_parse_call_end", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, fmt.Sprintf("ok=%t root_present=%t decline_reason=%s", ok, root != nil, forestLastDeclineReason))
 	}
@@ -2750,7 +2766,7 @@ func (s *gssForestNodeSlab) retainedBytes() int {
 // returned, or (nil,false) if the parse dies. This is the forest path the
 // GOT_GLR_FOREST flag dispatches into; parity-iteration (extras, recovery,
 // external scanners, full GLR-lexing) is layered on this core.
-func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalCheckpoints bool) (*Node, bool) {
+func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalCheckpoints bool, memoryBudget int64) (*Node, bool) {
 	lang := p.language
 	meta := lang.SymbolMetadata
 	named := func(sym Symbol) bool { return int(sym) < len(meta) && meta[sym].Named }
@@ -2792,12 +2808,11 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 	defer releaseGSSForestNodeSlab(slab)
 	linkCap := forestLinkCapForLanguage(lang.Name)
 
-	// Honor the same per-parse memory budget the production loop enforces.
-	// The arena counter covers tree materialization, while the runtime-wide
-	// guard also covers forest-only heap such as GSS slabs and the alternative
-	// indexes. The forest has no partial-tree/error-recovery path, so on
-	// exhaustion it declines and lets the production parser report the stop.
-	restoreRuntimeMemoryBudget := p.enterForestMemoryBudget(arena, len(source))
+	// Apply this attempt's memory limit to both arena-backed tree materialization
+	// and forest-only heap such as GSS slabs and the alternative indexes. The
+	// forest has no partial-tree/error-recovery path, so exhaustion declines and
+	// leaves authoritative completion and stop semantics to the production parser.
+	restoreRuntimeMemoryBudget := p.enterForestMemoryBudgetWithLimit(arena, len(source), memoryBudget)
 	if restoreRuntimeMemoryBudget.parser != nil {
 		defer restoreRuntimeMemoryBudget.restore()
 	}
@@ -2858,8 +2873,9 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 				forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, nil, ""))
 		}
 		if p.forestMemoryBudgetExceeded(arena, false) {
-			// Memory budget hit; decline so the production parser re-runs and
-			// reports ParseStopMemoryBudget (the forest has no partial-tree path).
+			// Memory budget hit; decline so the production parser retains
+			// authoritative completion and stop semantics. The forest has no
+			// partial-tree path and may have a narrower speculative allowance.
 			p.recordForestDecline("budget", Token{StartByte: frontier[len(frontier)-1].byteOffset}, nil)
 			if progress.enabled {
 				progress.emit(time.Now(), "forest_decline", iter, tokens, Token{}, false, nil, 0, 0, 0, false, 0, 0,
@@ -3556,6 +3572,10 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 
 func (p *Parser) enterForestMemoryBudget(arena *nodeArena, sourceLen int) runtimeMemoryBudgetRestore {
 	memoryBudget := parseMemoryBudgetForParser(p, sourceLen)
+	return p.enterForestMemoryBudgetWithLimit(arena, sourceLen, memoryBudget)
+}
+
+func (p *Parser) enterForestMemoryBudgetWithLimit(arena *nodeArena, sourceLen int, memoryBudget int64) runtimeMemoryBudgetRestore {
 	arena.setBudget(memoryBudget)
 	return p.enterRuntimeMemoryBudget(memoryBudget, sourceLen)
 }

--- a/glr_forest_budget_test.go
+++ b/glr_forest_budget_test.go
@@ -57,6 +57,58 @@ func TestEnterForestMemoryBudgetArmsAndRestoresState(t *testing.T) {
 	}
 }
 
+func TestAutomaticForestMemoryBudgetUsesCertifiedProfileAndCaps(t *testing.T) {
+	operationBudget := int64(512 << 20)
+	unprofiled := NewParser(&Language{Name: "javascript"})
+	if got := automaticForestMemoryBudget(unprofiled, operationBudget); got != operationBudget {
+		t.Fatalf("unprofiled allowance = %d, want full budget %d", got, operationBudget)
+	}
+	custom := NewParser(&Language{Name: "custom", WantsForest: true})
+	if got := automaticForestMemoryBudget(custom, operationBudget); got != operationBudget {
+		t.Fatalf("custom WantsForest allowance = %d, want full budget %d", got, operationBudget)
+	}
+	profiled := NewParser(&Language{
+		Name:                                "javascript",
+		AutomaticForestMemoryAllowanceBytes: 128 << 20,
+	})
+	if got := automaticForestMemoryBudget(profiled, operationBudget); got != 128<<20 {
+		t.Fatalf("profiled allowance = %d, want %d", got, 128<<20)
+	}
+	if got := automaticForestMemoryBudget(profiled, 32<<20); got != 32<<20 {
+		t.Fatalf("profiled allowance under smaller operation budget = %d, want %d", got, 32<<20)
+	}
+	if got := automaticForestMemoryBudget(profiled, 0); got != 0 {
+		t.Fatalf("profiled allowance with disabled operation budget = %d, want disabled", got)
+	}
+}
+
+func TestAutomaticForestAllowanceDoesNotChangeExplicitForestBudget(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "512")
+	t.Setenv("GOT_PARSE_MEMORY_HARD_CEILING_MB", "0")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+	DrainArenaPools()
+
+	parser := NewParser(loadBlobForDecode(t, "json"))
+	parser.language.AutomaticForestMemoryAllowanceBytes = 128 << 20
+	explicitArena := acquireNodeArena(arenaClassFull)
+	explicitRestore := parser.enterForestMemoryBudget(explicitArena, parseRuntimeMemoryMinSourceBytes)
+	if got, want := explicitArena.budgetBytes, int64(512<<20); got != want {
+		t.Fatalf("explicit forest arena budget = %d, want full %d", got, want)
+	}
+	explicitRestore.restore()
+	explicitArena.Release()
+
+	automaticArena := acquireNodeArena(arenaClassFull)
+	automaticBudget := automaticForestMemoryBudget(parser, 512<<20)
+	automaticRestore := parser.enterForestMemoryBudgetWithLimit(automaticArena, parseRuntimeMemoryMinSourceBytes, automaticBudget)
+	if got, want := automaticArena.budgetBytes, int64(128<<20); got != want {
+		t.Fatalf("automatic forest arena budget = %d, want allowance %d", got, want)
+	}
+	automaticRestore.restore()
+	automaticArena.Release()
+}
+
 func TestParseForestMemoryBudgetDeclines(t *testing.T) {
 	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "512")
 	t.Setenv("GOT_PARSE_MEMORY_HARD_CEILING_MB", "1")
@@ -72,7 +124,7 @@ func TestParseForestMemoryBudgetDeclines(t *testing.T) {
 	// this makes the regression sensitive to the forest's runtime-wide poll.
 	source := []byte("[" + strings.Repeat("0,", 40_000) + "0]")
 	arena := acquireNodeArena(arenaClassFull)
-	root, ok := parser.parseForest(arena, source, false)
+	root, ok := parser.parseForest(arena, source, false, parseMemoryBudgetForParser(parser, len(source)))
 	arenaBudgetExhausted := arena.budgetExhausted()
 	arena.Release()
 	if ok || root != nil {

--- a/glr_forest_e2e_test.go
+++ b/glr_forest_e2e_test.go
@@ -114,7 +114,8 @@ func mustParseSExpr(t *testing.T, lang *Language, src []byte) string {
 func forestParseSExpr(t *testing.T, lang *Language, src []byte) (string, bool) {
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()
-	root, ok := NewParser(lang).parseForest(arena, src, true)
+	parser := NewParser(lang)
+	root, ok := parser.parseForest(arena, src, true, parseMemoryBudgetForParser(parser, len(src)))
 	if !ok || root == nil {
 		return "", false
 	}

--- a/grammars/blob_export_test.go
+++ b/grammars/blob_export_test.go
@@ -86,6 +86,41 @@ func TestLoadLanguageAttachesCertifiedJavaRetryProfile(t *testing.T) {
 	}
 }
 
+func TestLoadLanguageAttachesCertifiedJavaScriptForestAllowance(t *testing.T) {
+	blob := BlobByName("javascript")
+	if len(blob) == 0 {
+		t.Fatal("expected javascript blob")
+	}
+	lang, err := LoadLanguage("javascript", blob)
+	if err != nil {
+		t.Fatalf("LoadLanguage(javascript) error = %v", err)
+	}
+	if got, want := lang.AutomaticForestMemoryAllowanceBytes, int64(128<<20); got != want {
+		t.Fatalf("LoadLanguage(javascript) automatic forest allowance = %d, want %d", got, want)
+	}
+}
+
+func TestJavaScriptForestAllowanceRequiresExactBuiltinBlobIdentity(t *testing.T) {
+	wrongSHA := [32]byte{1}
+	wrongIdentity := &gotreesitter.Language{Name: "javascript"}
+	if attachBuiltinLanguageRuntimeProfile("javascript", wrongSHA, wrongIdentity) {
+		t.Fatal("wrong blob identity unexpectedly attached a runtime profile")
+	}
+	if got := wrongIdentity.AutomaticForestMemoryAllowanceBytes; got != 0 {
+		t.Fatalf("wrong-identity allowance = %d, want zero", got)
+	}
+
+	blob := BlobByName("javascript")
+	custom, err := gotreesitter.LoadLanguage(blob)
+	if err != nil {
+		t.Fatalf("decode caller-owned javascript blob: %v", err)
+	}
+	custom.WantsForest = true
+	if got := custom.AutomaticForestMemoryAllowanceBytes; got != 0 {
+		t.Fatalf("caller-owned WantsForest allowance = %d, want zero/full-budget behavior", got)
+	}
+}
+
 func TestLoadLanguageAcceptsAliases(t *testing.T) {
 	blob := BlobByName("golang")
 	if len(blob) == 0 {

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -15,6 +15,7 @@ type builtinLanguageRuntimeProfile struct {
 	blobSHA256                         [32]byte
 	externalScannerFullParseRetry      gotreesitter.ExternalScannerFullParseRetryPolicy
 	fullParseAcceptedErrorRetryProfile gotreesitter.FullParseAcceptedErrorRetryProfile
+	automaticForestMemoryAllowance     int64
 	nativeResultCompatibility          gotreesitter.ResultCompatibilityCapability
 	conflictPolicies                   []gotreesitter.ConflictPolicy
 }
@@ -23,9 +24,18 @@ const (
 	csharpAcceptedErrorRetryMaxEntryScratchPeak = 690_365
 	csharpFreshErrorNoStacksRetryMaxStacks      = 16
 	mesonAcceptedErrorRetryMinSourceBytes       = 2 * 1024
+	javascriptAutomaticForestMemoryAllowance    = 128 * 1024 * 1024
 )
 
 var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
+	// JavaScript's speculative automatic forest phase is bounded separately
+	// from the production fallback. The exact locked corpus retained identical
+	// trees and outcomes across all files while cutting aggregate allocations;
+	// explicit forest parsing and non-certified languages keep the full budget.
+	"javascript": {
+		blobSHA256:                     mustRuntimeProfileSHA256("6706f93890f24d8ea90d6a140df5dde29c02ec8a3213bae16e8cc4df37e33ee0"),
+		automaticForestMemoryAllowance: javascriptAutomaticForestMemoryAllowance,
+	},
 	// These scanner-backed grammars have certified the first retry ladder's
 	// selected accepted-error tree as authoritative. Repeating the whole ladder
 	// does not improve the selected tree and imposes a full additional parse.
@@ -302,6 +312,11 @@ func attachBuiltinLanguageRuntimeProfile(name string, blobSHA256 [32]byte, lang 
 	if profile.fullParseAcceptedErrorRetryProfile != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) &&
 		lang.FullParseAcceptedErrorRetryProfile != profile.fullParseAcceptedErrorRetryProfile {
 		lang.FullParseAcceptedErrorRetryProfile = profile.fullParseAcceptedErrorRetryProfile
+		changed = true
+	}
+	if profile.automaticForestMemoryAllowance > 0 &&
+		lang.AutomaticForestMemoryAllowanceBytes != profile.automaticForestMemoryAllowance {
+		lang.AutomaticForestMemoryAllowanceBytes = profile.automaticForestMemoryAllowance
 		changed = true
 	}
 	if missing := profile.nativeResultCompatibility &^ lang.NativeResultCompatibility; missing != 0 {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -34,15 +34,16 @@ func TestBuiltinExternalScannerRetryProfilesAttach(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	// 23 = the prior 19 plus D and Groovy, whose retry ceilings moved out of
+	// 24 = the prior 19 plus D and Groovy, whose retry ceilings moved out of
 	// parser-core name switches and onto exact-blob profiles. The prior gomod
 	// and C additions moved hardcoded compat-tier behavior to profiles. Meson
-	// and Enforce add two exact-blob retry policies. The
+	// and Enforce add two exact-blob retry policies. JavaScript adds one
+	// exact-blob automatic-forest memory allowance. The
 	// repetition-conflict helpers were retired in favor of certified
 	// ConflictPolicies rows here. dot's helper was
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry.
-	if got, want := len(builtinLanguageRuntimeProfiles), 23; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 24; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -54,6 +55,9 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	}
 	if got := lang.FullParseAcceptedErrorRetryProfile; got != (gotreesitter.FullParseAcceptedErrorRetryProfile{}) {
 		t.Fatalf("unknown runtime profile changed accepted-error retry profile to %+v", got)
+	}
+	if got := lang.AutomaticForestMemoryAllowanceBytes; got != 0 {
+		t.Fatalf("unknown runtime profile changed automatic forest allowance to %d", got)
 	}
 }
 

--- a/language.go
+++ b/language.go
@@ -549,6 +549,13 @@ type Language struct {
 	// caller-constructed languages, and language overrides.
 	FullParseAcceptedErrorRetryProfile FullParseAcceptedErrorRetryProfile
 
+	// AutomaticForestMemoryAllowanceBytes bounds only the speculative forest
+	// phase used by automatic dispatch. Zero preserves the full parse budget for
+	// legacy blobs, caller-constructed languages, language overrides, and
+	// explicit ParseForestExperimental calls. Built-in values are certified and
+	// attached only after exact blob-identity verification.
+	AutomaticForestMemoryAllowanceBytes int64
+
 	// NativeResultCompatibility identifies result-tree shapes produced natively
 	// by this exact language artifact. Zero keeps conservative post-parse
 	// compatibility fallbacks for legacy blobs, generated grammars, caller-built


### PR DESCRIPTION
## Summary

- cap automatic forest parsing at 128 MiB for the exact built-in JavaScript blob
- preserve the full caller budget for production fallback and explicit forest parsing
- leave custom, modified, and same-name grammars unchanged through exact SHA validation

## Evidence

- two paired 20,784-file locked-corpus comparisons: zero source, tree, outcome, stop-sequence, or missing-file mismatches
- paired ABBA medians: parse time -3.09%, allocated bytes -2.96%, max RSS -19.02%
- focused Docker root and grammars tests passed (`harness_out/docker/20260714T031137Z`, `oom_killed=false`)
- JavaScript C-oracle profile smoke passed
- canonical full/incremental/no-edit trio remains healthy; both incremental lanes remain zero-allocation

`CHANGELOG.md` records the production-path measurements under Unreleased.