### PR TITLE
perf(parser): amortize compact scheduler rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ for tags and release notes while still in `0.x`.
 - Run the authenticated fresh compact scheduler as one fail-closed session,
   resetting the entire compact core after any error or panic instead of taking
   a rollback checkpoint for every successful operation. On the pinned quiet
-  host, the paired four-fixture candidate improves from 3.362496x to 3.129149x
-  static C by equal-fixture geomean (6.94%), with every fixture faster by
-  5.20-8.36%, exact static-C admission, and zero fallback. The compact route
+  host, the paired four-fixture candidate improves from 3.362496x to 3.118130x
+  static C by equal-fixture geomean (7.27%), with every fixture faster by
+  6.69-8.46%, exact static-C admission, and zero fallback. The compact route
   remains build-tagged and diagnostic-only.
 - Bypass general graph enumeration when a compact-parser reduction follows a
   single-link stack path, while retaining the existing enumerator for branched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Run the authenticated fresh compact scheduler as one fail-closed session,
+  resetting the entire compact core after any error or panic instead of taking
+  a rollback checkpoint for every successful operation. On the pinned quiet
+  host, the paired four-fixture candidate improves from 3.362496x to 3.129149x
+  static C by equal-fixture geomean (6.94%), with every fixture faster by
+  5.20-8.36%, exact static-C admission, and zero fallback. The compact route
+  remains build-tagged and diagnostic-only.
 - Bypass general graph enumeration when a compact-parser reduction follows a
   single-link stack path, while retaining the existing enumerator for branched
   paths and preserving its resource-limit checks. On the pinned quiet host,

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -593,6 +593,7 @@ type schedulerTransactionFrame struct {
 	epoch    uint64
 	poisoned error
 	active   bool
+	fresh    bool
 }
 
 // clearInactive releases every completed checkpoint reference, including the
@@ -713,10 +714,68 @@ func (c *Core) validateSchedulerTransaction(token SchedulerTransactionToken) err
 	if !frame.active || token.epoch == 0 || token.epoch != frame.epoch || token.transaction != frame.mark.transaction {
 		return errors.New("parser-core phase zero: stale scheduler transaction token")
 	}
+	if frame.fresh {
+		return nil
+	}
 	if len(c.transactions) == 0 || c.transactions[len(c.transactions)-1] != token.transaction {
 		return errors.New("parser-core phase zero: scheduler transaction token is not top-of-stack owner")
 	}
 	return nil
+}
+
+// RunFreshSchedulerSession authenticates one scheduler-owned run without
+// taking per-operation arena checkpoints. It is restricted to a core with no
+// active transaction. Successful runs keep their compact graph; any error or
+// panic resets the whole fresh core after invalidating the capability. The
+// session still poisons ignored owned-operation failures.
+func (c *Core) RunFreshSchedulerSession(fn func(SchedulerTransactionToken) error) (err error) {
+	frame := &c.schedulerFrame
+	if fn == nil {
+		err := errors.New("parser-core phase zero: nil fresh scheduler session")
+		if frame.active && frame.poisoned == nil {
+			frame.poisoned = err
+		}
+		return err
+	}
+	if frame.active {
+		err := errors.New("parser-core phase zero: nested fresh scheduler session")
+		if frame.poisoned == nil {
+			frame.poisoned = err
+		}
+		return err
+	}
+	if len(c.transactions) != 0 {
+		return errors.New("parser-core phase zero: fresh scheduler session inside active transaction")
+	}
+	if frame.epoch == math.MaxUint64 || c.nextTransaction == math.MaxUint64 {
+		return errors.New("parser-core phase zero: fresh scheduler session identity overflow")
+	}
+	frame.clearInactive()
+	frame.epoch++
+	c.nextTransaction++
+	frame.mark.transaction = c.nextTransaction
+	frame.active = true
+	frame.fresh = true
+	token := SchedulerTransactionToken{owner: c, epoch: frame.epoch, transaction: frame.mark.transaction}
+	defer func() {
+		recovered := recover()
+		if recovered != nil {
+			frame.clearInactive()
+			_ = c.Reset()
+			panic(recovered)
+		}
+		if err == nil && frame.poisoned != nil {
+			err = fmt.Errorf("parser-core phase zero: poisoned fresh scheduler session: %w", frame.poisoned)
+		}
+		frame.clearInactive()
+		if err != nil {
+			if resetErr := c.Reset(); resetErr != nil {
+				err = errors.Join(err, fmt.Errorf("parser-core phase zero: reset failed after fresh scheduler error: %w", resetErr))
+			}
+		}
+	}()
+	err = fn(token)
+	return err
 }
 
 func (c *Core) poisonSchedulerTransaction(token SchedulerTransactionToken, cause error) error {
@@ -778,6 +837,13 @@ func (c *Core) ApplySchedulerAtomic(fn func(SchedulerTransactionToken) error) (e
 		return err
 	}
 	frame := &c.schedulerFrame
+	if frame.active && frame.fresh {
+		token := SchedulerTransactionToken{owner: c, epoch: frame.epoch, transaction: frame.mark.transaction}
+		if err = fn(token); err != nil {
+			return c.poisonSchedulerTransaction(token, err)
+		}
+		return nil
+	}
 	if frame.active {
 		err := errors.New("parser-core phase zero: nested scheduler-owned transaction")
 		if frame.poisoned == nil {

--- a/internal/parsercorephase0/scheduler_transaction_test.go
+++ b/internal/parsercorephase0/scheduler_transaction_test.go
@@ -169,6 +169,133 @@ func TestSchedulerTransactionCommitAndRollback(t *testing.T) {
 	})
 }
 
+func TestFreshSchedulerSessionCommitAndResetContract(t *testing.T) {
+	compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+	var retained SchedulerTransactionToken
+	err := compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+		retained = owner
+		if len(compact.transactions) != 0 {
+			t.Fatalf("fresh session opened rollback transaction: %v", compact.transactions)
+		}
+		_, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{})
+		return err
+	})
+	if err != nil || compact.Work().Shifts != 1 || len(compact.transactions) != 0 {
+		t.Fatalf("fresh session commit err=%v work=%+v transactions=%v", err, compact.Work(), compact.transactions)
+	}
+	requireClearedSchedulerFrame(t, compact, retained.epoch)
+	if err := compact.Reset(); err != nil {
+		t.Fatalf("Reset after fresh session: %v", err)
+	}
+	requireClearedSchedulerFrame(t, compact, retained.epoch)
+}
+
+func TestFreshSchedulerSessionFailClosed(t *testing.T) {
+	t.Run("ignored-owned-error-poisons", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		err := compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+			if _, innerErr := compact.ShiftClassifiedOwned(owner, boundary, 1, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr == nil {
+				t.Fatal("invalid owned shift unexpectedly succeeded")
+			}
+			return nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "poisoned fresh scheduler session") {
+			t.Fatalf("ignored owned error did not poison fresh session: %v", err)
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+		if state := captureSchedulerTransactionState(compact); state.nodes != 0 || state.links != 0 || state.subtrees != 0 || state.work != (Work{}) {
+			t.Fatalf("failed fresh session retained published state: %+v", state)
+		}
+	})
+
+	t.Run("nested-session-poisons", func(t *testing.T) {
+		compact, _, _ := newSchedulerTransactionShiftFixture(t)
+		err := compact.RunFreshSchedulerSession(func(SchedulerTransactionToken) error {
+			if nestedErr := compact.RunFreshSchedulerSession(func(SchedulerTransactionToken) error { return nil }); nestedErr == nil {
+				t.Fatal("nested fresh session unexpectedly succeeded")
+			}
+			return nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "poisoned fresh scheduler session") {
+			t.Fatalf("ignored nested error did not poison fresh session: %v", err)
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+		if state := captureSchedulerTransactionState(compact); state.nodes != 0 || state.links != 0 || state.subtrees != 0 || state.work != (Work{}) {
+			t.Fatalf("nested fresh session retained published state: %+v", state)
+		}
+	})
+
+	t.Run("nested-nil-session-poisons", func(t *testing.T) {
+		compact, _, _ := newSchedulerTransactionShiftFixture(t)
+		err := compact.RunFreshSchedulerSession(func(SchedulerTransactionToken) error {
+			if nestedErr := compact.RunFreshSchedulerSession(nil); nestedErr == nil {
+				t.Fatal("nested nil fresh session unexpectedly succeeded")
+			}
+			return nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "poisoned fresh scheduler session") {
+			t.Fatalf("ignored nested nil error did not poison fresh session: %v", err)
+		}
+		requireClearedSchedulerFrame(t, compact, 1)
+		if state := captureSchedulerTransactionState(compact); state.nodes != 0 || state.links != 0 || state.subtrees != 0 || state.work != (Work{}) {
+			t.Fatalf("nested nil fresh session retained published state: %+v", state)
+		}
+	})
+
+	t.Run("panic-clears-capability", func(t *testing.T) {
+		compact, _, boundary := newSchedulerTransactionShiftFixture(t)
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != "fresh panic" {
+					t.Fatalf("recovered=%v", recovered)
+				}
+			}()
+			_ = compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+				if _, err := compact.ShiftClassifiedOwned(owner, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); err != nil {
+					return err
+				}
+				panic("fresh panic")
+			})
+		}()
+		requireClearedSchedulerFrame(t, compact, 1)
+		if state := captureSchedulerTransactionState(compact); state.nodes != 0 || state.links != 0 || state.subtrees != 0 || state.work != (Work{}) {
+			t.Fatalf("panicked fresh session retained published state: %+v", state)
+		}
+	})
+}
+
+func TestFreshSchedulerSessionRejectsRetainedToken(t *testing.T) {
+	compact, _, _ := newSchedulerTransactionShiftFixture(t)
+	var stale SchedulerTransactionToken
+	if err := compact.RunFreshSchedulerSession(func(owner SchedulerTransactionToken) error {
+		stale = owner
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary, err := compact.ClassifyBoundary(seed, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := captureSchedulerTransactionState(compact)
+	err = compact.ApplySchedulerAtomic(func(SchedulerTransactionToken) error {
+		if _, innerErr := compact.ShiftClassifiedOwned(stale, boundary, 0, Token{Symbol: 9, EndByte: 1}, ForkOrder{}); innerErr == nil || !strings.Contains(innerErr.Error(), "stale") {
+			t.Fatalf("retained fresh token error=%v", innerErr)
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "poisoned scheduler transaction") || !reflect.DeepEqual(captureSchedulerTransactionState(compact), before) {
+		t.Fatalf("retained fresh token did not fail closed: %v", err)
+	}
+}
+
 func TestSchedulerTransactionInsideStandaloneOwner(t *testing.T) {
 	t.Run("outer-rollback", func(t *testing.T) {
 		compact, _, boundary := newSchedulerTransactionShiftFixture(t)

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -52,6 +52,9 @@ type DiagnosticParserCorePrefixOptions struct {
 	MaxDispatches           uint64
 	MaxTokens               uint64
 	Limits                  core.Limits
+	// freshSchedulerSession is set only by the reusable fresh-full runner,
+	// which resets before every call and never exposes a declined core.
+	freshSchedulerSession bool
 }
 
 type DiagnosticParserCoreScannerCheckpoint struct {
@@ -1217,6 +1220,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	acceptedHead               core.Head
 	conflictPostExecutionFault func() error
 	extraPostExecutionFault    func() error
+	freshSessionOwner          *core.SchedulerTransactionToken
 	observer                   diagnosticParserCoreSeedObserver
 	stoppedAfterElection       bool
 }
@@ -1437,7 +1441,17 @@ func executeDiagnosticParserCoreGenericSchedulerFromSeed(
 		return nil, err
 	}
 	defer scheduler.headerRollbackScratch.reset()
-	if err := scheduler.run(); err != nil {
+	run := scheduler.run
+	if options.freshSchedulerSession {
+		run = func() error {
+			return compact.RunFreshSchedulerSession(func(owner core.SchedulerTransactionToken) error {
+				scheduler.freshSessionOwner = &owner
+				defer func() { scheduler.freshSessionOwner = nil }()
+				return scheduler.run()
+			})
+		}
+	}
+	if err := run(); err != nil {
 		return scheduler, err
 	}
 	return scheduler, nil
@@ -2071,6 +2085,9 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
+	if s.freshSessionOwner != nil {
+		return s.applyGenericReductionOwned(*s.freshSessionOwner, before, cell)
+	}
 	if err := s.headerRollbackScratch.begin(s.headers); err != nil {
 		return err
 	}
@@ -2214,6 +2231,9 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(s
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []DiagnosticParserCoreHeaderReceipt, cell diagnosticParserCoreGenericCell) (err error) {
+	if s.freshSessionOwner != nil {
+		return s.applyGenericConflictOwned(*s.freshSessionOwner, before, cell)
+	}
 	if err := s.headerRollbackScratch.begin(s.headers); err != nil {
 		return err
 	}
@@ -2405,6 +2425,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 }
 
 func (s *diagnosticParserCoreGenericScheduler) applyGenericShifts(before []DiagnosticParserCoreHeaderReceipt, cells []diagnosticParserCoreGenericCell) (err error) {
+	if s.freshSessionOwner != nil {
+		return s.applyGenericShiftsOwned(*s.freshSessionOwner, before, cells)
+	}
 	if err := s.headerRollbackScratch.begin(s.headers); err != nil {
 		return err
 	}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -51,6 +51,7 @@ func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticPar
 	if options.MaxTokens == 0 {
 		options.MaxTokens = 100000
 	}
+	options.freshSchedulerSession = true
 
 	lang, err := authenticatedParserCoreGoLanguage(scanner)
 	if err != nil {
@@ -89,11 +90,11 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	)
 	if err != nil {
 		tokenSource.Close()
-		return scheduler, nil, err
+		return nil, nil, err
 	}
 	if err := requireParserCoreFreshFullAcceptance(scheduler, len(source)); err != nil {
 		tokenSource.Close()
-		return scheduler, nil, err
+		return nil, nil, err
 	}
 	return scheduler, tokenSource, nil
 }


### PR DESCRIPTION
## Summary

- run the authenticated fresh compact scheduler as one fail-closed session
- reset the complete compact core on errors and panics while retaining per-operation rollback for generic diagnostics
- add capability, poison, panic, reset, cap, and stale-token coverage

## Validation

- `go test ./internal/parsercorephase0 -count=1`
- `go test -tags gts_parsercorephase0 . -count=1`
- locked static-C deep admission: pass
- authenticated candidate: 3.118130x C geomean, 3.169740x suite sum, 3.185522x worst fixture
- paired current-main control: 3.362496x C geomean
- every fixture improved by 6.69-8.46%; compact work unchanged; zero fallback

The compact route remains build-tagged and diagnostic-only.
