### PR TITLE
perf(harness): publish terminal fleet findings

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -215,6 +215,13 @@ Named large-file witnesses (tracked, not hidden): JavaScript
 generated-table class (Go `opGen.go` / `rewriteAMD64.go` and in-repo
 witnesses).
 
+Fleet report reduction can preserve a terminal shard only when it carries the
+closed status `no_static_c_oracle`, `no_corpus`, or `no_corpus_files` and no
+measurement or oracle payload. These rows remain fatal closure findings and
+are omitted from the combined oracle-language manifest. Certification still
+rejects them; both modes reject missing, generic, contradictory, or mixed
+identity evidence.
+
 ### Forest-routing screen and confirmation
 
 The authenticated forest audit separates discovery from promotion. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ for tags and release notes while still in `0.x`.
 
 ### Tooling
 
+- Report-mode fleet reduction now preserves closed-vocabulary
+  `no_static_c_oracle`, `no_corpus`, and `no_corpus_files` shards as fatal
+  closure findings in the combined artifact. Certification remains fail-closed,
+  and report mode still rejects untyped, contradictory, or mixed oracle
+  evidence.
 - The authenticated fleet scoreboard now times fresh full parses against a
   per-language, fully static executable built from the locked upstream runtime
   and grammar sources. Every selected file requires matching static/cgo deep

--- a/cgo_harness/perf_scan/README.md
+++ b/cgo_harness/perf_scan/README.md
@@ -250,6 +250,14 @@ writes the identical board, then fails the test when the combined hard gate is
 FAIL and reports the artifact path and finding count. An unknown mode fails
 before any scoreboard is published.
 
+Only report mode can close a complete fleet cohort around a terminal
+`no_static_c_oracle`, `no_corpus`, or `no_corpus_files` shard. The reducer
+authenticates that closed status and requires an otherwise empty measurement
+payload, preserves it as a fatal coverage finding, and omits only that row from
+the combined static-oracle language manifest. Certification rejects the same
+row before publication. Missing, generic, contradictory, or mixed identity
+evidence remains inadmissible in both modes.
+
 New scoreboards record the full repository revision and clean-source attestation.
 Revisionless v1 JSON still decodes for existing readers, but is deliberately
 ineligible for authoritative reduction. Git and Go build VCS metadata must

--- a/cgo_harness/static_c_perf_oracle_test.go
+++ b/cgo_harness/static_c_perf_oracle_test.go
@@ -605,8 +605,19 @@ func TestStaticCPerfOracleClosedFailureVocabulary(t *testing.T) {
 }
 
 func perfScanOracleBoardFromRows(rows []*perfScanLanguage) (*perfScanOracleBoardIdentity, error) {
+	return perfScanOracleBoardFromRowsForMode(rows, perfScanReduceModeCertify)
+}
+
+func perfScanOracleBoardFromRowsForMode(rows []*perfScanLanguage, mode string) (*perfScanOracleBoardIdentity, error) {
+	allowReportClosures := mode == perfScanReduceModeReport
 	board := &perfScanOracleBoardIdentity{}
 	for _, row := range rows {
+		if allowReportClosures && row != nil && perfScanReportClosureStatus(row.Status) {
+			if err := perfScanValidateReportClosureRow(row); err != nil {
+				return nil, err
+			}
+			continue
+		}
 		if row == nil || row.Oracle == nil {
 			return nil, fmt.Errorf("language row is missing static C oracle identity")
 		}
@@ -617,11 +628,19 @@ func perfScanOracleBoardFromRows(rows []*perfScanLanguage) (*perfScanOracleBoard
 		}
 		board.Languages = append(board.Languages, row.Oracle.Language)
 	}
+	if board.Common.Contract == "" || len(board.Languages) == 0 {
+		return nil, fmt.Errorf("reduced scoreboard has no authenticated static C oracle identity")
+	}
 	sort.Slice(board.Languages, func(i, j int) bool { return board.Languages[i].Language < board.Languages[j].Language })
 	return board, nil
 }
 
 func perfScanValidateOracleEvidence(board *perfScanScoreboard) error {
+	return perfScanValidateOracleEvidenceForMode(board, perfScanReduceModeCertify)
+}
+
+func perfScanValidateOracleEvidenceForMode(board *perfScanScoreboard, mode string) error {
+	allowReportClosures := mode == perfScanReduceModeReport
 	if board == nil || board.Oracle == nil {
 		return fmt.Errorf("scoreboard is missing static C oracle identity")
 	}
@@ -681,10 +700,27 @@ func perfScanValidateOracleEvidence(board *perfScanScoreboard) error {
 		}
 		boardByLanguage[identity.Language] = identity
 	}
-	if len(boardByLanguage) != len(board.Languages) {
-		return fmt.Errorf("oracle identity has %d languages, scoreboard has %d", len(boardByLanguage), len(board.Languages))
+	wantOracleLanguages := len(board.Languages)
+	if allowReportClosures {
+		for _, row := range board.Languages {
+			if row != nil && perfScanReportClosureStatus(row.Status) {
+				if err := perfScanValidateReportClosureRow(row); err != nil {
+					return fmt.Errorf("language %q report closure: %w", row.Language, err)
+				}
+				if _, exists := boardByLanguage[row.Language]; exists {
+					return fmt.Errorf("language %q typed closure contradicts a scoreboard oracle identity", row.Language)
+				}
+				wantOracleLanguages--
+			}
+		}
+	}
+	if len(boardByLanguage) != wantOracleLanguages {
+		return fmt.Errorf("oracle identity has %d languages, scoreboard requires %d", len(boardByLanguage), wantOracleLanguages)
 	}
 	for _, row := range board.Languages {
+		if allowReportClosures && row != nil && perfScanReportClosureStatus(row.Status) {
+			continue
+		}
 		if row == nil || row.Oracle == nil {
 			return fmt.Errorf("language row is missing oracle identity")
 		}

--- a/cgo_harness/zz_perf_scan_reduce_test.go
+++ b/cgo_harness/zz_perf_scan_reduce_test.go
@@ -71,7 +71,7 @@ func TestPerfScanReduce(t *testing.T) {
 	}
 	sort.Strings(lockLanguages)
 
-	board, err := perfScanReduceScoreboards(paths, coverage.LockPath, coverage.LockSHA256, lockLanguages, time.Now().UTC())
+	board, err := perfScanReduceScoreboardsForMode(paths, coverage.LockPath, coverage.LockSHA256, lockLanguages, time.Now().UTC(), reduceMode)
 	if err != nil {
 		t.Fatalf("reduce shard scoreboards: %v", err)
 	}
@@ -192,6 +192,13 @@ func perfScanReadScoreboard(path string) (*perfScanScoreboard, error) {
 }
 
 func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLanguages []string, generatedAt time.Time) (*perfScanScoreboard, error) {
+	return perfScanReduceScoreboardsForMode(paths, lockPath, lockSHA, lockLanguages, generatedAt, perfScanReduceModeCertify)
+}
+
+func perfScanReduceScoreboardsForMode(paths []string, lockPath, lockSHA string, lockLanguages []string, generatedAt time.Time, mode string) (*perfScanScoreboard, error) {
+	if mode != perfScanReduceModeReport && mode != perfScanReduceModeCertify {
+		return nil, fmt.Errorf("invalid resolved reducer mode %q", mode)
+	}
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("no shard scoreboards")
 	}
@@ -294,14 +301,24 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 				return nil, fmt.Errorf("shard %s language %q file %q classification: %w", shardPath, lang, file.Path, err)
 			}
 		}
-		if err := perfScanValidateOracleEvidence(shard); err != nil {
-			return nil, fmt.Errorf("shard %s static C oracle evidence: %w", shardPath, err)
-		}
-		if baseOracle == nil {
-			common := shard.Oracle.Common
-			baseOracle = &common
-		} else if !reflect.DeepEqual(*baseOracle, shard.Oracle.Common) {
-			return nil, fmt.Errorf("shard %s static C oracle common identity differs from earlier shards", shardPath)
+		reportClosure := perfScanReportClosureStatus(row.Status)
+		if reportClosure {
+			if mode != perfScanReduceModeReport {
+				return nil, fmt.Errorf("shard %s status %q is authenticated failure evidence only in report mode", shardPath, row.Status)
+			}
+			if err := perfScanValidateReportClosureShard(shard); err != nil {
+				return nil, fmt.Errorf("shard %s report closure evidence: %w", shardPath, err)
+			}
+		} else {
+			if err := perfScanValidateOracleEvidence(shard); err != nil {
+				return nil, fmt.Errorf("shard %s static C oracle evidence: %w", shardPath, err)
+			}
+			if baseOracle == nil {
+				common := shard.Oracle.Common
+				baseOracle = &common
+			} else if !reflect.DeepEqual(*baseOracle, shard.Oracle.Common) {
+				return nil, fmt.Errorf("shard %s static C oracle common identity differs from earlier shards", shardPath)
+			}
 		}
 
 		comparable := perfScanComparableShardConfig(shard.Config)
@@ -378,19 +395,75 @@ func perfScanReduceScoreboards(paths []string, lockPath, lockSHA string, lockLan
 	}
 	for _, lang := range wantLanguages {
 		row := rowsByLang[lang]
-		perfScanRefreshLanguageAggregates(row, outputConfig)
+		if mode != perfScanReduceModeReport || !perfScanReportClosureStatus(row.Status) {
+			perfScanRefreshLanguageAggregates(row, outputConfig)
+		}
 		board.Languages = append(board.Languages, row)
 		board.Summary[row.Verdict]++
 	}
-	oracleIdentity, err := perfScanOracleBoardFromRows(board.Languages)
+	oracleIdentity, err := perfScanOracleBoardFromRowsForMode(board.Languages, mode)
 	if err != nil {
 		return nil, fmt.Errorf("assemble reduced static C oracle identity: %w", err)
 	}
 	board.Oracle = oracleIdentity
 	board.FullParseSplit = perfScanAggregateFleetCleanErrorSplit(board.Languages)
 	gate := perfScanEvaluateHardGate(board)
+	if mode == perfScanReduceModeReport {
+		gate = perfScanEvaluateHardGateWithReportClosures(board)
+	}
 	board.Gate = &gate
 	return board, nil
+}
+
+func perfScanReportClosureStatus(status string) bool {
+	switch status {
+	case "no_static_c_oracle", "no_corpus", "no_corpus_files":
+		return true
+	default:
+		return false
+	}
+}
+
+func perfScanValidateReportClosureShard(shard *perfScanScoreboard) error {
+	if shard == nil || len(shard.Languages) != 1 || shard.Languages[0] == nil {
+		return fmt.Errorf("closure shard must contain exactly one language row")
+	}
+	if shard.Oracle != nil {
+		return fmt.Errorf("typed closure shard contradicts its status with a scoreboard oracle identity")
+	}
+	return perfScanValidateReportClosureRow(shard.Languages[0])
+}
+
+func perfScanValidateReportClosureRow(row *perfScanLanguage) error {
+	if row == nil || !perfScanReportClosureStatus(row.Status) {
+		return fmt.Errorf("unrecognized report closure status %q", row.Status)
+	}
+	if strings.TrimSpace(row.Language) == "" || strings.TrimSpace(row.Detail) == "" || strings.TrimSpace(row.Backend) == "" {
+		return fmt.Errorf("typed closure must record language, detail, and backend")
+	}
+	if row.Oracle != nil {
+		return fmt.Errorf("typed closure status %q contradicts a language oracle identity", row.Status)
+	}
+	if row.FilesMeasured != 0 || row.BytesMeasured != 0 || len(row.Files) != 0 || len(row.Axes) != 0 || row.FullParseSplit != nil {
+		return fmt.Errorf("typed closure status %q contains measured file, byte, axis, or split evidence", row.Status)
+	}
+	if row.ActiveFile != "" || row.ActiveFileIndex != nil || row.ActiveFileBytes != nil || row.ActiveAxis != "" || row.ActiveImpl != "" || row.ActivePhase != "" || row.ActiveAttempt != nil || row.Stop != nil {
+		return fmt.Errorf("typed closure status %q contains active or stopped measurement state", row.Status)
+	}
+	if row.Verdict != perfScanBucketNoData {
+		return fmt.Errorf("typed closure status %q has verdict %q, want %q", row.Status, row.Verdict, perfScanBucketNoData)
+	}
+	switch row.Status {
+	case "no_static_c_oracle":
+		if row.FilesSelected <= 0 {
+			return fmt.Errorf("no_static_c_oracle closure has no selected corpus files")
+		}
+	case "no_corpus", "no_corpus_files":
+		if row.FilesSelected != 0 {
+			return fmt.Errorf("%s closure selected %d corpus files", row.Status, row.FilesSelected)
+		}
+	}
+	return nil
 }
 
 func perfScanComparableShardConfig(cfg perfScanConfig) perfScanConfig {
@@ -1235,6 +1308,181 @@ func TestPerfScanReduceScoreboards(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPerfScanReduceReportTypedClosures(t *testing.T) {
+	const (
+		lockPath = "/corpus/corpus_sources.lock"
+		lockSHA  = "cf108b005fe41c4513bae14eafd4f4ec72e64454ca2eb6bbf4d18d25caab24f2"
+		revision = "7b797554397b814f981e9a3fb462b84a3d0f1837"
+	)
+	lockLanguages := []string{"go", "python"}
+	configureClosure := func(shard *perfScanScoreboard, status string) {
+		row := shard.Languages[0]
+		row.Status = status
+		row.Detail = "typed terminal closure evidence"
+		row.Backend = "dfa"
+		row.FilesMeasured = 0
+		row.BytesMeasured = 0
+		row.Verdict = perfScanBucketNoData
+		row.Oracle = nil
+		row.Axes = nil
+		row.FullParseSplit = nil
+		row.Files = nil
+		row.Stop = nil
+		if status == "no_static_c_oracle" {
+			row.FilesSelected = 1
+		} else {
+			row.FilesSelected = 0
+		}
+		shard.Oracle = nil
+		shard.FullParseSplit = nil
+		shard.Summary = map[string]int{perfScanBucketNoData: 1}
+		gate := perfScanEvaluateHardGate(shard)
+		shard.Gate = &gate
+	}
+	makeInputs := func(t *testing.T, status string, mutate func(*perfScanScoreboard)) []string {
+		t.Helper()
+		goShard := perfScanTestShard("go", lockPath, lockSHA, len(lockLanguages), revision)
+		pythonShard := perfScanTestShard("python", lockPath, lockSHA, len(lockLanguages), revision)
+		configureClosure(pythonShard, status)
+		if mutate != nil {
+			mutate(pythonShard)
+		}
+		if pythonShard.Gate != nil {
+			gate := perfScanEvaluateHardGate(pythonShard)
+			pythonShard.Gate = &gate
+		}
+		dir := t.TempDir()
+		return []string{
+			perfScanWriteTestScoreboard(t, dir, "go.json", goShard),
+			perfScanWriteTestScoreboard(t, dir, "python.json", pythonShard),
+		}
+	}
+	reduceReport := func(paths []string) (*perfScanScoreboard, error) {
+		return perfScanReduceScoreboardsForMode(paths, lockPath, lockSHA, lockLanguages, time.Unix(1_752_400_000, 0), perfScanReduceModeReport)
+	}
+
+	for _, status := range []string{"no_static_c_oracle", "no_corpus", "no_corpus_files"} {
+		t.Run(status+" is published as fatal closure evidence", func(t *testing.T) {
+			paths := makeInputs(t, status, nil)
+			board, err := reduceReport(paths)
+			if err != nil {
+				t.Fatalf("report reduction: %v", err)
+			}
+			if len(board.Languages) != 2 || board.Oracle == nil || len(board.Oracle.Languages) != 1 || board.Oracle.Languages[0].Language != "go" {
+				t.Fatalf("report closure identities = languages:%d oracle:%+v", len(board.Languages), board.Oracle)
+			}
+			if err := perfScanValidateOracleEvidenceForMode(board, perfScanReduceModeReport); err != nil {
+				t.Fatalf("combined report oracle evidence: %v", err)
+			}
+			if err := perfScanValidateOracleEvidence(board); err == nil {
+				t.Fatal("strict oracle validation accepted a report-only closure")
+			}
+			if board.Gate == nil || board.Gate.Status != perfScanGateFail {
+				t.Fatalf("combined report gate = %+v", board.Gate)
+			}
+			var found bool
+			for _, finding := range board.Gate.Failures {
+				if finding.Kind == "oracle" {
+					t.Fatalf("typed closure was downgraded to generic oracle evidence: %+v", board.Gate)
+				}
+				if finding.Language == "python" && finding.Status == status {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("typed closure status %q absent from gate: %+v", status, board.Gate)
+			}
+			out := filepath.Join(t.TempDir(), "report")
+			if err := perfScanPublishReducedScoreboard(out, board, perfScanReduceModeReport); err != nil {
+				t.Fatalf("publish report closure: %v", err)
+			}
+			assertPerfScanPublishedGate(t, out, perfScanGateFail)
+
+			if _, err := perfScanReduceScoreboards(paths, lockPath, lockSHA, lockLanguages, time.Unix(1_752_400_000, 0)); err == nil || !strings.Contains(err.Error(), "report mode") {
+				t.Fatalf("certify reduction error = %v, want report-only failure", err)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name   string
+		status string
+		mutate func(*perfScanScoreboard)
+		want   string
+	}{
+		{
+			name:   "untyped missing oracle",
+			status: "no_static_c_oracle",
+			mutate: func(shard *perfScanScoreboard) { shard.Languages[0].Status = "oracle_unavailable" },
+			want:   "missing static C oracle identity",
+		},
+		{
+			name:   "missing closure detail",
+			status: "no_static_c_oracle",
+			mutate: func(shard *perfScanScoreboard) { shard.Languages[0].Detail = "" },
+			want:   "must record language, detail, and backend",
+		},
+		{
+			name:   "closure retains measured evidence",
+			status: "no_static_c_oracle",
+			mutate: func(shard *perfScanScoreboard) { shard.Languages[0].FilesMeasured = 1 },
+			want:   "contains measured file, byte, axis, or split evidence",
+		},
+		{
+			name:   "closure retains language identity",
+			status: "no_static_c_oracle",
+			mutate: func(shard *perfScanScoreboard) { shard.Languages[0].Oracle = perfScanTestOracleIdentity("python") },
+			want:   "contradicts a language oracle identity",
+		},
+		{
+			name:   "closure retains scoreboard identity",
+			status: "no_static_c_oracle",
+			mutate: func(shard *perfScanScoreboard) {
+				shard.Oracle, _ = perfScanOracleBoardFromRows([]*perfScanLanguage{perfScanTestShard("python", lockPath, lockSHA, len(lockLanguages), revision).Languages[0]})
+			},
+			want: "contradicts its status with a scoreboard oracle identity",
+		},
+		{
+			name:   "no corpus contradicts selection",
+			status: "no_corpus",
+			mutate: func(shard *perfScanScoreboard) { shard.Languages[0].FilesSelected = 1 },
+			want:   "selected 1 corpus files",
+		},
+		{
+			name:   "missing stored closure gate",
+			status: "no_corpus",
+			mutate: func(shard *perfScanScoreboard) { shard.Gate = nil },
+			want:   "no stored hard gate",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := reduceReport(makeInputs(t, tc.status, tc.mutate)); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("report reduction error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("report mode still rejects mixed ordinary oracle identity", func(t *testing.T) {
+		goShard := perfScanTestShard("go", lockPath, lockSHA, len(lockLanguages), revision)
+		pythonShard := perfScanTestShard("python", lockPath, lockSHA, len(lockLanguages), revision)
+		pythonShard.Oracle.Common.CompilerVersion = "another cc"
+		pythonShard.Languages[0].Oracle.Common.CompilerVersion = "another cc"
+		identity := pythonShard.Languages[0].Oracle
+		identity.Language.BuildKeySHA256 = staticCBuildKey(identity.Common, identity.Language)
+		pythonShard.Oracle.Languages[0] = identity.Language
+		gate := perfScanEvaluateHardGate(pythonShard)
+		pythonShard.Gate = &gate
+		dir := t.TempDir()
+		paths := []string{
+			perfScanWriteTestScoreboard(t, dir, "go.json", goShard),
+			perfScanWriteTestScoreboard(t, dir, "python.json", pythonShard),
+		}
+		if _, err := reduceReport(paths); err == nil || !strings.Contains(err.Error(), "common identity differs") {
+			t.Fatalf("mixed ordinary identity error = %v", err)
+		}
+	})
 }
 
 func TestPerfScanRefreshLanguageAggregatesClearsStaleAxes(t *testing.T) {

--- a/cgo_harness/zz_perf_scan_test.go
+++ b/cgo_harness/zz_perf_scan_test.go
@@ -865,6 +865,14 @@ func perfScanCompareGateStop(a, b *perfScanStop) int {
 }
 
 func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
+	return perfScanEvaluateHardGateForMode(board, perfScanReduceModeCertify)
+}
+
+func perfScanEvaluateHardGateWithReportClosures(board *perfScanScoreboard) perfScanGateReport {
+	return perfScanEvaluateHardGateForMode(board, perfScanReduceModeReport)
+}
+
+func perfScanEvaluateHardGateForMode(board *perfScanScoreboard, mode string) perfScanGateReport {
 	report := perfScanGateReport{
 		Status:             perfScanGatePass,
 		MaxFullParseRatio:  perfScanHardFullRatio,
@@ -882,7 +890,7 @@ func perfScanEvaluateHardGate(board *perfScanScoreboard) perfScanGateReport {
 		addFailure(perfScanGateFinding{Kind: "coverage", Status: "no_evidence", Detail: "scoreboard contains no language rows"})
 	}
 	if board.Schema == perfScanSchema {
-		if err := perfScanValidateOracleEvidence(board); err != nil {
+		if err := perfScanValidateOracleEvidenceForMode(board, mode); err != nil {
 			addFailure(perfScanGateFinding{Kind: "oracle", Status: "inadmissible", Detail: err.Error()})
 		}
 	}


### PR DESCRIPTION
Summary:
- preserve typed no-oracle and no-corpus rows in report-mode fleet artifacts
- keep certification and malformed evidence fail-closed
- document the report/certification boundary

Validation:
- focused reducer and security tests in Docker
- authenticated 206-language report reduction on the pinned quiet host
- exact-head independent review