### PR TITLE
perf(parser): tighten automatic forest routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Move Faust, CMake, and Erlang automatic forest routing back to explicit-only
+  experiments after full locked-corpus recertification superseded their earlier
+  small-corpus receipts. Faust remained exact across 706 files but routed in
+  9.94 seconds versus 6.52 seconds for production; CMake remained exact across
+  11,506 files but routed in 35.03 seconds versus 23.36 seconds. Erlang's route
+  improved 4,114 files from 213.14 to 183.94 seconds, but 175 routed trees
+  differed from production and 125 forest trees differed from the direct C
+  oracle. Explicit `Language.WantsForest` experiments remain available for all
+  three while route overhead and Erlang result selection are improved.
 - Keep Common Lisp on the production parser unless callers explicitly request
   the forest path. On the locked 1,357-file corpus, the routed parser took
   173.6 seconds versus 46.0 seconds for production, dispatched one file, fell

--- a/forest_incremental_correctness_test.go
+++ b/forest_incremental_correctness_test.go
@@ -71,11 +71,12 @@ func deleteEdit(src []byte, p int) forestEdit {
 // tree is byte-for-byte identical (s-expr) to a fresh parse of the same edited
 // source — only over edits that keep the source valid (an edit that breaks
 // syntax routes fresh through production error recovery, a different-but-valid
-// path). erlang + javascript pass via real forest-incremental reuse; scss/css/
-// cmake are demoted from languageAllowsForestIncrementalPath (they FAILED this
+// path). Erlang + JavaScript pass via real forest-incremental reuse; SCSS/CSS/
+// CMake are demoted from languageAllowsForestIncrementalPath (they FAILED this
 // gate — wrong/truncated trees) and reach the same assertion via fresh-parse
 // fallback. Re-adding a language to that list without it passing here regresses
-// incremental correctness.
+// incremental correctness. Each case opts in explicitly so this experimental
+// gate remains independent of automatic-routing policy.
 func TestForestIncrementalCorrectness(t *testing.T) {
 	if os.Getenv("GTS_FOREST_INCR") == "" {
 		t.Skip("set GTS_FOREST_INCR=1 to run the forest incremental correctness matrix (heavy)")
@@ -85,13 +86,10 @@ func TestForestIncrementalCorrectness(t *testing.T) {
 		file string
 		lang func() *gts.Language
 	}{
-		// These are forest-default languages (builtinForestDefaults). erlang +
-		// javascript do real forest-incremental reuse (must match fresh); scss,
-		// css and cmake are forest for full parses but demoted from the
-		// incremental path, so they reach the same assertion via fresh-parse
-		// fallback. (python is NOT a forest language and its PRODUCTION incremental
-		// reuse has its own pre-existing bug — tracked separately — so it is out of
-		// scope here.)
+		// Erlang + JavaScript do real forest-incremental reuse (must match fresh);
+		// SCSS, CSS and CMake are demoted from the incremental path, so they reach
+		// the same assertion via fresh-parse fallback. (Python's production
+		// incremental reuse has its own pre-existing bug and is out of scope.)
 		{"javascript", "cgo_harness/corpus_real/javascript/large__jquery.js", grammars.JavascriptLanguage},
 		{"scss", "cgo_harness/corpus_real/scss/large__github.com.scss", grammars.ScssLanguage},
 		{"css", "cgo_harness/corpus_real/css/large__github.com.css", grammars.CssLanguage},
@@ -105,7 +103,9 @@ func TestForestIncrementalCorrectness(t *testing.T) {
 			if err != nil {
 				t.Skipf("corpus missing: %v", err)
 			}
-			lang := tc.lang()
+			langCopy := *tc.lang()
+			langCopy.WantsForest = true
+			lang := &langCopy
 
 			// Positions spread across the file, each exercised with replace,
 			// insert and delete.

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -397,10 +397,10 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // TestForestCorpusParity (which compares all nodes, byte ranges, points,
 // named/extra/missing bits, child counts, and fields — named-only gates hid
 // systematic span bugs).
-// Measured production-vs-forest speedups on the real corpus: bash
-// 803x, erlang 664x, cmake 166x, awk 202x, javascript 36x, css 5x, scss 3x,
-// c_sharp 3x. GraphQL is clean against production here too, but stays out
-// until the production tree is C-oracle-clean on the ring matrix. The forest
+// Historical small-corpus speedups are not sufficient for admission. Current
+// locked full-corpus evidence must show both exact direct-C parity and a net
+// routed wall-time win. GraphQL is clean against production here too, but stays
+// out until the production tree is C-oracle-clean on the ring matrix. The forest
 // has no error recovery, so tryForestFastPath falls back to production on any
 // decline (failure / error / truncation); that fallback means a language can
 // never regress the cases it declines, but does NOT catch a clean-but-different
@@ -471,6 +471,15 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // its recovery machinery available to explicit experiments, but do not charge
 // every normal parse for a route that almost always falls back.
 //
+// Faust, CMake, and Erlang are explicit-only after a full-corpus
+// recertification at 04a2cf92 superseded their earlier small-corpus receipts.
+// Faust was exact across 706 files, but routing took 9.94 seconds versus 6.52
+// seconds for production. CMake was exact across 11,506 files, but routing took
+// 35.03 seconds versus 23.36 seconds. Erlang's route was faster across 4,114
+// files, but 175 routed trees differed from production and 125 forest trees
+// differed from the direct C oracle. Keep all three available to explicit
+// callers while the route overhead and Erlang result-selection gaps are worked.
+//
 // Non-built-in languages opt in per-Language via Language.WantsForest (see
 // parserWantsForest) instead of joining this map — e.g. a grammargen consumer
 // generating its own grammar (a Pawn grammar, say) sets WantsForest directly
@@ -481,8 +490,6 @@ func (p *Parser) recordForestDecline(reason string, tok Token, states []StateID)
 // responsibility.
 var builtinForestDefaults = map[string]bool{
 	"bash":       true,
-	"erlang":     true,
-	"cmake":      true,
 	"css":        true,
 	"scss":       true,
 	"javascript": true,
@@ -518,13 +525,11 @@ var builtinForestDefaults = map[string]bool{
 
 	// Promoted 2026-06-08 via the forest-vs-C sweep (TestForestVsCSources):
 	// the forest introduces ZERO C-divergences (every divergence is inherited
-	// from production) and is a net-wall WIN — bibtex 109.8x, faust 34.5x,
-	// arduino 1.3x. faust/arduino also FIX production: the forest matches C on
-	// files where the culled production parser does not (faust 108/120,
-	// arduino 10/19 production-mismatches that are the forest being C-correct).
+	// from production) and is a net-wall WIN — bibtex 109.8x and arduino 1.3x.
+	// Arduino also fixes production on 10/19 production-mismatched files. The
+	// earlier Faust promotion was superseded by the full-corpus receipt above.
 	// Held: make (forest=C-clean but net-wall NEUTRAL 1.0x — no lift).
 	"bibtex":  true,
-	"faust":   true,
 	"arduino": true,
 	"authzed": true,
 	"make":    true,

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -1167,7 +1167,9 @@ func TestForestTreeIncrementalEditCMakeTextInvariantLeafReuseIsCorrect(t *testin
 		NewEndPoint: pointForOffset(edited, offset+1),
 	}
 
-	parser := gts.NewParser(grm.CmakeLanguage())
+	lang := *grm.CmakeLanguage()
+	lang.WantsForest = true
+	parser := gts.NewParser(&lang)
 	oldTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("initial parse: %v", err)
@@ -1188,7 +1190,7 @@ func TestForestTreeIncrementalEditCMakeTextInvariantLeafReuseIsCorrect(t *testin
 		leafType := "<nil>"
 		leafText := ""
 		if leaf != nil {
-			leafType = leaf.Type(grm.CmakeLanguage())
+			leafType = leaf.Type(&lang)
 			leafText = leaf.Text(src)
 		}
 		t.Fatalf("cmake text-invariant leaf edit fell back to fresh parse: %s leaf=%s text=%q", profile.ReuseUnsupportedReason, leafType, leafText)
@@ -1204,7 +1206,7 @@ func TestForestTreeIncrementalEditCMakeTextInvariantLeafReuseIsCorrect(t *testin
 		t.Fatalf("fresh parse: %v", err)
 	}
 	defer freshTree.Release()
-	if got, want := newTree.RootNode().SExpr(grm.CmakeLanguage()), freshTree.RootNode().SExpr(grm.CmakeLanguage()); got != want {
+	if got, want := newTree.RootNode().SExpr(&lang), freshTree.RootNode().SExpr(&lang); got != want {
 		t.Fatalf("incremental CMake tree diverged from fresh parse\n got: %s\nwant: %s", got, want)
 	}
 }

--- a/language_forest_optin_test.go
+++ b/language_forest_optin_test.go
@@ -53,10 +53,10 @@ func TestParserWantsForestFieldDrivesDispatch(t *testing.T) {
 // ordinary path does not need; see the builtinForestDefaults doc comment.
 func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	want := []string{
-		"bash", "erlang", "cmake", "css", "scss", "javascript", "c_sharp",
+		"bash", "css", "scss", "javascript", "c_sharp",
 		"gitignore", "nix", "squirrel", "prisma",
 		"agda", "ledger", "yuck", "json5",
-		"bibtex", "faust", "arduino", "authzed", "make", "tlaplus",
+		"bibtex", "arduino", "authzed", "make", "tlaplus",
 		"gitattributes",
 	}
 	if len(builtinForestDefaults) != len(want) {
@@ -70,7 +70,7 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 	// A handful of explicitly-NOT-forest-amenable languages (see the doc
 	// comment) must stay out of the curated set. "go" is intentionally held
 	// out of default dispatch (commit 6894fc9f) even though it is forest-clean.
-	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc", "fish", "racket", "commonlisp"}
+	notWanted := []string{"python", "rust", "dart", "ruby", "haskell", "php", "go", "csv", "beancount", "org", "vimdoc", "fish", "racket", "commonlisp", "faust", "cmake", "erlang"}
 	for _, name := range notWanted {
 		if builtinForestDefaults[name] {
 			t.Errorf("builtinForestDefaults unexpectedly contains %q", name)
@@ -121,6 +121,15 @@ func TestBuiltinForestDefaultsCuratedSet(t *testing.T) {
 		}
 		if !languageWantsForestRecover(name) {
 			t.Errorf("%s forest recovery should remain available to explicit forest runs", name)
+		}
+	}
+
+	// Full-corpus recertification moved these legacy promotions to the same
+	// explicit-only policy without removing their experimental entry point.
+	for _, name := range []string{"faust", "cmake", "erlang"} {
+		parser := &Parser{language: &Language{Name: name, WantsForest: true}}
+		if !parserWantsForest(parser) {
+			t.Errorf("explicit Language.WantsForest should still dispatch %s to forest", name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- keep Faust and CMake on the production parser by default after full-corpus routing proved slower
- keep Erlang on the production parser by default after full-corpus forest results diverged from the locked C oracle
- preserve explicit forest experiments and make incremental forest tests opt in directly

## Validation

- authenticated full-corpus production/forest/routed/static-C receipts
- focused native and linux/386 policy tests
- `go vet .` and root package tests
- focused and full-root Docker gates
- independent exact-head review: GO, no findings

## Risk

The change only narrows automatic routing. Explicit `Language.WantsForest` remains available, and JavaScript and all other automatic routes are unchanged.