### PR TITLE
fix(query, tree): align missing, property, and descendant semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ for tags and release notes while still in `0.x`.
   validates complete ABI-15 supertype metadata before emission. Lowercase
   keyword leaves are classified from parser-reachable ownership like
   tree-sitter.
+- Query `MISSING` patterns now test missing nodes, and inert `#is?`/`#is-not?`
+  properties are available through public metadata accessors. Descendant range
+  walks now match upstream behavior for reversed ranges and zero-width missing
+  children.
 - Highlight queries now resolve supported built-in inheritance chains across
   registration order and same-name replacements without duplicating cyclic
   queries. Incompatible locked grammar/query pairs remain fail-closed.

--- a/cgo_harness/parity_query_exact_test.go
+++ b/cgo_harness/parity_query_exact_test.go
@@ -360,6 +360,24 @@ func TestParityQueryExactMissing(t *testing.T) {
 			source: "int a\n",
 			query:  `(MISSING ";") @missing`,
 		},
+		{
+			name:   "missing_or_identifier_alternation",
+			lang:   "c",
+			source: "int a;\nint b\n",
+			query:  `[(MISSING) (identifier)] @match`,
+		},
+		{
+			name:   "qualified_missing_or_identifier_alternation",
+			lang:   "c",
+			source: "int a;\nint b\n",
+			query:  `[(MISSING ";") (identifier)] @match`,
+		},
+		{
+			name:   "qualified_missing_named_alternation",
+			lang:   "typescript",
+			source: "const { value: [dirPath, { dirName, options, fileNames }] } = result;\nswitch (x) { case: }\n",
+			query:  `[(MISSING identifier) (switch_case)] @match`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/cgo_harness/parity_query_exact_test.go
+++ b/cgo_harness/parity_query_exact_test.go
@@ -352,6 +352,70 @@ func collectCByteRangeCaptureNames(q *sitter.Query, tree *sitter.Tree, source []
 	}
 }
 
+func TestParityQueryExactMissing(t *testing.T) {
+	cases := []exactQueryCase{
+		{
+			name:   "missing_semicolon",
+			lang:   "c",
+			source: "int a\n",
+			query:  `(MISSING ";") @missing`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertExactQueryParity(t, tc)
+		})
+	}
+}
+
+func TestParityDescendantByteRangeBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		lang       string
+		source     string
+		start, end uint32
+	}{
+		{name: "token_end", lang: "go", source: "package main\n\nimport \"fmt\"\n", start: 7, end: 7},
+		{name: "line_end", lang: "go", source: "package main\n\nimport \"fmt\"\n", start: 12, end: 12},
+		{name: "out_of_bounds", lang: "go", source: "package main\n\nimport \"fmt\"\n", start: 1000, end: 1005},
+		{name: "reversed", lang: "go", source: "package main\n\nimport \"fmt\"\n", start: 5, end: 4},
+		{name: "zero_width_missing", lang: "c", source: "int a\n", start: 5, end: 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.source)
+			goTree, goLang, err := parseWithGo(parityCase{name: tc.lang, source: tc.source}, src, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer releaseGoTree(goTree)
+			cLang, err := ParityCLanguage(tc.lang)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(src, nil)
+			defer cTree.Close()
+
+			goNode := goTree.RootNode().DescendantForByteRange(tc.start, tc.end)
+			cNode := cTree.RootNode().DescendantForByteRange(uint(tc.start), uint(tc.end))
+			if (goNode == nil) != (cNode == nil) {
+				t.Fatalf("nil mismatch: Go=%v C=%v", goNode == nil, cNode == nil)
+			}
+			if goNode == nil {
+				return
+			}
+			if goNode.Type(goLang) != cNode.Kind() || goNode.StartByte() != uint32(cNode.StartByte()) || goNode.EndByte() != uint32(cNode.EndByte()) || goNode.IsMissing() != cNode.IsMissing() {
+				t.Fatalf("descendant mismatch: Go=%s[%d,%d] missing=%v C=%s[%d,%d] missing=%v", goNode.Type(goLang), goNode.StartByte(), goNode.EndByte(), goNode.IsMissing(), cNode.Kind(), cNode.StartByte(), cNode.EndByte(), cNode.IsMissing())
+			}
+		})
+	}
+}
+
 func assertExactQueryParity(t *testing.T, tc exactQueryCase) {
 	t.Helper()
 

--- a/descendant_range_parity_test.go
+++ b/descendant_range_parity_test.go
@@ -41,4 +41,35 @@ func TestDescendantForByteRangeCParity(t *testing.T) {
 	if got := root.DescendantForPointRange(gts.Point{Row: 0, Column: 12}, gts.Point{Row: 0, Column: 12}); typ(got) != "source_file" {
 		t.Fatalf("point (0,12) = %s, want source_file", typ(got))
 	}
+	if got := root.DescendantForByteRange(5, 4); got != nil {
+		t.Fatalf("reversed byte range = %s, want <nil>", typ(got))
+	}
+	if got := root.DescendantForPointRange(gts.Point{Row: 1, Column: 0}, gts.Point{Row: 0, Column: 0}); got != nil {
+		t.Fatalf("reversed point range = %s, want <nil>", typ(got))
+	}
+}
+
+func TestDescendantRangeIncludesZeroWidthMissingChild(t *testing.T) {
+	src := []byte("int a\n")
+	lang := grammars.CLanguage()
+	tree, err := gts.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	declaration := root.NamedChild(0)
+	if declaration == nil {
+		t.Fatal("missing declaration")
+	}
+
+	for name, got := range map[string]*gts.Node{
+		"byte":  declaration.DescendantForByteRange(5, 5),
+		"point": declaration.DescendantForPointRange(gts.Point{Row: 0, Column: 5}, gts.Point{Row: 0, Column: 5}),
+	} {
+		if got == nil || got.Type(lang) != ";" || !got.IsMissing() || got.StartByte() != got.EndByte() {
+			t.Fatalf("%s zero-width lookup = %#v, want missing semicolon", name, got)
+		}
+	}
 }

--- a/descendant_range_parity_test.go
+++ b/descendant_range_parity_test.go
@@ -1,0 +1,44 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestDescendantForByteRangeCParity locks the tree-sitter C boundary/out-of-
+// range semantics (audit D1): an empty range at a token's end boundary belongs
+// to the enclosing node, and an unsatisfiable range returns the node itself,
+// never nil.
+func TestDescendantForByteRangeCParity(t *testing.T) {
+	src := []byte("package main\n\nimport \"fmt\"\n")
+	lang := grammars.GoLanguage()
+	tree, err := gts.NewParser(lang).Parse(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := tree.RootNode()
+	typ := func(n *gts.Node) string {
+		if n == nil {
+			return "<nil>"
+		}
+		return n.Type(lang)
+	}
+
+	if got := root.DescendantForByteRange(7, 7); typ(got) != "package_clause" {
+		t.Fatalf("(7,7) = %s, want package_clause (end boundary belongs to parent)", typ(got))
+	}
+	if got := root.DescendantForByteRange(12, 12); typ(got) != "source_file" {
+		t.Fatalf("(12,12) = %s, want source_file", typ(got))
+	}
+	if got := root.DescendantForByteRange(1000, 1005); got != root {
+		t.Fatalf("out-of-bounds range must return the node itself, got %s", typ(got))
+	}
+	if got := root.DescendantForByteRange(8, 12); typ(got) != "package_identifier" {
+		t.Fatalf("(8,12) = %s, want package_identifier", typ(got))
+	}
+	if got := root.DescendantForPointRange(gts.Point{Row: 0, Column: 12}, gts.Point{Row: 0, Column: 12}); typ(got) != "source_file" {
+		t.Fatalf("point (0,12) = %s, want source_file", typ(got))
+	}
+}

--- a/parser_api.go
+++ b/parser_api.go
@@ -221,7 +221,10 @@ func (p *Parser) disabledOldTreeTokenInvariantLeafAllowed(source []byte, oldTree
 	}
 	node := oldTree.lastEditedLeaf
 	if node == nil || !node.containsByteRange(edit.StartByte, edit.OldEndByte) {
-		node = root.DescendantForByteRange(edit.StartByte, edit.OldEndByte)
+		// Incremental reuse needs the fully-contained (nil-on-miss) semantics,
+		// not the C-faithful public walk (which returns the node itself on a
+		// miss). Use the contained helper so this fast path is unchanged.
+		node = root.descendantForByteRangeContained(edit.StartByte, edit.OldEndByte, false)
 	}
 	if p.canReuseLanguageTextInvariantNode(source, oldTree, node, edit) {
 		return true

--- a/query.go
+++ b/query.go
@@ -65,18 +65,8 @@ type QueryStep struct {
 	// isMissing marks a step compiled from the special "MISSING" node
 	// pattern ((MISSING), (MISSING kind), or (MISSING "token")). Such a
 	// step only matches nodes for which Node.IsMissing() is true, in
-	// addition to any symbol/textMatch constraint carried above. This
-	// mirrors upstream tree-sitter 0.24+ query semantics.
+	// addition to any symbol/textMatch constraint carried above.
 	isMissing bool
-	// supertypeSymbol is set when this step's node-type name resolved to a
-	// supertype (e.g. "expression", "_statement"). Supertype symbols never
-	// appear as a concrete node's own symbol in the tree (the concrete
-	// subtype node takes their place), so -- mirroring upstream
-	// tree-sitter's compiler (step->supertype_symbol / WILDCARD_SYMBOL) --
-	// `symbol` is reset to 0 (wildcard) and matching instead requires the
-	// candidate node's symbol to be a (possibly transitive) member of
-	// supertypeSymbol's subtype set (see nodeMatchesSupertypeStep).
-	supertypeSymbol Symbol
 }
 
 type queryQuantifier uint8
@@ -156,6 +146,29 @@ type QueryPredicate struct {
 	allowMissing bool // true when scoped under a child pattern that may match zero times
 }
 
+// QueryPropertyPredicate is host-consumable metadata for an inert #is? or
+// #is-not? predicate. Property is the queried property name, Capture is the
+// optional capture name without its leading '@', and Positive distinguishes
+// #is? from #is-not?. Property predicates do not filter query matches.
+type QueryPropertyPredicate struct {
+	Property string
+	Capture  string
+	Positive bool
+}
+
+// PropertyPredicate exposes p when it represents #is? or #is-not? metadata.
+// Other predicate kinds return ok=false.
+func (p QueryPredicate) PropertyPredicate() (property QueryPropertyPredicate, ok bool) {
+	switch p.kind {
+	case predicateIs:
+		return QueryPropertyPredicate{Property: p.property, Capture: p.leftCapture, Positive: true}, true
+	case predicateIsNot:
+		return QueryPropertyPredicate{Property: p.property, Capture: p.leftCapture, Positive: false}, true
+	default:
+		return QueryPropertyPredicate{}, false
+	}
+}
+
 // alternativeSymbol is one branch of an alternation like [(true) (false)].
 type alternativeSymbol struct {
 	symbol  Symbol
@@ -170,11 +183,6 @@ type alternativeSymbol struct {
 	// [(function_declaration name: (identifier) @name) ...].
 	steps      []QueryStep
 	predicates []QueryPredicate
-	// supertypeSymbol mirrors QueryStep.supertypeSymbol for alternation
-	// branches whose node-type name resolved to a supertype (e.g.
-	// `[(expression) (statement)] @x`): symbol is reset to 0 (wildcard)
-	// and this field carries the supertype to check against instead.
-	supertypeSymbol Symbol
 }
 
 // QueryMatch represents a successful pattern match with its captures.
@@ -1183,6 +1191,23 @@ func (q *Query) PredicatesForPattern(patternIndex uint32) ([]QueryPredicate, boo
 	out := make([]QueryPredicate, len(preds))
 	copy(out, preds)
 	return out, true
+}
+
+// PropertyPredicatesForPattern returns the #is? and #is-not? metadata attached
+// to patternIndex in source order. A valid pattern with no property predicates
+// returns an empty slice and ok=true.
+func (q *Query) PropertyPredicatesForPattern(patternIndex uint32) ([]QueryPropertyPredicate, bool) {
+	predicates, ok := q.PredicatesForPattern(patternIndex)
+	if !ok {
+		return nil, false
+	}
+	var properties []QueryPropertyPredicate
+	for _, predicate := range predicates {
+		if property, isProperty := predicate.PropertyPredicate(); isProperty {
+			properties = append(properties, property)
+		}
+	}
+	return properties, true
 }
 
 // IsPatternRooted reports whether the pattern has exactly one root step at

--- a/query.go
+++ b/query.go
@@ -62,6 +62,21 @@ type QueryStep struct {
 	// textMatch is for string literal matching ("func", "return", etc.).
 	// When non-empty, we match anonymous nodes whose symbol name equals this.
 	textMatch string
+	// isMissing marks a step compiled from the special "MISSING" node
+	// pattern ((MISSING), (MISSING kind), or (MISSING "token")). Such a
+	// step only matches nodes for which Node.IsMissing() is true, in
+	// addition to any symbol/textMatch constraint carried above. This
+	// mirrors upstream tree-sitter 0.24+ query semantics.
+	isMissing bool
+	// supertypeSymbol is set when this step's node-type name resolved to a
+	// supertype (e.g. "expression", "_statement"). Supertype symbols never
+	// appear as a concrete node's own symbol in the tree (the concrete
+	// subtype node takes their place), so -- mirroring upstream
+	// tree-sitter's compiler (step->supertype_symbol / WILDCARD_SYMBOL) --
+	// `symbol` is reset to 0 (wildcard) and matching instead requires the
+	// candidate node's symbol to be a (possibly transitive) member of
+	// supertypeSymbol's subtype set (see nodeMatchesSupertypeStep).
+	supertypeSymbol Symbol
 }
 
 type queryQuantifier uint8
@@ -155,6 +170,11 @@ type alternativeSymbol struct {
 	// [(function_declaration name: (identifier) @name) ...].
 	steps      []QueryStep
 	predicates []QueryPredicate
+	// supertypeSymbol mirrors QueryStep.supertypeSymbol for alternation
+	// branches whose node-type name resolved to a supertype (e.g.
+	// `[(expression) (statement)] @x`): symbol is reset to 0 (wildcard)
+	// and this field carries the supertype to check against instead.
+	supertypeSymbol Symbol
 }
 
 // QueryMatch represents a successful pattern match with its captures.

--- a/query.go
+++ b/query.go
@@ -171,8 +171,9 @@ func (p QueryPredicate) PropertyPredicate() (property QueryPropertyPredicate, ok
 
 // alternativeSymbol is one branch of an alternation like [(true) (false)].
 type alternativeSymbol struct {
-	symbol  Symbol
-	isNamed bool
+	symbol    Symbol
+	isNamed   bool
+	isMissing bool
 	// field constrains this branch to a child with the given parent field ID.
 	// It is only evaluated when the alternation step is matched as a child.
 	field FieldID

--- a/query_alternation_index.go
+++ b/query_alternation_index.go
@@ -4,6 +4,13 @@ type queryAlternationIndex struct {
 	bySymbolNamed map[uint64][]int
 	byText        map[string][]int
 	wildcard      []int
+	// supertype holds alternative indices whose node-type name resolved to
+	// a supertype (e.g. `[(expression) (statement)] @x`). These can't be
+	// bucketed by exact symbol (no concrete node ever carries a
+	// supertype's own symbol) or treated as unconditional wildcards
+	// (that would match every node), so they're checked individually via
+	// alternativeSupertypeMatchesNode / alternativeSupertypeMatchesStackEntry.
+	supertype []int
 }
 
 func alternationSymbolNamedKey(symbol Symbol, isNamed bool) uint64 {
@@ -34,6 +41,8 @@ func buildAlternationIndicesForSteps(steps []QueryStep) {
 				buildAlternationIndicesForSteps(alt.steps)
 			}
 			switch {
+			case alt.symbol == 0 && alt.textMatch == "" && alt.supertypeSymbol != 0:
+				idx.supertype = append(idx.supertype, ai)
 			case alt.symbol == 0 && alt.textMatch == "":
 				idx.wildcard = append(idx.wildcard, ai)
 			case alt.textMatch != "":

--- a/query_alternation_index.go
+++ b/query_alternation_index.go
@@ -28,10 +28,14 @@ func buildAlternationIndicesForSteps(steps []QueryStep) {
 		}
 
 		idx := &queryAlternationIndex{}
+		hasMissing := false
 		for ai := range step.alternatives {
 			alt := &step.alternatives[ai]
 			if len(alt.steps) > 0 {
 				buildAlternationIndicesForSteps(alt.steps)
+			}
+			if alt.isMissing {
+				hasMissing = true
 			}
 			switch {
 			case alt.symbol == 0 && alt.textMatch == "":
@@ -50,6 +54,11 @@ func buildAlternationIndicesForSteps(steps []QueryStep) {
 			}
 		}
 
-		step.altIndex = idx
+		// MISSING is a semantic qualifier, not a symbol class. Keep these rare
+		// alternations on the exact linear matcher rather than admitting ordinary
+		// nodes from a symbol-only index bucket.
+		if !hasMissing {
+			step.altIndex = idx
+		}
 	}
 }

--- a/query_alternation_index.go
+++ b/query_alternation_index.go
@@ -4,13 +4,6 @@ type queryAlternationIndex struct {
 	bySymbolNamed map[uint64][]int
 	byText        map[string][]int
 	wildcard      []int
-	// supertype holds alternative indices whose node-type name resolved to
-	// a supertype (e.g. `[(expression) (statement)] @x`). These can't be
-	// bucketed by exact symbol (no concrete node ever carries a
-	// supertype's own symbol) or treated as unconditional wildcards
-	// (that would match every node), so they're checked individually via
-	// alternativeSupertypeMatchesNode / alternativeSupertypeMatchesStackEntry.
-	supertype []int
 }
 
 func alternationSymbolNamedKey(symbol Symbol, isNamed bool) uint64 {
@@ -41,8 +34,6 @@ func buildAlternationIndicesForSteps(steps []QueryStep) {
 				buildAlternationIndicesForSteps(alt.steps)
 			}
 			switch {
-			case alt.symbol == 0 && alt.textMatch == "" && alt.supertypeSymbol != 0:
-				idx.supertype = append(idx.supertype, ai)
 			case alt.symbol == 0 && alt.textMatch == "":
 				idx.wildcard = append(idx.wildcard, ai)
 			case alt.textMatch != "":

--- a/query_c_parity_fixes_test.go
+++ b/query_c_parity_fixes_test.go
@@ -1,18 +1,12 @@
 package gotreesitter_test
 
-// Focused C-parity regression tests for the four tree-sitter query-engine
+// Focused C-parity regression tests for the tree-sitter query-engine
 // parity fixes landed on this branch:
 //
 //   - D8: #is?/#is-not? are inert property predicates and must not filter
 //     matches.
 //   - D4: (MISSING) / (MISSING kind) query patterns test Node.IsMissing(),
 //     instead of matching every node like an unqualified wildcard.
-//   - D3: supertype node-type patterns (e.g. (expression)) expand to their
-//     subtype symbols at match time instead of matching nothing.
-//   - D5: captures inside quantified multi-step groups (e.g.
-//     ((a) (b)?)*) are collected across every repetition instead of being
-//     dropped.
-//
 // Each test's expected result was cross-checked against the real C
 // tree-sitter runtime (github.com/tree-sitter/go-tree-sitter) via the
 // parity-audit probe harness; the numbers baked in here are the C behavior,
@@ -74,6 +68,34 @@ func TestParityD8IsPredicateDoesNotFilterMatches(t *testing.T) {
 	}
 }
 
+func TestParityD8PropertyPredicateMetadataIsPublic(t *testing.T) {
+	lang := grammars.GoLanguage()
+	query, err := gotreesitter.NewQuery(`
+		((identifier) @id (#is? @id local) (#is-not? local.definition @id))
+	`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery: %v", err)
+	}
+
+	predicates, ok := query.PredicatesForPattern(0)
+	if !ok || len(predicates) != 2 {
+		t.Fatalf("PredicatesForPattern = %d, %v; want 2, true", len(predicates), ok)
+	}
+	first, ok := predicates[0].PropertyPredicate()
+	if !ok || first.Property != "local" || first.Capture != "id" || !first.Positive {
+		t.Fatalf("first property predicate = %#v, %v", first, ok)
+	}
+	second, ok := predicates[1].PropertyPredicate()
+	if !ok || second.Property != "local.definition" || second.Capture != "id" || second.Positive {
+		t.Fatalf("second property predicate = %#v, %v", second, ok)
+	}
+
+	properties, ok := query.PropertyPredicatesForPattern(0)
+	if !ok || len(properties) != 2 || properties[0] != first || properties[1] != second {
+		t.Fatalf("PropertyPredicatesForPattern = %#v, %v", properties, ok)
+	}
+}
+
 // --- D4: (MISSING) / (MISSING kind) -----------------------------------------
 
 func TestParityD4MissingPatternMatchesOnlyMissingNode(t *testing.T) {
@@ -129,115 +151,5 @@ func TestParityD4MissingPatternMatchesOnlyMissingNode(t *testing.T) {
 	// string-literal token qualifier -- never a nested child pattern.
 	if _, err := gotreesitter.NewQuery(`(MISSING (identifier))`, lang); err == nil {
 		t.Fatal("(MISSING (identifier)): expected a compile error, got nil")
-	}
-}
-
-// --- D3: supertype patterns expand to subtype symbols -----------------------
-
-func TestParityD3SupertypePatternMatchesSubtypes(t *testing.T) {
-	lang := grammars.GoLanguage()
-	src := []byte("package main\nfunc f() { x := 1 + 2 }\n")
-	tree := parseWithLanguage(t, lang, src)
-	defer tree.Release()
-
-	// Nested/field-constrained supertype position: the go blob's _expression
-	// supertype table is intact, so this achieves exact parity with C (unlike
-	// the bare/unconstrained form, which is a known approximation -- see the
-	// worklog notes in the branch report).
-	query, err := gotreesitter.NewQuery(`(binary_expression left: (_expression) @l)`, lang)
-	if err != nil {
-		t.Fatalf("NewQuery: %v", err)
-	}
-	matches := query.Execute(tree)
-	if len(matches) != 1 {
-		t.Fatalf("(binary_expression left: (_expression) @l): got %d matches, want 1", len(matches))
-	}
-	if got := len(matches[0].Captures); got != 1 {
-		t.Fatalf("expected exactly 1 capture, got %d", got)
-	}
-	capture := matches[0].Captures[0]
-	if capture.Node.Type(lang) != "int_literal" {
-		t.Fatalf("captured node type = %q, want %q (the literal \"1\", a subtype of _expression)", capture.Node.Type(lang), "int_literal")
-	}
-	if capture.Text(src) != "1" {
-		t.Fatalf("captured text = %q, want %q", capture.Text(src), "1")
-	}
-
-	// Bare/unconstrained supertype pattern must, at minimum, stop matching
-	// nothing (the pre-fix bug) and must include known subtype instances.
-	stmtQuery, err := gotreesitter.NewQuery(`(_statement) @st`, lang)
-	if err != nil {
-		t.Fatalf("NewQuery((_statement)): %v", err)
-	}
-	stmtMatches := stmtQuery.Execute(tree)
-	if len(stmtMatches) == 0 {
-		t.Fatal("(_statement) @st: got 0 matches, want at least 1 (supertype patterns must match concrete subtype nodes)")
-	}
-	var sawShortVarDecl bool
-	for _, m := range stmtMatches {
-		for _, c := range m.Captures {
-			if c.Node.Type(lang) == "short_var_declaration" {
-				sawShortVarDecl = true
-			}
-		}
-	}
-	if !sawShortVarDecl {
-		t.Fatal("(_statement) @st: expected a short_var_declaration match (x := 1 + 2), a direct _statement subtype")
-	}
-}
-
-// --- D5: captures inside quantified multi-step groups ----------------------
-
-func TestParityD5QuantifiedGroupCapturesAllRepetitions(t *testing.T) {
-	lang := grammars.JavascriptLanguage()
-	src := []byte("function add(x, y) { return x; }\n")
-	tree := parseWithLanguage(t, lang, src)
-	defer tree.Release()
-
-	cases := []struct {
-		name      string
-		query     string
-		wantTexts []string // in order; nil means "expect zero matches"
-	}{
-		{
-			name:      "star",
-			query:     `(formal_parameters ((identifier) @p (",")?)*)`,
-			wantTexts: []string{"x", "y"},
-		},
-		{
-			name:      "plus",
-			query:     `(formal_parameters ((identifier) @p (",")?)+)`,
-			wantTexts: []string{"x", "y"},
-		},
-		{
-			name:      "optional",
-			query:     `(formal_parameters ((identifier) @p ",")?)`,
-			wantTexts: []string{"x"},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			query, err := gotreesitter.NewQuery(tc.query, lang)
-			if err != nil {
-				t.Fatalf("NewQuery(%q): %v", tc.query, err)
-			}
-			matches := query.Execute(tree)
-			if len(matches) != 1 {
-				t.Fatalf("%s: got %d matches, want 1", tc.query, len(matches))
-			}
-			var got []string
-			for _, c := range matches[0].Captures {
-				got = append(got, c.Text(src))
-			}
-			if len(got) != len(tc.wantTexts) {
-				t.Fatalf("%s: got %d captures %v, want %v", tc.query, len(got), got, tc.wantTexts)
-			}
-			for i, want := range tc.wantTexts {
-				if got[i] != want {
-					t.Fatalf("%s: capture[%d] = %q, want %q (full: %v)", tc.query, i, got[i], want, got)
-				}
-			}
-		})
 	}
 }

--- a/query_c_parity_fixes_test.go
+++ b/query_c_parity_fixes_test.go
@@ -1,0 +1,243 @@
+package gotreesitter_test
+
+// Focused C-parity regression tests for the four tree-sitter query-engine
+// parity fixes landed on this branch:
+//
+//   - D8: #is?/#is-not? are inert property predicates and must not filter
+//     matches.
+//   - D4: (MISSING) / (MISSING kind) query patterns test Node.IsMissing(),
+//     instead of matching every node like an unqualified wildcard.
+//   - D3: supertype node-type patterns (e.g. (expression)) expand to their
+//     subtype symbols at match time instead of matching nothing.
+//   - D5: captures inside quantified multi-step groups (e.g.
+//     ((a) (b)?)*) are collected across every repetition instead of being
+//     dropped.
+//
+// Each test's expected result was cross-checked against the real C
+// tree-sitter runtime (github.com/tree-sitter/go-tree-sitter) via the
+// parity-audit probe harness; the numbers baked in here are the C behavior,
+// not a description of the old (buggy) Go behavior.
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func parseWithLanguage(t *testing.T, lang *gotreesitter.Language, src []byte) *gotreesitter.Tree {
+	t.Helper()
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("Parse returned nil tree/root")
+	}
+	return tree
+}
+
+// --- D8: #is?/#is-not? must not filter matches -----------------------------
+
+func TestParityD8IsPredicateDoesNotFilterMatches(t *testing.T) {
+	lang := grammars.GoLanguage()
+	src := []byte("package main\nvar count = 1\n")
+	tree := parseWithLanguage(t, lang, src)
+	defer tree.Release()
+
+	for _, q := range []string{
+		`((identifier) @id (#is? local))`,
+		`((identifier) @id (#is-not? local))`,
+		`((identifier) @id (#is? "local"))`,
+	} {
+		query, err := gotreesitter.NewQuery(q, lang)
+		if err != nil {
+			t.Fatalf("NewQuery(%q): %v", q, err)
+		}
+		matches := query.Execute(tree)
+		if len(matches) == 0 {
+			t.Errorf("query %q: got 0 matches, want at least 1 (C treats #is?/#is-not? as inert metadata, never filtering)", q)
+			continue
+		}
+		var sawCount bool
+		for _, m := range matches {
+			for _, c := range m.Captures {
+				if c.Text(src) == "count" {
+					sawCount = true
+				}
+			}
+		}
+		if !sawCount {
+			t.Errorf("query %q: expected the \"count\" identifier to be captured (C does not drop it)", q)
+		}
+	}
+}
+
+// --- D4: (MISSING) / (MISSING kind) -----------------------------------------
+
+func TestParityD4MissingPatternMatchesOnlyMissingNode(t *testing.T) {
+	lang := grammars.CLanguage()
+	src := []byte("int a\n")
+	tree := parseWithLanguage(t, lang, src)
+	defer tree.Release()
+
+	bare, err := gotreesitter.NewQuery(`(MISSING) @m`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery((MISSING)): %v", err)
+	}
+	matches := bare.Execute(tree)
+	if len(matches) != 1 {
+		t.Fatalf("(MISSING) @m: got %d matches, want 1 (C matches only the missing ';')", len(matches))
+	}
+	if got := len(matches[0].Captures); got != 1 {
+		t.Fatalf("(MISSING) @m: got %d captures, want 1", got)
+	}
+	mc := matches[0].Captures[0]
+	if !mc.Node.IsMissing() {
+		t.Fatalf("(MISSING) @m: matched node is not IsMissing()")
+	}
+	if mc.Node.StartByte() != mc.Node.EndByte() {
+		t.Fatalf("(MISSING) @m: matched node is not zero-width (start=%d end=%d)", mc.Node.StartByte(), mc.Node.EndByte())
+	}
+
+	kinded, err := gotreesitter.NewQuery(`(MISSING ";") @m`, lang)
+	if err != nil {
+		t.Fatalf(`NewQuery((MISSING ";")): %v`, err)
+	}
+	matches = kinded.Execute(tree)
+	if len(matches) != 1 {
+		t.Fatalf(`(MISSING ";") @m: got %d matches, want 1`, len(matches))
+	}
+	if got := len(matches[0].Captures); got != 1 || !matches[0].Captures[0].Node.IsMissing() {
+		t.Fatalf(`(MISSING ";") @m: expected exactly one missing-node capture`)
+	}
+
+	// A pattern that treats MISSING as an unqualified wildcard (the old,
+	// buggy Go behavior) would match every node in the tree, not just the
+	// missing token -- guard against regressing back to that.
+	allNodes, err := gotreesitter.NewQuery(`(_) @all`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery((_)): %v", err)
+	}
+	if got := len(allNodes.Execute(tree)); got <= 1 {
+		t.Fatalf("sanity check failed: (_) @all matched %d nodes, expected the tree to contain more than just the missing node", got)
+	}
+
+	// (MISSING (child)) must be rejected at compile time (TSQueryErrorSyntax
+	// upstream): MISSING only accepts a bare form, a kind identifier, or a
+	// string-literal token qualifier -- never a nested child pattern.
+	if _, err := gotreesitter.NewQuery(`(MISSING (identifier))`, lang); err == nil {
+		t.Fatal("(MISSING (identifier)): expected a compile error, got nil")
+	}
+}
+
+// --- D3: supertype patterns expand to subtype symbols -----------------------
+
+func TestParityD3SupertypePatternMatchesSubtypes(t *testing.T) {
+	lang := grammars.GoLanguage()
+	src := []byte("package main\nfunc f() { x := 1 + 2 }\n")
+	tree := parseWithLanguage(t, lang, src)
+	defer tree.Release()
+
+	// Nested/field-constrained supertype position: the go blob's _expression
+	// supertype table is intact, so this achieves exact parity with C (unlike
+	// the bare/unconstrained form, which is a known approximation -- see the
+	// worklog notes in the branch report).
+	query, err := gotreesitter.NewQuery(`(binary_expression left: (_expression) @l)`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery: %v", err)
+	}
+	matches := query.Execute(tree)
+	if len(matches) != 1 {
+		t.Fatalf("(binary_expression left: (_expression) @l): got %d matches, want 1", len(matches))
+	}
+	if got := len(matches[0].Captures); got != 1 {
+		t.Fatalf("expected exactly 1 capture, got %d", got)
+	}
+	capture := matches[0].Captures[0]
+	if capture.Node.Type(lang) != "int_literal" {
+		t.Fatalf("captured node type = %q, want %q (the literal \"1\", a subtype of _expression)", capture.Node.Type(lang), "int_literal")
+	}
+	if capture.Text(src) != "1" {
+		t.Fatalf("captured text = %q, want %q", capture.Text(src), "1")
+	}
+
+	// Bare/unconstrained supertype pattern must, at minimum, stop matching
+	// nothing (the pre-fix bug) and must include known subtype instances.
+	stmtQuery, err := gotreesitter.NewQuery(`(_statement) @st`, lang)
+	if err != nil {
+		t.Fatalf("NewQuery((_statement)): %v", err)
+	}
+	stmtMatches := stmtQuery.Execute(tree)
+	if len(stmtMatches) == 0 {
+		t.Fatal("(_statement) @st: got 0 matches, want at least 1 (supertype patterns must match concrete subtype nodes)")
+	}
+	var sawShortVarDecl bool
+	for _, m := range stmtMatches {
+		for _, c := range m.Captures {
+			if c.Node.Type(lang) == "short_var_declaration" {
+				sawShortVarDecl = true
+			}
+		}
+	}
+	if !sawShortVarDecl {
+		t.Fatal("(_statement) @st: expected a short_var_declaration match (x := 1 + 2), a direct _statement subtype")
+	}
+}
+
+// --- D5: captures inside quantified multi-step groups ----------------------
+
+func TestParityD5QuantifiedGroupCapturesAllRepetitions(t *testing.T) {
+	lang := grammars.JavascriptLanguage()
+	src := []byte("function add(x, y) { return x; }\n")
+	tree := parseWithLanguage(t, lang, src)
+	defer tree.Release()
+
+	cases := []struct {
+		name      string
+		query     string
+		wantTexts []string // in order; nil means "expect zero matches"
+	}{
+		{
+			name:      "star",
+			query:     `(formal_parameters ((identifier) @p (",")?)*)`,
+			wantTexts: []string{"x", "y"},
+		},
+		{
+			name:      "plus",
+			query:     `(formal_parameters ((identifier) @p (",")?)+)`,
+			wantTexts: []string{"x", "y"},
+		},
+		{
+			name:      "optional",
+			query:     `(formal_parameters ((identifier) @p ",")?)`,
+			wantTexts: []string{"x"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			query, err := gotreesitter.NewQuery(tc.query, lang)
+			if err != nil {
+				t.Fatalf("NewQuery(%q): %v", tc.query, err)
+			}
+			matches := query.Execute(tree)
+			if len(matches) != 1 {
+				t.Fatalf("%s: got %d matches, want 1", tc.query, len(matches))
+			}
+			var got []string
+			for _, c := range matches[0].Captures {
+				got = append(got, c.Text(src))
+			}
+			if len(got) != len(tc.wantTexts) {
+				t.Fatalf("%s: got %d captures %v, want %v", tc.query, len(got), got, tc.wantTexts)
+			}
+			for i, want := range tc.wantTexts {
+				if got[i] != want {
+					t.Fatalf("%s: capture[%d] = %q, want %q (full: %v)", tc.query, i, got[i], want, got)
+				}
+			}
+		})
+	}
+}

--- a/query_c_parity_fixes_test.go
+++ b/query_c_parity_fixes_test.go
@@ -153,3 +153,85 @@ func TestParityD4MissingPatternMatchesOnlyMissingNode(t *testing.T) {
 		t.Fatal("(MISSING (identifier)): expected a compile error, got nil")
 	}
 }
+
+func TestParityD4MissingAlternationPreservesIdentity(t *testing.T) {
+	lang := grammars.CLanguage()
+	src := []byte("int a;\nint b\n")
+	tree := parseWithLanguage(t, lang, src)
+	defer tree.Release()
+
+	for _, querySource := range []string{
+		`[(MISSING) (identifier)] @match`,
+		`[(MISSING ";") (identifier)] @match`,
+	} {
+		t.Run(querySource, func(t *testing.T) {
+			query, err := gotreesitter.NewQuery(querySource, lang)
+			if err != nil {
+				t.Fatalf("NewQuery(%q): %v", querySource, err)
+			}
+			matches := query.Execute(tree)
+			if len(matches) != 3 {
+				t.Fatalf("%s: got %d matches, want the two identifiers and one missing semicolon", querySource, len(matches))
+			}
+
+			var missing int
+			identifiers := map[string]int{}
+			for _, match := range matches {
+				if len(match.Captures) != 1 {
+					t.Fatalf("%s: got %d captures in match, want 1", querySource, len(match.Captures))
+				}
+				capture := match.Captures[0]
+				if capture.Node.IsMissing() {
+					missing++
+					if capture.Node.Type(lang) != ";" {
+						t.Fatalf("%s: missing capture type = %q, want semicolon", querySource, capture.Node.Type(lang))
+					}
+					continue
+				}
+				if capture.Node.Type(lang) != "identifier" {
+					t.Fatalf("%s: non-missing capture type = %q, want identifier", querySource, capture.Node.Type(lang))
+				}
+				identifiers[capture.Text(src)]++
+			}
+			if missing != 1 || identifiers["a"] != 1 || identifiers["b"] != 1 || len(identifiers) != 2 {
+				t.Fatalf("%s: missing=%d identifiers=%v, want missing=1 identifiers={a:1 b:1}", querySource, missing, identifiers)
+			}
+		})
+	}
+}
+
+func TestParityD4QualifiedMissingNamedAlternationPreservesIdentity(t *testing.T) {
+	lang := grammars.TypescriptLanguage()
+	src := []byte("const { value: [dirPath, { dirName, options, fileNames }] } = result;\nswitch (x) { case: }\n")
+	tree := parseWithLanguage(t, lang, src)
+	defer tree.Release()
+
+	querySource := `[(MISSING identifier) (switch_case)] @match`
+	query, err := gotreesitter.NewQuery(querySource, lang)
+	if err != nil {
+		t.Fatalf("NewQuery(%q): %v", querySource, err)
+	}
+	matches := query.Execute(tree)
+	if len(matches) != 2 {
+		t.Fatalf("%s: got %d matches, want one missing identifier and one switch_case", querySource, len(matches))
+	}
+
+	var missingIdentifier, switchCase int
+	for _, match := range matches {
+		if len(match.Captures) != 1 {
+			t.Fatalf("%s: got %d captures in match, want 1", querySource, len(match.Captures))
+		}
+		capture := match.Captures[0]
+		switch {
+		case capture.Node.IsMissing() && capture.Node.Type(lang) == "identifier":
+			missingIdentifier++
+		case !capture.Node.IsMissing() && capture.Node.Type(lang) == "switch_case":
+			switchCase++
+		default:
+			t.Fatalf("%s: unexpected capture type=%q missing=%v", querySource, capture.Node.Type(lang), capture.Node.IsMissing())
+		}
+	}
+	if missingIdentifier != 1 || switchCase != 1 {
+		t.Fatalf("%s: missing identifiers=%d switch cases=%d, want 1 each", querySource, missingIdentifier, switchCase)
+	}
+}

--- a/query_compile.go
+++ b/query_compile.go
@@ -600,10 +600,11 @@ func (p *queryParser) parseAlternationBranch(depth int, parentSymbolHint Symbol)
 
 	root := branchPat.steps[0]
 	alt := alternativeSymbol{
-		symbol:    root.symbol,
-		isNamed:   root.isNamed,
-		field:     altField,
-		textMatch: root.textMatch,
+		symbol:          root.symbol,
+		isNamed:         root.isNamed,
+		field:           altField,
+		textMatch:       root.textMatch,
+		supertypeSymbol: root.supertypeSymbol,
 	}
 	if root.field != 0 {
 		alt.field = root.field
@@ -701,16 +702,82 @@ func (p *queryParser) parsePatternElement(depth int, parentSymbolHint Symbol) (*
 }
 
 func (p *queryParser) stepFromIdentifierName(depth int, name string) (QueryStep, error) {
+	if name == "MISSING" {
+		return p.stepFromMissingKeyword(depth)
+	}
+
 	sym, isNamed, err := p.resolveSymbol(name)
 	if err != nil {
 		return QueryStep{}, err
 	}
 
-	return QueryStep{
+	step := QueryStep{
 		symbol:  sym,
 		isNamed: isNamed,
 		depth:   depth,
-	}, nil
+	}
+	p.applySupertypeConversion(&step, sym)
+	return step, nil
+}
+
+// applySupertypeConversion mirrors upstream tree-sitter's query compiler:
+// when a node-type name resolves to a supertype symbol (e.g. "expression"),
+// no concrete tree node ever carries that symbol directly (the matching
+// subtype node takes its place), so the step is rewritten into a
+// named-wildcard step carrying supertypeSymbol, which nodeMatchesStep /
+// stackEntryCanMatchStep use to test subtype membership at match time
+// (fixes D3: supertype patterns matching nothing).
+func (p *queryParser) applySupertypeConversion(step *QueryStep, sym Symbol) {
+	if sym == 0 || p.lang == nil || !p.lang.IsSupertype(sym) {
+		return
+	}
+	step.supertypeSymbol = sym
+	step.symbol = 0
+	step.isNamed = true
+}
+
+// stepFromMissingKeyword parses the special "MISSING" node pattern
+// (upstream tree-sitter 0.24+ semantics): (MISSING), (MISSING <kind>), or
+// (MISSING "<token>"). It is called immediately after the "MISSING"
+// identifier itself has been consumed, mirroring the corresponding branch
+// of ts_query__parse_pattern in the C runtime. A "MISSING" step tests
+// Node.IsMissing() at match time (see nodeMatchesScalarStep /
+// stackEntryMatchesScalarStep); when a kind or token qualifier is given,
+// the node's symbol must also match it.
+//
+// Anything other than an immediate kind identifier, a string-literal
+// token, or a closing ')' is rejected as a syntax error -- in particular
+// "(MISSING (child))" is invalid, matching upstream's TSQueryErrorSyntax.
+func (p *queryParser) stepFromMissingKeyword(depth int) (QueryStep, error) {
+	p.skipWhitespaceAndComments()
+	step := QueryStep{depth: depth, isMissing: true}
+
+	switch {
+	case p.pos < len(p.input) && isIdentStart(p.input[p.pos]):
+		name, err := p.readIdentifier()
+		if err != nil {
+			return QueryStep{}, err
+		}
+		sym, isNamed, err := p.resolveSymbol(name)
+		if err != nil {
+			return QueryStep{}, err
+		}
+		step.symbol = sym
+		step.isNamed = isNamed
+	case p.pos < len(p.input) && p.input[p.pos] == '"':
+		text, err := p.readString()
+		if err != nil {
+			return QueryStep{}, err
+		}
+		step.textMatch = text
+	case p.pos < len(p.input) && p.input[p.pos] == ')':
+		// Bare (MISSING): matches any missing node, named or anonymous.
+		step.isNamed = true
+	default:
+		return QueryStep{}, fmt.Errorf("query: expected node type, string literal, or ')' after 'MISSING' at position %d", p.pos)
+	}
+
+	return step, nil
 }
 
 func (p *queryParser) parseIdentifierPatternFromName(depth int, name string) (*Pattern, error) {

--- a/query_compile.go
+++ b/query_compile.go
@@ -602,6 +602,7 @@ func (p *queryParser) parseAlternationBranch(depth int, parentSymbolHint Symbol)
 	alt := alternativeSymbol{
 		symbol:    root.symbol,
 		isNamed:   root.isNamed,
+		isMissing: root.isMissing,
 		field:     altField,
 		textMatch: root.textMatch,
 	}

--- a/query_compile.go
+++ b/query_compile.go
@@ -600,11 +600,10 @@ func (p *queryParser) parseAlternationBranch(depth int, parentSymbolHint Symbol)
 
 	root := branchPat.steps[0]
 	alt := alternativeSymbol{
-		symbol:          root.symbol,
-		isNamed:         root.isNamed,
-		field:           altField,
-		textMatch:       root.textMatch,
-		supertypeSymbol: root.supertypeSymbol,
+		symbol:    root.symbol,
+		isNamed:   root.isNamed,
+		field:     altField,
+		textMatch: root.textMatch,
 	}
 	if root.field != 0 {
 		alt.field = root.field
@@ -711,29 +710,11 @@ func (p *queryParser) stepFromIdentifierName(depth int, name string) (QueryStep,
 		return QueryStep{}, err
 	}
 
-	step := QueryStep{
+	return QueryStep{
 		symbol:  sym,
 		isNamed: isNamed,
 		depth:   depth,
-	}
-	p.applySupertypeConversion(&step, sym)
-	return step, nil
-}
-
-// applySupertypeConversion mirrors upstream tree-sitter's query compiler:
-// when a node-type name resolves to a supertype symbol (e.g. "expression"),
-// no concrete tree node ever carries that symbol directly (the matching
-// subtype node takes its place), so the step is rewritten into a
-// named-wildcard step carrying supertypeSymbol, which nodeMatchesStep /
-// stackEntryCanMatchStep use to test subtype membership at match time
-// (fixes D3: supertype patterns matching nothing).
-func (p *queryParser) applySupertypeConversion(step *QueryStep, sym Symbol) {
-	if sym == 0 || p.lang == nil || !p.lang.IsSupertype(sym) {
-		return
-	}
-	step.supertypeSymbol = sym
-	step.symbol = 0
-	step.isNamed = true
+	}, nil
 }
 
 // stepFromMissingKeyword parses the special "MISSING" node pattern

--- a/query_compile_helpers.go
+++ b/query_compile_helpers.go
@@ -132,9 +132,9 @@ func (p *queryParser) resolveSymbol(name string) (Symbol, bool, error) {
 	if name == "ERROR" {
 		return errorSymbol, true, nil
 	}
-	if name == "MISSING" {
-		return 0, false, nil
-	}
+	// "MISSING" is handled specially by stepFromIdentifierName /
+	// stepFromMissingKeyword before resolveSymbol is ever reached for that
+	// name; it is a query-language keyword, not a grammar node type.
 
 	sym, ok := p.lang.symbolByNamePreferNamed(name)
 	if !ok {

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -435,24 +435,6 @@ func (q *Query) matchChildStepsRecursiveAll(
 
 	cs := childSteps[childPos]
 	step := &steps[cs.stepIdx]
-
-	// A synthetic step with a quantifier other than "exactly one" is the
-	// root of a multi-step quantified group, e.g. ((a) (b)?)* used as a
-	// child pattern. Such groups represent a repeatable SEQUENCE of
-	// sibling patterns within `parent`'s own children -- not a single
-	// wildcard-matched node whose children happen to satisfy the group's
-	// members (that interpretation is only correct for ungrouped/root
-	// patterns, where the synthetic wildcard genuinely stands in for an
-	// unknown containing node). See matchGroupStep for the fix (D5).
-	if step.synthetic && step.quantifier != queryQuantifierOne {
-		q.matchGroupStep(
-			parent, children, namedPosByIndex, parentLastNamedPos,
-			steps, childSteps, childPos, nextChildIdx, prevHasNamed, prevLastNamedPos,
-			lang, source, predicates, captures, emit,
-		)
-		return
-	}
-
 	minCount, maxCount, ok := quantifierBounds(step.quantifier)
 	if !ok {
 		return
@@ -562,248 +544,6 @@ func (q *Query) matchChildStepsRecursiveAll(
 
 		tryCombinations(0, 0, nextChildIdx, false, -1, -1, captures)
 		if step.quantifier != queryQuantifierOne && emittedForCount {
-			return
-		}
-	}
-}
-
-// collectDirectMemberSteps scans steps[start:] for entries at exactly
-// parentDepth+1, stopping once a step at depth <= parentDepth is reached.
-// This is the same "direct children in the flat step array" scan used by
-// matchStepChildrenAll, applied instead to a quantified group's inner
-// member sequence (which is compiled one depth level below its synthetic
-// wrapper step, using the same nesting convention as an ordinary node
-// pattern's children).
-func collectDirectMemberSteps(steps []QueryStep, start int, parentDepth int) []queryChildStepInfo {
-	childDepth := parentDepth + 1
-	var memberSteps []queryChildStepInfo
-	for i := start; i < len(steps); i++ {
-		if steps[i].depth <= parentDepth {
-			break
-		}
-		if steps[i].depth == childDepth {
-			memberSteps = append(memberSteps, queryChildStepInfo{
-				stepIdx: i,
-				field:   steps[i].field,
-			})
-		}
-	}
-	return memberSteps
-}
-
-// matchGroupInnerSequence matches one repetition of a quantified group's
-// inner member sequence (memberSteps) against parent's children, starting
-// the search at nextChildIdx. It mirrors matchChildStepsRecursiveAll's
-// algorithm (greedy per-member candidate counts, anchors relative to
-// `parent`) but reports, via emit, the child index immediately after the
-// last consumed sibling so that matchGroupStep can chain multiple
-// repetitions and know where each one left off.
-func (q *Query) matchGroupInnerSequence(
-	parent *Node,
-	children []*Node,
-	namedPosByIndex []int,
-	parentLastNamedPos int,
-	steps []QueryStep,
-	memberSteps []queryChildStepInfo,
-	memberPos int,
-	nextChildIdx int,
-	prevHasNamed bool,
-	prevLastNamedPos int,
-	lang *Language,
-	source []byte,
-	predicates []QueryPredicate,
-	captures []QueryCapture,
-	emit func(captures []QueryCapture, nextChildIdx int, hasNamed bool, lastNamedPos int),
-) {
-	if memberPos >= len(memberSteps) {
-		emit(captures, nextChildIdx, prevHasNamed, prevLastNamedPos)
-		return
-	}
-
-	cs := memberSteps[memberPos]
-	step := &steps[cs.stepIdx]
-	minCount, maxCount, ok := quantifierBounds(step.quantifier)
-	if !ok {
-		return
-	}
-
-	var candidateIndicesBuf [32]int
-	candidateIndices, candidatesOK := q.collectChildCandidateIndices(parent, children, step, cs.field, nextChildIdx, lang, candidateIndicesBuf[:0])
-	if !candidatesOK {
-		return
-	}
-	if maxCount < 0 || maxCount > len(candidateIndices) {
-		maxCount = len(candidateIndices)
-	}
-	if minCount > len(candidateIndices) {
-		return
-	}
-
-	for count := maxCount; count >= minCount; count-- {
-		emitted := false
-
-		var tryCombinations func(candidatePos, chosen, nextIdx int, hasNamed bool, firstNamedPos, lastNamedPos int, current []QueryCapture)
-		tryCombinations = func(candidatePos, chosen, nextIdx int, hasNamed bool, firstNamedPos, lastNamedPos int, current []QueryCapture) {
-			if chosen == count {
-				if count > 0 && !q.stepAnchorsSatisfied(
-					step, memberPos, hasNamed, firstNamedPos, lastNamedPos,
-					prevHasNamed, prevLastNamedPos, parentLastNamedPos,
-				) {
-					return
-				}
-				nextPrevHasNamed := prevHasNamed || hasNamed
-				nextPrevLastNamedPos := prevLastNamedPos
-				if hasNamed {
-					nextPrevLastNamedPos = lastNamedPos
-				}
-				q.matchGroupInnerSequence(
-					parent, children, namedPosByIndex, parentLastNamedPos,
-					steps, memberSteps, memberPos+1, nextIdx,
-					nextPrevHasNamed, nextPrevLastNamedPos,
-					lang, source, predicates, current,
-					func(next []QueryCapture, endIdx int, hn bool, lnp int) {
-						emitted = true
-						emit(next, endIdx, hn, lnp)
-					},
-				)
-				return
-			}
-
-			remaining := count - chosen
-			limit := len(candidateIndices) - remaining
-			for i := candidatePos; i <= limit; i++ {
-				childIdx := candidateIndices[i]
-				child := materializedQueryChild(parent, children, childIdx)
-				if child == nil {
-					continue
-				}
-
-				nextIdxForChoice := nextIdx
-				if childIdx+1 > nextIdxForChoice {
-					nextIdxForChoice = childIdx + 1
-				}
-
-				hasNamedForChoice := hasNamed
-				firstNamedForChoice := firstNamedPos
-				lastNamedForChoice := lastNamedPos
-				if np := namedPosByIndex[childIdx]; np >= 0 {
-					if !hasNamedForChoice {
-						hasNamedForChoice = true
-						firstNamedForChoice = np
-					}
-					lastNamedForChoice = np
-				}
-
-				q.matchStepsAllWithParentPredicates(
-					steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, current,
-					func(next []QueryCapture) {
-						tryCombinations(
-							i+1, chosen+1, nextIdxForChoice,
-							hasNamedForChoice, firstNamedForChoice, lastNamedForChoice,
-							next,
-						)
-					},
-				)
-			}
-		}
-
-		tryCombinations(0, 0, nextChildIdx, false, -1, -1, captures)
-		if emitted {
-			return
-		}
-	}
-}
-
-// matchGroupStep handles a childStepInfo entry whose step is the synthetic
-// root of a multi-step quantified group (e.g. ((a) (b)?)* used as a child
-// pattern -- see the synthetic/quantifier guard in
-// matchChildStepsRecursiveAll). It repeats the group's inner member
-// sequence as many times as the group's own quantifier allows -- trying
-// the greediest (most repetitions) option first and backing off only if
-// the rest of the pattern then fails to match, mirroring tree-sitter's
-// greedy quantifier semantics -- accumulating captures from every
-// repetition (fixing the D5 parity bug where such captures were silently
-// dropped), then continues matching the rest of the parent pattern's
-// childSteps from wherever the chosen repetition count left off.
-func (q *Query) matchGroupStep(
-	parent *Node,
-	children []*Node,
-	namedPosByIndex []int,
-	parentLastNamedPos int,
-	steps []QueryStep,
-	childSteps []queryChildStepInfo,
-	childPos int,
-	nextChildIdx int,
-	prevHasNamed bool,
-	prevLastNamedPos int,
-	lang *Language,
-	source []byte,
-	predicates []QueryPredicate,
-	captures []QueryCapture,
-	emit func([]QueryCapture),
-) {
-	cs := childSteps[childPos]
-	groupStep := &steps[cs.stepIdx]
-	minReps, maxReps, ok := quantifierBounds(groupStep.quantifier)
-	if !ok {
-		return
-	}
-
-	memberSteps := collectDirectMemberSteps(steps, cs.stepIdx+1, groupStep.depth)
-	if len(memberSteps) == 0 {
-		// Nothing to repeat; treat like a zero-length group (matches once,
-		// vacuously, same as zero repetitions).
-		minReps = 0
-	}
-
-	type groupCheckpoint struct {
-		idx          int
-		hasNamed     bool
-		lastNamedPos int
-		captures     []QueryCapture
-	}
-	checkpoints := []groupCheckpoint{{idx: nextChildIdx, hasNamed: false, lastNamedPos: -1, captures: captures}}
-
-	for len(memberSteps) > 0 && (maxReps < 0 || len(checkpoints)-1 < maxReps) {
-		last := checkpoints[len(checkpoints)-1]
-		advanced := false
-		q.matchGroupInnerSequence(
-			parent, children, namedPosByIndex, parentLastNamedPos,
-			steps, memberSteps, 0, last.idx, last.hasNamed, last.lastNamedPos,
-			lang, source, predicates, last.captures,
-			func(next []QueryCapture, endIdx int, hn bool, lnp int) {
-				// Only the first (greediest) successful repetition is kept;
-				// guard against zero-width repetitions looping forever.
-				if advanced || endIdx <= last.idx {
-					return
-				}
-				advanced = true
-				checkpoints = append(checkpoints, groupCheckpoint{idx: endIdx, hasNamed: hn, lastNamedPos: lnp, captures: next})
-			},
-		)
-		if !advanced {
-			break
-		}
-	}
-
-	for i := len(checkpoints) - 1; i >= minReps; i-- {
-		cp := checkpoints[i]
-		nextPrevHasNamed := prevHasNamed || cp.hasNamed
-		nextPrevLastNamedPos := prevLastNamedPos
-		if cp.hasNamed {
-			nextPrevLastNamedPos = cp.lastNamedPos
-		}
-		matched := false
-		q.matchChildStepsRecursiveAll(
-			parent, children, namedPosByIndex, parentLastNamedPos,
-			steps, childSteps, childPos+1, cp.idx, nextPrevHasNamed, nextPrevLastNamedPos,
-			lang, source, predicates, cp.captures,
-			func(next []QueryCapture) {
-				matched = true
-				emit(next)
-			},
-		)
-		if matched {
 			return
 		}
 	}
@@ -1553,79 +1293,12 @@ func queryStackEntryTypeName(entry stackEntry, lang *Language) string {
 
 func alternativeMatchesStackEntry(alt alternativeSymbol, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if alt.symbol == 0 && alt.textMatch == "" {
-		if !alt.isNamed || nodeNamed {
-			return alternativeSupertypeMatchesStackEntry(alt, entry, lang)
-		}
-		return false
+		return !alt.isNamed || nodeNamed
 	}
 	if alt.textMatch != "" {
 		return !nodeNamed && queryStackEntryTypeName(entry, lang) == alt.textMatch
 	}
 	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
-}
-
-func alternativeSupertypeMatchesStackEntry(alt alternativeSymbol, entry stackEntry, lang *Language) bool {
-	if alt.supertypeSymbol == 0 {
-		return true
-	}
-	nodeInternal := stackEntryNodeSymbol(entry)
-	nodePublic := lang.PublicSymbol(nodeInternal)
-	return languageSymbolIsSubtypeOf(lang, alt.supertypeSymbol, nodeInternal, nodePublic)
-}
-
-// languageSymbolIsSubtypeOf reports whether a candidate node (identified by
-// its internal and public symbol) is a member of supertype's subtype set,
-// per Language.SupertypeChildren. Nested supertypes are followed
-// recursively (e.g. python's "expression" containing "primary_expression"
-// containing "call"), approximating upstream tree-sitter's per-node
-// supertype-ancestor-chain check (ts_tree_cursor_current_status) closely
-// enough for query matching purposes. A depth cap guards against
-// malformed/cyclic supertype tables; symbol 0 entries (never a legitimate
-// concrete node type) are skipped defensively.
-func languageSymbolIsSubtypeOf(lang *Language, supertype Symbol, nodeInternal Symbol, nodePublic Symbol) bool {
-	return languageSubtypeSearch(lang, supertype, nodeInternal, nodePublic, 0)
-}
-
-const querySupertypeSearchDepthLimit = 8
-
-func languageSubtypeSearch(lang *Language, supertype Symbol, nodeInternal Symbol, nodePublic Symbol, depth int) bool {
-	if lang == nil || depth > querySupertypeSearchDepthLimit {
-		return false
-	}
-	for _, child := range lang.SupertypeChildren(supertype) {
-		if child == 0 {
-			continue
-		}
-		if child == nodeInternal || lang.PublicSymbol(child) == nodePublic {
-			return true
-		}
-		if child != supertype && lang.IsSupertype(child) &&
-			languageSubtypeSearch(lang, child, nodeInternal, nodePublic, depth+1) {
-			return true
-		}
-	}
-	return false
-}
-
-// nodeMatchesSupertypeStep reports whether node satisfies step's
-// supertypeSymbol constraint (a no-op, returning true, when the step
-// doesn't carry one).
-func nodeMatchesSupertypeStep(step *QueryStep, node *Node, lang *Language) bool {
-	if step.supertypeSymbol == 0 {
-		return true
-	}
-	nodeInternal := node.Symbol()
-	nodePublic := lang.PublicSymbol(nodeInternal)
-	return languageSymbolIsSubtypeOf(lang, step.supertypeSymbol, nodeInternal, nodePublic)
-}
-
-func stackEntryMatchesSupertypeStep(step *QueryStep, entry stackEntry, lang *Language) bool {
-	if step.supertypeSymbol == 0 {
-		return true
-	}
-	nodeInternal := stackEntryNodeSymbol(entry)
-	nodePublic := lang.PublicSymbol(nodeInternal)
-	return languageSymbolIsSubtypeOf(lang, step.supertypeSymbol, nodeInternal, nodePublic)
 }
 
 // nodeMatchesStep checks if a single node matches a single step's type/symbol constraint.
@@ -1638,7 +1311,7 @@ func (q *Query) nodeMatchesStep(step *QueryStep, node *Node, lang *Language) boo
 
 func stackEntryMatchesAlternatives(step *QueryStep, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if idx := step.altIndex; idx != nil {
-		return indexedAlternativesMatchStackEntry(idx, step.alternatives, entry, lang, nodeSymbol, nodeNamed)
+		return indexedAlternativesMatchStackEntry(idx, entry, lang, nodeSymbol, nodeNamed)
 	}
 	for _, alt := range step.alternatives {
 		if alternativeMatchesStackEntry(alt, entry, lang, nodeSymbol, nodeNamed) {
@@ -1648,7 +1321,7 @@ func stackEntryMatchesAlternatives(step *QueryStep, entry stackEntry, lang *Lang
 	return false
 }
 
-func indexedAlternativesMatchStackEntry(idx *queryAlternationIndex, alternatives []alternativeSymbol, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
+func indexedAlternativesMatchStackEntry(idx *queryAlternationIndex, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if len(idx.wildcard) > 0 {
 		return true
 	}
@@ -1657,15 +1330,6 @@ func indexedAlternativesMatchStackEntry(idx *queryAlternationIndex, alternatives
 	}
 	if !nodeNamed && len(idx.byText) > 0 {
 		return len(idx.byText[queryStackEntryTypeName(entry, lang)]) > 0
-	}
-	if nodeNamed && len(idx.supertype) > 0 {
-		nodeInternal := stackEntryNodeSymbol(entry)
-		nodePublic := lang.PublicSymbol(nodeInternal)
-		for _, ai := range idx.supertype {
-			if languageSymbolIsSubtypeOf(lang, alternatives[ai].supertypeSymbol, nodeInternal, nodePublic) {
-				return true
-			}
-		}
 	}
 	return false
 }
@@ -1679,14 +1343,9 @@ func stackEntryMatchesScalarStep(step *QueryStep, entry stackEntry, lang *Langua
 	}
 	if step.symbol == 0 {
 		if step.isMissing {
-			// Bare (MISSING) matches any missing node, ignoring namedness
-			// (mirrors upstream: node_does_match = is_missing).
 			return stackEntryNodeIsMissing(entry)
 		}
-		if !step.isNamed || nodeNamed {
-			return stackEntryMatchesSupertypeStep(step, entry, lang)
-		}
-		return false
+		return !step.isNamed || nodeNamed
 	}
 	if nodeNamed != step.isNamed || nodeSymbol != lang.PublicSymbolForNamedness(step.symbol, step.isNamed) {
 		return false
@@ -1698,7 +1357,7 @@ func nodeMatchesAlternatives(step *QueryStep, node *Node, lang *Language) bool {
 	nodeNamed := node.IsNamed()
 	nodeSymbol := lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed)
 	if idx := step.altIndex; idx != nil {
-		return indexedAlternativesMatchNode(idx, step.alternatives, node, lang, nodeSymbol, nodeNamed)
+		return indexedAlternativesMatchNode(idx, node, lang, nodeSymbol, nodeNamed)
 	}
 
 	var nodeType string
@@ -1711,7 +1370,7 @@ func nodeMatchesAlternatives(step *QueryStep, node *Node, lang *Language) bool {
 	return false
 }
 
-func indexedAlternativesMatchNode(idx *queryAlternationIndex, alternatives []alternativeSymbol, node *Node, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
+func indexedAlternativesMatchNode(idx *queryAlternationIndex, node *Node, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if len(idx.wildcard) > 0 {
 		return true
 	}
@@ -1720,15 +1379,6 @@ func indexedAlternativesMatchNode(idx *queryAlternationIndex, alternatives []alt
 	}
 	if !nodeNamed && len(idx.byText) > 0 {
 		return len(idx.byText[node.Type(lang)]) > 0
-	}
-	if nodeNamed && len(idx.supertype) > 0 {
-		nodeInternal := node.Symbol()
-		nodePublic := lang.PublicSymbol(nodeInternal)
-		for _, ai := range idx.supertype {
-			if languageSymbolIsSubtypeOf(lang, alternatives[ai].supertypeSymbol, nodeInternal, nodePublic) {
-				return true
-			}
-		}
 	}
 	return false
 }
@@ -1743,14 +1393,9 @@ func nodeMatchesScalarStep(step *QueryStep, node *Node, lang *Language) bool {
 
 	if step.symbol == 0 {
 		if step.isMissing {
-			// Bare (MISSING) matches any missing node, ignoring namedness
-			// (mirrors upstream: node_does_match = is_missing).
 			return node.IsMissing()
 		}
-		if !step.isNamed || node.IsNamed() {
-			return nodeMatchesSupertypeStep(step, node, lang)
-		}
-		return false
+		return !step.isNamed || node.IsNamed()
 	}
 
 	nodeNamed := node.IsNamed()
@@ -1761,7 +1406,6 @@ func nodeMatchesScalarStep(step *QueryStep, node *Node, lang *Language) bool {
 	if lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed) != lang.PublicSymbolForNamedness(step.symbol, step.isNamed) {
 		return false
 	}
-
 	if step.isMissing && !node.IsMissing() {
 		return false
 	}
@@ -1795,13 +1439,9 @@ func alternativeMatchesNodeCached(
 	nodeType *string,
 	nodeTypeLoaded *bool,
 ) bool {
-	// Wildcard in alternation `( _ )` should match any node, subject to an
-	// optional supertype-membership constraint (`[(expression) ...]`).
+	// Wildcard in alternation `( _ )` should match any node.
 	if alt.symbol == 0 && alt.textMatch == "" {
-		if !alt.isNamed || nodeNamed {
-			return alternativeSupertypeMatchesNode(alt, node, lang)
-		}
-		return false
+		return !alt.isNamed || nodeNamed
 	}
 
 	if alt.textMatch != "" {
@@ -1817,13 +1457,4 @@ func alternativeMatchesNodeCached(
 	}
 
 	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
-}
-
-func alternativeSupertypeMatchesNode(alt alternativeSymbol, node *Node, lang *Language) bool {
-	if alt.supertypeSymbol == 0 {
-		return true
-	}
-	nodeInternal := node.Symbol()
-	nodePublic := lang.PublicSymbol(nodeInternal)
-	return languageSymbolIsSubtypeOf(lang, alt.supertypeSymbol, nodeInternal, nodePublic)
 }

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -1094,6 +1094,9 @@ func (c *alternationMatchContext) matchLinearAlternation() bool {
 }
 
 func (c *alternationMatchContext) alternativeMatches(alt *alternativeSymbol) bool {
+	if alt.isMissing && !alternativeMatchesNodeCached(*alt, c.node, c.lang, c.nodeSymbol, c.nodeNamed, &c.nodeType, &c.nodeTypeLoaded) {
+		return false
+	}
 	if !c.q.alternativeFieldMatches(alt, c.node, c.parent, c.childIdx, c.lang) {
 		return false
 	}
@@ -1293,12 +1296,18 @@ func queryStackEntryTypeName(entry stackEntry, lang *Language) string {
 
 func alternativeMatchesStackEntry(alt alternativeSymbol, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if alt.symbol == 0 && alt.textMatch == "" {
+		if alt.isMissing {
+			return stackEntryNodeIsMissing(entry)
+		}
 		return !alt.isNamed || nodeNamed
 	}
 	if alt.textMatch != "" {
-		return !nodeNamed && queryStackEntryTypeName(entry, lang) == alt.textMatch
+		return !nodeNamed && queryStackEntryTypeName(entry, lang) == alt.textMatch &&
+			(!alt.isMissing || stackEntryNodeIsMissing(entry))
 	}
-	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
+	return nodeNamed == alt.isNamed &&
+		nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed) &&
+		(!alt.isMissing || stackEntryNodeIsMissing(entry))
 }
 
 // nodeMatchesStep checks if a single node matches a single step's type/symbol constraint.
@@ -1441,6 +1450,9 @@ func alternativeMatchesNodeCached(
 ) bool {
 	// Wildcard in alternation `( _ )` should match any node.
 	if alt.symbol == 0 && alt.textMatch == "" {
+		if alt.isMissing {
+			return node.IsMissing()
+		}
 		return !alt.isNamed || nodeNamed
 	}
 
@@ -1453,8 +1465,10 @@ func alternativeMatchesNodeCached(
 			*nodeType = node.Type(lang)
 			*nodeTypeLoaded = true
 		}
-		return *nodeType == alt.textMatch
+		return *nodeType == alt.textMatch && (!alt.isMissing || node.IsMissing())
 	}
 
-	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
+	return nodeNamed == alt.isNamed &&
+		nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed) &&
+		(!alt.isMissing || node.IsMissing())
 }

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -435,6 +435,24 @@ func (q *Query) matchChildStepsRecursiveAll(
 
 	cs := childSteps[childPos]
 	step := &steps[cs.stepIdx]
+
+	// A synthetic step with a quantifier other than "exactly one" is the
+	// root of a multi-step quantified group, e.g. ((a) (b)?)* used as a
+	// child pattern. Such groups represent a repeatable SEQUENCE of
+	// sibling patterns within `parent`'s own children -- not a single
+	// wildcard-matched node whose children happen to satisfy the group's
+	// members (that interpretation is only correct for ungrouped/root
+	// patterns, where the synthetic wildcard genuinely stands in for an
+	// unknown containing node). See matchGroupStep for the fix (D5).
+	if step.synthetic && step.quantifier != queryQuantifierOne {
+		q.matchGroupStep(
+			parent, children, namedPosByIndex, parentLastNamedPos,
+			steps, childSteps, childPos, nextChildIdx, prevHasNamed, prevLastNamedPos,
+			lang, source, predicates, captures, emit,
+		)
+		return
+	}
+
 	minCount, maxCount, ok := quantifierBounds(step.quantifier)
 	if !ok {
 		return
@@ -544,6 +562,248 @@ func (q *Query) matchChildStepsRecursiveAll(
 
 		tryCombinations(0, 0, nextChildIdx, false, -1, -1, captures)
 		if step.quantifier != queryQuantifierOne && emittedForCount {
+			return
+		}
+	}
+}
+
+// collectDirectMemberSteps scans steps[start:] for entries at exactly
+// parentDepth+1, stopping once a step at depth <= parentDepth is reached.
+// This is the same "direct children in the flat step array" scan used by
+// matchStepChildrenAll, applied instead to a quantified group's inner
+// member sequence (which is compiled one depth level below its synthetic
+// wrapper step, using the same nesting convention as an ordinary node
+// pattern's children).
+func collectDirectMemberSteps(steps []QueryStep, start int, parentDepth int) []queryChildStepInfo {
+	childDepth := parentDepth + 1
+	var memberSteps []queryChildStepInfo
+	for i := start; i < len(steps); i++ {
+		if steps[i].depth <= parentDepth {
+			break
+		}
+		if steps[i].depth == childDepth {
+			memberSteps = append(memberSteps, queryChildStepInfo{
+				stepIdx: i,
+				field:   steps[i].field,
+			})
+		}
+	}
+	return memberSteps
+}
+
+// matchGroupInnerSequence matches one repetition of a quantified group's
+// inner member sequence (memberSteps) against parent's children, starting
+// the search at nextChildIdx. It mirrors matchChildStepsRecursiveAll's
+// algorithm (greedy per-member candidate counts, anchors relative to
+// `parent`) but reports, via emit, the child index immediately after the
+// last consumed sibling so that matchGroupStep can chain multiple
+// repetitions and know where each one left off.
+func (q *Query) matchGroupInnerSequence(
+	parent *Node,
+	children []*Node,
+	namedPosByIndex []int,
+	parentLastNamedPos int,
+	steps []QueryStep,
+	memberSteps []queryChildStepInfo,
+	memberPos int,
+	nextChildIdx int,
+	prevHasNamed bool,
+	prevLastNamedPos int,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func(captures []QueryCapture, nextChildIdx int, hasNamed bool, lastNamedPos int),
+) {
+	if memberPos >= len(memberSteps) {
+		emit(captures, nextChildIdx, prevHasNamed, prevLastNamedPos)
+		return
+	}
+
+	cs := memberSteps[memberPos]
+	step := &steps[cs.stepIdx]
+	minCount, maxCount, ok := quantifierBounds(step.quantifier)
+	if !ok {
+		return
+	}
+
+	var candidateIndicesBuf [32]int
+	candidateIndices, candidatesOK := q.collectChildCandidateIndices(parent, children, step, cs.field, nextChildIdx, lang, candidateIndicesBuf[:0])
+	if !candidatesOK {
+		return
+	}
+	if maxCount < 0 || maxCount > len(candidateIndices) {
+		maxCount = len(candidateIndices)
+	}
+	if minCount > len(candidateIndices) {
+		return
+	}
+
+	for count := maxCount; count >= minCount; count-- {
+		emitted := false
+
+		var tryCombinations func(candidatePos, chosen, nextIdx int, hasNamed bool, firstNamedPos, lastNamedPos int, current []QueryCapture)
+		tryCombinations = func(candidatePos, chosen, nextIdx int, hasNamed bool, firstNamedPos, lastNamedPos int, current []QueryCapture) {
+			if chosen == count {
+				if count > 0 && !q.stepAnchorsSatisfied(
+					step, memberPos, hasNamed, firstNamedPos, lastNamedPos,
+					prevHasNamed, prevLastNamedPos, parentLastNamedPos,
+				) {
+					return
+				}
+				nextPrevHasNamed := prevHasNamed || hasNamed
+				nextPrevLastNamedPos := prevLastNamedPos
+				if hasNamed {
+					nextPrevLastNamedPos = lastNamedPos
+				}
+				q.matchGroupInnerSequence(
+					parent, children, namedPosByIndex, parentLastNamedPos,
+					steps, memberSteps, memberPos+1, nextIdx,
+					nextPrevHasNamed, nextPrevLastNamedPos,
+					lang, source, predicates, current,
+					func(next []QueryCapture, endIdx int, hn bool, lnp int) {
+						emitted = true
+						emit(next, endIdx, hn, lnp)
+					},
+				)
+				return
+			}
+
+			remaining := count - chosen
+			limit := len(candidateIndices) - remaining
+			for i := candidatePos; i <= limit; i++ {
+				childIdx := candidateIndices[i]
+				child := materializedQueryChild(parent, children, childIdx)
+				if child == nil {
+					continue
+				}
+
+				nextIdxForChoice := nextIdx
+				if childIdx+1 > nextIdxForChoice {
+					nextIdxForChoice = childIdx + 1
+				}
+
+				hasNamedForChoice := hasNamed
+				firstNamedForChoice := firstNamedPos
+				lastNamedForChoice := lastNamedPos
+				if np := namedPosByIndex[childIdx]; np >= 0 {
+					if !hasNamedForChoice {
+						hasNamedForChoice = true
+						firstNamedForChoice = np
+					}
+					lastNamedForChoice = np
+				}
+
+				q.matchStepsAllWithParentPredicates(
+					steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, current,
+					func(next []QueryCapture) {
+						tryCombinations(
+							i+1, chosen+1, nextIdxForChoice,
+							hasNamedForChoice, firstNamedForChoice, lastNamedForChoice,
+							next,
+						)
+					},
+				)
+			}
+		}
+
+		tryCombinations(0, 0, nextChildIdx, false, -1, -1, captures)
+		if emitted {
+			return
+		}
+	}
+}
+
+// matchGroupStep handles a childStepInfo entry whose step is the synthetic
+// root of a multi-step quantified group (e.g. ((a) (b)?)* used as a child
+// pattern -- see the synthetic/quantifier guard in
+// matchChildStepsRecursiveAll). It repeats the group's inner member
+// sequence as many times as the group's own quantifier allows -- trying
+// the greediest (most repetitions) option first and backing off only if
+// the rest of the pattern then fails to match, mirroring tree-sitter's
+// greedy quantifier semantics -- accumulating captures from every
+// repetition (fixing the D5 parity bug where such captures were silently
+// dropped), then continues matching the rest of the parent pattern's
+// childSteps from wherever the chosen repetition count left off.
+func (q *Query) matchGroupStep(
+	parent *Node,
+	children []*Node,
+	namedPosByIndex []int,
+	parentLastNamedPos int,
+	steps []QueryStep,
+	childSteps []queryChildStepInfo,
+	childPos int,
+	nextChildIdx int,
+	prevHasNamed bool,
+	prevLastNamedPos int,
+	lang *Language,
+	source []byte,
+	predicates []QueryPredicate,
+	captures []QueryCapture,
+	emit func([]QueryCapture),
+) {
+	cs := childSteps[childPos]
+	groupStep := &steps[cs.stepIdx]
+	minReps, maxReps, ok := quantifierBounds(groupStep.quantifier)
+	if !ok {
+		return
+	}
+
+	memberSteps := collectDirectMemberSteps(steps, cs.stepIdx+1, groupStep.depth)
+	if len(memberSteps) == 0 {
+		// Nothing to repeat; treat like a zero-length group (matches once,
+		// vacuously, same as zero repetitions).
+		minReps = 0
+	}
+
+	type groupCheckpoint struct {
+		idx          int
+		hasNamed     bool
+		lastNamedPos int
+		captures     []QueryCapture
+	}
+	checkpoints := []groupCheckpoint{{idx: nextChildIdx, hasNamed: false, lastNamedPos: -1, captures: captures}}
+
+	for len(memberSteps) > 0 && (maxReps < 0 || len(checkpoints)-1 < maxReps) {
+		last := checkpoints[len(checkpoints)-1]
+		advanced := false
+		q.matchGroupInnerSequence(
+			parent, children, namedPosByIndex, parentLastNamedPos,
+			steps, memberSteps, 0, last.idx, last.hasNamed, last.lastNamedPos,
+			lang, source, predicates, last.captures,
+			func(next []QueryCapture, endIdx int, hn bool, lnp int) {
+				// Only the first (greediest) successful repetition is kept;
+				// guard against zero-width repetitions looping forever.
+				if advanced || endIdx <= last.idx {
+					return
+				}
+				advanced = true
+				checkpoints = append(checkpoints, groupCheckpoint{idx: endIdx, hasNamed: hn, lastNamedPos: lnp, captures: next})
+			},
+		)
+		if !advanced {
+			break
+		}
+	}
+
+	for i := len(checkpoints) - 1; i >= minReps; i-- {
+		cp := checkpoints[i]
+		nextPrevHasNamed := prevHasNamed || cp.hasNamed
+		nextPrevLastNamedPos := prevLastNamedPos
+		if cp.hasNamed {
+			nextPrevLastNamedPos = cp.lastNamedPos
+		}
+		matched := false
+		q.matchChildStepsRecursiveAll(
+			parent, children, namedPosByIndex, parentLastNamedPos,
+			steps, childSteps, childPos+1, cp.idx, nextPrevHasNamed, nextPrevLastNamedPos,
+			lang, source, predicates, cp.captures,
+			func(next []QueryCapture) {
+				matched = true
+				emit(next)
+			},
+		)
+		if matched {
 			return
 		}
 	}
@@ -1293,12 +1553,79 @@ func queryStackEntryTypeName(entry stackEntry, lang *Language) string {
 
 func alternativeMatchesStackEntry(alt alternativeSymbol, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if alt.symbol == 0 && alt.textMatch == "" {
-		return !alt.isNamed || nodeNamed
+		if !alt.isNamed || nodeNamed {
+			return alternativeSupertypeMatchesStackEntry(alt, entry, lang)
+		}
+		return false
 	}
 	if alt.textMatch != "" {
 		return !nodeNamed && queryStackEntryTypeName(entry, lang) == alt.textMatch
 	}
 	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
+}
+
+func alternativeSupertypeMatchesStackEntry(alt alternativeSymbol, entry stackEntry, lang *Language) bool {
+	if alt.supertypeSymbol == 0 {
+		return true
+	}
+	nodeInternal := stackEntryNodeSymbol(entry)
+	nodePublic := lang.PublicSymbol(nodeInternal)
+	return languageSymbolIsSubtypeOf(lang, alt.supertypeSymbol, nodeInternal, nodePublic)
+}
+
+// languageSymbolIsSubtypeOf reports whether a candidate node (identified by
+// its internal and public symbol) is a member of supertype's subtype set,
+// per Language.SupertypeChildren. Nested supertypes are followed
+// recursively (e.g. python's "expression" containing "primary_expression"
+// containing "call"), approximating upstream tree-sitter's per-node
+// supertype-ancestor-chain check (ts_tree_cursor_current_status) closely
+// enough for query matching purposes. A depth cap guards against
+// malformed/cyclic supertype tables; symbol 0 entries (never a legitimate
+// concrete node type) are skipped defensively.
+func languageSymbolIsSubtypeOf(lang *Language, supertype Symbol, nodeInternal Symbol, nodePublic Symbol) bool {
+	return languageSubtypeSearch(lang, supertype, nodeInternal, nodePublic, 0)
+}
+
+const querySupertypeSearchDepthLimit = 8
+
+func languageSubtypeSearch(lang *Language, supertype Symbol, nodeInternal Symbol, nodePublic Symbol, depth int) bool {
+	if lang == nil || depth > querySupertypeSearchDepthLimit {
+		return false
+	}
+	for _, child := range lang.SupertypeChildren(supertype) {
+		if child == 0 {
+			continue
+		}
+		if child == nodeInternal || lang.PublicSymbol(child) == nodePublic {
+			return true
+		}
+		if child != supertype && lang.IsSupertype(child) &&
+			languageSubtypeSearch(lang, child, nodeInternal, nodePublic, depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeMatchesSupertypeStep reports whether node satisfies step's
+// supertypeSymbol constraint (a no-op, returning true, when the step
+// doesn't carry one).
+func nodeMatchesSupertypeStep(step *QueryStep, node *Node, lang *Language) bool {
+	if step.supertypeSymbol == 0 {
+		return true
+	}
+	nodeInternal := node.Symbol()
+	nodePublic := lang.PublicSymbol(nodeInternal)
+	return languageSymbolIsSubtypeOf(lang, step.supertypeSymbol, nodeInternal, nodePublic)
+}
+
+func stackEntryMatchesSupertypeStep(step *QueryStep, entry stackEntry, lang *Language) bool {
+	if step.supertypeSymbol == 0 {
+		return true
+	}
+	nodeInternal := stackEntryNodeSymbol(entry)
+	nodePublic := lang.PublicSymbol(nodeInternal)
+	return languageSymbolIsSubtypeOf(lang, step.supertypeSymbol, nodeInternal, nodePublic)
 }
 
 // nodeMatchesStep checks if a single node matches a single step's type/symbol constraint.
@@ -1311,7 +1638,7 @@ func (q *Query) nodeMatchesStep(step *QueryStep, node *Node, lang *Language) boo
 
 func stackEntryMatchesAlternatives(step *QueryStep, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if idx := step.altIndex; idx != nil {
-		return indexedAlternativesMatchStackEntry(idx, entry, lang, nodeSymbol, nodeNamed)
+		return indexedAlternativesMatchStackEntry(idx, step.alternatives, entry, lang, nodeSymbol, nodeNamed)
 	}
 	for _, alt := range step.alternatives {
 		if alternativeMatchesStackEntry(alt, entry, lang, nodeSymbol, nodeNamed) {
@@ -1321,7 +1648,7 @@ func stackEntryMatchesAlternatives(step *QueryStep, entry stackEntry, lang *Lang
 	return false
 }
 
-func indexedAlternativesMatchStackEntry(idx *queryAlternationIndex, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
+func indexedAlternativesMatchStackEntry(idx *queryAlternationIndex, alternatives []alternativeSymbol, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if len(idx.wildcard) > 0 {
 		return true
 	}
@@ -1331,24 +1658,47 @@ func indexedAlternativesMatchStackEntry(idx *queryAlternationIndex, entry stackE
 	if !nodeNamed && len(idx.byText) > 0 {
 		return len(idx.byText[queryStackEntryTypeName(entry, lang)]) > 0
 	}
+	if nodeNamed && len(idx.supertype) > 0 {
+		nodeInternal := stackEntryNodeSymbol(entry)
+		nodePublic := lang.PublicSymbol(nodeInternal)
+		for _, ai := range idx.supertype {
+			if languageSymbolIsSubtypeOf(lang, alternatives[ai].supertypeSymbol, nodeInternal, nodePublic) {
+				return true
+			}
+		}
+	}
 	return false
 }
 
 func stackEntryMatchesScalarStep(step *QueryStep, entry stackEntry, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if step.textMatch != "" {
-		return !nodeNamed && queryStackEntryTypeName(entry, lang) == step.textMatch
+		if !nodeNamed && queryStackEntryTypeName(entry, lang) == step.textMatch {
+			return !step.isMissing || stackEntryNodeIsMissing(entry)
+		}
+		return false
 	}
 	if step.symbol == 0 {
-		return !step.isNamed || nodeNamed
+		if step.isMissing {
+			// Bare (MISSING) matches any missing node, ignoring namedness
+			// (mirrors upstream: node_does_match = is_missing).
+			return stackEntryNodeIsMissing(entry)
+		}
+		if !step.isNamed || nodeNamed {
+			return stackEntryMatchesSupertypeStep(step, entry, lang)
+		}
+		return false
 	}
-	return nodeNamed == step.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(step.symbol, step.isNamed)
+	if nodeNamed != step.isNamed || nodeSymbol != lang.PublicSymbolForNamedness(step.symbol, step.isNamed) {
+		return false
+	}
+	return !step.isMissing || stackEntryNodeIsMissing(entry)
 }
 
 func nodeMatchesAlternatives(step *QueryStep, node *Node, lang *Language) bool {
 	nodeNamed := node.IsNamed()
 	nodeSymbol := lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed)
 	if idx := step.altIndex; idx != nil {
-		return indexedAlternativesMatchNode(idx, node, lang, nodeSymbol, nodeNamed)
+		return indexedAlternativesMatchNode(idx, step.alternatives, node, lang, nodeSymbol, nodeNamed)
 	}
 
 	var nodeType string
@@ -1361,7 +1711,7 @@ func nodeMatchesAlternatives(step *QueryStep, node *Node, lang *Language) bool {
 	return false
 }
 
-func indexedAlternativesMatchNode(idx *queryAlternationIndex, node *Node, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
+func indexedAlternativesMatchNode(idx *queryAlternationIndex, alternatives []alternativeSymbol, node *Node, lang *Language, nodeSymbol Symbol, nodeNamed bool) bool {
 	if len(idx.wildcard) > 0 {
 		return true
 	}
@@ -1371,16 +1721,36 @@ func indexedAlternativesMatchNode(idx *queryAlternationIndex, node *Node, lang *
 	if !nodeNamed && len(idx.byText) > 0 {
 		return len(idx.byText[node.Type(lang)]) > 0
 	}
+	if nodeNamed && len(idx.supertype) > 0 {
+		nodeInternal := node.Symbol()
+		nodePublic := lang.PublicSymbol(nodeInternal)
+		for _, ai := range idx.supertype {
+			if languageSymbolIsSubtypeOf(lang, alternatives[ai].supertypeSymbol, nodeInternal, nodePublic) {
+				return true
+			}
+		}
+	}
 	return false
 }
 
 func nodeMatchesScalarStep(step *QueryStep, node *Node, lang *Language) bool {
 	if step.textMatch != "" {
-		return !node.IsNamed() && node.Type(lang) == step.textMatch
+		if !node.IsNamed() && node.Type(lang) == step.textMatch {
+			return !step.isMissing || node.IsMissing()
+		}
+		return false
 	}
 
 	if step.symbol == 0 {
-		return !step.isNamed || node.IsNamed()
+		if step.isMissing {
+			// Bare (MISSING) matches any missing node, ignoring namedness
+			// (mirrors upstream: node_does_match = is_missing).
+			return node.IsMissing()
+		}
+		if !step.isNamed || node.IsNamed() {
+			return nodeMatchesSupertypeStep(step, node, lang)
+		}
+		return false
 	}
 
 	nodeNamed := node.IsNamed()
@@ -1389,6 +1759,10 @@ func nodeMatchesScalarStep(step *QueryStep, node *Node, lang *Language) bool {
 	}
 
 	if lang.PublicSymbolForNamedness(node.Symbol(), nodeNamed) != lang.PublicSymbolForNamedness(step.symbol, step.isNamed) {
+		return false
+	}
+
+	if step.isMissing && !node.IsMissing() {
 		return false
 	}
 
@@ -1421,9 +1795,13 @@ func alternativeMatchesNodeCached(
 	nodeType *string,
 	nodeTypeLoaded *bool,
 ) bool {
-	// Wildcard in alternation `( _ )` should match any node.
+	// Wildcard in alternation `( _ )` should match any node, subject to an
+	// optional supertype-membership constraint (`[(expression) ...]`).
 	if alt.symbol == 0 && alt.textMatch == "" {
-		return !alt.isNamed || nodeNamed
+		if !alt.isNamed || nodeNamed {
+			return alternativeSupertypeMatchesNode(alt, node, lang)
+		}
+		return false
 	}
 
 	if alt.textMatch != "" {
@@ -1439,4 +1817,13 @@ func alternativeMatchesNodeCached(
 	}
 
 	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed)
+}
+
+func alternativeSupertypeMatchesNode(alt alternativeSymbol, node *Node, lang *Language) bool {
+	if alt.supertypeSymbol == 0 {
+		return true
+	}
+	nodeInternal := node.Symbol()
+	nodePublic := lang.PublicSymbol(nodeInternal)
+	return languageSymbolIsSubtypeOf(lang, alt.supertypeSymbol, nodeInternal, nodePublic)
 }

--- a/query_predicates.go
+++ b/query_predicates.go
@@ -55,8 +55,8 @@ func (q *Query) matchesPredicate(pred QueryPredicate, captures []QueryCapture, l
 		// #is? / #is-not? are property predicates: in upstream tree-sitter
 		// they are inert metadata consumed by the host application (e.g.
 		// locals.scm tracking via "local"/"local.definition" properties)
-		// and never filter the match set. See PredicatesForPattern for the
-		// exposed-metadata path hosts should use instead.
+		// and never filter the match set. See PropertyPredicate and
+		// PropertyPredicatesForPattern for the host-consumable metadata path.
 		return true
 	case predicateCount:
 		return countPredicateMatches(pred, captures)

--- a/query_predicates.go
+++ b/query_predicates.go
@@ -1,7 +1,6 @@
 package gotreesitter
 
 import (
-	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -52,10 +51,13 @@ func (q *Query) matchesPredicate(pred QueryPredicate, captures []QueryCapture, l
 		return parentPredicateMatches(pred, captures, lang, false)
 	case predicateNotHasParent:
 		return parentPredicateMatches(pred, captures, lang, true)
-	case predicateIs:
-		return predicateIsSatisfied(pred, captures)
-	case predicateIsNot:
-		return !predicateIsSatisfied(pred, captures)
+	case predicateIs, predicateIsNot:
+		// #is? / #is-not? are property predicates: in upstream tree-sitter
+		// they are inert metadata consumed by the host application (e.g.
+		// locals.scm tracking via "local"/"local.definition" properties)
+		// and never filter the match set. See PredicatesForPattern for the
+		// exposed-metadata path hosts should use instead.
+		return true
 	case predicateCount:
 		return countPredicateMatches(pred, captures)
 	case predicateIsExported:
@@ -145,7 +147,7 @@ func exportedPredicateStillViable(pred QueryPredicate, captures []QueryCapture, 
 func predicatesCanRejectMatch(predicates []QueryPredicate) bool {
 	for _, pred := range predicates {
 		switch pred.kind {
-		case predicateSet, predicateOffset, predicateSelectAdjacent, predicateStrip:
+		case predicateSet, predicateOffset, predicateSelectAdjacent, predicateStrip, predicateIs, predicateIsNot:
 			continue
 		default:
 			return true
@@ -464,44 +466,6 @@ func nodeHasAncestorType(node *Node, typeNames []string, lang *Language) bool {
 	}
 	for p := node.Parent(); p != nil; p = p.Parent() {
 		if nodeTypeMatchesAny(p, typeNames, lang) {
-			return true
-		}
-	}
-	return false
-}
-
-func capturePropertyMatches(captureName string, property string) bool {
-	prop := strings.Trim(property, "\"")
-	switch prop {
-	case "local":
-		return strings.Contains(captureName, "local") || strings.Contains(captureName, "parameter")
-	case "local.parameter", "parameter":
-		return strings.Contains(captureName, "parameter")
-	case "function":
-		return strings.Contains(captureName, "function")
-	case "var", "variable":
-		return strings.Contains(captureName, "var") || strings.Contains(captureName, "variable")
-	}
-	if captureName == prop {
-		return true
-	}
-	return strings.HasSuffix(captureName, "."+prop)
-}
-
-func predicateIsSatisfied(pred QueryPredicate, captures []QueryCapture) bool {
-	if pred.property == "" {
-		return false
-	}
-	if pred.leftCapture != "" {
-		nodes := captureNodes(pred.leftCapture, captures)
-		if len(nodes) == 0 {
-			return false
-		}
-		return capturePropertyMatches(pred.leftCapture, pred.property)
-	}
-
-	for _, c := range captures {
-		if capturePropertyMatches(c.Name, pred.property) {
 			return true
 		}
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1647,6 +1647,9 @@ func TestMatchPredicateNotHasParent(t *testing.T) {
 }
 
 func TestMatchPredicateIsAndIsNot(t *testing.T) {
+	// #is?/#is-not? are property predicates: upstream tree-sitter treats
+	// them as inert metadata for the host application (e.g. locals.scm
+	// tracking) and they never filter the match set. See D8 parity fix.
 	lang := queryTestLanguage()
 	tree := buildSimpleTree(lang)
 
@@ -1662,8 +1665,8 @@ func TestMatchPredicateIsAndIsNot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
-	if got := len(q2.Execute(tree)); got != 0 {
-		t.Fatalf("matches (#is-not?): got %d, want 0", got)
+	if got := len(q2.Execute(tree)); got != 1 {
+		t.Fatalf("matches (#is-not?): got %d, want 1 (is-not? must not filter matches)", got)
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -1672,7 +1672,61 @@ func stackEntryContainsPointRange(entry stackEntry, startPoint, endPoint Point) 
 	return pointLessOrEqual(stackEntryNodeStartPoint(entry), startPoint) && pointLessOrEqual(endPoint, stackEntryNodeEndPoint(entry))
 }
 
+// descendantForByteRange walks to the smallest descendant covering [startByte,
+// endByte], matching upstream tree-sitter's ts_node__descendant_for_byte_range
+// (lib/src/node.c): descend into the first child whose end reaches range_end
+// AND *exceeds* range_start — so an empty range at a token's end boundary
+// belongs to the parent/next node — and whose start is at or before
+// range_start; stop scanning once a child starts past range_start. It returns
+// the last relevant node visited, i.e. the node itself for an unsatisfiable or
+// out-of-bounds range, never nil. (The C runtime never returns a null node
+// here; earlier gotreesitter behavior included the end boundary and returned
+// nil, diverging on exactly the cursor-at-token-end position editors hit most.)
 func (n *Node) descendantForByteRange(startByte, endByte uint32, namedOnly bool) *Node {
+	if n == nil {
+		return nil
+	}
+	node := n
+	lastRelevant := n
+	for {
+		descended := false
+		childCount := nodeChildCountNoMaterialize(node)
+		for i := 0; i < childCount; i++ {
+			entry, ok := nodeChildEntryAtNoMaterialize(node, i)
+			if !ok {
+				continue
+			}
+			childEnd := stackEntryNodeEndByte(entry)
+			if childEnd < endByte || childEnd <= startByte {
+				continue
+			}
+			if stackEntryNodeStartByte(entry) > startByte {
+				break
+			}
+			child := nodeChildAtForReason(node, i, materializeForParentAPI)
+			if child == nil {
+				continue
+			}
+			node = child
+			if !namedOnly || child.isNamed() {
+				lastRelevant = child
+			}
+			descended = true
+			break
+		}
+		if !descended {
+			break
+		}
+	}
+	return lastRelevant
+}
+
+// descendantForByteRangeContained is the pre-C-parity walk: it returns the
+// smallest descendant that *fully contains* [startByte, endByte], or nil when
+// the range is not contained. It is retained for internal callers (incremental
+// reuse fast paths) that depend on the nil-on-miss / boundary-inclusive
+// behavior; the public Descendant*ForByteRange API uses the C-faithful walk.
+func (n *Node) descendantForByteRangeContained(startByte, endByte uint32, namedOnly bool) *Node {
 	if n == nil || endByte < startByte || !n.containsByteRange(startByte, endByte) {
 		return nil
 	}
@@ -1694,40 +1748,52 @@ func (n *Node) descendantForByteRange(startByte, endByte uint32, namedOnly bool)
 		if !child.containsByteRange(startByte, endByte) {
 			continue
 		}
-		if d := child.descendantForByteRange(startByte, endByte, namedOnly); d != nil {
+		if d := child.descendantForByteRangeContained(startByte, endByte, namedOnly); d != nil {
 			deepest = d
 		}
 	}
 	return deepest
 }
 
+// descendantForPointRange is the point-coordinate C-faithful walk; see
+// descendantForByteRange for the boundary/out-of-range rule it mirrors.
 func (n *Node) descendantForPointRange(startPoint, endPoint Point, namedOnly bool) *Node {
-	if n == nil || pointLessThan(endPoint, startPoint) || !n.containsPointRange(startPoint, endPoint) {
+	if n == nil {
 		return nil
 	}
-
-	var deepest *Node
-	if !namedOnly || n.isNamed() {
-		deepest = n
+	node := n
+	lastRelevant := n
+	for {
+		descended := false
+		childCount := nodeChildCountNoMaterialize(node)
+		for i := 0; i < childCount; i++ {
+			entry, ok := nodeChildEntryAtNoMaterialize(node, i)
+			if !ok {
+				continue
+			}
+			childEnd := stackEntryNodeEndPoint(entry)
+			if pointLessThan(childEnd, endPoint) || pointLessOrEqual(childEnd, startPoint) {
+				continue
+			}
+			if pointGreaterThan(stackEntryNodeStartPoint(entry), startPoint) {
+				break
+			}
+			child := nodeChildAtForReason(node, i, materializeForParentAPI)
+			if child == nil {
+				continue
+			}
+			node = child
+			if !namedOnly || child.isNamed() {
+				lastRelevant = child
+			}
+			descended = true
+			break
+		}
+		if !descended {
+			break
+		}
 	}
-	childCount := nodeChildCountNoMaterialize(n)
-	for i := 0; i < childCount; i++ {
-		entry, ok := nodeChildEntryAtNoMaterialize(n, i)
-		if !ok || !stackEntryContainsPointRange(entry, startPoint, endPoint) {
-			continue
-		}
-		child := nodeChildAtForReason(n, i, materializeForParentAPI)
-		if child == nil {
-			continue
-		}
-		if !child.containsPointRange(startPoint, endPoint) {
-			continue
-		}
-		if d := child.descendantForPointRange(startPoint, endPoint, namedOnly); d != nil {
-			deepest = d
-		}
-	}
-	return deepest
+	return lastRelevant
 }
 
 // DescendantForByteRange returns the smallest descendant that fully contains
@@ -1747,7 +1813,7 @@ func (n *Node) NodeAtByte(byteOffset uint32) *Node {
 	if byteOffset < n.endByte {
 		endByte = byteOffset + 1
 	}
-	return n.DescendantForByteRange(byteOffset, endByte)
+	return n.descendantForByteRangeContained(byteOffset, endByte, false)
 }
 
 // NamedDescendantForByteRange returns the smallest named descendant that fully
@@ -1766,7 +1832,7 @@ func (n *Node) NamedNodeAtByte(byteOffset uint32) *Node {
 	if byteOffset < n.endByte {
 		endByte = byteOffset + 1
 	}
-	return n.NamedDescendantForByteRange(byteOffset, endByte)
+	return n.descendantForByteRangeContained(byteOffset, endByte, true)
 }
 
 // DescendantForPointRange returns the smallest descendant that fully contains

--- a/tree.go
+++ b/tree.go
@@ -1675,15 +1675,13 @@ func stackEntryContainsPointRange(entry stackEntry, startPoint, endPoint Point) 
 // descendantForByteRange walks to the smallest descendant covering [startByte,
 // endByte], matching upstream tree-sitter's ts_node__descendant_for_byte_range
 // (lib/src/node.c): descend into the first child whose end reaches range_end
-// AND *exceeds* range_start — so an empty range at a token's end boundary
-// belongs to the parent/next node — and whose start is at or before
-// range_start; stop scanning once a child starts past range_start. It returns
-// the last relevant node visited, i.e. the node itself for an unsatisfiable or
-// out-of-bounds range, never nil. (The C runtime never returns a null node
-// here; earlier gotreesitter behavior included the end boundary and returned
-// nil, diverging on exactly the cursor-at-token-end position editors hit most.)
+// and whose start is at or before range_start; stop scanning once a child
+// starts past range_start. Non-empty children must extend past range_start,
+// while zero-width children at range_start remain eligible. It returns the
+// last relevant node visited, i.e. the node itself for a valid unsatisfiable
+// or out-of-bounds range. A nil receiver or reversed range returns nil.
 func (n *Node) descendantForByteRange(startByte, endByte uint32, namedOnly bool) *Node {
-	if n == nil {
+	if n == nil || endByte < startByte {
 		return nil
 	}
 	node := n
@@ -1696,11 +1694,19 @@ func (n *Node) descendantForByteRange(startByte, endByte uint32, namedOnly bool)
 			if !ok {
 				continue
 			}
+			childStart := stackEntryNodeStartByte(entry)
 			childEnd := stackEntryNodeEndByte(entry)
-			if childEnd < endByte || childEnd <= startByte {
+			if childEnd < endByte {
 				continue
 			}
-			if stackEntryNodeStartByte(entry) > startByte {
+			if childStart == childEnd {
+				if childEnd < startByte {
+					continue
+				}
+			} else if childEnd <= startByte {
+				continue
+			}
+			if childStart > startByte {
 				break
 			}
 			child := nodeChildAtForReason(node, i, materializeForParentAPI)
@@ -1758,7 +1764,7 @@ func (n *Node) descendantForByteRangeContained(startByte, endByte uint32, namedO
 // descendantForPointRange is the point-coordinate C-faithful walk; see
 // descendantForByteRange for the boundary/out-of-range rule it mirrors.
 func (n *Node) descendantForPointRange(startPoint, endPoint Point, namedOnly bool) *Node {
-	if n == nil {
+	if n == nil || pointLessThan(endPoint, startPoint) {
 		return nil
 	}
 	node := n
@@ -1771,11 +1777,19 @@ func (n *Node) descendantForPointRange(startPoint, endPoint Point, namedOnly boo
 			if !ok {
 				continue
 			}
+			childStart := stackEntryNodeStartPoint(entry)
 			childEnd := stackEntryNodeEndPoint(entry)
-			if pointLessThan(childEnd, endPoint) || pointLessOrEqual(childEnd, startPoint) {
+			if pointLessThan(childEnd, endPoint) {
 				continue
 			}
-			if pointGreaterThan(stackEntryNodeStartPoint(entry), startPoint) {
+			if childStart == childEnd {
+				if pointLessThan(childEnd, startPoint) {
+					continue
+				}
+			} else if pointLessOrEqual(childEnd, startPoint) {
+				continue
+			}
+			if pointGreaterThan(childStart, startPoint) {
 				break
 			}
 			child := nodeChildAtForReason(node, i, materializeForParentAPI)
@@ -1796,8 +1810,9 @@ func (n *Node) descendantForPointRange(startPoint, endPoint Point, namedOnly boo
 	return lastRelevant
 }
 
-// DescendantForByteRange returns the smallest descendant that fully contains
-// the given byte range, or nil when no such descendant exists.
+// DescendantForByteRange returns the smallest descendant selected by upstream
+// tree-sitter's byte-range walk. For a valid unsatisfiable or out-of-bounds
+// range it returns the receiver; a nil receiver or reversed range returns nil.
 func (n *Node) DescendantForByteRange(startByte, endByte uint32) *Node {
 	return n.descendantForByteRange(startByte, endByte, false)
 }
@@ -1816,8 +1831,10 @@ func (n *Node) NodeAtByte(byteOffset uint32) *Node {
 	return n.descendantForByteRangeContained(byteOffset, endByte, false)
 }
 
-// NamedDescendantForByteRange returns the smallest named descendant that fully
-// contains the given byte range, or nil when no such descendant exists.
+// NamedDescendantForByteRange returns the smallest named descendant selected
+// by upstream tree-sitter's byte-range walk. For a valid unsatisfiable or
+// out-of-bounds range it returns the receiver; a nil receiver or reversed
+// range returns nil.
 func (n *Node) NamedDescendantForByteRange(startByte, endByte uint32) *Node {
 	return n.descendantForByteRange(startByte, endByte, true)
 }
@@ -1835,14 +1852,17 @@ func (n *Node) NamedNodeAtByte(byteOffset uint32) *Node {
 	return n.descendantForByteRangeContained(byteOffset, endByte, true)
 }
 
-// DescendantForPointRange returns the smallest descendant that fully contains
-// the given point range, or nil when no such descendant exists.
+// DescendantForPointRange returns the smallest descendant selected by upstream
+// tree-sitter's point-range walk. For a valid unsatisfiable or out-of-bounds
+// range it returns the receiver; a nil receiver or reversed range returns nil.
 func (n *Node) DescendantForPointRange(startPoint, endPoint Point) *Node {
 	return n.descendantForPointRange(startPoint, endPoint, false)
 }
 
-// NamedDescendantForPointRange returns the smallest named descendant that
-// fully contains the given point range, or nil when no such descendant exists.
+// NamedDescendantForPointRange returns the smallest named descendant selected
+// by upstream tree-sitter's point-range walk. For a valid unsatisfiable or
+// out-of-bounds range it returns the receiver; a nil receiver or reversed
+// range returns nil.
 func (n *Node) NamedDescendantForPointRange(startPoint, endPoint Point) *Node {
 	return n.descendantForPointRange(startPoint, endPoint, true)
 }

--- a/utf16_test.go
+++ b/utf16_test.go
@@ -667,8 +667,12 @@ func TestDescendantForUTF16Range(t *testing.T) {
 		t.Fatalf("ParseUTF16 failed: %v", err)
 	}
 
-	if got := tree.RootNode().DescendantForByteRange(0, uint32(len(source))*2); got != nil {
-		t.Fatalf("DescendantForByteRange with UTF16 byte offsets = %s, want nil", got.Type(lang))
+	// UTF-16 code-unit offsets misused as byte offsets over-run the byte span.
+	// The byte API mirrors C tree-sitter, which returns the node itself for an
+	// unsatisfiable range (never nil) — so this yields the whole root, not a
+	// precise descendant. Use DescendantForUTF16Range for UTF-16 coordinates.
+	if got := tree.RootNode().DescendantForByteRange(0, uint32(len(source))*2); got != tree.RootNode() {
+		t.Fatalf("out-of-range byte range = %v, want the root node (C semantics)", got)
 	}
 
 	root := tree.DescendantForUTF16Range(0, uint32(len(source)))


### PR DESCRIPTION
## Summary

Aligns three query/tree surfaces with the locked upstream C runtime: strict `MISSING` patterns, host-visible inert property predicates, and descendant byte/point range selection. The final branch is intentionally limited to behavior authenticated by focused Go tests and locked-C differentials.

## Changes

- Match scalar and alternation `MISSING` patterns only against missing nodes, including anonymous token-qualified and named-symbol-qualified forms.
- Preserve MISSING identity through alternation compilation and keep those alternations on the exact matcher instead of the symbol-only index.
- Expose inert `#is?` and `#is-not?` predicates through documented public metadata accessors without filtering matches.
- Match upstream descendant range behavior for reversed ranges, out-of-bounds ranges, token/line boundaries, and zero-width missing children.
- Retain contained nil-on-miss walks for incremental and byte-offset helpers whose existing semantics must not change.
- Record the user-visible fixes under CHANGELOG Unreleased.

## Validation

- Full root package tests
- Focused MISSING/property/descendant tests
- `go vet .`
- Four-fixture real-Go arena board: byte-for-byte neutral versus main
- Locked-C MISSING scalar/alternation differential: `harness_out/docker/20260717T062751Z`
- Locked-C descendant byte-range differential: `harness_out/docker/20260717T061625Z`
- Fresh hosted CI on the repaired head
