### PR TITLE
docs: refresh parser benchmark receipts and corpus guidance

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -160,8 +160,9 @@ timing. Medians from ten process-isolated samples per backend and fixture:
 
 The canonical equal-fixture geomean is **5.481673x C**. The fixed-suite sum of
 medians is **6.313799x C**; it is reported separately because the largest file
-dominates aggregate wall time. This is the baseline for future full-parse
-claims, not a retrospective adjustment to the withdrawn straight-LR ratio.
+dominates aggregate wall time. This is the first locked-oracle historical
+baseline, not a retrospective adjustment to the withdrawn straight-LR ratio;
+the current production receipt is the current-main result below.
 
 Receipt identities:
 
@@ -173,6 +174,41 @@ Receipt identities:
   `aecb7f76e3df4832877f4526280849257826f3d84f2f104379a57748f4f6f310`;
 - static C artifact SHA-256:
   `dfbed45811491be8d81e32b293ed5577222445dae47b67d876cedae09679a871`.
+
+### Current-main production receipt
+
+An authenticated production receipt was collected on 2026-07-17 from the same
+quiet host, core 6, and Go 1.22.2. The worktree was clean current main at
+`2c7026563f3827da87e637bcb246d4a8f287c022`; its `PUBLICATION` receipt measures
+the public `Parser.Parse` lifecycle, completeness check, and `Tree.Release`.
+
+| Fixture | Go median | static C median | Go / C | B/op | allocs/op | Go max RSS | C max RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `query_compile.go` | 29.313 ms | 5.591 ms | **5.242927x** | 157,657 | 13 | 68,528 KiB | 2,816 KiB |
+| `rewrite.go` | 5.110 ms | 1.260 ms | **4.055251x** | 2,040 | 14 | 54,052 KiB | 2,304 KiB |
+| `language.go` | 28.383 ms | 5.980 ms | **4.746044x** | 163,060 | 32 | 67,620 KiB | 2,816 KiB |
+| `grammargen/lr.go` | 345.658 ms | 61.198 ms | **5.648204x** | 13,165,973 | 561.5 | 205,716 KiB | 9,216 KiB |
+
+The current-main public-parser equal-fixture geomean is **4.886056x C**. Its
+fixed-suite sum of medians is **5.517602x C** (408.464 ms Go versus 74.029 ms
+static C), and its worst fixture is `grammargen/lr.go` at **5.648204x C**.
+
+Receipt identities:
+
+- manifest SHA-256:
+  `8933650e446b14db263e165bbfed0bd68cebeb15898b7b818c57040e10b31b46`;
+- report SHA-256:
+  `19a68af15fe1f413e628d3f5a7aed0b7fb975652028aee685d5b30769151d2f3`;
+- complete receipt bundle SHA-256:
+  `3c529e002cee1ab28e7ec11edc826d3b31b298dec616e14aa0fd405e11c84a09`;
+- static C artifact SHA-256:
+  `dfbed45811491be8d81e32b293ed5577222445dae47b67d876cedae09679a871`.
+
+For incremental parsing, the versioned, hash-locked admission matrix documented
+in [`cgo_harness/README.md`](cgo_harness/README.md#run-locked-canonical-incremental-benchmarks)
+validates exact correctness and classifies identity, leaf validation, real-code
+GLR, recovery, and scanner-state work. It publishes no general comparative
+incremental speed headline.
 
 ### Diagnostic workload-regime receipt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ for tags and release notes while still in `0.x`.
 
 ### Tooling
 
+- Bank an authenticated quiet-host production receipt against the locked
+  static `-O2` C oracle. At current main `2c702656`, public `Parser.Parse`
+  measures 4.886056x C by equal-fixture geomean and 5.517602x C by fixed-suite
+  sum of medians, with a 5.648204x worst fixture.
 - Add a bounded, build-tagged parser trace that separates lookup cells from
   execution-time cell reconstruction and retains whole-parse aggregates after
   its chronological event prefix fills. Scanner checkpoints bind their cached

--- a/README.md
+++ b/README.md
@@ -386,6 +386,11 @@ than the withdrawn 1.895x straight-LR comparison, established the full-parse
 baseline; [BENCH.md](BENCH.md) records every per-fixture median, RSS value, and
 receipt hash.
 
+A strict current-main rerun at `2c702656` now measures public `Parser.Parse` at
+**4.886056x C** by equal-fixture geomean and **5.517602x C** by fixed-suite sum
+of medians, with a **5.648204x** worst fixture. See [BENCH.md](BENCH.md) for the
+per-fixture table, exact identities, and receipt hashes.
+
 The historical incremental measurements on the same generated 500-function Go
 workload were `649 ns` for a one-byte edit and `2.43 ns` for a no-edit reparse.
 They remain workload-specific; use the real-corpus perf scoreboard for
@@ -469,7 +474,7 @@ Each `LangEntry` carries a `Quality` field:
 | `#lua-match?` | supported |
 | `#has-ancestor?` / `#not-has-ancestor?` | supported |
 | `#has-parent?` / `#not-has-parent?` | supported |
-| `#is?` / `#is-not?` | supported |
+| `#is?` / `#is-not?` | parsed; inert property metadata is exposed, not evaluated as a filter |
 | `#any-eq?` / `#any-not-eq?` | supported |
 | `#any-match?` / `#any-not-match?` | supported |
 | `#select-adjacent!` | supported |
@@ -489,7 +494,7 @@ witness, and shrinks as certified engine mechanisms subsume shims. See
 
 ## Known limitations
 
-- **Full-parse throughput**: the first strict materialized real-Go publication receipt, shipped with v0.37.0, measured **5.481673x C** by equal-fixture geomean and **6.313799x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)). v0.38.0 does not claim a replacement suite-wide ratio. The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it is historical only. Incremental lanes remain dramatically faster than the cgo binding on their workload-specific controls. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files are the main performance frontier.
+- **Full-parse throughput**: the strict current-main materialized real-Go publication receipt measures public `Parser.Parse` at **4.886056x C** by equal-fixture geomean and **5.517602x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)). The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it is historical only. The locked incremental matrix validates correctness and classifies work, but general incremental Go/C performance has no current publication-grade headline. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files are the main performance frontier.
 - **GLR safety caps**: The parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity but impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
 
 ## Adding a language
@@ -703,8 +708,9 @@ fleet, work-count, and forest-confirmation tooling also closes measurement
 gaps. The invalid historical 1.895x headline remains withdrawn. The first
 strict materialized real-Go publication receipt, shipped with v0.37.0, measured
 5.481673x C by equal-fixture geomean and 6.313799x C for the fixed-suite sum of
-medians; v0.38.0 does not claim a replacement suite-wide ratio. Detailed
-history lives in [CHANGELOG.md](CHANGELOG.md).
+medians. A post-release current-main receipt now measures public `Parser.Parse`
+at 4.886056x C and 5.517602x C, respectively. Detailed history lives in
+[CHANGELOG.md](CHANGELOG.md).
 
 ### Now — performance and extreme hygiene
 

--- a/cgo_harness/README.md
+++ b/cgo_harness/README.md
@@ -478,6 +478,27 @@ pass `--unsafe-fortran-defaults`: `--memory 3g`, `--cpus 1`, `--pids 512`,
 `GOMAXPROCS=1`, `GOFLAGS=-p=1`, `GOT_LALR_LR0_CORE_BUDGET=160000000`, and
 `GTS_GRAMMARGEN_REAL_CORPUS_GENERATE_TIMEOUT=15m`.
 
+The underlying real-corpus test accepts a durable checkout root through
+`GTS_GRAMMARGEN_REAL_CORPUS_ROOT`; use
+`GTS_GRAMMARGEN_REAL_CORPUS_ONLY=<grammar>` to keep a direct run scoped to one
+grammar:
+
+```sh
+GTS_GRAMMARGEN_REAL_CORPUS_ENABLE=1 \
+GTS_GRAMMARGEN_REAL_CORPUS_ROOT=/path/to/grammar-checkouts \
+GTS_GRAMMARGEN_REAL_CORPUS_ONLY=markdown_inline \
+go test ./grammargen \
+  -run '^TestMultiGrammarImportRealCorpusParity$' -count=1 -v
+```
+
+For the Docker runners, pass `--seed-dir <path>` to either
+`run_grammargen_real_corpus_in_docker.sh` or
+`run_grammargen_focus_targets.sh`; the seed directory must be under the
+repository root and is copied into the container's configured corpus root.
+Split-grammar repositories such as Markdown and XML need no additional flag:
+the test probes the grammar package root above `src/grammar.json` for its corpus
+before falling back to the repository root.
+
 ## Run C Baseline Benchmarks
 
 ```sh


### PR DESCRIPTION
## Summary
- publish the authenticated current-main public-parser receipt against the locked static C oracle
- clarify the scope of incremental and query-property claims
- document configurable real-corpus roots and split-grammar layouts

## Validation
- `mdpp parse` passes for README.md, BENCH.md, CHANGELOG.md, and cgo_harness/README.md
- `mdpp lint` passes for README.md, BENCH.md, and cgo_harness/README.md
- CHANGELOG retains only its pre-existing diagnostics
- `git diff --check` passes
- v0.38.0 release text remains byte-identical