### PR TITLE
Release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-07-14
+
+Full-parse benchmark-integrity, forest-certification, and GLR-performance
+release. Publication now uses one locked static C oracle and authenticated,
+forking real-Go fixtures; authenticated C-first fleet evidence gates automatic
+forest routes; general multi-stack work is reduced; and high-level highlight
+and tag parsing can be bounded. The 206-grammar curated structural-parity
+milestone remains banked.
+
 ### Added
 
 - Highlighter and tagger construction now accept parser timeout options, and
@@ -2512,7 +2521,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/odvcencio/gotreesitter/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/odvcencio/gotreesitter/compare/v0.34.0...v0.36.0
 [0.34.0]: https://github.com/odvcencio/gotreesitter/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/odvcencio/gotreesitter/compare/v0.32.0...v0.33.0

--- a/README.md
+++ b/README.md
@@ -693,12 +693,14 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.36.0**. The 206-grammar curated parity milestone is
-banked. v0.36.0 reduces recurring recovery work, hardens retry selection and
-generated-language provenance, and adds persistent incremental browser
-documents plus reproducible selected-language Go and TinyGo bundles. It
-supersedes the incomplete v0.35.0 release ancestry without rewriting that
-published Go module tag. Detailed history lives in [CHANGELOG.md](CHANGELOG.md).
+The current release is **v0.37.0**. The 206-grammar curated parity milestone is
+banked. v0.37.0 rebuilds full-parse publication on one locked static C oracle
+and authenticated, forking real-Go fixtures; banks general multi-stack parser
+improvements and the first C-certified automatic forest routes; and adds
+bounded high-level highlight and tag parsing. The invalid historical 1.895x
+headline remains withdrawn: the current materialized real-Go baseline is
+5.481673x C by equal-fixture geomean and 6.313799x C for the fixed-suite sum of
+medians. Detailed history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ### Now — performance and extreme hygiene
 


### PR DESCRIPTION
## Summary

- promote the accumulated Unreleased changes to v0.37.0
- update README current-release and corrected full-parse baseline text
- advance changelog comparison links to v0.37.0

## Release contents

- one locked static C oracle and authenticated forking real-Go benchmark fixtures
- authenticated C-first forest certification and exact blob-scoped routes
- general multi-stack parser performance improvements
- bounded high-level highlight and tag parsing
- preserved 206-grammar curated structural parity

## Validation

- constituent code PRs passed compile, race, parity, grammargen, performance, and applicable exhaustive C-oracle gates
- release diff is limited to CHANGELOG.md and README.md
- git diff --check passes