### PR TITLE
release: v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-07-18
+
 ### Performance
 
 - Refresh the opt-in Go build-time PGO artifact with a hash-verified composite
@@ -2997,7 +2999,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.41.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.42.0...HEAD
+[0.42.0]: https://github.com/odvcencio/gotreesitter/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/odvcencio/gotreesitter/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/odvcencio/gotreesitter/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/odvcencio/gotreesitter/compare/v0.38.0...v0.39.0

--- a/README.md
+++ b/README.md
@@ -713,16 +713,16 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.41.0**. It banks the post-v0.40 correctness and
-tooling tranche plus five exact, build-tagged compact-parser performance wins.
-Subsequent unreleased selected-store work keeps the public parser unchanged
-while reducing the authenticated compact candidate to **2.685181x C** by
-equal-fixture geomean, **2.676794x C** by fixed-suite sum, and **2.791974x C**
-on its worst fixture, with zero timed fallback. Its measured lifecycle seals,
-traverses, and releases the selected store; it is not public `Parser.Parse`.
-The v0.41.0 release also includes build-time PGO,
-forest-path pooling and copy elimination, query work budgeting, and incremental
-reuse boundary corrections from the v0.40.0 line.
+The current release is **v0.42.0**. It banks the authenticated, build-tagged
+selected-store candidate at **2.685181x C** by equal-fixture geomean,
+**2.676794x C** by fixed-suite sum, and **2.791974x C** on its worst fixture,
+with zero timed fallback. Its measured lifecycle seals, traverses, and releases
+the selected store; it is not public `Parser.Parse`. The release also banks
+full-manifest forest-route corrections, exact-blob Crystal and Matlab retry
+economy, compact-scheduler defer-frame cleanup, and a reproducible
+representative refresh of the opt-in build-time PGO artifact. These changes do
+not replace the public-parser receipt or turn diagnostic compact routes into
+public `Parser.Parse`.
 The authenticated production receipt at tag target `1935a42c` measures public
 `Parser.Parse` at **4.851050x C** by equal-fixture geomean, **5.472406x C** by
 fixed-suite sum, and **5.608320x C** on the worst fixture against the locked


### PR DESCRIPTION
## Summary

- promote the accumulated changelog to v0.42.0
- refresh the README current-release summary while preserving the selected-store and public-parser scope distinction
- reset the Unreleased comparison link

## Verification

- independent release review: strict GO, no P0-P2 findings
- source is byte-identical to the fully green #372 merge
- PGO-built external-blob parity report: 206/206
- focused build, vet, document parsing, links, and diff checks pass

After merge, the annotated v0.42.0 tag and GitHub release will target the release commit.