### PR TITLE
fix(glr): make incremental scoring and culling match fresh parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ for tags and release notes while still in `0.x`.
   quality-tied fresh tree. This stops spurious `incremental_parse_full_retry`
   reporting on grammars whose intended trees contain ERROR productions and
   legitimately use the full GLR width.
+- Reused subtrees now credit their cumulative dynamic precedence to the GLR
+  stack score, so score-sensitive merge, cull, and result-selection decisions
+  in an incremental parse match a fresh parse of the same structure.
+- The GLR stack-cull trigger no longer depends on the arena class: incremental
+  parses keep the same cull slack window as fresh parses, which previously
+  pruned disambiguating forks early and changed selected trees on the
+  early-newline canonical witness.
 - Multiline tree edits now keep node byte and point ranges aligned with the C
   runtime across insertions, deletions, and replacements.
 - Rewriter edits now reject reversed and out-of-source byte ranges instead of

--- a/incremental.go
+++ b/incremental.go
@@ -530,6 +530,12 @@ func reuseNode(p *Parser, s *glrStack, n *Node, nextState StateID, startState St
 		}
 	}
 	p.pushStackNode(s, nextState, n, entryScratch, gssScratch)
+	// A fresh parse accumulates every reduction's dynamic precedence into the
+	// stack score; a reused subtree carries that same contribution precomputed
+	// in its cumulative dynamicPrecedence. Credit it so score-sensitive
+	// decisions (merge survival, culls, result selection) see the score a
+	// fresh parse of the identical structure would.
+	s.score += int(n.dynamicPrecedence)
 	reusedBytes := n.EndByte() - n.StartByte()
 
 	// If the reused node reaches EOF, we can synthesize EOF directly

--- a/parser.go
+++ b/parser.go
@@ -6304,7 +6304,7 @@ func (p *Parser) configureParseCaps(source []byte, reuse *reuseCursor, arenaClas
 		maxStacks:           maxStacks,
 		retryPass:           retryPass,
 		mergePerKeyCap:      mergePerKeyCap,
-		maxStackCullTrigger: glrStackCullTrigger(maxStacks, arenaClass, languageName(p.language)),
+		maxStackCullTrigger: glrStackCullTrigger(maxStacks, languageName(p.language)),
 		maxIter:             parseIterationsForLanguage(len(source), p.language),
 		maxDepth:            parseStackDepth(len(source)),
 		maxNodes:            maxNodes,
@@ -7606,11 +7606,16 @@ func stackCullLanguageForArena(lang *Language, class arenaClass) *Language {
 	return lang
 }
 
-func glrStackCullTrigger(maxStacks int, class arenaClass, langName string) int {
+// glrStackCullTrigger returns the live-stack population at which per-iteration
+// culling engages. The slack window is a function of the language only: which
+// memory pool the arena came from must never influence which GLR branches
+// survive, or incremental parses select different trees than fresh parses of
+// the same source (the early_newline canonical witness).
+func glrStackCullTrigger(maxStacks int, langName string) int {
 	if maxStacks <= 0 {
 		return maxStacks
 	}
-	if class != arenaClassFull || langName == "c_sharp" {
+	if langName == "c_sharp" {
 		return maxStacks
 	}
 	maxInt := int(^uint(0) >> 1)

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1899,17 +1899,17 @@ func TestPreferRetryTreeAcceptedCandidateCanBeatStoppedIncumbent(t *testing.T) {
 }
 
 func TestGLRStackCullTrigger(t *testing.T) {
-	if got := glrStackCullTrigger(8, arenaClassFull, "go"); got != 12 {
-		t.Fatalf("glrStackCullTrigger(full, go) = %d, want 12", got)
+	// The slack window is arena-class-invariant: fresh and incremental parses
+	// of the same source must cull GLR branches at the same population, or
+	// the memory pool an arena came from changes the selected tree.
+	if got := glrStackCullTrigger(8, "go"); got != 12 {
+		t.Fatalf("glrStackCullTrigger(go) = %d, want 12", got)
 	}
-	if got := glrStackCullTrigger(8, arenaClassFull, "c_sharp"); got != 8 {
-		t.Fatalf("glrStackCullTrigger(full, c_sharp) = %d, want 8", got)
-	}
-	if got := glrStackCullTrigger(8, arenaClassIncremental, "go"); got != 8 {
-		t.Fatalf("glrStackCullTrigger(incremental, go) = %d, want 8", got)
+	if got := glrStackCullTrigger(8, "c_sharp"); got != 8 {
+		t.Fatalf("glrStackCullTrigger(c_sharp) = %d, want 8", got)
 	}
 	maxInt := int(^uint(0) >> 1)
-	if got := glrStackCullTrigger(maxInt, arenaClassFull, "go"); got != maxInt {
+	if got := glrStackCullTrigger(maxInt, "go"); got != maxInt {
 		t.Fatalf("glrStackCullTrigger(maxInt) = %d, want %d", got, maxInt)
 	}
 }


### PR DESCRIPTION
## Summary

Two selection-parity fixes make incremental GLR decisions match a fresh parse of the same structure:

- Reused subtrees credit their cumulative dynamic precedence to the stack score. Fresh parsing accumulates the same credit while reducing; reuse previously omitted it, allowing merge, cull, and result selection to diverge after an edit.
- The GLR stack-cull trigger is arena-class-invariant. Fresh and incremental parses now use the same language-specific slack window, while preserving the existing C# exception.

## Validation

- Added `TestReuseNodePreservesFreshDynamicPrecedenceSelection`, which constructs a non-leaf reduced subtree, scores the fresh path through `markReduceApplied`, scores the incremental path through `reuseNode`, and checks actual primary-stack selection. Removing only the reuse credit flips the selected lineage and fails the test.
- Updated `TestGLRStackCullTrigger` to pin the arena-invariant contract.
- Focused incremental, reuse, culling, dynamic-precedence, GSS, forest, and selection tests pass in Docker.
- The isolated Go real-corpus gate remains 25/25 for no-error, S-expression, and deep-tree parity.
