### PR TITLE
perf(query): execute selected-store highlights directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Execute Go highlight queries directly over the build-tagged compact selected
+  store through value node handles, without constructing public-node proxies.
+  All four locked real-Go fixtures preserve exact ordered query captures,
+  directives, and final highlight ranges; unsupported missing-node queries
+  decline explicitly. On the exact rebased revision, selected-store query time
+  improves by 8.51% and B/op by 14.18% against the public-tree control by
+  equal-fixture geomean. End-to-end selected parse plus highlight improves by
+  12.90% with 26.38% fewer B/op, and every fixture median is faster. A balanced
+  two-order public `Query.Execute` control preserves wall time while reducing
+  B/op and allocations by 14.50%; direct streaming-cursor allocations remain
+  unchanged. The selected route remains diagnostic-only.
 - Keep Common Lisp on the production parser unless callers explicitly request
   the forest path. On the locked 1,357-file corpus, the routed parser took
   173.6 seconds versus 46.0 seconds for production, dispatched one file, fell

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -208,15 +208,83 @@ func selectedStoreRetainedBytes(recordCapacity, childCapacity int) uint64 {
 		uint64(childCapacity)*uint64(unsafe.Sizeof(SelectedNodeID(0)))
 }
 
-func (s *SelectedStore) Record(id SelectedNodeID) (SelectedNodeRecord, bool) {
+func (s *SelectedStore) record(id SelectedNodeID) (*SelectedNodeRecord, bool) {
 	if s == nil || s.released || id == 0 || uint64(id) > uint64(len(s.records)) {
+		return nil, false
+	}
+	return &s.records[id-1], true
+}
+
+func (s *SelectedStore) Record(id SelectedNodeID) (SelectedNodeRecord, bool) {
+	record, ok := s.record(id)
+	if !ok {
 		return SelectedNodeRecord{}, false
 	}
-	return s.records[id-1], true
+	return *record, true
+}
+
+func (s *SelectedStore) NodeSymbol(id SelectedNodeID) (Symbol, bool) {
+	record, ok := s.record(id)
+	if !ok {
+		return 0, false
+	}
+	return record.Symbol, true
+}
+
+func (s *SelectedStore) NodeNamed(id SelectedNodeID) (bool, bool) {
+	record, ok := s.record(id)
+	if !ok {
+		return false, false
+	}
+	return record.Named(), true
+}
+
+func (s *SelectedStore) NodeRange(id SelectedNodeID) (uint32, uint32, bool) {
+	record, ok := s.record(id)
+	if !ok {
+		return 0, 0, false
+	}
+	return record.StartByte, record.EndByte, true
+}
+
+func (s *SelectedStore) NodeParent(id SelectedNodeID) (SelectedNodeID, bool) {
+	record, ok := s.record(id)
+	if !ok || record.Parent == 0 {
+		return 0, false
+	}
+	return record.Parent, true
+}
+
+func (s *SelectedStore) NodeChildCount(id SelectedNodeID) (uint16, bool) {
+	record, ok := s.record(id)
+	if !ok {
+		return 0, false
+	}
+	return record.ChildCount, true
+}
+
+func (s *SelectedStore) NodeField(id SelectedNodeID) (FieldID, bool) {
+	record, ok := s.record(id)
+	if !ok {
+		return 0, false
+	}
+	return record.Field, true
+}
+
+func (s *SelectedStore) ChildID(parent SelectedNodeID, index uint32) (SelectedNodeID, bool) {
+	record, ok := s.record(parent)
+	if !ok {
+		return 0, false
+	}
+	return s.child(record, index)
 }
 
 func (s *SelectedStore) Child(record SelectedNodeRecord, index uint32) (SelectedNodeID, bool) {
-	if s == nil || s.released || index >= uint32(record.ChildCount) {
+	return s.child(&record, index)
+}
+
+func (s *SelectedStore) child(record *SelectedNodeRecord, index uint32) (SelectedNodeID, bool) {
+	if s == nil || s.released || record == nil || index >= uint32(record.ChildCount) {
 		return 0, false
 	}
 	slot := uint64(record.FirstChild) + uint64(index)

--- a/parsercore_phase0_canonical_fixtures_external_test.go
+++ b/parsercore_phase0_canonical_fixtures_external_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
@@ -38,5 +39,12 @@ func init() {
 			return "", err
 		}
 		return inspection.SHA256, nil
+	})
+	gotreesitter.SetDiagnosticParserCoreGoHighlightQueryForTest(func() (string, error) {
+		entry := grammars.DetectLanguage("main.go")
+		if entry == nil {
+			return "", fmt.Errorf("Go grammar registry entry not found")
+		}
+		return entry.HighlightQuery, nil
 	})
 }

--- a/parsercore_phase0_selected_query.go
+++ b/parsercore_phase0_selected_query.go
@@ -1,0 +1,256 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+var errSelectedStoreQueryMissingUnsupported = errors.New("selected-store query route does not support MISSING patterns")
+
+type selectedStoreQueryBuffer struct {
+	matches  []queryReaderMatch[queryValueCapture[core.SelectedNodeID]]
+	worklist []queryReaderWorkItem[core.SelectedNodeID]
+	ranges   []HighlightRange
+	resolved []HighlightRange
+}
+
+type selectedStoreQueryReader struct {
+	store *core.SelectedStore
+}
+
+func (r selectedStoreQueryReader) IsNil(id core.SelectedNodeID) bool { return id == 0 }
+
+func (r selectedStoreQueryReader) Symbol(id core.SelectedNodeID) Symbol {
+	if r.store == nil {
+		return 0
+	}
+	symbol, _ := r.store.NodeSymbol(id)
+	return Symbol(symbol)
+}
+
+func (r selectedStoreQueryReader) IsNamed(id core.SelectedNodeID) bool {
+	if r.store == nil {
+		return false
+	}
+	named, _ := r.store.NodeNamed(id)
+	return named
+}
+
+// The selected clean-full route cannot contain recovery-inserted nodes. Query
+// admission rejects MISSING patterns before the matcher reaches this reader.
+func (selectedStoreQueryReader) IsMissing(core.SelectedNodeID) bool { return false }
+
+func (r selectedStoreQueryReader) Type(id core.SelectedNodeID, lang *Language) string {
+	symbol := r.Symbol(id)
+	if symbol == errorSymbol {
+		return "ERROR"
+	}
+	if lang != nil && int(symbol) < len(lang.SymbolNames) {
+		return unescapePunctuationSymbolName(lang.SymbolNames[symbol])
+	}
+	return ""
+}
+
+func (r selectedStoreQueryReader) StartByte(id core.SelectedNodeID) uint32 {
+	if r.store == nil {
+		return 0
+	}
+	start, _, _ := r.store.NodeRange(id)
+	return start
+}
+
+func (r selectedStoreQueryReader) EndByte(id core.SelectedNodeID) uint32 {
+	if r.store == nil {
+		return 0
+	}
+	_, end, _ := r.store.NodeRange(id)
+	return end
+}
+
+func (r selectedStoreQueryReader) Text(id core.SelectedNodeID, source []byte) string {
+	if r.store == nil {
+		return ""
+	}
+	start, end, ok := r.store.NodeRange(id)
+	if !ok || end < start || uint64(end) > uint64(len(source)) {
+		return ""
+	}
+	return string(source[start:end])
+}
+
+func (r selectedStoreQueryReader) Parent(id core.SelectedNodeID) (core.SelectedNodeID, bool) {
+	if r.store == nil {
+		return 0, false
+	}
+	return r.store.NodeParent(id)
+}
+
+func (r selectedStoreQueryReader) ChildCount(id core.SelectedNodeID) int {
+	if r.store == nil {
+		return 0
+	}
+	count, _ := r.store.NodeChildCount(id)
+	return int(count)
+}
+
+func (r selectedStoreQueryReader) Child(id core.SelectedNodeID, index int) (core.SelectedNodeID, bool) {
+	if r.store == nil || index < 0 {
+		return 0, false
+	}
+	return r.store.ChildID(id, uint32(index))
+}
+
+func (r selectedStoreQueryReader) ChildNamed(parent core.SelectedNodeID, index int) (bool, bool) {
+	child, ok := r.Child(parent, index)
+	if !ok {
+		return false, false
+	}
+	return r.store.NodeNamed(child)
+}
+
+func (r selectedStoreQueryReader) ChildCanMatch(q *Query, step *QueryStep, parent core.SelectedNodeID, index int, lang *Language) bool {
+	child, ok := r.Child(parent, index)
+	return ok && nodeCanMatchStepShallowWithReader(q, step, child, lang, r)
+}
+
+func (r selectedStoreQueryReader) ChildHasField(parent core.SelectedNodeID, index int, field FieldID, _ *Language) bool {
+	if field == 0 {
+		return true
+	}
+	child, ok := r.Child(parent, index)
+	if !ok {
+		return false
+	}
+	childField, ok := r.store.NodeField(child)
+	return ok && FieldID(childField) == field
+}
+
+func (r selectedStoreQueryReader) HasChildWithField(parent core.SelectedNodeID, field FieldID, lang *Language) bool {
+	for index := 0; index < r.ChildCount(parent); index++ {
+		if r.ChildHasField(parent, index, field, lang) {
+			return true
+		}
+	}
+	return false
+}
+
+func (selectedStoreQueryReader) NewCapture(name string, id core.SelectedNodeID) queryValueCapture[core.SelectedNodeID] {
+	return queryValueCapture[core.SelectedNodeID]{Name: name, Node: id}
+}
+
+func (selectedStoreQueryReader) CaptureName(capture queryValueCapture[core.SelectedNodeID]) string {
+	return capture.Name
+}
+
+func (selectedStoreQueryReader) CaptureNode(capture queryValueCapture[core.SelectedNodeID]) core.SelectedNodeID {
+	return capture.Node
+}
+
+func (selectedStoreQueryReader) CaptureTextOverride(capture queryValueCapture[core.SelectedNodeID]) string {
+	return capture.TextOverride
+}
+
+func (selectedStoreQueryReader) SetCaptureTextOverride(capture *queryValueCapture[core.SelectedNodeID], text string) {
+	capture.TextOverride = text
+}
+
+func selectedStoreQuerySupports(q *Query) bool {
+	if q == nil {
+		return false
+	}
+	for patternIndex := range q.patterns {
+		if queryStepsRequireMissing(q.patterns[patternIndex].steps) {
+			return false
+		}
+	}
+	return true
+}
+
+func executeSelectedStoreQuery(
+	q *Query,
+	store *core.SelectedStore,
+	lang *Language,
+	source []byte,
+	buffer *selectedStoreQueryBuffer,
+) ([]queryReaderMatch[queryValueCapture[core.SelectedNodeID]], error) {
+	if !selectedStoreQuerySupports(q) {
+		return nil, errSelectedStoreQueryMissingUnsupported
+	}
+	if store == nil || lang == nil || store.Root() == 0 {
+		return nil, nil
+	}
+	if buffer == nil {
+		buffer = &selectedStoreQueryBuffer{}
+	}
+	reader := selectedStoreQueryReader{store: store}
+	buffer.matches, buffer.worklist = executeQueryWithReader(
+		q,
+		store.Root(),
+		lang,
+		source,
+		reader,
+		buffer.matches[:0],
+		buffer.worklist[:0],
+	)
+	return buffer.matches, nil
+}
+
+func highlightSelectedStore(
+	q *Query,
+	store *core.SelectedStore,
+	lang *Language,
+	source []byte,
+	buffer *selectedStoreQueryBuffer,
+) ([]HighlightRange, error) {
+	if buffer == nil {
+		buffer = &selectedStoreQueryBuffer{}
+	}
+	matches, err := executeSelectedStoreQuery(q, store, lang, source, buffer)
+	if err != nil {
+		return nil, err
+	}
+	ranges := buffer.ranges[:0]
+	if cap(ranges) < len(matches) {
+		ranges = make([]HighlightRange, 0, len(matches))
+	}
+	for _, match := range matches {
+		for _, capture := range match.Captures {
+			start, end, ok := store.NodeRange(capture.Node)
+			if !ok || start == end {
+				continue
+			}
+			ranges = append(ranges, HighlightRange{
+				StartByte:    start,
+				EndByte:      end,
+				Capture:      capture.Name,
+				PatternIndex: match.PatternIndex,
+			})
+		}
+	}
+	buffer.ranges = ranges[:0]
+	if len(ranges) == 0 {
+		return nil, nil
+	}
+	resolved := resolveOverlapsInto(ranges, buffer.resolved[:0])
+	buffer.resolved = resolved[:0]
+	return resolved, nil
+}
+
+func queryStepsRequireMissing(steps []QueryStep) bool {
+	for stepIndex := range steps {
+		step := &steps[stepIndex]
+		if step.isMissing {
+			return true
+		}
+		for alternativeIndex := range step.alternatives {
+			alternative := &step.alternatives[alternativeIndex]
+			if alternative.isMissing || queryStepsRequireMissing(alternative.steps) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/parsercore_phase0_selected_query_highlight_internal_test.go
+++ b/parsercore_phase0_selected_query_highlight_internal_test.go
@@ -1,0 +1,366 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+var diagnosticParserCoreGoHighlightQueryForTest func() (string, error)
+
+// SetDiagnosticParserCoreGoHighlightQueryForTest installs the real registry
+// query from the external test package without introducing a grammars -> root
+// import cycle in the tagged internal admission suite.
+func SetDiagnosticParserCoreGoHighlightQueryForTest(loader func() (string, error)) {
+	diagnosticParserCoreGoHighlightQueryForTest = loader
+}
+
+func loadDiagnosticParserCoreGoHighlightQueryForTest() (string, error) {
+	if diagnosticParserCoreGoHighlightQueryForTest == nil {
+		return "", fmt.Errorf("diagnostic parser-core Go highlight query loader is not installed")
+	}
+	return diagnosticParserCoreGoHighlightQueryForTest()
+}
+
+type selectedQueryParityCapture struct {
+	PatternIndex int
+	CaptureIndex int
+	Name         string
+	Symbol       Symbol
+	Named        bool
+	StartByte    uint32
+	EndByte      uint32
+	Text         string
+	TextOverride string
+}
+
+func TestDiagnosticParserCoreSelectedStoreGoHighlightParity(t *testing.T) {
+	querySource, err := loadDiagnosticParserCoreGoHighlightQueryForTest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		t.Run(row.id, func(t *testing.T) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+			runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+			if err != nil {
+				t.Fatal(err)
+			}
+			query, err := NewQuery(querySource, runner.lang)
+			if err != nil {
+				t.Fatalf("compile Go highlight query: %v", err)
+			}
+			store, err := runner.parseSelectedStore(fixture.Source)
+			if err != nil {
+				t.Fatalf("selected parse: %v", err)
+			}
+			defer store.Release()
+			tree, err := runner.parse(fixture.Source)
+			if err != nil {
+				t.Fatalf("materialized parse: %v", err)
+			}
+			defer tree.Release()
+
+			var selectedBuffer selectedStoreQueryBuffer
+			selectedMatches, err := executeSelectedStoreQuery(query, store, runner.lang, fixture.Source, &selectedBuffer)
+			if err != nil {
+				t.Fatalf("selected query: %v", err)
+			}
+			publicMatches := query.Execute(tree)
+			want := normalizePublicQueryMatches(publicMatches, fixture.Source)
+			got := normalizeSelectedQueryMatches(selectedMatches, store, fixture.Source)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("ordered query output differs: selected=%d public=%d\nfirst difference: %s", len(got), len(want), firstSelectedQueryParityDifference(got, want))
+			}
+
+			selectedRanges, err := highlightSelectedStore(query, store, runner.lang, fixture.Source, &selectedBuffer)
+			if err != nil {
+				t.Fatalf("selected highlight: %v", err)
+			}
+			publicRanges := highlightRangesFromPublicMatches(publicMatches)
+			if !reflect.DeepEqual(selectedRanges, publicRanges) {
+				t.Fatalf("resolved highlights differ: selected=%d public=%d", len(selectedRanges), len(publicRanges))
+			}
+		})
+	}
+}
+
+func TestDiagnosticParserCoreSelectedStoreQueryDirectiveParity(t *testing.T) {
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := NewQuery(`
+((identifier) @name
+ (#strip! @name "^."))
+((selector_expression
+   operand: (_) @operand
+   "." @dot
+   field: (field_identifier) @field)
+ (#select-adjacent! @operand @dot))
+`, runner.lang)
+	if err != nil {
+		t.Fatalf("compile directive query: %v", err)
+	}
+	store, err := runner.parseSelectedStore(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Release()
+	tree, err := runner.parse(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+
+	selectedMatches, err := executeSelectedStoreQuery(query, store, runner.lang, fixture.Source, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := normalizePublicQueryMatches(query.Execute(tree), fixture.Source)
+	got := normalizeSelectedQueryMatches(selectedMatches, store, fixture.Source)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("directive output differs: selected=%d public=%d\nfirst difference: %s", len(got), len(want), firstSelectedQueryParityDifference(got, want))
+	}
+	stripped := 0
+	adjacent := 0
+	for _, capture := range got {
+		if capture.Name == "name" && capture.TextOverride != "" {
+			stripped++
+		}
+		if capture.Name == "operand" {
+			adjacent++
+		}
+	}
+	if stripped == 0 || adjacent == 0 {
+		t.Fatalf("directive proof was not exercised: stripped=%d adjacent=%d", stripped, adjacent)
+	}
+}
+
+func TestDiagnosticParserCoreSelectedStoreQueryMissingDeclines(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := NewQuery(`(MISSING) @missing`, runner.lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	store, err := runner.parseSelectedStore(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Release()
+	if _, err := executeSelectedStoreQuery(query, store, runner.lang, fixture.Source, nil); !errors.Is(err, errSelectedStoreQueryMissingUnsupported) {
+		t.Fatalf("missing query error=%v want=%v", err, errSelectedStoreQueryMissingUnsupported)
+	}
+}
+
+func TestDiagnosticParserCoreSelectedStoreQueryTraversalAllocations(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	query, err := NewQuery(`(identifier) @name`, runner.lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query.DisablePattern(0)
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "query_compile")
+	store, err := runner.parseSelectedStore(fixture.Source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Release()
+	var buffer selectedStoreQueryBuffer
+	if _, err := executeSelectedStoreQuery(query, store, runner.lang, fixture.Source, &buffer); err != nil {
+		t.Fatal(err)
+	}
+	allocations := testing.AllocsPerRun(20, func() {
+		matches, err := executeSelectedStoreQuery(query, store, runner.lang, fixture.Source, &buffer)
+		if err != nil || len(matches) != 0 {
+			panic("selected traversal allocation probe changed result")
+		}
+	})
+	if allocations != 0 {
+		t.Fatalf("allocation-free selected traversal: got %.2f allocs/run", allocations)
+	}
+}
+
+func BenchmarkDiagnosticParserCoreSelectedStoreGoHighlight(b *testing.B) {
+	querySource, err := loadDiagnosticParserCoreGoHighlightQueryForTest()
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		b.Run(row.id, func(b *testing.B) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(b, row.id)
+			runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+			if err != nil {
+				b.Fatal(err)
+			}
+			query, err := NewQuery(querySource, runner.lang)
+			if err != nil {
+				b.Fatal(err)
+			}
+			store, err := runner.parseSelectedStore(fixture.Source)
+			if err != nil {
+				b.Fatal(err)
+			}
+			tree, err := runner.parse(fixture.Source)
+			if err != nil {
+				store.Release()
+				b.Fatal(err)
+			}
+			var selectedBuffer selectedStoreQueryBuffer
+			selectedRanges, err := highlightSelectedStore(query, store, runner.lang, fixture.Source, &selectedBuffer)
+			if err != nil || len(selectedRanges) == 0 {
+				tree.Release()
+				store.Release()
+				b.Fatalf("selected preflight: ranges=%d err=%v", len(selectedRanges), err)
+			}
+			publicMatches := query.Execute(tree)
+			if len(publicMatches) == 0 {
+				tree.Release()
+				store.Release()
+				b.Fatal("public query preflight returned no matches")
+			}
+
+			b.Run("selected_query", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(fixture.Source)))
+				for index := 0; index < b.N; index++ {
+					matches, err := executeSelectedStoreQuery(query, store, runner.lang, fixture.Source, &selectedBuffer)
+					if err != nil || len(matches) == 0 {
+						b.Fatalf("matches=%d err=%v", len(matches), err)
+					}
+				}
+			})
+			b.Run("legacy_query", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(fixture.Source)))
+				for index := 0; index < b.N; index++ {
+					if matches := query.Execute(tree); len(matches) == 0 {
+						b.Fatal("public query returned no matches")
+					}
+				}
+			})
+			b.Run("selected_parse_highlight", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(fixture.Source)))
+				for index := 0; index < b.N; index++ {
+					candidate, err := runner.parseSelectedStore(fixture.Source)
+					if err != nil {
+						b.Fatal(err)
+					}
+					ranges, err := highlightSelectedStore(query, candidate, runner.lang, fixture.Source, &selectedBuffer)
+					candidate.Release()
+					if err != nil || len(ranges) == 0 {
+						b.Fatalf("ranges=%d err=%v", len(ranges), err)
+					}
+				}
+			})
+			b.Run("legacy_parse_highlight", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(fixture.Source)))
+				for index := 0; index < b.N; index++ {
+					candidate, err := runner.parse(fixture.Source)
+					if err != nil {
+						b.Fatal(err)
+					}
+					ranges := highlightRangesFromPublicMatches(query.Execute(candidate))
+					candidate.Release()
+					if len(ranges) == 0 {
+						b.Fatal("public parse+highlight returned no ranges")
+					}
+				}
+			})
+			tree.Release()
+			store.Release()
+		})
+	}
+}
+
+func normalizePublicQueryMatches(matches []QueryMatch, source []byte) []selectedQueryParityCapture {
+	var normalized []selectedQueryParityCapture
+	for _, match := range matches {
+		for captureIndex, capture := range match.Captures {
+			if capture.Node == nil {
+				continue
+			}
+			normalized = append(normalized, selectedQueryParityCapture{
+				PatternIndex: match.PatternIndex,
+				CaptureIndex: captureIndex,
+				Name:         capture.Name,
+				Symbol:       capture.Node.Symbol(),
+				Named:        capture.Node.IsNamed(),
+				StartByte:    capture.Node.StartByte(),
+				EndByte:      capture.Node.EndByte(),
+				Text:         capture.Node.Text(source),
+				TextOverride: capture.TextOverride,
+			})
+		}
+	}
+	return normalized
+}
+
+func normalizeSelectedQueryMatches(matches []queryReaderMatch[queryValueCapture[core.SelectedNodeID]], store *core.SelectedStore, source []byte) []selectedQueryParityCapture {
+	reader := selectedStoreQueryReader{store: store}
+	var normalized []selectedQueryParityCapture
+	for _, match := range matches {
+		for captureIndex, capture := range match.Captures {
+			normalized = append(normalized, selectedQueryParityCapture{
+				PatternIndex: match.PatternIndex,
+				CaptureIndex: captureIndex,
+				Name:         capture.Name,
+				Symbol:       reader.Symbol(capture.Node),
+				Named:        reader.IsNamed(capture.Node),
+				StartByte:    reader.StartByte(capture.Node),
+				EndByte:      reader.EndByte(capture.Node),
+				Text:         reader.Text(capture.Node, source),
+				TextOverride: capture.TextOverride,
+			})
+		}
+	}
+	return normalized
+}
+
+func firstSelectedQueryParityDifference(got, want []selectedQueryParityCapture) string {
+	limit := len(got)
+	if len(want) < limit {
+		limit = len(want)
+	}
+	for index := 0; index < limit; index++ {
+		if got[index] != want[index] {
+			return fmt.Sprintf("index=%d selected=%+v public=%+v", index, got[index], want[index])
+		}
+	}
+	return fmt.Sprintf("common prefix=%d selected=%d public=%d", limit, len(got), len(want))
+}
+
+func highlightRangesFromPublicMatches(matches []QueryMatch) []HighlightRange {
+	var ranges []HighlightRange
+	for _, match := range matches {
+		for _, capture := range match.Captures {
+			if capture.Node == nil || capture.Node.StartByte() == capture.Node.EndByte() {
+				continue
+			}
+			ranges = append(ranges, HighlightRange{
+				StartByte:    capture.Node.StartByte(),
+				EndByte:      capture.Node.EndByte(),
+				Capture:      capture.Name,
+				PatternIndex: match.PatternIndex,
+			})
+		}
+	}
+	return resolveOverlaps(ranges)
+}

--- a/query.go
+++ b/query.go
@@ -3,6 +3,7 @@ package gotreesitter
 import (
 	"fmt"
 	"regexp"
+	"slices"
 )
 
 // Query holds compiled patterns parsed from a tree-sitter .scm query file.
@@ -287,8 +288,9 @@ type queryCursorWorkItem struct {
 }
 
 type queryExecBuffer struct {
-	matches  []QueryMatch
-	worklist []queryCursorWorkItem
+	matches        []QueryMatch
+	readerMatches  []queryReaderMatch[QueryCapture]
+	readerWorklist []queryReaderWorkItem[*Node]
 }
 
 // NewQuery compiles query source (tree-sitter .scm format) against a language.
@@ -532,20 +534,8 @@ func (q *Query) executeNode(root *Node, lang *Language, source []byte) []QueryMa
 	if root == nil || lang == nil {
 		return nil
 	}
-
-	cursor := q.Exec(root, lang, source)
-	// Pre-size based on source length: empirically ~1 match per 40 bytes for
-	// typical highlight queries. Underestimating is fine; we just grow once more.
-	initCap := len(source)/40 + 16
-	matches := make([]QueryMatch, 0, initCap)
-	for {
-		m, ok := cursor.NextMatch()
-		if !ok {
-			break
-		}
-		matches = append(matches, m)
-	}
-	return matches
+	var buf queryExecBuffer
+	return q.executeNodeIntoBuffer(root, lang, source, &buf)
 }
 
 func (q *Query) executeNodeInto(root *Node, lang *Language, source []byte, dst []QueryMatch) []QueryMatch {
@@ -565,101 +555,17 @@ func (q *Query) executeNodeInto(root *Node, lang *Language, source []byte, dst [
 }
 
 func (q *Query) executeNodeIntoBuffer(root *Node, lang *Language, source []byte, buf *queryExecBuffer) []QueryMatch {
-	if root == nil || lang == nil {
-		if buf == nil {
-			return nil
-		}
-		buf.matches = buf.matches[:0]
-		buf.worklist = buf.worklist[:0]
-		return buf.matches
-	}
 	if buf == nil {
 		return q.executeNode(root, lang, source)
 	}
-	if q.rootCandidatesBySymbol == nil && q.rootFallbackCandidates == nil {
-		q.buildRootPatternIndex()
-	}
-
 	buf.matches = buf.matches[:0]
-	buf.worklist = append(buf.worklist[:0], queryCursorWorkItem{node: root, childIdx: -1, depth: 0})
-
-	for len(buf.worklist) > 0 {
-		last := len(buf.worklist) - 1
-		item := buf.worklist[last]
-		buf.worklist = buf.worklist[:last]
-
-		n := item.node
-		if n == nil {
-			continue
-		}
-		if item.post {
-			candidates := q.postorderPatternCandidates(lang.PublicSymbolForNamedness(n.Symbol(), n.IsNamed()))
-			candidates = mergePatternIndexLists(q.rootRepetitionPostPatterns, candidates)
-			for _, pi := range candidates {
-				if q.isPatternDisabled(pi) {
-					continue
-				}
-				pat := q.patterns[pi]
-				budget := newQueryMatchBudget(defaultQueryMatchWorkBudget)
-				var captureSets [][]QueryCapture
-				if pat.steps[0].quantifier == queryQuantifierZeroOrMore || pat.steps[0].quantifier == queryQuantifierOneOrMore {
-					captureSets = q.matchPatternPostorderAll(&pat, n, item.parent, item.childIdx, lang, source, budget)
-				} else {
-					captureSets = q.matchPatternAll(&pat, n, lang, source, budget)
-				}
-				for _, captures := range captureSets {
-					buf.matches = append(buf.matches, QueryMatch{
-						PatternIndex: pi,
-						Captures:     captures,
-					})
-				}
-			}
-			continue
-		}
-
-		if q.hasPostorderPatterns() {
-			buf.worklist = append(buf.worklist, queryCursorWorkItem{
-				node:     n,
-				parent:   item.parent,
-				childIdx: item.childIdx,
-				depth:    item.depth,
-				post:     true,
-			})
-		}
-
-		for i := nodeChildCountNoMaterialize(n) - 1; i >= 0; i-- {
-			child := nodeChildAtForReason(n, i, materializeForQuery)
-			if child == nil {
-				continue
-			}
-			buf.worklist = append(buf.worklist, queryCursorWorkItem{
-				node:     child,
-				parent:   n,
-				childIdx: i,
-				depth:    item.depth + 1,
-			})
-		}
-
-		candidates := q.rootPatternCandidates(lang.PublicSymbolForNamedness(n.Symbol(), n.IsNamed()))
-		for _, pi := range candidates {
-			if q.isPatternDisabled(pi) {
-				continue
-			}
-			pat := q.patterns[pi]
-			budget := newQueryMatchBudget(defaultQueryMatchWorkBudget)
-			captureSets := q.matchPatternAll(&pat, n, lang, source, budget)
-			if len(captureSets) == 0 {
-				continue
-			}
-			for _, captures := range captureSets {
-				buf.matches = append(buf.matches, QueryMatch{
-					PatternIndex: pi,
-					Captures:     captures,
-				})
-			}
-		}
+	buf.readerMatches, buf.readerWorklist = executeQueryWithReader(
+		q, root, lang, source, publicQueryReader{}, buf.readerMatches, buf.readerWorklist,
+	)
+	buf.matches = slices.Grow(buf.matches, len(buf.readerMatches))
+	for _, match := range buf.readerMatches {
+		buf.matches = append(buf.matches, QueryMatch{PatternIndex: match.PatternIndex, Captures: match.Captures})
 	}
-
 	return buf.matches
 }
 

--- a/query_matcher_generic.go
+++ b/query_matcher_generic.go
@@ -1,0 +1,463 @@
+package gotreesitter
+
+import "slices"
+
+func cloneQueryCapturesWithReader[C any](captures []C) []C {
+	if len(captures) == 0 {
+		return nil
+	}
+	return slices.Clone(captures)
+}
+
+func appendCaptureIDsWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, ids []int, node N, captures *[]C, reader R) {
+	if len(ids) == 0 {
+		return
+	}
+	if len(q.disabledCaptureName) == 0 {
+		start := len(*captures)
+		*captures = slices.Grow(*captures, len(ids))
+		expanded := (*captures)[:start+len(ids)]
+		for i, captureID := range ids {
+			expanded[start+i] = reader.NewCapture(q.captures[captureID], node)
+		}
+		*captures = expanded
+		return
+	}
+	for _, captureID := range ids {
+		name := q.captures[captureID]
+		if !q.isCaptureDisabled(name) {
+			*captures = append(*captures, reader.NewCapture(name, node))
+		}
+	}
+}
+
+func matchPatternAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, pat *Pattern, node N, lang *Language, source []byte, budget *queryMatchBudget, reader R) [][]C {
+	if len(pat.steps) == 0 || reader.IsNil(node) {
+		return nil
+	}
+	if pat.steps[0].quantifier == queryQuantifierZeroOrMore {
+		if matchesPredicatesWithReader(q, pat.predicates, []C(nil), lang, source, reader) {
+			captures := applyDirectivesWithReader(q, pat.predicates, []C(nil), source, reader)
+			return [][]C{cloneQueryCapturesWithReader(captures)}
+		}
+		return nil
+	}
+	if pat.steps[0].quantifier == queryQuantifierOneOrMore {
+		return nil
+	}
+
+	var matches [][]C
+	matchStepsAllWithReader(q, pat.steps, 0, node, *new(N), -1, lang, source, pat.predicates, nil, budget, reader, func(captures []C) {
+		if !matchesPredicatesWithReader(q, pat.predicates, captures, lang, source, reader) {
+			return
+		}
+		captures = applyDirectivesWithReader(q, pat.predicates, captures, source, reader)
+		matches = append(matches, cloneQueryCapturesWithReader(captures))
+	})
+	return matches
+}
+
+func matchPatternPostorderAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, pat *Pattern, node, parent N, childIdx int, lang *Language, source []byte, budget *queryMatchBudget, reader R) [][]C {
+	if len(pat.steps) == 0 || reader.IsNil(node) {
+		return nil
+	}
+	switch pat.steps[0].quantifier {
+	case queryQuantifierZeroOrMore, queryQuantifierOneOrMore:
+	default:
+		return nil
+	}
+	parent, childIdx = queryPatternSiblingContextWithReader(node, parent, childIdx, reader)
+	if len(matchPatternOnceAllWithReader(q, pat, node, parent, childIdx, lang, source, nil, budget, reader)) == 0 {
+		return nil
+	}
+	if next, nextParent, nextChildIdx, ok := queryAdjacentSiblingWithReader(node, parent, childIdx, 1, reader); ok {
+		if len(matchPatternOnceAllWithReader(q, pat, next, nextParent, nextChildIdx, lang, source, nil, budget, reader)) > 0 {
+			return nil
+		}
+	}
+
+	runStart, runParent, runChildIdx := node, parent, childIdx
+	for {
+		prev, prevParent, prevChildIdx, ok := queryAdjacentSiblingWithReader(runStart, runParent, runChildIdx, -1, reader)
+		if !ok || len(matchPatternOnceAllWithReader(q, pat, prev, prevParent, prevChildIdx, lang, source, nil, budget, reader)) == 0 {
+			break
+		}
+		runStart, runParent, runChildIdx = prev, prevParent, prevChildIdx
+	}
+
+	partials := [][]C{nil}
+	current, currentParent, currentChildIdx := runStart, runParent, runChildIdx
+	for !reader.IsNil(current) {
+		var nextPartials [][]C
+		for _, captures := range partials {
+			nextPartials = append(nextPartials, matchPatternOnceAllWithReader(q, pat, current, currentParent, currentChildIdx, lang, source, captures, budget, reader)...)
+		}
+		if len(nextPartials) == 0 {
+			break
+		}
+		partials = nextPartials
+		if current == node {
+			break
+		}
+		var ok bool
+		current, currentParent, currentChildIdx, ok = queryAdjacentSiblingWithReader(current, currentParent, currentChildIdx, 1, reader)
+		if !ok {
+			break
+		}
+	}
+
+	var matches [][]C
+	for _, captures := range partials {
+		if matchesPredicatesWithReader(q, pat.predicates, captures, lang, source, reader) {
+			captures = applyDirectivesWithReader(q, pat.predicates, captures, source, reader)
+			matches = append(matches, cloneQueryCapturesWithReader(captures))
+		}
+	}
+	return matches
+}
+
+func queryPatternSiblingContextWithReader[N comparable, C any, R queryNodeReader[N, C]](node, parent N, childIdx int, reader R) (N, int) {
+	if reader.IsNil(node) {
+		var zero N
+		return zero, -1
+	}
+	if !reader.IsNil(parent) && childIdx >= 0 {
+		return parent, childIdx
+	}
+	parent, ok := reader.Parent(node)
+	if !ok {
+		var zero N
+		return zero, -1
+	}
+	for i := 0; i < reader.ChildCount(parent); i++ {
+		if child, ok := reader.Child(parent, i); ok && child == node {
+			return parent, i
+		}
+	}
+	return parent, -1
+}
+
+func queryAdjacentSiblingWithReader[N comparable, C any, R queryNodeReader[N, C]](node, parent N, childIdx, delta int, reader R) (N, N, int, bool) {
+	if reader.IsNil(node) {
+		var zero N
+		return zero, zero, -1, false
+	}
+	if reader.IsNil(parent) || childIdx < 0 {
+		parent, childIdx = queryPatternSiblingContextWithReader(node, parent, childIdx, reader)
+	}
+	nextIdx := childIdx + delta
+	if reader.IsNil(parent) || nextIdx < 0 || nextIdx >= reader.ChildCount(parent) {
+		var zero N
+		return zero, parent, -1, false
+	}
+	next, ok := reader.Child(parent, nextIdx)
+	return next, parent, nextIdx, ok
+}
+
+func matchPatternOnceAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, pat *Pattern, node, parent N, childIdx int, lang *Language, source []byte, captures []C, budget *queryMatchBudget, reader R) [][]C {
+	var matches [][]C
+	matchStepsAllWithReader(q, pat.steps, 0, node, parent, childIdx, lang, source, pat.predicates, captures, budget, reader, func(next []C) {
+		matches = append(matches, cloneQueryCapturesWithReader(next))
+	})
+	return matches
+}
+
+func matchStepsAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, steps []QueryStep, stepIdx int, node, parent N, childIdx int, lang *Language, source []byte, predicates []QueryPredicate, captures []C, budget *queryMatchBudget, reader R, emit func([]C)) {
+	if stepIdx >= len(steps) || reader.IsNil(node) {
+		return
+	}
+	step := &steps[stepIdx]
+	if len(step.alternatives) > 0 {
+		matchAlternationStepAllWithReader(q, step, node, parent, childIdx, lang, source, predicates, captures, reader, func(next []C) {
+			matchStepChildrenAllWithReader(q, steps, stepIdx, node, lang, source, predicates, next, budget, reader, emit)
+		})
+		return
+	}
+	if !nodeMatchesStepWithReader(q, step, node, lang, reader) {
+		return
+	}
+	next := cloneQueryCapturesWithReader(captures)
+	appendCaptureIDsWithReader(q, step.captureIDs, node, &next, reader)
+	if predicatesStillViableWithReader(q, predicates, next, source, reader) {
+		matchStepChildrenAllWithReader(q, steps, stepIdx, node, lang, source, predicates, next, budget, reader, emit)
+	}
+}
+
+func matchStepChildrenAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, steps []QueryStep, stepIdx int, node N, lang *Language, source []byte, predicates []QueryPredicate, captures []C, budget *queryMatchBudget, reader R, emit func([]C)) {
+	step := &steps[stepIdx]
+	childStart := stepIdx + 1
+	if childStart >= len(steps) || steps[childStart].depth <= step.depth {
+		emit(captures)
+		return
+	}
+	childDepth := step.depth + 1
+	var inline [16]queryChildStepInfo
+	childSteps := inline[:0]
+	for i := childStart; i < len(steps) && steps[i].depth > step.depth; i++ {
+		if steps[i].depth == childDepth {
+			childSteps = append(childSteps, queryChildStepInfo{stepIdx: i, field: steps[i].field})
+		}
+	}
+	matchChildStepsAllWithReader(q, node, steps, childSteps, lang, source, predicates, captures, budget, reader, emit)
+}
+
+func matchAlternationStepAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, step *QueryStep, node, parent N, childIdx int, lang *Language, source []byte, predicates []QueryPredicate, captures []C, reader R, emit func([]C)) {
+	hasStepCaptures := len(step.captureIDs) > 0
+	nodeNamed := reader.IsNamed(node)
+	nodeSymbol := lang.PublicSymbolForNamedness(reader.Symbol(node), nodeNamed)
+	var nodeType string
+	nodeTypeLoaded := false
+	for i := range step.alternatives {
+		alt := &step.alternatives[i]
+		if !alternativeMatchesNodeWithReader(*alt, node, lang, nodeSymbol, nodeNamed, &nodeType, &nodeTypeLoaded, reader) ||
+			!alternativeFieldMatchesWithReader(alt, node, parent, childIdx, lang, reader) {
+			continue
+		}
+		next := cloneQueryCapturesWithReader(captures)
+		if matchAlternationBranchWithReader(q, step, alt, node, lang, source, predicates, &next, hasStepCaptures, reader) {
+			emit(next)
+		}
+	}
+}
+
+func matchAlternationBranchWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, step *QueryStep, alt *alternativeSymbol, node N, lang *Language, source []byte, predicates []QueryPredicate, captures *[]C, hasStepCaptures bool, reader R) bool {
+	if len(alt.steps) > 0 {
+		checkpoint := len(*captures)
+		if hasStepCaptures {
+			appendCaptureIDsWithReader(q, step.captureIDs, node, captures, reader)
+			if !predicatesStillViableWithReader(q, predicates, *captures, source, reader) {
+				*captures = (*captures)[:checkpoint]
+				return false
+			}
+		}
+		matched := false
+		matchStepsAllWithReader(q, alt.steps, 0, node, *new(N), -1, lang, source, predicates, *captures, newQueryMatchBudget(defaultQueryMatchWorkBudget), reader, func(next []C) {
+			if matched {
+				return
+			}
+			if len(alt.predicates) == 0 || matchesPredicatesWithReader(q, alt.predicates, next, lang, source, reader) {
+				*captures = cloneQueryCapturesWithReader(next)
+				matched = true
+			}
+		})
+		if !matched {
+			*captures = (*captures)[:checkpoint]
+		}
+		return matched
+	}
+	if !hasStepCaptures && len(alt.captureIDs) == 0 {
+		return true
+	}
+	checkpoint := len(*captures)
+	if hasStepCaptures {
+		appendCaptureIDsWithReader(q, step.captureIDs, node, captures, reader)
+		if !predicatesStillViableWithReader(q, predicates, *captures, source, reader) {
+			*captures = (*captures)[:checkpoint]
+			return false
+		}
+	}
+	appendCaptureIDsWithReader(q, alt.captureIDs, node, captures, reader)
+	if !predicatesStillViableWithReader(q, predicates, *captures, source, reader) {
+		*captures = (*captures)[:checkpoint]
+		return false
+	}
+	return true
+}
+
+func matchChildStepsAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, parent N, steps []QueryStep, childSteps []queryChildStepInfo, lang *Language, source []byte, predicates []QueryPredicate, captures []C, budget *queryMatchBudget, reader R, emit func([]C)) {
+	childCount := reader.ChildCount(parent)
+	var inline [64]int
+	namedPositions := inline[:0]
+	if childCount <= len(inline) {
+		namedPositions = inline[:childCount]
+	} else {
+		namedPositions = make([]int, childCount)
+	}
+	namedPosition := 0
+	for i := 0; i < childCount; i++ {
+		named, ok := reader.ChildNamed(parent, i)
+		if ok && named {
+			namedPositions[i] = namedPosition
+			namedPosition++
+		} else {
+			namedPositions[i] = -1
+		}
+	}
+	matchChildStepsRecursiveAllWithReader(q, parent, namedPositions, namedPosition-1, steps, childSteps, 0, 0, false, -1, lang, source, predicates, captures, budget, reader, emit)
+}
+
+func matchChildStepsRecursiveAllWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, parent N, namedPositions []int, parentLastNamedPos int, steps []QueryStep, childSteps []queryChildStepInfo, childPos, nextChildIdx int, prevHasNamed bool, prevLastNamedPos int, lang *Language, source []byte, predicates []QueryPredicate, captures []C, budget *queryMatchBudget, reader R, emit func([]C)) {
+	if childPos >= len(childSteps) {
+		emit(captures)
+		return
+	}
+	cs := childSteps[childPos]
+	step := &steps[cs.stepIdx]
+	minCount, maxCount, ok := quantifierBounds(step.quantifier)
+	if !ok {
+		return
+	}
+	var inline [32]int
+	candidates, ok := collectChildCandidateIndicesWithReader(q, parent, step, cs.field, nextChildIdx, lang, inline[:0], reader)
+	if !ok {
+		return
+	}
+	if maxCount < 0 || maxCount > len(candidates) {
+		maxCount = len(candidates)
+	}
+	if minCount > len(candidates) {
+		return
+	}
+	for count := maxCount; count >= minCount; count-- {
+		emittedForCount := false
+		emitForCount := emit
+		if step.quantifier != queryQuantifierOne {
+			emitForCount = func(next []C) { emittedForCount = true; emit(next) }
+		}
+		var combinations func(int, int, int, bool, int, int, []C)
+		combinations = func(candidatePos, chosen, nextIdx int, hasNamed bool, firstNamed, lastNamed int, current []C) {
+			if !budget.charge() {
+				return
+			}
+			if chosen == count {
+				if count > 0 && !q.stepAnchorsSatisfied(step, childPos, hasNamed, firstNamed, lastNamed, prevHasNamed, prevLastNamedPos, parentLastNamedPos) {
+					return
+				}
+				nextHasNamed := prevHasNamed || hasNamed
+				nextLastNamed := prevLastNamedPos
+				if hasNamed {
+					nextLastNamed = lastNamed
+				}
+				matchChildStepsRecursiveAllWithReader(q, parent, namedPositions, parentLastNamedPos, steps, childSteps, childPos+1, nextIdx, nextHasNamed, nextLastNamed, lang, source, predicates, current, budget, reader, emitForCount)
+				return
+			}
+			remaining := count - chosen
+			limit := len(candidates) - remaining
+			for i := candidatePos; i <= limit; i++ {
+				childIdx := candidates[i]
+				child, ok := reader.Child(parent, childIdx)
+				if !ok {
+					continue
+				}
+				nextIdxForChoice := maxInt(nextIdx, childIdx+1)
+				hasNamedForChoice, firstNamedForChoice, lastNamedForChoice := hasNamed, firstNamed, lastNamed
+				if named := namedPositions[childIdx]; named >= 0 {
+					if !hasNamedForChoice {
+						hasNamedForChoice, firstNamedForChoice = true, named
+					}
+					lastNamedForChoice = named
+				}
+				matchStepsAllWithReader(q, steps, cs.stepIdx, child, parent, childIdx, lang, source, predicates, current, budget, reader, func(next []C) {
+					combinations(i+1, chosen+1, nextIdxForChoice, hasNamedForChoice, firstNamedForChoice, lastNamedForChoice, next)
+				})
+			}
+		}
+		combinations(0, 0, nextChildIdx, false, -1, -1, captures)
+		if budget.tripped() || (step.quantifier != queryQuantifierOne && emittedForCount) {
+			return
+		}
+	}
+}
+
+func collectChildCandidateIndicesWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, parent N, step *QueryStep, field FieldID, nextChildIdx int, lang *Language, dst []int, reader R) ([]int, bool) {
+	if field != 0 && (lang == nil || int(field) <= 0 || int(field) >= len(lang.FieldNames) || lang.FieldNames[field] == "") {
+		return dst, false
+	}
+	contiguous, started := stepUsesContiguousRun(step), false
+	for i := nextChildIdx; i < reader.ChildCount(parent); i++ {
+		matched := reader.ChildCanMatch(q, step, parent, i, lang) && reader.ChildHasField(parent, i, field, lang)
+		if matched {
+			dst = append(dst, i)
+			started = true
+		} else if contiguous && started {
+			break
+		}
+	}
+	return dst, true
+}
+
+func nodeMatchesStepWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, step *QueryStep, node N, lang *Language, reader R) bool {
+	if !nodeCanMatchStepShallowWithReader(q, step, node, lang, reader) {
+		return false
+	}
+	// The legacy matcher only evaluates absent fields on scalar symbol steps.
+	if len(step.alternatives) > 0 || step.textMatch != "" || step.symbol == 0 {
+		return true
+	}
+	for _, field := range step.absentFields {
+		if int(field) <= 0 || int(field) >= len(lang.FieldNames) || lang.FieldNames[field] == "" || reader.HasChildWithField(node, field, lang) {
+			return false
+		}
+	}
+	return true
+}
+
+// nodeCanMatchStepShallowWithReader is the shared child-prefilter contract.
+// It deliberately omits absent-field traversal, matching the legacy
+// stack-entry prefilter; exact absence is checked after candidate selection.
+func nodeCanMatchStepShallowWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, step *QueryStep, node N, lang *Language, reader R) bool {
+	if q == nil || step == nil || reader.IsNil(node) || lang == nil {
+		return false
+	}
+	if len(step.alternatives) > 0 {
+		named := reader.IsNamed(node)
+		symbol := lang.PublicSymbolForNamedness(reader.Symbol(node), named)
+		if idx := step.altIndex; idx != nil {
+			if len(idx.wildcard) > 0 || len(idx.bySymbolNamed[alternationSymbolNamedKey(symbol, named)]) > 0 {
+				return true
+			}
+			return !named && len(idx.byText[reader.Type(node, lang)]) > 0
+		}
+		var nodeType string
+		loaded := false
+		for _, alt := range step.alternatives {
+			if alternativeMatchesNodeWithReader(alt, node, lang, symbol, named, &nodeType, &loaded, reader) {
+				return true
+			}
+		}
+		return false
+	}
+	if step.textMatch != "" {
+		return !reader.IsNamed(node) && reader.Type(node, lang) == step.textMatch && (!step.isMissing || reader.IsMissing(node))
+	}
+	if step.symbol == 0 {
+		if step.isMissing {
+			return reader.IsMissing(node)
+		}
+		return !step.isNamed || reader.IsNamed(node)
+	}
+	named := reader.IsNamed(node)
+	if named != step.isNamed || lang.PublicSymbolForNamedness(reader.Symbol(node), named) != lang.PublicSymbolForNamedness(step.symbol, step.isNamed) || (step.isMissing && !reader.IsMissing(node)) {
+		return false
+	}
+	return true
+}
+
+func alternativeMatchesNodeWithReader[N comparable, C any, R queryNodeReader[N, C]](alt alternativeSymbol, node N, lang *Language, nodeSymbol Symbol, nodeNamed bool, nodeType *string, loaded *bool, reader R) bool {
+	if alt.symbol == 0 && alt.textMatch == "" {
+		if alt.isMissing {
+			return reader.IsMissing(node)
+		}
+		return !alt.isNamed || nodeNamed
+	}
+	if alt.textMatch != "" {
+		if nodeNamed {
+			return false
+		}
+		if !*loaded {
+			*nodeType, *loaded = reader.Type(node, lang), true
+		}
+		return *nodeType == alt.textMatch && (!alt.isMissing || reader.IsMissing(node))
+	}
+	return nodeNamed == alt.isNamed && nodeSymbol == lang.PublicSymbolForNamedness(alt.symbol, alt.isNamed) && (!alt.isMissing || reader.IsMissing(node))
+}
+
+func alternativeFieldMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](alt *alternativeSymbol, node, parent N, childIdx int, lang *Language, reader R) bool {
+	if alt == nil || alt.field == 0 {
+		return true
+	}
+	if reader.IsNil(parent) || childIdx < 0 {
+		parent, childIdx = queryPatternSiblingContextWithReader(node, parent, childIdx, reader)
+	}
+	return !reader.IsNil(parent) && childIdx >= 0 && reader.ChildHasField(parent, childIdx, alt.field, lang)
+}

--- a/query_predicates.go
+++ b/query_predicates.go
@@ -6,62 +6,65 @@ import (
 )
 
 func (q *Query) matchesPredicates(predicates []QueryPredicate, captures []QueryCapture, lang *Language, source []byte) bool {
-	if len(predicates) == 0 {
-		return true
-	}
+	return matchesPredicatesWithReader(q, predicates, captures, lang, source, publicQueryReader{})
+}
 
+func (q *Query) predicatesStillViable(predicates []QueryPredicate, captures []QueryCapture, source []byte) bool {
+	return predicatesStillViableWithReader(q, predicates, captures, source, publicQueryReader{})
+}
+
+func (q *Query) applyDirectives(predicates []QueryPredicate, captures []QueryCapture, source []byte) []QueryCapture {
+	return applyDirectivesWithReader(q, predicates, captures, source, publicQueryReader{})
+}
+
+func matchesPredicatesWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, predicates []QueryPredicate, captures []C, lang *Language, source []byte, reader R) bool {
 	for _, pred := range predicates {
-		if !q.matchesPredicate(pred, captures, lang, source) {
+		if !matchesPredicateWithReader(q, pred, captures, lang, source, reader) {
 			return false
 		}
 	}
-
 	return true
 }
 
-func (q *Query) matchesPredicate(pred QueryPredicate, captures []QueryCapture, lang *Language, source []byte) bool {
+func matchesPredicateWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, pred QueryPredicate, captures []C, lang *Language, source []byte, reader R) bool {
 	switch pred.kind {
 	case predicateEq:
-		return textEqualityPredicateMatches(pred, captures, source, true)
+		return textEqualityPredicateMatchesWithReader(pred, captures, source, true, reader)
 	case predicateNotEq:
-		return textEqualityPredicateMatches(pred, captures, source, false)
+		return textEqualityPredicateMatchesWithReader(pred, captures, source, false, reader)
 	case predicateMatch, predicateLuaMatch:
-		return regexPredicateMatches(pred, captures, source, false)
+		return regexPredicateMatchesWithReader(pred, captures, source, false, reader)
 	case predicateNotMatch:
-		return regexPredicateMatches(pred, captures, source, true)
+		return regexPredicateMatchesWithReader(pred, captures, source, true, reader)
 	case predicateAnyEq:
-		return anyCaptureTextEquals(pred, captures, source, true)
+		return anyCaptureTextEqualsWithReader(pred, captures, source, true, reader)
 	case predicateAnyNotEq:
-		return anyCaptureTextEquals(pred, captures, source, false)
+		return anyCaptureTextEqualsWithReader(pred, captures, source, false, reader)
 	case predicateAnyMatch:
-		return anyCaptureRegexMatches(pred, captures, source, false)
+		return anyCaptureRegexMatchesWithReader(pred, captures, source, false, reader)
 	case predicateAnyNotMatch:
-		return anyCaptureRegexMatches(pred, captures, source, true)
+		return anyCaptureRegexMatchesWithReader(pred, captures, source, true, reader)
 	case predicateAnyOf:
-		left, ok := captureText(pred.leftCapture, captures, source)
+		left, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
 		return (ok && stringInList(left, pred.values)) || (!ok && pred.allowMissing)
 	case predicateNotAnyOf:
-		left, ok := captureText(pred.leftCapture, captures, source)
+		left, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
 		return (ok && !stringInList(left, pred.values)) || (!ok && pred.allowMissing)
 	case predicateHasAncestor:
-		return ancestorPredicateMatches(pred, captures, lang, false)
+		return ancestorPredicateMatchesWithReader(pred, captures, lang, false, reader)
 	case predicateNotHasAncestor:
-		return ancestorPredicateMatches(pred, captures, lang, true)
+		return ancestorPredicateMatchesWithReader(pred, captures, lang, true, reader)
 	case predicateHasParent:
-		return parentPredicateMatches(pred, captures, lang, false)
+		return parentPredicateMatchesWithReader(pred, captures, lang, false, reader)
 	case predicateNotHasParent:
-		return parentPredicateMatches(pred, captures, lang, true)
+		return parentPredicateMatchesWithReader(pred, captures, lang, true, reader)
 	case predicateIs, predicateIsNot:
-		// #is? / #is-not? are property predicates: in upstream tree-sitter
-		// they are inert metadata consumed by the host application (e.g.
-		// locals.scm tracking via "local"/"local.definition" properties)
-		// and never filter the match set. See PropertyPredicate and
-		// PropertyPredicatesForPattern for the host-consumable metadata path.
 		return true
 	case predicateCount:
-		return countPredicateMatches(pred, captures)
+		return countPredicateMatchesWithReader(pred, captures, reader)
 	case predicateIsExported:
-		return captureTextIsExported(pred.leftCapture, captures, source)
+		text, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
+		return ok && textIsExported(text)
 	case predicateSet, predicateOffset, predicateSelectAdjacent, predicateStrip:
 		return true
 	default:
@@ -69,86 +72,42 @@ func (q *Query) matchesPredicate(pred QueryPredicate, captures []QueryCapture, l
 	}
 }
 
-func (q *Query) predicatesStillViable(predicates []QueryPredicate, captures []QueryCapture, source []byte) bool {
-	if len(predicates) == 0 {
-		return true
-	}
-
+func predicatesStillViableWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, predicates []QueryPredicate, captures []C, source []byte, reader R) bool {
 	for _, pred := range predicates {
-		if !predicateStillViable(pred, captures, source) {
-			return false
+		switch pred.kind {
+		case predicateEq, predicateNotEq:
+			left, leftOK := captureTextWithReader(pred.leftCapture, captures, source, reader)
+			right, rightOK := predicateRightTextWithReader(pred, captures, source, reader)
+			if leftOK && rightOK && ((left == right) != (pred.kind == predicateEq)) {
+				return false
+			}
+		case predicateMatch, predicateLuaMatch, predicateNotMatch:
+			left, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
+			if ok {
+				matched := pred.regex != nil && pred.regex.MatchString(left)
+				if matched != (pred.kind != predicateNotMatch) {
+					return false
+				}
+			}
+		case predicateAnyOf, predicateNotAnyOf:
+			left, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
+			if ok && (stringInList(left, pred.values) != (pred.kind == predicateAnyOf)) {
+				return false
+			}
+		case predicateIsExported:
+			text, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
+			if ok && !textIsExported(text) {
+				return false
+			}
 		}
 	}
-
 	return true
-}
-
-func predicateStillViable(pred QueryPredicate, captures []QueryCapture, source []byte) bool {
-	switch pred.kind {
-	case predicateEq:
-		return textEqualityPredicateStillViable(pred, captures, source, true)
-	case predicateNotEq:
-		return textEqualityPredicateStillViable(pred, captures, source, false)
-	case predicateMatch, predicateLuaMatch:
-		return regexPredicateStillViable(pred, captures, source, false)
-	case predicateNotMatch:
-		return regexPredicateStillViable(pred, captures, source, true)
-	case predicateAnyOf:
-		return listPredicateStillViable(pred, captures, source, true)
-	case predicateNotAnyOf:
-		return listPredicateStillViable(pred, captures, source, false)
-	case predicateIsExported:
-		return exportedPredicateStillViable(pred, captures, source)
-	default:
-		return true
-	}
-}
-
-func textEqualityPredicateStillViable(pred QueryPredicate, captures []QueryCapture, source []byte, wantEqual bool) bool {
-	left, ok := captureText(pred.leftCapture, captures, source)
-	if !ok {
-		return true
-	}
-	right, ok := predicateRightText(pred, captures, source)
-	if !ok {
-		return true
-	}
-	return (left == right) == wantEqual
-}
-
-func regexPredicateStillViable(pred QueryPredicate, captures []QueryCapture, source []byte, negated bool) bool {
-	left, ok := captureText(pred.leftCapture, captures, source)
-	if !ok {
-		return true
-	}
-	if pred.regex == nil {
-		return negated
-	}
-	matched := pred.regex.MatchString(left)
-	if negated {
-		return !matched
-	}
-	return matched
-}
-
-func listPredicateStillViable(pred QueryPredicate, captures []QueryCapture, source []byte, wantInList bool) bool {
-	left, ok := captureText(pred.leftCapture, captures, source)
-	if !ok {
-		return true
-	}
-	return stringInList(left, pred.values) == wantInList
-}
-
-func exportedPredicateStillViable(pred QueryPredicate, captures []QueryCapture, source []byte) bool {
-	text, ok := captureText(pred.leftCapture, captures, source)
-	return !ok || textIsExported(text)
 }
 
 func predicatesCanRejectMatch(predicates []QueryPredicate) bool {
 	for _, pred := range predicates {
 		switch pred.kind {
 		case predicateSet, predicateOffset, predicateSelectAdjacent, predicateStrip, predicateIs, predicateIsNot:
-			continue
 		default:
 			return true
 		}
@@ -156,226 +115,176 @@ func predicatesCanRejectMatch(predicates []QueryPredicate) bool {
 	return false
 }
 
-// applyDirectives applies capture-modifying directives (#select-adjacent!,
-// #strip!) to the captures list after a match has been accepted.
-func (q *Query) applyDirectives(predicates []QueryPredicate, captures []QueryCapture, source []byte) []QueryCapture {
+func applyDirectivesWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, predicates []QueryPredicate, captures []C, source []byte, reader R) []C {
 	for _, pred := range predicates {
 		switch pred.kind {
 		case predicateSelectAdjacent:
-			captures = applySelectAdjacent(pred, captures)
+			captures = applySelectAdjacentWithReader(pred, captures, reader)
 		case predicateStrip:
-			captures = applyStrip(pred, captures, source)
+			captures = applyStripWithReader(pred, captures, source, reader)
 		}
 	}
 	return captures
 }
 
-// applySelectAdjacent filters the captures named by pred.leftCapture to only
-// those that are byte-adjacent to at least one capture named by
-// pred.rightCapture. "Adjacent" means one node's end byte equals the other's
-// start byte.
+type captureBoundary struct{ start, end uint32 }
+
 func applySelectAdjacent(pred QueryPredicate, captures []QueryCapture) []QueryCapture {
-	anchors := captureBoundaries(pred.rightCapture, captures)
-	if len(anchors) == 0 {
-		return removeCapturesByName(captures, pred.leftCapture)
-	}
-	return keepAdjacentCaptures(captures, pred.leftCapture, anchors)
+	return applySelectAdjacentWithReader(pred, captures, publicQueryReader{})
 }
 
-type captureBoundary struct {
-	start, end uint32
-}
-
-func captureBoundaries(name string, captures []QueryCapture) []captureBoundary {
-	var boundaries []captureBoundary
-	for _, c := range captures {
-		if c.Name == name && c.Node != nil {
-			boundaries = append(boundaries, captureBoundary{c.Node.StartByte(), c.Node.EndByte()})
+func applySelectAdjacentWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, reader R) []C {
+	var inline [8]captureBoundary
+	anchors := inline[:0]
+	for _, capture := range captures {
+		node := reader.CaptureNode(capture)
+		if reader.CaptureName(capture) == pred.rightCapture && !reader.IsNil(node) {
+			anchors = append(anchors, captureBoundary{reader.StartByte(node), reader.EndByte(node)})
 		}
 	}
-	return boundaries
-}
-
-func removeCapturesByName(captures []QueryCapture, name string) []QueryCapture {
 	out := captures[:0]
-	for _, c := range captures {
-		if c.Name != name {
-			out = append(out, c)
+	for _, capture := range captures {
+		if reader.CaptureName(capture) != pred.leftCapture {
+			out = append(out, capture)
+			continue
+		}
+		node := reader.CaptureNode(capture)
+		adjacent := false
+		if !reader.IsNil(node) {
+			start, end := reader.StartByte(node), reader.EndByte(node)
+			for _, anchor := range anchors {
+				if end == anchor.start || start == anchor.end {
+					adjacent = true
+					break
+				}
+			}
+		}
+		if adjacent {
+			out = append(out, capture)
 		}
 	}
 	return out
 }
 
-func keepAdjacentCaptures(captures []QueryCapture, name string, anchors []captureBoundary) []QueryCapture {
-	out := captures[:0]
-	for _, c := range captures {
-		if c.Name != name || nodeAdjacentToBoundaries(c.Node, anchors) {
-			out = append(out, c)
-		}
-	}
-	return out
-}
-
-func nodeAdjacentToBoundaries(n *Node, boundaries []captureBoundary) bool {
-	if n == nil {
-		return false
-	}
-	nStart := n.StartByte()
-	nEnd := n.EndByte()
-	for _, boundary := range boundaries {
-		if nEnd == boundary.start || nStart == boundary.end {
-			return true
-		}
-	}
-	return false
-}
-
-// applyStrip applies the #strip! directive: for each capture named by
-// pred.leftCapture, it sets TextOverride to the node's text with all
-// matches of pred.regex removed.
 func applyStrip(pred QueryPredicate, captures []QueryCapture, source []byte) []QueryCapture {
+	return applyStripWithReader(pred, captures, source, publicQueryReader{})
+}
+
+func applyStripWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, source []byte, reader R) []C {
 	if pred.regex == nil {
 		return captures
 	}
-	// Mutate captures in place: directive application owns this slice and the
-	// updated TextOverride should be visible to downstream consumers.
 	for i := range captures {
-		if captures[i].Name == pred.leftCapture && captures[i].Node != nil {
-			text := captures[i].Node.Text(source)
-			stripped := pred.regex.ReplaceAllString(text, "")
-			if stripped != text {
-				captures[i].TextOverride = stripped
-			}
+		node := reader.CaptureNode(captures[i])
+		if reader.CaptureName(captures[i]) != pred.leftCapture || reader.IsNil(node) {
+			continue
+		}
+		text := reader.Text(node, source)
+		if stripped := pred.regex.ReplaceAllString(text, ""); stripped != text {
+			reader.SetCaptureTextOverride(&captures[i], stripped)
 		}
 	}
 	return captures
 }
 
-func captureNodes(name string, captures []QueryCapture) []*Node {
-	var nodes []*Node
-	for _, c := range captures {
-		if c.Name == name && c.Node != nil {
-			nodes = append(nodes, c.Node)
-		}
-	}
-	return nodes
-}
-
-func predicateRightText(pred QueryPredicate, captures []QueryCapture, source []byte) (string, bool) {
+func predicateRightTextWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, source []byte, reader R) (string, bool) {
 	if pred.rightCapture == "" {
 		return pred.literal, true
 	}
-	return captureText(pred.rightCapture, captures, source)
+	return captureTextWithReader(pred.rightCapture, captures, source, reader)
 }
 
-func textEqualityPredicateMatches(pred QueryPredicate, captures []QueryCapture, source []byte, wantEqual bool) bool {
-	left, ok := captureText(pred.leftCapture, captures, source)
+func textEqualityPredicateMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, source []byte, wantEqual bool, reader R) bool {
+	left, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
 	if !ok {
 		return pred.allowMissing
 	}
-	right, ok := predicateRightText(pred, captures, source)
+	right, ok := predicateRightTextWithReader(pred, captures, source, reader)
+	return ok && ((left == right) == wantEqual)
+}
+
+func regexPredicateMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, source []byte, negated bool, reader R) bool {
+	left, ok := captureTextWithReader(pred.leftCapture, captures, source, reader)
 	if !ok {
+		return pred.allowMissing
+	}
+	matched := pred.regex != nil && pred.regex.MatchString(left)
+	return matched != negated
+}
+
+func anyCaptureTextEqualsWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, source []byte, wantEqual bool, reader R) bool {
+	right, rightOK := predicateRightTextWithReader(pred, captures, source, reader)
+	found := false
+	for _, capture := range captures {
+		node := reader.CaptureNode(capture)
+		if reader.CaptureName(capture) != pred.leftCapture || reader.IsNil(node) {
+			continue
+		}
+		found = true
+		if rightOK && ((reader.Text(node, source) == right) == wantEqual) {
+			return true
+		}
+	}
+	return !found && pred.allowMissing
+}
+
+func anyCaptureRegexMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, source []byte, negated bool, reader R) bool {
+	found := false
+	for _, capture := range captures {
+		node := reader.CaptureNode(capture)
+		if reader.CaptureName(capture) != pred.leftCapture || reader.IsNil(node) {
+			continue
+		}
+		found = true
+		if pred.regex == nil {
+			continue
+		}
+		matched := pred.regex != nil && pred.regex.MatchString(reader.Text(node, source))
+		if matched != negated {
+			return true
+		}
+	}
+	return !found && pred.allowMissing
+}
+
+func ancestorPredicateMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, lang *Language, negated bool, reader R) bool {
+	return captureNodePredicateMatchesWithReader(pred.leftCapture, captures, negated, reader, func(node N) bool {
+		for parent, ok := reader.Parent(node); ok; parent, ok = reader.Parent(parent) {
+			if nodeTypeMatchesAnyWithReader(parent, pred.values, lang, reader) {
+				return true
+			}
+		}
 		return false
-	}
-	return (left == right) == wantEqual
-}
-
-func regexPredicateMatches(pred QueryPredicate, captures []QueryCapture, source []byte, negated bool) bool {
-	left, ok := captureText(pred.leftCapture, captures, source)
-	if !ok {
-		return pred.allowMissing
-	}
-	if pred.regex == nil {
-		return negated
-	}
-	matched := pred.regex.MatchString(left)
-	if negated {
-		return !matched
-	}
-	return matched
-}
-
-func anyCaptureTextEquals(pred QueryPredicate, captures []QueryCapture, source []byte, wantEqual bool) bool {
-	nodes := captureNodes(pred.leftCapture, captures)
-	if len(nodes) == 0 {
-		return pred.allowMissing
-	}
-	right, ok := predicateRightText(pred, captures, source)
-	if !ok {
-		return false
-	}
-	for _, n := range nodes {
-		if (n.Text(source) == right) == wantEqual {
-			return true
-		}
-	}
-	return false
-}
-
-func anyCaptureRegexMatches(pred QueryPredicate, captures []QueryCapture, source []byte, negated bool) bool {
-	nodes := captureNodes(pred.leftCapture, captures)
-	if len(nodes) == 0 || pred.regex == nil {
-		return len(nodes) == 0 && pred.allowMissing
-	}
-	for _, n := range nodes {
-		matched := pred.regex.MatchString(n.Text(source))
-		if negated {
-			matched = !matched
-		}
-		if matched {
-			return true
-		}
-	}
-	return false
-}
-
-func stringInList(value string, values []string) bool {
-	for _, v := range values {
-		if value == v {
-			return true
-		}
-	}
-	return false
-}
-
-func ancestorPredicateMatches(pred QueryPredicate, captures []QueryCapture, lang *Language, negated bool) bool {
-	return captureNodePredicateMatches(pred.leftCapture, captures, negated, func(n *Node) bool {
-		return nodeHasAncestorType(n, pred.values, lang)
 	})
 }
 
-func parentPredicateMatches(pred QueryPredicate, captures []QueryCapture, lang *Language, negated bool) bool {
-	return captureNodePredicateMatches(pred.leftCapture, captures, negated, func(n *Node) bool {
-		parent := n.Parent()
-		return parent != nil && nodeTypeMatchesAny(parent, pred.values, lang)
+func parentPredicateMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, lang *Language, negated bool, reader R) bool {
+	return captureNodePredicateMatchesWithReader(pred.leftCapture, captures, negated, reader, func(node N) bool {
+		parent, ok := reader.Parent(node)
+		return ok && nodeTypeMatchesAnyWithReader(parent, pred.values, lang, reader)
 	})
 }
 
-func captureNodePredicateMatches(name string, captures []QueryCapture, negated bool, matches func(*Node) bool) bool {
-	nodes := captureNodes(name, captures)
-	if len(nodes) == 0 {
-		return false
-	}
-	matched := anyCaptureNodeMatches(nodes, matches)
-	if negated {
-		return !matched
-	}
-	return matched
-}
-
-func anyCaptureNodeMatches(nodes []*Node, matches func(*Node) bool) bool {
-	for _, n := range nodes {
-		if matches(n) {
-			return true
+func captureNodePredicateMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](name string, captures []C, negated bool, reader R, matches func(N) bool) bool {
+	found, matched := false, false
+	for _, capture := range captures {
+		node := reader.CaptureNode(capture)
+		if reader.CaptureName(capture) != name || reader.IsNil(node) {
+			continue
+		}
+		found = true
+		if matches(node) {
+			matched = true
+			break
 		}
 	}
-	return false
+	return found && (matched != negated)
 }
 
-func countPredicateMatches(pred QueryPredicate, captures []QueryCapture) bool {
+func countPredicateMatchesWithReader[N comparable, C any, R queryNodeReader[N, C]](pred QueryPredicate, captures []C, reader R) bool {
 	count := 0
-	for _, c := range captures {
-		if c.Name == pred.leftCapture && c.Node != nil {
+	for _, capture := range captures {
+		if reader.CaptureName(capture) == pred.leftCapture && !reader.IsNil(reader.CaptureNode(capture)) {
 			count++
 		}
 	}
@@ -397,9 +306,33 @@ func countPredicateMatches(pred QueryPredicate, captures []QueryCapture) bool {
 	}
 }
 
-func captureTextIsExported(name string, captures []QueryCapture, source []byte) bool {
-	text, ok := captureText(name, captures, source)
-	return ok && textIsExported(text)
+func captureTextWithReader[N comparable, C any, R queryNodeReader[N, C]](name string, captures []C, source []byte, reader R) (string, bool) {
+	if source == nil {
+		return "", false
+	}
+	for _, capture := range captures {
+		if reader.CaptureName(capture) != name {
+			continue
+		}
+		if override := reader.CaptureTextOverride(capture); override != "" {
+			return override, true
+		}
+		node := reader.CaptureNode(capture)
+		if reader.IsNil(node) {
+			return "", false
+		}
+		return reader.Text(node, source), true
+	}
+	return "", false
+}
+
+func stringInList(value string, values []string) bool {
+	for _, item := range values {
+		if value == item {
+			return true
+		}
+	}
+	return false
 }
 
 func textIsExported(text string) bool {
@@ -411,75 +344,46 @@ func textIsExported(text string) bool {
 }
 
 func typeNameMatchesAny(typeName string, names []string) bool {
-	for _, n := range names {
-		if n == typeName {
+	for _, name := range names {
+		if name == typeName {
 			return true
 		}
 	}
 	return false
 }
 
-func nodeTypeMatchesAny(node *Node, typeNames []string, lang *Language) bool {
-	if node == nil || lang == nil {
+func nodeTypeMatchesAnyWithReader[N comparable, C any, R queryNodeReader[N, C]](node N, names []string, lang *Language, reader R) bool {
+	if reader.IsNil(node) || lang == nil {
 		return false
 	}
-	if typeNameMatchesAny(node.Type(lang), typeNames) {
+	if typeNameMatchesAny(reader.Type(node, lang), names) {
 		return true
 	}
-	nodeInternal := node.Symbol()
-	nodePublic := lang.PublicSymbol(nodeInternal)
-	for _, typeName := range typeNames {
-		if nodeSymbolMatchesTypeName(nodeInternal, nodePublic, typeName, lang) {
+	internal := reader.Symbol(node)
+	public := lang.PublicSymbol(internal)
+	for _, name := range names {
+		if nodeSymbolMatchesTypeName(internal, public, name, lang) {
 			return true
 		}
 	}
 	return false
 }
 
-func nodeSymbolMatchesTypeName(nodeInternal Symbol, nodePublic Symbol, typeName string, lang *Language) bool {
+func nodeSymbolMatchesTypeName(nodeInternal, nodePublic Symbol, typeName string, lang *Language) bool {
 	symbol, ok := lang.SymbolByName(typeName)
 	if !ok {
 		return false
 	}
-	if nodeSymbolMatches(nodeInternal, nodePublic, symbol) {
+	if nodeInternal == symbol || nodePublic == symbol {
 		return true
 	}
-	return lang.IsSupertype(symbol) && supertypeContainsNodeSymbol(symbol, nodeInternal, nodePublic, lang)
-}
-
-func nodeSymbolMatches(nodeInternal Symbol, nodePublic Symbol, candidate Symbol) bool {
-	return nodeInternal == candidate || nodePublic == candidate
-}
-
-func supertypeContainsNodeSymbol(supertype Symbol, nodeInternal Symbol, nodePublic Symbol, lang *Language) bool {
-	for _, child := range lang.SupertypeChildren(supertype) {
+	if !lang.IsSupertype(symbol) {
+		return false
+	}
+	for _, child := range lang.SupertypeChildren(symbol) {
 		if child == nodeInternal || lang.PublicSymbol(child) == nodePublic {
 			return true
 		}
 	}
 	return false
-}
-
-func nodeHasAncestorType(node *Node, typeNames []string, lang *Language) bool {
-	if node == nil || lang == nil {
-		return false
-	}
-	for p := node.Parent(); p != nil; p = p.Parent() {
-		if nodeTypeMatchesAny(p, typeNames, lang) {
-			return true
-		}
-	}
-	return false
-}
-
-func captureText(name string, captures []QueryCapture, source []byte) (string, bool) {
-	for _, c := range captures {
-		if c.Name == name {
-			if source == nil {
-				return "", false
-			}
-			return c.Node.Text(source), true
-		}
-	}
-	return "", false
 }

--- a/query_reader.go
+++ b/query_reader.go
@@ -1,0 +1,192 @@
+package gotreesitter
+
+// queryNodeReader is the compile-time-specialized syntax-tree seam used by
+// the non-streaming matcher. N and C are value types selected by the caller;
+// concrete readers must not manufacture public *Node proxies for other tree
+// backings.
+//
+// The type parameter keeps the hot matcher monomorphic. This is intentionally
+// not a stored interface: reader calls do not box nodes while walking a tree.
+type queryNodeReader[N comparable, C any] interface {
+	IsNil(N) bool
+	Symbol(N) Symbol
+	IsNamed(N) bool
+	IsMissing(N) bool
+	Type(N, *Language) string
+	StartByte(N) uint32
+	EndByte(N) uint32
+	Text(N, []byte) string
+	Parent(N) (N, bool)
+	ChildCount(N) int
+	Child(N, int) (N, bool)
+	ChildNamed(N, int) (bool, bool)
+	ChildCanMatch(*Query, *QueryStep, N, int, *Language) bool
+	ChildHasField(N, int, FieldID, *Language) bool
+	HasChildWithField(N, FieldID, *Language) bool
+
+	NewCapture(string, N) C
+	CaptureName(C) string
+	CaptureNode(C) N
+	CaptureTextOverride(C) string
+	SetCaptureTextOverride(*C, string)
+}
+
+// queryValueCapture is the compact-consumer capture representation. It keeps
+// the reader's node value directly and therefore never requires a public Node
+// proxy. Readers for alternate immutable stores can use this type unchanged.
+type queryValueCapture[N comparable] struct {
+	Name         string
+	Node         N
+	TextOverride string
+}
+
+type queryReaderMatch[C any] struct {
+	PatternIndex int
+	Captures     []C
+}
+
+type queryReaderWorkItem[N comparable] struct {
+	node     N
+	parent   N
+	childIdx int
+	post     bool
+}
+
+// executeQueryWithReader is the sole non-streaming matcher traversal. dst and
+// worklist are caller-owned reusable buffers; returned captures hold reader
+// value nodes directly.
+func executeQueryWithReader[N comparable, C any, R queryNodeReader[N, C]](q *Query, root N, lang *Language, source []byte, reader R, dst []queryReaderMatch[C], worklist []queryReaderWorkItem[N]) ([]queryReaderMatch[C], []queryReaderWorkItem[N]) {
+	dst = dst[:0]
+	worklist = worklist[:0]
+	if q == nil || lang == nil || reader.IsNil(root) {
+		return dst, worklist
+	}
+	if q.rootCandidatesBySymbol == nil && q.rootFallbackCandidates == nil {
+		q.buildRootPatternIndex()
+	}
+	worklist = append(worklist, queryReaderWorkItem[N]{node: root, childIdx: -1})
+	for len(worklist) > 0 {
+		last := len(worklist) - 1
+		item := worklist[last]
+		worklist = worklist[:last]
+		node := item.node
+		if reader.IsNil(node) {
+			continue
+		}
+		if item.post {
+			candidates := q.postorderPatternCandidates(lang.PublicSymbolForNamedness(reader.Symbol(node), reader.IsNamed(node)))
+			candidates = mergePatternIndexLists(q.rootRepetitionPostPatterns, candidates)
+			for _, patternIndex := range candidates {
+				if q.isPatternDisabled(patternIndex) {
+					continue
+				}
+				pattern := &q.patterns[patternIndex]
+				budget := newQueryMatchBudget(defaultQueryMatchWorkBudget)
+				var captureSets [][]C
+				if pattern.steps[0].quantifier == queryQuantifierZeroOrMore || pattern.steps[0].quantifier == queryQuantifierOneOrMore {
+					captureSets = matchPatternPostorderAllWithReader(q, pattern, node, item.parent, item.childIdx, lang, source, budget, reader)
+				} else {
+					captureSets = matchPatternAllWithReader(q, pattern, node, lang, source, budget, reader)
+				}
+				for _, captures := range captureSets {
+					dst = append(dst, queryReaderMatch[C]{PatternIndex: patternIndex, Captures: captures})
+				}
+			}
+			continue
+		}
+		if q.hasPostorderPatterns() {
+			worklist = append(worklist, queryReaderWorkItem[N]{node: node, parent: item.parent, childIdx: item.childIdx, post: true})
+		}
+		for index := reader.ChildCount(node) - 1; index >= 0; index-- {
+			child, ok := reader.Child(node, index)
+			if ok {
+				worklist = append(worklist, queryReaderWorkItem[N]{node: child, parent: node, childIdx: index})
+			}
+		}
+		for _, patternIndex := range q.rootPatternCandidates(lang.PublicSymbolForNamedness(reader.Symbol(node), reader.IsNamed(node))) {
+			if q.isPatternDisabled(patternIndex) {
+				continue
+			}
+			pattern := &q.patterns[patternIndex]
+			captures := matchPatternAllWithReader(q, pattern, node, lang, source, newQueryMatchBudget(defaultQueryMatchWorkBudget), reader)
+			for _, set := range captures {
+				dst = append(dst, queryReaderMatch[C]{PatternIndex: patternIndex, Captures: set})
+			}
+		}
+	}
+	return dst, worklist
+}
+
+// publicQueryReader preserves the public Node/QueryCapture representation as
+// one concrete specialization of the shared matcher.
+type publicQueryReader struct{}
+
+func (publicQueryReader) IsNil(node *Node) bool                  { return node == nil }
+func (publicQueryReader) Symbol(node *Node) Symbol               { return node.Symbol() }
+func (publicQueryReader) IsNamed(node *Node) bool                { return node.IsNamed() }
+func (publicQueryReader) IsMissing(node *Node) bool              { return node.IsMissing() }
+func (publicQueryReader) Type(node *Node, lang *Language) string { return node.Type(lang) }
+func (publicQueryReader) StartByte(node *Node) uint32            { return node.StartByte() }
+func (publicQueryReader) EndByte(node *Node) uint32              { return node.EndByte() }
+func (publicQueryReader) Text(node *Node, source []byte) string  { return node.Text(source) }
+func (publicQueryReader) Parent(node *Node) (*Node, bool) {
+	if node == nil {
+		return nil, false
+	}
+	parent := node.Parent()
+	return parent, parent != nil
+}
+func (publicQueryReader) ChildCount(node *Node) int {
+	return nodeChildCountNoMaterialize(node)
+}
+func (publicQueryReader) Child(node *Node, index int) (*Node, bool) {
+	entry, ok := nodeChildEntryAtNoMaterialize(node, index)
+	if !ok {
+		return nil, false
+	}
+	if child := stackEntryNode(entry); child != nil {
+		return child, true
+	}
+	child := nodeChildAtForReason(node, index, materializeForQuery)
+	return child, child != nil
+}
+func (publicQueryReader) ChildNamed(node *Node, index int) (bool, bool) {
+	entry, ok := nodeChildEntryAtNoMaterialize(node, index)
+	return ok && stackEntryNodeIsNamed(entry), ok
+}
+func (publicQueryReader) ChildCanMatch(q *Query, step *QueryStep, parent *Node, index int, lang *Language) bool {
+	entry, ok := nodeChildEntryAtNoMaterialize(parent, index)
+	return ok && q.stackEntryCanMatchStep(step, entry, lang)
+}
+func (publicQueryReader) ChildHasField(parent *Node, index int, field FieldID, lang *Language) bool {
+	if field == 0 {
+		return true
+	}
+	if parent == nil || lang == nil || int(field) <= 0 || int(field) >= len(lang.FieldNames) {
+		return false
+	}
+	name := lang.FieldNames[field]
+	return name != "" && parent.FieldNameForChild(index, lang) == name
+}
+func (r publicQueryReader) HasChildWithField(parent *Node, field FieldID, lang *Language) bool {
+	if parent == nil {
+		return false
+	}
+	for index := 0; index < r.ChildCount(parent); index++ {
+		if r.ChildHasField(parent, index, field, lang) {
+			return true
+		}
+	}
+	return false
+}
+func (publicQueryReader) NewCapture(name string, node *Node) QueryCapture {
+	return QueryCapture{Name: name, Node: node}
+}
+func (publicQueryReader) CaptureName(capture QueryCapture) string { return capture.Name }
+func (publicQueryReader) CaptureNode(capture QueryCapture) *Node  { return capture.Node }
+func (publicQueryReader) CaptureTextOverride(capture QueryCapture) string {
+	return capture.TextOverride
+}
+func (publicQueryReader) SetCaptureTextOverride(capture *QueryCapture, text string) {
+	capture.TextOverride = text
+}


### PR DESCRIPTION
## Summary

- add a shared query reader used by public-tree and compact selected-store execution
- execute Go highlight queries directly over selected-store value handles
- preserve the public streaming cursor path and explicitly decline unsupported selected-store missing-node queries

## Performance

- selected query geomean: 8.51% faster, 14.18% lower B/op
- selected parse plus highlight: 12.90% faster, 26.38% lower B/op
- public execution: no regression in balanced order, 14.50% lower B/op and 14.53% fewer allocations

## Validation

- exact four-fixture ordered captures, directives, and highlight ranges
- root/internal/tagged/386/vet gates
- locked-C Go and JavaScript query/highlight Docker gates
- selected-store race gate
- independent exact-head review and 16-query differential: GO, no findings

## Risk

The selected route remains build-tagged and diagnostic-only. Unsupported missing-node patterns decline explicitly; public streaming behavior is unchanged.