### PR TITLE
release: v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-07-17
+
+Correctness-and-evidence release. Query ranges, literals, missing-node patterns,
+property metadata, highlight inheritance, lazy tree finalization, DFA EOF
+seeking, grammar imports, and generated C metadata now match their locked
+contracts more closely. Locked incremental and work-count receipts authenticate
+the exercised behavior, while durable corpus roots, split-grammar layouts, and
+bounded floors make real-corpus checks reproducible. The authenticated
+production receipt at `2c702656` measures public `Parser.Parse` at 4.886056x C
+by equal-fixture geomean, 5.517602x C by fixed-suite sum, and 5.648204x C on the
+worst fixture against the locked static `-O2` C oracle.
+
 ### Fixed
 
 - Deferred result-compatibility finalization stays lazy while trees are owned by
@@ -2707,7 +2719,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.38.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.39.0...HEAD
+[0.39.0]: https://github.com/odvcencio/gotreesitter/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/odvcencio/gotreesitter/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/odvcencio/gotreesitter/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/odvcencio/gotreesitter/compare/v0.34.0...v0.36.0

--- a/README.md
+++ b/README.md
@@ -386,10 +386,11 @@ than the withdrawn 1.895x straight-LR comparison, established the full-parse
 baseline; [BENCH.md](BENCH.md) records every per-fixture median, RSS value, and
 receipt hash.
 
-A strict current-main rerun at `2c702656` now measures public `Parser.Parse` at
-**4.886056x C** by equal-fixture geomean and **5.517602x C** by fixed-suite sum
-of medians, with a **5.648204x** worst fixture. See [BENCH.md](BENCH.md) for the
-per-fixture table, exact identities, and receipt hashes.
+The v0.39.0 release records a strict production receipt collected at
+`2c702656`: public `Parser.Parse` measures **4.886056x C** by equal-fixture
+geomean and **5.517602x C** by fixed-suite sum of medians, with a **5.648204x**
+worst fixture. See [BENCH.md](BENCH.md) for the per-fixture table, exact
+identities, and receipt hashes.
 
 The historical incremental measurements on the same generated 500-function Go
 workload were `649 ns` for a one-byte edit and `2.43 ns` for a no-edit reparse.
@@ -494,7 +495,7 @@ witness, and shrinks as certified engine mechanisms subsume shims. See
 
 ## Known limitations
 
-- **Full-parse throughput**: the strict current-main materialized real-Go publication receipt measures public `Parser.Parse` at **4.886056x C** by equal-fixture geomean and **5.517602x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)). The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it is historical only. The locked incremental matrix validates correctness and classifies work, but general incremental Go/C performance has no current publication-grade headline. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files are the main performance frontier.
+- **Full-parse throughput**: the strict materialized real-Go production receipt collected at `2c702656` measures public `Parser.Parse` at **4.886056x C** by equal-fixture geomean and **5.517602x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)); its worst fixture is **5.648204x C**. The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it is historical only. The locked incremental matrix validates correctness and classifies work, but general incremental Go/C performance has no current publication-grade headline. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files are the main performance frontier.
 - **GLR safety caps**: The parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity but impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
 
 ## Adding a language
@@ -699,17 +700,16 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.38.0**. The 206-grammar curated parity milestone is
-banked. v0.38.0 strengthens incremental tree parity across GLR reuse, scoring,
-culling, and retry selection; reports terminal materialization stops and edit
-ranges accurately; and banks evidence-gated full-parse savings from early
-cumulative-score rejection and exact-profile Odin arena sizing. Its static-C
-fleet, work-count, and forest-confirmation tooling also closes measurement
-gaps. The invalid historical 1.895x headline remains withdrawn. The first
-strict materialized real-Go publication receipt, shipped with v0.37.0, measured
-5.481673x C by equal-fixture geomean and 6.313799x C for the fixed-suite sum of
-medians. A post-release current-main receipt now measures public `Parser.Parse`
-at 4.886056x C and 5.517602x C, respectively. Detailed history lives in
+The current release is **v0.39.0**. The 206-grammar curated parity milestone is
+banked. v0.39.0 tightens query, tree, DFA, grammar-import, generated-C, and
+highlight correctness; adds locked incremental and work-count evidence; and
+makes real-corpus roots, split-grammar layouts, and sample floors more
+reproducible. Its authenticated production receipt, collected at `2c702656`,
+measures public `Parser.Parse` at 4.886056x C by equal-fixture geomean, 5.517602x
+C by fixed-suite sum, and 5.648204x C on the worst fixture against the locked
+static `-O2` C oracle. The invalid historical 1.895x headline remains withdrawn,
+and the incremental matrix is a correctness/work-classification receipt rather
+than a representative comparative speed headline. Detailed history lives in
 [CHANGELOG.md](CHANGELOG.md).
 
 ### Now — performance and extreme hygiene


### PR DESCRIPTION
## Summary
- roll the reviewed post-v0.38 changes into v0.39.0
- update the public release snapshot and authenticated production receipt
- preserve all prior release sections byte-for-byte

## Validation
- independent aggregate review: GO
- all nine post-v0.38 merges represented exactly once
- `mdpp parse` passes for README.md and CHANGELOG.md
- README lint is clean; CHANGELOG has only its pre-existing diagnostics
- compare links and release-section hashes verified
- `git diff --check` passes

The tag and GitHub release will target the reviewed merge commit only after this PR is green.