### PR TITLE
test(parser): add bounded semantic phase tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ for tags and release notes while still in `0.x`.
 
 ### Tooling
 
+- Add a bounded, build-tagged parser trace that records action lookup, dispatch,
+  and convergence context without retaining physical stack IDs. Coarse boundary
+  classes are labeled non-canonical; observer equality and untagged assembly
+  tests keep the trace diagnostic-only.
 - Add the four-fixture authenticated Go/static-C work-count board with direct
   counters at their exact hook boundaries, Go-only representation rows marked
   incomparable, and missing mandatory instrumentation reported separately from

--- a/cgo_harness/work_count/semantic_phase_trace_contract_v4.json
+++ b/cgo_harness/work_count/semantic_phase_trace_contract_v4.json
@@ -1,0 +1,124 @@
+{
+  "schema": "gts-semantic-phase-trace-contract/v4",
+  "event_contract": "gts-semantic-phase-trace/v4",
+  "scope": "Diagnostic Go full-parse action lookup, dispatch, and convergence events. The contract and all ordinal reconstruction are absent from untagged builds.",
+  "retention": {
+    "maximum_events": 8192,
+    "policy": "retain_chronological_prefix",
+    "overflow": "saturate counters and expose events_dropped plus arithmetic_overflow"
+  },
+  "classification": {
+    "name": "coarse_go_lookup_class",
+    "purpose": "Locate candidate repetition classes that justify a later paired canonical Go/C trace.",
+    "not_proved": [
+      "semantic replay",
+      "full predecessor-spine equality",
+      "exact scanner-checkpoint equality",
+      "whole-parse repetition rate",
+      "Go/C event equivalence"
+    ],
+    "collision_policy": "The coarse boundary hash may collide or merge distinct predecessor spines. Repeated classes are attribution hints only."
+  },
+  "event_context": {
+    "action_lookup": "The actual election ordinal, parse-loop iteration, stack state/byte, current lookahead, ordered action-cell fingerprint, action ordinal/type, and coarse current-head class.",
+    "action_execution": "Direct table dispatches thread the selected action ordinal. The deterministic-conflict seam passes an inference sentinel whose uniqueness scan exists only in the tagged trace implementation; duplicate-equal actions remain explicit unknown ordinal. Synthetic no-action and retry recovery actions always use unknown ordinal.",
+    "decision": "Election ordinal, iteration, and current lookahead come from the active parse attempt. Relex refreshes the lookahead without advancing the election ordinal. State, byte, and coarse classes come from the actual target and candidate. Action-cell fingerprint and ordinal/type are unset because convergence decisions are not assigned by last-writer context to an action lookup."
+  },
+  "dispatch_bypass_audit": {
+    "parse_table_routes_instrumented": [
+      "ordinary single action",
+      "conflict original and forks",
+      "deterministic conflict selection",
+      "reduce chains and conflict frontiers",
+      "extra-shift fast path",
+      "post-reduce terminal frontier",
+      "trailing-EOF prefix single-action REDUCE and ACCEPT"
+    ],
+    "synthetic_routes_not_claimed_as_table_ordinals": [
+      "no-action recovery found by stack search",
+      "retry recovery found by stack search",
+      "missing-token insertion",
+      "external no-action default reduction",
+      "eager default reduction",
+      "C-shaped error-state recovery"
+    ],
+    "ordinal_policy": "A table ordinal is emitted only when it is directly threaded or uniquely inferred inside the tagged implementation. Synthetic routes and duplicate-equal candidates emit -1.",
+    "trailing_eof_call_site_audit": "Both calls in advanceTrailingEOFPrefix enter the same instrumented tryAdvanceEOFOnSingleStack loop: the first before missing insertion and the second after it. The focused route admission proves the loop's ordinal-0 REDUCE followed by ordinal-0 ACCEPT path."
+  },
+  "physical_identity": {
+    "excluded": [
+      "stack_pointer",
+      "stack_version_id",
+      "gss_node_id",
+      "subtree_pointer"
+    ],
+    "scanner_checkpoint": "Not represented in v4. This omission is one reason the coarse class is not semantic identity."
+  },
+  "hash": {
+    "algorithm": "fnv1a-64",
+    "word_encoding": "eight little-endian bytes per unsigned 64-bit word",
+    "action_cell_words": [
+      "action_count",
+      "for each ordered action: type",
+      "state",
+      "symbol",
+      "child_count",
+      "dynamic_precedence_as_uint16",
+      "production_id",
+      "flags(extra=1, extra_chain=2, repetition=4)"
+    ],
+    "coarse_boundary_words": [
+      "stack_byte_offset",
+      "logical_depth",
+      "top_state",
+      "top_symbol",
+      "top_start_byte<<32 | top_end_byte",
+      "top_child_count",
+      "top_production_id",
+      "top_dynamic_precedence_as_uint32",
+      "flags(extra=1, missing=2, has_error=4, dead=8, accepted=16, paused=32)"
+    ]
+  },
+  "paired_canonical_trace_plan": {
+    "prerequisite": "Do not compare v4 coarse hashes across engines. First define canonical variable-length fields and audit hash collisions by full field equality.",
+    "canonical_fields": [
+      "parse attempt and lexer election ordinal",
+      "lookahead symbol, byte/point span, and no-lookahead/external flags",
+      "exact serialized scanner checkpoint bytes and length; hashes are transport checks only",
+      "ordered action cell with exact action fields and table ordinal",
+      "stack status, state, byte/point position, error cost, dynamic precedence, and node count",
+      "ordered predecessor spine to the reduction boundary",
+      "for each popped subtree: symbol, padding, size, child count, production id, flags, dynamic precedence, and exact external scanner state bytes",
+      "decision outcome and resulting canonical boundary fields"
+    ],
+    "collision_audit": "Retain canonical fields alongside any digest. Fail admission if equal digests have unequal canonical fields in either engine.",
+    "hooks": [
+      {
+        "file": "lib/src/parser.c",
+        "function": "ts_parser__advance",
+        "point": "After ts_language_table_entry and before the ordered action loop; then at each action-loop iteration before dispatch."
+      },
+      {
+        "file": "lib/src/parser.c",
+        "function": "ts_parser__reduce",
+        "point": "Around ts_stack_pop_count and each produced StackSlice/version."
+      },
+      {
+        "file": "lib/src/stack.c",
+        "function": "ts_stack_pop_count",
+        "point": "Expose the ordered predecessor spine, popped subtree descriptors, and exact external states for each path."
+      },
+      {
+        "file": "lib/src/stack.c",
+        "function": "ts_stack_merge",
+        "point": "Before can-merge and after merge/removal."
+      },
+      {
+        "file": "lib/src/parser.c",
+        "function": "ts_parser__condense_stack",
+        "point": "At pause, resume, remove, and cull decisions."
+      }
+    ],
+    "oracle_policy": "Extend only the locked diagnostic work-count patch and static driver. Do not change the grammar, compiler flags, parser options, tree admission, or timing oracle."
+  }
+}

--- a/parser.go
+++ b/parser.go
@@ -1025,7 +1025,8 @@ func (d *parseStopActionDiagnostic) beginDispatch() {
 	d.lastReduceCaptured = false
 }
 
-func (p *Parser) noteStopActionDiagnostic(phase string, s *glrStack, tok Token, act ParseAction, actionCount int, inReduceChain bool, chainStep int, repeatedCount int, cycle bool) {
+func (p *Parser) noteStopActionDiagnostic(phase string, s *glrStack, tok Token, act ParseAction, actionOrdinal, actionCount int, inReduceChain bool, chainStep int, repeatedCount int, cycle bool) {
+	semanticPhaseTraceRecordActionExecution(p, s, tok, act, actionOrdinal, phase, cycle) // semantic-phase-assembly: action-execution seam
 	if p == nil || p.stopActionDiag == nil || s == nil || s.dead || s.accepted || s.depth() == 0 {
 		return
 	}
@@ -2572,8 +2573,14 @@ func (p *Parser) tryAdvanceEOFOnSingleStack(s *glrStack, tok Token, expectedEOFB
 			return false
 		}
 		act := actions[0]
+		if semanticPhaseTraceActive() {
+			semanticPhaseTraceRecordActionCell(p, s, s.top().state, tok, actions) // semantic-phase-assembly: EOF-prefix action-cell seam
+		}
 		switch act.Type {
 		case ParseActionReduce:
+			if semanticPhaseTraceActive() {
+				semanticPhaseTraceRecordActionExecution(p, s, tok, act, 0, "eof-prefix-reduce", false) // semantic-phase-assembly: EOF-prefix action-execution seam
+			}
 			p.applyAction(nil, s, act, tok, &anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, false, nil)
 			if p.rejectUndrainedPendingForkStacks(s) {
 				return false
@@ -2582,6 +2589,9 @@ func (p *Parser) tryAdvanceEOFOnSingleStack(s *glrStack, tok Token, expectedEOFB
 				return false
 			}
 		case ParseActionAccept:
+			if semanticPhaseTraceActive() {
+				semanticPhaseTraceRecordActionExecution(p, s, tok, act, 0, "eof-prefix-accept", false)
+			}
 			s.accepted = true
 			return true
 		default:
@@ -4759,6 +4769,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if reuse != nil && len(stacks) == 1 && !stacks[0].dead && tok.Symbol != 0 {
 			if nextTok, ok := p.tryReuseCurrentParseSubtree(&stacks[0], tok, ts, reuse, scratch, arena, &reuseState, timing); ok {
 				tok = nextTok
+				workCountRefreshConvergenceLookahead(tok)
 				needToken = false
 				consecutiveReduces = 0
 				consecutiveNoTokenDispatches = 0
@@ -5006,6 +5017,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 								tok.Symbol, tok.StartByte, tok.EndByte, nextTok.Symbol, nextTok.StartByte, nextTok.EndByte)
 						}
 						tok = nextTok
+						workCountRefreshConvergenceLookahead(tok)
 						noteStopDiagnosticToken(tok)
 						p.updateCurrentExternalTokenCheckpoint(ts, tok)
 						lastTokenEndByte = tok.EndByte
@@ -5073,6 +5085,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if actionIdx != 0 && int(actionIdx) < len(parseActions) {
 				actions = parseActions[actionIdx].Actions
 			}
+			semanticPhaseTraceRecordActionCell(p, s, currentState, tok, actions) // semantic-phase-assembly: action-cell seam
 			workCountRecordResolvedActionCell(len(actions))
 			workCountAddActionEntries(len(actions))
 			if phaseTiming {
@@ -5081,6 +5094,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if keywordSym, ok := p.typeScriptContextualPropertyKeywordSymbol(tok, source); ok && parseStacksShareState(stacks[:numStacks], currentState) {
 				if p.typeScriptContextualPropertyKeywordHasAction(keywordSym, currentState) {
 					tok.Symbol = keywordSym
+					workCountRefreshConvergenceLookahead(tok)
 					needToken = false
 					goto retryAction
 				}
@@ -5103,6 +5117,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					continue
 				}
 				traceVisit(si, s, "extra-shift", 0, len(actions), actions[0])
+				semanticPhaseTraceRecordActionExecution(p, s, tok, actions[0], 0, "extra-shift", false) // semantic-phase-assembly: extra-shift-execution seam
 				p.applyExtraShiftAction(s, currentState, actions[0], tok, arena, scratch, trackChildErrors)
 				nodeCount++
 				traceAfterPrimary(si, s)
@@ -5169,6 +5184,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					if sameState {
 						if reTok, ok := p.tryRelexCurrentStateDFA(tok, currentState, ts); ok {
 							tok = reTok
+							workCountRefreshConvergenceLookahead(tok)
 							needToken = false
 							if actionTiming != nil {
 								ns := recordNoActionTiming()
@@ -5233,6 +5249,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if canRelexNoLiveAction {
 					if reTok, ok := p.tryRelexSingleParserState(tok, currentState, ts, stacks, scratch); ok {
 						tok = reTok
+						workCountRefreshConvergenceLookahead(tok)
 						needToken = false
 						if actionTiming != nil {
 							ns := recordNoActionTiming()
@@ -5244,6 +5261,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if sameState {
 					if reTok, ok := p.tryRelexCurrentStateDFA(tok, currentState, ts); ok {
 						tok = reTok
+						workCountRefreshConvergenceLookahead(tok)
 						needToken = false
 						if actionTiming != nil {
 							ns := recordNoActionTiming()
@@ -5253,6 +5271,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					if reTok, ok := p.tryRelexBroadDFA(tok, currentState, ts); ok {
 						tok = reTok
+						workCountRefreshConvergenceLookahead(tok)
 						needToken = false
 						if actionTiming != nil {
 							ns := recordNoActionTiming()
@@ -5355,7 +5374,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					if !p.guardRealTokenAttachmentGap(source, s, tok, "recover") {
 						continue
 					}
-					p.noteStopActionDiagnostic("no-action-recover", s, tok, recoverAct, 1, false, 0, 0, false)
+					p.noteStopActionDiagnostic("no-action-recover", s, tok, recoverAct, -1, 1, false, 0, 0, false)
 					p.applyAction(source, s, recoverAct, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
 					drainPendingForkStacks()
@@ -5440,12 +5459,16 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					conflictStart = time.Now()
 				}
 				var chosen ParseAction
+				chosenOrdinal := -1
 				choice := false
 				if next, ok := p.deterministicConflictChoiceForDispatch(source, s, tok, currentState, actions, maxStacksSeen, reuse); ok {
 					chosen, choice = next, true
+					// The diagnostic tagged seam may infer a unique ordinal. The
+					// production build deliberately performs no reconstruction scan.
+					chosenOrdinal = -2
 				}
 				if !choice && deterministicExternalConflicts && p.language != nil && p.language.Name == "yaml" && p.language.ExternalScanner != nil {
-					chosen, choice = deterministicExternalConflictAction(actions), true
+					chosen, chosenOrdinal, choice = deterministicExternalConflictActionAt(actions)
 				}
 				if choice {
 					skipRepetitionShift := false
@@ -5462,7 +5485,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					traceVisit(si, s, "conflict-choice", -1, len(actions), chosen)
 					setPendingTrace("conflict-choice", si, -1, len(actions), chosen)
-					p.noteStopActionDiagnostic("conflict-choice", s, tok, chosen, len(actions), false, 0, 0, false)
+					p.noteStopActionDiagnostic("conflict-choice", s, tok, chosen, chosenOrdinal, len(actions), false, 0, 0, false)
 					actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
 					p.applyAction(source, s, chosen, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
@@ -5517,7 +5540,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 					traceVisit(si, s, "conflict-depth-cap", 0, len(actions), actions[0])
 					setPendingTrace("conflict-depth-cap", si, 0, len(actions), actions[0])
-					p.noteStopActionDiagnostic("conflict-depth-cap", s, tok, actions[0], len(actions), false, 0, 0, false)
+					p.noteStopActionDiagnostic("conflict-depth-cap", s, tok, actions[0], 0, len(actions), false, 0, 0, false)
 					actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
 					p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
@@ -5554,7 +5577,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					if actions[ai].Type != ParseActionShift || p.guardRealShiftGap(source, &fork, tok) {
 						if actions[ai].Type != ParseActionRecover || p.guardRealTokenAttachmentGap(source, &fork, tok, "recover") {
 							setPendingTrace("conflict-fork", si, ai, len(actions), actions[ai])
-							p.noteStopActionDiagnostic("conflict-fork", &fork, tok, actions[ai], len(actions), false, 0, 0, false)
+							p.noteStopActionDiagnostic("conflict-fork", &fork, tok, actions[ai], ai, len(actions), false, 0, 0, false)
 							actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(&fork)
 							p.applyAction(source, &fork, actions[ai], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 							p.noteStopActionResult(&fork)
@@ -5602,7 +5625,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				}
 				traceVisit(si, s, "conflict-original", 0, len(actions), actions[0])
 				setPendingTrace("conflict-original", si, 0, len(actions), actions[0])
-				p.noteStopActionDiagnostic("conflict-original", s, tok, actions[0], len(actions), false, 0, 0, false)
+				p.noteStopActionDiagnostic("conflict-original", s, tok, actions[0], 0, len(actions), false, 0, 0, false)
 				actionBeforeState, actionBeforeByte, actionBeforeDepth := stackTraceState(s)
 				p.applyAction(source, s, actions[0], tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 				p.noteStopActionResult(s)
@@ -5642,7 +5665,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if act.Type == ParseActionReduce && !disableBashReduceChain {
 				traceVisit(si, s, "single-reduce", 0, len(actions), act)
 				setPendingTrace("single-reduce", si, 0, len(actions), act)
-				p.noteStopActionDiagnostic("single-reduce", s, tok, act, len(actions), false, 0, 0, false)
+				p.noteStopActionDiagnostic("single-reduce", s, tok, act, 0, len(actions), false, 0, 0, false)
 				if p.applyActionWithReduceChain(source, s, act, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors) {
 					forceAdvanceAfterReduce = true
 				}
@@ -5666,7 +5689,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						continue
 					}
 					traceVisit(si, s, "single-shift", 0, len(actions), act)
-					p.noteStopActionDiagnostic("single-shift", s, tok, act, len(actions), false, 0, 0, false)
+					p.noteStopActionDiagnostic("single-shift", s, tok, act, 0, len(actions), false, 0, 0, false)
 					p.applyShiftAction(s, act, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
@@ -5678,7 +5701,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 				case ParseActionAccept:
 					traceVisit(si, s, "single-accept", 0, len(actions), act)
-					p.noteStopActionDiagnostic("single-accept", s, tok, act, len(actions), false, 0, 0, false)
+					p.noteStopActionDiagnostic("single-accept", s, tok, act, 0, len(actions), false, 0, 0, false)
 					p.applyAcceptAction(s)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
@@ -5697,7 +5720,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						continue
 					}
 					traceVisit(si, s, "single-recover", 0, len(actions), act)
-					p.noteStopActionDiagnostic("single-recover", s, tok, act, len(actions), false, 0, 0, false)
+					p.noteStopActionDiagnostic("single-recover", s, tok, act, 0, len(actions), false, 0, 0, false)
 					p.applyRecoverAction(s, act, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
@@ -5710,7 +5733,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				default:
 					traceVisit(si, s, "single-other", 0, len(actions), act)
 					setPendingTrace("single-other", si, 0, len(actions), act)
-					p.noteStopActionDiagnostic("single-other", s, tok, act, len(actions), false, 0, 0, false)
+					p.noteStopActionDiagnostic("single-other", s, tok, act, 0, len(actions), false, 0, 0, false)
 					p.applyAction(source, s, act, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(s)
 					traceAfterPrimary(si, s)
@@ -5761,7 +5784,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					if !p.guardRealTokenAttachmentGap(source, &stacks[0], tok, "recover") {
 						continue
 					}
-					p.noteStopActionDiagnostic("retry-recover", &stacks[0], tok, recoverAct, 1, false, 0, 0, false)
+					p.noteStopActionDiagnostic("retry-recover", &stacks[0], tok, recoverAct, -1, 1, false, 0, 0, false)
 					p.applyAction(source, &stacks[0], recoverAct, tok, &anyReduced, &nodeCount, arena, &scratch.entries, &scratch.gss, &scratch.tmpEntries, deferParentLinks, trackChildErrors)
 					p.noteStopActionResult(&stacks[0])
 					drainPendingForkStacks()
@@ -5795,6 +5818,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			condenseRan = true
 			var reason ParseStopReason
 			stacks, resumed, tok, reason = p.cCondenseAndResume(stacks, source, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
+			workCountRefreshConvergenceLookahead(tok)
 			if resultMaterializationShouldStop(reason) {
 				return finalize(stacks, reason)
 			}
@@ -5835,6 +5859,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 									tok.Symbol, tok.StartByte, tok.EndByte, nextTok.Symbol, nextTok.StartByte, nextTok.EndByte)
 							}
 							tok = nextTok
+							workCountRefreshConvergenceLookahead(tok)
 							noteStopDiagnosticToken(tok)
 							p.updateCurrentExternalTokenCheckpoint(ts, tok)
 							lastTokenEndByte = tok.EndByte
@@ -5917,7 +5942,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							needToken = false
 							break
 						}
-						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-shift", s, tok, item.action, 1, false, 0, 0, false)
+						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-shift", s, tok, item.action, 0, 1, false, 0, 0, false)
 						p.applyShiftAction(s, item.action, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 						p.noteStopActionResult(s)
 					case ParseActionRecover:
@@ -5927,12 +5952,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							needToken = false
 							break
 						}
-						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-recover", s, tok, item.action, 1, false, 0, 0, false)
+						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-recover", s, tok, item.action, 0, 1, false, 0, 0, false)
 						p.applyRecoverAction(s, item.action, tok, &nodeCount, arena, &scratch.entries, &scratch.gss, trackChildErrors)
 						s.shifted = true
 						p.noteStopActionResult(s)
 					case ParseActionAccept:
-						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-accept", s, tok, item.action, 1, false, 0, 0, false)
+						p.noteStopActionDiagnostic("post-reduce-terminal-frontier-accept", s, tok, item.action, 0, 1, false, 0, 0, false)
 						p.applyAcceptAction(s)
 						p.noteStopActionResult(s)
 					}
@@ -6864,17 +6889,27 @@ func (p *Parser) traceStackActions(stackIndex int, state StateID, symbol Symbol,
 }
 
 func deterministicExternalConflictAction(actions []ParseAction) ParseAction {
+	chosen, _, _ := deterministicExternalConflictActionAt(actions)
+	return chosen
+}
+
+func deterministicExternalConflictActionAt(actions []ParseAction) (ParseAction, int, bool) {
+	if len(actions) == 0 {
+		return ParseAction{}, -1, false
+	}
 	chosen := actions[0]
+	chosenOrdinal := 0
 	for ai := 1; ai < len(actions); ai++ {
 		cand := actions[ai]
 		if cand.Type == ParseActionShift {
-			return cand
+			return cand, ai, true
 		}
 		if chosen.Type == ParseActionReduce && cand.Type == ParseActionReduce && cand.DynamicPrecedence > chosen.DynamicPrecedence {
 			chosen = cand
+			chosenOrdinal = ai
 		}
 	}
-	return chosen
+	return chosen, chosenOrdinal, true
 }
 
 func (p *Parser) traceParseFork(currentState StateID, actions []ParseAction) {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -778,22 +778,26 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			return false
 		}
 		var terminal ParseAction
+		terminalOrdinal := -1
 		terminalSet := false
 		var reduce ParseAction
+		reduceOrdinal := -1
 		reduceSet := false
-		for _, act := range actions {
+		for actionOrdinal, act := range actions {
 			switch act.Type {
 			case ParseActionReduce:
 				if reduceSet {
 					return false
 				}
 				reduce = act
+				reduceOrdinal = actionOrdinal
 				reduceSet = true
 			case ParseActionShift, ParseActionRecover, ParseActionAccept:
 				if terminalSet {
 					return false
 				}
 				terminal = act
+				terminalOrdinal = actionOrdinal
 				terminalSet = true
 			default:
 				return false
@@ -823,7 +827,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			case ParseActionShift:
 				fork := s.cloneWithScratch(gssScratch)
 				if p.guardRealShiftGap(source, &fork, tok) {
-					p.noteStopActionDiagnostic("conflict-frontier-fork-shift", &fork, tok, terminal, len(actions), true, step, 0, false)
+					p.noteStopActionDiagnostic("conflict-frontier-fork-shift", &fork, tok, terminal, terminalOrdinal, len(actions), true, step, 0, false)
 					p.applyShiftAction(&fork, terminal, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 					p.noteStopActionResult(&fork)
 					appendTerminalFork(fork)
@@ -831,7 +835,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 				}
 			case ParseActionAccept:
 				fork := s.cloneWithScratch(gssScratch)
-				p.noteStopActionDiagnostic("conflict-frontier-fork-accept", &fork, tok, terminal, len(actions), true, step, 0, false)
+				p.noteStopActionDiagnostic("conflict-frontier-fork-accept", &fork, tok, terminal, terminalOrdinal, len(actions), true, step, 0, false)
 				p.applyAcceptAction(&fork)
 				p.noteStopActionResult(&fork)
 				appendTerminalFork(fork)
@@ -839,7 +843,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			case ParseActionRecover:
 				fork := s.cloneWithScratch(gssScratch)
 				if p.guardRealTokenAttachmentGap(source, &fork, tok, "conflict-frontier-fork-recover") {
-					p.noteStopActionDiagnostic("conflict-frontier-fork-recover", &fork, tok, terminal, len(actions), true, step, 0, false)
+					p.noteStopActionDiagnostic("conflict-frontier-fork-recover", &fork, tok, terminal, terminalOrdinal, len(actions), true, step, 0, false)
 					p.applyRecoverAction(&fork, terminal, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 					fork.shifted = true
 					p.noteStopActionResult(&fork)
@@ -860,7 +864,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 		if currentReduceEntry != nil {
 			currentReduceEntry.flags |= conflictReduceFrontierSeen
 		}
-		p.noteStopActionDiagnostic("conflict-frontier-fork-reduce", s, tok, reduce, len(actions), true, step, 0, false)
+		p.noteStopActionDiagnostic("conflict-frontier-fork-reduce", s, tok, reduce, reduceOrdinal, len(actions), true, step, 0, false)
 		p.applyReduceActionDispatch(source, s, reduce, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 		p.noteStopActionResult(s)
 		return true
@@ -891,19 +895,19 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			if entry != nil {
 				entry.flags |= conflictReduceFrontierSeen
 			}
-			p.noteStopActionDiagnostic("conflict-frontier-reduce", s, tok, act, 1, true, step, 0, false)
+			p.noteStopActionDiagnostic("conflict-frontier-reduce", s, tok, act, 0, 1, true, step, 0, false)
 			p.applyReduceActionDispatch(source, s, act, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)
 		case ParseActionShift:
 			if !p.guardRealShiftGap(source, s, tok) {
 				return
 			}
-			p.noteStopActionDiagnostic("conflict-frontier-shift", s, tok, act, 1, true, step, 0, false)
+			p.noteStopActionDiagnostic("conflict-frontier-shift", s, tok, act, 0, 1, true, step, 0, false)
 			p.applyShiftAction(s, act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			p.noteStopActionResult(s)
 			return
 		case ParseActionAccept:
-			p.noteStopActionDiagnostic("conflict-frontier-accept", s, tok, act, 1, true, step, 0, false)
+			p.noteStopActionDiagnostic("conflict-frontier-accept", s, tok, act, 0, 1, true, step, 0, false)
 			p.applyAcceptAction(s)
 			p.noteStopActionResult(s)
 			return
@@ -911,7 +915,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 			if !p.guardRealTokenAttachmentGap(source, s, tok, "conflict-frontier-recover") {
 				return
 			}
-			p.noteStopActionDiagnostic("conflict-frontier-recover", s, tok, act, 1, true, step, 0, false)
+			p.noteStopActionDiagnostic("conflict-frontier-recover", s, tok, act, 0, 1, true, step, 0, false)
 			p.applyRecoverAction(s, act, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			s.shifted = true
 			p.noteStopActionResult(s)
@@ -1993,14 +1997,14 @@ func (p *Parser) chainSingleReduceActions(source []byte, s *glrStack, tok Token,
 					fmt.Printf("      -> REDUCE-CHAIN CYCLE state=%d depth=%d sym=%d prod=%d count=%d\n",
 						currentState, currentDepth, next.Symbol, next.ProductionID, repeatedSigCount)
 				}
-				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 1, true, chainLen+1, repeatedSigCount, true)
+				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 0, 1, true, chainLen+1, repeatedSigCount, true)
 				return p.recoverReduceChainCycle(source, s, currentState, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			}
 			chainLen++
 			if perfCountersEnabled {
 				perfRecordReduceChainStep(chainLen)
 			}
-			p.noteStopActionDiagnostic("reduce-chain", s, tok, next, 1, true, chainLen, repeatedSigCount, false)
+			p.noteStopActionDiagnostic("reduce-chain", s, tok, next, 0, 1, true, chainLen, repeatedSigCount, false)
 			p.applyReduceActionDispatch(source, s, next, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)
 			if s.dead || s.accepted || s.shifted {
@@ -2131,7 +2135,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedHinted(source []byte, s *glrS
 			perfRecordReduceChainStep(steps)
 			perfRecordReduceChainHintSteps(1)
 		}
-		p.noteStopActionDiagnostic("reduce-chain-hint", s, tok, classified.action, 1, true, steps, 0, false)
+		p.noteStopActionDiagnostic("reduce-chain-hint", s, tok, classified.action, 0, 1, true, steps, 0, false)
 		p.applyReduceActionDispatch(source, s, classified.action, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 		p.noteStopActionResult(s)
 		if s.dead || s.accepted || s.shifted {
@@ -2175,14 +2179,14 @@ func (p *Parser) chainSingleReduceActionsClassifiedDefault(source []byte, s *glr
 					fmt.Printf("      -> REDUCE-CHAIN CYCLE state=%d depth=%d sym=%d prod=%d count=%d\n",
 						currentState, currentDepth, next.Symbol, next.ProductionID, repeatedSigCount)
 				}
-				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 1, true, chainLen+1, repeatedSigCount, true)
+				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 0, 1, true, chainLen+1, repeatedSigCount, true)
 				return p.recoverReduceChainCycle(source, s, currentState, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			}
 			chainLen++
 			if perfCountersEnabled {
 				perfRecordReduceChainStep(chainLen)
 			}
-			p.noteStopActionDiagnostic("reduce-chain", s, tok, next, 1, true, chainLen, repeatedSigCount, false)
+			p.noteStopActionDiagnostic("reduce-chain", s, tok, next, 0, 1, true, chainLen, repeatedSigCount, false)
 			p.applyReduceActionDispatch(source, s, next, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)
 			if s.dead || s.accepted || s.shifted {
@@ -2290,7 +2294,7 @@ func (p *Parser) chainSingleReduceActionsProfiled(source []byte, s *glrStack, to
 						currentState, currentDepth, next.Symbol, next.ProductionID, repeatedSigCount)
 				}
 				p.ambiguityProfile.recordReduceChainRun(chainStartState, tok.Symbol, currentState, classifiedParseActionSingleReduce, chainLen, chainLen, classHits, time.Since(chainStart).Nanoseconds(), reduceChainStopCycle)
-				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 1, true, chainLen+1, repeatedSigCount, true)
+				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 0, 1, true, chainLen+1, repeatedSigCount, true)
 				return p.recoverReduceChainCycle(source, s, currentState, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			}
 			chainLen++
@@ -2298,7 +2302,7 @@ func (p *Parser) chainSingleReduceActionsProfiled(source []byte, s *glrStack, to
 				perfRecordReduceChainStep(chainLen)
 			}
 			reduceStart := time.Now()
-			p.noteStopActionDiagnostic("reduce-chain-profiled", s, tok, next, 1, true, chainLen, repeatedSigCount, false)
+			p.noteStopActionDiagnostic("reduce-chain-profiled", s, tok, next, 0, 1, true, chainLen, repeatedSigCount, false)
 			p.applyReduceActionDispatch(source, s, next, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)
 			p.ambiguityProfile.recordReduceChainStep(currentState, tok.Symbol, next, chainLen, time.Since(reduceStart).Nanoseconds())
@@ -2413,7 +2417,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedHintedProfiled(source []byte,
 			perfRecordReduceChainHintSteps(1)
 		}
 		reduceStart := time.Now()
-		p.noteStopActionDiagnostic("reduce-chain-hint-profiled", s, tok, next, 1, true, chainLen, 0, false)
+		p.noteStopActionDiagnostic("reduce-chain-hint-profiled", s, tok, next, 0, 1, true, chainLen, 0, false)
 		p.applyReduceActionDispatch(source, s, next, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 		p.noteStopActionResult(s)
 		p.ambiguityProfile.recordReduceChainStep(currentState, tok.Symbol, next, chainLen, time.Since(reduceStart).Nanoseconds())
@@ -2469,7 +2473,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedProfiledDefault(source []byte
 						currentState, currentDepth, next.Symbol, next.ProductionID, repeatedSigCount)
 				}
 				p.ambiguityProfile.recordReduceChainRun(chainStartState, tok.Symbol, currentState, classifiedParseActionSingleReduce, chainLen, chainLen, classHits, time.Since(chainStart).Nanoseconds(), reduceChainStopCycle)
-				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 1, true, chainLen+1, repeatedSigCount, true)
+				p.noteStopActionDiagnostic("reduce-chain-cycle", s, tok, next, 0, 1, true, chainLen+1, repeatedSigCount, true)
 				return p.recoverReduceChainCycle(source, s, currentState, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 			}
 			chainLen++
@@ -2477,7 +2481,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedProfiledDefault(source []byte
 				perfRecordReduceChainStep(chainLen)
 			}
 			reduceStart := time.Now()
-			p.noteStopActionDiagnostic("reduce-chain-profiled", s, tok, next, 1, true, chainLen, repeatedSigCount, false)
+			p.noteStopActionDiagnostic("reduce-chain-profiled", s, tok, next, 0, 1, true, chainLen, repeatedSigCount, false)
 			p.applyReduceActionDispatch(source, s, next, tok, anyReduced, nodeCount, arena, entryScratch, gssScratch, tmpEntries, deferParentLinks, trackChildErrors)
 			p.noteStopActionResult(s)
 			p.ambiguityProfile.recordReduceChainStep(currentState, tok.Symbol, next, chainLen, time.Since(reduceStart).Nanoseconds())

--- a/work_count_convergence.go
+++ b/work_count_convergence.go
@@ -213,6 +213,7 @@ const workCountConvergenceDecisionSlots = workCountConvergenceMaxEvents
 var activeWorkCountConvergence struct {
 	attempt           uint32
 	iteration         uint64
+	electionOrdinal   uint64
 	lookahead         Token
 	lookaheadPresent  bool
 	nextDecision      uint32
@@ -228,6 +229,7 @@ func workCountBeginConvergence(c *DiagnosticWorkCount) {
 	activeWorkCountConvergence = struct {
 		attempt           uint32
 		iteration         uint64
+		electionOrdinal   uint64
 		lookahead         Token
 		lookaheadPresent  bool
 		nextDecision      uint32
@@ -251,6 +253,7 @@ func workCountBeginConvergence(c *DiagnosticWorkCount) {
 func workCountResetConvergenceAttempt(index uint32) {
 	activeWorkCountConvergence.attempt = index
 	activeWorkCountConvergence.iteration = 0
+	activeWorkCountConvergence.electionOrdinal = 0
 	activeWorkCountConvergence.lookahead = Token{}
 	activeWorkCountConvergence.lookaheadPresent = false
 	activeWorkCountConvergence.nextDecision = 0
@@ -263,6 +266,7 @@ func workCountEndConvergence() {
 	activeWorkCountConvergence = struct {
 		attempt           uint32
 		iteration         uint64
+		electionOrdinal   uint64
 		lookahead         Token
 		lookaheadPresent  bool
 		nextDecision      uint32
@@ -288,6 +292,22 @@ func workCountConvergenceActive() bool {
 }
 
 func workCountSetConvergenceLookahead(tok Token) {
+	if activeWorkCountConvergence.electionOrdinal == math.MaxUint64 {
+		if c := activeDiagnosticWorkCount; c != nil {
+			c.Convergence.ArithmeticOverflow = true
+			c.Overflow = true
+		}
+	} else {
+		activeWorkCountConvergence.electionOrdinal++
+	}
+	activeWorkCountConvergence.lookahead = tok
+	activeWorkCountConvergence.lookaheadPresent = true
+}
+
+// workCountRefreshConvergenceLookahead replaces the token attached to the
+// current election without advancing its ordinal. Relexing changes the
+// decision input, not the identity of the parser election that requested it.
+func workCountRefreshConvergenceLookahead(tok Token) {
 	activeWorkCountConvergence.lookahead = tok
 	activeWorkCountConvergence.lookaheadPresent = true
 }
@@ -633,6 +653,7 @@ func workCountRecordConvergence(p *Parser, phase, outcome, reason, detail string
 		workCountConvergenceVocabularyViolation()
 		return
 	}
+	semanticPhaseTraceRecordDecision(p, phase, outcome, reason, target, candidate, candidateCountBefore, candidateCountAfter)
 	if activeWorkCountConvergence.attempt == 0 {
 		workCountConvergenceVocabularyViolation()
 		return

--- a/work_count_hooks.go
+++ b/work_count_hooks.go
@@ -37,6 +37,13 @@ func workCountRecordNoTreeParentConstruction()                                  
 func workCountSetConvergenceIteration(int)                                              {}
 func workCountConvergenceActive() bool                                                  { return false }
 func workCountSetConvergenceLookahead(Token)                                            {}
+func workCountRefreshConvergenceLookahead(Token)                                        {}
+
+func semanticPhaseTraceRecordActionCell(*Parser, *glrStack, StateID, Token, []ParseAction) {}
+func semanticPhaseTraceActive() bool                                                       { return false }
+func semanticPhaseTraceRecordActionExecution(*Parser, *glrStack, Token, ParseAction, int, string, bool) {
+}
+
 func workCountConvergenceShapeOf(*glrStack) workCountConvergenceShape {
 	return workCountConvergenceShape{}
 }

--- a/work_count_production_assembly_test.go
+++ b/work_count_production_assembly_test.go
@@ -16,15 +16,20 @@ import (
 )
 
 const (
-	finalizeDeferGuardMarker     = "work-count-assembly: finalize-defer guard"
-	popPayloadCensusMarker       = "work-count-assembly: payload-census seam"
-	convergenceIterationMarker   = "work-count-assembly: convergence iteration seam"
-	convergenceFinalExpandMarker = "work-count-assembly: convergence final-expand seam"
-	convergenceGSSMarker         = "work-count-assembly: convergence GSS seam"
-	gssMutationSetPrimaryMarker  = "work-count-assembly: GSS mutation set-primary seam"
-	gssMutationSetExtraMarker    = "work-count-assembly: GSS mutation set-extra seam"
-	gssMutationAppendReuseMarker = "work-count-assembly: GSS mutation append-reuse seam"
-	gssMutationAppendGrowMarker  = "work-count-assembly: GSS mutation append-grow seam"
+	finalizeDeferGuardMarker               = "work-count-assembly: finalize-defer guard"
+	popPayloadCensusMarker                 = "work-count-assembly: payload-census seam"
+	convergenceIterationMarker             = "work-count-assembly: convergence iteration seam"
+	convergenceFinalExpandMarker           = "work-count-assembly: convergence final-expand seam"
+	convergenceGSSMarker                   = "work-count-assembly: convergence GSS seam"
+	gssMutationSetPrimaryMarker            = "work-count-assembly: GSS mutation set-primary seam"
+	gssMutationSetExtraMarker              = "work-count-assembly: GSS mutation set-extra seam"
+	gssMutationAppendReuseMarker           = "work-count-assembly: GSS mutation append-reuse seam"
+	gssMutationAppendGrowMarker            = "work-count-assembly: GSS mutation append-grow seam"
+	semanticPhaseActionCellMarker          = "semantic-phase-assembly: action-cell seam"
+	semanticPhaseActionExecutionMarker     = "semantic-phase-assembly: action-execution seam"
+	semanticPhaseExtraShiftExecutionMarker = "semantic-phase-assembly: extra-shift-execution seam"
+	semanticPhaseEOFActionCellMarker       = "semantic-phase-assembly: EOF-prefix action-cell seam"
+	semanticPhaseEOFActionExecutionMarker  = "semantic-phase-assembly: EOF-prefix action-execution seam"
 )
 
 func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
@@ -34,6 +39,9 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	productionWorkCountSymbol := regexp.MustCompile(`(?m)^\s*[0-9a-f]+\s+\S\s+github\.com/odvcencio/gotreesitter\.(?:\(\*[^)]*\)\.)?workCount`)
 	if match := productionWorkCountSymbol.Find(nm); match != nil {
 		t.Fatalf("untagged binary retains a production work-count symbol: %s", match)
+	}
+	if bytes.Contains(nm, []byte("github.com/odvcencio/gotreesitter.semanticPhaseTrace")) {
+		t.Fatal("untagged binary retains semantic-phase trace symbols")
 	}
 	for _, forbidden := range []string{
 		"gssMainCanMergeForParserPhase",
@@ -62,6 +70,15 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	assertNoDiagnosticAssembly(t, reduceAssembly)
 
 	assertNoAssemblyAtMarker(t, closures, "parser.go", convergenceIterationMarker)
+	assertNoAssemblyAtMarker(t, closures, "parser.go", semanticPhaseActionCellMarker)
+	assertNoAssemblyAtMarker(t, closures, "parser.go", semanticPhaseExtraShiftExecutionMarker)
+	eofAdvanceAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.tryAdvanceEOFOnSingleStack`, testBinary)
+	assertNoAssemblyAtMarker(t, eofAdvanceAssembly, "parser.go", semanticPhaseEOFActionCellMarker)
+	assertNoAssemblyAtMarker(t, eofAdvanceAssembly, "parser.go", semanticPhaseEOFActionExecutionMarker)
+	assertNoDiagnosticAssembly(t, eofAdvanceAssembly)
+	noteStopAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.noteStopActionDiagnostic`, testBinary)
+	assertNoAssemblyAtMarker(t, noteStopAssembly, "parser.go", semanticPhaseActionExecutionMarker)
+	assertNoDiagnosticAssembly(t, noteStopAssembly)
 	resultAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.\(\*Parser\)\.buildResultFromGLR`, testBinary)
 	assertNoAssemblyAtMarker(t, resultAssembly, "parser_result.go", convergenceFinalExpandMarker)
 	assertNoDiagnosticAssembly(t, resultAssembly)
@@ -76,6 +93,10 @@ func TestWorkCountProductionAssemblyHasNoDiagnosticScaffolding(t *testing.T) {
 	assertNoDiagnosticAssembly(t, gssMutationAssembly)
 	postReduceAssembly := runGoTool(t, "objdump", "-s", `github.com/odvcencio/gotreesitter\.(?:tryMergePostReduceFork|postReduceForkMergePreflight|\(\*Parser\)\.(?:applyReduceActionForked|applyReduceActionFromGSS))`, testBinary)
 	assertNoDiagnosticAssembly(t, postReduceAssembly)
+	allSymbols := runGoTool(t, "nm", testBinary)
+	if bytes.Contains(allSymbols, []byte("uniqueActionOrdinal")) {
+		t.Fatalf("untagged binary retains action-ordinal reconstruction symbol:\n%s", allSymbols)
+	}
 }
 
 func assertNoAssemblyAtMarker(t *testing.T, assembly []byte, file, marker string) {
@@ -93,6 +114,8 @@ func assertNoDiagnosticAssembly(t *testing.T, assembly []byte) {
 		[]byte("workCountConvergence"),
 		[]byte("work_count_convergence.go:"),
 		[]byte("work_count_hooks.go:"),
+		[]byte("semanticPhaseTrace"),
+		[]byte("work_count_semantic_phase_trace.go:"),
 	} {
 		if bytes.Contains(assembly, forbidden) {
 			t.Fatalf("untagged assembly retains diagnostic code %q:\n%s", forbidden, assembly)

--- a/work_count_semantic_phase_trace.go
+++ b/work_count_semantic_phase_trace.go
@@ -1,0 +1,344 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import "math"
+
+const (
+	DiagnosticSemanticPhaseTraceContract  = "gts-semantic-phase-trace/v4"
+	DiagnosticSemanticPhaseTraceMaxEvents = 8192
+)
+
+// DiagnosticSemanticPhaseTrace is a bounded, diagnostic-only ledger for
+// locating repeated coarse action-cell classes after the parse table lookup.
+// The coarse class deliberately excludes Go pointers and physical IDs, but is
+// not a canonical predecessor-spine identity and may contain collisions.
+type DiagnosticSemanticPhaseTrace struct {
+	Contract           string                         `json:"contract"`
+	MaxEvents          uint32                         `json:"max_events"`
+	EventsSeen         uint64                         `json:"events_seen"`
+	EventsDropped      uint64                         `json:"events_dropped"`
+	ArithmeticOverflow bool                           `json:"arithmetic_overflow"`
+	Events             []DiagnosticSemanticPhaseEvent `json:"events"`
+}
+
+// DiagnosticSemanticPhaseEvent identifies either an action-table lookup or a
+// post-reduction convergence decision. Coarse boundary classes summarize only
+// the current head; they are attribution hints, not cross-engine equality.
+type DiagnosticSemanticPhaseEvent struct {
+	Sequence uint64 `json:"sequence"`
+	Kind     string `json:"kind"`
+
+	TokenOrdinal uint64 `json:"token_ordinal"`
+	Iteration    uint64 `json:"iteration"`
+	ByteOffset   uint32 `json:"byte_offset"`
+	State        uint32 `json:"state"`
+
+	LookaheadSymbol    uint32 `json:"lookahead_symbol"`
+	LookaheadStartByte uint32 `json:"lookahead_start_byte"`
+	LookaheadEndByte   uint32 `json:"lookahead_end_byte"`
+	LookaheadFlags     uint8  `json:"lookahead_flags"`
+
+	ActionCellFingerprint  uint64 `json:"action_cell_fingerprint"`
+	CoarseBoundaryClass    uint64 `json:"coarse_boundary_class"`
+	CandidateBoundaryClass uint64 `json:"candidate_coarse_boundary_class,omitempty"`
+	ActionOrdinal          int16  `json:"action_ordinal"`
+	ActionType             int16  `json:"action_type"`
+
+	Phase                string `json:"phase"`
+	Outcome              string `json:"outcome"`
+	Reason               string `json:"reason,omitempty"`
+	CandidateCountBefore uint32 `json:"candidate_count_before"`
+	CandidateCountAfter  uint32 `json:"candidate_count_after"`
+}
+
+var activeDiagnosticSemanticPhaseTrace *DiagnosticSemanticPhaseTrace
+
+func semanticPhaseTraceActive() bool {
+	return activeDiagnosticSemanticPhaseTrace != nil
+}
+
+// BeginDiagnosticSemanticPhaseTrace starts a parse-local trace. The trace is
+// only available in gts_workcount builds and must be paired with
+// BeginDiagnosticWorkCount when convergence decisions are required.
+func BeginDiagnosticSemanticPhaseTrace() {
+	if activeDiagnosticSemanticPhaseTrace != nil {
+		panic("gotreesitter: diagnostic semantic-phase trace already active")
+	}
+	activeDiagnosticSemanticPhaseTrace = &DiagnosticSemanticPhaseTrace{
+		Contract:  DiagnosticSemanticPhaseTraceContract,
+		MaxEvents: DiagnosticSemanticPhaseTraceMaxEvents,
+		Events:    make([]DiagnosticSemanticPhaseEvent, 0, DiagnosticSemanticPhaseTraceMaxEvents),
+	}
+}
+
+// EndDiagnosticSemanticPhaseTrace returns the current trace and disables
+// recording. All retained events own value data only.
+func EndDiagnosticSemanticPhaseTrace() DiagnosticSemanticPhaseTrace {
+	if activeDiagnosticSemanticPhaseTrace == nil {
+		panic("gotreesitter: diagnostic semantic-phase trace is not active")
+	}
+	out := *activeDiagnosticSemanticPhaseTrace
+	activeDiagnosticSemanticPhaseTrace = nil
+	return out
+}
+
+func semanticPhaseTraceRecordActionCell(_ *Parser, stack *glrStack, state StateID, tok Token, actions []ParseAction) {
+	trace := activeDiagnosticSemanticPhaseTrace
+	if trace == nil {
+		return
+	}
+	cellHash := semanticPhaseActionCellFingerprint(actions)
+	boundaryClass := semanticPhaseCoarseBoundaryClass(stack)
+	if len(actions) == 0 {
+		semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+			Kind: "action_lookup", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
+			ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
+			LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
+			LookaheadFlags: semanticPhaseLookaheadFlags(tok), ActionCellFingerprint: cellHash,
+			CoarseBoundaryClass: boundaryClass, ActionOrdinal: -1, ActionType: -1,
+			Phase: "action_cell", Outcome: "empty",
+		})
+		return
+	}
+	for ordinal, action := range actions {
+		ordinalValue := int16(ordinal)
+		if ordinal > math.MaxInt16 {
+			ordinalValue = math.MaxInt16
+			trace.ArithmeticOverflow = true
+		}
+		semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+			Kind: "action_lookup", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
+			ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
+			LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
+			LookaheadFlags: semanticPhaseLookaheadFlags(tok), ActionCellFingerprint: cellHash,
+			CoarseBoundaryClass: boundaryClass, ActionOrdinal: ordinalValue, ActionType: int16(action.Type),
+			Phase: "action_cell", Outcome: "candidate",
+		})
+	}
+}
+
+func semanticPhaseTraceRecordActionExecution(p *Parser, stack *glrStack, tok Token, action ParseAction, actionOrdinal int, phase string, cycle bool) {
+	if activeDiagnosticSemanticPhaseTrace == nil || p == nil || stack == nil || stack.depth() == 0 {
+		return
+	}
+	state := stack.top().state
+	actions := semanticPhaseActionsAt(p, state, tok.Symbol)
+	cellHash := semanticPhaseActionCellFingerprint(actions)
+	// -2 is emitted only by the production deterministic-conflict seam. Keep
+	// uniqueness reconstruction entirely inside the diagnostic build so an
+	// untagged parser executes no scan, call, or helper symbol for tracing.
+	if actionOrdinal == -2 {
+		actionOrdinal = semanticPhaseUniqueActionOrdinal(actions, action)
+	}
+	ordinal := int16(actionOrdinal)
+	if actionOrdinal < 0 {
+		ordinal = -1
+	} else if actionOrdinal > math.MaxInt16 {
+		ordinal = math.MaxInt16
+		activeDiagnosticSemanticPhaseTrace.ArithmeticOverflow = true
+	}
+	outcome := "dispatched"
+	if cycle {
+		outcome = "cycle_rejected"
+	}
+	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+		Kind: "action_execution", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
+		ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
+		LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
+		LookaheadFlags: semanticPhaseLookaheadFlags(tok), ActionCellFingerprint: cellHash,
+		CoarseBoundaryClass: semanticPhaseCoarseBoundaryClass(stack), ActionOrdinal: ordinal, ActionType: int16(action.Type),
+		Phase: phase, Outcome: outcome,
+	})
+}
+
+func semanticPhaseUniqueActionOrdinal(actions []ParseAction, chosen ParseAction) int {
+	ordinal := -1
+	for index := range actions {
+		if actions[index] != chosen {
+			continue
+		}
+		if ordinal != -1 {
+			return -1
+		}
+		ordinal = index
+	}
+	return ordinal
+}
+
+func semanticPhaseActionsAt(p *Parser, state StateID, symbol Symbol) []ParseAction {
+	if p == nil || p.language == nil {
+		return nil
+	}
+	var actionIndex uint16
+	if int(state) < p.denseLimit {
+		if int(state) >= len(p.language.ParseTable) || int(symbol) >= len(p.language.ParseTable[state]) {
+			return nil
+		}
+		actionIndex = p.language.ParseTable[state][symbol]
+	} else {
+		actionIndex = p.lookupActionIndexSmall(state, symbol)
+	}
+	if actionIndex == 0 || int(actionIndex) >= len(p.language.ParseActions) {
+		return nil
+	}
+	return p.language.ParseActions[actionIndex].Actions
+}
+
+func semanticPhaseTraceRecordDecision(_ *Parser, phase, outcome, reason string, target, candidate *glrStack, before, after int) {
+	if activeDiagnosticSemanticPhaseTrace == nil {
+		return
+	}
+	stack := target
+	if stack == nil {
+		stack = candidate
+	}
+	lookahead := activeWorkCountConvergence.lookahead
+	beforeValue, beforeOverflow := semanticPhaseBoundedUint32(before)
+	afterValue, afterOverflow := semanticPhaseBoundedUint32(after)
+	if beforeOverflow || afterOverflow {
+		activeDiagnosticSemanticPhaseTrace.ArithmeticOverflow = true
+	}
+	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
+		Kind: "decision", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
+		ByteOffset: semanticPhaseStackByte(stack), State: uint32(semanticPhaseStackState(stack)),
+		LookaheadSymbol: uint32(lookahead.Symbol), LookaheadStartByte: lookahead.StartByte, LookaheadEndByte: lookahead.EndByte,
+		LookaheadFlags: semanticPhaseLookaheadFlags(lookahead), ActionCellFingerprint: 0,
+		CoarseBoundaryClass: semanticPhaseCoarseBoundaryClass(target), CandidateBoundaryClass: semanticPhaseCoarseBoundaryClass(candidate),
+		ActionOrdinal: -1, ActionType: -1, Phase: phase, Outcome: outcome, Reason: reason,
+		CandidateCountBefore: beforeValue, CandidateCountAfter: afterValue,
+	})
+}
+
+func semanticPhaseTraceAppend(event DiagnosticSemanticPhaseEvent) {
+	trace := activeDiagnosticSemanticPhaseTrace
+	if trace == nil {
+		return
+	}
+	if trace.EventsSeen == math.MaxUint64 {
+		trace.ArithmeticOverflow = true
+	} else {
+		trace.EventsSeen++
+	}
+	event.Sequence = trace.EventsSeen
+	if len(trace.Events) < int(trace.MaxEvents) {
+		trace.Events = append(trace.Events, event)
+		return
+	}
+	if trace.EventsDropped == math.MaxUint64 {
+		trace.ArithmeticOverflow = true
+	} else {
+		trace.EventsDropped++
+	}
+}
+
+func semanticPhaseActionCellFingerprint(actions []ParseAction) uint64 {
+	h := semanticPhaseHashWord(semanticPhaseHashSeed, uint64(len(actions)))
+	for _, action := range actions {
+		h = semanticPhaseHashWord(h, uint64(action.Type))
+		h = semanticPhaseHashWord(h, uint64(action.State))
+		h = semanticPhaseHashWord(h, uint64(action.Symbol))
+		h = semanticPhaseHashWord(h, uint64(action.ChildCount))
+		h = semanticPhaseHashWord(h, uint64(uint16(action.DynamicPrecedence)))
+		h = semanticPhaseHashWord(h, uint64(action.ProductionID))
+		var flags uint64
+		if action.Extra {
+			flags |= 1
+		}
+		if action.ExtraChain {
+			flags |= 2
+		}
+		if action.Repetition {
+			flags |= 4
+		}
+		h = semanticPhaseHashWord(h, flags)
+	}
+	return h
+}
+
+func semanticPhaseCoarseBoundaryClass(stack *glrStack) uint64 {
+	if stack == nil {
+		return 0
+	}
+	h := semanticPhaseHashWord(semanticPhaseHashSeed, uint64(semanticPhaseStackByte(stack)))
+	h = semanticPhaseHashWord(h, uint64(stack.depth()))
+	if stack.depth() == 0 {
+		return h
+	}
+	entry := stack.top()
+	h = semanticPhaseHashWord(h, uint64(entry.state))
+	h = semanticPhaseHashWord(h, uint64(stackEntryNodeSymbol(entry)))
+	h = semanticPhaseHashWord(h, uint64(stackEntryNodeStartByte(entry))<<32|uint64(stackEntryNodeEndByte(entry)))
+	h = semanticPhaseHashWord(h, uint64(stackEntryNodeChildCount(entry)))
+	h = semanticPhaseHashWord(h, uint64(stackEntryNodeProductionID(entry)))
+	h = semanticPhaseHashWord(h, uint64(uint32(stackEntryDynamicPrecedence(entry))))
+	var flags uint64
+	if stackEntryNodeIsExtra(entry) {
+		flags |= 1
+	}
+	if stackEntryNodeIsMissing(entry) {
+		flags |= 2
+	}
+	if stackEntryNodeHasError(entry) {
+		flags |= 4
+	}
+	if stack.dead {
+		flags |= 8
+	}
+	if stack.accepted {
+		flags |= 16
+	}
+	if stack.cPaused {
+		flags |= 32
+	}
+	h = semanticPhaseHashWord(h, flags)
+	return h
+}
+
+func semanticPhaseStackState(stack *glrStack) StateID {
+	if stack == nil || stack.depth() == 0 {
+		return 0
+	}
+	return stack.top().state
+}
+
+func semanticPhaseStackByte(stack *glrStack) uint32 {
+	if stack == nil {
+		return 0
+	}
+	return stack.byteOffset
+}
+
+func semanticPhaseLookaheadFlags(tok Token) uint8 {
+	var flags uint8
+	if tok.NoLookahead {
+		flags |= 1
+	}
+	if tok.ExternalScannerToken {
+		flags |= 2
+	}
+	return flags
+}
+
+func semanticPhaseBoundedUint32(value int) (uint32, bool) {
+	if value < 0 {
+		return 0, true
+	}
+	if uint64(value) > math.MaxUint32 {
+		return math.MaxUint32, true
+	}
+	return uint32(value), false
+}
+
+const (
+	semanticPhaseHashSeed  uint64 = 1469598103934665603
+	semanticPhaseHashPrime uint64 = 1099511628211
+)
+
+func semanticPhaseHashWord(hash, value uint64) uint64 {
+	for shift := uint(0); shift < 64; shift += 8 {
+		hash ^= (value >> shift) & 0xff
+		hash *= semanticPhaseHashPrime
+	}
+	return hash
+}

--- a/work_count_semantic_phase_trace_internal_test.go
+++ b/work_count_semantic_phase_trace_internal_test.go
@@ -1,0 +1,102 @@
+//go:build gts_workcount
+
+package gotreesitter
+
+import "testing"
+
+func TestWorkCountRefreshConvergenceLookaheadKeepsElectionOrdinal(t *testing.T) {
+	previous := activeWorkCountConvergence
+	t.Cleanup(func() { activeWorkCountConvergence = previous })
+	activeWorkCountConvergence.electionOrdinal = 0
+	activeWorkCountConvergence.lookahead = Token{}
+	activeWorkCountConvergence.lookaheadPresent = false
+
+	initial := Token{Symbol: 7, StartByte: 11, EndByte: 14}
+	relexed := Token{Symbol: 9, StartByte: 11, EndByte: 15}
+	workCountSetConvergenceLookahead(initial)
+	ordinal := activeWorkCountConvergence.electionOrdinal
+	workCountRefreshConvergenceLookahead(relexed)
+
+	if ordinal != 1 || activeWorkCountConvergence.electionOrdinal != ordinal {
+		t.Fatalf("refresh changed election ordinal: before=%d after=%d", ordinal, activeWorkCountConvergence.electionOrdinal)
+	}
+	if activeWorkCountConvergence.lookahead != relexed || !activeWorkCountConvergence.lookaheadPresent {
+		t.Fatalf("refresh did not publish current lookahead: got=%+v present=%v want=%+v", activeWorkCountConvergence.lookahead, activeWorkCountConvergence.lookaheadPresent, relexed)
+	}
+}
+
+func TestSemanticPhaseTraceEOFPrefixTableRoute(t *testing.T) {
+	previousConvergence := activeWorkCountConvergence
+	previousTrace := activeDiagnosticSemanticPhaseTrace
+	t.Cleanup(func() {
+		activeWorkCountConvergence = previousConvergence
+		activeDiagnosticSemanticPhaseTrace = previousTrace
+	})
+	activeWorkCountConvergence.electionOrdinal = 0
+	activeWorkCountConvergence.iteration = 17
+	activeWorkCountConvergence.lookahead = Token{}
+	activeWorkCountConvergence.lookaheadPresent = false
+	activeDiagnosticSemanticPhaseTrace = nil
+
+	lang := &Language{
+		Name:            "semantic-trace-eof-prefix",
+		SymbolCount:     3,
+		TokenCount:      1,
+		StateCount:      3,
+		LargeStateCount: 3,
+		InitialState:    1,
+		SymbolNames:     []string{"end", "unused", "root"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "end"},
+			{Name: "unused"},
+			{Name: "root", Visible: true, Named: true},
+		},
+		ParseTable: [][]uint16{
+			{0, 0, 0},
+			{1, 0, 2}, // EOF reduces root; root GOTO enters state 2.
+			{2, 0, 0}, // EOF then accepts.
+		},
+		ParseActions: []ParseActionEntry{
+			{},
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 2}}},
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},
+		},
+	}
+	parser := NewParser(lang)
+	stack := newGLRStack(1)
+	tok := Token{}
+	workCountSetConvergenceLookahead(tok)
+	BeginDiagnosticSemanticPhaseTrace()
+
+	arena := newNodeArena(arenaClassFull)
+	var entryScratch glrEntryScratch
+	var gssScratch gssScratch
+	var tmpEntries []stackEntry
+	nodeCount := 0
+	insertedMissing, advanced := parser.advanceTrailingEOFPrefix(&stack, tok, 0, nil, &nodeCount, arena, &entryScratch, &gssScratch, &tmpEntries)
+	trace := EndDiagnosticSemanticPhaseTrace()
+
+	if insertedMissing || !advanced || !stack.accepted {
+		t.Fatalf("EOF prefix route inserted_missing=%v advanced=%v accepted=%v", insertedMissing, advanced, stack.accepted)
+	}
+	var lookups, executions int
+	wantPhases := map[string]int{"eof-prefix-reduce": 1, "eof-prefix-accept": 1}
+	for _, event := range trace.Events {
+		switch event.Kind {
+		case "action_lookup":
+			lookups++
+			if event.ActionOrdinal != 0 || event.TokenOrdinal != 1 || event.Iteration != 17 {
+				t.Fatalf("EOF lookup context=%+v", event)
+			}
+		case "action_execution":
+			executions++
+			wantPhases[event.Phase]--
+			if event.ActionOrdinal != 0 || event.TokenOrdinal != 1 || event.Iteration != 17 {
+				t.Fatalf("EOF execution context=%+v", event)
+			}
+		}
+	}
+	if lookups != 2 || executions != 2 || wantPhases["eof-prefix-reduce"] != 0 || wantPhases["eof-prefix-accept"] != 0 {
+		t.Fatalf("EOF route lookups=%d executions=%d phases=%v", lookups, executions, wantPhases)
+	}
+}

--- a/work_count_semantic_phase_trace_test.go
+++ b/work_count_semantic_phase_trace_test.go
@@ -1,0 +1,205 @@
+//go:build gts_workcount
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestDiagnosticSemanticPhaseTraceObserverEquality(t *testing.T) {
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fixtures[0].Fixture.ID != "query_compile" {
+		t.Fatalf("first canonical fixture=%q want query_compile", fixtures[0].Fixture.ID)
+	}
+	cases := []struct {
+		name       string
+		source     []byte
+		wantDigest string
+		wantGLR    bool
+		want       semanticTraceReceipt
+	}{
+		{
+			name: "query_compile", source: fixtures[0].Source, wantDigest: fixtures[0].Fixture.DeepTreeSHA256, wantGLR: true,
+			want: semanticTraceReceipt{eventsSeen: 83689, retained: 8192, dropped: 75497, lookups: 1797, executions: 3239, decisions: 3156, unique: 749, repeated: 1048, maxMultiplicity: 4},
+		},
+		{
+			name: "straight_lr", source: loadWorkCountAttributionFixture(t, straightLRFixturePath, straightLRFixtureBytes, straightLRFixtureSHA256),
+			want: semanticTraceReceipt{eventsSeen: 193, retained: 193, lookups: 61, executions: 130, decisions: 2, unique: 61, maxMultiplicity: 1},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			offCounts, offDigest := parseSemanticPhaseTraceFixture(t, tc.source)
+			onCounts, onDigest, trace := parseSemanticPhaseTraceFixtureObserved(t, tc.source)
+			if offDigest != onDigest {
+				t.Fatalf("observer changed tree digest: off=%s on=%s", offDigest, onDigest)
+			}
+			if tc.wantDigest != "" && onDigest != tc.wantDigest {
+				t.Fatalf("tree digest=%s want frozen=%s", onDigest, tc.wantDigest)
+			}
+			if !reflect.DeepEqual(offCounts, onCounts) {
+				t.Fatal("semantic trace changed diagnostic work counts")
+			}
+			if trace.Contract != gotreesitter.DiagnosticSemanticPhaseTraceContract || trace.MaxEvents != gotreesitter.DiagnosticSemanticPhaseTraceMaxEvents {
+				t.Fatalf("trace contract=%q max=%d", trace.Contract, trace.MaxEvents)
+			}
+			if trace.EventsSeen == 0 || len(trace.Events) == 0 || trace.ArithmeticOverflow {
+				t.Fatalf("trace events_seen=%d retained=%d overflow=%v", trace.EventsSeen, len(trace.Events), trace.ArithmeticOverflow)
+			}
+			var lookupEvents, executionEvents, executionUnknownOrdinal, decisionEvents, convergenceDecisions int
+			lookupCounts := make(map[coarseLookupClass]int)
+			executionPhases := make(map[string]int)
+			decisionPhases := make(map[string]int)
+			for _, event := range trace.Events {
+				switch event.Kind {
+				case "action_lookup":
+					lookupEvents++
+					lookupCounts[coarseLookupClass{
+						token: event.TokenOrdinal, byteOffset: event.ByteOffset, state: event.State,
+						lookahead: event.LookaheadSymbol, cell: event.ActionCellFingerprint,
+						boundary: event.CoarseBoundaryClass, ordinal: event.ActionOrdinal,
+					}]++
+					if event.ActionCellFingerprint == 0 || event.CoarseBoundaryClass == 0 || event.ActionOrdinal < -1 || event.ActionType < -1 {
+						t.Fatalf("invalid lookup event: %+v", event)
+					}
+				case "action_execution":
+					executionEvents++
+					executionPhases[event.Phase]++
+					if event.ActionOrdinal < 0 {
+						executionUnknownOrdinal++
+					}
+					if event.ActionCellFingerprint == 0 || event.CoarseBoundaryClass == 0 || event.ActionOrdinal < -1 || event.ActionType < 0 {
+						t.Fatalf("invalid execution event: %+v", event)
+					}
+				case "decision":
+					decisionEvents++
+					decisionPhases[event.Phase+"/"+event.Outcome]++
+					if event.Phase != "final_select" && event.Phase != "terminal_accept" {
+						convergenceDecisions++
+					}
+				default:
+					t.Fatalf("unknown event kind %q", event.Kind)
+				}
+			}
+			if lookupEvents == 0 || executionEvents == 0 {
+				t.Fatalf("trace retained lookups=%d executions=%d", lookupEvents, executionEvents)
+			}
+			if tc.wantGLR && decisionEvents == 0 {
+				t.Fatal("GLR fixture retained no post-reduction decisions")
+			}
+			if tc.wantGLR && executionPhases["extra-shift"] == 0 {
+				t.Fatal("GLR fixture retained no extra-shift fast-path execution")
+			}
+			if !tc.wantGLR && convergenceDecisions != 0 {
+				t.Fatalf("straight-LR control nonterminal convergence decisions=%d", convergenceDecisions)
+			}
+			uniqueClasses, repeatedClassEvents, maxClassMultiplicity := len(lookupCounts), 0, 0
+			for _, count := range lookupCounts {
+				if count > 1 {
+					repeatedClassEvents += count - 1
+				}
+				if count > maxClassMultiplicity {
+					maxClassMultiplicity = count
+				}
+			}
+			gotReceipt := semanticTraceReceipt{
+				eventsSeen: trace.EventsSeen, retained: len(trace.Events), dropped: trace.EventsDropped,
+				lookups: lookupEvents, executions: executionEvents, decisions: decisionEvents,
+				unique: uniqueClasses, repeated: repeatedClassEvents, maxMultiplicity: maxClassMultiplicity,
+			}
+			if gotReceipt != tc.want {
+				t.Fatalf("trace receipt=%+v want=%+v", gotReceipt, tc.want)
+			}
+			if executionUnknownOrdinal != 0 {
+				t.Fatalf("execution events with unknown action ordinal=%d", executionUnknownOrdinal)
+			}
+			t.Logf("semantic_phase_trace fixture=%s events_seen=%d retained=%d dropped=%d lookups=%d executions=%d execution_unknown_ordinal=%d execution_phases=%v unique_coarse_classes=%d repeated_coarse_class_events=%d max_coarse_class_multiplicity=%d decisions=%d decision_phases=%v digest=%s", tc.name, trace.EventsSeen, len(trace.Events), trace.EventsDropped, lookupEvents, executionEvents, executionUnknownOrdinal, executionPhases, uniqueClasses, repeatedClassEvents, maxClassMultiplicity, decisionEvents, decisionPhases, onDigest)
+		})
+	}
+}
+
+type semanticTraceReceipt struct {
+	eventsSeen      uint64
+	retained        int
+	dropped         uint64
+	lookups         int
+	executions      int
+	decisions       int
+	unique          int
+	repeated        int
+	maxMultiplicity int
+}
+
+type coarseLookupClass struct {
+	token      uint64
+	byteOffset uint32
+	state      uint32
+	lookahead  uint32
+	cell       uint64
+	boundary   uint64
+	ordinal    int16
+}
+
+func TestDiagnosticSemanticPhaseTraceContractIdentity(t *testing.T) {
+	const wantSHA256 = "cbe46fcf6f41da65f44d7191456fae86d5c8b9f845fd516fc3111b3a62095076"
+	data, err := os.ReadFile("cgo_harness/work_count/semantic_phase_trace_contract_v4.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(data)); got != wantSHA256 {
+		t.Fatalf("semantic trace contract sha256=%s want=%s", got, wantSHA256)
+	}
+}
+
+func parseSemanticPhaseTraceFixture(t *testing.T, source []byte) (gotreesitter.DiagnosticWorkCount, string) {
+	t.Helper()
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	gotreesitter.BeginDiagnosticWorkCount()
+	tree, err := parser.Parse(source)
+	counts := gotreesitter.EndDiagnosticWorkCount()
+	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), grammars.GoLanguage())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return counts, inspection.SHA256
+}
+
+func parseSemanticPhaseTraceFixtureObserved(t *testing.T, source []byte) (gotreesitter.DiagnosticWorkCount, string, gotreesitter.DiagnosticSemanticPhaseTrace) {
+	t.Helper()
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	gotreesitter.BeginDiagnosticWorkCount()
+	gotreesitter.BeginDiagnosticSemanticPhaseTrace()
+	tree, err := parser.Parse(source)
+	trace := gotreesitter.EndDiagnosticSemanticPhaseTrace()
+	counts := gotreesitter.EndDiagnosticWorkCount()
+	if err != nil {
+		if tree != nil {
+			tree.Release()
+		}
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), grammars.GoLanguage())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return counts, inspection.SHA256, trace
+}


### PR DESCRIPTION
## Summary

- add a build-tagged, bounded trace for parser action lookup, execution, and convergence context
- cover conflict, recovery, relex, extra-shift, and trailing-EOF dispatch paths
- verify observer equality and compile all trace scaffolding out of ordinary builds

## Validation

- focused tagged trace and contract tests
- untagged assembly and binary-symbol checks
- tagged root test suite in the parity Docker image
- exact tree and work-count equality with tracing enabled and disabled

The changelog records the new diagnostic tooling under Unreleased.