### PR TITLE
fix: shift points after multiline edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Multiline tree edits now keep node byte and point ranges aligned with the C
+  runtime across insertions, deletions, and replacements.
+
 ### Tooling
 
 - The authenticated fleet scoreboard now times fresh full parses against a

--- a/cgo_harness/tree_edit_multiline_parity_test.go
+++ b/cgo_harness/tree_edit_multiline_parity_test.go
@@ -1,0 +1,102 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestTreeEditMultilineCoordinatesMatchC(t *testing.T) {
+	source := []byte("package p\n\nfunc f() {\n\tx := 1\n\ty := 2\n\tprintln(x, y)\n}\n")
+	cLang := loadCanonicalGoCLanguage(t)
+
+	tests := []struct {
+		name        string
+		startNeedle string
+		endNeedle   string
+		newText     string
+	}{
+		{name: "multiline insertion", startNeedle: "\tx := 1", endNeedle: "\tx := 1", newText: "// one\n// two\n"},
+		{name: "whole-line deletion", startNeedle: "\tx := 1\n", endNeedle: "\ty := 2", newText: ""},
+		{name: "cross-line replacement", startNeedle: "x := 1", endNeedle: " := 2", newText: "replacement\n\tcontinued"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start := strings.Index(string(source), tc.startNeedle)
+			oldEnd := strings.Index(string(source), tc.endNeedle)
+			if start < 0 || oldEnd < 0 {
+				t.Fatal("missing test needle")
+			}
+			if tc.startNeedle == tc.endNeedle {
+				oldEnd = start
+			} else {
+				oldEnd += len(tc.endNeedle)
+			}
+			edited := append([]byte(nil), source[:start]...)
+			edited = append(edited, tc.newText...)
+			edited = append(edited, source[oldEnd:]...)
+			newEnd := start + len(tc.newText)
+
+			goTree, goLang, err := parseWithGo(parityCase{name: "go", source: string(source)}, source, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer releaseGoTree(goTree)
+
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil {
+				t.Fatal("C parse returned nil")
+			}
+			defer cTree.Close()
+			if diff := FirstDivergenceDumpV1(goTree.RootNode(), goLang, cTree.RootNode()); diff != nil {
+				t.Fatalf("pre-edit tree differs from C: %+v", diff)
+			}
+
+			goEdit := gotreesitter.InputEdit{
+				StartByte:   uint32(start),
+				OldEndByte:  uint32(oldEnd),
+				NewEndByte:  uint32(newEnd),
+				StartPoint:  pointAtOffset(source, start),
+				OldEndPoint: pointAtOffset(source, oldEnd),
+				NewEndPoint: pointAtOffset(edited, newEnd),
+			}
+			goTree.Edit(goEdit)
+			cTree.Edit(&sitter.InputEdit{
+				StartByte:      uint(start),
+				OldEndByte:     uint(oldEnd),
+				NewEndByte:     uint(newEnd),
+				StartPosition:  sitter.Point{Row: uint(goEdit.StartPoint.Row), Column: uint(goEdit.StartPoint.Column)},
+				OldEndPosition: sitter.Point{Row: uint(goEdit.OldEndPoint.Row), Column: uint(goEdit.OldEndPoint.Column)},
+				NewEndPosition: sitter.Point{Row: uint(goEdit.NewEndPoint.Row), Column: uint(goEdit.NewEndPoint.Column)},
+			})
+
+			if diff := FirstDivergenceDumpV1(goTree.RootNode(), goLang, cTree.RootNode()); diff != nil {
+				t.Fatalf("post-edit tree differs from C: %+v", diff)
+			}
+
+			goIncremental, _, err := parseWithGo(parityCase{name: "go", source: string(edited)}, edited, goTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer releaseGoTree(goIncremental)
+			cFresh := cParser.Parse(edited, nil)
+			if cFresh == nil {
+				t.Fatal("fresh C parse returned nil")
+			}
+			defer cFresh.Close()
+			if diff := FirstDivergenceDumpV1(goIncremental.RootNode(), goLang, cFresh.RootNode()); diff != nil {
+				t.Fatalf("incremental Go tree differs from fresh C: %+v", diff)
+			}
+		})
+	}
+}

--- a/parser_result_javascript_typescript.go
+++ b/parser_result_javascript_typescript.go
@@ -694,27 +694,6 @@ func firstAndLastStackEntryChild(arena *nodeArena, entry stackEntry) (stackEntry
 	return first, last, true
 }
 
-func setStackEntryStart(entry stackEntry, startByte uint32, startPoint Point) {
-	if node := stackEntryNode(entry); node != nil {
-		node.startByte = startByte
-		node.startPoint = startPoint
-		return
-	}
-	if node := stackEntryNoTreeNode(entry); node != nil {
-		node.startByte = startByte
-		return
-	}
-	if leaf := stackEntryCompactFullLeaf(entry); leaf != nil {
-		leaf.startByte = startByte
-		leaf.startPoint = startPoint
-		return
-	}
-	if parent := stackEntryPendingParent(entry); parent != nil {
-		parent.startByte = startByte
-		parent.startPoint = startPoint
-	}
-}
-
 func normalizeJavaScriptTrailingContinueComments(root *Node, source []byte, lang *Language, poller *parseStopPoller) ParseStopReason {
 	if root == nil || lang == nil || lang.Name != "javascript" || len(source) == 0 {
 		return ParseStopNone

--- a/tree.go
+++ b/tree.go
@@ -3564,10 +3564,9 @@ func (t *Tree) Edit(edit InputEdit) {
 	if t.root != nil {
 		byteDelta := int64(edit.NewEndByte) - int64(edit.OldEndByte)
 		rowDelta := int64(edit.NewEndPoint.Row) - int64(edit.OldEndPoint.Row)
-		colDelta := int64(edit.NewEndPoint.Column) - int64(edit.OldEndPoint.Column)
 		hasTailShift := byteDelta != 0 || edit.NewEndPoint != edit.OldEndPoint
 		var shiftScratch []*Node
-		editNodeWithDelta(t.root, edit, byteDelta, rowDelta, colDelta, hasTailShift, &shiftScratch, &t.lastEditedLeaf)
+		editNodeWithDelta(t.root, edit, byteDelta, rowDelta, hasTailShift, &shiftScratch, &t.lastEditedLeaf)
 	}
 }
 
@@ -3633,10 +3632,9 @@ func coalesceRanges(in []Range) []Range {
 func editNode(n *Node, edit InputEdit) {
 	byteDelta := int64(edit.NewEndByte) - int64(edit.OldEndByte)
 	rowDelta := int64(edit.NewEndPoint.Row) - int64(edit.OldEndPoint.Row)
-	colDelta := int64(edit.NewEndPoint.Column) - int64(edit.OldEndPoint.Column)
 	hasTailShift := byteDelta != 0 || edit.NewEndPoint != edit.OldEndPoint
 	var shiftScratch []*Node
-	editNodeWithDelta(n, edit, byteDelta, rowDelta, colDelta, hasTailShift, &shiftScratch, nil)
+	editNodeWithDelta(n, edit, byteDelta, rowDelta, hasTailShift, &shiftScratch, nil)
 }
 
 func addUint32Delta(value uint32, delta int64) uint32 {
@@ -3650,7 +3648,7 @@ func addUint32Delta(value uint32, delta int64) uint32 {
 	return uint32(next)
 }
 
-func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta int64, hasTailShift bool, shiftScratch *[]*Node, leafHint **Node) {
+func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta int64, hasTailShift bool, shiftScratch *[]*Node, leafHint **Node) {
 	// If the node ends before the edit starts, it's completely unaffected.
 	if n.endByte <= edit.StartByte {
 		return
@@ -3665,7 +3663,7 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 		n.endByte = addUint32Delta(n.endByte, byteDelta)
 		n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
 		n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
-		shiftNodeChildrenAfterEdit(n, edit, byteDelta, rowDelta, colDelta, shiftScratch)
+		shiftNodeChildrenAfterEdit(n, edit, byteDelta, rowDelta, shiftScratch)
 		return
 	}
 
@@ -3673,6 +3671,10 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 	n.setDirty(true)
 	if perfCountersEnabled {
 		perfRecordNodeEditMarked()
+	}
+	if n.startByte > edit.StartByte {
+		n.startByte = edit.NewEndByte
+		n.startPoint = edit.NewEndPoint
 	}
 	if n.endByte <= edit.OldEndByte {
 		// Node is fully within the edited region.
@@ -3696,11 +3698,11 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 				if !hasTailShift {
 					break
 				}
-				shiftSubtreeNodeAfterEdit(c, edit, byteDelta, rowDelta, colDelta, shiftScratch)
+				shiftSubtreeNodeAfterEdit(c, edit, byteDelta, rowDelta, shiftScratch)
 				continue
 			}
 			descended = true
-			editNodeWithDelta(c, edit, byteDelta, rowDelta, colDelta, hasTailShift, shiftScratch, leafHint)
+			editNodeWithDelta(c, edit, byteDelta, rowDelta, hasTailShift, shiftScratch, leafHint)
 		}
 	} else {
 		for i := 0; i < childCount; i++ {
@@ -3715,11 +3717,11 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 				if !hasTailShift {
 					break
 				}
-				shiftStackEntrySubtreeAfterEdit(n.ownerArena, entry, edit, byteDelta, rowDelta, colDelta)
+				shiftStackEntrySubtreeAfterEdit(n.ownerArena, entry, edit, byteDelta, rowDelta)
 				continue
 			}
 			descended = true
-			editStackEntryWithDelta(n.ownerArena, entry, edit, byteDelta, rowDelta, colDelta, hasTailShift, shiftScratch, leafHint)
+			editStackEntryWithDelta(n.ownerArena, entry, edit, byteDelta, rowDelta, hasTailShift, shiftScratch, leafHint)
 		}
 	}
 	if leafHint != nil && !descended && childCount == 0 {
@@ -3727,9 +3729,9 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 	}
 }
 
-func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit, byteDelta, rowDelta, colDelta int64, hasTailShift bool, shiftScratch *[]*Node, leafHint **Node) {
+func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit, byteDelta, rowDelta int64, hasTailShift bool, shiftScratch *[]*Node, leafHint **Node) {
 	if node := stackEntryNode(entry); node != nil {
-		editNodeWithDelta(node, edit, byteDelta, rowDelta, colDelta, hasTailShift, shiftScratch, leafHint)
+		editNodeWithDelta(node, edit, byteDelta, rowDelta, hasTailShift, shiftScratch, leafHint)
 		return
 	}
 	if !stackEntryHasNode(entry) || stackEntryNodeEndByte(entry) <= edit.StartByte {
@@ -3737,7 +3739,7 @@ func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit,
 	}
 	if stackEntryNodeStartByte(entry) >= edit.OldEndByte {
 		if hasTailShift {
-			shiftStackEntrySubtreeAfterEdit(arena, entry, edit, byteDelta, rowDelta, colDelta)
+			shiftStackEntrySubtreeAfterEdit(arena, entry, edit, byteDelta, rowDelta)
 		}
 		return
 	}
@@ -3745,6 +3747,9 @@ func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit,
 	setStackEntryDirty(entry, true)
 	if perfCountersEnabled {
 		perfRecordNodeEditMarked()
+	}
+	if stackEntryNodeStartByte(entry) > edit.StartByte {
+		setStackEntryStart(entry, edit.NewEndByte, edit.NewEndPoint)
 	}
 	if stackEntryNodeEndByte(entry) <= edit.OldEndByte {
 		setStackEntryEnd(entry, edit.NewEndByte, edit.NewEndPoint)
@@ -3768,13 +3773,13 @@ func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit,
 			if !hasTailShift {
 				break
 			}
-			shiftStackEntrySubtreeAfterEdit(arena, child, edit, byteDelta, rowDelta, colDelta)
+			shiftStackEntrySubtreeAfterEdit(arena, child, edit, byteDelta, rowDelta)
 			continue
 		}
 		if perfCountersEnabled {
 			perfRecordNodeEditCompactRef()
 		}
-		editStackEntryWithDelta(arena, child, edit, byteDelta, rowDelta, colDelta, hasTailShift, shiftScratch, leafHint)
+		editStackEntryWithDelta(arena, child, edit, byteDelta, rowDelta, hasTailShift, shiftScratch, leafHint)
 	}
 }
 
@@ -3793,6 +3798,27 @@ func setStackEntryDirty(entry stackEntry, dirty bool) {
 	}
 	if parent := stackEntryPendingParent(entry); parent != nil {
 		parent.setDirty(dirty)
+	}
+}
+
+func setStackEntryStart(entry stackEntry, startByte uint32, startPoint Point) {
+	if node := stackEntryNode(entry); node != nil {
+		node.startByte = startByte
+		node.startPoint = startPoint
+		return
+	}
+	if node := stackEntryNoTreeNode(entry); node != nil {
+		node.startByte = startByte
+		return
+	}
+	if leaf := stackEntryCompactFullLeaf(entry); leaf != nil {
+		leaf.startByte = startByte
+		leaf.startPoint = startPoint
+		return
+	}
+	if parent := stackEntryPendingParent(entry); parent != nil {
+		parent.startByte = startByte
+		parent.startPoint = startPoint
 	}
 }
 
@@ -3817,31 +3843,13 @@ func setStackEntryEnd(entry stackEntry, endByte uint32, endPoint Point) {
 	}
 }
 
-func setStackEntryEndByte(entry stackEntry, endByte uint32) {
-	if node := stackEntryNode(entry); node != nil {
-		node.endByte = endByte
-		return
-	}
-	if node := stackEntryNoTreeNode(entry); node != nil {
-		node.endByte = endByte
-		return
-	}
-	if leaf := stackEntryCompactFullLeaf(entry); leaf != nil {
-		leaf.endByte = endByte
-		return
-	}
-	if parent := stackEntryPendingParent(entry); parent != nil {
-		parent.endByte = endByte
-	}
-}
-
-func shiftNodeChildrenAfterEdit(parent *Node, edit InputEdit, byteDelta, rowDelta, colDelta int64, shiftScratch *[]*Node) {
+func shiftNodeChildrenAfterEdit(parent *Node, edit InputEdit, byteDelta, rowDelta int64, shiftScratch *[]*Node) {
 	childCount := nodeChildCountNoMaterialize(parent)
 	if childCount == 0 {
 		return
 	}
 	if !nodeHasFinalChildRefs(parent) {
-		shiftSubtreeAfterEdit(parent.children, edit, byteDelta, rowDelta, colDelta, shiftScratch)
+		shiftSubtreeAfterEdit(parent.children, edit, byteDelta, rowDelta, shiftScratch)
 		return
 	}
 	for i := 0; i < childCount; i++ {
@@ -3852,11 +3860,11 @@ func shiftNodeChildrenAfterEdit(parent *Node, edit InputEdit, byteDelta, rowDelt
 		if !ok {
 			continue
 		}
-		shiftStackEntrySubtreeAfterEdit(parent.ownerArena, entry, edit, byteDelta, rowDelta, colDelta)
+		shiftStackEntrySubtreeAfterEdit(parent.ownerArena, entry, edit, byteDelta, rowDelta)
 	}
 }
 
-func shiftSubtreeAfterEdit(roots []*Node, edit InputEdit, byteDelta, rowDelta, colDelta int64, shiftScratch *[]*Node) {
+func shiftSubtreeAfterEdit(roots []*Node, edit InputEdit, byteDelta, rowDelta int64, shiftScratch *[]*Node) {
 	if len(roots) == 0 {
 		return
 	}
@@ -3888,7 +3896,7 @@ func shiftSubtreeAfterEdit(roots []*Node, edit InputEdit, byteDelta, rowDelta, c
 				if !ok {
 					continue
 				}
-				shiftStackEntrySubtreeAfterEdit(n.ownerArena, entry, edit, byteDelta, rowDelta, colDelta)
+				shiftStackEntrySubtreeAfterEdit(n.ownerArena, entry, edit, byteDelta, rowDelta)
 			}
 		}
 	}
@@ -3897,26 +3905,26 @@ func shiftSubtreeAfterEdit(roots []*Node, edit InputEdit, byteDelta, rowDelta, c
 	}
 }
 
-func shiftSubtreeNodeAfterEdit(root *Node, edit InputEdit, byteDelta, rowDelta, colDelta int64, shiftScratch *[]*Node) {
+func shiftSubtreeNodeAfterEdit(root *Node, edit InputEdit, byteDelta, rowDelta int64, shiftScratch *[]*Node) {
 	if root == nil {
 		return
 	}
 	var roots [1]*Node
 	roots[0] = root
-	shiftSubtreeAfterEdit(roots[:], edit, byteDelta, rowDelta, colDelta, shiftScratch)
+	shiftSubtreeAfterEdit(roots[:], edit, byteDelta, rowDelta, shiftScratch)
 }
 
-func shiftStackEntrySubtreeAfterEdit(arena *nodeArena, entry stackEntry, edit InputEdit, byteDelta, rowDelta, colDelta int64) {
+func shiftStackEntrySubtreeAfterEdit(arena *nodeArena, entry stackEntry, edit InputEdit, byteDelta, rowDelta int64) {
 	if node := stackEntryNode(entry); node != nil {
-		shiftSubtreeNodeAfterEdit(node, edit, byteDelta, rowDelta, colDelta, nil)
+		shiftSubtreeNodeAfterEdit(node, edit, byteDelta, rowDelta, nil)
 		return
 	}
 	if leaf := stackEntryCompactFullLeaf(entry); leaf != nil {
-		shiftCompactFullLeafAfterEdit(leaf, edit, byteDelta, rowDelta, colDelta)
+		shiftCompactFullLeafAfterEdit(leaf, edit, byteDelta, rowDelta)
 		return
 	}
 	if parent := stackEntryPendingParent(entry); parent != nil {
-		shiftPendingParentAfterEdit(arena, parent, edit, byteDelta, rowDelta, colDelta)
+		shiftPendingParentAfterEdit(arena, parent, edit, byteDelta, rowDelta)
 		return
 	}
 	if noTree := stackEntryNoTreeNode(entry); noTree != nil {
@@ -3935,7 +3943,7 @@ func shiftNoTreeNodeAfterEdit(n *noTreeNode, byteDelta int64) {
 	}
 }
 
-func shiftCompactFullLeafAfterEdit(n *compactFullLeaf, edit InputEdit, byteDelta, rowDelta, colDelta int64) {
+func shiftCompactFullLeafAfterEdit(n *compactFullLeaf, edit InputEdit, byteDelta, rowDelta int64) {
 	if n == nil {
 		return
 	}
@@ -3944,7 +3952,7 @@ func shiftCompactFullLeafAfterEdit(n *compactFullLeaf, edit InputEdit, byteDelta
 	n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
 }
 
-func shiftPendingParentAfterEdit(arena *nodeArena, n *pendingParent, edit InputEdit, byteDelta, rowDelta, colDelta int64) {
+func shiftPendingParentAfterEdit(arena *nodeArena, n *pendingParent, edit InputEdit, byteDelta, rowDelta int64) {
 	if n == nil {
 		return
 	}
@@ -3960,7 +3968,7 @@ func shiftPendingParentAfterEdit(arena *nodeArena, n *pendingParent, edit InputE
 		if perfCountersEnabled {
 			perfRecordNodeEditCompactRef()
 		}
-		shiftStackEntrySubtreeAfterEdit(arena, child, edit, byteDelta, rowDelta, colDelta)
+		shiftStackEntrySubtreeAfterEdit(arena, child, edit, byteDelta, rowDelta)
 	}
 }
 
@@ -3973,7 +3981,11 @@ func shiftPointAfterEdit(p Point, edit InputEdit, rowDelta int64) Point {
 		return p
 	}
 	p.Row = addUint32Delta(p.Row, rowDelta)
-	p.Column = addUint32Delta(edit.NewEndPoint.Column, int64(p.Column)-int64(edit.OldEndPoint.Column))
+	columnDelta := uint32(0)
+	if p.Column >= edit.OldEndPoint.Column {
+		columnDelta = p.Column - edit.OldEndPoint.Column
+	}
+	p.Column = addUint32Delta(edit.NewEndPoint.Column, int64(columnDelta))
 	return p
 }
 

--- a/tree.go
+++ b/tree.go
@@ -3663,19 +3663,8 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 		}
 		n.startByte = addUint32Delta(n.startByte, byteDelta)
 		n.endByte = addUint32Delta(n.endByte, byteDelta)
-		// Shift points approximately (row stays, col shifts if same row).
-		if n.startPoint.Row == edit.OldEndPoint.Row {
-			n.startPoint.Row = addUint32Delta(n.startPoint.Row, rowDelta)
-			if rowDelta == 0 {
-				n.startPoint.Column = addUint32Delta(n.startPoint.Column, colDelta)
-			}
-		}
-		if n.endPoint.Row == edit.OldEndPoint.Row {
-			n.endPoint.Row = addUint32Delta(n.endPoint.Row, rowDelta)
-			if rowDelta == 0 {
-				n.endPoint.Column = addUint32Delta(n.endPoint.Column, colDelta)
-			}
-		}
+		n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
+		n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
 		shiftNodeChildrenAfterEdit(n, edit, byteDelta, rowDelta, colDelta, shiftScratch)
 		return
 	}
@@ -3692,6 +3681,7 @@ func editNodeWithDelta(n *Node, edit InputEdit, byteDelta, rowDelta, colDelta in
 	} else {
 		// Node extends past the edit — adjust end.
 		n.endByte = addUint32Delta(n.endByte, byteDelta)
+		n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
 	}
 
 	// Recurse only into children that can be affected.
@@ -3759,7 +3749,9 @@ func editStackEntryWithDelta(arena *nodeArena, entry stackEntry, edit InputEdit,
 	if stackEntryNodeEndByte(entry) <= edit.OldEndByte {
 		setStackEntryEnd(entry, edit.NewEndByte, edit.NewEndPoint)
 	} else {
-		setStackEntryEndByte(entry, addUint32Delta(stackEntryNodeEndByte(entry), byteDelta))
+		setStackEntryEnd(entry,
+			addUint32Delta(stackEntryNodeEndByte(entry), byteDelta),
+			shiftPointAfterEdit(stackEntryNodeEndPoint(entry), edit, rowDelta))
 	}
 
 	parent := stackEntryPendingParent(entry)
@@ -3881,18 +3873,8 @@ func shiftSubtreeAfterEdit(roots []*Node, edit InputEdit, byteDelta, rowDelta, c
 		n.startByte = addUint32Delta(n.startByte, byteDelta)
 		n.endByte = addUint32Delta(n.endByte, byteDelta)
 
-		if n.startPoint.Row == edit.OldEndPoint.Row {
-			n.startPoint.Row = addUint32Delta(n.startPoint.Row, rowDelta)
-			if rowDelta == 0 {
-				n.startPoint.Column = addUint32Delta(n.startPoint.Column, colDelta)
-			}
-		}
-		if n.endPoint.Row == edit.OldEndPoint.Row {
-			n.endPoint.Row = addUint32Delta(n.endPoint.Row, rowDelta)
-			if rowDelta == 0 {
-				n.endPoint.Column = addUint32Delta(n.endPoint.Column, colDelta)
-			}
-		}
+		n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
+		n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
 
 		if !nodeHasFinalChildRefs(n) {
 			stack = append(stack, n.children...)
@@ -3958,8 +3940,8 @@ func shiftCompactFullLeafAfterEdit(n *compactFullLeaf, edit InputEdit, byteDelta
 		return
 	}
 	shiftNoTreeNodeAfterEdit(&n.noTreeNode, byteDelta)
-	n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta, colDelta)
-	n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta, colDelta)
+	n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
+	n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
 }
 
 func shiftPendingParentAfterEdit(arena *nodeArena, n *pendingParent, edit InputEdit, byteDelta, rowDelta, colDelta int64) {
@@ -3967,8 +3949,8 @@ func shiftPendingParentAfterEdit(arena *nodeArena, n *pendingParent, edit InputE
 		return
 	}
 	shiftNoTreeNodeAfterEdit(&n.noTreeNode, byteDelta)
-	n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta, colDelta)
-	n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta, colDelta)
+	n.startPoint = shiftPointAfterEdit(n.startPoint, edit, rowDelta)
+	n.endPoint = shiftPointAfterEdit(n.endPoint, edit, rowDelta)
 	childCount := n.childEntryCount()
 	for i := 0; i < childCount; i++ {
 		child := n.childEntry(arena, i)
@@ -3982,14 +3964,16 @@ func shiftPendingParentAfterEdit(arena *nodeArena, n *pendingParent, edit InputE
 	}
 }
 
-func shiftPointAfterEdit(p Point, edit InputEdit, rowDelta, colDelta int64) Point {
-	if p.Row != edit.OldEndPoint.Row {
+func shiftPointAfterEdit(p Point, edit InputEdit, rowDelta int64) Point {
+	if p.Row < edit.OldEndPoint.Row {
+		return p
+	}
+	if p.Row > edit.OldEndPoint.Row {
+		p.Row = addUint32Delta(p.Row, rowDelta)
 		return p
 	}
 	p.Row = addUint32Delta(p.Row, rowDelta)
-	if rowDelta == 0 {
-		p.Column = addUint32Delta(p.Column, colDelta)
-	}
+	p.Column = addUint32Delta(edit.NewEndPoint.Column, int64(p.Column)-int64(edit.OldEndPoint.Column))
 	return p
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1015,6 +1015,83 @@ func TestTreeChangedRanges(t *testing.T) {
 	}
 }
 
+func TestTreeEditShiftsPointsAfterMultilineInsertion(t *testing.T) {
+	left := NewLeafNode(Symbol(1), true, 0, 1, Point{Row: 0, Column: 0}, Point{Row: 0, Column: 1})
+	right := NewLeafNode(Symbol(2), true, 2, 3, Point{Row: 1, Column: 0}, Point{Row: 1, Column: 1})
+	root := NewParentNode(Symbol(3), true, []*Node{left, right}, nil, 0)
+	tree := NewTree(root, []byte("a\nb"), testLanguage())
+
+	tree.Edit(InputEdit{
+		StartByte:   1,
+		OldEndByte:  1,
+		NewEndByte:  3,
+		StartPoint:  Point{Row: 0, Column: 1},
+		OldEndPoint: Point{Row: 0, Column: 1},
+		NewEndPoint: Point{Row: 1, Column: 0},
+	})
+
+	if got, want := root.EndPoint(), (Point{Row: 2, Column: 1}); got != want {
+		t.Fatalf("root EndPoint = %+v, want %+v", got, want)
+	}
+	if got, want := right.StartPoint(), (Point{Row: 2, Column: 0}); got != want {
+		t.Fatalf("right StartPoint = %+v, want %+v", got, want)
+	}
+	if got, want := right.EndPoint(), (Point{Row: 2, Column: 1}); got != want {
+		t.Fatalf("right EndPoint = %+v, want %+v", got, want)
+	}
+
+	left = NewLeafNode(Symbol(1), true, 0, 3, Point{Row: 0, Column: 0}, Point{Row: 1, Column: 1})
+	right = NewLeafNode(Symbol(2), true, 3, 4, Point{Row: 1, Column: 1}, Point{Row: 1, Column: 2})
+	last := NewLeafNode(Symbol(3), true, 5, 6, Point{Row: 2, Column: 0}, Point{Row: 2, Column: 1})
+	root = NewParentNode(Symbol(4), true, []*Node{left, right, last}, nil, 0)
+	tree = NewTree(root, []byte("a\nxy\nz"), testLanguage())
+
+	tree.Edit(InputEdit{
+		StartByte:   3,
+		OldEndByte:  3,
+		NewEndByte:  4,
+		StartPoint:  Point{Row: 1, Column: 1},
+		OldEndPoint: Point{Row: 1, Column: 1},
+		NewEndPoint: Point{Row: 2, Column: 0},
+	})
+
+	if got, want := root.EndPoint(), (Point{Row: 3, Column: 1}); got != want {
+		t.Fatalf("multiline root EndPoint = %+v, want %+v", got, want)
+	}
+	if got, want := right.StartPoint(), (Point{Row: 2, Column: 0}); got != want {
+		t.Fatalf("same-row tail StartPoint = %+v, want %+v", got, want)
+	}
+	if got, want := last.StartPoint(), (Point{Row: 3, Column: 0}); got != want {
+		t.Fatalf("later-row tail StartPoint = %+v, want %+v", got, want)
+	}
+}
+
+func TestEditStackEntryShiftsMultilineEndPoint(t *testing.T) {
+	leaf := &compactFullLeaf{
+		noTreeNode: noTreeNode{startByte: 0, endByte: 6},
+		startPoint: Point{Row: 0, Column: 0},
+		endPoint:   Point{Row: 2, Column: 1},
+	}
+	entry := newStackEntryCompactFullLeaf(0, leaf)
+	edit := InputEdit{
+		StartByte:   3,
+		OldEndByte:  3,
+		NewEndByte:  4,
+		StartPoint:  Point{Row: 1, Column: 1},
+		OldEndPoint: Point{Row: 1, Column: 1},
+		NewEndPoint: Point{Row: 2, Column: 0},
+	}
+	var scratch []*Node
+	editStackEntryWithDelta(nil, entry, edit, 1, 1, -1, true, &scratch, nil)
+
+	if got, want := stackEntryNodeEndByte(entry), uint32(7); got != want {
+		t.Fatalf("compact entry EndByte = %d, want %d", got, want)
+	}
+	if got, want := stackEntryNodeEndPoint(entry), (Point{Row: 3, Column: 1}); got != want {
+		t.Fatalf("compact entry EndPoint = %+v, want %+v", got, want)
+	}
+}
+
 func TestNodeEditFromSubnodeMutatesContainingRoot(t *testing.T) {
 	left := NewLeafNode(Symbol(1), true, 0, 3, Point{Row: 0, Column: 0}, Point{Row: 0, Column: 3})
 	right := NewLeafNode(Symbol(2), true, 3, 6, Point{Row: 0, Column: 3}, Point{Row: 0, Column: 6})

--- a/tree_test.go
+++ b/tree_test.go
@@ -1082,13 +1082,129 @@ func TestEditStackEntryShiftsMultilineEndPoint(t *testing.T) {
 		NewEndPoint: Point{Row: 2, Column: 0},
 	}
 	var scratch []*Node
-	editStackEntryWithDelta(nil, entry, edit, 1, 1, -1, true, &scratch, nil)
+	editStackEntryWithDelta(nil, entry, edit, 1, 1, true, &scratch, nil)
 
 	if got, want := stackEntryNodeEndByte(entry), uint32(7); got != want {
 		t.Fatalf("compact entry EndByte = %d, want %d", got, want)
 	}
 	if got, want := stackEntryNodeEndPoint(entry), (Point{Row: 3, Column: 1}); got != want {
 		t.Fatalf("compact entry EndPoint = %+v, want %+v", got, want)
+	}
+}
+
+func TestTreeEditMatchesCMultilineDeletionAndReplacement(t *testing.T) {
+	tests := []struct {
+		name                  string
+		edit                  InputEdit
+		wantRootEnd           Point
+		wantInsidePoint       Point
+		wantTrailingStart     Point
+		wantTrailingEnd       Point
+		wantRootEndByte       uint32
+		wantInsideByte        uint32
+		wantTrailingStartByte uint32
+	}{
+		{
+			name: "deletion",
+			edit: InputEdit{
+				StartByte: 10, OldEndByte: 20, NewEndByte: 10,
+				StartPoint: Point{Row: 1, Column: 2}, OldEndPoint: Point{Row: 3, Column: 5}, NewEndPoint: Point{Row: 1, Column: 2},
+			},
+			wantRootEnd: Point{Row: 2, Column: 2}, wantInsidePoint: Point{Row: 1, Column: 2},
+			wantTrailingStart: Point{Row: 1, Column: 4}, wantTrailingEnd: Point{Row: 2, Column: 2},
+			wantRootEndByte: 14, wantInsideByte: 10, wantTrailingStartByte: 12,
+		},
+		{
+			name: "replacement",
+			edit: InputEdit{
+				StartByte: 10, OldEndByte: 20, NewEndByte: 25,
+				StartPoint: Point{Row: 1, Column: 2}, OldEndPoint: Point{Row: 3, Column: 5}, NewEndPoint: Point{Row: 2, Column: 4},
+			},
+			wantRootEnd: Point{Row: 3, Column: 2}, wantInsidePoint: Point{Row: 2, Column: 4},
+			wantTrailingStart: Point{Row: 2, Column: 6}, wantTrailingEnd: Point{Row: 3, Column: 2},
+			wantRootEndByte: 29, wantInsideByte: 25, wantTrailingStartByte: 27,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inside := NewLeafNode(Symbol(1), true, 12, 18, Point{Row: 1, Column: 4}, Point{Row: 3, Column: 3})
+			trailing := NewLeafNode(Symbol(2), true, 22, 24, Point{Row: 3, Column: 7}, Point{Row: 4, Column: 2})
+			root := NewParentNode(Symbol(3), true, []*Node{inside, trailing}, nil, 0)
+			root.startByte, root.endByte = 0, 24
+			root.startPoint, root.endPoint = Point{}, (Point{Row: 4, Column: 2})
+			tree := NewTree(root, make([]byte, 24), testLanguage())
+
+			tree.Edit(tc.edit)
+
+			if got := root.EndByte(); got != tc.wantRootEndByte {
+				t.Fatalf("root EndByte = %d, want %d", got, tc.wantRootEndByte)
+			}
+			if got := root.EndPoint(); got != tc.wantRootEnd {
+				t.Fatalf("root EndPoint = %+v, want %+v", got, tc.wantRootEnd)
+			}
+			if got := inside.StartByte(); got != tc.wantInsideByte {
+				t.Fatalf("inside StartByte = %d, want %d", got, tc.wantInsideByte)
+			}
+			if got := inside.EndByte(); got != tc.wantInsideByte {
+				t.Fatalf("inside EndByte = %d, want %d", got, tc.wantInsideByte)
+			}
+			if got := inside.StartPoint(); got != tc.wantInsidePoint {
+				t.Fatalf("inside StartPoint = %+v, want %+v", got, tc.wantInsidePoint)
+			}
+			if got := inside.EndPoint(); got != tc.wantInsidePoint {
+				t.Fatalf("inside EndPoint = %+v, want %+v", got, tc.wantInsidePoint)
+			}
+			if got := trailing.StartByte(); got != tc.wantTrailingStartByte {
+				t.Fatalf("trailing StartByte = %d, want %d", got, tc.wantTrailingStartByte)
+			}
+			if got := trailing.StartPoint(); got != tc.wantTrailingStart {
+				t.Fatalf("trailing StartPoint = %+v, want %+v", got, tc.wantTrailingStart)
+			}
+			if got := trailing.EndPoint(); got != tc.wantTrailingEnd {
+				t.Fatalf("trailing EndPoint = %+v, want %+v", got, tc.wantTrailingEnd)
+			}
+		})
+	}
+}
+
+func TestEditPendingParentAndChildrenMatchesCMultilineCoordinates(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	inside := newCompactFullLeafInArena(arena, 1, true, 12, 18, Point{Row: 1, Column: 4}, Point{Row: 3, Column: 3})
+	trailing := newCompactFullLeafInArena(arena, 2, true, 22, 24, Point{Row: 3, Column: 7}, Point{Row: 4, Column: 2})
+	parent := newPendingParentInArena(arena, 3, true, 0, []stackEntry{
+		newStackEntryCompactFullLeaf(1, inside),
+		newStackEntryCompactFullLeaf(2, trailing),
+	}, 12, 24, Point{Row: 1, Column: 4}, Point{Row: 4, Column: 2}, false)
+	entry := newStackEntryPendingParent(3, parent)
+	edit := InputEdit{
+		StartByte: 10, OldEndByte: 20, NewEndByte: 25,
+		StartPoint: Point{Row: 1, Column: 2}, OldEndPoint: Point{Row: 3, Column: 5}, NewEndPoint: Point{Row: 2, Column: 4},
+	}
+	var scratch []*Node
+
+	editStackEntryWithDelta(arena, entry, edit, 5, -1, true, &scratch, nil)
+
+	if got, want := parent.startByte, uint32(25); got != want {
+		t.Fatalf("parent startByte = %d, want %d", got, want)
+	}
+	if got, want := parent.startPoint, (Point{Row: 2, Column: 4}); got != want {
+		t.Fatalf("parent startPoint = %+v, want %+v", got, want)
+	}
+	if got, want := parent.endPoint, (Point{Row: 3, Column: 2}); got != want {
+		t.Fatalf("parent endPoint = %+v, want %+v", got, want)
+	}
+	if got, want := inside.startPoint, (Point{Row: 2, Column: 4}); got != want {
+		t.Fatalf("inside startPoint = %+v, want %+v", got, want)
+	}
+	if got, want := inside.endPoint, (Point{Row: 2, Column: 4}); got != want {
+		t.Fatalf("inside endPoint = %+v, want %+v", got, want)
+	}
+	if got, want := trailing.startPoint, (Point{Row: 2, Column: 6}); got != want {
+		t.Fatalf("trailing startPoint = %+v, want %+v", got, want)
+	}
+	if got, want := trailing.endPoint, (Point{Row: 3, Column: 2}); got != want {
+		t.Fatalf("trailing endPoint = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Correct point coordinates after edits that add or remove lines.
- Cover normal, compact, same-line-tail, and later-row node paths.

## Root cause

Tree editing shifted bytes but only adjusted points on the edited row. Nodes on later rows and overlapping compact entries retained stale coordinates.

## Validation

- `go vet .`
- `go test . -run '^(TestTreeEditShiftsPointsAfterMultilineInsertion|TestEditStackEntryShiftsMultilineEndPoint|TestTreeChangedRanges|TestTreeCopyIndependentNodes|TestNodeEditFromSubnodeMutatesContainingRoot|TestNodeEditDetachedNode)$' -count=1`
- `go test . -run '^(TestParseIncremental|TestParseIncrementalReusesUnchangedLeaf|TestParseIncrementalReusesRootWhenUnchanged|TestParseIncrementalReusesRootAfterUndo|TestParseIncrementalReleaseKeepsBorrowedNodesAlive)$' -count=1`
