### PR TITLE
perf(glr): reject incompatible merges earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ for tags and release notes while still in `0.x`.
 - Rewriter edits now reject reversed and out-of-source byte ranges instead of
   panicking while applying them.
 
+### Performance
+
+- GLR boundary merging now rejects candidates with unequal cumulative scores
+  before recovery-cost and graph-equivalence work. The order-balanced canonical
+  real-Go benchmark improved by 4.3% geomean with unchanged parser work, tree
+  identity, arena use, and stack maxima.
+
 ### Tooling
 
 - Report-mode fleet reduction now preserves closed-vocabulary

--- a/glr.go
+++ b/glr.go
@@ -4271,6 +4271,18 @@ func tryGSSMainMergeResult(scratch *glrMergeScratch, result []glrStack, idx int,
 	if workCountInstrumentationEnabled {
 		workCountRecordPairCandidate(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, "boundary merge entered eligibility preflight", &result[idx], stack)
 	}
+	// Score is an unconditional GSS merge identity component (see
+	// gssMainCanMergeWithScratch). Reject it before recovery-cost attribution
+	// and deeper graph/equivalence work: on ambiguity-heavy parses most
+	// same-state, same-offset candidates carry distinct cumulative dynamic
+	// precedence, so walking recovery state for those pairs can never affect the
+	// outcome. Diagnostic builds still retain the candidate and score rejection.
+	if result[idx].score != stack.score {
+		if workCountInstrumentationEnabled {
+			workCountRecordGSSScoreShiftReject(workCountParserFromMergeScratch(scratch), workCountConvergencePhaseBoundaryGSS, &result[idx], stack)
+		}
+		return false, false
+	}
 	if cRecoveryMergeCostsDiffer(scratch, &result[idx], stack) {
 		traceCRecoverMergeDecision(scratch, "gss", "reject-cost", &result[idx], stack)
 		if workCountInstrumentationEnabled {

--- a/glr_test.go
+++ b/glr_test.go
@@ -3184,6 +3184,42 @@ func TestTryGSSMainMergeResultClearsMaterializingCache(t *testing.T) {
 	}
 }
 
+func TestTryGSSMainMergeResultRejectsDistinctScoreBeforeMutation(t *testing.T) {
+	var gssScratch gssScratch
+	node := NewLeafNode(11, true, 0, 5, Point{}, Point{Column: 5})
+	entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+	left := glrStack{
+		gss:        buildGSSStack(entries, &gssScratch),
+		byteOffset: 5,
+		score:      1,
+	}
+	right := glrStack{
+		gss:        buildGSSStack(entries, &gssScratch),
+		byteOffset: 5,
+		score:      2,
+		cPaused:    true,
+	}
+	if !stacksHeaderEquivalent(&left, &right) {
+		t.Fatal("test setup did not produce same-header stacks")
+	}
+	if leftCost, rightCost := cStackErrorCostForMerge(nil, &left), cStackErrorCostForMerge(nil, &right); leftCost == rightCost {
+		t.Fatalf("test setup recovery costs equal: left=%d right=%d", leftCost, rightCost)
+	}
+	leftHead := left.gss.head
+	leftLinks := leftHead.linkCount()
+
+	scratch := glrMergeScratch{cRecoveryCost: true}
+	scratch.beginEquivEpoch()
+	result := []glrStack{left}
+	merged, attempted := tryGSSMainMergeResult(&scratch, result, 0, &right)
+	if merged || attempted {
+		t.Fatalf("distinct-score GSS merge = merged:%v attempted:%v, want false/false", merged, attempted)
+	}
+	if result[0].gss.head != leftHead || leftHead.linkCount() != leftLinks {
+		t.Fatal("distinct-score GSS prefilter mutated the retained stack")
+	}
+}
+
 func TestTryGSSMainMergeForParserBumpsShapePrefixEpoch(t *testing.T) {
 	// Cross-token invalidation guard for the DISPATCH-time GSS main merge
 	// (reached through tryGSSMainMergeForParser from parser_reduce /

--- a/work_count_convergence_test.go
+++ b/work_count_convergence_test.go
@@ -142,6 +142,53 @@ func TestWorkCountContractV3Stability(t *testing.T) {
 	}
 }
 
+func TestWorkCountConvergenceRetainsScorePrefilterDecision(t *testing.T) {
+	var nodes gssScratch
+	node := NewLeafNode(11, true, 0, 5, Point{}, Point{Column: 5})
+	entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+	makeStack := func(score int, paused bool) glrStack {
+		return glrStack{
+			gss:        buildGSSStack(entries, &nodes),
+			byteOffset: 5,
+			score:      score,
+			cPaused:    paused,
+		}
+	}
+	left := makeStack(1, false)
+	right := makeStack(2, true)
+	if !stacksHeaderEquivalent(&left, &right) {
+		t.Fatal("test setup did not produce same-header stacks")
+	}
+	if leftCost, rightCost := cStackErrorCostForMerge(nil, &left), cStackErrorCostForMerge(nil, &right); leftCost == rightCost {
+		t.Fatalf("test setup recovery costs equal: left=%d right=%d", leftCost, rightCost)
+	}
+	result := []glrStack{left}
+	leftHead := left.gss.head
+	leftLinks := leftHead.linkCount()
+	scratch := glrMergeScratch{cRecoveryCost: true}
+
+	token := beginWorkCountConvergenceAttempt(t)
+	merged, attempted := tryGSSMainMergeResult(&scratch, result, 0, &right)
+	counts := endWorkCountConvergenceAttempt(t, token)
+	if merged || attempted {
+		t.Fatalf("distinct-score GSS merge = merged:%v attempted:%v, want false/false", merged, attempted)
+	}
+	if result[0].gss.head != leftHead || leftHead.linkCount() != leftLinks {
+		t.Fatal("distinct-score GSS prefilter mutated the retained stack")
+	}
+	if counts.MergeAttemptsProxy != 1 {
+		t.Fatalf("merge front-door calls = %d, want 1", counts.MergeAttemptsProxy)
+	}
+	if len(counts.Convergence.Events) != 2 {
+		t.Fatalf("retained convergence events = %d, want candidate+rejection", len(counts.Convergence.Events))
+	}
+	candidate, rejected := counts.Convergence.Events[0], counts.Convergence.Events[1]
+	if candidate.Outcome != workCountConvergenceOutcomeCandidate || rejected.Outcome != workCountConvergenceOutcomeRejected ||
+		rejected.RejectReason != workCountConvergenceReasonScore || candidate.DecisionID != rejected.DecisionID {
+		t.Fatalf("score prefilter events = candidate:%+v rejected:%+v", candidate, rejected)
+	}
+}
+
 func TestWorkCountConvergenceRetainsFirstRejectBeyondEventCap(t *testing.T) {
 	token := beginWorkCountConvergenceAttempt(t)
 	for i := 0; i < workCountConvergenceMaxEvents; i++ {


### PR DESCRIPTION
## Summary

- reject unequal-score GSS merge candidates before recovery-cost and graph-equivalence work
- preserve the existing shared survivor cap and merge semantics
- keep diagnostic front-door counts and explicit score-rejection evidence intact

## Performance

Order-balanced canonical real-Go warm full parse:

- equal-fixture geomean: 23.26 ms → 22.25 ms (-4.32%)
- query_compile: -5.72%
- language: -5.31%
- rewrite: neutral
- grammargen/lr: favorable, p=0.055

Parser work, selected tree identity, arena bytes, node/token counts, and stack maxima were unchanged.

## Validation

- focused score/recovery merge tests
- tagged convergence-contract and canonical observer tests
- production assembly compile-out gate
- independent review
- isolated Go real-corpus parity: 25/25 no-error, S-expression, and deep parity