### PR TITLE
improve(grammars): improve highlight inheritance resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Highlight queries now resolve supported built-in inheritance chains across
+  registration order and same-name replacements without duplicating cyclic
+  queries. Incompatible locked grammar/query pairs remain fail-closed.
 - Incremental parses that accept a full-span ERROR tree under a wider merge
   policy may retry once with the corresponding fresh-parse policy and adopt
   only a strictly better result. Runtime and profile diagnostics report the

--- a/grammars/registry.go
+++ b/grammars/registry.go
@@ -48,8 +48,9 @@ type LangEntry struct {
 	// rawHighlightQuery preserves the entry's pre-composition highlight query
 	// so re-running inheritance resolution (any Register call resets it) stays
 	// idempotent instead of prepending parent queries a second time.
-	rawHighlightQuery    string
-	highlightRawCaptured bool
+	rawHighlightQuery      string
+	resolvedHighlightQuery string
+	highlightRawCaptured   bool
 }
 
 var registry []LangEntry
@@ -126,12 +127,25 @@ func Register(entry LangEntry) {
 	defer registryMu.Unlock()
 	for i := range registry {
 		if registry[i].Name == entry.Name {
+			// Copies returned by AllLanguages and DetectLanguageByName retain the
+			// private raw-query metadata. Preserve that metadata when callers
+			// re-register an otherwise unchanged composed query, but recapture a
+			// deliberately replaced public query as the new raw child query.
+			if entry.highlightRawCaptured && entry.HighlightQuery == registry[i].resolvedHighlightQuery {
+				entry.rawHighlightQuery = registry[i].rawHighlightQuery
+			} else {
+				entry.rawHighlightQuery = entry.HighlightQuery
+				entry.highlightRawCaptured = true
+			}
+			entry.resolvedHighlightQuery = ""
 			registry[i] = entry
 			highlightInheritanceResolved = false
 			extIndex = nil
 			return
 		}
 	}
+	entry.rawHighlightQuery = entry.HighlightQuery
+	entry.highlightRawCaptured = true
 	registry = append(registry, entry)
 	highlightInheritanceResolved = false
 	extIndex = nil
@@ -215,9 +229,22 @@ var extensionAliases = map[string]string{}
 // language-specific additions and expects the parent's query ahead of it.
 // An entry's explicit InheritHighlights always takes priority.
 var defaultHighlightInherits = map[string]string{
+	"blade":      "html",
+	"cpp":        "c",
+	"cuda":       "cpp",
+	"glsl":       "c",
+	"objc":       "c",
+	"svelte":     "html",
+	"templ":      "go",
 	"typescript": "javascript",
 	"tsx":        "typescript",
-	"cpp":        "c",
+}
+
+// blockedDefaultHighlightInherits keeps upstream inheritance metadata visible
+// when the locked child grammar cannot compile the current parent's query.
+// The edge remains fail-closed until the grammar/query revisions are aligned.
+var blockedDefaultHighlightInherits = map[string]string{
+	"cuda": "the locked CUDA grammar lacks C++'s module_name node",
 }
 
 // resolveHighlightInheritance composes highlight queries for languages that
@@ -241,25 +268,41 @@ func resolveHighlightInheritance() {
 			registry[i].highlightRawCaptured = true
 		}
 	}
+	const (
+		resolveVisiting uint8 = iota + 1
+		resolveDone
+	)
+	state := make(map[string]uint8, len(registry))
 	composed := make(map[string]string, len(registry))
+	cyclic := make(map[string]bool, len(registry))
 
-	var resolve func(name string, chain map[string]bool) string
-	resolve = func(name string, chain map[string]bool) string {
-		if q, ok := composed[name]; ok {
-			return q
+	var resolve func(name string) (string, bool)
+	resolve = func(name string) (string, bool) {
+		switch state[name] {
+		case resolveVisiting:
+			return "", true
+		case resolveDone:
+			return composed[name], cyclic[name]
 		}
 		i, ok := index[name]
 		if !ok {
-			return ""
+			return "", false
 		}
+		state[name] = resolveVisiting
 		query := registry[i].rawHighlightQuery
 		parent := registry[i].InheritHighlights
+		blocked := false
 		if parent == "" {
 			parent = defaultHighlightInherits[name]
+			_, blocked = blockedDefaultHighlightInherits[name]
 		}
-		if parent != "" && !chain[parent] {
-			chain[name] = true
-			if parentQuery := resolve(parent, chain); strings.TrimSpace(parentQuery) != "" {
+		if parent != "" && !blocked {
+			parentQuery, parentCyclic := resolve(parent)
+			if parentCyclic {
+				// Fail closed for the entire invalid inheritance chain. Every
+				// affected language keeps exactly its own raw query.
+				cyclic[name] = true
+			} else if strings.TrimSpace(parentQuery) != "" {
 				if strings.TrimSpace(query) == "" {
 					// Prepend parent query so child overrides win (last match wins in tree-sitter).
 					query = parentQuery
@@ -269,11 +312,13 @@ func resolveHighlightInheritance() {
 			}
 		}
 		composed[name] = query
-		return query
+		state[name] = resolveDone
+		return query, cyclic[name]
 	}
 
 	for i := range registry {
-		registry[i].HighlightQuery = resolve(registry[i].Name, map[string]bool{})
+		registry[i].HighlightQuery, _ = resolve(registry[i].Name)
+		registry[i].resolvedHighlightQuery = registry[i].HighlightQuery
 	}
 }
 

--- a/grammars/registry.go
+++ b/grammars/registry.go
@@ -44,6 +44,12 @@ type LangEntry struct {
 	TagsQuery          string                                                                 // tree-sitter tags.scm query for symbol extraction
 	TokenSourceFactory func(src []byte, lang *gotreesitter.Language) gotreesitter.TokenSource // nil = use DFA
 	Quality            ParseQuality                                                           // populated by AuditParseSupport
+
+	// rawHighlightQuery preserves the entry's pre-composition highlight query
+	// so re-running inheritance resolution (any Register call resets it) stays
+	// idempotent instead of prepending parent queries a second time.
+	rawHighlightQuery    string
+	highlightRawCaptured bool
 }
 
 var registry []LangEntry
@@ -203,26 +209,71 @@ func RegisterExtension(ext ExtensionEntry) {
 // Protected by registryMu.
 var extensionAliases = map[string]string{}
 
+// defaultHighlightInherits records the upstream tree-sitter highlight
+// inheritance convention for grammars whose generated registry entries do
+// not populate InheritHighlights: their bundled highlights.scm contains only
+// language-specific additions and expects the parent's query ahead of it.
+// An entry's explicit InheritHighlights always takes priority.
+var defaultHighlightInherits = map[string]string{
+	"typescript": "javascript",
+	"tsx":        "typescript",
+	"cpp":        "c",
+}
+
 // resolveHighlightInheritance composes highlight queries for languages that
-// inherit from a parent. MUST be called with registryMu.Lock() held.
-// Callers are responsible for ensuring builtins are registered first.
+// inherit from a parent, walking multi-level chains (tsx -> typescript ->
+// javascript) regardless of registration order and guarding against cycles.
+// The parent is the entry's InheritHighlights, falling back to the upstream
+// convention in defaultHighlightInherits. MUST be called with registryMu
+// .Lock() held. Callers are responsible for ensuring builtins are registered
+// first.
 func resolveHighlightInheritance() {
 	if highlightInheritanceResolved {
 		return
 	}
 	highlightInheritanceResolved = true
+
+	index := make(map[string]int, len(registry))
 	for i := range registry {
+		index[registry[i].Name] = i
+		if !registry[i].highlightRawCaptured {
+			registry[i].rawHighlightQuery = registry[i].HighlightQuery
+			registry[i].highlightRawCaptured = true
+		}
+	}
+	composed := make(map[string]string, len(registry))
+
+	var resolve func(name string, chain map[string]bool) string
+	resolve = func(name string, chain map[string]bool) string {
+		if q, ok := composed[name]; ok {
+			return q
+		}
+		i, ok := index[name]
+		if !ok {
+			return ""
+		}
+		query := registry[i].rawHighlightQuery
 		parent := registry[i].InheritHighlights
 		if parent == "" {
-			continue
+			parent = defaultHighlightInherits[name]
 		}
-		for j := range registry {
-			if registry[j].Name == parent {
-				// Prepend parent query so child overrides win (last match wins in tree-sitter).
-				registry[i].HighlightQuery = registry[j].HighlightQuery + "\n" + registry[i].HighlightQuery
-				break
+		if parent != "" && !chain[parent] {
+			chain[name] = true
+			if parentQuery := resolve(parent, chain); strings.TrimSpace(parentQuery) != "" {
+				if strings.TrimSpace(query) == "" {
+					// Prepend parent query so child overrides win (last match wins in tree-sitter).
+					query = parentQuery
+				} else {
+					query = parentQuery + "\n" + query
+				}
 			}
 		}
+		composed[name] = query
+		return query
+	}
+
+	for i := range registry {
+		registry[i].HighlightQuery = resolve(registry[i].Name, map[string]bool{})
 	}
 }
 

--- a/grammars/registry_test.go
+++ b/grammars/registry_test.go
@@ -642,18 +642,21 @@ func TestHighlightInheritanceComposesDefaultChains(t *testing.T) {
 		}
 		return entry.HighlightQuery
 	}
-	jsQ, tsQ, tsxQ := get("javascript"), get("typescript"), get("tsx")
-	cQ, cppQ := get("c"), get("cpp")
-
-	if !strings.HasPrefix(tsQ, jsQ) || len(tsQ) <= len(jsQ) {
-		t.Errorf("typescript highlight query should compose javascript base ahead of its additions (js=%dB ts=%dB)", len(jsQ), len(tsQ))
+	for child, parent := range defaultHighlightInherits {
+		childQuery, parentQuery := get(child), get(parent)
+		if reason := blockedDefaultHighlightInherits[child]; reason != "" {
+			entry := DetectLanguageByName(child)
+			if childQuery != entry.rawHighlightQuery {
+				t.Errorf("%s blocked inheritance should keep its raw query (%s)", child, reason)
+			}
+			continue
+		}
+		if !strings.HasPrefix(childQuery, parentQuery) || len(childQuery) <= len(parentQuery) {
+			t.Errorf("%s highlight query should compose %s base ahead of its additions (%s=%dB %s=%dB)",
+				child, parent, parent, len(parentQuery), child, len(childQuery))
+		}
 	}
-	if !strings.HasPrefix(tsxQ, tsQ) {
-		t.Errorf("tsx highlight query should compose the already-composed typescript query (ts=%dB tsx=%dB)", len(tsQ), len(tsxQ))
-	}
-	if !strings.HasPrefix(cppQ, cQ) || len(cppQ) <= len(cQ) {
-		t.Errorf("cpp highlight query should compose c base ahead of its additions (c=%dB cpp=%dB)", len(cQ), len(cppQ))
-	}
+	jsQ := get("javascript")
 
 	goEntry := DetectLanguageByName("go")
 	if goEntry == nil {
@@ -685,6 +688,48 @@ func TestHighlightInheritanceIdempotentAcrossReregistration(t *testing.T) {
 	}
 }
 
+func TestHighlightInheritanceSameNameReplacementRecapturesRawQuery(t *testing.T) {
+	oldRegistry := append([]LangEntry(nil), registry...)
+	oldResolved := highlightInheritanceResolved
+	t.Cleanup(func() {
+		registry = oldRegistry
+		highlightInheritanceResolved = oldResolved
+		extIndex = nil
+	})
+
+	entry := DetectLanguageByName("typescript")
+	if entry == nil {
+		t.Fatal("expected typescript to be registered")
+	}
+	replacement := *entry
+	replacementQuery := "(type_identifier) @type.definition"
+	replacement.HighlightQuery = replacementQuery
+	Register(replacement)
+
+	got := DetectLanguageByName("typescript")
+	parent := DetectLanguageByName("javascript")
+	if got == nil || parent == nil {
+		t.Fatal("expected typescript and javascript to remain registered")
+	}
+	if !strings.HasPrefix(got.HighlightQuery, parent.HighlightQuery) {
+		t.Fatal("replacement should retain javascript inheritance")
+	}
+	if strings.Count(got.HighlightQuery, replacementQuery) != 1 {
+		t.Fatalf("replacement query count = %d, want 1", strings.Count(got.HighlightQuery, replacementQuery))
+	}
+
+	// DetectLanguageByName historically returns the registry entry itself, so
+	// recapture an in-place public query update too rather than mistaking it for
+	// an unchanged composed query.
+	inPlaceQuery := "(predefined_type) @type.builtin"
+	got.HighlightQuery = inPlaceQuery
+	Register(*got)
+	got = DetectLanguageByName("typescript")
+	if strings.Count(got.HighlightQuery, inPlaceQuery) != 1 {
+		t.Fatalf("in-place replacement query count = %d, want 1", strings.Count(got.HighlightQuery, inPlaceQuery))
+	}
+}
+
 func TestHighlightInheritanceCycleTerminates(t *testing.T) {
 	oldRegistry := append([]LangEntry(nil), registry...)
 	oldResolved := highlightInheritanceResolved
@@ -696,10 +741,12 @@ func TestHighlightInheritanceCycleTerminates(t *testing.T) {
 
 	Register(LangEntry{Name: "zz_cycle_a", HighlightQuery: "(a) @x", InheritHighlights: "zz_cycle_b"})
 	Register(LangEntry{Name: "zz_cycle_b", HighlightQuery: "(b) @y", InheritHighlights: "zz_cycle_a"})
+	Register(LangEntry{Name: "zz_self_cycle", HighlightQuery: "(self) @z", InheritHighlights: "zz_self_cycle"})
 
 	a := DetectLanguageByName("zz_cycle_a")
 	b := DetectLanguageByName("zz_cycle_b")
-	if a == nil || b == nil {
+	self := DetectLanguageByName("zz_self_cycle")
+	if a == nil || b == nil || self == nil {
 		t.Fatal("cycle entries should still be registered")
 	}
 	if !strings.Contains(a.HighlightQuery, "(a) @x") || !strings.Contains(b.HighlightQuery, "(b) @y") {
@@ -707,5 +754,8 @@ func TestHighlightInheritanceCycleTerminates(t *testing.T) {
 	}
 	if strings.Count(a.HighlightQuery, "(a) @x") != 1 || strings.Count(b.HighlightQuery, "(b) @y") != 1 {
 		t.Error("cycle resolution must not duplicate queries")
+	}
+	if strings.Count(self.HighlightQuery, "(self) @z") != 1 {
+		t.Errorf("self-cycle query count = %d, want 1", strings.Count(self.HighlightQuery, "(self) @z"))
 	}
 }

--- a/grammars/registry_test.go
+++ b/grammars/registry_test.go
@@ -633,3 +633,79 @@ func TestDetectLanguageByNameRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+func TestHighlightInheritanceComposesDefaultChains(t *testing.T) {
+	get := func(name string) string {
+		entry := DetectLanguageByName(name)
+		if entry == nil {
+			t.Fatalf("expected %s to be registered", name)
+		}
+		return entry.HighlightQuery
+	}
+	jsQ, tsQ, tsxQ := get("javascript"), get("typescript"), get("tsx")
+	cQ, cppQ := get("c"), get("cpp")
+
+	if !strings.HasPrefix(tsQ, jsQ) || len(tsQ) <= len(jsQ) {
+		t.Errorf("typescript highlight query should compose javascript base ahead of its additions (js=%dB ts=%dB)", len(jsQ), len(tsQ))
+	}
+	if !strings.HasPrefix(tsxQ, tsQ) {
+		t.Errorf("tsx highlight query should compose the already-composed typescript query (ts=%dB tsx=%dB)", len(tsQ), len(tsxQ))
+	}
+	if !strings.HasPrefix(cppQ, cQ) || len(cppQ) <= len(cQ) {
+		t.Errorf("cpp highlight query should compose c base ahead of its additions (c=%dB cpp=%dB)", len(cQ), len(cppQ))
+	}
+
+	goEntry := DetectLanguageByName("go")
+	if goEntry == nil {
+		t.Fatal("expected go to be registered")
+	}
+	if strings.HasPrefix(goEntry.HighlightQuery, jsQ) {
+		t.Error("go has no highlight parent and must not gain one")
+	}
+}
+
+func TestHighlightInheritanceIdempotentAcrossReregistration(t *testing.T) {
+	before := DetectLanguageByName("typescript").HighlightQuery
+
+	oldRegistry := append([]LangEntry(nil), registry...)
+	oldResolved := highlightInheritanceResolved
+	t.Cleanup(func() {
+		registry = oldRegistry
+		highlightInheritanceResolved = oldResolved
+		extIndex = nil
+	})
+
+	// Any registration resets highlightInheritanceResolved; the next lookup
+	// re-runs resolution over already-composed entries.
+	Register(LangEntry{Name: "zz_idempotency_probe", HighlightQuery: "(identifier) @variable"})
+
+	after := DetectLanguageByName("typescript").HighlightQuery
+	if after != before {
+		t.Fatalf("re-resolution must be idempotent: typescript query changed %dB -> %dB", len(before), len(after))
+	}
+}
+
+func TestHighlightInheritanceCycleTerminates(t *testing.T) {
+	oldRegistry := append([]LangEntry(nil), registry...)
+	oldResolved := highlightInheritanceResolved
+	t.Cleanup(func() {
+		registry = oldRegistry
+		highlightInheritanceResolved = oldResolved
+		extIndex = nil
+	})
+
+	Register(LangEntry{Name: "zz_cycle_a", HighlightQuery: "(a) @x", InheritHighlights: "zz_cycle_b"})
+	Register(LangEntry{Name: "zz_cycle_b", HighlightQuery: "(b) @y", InheritHighlights: "zz_cycle_a"})
+
+	a := DetectLanguageByName("zz_cycle_a")
+	b := DetectLanguageByName("zz_cycle_b")
+	if a == nil || b == nil {
+		t.Fatal("cycle entries should still be registered")
+	}
+	if !strings.Contains(a.HighlightQuery, "(a) @x") || !strings.Contains(b.HighlightQuery, "(b) @y") {
+		t.Error("cycle members must keep their own query")
+	}
+	if strings.Count(a.HighlightQuery, "(a) @x") != 1 || strings.Count(b.HighlightQuery, "(b) @y") != 1 {
+		t.Error("cycle resolution must not duplicate queries")
+	}
+}


### PR DESCRIPTION
## Summary

Significantly improve the highlight inheritance resolution in the grammar registry to correctly handle multi-level inheritance chains (e.g., tsx → typescript → javascript), prevent query duplication on re-registration, and safely terminate infinite cycles. This ensures highlight queries are composed correctly regardless of registration order and remain idempotent across registry mutations.

## Changes

- Add rawHighlightQuery and highlightRawCaptured fields to LangEntry to preserve the original highlight query before composition, preventing query duplication on re-resolution
- Introduce defaultHighlightInherits map for upstream tree-sitter conventions (typescript→javascript, tsx→typescript, cpp→c) for grammars that don't explicitly set InheritHighlights
- Refactor resolveHighlightInheritance to use recursive resolution with caching and cycle detection, supporting multi-level chains regardless of registration order
- Add TestHighlightInheritanceComposesDefaultChains verifying proper query composition for inherited languages, and that non-inheriting languages like Go remain unaffected
- Add TestHighlightInheritanceIdempotentAcrossReregistration confirming that re-running resolution after any Register call produces identical results
- Add TestHighlightInheritanceCycleTerminates ensuring mutual inheritance cycles are safely terminated without duplicating queries

## Testing

- Run go test ./grammars -run 'TestHighlightInheritance' -v to verify the three new inheritance tests pass
- Run existing highlight-related tests: go test ./grammars -run 'Highlight' -count=1 to confirm no regressions