### PR TITLE
perf(parsercore): fuse scheduler transaction checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ for tags and release notes while still in `0.x`.
   4.061655x worst fixture and zero fallback in every timed sample. These
   candidate numbers apply only to its authenticated clean fresh-full surface;
   they do not replace the public parser claim.
+- Fuse nested transaction checkpoints across the build-tagged compact
+  scheduler while preserving standalone rollback and capability semantics.
+  The authenticated four-fixture Total geomean improves by 8.25%, every
+  fixture improves by 7.21-8.96%, and allocation counts remain unchanged.
 - Add a versioned, locked incremental admission matrix that separates identity,
   leaf-validation, real-code GLR, recovery, and stateful-scanner behavior using
   runtime evidence. It rejects full-parse fallback, authenticates both edit

--- a/internal/parsercorephase0/checkpoint_interner_test.go
+++ b/internal/parsercorephase0/checkpoint_interner_test.go
@@ -68,7 +68,7 @@ func TestEmptyCheckpointReceiptIsConstantAndAllocationFree(t *testing.T) {
 
 func BenchmarkCheckpointReceiptEmpty(b *testing.B) {
 	interner := newCheckpointInterner(1, 1)
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		_, _, _ = interner.receipt(0)
 	}
 }

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -464,6 +464,7 @@ type Core struct {
 	work                Work
 	popScratch          popEnumerationScratch
 	reductionScratch    reductionOutputScratch
+	schedulerFrame      schedulerTransactionFrame
 }
 
 // inlineAdjacencyCapacity covers the production default without forcing a
@@ -485,12 +486,40 @@ type checkpoint struct {
 	work                                              Work
 }
 
-func (c *Core) mark() checkpoint {
+// SchedulerTransactionToken is an opaque capability for one active
+// scheduler-owned transaction. Callers may pass it only to the authenticated
+// Owned methods below; core identity, epoch, transaction identity, and
+// top-of-stack ownership are validated on every use.
+type SchedulerTransactionToken struct {
+	owner       *Core
+	epoch       uint64
+	transaction uint64
+}
+
+type schedulerTransactionFrame struct {
+	mark     checkpoint
+	epoch    uint64
+	poisoned error
+	active   bool
+}
+
+// clearInactive releases every completed checkpoint reference, including the
+// boundary-index snapshot backing array, while preserving the monotonic epoch
+// that prevents Reset from making an escaped token current again.
+func (f *schedulerTransactionFrame) clearInactive() {
+	epoch := f.epoch
+	*f = schedulerTransactionFrame{epoch: epoch}
+}
+
+func (c *Core) markInto(mark *checkpoint) {
+	if mark == nil {
+		panic("parser-core phase zero: nil transaction checkpoint")
+	}
 	if c.nextTransaction == math.MaxUint64 {
 		panic("parser-core phase zero: transaction identity overflow")
 	}
 	c.nextTransaction++
-	mark := checkpoint{
+	*mark = checkpoint{
 		nodes: len(c.nodes), links: len(c.links), subtrees: len(c.subtrees),
 		children: len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 		frontier: c.frontier, checkpoint: c.checkpoint,
@@ -499,11 +528,16 @@ func (c *Core) mark() checkpoint {
 		work: c.work,
 	}
 	c.transactions = append(c.transactions, mark.transaction)
+}
+
+func (c *Core) mark() checkpoint {
+	var mark checkpoint
+	c.markInto(&mark)
 	return mark
 }
 
-func (c *Core) restore(mark checkpoint) {
-	c.assertTopTransaction(mark)
+func (c *Core) restoreCheckpoint(mark *checkpoint) {
+	c.assertTopTransactionCheckpoint(mark)
 	// A classification may have escaped from any nested operation that
 	// published arena records after this mark. Rollback makes those NodeIDs
 	// reusable, so invalidate every outstanding capability before truncating
@@ -531,13 +565,21 @@ func (c *Core) restore(mark checkpoint) {
 	c.finishTransaction()
 }
 
+func (c *Core) restore(mark checkpoint) {
+	c.restoreCheckpoint(&mark)
+}
+
 func (c *Core) commit(mark checkpoint) {
-	c.assertTopTransaction(mark)
+	c.assertTopTransactionCheckpoint(&mark)
 	c.finishTransaction()
 }
 
 func (c *Core) assertTopTransaction(mark checkpoint) {
-	if len(c.transactions) == 0 || c.transactions[len(c.transactions)-1] != mark.transaction {
+	c.assertTopTransactionCheckpoint(&mark)
+}
+
+func (c *Core) assertTopTransactionCheckpoint(mark *checkpoint) {
+	if mark == nil || len(c.transactions) == 0 || c.transactions[len(c.transactions)-1] != mark.transaction {
 		panic("parser-core phase zero: transaction checkpoint used out of LIFO order")
 	}
 }
@@ -560,6 +602,113 @@ func (c *Core) completeTransaction(mark checkpoint, err *error) {
 	} else {
 		c.commit(mark)
 	}
+}
+
+func (c *Core) validateSchedulerTransaction(token SchedulerTransactionToken) error {
+	frame := &c.schedulerFrame
+	if token.owner != c {
+		return errors.New("parser-core phase zero: scheduler transaction token belongs to a different core")
+	}
+	if !frame.active || token.epoch == 0 || token.epoch != frame.epoch || token.transaction != frame.mark.transaction {
+		return errors.New("parser-core phase zero: stale scheduler transaction token")
+	}
+	if len(c.transactions) == 0 || c.transactions[len(c.transactions)-1] != token.transaction {
+		return errors.New("parser-core phase zero: scheduler transaction token is not top-of-stack owner")
+	}
+	return nil
+}
+
+func (c *Core) poisonSchedulerTransaction(token SchedulerTransactionToken, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	if err := c.validateSchedulerTransaction(token); err != nil {
+		if owner := token.owner; owner != nil && owner.schedulerFrame.active &&
+			owner.schedulerFrame.epoch == token.epoch && owner.schedulerFrame.mark.transaction == token.transaction &&
+			owner.schedulerFrame.poisoned == nil {
+			owner.schedulerFrame.poisoned = err
+		}
+		if c.schedulerFrame.active && c.schedulerFrame.poisoned == nil {
+			c.schedulerFrame.poisoned = err
+		}
+		return err
+	}
+	if c.schedulerFrame.poisoned == nil {
+		c.schedulerFrame.poisoned = cause
+	}
+	return cause
+}
+
+// RunSchedulerOwned validates token ownership, executes one uncheckpointed
+// inner scheduler mutation, and poisons the outer owner on every returned
+// error. Ignoring the returned error therefore cannot commit partial state.
+func (c *Core) RunSchedulerOwned(token SchedulerTransactionToken, fn func() error) (err error) {
+	if fn == nil {
+		return c.poisonSchedulerTransaction(token, errors.New("parser-core phase zero: nil scheduler-owned operation"))
+	}
+	if err := c.validateSchedulerTransaction(token); err != nil {
+		return c.poisonSchedulerTransaction(token, err)
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.poisonSchedulerTransaction(token, fmt.Errorf("parser-core phase zero: scheduler-owned operation panicked: %v", recovered))
+			panic(recovered)
+		}
+	}()
+	if err = fn(); err != nil {
+		return c.poisonSchedulerTransaction(token, err)
+	}
+	return nil
+}
+
+// ApplySchedulerAtomic owns one retained checkpoint for an authenticated
+// scheduler operation. Standalone public wrappers continue to own their
+// ordinary checkpoints; only methods explicitly passed the returned opaque
+// token may execute without another frame.
+func (c *Core) ApplySchedulerAtomic(fn func(SchedulerTransactionToken) error) (err error) {
+	if fn == nil {
+		err := errors.New("parser-core phase zero: nil scheduler atomic operation")
+		if c.schedulerFrame.active && c.schedulerFrame.poisoned == nil {
+			c.schedulerFrame.poisoned = err
+		}
+		return err
+	}
+	frame := &c.schedulerFrame
+	if frame.active {
+		err := errors.New("parser-core phase zero: nested scheduler-owned transaction")
+		if frame.poisoned == nil {
+			frame.poisoned = err
+		}
+		return err
+	}
+	if frame.epoch == math.MaxUint64 {
+		return errors.New("parser-core phase zero: scheduler transaction epoch overflow")
+	}
+	frame.clearInactive()
+	frame.epoch++
+	c.markInto(&frame.mark)
+	frame.active = true
+	token := SchedulerTransactionToken{owner: c, epoch: frame.epoch, transaction: frame.mark.transaction}
+	defer func() {
+		recovered := recover()
+		if recovered != nil {
+			c.restoreCheckpoint(&frame.mark)
+			frame.clearInactive()
+			panic(recovered)
+		}
+		if err == nil && frame.poisoned != nil {
+			err = fmt.Errorf("parser-core phase zero: poisoned scheduler transaction: %w", frame.poisoned)
+		}
+		if err != nil {
+			c.restoreCheckpoint(&frame.mark)
+		} else {
+			c.assertTopTransactionCheckpoint(&frame.mark)
+			c.finishTransaction()
+		}
+		frame.clearInactive()
+	}()
+	err = fn(token)
+	return err
 }
 
 func (c *Core) writeBoundary(key boundaryKey, id NodeID) error {
@@ -604,7 +753,7 @@ func (c *Core) Reset() error {
 	if c == nil {
 		return errors.New("parser-core phase zero: reset nil core")
 	}
-	if len(c.transactions) != 0 {
+	if len(c.transactions) != 0 || c.schedulerFrame.active {
 		return errors.New("parser-core phase zero: reset during active transaction")
 	}
 	if c.classificationPhase == math.MaxUint64 {
@@ -625,6 +774,7 @@ func (c *Core) Reset() error {
 	c.boundaryJournal = c.boundaryJournal[:0]
 	c.transactions = c.transactions[:0]
 	c.nextTransaction = 0
+	c.schedulerFrame.clearInactive()
 	c.work = Work{}
 	c.popScratch.resetLogical()
 	c.reductionScratch.finish()
@@ -833,40 +983,7 @@ func (c *Core) Shift(head Head, lookahead Symbol, actionOrdinal int, token Token
 func (c *Core) ShiftClassified(boundary ClassifiedBoundary, actionOrdinal int, token Token, fork ForkOrder) (out Head, err error) {
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
-	act, err := c.classifiedAction(boundary, actionOrdinal)
-	if err != nil {
-		return Head{}, err
-	}
-	if act.Type != ActionShift {
-		return Head{}, fmt.Errorf("parser-core phase zero: action %d is %v, not shift", actionOrdinal, act.Type)
-	}
-	if token.Symbol != boundary.lookahead {
-		return Head{}, fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", token.Symbol, boundary.lookahead)
-	}
-	if token.Extra != act.Extra {
-		return Head{}, fmt.Errorf("parser-core phase zero: token extra=%t disagrees with decoded action extra=%t", token.Extra, act.Extra)
-	}
-	targetState := act.State
-	if act.Extra && targetState == 0 {
-		// Match production extraShiftTargetState: an extra shift with target
-		// zero leaves the LR state unchanged.
-		targetState = boundary.state
-	}
-	payload, err := c.appendSubtree(subtreeRecord{
-		symbol: token.Symbol, startByte: token.StartByte, endByte: token.EndByte,
-		extra: act.Extra, external: token.External, terminal: true,
-	}, nil, nil, nil)
-	if err != nil {
-		return Head{}, err
-	}
-	out, err = c.condense(c.shiftedBoundaryKey(targetState, token.EndByte), linkInput{
-		prev: boundary.head.Node, payload: payload, order: fork,
-	})
-	if err != nil {
-		return Head{}, err
-	}
-	c.addWork(&c.work.Shifts, 1)
-	return out, nil
+	return c.shiftClassifiedUncheckpointed(boundary, actionOrdinal, token, fork)
 }
 
 // ShiftOrdinaryCohort applies one ordinary terminal election to distinct
@@ -897,50 +1014,20 @@ func (c *Core) ShiftOrdinaryCohort(inputs []OrdinaryCohortShiftInput, lookahead 
 // ShiftOrdinaryClassifiedCohort is the classified scheduler form of
 // ShiftOrdinaryCohort. Every boundary must select one ordinary shift.
 func (c *Core) ShiftOrdinaryClassifiedCohort(boundaries []ClassifiedBoundary, token Token) (out []Head, err error) {
-	if len(boundaries) == 0 {
-		return nil, errors.New("parser-core phase zero: empty ordinary classified shift cohort")
+	var inlineTargets [inlineSchedulerCohortTargets]StateID
+	targets := inlineTargets[:]
+	if len(boundaries) > len(targets) {
+		targets = make([]StateID, len(boundaries))
+	} else {
+		targets = targets[:len(boundaries)]
 	}
-	if token.Extra || token.EndByte <= token.StartByte {
-		return nil, errors.New("parser-core phase zero: cohort token is not an ordinary positive-width terminal")
-	}
-	targets := make([]StateID, len(boundaries))
-	seen := make(map[NodeID]struct{}, len(boundaries))
-	for index, boundary := range boundaries {
-		if token.Symbol != boundary.lookahead {
-			return nil, fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", token.Symbol, boundary.lookahead)
-		}
-		if _, duplicate := seen[boundary.head.Node]; duplicate {
-			return nil, fmt.Errorf("parser-core phase zero: duplicate ordinary cohort head %d", boundary.head.Node)
-		}
-		seen[boundary.head.Node] = struct{}{}
-		action, err := c.classifiedAction(boundary, 0)
-		if err != nil {
-			return nil, err
-		}
-		if boundary.actions.Len() != 1 || action.State == 0 || action != (Action{Type: ActionShift, State: action.State}) {
-			return nil, fmt.Errorf("parser-core phase zero: head %d does not select one ordinary shift", boundary.head.Node)
-		}
-		targets[index] = action.State
+	if err := c.prepareOrdinaryClassifiedCohortInto(boundaries, token, targets); err != nil {
+		return nil, err
 	}
 	err = c.ApplyAtomic(func() error {
-		payload, err := c.appendSubtree(subtreeRecord{
-			symbol: token.Symbol, startByte: token.StartByte, endByte: token.EndByte,
-			external: token.External, terminal: true,
-		}, nil, nil, nil)
-		if err != nil {
-			return err
-		}
-		out = make([]Head, len(boundaries))
-		for index, boundary := range boundaries {
-			out[index], err = c.condense(c.shiftedBoundaryKey(targets[index], token.EndByte), linkInput{
-				prev: boundary.head.Node, payload: payload,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		c.addWork(&c.work.Shifts, uint64(len(boundaries)))
-		return nil
+		var innerErr error
+		out, innerErr = c.shiftOrdinaryClassifiedCohortUncheckpointed(boundaries, targets, token)
+		return innerErr
 	})
 	return out, err
 }
@@ -971,53 +1058,20 @@ func (c *Core) ShiftExtraCohort(inputs []ExtraCohortShiftInput, lookahead Symbol
 // ShiftExtraClassifiedCohort is the classified scheduler form of
 // ShiftExtraCohort. Every boundary must select one extra shift.
 func (c *Core) ShiftExtraClassifiedCohort(boundaries []ClassifiedBoundary, token Token) (out []Head, err error) {
-	if len(boundaries) == 0 {
-		return nil, errors.New("parser-core phase zero: empty extra classified shift cohort")
+	var inlineTargets [inlineSchedulerCohortTargets]StateID
+	targets := inlineTargets[:]
+	if len(boundaries) > len(targets) {
+		targets = make([]StateID, len(boundaries))
+	} else {
+		targets = targets[:len(boundaries)]
 	}
-	if !token.Extra || token.EndByte <= token.StartByte {
-		return nil, errors.New("parser-core phase zero: cohort token is not a positive-width extra terminal")
-	}
-	targets := make([]StateID, len(boundaries))
-	seen := make(map[NodeID]struct{}, len(boundaries))
-	for index, boundary := range boundaries {
-		if token.Symbol != boundary.lookahead {
-			return nil, fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", token.Symbol, boundary.lookahead)
-		}
-		if _, duplicate := seen[boundary.head.Node]; duplicate {
-			return nil, fmt.Errorf("parser-core phase zero: duplicate extra cohort head %d", boundary.head.Node)
-		}
-		seen[boundary.head.Node] = struct{}{}
-		action, err := c.classifiedAction(boundary, 0)
-		if err != nil {
-			return nil, err
-		}
-		if boundary.actions.Len() != 1 || action != (Action{Type: ActionShift, State: action.State, Extra: true}) {
-			return nil, fmt.Errorf("parser-core phase zero: head %d does not select one extra shift", boundary.head.Node)
-		}
-		targets[index] = action.State
-		if targets[index] == 0 {
-			targets[index] = boundary.state
-		}
+	if err := c.prepareExtraClassifiedCohortInto(boundaries, token, targets); err != nil {
+		return nil, err
 	}
 	err = c.ApplyAtomic(func() error {
-		payload, err := c.appendSubtree(subtreeRecord{
-			symbol: token.Symbol, startByte: token.StartByte, endByte: token.EndByte,
-			extra: true, external: token.External, terminal: true,
-		}, nil, nil, nil)
-		if err != nil {
-			return err
-		}
-		out = make([]Head, len(boundaries))
-		for index, boundary := range boundaries {
-			out[index], err = c.condense(c.shiftedBoundaryKey(targets[index], token.EndByte), linkInput{
-				prev: boundary.head.Node, payload: payload,
-			})
-			if err != nil {
-				return err
-			}
-		}
-		c.addWork(&c.work.Shifts, uint64(len(boundaries)))
-		return nil
+		var innerErr error
+		out, innerErr = c.shiftExtraClassifiedCohortUncheckpointed(boundaries, targets, token)
+		return innerErr
 	})
 	return out, err
 }
@@ -1187,114 +1241,9 @@ func (c *Core) ReduceOutputsInto(dst []ReductionOutput, head Head, lookahead Sym
 // ReduceOutputsClassifiedInto applies one reduction using a current
 // owner-authenticated classification and caller-owned destination storage.
 func (c *Core) ReduceOutputsClassifiedInto(dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
-	frontier = dst[:0]
 	mark := c.mark()
 	defer c.completeTransaction(mark, &err)
-	if c.popScratch.busy {
-		return nil, errors.New("parser-core phase zero: reentrant reduction while pop scratch is active")
-	}
-	c.popScratch.busy = true
-	defer c.popScratch.resetLogical()
-	c.reductionScratch.begin()
-	defer c.reductionScratch.finish()
-	act, err := c.classifiedAction(boundary, actionOrdinal)
-	if err != nil {
-		return nil, err
-	}
-	if act.Type != ActionReduce {
-		return nil, fmt.Errorf("parser-core phase zero: action %d is %v, not reduce", actionOrdinal, act.Type)
-	}
-	plan, err := c.reductionPlan(act)
-	if err != nil {
-		return nil, err
-	}
-	paths, err := c.popPaths(boundary.head.Node, int(act.ChildCount))
-	if err != nil {
-		return nil, err
-	}
-	if len(paths) == 0 {
-		return nil, errors.New("parser-core phase zero: reduction has no exact pop path")
-	}
-	c.addWork(&c.work.Reductions, 1)
-	c.addWork(&c.work.ReductionPopRequests, 1)
-	c.addWork(&c.work.EmittedPopPaths, uint64(len(paths)))
-	for _, path := range paths {
-		c.addWork(&c.work.EmittedPopPayloads, uint64(len(path.children)+len(path.trailing)))
-	}
-	scratch := &c.reductionScratch
-	for _, path := range paths {
-		prev, err := c.node(path.prev)
-		if err != nil {
-			return nil, err
-		}
-		gotoState, err := c.tables.Goto(prev.state, act.Symbol)
-		if err != nil {
-			return nil, err
-		}
-		if gotoState == 0 {
-			return nil, fmt.Errorf("parser-core phase zero: no goto from state %d for reduced symbol %d", prev.state, act.Symbol)
-		}
-		key := c.boundaryKey(gotoState, path.structuralEnd)
-		payload, scoreDelta, order, err := c.reductionParentForPath(act, &plan, path, key, fork, scratch)
-		if err != nil {
-			return nil, err
-		}
-		parentLink := linkInput{
-			prev: path.prev, payload: payload,
-			scoreDelta: scoreDelta, order: order,
-		}
-		var out Head
-		var outcome condenseOutcome
-		if len(path.trailing) == 0 {
-			outcome, err = c.condenseWithOutcome(key, parentLink)
-			out = outcome.head
-		} else {
-			out, err = c.appendPrivate(gotoState, path.structuralEnd, parentLink)
-		}
-		if err != nil {
-			return nil, err
-		}
-		for index, trailing := range path.trailing {
-			extra, err := c.subtree(trailing.payload)
-			if err != nil {
-				return nil, err
-			}
-			key = c.boundaryKey(gotoState, extra.endByte)
-			extraLink := linkInput{prev: out.Node, payload: trailing.payload, scoreDelta: trailing.scoreDelta}
-			if index == len(path.trailing)-1 {
-				outcome, err = c.condenseWithOutcome(key, extraLink)
-				out = outcome.head
-			} else {
-				out, err = c.appendPrivate(gotoState, extra.endByte, extraLink)
-			}
-			if err != nil {
-				return nil, err
-			}
-		}
-		boundaryIndex, seen := scratch.boundary(key)
-		var previous reductionBoundaryOutput
-		if seen {
-			previous = scratch.boundaries[boundaryIndex]
-		}
-		freshness := previous.freshness
-		switch outcome.change {
-		case condenseUnchanged:
-			if !seen {
-				freshness = ReductionUnchanged
-			}
-		case condenseNew:
-			freshness = ReductionNew
-		case condenseUpdated:
-			if freshness != ReductionNew {
-				freshness = ReductionUpdated
-			}
-		}
-		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{key: key, head: out, freshness: freshness})
-	}
-	for _, output := range scratch.boundaries {
-		frontier = append(frontier, ReductionOutput{Head: output.head, Freshness: output.freshness})
-	}
-	return frontier, nil
+	return c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
 }
 
 func (c *Core) reductionParentForPath(

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -1,0 +1,322 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+)
+
+const inlineSchedulerCohortTargets = 8
+
+// ShiftClassifiedOwned authenticates the scheduler owner, then delegates to
+// the same uncheckpointed implementation used by standalone ShiftClassified.
+func (c *Core) ShiftClassifiedOwned(owner SchedulerTransactionToken, boundary ClassifiedBoundary, actionOrdinal int, shifted Token, fork ForkOrder) (out Head, err error) {
+	err = c.RunSchedulerOwned(owner, func() error {
+		var innerErr error
+		out, innerErr = c.shiftClassifiedUncheckpointed(boundary, actionOrdinal, shifted, fork)
+		return innerErr
+	})
+	return out, err
+}
+
+func (c *Core) shiftClassifiedUncheckpointed(boundary ClassifiedBoundary, actionOrdinal int, shifted Token, fork ForkOrder) (Head, error) {
+	act, err := c.classifiedAction(boundary, actionOrdinal)
+	if err != nil {
+		return Head{}, err
+	}
+	if act.Type != ActionShift {
+		return Head{}, fmt.Errorf("parser-core phase zero: action %d is %v, not shift", actionOrdinal, act.Type)
+	}
+	if shifted.Symbol != boundary.lookahead {
+		return Head{}, fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", shifted.Symbol, boundary.lookahead)
+	}
+	if shifted.Extra != act.Extra {
+		return Head{}, fmt.Errorf("parser-core phase zero: token extra=%t disagrees with decoded action extra=%t", shifted.Extra, act.Extra)
+	}
+	targetState := act.State
+	if act.Extra && targetState == 0 {
+		targetState = boundary.state
+	}
+	payload, err := c.appendSubtree(subtreeRecord{
+		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
+		extra: act.Extra, external: shifted.External, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		return Head{}, err
+	}
+	outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targetState, shifted.EndByte), linkInput{
+		prev: boundary.head.Node, payload: payload, order: fork,
+	})
+	if err != nil {
+		return Head{}, err
+	}
+	c.addWork(&c.work.Shifts, 1)
+	return outcome.head, nil
+}
+
+// ShiftOrdinaryClassifiedCohortOwned authenticates the scheduler owner, then
+// delegates to the standalone cohort's uncheckpointed implementation.
+func (c *Core) ShiftOrdinaryClassifiedCohortOwned(owner SchedulerTransactionToken, boundaries []ClassifiedBoundary, shifted Token) (out []Head, err error) {
+	err = c.RunSchedulerOwned(owner, func() error {
+		var inlineTargets [inlineSchedulerCohortTargets]StateID
+		targets := inlineTargets[:]
+		if len(boundaries) > len(targets) {
+			targets = make([]StateID, len(boundaries))
+		} else {
+			targets = targets[:len(boundaries)]
+		}
+		if err := c.prepareOrdinaryClassifiedCohortInto(boundaries, shifted, targets); err != nil {
+			return err
+		}
+		var innerErr error
+		out, innerErr = c.shiftOrdinaryClassifiedCohortUncheckpointed(boundaries, targets, shifted)
+		return innerErr
+	})
+	return out, err
+}
+
+func (c *Core) prepareOrdinaryClassifiedCohortInto(boundaries []ClassifiedBoundary, shifted Token, targets []StateID) error {
+	if len(boundaries) == 0 {
+		return errors.New("parser-core phase zero: empty ordinary classified shift cohort")
+	}
+	if len(targets) != len(boundaries) {
+		return errors.New("parser-core phase zero: ordinary cohort target storage length mismatch")
+	}
+	if shifted.Extra || shifted.EndByte <= shifted.StartByte {
+		return errors.New("parser-core phase zero: cohort token is not an ordinary positive-width terminal")
+	}
+	seen := make(map[NodeID]struct{}, len(boundaries))
+	for index, boundary := range boundaries {
+		if shifted.Symbol != boundary.lookahead {
+			return fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", shifted.Symbol, boundary.lookahead)
+		}
+		if _, duplicate := seen[boundary.head.Node]; duplicate {
+			return fmt.Errorf("parser-core phase zero: duplicate ordinary cohort head %d", boundary.head.Node)
+		}
+		seen[boundary.head.Node] = struct{}{}
+		action, err := c.classifiedAction(boundary, 0)
+		if err != nil {
+			return err
+		}
+		if boundary.actions.Len() != 1 || action.State == 0 || action != (Action{Type: ActionShift, State: action.State}) {
+			return fmt.Errorf("parser-core phase zero: head %d does not select one ordinary shift", boundary.head.Node)
+		}
+		targets[index] = action.State
+	}
+	return nil
+}
+
+func (c *Core) shiftOrdinaryClassifiedCohortUncheckpointed(boundaries []ClassifiedBoundary, targets []StateID, shifted Token) ([]Head, error) {
+	payload, err := c.appendSubtree(subtreeRecord{
+		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
+		external: shifted.External, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Head, len(boundaries))
+	for index, boundary := range boundaries {
+		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targets[index], shifted.EndByte), linkInput{
+			prev: boundary.head.Node, payload: payload,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out[index] = outcome.head
+	}
+	c.addWork(&c.work.Shifts, uint64(len(boundaries)))
+	return out, nil
+}
+
+// ShiftExtraClassifiedCohortOwned authenticates the scheduler owner, then
+// delegates to the standalone cohort's uncheckpointed implementation.
+func (c *Core) ShiftExtraClassifiedCohortOwned(owner SchedulerTransactionToken, boundaries []ClassifiedBoundary, shifted Token) (out []Head, err error) {
+	err = c.RunSchedulerOwned(owner, func() error {
+		var inlineTargets [inlineSchedulerCohortTargets]StateID
+		targets := inlineTargets[:]
+		if len(boundaries) > len(targets) {
+			targets = make([]StateID, len(boundaries))
+		} else {
+			targets = targets[:len(boundaries)]
+		}
+		if err := c.prepareExtraClassifiedCohortInto(boundaries, shifted, targets); err != nil {
+			return err
+		}
+		var innerErr error
+		out, innerErr = c.shiftExtraClassifiedCohortUncheckpointed(boundaries, targets, shifted)
+		return innerErr
+	})
+	return out, err
+}
+
+func (c *Core) prepareExtraClassifiedCohortInto(boundaries []ClassifiedBoundary, shifted Token, targets []StateID) error {
+	if len(boundaries) == 0 {
+		return errors.New("parser-core phase zero: empty extra classified shift cohort")
+	}
+	if len(targets) != len(boundaries) {
+		return errors.New("parser-core phase zero: extra cohort target storage length mismatch")
+	}
+	if !shifted.Extra || shifted.EndByte <= shifted.StartByte {
+		return errors.New("parser-core phase zero: cohort token is not a positive-width extra terminal")
+	}
+	seen := make(map[NodeID]struct{}, len(boundaries))
+	for index, boundary := range boundaries {
+		if shifted.Symbol != boundary.lookahead {
+			return fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", shifted.Symbol, boundary.lookahead)
+		}
+		if _, duplicate := seen[boundary.head.Node]; duplicate {
+			return fmt.Errorf("parser-core phase zero: duplicate extra cohort head %d", boundary.head.Node)
+		}
+		seen[boundary.head.Node] = struct{}{}
+		action, err := c.classifiedAction(boundary, 0)
+		if err != nil {
+			return err
+		}
+		if boundary.actions.Len() != 1 || action != (Action{Type: ActionShift, State: action.State, Extra: true}) {
+			return fmt.Errorf("parser-core phase zero: head %d does not select one extra shift", boundary.head.Node)
+		}
+		targets[index] = action.State
+		if targets[index] == 0 {
+			targets[index] = boundary.state
+		}
+	}
+	return nil
+}
+
+func (c *Core) shiftExtraClassifiedCohortUncheckpointed(boundaries []ClassifiedBoundary, targets []StateID, shifted Token) ([]Head, error) {
+	payload, err := c.appendSubtree(subtreeRecord{
+		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
+		extra: true, external: shifted.External, terminal: true,
+	}, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Head, len(boundaries))
+	for index, boundary := range boundaries {
+		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targets[index], shifted.EndByte), linkInput{
+			prev: boundary.head.Node, payload: payload,
+		})
+		if err != nil {
+			return nil, err
+		}
+		out[index] = outcome.head
+	}
+	c.addWork(&c.work.Shifts, uint64(len(boundaries)))
+	return out, nil
+}
+
+// ReduceOutputsClassifiedIntoOwned authenticates the scheduler owner, then
+// delegates to the standalone reduction's uncheckpointed implementation.
+func (c *Core) ReduceOutputsClassifiedIntoOwned(owner SchedulerTransactionToken, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
+	err = c.RunSchedulerOwned(owner, func() error {
+		var innerErr error
+		frontier, innerErr = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+		return innerErr
+	})
+	return frontier, err
+}
+
+func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) ([]ReductionOutput, error) {
+	frontier := dst[:0]
+	if c.popScratch.busy {
+		return nil, errors.New("parser-core phase zero: reentrant reduction while pop scratch is active")
+	}
+	c.popScratch.busy = true
+	defer c.popScratch.resetLogical()
+	c.reductionScratch.begin()
+	defer c.reductionScratch.finish()
+	act, err := c.classifiedAction(boundary, actionOrdinal)
+	if err != nil {
+		return nil, err
+	}
+	if act.Type != ActionReduce {
+		return nil, fmt.Errorf("parser-core phase zero: action %d is %v, not reduce", actionOrdinal, act.Type)
+	}
+	plan, err := c.reductionPlan(act)
+	if err != nil {
+		return nil, err
+	}
+	paths, err := c.popPaths(boundary.head.Node, int(act.ChildCount))
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, errors.New("parser-core phase zero: reduction has no exact pop path")
+	}
+	c.addWork(&c.work.Reductions, 1)
+	c.addWork(&c.work.ReductionPopRequests, 1)
+	c.addWork(&c.work.EmittedPopPaths, uint64(len(paths)))
+	for _, path := range paths {
+		c.addWork(&c.work.EmittedPopPayloads, uint64(len(path.children)+len(path.trailing)))
+	}
+	scratch := &c.reductionScratch
+	for _, path := range paths {
+		prev, err := c.node(path.prev)
+		if err != nil {
+			return nil, err
+		}
+		gotoState, err := c.tables.Goto(prev.state, act.Symbol)
+		if err != nil {
+			return nil, err
+		}
+		if gotoState == 0 {
+			return nil, fmt.Errorf("parser-core phase zero: no goto from state %d for reduced symbol %d", prev.state, act.Symbol)
+		}
+		key := c.boundaryKey(gotoState, path.structuralEnd)
+		payload, scoreDelta, order, err := c.reductionParentForPath(act, &plan, path, key, fork, scratch)
+		if err != nil {
+			return nil, err
+		}
+		parentLink := linkInput{prev: path.prev, payload: payload, scoreDelta: scoreDelta, order: order}
+		var out Head
+		var outcome condenseOutcome
+		if len(path.trailing) == 0 {
+			outcome, err = c.condenseWithOutcomeAtomic(key, parentLink)
+			out = outcome.head
+		} else {
+			out, err = c.appendPrivate(gotoState, path.structuralEnd, parentLink)
+		}
+		if err != nil {
+			return nil, err
+		}
+		for index, trailing := range path.trailing {
+			extra, err := c.subtree(trailing.payload)
+			if err != nil {
+				return nil, err
+			}
+			key = c.boundaryKey(gotoState, extra.endByte)
+			extraLink := linkInput{prev: out.Node, payload: trailing.payload, scoreDelta: trailing.scoreDelta}
+			if index == len(path.trailing)-1 {
+				outcome, err = c.condenseWithOutcomeAtomic(key, extraLink)
+				out = outcome.head
+			} else {
+				out, err = c.appendPrivate(gotoState, extra.endByte, extraLink)
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+		boundaryIndex, seen := scratch.boundary(key)
+		var previous reductionBoundaryOutput
+		if seen {
+			previous = scratch.boundaries[boundaryIndex]
+		}
+		freshness := previous.freshness
+		switch outcome.change {
+		case condenseUnchanged:
+			if !seen {
+				freshness = ReductionUnchanged
+			}
+		case condenseNew:
+			freshness = ReductionNew
+		case condenseUpdated:
+			if freshness != ReductionNew {
+				freshness = ReductionUpdated
+			}
+		}
+		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{key: key, head: out, freshness: freshness})
+	}
+	for _, output := range scratch.boundaries {
+		frontier = append(frontier, ReductionOutput{Head: output.head, Freshness: output.freshness})
+	}
+	return frontier, nil
+}

--- a/internal/parsercorephase0/scheduler_transaction_test.go
+++ b/internal/parsercorephase0/scheduler_transaction_test.go
@@ -1,0 +1,446 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type schedulerTransactionState struct {
+	nodes, links, subtrees, children, fields, aliases int
+	boundaries                                        map[boundaryIdentity]NodeID
+	work                                              Work
+}
+
+func captureSchedulerTransactionState(c *Core) schedulerTransactionState {
+	return schedulerTransactionState{
+		nodes: len(c.nodes), links: len(c.links), subtrees: len(c.subtrees),
+		children: len(c.children), fields: len(c.fields), aliases: len(c.aliases),
+		boundaries: cloneBoundaryMap(c.boundaries), work: c.Work(),
+	}
+}
+
+func requireClearedSchedulerFrame(t *testing.T, c *Core, epoch uint64) {
+	t.Helper()
+	if c.schedulerFrame.active || c.schedulerFrame.poisoned != nil || c.schedulerFrame.epoch != epoch ||
+		!reflect.DeepEqual(c.schedulerFrame.mark, checkpoint{}) {
+		t.Fatalf("scheduler frame retained completed state: %+v", c.schedulerFrame)
+	}
+}
+
+func newSchedulerTransactionShiftFixture(t *testing.T) (*Core, Head, ClassifiedBoundary) {
+	t.Helper()
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 1, symbol: 9}: {{Type: ActionShift, State: 2}},
+	}}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := compact.ClassifyBoundary(seed, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, seed, boundary
+}
+
+func newSchedulerTransactionExtraShiftFixture(t *testing.T) (*Core, Head, ClassifiedBoundary) {
+	t.Helper()
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 1, symbol: 9}: {{Type: ActionShift, Extra: true}},
+	}}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := compact.ClassifyBoundary(seed, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compact, seed, boundary
+}
+
+func TestStandaloneCohortValidationPreservesClassifiedBoundary(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(*testing.T) (*Core, Head, ClassifiedBoundary)
+		token Token
+		shift func(*Core, []ClassifiedBoundary, Token) ([]Head, error)
+	}{
+		{
+			name: "ordinary", setup: newSchedulerTransactionShiftFixture,
+			token: Token{Symbol: 9, EndByte: 1},
+			shift: (*Core).ShiftOrdinaryClassifiedCohort,
+		},
+		{
+			name: "extra", setup: newSchedulerTransactionExtraShiftFixture,
+			token: Token{Symbol: 9, EndByte: 1, Extra: true},
+			shift: (*Core).ShiftExtraClassifiedCohort,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact, _, boundary := test.setup(t)
+			before := captureSchedulerTransactionState(compact)
+			phase := compact.classificationPhase
+			if _, err := test.shift(compact, []ClassifiedBoundary{boundary, boundary}, test.token); err == nil || !strings.Contains(err.Error(), "duplicate") {
+				t.Fatalf("invalid standalone cohort error=%v", err)
+			}
+			if compact.classificationPhase != phase || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) || len(compact.transactions) != 0 {
+				t.Fatalf("invalid standalone cohort changed state: phase=%d want=%d", compact.classificationPhase, phase)
+			}
+			if _, err := compact.ShiftClassified(boundary, 0, test.token, ForkOrder{}); err != nil {
+				t.Fatalf("previously valid classification became stale: %v", err)
+			}
+		})
+	}
+}
+
+func TestOwnedCohortValidationPoisonsOwner(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(*testing.T) (*Core, Head, ClassifiedBoundary)
+		token Token
+		shift func(*Core, SchedulerTransactionToken, []ClassifiedBoundary, Token) ([]Head, error)
+	}{
+		{
+			name: "ordinary", setup: newSchedulerTransactionShiftFixture,
+			token: Token{Symbol: 9, EndByte: 1},
+			shift: (*Core).ShiftOrdinaryClassifiedCohortOwned,
+		},
+		{
+			name: "extra", setup: newSchedulerTransactionExtraShiftFixture,
+			token: Token{Symbol: 9, EndByte: 1, Extra: true},
+			shift: (*Core).ShiftExtraClassifiedCohortOwned,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact, _, boundary := test.setup(t)
+			before := captureSchedulerTransactionState(compact)
+			err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				if _, innerErr := test.shift(compact, owner, []ClassifiedBoundary{boundary, boundary}, test.token); innerErr == nil || !strings.Contains(innerErr.Error(), "duplicate") {
+					t.Fatalf("invalid owned cohort error=%v", innerErr)
+				}
+				return nil // Deliberately ignore the validation failure.
+			})
+			if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+				t.Fatalf("owned validation did not poison and roll back: %v", err)
+			}
+		})
+	}
+}
+
+func TestSchedulerTransactionCommitAndRollback(t *testing.T) {
+	t.Run("commit", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			_, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+			return err
+		})
+		if err != nil || compact.Work().Shifts != 1 || len(compact.transactions) != 0 {
+			t.Fatalf("scheduler commit err=%v work=%+v frame=%+v transactions=%v", err, compact.Work(), compact.schedulerFrame, compact.transactions)
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+	})
+
+	t.Run("returned-error", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		sentinel := errors.New("scheduler rollback")
+		err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			if _, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+				return err
+			}
+			return sentinel
+		})
+		after := captureSchedulerTransactionState(compact)
+		if !errors.Is(err, sentinel) || !reflect.DeepEqual(after, before) || len(compact.transactions) != 0 {
+			t.Fatalf("scheduler rollback err=%v before=%+v after=%+v frame=%+v transactions=%v", err, before, after, compact.schedulerFrame, compact.transactions)
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+	})
+}
+
+func TestSchedulerTransactionInsideStandaloneOwner(t *testing.T) {
+	t.Run("outer-rollback", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		sentinel := errors.New("outer rollback")
+		err := compact.ApplyAtomic(func() error {
+			if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				_, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+				return err
+			}); err != nil {
+				return err
+			}
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) || len(compact.transactions) != 0 {
+			t.Fatalf("standalone outer rollback err=%v", err)
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+	})
+
+	t.Run("outer-panic", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != "outer panic" {
+					t.Fatalf("recovered=%v", recovered)
+				}
+			}()
+			_ = compact.ApplyAtomic(func() error {
+				if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+					_, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+					return err
+				}); err != nil {
+					return err
+				}
+				panic("outer panic")
+			})
+		}()
+		if !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) || len(compact.transactions) != 0 {
+			t.Fatal("standalone outer panic did not restore pre-owner state")
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+	})
+}
+
+func TestSchedulerTransactionResetPreservesEpochAndRejectsRetainedToken(t *testing.T) {
+	compact, _, _ := newSchedulerTransactionShiftFixture(t)
+	var stale SchedulerTransactionToken
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		stale = owner
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	requireClearedSchedulerFrame(t, compact, stale.epoch)
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	requireClearedSchedulerFrame(t, compact, stale.epoch)
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := compact.ClassifyBoundary(seed, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := captureSchedulerTransactionState(compact)
+	err = compact.ApplySchedulerAtomic(func(current SchedulerTransactionToken) error {
+		if current.epoch == stale.epoch {
+			t.Fatalf("Reset reused scheduler epoch %d", current.epoch)
+		}
+		if _, innerErr := compact.ShiftClassifiedOwned(stale, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr == nil || !strings.Contains(innerErr.Error(), "stale") {
+			t.Fatalf("retained token error=%v", innerErr)
+		}
+		return nil // The stale-token error must poison the current owner.
+	})
+	if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+		t.Fatalf("retained token after Reset err=%v", err)
+	}
+	requireClearedSchedulerFrame(t, compact, stale.epoch+1)
+}
+
+func TestSchedulerTransactionBoundaryIndexRehash(t *testing.T) {
+	fill := func(t *testing.T, compact *Core, start, end int) {
+		t.Helper()
+		for index := start; index < end; index++ {
+			if _, err := compact.Seed(StateID(index+1), uint32(index)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	for _, test := range []struct {
+		name     string
+		rollback bool
+	}{
+		{name: "commit"},
+		{name: "rollback", rollback: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact, err := New(&fakeTable{}, Limits{MaxNodes: 64})
+			if err != nil {
+				t.Fatal(err)
+			}
+			fill(t, compact, 0, 11)
+			if len(compact.boundaries.slots) != 16 {
+				t.Fatalf("pre-owner slots=%d want=16", len(compact.boundaries.slots))
+			}
+			oldSlots := compact.boundaries.slots
+			before := captureSchedulerTransactionState(compact)
+			sentinel := errors.New("rehash rollback")
+			err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+				if innerErr := compact.RunSchedulerOwned(owner, func() error {
+					_, appendErr := compact.Seed(12, 11)
+					return appendErr
+				}); innerErr != nil {
+					return innerErr
+				}
+				if len(compact.boundaries.slots) != 32 || &compact.boundaries.slots[0] == &oldSlots[0] {
+					t.Fatalf("scheduler rehash slots=%d", len(compact.boundaries.slots))
+				}
+				if test.rollback {
+					return sentinel
+				}
+				return nil
+			})
+			if test.rollback {
+				if !errors.Is(err, sentinel) || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) ||
+					len(compact.boundaries.slots) != 16 || &compact.boundaries.slots[0] != &oldSlots[0] {
+					t.Fatalf("rehash rollback err=%v slots=%d", err, len(compact.boundaries.slots))
+				}
+			} else if err != nil || len(compact.boundaries.slots) != 32 || compact.boundaries.count != 12 {
+				t.Fatalf("rehash commit err=%v slots=%d count=%d", err, len(compact.boundaries.slots), compact.boundaries.count)
+			}
+			requireClearedSchedulerFrame(t, compact, 1)
+			if compact.schedulerFrame.mark.boundaryIndex.slots != nil {
+				t.Fatal("completed scheduler frame retained old boundary-index snapshot")
+			}
+		})
+	}
+}
+
+func TestSchedulerTransactionIgnoredInnerErrorPoisonsOwner(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	before := captureSchedulerTransactionState(compact)
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if _, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr != nil {
+			return innerErr
+		}
+		_, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 7, Token{Symbol: 9, EndByte: 2}, ForkOrder{})
+		if innerErr == nil {
+			t.Fatal("invalid owned shift did not fail")
+		}
+		return nil // Deliberately ignore the inner failure.
+	})
+	after := captureSchedulerTransactionState(compact)
+	if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(after, before) {
+		t.Fatalf("ignored error err=%v before=%+v after=%+v", err, before, after)
+	}
+}
+
+func TestSchedulerTransactionIgnoredNestedOwnerErrorPoisonsOwner(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	before := captureSchedulerTransactionState(compact)
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if _, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr != nil {
+			return innerErr
+		}
+		if nestedErr := compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error { return nil }); nestedErr == nil {
+			t.Fatal("nested scheduler owner did not fail")
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+		t.Fatalf("ignored nested owner error err=%v", err)
+	}
+}
+
+func TestSchedulerTransactionRecoveredOwnedPanicStillPoisonsOwner(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	before := captureSchedulerTransactionState(compact)
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("owned panic did not repanic")
+				}
+			}()
+			_ = compact.RunSchedulerOwned(owner, func() error {
+				if _, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr != nil {
+					return innerErr
+				}
+				panic("recovered owned panic")
+			})
+		}()
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+		t.Fatalf("recovered owned panic err=%v", err)
+	}
+}
+
+func TestSchedulerTransactionTokenValidationPoisonsOwner(t *testing.T) {
+	t.Run("wrong-core", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		other, _, otherBoundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			if _, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr != nil {
+				return innerErr
+			}
+			_, innerErr := other.ShiftClassifiedOwned(owner, otherBoundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+			if innerErr == nil || !strings.Contains(innerErr.Error(), "different core") {
+				t.Fatalf("wrong-core validation error=%v", innerErr)
+			}
+			return nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+			t.Fatalf("wrong-core owner was not poisoned: err=%v", err)
+		}
+	})
+
+	t.Run("not-top-of-stack", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		before := captureSchedulerTransactionState(compact)
+		err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			return compact.ApplyAtomic(func() error {
+				_, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+				if innerErr == nil || !strings.Contains(innerErr.Error(), "top-of-stack") {
+					t.Fatalf("top-of-stack validation error=%v", innerErr)
+				}
+				return nil
+			})
+		})
+		if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+			t.Fatalf("non-top owner was not poisoned: err=%v", err)
+		}
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		var stale SchedulerTransactionToken
+		if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			stale = owner
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := compact.ShiftClassifiedOwned(stale, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err == nil || !strings.Contains(err.Error(), "stale") {
+			t.Fatalf("stale token error=%v", err)
+		}
+	})
+}
+
+func TestSchedulerTransactionPanicRollsBackAndRepanics(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	before := captureSchedulerTransactionState(compact)
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != "scheduler panic" {
+				t.Fatalf("recovered=%v", recovered)
+			}
+		}()
+		_ = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+			if _, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+				return err
+			}
+			panic("scheduler panic")
+		})
+	}()
+	if after := captureSchedulerTransactionState(compact); !reflect.DeepEqual(after, before) || compact.schedulerFrame.active || len(compact.transactions) != 0 {
+		t.Fatalf("panic rollback before=%+v after=%+v frame=%+v transactions=%v", before, after, compact.schedulerFrame, compact.transactions)
+	}
+}

--- a/parsercore_phase0_canonical_admission_internal_test.go
+++ b/parsercore_phase0_canonical_admission_internal_test.go
@@ -293,6 +293,43 @@ func BenchmarkDiagnosticParserCoreCanonicalSchedulerCold(b *testing.B) {
 	}
 }
 
+func BenchmarkDiagnosticParserCoreCanonicalTotal(b *testing.B) {
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		b.Run(row.id, func(b *testing.B) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(b, row.id)
+			requireDiagnosticParserCoreCanonicalFixtureIdentity(b, fixture, row)
+			runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, DiagnosticParserCorePrefixOptions{
+				ReceiptMode: DiagnosticParserCoreReceiptSummary,
+				MaxTokens:   300000, MaxDispatches: 600000,
+				Limits: diagnosticParserCoreCanonicalLimits(),
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+			tree, err := runner.parse(fixture.Source)
+			if err != nil {
+				b.Fatal(err)
+			}
+			requireDiagnosticParserCoreCanonicalEOF(b, tree, len(fixture.Source))
+			if got := diagnosticParserCoreSelectedNodeCensus(tree.root); got.total != row.selectedNodes || got.parents != row.selectedParents || got.leaves != row.selectedLeaves {
+				b.Fatalf("canonical total selected census=%+v want=%d/%d/%d", got, row.selectedNodes, row.selectedParents, row.selectedLeaves)
+			}
+			tree.Release()
+			b.ReportAllocs()
+			b.SetBytes(int64(len(fixture.Source)))
+			b.ResetTimer()
+			for range b.N {
+				tree, err := runner.parse(fixture.Source)
+				if err != nil {
+					b.Fatal(err)
+				}
+				tree.Release()
+			}
+		})
+	}
+}
+
 func diagnosticParserCoreCanonicalLimits() core.Limits {
 	return core.Limits{
 		MaxNodes: 1 << 20, MaxLinks: 1 << 20, MaxSubtrees: 1 << 20,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -853,6 +853,7 @@ type diagnosticParserCoreActionOutput struct {
 
 func executeDiagnosticParserCoreGenericConflictDetailed(
 	compact *core.Core,
+	owner core.SchedulerTransactionToken,
 	incoming diagnosticParserCoreHeader,
 	headerIndex int,
 	token Token,
@@ -885,13 +886,13 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	}
 	trialOrder := branchOrder
 	var receipts []DiagnosticParserCoreRoundAction
-	err := compact.ApplyAtomic(func() error {
+	err := compact.RunSchedulerOwned(owner, func() error {
 		for ordinal := 1; ordinal < actions.Len(); ordinal++ {
 			action := actions.At(ordinal)
 			trialOrder++
 			var applyErr error
 			scratch.actionOutputs, scratch.reductionOutputs, applyErr = applyParserCoreConflictActionInto(
-				scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, classified, token,
+				scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
 				action, ordinal, core.ForkOrder{Present: true, Value: trialOrder},
 			)
 			if applyErr != nil {
@@ -915,7 +916,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		primaryAction := actions.At(0)
 		var applyErr error
 		scratch.actionOutputs, scratch.reductionOutputs, applyErr = applyParserCoreConflictActionInto(
-			scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, classified, token,
+			scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
 			primaryAction, 0, core.ForkOrder{},
 		)
 		if applyErr != nil {
@@ -2027,16 +2028,16 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 		s.work, s.epochProgress = workBefore, epochProgressBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 	}()
-	return s.compact.ApplyAtomic(func() error {
-		return s.applyGenericReductionAtomic(before, cell)
+	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return s.applyGenericReductionOwned(owner, before, cell)
 	})
 }
 
-func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionAtomic(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) error {
+func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) error {
 	if err := s.reserveDispatches(1); err != nil {
 		return err
 	}
-	outputs, err := s.compact.ReduceOutputsClassifiedInto(s.reductionOutputs, cell.boundary, 0, core.ForkOrder{})
+	outputs, err := s.compact.ReduceOutputsClassifiedIntoOwned(owner, s.reductionOutputs, cell.boundary, 0, core.ForkOrder{})
 	if err != nil {
 		return err
 	}
@@ -2173,12 +2174,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 		s.receipt.Conflicts = s.receipt.Conflicts[:conflictsBefore]
 		s.receipt.ExternalShifts = s.receipt.ExternalShifts[:externalShiftsBefore]
 	}()
-	return s.compact.ApplyAtomic(func() error {
-		return s.applyGenericConflictAtomic(before, cell)
+	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return s.applyGenericConflictOwned(owner, before, cell)
 	})
 }
 
-func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictAtomic(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
+func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
 	branchOrderBefore, nextSeqBefore := s.branchOrder, s.nextSeq
 	if err = s.reserveDispatches(1); err != nil {
 		return err
@@ -2193,7 +2194,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictAtomic(before
 	}
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
-		s.compact, s.headers[cell.headerIndex], cell.headerIndex, s.token, cell.boundary,
+		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, s.token, cell.boundary,
 		s.branchOrder, s.fullReceipts(), &s.conflictScratch,
 	)
 	if err != nil {
@@ -2360,6 +2361,12 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []Diagn
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 		s.receipt.ExternalShifts = s.receipt.ExternalShifts[:externalBefore]
 	}()
+	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
+		return s.applyGenericShiftsOwned(owner, before, cells)
+	})
+}
+
+func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner core.SchedulerTransactionToken, before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) error {
 	if err := s.reserveDispatches(uint64(len(cells))); err != nil {
 		return err
 	}
@@ -2369,7 +2376,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []Diagn
 	}
 	if len(cells) == 1 {
 		cell := cells[0]
-		head, err := s.compact.ShiftClassified(cell.boundary, 0, core.Token{
+		head, err := s.compact.ShiftClassifiedOwned(owner, cell.boundary, 0, core.Token{
 			Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte, External: s.token.ExternalScannerToken,
 		}, core.ForkOrder{})
 		if err != nil {
@@ -2382,7 +2389,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []Diagn
 		for _, cell := range cells {
 			s.classifiedBoundaries = append(s.classifiedBoundaries, cell.boundary)
 		}
-		heads, err := s.compact.ShiftOrdinaryClassifiedCohort(s.classifiedBoundaries, core.Token{
+		heads, err := s.compact.ShiftOrdinaryClassifiedCohortOwned(owner, s.classifiedBoundaries, core.Token{
 			Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte, External: s.token.ExternalScannerToken,
 		})
 		if err != nil {
@@ -2437,7 +2444,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 		s.receipt.ExternalShifts = s.receipt.ExternalShifts[:externalShiftsBefore]
 	}()
-	return s.compact.ApplyAtomic(func() error {
+	return s.compact.ApplySchedulerAtomic(func(owner core.SchedulerTransactionToken) error {
 		if len(cells) == 0 {
 			return errors.New("parser-core phase zero: empty extra shift cohort")
 		}
@@ -2457,7 +2464,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		for _, cell := range cells {
 			s.classifiedBoundaries = append(s.classifiedBoundaries, cell.boundary)
 		}
-		heads, err := s.compact.ShiftExtraClassifiedCohort(s.classifiedBoundaries, core.Token{
+		heads, err := s.compact.ShiftExtraClassifiedCohortOwned(owner, s.classifiedBoundaries, core.Token{
 			Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte,
 			Extra: true, External: s.token.ExternalScannerToken,
 		})
@@ -2826,6 +2833,7 @@ func applyParserCoreConflictActionInto(
 	dst []diagnosticParserCoreActionOutput,
 	reductionDst []core.ReductionOutput,
 	compact *core.Core,
+	owner core.SchedulerTransactionToken,
 	classified core.ClassifiedBoundary,
 	token Token,
 	action core.Action,
@@ -2835,7 +2843,7 @@ func applyParserCoreConflictActionInto(
 	if action.Type != core.ActionReduce {
 		switch action.Type {
 		case core.ActionShift:
-			head, err := compact.ShiftClassified(classified, ordinal, core.Token{Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, Extra: action.Extra, External: token.ExternalScannerToken}, fork)
+			head, err := compact.ShiftClassifiedOwned(owner, classified, ordinal, core.Token{Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, Extra: action.Extra, External: token.ExternalScannerToken}, fork)
 			if err != nil {
 				return nil, reductionDst, err
 			}
@@ -2848,7 +2856,7 @@ func applyParserCoreConflictActionInto(
 			return nil, reductionDst, errors.New("parser-core phase zero: unknown conflict action")
 		}
 	}
-	outputs, err := compact.ReduceOutputsClassifiedInto(reductionDst, classified, ordinal, fork)
+	outputs, err := compact.ReduceOutputsClassifiedIntoOwned(owner, reductionDst, classified, ordinal, fork)
 	if err != nil {
 		return nil, outputs, err
 	}


### PR DESCRIPTION
## Summary

- retain one authenticated transaction frame per compact scheduler mutation
- share uncheckpointed shift, cohort, and reduction implementations between standalone and owned wrappers
- preserve rollback, panic, reset, boundary-rehash, and classified-capability behavior

## Evidence

- authenticated four-fixture Total geomean: **-8.25%**
- every fixture: **-7.21% to -8.96%**
- query scheduler-only: **-10.70%**
- allocation counts unchanged
- exact EOF, selected census, deep-tree digest, production-tree equality, and locked work receipts unchanged

## Validation

- `go test ./internal/parsercorephase0 -count=1`
- focused scheduler transaction, rollback, reset-token, rehash, and panic tests
- tagged four-fixture canonical admission and failure rollback gates

This remains build-tagged and diagnostic-only; it does not change production parser routing.
