### PR TITLE
Optimize clean GLR cost checks and conflict-frontier bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Fresh full parses now share the parser's existing no-error-payload proof with
+  GSS merge and C-recovery cost selection, avoiding recursive graph and subtree
+  walks until an `ERROR`, `MISSING`, or inherited error is actually
+  constructed. Paired runs of a 148 KiB clean Java witness improved by 43-47%
+  with unchanged full-span acceptance; isolated Go, Python, and Swift corpus
+  parity remained exact, and incremental/reuse parses retain the conservative
+  path.
+- Conflict-reduction frontiers now reuse one fixed-table lookup when reading
+  and updating the `forked` and `seen` flags for a reduction key. Paired runs
+  of a 707 KiB clean Dart witness improved by a further 6-13%, with fresh and
+  incremental C parity unchanged.
 - Automatic forest dispatch for the exact built-in JavaScript grammar now
   limits the speculative forest phase to 128 MiB while preserving the caller's
   full budget for the production fallback and for explicit forest parsing. A

--- a/glr.go
+++ b/glr.go
@@ -198,6 +198,13 @@ type glrMergeScratch struct {
 	cleanZeroBytes   int64
 	cleanZeroStack   []*gssNode
 	cleanZeroVisited []*gssNode
+	// childErrors points at parseInternal's sticky proof for fresh full parses.
+	// false means no ERROR, MISSING, or has-error payload has been constructed
+	// anywhere in this parse, so every GSS path has zero subtree error cost and
+	// the all-links DFS below is unnecessary. Incremental parses start true and
+	// every recovery insertion flips the value before merge/condense observes
+	// the new payload. reset clears the pointer before this scratch is pooled.
+	childErrors *bool
 	// preflight + mergeSeen are pooled per-scratch so the GSS merge can-phase
 	// stops allocating a preflight object plus several maps per merge attempt
 	// (the dominant profile cost on low-stack GLR grammars like json — maps
@@ -226,6 +233,10 @@ type glrMergeScratch struct {
 	// at the top of every mergeStacksWithScratch call so a stale flag from a
 	// previous merge in the same pooled scratch can never leak forward.
 	mergeBudgetStopReason ParseStopReason
+}
+
+func (s *glrMergeScratch) provesNoChildErrors() bool {
+	return s != nil && s.childErrors != nil && !*s.childErrors
 }
 
 type glrCErrorCostEntry struct {
@@ -1967,6 +1978,9 @@ func cStackCleanZeroErrorCostForMerge(scratch *glrMergeScratch, s *glrStack) (ui
 	if s == nil {
 		return 0, true
 	}
+	if scratch.provesNoChildErrors() {
+		return cStackOpenRecoveryCost(s), true
+	}
 	if scratch == nil || len(s.entries) != 0 || s.gss.head == nil {
 		return 0, false
 	}
@@ -3325,6 +3339,9 @@ func gssLinkByteOffset(prev *gssNode, entry stackEntry, seen map[*gssNode]bool) 
 
 func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNode) bool {
 	if n == nil {
+		return true
+	}
+	if scratch.provesNoChildErrors() {
 		return true
 	}
 	var local glrMergeScratch
@@ -5265,6 +5282,7 @@ func (s *glrMergeScratch) reset() {
 		s.cleanZeroVisited = s.cleanZeroVisited[:0]
 	}
 	s.cleanZeroScan = 0
+	s.childErrors = nil
 	s.perKeyCap = 0
 	s.language = nil
 	s.arena = nil

--- a/glr_test.go
+++ b/glr_test.go
@@ -3798,6 +3798,50 @@ func TestGSSCleanZeroAllLinksRejectsErrorBearingPackedPredecessor(t *testing.T) 
 	}
 }
 
+func TestGSSCleanZeroAllLinksFreshParseProofFallsBackAfterError(t *testing.T) {
+	var gssScratch gssScratch
+	childErrors := false
+	mergeScratch := glrMergeScratch{childErrors: &childErrors}
+	mergeScratch.beginEquivEpoch()
+
+	errorEntry := newStackEntryNode(2, NewLeafNode(errorSymbol, true, 0, 1, Point{}, Point{Column: 1}))
+	stackEntryNode(errorEntry).setHasError(true)
+	head := gssScratch.allocNode(errorEntry, nil, 1)
+
+	// parseInternal only exposes the false proof before any error-bearing
+	// payload exists. While it is valid, the hot path must not walk the graph.
+	if !gssNodeCleanZeroErrorAllLinksWithScratch(&mergeScratch, head) {
+		t.Fatal("fresh full-parse clean proof did not bypass the GSS walk")
+	}
+	childErrors = true
+	if gssNodeCleanZeroErrorAllLinksWithScratch(&mergeScratch, head) {
+		t.Fatal("clean-zero proof did not fall back after an error was recorded")
+	}
+}
+
+func TestStackCleanZeroErrorCostFreshParseProofCoversContiguousStacks(t *testing.T) {
+	childErrors := false
+	mergeScratch := glrMergeScratch{childErrors: &childErrors}
+	errorNode := NewLeafNode(errorSymbol, true, 0, 1, Point{}, Point{Column: 1})
+	errorNode.setHasError(true)
+	stack := glrStack{
+		entries: []stackEntry{newStackEntryNode(2, errorNode)},
+		cPaused: true,
+	}
+
+	got, ok := cStackCleanZeroErrorCostForMerge(&mergeScratch, &stack)
+	if want := cStackOpenRecoveryCost(&stack); !ok || got != want {
+		t.Fatalf("fresh full-parse cost proof = (%d, %v), want (%d, true)", got, ok, want)
+	}
+	childErrors = true
+	if _, ok := cStackCleanZeroErrorCostForMerge(&mergeScratch, &stack); ok {
+		t.Fatal("clean-zero cost proof did not fall back after an error was recorded")
+	}
+	if got := cStackErrorCostForMergeCached(&mergeScratch, nil, &stack); got <= cStackOpenRecoveryCost(&stack) {
+		t.Fatalf("fallback cost = %d, want child error cost above open recovery cost", got)
+	}
+}
+
 func TestGSSNodesCanMergeAllowsCleanPackedPredecessorLinks(t *testing.T) {
 	var scratch gssScratch
 	base := scratch.allocNode(stackEntry{state: 1}, nil, 1)

--- a/parser.go
+++ b/parser.go
@@ -3965,7 +3965,9 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	// sticky proof consumed by C-recovery condense: every path that inserts an
 	// ERROR or MISSING payload must flip it before the next condense pass.
 	// Incremental/reuse parses start true because old subtrees may carry errors.
-	trackChildErrors := !deferParentLinks
+	scratch.trackChildErrors = !deferParentLinks
+	trackChildErrors := &scratch.trackChildErrors
+	scratch.merge.childErrors = trackChildErrors
 
 	arena := acquireNodeArena(arenaClass)
 	arena.skipChildClear = reuse == nil && oldTree == nil
@@ -4478,7 +4480,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			&scratch.nodeLinks,
 			scratch.reduce.transientParents,
 			scratch.reduce.transientChildren,
-			!trackChildErrors,
+			!*trackChildErrors,
 			materializationTimingRef,
 		)
 		if tree != nil && !parseStopReasonIsTerminal(stopReason) {
@@ -4572,7 +4574,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 	noTokenProgressHaveLast := false
 	missingShift := parseMissingShiftTracker{lastDepth: -1}
 	tryMissingSingleShift := func(stackIndex int, s *glrStack, currentState StateID) bool {
-		return missingShift.tryInsert(p, source, stackIndex, s, currentState, tok, ts, &nodeCount, arena, scratch, &trackChildErrors)
+		return missingShift.tryInsert(p, source, stackIndex, s, currentState, tok, ts, &nodeCount, arena, scratch, trackChildErrors)
 	}
 
 	for iter := 0; iter < maxIter; iter++ {
@@ -4900,7 +4902,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				preDispatchDefaultReduced := false
 				seen := make(map[externalDefaultReduceSeenKey]int)
 				for step := 0; step < maxConsecutivePrimaryReduces; step++ {
-					if !p.applyExternalNoActionDefaultReduceStep(source, tok, stacks, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors, seen) {
+					if !p.applyExternalNoActionDefaultReduceStep(source, tok, stacks, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors, seen) {
 						break
 					}
 					preDispatchDefaultReduced = true
@@ -4979,7 +4981,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			// in the C error state dispatches through ts_parser__recover
 			// instead of the parse table, except for shiftable tokens.
 			if s.cRec != nil && p.errorCostCompetitionEnabled() {
-				outcome, redispatch, reason := p.cRecoverDispatchInError(&stacks, si, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+				outcome, redispatch, reason := p.cRecoverDispatchInError(&stacks, si, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 				if resultMaterializationShouldStop(reason) {
 					return finalize(stacks, reason)
 				}
@@ -5026,7 +5028,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if actionTiming != nil {
 					actionKindStart = time.Now()
 				}
-				if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+				if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 					anyReduced = true
 					needToken = false
 					goto retryAction
@@ -5035,7 +5037,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					continue
 				}
 				traceVisit(si, s, "extra-shift", 0, len(actions), actions[0])
-				p.applyExtraShiftAction(s, currentState, actions[0], tok, arena, scratch, &trackChildErrors)
+				p.applyExtraShiftAction(s, currentState, actions[0], tok, arena, scratch, trackChildErrors)
 				nodeCount++
 				traceAfterPrimary(si, s)
 				consumeCurrentToken(s)
@@ -5089,7 +5091,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					if !p.guardRealTokenAttachmentGap(source, s, tok, "lex-error") {
 						continue
 					}
-					p.pushLexErrorRunLeaf(s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+					p.pushLexErrorRunLeaf(s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 					consumeCurrentToken(s)
 					if actionTiming != nil {
 						ns := recordNoActionTiming()
@@ -5210,7 +5212,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// silently accepting it — see
 				// TestOpportunisticTopLevelResyncDoesNotLiftNestedDeclarationStarts/java_import_inside_malformed_method.
 				if len(stacks) == 1 && !p.resyncTopLevelLanguage() && !p.errorCostCompetitionEnabled() {
-					switch p.tryOpportunisticTopLevelResyncRecovery(source, s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+					switch p.tryOpportunisticTopLevelResyncRecovery(source, s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 					case resyncRetry:
 						currentState = s.top().state
 						needToken = false
@@ -5244,7 +5246,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					continue
 				}
 				if _, _, hasRecoverAction := p.findRecoverActionOnStack(s, tok.Symbol, timing); !hasRecoverAction &&
-					p.tryRecoverPreviousShiftAsError(s, tok, &nodeCount, arena, &scratch.entries, &trackChildErrors) {
+					p.tryRecoverPreviousShiftAsError(s, tok, &nodeCount, arena, &scratch.entries, trackChildErrors) {
 					anyReduced = true
 					needToken = false
 					consecutiveReduces = 0
@@ -5288,7 +5290,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						continue
 					}
 					p.noteStopActionDiagnostic("no-action-recover", s, tok, recoverAct, 1, false, 0, 0, false)
-					p.applyAction(source, s, recoverAct, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					p.applyAction(source, s, recoverAct, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
 					drainPendingForkStacks()
 					consumeCurrentToken(s)
@@ -5313,7 +5315,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// lookahead, wrap only the popped fragments into an extra
 				// ERROR, and retry there. Runs before the top-level resync so
 				// damage stays contained inside the enclosing construct.
-				if p.tryNearestActionStateRecovery(s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+				if p.tryNearestActionStateRecovery(s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 					currentState = s.top().state
 					needToken = false
 					if actionTiming != nil {
@@ -5329,7 +5331,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// completed valid top-level siblings), and resume there. This keeps
 				// subsequent valid top-level constructs nested under the real root
 				// instead of shredding the rest of the file into flat fragments.
-				switch p.tryResyncErrorRecovery(source, s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+				switch p.tryResyncErrorRecovery(source, s, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 				case resyncRetry:
 					currentState = s.top().state
 					needToken = false
@@ -5349,7 +5351,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if !p.guardRealTokenAttachmentGap(source, s, tok, "error") {
 					continue
 				}
-				p.pushOrExtendErrorNode(s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+				p.pushOrExtendErrorNode(s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 				consumeCurrentToken(s)
 				if actionTiming != nil {
 					ns := recordNoActionTiming()
@@ -5396,7 +5398,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					setPendingTrace("conflict-choice", si, -1, len(actions), chosen)
 					p.noteStopActionDiagnostic("conflict-choice", s, tok, chosen, len(actions), false, 0, 0, false)
 					actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
-					p.applyAction(source, s, chosen, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					p.applyAction(source, s, chosen, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
 					actionAfterState, actionAfterByte, actionAfterDepth := stackTraceState(s)
 					traceAfterPrimary(si, s)
@@ -5410,7 +5412,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							afterByte:           actionAfterByte,
 							afterDepth:          actionAfterDepth,
 							skipRepetitionShift: skipRepetitionShift,
-						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 						traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 					}
 					drainPendingForkStacks()
@@ -5451,7 +5453,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					setPendingTrace("conflict-depth-cap", si, 0, len(actions), actions[0])
 					p.noteStopActionDiagnostic("conflict-depth-cap", s, tok, actions[0], len(actions), false, 0, 0, false)
 					actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
-					p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
 					actionAfterState, actionAfterByte, actionAfterDepth := stackTraceState(s)
 					traceAfterPrimary(si, s)
@@ -5464,7 +5466,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							afterState:  actionAfterState,
 							afterByte:   actionAfterByte,
 							afterDepth:  actionAfterDepth,
-						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+						}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 						traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 					}
 					drainPendingForkStacks()
@@ -5488,7 +5490,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							setPendingTrace("conflict-fork", si, ai, len(actions), actions[ai])
 							p.noteStopActionDiagnostic("conflict-fork", &fork, tok, actions[ai], len(actions), false, 0, 0, false)
 							actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(&fork)
-							p.applyAction(source, &fork, actions[ai], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+							p.applyAction(source, &fork, actions[ai], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 							p.noteStopActionResult(&fork)
 							actionAfterState, actionAfterByte, actionAfterDepth := stackTraceState(&fork)
 							if actions[ai].Type == ParseActionReduce {
@@ -5500,7 +5502,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 									afterState:  actionAfterState,
 									afterByte:   actionAfterByte,
 									afterDepth:  actionAfterDepth,
-								}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+								}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 								frontier := traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, &fork)
 								traceAppend("conflict-fork", si, ai, len(actions), actions[ai], &fork, frontier)
 							} else {
@@ -5536,7 +5538,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				setPendingTrace("conflict-original", si, 0, len(actions), actions[0])
 				p.noteStopActionDiagnostic("conflict-original", s, tok, actions[0], len(actions), false, 0, 0, false)
 				actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
-				p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+				p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 				p.noteStopActionResult(s)
 				actionAfterState, actionAfterByte, actionAfterDepth := stackTraceState(s)
 				traceAfterPrimary(si, s)
@@ -5549,7 +5551,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						afterState:  actionAfterState,
 						afterByte:   actionAfterByte,
 						afterDepth:  actionAfterDepth,
-					}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					}, len(stacks), frontierForkPopulationCap, allocBranchOrder, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					traceFrontier(si, s, traceFrontierResult(actionAfterState, actionAfterByte, actionAfterDepth, s))
 				}
 				if p.glrTrace {
@@ -5575,7 +5577,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				traceVisit(si, s, "single-reduce", 0, len(actions), act)
 				setPendingTrace("single-reduce", si, 0, len(actions), act)
 				p.noteStopActionDiagnostic("single-reduce", s, tok, act, len(actions), false, 0, 0, false)
-				if p.applyActionWithReduceChain(source, s, act, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors) {
+				if p.applyActionWithReduceChain(source, s, act, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors) {
 					forceAdvanceAfterReduce = true
 				}
 				p.noteStopActionResult(s)
@@ -5589,7 +5591,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			} else {
 				switch act.Type {
 				case ParseActionShift:
-					if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+					if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 						anyReduced = true
 						needToken = false
 						goto retryAction
@@ -5599,7 +5601,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					traceVisit(si, s, "single-shift", 0, len(actions), act)
 					p.noteStopActionDiagnostic("single-shift", s, tok, act, len(actions), false, 0, 0, false)
-					p.applyShiftAction(s, act, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+					p.applyShiftAction(s, act, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
 					consumeCurrentToken(s)
@@ -5620,7 +5622,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						recordActionTiming(currentState, tok.Symbol, actions, ambiguityActionSingleAccept, ns)
 					}
 				case ParseActionRecover:
-					if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+					if numStacks == 1 && p.tryMaterializeSkippedRealGap(source, s, currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 						anyReduced = true
 						needToken = false
 						goto retryAction
@@ -5630,7 +5632,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					traceVisit(si, s, "single-recover", 0, len(actions), act)
 					p.noteStopActionDiagnostic("single-recover", s, tok, act, len(actions), false, 0, 0, false)
-					p.applyRecoverAction(s, act, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+					p.applyRecoverAction(s, act, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
 					consumeCurrentToken(s)
@@ -5643,7 +5645,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					traceVisit(si, s, "single-other", 0, len(actions), act)
 					setPendingTrace("single-other", si, 0, len(actions), act)
 					p.noteStopActionDiagnostic("single-other", s, tok, act, len(actions), false, 0, 0, false)
-					p.applyAction(source, s, act, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					p.applyAction(source, s, act, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
 					drainPendingForkStacks()
@@ -5684,7 +5686,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				needToken = false
 				consecutiveReduces = 0
 			} else if _, _, hasRecoverAction := p.findRecoverActionOnStack(&stacks[0], tok.Symbol, timing); !hasRecoverAction &&
-				p.tryRecoverPreviousShiftAsError(&stacks[0], tok, &nodeCount, arena, &scratch.entries, &trackChildErrors) {
+				p.tryRecoverPreviousShiftAsError(&stacks[0], tok, &nodeCount, arena, &scratch.entries, trackChildErrors) {
 				anyReduced = true
 				needToken = false
 				consecutiveReduces = 0
@@ -5694,7 +5696,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						continue
 					}
 					p.noteStopActionDiagnostic("retry-recover", &stacks[0], tok, recoverAct, 1, false, 0, 0, false)
-					p.applyAction(source, &stacks[0], recoverAct, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+					p.applyAction(source, &stacks[0], recoverAct, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(&stacks[0])
 					drainPendingForkStacks()
 					consumeCurrentToken(&stacks[0])
@@ -5705,7 +5707,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if !p.guardRealTokenAttachmentGap(source, &stacks[0], tok, "error") {
 					continue
 				}
-				p.pushOrExtendErrorNode(&stacks[0], currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+				p.pushOrExtendErrorNode(&stacks[0], currentState, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 				consumeCurrentToken(&stacks[0])
 			}
 		}
@@ -5726,7 +5728,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			var resumed bool
 			condenseRan = true
 			var reason ParseStopReason
-			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 			if resultMaterializationShouldStop(reason) {
 				return finalize(stacks, reason)
 			}
@@ -5745,7 +5747,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		postDispatchDefaultReduced := false
 		if anyReduced && !tok.NoLookahead && parseEagerDefaultReduceEnabled() && p.isExternalToken(tok.Symbol) {
 			if relexer, canRelex := ts.(tokenSourceRelexer); canRelex && relexer.CanRelexFromTokenStart(tok) {
-				postDispatchDefaultReduced = p.applyEagerDefaultReduces(source, "post-dispatch", stacks, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, &trackChildErrors)
+				postDispatchDefaultReduced = p.applyEagerDefaultReduces(source, "post-dispatch", stacks, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 				if postDispatchDefaultReduced {
 					drainPendingForkStacks()
 					if !p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch) {
@@ -5806,7 +5808,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				act := actions[0]
 				switch act.Type {
 				case ParseActionShift:
-					if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+					if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 						terminalFrontierOK = false
 						terminalFrontier = terminalFrontier[:0]
 						needToken = false
@@ -5818,7 +5820,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					terminalFrontierConsumes = true
 				case ParseActionRecover:
-					if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+					if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 						terminalFrontierOK = false
 						terminalFrontier = terminalFrontier[:0]
 						needToken = false
@@ -5843,24 +5845,24 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					s := &stacks[item.index]
 					switch item.action.Type {
 					case ParseActionShift:
-						if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+						if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 							terminalFrontierOK = false
 							terminalFrontier = terminalFrontier[:0]
 							needToken = false
 							break
 						}
 						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-shift", s, tok, item.action, 1, false, 0, 0, false)
-						p.applyShiftAction(s, item.action, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+						p.applyShiftAction(s, item.action, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 						p.noteStopActionResult(s)
 					case ParseActionRecover:
-						if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors) {
+						if len(stacks) == 1 && p.tryMaterializeSkippedRealGap(source, s, s.top().state, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors) {
 							terminalFrontierOK = false
 							terminalFrontier = terminalFrontier[:0]
 							needToken = false
 							break
 						}
 						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-recover", s, tok, item.action, 1, false, 0, 0, false)
-						p.applyRecoverAction(s, item.action, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+						p.applyRecoverAction(s, item.action, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 						s.shifted = true
 						p.noteStopActionResult(s)
 					case ParseActionAccept:
@@ -5892,7 +5894,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			var resumed bool
 			condenseRan = true
 			var reason ParseStopReason
-			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, &trackChildErrors)
+			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 			if resultMaterializationShouldStop(reason) {
 				return finalize(stacks, reason)
 			}

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -1877,6 +1877,9 @@ func (p *Parser) cStackErrorCost(s *glrStack) uint32 {
 	if s == nil {
 		return 0
 	}
+	if p != nil && p.mergeScratch.provesNoChildErrors() {
+		return cStackOpenRecoveryCost(s)
+	}
 	var cost uint32
 	if len(s.entries) > 0 {
 		if p != nil && len(p.cNodeMemoCache) != 0 && s.cRec != nil {

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -38,6 +38,22 @@ func TestCVersionStatusAddsPausedSkippedTreeCost(t *testing.T) {
 	}
 }
 
+func TestCStackErrorCostFreshParseProofFallsBackAfterError(t *testing.T) {
+	childErrors := false
+	parser := &Parser{mergeScratch: &glrMergeScratch{childErrors: &childErrors}}
+	errorNode := NewLeafNode(errorSymbol, true, 0, 1, Point{}, Point{Column: 1})
+	errorNode.setHasError(true)
+	stack := glrStack{entries: []stackEntry{newStackEntryNode(2, errorNode)}}
+
+	if got := parser.cStackErrorCost(&stack); got != 0 {
+		t.Fatalf("fresh full-parse proof cost = %d, want 0", got)
+	}
+	childErrors = true
+	if got := parser.cStackErrorCost(&stack); got == 0 {
+		t.Fatal("error cost remained zero after the proof was invalidated")
+	}
+}
+
 func TestCCondenseFreshTreeGatePreservesOpenRecoveryCosts(t *testing.T) {
 	parser := &Parser{language: &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}}
 	open := &Node{symbol: errorSymbol}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -803,15 +803,18 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			return false
 		}
 		currentReduceKey := makeReduceKey(reduce)
+		currentReduceEntry := frontier.entry(currentReduceKey, true)
 		appendTerminalFork := func(fork glrStack) {
 			if allocBranchOrder != nil {
 				fork.branchOrder = allocBranchOrder()
 			}
 			p.pendingFrontierForkStacks = append(p.pendingFrontierForkStacks, fork)
-			frontier.add(currentReduceKey, conflictReduceFrontierForked)
+			if currentReduceEntry != nil {
+				currentReduceEntry.flags |= conflictReduceFrontierForked
+			}
 		}
 		terminalAppended := false
-		terminalAlreadyForked := frontier.has(currentReduceKey, conflictReduceFrontierForked)
+		terminalAlreadyForked := currentReduceEntry != nil && currentReduceEntry.flags&conflictReduceFrontierForked != 0
 		skipTerminalFork := seed.skipRepetitionShift && terminal.Type == ParseActionShift && terminal.Repetition
 		if !skipTerminalFork && !terminalAlreadyForked && frontierForkAdmissible() {
 			switch terminal.Type {
@@ -845,14 +848,16 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 				return false
 			}
 		}
-		if frontier.has(currentReduceKey, conflictReduceFrontierSeen) {
+		if currentReduceEntry != nil && currentReduceEntry.flags&conflictReduceFrontierSeen != 0 {
 			if terminalAppended || terminalAlreadyForked {
 				s.dead = true
 				return true
 			}
 			return false
 		}
-		frontier.add(currentReduceKey, conflictReduceFrontierSeen)
+		if currentReduceEntry != nil {
+			currentReduceEntry.flags |= conflictReduceFrontierSeen
+		}
 		p.noteStopActionDiagnostic("conflict-frontier-fork-reduce", s, tok, reduce, len(actions), true, step, 0, false)
 		p.applyReduceActionDispatch(source, s, reduce, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 		p.noteStopActionResult(s)
@@ -877,10 +882,13 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 		switch act.Type {
 		case ParseActionReduce:
 			key := makeReduceKey(act)
-			if frontier.has(key, conflictReduceFrontierSeen) {
+			entry := frontier.entry(key, true)
+			if entry != nil && entry.flags&conflictReduceFrontierSeen != 0 {
 				return
 			}
-			frontier.add(key, conflictReduceFrontierSeen)
+			if entry != nil {
+				entry.flags |= conflictReduceFrontierSeen
+			}
 			p.noteStopActionDiagnostic("conflict-frontier-reduce", s, tok, act, 1, true, step, 0, false)
 			p.applyReduceActionDispatch(source, s, act, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)

--- a/parser_scratch.go
+++ b/parser_scratch.go
@@ -23,6 +23,7 @@ type parserScratch struct {
 	transientParents         transientParentScratch
 	transientCheckpointBytes int64
 	transientCheckpoints     uint64
+	trackChildErrors         bool
 	budgetBytes              int64
 	budgetBaselineBytes      int64
 	gssBaselineBytes         int64
@@ -149,6 +150,7 @@ func releaseParserScratch(s *parserScratch, skipGSSClear bool) {
 	s.transientParents.resetForRelease()
 	s.transientCheckpointBytes = 0
 	s.transientCheckpoints = 0
+	s.trackChildErrors = false
 	s.entries.reset()
 	s.gss.skipClear = skipGSSClear
 	s.gss.audit = nil

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -7,6 +7,8 @@ import (
 
 func TestGLRMergeScratchResetInvalidatesEquivCacheByEpoch(t *testing.T) {
 	var scratch glrMergeScratch
+	childErrors := false
+	scratch.childErrors = &childErrors
 	scratch.beginEquivEpoch()
 
 	a := &Node{symbol: 1, startByte: 1, endByte: 2, equivVersion: 1}
@@ -18,6 +20,9 @@ func TestGLRMergeScratchResetInvalidatesEquivCacheByEpoch(t *testing.T) {
 
 	before := scratch.equivEpoch
 	scratch.reset()
+	if scratch.childErrors != nil {
+		t.Fatal("reset retained fresh-parse child-error proof pointer")
+	}
 	scratch.beginEquivEpoch()
 	if scratch.equivEpoch == before {
 		t.Fatalf("equiv epoch did not advance after reset: %d", before)


### PR DESCRIPTION
## Summary

- reuse the fresh-parse no-error proof in GLR stack and subtree error-cost checks while retaining open-recovery penalties and conservative incremental behavior
- coalesce repeated same-key conflict-frontier lookups into one stable entry lookup
- add focused proof/reset coverage and record both changes in the unreleased changelog

## Performance receipts

- on a 148 KiB clean Java witness, paired parses improved from 298/334 ms to 159/190 ms
- on a 707 KiB clean Dart witness, the conflict-frontier change improved the clean-proof candidate by a further 6–13%
- the canonical full-parse benchmark remains at 8 allocations per operation; incremental allocation counts are unchanged

## Validation

- `go vet .`
- root package tests in Docker
- isolated real-corpus checks: Go 25/25, Python 25/25, Swift 25/25
- curated Java and Dart fresh-parse parity
- curated Dart incremental parity
- independent implementation and correctness review

The exhaustive CI parity lanes remain required before merge.
