### PR TITLE
test(parser): harden semantic trace receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,16 @@ for tags and release notes while still in `0.x`.
 
 ### Tooling
 
-- Add a bounded, build-tagged parser trace that records action lookup, dispatch,
-  and convergence context without retaining physical stack IDs. Coarse boundary
-  classes are labeled non-canonical; observer equality and untagged assembly
-  tests keep the trace diagnostic-only.
+- Add a bounded, build-tagged parser trace that separates lookup cells from
+  execution-time cell reconstruction and retains whole-parse aggregates after
+  its chronological event prefix fills. Scanner checkpoints bind their cached
+  state to the current event token span and remain distinct from unavailable
+  state after relexing. Collision keys have explicit memory caps; reaching a
+  cap exposes unaudited counts, marks the audit incomplete, and blocks claims
+  that require complete collision evidence. A base-pinned content manifest and
+  fail-closed paired receipt identify which production, compact, and locked-C
+  observations can actually be compared. Observer equality and untagged
+  assembly tests keep the trace diagnostic-only.
 - Add the four-fixture authenticated Go/static-C work-count board with direct
   counters at their exact hook boundaries, Go-only representation rows marked
   incomparable, and missing mandatory instrumentation reported separately from

--- a/cgo_harness/work_count/paired_semantic_trace_contract_v1.json
+++ b/cgo_harness/work_count/paired_semantic_trace_contract_v1.json
@@ -1,0 +1,77 @@
+{
+  "schema": "gts-paired-semantic-trace-contract/v1",
+  "receipt_schema": "gts-paired-semantic-trace-receipt/v1",
+  "purpose": "Decide whether production full-parse work can be routed to the compact scheduler without asserting event equality that the engines do not expose.",
+  "engines": {
+    "production_go": "gts-semantic-phase-trace/v5",
+    "compact_go": "diagnostic parsercorephase0 summary at an exact Git commit",
+    "static_c": "locked gts-work-count-c-child/v4 aggregate oracle"
+  },
+	"production_provenance": {
+		"manifest_schema": "gts-base-pinned-patch-manifest/v1",
+		"hash_contract": "gts-base-pinned-patch-set/v1",
+		"base_commit": "1743205133e5776b82d175ccf157927198e365de",
+		"canonical_encoding": "SHA-256 over NUL-terminated hash-contract and base-commit fields followed by each path-sorted file's status, path, base-content SHA-256, and current-content SHA-256 as NUL-terminated UTF-8 fields",
+		"self_reference_rule": "The manifest and generated paired receipt are excluded from the patch set. The receipt pins both the manifest file SHA-256 and its non-self-referential patch-set SHA-256."
+	},
+  "retention": {
+    "production_events": "chronological prefix of 8192 events",
+    "production_aggregates": "whole parse, saturating uint64",
+	"production_action_cell_collision_keys": "at most 4096 distinct hashes; additional unseen hashes set truncation and fail completeness",
+	"production_boundary_collision_keys": "at most 262144 distinct hashes; additional unseen hashes set truncation and fail completeness",
+    "compact_events": "not retained; exact scheduler and compact-core aggregate work only",
+    "static_c_events": "not available; aggregate work counters only"
+  },
+  "identity": {
+    "fixture": "source SHA-256 plus byte length",
+    "grammar": "tree-sitter-go commit plus embedded grammar-blob SHA-256",
+    "selected_tree": "gts-deep-tree-v1 SHA-256",
+	"scanner_checkpoint": "current event token start/end bytes plus exact serialized start/end lengths and SHA-256 under gts-semantic-scanner-checkpoint/v2; cached checkpoint spans must equal the event token span, and unavailable is distinct from empty",
+    "ordered_predecessor_spine": "unavailable cross-engine: production exposes a collision-audited shallow head key and compact exposes implementation-specific header paths, but neither exports one shared canonical ordered-spine record"
+  },
+  "action_cells": {
+    "lookup": "fingerprint the exact ordered table cell passed by the production lookup seam",
+    "execution": "re-read the action cell from the execution-time stack state and current lookahead, then fingerprint it independently",
+    "hash": "FNV-1a 64 over versioned fixed-width action fields",
+	"collision_policy": "retain complete canonical action-cell keys up to the declared cap; fail the collision audit on collision, capacity truncation, unaudited keys, or arithmetic overflow"
+  },
+  "boundaries": {
+    "hash": "FNV-1a 64 over the documented shallow production head key",
+	"collision_policy": "retain complete shallow keys up to the declared cap; fail the collision audit on collision, capacity truncation, unaudited keys, or arithmetic overflow",
+    "not_proved": "equal hashes do not prove equal predecessor spines, derivations, scanner states, or cross-engine semantic boundaries"
+  },
+  "comparison_matrix": [
+    {
+      "field": "fixture_grammar_selected_tree",
+      "production_compact": "comparable",
+      "production_static_c": "comparable"
+    },
+    {
+      "field": "aggregate_shifts_reductions_accepts",
+      "production_compact": "descriptive_only_until_one_shared_counter_contract",
+      "production_static_c": "use_gts-work-count-board-v2"
+    },
+    {
+      "field": "ordered_action_cell_and_execution",
+      "production_compact": "unavailable_compact_summary_has_no_ordered_cells",
+      "production_static_c": "unavailable_locked_c_patch_has_no_semantic_cell_events"
+    },
+    {
+      "field": "exact_scanner_checkpoint",
+      "production_compact": "unavailable_when_production_current_token_checkpoint_is_not_exposed",
+      "production_static_c": "unavailable_locked_c_patch_has_no_checkpoint_events"
+    },
+    {
+      "field": "ordered_predecessor_spine",
+      "production_compact": "unavailable_no_shared_canonical_spine_contract",
+      "production_static_c": "unavailable_no_shared_canonical_spine_contract"
+    },
+    {
+      "field": "event_order_or_replay_ratio",
+      "production_compact": "blocked",
+      "production_static_c": "blocked"
+    }
+  ],
+	"admission": "A routing hypothesis may use aggregate replay counts to select the next experiment only when every collision audit used by that hypothesis is complete and untruncated. No semantic event-elision or cross-engine replay claim is admitted until ordered action cells, token-span-bound exact scanner checkpoints, and ordered predecessor spines are comparable and collision-audited in both engines.",
+  "static_c_extension_boundary": "A direct C semantic trace requires new hooks in ts_parser__advance, ts_parser__reduce, ts_stack_pop_count, ts_stack_merge, and ts_parser__condense_stack. This contract deliberately does not modify the locked upstream patch because aggregate C work is sufficient for the current route decision and the event-level patch would be invasive."
+}

--- a/cgo_harness/work_count/paired_semantic_trace_patch_manifest_v1.json
+++ b/cgo_harness/work_count/paired_semantic_trace_patch_manifest_v1.json
@@ -1,0 +1,48 @@
+{
+  "schema": "gts-base-pinned-patch-manifest/v1",
+  "hash_contract": "gts-base-pinned-patch-set/v1",
+  "base_commit": "1743205133e5776b82d175ccf157927198e365de",
+  "patch_set_sha256": "64926965abe387ab4ccc2efa74f1799333e54674af4cf3991a7e5eeb7eaa603f",
+  "files": [
+    {
+      "path": "CHANGELOG.md",
+      "status": "modified",
+      "base_content_sha256": "90caf2620f5528bc1902bd09088b3c13598ad719869877c4572ab4d83635eeff",
+      "content_sha256": "b6c2dadb5eba91f24ba1e6676d48073cea13f74049bb41ba4e0558776faf81a3"
+    },
+    {
+      "path": "cgo_harness/work_count/paired_semantic_trace_contract_v1.json",
+      "status": "added",
+      "base_content_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "content_sha256": "1ca1b5822396b995c0b3d0760c011daa6dcf5b4e91977a449d10490899c9ccac"
+    },
+    {
+      "path": "cgo_harness/work_count/semantic_phase_trace_contract_v5.json",
+      "status": "added",
+      "base_content_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "content_sha256": "dafbe93d17e9ceee9ef5a015440a8452c981eaaf22e794cff2069bcefdc89f8d"
+    },
+    {
+      "path": "work_count_semantic_phase_trace.go",
+      "status": "modified",
+      "base_content_sha256": "274d73e033b33187baa41609a6b4a78928815e69c549e8c236b02946f3420cb0",
+      "content_sha256": "b65fd47799b74ed947c3c1e2f6349b67d394d0407bc49f7b74014e96c523eb92"
+    },
+    {
+      "path": "work_count_semantic_phase_trace_internal_test.go",
+      "status": "modified",
+      "base_content_sha256": "128d981b0cba4184205022957f91561c34d1bc6e259b6ae1424fd3b7b2dff642",
+      "content_sha256": "0960ea156efce5f6beccb9f015e4c3b7efa2f1faea78cc2c776fa57c8fddaa8d"
+    },
+    {
+      "path": "work_count_semantic_phase_trace_test.go",
+      "status": "modified",
+      "base_content_sha256": "3997d2a8f47e42b03f888a8f5376c2bb470e4f7489621e5e3e360643d4d9b776",
+      "content_sha256": "8080c28221af123b5a5e56b7c86317aeb099b2a44a9acd5538255464143f56a5"
+    }
+  ],
+  "excluded_generated": [
+    "cgo_harness/work_count/paired_semantic_trace_patch_manifest_v1.json",
+    "cgo_harness/work_count/paired_semantic_trace_receipt_v1.json"
+  ]
+}

--- a/cgo_harness/work_count/paired_semantic_trace_receipt_v1.json
+++ b/cgo_harness/work_count/paired_semantic_trace_receipt_v1.json
@@ -1,0 +1,65 @@
+{
+  "schema": "gts-paired-semantic-trace-receipt/v1",
+  "contract": "gts-paired-semantic-trace-contract/v1",
+  "production": {
+    "base_commit": "1743205133e5776b82d175ccf157927198e365de",
+	"patch_manifest": "cgo_harness/work_count/paired_semantic_trace_patch_manifest_v1.json",
+	"patch_manifest_sha256": "59d7865f59ec682977281b4903f74b420cc595c6569746a72568bba5081930df",
+	"patch_set_sha256": "64926965abe387ab4ccc2efa74f1799333e54674af4cf3991a7e5eeb7eaa603f",
+    "trace_contract": "gts-semantic-phase-trace/v5",
+    "observer": "diagnostic_only"
+  },
+  "compact": {
+    "commit": "44b3a2e5a81eb6b277d8c323eb950173f2364030",
+    "tree": "6e08be29b830920ef70733762fd559886087af12",
+    "receipt_mode": "summary",
+    "exact_eof_and_tree_admission": true
+  },
+  "static_c": {
+    "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+    "grammar_commit": "2346a3ab1bb3857b48b29d779a1ef9799a248cd7",
+    "compiler_contract": "-O2 -DNDEBUG static",
+    "semantic_event_trace": "unavailable",
+    "aggregate_reference": "gts-work-count-board/v2"
+  },
+  "grammar_blob_sha256": "9cf914d26d962d1a62e7954f8b20b302337a44cb7d4a07218eec482c45a57a08",
+  "rows": [
+    {
+      "fixture": "query_compile",
+      "source_sha256": "b788ee19b0075f0b9b567a9f93ea657e715bc8a6a40a99d3ca5c761404e71894",
+      "source_bytes": 20168,
+      "deep_tree_sha256": "ecc090a83a4343a1c7c2afbad63277f5b4d60c42d8d94a2af2a9b16e46f2ccb5",
+      "production": {"trace_sha256":"5ce16cd7427b99c0dfdba543319d4198b2c0daf391c527a8988d6514d30e922e","events_seen":83689,"events_dropped":75497,"action_lookups":18503,"action_executions":33592,"decisions":31594,"shifts":15986,"reductions":17603,"accepts":3,"scanner_exact_retained":0,"scanner_unavailable_retained":8192,"action_cell_distinct_hashes":267,"boundary_distinct_hashes":14987,"action_cell_audit_truncated":false,"boundary_audit_truncated":false,"collision_audit_complete":true},
+      "compact": {"tokens":5126,"dispatches":13441,"action_lookups":17384,"canonicalizations":12302,"shifts":6685,"reductions":7440,"accepts":1,"emitted_pop_paths":8103,"emitted_pop_payloads":14703}
+    },
+    {
+      "fixture": "rewrite",
+      "source_sha256": "74c0705f8729670559492fb5460a01b2a1a2a109928e1aeb52736e485e8ff097",
+      "source_bytes": 5116,
+      "deep_tree_sha256": "b3f9814b65763642d4eac58b9065018048ea13e6f10d56afb28a0479bf5a68a1",
+      "production": {"trace_sha256":"e0c8cce327229f8f533e4184dc4ba81661bdd7bbb973f12d048be628edb10583","events_seen":14001,"events_dropped":5809,"action_lookups":3347,"action_executions":5818,"decisions":4836,"shifts":2760,"reductions":3057,"accepts":1,"scanner_exact_retained":0,"scanner_unavailable_retained":8192,"action_cell_distinct_hashes":216,"boundary_distinct_hashes":2959,"action_cell_audit_truncated":false,"boundary_audit_truncated":false,"collision_audit_complete":true},
+      "compact": {"tokens":1036,"dispatches":2682,"action_lookups":3545,"canonicalizations":2443,"shifts":1348,"reductions":1501,"accepts":1,"emitted_pop_paths":1646,"emitted_pop_payloads":2995}
+    },
+    {
+      "fixture": "language",
+      "source_sha256": "009aa9fd5352c712f3839670c7df8a9b00ae878ee20dc88131a438b2d5edfd9a",
+      "source_bytes": 41387,
+      "deep_tree_sha256": "583df223904fe414c33bba3b474c6557ecdb20e7f47e304b9a09bfcc2da44539",
+      "production": {"trace_sha256":"c101eddc92f559719ff0eac994691eeeb86ff45e4fa1f4d9a5e9689cac7c07ab","events_seen":85359,"events_dropped":77167,"action_lookups":18504,"action_executions":33403,"decisions":33452,"shifts":16008,"reductions":17392,"accepts":3,"scanner_exact_retained":0,"scanner_unavailable_retained":8192,"action_cell_distinct_hashes":288,"boundary_distinct_hashes":15048,"action_cell_audit_truncated":false,"boundary_audit_truncated":false,"collision_audit_complete":true},
+      "compact": {"tokens":5058,"dispatches":13456,"action_lookups":18687,"canonicalizations":12319,"shifts":6512,"reductions":7561,"accepts":1,"emitted_pop_paths":8408,"emitted_pop_payloads":15864}
+    },
+    {
+      "fixture": "grammargen_lr",
+      "source_sha256": "a7e4a1a64b25a60aea36183b9d6d53dcd9240942cdb10e67a3cf9e6ce30f95b2",
+      "source_bytes": 235626,
+      "deep_tree_sha256": "1472cfd9a014d4034dbc1456afd12c282630ef787c3543cf0cecb73619883ad2",
+      "production": {"trace_sha256":"820eb5e9f19a7a15535eb8d439de4c3d85022806d7c1260f69c38da35172ff30","events_seen":886966,"events_dropped":878774,"action_lookups":194781,"action_executions":346390,"decisions":345795,"shifts":163713,"reductions":182675,"accepts":2,"scanner_exact_retained":0,"scanner_unavailable_retained":8192,"action_cell_distinct_hashes":389,"boundary_distinct_hashes":151917,"action_cell_audit_truncated":false,"boundary_audit_truncated":false,"collision_audit_complete":true},
+      "compact": {"tokens":49912,"dispatches":133952,"action_lookups":184717,"canonicalizations":121730,"shifts":66119,"reductions":75988,"accepts":1,"emitted_pop_paths":84924,"emitted_pop_payloads":153451}
+    }
+  ],
+  "decision": {
+    "event_level_replay_status": "blocked",
+    "aggregate_route_hypothesis": "production executes materially more action/reduction work than the accepted compact route on every fixture; investigate whole-pass replay and route ownership before additional local instruction tuning",
+    "claim_limit": "counts are descriptive across production and compact until one shared semantic counter contract exists; do not publish ratios as equivalent work"
+  }
+}

--- a/cgo_harness/work_count/semantic_phase_trace_contract_v5.json
+++ b/cgo_harness/work_count/semantic_phase_trace_contract_v5.json
@@ -1,0 +1,102 @@
+{
+  "schema": "gts-semantic-phase-trace-contract/v5",
+  "event_contract": "gts-semantic-phase-trace/v5",
+  "scope": "Diagnostic production-Go full-parse action lookup, action execution, and convergence events. The contract, observers, collision keys, and ordinal reconstruction are absent from untagged builds.",
+  "retention": {
+    "maximum_events": 8192,
+    "event_policy": "retain_chronological_prefix",
+    "aggregate_policy": "count_the_whole_observed_parse_even_after_event_retention_fills",
+	"action_cell_collision_key_cap": 4096,
+	"coarse_boundary_collision_key_cap": 262144,
+    "overflow": "saturate uint64 counters and expose events_dropped plus arithmetic_overflow"
+  },
+  "event_kinds": {
+    "action_lookup": "One event per ordered action candidate in the actual table cell, or one empty-cell event. lookup_action_cell_fingerprint is populated; execution_action_cell_fingerprint is absent.",
+    "action_execution": "One event at a production dispatch seam. The table cell is re-read from the execution-time state and lookahead; execution_action_cell_fingerprint is populated and execution_cell_recomputed is true.",
+    "decision": "One convergence decision. Action-cell fingerprints and ordinals are absent because no last-writer action context is assigned to convergence."
+  },
+  "action_cell": {
+    "hash": "FNV-1a 64 over eight little-endian bytes per word",
+    "ordered_words": [
+      "action_count",
+      "for each ordered action: type",
+      "state",
+      "symbol",
+      "child_count",
+      "dynamic_precedence_as_uint16",
+      "production_id",
+      "flags(extra=1, extra_chain=2, repetition=4)"
+    ],
+    "collision_audit": "Observed hashes are joined to complete canonical word strings across retained and dropped events until 4096 distinct action-cell hashes have been retained. A new hash after that cap increments action_cell_keys_unaudited, sets action_cell_audit_truncated, and makes collision_audit.complete false. Equal retained hashes with unequal canonical keys increment action_cell_hash_collisions and also fail completeness."
+  },
+  "coarse_boundary": {
+    "purpose": "Production-only attribution hint; never a predecessor-spine identity.",
+    "ordered_words": [
+      "stack_byte_offset",
+      "logical_depth",
+      "top_state",
+      "top_symbol",
+      "top_start_byte<<32 | top_end_byte",
+      "top_child_count",
+      "top_production_id",
+      "top_dynamic_precedence_as_uint32",
+      "flags(extra=1, missing=2, has_error=4, dead=8, accepted=16, paused=32)"
+    ],
+    "collision_audit": "Observed hashes are joined to complete shallow keys across retained and dropped events until 262144 distinct boundary hashes have been retained. A new hash after that cap increments coarse_boundary_keys_unaudited, sets coarse_boundary_audit_truncated, and makes collision_audit.complete false. Equal retained hashes with unequal keys increment coarse_boundary_hash_collisions and also fail completeness.",
+    "not_proved": [
+      "full predecessor-spine equality",
+      "derivation equality",
+      "exact scanner-state equality",
+      "cross-engine boundary equality"
+    ]
+  },
+  "scanner_checkpoint": {
+    "states": ["exact", "exact_empty", "unavailable"],
+	"exact_identity": "event token start byte, event token end byte, start length, end length, and SHA-256 over domain gts-semantic-scanner-checkpoint/v2 followed by the token span and both length-delimited serialized byte strings",
+    "transport_rule": "The digest authenticates bytes but does not replace byte equality in a future in-process cross-engine admission.",
+	"span_binding_rule": "An exact checkpoint is emitted only when the parser's cached checkpoint start/end bytes equal the current event token span. Relex span drift emits unavailable/current_token_checkpoint_span_mismatch until the cache is refreshed.",
+	"unavailable_rule": "Missing or span-mismatched production current-token checkpoint data is emitted as unavailable with a reason, never coerced to empty."
+  },
+  "ordinal_policy": {
+    "direct": "Thread the parse-table ordinal from the dispatch call site.",
+    "unique_inference": "The deterministic-conflict seam may infer an ordinal only when exactly one execution-time cell entry equals the chosen action. The scan exists only in the tagged implementation.",
+    "unknown": "Synthetic actions and duplicate-equal candidates emit -1."
+  },
+  "dispatch_bypass_audit": {
+    "instrumented": [
+      "ordinary single action",
+      "conflict original and forks",
+      "deterministic conflict selection",
+      "reduce chains and conflict frontiers",
+      "extra-shift fast path",
+      "post-reduce terminal frontier",
+      "trailing-EOF prefix REDUCE and ACCEPT"
+    ],
+    "synthetic_without_table_ordinal": [
+      "no-action recovery found by stack search",
+      "retry recovery found by stack search",
+      "missing-token insertion",
+      "external no-action default reduction",
+      "eager default reduction",
+      "C-shaped error-state recovery"
+    ]
+  },
+  "comparability": {
+    "ordered_action_cell": "Production canonical fields are present, but compact and locked C do not yet emit the same event record.",
+    "exact_scanner_checkpoint": "Comparable only for events whose state is exact or exact_empty and only against an engine exposing the identical byte contract.",
+    "ordered_predecessor_spine": "Unavailable: no shared canonical spine contract exists across production, compact, and locked C.",
+    "static_c_semantic_events": "Unavailable: the locked static-C work-count patch exposes aggregate counters only."
+  },
+  "physical_identity_excluded": [
+    "Go pointer",
+    "stack version ID",
+    "GSS node ID",
+    "compact arena ID",
+    "subtree pointer"
+  ],
+  "paired_receipt": {
+    "contract": "gts-paired-semantic-trace-contract/v1",
+    "receipt": "gts-paired-semantic-trace-receipt/v1",
+	"claim_limit": "The paired receipt may select a routing or replay hypothesis from authenticated aggregate differences only when every collision audit used by that hypothesis is complete and untruncated. It cannot assert event equality, event-elision safety, or ratios of equivalent work until shared ordered cells, checkpoints, and predecessor spines exist."
+  }
+}

--- a/work_count_semantic_phase_trace.go
+++ b/work_count_semantic_phase_trace.go
@@ -2,11 +2,18 @@
 
 package gotreesitter
 
-import "math"
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"math"
+)
 
 const (
-	DiagnosticSemanticPhaseTraceContract  = "gts-semantic-phase-trace/v4"
-	DiagnosticSemanticPhaseTraceMaxEvents = 8192
+	DiagnosticSemanticPhaseTraceContract          = "gts-semantic-phase-trace/v5"
+	DiagnosticSemanticPhaseTraceMaxEvents         = 8192
+	DiagnosticSemanticPhaseTraceMaxActionCellKeys = 4096
+	DiagnosticSemanticPhaseTraceMaxBoundaryKeys   = 262144
 )
 
 // DiagnosticSemanticPhaseTrace is a bounded, diagnostic-only ledger for
@@ -14,12 +21,63 @@ const (
 // The coarse class deliberately excludes Go pointers and physical IDs, but is
 // not a canonical predecessor-spine identity and may contain collisions.
 type DiagnosticSemanticPhaseTrace struct {
-	Contract           string                         `json:"contract"`
-	MaxEvents          uint32                         `json:"max_events"`
-	EventsSeen         uint64                         `json:"events_seen"`
-	EventsDropped      uint64                         `json:"events_dropped"`
-	ArithmeticOverflow bool                           `json:"arithmetic_overflow"`
-	Events             []DiagnosticSemanticPhaseEvent `json:"events"`
+	Contract           string                           `json:"contract"`
+	MaxEvents          uint32                           `json:"max_events"`
+	EventsSeen         uint64                           `json:"events_seen"`
+	EventsDropped      uint64                           `json:"events_dropped"`
+	ArithmeticOverflow bool                             `json:"arithmetic_overflow"`
+	Aggregates         DiagnosticSemanticPhaseTotals    `json:"aggregates"`
+	CollisionAudit     DiagnosticSemanticCollisionAudit `json:"collision_audit"`
+	Comparability      DiagnosticSemanticComparability  `json:"comparability"`
+	Events             []DiagnosticSemanticPhaseEvent   `json:"events"`
+
+	actionCellKeys map[uint64]string
+	boundaryKeys   map[uint64]semanticPhaseBoundaryKey
+}
+
+// DiagnosticSemanticPhaseTotals survives chronological-prefix truncation and
+// therefore describes the whole observed parse. Phase maps are diagnostic
+// vocabularies, not a cross-engine ordering contract.
+type DiagnosticSemanticPhaseTotals struct {
+	ActionLookupEvents    uint64            `json:"action_lookup_events"`
+	ActionExecutionEvents uint64            `json:"action_execution_events"`
+	DecisionEvents        uint64            `json:"decision_events"`
+	LookupEmptyCells      uint64            `json:"lookup_empty_cells"`
+	LookupCandidates      uint64            `json:"lookup_candidates"`
+	ExecutionByActionType [4]uint64         `json:"execution_by_action_type"`
+	ExecutionPhases       map[string]uint64 `json:"execution_phases"`
+	DecisionPhases        map[string]uint64 `json:"decision_phases"`
+	DecisionOutcomes      map[string]uint64 `json:"decision_outcomes"`
+}
+
+// DiagnosticSemanticCollisionAudit proves that equal retained hashes always
+// named equal canonical input fields during the entire observed parse. It
+// does not turn the deliberately shallow boundary key into predecessor-spine
+// identity.
+type DiagnosticSemanticCollisionAudit struct {
+	Complete                        bool   `json:"complete"`
+	MaxActionCellDistinctHashes     uint32 `json:"max_action_cell_distinct_hashes"`
+	ActionCellKeysObserved          uint64 `json:"action_cell_keys_observed"`
+	ActionCellDistinctHashes        uint64 `json:"action_cell_distinct_hashes"`
+	ActionCellHashCollisions        uint64 `json:"action_cell_hash_collisions"`
+	ActionCellAuditTruncated        bool   `json:"action_cell_audit_truncated"`
+	ActionCellKeysUnaudited         uint64 `json:"action_cell_keys_unaudited"`
+	MaxCoarseBoundaryDistinctHashes uint32 `json:"max_coarse_boundary_distinct_hashes"`
+	CoarseBoundaryKeysObserved      uint64 `json:"coarse_boundary_keys_observed"`
+	CoarseBoundaryDistinctHashes    uint64 `json:"coarse_boundary_distinct_hashes"`
+	CoarseBoundaryHashCollisions    uint64 `json:"coarse_boundary_hash_collisions"`
+	CoarseBoundaryAuditTruncated    bool   `json:"coarse_boundary_audit_truncated"`
+	CoarseBoundaryKeysUnaudited     uint64 `json:"coarse_boundary_keys_unaudited"`
+}
+
+// DiagnosticSemanticComparability is deliberately fail-closed. These states
+// describe what this production trace can be paired against without treating
+// a transport hash or implementation-specific physical ID as semantic proof.
+type DiagnosticSemanticComparability struct {
+	OrderedActionCell       string `json:"ordered_action_cell"`
+	ExactScannerCheckpoint  string `json:"exact_scanner_checkpoint"`
+	OrderedPredecessorSpine string `json:"ordered_predecessor_spine"`
+	StaticCSemanticEvents   string `json:"static_c_semantic_events"`
 }
 
 // DiagnosticSemanticPhaseEvent identifies either an action-table lookup or a
@@ -39,17 +97,35 @@ type DiagnosticSemanticPhaseEvent struct {
 	LookaheadEndByte   uint32 `json:"lookahead_end_byte"`
 	LookaheadFlags     uint8  `json:"lookahead_flags"`
 
-	ActionCellFingerprint  uint64 `json:"action_cell_fingerprint"`
-	CoarseBoundaryClass    uint64 `json:"coarse_boundary_class"`
-	CandidateBoundaryClass uint64 `json:"candidate_coarse_boundary_class,omitempty"`
-	ActionOrdinal          int16  `json:"action_ordinal"`
-	ActionType             int16  `json:"action_type"`
+	LookupActionCellFingerprint    uint64 `json:"lookup_action_cell_fingerprint,omitempty"`
+	ExecutionActionCellFingerprint uint64 `json:"execution_action_cell_fingerprint,omitempty"`
+	ExecutionCellRecomputed        bool   `json:"execution_cell_recomputed,omitempty"`
+	CoarseBoundaryClass            uint64 `json:"coarse_boundary_class"`
+	CandidateBoundaryClass         uint64 `json:"candidate_coarse_boundary_class,omitempty"`
+	ActionOrdinal                  int16  `json:"action_ordinal"`
+	ActionType                     int16  `json:"action_type"`
 
 	Phase                string `json:"phase"`
 	Outcome              string `json:"outcome"`
 	Reason               string `json:"reason,omitempty"`
 	CandidateCountBefore uint32 `json:"candidate_count_before"`
 	CandidateCountAfter  uint32 `json:"candidate_count_after"`
+
+	ScannerCheckpoint DiagnosticSemanticScannerCheckpoint `json:"scanner_checkpoint"`
+}
+
+// DiagnosticSemanticScannerCheckpoint authenticates the exact start/end
+// serialized scanner states associated with the current token when production
+// exposes them. SHA-256 is a transport digest; equality is admitted only with
+// equal lengths and equal digests under the versioned domain separator.
+type DiagnosticSemanticScannerCheckpoint struct {
+	State       string `json:"state"`
+	Reason      string `json:"reason,omitempty"`
+	StartByte   uint32 `json:"start_byte"`
+	EndByte     uint32 `json:"end_byte"`
+	StartLength uint32 `json:"start_length,omitempty"`
+	EndLength   uint32 `json:"end_length,omitempty"`
+	SHA256      string `json:"sha256,omitempty"`
 }
 
 var activeDiagnosticSemanticPhaseTrace *DiagnosticSemanticPhaseTrace
@@ -69,6 +145,21 @@ func BeginDiagnosticSemanticPhaseTrace() {
 		Contract:  DiagnosticSemanticPhaseTraceContract,
 		MaxEvents: DiagnosticSemanticPhaseTraceMaxEvents,
 		Events:    make([]DiagnosticSemanticPhaseEvent, 0, DiagnosticSemanticPhaseTraceMaxEvents),
+		Aggregates: DiagnosticSemanticPhaseTotals{
+			ExecutionPhases: make(map[string]uint64), DecisionPhases: make(map[string]uint64),
+			DecisionOutcomes: make(map[string]uint64),
+		},
+		Comparability: DiagnosticSemanticComparability{
+			OrderedActionCell:       "production_only_canonical_fields",
+			ExactScannerCheckpoint:  "per_event_when_present",
+			OrderedPredecessorSpine: "unavailable_cross_engine_no_shared_canonical_spine_contract",
+			StaticCSemanticEvents:   "unavailable_locked_c_exposes_aggregate_work_counts_only",
+		},
+		CollisionAudit: DiagnosticSemanticCollisionAudit{
+			MaxActionCellDistinctHashes:     DiagnosticSemanticPhaseTraceMaxActionCellKeys,
+			MaxCoarseBoundaryDistinctHashes: DiagnosticSemanticPhaseTraceMaxBoundaryKeys,
+		},
+		actionCellKeys: make(map[uint64]string), boundaryKeys: make(map[uint64]semanticPhaseBoundaryKey),
 	}
 }
 
@@ -79,25 +170,35 @@ func EndDiagnosticSemanticPhaseTrace() DiagnosticSemanticPhaseTrace {
 		panic("gotreesitter: diagnostic semantic-phase trace is not active")
 	}
 	out := *activeDiagnosticSemanticPhaseTrace
+	out.CollisionAudit.Complete = !out.ArithmeticOverflow &&
+		!out.CollisionAudit.ActionCellAuditTruncated && !out.CollisionAudit.CoarseBoundaryAuditTruncated &&
+		out.CollisionAudit.ActionCellHashCollisions == 0 && out.CollisionAudit.CoarseBoundaryHashCollisions == 0
+	out.CollisionAudit.ActionCellDistinctHashes = uint64(len(out.actionCellKeys))
+	out.CollisionAudit.CoarseBoundaryDistinctHashes = uint64(len(out.boundaryKeys))
+	out.actionCellKeys = nil
+	out.boundaryKeys = nil
 	activeDiagnosticSemanticPhaseTrace = nil
 	return out
 }
 
-func semanticPhaseTraceRecordActionCell(_ *Parser, stack *glrStack, state StateID, tok Token, actions []ParseAction) {
+func semanticPhaseTraceRecordActionCell(p *Parser, stack *glrStack, state StateID, tok Token, actions []ParseAction) {
 	trace := activeDiagnosticSemanticPhaseTrace
 	if trace == nil {
 		return
 	}
 	cellHash := semanticPhaseActionCellFingerprint(actions)
 	boundaryClass := semanticPhaseCoarseBoundaryClass(stack)
+	semanticPhaseAuditActionCell(actions, cellHash)
+	semanticPhaseAuditBoundary(stack, boundaryClass)
+	checkpoint := semanticPhaseScannerCheckpoint(p, tok)
 	if len(actions) == 0 {
 		semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
 			Kind: "action_lookup", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 			ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
 			LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
-			LookaheadFlags: semanticPhaseLookaheadFlags(tok), ActionCellFingerprint: cellHash,
+			LookaheadFlags: semanticPhaseLookaheadFlags(tok), LookupActionCellFingerprint: cellHash,
 			CoarseBoundaryClass: boundaryClass, ActionOrdinal: -1, ActionType: -1,
-			Phase: "action_cell", Outcome: "empty",
+			Phase: "action_cell", Outcome: "empty", ScannerCheckpoint: checkpoint,
 		})
 		return
 	}
@@ -111,9 +212,9 @@ func semanticPhaseTraceRecordActionCell(_ *Parser, stack *glrStack, state StateI
 			Kind: "action_lookup", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 			ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
 			LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
-			LookaheadFlags: semanticPhaseLookaheadFlags(tok), ActionCellFingerprint: cellHash,
+			LookaheadFlags: semanticPhaseLookaheadFlags(tok), LookupActionCellFingerprint: cellHash,
 			CoarseBoundaryClass: boundaryClass, ActionOrdinal: ordinalValue, ActionType: int16(action.Type),
-			Phase: "action_cell", Outcome: "candidate",
+			Phase: "action_cell", Outcome: "candidate", ScannerCheckpoint: checkpoint,
 		})
 	}
 }
@@ -125,6 +226,9 @@ func semanticPhaseTraceRecordActionExecution(p *Parser, stack *glrStack, tok Tok
 	state := stack.top().state
 	actions := semanticPhaseActionsAt(p, state, tok.Symbol)
 	cellHash := semanticPhaseActionCellFingerprint(actions)
+	semanticPhaseAuditActionCell(actions, cellHash)
+	boundaryClass := semanticPhaseCoarseBoundaryClass(stack)
+	semanticPhaseAuditBoundary(stack, boundaryClass)
 	// -2 is emitted only by the production deterministic-conflict seam. Keep
 	// uniqueness reconstruction entirely inside the diagnostic build so an
 	// untagged parser executes no scan, call, or helper symbol for tracing.
@@ -146,9 +250,9 @@ func semanticPhaseTraceRecordActionExecution(p *Parser, stack *glrStack, tok Tok
 		Kind: "action_execution", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 		ByteOffset: semanticPhaseStackByte(stack), State: uint32(state),
 		LookaheadSymbol: uint32(tok.Symbol), LookaheadStartByte: tok.StartByte, LookaheadEndByte: tok.EndByte,
-		LookaheadFlags: semanticPhaseLookaheadFlags(tok), ActionCellFingerprint: cellHash,
-		CoarseBoundaryClass: semanticPhaseCoarseBoundaryClass(stack), ActionOrdinal: ordinal, ActionType: int16(action.Type),
-		Phase: phase, Outcome: outcome,
+		LookaheadFlags: semanticPhaseLookaheadFlags(tok), ExecutionActionCellFingerprint: cellHash, ExecutionCellRecomputed: true,
+		CoarseBoundaryClass: boundaryClass, ActionOrdinal: ordinal, ActionType: int16(action.Type),
+		Phase: phase, Outcome: outcome, ScannerCheckpoint: semanticPhaseScannerCheckpoint(p, tok),
 	})
 }
 
@@ -185,7 +289,7 @@ func semanticPhaseActionsAt(p *Parser, state StateID, symbol Symbol) []ParseActi
 	return p.language.ParseActions[actionIndex].Actions
 }
 
-func semanticPhaseTraceRecordDecision(_ *Parser, phase, outcome, reason string, target, candidate *glrStack, before, after int) {
+func semanticPhaseTraceRecordDecision(p *Parser, phase, outcome, reason string, target, candidate *glrStack, before, after int) {
 	if activeDiagnosticSemanticPhaseTrace == nil {
 		return
 	}
@@ -199,14 +303,18 @@ func semanticPhaseTraceRecordDecision(_ *Parser, phase, outcome, reason string, 
 	if beforeOverflow || afterOverflow {
 		activeDiagnosticSemanticPhaseTrace.ArithmeticOverflow = true
 	}
+	targetClass := semanticPhaseCoarseBoundaryClass(target)
+	candidateClass := semanticPhaseCoarseBoundaryClass(candidate)
+	semanticPhaseAuditBoundary(target, targetClass)
+	semanticPhaseAuditBoundary(candidate, candidateClass)
 	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{
 		Kind: "decision", TokenOrdinal: activeWorkCountConvergence.electionOrdinal, Iteration: activeWorkCountConvergence.iteration,
 		ByteOffset: semanticPhaseStackByte(stack), State: uint32(semanticPhaseStackState(stack)),
 		LookaheadSymbol: uint32(lookahead.Symbol), LookaheadStartByte: lookahead.StartByte, LookaheadEndByte: lookahead.EndByte,
-		LookaheadFlags: semanticPhaseLookaheadFlags(lookahead), ActionCellFingerprint: 0,
-		CoarseBoundaryClass: semanticPhaseCoarseBoundaryClass(target), CandidateBoundaryClass: semanticPhaseCoarseBoundaryClass(candidate),
+		LookaheadFlags:      semanticPhaseLookaheadFlags(lookahead),
+		CoarseBoundaryClass: targetClass, CandidateBoundaryClass: candidateClass,
 		ActionOrdinal: -1, ActionType: -1, Phase: phase, Outcome: outcome, Reason: reason,
-		CandidateCountBefore: beforeValue, CandidateCountAfter: afterValue,
+		CandidateCountBefore: beforeValue, CandidateCountAfter: afterValue, ScannerCheckpoint: semanticPhaseScannerCheckpoint(p, lookahead),
 	})
 }
 
@@ -215,6 +323,7 @@ func semanticPhaseTraceAppend(event DiagnosticSemanticPhaseEvent) {
 	if trace == nil {
 		return
 	}
+	semanticPhaseTraceAggregate(trace, event)
 	if trace.EventsSeen == math.MaxUint64 {
 		trace.ArithmeticOverflow = true
 	} else {
@@ -230,6 +339,48 @@ func semanticPhaseTraceAppend(event DiagnosticSemanticPhaseEvent) {
 	} else {
 		trace.EventsDropped++
 	}
+}
+
+func semanticPhaseTraceAggregate(trace *DiagnosticSemanticPhaseTrace, event DiagnosticSemanticPhaseEvent) {
+	if trace == nil {
+		return
+	}
+	add := func(counter *uint64) {
+		if *counter == math.MaxUint64 {
+			trace.ArithmeticOverflow = true
+			return
+		}
+		(*counter)++
+	}
+	switch event.Kind {
+	case "action_lookup":
+		add(&trace.Aggregates.ActionLookupEvents)
+		if event.Outcome == "empty" {
+			add(&trace.Aggregates.LookupEmptyCells)
+		} else {
+			add(&trace.Aggregates.LookupCandidates)
+		}
+	case "action_execution":
+		add(&trace.Aggregates.ActionExecutionEvents)
+		if event.ActionType >= 0 && int(event.ActionType) < len(trace.Aggregates.ExecutionByActionType) {
+			add(&trace.Aggregates.ExecutionByActionType[int(event.ActionType)])
+		} else {
+			trace.ArithmeticOverflow = true
+		}
+		semanticPhaseMapAdd(trace, trace.Aggregates.ExecutionPhases, event.Phase)
+	case "decision":
+		add(&trace.Aggregates.DecisionEvents)
+		semanticPhaseMapAdd(trace, trace.Aggregates.DecisionPhases, event.Phase)
+		semanticPhaseMapAdd(trace, trace.Aggregates.DecisionOutcomes, event.Outcome)
+	}
+}
+
+func semanticPhaseMapAdd(trace *DiagnosticSemanticPhaseTrace, values map[string]uint64, key string) {
+	if values[key] == math.MaxUint64 {
+		trace.ArithmeticOverflow = true
+		return
+	}
+	values[key]++
 }
 
 func semanticPhaseActionCellFingerprint(actions []ParseAction) uint64 {
@@ -256,43 +407,211 @@ func semanticPhaseActionCellFingerprint(actions []ParseAction) uint64 {
 	return h
 }
 
-func semanticPhaseCoarseBoundaryClass(stack *glrStack) uint64 {
-	if stack == nil {
-		return 0
+func semanticPhaseAuditActionCell(actions []ParseAction, hash uint64) {
+	trace := activeDiagnosticSemanticPhaseTrace
+	if trace == nil {
+		return
 	}
-	h := semanticPhaseHashWord(semanticPhaseHashSeed, uint64(semanticPhaseStackByte(stack)))
-	h = semanticPhaseHashWord(h, uint64(stack.depth()))
+	semanticPhaseAuditAdd(trace, &trace.CollisionAudit.ActionCellKeysObserved, 1)
+	if previous, ok := trace.actionCellKeys[hash]; ok {
+		key := semanticPhaseActionCellKey(actions)
+		if previous != key {
+			semanticPhaseAuditAdd(trace, &trace.CollisionAudit.ActionCellHashCollisions, 1)
+		}
+		return
+	}
+	if uint64(len(trace.actionCellKeys)) >= uint64(trace.CollisionAudit.MaxActionCellDistinctHashes) {
+		trace.CollisionAudit.ActionCellAuditTruncated = true
+		semanticPhaseAuditAdd(trace, &trace.CollisionAudit.ActionCellKeysUnaudited, 1)
+		return
+	}
+	trace.actionCellKeys[hash] = semanticPhaseActionCellKey(actions)
+}
+
+func semanticPhaseActionCellKey(actions []ParseAction) string {
+	words := make([]byte, 0, 8+len(actions)*64)
+	words = semanticPhaseAppendWord(words, uint64(len(actions)))
+	for _, action := range actions {
+		words = semanticPhaseAppendWord(words, uint64(action.Type))
+		words = semanticPhaseAppendWord(words, uint64(action.State))
+		words = semanticPhaseAppendWord(words, uint64(action.Symbol))
+		words = semanticPhaseAppendWord(words, uint64(action.ChildCount))
+		words = semanticPhaseAppendWord(words, uint64(uint16(action.DynamicPrecedence)))
+		words = semanticPhaseAppendWord(words, uint64(action.ProductionID))
+		var flags uint64
+		if action.Extra {
+			flags |= 1
+		}
+		if action.ExtraChain {
+			flags |= 2
+		}
+		if action.Repetition {
+			flags |= 4
+		}
+		words = semanticPhaseAppendWord(words, flags)
+	}
+	return string(words)
+}
+
+type semanticPhaseBoundaryKey struct {
+	Present           bool
+	ByteOffset        uint32
+	Depth             uint32
+	State             StateID
+	Symbol            Symbol
+	StartByte         uint32
+	EndByte           uint32
+	ChildCount        uint32
+	ProductionID      uint16
+	DynamicPrecedence int32
+	Flags             uint8
+}
+
+func semanticPhaseBoundaryKeyOf(stack *glrStack) semanticPhaseBoundaryKey {
+	if stack == nil {
+		return semanticPhaseBoundaryKey{}
+	}
+	depth, overflow := semanticPhaseBoundedUint32(stack.depth())
+	if overflow && activeDiagnosticSemanticPhaseTrace != nil {
+		activeDiagnosticSemanticPhaseTrace.ArithmeticOverflow = true
+	}
+	key := semanticPhaseBoundaryKey{Present: true, ByteOffset: stack.byteOffset, Depth: depth}
 	if stack.depth() == 0 {
-		return h
+		return key
 	}
 	entry := stack.top()
-	h = semanticPhaseHashWord(h, uint64(entry.state))
-	h = semanticPhaseHashWord(h, uint64(stackEntryNodeSymbol(entry)))
-	h = semanticPhaseHashWord(h, uint64(stackEntryNodeStartByte(entry))<<32|uint64(stackEntryNodeEndByte(entry)))
-	h = semanticPhaseHashWord(h, uint64(stackEntryNodeChildCount(entry)))
-	h = semanticPhaseHashWord(h, uint64(stackEntryNodeProductionID(entry)))
-	h = semanticPhaseHashWord(h, uint64(uint32(stackEntryDynamicPrecedence(entry))))
-	var flags uint64
+	key.State = entry.state
+	key.Symbol = stackEntryNodeSymbol(entry)
+	key.StartByte = stackEntryNodeStartByte(entry)
+	key.EndByte = stackEntryNodeEndByte(entry)
+	key.ChildCount = uint32(stackEntryNodeChildCount(entry))
+	key.ProductionID = stackEntryNodeProductionID(entry)
+	key.DynamicPrecedence = stackEntryDynamicPrecedence(entry)
 	if stackEntryNodeIsExtra(entry) {
-		flags |= 1
+		key.Flags |= 1
 	}
 	if stackEntryNodeIsMissing(entry) {
-		flags |= 2
+		key.Flags |= 2
 	}
 	if stackEntryNodeHasError(entry) {
-		flags |= 4
+		key.Flags |= 4
 	}
 	if stack.dead {
-		flags |= 8
+		key.Flags |= 8
 	}
 	if stack.accepted {
-		flags |= 16
+		key.Flags |= 16
 	}
 	if stack.cPaused {
-		flags |= 32
+		key.Flags |= 32
 	}
-	h = semanticPhaseHashWord(h, flags)
+	return key
+}
+
+func semanticPhaseAuditBoundary(stack *glrStack, hash uint64) {
+	trace := activeDiagnosticSemanticPhaseTrace
+	if trace == nil {
+		return
+	}
+	semanticPhaseAuditAdd(trace, &trace.CollisionAudit.CoarseBoundaryKeysObserved, 1)
+	key := semanticPhaseBoundaryKeyOf(stack)
+	if previous, ok := trace.boundaryKeys[hash]; ok {
+		if previous != key {
+			semanticPhaseAuditAdd(trace, &trace.CollisionAudit.CoarseBoundaryHashCollisions, 1)
+		}
+		return
+	}
+	if uint64(len(trace.boundaryKeys)) >= uint64(trace.CollisionAudit.MaxCoarseBoundaryDistinctHashes) {
+		trace.CollisionAudit.CoarseBoundaryAuditTruncated = true
+		semanticPhaseAuditAdd(trace, &trace.CollisionAudit.CoarseBoundaryKeysUnaudited, 1)
+		return
+	}
+	trace.boundaryKeys[hash] = key
+}
+
+func semanticPhaseAuditAdd(trace *DiagnosticSemanticPhaseTrace, counter *uint64, value uint64) {
+	if trace == nil {
+		return
+	}
+	if *counter > math.MaxUint64-value {
+		*counter = math.MaxUint64
+		trace.ArithmeticOverflow = true
+		return
+	}
+	*counter += value
+}
+
+func semanticPhaseCoarseBoundaryClass(stack *glrStack) uint64 {
+	key := semanticPhaseBoundaryKeyOf(stack)
+	if !key.Present {
+		return 0
+	}
+	h := semanticPhaseHashWord(semanticPhaseHashSeed, uint64(key.ByteOffset))
+	h = semanticPhaseHashWord(h, uint64(key.Depth))
+	if key.Depth == 0 {
+		return h
+	}
+	h = semanticPhaseHashWord(h, uint64(key.State))
+	h = semanticPhaseHashWord(h, uint64(key.Symbol))
+	h = semanticPhaseHashWord(h, uint64(key.StartByte)<<32|uint64(key.EndByte))
+	h = semanticPhaseHashWord(h, uint64(key.ChildCount))
+	h = semanticPhaseHashWord(h, uint64(key.ProductionID))
+	h = semanticPhaseHashWord(h, uint64(uint32(key.DynamicPrecedence)))
+	h = semanticPhaseHashWord(h, uint64(key.Flags))
 	return h
+}
+
+func semanticPhaseScannerCheckpoint(p *Parser, tok Token) DiagnosticSemanticScannerCheckpoint {
+	if p == nil || p.language == nil {
+		return DiagnosticSemanticScannerCheckpoint{State: "unavailable", Reason: "parser_or_language_absent"}
+	}
+	if p.language.ExternalScanner == nil {
+		return DiagnosticSemanticScannerCheckpoint{
+			State: "exact_empty", StartByte: tok.StartByte, EndByte: tok.EndByte,
+			SHA256: semanticPhaseCheckpointDigest(tok.StartByte, tok.EndByte, nil, nil),
+		}
+	}
+	if !p.currentExternalTokenCheckpointValid {
+		return DiagnosticSemanticScannerCheckpoint{State: "unavailable", Reason: "current_token_checkpoint_not_exposed"}
+	}
+	if p.currentExternalTokenCheckpointStart != tok.StartByte || p.currentExternalTokenCheckpointEnd != tok.EndByte {
+		return DiagnosticSemanticScannerCheckpoint{State: "unavailable", Reason: "current_token_checkpoint_span_mismatch"}
+	}
+	startLength, startOverflow := semanticPhaseBoundedUint32(len(p.currentExternalTokenCheckpoint.start))
+	endLength, endOverflow := semanticPhaseBoundedUint32(len(p.currentExternalTokenCheckpoint.end))
+	if startOverflow || endOverflow {
+		if activeDiagnosticSemanticPhaseTrace != nil {
+			activeDiagnosticSemanticPhaseTrace.ArithmeticOverflow = true
+		}
+		return DiagnosticSemanticScannerCheckpoint{State: "unavailable", Reason: "checkpoint_length_overflow"}
+	}
+	return DiagnosticSemanticScannerCheckpoint{
+		State: "exact", StartByte: tok.StartByte, EndByte: tok.EndByte, StartLength: startLength, EndLength: endLength,
+		SHA256: semanticPhaseCheckpointDigest(tok.StartByte, tok.EndByte, p.currentExternalTokenCheckpoint.start, p.currentExternalTokenCheckpoint.end),
+	}
+}
+
+func semanticPhaseCheckpointDigest(startByte, endByte uint32, start, end []byte) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("gts-semantic-scanner-checkpoint/v2\x00"))
+	var span [8]byte
+	binary.LittleEndian.PutUint32(span[:4], startByte)
+	binary.LittleEndian.PutUint32(span[4:], endByte)
+	_, _ = h.Write(span[:])
+	var length [8]byte
+	binary.LittleEndian.PutUint64(length[:], uint64(len(start)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write(start)
+	binary.LittleEndian.PutUint64(length[:], uint64(len(end)))
+	_, _ = h.Write(length[:])
+	_, _ = h.Write(end)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func semanticPhaseAppendWord(dst []byte, value uint64) []byte {
+	var word [8]byte
+	binary.LittleEndian.PutUint64(word[:], value)
+	return append(dst, word[:]...)
 }
 
 func semanticPhaseStackState(stack *glrStack) StateID {

--- a/work_count_semantic_phase_trace_internal_test.go
+++ b/work_count_semantic_phase_trace_internal_test.go
@@ -2,7 +2,98 @@
 
 package gotreesitter
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestSemanticPhaseExactScannerCheckpointNeverCoercesUnavailableToEmpty(t *testing.T) {
+	previousConvergence := activeWorkCountConvergence
+	t.Cleanup(func() { activeWorkCountConvergence = previousConvergence })
+	parser := &Parser{language: &Language{ExternalScanner: &mockExternalScanner{}}}
+	tok := Token{Symbol: 7, StartByte: 11, EndByte: 14, ExternalScannerToken: true}
+	missing := semanticPhaseScannerCheckpoint(parser, tok)
+	if missing.State != "unavailable" || missing.Reason != "current_token_checkpoint_not_exposed" || missing.SHA256 != "" {
+		t.Fatalf("missing checkpoint was not fail-closed: %+v", missing)
+	}
+	parser.currentExternalTokenCheckpointValid = true
+	parser.currentExternalTokenCheckpoint = externalScannerCheckpoint{start: []byte{1, 2}, end: []byte{3, 4, 5}}
+	parser.currentExternalTokenCheckpointStart = tok.StartByte
+	parser.currentExternalTokenCheckpointEnd = tok.EndByte
+	exact := semanticPhaseScannerCheckpoint(parser, tok)
+	if exact.State != "exact" || exact.StartByte != tok.StartByte || exact.EndByte != tok.EndByte || exact.StartLength != 2 || exact.EndLength != 3 || len(exact.SHA256) != 64 || strings.Trim(exact.SHA256, "0123456789abcdef") != "" {
+		t.Fatalf("exact checkpoint identity invalid: %+v", exact)
+	}
+	if exact.SHA256 != semanticPhaseCheckpointDigest(tok.StartByte, tok.EndByte, []byte{1, 2}, []byte{3, 4, 5}) || exact.SHA256 == semanticPhaseCheckpointDigest(tok.StartByte, tok.EndByte, nil, nil) {
+		t.Fatal("exact checkpoint digest lost byte/length identity")
+	}
+	relexed := Token{Symbol: 9, StartByte: tok.StartByte, EndByte: tok.EndByte + 1, ExternalScannerToken: true}
+	workCountSetConvergenceLookahead(tok)
+	workCountRefreshConvergenceLookahead(relexed)
+	mismatch := semanticPhaseScannerCheckpoint(parser, activeWorkCountConvergence.lookahead)
+	if mismatch.State != "unavailable" || mismatch.Reason != "current_token_checkpoint_span_mismatch" || mismatch.SHA256 != "" {
+		t.Fatalf("relexed token inherited stale checkpoint: %+v", mismatch)
+	}
+	parser.currentExternalTokenCheckpointStart = relexed.StartByte
+	parser.currentExternalTokenCheckpointEnd = relexed.EndByte
+	refreshed := semanticPhaseScannerCheckpoint(parser, activeWorkCountConvergence.lookahead)
+	if refreshed.State != "exact" || refreshed.StartByte != relexed.StartByte || refreshed.EndByte != relexed.EndByte || refreshed.SHA256 == exact.SHA256 {
+		t.Fatalf("relexed checkpoint was not rebound to the current span: old=%+v new=%+v", exact, refreshed)
+	}
+}
+
+func TestSemanticPhaseCollisionAuditFailsClosed(t *testing.T) {
+	previous := activeDiagnosticSemanticPhaseTrace
+	t.Cleanup(func() { activeDiagnosticSemanticPhaseTrace = previous })
+	activeDiagnosticSemanticPhaseTrace = nil
+	BeginDiagnosticSemanticPhaseTrace()
+	semanticPhaseAuditActionCell([]ParseAction{{Type: ParseActionShift, State: 1}}, 7)
+	semanticPhaseAuditActionCell([]ParseAction{{Type: ParseActionReduce, Symbol: 2}}, 7)
+	first := newGLRStack(1)
+	second := newGLRStack(2)
+	semanticPhaseAuditBoundary(&first, 9)
+	semanticPhaseAuditBoundary(&second, 9)
+	trace := EndDiagnosticSemanticPhaseTrace()
+	if trace.CollisionAudit.Complete || trace.CollisionAudit.ActionCellHashCollisions != 1 || trace.CollisionAudit.CoarseBoundaryHashCollisions != 1 {
+		t.Fatalf("collision audit did not fail closed: %+v", trace.CollisionAudit)
+	}
+}
+
+func TestSemanticPhaseCollisionAuditCapacityFailsClosed(t *testing.T) {
+	previous := activeDiagnosticSemanticPhaseTrace
+	t.Cleanup(func() { activeDiagnosticSemanticPhaseTrace = previous })
+	activeDiagnosticSemanticPhaseTrace = nil
+	BeginDiagnosticSemanticPhaseTrace()
+	activeDiagnosticSemanticPhaseTrace.CollisionAudit.MaxActionCellDistinctHashes = 1
+	activeDiagnosticSemanticPhaseTrace.CollisionAudit.MaxCoarseBoundaryDistinctHashes = 1
+	semanticPhaseAuditActionCell([]ParseAction{{Type: ParseActionShift, State: 1}}, 7)
+	semanticPhaseAuditActionCell([]ParseAction{{Type: ParseActionReduce, Symbol: 2}}, 8)
+	first := newGLRStack(1)
+	second := newGLRStack(2)
+	semanticPhaseAuditBoundary(&first, 9)
+	semanticPhaseAuditBoundary(&second, 10)
+	trace := EndDiagnosticSemanticPhaseTrace()
+	if trace.CollisionAudit.Complete || !trace.CollisionAudit.ActionCellAuditTruncated || !trace.CollisionAudit.CoarseBoundaryAuditTruncated ||
+		trace.CollisionAudit.ActionCellKeysUnaudited != 1 || trace.CollisionAudit.CoarseBoundaryKeysUnaudited != 1 ||
+		trace.CollisionAudit.ActionCellDistinctHashes != 1 || trace.CollisionAudit.CoarseBoundaryDistinctHashes != 1 {
+		t.Fatalf("bounded collision audit did not fail closed: %+v", trace.CollisionAudit)
+	}
+}
+
+func TestSemanticPhaseAggregatesSurviveRetentionTruncation(t *testing.T) {
+	previous := activeDiagnosticSemanticPhaseTrace
+	t.Cleanup(func() { activeDiagnosticSemanticPhaseTrace = previous })
+	activeDiagnosticSemanticPhaseTrace = nil
+	BeginDiagnosticSemanticPhaseTrace()
+	activeDiagnosticSemanticPhaseTrace.MaxEvents = 1
+	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{Kind: "action_lookup", Outcome: "candidate"})
+	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{Kind: "action_execution", ActionType: int16(ParseActionShift), Phase: "shift"})
+	semanticPhaseTraceAppend(DiagnosticSemanticPhaseEvent{Kind: "decision", Phase: "merge", Outcome: "packed"})
+	trace := EndDiagnosticSemanticPhaseTrace()
+	if trace.EventsSeen != 3 || len(trace.Events) != 1 || trace.EventsDropped != 2 || trace.Aggregates.ActionLookupEvents != 1 || trace.Aggregates.ActionExecutionEvents != 1 || trace.Aggregates.DecisionEvents != 1 {
+		t.Fatalf("truncated aggregate receipt drifted: %+v", trace)
+	}
+}
 
 func TestWorkCountRefreshConvergenceLookaheadKeepsElectionOrdinal(t *testing.T) {
 	previous := activeWorkCountConvergence

--- a/work_count_semantic_phase_trace_test.go
+++ b/work_count_semantic_phase_trace_test.go
@@ -4,15 +4,231 @@ package gotreesitter_test
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
+
+type pairedSemanticTraceReceipt struct {
+	Schema            string                   `json:"schema"`
+	Contract          string                   `json:"contract"`
+	GrammarBlobSHA256 string                   `json:"grammar_blob_sha256"`
+	Rows              []pairedSemanticTraceRow `json:"rows"`
+	Production        pairedSemanticProduction `json:"production"`
+	Compact           json.RawMessage          `json:"compact"`
+	StaticC           json.RawMessage          `json:"static_c"`
+	Decision          json.RawMessage          `json:"decision"`
+}
+
+type pairedSemanticProduction struct {
+	BaseCommit          string `json:"base_commit"`
+	PatchManifest       string `json:"patch_manifest"`
+	PatchManifestSHA256 string `json:"patch_manifest_sha256"`
+	PatchSetSHA256      string `json:"patch_set_sha256"`
+	TraceContract       string `json:"trace_contract"`
+	Observer            string `json:"observer"`
+}
+
+type pairedSemanticPatchManifest struct {
+	Schema            string                            `json:"schema"`
+	HashContract      string                            `json:"hash_contract"`
+	BaseCommit        string                            `json:"base_commit"`
+	PatchSetSHA256    string                            `json:"patch_set_sha256"`
+	Files             []pairedSemanticPatchManifestFile `json:"files"`
+	ExcludedGenerated []string                          `json:"excluded_generated"`
+}
+
+type pairedSemanticPatchManifestFile struct {
+	Path              string `json:"path"`
+	Status            string `json:"status"`
+	BaseContentSHA256 string `json:"base_content_sha256"`
+	ContentSHA256     string `json:"content_sha256"`
+}
+
+func TestDiagnosticPairedSemanticTracePatchManifest(t *testing.T) {
+	const manifestPath = "cgo_harness/work_count/paired_semantic_trace_patch_manifest_v1.json"
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest pairedSemanticPatchManifest
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Schema != "gts-base-pinned-patch-manifest/v1" || manifest.HashContract != "gts-base-pinned-patch-set/v1" || manifest.BaseCommit != "1743205133e5776b82d175ccf157927198e365de" {
+		t.Fatalf("patch manifest identity drifted: %+v", manifest)
+	}
+	if len(manifest.Files) == 0 || !sort.SliceIsSorted(manifest.Files, func(i, j int) bool { return manifest.Files[i].Path < manifest.Files[j].Path }) {
+		t.Fatalf("patch manifest files are absent or unsorted: %+v", manifest.Files)
+	}
+	h := sha256.New()
+	writePatchField := func(value string) {
+		_, _ = h.Write([]byte(value))
+		_, _ = h.Write([]byte{0})
+	}
+	writePatchField(manifest.HashContract)
+	writePatchField(manifest.BaseCommit)
+	seen := make(map[string]bool, len(manifest.Files))
+	for _, file := range manifest.Files {
+		if file.Path == manifestPath || file.Path == "cgo_harness/work_count/paired_semantic_trace_receipt_v1.json" || seen[file.Path] || (file.Status != "modified" && file.Status != "added") || len(file.BaseContentSHA256) != 64 || len(file.ContentSHA256) != 64 {
+			t.Fatalf("invalid or self-referential patch manifest file: %+v", file)
+		}
+		seen[file.Path] = true
+		contents, err := os.ReadFile(file.Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fmt.Sprintf("%x", sha256.Sum256(contents)); got != file.ContentSHA256 {
+			t.Fatalf("patch manifest content drift path=%s got=%s want=%s", file.Path, got, file.ContentSHA256)
+		}
+		writePatchField(file.Status)
+		writePatchField(file.Path)
+		writePatchField(file.BaseContentSHA256)
+		writePatchField(file.ContentSHA256)
+	}
+	if got := fmt.Sprintf("%x", h.Sum(nil)); got != manifest.PatchSetSHA256 {
+		t.Fatalf("patch-set digest=%s want=%s", got, manifest.PatchSetSHA256)
+	}
+	wantExcluded := []string{manifestPath, "cgo_harness/work_count/paired_semantic_trace_receipt_v1.json"}
+	if !reflect.DeepEqual(manifest.ExcludedGenerated, wantExcluded) {
+		t.Fatalf("patch manifest exclusions=%v want=%v", manifest.ExcludedGenerated, wantExcluded)
+	}
+}
+
+type pairedSemanticTraceRow struct {
+	Fixture        string `json:"fixture"`
+	SourceSHA256   string `json:"source_sha256"`
+	SourceBytes    uint32 `json:"source_bytes"`
+	DeepTreeSHA256 string `json:"deep_tree_sha256"`
+	Production     struct {
+		TraceSHA256                string `json:"trace_sha256"`
+		EventsSeen                 uint64 `json:"events_seen"`
+		EventsDropped              uint64 `json:"events_dropped"`
+		ActionLookups              uint64 `json:"action_lookups"`
+		ActionExecutions           uint64 `json:"action_executions"`
+		Decisions                  uint64 `json:"decisions"`
+		Shifts                     uint64 `json:"shifts"`
+		Reductions                 uint64 `json:"reductions"`
+		Accepts                    uint64 `json:"accepts"`
+		ScannerExactRetained       uint64 `json:"scanner_exact_retained"`
+		ScannerUnavailableRetained uint64 `json:"scanner_unavailable_retained"`
+		ActionCellDistinctHashes   uint64 `json:"action_cell_distinct_hashes"`
+		BoundaryDistinctHashes     uint64 `json:"boundary_distinct_hashes"`
+		ActionCellAuditTruncated   bool   `json:"action_cell_audit_truncated"`
+		BoundaryAuditTruncated     bool   `json:"boundary_audit_truncated"`
+		CollisionAuditComplete     bool   `json:"collision_audit_complete"`
+	} `json:"production"`
+	Compact struct {
+		Tokens             uint64 `json:"tokens"`
+		Dispatches         uint64 `json:"dispatches"`
+		ActionLookups      uint64 `json:"action_lookups"`
+		Canonicalizations  uint64 `json:"canonicalizations"`
+		Shifts             uint64 `json:"shifts"`
+		Reductions         uint64 `json:"reductions"`
+		Accepts            uint64 `json:"accepts"`
+		EmittedPopPaths    uint64 `json:"emitted_pop_paths"`
+		EmittedPopPayloads uint64 `json:"emitted_pop_payloads"`
+	} `json:"compact"`
+}
+
+func TestDiagnosticPairedSemanticTraceCanonicalReceipt(t *testing.T) {
+	data, err := os.ReadFile("cgo_harness/work_count/paired_semantic_trace_receipt_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt pairedSemanticTraceReceipt
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Schema != "gts-paired-semantic-trace-receipt/v1" || receipt.Contract != "gts-paired-semantic-trace-contract/v1" || receipt.GrammarBlobSHA256 != benchfixtures.GoGrammarBlobSHA256 {
+		t.Fatalf("paired receipt identity drifted: schema=%q contract=%q grammar=%q", receipt.Schema, receipt.Contract, receipt.GrammarBlobSHA256)
+	}
+	manifestData, err := os.ReadFile(receipt.Production.PatchManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest pairedSemanticPatchManifest
+	manifestDecoder := json.NewDecoder(strings.NewReader(string(manifestData)))
+	manifestDecoder.DisallowUnknownFields()
+	if err := manifestDecoder.Decode(&manifest); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Production.BaseCommit != manifest.BaseCommit || receipt.Production.TraceContract != gotreesitter.DiagnosticSemanticPhaseTraceContract || receipt.Production.Observer != "diagnostic_only" ||
+		receipt.Production.PatchSetSHA256 != manifest.PatchSetSHA256 || receipt.Production.PatchManifestSHA256 != fmt.Sprintf("%x", sha256.Sum256(manifestData)) {
+		t.Fatalf("paired receipt does not pin its production patch manifest: production=%+v manifest=%+v", receipt.Production, manifest)
+	}
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(receipt.Rows) != len(fixtures) {
+		t.Fatalf("paired rows=%d want=%d", len(receipt.Rows), len(fixtures))
+	}
+	rows := make(map[string]pairedSemanticTraceRow, len(receipt.Rows))
+	for _, row := range receipt.Rows {
+		if _, exists := rows[row.Fixture]; exists {
+			t.Fatalf("duplicate paired fixture %q", row.Fixture)
+		}
+		rows[row.Fixture] = row
+	}
+	for _, fixture := range fixtures {
+		row, ok := rows[fixture.Fixture.ID]
+		if !ok {
+			t.Fatalf("paired receipt missing fixture %q", fixture.Fixture.ID)
+		}
+		if row.SourceSHA256 != fixture.Fixture.SHA256 || row.SourceBytes != uint32(len(fixture.Source)) || row.DeepTreeSHA256 != fixture.Fixture.DeepTreeSHA256 {
+			t.Fatalf("%s paired fixture identity drifted: %+v", fixture.Fixture.ID, row)
+		}
+		offCounts, offDigest := parseSemanticPhaseTraceFixture(t, fixture.Source)
+		onCounts, onDigest, trace := parseSemanticPhaseTraceFixtureObserved(t, fixture.Source)
+		if offDigest != onDigest || onDigest != fixture.Fixture.DeepTreeSHA256 || !reflect.DeepEqual(offCounts, onCounts) {
+			t.Fatalf("%s observer mismatch off/on=%s/%s counts_equal=%v", fixture.Fixture.ID, offDigest, onDigest, reflect.DeepEqual(offCounts, onCounts))
+		}
+		traceData, err := json.Marshal(trace)
+		if err != nil {
+			t.Fatal(err)
+		}
+		traceSum := sha256.Sum256(traceData)
+		var exact, missing uint64
+		for _, event := range trace.Events {
+			if event.ScannerCheckpoint.State == "exact" || event.ScannerCheckpoint.State == "exact_empty" {
+				exact++
+			} else {
+				missing++
+			}
+		}
+		gotTraceSHA := fmt.Sprintf("%x", traceSum)
+		production := row.Production
+		t.Logf("paired trace refresh fixture=%s sha=%s events=%d/%d aggregates=%+v audit=%+v", fixture.Fixture.ID, gotTraceSHA, trace.EventsSeen, trace.EventsDropped, trace.Aggregates, trace.CollisionAudit)
+		if gotTraceSHA != production.TraceSHA256 || trace.EventsSeen != production.EventsSeen || trace.EventsDropped != production.EventsDropped ||
+			trace.Aggregates.ActionLookupEvents != production.ActionLookups || trace.Aggregates.ActionExecutionEvents != production.ActionExecutions || trace.Aggregates.DecisionEvents != production.Decisions ||
+			trace.Aggregates.ExecutionByActionType[0] != production.Shifts || trace.Aggregates.ExecutionByActionType[1] != production.Reductions || trace.Aggregates.ExecutionByActionType[2] != production.Accepts ||
+			exact != production.ScannerExactRetained || missing != production.ScannerUnavailableRetained ||
+			trace.CollisionAudit.ActionCellDistinctHashes != production.ActionCellDistinctHashes || trace.CollisionAudit.CoarseBoundaryDistinctHashes != production.BoundaryDistinctHashes ||
+			trace.CollisionAudit.ActionCellAuditTruncated != production.ActionCellAuditTruncated || trace.CollisionAudit.CoarseBoundaryAuditTruncated != production.BoundaryAuditTruncated ||
+			trace.CollisionAudit.Complete != production.CollisionAuditComplete {
+			t.Errorf("%s production paired trace drifted: sha=%s exact/missing=%d/%d aggregates=%+v audit=%+v want=%+v", fixture.Fixture.ID, gotTraceSHA, exact, missing, trace.Aggregates, trace.CollisionAudit, production)
+		}
+		if production.ScannerExactRetained != 0 || production.ScannerUnavailableRetained != uint64(len(trace.Events)) {
+			t.Fatalf("%s unexpectedly acquired a cross-engine scanner join: exact=%d unavailable=%d retained=%d", fixture.Fixture.ID, production.ScannerExactRetained, production.ScannerUnavailableRetained, len(trace.Events))
+		}
+		if row.Compact.Accepts != 1 || row.Compact.Dispatches == 0 || row.Compact.ActionLookups == 0 || row.Compact.Shifts == 0 || row.Compact.Reductions == 0 || row.Compact.EmittedPopPaths == 0 || row.Compact.EmittedPopPayloads == 0 {
+			t.Fatalf("%s compact aggregate receipt is incomplete: %+v", fixture.Fixture.ID, row.Compact)
+		}
+	}
+}
 
 func TestDiagnosticSemanticPhaseTraceObserverEquality(t *testing.T) {
 	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
@@ -57,6 +273,9 @@ func TestDiagnosticSemanticPhaseTraceObserverEquality(t *testing.T) {
 			if trace.EventsSeen == 0 || len(trace.Events) == 0 || trace.ArithmeticOverflow {
 				t.Fatalf("trace events_seen=%d retained=%d overflow=%v", trace.EventsSeen, len(trace.Events), trace.ArithmeticOverflow)
 			}
+			if !trace.CollisionAudit.Complete || trace.CollisionAudit.ActionCellHashCollisions != 0 || trace.CollisionAudit.CoarseBoundaryHashCollisions != 0 {
+				t.Fatalf("semantic trace collision audit failed: %+v", trace.CollisionAudit)
+			}
 			var lookupEvents, executionEvents, executionUnknownOrdinal, decisionEvents, convergenceDecisions int
 			lookupCounts := make(map[coarseLookupClass]int)
 			executionPhases := make(map[string]int)
@@ -67,10 +286,10 @@ func TestDiagnosticSemanticPhaseTraceObserverEquality(t *testing.T) {
 					lookupEvents++
 					lookupCounts[coarseLookupClass{
 						token: event.TokenOrdinal, byteOffset: event.ByteOffset, state: event.State,
-						lookahead: event.LookaheadSymbol, cell: event.ActionCellFingerprint,
+						lookahead: event.LookaheadSymbol, cell: event.LookupActionCellFingerprint,
 						boundary: event.CoarseBoundaryClass, ordinal: event.ActionOrdinal,
 					}]++
-					if event.ActionCellFingerprint == 0 || event.CoarseBoundaryClass == 0 || event.ActionOrdinal < -1 || event.ActionType < -1 {
+					if event.LookupActionCellFingerprint == 0 || event.ExecutionActionCellFingerprint != 0 || event.ExecutionCellRecomputed || event.CoarseBoundaryClass == 0 || event.ActionOrdinal < -1 || event.ActionType < -1 {
 						t.Fatalf("invalid lookup event: %+v", event)
 					}
 				case "action_execution":
@@ -79,7 +298,7 @@ func TestDiagnosticSemanticPhaseTraceObserverEquality(t *testing.T) {
 					if event.ActionOrdinal < 0 {
 						executionUnknownOrdinal++
 					}
-					if event.ActionCellFingerprint == 0 || event.CoarseBoundaryClass == 0 || event.ActionOrdinal < -1 || event.ActionType < 0 {
+					if event.ExecutionActionCellFingerprint == 0 || event.LookupActionCellFingerprint != 0 || !event.ExecutionCellRecomputed || event.CoarseBoundaryClass == 0 || event.ActionOrdinal < -1 || event.ActionType < 0 {
 						t.Fatalf("invalid execution event: %+v", event)
 					}
 				case "decision":
@@ -124,6 +343,10 @@ func TestDiagnosticSemanticPhaseTraceObserverEquality(t *testing.T) {
 			if executionUnknownOrdinal != 0 {
 				t.Fatalf("execution events with unknown action ordinal=%d", executionUnknownOrdinal)
 			}
+			if trace.Aggregates.ActionLookupEvents+trace.Aggregates.ActionExecutionEvents+trace.Aggregates.DecisionEvents != trace.EventsSeen ||
+				trace.Aggregates.ActionLookupEvents < uint64(lookupEvents) || trace.Aggregates.ActionExecutionEvents < uint64(executionEvents) || trace.Aggregates.DecisionEvents < uint64(decisionEvents) {
+				t.Fatalf("whole-parse aggregates do not cover retained prefix: aggregates=%+v retained=%d/%d/%d seen=%d", trace.Aggregates, lookupEvents, executionEvents, decisionEvents, trace.EventsSeen)
+			}
 			t.Logf("semantic_phase_trace fixture=%s events_seen=%d retained=%d dropped=%d lookups=%d executions=%d execution_unknown_ordinal=%d execution_phases=%v unique_coarse_classes=%d repeated_coarse_class_events=%d max_coarse_class_multiplicity=%d decisions=%d decision_phases=%v digest=%s", tc.name, trace.EventsSeen, len(trace.Events), trace.EventsDropped, lookupEvents, executionEvents, executionUnknownOrdinal, executionPhases, uniqueClasses, repeatedClassEvents, maxClassMultiplicity, decisionEvents, decisionPhases, onDigest)
 		})
 	}
@@ -152,13 +375,19 @@ type coarseLookupClass struct {
 }
 
 func TestDiagnosticSemanticPhaseTraceContractIdentity(t *testing.T) {
-	const wantSHA256 = "cbe46fcf6f41da65f44d7191456fae86d5c8b9f845fd516fc3111b3a62095076"
-	data, err := os.ReadFile("cgo_harness/work_count/semantic_phase_trace_contract_v4.json")
-	if err != nil {
-		t.Fatal(err)
+	files := map[string]string{
+		"cgo_harness/work_count/semantic_phase_trace_contract_v4.json":  "cbe46fcf6f41da65f44d7191456fae86d5c8b9f845fd516fc3111b3a62095076",
+		"cgo_harness/work_count/semantic_phase_trace_contract_v5.json":  "dafbe93d17e9ceee9ef5a015440a8452c981eaaf22e794cff2069bcefdc89f8d",
+		"cgo_harness/work_count/paired_semantic_trace_contract_v1.json": "1ca1b5822396b995c0b3d0760c011daa6dcf5b4e91977a449d10490899c9ccac",
 	}
-	if got := fmt.Sprintf("%x", sha256.Sum256(data)); got != wantSHA256 {
-		t.Fatalf("semantic trace contract sha256=%s want=%s", got, wantSHA256)
+	for path, wantSHA256 := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fmt.Sprintf("%x", sha256.Sum256(data)); got != wantSHA256 {
+			t.Fatalf("%s sha256=%s want=%s", path, got, wantSHA256)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- retain whole-parse action aggregates beyond the bounded chronological prefix
- add fail-closed collision auditing with explicit capacity and completeness state
- bind exact scanner checkpoints to the current token span
- add reproducible paired receipt, contract, and patch-manifest artifacts

## Validation

- four authenticated Go fixtures with observer on/off deep-tree and work equality
- forced capacity, collision, stale-relex, provenance, and contract tests
- untagged binary and assembly checks proving trace scaffolding is absent
- tagged root suite in the parity Docker image

The paired counters are explicitly descriptive and do not claim equivalent work, timing improvement, or automatic routing.