### PR TITLE
perf(harness): authenticate static C fleet baselines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Tooling
+
+- The authenticated fleet scoreboard now times fresh full parses against a
+  per-language, fully static executable built from the locked upstream runtime
+  and grammar sources. Every selected file requires matching static/cgo deep
+  tree digests, and reduction fails closed on missing or mixed oracle identity,
+  dynamic linkage, source/flag drift, or legacy incremental axes. Deep dumps
+  and cgo admissions use iterative cursors with independent wall bounds; C
+  failures retain bounded Go evidence without fabricating ratios. Each file
+  measures one whole Go block and one whole static-C block, alternating their
+  order across file ordinals; compiler/linker absolute paths and executable
+  hashes are part of the serialized protocol. The reducer preserves complete,
+  typed C-oracle failures as authenticated closure
+  failures while rejecting untyped, generic, or incomplete evidence. Admission,
+  parser, transport, digest, measurement, and protocol failures now have a
+  closed serialized status vocabulary. Content-keyed
+  static executables are atomically installed with build-key/artifact-hash
+  manifests only after a post-link recheck of the captured compiler, linker,
+  pinned source trees, and every compiled source hash; cache hits repeat that
+  check before use, and unstable inputs are recaptured once before failing.
+  Shards execute a reverified private artifact snapshot, and per-language
+  wall/RSS stops kill the entire child process group. The budget and status
+  tools read both schema generations while keeping v1
+  historical ratchets separate from v2 full-only hard-gate verdicts.
+
 ## [0.37.0] - 2026-07-14
 
 Full-parse benchmark-integrity, forest-certification, and GLR-performance

--- a/cgo_harness/c_oracle_contract_test.go
+++ b/cgo_harness/c_oracle_contract_test.go
@@ -4,15 +4,76 @@ package cgoharness
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 	sitter "github.com/tree-sitter/go-tree-sitter"
 )
+
+func TestCOracleDeepDigestIterativeDeepAndWide(t *testing.T) {
+	language, err := COracleLanguage("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	fixtures := map[string]string{
+		"deep": strings.Repeat("[", 4096) + "0" + strings.Repeat("]", 4096),
+		"wide": "[" + strings.Repeat("0,", 20000) + "0]",
+	}
+	for name, source := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			tree := parser.Parse([]byte(source), nil)
+			if tree == nil || tree.RootNode() == nil || tree.RootNode().HasError() {
+				if tree != nil {
+					tree.Close()
+				}
+				t.Fatal("C oracle did not produce a complete regression tree")
+			}
+			defer tree.Close()
+			bounded, err := cOracleDeepDigestWithin(tree, 10*time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unbounded, err := COracleDeepDigest(tree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bounded != unbounded || len(bounded) != 64 {
+				t.Fatalf("digest mismatch bounded=%q unbounded=%q", bounded, unbounded)
+			}
+		})
+	}
+}
+
+func TestCOracleDeepDigestWallTimeout(t *testing.T) {
+	language, err := COracleLanguage("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatal(err)
+	}
+	tree := parser.Parse([]byte("[0,1,2,3]"), nil)
+	if tree == nil {
+		t.Fatal("C oracle returned nil timeout fixture")
+	}
+	defer tree.Close()
+	if _, err := cOracleDeepDigestWithin(tree, 0); !errors.Is(err, errCOracleDeepDigestTimeout) {
+		t.Fatalf("digest timeout error=%v", err)
+	}
+}
 
 func TestCOracleContractPreflight(t *testing.T) {
 	identity, err := COracleIdentity("go")

--- a/cgo_harness/cmd/perf_scan_budget/main.go
+++ b/cgo_harness/cmd/perf_scan_budget/main.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	budgetSchema     = "gts-perf-ratio-budgets/v1"
-	scoreboardSchema = "gts-perf-scan/v1"
+	budgetSchema       = "gts-perf-ratio-budgets/v1"
+	scoreboardSchemaV1 = "gts-perf-scan/v1"
+	scoreboardSchemaV2 = "gts-perf-scan/v2"
 
 	axisFull   = "full"
 	axisNoEdit = "noedit"
@@ -305,8 +306,17 @@ type compareOptions struct {
 
 func compareScoreboard(b *budgetFile, s *scoreboardFile, opts compareOptions) []evalFinding {
 	var out []evalFinding
-	if s.Schema != scoreboardSchema {
-		out = append(out, evalFinding{Metric: "scoreboard.schema", Got: s.Schema, Want: scoreboardSchema})
+	switch s.Schema {
+	case scoreboardSchemaV1:
+		if opts.HardGateOnly {
+			out = append(out, evalFinding{Metric: "scoreboard.schema_mode", Got: s.Schema, Want: scoreboardSchemaV2 + " for a current hard-gate verdict"})
+		}
+	case scoreboardSchemaV2:
+		if !opts.HardGateOnly {
+			out = append(out, evalFinding{Metric: "scoreboard.schema_mode", Got: s.Schema, Want: "--hard-gate-only (historical v1 aggregate ratchets are not comparable to the static full-only transport)"})
+		}
+	default:
+		out = append(out, evalFinding{Metric: "scoreboard.schema", Got: s.Schema, Want: scoreboardSchemaV1 + " or " + scoreboardSchemaV2})
 	}
 	if opts.StrictConfig {
 		out = append(out, compareConfig(b.MeasurementBasis, s.Config, opts.HardGateOnly)...)
@@ -505,9 +515,15 @@ func compareConfig(b budgetMeasurementBasis, s scoreboardConfig, hardGateOnly bo
 	if b.Order != "" && s.Order != b.Order {
 		out = append(out, evalFinding{Metric: "config.order", Got: s.Order, Want: b.Order})
 	}
-	for _, axis := range b.Axes {
-		if !contains(s.Axes, axis) {
-			out = append(out, evalFinding{Axis: axis, Metric: "config.axes", Got: strings.Join(s.Axes, ","), Want: "include " + axis})
+	if hardGateOnly {
+		if len(s.Axes) != 1 || s.Axes[0] != axisFull {
+			out = append(out, evalFinding{Axis: axisFull, Metric: "config.axes", Got: strings.Join(s.Axes, ","), Want: axisFull + " only"})
+		}
+	} else {
+		for _, axis := range b.Axes {
+			if !contains(s.Axes, axis) {
+				out = append(out, evalFinding{Axis: axis, Metric: "config.axes", Got: strings.Join(s.Axes, ","), Want: "include " + axis})
+			}
 		}
 	}
 	if hardGateOnly {

--- a/cgo_harness/cmd/perf_scan_budget/main_test.go
+++ b/cgo_harness/cmd/perf_scan_budget/main_test.go
@@ -144,6 +144,7 @@ func TestCompareScoreboardHardGateOnlyUsesUniversalUnexcludedBasis(t *testing.T)
 	lang.FullAxis.MaxRatioByTotal = 1
 	b.Languages["go"] = lang
 	s := testScoreboard(2.5, 0, 0)
+	makeV2FullBoard(s)
 
 	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true, HardGateOnly: true})
 	if len(findings) != 0 {
@@ -154,6 +155,41 @@ func TestCompareScoreboardHardGateOnlyUsesUniversalUnexcludedBasis(t *testing.T)
 	findings = compareScoreboard(b, s, compareOptions{StrictConfig: true, HardGateOnly: true})
 	if got := renderFindingKeys(findings); !strings.Contains(got, "::config.exclude_paths") {
 		t.Fatalf("hard-gate-only comparison accepted an exclusion: %q (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardKeepsV1HistoricalAndV2HardGateModesSeparate(t *testing.T) {
+	b := testBudget()
+
+	legacy := testScoreboard(1.5, 0, 0)
+	findings := compareScoreboard(b, legacy, compareOptions{StrictConfig: true, HardGateOnly: true})
+	if got := renderFindingKeys(findings); !strings.Contains(got, "::scoreboard.schema_mode") {
+		t.Fatalf("v1 scoreboard established a current hard-gate verdict: %q (%#v)", got, findings)
+	}
+
+	current := testScoreboard(1.5, 0, 0)
+	makeV2FullBoard(current)
+	findings = compareScoreboard(b, current, compareOptions{StrictConfig: true})
+	if got := renderFindingKeys(findings); !strings.Contains(got, "::scoreboard.schema_mode") {
+		t.Fatalf("v2 scoreboard entered historical aggregate comparison: %q (%#v)", got, findings)
+	}
+
+	current.Schema = "gts-perf-scan/v99"
+	findings = compareScoreboard(b, current, compareOptions{StrictConfig: true, HardGateOnly: true})
+	if got := renderFindingKeys(findings); !strings.Contains(got, "::scoreboard.schema") {
+		t.Fatalf("unknown scoreboard schema was accepted: %q (%#v)", got, findings)
+	}
+}
+
+func TestCompareScoreboardV2HardGateRequiresFullOnlyAxis(t *testing.T) {
+	b := testBudget()
+	s := testScoreboard(1.5, 0, 0)
+	makeV2FullBoard(s)
+	s.Config.Axes = []string{axisFull, axisNoEdit}
+
+	findings := compareScoreboard(b, s, compareOptions{StrictConfig: true, HardGateOnly: true})
+	if got := renderFindingKeys(findings); !strings.Contains(got, ":full:config.axes") {
+		t.Fatalf("v2 publication admitted a legacy axis: %q (%#v)", got, findings)
 	}
 }
 
@@ -378,7 +414,7 @@ func TestMainWritesMarkdownSummary(t *testing.T) {
   }
 }`)
 	writeFile(t, scoreboardPath, `{
-  "schema": "gts-perf-scan/v1",
+	  "schema": "gts-perf-scan/v1",
   "config": {"reps": 5, "warmup": 1, "file_budget_ms": 10000, "max_files": 8, "order": "largest", "axes": ["full", "noedit"], "hard_gate": true, "corpus_lock_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
   "corpus_coverage": {"lock_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "lock_languages": 1, "selected_languages": 1},
   "hard_gate": {"status": "pass", "max_full_parse_ratio": 10, "fast_full_parse_ratio": 0.1, "files_expected": 1, "files_measured": 1, "full_files_evaluated": 1},
@@ -470,7 +506,7 @@ func testScoreboard(fullRatio float64, timeouts, errors int) *scoreboardFile {
 		}})
 	}
 	return &scoreboardFile{
-		Schema: scoreboardSchema,
+		Schema: scoreboardSchemaV1,
 		Config: scoreboardConfig{
 			Reps:             5,
 			Warmup:           1,
@@ -515,6 +551,17 @@ func testScoreboard(fullRatio float64, timeouts, errors int) *scoreboardFile {
 			FilesMeasured:      len(files),
 			FullFilesEvaluated: len(files),
 		},
+	}
+}
+
+func makeV2FullBoard(s *scoreboardFile) {
+	s.Schema = scoreboardSchemaV2
+	s.Config.Axes = []string{axisFull}
+	for i := range s.Languages {
+		delete(s.Languages[i].Axes, axisNoEdit)
+		for j := range s.Languages[i].Files {
+			delete(s.Languages[i].Files[j].Axes, axisNoEdit)
+		}
 	}
 }
 

--- a/cgo_harness/cmd/perf_scan_status/main.go
+++ b/cgo_harness/cmd/perf_scan_status/main.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	statusSchema     = "gts-wave3-perf-sweep-status/v1"
-	budgetSchema     = "gts-perf-ratio-budgets/v1"
-	scoreboardSchema = "gts-perf-scan/v1"
+	statusSchema       = "gts-wave3-perf-sweep-status/v1"
+	budgetSchema       = "gts-perf-ratio-budgets/v1"
+	scoreboardSchemaV1 = "gts-perf-scan/v1"
+	scoreboardSchemaV2 = "gts-perf-scan/v2"
 )
 
 type options struct {
@@ -283,6 +284,7 @@ type scoreboardCoverage struct {
 
 type scoreboardSummary struct {
 	Path             string         `json:"path"`
+	Schema           string         `json:"schema"`
 	GeneratedAt      string         `json:"generated_at,omitempty"`
 	Languages        int            `json:"languages"`
 	BudgetLanguages  int            `json:"budget_languages"`
@@ -442,7 +444,7 @@ func buildStatus(opts options) (*statusDocument, error) {
 			doc.Caveats = append(doc.Caveats, "At least one local scoreboard was harness-flagged as contended; treat those ratios as smoke or visibility evidence rather than quiet-box ratchets.")
 		}
 		if doc.ScoreboardCoverage.LegacyScoreboards > 0 {
-			doc.Caveats = append(doc.Caveats, "Legacy scoreboards remain readable, but they predate the structured hard-gate report and are shown as not_evaluated; rerun the harness for a fail-closed verdict.")
+			doc.Caveats = append(doc.Caveats, "Historical v1 scoreboards and v2 scoreboards without a structured hard-gate report remain readable but are shown as not_evaluated; rerun the current harness for a fail-closed verdict.")
 		}
 	}
 
@@ -552,7 +554,7 @@ func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet 
 		gateFailureCount := 0
 		fullFilesChecked := 0
 		fastFullFiles := 0
-		if board.Gate == nil {
+		if board.Schema != scoreboardSchemaV2 || board.Gate == nil {
 			legacyBoards++
 		} else {
 			hardGateBoards++
@@ -575,6 +577,7 @@ func summarizeScoreboards(paths []string, budgetSet map[string]bool, heldOutSet 
 		}
 		summaries = append(summaries, scoreboardSummary{
 			Path:             path,
+			Schema:           board.Schema,
 			GeneratedAt:      board.GeneratedAt,
 			Languages:        len(board.Languages),
 			BudgetLanguages:  budgetLangs,
@@ -666,8 +669,8 @@ func loadScoreboard(path string) (*scoreboardFile, error) {
 	if err := json.Unmarshal(data, &out); err != nil {
 		return nil, fmt.Errorf("decode scoreboard %s: %w", path, err)
 	}
-	if out.Schema != scoreboardSchema {
-		return nil, fmt.Errorf("scoreboard %s schema %q, want %q", path, out.Schema, scoreboardSchema)
+	if out.Schema != scoreboardSchemaV1 && out.Schema != scoreboardSchemaV2 {
+		return nil, fmt.Errorf("scoreboard %s schema %q, want %q or %q", path, out.Schema, scoreboardSchemaV1, scoreboardSchemaV2)
 	}
 	out.SourcePath = path
 	return &out, nil

--- a/cgo_harness/cmd/perf_scan_status/main_test.go
+++ b/cgo_harness/cmd/perf_scan_status/main_test.go
@@ -117,7 +117,7 @@ func TestBuildStatusWithScoreboards(t *testing.T) {
 		},
 	})
 	writeJSON(t, scoreboardPath, map[string]any{
-		"schema":       scoreboardSchema,
+		"schema":       scoreboardSchemaV1,
 		"generated_at": "2026-07-09T04:34:09Z",
 		"config": map[string]any{
 			"reps": 5, "warmup": 1, "file_budget_ms": 10000, "lang_timeout_ms": 900000,
@@ -199,7 +199,7 @@ func TestBuildStatusReportsStructuredHardGateAndFastFiles(t *testing.T) {
 		},
 	})
 	writeJSON(t, scoreboardPath, map[string]any{
-		"schema": scoreboardSchema,
+		"schema": scoreboardSchemaV2,
 		"config": map[string]any{
 			"hard_gate": true, "require_fleet": true,
 			"corpus_lock_sha256": strings.Repeat("a", 64),
@@ -238,11 +238,31 @@ func TestBuildStatusReportsStructuredHardGateAndFastFiles(t *testing.T) {
 	if doc.ScoreboardCoverage.FastFullParseFiles != 1 || len(doc.FastFullFiles) != 1 {
 		t.Fatalf("fast-file accounting = %+v / %+v", doc.ScoreboardCoverage, doc.FastFullFiles)
 	}
+	if len(doc.Scoreboards) != 1 || doc.Scoreboards[0].Schema != scoreboardSchemaV2 {
+		t.Fatalf("scoreboard schema provenance = %+v", doc.Scoreboards)
+	}
 	md := renderMarkdown(doc)
 	for _, needle := range []string{"hard-gate passes", "Full-parse files at least 10x faster than C", "fast.go"} {
 		if !strings.Contains(md, needle) {
 			t.Fatalf("markdown missing %q:\n%s", needle, md)
 		}
+	}
+}
+
+func TestLoadScoreboardAcceptsHistoricalAndCurrentSchemasOnly(t *testing.T) {
+	dir := t.TempDir()
+	for _, schema := range []string{scoreboardSchemaV1, scoreboardSchemaV2} {
+		path := filepath.Join(dir, strings.ReplaceAll(schema, "/", "_")+".json")
+		writeJSON(t, path, map[string]any{"schema": schema})
+		if _, err := loadScoreboard(path); err != nil {
+			t.Fatalf("loadScoreboard(%q): %v", schema, err)
+		}
+	}
+
+	path := filepath.Join(dir, "unknown.json")
+	writeJSON(t, path, map[string]any{"schema": "gts-perf-scan/v99"})
+	if _, err := loadScoreboard(path); err == nil {
+		t.Fatal("loadScoreboard accepted an unknown schema")
 	}
 }
 

--- a/cgo_harness/parity_c_loader_cgo.go
+++ b/cgo_harness/parity_c_loader_cgo.go
@@ -43,6 +43,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"os"
@@ -274,16 +275,61 @@ func COracleIdentity(name string) (COracleBuildIdentity, error) {
 // identity through type+named, byte and point spans, extra/missing/error
 // flags, child order and incoming field identity.
 func COracleDeepDigest(tree *sitter.Tree) (string, error) {
+	return cOracleDeepDigest(tree, time.Time{})
+}
+
+var errCOracleDeepDigestTimeout = errors.New("C oracle deep digest exceeded wall timeout")
+
+// cOracleDeepDigestWithin applies a wall bound to digest materialization. The
+// parser timeout has already ended when admission reaches this walk, so the
+// digest needs its own independent bound.
+func cOracleDeepDigestWithin(tree *sitter.Tree, timeout time.Duration) (string, error) {
+	if timeout <= 0 {
+		return "", errCOracleDeepDigestTimeout
+	}
+	return cOracleDeepDigest(tree, time.Now().Add(timeout))
+}
+
+func cOracleDeepDigest(tree *sitter.Tree, deadline time.Time) (string, error) {
 	if tree == nil || tree.RootNode() == nil {
 		return "", fmt.Errorf("cannot digest nil C oracle tree")
 	}
+	checkDeadline := func() error {
+		if !deadline.IsZero() && !time.Now().Before(deadline) {
+			return errCOracleDeepDigestTimeout
+		}
+		return nil
+	}
+	if err := checkDeadline(); err != nil {
+		return "", err
+	}
 	h := sha256.New()
 	_, _ = h.Write([]byte("gts-deep-tree-v1\x00"))
-	writeCOracleDeepNode(h, tree.RootNode(), "")
-	return hex.EncodeToString(h.Sum(nil)), nil
+	root := tree.RootNode()
+	cursor := root.Walk()
+	defer cursor.Close()
+	writeCOracleDeepNodeHeader(h, root, "")
+	for {
+		if err := checkDeadline(); err != nil {
+			return "", err
+		}
+		if cursor.GotoFirstChild() {
+			writeCOracleDeepNodeHeader(h, cursor.Node(), cursor.FieldName())
+			continue
+		}
+		for !cursor.GotoNextSibling() {
+			if err := checkDeadline(); err != nil {
+				return "", err
+			}
+			if !cursor.GotoParent() {
+				return hex.EncodeToString(h.Sum(nil)), nil
+			}
+		}
+		writeCOracleDeepNodeHeader(h, cursor.Node(), cursor.FieldName())
+	}
 }
 
-func writeCOracleDeepNode(h hash.Hash, node *sitter.Node, field string) {
+func writeCOracleDeepNodeHeader(h hash.Hash, node *sitter.Node, field string) {
 	writeCOracleDeepString(h, node.Kind())
 	writeCOracleDeepString(h, field)
 	writeCOracleDeepU32(h, uint32(node.StartByte()))
@@ -313,9 +359,6 @@ func writeCOracleDeepNode(h hash.Hash, node *sitter.Node, field string) {
 	_, _ = h.Write([]byte{flags})
 	childCount := node.ChildCount()
 	writeCOracleDeepU32(h, uint32(childCount))
-	for i := uint(0); i < childCount; i++ {
-		writeCOracleDeepNode(h, node.Child(i), node.FieldNameForChild(uint32(i)))
-	}
 }
 
 func writeCOracleDeepU32(h hash.Hash, value uint32) {

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -2,9 +2,8 @@
 
 Measures gotreesitter (pure Go) against the C tree-sitter reference, per
 language, on real corpus files, and emits a scoreboard (JSON + markdown).
-This is the measurement half of the "drop-in tree-sitter replacement" bar:
-universal C-similar performance on full parse / no-edit reparse /
-incremental edit.
+This is the measurement half of the fresh full-parse performance bar:
+universal C-similar performance on materialized trees from real source files.
 
 The tool lives in `cgo_harness/zz_perf_scan_test.go` behind the build tags
 `treesitter_c_parity treesitter_c_perfscan` — it never compiles into normal
@@ -13,17 +12,66 @@ builds or the parity suites. Outputs land under `cgo_harness/perf_scan/out/`
 
 ## What is measured (per language, per file)
 
-| axis | Go side | C side | default |
+| axis | Go side | C side | authoritative |
 |---|---|---|---|
-| `full` | `Parser.Parse` / `ParseWithTokenSource` (fresh) | `ts_parser_parse(NULL, src)` | on |
-| `noedit` | `ParseIncremental(src, oldTree)`, unchanged source | `ts_parser_parse(oldTree, src)` | on |
-| `edit` | single-byte replace + `Tree.Edit` + incremental reparse | same via C `Tree.Edit` | opt-in (`GTS_PERF_SCAN_AXES=full,noedit,edit`) |
+| `full` | `Parser.Parse` / `ParseWithTokenSource` (fresh) | locked upstream `ts_parser_parse_string(NULL, src)` in a fully static sidecar | yes |
 
-Protocol per file/axis: `warmup` untimed attempts, then `reps` timed attempts
-alternating Go/C (drift-resistant on shared boxes); the reported number is the
-median, with min/max recorded. Per-file ratio = Go median / C median. Language
-aggregate = ratio-by-total (sum of Go medians / sum of C medians) plus
-median-of-file-ratios.
+Protocol per file: `warmup` untimed attempts, then `reps` timed attempts on
+each implementation; the reported number is the median, with min/max recorded.
+The C timing process loads the immutable source snapshot and constructs its
+parser before sampling. Its timer covers only `ts_parser_parse_string`; process
+startup, source loading, parser setup, and tree deletion are excluded. Go
+sampling retains the existing parser and parse-call timing path. To avoid a
+systematic implementation-order bias while keeping C process setup outside the
+timer, each selected file contains one whole Go measurement block and one whole
+static-C measurement block. Their order alternates across selected-file
+ordinals; there is no within-file AB/BA interleaving or per-repetition
+alternation. The language-name SHA-256 low bit selects the first file's block
+order, so one-file rows start on different sides across the fleet. The common
+protocol and each file's actual order are serialized and reducer-checked.
+Per-file ratio = Go median / C median. Language aggregate = ratio-by-total
+(sum of Go medians / sum of C medians) plus median-of-file-ratios.
+
+Before accepting any C sample, the harness parses that exact source through
+both the in-process parity binding and the fully static sidecar and requires an
+identical `gts-deep-tree-v1` digest. Each shard serializes the locked binding,
+runtime, grammar, parser/scanner source hashes, exact C/C++ compile and static
+link flags, compiler/linker paths, versions, executable hashes, artifact hash,
+linkage proof, and every per-file admission digest. The reducer rejects missing
+or mixed identity,
+dynamic linkage, wrong commits or flags, and absent deep admission. The
+content-keyed artifact cache installs the executable and a build-key/artifact-
+hash manifest together by atomic directory rename. After linking and before a
+manifest or shared cache path becomes visible, the harness rechecks the
+already-resolved compiler/linker versions and hashes, pinned runtime/grammar
+worktrees and tree identities, and every runtime/parser/scanner/driver hash
+used by that build. Cache hits repeat the same input check before use. Drift
+retries once from a fresh identity capture and generated-source workspace;
+persistent instability fails closed. Reuse also rechecks the manifest,
+executable hash, required symbols, and static linkage; an absent or mismatched
+manifest quarantines the entry and forces a verified rebuild.
+After validation, execution uses a private copy whose hash and linkage are
+reverified, so replacing the shared cache path cannot change an in-flight
+shard's executable. This closes realistic same-user concurrent source/tool/cache
+replacement; it does not claim adversarial protection from a privileged actor
+that can alter a running compiler or process memory. Publication schema is
+fresh-full-only. Legacy `noedit` and `edit` diagnostics
+can still be requested locally, but any such shard is reducer-inadmissible.
+
+Deep admission uses iterative tree cursors in both the static sidecar and the
+in-process cgo binding, so deep or wide witnesses do not consume one call-stack
+frame per syntax node. The dump parse and cgo digest each have an explicit
+wall bound independent of the parser timeout. Admission, parser, transport,
+digest, measurement, and protocol failures use a closed `c_oracle_*`
+vocabulary with distinct parser/transport/digest timeout statuses; generic
+`c_error` and `c_oracle_error` evidence is inadmissible. Any C timeout,
+incomplete tree, transport error, or digest mismatch fails the hard gate, but
+it does not suppress the bounded Go full parse: Go completion/stop
+classification and timing evidence are still emitted, with no fabricated
+ratio. The reducer accepts such a row as authenticated failure evidence only
+when its source hash, typed C status/detail, measurement order, static identity,
+and bounded Go evidence are complete; missing or contradictory provenance
+remains inadmissible.
 
 The full axis also records an untimed corpus-policy classification for each
 file. `clean` requires a successful Go parse whose root spans `[0,len(source))`,
@@ -61,11 +109,8 @@ Notes on interpretation:
   tier_scan. A missing or non-OK full-parse measurement still fails this gate
   closed because no exact Go/C ratio was produced; that is coverage, not a
   claim that this harness proved structural parity.
-- The Go no-edit path may legitimately short-circuit (near-zero ns) when the
-  engine returns the old tree for an unchanged reparse; the C side always
-  pays its reuse walk. The scoreboard reports honest wall time of the API call.
-- The `edit` axis verifies only that both incremental reparses complete
-  (completeness, not structural parity) before timing — see Phase 2.
+- Incremental and no-edit performance use separate benchmark lanes. They are
+  deliberately outside this publication scoreboard.
 
 ## Cliff containment (why one 17s file cannot hang the sweep)
 
@@ -86,10 +131,12 @@ Two layers, both represented by structured stop records in `scoreboard.json`:
 
 ## Running
 
-Requires: cgo + C toolchain, the parity container OR `GTS_PARITY_ALLOW_HOST=1`,
-and a corpus. C reference grammars are built/loaded by the existing parity
-machinery (`ParityCLanguage`, `grammars/languages.lock`, cached under
-`harness_out/parity_c_ref_cache/`).
+Requires: cgo, a C/C++ toolchain with static runtime libraries, `nm`, `readelf`,
+the parity container OR `GTS_PARITY_ALLOW_HOST=1`, and a corpus. The admission
+binding uses the existing parity machinery (`ParityCLanguage`). The timing
+sidecar independently builds the same locked runtime and grammar from
+`grammars/languages.lock`, cached under `harness_out/c_oracle/fleet_static/` by
+default.
 
 Exploratory smoke (explicit languages, default corpus `corpus_real/`). This
 opts out of the hard gate because it does not use the authenticated fleet lock:
@@ -166,12 +213,16 @@ GOWORK=off GTS_PARITY_ALLOW_HOST=1 GTS_PERF_SCAN=1 \
   -run '^TestPerfScanReduce$' -v -count=1 -timeout 0 .
 ```
 
-Reduction requires exactly one scoreboard for every locked language. It
+Reduction requires exactly one fresh-full `gts-perf-scan/v2` scoreboard for
+every locked language. It
 rejects missing or duplicate languages, schema or measurement-config drift,
 corpus-lock drift, path exclusions, contended runs, mixed or absent repository
 revisions, dirty source trees, mixed host/runtime identities, contradictory or
 malformed file classifications, pre-existing reduction provenance, and absent
-or stale shard hard gates. Raw one-language measurement shards must not contain
+or stale shard hard gates. It also rejects absent or mixed static-C identities,
+non-static linkage, compile/link flag drift, wrong runtime or grammar commits,
+and any selected file without matching static/cgo deep-tree admission. Raw
+one-language measurement shards must not contain
 a `reduction` object. A stored shard gate may be either PASS or FAIL, but it
 must exactly equal the gate recomputed from that shard's evidence after
 canonical ordering. Published `failures` and `fast_full_files` are sorted by
@@ -248,12 +299,13 @@ the corpus builder deliberately supplies nested dependency checkouts and
 | `GTS_PERF_SCAN_MIN_FILE_BYTES` / `_MAX_FILE_BYTES` | 0 / 4MiB | size filters |
 | `GTS_PERF_SCAN_EXCLUDE_PATHS` | — | comma-separated language-relative or `language/path` exact paths/globs to omit from selection; globs use Go `path.Match` semantics (`*` does not cross `/`, and `**` is not recursive), while trailing `/` means recursive directory prefix. Intended for named C-oracle cliff witnesses that remain tracked in the ledger |
 | `GTS_PERF_SCAN_ORDER` | `largest` | `largest` / `smallest` / `path` selection order |
-| `GTS_PERF_SCAN_AXES` | `full,noedit` | add `edit` for the incremental-edit axis |
+| `GTS_PERF_SCAN_AXES` | `full` | publication accepts only `full`; legacy `noedit`/`edit` requests are diagnostic and reducer-inadmissible |
 | `GTS_PERF_SCAN_CONTENDED` | auto (loadavg) | mark run as contended (smoke-only numbers) |
 | `GTS_PERF_SCAN_INPROCESS` | 0 | debug: run languages in-process (no crash isolation) |
 | `GTS_PERF_SCAN_EDIT_CANDIDATES` | 16 | edit-site candidates tried per file |
-| `GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB` | 0 | optional parent-side RSS watchdog for the per-language child process; when set, kills the child before a container cgroup OOM can kill the sweep parent |
+| `GTS_PERF_SCAN_CHILD_RSS_LIMIT_MB` | 0 | optional parent-side RSS watchdog for the per-language child process group; when set, kills and reaps the child and its descendants before a container cgroup OOM can kill the sweep parent |
 | `GTS_REAL_CORPUS_BENCH_LOCK` | required by hard gate | authenticated corpus selection lock; digest is checked before any language runs |
+| `GTS_C_ORACLE_CACHE` | `harness_out/c_oracle/fleet_static` | cache for pinned runtime/grammar sources and content-keyed fully static timing artifacts |
 
 Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 `GTS_PARITY_REPO_ROOT`, `GTS_PARITY_REPO_CACHE`,
@@ -262,7 +314,7 @@ Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 ## Outputs
 
 ```
-<out>/scoreboard.json   machine-readable (schema gts-perf-scan/v1)
+<out>/scoreboard.json   machine-readable (schema gts-perf-scan/v2)
 <out>/scoreboard.md     human scoreboard + cliff appendix
 <out>/langs/<lang>.json per-language fragments (partial results survive kills)
 <out>/logs/<lang>.log   child stdout/stderr per language
@@ -270,7 +322,8 @@ Also honored: `GTS_PARITY_ALLOW_HOST`, `GTS_PARITY_SKIP_LANGS`,
 
 `scoreboard.json` carries the repository revision, host metadata (loadavg at
 start/end), the full config, authenticated corpus coverage, a `contended` flag,
-structured stop records, per-language per-axis aggregates, per-file medians/ratios/statuses,
+static-C oracle identity and admissions, structured stop records, per-language
+full-parse aggregates, per-file medians/ratios/statuses,
 optional per-file full-parse classifications, per-language clean/error timing
 splits, a fleet clean/error timing split, and a `hard_gate` report. The markdown
 renders the same class totals and lists each non-clean file with its reason.
@@ -322,7 +375,7 @@ requiring git-ignored local scoreboard artifacts. To fold in local scoreboards
 when they exist, add `-scoreboards 'perf_scan/out/wave3_batch*/scoreboard.json'`;
 contended runs remain explicitly labeled as smoke/visibility evidence.
 
-Compare an authoritative scoreboard against the ratchet:
+Compare a historical v1 scoreboard against the matching aggregate ratchet:
 
 ```sh
 cd cgo_harness
@@ -333,9 +386,11 @@ GOWORK=off go run ./cmd/perf_scan_budget \
   -out-md perf_scan/out/authoritative_YYYYMMDDTHHMMSSZ/budget.md
 ```
 
-The checked-in budget was seeded with `order=largest`, `max_files=8`,
-`reps=5`, `warmup=1`, `file_budget_ms=10000`, and axes `full,noedit`. Generate
-a strict ratchet scoreboard with those same knobs inside the parity container:
+The checked-in historical budget was seeded with `order=largest`,
+`max_files=8`, `reps=5`, `warmup=1`, `file_budget_ms=10000`, and the former
+in-process C transport. It remains historical context, not admissible v2
+publication evidence. Generate the replacement static-C full-parse board with
+the same corpus-selection knobs inside the parity container:
 
 ```sh
 bash cgo_harness/docker/run_parity_in_docker.sh \
@@ -357,13 +412,31 @@ bash cgo_harness/docker/run_parity_in_docker.sh \
       -run '^TestPerfScanSweep$' -v -count=1 -timeout 0 ."
 ```
 
-For a targeted language refresh, scope the comparison:
+Evaluate the resulting v2 board with the current fail-closed contract:
+
+```sh
+cd cgo_harness
+GOWORK=off go run ./cmd/perf_scan_budget \
+  -budget perf_scan/perf_ratio_budgets.json \
+  -scoreboard perf_scan/out/ratchet_YYYYMMDDTHHMMSSZ/scoreboard.json \
+  -hard-gate-only \
+  -out-md perf_scan/out/ratchet_YYYYMMDDTHHMMSSZ/hard-gate.md
+```
+
+The budget command deliberately keeps the transports separate: v1 boards may
+only be compared with the historical aggregate ratchets, while v2 boards may
+only be evaluated with `-hard-gate-only`. A v2 board contains exactly the
+`full` axis, so applying old `noedit` allowances or ratios to it would be a
+false comparison.
+
+For a targeted v2 language refresh, scope the hard-gate evaluation:
 
 ```sh
 cd cgo_harness
 GOWORK=off go run ./cmd/perf_scan_budget \
   -budget perf_scan/perf_ratio_budgets.json \
   -scoreboard perf_scan/out/go_refresh/scoreboard.json \
+  -hard-gate-only \
   -langs go
 ```
 
@@ -377,21 +450,16 @@ requires `hard_gate=true` and the authenticated corpus-lock digest in addition
 to the measurement knobs (`reps`, `warmup`, `file_budget_ms`, `max_files`,
 `order`, exclusions, and axes).
 
-The universal hard-gate run passes `-hard-gate-only`. That mode requires an
+The universal hard-gate run passes `-hard-gate-only`. That mode requires a v2,
+full-only,
 unexcluded scoreboard and checks authenticated fleet coverage plus the exact
 per-file hard rules without applying historical aggregates whose seeded sample
 basis included an exclusion. Historical ratchets remain available through the
 normal comparator on scoreboards produced with their exact recorded basis.
 
-Older `gts-perf-scan/v1` scoreboards still decode. They predate structured
-stops, corpus coverage, and the embedded hard-gate report, so use
-`-strict-config=false` only for historical analysis; they cannot establish a
-new hard-gate pass. `cmd/perf_scan_status` labels them `not_evaluated`.
-The clean/error, repository-revision, and reduction-provenance fields are
-optional additions to the same v1 schema: readers must continue to accept rows
-without `classification`, `full_parse_split`, `git_revision`, or `reduction`,
-and current Go decoders do so. The authoritative shard reducer applies a
-stronger provenance policy after decoding and rejects revisionless inputs.
+Older `gts-perf-scan/v1` scoreboards remain historical analysis only. They do
+not carry the fully static oracle identity or per-file cgo/static admission and
+cannot establish a new hard-gate pass or enter the v2 shard reducer.
 
 ## Phase 2 (documented, not built)
 

--- a/cgo_harness/pure_c/perf_oracle.c
+++ b/cgo_harness/pure_c/perf_oracle.c
@@ -1,0 +1,258 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "api.h"
+
+#ifndef TS_LANG_FN
+#error "TS_LANG_FN macro is required"
+#endif
+
+extern const TSLanguage *TS_LANG_FN(void);
+
+static uint64_t now_ns(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+static char *read_source(const char *path, size_t *out_len) {
+  FILE *file = fopen(path, "rb");
+  if (!file || fseek(file, 0, SEEK_END) != 0) {
+    if (file) fclose(file);
+    return NULL;
+  }
+  long end = ftell(file);
+  if (end < 0 || fseek(file, 0, SEEK_SET) != 0) {
+    fclose(file);
+    return NULL;
+  }
+  char *buf = (char *)malloc((size_t)end + 1u);
+  if (!buf) {
+    fclose(file);
+    return NULL;
+  }
+  size_t n = fread(buf, 1u, (size_t)end, file);
+  if (n != (size_t)end || ferror(file)) {
+    free(buf);
+    fclose(file);
+    return NULL;
+  }
+  fclose(file);
+  buf[n] = '\0';
+  *out_len = n;
+  return buf;
+}
+
+static bool tree_complete(TSTree *tree, uint32_t source_len) {
+  if (!tree) return false;
+  TSNode root = ts_tree_root_node(tree);
+  return !ts_node_is_null(root) && ts_node_end_byte(root) == source_len;
+}
+
+static void dump_u32(uint32_t value) {
+  unsigned char bytes[4] = {
+      (unsigned char)value, (unsigned char)(value >> 8),
+      (unsigned char)(value >> 16), (unsigned char)(value >> 24)};
+  fwrite(bytes, 1u, sizeof(bytes), stdout);
+}
+
+static void dump_string(const char *value) {
+  uint32_t len = value ? (uint32_t)strlen(value) : 0u;
+  dump_u32(len);
+  if (len > 0) fwrite(value, 1u, len, stdout);
+}
+
+static void dump_node_header(TSNode node, const char *field_name) {
+  dump_string(ts_node_type(node));
+  dump_string(field_name);
+  dump_u32(ts_node_start_byte(node));
+  dump_u32(ts_node_end_byte(node));
+  TSPoint start = ts_node_start_point(node);
+  TSPoint end = ts_node_end_point(node);
+  dump_u32(start.row);
+  dump_u32(start.column);
+  dump_u32(end.row);
+  dump_u32(end.column);
+  unsigned char flags = 0u;
+  if (ts_node_is_named(node)) flags |= 1u << 0;
+  if (ts_node_is_extra(node)) flags |= 1u << 1;
+  if (ts_node_is_missing(node)) flags |= 1u << 2;
+  if (ts_node_is_error(node)) flags |= 1u << 3;
+  if (ts_node_has_error(node)) flags |= 1u << 4;
+  fwrite(&flags, 1u, 1u, stdout);
+  uint32_t count = ts_node_child_count(node);
+  dump_u32(count);
+}
+
+static void dump_tree_nodes(TSNode root) {
+  TSTreeCursor cursor = ts_tree_cursor_new(root);
+  dump_node_header(root, NULL);
+  for (;;) {
+    if (ts_tree_cursor_goto_first_child(&cursor)) {
+      dump_node_header(ts_tree_cursor_current_node(&cursor),
+                       ts_tree_cursor_current_field_name(&cursor));
+      continue;
+    }
+    while (!ts_tree_cursor_goto_next_sibling(&cursor)) {
+      if (!ts_tree_cursor_goto_parent(&cursor)) {
+        ts_tree_cursor_delete(&cursor);
+        return;
+      }
+    }
+    dump_node_header(ts_tree_cursor_current_node(&cursor),
+                     ts_tree_cursor_current_field_name(&cursor));
+  }
+}
+
+static int dump_tree(const char *source, uint32_t source_len,
+                     uint64_t timeout_us) {
+  TSParser *parser = ts_parser_new();
+  if (!parser || !ts_parser_set_language(parser, TS_LANG_FN())) {
+    fputs("status=c_parser_error\n", stderr);
+    if (parser) ts_parser_delete(parser);
+    return 2;
+  }
+  ts_parser_set_timeout_micros(parser, timeout_us);
+  TSTree *tree = ts_parser_parse_string(parser, NULL, source, source_len);
+  if (!tree) {
+    fputs("status=c_timeout\n", stderr);
+    ts_parser_delete(parser);
+    return 10;
+  }
+  if (!tree_complete(tree, source_len)) {
+    fputs("status=c_incomplete\n", stderr);
+    if (tree) ts_tree_delete(tree);
+    ts_parser_delete(parser);
+    return 11;
+  }
+  static const unsigned char magic[] = "gts-deep-tree-v1";
+  fwrite(magic, 1u, sizeof(magic), stdout);
+  dump_tree_nodes(ts_tree_root_node(tree));
+  ts_tree_delete(tree);
+  ts_parser_delete(parser);
+  if (ferror(stdout)) {
+    fputs("status=c_digest_error\n", stderr);
+    return 4;
+  }
+  return 0;
+}
+
+static int parse_int(const char *raw, int fallback) {
+  char *end = NULL;
+  long value = strtol(raw, &end, 10);
+  if (!raw[0] || (end && *end) || value < 0 || value > 1000000000L) {
+    return fallback;
+  }
+  return (int)value;
+}
+
+static int measure_full(TSParser *parser, const char *source, uint32_t len,
+                        int warmup, int reps) {
+  for (int i = 0; i < warmup; i++) {
+    TSTree *tree = ts_parser_parse_string(parser, NULL, source, len);
+    if (!tree) {
+      puts("status=c_timeout");
+      return 0;
+    }
+    if (!tree_complete(tree, len)) {
+      ts_tree_delete(tree);
+      puts("status=c_incomplete");
+      return 0;
+    }
+    ts_tree_delete(tree);
+  }
+  for (int i = 0; i < reps; i++) {
+    uint64_t start = now_ns();
+    TSTree *tree = ts_parser_parse_string(parser, NULL, source, len);
+    uint64_t elapsed = now_ns() - start;
+    if (!tree) {
+      puts("status=c_timeout");
+      return 0;
+    }
+    if (!tree_complete(tree, len)) {
+      ts_tree_delete(tree);
+      puts("status=c_incomplete");
+      return 0;
+    }
+    ts_tree_delete(tree);
+    printf("sample_ns=%llu\n", (unsigned long long)elapsed);
+  }
+  puts("status=ok");
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 3) {
+    fputs("status=c_protocol_error\n", stderr);
+    fprintf(stderr, "usage: %s dump <source> <timeout-us> | measure full <source> <warmup> <reps> <timeout-us>\n", argv[0]);
+    return 2;
+  }
+  size_t source_len = 0;
+  const char *source_path = strcmp(argv[1], "dump") == 0 ? argv[2] : (argc >= 4 ? argv[3] : "");
+  char *source = read_source(source_path, &source_len);
+  if (!source || source_len > UINT32_MAX) {
+    fputs("status=c_transport_error\n", stderr);
+    fprintf(stderr, "source load failed: %s\n", source_path);
+    free(source);
+    return 2;
+  }
+  if (strcmp(argv[1], "dump") == 0) {
+    if (argc != 4) {
+      fputs("status=c_protocol_error\n", stderr);
+      fprintf(stderr, "invalid dump command\n");
+      free(source);
+      return 2;
+    }
+    int timeout_us = parse_int(argv[3], -1);
+    if (timeout_us < 0) {
+      fputs("status=c_protocol_error\n", stderr);
+      fprintf(stderr, "invalid dump timeout\n");
+      free(source);
+      return 2;
+    }
+    int status = dump_tree(source, (uint32_t)source_len,
+                           (uint64_t)timeout_us);
+    free(source);
+    return status;
+  }
+  if (strcmp(argv[1], "measure") != 0 || argc != 7) {
+    fputs("status=c_protocol_error\n", stderr);
+    fprintf(stderr, "invalid measurement command\n");
+    free(source);
+    return 2;
+  }
+  const char *axis = argv[2];
+  int warmup = parse_int(argv[4], -1);
+  int reps = parse_int(argv[5], -1);
+  int timeout_us = parse_int(argv[6], -1);
+  if (warmup < 0 || reps < 1 || timeout_us < 0) {
+    fputs("status=c_protocol_error\n", stderr);
+    fprintf(stderr, "invalid warmup/reps/timeout\n");
+    free(source);
+    return 2;
+  }
+  TSParser *parser = ts_parser_new();
+  if (!parser || !ts_parser_set_language(parser, TS_LANG_FN())) {
+    fputs("status=c_parser_error\n", stderr);
+    fprintf(stderr, "parser init failed\n");
+    if (parser) ts_parser_delete(parser);
+    free(source);
+    return 2;
+  }
+  ts_parser_set_timeout_micros(parser, (uint64_t)timeout_us);
+  printf("schema=gts-static-c-perf/v2\naxis=%s\n", axis);
+  int status = 2;
+  if (strcmp(axis, "full") == 0) {
+    status = measure_full(parser, source, (uint32_t)source_len, warmup, reps);
+  } else {
+    fputs("status=c_protocol_error\n", stderr);
+    fprintf(stderr, "unsupported axis: %s\n", axis);
+  }
+  ts_parser_delete(parser);
+  free(source);
+  return status;
+}

--- a/cgo_harness/static_c_perf_oracle_test.go
+++ b/cgo_harness/static_c_perf_oracle_test.go
@@ -1,0 +1,1818 @@
+//go:build cgo && treesitter_c_parity && treesitter_c_perfscan
+
+package cgoharness
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+const (
+	staticCPerfSchema             = "gts-static-c-perf/v2"
+	staticCArtifactManifestSchema = "gts-static-c-perf-artifact/v1"
+	staticCPerfTransport          = "static_executable"
+	staticCPerfLinkage            = "fully_static_executable"
+	staticCPerfLinkageProof       = "elf:no_interp,no_needed"
+	staticCPerfRuntimeRepo        = "https://github.com/tree-sitter/tree-sitter.git"
+	staticCPerfOptimizationFlags  = "-O2 -DNDEBUG"
+	staticCPerfRuntimeCFlags      = "-O2 -DNDEBUG -std=c11 -D_POSIX_C_SOURCE=200112L -D_DEFAULT_SOURCE"
+	staticCPerfGrammarCFlags      = "-O2 -DNDEBUG -std=c11"
+	staticCPerfGrammarCXXFlags    = "-O2 -DNDEBUG -std=c++17"
+	staticCPerfDriverCFlags       = "-O2 -DNDEBUG -std=c11 -D_POSIX_C_SOURCE=200112L"
+	staticCPerfLinkFlags          = "-static -O2"
+	staticCPerfTimingRegion       = "ts_parser_parse_string_only;process,source,parser_setup,tree_delete_excluded"
+	staticCPerfOrderProtocol      = "whole_file_blocks_alternate_by_language_sha256_low_bit_xor_selected_file_ordinal"
+	staticCPerfFailureVocabulary  = "c_oracle_status/v2:admission_error,parser_error,parser_timeout,transport_error,transport_timeout,digest_error,digest_timeout,measurement_error,protocol_error,incomplete,mismatch"
+	staticCPerfCacheEnv           = "GTS_C_ORACLE_CACHE"
+	staticCPerfCanaryEnv          = "GTS_STATIC_C_PERF_CANARY"
+	staticCPerfWallGrace          = 2 * time.Second
+	staticCSourceLocked           = "locked_commit"
+	staticCSourceGenerated        = "generated_from_locked_grammar"
+	staticCStatusAdmissionError   = "c_oracle_admission_error"
+	staticCStatusParserError      = "c_oracle_parser_error"
+	staticCStatusParserTimeout    = "c_oracle_parser_timeout"
+	staticCStatusTransportError   = "c_oracle_transport_error"
+	staticCStatusTransportTimeout = "c_oracle_transport_timeout"
+	staticCStatusDigestError      = "c_oracle_digest_error"
+	staticCStatusDigestTimeout    = "c_oracle_digest_timeout"
+	staticCStatusMeasurementError = "c_oracle_measurement_error"
+	staticCStatusProtocolError    = "c_oracle_protocol_error"
+	staticCStatusIncomplete       = "c_oracle_incomplete"
+	staticCStatusMismatch         = "c_oracle_mismatch"
+)
+
+type perfScanOracleCommonIdentity struct {
+	Contract             string `json:"contract"`
+	Transport            string `json:"transport"`
+	Linkage              string `json:"linkage"`
+	BindingModule        string `json:"binding_module"`
+	BindingVersion       string `json:"binding_version"`
+	BindingCommit        string `json:"binding_commit"`
+	RuntimeRepo          string `json:"runtime_repo"`
+	RuntimeVersion       string `json:"runtime_version"`
+	RuntimeCommit        string `json:"runtime_commit"`
+	RuntimeSourceTreeOID string `json:"runtime_source_tree_oid"`
+	RuntimeSourceSHA256  string `json:"runtime_source_sha256"`
+	OptimizationFlags    string `json:"optimization_flags"`
+	RuntimeCFlags        string `json:"runtime_c_flags"`
+	GrammarCFlags        string `json:"grammar_c_flags"`
+	GrammarCXXFlags      string `json:"grammar_cxx_flags"`
+	DriverCFlags         string `json:"driver_c_flags"`
+	LinkFlags            string `json:"link_flags"`
+	TimingRegion         string `json:"timing_region"`
+	OrderProtocol        string `json:"measurement_order_protocol"`
+	FailureVocabulary    string `json:"failure_vocabulary"`
+	TargetOS             string `json:"target_os"`
+	TargetArch           string `json:"target_arch"`
+	CompilerPath         string `json:"compiler_path"`
+	CompilerVersion      string `json:"compiler_version"`
+	CompilerSHA256       string `json:"compiler_sha256"`
+	DriverSHA256         string `json:"driver_sha256"`
+	DeepDigestFormat     string `json:"deep_digest_format"`
+}
+
+type perfScanOracleSourceIdentity struct {
+	Path         string `json:"path"`
+	SHA256       string `json:"sha256"`
+	CompileFlags string `json:"compile_flags"`
+}
+
+type perfScanOracleLanguageIdentity struct {
+	Language          string                         `json:"language"`
+	GrammarRepo       string                         `json:"grammar_repo"`
+	GrammarCommit     string                         `json:"grammar_commit"`
+	GrammarSourceTree string                         `json:"grammar_source_tree_oid"`
+	GrammarSourceMode string                         `json:"grammar_source_mode"`
+	LanguageSymbol    string                         `json:"language_symbol"`
+	Parser            perfScanOracleSourceIdentity   `json:"parser"`
+	Scanners          []perfScanOracleSourceIdentity `json:"scanners,omitempty"`
+	LinkerPath        string                         `json:"linker_path"`
+	LinkerVersion     string                         `json:"linker_version"`
+	LinkerSHA256      string                         `json:"linker_sha256"`
+	BuildKeySHA256    string                         `json:"build_key_sha256"`
+	ArtifactSHA256    string                         `json:"artifact_sha256"`
+	ArtifactStatic    bool                           `json:"artifact_static"`
+	ArtifactLinkage   string                         `json:"artifact_linkage_proof"`
+}
+
+type perfScanOracleIdentity struct {
+	Common   perfScanOracleCommonIdentity   `json:"common"`
+	Language perfScanOracleLanguageIdentity `json:"language"`
+}
+
+type perfScanOracleBoardIdentity struct {
+	Common    perfScanOracleCommonIdentity     `json:"common"`
+	Languages []perfScanOracleLanguageIdentity `json:"languages"`
+}
+
+type perfScanOracleAdmission struct {
+	DigestFormat     string `json:"digest_format"`
+	SourceSHA256     string `json:"source_sha256"`
+	StaticDeepSHA256 string `json:"static_deep_sha256"`
+	ParityDeepSHA256 string `json:"parity_deep_sha256"`
+	Admitted         bool   `json:"admitted"`
+	Status           string `json:"status,omitempty"`
+	Detail           string `json:"detail,omitempty"`
+}
+
+type staticCPerfOracle struct {
+	artifact  string
+	identity  perfScanOracleIdentity
+	cleanup   func()
+	wallGrace time.Duration
+}
+
+func (oracle *staticCPerfOracle) Close() {
+	if oracle != nil && oracle.cleanup != nil {
+		oracle.cleanup()
+		oracle.cleanup = nil
+	}
+}
+
+func (oracle *staticCPerfOracle) transportGrace() time.Duration {
+	if oracle != nil && oracle.wallGrace > 0 {
+		return oracle.wallGrace
+	}
+	return staticCPerfWallGrace
+}
+
+func staticCAdmissionFailureStatus(status string) bool {
+	switch status {
+	case staticCStatusAdmissionError,
+		staticCStatusParserError, staticCStatusParserTimeout,
+		staticCStatusTransportError, staticCStatusTransportTimeout,
+		staticCStatusDigestError, staticCStatusDigestTimeout,
+		staticCStatusProtocolError,
+		staticCStatusIncomplete, staticCStatusMismatch:
+		return true
+	default:
+		return false
+	}
+}
+
+func staticCMeasurementFailureStatus(status string) bool {
+	switch status {
+	case staticCStatusParserError, staticCStatusParserTimeout,
+		staticCStatusTransportError, staticCStatusTransportTimeout,
+		staticCStatusMeasurementError, staticCStatusProtocolError,
+		staticCStatusIncomplete:
+		return true
+	default:
+		return false
+	}
+}
+
+func staticCTimeoutStatus(status string) bool {
+	return status == staticCStatusParserTimeout || status == staticCStatusTransportTimeout || status == staticCStatusDigestTimeout
+}
+
+type staticCArtifactManifest struct {
+	Schema         string `json:"schema"`
+	BuildKeySHA256 string `json:"build_key_sha256"`
+	ArtifactSHA256 string `json:"artifact_sha256"`
+}
+
+type staticCBuildInputSnapshot struct {
+	Common          perfScanOracleCommonIdentity
+	Language        perfScanOracleLanguageIdentity
+	RuntimeRepoDir  string
+	RuntimeSource   string
+	GrammarRepoDir  string
+	GrammarTreePath string
+	SourceRoot      string
+	ParserPath      string
+	ScannerPaths    []string
+	DriverPath      string
+}
+
+var errStaticCBuildInputDrift = errors.New("static C build input drift")
+
+type staticCPerfMeasurement struct {
+	Status  string
+	Samples []int64
+	Detail  string
+}
+
+type staticCOracleError struct {
+	Status string
+	Detail string
+}
+
+func (err *staticCOracleError) Error() string { return err.Detail }
+
+func staticCOracleErrorStatus(err error) string {
+	var oracleErr *staticCOracleError
+	if errors.As(err, &oracleErr) && oracleErr.Status != "" {
+		return oracleErr.Status
+	}
+	return staticCStatusAdmissionError
+}
+
+func newStaticCOracleError(status, detail string) error {
+	return &staticCOracleError{Status: status, Detail: detail}
+}
+
+func TestStaticCVerifyArtifactRejectsDynamicExecutable(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "dynamic.c")
+	artifact := filepath.Join(t.TempDir(), "dynamic")
+	program := []byte("void ts_parser_parse(void) {}\nvoid tree_sitter_canary(void) {}\nint main(void) { return 0; }\n")
+	if err := os.WriteFile(source, program, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("cc", "-O2", source, "-o", artifact).CombinedOutput(); err != nil {
+		t.Fatalf("compile dynamic canary: %v\n%s", err, out)
+	}
+	if proof, err := staticCVerifyArtifact(artifact, "tree_sitter_canary"); err == nil || proof != "" {
+		t.Fatalf("dynamic executable accepted: proof=%q err=%v", proof, err)
+	}
+}
+
+func TestStaticCValidateCachedArtifactRejectsAndRebuildsTampering(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "cache")
+	artifact := filepath.Join(dir, "perf_oracle")
+	source := filepath.Join(root, "static.c")
+	program := []byte("void ts_parser_parse(void) {}\nvoid tree_sitter_canary(void) {}\nint main(void) { return 0; }\n")
+	if err := os.WriteFile(source, program, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	buildKey := strings.Repeat("a", 64)
+	build := func() error {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		if out, err := exec.Command("cc", "-static", "-O2", source, "-o", artifact).CombinedOutput(); err != nil {
+			return fmt.Errorf("compile static cache canary: %w: %s", err, out)
+		}
+		return staticCWriteArtifactManifest(dir, artifact, buildKey)
+	}
+	if err := build(); err != nil {
+		t.Fatal(err)
+	}
+	if _, proof, err := staticCValidateCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary"); err != nil || proof != staticCPerfLinkageProof {
+		t.Fatalf("fresh cache validation: proof=%q err=%v", proof, err)
+	}
+	buildsOnDrift := 0
+	if _, _, err := staticCEnsureCachedArtifactValidated(dir, artifact, buildKey, "tree_sitter_canary", func() error {
+		return fmt.Errorf("%w: compiler replaced after capture", errStaticCBuildInputDrift)
+	}, func() error {
+		buildsOnDrift++
+		return nil
+	}); !errors.Is(err, errStaticCBuildInputDrift) || buildsOnDrift != 0 {
+		t.Fatalf("cache-hit input drift err=%v builds=%d", err, buildsOnDrift)
+	}
+	if _, proof, err := staticCValidateCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary"); err != nil || proof != staticCPerfLinkageProof {
+		t.Fatalf("valid cache was quarantined after current-input drift: proof=%q err=%v", proof, err)
+	}
+
+	file, err := os.OpenFile(artifact, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte("tampered")); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := staticCValidateCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary"); err == nil || !strings.Contains(err.Error(), "artifact SHA") {
+		t.Fatalf("tampered cached executable was accepted: %v", err)
+	}
+	rebuilds := 0
+	if _, proof, err := staticCEnsureCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary", func() error {
+		rebuilds++
+		return build()
+	}); err != nil || proof != staticCPerfLinkageProof || rebuilds != 1 {
+		t.Fatalf("tampered cache rebuild: proof=%q rebuilds=%d err=%v", proof, rebuilds, err)
+	}
+
+	if err := os.Remove(staticCArtifactManifestPath(dir)); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := staticCValidateCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary"); err == nil || !strings.Contains(err.Error(), "manifest") {
+		t.Fatalf("manifest-free cached executable was accepted: %v", err)
+	}
+	if _, proof, err := staticCEnsureCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary", func() error {
+		rebuilds++
+		return build()
+	}); err != nil || proof != staticCPerfLinkageProof || rebuilds != 2 {
+		t.Fatalf("manifest-free cache rebuild: proof=%q rebuilds=%d err=%v", proof, rebuilds, err)
+	}
+	artifactSHA, _, err := staticCValidateCachedArtifact(dir, artifact, buildKey, "tree_sitter_canary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateArtifact, cleanup, err := staticCPrivateExecutableSnapshot(artifact, artifactSHA, "tree_sitter_canary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	if err := os.WriteFile(artifact, []byte("cache path replaced after validation"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command(privateArtifact).CombinedOutput(); err != nil {
+		t.Fatalf("verified private artifact did not survive cache replacement: %v: %s", err, out)
+	}
+}
+
+func TestStaticCInstallBuiltArtifactDoesNotPublishDriftedInputs(t *testing.T) {
+	parent := t.TempDir()
+	buildDir := filepath.Join(parent, "shared-cache-entry")
+	artifact := filepath.Join(buildDir, "perf_oracle")
+	tmp := filepath.Join(parent, "private-build")
+	if err := os.MkdirAll(tmp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "perf_oracle"), []byte("unpublished fixture"), 0o500); err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Errorf("%w: deterministic mutation", errStaticCBuildInputDrift)
+	err := staticCInstallBuiltArtifact(tmp, buildDir, artifact, strings.Repeat("a", 64), "tree_sitter_canary", func() error { return want })
+	if !errors.Is(err, errStaticCBuildInputDrift) {
+		t.Fatalf("drifted install error=%v", err)
+	}
+	if _, statErr := os.Stat(buildDir); !os.IsNotExist(statErr) {
+		t.Fatalf("drifted artifact became visible in shared cache: %v", statErr)
+	}
+	if _, statErr := os.Stat(staticCArtifactManifestPath(tmp)); !os.IsNotExist(statErr) {
+		t.Fatalf("drifted private build received a publishable manifest: %v", statErr)
+	}
+}
+
+func TestStaticCRevalidateBuildInputsRejectsDeterministicMutations(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string, mode os.FileMode) string {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), mode); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	compiler := write("compiler", "#!/bin/sh\necho fixture-compiler\n", 0o700)
+	linker := write("linker", "#!/bin/sh\necho fixture-linker\n", 0o700)
+	runtimeSource := write("runtime.c", "runtime-v1", 0o600)
+	driver := write("driver.c", "driver-v1", 0o600)
+	parser := write("parser.c", "parser-v1", 0o600)
+	scanner := write("scanner.c", "scanner-v1", 0o600)
+	compilerPath, compilerVersion, compilerSHA, err := staticCToolIdentityAtPath(compiler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	linkerPath, linkerVersion, linkerSHA, err := staticCToolIdentityAtPath(linker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha := func(path string) string {
+		value, err := fileSHA256(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return value
+	}
+	inputs := staticCBuildInputSnapshot{
+		Common: perfScanOracleCommonIdentity{
+			CompilerPath: compilerPath, CompilerVersion: compilerVersion, CompilerSHA256: compilerSHA,
+			RuntimeSourceSHA256: sha(runtimeSource), DriverSHA256: sha(driver),
+		},
+		Language: perfScanOracleLanguageIdentity{
+			LinkerPath: linkerPath, LinkerVersion: linkerVersion, LinkerSHA256: linkerSHA,
+			Parser:   perfScanOracleSourceIdentity{Path: "parser.c", SHA256: sha(parser)},
+			Scanners: []perfScanOracleSourceIdentity{{Path: "scanner.c", SHA256: sha(scanner)}},
+		},
+		RuntimeSource: runtimeSource,
+		DriverPath:    driver,
+		SourceRoot:    dir,
+		ParserPath:    parser,
+		ScannerPaths:  []string{scanner},
+	}
+	if err := staticCRevalidateBuildInputs(inputs); err != nil {
+		t.Fatalf("stable inputs rejected: %v", err)
+	}
+	for _, tc := range []struct {
+		label   string
+		path    string
+		content string
+		mode    os.FileMode
+	}{
+		{label: "compiler", path: compiler, content: "#!/bin/sh\necho changed-compiler\n", mode: 0o700},
+		{label: "linker", path: linker, content: "#!/bin/sh\necho changed-linker\n", mode: 0o700},
+		{label: "runtime", path: runtimeSource, content: "runtime-v2", mode: 0o600},
+		{label: "driver", path: driver, content: "driver-v2", mode: 0o600},
+		{label: "parser", path: parser, content: "parser-v2", mode: 0o600},
+		{label: "scanner", path: scanner, content: "scanner-v2", mode: 0o600},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			original, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(tc.path, []byte(tc.content), tc.mode); err != nil {
+				t.Fatal(err)
+			}
+			if err := staticCRevalidateBuildInputs(inputs); err == nil || !strings.Contains(err.Error(), tc.label) {
+				t.Fatalf("%s mutation was not rejected: %v", tc.label, err)
+			}
+			if err := os.WriteFile(tc.path, original, tc.mode); err != nil {
+				t.Fatal(err)
+			}
+			if err := staticCRevalidateBuildInputs(inputs); err != nil {
+				t.Fatalf("restored %s input rejected: %v", tc.label, err)
+			}
+		})
+	}
+}
+
+func TestStaticCPerfOracleCanaries(t *testing.T) {
+	if os.Getenv(staticCPerfCanaryEnv) != "1" {
+		t.Skip("set " + staticCPerfCanaryEnv + "=1 to build locked static C oracle canaries")
+	}
+	tests := []struct {
+		name        string
+		language    string
+		source      string
+		scannerKind string
+		nonzeroRoot bool
+	}{
+		{name: "no_scanner", language: "go", source: "package main\n\nfunc main() {}\n", scannerKind: "none"},
+		{name: "leading_trivia", language: "go", source: " \n\t", scannerKind: "none", nonzeroRoot: true},
+		{name: "c_scanner", language: "python", source: "def f(x):\n    return x + 1\n", scannerKind: "c"},
+		{name: "cxx_scanner", language: "norg", source: "* Heading\n\nBody\n", scannerKind: "cxx"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oracle, err := buildStaticCPerfOracle(tc.language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oracle.Close()
+			if oracle.identity.Language.ArtifactLinkage != staticCPerfLinkageProof || !oracle.identity.Language.ArtifactStatic {
+				t.Fatalf("static linkage identity = %+v", oracle.identity.Language)
+			}
+			gotScannerKind := "none"
+			for _, scanner := range oracle.identity.Language.Scanners {
+				switch strings.ToLower(filepath.Ext(scanner.Path)) {
+				case ".c":
+					if gotScannerKind == "none" {
+						gotScannerKind = "c"
+					}
+				case ".cc", ".cpp", ".cxx":
+					gotScannerKind = "cxx"
+				}
+			}
+			if gotScannerKind != tc.scannerKind {
+				t.Fatalf("scanner kind=%q want %q; sources=%+v", gotScannerKind, tc.scannerKind, oracle.identity.Language.Scanners)
+			}
+
+			cLang, err := ParityCLanguage(tc.language)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parser := sitter.NewParser()
+			defer parser.Close()
+			if err := parser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			const budget = 10 * time.Second
+			parser.SetTimeoutMicros(uint64(budget.Microseconds()))
+			measurer := &perfScanLangMeasurer{staticC: oracle, cPsr: parser, budget: budget}
+			admission, err := measurer.admitStaticOracle([]byte(tc.source))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !admission.Admitted || admission.StaticDeepSHA256 != admission.ParityDeepSHA256 {
+				t.Fatalf("deep admission = %+v", admission)
+			}
+			if tc.nonzeroRoot {
+				tree := parser.Parse([]byte(tc.source), nil)
+				if tree == nil {
+					t.Fatal("leading-trivia C parse returned nil")
+				}
+				root := tree.RootNode()
+				start, end := root.StartByte(), root.EndByte()
+				tree.Close()
+				if start == 0 || end != uint(len(tc.source)) {
+					t.Fatalf("leading-trivia regression requires nonzero-start complete root: start=%d end=%d len=%d", start, end, len(tc.source))
+				}
+			}
+			measurement := oracle.measure([]byte(tc.source), perfScanAxisFull, 1, 2, budget)
+			if measurement.Status != perfScanStatusOK || len(measurement.Samples) != 2 {
+				t.Fatalf("measurement = %+v", measurement)
+			}
+			for _, sample := range measurement.Samples {
+				if sample <= 0 {
+					t.Fatalf("non-positive static C full-parse sample: %d", sample)
+				}
+			}
+			t.Logf("language=%s artifact=%s admission=%s samples=%v", tc.language, oracle.identity.Language.ArtifactSHA256, admission.StaticDeepSHA256, measurement.Samples)
+		})
+	}
+}
+
+func TestStaticCPerfOracleTimeoutCanary(t *testing.T) {
+	if os.Getenv(staticCPerfCanaryEnv) != "1" {
+		t.Skip("set " + staticCPerfCanaryEnv + "=1 to build the locked static C timeout canary")
+	}
+	oracle, err := buildStaticCPerfOracle("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oracle.Close()
+	source := append([]byte("package p\n"), bytes.Repeat([]byte("var x = 1\n"), 200_000)...)
+	_, sourceSHA, err := oracle.deepDigest(source, time.Microsecond)
+	if err == nil || staticCOracleErrorStatus(err) != staticCStatusParserTimeout {
+		t.Fatalf("bounded deep admission err=%v status=%q", err, staticCOracleErrorStatus(err))
+	}
+	if !staticCHashIdentity(sourceSHA) {
+		t.Fatalf("timeout lost immutable source identity: %q", sourceSHA)
+	}
+}
+
+func TestStaticCPerfOracleDistinguishesTransportTimeout(t *testing.T) {
+	artifact := filepath.Join(t.TempDir(), "blocking-oracle")
+	if err := os.WriteFile(artifact, []byte("#!/bin/sh\nexec sleep 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oracle := &staticCPerfOracle{artifact: artifact, wallGrace: 10 * time.Millisecond}
+	if _, _, err := oracle.deepDigest([]byte("source"), 10*time.Millisecond); err == nil || staticCOracleErrorStatus(err) != staticCStatusTransportTimeout {
+		t.Fatalf("deep transport timeout err=%v status=%q", err, staticCOracleErrorStatus(err))
+	}
+	measurement := oracle.measure([]byte("source"), perfScanAxisFull, 0, 1, 10*time.Millisecond)
+	if measurement.Status != staticCStatusTransportTimeout {
+		t.Fatalf("measurement transport timeout = %+v", measurement)
+	}
+}
+
+func TestStaticCPerfOracleClosedFailureVocabulary(t *testing.T) {
+	writeOracle := func(script string) *staticCPerfOracle {
+		artifact := filepath.Join(t.TempDir(), "fixture-oracle")
+		if err := os.WriteFile(artifact, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return &staticCPerfOracle{artifact: artifact, wallGrace: 50 * time.Millisecond}
+	}
+	for _, tc := range []struct {
+		name   string
+		marker string
+		want   string
+	}{
+		{name: "parser", marker: "status=c_parser_error", want: staticCStatusParserError},
+		{name: "digest", marker: "status=c_digest_error", want: staticCStatusDigestError},
+		{name: "transport", marker: "transport failed without a protocol status", want: staticCStatusTransportError},
+	} {
+		t.Run(tc.name+"_deep", func(t *testing.T) {
+			oracle := writeOracle("echo '" + tc.marker + "' >&2; exit 2")
+			_, _, err := oracle.deepDigest([]byte("source"), time.Second)
+			if err == nil || staticCOracleErrorStatus(err) != tc.want {
+				t.Fatalf("failure err=%v status=%q want=%q", err, staticCOracleErrorStatus(err), tc.want)
+			}
+		})
+	}
+	t.Run("protocol_measurement", func(t *testing.T) {
+		oracle := writeOracle("printf 'schema=wrong\\naxis=full\\nstatus=ok\\n'")
+		measurement := oracle.measure([]byte("source"), perfScanAxisFull, 0, 1, time.Second)
+		if measurement.Status != staticCStatusProtocolError {
+			t.Fatalf("protocol measurement=%+v", measurement)
+		}
+	})
+	t.Run("missing_sample_measurement", func(t *testing.T) {
+		oracle := writeOracle("printf 'schema=" + staticCPerfSchema + "\\naxis=full\\nstatus=ok\\n'")
+		measurement := oracle.measure([]byte("source"), perfScanAxisFull, 0, 1, time.Second)
+		if measurement.Status != staticCStatusMeasurementError {
+			t.Fatalf("missing-sample measurement=%+v", measurement)
+		}
+	})
+}
+
+func perfScanOracleBoardFromRows(rows []*perfScanLanguage) (*perfScanOracleBoardIdentity, error) {
+	board := &perfScanOracleBoardIdentity{}
+	for _, row := range rows {
+		if row == nil || row.Oracle == nil {
+			return nil, fmt.Errorf("language row is missing static C oracle identity")
+		}
+		if board.Common.Contract == "" {
+			board.Common = row.Oracle.Common
+		} else if !reflect.DeepEqual(board.Common, row.Oracle.Common) {
+			return nil, fmt.Errorf("language %q static C common identity differs", row.Language)
+		}
+		board.Languages = append(board.Languages, row.Oracle.Language)
+	}
+	sort.Slice(board.Languages, func(i, j int) bool { return board.Languages[i].Language < board.Languages[j].Language })
+	return board, nil
+}
+
+func perfScanValidateOracleEvidence(board *perfScanScoreboard) error {
+	if board == nil || board.Oracle == nil {
+		return fmt.Errorf("scoreboard is missing static C oracle identity")
+	}
+	common := board.Oracle.Common
+	if common.Contract != COracleContractVersion || common.Transport != staticCPerfTransport || common.Linkage != staticCPerfLinkage {
+		return fmt.Errorf("oracle contract/transport/linkage=%q/%q/%q", common.Contract, common.Transport, common.Linkage)
+	}
+	if common.BindingModule != COracleBindingModule || common.BindingVersion != COracleBindingVersion || common.BindingCommit != COracleBindingCommit {
+		return fmt.Errorf("oracle binding identity is not the locked %s@%s (%s)", COracleBindingModule, COracleBindingVersion, COracleBindingCommit)
+	}
+	if common.RuntimeRepo != staticCPerfRuntimeRepo || common.RuntimeVersion != COracleRuntimeVersion || common.RuntimeCommit != COracleRuntimeCommit {
+		return fmt.Errorf("oracle runtime identity is not locked to %s", COracleRuntimeCommit)
+	}
+	if common.OptimizationFlags != staticCPerfOptimizationFlags ||
+		common.RuntimeCFlags != staticCPerfRuntimeCFlags ||
+		common.GrammarCFlags != staticCPerfGrammarCFlags ||
+		common.GrammarCXXFlags != staticCPerfGrammarCXXFlags ||
+		common.DriverCFlags != staticCPerfDriverCFlags ||
+		common.LinkFlags != staticCPerfLinkFlags ||
+		common.TimingRegion != staticCPerfTimingRegion ||
+		common.OrderProtocol != staticCPerfOrderProtocol ||
+		common.FailureVocabulary != staticCPerfFailureVocabulary ||
+		common.DeepDigestFormat != "gts-deep-tree-v1" {
+		return fmt.Errorf("oracle compile/link/timing/digest contract differs from the locked static full-parse protocol")
+	}
+	for label, value := range map[string]string{
+		"runtime source tree": common.RuntimeSourceTreeOID,
+		"runtime source":      common.RuntimeSourceSHA256,
+		"driver":              common.DriverSHA256,
+	} {
+		if !staticCHashIdentity(value) {
+			return fmt.Errorf("oracle %s identity %q is not a full hash", label, value)
+		}
+	}
+	if !filepath.IsAbs(common.CompilerPath) || strings.TrimSpace(common.CompilerVersion) == "" || !staticCHashIdentity(common.CompilerSHA256) {
+		return fmt.Errorf("oracle compiler identity is incomplete")
+	}
+	if common.TargetOS != board.Host.GOOS || common.TargetArch != board.Host.GOARCH {
+		return fmt.Errorf("oracle target %s/%s differs from scoreboard host %s/%s", common.TargetOS, common.TargetArch, board.Host.GOOS, board.Host.GOARCH)
+	}
+	if !reflect.DeepEqual(board.Config.Axes, []string{perfScanAxisFull}) {
+		return fmt.Errorf("authoritative static C scoreboard axes=%v, want [%s]", board.Config.Axes, perfScanAxisFull)
+	}
+
+	lockPath, err := findParityLockPath()
+	if err != nil {
+		return err
+	}
+	lock, err := loadParityLock(lockPath)
+	if err != nil {
+		return err
+	}
+	boardByLanguage := make(map[string]perfScanOracleLanguageIdentity, len(board.Oracle.Languages))
+	for _, identity := range board.Oracle.Languages {
+		if _, duplicate := boardByLanguage[identity.Language]; duplicate {
+			return fmt.Errorf("duplicate oracle language identity %q", identity.Language)
+		}
+		boardByLanguage[identity.Language] = identity
+	}
+	if len(boardByLanguage) != len(board.Languages) {
+		return fmt.Errorf("oracle identity has %d languages, scoreboard has %d", len(boardByLanguage), len(board.Languages))
+	}
+	for _, row := range board.Languages {
+		if row == nil || row.Oracle == nil {
+			return fmt.Errorf("language row is missing oracle identity")
+		}
+		if !reflect.DeepEqual(common, row.Oracle.Common) {
+			return fmt.Errorf("language %q common oracle identity differs from scoreboard", row.Language)
+		}
+		identity := row.Oracle.Language
+		if identity.Language != row.Language || !reflect.DeepEqual(boardByLanguage[row.Language], identity) {
+			return fmt.Errorf("language %q oracle identity does not match its row/board entry", row.Language)
+		}
+		locked, ok := lock[row.Language]
+		if !ok || identity.GrammarRepo != locked.RepoURL || identity.GrammarCommit != locked.Commit {
+			return fmt.Errorf("language %q grammar identity is not the languages.lock entry", row.Language)
+		}
+		if !identity.ArtifactStatic || identity.ArtifactLinkage != staticCPerfLinkageProof || identity.LanguageSymbol == "" || !filepath.IsAbs(identity.LinkerPath) || identity.LinkerVersion == "" || !staticCHashIdentity(identity.LinkerSHA256) {
+			return fmt.Errorf("language %q artifact/linker/symbol identity is incomplete", row.Language)
+		}
+		if identity.GrammarSourceMode != staticCSourceLocked && identity.GrammarSourceMode != staticCSourceGenerated {
+			return fmt.Errorf("language %q grammar source mode %q is not recognized", row.Language, identity.GrammarSourceMode)
+		}
+		if identity.Parser.Path == "" || identity.Parser.CompileFlags != common.GrammarCFlags {
+			return fmt.Errorf("language %q parser compile identity is not the locked C protocol", row.Language)
+		}
+		if want := staticCBuildKey(common, identity); identity.BuildKeySHA256 != want {
+			return fmt.Errorf("language %q static C build key does not match its serialized inputs", row.Language)
+		}
+		for label, value := range map[string]string{
+			"grammar source tree": identity.GrammarSourceTree,
+			"parser":              identity.Parser.SHA256,
+			"build key":           identity.BuildKeySHA256,
+			"artifact":            identity.ArtifactSHA256,
+		} {
+			if !staticCHashIdentity(value) {
+				return fmt.Errorf("language %q %s identity %q is not a full hash", row.Language, label, value)
+			}
+		}
+		seenSources := map[string]bool{identity.Parser.Path: true}
+		for _, scanner := range identity.Scanners {
+			if scanner.Path == "" || !staticCHashIdentity(scanner.SHA256) {
+				return fmt.Errorf("language %q scanner identity is incomplete", row.Language)
+			}
+			if seenSources[scanner.Path] {
+				return fmt.Errorf("language %q has duplicate oracle source %q", row.Language, scanner.Path)
+			}
+			seenSources[scanner.Path] = true
+			wantFlags := common.GrammarCFlags
+			switch strings.ToLower(filepath.Ext(scanner.Path)) {
+			case ".cc", ".cpp", ".cxx":
+				wantFlags = common.GrammarCXXFlags
+			case ".c":
+			default:
+				return fmt.Errorf("language %q scanner %q has unsupported source type", row.Language, scanner.Path)
+			}
+			if scanner.CompileFlags != wantFlags {
+				return fmt.Errorf("language %q scanner %q compile flags are not locked", row.Language, scanner.Path)
+			}
+		}
+		for fileIndex, file := range row.Files {
+			if file == nil || file.OracleAdmission == nil {
+				return fmt.Errorf("language %q file is missing oracle admission", row.Language)
+			}
+			wantOrder := "go_then_static_c"
+			if staticCFirstFor(row.Language, fileIndex) {
+				wantOrder = "static_c_then_go"
+			}
+			if file.MeasurementOrder != wantOrder {
+				return fmt.Errorf("language %q file %q measurement order=%q, want %q", row.Language, file.Path, file.MeasurementOrder, wantOrder)
+			}
+			if err := perfScanValidateFileOracleEvidence(file, common.DeepDigestFormat); err != nil {
+				return fmt.Errorf("language %q file %q: %w", row.Language, file.Path, err)
+			}
+		}
+	}
+	return nil
+}
+
+func perfScanValidateFileOracleEvidence(file *perfScanFile, digestFormat string) error {
+	admission := file.OracleAdmission
+	if admission.DigestFormat != digestFormat || !staticCSHA256Identity(admission.SourceSHA256) {
+		return fmt.Errorf("invalid static/cgo admission format or source identity")
+	}
+	if admission.Admitted {
+		if admission.Status != "" || admission.Detail != "" ||
+			!staticCSHA256Identity(admission.StaticDeepSHA256) ||
+			admission.StaticDeepSHA256 != admission.ParityDeepSHA256 {
+			return fmt.Errorf("invalid static/cgo deep admission")
+		}
+		return perfScanValidateAdmittedFullMeasurement(file)
+	}
+
+	if !staticCAdmissionFailureStatus(admission.Status) {
+		return fmt.Errorf("unrecognized failed oracle admission status %q", admission.Status)
+	}
+	if strings.TrimSpace(admission.Detail) == "" {
+		return fmt.Errorf("failed oracle admission %q has no detail", admission.Status)
+	}
+	if admission.Status == staticCStatusMismatch {
+		if !staticCSHA256Identity(admission.StaticDeepSHA256) ||
+			!staticCSHA256Identity(admission.ParityDeepSHA256) ||
+			admission.StaticDeepSHA256 == admission.ParityDeepSHA256 {
+			return fmt.Errorf("oracle mismatch admission lacks two distinct deep digests")
+		}
+	} else {
+		for label, digest := range map[string]string{"static": admission.StaticDeepSHA256, "parity": admission.ParityDeepSHA256} {
+			if digest != "" && !staticCSHA256Identity(digest) {
+				return fmt.Errorf("failed oracle admission has invalid %s deep digest %q", label, digest)
+			}
+		}
+		if admission.StaticDeepSHA256 != "" && admission.StaticDeepSHA256 == admission.ParityDeepSHA256 {
+			return fmt.Errorf("failed oracle admission contradicts equal completed deep digests")
+		}
+	}
+
+	full := file.Axes[perfScanAxisFull]
+	if full == nil {
+		return fmt.Errorf("failed oracle admission has no full-parse Go evidence")
+	}
+	if full.Status != admission.Status || strings.TrimSpace(full.Detail) == "" || !strings.Contains(full.Detail, admission.Detail) {
+		return fmt.Errorf("failed oracle admission is not reflected by the full-parse result")
+	}
+	if full.CMedianNs != 0 || full.CMinNs != 0 || full.CMaxNs != 0 || full.Ratio != 0 || full.RatioIsLowerBound || full.Verdict != perfScanBucketNoData {
+		return fmt.Errorf("failed oracle admission contains fabricated C timing or ratio evidence")
+	}
+	if err := perfScanValidateClassification(file.Classification); err != nil {
+		return fmt.Errorf("failed oracle admission Go classification: %w", err)
+	}
+	if full.GoMedianNs > 0 {
+		if full.GoMinNs <= 0 || full.GoMaxNs <= 0 || full.GoMinNs > full.GoMedianNs || full.GoMedianNs > full.GoMaxNs || file.Classification.GoStatus != perfScanStatusOK {
+			return fmt.Errorf("failed oracle admission has incomplete Go timing evidence")
+		}
+		return nil
+	}
+	if file.Classification.GoStatus == perfScanStatusOK {
+		return fmt.Errorf("failed oracle admission has neither Go timing nor a typed Go failure")
+	}
+	if perfScanClassificationStatusIsStopped(file.Classification.GoStatus) && !perfScanIsGoStop(full.Stop) {
+		return fmt.Errorf("failed oracle admission stopped Go classification lacks a structured Go stop")
+	}
+	return nil
+}
+
+func perfScanValidateAdmittedFullMeasurement(file *perfScanFile) error {
+	full := file.Axes[perfScanAxisFull]
+	if full == nil {
+		return fmt.Errorf("admitted oracle file has no full-parse measurement")
+	}
+	if full.Status == perfScanStatusOK {
+		return nil
+	}
+	if !staticCMeasurementFailureStatus(full.Status) {
+		switch full.Status {
+		case "go_timeout", "go_budget_stop", "go_stopped", "go_error", "go_panic":
+		default:
+			return fmt.Errorf("admitted oracle file has unrecognized full-parse status %q", full.Status)
+		}
+	}
+	if strings.TrimSpace(full.Detail) == "" {
+		return fmt.Errorf("admitted oracle file full-parse failure %q has no detail", full.Status)
+	}
+	if strings.HasPrefix(full.Status, "c_oracle_") {
+		if full.CMedianNs != 0 || full.CMinNs != 0 || full.CMaxNs != 0 || full.Ratio != 0 || full.RatioIsLowerBound || full.Verdict != perfScanBucketNoData {
+			return fmt.Errorf("admitted oracle file C measurement failure contains fabricated C timing or ratio evidence")
+		}
+	}
+	return nil
+}
+
+func staticCSHA256Identity(value string) bool {
+	return len(value) == sha256.Size*2 && staticCHashIdentity(value)
+}
+
+func staticCHashIdentity(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func staticCFirstFor(language string, fileIndex int) bool {
+	sum := sha256.Sum256([]byte(language))
+	return (int(sum[0]&1)+fileIndex)%2 == 1
+}
+
+var staticLanguageSymbolPattern = regexp.MustCompile(`(?m)const\s+TSLanguage\s*\*\s*(tree_sitter_[A-Za-z0-9_]+)\s*\(void\)`)
+
+func buildStaticCPerfOracle(language string) (*staticCPerfOracle, error) {
+	lockPath, err := findParityLockPath()
+	if err != nil {
+		return nil, err
+	}
+	lock, err := loadParityLock(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := lock[language]
+	if !ok {
+		return nil, fmt.Errorf("static C oracle lock has no entry for %q", language)
+	}
+
+	cacheRoot := strings.TrimSpace(os.Getenv(staticCPerfCacheEnv))
+	if cacheRoot == "" {
+		repoRoot := filepath.Dir(filepath.Dir(lockPath))
+		cacheRoot = filepath.Join(repoRoot, "harness_out", "c_oracle", "fleet_static")
+	}
+	cacheRoot, err = filepath.Abs(cacheRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve static C oracle cache: %w", err)
+	}
+	sourcesRoot := filepath.Join(cacheRoot, "sources")
+	runtimeDir := filepath.Join(sourcesRoot, "tree-sitter-"+COracleRuntimeCommit)
+	if err := staticCEnsurePinnedRepo("runtime", staticCPerfRuntimeRepo, COracleRuntimeCommit, runtimeDir, ""); err != nil {
+		return nil, err
+	}
+	pinnedGrammarDir := filepath.Join(sourcesRoot, paritySafeName(language)+"-"+entry.Commit)
+	if err := staticCEnsurePinnedRepo(language+" grammar", entry.RepoURL, entry.Commit, pinnedGrammarDir, language); err != nil {
+		return nil, err
+	}
+	runtimeSource := filepath.Join(runtimeDir, "lib", "src", "lib.c")
+	var lastDrift error
+	for attempt := 1; attempt <= 2; attempt++ {
+		grammarDir, srcDir, parserPath, sourceMode, cleanupGrammar, resolveErr := staticCResolveGrammarSources(entry, pinnedGrammarDir, cacheRoot)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("%s: resolve locked parser: %w", language, resolveErr)
+		}
+		oracle, _, buildErr := func() (*staticCPerfOracle, string, error) {
+			defer cleanupGrammar()
+			symbol, err := staticCLanguageSymbol(entry, parserPath)
+			if err != nil {
+				return nil, "", err
+			}
+			scanners := staticCScannerSources(srcDir)
+			hasCXX := false
+			for _, scanner := range scanners {
+				switch strings.ToLower(filepath.Ext(scanner)) {
+				case ".cc", ".cpp", ".cxx":
+					hasCXX = true
+				}
+			}
+			driverPath, err := staticCPerfDriverPath()
+			if err != nil {
+				return nil, "", err
+			}
+			common, err := staticCCommonIdentity(runtimeDir, runtimeSource, driverPath)
+			if err != nil {
+				return nil, "", err
+			}
+			languageIdentity, err := staticCLanguageIdentity(entry, grammarDir, srcDir, parserPath, scanners, symbol, sourceMode, hasCXX)
+			if err != nil {
+				return nil, "", err
+			}
+			languageIdentity.BuildKeySHA256 = staticCBuildKey(common, languageIdentity)
+			buildDir := filepath.Join(cacheRoot, "artifacts", languageIdentity.BuildKeySHA256)
+			artifact := filepath.Join(buildDir, "perf_oracle")
+			inputs := staticCBuildInputSnapshot{
+				Common: common, Language: languageIdentity,
+				RuntimeRepoDir: runtimeDir, RuntimeSource: runtimeSource,
+				GrammarRepoDir: pinnedGrammarDir, GrammarTreePath: entry.Subdir,
+				SourceRoot: srcDir, ParserPath: parserPath, ScannerPaths: scanners,
+				DriverPath: driverPath,
+			}
+			validateInputs := func() error {
+				if err := staticCRevalidateBuildInputs(inputs); err != nil {
+					return fmt.Errorf("%w: %v", errStaticCBuildInputDrift, err)
+				}
+				return nil
+			}
+			artifactSHA, linkageProof, err := staticCEnsureArtifact(
+				buildDir,
+				artifact,
+				languageIdentity.BuildKeySHA256,
+				runtimeDir,
+				runtimeSource,
+				srcDir,
+				parserPath,
+				scanners,
+				driverPath,
+				symbol,
+				hasCXX,
+				common.CompilerPath,
+				languageIdentity.LinkerPath,
+				validateInputs,
+			)
+			if err != nil {
+				return nil, buildDir, fmt.Errorf("prepare static C oracle: %w", err)
+			}
+			if err := validateInputs(); err != nil {
+				return nil, buildDir, err
+			}
+			languageIdentity.ArtifactSHA256 = artifactSHA
+			languageIdentity.ArtifactStatic = true
+			languageIdentity.ArtifactLinkage = linkageProof
+			executable, cleanup, err := staticCPrivateExecutableSnapshot(artifact, artifactSHA, symbol)
+			if err != nil {
+				return nil, buildDir, fmt.Errorf("snapshot verified static C oracle: %w", err)
+			}
+			return &staticCPerfOracle{artifact: executable, identity: perfScanOracleIdentity{Common: common, Language: languageIdentity}, cleanup: cleanup}, buildDir, nil
+		}()
+		if buildErr == nil {
+			return oracle, nil
+		}
+		if !errors.Is(buildErr, errStaticCBuildInputDrift) {
+			return nil, fmt.Errorf("%s: %w", language, buildErr)
+		}
+		lastDrift = buildErr
+	}
+	return nil, fmt.Errorf("%s: static C build inputs remained unstable after retry: %w", language, lastDrift)
+}
+
+func staticCEnsurePinnedRepo(label, repoURL, commit, dest, language string) error {
+	if _, err := os.Stat(dest); err == nil {
+		if err := verifyPinnedRepo(dest, commit); err != nil {
+			return fmt.Errorf("%s cached checkout rejected: %w", label, err)
+		}
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.MkdirTemp(filepath.Dir(dest), filepath.Base(dest)+".tmp.")
+	if err != nil {
+		return err
+	}
+	_ = os.Remove(tmp)
+	defer os.RemoveAll(tmp)
+	if language != "" {
+		if cacheDir := parityRepoCacheDir(); cacheDir != "" {
+			short := commit
+			if len(short) > 12 {
+				short = short[:12]
+			}
+			if cached, err := findCachedParityRepo(cacheDir, language, short); err == nil {
+				if err := clonePinnedRepoFromLocalCache(cached, commit, tmp); err != nil {
+					return err
+				}
+				if err := os.Rename(tmp, dest); err != nil {
+					if verifyErr := verifyPinnedRepo(dest, commit); verifyErr != nil {
+						return err
+					}
+				}
+				return verifyPinnedRepo(dest, commit)
+			}
+		}
+	}
+	if err := clonePinnedRepo(repoURL, commit, tmp); err != nil {
+		return fmt.Errorf("clone pinned %s: %w", label, err)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		if verifyErr := verifyPinnedRepo(dest, commit); verifyErr != nil {
+			return fmt.Errorf("install pinned %s: %w", label, err)
+		}
+	}
+	return verifyPinnedRepo(dest, commit)
+}
+
+func staticCPerfDriverPath() (string, error) {
+	for _, candidate := range []string{
+		filepath.Join("pure_c", "perf_oracle.c"),
+		filepath.Join("cgo_harness", "pure_c", "perf_oracle.c"),
+		filepath.Join("..", "cgo_harness", "pure_c", "perf_oracle.c"),
+	} {
+		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() {
+			return filepath.Abs(candidate)
+		}
+	}
+	return "", fmt.Errorf("could not find pure_c/perf_oracle.c")
+}
+
+func staticCResolveGrammarSources(entry parityLockEntry, pinnedDir, cacheRoot string) (grammarDir, srcDir, parserPath, sourceMode string, cleanup func(), err error) {
+	cleanup = func() {}
+	expectedParser := filepath.Join(pinnedDir, entry.Subdir, "parser.c")
+	needsPreparedCopy := false
+	if _, statErr := os.Stat(expectedParser); statErr != nil {
+		needsPreparedCopy = true
+	} else if version, ok := readParserLanguageVersion(expectedParser); ok && (version < parityMinLanguageVersion || version > parityMaxLanguageVersion) {
+		needsPreparedCopy = true
+	}
+	grammarDir = pinnedDir
+	if needsPreparedCopy {
+		workRoot := filepath.Join(cacheRoot, "work")
+		if err = os.MkdirAll(workRoot, 0o755); err != nil {
+			return "", "", "", "", cleanup, err
+		}
+		grammarDir, err = os.MkdirTemp(workRoot, paritySafeName(entry.Name)+"-sources-")
+		if err != nil {
+			return "", "", "", "", cleanup, err
+		}
+		cleanup = func() { _ = os.RemoveAll(grammarDir) }
+		if err = clonePinnedRepoFromLocalCache(pinnedDir, entry.Commit, grammarDir); err != nil {
+			cleanup()
+			return "", "", "", "", func() {}, err
+		}
+	}
+	srcDir, parserPath, err = resolveParserSource(entry, grammarDir)
+	if err != nil {
+		cleanup()
+		return "", "", "", "", func() {}, err
+	}
+	sourceMode = staticCSourceLocked
+	if verifyErr := verifyPinnedRepo(grammarDir, entry.Commit); verifyErr != nil {
+		if !needsPreparedCopy {
+			return "", "", "", "", cleanup, fmt.Errorf("locked grammar checkout was modified while resolving sources: %w", verifyErr)
+		}
+		sourceMode = staticCSourceGenerated
+	}
+	return grammarDir, srcDir, parserPath, sourceMode, cleanup, nil
+}
+
+func staticCLanguageSymbol(entry parityLockEntry, parserPath string) (string, error) {
+	data, err := os.ReadFile(parserPath)
+	if err != nil {
+		return "", err
+	}
+	found := make(map[string]bool)
+	for _, match := range staticLanguageSymbolPattern.FindAllSubmatch(data, -1) {
+		found[string(match[1])] = true
+	}
+	for _, candidate := range parityLanguageSymbols(entry) {
+		if found[candidate] {
+			return candidate, nil
+		}
+	}
+	if len(found) == 1 {
+		for symbol := range found {
+			return symbol, nil
+		}
+	}
+	var symbols []string
+	for symbol := range found {
+		symbols = append(symbols, symbol)
+	}
+	sort.Strings(symbols)
+	return "", fmt.Errorf("%s: cannot select language symbol from %v", entry.Name, symbols)
+}
+
+func staticCScannerSources(srcDir string) []string {
+	var sources []string
+	for _, name := range []string{"scanner.c", "scanner.cc", "scanner.cpp", "scanner.cxx"} {
+		path := filepath.Join(srcDir, name)
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			sources = append(sources, path)
+		}
+	}
+	return sources
+}
+
+func staticCCommonIdentity(runtimeDir, runtimeSource, driverPath string) (perfScanOracleCommonIdentity, error) {
+	compilerPath, compilerVersion, compilerSHA, err := staticCToolIdentity("cc")
+	if err != nil {
+		return perfScanOracleCommonIdentity{}, err
+	}
+	runtimeTree, err := parityGitOutput(runtimeDir, "rev-parse", COracleRuntimeCommit+":lib/src")
+	if err != nil {
+		return perfScanOracleCommonIdentity{}, err
+	}
+	runtimeSHA, err := fileSHA256(runtimeSource)
+	if err != nil {
+		return perfScanOracleCommonIdentity{}, err
+	}
+	driverSHA, err := fileSHA256(driverPath)
+	if err != nil {
+		return perfScanOracleCommonIdentity{}, err
+	}
+	return perfScanOracleCommonIdentity{
+		Contract:             COracleContractVersion,
+		Transport:            staticCPerfTransport,
+		Linkage:              staticCPerfLinkage,
+		BindingModule:        COracleBindingModule,
+		BindingVersion:       COracleBindingVersion,
+		BindingCommit:        COracleBindingCommit,
+		RuntimeRepo:          staticCPerfRuntimeRepo,
+		RuntimeVersion:       COracleRuntimeVersion,
+		RuntimeCommit:        COracleRuntimeCommit,
+		RuntimeSourceTreeOID: strings.TrimSpace(runtimeTree),
+		RuntimeSourceSHA256:  runtimeSHA,
+		OptimizationFlags:    staticCPerfOptimizationFlags,
+		RuntimeCFlags:        staticCPerfRuntimeCFlags,
+		GrammarCFlags:        staticCPerfGrammarCFlags,
+		GrammarCXXFlags:      staticCPerfGrammarCXXFlags,
+		DriverCFlags:         staticCPerfDriverCFlags,
+		LinkFlags:            staticCPerfLinkFlags,
+		TimingRegion:         staticCPerfTimingRegion,
+		OrderProtocol:        staticCPerfOrderProtocol,
+		FailureVocabulary:    staticCPerfFailureVocabulary,
+		TargetOS:             runtime.GOOS,
+		TargetArch:           runtime.GOARCH,
+		CompilerPath:         compilerPath,
+		CompilerVersion:      compilerVersion,
+		CompilerSHA256:       compilerSHA,
+		DriverSHA256:         driverSHA,
+		DeepDigestFormat:     "gts-deep-tree-v1",
+	}, nil
+}
+
+func staticCLanguageIdentity(entry parityLockEntry, grammarDir, srcDir, parserPath string, scanners []string, symbol, sourceMode string, hasCXX bool) (perfScanOracleLanguageIdentity, error) {
+	tree, err := parityGitOutput(grammarDir, "rev-parse", entry.Commit+":"+filepath.ToSlash(entry.Subdir))
+	if err != nil {
+		return perfScanOracleLanguageIdentity{}, err
+	}
+	parserSHA, err := fileSHA256(parserPath)
+	if err != nil {
+		return perfScanOracleLanguageIdentity{}, err
+	}
+	identity := perfScanOracleLanguageIdentity{
+		Language:          entry.Name,
+		GrammarRepo:       entry.RepoURL,
+		GrammarCommit:     entry.Commit,
+		GrammarSourceTree: strings.TrimSpace(tree),
+		GrammarSourceMode: sourceMode,
+		LanguageSymbol:    symbol,
+		Parser: perfScanOracleSourceIdentity{
+			Path:         staticCSourceRelative(srcDir, parserPath),
+			SHA256:       parserSHA,
+			CompileFlags: staticCPerfGrammarCFlags,
+		},
+	}
+	for _, scanner := range scanners {
+		sha, err := fileSHA256(scanner)
+		if err != nil {
+			return perfScanOracleLanguageIdentity{}, err
+		}
+		flags := staticCPerfGrammarCFlags
+		switch strings.ToLower(filepath.Ext(scanner)) {
+		case ".cc", ".cpp", ".cxx":
+			flags = staticCPerfGrammarCXXFlags
+		}
+		identity.Scanners = append(identity.Scanners, perfScanOracleSourceIdentity{
+			Path: staticCSourceRelative(srcDir, scanner), SHA256: sha, CompileFlags: flags,
+		})
+	}
+	linker := "cc"
+	if hasCXX {
+		linker = "c++"
+	}
+	identity.LinkerPath, identity.LinkerVersion, identity.LinkerSHA256, err = staticCToolIdentity(linker)
+	if err != nil {
+		return perfScanOracleLanguageIdentity{}, err
+	}
+	return identity, nil
+}
+
+func staticCSourceRelative(root, path string) string {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func staticCToolIdentity(name string) (string, string, string, error) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve C oracle tool %s: %w", name, err)
+	}
+	return staticCToolIdentityAtPath(path)
+}
+
+func staticCToolIdentityAtPath(path string) (string, string, string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve C oracle tool path %s: %w", path, err)
+	}
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return "", "", "", fmt.Errorf("read C oracle tool version %s: %w", path, err)
+	}
+	version := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	if version == "" {
+		return "", "", "", fmt.Errorf("C oracle tool %s returned an empty version", path)
+	}
+	sha, err := fileSHA256(path)
+	if err != nil {
+		return "", "", "", fmt.Errorf("hash C oracle tool %s: %w", path, err)
+	}
+	return path, version, sha, nil
+}
+
+func staticCRevalidateBuildInputs(inputs staticCBuildInputSnapshot) error {
+	common := inputs.Common
+	language := inputs.Language
+	checkTool := func(label, path, wantVersion, wantSHA string) error {
+		gotPath, gotVersion, gotSHA, err := staticCToolIdentityAtPath(path)
+		if err != nil {
+			return fmt.Errorf("%s executable: %w", label, err)
+		}
+		if gotPath != path || gotVersion != wantVersion || gotSHA != wantSHA {
+			return fmt.Errorf("%s executable changed: path/version/sha=%q/%q/%q, want %q/%q/%q", label, gotPath, gotVersion, gotSHA, path, wantVersion, wantSHA)
+		}
+		return nil
+	}
+	if err := checkTool("compiler", common.CompilerPath, common.CompilerVersion, common.CompilerSHA256); err != nil {
+		return err
+	}
+	if err := checkTool("linker", language.LinkerPath, language.LinkerVersion, language.LinkerSHA256); err != nil {
+		return err
+	}
+	checkFile := func(label, path, wantSHA string) error {
+		gotSHA, err := fileSHA256(path)
+		if err != nil {
+			return fmt.Errorf("%s source: %w", label, err)
+		}
+		if gotSHA != wantSHA {
+			return fmt.Errorf("%s source changed: sha=%s, want %s", label, gotSHA, wantSHA)
+		}
+		return nil
+	}
+	if err := checkFile("runtime", inputs.RuntimeSource, common.RuntimeSourceSHA256); err != nil {
+		return err
+	}
+	if err := checkFile("driver", inputs.DriverPath, common.DriverSHA256); err != nil {
+		return err
+	}
+	if got := staticCSourceRelative(inputs.SourceRoot, inputs.ParserPath); got != language.Parser.Path {
+		return fmt.Errorf("parser source path changed: %q, want %q", got, language.Parser.Path)
+	}
+	if err := checkFile("parser", inputs.ParserPath, language.Parser.SHA256); err != nil {
+		return err
+	}
+	if len(inputs.ScannerPaths) != len(language.Scanners) {
+		return fmt.Errorf("scanner source count changed: %d, want %d", len(inputs.ScannerPaths), len(language.Scanners))
+	}
+	for i, scanner := range inputs.ScannerPaths {
+		identity := language.Scanners[i]
+		if got := staticCSourceRelative(inputs.SourceRoot, scanner); got != identity.Path {
+			return fmt.Errorf("scanner %d source path changed: %q, want %q", i, got, identity.Path)
+		}
+		if err := checkFile(fmt.Sprintf("scanner %d", i), scanner, identity.SHA256); err != nil {
+			return err
+		}
+	}
+	if inputs.RuntimeRepoDir != "" {
+		if err := verifyPinnedRepo(inputs.RuntimeRepoDir, common.RuntimeCommit); err != nil {
+			return fmt.Errorf("runtime repository: %w", err)
+		}
+		tree, err := parityGitOutput(inputs.RuntimeRepoDir, "rev-parse", common.RuntimeCommit+":lib/src")
+		if err != nil || strings.TrimSpace(tree) != common.RuntimeSourceTreeOID {
+			return fmt.Errorf("runtime source tree changed: oid=%q want=%q err=%v", strings.TrimSpace(tree), common.RuntimeSourceTreeOID, err)
+		}
+	}
+	if inputs.GrammarRepoDir != "" {
+		if err := verifyPinnedRepo(inputs.GrammarRepoDir, language.GrammarCommit); err != nil {
+			return fmt.Errorf("grammar repository: %w", err)
+		}
+		tree, err := parityGitOutput(inputs.GrammarRepoDir, "rev-parse", language.GrammarCommit+":"+filepath.ToSlash(inputs.GrammarTreePath))
+		if err != nil || strings.TrimSpace(tree) != language.GrammarSourceTree {
+			return fmt.Errorf("grammar source tree changed: oid=%q want=%q err=%v", strings.TrimSpace(tree), language.GrammarSourceTree, err)
+		}
+	}
+	return nil
+}
+
+func staticCScannerKey(scanners []perfScanOracleSourceIdentity) string {
+	var parts []string
+	for _, scanner := range scanners {
+		parts = append(parts, scanner.Path+"="+scanner.SHA256)
+	}
+	return strings.Join(parts, ";")
+}
+
+func staticCBuildKey(common perfScanOracleCommonIdentity, language perfScanOracleLanguageIdentity) string {
+	keyInput := strings.Join([]string{
+		common.Contract, common.BindingCommit, common.RuntimeCommit,
+		common.RuntimeSourceTreeOID, common.RuntimeSourceSHA256,
+		common.OptimizationFlags, common.RuntimeCFlags, common.GrammarCFlags,
+		common.GrammarCXXFlags, common.DriverCFlags, common.LinkFlags,
+		common.TimingRegion, common.OrderProtocol, common.FailureVocabulary, common.TargetOS, common.TargetArch,
+		common.CompilerPath, common.CompilerVersion, common.CompilerSHA256, common.DriverSHA256,
+		language.Language, language.GrammarRepo, language.GrammarCommit,
+		language.GrammarSourceTree, language.GrammarSourceMode, language.LanguageSymbol,
+		language.Parser.Path, language.Parser.SHA256, language.Parser.CompileFlags,
+		staticCScannerKey(language.Scanners),
+		language.LinkerPath, language.LinkerVersion, language.LinkerSHA256,
+	}, "\x00")
+	key := sha256.Sum256([]byte(keyInput))
+	return hex.EncodeToString(key[:])
+}
+
+func staticCEnsureArtifact(buildDir, artifact, buildKey, runtimeDir, runtimeSource, srcDir, parserPath string, scanners []string, driverPath, symbol string, hasCXX bool, compilerPath, linkerPath string, validateInputs func() error) (string, string, error) {
+	return staticCEnsureCachedArtifactValidated(buildDir, artifact, buildKey, symbol, validateInputs, func() error {
+		return staticCBuildArtifact(buildDir, artifact, buildKey, runtimeDir, runtimeSource, srcDir, parserPath, scanners, driverPath, symbol, hasCXX, compilerPath, linkerPath, validateInputs)
+	})
+}
+
+func staticCEnsureCachedArtifact(buildDir, artifact, buildKey, symbol string, build func() error) (string, string, error) {
+	return staticCEnsureCachedArtifactValidated(buildDir, artifact, buildKey, symbol, nil, build)
+}
+
+func staticCEnsureCachedArtifactValidated(buildDir, artifact, buildKey, symbol string, validateInputs func() error, build func() error) (string, string, error) {
+	if artifactSHA, proof, err := staticCValidateCachedArtifact(buildDir, artifact, buildKey, symbol); err == nil {
+		if validateInputs != nil {
+			if err := validateInputs(); err != nil {
+				return "", "", err
+			}
+		}
+		return artifactSHA, proof, nil
+	}
+
+	var rejectedDir string
+	if _, err := os.Stat(buildDir); err == nil {
+		if err := os.MkdirAll(filepath.Dir(buildDir), 0o755); err != nil {
+			return "", "", err
+		}
+		rejectedDir, err = os.MkdirTemp(filepath.Dir(buildDir), filepath.Base(buildDir)+".rejected.")
+		if err != nil {
+			return "", "", fmt.Errorf("reserve rejected cache path: %w", err)
+		}
+		if err := os.Remove(rejectedDir); err != nil {
+			return "", "", err
+		}
+		if err := os.Rename(buildDir, rejectedDir); err != nil {
+			// A concurrent builder may have replaced the entry between validation
+			// and quarantine. Accept it only after the complete manifest/hash/static
+			// validation succeeds against the same content key.
+			if artifactSHA, proof, validateErr := staticCValidateCachedArtifact(buildDir, artifact, buildKey, symbol); validateErr == nil {
+				if validateInputs != nil {
+					if err := validateInputs(); err != nil {
+						return "", "", err
+					}
+				}
+				return artifactSHA, proof, nil
+			}
+			return "", "", fmt.Errorf("quarantine invalid static C artifact cache: %w", err)
+		}
+		defer os.RemoveAll(rejectedDir)
+	} else if !os.IsNotExist(err) {
+		return "", "", fmt.Errorf("inspect static C artifact cache: %w", err)
+	}
+
+	if build == nil {
+		return "", "", fmt.Errorf("static C artifact builder is nil")
+	}
+	if err := build(); err != nil {
+		return "", "", fmt.Errorf("build static C oracle: %w", err)
+	}
+	artifactSHA, proof, err := staticCValidateCachedArtifact(buildDir, artifact, buildKey, symbol)
+	if err != nil {
+		return "", "", fmt.Errorf("validate installed static C oracle: %w", err)
+	}
+	if validateInputs != nil {
+		if err := validateInputs(); err != nil {
+			return "", "", err
+		}
+	}
+	return artifactSHA, proof, nil
+}
+
+func staticCBuildArtifact(buildDir, artifact, buildKey, runtimeDir, runtimeSource, srcDir, parserPath string, scanners []string, driverPath, symbol string, hasCXX bool, compilerPath, linkerPath string, validateInputs func() error) error {
+	if !filepath.IsAbs(compilerPath) || !filepath.IsAbs(linkerPath) {
+		return fmt.Errorf("static C compiler/linker paths must be absolute")
+	}
+	if err := os.MkdirAll(filepath.Dir(buildDir), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.MkdirTemp(filepath.Dir(buildDir), filepath.Base(buildDir)+".tmp.")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+	runtimeObj := filepath.Join(tmp, "runtime.o")
+	runtimeArgs := append(strings.Fields(staticCPerfRuntimeCFlags), "-I", filepath.Join(runtimeDir, "lib", "include"), "-I", filepath.Join(runtimeDir, "lib", "src"), "-c", runtimeSource, "-o", runtimeObj)
+	if err := runCommand("", compilerPath, runtimeArgs...); err != nil {
+		return err
+	}
+	var objects []string
+	compileGrammar := func(source, object string) error {
+		ext := strings.ToLower(filepath.Ext(source))
+		if ext == ".cc" || ext == ".cpp" || ext == ".cxx" {
+			args := append(strings.Fields(staticCPerfGrammarCXXFlags), "-I", srcDir, "-I", filepath.Join(runtimeDir, "lib", "include"), "-c", source, "-o", object)
+			return runCommand("", linkerPath, args...)
+		}
+		args := append(strings.Fields(staticCPerfGrammarCFlags), "-I", srcDir, "-I", filepath.Join(runtimeDir, "lib", "include"), "-c", source, "-o", object)
+		return runCommand("", compilerPath, args...)
+	}
+	allGrammar := append([]string{parserPath}, scanners...)
+	for i, source := range allGrammar {
+		object := filepath.Join(tmp, fmt.Sprintf("grammar_%d.o", i))
+		if err := compileGrammar(source, object); err != nil {
+			return err
+		}
+		objects = append(objects, object)
+	}
+	driverObj := filepath.Join(tmp, "driver.o")
+	driverArgs := append(strings.Fields(staticCPerfDriverCFlags), "-DTS_LANG_FN="+symbol, "-I", filepath.Join(runtimeDir, "lib", "include", "tree_sitter"), "-c", driverPath, "-o", driverObj)
+	if err := runCommand("", compilerPath, driverArgs...); err != nil {
+		return err
+	}
+	if hasCXX && linkerPath == compilerPath {
+		return fmt.Errorf("C++ scanner build did not resolve a distinct C++ linker")
+	}
+	args := append(strings.Fields(staticCPerfLinkFlags), "-o", filepath.Join(tmp, "perf_oracle"), driverObj)
+	args = append(args, objects...)
+	args = append(args, runtimeObj)
+	if err := runCommand("", linkerPath, args...); err != nil {
+		return err
+	}
+	return staticCInstallBuiltArtifact(tmp, buildDir, artifact, buildKey, symbol, validateInputs)
+}
+
+func staticCInstallBuiltArtifact(tmp, buildDir, artifact, buildKey, symbol string, validateInputs func() error) error {
+	if validateInputs != nil {
+		if err := validateInputs(); err != nil {
+			return err
+		}
+	}
+	if err := staticCWriteArtifactManifest(tmp, filepath.Join(tmp, "perf_oracle"), buildKey); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, buildDir); err != nil {
+		// Content-keyed artifacts are immutable. Another shard may have won
+		// the same atomic install while this one compiled. It is acceptable
+		// only if the winner installed the matching manifest and artifact and
+		// the captured build inputs are still current.
+		if _, _, validateErr := staticCValidateCachedArtifact(buildDir, artifact, buildKey, symbol); validateErr != nil {
+			return fmt.Errorf("install artifact: %w (concurrent cache validation: %v)", err, validateErr)
+		}
+		if validateInputs != nil {
+			if validateErr := validateInputs(); validateErr != nil {
+				return validateErr
+			}
+		}
+	}
+	return nil
+}
+
+func staticCArtifactManifestPath(buildDir string) string {
+	return filepath.Join(buildDir, "manifest.json")
+}
+
+func staticCWriteArtifactManifest(buildDir, artifact, buildKey string) error {
+	if len(buildKey) != sha256.Size*2 || !staticCHashIdentity(buildKey) {
+		return fmt.Errorf("invalid static C artifact build key %q", buildKey)
+	}
+	artifactSHA, err := fileSHA256(artifact)
+	if err != nil {
+		return fmt.Errorf("hash static C artifact for manifest: %w", err)
+	}
+	manifest := staticCArtifactManifest{
+		Schema:         staticCArtifactManifestSchema,
+		BuildKeySHA256: buildKey,
+		ArtifactSHA256: artifactSHA,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(staticCArtifactManifestPath(buildDir), data, 0o444); err != nil {
+		return fmt.Errorf("write static C artifact manifest: %w", err)
+	}
+	return nil
+}
+
+func staticCValidateCachedArtifact(buildDir, artifact, buildKey, symbol string) (string, string, error) {
+	data, err := os.ReadFile(staticCArtifactManifestPath(buildDir))
+	if err != nil {
+		return "", "", fmt.Errorf("read static C artifact manifest: %w", err)
+	}
+	var manifest staticCArtifactManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", "", fmt.Errorf("decode static C artifact manifest: %w", err)
+	}
+	if manifest.Schema != staticCArtifactManifestSchema {
+		return "", "", fmt.Errorf("static C artifact manifest schema=%q, want %q", manifest.Schema, staticCArtifactManifestSchema)
+	}
+	if manifest.BuildKeySHA256 != buildKey {
+		return "", "", fmt.Errorf("static C artifact manifest build key=%q, want %q", manifest.BuildKeySHA256, buildKey)
+	}
+	if len(manifest.ArtifactSHA256) != sha256.Size*2 || !staticCHashIdentity(manifest.ArtifactSHA256) {
+		return "", "", fmt.Errorf("static C artifact manifest has invalid artifact SHA %q", manifest.ArtifactSHA256)
+	}
+	artifactSHA, err := fileSHA256(artifact)
+	if err != nil {
+		return "", "", fmt.Errorf("hash cached static C artifact: %w", err)
+	}
+	if artifactSHA != manifest.ArtifactSHA256 {
+		return "", "", fmt.Errorf("cached static C artifact SHA=%s, manifest=%s", artifactSHA, manifest.ArtifactSHA256)
+	}
+	proof, err := staticCVerifyArtifact(artifact, symbol)
+	if err != nil {
+		return "", "", err
+	}
+	return artifactSHA, proof, nil
+}
+
+func staticCVerifyArtifact(artifact, symbol string) (string, error) {
+	if strings.TrimSpace(symbol) == "" {
+		return "", fmt.Errorf("language symbol is empty")
+	}
+	nmOut, err := exec.Command("nm", artifact).Output()
+	if err != nil {
+		return "", fmt.Errorf("nm: %w", err)
+	}
+	defined := make(map[string]bool)
+	for line := range strings.SplitSeq(string(nmOut), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && !strings.EqualFold(fields[len(fields)-2], "U") {
+			defined[fields[len(fields)-1]] = true
+		}
+	}
+	for _, required := range []string{"ts_parser_parse", symbol} {
+		if !defined[required] {
+			return "", fmt.Errorf("artifact does not define %s", required)
+		}
+	}
+	readelfOut, err := exec.Command("readelf", "-d", artifact).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("readelf dynamic-section proof: %w: %s", err, strings.TrimSpace(string(readelfOut)))
+	}
+	if bytes.Contains(readelfOut, []byte("NEEDED")) {
+		return "", fmt.Errorf("artifact has dynamic dependencies: %s", strings.TrimSpace(string(readelfOut)))
+	}
+	programOut, err := exec.Command("readelf", "-l", artifact).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("readelf program-header proof: %w: %s", err, strings.TrimSpace(string(programOut)))
+	}
+	if bytes.Contains(programOut, []byte("INTERP")) {
+		return "", fmt.Errorf("artifact has a dynamic program interpreter: %s", strings.TrimSpace(string(programOut)))
+	}
+	return staticCPerfLinkageProof, nil
+}
+
+func staticCPrivateExecutableSnapshot(artifact, expectedSHA, symbol string) (string, func(), error) {
+	dir, err := os.MkdirTemp("", "gts-static-c-exec-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	source, err := os.Open(artifact)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	info, err := source.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		_ = source.Close()
+		cleanup()
+		if err == nil {
+			err = fmt.Errorf("cached static C artifact is not a regular file")
+		}
+		return "", nil, err
+	}
+	privatePath := filepath.Join(dir, "perf_oracle")
+	destination, err := os.OpenFile(privatePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o500)
+	if err != nil {
+		_ = source.Close()
+		cleanup()
+		return "", nil, err
+	}
+	_, copyErr := io.Copy(destination, source)
+	closeSourceErr := source.Close()
+	syncErr := destination.Sync()
+	closeDestinationErr := destination.Close()
+	for _, candidate := range []error{copyErr, closeSourceErr, syncErr, closeDestinationErr} {
+		if candidate != nil {
+			cleanup()
+			return "", nil, candidate
+		}
+	}
+	snapshotSHA, err := fileSHA256(privatePath)
+	if err != nil || snapshotSHA != expectedSHA {
+		cleanup()
+		if err == nil {
+			err = fmt.Errorf("private static C artifact SHA=%s, want %s", snapshotSHA, expectedSHA)
+		}
+		return "", nil, err
+	}
+	if _, err := staticCVerifyArtifact(privatePath, symbol); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return privatePath, cleanup, nil
+}
+
+func (oracle *staticCPerfOracle) snapshot(source []byte) (string, string, func(), error) {
+	sum := sha256.Sum256(source)
+	sourceSHA := hex.EncodeToString(sum[:])
+	dir, err := os.MkdirTemp("", "gts-static-c-source-*")
+	if err != nil {
+		return "", sourceSHA, nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	path := filepath.Join(dir, "source.snapshot")
+	if err := os.WriteFile(path, source, 0o444); err != nil {
+		cleanup()
+		return "", sourceSHA, nil, err
+	}
+	return path, sourceSHA, cleanup, nil
+}
+
+func staticCSidecarFailureStatus(detail string, contextErr error, fallback string) string {
+	for marker, status := range map[string]string{
+		"status=c_timeout":           staticCStatusParserTimeout,
+		"status=c_parser_error":      staticCStatusParserError,
+		"status=c_transport_error":   staticCStatusTransportError,
+		"status=c_digest_error":      staticCStatusDigestError,
+		"status=c_measurement_error": staticCStatusMeasurementError,
+		"status=c_protocol_error":    staticCStatusProtocolError,
+		"status=c_incomplete":        staticCStatusIncomplete,
+	} {
+		if strings.Contains(detail, marker) {
+			return status
+		}
+	}
+	if contextErr != nil {
+		return staticCStatusTransportTimeout
+	}
+	return fallback
+}
+
+func (oracle *staticCPerfOracle) deepDigest(source []byte, budget time.Duration) (string, string, error) {
+	path, sourceSHA, cleanup, err := oracle.snapshot(source)
+	if err != nil {
+		return "", sourceSHA, newStaticCOracleError(staticCStatusTransportError, "snapshot static C deep-digest source: "+err.Error())
+	}
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), budget+oracle.transportGrace())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, oracle.artifact, "dump", path, strconv.FormatInt(budget.Microseconds(), 10))
+	h := sha256.New()
+	cmd.Stdout = h
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		status := staticCSidecarFailureStatus(detail, ctx.Err(), staticCStatusTransportError)
+		return "", sourceSHA, newStaticCOracleError(status, strings.TrimSpace(fmt.Sprintf("static C deep dump: %v: %s", err, detail)))
+	}
+	if detail := strings.TrimSpace(stderr.String()); detail != "" {
+		return "", sourceSHA, newStaticCOracleError(staticCStatusProtocolError, "static C deep dump wrote stderr: "+detail)
+	}
+	return hex.EncodeToString(h.Sum(nil)), sourceSHA, nil
+}
+
+func (oracle *staticCPerfOracle) measure(source []byte, axis string, warmup, reps int, budget time.Duration) staticCPerfMeasurement {
+	if axis != perfScanAxisFull {
+		return staticCPerfMeasurement{Status: staticCStatusMeasurementError, Detail: "static C publication oracle supports fresh full parse only"}
+	}
+	path, _, cleanup, err := oracle.snapshot(source)
+	if err != nil {
+		return staticCPerfMeasurement{Status: staticCStatusTransportError, Detail: err.Error()}
+	}
+	defer cleanup()
+	wall := time.Duration(warmup+reps+1)*budget + oracle.transportGrace()
+	ctx, cancel := context.WithTimeout(context.Background(), wall)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, oracle.artifact, "measure", axis, path, strconv.Itoa(warmup), strconv.Itoa(reps), strconv.FormatInt(budget.Microseconds(), 10))
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return staticCPerfMeasurement{Status: staticCStatusTransportError, Detail: err.Error()}
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return staticCPerfMeasurement{Status: staticCStatusTransportError, Detail: err.Error()}
+	}
+	result := staticCPerfMeasurement{}
+	var schemaSeen, axisSeen, statusSeen bool
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "schema="):
+			if schemaSeen || strings.TrimPrefix(line, "schema=") != staticCPerfSchema {
+				result.Status = staticCStatusProtocolError
+				result.Detail = "unexpected static C schema: " + line
+			}
+			schemaSeen = true
+		case strings.HasPrefix(line, "axis="):
+			if axisSeen || strings.TrimPrefix(line, "axis=") != axis {
+				result.Status = staticCStatusProtocolError
+				result.Detail = "unexpected static C axis: " + line
+			}
+			axisSeen = true
+		case strings.HasPrefix(line, "sample_ns="):
+			ns, parseErr := strconv.ParseInt(strings.TrimPrefix(line, "sample_ns="), 10, 64)
+			if parseErr != nil || ns <= 0 {
+				result.Status = staticCStatusMeasurementError
+				result.Detail = "invalid static C sample: " + line
+			} else {
+				result.Samples = append(result.Samples, ns)
+			}
+		case strings.HasPrefix(line, "status="):
+			status := strings.TrimPrefix(line, "status=")
+			if statusSeen {
+				result.Status = staticCStatusProtocolError
+				result.Detail = "duplicate static C status"
+			} else if status == "ok" {
+				if result.Status == "" {
+					result.Status = perfScanStatusOK
+				}
+			} else if status == "c_timeout" {
+				result.Status = staticCStatusParserTimeout
+				result.Detail = status
+			} else if status == "c_incomplete" {
+				result.Status = staticCStatusIncomplete
+				result.Detail = status
+			} else {
+				result.Status = staticCStatusProtocolError
+				result.Detail = "unexpected static C status: " + status
+			}
+			statusSeen = true
+		default:
+			result.Status = staticCStatusProtocolError
+			result.Detail = "unexpected static C protocol line: " + line
+		}
+	}
+	waitErr := cmd.Wait()
+	if scanner.Err() != nil && result.Detail == "" {
+		result.Status, result.Detail = staticCStatusTransportError, scanner.Err().Error()
+	}
+	if waitErr != nil {
+		result.Detail = strings.TrimSpace(fmt.Sprintf("%v %s", waitErr, stderr.String()))
+		result.Status = staticCSidecarFailureStatus(result.Detail, ctx.Err(), staticCStatusTransportError)
+	} else if detail := strings.TrimSpace(stderr.String()); detail != "" {
+		result.Status = staticCStatusProtocolError
+		result.Detail = "static C measurement wrote stderr: " + detail
+	}
+	if result.Status == perfScanStatusOK && (!schemaSeen || !axisSeen || !statusSeen) {
+		result.Status = staticCStatusProtocolError
+		result.Detail = "static C response is missing schema, axis, or status"
+	}
+	if result.Status == perfScanStatusOK && len(result.Samples) != reps {
+		result.Status = staticCStatusMeasurementError
+		result.Detail = fmt.Sprintf("static C returned %d samples, want %d", len(result.Samples), reps)
+	}
+	if result.Status == "" {
+		result.Status = staticCStatusProtocolError
+		result.Detail = "static C returned no status"
+	}
+	return result
+}

--- a/cgo_harness/zz_perf_scan_reduce_test.go
+++ b/cgo_harness/zz_perf_scan_reduce_test.go
@@ -215,6 +215,7 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 	var (
 		baseConfig   *perfScanConfig
 		baseHost     perfScanHost
+		baseOracle   *perfScanOracleCommonIdentity
 		revision     string
 		rowsByLang   = make(map[string]*perfScanLanguage, len(wantLanguages))
 		generatedMax time.Time
@@ -292,6 +293,15 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 			if err := perfScanValidateClassification(file.Classification); err != nil {
 				return nil, fmt.Errorf("shard %s language %q file %q classification: %w", shardPath, lang, file.Path, err)
 			}
+		}
+		if err := perfScanValidateOracleEvidence(shard); err != nil {
+			return nil, fmt.Errorf("shard %s static C oracle evidence: %w", shardPath, err)
+		}
+		if baseOracle == nil {
+			common := shard.Oracle.Common
+			baseOracle = &common
+		} else if !reflect.DeepEqual(*baseOracle, shard.Oracle.Common) {
+			return nil, fmt.Errorf("shard %s static C oracle common identity differs from earlier shards", shardPath)
 		}
 
 		comparable := perfScanComparableShardConfig(shard.Config)
@@ -372,6 +382,11 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 		board.Languages = append(board.Languages, row)
 		board.Summary[row.Verdict]++
 	}
+	oracleIdentity, err := perfScanOracleBoardFromRows(board.Languages)
+	if err != nil {
+		return nil, fmt.Errorf("assemble reduced static C oracle identity: %w", err)
+	}
+	board.Oracle = oracleIdentity
 	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
 	gate := perfScanEvaluateHardGate(board)
 	board.Gate = &gate
@@ -734,6 +749,83 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 		})
 	}
 
+	t.Run("typed C admission timeout remains authenticated failing evidence", func(t *testing.T) {
+		paths := makeInputs(t, func(_ *perfScanScoreboard, pythonShard *perfScanScoreboard) {
+			row := pythonShard.Languages[0]
+			file := row.Files[0]
+			admission := file.OracleAdmission
+			admission.Admitted = false
+			admission.StaticDeepSHA256 = ""
+			admission.ParityDeepSHA256 = ""
+			admission.Status = staticCStatusParserTimeout
+			admission.Detail = "static C deep dump reached the per-file timeout"
+			full := file.Axes[perfScanAxisFull]
+			full.Status = staticCStatusParserTimeout
+			full.Detail = admission.Detail
+			full.CMedianNs = 0
+			full.CMinNs = 0
+			full.CMaxNs = 0
+			full.Ratio = 0
+			full.RatioIsLowerBound = false
+			full.Verdict = perfScanBucketNoData
+			full.GoMinNs = full.GoMedianNs
+			full.GoMaxNs = full.GoMedianNs
+			row.Status = staticCStatusParserTimeout
+			row.Detail = admission.Detail
+			gate := perfScanEvaluateHardGate(pythonShard)
+			pythonShard.Gate = &gate
+		})
+		board, err := reduce(paths)
+		if err != nil {
+			t.Fatalf("reduce typed C timeout evidence: %v", err)
+		}
+		if board.Gate == nil || board.Gate.Status != perfScanGateFail {
+			t.Fatalf("typed C timeout did not fail closure: %+v", board.Gate)
+		}
+		var sawCFailure bool
+		for _, finding := range board.Gate.Failures {
+			if finding.Kind == "oracle" {
+				t.Fatalf("typed C timeout was misclassified as unauthenticated provenance: %+v", board.Gate)
+			}
+			if finding.Language == "python" && finding.Status == staticCStatusParserTimeout {
+				sawCFailure = true
+			}
+		}
+		if !sawCFailure {
+			t.Fatalf("typed C timeout was not retained as a closure failure: %+v", board.Gate)
+		}
+	})
+
+	t.Run("typed C measurement protocol failure remains authenticated failing evidence", func(t *testing.T) {
+		paths := makeInputs(t, func(_ *perfScanScoreboard, pythonShard *perfScanScoreboard) {
+			row := pythonShard.Languages[0]
+			file := row.Files[0]
+			full := file.Axes[perfScanAxisFull]
+			full.Status = staticCStatusProtocolError
+			full.Detail = "static C response omitted its schema"
+			full.CMedianNs = 0
+			full.CMinNs = 0
+			full.CMaxNs = 0
+			full.Ratio = 0
+			full.RatioIsLowerBound = false
+			full.Verdict = perfScanBucketNoData
+			gate := perfScanEvaluateHardGate(pythonShard)
+			pythonShard.Gate = &gate
+		})
+		board, err := reduce(paths)
+		if err != nil {
+			t.Fatalf("reduce typed C measurement failure: %v", err)
+		}
+		if board.Gate == nil || board.Gate.Status != perfScanGateFail {
+			t.Fatalf("typed C measurement failure did not fail closure: %+v", board.Gate)
+		}
+		for _, finding := range board.Gate.Failures {
+			if finding.Kind == "oracle" {
+				t.Fatalf("typed C measurement failure was misclassified as unauthenticated provenance: %+v", board.Gate)
+			}
+		}
+	})
+
 	tests := []struct {
 		name   string
 		paths  func(*testing.T) []string
@@ -752,6 +844,8 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 			mutate: func(_, pythonShard *perfScanScoreboard) {
 				pythonShard.Config.Languages = []string{"go"}
 				pythonShard.Languages[0].Language = "go"
+				pythonShard.Languages[0].Oracle = perfScanTestOracleIdentity("go")
+				pythonShard.Oracle, _ = perfScanOracleBoardFromRows(pythonShard.Languages)
 			},
 			want: "duplicate shard language",
 		},
@@ -761,6 +855,197 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 				pythonShard.Schema = "gts-perf-scan/v0"
 			},
 			want: "schema",
+		},
+		{
+			name: "missing static oracle identity",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle = nil
+			},
+			want: "missing static C oracle identity",
+		},
+		{
+			name: "dynamic oracle linkage",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle.Common.Linkage = "shared_dlopen"
+				pythonShard.Languages[0].Oracle.Common.Linkage = "shared_dlopen"
+			},
+			want: "contract/transport/linkage",
+		},
+		{
+			name: "missing deep admission",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].OracleAdmission = nil
+			},
+			want: "missing oracle admission",
+		},
+		{
+			name: "wrong measurement order",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				file := pythonShard.Languages[0].Files[0]
+				file.MeasurementOrder = "go_then_static_c"
+				if perfScanTestMeasurementOrder("python", 0) == file.MeasurementOrder {
+					file.MeasurementOrder = "static_c_then_go"
+				}
+			},
+			want: "measurement order",
+		},
+		{
+			name: "deep admission mismatch",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Languages[0].Files[0].OracleAdmission.ParityDeepSHA256 = strings.Repeat("a", 64)
+			},
+			want: "invalid static/cgo deep admission",
+		},
+		{
+			name: "untyped failed admission",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				admission := pythonShard.Languages[0].Files[0].OracleAdmission
+				admission.Admitted = false
+				admission.StaticDeepSHA256 = ""
+				admission.ParityDeepSHA256 = ""
+				admission.Detail = "untyped failure"
+			},
+			want: "unrecognized failed oracle admission status",
+		},
+		{
+			name: "failed admission legacy c error",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				file := pythonShard.Languages[0].Files[0]
+				admission := file.OracleAdmission
+				admission.Admitted = false
+				admission.StaticDeepSHA256 = ""
+				admission.ParityDeepSHA256 = ""
+				admission.Status = "c_error"
+				admission.Detail = "legacy C failure"
+				full := file.Axes[perfScanAxisFull]
+				full.Status = admission.Status
+				full.Detail = admission.Detail
+				full.CMedianNs = 0
+				full.CMinNs = 0
+				full.CMaxNs = 0
+				full.Ratio = 0
+				full.Verdict = perfScanBucketNoData
+			},
+			want: "unrecognized failed oracle admission status",
+		},
+		{
+			name: "failed admission removed generic oracle error",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				file := pythonShard.Languages[0].Files[0]
+				admission := file.OracleAdmission
+				admission.Admitted = false
+				admission.StaticDeepSHA256 = ""
+				admission.ParityDeepSHA256 = ""
+				admission.Status = "c_oracle_error"
+				admission.Detail = "removed generic failure"
+				full := file.Axes[perfScanAxisFull]
+				full.Status = admission.Status
+				full.Detail = admission.Detail
+				full.CMedianNs = 0
+				full.CMinNs = 0
+				full.CMaxNs = 0
+				full.Ratio = 0
+				full.Verdict = perfScanBucketNoData
+			},
+			want: "unrecognized failed oracle admission status",
+		},
+		{
+			name: "failed admission missing bounded Go evidence",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				file := pythonShard.Languages[0].Files[0]
+				admission := file.OracleAdmission
+				admission.Admitted = false
+				admission.StaticDeepSHA256 = ""
+				admission.ParityDeepSHA256 = ""
+				admission.Status = staticCStatusParserTimeout
+				admission.Detail = "static C timeout"
+				full := file.Axes[perfScanAxisFull]
+				full.Status = staticCStatusParserTimeout
+				full.Detail = admission.Detail
+				full.GoMedianNs = 0
+				full.CMedianNs = 0
+				full.Ratio = 0
+				full.Verdict = perfScanBucketNoData
+			},
+			want: "neither Go timing nor a typed Go failure",
+		},
+		{
+			name: "admitted file arbitrary measurement status",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				full := pythonShard.Languages[0].Files[0].Axes[perfScanAxisFull]
+				full.Status = "c_timeout"
+				full.Detail = "legacy untyped measurement failure"
+				full.CMedianNs = 0
+				full.CMinNs = 0
+				full.CMaxNs = 0
+				full.Ratio = 0
+				full.Verdict = perfScanBucketNoData
+			},
+			want: "unrecognized full-parse status",
+		},
+		{
+			name: "admitted file removed generic oracle error",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				full := pythonShard.Languages[0].Files[0].Axes[perfScanAxisFull]
+				full.Status = "c_oracle_error"
+				full.Detail = "removed generic measurement failure"
+				full.CMedianNs = 0
+				full.CMinNs = 0
+				full.CMaxNs = 0
+				full.Ratio = 0
+				full.Verdict = perfScanBucketNoData
+			},
+			want: "unrecognized full-parse status",
+		},
+		{
+			name: "grammar commit mismatch",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle.Languages[0].GrammarCommit = strings.Repeat("b", 40)
+				pythonShard.Languages[0].Oracle.Language.GrammarCommit = strings.Repeat("b", 40)
+			},
+			want: "grammar identity is not the languages.lock entry",
+		},
+		{
+			name: "mixed compiler identity",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle.Common.CompilerVersion = "another cc"
+				pythonShard.Languages[0].Oracle.Common.CompilerVersion = "another cc"
+				identity := pythonShard.Languages[0].Oracle
+				identity.Language.BuildKeySHA256 = staticCBuildKey(identity.Common, identity.Language)
+				pythonShard.Oracle.Languages[0] = identity.Language
+			},
+			want: "common identity differs",
+		},
+		{
+			name: "wrong locked compile flags",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle.Common.RuntimeCFlags = "-O0"
+				pythonShard.Languages[0].Oracle.Common.RuntimeCFlags = "-O0"
+			},
+			want: "compile/link/timing/digest contract",
+		},
+		{
+			name: "wrong parser compile flags",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle.Languages[0].Parser.CompileFlags = "-O0"
+				pythonShard.Languages[0].Oracle.Language.Parser.CompileFlags = "-O0"
+			},
+			want: "parser compile identity",
+		},
+		{
+			name: "wrong static build key",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Oracle.Languages[0].BuildKeySHA256 = strings.Repeat("0", 64)
+				pythonShard.Languages[0].Oracle.Language.BuildKeySHA256 = strings.Repeat("0", 64)
+			},
+			want: "build key does not match",
+		},
+		{
+			name: "non-full authoritative axes",
+			mutate: func(_, pythonShard *perfScanScoreboard) {
+				pythonShard.Config.Axes = []string{perfScanAxisFull, perfScanAxisNoEdit}
+			},
+			want: "authoritative static C scoreboard axes",
 		},
 		{
 			name: "chained reduction provenance",
@@ -1309,9 +1594,18 @@ func perfScanTestShard(lang, lockPath, lockSHA string, lockLanguages int, revisi
 		FilesMeasured: 1,
 		BytesMeasured: 64,
 		Axes:          map[string]*perfScanLangAxis{},
+		Oracle:        perfScanTestOracleIdentity(lang),
 		Files: []*perfScanFile{{
-			Path:  "fixture." + lang,
-			Bytes: 64,
+			Path:             "fixture." + lang,
+			Bytes:            64,
+			MeasurementOrder: perfScanTestMeasurementOrder(lang, 0),
+			OracleAdmission: &perfScanOracleAdmission{
+				DigestFormat:     "gts-deep-tree-v1",
+				SourceSHA256:     strings.Repeat("1", 64),
+				StaticDeepSHA256: strings.Repeat("2", 64),
+				ParityDeepSHA256: strings.Repeat("2", 64),
+				Admitted:         true,
+			},
 			Classification: &perfScanFileClassification{
 				Class:    perfScanClassClean,
 				Reason:   "accepted full-span tree without ERROR nodes",
@@ -1364,10 +1658,76 @@ func perfScanTestShard(lang, lockPath, lockSHA string, lockLanguages int, revisi
 			SelectedLanguages: 1,
 		},
 	}
+	board.Oracle, _ = perfScanOracleBoardFromRows(board.Languages)
 	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
 	gate := perfScanEvaluateHardGate(board)
 	board.Gate = &gate
 	return board
+}
+
+func perfScanTestMeasurementOrder(lang string, fileIndex int) string {
+	if staticCFirstFor(lang, fileIndex) {
+		return "static_c_then_go"
+	}
+	return "go_then_static_c"
+}
+
+func perfScanTestOracleIdentity(lang string) *perfScanOracleIdentity {
+	lockPath, err := findParityLockPath()
+	if err != nil {
+		panic(err)
+	}
+	lock, err := loadParityLock(lockPath)
+	if err != nil {
+		panic(err)
+	}
+	entry := lock[lang]
+	common := perfScanOracleCommonIdentity{
+		Contract:             COracleContractVersion,
+		Transport:            staticCPerfTransport,
+		Linkage:              staticCPerfLinkage,
+		BindingModule:        COracleBindingModule,
+		BindingVersion:       COracleBindingVersion,
+		BindingCommit:        COracleBindingCommit,
+		RuntimeRepo:          staticCPerfRuntimeRepo,
+		RuntimeVersion:       COracleRuntimeVersion,
+		RuntimeCommit:        COracleRuntimeCommit,
+		RuntimeSourceTreeOID: strings.Repeat("3", 40),
+		RuntimeSourceSHA256:  strings.Repeat("4", 64),
+		OptimizationFlags:    staticCPerfOptimizationFlags,
+		RuntimeCFlags:        staticCPerfRuntimeCFlags,
+		GrammarCFlags:        staticCPerfGrammarCFlags,
+		GrammarCXXFlags:      staticCPerfGrammarCXXFlags,
+		DriverCFlags:         staticCPerfDriverCFlags,
+		LinkFlags:            staticCPerfLinkFlags,
+		TimingRegion:         staticCPerfTimingRegion,
+		OrderProtocol:        staticCPerfOrderProtocol,
+		FailureVocabulary:    staticCPerfFailureVocabulary,
+		TargetOS:             "linux",
+		TargetArch:           "amd64",
+		CompilerPath:         "/usr/bin/cc",
+		CompilerVersion:      "cc test",
+		CompilerSHA256:       strings.Repeat("a", 64),
+		DriverSHA256:         strings.Repeat("5", 64),
+		DeepDigestFormat:     "gts-deep-tree-v1",
+	}
+	language := perfScanOracleLanguageIdentity{
+		Language:          lang,
+		GrammarRepo:       entry.RepoURL,
+		GrammarCommit:     entry.Commit,
+		GrammarSourceTree: strings.Repeat("6", 40),
+		GrammarSourceMode: staticCSourceLocked,
+		LanguageSymbol:    "tree_sitter_" + paritySafeName(lang),
+		Parser:            perfScanOracleSourceIdentity{Path: "parser.c", SHA256: strings.Repeat("7", 64), CompileFlags: staticCPerfGrammarCFlags},
+		LinkerPath:        "/usr/bin/cc",
+		LinkerVersion:     "cc test",
+		LinkerSHA256:      strings.Repeat("a", 64),
+		ArtifactSHA256:    strings.Repeat("9", 64),
+		ArtifactStatic:    true,
+		ArtifactLinkage:   staticCPerfLinkageProof,
+	}
+	language.BuildKeySHA256 = staticCBuildKey(common, language)
+	return &perfScanOracleIdentity{Common: common, Language: language}
 }
 
 func perfScanWriteTestScoreboard(t *testing.T, dir, name string, board *perfScanScoreboard) string {

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -10,9 +10,9 @@ package cgoharness
 // corpus files:
 //
 //   - full     fresh full-parse wall time, Go vs C, median of N reps
-//   - noedit   no-edit reparse with the previous tree (Go ParseIncremental /
-//              C ts_parser_parse with old tree), median of N reps
-//   - edit     single-byte-edit incremental reparse (opt-in axis; see README)
+// The authoritative lane measures materialized fresh full parses only. Legacy
+// no-edit and edit axes remain available for diagnostics, but the reducer will
+// not certify them as publication evidence.
 //
 // Cliff containment: every parse attempt runs under a per-file budget
 // (Go: Parser.SetTimeoutMicros -> ParseStoppedEarly; C: SetTimeoutMicros ->
@@ -43,6 +43,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -63,7 +64,7 @@ import (
 )
 
 const (
-	perfScanSchema = "gts-perf-scan/v1"
+	perfScanSchema = "gts-perf-scan/v2"
 
 	perfScanEnvGate         = "GTS_PERF_SCAN"
 	perfScanEnvLang         = "GTS_PERF_SCAN_LANG"
@@ -183,10 +184,12 @@ type perfScanStop struct {
 }
 
 type perfScanFile struct {
-	Path           string                       `json:"path"`
-	Bytes          int                          `json:"bytes"`
-	Classification *perfScanFileClassification  `json:"classification,omitempty"`
-	Axes           map[string]*perfScanFileAxis `json:"axes"`
+	Path             string                       `json:"path"`
+	Bytes            int                          `json:"bytes"`
+	MeasurementOrder string                       `json:"measurement_order,omitempty"`
+	OracleAdmission  *perfScanOracleAdmission     `json:"oracle_admission,omitempty"`
+	Classification   *perfScanFileClassification  `json:"classification,omitempty"`
+	Axes             map[string]*perfScanFileAxis `json:"axes"`
 }
 
 // perfScanFileClassification records the untimed Go full-parse corpus-policy
@@ -236,15 +239,16 @@ type perfScanLangAxis struct {
 }
 
 type perfScanLanguage struct {
-	Language      string `json:"language"`
-	Status        string `json:"status"`
-	Detail        string `json:"detail,omitempty"`
-	Backend       string `json:"backend,omitempty"`
-	FilesSelected int    `json:"files_selected"`
-	FilesMeasured int    `json:"files_measured"`
-	BytesMeasured int64  `json:"bytes_measured"`
-	ElapsedMS     int64  `json:"elapsed_ms"`
-	Verdict       string `json:"verdict"`
+	Language      string                  `json:"language"`
+	Status        string                  `json:"status"`
+	Detail        string                  `json:"detail,omitempty"`
+	Backend       string                  `json:"backend,omitempty"`
+	FilesSelected int                     `json:"files_selected"`
+	FilesMeasured int                     `json:"files_measured"`
+	BytesMeasured int64                   `json:"bytes_measured"`
+	ElapsedMS     int64                   `json:"elapsed_ms"`
+	Verdict       string                  `json:"verdict"`
+	Oracle        *perfScanOracleIdentity `json:"oracle,omitempty"`
 	// ActiveFile is the canonical active-measurement signal. The numeric
 	// fields are pointers so active zero-byte files still serialize bytes=0.
 	ActiveFile       string                       `json:"active_file,omitempty"`
@@ -305,6 +309,7 @@ type perfScanScoreboard struct {
 	GitRevision    string                       `json:"git_revision,omitempty"`
 	GitClean       bool                         `json:"git_clean"`
 	Host           perfScanHost                 `json:"host"`
+	Oracle         *perfScanOracleBoardIdentity `json:"oracle,omitempty"`
 	Config         perfScanConfig               `json:"config"`
 	Notes          []string                     `json:"notes,omitempty"`
 	Summary        map[string]int               `json:"summary_verdicts"`
@@ -517,7 +522,7 @@ func perfScanNormalizeRevision(raw string) (string, error) {
 func perfScanAxes() []string {
 	raw := strings.TrimSpace(os.Getenv(perfScanEnvAxes))
 	if raw == "" {
-		return []string{perfScanAxisFull, perfScanAxisNoEdit}
+		return []string{perfScanAxisFull}
 	}
 	var axes []string
 	for _, part := range strings.Split(raw, ",") {
@@ -528,7 +533,7 @@ func perfScanAxes() []string {
 		}
 	}
 	if len(axes) == 0 {
-		return []string{perfScanAxisFull, perfScanAxisNoEdit}
+		return []string{perfScanAxisFull}
 	}
 	return axes
 }
@@ -876,6 +881,11 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 	if len(board.Languages) == 0 {
 		addFailure(perfScanGateFinding{Kind: "coverage", Status: "no_evidence", Detail: "scoreboard contains no language rows"})
 	}
+	if board.Schema == perfScanSchema {
+		if err := perfScanValidateOracleEvidence(board); err != nil {
+			addFailure(perfScanGateFinding{Kind: "oracle", Status: "inadmissible", Detail: err.Error()})
+		}
+	}
 	for _, lang := range board.Corpus.MissingFromLock {
 		addFailure(perfScanGateFinding{Kind: "coverage", Language: lang, Detail: "language missing from authenticated corpus lock"})
 	}
@@ -1132,6 +1142,13 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		}
 		return finish("no_c_reference", fmt.Sprintf("load C parser: %v", err))
 	}
+	staticOracle, err := buildStaticCPerfOracle(lang)
+	if err != nil {
+		return finish("no_static_c_oracle", fmt.Sprintf("build locked static C oracle: %v", err))
+	}
+	defer staticOracle.Close()
+	identity := staticOracle.identity
+	row.Oracle = &identity
 
 	goLang := entry.Language()
 	if goLang == nil {
@@ -1145,6 +1162,7 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 		report:  report,
 		goLang:  goLang,
 		cLang:   cLang,
+		staticC: staticOracle,
 		budget:  time.Duration(cfg.FileBudgetMS) * time.Millisecond,
 		goPsr:   gotreesitter.NewParser(goLang),
 		editMax: perfScanEnvIntDefault(perfScanEnvEditCands, 16),
@@ -1159,6 +1177,8 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 	m.cPsr = cParser
 	defer cParser.Close()
 
+	measurementStatus := perfScanStatusOK
+	var measurementDetails []string
 	for i, file := range files {
 		perfScanSetActiveFile(row, file, i+1, len(files))
 		if flush != nil {
@@ -1177,10 +1197,36 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 			continue
 		}
 		fileRow := &perfScanFile{
-			Path:  file.rel,
-			Bytes: len(src),
-			Axes:  map[string]*perfScanFileAxis{},
+			Path:             file.rel,
+			Bytes:            len(src),
+			MeasurementOrder: "go_then_static_c",
+			Axes:             map[string]*perfScanFileAxis{},
 		}
+		m.staticCFirst = staticCFirstFor(lang, i)
+		if m.staticCFirst {
+			fileRow.MeasurementOrder = "static_c_then_go"
+		}
+		m.staticAdmissionStatus = ""
+		m.staticAdmissionDetail = ""
+		if flush != nil {
+			perfScanSetActiveAttempt(row, perfScanAxisFull, "c", "oracle_admission", 1)
+			row.ElapsedMS = time.Since(start).Milliseconds()
+			flush(row)
+		}
+		admission, admissionErr := m.admitStaticOracle(src)
+		fileRow.OracleAdmission = admission
+		if admissionErr != nil {
+			status := staticCOracleErrorStatus(admissionErr)
+			admission.Status = status
+			admission.Detail = admissionErr.Error()
+			m.staticAdmissionStatus = status
+			m.staticAdmissionDetail = admissionErr.Error()
+			if measurementStatus == perfScanStatusOK {
+				measurementStatus = status
+			}
+			measurementDetails = append(measurementDetails, fmt.Sprintf("%s: %s: %v", file.rel, status, admissionErr))
+		}
+		perfScanClearActiveAttempt(row)
 		m.progress = nil
 		if flush != nil {
 			fileIndex := i + 1
@@ -1198,6 +1244,10 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 				fileRow.Axes[axis], fileRow.Classification = m.measureFull(src)
 				continue
 			}
+			if admissionErr != nil {
+				fileRow.Axes[axis] = &perfScanFileAxis{Status: m.staticAdmissionStatus, Detail: m.staticAdmissionDetail, Verdict: perfScanBucketNoData}
+				continue
+			}
 			fileRow.Axes[axis] = m.measureFileAxis(axis, src)
 		}
 		row.Files = append(row.Files, fileRow)
@@ -1211,6 +1261,9 @@ func perfScanMeasureLanguage(t *testing.T, lang string, cfg perfScanConfig, flus
 	}
 
 	perfScanAggregateLanguage(row, cfg)
+	if measurementStatus != perfScanStatusOK {
+		return finish(measurementStatus, strings.Join(measurementDetails, "; "))
+	}
 	return finish(perfScanStatusOK, "")
 }
 
@@ -1296,17 +1349,21 @@ func perfScanSelectFiles(t *testing.T, lang string, cfg perfScanConfig, langRoot
 // ---------------------------------------------------------------------------
 
 type perfScanLangMeasurer struct {
-	cfg      perfScanConfig
-	lang     string
-	entry    grammars.LangEntry
-	report   grammars.ParseSupport
-	goLang   *gotreesitter.Language
-	cLang    *sitter.Language
-	goPsr    *gotreesitter.Parser
-	cPsr     *sitter.Parser
-	budget   time.Duration
-	editMax  int
-	progress func(axis, impl, phase string, attempt int)
+	cfg                   perfScanConfig
+	lang                  string
+	entry                 grammars.LangEntry
+	report                grammars.ParseSupport
+	goLang                *gotreesitter.Language
+	cLang                 *sitter.Language
+	goPsr                 *gotreesitter.Parser
+	cPsr                  *sitter.Parser
+	staticC               *staticCPerfOracle
+	staticCFirst          bool
+	staticAdmissionStatus string
+	staticAdmissionDetail string
+	budget                time.Duration
+	editMax               int
+	progress              func(axis, impl, phase string, attempt int)
 	// Full-axis hooks are nil in production and exist so protocol tests can
 	// deterministically separate timed failures from classification probes.
 	goFullAttempt func(src []byte, keepTree bool) (*gotreesitter.Tree, perfScanAttempt)
@@ -1532,6 +1589,50 @@ func (m *perfScanLangMeasurer) cAttempt(src []byte, oldTree *sitter.Tree, keepTr
 	return tree, att
 }
 
+// admitStaticOracle proves that the per-language static timing artifact and
+// the single in-process parity binding materialize the same deep tree for this
+// exact source before any C timing sample is accepted.
+func (m *perfScanLangMeasurer) admitStaticOracle(src []byte) (*perfScanOracleAdmission, error) {
+	admission := &perfScanOracleAdmission{DigestFormat: "gts-deep-tree-v1"}
+	if m.staticC == nil {
+		return admission, newStaticCOracleError(staticCStatusAdmissionError, "static C oracle is not configured")
+	}
+	staticDigest, sourceSHA, err := m.staticC.deepDigest(src, m.budget)
+	admission.SourceSHA256 = sourceSHA
+	admission.StaticDeepSHA256 = staticDigest
+	if err != nil {
+		return admission, err
+	}
+	if m.cPsr == nil {
+		return admission, newStaticCOracleError(staticCStatusAdmissionError, "cgo parity admission parser is not configured")
+	}
+	m.cPsr.Reset()
+	tree, att := m.cAttempt(src, nil, true)
+	if att.status != "" {
+		status := staticCStatusParserError
+		if att.status == "c_timeout" {
+			status = staticCStatusParserTimeout
+		} else if att.status == "c_error" {
+			status = staticCStatusIncomplete
+		}
+		return admission, newStaticCOracleError(status, fmt.Sprintf("cgo parity admission parse: %s: %s", att.status, att.detail))
+	}
+	defer tree.Close()
+	parityDigest, err := cOracleDeepDigestWithin(tree, m.budget)
+	if err != nil {
+		if errors.Is(err, errCOracleDeepDigestTimeout) {
+			return admission, newStaticCOracleError(staticCStatusDigestTimeout, fmt.Sprintf("cgo parity deep digest exceeded independent wall budget %s", m.budget))
+		}
+		return admission, newStaticCOracleError(staticCStatusDigestError, fmt.Sprintf("cgo parity deep digest: %v", err))
+	}
+	admission.ParityDeepSHA256 = parityDigest
+	if staticDigest != parityDigest {
+		return admission, newStaticCOracleError(staticCStatusMismatch, fmt.Sprintf("static/cgo parity deep digest mismatch: static=%s parity=%s", staticDigest, parityDigest))
+	}
+	admission.Admitted = true
+	return admission, nil
+}
+
 func perfScanGoParserStop(reason gotreesitter.ParseStopReason, budget time.Duration) *perfScanStop {
 	class := perfScanStopParserStopped
 	switch reason {
@@ -1657,6 +1758,38 @@ func perfScanClassifyGoFull(tree *gotreesitter.Tree, att perfScanAttempt, source
 func (m *perfScanLangMeasurer) measureFull(src []byte) (*perfScanFileAxis, *perfScanFileClassification) {
 	out := &perfScanFileAxis{Status: perfScanStatusOK}
 	var classification *perfScanFileClassification
+	var goSamples, cSamples []int64
+
+	cOK := m.staticAdmissionStatus == ""
+	if !cOK {
+		out.Status = m.staticAdmissionStatus
+		out.Detail = m.staticAdmissionDetail
+		if staticCTimeoutStatus(m.staticAdmissionStatus) {
+			out.Stop = &perfScanStop{Class: perfScanStopCTimeout, Implementation: "c", Phase: "oracle_admission", Attempt: 1, Detail: m.staticAdmissionDetail}
+		}
+	}
+	measureStatic := func() {
+		if !cOK || m.staticC == nil {
+			return
+		}
+		m.checkpoint(perfScanAxisFull, "c", "static_sidecar", 1)
+		measurement := m.staticC.measure(src, perfScanAxisFull, m.cfg.Warmup, m.cfg.Reps, m.budget)
+		if measurement.Status != perfScanStatusOK {
+			cOK = false
+			if out.Status == perfScanStatusOK {
+				out.Status = measurement.Status
+			}
+			out.Detail = strings.TrimSpace(out.Detail + " " + measurement.Detail)
+			if staticCTimeoutStatus(measurement.Status) {
+				out.Stop = &perfScanStop{Class: perfScanStopCTimeout, Implementation: "c", Phase: "static_sidecar", Attempt: 1, Detail: measurement.Detail}
+			}
+			return
+		}
+		cSamples = append(cSamples, measurement.Samples...)
+	}
+	if m.staticC != nil && m.staticCFirst {
+		measureStatic()
+	}
 
 	goOK := true
 	var goDetail string
@@ -1670,42 +1803,46 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) (*perfScanFileAxis, *perf
 		releaseGoTree(tree)
 		if att.status != "" {
 			goOK = false
-			out.Status = att.status
+			if out.Status == perfScanStatusOK {
+				out.Status = att.status
+			}
 			goDetail = att.detail
 			perfScanRecordAttemptStop(out, att, "warmup", i+1)
 			break
 		}
 	}
-	cOK := true
-	for i := 0; i < m.cfg.Warmup; i++ {
-		m.checkpoint(perfScanAxisFull, "c", "warmup", i+1)
-		_, att := m.attemptCFull(src, nil, false)
-		if att.status != "" {
-			cOK = false
-			if out.Status == perfScanStatusOK {
-				out.Status = att.status
+	if m.staticC == nil {
+		for i := 0; i < m.cfg.Warmup; i++ {
+			m.checkpoint(perfScanAxisFull, "c", "warmup", i+1)
+			_, att := m.attemptCFull(src, nil, false)
+			if att.status != "" {
+				cOK = false
+				if out.Status == perfScanStatusOK {
+					out.Status = att.status
+				}
+				out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
+				perfScanRecordAttemptStop(out, att, "warmup", i+1)
+				break
 			}
-			out.Detail = strings.TrimSpace(out.Detail + " " + att.detail)
-			perfScanRecordAttemptStop(out, att, "warmup", i+1)
-			break
 		}
 	}
 
-	var goSamples, cSamples []int64
 	for i := 0; i < m.cfg.Reps; i++ {
 		if goOK {
 			m.checkpoint(perfScanAxisFull, "go", "rep", i+1)
 			_, att := m.attemptGoFull(src, false)
 			if att.status != "" {
 				goOK = false
-				out.Status = att.status
+				if out.Status == perfScanStatusOK {
+					out.Status = att.status
+				}
 				goDetail = att.detail
 				perfScanRecordAttemptStop(out, att, "rep", i+1)
 			} else {
 				goSamples = append(goSamples, att.ns)
 			}
 		}
-		if cOK {
+		if cOK && m.staticC == nil {
 			m.checkpoint(perfScanAxisFull, "c", "rep", i+1)
 			_, att := m.attemptCFull(src, nil, false)
 			if att.status != "" {
@@ -1719,6 +1856,9 @@ func (m *perfScanLangMeasurer) measureFull(src []byte) (*perfScanFileAxis, *perf
 				cSamples = append(cSamples, att.ns)
 			}
 		}
+	}
+	if m.staticC != nil && !m.staticCFirst {
+		measureStatic()
 	}
 	// With warmup=0, classify after the timed samples so the classification
 	// probe cannot warm parser caches or otherwise alter the requested timing
@@ -2154,6 +2294,12 @@ func TestPerfScanSweep(t *testing.T) {
 		t.Logf("  %-14s status=%-14s verdict=%-9s files=%d/%d elapsed=%dms %s",
 			lang, row.Status, row.Verdict, row.FilesMeasured, row.FilesSelected, row.ElapsedMS, row.Detail)
 	}
+	oracleIdentity, oracleErr := perfScanOracleBoardFromRows(board.Languages)
+	if oracleErr != nil {
+		board.Notes = append(board.Notes, "STATIC C ORACLE IDENTITY FAILURE — "+oracleErr.Error())
+	} else {
+		board.Oracle = oracleIdentity
+	}
 	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
 	board.Host.LoadavgEnd = perfScanReadLoadavg()
 	if contended, note := perfScanContended(); contended {
@@ -2317,6 +2463,9 @@ func perfScanRunLanguageSubprocess(t *testing.T, lang string, cfg perfScanConfig
 }
 
 func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error, *perfScanStop) {
+	if err := perfScanConfigureChildProcessGroup(cmd); err != nil {
+		return err, nil
+	}
 	if rssLimitMB <= 0 {
 		err := cmd.Run()
 		return err, perfScanChildExitStop(ctx, err)
@@ -2355,7 +2504,7 @@ func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error
 		default:
 		}
 		if kill, stop := checkRSS(); kill {
-			_ = cmd.Process.Kill()
+			_ = perfScanKillChildProcessGroup(cmd)
 			return <-done, stop
 		}
 		select {
@@ -2363,12 +2512,45 @@ func perfScanRunChild(ctx context.Context, cmd *exec.Cmd, rssLimitMB int) (error
 			return err, perfScanChildExitStop(ctx, err)
 		case <-ctx.Done():
 			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
+				_ = perfScanKillChildProcessGroup(cmd)
 			}
 			return <-done, &perfScanStop{Class: perfScanStopWallTimeout, Detail: "language subprocess exceeded hard wall timeout"}
 		case <-ticker.C:
 		}
 	}
+}
+
+func perfScanConfigureChildProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil {
+		return fmt.Errorf("language subprocess command is nil")
+	}
+	if cmd.Process != nil {
+		return fmt.Errorf("language subprocess already started")
+	}
+	attr := syscall.SysProcAttr{}
+	if cmd.SysProcAttr != nil {
+		attr = *cmd.SysProcAttr
+	}
+	attr.Setpgid = true
+	cmd.SysProcAttr = &attr
+	cmd.Cancel = func() error {
+		err := perfScanKillChildProcessGroup(cmd)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+	return nil
+}
+
+func perfScanKillChildProcessGroup(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	// Setpgid makes the direct child's PID the process-group ID. A negative
+	// target kills the child and every compiler/oracle descendant before Wait
+	// reaps the direct child.
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }
 
 func perfScanChildExitStop(ctx context.Context, err error) *perfScanStop {
@@ -2458,6 +2640,27 @@ func perfScanParseStatusRSSBytes(status string) (int64, bool) {
 		return kib * 1024, true
 	}
 	return 0, false
+}
+
+func TestPerfScanRunChildKillsDescendantProcessGroupOnWallStop(t *testing.T) {
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "descendant.pid")
+	markerPath := filepath.Join(dir, "descendant-survived")
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	script := fmt.Sprintf("(sleep 0.4; touch %q) & echo $! > %q; wait", markerPath, pidPath)
+	cmd := exec.CommandContext(ctx, "sh", "-c", script)
+	err, stop := perfScanRunChild(ctx, cmd, 0)
+	if err == nil || stop == nil || stop.Class != perfScanStopWallTimeout {
+		t.Fatalf("wall-stopped child err=%v stop=%+v", err, stop)
+	}
+	if _, statErr := os.Stat(pidPath); statErr != nil {
+		t.Fatalf("descendant was not started before wall stop: %v", statErr)
+	}
+	time.Sleep(450 * time.Millisecond)
+	if _, statErr := os.Stat(markerPath); !os.IsNotExist(statErr) {
+		t.Fatalf("descendant survived process-group kill: stat=%v", statErr)
+	}
 }
 
 func perfScanReadLangFragment(outDir, lang string) (*perfScanLanguage, error) {
@@ -2761,6 +2964,19 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 		fmt.Fprintf(&b, "- corpus lock: `%s` sha256=`%s` languages=%d selected=%d\n",
 			board.Corpus.LockPath, board.Corpus.LockSHA256, board.Corpus.LockLanguages, board.Corpus.SelectedLanguages)
 	}
+	if board.Oracle != nil {
+		oracle := board.Oracle.Common
+		fmt.Fprintf(&b, "- C oracle: `%s@%s` binding_commit=`%s`, upstream runtime `%s@%s` commit=`%s`, flags=`%s`, linkage=`%s`\n",
+			oracle.BindingModule, oracle.BindingVersion, oracle.BindingCommit,
+			oracle.RuntimeRepo, oracle.RuntimeVersion, oracle.RuntimeCommit,
+			oracle.OptimizationFlags, oracle.Linkage)
+		fmt.Fprintf(&b, "- C oracle runtime flags=`%s`; grammar C/C++ flags=`%s` / `%s`; link flags=`%s`\n",
+			oracle.RuntimeCFlags, oracle.GrammarCFlags, oracle.GrammarCXXFlags, oracle.LinkFlags)
+		fmt.Fprintf(&b, "- C oracle driver sha256=`%s`; runtime tree=`%s`; admitted deep format=`%s`; timing=`%s`\n",
+			oracle.DriverSHA256, oracle.RuntimeSourceTreeOID, oracle.DeepDigestFormat, oracle.TimingRegion)
+		fmt.Fprintf(&b, "- C oracle compiler sha256=`%s`; measurement order=`%s`\n",
+			oracle.CompilerSHA256, oracle.OrderProtocol)
+	}
 	if board.Config.ChildRSSMB > 0 {
 		fmt.Fprintf(&b, "- child RSS limit: `%d MiB`\n", board.Config.ChildRSSMB)
 	}
@@ -2814,19 +3030,18 @@ func perfScanRenderMarkdown(board *perfScanScoreboard) string {
 	}
 
 	fmt.Fprintf(&b, "\n## Per-language scoreboard\n\n")
-	fmt.Fprintf(&b, "| language | status | files | bytes | full Go | full C | full ratio | noedit ratio | verdict |\n")
-	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|---|\n")
+	fmt.Fprintf(&b, "| language | status | files | bytes | full Go | full C | full ratio | verdict |\n")
+	fmt.Fprintf(&b, "|---|---|---|---|---|---|---|---|\n")
 	for _, row := range board.Languages {
 		full := row.Axes[perfScanAxisFull]
-		noedit := row.Axes[perfScanAxisNoEdit]
 		var goNs, cNs int64
 		if full != nil {
 			goNs, cNs = full.GoTotalNs, full.CTotalNs
 		}
-		fmt.Fprintf(&b, "| %s | %s | %d/%d | %d | %s | %s | %s | %s | %s |\n",
+		fmt.Fprintf(&b, "| %s | %s | %d/%d | %d | %s | %s | %s | %s |\n",
 			row.Language, row.Status, row.FilesMeasured, row.FilesSelected, row.BytesMeasured,
 			perfScanFmtNs(goNs), perfScanFmtNs(cNs),
-			perfScanFmtRatio(full), perfScanFmtRatio(noedit), row.Verdict)
+			perfScanFmtRatio(full), row.Verdict)
 	}
 
 	perfScanRenderCleanErrorSplit(&b, board.Languages)
@@ -3361,6 +3576,39 @@ func TestPerfScanCleanErrorSplitUnit(t *testing.T) {
 			t.Fatalf("all-error split = %+v", row.FullParseSplit)
 		}
 	})
+}
+
+func TestPerfScanStaticAdmissionFailureRetainsGoEvidenceUnit(t *testing.T) {
+	const lang = "go"
+	entry, ok := parityEntriesByName[lang]
+	if !ok {
+		t.Fatal("Go registry entry is unavailable")
+	}
+	report, ok := paritySupportForName(lang)
+	if !ok {
+		t.Fatal("Go support report is unavailable")
+	}
+	goLang := entry.Language()
+	if goLang == nil {
+		t.Fatal("Go language is nil")
+	}
+	parser := gotreesitter.NewParser(goLang)
+	const budget = time.Second
+	parser.SetTimeoutMicros(uint64(budget.Microseconds()))
+	m := &perfScanLangMeasurer{
+		cfg: perfScanConfig{Warmup: 1, Reps: 2}, lang: lang,
+		entry: entry, report: report, goLang: goLang, goPsr: parser,
+		staticC: &staticCPerfOracle{}, budget: budget,
+		staticAdmissionStatus: staticCStatusParserTimeout,
+		staticAdmissionDetail: "bounded static C admission timeout",
+	}
+	axis, classification := m.measureFull([]byte("package p\n\nvar X = 1\n"))
+	if axis.Status != staticCStatusParserTimeout || axis.GoMedianNs <= 0 || axis.CMedianNs != 0 || axis.Ratio != 0 || axis.Verdict != perfScanBucketNoData {
+		t.Fatalf("C admission failure fabricated or dropped timing evidence: %+v", axis)
+	}
+	if classification == nil || classification.GoStatus != perfScanStatusOK || !classification.FullSpan || classification.StoppedEarly {
+		t.Fatalf("bounded Go classification was not retained: %+v", classification)
+	}
 }
 
 func TestPerfScanCleanErrorSerializationAndMarkdownUnit(t *testing.T) {


### PR DESCRIPTION
## Summary
- time fresh full parses in per-language fully static artifacts built from locked upstream sources
- require exact static/cgo deep-tree admission and serialized build, tool, source, linkage, and failure identity
- publish v2 full-only scoreboards while retaining v1 boards as historical evidence

## Validation
- focused Docker regressions and tagged compilation
- Go, Python, and Norg static canaries
- iterative deep/wide digest, timeout, and exact digest-contract tests
- tagged go vet, Canopy analysis, and diff checks
- clean-commit Go shards admitted matching static/cgo trees and correctly failed existing full-parse performance gates

Changelog Unreleased documents the change.