### PR TITLE
perf(harness): authenticate forest route confirmations

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -215,6 +215,45 @@ Named large-file witnesses (tracked, not hidden): JavaScript
 generated-table class (Go `opGen.go` / `rewriteAMD64.go` and in-repo
 witnesses).
 
+### Forest-routing screen and confirmation
+
+The authenticated forest audit separates discovery from promotion. A
+`forest-audit-result-v2` production shard is a directional screen: it can show
+that the routed parser was faster on that run, but it cannot by itself promote
+a language. Promotion requires fresh, isolated confirmation trials with the
+same hashed host fingerprint, image, and resource configuration. Confirmation
+uses `--cpus 1` and one numeric `--cpuset-cpus`; `--host-label` is an operator
+label and is recorded separately from the automatically hashed host
+fingerprint:
+
+1. run one complete production-first trial (`pair-a`);
+2. run one complete routed-first trial (`pair-b`);
+3. pool the two orders only when both preserve exact production identity;
+4. confirm only when the pooled routed speedup is at least 1.05x, each timed
+   side lasts at least 750 ms, and order speedups stay within 10%;
+5. escalate short, marginal, sign-changing, or order-sensitive results to an
+   A-B-B-A sequence, increasing complete-corpus repetitions up to 20 for the
+   duration floor.
+
+The runner writes into an attempt directory, mounts the source tree read-only,
+and publishes only after a successful container exit and a same-HEAD clean
+worktree postcheck. Trial, run-config, and cohort receipts are immutable and
+content-addressed. The reducer admits a cohort only through an explicitly
+selected, content-addressed confirmation index; an unindexed or failed attempt
+cannot complete a trial. `plan-confirmations` output is a planning artifact,
+not evidence, and should live outside the results bundle (the reducer also
+ignores its schema if it is copied there).
+
+The reducer emits a win-only confirmation plan, keeps a screen win `incomplete`,
+and records screening eligibility separately from promotion eligibility. Trees
+are released after every repetition, including error, decline, nil-tree, and
+divergence paths, and authoritative shards run exactly one language per
+container. Every routed path must have accepted coverage in the locked C
+shard. The locked C oracle remains the correctness authority: if forest and
+routed results appear to correct a production-parser divergence, the reducer
+records `oracle_correction_review_required` for direct three-way review instead
+of auto-promoting or forcing a second four-runtime benchmark lane.
+
 ## Memory receipts (the v0.24 → v0.26.1 campaign)
 
 On the exact Poppler witness under a hard 2 GiB container:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ for tags and release notes while still in `0.x`.
   wall/RSS stops kill the entire child process group. The budget and status
   tools read both schema generations while keeping v1
   historical ratchets separate from v2 full-only hard-gate verdicts.
+- Forest-routing performance screens now require fresh order-balanced
+  confirmation before promotion. Immutable content-addressed trial, run-config,
+  cohort, and index receipts bind the selected head to the recorded host
+  fingerprint, image, and single-CPU resource configuration. Failed or
+  drifting attempts remain unpublished: the runner executes the recorded image
+  digest, verifies the created container identity, and reauthenticates every
+  corpus read by manifest size and SHA-256 before timing. The reducer requires
+  locked-C coverage for every routed path, emits explicit A+B or A-B-B-A
+  plans, pools reverse-order evidence, and keeps possible C-oracle corrections
+  review-required. Repeated trials release every tree on success and negative
+  paths, complete the full corpus before the next sweep, and remain isolated
+  to one language per container.
 
 ## [0.37.0] - 2026-07-14
 

--- a/cgo_harness/cmd/forest_audit/main.go
+++ b/cgo_harness/cmd/forest_audit/main.go
@@ -14,7 +14,7 @@ import (
 
 func main() {
 	if len(os.Args) < 2 {
-		fatalf("usage: forest_audit <manifest|reduce> [options]")
+		fatalf("usage: forest_audit <manifest|reduce|plan-confirmations|publish-result|publish-confirmation|index-confirmations> [options]")
 	}
 	var err error
 	switch os.Args[1] {
@@ -22,6 +22,14 @@ func main() {
 		err = runManifest(os.Args[2:])
 	case "reduce":
 		err = runReduce(os.Args[2:])
+	case "plan-confirmations":
+		err = runPlanConfirmations(os.Args[2:])
+	case "publish-confirmation":
+		err = runPublishConfirmation(os.Args[2:])
+	case "publish-result":
+		err = runPublishResult(os.Args[2:])
+	case "index-confirmations":
+		err = runIndexConfirmations(os.Args[2:])
 	default:
 		err = fmt.Errorf("unknown command %q", os.Args[1])
 	}
@@ -78,9 +86,10 @@ func runManifest(args []string) error {
 
 func runReduce(args []string) error {
 	flags := flag.NewFlagSet("reduce", flag.ContinueOnError)
-	var manifestPath, resultsRoot, out string
+	var manifestPath, resultsRoot, confirmationIndex, out string
 	flags.StringVar(&manifestPath, "manifest", "", "authenticated input manifest")
 	flags.StringVar(&resultsRoot, "results-root", "", "root containing per-language result JSON")
+	flags.StringVar(&confirmationIndex, "confirmation-index", "", "optional content-addressed confirmation index JSON")
 	flags.StringVar(&out, "out", "", "output reduced report JSON")
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -88,11 +97,104 @@ func runReduce(args []string) error {
 	if manifestPath == "" || resultsRoot == "" || out == "" {
 		return fmt.Errorf("--manifest, --results-root, and --out are required")
 	}
-	report, err := cgoharness.ReduceForestAuditResults(manifestPath, resultsRoot)
+	report, err := cgoharness.ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, confirmationIndex)
 	if err != nil {
 		return err
 	}
 	return cgoharness.WriteForestAuditReport(out, report)
+}
+
+func runPublishConfirmation(args []string) error {
+	flags := flag.NewFlagSet("publish-confirmation", flag.ContinueOnError)
+	var resultsRoot, runConfigPath, trialPath string
+	flags.StringVar(&resultsRoot, "results-root", "", "forest audit bundle root")
+	flags.StringVar(&runConfigPath, "run-config", "", "staged run-config JSON")
+	flags.StringVar(&trialPath, "trial", "", "successful staged confirmation trial JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if resultsRoot == "" || runConfigPath == "" || trialPath == "" {
+		return fmt.Errorf("--results-root, --run-config, and --trial are required")
+	}
+	stored, err := cgoharness.StoreForestAuditConfirmation(resultsRoot, runConfigPath, trialPath)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("trial_sha256=%s\ncohort_sha256=%s\nconfirmation_index_sha256=%s\nconfirmation_index=%s\n",
+		stored.TrialSHA256, stored.CohortSHA256, stored.IndexSHA256, stored.IndexPath)
+	return nil
+}
+
+func runPublishResult(args []string) error {
+	flags := flag.NewFlagSet("publish-result", flag.ContinueOnError)
+	var resultsRoot, stagedPath string
+	flags.StringVar(&resultsRoot, "results-root", "", "forest audit bundle root")
+	flags.StringVar(&stagedPath, "result", "", "successful staged forest audit result JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if resultsRoot == "" || stagedPath == "" {
+		return fmt.Errorf("--results-root and --result are required")
+	}
+	path, err := cgoharness.PublishForestAuditResult(resultsRoot, stagedPath)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("result=%s\n", path)
+	return nil
+}
+
+func runIndexConfirmations(args []string) error {
+	flags := flag.NewFlagSet("index-confirmations", flag.ContinueOnError)
+	var reportPath, resultsRoot, cohortsRaw string
+	flags.StringVar(&reportPath, "report", "", "forest audit report providing the authenticated board identity")
+	flags.StringVar(&resultsRoot, "results-root", "", "forest audit bundle root")
+	flags.StringVar(&cohortsRaw, "cohorts", "", "comma-separated language=cohort_sha256 selections")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if reportPath == "" || resultsRoot == "" || cohortsRaw == "" {
+		return fmt.Errorf("--report, --results-root, and --cohorts are required")
+	}
+	report, err := cgoharness.ReadForestAuditReport(reportPath)
+	if err != nil {
+		return err
+	}
+	index := cgoharness.ForestAuditConfirmationIndex{
+		Schema: cgoharness.ForestAuditConfirmationIndexSchema, GotreesitterRevision: report.GotreesitterRevision,
+		CorpusManifestSHA256: report.CorpusManifestSHA256, CorpusLockSHA256: report.CorpusLockSHA256,
+	}
+	for _, raw := range strings.Split(cohortsRaw, ",") {
+		parts := strings.Split(strings.TrimSpace(raw), "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid cohort selection %q", raw)
+		}
+		index.Cohorts = append(index.Cohorts, cgoharness.ForestAuditConfirmationIndexEntry{Language: parts[0], CohortSHA256: parts[1]})
+	}
+	digest, path, err := cgoharness.PublishForestAuditConfirmationIndex(resultsRoot, index)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("confirmation_index_sha256=%s\nconfirmation_index=%s\n", digest, path)
+	return nil
+}
+
+func runPlanConfirmations(args []string) error {
+	flags := flag.NewFlagSet("plan-confirmations", flag.ContinueOnError)
+	var reportPath, out string
+	flags.StringVar(&reportPath, "report", "", "forest audit report-v4 JSON")
+	flags.StringVar(&out, "out", "", "output win-only confirmation plan JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if reportPath == "" || out == "" {
+		return fmt.Errorf("--report and --out are required")
+	}
+	report, err := cgoharness.ReadForestAuditReport(reportPath)
+	if err != nil {
+		return err
+	}
+	return cgoharness.WriteForestAuditConfirmationPlan(out, cgoharness.BuildForestAuditConfirmationPlan(report))
 }
 
 func splitList(raw string) []string {

--- a/cgo_harness/docker/run_forest_corpus_parity.sh
+++ b/cgo_harness/docker/run_forest_corpus_parity.sh
@@ -16,8 +16,12 @@ OUT_ROOT="$REPO_ROOT/harness_out/forest_corpus"
 IMAGE_TAG="gotreesitter/cgo-harness:go1.25-local"
 MEMORY_LIMIT="12g"
 CPUS_LIMIT="4"
+CPUSET_CPUS=""
+HOST_LABEL=""
+HOST_FINGERPRINT=""
 PIDS_LIMIT="4096"
 TIMEOUT="20m"
+GOMEMLIMIT_VALUE="10GiB"
 LANGS="bash"
 BUILD_IMAGE=1
 MANIFEST=""
@@ -27,6 +31,10 @@ RESULTS_ROOT=""
 LEGACY_MANUAL=0
 LOCK_SHA256=""
 GIT_REVISION=""
+CONFIRMATION_TRIAL=""
+EXECUTION_ORDER="production_first"
+REPEAT_COUNT="1"
+PREVIOUS_TRIAL_SHA256=""
 
 usage() {
   cat <<'EOF'
@@ -34,13 +42,20 @@ Usage: run_forest_corpus_parity.sh [options]
   --langs <name>     one authenticated language to gate (default: bash)
   --image <tag>      docker image tag (default: gotreesitter/cgo-harness:go1.25-local)
   --memory <limit>   container memory limit (default: 12g)
-  --cpus <count>     cpu limit (default: 4)
+  --cpus <count>     cpu limit (default: 4; confirmation trials require 1)
+  --cpuset-cpus <id> pin to one numeric CPU (required for confirmation trials)
+  --host-label <name> operator label for the physical host (required for confirmation trials)
+  --gomemlimit <v>   GOMEMLIMIT inside the container (default: 10GiB)
   --timeout <dur>    go test timeout (default: 20m)
   --manifest <path>  authenticated manifest host path (mounted read-only)
   --corpus-root <p>  locked checkout root host path (mounted read-only)
   --corpus-lock <p>  authenticated corpus_sources.lock host path
-  --results-root <p> host root for production/<language>.json
+  --results-root <p> host root for production, C-oracle, and confirmation receipts
   --lock-sha256 <hex> expected corpus board lock SHA-256 (default: checked-in perf_scan digest)
+  --confirmation-trial <id> write a confirmation envelope (pair-a, pair-b, or ABBA id)
+  --execution-order <order>  production_first or routed_first
+  --repeat-count <n>         complete corpus repetitions inside the isolated shard (1..20)
+  --previous-trial-sha256 <hex> selected predecessor receipt for non-pair-a trials
   --legacy-manual    use the flat corpus explicitly as a non-authoritative manual run
   --no-build         skip docker build step
   -h, --help         show this help
@@ -53,18 +68,87 @@ while [[ $# -gt 0 ]]; do
     --image) IMAGE_TAG="$2"; shift 2 ;;
     --memory) MEMORY_LIMIT="$2"; shift 2 ;;
     --cpus) CPUS_LIMIT="$2"; shift 2 ;;
+    --cpuset-cpus) CPUSET_CPUS="$2"; shift 2 ;;
+    --host-label) HOST_LABEL="$2"; shift 2 ;;
+    --hostname) echo "--hostname was replaced by the honest --host-label receipt field" >&2; exit 2 ;;
+    --gomemlimit) GOMEMLIMIT_VALUE="$2"; shift 2 ;;
     --timeout) TIMEOUT="$2"; shift 2 ;;
     --manifest) MANIFEST="$2"; shift 2 ;;
     --corpus-root) CORPUS_ROOT="$2"; shift 2 ;;
     --corpus-lock) CORPUS_LOCK="$2"; shift 2 ;;
     --results-root) RESULTS_ROOT="$2"; shift 2 ;;
     --lock-sha256) LOCK_SHA256="$2"; shift 2 ;;
+    --confirmation-trial) CONFIRMATION_TRIAL="$2"; shift 2 ;;
+    --execution-order) EXECUTION_ORDER="$2"; shift 2 ;;
+    --repeat-count) REPEAT_COUNT="$2"; shift 2 ;;
+    --previous-trial-sha256) PREVIOUS_TRIAL_SHA256="$2"; shift 2 ;;
     --legacy-manual) LEGACY_MANUAL=1; shift ;;
     --no-build) BUILD_IMAGE=0; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage; exit 2 ;;
   esac
 done
+
+if [[ "$EXECUTION_ORDER" != "production_first" && "$EXECUTION_ORDER" != "routed_first" ]]; then
+  echo "--execution-order must be production_first or routed_first" >&2
+  exit 2
+fi
+if ! [[ "$REPEAT_COUNT" =~ ^([1-9]|1[0-9]|20)$ ]]; then
+  echo "--repeat-count must be an integer from 1 through 20" >&2
+  exit 2
+fi
+if [[ -n "$CPUSET_CPUS" && ! "$CPUSET_CPUS" =~ ^[0-9]+$ ]]; then
+  echo "--cpuset-cpus must name one numeric CPU" >&2
+  exit 2
+fi
+if [[ -n "$HOST_LABEL" && ! "$HOST_LABEL" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  echo "--host-label contains unsupported characters" >&2
+  exit 2
+fi
+if [[ ! "$MEMORY_LIMIT" =~ ^[0-9]+([kKmMgGtT][bB]?)?$ ]]; then
+  echo "--memory must be a Docker byte limit such as 12g" >&2
+  exit 2
+fi
+if [[ ! "$CPUS_LIMIT" =~ ^[0-9]+([.][0-9]+)?$ || "$CPUS_LIMIT" =~ ^0([.]0+)?$ ]]; then
+  echo "--cpus must be a positive number" >&2
+  exit 2
+fi
+if [[ ! "$GOMEMLIMIT_VALUE" =~ ^[0-9]+([KMGTP]i?B)?$ ]]; then
+  echo "--gomemlimit must be a Go byte limit such as 10GiB" >&2
+  exit 2
+fi
+if [[ ! "$TIMEOUT" =~ ^[0-9]+(ns|us|ms|s|m|h)$ ]]; then
+  echo "--timeout must be a single Go duration such as 20m" >&2
+  exit 2
+fi
+if [[ -n "$CONFIRMATION_TRIAL" ]]; then
+  if [[ -z "$MANIFEST" ]]; then
+    echo "--confirmation-trial requires an authenticated manifest" >&2
+    exit 2
+  fi
+  if [[ -z "$CPUSET_CPUS" || -z "$HOST_LABEL" || "$CPUS_LIMIT" != "1" ]]; then
+    echo "confirmation trials require --cpus 1, one numeric --cpuset-cpus, and --host-label" >&2
+    exit 2
+  fi
+  case "$CONFIRMATION_TRIAL:$EXECUTION_ORDER" in
+    pair-a:production_first|pair-b:routed_first|abba-a1:production_first|abba-b1:routed_first|abba-b2:routed_first|abba-a2:production_first) ;;
+    *) echo "confirmation trial id/order pair is invalid" >&2; exit 2 ;;
+  esac
+  case "$CONFIRMATION_TRIAL" in
+    pair-a)
+      if [[ -n "$PREVIOUS_TRIAL_SHA256" ]]; then
+        echo "pair-a must not name a predecessor" >&2
+        exit 2
+      fi
+      ;;
+    *)
+      if [[ ! "$PREVIOUS_TRIAL_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "non-pair-a confirmation trials require --previous-trial-sha256" >&2
+        exit 2
+      fi
+      ;;
+  esac
+fi
 
 if [[ -z "$MANIFEST" && "$LEGACY_MANUAL" != "1" ]]; then
   echo "--manifest is required for an authoritative gate; use --legacy-manual only for non-authoritative inspection" >&2
@@ -106,13 +190,31 @@ if [[ -n "$MANIFEST" ]]; then
     echo "--results-root is required for authoritative per-language evidence" >&2
     exit 2
   fi
-  mkdir -p "$RESULTS_ROOT/production"
+  mkdir -p "$RESULTS_ROOT/production" "$RESULTS_ROOT/c_oracle" \
+    "$RESULTS_ROOT/confirmation/trials" "$RESULTS_ROOT/confirmation/cohorts" \
+    "$RESULTS_ROOT/confirmation/indexes" "$RESULTS_ROOT/confirmation/run-configs"
   RESULTS_ROOT="$(realpath "$RESULTS_ROOT")"
+  if [[ -n "$CONFIRMATION_TRIAL" ]]; then
+    if [[ -n "$PREVIOUS_TRIAL_SHA256" && ! -f "$RESULTS_ROOT/confirmation/trials/$PREVIOUS_TRIAL_SHA256.json" ]]; then
+      echo "selected predecessor receipt is missing: $RESULTS_ROOT/confirmation/trials/$PREVIOUS_TRIAL_SHA256.json" >&2
+      exit 2
+    fi
+  fi
   if [[ -n "$(git -C "$REPO_ROOT" status --porcelain --untracked-files=normal)" ]]; then
     echo "authoritative forest corpus gates require a clean gotreesitter worktree" >&2
     exit 2
   fi
   GIT_REVISION="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  HOST_FINGERPRINT="$({
+    if [[ -r /etc/machine-id ]]; then
+      cat /etc/machine-id
+    elif [[ -r /sys/class/dmi/id/product_uuid ]]; then
+      cat /sys/class/dmi/id/product_uuid
+    else
+      hostname
+    fi
+    uname -m
+  } | sha256sum | awk '{print $1}')"
   if [[ -z "$LOCK_SHA256" ]]; then
     read -r LOCK_SHA256 _ < "$REPO_ROOT/cgo_harness/perf_scan/corpus_sources.lock.sha256"
   fi
@@ -120,16 +222,26 @@ fi
 
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 OUT_DIR="$OUT_ROOT/$STAMP"
-mkdir -p "$OUT_DIR"
+ATTEMPT_DIR="$OUT_DIR/attempt"
+mkdir -p "$ATTEMPT_DIR"
 
 if [[ "$BUILD_IMAGE" == "1" ]]; then
   docker build -t "$IMAGE_TAG" "$SCRIPT_DIR"
 fi
+IMAGE_ID="$(docker image inspect -f '{{.Id}}' "$IMAGE_TAG")"
+
+RUN_CONFIG_FILE="$OUT_DIR/run-config.json"
+cat > "$RUN_CONFIG_FILE" <<EOF
+{"schema":"forest-audit-run-config-v1","host_label":"$HOST_LABEL","host_fingerprint":"$HOST_FINGERPRINT","image_id":"$IMAGE_ID","memory":"$MEMORY_LIMIT","cpus":"$CPUS_LIMIT","cpuset_cpus":"$CPUSET_CPUS","pids":"$PIDS_LIMIT","gomemlimit":"$GOMEMLIMIT_VALUE","gomaxprocs":1,"timeout":"$TIMEOUT"}
+EOF
+RUN_CONFIG_SHA256="$(sha256sum "$RUN_CONFIG_FILE" | awk '{print $1}')"
 
 CONTAINER_NAME="gts-forest-corpus-$STAMP"
 DOCKER_AUTH_ARGS=(
   --env "GTS_FOREST_CORPUS=1"
   --env "GTS_FOREST_LANGS=$LANGS"
+  --env "GOMAXPROCS=1"
+  --env "GOMEMLIMIT=$GOMEMLIMIT_VALUE"
 )
 if [[ -n "$MANIFEST" ]]; then
   DOCKER_AUTH_ARGS+=(
@@ -138,16 +250,32 @@ if [[ -n "$MANIFEST" ]]; then
     --env "GTS_FOREST_CORPUS_LOCK_PATH=/forest-corpus.lock"
     --env "GTS_FOREST_GOTREESITTER_REVISION=$GIT_REVISION"
     --env "GTS_FOREST_CORPUS_LOCK_SHA256=$LOCK_SHA256"
-    --env "GTS_FOREST_AUDIT_RESULT_OUT=/forest-results/production/$LANGS.json"
     --mount "type=bind,src=$MANIFEST,dst=/forest-manifest.json,readonly"
     --mount "type=bind,src=$CORPUS_ROOT,dst=/forest-corpus,readonly"
     --mount "type=bind,src=$CORPUS_LOCK,dst=/forest-corpus.lock,readonly"
-    --mount "type=bind,src=$RESULTS_ROOT,dst=/forest-results"
+    --mount "type=bind,src=$ATTEMPT_DIR,dst=/forest-output"
   )
+  if [[ -n "$CONFIRMATION_TRIAL" ]]; then
+    DOCKER_AUTH_ARGS+=(
+      --env "GTS_FOREST_AUDIT_CONFIRMATION_OUT=/forest-output/trial.json"
+      --env "GTS_FOREST_AUDIT_TRIAL_ID=$CONFIRMATION_TRIAL"
+      --env "GTS_FOREST_AUDIT_EXECUTION_ORDER=$EXECUTION_ORDER"
+      --env "GTS_FOREST_AUDIT_REPEAT_COUNT=$REPEAT_COUNT"
+      --env "GTS_FOREST_AUDIT_RUN_CONFIG_SHA256=$RUN_CONFIG_SHA256"
+      --env "GTS_FOREST_AUDIT_PREVIOUS_TRIAL_SHA256=$PREVIOUS_TRIAL_SHA256"
+    )
+  else
+    DOCKER_AUTH_ARGS+=(--env "GTS_FOREST_AUDIT_RESULT_OUT=/forest-output/result.json")
+  fi
 else
   DOCKER_AUTH_ARGS+=(--env "GTS_FOREST_CORPUS_LEGACY_MANUAL=1")
 fi
 INNER_CMD="cd /workspace/cgo_harness && /usr/bin/time -v go test ./ -run '^TestForestCorpusParity$' -count=1 -timeout $TIMEOUT -v"
+
+DOCKER_PLACEMENT_ARGS=()
+if [[ -n "$CPUSET_CPUS" ]]; then
+  DOCKER_PLACEMENT_ARGS+=(--cpuset-cpus "$CPUSET_CPUS")
+fi
 
 CID="$(docker create \
   --name "$CONTAINER_NAME" \
@@ -156,12 +284,19 @@ CID="$(docker create \
   --memory-swap "$MEMORY_LIMIT" \
   --cpus "$CPUS_LIMIT" \
   --pids-limit "$PIDS_LIMIT" \
+  "${DOCKER_PLACEMENT_ARGS[@]}" \
   "${DOCKER_AUTH_ARGS[@]}" \
-  --mount "type=bind,src=$REPO_ROOT,dst=/workspace" \
+  --mount "type=bind,src=$REPO_ROOT,dst=/workspace,readonly" \
   --mount "type=volume,src=gotreesitter-go-mod-cache,dst=/go/pkg/mod" \
   --mount "type=volume,src=gotreesitter-go-build-cache,dst=/root/.cache/go-build" \
-  "$IMAGE_TAG" \
+  "$IMAGE_ID" \
   bash -c "$INNER_CMD")"
+CONTAINER_IMAGE_ID="$(docker inspect -f '{{.Image}}' "$CID")"
+if [[ "$CONTAINER_IMAGE_ID" != "$IMAGE_ID" ]]; then
+  docker rm "$CID" >/dev/null 2>&1 || true
+  echo "container image drifted: recorded $IMAGE_ID, created $CONTAINER_IMAGE_ID" >&2
+  exit 2
+fi
 
 docker start "$CID" >/dev/null
 docker logs -f "$CID" 2>&1 | tee "$OUT_DIR/container.log"
@@ -169,10 +304,48 @@ EXIT_CODE="$(docker wait "$CID")"
 OOM_KILLED="$(docker inspect -f '{{.State.OOMKilled}}' "$CID")"
 docker rm "$CID" >/dev/null 2>&1 || true
 
+if [[ "$EXIT_CODE" == "0" && -n "$MANIFEST" ]]; then
+  AFTER_REVISION="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  AFTER_STATUS="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=normal)"
+  if [[ "$AFTER_REVISION" != "$GIT_REVISION" || -n "$AFTER_STATUS" ]]; then
+    echo "gotreesitter worktree changed during authoritative run; staged evidence was not published" >&2
+    EXIT_CODE=2
+  elif [[ -n "$CONFIRMATION_TRIAL" ]]; then
+    if [[ ! -f "$ATTEMPT_DIR/trial.json" ]]; then
+      echo "successful confirmation run produced no staged trial" >&2
+      EXIT_CODE=2
+    else
+      PUBLISH_OUTPUT="$(cd "$REPO_ROOT/cgo_harness" && go run ./cmd/forest_audit publish-confirmation \
+        --results-root "$RESULTS_ROOT" --run-config "$RUN_CONFIG_FILE" --trial "$ATTEMPT_DIR/trial.json")" || EXIT_CODE=$?
+      if [[ "$EXIT_CODE" == "0" ]]; then
+        printf '%s\n' "$PUBLISH_OUTPUT" | tee "$OUT_DIR/published-confirmation.txt"
+      fi
+    fi
+  else
+    if [[ ! -f "$ATTEMPT_DIR/result.json" ]]; then
+      echo "successful forest screen produced no staged result" >&2
+      EXIT_CODE=2
+    else
+      PUBLISH_OUTPUT="$(cd "$REPO_ROOT/cgo_harness" && go run ./cmd/forest_audit publish-result \
+        --results-root "$RESULTS_ROOT" --result "$ATTEMPT_DIR/result.json")" || EXIT_CODE=$?
+      if [[ "$EXIT_CODE" == "0" ]]; then
+        printf '%s\n' "$PUBLISH_OUTPUT" | tee "$OUT_DIR/published-result.txt"
+      fi
+    fi
+  fi
+fi
+
 {
   echo "langs=$LANGS"
   echo "image=$IMAGE_TAG"
+  echo "image_id=$IMAGE_ID"
+  echo "container_image_id=$CONTAINER_IMAGE_ID"
   echo "memory=$MEMORY_LIMIT"
+  echo "cpus=$CPUS_LIMIT"
+  echo "cpuset_cpus=$CPUSET_CPUS"
+  echo "host_label=$HOST_LABEL"
+  echo "host_fingerprint=$HOST_FINGERPRINT"
+  echo "gomemlimit=$GOMEMLIMIT_VALUE"
   echo "manifest=$MANIFEST"
   echo "corpus_root=$CORPUS_ROOT"
   echo "corpus_lock=$CORPUS_LOCK"
@@ -180,6 +353,11 @@ docker rm "$CID" >/dev/null 2>&1 || true
   echo "legacy_manual=$LEGACY_MANUAL"
   echo "gotreesitter_revision=$GIT_REVISION"
   echo "corpus_lock_sha256=$LOCK_SHA256"
+  echo "confirmation_trial=$CONFIRMATION_TRIAL"
+  echo "execution_order=$EXECUTION_ORDER"
+  echo "repeat_count=$REPEAT_COUNT"
+  echo "run_config_sha256=$RUN_CONFIG_SHA256"
+  echo "previous_trial_sha256=$PREVIOUS_TRIAL_SHA256"
   echo "exit_code=$EXIT_CODE"
   echo "oom_killed=$OOM_KILLED"
 } | tee "$OUT_DIR/summary.txt"

--- a/cgo_harness/forest_audit.go
+++ b/cgo_harness/forest_audit.go
@@ -15,7 +15,7 @@ import (
 const (
 	ForestCorpusManifestSchema = "forest-corpus-manifest-v2"
 	ForestAuditResultSchema    = "forest-audit-result-v2"
-	ForestAuditReportSchema    = "forest-audit-report-v3"
+	ForestAuditReportSchema    = "forest-audit-report-v4"
 )
 
 type ForestCorpusManifest struct {
@@ -225,6 +225,10 @@ func readForestAuditJSON(filePath string, value any) error {
 	if err != nil {
 		return err
 	}
+	return decodeForestAuditJSON(data, value)
+}
+
+func decodeForestAuditJSON(data []byte, value any) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(value); err != nil {
@@ -234,6 +238,14 @@ func readForestAuditJSON(filePath string, value any) error {
 }
 
 func writeForestAuditJSON(filePath string, value any) error {
+	return writeForestAuditJSONMode(filePath, value, false)
+}
+
+func writeForestAuditJSONExclusive(filePath string, value any) error {
+	return writeForestAuditJSONMode(filePath, value, true)
+}
+
+func writeForestAuditJSONMode(filePath string, value any, exclusive bool) error {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return err
@@ -242,6 +254,27 @@ func writeForestAuditJSON(filePath string, value any) error {
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
+	}
+	if exclusive {
+		destination, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err != nil {
+			return err
+		}
+		if _, err := destination.Write(data); err != nil {
+			destination.Close()
+			_ = os.Remove(filePath)
+			return err
+		}
+		if err := destination.Sync(); err != nil {
+			destination.Close()
+			_ = os.Remove(filePath)
+			return err
+		}
+		if err := destination.Close(); err != nil {
+			_ = os.Remove(filePath)
+			return err
+		}
+		return nil
 	}
 	temp, err := os.CreateTemp(dir, ".forest-audit-*.tmp")
 	if err != nil {

--- a/cgo_harness/forest_audit_confirmation.go
+++ b/cgo_harness/forest_audit_confirmation.go
@@ -1,0 +1,1120 @@
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const (
+	ForestAuditConfirmationTrialSchema  = "forest-audit-confirmation-trial-v1"
+	ForestAuditConfirmationPlanSchema   = "forest-audit-confirmation-plan-v1"
+	ForestAuditRunConfigSchema          = "forest-audit-run-config-v1"
+	ForestAuditConfirmationCohortSchema = "forest-audit-confirmation-cohort-v1"
+	ForestAuditConfirmationIndexSchema  = "forest-audit-confirmation-index-v1"
+
+	ForestAuditOrderProductionFirst = "production_first"
+	ForestAuditOrderRoutedFirst     = "routed_first"
+
+	forestAuditConfirmationPairA  = "pair-a"
+	forestAuditConfirmationPairB  = "pair-b"
+	forestAuditConfirmationABBAA1 = "abba-a1"
+	forestAuditConfirmationABBAB1 = "abba-b1"
+	forestAuditConfirmationABBAB2 = "abba-b2"
+	forestAuditConfirmationABBAA2 = "abba-a2"
+
+	forestAuditConfirmationRequired     = "confirmation_required"
+	forestAuditConfirmationReverse      = "reverse_required"
+	forestAuditConfirmationABBA         = "abba_required"
+	forestAuditConfirmationConfirmed    = "confirmed"
+	forestAuditConfirmationNeutral      = "economically_neutral"
+	forestAuditConfirmationInconclusive = "inconclusive"
+
+	forestAuditRelationProductionIdentity     = "production_identity"
+	forestAuditRelationOracleCorrectionReview = "oracle_correction_review_required"
+	forestAuditRelationUnresolvedDivergence   = "unresolved_divergence"
+)
+
+const (
+	forestAuditConfirmationMinSpeedup = 1.05
+	forestAuditConfirmationMaxSpread  = 1.10
+	forestAuditConfirmationMinNanos   = int64(750_000_000)
+	forestAuditConfirmationMaxRepeats = 20
+)
+
+// ForestAuditRunPlan controls pair order and the number of complete-corpus
+// production/routed sweeps inside one isolated language shard. The default
+// exactly preserves the v2 screening behavior.
+type ForestAuditRunPlan struct {
+	ExecutionOrder string
+	RepeatCount    int
+}
+
+func DefaultForestAuditRunPlan() ForestAuditRunPlan {
+	return ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1}
+}
+
+func ForestAuditRunPlanFromEnv() (ForestAuditRunPlan, error) {
+	plan := DefaultForestAuditRunPlan()
+	if raw := strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_EXECUTION_ORDER")); raw != "" {
+		plan.ExecutionOrder = raw
+	}
+	if raw := strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_REPEAT_COUNT")); raw != "" {
+		repeats, err := strconv.Atoi(raw)
+		if err != nil {
+			return plan, fmt.Errorf("parse GTS_FOREST_AUDIT_REPEAT_COUNT: %w", err)
+		}
+		plan.RepeatCount = repeats
+	}
+	return plan, validateForestAuditRunPlan(plan)
+}
+
+func validateForestAuditRunPlan(plan ForestAuditRunPlan) error {
+	if plan.ExecutionOrder != ForestAuditOrderProductionFirst && plan.ExecutionOrder != ForestAuditOrderRoutedFirst {
+		return fmt.Errorf("invalid forest audit execution order %q", plan.ExecutionOrder)
+	}
+	if plan.RepeatCount < 1 || plan.RepeatCount > forestAuditConfirmationMaxRepeats {
+		return fmt.Errorf("forest audit repeat count %d outside 1..%d", plan.RepeatCount, forestAuditConfirmationMaxRepeats)
+	}
+	return nil
+}
+
+// ForestAuditConfirmationTrial is a self-describing timing block. Its nested
+// result remains forest-audit-result-v2 so historical screening shards retain
+// their exact schema and validation contract.
+type ForestAuditConfirmationTrial struct {
+	Schema          string            `json:"schema"`
+	TrialID         string            `json:"trial_id"`
+	Sequence        int               `json:"sequence"`
+	ExecutionOrder  string            `json:"execution_order"`
+	RepeatCount     int               `json:"repeat_count"`
+	RunConfigSHA256 string            `json:"run_config_sha256"`
+	PreviousSHA256  string            `json:"previous_trial_sha256,omitempty"`
+	Result          ForestAuditResult `json:"result"`
+	receiptSHA256   string
+	receiptPath     string
+}
+
+type ForestAuditRunConfig struct {
+	Schema          string `json:"schema"`
+	HostLabel       string `json:"host_label"`
+	HostFingerprint string `json:"host_fingerprint"`
+	ImageID         string `json:"image_id"`
+	Memory          string `json:"memory"`
+	CPUs            string `json:"cpus"`
+	CPUSetCPUs      string `json:"cpuset_cpus"`
+	PIDs            string `json:"pids"`
+	GoMemLimit      string `json:"gomemlimit"`
+	GOMAXPROCS      int    `json:"gomaxprocs"`
+	TestTimeout     string `json:"timeout"`
+}
+
+type ForestAuditConfirmationTrialRef struct {
+	TrialID string `json:"trial_id"`
+	SHA256  string `json:"sha256"`
+}
+
+type ForestAuditConfirmationCohort struct {
+	Schema               string                            `json:"schema"`
+	GotreesitterRevision string                            `json:"gotreesitter_revision"`
+	CorpusManifestSHA256 string                            `json:"corpus_manifest_sha256"`
+	CorpusLockSHA256     string                            `json:"corpus_lock_sha256"`
+	Language             string                            `json:"language"`
+	RunConfigSHA256      string                            `json:"run_config_sha256"`
+	HeadTrialSHA256      string                            `json:"head_trial_sha256"`
+	Trials               []ForestAuditConfirmationTrialRef `json:"trials"`
+}
+
+type ForestAuditConfirmationIndexEntry struct {
+	Language     string `json:"language"`
+	CohortSHA256 string `json:"cohort_sha256"`
+}
+
+type ForestAuditConfirmationIndex struct {
+	Schema               string                              `json:"schema"`
+	GotreesitterRevision string                              `json:"gotreesitter_revision"`
+	CorpusManifestSHA256 string                              `json:"corpus_manifest_sha256"`
+	CorpusLockSHA256     string                              `json:"corpus_lock_sha256"`
+	Cohorts              []ForestAuditConfirmationIndexEntry `json:"cohorts"`
+}
+
+type ForestAuditStoredConfirmation struct {
+	TrialSHA256  string
+	CohortSHA256 string
+	IndexSHA256  string
+	IndexPath    string
+}
+
+func PublishForestAuditConfirmationIndex(resultsRoot string, index ForestAuditConfirmationIndex) (string, string, error) {
+	if index.Schema != ForestAuditConfirmationIndexSchema {
+		return "", "", fmt.Errorf("confirmation index schema %q", index.Schema)
+	}
+	if err := forestManifestRevision(index.GotreesitterRevision); err != nil {
+		return "", "", err
+	}
+	if _, err := forestManifestDigest("manifest", index.CorpusManifestSHA256); err != nil {
+		return "", "", err
+	}
+	if _, err := forestManifestDigest("corpus lock", index.CorpusLockSHA256); err != nil {
+		return "", "", err
+	}
+	sort.Slice(index.Cohorts, func(i, j int) bool { return index.Cohorts[i].Language < index.Cohorts[j].Language })
+	previous := ""
+	for _, entry := range index.Cohorts {
+		if err := forestManifestLanguage(entry.Language); err != nil {
+			return "", "", err
+		}
+		if entry.Language <= previous {
+			return "", "", fmt.Errorf("confirmation index cohorts are duplicate")
+		}
+		if _, err := forestManifestDigest("cohort", entry.CohortSHA256); err != nil {
+			return "", "", err
+		}
+		cohortPath := filepath.Join(resultsRoot, "confirmation", "cohorts", entry.CohortSHA256+".json")
+		artifact, err := readForestAuditArtifact(cohortPath)
+		if err != nil || artifact.schema != ForestAuditConfirmationCohortSchema || artifact.digest != entry.CohortSHA256 {
+			return "", "", fmt.Errorf("selected cohort for %s is unavailable or invalid", entry.Language)
+		}
+		var cohort ForestAuditConfirmationCohort
+		if err := artifact.decode(&cohort); err != nil {
+			return "", "", fmt.Errorf("decode selected cohort for %s: %w", entry.Language, err)
+		}
+		if err := validateForestAuditConfirmationCohortIdentity(
+			cohort, entry.Language, index.GotreesitterRevision, index.CorpusManifestSHA256, index.CorpusLockSHA256,
+		); err != nil {
+			return "", "", err
+		}
+		previous = entry.Language
+	}
+	if len(index.Cohorts) == 0 {
+		return "", "", fmt.Errorf("confirmation index has no cohorts")
+	}
+	data, digest, err := marshalForestAuditContent(index)
+	if err != nil {
+		return "", "", err
+	}
+	path := filepath.Join(resultsRoot, "confirmation", "indexes", digest+".json")
+	if err := copyForestAuditArtifactExclusive(path, data); err != nil {
+		return "", "", err
+	}
+	return digest, path, nil
+}
+
+func NewForestAuditConfirmationTrial(trialID, runConfigSHA, previousTrialSHA string, plan ForestAuditRunPlan, result ForestAuditResult) (ForestAuditConfirmationTrial, error) {
+	spec, ok := forestAuditConfirmationTrialSpec(trialID)
+	if !ok {
+		return ForestAuditConfirmationTrial{}, fmt.Errorf("invalid forest confirmation trial id %q", trialID)
+	}
+	trial := ForestAuditConfirmationTrial{
+		Schema: ForestAuditConfirmationTrialSchema, TrialID: trialID, Sequence: spec.sequence,
+		ExecutionOrder: plan.ExecutionOrder, RepeatCount: plan.RepeatCount,
+		RunConfigSHA256: strings.ToLower(strings.TrimSpace(runConfigSHA)),
+		PreviousSHA256:  strings.ToLower(strings.TrimSpace(previousTrialSHA)), Result: result,
+	}
+	return trial, validateForestAuditConfirmationTrial(trial)
+}
+
+func WriteForestAuditConfirmationTrial(path string, trial ForestAuditConfirmationTrial) error {
+	if err := validateForestAuditConfirmationTrial(trial); err != nil {
+		return err
+	}
+	return writeForestAuditJSONExclusive(path, trial)
+}
+
+func (reduction *forestAuditReduction) admitConfirmationTrial(artifact forestAuditArtifact, expectedSHA string) error {
+	var trial ForestAuditConfirmationTrial
+	if err := artifact.decode(&trial); err != nil {
+		return fmt.Errorf("read confirmation trial %s: %w", artifact.path, err)
+	}
+	if err := validateForestAuditConfirmationTrial(trial); err != nil {
+		return fmt.Errorf("validate confirmation trial %s: %w", artifact.path, err)
+	}
+	if err := reduction.validateResultIdentity(trial.Result); err != nil {
+		return fmt.Errorf("confirmation trial %s: %w", artifact.path, err)
+	}
+	if artifact.digest != expectedSHA || filepath.Base(artifact.path) != expectedSHA+".json" {
+		return fmt.Errorf("confirmation trial %s content hash is %s, want %s", artifact.path, artifact.digest, expectedSHA)
+	}
+	trial.receiptSHA256 = artifact.digest
+	trial.receiptPath = artifact.path
+	language := trial.Result.Language
+	if reduction.confirmations[language] == nil {
+		reduction.confirmations[language] = make(map[string]ForestAuditConfirmationTrial)
+	}
+	if _, exists := reduction.confirmations[language][trial.TrialID]; exists {
+		return fmt.Errorf("duplicate confirmation trial %q for %s", trial.TrialID, language)
+	}
+	reduction.confirmations[language][trial.TrialID] = trial
+	return nil
+}
+
+func (reduction *forestAuditReduction) admitRunConfig(artifact forestAuditArtifact, expectedSHA string) error {
+	var config ForestAuditRunConfig
+	if err := artifact.decode(&config); err != nil {
+		return fmt.Errorf("read forest audit run config %s: %w", artifact.path, err)
+	}
+	if err := validateForestAuditRunConfig(config); err != nil {
+		return fmt.Errorf("validate forest audit run config %s: %w", artifact.path, err)
+	}
+	if artifact.digest != expectedSHA || filepath.Base(artifact.path) != expectedSHA+".json" {
+		return fmt.Errorf("run-config receipt %s content hash is %s, want %s", artifact.path, artifact.digest, expectedSHA)
+	}
+	if _, exists := reduction.runConfigs[expectedSHA]; exists {
+		return nil
+	}
+	reduction.runConfigs[expectedSHA] = config
+	return nil
+}
+
+func (reduction *forestAuditReduction) loadConfirmationIndex(resultsRoot, indexPath string) error {
+	indexArtifact, err := readForestAuditArtifact(indexPath)
+	if err != nil {
+		return fmt.Errorf("read confirmation index: %w", err)
+	}
+	if indexArtifact.schema != ForestAuditConfirmationIndexSchema {
+		return fmt.Errorf("confirmation index schema %q, want %q", indexArtifact.schema, ForestAuditConfirmationIndexSchema)
+	}
+	if filepath.Base(indexPath) != indexArtifact.digest+".json" {
+		return fmt.Errorf("confirmation index %s is not named by content hash %s", indexPath, indexArtifact.digest)
+	}
+	var index ForestAuditConfirmationIndex
+	if err := indexArtifact.decode(&index); err != nil {
+		return fmt.Errorf("decode confirmation index: %w", err)
+	}
+	if err := reduction.validateConfirmationIndex(index); err != nil {
+		return err
+	}
+	reduction.confirmationIndexDigest = indexArtifact.digest
+	for _, entry := range index.Cohorts {
+		cohortPath := filepath.Join(resultsRoot, "confirmation", "cohorts", entry.CohortSHA256+".json")
+		cohortArtifact, err := readForestAuditArtifact(cohortPath)
+		if err != nil {
+			return fmt.Errorf("read confirmation cohort for %s: %w", entry.Language, err)
+		}
+		if cohortArtifact.schema != ForestAuditConfirmationCohortSchema || cohortArtifact.digest != entry.CohortSHA256 {
+			return fmt.Errorf("confirmation cohort for %s does not match selected digest %s", entry.Language, entry.CohortSHA256)
+		}
+		var cohort ForestAuditConfirmationCohort
+		if err := cohortArtifact.decode(&cohort); err != nil {
+			return fmt.Errorf("decode confirmation cohort for %s: %w", entry.Language, err)
+		}
+		if err := reduction.validateConfirmationCohort(cohort, entry.Language); err != nil {
+			return err
+		}
+		reduction.confirmationCohorts[entry.Language] = cohortArtifact.digest
+		configPath := filepath.Join(resultsRoot, "confirmation", "run-configs", cohort.RunConfigSHA256+".json")
+		configArtifact, err := readForestAuditArtifact(configPath)
+		if err != nil {
+			return fmt.Errorf("read run config for %s: %w", entry.Language, err)
+		}
+		if err := reduction.admitRunConfig(configArtifact, cohort.RunConfigSHA256); err != nil {
+			return err
+		}
+		for _, ref := range cohort.Trials {
+			trialPath := filepath.Join(resultsRoot, "confirmation", "trials", ref.SHA256+".json")
+			trialArtifact, err := readForestAuditArtifact(trialPath)
+			if err != nil {
+				return fmt.Errorf("read confirmation trial %s/%s: %w", entry.Language, ref.TrialID, err)
+			}
+			if trialArtifact.schema != ForestAuditConfirmationTrialSchema {
+				return fmt.Errorf("confirmation trial %s/%s schema %q", entry.Language, ref.TrialID, trialArtifact.schema)
+			}
+			if err := reduction.admitConfirmationTrial(trialArtifact, ref.SHA256); err != nil {
+				return err
+			}
+			admitted := reduction.confirmations[entry.Language][ref.TrialID]
+			if admitted.TrialID != ref.TrialID || admitted.RunConfigSHA256 != cohort.RunConfigSHA256 {
+				return fmt.Errorf("confirmation cohort reference %s/%s does not match decoded trial", entry.Language, ref.TrialID)
+			}
+		}
+	}
+	return nil
+}
+
+func (reduction *forestAuditReduction) validateConfirmationIndex(index ForestAuditConfirmationIndex) error {
+	if index.Schema != ForestAuditConfirmationIndexSchema ||
+		index.GotreesitterRevision != reduction.manifest.GotreesitterRevision ||
+		index.CorpusManifestSHA256 != reduction.manifestDigest ||
+		index.CorpusLockSHA256 != reduction.manifest.CorpusLock.SHA256 {
+		return fmt.Errorf("confirmation index identity does not match manifest")
+	}
+	previous := ""
+	for i, entry := range index.Cohorts {
+		if err := forestManifestLanguage(entry.Language); err != nil {
+			return fmt.Errorf("confirmation index cohort %d: %w", i, err)
+		}
+		if _, ok := reduction.manifestFiles[entry.Language]; !ok {
+			return fmt.Errorf("confirmation index language %q absent from manifest", entry.Language)
+		}
+		if _, err := forestManifestDigest("cohort", entry.CohortSHA256); err != nil {
+			return err
+		}
+		if entry.Language <= previous {
+			return fmt.Errorf("confirmation index cohorts are duplicate or unsorted")
+		}
+		previous = entry.Language
+	}
+	if len(index.Cohorts) == 0 {
+		return fmt.Errorf("confirmation index has no cohorts")
+	}
+	return nil
+}
+
+func (reduction *forestAuditReduction) validateConfirmationCohort(cohort ForestAuditConfirmationCohort, language string) error {
+	return validateForestAuditConfirmationCohortIdentity(
+		cohort, language, reduction.manifest.GotreesitterRevision, reduction.manifestDigest, reduction.manifest.CorpusLock.SHA256,
+	)
+}
+
+func validateForestAuditConfirmationCohortIdentity(cohort ForestAuditConfirmationCohort, language, revision, manifestSHA, lockSHA string) error {
+	if cohort.Schema != ForestAuditConfirmationCohortSchema || cohort.Language != language ||
+		cohort.GotreesitterRevision != revision || cohort.CorpusManifestSHA256 != manifestSHA || cohort.CorpusLockSHA256 != lockSHA {
+		return fmt.Errorf("confirmation cohort identity does not match manifest for %s", language)
+	}
+	if _, err := forestManifestDigest("run config", cohort.RunConfigSHA256); err != nil {
+		return err
+	}
+	if len(cohort.Trials) == 0 || len(cohort.Trials) > 6 {
+		return fmt.Errorf("confirmation cohort for %s has %d trials", language, len(cohort.Trials))
+	}
+	for i, ref := range cohort.Trials {
+		spec, ok := forestAuditConfirmationTrialSpec(ref.TrialID)
+		if !ok || spec.sequence != i+1 {
+			return fmt.Errorf("confirmation cohort for %s has invalid trial %q at sequence %d", language, ref.TrialID, i+1)
+		}
+		if _, err := forestManifestDigest("trial", ref.SHA256); err != nil {
+			return err
+		}
+	}
+	if cohort.HeadTrialSHA256 != cohort.Trials[len(cohort.Trials)-1].SHA256 {
+		return fmt.Errorf("confirmation cohort head for %s does not match final trial", language)
+	}
+	return nil
+}
+
+func StoreForestAuditConfirmation(resultsRoot, runConfigPath, trialPath string) (ForestAuditStoredConfirmation, error) {
+	var stored ForestAuditStoredConfirmation
+	runConfigArtifact, err := readForestAuditArtifact(runConfigPath)
+	if err != nil {
+		return stored, err
+	}
+	if runConfigArtifact.schema != ForestAuditRunConfigSchema {
+		return stored, fmt.Errorf("run config schema %q", runConfigArtifact.schema)
+	}
+	var runConfig ForestAuditRunConfig
+	if err := runConfigArtifact.decode(&runConfig); err != nil {
+		return stored, err
+	}
+	if err := validateForestAuditRunConfig(runConfig); err != nil {
+		return stored, err
+	}
+	trialArtifact, err := readForestAuditArtifact(trialPath)
+	if err != nil {
+		return stored, err
+	}
+	if trialArtifact.schema != ForestAuditConfirmationTrialSchema {
+		return stored, fmt.Errorf("confirmation trial schema %q", trialArtifact.schema)
+	}
+	var trial ForestAuditConfirmationTrial
+	if err := trialArtifact.decode(&trial); err != nil {
+		return stored, err
+	}
+	if err := validateForestAuditConfirmationTrial(trial); err != nil {
+		return stored, err
+	}
+	if trial.RunConfigSHA256 != runConfigArtifact.digest {
+		return stored, fmt.Errorf("trial run config %s does not match receipt %s", trial.RunConfigSHA256, runConfigArtifact.digest)
+	}
+	trial.receiptSHA256 = trialArtifact.digest
+	refs, err := forestAuditConfirmationRefs(resultsRoot, trial)
+	if err != nil {
+		return stored, err
+	}
+	trialPathInBundle := filepath.Join(resultsRoot, "confirmation", "trials", trialArtifact.digest+".json")
+	configPathInBundle := filepath.Join(resultsRoot, "confirmation", "run-configs", runConfigArtifact.digest+".json")
+	if err := copyForestAuditArtifactExclusive(configPathInBundle, runConfigArtifact.data); err != nil {
+		return stored, err
+	}
+	if err := copyForestAuditArtifactExclusive(trialPathInBundle, trialArtifact.data); err != nil {
+		return stored, err
+	}
+	cohort := ForestAuditConfirmationCohort{
+		Schema: ForestAuditConfirmationCohortSchema, GotreesitterRevision: trial.Result.GotreesitterRevision,
+		CorpusManifestSHA256: trial.Result.CorpusManifestSHA256, CorpusLockSHA256: trial.Result.CorpusLockSHA256,
+		Language: trial.Result.Language, RunConfigSHA256: trial.RunConfigSHA256,
+		HeadTrialSHA256: trialArtifact.digest, Trials: refs,
+	}
+	cohortData, cohortSHA, err := marshalForestAuditContent(cohort)
+	if err != nil {
+		return stored, err
+	}
+	cohortPath := filepath.Join(resultsRoot, "confirmation", "cohorts", cohortSHA+".json")
+	if err := copyForestAuditArtifactExclusive(cohortPath, cohortData); err != nil {
+		return stored, err
+	}
+	index := ForestAuditConfirmationIndex{
+		Schema: ForestAuditConfirmationIndexSchema, GotreesitterRevision: trial.Result.GotreesitterRevision,
+		CorpusManifestSHA256: trial.Result.CorpusManifestSHA256, CorpusLockSHA256: trial.Result.CorpusLockSHA256,
+		Cohorts: []ForestAuditConfirmationIndexEntry{{Language: trial.Result.Language, CohortSHA256: cohortSHA}},
+	}
+	indexData, indexSHA, err := marshalForestAuditContent(index)
+	if err != nil {
+		return stored, err
+	}
+	indexPath := filepath.Join(resultsRoot, "confirmation", "indexes", indexSHA+".json")
+	if err := copyForestAuditArtifactExclusive(indexPath, indexData); err != nil {
+		return stored, err
+	}
+	return ForestAuditStoredConfirmation{TrialSHA256: trialArtifact.digest, CohortSHA256: cohortSHA, IndexSHA256: indexSHA, IndexPath: indexPath}, nil
+}
+
+func forestAuditConfirmationRefs(resultsRoot string, trial ForestAuditConfirmationTrial) ([]ForestAuditConfirmationTrialRef, error) {
+	spec, _ := forestAuditConfirmationTrialSpec(trial.TrialID)
+	refs := make([]ForestAuditConfirmationTrialRef, 0, spec.sequence)
+	if spec.previousID != "" {
+		previousPath := filepath.Join(resultsRoot, "confirmation", "trials", trial.PreviousSHA256+".json")
+		previousArtifact, err := readForestAuditArtifact(previousPath)
+		if err != nil {
+			return nil, fmt.Errorf("read predecessor %s: %w", spec.previousID, err)
+		}
+		var previous ForestAuditConfirmationTrial
+		if previousArtifact.schema != ForestAuditConfirmationTrialSchema || previousArtifact.digest != trial.PreviousSHA256 || previousArtifact.decode(&previous) != nil {
+			return nil, fmt.Errorf("invalid predecessor receipt %s", trial.PreviousSHA256)
+		}
+		previous.receiptSHA256 = previousArtifact.digest
+		if err := validateForestAuditConfirmationTrial(previous); err != nil {
+			return nil, fmt.Errorf("invalid predecessor receipt %s: %w", trial.PreviousSHA256, err)
+		}
+		previousRefs, err := forestAuditConfirmationRefs(resultsRoot, previous)
+		if err != nil {
+			return nil, err
+		}
+		if previous.TrialID != spec.previousID || previous.Result.Language != trial.Result.Language ||
+			previous.RunConfigSHA256 != trial.RunConfigSHA256 || previous.Result.GotreesitterRevision != trial.Result.GotreesitterRevision ||
+			previous.Result.CorpusManifestSHA256 != trial.Result.CorpusManifestSHA256 || previous.Result.CorpusLockSHA256 != trial.Result.CorpusLockSHA256 {
+			return nil, fmt.Errorf("predecessor identity does not match trial %s", trial.TrialID)
+		}
+		refs = append(refs, previousRefs...)
+	}
+	return append(refs, ForestAuditConfirmationTrialRef{TrialID: trial.TrialID, SHA256: trial.receiptSHA256}), nil
+}
+
+func marshalForestAuditContent(value any) ([]byte, string, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, "", err
+	}
+	data = append(data, '\n')
+	return data, fmt.Sprintf("%x", sha256.Sum256(data)), nil
+}
+
+func copyForestAuditArtifactExclusive(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(dir, ".forest-audit-publish-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(0o444); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Link(tempPath, path); err != nil {
+		if os.IsExist(err) {
+			existing, readErr := readForestAuditArtifact(path)
+			if readErr == nil && fmt.Sprintf("%x", sha256.Sum256(data)) == existing.digest && string(existing.data) == string(data) {
+				return syncForestAuditDirectory(dir)
+			}
+			if readErr != nil {
+				return fmt.Errorf("publish immutable forest audit artifact %s: existing target is invalid; quarantine it before retrying: %w", path, readErr)
+			}
+			return fmt.Errorf("publish immutable forest audit artifact %s: existing target has different content; quarantine it before retrying", path)
+		}
+		return fmt.Errorf("publish immutable forest audit artifact %s: %w", path, err)
+	}
+	return syncForestAuditDirectory(dir)
+}
+
+func syncForestAuditDirectory(dir string) error {
+	directory, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func validateForestAuditRunConfig(config ForestAuditRunConfig) error {
+	if config.Schema != ForestAuditRunConfigSchema {
+		return fmt.Errorf("forest audit run config schema %q", config.Schema)
+	}
+	if strings.TrimSpace(config.HostLabel) == "" || strings.TrimSpace(config.HostFingerprint) == "" || strings.TrimSpace(config.ImageID) == "" ||
+		strings.TrimSpace(config.Memory) == "" || strings.TrimSpace(config.CPUs) == "" ||
+		strings.TrimSpace(config.CPUSetCPUs) == "" || strings.TrimSpace(config.PIDs) == "" ||
+		strings.TrimSpace(config.GoMemLimit) == "" || strings.TrimSpace(config.TestTimeout) == "" {
+		return fmt.Errorf("forest audit run config lacks an isolation identity")
+	}
+	if !strings.HasPrefix(config.ImageID, "sha256:") {
+		return fmt.Errorf("forest audit image id %q is not content-addressed", config.ImageID)
+	}
+	if _, err := forestManifestDigest("image", strings.TrimPrefix(config.ImageID, "sha256:")); err != nil {
+		return err
+	}
+	if _, err := forestManifestDigest("host fingerprint", config.HostFingerprint); err != nil {
+		return err
+	}
+	if config.CPUs != "1" {
+		return fmt.Errorf("forest audit CPU limit %q, want 1", config.CPUs)
+	}
+	if _, err := strconv.Atoi(config.CPUSetCPUs); err != nil || strings.ContainsAny(config.CPUSetCPUs, ",- ") {
+		return fmt.Errorf("forest audit CPU set %q is not one numeric CPU", config.CPUSetCPUs)
+	}
+	if config.GOMAXPROCS != 1 {
+		return fmt.Errorf("forest audit GOMAXPROCS=%d, want 1", config.GOMAXPROCS)
+	}
+	return nil
+}
+
+func (reduction *forestAuditReduction) validateConfirmationEvidence() error {
+	languages := make([]string, 0, len(reduction.confirmations))
+	for language := range reduction.confirmations {
+		languages = append(languages, language)
+	}
+	sort.Strings(languages)
+	for _, language := range languages {
+		trials := reduction.confirmations[language]
+		production := reduction.results[language]["production"]
+		cOracle := reduction.results[language]["c_oracle"]
+		if production == nil {
+			return fmt.Errorf("confirmation evidence for %s lacks its production screen", language)
+		}
+		if cOracle == nil {
+			return fmt.Errorf("confirmation evidence for %s lacks its locked C oracle", language)
+		}
+		screenPaths, err := forestAuditRoutedCoveragePaths(production)
+		if err != nil {
+			return fmt.Errorf("production screen %s: %w", language, err)
+		}
+		if err := forestAuditRequireCOracleCoverage(cOracle, screenPaths); err != nil {
+			return fmt.Errorf("confirmation evidence for %s: %w", language, err)
+		}
+		trialIDs := make([]string, 0, len(trials))
+		for trialID := range trials {
+			trialIDs = append(trialIDs, trialID)
+		}
+		sort.Slice(trialIDs, func(i, j int) bool {
+			left, _ := forestAuditConfirmationTrialSpec(trialIDs[i])
+			right, _ := forestAuditConfirmationTrialSpec(trialIDs[j])
+			return left.sequence < right.sequence
+		})
+		for _, trialID := range trialIDs {
+			trial := trials[trialID]
+			if _, ok := reduction.runConfigs[trial.RunConfigSHA256]; !ok {
+				return fmt.Errorf("confirmation trial %s/%s is missing run-config receipt %s", language, trialID, trial.RunConfigSHA256)
+			}
+			trialPaths, err := forestAuditRoutedCoveragePaths(&trial.Result)
+			if err != nil {
+				return fmt.Errorf("confirmation trial %s/%s: %w", language, trialID, err)
+			}
+			if !forestAuditSamePaths(screenPaths, trialPaths) {
+				return fmt.Errorf("confirmation trial %s/%s routed forest paths %v differ from screen %v", language, trialID, trialPaths, screenPaths)
+			}
+			spec, _ := forestAuditConfirmationTrialSpec(trialID)
+			if spec.previousID == "" {
+				continue
+			}
+			previous, ok := trials[spec.previousID]
+			if !ok {
+				return fmt.Errorf("confirmation trial %s/%s lacks predecessor %s", language, trialID, spec.previousID)
+			}
+			if previous.receiptSHA256 == "" || trial.PreviousSHA256 != previous.receiptSHA256 {
+				return fmt.Errorf("confirmation trial %s/%s predecessor hash does not match %s", language, trialID, spec.previousID)
+			}
+		}
+	}
+	return nil
+}
+
+func forestAuditRequireCOracleCoverage(cOracle *ForestAuditResult, routedPaths []string) error {
+	if cOracle == nil || cOracle.Mode != "c_oracle" || cOracle.Status != "pass" {
+		return fmt.Errorf("locked C oracle is not a passing c_oracle result")
+	}
+	accepted := make(map[string]bool, len(cOracle.Files))
+	for _, file := range cOracle.Files {
+		if file.Disposition == "accepted" && file.Diff == "" && file.Peer.Accepted && file.Peer.FullSpan {
+			accepted[file.Path] = true
+		}
+	}
+	for _, path := range routedPaths {
+		if !accepted[path] {
+			return fmt.Errorf("routed forest path %q lacks accepted locked-C coverage", path)
+		}
+	}
+	return nil
+}
+
+func forestAuditRoutedCoveragePaths(result *ForestAuditResult) ([]string, error) {
+	if result == nil || result.FilesRoutedForest == 0 {
+		return nil, fmt.Errorf("zero routed forest coverage")
+	}
+	paths := make([]string, 0, result.FilesRoutedForest)
+	for _, file := range result.Files {
+		if file.RoutedProvenance == forestAuditRouteForestFastPath {
+			paths = append(paths, file.Path)
+		}
+	}
+	if len(paths) != result.FilesRoutedForest {
+		return nil, fmt.Errorf("routed forest coverage count %d does not match %d paths", result.FilesRoutedForest, len(paths))
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func forestAuditSamePaths(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateForestAuditConfirmationTrial(trial ForestAuditConfirmationTrial) error {
+	if trial.Schema != ForestAuditConfirmationTrialSchema {
+		return fmt.Errorf("forest confirmation trial schema %q", trial.Schema)
+	}
+	spec, ok := forestAuditConfirmationTrialSpec(trial.TrialID)
+	if !ok {
+		return fmt.Errorf("invalid forest confirmation trial id %q", trial.TrialID)
+	}
+	if err := validateForestAuditTrialID(trial.TrialID, trial.ExecutionOrder); err != nil {
+		return err
+	}
+	if trial.Sequence != spec.sequence {
+		return fmt.Errorf("forest confirmation trial %q sequence %d, want %d", trial.TrialID, trial.Sequence, spec.sequence)
+	}
+	if err := validateForestAuditRunPlan(ForestAuditRunPlan{ExecutionOrder: trial.ExecutionOrder, RepeatCount: trial.RepeatCount}); err != nil {
+		return err
+	}
+	if _, err := forestManifestDigest("run config", trial.RunConfigSHA256); err != nil {
+		return err
+	}
+	if err := validateForestAuditPreviousTrialSHA(trial.TrialID, trial.PreviousSHA256); err != nil {
+		return err
+	}
+	if err := validateForestAuditResult(trial.Result); err != nil {
+		return fmt.Errorf("confirmation result: %w", err)
+	}
+	if trial.Result.Mode != "production" {
+		return fmt.Errorf("confirmation trial mode %q, want production", trial.Result.Mode)
+	}
+	if trial.Result.FilesRoutedForest == 0 {
+		return fmt.Errorf("confirmation trial %q has zero routed forest coverage", trial.TrialID)
+	}
+	if trial.Result.Status != "pass" || trial.Result.FilesDiverged != 0 || trial.Result.FilesRoutedDiverged != 0 {
+		return fmt.Errorf("confirmation trial %q is failed evidence and cannot be published", trial.TrialID)
+	}
+	if trial.Result.PeerNanos <= 0 || trial.Result.RoutedNanos <= 0 {
+		return fmt.Errorf("confirmation trial %q lacks positive peer and routed timings", trial.TrialID)
+	}
+	return nil
+}
+
+func validateForestAuditPreviousTrialSHA(trialID, previousSHA string) error {
+	spec, ok := forestAuditConfirmationTrialSpec(trialID)
+	if !ok {
+		return fmt.Errorf("invalid forest confirmation trial id %q", trialID)
+	}
+	if spec.previousID == "" {
+		if previousSHA != "" {
+			return fmt.Errorf("forest confirmation trial %q unexpectedly chains a predecessor", trialID)
+		}
+		return nil
+	}
+	_, err := forestManifestDigest("previous trial", previousSHA)
+	return err
+}
+
+func validateForestAuditTrialID(trialID, order string) error {
+	spec, ok := forestAuditConfirmationTrialSpec(trialID)
+	if !ok {
+		return fmt.Errorf("invalid forest confirmation trial id %q", trialID)
+	}
+	if order != spec.order {
+		return fmt.Errorf("forest confirmation trial %q order %q, want %q", trialID, order, spec.order)
+	}
+	return nil
+}
+
+type forestAuditTrialSpec struct {
+	order      string
+	sequence   int
+	previousID string
+}
+
+func forestAuditConfirmationTrialSpec(trialID string) (forestAuditTrialSpec, bool) {
+	spec, ok := map[string]forestAuditTrialSpec{
+		forestAuditConfirmationPairA:  {order: ForestAuditOrderProductionFirst, sequence: 1},
+		forestAuditConfirmationPairB:  {order: ForestAuditOrderRoutedFirst, sequence: 2, previousID: forestAuditConfirmationPairA},
+		forestAuditConfirmationABBAA1: {order: ForestAuditOrderProductionFirst, sequence: 3, previousID: forestAuditConfirmationPairB},
+		forestAuditConfirmationABBAB1: {order: ForestAuditOrderRoutedFirst, sequence: 4, previousID: forestAuditConfirmationABBAA1},
+		forestAuditConfirmationABBAB2: {order: ForestAuditOrderRoutedFirst, sequence: 5, previousID: forestAuditConfirmationABBAB1},
+		forestAuditConfirmationABBAA2: {order: ForestAuditOrderProductionFirst, sequence: 6, previousID: forestAuditConfirmationABBAB2},
+	}[trialID]
+	return spec, ok
+}
+
+type ForestAuditConfirmationSummary struct {
+	Status              string    `json:"status"`
+	PooledRoutedSpeedup float64   `json:"pooled_routed_speedup,omitempty"`
+	OrderSpeedups       []float64 `json:"order_speedups,omitempty"`
+	RunConfigSHA256     string    `json:"run_config_sha256,omitempty"`
+	CompletedTrialIDs   []string  `json:"completed_trial_ids,omitempty"`
+	TrialsComplete      int       `json:"trials_complete"`
+	RequiredRepeatCount int       `json:"required_repeat_count,omitempty"`
+}
+
+type ForestAuditThreeWayRelation struct {
+	Classification   string   `json:"classification"`
+	Paths            []string `json:"paths,omitempty"`
+	EvidenceComplete bool     `json:"evidence_complete"`
+}
+
+type ForestAuditPlannedTrial struct {
+	Language       string `json:"language"`
+	Sequence       int    `json:"sequence"`
+	TrialID        string `json:"trial_id"`
+	ExecutionOrder string `json:"execution_order"`
+	RepeatCount    int    `json:"repeat_count"`
+	Reason         string `json:"reason"`
+}
+
+type ForestAuditConfirmationPlan struct {
+	Schema               string                    `json:"schema"`
+	GotreesitterRevision string                    `json:"gotreesitter_revision"`
+	CorpusManifestSHA256 string                    `json:"corpus_manifest_sha256"`
+	CorpusLockSHA256     string                    `json:"corpus_lock_sha256"`
+	Trials               []ForestAuditPlannedTrial `json:"trials"`
+}
+
+func BuildForestAuditConfirmationPlan(report ForestAuditReport) ForestAuditConfirmationPlan {
+	plan := ForestAuditConfirmationPlan{
+		Schema:               ForestAuditConfirmationPlanSchema,
+		GotreesitterRevision: report.GotreesitterRevision,
+		CorpusManifestSHA256: report.CorpusManifestSHA256,
+		CorpusLockSHA256:     report.CorpusLockSHA256,
+		Trials:               []ForestAuditPlannedTrial{},
+	}
+	for _, row := range report.Languages {
+		if !row.ScreeningEligible || row.CorrectnessRelation != forestAuditRelationProductionIdentity {
+			continue
+		}
+		repeats := 1
+		reason := row.ConfirmationStatus
+		switch row.ConfirmationStatus {
+		case forestAuditConfirmationRequired, "":
+			if reason == "" {
+				reason = forestAuditConfirmationRequired
+			}
+			completed := forestAuditCompletedTrialSet(row.Confirmation)
+			if !completed[forestAuditConfirmationPairA] {
+				plan.Trials = append(plan.Trials, ForestAuditPlannedTrial{
+					Language: row.Language, Sequence: 1, TrialID: forestAuditConfirmationPairA,
+					ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1, Reason: reason,
+				})
+			}
+			if !completed[forestAuditConfirmationPairB] {
+				plan.Trials = append(plan.Trials, ForestAuditPlannedTrial{
+					Language: row.Language, Sequence: 2, TrialID: forestAuditConfirmationPairB,
+					ExecutionOrder: ForestAuditOrderRoutedFirst, RepeatCount: 1, Reason: reason,
+				})
+			}
+		case forestAuditConfirmationReverse:
+			plan.Trials = append(plan.Trials, ForestAuditPlannedTrial{Language: row.Language, Sequence: 2, TrialID: forestAuditConfirmationPairB, ExecutionOrder: ForestAuditOrderRoutedFirst, RepeatCount: 1, Reason: forestAuditConfirmationReverse})
+		case forestAuditConfirmationABBA:
+			if row.Confirmation != nil && row.Confirmation.RequiredRepeatCount > 1 {
+				repeats = row.Confirmation.RequiredRepeatCount
+			}
+			completed := forestAuditCompletedTrialSet(row.Confirmation)
+			for _, spec := range []struct{ id, order string }{
+				{forestAuditConfirmationABBAA1, ForestAuditOrderProductionFirst},
+				{forestAuditConfirmationABBAB1, ForestAuditOrderRoutedFirst},
+				{forestAuditConfirmationABBAB2, ForestAuditOrderRoutedFirst},
+				{forestAuditConfirmationABBAA2, ForestAuditOrderProductionFirst},
+			} {
+				if !completed[spec.id] {
+					trialSpec, _ := forestAuditConfirmationTrialSpec(spec.id)
+					plan.Trials = append(plan.Trials, ForestAuditPlannedTrial{Language: row.Language, Sequence: trialSpec.sequence, TrialID: spec.id, ExecutionOrder: spec.order, RepeatCount: repeats, Reason: reason})
+				}
+			}
+		}
+	}
+	sort.Slice(plan.Trials, func(i, j int) bool {
+		if plan.Trials[i].Language != plan.Trials[j].Language {
+			return plan.Trials[i].Language < plan.Trials[j].Language
+		}
+		return plan.Trials[i].Sequence < plan.Trials[j].Sequence
+	})
+	return plan
+}
+
+func forestAuditCompletedTrialSet(summary *ForestAuditConfirmationSummary) map[string]bool {
+	completed := make(map[string]bool)
+	if summary == nil {
+		return completed
+	}
+	for _, id := range summary.CompletedTrialIDs {
+		completed[id] = true
+	}
+	return completed
+}
+
+func WriteForestAuditConfirmationPlan(path string, plan ForestAuditConfirmationPlan) error {
+	if err := validateForestAuditConfirmationPlan(plan); err != nil {
+		return err
+	}
+	return writeForestAuditJSON(path, plan)
+}
+
+func validateForestAuditConfirmationPlan(plan ForestAuditConfirmationPlan) error {
+	if plan.Schema != ForestAuditConfirmationPlanSchema {
+		return fmt.Errorf("forest confirmation plan schema %q", plan.Schema)
+	}
+	if err := forestManifestRevision(plan.GotreesitterRevision); err != nil {
+		return err
+	}
+	if _, err := forestManifestDigest("manifest", plan.CorpusManifestSHA256); err != nil {
+		return err
+	}
+	if _, err := forestManifestDigest("corpus lock", plan.CorpusLockSHA256); err != nil {
+		return err
+	}
+	seen := make(map[string]bool, len(plan.Trials))
+	for index, trial := range plan.Trials {
+		if err := forestManifestLanguage(trial.Language); err != nil {
+			return fmt.Errorf("confirmation plan trial %d: %w", index, err)
+		}
+		if err := validateForestAuditTrialID(trial.TrialID, trial.ExecutionOrder); err != nil {
+			return fmt.Errorf("confirmation plan trial %d: %w", index, err)
+		}
+		if err := validateForestAuditRunPlan(ForestAuditRunPlan{ExecutionOrder: trial.ExecutionOrder, RepeatCount: trial.RepeatCount}); err != nil {
+			return fmt.Errorf("confirmation plan trial %d: %w", index, err)
+		}
+		if trial.Sequence < 1 || trial.Sequence > 6 {
+			return fmt.Errorf("confirmation plan trial %d has sequence %d outside 1..6", index, trial.Sequence)
+		}
+		spec, _ := forestAuditConfirmationTrialSpec(trial.TrialID)
+		if trial.Sequence != spec.sequence {
+			return fmt.Errorf("confirmation plan trial %d sequence %d, want %d", index, trial.Sequence, spec.sequence)
+		}
+		key := trial.Language + "\x00" + trial.TrialID
+		if seen[key] {
+			return fmt.Errorf("confirmation plan duplicates %s %s", trial.Language, trial.TrialID)
+		}
+		seen[key] = true
+	}
+	return nil
+}
+
+func summarizeForestAuditConfirmations(trials map[string]ForestAuditConfirmationTrial) ForestAuditConfirmationSummary {
+	if len(trials) == 0 {
+		return ForestAuditConfirmationSummary{Status: forestAuditConfirmationRequired}
+	}
+	completed := make([]string, 0, len(trials))
+	for id := range trials {
+		completed = append(completed, id)
+	}
+	sort.Strings(completed)
+	if _, ok := trials[forestAuditConfirmationPairA]; !ok {
+		return ForestAuditConfirmationSummary{Status: forestAuditConfirmationRequired, CompletedTrialIDs: completed, TrialsComplete: len(trials)}
+	}
+	if _, ok := trials[forestAuditConfirmationPairB]; !ok {
+		return ForestAuditConfirmationSummary{Status: forestAuditConfirmationReverse, CompletedTrialIDs: completed, TrialsComplete: len(trials)}
+	}
+	pairIDs := []string{forestAuditConfirmationPairA, forestAuditConfirmationPairB}
+	pair, coherent := summarizeForestAuditTrialSet(trials, pairIDs)
+	pair.TrialsComplete = len(trials)
+	pair.CompletedTrialIDs = completed
+	if !coherent {
+		pair.Status = forestAuditConfirmationInconclusive
+		return pair
+	}
+	short := forestAuditTrialSetShort(trials, pairIDs)
+	unstable := forestAuditSpeedupsUnstable(pair.OrderSpeedups)
+	if pair.PooledRoutedSpeedup >= forestAuditConfirmationMinSpeedup && !short && !unstable {
+		pair.Status = forestAuditConfirmationConfirmed
+		return pair
+	}
+	if !short && forestAuditAllSpeedupsNonPositive(pair.OrderSpeedups) && !forestAuditSpeedupSpreadExceedsLimit(pair.OrderSpeedups) {
+		pair.Status = forestAuditConfirmationNeutral
+		return pair
+	}
+	pair.Status = forestAuditConfirmationABBA
+	pair.RequiredRepeatCount = forestAuditRequiredRepeatCount(trials, pairIDs)
+
+	abbaIDs := []string{forestAuditConfirmationABBAA1, forestAuditConfirmationABBAB1, forestAuditConfirmationABBAB2, forestAuditConfirmationABBAA2}
+	for _, id := range abbaIDs {
+		if _, ok := trials[id]; !ok {
+			return pair
+		}
+	}
+	abba, coherent := summarizeForestAuditTrialSet(trials, abbaIDs)
+	abba.TrialsComplete = len(trials)
+	abba.CompletedTrialIDs = completed
+	if !coherent || abba.RunConfigSHA256 != pair.RunConfigSHA256 || forestAuditTrialSetShort(trials, abbaIDs) {
+		abba.Status = forestAuditConfirmationInconclusive
+		return abba
+	}
+	if forestAuditSpeedupSpreadExceedsLimit(abba.OrderSpeedups) {
+		abba.Status = forestAuditConfirmationInconclusive
+	} else if abba.PooledRoutedSpeedup >= forestAuditConfirmationMinSpeedup && forestAuditAllSpeedupsPositive(abba.OrderSpeedups) {
+		abba.Status = forestAuditConfirmationConfirmed
+	} else {
+		abba.Status = forestAuditConfirmationNeutral
+	}
+	return abba
+}
+
+func summarizeForestAuditTrialSet(trials map[string]ForestAuditConfirmationTrial, ids []string) (ForestAuditConfirmationSummary, bool) {
+	summary := ForestAuditConfirmationSummary{TrialsComplete: len(ids)}
+	var peerNanos, routedNanos int64
+	repeatCount := 0
+	var coveredPaths []string
+	for _, id := range ids {
+		trial := trials[id]
+		if summary.RunConfigSHA256 == "" {
+			summary.RunConfigSHA256 = trial.RunConfigSHA256
+		} else if summary.RunConfigSHA256 != trial.RunConfigSHA256 {
+			return summary, false
+		}
+		if repeatCount == 0 {
+			repeatCount = trial.RepeatCount
+		} else if repeatCount != trial.RepeatCount {
+			return summary, false
+		}
+		if trial.Result.Status != "pass" || trial.Result.FilesDiverged != 0 || trial.Result.FilesRoutedDiverged != 0 || trial.Result.PeerNanos <= 0 || trial.Result.RoutedNanos <= 0 {
+			return summary, false
+		}
+		trialPaths, err := forestAuditRoutedCoveragePaths(&trial.Result)
+		if err != nil {
+			return summary, false
+		}
+		if coveredPaths == nil {
+			coveredPaths = trialPaths
+		} else if !forestAuditSamePaths(coveredPaths, trialPaths) {
+			return summary, false
+		}
+		peerNanos += trial.Result.PeerNanos
+		routedNanos += trial.Result.RoutedNanos
+		summary.OrderSpeedups = append(summary.OrderSpeedups, float64(trial.Result.PeerNanos)/float64(trial.Result.RoutedNanos))
+	}
+	if routedNanos == 0 {
+		return summary, false
+	}
+	summary.PooledRoutedSpeedup = float64(peerNanos) / float64(routedNanos)
+	return summary, true
+}
+
+func forestAuditTrialSetShort(trials map[string]ForestAuditConfirmationTrial, ids []string) bool {
+	for _, id := range ids {
+		trial := trials[id]
+		if minInt64(trial.Result.PeerNanos, trial.Result.RoutedNanos) < forestAuditConfirmationMinNanos {
+			return true
+		}
+	}
+	return false
+}
+
+func forestAuditRequiredRepeatCount(trials map[string]ForestAuditConfirmationTrial, ids []string) int {
+	shortest := int64(math.MaxInt64)
+	for _, id := range ids {
+		trial := trials[id]
+		perRepeat := minInt64(trial.Result.PeerNanos, trial.Result.RoutedNanos) / int64(trial.RepeatCount)
+		if perRepeat > 0 && perRepeat < shortest {
+			shortest = perRepeat
+		}
+	}
+	if shortest == int64(math.MaxInt64) || shortest <= 0 {
+		return forestAuditConfirmationMaxRepeats
+	}
+	repeats := int((forestAuditConfirmationMinNanos + shortest - 1) / shortest)
+	if repeats < 1 {
+		return 1
+	}
+	if repeats > forestAuditConfirmationMaxRepeats {
+		return forestAuditConfirmationMaxRepeats
+	}
+	return repeats
+}
+
+func forestAuditSpeedupsUnstable(speedups []float64) bool {
+	if len(speedups) < 2 || !forestAuditAllSpeedupsPositive(speedups) {
+		return true
+	}
+	return forestAuditSpeedupSpreadExceedsLimit(speedups)
+}
+
+func forestAuditSpeedupSpreadExceedsLimit(speedups []float64) bool {
+	if len(speedups) < 2 {
+		return true
+	}
+	low, high := speedups[0], speedups[0]
+	for _, speedup := range speedups[1:] {
+		if speedup < low {
+			low = speedup
+		}
+		if speedup > high {
+			high = speedup
+		}
+	}
+	return low <= 0 || high/low > forestAuditConfirmationMaxSpread
+}
+
+func forestAuditAllSpeedupsPositive(speedups []float64) bool {
+	for _, speedup := range speedups {
+		if speedup <= 1 {
+			return false
+		}
+	}
+	return len(speedups) > 0
+}
+
+func forestAuditAllSpeedupsNonPositive(speedups []float64) bool {
+	for _, speedup := range speedups {
+		if speedup > 1 {
+			return false
+		}
+	}
+	return len(speedups) > 0
+}
+
+func minInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cgo_harness/forest_audit_confirmation_test.go
+++ b/cgo_harness/forest_audit_confirmation_test.go
@@ -1,0 +1,592 @@
+package cgoharness
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestForestAuditRunPlanValidation(t *testing.T) {
+	t.Setenv("GTS_FOREST_AUDIT_EXECUTION_ORDER", ForestAuditOrderRoutedFirst)
+	t.Setenv("GTS_FOREST_AUDIT_REPEAT_COUNT", "7")
+	plan, err := ForestAuditRunPlanFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.ExecutionOrder != ForestAuditOrderRoutedFirst || plan.RepeatCount != 7 {
+		t.Fatalf("plan = %#v", plan)
+	}
+
+	for name, plan := range map[string]ForestAuditRunPlan{
+		"bad order":   {ExecutionOrder: "alternating", RepeatCount: 1},
+		"zero repeat": {ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 0},
+		"too many":    {ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: forestAuditConfirmationMaxRepeats + 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateForestAuditRunPlan(plan); err == nil {
+				t.Fatalf("accepted invalid plan %#v", plan)
+			}
+		})
+	}
+}
+
+func TestForestAuditRunConfigRequiresSingleCPUAndHostFingerprint(t *testing.T) {
+	valid := ForestAuditRunConfig{
+		Schema: ForestAuditRunConfigSchema, HostLabel: "quiet-box", HostFingerprint: strings.Repeat("b", 64),
+		ImageID: "sha256:" + strings.Repeat("a", 64), Memory: "4g", CPUs: "1", CPUSetCPUs: "7",
+		PIDs: "4096", GoMemLimit: "3GiB", GOMAXPROCS: 1, TestTimeout: "10m",
+	}
+	if err := validateForestAuditRunConfig(valid); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*ForestAuditRunConfig){
+		"multiple CPUs":  func(config *ForestAuditRunConfig) { config.CPUs = "4" },
+		"CPU range":      func(config *ForestAuditRunConfig) { config.CPUSetCPUs = "7-8" },
+		"CPU list":       func(config *ForestAuditRunConfig) { config.CPUSetCPUs = "7,8" },
+		"no fingerprint": func(config *ForestAuditRunConfig) { config.HostFingerprint = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			mutate(&candidate)
+			if err := validateForestAuditRunConfig(candidate); err == nil {
+				t.Fatalf("accepted invalid run config %#v", candidate)
+			}
+		})
+	}
+}
+
+func TestForestAuditConfirmationTrialValidatesAuthenticatedIdentity(t *testing.T) {
+	result := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+	plan := ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1}
+	trial, err := NewForestAuditConfirmationTrial(forestAuditConfirmationPairA, strings.Repeat("d", 64), "", plan, result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trial.Schema != ForestAuditConfirmationTrialSchema || trial.Result.Schema != "forest-audit-result-v2" {
+		t.Fatalf("trial = %#v", trial)
+	}
+
+	for name, mutate := range map[string]func(*ForestAuditConfirmationTrial){
+		"order mismatch":         func(trial *ForestAuditConfirmationTrial) { trial.ExecutionOrder = ForestAuditOrderRoutedFirst },
+		"bad sequence":           func(trial *ForestAuditConfirmationTrial) { trial.Sequence = 6 },
+		"bad digest":             func(trial *ForestAuditConfirmationTrial) { trial.RunConfigSHA256 = "unverified" },
+		"unexpected predecessor": func(trial *ForestAuditConfirmationTrial) { trial.PreviousSHA256 = strings.Repeat("f", 64) },
+		"bad repeats":            func(trial *ForestAuditConfirmationTrial) { trial.RepeatCount = 0 },
+		"wrong mode":             func(trial *ForestAuditConfirmationTrial) { trial.Result.Mode = "c_oracle" },
+		"failed result":          func(trial *ForestAuditConfirmationTrial) { trial.Result.Status = "fail" },
+		"zero timing":            func(trial *ForestAuditConfirmationTrial) { trial.Result.RoutedNanos = 0 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := trial
+			mutate(&candidate)
+			if err := validateForestAuditConfirmationTrial(candidate); err == nil {
+				t.Fatalf("accepted invalid trial %#v", candidate)
+			}
+		})
+	}
+}
+
+func TestForestAuditConfirmationRejectsZeroRoutedCoverage(t *testing.T) {
+	result := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+	result.Files[0].Routed = result.Files[0].Peer
+	result.Files[0].RoutedProvenance = forestAuditRouteProductionFallback
+	result.FilesRoutedForest = 0
+	result.FilesRoutedFallback = 1
+	if _, err := NewForestAuditConfirmationTrial(
+		forestAuditConfirmationPairA,
+		strings.Repeat("d", 64),
+		"",
+		ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1},
+		result,
+	); err == nil || !strings.Contains(err.Error(), "zero routed forest coverage") {
+		t.Fatalf("zero confirmation coverage error = %v", err)
+	}
+	blockers := forestPromotionBlockers(&result, &ForestAuditResult{Status: "pass"})
+	if !reflect.DeepEqual(blockers, []string{"no_routed_forest_coverage"}) {
+		t.Fatalf("zero screen coverage blockers = %v", blockers)
+	}
+}
+
+func TestValidateForestAuditConfirmationEvidenceRejectsCoveredPathDrift(t *testing.T) {
+	digest := strings.Repeat("d", 64)
+	screen := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+	screen.Files = append(screen.Files, screen.Files[0])
+	screen.Files[1].Path = "b.go"
+	screen.Files[1].SHA256 = strings.Repeat("e", 64)
+	screen.Files[1].Routed = screen.Files[1].Peer
+	screen.Files[1].RoutedProvenance = forestAuditRouteProductionFallback
+	screen.FilesRoutedFallback = 1
+	screen.FilesTotal, screen.FilesAccepted = 2, 2
+	screen.PeerNanos, screen.RoutedNanos, screen.RoutedImproved = 2_400_000_000, 2_000_000_000, true
+
+	trialResult := screen
+	trialResult.Files = append([]ForestAuditFileResult(nil), screen.Files...)
+	trialResult.Files[0].Routed = trialResult.Files[0].Peer
+	trialResult.Files[0].RoutedProvenance = forestAuditRouteProductionFallback
+	trialResult.Files[1].Routed = forestAuditTestAcceptedOutcome(1, true)
+	trialResult.Files[1].RoutedProvenance = forestAuditRouteForestFastPath
+	trial, err := NewForestAuditConfirmationTrial(
+		forestAuditConfirmationPairA,
+		digest,
+		"",
+		ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1},
+		trialResult,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cOracle := screen
+	cOracle.Mode = "c_oracle"
+	cOracle.Files = append([]ForestAuditFileResult(nil), screen.Files...)
+	for i := range cOracle.Files {
+		cOracle.Files[i].Peer = forestAuditTestAcceptedOutcome(uint32(cOracle.Files[i].Bytes), false)
+	}
+	reduction := &forestAuditReduction{
+		results: map[string]map[string]*ForestAuditResult{
+			"go": {"production": &screen, "c_oracle": &cOracle},
+		},
+		confirmations: map[string]map[string]ForestAuditConfirmationTrial{
+			"go": {forestAuditConfirmationPairA: trial},
+		},
+		runConfigs: map[string]ForestAuditRunConfig{digest: {Schema: ForestAuditRunConfigSchema}},
+	}
+	if err := reduction.validateConfirmationEvidence(); err == nil || !strings.Contains(err.Error(), "differ from screen") {
+		t.Fatalf("covered path drift error = %v", err)
+	}
+}
+
+func TestValidateForestAuditConfirmationEvidenceRequiresPathCompleteCOracle(t *testing.T) {
+	digest := strings.Repeat("d", 64)
+	screen := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+	trial, err := NewForestAuditConfirmationTrial(
+		forestAuditConfirmationPairA, digest, "",
+		ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1}, screen,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cOracle := screen
+	cOracle.Mode = "c_oracle"
+	cOracle.Files = append([]ForestAuditFileResult(nil), screen.Files...)
+	cOracle.Files[0].Disposition = "declined"
+	cOracle.Files[0].Decline = "not_covered"
+	cOracle.Files[0].Peer = forestAuditTestNotRunOutcome(1)
+	reduction := &forestAuditReduction{
+		results:       map[string]map[string]*ForestAuditResult{"go": {"production": &screen, "c_oracle": &cOracle}},
+		confirmations: map[string]map[string]ForestAuditConfirmationTrial{"go": {forestAuditConfirmationPairA: trial}},
+		runConfigs:    map[string]ForestAuditRunConfig{digest: {Schema: ForestAuditRunConfigSchema}},
+	}
+	if err := reduction.validateConfirmationEvidence(); err == nil || !strings.Contains(err.Error(), "lacks accepted locked-C coverage") {
+		t.Fatalf("path-incomplete C oracle error = %v", err)
+	}
+}
+
+func TestReadForestAuditArtifactRejectsSymlinksAndOversizeFiles(t *testing.T) {
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "artifact.json")
+	if err := os.WriteFile(regular, []byte(`{"schema":"forest-audit-confirmation-plan-v1"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(dir, "symlink.json")
+	if err := os.Symlink(regular, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readForestAuditArtifact(symlink); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("symlink artifact error = %v", err)
+	}
+	oversize := filepath.Join(dir, "oversize.json")
+	file, err := os.Create(oversize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(forestAuditMaxArtifactBytes + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readForestAuditArtifact(oversize); err == nil || !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("oversize artifact error = %v", err)
+	}
+}
+
+func TestCopyForestAuditArtifactExclusiveNeverReplacesOrExposesPartialTarget(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("{\"schema\":\"forest-audit-confirmation-plan-v1\"}\n")
+	target := filepath.Join(dir, "receipt.json")
+	if err := copyForestAuditArtifactExclusive(target, data); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyForestAuditArtifactExclusive(target, data); err != nil {
+		t.Fatalf("identical retry: %v", err)
+	}
+	partial := filepath.Join(dir, "partial.json")
+	if err := os.WriteFile(partial, []byte("partial"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyForestAuditArtifactExclusive(partial, data); err == nil || !strings.Contains(err.Error(), "quarantine") {
+		t.Fatalf("partial target error = %v", err)
+	}
+	got, err := os.ReadFile(partial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "partial" {
+		t.Fatalf("partial target was replaced: %q", got)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".forest-audit-publish-*.tmp"))
+	if err != nil || len(leftovers) != 0 {
+		t.Fatalf("publisher temp leftovers = %v, err=%v", leftovers, err)
+	}
+}
+
+func TestPublishForestAuditConfirmationIndexRejectsMismatchedCohortBeforeInstall(t *testing.T) {
+	revision := strings.Repeat("a", 40)
+	manifestSHA := strings.Repeat("b", 64)
+	lockSHA := strings.Repeat("c", 64)
+	base := ForestAuditConfirmationCohort{
+		Schema: ForestAuditConfirmationCohortSchema, GotreesitterRevision: revision,
+		CorpusManifestSHA256: manifestSHA, CorpusLockSHA256: lockSHA, Language: "go",
+		RunConfigSHA256: strings.Repeat("d", 64), HeadTrialSHA256: strings.Repeat("e", 64),
+		Trials: []ForestAuditConfirmationTrialRef{{TrialID: forestAuditConfirmationPairA, SHA256: strings.Repeat("e", 64)}},
+	}
+	for name, mutate := range map[string]func(*ForestAuditConfirmationCohort){
+		"language": func(cohort *ForestAuditConfirmationCohort) { cohort.Language = "python" },
+		"revision": func(cohort *ForestAuditConfirmationCohort) { cohort.GotreesitterRevision = strings.Repeat("f", 40) },
+		"manifest": func(cohort *ForestAuditConfirmationCohort) { cohort.CorpusManifestSHA256 = strings.Repeat("f", 64) },
+		"lock":     func(cohort *ForestAuditConfirmationCohort) { cohort.CorpusLockSHA256 = strings.Repeat("f", 64) },
+		"shape": func(cohort *ForestAuditConfirmationCohort) {
+			cohort.Trials[0].TrialID = forestAuditConfirmationPairB
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resultsRoot := t.TempDir()
+			cohort := base
+			cohort.Trials = append([]ForestAuditConfirmationTrialRef(nil), base.Trials...)
+			mutate(&cohort)
+			data, digest, err := marshalForestAuditContent(cohort)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cohortPath := filepath.Join(resultsRoot, "confirmation", "cohorts", digest+".json")
+			if err := copyForestAuditArtifactExclusive(cohortPath, data); err != nil {
+				t.Fatal(err)
+			}
+			index := ForestAuditConfirmationIndex{
+				Schema: ForestAuditConfirmationIndexSchema, GotreesitterRevision: revision,
+				CorpusManifestSHA256: manifestSHA, CorpusLockSHA256: lockSHA,
+				Cohorts: []ForestAuditConfirmationIndexEntry{{Language: "go", CohortSHA256: digest}},
+			}
+			if _, _, err := PublishForestAuditConfirmationIndex(resultsRoot, index); err == nil {
+				t.Fatalf("published index with mismatched cohort %#v", cohort)
+			}
+			installed, err := filepath.Glob(filepath.Join(resultsRoot, "confirmation", "indexes", "*.json"))
+			if err != nil || len(installed) != 0 {
+				t.Fatalf("installed mismatched index artifacts = %v, err=%v", installed, err)
+			}
+		})
+	}
+}
+
+func TestStoreForestAuditConfirmationValidatesPredecessorChainBeforePublication(t *testing.T) {
+	for name, setupPredecessor := range map[string]func(*testing.T, string, string) string{
+		"missing": func(_ *testing.T, _, _ string) string {
+			return strings.Repeat("9", 64)
+		},
+		"corrupt": func(t *testing.T, resultsRoot, _ string) string {
+			t.Helper()
+			digest := strings.Repeat("9", 64)
+			path := filepath.Join(resultsRoot, "confirmation", "trials", digest+".json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("not json\n"), 0o444); err != nil {
+				t.Fatal(err)
+			}
+			return digest
+		},
+		"identity mismatch": func(t *testing.T, resultsRoot, runConfigSHA string) string {
+			t.Helper()
+			result := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+			result.Language = "python"
+			predecessor, err := NewForestAuditConfirmationTrial(
+				forestAuditConfirmationPairA,
+				runConfigSHA,
+				"",
+				ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderProductionFirst, RepeatCount: 1},
+				result,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, digest, err := marshalForestAuditContent(predecessor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(resultsRoot, "confirmation", "trials", digest+".json")
+			if err := copyForestAuditArtifactExclusive(path, data); err != nil {
+				t.Fatal(err)
+			}
+			return digest
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resultsRoot := t.TempDir()
+			runConfigSHA, runConfigPath, _ := writeForestAuditTestRunConfig(t)
+			previousSHA := setupPredecessor(t, resultsRoot, runConfigSHA)
+			before := snapshotForestAuditConfirmationArtifacts(t, resultsRoot)
+
+			trial, err := NewForestAuditConfirmationTrial(
+				forestAuditConfirmationPairB,
+				runConfigSHA,
+				previousSHA,
+				ForestAuditRunPlan{ExecutionOrder: ForestAuditOrderRoutedFirst, RepeatCount: 1},
+				forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			trialPath := filepath.Join(t.TempDir(), "pair-b.json")
+			if err := WriteForestAuditConfirmationTrial(trialPath, trial); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := StoreForestAuditConfirmation(resultsRoot, runConfigPath, trialPath); err == nil {
+				t.Fatalf("stored pair-b with %s predecessor", name)
+			}
+			after := snapshotForestAuditConfirmationArtifacts(t, resultsRoot)
+			if !reflect.DeepEqual(after, before) {
+				t.Fatalf("immutable artifacts changed after %s predecessor: before=%v after=%v", name, before, after)
+			}
+		})
+	}
+}
+
+func snapshotForestAuditConfirmationArtifacts(t *testing.T, resultsRoot string) map[string]string {
+	t.Helper()
+	snapshot := make(map[string]string)
+	root := filepath.Join(resultsRoot, "confirmation")
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return snapshot
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type().IsRegular() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			relative, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			snapshot[relative] = string(data)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func TestSummarizeForestAuditConfirmationsRequiresOrderBalancedEvidence(t *testing.T) {
+	digest := strings.Repeat("e", 64)
+	pairA := forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairA, digest, 1, 1_200_000_000, 1_000_000_000)
+	pairB := forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, digest, 1, 1_180_000_000, 1_000_000_000)
+
+	tests := []struct {
+		name       string
+		trials     map[string]ForestAuditConfirmationTrial
+		wantStatus string
+		wantRepeat int
+	}{
+		{name: "no trials", trials: nil, wantStatus: forestAuditConfirmationRequired},
+		{name: "forward only", trials: map[string]ForestAuditConfirmationTrial{forestAuditConfirmationPairA: pairA}, wantStatus: forestAuditConfirmationReverse},
+		{name: "balanced stable win", trials: map[string]ForestAuditConfirmationTrial{
+			forestAuditConfirmationPairA: pairA, forestAuditConfirmationPairB: pairB,
+		}, wantStatus: forestAuditConfirmationConfirmed},
+		{name: "short win escalates", trials: map[string]ForestAuditConfirmationTrial{
+			forestAuditConfirmationPairA: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairA, digest, 1, 200_000_000, 100_000_000),
+			forestAuditConfirmationPairB: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, digest, 1, 190_000_000, 100_000_000),
+		}, wantStatus: forestAuditConfirmationABBA, wantRepeat: 8},
+		{name: "marginal win escalates", trials: map[string]ForestAuditConfirmationTrial{
+			forestAuditConfirmationPairA: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairA, digest, 1, 1_030_000_000, 1_000_000_000),
+			forestAuditConfirmationPairB: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, digest, 1, 1_020_000_000, 1_000_000_000),
+		}, wantStatus: forestAuditConfirmationABBA, wantRepeat: 1},
+		{name: "order sign change escalates", trials: map[string]ForestAuditConfirmationTrial{
+			forestAuditConfirmationPairA: pairA,
+			forestAuditConfirmationPairB: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, digest, 1, 900_000_000, 1_000_000_000),
+		}, wantStatus: forestAuditConfirmationABBA, wantRepeat: 1},
+		{name: "stable clear loss stops", trials: map[string]ForestAuditConfirmationTrial{
+			forestAuditConfirmationPairA: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairA, digest, 1, 900_000_000, 1_000_000_000),
+			forestAuditConfirmationPairB: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, digest, 1, 950_000_000, 1_000_000_000),
+		}, wantStatus: forestAuditConfirmationNeutral},
+		{name: "config mismatch is inconclusive", trials: map[string]ForestAuditConfirmationTrial{
+			forestAuditConfirmationPairA: pairA,
+			forestAuditConfirmationPairB: forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, strings.Repeat("f", 64), 1, 1_180_000_000, 1_000_000_000),
+		}, wantStatus: forestAuditConfirmationInconclusive},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := summarizeForestAuditConfirmations(tc.trials)
+			if summary.Status != tc.wantStatus || summary.RequiredRepeatCount != tc.wantRepeat {
+				t.Fatalf("summary = %#v", summary)
+			}
+			if len(tc.trials) > 0 && len(summary.CompletedTrialIDs) != len(tc.trials) {
+				t.Fatalf("completed ids = %v, trials = %d", summary.CompletedTrialIDs, len(tc.trials))
+			}
+		})
+	}
+}
+
+func TestSummarizeForestAuditConfirmationsAcceptsCompleteABBA(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	trials := map[string]ForestAuditConfirmationTrial{
+		forestAuditConfirmationPairA:  forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairA, digest, 1, 1_030_000_000, 1_000_000_000),
+		forestAuditConfirmationPairB:  forestAuditConfirmationTestTrial(t, forestAuditConfirmationPairB, digest, 1, 1_020_000_000, 1_000_000_000),
+		forestAuditConfirmationABBAA1: forestAuditConfirmationTestTrial(t, forestAuditConfirmationABBAA1, digest, 2, 2_400_000_000, 2_000_000_000),
+		forestAuditConfirmationABBAB1: forestAuditConfirmationTestTrial(t, forestAuditConfirmationABBAB1, digest, 2, 2_300_000_000, 2_000_000_000),
+		forestAuditConfirmationABBAB2: forestAuditConfirmationTestTrial(t, forestAuditConfirmationABBAB2, digest, 2, 2_200_000_000, 2_000_000_000),
+		forestAuditConfirmationABBAA2: forestAuditConfirmationTestTrial(t, forestAuditConfirmationABBAA2, digest, 2, 2_300_000_000, 2_000_000_000),
+	}
+	summary := summarizeForestAuditConfirmations(trials)
+	if summary.Status != forestAuditConfirmationConfirmed || summary.TrialsComplete != len(trials) || len(summary.OrderSpeedups) != 4 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	mismatched := make(map[string]ForestAuditConfirmationTrial, len(trials))
+	for id, trial := range trials {
+		mismatched[id] = trial
+	}
+	trial := mismatched[forestAuditConfirmationABBAA2]
+	trial.RunConfigSHA256 = strings.Repeat("b", 64)
+	mismatched[forestAuditConfirmationABBAA2] = trial
+	if summary := summarizeForestAuditConfirmations(mismatched); summary.Status != forestAuditConfirmationInconclusive {
+		t.Fatalf("mismatched ABBA summary = %#v", summary)
+	}
+	highSpread := make(map[string]ForestAuditConfirmationTrial, len(trials))
+	for id, trial := range trials {
+		highSpread[id] = trial
+	}
+	trial = highSpread[forestAuditConfirmationABBAA1]
+	trial.Result.PeerNanos = 3_000_000_000
+	highSpread[forestAuditConfirmationABBAA1] = trial
+	trial = highSpread[forestAuditConfirmationABBAB1]
+	trial.Result.PeerNanos = 2_020_000_000
+	highSpread[forestAuditConfirmationABBAB1] = trial
+	if summary := summarizeForestAuditConfirmations(highSpread); summary.Status != forestAuditConfirmationInconclusive {
+		t.Fatalf("high-spread ABBA summary = %#v", summary)
+	}
+}
+
+func TestBuildForestAuditConfirmationPlanIsWinOnlyAndKeepsABBAOrder(t *testing.T) {
+	report := ForestAuditReport{
+		Schema: ForestAuditReportSchema, GotreesitterRevision: strings.Repeat("a", 40),
+		CorpusManifestSHA256: strings.Repeat("b", 64), CorpusLockSHA256: strings.Repeat("c", 64),
+		Languages: []ForestAuditLanguageReport{
+			{Language: "skip-correction", ScreeningEligible: true, CorrectnessRelation: forestAuditRelationOracleCorrectionReview, ConfirmationStatus: forestAuditConfirmationRequired},
+			{Language: "skip-inconclusive", ScreeningEligible: true, CorrectnessRelation: forestAuditRelationProductionIdentity, ConfirmationStatus: forestAuditConfirmationInconclusive},
+			{Language: "skip-loss", CorrectnessRelation: forestAuditRelationProductionIdentity},
+			{Language: "abba", ScreeningEligible: true, CorrectnessRelation: forestAuditRelationProductionIdentity, ConfirmationStatus: forestAuditConfirmationABBA,
+				Confirmation: &ForestAuditConfirmationSummary{RequiredRepeatCount: 6, CompletedTrialIDs: []string{forestAuditConfirmationABBAA1}}},
+			{Language: "fresh", ScreeningEligible: true, CorrectnessRelation: forestAuditRelationProductionIdentity, ConfirmationStatus: forestAuditConfirmationRequired},
+		},
+	}
+	plan := BuildForestAuditConfirmationPlan(report)
+	if err := validateForestAuditConfirmationPlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(plan.Trials))
+	for _, trial := range plan.Trials {
+		got = append(got, trial.Language+":"+trial.TrialID+":"+trial.ExecutionOrder)
+		if trial.Language == "abba" && trial.RepeatCount != 6 {
+			t.Fatalf("ABBA repeat count = %d", trial.RepeatCount)
+		}
+	}
+	want := []string{
+		"abba:abba-b1:routed_first",
+		"abba:abba-b2:routed_first",
+		"abba:abba-a2:production_first",
+		"fresh:pair-a:production_first",
+		"fresh:pair-b:routed_first",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("plan order = %v, want %v", got, want)
+	}
+	invalid := plan
+	invalid.Trials = append([]ForestAuditPlannedTrial(nil), plan.Trials...)
+	invalid.Trials[0].ExecutionOrder = ForestAuditOrderProductionFirst
+	if err := validateForestAuditConfirmationPlan(invalid); err == nil {
+		t.Fatal("accepted plan with mismatched trial order")
+	}
+}
+
+func TestForestAuditCorrectnessRelationLeavesOracleCorrectionForReview(t *testing.T) {
+	production := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+	production.Status = "fail"
+	production.FilesDiverged = 1
+	production.FilesRoutedDiverged = 1
+	production.Files[0].Disposition = "diverged"
+	production.Files[0].Diff = "forest matches C, not production"
+	production.Files[0].RoutedDiff = "routed matches C, not production"
+
+	cOracle := ForestAuditResult{
+		Schema: ForestAuditResultSchema, Mode: "c_oracle", GotreesitterRevision: strings.Repeat("a", 40),
+		CorpusManifestSHA256: strings.Repeat("b", 64), CorpusLockSHA256: strings.Repeat("c", 64),
+		Language: "go", Status: "pass", FilesTotal: 1, FilesAccepted: 1,
+		Files: []ForestAuditFileResult{{
+			Path: "a.go", Bytes: 1, SHA256: strings.Repeat("d", 64), Disposition: "accepted",
+			Forest: forestAuditTestAcceptedOutcome(1, true), Peer: forestAuditTestAcceptedOutcome(1, false),
+			Routed: forestAuditTestNotRunOutcome(1), RoutedProvenance: forestAuditRouteNotRun,
+		}},
+	}
+	relation, evidence := forestAuditCorrectnessRelation(&production, &cOracle)
+	if relation != forestAuditRelationOracleCorrectionReview || evidence == nil || evidence.EvidenceComplete ||
+		!reflect.DeepEqual(evidence.Paths, []string{"a.go"}) {
+		t.Fatalf("relation=%q evidence=%#v", relation, evidence)
+	}
+
+	production.Files[0].RoutedProvenance = forestAuditRouteProductionFallback
+	relation, evidence = forestAuditCorrectnessRelation(&production, &cOracle)
+	if relation != forestAuditRelationUnresolvedDivergence || evidence == nil || evidence.EvidenceComplete {
+		t.Fatalf("fallback relation=%q evidence=%#v", relation, evidence)
+	}
+}
+
+func forestAuditConfirmationTestTrial(t *testing.T, id, digest string, repeats int, peerNanos, routedNanos int64) ForestAuditConfirmationTrial {
+	t.Helper()
+	order := ForestAuditOrderProductionFirst
+	previousSHA := strings.Repeat("9", 64)
+	if id == forestAuditConfirmationPairB || id == forestAuditConfirmationABBAB1 || id == forestAuditConfirmationABBAB2 {
+		order = ForestAuditOrderRoutedFirst
+	}
+	if id == forestAuditConfirmationPairA {
+		previousSHA = ""
+	}
+	trial, err := NewForestAuditConfirmationTrial(id, digest, previousSHA, ForestAuditRunPlan{ExecutionOrder: order, RepeatCount: repeats}, forestAuditConfirmationTestResult(peerNanos, routedNanos))
+	if err != nil {
+		t.Fatalf("build trial %s: %v", id, err)
+	}
+	return trial
+}
+
+func forestAuditConfirmationTestResult(peerNanos, routedNanos int64) ForestAuditResult {
+	result := ForestAuditResult{
+		Schema: ForestAuditResultSchema, Mode: "production", GotreesitterRevision: strings.Repeat("a", 40),
+		CorpusManifestSHA256: strings.Repeat("b", 64), CorpusLockSHA256: strings.Repeat("c", 64),
+		Language: "go", Status: "pass", FilesTotal: 1, FilesAccepted: 1, FilesRoutedForest: 1,
+		PeerNanos: peerNanos, RoutedNanos: routedNanos, RoutedImproved: routedNanos < peerNanos,
+	}
+	result.Files = []ForestAuditFileResult{{
+		Path: "a.go", Bytes: 1, SHA256: strings.Repeat("d", 64), Disposition: "accepted",
+		Forest: forestAuditTestAcceptedOutcome(1, true), Peer: forestAuditTestAcceptedOutcome(1, false),
+		Routed: forestAuditTestAcceptedOutcome(1, true), RoutedProvenance: forestAuditRouteForestFastPath, RoutedNanos: routedNanos,
+	}}
+	return result
+}

--- a/cgo_harness/forest_audit_results.go
+++ b/cgo_harness/forest_audit_results.go
@@ -1,8 +1,10 @@
 package cgoharness
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"math"
 	"os"
@@ -10,6 +12,74 @@ import (
 	"sort"
 	"strings"
 )
+
+const (
+	forestAuditMaxArtifactBytes = int64(64 << 20)
+	forestAuditMaxArtifacts     = 4096
+)
+
+type forestAuditArtifact struct {
+	path   string
+	data   []byte
+	schema string
+	digest string
+}
+
+func readForestAuditArtifact(filePath string) (forestAuditArtifact, error) {
+	artifact := forestAuditArtifact{path: filePath}
+	pathInfo, err := os.Lstat(filePath)
+	if err != nil {
+		return artifact, err
+	}
+	if !pathInfo.Mode().IsRegular() {
+		return artifact, fmt.Errorf("forest audit artifact %s is not a regular file", filePath)
+	}
+	if pathInfo.Size() < 1 || pathInfo.Size() > forestAuditMaxArtifactBytes {
+		return artifact, fmt.Errorf("forest audit artifact %s size %d outside 1..%d", filePath, pathInfo.Size(), forestAuditMaxArtifactBytes)
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return artifact, err
+	}
+	defer file.Close()
+	openInfo, err := file.Stat()
+	if err != nil {
+		return artifact, err
+	}
+	if !openInfo.Mode().IsRegular() || !os.SameFile(pathInfo, openInfo) || openInfo.Size() != pathInfo.Size() ||
+		!openInfo.ModTime().Equal(pathInfo.ModTime()) {
+		return artifact, fmt.Errorf("forest audit artifact %s changed while opening", filePath)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, forestAuditMaxArtifactBytes+1))
+	if err != nil {
+		return artifact, err
+	}
+	if int64(len(data)) != openInfo.Size() {
+		return artifact, fmt.Errorf("forest audit artifact %s changed while reading", filePath)
+	}
+	afterInfo, err := os.Lstat(filePath)
+	if err != nil || !afterInfo.Mode().IsRegular() || !os.SameFile(openInfo, afterInfo) ||
+		afterInfo.Size() != openInfo.Size() || !afterInfo.ModTime().Equal(openInfo.ModTime()) {
+		return artifact, fmt.Errorf("forest audit artifact %s changed after reading", filePath)
+	}
+	var header struct {
+		Schema string `json:"schema"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return artifact, fmt.Errorf("decode forest audit schema for %s: %w", filePath, err)
+	}
+	if strings.TrimSpace(header.Schema) == "" {
+		return artifact, fmt.Errorf("forest audit artifact %s has no schema", filePath)
+	}
+	artifact.data = data
+	artifact.schema = header.Schema
+	artifact.digest = fmt.Sprintf("%x", sha256.Sum256(data))
+	return artifact, nil
+}
+
+func (artifact forestAuditArtifact) decode(value any) error {
+	return decodeForestAuditJSON(artifact.data, value)
+}
 
 const (
 	forestAuditRouteNotRun             = "not_run"
@@ -71,26 +141,34 @@ type ForestAuditResult struct {
 }
 
 type ForestAuditLanguageReport struct {
-	Language          string             `json:"language"`
-	Status            string             `json:"status"`
-	Classification    string             `json:"classification,omitempty"`
-	PromotionEligible bool               `json:"promotion_eligible"`
-	RoutedSpeedup     float64            `json:"routed_speedup,omitempty"`
-	PromotionBlockers []string           `json:"promotion_blockers,omitempty"`
-	Production        *ForestAuditResult `json:"production,omitempty"`
-	COracle           *ForestAuditResult `json:"c_oracle,omitempty"`
+	Language                 string                          `json:"language"`
+	Status                   string                          `json:"status"`
+	Classification           string                          `json:"classification,omitempty"`
+	CorrectnessRelation      string                          `json:"correctness_relation,omitempty"`
+	ScreeningEligible        bool                            `json:"screening_eligible"`
+	PromotionEligible        bool                            `json:"promotion_eligible"`
+	RoutedSpeedup            float64                         `json:"routed_speedup,omitempty"`
+	ScreenRoutedSpeedup      float64                         `json:"screen_routed_speedup,omitempty"`
+	ConfirmationStatus       string                          `json:"confirmation_status,omitempty"`
+	Confirmation             *ForestAuditConfirmationSummary `json:"confirmation,omitempty"`
+	ConfirmationCohortSHA256 string                          `json:"confirmation_cohort_sha256,omitempty"`
+	ThreeWay                 *ForestAuditThreeWayRelation    `json:"three_way,omitempty"`
+	PromotionBlockers        []string                        `json:"promotion_blockers,omitempty"`
+	Production               *ForestAuditResult              `json:"production,omitempty"`
+	COracle                  *ForestAuditResult              `json:"c_oracle,omitempty"`
 }
 
 type ForestAuditReport struct {
-	Schema               string                      `json:"schema"`
-	GotreesitterRevision string                      `json:"gotreesitter_revision"`
-	CorpusManifestSHA256 string                      `json:"corpus_manifest_sha256"`
-	CorpusLockSHA256     string                      `json:"corpus_lock_sha256"`
-	Status               string                      `json:"status"`
-	LanguagesExpected    int                         `json:"languages_expected"`
-	LanguagesComplete    int                         `json:"languages_complete"`
-	LanguagesNoCoverage  int                         `json:"languages_no_forest_coverage"`
-	Languages            []ForestAuditLanguageReport `json:"languages"`
+	Schema                  string                      `json:"schema"`
+	GotreesitterRevision    string                      `json:"gotreesitter_revision"`
+	CorpusManifestSHA256    string                      `json:"corpus_manifest_sha256"`
+	CorpusLockSHA256        string                      `json:"corpus_lock_sha256"`
+	ConfirmationIndexSHA256 string                      `json:"confirmation_index_sha256,omitempty"`
+	Status                  string                      `json:"status"`
+	LanguagesExpected       int                         `json:"languages_expected"`
+	LanguagesComplete       int                         `json:"languages_complete"`
+	LanguagesNoCoverage     int                         `json:"languages_no_forest_coverage"`
+	Languages               []ForestAuditLanguageReport `json:"languages"`
 }
 
 func NewForestAuditResult(mode, revision, manifestPath, lockSHA, language string) (ForestAuditResult, error) {
@@ -116,7 +194,33 @@ func WriteForestAuditResult(path string, result ForestAuditResult) error {
 	return writeForestAuditJSON(path, result)
 }
 
+func PublishForestAuditResult(resultsRoot, stagedPath string) (string, error) {
+	artifact, err := readForestAuditArtifact(stagedPath)
+	if err != nil {
+		return "", err
+	}
+	if artifact.schema != ForestAuditResultSchema {
+		return "", fmt.Errorf("forest audit result schema %q", artifact.schema)
+	}
+	var result ForestAuditResult
+	if err := artifact.decode(&result); err != nil {
+		return "", err
+	}
+	if err := validateForestAuditResult(result); err != nil {
+		return "", err
+	}
+	target := filepath.Join(resultsRoot, result.Mode, result.Language+".json")
+	if err := copyForestAuditArtifactExclusive(target, artifact.data); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
 func ReduceForestAuditResults(manifestPath, resultsRoot string) (ForestAuditReport, error) {
+	return ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, "")
+}
+
+func ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, confirmationIndexPath string) (ForestAuditReport, error) {
 	reduction, err := newForestAuditReduction(manifestPath)
 	if err != nil {
 		return ForestAuditReport{}, err
@@ -124,31 +228,52 @@ func ReduceForestAuditResults(manifestPath, resultsRoot string) (ForestAuditRepo
 	if err := reduction.loadResults(resultsRoot); err != nil {
 		return ForestAuditReport{}, err
 	}
+	if confirmationIndexPath != "" {
+		if err := reduction.loadConfirmationIndex(resultsRoot, confirmationIndexPath); err != nil {
+			return ForestAuditReport{}, err
+		}
+	}
+	if err := reduction.validateConfirmationEvidence(); err != nil {
+		return ForestAuditReport{}, err
+	}
 	return reduction.report(), nil
 }
 
 type forestAuditReduction struct {
-	manifestDigest string
-	manifest       ForestCorpusManifest
-	languages      []string
-	manifestFiles  map[string]map[string]ForestCorpusManifestFile
-	results        map[string]map[string]*ForestAuditResult
+	manifestDigest          string
+	manifest                ForestCorpusManifest
+	languages               []string
+	manifestFiles           map[string]map[string]ForestCorpusManifestFile
+	results                 map[string]map[string]*ForestAuditResult
+	confirmations           map[string]map[string]ForestAuditConfirmationTrial
+	runConfigs              map[string]ForestAuditRunConfig
+	confirmationCohorts     map[string]string
+	confirmationIndexDigest string
 }
 
 func newForestAuditReduction(manifestPath string) (*forestAuditReduction, error) {
-	manifest, err := decodeForestCorpusManifest(manifestPath)
+	artifact, err := readForestAuditArtifact(manifestPath)
 	if err != nil {
 		return nil, err
 	}
-	digest, err := forestFileSHA256(manifestPath)
-	if err != nil {
+	if artifact.schema != ForestCorpusManifestSchema {
+		return nil, fmt.Errorf("forest corpus manifest schema %q, want %q", artifact.schema, ForestCorpusManifestSchema)
+	}
+	var manifest ForestCorpusManifest
+	if err := artifact.decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode forest corpus manifest: %w", err)
+	}
+	if err := validateForestCorpusManifestMetadata(manifest); err != nil {
 		return nil, err
 	}
 	reduction := &forestAuditReduction{
-		manifestDigest: digest,
-		manifest:       manifest,
-		manifestFiles:  make(map[string]map[string]ForestCorpusManifestFile),
-		results:        make(map[string]map[string]*ForestAuditResult),
+		manifestDigest:      artifact.digest,
+		manifest:            manifest,
+		manifestFiles:       make(map[string]map[string]ForestCorpusManifestFile),
+		results:             make(map[string]map[string]*ForestAuditResult),
+		confirmations:       make(map[string]map[string]ForestAuditConfirmationTrial),
+		runConfigs:          make(map[string]ForestAuditRunConfig),
+		confirmationCohorts: make(map[string]string),
 	}
 	for _, file := range manifest.Files {
 		if reduction.manifestFiles[file.Language] == nil {
@@ -162,48 +287,61 @@ func newForestAuditReduction(manifestPath string) (*forestAuditReduction, error)
 }
 
 func (reduction *forestAuditReduction) loadResults(resultsRoot string) error {
+	artifactCount := 0
 	return filepath.WalkDir(resultsRoot, func(filePath string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+		if entry.IsDir() {
+			rel, err := filepath.Rel(resultsRoot, filePath)
+			if err != nil {
+				return err
+			}
+			if filepath.ToSlash(rel) == "confirmation" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		isReport, err := forestAuditFileIsReport(filePath)
+		if !strings.HasSuffix(entry.Name(), ".json") {
+			return nil
+		}
+		artifactCount++
+		if artifactCount > forestAuditMaxArtifacts {
+			return fmt.Errorf("forest audit bundle exceeds %d JSON artifacts", forestAuditMaxArtifacts)
+		}
+		artifact, err := readForestAuditArtifact(filePath)
 		if err != nil {
 			return err
 		}
-		if isReport {
+		switch artifact.schema {
+		case ForestAuditReportSchema, "forest-audit-report-v3", "forest-audit-report-v2":
 			return nil
+		case ForestAuditResultSchema:
+			return reduction.admitResult(artifact, resultsRoot)
+		default:
+			return fmt.Errorf("unsupported forest audit schema %q in %s", artifact.schema, filePath)
 		}
-		return reduction.admitResult(filePath)
 	})
 }
 
-func forestAuditFileIsReport(filePath string) (bool, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return false, err
-	}
-	var header struct {
-		Schema string `json:"schema"`
-	}
-	if err := json.Unmarshal(data, &header); err != nil {
-		return false, nil
-	}
-	return header.Schema == ForestAuditReportSchema || header.Schema == "forest-audit-report-v2", nil
-}
-
-func (reduction *forestAuditReduction) admitResult(filePath string) error {
+func (reduction *forestAuditReduction) admitResult(artifact forestAuditArtifact, resultsRoot string) error {
 	var result ForestAuditResult
-	if err := readForestAuditJSON(filePath, &result); err != nil {
-		return fmt.Errorf("read result %s: %w", filePath, err)
+	if err := artifact.decode(&result); err != nil {
+		return fmt.Errorf("read result %s: %w", artifact.path, err)
 	}
 	if err := validateForestAuditResult(result); err != nil {
-		return fmt.Errorf("validate result %s: %w", filePath, err)
+		return fmt.Errorf("validate result %s: %w", artifact.path, err)
 	}
 	if err := reduction.validateResultIdentity(result); err != nil {
-		return fmt.Errorf("result %s: %w", filePath, err)
+		return fmt.Errorf("result %s: %w", artifact.path, err)
+	}
+	rel, err := filepath.Rel(resultsRoot, artifact.path)
+	if err != nil {
+		return err
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 2 || parts[0] != result.Mode || parts[1] != result.Language+".json" {
+		return fmt.Errorf("result %s is outside %s/<language>.json layout", artifact.path, result.Mode)
 	}
 	if reduction.results[result.Language] == nil {
 		reduction.results[result.Language] = make(map[string]*ForestAuditResult)
@@ -231,12 +369,13 @@ func (reduction *forestAuditReduction) validateResultIdentity(result ForestAudit
 
 func (reduction *forestAuditReduction) report() ForestAuditReport {
 	report := ForestAuditReport{
-		Schema:               ForestAuditReportSchema,
-		GotreesitterRevision: reduction.manifest.GotreesitterRevision,
-		CorpusManifestSHA256: reduction.manifestDigest,
-		CorpusLockSHA256:     reduction.manifest.CorpusLock.SHA256,
-		Status:               "pass",
-		LanguagesExpected:    len(reduction.languages),
+		Schema:                  ForestAuditReportSchema,
+		GotreesitterRevision:    reduction.manifest.GotreesitterRevision,
+		CorpusManifestSHA256:    reduction.manifestDigest,
+		CorpusLockSHA256:        reduction.manifest.CorpusLock.SHA256,
+		ConfirmationIndexSHA256: reduction.confirmationIndexDigest,
+		Status:                  "pass",
+		LanguagesExpected:       len(reduction.languages),
 	}
 	for _, language := range reduction.languages {
 		row := reduction.languageReport(language)
@@ -254,11 +393,13 @@ func (reduction *forestAuditReduction) report() ForestAuditReport {
 
 func (reduction *forestAuditReduction) languageReport(language string) ForestAuditLanguageReport {
 	row := ForestAuditLanguageReport{Language: language, Status: "incomplete"}
+	row.ConfirmationCohortSHA256 = reduction.confirmationCohorts[language]
 	row.Production = reduction.results[language]["production"]
 	row.COracle = reduction.results[language]["c_oracle"]
 	row.PromotionBlockers = forestPromotionBlockers(row.Production, row.COracle)
 	if row.Production != nil && row.Production.RoutedNanos > 0 {
 		row.RoutedSpeedup = float64(row.Production.PeerNanos) / float64(row.Production.RoutedNanos)
+		row.ScreenRoutedSpeedup = row.RoutedSpeedup
 	}
 	if row.Production == nil && forestCOracleProvesNoCoverage(row.COracle) {
 		row.Status = "pass"
@@ -269,12 +410,84 @@ func (reduction *forestAuditReduction) languageReport(language string) ForestAud
 	if row.Production == nil || row.COracle == nil {
 		return row
 	}
+	row.CorrectnessRelation, row.ThreeWay = forestAuditCorrectnessRelation(row.Production, row.COracle)
+	if row.CorrectnessRelation == forestAuditRelationOracleCorrectionReview {
+		row.Status = "incomplete"
+		row.ConfirmationStatus = forestAuditRelationOracleCorrectionReview
+		row.PromotionBlockers = []string{forestAuditRelationOracleCorrectionReview}
+		return row
+	}
 	row.Status = "pass"
-	if row.Production.Status != "pass" || row.COracle.Status != "pass" {
+	if row.Production.Status != "pass" || row.COracle.Status != "pass" || row.CorrectnessRelation != forestAuditRelationProductionIdentity {
 		row.Status = "fail"
 	}
-	row.PromotionEligible = row.Status == "pass" && len(row.PromotionBlockers) == 0
+	baseBlockers := forestPromotionBlockers(row.Production, row.COracle)
+	row.ScreeningEligible = row.Status == "pass" && len(baseBlockers) == 0
+	row.PromotionBlockers = baseBlockers
+	if !row.ScreeningEligible {
+		return row
+	}
+	confirmation := summarizeForestAuditConfirmations(reduction.confirmations[language])
+	row.Confirmation = &confirmation
+	row.ConfirmationStatus = confirmation.Status
+	if confirmation.Status == forestAuditConfirmationConfirmed {
+		row.PromotionEligible = true
+		row.PromotionBlockers = nil
+	} else {
+		row.PromotionBlockers = append(row.PromotionBlockers, confirmation.Status)
+		if confirmation.Status != forestAuditConfirmationNeutral {
+			row.Status = "incomplete"
+		}
+	}
 	return row
+}
+
+func forestAuditCorrectnessRelation(production, cOracle *ForestAuditResult) (string, *ForestAuditThreeWayRelation) {
+	if production == nil || cOracle == nil {
+		return "", nil
+	}
+	if production.FilesDiverged == 0 && production.FilesRoutedDiverged == 0 {
+		return forestAuditRelationProductionIdentity, nil
+	}
+	paths, ok := forestPotentialOracleCorrectionPaths(production, cOracle)
+	if ok {
+		return forestAuditRelationOracleCorrectionReview, &ForestAuditThreeWayRelation{
+			Classification:   forestAuditRelationOracleCorrectionReview,
+			Paths:            paths,
+			EvidenceComplete: false,
+		}
+	}
+	return forestAuditRelationUnresolvedDivergence, &ForestAuditThreeWayRelation{
+		Classification:   forestAuditRelationUnresolvedDivergence,
+		EvidenceComplete: false,
+	}
+}
+
+func forestPotentialOracleCorrectionPaths(production, cOracle *ForestAuditResult) ([]string, bool) {
+	if production == nil || cOracle == nil || cOracle.Status != "pass" || production.FilesRoutedDiverged == 0 {
+		return nil, false
+	}
+	oracleByPath := make(map[string]ForestAuditFileResult, len(cOracle.Files))
+	for _, file := range cOracle.Files {
+		oracleByPath[file.Path] = file
+	}
+	var paths []string
+	for _, file := range production.Files {
+		if file.RoutedDiff == "" && file.Diff == "" {
+			continue
+		}
+		oracle, ok := oracleByPath[file.Path]
+		if !ok || oracle.Disposition != "accepted" || oracle.Diff != "" ||
+			file.RoutedProvenance != forestAuditRouteForestFastPath || !file.Routed.Accepted || !file.Forest.Accepted {
+			return nil, false
+		}
+		paths = append(paths, file.Path)
+	}
+	if len(paths) == 0 {
+		return nil, false
+	}
+	sort.Strings(paths)
+	return paths, true
 }
 
 func forestPromotionBlockers(production, cOracle *ForestAuditResult) []string {
@@ -287,6 +500,9 @@ func forestPromotionBlockers(production, cOracle *ForestAuditResult) []string {
 		}
 		if production.FilesRoutedDiverged > 0 {
 			blockers = append(blockers, "routed_divergence")
+		}
+		if production.FilesRoutedForest == 0 {
+			blockers = append(blockers, "no_routed_forest_coverage")
 		}
 		if !production.RoutedImproved {
 			blockers = append(blockers, "routed_not_faster")
@@ -351,6 +567,21 @@ func mergeForestAuditReportStatus(current, next string) string {
 
 func WriteForestAuditReport(path string, report ForestAuditReport) error {
 	return writeForestAuditJSON(path, report)
+}
+
+func ReadForestAuditReport(path string) (ForestAuditReport, error) {
+	var report ForestAuditReport
+	artifact, err := readForestAuditArtifact(path)
+	if err != nil {
+		return report, err
+	}
+	if err := artifact.decode(&report); err != nil {
+		return report, err
+	}
+	if report.Schema != ForestAuditReportSchema {
+		return report, fmt.Errorf("forest audit report schema %q, want %q", report.Schema, ForestAuditReportSchema)
+	}
+	return report, nil
 }
 
 func validateForestAuditResult(result ForestAuditResult) error {

--- a/cgo_harness/forest_corpus_manifest_test.go
+++ b/cgo_harness/forest_corpus_manifest_test.go
@@ -353,10 +353,10 @@ func TestReduceForestAuditResultsIsDeterministicAndResumable(t *testing.T) {
 	result.Files = []ForestAuditFileResult{{
 		Path: "a.go", Bytes: 1, SHA256: strings.Repeat("d", 64), Disposition: "accepted",
 		Forest: forestAuditTestAcceptedOutcome(1, true), Peer: forestAuditTestAcceptedOutcome(1, false),
-		Routed: forestAuditTestAcceptedOutcome(1, false), RoutedProvenance: forestAuditRouteProductionFallback, RoutedNanos: 1,
+		Routed: forestAuditTestAcceptedOutcome(1, true), RoutedProvenance: forestAuditRouteForestFastPath, RoutedNanos: 1,
 	}}
 	result.FilesTotal, result.FilesAccepted = 1, 1
-	result.FilesRoutedFallback = 1
+	result.FilesRoutedForest = 1
 	result.PeerNanos, result.RoutedNanos, result.RoutedImproved = 2, 1, true
 	if err := WriteForestAuditResult(filepath.Join(dir, "results", "production", "go.json"), result); err != nil {
 		t.Fatal(err)
@@ -366,7 +366,7 @@ func TestReduceForestAuditResultsIsDeterministicAndResumable(t *testing.T) {
 	bad.Files[0].Bytes++
 	bad.Files[0].Forest = forestAuditTestAcceptedOutcome(2, true)
 	bad.Files[0].Peer = forestAuditTestAcceptedOutcome(2, false)
-	bad.Files[0].Routed = forestAuditTestAcceptedOutcome(2, false)
+	bad.Files[0].Routed = forestAuditTestAcceptedOutcome(2, true)
 	badRoot := filepath.Join(dir, "bad-results")
 	if err := WriteForestAuditResult(filepath.Join(badRoot, "production", "go.json"), bad); err != nil {
 		t.Fatal(err)
@@ -401,14 +401,181 @@ func TestReduceForestAuditResultsIsDeterministicAndResumable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if report.LanguagesComplete != 1 || report.Languages[0].Language != "go" || report.Languages[0].Status != "pass" ||
-		!report.Languages[0].PromotionEligible || report.Languages[0].RoutedSpeedup != 2 || len(report.Languages[0].PromotionBlockers) != 0 {
+	if report.Status != "incomplete" || report.LanguagesComplete != 0 || report.Languages[0].Language != "go" || report.Languages[0].Status != "incomplete" ||
+		!report.Languages[0].ScreeningEligible || report.Languages[0].PromotionEligible ||
+		report.Languages[0].CorrectnessRelation != forestAuditRelationProductionIdentity ||
+		report.Languages[0].ConfirmationStatus != forestAuditConfirmationRequired ||
+		report.Languages[0].RoutedSpeedup != 2 || report.Languages[0].ScreenRoutedSpeedup != 2 ||
+		!reflect.DeepEqual(report.Languages[0].PromotionBlockers, []string{forestAuditConfirmationRequired}) {
 		t.Fatalf("resumed report = %#v", report)
 	}
 	data, err := json.Marshal(report)
 	if err != nil || len(data) == 0 {
 		t.Fatalf("marshal report: bytes=%d err=%v", len(data), err)
 	}
+
+	verifyForestAuditConfirmationLayout(t, manifestPath, filepath.Join(dir, "results"), result)
+}
+
+type forestAuditConfirmationLayoutFixture struct {
+	runConfigSHA  string
+	runConfigPath string
+	runConfig     ForestAuditRunConfig
+	finalPath     string
+	finalTrial    ForestAuditConfirmationTrial
+	indexPath     string
+	cohortSHA     string
+}
+
+func verifyForestAuditConfirmationLayout(t *testing.T, manifestPath, resultsRoot string, screen ForestAuditResult) {
+	t.Helper()
+	fixture := writeForestAuditTestConfirmationChain(t, resultsRoot, screen)
+	report, err := ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, fixture.indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Languages[0].PromotionEligible || report.Languages[0].ConfirmationStatus != forestAuditConfirmationConfirmed ||
+		report.Status != "incomplete" || report.LanguagesComplete != 1 || len(report.Languages[0].PromotionBlockers) != 0 ||
+		report.ConfirmationIndexSHA256+".json" != filepath.Base(fixture.indexPath) ||
+		report.Languages[0].ConfirmationCohortSHA256 != fixture.cohortSHA {
+		t.Fatalf("confirmed report = %#v", report)
+	}
+	verifyForestAuditCLIConfirmationFlow(t, manifestPath, resultsRoot, fixture)
+	verifyForestAuditConfirmationTamperRejection(t, manifestPath, resultsRoot, fixture)
+}
+
+func verifyForestAuditCLIConfirmationFlow(t *testing.T, manifestPath, resultsRoot string, fixture forestAuditConfirmationLayoutFixture) {
+	t.Helper()
+	runCLI := func(args ...string) {
+		t.Helper()
+		command := exec.Command("go", append([]string{"run", "./cmd/forest_audit"}, args...)...)
+		command.Dir = "."
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("forest_audit %v: %v\n%s", args, err, output)
+		}
+	}
+	runCLI("publish-confirmation", "--results-root", resultsRoot, "--run-config", fixture.runConfigPath, "--trial", fixture.finalPath)
+	runCLI("publish-result", "--results-root", resultsRoot, "--result", filepath.Join(resultsRoot, "production", "go.json"))
+	reportPath := filepath.Join(t.TempDir(), "report.json")
+	runCLI("reduce", "--manifest", manifestPath, "--results-root", resultsRoot, "--confirmation-index", fixture.indexPath, "--out", reportPath)
+	runCLI("index-confirmations", "--report", reportPath, "--results-root", resultsRoot, "--cohorts", "go="+fixture.cohortSHA)
+	planPath := filepath.Join(resultsRoot, "confirmation", "plan.json")
+	runCLI("plan-confirmations", "--report", reportPath, "--out", planPath)
+	secondReportPath := filepath.Join(t.TempDir(), "report.json")
+	runCLI("reduce", "--manifest", manifestPath, "--results-root", resultsRoot, "--confirmation-index", fixture.indexPath, "--out", secondReportPath)
+}
+
+func writeForestAuditTestConfirmationChain(t *testing.T, resultsRoot string, screen ForestAuditResult) forestAuditConfirmationLayoutFixture {
+	t.Helper()
+	runConfigSHA, stagedRunConfigPath, runConfig := writeForestAuditTestRunConfig(t)
+	var previousTrialSHA string
+	var finalTrialPath, finalIndexPath, finalCohortSHA string
+	var finalTrial ForestAuditConfirmationTrial
+	for _, spec := range []struct {
+		id, order   string
+		repeats     int
+		peerNanos   int64
+		routedNanos int64
+	}{
+		{id: forestAuditConfirmationPairA, order: ForestAuditOrderProductionFirst, repeats: 1, peerNanos: 1_030_000_000, routedNanos: 1_000_000_000},
+		{id: forestAuditConfirmationPairB, order: ForestAuditOrderRoutedFirst, repeats: 1, peerNanos: 1_020_000_000, routedNanos: 1_000_000_000},
+		{id: forestAuditConfirmationABBAA1, order: ForestAuditOrderProductionFirst, repeats: 2, peerNanos: 2_400_000_000, routedNanos: 2_000_000_000},
+		{id: forestAuditConfirmationABBAB1, order: ForestAuditOrderRoutedFirst, repeats: 2, peerNanos: 2_300_000_000, routedNanos: 2_000_000_000},
+		{id: forestAuditConfirmationABBAB2, order: ForestAuditOrderRoutedFirst, repeats: 2, peerNanos: 2_200_000_000, routedNanos: 2_000_000_000},
+		{id: forestAuditConfirmationABBAA2, order: ForestAuditOrderProductionFirst, repeats: 2, peerNanos: 2_300_000_000, routedNanos: 2_000_000_000},
+	} {
+		confirmedResult := screen
+		confirmedResult.Files = append([]ForestAuditFileResult(nil), screen.Files...)
+		confirmedResult.PeerNanos = spec.peerNanos
+		confirmedResult.RoutedNanos = spec.routedNanos
+		confirmedResult.RoutedImproved = true
+		confirmedResult.Files[0].RoutedNanos = spec.routedNanos
+		trial, err := NewForestAuditConfirmationTrial(spec.id, runConfigSHA, previousTrialSHA, ForestAuditRunPlan{
+			ExecutionOrder: spec.order, RepeatCount: spec.repeats,
+		}, confirmedResult)
+		if err != nil {
+			t.Fatal(err)
+		}
+		trialPath := filepath.Join(t.TempDir(), spec.id+".json")
+		if err := WriteForestAuditConfirmationTrial(trialPath, trial); err != nil {
+			t.Fatal(err)
+		}
+		stored, err := StoreForestAuditConfirmation(resultsRoot, stagedRunConfigPath, trialPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		previousTrialSHA = stored.TrialSHA256
+		finalTrialPath = filepath.Join(resultsRoot, "confirmation", "trials", stored.TrialSHA256+".json")
+		finalIndexPath, finalCohortSHA, finalTrial = stored.IndexPath, stored.CohortSHA256, trial
+	}
+	return forestAuditConfirmationLayoutFixture{
+		runConfigSHA: runConfigSHA, runConfigPath: filepath.Join(resultsRoot, "confirmation", "run-configs", runConfigSHA+".json"), runConfig: runConfig,
+		finalPath: finalTrialPath, finalTrial: finalTrial, indexPath: finalIndexPath, cohortSHA: finalCohortSHA,
+	}
+}
+
+func verifyForestAuditConfirmationTamperRejection(t *testing.T, manifestPath, resultsRoot string, fixture forestAuditConfirmationLayoutFixture) {
+	t.Helper()
+	if err := os.Remove(fixture.runConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, fixture.indexPath); err == nil || !strings.Contains(err.Error(), "read run config") {
+		t.Fatalf("missing run config error = %v", err)
+	}
+	if err := writeForestAuditJSON(fixture.runConfigPath, fixture.runConfig); err != nil {
+		t.Fatal(err)
+	}
+	forgedConfig := fixture.runConfig
+	forgedConfig.HostLabel = "forged-host"
+	if err := writeForestAuditJSON(fixture.runConfigPath, forgedConfig); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, fixture.indexPath); err == nil || !strings.Contains(err.Error(), "content hash") {
+		t.Fatalf("forged run config error = %v", err)
+	}
+	if err := writeForestAuditJSON(fixture.runConfigPath, fixture.runConfig); err != nil {
+		t.Fatal(err)
+	}
+	fixture.finalTrial.Result.PeerNanos += 500_000_000
+	fixture.finalTrial.Result.Files[0].RoutedNanos = fixture.finalTrial.Result.RoutedNanos
+	if err := writeForestAuditJSON(fixture.finalPath, fixture.finalTrial); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, fixture.indexPath); err == nil || !strings.Contains(err.Error(), "content hash") {
+		t.Fatalf("tampered head timing error = %v", err)
+	}
+	fixture.finalTrial.Result.PeerNanos -= 500_000_000
+	if err := writeForestAuditJSON(fixture.finalPath, fixture.finalTrial); err != nil {
+		t.Fatal(err)
+	}
+	var index ForestAuditConfirmationIndex
+	if err := readForestAuditJSON(fixture.indexPath, &index); err != nil {
+		t.Fatal(err)
+	}
+	index.Cohorts[0].CohortSHA256 = strings.Repeat("f", 64)
+	if err := writeForestAuditJSON(fixture.indexPath, index); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReduceForestAuditResultsWithConfirmations(manifestPath, resultsRoot, fixture.indexPath); err == nil || !strings.Contains(err.Error(), "not named by content hash") {
+		t.Fatalf("forged confirmation index error = %v", err)
+	}
+}
+
+func writeForestAuditTestRunConfig(t *testing.T) (string, string, ForestAuditRunConfig) {
+	t.Helper()
+	config := ForestAuditRunConfig{
+		Schema: ForestAuditRunConfigSchema, HostLabel: "quiet-box", HostFingerprint: strings.Repeat("b", 64), ImageID: "sha256:" + strings.Repeat("a", 64),
+		Memory: "4g", CPUs: "1", CPUSetCPUs: "7", PIDs: "4096", GoMemLimit: "3GiB", GOMAXPROCS: 1, TestTimeout: "10m",
+	}
+	tempPath := filepath.Join(t.TempDir(), "run-config.json")
+	if err := writeForestAuditJSON(tempPath, config); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := forestFileSHA256(tempPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest, tempPath, config
 }
 
 func TestReduceForestAuditResultsClassifiesCFirstNoCoverage(t *testing.T) {
@@ -595,7 +762,11 @@ func TestValidateForestAuditResultRejectsIncoherentOutcomes(t *testing.T) {
 
 	routedDiverged := clone()
 	routedDiverged.Status = "fail"
+	routedDiverged.FilesRoutedFallback = 0
+	routedDiverged.FilesRoutedForest = 1
 	routedDiverged.FilesRoutedDiverged = 1
+	routedDiverged.Files[0].Routed = forestAuditTestAcceptedOutcome(1, true)
+	routedDiverged.Files[0].RoutedProvenance = forestAuditRouteForestFastPath
 	routedDiverged.Files[0].RoutedDiff = "routed shape mismatch"
 	if err := validateForestAuditResult(routedDiverged); err != nil {
 		t.Fatalf("routed divergence should remain admissible evidence: %v", err)
@@ -606,6 +777,10 @@ func TestValidateForestAuditResultRejectsIncoherentOutcomes(t *testing.T) {
 	}
 
 	routedSlower := clone()
+	routedSlower.FilesRoutedFallback = 0
+	routedSlower.FilesRoutedForest = 1
+	routedSlower.Files[0].Routed = forestAuditTestAcceptedOutcome(1, true)
+	routedSlower.Files[0].RoutedProvenance = forestAuditRouteForestFastPath
 	routedSlower.RoutedNanos, routedSlower.Files[0].RoutedNanos, routedSlower.RoutedImproved = 2, 2, false
 	if err := validateForestAuditResult(routedSlower); err != nil {
 		t.Fatalf("slower routed result should pass correctness validation: %v", err)

--- a/cgo_harness/forest_corpus_parity_test.go
+++ b/cgo_harness/forest_corpus_parity_test.go
@@ -1,6 +1,8 @@
 package cgoharness
 
 import (
+	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,6 +48,11 @@ func TestForestCorpusParity(t *testing.T) {
 	loaders := forestLanguageLoaders()
 	manifestPath := strings.TrimSpace(os.Getenv("GTS_FOREST_CORPUS_MANIFEST"))
 	resultOut := strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_RESULT_OUT"))
+	confirmationOut := strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_CONFIRMATION_OUT"))
+	plan, err := ForestAuditRunPlanFromEnv()
+	if err != nil {
+		t.Fatalf("forest audit run plan: %v", err)
+	}
 	var manifestFiles map[string][]string
 	var manifest ForestCorpusManifest
 	if manifestPath != "" {
@@ -68,8 +75,23 @@ func TestForestCorpusParity(t *testing.T) {
 	} else if strings.TrimSpace(os.Getenv("GTS_FOREST_CORPUS_LEGACY_MANUAL")) == "" {
 		t.Fatal("set GTS_FOREST_CORPUS_MANIFEST to an authenticated manifest; set GTS_FOREST_CORPUS_LEGACY_MANUAL=1 only for a non-authoritative manual flat-corpus run")
 	}
-	if resultOut != "" && (manifestPath == "" || len(langs) != 1) {
-		t.Fatal("GTS_FOREST_AUDIT_RESULT_OUT requires one authenticated language")
+	if resultOut != "" && confirmationOut != "" {
+		t.Fatal("GTS_FOREST_AUDIT_RESULT_OUT and GTS_FOREST_AUDIT_CONFIRMATION_OUT are mutually exclusive")
+	}
+	if (resultOut != "" || confirmationOut != "") && (manifestPath == "" || len(langs) != 1) {
+		t.Fatal("forest audit output requires one authenticated language")
+	}
+	if confirmationOut != "" {
+		trialID := strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_TRIAL_ID"))
+		if err := validateForestAuditTrialID(trialID, plan.ExecutionOrder); err != nil {
+			t.Fatalf("forest confirmation trial: %v", err)
+		}
+		if _, err := forestManifestDigest("run config", strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_RUN_CONFIG_SHA256"))); err != nil {
+			t.Fatalf("forest confirmation run config: %v", err)
+		}
+		if err := validateForestAuditPreviousTrialSHA(trialID, strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_PREVIOUS_TRIAL_SHA256"))); err != nil {
+			t.Fatalf("forest confirmation chronology: %v", err)
+		}
 	}
 	var repoRoot string
 	if manifestFiles == nil {
@@ -110,10 +132,29 @@ func TestForestCorpusParity(t *testing.T) {
 		anyRun = true
 		lang := load()
 		result := runForestLangParity(t, name, lang, files, manifestPath, manifest.CorpusLock.SHA256,
-			strings.TrimSpace(os.Getenv("GTS_FOREST_GOTREESITTER_REVISION")), forestManifestMetadata(manifest, name, files))
+			strings.TrimSpace(os.Getenv("GTS_FOREST_GOTREESITTER_REVISION")), forestManifestMetadata(manifest, name, files), plan)
+		if (resultOut != "" || confirmationOut != "") && (result.Status != "pass" || t.Failed()) {
+			t.Logf("%s: failed audit evidence remains staged only; no result receipt written", name)
+			continue
+		}
 		if resultOut != "" {
 			if err := WriteForestAuditResult(resultOut, result); err != nil {
 				t.Fatalf("write forest audit result: %v", err)
+			}
+		}
+		if confirmationOut != "" {
+			trial, err := NewForestAuditConfirmationTrial(
+				strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_TRIAL_ID")),
+				strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_RUN_CONFIG_SHA256")),
+				strings.TrimSpace(os.Getenv("GTS_FOREST_AUDIT_PREVIOUS_TRIAL_SHA256")),
+				plan,
+				result,
+			)
+			if err != nil {
+				t.Fatalf("initialize forest confirmation trial: %v", err)
+			}
+			if err := WriteForestAuditConfirmationTrial(confirmationOut, trial); err != nil {
+				t.Fatalf("write forest confirmation trial: %v", err)
 			}
 		}
 	}
@@ -123,39 +164,59 @@ func TestForestCorpusParity(t *testing.T) {
 }
 
 type forestProductionAudit struct {
-	t                *testing.T
-	name             string
-	lang             *gts.Language
-	metadata         map[string]ForestCorpusManifestFile
-	result           ForestAuditResult
-	total            int
-	dispatched       int
-	fellBack         int
-	diverged         int
-	prodNanos        int64
-	forestNanos      int64
-	routedNanos      int64
-	routedForest     int
-	routedFallback   int
-	auditFailed      bool
-	divergedFiles    []string
-	routedDiverged   int
-	routedDiffFiles  []string
-	fallbackReasons  map[string]int
-	verboseFallbacks bool
+	t                   forestAuditReporter
+	name                string
+	lang                *gts.Language
+	metadata            map[string]ForestCorpusManifestFile
+	result              ForestAuditResult
+	total               int
+	dispatched          int
+	fellBack            int
+	diverged            int
+	prodNanos           int64
+	forestNanos         int64
+	forestRuns          int
+	routedNanos         int64
+	routedForest        int
+	routedFallback      int
+	auditFailed         bool
+	divergedFiles       []string
+	routedDiverged      int
+	routedDiffFiles     []string
+	fallbackReasons     map[string]int
+	verboseFallbacks    bool
+	plan                ForestAuditRunPlan
+	resultIndexes       map[string]int
+	releaseTree         func(*gts.Tree)
+	parseProductionTree func([]byte) (*gts.Tree, error)
+	parseRoutedTree     func([]byte) (*gts.Tree, int64, error)
+	parseForestTree     func([]byte) (*gts.Tree, bool, error)
 }
 
-func runForestLangParity(t *testing.T, name string, lang *gts.Language, files []string, manifestPath, lockSHA, revision string, metadata map[string]ForestCorpusManifestFile) ForestAuditResult {
+type forestAuditReporter interface {
+	Errorf(string, ...any)
+	Logf(string, ...any)
+}
+
+func runForestLangParity(t *testing.T, name string, lang *gts.Language, files []string, manifestPath, lockSHA, revision string, metadata map[string]ForestCorpusManifestFile, plan ForestAuditRunPlan) ForestAuditResult {
 	t.Helper()
-	audit := newForestProductionAudit(t, name, lang, manifestPath, lockSHA, revision, metadata)
+	audit := newForestProductionAudit(t, name, lang, manifestPath, lockSHA, revision, metadata, plan)
 	gts.ResetPerfCounters()
-	for _, filePath := range files {
-		audit.evaluateFile(filePath)
-	}
+	// Finish every file before beginning the next repetition. evaluateFile
+	// records raw-forest evidence only during repetition zero.
+	forEachForestAuditCorpusRepetition(files, plan.RepeatCount, audit.evaluateFile)
 	return audit.finish()
 }
 
-func newForestProductionAudit(t *testing.T, name string, lang *gts.Language, manifestPath, lockSHA, revision string, metadata map[string]ForestCorpusManifestFile) *forestProductionAudit {
+func forEachForestAuditCorpusRepetition(files []string, repeatCount int, evaluate func(string, int)) {
+	for repetition := 0; repetition < repeatCount; repetition++ {
+		for _, filePath := range files {
+			evaluate(filePath, repetition)
+		}
+	}
+}
+
+func newForestProductionAudit(t *testing.T, name string, lang *gts.Language, manifestPath, lockSHA, revision string, metadata map[string]ForestCorpusManifestFile, plan ForestAuditRunPlan) *forestProductionAudit {
 	result := ForestAuditResult{Schema: ForestAuditResultSchema, Mode: "production", Language: name, Status: "pass"}
 	if manifestPath != "" {
 		var err error
@@ -164,114 +225,202 @@ func newForestProductionAudit(t *testing.T, name string, lang *gts.Language, man
 			t.Fatalf("initialize forest audit result: %v", err)
 		}
 	}
-	return &forestProductionAudit{
+	audit := &forestProductionAudit{
 		t: t, name: name, lang: lang, metadata: metadata, result: result,
 		fallbackReasons:  map[string]int{},
 		verboseFallbacks: strings.TrimSpace(os.Getenv("GTS_FOREST_CORPUS_VERBOSE")) != "",
+		plan:             plan,
+		resultIndexes:    make(map[string]int, len(metadata)),
+		releaseTree:      func(tree *gts.Tree) { tree.Release() },
 	}
+	audit.parseProductionTree = audit.parseProduction
+	audit.parseRoutedTree = audit.parseRouted
+	audit.parseForestTree = audit.parseForest
+	return audit
 }
 
-func (audit *forestProductionAudit) evaluateFile(filePath string) {
-	src, err := os.ReadFile(filePath)
-	if err != nil {
-		audit.t.Errorf("%s: read %s: %v", audit.name, filePath, err)
-		return
-	}
-	audit.total++
+func (audit *forestProductionAudit) evaluateFile(filePath string, repetition int) {
 	meta, ok := audit.metadata[filePath]
 	if !ok {
-		audit.fellBack++
+		if repetition == 0 {
+			audit.total++
+			audit.fellBack++
+		}
+		audit.auditFailed = true
 		audit.t.Errorf("%s: authenticated metadata missing for %s", audit.name, filePath)
 		return
 	}
-	notRun := forestAuditNotRunOutcome(src)
-	fileResult := ForestAuditFileResult{
-		Path: meta.Path, Bytes: meta.Bytes, SHA256: meta.SHA256,
-		Forest: notRun, Peer: notRun, Routed: notRun, RoutedProvenance: forestAuditRouteNotRun,
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		audit.auditFailed = true
+		audit.t.Errorf("%s: read %s: %v", audit.name, filePath, err)
+		return
 	}
-	defer func() { audit.result.Files = append(audit.result.Files, fileResult) }()
+	if err := validateForestAuditSourceIdentity(src, meta); err != nil {
+		audit.auditFailed = true
+		audit.t.Errorf("%s: authenticated source drift for %s before repetition %d: %v", audit.name, filePath, repetition, err)
+		return
+	}
+	resultIndex, exists := audit.resultIndexes[filePath]
+	if repetition == 0 {
+		audit.total++
+		notRun := forestAuditNotRunOutcome(src)
+		audit.result.Files = append(audit.result.Files, ForestAuditFileResult{
+			Path: meta.Path, Bytes: meta.Bytes, SHA256: meta.SHA256,
+			Forest: notRun, Peer: notRun, Routed: notRun, RoutedProvenance: forestAuditRouteNotRun,
+		})
+		resultIndex = len(audit.result.Files) - 1
+		audit.resultIndexes[filePath] = resultIndex
+		exists = true
+	}
+	if !exists {
+		return
+	}
+	fileResult := &audit.result.Files[resultIndex]
 
-	prodTree := audit.parseProduction(src)
-	fileResult.Peer = forestGoTreeOutcome(prodTree, src)
-	if prodTree != nil {
-		defer prodTree.Release()
+	prodTree, routedTree, routedNanos, prodErr, routedErr := audit.parsePeerPair(src)
+	defer audit.release(prodTree)
+	defer audit.release(routedTree)
+	if prodErr != nil || routedErr != nil {
+		if repetition == 0 {
+			fileResult.Disposition = "declined"
+			fileResult.Decline = "peer_parse_error"
+			audit.fellBack++
+		}
+		audit.auditFailed = true
+		audit.t.Errorf("%s: peer parse error for %s: production=%v routed=%v", audit.name, filepath.Base(filePath), prodErr, routedErr)
+		return
 	}
-	var prodRoot *gts.Node
+	prodOutcome := forestGoTreeOutcome(prodTree, src)
+	routedOutcome := forestGoTreeOutcome(routedTree, src)
+	provenance := forestAuditRouteProductionFallback
+	if routedOutcome.ForestFastPath {
+		provenance = forestAuditRouteForestFastPath
+	}
+	fileResult.RoutedNanos += routedNanos
+
+	var prodRoot, routedRoot *gts.Node
 	if prodTree != nil {
 		prodRoot = prodTree.RootNode()
 	}
-
-	routedTree, routedNanos := audit.parseRouted(src)
-	fileResult.RoutedNanos = routedNanos
-	fileResult.Routed = forestGoTreeOutcome(routedTree, src)
-	fileResult.RoutedProvenance = forestAuditRouteProductionFallback
-	if fileResult.Routed.ForestFastPath {
-		fileResult.RoutedProvenance = forestAuditRouteForestFastPath
-		audit.routedForest++
-	} else {
-		audit.routedFallback++
-	}
-	if routedTree != nil {
-		defer routedTree.Release()
-	}
-	var routedRoot *gts.Node
 	if routedTree != nil {
 		routedRoot = routedTree.RootNode()
 	}
-	audit.compareRouted(filePath, routedRoot, prodRoot, &fileResult)
+	if repetition == 0 {
+		fileResult.Peer = prodOutcome
+		fileResult.Routed = routedOutcome
+		fileResult.RoutedProvenance = provenance
+		if provenance == forestAuditRouteForestFastPath {
+			audit.routedForest++
+		} else {
+			audit.routedFallback++
+		}
+	} else if prodOutcome != fileResult.Peer || routedOutcome != fileResult.Routed || provenance != fileResult.RoutedProvenance {
+		audit.recordRoutedDiff(filePath, "repeated routed/production outcome changed", fileResult)
+	}
+	audit.compareRouted(filePath, routedRoot, prodRoot, fileResult)
 
 	if prodRoot == nil {
-		fileResult.Disposition = "declined"
-		fileResult.Decline = "production_no_tree"
-		audit.fellBack++
+		if repetition == 0 {
+			fileResult.Disposition = "declined"
+			fileResult.Decline = "production_no_tree"
+			audit.fellBack++
+		} else {
+			audit.recordRoutedDiff(filePath, "production tree disappeared during repeated trial", fileResult)
+		}
 		audit.auditFailed = true
 		audit.t.Errorf("%s: production produced no tree for %s", audit.name, filepath.Base(filePath))
 		return
 	}
 
-	forestTree, forestOK := audit.parseForest(src)
-	if forestTree != nil {
-		defer forestTree.Release()
+	if repetition == 0 {
+		forestTree, forestOK, forestErr := audit.parseForestTree(src)
+		defer audit.release(forestTree)
+		if forestErr != nil {
+			fileResult.Disposition = "declined"
+			fileResult.Decline = "forest_parse_error"
+			audit.fellBack++
+			audit.auditFailed = true
+			audit.t.Errorf("%s: forest parse error for %s: %v", audit.name, filepath.Base(filePath), forestErr)
+			return
+		}
+		var forestRoot *gts.Node
+		if forestTree != nil {
+			forestRoot = forestTree.RootNode()
+		}
+		fileResult.Forest = forestGoTreeOutcome(forestTree, src)
+		if !audit.forestDeclined(filePath, src, forestOK, forestRoot, prodRoot, fileResult.Forest, fileResult) {
+			audit.dispatched++
+			fileResult.Disposition = "accepted"
+			audit.compareProduction(filePath, forestRoot, prodRoot, fileResult)
+		}
 	}
-	var forestRoot *gts.Node
-	if forestTree != nil {
-		forestRoot = forestTree.RootNode()
-	}
-	fileResult.Forest = forestGoTreeOutcome(forestTree, src)
-	if audit.forestDeclined(filePath, src, forestOK, forestRoot, prodRoot, fileResult.Forest, &fileResult) {
-		return
-	}
-	audit.dispatched++
-	fileResult.Disposition = "accepted"
-	audit.compareProduction(filePath, forestRoot, prodRoot, &fileResult)
 }
 
-func (audit *forestProductionAudit) parseProduction(src []byte) *gts.Tree {
+func validateForestAuditSourceIdentity(src []byte, meta ForestCorpusManifestFile) error {
+	if int64(len(src)) != meta.Bytes {
+		return fmt.Errorf("byte count %d, manifest requires %d", len(src), meta.Bytes)
+	}
+	digest := fmt.Sprintf("%x", sha256.Sum256(src))
+	if digest != meta.SHA256 {
+		return fmt.Errorf("sha256 %s, manifest requires %s", digest, meta.SHA256)
+	}
+	return nil
+}
+
+func (audit *forestProductionAudit) parsePeerPair(src []byte) (production, routed *gts.Tree, routedNanos int64, productionErr, routedErr error) {
+	return runForestAuditPeerPair(
+		audit.plan.ExecutionOrder,
+		func() (*gts.Tree, error) { return audit.parseProductionTree(src) },
+		func() (*gts.Tree, int64, error) { return audit.parseRoutedTree(src) },
+	)
+}
+
+func runForestAuditPeerPair[T any](order string, production func() (T, error), routed func() (T, int64, error)) (productionResult, routedResult T, routedNanos int64, productionErr, routedErr error) {
+	if order == ForestAuditOrderRoutedFirst {
+		routedResult, routedNanos, routedErr = routed()
+		productionResult, productionErr = production()
+		return
+	}
+	productionResult, productionErr = production()
+	routedResult, routedNanos, routedErr = routed()
+	return
+}
+
+func (audit *forestProductionAudit) release(tree *gts.Tree) {
+	if tree == nil {
+		return
+	}
+	audit.releaseTree(tree)
+}
+
+func (audit *forestProductionAudit) parseProduction(src []byte) (*gts.Tree, error) {
 	gts.SetGLRForestEnabled(false)
 	defer gts.SetGLRForestEnabled(true)
 	start := time.Now()
-	tree, _ := gts.NewParser(audit.lang).Parse(src)
+	tree, err := gts.NewParser(audit.lang).Parse(src)
 	audit.prodNanos += time.Since(start).Nanoseconds()
-	return tree
+	return tree, err
 }
 
-func (audit *forestProductionAudit) parseRouted(src []byte) (*gts.Tree, int64) {
+func (audit *forestProductionAudit) parseRouted(src []byte) (*gts.Tree, int64, error) {
 	previous := audit.lang.WantsForest
 	audit.lang.WantsForest = true
 	defer func() { audit.lang.WantsForest = previous }()
 	gts.SetGLRForestEnabled(true)
 	start := time.Now()
-	tree, _ := gts.NewParser(audit.lang).Parse(src)
+	tree, err := gts.NewParser(audit.lang).Parse(src)
 	elapsed := time.Since(start).Nanoseconds()
 	audit.routedNanos += elapsed
-	return tree, elapsed
+	return tree, elapsed, err
 }
 
-func (audit *forestProductionAudit) parseForest(src []byte) (*gts.Tree, bool) {
+func (audit *forestProductionAudit) parseForest(src []byte) (*gts.Tree, bool, error) {
+	audit.forestRuns++
 	start := time.Now()
 	tree, ok := gts.NewParser(audit.lang).ParseForestExperimental(src)
 	audit.forestNanos += time.Since(start).Nanoseconds()
-	return tree, ok
+	return tree, ok, nil
 }
 
 func (audit *forestProductionAudit) forestDeclined(filePath string, src []byte, ok bool, root, productionRoot *gts.Node, outcome ForestAuditOutcome, fileResult *ForestAuditFileResult) bool {
@@ -319,17 +468,29 @@ func (audit *forestProductionAudit) compareProduction(filePath string, forestRoo
 }
 
 func (audit *forestProductionAudit) compareRouted(filePath string, routedRoot, productionRoot *gts.Node, fileResult *ForestAuditFileResult) {
+	if fileResult.RoutedDiff != "" {
+		return
+	}
+	var diff string
 	if productionRoot == nil {
-		fileResult.RoutedDiff = "production tree missing"
+		diff = "production tree missing"
 	} else if routedRoot == nil {
-		fileResult.RoutedDiff = "routed tree missing"
-	} else if diff := completeGoTreeIdentityDiff(routedRoot, productionRoot, audit.lang); diff != "" {
-		fileResult.RoutedDiff = diff
+		diff = "routed tree missing"
+	} else if treeDiff := completeGoTreeIdentityDiff(routedRoot, productionRoot, audit.lang); treeDiff != "" {
+		diff = treeDiff
 	} else {
 		return
 	}
+	audit.recordRoutedDiff(filePath, diff, fileResult)
+}
+
+func (audit *forestProductionAudit) recordRoutedDiff(filePath, diff string, fileResult *ForestAuditFileResult) {
+	if fileResult.RoutedDiff != "" {
+		return
+	}
+	fileResult.RoutedDiff = diff
 	audit.routedDiverged++
-	audit.routedDiffFiles = append(audit.routedDiffFiles, filepath.Base(filePath)+": "+fileResult.RoutedDiff)
+	audit.routedDiffFiles = append(audit.routedDiffFiles, filepath.Base(filePath)+": "+diff)
 }
 
 func (audit *forestProductionAudit) finish() ForestAuditResult {
@@ -672,12 +833,18 @@ func TestForestProductionAuditRoutedParseUsesAndRestoresLanguageOptIn(t *testing
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			audit := &forestProductionAudit{t: t, name: "json", lang: lang}
-			production := audit.parseProduction([]byte(tc.source))
+			production, err := audit.parseProduction([]byte(tc.source))
+			if err != nil {
+				t.Fatal(err)
+			}
 			if production == nil || production.RootNode() == nil {
 				t.Fatal("production parse returned no tree")
 			}
 			defer production.Release()
-			routed, _ := audit.parseRouted([]byte(tc.source))
+			routed, _, err := audit.parseRouted([]byte(tc.source))
+			if err != nil {
+				t.Fatal(err)
+			}
 			if routed == nil || routed.RootNode() == nil {
 				t.Fatal("routed parse returned no tree")
 			}
@@ -697,6 +864,259 @@ func TestForestProductionAuditRoutedParseUsesAndRestoresLanguageOptIn(t *testing
 				t.Fatalf("routed parse differs from production: %s", file.RoutedDiff)
 			}
 		})
+	}
+}
+
+func TestForestProductionAuditRepeatsBothExecutionOrders(t *testing.T) {
+	gts.SetGLRForestEnabled(true)
+	defer gts.SetGLRForestEnabled(true)
+	gts.EnableArenaProfile(true)
+	defer gts.EnableArenaProfile(false)
+	lang := grm.JsonLanguage()
+	previous := lang.WantsForest
+	lang.WantsForest = false
+	defer func() { lang.WantsForest = previous }()
+
+	dir := t.TempDir()
+	files := []string{filepath.Join(dir, "a.json"), filepath.Join(dir, "b.json")}
+	sources := [][]byte{[]byte(`{"key":1}`), []byte(`{"other":2}`)}
+	metadata := make(map[string]ForestCorpusManifestFile, len(files))
+	for i, filePath := range files {
+		if err := os.WriteFile(filePath, sources[i], 0o644); err != nil {
+			t.Fatal(err)
+		}
+		digest, err := forestFileSHA256(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		metadata[filePath] = ForestCorpusManifestFile{
+			Language: "json", Path: filepath.Base(filePath), Bytes: int64(len(sources[i])), SHA256: digest,
+		}
+	}
+	for _, order := range []string{ForestAuditOrderProductionFirst, ForestAuditOrderRoutedFirst} {
+		t.Run(order, func(t *testing.T) {
+			gts.ResetArenaProfile()
+			plan := ForestAuditRunPlan{
+				ExecutionOrder: order, RepeatCount: 3,
+			}
+			audit := newForestProductionAudit(t, "json", lang, "", "", "", metadata, plan)
+			releaseCount := 0
+			audit.releaseTree = func(tree *gts.Tree) {
+				releaseCount++
+				tree.Release()
+			}
+			forEachForestAuditCorpusRepetition(files, plan.RepeatCount, audit.evaluateFile)
+			result := audit.finish()
+			if result.FilesTotal != 2 || result.FilesAccepted != 2 || result.FilesDiverged != 0 ||
+				result.FilesRoutedDiverged != 0 || len(result.Files) != 2 ||
+				result.PeerNanos <= 0 || result.RoutedNanos <= 0 ||
+				result.Files[0].RoutedNanos <= 0 || result.Files[1].RoutedNanos <= 0 {
+				t.Fatalf("repeated result = %#v", result)
+			}
+			if audit.forestRuns != len(files) {
+				t.Fatalf("raw forest runs = %d, want one per file (%d)", audit.forestRuns, len(files))
+			}
+			wantReleases := len(files) * (plan.RepeatCount*2 + 1)
+			if releaseCount != wantReleases {
+				t.Fatalf("tree releases = %d, want %d", releaseCount, wantReleases)
+			}
+			if lang.WantsForest {
+				t.Fatal("repeated audit did not restore Language.WantsForest")
+			}
+			profile := gts.ArenaProfileSnapshot()
+			wantAcquires := uint64(len(files) * (plan.RepeatCount*2 + 1))
+			if profile.FullAcquire != wantAcquires {
+				t.Fatalf("full arena acquires = %d, want %d", profile.FullAcquire, wantAcquires)
+			}
+			if profile.FullNew > 4 {
+				t.Fatalf("full arenas allocated = %d; per-repetition trees were not promptly reusable", profile.FullNew)
+			}
+		})
+	}
+}
+
+type forestAuditRecordingReporter struct {
+	errors int
+}
+
+func (reporter *forestAuditRecordingReporter) Errorf(string, ...any) { reporter.errors++ }
+func (reporter *forestAuditRecordingReporter) Logf(string, ...any)   {}
+
+func TestForestProductionAuditReleasesTreesOnNegativePaths(t *testing.T) {
+	lang := grm.JsonLanguage()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "a.json")
+	source := []byte(`{"a":1}`)
+	if err := os.WriteFile(filePath, source, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := forestFileSHA256(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata := map[string]ForestCorpusManifestFile{filePath: {
+		Language: "json", Path: "a.json", Bytes: int64(len(source)), SHA256: digest,
+	}}
+	parse := func(src []byte) *gts.Tree {
+		tree, err := gts.NewParser(lang).Parse(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tree
+	}
+	for _, tc := range []struct {
+		name        string
+		configure   func(*forestProductionAudit)
+		wantRelease int
+	}{
+		{name: "nil production", wantRelease: 1, configure: func(audit *forestProductionAudit) {
+			audit.parseProductionTree = func([]byte) (*gts.Tree, error) { return nil, nil }
+			audit.parseRoutedTree = func(src []byte) (*gts.Tree, int64, error) { return parse(src), 1, nil }
+		}},
+		{name: "peer error", wantRelease: 2, configure: func(audit *forestProductionAudit) {
+			audit.parseProductionTree = func(src []byte) (*gts.Tree, error) { return parse(src), errors.New("injected") }
+			audit.parseRoutedTree = func(src []byte) (*gts.Tree, int64, error) { return parse(src), 1, nil }
+		}},
+		{name: "forest decline", wantRelease: 2, configure: func(audit *forestProductionAudit) {
+			audit.parseProductionTree = func(src []byte) (*gts.Tree, error) { return parse(src), nil }
+			audit.parseRoutedTree = func(src []byte) (*gts.Tree, int64, error) { return parse(src), 1, nil }
+			audit.parseForestTree = func([]byte) (*gts.Tree, bool, error) { return nil, false, nil }
+		}},
+		{name: "routed divergence", wantRelease: 3, configure: func(audit *forestProductionAudit) {
+			audit.parseProductionTree = func(src []byte) (*gts.Tree, error) { return parse(src), nil }
+			audit.parseRoutedTree = func([]byte) (*gts.Tree, int64, error) { return parse([]byte(`[]`)), 1, nil }
+			audit.parseForestTree = func(src []byte) (*gts.Tree, bool, error) { return parse(src), true, nil }
+		}},
+		{name: "forest error", wantRelease: 3, configure: func(audit *forestProductionAudit) {
+			audit.parseProductionTree = func(src []byte) (*gts.Tree, error) { return parse(src), nil }
+			audit.parseRoutedTree = func(src []byte) (*gts.Tree, int64, error) { return parse(src), 1, nil }
+			audit.parseForestTree = func(src []byte) (*gts.Tree, bool, error) { return parse(src), false, errors.New("injected") }
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reporter := &forestAuditRecordingReporter{}
+			audit := newForestProductionAudit(t, "json", lang, "", "", "", metadata, DefaultForestAuditRunPlan())
+			audit.t = reporter
+			releases := 0
+			audit.releaseTree = func(tree *gts.Tree) {
+				releases++
+				tree.Release()
+			}
+			tc.configure(audit)
+			audit.evaluateFile(filePath, 0)
+			if releases != tc.wantRelease {
+				t.Fatalf("tree releases = %d, want %d", releases, tc.wantRelease)
+			}
+		})
+	}
+}
+
+func TestForestProductionAuditPeerPairHonorsExecutionOrder(t *testing.T) {
+	for _, test := range []struct {
+		order string
+		want  string
+	}{
+		{order: ForestAuditOrderProductionFirst, want: "production,routed"},
+		{order: ForestAuditOrderRoutedFirst, want: "routed,production"},
+	} {
+		t.Run(test.order, func(t *testing.T) {
+			var calls []string
+			production, routed, elapsed, productionErr, routedErr := runForestAuditPeerPair(
+				test.order,
+				func() (string, error) { calls = append(calls, "production"); return "production-result", nil },
+				func() (string, int64, error) { calls = append(calls, "routed"); return "routed-result", 17, nil },
+			)
+			if got := strings.Join(calls, ","); got != test.want {
+				t.Fatalf("peer order = %q, want %q", got, test.want)
+			}
+			if production != "production-result" || routed != "routed-result" || elapsed != 17 || productionErr != nil || routedErr != nil {
+				t.Fatalf("peer results = %q %q %d", production, routed, elapsed)
+			}
+		})
+	}
+}
+
+func TestForestProductionAuditRepeatsCompleteCorpusSweeps(t *testing.T) {
+	var got []string
+	forEachForestAuditCorpusRepetition([]string{"a", "b", "c"}, 3, func(file string, repetition int) {
+		got = append(got, fmt.Sprintf("%d:%s", repetition, file))
+	})
+	want := []string{"0:a", "0:b", "0:c", "1:a", "1:b", "1:c", "2:a", "2:b", "2:c"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("corpus repetition order = %v, want %v", got, want)
+	}
+}
+
+func TestForestProductionAuditRejectsSameLengthSourceDriftBetweenRepetitions(t *testing.T) {
+	lang := grm.JsonLanguage()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "a.json")
+	original := []byte(`{"a":1}`)
+	if err := os.WriteFile(filePath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest := fmt.Sprintf("%x", sha256.Sum256(original))
+	metadata := map[string]ForestCorpusManifestFile{filePath: {
+		Language: "json", Path: "a.json", Bytes: int64(len(original)), SHA256: digest,
+	}}
+	reporter := &forestAuditRecordingReporter{}
+	audit := newForestProductionAudit(t, "json", lang, "", "", "", metadata, ForestAuditRunPlan{
+		ExecutionOrder: ForestAuditOrderProductionFirst,
+		RepeatCount:    2,
+	})
+	audit.t = reporter
+	peerCalls := 0
+	parse := func(src []byte) *gts.Tree {
+		tree, err := gts.NewParser(lang).Parse(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tree
+	}
+	audit.parseProductionTree = func(src []byte) (*gts.Tree, error) {
+		peerCalls++
+		return parse(src), nil
+	}
+	audit.parseRoutedTree = func(src []byte) (*gts.Tree, int64, error) {
+		peerCalls++
+		return parse(src), 1, nil
+	}
+	audit.parseForestTree = func(src []byte) (*gts.Tree, bool, error) { return parse(src), true, nil }
+
+	audit.evaluateFile(filePath, 0)
+	if peerCalls != 2 || reporter.errors != 0 {
+		t.Fatalf("initial repetition: peer_calls=%d errors=%d", peerCalls, reporter.errors)
+	}
+	mutated := []byte(`{"b":1}`)
+	if len(mutated) != len(original) {
+		t.Fatal("test mutation changed source length")
+	}
+	if err := os.WriteFile(filePath, mutated, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	audit.evaluateFile(filePath, 1)
+	if peerCalls != 2 || reporter.errors != 1 || !audit.auditFailed {
+		t.Fatalf("drift repetition: peer_calls=%d errors=%d failed=%t", peerCalls, reporter.errors, audit.auditFailed)
+	}
+	if result := audit.finish(); result.Status != "fail" {
+		t.Fatalf("drift result status = %q, want fail", result.Status)
+	}
+}
+
+func TestForestProductionAuditRoutedDiffIsIdempotentPerFile(t *testing.T) {
+	result := forestAuditConfirmationTestResult(1_200_000_000, 1_000_000_000)
+	audit := &forestProductionAudit{result: result}
+	fileResult := &audit.result.Files[0]
+	audit.recordRoutedDiff("a.go", "first divergence", fileResult)
+	audit.recordRoutedDiff("a.go", "first divergence", fileResult)
+	audit.recordRoutedDiff("a.go", "later divergence", fileResult)
+	if audit.routedDiverged != 1 || len(audit.routedDiffFiles) != 1 || fileResult.RoutedDiff != "first divergence" {
+		t.Fatalf("routed divergence accounting: count=%d files=%v diff=%q", audit.routedDiverged, audit.routedDiffFiles, fileResult.RoutedDiff)
+	}
+	audit.result.FilesRoutedDiverged = audit.routedDiverged
+	audit.result.Status = "fail"
+	if err := validateForestAuditResult(audit.result); err != nil {
+		t.Fatalf("idempotent routed divergence result does not validate: %v", err)
 	}
 }
 

--- a/cgo_harness/forest_oracle_parity_test.go
+++ b/cgo_harness/forest_oracle_parity_test.go
@@ -165,17 +165,21 @@ func runForestCOracleAudit(t *testing.T, name string, lang *gts.Language, cLang 
 }
 
 func (audit *forestCOracleAudit) evaluateFile(filePath string) {
-	src, err := os.ReadFile(filePath)
-	if err != nil {
-		audit.t.Errorf("%s: read %s: %v", audit.name, filePath, err)
-		return
-	}
-	audit.total++
 	meta, ok := audit.metadata[filePath]
 	if !ok {
 		audit.t.Errorf("%s: authenticated metadata missing for %s", audit.name, filePath)
 		return
 	}
+	src, err := os.ReadFile(filePath)
+	if err != nil {
+		audit.t.Errorf("%s: read %s: %v", audit.name, filePath, err)
+		return
+	}
+	if err := validateForestAuditSourceIdentity(src, meta); err != nil {
+		audit.t.Errorf("%s: authenticated source drift for %s before C-oracle parse: %v", audit.name, filePath, err)
+		return
+	}
+	audit.total++
 	notRun := forestAuditNotRunOutcome(src)
 	fileResult := ForestAuditFileResult{
 		Path: meta.Path, Bytes: meta.Bytes, SHA256: meta.SHA256,


### PR DESCRIPTION
## Summary

- require fresh order-balanced confirmation before a forest screen can promote a route
- publish immutable trial, run-config, cohort, and selected-index receipts bound to source, locked-C coverage, image, host, and CPU identity
- fail closed on source drift, incomplete predecessors, marginal evidence, and possible C-oracle corrections

## Validation

- focused forest confirmation tests and `go vet` in Docker
- shell syntax, Markdown parsing, and changed-file Canopy gate
- authenticated KDL production shard: 8 files, zero divergences, immutable v2 receipt

The KDL run is directional screening evidence only; this change does not promote a route or make a new performance claim.