### PR TITLE
perf(parser): keep Common Lisp forest routing explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Keep Common Lisp on the production parser unless callers explicitly request
+  the forest path. On the locked 1,357-file corpus, the routed parser took
+  173.6 seconds versus 46.0 seconds for production, dispatched one file, fell
+  back on 1,356, and diverged on the sole dispatched result. A separate direct
+  C-oracle audit rejected that result as well. On the authenticated
+  largest-eight static-C board, disabling automatic routing completed all eight
+  files instead of timing out on two, cut the six matched files by 58.3%,
+  reduced isolated sweep wall time by 19.9%, and lowered max RSS from 2.14 GB
+  to 746 MB. Explicit forest and recovery experiments remain available.
 - Add an opt-in, build-tagged selected-tree backing store at the compact
   parser/consumer boundary. Accepted payloads are sealed only for the direct
   consumer; the public-node control remains store-free. The store preserves

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -464,6 +464,13 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // same cost on reused parsers. Their recovery policies remain available to
 // explicit forest experiments.
 //
+// Common Lisp is also explicit-only. A locked 1,357-file corpus audit at
+// 04a2cf92 measured 173.6 seconds routed versus 46.0 seconds for production,
+// dispatched one file, fell back on 1,356, and diverged on the sole dispatched
+// result. A separate direct C-oracle audit rejected that result as well. Keep
+// its recovery machinery available to explicit experiments, but do not charge
+// every normal parse for a route that almost always falls back.
+//
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
 // parserWantsForest) instead of joining this map — e.g. a grammargen consumer
 // generating its own grammar (a Pawn grammar, say) sets WantsForest directly
@@ -501,14 +508,13 @@ var builtinForestDefaults = map[string]bool{
 	"prisma":    true,
 
 	// Phase 2 promotions 2026-06-08: forest+recovery, introduced=0 vs C and a
-	// large net-wall win. Org and Vimdoc later moved back to explicit-only
-	// routing after current clean witnesses showed only discarded attempts;
-	// their certified recovery profiles remain in languageWantsForestRecover.
-	"agda":       true,
-	"ledger":     true,
-	"yuck":       true,
-	"json5":      true,
-	"commonlisp": true,
+	// large net-wall win. Org, Vimdoc, and Common Lisp later moved back to
+	// explicit-only routing after current corpus evidence showed only discarded
+	// attempts; their recovery profiles remain in languageWantsForestRecover.
+	"agda":   true,
+	"ledger": true,
+	"yuck":   true,
+	"json5":  true,
 
 	// Promoted 2026-06-08 via the forest-vs-C sweep (TestForestVsCSources):
 	// the forest introduces ZERO C-divergences (every divergence is inherited
@@ -516,8 +522,7 @@ var builtinForestDefaults = map[string]bool{
 	// arduino 1.3x. faust/arduino also FIX production: the forest matches C on
 	// files where the culled production parser does not (faust 108/120,
 	// arduino 10/19 production-mismatches that are the forest being C-correct).
-	// Held: make (forest=C-clean but net-wall NEUTRAL 1.0x — no lift) and
-	// commonlisp (net-wall unverified; rich corpus times out — revisit).
+	// Held: make (forest=C-clean but net-wall NEUTRAL 1.0x — no lift).
 	"bibtex":  true,
 	"faust":   true,
 	"arduino": true,

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -55,7 +55,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	want := []string{
 		"bash", "erlang", "cmake", "css", "scss", "javascript", "c_sharp",
 		"gitignore", "nix", "squirrel", "prisma",
-		"agda", "ledger", "yuck", "json5", "commonlisp",
+		"agda", "ledger", "yuck", "json5",
 		"bibtex", "faust", "arduino", "authzed", "make", "tlaplus",
 		"gitattributes",
 	}
@@ -70,7 +70,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// A handful of explicitly-NOT-forest-amenable languages (see the doc
 	// comment) must stay out of the curated set. "go" is intentionally held
 	// out of default dispatch (commit 6894fc9f) even though it is forest-clean.
-	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc", "fish", "racket"}
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc", "fish", "racket", "commonlisp"}
 	for _, name := range notWanted {
 		if builtinForestDefaults[name] {
 			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
@@ -100,9 +100,9 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 		t.Error("Beancount forest recovery should remain available to explicit forest runs")
 	}
 
-	// Org and Vimdoc retain the same explicit-only split without losing their
-	// certified recovery profiles.
-	for _, name := range []string{"org", "vimdoc"} {
+	// Org, Vimdoc, and Common Lisp retain the same explicit-only split without
+	// losing their recovery profiles.
+	for _, name := range []string{"org", "vimdoc", "commonlisp"} {
 		parser := &Parser{language: &Language{Name: name, WantsForest: true}}
 		if !parserWantsForest(parser) {
 			t.Errorf("explicit Language.WantsForest should still dispatch %s to forest", name)


### PR DESCRIPTION
## Summary

- stop speculating through the forest parser for normal Common Lisp parses
- retain explicit forest and recovery experiments
- document the locked corpus and static-C evidence in the changelog

## Validation

- focused unit tests and `go vet`
- Docker Common Lisp C-reference parity
- locked 1,357-file routed-vs-production and direct-C audits
- authenticated largest-eight static-C A/B

Automatic routing dispatched only one of 1,357 files, fell back on the rest, and was 3.77x slower than production across the corpus. The sole dispatch did not clear the C oracle.