### PR TITLE
fix(parser): report materialization stop reasons instead of accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- A parse whose result materialization stops on a terminal condition (for
+  example the memory budget tripping while the tree is being built) after the
+  parser loop already accepted now reports that condition through
+  `Tree.ParseStopReason` instead of `accepted`. Previously such a parse could
+  return a sentinel full-span ERROR root labeled as a successful parse.
+
 - Multiline tree edits now keep node byte and point ranges aligned with the C
   runtime across insertions, deletions, and replacements.
 - Rewriter edits now reject reversed and out-of-source byte ranges instead of

--- a/parser.go
+++ b/parser.go
@@ -3219,6 +3219,24 @@ func parseStopReasonWithTokenSourceEOF(stopReason ParseStopReason, tokenSourceEO
 	return stopReason
 }
 
+// rescueMaterializationStopReason preserves a stop reason that result
+// materialization stamped onto a replacement error tree after the parse loop
+// had already accepted. buildResultFromGLR can discard the accepted stacks and
+// return a sentinel error tree carrying its own terminal reason (for example
+// memory_budget when the budget trips during materialization); the loop-level
+// stopReason still says accepted at that point, and stamping it over the tree
+// would report a full-span sentinel ERROR root as a successful parse.
+func rescueMaterializationStopReason(loopReason ParseStopReason, tree *Tree) ParseStopReason {
+	if loopReason != ParseStopAccepted || tree == nil {
+		return loopReason
+	}
+	already := tree.parseRuntimeReadOnly().StopReason
+	if already == "" || already == ParseStopNone || already == ParseStopAccepted {
+		return loopReason
+	}
+	return already
+}
+
 func recordParseRuntimeLoopStats(parseRuntime *ParseRuntime, scratch *parserScratch, iterationsUsed, nodeCount, peakStackDepth, maxStacksSeen, singleStackIterations, multiStackIterations int, singleStackTokens, multiStackTokens uint64) {
 	if parseRuntime == nil {
 		return
@@ -4412,6 +4430,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		scratch.audit.finishParse(stacks)
 		captureArenaStats()
 		captureScratchStats()
+		stopReason = rescueMaterializationStopReason(stopReason, tree)
 		parseRuntime.StopReason = parseStopReasonWithTokenSourceEOF(stopReason, tokenSourceEOFEarly)
 		parseRuntime.MemoryBudgetStopSource = memoryBudgetDiag.source
 		parseRuntime.RuntimeHeapGrowthBytes = memoryBudgetDiag.runtimeHeapGrowthBytes

--- a/parser_stop_reason_rescue_test.go
+++ b/parser_stop_reason_rescue_test.go
@@ -1,0 +1,38 @@
+package gotreesitter
+
+import "testing"
+
+func stopReasonRescueTestTree(reason ParseStopReason) *Tree {
+	tree := &Tree{}
+	if reason != "" {
+		tree.setParseStopReason(reason)
+	}
+	return tree
+}
+
+func TestRescueMaterializationStopReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		loopReason ParseStopReason
+		treeReason ParseStopReason
+		want       ParseStopReason
+	}{
+		{"accepted loop, budget-stamped sentinel tree", ParseStopAccepted, ParseStopMemoryBudget, ParseStopMemoryBudget},
+		{"accepted loop, node-limit sentinel tree", ParseStopAccepted, ParseStopNodeLimit, ParseStopNodeLimit},
+		{"accepted loop, ordinary tree without a reason", ParseStopAccepted, "", ParseStopAccepted},
+		{"accepted loop, tree already accepted", ParseStopAccepted, ParseStopAccepted, ParseStopAccepted},
+		{"loop stop wins over materialization reason", ParseStopNoStacksAlive, ParseStopMemoryBudget, ParseStopNoStacksAlive},
+		{"loop budget stop passes through", ParseStopMemoryBudget, "", ParseStopMemoryBudget},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := stopReasonRescueTestTree(tc.treeReason)
+			if got := rescueMaterializationStopReason(tc.loopReason, tree); got != tc.want {
+				t.Fatalf("rescueMaterializationStopReason(%q, tree=%q) = %q, want %q", tc.loopReason, tc.treeReason, got, tc.want)
+			}
+		})
+	}
+	if got := rescueMaterializationStopReason(ParseStopAccepted, nil); got != ParseStopAccepted {
+		t.Fatalf("nil tree: got %q, want accepted", got)
+	}
+}


### PR DESCRIPTION
## Summary

When result materialization stops on a terminal condition after the parser loop has already accepted — for example the memory budget tripping while the final tree is built — `buildResultFromGLR` returns a sentinel error tree carrying the correct stop reason, but the parse-loop epilogue then stamped the loop's `accepted` over it. Callers gating on `Tree.ParseStopReason() == accepted` would treat a full-span sentinel ERROR root as a successful parse.

Witness: a cold-parser parse of a 3.9MB generated Go file whose natural heap growth exceeds the default soft memory budget returned `root=ERROR, stop=accepted`; the same trip during the parse loop (a different 2.6MB witness) correctly reported `memory_budget`.

The fix rescues a terminal reason already stamped on the returned tree when the loop reason is `accepted`, before the runtime stamp. Loop-level stop reasons keep priority in every other combination.

## Testing

- New unit test covers the rescue matrix (budget/node-limit sentinel trees, ordinary trees, loop-stop priority, nil tree).
- Memory-budget, stop-reason, retry, and truncation suites pass.
- End-to-end: the cold-parse witness now reports `root=ERROR, stop=memory_budget`; warm parses are unchanged (`source_file, accepted`).