### PR TITLE
refactor(glr): change glrStack parameters to pointers

### DIFF
--- a/glr_test.go
+++ b/glr_test.go
@@ -2363,10 +2363,10 @@ func TestCompareAcceptedStackAliasPreferenceIncludesCompactRefs(t *testing.T) {
 	aliasLeaf := newCompactFullLeafInArena(arena, 2, true, 0, 1, Point{}, Point{Column: 1})
 	normalStack := glrStack{entries: []stackEntry{newStackEntryNode(1, normalLeaf)}}
 	aliasStack := glrStack{entries: []stackEntry{newStackEntryCompactFullLeaf(1, aliasLeaf)}}
-	if got := compareAcceptedStackAliasPreference(parser, arena, aliasStack, normalStack); got != 1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &aliasStack, &normalStack); got != 1 {
 		t.Fatalf("compact alias preference = %d, want 1", got)
 	}
-	if got := compareAcceptedStackAliasPreference(parser, arena, normalStack, aliasStack); got != -1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &normalStack, &aliasStack); got != -1 {
 		t.Fatalf("reverse compact alias preference = %d, want -1", got)
 	}
 
@@ -2374,7 +2374,7 @@ func TestCompareAcceptedStackAliasPreferenceIncludesCompactRefs(t *testing.T) {
 	aliasParent := newPendingParentInArena(arena, 3, true, 0, []stackEntry{newStackEntryCompactFullLeaf(1, aliasLeaf)}, 0, 1, Point{}, Point{Column: 1}, false)
 	parentNormalStack := glrStack{entries: []stackEntry{newStackEntryNode(2, normalParent)}}
 	parentAliasStack := glrStack{entries: []stackEntry{newStackEntryPendingParent(2, aliasParent)}}
-	if got := compareAcceptedStackAliasPreference(parser, arena, parentAliasStack, parentNormalStack); got != 1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &parentAliasStack, &parentNormalStack); got != 1 {
 		t.Fatalf("pending alias preference = %d, want 1", got)
 	}
 }
@@ -2400,10 +2400,10 @@ func TestCompareAcceptedStackAliasPreferenceIncludesGSSCompactRefs(t *testing.T)
 	aliasGSSStack := glrStack{
 		gss: buildGSSStack([]stackEntry{{state: 0}, newStackEntryCompactFullLeaf(1, aliasLeaf)}, &scratch),
 	}
-	if got := compareAcceptedStackAliasPreference(parser, arena, aliasGSSStack, normalStack); got != 1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &aliasGSSStack, &normalStack); got != 1 {
 		t.Fatalf("gss compact alias preference = %d, want 1", got)
 	}
-	if got := compareAcceptedStackAliasPreference(parser, arena, normalStack, aliasGSSStack); got != -1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &normalStack, &aliasGSSStack); got != -1 {
 		t.Fatalf("reverse gss compact alias preference = %d, want -1", got)
 	}
 
@@ -2415,7 +2415,7 @@ func TestCompareAcceptedStackAliasPreferenceIncludesGSSCompactRefs(t *testing.T)
 	parentAliasGSS := glrStack{
 		gss: buildGSSStack([]stackEntry{{state: 0}, newStackEntryPendingParent(2, aliasParent)}, &scratch),
 	}
-	if got := compareAcceptedStackAliasPreference(parser, arena, parentAliasGSS, parentNormalGSS); got != 1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &parentAliasGSS, &parentNormalGSS); got != 1 {
 		t.Fatalf("gss pending alias preference = %d, want 1", got)
 	}
 	if got := arena.compactFullLeafMaterialized; got != 0 {
@@ -2460,7 +2460,7 @@ func TestCompareAcceptedStackAliasPreferencePreservesGSSResultOrder(t *testing.T
 			newStackEntryCompactFullLeaf(2, topAlias),
 		}, &scratch),
 	}
-	if got := compareAcceptedStackAliasPreference(parser, arena, preferBottomStack, preferTopStack); got != 1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &preferBottomStack, &preferTopStack); got != 1 {
 		t.Fatalf("gss alias preference order = %d, want 1", got)
 	}
 }
@@ -2493,7 +2493,7 @@ func TestCompareAcceptedStackAliasPreferenceKeepsWideNodeFallback(t *testing.T) 
 	}
 	aStack := glrStack{gss: buildGSSStack(aEntries, &scratch)}
 	bStack := glrStack{gss: buildGSSStack(bEntries, &scratch)}
-	if got := compareAcceptedStackAliasPreference(parser, arena, aStack, bStack); got != 1 {
+	if got := compareAcceptedStackAliasPreference(parser, arena, &aStack, &bStack); got != 1 {
 		t.Fatalf("wide node alias preference = %d, want 1", got)
 	}
 }

--- a/parser_result.go
+++ b/parser_result.go
@@ -552,14 +552,14 @@ func stackCompareForResultSelectionWithRawShape(p *Parser, arena *nodeArena, a, 
 		}
 		return -1
 	}
-	if cmp := compareAcceptedStackAliasPreference(p, arena, *a, *b); cmp != 0 {
+	if cmp := compareAcceptedStackAliasPreference(p, arena, a, b); cmp != 0 {
 		return cmp
 	}
-	if cmp := compareAcceptedStackTreeOrderPreference(p, arena, *a, *b); cmp != 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(p, arena, a, b); cmp != 0 {
 		return cmp
 	}
 	if useRawShape {
-		if cmp := compareAcceptedStackRawShapePreference(p, arena, *a, *b); cmp != 0 {
+		if cmp := compareAcceptedStackRawShapePreference(p, arena, a, b); cmp != 0 {
 			return cmp
 		}
 	}
@@ -597,7 +597,7 @@ func stackCompareForResultSelectionWithRawShape(p *Parser, arena *nodeArena, a, 
 // does not count descendants. It only compares candidates whose top-level
 // result entries have identical envelopes, and it only prefers a sibling-spliced
 // tree when both sides preserve a concrete shared prefix.
-func compareAcceptedStackTreeOrderPreference(p *Parser, arena *nodeArena, a, b glrStack) int {
+func compareAcceptedStackTreeOrderPreference(p *Parser, arena *nodeArena, a, b *glrStack) int {
 	if !a.accepted || !b.accepted {
 		return 0
 	}
@@ -1011,7 +1011,7 @@ func computeStackEntryErrorRank(entry stackEntry, arena *nodeArena) int {
 	return rank
 }
 
-func compareAcceptedStackAliasPreference(p *Parser, arena *nodeArena, a, b glrStack) int {
+func compareAcceptedStackAliasPreference(p *Parser, arena *nodeArena, a, b *glrStack) int {
 	if p == nil || p.language == nil {
 		return 0
 	}
@@ -1046,7 +1046,7 @@ func compareAcceptedStackAliasPreference(p *Parser, arena *nodeArena, a, b glrSt
 	return 0
 }
 
-func compareAcceptedStackNodeAliasPreference(p *Parser, arena *nodeArena, a, b glrStack) int {
+func compareAcceptedStackNodeAliasPreference(p *Parser, arena *nodeArena, a, b *glrStack) int {
 	aNodes := resultNodesFromStack(a)
 	bNodes := resultNodesFromStack(b)
 	if len(aNodes) != len(bNodes) {
@@ -1111,7 +1111,7 @@ func stackEntryHasCompactResultPayload(entry stackEntry) bool {
 	return stackEntryCompactFullLeaf(entry) != nil || stackEntryPendingParent(entry) != nil
 }
 
-func stackHasCompactResultPayload(s glrStack) bool {
+func stackHasCompactResultPayload(s *glrStack) bool {
 	if len(s.entries) > 0 {
 		for i := range s.entries {
 			if stackEntryHasCompactResultPayload(s.entries[i]) {
@@ -1128,7 +1128,7 @@ func stackHasCompactResultPayload(s glrStack) bool {
 	return false
 }
 
-func stackMaterializingResultEntryCount(s glrStack) int {
+func stackMaterializingResultEntryCount(s *glrStack) int {
 	if len(s.entries) > 0 {
 		return countMaterializingResultEntries(s.entries)
 	}
@@ -1144,7 +1144,7 @@ func stackMaterializingResultEntryCount(s glrStack) int {
 	return count
 }
 
-func stackMaterializingResultEntries(s glrStack, dst []stackEntry, materializingCount int) ([]stackEntry, bool) {
+func stackMaterializingResultEntries(s *glrStack, dst []stackEntry, materializingCount int) ([]stackEntry, bool) {
 	if materializingCount == 0 || cap(dst) < materializingCount {
 		return nil, false
 	}
@@ -1177,7 +1177,7 @@ func stackMaterializingResultEntries(s glrStack, dst []stackEntry, materializing
 	return dst, index == -1
 }
 
-func resultNodesFromStack(s glrStack) []*Node {
+func resultNodesFromStack(s *glrStack) []*Node {
 	if len(s.entries) > 0 {
 		count := 0
 		for i := range s.entries {

--- a/raw_shape.go
+++ b/raw_shape.go
@@ -460,7 +460,7 @@ func setStackEntryRawShapeRef(entry *stackEntry, ref rawShapeRef) {
 	}
 }
 
-func compareAcceptedStackRawShapePreference(p *Parser, arena *nodeArena, a, b glrStack) int {
+func compareAcceptedStackRawShapePreference(p *Parser, arena *nodeArena, a, b *glrStack) int {
 	if !a.accepted || !b.accepted || arena == nil {
 		return 0
 	}

--- a/raw_shape_diag.go
+++ b/raw_shape_diag.go
@@ -51,7 +51,7 @@ func (p *Parser) emitRawShapeDiag(phase string, stacks []glrStack, arena *nodeAr
 		if !s.accepted {
 			continue
 		}
-		entries, total := rawShapeDiagResultEntries(*s, childLimit)
+		entries, total := rawShapeDiagResultEntries(s, childLimit)
 		fmt.Fprintf(os.Stderr, "GLR-RAW-SHAPE stack=%d accepted=%t dead=%t state=%d byte=%d depth=%d score=%d dyn=%d err_rank=%d roots=%d roots_emitted=%d\n",
 			i,
 			s.accepted,
@@ -81,7 +81,7 @@ func rawShapeDiagStackState(s *glrStack) StateID {
 	return s.top().state
 }
 
-func rawShapeDiagResultEntries(s glrStack, limit int) ([]stackEntry, int) {
+func rawShapeDiagResultEntries(s *glrStack, limit int) ([]stackEntry, int) {
 	if limit <= 0 {
 		limit = defaultRawShapeDiagChildLimit
 	}

--- a/raw_shape_test.go
+++ b/raw_shape_test.go
@@ -169,7 +169,7 @@ func TestAcceptedStackRawShapeDoesNotOverrideDistinctMaterializedRoot(t *testing
 		branchOrder: 7,
 		entries:     []stackEntry{callEntry},
 	}
-	if cmp := compareAcceptedStackRawShapePreference(parser, arena, laterCall, earlierMacro); cmp <= 0 {
+	if cmp := compareAcceptedStackRawShapePreference(parser, arena, &laterCall, &earlierMacro); cmp <= 0 {
 		t.Fatalf("accepted raw-shape compare(call, macro) = %d, want later call raw-shape preferred in the full-root ordering", cmp)
 	}
 	if cmp := stackCompareForResultSelection(parser, arena, &laterCall, &earlierMacro, false); cmp <= 0 {
@@ -698,13 +698,13 @@ func TestAcceptedStackSelectionPrefersSharedPrefixSpliceBeforeRawShape(t *testin
 		entries:     []stackEntry{newStackEntryNode(1, splicedRoot)},
 	}
 
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, wrapped, spliced); cmp >= 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &wrapped, &spliced); cmp >= 0 {
 		t.Fatalf("tree-order compare(wrapped, spliced) = %d, want wrapped loser", cmp)
 	}
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, spliced, wrapped); cmp <= 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &spliced, &wrapped); cmp <= 0 {
 		t.Fatalf("tree-order compare(spliced, wrapped) = %d, want spliced winner", cmp)
 	}
-	if cmp := compareAcceptedStackRawShapePreference(parser, arena, wrapped, spliced); cmp <= 0 {
+	if cmp := compareAcceptedStackRawShapePreference(parser, arena, &wrapped, &spliced); cmp <= 0 {
 		t.Fatalf("raw-shape compare(wrapped, spliced) = %d, want wrapped raw shape winner before result-selection override", cmp)
 	}
 	if cmp := stackCompareForResultSelection(parser, arena, &spliced, &wrapped, false); cmp <= 0 {
@@ -767,10 +767,10 @@ func TestAcceptedStackSelectionDoesNotSpliceVisibleNamedStructuralContainer(t *t
 		entries:     []stackEntry{newStackEntryNode(1, splicedRoot)},
 	}
 
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, wrapped, spliced); cmp != 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &wrapped, &spliced); cmp != 0 {
 		t.Fatalf("tree-order compare(wrapped, spliced) = %d, want neutral when splice would remove section", cmp)
 	}
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, spliced, wrapped); cmp != 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &spliced, &wrapped); cmp != 0 {
 		t.Fatalf("tree-order compare(spliced, wrapped) = %d, want neutral when splice would remove section", cmp)
 	}
 	if cmp := stackCompareForResultSelection(parser, arena, &wrapped, &spliced, false); cmp <= 0 {
@@ -884,10 +884,10 @@ func TestAcceptedStackTreeOrderPreservesVisibleNamedUnaryWrapper(t *testing.T) {
 		entries:     []stackEntry{newStackEntryNode(1, directRoot)},
 	}
 
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, directStack, wrapped); cmp != 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &directStack, &wrapped); cmp != 0 {
 		t.Fatalf("tree-order compare(direct, wrapped) = %d, want neutral for visible semantic wrapper", cmp)
 	}
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, wrapped, directStack); cmp != 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &wrapped, &directStack); cmp != 0 {
 		t.Fatalf("tree-order compare(wrapped, direct) = %d, want neutral for visible semantic wrapper", cmp)
 	}
 	if cmp := stackCompareForResultSelection(parser, arena, &wrapped, &directStack, false); cmp <= 0 {
@@ -946,7 +946,7 @@ func TestAcceptedStackTreeOrderPrefersDirectChildOverTransparentUnaryWrapperChai
 		entries:     []stackEntry{newStackEntryNode(1, directRoot)},
 	}
 
-	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, directStack, wrapped); cmp <= 0 {
+	if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &directStack, &wrapped); cmp <= 0 {
 		t.Fatalf("tree-order compare(direct, wrapped) = %d, want direct child winner", cmp)
 	}
 	if cmp := stackCompareForResultSelection(parser, arena, &directStack, &wrapped, false); cmp <= 0 {
@@ -990,13 +990,13 @@ func TestAcceptedStackTreeOrderDoesNotStripSemanticInvisibleWrappers(t *testing.
 
 			parser, wrapped, spliced := testSemanticInvisibleWrapperRawShapeStacks(t, arena, tt.configure)
 
-			if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, wrapped, spliced); cmp != 0 {
+			if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &wrapped, &spliced); cmp != 0 {
 				t.Fatalf("tree-order compare(wrapped, spliced) = %d, want neutral for semantic wrapper", cmp)
 			}
-			if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, spliced, wrapped); cmp != 0 {
+			if cmp := compareAcceptedStackTreeOrderPreference(parser, arena, &spliced, &wrapped); cmp != 0 {
 				t.Fatalf("tree-order compare(spliced, wrapped) = %d, want neutral for semantic wrapper", cmp)
 			}
-			if cmp := compareAcceptedStackRawShapePreference(parser, arena, wrapped, spliced); cmp <= 0 {
+			if cmp := compareAcceptedStackRawShapePreference(parser, arena, &wrapped, &spliced); cmp <= 0 {
 				t.Fatalf("raw-shape compare(wrapped, spliced) = %d, want semantic wrapper protected", cmp)
 			}
 			if cmp := stackCompareForResultSelection(parser, arena, &wrapped, &spliced, false); cmp <= 0 {


### PR DESCRIPTION
## Summary

Refactor GLR stack comparison and helper functions to accept `*glrStack` pointers instead of value copies. This eliminates unnecessary struct copies during result selection, alias preference checks, and raw shape diagnostics, reducing allocation overhead and aligning with Go best practices for large structs.

## Changes

- Convert `compareAcceptedStackAliasPreference`, `compareAcceptedStackTreeOrderPreference`, `compareAcceptedStackRawShapePreference`, and `compareAcceptedStackNodeAliasPreference` from `glrStack` values to `*glrStack` pointers.
- Update downstream helpers (`stackHasCompactResultPayload`, `stackMaterializingResultEntryCount`, `stackMaterializingResultEntries`, `resultNodesFromStack`, `rawShapeDiagResultEntries`) to accept pointers.
- Adjust `stackCompareForResultSelectionWithRawShape` and diagnostic emission to pass stack addresses directly.
- Update all test assertions in `glr_test.go` and `raw_shape_test.go` to pass pointers to the modified functions.

## Testing

- Run `go test -run 'TestCompareAcceptedStackAliasPreference|TestAcceptedStackRawShape|TestAcceptedStackSelection' ./...` to verify comparison logic remains correct.
- Check baseline against parity suites for the affected grammar to ensure result selection order is unchanged.