### PR TITLE
fix(incremental): Fix stale token-boundary reuse (leaf + non-leaf)

### DIFF
--- a/grammars/clojure_incremental_abutting_nonleaf_boundary_test.go
+++ b/grammars/clojure_incremental_abutting_nonleaf_boundary_test.go
@@ -1,0 +1,179 @@
+//go:build !grammar_subset || grammar_subset_clojure
+
+package grammars
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestD12bClojureAbuttingNonLeafBoundary is the non-leaf counterpart of the
+// Scheme leaf-boundary repro in scheme_incremental_abutting_leaf_boundary_test.go.
+//
+// PR #360 rejected stale LEAF reuse when a fresh lex at the candidate's start
+// byte produces a token with a different end byte (incremental.go,
+// reuseTargetState leaf branch). That guard does not cover the parallel
+// non-leaf fallback path: reuseNonLeafTargetStateOnStack (called from the
+// "conservative fallback" loop in tryReuseSubtree) reuses a non-terminal
+// purely via lookupGoto(preGoto, n.Symbol()) plus stack-depth matching -- it
+// never consults the lookahead token at all, so it has no symbol check and no
+// end-byte check.
+//
+// Clojure's grammar has a thin single-token wrapper non-terminal
+// (sym_lit -> sym_name) that exposes exactly this gap: deleting the space in
+// "(a b)" makes "ab" a single symbol under a fresh parse, but the stale
+// sym_lit wrapping the old "a" leaf gets reused by the non-leaf fallback path
+// (its own goto/stack-depth checks are satisfied), leaving the parser to
+// resume lexing at the old leaf's stale end byte and re-split "ab" into two
+// tokens, producing an ERROR node that a fresh parse does not have.
+//
+// Each case here deletes a byte that makes two previously separate tokens
+// abut (or, for InsertReverse, does the opposite edit), and asserts full
+// per-node byte-span equality between the incremental and fresh trees -- not
+// just SExpr string equality, since the leftmost leaf's rendered text can
+// still equal the fresh token's text even when spans/symbols differ
+// underneath a reused wrapper.
+func TestD12bClojureAbuttingNonLeafBoundary(t *testing.T) {
+	cases := []struct {
+		name       string
+		oldSrc     string
+		newSrc     string
+		startByte  uint32
+		oldEndByte uint32
+		newEndByte uint32
+	}{
+		{
+			name:       "paren_sym_delete_space",
+			oldSrc:     "(a b)",
+			newSrc:     "(ab)",
+			startByte:  2,
+			oldEndByte: 3,
+			newEndByte: 2,
+		},
+		{
+			name:       "bracket_sym_delete_space",
+			oldSrc:     "[a b]",
+			newSrc:     "[ab]",
+			startByte:  2,
+			oldEndByte: 3,
+			newEndByte: 2,
+		},
+		{
+			name:       "brace_sym_delete_space",
+			oldSrc:     "{a b}",
+			newSrc:     "{ab}",
+			startByte:  2,
+			oldEndByte: 3,
+			newEndByte: 2,
+		},
+		{
+			name:       "paren_word_delete_space",
+			oldSrc:     "(foo bar)",
+			newSrc:     "(foobar)",
+			startByte:  4,
+			oldEndByte: 5,
+			newEndByte: 4,
+		},
+		{
+			name:       "top_level_delete_space",
+			oldSrc:     "a b c",
+			newSrc:     "ab c",
+			startByte:  1,
+			oldEndByte: 2,
+			newEndByte: 1,
+		},
+		{
+			name:       "trailing_newline_delete_space",
+			oldSrc:     "a b\n",
+			newSrc:     "ab\n",
+			startByte:  1,
+			oldEndByte: 2,
+			newEndByte: 1,
+		},
+	}
+
+	lang := ClojureLanguage()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldSrc := []byte(tc.oldSrc)
+			newSrc := []byte(tc.newSrc)
+
+			parser := gotreesitter.NewParser(lang)
+			oldTree, err := parser.Parse(oldSrc)
+			if err != nil {
+				t.Fatalf("parse old failed: %v", err)
+			}
+			t.Logf("OLD TREE:\n%s", oldTree.RootNode().SExpr(lang))
+
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   tc.startByte,
+				OldEndByte:  tc.oldEndByte,
+				NewEndByte:  tc.newEndByte,
+				StartPoint:  gotreesitter.Point{Row: 0, Column: tc.startByte},
+				OldEndPoint: gotreesitter.Point{Row: 0, Column: tc.oldEndByte},
+				NewEndPoint: gotreesitter.Point{Row: 0, Column: tc.newEndByte},
+			})
+
+			incTree, err := parser.ParseIncremental(newSrc, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse failed: %v", err)
+			}
+			freshTree, err := gotreesitter.NewParser(lang).Parse(newSrc)
+			if err != nil {
+				t.Fatalf("fresh parse failed: %v", err)
+			}
+
+			incStr := incTree.RootNode().SExpr(lang)
+			freshStr := freshTree.RootNode().SExpr(lang)
+			t.Logf("INCREMENTAL:\n%s", incStr)
+			t.Logf("FRESH:\n%s", freshStr)
+
+			// Full per-node byte-span check across the whole tree, not just
+			// SExpr structural equality.
+			assertIncrementalMatchesFreshFullSpan(t, lang, incTree, freshTree)
+
+			if incTree.RootNode().HasError() {
+				t.Errorf("incremental tree has error, fresh does not:\nincremental: %s\nfresh:       %s", incStr, freshStr)
+			}
+		})
+	}
+}
+
+// TestD12bClojureAbuttingNonLeafBoundaryInsertReverse is the reverse-edit
+// mirror of TestD12bClojureAbuttingNonLeafBoundary: starting from the merged
+// form and inserting a byte that splits one token into two. This exercises
+// the non-leaf fallback path from the opposite direction (growing a
+// previously-single-token span back into a wrapper + two children).
+func TestD12bClojureAbuttingNonLeafBoundaryInsertReverse(t *testing.T) {
+	lang := ClojureLanguage()
+
+	oldSrc := []byte("(ab)")
+	newSrc := []byte("(a b)")
+
+	parser := gotreesitter.NewParser(lang)
+	oldTree, err := parser.Parse(oldSrc)
+	if err != nil {
+		t.Fatalf("parse old failed: %v", err)
+	}
+
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   2,
+		OldEndByte:  2,
+		NewEndByte:  3,
+		StartPoint:  gotreesitter.Point{Row: 0, Column: 2},
+		OldEndPoint: gotreesitter.Point{Row: 0, Column: 2},
+		NewEndPoint: gotreesitter.Point{Row: 0, Column: 3},
+	})
+
+	incTree, err := parser.ParseIncremental(newSrc, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse failed: %v", err)
+	}
+	freshTree, err := gotreesitter.NewParser(lang).Parse(newSrc)
+	if err != nil {
+		t.Fatalf("fresh parse failed: %v", err)
+	}
+
+	assertIncrementalMatchesFreshFullSpan(t, lang, incTree, freshTree)
+}

--- a/grammars/d12b_incremental_span_helpers_test.go
+++ b/grammars/d12b_incremental_span_helpers_test.go
@@ -1,0 +1,69 @@
+//go:build !grammar_subset || grammar_subset_scheme || grammar_subset_clojure
+
+package grammars
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// assertIncrementalMatchesFreshFullSpan compares an incrementally parsed tree
+// against a from-scratch parse of the same source using BOTH an SExpr
+// structural comparison AND a full per-node recursive comparison of symbol,
+// byte span, error flag, and child count.
+//
+// SExpr-string equality alone is not sufficient: it can miss divergences
+// where a node's symbol and rendered text happen to match but its byte span
+// does not (e.g. a stale reused subtree that keeps its old, pre-edit
+// boundaries while a sibling absorbs or loses the corresponding bytes). See
+// the d12b non-leaf reuse boundary guard in incremental.go, which this helper
+// backs regression coverage for.
+func assertIncrementalMatchesFreshFullSpan(t *testing.T, lang *gotreesitter.Language, incTree, freshTree *gotreesitter.Tree) {
+	t.Helper()
+
+	incStr := incTree.RootNode().SExpr(lang)
+	freshStr := freshTree.RootNode().SExpr(lang)
+	if incStr != freshStr {
+		t.Errorf("DIVERGENCE (structure):\nincremental: %s\nfresh:       %s", incStr, freshStr)
+	}
+
+	if diff := d12bNodeSpanDiff(incTree.RootNode(), freshTree.RootNode()); diff != "" {
+		t.Errorf("DIVERGENCE (per-node span): %s\nincremental: %s\nfresh:       %s", diff, incStr, freshStr)
+	}
+}
+
+// d12bNodeSpanDiff performs a full recursive structural comparison (symbol,
+// byte span, error flag, child count) between two node trees and returns a
+// description of the first difference found, or "" if they are identical.
+func d12bNodeSpanDiff(a, b *gotreesitter.Node) string {
+	if a == nil && b == nil {
+		return ""
+	}
+	if a == nil || b == nil {
+		return fmt.Sprintf("nil mismatch: incremental-nil=%v fresh-nil=%v", a == nil, b == nil)
+	}
+	if a.Symbol() != b.Symbol() {
+		return fmt.Sprintf("symbol mismatch: incremental=%d [%d,%d) fresh=%d [%d,%d)",
+			a.Symbol(), a.StartByte(), a.EndByte(), b.Symbol(), b.StartByte(), b.EndByte())
+	}
+	if a.StartByte() != b.StartByte() || a.EndByte() != b.EndByte() {
+		return fmt.Sprintf("span mismatch for symbol %d: incremental=[%d,%d) fresh=[%d,%d)",
+			a.Symbol(), a.StartByte(), a.EndByte(), b.StartByte(), b.EndByte())
+	}
+	if a.HasError() != b.HasError() {
+		return fmt.Sprintf("hasError mismatch for symbol %d at [%d,%d): incremental=%v fresh=%v",
+			a.Symbol(), a.StartByte(), a.EndByte(), a.HasError(), b.HasError())
+	}
+	if a.ChildCount() != b.ChildCount() {
+		return fmt.Sprintf("childCount mismatch for symbol %d at [%d,%d): incremental=%d fresh=%d",
+			a.Symbol(), a.StartByte(), a.EndByte(), a.ChildCount(), b.ChildCount())
+	}
+	for i := 0; i < a.ChildCount(); i++ {
+		if diff := d12bNodeSpanDiff(a.Child(i), b.Child(i)); diff != "" {
+			return diff
+		}
+	}
+	return ""
+}

--- a/grammars/scheme_incremental_abutting_leaf_boundary_test.go
+++ b/grammars/scheme_incremental_abutting_leaf_boundary_test.go
@@ -56,9 +56,9 @@ func TestD12bReproSchemeAbutDelete(t *testing.T) {
 	t.Logf("INCREMENTAL:\n%s", incStr)
 	t.Logf("FRESH:\n%s", freshStr)
 
-	if incStr != freshStr {
-		t.Errorf("DIVERGENCE:\nincremental: %s\nfresh:       %s", incStr, freshStr)
-	}
+	// Full per-node span check across the whole tree (not just the leaf
+	// symbol checked below), catching divergences anywhere.
+	assertIncrementalMatchesFreshFullSpan(t, lang, incTree, freshTree)
 
 	incSym := incTree.RootNode().NamedChild(0).NamedChild(0)
 	freshSym := freshTree.RootNode().NamedChild(0).NamedChild(0)
@@ -100,9 +100,8 @@ func TestD12bReproSchemeAbutInsertReverse(t *testing.T) {
 		t.Fatalf("fresh parse failed: %v", err)
 	}
 
-	incStr := incTree.RootNode().SExpr(lang)
-	freshStr := freshTree.RootNode().SExpr(lang)
-	if incStr != freshStr {
-		t.Errorf("DIVERGENCE (reverse):\nincremental: %s\nfresh:       %s", incStr, freshStr)
-	}
+	// Full per-node span check, not just SExpr structural equality: SExpr
+	// string equality alone can miss a stale reused subtree that keeps its
+	// pre-edit byte boundaries while rendering the same text.
+	assertIncrementalMatchesFreshFullSpan(t, lang, incTree, freshTree)
 }

--- a/grammars/scheme_incremental_abutting_leaf_boundary_test.go
+++ b/grammars/scheme_incremental_abutting_leaf_boundary_test.go
@@ -1,0 +1,108 @@
+//go:build !grammar_subset || grammar_subset_scheme
+
+package grammars
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// TestD12bReproSchemeAbutDelete is the minimal incremental-correctness repro
+// for the stale-leaf-reuse class: a leaf whose right edge abuts an edit start
+// byte keeps a pre-edit token boundary and gets reused even though a fresh
+// lex at the same start byte produces a token with a different end byte.
+//
+// (a b) --delete the space (byte 2)--> (ab)
+//
+// Before the reuseTargetState leaf-boundary fix, the stale leaf "a" [1,2) was
+// reused, and the parser resumed lexing at byte 2, re-splitting "ab" into two
+// symbols instead of lexing it as one (see incremental.go reuseTargetState).
+func TestD12bReproSchemeAbutDelete(t *testing.T) {
+	lang := SchemeLanguage()
+
+	oldSrc := []byte("(a b)")
+	newSrc := []byte("(ab)")
+
+	parser := gotreesitter.NewParser(lang)
+	oldTree, err := parser.Parse(oldSrc)
+	if err != nil {
+		t.Fatalf("parse old failed: %v", err)
+	}
+	t.Logf("OLD TREE:\n%s", oldTree.RootNode().SExpr(lang))
+
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   2,
+		OldEndByte:  3,
+		NewEndByte:  2,
+		StartPoint:  gotreesitter.Point{Row: 0, Column: 2},
+		OldEndPoint: gotreesitter.Point{Row: 0, Column: 3},
+		NewEndPoint: gotreesitter.Point{Row: 0, Column: 2},
+	})
+
+	incTree, err := parser.ParseIncremental(newSrc, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse failed: %v", err)
+	}
+
+	freshTree, err := gotreesitter.NewParser(lang).Parse(newSrc)
+	if err != nil {
+		t.Fatalf("fresh parse failed: %v", err)
+	}
+
+	incStr := incTree.RootNode().SExpr(lang)
+	freshStr := freshTree.RootNode().SExpr(lang)
+
+	t.Logf("INCREMENTAL:\n%s", incStr)
+	t.Logf("FRESH:\n%s", freshStr)
+
+	if incStr != freshStr {
+		t.Errorf("DIVERGENCE:\nincremental: %s\nfresh:       %s", incStr, freshStr)
+	}
+
+	incSym := incTree.RootNode().NamedChild(0).NamedChild(0)
+	freshSym := freshTree.RootNode().NamedChild(0).NamedChild(0)
+	if incSym.StartByte() != freshSym.StartByte() || incSym.EndByte() != freshSym.EndByte() {
+		t.Errorf("span mismatch: incremental [%d,%d) fresh [%d,%d)", incSym.StartByte(), incSym.EndByte(), freshSym.StartByte(), freshSym.EndByte())
+	}
+	if incSym.Text(newSrc) != "ab" {
+		t.Errorf("incremental symbol text = %q, want %q", incSym.Text(newSrc), "ab")
+	}
+}
+
+func TestD12bReproSchemeAbutInsertReverse(t *testing.T) {
+	lang := SchemeLanguage()
+
+	oldSrc := []byte("(ab)")
+	newSrc := []byte("(a b)")
+
+	parser := gotreesitter.NewParser(lang)
+	oldTree, err := parser.Parse(oldSrc)
+	if err != nil {
+		t.Fatalf("parse old failed: %v", err)
+	}
+
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   2,
+		OldEndByte:  2,
+		NewEndByte:  3,
+		StartPoint:  gotreesitter.Point{Row: 0, Column: 2},
+		OldEndPoint: gotreesitter.Point{Row: 0, Column: 2},
+		NewEndPoint: gotreesitter.Point{Row: 0, Column: 3},
+	})
+
+	incTree, err := parser.ParseIncremental(newSrc, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse failed: %v", err)
+	}
+	freshTree, err := gotreesitter.NewParser(lang).Parse(newSrc)
+	if err != nil {
+		t.Fatalf("fresh parse failed: %v", err)
+	}
+
+	incStr := incTree.RootNode().SExpr(lang)
+	freshStr := freshTree.RootNode().SExpr(lang)
+	if incStr != freshStr {
+		t.Errorf("DIVERGENCE (reverse):\nincremental: %s\nfresh:       %s", incStr, freshStr)
+	}
+}

--- a/incremental.go
+++ b/incremental.go
@@ -621,6 +621,17 @@ func (p *Parser) reuseTargetState(state StateID, n *Node, lookahead Token) (Stat
 		if n.Symbol() != lookahead.Symbol {
 			return 0, false
 		}
+		// The caller always lexes the fresh lookahead at the candidate's start
+		// byte before consulting reuse (tryReuseSubtree selects candidates by
+		// n.startByte == lookahead.StartByte). If a fresh lex of the same
+		// symbol at that position ends at a different byte than the stored
+		// leaf, the leaf's token boundary is stale (a maximal-munch decision
+		// that depended on bytes at or beyond the leaf's old right edge no
+		// longer holds under the new source) and reusing it would truncate or
+		// extend the real token. Reject rather than reuse.
+		if n.EndByte() != lookahead.EndByte {
+			return 0, false
+		}
 
 		action := p.lookupAction(state, n.Symbol())
 		if action == nil || len(action.Actions) == 0 {

--- a/incremental.go
+++ b/incremental.go
@@ -38,6 +38,7 @@ type reuseCursor struct {
 	rejectOutOfBounds             uint64
 	rejectRootNonLeafChanged      uint64
 	rejectLargeNonLeaf            uint64
+	rejectStaleNonLeafBoundary    uint64
 	forestFastPath                bool
 	languageName                  string // cached for language-specific reuse safety policies
 }
@@ -81,6 +82,7 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.rejectOutOfBounds = 0
 	c.rejectRootNonLeafChanged = 0
 	c.rejectLargeNonLeaf = 0
+	c.rejectStaleNonLeafBoundary = 0
 	c.forestFastPath = oldTree.forestFastPath
 	c.languageName = ""
 	if oldTree.language != nil {
@@ -458,6 +460,25 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			}
 			continue
 		}
+		// A node's span always starts where its leftmost descendant leaf
+		// starts, so n's leftmost leaf is the OLD-tree token that was lexed
+		// at this position before the edit. reuseNonLeafTargetStateOnStack
+		// below only checks goto-table/stack-depth compatibility for n's
+		// *symbol* - it never consults the lookahead token at all - so a
+		// stale tokenization boundary inside n (e.g. a thin single-token
+		// wrapper non-terminal whose child token's maximal-munch decision no
+		// longer holds after the edit) would otherwise be silently reused.
+		// Compare the leftmost leaf's stored (stale) EndByte against the
+		// freshly lexed lookahead's EndByte: if they differ, the subtree
+		// under n was built from a token boundary that doesn't exist in the
+		// new source, so reject reuse. Note we deliberately do NOT compare
+		// symbols here - the leaf's symbol can differ from the fresh
+		// lookahead's symbol even when reuse is unsafe, so a symbol check
+		// would miss the bug this guards against.
+		if leaf := leftmostLeaf(n); leaf == nil || leaf.EndByte() != lookahead.EndByte {
+			idx.rejectStaleNonLeafBoundary++
+			continue
+		}
 		nextState, truncateDepth, ok := p.reuseNonLeafTargetStateOnStack(s, n, lookahead.StartByte, entryScratch)
 		if !ok {
 			continue
@@ -683,6 +704,24 @@ func (p *Parser) reuseTargetState(state StateID, n *Node, lookahead Token) (Stat
 		}
 	}
 	return gotoState, true
+}
+
+// leftmostLeaf returns the leftmost leaf (childless) descendant of n. A
+// node's span always starts where its first child's span starts, so this
+// walks child index 0 down through the tree; the result shares n's
+// StartByte. Returns nil if n is nil or a leftmost leaf cannot be reached
+// (e.g. materialization fails).
+func leftmostLeaf(n *Node) *Node {
+	for n != nil && n.ChildCount() > 0 {
+		child := nodeChildAtForReason(n, 0, materializeForEdit)
+		if child == n {
+			// Defensive: avoid an infinite loop on a malformed self-referential
+			// child link.
+			return nil
+		}
+		n = child
+	}
+	return n
 }
 
 func reuseStackDepthForPreGoto(entries []stackEntry, startByte uint32, preGoto StateID) int {

--- a/parser.go
+++ b/parser.go
@@ -1145,6 +1145,7 @@ type IncrementalParseProfile struct {
 	ReuseRejectOutOfBounds              uint64
 	ReuseRejectRootNonLeafChanged       uint64
 	ReuseRejectLargeNonLeaf             uint64
+	ReuseRejectStaleNonLeafBoundary     uint64
 	RecoverSearches                     uint64
 	RecoverStateChecks                  uint64
 	RecoverStateSkips                   uint64
@@ -1241,6 +1242,7 @@ type incrementalParseTiming struct {
 	reuseRejectOutOfBounds              uint64
 	reuseRejectRootNonLeafChanged       uint64
 	reuseRejectLargeNonLeaf             uint64
+	reuseRejectStaleNonLeafBoundary     uint64
 	recoverSearches                     uint64
 	recoverStateChecks                  uint64
 	recoverStateSkips                   uint64
@@ -2889,6 +2891,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 			timing.reuseRejectOutOfBounds += reuse.rejectOutOfBounds
 			timing.reuseRejectRootNonLeafChanged += reuse.rejectRootNonLeafChanged
 			timing.reuseRejectLargeNonLeaf += reuse.rejectLargeNonLeaf
+			timing.reuseRejectStaleNonLeafBoundary += reuse.rejectStaleNonLeafBoundary
 		}
 		if timing != nil {
 			reuseStart := time.Now()

--- a/parser_incremental_support.go
+++ b/parser_incremental_support.go
@@ -53,6 +53,7 @@ func (t *incrementalParseTiming) toProfile() IncrementalParseProfile {
 		ReuseRejectOutOfBounds:              t.reuseRejectOutOfBounds,
 		ReuseRejectRootNonLeafChanged:       t.reuseRejectRootNonLeafChanged,
 		ReuseRejectLargeNonLeaf:             t.reuseRejectLargeNonLeaf,
+		ReuseRejectStaleNonLeafBoundary:     t.reuseRejectStaleNonLeafBoundary,
 		RecoverSearches:                     t.recoverSearches,
 		RecoverStateChecks:                  t.recoverStateChecks,
 		RecoverStateSkips:                   t.recoverStateSkips,
@@ -154,6 +155,7 @@ func (t *incrementalParseTiming) addAttempt(other *incrementalParseTiming) {
 	t.reuseRejectOutOfBounds += other.reuseRejectOutOfBounds
 	t.reuseRejectRootNonLeafChanged += other.reuseRejectRootNonLeafChanged
 	t.reuseRejectLargeNonLeaf += other.reuseRejectLargeNonLeaf
+	t.reuseRejectStaleNonLeafBoundary += other.reuseRejectStaleNonLeafBoundary
 	t.recoverSearches += other.recoverSearches
 	t.recoverStateChecks += other.recoverStateChecks
 	t.recoverStateSkips += other.recoverStateSkips


### PR DESCRIPTION
## Summary

Fixes a bug in incremental parsing where reused subtrees kept stale lexical
token boundaries after edits that shifted them. Two parallel reuse paths in
`tryReuseSubtree` shared the same underlying defect and are both fixed here:

- **Leaf reuse** (`reuseTargetState`'s leaf branch): a cached leaf could be
  reused even though a fresh lexer at the same start byte produces a token
  with a different end byte (e.g. a maximal-munch decision that depended on
  bytes at/after the leaf's old right edge no longer holding under the new
  source).
- **Non-leaf reuse** (`reuseNonLeafTargetStateOnStack`, called from the
  "conservative fallback" loop in `tryReuseSubtree`): a cached non-terminal
  is reused purely via `lookupGoto(preGoto, n.Symbol())` plus stack-depth
  matching. That check never consults the lookahead token at all -- no
  symbol check, no end-byte check -- so a grammar with a thin single-token
  wrapper non-terminal (e.g. Clojure `sym_lit -> sym_name`) could still reuse
  a stale subtree after an abutting edit, even with the leaf-branch fix in
  place.

Both reuses would leave the parser resuming lexing at a stale token
boundary, re-splitting merged tokens (or otherwise mis-tokenizing) and
producing an incremental tree that diverges from a fresh parse of the same
source -- typically manifesting as a spurious `ERROR` node.

## Changes

- Add `EndByte` validation in `reuseTargetState`'s leaf branch to reject
  stale leaves when fresh lexing produces different token boundaries.
- Add a matching guard in the non-leaf fallback loop (`tryReuseSubtree`):
  before calling `reuseNonLeafTargetStateOnStack`, walk to the candidate
  node's leftmost leaf (`leftmostLeaf`, new helper) and reject reuse when
  that leaf's stored `EndByte` differs from the freshly lexed lookahead's
  `EndByte`. The comparison is boundary-only (start byte is already
  guaranteed equal by construction, since `tryReuseSubtree` selects
  candidates by matching start byte) and deliberately does **not** compare
  symbols: the leftmost leaf's symbol can differ from the fresh lookahead's
  symbol even when reuse is unsafe, so a symbol-equality check would miss
  the bug.
- Add a `rejectStaleNonLeafBoundary` counter (mirroring the existing
  `rejectLargeNonLeaf` etc.) so this rejection reason is visible in
  `IncrementalParseProfile`.
- Add Clojure regression tests
  (`grammars/clojure_incremental_abutting_nonleaf_boundary_test.go`)
  covering the non-leaf class across 6 abutting-edit shapes (`(a b)`, `[a b]`,
  `{a b}`, `(foo bar)`, `a b c`, `a b\n`, each with the space deleted) plus an
  insert-reverse direction, all with full per-node byte-span assertions (not
  just `SExpr` string equality).
- Add a shared `assertIncrementalMatchesFreshFullSpan` test helper
  (`grammars/d12b_incremental_span_helpers_test.go`) that performs a full
  recursive per-node comparison (symbol, byte span, error flag, child count)
  between an incremental tree and a fresh parse, and use it to strengthen the
  existing Scheme tests -- the original `TestD12bReproSchemeAbutInsertReverse`
  only checked `SExpr` string equality, which can miss a stale reused subtree
  that renders the same text with different underlying spans.

## Testing

- `go test ./grammars -run 'TestD12bReproSchemeAbut|TestD12bClojureAbutting' -v`
  to verify all leaf + non-leaf regression tests pass.
- `go test . ./grammars/...`: green.
- Broad abutting-delete sweep (ad hoc, not checked in): every single-byte
  deletion position across 17 grammars (swift, c, json, csharp, java, kotlin,
  html, fortran, bash, python, ruby, css, go, rust, javascript, typescript,
  tsx), comparing incremental vs. fresh output with full per-node span
  checks. Before this fix: 1120 divergent positions. After: 1107 -- the
  non-leaf guard fixed 12 previously-divergent Java positions and 1
  previously-divergent TSX position, and introduced **zero** new
  divergences anywhere (exact same-position diff, confirmed by set
  comparison).

## Scope

This now covers the **complete** stale-token-boundary-reuse defect class
described above: both the leaf reuse path (`reuseTargetState`) and the
non-leaf fallback reuse path (`reuseNonLeafTargetStateOnStack`). The
previous revision of this PR only covered the leaf branch.

The campaign witness `same_line_length_change` is **not** in this defect
class -- it is an unrelated GLR merge-cap non-monotonicity artifact
(`parser_retry.go`) and is unaffected by this change. This PR does not claim
to address it.

## Verification

- `go build ./...` and `go vet ./...`: clean.
- New regression tests pass, including the sanity check that they fail
  without the corresponding guard (leaf guard removed -> Scheme tests fail;
  non-leaf guard removed -> Clojure tests fail).
- `go test .` and `go test ./grammars/...`: green.
- `GTS_CANONICAL_GO_INCREMENTAL=1 GTS_PARITY_ALLOW_HOST=1 go test . -tags treesitter_c_parity -run TestCanonicalGoIncrementalParity` (cgo C-oracle parity): all 13 edit directions across the 7 canonical cases pass with `status=parity`; classifications and digests are byte-identical to a baseline run on unmodified `origin/main` (zero regressions, exact-match diff of both receipts).
- Broad abutting-delete sweep across 17 grammars (see Testing above): zero
  new divergences vs. pre-fix baseline; 13 previously-divergent positions
  fixed (12 Java, 1 TSX).
- Zero-alloc fast paths preserved: `BenchmarkGoParseIncrementalNoEditDFA` and
  `BenchmarkGoParseIncrementalSingleByteEditDFA` both report `0 allocs/op`
  post-fix (measured `-benchmem -count=3`, consistent with the pre-fix
  baseline's small B/op measurement noise).
