### PR TITLE
fix: validate rewriter ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Rewriter edits now reject reversed and out-of-source byte ranges instead of
+  panicking while applying them.
+
 ### Tooling
 
 - The authenticated fleet scoreboard now times fresh full parses against a

--- a/rewrite.go
+++ b/rewrite.go
@@ -74,7 +74,8 @@ func (r *Rewriter) Delete(node *Node) {
 
 // Apply sorts edits, validates no overlaps, applies them, and returns the
 // new source bytes plus InputEdit records for incremental reparsing.
-// Returns error if edits overlap.
+// Returns an error if edits overlap, use reversed ranges, or extend beyond
+// the source.
 func (r *Rewriter) Apply() (newSource []byte, edits []InputEdit, err error) {
 	if len(r.edits) == 0 {
 		out := make([]byte, len(r.source))

--- a/rewrite.go
+++ b/rewrite.go
@@ -91,6 +91,12 @@ func (r *Rewriter) Apply() (newSource []byte, edits []InputEdit, err error) {
 		}
 		return sorted[i].endByte < sorted[j].endByte
 	})
+	for _, edit := range sorted {
+		if edit.startByte > edit.endByte || uint64(edit.endByte) > uint64(len(r.source)) {
+			return nil, nil, fmt.Errorf("rewrite: invalid edit range [%d,%d) for source length %d",
+				edit.startByte, edit.endByte, len(r.source))
+		}
+	}
 
 	// Validate no overlaps: edit N's endByte <= edit N+1's startByte.
 	// Zero-width insertions at the same point are allowed only if they don't

--- a/rewrite_test.go
+++ b/rewrite_test.go
@@ -173,6 +173,25 @@ func TestRewriteOverlappingInsertionsError(t *testing.T) {
 	}
 }
 
+func TestRewriteInvalidRangeReturnsError(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		start, end uint32
+	}{
+		{name: "end beyond source", start: 0, end: 6},
+		{name: "start beyond source", start: 6, end: 6},
+		{name: "reversed range", start: 4, end: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := NewRewriter([]byte("hello"))
+			rw.ReplaceRange(tc.start, tc.end, []byte("x"))
+			if _, _, err := rw.Apply(); err == nil {
+				t.Fatal("Apply() succeeded for an invalid range")
+			}
+		})
+	}
+}
+
 func TestRewriteAdjacentEdits(t *testing.T) {
 	source := []byte("abcdef")
 


### PR DESCRIPTION
## Summary

- Validate source ranges before applying queued rewrites.
- Return an error rather than panic when `ReplaceRange` receives an invalid range.

## Root cause

`Rewriter.Apply` validated overlap but sliced using public byte offsets without checking that they were ordered and within the source.

## Validation

- `go vet .`
- `go test . -run '^TestRewrite' -count=1`
