### PR TITLE
perf(harness): compare locked parser work

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -185,6 +185,94 @@ stack and no forks or merges; the real file reached 12 stacks, 1,765 forks,
 workload-regime defect, not the final C ratio. Report SHA-256:
 `c6de42e12724f72393162a0a50ecb8247f97312eaaff6cb5b093746b1206b4ab`.
 
+### Authenticated work-count diagnostic harness
+
+Wall time alone cannot distinguish excess GLR work from higher cost per event.
+The diagnostic-only `gts-work-count/v2` contract therefore runs one fresh
+public `query_compile.go` parse invocation through a tagged diagnostic Go test
+binary and a fully static C binary built from the same locked runtime and
+grammar as the publication oracle. The tagged parse is diagnostic, not a
+production-path claim. It is not a timing lane, does not modify the production
+static timing artifact, and emits no elapsed time. Every internal Go retry or
+recovery reparse triggered by that single public invocation remains inside the
+counter window.
+
+Admission happens before instrumentation: a separate ordinary untagged Go
+binary and the unmodified static C oracle must both reproduce the frozen
+`gts-deep-tree-v1` digest. The tagged Go child independently authenticates the
+fixture hash, grammar commit/blob, GLR workload regime, full clean span, and
+deep tree before reporting counters. The C child must reproduce the same tree.
+The complete unmodified-C cold build and admission runs in a dedicated,
+wall-bounded process group, so repository acquisition, compiler/linker,
+identity, `nm`, and `readelf` descendants are killed together on timeout.
+
+The Go schema attributes counter deltas to every `parseInternal` attempt at
+entry, after cap resolution, and during finalization. A logical retry rung is
+reported separately from the resolved `retry_pass` mode. The aggregate must
+equal the sum of attempt counters plus the explicitly reported outside-attempt
+residual. On the frozen canonical fixture, `accept_actions=3` means three GLR
+accept actions inside one `initial_full` attempt; it does not mean three parse
+attempts. A content-addressed valid-Go retry witness pins the two-attempt
+`initial_full` accepted-error to `initial_merge` accepted-clean sequence, and a
+separate content-addressed straight-LR control pins the one-stack case.
+
+`accept_actions` is a terminal-event counter, not a convergence counter. C can
+accept once and then emit multiple packed roots during `pop_all`, while Go can
+apply multiple accept actions inside one attempt. Contract v2 therefore
+reserves, but does not yet implement, a bounded convergence-frontier record:
+the first 256 events plus the first rejection for each reason, keyed by
+attempt, lookahead, phase, head state/byte/status/error/scanner identity, with
+before/after links and packed paths, cumulative counters, and separate
+`accept_actions` and `packed_roots_emitted`. No current receipt makes a
+convergence claim from the accept-action row.
+
+An authoritative `gts-work-count-receipt/v3` requires a clean Git checkout and
+records `HEAD`, `HEAD^{tree}`, and `git_clean=true`. Both Go binaries compile
+from one sealed content-addressed Git source snapshot. C compiles from private
+snapshots of the runtime, grammar, patch, and driver. Ambient `GOT_*`,
+`GOFLAGS`, `GOAMD64`, `GOEXPERIMENT`, and `GODEBUG` values are removed and the
+chosen build/runtime environments are serialized. Build, patch, link, and
+child process groups are wall-bounded. A stale receipt is removed before work
+starts, and a successful receipt is published atomically in its destination
+directory.
+
+Directly comparable counters are limited to applied shift/reduce/recover
+actions, reduction pop requests and emitted paths/payloads, and the selected
+tree census. Accept actions are reported as terminal evidence but require the
+future packed-root/convergence record for interpretation. Table
+lookups, lexer calls, stack versions, merges, graph links, and transient
+payload construction remain explicitly labeled representation-specific
+proxies.
+
+Run the focused Docker gate from a linked worktree by mounting its absolute
+Git common directory and selecting the worktree-specific Git directory inside
+the container:
+
+```sh
+git_common=$(git rev-parse --path-format=absolute --git-common-dir)
+git_dir_name=$(basename "$(git rev-parse --path-format=absolute --git-dir)")
+bash cgo_harness/docker/run_parity_in_docker.sh \
+  --label work-count-query-compile --memory 8g --cpus 2 --timeout 12m \
+  --mount "$git_common:/git-common:ro" -- \
+  "export GIT_DIR=/git-common/worktrees/$git_dir_name GIT_WORK_TREE=/workspace; \
+   cd /workspace/cgo_harness && env \
+   GTS_WORK_COUNT_ORACLE=1 \
+   GTS_WORK_COUNT_RECEIPT=/workspace/harness_out/work_count/query_compile.json \
+   go test . -tags 'treesitter_c_parity treesitter_c_perfscan' \
+   -run '^TestAuthenticatedWorkCountOracle$|^TestWorkCountSanitizedEnvDropsParserAndGoOverrides$|^TestWorkCountRunCapturedKillsDescendantProcessGroup$|^TestStaticCLanguageSymbol' \
+   -count=1 -parallel 1 -timeout 12m -v"
+```
+
+The checkout must expose usable Git metadata inside the container. Dirty
+source fails closed. `GTS_WORK_COUNT_ALLOW_DIRTY=1` exists only for focused
+pre-commit harness tests; its receipt records `authoritative=false` and cannot
+enter the evidence ledger.
+The checked-in semantic contract is
+[`cgo_harness/work_count/contract_v2.json`](cgo_harness/work_count/contract_v2.json).
+`construction_surplus` means representation-specific leaf plus parent
+constructions minus selected nodes; it must never be relabeled as a count of
+discarded nodes.
+
 ## Go-vs-C fleet scoreboard (full parse, real corpora)
 
 Source of truth: [`cgo_harness/perf_scan/perf_ratio_budgets.json`](cgo_harness/perf_scan/perf_ratio_budgets.json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ for tags and release notes while still in `0.x`.
 
 ### Tooling
 
+- Add a diagnostic-only, authenticated Go/static-C GLR work-count contract for
+  the locked real-Go `query_compile` fixture. A separate ordinary untagged Go
+  child performs admission before tagged Go and fully static C diagnostic
+  children report saturating direct action/pop/selected-tree counters and
+  explicitly labeled representation proxies. Go counters attribute each
+  `parseInternal` attempt to a logical retry rung, resolved cap mode, parser
+  loop, and finalization; `accept_actions` is explicitly an action count, and
+  aggregate counters must equal attempts plus the outside-attempt residual.
+  Frozen retry-active and straight-LR witnesses pin the attribution semantics;
+  the contract reserves a bounded convergence-frontier schema and distinguishes
+  accept actions from packed roots without claiming that instrumentation yet.
+  Authoritative receipts require a clean Git source identity; compile from
+  sealed private Go and C input snapshots; bind sanitized build/runtime
+  environments; independently verify fixture, grammar, GLR-regime, span, and
+  deep-tree identities; contain the complete cold static-C admission plus all
+  repository, compiler, linker, identity, and linkage-verifier descendants in
+  wall-bounded process groups; and publish atomically only after all rechecks
+  pass.
+- The static C oracle now recognizes locked grammar entry points declared with
+  either C's empty `()` or `(void)` parameter spelling, restoring artifact
+  construction for SCSS while rejecting genuinely parameterized near misses.
 - The authenticated fleet scoreboard now times fresh full parses against a
   per-language, fully static executable built from the locked upstream runtime
   and grammar sources. Every selected file requires matching static/cgo deep

--- a/cgo_harness/pure_c/work_count_oracle.c
+++ b/cgo_harness/pure_c/work_count_oracle.c
@@ -1,0 +1,241 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "api.h"
+#include "work_count.h"
+
+#ifndef TS_LANG_FN
+#error "TS_LANG_FN macro is required"
+#endif
+
+extern const TSLanguage *TS_LANG_FN(void);
+
+static char *read_source(const char *path, size_t *out_len) {
+  FILE *file = fopen(path, "rb");
+  if (!file || fseek(file, 0, SEEK_END) != 0) {
+    if (file) fclose(file);
+    return NULL;
+  }
+  long end = ftell(file);
+  if (end < 0 || fseek(file, 0, SEEK_SET) != 0) {
+    fclose(file);
+    return NULL;
+  }
+  char *buf = malloc((size_t)end + 1u);
+  if (!buf) {
+    fclose(file);
+    return NULL;
+  }
+  size_t n = fread(buf, 1u, (size_t)end, file);
+  if (n != (size_t)end || ferror(file)) {
+    free(buf);
+    fclose(file);
+    return NULL;
+  }
+  fclose(file);
+  buf[n] = '\0';
+  *out_len = n;
+  return buf;
+}
+
+static bool tree_complete(TSTree *tree, uint32_t source_len) {
+  if (!tree) return false;
+  TSNode root = ts_tree_root_node(tree);
+  return !ts_node_is_null(root) && ts_node_end_byte(root) == source_len;
+}
+
+static bool write_u32(FILE *file, uint32_t value) {
+  unsigned char bytes[4] = {
+      (unsigned char)value, (unsigned char)(value >> 8),
+      (unsigned char)(value >> 16), (unsigned char)(value >> 24)};
+  return fwrite(bytes, 1u, sizeof(bytes), file) == sizeof(bytes);
+}
+
+static bool write_string(FILE *file, const char *value) {
+  uint32_t len = value ? (uint32_t)strlen(value) : 0u;
+  return write_u32(file, len) &&
+         (len == 0 || fwrite(value, 1u, len, file) == len);
+}
+
+static bool write_node_header(FILE *file, TSNode node, const char *field_name) {
+  uint32_t child_count = ts_node_child_count(node);
+  gts_work_count_add(&gts_work_count_current.selected_nodes, 1);
+  if (child_count == 0) {
+    gts_work_count_add(&gts_work_count_current.selected_leaf_nodes, 1);
+  } else {
+    gts_work_count_add(&gts_work_count_current.selected_parent_nodes, 1);
+  }
+
+  if (!write_string(file, ts_node_type(node)) ||
+      !write_string(file, field_name) ||
+      !write_u32(file, ts_node_start_byte(node)) ||
+      !write_u32(file, ts_node_end_byte(node))) {
+    return false;
+  }
+  TSPoint start = ts_node_start_point(node);
+  TSPoint end = ts_node_end_point(node);
+  if (!write_u32(file, start.row) || !write_u32(file, start.column) ||
+      !write_u32(file, end.row) || !write_u32(file, end.column)) {
+    return false;
+  }
+  unsigned char flags = 0u;
+  if (ts_node_is_named(node)) flags |= 1u << 0;
+  if (ts_node_is_extra(node)) flags |= 1u << 1;
+  if (ts_node_is_missing(node)) flags |= 1u << 2;
+  if (ts_node_is_error(node)) flags |= 1u << 3;
+  if (ts_node_has_error(node)) flags |= 1u << 4;
+  return fwrite(&flags, 1u, 1u, file) == 1u &&
+         write_u32(file, child_count);
+}
+
+static bool write_tree(FILE *file, TSNode root) {
+  static const unsigned char magic[] = "gts-deep-tree-v1";
+  if (fwrite(magic, 1u, sizeof(magic), file) != sizeof(magic) ||
+      !write_node_header(file, root, NULL)) {
+    return false;
+  }
+  TSTreeCursor cursor = ts_tree_cursor_new(root);
+  for (;;) {
+    if (ts_tree_cursor_goto_first_child(&cursor)) {
+      if (!write_node_header(file, ts_tree_cursor_current_node(&cursor),
+                             ts_tree_cursor_current_field_name(&cursor))) {
+        ts_tree_cursor_delete(&cursor);
+        return false;
+      }
+      continue;
+    }
+    while (!ts_tree_cursor_goto_next_sibling(&cursor)) {
+      if (!ts_tree_cursor_goto_parent(&cursor)) {
+        ts_tree_cursor_delete(&cursor);
+        return !ferror(file);
+      }
+    }
+    if (!write_node_header(file, ts_tree_cursor_current_node(&cursor),
+                           ts_tree_cursor_current_field_name(&cursor))) {
+      ts_tree_cursor_delete(&cursor);
+      return false;
+    }
+  }
+}
+
+static unsigned long long parse_timeout(const char *raw) {
+  char *end = NULL;
+  unsigned long long value = strtoull(raw, &end, 10);
+  if (!raw[0] || (end && *end)) return 0;
+  return value;
+}
+
+static void print_counts(GTSWorkCount c, uint32_t source_len,
+                         uint32_t root_end_byte, bool root_has_error) {
+  printf("{\n");
+  printf("  \"schema\": \"gts-work-count-c-child/v3\",\n");
+  printf("  \"engine\": \"static-c-instrumented-glr\",\n");
+  printf("  \"digest_format\": \"gts-deep-tree-v1\",\n");
+  printf("  \"source_bytes\": %u,\n", source_len);
+  printf("  \"root_end_byte\": %u,\n", root_end_byte);
+  printf("  \"root_has_error\": %s,\n", root_has_error ? "true" : "false");
+  printf("  \"counters\": {\n");
+  printf("    \"contract\": \"gts-work-count/v2\",\n");
+  printf("    \"overflow\": %s,\n", c.overflow ? "true" : "false");
+#define PRINT_COUNT(field) \
+  printf("    \"" #field "\": %llu,\n", (unsigned long long)c.field)
+  PRINT_COUNT(shifts);
+  PRINT_COUNT(reductions);
+  PRINT_COUNT(accept_actions);
+  PRINT_COUNT(explicit_recover_actions);
+  PRINT_COUNT(reduction_pop_requests);
+  PRINT_COUNT(emitted_pop_paths);
+  PRINT_COUNT(emitted_pop_payloads);
+  PRINT_COUNT(selected_nodes);
+  PRINT_COUNT(selected_parent_nodes);
+  PRINT_COUNT(selected_leaf_nodes);
+  PRINT_COUNT(table_lookups_proxy);
+  PRINT_COUNT(action_entries_examined_proxy);
+  PRINT_COUNT(lexer_front_door_calls_proxy);
+  PRINT_COUNT(stack_version_creations_proxy);
+  PRINT_COUNT(merge_attempts_proxy);
+  PRINT_COUNT(merge_successes_proxy);
+  PRINT_COUNT(graph_link_additions_proxy);
+  PRINT_COUNT(leaf_constructions_proxy);
+  PRINT_COUNT(parent_constructions_proxy);
+  PRINT_COUNT(pending_parent_constructions_proxy);
+#undef PRINT_COUNT
+  printf("    \"no_tree_parent_constructions_proxy\": %llu\n",
+         (unsigned long long)c.no_tree_parent_constructions_proxy);
+  printf("  }\n");
+  printf("}\n");
+}
+
+int main(int argc, char **argv) {
+  if (argc != 4) {
+    fputs("status=c_protocol_error\n", stderr);
+    fprintf(stderr, "usage: %s <source> <digest-dump> <timeout-us>\n", argv[0]);
+    return 2;
+  }
+
+  size_t source_len = 0;
+  char *source = read_source(argv[1], &source_len);
+  if (!source || source_len > UINT32_MAX) {
+    fputs("status=c_transport_error\n", stderr);
+    free(source);
+    return 3;
+  }
+  unsigned long long timeout_us = parse_timeout(argv[3]);
+  if (timeout_us == 0) {
+    fputs("status=c_protocol_error\n", stderr);
+    free(source);
+    return 2;
+  }
+
+  TSParser *parser = ts_parser_new();
+  if (!parser || !ts_parser_set_language(parser, TS_LANG_FN())) {
+    fputs("status=c_parser_error\n", stderr);
+    if (parser) ts_parser_delete(parser);
+    free(source);
+    return 4;
+  }
+  ts_parser_set_timeout_micros(parser, timeout_us);
+
+  gts_work_count_reset();
+  TSTree *tree = ts_parser_parse_string(parser, NULL, source, (uint32_t)source_len);
+  if (!tree) {
+    fputs("status=c_timeout\n", stderr);
+    ts_parser_delete(parser);
+    free(source);
+    return 10;
+  }
+  if (!tree_complete(tree, (uint32_t)source_len)) {
+    fputs("status=c_incomplete\n", stderr);
+    ts_tree_delete(tree);
+    ts_parser_delete(parser);
+    free(source);
+    return 11;
+  }
+
+  TSNode root = ts_tree_root_node(tree);
+  FILE *dump = fopen(argv[2], "wb");
+  bool dump_ok = false;
+  if (dump) {
+    dump_ok = write_tree(dump, root);
+    if (fclose(dump) != 0) dump_ok = false;
+    dump = NULL;
+  }
+  if (!dump_ok) {
+    fputs("status=c_digest_error\n", stderr);
+    ts_tree_delete(tree);
+    ts_parser_delete(parser);
+    free(source);
+    return 5;
+  }
+  GTSWorkCount counts = gts_work_count_snapshot();
+  print_counts(counts, (uint32_t)source_len, ts_node_end_byte(root),
+               ts_node_has_error(root));
+
+  ts_tree_delete(tree);
+  ts_parser_delete(parser);
+  free(source);
+  return ferror(stdout) ? 6 : 0;
+}

--- a/cgo_harness/static_c_language_symbol_test.go
+++ b/cgo_harness/static_c_language_symbol_test.go
@@ -1,0 +1,110 @@
+//go:build cgo && treesitter_c_parity && treesitter_c_perfscan
+
+package cgoharness
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStaticCLanguageSymbolAcceptsVoidAndEmptyParameterLists(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		entry  parityLockEntry
+		source string
+		want   string
+	}{
+		{
+			name:   "void",
+			entry:  parityLockEntry{Name: "go", RepoURL: "https://github.com/tree-sitter/tree-sitter-go"},
+			source: "const TSLanguage *tree_sitter_go(void) { return 0; }\n",
+			want:   "tree_sitter_go",
+		},
+		{
+			name:   "empty_with_export_macro",
+			entry:  parityLockEntry{Name: "scss", RepoURL: "https://github.com/serenadeai/tree-sitter-scss"},
+			source: "TS_PUBLIC const TSLanguage *tree_sitter_scss() { return 0; }\n",
+			want:   "tree_sitter_scss",
+		},
+		{
+			name:   "whitespace",
+			entry:  parityLockEntry{Name: "scss", RepoURL: "https://github.com/serenadeai/tree-sitter-scss"},
+			source: "TS_PUBLIC const TSLanguage * tree_sitter_scss(  void  ) { return 0; }\n",
+			want:   "tree_sitter_scss",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "parser.c")
+			if err := os.WriteFile(path, []byte(tc.source), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, err := staticCLanguageSymbol(tc.entry, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("symbol=%q want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStaticCLanguageSymbolRejectsParameterizedNearMisses(t *testing.T) {
+	entry := parityLockEntry{Name: "scss", RepoURL: "https://github.com/serenadeai/tree-sitter-scss"}
+	for _, params := range []string{"int state", "void *payload", "void, int"} {
+		t.Run(strings.NewReplacer(" ", "_", "*", "ptr", ",", "comma").Replace(params), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "parser.c")
+			source := "TS_PUBLIC const TSLanguage *tree_sitter_scss(" + params + ") { return 0; }\n"
+			if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got, err := staticCLanguageSymbol(entry, path); err == nil {
+				t.Fatalf("near-miss parameter list admitted as %q", got)
+			}
+		})
+	}
+}
+
+func TestStaticCLanguageSymbolRejectsNonDefinitions(t *testing.T) {
+	entry := parityLockEntry{Name: "scss", RepoURL: "https://github.com/serenadeai/tree-sitter-scss"}
+	for _, tc := range []struct {
+		name   string
+		source string
+	}{
+		{name: "prototype", source: "TS_PUBLIC const TSLanguage *tree_sitter_scss();\n"},
+		{name: "void_prototype", source: "const TSLanguage *tree_sitter_scss(void);\n"},
+		{name: "line_comment", source: "// const TSLanguage *tree_sitter_scss() { return 0; }\n"},
+		{name: "block_comment", source: "/* const TSLanguage *tree_sitter_scss(void) { return 0; } */\n"},
+		{name: "string", source: "const char *s = \"const TSLanguage *tree_sitter_scss() {\";\n"},
+		{name: "character_noise", source: "char c = '}'; /* tree_sitter_scss */\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "parser.c")
+			if err := os.WriteFile(path, []byte(tc.source), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got, err := staticCLanguageSymbol(entry, path); err == nil {
+				t.Fatalf("non-definition admitted as %q", got)
+			}
+		})
+	}
+}
+
+func TestStaticCLanguageSymbolIgnoresFalseDefinitionBeforeRealOne(t *testing.T) {
+	entry := parityLockEntry{Name: "scss", RepoURL: "https://github.com/serenadeai/tree-sitter-scss"}
+	path := filepath.Join(t.TempDir(), "parser.c")
+	source := "/* const TSLanguage *tree_sitter_fake() { } */\n" +
+		"TS_PUBLIC const TSLanguage *tree_sitter_scss() { return 0; }\n"
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := staticCLanguageSymbol(entry, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "tree_sitter_scss" {
+		t.Fatalf("symbol=%q want tree_sitter_scss", got)
+	}
+}

--- a/cgo_harness/static_c_perf_oracle_test.go
+++ b/cgo_harness/static_c_perf_oracle_test.go
@@ -869,7 +869,7 @@ func staticCFirstFor(language string, fileIndex int) bool {
 	return (int(sum[0]&1)+fileIndex)%2 == 1
 }
 
-var staticLanguageSymbolPattern = regexp.MustCompile(`(?m)const\s+TSLanguage\s*\*\s*(tree_sitter_[A-Za-z0-9_]+)\s*\(void\)`)
+var staticLanguageSymbolPattern = regexp.MustCompile(`(?m)const\s+TSLanguage\s*\*\s*(tree_sitter_[A-Za-z0-9_]+)\s*\(\s*(?:void\s*)?\)\s*\{`)
 
 func buildStaticCPerfOracle(language string) (*staticCPerfOracle, error) {
 	lockPath, err := findParityLockPath()
@@ -1099,7 +1099,7 @@ func staticCLanguageSymbol(entry parityLockEntry, parserPath string) (string, er
 		return "", err
 	}
 	found := make(map[string]bool)
-	for _, match := range staticLanguageSymbolPattern.FindAllSubmatch(data, -1) {
+	for _, match := range staticLanguageSymbolPattern.FindAllSubmatch(staticCCodeOnly(data), -1) {
 		found[string(match[1])] = true
 	}
 	for _, candidate := range parityLanguageSymbols(entry) {
@@ -1118,6 +1118,83 @@ func staticCLanguageSymbol(entry parityLockEntry, parserPath string) (string, er
 	}
 	sort.Strings(symbols)
 	return "", fmt.Errorf("%s: cannot select language symbol from %v", entry.Name, symbols)
+}
+
+// staticCCodeOnly preserves C token boundaries while blanking comments and
+// string/character literals. Language entry-point discovery must never accept
+// a prototype or text that merely mentions a definition-shaped signature.
+func staticCCodeOnly(source []byte) []byte {
+	out := append([]byte(nil), source...)
+	const (
+		code = iota
+		lineComment
+		blockComment
+		stringLiteral
+		charLiteral
+	)
+	state := code
+	escaped := false
+	for i := 0; i < len(out); i++ {
+		current := out[i]
+		next := byte(0)
+		if i+1 < len(out) {
+			next = out[i+1]
+		}
+		switch state {
+		case code:
+			switch {
+			case current == '/' && next == '/':
+				out[i], out[i+1] = ' ', ' '
+				i++
+				state = lineComment
+			case current == '/' && next == '*':
+				out[i], out[i+1] = ' ', ' '
+				i++
+				state = blockComment
+			case current == '"':
+				out[i] = ' '
+				state = stringLiteral
+				escaped = false
+			case current == '\'':
+				out[i] = ' '
+				state = charLiteral
+				escaped = false
+			}
+		case lineComment:
+			if current == '\n' {
+				state = code
+			} else {
+				out[i] = ' '
+			}
+		case blockComment:
+			if current == '*' && next == '/' {
+				out[i], out[i+1] = ' ', ' '
+				i++
+				state = code
+			} else if current != '\n' {
+				out[i] = ' '
+			}
+		case stringLiteral, charLiteral:
+			quote := byte('"')
+			if state == charLiteral {
+				quote = '\''
+			}
+			if current == '\n' {
+				state = code
+				escaped = false
+				continue
+			}
+			out[i] = ' '
+			if escaped {
+				escaped = false
+			} else if current == '\\' {
+				escaped = true
+			} else if current == quote {
+				state = code
+			}
+		}
+	}
+	return out
 }
 
 func staticCScannerSources(srcDir string) []string {

--- a/cgo_harness/work_count/contract_v2.json
+++ b/cgo_harness/work_count/contract_v2.json
@@ -1,0 +1,127 @@
+{
+  "schema": "gts-work-count-contract/v2",
+  "counter_contract": "gts-work-count/v2",
+  "scope": "one fresh public full-parse invocation in one tagged diagnostic child process; all internal parseInternal attempts and retry/reparse work are counted and attributed; no elapsed-time evidence",
+  "direct": {
+    "shifts": "shift actions applied",
+    "reductions": "reduce actions applied",
+    "explicit_recover_actions": "explicit recover parse actions applied",
+    "reduction_pop_requests": "pop-count requests issued by reduce actions",
+    "emitted_pop_paths": "concrete pop paths emitted by a pop-count request",
+    "emitted_pop_payloads": "payload entries carried by emitted pop paths",
+    "selected_nodes": "nodes in the selected returned tree",
+    "selected_parent_nodes": "selected returned-tree nodes with children",
+    "selected_leaf_nodes": "selected returned-tree nodes without children"
+  },
+  "terminal": {
+    "accept_actions": "terminal accept actions applied; multiple actions may occur inside one parseInternal attempt, and this count alone does not measure convergence or packed roots emitted"
+  },
+  "proxy": {
+    "table_lookups_proxy": "implementation-specific parse-table lookup front-door calls",
+    "action_entries_examined_proxy": "implementation-specific action entries exposed at instrumented dispatch lookups",
+    "lexer_front_door_calls_proxy": "implementation-specific production lexer front-door calls",
+    "stack_version_creations_proxy": "implementation-specific initial-stack and clone/version creation events",
+    "merge_attempts_proxy": "implementation-specific merge front-door candidate calls",
+    "merge_successes_proxy": "implementation-specific successful merge front-door calls",
+    "graph_link_additions_proxy": "implementation-specific physical primary or alternate stack-graph links added",
+    "leaf_constructions_proxy": "representation-specific transient leaf payload constructions",
+    "parent_constructions_proxy": "representation-specific transient parent payload constructions",
+    "pending_parent_constructions_proxy": "Go-only pending-parent subset; always zero in C",
+    "no_tree_parent_constructions_proxy": "Go-only no-tree parent subset; always zero in C"
+  },
+  "derived": {
+    "construction_surplus": "leaf_constructions_proxy + parent_constructions_proxy - selected_nodes; never described as discarded nodes"
+  },
+  "attempt_attribution": {
+    "logical_rungs": [
+      "initial_full",
+      "initial_merge",
+      "clean_wide",
+      "clean_wide_merge",
+      "recovery_wide_or_node",
+      "secondary_node",
+      "final_merge"
+    ],
+    "resolved_retry_pass_is_independent": true,
+    "phases": [
+      "entry_to_caps",
+      "caps_to_finalize",
+      "finalize"
+    ],
+    "require_aggregate_equals_attempts_plus_outside": true,
+    "canonical_query_compile_attempts": 1,
+    "canonical_query_compile_accept_actions": 3,
+    "retry_witness": {
+      "path": "testdata/work_count/retry_go_query_kotlin_regression.go",
+      "bytes": 3435,
+      "sha256": "ada50bc6eef16b831e7ca0c44f11dffbcff7d9695515519cd5090b2aacf4789a",
+      "expected_rungs": [
+        "initial_full",
+        "initial_merge"
+      ]
+    },
+    "straight_lr_control": {
+      "path": "testdata/work_count/straight_lr_control.go",
+      "bytes": 154,
+      "sha256": "4c584e187fdd4fb62dbf3953ca771e868bd3037e44abe5349c1cc0b3faf6532b",
+      "expected_max_stacks": 1
+    }
+  },
+  "convergence_frontier": {
+    "status": "schema_reserved_not_implemented",
+    "max_events": 256,
+    "record_first_reject_per_reason": true,
+    "identity": [
+      "attempt",
+      "lookahead",
+      "phase",
+      "head_state",
+      "head_byte",
+      "head_status",
+      "head_error",
+      "head_scanner"
+    ],
+    "outcomes": [
+      "status",
+      "score",
+      "shifted",
+      "error_cost",
+      "scanner",
+      "not_gss",
+      "not_clean",
+      "distinct_shape",
+      "payload",
+      "cycle",
+      "link_cap",
+      "cull"
+    ],
+    "snapshots": [
+      "links_before",
+      "links_after",
+      "packed_paths_before",
+      "packed_paths_after"
+    ],
+    "include_cumulative_direct_and_proxy_counts": true,
+    "terminal_counters": [
+      "accept_actions",
+      "packed_roots_emitted"
+    ],
+    "interpretation": "accept actions and packed roots emitted are distinct; neither action count nor attempt count alone establishes convergence work"
+  },
+  "admission": {
+    "digest_format": "gts-deep-tree-v1",
+    "fixture": "query_compile",
+    "require_uninstrumented_go_static_c_digest_match_first": true,
+    "require_instrumented_digest_match": true,
+    "require_full_span": true,
+    "require_clean_root": true,
+    "require_no_overflow": true,
+    "require_exact_fields": true,
+    "require_ordinary_untagged_go_child_first": true,
+    "require_clean_git_source_for_authoritative_receipt": true,
+    "require_private_content_addressed_go_source_snapshot": true,
+    "require_private_c_input_snapshot": true,
+    "sanitize_go_and_parser_environment": true,
+    "atomic_receipt_publish": true
+  }
+}

--- a/cgo_harness/work_count/tree_sitter_v0_25_1.patch
+++ b/cgo_harness/work_count/tree_sitter_v0_25_1.patch
@@ -1,0 +1,262 @@
+diff --git a/lib/src/language.c b/lib/src/language.c
+index b341a670..07ac8155 100644
+--- a/lib/src/language.c
++++ b/lib/src/language.c
+@@ -1,6 +1,7 @@
+ #include "./language.h"
+ #include "./wasm_store.h"
+ #include "tree_sitter/api.h"
++#include "./work_count.h"
+ #include <string.h>
+ 
+ const TSLanguage *ts_language_copy(const TSLanguage *self) {
+@@ -75,6 +76,7 @@ void ts_language_table_entry(
+   TSSymbol symbol,
+   TableEntry *result
+ ) {
++  gts_work_count_add(&gts_work_count_current.table_lookups_proxy, 1);
+   if (symbol == ts_builtin_sym_error || symbol == ts_builtin_sym_error_repeat) {
+     result->action_count = 0;
+     result->is_reusable = false;
+@@ -87,6 +89,10 @@ void ts_language_table_entry(
+     result->is_reusable = entry->entry.reusable;
+     result->actions = (const TSParseAction *)(entry + 1);
+   }
++  gts_work_count_add(
++    &gts_work_count_current.action_entries_examined_proxy,
++    result->action_count
++  );
+ }
+ 
+ TSLexerMode ts_language_lex_mode_for_state(
+diff --git a/lib/src/parser.c b/lib/src/parser.c
+index 7aac259e..49ffbcfa 100644
+--- a/lib/src/parser.c
++++ b/lib/src/parser.c
+@@ -20,6 +20,17 @@
+ #include "./tree.h"
+ #include "./ts_assert.h"
+ #include "./wasm_store.h"
++#include "./work_count.h"
++
++_Thread_local GTSWorkCount gts_work_count_current;
++
++void gts_work_count_reset(void) {
++  gts_work_count_current = (GTSWorkCount) {0};
++}
++
++GTSWorkCount gts_work_count_snapshot(void) {
++  return gts_work_count_current;
++}
+ 
+ #define LOG(...)                                                                            \
+   if (self->lexer.logger.log || self->dot_graph_file) {                                     \
+@@ -509,6 +520,7 @@ static Subtree ts_parser__lex(
+   StackVersion version,
+   TSStateId parse_state
+ ) {
++  gts_work_count_add(&gts_work_count_current.lexer_front_door_calls_proxy, 1);
+   TSLexerMode lex_mode = ts_language_lex_mode_for_state(self->language, parse_state);
+   if (lex_mode.lex_state == (uint16_t)-1) {
+     LOG("no_lookahead_after_non_terminal_extra");
+@@ -912,6 +924,7 @@ static void ts_parser__shift(
+   Subtree lookahead,
+   bool extra
+ ) {
++  gts_work_count_add(&gts_work_count_current.shifts, 1);
+   bool is_leaf = ts_subtree_child_count(lookahead) == 0;
+   Subtree subtree_to_push = lookahead;
+   if (extra != ts_subtree_extra(lookahead) && is_leaf) {
+@@ -938,6 +951,7 @@ static StackVersion ts_parser__reduce(
+   bool is_fragile,
+   bool end_of_non_terminal_extra
+ ) {
++  gts_work_count_add(&gts_work_count_current.reductions, 1);
+   uint32_t initial_version_count = ts_stack_version_count(self->stack);
+ 
+   // Pop the given number of nodes from the given version of the parse stack.
+@@ -1048,6 +1062,7 @@ static void ts_parser__accept(
+   StackVersion version,
+   Subtree lookahead
+ ) {
++  gts_work_count_add(&gts_work_count_current.accept_actions, 1);
+   ts_assert(ts_subtree_is_eof(lookahead));
+   ts_stack_push(self->stack, version, lookahead, false, 1);
+ 
+@@ -1664,6 +1679,7 @@ static bool ts_parser__advance(
+         }
+ 
+         case TSParseActionTypeRecover: {
++          gts_work_count_add(&gts_work_count_current.explicit_recover_actions, 1);
+           if (ts_subtree_child_count(lookahead) > 0) {
+             ts_parser__breakdown_lookahead(self, &lookahead, ERROR_STATE, &self->reusable_node);
+           }
+diff --git a/lib/src/stack.c b/lib/src/stack.c
+index f0d57108..3fd2a602 100644
+--- a/lib/src/stack.c
++++ b/lib/src/stack.c
+@@ -4,6 +4,7 @@
+ #include "./array.h"
+ #include "./stack.h"
+ #include "./length.h"
++#include "./work_count.h"
+ #include <assert.h>
+ #include <inttypes.h>
+ #include <stdio.h>
+@@ -158,6 +159,7 @@ static StackNode *stack_node_new(
+       .subtree = subtree,
+       .is_pending = is_pending,
+     };
++    gts_work_count_add(&gts_work_count_current.graph_link_additions_proxy, 1);
+ 
+     node->position = previous_node->position;
+     node->error_cost = previous_node->error_cost;
+@@ -252,6 +254,7 @@ static void stack_node_add_link(
+   unsigned node_count = link.node->node_count;
+   int dynamic_precedence = link.node->dynamic_precedence;
+   self->links[self->link_count++] = link;
++  gts_work_count_add(&gts_work_count_current.graph_link_additions_proxy, 1);
+ 
+   if (link.subtree.ptr) {
+     ts_subtree_retain(link.subtree);
+@@ -296,6 +299,7 @@ static StackVersion ts_stack__add_version(
+     .lookahead_when_paused = NULL_SUBTREE,
+   };
+   array_push(&self->heads, head);
++  gts_work_count_add(&gts_work_count_current.stack_version_creations_proxy, 1);
+   stack_node_retain(node);
+   if (head.last_external_token.ptr) ts_subtree_retain(head.last_external_token);
+   return (StackVersion)(self->heads.size - 1);
+@@ -521,7 +525,16 @@ forceinline StackAction pop_count_callback(void *payload, const StackIterator *i
+ }
+ 
+ StackSliceArray ts_stack_pop_count(Stack *self, StackVersion version, uint32_t count) {
+-  return stack__iter(self, version, pop_count_callback, &count, (int)count);
++  gts_work_count_add(&gts_work_count_current.reduction_pop_requests, 1);
++  StackSliceArray result = stack__iter(self, version, pop_count_callback, &count, (int)count);
++  gts_work_count_add(&gts_work_count_current.emitted_pop_paths, result.size);
++  for (uint32_t i = 0; i < result.size; i++) {
++    gts_work_count_add(
++      &gts_work_count_current.emitted_pop_payloads,
++      result.contents[i].subtrees.size
++    );
++  }
++  return result;
+ }
+ 
+ forceinline StackAction pop_pending_callback(void *payload, const StackIterator *iterator) {
+@@ -685,6 +698,7 @@ void ts_stack_swap_versions(Stack *self, StackVersion v1, StackVersion v2) {
+ StackVersion ts_stack_copy_version(Stack *self, StackVersion version) {
+   ts_assert(version < self->heads.size);
+   array_push(&self->heads, self->heads.contents[version]);
++  gts_work_count_add(&gts_work_count_current.stack_version_creations_proxy, 1);
+   StackHead *head = array_back(&self->heads);
+   stack_node_retain(head->node);
+   if (head->last_external_token.ptr) ts_subtree_retain(head->last_external_token);
+@@ -693,6 +707,7 @@ StackVersion ts_stack_copy_version(Stack *self, StackVersion version) {
+ }
+ 
+ bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2) {
++  gts_work_count_add(&gts_work_count_current.merge_attempts_proxy, 1);
+   if (!ts_stack_can_merge(self, version1, version2)) return false;
+   StackHead *head1 = &self->heads.contents[version1];
+   StackHead *head2 = &self->heads.contents[version2];
+@@ -703,6 +718,7 @@ bool ts_stack_merge(Stack *self, StackVersion version1, StackVersion version2) {
+     head1->node_count_at_last_error = head1->node->node_count;
+   }
+   ts_stack_remove_version(self, version2);
++  gts_work_count_add(&gts_work_count_current.merge_successes_proxy, 1);
+   return true;
+ }
+ 
+@@ -762,6 +778,7 @@ void ts_stack_clear(Stack *self) {
+     .last_external_token = NULL_SUBTREE,
+     .lookahead_when_paused = NULL_SUBTREE,
+   }));
++  gts_work_count_add(&gts_work_count_current.stack_version_creations_proxy, 1);
+ }
+ 
+ bool ts_stack_print_dot_graph(Stack *self, const TSLanguage *language, FILE *f) {
+diff --git a/lib/src/subtree.c b/lib/src/subtree.c
+index 42794de7..c814693e 100644
+--- a/lib/src/subtree.c
++++ b/lib/src/subtree.c
+@@ -10,6 +10,7 @@
+ #include "./length.h"
+ #include "./language.h"
+ #include "./error_costs.h"
++#include "./work_count.h"
+ #include "./ts_assert.h"
+ #include <stddef.h>
+ 
+@@ -169,6 +170,7 @@ Subtree ts_subtree_new_leaf(
+   bool has_external_tokens, bool depends_on_column,
+   bool is_keyword, const TSLanguage *language
+ ) {
++  gts_work_count_add(&gts_work_count_current.leaf_constructions_proxy, 1);
+   TSSymbolMetadata metadata = ts_language_symbol_metadata(language, symbol);
+   bool extra = symbol == ts_builtin_sym_end;
+ 
+@@ -478,6 +480,7 @@ MutableSubtree ts_subtree_new_node(
+   unsigned production_id,
+   const TSLanguage *language
+ ) {
++  gts_work_count_add(&gts_work_count_current.parent_constructions_proxy, 1);
+   TSSymbolMetadata metadata = ts_language_symbol_metadata(language, symbol);
+   bool fragile = symbol == ts_builtin_sym_error || symbol == ts_builtin_sym_error_repeat;
+ 
+diff --git a/lib/src/work_count.h b/lib/src/work_count.h
+new file mode 100644
+index 00000000..963fac8a
+--- /dev/null
++++ b/lib/src/work_count.h
+@@ -0,0 +1,49 @@
++#ifndef TREE_SITTER_WORK_COUNT_H_
++#define TREE_SITTER_WORK_COUNT_H_
++
++#include <stdbool.h>
++#include <stdint.h>
++
++typedef struct {
++  bool overflow;
++
++  uint64_t shifts;
++  uint64_t reductions;
++  uint64_t accept_actions;
++  uint64_t explicit_recover_actions;
++  uint64_t reduction_pop_requests;
++  uint64_t emitted_pop_paths;
++  uint64_t emitted_pop_payloads;
++  uint64_t selected_nodes;
++  uint64_t selected_parent_nodes;
++  uint64_t selected_leaf_nodes;
++
++  uint64_t table_lookups_proxy;
++  uint64_t action_entries_examined_proxy;
++  uint64_t lexer_front_door_calls_proxy;
++  uint64_t stack_version_creations_proxy;
++  uint64_t merge_attempts_proxy;
++  uint64_t merge_successes_proxy;
++  uint64_t graph_link_additions_proxy;
++  uint64_t leaf_constructions_proxy;
++  uint64_t parent_constructions_proxy;
++  uint64_t pending_parent_constructions_proxy;
++  uint64_t no_tree_parent_constructions_proxy;
++} GTSWorkCount;
++
++extern _Thread_local GTSWorkCount gts_work_count_current;
++
++void gts_work_count_reset(void);
++GTSWorkCount gts_work_count_snapshot(void);
++
++static inline void gts_work_count_add(uint64_t *slot, uint64_t delta) {
++  if (!slot || delta == 0) return;
++  if (UINT64_MAX - *slot < delta) {
++    *slot = UINT64_MAX;
++    gts_work_count_current.overflow = true;
++    return;
++  }
++  *slot += delta;
++}
++
++#endif

--- a/cgo_harness/work_count_oracle_test.go
+++ b/cgo_harness/work_count_oracle_test.go
@@ -1,0 +1,1520 @@
+//go:build cgo && treesitter_c_parity && treesitter_c_perfscan
+
+package cgoharness
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	workCountEnableEnv     = "GTS_WORK_COUNT_ORACLE"
+	workCountReceiptEnv    = "GTS_WORK_COUNT_RECEIPT"
+	workCountFixtureID     = "query_compile"
+	workCountGoChildSchema = "gts-work-count-go-child/v3"
+	workCountCChildSchema  = "gts-work-count-c-child/v3"
+	workCountContract      = "gts-work-count/v2"
+	workCountReceiptSchema = "gts-work-count-receipt/v3"
+	workCountTimeout       = 2 * time.Minute
+
+	workCountCAdmissionChildEnv    = "GTS_WORK_COUNT_C_ADMISSION_CHILD"
+	workCountCAdmissionSourceEnv   = "GTS_WORK_COUNT_C_ADMISSION_SOURCE"
+	workCountCAdmissionResultEnv   = "GTS_WORK_COUNT_C_ADMISSION_RESULT"
+	workCountCAdmissionChildSchema = "gts-work-count-c-admission-child/v1"
+	workCountRepoChildEnv          = "GTS_WORK_COUNT_REPO_CHILD"
+	workCountRepoLabelEnv          = "GTS_WORK_COUNT_REPO_LABEL"
+	workCountRepoURLEnv            = "GTS_WORK_COUNT_REPO_URL"
+	workCountRepoCommitEnv         = "GTS_WORK_COUNT_REPO_COMMIT"
+	workCountRepoDestinationEnv    = "GTS_WORK_COUNT_REPO_DESTINATION"
+	workCountRepoLanguageEnv       = "GTS_WORK_COUNT_REPO_LANGUAGE"
+)
+
+var workCountDirectFields = []string{
+	"shifts", "reductions", "explicit_recover_actions",
+	"reduction_pop_requests", "emitted_pop_paths", "emitted_pop_payloads",
+	"selected_nodes", "selected_parent_nodes", "selected_leaf_nodes",
+}
+
+var workCountTerminalFields = []string{"accept_actions"}
+
+var workCountProxyFields = []string{
+	"table_lookups_proxy", "action_entries_examined_proxy",
+	"lexer_front_door_calls_proxy", "stack_version_creations_proxy",
+	"merge_attempts_proxy", "merge_successes_proxy",
+	"graph_link_additions_proxy", "leaf_constructions_proxy",
+	"parent_constructions_proxy", "pending_parent_constructions_proxy",
+	"no_tree_parent_constructions_proxy",
+}
+
+type workCountCounters struct {
+	Contract string `json:"contract"`
+	Overflow bool   `json:"overflow"`
+	workCountCounterValues
+}
+
+type workCountCounterValues struct {
+	Shifts                 uint64 `json:"shifts"`
+	Reductions             uint64 `json:"reductions"`
+	AcceptActions          uint64 `json:"accept_actions"`
+	ExplicitRecoverActions uint64 `json:"explicit_recover_actions"`
+	ReductionPopRequests   uint64 `json:"reduction_pop_requests"`
+	EmittedPopPaths        uint64 `json:"emitted_pop_paths"`
+	EmittedPopPayloads     uint64 `json:"emitted_pop_payloads"`
+	SelectedNodes          uint64 `json:"selected_nodes"`
+	SelectedParentNodes    uint64 `json:"selected_parent_nodes"`
+	SelectedLeafNodes      uint64 `json:"selected_leaf_nodes"`
+
+	TableLookupsProxy               uint64 `json:"table_lookups_proxy"`
+	ActionEntriesExaminedProxy      uint64 `json:"action_entries_examined_proxy"`
+	LexerFrontDoorCallsProxy        uint64 `json:"lexer_front_door_calls_proxy"`
+	StackVersionCreationsProxy      uint64 `json:"stack_version_creations_proxy"`
+	MergeAttemptsProxy              uint64 `json:"merge_attempts_proxy"`
+	MergeSuccessesProxy             uint64 `json:"merge_successes_proxy"`
+	GraphLinkAdditionsProxy         uint64 `json:"graph_link_additions_proxy"`
+	LeafConstructionsProxy          uint64 `json:"leaf_constructions_proxy"`
+	ParentConstructionsProxy        uint64 `json:"parent_constructions_proxy"`
+	PendingParentConstructionsProxy uint64 `json:"pending_parent_constructions_proxy"`
+	NoTreeParentConstructionsProxy  uint64 `json:"no_tree_parent_constructions_proxy"`
+}
+
+type workCountAttempt struct {
+	Index          uint32 `json:"index"`
+	LogicalRung    string `json:"logical_rung"`
+	OperationCause string `json:"operation_cause"`
+
+	RequestedMaxStacks       int  `json:"requested_max_stacks"`
+	RequestedMaxNodes        int  `json:"requested_max_nodes"`
+	RequestedMaxMergePerKey  int  `json:"requested_max_merge_per_key"`
+	CapsResolved             bool `json:"caps_resolved"`
+	ResolvedMaxStacks        int  `json:"resolved_max_stacks"`
+	ResolvedRetryPass        bool `json:"resolved_retry_pass"`
+	ResolvedMaxMergePerKey   int  `json:"resolved_max_merge_per_key"`
+	ResolvedStackCullTrigger int  `json:"resolved_stack_cull_trigger"`
+	ResolvedMaxIterations    int  `json:"resolved_max_iterations"`
+	ResolvedMaxNodes         int  `json:"resolved_max_nodes"`
+
+	StopReason   string `json:"stop_reason"`
+	RootHasError bool   `json:"root_has_error"`
+	RootEndByte  uint32 `json:"root_end_byte"`
+
+	EntryToCaps    workCountCounterValues `json:"entry_to_caps"`
+	CapsToFinalize workCountCounterValues `json:"caps_to_finalize"`
+	Finalize       workCountCounterValues `json:"finalize"`
+	Counters       workCountCounterValues `json:"counters"`
+}
+
+type workCountGoCounters struct {
+	workCountCounters
+	Attempts       []workCountAttempt     `json:"attempts"`
+	OutsideAttempt workCountCounterValues `json:"outside_attempt"`
+}
+
+type workCountGoChildResult struct {
+	Schema            string `json:"schema"`
+	Engine            string `json:"engine"`
+	Fixture           string `json:"fixture"`
+	SourceSHA256      string `json:"source_sha256"`
+	SourceBytes       uint32 `json:"source_bytes"`
+	GrammarCommit     string `json:"grammar_commit"`
+	GrammarBlobSHA256 string `json:"grammar_blob_sha256"`
+	DigestFormat      string `json:"digest_format"`
+	DeepTreeSHA256    string `json:"deep_tree_sha256"`
+	RootEndByte       uint32 `json:"root_end_byte"`
+	RootHasError      bool   `json:"root_has_error"`
+	MaxStacksSeen     int    `json:"max_stacks_seen"`
+	MultiStackIters   int    `json:"multi_stack_iterations"`
+	MultiStackTokens  uint64 `json:"multi_stack_tokens"`
+}
+
+type workCountTaggedChildResult struct {
+	workCountGoChildResult
+	Counters workCountGoCounters `json:"counters"`
+}
+
+type workCountCChildResult struct {
+	Schema         string            `json:"schema"`
+	Engine         string            `json:"engine"`
+	DigestFormat   string            `json:"digest_format"`
+	DeepTreeSHA256 string            `json:"deep_tree_sha256,omitempty"`
+	SourceBytes    uint32            `json:"source_bytes"`
+	RootEndByte    uint32            `json:"root_end_byte"`
+	RootHasError   bool              `json:"root_has_error"`
+	Counters       workCountCounters `json:"counters"`
+}
+
+type workCountCAdmissionChildResult struct {
+	Schema         string `json:"schema"`
+	DigestFormat   string `json:"digest_format"`
+	DeepTreeSHA256 string `json:"deep_tree_sha256"`
+	SourceSHA256   string `json:"source_sha256"`
+}
+
+type workCountToolIdentity struct {
+	Path    string `json:"path"`
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+}
+
+type workCountArtifactIdentity struct {
+	ArtifactSHA256    string                `json:"artifact_sha256"`
+	SourceSnapshotSHA string                `json:"source_snapshot_sha256,omitempty"`
+	Tool              workCountToolIdentity `json:"tool"`
+	Flags             []string              `json:"flags"`
+}
+
+type workCountCIdentity struct {
+	Artifact      workCountArtifactIdentity        `json:"artifact"`
+	Linker        workCountToolIdentity            `json:"linker"`
+	PatchTool     workCountToolIdentity            `json:"patch_tool"`
+	SymbolTool    workCountToolIdentity            `json:"symbol_tool"`
+	VerifierTools map[string]workCountToolIdentity `json:"verifier_tools"`
+	LinkageProof  string                           `json:"linkage_proof"`
+	RuntimeCommit string                           `json:"runtime_commit"`
+	RuntimeTree   string                           `json:"runtime_source_tree_oid"`
+	PatchSHA256   string                           `json:"patch_sha256"`
+	DriverSHA256  string                           `json:"driver_sha256"`
+	InputSHA256   string                           `json:"input_snapshot_sha256"`
+	InputFiles    int                              `json:"input_snapshot_files"`
+	Environment   map[string]string                `json:"environment"`
+	Language      perfScanOracleLanguageIdentity   `json:"language"`
+}
+
+type workCountRatio struct {
+	Field   string   `json:"field"`
+	Class   string   `json:"class"`
+	Go      uint64   `json:"go"`
+	C       uint64   `json:"c"`
+	GoOverC *float64 `json:"go_over_c,omitempty"`
+}
+
+type workCountReceipt struct {
+	Schema         string                    `json:"schema"`
+	Fixture        string                    `json:"fixture"`
+	SourceSHA256   string                    `json:"source_sha256"`
+	SourceBytes    int                       `json:"source_bytes"`
+	DigestFormat   string                    `json:"digest_format"`
+	DeepTreeSHA256 string                    `json:"deep_tree_sha256"`
+	ManifestSHA256 string                    `json:"contract_manifest_sha256"`
+	Source         workCountGitProvenance    `json:"source"`
+	GoEnvironment  workCountEnvironment      `json:"go_environment"`
+	GoAdmission    workCountArtifactIdentity `json:"go_admission_artifact"`
+	GoArtifact     workCountArtifactIdentity `json:"go_work_count_artifact"`
+	CArtifact      workCountCIdentity        `json:"static_c_artifact"`
+	GoCounts       workCountGoCounters       `json:"go_counts"`
+	CCounts        workCountCounters         `json:"static_c_counts"`
+	Ratios         []workCountRatio          `json:"ratios"`
+	GoSurplus      uint64                    `json:"go_construction_surplus"`
+	CSurplus       uint64                    `json:"static_c_construction_surplus"`
+}
+
+type workCountCBuild struct {
+	Artifact string
+	Identity workCountCIdentity
+	Cleanup  func()
+	Recheck  func() error
+}
+
+func TestAuthenticatedWorkCountOracle(t *testing.T) {
+	if os.Getenv(workCountEnableEnv) != "1" {
+		t.Skip(workCountEnableEnv + "=1 is required")
+	}
+	repoRoot := workCountRepoRoot(t)
+	receiptPath := workCountPrepareReceiptPath(t, repoRoot)
+	tempRoot := t.TempDir()
+	sourceSnapshot := workCountPrepareSourceSnapshot(t, repoRoot, tempRoot)
+	// Worktree-routing variables are needed only to authenticate and snapshot
+	// the mounted source. They must not leak into pinned runtime/grammar Git
+	// operations performed later by the static-C builders.
+	workCountClearAmbientGitRouting(t)
+	fixture := workCountLoadFixture(t)
+	manifestPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "work_count", "contract_v2.json")
+	patchPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "work_count", "tree_sitter_v0_25_1.patch")
+	driverPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "pure_c", "work_count_oracle.c")
+	manifestSHA := workCountFileSHA(t, manifestPath)
+	patchSHA := workCountFileSHA(t, patchPath)
+	driverSHA := workCountFileSHA(t, driverPath)
+	workCountValidateManifest(t, manifestPath)
+
+	sourcePath := filepath.Join(tempRoot, "query_compile.go")
+	if err := os.WriteFile(sourcePath, fixture.Source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := workCountFileSHA(t, sourcePath); got != fixture.Fixture.SHA256 {
+		t.Fatalf("source snapshot sha=%s want=%s", got, fixture.Fixture.SHA256)
+	}
+
+	// Admission deliberately precedes every instrumented build and run. An
+	// ordinary untagged child built from the private source snapshot and the
+	// unmodified static C oracle must reproduce the frozen digest first.
+	goEnvironment := workCountChosenEnvironment()
+	t.Log("build: ordinary untagged Go admission child")
+	goAdmissionArtifact, goAdmissionIdentity, goAdmissionRecheck := workCountBuildGo(t, sourceSnapshot, tempRoot, goEnvironment, false)
+	t.Log("admission: ordinary untagged Go child")
+	uninstGo := workCountRunGoAdmission(t, goAdmissionArtifact, sourcePath, tempRoot, goEnvironment)
+	workCountValidateGoChild(t, "ordinary Go admission", "go-production-glr-untagged", uninstGo, fixture)
+	t.Log("admission: unmodified static C")
+	uninstC := workCountUninstrumentedCAdmission(t, fixture, sourcePath, tempRoot)
+	if uninstGo.DeepTreeSHA256 != uninstC || uninstGo.DeepTreeSHA256 != fixture.Fixture.DeepTreeSHA256 {
+		t.Fatalf("uninstrumented admission mismatch: go=%s static_c=%s frozen=%s", uninstGo.DeepTreeSHA256, uninstC, fixture.Fixture.DeepTreeSHA256)
+	}
+
+	t.Log("build: instrumented static C child")
+	cBuild := workCountBuildC(t, repoRoot, sourceSnapshot.Root, patchPath, driverPath)
+	defer cBuild.Cleanup()
+	t.Log("build: tagged diagnostic Go child")
+	goArtifact, goIdentity, goRecheck := workCountBuildGo(t, sourceSnapshot, tempRoot, goEnvironment, true)
+
+	t.Log("run: instrumented static C child")
+	cResult := workCountRunC(t, cBuild.Artifact, sourcePath, tempRoot)
+	t.Log("run: tagged diagnostic Go child")
+	goResult := workCountRunGo(t, goArtifact, sourcePath, tempRoot, goEnvironment)
+	workCountValidateCChild(t, "static C", "static-c-instrumented-glr", cResult, fixture, uninstC)
+	workCountValidateGoChild(t, "tagged Go", "go-production-glr-tagged-diagnostic", goResult.workCountGoChildResult, fixture)
+	workCountValidateGoCounters(t, "tagged Go", goResult.Counters, uint32(len(fixture.Source)))
+	if cResult.DeepTreeSHA256 != goResult.DeepTreeSHA256 {
+		t.Fatalf("instrumented deep digest mismatch: go=%s static_c=%s", goResult.DeepTreeSHA256, cResult.DeepTreeSHA256)
+	}
+	if err := cBuild.Recheck(); err != nil {
+		t.Fatalf("static C identity drift: %v", err)
+	}
+	if err := goRecheck(); err != nil {
+		t.Fatalf("Go identity drift: %v", err)
+	}
+	if err := goAdmissionRecheck(); err != nil {
+		t.Fatalf("Go admission identity drift: %v", err)
+	}
+	if err := sourceSnapshot.Recheck(); err != nil {
+		t.Fatalf("source provenance drift: %v", err)
+	}
+	if got := workCountFileSHA(t, sourcePath); got != fixture.Fixture.SHA256 {
+		t.Fatalf("source snapshot identity drift: got %s want %s", got, fixture.Fixture.SHA256)
+	}
+	for label, pathAndSHA := range map[string][2]string{
+		"manifest": {manifestPath, manifestSHA}, "patch": {patchPath, patchSHA}, "driver": {driverPath, driverSHA},
+	} {
+		if got := workCountFileSHA(t, pathAndSHA[0]); got != pathAndSHA[1] {
+			t.Fatalf("%s identity drift: got %s want %s", label, got, pathAndSHA[1])
+		}
+	}
+
+	receipt := workCountReceipt{
+		Schema: workCountReceiptSchema, Fixture: fixture.Fixture.ID,
+		SourceSHA256: fixture.Fixture.SHA256, SourceBytes: len(fixture.Source),
+		DigestFormat: benchfixtures.DeepTreeDigestVersion, DeepTreeSHA256: uninstGo.DeepTreeSHA256,
+		ManifestSHA256: manifestSHA, Source: sourceSnapshot.Provenance,
+		GoEnvironment: goEnvironment, GoAdmission: goAdmissionIdentity,
+		GoArtifact: goIdentity, CArtifact: cBuild.Identity,
+		GoCounts: goResult.Counters, CCounts: cResult.Counters,
+		Ratios:    workCountRatios(goResult.Counters.workCountCounters, cResult.Counters),
+		GoSurplus: workCountConstructionSurplus(t, "Go", goResult.Counters.workCountCounters),
+		CSurplus:  workCountConstructionSurplus(t, "static C", cResult.Counters),
+	}
+	data, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := workCountAtomicPublish(receiptPath, data); err != nil {
+		t.Fatal(err)
+	}
+	if sourceSnapshot.Provenance.Authoritative {
+		t.Logf("authenticated work-count receipt: %s", receiptPath)
+	} else {
+		t.Logf("non-authoritative dirty-source work-count receipt: %s", receiptPath)
+	}
+}
+
+func workCountRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(wd)
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolve repository root from %s: %v", wd, err)
+	}
+	return root
+}
+
+func workCountLoadFixture(t *testing.T) benchfixtures.LoadedFixture {
+	t.Helper()
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fixture := range fixtures {
+		if fixture.Fixture.ID == workCountFixtureID {
+			return fixture
+		}
+	}
+	t.Fatalf("fixture %s not found", workCountFixtureID)
+	return benchfixtures.LoadedFixture{}
+}
+
+func workCountUninstrumentedCAdmission(t *testing.T, fixture benchfixtures.LoadedFixture, sourcePath, tempRoot string) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(tempRoot, "static_c_admission.json")
+	environment := workCountSanitizedEnv(os.Environ(), workCountCBuildEnvironment(), map[string]string{
+		workCountCAdmissionChildEnv:  "1",
+		workCountCAdmissionSourceEnv: sourcePath,
+		workCountCAdmissionResultEnv: resultPath,
+	})
+	_, stderr, err := workCountRunCaptured(
+		"",
+		environment,
+		workCountBuildTimeout+workCountTimeout+staticCPerfWallGrace,
+		self,
+		"-test.run", "^TestWorkCountStaticCAdmissionChild$",
+		"-test.count=1",
+	)
+	if err != nil {
+		t.Fatalf("bounded static C admission child: %v", err)
+	}
+	if len(stderr) != 0 {
+		t.Fatalf("bounded static C admission child wrote stderr: %s", strings.TrimSpace(string(stderr)))
+	}
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result workCountCAdmissionChildResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Schema != workCountCAdmissionChildSchema || result.DigestFormat != benchfixtures.DeepTreeDigestVersion {
+		t.Fatalf("static C admission child identity=%q/%q", result.Schema, result.DigestFormat)
+	}
+	if result.SourceSHA256 != fixture.Fixture.SHA256 {
+		t.Fatalf("static C admission source sha=%s want=%s", result.SourceSHA256, fixture.Fixture.SHA256)
+	}
+	if err := fixture.Fixture.VerifyDeepTreeDigest(result.DeepTreeSHA256); err != nil {
+		t.Fatal(err)
+	}
+	return result.DeepTreeSHA256
+}
+
+func TestWorkCountStaticCAdmissionChild(t *testing.T) {
+	if os.Getenv(workCountCAdmissionChildEnv) != "1" {
+		t.Skip("work-count static C admission child is not configured")
+	}
+	sourcePath := strings.TrimSpace(os.Getenv(workCountCAdmissionSourceEnv))
+	resultPath := strings.TrimSpace(os.Getenv(workCountCAdmissionResultEnv))
+	if sourcePath == "" || resultPath == "" {
+		t.Fatal("work-count static C admission child paths are incomplete")
+	}
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oracle, err := buildStaticCPerfOracle("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oracle.Close()
+	digest, sourceSHA, err := oracle.deepDigest(source, workCountTimeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := workCountCAdmissionChildResult{
+		Schema: workCountCAdmissionChildSchema, DigestFormat: benchfixtures.DeepTreeDigestVersion,
+		DeepTreeSHA256: digest, SourceSHA256: sourceSHA,
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(resultPath, append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func workCountEnsurePinnedRepo(t *testing.T, label, repoURL, commit, destination, language string) {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	environment := workCountSanitizedEnv(os.Environ(), workCountCBuildEnvironment(), map[string]string{
+		workCountRepoChildEnv:       "1",
+		workCountRepoLabelEnv:       label,
+		workCountRepoURLEnv:         repoURL,
+		workCountRepoCommitEnv:      commit,
+		workCountRepoDestinationEnv: destination,
+		workCountRepoLanguageEnv:    language,
+		"GIT_TERMINAL_PROMPT":       "0",
+	})
+	_, stderr, err := workCountRunCaptured(
+		"",
+		environment,
+		workCountBuildTimeout,
+		self,
+		"-test.run", "^TestWorkCountEnsurePinnedRepoChild$",
+		"-test.count=1",
+	)
+	if err != nil {
+		t.Fatalf("bounded %s acquisition: %v", label, err)
+	}
+	if len(stderr) != 0 {
+		t.Fatalf("bounded %s acquisition wrote stderr: %s", label, strings.TrimSpace(string(stderr)))
+	}
+	if err := workCountVerifyPinnedRepo(destination, commit, environment); err != nil {
+		t.Fatalf("bounded %s verification: %v", label, err)
+	}
+}
+
+func TestWorkCountEnsurePinnedRepoChild(t *testing.T) {
+	if os.Getenv(workCountRepoChildEnv) != "1" {
+		t.Skip("work-count pinned repository child is not configured")
+	}
+	label := strings.TrimSpace(os.Getenv(workCountRepoLabelEnv))
+	repoURL := strings.TrimSpace(os.Getenv(workCountRepoURLEnv))
+	commit := strings.TrimSpace(os.Getenv(workCountRepoCommitEnv))
+	destination := strings.TrimSpace(os.Getenv(workCountRepoDestinationEnv))
+	language := strings.TrimSpace(os.Getenv(workCountRepoLanguageEnv))
+	if label == "" || repoURL == "" || commit == "" || destination == "" {
+		t.Fatal("work-count pinned repository child configuration is incomplete")
+	}
+	if err := staticCEnsurePinnedRepo(label, repoURL, commit, destination, language); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func workCountGitOutput(repoDir string, environment []string, args ...string) (string, error) {
+	gitArgs := append([]string{"-c", "safe.directory=" + repoDir, "-C", repoDir}, args...)
+	output, err := workCountRunBounded("", environment, workCountGitTimeout, "git", gitArgs...)
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+func workCountVerifyPinnedRepo(repoDir, commit string, environment []string) error {
+	head, err := workCountGitOutput(repoDir, environment, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return fmt.Errorf("read HEAD: %w", err)
+	}
+	want, err := workCountGitOutput(repoDir, environment, "rev-parse", "--verify", commit+"^{commit}")
+	if err != nil {
+		return fmt.Errorf("resolve pinned commit: %w", err)
+	}
+	if strings.TrimSpace(head) != strings.TrimSpace(want) {
+		return fmt.Errorf("HEAD mismatch: got %s want %s", strings.TrimSpace(head), strings.TrimSpace(want))
+	}
+	status, err := workCountGitOutput(repoDir, environment, "status", "--porcelain=v1", "--untracked-files=all", "--ignore-submodules=none")
+	if err != nil {
+		return fmt.Errorf("inspect worktree: %w", err)
+	}
+	if strings.TrimSpace(status) != "" {
+		return fmt.Errorf("pinned worktree is dirty: %s", strings.TrimSpace(status))
+	}
+	return nil
+}
+
+func workCountResolveGoGrammarSources(entry parityLockEntry, pinnedDir string) (grammarDir, srcDir, parserPath, sourceMode string, cleanup func(), err error) {
+	cleanup = func() {}
+	srcDir = filepath.Join(pinnedDir, entry.Subdir)
+	parserPath = filepath.Join(srcDir, "parser.c")
+	info, err := os.Stat(parserPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", "", "", "", cleanup, fmt.Errorf("locked Go parser is unavailable at %s: %w", parserPath, err)
+	}
+	if version, ok := readParserLanguageVersion(parserPath); ok && (version < parityMinLanguageVersion || version > parityMaxLanguageVersion) {
+		return "", "", "", "", cleanup, fmt.Errorf("locked Go parser ABI %d is outside %d..%d", version, parityMinLanguageVersion, parityMaxLanguageVersion)
+	}
+	return pinnedDir, srcDir, parserPath, staticCSourceLocked, cleanup, nil
+}
+
+func workCountLanguageIdentity(entry parityLockEntry, grammarDir, srcDir, parserPath string, scanners []string, symbol, sourceMode string, hasCXX bool, linker workCountToolIdentity) (perfScanOracleLanguageIdentity, error) {
+	environment := workCountSanitizedEnv(os.Environ(), workCountCBuildEnvironment(), nil)
+	tree, err := workCountGitOutput(grammarDir, environment, "rev-parse", entry.Commit+":"+filepath.ToSlash(entry.Subdir))
+	if err != nil {
+		return perfScanOracleLanguageIdentity{}, err
+	}
+	parserSHA, err := fileSHA256(parserPath)
+	if err != nil {
+		return perfScanOracleLanguageIdentity{}, err
+	}
+	identity := perfScanOracleLanguageIdentity{
+		Language: entry.Name, GrammarRepo: entry.RepoURL, GrammarCommit: entry.Commit,
+		GrammarSourceTree: strings.TrimSpace(tree), GrammarSourceMode: sourceMode,
+		LanguageSymbol: symbol,
+		Parser: perfScanOracleSourceIdentity{
+			Path: staticCSourceRelative(srcDir, parserPath), SHA256: parserSHA, CompileFlags: staticCPerfGrammarCFlags,
+		},
+		LinkerPath: linker.Path, LinkerVersion: linker.Version, LinkerSHA256: linker.SHA256,
+	}
+	for _, scanner := range scanners {
+		sha, err := fileSHA256(scanner)
+		if err != nil {
+			return perfScanOracleLanguageIdentity{}, err
+		}
+		flags := staticCPerfGrammarCFlags
+		if ext := strings.ToLower(filepath.Ext(scanner)); ext == ".cc" || ext == ".cpp" || ext == ".cxx" {
+			flags = staticCPerfGrammarCXXFlags
+		}
+		identity.Scanners = append(identity.Scanners, perfScanOracleSourceIdentity{
+			Path: staticCSourceRelative(srcDir, scanner), SHA256: sha, CompileFlags: flags,
+		})
+	}
+	if hasCXX && filepath.Base(linker.Path) != "c++" && filepath.Base(linker.Path) != "g++" {
+		return perfScanOracleLanguageIdentity{}, fmt.Errorf("C++ grammar resolved non-C++ linker %s", linker.Path)
+	}
+	return identity, nil
+}
+
+func workCountBuildC(t *testing.T, repoRoot, sourceRoot, patchPath, driverPath string) workCountCBuild {
+	t.Helper()
+	lockPath := filepath.Join(sourceRoot, "grammars", "languages.lock")
+	lock, err := loadParityLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := lock["go"]
+	cacheRoot := strings.TrimSpace(os.Getenv(staticCPerfCacheEnv))
+	if cacheRoot == "" {
+		cacheRoot = filepath.Join(repoRoot, "harness_out", "c_oracle", "fleet_static")
+	}
+	runtimeDir := filepath.Join(cacheRoot, "sources", "tree-sitter-"+COracleRuntimeCommit)
+	grammarDir := filepath.Join(cacheRoot, "sources", paritySafeName("go")+"-"+entry.Commit)
+	workCountEnsurePinnedRepo(t, "runtime", staticCPerfRuntimeRepo, COracleRuntimeCommit, runtimeDir, "")
+	workCountEnsurePinnedRepo(t, "go grammar", entry.RepoURL, entry.Commit, grammarDir, "go")
+	resolvedGrammar, srcDir, parserPath, sourceMode, cleanupGrammar, err := workCountResolveGoGrammarSources(entry, grammarDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanners := staticCScannerSources(srcDir)
+	hasCXX := false
+	for _, scanner := range scanners {
+		switch strings.ToLower(filepath.Ext(scanner)) {
+		case ".cc", ".cpp", ".cxx":
+			hasCXX = true
+		}
+	}
+	compiler := workCountTool(t, "cc")
+	linkerName := "cc"
+	if hasCXX {
+		linkerName = "c++"
+	}
+	linker := workCountTool(t, linkerName)
+	patchTool := workCountTool(t, "git")
+	symbolTool := workCountTool(t, "nm")
+	cEnvironment := workCountCBuildEnvironment()
+	commandEnvironment := workCountSanitizedEnv(os.Environ(), cEnvironment, nil)
+	buildRoot, err := os.MkdirTemp("", "gts-work-count-c-*")
+	if err != nil {
+		cleanupGrammar()
+		t.Fatal(err)
+	}
+	cleanup := func() {
+		cleanupGrammar()
+		_ = workCountMakeTreeWritable(filepath.Join(buildRoot, "inputs"))
+		_ = os.RemoveAll(buildRoot)
+	}
+
+	// Copy every compiler input into a private snapshot before patching or
+	// compiling. The pinned caches and outer worktree are never compiler input.
+	inputRoot := filepath.Join(buildRoot, "inputs")
+	privateRuntime := filepath.Join(inputRoot, "runtime")
+	privateGrammar := filepath.Join(inputRoot, "grammar")
+	privatePatch := filepath.Join(inputRoot, "tree_sitter.patch")
+	privateDriver := filepath.Join(inputRoot, "work_count_oracle.c")
+	privateLock := filepath.Join(inputRoot, "languages.lock")
+	if err := workCountCopyTree(filepath.Join(runtimeDir, "lib"), filepath.Join(privateRuntime, "lib")); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := workCountCopyTree(srcDir, privateGrammar); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := workCountCopyFile(patchPath, privatePatch, 0o444); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := workCountCopyFile(driverPath, privateDriver, 0o444); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := workCountCopyFile(lockPath, privateLock, 0o444); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	inputSHA, inputFiles, err := workCountTreeSHA(inputRoot)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := workCountMakeTreeReadOnly(inputRoot); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if got, files, err := workCountTreeSHA(inputRoot); err != nil || got != inputSHA || files != inputFiles {
+		cleanup()
+		t.Fatalf("C input snapshot drift after sealing: sha=%s files=%d want=%s/%d err=%v", got, files, inputSHA, inputFiles, err)
+	}
+	parserRel := staticCSourceRelative(srcDir, parserPath)
+	privateParser := filepath.Join(privateGrammar, filepath.FromSlash(parserRel))
+	privateScanners := make([]string, 0, len(scanners))
+	for _, scanner := range scanners {
+		privateScanners = append(privateScanners, filepath.Join(privateGrammar, filepath.FromSlash(staticCSourceRelative(srcDir, scanner))))
+	}
+
+	patchedRuntime := filepath.Join(buildRoot, "patched-runtime")
+	if err := workCountCopyTree(privateRuntime, patchedRuntime); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if err := workCountMakeTreeWritable(patchedRuntime); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if _, err := workCountRunBounded(patchedRuntime, commandEnvironment, workCountBuildTimeout, patchTool.Path, "apply", "--check", privatePatch); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	if _, err := workCountRunBounded(patchedRuntime, commandEnvironment, workCountBuildTimeout, patchTool.Path, "apply", privatePatch); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+
+	objects := filepath.Join(buildRoot, "objects")
+	if err := os.MkdirAll(objects, 0o755); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	runtimeObj := filepath.Join(objects, "runtime.o")
+	runtimeFlags := strings.Fields(staticCPerfRuntimeCFlags)
+	runtimeArgs := append([]string{}, runtimeFlags...)
+	runtimeArgs = append(runtimeArgs, "-I", filepath.Join(patchedRuntime, "lib", "include"), "-I", filepath.Join(patchedRuntime, "lib", "src"), "-c", filepath.Join(patchedRuntime, "lib", "src", "lib.c"), "-o", runtimeObj)
+	if _, err := workCountRunBounded("", commandEnvironment, workCountBuildTimeout, compiler.Path, runtimeArgs...); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	var grammarObjects []string
+	for i, source := range append([]string{privateParser}, privateScanners...) {
+		obj := filepath.Join(objects, fmt.Sprintf("grammar_%d.o", i))
+		tool := compiler.Path
+		flags := strings.Fields(staticCPerfGrammarCFlags)
+		ext := strings.ToLower(filepath.Ext(source))
+		if ext == ".cc" || ext == ".cpp" || ext == ".cxx" {
+			tool = linker.Path
+			flags = strings.Fields(staticCPerfGrammarCXXFlags)
+		}
+		args := append([]string{}, flags...)
+		args = append(args, "-I", privateGrammar, "-I", filepath.Join(patchedRuntime, "lib", "include"), "-c", source, "-o", obj)
+		if _, err := workCountRunBounded("", commandEnvironment, workCountBuildTimeout, tool, args...); err != nil {
+			cleanup()
+			t.Fatal(err)
+		}
+		grammarObjects = append(grammarObjects, obj)
+	}
+	symbol := workCountDefinedLanguageSymbol(t, entry, symbolTool.Path, grammarObjects[0], commandEnvironment)
+	languageIdentity, err := workCountLanguageIdentity(entry, resolvedGrammar, privateGrammar, privateParser, privateScanners, symbol, sourceMode, hasCXX, linker)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	driverObj := filepath.Join(objects, "driver.o")
+	driverFlags := strings.Fields(staticCPerfDriverCFlags)
+	driverArgs := append([]string{}, driverFlags...)
+	driverArgs = append(driverArgs, "-DTS_LANG_FN="+symbol, "-I", filepath.Join(patchedRuntime, "lib", "include", "tree_sitter"), "-I", filepath.Join(patchedRuntime, "lib", "src"), "-c", privateDriver, "-o", driverObj)
+	if _, err := workCountRunBounded("", commandEnvironment, workCountBuildTimeout, compiler.Path, driverArgs...); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	artifact := filepath.Join(buildRoot, "work_count_oracle")
+	linkArgs := append(strings.Fields(staticCPerfLinkFlags), "-o", artifact, driverObj)
+	linkArgs = append(linkArgs, grammarObjects...)
+	linkArgs = append(linkArgs, runtimeObj)
+	if _, err := workCountRunBounded("", commandEnvironment, workCountBuildTimeout, linker.Path, linkArgs...); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	artifactSHA := workCountFileSHA(t, artifact)
+	linkageProof, verifierTools, err := workCountVerifyStaticArtifact(artifact, symbol, commandEnvironment)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	runtimeTree, err := workCountGitOutput(runtimeDir, commandEnvironment, "rev-parse", COracleRuntimeCommit+":lib/src")
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	buildKeyInput, err := json.Marshal(struct {
+		RuntimeCommit string                         `json:"runtime_commit"`
+		RuntimeTree   string                         `json:"runtime_tree"`
+		PatchSHA256   string                         `json:"patch_sha256"`
+		DriverSHA256  string                         `json:"driver_sha256"`
+		Compiler      workCountToolIdentity          `json:"compiler"`
+		Linker        workCountToolIdentity          `json:"linker"`
+		SymbolTool    workCountToolIdentity          `json:"symbol_tool"`
+		Language      perfScanOracleLanguageIdentity `json:"language"`
+		Flags         []string                       `json:"flags"`
+		Environment   map[string]string              `json:"environment"`
+		InputSHA256   string                         `json:"input_snapshot_sha256"`
+	}{
+		RuntimeCommit: COracleRuntimeCommit, RuntimeTree: strings.TrimSpace(runtimeTree),
+		PatchSHA256: workCountFileSHA(t, privatePatch), DriverSHA256: workCountFileSHA(t, privateDriver),
+		Compiler: compiler, Linker: linker, SymbolTool: symbolTool, Language: languageIdentity,
+		Flags: []string{
+			"runtime:" + staticCPerfRuntimeCFlags,
+			"grammar_c:" + staticCPerfGrammarCFlags,
+			"grammar_cxx:" + staticCPerfGrammarCXXFlags,
+			"driver:" + staticCPerfDriverCFlags,
+			"link:" + staticCPerfLinkFlags,
+		},
+		Environment: cEnvironment, InputSHA256: inputSHA,
+	})
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	buildKey := sha256.Sum256(buildKeyInput)
+	languageIdentity.BuildKeySHA256 = hex.EncodeToString(buildKey[:])
+	languageIdentity.ArtifactSHA256 = artifactSHA
+	languageIdentity.ArtifactStatic = true
+	languageIdentity.ArtifactLinkage = linkageProof
+	identity := workCountCIdentity{
+		Artifact: workCountArtifactIdentity{ArtifactSHA256: artifactSHA, Tool: compiler, Flags: []string{
+			"runtime:" + staticCPerfRuntimeCFlags,
+			"grammar_c:" + staticCPerfGrammarCFlags,
+			"grammar_cxx:" + staticCPerfGrammarCXXFlags,
+			"driver:" + staticCPerfDriverCFlags,
+			"link:" + staticCPerfLinkFlags,
+		}},
+		Linker: linker, PatchTool: patchTool, SymbolTool: symbolTool, VerifierTools: verifierTools, LinkageProof: linkageProof,
+		RuntimeCommit: COracleRuntimeCommit, RuntimeTree: strings.TrimSpace(runtimeTree),
+		PatchSHA256: workCountFileSHA(t, privatePatch), DriverSHA256: workCountFileSHA(t, privateDriver),
+		InputSHA256: inputSHA, InputFiles: inputFiles, Environment: cEnvironment,
+		Language: languageIdentity,
+	}
+	recheck := func() error {
+		if got, err := fileSHA256(artifact); err != nil || got != artifactSHA {
+			return fmt.Errorf("artifact sha=%s want=%s err=%v", got, artifactSHA, err)
+		}
+		if got, files, err := workCountTreeSHA(inputRoot); err != nil || got != inputSHA || files != inputFiles {
+			return fmt.Errorf("C input snapshot sha=%s files=%d want=%s/%d err=%v", got, files, inputSHA, inputFiles, err)
+		}
+		tools := map[string]workCountToolIdentity{"compiler": compiler, "linker": linker, "patch": patchTool, "symbol": symbolTool}
+		for label, identity := range verifierTools {
+			tools["verifier_"+label] = identity
+		}
+		for label, want := range tools {
+			got, err := workCountToolAt(want.Path)
+			if err != nil || got != want {
+				return fmt.Errorf("%s identity=%+v want=%+v err=%v", label, got, want, err)
+			}
+		}
+		return nil
+	}
+	return workCountCBuild{Artifact: artifact, Identity: identity, Cleanup: cleanup, Recheck: recheck}
+}
+
+func workCountDefinedLanguageSymbol(t *testing.T, entry parityLockEntry, symbolTool, object string, environment []string) string {
+	t.Helper()
+	output, err := workCountRunBounded("", environment, workCountBuildTimeout, symbolTool, "-g", "--defined-only", object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		symbol := fields[len(fields)-1]
+		if strings.HasPrefix(symbol, "tree_sitter_") {
+			found[symbol] = true
+		}
+	}
+	for _, candidate := range parityLanguageSymbols(entry) {
+		if found[candidate] {
+			if len(found) != 1 {
+				t.Fatalf("compiled parser object has ambiguous language symbols: %v", found)
+			}
+			return candidate
+		}
+	}
+	t.Fatalf("compiled parser object has no accepted language symbol: %v", found)
+	return ""
+}
+
+func workCountVerifyStaticArtifact(artifact, symbol string, environment []string) (string, map[string]workCountToolIdentity, error) {
+	if strings.TrimSpace(symbol) == "" {
+		return "", nil, fmt.Errorf("language symbol is empty")
+	}
+	nm, err := workCountToolNamed("nm")
+	if err != nil {
+		return "", nil, err
+	}
+	readelf, err := workCountToolNamed("readelf")
+	if err != nil {
+		return "", nil, err
+	}
+	nmOutput, err := workCountRunBounded("", environment, workCountGitTimeout, nm.Path, artifact)
+	if err != nil {
+		return "", nil, fmt.Errorf("nm: %w", err)
+	}
+	defined := make(map[string]bool)
+	for _, line := range strings.Split(string(nmOutput), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && !strings.EqualFold(fields[len(fields)-2], "U") {
+			defined[fields[len(fields)-1]] = true
+		}
+	}
+	for _, required := range []string{"ts_parser_parse", symbol} {
+		if !defined[required] {
+			return "", nil, fmt.Errorf("artifact does not define %s", required)
+		}
+	}
+	dynamicOutput, err := workCountRunBounded("", environment, workCountGitTimeout, readelf.Path, "-d", artifact)
+	if err != nil {
+		return "", nil, fmt.Errorf("readelf dynamic-section proof: %w", err)
+	}
+	if bytes.Contains(dynamicOutput, []byte("NEEDED")) {
+		return "", nil, fmt.Errorf("artifact has dynamic dependencies: %s", strings.TrimSpace(string(dynamicOutput)))
+	}
+	programOutput, err := workCountRunBounded("", environment, workCountGitTimeout, readelf.Path, "-l", artifact)
+	if err != nil {
+		return "", nil, fmt.Errorf("readelf program-header proof: %w", err)
+	}
+	if bytes.Contains(programOutput, []byte("INTERP")) {
+		return "", nil, fmt.Errorf("artifact has a dynamic program interpreter: %s", strings.TrimSpace(string(programOutput)))
+	}
+	return staticCPerfLinkageProof, map[string]workCountToolIdentity{"nm": nm, "readelf": readelf}, nil
+}
+
+func workCountBuildGo(t *testing.T, source workCountSourceSnapshot, tempRoot string, environment workCountEnvironment, tagged bool) (string, workCountArtifactIdentity, func() error) {
+	t.Helper()
+	tool := workCountTool(t, "go")
+	name := "go_admission.test"
+	flags := []string{"test", "-c", "."}
+	args := []string{"test", "-c"}
+	if tagged {
+		name = "go_work_count.test"
+		flags = []string{"test", "-c", "-tags", "gts_workcount", "."}
+		args = append(args, "-tags", "gts_workcount")
+	}
+	artifact := filepath.Join(tempRoot, name)
+	args = append(args, "-o", artifact, ".")
+	buildEnv := workCountSanitizedEnv(os.Environ(), environment.Build, nil)
+	if _, err := workCountRunBounded(source.Root, buildEnv, workCountBuildTimeout, tool.Path, args...); err != nil {
+		t.Fatal(err)
+	}
+	sha := workCountFileSHA(t, artifact)
+	identity := workCountArtifactIdentity{
+		ArtifactSHA256: sha, SourceSnapshotSHA: source.Provenance.SnapshotSHA256,
+		Tool: tool, Flags: flags,
+	}
+	return artifact, identity, func() error {
+		gotSHA, err := fileSHA256(artifact)
+		if err != nil || gotSHA != sha {
+			return fmt.Errorf("artifact sha=%s want=%s err=%v", gotSHA, sha, err)
+		}
+		gotTool, err := workCountToolAt(tool.Path)
+		if err != nil || gotTool != tool {
+			return fmt.Errorf("Go tool identity=%+v want=%+v err=%v", gotTool, tool, err)
+		}
+		return source.Recheck()
+	}
+}
+
+func workCountRunC(t *testing.T, artifact, sourcePath, tempRoot string) workCountCChildResult {
+	t.Helper()
+	dumpPath := filepath.Join(tempRoot, "c.deep")
+	environment := workCountSanitizedEnv(os.Environ(), workCountCBuildEnvironment(), nil)
+	stdout, stderr, err := workCountRunCaptured("", environment, workCountTimeout+staticCPerfWallGrace, artifact, sourcePath, dumpPath, strconv.FormatInt(workCountTimeout.Microseconds(), 10))
+	if err != nil {
+		t.Fatalf("static C work-count child: %v", err)
+	}
+	if len(stderr) != 0 {
+		t.Fatalf("static C work-count child wrote stderr: %s", strings.TrimSpace(string(stderr)))
+	}
+	result := workCountDecodeCChild(t, stdout)
+	result.DeepTreeSHA256 = workCountFileSHA(t, dumpPath)
+	return result
+}
+
+func workCountRunGoAdmission(t *testing.T, artifact, sourcePath, tempRoot string, environment workCountEnvironment) workCountGoChildResult {
+	t.Helper()
+	resultPath := filepath.Join(tempRoot, "go-admission.json")
+	workCountRunGoChild(t, artifact, "^TestWorkCountAdmissionChild$", sourcePath, resultPath, environment)
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return workCountDecodeGoChild(t, data)
+}
+
+func workCountRunGo(t *testing.T, artifact, sourcePath, tempRoot string, environment workCountEnvironment) workCountTaggedChildResult {
+	t.Helper()
+	resultPath := filepath.Join(tempRoot, "go-work-count.json")
+	workCountRunGoChild(t, artifact, "^TestDiagnosticWorkCountChild$", sourcePath, resultPath, environment)
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return workCountDecodeTaggedGoChild(t, data)
+}
+
+func workCountRunGoChild(t *testing.T, artifact, testPattern, sourcePath, resultPath string, environment workCountEnvironment) {
+	t.Helper()
+	if err := os.Remove(resultPath); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	runtimeEnv := workCountSanitizedEnv(os.Environ(), environment.Runtime, map[string]string{
+		"GTS_WORK_COUNT_SOURCE": sourcePath,
+		"GTS_WORK_COUNT_RESULT": resultPath,
+	})
+	stdout, stderr, err := workCountRunCaptured("", runtimeEnv, workCountTimeout+staticCPerfWallGrace, artifact, "-test.run", testPattern, "-test.count=1")
+	if err != nil {
+		t.Fatalf("Go child: %v: stdout=%s stderr=%s", err, strings.TrimSpace(string(stdout)), strings.TrimSpace(string(stderr)))
+	}
+	if len(stderr) != 0 {
+		t.Fatalf("Go child wrote stderr: %s", strings.TrimSpace(string(stderr)))
+	}
+}
+
+var workCountGoChildFields = []string{
+	"schema", "engine", "fixture", "source_sha256", "source_bytes",
+	"grammar_commit", "grammar_blob_sha256", "digest_format",
+	"deep_tree_sha256", "root_end_byte", "root_has_error",
+	"max_stacks_seen", "multi_stack_iterations", "multi_stack_tokens",
+}
+
+func workCountDecodeGoChild(t *testing.T, data []byte) workCountGoChildResult {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode child object: %v: %s", err, data)
+	}
+	workCountRequireKeys(t, "Go child", raw, workCountGoChildFields)
+	var result workCountGoChildResult
+	workCountDecodeExact(t, data, &result)
+	return result
+}
+
+func workCountDecodeTaggedGoChild(t *testing.T, data []byte) workCountTaggedChildResult {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode child object: %v: %s", err, data)
+	}
+	fields := append(append([]string(nil), workCountGoChildFields...), "counters")
+	workCountRequireKeys(t, "tagged Go child", raw, fields)
+	workCountValidateGoCounterObject(t, raw["counters"])
+	var result workCountTaggedChildResult
+	workCountDecodeExact(t, data, &result)
+	return result
+}
+
+func workCountDecodeCChild(t *testing.T, data []byte) workCountCChildResult {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode C child object: %v: %s", err, data)
+	}
+	workCountRequireKeys(t, "C child", raw, []string{"schema", "engine", "digest_format", "source_bytes", "root_end_byte", "root_has_error", "counters"})
+	workCountValidateCounterObject(t, raw["counters"])
+	var result workCountCChildResult
+	workCountDecodeExact(t, data, &result)
+	return result
+}
+
+func workCountValidateCounterObject(t *testing.T, data json.RawMessage) {
+	t.Helper()
+	var counterRaw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &counterRaw); err != nil {
+		t.Fatal(err)
+	}
+	counterKeys := append([]string{"contract", "overflow"}, workCountDirectFields...)
+	counterKeys = append(counterKeys, workCountTerminalFields...)
+	counterKeys = append(counterKeys, workCountProxyFields...)
+	workCountRequireKeys(t, "counters", counterRaw, counterKeys)
+}
+
+func workCountValidateGoCounterObject(t *testing.T, data json.RawMessage) {
+	t.Helper()
+	var counterRaw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &counterRaw); err != nil {
+		t.Fatal(err)
+	}
+	counterKeys := append([]string{"contract", "overflow"}, workCountDirectFields...)
+	counterKeys = append(counterKeys, workCountTerminalFields...)
+	counterKeys = append(counterKeys, workCountProxyFields...)
+	counterKeys = append(counterKeys, "attempts", "outside_attempt")
+	workCountRequireKeys(t, "Go counters", counterRaw, counterKeys)
+	workCountValidateCounterValuesObject(t, "Go outside-attempt counters", counterRaw["outside_attempt"])
+	var attempts []json.RawMessage
+	if err := json.Unmarshal(counterRaw["attempts"], &attempts); err != nil {
+		t.Fatal(err)
+	}
+	for i, attemptRaw := range attempts {
+		var attempt map[string]json.RawMessage
+		if err := json.Unmarshal(attemptRaw, &attempt); err != nil {
+			t.Fatal(err)
+		}
+		workCountRequireKeys(t, fmt.Sprintf("Go attempt %d", i+1), attempt, []string{
+			"index", "logical_rung", "operation_cause",
+			"requested_max_stacks", "requested_max_nodes", "requested_max_merge_per_key",
+			"caps_resolved", "resolved_max_stacks", "resolved_retry_pass", "resolved_max_merge_per_key",
+			"resolved_stack_cull_trigger", "resolved_max_iterations", "resolved_max_nodes",
+			"stop_reason", "root_has_error", "root_end_byte",
+			"entry_to_caps", "caps_to_finalize", "finalize", "counters",
+		})
+		for _, key := range []string{"entry_to_caps", "caps_to_finalize", "finalize", "counters"} {
+			workCountValidateCounterValuesObject(t, fmt.Sprintf("Go attempt %d %s", i+1, key), attempt[key])
+		}
+	}
+}
+
+func workCountValidateCounterValuesObject(t *testing.T, label string, data json.RawMessage) {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	fields := append(append([]string(nil), workCountDirectFields...), workCountTerminalFields...)
+	fields = append(fields, workCountProxyFields...)
+	workCountRequireKeys(t, label, raw, fields)
+}
+
+func workCountDecodeExact(t *testing.T, data []byte, result any) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(result); err != nil {
+		t.Fatal(err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("child JSON has trailing value: %v", err)
+	}
+}
+
+func workCountValidateGoChild(t *testing.T, label, expectedEngine string, result workCountGoChildResult, fixture benchfixtures.LoadedFixture) {
+	t.Helper()
+	if result.Schema != workCountGoChildSchema || result.DigestFormat != benchfixtures.DeepTreeDigestVersion {
+		t.Fatalf("%s mixed contract: schema=%q digest=%q", label, result.Schema, result.DigestFormat)
+	}
+	if result.Engine != expectedEngine {
+		t.Fatalf("%s engine=%q want=%q", label, result.Engine, expectedEngine)
+	}
+	if result.Fixture != fixture.Fixture.ID || result.SourceSHA256 != fixture.Fixture.SHA256 {
+		t.Fatalf("%s fixture/source=%q/%s want=%q/%s", label, result.Fixture, result.SourceSHA256, fixture.Fixture.ID, fixture.Fixture.SHA256)
+	}
+	if result.GrammarCommit != benchfixtures.GoGrammarCommit || result.GrammarBlobSHA256 != benchfixtures.GoGrammarBlobSHA256 {
+		t.Fatalf("%s grammar=%s/%s want=%s/%s", label, result.GrammarCommit, result.GrammarBlobSHA256, benchfixtures.GoGrammarCommit, benchfixtures.GoGrammarBlobSHA256)
+	}
+	if result.SourceBytes != uint32(len(fixture.Source)) || result.RootEndByte != uint32(len(fixture.Source)) || result.RootHasError {
+		t.Fatalf("%s span/error admission: source=%d root_end=%d error=%v", label, result.SourceBytes, result.RootEndByte, result.RootHasError)
+	}
+	if result.DeepTreeSHA256 != fixture.Fixture.DeepTreeSHA256 {
+		t.Fatalf("%s digest=%s want=%s", label, result.DeepTreeSHA256, fixture.Fixture.DeepTreeSHA256)
+	}
+	identity := fixture.Fixture.WorkloadIdentity
+	if result.MaxStacksSeen < identity.MinMaxStacksSeen || result.MultiStackIters < identity.MinMultiStackIterations || result.MultiStackTokens < identity.MinMultiStackTokens {
+		t.Fatalf("%s GLR identity stacks=%d iterations=%d tokens=%d", label, result.MaxStacksSeen, result.MultiStackIters, result.MultiStackTokens)
+	}
+}
+
+func workCountValidateCChild(t *testing.T, label, expectedEngine string, result workCountCChildResult, fixture benchfixtures.LoadedFixture, digest string) {
+	t.Helper()
+	if result.Schema != workCountCChildSchema || result.DigestFormat != benchfixtures.DeepTreeDigestVersion {
+		t.Fatalf("%s mixed contract: schema=%q digest=%q", label, result.Schema, result.DigestFormat)
+	}
+	if result.Engine != expectedEngine {
+		t.Fatalf("%s engine=%q want=%q", label, result.Engine, expectedEngine)
+	}
+	if result.SourceBytes != uint32(len(fixture.Source)) || result.RootEndByte != uint32(len(fixture.Source)) || result.RootHasError {
+		t.Fatalf("%s span/error admission: source=%d root_end=%d error=%v", label, result.SourceBytes, result.RootEndByte, result.RootHasError)
+	}
+	if result.DeepTreeSHA256 != digest {
+		t.Fatalf("%s instrumented digest=%s want uninstrumented=%s", label, result.DeepTreeSHA256, digest)
+	}
+	workCountValidateCounters(t, label, result.Counters)
+}
+
+func workCountValidateCounters(t *testing.T, label string, c workCountCounters) {
+	t.Helper()
+	if c.Contract != workCountContract || c.Overflow {
+		t.Fatalf("%s counters contract=%q overflow=%v", label, c.Contract, c.Overflow)
+	}
+	if c.SelectedNodes == 0 || c.SelectedNodes != c.SelectedParentNodes+c.SelectedLeafNodes {
+		t.Fatalf("%s selected node census invalid: total=%d parent=%d leaf=%d", label, c.SelectedNodes, c.SelectedParentNodes, c.SelectedLeafNodes)
+	}
+	if c.Reductions != c.ReductionPopRequests {
+		t.Fatalf("%s reduce/pop-request mismatch: reductions=%d requests=%d", label, c.Reductions, c.ReductionPopRequests)
+	}
+}
+
+func workCountValidateGoCounters(t *testing.T, label string, c workCountGoCounters, sourceBytes uint32) {
+	t.Helper()
+	workCountValidateCounters(t, label, c.workCountCounters)
+	if len(c.Attempts) != 1 {
+		t.Fatalf("%s attempts=%d want=1", label, len(c.Attempts))
+	}
+	attempt := c.Attempts[0]
+	if attempt.Index != 1 || attempt.LogicalRung != "initial_full" || attempt.OperationCause != "fresh_dfa_full_parse" {
+		t.Fatalf("%s attempt identity=%d/%q/%q", label, attempt.Index, attempt.LogicalRung, attempt.OperationCause)
+	}
+	if !attempt.CapsResolved {
+		t.Fatalf("%s attempt caps were not resolved", label)
+	}
+	if attempt.StopReason != string("accepted") || attempt.RootHasError || attempt.RootEndByte != sourceBytes {
+		t.Fatalf("%s attempt result stop=%q error=%v end=%d want=%d", label, attempt.StopReason, attempt.RootHasError, attempt.RootEndByte, sourceBytes)
+	}
+	if c.AcceptActions != 3 || attempt.Counters.AcceptActions != 3 {
+		t.Fatalf("%s accept actions aggregate=%d attempt=%d want=3", label, c.AcceptActions, attempt.Counters.AcceptActions)
+	}
+	workCountRequireValueSum(t, label+" attempt phases", attempt.Counters, attempt.EntryToCaps, attempt.CapsToFinalize, attempt.Finalize)
+	parts := make([]workCountCounterValues, 0, len(c.Attempts)+1)
+	for _, item := range c.Attempts {
+		parts = append(parts, item.Counters)
+	}
+	parts = append(parts, c.OutsideAttempt)
+	workCountRequireValueSum(t, label+" aggregate attribution", c.workCountCounterValues, parts...)
+}
+
+func workCountRequireValueSum(t *testing.T, label string, total workCountCounterValues, parts ...workCountCounterValues) {
+	t.Helper()
+	totalValues := workCountCounterValueMap(total)
+	sums := make(map[string]uint64, len(totalValues))
+	for _, part := range parts {
+		for field, value := range workCountCounterValueMap(part) {
+			if ^uint64(0)-sums[field] < value {
+				t.Fatalf("%s field %s sum overflow", label, field)
+			}
+			sums[field] += value
+		}
+	}
+	for field, want := range totalValues {
+		if got := sums[field]; got != want {
+			t.Fatalf("%s field %s sum=%d want=%d", label, field, got, want)
+		}
+	}
+}
+
+func workCountCounterValueMap(values workCountCounterValues) map[string]uint64 {
+	data, _ := json.Marshal(values)
+	var raw map[string]uint64
+	_ = json.Unmarshal(data, &raw)
+	return raw
+}
+
+func workCountRatios(goCounts, cCounts workCountCounters) []workCountRatio {
+	goValues := workCountValues(goCounts)
+	cValues := workCountValues(cCounts)
+	var ratios []workCountRatio
+	for _, classFields := range []struct {
+		class  string
+		fields []string
+	}{{"direct", workCountDirectFields}, {"terminal", workCountTerminalFields}, {"proxy", workCountProxyFields}} {
+		for _, field := range classFields.fields {
+			ratio := workCountRatio{Field: field, Class: classFields.class, Go: goValues[field], C: cValues[field]}
+			if ratio.C != 0 {
+				value := float64(ratio.Go) / float64(ratio.C)
+				ratio.GoOverC = &value
+			}
+			ratios = append(ratios, ratio)
+		}
+	}
+	return ratios
+}
+
+func workCountValues(c workCountCounters) map[string]uint64 {
+	data, _ := json.Marshal(c)
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(data, &raw)
+	values := make(map[string]uint64, len(raw))
+	for key, value := range raw {
+		var count uint64
+		if json.Unmarshal(value, &count) == nil {
+			values[key] = count
+		}
+	}
+	return values
+}
+
+func workCountConstructionSurplus(t *testing.T, label string, c workCountCounters) uint64 {
+	t.Helper()
+	if ^uint64(0)-c.LeafConstructionsProxy < c.ParentConstructionsProxy {
+		t.Fatalf("%s construction sum overflow", label)
+	}
+	constructed := c.LeafConstructionsProxy + c.ParentConstructionsProxy
+	if constructed < c.SelectedNodes {
+		t.Fatalf("%s constructed payloads=%d below selected nodes=%d", label, constructed, c.SelectedNodes)
+	}
+	return constructed - c.SelectedNodes
+}
+
+func workCountValidateManifest(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	workCountRequireKeys(t, "manifest", raw, []string{"schema", "counter_contract", "scope", "direct", "terminal", "proxy", "derived", "attempt_attribution", "convergence_frontier", "admission"})
+	var manifest struct {
+		Schema          string            `json:"schema"`
+		CounterContract string            `json:"counter_contract"`
+		Scope           string            `json:"scope"`
+		Direct          map[string]string `json:"direct"`
+		Terminal        map[string]string `json:"terminal"`
+		Proxy           map[string]string `json:"proxy"`
+		Derived         map[string]string `json:"derived"`
+		Attempt         struct {
+			LogicalRungs                     []string `json:"logical_rungs"`
+			ResolvedRetryPassIsIndependent   bool     `json:"resolved_retry_pass_is_independent"`
+			Phases                           []string `json:"phases"`
+			RequireAggregateEqualsAttributed bool     `json:"require_aggregate_equals_attempts_plus_outside"`
+			CanonicalAttempts                int      `json:"canonical_query_compile_attempts"`
+			CanonicalAcceptActions           uint64   `json:"canonical_query_compile_accept_actions"`
+			RetryWitness                     struct {
+				Path          string   `json:"path"`
+				Bytes         int      `json:"bytes"`
+				SHA256        string   `json:"sha256"`
+				ExpectedRungs []string `json:"expected_rungs"`
+			} `json:"retry_witness"`
+			StraightLRControl struct {
+				Path              string `json:"path"`
+				Bytes             int    `json:"bytes"`
+				SHA256            string `json:"sha256"`
+				ExpectedMaxStacks int    `json:"expected_max_stacks"`
+			} `json:"straight_lr_control"`
+		} `json:"attempt_attribution"`
+		Convergence map[string]any `json:"convergence_frontier"`
+		Admission   map[string]any `json:"admission"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Schema != "gts-work-count-contract/v2" || manifest.CounterContract != workCountContract || strings.TrimSpace(manifest.Scope) == "" {
+		t.Fatalf("manifest contract mismatch: schema=%q counters=%q scope=%q", manifest.Schema, manifest.CounterContract, manifest.Scope)
+	}
+	workCountRequireStringKeys(t, "manifest direct", manifest.Direct, workCountDirectFields)
+	workCountRequireStringKeys(t, "manifest terminal", manifest.Terminal, workCountTerminalFields)
+	workCountRequireStringKeys(t, "manifest proxy", manifest.Proxy, workCountProxyFields)
+	workCountRequireStringKeys(t, "manifest derived", manifest.Derived, []string{"construction_surplus"})
+	var attemptRaw map[string]json.RawMessage
+	if err := json.Unmarshal(raw["attempt_attribution"], &attemptRaw); err != nil {
+		t.Fatal(err)
+	}
+	attempt := make(map[string]json.RawMessage, len(attemptRaw))
+	for key := range attemptRaw {
+		attempt[key] = nil
+	}
+	workCountRequireKeys(t, "manifest attempt attribution", attempt, []string{
+		"logical_rungs", "resolved_retry_pass_is_independent", "phases",
+		"require_aggregate_equals_attempts_plus_outside", "canonical_query_compile_attempts",
+		"canonical_query_compile_accept_actions", "retry_witness", "straight_lr_control",
+	})
+	if got := strings.Join(manifest.Attempt.LogicalRungs, ","); got != "initial_full,initial_merge,clean_wide,clean_wide_merge,recovery_wide_or_node,secondary_node,final_merge" {
+		t.Fatalf("manifest logical rungs=%q", got)
+	}
+	if got := strings.Join(manifest.Attempt.Phases, ","); got != "entry_to_caps,caps_to_finalize,finalize" {
+		t.Fatalf("manifest attempt phases=%q", got)
+	}
+	if !manifest.Attempt.ResolvedRetryPassIsIndependent || !manifest.Attempt.RequireAggregateEqualsAttributed ||
+		manifest.Attempt.CanonicalAttempts != 1 || manifest.Attempt.CanonicalAcceptActions != 3 {
+		t.Fatalf("manifest attribution invariants are incomplete: %+v", manifest.Attempt)
+	}
+	if got := strings.Join(manifest.Attempt.RetryWitness.ExpectedRungs, ","); got != "initial_full,initial_merge" {
+		t.Fatalf("manifest retry witness rungs=%q", got)
+	}
+	if manifest.Attempt.StraightLRControl.ExpectedMaxStacks != 1 {
+		t.Fatalf("manifest straight-LR max stacks=%d want=1", manifest.Attempt.StraightLRControl.ExpectedMaxStacks)
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(path), "..", ".."))
+	workCountValidateFrozenWitness(t, repoRoot, "retry", manifest.Attempt.RetryWitness.Path, manifest.Attempt.RetryWitness.Bytes, manifest.Attempt.RetryWitness.SHA256)
+	workCountValidateFrozenWitness(t, repoRoot, "straight-LR", manifest.Attempt.StraightLRControl.Path, manifest.Attempt.StraightLRControl.Bytes, manifest.Attempt.StraightLRControl.SHA256)
+	convergence := make(map[string]json.RawMessage, len(manifest.Convergence))
+	for key := range manifest.Convergence {
+		convergence[key] = nil
+	}
+	workCountRequireKeys(t, "manifest convergence frontier", convergence, []string{
+		"status", "max_events", "record_first_reject_per_reason", "identity", "outcomes", "snapshots",
+		"include_cumulative_direct_and_proxy_counts", "terminal_counters", "interpretation",
+	})
+	if status, _ := manifest.Convergence["status"].(string); status != "schema_reserved_not_implemented" {
+		t.Fatalf("manifest convergence status=%q", status)
+	}
+	if maxEvents, _ := manifest.Convergence["max_events"].(float64); maxEvents != 256 {
+		t.Fatalf("manifest convergence max events=%v", manifest.Convergence["max_events"])
+	}
+	admission := make(map[string]json.RawMessage, len(manifest.Admission))
+	for key := range manifest.Admission {
+		admission[key] = nil
+	}
+	workCountRequireKeys(t, "manifest admission", admission, []string{
+		"digest_format", "fixture", "require_uninstrumented_go_static_c_digest_match_first",
+		"require_instrumented_digest_match", "require_full_span", "require_clean_root",
+		"require_no_overflow", "require_exact_fields", "require_ordinary_untagged_go_child_first",
+		"require_clean_git_source_for_authoritative_receipt", "require_private_content_addressed_go_source_snapshot",
+		"require_private_c_input_snapshot", "sanitize_go_and_parser_environment", "atomic_receipt_publish",
+	})
+}
+
+func workCountValidateFrozenWitness(t *testing.T, repoRoot, label, relativePath string, wantBytes int, wantSHA string) {
+	t.Helper()
+	if relativePath == "" || filepath.IsAbs(relativePath) {
+		t.Fatalf("manifest %s witness path=%q", label, relativePath)
+	}
+	path := filepath.Clean(filepath.Join(repoRoot, filepath.FromSlash(relativePath)))
+	rel, err := filepath.Rel(repoRoot, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		t.Fatalf("manifest %s witness escapes repository: path=%q rel=%q err=%v", label, path, rel, err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != int64(wantBytes) {
+		t.Fatalf("manifest %s witness mode/bytes=%s/%d want regular/%d", label, info.Mode(), info.Size(), wantBytes)
+	}
+	if got := workCountFileSHA(t, path); got != wantSHA {
+		t.Fatalf("manifest %s witness sha256=%s want=%s", label, got, wantSHA)
+	}
+}
+
+func workCountRequireKeys(t *testing.T, label string, values map[string]json.RawMessage, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(values))
+	for key := range values {
+		got = append(got, key)
+	}
+	sort.Strings(got)
+	want = append([]string(nil), want...)
+	sort.Strings(want)
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("%s fields=%v want=%v", label, got, want)
+	}
+}
+
+func workCountRequireStringKeys(t *testing.T, label string, values map[string]string, want []string) {
+	t.Helper()
+	raw := make(map[string]json.RawMessage, len(values))
+	for key, value := range values {
+		if strings.TrimSpace(value) == "" {
+			t.Fatalf("%s field %s has empty definition", label, key)
+		}
+		raw[key] = nil
+	}
+	workCountRequireKeys(t, label, raw, want)
+}
+
+func workCountTool(t *testing.T, name string) workCountToolIdentity {
+	t.Helper()
+	identity, err := workCountToolNamed(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func workCountToolNamed(name string) (workCountToolIdentity, error) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return workCountToolIdentity{}, err
+	}
+	return workCountToolAt(path)
+}
+
+func workCountToolAt(path string) (workCountToolIdentity, error) {
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return workCountToolIdentity{}, err
+	}
+	args := []string{"--version"}
+	if filepath.Base(resolved) == "go" || filepath.Base(resolved) == "go.exe" {
+		args = []string{"version"}
+	}
+	environment := workCountSanitizedEnv(os.Environ(), workCountCBuildEnvironment(), nil)
+	out, err := workCountRunBounded("", environment, workCountGitTimeout, resolved, args...)
+	if err != nil {
+		return workCountToolIdentity{}, fmt.Errorf("read tool version %s: %w", resolved, err)
+	}
+	version := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	if version == "" {
+		return workCountToolIdentity{}, fmt.Errorf("tool %s returned an empty version", resolved)
+	}
+	sha, err := fileSHA256(resolved)
+	if err != nil {
+		return workCountToolIdentity{}, err
+	}
+	return workCountToolIdentity{Path: resolved, Version: version, SHA256: sha}, nil
+}
+
+func workCountFileSHA(t *testing.T, path string) string {
+	t.Helper()
+	sha, err := fileSHA256(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sha
+}
+
+func workCountCopyTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+		if err != nil {
+			_ = in.Close()
+			return err
+		}
+		_, copyErr := io.Copy(out, in)
+		closeInErr := in.Close()
+		closeErr := out.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeInErr != nil {
+			return closeInErr
+		}
+		return closeErr
+	})
+}

--- a/cgo_harness/work_count_security_test.go
+++ b/cgo_harness/work_count_security_test.go
@@ -1,0 +1,739 @@
+//go:build cgo && treesitter_c_parity && treesitter_c_perfscan
+
+package cgoharness
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	workCountAllowDirtyEnv     = "GTS_WORK_COUNT_ALLOW_DIRTY"
+	workCountColdCAdmissionEnv = "GTS_WORK_COUNT_COLD_C_ADMISSION_TEST"
+	workCountBuildTimeout      = 3 * time.Minute
+	workCountGitTimeout        = 30 * time.Second
+	workCountUnsetEnvValue     = "<unset>"
+)
+
+type workCountGitProvenance struct {
+	Authoritative     bool   `json:"authoritative"`
+	GitClean          bool   `json:"git_clean"`
+	Head              string `json:"head"`
+	HeadTree          string `json:"head_tree"`
+	SnapshotSHA256    string `json:"snapshot_sha256"`
+	SnapshotFiles     int    `json:"snapshot_files"`
+	SnapshotMode      string `json:"snapshot_mode"`
+	DirtyStatusSHA256 string `json:"dirty_status_sha256,omitempty"`
+}
+
+type workCountSourceSnapshot struct {
+	Root       string
+	Provenance workCountGitProvenance
+	Recheck    func() error
+}
+
+type workCountEnvironment struct {
+	Build   map[string]string `json:"build"`
+	Runtime map[string]string `json:"runtime"`
+}
+
+func workCountChosenEnvironment() workCountEnvironment {
+	return workCountEnvironment{
+		Build: map[string]string{
+			"CGO_ENABLED":  "0",
+			"GOAMD64":      "v1",
+			"GOARCH":       runtime.GOARCH,
+			"GODEBUG":      "",
+			"GOENV":        "off",
+			"GOEXPERIMENT": "",
+			"GOFLAGS":      "-mod=readonly -trimpath -buildvcs=false -p=1",
+			"GOGC":         "100",
+			"GOMEMLIMIT":   "off",
+			"GOMAXPROCS":   "1",
+			"GOOS":         runtime.GOOS,
+			"GOTOOLCHAIN":  "local",
+			"GONOPROXY":    "",
+			"GONOSUMDB":    "",
+			"GOPRIVATE":    "",
+			"GOPROXY":      "off",
+			"GOSUMDB":      "sum.golang.org",
+			"GOT_*":        "unset",
+			"GOVCS":        "*:off",
+			"GOWORK":       "off",
+			"LANG":         "C",
+			"LC_ALL":       "C",
+			"TZ":           "UTC",
+		},
+		Runtime: map[string]string{
+			"GOAMD64":      "v1",
+			"GODEBUG":      "",
+			"GOENV":        "off",
+			"GOEXPERIMENT": "",
+			"GOFLAGS":      "",
+			"GOGC":         "100",
+			"GOMEMLIMIT":   "off",
+			"GOMAXPROCS":   "1",
+			"GOTOOLCHAIN":  "local",
+			"GOT_*":        "unset",
+			"LANG":         "C",
+			"LC_ALL":       "C",
+			"TZ":           "UTC",
+		},
+	}
+}
+
+func workCountCBuildEnvironment() map[string]string {
+	return map[string]string{
+		"CFLAGS":              "",
+		"CPPFLAGS":            "",
+		"CPATH":               "",
+		"CPLUS_INCLUDE_PATH":  "",
+		"CXXFLAGS":            "",
+		"COMPILER_PATH":       workCountUnsetEnvValue,
+		"GCC_EXEC_PREFIX":     workCountUnsetEnvValue,
+		"GIT_CONFIG_GLOBAL":   "/dev/null",
+		"GIT_CONFIG_NOSYSTEM": "1",
+		"GIT_DIR":             workCountUnsetEnvValue,
+		"GIT_WORK_TREE":       workCountUnsetEnvValue,
+		"LANG":                "C",
+		"LC_ALL":              "C",
+		"LDFLAGS":             "",
+		"LIBRARY_PATH":        "",
+		"LD_LIBRARY_PATH":     "",
+		"SOURCE_DATE_EPOCH":   "0",
+		"TZ":                  "UTC",
+	}
+}
+
+func workCountSanitizedEnv(base []string, chosen map[string]string, extra map[string]string) []string {
+	removed := map[string]bool{
+		"CGO_ENABLED": true, "GOAMD64": true, "GOARCH": true,
+		"GODEBUG": true, "GOENV": true, "GOEXPERIMENT": true,
+		"GOFLAGS": true, "GOGC": true, "GOMEMLIMIT": true,
+		"GOMAXPROCS": true, "GOOS": true, "GOTOOLCHAIN": true,
+	}
+	for key := range chosen {
+		removed[key] = true
+	}
+	for key := range extra {
+		removed[key] = true
+	}
+	out := make([]string, 0, len(base)+len(chosen)+len(extra))
+	for _, item := range base {
+		key := item
+		if index := strings.IndexByte(item, '='); index >= 0 {
+			key = item[:index]
+		}
+		if removed[key] || strings.HasPrefix(key, "GOT_") {
+			continue
+		}
+		out = append(out, item)
+	}
+	appendMap := func(values map[string]string) {
+		keys := make([]string, 0, len(values))
+		for key := range values {
+			if key == "GOT_*" {
+				continue
+			}
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if values[key] == workCountUnsetEnvValue {
+				continue
+			}
+			out = append(out, key+"="+values[key])
+		}
+	}
+	appendMap(chosen)
+	appendMap(extra)
+	return out
+}
+
+func workCountRunBounded(dir string, env []string, timeout time.Duration, name string, args ...string) ([]byte, error) {
+	stdout, stderr, err := workCountRunCaptured(dir, env, timeout, name, args...)
+	output := append(append([]byte(nil), stdout...), stderr...)
+	return output, err
+}
+
+func workCountRunCaptured(dir string, env []string, timeout time.Duration, name string, args ...string) ([]byte, []byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err, stop := perfScanRunChild(ctx, cmd, 0)
+	if stop != nil && stop.Class == perfScanStopWallTimeout {
+		return stdout.Bytes(), stderr.Bytes(), fmt.Errorf("%s timed out after %s", filepath.Base(name), timeout)
+	}
+	if err != nil {
+		message := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return stdout.Bytes(), stderr.Bytes(), fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), message)
+	}
+	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
+func workCountPrepareSourceSnapshot(t *testing.T, repoRoot, tempRoot string) workCountSourceSnapshot {
+	t.Helper()
+	gitEnv := workCountSanitizedEnv(os.Environ(), nil, map[string]string{
+		"GIT_CONFIG_GLOBAL":   "/dev/null",
+		"GIT_CONFIG_NOSYSTEM": "1",
+		"GIT_TERMINAL_PROMPT": "0",
+	})
+	gitOutput := func(args ...string) []byte {
+		output, err := workCountRunBounded(repoRoot, gitEnv, workCountGitTimeout, "git", args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return output
+	}
+	head := strings.TrimSpace(string(gitOutput("rev-parse", "--verify", "HEAD^{commit}")))
+	headTree := strings.TrimSpace(string(gitOutput("rev-parse", "--verify", "HEAD^{tree}")))
+	if !staticCHashIdentity(head) || !staticCHashIdentity(headTree) {
+		t.Fatalf("invalid source provenance head=%q tree=%q", head, headTree)
+	}
+	status := gitOutput("status", "--porcelain=v1", "-z", "--untracked-files=all")
+	clean := len(status) == 0
+	authoritative := clean
+	if !clean && os.Getenv(workCountAllowDirtyEnv) != "1" {
+		t.Fatalf("authoritative work-count source must be clean; set %s=1 only for a non-authoritative pre-commit test", workCountAllowDirtyEnv)
+	}
+
+	staging := filepath.Join(tempRoot, "go-source-staging")
+	if err := os.Mkdir(staging, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mode := "git-archive-head"
+	if clean {
+		archivePath := filepath.Join(tempRoot, "go-source.tar")
+		if _, err := workCountRunBounded(repoRoot, gitEnv, workCountGitTimeout, "git", "archive", "--format=tar", "-o", archivePath, head); err != nil {
+			t.Fatal(err)
+		}
+		if err := workCountExtractTar(archivePath, staging); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(archivePath); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		mode = "dirty-worktree-test-only"
+		paths := gitOutput("ls-files", "-z", "--cached", "--others", "--exclude-standard")
+		for _, raw := range bytes.Split(paths, []byte{0}) {
+			if len(raw) == 0 {
+				continue
+			}
+			if err := workCountCopySnapshotPath(repoRoot, staging, string(raw)); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					continue
+				}
+				t.Fatal(err)
+			}
+		}
+	}
+	snapshotSHA, files, err := workCountTreeSHA(staging)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(tempRoot, "go-source-"+snapshotSHA)
+	if err := os.Rename(staging, root); err != nil {
+		t.Fatal(err)
+	}
+	if err := workCountMakeTreeReadOnly(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = workCountMakeTreeWritable(root) })
+	if got, gotFiles, err := workCountTreeSHA(root); err != nil || got != snapshotSHA || gotFiles != files {
+		t.Fatalf("private Go source snapshot drift after sealing: sha=%s files=%d want=%s/%d err=%v", got, gotFiles, snapshotSHA, files, err)
+	}
+	statusHash := ""
+	if !clean {
+		sum := sha256.Sum256(status)
+		statusHash = hex.EncodeToString(sum[:])
+	}
+	provenance := workCountGitProvenance{
+		Authoritative:     authoritative,
+		GitClean:          clean,
+		Head:              head,
+		HeadTree:          headTree,
+		SnapshotSHA256:    snapshotSHA,
+		SnapshotFiles:     files,
+		SnapshotMode:      mode,
+		DirtyStatusSHA256: statusHash,
+	}
+	recheck := func() error {
+		gotSHA, gotFiles, err := workCountTreeSHA(root)
+		if err != nil || gotSHA != snapshotSHA || gotFiles != files {
+			return fmt.Errorf("private source snapshot sha=%s files=%d want=%s/%d err=%v", gotSHA, gotFiles, snapshotSHA, files, err)
+		}
+		if !authoritative {
+			return nil
+		}
+		gotHead, err := workCountRunBounded(repoRoot, gitEnv, workCountGitTimeout, "git", "rev-parse", "--verify", "HEAD^{commit}")
+		if err != nil || strings.TrimSpace(string(gotHead)) != head {
+			return fmt.Errorf("Git HEAD drift: got=%q want=%q err=%v", strings.TrimSpace(string(gotHead)), head, err)
+		}
+		gotTree, err := workCountRunBounded(repoRoot, gitEnv, workCountGitTimeout, "git", "rev-parse", "--verify", "HEAD^{tree}")
+		if err != nil || strings.TrimSpace(string(gotTree)) != headTree {
+			return fmt.Errorf("Git tree drift: got=%q want=%q err=%v", strings.TrimSpace(string(gotTree)), headTree, err)
+		}
+		gotStatus, err := workCountRunBounded(repoRoot, gitEnv, workCountGitTimeout, "git", "status", "--porcelain=v1", "-z", "--untracked-files=all")
+		if err != nil || len(gotStatus) != 0 {
+			return fmt.Errorf("Git worktree ceased to be clean: status=%q err=%v", gotStatus, err)
+		}
+		return nil
+	}
+	return workCountSourceSnapshot{Root: root, Provenance: provenance, Recheck: recheck}
+}
+
+func workCountClearAmbientGitRouting(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"GIT_DIR", "GIT_WORK_TREE"} {
+		value, present := os.LookupEnv(key)
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+		key, value, present := key, value, present
+		t.Cleanup(func() {
+			if present {
+				_ = os.Setenv(key, value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+	}
+}
+
+func workCountExtractTar(path, destination string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	reader := tar.NewReader(file)
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		target, err := workCountSafeSnapshotTarget(destination, header.Name)
+		if err != nil {
+			return err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fs.FileMode(header.Mode).Perm())
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(out, reader)
+			closeErr := out.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := os.Symlink(header.Linkname, target); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported Git archive entry %q type=%d", header.Name, header.Typeflag)
+		}
+	}
+}
+
+func workCountCopySnapshotPath(sourceRoot, destinationRoot, relative string) error {
+	target, err := workCountSafeSnapshotTarget(destinationRoot, relative)
+	if err != nil {
+		return err
+	}
+	source, err := workCountSafeSnapshotTarget(sourceRoot, relative)
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(source)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		link, err := os.Readlink(source)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(link, target)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("unsupported worktree path %s mode=%s", relative, info.Mode())
+	}
+	return workCountCopyFile(source, target, info.Mode().Perm())
+}
+
+func workCountSafeSnapshotTarget(root, relative string) (string, error) {
+	clean := filepath.Clean(filepath.FromSlash(relative))
+	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("unsafe snapshot path %q", relative)
+	}
+	target := filepath.Join(root, clean)
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("snapshot path escapes root: %q", relative)
+	}
+	return target, nil
+}
+
+func workCountCopyFile(source, destination string, mode fs.FileMode) error {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode.Perm())
+	if err != nil {
+		_ = in.Close()
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	closeInErr := in.Close()
+	closeOutErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeInErr != nil {
+		return closeInErr
+	}
+	return closeOutErr
+}
+
+func workCountTreeSHA(root string) (string, int, error) {
+	hash := sha256.New()
+	files := 0
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root || entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		files++
+		workCountHashField(hash, filepath.ToSlash(relative))
+		var mode [4]byte
+		// Content identity retains type and executable intent but deliberately
+		// ignores writable/readable permission bits changed by source sealing.
+		normalizedMode := info.Mode().Type() | (info.Mode().Perm() & 0o111)
+		binary.LittleEndian.PutUint32(mode[:], uint32(normalizedMode))
+		_, _ = hash.Write(mode[:])
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			workCountHashField(hash, link)
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("unsupported snapshot entry %s mode=%s", relative, info.Mode())
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), files, nil
+}
+
+func workCountHashField(writer io.Writer, value string) {
+	var size [8]byte
+	binary.LittleEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = writer.Write(size[:])
+	_, _ = io.WriteString(writer, value)
+}
+
+func workCountMakeTreeReadOnly(root string) error {
+	var directories []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			directories = append(directories, path)
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		return os.Chmod(path, 0o444|(info.Mode().Perm()&0o111))
+	})
+	if err != nil {
+		return err
+	}
+	for i := len(directories) - 1; i >= 0; i-- {
+		if err := os.Chmod(directories[i], 0o555); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func workCountMakeTreeWritable(root string) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, 0o755)
+		}
+		return os.Chmod(path, 0o644|(info.Mode().Perm()&0o111))
+	})
+}
+
+func workCountPrepareReceiptPath(t *testing.T, repoRoot string) string {
+	t.Helper()
+	path := strings.TrimSpace(os.Getenv(workCountReceiptEnv))
+	if path == "" {
+		path = filepath.Join(repoRoot, "harness_out", "work_count", workCountFixtureID+".json")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resolvedDirectory, err := filepath.EvalSymlinks(filepath.Dir(absolute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	absolute = filepath.Join(resolvedDirectory, filepath.Base(absolute))
+	if err := os.Remove(absolute); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatal(err)
+	}
+	return absolute
+}
+
+func workCountAtomicPublish(path string, data []byte) error {
+	directory := filepath.Dir(path)
+	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	keep := false
+	defer func() {
+		_ = temp.Close()
+		if !keep {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(0o644); err != nil {
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	directoryHandle, err := os.Open(directory)
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	syncErr := directoryHandle.Sync()
+	closeErr := directoryHandle.Close()
+	if syncErr != nil {
+		_ = os.Remove(path)
+		return syncErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(path)
+		return closeErr
+	}
+	keep = true
+	return nil
+}
+
+func TestWorkCountSanitizedEnvDropsParserAndGoOverrides(t *testing.T) {
+	base := []string{
+		"PATH=/bin", "GOFLAGS=-race", "GOAMD64=v4", "GOEXPERIMENT=fieldtrack",
+		"GODEBUG=gctrace=1", "GOT_GLR_MAX_STACKS=99", "GOT_FAKE=1",
+	}
+	chosen := workCountChosenEnvironment().Build
+	got := workCountSanitizedEnv(base, chosen, map[string]string{"EXTRA": "yes"})
+	joined := strings.Join(got, "\n")
+	for _, forbidden := range []string{"-race", "GOAMD64=v4", "fieldtrack", "gctrace=1", "GOT_GLR", "GOT_FAKE"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("sanitized environment retained %q: %s", forbidden, joined)
+		}
+	}
+	for _, required := range []string{"GOFLAGS=-mod=readonly -trimpath -buildvcs=false -p=1", "GOAMD64=v1", "EXTRA=yes"} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("sanitized environment omitted %q: %s", required, joined)
+		}
+	}
+	cChosen := workCountCBuildEnvironment()
+	cGot := strings.Join(workCountSanitizedEnv(
+		[]string{"PATH=/usr/bin", "COMPILER_PATH=/host/compiler", "GCC_EXEC_PREFIX=/host/gcc", "GIT_DIR=/host/repo", "GIT_WORK_TREE=/host/tree"},
+		cChosen,
+		nil,
+	), "\n")
+	for _, forbidden := range []string{"COMPILER_PATH=", "GCC_EXEC_PREFIX=", "GIT_DIR=", "GIT_WORK_TREE="} {
+		if strings.Contains(cGot, forbidden) {
+			t.Fatalf("sanitized C environment retained %q: %s", forbidden, cGot)
+		}
+	}
+	if cChosen["COMPILER_PATH"] != workCountUnsetEnvValue || cChosen["GCC_EXEC_PREFIX"] != workCountUnsetEnvValue {
+		t.Fatalf("unset C environment is not recorded explicitly: %v", cChosen)
+	}
+}
+
+func TestWorkCountRunCapturedKillsDescendantProcessGroup(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "descendant-escaped")
+	environment := workCountSanitizedEnv(os.Environ(), nil, map[string]string{
+		"LANG": "C", "LC_ALL": "C", "TZ": "UTC",
+	})
+	_, _, err := workCountRunCaptured(
+		"",
+		environment,
+		40*time.Millisecond,
+		"sh", "-c", `(sleep 0.2; printf escaped > "$1") & wait`, "work-count-helper", marker,
+	)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("bounded process group error=%v, want timeout", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Fatalf("timed-out descendant escaped process-group kill: %v", statErr)
+	}
+}
+
+func TestWorkCountStaticCAdmissionColdArtifactCache(t *testing.T) {
+	if os.Getenv(workCountColdCAdmissionEnv) != "1" {
+		t.Skipf("set %s=1 for the focused cold-artifact gate", workCountColdCAdmissionEnv)
+	}
+	fixture := workCountLoadFixture(t)
+	repoRoot := workCountRepoRoot(t)
+	lock, err := loadParityLock(filepath.Join(repoRoot, "grammars", "languages.lock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := lock["go"]
+	warmRoot := strings.TrimSpace(os.Getenv(staticCPerfCacheEnv))
+	if warmRoot == "" {
+		warmRoot = filepath.Join(repoRoot, "harness_out", "c_oracle", "fleet_static")
+	}
+	warmRuntime := filepath.Join(warmRoot, "sources", "tree-sitter-"+COracleRuntimeCommit)
+	warmGrammar := filepath.Join(warmRoot, "sources", paritySafeName("go")+"-"+entry.Commit)
+	workCountEnsurePinnedRepo(t, "runtime", staticCPerfRuntimeRepo, COracleRuntimeCommit, warmRuntime, "")
+	workCountEnsurePinnedRepo(t, "go grammar", entry.RepoURL, entry.Commit, warmGrammar, "go")
+
+	tempRoot := t.TempDir()
+	coldRoot := filepath.Join(tempRoot, "cold-c-oracle")
+	coldRuntime := filepath.Join(coldRoot, "sources", filepath.Base(warmRuntime))
+	coldGrammar := filepath.Join(coldRoot, "sources", filepath.Base(warmGrammar))
+	copyTool := workCountTool(t, "cp")
+	environment := workCountSanitizedEnv(os.Environ(), workCountCBuildEnvironment(), nil)
+	for source, destination := range map[string]string{warmRuntime: coldRuntime, warmGrammar: coldGrammar} {
+		if err := os.MkdirAll(destination, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := workCountRunBounded("", environment, workCountBuildTimeout, copyTool.Path, "-a", source+string(filepath.Separator)+".", destination); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := workCountVerifyPinnedRepo(coldRuntime, COracleRuntimeCommit, environment); err != nil {
+		t.Fatal(err)
+	}
+	if err := workCountVerifyPinnedRepo(coldGrammar, entry.Commit, environment); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(coldRoot, "artifacts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if entries, err := os.ReadDir(filepath.Join(coldRoot, "artifacts")); err != nil || len(entries) != 0 {
+		t.Fatalf("cold artifact cache is not empty: entries=%d err=%v", len(entries), err)
+	}
+	t.Setenv(staticCPerfCacheEnv, coldRoot)
+	sourcePath := filepath.Join(tempRoot, "query_compile.go")
+	if err := os.WriteFile(sourcePath, fixture.Source, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := workCountUninstrumentedCAdmission(t, fixture, sourcePath, tempRoot); got != fixture.Fixture.DeepTreeSHA256 {
+		t.Fatalf("cold static C admission digest=%s want=%s", got, fixture.Fixture.DeepTreeSHA256)
+	}
+	artifacts, err := os.ReadDir(filepath.Join(coldRoot, "artifacts"))
+	if err != nil || len(artifacts) != 1 {
+		t.Fatalf("cold static C admission artifact count=%d want=1 err=%v", len(artifacts), err)
+	}
+}

--- a/cgo_harness/work_count_security_test.go
+++ b/cgo_harness/work_count_security_test.go
@@ -340,6 +340,11 @@ func workCountExtractTar(path, destination string) error {
 		if err != nil {
 			return err
 		}
+		// Git archives may carry a global PAX record containing the source
+		// commit identity. It is archive metadata, not a filesystem entry.
+		if header.Typeflag == tar.TypeXGlobalHeader || header.Typeflag == tar.TypeXHeader {
+			continue
+		}
 		target, err := workCountSafeSnapshotTarget(destination, header.Name)
 		if err != nil {
 			return err
@@ -675,6 +680,46 @@ func TestWorkCountRunCapturedKillsDescendantProcessGroup(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 	if _, statErr := os.Stat(marker); !errors.Is(statErr, fs.ErrNotExist) {
 		t.Fatalf("timed-out descendant escaped process-group kill: %v", statErr)
+	}
+}
+
+func TestWorkCountExtractTarAcceptsPAXMetadata(t *testing.T) {
+	root := t.TempDir()
+	archivePath := filepath.Join(root, "snapshot.tar")
+	file, err := os.OpenFile(archivePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := tar.NewWriter(file)
+	if err := writer.WriteHeader(&tar.Header{
+		Typeflag:   tar.TypeXGlobalHeader,
+		PAXRecords: map[string]string{"comment": "0123456789abcdef"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("package fixture\n")
+	if err := writer.WriteHeader(&tar.Header{Name: "fixture.go", Mode: 0o644, Size: int64(len(payload))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(root, "extracted")
+	if err := workCountExtractTar(archivePath, destination); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(destination, "fixture.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("extracted payload=%q want=%q", got, payload)
 	}
 }
 

--- a/glr.go
+++ b/glr.go
@@ -397,6 +397,7 @@ func newGLRStackWithScratch(initial StateID, scratch *glrEntryScratch) glrStack 
 }
 
 func newGLRStackWithScratchCap(initial StateID, scratch *glrEntryScratch, maxInitialCap int) glrStack {
+	workCountRecordVersionCreation()
 	if scratch == nil {
 		return newGLRStack(initial)
 	}
@@ -444,6 +445,7 @@ func (s *glrStack) top() stackEntry {
 }
 
 func (s *glrStack) clone() glrStack {
+	workCountRecordVersionCreation()
 	if s.gss.head == nil && len(s.entries) > 0 {
 		entries := make([]stackEntry, len(s.entries))
 		copy(entries, s.entries)
@@ -486,6 +488,7 @@ func (s *glrStack) clone() glrStack {
 }
 
 func (s *glrStack) cloneWithScratch(scratch *gssScratch) glrStack {
+	workCountRecordVersionCreation()
 	s.ensureGSS(scratch)
 	return glrStack{
 		gss:                        s.gss.clone(),
@@ -3155,6 +3158,7 @@ func gssMainCanMergeForParser(p *Parser, a, b *glrStack) bool {
 }
 
 func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
+	workCountRecordMergeAttempt()
 	if !gssMainCanMergeForParser(p, a, b) {
 		return false
 	}
@@ -3164,6 +3168,7 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 	}
 	merged := gssMainMergeWithScratch(scratch, a, b)
 	if merged {
+		workCountRecordMergeSuccess()
 		// a survives and absorbs b, so OR the sticky wreckage bit: cEverErrored
 		// is lineage history, not current shape, and a clean survivor must not
 		// shed a merged-in recovered-wreckage lineage's error history (see
@@ -4179,6 +4184,7 @@ func gssMainMergeWithScratch(scratch *glrMergeScratch, a, b *glrStack) bool {
 }
 
 func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int, stack *glrStack) (merged bool, attempted bool) {
+	workCountRecordMergeAttempt()
 	if idx < 0 || idx >= len(result) || stack == nil {
 		return false, false
 	}
@@ -4195,6 +4201,7 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 	}
 	merged = gssMainMergeWithScratch(scratch, &result[idx], stack)
 	if merged {
+		workCountRecordMergeSuccess()
 		// result[idx] survives and absorbs stack, so OR the sticky wreckage bit:
 		// a clean survivor that merges a recovered-wreckage lineage must inherit
 		// its error history (see glrStack.cEverErrored / tryGSSMainMergeForParser).

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -91,6 +91,7 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 	if count < capacity && n.extraLinks != nil {
 		unsafe.Slice(n.extraLinks, capacity)[count] = link
 		n.extraLinkCount++
+		workCountRecordGraphLinkAddition()
 		return
 	}
 	newCapacity := 1
@@ -108,6 +109,7 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 	n.extraLinks = &links[0]
 	n.extraLinkCount++
 	n.extraLinkCap = uint8(newCapacity)
+	workCountRecordGraphLinkAddition()
 }
 
 // gssStack is a shared-prefix stack foundation for future GLR work.
@@ -430,6 +432,9 @@ func (s *gssStack) pushEntry(entry stackEntry, scratch *gssScratch) {
 		depth = s.head.depth + 1
 	}
 	n := scratch.allocNode(entry, s.head, depth)
+	if s.head != nil {
+		workCountRecordGraphLinkAddition()
+	}
 	s.head = n
 }
 

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -505,6 +505,7 @@ func newNoTreeLeafNodeInArena(arena *nodeArena, sym Symbol, named bool, startByt
 	} else {
 		n = arena.allocNoTreeNode()
 		arena.noTreeLeafNodesConstructed++
+		workCountRecordLeafConstruction()
 	}
 	n.symbol = sym
 	n.startByte = startByte
@@ -524,6 +525,7 @@ func newCompactCheckpointLeafInArena(arena *nodeArena, sym Symbol, named bool, s
 		n = &compactCheckpointLeaf{}
 	} else {
 		n = arena.allocCompactCheckpointLeaf()
+		workCountRecordLeafConstruction()
 	}
 	n.symbol = sym
 	n.startByte = startByte
@@ -545,6 +547,7 @@ func newCompactFullLeafInArena(arena *nodeArena, sym Symbol, named bool, startBy
 	} else {
 		n = arena.allocCompactFullLeaf()
 		arena.compactFullLeafCreated++
+		workCountRecordLeafConstruction()
 	}
 	n.symbol = sym
 	n.startByte = startByte

--- a/parser.go
+++ b/parser.go
@@ -4341,10 +4341,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		return errorTreeWithOwnedArena(reason)
 	}
 	finalizeTree := func(tree *Tree, stopReason ParseStopReason) *Tree {
-		workCountBeginFinalizeParseAttempt(workCountAttempt)
-		defer func() {
-			workCountEndFinalizeParseAttempt(workCountAttempt, stopReason, tree)
-		}()
+		if workCountInstrumentationEnabled { // work-count-assembly: finalize-defer guard
+			workCountBeginFinalizeParseAttempt(workCountAttempt)
+			defer func() {
+				workCountEndFinalizeParseAttempt(workCountAttempt, stopReason, tree)
+			}()
+		}
 		if phaseTiming && parserLoopNanos == 0 {
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}

--- a/parser.go
+++ b/parser.go
@@ -2819,6 +2819,7 @@ func (p *Parser) parseIncrementalInternal(source []byte, oldTree *Tree, ts Token
 		// correctness footing as Parse.
 		deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
 		initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
+		workCountSetNextParseAttempt("initial_full", "incremental_token_source_fallback_full_parse")
 		tree := p.parseInternal(source, ts, nil, nil, arenaClassFull, timing, initialMaxStacks, 0, 0, deterministicExternalConflicts)
 		tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
 		if shouldRepeatExternalScannerFullParse(p.language, tree) {
@@ -3893,6 +3894,7 @@ func (p *Parser) guardRealShiftGap(source []byte, s *glrStack, tok Token) bool {
 // Stacks that error out are dropped. Only duplicate stack versions are
 // merged; distinct alternatives are preserved.
 func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor, oldTree *Tree, arenaClass arenaClass, timing *incrementalParseTiming, maxStacksOverride int, maxNodesOverride int, maxMergePerKeyOverride int, deterministicExternalConflicts bool) *Tree {
+	workCountAttempt := workCountBeginParseAttempt(maxStacksOverride, maxNodesOverride, maxMergePerKeyOverride)
 	parseStart := time.Now()
 	previousMemoryBudgetDiag := p.parseMemoryBudgetDiag
 	previousMemoryBudgetDiagActive := p.parseMemoryBudgetDiagActive
@@ -4339,6 +4341,10 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		return errorTreeWithOwnedArena(reason)
 	}
 	finalizeTree := func(tree *Tree, stopReason ParseStopReason) *Tree {
+		workCountBeginFinalizeParseAttempt(workCountAttempt)
+		defer func() {
+			workCountEndFinalizeParseAttempt(workCountAttempt, stopReason, tree)
+		}()
 		if phaseTiming && parserLoopNanos == 0 {
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
@@ -4535,6 +4541,15 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 
 	stacks, maxStacksSeen = p.newInitialParseStacks(scratch, reuse, timing, len(source))
 	caps := p.configureParseCaps(source, reuse, arenaClass, scratch, maxStacksOverride, maxNodesOverride, maxMergePerKeyOverride)
+	workCountResolveParseAttempt(
+		workCountAttempt,
+		caps.maxStacks,
+		caps.retryPass,
+		caps.mergePerKeyCap,
+		caps.maxStackCullTrigger,
+		caps.maxIter,
+		caps.maxNodes,
+	)
 	maxStacks := caps.maxStacks
 	retryPass := caps.retryPass
 	mergePerKeyCap := caps.mergePerKeyCap
@@ -5009,6 +5024,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if actionIdx != 0 && int(actionIdx) < len(parseActions) {
 				actions = parseActions[actionIdx].Actions
 			}
+			workCountAddActionEntries(len(actions))
 			if phaseTiming {
 				actionLookupNanos += time.Since(actionStart).Nanoseconds()
 			}
@@ -7036,6 +7052,7 @@ func clearGLRStateTokenSource(stateful parserStateTokenSource, scratch *parserSc
 }
 
 func (p *Parser) applyExtraShiftAction(s *glrStack, currentState StateID, act ParseAction, tok Token, arena *nodeArena, scratch *parserScratch, trackChildErrors *bool) {
+	workCountRecordShift()
 	named := p.isNamedSymbol(tok.Symbol)
 	targetState := extraShiftTargetState(currentState, act)
 	isMissing := p.shiftTokenIsMissingError(tok)

--- a/parser_api.go
+++ b/parser_api.go
@@ -614,6 +614,7 @@ func (p *Parser) parseWithTokenSource(source []byte, ts TokenSource, reparseFact
 	}()
 	deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
 	initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
+	workCountSetNextParseAttempt("initial_full", "fresh_token_source_full_parse")
 	tree := p.parseInternal(source, p.wrapIncludedRanges(ts), nil, nil, arenaClassFull, nil, initialMaxStacks, 0, 0, deterministicExternalConflicts)
 	if tree != nil && !tree.ParseStoppedEarly() && !parseStopReasonIsActive(p.activeParseStopReason()) {
 		tree = p.retryFullParseWithTokenSource(source, ts, initialMaxStacks, deterministicExternalConflicts, tree)
@@ -968,6 +969,7 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	if progress.enabled {
 		progress.emit(time.Now(), "parse_internal_begin", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, fmt.Sprintf("initial_max_stacks=%d deterministic_external_conflicts=%t", initialMaxStacks, deterministicExternalConflicts))
 	}
+	workCountSetNextParseAttempt("initial_full", "fresh_dfa_full_parse")
 	tree := p.parseInternal(source, p.wrapIncludedRanges(ts), nil, nil, arenaClassFull, nil, initialMaxStacks, 0, 0, deterministicExternalConflicts)
 	if progress.enabled {
 		progress.emit(time.Now(), "parse_internal_end", 0, 0, Token{}, false, nil, 0, 0, 0, false, 0, 0, "")

--- a/parser_memory_budget_merge_test.go
+++ b/parser_memory_budget_merge_test.go
@@ -1,10 +1,6 @@
 package gotreesitter
 
-import (
-	"runtime"
-	"runtime/debug"
-	"testing"
-)
+import "testing"
 
 // TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind exercises the
 // coarse-stride in-merge poll added to mergeStacksWithScratchLargeCap (2026-07-12
@@ -20,16 +16,6 @@ import (
 // result, far short of the full input) with mergeBudgetStopReason set, proving
 // the stride poll actually fires mid-grind rather than only at entry/exit.
 func TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind(t *testing.T) {
-	// Disable GC for the duration of the measured window. This package's full
-	// test binary allocates heavily elsewhere (including deliberately huge,
-	// short-lived allocations in nearby memory-budget tests); a concurrent GC
-	// cycle reclaiming that unrelated garbage can otherwise make this test's
-	// own net HeapAlloc delta read as flat or negative at the exact instant
-	// the poll samples it, even though real, live growth occurred. Disabling
-	// GC makes HeapAlloc monotonically non-decreasing for the test's duration.
-	oldGC := debug.SetGCPercent(-1)
-	defer debug.SetGCPercent(oldGC)
-
 	const n = 4000
 	stacks := make([]glrStack, n)
 	for i := range stacks {
@@ -47,15 +33,16 @@ func TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind(t *testing.T) {
 	}
 
 	parser := &Parser{}
-	var stats runtime.MemStats
-	runtime.ReadMemStats(&stats)
-	// Arm the runtime budget directly (bypassing enterRuntimeMemoryBudget's
-	// min-source-length gate, irrelevant when calling the merge function
-	// directly): baseline "now", budget of 1 byte so any further heap growth
-	// trips the very first real check the stride poll performs.
+	// Arm an already-exceeded runtime budget directly (bypassing
+	// enterRuntimeMemoryBudget's min-source-length gate, irrelevant when calling
+	// the merge function directly). A zero baseline makes the first real
+	// ReadMemStats check trip deterministically, independent of whether the race
+	// allocator can reuse spans from earlier package tests. Separate runtime
+	// budget tests cover HeapAlloc/Sys delta accounting; this test's contract is
+	// that the O(n^2) merge reaches its coarse poll and stops mid-grind.
 	parser.parseRuntimeMemoryBudgetBytes = 1
-	parser.parseRuntimeMemoryBaselineBytes = stats.HeapAlloc
-	parser.parseRuntimeMemoryBaselineSys = stats.Sys
+	parser.parseRuntimeMemoryBaselineBytes = 0
+	parser.parseRuntimeMemoryBaselineSys = 0
 	parser.parseMemoryBudgetDiagActive = true
 
 	scratch := &glrMergeScratch{

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -637,6 +637,7 @@ func (p *Parser) errorCostCompetitionEnabled() bool {
 // engine's own DFA from the group position and resynchronize the custom
 // source afterwards (SkipToByte) once normal parsing resumes.
 func (p *Parser) cRecoverAcquireToken(ts TokenSource, stacks []glrStack, source []byte) Token {
+	workCountRecordLexerFrontDoor()
 	if !p.errorCostCompetitionEnabled() {
 		return ts.Next()
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -3445,13 +3445,7 @@ func (p *Parser) selectedReduceWindowsFromGSSWithBudget(arena *nodeArena, act Pa
 					for j := 0; j < pathLen; j++ {
 						window[j] = revPath[pathLen-1-j]
 					}
-					payloads := uint64(0)
-					for _, pathEntry := range window {
-						if stackEntryHasNode(pathEntry) {
-							payloads++
-						}
-					}
-					workCountAddPopPaths(1, payloads)
+					workCountObservePopWindow(window) // work-count-assembly: payload-census seam
 					addFork(reduceFork{
 						window:   window,
 						topState: prev.entry.state,

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -2536,6 +2536,7 @@ func (p *Parser) applyAction(source []byte, s *glrStack, act ParseAction, tok To
 }
 
 func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) {
+	workCountRecordShift()
 	named := p.isNamedSymbol(tok.Symbol)
 	currentState := s.top().state
 	targetState := extraShiftTargetState(currentState, act)
@@ -2662,6 +2663,8 @@ func (p *Parser) applyShiftAction(s *glrStack, act ParseAction, tok Token, nodeC
 }
 
 func (p *Parser) applyReduceActionDispatch(source []byte, s *glrStack, act ParseAction, tok Token, anyReduced *bool, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, deferParentLinks bool, trackChildErrors *bool) {
+	workCountRecordReduce()
+	workCountObserveReductionPop(s, int(act.ChildCount))
 	entries := s.entries
 	borrowed := false
 	if entries == nil {
@@ -2701,6 +2704,7 @@ func (p *Parser) applyReduceActionDispatch(source []byte, s *glrStack, act Parse
 }
 
 func (p *Parser) applyAcceptAction(s *glrStack) {
+	workCountRecordAccept()
 	s.accepted = true
 	if p != nil && p.glrTrace {
 		fmt.Printf("      -> ACCEPT\n")
@@ -2708,6 +2712,7 @@ func (p *Parser) applyAcceptAction(s *glrStack) {
 }
 
 func (p *Parser) applyRecoverAction(s *glrStack, act ParseAction, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) {
+	workCountRecordExplicitRecover()
 	if tok.Symbol == 0 && tok.StartByte == tok.EndByte {
 		s.accepted = true
 		return
@@ -3440,6 +3445,13 @@ func (p *Parser) selectedReduceWindowsFromGSSWithBudget(arena *nodeArena, act Pa
 					for j := 0; j < pathLen; j++ {
 						window[j] = revPath[pathLen-1-j]
 					}
+					payloads := uint64(0)
+					for _, pathEntry := range window {
+						if stackEntryHasNode(pathEntry) {
+							payloads++
+						}
+					}
+					workCountAddPopPaths(1, payloads)
 					addFork(reduceFork{
 						window:   window,
 						topState: prev.entry.state,
@@ -7313,6 +7325,7 @@ func newNoTreeReduceNodeInArenaWithRawShape(arena *nodeArena, act ParseAction, n
 	} else {
 		n = arena.allocNoTreeNode()
 		arena.noTreeReduceNodesConstructed++
+		workCountRecordNoTreeParentConstruction()
 	}
 	n.symbol = act.Symbol
 	n.startByte = tok.StartByte

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1522,7 +1522,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	if csharpAcceptedErrorTreeCanUseNamespaceRecovery(tree, source) {
 		return tree
 	}
-	runRetryAttempt := func(maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
+	runRetryAttempt := func(logicalRung, operationCause string, maxStacks int, maxMergePerKeyOverride int, maxNodes int) *Tree {
 		if p != nil {
 			if retryPassLimitReached() {
 				// Budget exhausted: a nil candidate is a no-op for every
@@ -1537,6 +1537,7 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			t0 = time.Now()
 		}
 		var result *Tree
+		workCountSetNextParseAttempt(logicalRung, operationCause)
 		if !structuralResyncRetry || p == nil || p.forceCleanRetryPass {
 			result = runRetry(maxStacks, maxMergePerKeyOverride, maxNodes)
 		} else {
@@ -1563,7 +1564,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	bestTree := tree
 	if shouldRunInitialFullParseMergeRetry(tree, len(source), origin) {
 		if initialMergePerKey := fullParseRetryMergePerKeyOverride(tree, len(source), initialMaxStacks); initialMergePerKey != 0 {
-			mergeRetryTree := runRetryAttempt(initialMaxStacks, initialMergePerKey, 0)
+			mergeRetryTree := runRetryAttempt(
+				"initial_merge",
+				"initial_result_requires_merge_width",
+				initialMaxStacks,
+				initialMergePerKey,
+				0,
+			)
 			replaceBest(&bestTree, mergeRetryTree)
 			if treeParseClean(bestTree) {
 				return bestTree
@@ -1591,7 +1598,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	// retry-pass-enabled retry below, preserving prior recovery behavior.
 	if maxStacksOverride > 0 && p != nil && !p.forceCleanRetryPass {
 		p.forceCleanRetryPass = true
-		cleanRetryTree := runRetryAttempt(retryMaxStacks, 0, maxNodesOverride)
+		cleanRetryTree := runRetryAttempt(
+			"clean_wide",
+			"stack_or_node_budget_requires_clean_wide",
+			retryMaxStacks,
+			0,
+			maxNodesOverride,
+		)
 		p.forceCleanRetryPass = false
 		// A clean (non-retry-pass) wider-budget parse legitimately ends on
 		// ParseStopNoStacksAlive after the winning branch reduces to the start
@@ -1607,7 +1620,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			}
 			if cleanMergePerKey != 0 && !retryDeadlineExceeded() {
 				p.forceCleanRetryPass = true
-				cleanMergeTree := runRetryAttempt(retryMaxStacks, cleanMergePerKey, maxNodesOverride)
+				cleanMergeTree := runRetryAttempt(
+					"clean_wide_merge",
+					"clean_wide_result_requires_merge_width",
+					retryMaxStacks,
+					cleanMergePerKey,
+					maxNodesOverride,
+				)
 				p.forceCleanRetryPass = false
 				replaceBest(&bestTree, cleanMergeTree)
 				if !retryTreeHasError(bestTree) && retryTreeCoversExpectedEOF(bestTree) {
@@ -1633,7 +1652,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			retryTree = reusableCleanWideTree
 			reusableCleanWideTree = nil
 		} else {
-			retryTree = runRetryAttempt(retryMaxStacks, 0, maxNodesOverride)
+			retryTree = runRetryAttempt(
+				"recovery_wide_or_node",
+				"stack_or_node_budget_requires_recovery_wide",
+				retryMaxStacks,
+				0,
+				maxNodesOverride,
+			)
 		}
 		// nodeRetryTree is read below for stop-reason inspection, so we hold
 		// a pointer to it without handing it through replaceBest until the
@@ -1645,7 +1670,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 			return bestTree
 		}
 		if extraNodeLimit := fullParseRetrySecondaryNodeLimitOverride(retryTree, len(source)); extraNodeLimit > 0 {
-			secondaryTree := runRetryAttempt(retryMaxStacks, 0, extraNodeLimit)
+			secondaryTree := runRetryAttempt(
+				"secondary_node",
+				"primary_node_retry_requires_secondary_node_budget",
+				retryMaxStacks,
+				0,
+				extraNodeLimit,
+			)
 			// Fold the primary retry into bestTree before we overwrite
 			// nodeRetryTree, so the loser's arena is returned.
 			if retryTree != nil {
@@ -1681,7 +1712,13 @@ func (p *Parser) retryFullParseForOrigin(source []byte, initialMaxStacks int, tr
 	if retryDeadlineExceeded() {
 		return bestTree
 	}
-	mergeRetryTree := runRetryAttempt(retryMaxStacks, maxMergePerKeyOverride, maxNodesOverride)
+	mergeRetryTree := runRetryAttempt(
+		"final_merge",
+		"best_retry_result_requires_merge_width",
+		retryMaxStacks,
+		maxMergePerKeyOverride,
+		maxNodesOverride,
+	)
 	// nodeRetryTree is no longer needed; drop it before potentially replacing
 	// bestTree so we don't leak it if it was also the incumbent.
 	if nodeRetryTree != nil && nodeRetryTree != bestTree && nodeRetryTree != tree {

--- a/parser_tables.go
+++ b/parser_tables.go
@@ -238,6 +238,7 @@ func (p *Parser) lookupActionIndexFunc() func(state StateID, sym Symbol) uint16 
 // lookupActionIndex returns the parse action index for (state, symbol).
 // Returns 0 (the error/no-action entry) if not found.
 func (p *Parser) lookupActionIndex(state StateID, sym Symbol) uint16 {
+	workCountRecordTableLookup()
 	if int(state) < p.denseLimit {
 		if int(state) >= len(p.language.ParseTable) {
 			return 0

--- a/pending_parent.go
+++ b/pending_parent.go
@@ -131,6 +131,7 @@ func newPendingParentShellInArena(arena *nodeArena, sym Symbol, named bool, prod
 		p = arena.allocPendingParent()
 		childRange, _ = arena.allocPendingChildEntries(childCount)
 		arena.pendingParentCreated++
+		workCountRecordPendingParentConstruction()
 	}
 	p.setChildEntries(childRange)
 	p.symbol = sym

--- a/testdata/work_count/retry_go_query_kotlin_regression.go
+++ b/testdata/work_count/retry_go_query_kotlin_regression.go
@@ -1,0 +1,149 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestKotlinNestedImportQueryMatchesRepeatedHeaders(t *testing.T) {
+	src := []byte("package com.example\n\nimport foo.bar.Baz\nimport foo.qux.*\nfun main() {}\n")
+	lang := grammars.KotlinLanguage()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	defer tree.Release()
+	if tree.RootNode().HasError() {
+		t.Fatalf("root has error:\n%s", tree.RootNode().SExpr(lang))
+	}
+
+	q, err := gotreesitter.NewQuery(`
+		(source_file
+			(import_list
+				(import_header (identifier) @imp (wildcard_import)? @is_star)
+			)
+		)
+	`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery failed: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), lang, src)
+	var got []string
+	var wildcard bool
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		for _, capture := range match.Captures {
+			switch capture.Name {
+			case "imp":
+				got = append(got, capture.Text(src))
+			case "is_star":
+				wildcard = true
+			}
+		}
+	}
+
+	want := []string{"foo.bar.Baz", "foo.qux"}
+	if len(got) != len(want) {
+		t.Fatalf("captures = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("captures = %v, want %v", got, want)
+		}
+	}
+	if !wildcard {
+		t.Fatal("expected wildcard_import capture")
+	}
+}
+
+func TestKotlinRecoveredRootPreservesSourceFileQueries(t *testing.T) {
+	src := []byte(`package com.example.deepimport
+
+import com.google.common.base.pretend.deep.Thing
+import com.google.common.base.pretend.deep.Things as ThingsHelper
+
+class DeepCompare() {}
+
+fun main(vararg args: string) {
+    var app = new DeepCompare();
+    System.out.println("Success: " + app.compare(Thing(1), Thing(2)));
+}
+`)
+	lang := grammars.KotlinLanguage()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	defer tree.Release()
+
+	if got := tree.RootNode().Type(lang); got != "source_file" {
+		t.Fatalf("root type = %q, want source_file:\n%s", got, tree.RootNode().SExpr(lang))
+	}
+
+	q, err := gotreesitter.NewQuery(`
+		(source_file
+			(import_list
+				(import_header (identifier) @imp)
+			)
+		)
+
+		(source_file
+			(function_declaration
+				"fun" @fn_keyword
+				(simple_identifier) @fn
+				(#eq? @fn "main")
+			)
+		)
+	`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery failed: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), lang, src)
+	var imports []string
+	var hasMain bool
+	var hasFunKeyword bool
+	for {
+		match, ok := cursor.NextMatch()
+		if !ok {
+			break
+		}
+		for _, capture := range match.Captures {
+			switch capture.Name {
+			case "imp":
+				imports = append(imports, capture.Text(src))
+			case "fn":
+				hasMain = true
+			case "fn_keyword":
+				hasFunKeyword = capture.Text(src) == "fun"
+			}
+		}
+	}
+
+	wantImports := []string{
+		"com.google.common.base.pretend.deep.Thing",
+		"com.google.common.base.pretend.deep.Things",
+	}
+	if len(imports) != len(wantImports) {
+		t.Fatalf("imports = %v, want %v", imports, wantImports)
+	}
+	for i := range wantImports {
+		if imports[i] != wantImports[i] {
+			t.Fatalf("imports = %v, want %v", imports, wantImports)
+		}
+	}
+	if !hasMain {
+		t.Fatal("expected recovered main function to match source_file-rooted query")
+	}
+	if !hasFunKeyword {
+		t.Fatal("expected recovered function declaration to expose fun keyword")
+	}
+}

--- a/testdata/work_count/straight_lr_control.go
+++ b/testdata/work_count/straight_lr_control.go
@@ -1,0 +1,6 @@
+package main
+
+func f0() int { v := 0; return v }
+func f1() int { v := 1; return v }
+func f2() int { v := 2; return v }
+func f3() int { v := 3; return v }

--- a/tree.go
+++ b/tree.go
@@ -2242,6 +2242,7 @@ func newLeafNodeInArena(arena *nodeArena, sym Symbol, named bool, startByte, end
 	n.childIndex = -1
 	n.ownerArena = arena
 	arena.leafNodesConstructed++
+	workCountRecordLeafConstruction()
 	if arena.audit != nil {
 		arena.audit.recordNodeAlloc(n, runtimeAuditNodeKindLeaf)
 	}
@@ -2291,6 +2292,7 @@ func newParentNodeInArenaWithFieldSources(arena *nodeArena, sym Symbol, named bo
 	n.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
 	n.childIndex = -1
 	arena.parentNodesConstructed++
+	workCountRecordParentConstruction()
 	if arena.breakdownEnabled {
 		arena.recordParentNodeConstructedBreakdown(len(children), fieldIDs, resolvedFieldSources, fieldSources != nil, false, false)
 	}
@@ -2323,6 +2325,7 @@ func newParentNodeInArenaNoLinksWithFieldSources(arena *nodeArena, sym Symbol, n
 	n.dynamicPrecedence = nodeSliceDynamicPrecedence(children)
 	n.childIndex = -1
 	arena.parentNodesConstructed++
+	workCountRecordParentConstruction()
 	if arena.breakdownEnabled {
 		arena.recordParentNodeConstructedBreakdown(len(children), fieldIDs, resolvedFieldSources, fieldSources != nil, true, trackChildErrors)
 	}
@@ -2349,6 +2352,7 @@ func newParentNodeInArenaWithFinalChildRefs(arena *nodeArena, sym Symbol, named 
 	n.productionID = productionID
 	n.childIndex = -1
 	arena.parentNodesConstructed++
+	workCountRecordParentConstruction()
 	if arena.breakdownEnabled {
 		arena.recordParentNodeConstructedBreakdown(childCount, nil, nil, false, true, trackChildErrors)
 	}
@@ -2365,6 +2369,7 @@ func (a *nodeArena) recordParentNodeConstructed(childCount int, fieldIDs []Field
 		return
 	}
 	a.parentNodesConstructed++
+	workCountRecordParentConstruction()
 	if !a.breakdownEnabled {
 		return
 	}

--- a/work_count_admission_child_test.go
+++ b/work_count_admission_child_test.go
@@ -1,0 +1,38 @@
+package gotreesitter_test
+
+import (
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// TestWorkCountAdmissionChild is the ordinary, untagged admission endpoint.
+// The outer harness compiles it from the same private source snapshot as the
+// tagged diagnostic child, then starts one fresh process for one public parse.
+func TestWorkCountAdmissionChild(t *testing.T) {
+	if os.Getenv(workCountSourcePathEnv) == "" || os.Getenv(workCountResultPathEnv) == "" {
+		t.Skip("diagnostic work-count admission child is not configured")
+	}
+	input, err := loadWorkCountChildInput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parser := gotreesitter.NewParser(input.lang)
+	tree, parseErr := parser.Parse(input.source)
+	if parseErr != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatalf("parse: %v", parseErr)
+	}
+	defer tree.Release()
+	result, err := authenticateWorkCountTree(input, tree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result.Engine = workCountAdmissionEngine
+	if err := writeWorkCountChildResult(result); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/work_count_attempt_attribution_test.go
+++ b/work_count_attempt_attribution_test.go
@@ -1,0 +1,133 @@
+//go:build gts_workcount
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+const (
+	retryAttributionFixturePath   = "testdata/work_count/retry_go_query_kotlin_regression.go"
+	retryAttributionFixtureBytes  = 3435
+	retryAttributionFixtureSHA256 = "ada50bc6eef16b831e7ca0c44f11dffbcff7d9695515519cd5090b2aacf4789a"
+	straightLRFixturePath         = "testdata/work_count/straight_lr_control.go"
+	straightLRFixtureBytes        = 154
+	straightLRFixtureSHA256       = "4c584e187fdd4fb62dbf3953ca771e868bd3037e44abe5349c1cc0b3faf6532b"
+)
+
+func TestDiagnosticWorkCountAttemptAttributionRetryWitness(t *testing.T) {
+	source := loadWorkCountAttributionFixture(t, retryAttributionFixturePath, retryAttributionFixtureBytes, retryAttributionFixtureSHA256)
+	counts, tree := parseWithDiagnosticWorkCount(t, source)
+	defer tree.Release()
+
+	if len(counts.Attempts) != 2 {
+		t.Fatalf("attempts=%d want=2", len(counts.Attempts))
+	}
+	initial, merge := counts.Attempts[0], counts.Attempts[1]
+	if initial.LogicalRung != "initial_full" || initial.OperationCause != "fresh_dfa_full_parse" || initial.StopReason != gotreesitter.ParseStopAccepted || !initial.RootHasError {
+		t.Fatalf("initial attempt=%+v", initial)
+	}
+	if merge.LogicalRung != "initial_merge" || merge.OperationCause != "initial_result_requires_merge_width" || merge.StopReason != gotreesitter.ParseStopAccepted || merge.RootHasError {
+		t.Fatalf("merge attempt=%+v", merge)
+	}
+	if tree.RootNode().HasError() || tree.RootNode().EndByte() != uint32(len(source)) {
+		t.Fatalf("returned tree error=%v end=%d want=%d", tree.RootNode().HasError(), tree.RootNode().EndByte(), len(source))
+	}
+	requireWorkCountAttributionSum(t, counts)
+}
+
+func TestDiagnosticWorkCountAttemptAttributionStraightLRControl(t *testing.T) {
+	source := loadWorkCountAttributionFixture(t, straightLRFixturePath, straightLRFixtureBytes, straightLRFixtureSHA256)
+	counts, tree := parseWithDiagnosticWorkCount(t, source)
+	defer tree.Release()
+
+	if len(counts.Attempts) != 1 {
+		t.Fatalf("attempts=%d want=1", len(counts.Attempts))
+	}
+	attempt := counts.Attempts[0]
+	if attempt.LogicalRung != "initial_full" || attempt.OperationCause != "fresh_dfa_full_parse" || attempt.StopReason != gotreesitter.ParseStopAccepted || attempt.RootHasError {
+		t.Fatalf("attempt=%+v", attempt)
+	}
+	if runtime := tree.ParseRuntime(); runtime.MaxStacksSeen != 1 || runtime.MultiStackIterations != 0 {
+		t.Fatalf("straight-LR identity: max_stacks=%d multi_stack_iterations=%d", runtime.MaxStacksSeen, runtime.MultiStackIterations)
+	}
+	requireWorkCountAttributionSum(t, counts)
+}
+
+func loadWorkCountAttributionFixture(t *testing.T, path string, wantBytes int, wantSHA string) []byte {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(source) != wantBytes {
+		t.Fatalf("fixture %s bytes=%d want=%d", path, len(source), wantBytes)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != wantSHA {
+		t.Fatalf("fixture %s sha256=%s want=%s", path, got, wantSHA)
+	}
+	return source
+}
+
+func parseWithDiagnosticWorkCount(t *testing.T, source []byte) (gotreesitter.DiagnosticWorkCount, *gotreesitter.Tree) {
+	t.Helper()
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	gotreesitter.BeginDiagnosticWorkCount()
+	tree, err := parser.Parse(source)
+	counts := gotreesitter.EndDiagnosticWorkCount()
+	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal(err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal("parse returned no tree")
+	}
+	return counts, tree
+}
+
+func requireWorkCountAttributionSum(t *testing.T, counts gotreesitter.DiagnosticWorkCount) {
+	t.Helper()
+	total := reflect.ValueOf(counts.DiagnosticWorkCountValues)
+	sums := reflect.New(total.Type()).Elem()
+	add := func(values gotreesitter.DiagnosticWorkCountValues) {
+		value := reflect.ValueOf(values)
+		for i := 0; i < value.NumField(); i++ {
+			current := sums.Field(i).Uint()
+			delta := value.Field(i).Uint()
+			if ^uint64(0)-current < delta {
+				t.Fatalf("counter %s sum overflow", value.Type().Field(i).Name)
+			}
+			sums.Field(i).SetUint(current + delta)
+		}
+	}
+	for _, attempt := range counts.Attempts {
+		add(attempt.Counters)
+		var phases gotreesitter.DiagnosticWorkCountValues
+		phaseValue := reflect.ValueOf(&phases).Elem()
+		for _, phase := range []gotreesitter.DiagnosticWorkCountValues{attempt.EntryToCaps, attempt.CapsToFinalize, attempt.Finalize} {
+			value := reflect.ValueOf(phase)
+			for i := 0; i < value.NumField(); i++ {
+				phaseValue.Field(i).SetUint(phaseValue.Field(i).Uint() + value.Field(i).Uint())
+			}
+		}
+		if !reflect.DeepEqual(phases, attempt.Counters) {
+			t.Fatalf("attempt %d phase sum does not match counters", attempt.Index)
+		}
+	}
+	add(counts.OutsideAttempt)
+	if !reflect.DeepEqual(sums.Interface(), counts.DiagnosticWorkCountValues) {
+		t.Fatalf("aggregate counters do not equal attempts plus outside-attempt residual")
+	}
+}

--- a/work_count_child_common_test.go
+++ b/work_count_child_common_test.go
@@ -1,0 +1,142 @@
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+const (
+	workCountFixtureID       = "query_compile"
+	workCountSourcePathEnv   = "GTS_WORK_COUNT_SOURCE"
+	workCountResultPathEnv   = "GTS_WORK_COUNT_RESULT"
+	workCountGoChildSchema   = "gts-work-count-go-child/v3"
+	workCountAdmissionEngine = "go-production-glr-untagged"
+	workCountTaggedEngine    = "go-production-glr-tagged-diagnostic"
+)
+
+type workCountGoChildResult struct {
+	Schema            string `json:"schema"`
+	Engine            string `json:"engine"`
+	Fixture           string `json:"fixture"`
+	SourceSHA256      string `json:"source_sha256"`
+	SourceBytes       uint32 `json:"source_bytes"`
+	GrammarCommit     string `json:"grammar_commit"`
+	GrammarBlobSHA256 string `json:"grammar_blob_sha256"`
+	DigestFormat      string `json:"digest_format"`
+	DeepTreeSHA256    string `json:"deep_tree_sha256"`
+	RootEndByte       uint32 `json:"root_end_byte"`
+	RootHasError      bool   `json:"root_has_error"`
+	MaxStacksSeen     int    `json:"max_stacks_seen"`
+	MultiStackIters   int    `json:"multi_stack_iterations"`
+	MultiStackTokens  uint64 `json:"multi_stack_tokens"`
+}
+
+type workCountChildInput struct {
+	fixture benchfixtures.LoadedFixture
+	source  []byte
+	lang    *gotreesitter.Language
+	blobSHA string
+}
+
+func loadWorkCountChildInput() (workCountChildInput, error) {
+	sourcePath := os.Getenv(workCountSourcePathEnv)
+	if sourcePath == "" {
+		return workCountChildInput{}, fmt.Errorf("%s is empty", workCountSourcePathEnv)
+	}
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		return workCountChildInput{}, fmt.Errorf("load frozen fixtures: %w", err)
+	}
+	var fixture benchfixtures.LoadedFixture
+	found := false
+	for _, candidate := range fixtures {
+		if candidate.Fixture.ID == workCountFixtureID {
+			fixture = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		return workCountChildInput{}, fmt.Errorf("fixture %s is absent", workCountFixtureID)
+	}
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return workCountChildInput{}, fmt.Errorf("read source: %w", err)
+	}
+	if err := fixture.Fixture.VerifySource(source); err != nil {
+		return workCountChildInput{}, err
+	}
+	blob := grammars.BlobByName("go")
+	if len(blob) == 0 {
+		return workCountChildInput{}, fmt.Errorf("embedded Go grammar blob is empty")
+	}
+	blobHash := sha256.Sum256(blob)
+	blobSHA := hex.EncodeToString(blobHash[:])
+	if err := benchfixtures.VerifyGoGrammarIdentity(benchfixtures.GoGrammarCommit, blobSHA); err != nil {
+		return workCountChildInput{}, err
+	}
+	lang := grammars.GoLanguage()
+	if lang == nil {
+		return workCountChildInput{}, fmt.Errorf("load embedded Go language: nil")
+	}
+	return workCountChildInput{fixture: fixture, source: source, lang: lang, blobSHA: blobSHA}, nil
+}
+
+func authenticateWorkCountTree(input workCountChildInput, tree *gotreesitter.Tree) (workCountGoChildResult, error) {
+	if tree == nil || tree.RootNode() == nil {
+		return workCountGoChildResult{}, fmt.Errorf("parse returned no root")
+	}
+	root := tree.RootNode()
+	if root.EndByte() != uint32(len(input.source)) || root.HasError() {
+		return workCountGoChildResult{}, fmt.Errorf("tree span/error: end=%d bytes=%d error=%v", root.EndByte(), len(input.source), root.HasError())
+	}
+	inspection, err := benchfixtures.InspectGoTree(root, input.lang)
+	if err != nil {
+		return workCountGoChildResult{}, fmt.Errorf("deep tree digest: %w", err)
+	}
+	if err := input.fixture.Fixture.VerifyDeepTreeDigest(inspection.SHA256); err != nil {
+		return workCountGoChildResult{}, err
+	}
+	runtime := tree.ParseRuntime()
+	if err := input.fixture.Fixture.VerifyWorkloadIdentity(runtime, inspection.NodeKinds); err != nil {
+		return workCountGoChildResult{}, err
+	}
+	return workCountGoChildResult{
+		Schema:            workCountGoChildSchema,
+		Fixture:           input.fixture.Fixture.ID,
+		SourceSHA256:      input.fixture.Fixture.SHA256,
+		SourceBytes:       uint32(len(input.source)),
+		GrammarCommit:     benchfixtures.GoGrammarCommit,
+		GrammarBlobSHA256: input.blobSHA,
+		DigestFormat:      benchfixtures.DeepTreeDigestVersion,
+		DeepTreeSHA256:    inspection.SHA256,
+		RootEndByte:       root.EndByte(),
+		RootHasError:      root.HasError(),
+		MaxStacksSeen:     runtime.MaxStacksSeen,
+		MultiStackIters:   runtime.MultiStackIterations,
+		MultiStackTokens:  runtime.MultiStackTokens,
+	}, nil
+}
+
+func writeWorkCountChildResult(value any) error {
+	resultPath := os.Getenv(workCountResultPathEnv)
+	if resultPath == "" {
+		return fmt.Errorf("%s is empty", workCountResultPathEnv)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode result: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(resultPath, data, 0o600); err != nil {
+		return fmt.Errorf("write result: %w", err)
+	}
+	return nil
+}

--- a/work_count_child_test.go
+++ b/work_count_child_test.go
@@ -1,0 +1,86 @@
+//go:build gts_workcount
+
+package gotreesitter_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+type workCountTaggedChildResult struct {
+	workCountGoChildResult
+	Counters gotreesitter.DiagnosticWorkCount `json:"counters"`
+}
+
+// TestDiagnosticWorkCountChild is an executable protocol endpoint, not a
+// normal unit test. The authenticated parent harness compiles this test into a
+// separate gts_workcount artifact and starts one fresh process for one parse.
+func TestDiagnosticWorkCountChild(t *testing.T) {
+	if os.Getenv(workCountSourcePathEnv) == "" || os.Getenv(workCountResultPathEnv) == "" {
+		t.Skip("diagnostic work-count child protocol is not configured")
+	}
+	input, err := loadWorkCountChildInput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parser := gotreesitter.NewParser(input.lang)
+	gotreesitter.BeginDiagnosticWorkCount()
+	tree, parseErr := parser.Parse(input.source)
+	counts := gotreesitter.EndDiagnosticWorkCount()
+	if parseErr != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatalf("parse: %v", parseErr)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal("parse returned no root")
+	}
+	defer tree.Release()
+
+	base, err := authenticateWorkCountTree(input, tree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := countSelectedGoNodes(tree.RootNode(), &counts); err != nil {
+		t.Fatalf("selected tree census: %v", err)
+	}
+	base.Engine = workCountTaggedEngine
+	result := workCountTaggedChildResult{workCountGoChildResult: base, Counters: counts}
+	if err := writeWorkCountChildResult(result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func countSelectedGoNodes(root *gotreesitter.Node, counts *gotreesitter.DiagnosticWorkCount) error {
+	if root == nil {
+		return fmt.Errorf("nil root")
+	}
+	if counts == nil {
+		return fmt.Errorf("nil counters")
+	}
+	stack := []*gotreesitter.Node{root}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if node == nil {
+			return fmt.Errorf("nil child")
+		}
+		childCount := node.ChildCount()
+		counts.AddDiagnosticSelectedNode(childCount != 0)
+		if childCount == 0 {
+			continue
+		}
+		for i := childCount - 1; i >= 0; i-- {
+			stack = append(stack, node.Child(i))
+		}
+	}
+	return nil
+}

--- a/work_count_diagnostic.go
+++ b/work_count_diagnostic.go
@@ -81,6 +81,8 @@ type DiagnosticWorkCountAttempt struct {
 
 const DiagnosticWorkCountContract = "gts-work-count/v2"
 
+const workCountInstrumentationEnabled = true
+
 var activeDiagnosticWorkCount *DiagnosticWorkCount
 
 var pendingDiagnosticWorkCountAttempt struct {
@@ -402,6 +404,16 @@ func workCountAddPopPaths(paths, payloads uint64) {
 		workCountSaturatingAdd(&c.EmittedPopPaths, paths)
 		workCountSaturatingAdd(&c.EmittedPopPayloads, payloads)
 	}
+}
+
+func workCountObservePopWindow(window []stackEntry) {
+	payloads := uint64(0)
+	for _, entry := range window {
+		if stackEntryHasNode(entry) {
+			payloads++
+		}
+	}
+	workCountAddPopPaths(1, payloads)
 }
 
 func workCountRecordVersionCreation() {

--- a/work_count_diagnostic.go
+++ b/work_count_diagnostic.go
@@ -1,0 +1,455 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import "math"
+
+// DiagnosticWorkCount is the diagnostic-only Go GLR counter contract. Direct
+// counters describe parser actions or selected-tree events with a common
+// semantic definition. Fields ending in Proxy describe implementation work;
+// their values must not be presented as if Go and C used identical machinery.
+type DiagnosticWorkCount struct {
+	Contract string `json:"contract"`
+	Overflow bool   `json:"overflow"`
+	DiagnosticWorkCountValues
+
+	Attempts       []DiagnosticWorkCountAttempt `json:"attempts"`
+	OutsideAttempt DiagnosticWorkCountValues    `json:"outside_attempt"`
+}
+
+// DiagnosticWorkCountValues is one additive counter vector. The aggregate
+// vector on DiagnosticWorkCount must equal the sum of Attempts plus
+// OutsideAttempt for every field.
+type DiagnosticWorkCountValues struct {
+	Shifts                 uint64 `json:"shifts"`
+	Reductions             uint64 `json:"reductions"`
+	AcceptActions          uint64 `json:"accept_actions"`
+	ExplicitRecoverActions uint64 `json:"explicit_recover_actions"`
+	ReductionPopRequests   uint64 `json:"reduction_pop_requests"`
+	EmittedPopPaths        uint64 `json:"emitted_pop_paths"`
+	EmittedPopPayloads     uint64 `json:"emitted_pop_payloads"`
+	SelectedNodes          uint64 `json:"selected_nodes"`
+	SelectedParentNodes    uint64 `json:"selected_parent_nodes"`
+	SelectedLeafNodes      uint64 `json:"selected_leaf_nodes"`
+
+	TableLookupsProxy               uint64 `json:"table_lookups_proxy"`
+	ActionEntriesExaminedProxy      uint64 `json:"action_entries_examined_proxy"`
+	LexerFrontDoorCallsProxy        uint64 `json:"lexer_front_door_calls_proxy"`
+	StackVersionCreationsProxy      uint64 `json:"stack_version_creations_proxy"`
+	MergeAttemptsProxy              uint64 `json:"merge_attempts_proxy"`
+	MergeSuccessesProxy             uint64 `json:"merge_successes_proxy"`
+	GraphLinkAdditionsProxy         uint64 `json:"graph_link_additions_proxy"`
+	LeafConstructionsProxy          uint64 `json:"leaf_constructions_proxy"`
+	ParentConstructionsProxy        uint64 `json:"parent_constructions_proxy"`
+	PendingParentConstructionsProxy uint64 `json:"pending_parent_constructions_proxy"`
+	NoTreeParentConstructionsProxy  uint64 `json:"no_tree_parent_constructions_proxy"`
+}
+
+// DiagnosticWorkCountAttempt attributes one parseInternal invocation to the
+// retry ladder that scheduled it. LogicalRung describes scheduler intent;
+// ResolvedRetryPass records the independent cap-derived parser mode.
+type DiagnosticWorkCountAttempt struct {
+	Index          uint32 `json:"index"`
+	LogicalRung    string `json:"logical_rung"`
+	OperationCause string `json:"operation_cause"`
+
+	RequestedMaxStacks       int  `json:"requested_max_stacks"`
+	RequestedMaxNodes        int  `json:"requested_max_nodes"`
+	RequestedMaxMergePerKey  int  `json:"requested_max_merge_per_key"`
+	CapsResolved             bool `json:"caps_resolved"`
+	ResolvedMaxStacks        int  `json:"resolved_max_stacks"`
+	ResolvedRetryPass        bool `json:"resolved_retry_pass"`
+	ResolvedMaxMergePerKey   int  `json:"resolved_max_merge_per_key"`
+	ResolvedStackCullTrigger int  `json:"resolved_stack_cull_trigger"`
+	ResolvedMaxIterations    int  `json:"resolved_max_iterations"`
+	ResolvedMaxNodes         int  `json:"resolved_max_nodes"`
+
+	StopReason   ParseStopReason `json:"stop_reason"`
+	RootHasError bool            `json:"root_has_error"`
+	RootEndByte  uint32          `json:"root_end_byte"`
+
+	EntryToCaps    DiagnosticWorkCountValues `json:"entry_to_caps"`
+	CapsToFinalize DiagnosticWorkCountValues `json:"caps_to_finalize"`
+	Finalize       DiagnosticWorkCountValues `json:"finalize"`
+	Counters       DiagnosticWorkCountValues `json:"counters"`
+
+	entrySnapshot    DiagnosticWorkCountValues
+	capsSnapshot     DiagnosticWorkCountValues
+	finalizeSnapshot DiagnosticWorkCountValues
+	finalized        bool
+}
+
+const DiagnosticWorkCountContract = "gts-work-count/v2"
+
+var activeDiagnosticWorkCount *DiagnosticWorkCount
+
+var pendingDiagnosticWorkCountAttempt struct {
+	logicalRung    string
+	operationCause string
+}
+
+// BeginDiagnosticWorkCount starts one diagnostic parse. The work-count child
+// protocol runs one parse with GOMAXPROCS=1, so a process-local pointer avoids
+// adding instrumentation state to every production Parser or stack record.
+func BeginDiagnosticWorkCount() {
+	if activeDiagnosticWorkCount != nil {
+		panic("gotreesitter: diagnostic work-count parse already active")
+	}
+	activeDiagnosticWorkCount = &DiagnosticWorkCount{Contract: DiagnosticWorkCountContract}
+	pendingDiagnosticWorkCountAttempt = struct {
+		logicalRung    string
+		operationCause string
+	}{}
+}
+
+// EndDiagnosticWorkCount returns the current parse-local counters and disables
+// further recording. It is available only in gts_workcount builds.
+func EndDiagnosticWorkCount() DiagnosticWorkCount {
+	if activeDiagnosticWorkCount == nil {
+		panic("gotreesitter: diagnostic work-count parse is not active")
+	}
+	for i := range activeDiagnosticWorkCount.Attempts {
+		if !activeDiagnosticWorkCount.Attempts[i].finalized {
+			panic("gotreesitter: diagnostic work-count parse attempt did not finalize")
+		}
+	}
+	activeDiagnosticWorkCount.reconcileOutsideAttempt()
+	out := *activeDiagnosticWorkCount
+	activeDiagnosticWorkCount = nil
+	return out
+}
+
+func workCountValuesSnapshot(c *DiagnosticWorkCount) DiagnosticWorkCountValues {
+	if c == nil {
+		return DiagnosticWorkCountValues{}
+	}
+	return c.DiagnosticWorkCountValues
+}
+
+func workCountValuesDelta(c *DiagnosticWorkCount, after, before DiagnosticWorkCountValues) DiagnosticWorkCountValues {
+	var out DiagnosticWorkCountValues
+	workCountForEachValue(&out, func(dst *uint64, afterValue, beforeValue uint64) {
+		if afterValue < beforeValue {
+			if c != nil {
+				c.Overflow = true
+			}
+			*dst = 0
+			return
+		}
+		*dst = afterValue - beforeValue
+	}, after, before)
+	return out
+}
+
+func workCountValuesAdd(c *DiagnosticWorkCount, dst *DiagnosticWorkCountValues, src DiagnosticWorkCountValues) {
+	workCountForEachValue(dst, func(slot *uint64, value, _ uint64) {
+		diagnosticWorkCountSaturatingAdd(c, slot, value)
+	}, src, DiagnosticWorkCountValues{})
+}
+
+func workCountForEachValue(dst *DiagnosticWorkCountValues, fn func(*uint64, uint64, uint64), a, b DiagnosticWorkCountValues) {
+	fn(&dst.Shifts, a.Shifts, b.Shifts)
+	fn(&dst.Reductions, a.Reductions, b.Reductions)
+	fn(&dst.AcceptActions, a.AcceptActions, b.AcceptActions)
+	fn(&dst.ExplicitRecoverActions, a.ExplicitRecoverActions, b.ExplicitRecoverActions)
+	fn(&dst.ReductionPopRequests, a.ReductionPopRequests, b.ReductionPopRequests)
+	fn(&dst.EmittedPopPaths, a.EmittedPopPaths, b.EmittedPopPaths)
+	fn(&dst.EmittedPopPayloads, a.EmittedPopPayloads, b.EmittedPopPayloads)
+	fn(&dst.SelectedNodes, a.SelectedNodes, b.SelectedNodes)
+	fn(&dst.SelectedParentNodes, a.SelectedParentNodes, b.SelectedParentNodes)
+	fn(&dst.SelectedLeafNodes, a.SelectedLeafNodes, b.SelectedLeafNodes)
+	fn(&dst.TableLookupsProxy, a.TableLookupsProxy, b.TableLookupsProxy)
+	fn(&dst.ActionEntriesExaminedProxy, a.ActionEntriesExaminedProxy, b.ActionEntriesExaminedProxy)
+	fn(&dst.LexerFrontDoorCallsProxy, a.LexerFrontDoorCallsProxy, b.LexerFrontDoorCallsProxy)
+	fn(&dst.StackVersionCreationsProxy, a.StackVersionCreationsProxy, b.StackVersionCreationsProxy)
+	fn(&dst.MergeAttemptsProxy, a.MergeAttemptsProxy, b.MergeAttemptsProxy)
+	fn(&dst.MergeSuccessesProxy, a.MergeSuccessesProxy, b.MergeSuccessesProxy)
+	fn(&dst.GraphLinkAdditionsProxy, a.GraphLinkAdditionsProxy, b.GraphLinkAdditionsProxy)
+	fn(&dst.LeafConstructionsProxy, a.LeafConstructionsProxy, b.LeafConstructionsProxy)
+	fn(&dst.ParentConstructionsProxy, a.ParentConstructionsProxy, b.ParentConstructionsProxy)
+	fn(&dst.PendingParentConstructionsProxy, a.PendingParentConstructionsProxy, b.PendingParentConstructionsProxy)
+	fn(&dst.NoTreeParentConstructionsProxy, a.NoTreeParentConstructionsProxy, b.NoTreeParentConstructionsProxy)
+}
+
+func (c *DiagnosticWorkCount) reconcileOutsideAttempt() {
+	if c == nil {
+		return
+	}
+	var attributed DiagnosticWorkCountValues
+	for i := range c.Attempts {
+		workCountValuesAdd(c, &attributed, c.Attempts[i].Counters)
+	}
+	c.OutsideAttempt = workCountValuesDelta(c, c.DiagnosticWorkCountValues, attributed)
+}
+
+func workCountSetNextParseAttempt(logicalRung, operationCause string) {
+	if activeDiagnosticWorkCount == nil {
+		return
+	}
+	pendingDiagnosticWorkCountAttempt.logicalRung = logicalRung
+	pendingDiagnosticWorkCountAttempt.operationCause = operationCause
+}
+
+type workCountAttemptToken uint32
+
+func workCountBeginParseAttempt(maxStacks, maxNodes, maxMergePerKey int) workCountAttemptToken {
+	c := activeDiagnosticWorkCount
+	if c == nil {
+		return 0
+	}
+	rung := pendingDiagnosticWorkCountAttempt.logicalRung
+	cause := pendingDiagnosticWorkCountAttempt.operationCause
+	pendingDiagnosticWorkCountAttempt.logicalRung = ""
+	pendingDiagnosticWorkCountAttempt.operationCause = ""
+	if rung == "" {
+		rung = "unspecified"
+	}
+	if cause == "" {
+		cause = "direct_parse_internal"
+	}
+	index := uint32(len(c.Attempts) + 1)
+	c.Attempts = append(c.Attempts, DiagnosticWorkCountAttempt{
+		Index:                   index,
+		LogicalRung:             rung,
+		OperationCause:          cause,
+		RequestedMaxStacks:      maxStacks,
+		RequestedMaxNodes:       maxNodes,
+		RequestedMaxMergePerKey: maxMergePerKey,
+		entrySnapshot:           workCountValuesSnapshot(c),
+	})
+	return workCountAttemptToken(index)
+}
+
+func workCountAttempt(c *DiagnosticWorkCount, token workCountAttemptToken) *DiagnosticWorkCountAttempt {
+	if c == nil || token == 0 || int(token) > len(c.Attempts) {
+		return nil
+	}
+	return &c.Attempts[int(token)-1]
+}
+
+func workCountResolveParseAttempt(token workCountAttemptToken, maxStacks int, retryPass bool, maxMergePerKey, stackCullTrigger, maxIterations, maxNodes int) {
+	c := activeDiagnosticWorkCount
+	attempt := workCountAttempt(c, token)
+	if attempt == nil {
+		return
+	}
+	attempt.CapsResolved = true
+	attempt.ResolvedMaxStacks = maxStacks
+	attempt.ResolvedRetryPass = retryPass
+	attempt.ResolvedMaxMergePerKey = maxMergePerKey
+	attempt.ResolvedStackCullTrigger = stackCullTrigger
+	attempt.ResolvedMaxIterations = maxIterations
+	attempt.ResolvedMaxNodes = maxNodes
+	attempt.capsSnapshot = workCountValuesSnapshot(c)
+	attempt.EntryToCaps = workCountValuesDelta(c, attempt.capsSnapshot, attempt.entrySnapshot)
+}
+
+func workCountBeginFinalizeParseAttempt(token workCountAttemptToken) {
+	c := activeDiagnosticWorkCount
+	attempt := workCountAttempt(c, token)
+	if attempt == nil {
+		return
+	}
+	if !attempt.CapsResolved {
+		attempt.capsSnapshot = attempt.entrySnapshot
+	}
+	attempt.finalizeSnapshot = workCountValuesSnapshot(c)
+	attempt.CapsToFinalize = workCountValuesDelta(c, attempt.finalizeSnapshot, attempt.capsSnapshot)
+}
+
+func workCountEndFinalizeParseAttempt(token workCountAttemptToken, stopReason ParseStopReason, tree *Tree) {
+	c := activeDiagnosticWorkCount
+	attempt := workCountAttempt(c, token)
+	if attempt == nil {
+		return
+	}
+	after := workCountValuesSnapshot(c)
+	attempt.Finalize = workCountValuesDelta(c, after, attempt.finalizeSnapshot)
+	attempt.Counters = workCountValuesDelta(c, after, attempt.entrySnapshot)
+	attempt.StopReason = stopReason
+	if root := rawRootOrNil(tree); root != nil {
+		attempt.RootHasError = root.hasError()
+		attempt.RootEndByte = root.endByte
+	}
+	attempt.finalized = true
+}
+
+func diagnosticWorkCountSaturatingAdd(counts *DiagnosticWorkCount, slot *uint64, delta uint64) {
+	if counts == nil || slot == nil || delta == 0 {
+		return
+	}
+	if math.MaxUint64-*slot < delta {
+		*slot = math.MaxUint64
+		counts.Overflow = true
+		return
+	}
+	*slot += delta
+}
+
+func workCountSaturatingAdd(slot *uint64, delta uint64) {
+	diagnosticWorkCountSaturatingAdd(activeDiagnosticWorkCount, slot, delta)
+}
+
+// AddDiagnosticSelectedNode records one node from the returned selected tree.
+// It is available only in tagged diagnostic builds and uses the same saturating
+// arithmetic and overflow bit as the parser-event counters.
+func (c *DiagnosticWorkCount) AddDiagnosticSelectedNode(parent bool) {
+	diagnosticWorkCountSaturatingAdd(c, &c.SelectedNodes, 1)
+	diagnosticWorkCountSaturatingAdd(c, &c.OutsideAttempt.SelectedNodes, 1)
+	if parent {
+		diagnosticWorkCountSaturatingAdd(c, &c.SelectedParentNodes, 1)
+		diagnosticWorkCountSaturatingAdd(c, &c.OutsideAttempt.SelectedParentNodes, 1)
+		return
+	}
+	diagnosticWorkCountSaturatingAdd(c, &c.SelectedLeafNodes, 1)
+	diagnosticWorkCountSaturatingAdd(c, &c.OutsideAttempt.SelectedLeafNodes, 1)
+}
+
+func workCountRecordLexerFrontDoor() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.LexerFrontDoorCallsProxy, 1)
+	}
+}
+
+func workCountRecordTableLookup() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.TableLookupsProxy, 1)
+	}
+}
+
+func workCountAddActionEntries(n int) {
+	if c := activeDiagnosticWorkCount; c != nil && n > 0 {
+		workCountSaturatingAdd(&c.ActionEntriesExaminedProxy, uint64(n))
+	}
+}
+
+func workCountRecordShift() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.Shifts, 1)
+	}
+}
+
+func workCountRecordReduce() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.Reductions, 1)
+		workCountSaturatingAdd(&c.ReductionPopRequests, 1)
+	}
+}
+
+func workCountRecordAccept() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.AcceptActions, 1)
+	}
+}
+
+func workCountRecordExplicitRecover() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.ExplicitRecoverActions, 1)
+	}
+}
+
+// workCountObserveReductionPop records direct pop-path output for stack forms
+// that have exactly one possible path. Non-linear GSS paths are recorded at
+// the point selectedReduceWindowsFromGSSWithBudget emits each concrete path.
+func workCountObserveReductionPop(s *glrStack, childCount int) {
+	if activeDiagnosticWorkCount == nil || s == nil || childCount < 0 {
+		return
+	}
+	if childCount == 0 {
+		workCountAddPopPaths(1, 0)
+		return
+	}
+	if s.entries != nil {
+		payloads, remaining := 0, childCount
+		for i := len(s.entries) - 1; i >= 0; i-- {
+			entry := s.entries[i]
+			if !stackEntryHasNode(entry) {
+				continue
+			}
+			payloads++
+			if !stackEntryNodeIsExtra(entry) {
+				remaining--
+				if remaining == 0 {
+					workCountAddPopPaths(1, uint64(payloads))
+					return
+				}
+			}
+		}
+		return
+	}
+	if s.gss.head == nil || !gssSpanIsLinear(s.gss.head, childCount) {
+		return
+	}
+	payloads, remaining := 0, childCount
+	for n := s.gss.head; n != nil; n = n.prev {
+		entry := n.entry
+		if !stackEntryHasNode(entry) {
+			continue
+		}
+		payloads++
+		if !stackEntryNodeIsExtra(entry) {
+			remaining--
+			if remaining == 0 {
+				workCountAddPopPaths(1, uint64(payloads))
+				return
+			}
+		}
+	}
+}
+
+func workCountAddPopPaths(paths, payloads uint64) {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.EmittedPopPaths, paths)
+		workCountSaturatingAdd(&c.EmittedPopPayloads, payloads)
+	}
+}
+
+func workCountRecordVersionCreation() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.StackVersionCreationsProxy, 1)
+	}
+}
+
+func workCountRecordMergeAttempt() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.MergeAttemptsProxy, 1)
+	}
+}
+
+func workCountRecordMergeSuccess() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.MergeSuccessesProxy, 1)
+	}
+}
+
+func workCountRecordGraphLinkAddition() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.GraphLinkAdditionsProxy, 1)
+	}
+}
+
+func workCountRecordLeafConstruction() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.LeafConstructionsProxy, 1)
+	}
+}
+
+func workCountRecordParentConstruction() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.ParentConstructionsProxy, 1)
+	}
+}
+
+func workCountRecordPendingParentConstruction() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.PendingParentConstructionsProxy, 1)
+		workCountSaturatingAdd(&c.ParentConstructionsProxy, 1)
+	}
+}
+
+func workCountRecordNoTreeParentConstruction() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		workCountSaturatingAdd(&c.NoTreeParentConstructionsProxy, 1)
+		workCountSaturatingAdd(&c.ParentConstructionsProxy, 1)
+	}
+}

--- a/work_count_diagnostic_test.go
+++ b/work_count_diagnostic_test.go
@@ -1,0 +1,49 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDiagnosticWorkCountSaturatesAndFlagsOverflow(t *testing.T) {
+	BeginDiagnosticWorkCount()
+	activeDiagnosticWorkCount.Shifts = math.MaxUint64
+	workCountRecordShift()
+	counts := EndDiagnosticWorkCount()
+	if !counts.Overflow {
+		t.Fatal("overflow flag is false")
+	}
+	if counts.Shifts != math.MaxUint64 {
+		t.Fatalf("shifts=%d want saturation at %d", counts.Shifts, uint64(math.MaxUint64))
+	}
+}
+
+func TestDiagnosticWorkCountLinearReductionPop(t *testing.T) {
+	leaf := newLeafNodeInArena(nil, 1, true, 0, 1, Point{}, Point{Column: 1})
+	extra := newLeafNodeInArena(nil, 2, false, 1, 2, Point{Column: 1}, Point{Column: 2})
+	extra.setExtra(true)
+	stack := newGLRStack(1)
+	stack.entries = append(stack.entries,
+		newStackEntryNode(2, leaf),
+		newStackEntryNode(2, extra),
+	)
+
+	BeginDiagnosticWorkCount()
+	workCountObserveReductionPop(&stack, 1)
+	counts := EndDiagnosticWorkCount()
+	if counts.EmittedPopPaths != 1 || counts.EmittedPopPayloads != 2 {
+		t.Fatalf("paths=%d payloads=%d want 1/2", counts.EmittedPopPaths, counts.EmittedPopPayloads)
+	}
+}
+
+func TestDiagnosticWorkCountSelectedCensusSaturates(t *testing.T) {
+	counts := DiagnosticWorkCount{
+		DiagnosticWorkCountValues: DiagnosticWorkCountValues{SelectedNodes: math.MaxUint64},
+	}
+	counts.AddDiagnosticSelectedNode(false)
+	if !counts.Overflow || counts.SelectedNodes != math.MaxUint64 || counts.SelectedLeafNodes != 1 {
+		t.Fatalf("selected census saturation=%+v", counts)
+	}
+}

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -4,6 +4,8 @@ package gotreesitter
 
 type workCountAttemptToken uint32
 
+const workCountInstrumentationEnabled = false
+
 // These hooks are compile-time instrumentation seams. The production build
 // supplies empty, inlineable bodies; the gts_workcount build replaces them
 // with parse-local saturating counters.
@@ -21,6 +23,7 @@ func workCountRecordAccept()                                                    
 func workCountRecordExplicitRecover()                                                   {}
 func workCountObserveReductionPop(*glrStack, int)                                       {}
 func workCountAddPopPaths(uint64, uint64)                                               {}
+func workCountObservePopWindow([]stackEntry)                                            {}
 func workCountRecordVersionCreation()                                                   {}
 func workCountRecordMergeAttempt()                                                      {}
 func workCountRecordMergeSuccess()                                                      {}

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -1,0 +1,31 @@
+//go:build !gts_workcount
+
+package gotreesitter
+
+type workCountAttemptToken uint32
+
+// These hooks are compile-time instrumentation seams. The production build
+// supplies empty, inlineable bodies; the gts_workcount build replaces them
+// with parse-local saturating counters.
+func workCountSetNextParseAttempt(string, string)                                       {}
+func workCountBeginParseAttempt(int, int, int) workCountAttemptToken                    { return 0 }
+func workCountResolveParseAttempt(workCountAttemptToken, int, bool, int, int, int, int) {}
+func workCountBeginFinalizeParseAttempt(workCountAttemptToken)                          {}
+func workCountEndFinalizeParseAttempt(workCountAttemptToken, ParseStopReason, *Tree)    {}
+func workCountRecordLexerFrontDoor()                                                    {}
+func workCountRecordTableLookup()                                                       {}
+func workCountAddActionEntries(int)                                                     {}
+func workCountRecordShift()                                                             {}
+func workCountRecordReduce()                                                            {}
+func workCountRecordAccept()                                                            {}
+func workCountRecordExplicitRecover()                                                   {}
+func workCountObserveReductionPop(*glrStack, int)                                       {}
+func workCountAddPopPaths(uint64, uint64)                                               {}
+func workCountRecordVersionCreation()                                                   {}
+func workCountRecordMergeAttempt()                                                      {}
+func workCountRecordMergeSuccess()                                                      {}
+func workCountRecordGraphLinkAddition()                                                 {}
+func workCountRecordLeafConstruction()                                                  {}
+func workCountRecordParentConstruction()                                                {}
+func workCountRecordPendingParentConstruction()                                         {}
+func workCountRecordNoTreeParentConstruction()                                          {}

--- a/work_count_production_assembly_test.go
+++ b/work_count_production_assembly_test.go
@@ -1,0 +1,150 @@
+//go:build !gts_workcount
+
+package gotreesitter
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	finalizeDeferGuardMarker = "work-count-assembly: finalize-defer guard"
+	popPayloadCensusMarker   = "work-count-assembly: payload-census seam"
+)
+
+func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
+	testBinary := buildProductionTestBinary(t)
+
+	nm := runGoTool(t, "nm", testBinary)
+	productionWorkCountSymbol := regexp.MustCompile(`(?m)^\s*[0-9a-f]+\s+\S\s+github\.com/odvcencio/gotreesitter\.(?:\(\*[^)]*\)\.)?workCount`)
+	if match := productionWorkCountSymbol.Find(nm); match != nil {
+		t.Fatalf("untagged binary retains a production work-count symbol: %s", match)
+	}
+
+	finalizeLine := sourceMarkerLine(t, "parser.go", finalizeDeferGuardMarker) - 1
+	closures := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.parseInternal\.func`, testBinary)
+	finalizeAssembly := uniqueAssemblySectionForLine(t, closures, "parser.go", finalizeLine)
+	if bytes.Contains(finalizeAssembly, []byte("runtime.deferreturn")) {
+		t.Fatalf("untagged finalizeTree retains defer scaffolding:\n%s", finalizeAssembly)
+	}
+	assertNoDiagnosticAssembly(t, finalizeAssembly)
+
+	popCensusLine := sourceMarkerLine(t, "parser_reduce.go", popPayloadCensusMarker)
+	reduceAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.selectedReduceWindowsFromGSSWithBudget`, testBinary)
+	if hasAssemblyForLine(reduceAssembly, "parser_reduce.go", popCensusLine) {
+		t.Fatalf("untagged reduction path retains instructions at the payload-census seam:\n%s", reduceAssembly)
+	}
+	assertNoDiagnosticAssembly(t, reduceAssembly)
+}
+
+func assertNoDiagnosticAssembly(t *testing.T, assembly []byte) {
+	t.Helper()
+	for _, forbidden := range [][]byte{
+		[]byte("workCount"),
+		[]byte("work_count_hooks.go:"),
+	} {
+		if bytes.Contains(assembly, forbidden) {
+			t.Fatalf("untagged assembly retains diagnostic code %q:\n%s", forbidden, assembly)
+		}
+	}
+}
+
+func sourceMarkerLine(t *testing.T, name, marker string) int {
+	t.Helper()
+	source, err := os.ReadFile(filepath.Join(".", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	lines := bytes.Split(source, []byte("\n"))
+	if got := bytes.Count(source, []byte(marker)); got != 1 {
+		t.Fatalf("want one %q marker in %s, got %d", marker, name, got)
+	}
+	for index, line := range lines {
+		if bytes.Contains(line, []byte(marker)) {
+			return index + 1
+		}
+	}
+	t.Fatalf("marker %q not found in %s", marker, name)
+	return 0
+}
+
+func uniqueAssemblySectionForLine(t *testing.T, assembly []byte, file string, line int) []byte {
+	t.Helper()
+	var matches [][]byte
+	for _, section := range splitAssemblySections(assembly) {
+		if hasAssemblyForLine(section, file, line) {
+			matches = append(matches, section)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want one assembly section for %s:%d, got %d", file, line, len(matches))
+	}
+	return matches[0]
+}
+
+func splitAssemblySections(assembly []byte) [][]byte {
+	const header = "TEXT "
+	text := string(assembly)
+	starts := regexp.MustCompile(`(?m)^TEXT `).FindAllStringIndex(text, -1)
+	sections := make([][]byte, 0, len(starts))
+	for index, start := range starts {
+		end := len(text)
+		if index+1 < len(starts) {
+			end = starts[index+1][0]
+		}
+		section := text[start[0]:end]
+		if strings.HasPrefix(section, header) {
+			sections = append(sections, []byte(section))
+		}
+	}
+	return sections
+}
+
+func hasAssemblyForLine(assembly []byte, file string, line int) bool {
+	needle := []byte(filepath.Base(file) + ":" + strconv.Itoa(line))
+	for _, assemblyLine := range bytes.Split(assembly, []byte("\n")) {
+		if bytes.Contains(assemblyLine, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func runGoTool(t *testing.T, arguments ...string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, "go", append([]string{"tool"}, arguments...)...)
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("go tool %s: %v", strings.Join(arguments, " "), ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("go tool %s: %v\n%s", strings.Join(arguments, " "), err, output)
+	}
+	return output
+}
+
+func buildProductionTestBinary(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(t.TempDir(), "gotreesitter.test")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, "go", "test", "-c", "-o", binary, ".")
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("build untagged test binary: %v", ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("build untagged test binary: %v\n%s", err, output)
+	}
+	return binary
+}


### PR DESCRIPTION
## Summary

- Add an authenticated Go/static-C work-count protocol for locked parser fixtures.
- Attribute internal parse attempts and classify direct, proxy, and terminal counters without timing inside the parser.
- Bind source, toolchain, environment, admission, and subprocess containment; compile all diagnostic seams out of normal builds.

## Validation

- Authenticated clean receipt: `174b6967b2dc4eca771b06f89bfd2122d04fed7d1f9652a464369081dd448af0`.
- Docker tagged diagnostics, production assembly, cold static-C admission, PAX extraction, and descendant cleanup.
- Go grammar real-corpus parity: 25/25 no-error, S-expression, and deep parity.
