### PR TITLE
perf(parser): add compact selected-tree materialization

### DIFF
--- a/BENCH.md
+++ b/BENCH.md
@@ -530,7 +530,7 @@ four clean fresh-full Go fixtures and visible deep-tree structure, not public
 `Parser.Parse`, recovery, incremental reuse, included ranges, parser-state
 metadata, query/cursor behavior, or multiple grammars.
 
-### Pre-review direct selected-store boundary board (superseded)
+### Direct selected-store boundary receipt
 
 The next diagnostic boundary removes public-node materialization from the
 opt-in compact consumer without changing the public-node control. Acceptance
@@ -542,28 +542,29 @@ public route never constructs that store. The store is readable after
 release. Cancellation, occurrence count, retained bytes, unsupported policy,
 precedence overflow, and root identity all fail closed.
 
-This board predates the final lifecycle review. It is retained only as a
-directional experiment and is **not publication evidence**: the reviewed
-implementation now creates unary policy metadata lazily, pools record and
-child backing as one synchronized capped pair, preflights root-extra growth,
-and releases the store on every post-build validation failure. A new locked-C
-publication is required after those corrections pass review.
+The reviewed lifecycle creates unary policy metadata lazily, polls cancellation
+before that width-squared construction, pools record and child backing as one
+synchronized capped pair, preflights root-extra growth, rejects non-extra
+sibling roots, and releases the store on every post-build validation failure.
+The record deliberately omits parser-state and pre-goto-state metadata.
 
-A balanced A-B-B-A board ran on 2026-07-18 on `ns1007492`, CPU 2, with Go
-1.22.2, `GOMAXPROCS=1`, 20 samples per lane and fixture, and 750 ms samples.
-The control is the post-#366 public-node lifecycle; the candidate includes
-selected-store sealing, a complete cursor traversal, and release.
+The exact reviewed revision `ba1ed1bf5e2e50e6125fbf1d66ea9fdbb8320bed`
+first passed a balanced A-B-B-A boundary gate on 2026-07-18 on `ns1007492`,
+CPU 2, with Go 1.22.2, `GOMAXPROCS=1`, 20 samples per lane and fixture, and
+750 ms samples. The control is the same-revision public-node lifecycle; the
+candidate includes selected-store sealing, complete cursor traversal, and
+release.
 
 | Fixture | Time delta | B/op delta | Retained selected bytes |
 |---|---:|---:|---:|
-| `rewrite.go` | **-13.18%** | **-55.45%** | 107,400 |
-| `query_compile.go` | **-13.03%** | **-58.40%** | 543,900 |
-| `language.go` | **-11.70%** | **-55.93%** | 516,500 |
-| `grammargen/lr.go` | **-15.45%** | **-55.83%** | 5,261,000 |
+| `rewrite.go` | **-12.68%** | **-55.45%** | 89,476 |
+| `query_compile.go` | **-13.57%** | **-58.40%** | 453,236 |
+| `language.go` | **-11.18%** | **-55.93%** | 430,416 |
+| `grammargen/lr.go` | **-15.58%** | **-55.83%** | 4,384,556 |
 
-The equal-fixture time geomean improves by **13.35%** and total B/op by
+The equal-fixture time geomean improves by **13.27%** and total B/op by
 **56.42%**; allocation count improves by 0.47%. Both direct-store orders peak
-below the public control (90,156/91,532 KiB versus 97,452/99,092 KiB). Every
+below the public control (87,084/88,028 KiB versus 99,864/100,724 KiB). Every
 timed sample reports zero fallback and the exact standing shifts, reductions,
 pop requests, pop paths, pop payloads, link additions, leaf constructions, and
 parent constructions for its fixture. Exact admissions additionally compare
@@ -576,11 +577,40 @@ record and are not part of this admission.
 Board identities:
 
 - combined benchstat SHA-256:
-  `82041c1f868f9972ff2ffbf47b076de78fde0a8a0a54d4b58439b1ad2900522a`;
+  `48f2c660f96a081db6ecd6b6c353de516fc80813bf82cff4d46fa8524ec0c355`;
 - public samples SHA-256:
-  `e17bd37ab0999fbf2803e0002229bd749bc02290c50569fce18ced36eeed2027`;
+  `3ca87a44ca37cb5cc962d1edf238567d6ad3a7fa1340f203ec4b68c3e41d9477`;
 - direct selected-store samples SHA-256:
-  `c0d200a7834afeb31b2931b6c4dc12b76a7b7405b0225472442b1ce04bbfce9d`.
+  `f8bd8a724235e3053b523d07a7b36b365d6f1d9dc1295bb1216d9765ed1ca857`;
+- test binary SHA-256:
+  `ab042ed4030a608ed5f527cfef1941152f4ae36b8b0838bfadeb4e323b133d8e`.
+
+The same clean revision then completed the strict locked-static-C publication
+driver with cgo/static deep admission, quiet-host admission, five Go-C-C-Go
+cycles, ten process-isolated samples per backend and fixture, exact work, and
+zero fallback:
+
+| Fixture | Selected store median | static C median | Selected / C | B/op | allocs/op | Selected max RSS | C max RSS |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `rewrite.go` | 3.140 ms | 1.208 ms | **2.599748x** | 24,824 | 1,909 | 39,888 KiB | 2,304 KiB |
+| `query_compile.go` | 15.235 ms | 5.457 ms | **2.791974x** | 95,978 | 9,000 | 39,788 KiB | 2,816 KiB |
+| `language.go` | 15.670 ms | 5.835 ms | **2.685641x** | 120,682 | 9,220 | 40,184 KiB | 2,816 KiB |
+| `grammargen/lr.go` | 157.935 ms | 59.221 ms | **2.666881x** | 1,066,512.5 | 91,156.5 | 84,008 KiB | 9,216 KiB |
+
+The selected-store equal-fixture geomean is **2.685181x C**. Its fixed-suite
+sum is **2.676794x C** (191.980 ms selected store versus 71.720 ms static C),
+and its worst fixture is `query_compile.go` at **2.791974x C**.
+
+Publication identities:
+
+- manifest SHA-256:
+  `dcbe8586283f16e7da1122b3991277383f5ce0494e23bce653cf91757673042f`;
+- report SHA-256:
+  `c3b96d8713566833367f893eb598b4bd912407b55e31d6c23ba04418d523b78f`;
+- complete receipt archive SHA-256:
+  `9600063ebabd54e73a83d9b4af0fb3b2cb79d582a3803a61fa7f90f58d726c51`;
+- locked static-C artifact SHA-256:
+  `dfbed45811491be8d81e32b293ed5577222445dae47b67d876cedae09679a871`.
 
 This is a diagnostic clean fresh-full Go consumer boundary. It is not a
 public `Parser.Parse`, recovery, incremental, included-range, multi-grammar,

--- a/BENCH.md
+++ b/BENCH.md
@@ -530,7 +530,7 @@ four clean fresh-full Go fixtures and visible deep-tree structure, not public
 `Parser.Parse`, recovery, incremental reuse, included ranges, parser-state
 metadata, query/cursor behavior, or multiple grammars.
 
-### Direct selected-store boundary receipt
+### Pre-review direct selected-store boundary board (superseded)
 
 The next diagnostic boundary removes public-node materialization from the
 opt-in compact consumer without changing the public-node control. Acceptance
@@ -541,6 +541,13 @@ public route never constructs that store. The store is readable after
 `Core.Reset`, retains no compact payload handle, and becomes unreadable after
 release. Cancellation, occurrence count, retained bytes, unsupported policy,
 precedence overflow, and root identity all fail closed.
+
+This board predates the final lifecycle review. It is retained only as a
+directional experiment and is **not publication evidence**: the reviewed
+implementation now creates unary policy metadata lazily, pools record and
+child backing as one synchronized capped pair, preflights root-extra growth,
+and releases the store on every post-build validation failure. A new locked-C
+publication is required after those corrections pass review.
 
 A balanced A-B-B-A board ran on 2026-07-18 on `ns1007492`, CPU 2, with Go
 1.22.2, `GOMAXPROCS=1`, 20 samples per lane and fixture, and 750 ms samples.
@@ -561,8 +568,10 @@ timed sample reports zero fallback and the exact standing shifts, reductions,
 pop requests, pop paths, pop payloads, link additions, leaf constructions, and
 parent constructions for its fixture. Exact admissions additionally compare
 all visible symbols, spans, fields, aliases/extras, terminal/external flags,
-production IDs, checked precedence, parser states, selected-node counts, and
-deep-tree digests against the public compact materializer.
+production IDs, checked precedence, selected-node counts, and deep-tree
+digests against the public compact materializer. Parser-state and
+pre-goto-state metadata are intentionally absent from the selected-store
+record and are not part of this admission.
 
 Board identities:
 

--- a/BENCH.md
+++ b/BENCH.md
@@ -530,6 +530,53 @@ four clean fresh-full Go fixtures and visible deep-tree structure, not public
 `Parser.Parse`, recovery, incremental reuse, included ranges, parser-state
 metadata, query/cursor behavior, or multiple grammars.
 
+### Direct selected-store boundary receipt
+
+The next diagnostic boundary removes public-node materialization from the
+opt-in compact consumer without changing the public-node control. Acceptance
+carries only the exact selected payload IDs. After a successful fresh
+scheduler session, the direct route seals a pointer-light occurrence store,
+walks it through `SelectedCursor`, and calls `SelectedStore.Release`; the
+public route never constructs that store. The store is readable after
+`Core.Reset`, retains no compact payload handle, and becomes unreadable after
+release. Cancellation, occurrence count, retained bytes, unsupported policy,
+precedence overflow, and root identity all fail closed.
+
+A balanced A-B-B-A board ran on 2026-07-18 on `ns1007492`, CPU 2, with Go
+1.22.2, `GOMAXPROCS=1`, 20 samples per lane and fixture, and 750 ms samples.
+The control is the post-#366 public-node lifecycle; the candidate includes
+selected-store sealing, a complete cursor traversal, and release.
+
+| Fixture | Time delta | B/op delta | Retained selected bytes |
+|---|---:|---:|---:|
+| `rewrite.go` | **-13.18%** | **-55.45%** | 107,400 |
+| `query_compile.go` | **-13.03%** | **-58.40%** | 543,900 |
+| `language.go` | **-11.70%** | **-55.93%** | 516,500 |
+| `grammargen/lr.go` | **-15.45%** | **-55.83%** | 5,261,000 |
+
+The equal-fixture time geomean improves by **13.35%** and total B/op by
+**56.42%**; allocation count improves by 0.47%. Both direct-store orders peak
+below the public control (90,156/91,532 KiB versus 97,452/99,092 KiB). Every
+timed sample reports zero fallback and the exact standing shifts, reductions,
+pop requests, pop paths, pop payloads, link additions, leaf constructions, and
+parent constructions for its fixture. Exact admissions additionally compare
+all visible symbols, spans, fields, aliases/extras, terminal/external flags,
+production IDs, checked precedence, parser states, selected-node counts, and
+deep-tree digests against the public compact materializer.
+
+Board identities:
+
+- combined benchstat SHA-256:
+  `82041c1f868f9972ff2ffbf47b076de78fde0a8a0a54d4b58439b1ad2900522a`;
+- public samples SHA-256:
+  `e17bd37ab0999fbf2803e0002229bd749bc02290c50569fce18ced36eeed2027`;
+- direct selected-store samples SHA-256:
+  `c0d200a7834afeb31b2931b6c4dc12b76a7b7405b0225472442b1ce04bbfce9d`.
+
+This is a diagnostic clean fresh-full Go consumer boundary. It is not a
+public `Parser.Parse`, recovery, incremental, included-range, multi-grammar,
+or public query API claim.
+
 ### Single-link compact reduction publication
 
 A clean candidate publication was collected on 2026-07-18 from quiet host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ for tags and release notes while still in `0.x`.
   consumer; the public-node control remains store-free. The store preserves
   occurrence identity and authenticated visible metadata across compact-core
   resets, polls cancellation and resource limits, enforces occurrence and
-  retained-byte caps, and returns its backing through an explicit release
-  lifecycle. On the pinned quiet host, a balanced post-#366 A/B board improves
-  the four-fixture fresh-full geomean by 13.35%, with every fixture faster by
-  11.70-15.45%, total allocation bytes down 56.42%, lower peak RSS, exact work
-  counts, and zero fallback. The route remains diagnostic-only.
+  retained-byte caps before growth, builds its quadratic unary policy only on
+  demand, and returns each atomic record/child backing pair through an explicit
+  synchronized release lifecycle. A pre-review A/B board found a promising
+  directional win, but it is superseded pending a post-review locked-C
+  publication. The route remains diagnostic-only and intentionally omits
+  parser-state metadata.
 
 ### Tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ for tags and release notes while still in `0.x`.
   selected-store backend and retain selected-store bytes alongside total
   allocation, work, fallback, and RSS metrics.
 
+### Fixed
+
+- Keep compact-parser arena and selected-root cap arithmetic portable on
+  32-bit targets by widening lengths before uint32-bound checks and additions.
+
 ## [0.41.0] - 2026-07-18
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Performance
+
+- Add an opt-in, build-tagged selected-tree backing store at the compact
+  parser/consumer boundary. Accepted payloads are sealed only for the direct
+  consumer; the public-node control remains store-free. The store preserves
+  occurrence identity and authenticated visible metadata across compact-core
+  resets, polls cancellation and resource limits, enforces occurrence and
+  retained-byte caps, and returns its backing through an explicit release
+  lifecycle. On the pinned quiet host, a balanced post-#366 A/B board improves
+  the four-fixture fresh-full geomean by 13.35%, with every fixture faster by
+  11.70-15.45%, total allocation bytes down 56.42%, lower peak RSS, exact work
+  counts, and zero fallback. The route remains diagnostic-only.
+
+### Tooling
+
+- Extend the locked static-C publication driver with an authenticated
+  selected-store backend and retain selected-store bytes alongside total
+  allocation, work, fallback, and RSS metrics.
+
 ## [0.41.0] - 2026-07-18
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ for tags and release notes while still in `0.x`.
   resets, polls cancellation and resource limits, enforces occurrence and
   retained-byte caps before growth, builds its quadratic unary policy only on
   demand, and returns each atomic record/child backing pair through an explicit
-  synchronized release lifecycle. A pre-review A/B board found a promising
-  directional win, but it is superseded pending a post-review locked-C
-  publication. The route remains diagnostic-only and intentionally omits
-  parser-state metadata.
+  synchronized release lifecycle. On the exact reviewed revision, the direct
+  consumer improves the same-revision public-node boundary by 13.27% across
+  the four locked fixtures, with every fixture 11.18-15.58% faster, B/op down
+  56.42%, lower RSS, exact work, and zero fallback. Its strict locked-static-C
+  publication measures 2.685181x C by equal-fixture geomean, 2.676794x by
+  fixed-suite sum, and 2.791974x on the worst fixture. The route remains
+  diagnostic-only and intentionally omits parser-state metadata.
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -389,9 +389,11 @@ receipt hash.
 A strict v0.40.0 production receipt at `1935a42c` measures public
 `Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x C**
 by fixed-suite sum of medians, with a **5.608320x C** worst fixture. The latest
-clean publication of the separately build-tagged, fail-closed compact
-candidate, at `19a8f526`, measures **3.118130x C** and **3.169740x C**,
-respectively, with every fixture below **3.19x C** and zero timed fallbacks.
+clean publication of the separately build-tagged, fail-closed selected-store
+candidate, at `ba1ed1bf`, measures **2.685181x C** and **2.676794x C**,
+respectively, with a **2.791974x C** worst fixture and zero timed fallbacks.
+The measured lifecycle seals the accepted compact payloads into the indexed
+selected store, walks them through `SelectedCursor`, and releases the store.
 That candidate result is diagnostic: it authenticates visible
 `gts-deep-tree-v1` structure for the four clean fresh-full fixtures, not
 parser-state metadata, recovery, incremental reuse, included ranges, or public
@@ -713,18 +715,20 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 The current release is **v0.41.0**. It banks the post-v0.40 correctness and
 tooling tranche plus five exact, build-tagged compact-parser performance wins.
-Those diagnostic improvements keep the public parser unchanged while reducing
-the authenticated compact candidate to **3.118130x C** by equal-fixture
-geomean, **3.169740x C** by fixed-suite sum, and **3.185522x C** on its worst
-fixture, with zero timed fallback. The release also includes build-time PGO,
+Subsequent unreleased selected-store work keeps the public parser unchanged
+while reducing the authenticated compact candidate to **2.685181x C** by
+equal-fixture geomean, **2.676794x C** by fixed-suite sum, and **2.791974x C**
+on its worst fixture, with zero timed fallback. Its measured lifecycle seals,
+traverses, and releases the selected store; it is not public `Parser.Parse`.
+The v0.41.0 release also includes build-time PGO,
 forest-path pooling and copy elimination, query work budgeting, and incremental
 reuse boundary corrections from the v0.40.0 line.
 The authenticated production receipt at tag target `1935a42c` measures public
 `Parser.Parse` at **4.851050x C** by equal-fixture geomean, **5.472406x C** by
 fixed-suite sum, and **5.608320x C** on the worst fixture against the locked
 static `-O2` C oracle. Its 0.716% geomean improvement over v0.39.0 is below the
-reproducible 2% win threshold. The latest build-tagged compact candidate,
-measured at `19a8f526`, remains outside public `Parser.Parse` despite its lower
+reproducible 2% win threshold. The latest build-tagged selected-store candidate,
+measured at `ba1ed1bf`, remains outside public `Parser.Parse` despite its lower
 authenticated ratio.
 The 206-grammar curated parity milestone is banked, the invalid historical
 1.895x headline remains withdrawn, and the incremental matrix is a

--- a/cgo_harness/pure_c/run_canonical_go_full_parse.sh
+++ b/cgo_harness/pure_c/run_canonical_go_full_parse.sh
@@ -32,9 +32,10 @@ benchmark worktree.
 
 Options:
   --out <dir>                 New private receipt directory.
-  --go-backend <backend>      Go backend: production (default) or candidate.
-                              Candidate is the authenticated tagged compact
-                              fresh-full route; it never falls back.
+  --go-backend <backend>      Go backend: production (default), candidate, or
+                              selected-store. Candidate materializes public
+                              nodes; selected-store consumes the authenticated
+                              compact snapshot directly. Neither falls back.
   --core <cpu>                Pin all calibration and samples to this CPU.
                               Default: least-busy allowed CPU from a 1s probe.
   --quiet-max-attempts <n>    Bounded quiet checks (default: 12).
@@ -130,8 +131,8 @@ while (($# > 0)); do
 done
 
 case "$GO_BACKEND" in
-  production|candidate) ;;
-  *) die "go backend must be production or candidate, got $GO_BACKEND" ;;
+  production|candidate|selected-store) ;;
+  *) die "go backend must be production, candidate, or selected-store, got $GO_BACKEND" ;;
 esac
 
 require_uint "cycles" "$CYCLES"
@@ -219,7 +220,7 @@ trap on_exit EXIT
 
 if [[ "$MODE" == "diagnostic" ]]; then
   RECEIPT_CLASS="NONPUBLICATION_DIAGNOSTIC"
-elif [[ "$GO_BACKEND" == "candidate" ]]; then
+elif [[ "$GO_BACKEND" != "production" ]]; then
   RECEIPT_CLASS="AUTHENTICATED_CANDIDATE"
 else
   RECEIPT_CLASS="PUBLICATION"
@@ -300,11 +301,17 @@ for spec in "${CANDIDATE_WORK_SPECS[@]}"; do
 done
 
 if [[ "$GO_BACKEND" == "candidate" ]]; then
-  GO_BUILD_TAGS="gts_parsercorephase0"
-  GO_BENCHMARK="BenchmarkParserCoreFreshFullCanonical"
-  GO_PREFLIGHT="TestParserCoreFreshFullRunnerRepeatedCanonicalLifecycle"
-  GO_LIFECYCLE="parserCoreFreshFullRunner.parse+shallow_completeness+Tree.Release"
-  GO_FALLBACK="none_fail_closed"
+	GO_BUILD_TAGS="gts_parsercorephase0"
+	GO_BENCHMARK="BenchmarkParserCoreFreshFullCanonical"
+	GO_PREFLIGHT="TestParserCoreFreshFullRunnerRepeatedCanonicalLifecycle"
+	GO_LIFECYCLE="parserCoreFreshFullRunner.parse+shallow_completeness+Tree.Release"
+	GO_FALLBACK="none_fail_closed"
+elif [[ "$GO_BACKEND" == "selected-store" ]]; then
+	GO_BUILD_TAGS="gts_parsercorephase0"
+	GO_BENCHMARK="BenchmarkParserCoreFreshFullSelectedStoreCanonical"
+	GO_PREFLIGHT="TestDiagnosticParserCoreSelectedStoreCanonicalAdmissions"
+	GO_LIFECYCLE="parserCoreFreshFullRunner.parseSelectedStore+SelectedCursor traversal+SelectedStore.Release"
+	GO_FALLBACK="none_fail_closed"
 else
   GO_BUILD_TAGS=""
   GO_BENCHMARK="BenchmarkGoParseWarmRealDFA"
@@ -314,7 +321,7 @@ else
 fi
 
 GO_BIN="$OUT_DIR/bin/gotreesitter.test"
-if [[ "$GO_BACKEND" == "candidate" ]]; then
+if [[ "$GO_BACKEND" != "production" ]]; then
   (
     cd "$REPO_ROOT"
     env GOMAXPROCS=1 go test -tags "$GO_BUILD_TAGS" -c -o "$GO_BIN" .
@@ -333,11 +340,11 @@ GO_BIN_SHA="$(sha256sum "$GO_BIN" | awk '{print $1}')"
 go version -m "$GO_BIN" > "$OUT_DIR/preflight/go_binary_modules.txt"
 
 if ((SKIP_CGO_ADMISSION == 0)); then
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
+  if [[ "$GO_BACKEND" != "production" ]]; then
     (
       cd "$REPO_ROOT"
       bash cgo_harness/docker/run_parity_in_docker.sh -- \
-        "cd /workspace && go test -tags gts_parsercorephase0 . -run '^TestParserCoreFreshFullRunnerRepeatedCanonicalLifecycle$' -count=1 -v && cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run '^(TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
+        "cd /workspace && go test -tags gts_parsercorephase0 . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run '^(TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
     ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
   else
     (
@@ -595,7 +602,7 @@ extract_rss_kb() {
 
 extract_go_metrics() {
   local fixture="$1" raw="$2"
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
+  if [[ "$GO_BACKEND" != "production" ]]; then
     awk -v name="${GO_BENCHMARK}/${fixture}" '
       $1 == name || index($1, name "-") == 1 {
         for (i = 2; i < NF; i++) metric[$(i + 1)] = $i
@@ -605,10 +612,11 @@ extract_go_metrics() {
         names[9] = "compact_pop_payloads/op"; names[10] = "compact_link_additions/op"
         names[11] = "compact_leaf_constructions/op"; names[12] = "compact_parent_constructions/op"
         names[13] = "candidate_fallback/op"
-        for (n = 1; n <= 13; n++) {
+        names[14] = "selected_retained_B/op"
+        for (n = 1; n <= 14; n++) {
           value = metric[names[n]]
           if (value == "") value = "NA"
-          printf "%s%s", value, (n == 13 ? ORS : OFS)
+          printf "%s%s", value, (n == 14 ? ORS : OFS)
         }
         found = 1
         exit
@@ -637,9 +645,9 @@ extract_go_metrics() {
   ' OFS='\t' "$raw"
 }
 
-if [[ "$GO_BACKEND" == "candidate" ]]; then
-  printf 'sequence\tfixture\tcycle\tposition\tbackend\tsample\tns_op\tB_op\tallocs_op\tMB_s\tcompact_shifts_op\tcompact_reductions_op\tcompact_pop_requests_op\tcompact_pop_paths_op\tcompact_pop_payloads_op\tcompact_link_additions_op\tcompact_leaf_constructions_op\tcompact_parent_constructions_op\tcandidate_fallback_op\tmax_rss_kb\n' > "$OUT_DIR/samples.tsv"
-  GO_METRIC_NA_COLUMNS=12
+if [[ "$GO_BACKEND" != "production" ]]; then
+  printf 'sequence\tfixture\tcycle\tposition\tbackend\tsample\tns_op\tB_op\tallocs_op\tMB_s\tcompact_shifts_op\tcompact_reductions_op\tcompact_pop_requests_op\tcompact_pop_paths_op\tcompact_pop_payloads_op\tcompact_link_additions_op\tcompact_leaf_constructions_op\tcompact_parent_constructions_op\tcandidate_fallback_op\tselected_retained_B_op\tmax_rss_kb\n' > "$OUT_DIR/samples.tsv"
+  GO_METRIC_NA_COLUMNS=13
 else
   printf 'sequence\tfixture\tcycle\tposition\tbackend\tsample\tns_op\tB_op\tallocs_op\tMB_s\tmax_stacks\tpeak_depth\ttokens_op\tmulti_iters_op\tmulti_tokens_op\tnodes_op\tarena_B_op\tnormalization_runs_op\tforest_fast_path\tconstructed_final\tmax_rss_kb\n' > "$OUT_DIR/samples.tsv"
   GO_METRIC_NA_COLUMNS=13
@@ -718,7 +726,7 @@ verify_candidate_work() {
 }
 
 for fixture in "${FIXTURE_IDS[@]}"; do
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
+  if [[ "$GO_BACKEND" != "production" ]]; then
     verify_candidate_work "$fixture" || die "$fixture sampled compact work identity failed"
   else
     verify_go_workload_floor "$fixture" || die "$fixture sampled workload identity failed"
@@ -740,8 +748,8 @@ max_column() {
     "$OUT_DIR/samples.tsv"
 }
 
-if [[ "$GO_BACKEND" == "candidate" ]]; then
-  printf 'fixture\tgo_median_ns_op\tc_median_ns_op\tgo_c_ratio\tgo_median_B_op\tgo_median_allocs_op\tgo_median_MB_s\tgo_median_compact_shifts_op\tgo_median_compact_reductions_op\tgo_median_compact_pop_requests_op\tgo_median_compact_pop_paths_op\tgo_median_compact_pop_payloads_op\tgo_median_compact_link_additions_op\tgo_median_compact_leaf_constructions_op\tgo_median_compact_parent_constructions_op\tgo_median_candidate_fallback_op\tc_fixed_iters\tgo_max_rss_kb\tc_max_rss_kb\n' > "$OUT_DIR/report.tsv"
+if [[ "$GO_BACKEND" != "production" ]]; then
+  printf 'fixture\tgo_median_ns_op\tc_median_ns_op\tgo_c_ratio\tgo_median_B_op\tgo_median_allocs_op\tgo_median_MB_s\tgo_median_compact_shifts_op\tgo_median_compact_reductions_op\tgo_median_compact_pop_requests_op\tgo_median_compact_pop_paths_op\tgo_median_compact_pop_payloads_op\tgo_median_compact_link_additions_op\tgo_median_compact_leaf_constructions_op\tgo_median_compact_parent_constructions_op\tgo_median_candidate_fallback_op\tgo_median_selected_retained_B_op\tc_fixed_iters\tgo_max_rss_kb\tc_max_rss_kb\n' > "$OUT_DIR/report.tsv"
 else
   printf 'fixture\tgo_median_ns_op\tc_median_ns_op\tgo_c_ratio\tgo_median_B_op\tgo_median_allocs_op\tgo_median_MB_s\tgo_median_max_stacks\tgo_median_peak_depth\tgo_median_tokens_op\tgo_median_multi_iters_op\tgo_median_multi_tokens_op\tgo_median_nodes_op\tgo_median_arena_B_op\tgo_median_normalization_runs_op\tgo_median_forest_fast_path\tgo_median_constructed_final\tc_fixed_iters\tgo_max_rss_kb\tc_max_rss_kb\n' > "$OUT_DIR/report.tsv"
 fi
@@ -759,11 +767,11 @@ for fixture in "${FIXTURE_IDS[@]}"; do
   go_sum="$(awk -v sum="$go_sum" -v value="$go_ns" 'BEGIN { printf "%.6f\n", sum + value }')"
   c_sum="$(awk -v sum="$c_sum" -v value="$c_ns" 'BEGIN { printf "%.6f\n", sum + value }')"
   printf '%s\t%s\t%s\t%s' "$fixture" "$go_ns" "$c_ns" "$ratio" >> "$OUT_DIR/report.tsv"
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
-    for column in 8 9 10 11 12 13 14 15 16 17 18 19; do
+  if [[ "$GO_BACKEND" != "production" ]]; then
+    for column in 8 9 10 11 12 13 14 15 16 17 18 19 20; do
       printf '\t%s' "$(median_column "$fixture" go "$column")" >> "$OUT_DIR/report.tsv"
     done
-    printf '\t%s\t%s\t%s\n' "${C_ITERS[$fixture]}" "$(max_column "$fixture" go 20)" "$(max_column "$fixture" c 20)" >> "$OUT_DIR/report.tsv"
+    printf '\t%s\t%s\t%s\n' "${C_ITERS[$fixture]}" "$(max_column "$fixture" go 21)" "$(max_column "$fixture" c 21)" >> "$OUT_DIR/report.tsv"
     if [[ -z "$MAX_FIXTURE_GO_C_RATIO" ]] || awk -v candidate="$ratio" -v current="$MAX_FIXTURE_GO_C_RATIO" 'BEGIN { exit !(candidate > current) }'; then
       MAX_FIXTURE_GO_C_RATIO="$ratio"
       MAX_RATIO_FIXTURE="$fixture"
@@ -778,9 +786,9 @@ done
 EQUAL_FIXTURE_GEOMEAN_RATIO="$(awk '{ sum += log($1); n++ } END { if (!n) exit 2; printf "%.6f\n", exp(sum / n) }' "$ratio_file")"
 SUITE_SUM_RATIO="$(awk -v go="$go_sum" -v c="$c_sum" 'BEGIN { printf "%.6f\n", go / c }')"
 LARGEST_FIXTURE="grammargen_lr"
-if [[ "$GO_BACKEND" == "candidate" ]]; then
-  LARGEST_GO_MAX_RSS_KB="$(max_column "$LARGEST_FIXTURE" go 20)"
-  LARGEST_C_MAX_RSS_KB="$(max_column "$LARGEST_FIXTURE" c 20)"
+if [[ "$GO_BACKEND" != "production" ]]; then
+  LARGEST_GO_MAX_RSS_KB="$(max_column "$LARGEST_FIXTURE" go 21)"
+  LARGEST_C_MAX_RSS_KB="$(max_column "$LARGEST_FIXTURE" c 21)"
 else
   LARGEST_GO_MAX_RSS_KB="$(max_column "$LARGEST_FIXTURE" go 21)"
   LARGEST_C_MAX_RSS_KB="$(max_column "$LARGEST_FIXTURE" c 21)"
@@ -791,7 +799,7 @@ printf 'equal_fixture_geomean_go_c_ratio\t%s\n' "$EQUAL_FIXTURE_GEOMEAN_RATIO" >
 printf 'fixed_suite_go_sum_of_medians_ns\t%s\n' "$go_sum" >> "$OUT_DIR/summary.tsv"
 printf 'fixed_suite_c_sum_of_medians_ns\t%s\n' "$c_sum" >> "$OUT_DIR/summary.tsv"
 printf 'fixed_suite_sum_of_medians_go_c_ratio\t%s\n' "$SUITE_SUM_RATIO" >> "$OUT_DIR/summary.tsv"
-if [[ "$GO_BACKEND" == "candidate" ]]; then
+if [[ "$GO_BACKEND" != "production" ]]; then
   printf 'max_fixture_go_c_ratio\t%s\n' "$MAX_FIXTURE_GO_C_RATIO" >> "$OUT_DIR/summary.tsv"
   printf 'max_ratio_fixture\t%s\n' "$MAX_RATIO_FIXTURE" >> "$OUT_DIR/summary.tsv"
 fi
@@ -810,18 +818,18 @@ REPORT_SHA="$(sha256sum "$OUT_DIR/report.tsv" | awk '{print $1}')"
 SUMMARY_SHA="$(sha256sum "$OUT_DIR/summary.tsv" | awk '{print $1}')"
 FIXTURE_MANIFEST_SHA="$(sha256sum "$OUT_DIR/fixture_manifest.tsv" | awk '{print $1}')"
 SAMPLES_SHA="$(sha256sum "$OUT_DIR/samples.tsv" | awk '{print $1}')"
-if [[ "$GO_BACKEND" == "candidate" ]]; then
+if [[ "$GO_BACKEND" != "production" ]]; then
   RUNNER_SOURCE_SHA="$(sha256sum "$REPO_ROOT/parsercore_phase0_fresh_full_runner.go" | awk '{print $1}')"
   BENCHMARK_SOURCE_SHA="$(sha256sum "$REPO_ROOT/parsercore_phase0_fresh_full_runner_internal_test.go" | awk '{print $1}')"
 fi
 {
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
+  if [[ "$GO_BACKEND" != "production" ]]; then
     printf 'receipt_version=canonical-go-full-parse-v2\n'
   else
     printf 'receipt_version=canonical-go-full-parse-v1\n'
   fi
   printf 'receipt_class=%s\n' "$RECEIPT_CLASS"
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
+  if [[ "$GO_BACKEND" != "production" ]]; then
     printf 'go_backend=%s\n' "$GO_BACKEND"
     printf 'go_build_tags=%s\n' "$GO_BUILD_TAGS"
     printf 'go_benchmark=%s\n' "$GO_BENCHMARK"
@@ -852,7 +860,7 @@ fi
   printf 'benchtime=%s\n' "$BENCHTIME"
   printf 'c_calibration_min_ns=%s\n' "$BENCHTIME_NS"
   printf 'cgo_static_deep_admission=%s\n' "$CGO_ADMISSION"
-  if [[ "$GO_BACKEND" == "candidate" ]]; then
+  if [[ "$GO_BACKEND" != "production" ]]; then
     printf 'workload_identity=compact_deep_tree_and_exact_work_admission_v1\n'
     printf 'candidate_cgo_admission_contract=root_tagged_fresh_runner+treesitter_c_parity_canonical_static_deep\n'
   else

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -533,6 +533,7 @@ type RawSelectedCensus struct {
 type Core struct {
 	tables              TableView
 	plans               ReductionPlanProvider
+	selectedPolicy      *SelectedStorePolicy
 	limits              Limits
 	diagnostics         diagnosticOptions
 	nodes               []nodeRecord
@@ -916,6 +917,13 @@ func New(tables TableView, limits Limits) (*Core, error) {
 		metadataConstructionAuthenticated: true,
 	}
 	core.plans, _ = tables.(ReductionPlanProvider)
+	if provider, ok := tables.(SelectedStorePolicyProvider); ok {
+		policy, policyErr := provider.SelectedStorePolicy()
+		if policyErr != nil {
+			return nil, policyErr
+		}
+		core.selectedPolicy = &policy
+	}
 	return core, nil
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -286,16 +286,18 @@ func (e *LiveLinkCapacityError) Error() string {
 // Limits bound every pointer-free arena and bounded diagnostic traversal.
 // Packed root-path multiplicity is telemetry, not an execution limit.
 type Limits struct {
-	MaxNodes            uint32
-	MaxLinks            uint32
-	MaxSubtrees         uint32
-	MaxChildren         uint32
-	MaxMetadata         uint32
-	MaxLinksPerBoundary uint32
-	MaxPopPaths         uint64
-	MaxDerivations      uint64
-	MaxCheckpoints      uint32
-	MaxCheckpointBytes  uint64
+	MaxNodes               uint32
+	MaxLinks               uint32
+	MaxSubtrees            uint32
+	MaxChildren            uint32
+	MaxMetadata            uint32
+	MaxLinksPerBoundary    uint32
+	MaxPopPaths            uint64
+	MaxDerivations         uint64
+	MaxCheckpoints         uint32
+	MaxCheckpointBytes     uint64
+	MaxSelectedOccurrences uint32
+	MaxSelectedBytes       uint64
 }
 
 func (l Limits) withDefaults() Limits {
@@ -328,6 +330,12 @@ func (l Limits) withDefaults() Limits {
 	}
 	if l.MaxCheckpointBytes == 0 {
 		l.MaxCheckpointBytes = 16 << 20
+	}
+	if l.MaxSelectedOccurrences == 0 {
+		l.MaxSelectedOccurrences = l.MaxSubtrees
+	}
+	if l.MaxSelectedBytes == 0 {
+		l.MaxSelectedBytes = uint64(l.MaxSelectedOccurrences) * 96
 	}
 	return l
 }
@@ -553,6 +561,8 @@ type Core struct {
 	work                Work
 	popScratch          popEnumerationScratch
 	reductionScratch    reductionOutputScratch
+	selectedBuild       selectedStoreBuildScratch
+	selectedPool        selectedStoreBacking
 	schedulerFrame      schedulerTransactionFrame
 	// metadataConstructionAuthenticated remains true only while every compact
 	// subtree was published through the authenticated shift/reduction seams.
@@ -922,7 +932,9 @@ func New(tables TableView, limits Limits) (*Core, error) {
 		if policyErr != nil {
 			return nil, policyErr
 		}
-		core.selectedPolicy = &policy
+		if len(policy.Symbols) != 0 {
+			core.selectedPolicy = &policy
+		}
 	}
 	return core, nil
 }

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1662,17 +1662,17 @@ func (c *Core) appendPrivate(state StateID, byteOffset uint32, in linkInput) (He
 	if _, err := c.subtree(in.payload); err != nil {
 		return Head{}, err
 	}
-	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || len(c.links) >= math.MaxUint32 {
+	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || uint64(len(c.links)) >= math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: link arena cap")
 	}
-	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || len(c.nodes) >= math.MaxUint32 {
+	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: node arena cap")
 	}
 	flags := uint32(0)
 	if in.order.Present {
 		flags |= linkFlagHasOrder
 	}
-	linkID := LinkID(len(c.links) + 1)
+	linkID := LinkID(uint64(len(c.links)) + 1)
 	c.links = append(c.links, linkRecord{
 		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
 		order: in.order.Value, flags: flags,
@@ -1845,13 +1845,13 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	if oldID != 0 {
 		newPathCount = saturatingAddPaths(newPathCount, old.pathCount)
 	}
-	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || len(c.links) >= math.MaxUint32 {
+	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || uint64(len(c.links)) >= math.MaxUint32 {
 		if oldID != 0 {
 			c.recordLinkUnionRejected()
 		}
 		return condenseOutcome{}, errors.New("parser-core phase zero: link arena cap")
 	}
-	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || len(c.nodes) >= math.MaxUint32 {
+	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		if oldID != 0 {
 			c.recordLinkUnionRejected()
 		}
@@ -1871,7 +1871,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		}
 		linkCount += old.linkCount
 	}
-	linkID := LinkID(len(c.links) + 1)
+	linkID := LinkID(uint64(len(c.links)) + 1)
 	flags := uint32(0)
 	if in.order.Present {
 		flags |= linkFlagHasOrder
@@ -2307,10 +2307,10 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 	if uint64(len(c.links))+uint64(len(links)) > uint64(c.limits.MaxLinks) || uint64(len(c.links))+uint64(len(links)) > math.MaxUint32 {
 		return 0, errors.New("parser-core phase zero: link arena cap")
 	}
-	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || len(c.nodes) >= math.MaxUint32 {
+	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return 0, errors.New("parser-core phase zero: node arena cap")
 	}
-	next := NodeID(len(c.nodes) + 1)
+	next := NodeID(uint64(len(c.nodes)) + 1)
 	pathCount := uint64(0)
 	for _, link := range links {
 		if link.prev == 0 || link.prev >= next {
@@ -2373,7 +2373,7 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 	if uint64(len(c.links))+uint64(len(oldLinks)) > uint64(c.limits.MaxLinks) || uint64(len(c.links))+uint64(len(oldLinks)) > math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: link arena cap")
 	}
-	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || len(c.nodes) >= math.MaxUint32 {
+	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return Head{}, errors.New("parser-core phase zero: node arena cap")
 	}
 
@@ -3101,10 +3101,10 @@ func (c *Core) RawSelectedSubtreeCensus(roots []SubtreeID) (RawSelectedCensus, e
 }
 
 func (c *Core) appendNode(r nodeRecord) (NodeID, error) {
-	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || len(c.nodes) >= math.MaxUint32 {
+	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
 		return 0, errors.New("parser-core phase zero: node arena cap")
 	}
-	next := NodeID(len(c.nodes) + 1)
+	next := NodeID(uint64(len(c.nodes)) + 1)
 	if err := c.validatePublishedNodeDAG(r, next); err != nil {
 		return 0, err
 	}
@@ -3167,7 +3167,7 @@ func (c *Core) appendAuthenticatedTerminal(r subtreeRecord) (SubtreeID, error) {
 }
 
 func (c *Core) appendSubtreeRecord(r subtreeRecord, children []SubtreeID, fields []FieldMapEntry, aliases []Symbol) (SubtreeID, error) {
-	if uint64(len(c.subtrees))+1 > uint64(c.limits.MaxSubtrees) || len(c.subtrees) >= math.MaxUint32 {
+	if uint64(len(c.subtrees))+1 > uint64(c.limits.MaxSubtrees) || uint64(len(c.subtrees)) >= math.MaxUint32 {
 		return 0, errors.New("parser-core phase zero: subtree arena cap")
 	}
 	if uint64(len(c.children))+uint64(len(children)) > uint64(c.limits.MaxChildren) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"slices"
+	"sync"
 )
 
 // Symbol and StateID are grammar-table identifiers. They intentionally use
@@ -541,6 +542,7 @@ type RawSelectedCensus struct {
 type Core struct {
 	tables              TableView
 	plans               ReductionPlanProvider
+	selectedProvider    SelectedStorePolicyProvider
 	selectedPolicy      *SelectedStorePolicy
 	limits              Limits
 	diagnostics         diagnosticOptions
@@ -562,6 +564,7 @@ type Core struct {
 	popScratch          popEnumerationScratch
 	reductionScratch    reductionOutputScratch
 	selectedBuild       selectedStoreBuildScratch
+	selectedPoolMu      sync.Mutex
 	selectedPool        selectedStoreBacking
 	schedulerFrame      schedulerTransactionFrame
 	// metadataConstructionAuthenticated remains true only while every compact
@@ -927,15 +930,7 @@ func New(tables TableView, limits Limits) (*Core, error) {
 		metadataConstructionAuthenticated: true,
 	}
 	core.plans, _ = tables.(ReductionPlanProvider)
-	if provider, ok := tables.(SelectedStorePolicyProvider); ok {
-		policy, policyErr := provider.SelectedStorePolicy()
-		if policyErr != nil {
-			return nil, policyErr
-		}
-		if len(policy.Symbols) != 0 {
-			core.selectedPolicy = &policy
-		}
-	}
+	core.selectedProvider, _ = tables.(SelectedStorePolicyProvider)
 	return core, nil
 }
 

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -9,8 +9,8 @@ import (
 )
 
 // SelectedSymbolPolicy is immutable materialization metadata for one grammar
-// symbol. It is built once with the authenticated table adapter, outside the
-// parse and selected-store timing boundaries.
+// symbol. The authenticated table adapter builds it lazily only when the
+// selected-store boundary is requested; the Core then caches it.
 type SelectedSymbolPolicy struct {
 	Visible bool
 	Named   bool
@@ -39,8 +39,8 @@ type SelectedStorePolicy struct {
 	StatementLists      []bool
 }
 
-// SelectedStorePolicyProvider lets an authenticated table adapter install the
-// compact-to-consumer policy once when a Core is constructed.
+// SelectedStorePolicyProvider lets an authenticated table adapter build the
+// compact-to-consumer policy lazily on first selected-store use.
 type SelectedStorePolicyProvider interface {
 	SelectedStorePolicy() (SelectedStorePolicy, error)
 }
@@ -127,8 +127,6 @@ type SelectedNodeRecord struct {
 	FirstChild        uint32
 	StartByte         uint32
 	EndByte           uint32
-	ParseState        StateID
-	PreGotoState      StateID
 	Symbol            Symbol
 	Field             FieldID
 	ProductionID      uint16
@@ -202,8 +200,12 @@ func (s *SelectedStore) RetainedBytes() uint64 {
 	if s == nil || s.released {
 		return 0
 	}
-	return uint64(cap(s.records))*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
-		uint64(cap(s.children))*uint64(unsafe.Sizeof(SelectedNodeID(0)))
+	return selectedStoreRetainedBytes(cap(s.records), cap(s.children))
+}
+
+func selectedStoreRetainedBytes(recordCapacity, childCapacity int) uint64 {
+	return uint64(recordCapacity)*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
+		uint64(childCapacity)*uint64(unsafe.Sizeof(SelectedNodeID(0)))
 }
 
 func (s *SelectedStore) Record(id SelectedNodeID) (SelectedNodeRecord, bool) {
@@ -225,8 +227,10 @@ func (s *SelectedStore) Child(record SelectedNodeRecord, index uint32) (Selected
 }
 
 // Release invalidates the selected snapshot and returns its pointer-free
-// backing to the owning compact core. It is idempotent and must not race with
-// cursor reads. The store remains independent of Core.Reset until Release.
+// backing to the owning compact core. It is idempotent when called serially,
+// but must not race with any operation on the same store. Releasing distinct
+// sibling stores is synchronized. The store remains independent of Core.Reset
+// until Release.
 func (s *SelectedStore) Release() {
 	if s == nil || s.released {
 		return
@@ -241,9 +245,16 @@ func (s *SelectedStore) Release() {
 }
 
 func (c *Core) acquireSelectedStore(recordCapacity, childCapacity int) *SelectedStore {
+	c.selectedPoolMu.Lock()
 	records := c.selectedPool.records
 	children := c.selectedPool.children
 	c.selectedPool = selectedStoreBacking{}
+	c.selectedPoolMu.Unlock()
+	prospectiveRecords := max(cap(records), recordCapacity)
+	prospectiveChildren := max(cap(children), childCapacity)
+	if selectedStoreRetainedBytes(prospectiveRecords, prospectiveChildren) > c.limits.MaxSelectedBytes {
+		records, children = nil, nil
+	}
 	if cap(records) < recordCapacity {
 		records = make([]SelectedNodeRecord, 0, recordCapacity)
 	} else {
@@ -265,11 +276,16 @@ func (c *Core) recycleSelectedStore(records []SelectedNodeRecord, children []Sel
 	}
 	clear(records)
 	clear(children)
-	if cap(records) >= cap(c.selectedPool.records) {
-		c.selectedPool.records = records[:0]
+	incoming := selectedStoreBacking{records: records[:0], children: children[:0]}
+	incomingBytes := selectedStoreRetainedBytes(cap(records), cap(children))
+	if incomingBytes > c.limits.MaxSelectedBytes {
+		return
 	}
-	if cap(children) >= cap(c.selectedPool.children) {
-		c.selectedPool.children = children[:0]
+	c.selectedPoolMu.Lock()
+	defer c.selectedPoolMu.Unlock()
+	pooledBytes := selectedStoreRetainedBytes(cap(c.selectedPool.records), cap(c.selectedPool.children))
+	if incomingBytes >= pooledBytes {
+		c.selectedPool = incoming
 	}
 }
 
@@ -327,7 +343,8 @@ type selectedRawOccurrence struct {
 
 // BuildSelectedStore seals accepted roots directly from compact immutable
 // payload arenas. It does not enumerate a head, construct public Nodes, or
-// invoke a per-occurrence callback.
+// invoke a per-occurrence callback. It borrows Core-owned scratch and therefore
+// must not run concurrently with any other operation on the same Core.
 func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
 	if c == nil || len(roots) == 0 {
 		return nil, errors.New("parser-core phase zero: selected store requires accepted roots")
@@ -497,7 +514,7 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 			}
 		}
 	}
-	if err := store.finishRoots(rootIDs, policy); err != nil {
+	if err := store.finishRoots(rootIDs, policy, c.limits.MaxSelectedBytes); err != nil {
 		return nil, err
 	}
 	if err := store.normalizeGoCompatibility(policy, source, poll); err != nil {
@@ -575,11 +592,27 @@ func (s *SelectedStore) recomputePrecedence(deltas []int32) error {
 	return recompute(s.root)
 }
 
-// BuildAuthenticatedSelectedStore uses the immutable policy captured from the
-// Core's exact table adapter.
+// BuildAuthenticatedSelectedStore lazily requests the immutable policy from
+// the Core's exact table adapter. Generic/public compact-parser controls do not
+// pay the quadratic unary-policy initialization or retention cost.
 func (c *Core) BuildAuthenticatedSelectedStore(roots []SubtreeID, source []byte, poll func() error) (*SelectedStore, error) {
-	if c == nil || c.selectedPolicy == nil {
+	if c == nil || c.selectedProvider == nil {
 		return nil, errors.New("parser-core phase zero: selected-store policy is unavailable")
+	}
+	if poll != nil {
+		if err := poll(); err != nil {
+			return nil, err
+		}
+	}
+	if c.selectedPolicy == nil {
+		policy, err := c.selectedProvider.SelectedStorePolicy()
+		if err != nil {
+			return nil, err
+		}
+		if len(policy.Symbols) == 0 {
+			return nil, errors.New("parser-core phase zero: selected-store policy is unavailable")
+		}
+		c.selectedPolicy = &policy
 	}
 	return c.BuildSelectedStore(roots, *c.selectedPolicy, source, poll)
 }
@@ -793,7 +826,7 @@ func (s *SelectedStore) applyDirectField(ids []SelectedNodeID, field FieldID) {
 	}
 }
 
-func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStorePolicy) error {
+func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStorePolicy, retainedCap uint64) error {
 	if len(roots) == 0 {
 		return errors.New("parser-core phase zero: selected store sealed no logical roots")
 	}
@@ -813,6 +846,10 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 				return errors.New("parser-core phase zero: selected store has multiple authenticated roots")
 			}
 			realIndex = index
+			continue
+		}
+		if !record.Extra() {
+			return errors.New("parser-core phase zero: selected store has a non-extra sibling root")
 		}
 	}
 	if realIndex < 0 {
@@ -822,17 +859,40 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 	real := &s.records[realID-1]
 	oldStart := real.FirstChild
 	oldEnd := oldStart + uint32(real.ChildCount)
-	mergedCount := len(roots) - 1 + int(real.ChildCount)
-	if mergedCount > math.MaxUint16 || len(s.children)+mergedCount > math.MaxUint32 {
+	extraCount := len(roots) - 1
+	mergedCount := extraCount + int(real.ChildCount)
+	finalChildren := len(s.children) + extraCount
+	if mergedCount > math.MaxUint16 || finalChildren > math.MaxUint32 {
 		return errors.New("parser-core phase zero: selected root extras exceed arena")
 	}
-	real.FirstChild = uint32(len(s.children))
+	childCapacity := cap(s.children)
+	if childCapacity < finalChildren {
+		childCapacity = finalChildren
+	}
+	if selectedStoreRetainedBytes(cap(s.records), childCapacity) > retainedCap {
+		return errors.New("parser-core phase zero: selected store retained-byte cap")
+	}
+	oldLength := len(s.children)
+	if cap(s.children) < finalChildren {
+		children := make([]SelectedNodeID, oldLength, finalChildren)
+		copy(children, s.children)
+		s.children = children
+	}
+	s.children = s.children[:finalChildren]
+	copy(s.children[oldEnd+uint32(extraCount):], s.children[oldEnd:uint32(oldLength)])
+	before := uint32(realIndex)
+	copy(s.children[oldStart+before:oldEnd+before], s.children[oldStart:oldEnd])
+	copy(s.children[oldStart:oldStart+before], roots[:realIndex])
+	copy(s.children[oldEnd+before:oldEnd+uint32(extraCount)], roots[realIndex+1:])
+	for index := range s.records {
+		record := &s.records[index]
+		if SelectedNodeID(index+1) != realID && record.ChildCount != 0 && record.FirstChild >= oldEnd {
+			record.FirstChild += uint32(extraCount)
+		}
+	}
 	real.ChildCount = uint16(mergedCount)
 	real.StartByte = 0
-	s.children = append(s.children, roots[:realIndex]...)
-	s.children = append(s.children, s.children[oldStart:oldEnd]...)
-	s.children = append(s.children, roots[realIndex+1:]...)
-	merged := s.children[real.FirstChild:]
+	merged := s.children[oldStart : oldStart+uint32(mergedCount)]
 	for childIndex, child := range merged {
 		s.records[child-1].Parent = realID
 		s.records[child-1].ChildIndex = uint16(childIndex)

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -1,0 +1,753 @@
+package parsercorephase0
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"unsafe"
+)
+
+// SelectedSymbolPolicy is immutable materialization metadata for one grammar
+// symbol. It is built once with the authenticated table adapter, outside the
+// parse and selected-store timing boundaries.
+type SelectedSymbolPolicy struct {
+	Visible bool
+	Named   bool
+}
+
+// SelectedUnaryRule is the exact clean-tree unary reduction decision for one
+// parent/child symbol pair.
+type SelectedUnaryRule uint8
+
+const (
+	SelectedUnaryKeep SelectedUnaryRule = iota
+	SelectedUnaryPass
+	SelectedUnaryRenameLeaf
+)
+
+// SelectedStorePolicy is the fail-closed compact-to-consumer contract. Unary
+// is a dense parent-major matrix with stride len(Symbols).
+type SelectedStorePolicy struct {
+	Symbols             []SelectedSymbolPolicy
+	Unary               []SelectedUnaryRule
+	ExpectedRoot        Symbol
+	Semicolon           Symbol
+	SemicolonNUL        Symbol
+	SemicolonContainers []bool
+	Cases               []bool
+	StatementLists      []bool
+}
+
+// SelectedStorePolicyProvider lets an authenticated table adapter install the
+// compact-to-consumer policy once when a Core is constructed.
+type SelectedStorePolicyProvider interface {
+	SelectedStorePolicy() (SelectedStorePolicy, error)
+}
+
+func NewSelectedStorePolicy(symbols []SelectedSymbolPolicy, unary []SelectedUnaryRule, expectedRoot Symbol) (SelectedStorePolicy, error) {
+	if len(symbols) == 0 || int(expectedRoot) >= len(symbols) {
+		return SelectedStorePolicy{}, errors.New("parser-core phase zero: selected-store policy has no authenticated root")
+	}
+	want := len(symbols) * len(symbols)
+	if (len(symbols) != 0 && want/len(symbols) != len(symbols)) || len(unary) != want {
+		return SelectedStorePolicy{}, errors.New("parser-core phase zero: selected-store unary policy width drifted")
+	}
+	return SelectedStorePolicy{
+		Symbols:      append([]SelectedSymbolPolicy(nil), symbols...),
+		Unary:        append([]SelectedUnaryRule(nil), unary...),
+		ExpectedRoot: expectedRoot,
+	}, nil
+}
+
+func (p *SelectedStorePolicy) SetGoCompatibility(semicolon, semicolonNUL Symbol, containers, cases, statementLists []bool) error {
+	if p == nil || len(p.Symbols) == 0 || len(containers) != len(p.Symbols) || len(cases) != len(p.Symbols) || len(statementLists) != len(p.Symbols) {
+		return errors.New("parser-core phase zero: selected-store Go compatibility width drifted")
+	}
+	p.Semicolon, p.SemicolonNUL = semicolon, semicolonNUL
+	p.SemicolonContainers = append([]bool(nil), containers...)
+	p.Cases = append([]bool(nil), cases...)
+	p.StatementLists = append([]bool(nil), statementLists...)
+	return nil
+}
+
+func (p SelectedStorePolicy) symbol(symbol Symbol) (SelectedSymbolPolicy, bool) {
+	if int(symbol) >= len(p.Symbols) {
+		return SelectedSymbolPolicy{}, false
+	}
+	return p.Symbols[symbol], true
+}
+
+func (p SelectedStorePolicy) unary(parent, child Symbol) SelectedUnaryRule {
+	stride := len(p.Symbols)
+	if int(parent) >= stride || int(child) >= stride {
+		return SelectedUnaryKeep
+	}
+	slot := int(parent)*stride + int(child)
+	if slot >= len(p.Unary) {
+		return SelectedUnaryKeep
+	}
+	return p.Unary[slot]
+}
+
+func (p SelectedStorePolicy) validate() error {
+	if len(p.Symbols) == 0 || int(p.ExpectedRoot) >= len(p.Symbols) {
+		return errors.New("parser-core phase zero: selected-store policy has no authenticated root")
+	}
+	width := len(p.Symbols)
+	if width > math.MaxInt/width || len(p.Unary) != width*width {
+		return errors.New("parser-core phase zero: selected-store unary policy width drifted")
+	}
+	compatWidth := len(p.SemicolonContainers)
+	if compatWidth == 0 {
+		if len(p.Cases) != 0 || len(p.StatementLists) != 0 {
+			return errors.New("parser-core phase zero: selected-store compatibility policy is partial")
+		}
+		return nil
+	}
+	if compatWidth != width || len(p.Cases) != width || len(p.StatementLists) != width {
+		return errors.New("parser-core phase zero: selected-store compatibility width drifted")
+	}
+	return nil
+}
+
+type SelectedNodeID uint32
+
+const (
+	selectedNodeFlagNamed uint8 = 1 << iota
+	selectedNodeFlagExtra
+	selectedNodeFlagExternal
+	selectedNodeFlagTerminal
+)
+
+// SelectedNodeRecord is one immutable logical occurrence after hidden-parent
+// elision and unary collapse. Field belongs to the incoming logical edge.
+type SelectedNodeRecord struct {
+	Parent            SelectedNodeID
+	FirstChild        uint32
+	StartByte         uint32
+	EndByte           uint32
+	Payload           SubtreeID
+	Symbol            Symbol
+	Field             FieldID
+	ProductionID      uint16
+	DynamicPrecedence int16
+	ChildCount        uint16
+	ChildIndex        uint16
+	flags             uint8
+}
+
+func (r SelectedNodeRecord) Named() bool    { return r.flags&selectedNodeFlagNamed != 0 }
+func (r SelectedNodeRecord) Extra() bool    { return r.flags&selectedNodeFlagExtra != 0 }
+func (r SelectedNodeRecord) External() bool { return r.flags&selectedNodeFlagExternal != 0 }
+func (r SelectedNodeRecord) Terminal() bool { return r.flags&selectedNodeFlagTerminal != 0 }
+
+// SelectedStore is the sealed, pointer-free selected syntax backing store.
+// IDs are occurrence identities; repeated compact SubtreeIDs remain distinct.
+type SelectedStore struct {
+	root     SelectedNodeID
+	records  []SelectedNodeRecord
+	children []SelectedNodeID
+}
+
+func (s *SelectedStore) Root() SelectedNodeID {
+	if s == nil {
+		return 0
+	}
+	return s.root
+}
+
+func (s *SelectedStore) NodeCount() uint64 {
+	if s == nil {
+		return 0
+	}
+	return uint64(len(s.records))
+}
+
+func (s *SelectedStore) ChildCount() uint64 {
+	if s == nil {
+		return 0
+	}
+	return uint64(len(s.children))
+}
+
+// RetainedBytes reports exact backing-array retention, excluding the small
+// store header itself so capacity changes remain visible.
+func (s *SelectedStore) RetainedBytes() uint64 {
+	if s == nil {
+		return 0
+	}
+	return uint64(cap(s.records))*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
+		uint64(cap(s.children))*uint64(unsafe.Sizeof(SelectedNodeID(0)))
+}
+
+func (s *SelectedStore) Record(id SelectedNodeID) (SelectedNodeRecord, bool) {
+	if s == nil || id == 0 || uint64(id) > uint64(len(s.records)) {
+		return SelectedNodeRecord{}, false
+	}
+	return s.records[id-1], true
+}
+
+func (s *SelectedStore) Child(record SelectedNodeRecord, index uint32) (SelectedNodeID, bool) {
+	if s == nil || index >= uint32(record.ChildCount) {
+		return 0, false
+	}
+	slot := uint64(record.FirstChild) + uint64(index)
+	if slot >= uint64(len(s.children)) {
+		return 0, false
+	}
+	return s.children[slot], true
+}
+
+// SelectedCursor is a direct indexed cursor over a sealed store. It contains
+// no interface, callback, or public Node pointer.
+type SelectedCursor struct {
+	store *SelectedStore
+	id    SelectedNodeID
+}
+
+func (s *SelectedStore) Cursor() SelectedCursor             { return SelectedCursor{store: s, id: s.Root()} }
+func (c SelectedCursor) ID() SelectedNodeID                 { return c.id }
+func (c SelectedCursor) Record() (SelectedNodeRecord, bool) { return c.store.Record(c.id) }
+func (c SelectedCursor) Parent() (SelectedCursor, bool) {
+	r, ok := c.Record()
+	if !ok || r.Parent == 0 {
+		return SelectedCursor{}, false
+	}
+	return SelectedCursor{store: c.store, id: r.Parent}, true
+}
+func (c SelectedCursor) Child(index uint32) (SelectedCursor, bool) {
+	r, ok := c.Record()
+	if !ok {
+		return SelectedCursor{}, false
+	}
+	id, ok := c.store.Child(r, index)
+	if !ok {
+		return SelectedCursor{}, false
+	}
+	return SelectedCursor{store: c.store, id: id}, true
+}
+func (c SelectedCursor) NextSibling() (SelectedCursor, bool) {
+	record, ok := c.Record()
+	if !ok || record.Parent == 0 {
+		return SelectedCursor{}, false
+	}
+	parent, ok := c.store.Record(record.Parent)
+	if !ok || uint32(record.ChildIndex)+1 >= uint32(parent.ChildCount) {
+		return SelectedCursor{}, false
+	}
+	id, ok := c.store.Child(parent, uint32(record.ChildIndex)+1)
+	if !ok {
+		return SelectedCursor{}, false
+	}
+	return SelectedCursor{store: c.store, id: id}, true
+}
+
+type selectedRawOccurrence struct {
+	payload    SubtreeID
+	firstChild uint32
+	childCount uint16
+	alias      Symbol
+	field      FieldID
+}
+
+// BuildSelectedStore seals accepted roots directly from compact immutable
+// payload arenas. It does not enumerate a head, construct public Nodes, or
+// invoke a per-occurrence callback.
+func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+	if c == nil || len(roots) == 0 {
+		return nil, errors.New("parser-core phase zero: selected store requires accepted roots")
+	}
+	if err := policy.validate(); err != nil {
+		return nil, err
+	}
+	if poll == nil {
+		poll = func() error { return nil }
+	}
+	if err := poll(); err != nil {
+		return nil, err
+	}
+
+	raw, rawChildren, rawRoots, err := c.selectedRawOccurrences(roots, poll)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]SelectedNodeID, len(raw))
+	store := &SelectedStore{
+		records:  make([]SelectedNodeRecord, 0, len(raw)),
+		children: make([]SelectedNodeID, 0, len(raw)-len(roots)),
+	}
+	collect := make([]uint32, 0, 32)
+	logical := make([]SelectedNodeID, 0, 32)
+
+	for index := len(raw) - 1; index >= 0; index-- {
+		if index&255 == 0 {
+			if err := poll(); err != nil {
+				return nil, err
+			}
+		}
+		occ := raw[index]
+		record, err := c.subtree(occ.payload)
+		if err != nil {
+			return nil, err
+		}
+		symbol := record.symbol
+		if occ.alias != 0 {
+			symbol = occ.alias
+		}
+		meta, ok := policy.symbol(symbol)
+		if !ok {
+			return nil, fmt.Errorf("parser-core phase zero: selected symbol %d is outside policy", symbol)
+		}
+
+		logical = logical[:0]
+		for childIndex := uint32(0); childIndex < uint32(occ.childCount); childIndex++ {
+			rawChild := rawChildren[occ.firstChild+childIndex]
+			start := len(logical)
+			collect = append(collect[:0], rawChild)
+			for len(collect) != 0 {
+				last := len(collect) - 1
+				candidate := collect[last]
+				collect = collect[:last]
+				if id := results[candidate]; id != 0 {
+					logical = append(logical, id)
+					continue
+				}
+				hidden := raw[candidate]
+				for nested := int(hidden.childCount) - 1; nested >= 0; nested-- {
+					collect = append(collect, rawChildren[hidden.firstChild+uint32(nested)])
+				}
+			}
+			if field := raw[rawChild].field; field != 0 {
+				store.applyDirectField(logical[start:], field)
+			}
+		}
+
+		if !record.terminal && record.childCount == 1 && record.fieldCount == 0 && record.aliasCount == 0 && len(logical) == 1 {
+			childID := logical[0]
+			child := &store.records[childID-1]
+			rule := policy.unary(record.symbol, child.Symbol)
+			if !child.Extra() && (rule == SelectedUnaryPass || rule == SelectedUnaryRenameLeaf && child.ChildCount == 0) {
+				if rule == SelectedUnaryRenameLeaf {
+					child.Symbol = record.symbol
+					child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal())
+				}
+				if occ.alias != 0 {
+					child.Symbol = occ.alias
+					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
+				}
+				child.ProductionID = record.productionID
+				child.DynamicPrecedence += record.dynamicPrecedence
+				if occ.field != 0 {
+					child.Field = occ.field
+				}
+				results[index] = childID
+				continue
+			}
+		}
+
+		if !meta.Visible && !record.extra {
+			continue
+		}
+		if len(logical) > math.MaxUint16 || len(store.children)+len(logical) > math.MaxUint32 || len(store.records) >= math.MaxUint32 {
+			return nil, errors.New("parser-core phase zero: selected store exceeded uint32 arena")
+		}
+		id := SelectedNodeID(len(store.records) + 1)
+		first := uint32(len(store.children))
+		store.children = append(store.children, logical...)
+		flags := selectedFlags(meta, record.extra, record.external, record.terminal)
+		startByte, endByte := record.startByte, record.endByte
+		if len(logical) != 0 {
+			firstChild := store.records[logical[0]-1]
+			lastChild := store.records[logical[len(logical)-1]-1]
+			if firstChild.StartByte < startByte {
+				startByte = firstChild.StartByte
+			}
+			if lastChild.EndByte > endByte {
+				endByte = lastChild.EndByte
+			}
+		}
+		store.records = append(store.records, SelectedNodeRecord{
+			FirstChild: first, StartByte: startByte, EndByte: endByte,
+			Payload: occ.payload, Symbol: symbol, Field: occ.field,
+			ProductionID: record.productionID, DynamicPrecedence: record.dynamicPrecedence,
+			ChildCount: uint16(len(logical)), flags: flags,
+		})
+		for childIndex, childID := range logical {
+			store.records[childID-1].Parent = id
+			store.records[childID-1].ChildIndex = uint16(childIndex)
+		}
+		results[index] = id
+	}
+
+	rootIDs := make([]SelectedNodeID, 0, len(roots))
+	for _, index := range rawRoots {
+		if id := results[index]; id != 0 {
+			rootIDs = append(rootIDs, id)
+			continue
+		}
+		collect = append(collect[:0], index)
+		for len(collect) != 0 {
+			last := len(collect) - 1
+			candidate := collect[last]
+			collect = collect[:last]
+			if id := results[candidate]; id != 0 {
+				rootIDs = append(rootIDs, id)
+				continue
+			}
+			hidden := raw[candidate]
+			for nested := int(hidden.childCount) - 1; nested >= 0; nested-- {
+				collect = append(collect, rawChildren[hidden.firstChild+uint32(nested)])
+			}
+		}
+	}
+	if err := store.finishRoots(rootIDs, policy); err != nil {
+		return nil, err
+	}
+	if err := store.normalizeGoCompatibility(policy, source, poll); err != nil {
+		return nil, err
+	}
+	if err := poll(); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// BuildAuthenticatedSelectedStore uses the immutable policy captured from the
+// Core's exact table adapter.
+func (c *Core) BuildAuthenticatedSelectedStore(roots []SubtreeID, source []byte, poll func() error) (*SelectedStore, error) {
+	if c == nil || c.selectedPolicy == nil {
+		return nil, errors.New("parser-core phase zero: selected-store policy is unavailable")
+	}
+	return c.BuildSelectedStore(roots, *c.selectedPolicy, source, poll)
+}
+
+func selectedMarked(table []bool, symbol Symbol) bool {
+	return int(symbol) < len(table) && table[symbol]
+}
+
+func (s *SelectedStore) normalizeGoCompatibility(policy SelectedStorePolicy, source []byte, poll func() error) error {
+	if s == nil || len(source) == 0 || len(policy.SemicolonContainers) == 0 {
+		return nil
+	}
+	// First drop implicit semicolon transport nodes. Compact the child arena in
+	// one pass so dead windows do not survive in retained bytes.
+	children := make([]SelectedNodeID, 0, len(s.children))
+	for index := range s.records {
+		if index&255 == 0 {
+			if err := poll(); err != nil {
+				return err
+			}
+		}
+		record := &s.records[index]
+		old := s.children[record.FirstChild : record.FirstChild+uint32(record.ChildCount)]
+		record.FirstChild = uint32(len(children))
+		for _, childID := range old {
+			child := s.records[childID-1]
+			drop := selectedMarked(policy.SemicolonContainers, record.Symbol) &&
+				(child.Symbol == policy.Semicolon || child.Symbol == policy.SemicolonNUL) &&
+				selectedDropSemicolon(child.StartByte, child.EndByte, source)
+			if !drop {
+				s.records[childID-1].ChildIndex = uint16(len(children) - int(record.FirstChild))
+				children = append(children, childID)
+			}
+		}
+		record.ChildCount = uint16(len(children) - int(record.FirstChild))
+	}
+	s.children = children
+
+	// Public Go compatibility applies sibling boundary ownership before the
+	// trailing statement-list adjustment. The selected store has unique parent
+	// ownership, so a dense record pass is sufficient.
+	for index := range s.records {
+		record := &s.records[index]
+		for childIndex := uint32(0); childIndex+1 < uint32(record.ChildCount); childIndex++ {
+			leftID := s.children[record.FirstChild+childIndex]
+			rightID := s.children[record.FirstChild+childIndex+1]
+			left, right := &s.records[leftID-1], s.records[rightID-1]
+			if selectedMarked(policy.StatementLists, left.Symbol) && left.EndByte < right.StartByte && selectedTrivia(source, left.EndByte, right.StartByte) {
+				if target := selectedTrailingNewline(left.EndByte, right.StartByte, source); target > left.EndByte {
+					left.EndByte = target
+				}
+			}
+			if selectedMarked(policy.Cases, left.Symbol) {
+				s.normalizeCaseBoundary(left, right.StartByte, policy, source)
+			}
+		}
+	}
+	for index := range s.records {
+		record := &s.records[index]
+		if !selectedMarked(policy.StatementLists, record.Symbol) || record.ChildCount == 0 {
+			continue
+		}
+		last := &s.records[s.children[record.FirstChild+uint32(record.ChildCount)-1]-1]
+		if last.EndByte >= record.EndByte {
+			continue
+		}
+		if target := selectedTriviaBeforeExtra(last.EndByte, record.EndByte, source); target > last.EndByte && target < record.EndByte {
+			record.EndByte = target
+		}
+	}
+	root := &s.records[s.root-1]
+	if root.EndByte < uint32(len(source)) && selectedTrivia(source, root.EndByte, uint32(len(source))) {
+		root.EndByte = uint32(len(source))
+	}
+	return nil
+}
+
+func selectedDropSemicolon(start, end uint32, source []byte) bool {
+	if start >= end || int(end) > len(source) {
+		return true
+	}
+	span := source[start:end]
+	return bytes.IndexByte(span, ';') < 0 && (bytes.IndexByte(span, '\n') >= 0 || bytes.IndexByte(span, '\r') >= 0)
+}
+
+func selectedTrivia(source []byte, start, end uint32) bool {
+	if start > end || int(end) > len(source) {
+		return false
+	}
+	for _, b := range source[start:end] {
+		if b != ' ' && b != '\t' && b != '\n' && b != '\r' {
+			return false
+		}
+	}
+	return true
+}
+
+func selectedTrailingNewline(start, end uint32, source []byte) uint32 {
+	if !selectedTrivia(source, start, end) {
+		return start
+	}
+	if index := bytes.LastIndexByte(source[start:end], '\n'); index >= 0 {
+		return start + uint32(index) + 1
+	}
+	return start
+}
+
+func selectedTriviaBeforeExtra(start, end uint32, source []byte) uint32 {
+	if start >= end || int(end) > len(source) {
+		return start
+	}
+	for cursor := start; cursor < end; cursor++ {
+		switch source[cursor] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		}
+		for newline := start; newline < cursor; newline++ {
+			if source[newline] == '\n' {
+				return newline + 1
+			}
+		}
+		return cursor
+	}
+	return end
+}
+
+func selectedTrailingTriviaBoundaryBefore(end uint32, source []byte) (uint32, bool) {
+	if end == 0 || int(end) > len(source) {
+		return end, false
+	}
+	start := int(end)
+	for start > 0 {
+		switch source[start-1] {
+		case ' ', '\t', '\r', '\n':
+			start--
+		default:
+			goto ready
+		}
+	}
+ready:
+	gap := source[start:int(end)]
+	if newline := bytes.LastIndexByte(gap, '\n'); newline >= 0 {
+		return uint32(start + newline + 1), true
+	}
+	return end, false
+}
+
+func (s *SelectedStore) normalizeCaseBoundary(current *SelectedNodeRecord, nextStart uint32, policy SelectedStorePolicy, source []byte) {
+	if current.ChildCount == 0 || int(nextStart) > len(source) {
+		return
+	}
+	tail := &s.records[s.children[current.FirstChild+uint32(current.ChildCount)-1]-1]
+	if !selectedMarked(policy.StatementLists, tail.Symbol) {
+		return
+	}
+	target, newline := selectedTrailingTriviaBoundaryBefore(nextStart, source)
+	if newline {
+		current.EndByte = target
+		if tail.EndByte > target || tail.EndByte < target && selectedTrivia(source, tail.EndByte, target) {
+			tail.EndByte = target
+		}
+		return
+	}
+	if current.EndByte > nextStart {
+		current.EndByte = nextStart
+	}
+	if tail.EndByte > nextStart {
+		tail.EndByte = nextStart
+	}
+}
+
+func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal bool) uint8 {
+	var flags uint8
+	if meta.Named {
+		flags |= selectedNodeFlagNamed
+	}
+	if extra {
+		flags |= selectedNodeFlagExtra
+	}
+	if external {
+		flags |= selectedNodeFlagExternal
+	}
+	if terminal {
+		flags |= selectedNodeFlagTerminal
+	}
+	return flags
+}
+
+func (s *SelectedStore) applyDirectField(ids []SelectedNodeID, field FieldID) {
+	if len(ids) == 0 || field == 0 {
+		return
+	}
+	named := 0
+	for _, id := range ids {
+		if s.records[id-1].Named() {
+			named++
+		}
+	}
+	for _, id := range ids {
+		r := &s.records[id-1]
+		if r.Field != 0 {
+			continue
+		}
+		if named > 0 && !r.Named() {
+			continue
+		}
+		r.Field = field
+		if named == 1 {
+			return
+		}
+	}
+}
+
+func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStorePolicy) error {
+	if len(roots) == 0 {
+		return errors.New("parser-core phase zero: selected store sealed no logical roots")
+	}
+	if len(roots) == 1 {
+		s.root = roots[0]
+		return nil
+	}
+	realIndex := -1
+	for index, id := range roots {
+		record := s.records[id-1]
+		if !record.Extra() && record.Symbol == policy.ExpectedRoot {
+			if realIndex != -1 {
+				return errors.New("parser-core phase zero: selected store has multiple authenticated roots")
+			}
+			realIndex = index
+		}
+	}
+	if realIndex < 0 {
+		return errors.New("parser-core phase zero: selected store cannot identify authenticated root")
+	}
+	realID := roots[realIndex]
+	real := &s.records[realID-1]
+	oldChildren := append([]SelectedNodeID(nil), s.children[real.FirstChild:real.FirstChild+uint32(real.ChildCount)]...)
+	merged := make([]SelectedNodeID, 0, len(roots)-1+len(oldChildren))
+	merged = append(merged, roots[:realIndex]...)
+	merged = append(merged, oldChildren...)
+	merged = append(merged, roots[realIndex+1:]...)
+	if len(merged) > math.MaxUint16 || len(s.children)+len(merged) > math.MaxUint32 {
+		return errors.New("parser-core phase zero: selected root extras exceed arena")
+	}
+	real.FirstChild = uint32(len(s.children))
+	real.ChildCount = uint16(len(merged))
+	real.StartByte = 0
+	s.children = append(s.children, merged...)
+	for childIndex, child := range merged {
+		s.records[child-1].Parent = realID
+		s.records[child-1].ChildIndex = uint16(childIndex)
+	}
+	s.root = realID
+	return nil
+}
+
+func (c *Core) selectedRawOccurrences(roots []SubtreeID, poll func() error) ([]selectedRawOccurrence, []uint32, []uint32, error) {
+	raw := make([]selectedRawOccurrence, 0, len(c.subtrees))
+	children := make([]uint32, 0, len(c.children))
+	rootOccurrences := make([]uint32, 0, len(roots))
+	type frame struct {
+		occurrence uint32
+		next       uint32
+	}
+	stack := make([]frame, 0, 64)
+	var work uint64
+	appendOccurrence := func(payload SubtreeID, alias Symbol, field FieldID) (uint32, error) {
+		record, err := c.subtree(payload)
+		if err != nil {
+			return 0, err
+		}
+		if record.childCount > math.MaxUint16 || len(raw) >= math.MaxUint32 || len(children)+int(record.childCount) > math.MaxUint32 {
+			return 0, errors.New("parser-core phase zero: raw selected occurrence exceeds arena")
+		}
+		id := uint32(len(raw))
+		raw = append(raw, selectedRawOccurrence{payload: payload, firstChild: uint32(len(children)), childCount: uint16(record.childCount), alias: alias, field: field})
+		children = append(children, make([]uint32, record.childCount)...)
+		return id, nil
+	}
+	for _, root := range roots {
+		rootID, err := appendOccurrence(root, 0, 0)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		rootOccurrences = append(rootOccurrences, rootID)
+		stack = append(stack, frame{occurrence: rootID})
+		for len(stack) != 0 {
+			work++
+			if work&255 == 0 {
+				if err := poll(); err != nil {
+					return nil, nil, nil, err
+				}
+			}
+			top := &stack[len(stack)-1]
+			parent := raw[top.occurrence]
+			if top.next >= uint32(parent.childCount) {
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			ordinal := top.next
+			top.next++
+			parentRecord, err := c.subtree(parent.payload)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			payload := c.children[parentRecord.firstChild+ordinal]
+			var alias Symbol
+			if parentRecord.aliasCount != 0 {
+				if parentRecord.aliasCount != parentRecord.childCount {
+					return nil, nil, nil, errors.New("parser-core phase zero: selected alias width drifted")
+				}
+				alias = c.aliases[parentRecord.firstAlias+ordinal]
+			}
+			var field FieldID
+			for _, entry := range c.fields[parentRecord.firstField : parentRecord.firstField+parentRecord.fieldCount] {
+				if uint32(entry.ChildIndex) != ordinal {
+					continue
+				}
+				if entry.Inherited || field != 0 {
+					return nil, nil, nil, errors.New("parser-core phase zero: selected field profile is outside admitted direct single-field scope")
+				}
+				field = entry.FieldID
+			}
+			childID, err := appendOccurrence(payload, alias, field)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			children[parent.firstChild+ordinal] = childID
+			stack = append(stack, frame{occurrence: childID})
+		}
+	}
+	return raw, children, rootOccurrences, nil
+}

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -127,11 +127,12 @@ type SelectedNodeRecord struct {
 	FirstChild        uint32
 	StartByte         uint32
 	EndByte           uint32
-	Payload           SubtreeID
+	ParseState        StateID
+	PreGotoState      StateID
 	Symbol            Symbol
 	Field             FieldID
 	ProductionID      uint16
-	DynamicPrecedence int16
+	DynamicPrecedence int32
 	ChildCount        uint16
 	ChildIndex        uint16
 	flags             uint8
@@ -148,24 +149,48 @@ type SelectedStore struct {
 	root     SelectedNodeID
 	records  []SelectedNodeRecord
 	children []SelectedNodeID
+	owner    *Core
+	released bool
+}
+
+type selectedStoreBacking struct {
+	records  []SelectedNodeRecord
+	children []SelectedNodeID
+}
+
+type selectedStoreBuildScratch struct {
+	raw         []selectedRawOccurrence
+	rawChildren []uint32
+	rawRoots    []uint32
+	results     []SelectedNodeID
+	precedence  []int32
+	collect     []uint32
+	logical     []SelectedNodeID
+	rootIDs     []SelectedNodeID
+	stack       []selectedOccurrenceFrame
+}
+
+type selectedOccurrenceFrame struct {
+	occurrence uint32
+	next       uint32
 }
 
 func (s *SelectedStore) Root() SelectedNodeID {
-	if s == nil {
+	if s == nil || s.released {
 		return 0
 	}
 	return s.root
 }
 
 func (s *SelectedStore) NodeCount() uint64 {
-	if s == nil {
+	if s == nil || s.released {
 		return 0
 	}
 	return uint64(len(s.records))
 }
 
 func (s *SelectedStore) ChildCount() uint64 {
-	if s == nil {
+	if s == nil || s.released {
 		return 0
 	}
 	return uint64(len(s.children))
@@ -174,7 +199,7 @@ func (s *SelectedStore) ChildCount() uint64 {
 // RetainedBytes reports exact backing-array retention, excluding the small
 // store header itself so capacity changes remain visible.
 func (s *SelectedStore) RetainedBytes() uint64 {
-	if s == nil {
+	if s == nil || s.released {
 		return 0
 	}
 	return uint64(cap(s.records))*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
@@ -182,14 +207,14 @@ func (s *SelectedStore) RetainedBytes() uint64 {
 }
 
 func (s *SelectedStore) Record(id SelectedNodeID) (SelectedNodeRecord, bool) {
-	if s == nil || id == 0 || uint64(id) > uint64(len(s.records)) {
+	if s == nil || s.released || id == 0 || uint64(id) > uint64(len(s.records)) {
 		return SelectedNodeRecord{}, false
 	}
 	return s.records[id-1], true
 }
 
 func (s *SelectedStore) Child(record SelectedNodeRecord, index uint32) (SelectedNodeID, bool) {
-	if s == nil || index >= uint32(record.ChildCount) {
+	if s == nil || s.released || index >= uint32(record.ChildCount) {
 		return 0, false
 	}
 	slot := uint64(record.FirstChild) + uint64(index)
@@ -197,6 +222,55 @@ func (s *SelectedStore) Child(record SelectedNodeRecord, index uint32) (Selected
 		return 0, false
 	}
 	return s.children[slot], true
+}
+
+// Release invalidates the selected snapshot and returns its pointer-free
+// backing to the owning compact core. It is idempotent and must not race with
+// cursor reads. The store remains independent of Core.Reset until Release.
+func (s *SelectedStore) Release() {
+	if s == nil || s.released {
+		return
+	}
+	s.released = true
+	owner := s.owner
+	records, children := s.records, s.children
+	s.root, s.owner, s.records, s.children = 0, nil, nil, nil
+	if owner != nil {
+		owner.recycleSelectedStore(records, children)
+	}
+}
+
+func (c *Core) acquireSelectedStore(recordCapacity, childCapacity int) *SelectedStore {
+	records := c.selectedPool.records
+	children := c.selectedPool.children
+	c.selectedPool = selectedStoreBacking{}
+	if cap(records) < recordCapacity {
+		records = make([]SelectedNodeRecord, 0, recordCapacity)
+	} else {
+		clear(records)
+		records = records[:0]
+	}
+	if cap(children) < childCapacity {
+		children = make([]SelectedNodeID, 0, childCapacity)
+	} else {
+		clear(children)
+		children = children[:0]
+	}
+	return &SelectedStore{records: records, children: children, owner: c}
+}
+
+func (c *Core) recycleSelectedStore(records []SelectedNodeRecord, children []SelectedNodeID) {
+	if c == nil {
+		return
+	}
+	clear(records)
+	clear(children)
+	if cap(records) >= cap(c.selectedPool.records) {
+		c.selectedPool.records = records[:0]
+	}
+	if cap(children) >= cap(c.selectedPool.children) {
+		c.selectedPool.children = children[:0]
+	}
 }
 
 // SelectedCursor is a direct indexed cursor over a sealed store. It contains
@@ -272,13 +346,31 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 	if err != nil {
 		return nil, err
 	}
-	results := make([]SelectedNodeID, len(raw))
-	store := &SelectedStore{
-		records:  make([]SelectedNodeRecord, 0, len(raw)),
-		children: make([]SelectedNodeID, 0, len(raw)-len(roots)),
+	defer c.finishSelectedBuildScratch()
+	results := resizeSelectedScratch(c.selectedBuild.results, len(raw))
+	c.selectedBuild.results = results
+	wantRetained := uint64(len(raw))*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
+		uint64(len(raw)-len(roots))*uint64(unsafe.Sizeof(SelectedNodeID(0)))
+	if wantRetained > c.limits.MaxSelectedBytes {
+		return nil, errors.New("parser-core phase zero: selected store retained-byte cap")
 	}
-	collect := make([]uint32, 0, 32)
-	logical := make([]SelectedNodeID, 0, 32)
+	store := c.acquireSelectedStore(len(raw), len(raw)-len(roots))
+	sealed := false
+	defer func() {
+		if !sealed {
+			store.Release()
+		}
+	}()
+	precedenceDeltas := resizeSelectedScratch(c.selectedBuild.precedence, 0)
+	if cap(precedenceDeltas) < len(raw) {
+		precedenceDeltas = make([]int32, 0, len(raw))
+	}
+	c.selectedBuild.precedence = precedenceDeltas
+	if store.RetainedBytes() > c.limits.MaxSelectedBytes {
+		return nil, errors.New("parser-core phase zero: selected store retained-byte cap")
+	}
+	collect := c.selectedBuild.collect[:0]
+	logical := c.selectedBuild.logical[:0]
 
 	for index := len(raw) - 1; index >= 0; index-- {
 		if index&255 == 0 {
@@ -299,7 +391,6 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 		if !ok {
 			return nil, fmt.Errorf("parser-core phase zero: selected symbol %d is outside policy", symbol)
 		}
-
 		logical = logical[:0]
 		for childIndex := uint32(0); childIndex < uint32(occ.childCount); childIndex++ {
 			rawChild := rawChildren[occ.firstChild+childIndex]
@@ -337,7 +428,11 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
 				}
 				child.ProductionID = record.productionID
-				child.DynamicPrecedence += record.dynamicPrecedence
+				delta, err := checkedSelectedPrecedence(precedenceDeltas[childID-1], int32(record.dynamicPrecedence))
+				if err != nil {
+					return nil, err
+				}
+				precedenceDeltas[childID-1] = delta
 				if occ.field != 0 {
 					child.Field = occ.field
 				}
@@ -369,10 +464,11 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 		}
 		store.records = append(store.records, SelectedNodeRecord{
 			FirstChild: first, StartByte: startByte, EndByte: endByte,
-			Payload: occ.payload, Symbol: symbol, Field: occ.field,
-			ProductionID: record.productionID, DynamicPrecedence: record.dynamicPrecedence,
+			Symbol: symbol, Field: occ.field,
+			ProductionID: record.productionID, DynamicPrecedence: int32(record.dynamicPrecedence),
 			ChildCount: uint16(len(logical)), flags: flags,
 		})
+		precedenceDeltas = append(precedenceDeltas, int32(record.dynamicPrecedence))
 		for childIndex, childID := range logical {
 			store.records[childID-1].Parent = id
 			store.records[childID-1].ChildIndex = uint16(childIndex)
@@ -380,7 +476,7 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 		results[index] = id
 	}
 
-	rootIDs := make([]SelectedNodeID, 0, len(roots))
+	rootIDs := c.selectedBuild.rootIDs[:0]
 	for _, index := range rawRoots {
 		if id := results[index]; id != 0 {
 			rootIDs = append(rootIDs, id)
@@ -407,10 +503,76 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 	if err := store.normalizeGoCompatibility(policy, source, poll); err != nil {
 		return nil, err
 	}
+	if err := store.recomputePrecedence(precedenceDeltas); err != nil {
+		return nil, err
+	}
+	if store.RetainedBytes() > c.limits.MaxSelectedBytes {
+		return nil, errors.New("parser-core phase zero: selected store retained-byte cap")
+	}
 	if err := poll(); err != nil {
 		return nil, err
 	}
+	sealed = true
 	return store, nil
+}
+
+func resizeSelectedScratch[T any](items []T, length int) []T {
+	if cap(items) < length {
+		return make([]T, length)
+	}
+	items = items[:length]
+	clear(items)
+	return items
+}
+
+func (c *Core) finishSelectedBuildScratch() {
+	if c == nil {
+		return
+	}
+	c.selectedBuild.raw = c.selectedBuild.raw[:0]
+	c.selectedBuild.rawChildren = c.selectedBuild.rawChildren[:0]
+	c.selectedBuild.rawRoots = c.selectedBuild.rawRoots[:0]
+	clear(c.selectedBuild.results)
+	c.selectedBuild.results = c.selectedBuild.results[:0]
+	c.selectedBuild.precedence = c.selectedBuild.precedence[:0]
+	c.selectedBuild.collect = c.selectedBuild.collect[:0]
+	c.selectedBuild.logical = c.selectedBuild.logical[:0]
+	c.selectedBuild.rootIDs = c.selectedBuild.rootIDs[:0]
+	c.selectedBuild.stack = c.selectedBuild.stack[:0]
+}
+
+func checkedSelectedPrecedence(left, right int32) (int32, error) {
+	value := int64(left) + int64(right)
+	if value < math.MinInt32 || value > math.MaxInt32 {
+		return 0, errors.New("parser-core phase zero: selected precedence overflow")
+	}
+	return int32(value), nil
+}
+
+func (s *SelectedStore) recomputePrecedence(deltas []int32) error {
+	if s == nil || s.root == 0 || len(deltas) != len(s.records) {
+		return errors.New("parser-core phase zero: selected precedence sidecar drifted")
+	}
+	recompute := func(id SelectedNodeID) error {
+		record := &s.records[id-1]
+		value := deltas[id-1]
+		for index := uint32(0); index < uint32(record.ChildCount); index++ {
+			child := s.children[record.FirstChild+index]
+			var err error
+			value, err = checkedSelectedPrecedence(value, s.records[child-1].DynamicPrecedence)
+			if err != nil {
+				return err
+			}
+		}
+		record.DynamicPrecedence = value
+		return nil
+	}
+	for index := range s.records {
+		if err := recompute(SelectedNodeID(index + 1)); err != nil {
+			return err
+		}
+	}
+	return recompute(s.root)
 }
 
 // BuildAuthenticatedSelectedStore uses the immutable policy captured from the
@@ -432,7 +594,7 @@ func (s *SelectedStore) normalizeGoCompatibility(policy SelectedStorePolicy, sou
 	}
 	// First drop implicit semicolon transport nodes. Compact the child arena in
 	// one pass so dead windows do not survive in retained bytes.
-	children := make([]SelectedNodeID, 0, len(s.children))
+	children := s.children[:0]
 	for index := range s.records {
 		if index&255 == 0 {
 			if err := poll(); err != nil {
@@ -636,6 +798,10 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 		return errors.New("parser-core phase zero: selected store sealed no logical roots")
 	}
 	if len(roots) == 1 {
+		root := s.records[roots[0]-1]
+		if root.Extra() || root.Symbol != policy.ExpectedRoot {
+			return errors.New("parser-core phase zero: selected store root is not authenticated")
+		}
 		s.root = roots[0]
 		return nil
 	}
@@ -654,18 +820,19 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 	}
 	realID := roots[realIndex]
 	real := &s.records[realID-1]
-	oldChildren := append([]SelectedNodeID(nil), s.children[real.FirstChild:real.FirstChild+uint32(real.ChildCount)]...)
-	merged := make([]SelectedNodeID, 0, len(roots)-1+len(oldChildren))
-	merged = append(merged, roots[:realIndex]...)
-	merged = append(merged, oldChildren...)
-	merged = append(merged, roots[realIndex+1:]...)
-	if len(merged) > math.MaxUint16 || len(s.children)+len(merged) > math.MaxUint32 {
+	oldStart := real.FirstChild
+	oldEnd := oldStart + uint32(real.ChildCount)
+	mergedCount := len(roots) - 1 + int(real.ChildCount)
+	if mergedCount > math.MaxUint16 || len(s.children)+mergedCount > math.MaxUint32 {
 		return errors.New("parser-core phase zero: selected root extras exceed arena")
 	}
 	real.FirstChild = uint32(len(s.children))
-	real.ChildCount = uint16(len(merged))
+	real.ChildCount = uint16(mergedCount)
 	real.StartByte = 0
-	s.children = append(s.children, merged...)
+	s.children = append(s.children, roots[:realIndex]...)
+	s.children = append(s.children, s.children[oldStart:oldEnd]...)
+	s.children = append(s.children, roots[realIndex+1:]...)
+	merged := s.children[real.FirstChild:]
 	for childIndex, child := range merged {
 		s.records[child-1].Parent = realID
 		s.records[child-1].ChildIndex = uint16(childIndex)
@@ -675,21 +842,37 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 }
 
 func (c *Core) selectedRawOccurrences(roots []SubtreeID, poll func() error) ([]selectedRawOccurrence, []uint32, []uint32, error) {
-	raw := make([]selectedRawOccurrence, 0, len(c.subtrees))
-	children := make([]uint32, 0, len(c.children))
-	rootOccurrences := make([]uint32, 0, len(roots))
-	type frame struct {
-		occurrence uint32
-		next       uint32
+	rawCapacity := min(len(c.subtrees), int(c.limits.MaxSelectedOccurrences))
+	raw := c.selectedBuild.raw[:0]
+	if cap(raw) < rawCapacity {
+		raw = make([]selectedRawOccurrence, 0, rawCapacity)
 	}
-	stack := make([]frame, 0, 64)
+	children := c.selectedBuild.rawChildren[:0]
+	childCapacity := min(len(c.children), int(c.limits.MaxSelectedOccurrences))
+	if cap(children) < childCapacity {
+		children = make([]uint32, 0, childCapacity)
+	}
+	rootOccurrences := c.selectedBuild.rawRoots[:0]
+	if cap(rootOccurrences) < len(roots) {
+		rootOccurrences = make([]uint32, 0, len(roots))
+	}
+	stack := c.selectedBuild.stack[:0]
+	if cap(stack) < 64 {
+		stack = make([]selectedOccurrenceFrame, 0, 64)
+	}
+	c.selectedBuild.raw, c.selectedBuild.rawChildren = raw, children
+	c.selectedBuild.rawRoots, c.selectedBuild.stack = rootOccurrences, stack
 	var work uint64
 	appendOccurrence := func(payload SubtreeID, alias Symbol, field FieldID) (uint32, error) {
 		record, err := c.subtree(payload)
 		if err != nil {
 			return 0, err
 		}
-		if record.childCount > math.MaxUint16 || len(raw) >= math.MaxUint32 || len(children)+int(record.childCount) > math.MaxUint32 {
+		if record.childCount > math.MaxUint16 || uint64(len(raw))+1 > uint64(c.limits.MaxSelectedOccurrences) ||
+			uint64(len(children))+uint64(record.childCount) > uint64(c.limits.MaxSelectedOccurrences) {
+			return 0, errors.New("parser-core phase zero: raw selected occurrence cap")
+		}
+		if len(raw) >= math.MaxUint32 || uint64(len(children))+uint64(record.childCount) > math.MaxUint32 {
 			return 0, errors.New("parser-core phase zero: raw selected occurrence exceeds arena")
 		}
 		id := uint32(len(raw))
@@ -703,7 +886,7 @@ func (c *Core) selectedRawOccurrences(roots []SubtreeID, poll func() error) ([]s
 			return nil, nil, nil, err
 		}
 		rootOccurrences = append(rootOccurrences, rootID)
-		stack = append(stack, frame{occurrence: rootID})
+		stack = append(stack, selectedOccurrenceFrame{occurrence: rootID})
 		for len(stack) != 0 {
 			work++
 			if work&255 == 0 {
@@ -746,8 +929,10 @@ func (c *Core) selectedRawOccurrences(roots []SubtreeID, poll func() error) ([]s
 				return nil, nil, nil, err
 			}
 			children[parent.firstChild+ordinal] = childID
-			stack = append(stack, frame{occurrence: childID})
+			stack = append(stack, selectedOccurrenceFrame{occurrence: childID})
 		}
 	}
+	c.selectedBuild.raw, c.selectedBuild.rawChildren = raw, children
+	c.selectedBuild.rawRoots, c.selectedBuild.stack = rootOccurrences, stack
 	return raw, children, rootOccurrences, nil
 }

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -461,10 +461,10 @@ func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy,
 		if !meta.Visible && !record.extra {
 			continue
 		}
-		if len(logical) > math.MaxUint16 || len(store.children)+len(logical) > math.MaxUint32 || len(store.records) >= math.MaxUint32 {
+		if len(logical) > math.MaxUint16 || uint64(len(store.children))+uint64(len(logical)) > math.MaxUint32 || uint64(len(store.records)) >= math.MaxUint32 {
 			return nil, errors.New("parser-core phase zero: selected store exceeded uint32 arena")
 		}
-		id := SelectedNodeID(len(store.records) + 1)
+		id := SelectedNodeID(uint64(len(store.records)) + 1)
 		first := uint32(len(store.children))
 		store.children = append(store.children, logical...)
 		flags := selectedFlags(meta, record.extra, record.external, record.terminal)
@@ -771,7 +771,7 @@ func (s *SelectedStore) normalizeCaseBoundary(current *SelectedNodeRecord, nextS
 	target, newline := selectedTrailingTriviaBoundaryBefore(nextStart, source)
 	if newline {
 		current.EndByte = target
-		if tail.EndByte > target || tail.EndByte < target && selectedTrivia(source, tail.EndByte, target) {
+		if tail.EndByte > target || (tail.EndByte < target && selectedTrivia(source, tail.EndByte, target)) {
 			tail.EndByte = target
 		}
 		return
@@ -826,6 +826,20 @@ func (s *SelectedStore) applyDirectField(ids []SelectedNodeID, field FieldID) {
 	}
 }
 
+func selectedRootMergeCounts(childCount, rootCount int, realChildCount uint16) (int, int, error) {
+	if childCount < 0 || rootCount < 1 {
+		return 0, 0, errors.New("parser-core phase zero: invalid selected root counts")
+	}
+	extraCount := uint64(rootCount - 1)
+	mergedCount := extraCount + uint64(realChildCount)
+	finalChildren := uint64(childCount) + extraCount
+	maxInt := uint64(^uint(0) >> 1)
+	if mergedCount > math.MaxUint16 || finalChildren > math.MaxUint32 || finalChildren > maxInt {
+		return 0, 0, errors.New("parser-core phase zero: selected root extras exceed arena")
+	}
+	return int(mergedCount), int(finalChildren), nil
+}
+
 func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStorePolicy, retainedCap uint64) error {
 	if len(roots) == 0 {
 		return errors.New("parser-core phase zero: selected store sealed no logical roots")
@@ -860,10 +874,9 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 	oldStart := real.FirstChild
 	oldEnd := oldStart + uint32(real.ChildCount)
 	extraCount := len(roots) - 1
-	mergedCount := extraCount + int(real.ChildCount)
-	finalChildren := len(s.children) + extraCount
-	if mergedCount > math.MaxUint16 || finalChildren > math.MaxUint32 {
-		return errors.New("parser-core phase zero: selected root extras exceed arena")
+	mergedCount, finalChildren, err := selectedRootMergeCounts(len(s.children), len(roots), real.ChildCount)
+	if err != nil {
+		return err
 	}
 	childCapacity := cap(s.children)
 	if childCapacity < finalChildren {
@@ -932,7 +945,7 @@ func (c *Core) selectedRawOccurrences(roots []SubtreeID, poll func() error) ([]s
 			uint64(len(children))+uint64(record.childCount) > uint64(c.limits.MaxSelectedOccurrences) {
 			return 0, errors.New("parser-core phase zero: raw selected occurrence cap")
 		}
-		if len(raw) >= math.MaxUint32 || uint64(len(children))+uint64(record.childCount) > math.MaxUint32 {
+		if uint64(len(raw)) >= math.MaxUint32 || uint64(len(children))+uint64(record.childCount) > math.MaxUint32 {
 			return 0, errors.New("parser-core phase zero: raw selected occurrence exceeds arena")
 		}
 		id := uint32(len(raw))

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -1,0 +1,227 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func selectedStoreTestPolicy(t *testing.T, visible ...Symbol) SelectedStorePolicy {
+	t.Helper()
+	symbols := make([]SelectedSymbolPolicy, 16)
+	for _, symbol := range visible {
+		symbols[symbol] = SelectedSymbolPolicy{Visible: true, Named: true}
+	}
+	unary := make([]SelectedUnaryRule, len(symbols)*len(symbols))
+	policy, err := NewSelectedStorePolicy(symbols, unary, visible[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy
+}
+
+func TestSelectedStorePreservesRepeatedOccurrenceIdentity(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent, err := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{leaf, leaf}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := compact.BuildSelectedStore([]SubtreeID{parent}, selectedStoreTestPolicy(t, 2, 1), []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _ := store.Record(store.Root())
+	left, _ := store.Child(root, 0)
+	right, _ := store.Child(root, 1)
+	if left == 0 || right == 0 || left == right || store.NodeCount() != 3 {
+		t.Fatalf("selected occurrences left=%d right=%d nodes=%d", left, right, store.NodeCount())
+	}
+}
+
+func TestSelectedStoreElidesHiddenParentsBeforeSeal(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	hidden, _ := compact.appendSubtree(subtreeRecord{symbol: 3, endByte: 1}, []SubtreeID{leaf}, nil, nil)
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{hidden}, nil, nil)
+	policy := selectedStoreTestPolicy(t, 2, 1)
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootRecord, _ := store.Record(store.Root())
+	child, _ := store.Child(rootRecord, 0)
+	childRecord, _ := store.Record(child)
+	if store.NodeCount() != 2 || childRecord.Symbol != 1 {
+		t.Fatalf("hidden-elided nodes=%d child=%+v", store.NodeCount(), childRecord)
+	}
+}
+
+func TestSelectedStoreDoesNotCollapseExtraUnaryChild(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	extra, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true, extra: true}, nil, nil, nil)
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{extra}, nil, nil)
+	policy := selectedStoreTestPolicy(t, 2, 1)
+	policy.Unary[int(Symbol(2))*len(policy.Symbols)+int(Symbol(1))] = SelectedUnaryPass
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.NodeCount() != 2 {
+		t.Fatalf("extra unary child collapsed: nodes=%d", store.NodeCount())
+	}
+}
+
+func TestSelectedStoreRejectsMalformedPolicy(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	valid := selectedStoreTestPolicy(t, 1)
+	tests := []struct {
+		name   string
+		mutate func(*SelectedStorePolicy)
+	}{
+		{name: "unary-width", mutate: func(policy *SelectedStorePolicy) { policy.Unary = policy.Unary[:1] }},
+		{name: "root", mutate: func(policy *SelectedStorePolicy) { policy.ExpectedRoot = Symbol(len(policy.Symbols)) }},
+		{name: "partial-compat", mutate: func(policy *SelectedStorePolicy) { policy.Cases = make([]bool, len(policy.Symbols)) }},
+		{name: "compat-width", mutate: func(policy *SelectedStorePolicy) {
+			policy.SemicolonContainers = make([]bool, len(policy.Symbols)-1)
+			policy.Cases = make([]bool, len(policy.Symbols))
+			policy.StatementLists = make([]bool, len(policy.Symbols))
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			policy := valid
+			test.mutate(&policy)
+			store, err := compact.BuildSelectedStore([]SubtreeID{leaf}, policy, []byte("x"), nil)
+			if err == nil || store != nil {
+				t.Fatalf("malformed policy store=%v err=%v", store, err)
+			}
+		})
+	}
+}
+
+func TestSelectedStoreDeepTraversalIsIterativeAndCancellable(t *testing.T) {
+	const depth = 20_000
+	compact, err := New(&fakeTable{}, Limits{MaxSubtrees: depth + 1, MaxChildren: depth + 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	for index := 0; index < depth; index++ {
+		root, err = compact.appendSubtree(subtreeRecord{symbol: 3, endByte: 1}, []SubtreeID{root}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	policy := selectedStoreTestPolicy(t, 1)
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.NodeCount() != 1 {
+		t.Fatalf("deep hidden store nodes=%d", store.NodeCount())
+	}
+	stop := errors.New("stop")
+	polls := 0
+	stopped, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), func() error {
+		polls++
+		if polls == 2 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) || stopped != nil {
+		t.Fatalf("cancelled store=%v err=%v", stopped, err)
+	}
+}
+
+func TestSelectedStoreDeclinesUnsupportedFieldProfile(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	parent, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{leaf}, []FieldMapEntry{{FieldID: 1, ChildIndex: 0, Inherited: true}}, nil)
+	store, err := compact.BuildSelectedStore([]SubtreeID{parent}, selectedStoreTestPolicy(t, 2, 1), []byte("x"), nil)
+	if err == nil || store != nil || !strings.Contains(err.Error(), "outside admitted") {
+		t.Fatalf("unsupported field store=%v err=%v", store, err)
+	}
+}
+
+type selectedStorePolicyTable struct {
+	fakeTable
+	policy SelectedStorePolicy
+}
+
+func (t *selectedStorePolicyTable) SelectedStorePolicy() (SelectedStorePolicy, error) {
+	return t.policy, nil
+}
+
+func TestSelectedStoreAuthenticatedPolicyCapability(t *testing.T) {
+	policy := selectedStoreTestPolicy(t, 1)
+	tables := &selectedStorePolicyTable{policy: policy}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	store, err := compact.BuildAuthenticatedSelectedStore([]SubtreeID{leaf}, []byte("x"), nil)
+	if err != nil || store == nil || store.NodeCount() != 1 {
+		t.Fatalf("authenticated store=%v err=%v", store, err)
+	}
+	if err := compact.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	if stale, err := compact.BuildAuthenticatedSelectedStore([]SubtreeID{leaf}, []byte("x"), nil); err == nil || stale != nil {
+		t.Fatalf("stale accepted roots store=%v err=%v", stale, err)
+	}
+	withoutPolicy, _ := New(&fakeTable{}, Limits{})
+	if missing, err := withoutPolicy.BuildAuthenticatedSelectedStore([]SubtreeID{1}, []byte("x"), nil); err == nil || missing != nil {
+		t.Fatalf("missing policy store=%v err=%v", missing, err)
+	}
+}
+
+func TestSelectedCursorWalksSealedStore(t *testing.T) {
+	compact, _ := New(&fakeTable{}, Limits{})
+	left, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	right, _ := compact.appendSubtree(subtreeRecord{symbol: 1, startByte: 1, endByte: 2, terminal: true}, nil, nil, nil)
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 2}, []SubtreeID{left, right}, nil, nil)
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, selectedStoreTestPolicy(t, 2, 1), []byte("xx"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := store.Cursor()
+	row, ok := cursor.Record()
+	if !ok || row.Symbol != 2 || row.ChildCount != 2 {
+		t.Fatalf("root cursor=%+v ok=%t", row, ok)
+	}
+	child, ok := cursor.Child(1)
+	if !ok {
+		t.Fatal("cursor child unavailable")
+	}
+	parent, ok := child.Parent()
+	if !ok || parent.ID() != cursor.ID() {
+		t.Fatalf("cursor parent=%d ok=%t", parent.ID(), ok)
+	}
+	first, _ := cursor.Child(0)
+	next, ok := first.NextSibling()
+	if !ok || next.ID() != child.ID() {
+		t.Fatalf("cursor next sibling=%d ok=%t want=%d", next.ID(), ok, child.ID())
+	}
+}

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -416,6 +416,30 @@ func TestSelectedStoreSiblingReleasesAreSynchronized(t *testing.T) {
 	}
 }
 
+func TestSelectedRootMergeCountsPreflightArithmetic(t *testing.T) {
+	tests := []struct {
+		name                          string
+		children, roots, realChildren int
+		wantMerged, wantFinal         int
+		wantErr                       bool
+	}{
+		{name: "ordinary", children: 10, roots: 3, realChildren: 2, wantMerged: 4, wantFinal: 12},
+		{name: "merged-overflow", children: 0, roots: math.MaxUint16 + 2, wantErr: true},
+		{name: "int-addition-overflow", children: int(^uint(0) >> 1), roots: 2, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			merged, final, err := selectedRootMergeCounts(test.children, test.roots, uint16(test.realChildren))
+			if (err != nil) != test.wantErr {
+				t.Fatalf("selectedRootMergeCounts() error=%v wantErr=%t", err, test.wantErr)
+			}
+			if !test.wantErr && (merged != test.wantMerged || final != test.wantFinal) {
+				t.Fatalf("selectedRootMergeCounts()=(%d,%d) want=(%d,%d)", merged, final, test.wantMerged, test.wantFinal)
+			}
+		})
+	}
+}
+
 func TestSelectedCursorWalksSealedStore(t *testing.T) {
 	compact, _ := New(&fakeTable{}, Limits{})
 	left, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -2,6 +2,7 @@ package parsercorephase0
 
 import (
 	"errors"
+	"math"
 	"strings"
 	"testing"
 )
@@ -116,6 +117,39 @@ func TestSelectedStoreRejectsMalformedPolicy(t *testing.T) {
 	}
 }
 
+func TestSelectedStoreEnforcesOccurrenceAndRetainedByteCaps(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		limits Limits
+		want   string
+	}{
+		{name: "occurrences", limits: Limits{MaxSelectedOccurrences: 2, MaxSelectedBytes: 1 << 20}, want: "occurrence cap"},
+		{name: "retained-bytes", limits: Limits{MaxSelectedOccurrences: 8, MaxSelectedBytes: 1}, want: "retained-byte cap"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			compact, err := New(&fakeTable{}, test.limits)
+			if err != nil {
+				t.Fatal(err)
+			}
+			leaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+			root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{leaf, leaf}, nil, nil)
+			store, err := compact.BuildSelectedStore([]SubtreeID{root}, selectedStoreTestPolicy(t, 2, 1), []byte("x"), nil)
+			if err == nil || store != nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("capped store=%v err=%v want=%q", store, err, test.want)
+			}
+		})
+	}
+}
+
+func TestSelectedStorePrecedenceOverflowFailsClosed(t *testing.T) {
+	if _, err := checkedSelectedPrecedence(math.MaxInt32, 1); err == nil {
+		t.Fatal("positive selected precedence overflow succeeded")
+	}
+	if _, err := checkedSelectedPrecedence(math.MinInt32, -1); err == nil {
+		t.Fatal("negative selected precedence overflow succeeded")
+	}
+}
+
 func TestSelectedStoreDeepTraversalIsIterativeAndCancellable(t *testing.T) {
 	const depth = 20_000
 	compact, err := New(&fakeTable{}, Limits{MaxSubtrees: depth + 1, MaxChildren: depth + 1})
@@ -188,9 +222,31 @@ func TestSelectedStoreAuthenticatedPolicyCapability(t *testing.T) {
 	if err := compact.Reset(); err != nil {
 		t.Fatal(err)
 	}
+	if record, ok := store.Record(store.Root()); !ok || record.Symbol != 1 || record.StartByte != 0 || record.EndByte != 1 {
+		t.Fatalf("sealed store changed after core reset: record=%+v ok=%t", record, ok)
+	}
 	if stale, err := compact.BuildAuthenticatedSelectedStore([]SubtreeID{leaf}, []byte("x"), nil); err == nil || stale != nil {
 		t.Fatalf("stale accepted roots store=%v err=%v", stale, err)
 	}
+	retained := store.RetainedBytes()
+	store.Release()
+	store.Release()
+	if retained == 0 || store.Root() != 0 || store.NodeCount() != 0 || store.ChildCount() != 0 || store.RetainedBytes() != 0 {
+		t.Fatalf("released store remained readable: retained=%d root=%d nodes=%d children=%d bytes=%d",
+			retained, store.Root(), store.NodeCount(), store.ChildCount(), store.RetainedBytes())
+	}
+	if _, ok := store.Record(1); ok {
+		t.Fatal("released store record remained readable")
+	}
+	if _, ok := store.Cursor().Record(); ok {
+		t.Fatal("released store cursor remained readable")
+	}
+	freshLeaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	freshStore, err := compact.BuildAuthenticatedSelectedStore([]SubtreeID{freshLeaf}, []byte("x"), nil)
+	if err != nil || freshStore == nil || freshStore.NodeCount() != 1 {
+		t.Fatalf("store backing was not reusable after release: store=%v err=%v", freshStore, err)
+	}
+	freshStore.Release()
 	withoutPolicy, _ := New(&fakeTable{}, Limits{})
 	if missing, err := withoutPolicy.BuildAuthenticatedSelectedStore([]SubtreeID{1}, []byte("x"), nil); err == nil || missing != nil {
 		t.Fatalf("missing policy store=%v err=%v", missing, err)

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"math"
 	"strings"
+	"sync"
 	"testing"
+	"unsafe"
 )
 
 func selectedStoreTestPolicy(t *testing.T, visible ...Symbol) SelectedStorePolicy {
@@ -201,9 +203,11 @@ func TestSelectedStoreDeclinesUnsupportedFieldProfile(t *testing.T) {
 type selectedStorePolicyTable struct {
 	fakeTable
 	policy SelectedStorePolicy
+	calls  int
 }
 
 func (t *selectedStorePolicyTable) SelectedStorePolicy() (SelectedStorePolicy, error) {
+	t.calls++
 	return t.policy, nil
 }
 
@@ -214,10 +218,16 @@ func TestSelectedStoreAuthenticatedPolicyCapability(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if tables.calls != 0 {
+		t.Fatalf("selected policy was built eagerly: calls=%d", tables.calls)
+	}
 	leaf, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
 	store, err := compact.BuildAuthenticatedSelectedStore([]SubtreeID{leaf}, []byte("x"), nil)
 	if err != nil || store == nil || store.NodeCount() != 1 {
 		t.Fatalf("authenticated store=%v err=%v", store, err)
+	}
+	if tables.calls != 1 {
+		t.Fatalf("selected policy lazy calls=%d want=1", tables.calls)
 	}
 	if err := compact.Reset(); err != nil {
 		t.Fatal(err)
@@ -246,10 +256,163 @@ func TestSelectedStoreAuthenticatedPolicyCapability(t *testing.T) {
 	if err != nil || freshStore == nil || freshStore.NodeCount() != 1 {
 		t.Fatalf("store backing was not reusable after release: store=%v err=%v", freshStore, err)
 	}
+	if tables.calls != 1 {
+		t.Fatalf("selected policy was rebuilt: calls=%d", tables.calls)
+	}
 	freshStore.Release()
 	withoutPolicy, _ := New(&fakeTable{}, Limits{})
 	if missing, err := withoutPolicy.BuildAuthenticatedSelectedStore([]SubtreeID{1}, []byte("x"), nil); err == nil || missing != nil {
 		t.Fatalf("missing policy store=%v err=%v", missing, err)
+	}
+}
+
+func TestSelectedStoreAuthenticatedPolicyCancellationPrecedesLazyBuild(t *testing.T) {
+	policy := selectedStoreTestPolicy(t, 1)
+	tables := &selectedStorePolicyTable{policy: policy}
+	compact, err := New(tables, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := errors.New("stop before policy")
+	store, err := compact.BuildAuthenticatedSelectedStore([]SubtreeID{1}, []byte("x"), func() error { return stop })
+	if !errors.Is(err, stop) || store != nil {
+		t.Fatalf("cancelled authenticated store=%v err=%v", store, err)
+	}
+	if tables.calls != 0 {
+		t.Fatalf("cancelled authenticated policy calls=%d want=0", tables.calls)
+	}
+}
+
+func TestSelectedStoreRootMergePreflightsCapAndLaterBuildRemainsBounded(t *testing.T) {
+	recordBytes := uint64(unsafe.Sizeof(SelectedNodeRecord{}))
+	childBytes := uint64(unsafe.Sizeof(SelectedNodeID(0)))
+	limit := 3*recordBytes + childBytes
+	compact, err := New(&fakeTable{}, Limits{MaxSelectedOccurrences: 8, MaxSelectedBytes: limit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{child}, nil, nil)
+	extra, _ := compact.appendSubtree(subtreeRecord{symbol: 3, endByte: 1, terminal: true, extra: true}, nil, nil, nil)
+	policy := selectedStoreTestPolicy(t, 2, 1, 3)
+	if store, err := compact.BuildSelectedStore([]SubtreeID{extra, root}, policy, []byte("x"), nil); err == nil || store != nil || !strings.Contains(err.Error(), "retained-byte cap") {
+		t.Fatalf("over-cap merged roots store=%v err=%v", store, err)
+	}
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Release()
+	if got := store.RetainedBytes(); got > limit {
+		t.Fatalf("later selected store retained=%d cap=%d", got, limit)
+	}
+}
+
+func TestSelectedStoreRootMergeRelocatesLaterChildWindows(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootChild, _ := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, []SubtreeID{rootChild}, nil, nil)
+	extraChild, _ := compact.appendSubtree(subtreeRecord{symbol: 4, endByte: 1, terminal: true}, nil, nil, nil)
+	extra, _ := compact.appendSubtree(subtreeRecord{symbol: 3, endByte: 1, extra: true}, []SubtreeID{extraChild}, nil, nil)
+	store, err := compact.BuildSelectedStore([]SubtreeID{extra, root}, selectedStoreTestPolicy(t, 2, 1, 3, 4), []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Release()
+	rootRecord, _ := store.Record(store.Root())
+	extraID, ok := store.Child(rootRecord, 0)
+	if !ok {
+		t.Fatal("merged extra root is missing")
+	}
+	extraRecord, _ := store.Record(extraID)
+	extraChildID, ok := store.Child(extraRecord, 0)
+	extraChildRecord, _ := store.Record(extraChildID)
+	if !ok || extraRecord.Symbol != 3 || extraRecord.ChildCount != 1 || extraChildRecord.Symbol != 4 {
+		t.Fatalf("relocated extra window extra=%+v child=%+v ok=%t", extraRecord, extraChildRecord, ok)
+	}
+}
+
+func TestSelectedStoreRejectsNonExtraSiblingRootAndRecoversLifecycle(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _ := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1, terminal: true}, nil, nil, nil)
+	other, _ := compact.appendSubtree(subtreeRecord{symbol: 3, endByte: 1, terminal: true}, nil, nil, nil)
+	policy := selectedStoreTestPolicy(t, 2, 3)
+	if store, err := compact.BuildSelectedStore([]SubtreeID{other, root}, policy, []byte("x"), nil); err == nil || store != nil || !strings.Contains(err.Error(), "non-extra sibling root") {
+		t.Fatalf("non-extra sibling store=%v err=%v", store, err)
+	}
+	if got := selectedStoreRetainedBytes(cap(compact.selectedPool.records), cap(compact.selectedPool.children)); got > compact.limits.MaxSelectedBytes {
+		t.Fatalf("failed sibling lifecycle pooled=%d cap=%d", got, compact.limits.MaxSelectedBytes)
+	}
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Release()
+}
+
+func TestSelectedStorePoolKeepsAtomicCappedBackingPair(t *testing.T) {
+	recordBytes := uint64(unsafe.Sizeof(SelectedNodeRecord{}))
+	childBytes := uint64(unsafe.Sizeof(SelectedNodeID(0)))
+	type capacities struct{ records, children int }
+	largeRecords := capacities{records: 20, children: 1}
+	largeChildren := capacities{records: 1, children: 100}
+	limit := max(
+		uint64(largeRecords.records)*recordBytes+uint64(largeRecords.children)*childBytes,
+		uint64(largeChildren.records)*recordBytes+uint64(largeChildren.children)*childBytes,
+	)
+	for _, order := range []struct {
+		name        string
+		first, last capacities
+	}{
+		{name: "records-then-children", first: largeRecords, last: largeChildren},
+		{name: "children-then-records", first: largeChildren, last: largeRecords},
+	} {
+		t.Run(order.name, func(t *testing.T) {
+			compact, err := New(&fakeTable{}, Limits{MaxSelectedBytes: limit})
+			if err != nil {
+				t.Fatal(err)
+			}
+			makeStore := func(c capacities) *SelectedStore {
+				return &SelectedStore{owner: compact, records: make([]SelectedNodeRecord, 0, c.records), children: make([]SelectedNodeID, 0, c.children)}
+			}
+			first, last := makeStore(order.first), makeStore(order.last)
+			first.Release()
+			last.Release()
+			pooled := compact.selectedPool
+			if got := selectedStoreRetainedBytes(cap(pooled.records), cap(pooled.children)); got > limit {
+				t.Fatalf("pooled pair retained=%d cap=%d", got, limit)
+			}
+			got := capacities{records: cap(pooled.records), children: cap(pooled.children)}
+			if got != largeRecords && got != largeChildren {
+				t.Fatalf("pooled pair synthesized capacities=%+v", got)
+			}
+		})
+	}
+}
+
+func TestSelectedStoreSiblingReleasesAreSynchronized(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	left := &SelectedStore{owner: compact, records: make([]SelectedNodeRecord, 0, 8), children: make([]SelectedNodeID, 0, 8)}
+	right := &SelectedStore{owner: compact, records: make([]SelectedNodeRecord, 0, 4), children: make([]SelectedNodeID, 0, 4)}
+	var wait sync.WaitGroup
+	wait.Add(2)
+	go func() { defer wait.Done(); left.Release() }()
+	go func() { defer wait.Done(); right.Release() }()
+	wait.Wait()
+	compact.selectedPoolMu.Lock()
+	retained := selectedStoreRetainedBytes(cap(compact.selectedPool.records), cap(compact.selectedPool.children))
+	compact.selectedPoolMu.Unlock()
+	if retained > compact.limits.MaxSelectedBytes {
+		t.Fatalf("concurrent releases retained=%d cap=%d", retained, compact.limits.MaxSelectedBytes)
 	}
 }
 

--- a/parsercore_phase0_action_test.go
+++ b/parsercore_phase0_action_test.go
@@ -103,6 +103,33 @@ func TestParserCoreRootTablesRejectInvalidActionWhileCaching(t *testing.T) {
 	}
 }
 
+func TestParserCoreRootlessTablesRemainUsableWithoutSelectedStorePolicy(t *testing.T) {
+	lang := &Language{
+		LargeStateCount: 1,
+		ParseTable:      [][]uint16{{0}},
+		ParseActions:    []ParseActionEntry{{}},
+	}
+	parser := NewParser(lang)
+	if parser.hasRootSymbol {
+		t.Fatal("fixture unexpectedly authenticated a root symbol")
+	}
+	tables, err := newParserCoreRootTables(parser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := tables.SelectedStorePolicy()
+	if err != nil || len(policy.Symbols) != 0 {
+		t.Fatalf("rootless selected policy=%+v err=%v", policy, err)
+	}
+	compact, err := core.New(tables, core.Limits{})
+	if err != nil {
+		t.Fatalf("rootless compact core construction: %v", err)
+	}
+	if store, err := compact.BuildAuthenticatedSelectedStore([]core.SubtreeID{1}, nil, nil); err == nil || store != nil {
+		t.Fatalf("rootless selected store=%v err=%v", store, err)
+	}
+}
+
 func TestParserCoreSameLookaheadGuardsDeclineBeforeMutation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -390,11 +390,13 @@ func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
 			tables.reductionPlanIndex[pairIndex] = uint16(len(tables.reductionPlans))
 		}
 	}
-	policy, err := buildParserCoreSelectedStorePolicy(parser)
-	if err != nil {
-		return nil, err
+	if parser.hasRootSymbol {
+		policy, err := buildParserCoreSelectedStorePolicy(parser)
+		if err != nil {
+			return nil, err
+		}
+		tables.selectedStorePolicy = policy
 	}
-	tables.selectedStorePolicy = policy
 	return tables, nil
 }
 
@@ -465,7 +467,7 @@ func buildParserCoreSelectedStorePolicy(parser *Parser) (core.SelectedStorePolic
 
 func (a *parserCoreRootTables) SelectedStorePolicy() (core.SelectedStorePolicy, error) {
 	if a == nil || len(a.selectedStorePolicy.Symbols) == 0 {
-		return core.SelectedStorePolicy{}, errors.New("parser-core phase zero: selected-store policy is unavailable")
+		return core.SelectedStorePolicy{}, nil
 	}
 	return a.selectedStorePolicy, nil
 }
@@ -1297,7 +1299,6 @@ type diagnosticParserCoreGenericScheduler struct {
 	epochProgress              bool
 	acceptedHead               core.Head
 	acceptedPayloads           []core.SubtreeID
-	selectedStore              *core.SelectedStore
 	conflictPostExecutionFault func() error
 	extraPostExecutionFault    func() error
 	freshSessionOwner          *core.SchedulerTransactionToken
@@ -2078,10 +2079,6 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 		return err
 	}
 	path := paths[0]
-	selectedStore, err := s.compact.BuildAuthenticatedSelectedStore(path.Payloads, s.tokenSource.lexer.source, nil)
-	if err != nil {
-		return err
-	}
 	var header DiagnosticParserCoreHeaderPathReceipt
 	var payloads []uint32
 	if s.fullReceipts() {
@@ -2103,7 +2100,6 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 	}
 	s.acceptedHead = s.headers[0].head
 	s.acceptedPayloads = append(s.acceptedPayloads[:0], path.Payloads...)
-	s.selectedStore = selectedStore
 	s.receipt.Acceptance = &DiagnosticParserCoreGenericAcceptance{
 		ElectionIndex: s.electionIndex, Token: s.token, Header: header,
 		Payloads: payloads, Score: path.Score, BranchOrder: path.BranchOrder,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -323,6 +323,7 @@ type parserCoreRootTables struct {
 	reductionPlans      []core.ReductionPlan
 	reductionPlanIndex  []uint16
 	reductionPlanStride int
+	selectedStorePolicy core.SelectedStorePolicy
 }
 
 func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
@@ -389,7 +390,84 @@ func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
 			tables.reductionPlanIndex[pairIndex] = uint16(len(tables.reductionPlans))
 		}
 	}
+	policy, err := buildParserCoreSelectedStorePolicy(parser)
+	if err != nil {
+		return nil, err
+	}
+	tables.selectedStorePolicy = policy
 	return tables, nil
+}
+
+func buildParserCoreSelectedStorePolicy(parser *Parser) (core.SelectedStorePolicy, error) {
+	if parser == nil || parser.language == nil || !parser.hasRootSymbol {
+		return core.SelectedStorePolicy{}, errors.New("parser-core phase zero: selected-store policy requires an authenticated parser root")
+	}
+	lang := parser.language
+	width := max(len(lang.SymbolMetadata), len(lang.SymbolNames), int(lang.SymbolCount))
+	symbols := make([]core.SelectedSymbolPolicy, width)
+	for index := range symbols {
+		visible, named := true, false
+		if index < len(lang.SymbolMetadata) {
+			visible = lang.SymbolMetadata[index].Visible
+			named = lang.SymbolMetadata[index].Named
+		}
+		symbols[index] = core.SelectedSymbolPolicy{Visible: visible, Named: named}
+	}
+	if width != 0 && width > math.MaxInt/width {
+		return core.SelectedStorePolicy{}, errors.New("parser-core phase zero: selected-store unary policy overflow")
+	}
+	unary := make([]core.SelectedUnaryRule, width*width)
+	for parent := 0; parent < width; parent++ {
+		for child := 0; child < width; child++ {
+			parentSymbol, childSymbol := Symbol(parent), Symbol(child)
+			rule := core.SelectedUnaryKeep
+			switch {
+			case parentSymbol == childSymbol && !parser.isSharedVisibleAnonymousToken(childSymbol):
+				rule = core.SelectedUnaryPass
+			case parser.canCollapseInvisibleUnaryWrapperSymbol(parentSymbol):
+				rule = core.SelectedUnaryPass
+			case parser.canCollapseNamedLeafWrapper(parentSymbol, childSymbol) &&
+				!parser.shouldPreserveVisibleUnaryTokenWrapper(parentSymbol) &&
+				!parser.shouldKeepVisibleAnonymousTokenChild(parentSymbol, childSymbol):
+				rule = core.SelectedUnaryRenameLeaf
+			}
+			unary[parent*width+child] = rule
+		}
+	}
+	policy, err := core.NewSelectedStorePolicy(symbols, unary, core.Symbol(parser.rootSymbol))
+	if err != nil {
+		return core.SelectedStorePolicy{}, err
+	}
+	syms, _ := goCompatibilitySymbolsForLanguage(lang)
+	containers := make([]bool, width)
+	for _, symbol := range syms.semiContainers[:syms.semiContainerLen] {
+		if int(symbol) < width {
+			containers[symbol] = true
+		}
+	}
+	cases := make([]bool, width)
+	for _, symbol := range [...]Symbol{syms.expressionCase, syms.defaultCase, syms.typeCase, syms.communicationCase} {
+		if symbol != 0 && int(symbol) < width {
+			cases[symbol] = true
+		}
+	}
+	statementLists := make([]bool, width)
+	for _, symbol := range [...]Symbol{syms.statementList, syms.statementListTail} {
+		if symbol != 0 && int(symbol) < width {
+			statementLists[symbol] = true
+		}
+	}
+	if err := policy.SetGoCompatibility(core.Symbol(syms.semicolon), core.Symbol(syms.semicolonSentinel), containers, cases, statementLists); err != nil {
+		return core.SelectedStorePolicy{}, err
+	}
+	return policy, nil
+}
+
+func (a *parserCoreRootTables) SelectedStorePolicy() (core.SelectedStorePolicy, error) {
+	if a == nil || len(a.selectedStorePolicy.Symbols) == 0 {
+		return core.SelectedStorePolicy{}, errors.New("parser-core phase zero: selected-store policy is unavailable")
+	}
+	return a.selectedStorePolicy, nil
 }
 
 func (a *parserCoreRootTables) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {
@@ -586,7 +664,7 @@ func diagnosticParseParserCoreGenericFromSeed(
 		return result, &diagnosticParserCoreDecline{boundary: result.Boundary, detail: result.Detail}
 	}
 	return publishDiagnosticParserCoreGenericResult(result, scheduler, func(head core.Head) (*Tree, error) {
-		return materializeDiagnosticParserCoreAcceptedTree(compact, head, parser, source)
+		return materializeDiagnosticParserCoreAcceptedSelection(compact, head, scheduler.acceptedPayloads, parser, source)
 	})
 }
 
@@ -1218,6 +1296,8 @@ type diagnosticParserCoreGenericScheduler struct {
 	work                       DiagnosticParserCoreGenericWork
 	epochProgress              bool
 	acceptedHead               core.Head
+	acceptedPayloads           []core.SubtreeID
+	selectedStore              *core.SelectedStore
 	conflictPostExecutionFault func() error
 	extraPostExecutionFault    func() error
 	freshSessionOwner          *core.SchedulerTransactionToken
@@ -1578,6 +1658,13 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 	if len(derivations) != 1 {
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreAccept, detail: "materialization requires one exact accepted derivation"}
 	}
+	return materializeDiagnosticParserCoreAcceptedSelection(compact, head, derivations[0].Payloads, parser, source)
+}
+
+func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head core.Head, payloads []core.SubtreeID, parser *Parser, source []byte) (*Tree, error) {
+	if compact == nil || parser == nil || parser.language == nil || head.Node == 0 || len(payloads) == 0 {
+		return nil, errors.New("parser-core phase zero: incomplete accepted-tree selection input")
+	}
 	stats, err := compact.Stats(head)
 	if err != nil {
 		return nil, err
@@ -1609,7 +1696,7 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 		return nil, err
 	}
 	err = withDiagnosticParserCoreMaterializationScratch(parser, func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
-		return compact.VisitMaterializationPostorder(derivations[0].Payloads, poll, func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
+		return compact.VisitMaterializationPostorder(payloads, poll, func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
 			if view.EndByte < view.StartByte || view.EndByte > uint32(len(source)) {
 				return errors.New("parser-core phase zero: compact subtree extent is outside source")
 			}
@@ -1674,8 +1761,8 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 		return nil, err
 	}
 
-	nodes := make([]*Node, len(derivations[0].Payloads))
-	for index, payload := range derivations[0].Payloads {
+	nodes := make([]*Node, len(payloads))
+	for index, payload := range payloads {
 		if uint64(payload) >= uint64(len(nodesByID)) || nodesByID[payload] == nil {
 			return nil, errors.New("parser-core phase zero: compact materialization order omitted an accepted payload")
 		}
@@ -1991,6 +2078,10 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 		return err
 	}
 	path := paths[0]
+	selectedStore, err := s.compact.BuildAuthenticatedSelectedStore(path.Payloads, s.tokenSource.lexer.source, nil)
+	if err != nil {
+		return err
+	}
 	var header DiagnosticParserCoreHeaderPathReceipt
 	var payloads []uint32
 	if s.fullReceipts() {
@@ -2011,6 +2102,8 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 		header.Header = receipt
 	}
 	s.acceptedHead = s.headers[0].head
+	s.acceptedPayloads = append(s.acceptedPayloads[:0], path.Payloads...)
+	s.selectedStore = selectedStore
 	s.receipt.Acceptance = &DiagnosticParserCoreGenericAcceptance{
 		ElectionIndex: s.electionIndex, Token: s.token, Header: header,
 		Payloads: payloads, Score: path.Score, BranchOrder: path.BranchOrder,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -323,7 +323,6 @@ type parserCoreRootTables struct {
 	reductionPlans      []core.ReductionPlan
 	reductionPlanIndex  []uint16
 	reductionPlanStride int
-	selectedStorePolicy core.SelectedStorePolicy
 }
 
 func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
@@ -389,13 +388,6 @@ func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
 			tables.reductionPlans = append(tables.reductionPlans, plan)
 			tables.reductionPlanIndex[pairIndex] = uint16(len(tables.reductionPlans))
 		}
-	}
-	if parser.hasRootSymbol {
-		policy, err := buildParserCoreSelectedStorePolicy(parser)
-		if err != nil {
-			return nil, err
-		}
-		tables.selectedStorePolicy = policy
 	}
 	return tables, nil
 }
@@ -466,10 +458,10 @@ func buildParserCoreSelectedStorePolicy(parser *Parser) (core.SelectedStorePolic
 }
 
 func (a *parserCoreRootTables) SelectedStorePolicy() (core.SelectedStorePolicy, error) {
-	if a == nil || len(a.selectedStorePolicy.Symbols) == 0 {
+	if a == nil || a.parser == nil || !a.parser.hasRootSymbol {
 		return core.SelectedStorePolicy{}, nil
 	}
-	return a.selectedStorePolicy, nil
+	return buildParserCoreSelectedStorePolicy(a.parser)
 }
 
 func (a *parserCoreRootTables) Actions(state core.StateID, symbol core.Symbol) (core.ActionRow, error) {

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -133,6 +133,13 @@ func (r *parserCoreFreshFullRunner) materialize(source []byte, compact *core.Cor
 	return materializeDiagnosticParserCoreAcceptedTree(compact, head, r.parser, source)
 }
 
+func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact *core.Core, scheduler *diagnosticParserCoreGenericScheduler) (*Tree, error) {
+	if r == nil || scheduler == nil {
+		return nil, errors.New("parser-core fresh-full selected materialization is incomplete")
+	}
+	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source)
+}
+
 func (r *parserCoreFreshFullRunner) parse(source []byte) (*Tree, error) {
 	if r == nil || r.compact == nil {
 		return nil, errors.New("parser-core fresh-full runner is incomplete")
@@ -142,9 +149,28 @@ func (r *parserCoreFreshFullRunner) parse(source []byte) (*Tree, error) {
 		return nil, err
 	}
 	defer tokenSource.Close()
-	tree, err := r.materialize(source, r.compact, scheduler.acceptedHead)
+	tree, err := r.materializeSelection(source, r.compact, scheduler)
 	if err != nil {
 		return nil, err
 	}
 	return tree, nil
+}
+
+func (r *parserCoreFreshFullRunner) parseSelectedStore(source []byte) (*core.SelectedStore, error) {
+	if r == nil || r.compact == nil {
+		return nil, errors.New("parser-core fresh-full selected-store runner is incomplete")
+	}
+	scheduler, tokenSource, err := r.executeSchedulerOpen(source, r.compact, true)
+	if err != nil {
+		return nil, err
+	}
+	defer tokenSource.Close()
+	if scheduler.selectedStore == nil || scheduler.selectedStore.Root() == 0 {
+		return nil, errors.New("parser-core fresh-full selected-store route fell back")
+	}
+	root, ok := scheduler.selectedStore.Record(scheduler.selectedStore.Root())
+	if !ok || root.StartByte != 0 || root.EndByte != uint32(len(source)) {
+		return nil, fmt.Errorf("parser-core fresh-full selected-store root is incomplete: %d..%d source=%d", root.StartByte, root.EndByte, len(source))
+	}
+	return scheduler.selectedStore, nil
 }

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -182,9 +182,22 @@ func (r *parserCoreFreshFullRunner) parseSelectedStore(source []byte) (*core.Sel
 	if err != nil {
 		return nil, err
 	}
+	return requireParserCoreSelectedStoreCompleteness(store, len(source))
+}
+
+// requireParserCoreSelectedStoreCompleteness adopts store on success and
+// releases it on every failure. Callers must not retain another owner.
+func requireParserCoreSelectedStoreCompleteness(store *core.SelectedStore, sourceBytes int) (*core.SelectedStore, error) {
+	if store == nil || sourceBytes < 0 || uint64(sourceBytes) > uint64(^uint32(0)) {
+		if store != nil {
+			store.Release()
+		}
+		return nil, errors.New("parser-core fresh-full selected-store completeness input is invalid")
+	}
 	root, ok := store.Record(store.Root())
-	if !ok || root.StartByte != 0 || root.EndByte != uint32(len(source)) {
-		return nil, fmt.Errorf("parser-core fresh-full selected-store root is incomplete: %d..%d source=%d", root.StartByte, root.EndByte, len(source))
+	if !ok || root.StartByte != 0 || root.EndByte != uint32(sourceBytes) {
+		store.Release()
+		return nil, fmt.Errorf("parser-core fresh-full selected-store root is incomplete: %d..%d source=%d", root.StartByte, root.EndByte, sourceBytes)
 	}
 	return store, nil
 }

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -165,12 +165,26 @@ func (r *parserCoreFreshFullRunner) parseSelectedStore(source []byte) (*core.Sel
 		return nil, err
 	}
 	defer tokenSource.Close()
-	if scheduler.selectedStore == nil || scheduler.selectedStore.Root() == 0 {
-		return nil, errors.New("parser-core fresh-full selected-store route fell back")
+	leaveBudget := r.parser.enterParseBudget()
+	defer leaveBudget()
+	poller := parseStopPoller{check: r.parser.activeParseStopCheck(), memoryBudgetParser: r.parser}
+	poll := func() error {
+		reason := poller.pollNow()
+		if reason == ParseStopNone || reason == "" {
+			return nil
+		}
+		return &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreCap,
+			detail:   "selected-store sealing stopped: " + string(reason),
+		}
 	}
-	root, ok := scheduler.selectedStore.Record(scheduler.selectedStore.Root())
+	store, err := r.compact.BuildAuthenticatedSelectedStore(scheduler.acceptedPayloads, source, poll)
+	if err != nil {
+		return nil, err
+	}
+	root, ok := store.Record(store.Root())
 	if !ok || root.StartByte != 0 || root.EndByte != uint32(len(source)) {
 		return nil, fmt.Errorf("parser-core fresh-full selected-store root is incomplete: %d..%d source=%d", root.StartByte, root.EndByte, len(source))
 	}
-	return scheduler.selectedStore, nil
+	return store, nil
 }

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
@@ -73,6 +74,45 @@ func TestParserCoreFreshFullRunnerResetsAfterCap(t *testing.T) {
 	requireDiagnosticParserCoreCanonicalEOF(t, tree, len(fixture.Source))
 	if work := runner.compact.Work(); work != diagnosticParserCoreCanonicalAdmissions[0].work || work.Overflow {
 		t.Fatalf("parse after cap work=%+v want=%+v", work, diagnosticParserCoreCanonicalAdmissions[0].work)
+	}
+}
+
+func TestParserCoreFreshFullPublicRouteIsSelectedStoreFree(t *testing.T) {
+	options := parserCoreFreshFullCanonicalOptions()
+	options.Limits.MaxSelectedOccurrences = 1
+	options.Limits.MaxSelectedBytes = 1
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	tree, err := runner.parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("public compatibility route paid selected-store cap: %v", err)
+	}
+	tree.Release()
+	if store, err := runner.parseSelectedStore(fixture.Source); err == nil || store != nil || !strings.Contains(err.Error(), "occurrence cap") {
+		t.Fatalf("direct selected-store cap store=%v err=%v", store, err)
+	}
+}
+
+func TestParserCoreFreshFullSelectedStorePollsCancellation(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cancelled uint32
+	runner.parser.SetCancellationFlag(&cancelled)
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	atomic.StoreUint32(&cancelled, 1)
+	store, err := runner.parseSelectedStore(fixture.Source)
+	if err == nil || store != nil || !strings.Contains(err.Error(), "selected-store sealing stopped: cancelled") {
+		t.Fatalf("cancelled direct store=%v err=%v", store, err)
+	}
+	atomic.StoreUint32(&cancelled, 0)
+	store, err = runner.parseSelectedStore(fixture.Source)
+	if err != nil || store == nil {
+		t.Fatalf("selected store after cancellation reset=%v err=%v", store, err)
 	}
 }
 
@@ -200,10 +240,11 @@ func BenchmarkParserCoreFreshFullSelectedStoreCanonical(b *testing.B) {
 			if got := diagnosticParserCoreSelectedStoreDeepDigest(b, store, runner.lang, fixture.Source); got != row.deepTreeSHA256 {
 				b.Fatalf("selected digest=%s want=%s", got, row.deepTreeSHA256)
 			}
-			var scratch []core.SelectedNodeID
-			if checksum, retained := diagnosticParserCoreTraverseSelectedStore(store, scratch); checksum == 0 || retained == nil {
+			if checksum := diagnosticParserCoreTraverseSelectedStore(store); checksum == 0 {
 				b.Fatal("selected traversal preflight failed")
 			}
+			retainedBytes := store.RetainedBytes()
+			store.Release()
 			runtime.GC()
 			b.ReportAllocs()
 			b.SetBytes(int64(len(fixture.Source)))
@@ -214,9 +255,8 @@ func BenchmarkParserCoreFreshFullSelectedStoreCanonical(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				var value uint64
-				value, scratch = diagnosticParserCoreTraverseSelectedStore(store, scratch)
-				checksum ^= value
+				checksum ^= diagnosticParserCoreTraverseSelectedStore(store)
+				store.Release()
 			}
 			b.StopTimer()
 			if checksum == ^uint64(0) {
@@ -224,37 +264,42 @@ func BenchmarkParserCoreFreshFullSelectedStoreCanonical(b *testing.B) {
 			}
 			if work := runner.compact.Work(); work != row.work || work.Overflow {
 				b.Fatalf("selected work=%+v want=%+v", work, row.work)
+			} else {
+				reportParserCoreFreshFullWork(b, work)
 			}
-			b.ReportMetric(0, "candidate_fallback/op")
-			b.ReportMetric(float64(store.RetainedBytes()), "selected_retained_B/op")
+			b.ReportMetric(float64(retainedBytes), "selected_retained_B/op")
 		})
 	}
 }
 
-func diagnosticParserCoreTraverseSelectedStore(store *core.SelectedStore, scratch []core.SelectedNodeID) (uint64, []core.SelectedNodeID) {
+func diagnosticParserCoreTraverseSelectedStore(store *core.SelectedStore) uint64 {
 	if store == nil || store.Root() == 0 {
-		return 0, scratch[:0]
+		return 0
 	}
-	stack := append(scratch[:0], store.Root())
+	cursor := store.Cursor()
 	var checksum uint64
-	for len(stack) != 0 {
-		last := len(stack) - 1
-		id := stack[last]
-		stack = stack[:last]
-		record, ok := store.Record(id)
+	for {
+		record, ok := cursor.Record()
 		if !ok {
-			return 0, stack
+			return 0
 		}
-		checksum += uint64(id) + uint64(record.Symbol) + uint64(record.StartByte) + uint64(record.EndByte) + uint64(record.Field)
-		for child := int(record.ChildCount) - 1; child >= 0; child-- {
-			childID, ok := store.Child(record, uint32(child))
-			if !ok {
-				return 0, stack
+		checksum += uint64(cursor.ID()) + uint64(record.Symbol) + uint64(record.StartByte) + uint64(record.EndByte) + uint64(record.Field)
+		if child, ok := cursor.Child(0); ok {
+			cursor = child
+			continue
+		}
+		for {
+			if sibling, ok := cursor.NextSibling(); ok {
+				cursor = sibling
+				break
 			}
-			stack = append(stack, childID)
+			parent, ok := cursor.Parent()
+			if !ok {
+				return checksum
+			}
+			cursor = parent
 		}
 	}
-	return checksum, stack[:0]
 }
 
 // Keep the deep admission in a separate frame. Returning drops the only

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -178,6 +178,85 @@ func BenchmarkParserCoreFreshFullCanonical(b *testing.B) {
 	}
 }
 
+// BenchmarkParserCoreFreshFullSelectedStoreCanonical measures the same
+// authenticated scheduler lifecycle but consumes the sealed store directly.
+// The compatibility benchmark above remains the public-Node fallback/control.
+func BenchmarkParserCoreFreshFullSelectedStoreCanonical(b *testing.B) {
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		b.Run(row.id, func(b *testing.B) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(b, row.id)
+			runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+			if err != nil {
+				b.Fatal(err)
+			}
+			store, err := runner.parseSelectedStore(fixture.Source)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if got := store.NodeCount(); got != row.selectedNodes {
+				b.Fatalf("selected nodes=%d want=%d", got, row.selectedNodes)
+			}
+			if got := diagnosticParserCoreSelectedStoreDeepDigest(b, store, runner.lang, fixture.Source); got != row.deepTreeSHA256 {
+				b.Fatalf("selected digest=%s want=%s", got, row.deepTreeSHA256)
+			}
+			var scratch []core.SelectedNodeID
+			if checksum, retained := diagnosticParserCoreTraverseSelectedStore(store, scratch); checksum == 0 || retained == nil {
+				b.Fatal("selected traversal preflight failed")
+			}
+			runtime.GC()
+			b.ReportAllocs()
+			b.SetBytes(int64(len(fixture.Source)))
+			b.ResetTimer()
+			var checksum uint64
+			for index := 0; index < b.N; index++ {
+				store, err = runner.parseSelectedStore(fixture.Source)
+				if err != nil {
+					b.Fatal(err)
+				}
+				var value uint64
+				value, scratch = diagnosticParserCoreTraverseSelectedStore(store, scratch)
+				checksum ^= value
+			}
+			b.StopTimer()
+			if checksum == ^uint64(0) {
+				b.Fatal("unreachable selected traversal checksum")
+			}
+			if work := runner.compact.Work(); work != row.work || work.Overflow {
+				b.Fatalf("selected work=%+v want=%+v", work, row.work)
+			}
+			b.ReportMetric(0, "candidate_fallback/op")
+			b.ReportMetric(float64(store.RetainedBytes()), "selected_retained_B/op")
+		})
+	}
+}
+
+func diagnosticParserCoreTraverseSelectedStore(store *core.SelectedStore, scratch []core.SelectedNodeID) (uint64, []core.SelectedNodeID) {
+	if store == nil || store.Root() == 0 {
+		return 0, scratch[:0]
+	}
+	stack := append(scratch[:0], store.Root())
+	var checksum uint64
+	for len(stack) != 0 {
+		last := len(stack) - 1
+		id := stack[last]
+		stack = stack[:last]
+		record, ok := store.Record(id)
+		if !ok {
+			return 0, stack
+		}
+		checksum += uint64(id) + uint64(record.Symbol) + uint64(record.StartByte) + uint64(record.EndByte) + uint64(record.Field)
+		for child := int(record.ChildCount) - 1; child >= 0; child-- {
+			childID, ok := store.Child(record, uint32(child))
+			if !ok {
+				return 0, stack
+			}
+			stack = append(stack, childID)
+		}
+	}
+	return checksum, stack[:0]
+}
+
 // Keep the deep admission in a separate frame. Returning drops the only
 // reference to its compact arenas before the measured runner is constructed,
 // so DrainArenaPools cannot overlap the preflight and measured lifecycles.

--- a/parsercore_selected_store_internal_test.go
+++ b/parsercore_selected_store_internal_test.go
@@ -35,6 +35,7 @@ func TestDiagnosticParserCoreSelectedStoreCanonicalAdmissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer store.Release()
 			if got := store.NodeCount(); got != row.selectedNodes {
 				t.Fatalf("selected store nodes=%d want=%d", got, row.selectedNodes)
 			}
@@ -56,6 +57,29 @@ func TestDiagnosticParserCoreSelectedStoreCanonicalAdmissions(t *testing.T) {
 			t.Logf("SELECTED_STORE fixture=%s nodes=%d retained_bytes=%d", row.id, store.NodeCount(), store.RetainedBytes())
 		})
 	}
+}
+
+func TestDiagnosticParserCoreSelectedStoreCompletenessFailureReleasesBacking(t *testing.T) {
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := runner.parseSelectedStore(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if adopted, err := requireParserCoreSelectedStoreCompleteness(store, len(fixture.Source)+1); err == nil || adopted != nil {
+		t.Fatalf("incomplete selected store adopted=%v err=%v", adopted, err)
+	}
+	if store.NodeCount() != 0 || store.RetainedBytes() != 0 {
+		t.Fatalf("failed completeness retained nodes=%d bytes=%d", store.NodeCount(), store.RetainedBytes())
+	}
+	fresh, err := runner.parseSelectedStore(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fresh.Release()
 }
 
 func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *core.SelectedStore, root *Node, lang *Language) {
@@ -82,9 +106,8 @@ func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *co
 		if Symbol(record.Symbol) != current.node.symbol || record.StartByte != current.node.startByte || record.EndByte != current.node.endByte ||
 			record.Named() != current.node.IsNamed() || record.Extra() != current.node.IsExtra() || record.External() != current.node.hasFlag(nodeFlagExternalScannerToken) ||
 			record.Terminal() != terminal || int(record.ChildCount) != current.node.ChildCount() || FieldID(current.field) != treeField ||
-			StateID(record.ParseState) != current.node.parseState || StateID(record.PreGotoState) != current.node.preGotoState ||
 			record.ProductionID != current.node.productionID || record.DynamicPrecedence != current.node.dynamicPrecedence {
-			t.Fatalf("selected store metadata mismatch visit=%d store=%+v tree={sym:%d span:%d..%d named:%t extra:%t external:%t terminal:%t children:%d field:%d parse:%d pre-goto:%d production:%d precedence:%d type:%s}", visited, record, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.hasFlag(nodeFlagExternalScannerToken), terminal, current.node.ChildCount(), treeField, current.node.parseState, current.node.preGotoState, current.node.productionID, current.node.dynamicPrecedence, current.node.Type(lang))
+			t.Fatalf("selected store metadata mismatch visit=%d store=%+v tree={sym:%d span:%d..%d named:%t extra:%t external:%t terminal:%t children:%d field:%d production:%d precedence:%d type:%s}", visited, record, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.hasFlag(nodeFlagExternalScannerToken), terminal, current.node.ChildCount(), treeField, current.node.productionID, current.node.dynamicPrecedence, current.node.Type(lang))
 		}
 		for index := int(record.ChildCount) - 1; index >= 0; index-- {
 			childID, _ := store.Child(record, uint32(index))

--- a/parsercore_selected_store_internal_test.go
+++ b/parsercore_selected_store_internal_test.go
@@ -28,22 +28,25 @@ func TestDiagnosticParserCoreSelectedStoreCanonicalAdmissions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			store := scheduler.selectedStore
-			if store == nil || store.Root() == 0 {
-				t.Fatal("selected store was not carried from acceptance")
+			if len(scheduler.acceptedPayloads) == 0 {
+				t.Fatal("accepted payloads were not carried from acceptance")
+			}
+			store, err := runner.compact.BuildAuthenticatedSelectedStore(scheduler.acceptedPayloads, fixture.Source, func() error { return nil })
+			if err != nil {
+				t.Fatal(err)
 			}
 			if got := store.NodeCount(); got != row.selectedNodes {
 				t.Fatalf("selected store nodes=%d want=%d", got, row.selectedNodes)
 			}
-			if bytesPerNode := store.RetainedBytes() / store.NodeCount(); bytesPerNode > 64 {
-				t.Fatalf("selected store retained bytes/node=%d want<=64", bytesPerNode)
+			if bytesPerNode := store.RetainedBytes() / store.NodeCount(); bytesPerNode > 80 {
+				t.Fatalf("selected store retained bytes/node=%d want<=80", bytesPerNode)
 			}
 			tree, materializeErr := runner.materialize(fixture.Source, runner.compact, scheduler.acceptedHead)
 			if materializeErr != nil {
 				t.Fatal(materializeErr)
 			}
 			defer tree.Release()
-			requireDiagnosticParserCoreSelectedStoreMatchesTree(t, store, tree.root, runner.lang, runner.compact)
+			requireDiagnosticParserCoreSelectedStoreMatchesTree(t, store, tree.root, runner.lang)
 			if got := diagnosticParserCoreSelectedStoreDeepDigest(t, store, runner.lang, fixture.Source); got != row.deepTreeSHA256 {
 				t.Fatalf("selected store digest=%s want=%s", got, row.deepTreeSHA256)
 			}
@@ -55,7 +58,7 @@ func TestDiagnosticParserCoreSelectedStoreCanonicalAdmissions(t *testing.T) {
 	}
 }
 
-func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *core.SelectedStore, root *Node, lang *Language, compact *core.Core) {
+func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *core.SelectedStore, root *Node, lang *Language) {
 	t.Helper()
 	type pair struct {
 		id    core.SelectedNodeID
@@ -75,14 +78,13 @@ func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *co
 		if current.node.parent != nil && current.node.childIndex >= 0 {
 			treeField = nodeFieldIDAt(current.node.parent, int(current.node.childIndex))
 		}
-		if Symbol(record.Symbol) != current.node.symbol || record.StartByte != current.node.startByte || record.EndByte != current.node.endByte || record.Named() != current.node.IsNamed() || record.Extra() != current.node.IsExtra() || int(record.ChildCount) != current.node.ChildCount() || FieldID(current.field) != treeField {
-			raw, _ := compact.Subtree(record.Payload)
-			var rawChildren []core.SubtreeView
-			for _, childID := range raw.Children {
-				child, _ := compact.Subtree(childID)
-				rawChildren = append(rawChildren, child)
-			}
-			t.Fatalf("selected store mismatch visit=%d store={id:%d sym:%d span:%d..%d named:%t extra:%t children:%d field:%d} tree={sym:%d span:%d..%d named:%t extra:%t children:%d field:%d type:%s} raw=%+v rawChildren=%+v", visited, current.id, record.Symbol, record.StartByte, record.EndByte, record.Named(), record.Extra(), record.ChildCount, current.field, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.ChildCount(), treeField, current.node.Type(lang), raw, rawChildren)
+		terminal := current.node.ChildCount() == 0
+		if Symbol(record.Symbol) != current.node.symbol || record.StartByte != current.node.startByte || record.EndByte != current.node.endByte ||
+			record.Named() != current.node.IsNamed() || record.Extra() != current.node.IsExtra() || record.External() != current.node.hasFlag(nodeFlagExternalScannerToken) ||
+			record.Terminal() != terminal || int(record.ChildCount) != current.node.ChildCount() || FieldID(current.field) != treeField ||
+			StateID(record.ParseState) != current.node.parseState || StateID(record.PreGotoState) != current.node.preGotoState ||
+			record.ProductionID != current.node.productionID || record.DynamicPrecedence != current.node.dynamicPrecedence {
+			t.Fatalf("selected store metadata mismatch visit=%d store=%+v tree={sym:%d span:%d..%d named:%t extra:%t external:%t terminal:%t children:%d field:%d parse:%d pre-goto:%d production:%d precedence:%d type:%s}", visited, record, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.hasFlag(nodeFlagExternalScannerToken), terminal, current.node.ChildCount(), treeField, current.node.parseState, current.node.preGotoState, current.node.productionID, current.node.dynamicPrecedence, current.node.Type(lang))
 		}
 		for index := int(record.ChildCount) - 1; index >= 0; index-- {
 			childID, _ := store.Child(record, uint32(index))

--- a/parsercore_selected_store_internal_test.go
+++ b/parsercore_selected_store_internal_test.go
@@ -1,0 +1,181 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestDiagnosticParserCoreSelectedStoreCanonicalAdmissions(t *testing.T) {
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		t.Run(row.id, func(t *testing.T) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+			runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+			scheduler, tokenSource, err := runner.executeSchedulerOpen(fixture.Source, runner.compact, false)
+			if tokenSource != nil {
+				defer tokenSource.Close()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			store := scheduler.selectedStore
+			if store == nil || store.Root() == 0 {
+				t.Fatal("selected store was not carried from acceptance")
+			}
+			if got := store.NodeCount(); got != row.selectedNodes {
+				t.Fatalf("selected store nodes=%d want=%d", got, row.selectedNodes)
+			}
+			if bytesPerNode := store.RetainedBytes() / store.NodeCount(); bytesPerNode > 64 {
+				t.Fatalf("selected store retained bytes/node=%d want<=64", bytesPerNode)
+			}
+			tree, materializeErr := runner.materialize(fixture.Source, runner.compact, scheduler.acceptedHead)
+			if materializeErr != nil {
+				t.Fatal(materializeErr)
+			}
+			defer tree.Release()
+			requireDiagnosticParserCoreSelectedStoreMatchesTree(t, store, tree.root, runner.lang, runner.compact)
+			if got := diagnosticParserCoreSelectedStoreDeepDigest(t, store, runner.lang, fixture.Source); got != row.deepTreeSHA256 {
+				t.Fatalf("selected store digest=%s want=%s", got, row.deepTreeSHA256)
+			}
+			if work := runner.compact.Work(); work != row.work || work.Overflow {
+				t.Fatalf("selected store work=%+v want=%+v", work, row.work)
+			}
+			t.Logf("SELECTED_STORE fixture=%s nodes=%d retained_bytes=%d", row.id, store.NodeCount(), store.RetainedBytes())
+		})
+	}
+}
+
+func requireDiagnosticParserCoreSelectedStoreMatchesTree(t testing.TB, store *core.SelectedStore, root *Node, lang *Language, compact *core.Core) {
+	t.Helper()
+	type pair struct {
+		id    core.SelectedNodeID
+		node  *Node
+		field core.FieldID
+	}
+	stack := []pair{{id: store.Root(), node: root}}
+	for visited := 0; len(stack) != 0; visited++ {
+		last := len(stack) - 1
+		current := stack[last]
+		stack = stack[:last]
+		record, ok := store.Record(current.id)
+		if !ok || current.node == nil {
+			t.Fatalf("selected store/tree missing node at visit %d", visited)
+		}
+		treeField := FieldID(0)
+		if current.node.parent != nil && current.node.childIndex >= 0 {
+			treeField = nodeFieldIDAt(current.node.parent, int(current.node.childIndex))
+		}
+		if Symbol(record.Symbol) != current.node.symbol || record.StartByte != current.node.startByte || record.EndByte != current.node.endByte || record.Named() != current.node.IsNamed() || record.Extra() != current.node.IsExtra() || int(record.ChildCount) != current.node.ChildCount() || FieldID(current.field) != treeField {
+			raw, _ := compact.Subtree(record.Payload)
+			var rawChildren []core.SubtreeView
+			for _, childID := range raw.Children {
+				child, _ := compact.Subtree(childID)
+				rawChildren = append(rawChildren, child)
+			}
+			t.Fatalf("selected store mismatch visit=%d store={id:%d sym:%d span:%d..%d named:%t extra:%t children:%d field:%d} tree={sym:%d span:%d..%d named:%t extra:%t children:%d field:%d type:%s} raw=%+v rawChildren=%+v", visited, current.id, record.Symbol, record.StartByte, record.EndByte, record.Named(), record.Extra(), record.ChildCount, current.field, current.node.symbol, current.node.startByte, current.node.endByte, current.node.IsNamed(), current.node.IsExtra(), current.node.ChildCount(), treeField, current.node.Type(lang), raw, rawChildren)
+		}
+		for index := int(record.ChildCount) - 1; index >= 0; index-- {
+			childID, _ := store.Child(record, uint32(index))
+			childRecord, _ := store.Record(childID)
+			stack = append(stack, pair{id: childID, node: current.node.Child(index), field: childRecord.Field})
+		}
+	}
+}
+
+type selectedStoreDigest struct {
+	h     hash.Hash
+	open  uint64
+	nodes uint64
+}
+
+func diagnosticParserCoreSelectedStoreDeepDigest(t testing.TB, store *core.SelectedStore, lang *Language, source []byte) string {
+	t.Helper()
+	if store == nil || lang == nil {
+		t.Fatal("selected store digest requires store and language")
+	}
+	d := selectedStoreDigest{h: sha256.New(), open: 1}
+	_, _ = d.h.Write([]byte("gts-deep-tree-v1\x00"))
+	points, err := newDiagnosticParserCorePointIndex(source, func() error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	type item struct {
+		id    core.SelectedNodeID
+		field core.FieldID
+	}
+	stack := []item{{id: store.Root()}}
+	for len(stack) != 0 {
+		last := len(stack) - 1
+		current := stack[last]
+		stack = stack[:last]
+		record, ok := store.Record(current.id)
+		if !ok {
+			t.Fatalf("selected store omitted node %d", current.id)
+		}
+		typeName := ""
+		if int(record.Symbol) < len(lang.SymbolNames) {
+			typeName = unescapePunctuationSymbolName(lang.SymbolNames[record.Symbol])
+		}
+		fieldName := ""
+		if current.field != 0 && int(current.field) < len(lang.FieldNames) {
+			fieldName = lang.FieldNames[current.field]
+		}
+		start, end := points.point(record.StartByte), points.point(record.EndByte)
+		d.addString(typeName)
+		d.addString(fieldName)
+		for _, value := range [...]uint32{record.StartByte, record.EndByte, start.Row, start.Column, end.Row, end.Column} {
+			d.add32(value)
+		}
+		var flags byte
+		if record.Named() {
+			flags |= 1 << 0
+		}
+		if record.Extra() {
+			flags |= 1 << 1
+		}
+		_, _ = d.h.Write([]byte{flags})
+		d.add32(uint32(record.ChildCount))
+		if d.open == 0 {
+			t.Fatal("selected store digest closed before traversal ended")
+		}
+		d.open--
+		d.open += uint64(record.ChildCount)
+		d.nodes++
+		for index := int(record.ChildCount) - 1; index >= 0; index-- {
+			childID, ok := store.Child(record, uint32(index))
+			if !ok {
+				t.Fatalf("selected store child window drifted at node %d child %d", current.id, index)
+			}
+			child, ok := store.Record(childID)
+			if !ok || child.Parent != current.id {
+				t.Fatalf("selected store parent linkage drifted at child %d", childID)
+			}
+			stack = append(stack, item{id: childID, field: child.Field})
+		}
+	}
+	if d.open != 0 || d.nodes == 0 {
+		t.Fatalf("selected store digest incomplete: open=%d nodes=%d", d.open, d.nodes)
+	}
+	return fmt.Sprintf("%x", d.h.Sum(nil))
+}
+
+func (d *selectedStoreDigest) addString(value string) {
+	d.add32(uint32(len(value)))
+	_, _ = d.h.Write([]byte(value))
+}
+
+func (d *selectedStoreDigest) add32(value uint32) {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], value)
+	_, _ = d.h.Write(buf[:])
+}


### PR DESCRIPTION
## Summary

- add an immutable, pointer-free occurrence store for selected compact-parser trees
- expose allocation-light cursor traversal with explicit release, bounded pooling, and fail-closed memory caps
- keep runtime policy construction lazy so the normal public parser path remains unaffected
- add focused lifecycle, cancellation, cap, root-selection, compile-out, and isolation coverage

## Performance

On the locked real-Go GLR suite, traversing the selected store directly instead of materializing public nodes improved every fixture:

- time geomean: **-13.27%**
- allocated bytes: **-56.42%**
- max RSS: lower in both paired cycles

The authenticated static -O2 C publication reports:

- equal-fixture geomean: **2.685181x C**
- fixed-suite sum: **2.676794x C**
- worst fixture: **2.791974x C**
- exact deep-tree admission and zero fallback

## Scope

This remains a build-tagged diagnostic fresh-full consumer. It does not change Parser.Parse, and it makes no claim for recovery, incremental parsing, included ranges, multi-grammar routing, public queries, or parser-state metadata.

## Validation

- independent code and receipt review: GO
- focused unit and tagged admission tests
- Docker race and canonical admission
- scoped vet and benchmark smoke
- raw paired-board and locked-C artifact hashes re-authenticated