### PR TITLE
perf(harness): authenticate parser convergence work

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -218,15 +218,28 @@ separate content-addressed straight-LR control pins the one-stack case.
 
 `accept_actions` is a terminal-event counter, not a convergence counter. C can
 accept once and then emit multiple packed roots during `pop_all`, while Go can
-apply multiple accept actions inside one attempt. Contract v2 therefore
-reserves, but does not yet implement, a bounded convergence-frontier record:
-the first 256 events plus the first rejection for each reason, keyed by
-attempt, lookahead, phase, head state/byte/status/error/scanner identity, with
-before/after links and packed paths, cumulative counters, and separate
-`accept_actions` and `packed_roots_emitted`. No current receipt makes a
-convergence claim from the accept-action row.
+apply multiple accept actions inside one attempt. The historical v2 contract
+therefore remains the shared Go/static-C counter vocabulary. The diagnostic
+v3 supplement implements a Go-only convergence frontier; the static C child
+does not fabricate equivalent events.
 
-An authoritative `gts-work-count-receipt/v3` requires a clean Git checkout and
+The v3 frontier retains at most the first 256 events plus the first rejection
+for each closed-vocabulary reason. Events are keyed by attempt-local decision
+IDs for a target/candidate pair, lookahead, and exact phase: reduce-window selection, post-reduce primary
+and pending packing, boundary GSS/equivalence/cull, pending work, final path
+expansion and selection, and terminal acceptance. Records contain values only,
+never Go pointers. External-scanner comparability and checkpoint identity are
+captured for the current token election, not inferred from either stack head.
+Link and packed-path counts saturate independently from event truncation.
+After chronological retention fills, scalar aggregates and bounded shapes
+continue to update, while decision correlation, formatted detail, and head
+snapshots are omitted. Packed final-path observation is bounded to the production
+expansion limit plus one path (currently seven) and by a parse-global traversal
+budget; an exhausted observation reports unknown snapshot evidence rather
+than claiming that the production cap fired. This lane remains diagnostic and
+untimed.
+
+An authoritative `gts-work-count-receipt/v4` requires a clean Git checkout and
 records `HEAD`, `HEAD^{tree}`, and `git_clean=true`. Both Go binaries compile
 from one sealed content-addressed Git source snapshot. C compiles from private
 snapshots of the runtime, grammar, patch, and driver. Ambient `GOT_*`,
@@ -235,14 +248,17 @@ chosen build/runtime environments are serialized. Build, patch, link, and
 child process groups are wall-bounded. A stale receipt is removed before work
 starts, and a successful receipt is published atomically in its destination
 directory.
+The ordinary untagged Go admission child remains on
+`gts-work-count-go-child/v3`; the tagged diagnostic child is v4, while the
+static-C child retains its historical schema.
 
 Directly comparable counters are limited to applied shift/reduce/recover
 actions, reduction pop requests and emitted paths/payloads, and the selected
-tree census. Accept actions are reported as terminal evidence but require the
-future packed-root/convergence record for interpretation. Table
-lookups, lexer calls, stack versions, merges, graph links, and transient
-payload construction remain explicitly labeled representation-specific
-proxies.
+tree census. Accept actions remain terminal evidence rather than packed-root
+counts. The Go-only v3 frontier supplies the missing interpretation without
+changing shared counter semantics. Table lookups, lexer calls, stack versions,
+merges, graph links, and transient payload construction remain explicitly
+labeled representation-specific proxies.
 
 Run the focused Docker gate from a linked worktree by mounting its absolute
 Git common directory and selecting the worktree-specific Git directory inside
@@ -267,8 +283,10 @@ The checkout must expose usable Git metadata inside the container. Dirty
 source fails closed. `GTS_WORK_COUNT_ALLOW_DIRTY=1` exists only for focused
 pre-commit harness tests; its receipt records `authoritative=false` and cannot
 enter the evidence ledger.
-The checked-in semantic contract is
+The checked-in shared semantic contract remains
 [`cgo_harness/work_count/contract_v2.json`](cgo_harness/work_count/contract_v2.json).
+The independently validated Go-only frontier vocabulary is
+[`cgo_harness/work_count/contract_v3.json`](cgo_harness/work_count/contract_v3.json).
 `construction_surplus` means representation-specific leaf plus parent
 constructions minus selected nodes; it must never be relabeled as a count of
 discarded nodes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,17 @@ for tags and release notes while still in `0.x`.
   loop, and finalization; `accept_actions` is explicitly an action count, and
   aggregate counters must equal attempts plus the outside-attempt residual.
   Frozen retry-active and straight-LR witnesses pin the attribution semantics;
-  the contract reserves a bounded convergence-frontier schema and distinguishes
-  accept actions from packed roots without claiming that instrumentation yet.
+  a Go-only v3 supplement now records a bounded, attempt-local convergence
+  frontier across reduction selection, post-reduce packing, boundary merge and
+  cull, pending work, terminal acceptance, packed-root expansion, and final
+  selection. It retains the first 256 events plus first rejection evidence,
+  uses attempt-local decision IDs for target/candidate pairs, records scanner
+  checkpoint identity at the current token election, detects partial merge
+  mutations from exact semantic GSS writes, separates saturation from
+  truncation, serializes no pointer identities, and
+  leaves the shared v2 Go/static-C counter semantics unchanged. Authenticated
+  v4 receipts bind both manifests and fail closed on malformed convergence
+  payloads.
   Authoritative receipts require a clean Git source identity; compile from
   sealed private Go and C input snapshots; bind sanitized build/runtime
   environments; independently verify fixture, grammar, GLR-regime, span, and

--- a/cgo_harness/work_count/contract_v3.json
+++ b/cgo_harness/work_count/contract_v3.json
@@ -1,0 +1,217 @@
+{
+  "schema": "gts-work-count-contract/v3",
+  "counter_contract": "gts-work-count/v2",
+  "scope": "one fresh public full-parse invocation in one tagged diagnostic child process; all internal parseInternal attempts and retry/reparse work are counted and attributed; no elapsed-time evidence",
+  "historical_compatibility": {
+    "v2_manifest": "contract_v2.json remains an immutable historical contract",
+    "direct_and_proxy_counter_semantics": "unchanged gts-work-count/v2 semantics for Go and static C",
+    "detailed_convergence": "additive Go-only diagnostic capability; static C does not emit comparable convergence events"
+  },
+  "direct": {
+    "shifts": "shift actions applied",
+    "reductions": "reduce actions applied",
+    "explicit_recover_actions": "explicit recover parse actions applied",
+    "reduction_pop_requests": "pop-count requests issued by reduce actions",
+    "emitted_pop_paths": "concrete pop paths emitted by a pop-count request",
+    "emitted_pop_payloads": "payload entries carried by emitted pop paths",
+    "selected_nodes": "nodes in the selected returned tree",
+    "selected_parent_nodes": "selected returned-tree nodes with children",
+    "selected_leaf_nodes": "selected returned-tree nodes without children"
+  },
+  "terminal": {
+    "accept_actions": "terminal accept actions applied; multiple actions may occur inside one parseInternal attempt, and this count alone does not measure convergence or packed roots emitted"
+  },
+  "proxy": {
+    "table_lookups_proxy": "implementation-specific parse-table lookup front-door calls",
+    "action_entries_examined_proxy": "implementation-specific action entries exposed at instrumented dispatch lookups",
+    "lexer_front_door_calls_proxy": "implementation-specific production lexer front-door calls",
+    "stack_version_creations_proxy": "implementation-specific initial-stack and clone/version creation events",
+    "merge_attempts_proxy": "implementation-specific merge front-door candidate calls",
+    "merge_successes_proxy": "implementation-specific successful merge front-door calls",
+    "graph_link_additions_proxy": "implementation-specific physical primary or alternate stack-graph links added",
+    "leaf_constructions_proxy": "representation-specific transient leaf payload constructions",
+    "parent_constructions_proxy": "representation-specific transient parent payload constructions",
+    "pending_parent_constructions_proxy": "Go-only pending-parent subset; always zero in C",
+    "no_tree_parent_constructions_proxy": "Go-only no-tree parent subset; always zero in C"
+  },
+  "derived": {
+    "construction_surplus": "leaf_constructions_proxy + parent_constructions_proxy - selected_nodes; never described as discarded nodes"
+  },
+  "attempt_attribution": {
+    "logical_rungs": [
+      "initial_full",
+      "initial_merge",
+      "clean_wide",
+      "clean_wide_merge",
+      "recovery_wide_or_node",
+      "secondary_node",
+      "final_merge"
+    ],
+    "resolved_retry_pass_is_independent": true,
+    "phases": [
+      "entry_to_caps",
+      "caps_to_finalize",
+      "finalize"
+    ],
+    "require_aggregate_equals_attempts_plus_outside": true,
+    "canonical_query_compile_attempts": 1,
+    "canonical_query_compile_accept_actions": 3,
+    "retry_witness": {
+      "path": "testdata/work_count/retry_go_query_kotlin_regression.go",
+      "bytes": 3435,
+      "sha256": "ada50bc6eef16b831e7ca0c44f11dffbcff7d9695515519cd5090b2aacf4789a",
+      "expected_rungs": [
+        "initial_full",
+        "initial_merge"
+      ]
+    },
+    "straight_lr_control": {
+      "path": "testdata/work_count/straight_lr_control.go",
+      "bytes": 154,
+      "sha256": "4c584e187fdd4fb62dbf3953ca771e868bd3037e44abe5349c1cc0b3faf6532b",
+      "expected_max_stacks": 1
+    }
+  },
+  "convergence_frontier": {
+    "status": "implemented",
+    "capability": "go_only_detailed_convergence",
+    "static_c_emits_comparable_events": false,
+    "max_events": 256,
+    "max_packed_path_count": 7,
+    "packed_path_parse_work_budget": 16384,
+    "packed_path_per_walk_work_budget": 256,
+    "packed_path_depth_budget": 128,
+    "record_first_reject_per_reason": true,
+    "first_reject_semantics": "one exact copy of the minimum-sequence rejected event for every observed closed-vocabulary reason; reasons and sequences are unique",
+    "decision_ids": "attempt-local monotonically increasing identifiers for a target/candidate decision-pair, correlated through a fixed 256-slot recent-key table; zero if and only if both heads are absent; table keys may use in-process addresses but addresses are never serialized and retention cannot grow with the parse",
+    "head_status_priority": ["dead", "accepted", "paused", "live"],
+    "phases": [
+      "reduce_window_select",
+      "post_reduce_primary",
+      "post_reduce_pending",
+      "boundary_gss",
+      "boundary_equivalence",
+      "boundary_cull",
+      "pending_work",
+      "final_expand",
+      "final_select",
+      "terminal_accept"
+    ],
+    "phase_outcomes": {
+      "reduce_window_select": ["candidate", "cap_hit"],
+      "post_reduce_primary": ["candidate", "packed", "rejected", "mutation_partial"],
+      "post_reduce_pending": ["candidate", "packed", "rejected", "mutation_partial"],
+      "boundary_gss": ["candidate", "packed", "rejected", "mutation_partial"],
+      "boundary_equivalence": ["rejected"],
+      "boundary_cull": ["rejected"],
+      "pending_work": ["pending_queued", "pending_drained", "pending_discarded"],
+      "final_expand": ["packed_root_emitted", "observation_unknown"],
+      "final_select": ["selected"],
+      "terminal_accept": ["accepted_head"]
+    },
+    "outcomes": [
+      "candidate",
+      "packed",
+      "rejected",
+      "pending_queued",
+      "pending_drained",
+      "pending_discarded",
+      "accepted_head",
+      "packed_root_emitted",
+      "mutation_partial",
+      "cap_hit",
+      "observation_unknown",
+      "selected"
+    ],
+    "reject_reasons": [
+      "status",
+      "score",
+      "shifted",
+      "error_cost",
+      "not_gss",
+      "not_clean",
+      "distinct_shape",
+      "preflight",
+      "cull"
+    ],
+    "identity": [
+      "attempt",
+      "iteration",
+      "decision_id",
+      "lookahead_symbol",
+      "lookahead_byte_range",
+      "phase",
+      "head_state",
+      "head_byte",
+      "head_status",
+      "head_error_or_recovery",
+      "head_score",
+      "election_scanner_checkpoint_presence_and_hash",
+      "head_and_predecessor_content_hash",
+      "head_depth_and_gss_link_count",
+      "head_link_count_capped",
+      "head_dead_accepted_paused_bits",
+      "head_node_baseline_and_error_cost",
+      "head_error_cost_comparable",
+      "election_scanner_comparable",
+      "lookahead_present",
+      "lookahead_no_lookahead_and_external_bits"
+    ],
+    "snapshots": [
+      "candidate_count_before",
+      "candidate_count_after",
+      "links_before",
+      "links_after",
+      "packed_paths_before",
+      "packed_paths_after"
+    ],
+    "event_invariants": [
+      "canonical fixture events use attempt 1",
+      "absent heads are otherwise zero",
+      "accepted-head and final-result events have no candidate head",
+      "non-comparable error cost is zero",
+      "non-GSS heads have zero links and graph hashes",
+      "capped link counts equal uint16 maximum",
+      "non-comparable scanner elections have no checkpoint or hash",
+      "absent scanner checkpoints have zero hash",
+      "unset lookahead has zero identity fields",
+      "packed-path sentinel 7 requires capped or unknown snapshot evidence",
+      "untruncated aggregates equal retained events; truncated aggregates are lower-bounded by retained events",
+      "top-level capped and unknown flags are the OR of event evidence when untruncated and retain every observed true signal when truncated"
+    ],
+    "candidate_count_units": "phase-local populations: reduce_window_select reports 1 to fork-count; post-reduce and boundary pair decisions report 2 to 1 when packed and 2 to 2 while still candidates or rejected; pending_work reports queue population; boundary_cull reports the whole frontier; final_expand reports 1 to emitted alternatives; final_select reports N to 1; never interpreted universally as pending work",
+    "bounded_trace": "the first 256 chronological events plus the first rejection for each closed reason; after the chronological cap, non-first-rejection traffic updates scalar saturating aggregates without decision correlation, formatted detail, or head snapshots; bounded shape and scalar aggregate work still runs; link counts saturate independently at uint16 maximum with explicit capped evidence; packed-path walks alone stop at the actual result cap plus one, a 256-node per-walk budget, a 16384-node parse-global budget, and depth 128; exhausted walks report an unknown observation without claiming a runtime cap hit or packed root emission, and paths or pointers are never serialized",
+    "separate_integrity_signals": [
+      "event_truncated",
+      "arithmetic_overflow",
+      "vocabulary_violation",
+      "snapshot_count_capped",
+      "snapshot_count_unknown",
+      "mutation_partial",
+      "cap_hit"
+    ],
+    "include_saturating_aggregates": true,
+    "terminal_counters": [
+      "accept_actions",
+      "accepted_heads",
+      "packed_roots_emitted"
+    ],
+    "interpretation": "detailed events and their aggregates describe Go implementation behavior only; accept actions and packed roots emitted remain distinct, and neither action count nor attempt count alone establishes convergence work"
+  },
+  "admission": {
+    "digest_format": "gts-deep-tree-v1",
+    "fixture": "query_compile",
+    "require_uninstrumented_go_static_c_digest_match_first": true,
+    "require_instrumented_digest_match": true,
+    "require_full_span": true,
+    "require_clean_root": true,
+    "require_no_overflow": true,
+    "require_exact_fields": true,
+    "require_ordinary_untagged_go_child_first": true,
+    "require_clean_git_source_for_authoritative_receipt": true,
+    "require_private_content_addressed_go_source_snapshot": true,
+    "require_private_c_input_snapshot": true,
+    "sanitize_go_and_parser_environment": true,
+    "atomic_receipt_publish": true
+  }
+}

--- a/cgo_harness/work_count_contract_v4_test.go
+++ b/cgo_harness/work_count_contract_v4_test.go
@@ -1,0 +1,336 @@
+//go:build cgo && treesitter_c_parity && treesitter_c_perfscan
+
+package cgoharness
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+const workCountConvergenceCorruptionEnv = "GTS_WORK_COUNT_CONVERGENCE_CORRUPTION_CHILD"
+
+func TestWorkCountV4SchemaBoundaries(t *testing.T) {
+	if workCountGoAdmissionChildSchema != "gts-work-count-go-child/v3" ||
+		workCountTaggedGoChildSchema != "gts-work-count-go-child/v4" ||
+		workCountCChildSchema != "gts-work-count-c-child/v3" ||
+		workCountReceiptSchema != "gts-work-count-receipt/v4" ||
+		workCountContract != "gts-work-count/v2" {
+		t.Fatalf("mixed work-count schema boundary: admission=%q tagged=%q C=%q receipt=%q counters=%q", workCountGoAdmissionChildSchema, workCountTaggedGoChildSchema, workCountCChildSchema, workCountReceiptSchema, workCountContract)
+	}
+}
+
+func TestWorkCountConvergenceAdmissionAcceptsValidFrontier(t *testing.T) {
+	frontier := workCountValidConvergenceForTest()
+	workCountValidateGoConvergence(t, frontier)
+	data, err := json.Marshal(frontier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workCountValidateGoConvergenceObject(t, data)
+}
+
+func TestWorkCountConvergenceAdmissionRejectsCorruption(t *testing.T) {
+	if corruption := os.Getenv(workCountConvergenceCorruptionEnv); corruption != "" {
+		frontier := workCountValidConvergenceForTest()
+		makeSecondEventReject := func() {
+			frontier.Events[1].Phase = "boundary_equivalence"
+			frontier.Events[1].Outcome = "rejected"
+			frontier.Events[1].RejectReason = "status"
+			frontier.Aggregates.Phases.FinalSelect = 0
+			frontier.Aggregates.Phases.BoundaryEquivalence = 1
+			frontier.Aggregates.Outcomes.Selected = 0
+			frontier.Aggregates.Outcomes.Rejected = 1
+			frontier.Aggregates.Rejections.Status = 1
+			frontier.FirstRejects = []workCountConvergenceEvent{frontier.Events[1]}
+		}
+		switch corruption {
+		case "retained_short":
+			frontier.Events = frontier.Events[:1]
+		case "sequence_gap":
+			frontier.Events[1].Sequence = 3
+		case "phase_sum":
+			frontier.Aggregates.Phases.FinalSelect = 0
+		case "phase_outcome":
+			frontier.Events[1].Phase = "terminal_accept"
+			frontier.Aggregates.Phases.FinalSelect = 0
+			frontier.Aggregates.Phases.TerminalAccept++
+		case "first_reject_missing":
+			makeSecondEventReject()
+			frontier.FirstRejects = nil
+		case "first_reject_not_exact":
+			makeSecondEventReject()
+			frontier.FirstRejects[0].Detail = "corrupt copy"
+		case "first_reject_nonminimal":
+			makeSecondEventReject()
+			frontier.Events[0].Phase = "boundary_equivalence"
+			frontier.Events[0].Outcome = "rejected"
+			frontier.Events[0].RejectReason = "status"
+			frontier.Aggregates.Phases.TerminalAccept = 0
+			frontier.Aggregates.Phases.BoundaryEquivalence = 2
+			frontier.Aggregates.Outcomes.AcceptedHead = 0
+			frontier.Aggregates.Outcomes.Rejected = 2
+			frontier.Aggregates.Rejections.Status = 2
+			frontier.Aggregates.AcceptedHeads = 0
+		case "first_reject_duplicate_sequence":
+			makeSecondEventReject()
+			duplicate := frontier.FirstRejects[0]
+			duplicate.RejectReason = "score"
+			frontier.FirstRejects = append(frontier.FirstRejects, duplicate)
+			frontier.Aggregates.Rejections.Score = 1
+			frontier.Aggregates.Outcomes.Rejected++
+			frontier.Aggregates.Phases.BoundaryEquivalence++
+		case "accepted_heads":
+			frontier.Aggregates.AcceptedHeads = 0
+		case "attempt_not_canonical":
+			frontier.Events[0].Attempt = 2
+		case "absent_head_data":
+			frontier.Events[0].Candidate.State = 1
+		case "decision_missing":
+			frontier.Events[0].DecisionID = 0
+		case "decision_without_heads":
+			frontier.Events[0].Target = workCountConvergenceHead{Status: "absent"}
+		case "accepted_candidate_present":
+			frontier.Events[0].Candidate = workCountConvergenceHead{Status: "live"}
+		case "final_candidate_present":
+			frontier.Events[1].Candidate = workCountConvergenceHead{Status: "live"}
+		case "head_link_without_gss":
+			frontier.Events[1].Target.LinkCount = 1
+		case "head_hash_without_gss":
+			frontier.Events[1].Target.HeadContentHash = 1
+		case "head_cost_not_comparable":
+			frontier.Events[1].Target.ErrorCost = 1
+		case "head_link_cap_not_saturated":
+			frontier.Events[1].Target.HasGSS = true
+			frontier.Events[1].Target.LinkCountCapped = true
+			frontier.Events[1].Target.LinkCount = math.MaxUint16 - 1
+		case "reversed_lookahead":
+			frontier.Events[0].LookaheadStartByte = 2
+			frontier.Events[0].LookaheadEndByte = 1
+		case "unset_lookahead_data":
+			frontier.Events[0].LookaheadSymbol = 1
+		case "scanner_noncomparable_hash":
+			frontier.Events[0].ElectionScannerCheckpointHash = 1
+		case "scanner_absent_checkpoint_hash":
+			frontier.Events[0].ElectionScannerComparable = true
+			frontier.Events[0].ElectionScannerCheckpointHash = 1
+		case "top_level_capped_or":
+			frontier.Events[0].SnapshotCapped = true
+		case "top_level_unknown_or":
+			frontier.Events[0].SnapshotUnknown = true
+		case "packed_sentinel_unproven":
+			frontier.Events[1].PathsBefore = 7
+			frontier.Aggregates.PathsBeforeTotal = 7
+		case "scalar_total":
+			frontier.Aggregates.CandidateCountBeforeTotal = 1
+		case "packed_roots":
+			frontier.Events[1].Phase = "final_expand"
+			frontier.Events[1].Outcome = "packed_root_emitted"
+			frontier.Events[1].PathsAfter = 2
+			frontier.Aggregates.Phases.FinalSelect = 0
+			frontier.Aggregates.Phases.FinalExpand = 1
+			frontier.Aggregates.Outcomes.Selected = 0
+			frontier.Aggregates.Outcomes.PackedRoot = 1
+			frontier.Aggregates.PathsAfterTotal = 2
+			frontier.Aggregates.PackedRoots = 7
+		case "lifecycle_orphan_candidate":
+			frontier.Events = frontier.Events[:3]
+			frontier.EventsSeen = 3
+			frontier.Aggregates.Phases.PostReducePrimary = 1
+			frontier.Aggregates.Outcomes.Packed = 0
+			frontier.Aggregates.CandidateCountBeforeTotal = 2
+			frontier.Aggregates.CandidateCountAfterTotal = 2
+		case "lifecycle_duplicate_terminal":
+			duplicate := frontier.Events[3]
+			duplicate.Sequence = 5
+			frontier.Events = append(frontier.Events, duplicate)
+			frontier.EventsSeen = 5
+			frontier.Aggregates.Phases.PostReducePrimary++
+			frontier.Aggregates.Outcomes.Packed++
+			frontier.Aggregates.CandidateCountBeforeTotal += 2
+			frontier.Aggregates.CandidateCountAfterTotal++
+		case "lifecycle_terminal_without_candidate":
+			frontier.Events[2].Outcome = "packed"
+			frontier.Aggregates.Outcomes.Candidate--
+			frontier.Aggregates.Outcomes.Packed++
+		case "lifecycle_phase_mismatch":
+			frontier.Events[3].Phase = "post_reduce_pending"
+			frontier.Aggregates.Phases.PostReducePrimary--
+			frontier.Aggregates.Phases.PostReducePending++
+		case "unknown_frontier_field", "wrong_snapshot_type", "wrong_head_type", "wrong_aggregate_type":
+			workCountValidateGoConvergenceObject(t, workCountCorruptConvergenceJSON(t, frontier, corruption))
+			return
+		default:
+			t.Fatalf("unknown corruption case %q", corruption)
+		}
+		workCountValidateGoConvergence(t, frontier)
+		return
+	}
+
+	for _, corruption := range []string{
+		"retained_short", "sequence_gap", "phase_sum", "phase_outcome", "first_reject_missing", "first_reject_not_exact", "first_reject_nonminimal", "first_reject_duplicate_sequence", "accepted_heads", "attempt_not_canonical",
+		"absent_head_data", "decision_missing", "decision_without_heads", "accepted_candidate_present", "final_candidate_present",
+		"head_link_without_gss", "head_hash_without_gss", "head_cost_not_comparable", "head_link_cap_not_saturated",
+		"reversed_lookahead", "unset_lookahead_data", "scanner_noncomparable_hash", "scanner_absent_checkpoint_hash",
+		"top_level_capped_or", "top_level_unknown_or", "packed_sentinel_unproven", "scalar_total", "packed_roots",
+		"lifecycle_orphan_candidate", "lifecycle_duplicate_terminal", "lifecycle_terminal_without_candidate", "lifecycle_phase_mismatch",
+		"unknown_frontier_field", "wrong_snapshot_type", "wrong_head_type", "wrong_aggregate_type",
+	} {
+		t.Run(corruption, func(t *testing.T) {
+			cmd := exec.Command(os.Args[0], "-test.run=^TestWorkCountConvergenceAdmissionRejectsCorruption$", "-test.count=1")
+			cmd.Env = append(os.Environ(), workCountConvergenceCorruptionEnv+"="+corruption, "GTS_PARITY_ALLOW_HOST=1")
+			if output, err := cmd.CombinedOutput(); err == nil {
+				t.Fatalf("corruption %q passed fail-closed admission: %s", corruption, output)
+			}
+		})
+	}
+}
+
+func TestWorkCountConvergenceAdmissionAcceptsUnknownPackedPathSentinel(t *testing.T) {
+	frontier := workCountValidConvergenceForTest()
+	frontier.Events[1].PathsBefore = 7
+	frontier.Events[1].SnapshotUnknown = true
+	frontier.SnapshotCountUnknown = true
+	frontier.Aggregates.PathsBeforeTotal = 7
+	workCountValidateGoConvergence(t, frontier)
+}
+
+func TestWorkCountConvergenceAdmissionAcceptsOverlappingStatusBitsByPriority(t *testing.T) {
+	frontier := workCountValidConvergenceForTest()
+	head := &frontier.Events[1].Target
+	head.Status, head.Dead, head.Accepted, head.Paused = "dead", true, true, true
+	workCountValidateGoConvergence(t, frontier)
+	head.Status, head.Dead = "accepted", false
+	workCountValidateGoConvergence(t, frontier)
+}
+
+func TestWorkCountConvergenceAdmissionAcceptsTruncatedAggregateLowerBounds(t *testing.T) {
+	frontier := workCountValidConvergenceForTest()
+	template := frontier.Events[1]
+	for sequence := uint64(5); sequence <= 256; sequence++ {
+		event := template
+		event.Sequence = sequence
+		event.DecisionID = uint32(sequence)
+		frontier.Events = append(frontier.Events, event)
+	}
+	frontier.EventsSeen = 257
+	frontier.EventTruncated = true
+	frontier.Aggregates.Phases.FinalSelect += 253
+	frontier.Aggregates.Outcomes.Selected += 253
+	frontier.Aggregates.CandidateCountBeforeTotal++
+	workCountValidateGoConvergence(t, frontier)
+}
+
+func TestWorkCountConvergenceManifestMatchesImmutableV2Sections(t *testing.T) {
+	repoRoot := workCountRepoRoot(t)
+	sharedPath := filepath.Join(repoRoot, "cgo_harness", "work_count", "contract_v2.json")
+	convergencePath := filepath.Join(repoRoot, "cgo_harness", "work_count", "contract_v3.json")
+	workCountValidateManifest(t, sharedPath)
+	workCountValidateConvergenceManifest(t, convergencePath)
+	workCountValidateManifestAgreement(t, sharedPath, convergencePath)
+	shared, err := os.ReadFile(sharedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	convergence, err := os.ReadFile(convergencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := workCountBytesSHA(shared); got != workCountSharedManifestSHA256 {
+		t.Fatalf("immutable v2 manifest sha256=%s want=%s", got, workCountSharedManifestSHA256)
+	}
+	if got := workCountBytesSHA(convergence); got != workCountConvergenceManifestSHA256 {
+		t.Fatalf("v3 manifest sha256=%s want=%s", got, workCountConvergenceManifestSHA256)
+	}
+	if err := workCountManifestAgreementError(shared, convergence); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, section := range []string{"direct", "terminal", "proxy", "derived", "attempt_attribution"} {
+		var mutated map[string]any
+		if err := json.Unmarshal(convergence, &mutated); err != nil {
+			t.Fatal(err)
+		}
+		value, ok := mutated[section].(map[string]any)
+		if !ok {
+			t.Fatalf("section %s is not an object", section)
+		}
+		value["__drift_test"] = true
+		data, err := json.Marshal(mutated)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := workCountManifestAgreementError(shared, data); err == nil {
+			t.Fatalf("semantic drift in %s was accepted", section)
+		}
+	}
+}
+
+func workCountBytesSHA(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func workCountValidConvergenceForTest() workCountConvergence {
+	absent := workCountConvergenceHead{Status: "absent"}
+	accepted := workCountConvergenceHead{Status: "accepted", Accepted: true}
+	live := workCountConvergenceHead{Status: "live"}
+	return workCountConvergence{
+		Capability:         "go_only_detailed_convergence",
+		MaxEvents:          256,
+		MaxPackedPathCount: 7,
+		EventsSeen:         4,
+		PathWalkWorkBudget: 16 * 1024,
+		Events: []workCountConvergenceEvent{
+			{Sequence: 1, Attempt: 1, DecisionID: 1, Phase: "terminal_accept", Outcome: "accepted_head", Target: accepted, Candidate: absent},
+			{Sequence: 2, Attempt: 1, DecisionID: 2, Phase: "final_select", Outcome: "selected", Target: live, Candidate: absent},
+			{Sequence: 3, Attempt: 1, DecisionID: 3, Phase: "post_reduce_primary", Outcome: "candidate", Target: live, Candidate: live, CandidateCountBefore: 2, CandidateCountAfter: 2},
+			{Sequence: 4, Attempt: 1, DecisionID: 3, Phase: "post_reduce_primary", Outcome: "packed", Target: live, Candidate: live, CandidateCountBefore: 2, CandidateCountAfter: 1},
+		},
+		Aggregates: workCountConvergenceTotals{
+			Phases:                    workCountConvergencePhaseTotals{TerminalAccept: 1, FinalSelect: 1, PostReducePrimary: 2},
+			Outcomes:                  workCountConvergenceOutcomeTotals{AcceptedHead: 1, Selected: 1, Candidate: 1, Packed: 1},
+			CandidateCountBeforeTotal: 4,
+			CandidateCountAfterTotal:  3,
+			AcceptedHeads:             1,
+		},
+	}
+}
+
+func workCountCorruptConvergenceJSON(t *testing.T, frontier workCountConvergence, corruption string) []byte {
+	t.Helper()
+	data, err := json.Marshal(frontier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	switch corruption {
+	case "unknown_frontier_field":
+		raw["unknown"] = true
+	case "wrong_snapshot_type":
+		raw["snapshot_count_capped"] = "false"
+	case "wrong_head_type":
+		events := raw["events"].([]any)
+		event := events[0].(map[string]any)
+		target := event["target"].(map[string]any)
+		target["state"] = "0"
+	case "wrong_aggregate_type":
+		aggregates := raw["aggregates"].(map[string]any)
+		aggregates["accepted_heads"] = "1"
+	default:
+		t.Fatalf("unknown raw corruption case %q", corruption)
+	}
+	data, err = json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}

--- a/cgo_harness/work_count_oracle_test.go
+++ b/cgo_harness/work_count_oracle_test.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,14 +25,17 @@ import (
 )
 
 const (
-	workCountEnableEnv     = "GTS_WORK_COUNT_ORACLE"
-	workCountReceiptEnv    = "GTS_WORK_COUNT_RECEIPT"
-	workCountFixtureID     = "query_compile"
-	workCountGoChildSchema = "gts-work-count-go-child/v3"
-	workCountCChildSchema  = "gts-work-count-c-child/v3"
-	workCountContract      = "gts-work-count/v2"
-	workCountReceiptSchema = "gts-work-count-receipt/v3"
-	workCountTimeout       = 2 * time.Minute
+	workCountEnableEnv                 = "GTS_WORK_COUNT_ORACLE"
+	workCountReceiptEnv                = "GTS_WORK_COUNT_RECEIPT"
+	workCountFixtureID                 = "query_compile"
+	workCountGoAdmissionChildSchema    = "gts-work-count-go-child/v3"
+	workCountTaggedGoChildSchema       = "gts-work-count-go-child/v4"
+	workCountCChildSchema              = "gts-work-count-c-child/v3"
+	workCountContract                  = "gts-work-count/v2"
+	workCountReceiptSchema             = "gts-work-count-receipt/v4"
+	workCountTimeout                   = 2 * time.Minute
+	workCountSharedManifestSHA256      = "a438ddae8eaaf8c343faeb5efccdc15035911ee4bf7d22e627091d123a9ff46d"
+	workCountConvergenceManifestSHA256 = "a4f28e92b4916277c56683b39a9e8da7358a9c8dd824b08f7f2be470e0daadde"
 
 	workCountCAdmissionChildEnv    = "GTS_WORK_COUNT_C_ADMISSION_CHILD"
 	workCountCAdmissionSourceEnv   = "GTS_WORK_COUNT_C_ADMISSION_SOURCE"
@@ -59,6 +64,33 @@ var workCountProxyFields = []string{
 	"graph_link_additions_proxy", "leaf_constructions_proxy",
 	"parent_constructions_proxy", "pending_parent_constructions_proxy",
 	"no_tree_parent_constructions_proxy",
+}
+
+var workCountConvergenceManifestPhases = []string{
+	"reduce_window_select", "post_reduce_primary", "post_reduce_pending", "boundary_gss", "boundary_equivalence",
+	"boundary_cull", "pending_work", "final_expand", "final_select", "terminal_accept",
+}
+
+var workCountConvergenceManifestOutcomes = []string{
+	"candidate", "packed", "rejected", "pending_queued", "pending_drained", "pending_discarded",
+	"accepted_head", "packed_root_emitted", "mutation_partial", "cap_hit", "observation_unknown", "selected",
+}
+
+var workCountConvergenceManifestReasons = []string{
+	"status", "score", "shifted", "error_cost", "not_gss", "not_clean", "distinct_shape", "preflight", "cull",
+}
+
+var workCountConvergencePhaseOutcomes = map[string][]string{
+	"reduce_window_select": {"candidate", "cap_hit"},
+	"post_reduce_primary":  {"candidate", "packed", "rejected", "mutation_partial"},
+	"post_reduce_pending":  {"candidate", "packed", "rejected", "mutation_partial"},
+	"boundary_gss":         {"candidate", "packed", "rejected", "mutation_partial"},
+	"boundary_equivalence": {"rejected"},
+	"boundary_cull":        {"rejected"},
+	"pending_work":         {"pending_queued", "pending_drained", "pending_discarded"},
+	"final_expand":         {"packed_root_emitted", "observation_unknown"},
+	"final_select":         {"selected"},
+	"terminal_accept":      {"accepted_head"},
 }
 
 type workCountCounters struct {
@@ -122,6 +154,136 @@ type workCountGoCounters struct {
 	workCountCounters
 	Attempts       []workCountAttempt     `json:"attempts"`
 	OutsideAttempt workCountCounterValues `json:"outside_attempt"`
+	Convergence    workCountConvergence   `json:"convergence_frontier"`
+}
+
+type workCountConvergence struct {
+	Capability            string                      `json:"capability"`
+	MaxEvents             uint16                      `json:"max_events"`
+	MaxPackedPathCount    uint16                      `json:"max_packed_path_count"`
+	EventsSeen            uint64                      `json:"events_seen"`
+	EventTruncated        bool                        `json:"event_truncated"`
+	ArithmeticOverflow    bool                        `json:"arithmetic_overflow"`
+	VocabularyViolation   bool                        `json:"vocabulary_violation"`
+	SnapshotCountCapped   bool                        `json:"snapshot_count_capped"`
+	SnapshotCountUnknown  bool                        `json:"snapshot_count_unknown"`
+	PathWalkWorkBudget    uint32                      `json:"path_walk_work_budget"`
+	PathWalkWorkUsed      uint32                      `json:"path_walk_work_used"`
+	PathWalkWorkExhausted bool                        `json:"path_walk_work_exhausted"`
+	Events                []workCountConvergenceEvent `json:"events"`
+	FirstRejects          []workCountConvergenceEvent `json:"first_rejects"`
+	Aggregates            workCountConvergenceTotals  `json:"aggregates"`
+}
+
+type workCountConvergenceTotals struct {
+	Phases                    workCountConvergencePhaseTotals   `json:"phases"`
+	Outcomes                  workCountConvergenceOutcomeTotals `json:"outcomes"`
+	Rejections                workCountConvergenceRejectTotals  `json:"rejections"`
+	CandidateCountBeforeTotal uint64                            `json:"candidate_count_before_total"`
+	CandidateCountAfterTotal  uint64                            `json:"candidate_count_after_total"`
+	LinksBeforeTotal          uint64                            `json:"links_before_total"`
+	LinksAfterTotal           uint64                            `json:"links_after_total"`
+	PathsBeforeTotal          uint64                            `json:"packed_paths_before_total"`
+	PathsAfterTotal           uint64                            `json:"packed_paths_after_total"`
+	MutationPartial           uint64                            `json:"mutation_partial"`
+	CapHits                   uint64                            `json:"cap_hits"`
+	AcceptedHeads             uint64                            `json:"accepted_heads"`
+	PackedRoots               uint64                            `json:"packed_roots_emitted"`
+}
+
+type workCountConvergencePhaseTotals struct {
+	ReduceWindowSelect  uint64 `json:"reduce_window_select"`
+	PostReducePrimary   uint64 `json:"post_reduce_primary"`
+	PostReducePending   uint64 `json:"post_reduce_pending"`
+	BoundaryGSS         uint64 `json:"boundary_gss"`
+	BoundaryEquivalence uint64 `json:"boundary_equivalence"`
+	BoundaryCull        uint64 `json:"boundary_cull"`
+	PendingWork         uint64 `json:"pending_work"`
+	FinalExpand         uint64 `json:"final_expand"`
+	FinalSelect         uint64 `json:"final_select"`
+	TerminalAccept      uint64 `json:"terminal_accept"`
+}
+
+type workCountConvergenceOutcomeTotals struct {
+	Candidate          uint64 `json:"candidate"`
+	Packed             uint64 `json:"packed"`
+	Rejected           uint64 `json:"rejected"`
+	PendingQueued      uint64 `json:"pending_queued"`
+	PendingDrained     uint64 `json:"pending_drained"`
+	PendingDiscarded   uint64 `json:"pending_discarded"`
+	AcceptedHead       uint64 `json:"accepted_head"`
+	PackedRoot         uint64 `json:"packed_root_emitted"`
+	MutationPartial    uint64 `json:"mutation_partial"`
+	CapHit             uint64 `json:"cap_hit"`
+	ObservationUnknown uint64 `json:"observation_unknown"`
+	Selected           uint64 `json:"selected"`
+}
+
+type workCountConvergenceRejectTotals struct {
+	Status        uint64 `json:"status"`
+	Score         uint64 `json:"score"`
+	Shifted       uint64 `json:"shifted"`
+	ErrorCost     uint64 `json:"error_cost"`
+	NotGSS        uint64 `json:"not_gss"`
+	NotClean      uint64 `json:"not_clean"`
+	DistinctShape uint64 `json:"distinct_shape"`
+	Preflight     uint64 `json:"preflight"`
+	Cull          uint64 `json:"cull"`
+}
+
+type workCountConvergenceEvent struct {
+	Sequence                         uint64                   `json:"sequence"`
+	Attempt                          uint32                   `json:"attempt"`
+	Iteration                        uint64                   `json:"iteration"`
+	DecisionID                       uint32                   `json:"decision_id"`
+	LookaheadSymbol                  uint32                   `json:"lookahead_symbol"`
+	LookaheadStartByte               uint32                   `json:"lookahead_start_byte"`
+	LookaheadEndByte                 uint32                   `json:"lookahead_end_byte"`
+	LookaheadPresent                 bool                     `json:"lookahead_present"`
+	LookaheadNoLookahead             bool                     `json:"lookahead_no_lookahead"`
+	LookaheadExternal                bool                     `json:"lookahead_external"`
+	ElectionScannerComparable        bool                     `json:"election_scanner_comparable"`
+	ElectionScannerCheckpointPresent bool                     `json:"election_scanner_checkpoint_present"`
+	ElectionScannerCheckpointHash    uint64                   `json:"election_scanner_checkpoint_hash"`
+	Phase                            string                   `json:"phase"`
+	Outcome                          string                   `json:"outcome"`
+	RejectReason                     string                   `json:"reject_reason,omitempty"`
+	Detail                           string                   `json:"detail,omitempty"`
+	Target                           workCountConvergenceHead `json:"target"`
+	Candidate                        workCountConvergenceHead `json:"candidate"`
+	CandidateCountBefore             uint32                   `json:"candidate_count_before"`
+	CandidateCountAfter              uint32                   `json:"candidate_count_after"`
+	LinksBefore                      uint16                   `json:"links_before"`
+	LinksAfter                       uint16                   `json:"links_after"`
+	PathsBefore                      uint16                   `json:"packed_paths_before"`
+	PathsAfter                       uint16                   `json:"packed_paths_after"`
+	MutationPartial                  bool                     `json:"mutation_partial"`
+	CapHit                           bool                     `json:"cap_hit"`
+	SnapshotCapped                   bool                     `json:"snapshot_capped"`
+	SnapshotUnknown                  bool                     `json:"snapshot_unknown"`
+}
+
+type workCountConvergenceHead struct {
+	State               uint32 `json:"state"`
+	Byte                uint32 `json:"byte"`
+	Status              string `json:"status"`
+	HasError            bool   `json:"has_error"`
+	Recovering          bool   `json:"recovering"`
+	Shifted             bool   `json:"shifted"`
+	Score               int64  `json:"score"`
+	BranchOrder         uint64 `json:"branch_order"`
+	Depth               uint32 `json:"depth"`
+	Dead                bool   `json:"dead"`
+	Accepted            bool   `json:"accepted"`
+	Paused              bool   `json:"paused"`
+	NodeBaseline        uint32 `json:"node_baseline"`
+	ErrorCost           uint32 `json:"error_cost"`
+	ErrorCostComparable bool   `json:"error_cost_comparable"`
+	HasGSS              bool   `json:"has_gss"`
+	LinkCount           uint16 `json:"link_count"`
+	LinkCountCapped     bool   `json:"link_count_capped"`
+	HeadContentHash     uint64 `json:"head_content_hash"`
+	PredecessorHash     uint64 `json:"predecessor_content_hash"`
 }
 
 type workCountGoChildResult struct {
@@ -203,23 +365,24 @@ type workCountRatio struct {
 }
 
 type workCountReceipt struct {
-	Schema         string                    `json:"schema"`
-	Fixture        string                    `json:"fixture"`
-	SourceSHA256   string                    `json:"source_sha256"`
-	SourceBytes    int                       `json:"source_bytes"`
-	DigestFormat   string                    `json:"digest_format"`
-	DeepTreeSHA256 string                    `json:"deep_tree_sha256"`
-	ManifestSHA256 string                    `json:"contract_manifest_sha256"`
-	Source         workCountGitProvenance    `json:"source"`
-	GoEnvironment  workCountEnvironment      `json:"go_environment"`
-	GoAdmission    workCountArtifactIdentity `json:"go_admission_artifact"`
-	GoArtifact     workCountArtifactIdentity `json:"go_work_count_artifact"`
-	CArtifact      workCountCIdentity        `json:"static_c_artifact"`
-	GoCounts       workCountGoCounters       `json:"go_counts"`
-	CCounts        workCountCounters         `json:"static_c_counts"`
-	Ratios         []workCountRatio          `json:"ratios"`
-	GoSurplus      uint64                    `json:"go_construction_surplus"`
-	CSurplus       uint64                    `json:"static_c_construction_surplus"`
+	Schema                      string                    `json:"schema"`
+	Fixture                     string                    `json:"fixture"`
+	SourceSHA256                string                    `json:"source_sha256"`
+	SourceBytes                 int                       `json:"source_bytes"`
+	DigestFormat                string                    `json:"digest_format"`
+	DeepTreeSHA256              string                    `json:"deep_tree_sha256"`
+	SharedCounterManifestSHA256 string                    `json:"shared_counter_manifest_sha256"`
+	ConvergenceManifestSHA256   string                    `json:"convergence_manifest_sha256"`
+	Source                      workCountGitProvenance    `json:"source"`
+	GoEnvironment               workCountEnvironment      `json:"go_environment"`
+	GoAdmission                 workCountArtifactIdentity `json:"go_admission_artifact"`
+	GoArtifact                  workCountArtifactIdentity `json:"go_work_count_artifact"`
+	CArtifact                   workCountCIdentity        `json:"static_c_artifact"`
+	GoCounts                    workCountGoCounters       `json:"go_counts"`
+	CCounts                     workCountCounters         `json:"static_c_counts"`
+	Ratios                      []workCountRatio          `json:"ratios"`
+	GoSurplus                   uint64                    `json:"go_construction_surplus"`
+	CSurplus                    uint64                    `json:"static_c_construction_surplus"`
 }
 
 type workCountCBuild struct {
@@ -242,13 +405,20 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 	// operations performed later by the static-C builders.
 	workCountClearAmbientGitRouting(t)
 	fixture := workCountLoadFixture(t)
-	manifestPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "work_count", "contract_v2.json")
+	sharedManifestPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "work_count", "contract_v2.json")
+	convergenceManifestPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "work_count", "contract_v3.json")
 	patchPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "work_count", "tree_sitter_v0_25_1.patch")
 	driverPath := filepath.Join(sourceSnapshot.Root, "cgo_harness", "pure_c", "work_count_oracle.c")
-	manifestSHA := workCountFileSHA(t, manifestPath)
+	sharedManifestSHA := workCountFileSHA(t, sharedManifestPath)
+	convergenceManifestSHA := workCountFileSHA(t, convergenceManifestPath)
+	if sharedManifestSHA != workCountSharedManifestSHA256 || convergenceManifestSHA != workCountConvergenceManifestSHA256 {
+		t.Fatalf("work-count manifest identity shared=%s/%s convergence=%s/%s", sharedManifestSHA, workCountSharedManifestSHA256, convergenceManifestSHA, workCountConvergenceManifestSHA256)
+	}
 	patchSHA := workCountFileSHA(t, patchPath)
 	driverSHA := workCountFileSHA(t, driverPath)
-	workCountValidateManifest(t, manifestPath)
+	workCountValidateManifest(t, sharedManifestPath)
+	workCountValidateConvergenceManifest(t, convergenceManifestPath)
+	workCountValidateManifestAgreement(t, sharedManifestPath, convergenceManifestPath)
 
 	sourcePath := filepath.Join(tempRoot, "query_compile.go")
 	if err := os.WriteFile(sourcePath, fixture.Source, 0o600); err != nil {
@@ -266,7 +436,7 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 	goAdmissionArtifact, goAdmissionIdentity, goAdmissionRecheck := workCountBuildGo(t, sourceSnapshot, tempRoot, goEnvironment, false)
 	t.Log("admission: ordinary untagged Go child")
 	uninstGo := workCountRunGoAdmission(t, goAdmissionArtifact, sourcePath, tempRoot, goEnvironment)
-	workCountValidateGoChild(t, "ordinary Go admission", "go-production-glr-untagged", uninstGo, fixture)
+	workCountValidateGoChild(t, "ordinary Go admission", workCountGoAdmissionChildSchema, "go-production-glr-untagged", uninstGo, fixture)
 	t.Log("admission: unmodified static C")
 	uninstC := workCountUninstrumentedCAdmission(t, fixture, sourcePath, tempRoot)
 	if uninstGo.DeepTreeSHA256 != uninstC || uninstGo.DeepTreeSHA256 != fixture.Fixture.DeepTreeSHA256 {
@@ -284,7 +454,7 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 	t.Log("run: tagged diagnostic Go child")
 	goResult := workCountRunGo(t, goArtifact, sourcePath, tempRoot, goEnvironment)
 	workCountValidateCChild(t, "static C", "static-c-instrumented-glr", cResult, fixture, uninstC)
-	workCountValidateGoChild(t, "tagged Go", "go-production-glr-tagged-diagnostic", goResult.workCountGoChildResult, fixture)
+	workCountValidateGoChild(t, "tagged Go", workCountTaggedGoChildSchema, "go-production-glr-tagged-diagnostic", goResult.workCountGoChildResult, fixture)
 	workCountValidateGoCounters(t, "tagged Go", goResult.Counters, uint32(len(fixture.Source)))
 	if cResult.DeepTreeSHA256 != goResult.DeepTreeSHA256 {
 		t.Fatalf("instrumented deep digest mismatch: go=%s static_c=%s", goResult.DeepTreeSHA256, cResult.DeepTreeSHA256)
@@ -305,7 +475,10 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 		t.Fatalf("source snapshot identity drift: got %s want %s", got, fixture.Fixture.SHA256)
 	}
 	for label, pathAndSHA := range map[string][2]string{
-		"manifest": {manifestPath, manifestSHA}, "patch": {patchPath, patchSHA}, "driver": {driverPath, driverSHA},
+		"shared counter manifest": {sharedManifestPath, sharedManifestSHA},
+		"convergence manifest":    {convergenceManifestPath, convergenceManifestSHA},
+		"patch":                   {patchPath, patchSHA},
+		"driver":                  {driverPath, driverSHA},
 	} {
 		if got := workCountFileSHA(t, pathAndSHA[0]); got != pathAndSHA[1] {
 			t.Fatalf("%s identity drift: got %s want %s", label, got, pathAndSHA[1])
@@ -316,7 +489,8 @@ func TestAuthenticatedWorkCountOracle(t *testing.T) {
 		Schema: workCountReceiptSchema, Fixture: fixture.Fixture.ID,
 		SourceSHA256: fixture.Fixture.SHA256, SourceBytes: len(fixture.Source),
 		DigestFormat: benchfixtures.DeepTreeDigestVersion, DeepTreeSHA256: uninstGo.DeepTreeSHA256,
-		ManifestSHA256: manifestSHA, Source: sourceSnapshot.Provenance,
+		SharedCounterManifestSHA256: sharedManifestSHA, ConvergenceManifestSHA256: convergenceManifestSHA,
+		Source:        sourceSnapshot.Provenance,
 		GoEnvironment: goEnvironment, GoAdmission: goAdmissionIdentity,
 		GoArtifact: goIdentity, CArtifact: cBuild.Identity,
 		GoCounts: goResult.Counters, CCounts: cResult.Counters,
@@ -1063,9 +1237,10 @@ func workCountValidateGoCounterObject(t *testing.T, data json.RawMessage) {
 	counterKeys := append([]string{"contract", "overflow"}, workCountDirectFields...)
 	counterKeys = append(counterKeys, workCountTerminalFields...)
 	counterKeys = append(counterKeys, workCountProxyFields...)
-	counterKeys = append(counterKeys, "attempts", "outside_attempt")
+	counterKeys = append(counterKeys, "attempts", "outside_attempt", "convergence_frontier")
 	workCountRequireKeys(t, "Go counters", counterRaw, counterKeys)
 	workCountValidateCounterValuesObject(t, "Go outside-attempt counters", counterRaw["outside_attempt"])
+	workCountValidateGoConvergenceObject(t, counterRaw["convergence_frontier"])
 	var attempts []json.RawMessage
 	if err := json.Unmarshal(counterRaw["attempts"], &attempts); err != nil {
 		t.Fatal(err)
@@ -1087,6 +1262,473 @@ func workCountValidateGoCounterObject(t *testing.T, data json.RawMessage) {
 			workCountValidateCounterValuesObject(t, fmt.Sprintf("Go attempt %d %s", i+1, key), attempt[key])
 		}
 	}
+}
+
+func workCountValidateGoConvergenceObject(t *testing.T, data json.RawMessage) {
+	t.Helper()
+	raw := workCountDecodeRawObject(t, "Go convergence frontier", data)
+	workCountRequireKeys(t, "Go convergence frontier", raw, []string{
+		"capability", "max_events", "max_packed_path_count", "events_seen", "event_truncated",
+		"arithmetic_overflow", "vocabulary_violation", "snapshot_count_capped", "snapshot_count_unknown",
+		"path_walk_work_budget", "path_walk_work_used", "path_walk_work_exhausted",
+		"events", "first_rejects", "aggregates",
+	})
+	var frontier workCountConvergence
+	workCountDecodeExact(t, data, &frontier)
+	var events, firstRejects []json.RawMessage
+	if err := json.Unmarshal(raw["events"], &events); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw["first_rejects"], &firstRejects); err != nil {
+		t.Fatal(err)
+	}
+	for i, event := range events {
+		workCountValidateConvergenceEvent(t, fmt.Sprintf("Go convergence event %d", i+1), event)
+	}
+	for i, event := range firstRejects {
+		workCountValidateConvergenceEvent(t, fmt.Sprintf("Go convergence first reject %d", i+1), event)
+	}
+	workCountValidateConvergenceAggregates(t, raw["aggregates"])
+	workCountValidateGoConvergence(t, frontier)
+}
+
+func workCountValidateGoConvergence(t *testing.T, frontier workCountConvergence) {
+	t.Helper()
+	workCountValidateConvergenceBounds(t, frontier)
+	workCountValidateConvergenceEvents(t, frontier)
+	workCountValidatePostReduceLifecycle(t, frontier)
+	reasons := workCountConvergenceRejectMap(frontier.Aggregates.Rejections)
+	workCountValidateConvergenceFirstRejects(t, frontier, reasons)
+	workCountValidateConvergenceTotals(t, frontier, reasons)
+}
+
+func workCountValidatePostReduceLifecycle(t *testing.T, frontier workCountConvergence) {
+	t.Helper()
+	isPostReduce := func(phase string) bool {
+		return phase == "post_reduce_primary" || phase == "post_reduce_pending"
+	}
+	isTerminal := func(outcome string) bool {
+		return outcome == "packed" || outcome == "rejected" || outcome == "mutation_partial"
+	}
+	for i, event := range frontier.Events {
+		if !isPostReduce(event.Phase) {
+			continue
+		}
+		switch {
+		case event.Outcome == "candidate":
+			if i+1 == len(frontier.Events) && frontier.EventTruncated {
+				// The retained chronological prefix may end between the candidate
+				// observation and its terminal event.
+				continue
+			}
+			if i+1 == len(frontier.Events) {
+				t.Fatalf("Go convergence post-reduce candidate sequence=%d has no terminal event", event.Sequence)
+			}
+			next := frontier.Events[i+1]
+			if next.DecisionID != event.DecisionID || next.Phase != event.Phase || !isTerminal(next.Outcome) {
+				t.Fatalf("Go convergence post-reduce candidate sequence=%d is not followed by one same-decision terminal: next=%+v", event.Sequence, next)
+			}
+		case isTerminal(event.Outcome):
+			if i == 0 {
+				t.Fatalf("Go convergence post-reduce terminal sequence=%d has no candidate event", event.Sequence)
+			}
+			previous := frontier.Events[i-1]
+			if previous.DecisionID != event.DecisionID || previous.Phase != event.Phase || previous.Outcome != "candidate" {
+				t.Fatalf("Go convergence post-reduce terminal sequence=%d is not preceded by its same-decision candidate: previous=%+v", event.Sequence, previous)
+			}
+		}
+	}
+}
+
+func workCountValidateConvergenceBounds(t *testing.T, frontier workCountConvergence) {
+	t.Helper()
+	if frontier.Capability != "go_only_detailed_convergence" || frontier.MaxEvents != 256 || frontier.MaxPackedPathCount != 7 || frontier.PathWalkWorkBudget != 16*1024 {
+		t.Fatalf("Go convergence capability/bounds=%q events=%d paths=%d work=%d", frontier.Capability, frontier.MaxEvents, frontier.MaxPackedPathCount, frontier.PathWalkWorkBudget)
+	}
+	if frontier.ArithmeticOverflow || frontier.VocabularyViolation || frontier.PathWalkWorkUsed > frontier.PathWalkWorkBudget || (frontier.PathWalkWorkExhausted && !frontier.SnapshotCountUnknown) {
+		t.Fatalf("Go convergence integrity overflow=%v vocabulary=%v snapshots=%v/%v path_work=%d/%d exhausted=%v", frontier.ArithmeticOverflow, frontier.VocabularyViolation, frontier.SnapshotCountCapped, frontier.SnapshotCountUnknown, frontier.PathWalkWorkUsed, frontier.PathWalkWorkBudget, frontier.PathWalkWorkExhausted)
+	}
+	wantRetained := frontier.EventsSeen
+	if wantRetained > uint64(frontier.MaxEvents) {
+		wantRetained = uint64(frontier.MaxEvents)
+	}
+	if frontier.EventsSeen == 0 || uint64(len(frontier.Events)) != wantRetained || frontier.EventTruncated != (frontier.EventsSeen > uint64(frontier.MaxEvents)) {
+		t.Fatalf("Go convergence event bound seen=%d retained=%d truncated=%v max=%d", frontier.EventsSeen, len(frontier.Events), frontier.EventTruncated, frontier.MaxEvents)
+	}
+}
+
+func workCountValidateConvergenceEvents(t *testing.T, frontier workCountConvergence) {
+	t.Helper()
+	for i, event := range frontier.Events {
+		if event.Sequence != uint64(i+1) {
+			t.Fatalf("Go convergence event %d sequence=%d want=%d", i+1, event.Sequence, i+1)
+		}
+		workCountValidateConvergenceEventValue(t, fmt.Sprintf("Go convergence event %d", i+1), event)
+		if event.SnapshotCapped && !frontier.SnapshotCountCapped {
+			t.Fatalf("Go convergence event %d capped snapshot missing top-level signal", i+1)
+		}
+		if event.SnapshotUnknown && !frontier.SnapshotCountUnknown {
+			t.Fatalf("Go convergence event %d unknown snapshot missing top-level signal", i+1)
+		}
+	}
+	var retainedCapped, retainedUnknown bool
+	for _, event := range frontier.Events {
+		retainedCapped = retainedCapped || event.SnapshotCapped
+		retainedUnknown = retainedUnknown || event.SnapshotUnknown
+	}
+	if !frontier.EventTruncated && (frontier.SnapshotCountCapped != retainedCapped || frontier.SnapshotCountUnknown != retainedUnknown) {
+		t.Fatalf("Go convergence top-level snapshot OR capped=%v/%v unknown=%v/%v", frontier.SnapshotCountCapped, retainedCapped, frontier.SnapshotCountUnknown, retainedUnknown)
+	}
+}
+
+func workCountValidateConvergenceFirstRejects(t *testing.T, frontier workCountConvergence, reasons map[string]uint64) {
+	t.Helper()
+	seenReasons := make(map[string]bool, len(frontier.FirstRejects))
+	seenSequences := make(map[uint64]bool, len(frontier.FirstRejects))
+	for i, event := range frontier.FirstRejects {
+		workCountValidateConvergenceEventValue(t, fmt.Sprintf("Go convergence first reject %d", i+1), event)
+		if event.Sequence == 0 || event.Sequence > frontier.EventsSeen || event.Outcome != "rejected" || event.RejectReason == "" || seenReasons[event.RejectReason] || seenSequences[event.Sequence] {
+			t.Fatalf("Go convergence first reject %d invalid/duplicate: %+v", i+1, event)
+		}
+		seenReasons[event.RejectReason] = true
+		seenSequences[event.Sequence] = true
+		if event.Sequence <= uint64(len(frontier.Events)) {
+			chronological := frontier.Events[event.Sequence-1]
+			if !reflect.DeepEqual(event, chronological) {
+				t.Fatalf("Go convergence first reject %d is not exact chronological event %d", i+1, event.Sequence)
+			}
+		}
+		for _, chronological := range frontier.Events {
+			if chronological.Sequence >= event.Sequence {
+				break
+			}
+			if chronological.RejectReason == event.RejectReason {
+				t.Fatalf("Go convergence first reject %d reason=%s is not minimal; earlier sequence=%d", i+1, event.RejectReason, chronological.Sequence)
+			}
+		}
+	}
+	for reason, count := range reasons {
+		if (count != 0) != seenReasons[reason] {
+			t.Fatalf("Go convergence first-reject coverage reason=%s count=%d retained=%v", reason, count, seenReasons[reason])
+		}
+	}
+}
+
+func workCountValidateConvergenceTotals(t *testing.T, frontier workCountConvergence, reasons map[string]uint64) {
+	t.Helper()
+	phases := workCountConvergencePhaseMap(frontier.Aggregates.Phases)
+	outcomes := workCountConvergenceOutcomeMap(frontier.Aggregates.Outcomes)
+	if workCountSumUint64Fields(t, "Go convergence phases", phases) != frontier.EventsSeen || workCountSumUint64Fields(t, "Go convergence outcomes", outcomes) != frontier.EventsSeen {
+		t.Fatalf("Go convergence aggregate/event mismatch seen=%d phases=%v outcomes=%v", frontier.EventsSeen, phases, outcomes)
+	}
+	if workCountSumUint64Fields(t, "Go convergence rejections", reasons) != outcomes["rejected"] {
+		t.Fatalf("Go convergence rejection sum=%d rejected=%d", workCountSumUint64Fields(t, "Go convergence rejections", reasons), outcomes["rejected"])
+	}
+	if frontier.Aggregates.AcceptedHeads != outcomes["accepted_head"] {
+		t.Fatalf("Go convergence accepted heads scalar=%d outcomes=%d", frontier.Aggregates.AcceptedHeads, outcomes["accepted_head"])
+	}
+	if frontier.Aggregates.MutationPartial != outcomes["mutation_partial"] {
+		t.Fatalf("Go convergence mutation-partial scalar=%d outcomes=%d", frontier.Aggregates.MutationPartial, outcomes["mutation_partial"])
+	}
+	if frontier.Aggregates.CapHits < outcomes["cap_hit"] {
+		t.Fatalf("Go convergence cap-hit scalar=%d cap-hit outcomes=%d", frontier.Aggregates.CapHits, outcomes["cap_hit"])
+	}
+	workCountValidatePackedRootTotals(t, frontier, outcomes["packed_root_emitted"])
+	workCountValidateRetainedAggregateBounds(t, frontier, phases, outcomes, reasons)
+}
+
+func workCountValidateRetainedAggregateBounds(t *testing.T, frontier workCountConvergence, phases, outcomes, reasons map[string]uint64) {
+	t.Helper()
+	retainedPhases := make(map[string]uint64, len(phases))
+	retainedOutcomes := make(map[string]uint64, len(outcomes))
+	retainedReasons := make(map[string]uint64, len(reasons))
+	var beforeCandidates, afterCandidates, beforeLinks, afterLinks, beforePaths, afterPaths uint64
+	for _, event := range frontier.Events {
+		retainedPhases[event.Phase]++
+		retainedOutcomes[event.Outcome]++
+		if event.RejectReason != "" {
+			retainedReasons[event.RejectReason]++
+		}
+		beforeCandidates += uint64(event.CandidateCountBefore)
+		afterCandidates += uint64(event.CandidateCountAfter)
+		beforeLinks += uint64(event.LinksBefore)
+		afterLinks += uint64(event.LinksAfter)
+		beforePaths += uint64(event.PathsBefore)
+		afterPaths += uint64(event.PathsAfter)
+	}
+	checkMap := func(label string, aggregate, retained map[string]uint64) {
+		for key, got := range aggregate {
+			want := retained[key]
+			if (!frontier.EventTruncated && got != want) || (frontier.EventTruncated && got < want) {
+				t.Fatalf("Go convergence %s aggregate %s=%d retained=%d truncated=%v", label, key, got, want, frontier.EventTruncated)
+			}
+		}
+	}
+	checkMap("phase", phases, retainedPhases)
+	checkMap("outcome", outcomes, retainedOutcomes)
+	checkMap("reason", reasons, retainedReasons)
+	values := [][3]uint64{
+		{frontier.Aggregates.CandidateCountBeforeTotal, beforeCandidates, 0}, {frontier.Aggregates.CandidateCountAfterTotal, afterCandidates, 0},
+		{frontier.Aggregates.LinksBeforeTotal, beforeLinks, 0}, {frontier.Aggregates.LinksAfterTotal, afterLinks, 0},
+		{frontier.Aggregates.PathsBeforeTotal, beforePaths, 0}, {frontier.Aggregates.PathsAfterTotal, afterPaths, 0},
+	}
+	for i, pair := range values {
+		if (!frontier.EventTruncated && pair[0] != pair[1]) || (frontier.EventTruncated && pair[0] < pair[1]) {
+			t.Fatalf("Go convergence scalar total %d=%d retained=%d truncated=%v", i, pair[0], pair[1], frontier.EventTruncated)
+		}
+	}
+	workCountValidateRetainedScalarTotals(t, frontier)
+}
+
+func workCountValidatePackedRootTotals(t *testing.T, frontier workCountConvergence, packedRootEvents uint64) {
+	t.Helper()
+	if packedRootEvents == 0 {
+		if frontier.Aggregates.PackedRoots != 0 {
+			t.Fatalf("Go convergence packed roots=%d without packed-root events", frontier.Aggregates.PackedRoots)
+		}
+	} else {
+		maxRoots := packedRootEvents * uint64(frontier.MaxPackedPathCount-1)
+		if frontier.Aggregates.PackedRoots < packedRootEvents || frontier.Aggregates.PackedRoots > maxRoots || frontier.Aggregates.PackedRoots > frontier.Aggregates.PathsAfterTotal {
+			t.Fatalf("Go convergence packed roots=%d events=%d max=%d paths-after=%d", frontier.Aggregates.PackedRoots, packedRootEvents, maxRoots, frontier.Aggregates.PathsAfterTotal)
+		}
+	}
+}
+
+func workCountValidateRetainedScalarTotals(t *testing.T, frontier workCountConvergence) {
+	t.Helper()
+	var mutationPartial, capHits, acceptedHeads, packedRoots uint64
+	for _, event := range frontier.Events {
+		if event.MutationPartial {
+			mutationPartial++
+		}
+		if event.CapHit {
+			capHits++
+		}
+		if event.Outcome == "accepted_head" {
+			acceptedHeads++
+		}
+		if event.Outcome == "packed_root_emitted" {
+			packedRoots += uint64(event.PathsAfter)
+		}
+	}
+	exact := !frontier.EventTruncated
+	bad := func(total, retained uint64) bool { return (exact && total != retained) || (!exact && total < retained) }
+	if bad(frontier.Aggregates.MutationPartial, mutationPartial) || bad(frontier.Aggregates.CapHits, capHits) || bad(frontier.Aggregates.AcceptedHeads, acceptedHeads) || bad(frontier.Aggregates.PackedRoots, packedRoots) {
+		t.Fatalf("Go convergence scalar aggregate drift mutation=%d/%d caps=%d/%d accepted=%d/%d roots=%d/%d", frontier.Aggregates.MutationPartial, mutationPartial, frontier.Aggregates.CapHits, capHits, frontier.Aggregates.AcceptedHeads, acceptedHeads, frontier.Aggregates.PackedRoots, packedRoots)
+	}
+}
+
+func workCountValidateConvergenceEventValue(t *testing.T, label string, event workCountConvergenceEvent) {
+	t.Helper()
+	workCountValidateConvergenceEventIdentity(t, label, event)
+	workCountValidateConvergenceEventSnapshots(t, label, event)
+	workCountValidateConvergenceEventHeads(t, label, event)
+}
+
+func workCountValidateConvergenceEventIdentity(t *testing.T, label string, event workCountConvergenceEvent) {
+	t.Helper()
+	if event.Sequence == 0 || event.Attempt != 1 || !workCountStringIn(event.Phase, workCountConvergenceManifestPhases) || !workCountStringIn(event.Outcome, workCountConvergenceManifestOutcomes) || (event.RejectReason != "" && !workCountStringIn(event.RejectReason, workCountConvergenceManifestReasons)) {
+		t.Fatalf("%s closed vocabulary/identity=%+v", label, event)
+	}
+	if (event.Outcome == "rejected") != (event.RejectReason != "") {
+		t.Fatalf("%s rejected/reason mismatch outcome=%q reason=%q", label, event.Outcome, event.RejectReason)
+	}
+	if !workCountConvergencePhaseAllowsOutcome(event.Phase, event.Outcome) {
+		t.Fatalf("%s phase/outcome mismatch phase=%q outcome=%q", label, event.Phase, event.Outcome)
+	}
+	if (event.DecisionID == 0) != (event.Target.Status == "absent" && event.Candidate.Status == "absent") {
+		t.Fatalf("%s decision/head identity mismatch decision=%d target=%q candidate=%q", label, event.DecisionID, event.Target.Status, event.Candidate.Status)
+	}
+	if !event.LookaheadPresent && (event.LookaheadSymbol != 0 || event.LookaheadStartByte != 0 || event.LookaheadEndByte != 0 || event.LookaheadNoLookahead || event.LookaheadExternal) {
+		t.Fatalf("%s unset lookahead carries data: %+v", label, event)
+	}
+	if !event.ElectionScannerComparable && (event.ElectionScannerCheckpointPresent || event.ElectionScannerCheckpointHash != 0) {
+		t.Fatalf("%s non-comparable election scanner carries checkpoint evidence", label)
+	}
+	if !event.ElectionScannerCheckpointPresent && event.ElectionScannerCheckpointHash != 0 {
+		t.Fatalf("%s absent election scanner checkpoint carries hash=%d", label, event.ElectionScannerCheckpointHash)
+	}
+	if event.ElectionScannerCheckpointPresent && !event.ElectionScannerComparable {
+		t.Fatalf("%s present election scanner checkpoint is not comparable", label)
+	}
+}
+
+func workCountValidateConvergenceEventSnapshots(t *testing.T, label string, event workCountConvergenceEvent) {
+	t.Helper()
+	if event.Outcome == "observation_unknown" && (!event.SnapshotUnknown || event.CapHit || event.PathsAfter != 0) {
+		t.Fatalf("%s unknown observation claims result: %+v", label, event)
+	}
+	if event.Outcome == "packed_root_emitted" && (event.SnapshotUnknown || event.PathsAfter == 0) {
+		t.Fatalf("%s packed-root emission is not proven: %+v", label, event)
+	}
+	if event.PathsBefore > 7 || event.PathsAfter > 7 {
+		t.Fatalf("%s packed-path snapshot exceeds contract bound: before=%d after=%d", label, event.PathsBefore, event.PathsAfter)
+	}
+	if (event.PathsBefore == 7 || event.PathsAfter == 7) && !event.SnapshotCapped && !event.SnapshotUnknown {
+		t.Fatalf("%s packed-path sentinel lacks capped or unknown evidence: before=%d after=%d", label, event.PathsBefore, event.PathsAfter)
+	}
+	if event.LookaheadStartByte > event.LookaheadEndByte {
+		t.Fatalf("%s lookahead range is reversed: start=%d end=%d", label, event.LookaheadStartByte, event.LookaheadEndByte)
+	}
+}
+
+func workCountValidateConvergenceEventHeads(t *testing.T, label string, event workCountConvergenceEvent) {
+	t.Helper()
+	workCountValidateConvergenceHeadValue(t, label+" target", event.Target)
+	workCountValidateConvergenceHeadValue(t, label+" candidate", event.Candidate)
+	if event.Outcome == "accepted_head" && (event.Target.Status != "accepted" || event.Candidate.Status != "absent") {
+		t.Fatalf("%s accepted-head event target status=%q", label, event.Target.Status)
+	}
+	if event.Phase == "final_expand" || event.Phase == "final_select" {
+		if event.Target.Status == "absent" || event.Candidate.Status != "absent" {
+			t.Fatalf("%s final event head identity target=%q candidate=%q", label, event.Target.Status, event.Candidate.Status)
+		}
+	}
+	if event.Outcome == "selected" && event.Candidate.Status != "absent" {
+		t.Fatalf("%s selected event has candidate head=%q", label, event.Candidate.Status)
+	}
+}
+
+func workCountConvergencePhaseAllowsOutcome(phase, outcome string) bool {
+	return workCountStringIn(outcome, workCountConvergencePhaseOutcomes[phase])
+}
+
+func workCountValidateConvergenceHeadValue(t *testing.T, label string, head workCountConvergenceHead) {
+	t.Helper()
+	if !workCountStringIn(head.Status, []string{"absent", "live", "dead", "accepted", "paused"}) {
+		t.Fatalf("%s status=%q is outside the closed vocabulary", label, head.Status)
+	}
+	if head.Status == "absent" {
+		if head != (workCountConvergenceHead{Status: "absent"}) {
+			t.Fatalf("%s absent head carries data: %+v", label, head)
+		}
+		return
+	}
+	if !head.ErrorCostComparable && head.ErrorCost != 0 {
+		t.Fatalf("%s non-comparable head reports error cost=%d", label, head.ErrorCost)
+	}
+	if !head.HasGSS && (head.LinkCount != 0 || head.LinkCountCapped || head.HeadContentHash != 0 || head.PredecessorHash != 0) {
+		t.Fatalf("%s non-GSS head reports graph identity: %+v", label, head)
+	}
+	if head.LinkCountCapped && head.LinkCount != math.MaxUint16 {
+		t.Fatalf("%s capped link count=%d want=%d", label, head.LinkCount, uint16(math.MaxUint16))
+	}
+	wantStatus := "live"
+	if head.Dead {
+		wantStatus = "dead"
+	} else if head.Accepted {
+		wantStatus = "accepted"
+	} else if head.Paused {
+		wantStatus = "paused"
+	}
+	if head.Status != wantStatus {
+		t.Fatalf("%s status/bit mismatch: %+v", label, head)
+	}
+}
+
+func workCountValidateConvergenceEvent(t *testing.T, label string, data json.RawMessage) {
+	t.Helper()
+	raw := workCountDecodeRawObject(t, label, data)
+	workCountRequireKeysWithOptional(t, label, raw, []string{
+		"sequence", "attempt", "iteration", "decision_id",
+		"lookahead_symbol", "lookahead_start_byte", "lookahead_end_byte", "lookahead_present", "lookahead_no_lookahead", "lookahead_external",
+		"election_scanner_comparable", "election_scanner_checkpoint_present", "election_scanner_checkpoint_hash",
+		"phase", "outcome", "target", "candidate",
+		"candidate_count_before", "candidate_count_after", "links_before", "links_after", "packed_paths_before", "packed_paths_after",
+		"mutation_partial", "cap_hit", "snapshot_capped", "snapshot_unknown",
+	}, []string{"reject_reason", "detail"})
+	workCountValidateConvergenceHead(t, label+" target", raw["target"])
+	workCountValidateConvergenceHead(t, label+" candidate", raw["candidate"])
+	var event workCountConvergenceEvent
+	workCountDecodeExact(t, data, &event)
+	workCountValidateConvergenceEventValue(t, label, event)
+}
+
+func workCountValidateConvergenceHead(t *testing.T, label string, data json.RawMessage) {
+	t.Helper()
+	raw := workCountDecodeRawObject(t, label, data)
+	workCountRequireKeys(t, label, raw, []string{
+		"state", "byte", "status", "has_error", "recovering", "shifted", "score", "branch_order", "depth",
+		"dead", "accepted", "paused", "node_baseline", "error_cost", "error_cost_comparable",
+		"has_gss", "link_count", "link_count_capped",
+		"head_content_hash", "predecessor_content_hash",
+	})
+	var head workCountConvergenceHead
+	workCountDecodeExact(t, data, &head)
+	workCountValidateConvergenceHeadValue(t, label, head)
+}
+
+func workCountValidateConvergenceAggregates(t *testing.T, data json.RawMessage) {
+	t.Helper()
+	raw := workCountDecodeRawObject(t, "Go convergence aggregates", data)
+	workCountRequireKeys(t, "Go convergence aggregates", raw, []string{
+		"phases", "outcomes", "rejections", "candidate_count_before_total", "candidate_count_after_total",
+		"links_before_total", "links_after_total", "packed_paths_before_total", "packed_paths_after_total",
+		"mutation_partial", "cap_hits", "accepted_heads", "packed_roots_emitted",
+	})
+	workCountRequireKeys(t, "Go convergence phase aggregates", workCountDecodeRawObject(t, "Go convergence phase aggregates", raw["phases"]), workCountConvergenceManifestPhases)
+	workCountRequireKeys(t, "Go convergence outcome aggregates", workCountDecodeRawObject(t, "Go convergence outcome aggregates", raw["outcomes"]), workCountConvergenceManifestOutcomes)
+	workCountRequireKeys(t, "Go convergence rejection aggregates", workCountDecodeRawObject(t, "Go convergence rejection aggregates", raw["rejections"]), workCountConvergenceManifestReasons)
+	var aggregates workCountConvergenceTotals
+	workCountDecodeExact(t, data, &aggregates)
+}
+
+func workCountConvergencePhaseMap(value workCountConvergencePhaseTotals) map[string]uint64 {
+	return map[string]uint64{
+		"reduce_window_select": value.ReduceWindowSelect,
+		"post_reduce_primary":  value.PostReducePrimary,
+		"post_reduce_pending":  value.PostReducePending,
+		"boundary_gss":         value.BoundaryGSS,
+		"boundary_equivalence": value.BoundaryEquivalence,
+		"boundary_cull":        value.BoundaryCull,
+		"pending_work":         value.PendingWork,
+		"final_expand":         value.FinalExpand,
+		"final_select":         value.FinalSelect,
+		"terminal_accept":      value.TerminalAccept,
+	}
+}
+
+func workCountConvergenceOutcomeMap(value workCountConvergenceOutcomeTotals) map[string]uint64 {
+	return map[string]uint64{
+		"candidate":           value.Candidate,
+		"packed":              value.Packed,
+		"rejected":            value.Rejected,
+		"pending_queued":      value.PendingQueued,
+		"pending_drained":     value.PendingDrained,
+		"pending_discarded":   value.PendingDiscarded,
+		"accepted_head":       value.AcceptedHead,
+		"packed_root_emitted": value.PackedRoot,
+		"mutation_partial":    value.MutationPartial,
+		"cap_hit":             value.CapHit,
+		"observation_unknown": value.ObservationUnknown,
+		"selected":            value.Selected,
+	}
+}
+
+func workCountConvergenceRejectMap(value workCountConvergenceRejectTotals) map[string]uint64 {
+	return map[string]uint64{
+		"status":         value.Status,
+		"score":          value.Score,
+		"shifted":        value.Shifted,
+		"error_cost":     value.ErrorCost,
+		"not_gss":        value.NotGSS,
+		"not_clean":      value.NotClean,
+		"distinct_shape": value.DistinctShape,
+		"preflight":      value.Preflight,
+		"cull":           value.Cull,
+	}
+}
+
+func workCountSumUint64Fields(t *testing.T, label string, values map[string]uint64) uint64 {
+	t.Helper()
+	var sum uint64
+	for field, value := range values {
+		if ^uint64(0)-sum < value {
+			t.Fatalf("%s field %s sum overflow", label, field)
+		}
+		sum += value
+	}
+	return sum
 }
 
 func workCountValidateCounterValuesObject(t *testing.T, label string, data json.RawMessage) {
@@ -1112,9 +1754,9 @@ func workCountDecodeExact(t *testing.T, data []byte, result any) {
 	}
 }
 
-func workCountValidateGoChild(t *testing.T, label, expectedEngine string, result workCountGoChildResult, fixture benchfixtures.LoadedFixture) {
+func workCountValidateGoChild(t *testing.T, label, expectedSchema, expectedEngine string, result workCountGoChildResult, fixture benchfixtures.LoadedFixture) {
 	t.Helper()
-	if result.Schema != workCountGoChildSchema || result.DigestFormat != benchfixtures.DeepTreeDigestVersion {
+	if result.Schema != expectedSchema || result.DigestFormat != benchfixtures.DeepTreeDigestVersion {
 		t.Fatalf("%s mixed contract: schema=%q digest=%q", label, result.Schema, result.DigestFormat)
 	}
 	if result.Engine != expectedEngine {
@@ -1171,6 +1813,10 @@ func workCountValidateCounters(t *testing.T, label string, c workCountCounters) 
 func workCountValidateGoCounters(t *testing.T, label string, c workCountGoCounters, sourceBytes uint32) {
 	t.Helper()
 	workCountValidateCounters(t, label, c.workCountCounters)
+	if c.Convergence.Capability == "" {
+		t.Fatalf("%s convergence frontier is absent", label)
+	}
+	workCountValidateGoConvergence(t, c.Convergence)
 	if len(c.Attempts) != 1 {
 		t.Fatalf("%s attempts=%d want=1", label, len(c.Attempts))
 	}
@@ -1310,11 +1956,7 @@ func workCountValidateManifest(t *testing.T, path string) {
 		Convergence map[string]any `json:"convergence_frontier"`
 		Admission   map[string]any `json:"admission"`
 	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&manifest); err != nil {
-		t.Fatal(err)
-	}
+	workCountDecodeExact(t, data, &manifest)
 	if manifest.Schema != "gts-work-count-contract/v2" || manifest.CounterContract != workCountContract || strings.TrimSpace(manifest.Scope) == "" {
 		t.Fatalf("manifest contract mismatch: schema=%q counters=%q scope=%q", manifest.Schema, manifest.CounterContract, manifest.Scope)
 	}
@@ -1381,6 +2023,181 @@ func workCountValidateManifest(t *testing.T, path string) {
 	})
 }
 
+func workCountValidateManifestAgreement(t *testing.T, sharedPath, convergencePath string) {
+	t.Helper()
+	shared, err := os.ReadFile(sharedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	convergence, err := os.ReadFile(convergencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workCountManifestAgreementError(shared, convergence); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func workCountManifestAgreementError(shared, convergence []byte) error {
+	var sharedRaw, convergenceRaw map[string]json.RawMessage
+	if err := json.Unmarshal(shared, &sharedRaw); err != nil {
+		return fmt.Errorf("decode shared counter manifest: %w", err)
+	}
+	if err := json.Unmarshal(convergence, &convergenceRaw); err != nil {
+		return fmt.Errorf("decode convergence manifest: %w", err)
+	}
+	for _, section := range []string{"direct", "terminal", "proxy", "derived", "attempt_attribution"} {
+		sharedSection, ok := sharedRaw[section]
+		if !ok {
+			return fmt.Errorf("shared counter manifest lacks %s", section)
+		}
+		convergenceSection, ok := convergenceRaw[section]
+		if !ok {
+			return fmt.Errorf("convergence manifest lacks %s", section)
+		}
+		var sharedValue, convergenceValue any
+		if err := json.Unmarshal(sharedSection, &sharedValue); err != nil {
+			return fmt.Errorf("decode shared counter manifest %s: %w", section, err)
+		}
+		if err := json.Unmarshal(convergenceSection, &convergenceValue); err != nil {
+			return fmt.Errorf("decode convergence manifest %s: %w", section, err)
+		}
+		if !reflect.DeepEqual(sharedValue, convergenceValue) {
+			return fmt.Errorf("convergence manifest %s drifts from immutable shared counter manifest", section)
+		}
+	}
+	return nil
+}
+
+func workCountValidateConvergenceManifest(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := workCountDecodeRawObject(t, "convergence manifest", data)
+	workCountRequireKeys(t, "convergence manifest", raw, []string{
+		"schema", "counter_contract", "scope", "historical_compatibility", "direct", "terminal", "proxy", "derived",
+		"attempt_attribution", "convergence_frontier", "admission",
+	})
+	var manifest struct {
+		Schema          string            `json:"schema"`
+		CounterContract string            `json:"counter_contract"`
+		Scope           string            `json:"scope"`
+		Historical      map[string]string `json:"historical_compatibility"`
+		Direct          map[string]string `json:"direct"`
+		Terminal        map[string]string `json:"terminal"`
+		Proxy           map[string]string `json:"proxy"`
+		Derived         map[string]string `json:"derived"`
+		Attempt         struct {
+			LogicalRungs                     []string `json:"logical_rungs"`
+			ResolvedRetryPassIsIndependent   bool     `json:"resolved_retry_pass_is_independent"`
+			Phases                           []string `json:"phases"`
+			RequireAggregateEqualsAttributed bool     `json:"require_aggregate_equals_attempts_plus_outside"`
+			CanonicalAttempts                int      `json:"canonical_query_compile_attempts"`
+			CanonicalAcceptActions           uint64   `json:"canonical_query_compile_accept_actions"`
+			RetryWitness                     struct {
+				Path          string   `json:"path"`
+				Bytes         int      `json:"bytes"`
+				SHA256        string   `json:"sha256"`
+				ExpectedRungs []string `json:"expected_rungs"`
+			} `json:"retry_witness"`
+			StraightLRControl struct {
+				Path              string `json:"path"`
+				Bytes             int    `json:"bytes"`
+				SHA256            string `json:"sha256"`
+				ExpectedMaxStacks int    `json:"expected_max_stacks"`
+			} `json:"straight_lr_control"`
+		} `json:"attempt_attribution"`
+		Convergence struct {
+			Status               string              `json:"status"`
+			Capability           string              `json:"capability"`
+			StaticCComparable    bool                `json:"static_c_emits_comparable_events"`
+			MaxEvents            int                 `json:"max_events"`
+			MaxPackedPaths       int                 `json:"max_packed_path_count"`
+			ParseWorkBudget      int                 `json:"packed_path_parse_work_budget"`
+			PerWalkWorkBudget    int                 `json:"packed_path_per_walk_work_budget"`
+			DepthBudget          int                 `json:"packed_path_depth_budget"`
+			RecordFirstReject    bool                `json:"record_first_reject_per_reason"`
+			FirstRejectSemantics string              `json:"first_reject_semantics"`
+			DecisionIDs          string              `json:"decision_ids"`
+			HeadStatusPriority   []string            `json:"head_status_priority"`
+			Phases               []string            `json:"phases"`
+			PhaseOutcomes        map[string][]string `json:"phase_outcomes"`
+			Outcomes             []string            `json:"outcomes"`
+			Reasons              []string            `json:"reject_reasons"`
+			Identity             []string            `json:"identity"`
+			Snapshots            []string            `json:"snapshots"`
+			EventInvariants      []string            `json:"event_invariants"`
+			CandidateCountUnits  string              `json:"candidate_count_units"`
+			BoundedTrace         string              `json:"bounded_trace"`
+			IntegritySignals     []string            `json:"separate_integrity_signals"`
+			SaturatingAggregates bool                `json:"include_saturating_aggregates"`
+			TerminalCounters     []string            `json:"terminal_counters"`
+			Interpretation       string              `json:"interpretation"`
+		} `json:"convergence_frontier"`
+		Admission map[string]any `json:"admission"`
+	}
+	workCountDecodeExact(t, data, &manifest)
+	if manifest.Schema != "gts-work-count-contract/v3" || manifest.CounterContract != workCountContract || strings.TrimSpace(manifest.Scope) == "" {
+		t.Fatalf("convergence manifest contract mismatch: schema=%q counters=%q scope=%q", manifest.Schema, manifest.CounterContract, manifest.Scope)
+	}
+	workCountRequireStringKeys(t, "convergence manifest history", manifest.Historical, []string{"v2_manifest", "direct_and_proxy_counter_semantics", "detailed_convergence"})
+	workCountRequireStringKeys(t, "convergence manifest direct", manifest.Direct, workCountDirectFields)
+	workCountRequireStringKeys(t, "convergence manifest terminal", manifest.Terminal, workCountTerminalFields)
+	workCountRequireStringKeys(t, "convergence manifest proxy", manifest.Proxy, workCountProxyFields)
+	workCountRequireStringKeys(t, "convergence manifest derived", manifest.Derived, []string{"construction_surplus"})
+	workCountRequireKeys(t, "convergence manifest attempt attribution", workCountDecodeRawObject(t, "convergence manifest attempt attribution", raw["attempt_attribution"]), []string{
+		"logical_rungs", "resolved_retry_pass_is_independent", "phases", "require_aggregate_equals_attempts_plus_outside",
+		"canonical_query_compile_attempts", "canonical_query_compile_accept_actions", "retry_witness", "straight_lr_control",
+	})
+	if strings.Join(manifest.Attempt.LogicalRungs, ",") != "initial_full,initial_merge,clean_wide,clean_wide_merge,recovery_wide_or_node,secondary_node,final_merge" ||
+		strings.Join(manifest.Attempt.Phases, ",") != "entry_to_caps,caps_to_finalize,finalize" || !manifest.Attempt.ResolvedRetryPassIsIndependent ||
+		!manifest.Attempt.RequireAggregateEqualsAttributed || manifest.Attempt.CanonicalAttempts != 1 || manifest.Attempt.CanonicalAcceptActions != 3 {
+		t.Fatalf("convergence manifest attempt invariants=%+v", manifest.Attempt)
+	}
+	workCountRequireKeys(t, "convergence manifest frontier", workCountDecodeRawObject(t, "convergence manifest frontier", raw["convergence_frontier"]), []string{
+		"status", "capability", "static_c_emits_comparable_events", "max_events", "max_packed_path_count",
+		"packed_path_parse_work_budget", "packed_path_per_walk_work_budget", "packed_path_depth_budget",
+		"record_first_reject_per_reason", "first_reject_semantics", "decision_ids", "head_status_priority", "phases", "phase_outcomes", "outcomes", "reject_reasons", "identity", "snapshots", "event_invariants",
+		"candidate_count_units", "bounded_trace", "separate_integrity_signals", "include_saturating_aggregates", "terminal_counters", "interpretation",
+	})
+	c := manifest.Convergence
+	if c.Status != "implemented" || c.Capability != "go_only_detailed_convergence" || c.StaticCComparable || c.MaxEvents != 256 || c.MaxPackedPaths != 7 ||
+		c.ParseWorkBudget != 16*1024 || c.PerWalkWorkBudget != 256 || c.DepthBudget != 128 || !c.RecordFirstReject || !c.SaturatingAggregates ||
+		strings.TrimSpace(c.FirstRejectSemantics) == "" || strings.TrimSpace(c.DecisionIDs) == "" || !reflect.DeepEqual(c.HeadStatusPriority, []string{"dead", "accepted", "paused", "live"}) || len(c.EventInvariants) == 0 || strings.TrimSpace(c.CandidateCountUnits) == "" || strings.TrimSpace(c.BoundedTrace) == "" || strings.TrimSpace(c.Interpretation) == "" {
+		t.Fatalf("convergence manifest frontier invariants=%+v", c)
+	}
+	if strings.Join(c.Phases, ",") != strings.Join(workCountConvergenceManifestPhases, ",") || strings.Join(c.Outcomes, ",") != strings.Join(workCountConvergenceManifestOutcomes, ",") || strings.Join(c.Reasons, ",") != strings.Join(workCountConvergenceManifestReasons, ",") {
+		t.Fatalf("convergence manifest vocabulary phases=%v outcomes=%v reasons=%v", c.Phases, c.Outcomes, c.Reasons)
+	}
+	if !reflect.DeepEqual(c.PhaseOutcomes, workCountConvergencePhaseOutcomes) {
+		t.Fatalf("convergence manifest phase/outcome matrix=%v want=%v", c.PhaseOutcomes, workCountConvergencePhaseOutcomes)
+	}
+	for _, required := range []string{"decision_id", "lookahead_present", "head_link_count_capped", "election_scanner_comparable", "election_scanner_checkpoint_presence_and_hash"} {
+		if !workCountStringIn(required, c.Identity) {
+			t.Fatalf("convergence manifest identity misses %q", required)
+		}
+	}
+	if strings.Join(c.TerminalCounters, ",") != "accept_actions,accepted_heads,packed_roots_emitted" {
+		t.Fatalf("convergence manifest terminal counters=%v", c.TerminalCounters)
+	}
+	workCountRequireKeys(t, "convergence manifest admission", workCountDecodeRawObject(t, "convergence manifest admission", raw["admission"]), []string{
+		"digest_format", "fixture", "require_uninstrumented_go_static_c_digest_match_first", "require_instrumented_digest_match",
+		"require_full_span", "require_clean_root", "require_no_overflow", "require_exact_fields", "require_ordinary_untagged_go_child_first",
+		"require_clean_git_source_for_authoritative_receipt", "require_private_content_addressed_go_source_snapshot", "require_private_c_input_snapshot",
+		"sanitize_go_and_parser_environment", "atomic_receipt_publish",
+	})
+	for key, value := range manifest.Admission {
+		if (strings.HasPrefix(key, "require_") || key == "sanitize_go_and_parser_environment" || key == "atomic_receipt_publish") && value != true {
+			t.Fatalf("convergence manifest admission %s=%v want true", key, value)
+		}
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(path), "..", ".."))
+	workCountValidateFrozenWitness(t, repoRoot, "retry", manifest.Attempt.RetryWitness.Path, manifest.Attempt.RetryWitness.Bytes, manifest.Attempt.RetryWitness.SHA256)
+	workCountValidateFrozenWitness(t, repoRoot, "straight-LR", manifest.Attempt.StraightLRControl.Path, manifest.Attempt.StraightLRControl.Bytes, manifest.Attempt.StraightLRControl.SHA256)
+}
+
 func workCountValidateFrozenWitness(t *testing.T, repoRoot, label, relativePath string, wantBytes int, wantSHA string) {
 	t.Helper()
 	if relativePath == "" || filepath.IsAbs(relativePath) {
@@ -1415,6 +2232,46 @@ func workCountRequireKeys(t *testing.T, label string, values map[string]json.Raw
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("%s fields=%v want=%v", label, got, want)
 	}
+}
+
+func workCountRequireKeysWithOptional(t *testing.T, label string, values map[string]json.RawMessage, required, optional []string) {
+	t.Helper()
+	allowed := make(map[string]bool, len(required)+len(optional))
+	for _, key := range required {
+		allowed[key] = true
+		if _, ok := values[key]; !ok {
+			t.Fatalf("%s missing required field %q", label, key)
+		}
+	}
+	for _, key := range optional {
+		allowed[key] = true
+	}
+	for key := range values {
+		if !allowed[key] {
+			t.Fatalf("%s unexpected field %q", label, key)
+		}
+	}
+}
+
+func workCountDecodeRawObject(t *testing.T, label string, data json.RawMessage) map[string]json.RawMessage {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode %s: %v", label, err)
+	}
+	if raw == nil {
+		t.Fatalf("%s is not an object", label)
+	}
+	return raw
+}
+
+func workCountStringIn(value string, values []string) bool {
+	for _, candidate := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func workCountRequireStringKeys(t *testing.T, label string, values map[string]string, want []string) {

--- a/glr.go
+++ b/glr.go
@@ -3144,6 +3144,9 @@ func gssMainCanMerge(a, b *glrStack) bool {
 }
 
 func gssMainCanMergeForParser(p *Parser, a, b *glrStack) bool {
+	if workCountInstrumentationEnabled {
+		return gssMainCanMergeForParserPhase(p, a, b, workCountConvergencePhaseBoundaryGSS)
+	}
 	if cRecoveryMergeCostsDifferForParser(p, a, b) {
 		if p != nil && p.glrTrace {
 			scratch := glrMergeScratch{language: p.language, trace: true, cRecoveryCost: true}
@@ -3157,7 +3160,25 @@ func gssMainCanMergeForParser(p *Parser, a, b *glrStack) bool {
 	return gssMainCanMergeWithScratch(nil, a, b)
 }
 
+func gssMainCanMergeForParserPhase(p *Parser, a, b *glrStack, phase string) bool {
+	if cRecoveryMergeCostsDifferForParser(p, a, b) {
+		workCountRecordGSSReject(p, phase, workCountConvergenceReasonErrorCost, "GSS merge rejected by recovery cost", a, b)
+		if p != nil && p.glrTrace {
+			scratch := glrMergeScratch{language: p.language, trace: true, cRecoveryCost: true}
+			traceCRecoverMergeDecision(&scratch, "gss-direct", "reject-cost", a, b)
+		}
+		return false
+	}
+	if p != nil {
+		return gssMainCanMergeWithScratchPhase(p.mergeScratch, a, b, phase)
+	}
+	return gssMainCanMergeWithScratchPhase(nil, a, b, phase)
+}
+
 func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
+	if workCountInstrumentationEnabled {
+		return tryGSSMainMergeForParserPhase(p, a, b, workCountConvergencePhaseBoundaryGSS, true)
+	}
 	workCountRecordMergeAttempt()
 	if !gssMainCanMergeForParser(p, a, b) {
 		return false
@@ -3167,6 +3188,34 @@ func tryGSSMainMergeForParser(p *Parser, a, b *glrStack) bool {
 		scratch = p.mergeScratch
 	}
 	merged := gssMainMergeWithScratch(scratch, a, b)
+	if merged {
+		workCountRecordMergeSuccess()
+		a.cEverErrored = a.cEverErrored || b.cEverErrored
+		if p != nil {
+			p.mergeScratch.bumpShapePrefixEpoch()
+		}
+	}
+	return merged
+}
+
+func tryGSSMainMergeForParserPhase(p *Parser, a, b *glrStack, phase string, recordDecision bool) bool {
+	workCountRecordMergeAttempt()
+	if recordDecision {
+		workCountRecordPairCandidate(p, phase, "GSS merge entered eligibility preflight", a, b) // work-count-assembly: convergence GSS seam
+	}
+	if !gssMainCanMergeForParserPhase(p, a, b, phase) {
+		return false
+	}
+	var scratch *glrMergeScratch
+	if p != nil {
+		scratch = p.mergeScratch
+	}
+	merged := false
+	if workCountInstrumentationEnabled {
+		merged = workCountMergeGSSObserved(p, scratch, phase, "GSS merge", a, b)
+	} else {
+		merged = gssMainMergeWithScratch(scratch, a, b)
+	}
 	if merged {
 		workCountRecordMergeSuccess()
 		// a survives and absorbs b, so OR the sticky wreckage bit: cEverErrored
@@ -3201,6 +3250,29 @@ func gssMainCanMergeWithScratch(scratch *glrMergeScratch, a, b *glrStack) bool {
 	}
 	return gssNodeCleanZeroErrorAllLinksWithScratch(scratch, a.gss.head) &&
 		gssNodeCleanZeroErrorAllLinksWithScratch(scratch, b.gss.head)
+}
+
+func gssMainCanMergeWithScratchPhase(scratch *glrMergeScratch, a, b *glrStack, phase string) bool {
+	if a.gss.head == nil || b.gss.head == nil {
+		workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), phase, workCountConvergenceReasonNotGSS, "GSS merge requires packed heads", a, b)
+		return false
+	}
+	if a.dead || b.dead || a.accepted != b.accepted {
+		workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), phase, workCountConvergenceReasonStatus, "GSS merge status differs", a, b)
+		return false
+	}
+	if a.score != b.score || a.shifted != b.shifted {
+		workCountRecordGSSScoreShiftReject(workCountParserFromMergeScratch(scratch), phase, a, b)
+		return false
+	}
+	if a.top().state != b.top().state || a.byteOffset != b.byteOffset {
+		workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), phase, workCountConvergenceReasonStatus, "GSS merge state or byte differs", a, b)
+		return false
+	}
+	clean := gssNodeCleanZeroErrorAllLinksWithScratch(scratch, a.gss.head) &&
+		gssNodeCleanZeroErrorAllLinksWithScratch(scratch, b.gss.head)
+	workCountRecordGSSCleanReject(workCountParserFromMergeScratch(scratch), phase, a, b, clean)
+	return clean
 }
 
 func gssNodeByteOffset(n *gssNode) uint32 {
@@ -3505,14 +3577,22 @@ func setGSSMainLink(n *gssNode, i int, prev *gssNode, entry stackEntry) {
 		// entries, which both contribute zero here) changes parser metadata but
 		// not either aggregate. Keep the cache in that explicit identity case;
 		// every other rewrite remains conservatively globally invalidating.
+		changed := n.prev != prev || n.entry != entry
 		if n.prev != prev || stackEntryNode(n.entry) != stackEntryNode(entry) {
 			gssPrefixAggGen.Add(1)
 		}
 		n.prev = prev
 		n.entry = entry
+		if changed {
+			workCountRecordGSSMutation() // work-count-assembly: GSS mutation set-primary seam
+		}
 		return
 	}
+	old := n.extraLink(i - 1)
 	n.setExtraLink(i-1, gssMainLink{prev: prev, entry: entry})
+	if old.prev != prev || old.entry != entry {
+		workCountRecordGSSMutation() // work-count-assembly: GSS mutation set-extra seam
+	}
 }
 
 func gssMainAddLink(n *gssNode, prev *gssNode, entry stackEntry) bool {
@@ -4188,18 +4268,35 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 	if idx < 0 || idx >= len(result) || stack == nil {
 		return false, false
 	}
+	if workCountInstrumentationEnabled {
+		workCountRecordPairCandidate(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, "boundary merge entered eligibility preflight", &result[idx], stack)
+	}
 	if cRecoveryMergeCostsDiffer(scratch, &result[idx], stack) {
 		traceCRecoverMergeDecision(scratch, "gss", "reject-cost", &result[idx], stack)
+		if workCountInstrumentationEnabled {
+			workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, workCountConvergenceReasonErrorCost, "boundary merge rejected by recovery cost", &result[idx], stack)
+		}
 		return false, false
 	}
-	if !gssMainCanMergeWithScratch(scratch, &result[idx], stack) {
+	if workCountInstrumentationEnabled {
+		if !gssMainCanMergeWithScratchPhase(scratch, &result[idx], stack, workCountConvergencePhaseBoundaryGSS) {
+			return false, false
+		}
+	} else if !gssMainCanMergeWithScratch(scratch, &result[idx], stack) {
 		return false, false
 	}
 	if (scratch == nil || scratch.perKeyCap != 1) &&
 		gssStacksHaveDistinctMaterializingShapesWithScratch(scratch, &result[idx], stack) {
+		if workCountInstrumentationEnabled {
+			workCountRecordGSSReject(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceReasonDistinctShape, "boundary merge retained distinct materializing shapes", &result[idx], stack)
+		}
 		return false, true
 	}
-	merged = gssMainMergeWithScratch(scratch, &result[idx], stack)
+	if workCountInstrumentationEnabled {
+		merged = workCountMergeGSSObserved(workCountParserFromMergeScratch(scratch), scratch, workCountConvergencePhaseBoundaryGSS, "boundary merge", &result[idx], stack)
+	} else {
+		merged = gssMainMergeWithScratch(scratch, &result[idx], stack)
+	}
 	if merged {
 		workCountRecordMergeSuccess()
 		// result[idx] survives and absorbs stack, so OR the sticky wreckage bit:

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -92,6 +92,7 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 		unsafe.Slice(n.extraLinks, capacity)[count] = link
 		n.extraLinkCount++
 		workCountRecordGraphLinkAddition()
+		workCountRecordGSSMutation() // work-count-assembly: GSS mutation append-reuse seam
 		return
 	}
 	newCapacity := 1
@@ -110,6 +111,7 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 	n.extraLinkCount++
 	n.extraLinkCap = uint8(newCapacity)
 	workCountRecordGraphLinkAddition()
+	workCountRecordGSSMutation() // work-count-assembly: GSS mutation append-grow seam
 }
 
 // gssStack is a shared-prefix stack foundation for future GLR work.

--- a/parser.go
+++ b/parser.go
@@ -2160,6 +2160,7 @@ func (p *Parser) rejectUndrainedPendingForkStacks(s *glrStack) bool {
 	if p == nil || !glrFaithfulCapOneMerge || len(p.pendingForkStacks) == 0 {
 		return false
 	}
+	workCountRecordPendingTransition(p, &p.pendingForkStacks[0], len(p.pendingForkStacks), 0, workCountConvergenceOutcomePendingDiscarded, "undrained post-reduce candidates rejected")
 	p.pendingForkStacks = p.pendingForkStacks[:0]
 	if s != nil {
 		s.dead = true
@@ -4093,6 +4094,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if !glrFaithfulCapOneMerge || len(p.pendingForkStacks) == 0 {
 			return
 		}
+		pendingCount := len(p.pendingForkStacks)
+		workCountRecordPendingTransition(p, &p.pendingForkStacks[0], pendingCount, 0, workCountConvergenceOutcomePendingDrained, "post-reduce pending queue drained into live frontier")
 		if progress.enabled {
 			for i := range p.pendingForkStacks {
 				pending := &p.pendingForkStacks[i]
@@ -4131,6 +4134,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if len(p.pendingFrontierForkStacks) == 0 {
 			return
 		}
+		pendingCount := len(p.pendingFrontierForkStacks)
+		workCountRecordPendingTransition(p, &p.pendingFrontierForkStacks[0], pendingCount, 0, workCountConvergenceOutcomePendingDrained, "frontier pending queue drained into live frontier")
 		if progress.enabled {
 			for i := range p.pendingFrontierForkStacks {
 				pending := &p.pendingFrontierForkStacks[i]
@@ -4341,7 +4346,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		return errorTreeWithOwnedArena(reason)
 	}
 	finalizeTree := func(tree *Tree, stopReason ParseStopReason) *Tree {
-		if workCountInstrumentationEnabled { // work-count-assembly: finalize-defer guard
+		if workCountInstrumentationEnabled && workCountConvergenceActive() { // work-count-assembly: finalize-defer guard
 			workCountBeginFinalizeParseAttempt(workCountAttempt)
 			defer func() {
 				workCountEndFinalizeParseAttempt(workCountAttempt, stopReason, tree)
@@ -4468,6 +4473,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if phaseTiming && parserLoopNanos == 0 {
 			parserLoopNanos = time.Since(parseStart).Nanoseconds()
 		}
+		workCountRecordFinalPendingDiscards(p, p.pendingForkStacks, p.pendingFrontierForkStacks)
 		if p.noTreeBenchmarkOnly {
 			rootEndByte := expectedEOFByte
 			if stopReason != ParseStopAccepted && stopReason != ParseStopNone {
@@ -4604,6 +4610,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			return finalize(stacks, reason)
 		}
 		iterationsUsed = iter + 1
+		workCountSetConvergenceIteration(iterationsUsed) // work-count-assembly: convergence iteration seam
 		if perfCountersEnabled {
 			perfRecordMaxConcurrentStacks(len(stacks))
 		}
@@ -4692,6 +4699,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				progress.emit(time.Now(), "token_end", iterationsUsed, perfTokensConsumed+1, tok, true, stacks, maxStacksSeen, nodeCount, peakStackDepth, needToken, singleStackIterations, multiStackIterations, "")
 			}
 			p.updateCurrentExternalTokenCheckpoint(ts, tok)
+			workCountSetConvergenceLookahead(tok)
 			if p.logger != nil {
 				p.logf(ParserLogLex, "token sym=%d start=%d end=%d", tok.Symbol, tok.StartByte, tok.EndByte)
 			}
@@ -6607,6 +6615,7 @@ func (p *Parser) cullParseStacksForIteration(stacks []glrStack, scratch *parserS
 		stacks = retainTopStacksForLanguageWithScratch(stacks, maxStacks, cullLang, &scratch.stackPick, &scratch.stackKeep, &scratch.stackCull)
 	}
 	scratch.audit.recordGlobalCull(cullIn, len(stacks))
+	workCountRecordBoundaryCull(p, cullIn, len(stacks))
 	if p.glrTrace {
 		p.traceParseStackCull("kept", stacks, maxStacks, maxStackCullTrigger)
 	}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -808,7 +808,9 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			if allocBranchOrder != nil {
 				fork.branchOrder = allocBranchOrder()
 			}
+			pendingBefore := len(p.pendingFrontierForkStacks)
 			p.pendingFrontierForkStacks = append(p.pendingFrontierForkStacks, fork)
+			workCountRecordPendingQueued(p, s, &fork, pendingBefore, len(p.pendingFrontierForkStacks), "conflict-frontier candidate queued")
 			if currentReduceEntry != nil {
 				currentReduceEntry.flags |= conflictReduceFrontierForked
 			}
@@ -2706,6 +2708,7 @@ func (p *Parser) applyReduceActionDispatch(source []byte, s *glrStack, act Parse
 func (p *Parser) applyAcceptAction(s *glrStack) {
 	workCountRecordAccept()
 	s.accepted = true
+	workCountRecordAcceptedHead(p, s, "parse-action accept")
 	if p != nil && p.glrTrace {
 		fmt.Printf("      -> ACCEPT\n")
 	}
@@ -2715,6 +2718,7 @@ func (p *Parser) applyRecoverAction(s *glrStack, act ParseAction, tok Token, nod
 	workCountRecordExplicitRecover()
 	if tok.Symbol == 0 && tok.StartByte == tok.EndByte {
 		s.accepted = true
+		workCountRecordAcceptedHead(p, s, "EOF recovery accepted head")
 		return
 	}
 	recoverState := s.top().state
@@ -3466,6 +3470,7 @@ func (p *Parser) selectedReduceWindowsFromGSSWithBudget(arena *nodeArena, act Pa
 	}
 
 	dfs(s.gss.head, childCount)
+	workCountRecordReduceWindow(p, s, len(forks), work, workBudget, capped)
 	return forks, work, capped
 }
 
@@ -3475,16 +3480,35 @@ func markReduceApplied(s *glrStack, act ParseAction, anyReduced *bool) {
 }
 
 func tryMergePostReduceFork(p *Parser, target, fork *glrStack) bool {
-	if target == nil || fork == nil || target.accepted || fork.accepted {
-		return false
-	}
-	if target.entries != nil || fork.entries != nil || target.gss.head == nil || fork.gss.head == nil {
-		return false
-	}
-	if target.top().state != fork.top().state || target.byteOffset != fork.byteOffset {
-		return false
+	if workCountInstrumentationEnabled {
+		if postReduceForkMergePreflight(target, fork) != workCountConvergenceReasonNone {
+			return false
+		}
+	} else {
+		if target == nil || fork == nil || target.accepted || fork.accepted {
+			return false
+		}
+		if target.entries != nil || fork.entries != nil || target.gss.head == nil || fork.gss.head == nil {
+			return false
+		}
+		if target.top().state != fork.top().state || target.byteOffset != fork.byteOffset {
+			return false
+		}
 	}
 	return tryGSSMainMergeForParser(p, target, fork)
+}
+
+func postReduceForkMergePreflight(target, fork *glrStack) string {
+	if target == nil || fork == nil || target.accepted || fork.accepted {
+		return workCountConvergenceReasonStatus
+	}
+	if target.entries != nil || fork.entries != nil || target.gss.head == nil || fork.gss.head == nil {
+		return workCountConvergenceReasonNotGSS
+	}
+	if target.top().state != fork.top().state || target.byteOffset != fork.byteOffset {
+		return workCountConvergenceReasonStatus
+	}
+	return workCountConvergenceReasonNone
 }
 
 func (p *Parser) postReduceForkMergeHasFinalizationRisk(s *glrStack, tok Token) bool {
@@ -3999,11 +4023,24 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 		applyForkToStack(&clone, forks[i])
 		clone.score = base.score + int(act.DynamicPrecedence)
 		if !p.disablePostReduceForkMerge {
-			if !p.postReduceForkMergeHasFinalizationRisk(&clone, tok) {
+			finalizationRisk := p.postReduceForkMergeHasFinalizationRisk(&clone, tok)
+			if finalizationRisk {
+				workCountRecordPostReduceCandidate(p, workCountConvergencePhasePostReducePrimary, "post-reduce candidate has finalization risk", s, &clone, workCountConvergenceReasonStatus)
+				if perfCountersEnabled {
+					perfRecordPostReduceMergeFinalizationRiskSkip()
+				}
+			} else {
+				workCountRecordPostReduceCandidate(p, workCountConvergencePhasePostReducePrimary, "post-reduce candidate is eligible for packing", s, &clone, workCountConvergenceReasonNone)
 				if perfCountersEnabled {
 					perfRecordPostReduceMergeAttempt()
 				}
-				if tryMergePostReduceFork(p, s, &clone) {
+				primaryMerged := false
+				if workCountInstrumentationEnabled {
+					primaryMerged = workCountTryPostReduceMergeObserved(p, workCountConvergencePhasePostReducePrimary, "post-reduce candidate packed into primary", s, &clone)
+				} else {
+					primaryMerged = tryMergePostReduceFork(p, s, &clone)
+				}
+				if primaryMerged {
 					if perfCountersEnabled {
 						perfRecordPostReduceMergePrimarySuccess()
 					}
@@ -4014,7 +4051,14 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 					if perfCountersEnabled {
 						perfRecordPostReduceMergeAttempt()
 					}
-					if tryMergePostReduceFork(p, &p.pendingForkStacks[j], &clone) {
+					workCountRecordPostReduceCandidate(p, workCountConvergencePhasePostReducePending, "pending head entered post-reduce packing", &p.pendingForkStacks[j], &clone, workCountConvergenceReasonNone)
+					pendingMerged := false
+					if workCountInstrumentationEnabled {
+						pendingMerged = workCountTryPostReduceMergeObserved(p, workCountConvergencePhasePostReducePending, "post-reduce candidate packed into pending head", &p.pendingForkStacks[j], &clone)
+					} else {
+						pendingMerged = tryMergePostReduceFork(p, &p.pendingForkStacks[j], &clone)
+					}
+					if pendingMerged {
 						if perfCountersEnabled {
 							perfRecordPostReduceMergePendingSuccess()
 						}
@@ -4025,13 +4069,13 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 				if merged {
 					continue
 				}
-			} else if perfCountersEnabled {
-				perfRecordPostReduceMergeFinalizationRiskSkip()
 			}
 		} else if perfCountersEnabled {
 			perfRecordPostReduceMergeDisabledSkip()
 		}
+		pendingBefore := len(p.pendingForkStacks)
 		p.pendingForkStacks = append(p.pendingForkStacks, clone)
+		workCountRecordPendingQueued(p, s, &clone, pendingBefore, len(p.pendingForkStacks), "post-reduce candidate queued")
 		if perfCountersEnabled {
 			perfRecordPendingForkStackAppend(len(p.pendingForkStacks))
 		}

--- a/parser_result.go
+++ b/parser_result.go
@@ -233,6 +233,7 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 	if len(stacks) == 0 {
 		return parseErrorTreeWithArena(source, p.language, arena)
 	}
+	workCountRecordFinalExpansions(p, stacks) // work-count-assembly: convergence final-expand seam
 	stacks = expandPackedGSSResultPaths(stacks)
 	p.emitRawShapeDiag("pre_result_selection", stacks, arena)
 	selectionStart := time.Time{}
@@ -258,6 +259,7 @@ func (p *Parser) buildResultFromGLR(stacks []glrStack, source []byte, arena *nod
 		materializationTiming.resultSelectionNanos += time.Since(selectionStart).Nanoseconds()
 	}
 	selected := stacks[best]
+	workCountRecordFinalSelect(p, stacks, &selected)
 	// crecoveryDroppedErrorForClean is set ONLY here, and only for the stack
 	// that is actually about to become the returned tree — never for a drop
 	// or fork that happened on some other, discarded lineage elsewhere in the

--- a/work_count_attempt_attribution_test.go
+++ b/work_count_attempt_attribution_test.go
@@ -11,6 +11,7 @@ import (
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 const (
@@ -24,6 +25,7 @@ const (
 
 func TestDiagnosticWorkCountAttemptAttributionRetryWitness(t *testing.T) {
 	source := loadWorkCountAttributionFixture(t, retryAttributionFixturePath, retryAttributionFixtureBytes, retryAttributionFixtureSHA256)
+	baselineDigest := attributionBaselineTreeDigest(t, source)
 	counts, tree := parseWithDiagnosticWorkCount(t, source)
 	defer tree.Release()
 
@@ -41,10 +43,13 @@ func TestDiagnosticWorkCountAttemptAttributionRetryWitness(t *testing.T) {
 		t.Fatalf("returned tree error=%v end=%d want=%d", tree.RootNode().HasError(), tree.RootNode().EndByte(), len(source))
 	}
 	requireWorkCountAttributionSum(t, counts)
+	requireAttributionTreeDigest(t, "retry_go_query_kotlin", tree, baselineDigest)
+	logWorkCountConvergenceReceipt(t, "retry_go_query_kotlin", counts)
 }
 
 func TestDiagnosticWorkCountAttemptAttributionStraightLRControl(t *testing.T) {
 	source := loadWorkCountAttributionFixture(t, straightLRFixturePath, straightLRFixtureBytes, straightLRFixtureSHA256)
+	baselineDigest := attributionBaselineTreeDigest(t, source)
 	counts, tree := parseWithDiagnosticWorkCount(t, source)
 	defer tree.Release()
 
@@ -59,6 +64,35 @@ func TestDiagnosticWorkCountAttemptAttributionStraightLRControl(t *testing.T) {
 		t.Fatalf("straight-LR identity: max_stacks=%d multi_stack_iterations=%d", runtime.MaxStacksSeen, runtime.MultiStackIterations)
 	}
 	requireWorkCountAttributionSum(t, counts)
+	requireAttributionTreeDigest(t, "straight_lr_control", tree, baselineDigest)
+	logWorkCountConvergenceReceipt(t, "straight_lr_control", counts)
+}
+
+func attributionBaselineTreeDigest(t *testing.T, source []byte) string {
+	t.Helper()
+	lang := grammars.GoLanguage()
+	baseline, err := gotreesitter.NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer baseline.Release()
+	baselineInspection, err := benchfixtures.InspectGoTree(baseline.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return baselineInspection.SHA256
+}
+
+func requireAttributionTreeDigest(t *testing.T, label string, observed *gotreesitter.Tree, baselineDigest string) {
+	t.Helper()
+	observedInspection, err := benchfixtures.InspectGoTree(observed.RootNode(), grammars.GoLanguage())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observedInspection.SHA256 != baselineDigest {
+		t.Fatalf("%s diagnostic digest=%s baseline=%s", label, observedInspection.SHA256, baselineDigest)
+	}
+	t.Logf("deep_tree_receipt fixture=%s format=%s sha256=%s", label, benchfixtures.DeepTreeDigestVersion, observedInspection.SHA256)
 }
 
 func loadWorkCountAttributionFixture(t *testing.T, path string, wantBytes int, wantSHA string) []byte {

--- a/work_count_child_common_test.go
+++ b/work_count_child_common_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 const (
-	workCountFixtureID       = "query_compile"
-	workCountSourcePathEnv   = "GTS_WORK_COUNT_SOURCE"
-	workCountResultPathEnv   = "GTS_WORK_COUNT_RESULT"
-	workCountGoChildSchema   = "gts-work-count-go-child/v3"
-	workCountAdmissionEngine = "go-production-glr-untagged"
-	workCountTaggedEngine    = "go-production-glr-tagged-diagnostic"
+	workCountFixtureID           = "query_compile"
+	workCountSourcePathEnv       = "GTS_WORK_COUNT_SOURCE"
+	workCountResultPathEnv       = "GTS_WORK_COUNT_RESULT"
+	workCountGoChildSchema       = "gts-work-count-go-child/v3"
+	workCountTaggedGoChildSchema = "gts-work-count-go-child/v4"
+	workCountAdmissionEngine     = "go-production-glr-untagged"
+	workCountTaggedEngine        = "go-production-glr-tagged-diagnostic"
 )
 
 type workCountGoChildResult struct {

--- a/work_count_child_test.go
+++ b/work_count_child_test.go
@@ -53,6 +53,7 @@ func TestDiagnosticWorkCountChild(t *testing.T) {
 		t.Fatalf("selected tree census: %v", err)
 	}
 	base.Engine = workCountTaggedEngine
+	base.Schema = workCountTaggedGoChildSchema
 	result := workCountTaggedChildResult{workCountGoChildResult: base, Counters: counts}
 	if err := writeWorkCountChildResult(result); err != nil {
 		t.Fatal(err)

--- a/work_count_convergence.go
+++ b/work_count_convergence.go
@@ -1,0 +1,948 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	workCountConvergenceCapability      = "go_only_detailed_convergence"
+	workCountConvergenceMaxEvents       = 256
+	workCountConvergenceMaxPackedPaths  = maxStacksPerMergeKey + 1
+	workCountConvergencePathParseBudget = 16 * 1024
+	workCountConvergencePathWalkBudget  = 256
+	workCountConvergencePathDepthBudget = 128
+)
+
+var workCountConvergencePhases = [...]string{
+	workCountConvergencePhaseReduceWindowSelect,
+	workCountConvergencePhasePostReducePrimary,
+	workCountConvergencePhasePostReducePending,
+	workCountConvergencePhaseBoundaryGSS,
+	workCountConvergencePhaseBoundaryEquivalence,
+	workCountConvergencePhaseBoundaryCull,
+	workCountConvergencePhasePendingWork,
+	workCountConvergencePhaseFinalExpand,
+	workCountConvergencePhaseFinalSelect,
+	workCountConvergencePhaseTerminalAccept,
+}
+
+var workCountConvergenceOutcomes = [...]string{
+	workCountConvergenceOutcomeCandidate,
+	workCountConvergenceOutcomePacked,
+	workCountConvergenceOutcomeRejected,
+	workCountConvergenceOutcomePendingQueued,
+	workCountConvergenceOutcomePendingDrained,
+	workCountConvergenceOutcomePendingDiscarded,
+	workCountConvergenceOutcomeAcceptedHead,
+	workCountConvergenceOutcomePackedRootEmitted,
+	workCountConvergenceOutcomeMutationPartial,
+	workCountConvergenceOutcomeCapHit,
+	workCountConvergenceOutcomeObservationUnknown,
+	workCountConvergenceOutcomeSelected,
+}
+
+var workCountConvergenceRejectReasons = [...]string{
+	workCountConvergenceReasonStatus,
+	workCountConvergenceReasonScore,
+	workCountConvergenceReasonShifted,
+	workCountConvergenceReasonErrorCost,
+	workCountConvergenceReasonNotGSS,
+	workCountConvergenceReasonNotClean,
+	workCountConvergenceReasonDistinctShape,
+	workCountConvergenceReasonPreflight,
+	workCountConvergenceReasonCull,
+}
+
+// DiagnosticWorkCountConvergence is a bounded Go-only convergence ledger.
+// It is additive to the gts-work-count/v2 Go/static-C counter vector; static C
+// does not emit comparable events.
+type DiagnosticWorkCountConvergence struct {
+	Capability            string `json:"capability"`
+	MaxEvents             uint16 `json:"max_events"`
+	MaxPackedPathCount    uint16 `json:"max_packed_path_count"`
+	EventsSeen            uint64 `json:"events_seen"`
+	EventTruncated        bool   `json:"event_truncated"`
+	ArithmeticOverflow    bool   `json:"arithmetic_overflow"`
+	VocabularyViolation   bool   `json:"vocabulary_violation"`
+	SnapshotCountCapped   bool   `json:"snapshot_count_capped"`
+	SnapshotCountUnknown  bool   `json:"snapshot_count_unknown"`
+	PathWalkWorkBudget    uint32 `json:"path_walk_work_budget"`
+	PathWalkWorkUsed      uint32 `json:"path_walk_work_used"`
+	PathWalkWorkExhausted bool   `json:"path_walk_work_exhausted"`
+
+	Events       []DiagnosticWorkCountConvergenceEvent `json:"events"`
+	FirstRejects []DiagnosticWorkCountConvergenceEvent `json:"first_rejects"`
+	Aggregates   DiagnosticWorkCountConvergenceTotals  `json:"aggregates"`
+}
+
+type DiagnosticWorkCountConvergenceTotals struct {
+	Phases     DiagnosticWorkCountConvergencePhaseTotals   `json:"phases"`
+	Outcomes   DiagnosticWorkCountConvergenceOutcomeTotals `json:"outcomes"`
+	Rejections DiagnosticWorkCountConvergenceRejectTotals  `json:"rejections"`
+
+	CandidateCountBeforeTotal uint64 `json:"candidate_count_before_total"`
+	CandidateCountAfterTotal  uint64 `json:"candidate_count_after_total"`
+	LinksBeforeTotal          uint64 `json:"links_before_total"`
+	LinksAfterTotal           uint64 `json:"links_after_total"`
+	PathsBeforeTotal          uint64 `json:"packed_paths_before_total"`
+	PathsAfterTotal           uint64 `json:"packed_paths_after_total"`
+
+	MutationPartial uint64 `json:"mutation_partial"`
+	CapHits         uint64 `json:"cap_hits"`
+	AcceptedHeads   uint64 `json:"accepted_heads"`
+	PackedRoots     uint64 `json:"packed_roots_emitted"`
+}
+
+type DiagnosticWorkCountConvergencePhaseTotals struct {
+	ReduceWindowSelect  uint64 `json:"reduce_window_select"`
+	PostReducePrimary   uint64 `json:"post_reduce_primary"`
+	PostReducePending   uint64 `json:"post_reduce_pending"`
+	BoundaryGSS         uint64 `json:"boundary_gss"`
+	BoundaryEquivalence uint64 `json:"boundary_equivalence"`
+	BoundaryCull        uint64 `json:"boundary_cull"`
+	PendingWork         uint64 `json:"pending_work"`
+	FinalExpand         uint64 `json:"final_expand"`
+	FinalSelect         uint64 `json:"final_select"`
+	TerminalAccept      uint64 `json:"terminal_accept"`
+}
+
+type DiagnosticWorkCountConvergenceOutcomeTotals struct {
+	Candidate          uint64 `json:"candidate"`
+	Packed             uint64 `json:"packed"`
+	Rejected           uint64 `json:"rejected"`
+	PendingQueued      uint64 `json:"pending_queued"`
+	PendingDrained     uint64 `json:"pending_drained"`
+	PendingDiscarded   uint64 `json:"pending_discarded"`
+	AcceptedHead       uint64 `json:"accepted_head"`
+	PackedRoot         uint64 `json:"packed_root_emitted"`
+	MutationPartial    uint64 `json:"mutation_partial"`
+	CapHit             uint64 `json:"cap_hit"`
+	ObservationUnknown uint64 `json:"observation_unknown"`
+	Selected           uint64 `json:"selected"`
+}
+
+type DiagnosticWorkCountConvergenceRejectTotals struct {
+	Status        uint64 `json:"status"`
+	Score         uint64 `json:"score"`
+	Shifted       uint64 `json:"shifted"`
+	ErrorCost     uint64 `json:"error_cost"`
+	NotGSS        uint64 `json:"not_gss"`
+	NotClean      uint64 `json:"not_clean"`
+	DistinctShape uint64 `json:"distinct_shape"`
+	Preflight     uint64 `json:"preflight"`
+	Cull          uint64 `json:"cull"`
+}
+
+type DiagnosticWorkCountConvergenceEvent struct {
+	Sequence   uint64 `json:"sequence"`
+	Attempt    uint32 `json:"attempt"`
+	Iteration  uint64 `json:"iteration"`
+	DecisionID uint32 `json:"decision_id"`
+
+	LookaheadSymbol      uint32 `json:"lookahead_symbol"`
+	LookaheadStartByte   uint32 `json:"lookahead_start_byte"`
+	LookaheadEndByte     uint32 `json:"lookahead_end_byte"`
+	LookaheadPresent     bool   `json:"lookahead_present"`
+	LookaheadNoLookahead bool   `json:"lookahead_no_lookahead"`
+	LookaheadExternal    bool   `json:"lookahead_external"`
+
+	ElectionScannerComparable        bool   `json:"election_scanner_comparable"`
+	ElectionScannerCheckpointPresent bool   `json:"election_scanner_checkpoint_present"`
+	ElectionScannerCheckpointHash    uint64 `json:"election_scanner_checkpoint_hash"`
+
+	Phase        string `json:"phase"`
+	Outcome      string `json:"outcome"`
+	RejectReason string `json:"reject_reason,omitempty"`
+	Detail       string `json:"detail,omitempty"`
+
+	Target    DiagnosticWorkCountConvergenceHead `json:"target"`
+	Candidate DiagnosticWorkCountConvergenceHead `json:"candidate"`
+
+	CandidateCountBefore uint32 `json:"candidate_count_before"`
+	CandidateCountAfter  uint32 `json:"candidate_count_after"`
+	LinksBefore          uint16 `json:"links_before"`
+	LinksAfter           uint16 `json:"links_after"`
+	PathsBefore          uint16 `json:"packed_paths_before"`
+	PathsAfter           uint16 `json:"packed_paths_after"`
+
+	MutationPartial bool `json:"mutation_partial"`
+	CapHit          bool `json:"cap_hit"`
+	SnapshotCapped  bool `json:"snapshot_capped"`
+	SnapshotUnknown bool `json:"snapshot_unknown"`
+}
+
+type DiagnosticWorkCountConvergenceHead struct {
+	State               uint32 `json:"state"`
+	Byte                uint32 `json:"byte"`
+	Status              string `json:"status"`
+	HasError            bool   `json:"has_error"`
+	Recovering          bool   `json:"recovering"`
+	Shifted             bool   `json:"shifted"`
+	Score               int64  `json:"score"`
+	BranchOrder         uint64 `json:"branch_order"`
+	Depth               uint32 `json:"depth"`
+	Dead                bool   `json:"dead"`
+	Accepted            bool   `json:"accepted"`
+	Paused              bool   `json:"paused"`
+	NodeBaseline        uint32 `json:"node_baseline"`
+	ErrorCost           uint32 `json:"error_cost"`
+	ErrorCostComparable bool   `json:"error_cost_comparable"`
+	HasGSS              bool   `json:"has_gss"`
+	LinkCount           uint16 `json:"link_count"`
+	LinkCountCapped     bool   `json:"link_count_capped"`
+	HeadContentHash     uint64 `json:"head_content_hash"`
+	PredecessorHash     uint64 `json:"predecessor_content_hash"`
+}
+
+type workCountConvergenceDecisionKey struct {
+	iteration         uint64
+	target            *glrStack
+	candidate         *glrStack
+	candidateBranch   uint64
+	candidateHeadHash uint64
+	candidateState    StateID
+	candidateByte     uint32
+	candidateScore    int
+}
+
+const workCountConvergenceDecisionSlots = workCountConvergenceMaxEvents
+
+var activeWorkCountConvergence struct {
+	attempt           uint32
+	iteration         uint64
+	lookahead         Token
+	lookaheadPresent  bool
+	nextDecision      uint32
+	pathWorkRemaining uint32
+	decisionKeys      [workCountConvergenceDecisionSlots]workCountConvergenceDecisionKey
+	decisionIDs       [workCountConvergenceDecisionSlots]uint32
+	decisionCursor    uint16
+	mutationEpoch     uint64
+	firstReject       [len(workCountConvergenceRejectReasons)]bool
+}
+
+func workCountBeginConvergence(c *DiagnosticWorkCount) {
+	activeWorkCountConvergence = struct {
+		attempt           uint32
+		iteration         uint64
+		lookahead         Token
+		lookaheadPresent  bool
+		nextDecision      uint32
+		pathWorkRemaining uint32
+		decisionKeys      [workCountConvergenceDecisionSlots]workCountConvergenceDecisionKey
+		decisionIDs       [workCountConvergenceDecisionSlots]uint32
+		decisionCursor    uint16
+		mutationEpoch     uint64
+		firstReject       [len(workCountConvergenceRejectReasons)]bool
+	}{}
+	if c == nil {
+		return
+	}
+	c.Convergence.Capability = workCountConvergenceCapability
+	c.Convergence.MaxEvents = workCountConvergenceMaxEvents
+	c.Convergence.MaxPackedPathCount = workCountConvergenceMaxPackedPaths
+	c.Convergence.PathWalkWorkBudget = workCountConvergencePathParseBudget
+	activeWorkCountConvergence.pathWorkRemaining = workCountConvergencePathParseBudget
+}
+
+func workCountResetConvergenceAttempt(index uint32) {
+	activeWorkCountConvergence.attempt = index
+	activeWorkCountConvergence.iteration = 0
+	activeWorkCountConvergence.lookahead = Token{}
+	activeWorkCountConvergence.lookaheadPresent = false
+	activeWorkCountConvergence.nextDecision = 0
+	activeWorkCountConvergence.decisionKeys = [workCountConvergenceDecisionSlots]workCountConvergenceDecisionKey{}
+	activeWorkCountConvergence.decisionIDs = [workCountConvergenceDecisionSlots]uint32{}
+	activeWorkCountConvergence.decisionCursor = 0
+}
+
+func workCountEndConvergence() {
+	activeWorkCountConvergence = struct {
+		attempt           uint32
+		iteration         uint64
+		lookahead         Token
+		lookaheadPresent  bool
+		nextDecision      uint32
+		pathWorkRemaining uint32
+		decisionKeys      [workCountConvergenceDecisionSlots]workCountConvergenceDecisionKey
+		decisionIDs       [workCountConvergenceDecisionSlots]uint32
+		decisionCursor    uint16
+		mutationEpoch     uint64
+		firstReject       [len(workCountConvergenceRejectReasons)]bool
+	}{}
+}
+
+func workCountSetConvergenceIteration(iteration int) {
+	if iteration < 0 {
+		workCountConvergenceVocabularyViolation()
+		return
+	}
+	activeWorkCountConvergence.iteration = uint64(iteration)
+}
+
+func workCountConvergenceActive() bool {
+	return activeDiagnosticWorkCount != nil
+}
+
+func workCountSetConvergenceLookahead(tok Token) {
+	activeWorkCountConvergence.lookahead = tok
+	activeWorkCountConvergence.lookaheadPresent = true
+}
+
+func workCountConvergenceShapeOf(stack *glrStack) workCountConvergenceShape {
+	if stack == nil {
+		return workCountConvergenceShape{}
+	}
+	if stack.gss.head == nil {
+		return workCountConvergenceShape{PackedPaths: 1}
+	}
+	links, linksCapped := workCountBoundedLinkCount(stack.gss.head.linkCount())
+	shape := workCountConvergenceShape{Links: links, LinkCountCapped: linksCapped}
+	paths, capped, cycle, budgetHit := workCountCountPackedPaths(stack.gss.head, workCountConvergenceMaxPackedPaths)
+	shape.PackedPaths = paths
+	shape.PathCountCapped = capped
+	shape.PathCountUnknown = budgetHit || cycle
+	shape.CycleSeen = cycle
+	return shape
+}
+
+func workCountCountPackedPaths(head *gssNode, limit uint16) (uint16, bool, bool, bool) {
+	if limit == 0 || limit > workCountConvergenceMaxPackedPaths {
+		limit = workCountConvergenceMaxPackedPaths
+	}
+	if activeWorkCountConvergence.pathWorkRemaining == 0 {
+		if c := activeDiagnosticWorkCount; c != nil {
+			c.Convergence.PathWalkWorkExhausted = true
+		}
+		return limit, false, false, true
+	}
+	visiting := make(map[*gssNode]bool)
+	capped := false
+	cycle := false
+	budgetHit := false
+	workRemaining := uint32(workCountConvergencePathWalkBudget)
+	if activeWorkCountConvergence.pathWorkRemaining < workRemaining {
+		workRemaining = activeWorkCountConvergence.pathWorkRemaining
+	}
+	var count func(*gssNode, int) uint16
+	count = func(node *gssNode, depth int) uint16 {
+		if node == nil {
+			return 1
+		}
+		if depth >= workCountConvergencePathDepthBudget || workRemaining == 0 {
+			budgetHit = true
+			if c := activeDiagnosticWorkCount; c != nil {
+				c.Convergence.PathWalkWorkExhausted = true
+			}
+			return limit
+		}
+		workRemaining--
+		activeWorkCountConvergence.pathWorkRemaining--
+		if c := activeDiagnosticWorkCount; c != nil {
+			c.Convergence.PathWalkWorkUsed++
+		}
+		if visiting[node] {
+			cycle = true
+			return 0
+		}
+		visiting[node] = true
+		var total uint16
+		for i, links := 0, node.linkCount(); i < links; i++ {
+			prev, _ := node.link(i)
+			value := count(prev, depth+1)
+			if value >= limit || total >= limit-value {
+				total = limit
+				if !budgetHit {
+					capped = true
+				}
+				break
+			}
+			total += value
+		}
+		delete(visiting, node)
+		return total
+	}
+	return count(head, 0), capped, cycle, budgetHit
+}
+
+// workCountConvergencePackedResultExpansion measures a pre-expansion source.
+// capHit is true only when the bounded walk proves at least limit+1 paths.
+func workCountConvergencePackedResultExpansion(stack *glrStack, limit int) (emitted int, capHit, unknown bool) {
+	if stack == nil || stack.gss.head == nil || limit <= 0 {
+		return 0, false, false
+	}
+	want := limit + 1
+	if want > workCountConvergenceMaxPackedPaths {
+		want = workCountConvergenceMaxPackedPaths
+	}
+	paths, _, cycle, budgetHit := workCountCountPackedPaths(stack.gss.head, uint16(want))
+	if cycle || budgetHit {
+		return 0, false, true
+	}
+	emitted = int(paths)
+	if emitted > limit {
+		emitted = limit
+		capHit = true
+	}
+	return emitted, capHit, false
+}
+
+func workCountRecordPairCandidate(p *Parser, phase, detail string, target, candidate *glrStack) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(target)
+	workCountRecordConvergence(p, phase, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, detail, target, candidate, 2, 2, shape, shape, false, false)
+}
+
+func workCountRecordGSSReject(p *Parser, phase, reason, detail string, target, candidate *glrStack) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(target)
+	workCountRecordConvergence(p, phase, workCountConvergenceOutcomeRejected, reason, detail, target, candidate, 2, 2, shape, shape, false, false)
+}
+
+func workCountRecordGSSScoreShiftReject(p *Parser, phase string, target, candidate *glrStack) {
+	if !workCountConvergenceActive() || target == nil || candidate == nil {
+		return
+	}
+	if target.score != candidate.score {
+		workCountRecordGSSReject(p, phase, workCountConvergenceReasonScore, "GSS merge score differs", target, candidate)
+		return
+	}
+	if target.shifted != candidate.shifted {
+		workCountRecordGSSReject(p, phase, workCountConvergenceReasonShifted, "GSS merge shifted status differs", target, candidate)
+	}
+}
+
+func workCountRecordGSSCleanReject(p *Parser, phase string, target, candidate *glrStack, clean bool) {
+	if clean || !workCountConvergenceActive() {
+		return
+	}
+	workCountRecordGSSReject(p, phase, workCountConvergenceReasonNotClean, "GSS merge requires clean zero-error paths", target, candidate)
+}
+
+func workCountGSSMutationEpoch() uint64 {
+	return activeWorkCountConvergence.mutationEpoch
+}
+
+func workCountRecordGSSMutation() {
+	if !workCountConvergenceActive() {
+		return
+	}
+	if activeWorkCountConvergence.mutationEpoch == math.MaxUint64 {
+		activeDiagnosticWorkCount.Convergence.ArithmeticOverflow = true
+		activeDiagnosticWorkCount.Overflow = true
+		return
+	}
+	activeWorkCountConvergence.mutationEpoch++
+}
+
+// workCountMergeGSSObserved performs the production merge in both build
+// variants. The tagged variant additionally records its bounded before/after
+// shape without making core call sites own diagnostic assembly.
+func workCountMergeGSSObserved(p *Parser, scratch *glrMergeScratch, phase, detail string, target, candidate *glrStack) bool {
+	if !workCountConvergenceActive() {
+		return gssMainMergeWithScratch(scratch, target, candidate)
+	}
+	before := workCountConvergenceShapeOf(target)
+	mutationBefore := workCountGSSMutationEpoch()
+	merged := gssMainMergeWithScratch(scratch, target, candidate)
+	workCountRecordGSSMergeResult(p, phase, detail, target, candidate, before, mutationBefore, merged)
+	return merged
+}
+
+func workCountRecordGSSMergeResult(p *Parser, phase, detail string, target, candidate *glrStack, before workCountConvergenceShape, mutationBefore uint64, merged bool) {
+	mutated := workCountGSSMutationEpoch() != mutationBefore
+	after := workCountConvergenceShapeOf(target)
+	outcome := workCountConvergenceOutcomePacked
+	reason := workCountConvergenceReasonNone
+	detailSuffix := " packed candidate"
+	partial := !merged && mutated
+	if !merged {
+		outcome = workCountConvergenceOutcomeRejected
+		reason = workCountConvergenceReasonPreflight
+		detailSuffix = " preflight declined candidate"
+		if partial {
+			outcome = workCountConvergenceOutcomeMutationPartial
+			reason = workCountConvergenceReasonNone
+			detailSuffix = " mutation changed shape without absorbing every link"
+		}
+	}
+	eventDetail := ""
+	if workCountConvergenceRetainsDetail(reason) {
+		eventDetail = detail + detailSuffix
+	}
+	afterCount := 2
+	if merged {
+		afterCount = 1
+	}
+	workCountRecordConvergence(p, phase, outcome, reason, eventDetail, target, candidate, 2, afterCount, before, after, partial, false)
+}
+
+func workCountConvergenceRetainsDetail(reason string) bool {
+	c := activeDiagnosticWorkCount
+	if c == nil {
+		return false
+	}
+	if len(c.Convergence.Events) < workCountConvergenceMaxEvents {
+		return true
+	}
+	reasonIndex := workCountConvergenceRejectReasonIndex(reason)
+	return reasonIndex >= 0 && !activeWorkCountConvergence.firstReject[reasonIndex]
+}
+
+func workCountRecordPostReduceCandidate(p *Parser, phase, detail string, target, candidate *glrStack, rejectReason string) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(target)
+	workCountRecordConvergence(p, phase, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, detail, target, candidate, 2, 2, shape, shape, false, false)
+	if rejectReason != workCountConvergenceReasonNone {
+		workCountRecordConvergence(p, phase, workCountConvergenceOutcomeRejected, rejectReason, detail, target, candidate, 2, 2, shape, shape, false, false)
+	}
+}
+
+func workCountRecordPendingQueued(p *Parser, target, candidate *glrStack, before, after int, detail string) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(candidate)
+	workCountRecordConvergence(p, workCountConvergencePhasePendingWork, workCountConvergenceOutcomePendingQueued, workCountConvergenceReasonNone, detail, target, candidate, before, after, shape, shape, false, false)
+}
+
+func workCountRecordAcceptedHead(p *Parser, stack *glrStack, detail string) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(stack)
+	workCountRecordConvergence(p, workCountConvergencePhaseTerminalAccept, workCountConvergenceOutcomeAcceptedHead, workCountConvergenceReasonNone, detail, stack, nil, 1, 1, shape, shape, false, false)
+}
+
+func workCountRecordReduceWindow(p *Parser, stack *glrStack, paths, work, budget int, capped bool) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	outcome := workCountConvergenceOutcomeCandidate
+	if capped {
+		outcome = workCountConvergenceOutcomeCapHit
+	}
+	shape := workCountConvergenceShapeOf(stack)
+	detail := ""
+	if activeDiagnosticWorkCount != nil && len(activeDiagnosticWorkCount.Convergence.Events) < workCountConvergenceMaxEvents {
+		detail = fmt.Sprintf("reduce-window paths=%d work=%d budget=%d", paths, work, budget)
+	}
+	workCountRecordConvergence(p, workCountConvergencePhaseReduceWindowSelect, outcome, workCountConvergenceReasonNone, detail, stack, nil, 1, paths, shape, shape, false, capped)
+}
+
+func workCountRecordPendingTransition(p *Parser, stack *glrStack, before, after int, outcome, detail string) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(stack)
+	workCountRecordConvergence(p, workCountConvergencePhasePendingWork, outcome, workCountConvergenceReasonNone, detail, stack, nil, before, after, shape, shape, false, false)
+}
+
+func workCountRecordFinalPendingDiscards(p *Parser, pending, frontier []glrStack) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	if len(pending) != 0 {
+		workCountRecordPendingTransition(p, &pending[0], len(pending), 0, workCountConvergenceOutcomePendingDiscarded, "finalization excludes undrained post-reduce candidates")
+	}
+	if len(frontier) != 0 {
+		workCountRecordPendingTransition(p, &frontier[0], len(frontier), 0, workCountConvergenceOutcomePendingDiscarded, "finalization excludes undrained frontier candidates")
+	}
+}
+
+func workCountRecordBoundaryCull(p *Parser, before, after int) {
+	if !workCountConvergenceActive() || before <= after {
+		return
+	}
+	workCountRecordConvergence(p, workCountConvergencePhaseBoundaryCull, workCountConvergenceOutcomeRejected, workCountConvergenceReasonCull, "global stack cap removed boundary candidates", nil, nil, before, after, workCountConvergenceShape{}, workCountConvergenceShape{}, false, true)
+}
+
+func workCountRecordFinalExpand(p *Parser, stack *glrStack, emitted int, capHit, unknown bool) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	links, linksCapped := uint16(0), false
+	if stack != nil && stack.gss.head != nil {
+		links, linksCapped = workCountBoundedLinkCount(stack.gss.head.linkCount())
+	}
+	before := workCountConvergenceShape{Links: links, LinkCountCapped: linksCapped, PackedPaths: uint16(emitted), PathCountUnknown: unknown}
+	after := before
+	if unknown {
+		workCountRecordConvergence(p, workCountConvergencePhaseFinalExpand, workCountConvergenceOutcomeObservationUnknown, workCountConvergenceReasonNone, "packed result root expansion count unknown", stack, nil, 1, 0, before, after, false, false)
+		return
+	}
+	if capHit {
+		before.PackedPaths++
+		before.PathCountCapped = true
+	}
+	after.PackedPaths = uint16(emitted)
+	after.PathCountCapped = false
+	workCountRecordConvergence(p, workCountConvergencePhaseFinalExpand, workCountConvergenceOutcomePackedRootEmitted, workCountConvergenceReasonNone, fmt.Sprintf("packed result root emitted %d alternatives", emitted), stack, nil, 1, emitted, before, after, false, capHit)
+}
+
+func workCountRecordFinalExpansions(p *Parser, stacks []glrStack) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	for i := range stacks {
+		stack := &stacks[i]
+		if len(stack.entries) > 0 || stack.gss.head == nil || !gssInlineChainHasPackedLinks(stack.gss.head) {
+			continue
+		}
+		emitted, capHit, unknown := workCountConvergencePackedResultExpansion(stack, maxStacksPerMergeKey)
+		workCountRecordFinalExpand(p, stack, emitted, capHit, unknown)
+	}
+}
+
+func workCountRecordFinalSelect(p *Parser, stacks []glrStack, selected *glrStack) {
+	if !workCountConvergenceActive() {
+		return
+	}
+	shape := workCountConvergenceShapeOf(selected)
+	workCountRecordConvergence(p, workCountConvergencePhaseFinalSelect, workCountConvergenceOutcomeSelected, workCountConvergenceReasonNone, "result head selected", selected, nil, len(stacks), 1, shape, shape, false, false)
+}
+
+// workCountTryPostReduceMergeObserved performs the real post-reduce merge in
+// both build variants and records a successful pack only in tagged runs.
+func workCountTryPostReduceMergeObserved(p *Parser, phase, detail string, target, candidate *glrStack) bool {
+	if reason := postReduceForkMergePreflight(target, candidate); reason != workCountConvergenceReasonNone {
+		workCountRecordGSSReject(p, phase, reason, "post-reduce merge preflight rejected candidate", target, candidate)
+		return false
+	}
+	return tryGSSMainMergeForParserPhase(p, target, candidate, phase, false)
+}
+
+func workCountRecordConvergence(p *Parser, phase, outcome, reason, detail string, target, candidate *glrStack, candidateCountBefore, candidateCountAfter int, before, after workCountConvergenceShape, partialMutation, capHit bool) {
+	c := activeDiagnosticWorkCount
+	if c == nil {
+		return
+	}
+	if !workCountConvergenceStringIn(phase, workCountConvergencePhases[:]) ||
+		!workCountConvergenceStringIn(outcome, workCountConvergenceOutcomes[:]) ||
+		(reason != workCountConvergenceReasonNone && !workCountConvergenceStringIn(reason, workCountConvergenceRejectReasons[:])) ||
+		(outcome == workCountConvergenceOutcomeRejected) != (reason != workCountConvergenceReasonNone) {
+		workCountConvergenceVocabularyViolation()
+		return
+	}
+	if activeWorkCountConvergence.attempt == 0 {
+		workCountConvergenceVocabularyViolation()
+		return
+	}
+
+	sequence := c.Convergence.EventsSeen
+	workCountConvergenceSaturatingAdd(c, &c.Convergence.EventsSeen, 1)
+	if sequence != math.MaxUint64 {
+		sequence++
+	}
+	candidateCountBeforeValue, candidateCountBeforeCapped := workCountBoundedUint32(candidateCountBefore)
+	candidateCountAfterValue, candidateCountAfterCapped := workCountBoundedUint32(candidateCountAfter)
+	snapshotCapped := before.PathCountCapped || after.PathCountCapped || before.LinkCountCapped || after.LinkCountCapped || candidateCountBeforeCapped || candidateCountAfterCapped
+	snapshotUnknown := before.PathCountUnknown || after.PathCountUnknown || before.CycleSeen || after.CycleSeen
+	if snapshotCapped {
+		c.Convergence.SnapshotCountCapped = true
+	}
+	if snapshotUnknown {
+		c.Convergence.SnapshotCountUnknown = true
+	}
+
+	reasonIndex := workCountConvergenceRejectReasonIndex(reason)
+	retainChronological := len(c.Convergence.Events) < workCountConvergenceMaxEvents
+	retainFirstReject := reasonIndex >= 0 && !activeWorkCountConvergence.firstReject[reasonIndex]
+	event := DiagnosticWorkCountConvergenceEvent{
+		Sequence: sequence, Attempt: activeWorkCountConvergence.attempt,
+		Iteration: activeWorkCountConvergence.iteration,
+		Phase:     phase, Outcome: outcome, RejectReason: reason, Detail: detail,
+		CandidateCountBefore: candidateCountBeforeValue, CandidateCountAfter: candidateCountAfterValue,
+		LinksBefore: before.Links, LinksAfter: after.Links,
+		PathsBefore: before.PackedPaths, PathsAfter: after.PackedPaths,
+		MutationPartial: partialMutation, CapHit: capHit,
+		SnapshotCapped: snapshotCapped, SnapshotUnknown: snapshotUnknown,
+	}
+	if retainChronological || retainFirstReject {
+		event.DecisionID = workCountConvergenceDecisionID(c, target, candidate)
+		event.LookaheadSymbol = uint32(activeWorkCountConvergence.lookahead.Symbol)
+		event.LookaheadStartByte = activeWorkCountConvergence.lookahead.StartByte
+		event.LookaheadEndByte = activeWorkCountConvergence.lookahead.EndByte
+		event.LookaheadPresent = activeWorkCountConvergence.lookaheadPresent
+		event.LookaheadNoLookahead = activeWorkCountConvergence.lookahead.NoLookahead
+		event.LookaheadExternal = activeWorkCountConvergence.lookahead.ExternalScannerToken
+		if p != nil {
+			event.ElectionScannerComparable = p.language == nil || p.language.ExternalScanner == nil || p.currentExternalTokenCheckpointValid
+			if p.currentExternalTokenCheckpointValid {
+				event.ElectionScannerCheckpointPresent = true
+				event.ElectionScannerCheckpointHash = workCountCheckpointHash(p.currentExternalTokenCheckpoint)
+			}
+		}
+		event.Target = workCountConvergenceHead(p, target)
+		event.Candidate = workCountConvergenceHead(p, candidate)
+		if event.Target.LinkCountCapped || event.Candidate.LinkCountCapped {
+			event.SnapshotCapped = true
+			c.Convergence.SnapshotCountCapped = true
+		}
+	}
+	workCountConvergenceAddAggregates(c, event)
+	if retainChronological {
+		c.Convergence.Events = append(c.Convergence.Events, event)
+	} else {
+		c.Convergence.EventTruncated = true
+	}
+	if retainFirstReject {
+		activeWorkCountConvergence.firstReject[reasonIndex] = true
+		c.Convergence.FirstRejects = append(c.Convergence.FirstRejects, event)
+	}
+}
+
+func workCountConvergenceDecisionID(c *DiagnosticWorkCount, target, candidate *glrStack) uint32 {
+	if target == nil && candidate == nil {
+		return 0
+	}
+	key := workCountConvergenceDecisionKey{iteration: activeWorkCountConvergence.iteration, target: target, candidate: candidate}
+	if candidate != nil {
+		key.candidateBranch = candidate.branchOrder
+		key.candidateByte = candidate.byteOffset
+		key.candidateScore = candidate.score
+		if candidate.depth() > 0 {
+			key.candidateState = candidate.top().state
+		}
+		if candidate.gss.head != nil {
+			key.candidateHeadHash = candidate.gss.head.hash
+		}
+	}
+	for index, id := range activeWorkCountConvergence.decisionIDs {
+		if id != 0 && activeWorkCountConvergence.decisionKeys[index] == key {
+			return id
+		}
+	}
+	if activeWorkCountConvergence.nextDecision == math.MaxUint32 {
+		c.Convergence.ArithmeticOverflow = true
+		c.Overflow = true
+		return math.MaxUint32
+	}
+	activeWorkCountConvergence.nextDecision++
+	slot := int(activeWorkCountConvergence.decisionCursor) % workCountConvergenceDecisionSlots
+	activeWorkCountConvergence.decisionCursor++
+	activeWorkCountConvergence.decisionKeys[slot] = key
+	activeWorkCountConvergence.decisionIDs[slot] = activeWorkCountConvergence.nextDecision
+	return activeWorkCountConvergence.nextDecision
+}
+
+func workCountConvergenceHead(p *Parser, stack *glrStack) DiagnosticWorkCountConvergenceHead {
+	if stack == nil {
+		return DiagnosticWorkCountConvergenceHead{Status: "absent"}
+	}
+	head := DiagnosticWorkCountConvergenceHead{
+		Byte: stack.byteOffset, Status: "live", HasError: stack.cEverErrored,
+		Recovering: stack.cPaused || stack.cRec != nil || stack.cRecoverMissingGroup != nil,
+		Shifted:    stack.shifted, Score: int64(stack.score), BranchOrder: stack.branchOrder,
+		Dead: stack.dead, Accepted: stack.accepted, Paused: stack.cPaused,
+		NodeBaseline: stack.cNodeBaseline,
+	}
+	depth, _ := workCountBoundedUint32(stack.depth())
+	head.Depth = depth
+	if p != nil {
+		head.ErrorCost = cStackErrorCostForMerge(p.language, stack)
+		head.ErrorCostComparable = true
+	}
+	if stack.dead {
+		head.Status = "dead"
+	} else if stack.accepted {
+		head.Status = "accepted"
+	} else if stack.cPaused {
+		head.Status = "paused"
+	}
+	if stack.depth() > 0 {
+		head.State = uint32(stack.top().state)
+	}
+	if stack.gss.head != nil {
+		head.HasGSS = true
+		head.LinkCount, head.LinkCountCapped = workCountBoundedLinkCount(stack.gss.head.linkCount())
+		head.HeadContentHash = stack.gss.head.hash
+		if stack.gss.head.prev != nil {
+			head.PredecessorHash = stack.gss.head.prev.hash
+		}
+	}
+	return head
+}
+
+func workCountCheckpointHash(checkpoint externalScannerCheckpoint) uint64 {
+	const (
+		offset = uint64(1469598103934665603)
+		prime  = uint64(1099511628211)
+	)
+	hash := offset
+	for _, value := range checkpoint.start {
+		hash ^= uint64(value)
+		hash *= prime
+	}
+	hash ^= 0xff
+	hash *= prime
+	for _, value := range checkpoint.end {
+		hash ^= uint64(value)
+		hash *= prime
+	}
+	return hash
+}
+
+func workCountConvergenceAddAggregates(c *DiagnosticWorkCount, event DiagnosticWorkCountConvergenceEvent) {
+	totals := &c.Convergence.Aggregates
+	workCountConvergenceIncrementPhase(c, &totals.Phases, event.Phase)
+	workCountConvergenceIncrementOutcome(c, &totals.Outcomes, event.Outcome)
+	workCountConvergenceIncrementReject(c, &totals.Rejections, event.RejectReason)
+	workCountConvergenceSaturatingAdd(c, &totals.CandidateCountBeforeTotal, uint64(event.CandidateCountBefore))
+	workCountConvergenceSaturatingAdd(c, &totals.CandidateCountAfterTotal, uint64(event.CandidateCountAfter))
+	workCountConvergenceSaturatingAdd(c, &totals.LinksBeforeTotal, uint64(event.LinksBefore))
+	workCountConvergenceSaturatingAdd(c, &totals.LinksAfterTotal, uint64(event.LinksAfter))
+	workCountConvergenceSaturatingAdd(c, &totals.PathsBeforeTotal, uint64(event.PathsBefore))
+	workCountConvergenceSaturatingAdd(c, &totals.PathsAfterTotal, uint64(event.PathsAfter))
+	if event.MutationPartial {
+		workCountConvergenceSaturatingAdd(c, &totals.MutationPartial, 1)
+	}
+	if event.CapHit {
+		workCountConvergenceSaturatingAdd(c, &totals.CapHits, 1)
+	}
+	if event.Outcome == workCountConvergenceOutcomeAcceptedHead {
+		workCountConvergenceSaturatingAdd(c, &totals.AcceptedHeads, 1)
+	}
+	if event.Outcome == workCountConvergenceOutcomePackedRootEmitted {
+		workCountConvergenceSaturatingAdd(c, &totals.PackedRoots, uint64(event.PathsAfter))
+	}
+}
+
+func workCountConvergenceIncrementPhase(c *DiagnosticWorkCount, totals *DiagnosticWorkCountConvergencePhaseTotals, value string) {
+	var slot *uint64
+	switch value {
+	case workCountConvergencePhaseReduceWindowSelect:
+		slot = &totals.ReduceWindowSelect
+	case workCountConvergencePhasePostReducePrimary:
+		slot = &totals.PostReducePrimary
+	case workCountConvergencePhasePostReducePending:
+		slot = &totals.PostReducePending
+	case workCountConvergencePhaseBoundaryGSS:
+		slot = &totals.BoundaryGSS
+	case workCountConvergencePhaseBoundaryEquivalence:
+		slot = &totals.BoundaryEquivalence
+	case workCountConvergencePhaseBoundaryCull:
+		slot = &totals.BoundaryCull
+	case workCountConvergencePhasePendingWork:
+		slot = &totals.PendingWork
+	case workCountConvergencePhaseFinalExpand:
+		slot = &totals.FinalExpand
+	case workCountConvergencePhaseFinalSelect:
+		slot = &totals.FinalSelect
+	case workCountConvergencePhaseTerminalAccept:
+		slot = &totals.TerminalAccept
+	}
+	workCountConvergenceSaturatingAdd(c, slot, 1)
+}
+
+func workCountConvergenceIncrementOutcome(c *DiagnosticWorkCount, totals *DiagnosticWorkCountConvergenceOutcomeTotals, value string) {
+	var slot *uint64
+	switch value {
+	case workCountConvergenceOutcomeCandidate:
+		slot = &totals.Candidate
+	case workCountConvergenceOutcomePacked:
+		slot = &totals.Packed
+	case workCountConvergenceOutcomeRejected:
+		slot = &totals.Rejected
+	case workCountConvergenceOutcomePendingQueued:
+		slot = &totals.PendingQueued
+	case workCountConvergenceOutcomePendingDrained:
+		slot = &totals.PendingDrained
+	case workCountConvergenceOutcomePendingDiscarded:
+		slot = &totals.PendingDiscarded
+	case workCountConvergenceOutcomeAcceptedHead:
+		slot = &totals.AcceptedHead
+	case workCountConvergenceOutcomePackedRootEmitted:
+		slot = &totals.PackedRoot
+	case workCountConvergenceOutcomeMutationPartial:
+		slot = &totals.MutationPartial
+	case workCountConvergenceOutcomeCapHit:
+		slot = &totals.CapHit
+	case workCountConvergenceOutcomeObservationUnknown:
+		slot = &totals.ObservationUnknown
+	case workCountConvergenceOutcomeSelected:
+		slot = &totals.Selected
+	}
+	workCountConvergenceSaturatingAdd(c, slot, 1)
+}
+
+func workCountConvergenceIncrementReject(c *DiagnosticWorkCount, totals *DiagnosticWorkCountConvergenceRejectTotals, value string) {
+	var slot *uint64
+	switch value {
+	case workCountConvergenceReasonStatus:
+		slot = &totals.Status
+	case workCountConvergenceReasonScore:
+		slot = &totals.Score
+	case workCountConvergenceReasonShifted:
+		slot = &totals.Shifted
+	case workCountConvergenceReasonErrorCost:
+		slot = &totals.ErrorCost
+	case workCountConvergenceReasonNotGSS:
+		slot = &totals.NotGSS
+	case workCountConvergenceReasonNotClean:
+		slot = &totals.NotClean
+	case workCountConvergenceReasonDistinctShape:
+		slot = &totals.DistinctShape
+	case workCountConvergenceReasonPreflight:
+		slot = &totals.Preflight
+	case workCountConvergenceReasonCull:
+		slot = &totals.Cull
+	}
+	workCountConvergenceSaturatingAdd(c, slot, 1)
+}
+
+func workCountConvergenceSaturatingAdd(c *DiagnosticWorkCount, slot *uint64, delta uint64) {
+	if c == nil || slot == nil || delta == 0 {
+		return
+	}
+	if math.MaxUint64-*slot < delta {
+		*slot = math.MaxUint64
+		c.Convergence.ArithmeticOverflow = true
+		c.Overflow = true
+		return
+	}
+	*slot += delta
+}
+
+func workCountConvergenceVocabularyViolation() {
+	if c := activeDiagnosticWorkCount; c != nil {
+		c.Convergence.VocabularyViolation = true
+	}
+}
+
+func workCountConvergenceStringIn(value string, values []string) bool {
+	for _, candidate := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func workCountConvergenceRejectReasonIndex(reason string) int {
+	for index, candidate := range workCountConvergenceRejectReasons {
+		if reason == candidate {
+			return index
+		}
+	}
+	return -1
+}
+
+func workCountBoundedUint32(value int) (uint32, bool) {
+	if value < 0 {
+		return 0, true
+	}
+	if uint64(value) > math.MaxUint32 {
+		return math.MaxUint32, true
+	}
+	return uint32(value), false
+}

--- a/work_count_convergence_contract.go
+++ b/work_count_convergence_contract.go
@@ -1,0 +1,67 @@
+package gotreesitter
+
+// Closed convergence vocabulary is shared by production seam call sites and
+// the gts_workcount recorder. Keeping it in one build-independent file avoids
+// drift without putting diagnostic implementation into production builds.
+const (
+	workCountConvergencePhaseReduceWindowSelect  = "reduce_window_select"
+	workCountConvergencePhasePostReducePrimary   = "post_reduce_primary"
+	workCountConvergencePhasePostReducePending   = "post_reduce_pending"
+	workCountConvergencePhaseBoundaryGSS         = "boundary_gss"
+	workCountConvergencePhaseBoundaryEquivalence = "boundary_equivalence"
+	workCountConvergencePhaseBoundaryCull        = "boundary_cull"
+	workCountConvergencePhasePendingWork         = "pending_work"
+	workCountConvergencePhaseFinalExpand         = "final_expand"
+	workCountConvergencePhaseFinalSelect         = "final_select"
+	workCountConvergencePhaseTerminalAccept      = "terminal_accept"
+
+	workCountConvergenceOutcomeCandidate          = "candidate"
+	workCountConvergenceOutcomePacked             = "packed"
+	workCountConvergenceOutcomeRejected           = "rejected"
+	workCountConvergenceOutcomePendingQueued      = "pending_queued"
+	workCountConvergenceOutcomePendingDrained     = "pending_drained"
+	workCountConvergenceOutcomePendingDiscarded   = "pending_discarded"
+	workCountConvergenceOutcomeAcceptedHead       = "accepted_head"
+	workCountConvergenceOutcomePackedRootEmitted  = "packed_root_emitted"
+	workCountConvergenceOutcomeMutationPartial    = "mutation_partial"
+	workCountConvergenceOutcomeCapHit             = "cap_hit"
+	workCountConvergenceOutcomeObservationUnknown = "observation_unknown"
+	workCountConvergenceOutcomeSelected           = "selected"
+
+	workCountConvergenceReasonNone          = ""
+	workCountConvergenceReasonStatus        = "status"
+	workCountConvergenceReasonScore         = "score"
+	workCountConvergenceReasonShifted       = "shifted"
+	workCountConvergenceReasonErrorCost     = "error_cost"
+	workCountConvergenceReasonNotGSS        = "not_gss"
+	workCountConvergenceReasonNotClean      = "not_clean"
+	workCountConvergenceReasonDistinctShape = "distinct_shape"
+	workCountConvergenceReasonPreflight     = "preflight"
+	workCountConvergenceReasonCull          = "cull"
+)
+
+type workCountConvergenceShape struct {
+	Links            uint16
+	LinkCountCapped  bool
+	PackedPaths      uint16
+	PathCountCapped  bool
+	PathCountUnknown bool
+	CycleSeen        bool
+}
+
+func workCountParserFromMergeScratch(scratch *glrMergeScratch) *Parser {
+	if scratch == nil {
+		return nil
+	}
+	return scratch.parser
+}
+
+func workCountBoundedLinkCount(value int) (uint16, bool) {
+	if value < 0 {
+		return 0, true
+	}
+	if uint64(value) > uint64(^uint16(0)) {
+		return ^uint16(0), true
+	}
+	return uint16(value), false
+}

--- a/work_count_convergence_observer_test.go
+++ b/work_count_convergence_observer_test.go
@@ -1,0 +1,79 @@
+//go:build gts_workcount
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestDiagnosticWorkCountConvergenceDoesNotChangeCanonicalTree(t *testing.T) {
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := fixtures[0]
+	if fixture.Fixture.ID != "query_compile" {
+		t.Fatalf("first canonical fixture=%q want query_compile", fixture.Fixture.ID)
+	}
+	lang := grammars.GoLanguage()
+	parser := gotreesitter.NewParser(lang)
+	baseline, err := parser.Parse(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer baseline.Release()
+	baselineInspection, err := benchfixtures.InspectGoTree(baseline.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotreesitter.BeginDiagnosticWorkCount()
+	observed, err := parser.Parse(fixture.Source)
+	counts := gotreesitter.EndDiagnosticWorkCount()
+	if err != nil {
+		if observed != nil {
+			observed.Release()
+		}
+		t.Fatal(err)
+	}
+	defer observed.Release()
+	observedInspection, err := benchfixtures.InspectGoTree(observed.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baselineInspection.SHA256 != fixture.Fixture.DeepTreeSHA256 || observedInspection.SHA256 != baselineInspection.SHA256 {
+		t.Fatalf("deep digest baseline=%s observed=%s frozen=%s", baselineInspection.SHA256, observedInspection.SHA256, fixture.Fixture.DeepTreeSHA256)
+	}
+	t.Logf("deep_tree_receipt fixture=query_compile format=%s sha256=%s", benchfixtures.DeepTreeDigestVersion, observedInspection.SHA256)
+	if counts.Convergence.EventsSeen == 0 || counts.Convergence.VocabularyViolation || counts.Convergence.ArithmeticOverflow {
+		t.Fatalf("convergence ledger events=%d vocabulary=%v overflow=%v", counts.Convergence.EventsSeen, counts.Convergence.VocabularyViolation, counts.Convergence.ArithmeticOverflow)
+	}
+	logWorkCountConvergenceReceipt(t, "query_compile", counts)
+}
+
+func logWorkCountConvergenceReceipt(t *testing.T, label string, counts gotreesitter.DiagnosticWorkCount) {
+	t.Helper()
+	c := counts.Convergence
+	t.Logf(
+		"convergence_receipt fixture=%s attempts=%d events_seen=%d events_retained=%d truncated=%v first_rejects=%d phases=%+v outcomes=%+v reasons=%+v cap_hits=%d snapshot_capped=%v snapshot_unknown=%v path_work=%d/%d path_exhausted=%v",
+		label,
+		len(counts.Attempts),
+		c.EventsSeen,
+		len(c.Events),
+		c.EventTruncated,
+		len(c.FirstRejects),
+		c.Aggregates.Phases,
+		c.Aggregates.Outcomes,
+		c.Aggregates.Rejections,
+		c.Aggregates.CapHits,
+		c.SnapshotCountCapped,
+		c.SnapshotCountUnknown,
+		c.PathWalkWorkUsed,
+		c.PathWalkWorkBudget,
+		c.PathWalkWorkExhausted,
+	)
+}

--- a/work_count_convergence_test.go
+++ b/work_count_convergence_test.go
@@ -1,0 +1,708 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"testing"
+)
+
+const workCountContractV2SHA256 = "a438ddae8eaaf8c343faeb5efccdc15035911ee4bf7d22e627091d123a9ff46d"
+const workCountContractV3SHA256 = "a4f28e92b4916277c56683b39a9e8da7358a9c8dd824b08f7f2be470e0daadde"
+
+func TestWorkCountContractV3Stability(t *testing.T) {
+	v2 := readWorkCountContract(t, "cgo_harness/work_count/contract_v2.json")
+	if got := fmt.Sprintf("%x", sha256.Sum256(v2)); got != workCountContractV2SHA256 {
+		t.Fatalf("contract v2 changed: sha256=%s want=%s", got, workCountContractV2SHA256)
+	}
+	v3 := readWorkCountContract(t, "cgo_harness/work_count/contract_v3.json")
+	if got := fmt.Sprintf("%x", sha256.Sum256(v3)); got != workCountContractV3SHA256 {
+		t.Fatalf("contract v3 changed: sha256=%s want=%s", got, workCountContractV3SHA256)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(v3, &raw); err != nil {
+		t.Fatal(err)
+	}
+	wantTop := []string{"schema", "counter_contract", "scope", "historical_compatibility", "direct", "terminal", "proxy", "derived", "attempt_attribution", "convergence_frontier", "admission"}
+	if len(raw) != len(wantTop) {
+		t.Fatalf("contract v3 top-level keys=%d want=%d", len(raw), len(wantTop))
+	}
+	for _, key := range wantTop {
+		if _, ok := raw[key]; !ok {
+			t.Fatalf("contract v3 missing %q", key)
+		}
+	}
+	requireExactJSONKeys(t, "historical_compatibility", raw["historical_compatibility"], []string{
+		"v2_manifest", "direct_and_proxy_counter_semantics", "detailed_convergence",
+	})
+	requireExactJSONKeys(t, "convergence_frontier", raw["convergence_frontier"], []string{
+		"status", "capability", "static_c_emits_comparable_events", "max_events", "max_packed_path_count",
+		"packed_path_parse_work_budget", "packed_path_per_walk_work_budget", "packed_path_depth_budget",
+		"record_first_reject_per_reason", "first_reject_semantics", "decision_ids", "head_status_priority", "phases", "phase_outcomes", "outcomes", "reject_reasons", "identity",
+		"snapshots", "event_invariants", "candidate_count_units", "bounded_trace", "separate_integrity_signals",
+		"include_saturating_aggregates", "terminal_counters", "interpretation",
+	})
+	requireExactJSONKeys(t, "admission", raw["admission"], []string{
+		"digest_format", "fixture", "require_uninstrumented_go_static_c_digest_match_first",
+		"require_instrumented_digest_match", "require_full_span", "require_clean_root", "require_no_overflow",
+		"require_exact_fields", "require_ordinary_untagged_go_child_first", "require_clean_git_source_for_authoritative_receipt",
+		"require_private_content_addressed_go_source_snapshot", "require_private_c_input_snapshot",
+		"sanitize_go_and_parser_environment", "atomic_receipt_publish",
+	})
+	var admission map[string]any
+	if err := json.Unmarshal(raw["admission"], &admission); err != nil {
+		t.Fatal(err)
+	}
+	if admission["digest_format"] != "gts-deep-tree-v1" || admission["fixture"] != "query_compile" {
+		t.Fatalf("admission identity=%v/%v", admission["digest_format"], admission["fixture"])
+	}
+	for key, value := range admission {
+		if len(key) > len("require_") && key[:len("require_")] == "require_" && value != true {
+			t.Fatalf("admission %s=%v want true", key, value)
+		}
+	}
+	for _, key := range []string{"sanitize_go_and_parser_environment", "atomic_receipt_publish"} {
+		if admission[key] != true {
+			t.Fatalf("admission %s=%v want true", key, admission[key])
+		}
+	}
+	var manifest struct {
+		Schema          string `json:"schema"`
+		CounterContract string `json:"counter_contract"`
+		Historical      struct {
+			Detailed string `json:"detailed_convergence"`
+		} `json:"historical_compatibility"`
+		Convergence struct {
+			Status               string              `json:"status"`
+			Capability           string              `json:"capability"`
+			StaticCComparable    bool                `json:"static_c_emits_comparable_events"`
+			MaxEvents            int                 `json:"max_events"`
+			MaxPackedPaths       int                 `json:"max_packed_path_count"`
+			ParseWorkBudget      int                 `json:"packed_path_parse_work_budget"`
+			PerWalkWorkBudget    int                 `json:"packed_path_per_walk_work_budget"`
+			DepthBudget          int                 `json:"packed_path_depth_budget"`
+			RecordFirstReject    bool                `json:"record_first_reject_per_reason"`
+			FirstRejectSemantics string              `json:"first_reject_semantics"`
+			HeadStatusPriority   []string            `json:"head_status_priority"`
+			Phases               []string            `json:"phases"`
+			PhaseOutcomes        map[string][]string `json:"phase_outcomes"`
+			Outcomes             []string            `json:"outcomes"`
+			Reasons              []string            `json:"reject_reasons"`
+			Identity             []string            `json:"identity"`
+			BoundedTrace         string              `json:"bounded_trace"`
+			CandidateCountUnits  string              `json:"candidate_count_units"`
+		} `json:"convergence_frontier"`
+	}
+	if err := json.Unmarshal(v3, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Schema != "gts-work-count-contract/v3" || manifest.CounterContract != DiagnosticWorkCountContract {
+		t.Fatalf("contract identity=%q/%q", manifest.Schema, manifest.CounterContract)
+	}
+	convergence := manifest.Convergence
+	if convergence.Status != "implemented" || convergence.Capability != workCountConvergenceCapability || convergence.StaticCComparable {
+		t.Fatalf("convergence capability=%q/%q static_c=%v", convergence.Status, convergence.Capability, convergence.StaticCComparable)
+	}
+	if convergence.MaxEvents != workCountConvergenceMaxEvents || convergence.MaxPackedPaths != workCountConvergenceMaxPackedPaths ||
+		convergence.ParseWorkBudget != workCountConvergencePathParseBudget || convergence.PerWalkWorkBudget != workCountConvergencePathWalkBudget ||
+		convergence.DepthBudget != workCountConvergencePathDepthBudget || !convergence.RecordFirstReject {
+		t.Fatalf("convergence bounds=%+v", convergence)
+	}
+	requireStringSliceEqual(t, "phases", convergence.Phases, workCountConvergencePhases[:])
+	requireStringSliceEqual(t, "outcomes", convergence.Outcomes, workCountConvergenceOutcomes[:])
+	requireStringSliceEqual(t, "reject reasons", convergence.Reasons, workCountConvergenceRejectReasons[:])
+	wantPhaseOutcomes := map[string][]string{
+		workCountConvergencePhaseReduceWindowSelect:  {workCountConvergenceOutcomeCandidate, workCountConvergenceOutcomeCapHit},
+		workCountConvergencePhasePostReducePrimary:   {workCountConvergenceOutcomeCandidate, workCountConvergenceOutcomePacked, workCountConvergenceOutcomeRejected, workCountConvergenceOutcomeMutationPartial},
+		workCountConvergencePhasePostReducePending:   {workCountConvergenceOutcomeCandidate, workCountConvergenceOutcomePacked, workCountConvergenceOutcomeRejected, workCountConvergenceOutcomeMutationPartial},
+		workCountConvergencePhaseBoundaryGSS:         {workCountConvergenceOutcomeCandidate, workCountConvergenceOutcomePacked, workCountConvergenceOutcomeRejected, workCountConvergenceOutcomeMutationPartial},
+		workCountConvergencePhaseBoundaryEquivalence: {workCountConvergenceOutcomeRejected},
+		workCountConvergencePhaseBoundaryCull:        {workCountConvergenceOutcomeRejected},
+		workCountConvergencePhasePendingWork:         {workCountConvergenceOutcomePendingQueued, workCountConvergenceOutcomePendingDrained, workCountConvergenceOutcomePendingDiscarded},
+		workCountConvergencePhaseFinalExpand:         {workCountConvergenceOutcomePackedRootEmitted, workCountConvergenceOutcomeObservationUnknown},
+		workCountConvergencePhaseFinalSelect:         {workCountConvergenceOutcomeSelected},
+		workCountConvergencePhaseTerminalAccept:      {workCountConvergenceOutcomeAcceptedHead},
+	}
+	if !reflect.DeepEqual(convergence.PhaseOutcomes, wantPhaseOutcomes) {
+		t.Fatalf("phase/outcome matrix=%v want=%v", convergence.PhaseOutcomes, wantPhaseOutcomes)
+	}
+	for _, required := range []string{"decision_id", "lookahead_present", "election_scanner_comparable", "election_scanner_checkpoint_presence_and_hash"} {
+		if !workCountConvergenceStringIn(required, convergence.Identity) {
+			t.Fatalf("contract identity misses %q", required)
+		}
+	}
+	if convergence.BoundedTrace == "" || convergence.CandidateCountUnits == "" || convergence.FirstRejectSemantics == "" || !reflect.DeepEqual(convergence.HeadStatusPriority, []string{"dead", "accepted", "paused", "live"}) || manifest.Historical.Detailed == "" {
+		t.Fatal("v3 compatibility/boundedness prose is empty")
+	}
+}
+
+func TestWorkCountConvergenceRetainsFirstRejectBeyondEventCap(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	for i := 0; i < workCountConvergenceMaxEvents; i++ {
+		workCountSetConvergenceIteration(i)
+		workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	}
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryCull, workCountConvergenceOutcomeRejected, workCountConvergenceReasonCull, "", nil, nil, 1, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	counts := endWorkCountConvergenceAttempt(t, token)
+
+	if len(counts.Convergence.Events) != workCountConvergenceMaxEvents || !counts.Convergence.EventTruncated || counts.Convergence.ArithmeticOverflow {
+		t.Fatalf("event bound=%d truncated=%v overflow=%v", len(counts.Convergence.Events), counts.Convergence.EventTruncated, counts.Convergence.ArithmeticOverflow)
+	}
+	if counts.Convergence.EventsSeen != workCountConvergenceMaxEvents+1 || len(counts.Convergence.FirstRejects) != 1 {
+		t.Fatalf("seen=%d first_rejects=%d", counts.Convergence.EventsSeen, len(counts.Convergence.FirstRejects))
+	}
+	first := counts.Convergence.FirstRejects[0]
+	if first.Sequence != workCountConvergenceMaxEvents+1 || first.RejectReason != workCountConvergenceReasonCull {
+		t.Fatalf("late first reject=%+v", first)
+	}
+}
+
+func TestWorkCountConvergenceSkipsFullSnapshotsBeyondEventCap(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	for i := 0; i < workCountConvergenceMaxEvents; i++ {
+		workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 2, 2, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	}
+	target := newGLRStack(1)
+	candidate := newGLRStack(1)
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", &target, &candidate, 2, 2, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	if activeWorkCountConvergence.nextDecision != 0 {
+		t.Fatalf("post-cap scalar event allocated decision ID %d", activeWorkCountConvergence.nextDecision)
+	}
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryGSS, workCountConvergenceOutcomeRejected, workCountConvergenceReasonStatus, "", &target, &candidate, 2, 2, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if len(counts.Convergence.Events) != workCountConvergenceMaxEvents || len(counts.Convergence.FirstRejects) != 1 {
+		t.Fatalf("retained events=%d first_rejects=%d", len(counts.Convergence.Events), len(counts.Convergence.FirstRejects))
+	}
+	if got := counts.Convergence.FirstRejects[0].DecisionID; got != 1 {
+		t.Fatalf("first-reject decision ID=%d want 1", got)
+	}
+	if counts.Convergence.Aggregates.Outcomes.Candidate != workCountConvergenceMaxEvents+1 || counts.Convergence.Aggregates.Outcomes.Rejected != 1 {
+		t.Fatalf("post-cap scalar aggregates=%+v", counts.Convergence.Aggregates.Outcomes)
+	}
+}
+
+func TestWorkCountConvergenceBoundsMergeDetailBeyondEventCap(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	for i := 0; i < workCountConvergenceMaxEvents; i++ {
+		workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	}
+	if workCountConvergenceRetainsDetail(workCountConvergenceReasonNone) {
+		t.Fatal("post-cap non-rejection traffic retained formatted detail")
+	}
+	if !workCountConvergenceRetainsDetail(workCountConvergenceReasonPreflight) {
+		t.Fatal("first post-cap rejection did not retain detail")
+	}
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryGSS, workCountConvergenceOutcomeRejected, workCountConvergenceReasonPreflight, "first preflight rejection", nil, nil, 2, 2, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	if workCountConvergenceRetainsDetail(workCountConvergenceReasonPreflight) {
+		t.Fatal("repeated post-cap rejection retained formatted detail")
+	}
+	_ = endWorkCountConvergenceAttempt(t, token)
+}
+
+func TestStopFrontierSummaryDoesNotRecordConvergenceEvents(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	parser := &Parser{language: &Language{}}
+	stacks := []glrStack{newGLRStack(1), newGLRStack(1)}
+	_ = parser.stopFrontierSameHeaderSummary(stacks)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if counts.Convergence.EventsSeen != 0 || len(counts.Convergence.Events) != 0 {
+		t.Fatalf("stop-frontier diagnostic polluted convergence ledger: seen=%d retained=%d", counts.Convergence.EventsSeen, len(counts.Convergence.Events))
+	}
+}
+
+func TestWorkCountConvergenceAttemptIDsResetAndCorrelate(t *testing.T) {
+	BeginDiagnosticWorkCount()
+	target := newGLRStack(1)
+	candidate := newGLRStack(1)
+	first := beginWorkCountConvergenceAttemptWithoutBegin(t)
+	for _, outcome := range []string{workCountConvergenceOutcomeCandidate, workCountConvergenceOutcomePacked} {
+		workCountRecordConvergence(nil, workCountConvergencePhasePostReducePrimary, outcome, workCountConvergenceReasonNone, "", &target, &candidate, 2, 1, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	}
+	candidate.branchOrder++
+	workCountRecordConvergence(nil, workCountConvergencePhasePostReducePrimary, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", &target, &candidate, 1, 1, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	finalizeWorkCountConvergenceAttempt(first)
+	second := beginWorkCountConvergenceAttemptWithoutBegin(t)
+	workCountRecordConvergence(nil, workCountConvergencePhasePostReducePrimary, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", &target, &candidate, 1, 1, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	finalizeWorkCountConvergenceAttempt(second)
+	counts := EndDiagnosticWorkCount()
+
+	if got := []uint32{counts.Convergence.Events[0].DecisionID, counts.Convergence.Events[1].DecisionID, counts.Convergence.Events[2].DecisionID, counts.Convergence.Events[3].DecisionID}; !reflect.DeepEqual(got, []uint32{1, 1, 2, 1}) {
+		t.Fatalf("decision IDs=%v want [1 1 2 1]", got)
+	}
+	if counts.Convergence.Events[0].Attempt != 1 || counts.Convergence.Events[3].Attempt != 2 {
+		t.Fatalf("attempt attribution=%d/%d", counts.Convergence.Events[0].Attempt, counts.Convergence.Events[3].Attempt)
+	}
+}
+
+func TestWorkCountConvergenceOverflowIsNotTruncation(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	activeDiagnosticWorkCount.Convergence.Aggregates.Outcomes.Candidate = math.MaxUint64
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if !counts.Overflow || !counts.Convergence.ArithmeticOverflow || counts.Convergence.EventTruncated {
+		t.Fatalf("overflow=%v convergence_overflow=%v truncated=%v", counts.Overflow, counts.Convergence.ArithmeticOverflow, counts.Convergence.EventTruncated)
+	}
+}
+
+func TestWorkCountConvergencePopulationEventHasNoDecisionID(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryCull, workCountConvergenceOutcomeRejected, workCountConvergenceReasonCull, "", nil, nil, 4, 2, workCountConvergenceShape{}, workCountConvergenceShape{}, false, true)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if got := counts.Convergence.Events[0].DecisionID; got != 0 {
+		t.Fatalf("population-only decision ID=%d want 0", got)
+	}
+}
+
+func TestWorkCountConvergenceDistinguishesUnsetAndSyntheticLookahead(t *testing.T) {
+	BeginDiagnosticWorkCount()
+	first := beginWorkCountConvergenceAttemptWithoutBegin(t)
+	workCountSetConvergenceLookahead(Token{NoLookahead: true})
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	finalizeWorkCountConvergenceAttempt(first)
+	second := beginWorkCountConvergenceAttemptWithoutBegin(t)
+	workCountRecordConvergence(nil, workCountConvergencePhaseBoundaryEquivalence, workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	finalizeWorkCountConvergenceAttempt(second)
+	counts := EndDiagnosticWorkCount()
+	synthetic, unset := counts.Convergence.Events[0], counts.Convergence.Events[1]
+	if unset.LookaheadPresent || unset.LookaheadNoLookahead {
+		t.Fatalf("unset lookahead=%+v", unset)
+	}
+	if !synthetic.LookaheadPresent || !synthetic.LookaheadNoLookahead {
+		t.Fatalf("synthetic lookahead=%+v", synthetic)
+	}
+}
+
+func TestWorkCountConvergenceScannerIdentityBelongsToCurrentElection(t *testing.T) {
+	t.Run("ordinary_language", func(t *testing.T) {
+		token := beginWorkCountConvergenceAttempt(t)
+		parser := &Parser{language: &Language{}}
+		workCountRecordConvergence(parser, workCountConvergencePhaseBoundaryCull, workCountConvergenceOutcomeRejected, workCountConvergenceReasonCull, "", nil, nil, 2, 1, workCountConvergenceShape{}, workCountConvergenceShape{}, false, true)
+		event := endWorkCountConvergenceAttempt(t, token).Convergence.Events[0]
+		if !event.ElectionScannerComparable || event.ElectionScannerCheckpointPresent || event.ElectionScannerCheckpointHash != 0 {
+			t.Fatalf("ordinary election scanner identity=%+v", event)
+		}
+	})
+	t.Run("external_checkpoint_present", func(t *testing.T) {
+		token := beginWorkCountConvergenceAttempt(t)
+		checkpoint := externalScannerCheckpoint{start: []byte{1, 2}, end: []byte{3, 4}}
+		parser := &Parser{language: &Language{ExternalScanner: &mockExternalScanner{}}, currentExternalTokenCheckpoint: checkpoint, currentExternalTokenCheckpointValid: true}
+		workCountRecordConvergence(parser, workCountConvergencePhaseBoundaryCull, workCountConvergenceOutcomeRejected, workCountConvergenceReasonCull, "", nil, nil, 2, 1, workCountConvergenceShape{}, workCountConvergenceShape{}, false, true)
+		event := endWorkCountConvergenceAttempt(t, token).Convergence.Events[0]
+		if !event.ElectionScannerComparable || !event.ElectionScannerCheckpointPresent || event.ElectionScannerCheckpointHash != workCountCheckpointHash(checkpoint) {
+			t.Fatalf("checkpoint election scanner identity=%+v", event)
+		}
+	})
+	t.Run("external_checkpoint_absent", func(t *testing.T) {
+		token := beginWorkCountConvergenceAttempt(t)
+		parser := &Parser{language: &Language{ExternalScanner: &mockExternalScanner{}}}
+		workCountRecordConvergence(parser, workCountConvergencePhaseBoundaryCull, workCountConvergenceOutcomeRejected, workCountConvergenceReasonCull, "", nil, nil, 2, 1, workCountConvergenceShape{}, workCountConvergenceShape{}, false, true)
+		event := endWorkCountConvergenceAttempt(t, token).Convergence.Events[0]
+		if event.ElectionScannerComparable || event.ElectionScannerCheckpointPresent || event.ElectionScannerCheckpointHash != 0 {
+			t.Fatalf("absent checkpoint election scanner identity=%+v", event)
+		}
+	})
+}
+
+func TestWorkCountConvergencePendingAndFinalAggregates(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	shape := workCountConvergenceShape{Links: 2, PackedPaths: 3}
+	workCountRecordConvergence(nil, workCountConvergencePhasePendingWork, workCountConvergenceOutcomePendingQueued, workCountConvergenceReasonNone, "", nil, nil, 0, 1, shape, shape, false, false)
+	workCountRecordConvergence(nil, workCountConvergencePhasePendingWork, workCountConvergenceOutcomePendingDiscarded, workCountConvergenceReasonNone, "", nil, nil, 1, 0, shape, shape, false, false)
+	workCountRecordConvergence(nil, workCountConvergencePhaseFinalExpand, workCountConvergenceOutcomePackedRootEmitted, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{PackedPaths: 4}, workCountConvergenceShape{PackedPaths: 3}, false, true)
+	workCountRecordConvergence(nil, workCountConvergencePhaseFinalSelect, workCountConvergenceOutcomeSelected, workCountConvergenceReasonNone, "", nil, nil, 3, 1, shape, shape, false, false)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	totals := counts.Convergence.Aggregates
+	if totals.Outcomes.PendingQueued != 1 || totals.Outcomes.PendingDiscarded != 1 || totals.Outcomes.Selected != 1 || totals.PackedRoots != 3 || totals.CapHits != 1 {
+		t.Fatalf("pending/final totals=%+v", totals)
+	}
+	if totals.CandidateCountBeforeTotal != 4 || totals.CandidateCountAfterTotal != 2 {
+		t.Fatalf("phase-local candidate counts=%d/%d", totals.CandidateCountBeforeTotal, totals.CandidateCountAfterTotal)
+	}
+	if counts.Convergence.VocabularyViolation {
+		t.Fatal("valid pending/final events triggered a vocabulary violation")
+	}
+}
+
+func TestWorkCountConvergencePathWalkIsParseBounded(t *testing.T) {
+	BeginDiagnosticWorkCount()
+	t.Cleanup(func() {
+		activeDiagnosticWorkCount = nil
+		workCountEndConvergence()
+	})
+	activeWorkCountConvergence.pathWorkRemaining = 2
+	stack := glrStack{gss: gssStack{head: &gssNode{prev: &gssNode{prev: &gssNode{}}}}}
+	shape := workCountConvergenceShapeOf(&stack)
+	if !shape.PathCountUnknown || shape.PathCountCapped || activeDiagnosticWorkCount.Convergence.PathWalkWorkUsed != 2 || !activeDiagnosticWorkCount.Convergence.PathWalkWorkExhausted {
+		t.Fatalf("bounded shape=%+v used=%d exhausted=%v", shape, activeDiagnosticWorkCount.Convergence.PathWalkWorkUsed, activeDiagnosticWorkCount.Convergence.PathWalkWorkExhausted)
+	}
+	beforeUsed := activeDiagnosticWorkCount.Convergence.PathWalkWorkUsed
+	_ = workCountConvergenceShapeOf(&stack)
+	if activeDiagnosticWorkCount.Convergence.PathWalkWorkUsed != beforeUsed {
+		t.Fatal("exhausted parse-global path budget performed more work")
+	}
+	activeDiagnosticWorkCount = nil
+	workCountEndConvergence()
+}
+
+func TestWorkCountConvergencePackedExpansionProvesCapHit(t *testing.T) {
+	leaf := &gssNode{}
+	branch := &gssNode{prev: leaf}
+	branch.appendExtraLink(gssMainLink{prev: leaf})
+	head := &gssNode{prev: branch}
+	for i := 0; i < 3; i++ {
+		head.appendExtraLink(gssMainLink{prev: branch})
+	}
+	stack := glrStack{gss: gssStack{head: head}}
+	BeginDiagnosticWorkCount()
+	t.Cleanup(func() {
+		activeDiagnosticWorkCount = nil
+		workCountEndConvergence()
+	})
+	emitted, capHit, unknown := workCountConvergencePackedResultExpansion(&stack, maxStacksPerMergeKey)
+	shape := workCountConvergenceShapeOf(&stack)
+	if emitted != maxStacksPerMergeKey || !capHit || unknown || shape.PackedPaths != workCountConvergenceMaxPackedPaths || !shape.PathCountCapped || shape.PathCountUnknown {
+		t.Fatalf("expansion emitted=%d cap=%v unknown=%v shape=%+v", emitted, capHit, unknown, shape)
+	}
+	activeDiagnosticWorkCount = nil
+	workCountEndConvergence()
+}
+
+func TestWorkCountConvergenceLinkCountDoesNotUsePackedPathCap(t *testing.T) {
+	links, capped := workCountBoundedLinkCount(workCountConvergenceMaxPackedPaths + 2)
+	if links != workCountConvergenceMaxPackedPaths+2 || capped {
+		t.Fatalf("link count=%d capped=%v want=%d,false", links, capped, workCountConvergenceMaxPackedPaths+2)
+	}
+	links, capped = workCountBoundedLinkCount(math.MaxUint16 + 1)
+	if links != math.MaxUint16 || !capped {
+		t.Fatalf("saturated link count=%d capped=%v", links, capped)
+	}
+
+	extraLinks := make([]gssMainLink, 8)
+	headNode := &gssNode{extraLinks: &extraLinks[0], extraLinkCount: 8, extraLinkCap: 8}
+	stack := glrStack{gss: gssStack{head: headNode}}
+	BeginDiagnosticWorkCount()
+	t.Cleanup(func() {
+		activeDiagnosticWorkCount = nil
+		workCountEndConvergence()
+	})
+	shape := workCountConvergenceShapeOf(&stack)
+	head := workCountConvergenceHead(nil, &stack)
+	if shape.Links != 9 || shape.LinkCountCapped || head.LinkCount != 9 || head.LinkCountCapped {
+		t.Fatalf("nine-link integration shape=%+v head=%+v", shape, head)
+	}
+	activeDiagnosticWorkCount = nil
+	workCountEndConvergence()
+}
+
+func TestWorkCountConvergenceNoCullEventWithoutRemoval(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	workCountRecordBoundaryCull(nil, 4, 4)
+	workCountRecordBoundaryCull(nil, 4, 2)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if counts.Convergence.EventsSeen != 1 || len(counts.Convergence.Events) != 1 {
+		t.Fatalf("cull events seen=%d retained=%d", counts.Convergence.EventsSeen, len(counts.Convergence.Events))
+	}
+	event := counts.Convergence.Events[0]
+	if event.RejectReason != workCountConvergenceReasonCull || event.CandidateCountBefore != 4 || event.CandidateCountAfter != 2 || !event.CapHit {
+		t.Fatalf("cull event=%+v", event)
+	}
+}
+
+func TestWorkCountConvergenceUnknownFinalExpansionDoesNotClaimPackedRoot(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	stack := newGLRStack(1)
+	workCountRecordFinalExpand(nil, &stack, 0, false, true)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if len(counts.Convergence.Events) != 1 || counts.Convergence.Events[0].Outcome != workCountConvergenceOutcomeObservationUnknown || !counts.Convergence.Events[0].SnapshotUnknown {
+		t.Fatalf("unknown expansion events=%+v", counts.Convergence.Events)
+	}
+	totals := counts.Convergence.Aggregates
+	if totals.Outcomes.ObservationUnknown != 1 || totals.Outcomes.PackedRoot != 0 || totals.PackedRoots != 0 || totals.CapHits != 0 {
+		t.Fatalf("unknown expansion totals=%+v", totals)
+	}
+}
+
+func TestWorkCountConvergenceFinalPendingDiscardBelongsToOneAttempt(t *testing.T) {
+	BeginDiagnosticWorkCount()
+	first := beginWorkCountConvergenceAttemptWithoutBegin(t)
+	pending := []glrStack{newGLRStack(1)}
+	workCountRecordFinalPendingDiscards(nil, pending, nil)
+	finalizeWorkCountConvergenceAttempt(first)
+	second := beginWorkCountConvergenceAttemptWithoutBegin(t)
+	pending = pending[:0] // parse-attempt reset is cleanup, not a second event.
+	finalizeWorkCountConvergenceAttempt(second)
+	counts := EndDiagnosticWorkCount()
+	if counts.Convergence.Aggregates.Outcomes.PendingDiscarded != 1 || len(counts.Convergence.Events) != 1 || counts.Convergence.Events[0].Attempt != 1 {
+		t.Fatalf("pending discard ownership events=%+v totals=%+v", counts.Convergence.Events, counts.Convergence.Aggregates.Outcomes)
+	}
+}
+
+func TestWorkCountConvergenceDoesNotAttributeInitialStalePending(t *testing.T) {
+	parser := NewParser(buildArithmeticLanguage())
+	parser.pendingForkStacks = []glrStack{newGLRStack(1)}
+	parser.pendingFrontierForkStacks = []glrStack{newGLRStack(1)}
+	BeginDiagnosticWorkCount()
+	tree, err := parser.Parse([]byte("1+2"))
+	counts := EndDiagnosticWorkCount()
+	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	if counts.Convergence.Aggregates.Outcomes.PendingDiscarded != 0 {
+		t.Fatalf("initial stale pending attributed to new attempt: %+v", counts.Convergence.Aggregates.Outcomes)
+	}
+}
+
+func TestWorkCountConvergenceHeadWithParserClaimsReadOnlyErrorCost(t *testing.T) {
+	stack := newGLRStack(1)
+	parser := &Parser{}
+	head := workCountConvergenceHead(parser, &stack)
+	if !head.ErrorCostComparable || head.ErrorCost != 0 {
+		t.Fatalf("head with parser did not claim read-only error cost: %+v", head)
+	}
+}
+
+func TestWorkCountConvergenceHeadStatusUsesDeadAcceptedPausedPriority(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		dead, accepted, paused bool
+		want                   string
+	}{
+		{name: "dead_over_all", dead: true, accepted: true, paused: true, want: "dead"},
+		{name: "accepted_over_paused", accepted: true, paused: true, want: "accepted"},
+		{name: "paused", paused: true, want: "paused"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stack := newGLRStack(1)
+			stack.dead, stack.accepted, stack.cPaused = tc.dead, tc.accepted, tc.paused
+			if got := workCountConvergenceHead(nil, &stack).Status; got != tc.want {
+				t.Fatalf("status=%q want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkCountConvergenceHeadErrorCostIsReadOnly(t *testing.T) {
+	lang := &Language{SymbolMetadata: []SymbolMetadata{{}, {Visible: true}}}
+	missing := &Node{symbol: 1, equivVersion: 1}
+	missing.setMissing(true)
+	headNode := &gssNode{
+		entry: newStackEntryNode(1, missing), depth: 1,
+		aggGen: 77, aggCost: 13, aggVis: 9, aggVisValid: true,
+	}
+	stack := glrStack{gss: gssStack{head: headNode}}
+	sentinel := &gssNode{depth: 99}
+	mergeScratch := &glrMergeScratch{cPrefixPath: []*gssNode{sentinel}}
+	parser := &Parser{
+		language:       lang,
+		mergeScratch:   mergeScratch,
+		cPrefixPath:    []*gssNode{sentinel},
+		cNodeMemoEpoch: 4,
+		cNodeMemoCache: make([]cNodeMemoCacheEntry, 4),
+	}
+	parser.cNodeMemoCache[0] = cNodeMemoCacheEntry{node: 17, epoch: 4, cost: 23, hasCost: true}
+	prefixBefore := append([]*gssNode(nil), parser.cPrefixPath...)
+	mergePrefixBefore := append([]*gssNode(nil), mergeScratch.cPrefixPath...)
+	memoBefore := append([]cNodeMemoCacheEntry(nil), parser.cNodeMemoCache...)
+	aggGen, aggCost, aggVis, aggValid := headNode.aggGen, headNode.aggCost, headNode.aggVis, headNode.aggVisValid
+
+	head := workCountConvergenceHead(parser, &stack)
+	if !head.ErrorCostComparable || head.ErrorCost == 0 {
+		t.Fatalf("read-only head cost=%+v", head)
+	}
+	if headNode.aggGen != aggGen || headNode.aggCost != aggCost || headNode.aggVis != aggVis || headNode.aggVisValid != aggValid {
+		t.Fatalf("head aggregate cache mutated: %+v", headNode)
+	}
+	if !reflect.DeepEqual(parser.cPrefixPath, prefixBefore) || !reflect.DeepEqual(mergeScratch.cPrefixPath, mergePrefixBefore) || !reflect.DeepEqual(parser.cNodeMemoCache, memoBefore) || parser.cNodeMemoEpoch != 4 {
+		t.Fatal("head observation mutated parser prefix or node memo scratch")
+	}
+}
+
+func TestWorkCountConvergenceMutationEpochTracksSemanticGSSWrites(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	node := &gssNode{}
+	base := &gssNode{}
+	entry := stackEntry{state: 1}
+	before := workCountGSSMutationEpoch()
+	setGSSMainLink(node, 0, base, entry)
+	if got := workCountGSSMutationEpoch(); got != before+1 {
+		t.Fatalf("primary set epoch=%d want=%d", got, before+1)
+	}
+	setGSSMainLink(node, 0, base, entry)
+	if got := workCountGSSMutationEpoch(); got != before+1 {
+		t.Fatalf("no-op primary set changed epoch=%d", got)
+	}
+	node.appendExtraLink(gssMainLink{prev: base, entry: entry})
+	if got := workCountGSSMutationEpoch(); got != before+2 {
+		t.Fatalf("append-grow epoch=%d want=%d", got, before+2)
+	}
+	setGSSMainLink(node, 1, &gssNode{}, stackEntry{state: 2})
+	if got := workCountGSSMutationEpoch(); got != before+3 {
+		t.Fatalf("extra set epoch=%d want=%d", got, before+3)
+	}
+	node.appendExtraLink(gssMainLink{prev: base, entry: stackEntry{state: 3}})
+	if got := workCountGSSMutationEpoch(); got != before+4 {
+		t.Fatalf("append-reuse epoch=%d want=%d", got, before+4)
+	}
+	_ = endWorkCountConvergenceAttempt(t, token)
+}
+
+func TestWorkCountConvergenceFailedMergeAfterSemanticMutationIsPartial(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	target, candidate := newGLRStack(1), newGLRStack(1)
+	before := workCountConvergenceShapeOf(&target)
+	epoch := workCountGSSMutationEpoch()
+	workCountRecordGSSMutation()
+	workCountRecordGSSMergeResult(nil, workCountConvergencePhaseBoundaryGSS, "test merge", &target, &candidate, before, epoch, false)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	event := counts.Convergence.Events[0]
+	if event.Outcome != workCountConvergenceOutcomeMutationPartial || !event.MutationPartial || event.RejectReason != "" {
+		t.Fatalf("partial mutation event=%+v", event)
+	}
+}
+
+func TestWorkCountConvergencePostReduceLifecycleStaysInOnePhase(t *testing.T) {
+	t.Run("early_reject", func(t *testing.T) {
+		token := beginWorkCountConvergenceAttempt(t)
+		target, candidate := newGLRStack(1), newGLRStack(1)
+		target.accepted = true
+		reason := postReduceForkMergePreflight(&target, &candidate)
+		workCountRecordPostReduceCandidate(nil, workCountConvergencePhasePostReducePrimary, "candidate", &target, &candidate, reason)
+		counts := endWorkCountConvergenceAttempt(t, token)
+		if len(counts.Convergence.Events) != 2 || counts.Convergence.Events[0].Outcome != workCountConvergenceOutcomeCandidate || counts.Convergence.Events[1].Outcome != workCountConvergenceOutcomeRejected {
+			t.Fatalf("early lifecycle=%+v", counts.Convergence.Events)
+		}
+		for _, event := range counts.Convergence.Events {
+			if event.Phase != workCountConvergencePhasePostReducePrimary {
+				t.Fatalf("early lifecycle leaked phase=%q", event.Phase)
+			}
+		}
+		if counts.Convergence.Aggregates.Phases.BoundaryGSS != 0 {
+			t.Fatalf("early lifecycle emitted boundary GSS event")
+		}
+	})
+	t.Run("success", func(t *testing.T) {
+		token := beginWorkCountConvergenceAttempt(t)
+		var scratch gssScratch
+		base := scratch.allocNode(stackEntry{state: 1}, nil, 1)
+		build := func() glrStack {
+			return glrStack{gss: gssStack{head: scratch.allocNode(stackEntry{state: 2}, base, 2)}, byteOffset: 3}
+		}
+		target, candidate := build(), build()
+		workCountRecordPostReduceCandidate(nil, workCountConvergencePhasePostReducePending, "candidate", &target, &candidate, workCountConvergenceReasonNone)
+		if !workCountTryPostReduceMergeObserved(nil, workCountConvergencePhasePostReducePending, "merge", &target, &candidate) {
+			t.Fatal("post-reduce merge declined")
+		}
+		counts := endWorkCountConvergenceAttempt(t, token)
+		if len(counts.Convergence.Events) != 2 || counts.Convergence.Events[0].Outcome != workCountConvergenceOutcomeCandidate || counts.Convergence.Events[1].Outcome != workCountConvergenceOutcomePacked {
+			t.Fatalf("success lifecycle=%+v", counts.Convergence.Events)
+		}
+		for _, event := range counts.Convergence.Events {
+			if event.Phase != workCountConvergencePhasePostReducePending {
+				t.Fatalf("success lifecycle leaked phase=%q", event.Phase)
+			}
+		}
+		if counts.Convergence.Aggregates.Phases.BoundaryGSS != 0 {
+			t.Fatalf("success lifecycle emitted boundary GSS event")
+		}
+	})
+}
+
+func TestWorkCountConvergenceClosedVocabularyAndPointerFreeJSON(t *testing.T) {
+	token := beginWorkCountConvergenceAttempt(t)
+	workCountRecordConvergence(nil, "not_a_phase", workCountConvergenceOutcomeCandidate, workCountConvergenceReasonNone, "", nil, nil, 0, 0, workCountConvergenceShape{}, workCountConvergenceShape{}, false, false)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if !counts.Convergence.VocabularyViolation || counts.Convergence.EventsSeen != 0 {
+		t.Fatalf("vocabulary violation=%v events=%d", counts.Convergence.VocabularyViolation, counts.Convergence.EventsSeen)
+	}
+	assertNoPointerKinds(t, reflect.TypeOf(DiagnosticWorkCountConvergenceEvent{}))
+	data, err := json.Marshal(counts.Convergence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte("0x")) || bytes.Contains(data, []byte("pointer")) || bytes.Contains(data, []byte("address")) {
+		t.Fatalf("serialized convergence ledger exposes pointer material: %s", data)
+	}
+}
+
+func beginWorkCountConvergenceAttempt(t *testing.T) workCountAttemptToken {
+	t.Helper()
+	BeginDiagnosticWorkCount()
+	return beginWorkCountConvergenceAttemptWithoutBegin(t)
+}
+
+func beginWorkCountConvergenceAttemptWithoutBegin(t *testing.T) workCountAttemptToken {
+	t.Helper()
+	token := workCountBeginParseAttempt(6, 1024, 6)
+	if token == 0 {
+		t.Fatal("zero attempt token")
+	}
+	workCountResolveParseAttempt(token, 6, false, 6, 6, 1024, 1024)
+	return token
+}
+
+func finalizeWorkCountConvergenceAttempt(token workCountAttemptToken) {
+	workCountBeginFinalizeParseAttempt(token)
+	workCountEndFinalizeParseAttempt(token, ParseStopAccepted, nil)
+}
+
+func endWorkCountConvergenceAttempt(t *testing.T, token workCountAttemptToken) DiagnosticWorkCount {
+	t.Helper()
+	finalizeWorkCountConvergenceAttempt(token)
+	return EndDiagnosticWorkCount()
+}
+
+func readWorkCountContract(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func requireStringSliceEqual(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s=%v want=%v", label, got, want)
+	}
+}
+
+func requireExactJSONKeys(t *testing.T, label string, data json.RawMessage, want []string) {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("decode %s: %v", label, err)
+	}
+	if len(raw) != len(want) {
+		t.Fatalf("%s keys=%d want=%d: %v", label, len(raw), len(want), raw)
+	}
+	for _, key := range want {
+		if _, ok := raw[key]; !ok {
+			t.Fatalf("%s missing key %q", label, key)
+		}
+	}
+}
+
+func assertNoPointerKinds(t *testing.T, typ reflect.Type) {
+	t.Helper()
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.UnsafePointer, reflect.Uintptr:
+		t.Fatalf("serialized type %s contains pointer kind %s", typ, typ.Kind())
+	case reflect.Array, reflect.Slice:
+		assertNoPointerKinds(t, typ.Elem())
+	case reflect.Struct:
+		for i := 0; i < typ.NumField(); i++ {
+			assertNoPointerKinds(t, typ.Field(i).Type)
+		}
+	}
+}

--- a/work_count_diagnostic.go
+++ b/work_count_diagnostic.go
@@ -13,8 +13,9 @@ type DiagnosticWorkCount struct {
 	Overflow bool   `json:"overflow"`
 	DiagnosticWorkCountValues
 
-	Attempts       []DiagnosticWorkCountAttempt `json:"attempts"`
-	OutsideAttempt DiagnosticWorkCountValues    `json:"outside_attempt"`
+	Attempts       []DiagnosticWorkCountAttempt   `json:"attempts"`
+	OutsideAttempt DiagnosticWorkCountValues      `json:"outside_attempt"`
+	Convergence    DiagnosticWorkCountConvergence `json:"convergence_frontier"`
 }
 
 // DiagnosticWorkCountValues is one additive counter vector. The aggregate
@@ -98,6 +99,7 @@ func BeginDiagnosticWorkCount() {
 		panic("gotreesitter: diagnostic work-count parse already active")
 	}
 	activeDiagnosticWorkCount = &DiagnosticWorkCount{Contract: DiagnosticWorkCountContract}
+	workCountBeginConvergence(activeDiagnosticWorkCount)
 	pendingDiagnosticWorkCountAttempt = struct {
 		logicalRung    string
 		operationCause string
@@ -117,6 +119,7 @@ func EndDiagnosticWorkCount() DiagnosticWorkCount {
 	}
 	activeDiagnosticWorkCount.reconcileOutsideAttempt()
 	out := *activeDiagnosticWorkCount
+	workCountEndConvergence()
 	activeDiagnosticWorkCount = nil
 	return out
 }
@@ -219,6 +222,7 @@ func workCountBeginParseAttempt(maxStacks, maxNodes, maxMergePerKey int) workCou
 		RequestedMaxMergePerKey: maxMergePerKey,
 		entrySnapshot:           workCountValuesSnapshot(c),
 	})
+	workCountResetConvergenceAttempt(index)
 	return workCountAttemptToken(index)
 }
 

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -32,3 +32,38 @@ func workCountRecordLeafConstruction()                                          
 func workCountRecordParentConstruction()                                                {}
 func workCountRecordPendingParentConstruction()                                         {}
 func workCountRecordNoTreeParentConstruction()                                          {}
+func workCountSetConvergenceIteration(int)                                              {}
+func workCountConvergenceActive() bool                                                  { return false }
+func workCountSetConvergenceLookahead(Token)                                            {}
+func workCountConvergenceShapeOf(*glrStack) workCountConvergenceShape {
+	return workCountConvergenceShape{}
+}
+func workCountRecordConvergence(*Parser, string, string, string, string, *glrStack, *glrStack, int, int, workCountConvergenceShape, workCountConvergenceShape, bool, bool) {
+}
+func workCountConvergencePackedResultExpansion(*glrStack, int) (int, bool, bool) {
+	return 0, false, false
+}
+func workCountRecordPairCandidate(*Parser, string, string, *glrStack, *glrStack) {}
+func workCountRecordGSSReject(*Parser, string, string, string, *glrStack, *glrStack) {
+}
+func workCountRecordGSSScoreShiftReject(*Parser, string, *glrStack, *glrStack)  {}
+func workCountRecordGSSCleanReject(*Parser, string, *glrStack, *glrStack, bool) {}
+func workCountGSSMutationEpoch() uint64                                         { return 0 }
+func workCountRecordGSSMutation()                                               {}
+func workCountMergeGSSObserved(_ *Parser, scratch *glrMergeScratch, _ string, _ string, target, candidate *glrStack) bool {
+	return gssMainMergeWithScratch(scratch, target, candidate)
+}
+func workCountRecordPostReduceCandidate(*Parser, string, string, *glrStack, *glrStack, string) {
+}
+func workCountRecordPendingQueued(*Parser, *glrStack, *glrStack, int, int, string)  {}
+func workCountRecordAcceptedHead(*Parser, *glrStack, string)                        {}
+func workCountRecordReduceWindow(*Parser, *glrStack, int, int, int, bool)           {}
+func workCountRecordPendingTransition(*Parser, *glrStack, int, int, string, string) {}
+func workCountRecordFinalPendingDiscards(*Parser, []glrStack, []glrStack)           {}
+func workCountRecordBoundaryCull(*Parser, int, int)                                 {}
+func workCountRecordFinalExpand(*Parser, *glrStack, int, bool, bool)                {}
+func workCountRecordFinalExpansions(*Parser, []glrStack)                            {}
+func workCountRecordFinalSelect(*Parser, []glrStack, *glrStack)                     {}
+func workCountTryPostReduceMergeObserved(p *Parser, _ string, _ string, target, candidate *glrStack) bool {
+	return tryMergePostReduceFork(p, target, candidate)
+}

--- a/work_count_production_assembly_test.go
+++ b/work_count_production_assembly_test.go
@@ -16,8 +16,15 @@ import (
 )
 
 const (
-	finalizeDeferGuardMarker = "work-count-assembly: finalize-defer guard"
-	popPayloadCensusMarker   = "work-count-assembly: payload-census seam"
+	finalizeDeferGuardMarker     = "work-count-assembly: finalize-defer guard"
+	popPayloadCensusMarker       = "work-count-assembly: payload-census seam"
+	convergenceIterationMarker   = "work-count-assembly: convergence iteration seam"
+	convergenceFinalExpandMarker = "work-count-assembly: convergence final-expand seam"
+	convergenceGSSMarker         = "work-count-assembly: convergence GSS seam"
+	gssMutationSetPrimaryMarker  = "work-count-assembly: GSS mutation set-primary seam"
+	gssMutationSetExtraMarker    = "work-count-assembly: GSS mutation set-extra seam"
+	gssMutationAppendReuseMarker = "work-count-assembly: GSS mutation append-reuse seam"
+	gssMutationAppendGrowMarker  = "work-count-assembly: GSS mutation append-grow seam"
 )
 
 func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
@@ -27,6 +34,16 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	productionWorkCountSymbol := regexp.MustCompile(`(?m)^\s*[0-9a-f]+\s+\S\s+github\.com/odvcencio/gotreesitter\.(?:\(\*[^)]*\)\.)?workCount`)
 	if match := productionWorkCountSymbol.Find(nm); match != nil {
 		t.Fatalf("untagged binary retains a production work-count symbol: %s", match)
+	}
+	for _, forbidden := range []string{
+		"gssMainCanMergeForParserPhase",
+		"gssMainCanMergeWithScratchPhase",
+		"tryGSSMainMergeForParserPhase",
+		"postReduceForkMergePreflight",
+	} {
+		if bytes.Contains(nm, []byte("github.com/odvcencio/gotreesitter."+forbidden)) {
+			t.Fatalf("untagged binary retains diagnostic merge helper %s", forbidden)
+		}
 	}
 
 	finalizeLine := sourceMarkerLine(t, "parser.go", finalizeDeferGuardMarker) - 1
@@ -43,12 +60,38 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 		t.Fatalf("untagged reduction path retains instructions at the payload-census seam:\n%s", reduceAssembly)
 	}
 	assertNoDiagnosticAssembly(t, reduceAssembly)
+
+	assertNoAssemblyAtMarker(t, closures, "parser.go", convergenceIterationMarker)
+	resultAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.buildResultFromGLR`, testBinary)
+	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", convergenceFinalExpandMarker)
+	assertNoDiagnosticAssembly(t, resultAssembly)
+	gssAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.tryGSSMainMergeForParser`, testBinary)
+	assertNoAssemblyAtMarker(t, gssAssembly, "glr.go", convergenceGSSMarker)
+	assertNoDiagnosticAssembly(t, gssAssembly)
+	gssMutationAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.(?:setGSSMainLink|gssMainAddLinkSeenMutate|gssMainReplaceWorstEquivalentLinkIfBetterMutate|gssMainMergeNodesSeenMutate|gssMainMergeWithScratch|tryGSSMainMergeResult|\(\*gssNode\)\.appendExtraLink)`, testBinary)
+	assertNoAssemblyAtMarker(t, gssMutationAssembly, "glr.go", gssMutationSetPrimaryMarker)
+	assertNoAssemblyAtMarker(t, gssMutationAssembly, "glr.go", gssMutationSetExtraMarker)
+	assertNoAssemblyAtMarker(t, gssMutationAssembly, "glr_gss.go", gssMutationAppendReuseMarker)
+	assertNoAssemblyAtMarker(t, gssMutationAssembly, "glr_gss.go", gssMutationAppendGrowMarker)
+	assertNoDiagnosticAssembly(t, gssMutationAssembly)
+	postReduceAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.(?:tryMergePostReduceFork|postReduceForkMergePreflight|\(\*Parser\)\.(?:applyReduceActionForked|applyReduceActionFromGSS))`, testBinary)
+	assertNoDiagnosticAssembly(t, postReduceAssembly)
+}
+
+func assertNoAssemblyAtMarker(t *testing.T, assembly []byte, file, marker string) {
+	t.Helper()
+	line := sourceMarkerLine(t, file, marker)
+	if hasAssemblyForLine(assembly, file, line) {
+		t.Fatalf("untagged build retains instructions at %s:%d (%s):\n%s", file, line, marker, assembly)
+	}
 }
 
 func assertNoDiagnosticAssembly(t *testing.T, assembly []byte) {
 	t.Helper()
 	for _, forbidden := range [][]byte{
 		[]byte("workCount"),
+		[]byte("workCountConvergence"),
+		[]byte("work_count_convergence.go:"),
 		[]byte("work_count_hooks.go:"),
 	} {
 		if bytes.Contains(assembly, forbidden) {


### PR DESCRIPTION
## Summary

- add a bounded Go-only convergence frontier alongside the shared Go/static-C work-count contract
- authenticate event lifecycles, aggregates, manifest identity, and clean source provenance
- compile diagnostic hooks out of ordinary parser builds and enforce that boundary in tests

## Validation

- focused tagged convergence and fail-closed corruption tests
- untagged production assembly gate
- isolated Docker authentication gate
- Go real-corpus parity: 25/25 no-error, S-expression, and deep parity
- independent code review

The instrumentation is diagnostic-only and does not change the shared static-C counter semantics.