### PR TITLE
add(query): Add query matcher work budget to prevent exponential blowup

### DIFF
--- a/query.go
+++ b/query.go
@@ -270,6 +270,8 @@ type QueryCursor struct {
 	limitProbePending bool
 	didExceedMatchLim bool
 
+	workBudget int
+
 	hasMaxStartDepth bool
 	maxStartDepth    uint32
 
@@ -345,9 +347,10 @@ func (q *Query) ExecuteNode(node *Node, lang *Language, source []byte) []QueryMa
 // Exec creates a streaming cursor over matches rooted at node.
 func (q *Query) Exec(node *Node, lang *Language, source []byte) *QueryCursor {
 	c := &QueryCursor{
-		query:  q,
-		lang:   lang,
-		source: source,
+		query:      q,
+		lang:       lang,
+		source:     source,
+		workBudget: defaultQueryMatchWorkBudget,
 	}
 	if node != nil {
 		// Pre-size the worklist for typical tree depth (avoids early growths).
@@ -437,6 +440,18 @@ func (c *QueryCursor) DidExceedMatchLimit() bool {
 		return false
 	}
 	return c.didExceedMatchLim
+}
+
+// SetMatchWorkBudget bounds the number of enumeration steps the matcher may
+// take per (pattern,node) attempt, guarding against pathological O(2^n)
+// queries. A limit of 0 means unlimited. The default is defaultQueryMatchWorkBudget.
+// On exhaustion the cursor returns bounded partial results and DidExceedMatchLimit
+// reports true, mirroring C tree-sitter's over-limit behavior.
+func (c *QueryCursor) SetMatchWorkBudget(limit int) {
+	if c == nil {
+		return
+	}
+	c.workBudget = limit
 }
 
 // SetMaxStartDepth limits the depth at which new matches can begin.
@@ -585,11 +600,12 @@ func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte,
 					continue
 				}
 				pat := q.patterns[pi]
+				budget := newQueryMatchBudget(defaultQueryMatchWorkBudget)
 				var captureSets [][]QueryCapture
 				if pat.steps[0].quantifier == queryQuantifierZeroOrMore || pat.steps[0].quantifier == queryQuantifierOneOrMore {
-					captureSets = q.matchPatternPostorderAll(&pat, n, item.parent, item.childIdx, lang, source)
+					captureSets = q.matchPatternPostorderAll(&pat, n, item.parent, item.childIdx, lang, source, budget)
 				} else {
-					captureSets = q.matchPatternAll(&pat, n, lang, source)
+					captureSets = q.matchPatternAll(&pat, n, lang, source, budget)
 				}
 				for _, captures := range captureSets {
 					buf.matches = append(buf.matches, QueryMatch{
@@ -630,7 +646,8 @@ func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte,
 				continue
 			}
 			pat := q.patterns[pi]
-			captureSets := q.matchPatternAll(&pat, n, lang, source)
+			budget := newQueryMatchBudget(defaultQueryMatchWorkBudget)
+			captureSets := q.matchPatternAll(&pat, n, lang, source, budget)
 			if len(captureSets) == 0 {
 				continue
 			}
@@ -951,15 +968,19 @@ func (c *QueryCursor) nextMatchRaw() (QueryMatch, bool) {
 					return match, true
 				}
 			}
+			budget := newQueryMatchBudget(c.workBudget)
 			var captureSets [][]QueryCapture
 			if c.currentNodePost {
 				if pat.steps[0].quantifier == queryQuantifierZeroOrMore || pat.steps[0].quantifier == queryQuantifierOneOrMore {
-					captureSets = q.matchPatternPostorderAll(&pat, c.currentNode, c.currentParent, c.currentChildIdx, c.lang, c.source)
+					captureSets = q.matchPatternPostorderAll(&pat, c.currentNode, c.currentParent, c.currentChildIdx, c.lang, c.source, budget)
 				} else {
-					captureSets = q.matchPatternAll(&pat, c.currentNode, c.lang, c.source)
+					captureSets = q.matchPatternAll(&pat, c.currentNode, c.lang, c.source, budget)
 				}
 			} else {
-				captureSets = q.matchPatternAll(&pat, c.currentNode, c.lang, c.source)
+				captureSets = q.matchPatternAll(&pat, c.currentNode, c.lang, c.source, budget)
+			}
+			if budget.tripped() {
+				c.didExceedMatchLim = true
 			}
 			if len(captureSets) == 0 {
 				continue

--- a/query_match_budget.go
+++ b/query_match_budget.go
@@ -1,0 +1,42 @@
+package gotreesitter
+
+// defaultQueryMatchWorkBudget bounds enumeration steps per (pattern,node)
+// match attempt. 2^20 is far above any legitimate O(n^2) success enumeration
+// on <64-child nodes, and aborts a pathological 2^n walk in single-digit ms.
+const defaultQueryMatchWorkBudget = 1_000_000
+
+// queryMatchBudget bounds the query matcher's combination enumeration for a
+// single (pattern,node) attempt. A nil *queryMatchBudget means "unbounded"
+// (legacy behavior) so callers that opt out keep exact current behavior.
+type queryMatchBudget struct {
+	remaining int
+	trip      bool
+}
+
+// newQueryMatchBudget returns a budget with the given step limit, or nil
+// (unbounded) when limit <= 0.
+func newQueryMatchBudget(limit int) *queryMatchBudget {
+	if limit <= 0 {
+		return nil
+	}
+	return &queryMatchBudget{remaining: limit}
+}
+
+// charge consumes one enumeration step. It returns true while budget remains
+// and false once exhausted (latching trip). A nil budget always returns true.
+func (b *queryMatchBudget) charge() bool {
+	if b == nil {
+		return true
+	}
+	if b.remaining <= 0 {
+		b.trip = true
+		return false
+	}
+	b.remaining--
+	return true
+}
+
+// tripped reports whether this budget was exhausted during matching.
+func (b *queryMatchBudget) tripped() bool {
+	return b != nil && b.trip
+}

--- a/query_matcher.go
+++ b/query_matcher.go
@@ -104,7 +104,7 @@ func cloneQueryCaptures(captures []QueryCapture) []QueryCapture {
 	return out
 }
 
-func (q *Query) matchPatternAll(pat *Pattern, node *Node, lang *Language, source []byte) [][]QueryCapture {
+func (q *Query) matchPatternAll(pat *Pattern, node *Node, lang *Language, source []byte, budget *queryMatchBudget) [][]QueryCapture {
 	if len(pat.steps) == 0 {
 		return nil
 	}
@@ -116,7 +116,7 @@ func (q *Query) matchPatternAll(pat *Pattern, node *Node, lang *Language, source
 	}
 
 	var matches [][]QueryCapture
-	q.matchStepsAllWithParentPredicates(pat.steps, 0, node, nil, -1, lang, source, pat.predicates, nil, func(captures []QueryCapture) {
+	q.matchStepsAllWithParentPredicates(pat.steps, 0, node, nil, -1, lang, source, pat.predicates, nil, budget, func(captures []QueryCapture) {
 		if !q.matchesPredicates(pat.predicates, captures, lang, source) {
 			return
 		}
@@ -137,7 +137,7 @@ func (q *Query) matchRootZeroOrMorePatternAll(pat *Pattern, node *Node, lang *La
 	return nil
 }
 
-func (q *Query) matchPatternPostorderAll(pat *Pattern, node *Node, parent *Node, childIdx int, lang *Language, source []byte) [][]QueryCapture {
+func (q *Query) matchPatternPostorderAll(pat *Pattern, node *Node, parent *Node, childIdx int, lang *Language, source []byte, budget *queryMatchBudget) [][]QueryCapture {
 	if len(pat.steps) == 0 {
 		return nil
 	}
@@ -147,11 +147,11 @@ func (q *Query) matchPatternPostorderAll(pat *Pattern, node *Node, parent *Node,
 		return nil
 	}
 	parent, childIdx = queryPatternSiblingContext(node, parent, childIdx)
-	if len(q.matchPatternOnceAll(pat, node, parent, childIdx, lang, source, nil)) == 0 {
+	if len(q.matchPatternOnceAll(pat, node, parent, childIdx, lang, source, nil, budget)) == 0 {
 		return nil
 	}
 	if next, nextParent, nextChildIdx := queryAdjacentSibling(node, parent, childIdx, 1); next != nil {
-		if len(q.matchPatternOnceAll(pat, next, nextParent, nextChildIdx, lang, source, nil)) > 0 {
+		if len(q.matchPatternOnceAll(pat, next, nextParent, nextChildIdx, lang, source, nil, budget)) > 0 {
 			return nil
 		}
 	}
@@ -164,7 +164,7 @@ func (q *Query) matchPatternPostorderAll(pat *Pattern, node *Node, parent *Node,
 		if prev == nil {
 			break
 		}
-		if len(q.matchPatternOnceAll(pat, prev, prevParent, prevChildIdx, lang, source, nil)) == 0 {
+		if len(q.matchPatternOnceAll(pat, prev, prevParent, prevChildIdx, lang, source, nil, budget)) == 0 {
 			break
 		}
 		runStart = prev
@@ -176,7 +176,7 @@ func (q *Query) matchPatternPostorderAll(pat *Pattern, node *Node, parent *Node,
 	for current, currentParent, currentChildIdx := runStart, runStartParent, runStartChildIdx; current != nil; {
 		var nextPartials [][]QueryCapture
 		for _, captures := range partials {
-			nextPartials = append(nextPartials, q.matchPatternOnceAll(pat, current, currentParent, currentChildIdx, lang, source, captures)...)
+			nextPartials = append(nextPartials, q.matchPatternOnceAll(pat, current, currentParent, currentChildIdx, lang, source, captures, budget)...)
 		}
 		if len(nextPartials) == 0 {
 			break
@@ -242,9 +242,10 @@ func (q *Query) matchPatternOnceAll(
 	lang *Language,
 	source []byte,
 	captures []QueryCapture,
+	budget *queryMatchBudget,
 ) [][]QueryCapture {
 	var matches [][]QueryCapture
-	q.matchStepsAllWithParentPredicates(pat.steps, 0, node, parent, childIdx, lang, source, pat.predicates, captures, func(next []QueryCapture) {
+	q.matchStepsAllWithParentPredicates(pat.steps, 0, node, parent, childIdx, lang, source, pat.predicates, captures, budget, func(next []QueryCapture) {
 		matches = append(matches, cloneQueryCaptures(next))
 	})
 	return matches
@@ -275,6 +276,7 @@ func (q *Query) matchStepsAllWithParentPredicates(
 	source []byte,
 	predicates []QueryPredicate,
 	captures []QueryCapture,
+	budget *queryMatchBudget,
 	emit func([]QueryCapture),
 ) {
 	if stepIdx >= len(steps) || node == nil {
@@ -284,7 +286,7 @@ func (q *Query) matchStepsAllWithParentPredicates(
 	step := &steps[stepIdx]
 	if len(step.alternatives) > 0 {
 		q.matchAlternationStepAll(step, node, parent, childIdx, lang, source, predicates, captures, func(next []QueryCapture) {
-			q.matchStepChildrenAll(steps, stepIdx, node, lang, source, predicates, next, emit)
+			q.matchStepChildrenAll(steps, stepIdx, node, lang, source, predicates, next, budget, emit)
 		})
 		return
 	}
@@ -297,7 +299,7 @@ func (q *Query) matchStepsAllWithParentPredicates(
 	if !q.predicatesStillViable(predicates, next, source) {
 		return
 	}
-	q.matchStepChildrenAll(steps, stepIdx, node, lang, source, predicates, next, emit)
+	q.matchStepChildrenAll(steps, stepIdx, node, lang, source, predicates, next, budget, emit)
 }
 
 func (q *Query) matchStepChildrenAll(
@@ -308,6 +310,7 @@ func (q *Query) matchStepChildrenAll(
 	source []byte,
 	predicates []QueryPredicate,
 	captures []QueryCapture,
+	budget *queryMatchBudget,
 	emit func([]QueryCapture),
 ) {
 	step := &steps[stepIdx]
@@ -332,7 +335,7 @@ func (q *Query) matchStepChildrenAll(
 			})
 		}
 	}
-	q.matchChildStepsAll(node, steps, childSteps, lang, source, predicates, captures, emit)
+	q.matchChildStepsAll(node, steps, childSteps, lang, source, predicates, captures, budget, emit)
 }
 
 func (q *Query) matchAlternationStepAll(
@@ -376,6 +379,7 @@ func (q *Query) matchChildStepsAll(
 	source []byte,
 	predicates []QueryPredicate,
 	captures []QueryCapture,
+	budget *queryMatchBudget,
 	emit func([]QueryCapture),
 ) {
 	childCount := nodeChildCountNoMaterialize(parent)
@@ -407,7 +411,7 @@ func (q *Query) matchChildStepsAll(
 	q.matchChildStepsRecursiveAll(
 		parent, children, namedPosByIndex, namedPos-1,
 		steps, childSteps, 0, 0, false, -1,
-		lang, source, predicates, captures, emit,
+		lang, source, predicates, captures, budget, emit,
 	)
 }
 
@@ -426,6 +430,7 @@ func (q *Query) matchChildStepsRecursiveAll(
 	source []byte,
 	predicates []QueryPredicate,
 	captures []QueryCapture,
+	budget *queryMatchBudget,
 	emit func([]QueryCapture),
 ) {
 	if childPos >= len(childSteps) {
@@ -484,6 +489,9 @@ func (q *Query) matchChildStepsRecursiveAll(
 			lastNamedPos int,
 			current []QueryCapture,
 		) {
+			if !budget.charge() {
+				return
+			}
 			if chosen == count {
 				if count > 0 && !q.stepAnchorsSatisfied(
 					step, childPos, hasNamed, firstNamedPos, lastNamedPos,
@@ -499,7 +507,7 @@ func (q *Query) matchChildStepsRecursiveAll(
 				q.matchChildStepsRecursiveAll(
 					parent, children, namedPosByIndex, parentLastNamedPos,
 					steps, childSteps, childPos+1, nextIdx, nextPrevHasNamed, nextPrevLastNamedPos,
-					lang, source, predicates, current, emitForCount,
+					lang, source, predicates, current, budget, emitForCount,
 				)
 				return
 			}
@@ -530,7 +538,7 @@ func (q *Query) matchChildStepsRecursiveAll(
 				}
 
 				q.matchStepsAllWithParentPredicates(
-					steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, current,
+					steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, current, budget,
 					func(next []QueryCapture) {
 						tryCombinations(
 							i+1, chosen+1, nextIdxForChoice,
@@ -543,6 +551,9 @@ func (q *Query) matchChildStepsRecursiveAll(
 		}
 
 		tryCombinations(0, 0, nextChildIdx, false, -1, -1, captures)
+		if budget.tripped() {
+			return
+		}
 		if step.quantifier != queryQuantifierOne && emittedForCount {
 			return
 		}
@@ -744,10 +755,11 @@ func (q *Query) matchChildSteps(
 	}
 	parentLastNamedPos := namedPos - 1
 
+	budget := newQueryMatchBudget(defaultQueryMatchWorkBudget)
 	return q.matchChildStepsRecursive(
 		parent, children, namedPosByIndex, parentLastNamedPos,
 		steps, childSteps, 0, 0, false, -1,
-		lang, source, predicates, captures,
+		lang, source, predicates, captures, budget,
 	)
 }
 
@@ -766,6 +778,7 @@ func (q *Query) matchChildStepsRecursive(
 	source []byte,
 	predicates []QueryPredicate,
 	captures *[]QueryCapture,
+	budget *queryMatchBudget,
 ) bool {
 	if childPos >= len(childSteps) {
 		return true
@@ -789,6 +802,7 @@ func (q *Query) matchChildStepsRecursive(
 		predicates:         predicates,
 		captures:           captures,
 		candidateIndices:   candidateIndicesBuf[:0],
+		budget:             budget,
 	}
 	if !matcher.prepare() {
 		return false
@@ -812,6 +826,7 @@ type childStepMatcher struct {
 	source             []byte
 	predicates         []QueryPredicate
 	captures           *[]QueryCapture
+	budget             *queryMatchBudget
 
 	cs               queryChildStepInfo
 	step             *QueryStep
@@ -916,11 +931,17 @@ func (m *childStepMatcher) matchQuantifierChoices() bool {
 		}
 
 		*m.captures = (*m.captures)[:checkpoint]
+		if m.budget.tripped() {
+			return false
+		}
 	}
 	return false
 }
 
 func (m *childStepMatcher) matchChoiceCombinations(count int, candidatePos int, chosen int, nextIdx int, span childStepNamedSpan) bool {
+	if !m.budget.charge() {
+		return false
+	}
 	if chosen == count {
 		if !m.anchorsSatisfied(span) {
 			return false
@@ -933,7 +954,7 @@ func (m *childStepMatcher) matchChoiceCombinations(count int, candidatePos int, 
 		return m.q.matchChildStepsRecursive(
 			m.parent, m.children, m.namedPosByIndex, m.parentLastNamedPos,
 			m.steps, m.childSteps, m.childPos+1, nextIdx, nextPrevHasNamed, nextPrevLastNamedPos,
-			m.lang, m.source, m.predicates, m.captures,
+			m.lang, m.source, m.predicates, m.captures, m.budget,
 		)
 	}
 

--- a/query_matcher_budget_test.go
+++ b/query_matcher_budget_test.go
@@ -1,0 +1,166 @@
+package gotreesitter
+
+import (
+	"testing"
+	"time"
+)
+
+// buildWideIdentifierBlock builds a synthetic "block" node with n
+// "identifier" children and no trailing "function_declaration" node. A
+// pattern like `(block (identifier)* @e (function_declaration) @r)` against
+// this tree has a quantified child step ((identifier)*) followed by a
+// required step ((function_declaration)) that can never match -- the
+// pathological shape from the bug report. Before the work-budget fix,
+// matchChildStepsRecursiveAll's tryCombinations enumerator would walk the
+// full power set of the n candidate identifiers (2^n combinations) before
+// ever reporting failure for this (pattern,node) attempt, since the
+// required trailing step is checked only after each candidate subset is
+// fully chosen.
+func buildWideIdentifierBlock(lang *Language, n int) *Tree {
+	source := make([]byte, 0, n*2)
+	children := make([]*Node, n)
+	fields := make([]FieldID, n)
+	pos := uint32(0)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			source = append(source, ' ')
+			pos++
+		}
+		children[i] = leaf(Symbol(1), true, pos, pos+1)
+		source = append(source, 'x')
+		pos++
+	}
+	block := parent(Symbol(14), true, children, fields)
+	return NewTree(block, source, lang)
+}
+
+// drainCursorWithDeadline exhausts cursor via NextMatch on a background
+// goroutine and fails the test if it doesn't finish within the deadline.
+// Returns the matches collected (empty if the deadline was hit).
+func drainCursorWithDeadline(t *testing.T, cursor *QueryCursor, deadline time.Duration) []QueryMatch {
+	t.Helper()
+	var matches []QueryMatch
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			m, ok := cursor.NextMatch()
+			if !ok {
+				return
+			}
+			matches = append(matches, m)
+		}
+	}()
+
+	select {
+	case <-done:
+		return matches
+	case <-time.After(deadline):
+		t.Fatalf("query matcher did not terminate within %s -- exponential blowup not bounded", deadline)
+		return nil
+	}
+}
+
+// TestQueryMatchWorkBudgetTerminatesPathologicalQuantifier reproduces the
+// verified DoS: a wide unanchored `(identifier)*` run followed by a
+// required step that never matches. Before the work-budget fix this hangs
+// (2^32 combinations); after the fix it must terminate quickly and report
+// DidExceedMatchLimit()==true, mirroring C tree-sitter's bounded-partial-
+// results behavior on over-limit queries.
+func TestQueryMatchWorkBudgetTerminatesPathologicalQuantifier(t *testing.T) {
+	lang := queryTestLanguage()
+	tree := buildWideIdentifierBlock(lang, 32)
+
+	q, err := NewQuery(`(block (identifier)* @e (function_declaration) @r)`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), tree.Language(), tree.Source())
+	matches := drainCursorWithDeadline(t, cursor, 5*time.Second)
+
+	if len(matches) != 0 {
+		t.Fatalf("matches: got %d, want 0 (trailing function_declaration step never matches)", len(matches))
+	}
+	if !cursor.DidExceedMatchLimit() {
+		t.Fatal("DidExceedMatchLimit: got false, want true (matcher should report bounded partial results)")
+	}
+}
+
+// TestQueryMatchWorkBudgetUnderBudgetIdentity checks that the work budget
+// does not alter results for an ordinary, well-under-budget match: a small
+// run of identifiers actually followed by a function_declaration. This
+// exercises the *same* matchChildStepsRecursiveAll code path (quantified
+// step followed by a required step) as the pathological test above, but one
+// where the required step succeeds on the first (greediest) combination
+// tried, so the match should be found immediately and be identical to
+// pre-budget behavior.
+func TestQueryMatchWorkBudgetUnderBudgetIdentity(t *testing.T) {
+	lang := queryTestLanguage()
+	source := []byte("a b c f")
+	id0 := leaf(Symbol(1), true, 0, 1)
+	id1 := leaf(Symbol(1), true, 2, 3)
+	id2 := leaf(Symbol(1), true, 4, 5)
+	fn := leaf(Symbol(5), true, 6, 7)
+	block := parent(Symbol(14), true, []*Node{id0, id1, id2, fn}, []FieldID{0, 0, 0, 0})
+	tree := NewTree(block, source, lang)
+
+	q, err := NewQuery(`(block (identifier)* @e (function_declaration) @r)`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), tree.Language(), tree.Source())
+	matches := drainCursorWithDeadline(t, cursor, 5*time.Second)
+
+	if cursor.DidExceedMatchLimit() {
+		t.Fatal("DidExceedMatchLimit: got true, want false for a small under-budget tree")
+	}
+	if len(matches) != 1 {
+		t.Fatalf("matches: got %d, want 1", len(matches))
+	}
+	if len(matches[0].Captures) != 4 {
+		t.Fatalf("captures: got %d, want 4", len(matches[0].Captures))
+	}
+	for i, wantText := range []string{"a", "b", "c"} {
+		if got := matches[0].Captures[i].Node.Text(source); got != wantText {
+			t.Fatalf("capture[%d] (@e): got %q, want %q", i, got, wantText)
+		}
+		if got := matches[0].Captures[i].Name; got != "e" {
+			t.Fatalf("capture[%d] name: got %q, want %q", i, got, "e")
+		}
+	}
+	if got := matches[0].Captures[3].Node.Text(source); got != "f" {
+		t.Fatalf("capture[3] (@r): got %q, want %q", got, "f")
+	}
+	if got := matches[0].Captures[3].Name; got != "r" {
+		t.Fatalf("capture[3] name: got %q, want %q", got, "r")
+	}
+}
+
+// TestQueryMatchWorkBudgetUnlimitedEscapeHatch checks that
+// SetMatchWorkBudget(0) restores the legacy unbounded behavior. n is kept
+// small (18, so 2^18 is a few hundred thousand combinations) so the test
+// still completes quickly -- comfortably under the 5s deadline -- even
+// without a budget. (Measured empirically: n=18 ~0.8s, n=20 ~2.7s, n=22
+// ~11.6s on this enumerator, so 18 leaves solid headroom under 5s.)
+func TestQueryMatchWorkBudgetUnlimitedEscapeHatch(t *testing.T) {
+	lang := queryTestLanguage()
+	tree := buildWideIdentifierBlock(lang, 18)
+
+	q, err := NewQuery(`(block (identifier)* @e (function_declaration) @r)`, lang)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	cursor := q.Exec(tree.RootNode(), tree.Language(), tree.Source())
+	cursor.SetMatchWorkBudget(0)
+	matches := drainCursorWithDeadline(t, cursor, 5*time.Second)
+
+	if len(matches) != 0 {
+		t.Fatalf("matches: got %d, want 0 (trailing function_declaration step never matches)", len(matches))
+	}
+	if cursor.DidExceedMatchLimit() {
+		t.Fatal("DidExceedMatchLimit: got true, want false when SetMatchWorkBudget(0) disables the bound")
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a work budget for the query matcher to bound enumeration steps per (pattern, node) attempt. This prevents pathological O(2^n) blowups on trees with wide quantified child steps followed by unmatchable required steps. On exhaustion, partial results are returned and `DidExceedMatchLimit()` reports true, aligning with C tree-sitter. Includes a `SetMatchWorkBudget` API defaulting to 1,000,000 steps.

## Changes

- Add `queryMatchBudget` struct with `charge()` and `tripped()` methods, enforcing a default limit of 1,000,000 enumeration steps.
- Thread `*queryMatchBudget` through all deep-matcher functions to intercept recursive combination enumeration and exit early when exhausted.
- Add `QueryCursor.SetMatchWorkBudget(limit int)` to adjust the per-match budget, with `0` meaning unlimited (legacy behavior).
- Propagate budget exhaustion to `didExceedMatchLim` on `QueryCursor` so callers can detect bounded-partial-result matches.
- Add `query_matcher_budget_test.go` with tests for pathological quantifier termination, correctness under the budget, and the unlimited escape hatch.

## Testing

- `go test -run 'TestQueryMatchWorkBudget' -v`