### PR TITLE
release: publish v0.41.0

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -574,6 +574,43 @@ The support boundary remains unchanged: this is a diagnostic clean fresh-full
 Go candidate, not a public `Parser.Parse`, recovery, incremental,
 included-range, query/cursor, or multi-grammar claim.
 
+### Fresh compact scheduler session publication
+
+A clean candidate publication was collected on 2026-07-18 from quiet host
+`ns1007492`, pinned to its least-busy admitted CPU with Go 1.22.2, at exact
+revision `19a8f5265d158703ba1465687178a2adf527a372`. It uses the same locked
+static `-O2` oracle and passed cgo/static deep admission before five Go-C-C-Go
+cycles produced ten samples per backend and fixture.
+
+The build-tagged `AUTHENTICATED_CANDIDATE` reports:
+
+| Fixture | Candidate median | static C median | Candidate / C | B/op | allocs/op | Candidate max RSS | C max RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `query_compile.go` | 17.573 ms | 5.516 ms | **3.185522x** | 230,909 | 9,030 | 46,948 KiB | 2,816 KiB |
+| `rewrite.go` | 3.621 ms | 1.203 ms | **3.010150x** | 55,897 | 1,935 | 50,644 KiB | 2,304 KiB |
+| `language.go` | 18.053 ms | 5.820 ms | **3.101863x** | 274,543 | 9,279 | 57,820 KiB | 2,816 KiB |
+| `grammargen/lr.go` | 187.140 ms | 58.882 ms | **3.178231x** | 2,414,818 | 91,201.5 | 96,336 KiB | 9,216 KiB |
+
+The equal-fixture geomean is **3.118130x C**, the fixed-suite sum of medians
+is **3.169740x C**, and every fixture is below 3.19x C. The paired same-session
+control measured 3.362496x C, so the fresh-session change improves the suite
+geomean by **7.27%**, with every fixture improving by 6.69-8.46%. Exact static-C
+admission, compact work signatures, and zero fallback remained unchanged.
+
+Receipt identities:
+
+- manifest/report/archive SHA-256:
+  `66242c222f60cafbbd4b1cf3b4deebd571e772f5c9f9981ef2aa17bbca404ed5`,
+  `3eb7accb7f227d426f7ecb38b7480ebadda6561a264ee0e013f66833dbd29f4e`,
+  `97c44e56600d60e6d8665c74e75f2da3dedf0347a009ed388634d79f16a938df`;
+- locked static C artifact SHA-256:
+  `dfbed45811491be8d81e32b293ed5577222445dae47b67d876cedae09679a871`.
+
+The support boundary remains diagnostic and unchanged: clean fresh-full Go,
+visible deep-tree structure, and exact work counts—not public `Parser.Parse`,
+recovery, incremental reuse, included ranges, query/cursor behavior, or
+multiple grammars.
+
 ### Diagnostic workload-regime receipt
 
 Before the static publication artifact was built, a strict-admitted quiet run

--- a/BENCH.md
+++ b/BENCH.md
@@ -592,10 +592,10 @@ The build-tagged `AUTHENTICATED_CANDIDATE` reports:
 | `grammargen/lr.go` | 187.140 ms | 58.882 ms | **3.178231x** | 2,414,818 | 91,201.5 | 96,336 KiB | 9,216 KiB |
 
 The equal-fixture geomean is **3.118130x C**, the fixed-suite sum of medians
-is **3.169740x C**, and every fixture is below 3.19x C. The paired same-session
-control measured 3.362496x C, so the fresh-session change improves the suite
-geomean by **7.27%**, with every fixture improving by 6.69-8.46%. Exact static-C
-admission, compact work signatures, and zero fallback remained unchanged.
+is **3.169740x C**, and every fixture is below 3.19x C. Exact static-C
+admission, compact work signatures, and zero fallback remained unchanged. This
+publication does not claim a paired per-change speedup: its diagnostic control
+used a different CPU, cycle count, and admission mode.
 
 Receipt identities:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ for tags and release notes while still in `0.x`.
 
 - Run the authenticated fresh compact scheduler as one fail-closed session,
   resetting the entire compact core after any error or panic instead of taking
-  a rollback checkpoint for every successful operation. On the pinned quiet
-  host, the paired four-fixture candidate improves from 3.362496x to 3.118130x
-  static C by equal-fixture geomean (7.27%), with every fixture faster by
-  6.69-8.46%, exact static-C admission, and zero fallback. The compact route
-  remains build-tagged and diagnostic-only.
+  a rollback checkpoint for every successful operation. Its clean pinned-host
+  publication measures 3.118130x static C by equal-fixture geomean, 3.169740x
+  by fixed-suite sum, and 3.185522x on the worst fixture, with exact static-C
+  admission and zero fallback. The compact route remains build-tagged and
+  diagnostic-only.
 - Bypass general graph enumeration when a compact-parser reduction follows a
   single-link stack path, while retaining the existing enumerator for branched
   paths and preserving its resource-limit checks. On the pinned quiet host,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-07-18
+
 ### Performance
 
 - Run the authenticated fresh compact scheduler as one fail-closed session,
@@ -2890,7 +2892,10 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.38.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.41.0...HEAD
+[0.41.0]: https://github.com/odvcencio/gotreesitter/compare/v0.40.0...v0.41.0
+[0.40.0]: https://github.com/odvcencio/gotreesitter/compare/v0.39.0...v0.40.0
+[0.39.0]: https://github.com/odvcencio/gotreesitter/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/odvcencio/gotreesitter/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/odvcencio/gotreesitter/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/odvcencio/gotreesitter/compare/v0.34.0...v0.36.0

--- a/README.md
+++ b/README.md
@@ -390,8 +390,8 @@ A strict v0.40.0 production receipt at `1935a42c` measures public
 `Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x C**
 by fixed-suite sum of medians, with a **5.608320x C** worst fixture. The latest
 clean publication of the separately build-tagged, fail-closed compact
-candidate, at `0062fe35`, measures **3.378660x C** and **3.392365x C**,
-respectively, with every fixture below **3.51x C** and zero timed fallbacks.
+candidate, at `19a8f526`, measures **3.118130x C** and **3.169740x C**,
+respectively, with every fixture below **3.19x C** and zero timed fallbacks.
 That candidate result is diagnostic: it authenticates visible
 `gts-deep-tree-v1` structure for the four clean fresh-full fixtures, not
 parser-state metadata, recovery, incremental reuse, included ranges, or public
@@ -711,16 +711,21 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.40.0**, which lands build-time PGO, forest-index
-allocation pooling, GLR comparator copy elimination, forest-reducer pooling, a
-query-matcher work-budget guard, and an incremental-reuse token-boundary fix.
+The current release is **v0.41.0**. It banks the post-v0.40 correctness and
+tooling tranche plus five exact, build-tagged compact-parser performance wins.
+Those diagnostic improvements keep the public parser unchanged while reducing
+the authenticated compact candidate to **3.118130x C** by equal-fixture
+geomean, **3.169740x C** by fixed-suite sum, and **3.185522x C** on its worst
+fixture, with zero timed fallback. The release also includes build-time PGO,
+forest-path pooling and copy elimination, query work budgeting, and incremental
+reuse boundary corrections merged after the v0.40.0 tag.
 The authenticated production receipt at tag target `1935a42c` measures public
 `Parser.Parse` at **4.851050x C** by equal-fixture geomean, **5.472406x C** by
 fixed-suite sum, and **5.608320x C** on the worst fixture against the locked
 static `-O2` C oracle. Its 0.716% geomean improvement over v0.39.0 is below the
-reproducible 2% win threshold. The build-tagged compact candidate at
-`0062fe35` measures **3.378660x C** on its narrower authenticated fresh-full
-surface with zero timed fallback, but remains outside public `Parser.Parse`.
+reproducible 2% win threshold. The latest build-tagged compact candidate,
+measured at `19a8f526`, remains outside public `Parser.Parse` despite its lower
+authenticated ratio.
 The 206-grammar curated parity milestone is banked, the invalid historical
 1.895x headline remains withdrawn, and the incremental matrix is a
 correctness/work-classification receipt rather than a representative

--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ the authenticated compact candidate to **3.118130x C** by equal-fixture
 geomean, **3.169740x C** by fixed-suite sum, and **3.185522x C** on its worst
 fixture, with zero timed fallback. The release also includes build-time PGO,
 forest-path pooling and copy elimination, query work budgeting, and incremental
-reuse boundary corrections merged after the v0.40.0 tag.
+reuse boundary corrections from the v0.40.0 line.
 The authenticated production receipt at tag target `1935a42c` measures public
 `Parser.Parse` at **4.851050x C** by equal-fixture geomean, **5.472406x C** by
 fixed-suite sum, and **5.608320x C** on the worst fixture against the locked


### PR DESCRIPTION
## Summary

- publish the accumulated post-v0.40 correctness, tooling, and performance work as v0.41.0
- document the authenticated fresh compact scheduler receipt
- repair changelog comparison links for v0.39.0 and v0.40.0

## Validation

- `git diff --check`
- `mdpp lint README.md BENCH.md`
- `mdpp lint CHANGELOG.md` (existing duplicate-section heading warnings only)
- exact receipt values re-read from the clean quiet-host artifact
