### PR TITLE
fix(incremental): preserve bounded GLR reuse and retry correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ for tags and release notes while still in `0.x`.
   rejects reused leaves whose stored parser state conflicts with the current
   shift. This prevents stale leaf context and over-aggressive two-stack
   pruning from changing selected trees on token-class and recovery edits.
+- An incremental parse whose full-parse retry produces no strictly better
+  tree now keeps its first-pass result instead of replacing it with a
+  quality-tied fresh tree. This stops spurious `incremental_parse_full_retry`
+  reporting on grammars whose intended trees contain ERROR productions and
+  legitimately use the full GLR width.
 - Multiline tree edits now keep node byte and point ranges aligned with the C
   runtime across insertions, deletions, and replacements.
 - Rewriter edits now reject reversed and out-of-source byte ranges instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Incremental parsing now preserves the configured bounded GLR width and
+  rejects reused leaves whose stored parser state conflicts with the current
+  shift. This prevents stale leaf context and over-aggressive two-stack
+  pruning from changing selected trees on token-class and recovery edits.
 - Multiline tree edits now keep node byte and point ranges aligned with the C
   runtime across insertions, deletions, and replacements.
 - Rewriter edits now reject reversed and out-of-source byte ranges instead of

--- a/incremental.go
+++ b/incremental.go
@@ -147,13 +147,6 @@ func (c *reuseCursor) releaseNodeRefs() {
 	}
 }
 
-func rejectForestLeafStateMismatch(n *Node, nextState StateID) bool {
-	return n != nil &&
-		n.ChildCount() == 0 &&
-		n.parseState != 0 &&
-		n.parseState != nextState
-}
-
 // releaseNodeRefs nils *Node pointers in the scratch buffers.
 func (s *reuseScratch) releaseNodeRefs() {
 	if cap(s.stack) > 0 {
@@ -440,9 +433,6 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		if !ok {
 			continue
 		}
-		if idx.forestFastPath && rejectForestLeafStateMismatch(n, nextState) {
-			continue
-		}
 		if !reuseSubtreeGapIsParserPadding(idx.newSource, s.byteOffset, n.StartByte()) {
 			continue
 		}
@@ -649,7 +639,7 @@ func (p *Parser) reuseTargetState(state StateID, n *Node, lookahead Token) (Stat
 			}
 			shiftCount++
 		}
-		if shiftCount == 1 {
+		if n.parseState == 0 && shiftCount == 1 {
 			return uniqueShiftState, true
 		}
 		return 0, false

--- a/incremental_test.go
+++ b/incremental_test.go
@@ -524,23 +524,39 @@ func TestReuseTargetStateAmbiguousShiftMustMatchNodeState(t *testing.T) {
 	}
 }
 
-func TestForestLeafReuseRejectsMismatchedNodeState(t *testing.T) {
+func TestLeafReuseRejectsMismatchedNodeState(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
 	lookahead := Token{Symbol: 1}
 
 	leaf := &Node{symbol: 1, parseState: 4}
+	if _, ok := parser.reuseTargetState(0, leaf, lookahead); ok {
+		t.Fatal("expected leaf reuse to reject a unique shift that does not match the stored parse state")
+	}
+
+	leaf.parseState = 0
 	nextState, ok := parser.reuseTargetState(0, leaf, lookahead)
 	if !ok {
-		t.Fatal("expected generic unique-shift fallback to remain available")
-	}
-	if !rejectForestLeafStateMismatch(leaf, nextState) {
-		t.Fatal("expected forest leaf reuse to reject mismatched parseState")
+		t.Fatal("expected unique-shift fallback for a leaf without stored parse-state metadata")
 	}
 
 	leaf.parseState = nextState
-	if rejectForestLeafStateMismatch(leaf, nextState) {
-		t.Fatal("expected forest leaf reuse to accept matching parseState")
+	if got, ok := parser.reuseTargetState(0, leaf, lookahead); !ok || got != nextState {
+		t.Fatalf("expected matching stored parse state %d, got state=%d ok=%t", nextState, got, ok)
+	}
+}
+
+func TestConfigureIncrementalParseCapsPreservesConfiguredWidth(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_STACKS", "18")
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "16")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	parser := NewParser(buildArithmeticLanguage())
+	var scratch parserScratch
+	caps := parser.configureParseCaps([]byte("1+2"), &reuseCursor{}, arenaClassIncremental, &scratch, 0, 0, 0)
+	if caps.maxStacks != 18 || caps.mergePerKeyCap != 16 {
+		t.Fatalf("incremental caps = stacks:%d merge:%d, want stacks:18 merge:16", caps.maxStacks, caps.mergePerKeyCap)
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -6291,7 +6291,9 @@ func (p *Parser) configureParseCaps(source []byte, reuse *reuseCursor, arenaClas
 	if mergePerKeyCap > maxStacksPerMergeKeyCeiling {
 		mergePerKeyCap = maxStacksPerMergeKeyCeiling
 	}
-	maxStacks, mergePerKeyCap = p.tuneParseGLRCaps(maxStacks, mergePerKeyCap, reuse)
+	if reuse == nil && p.language != nil && p.language.Name == "c_sharp" && mergePerKeyCap < 16 {
+		mergePerKeyCap = 16
+	}
 	scratch.merge.perKeyCap = mergePerKeyCap
 
 	maxNodes := parseNodeLimitForLanguage(len(source), p.language)
@@ -6315,16 +6317,6 @@ func javaFullParseNeedsAnnotationDeclarationMergeWidth(lang *Language, source []
 		reuse == nil &&
 		!parseMaxMergePerKeyEnvConfigured() &&
 		bytes.Contains(source, []byte("@interface"))
-}
-
-func (p *Parser) tuneParseGLRCaps(maxStacks, mergePerKeyCap int, reuse *reuseCursor) (int, int) {
-	if reuse == nil && p.language != nil && p.language.Name == "c_sharp" && mergePerKeyCap < 16 {
-		mergePerKeyCap = 16
-	}
-	if reuse != nil {
-		maxStacks, mergePerKeyCap = tuneIncrementalGLRCaps(maxStacks, mergePerKeyCap)
-	}
-	return maxStacks, mergePerKeyCap
 }
 
 func languageName(lang *Language) string {

--- a/parser_limits.go
+++ b/parser_limits.go
@@ -771,16 +771,6 @@ func parseFullEntryScratchReservation(sourceLen int) int {
 	return estimate
 }
 
-func tuneIncrementalGLRCaps(maxStacks, mergePerKeyCap int) (int, int) {
-	if maxStacks > 2 {
-		maxStacks = 2
-	}
-	if mergePerKeyCap > 2 {
-		mergePerKeyCap = 2
-	}
-	return maxStacks, mergePerKeyCap
-}
-
 func parseIncrementalArenaNodeCapacity(sourceLen, hint int) int {
 	base := nodeCapacityForClass(arenaClassIncremental)
 	target := base

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -358,6 +358,29 @@ func preferRetryTree(p *Parser, candidate, incumbent *Tree) bool {
 	return candRT.NodesAllocated < incRT.NodesAllocated
 }
 
+// preferRetryTreeOverFirstPass gates replacement of the ORIGINAL first-pass
+// tree. NodesAllocated is parse-run bookkeeping, not tree quality: two
+// byte-identical trees differ in it purely by how they were parsed
+// (incremental relex overhead vs a fresh pass). A retry must therefore be
+// strictly better on a tree-quality axis to displace the first-pass tree; on
+// a full quality tie the first pass wins, so an equal retry cannot burn the
+// incremental route's bookkeeping (ReuseUnsupportedReason) or release a good
+// tree. Retry-vs-retry replacement keeps the NodesAllocated tie-break so the
+// established ladder accounting is unchanged.
+func preferRetryTreeOverFirstPass(p *Parser, candidate, firstPass *Tree) bool {
+	if !preferRetryTree(p, candidate, firstPass) {
+		return false
+	}
+	// preferRetryTree said yes; reject the replacement if its only winning
+	// axis was the NodesAllocated bookkeeping tie-break, i.e. the reverse
+	// comparison with NodesAllocated ignored would also say yes.
+	saved := candidate.parseRuntime.NodesAllocated
+	candidate.parseRuntime.NodesAllocated = firstPass.parseRuntimeReadOnly().NodesAllocated
+	strict := preferRetryTree(p, candidate, firstPass)
+	candidate.parseRuntime.NodesAllocated = saved
+	return strict
+}
+
 func shouldTakeCleanWideRetry(incumbent, candidate *Tree, sourceLen int, initialMaxStacks int) bool {
 	if candidate == nil || retryTreeHasError(candidate) {
 		return false
@@ -1778,6 +1801,15 @@ func (p *Parser) retryFullParseWithTokenSourceForOrigin(source []byte, ts TokenS
 			deterministicExternalConflicts,
 		)
 	})
+	if origin == fullParseRetryOriginIncremental && result != tree && !preferRetryTreeOverFirstPass(p, result, tree) {
+		// The retry ladder finished without producing a strictly better tree
+		// on any quality axis. Keep the incremental first pass: replacing it
+		// with a quality-tied fresh tree would falsely report
+		// incremental_parse_full_retry and discard a good tree over parse-run
+		// bookkeeping (NodesAllocated).
+		result.Release()
+		return tree
+	}
 	// Same as retryFullParseWithDFA: release the original tree if a retry won.
 	if result != tree {
 		tree.Release()


### PR DESCRIPTION
## Summary\n\nThree incremental-parsing correctness fixes:\n\n- Preserve the configured bounded GLR width during incremental parsing instead of hard-capping stacks and merge survivors to 2. The language-specific C# minimum remains narrowly applied at its existing full-parse call site.\n- Reject leaf reuse when a reused leaf's nonzero stored parse state disagrees with the current unique shift target. State-zero metadata retains the conservative unique-shift fallback.\n- Keep the first-pass incremental tree when an accepted-error retry ties it on every tree-quality axis. Retry allocation bookkeeping no longer displaces an equally good incremental result; retry-vs-retry ladder selection remains unchanged.\n\nTogether these changes remove width-sensitive truncation, stale leaf-state reuse, and spurious full-retry replacement while retaining bounded parser limits.\n\n## Verification\n\n- Focused incremental, reuse, retry, pass-accounting, and Authzed associativity tests passed.\n- The stacked #341 CI run exercised this branch with the full root/package race matrix, including the previously failing Authzed lane.\n- Docker four-edit admission preserved exact fresh/incremental trees in both directions for the admitted token-class and recovery-deletion cases.\n- Changelog entries are included under Unreleased.\n\nThe remaining same-line branch-order divergence is tracked separately and is not claimed fixed here.