### PR TITLE
fix(fsharp_scanner): checkpoint truncation of indent levels > 255

### DIFF
--- a/grammars/fsharp_scanner.go
+++ b/grammars/fsharp_scanner.go
@@ -74,6 +74,13 @@ func (FsharpExternalScanner) Create() any {
 }
 func (FsharpExternalScanner) Destroy(payload any) {}
 
+// Serialize encodes the scanner checkpoint. Indentation levels are F#
+// column counts and are stored as uint16 (matching the indents/
+// preprocessorIndents field width), so each level is written as two
+// little-endian bytes. A single trailing byte for an entry that doesn't
+// fit is never emitted — an entry is only written if both of its bytes
+// fit in buf, preventing a truncated high byte from corrupting the
+// deserialized value on the next checkpoint restore.
 func (FsharpExternalScanner) Serialize(payload any, buf []byte) int {
 	s := payload.(*fsState)
 	size := 0
@@ -88,14 +95,18 @@ func (FsharpExternalScanner) Serialize(payload any, buf []byte) int {
 	buf[size] = byte(ppCount)
 	size++
 
-	for i := 0; i < ppCount && size < len(buf); i++ {
-		buf[size] = byte(s.preprocessorIndents[i])
-		size++
+	for i := 0; i < ppCount && size+2 <= len(buf); i++ {
+		v := s.preprocessorIndents[i]
+		buf[size] = byte(v)
+		buf[size+1] = byte(v >> 8)
+		size += 2
 	}
 
-	for i := 1; i < len(s.indents) && size < len(buf); i++ {
-		buf[size] = byte(s.indents[i])
-		size++
+	for i := 1; i < len(s.indents) && size+2 <= len(buf); i++ {
+		v := s.indents[i]
+		buf[size] = byte(v)
+		buf[size+1] = byte(v >> 8)
+		size += 2
 	}
 
 	return size
@@ -113,11 +124,14 @@ func (FsharpExternalScanner) Deserialize(payload any, buf []byte) {
 	size := 0
 	ppCount := int(buf[size])
 	size++
-	for ; size <= ppCount && size < len(buf); size++ {
-		s.preprocessorIndents = append(s.preprocessorIndents, uint16(buf[size]))
+	for i := 0; i < ppCount && size+2 <= len(buf); i++ {
+		v := uint16(buf[size]) | uint16(buf[size+1])<<8
+		s.preprocessorIndents = append(s.preprocessorIndents, v)
+		size += 2
 	}
-	for ; size < len(buf); size++ {
-		s.indents = append(s.indents, uint16(buf[size]))
+	for ; size+2 <= len(buf); size += 2 {
+		v := uint16(buf[size]) | uint16(buf[size+1])<<8
+		s.indents = append(s.indents, v)
 	}
 }
 

--- a/grammars/fsharp_scanner_test.go
+++ b/grammars/fsharp_scanner_test.go
@@ -4,6 +4,7 @@ package grammars
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	_ "unsafe"
 
@@ -48,6 +49,84 @@ func TestFsharpKeywordDedentFallbackIgnoresEmptyIndentStack(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestFsharpScannerSerializeDeserializeRoundTripLargeIndent guards against
+// checkpoint truncation of 16-bit indentation levels to a single byte.
+// indents/preprocessorIndents are []uint16 because F# indentation is a
+// column count that can exceed 255 (deeply nested code, wide alignment,
+// generated sources). A checkpoint round-trip through Serialize/Deserialize
+// must reproduce every level exactly, not just its low 8 bits.
+func TestFsharpScannerSerializeDeserializeRoundTripLargeIndent(t *testing.T) {
+	scanner := FsharpExternalScanner{}
+	original := &fsState{
+		indents:             []uint16{0, 4, 256, 260, 1000, 65535},
+		preprocessorIndents: []uint16{255, 300, 512},
+	}
+
+	buf := make([]byte, 4096)
+	n := scanner.Serialize(original, buf)
+	if n <= 0 {
+		t.Fatalf("Serialize() returned n=%d, want > 0", n)
+	}
+
+	restored := &fsState{}
+	scanner.Deserialize(restored, buf[:n])
+
+	if !reflect.DeepEqual(restored.indents, original.indents) {
+		t.Fatalf("indents after checkpoint round-trip = %#v, want %#v (levels above 255 must not be truncated to a byte)", restored.indents, original.indents)
+	}
+	if !reflect.DeepEqual(restored.preprocessorIndents, original.preprocessorIndents) {
+		t.Fatalf("preprocessorIndents after checkpoint round-trip = %#v, want %#v", restored.preprocessorIndents, original.preprocessorIndents)
+	}
+}
+
+// TestFsharpScannerCheckpointRoundTripPreservesDeepIndentDedent exercises the
+// same truncation bug end-to-end: a scanner state checkpointed with an
+// indent level above 255, restored, and then driven through Scan must still
+// compare the *real* indent level (not its truncated low byte) when deciding
+// whether to emit DEDENT. Before the fix, indents=[0,300] serialized and
+// deserialized as [0,44] (300 truncated mod 256), so a line indented to
+// column 100 would incorrectly look more indented than the (corrupted)
+// current level and no DEDENT would be produced.
+func TestFsharpScannerCheckpointRoundTripPreservesDeepIndentDedent(t *testing.T) {
+	scanner := FsharpExternalScanner{}
+
+	original := &fsState{indents: []uint16{0, 300}}
+	buf := make([]byte, 4096)
+	n := scanner.Serialize(original, buf)
+	if n <= 0 {
+		t.Fatalf("Serialize() returned n=%d, want > 0", n)
+	}
+
+	restored := &fsState{}
+	scanner.Deserialize(restored, buf[:n])
+	if !reflect.DeepEqual(restored.indents, original.indents) {
+		t.Fatalf("restored indents = %#v, want %#v", restored.indents, original.indents)
+	}
+
+	valid := make([]bool, fsTokErrorSentinel+1)
+	valid[fsTokNewline] = true
+	valid[fsTokDedent] = true
+
+	// A newline followed by 100 columns of indentation: less than the
+	// restored level of 300, so a DEDENT must be emitted.
+	src := "\n" + strings.Repeat(" ", 100) + "x"
+	lexer := newFsharpExternalLexer([]byte(src), 0, 0, 0)
+	if !scanner.Scan(restored, lexer, valid) {
+		t.Fatalf("Scan() returned false; expected DEDENT when unwinding from a restored indent level of 300 to a line indented 100")
+	}
+	tok, ok := fsharpExternalLexerToken(lexer)
+	if !ok {
+		t.Fatalf("Scan() reported success but produced no token")
+	}
+	if tok.Symbol != fsSymDedent {
+		t.Fatalf("Scan() emitted symbol %d, want DEDENT (%d) — indicates the restored indent level was corrupted by checkpoint truncation", tok.Symbol, fsSymDedent)
+	}
+	wantIndents := []uint16{0}
+	if !reflect.DeepEqual(restored.indents, wantIndents) {
+		t.Fatalf("indents after DEDENT = %#v, want %#v", restored.indents, wantIndents)
 	}
 }
 


### PR DESCRIPTION
## Summary

The F# scanner's checkpoint serialization was storing 16-bit indentation levels as single bytes, silently dropping the high byte for any level exceeding 255. This corrupted restored states and could cause the scanner to fail emitting necessary DEDENT tokens when unwinding indentation. The fix updates both `Serialize` and `Deserialize` to read/write indents as little-endian uint16 pairs, with safe buffer-bound checking to prevent truncation or overflows during checkpoint save/restore.

## Changes

- Update `Serialize` to write each indent level as two little-endian bytes, using `size+2 <= len(buf)` to prevent trailing byte truncation.
- Update `Deserialize` to reconstruct the full 16-bit value from the two-byte pairs.
- Add a doc comment to `Serialize` clarifying the serialized layout for indentation levels.
- Add `TestFsharpScannerSerializeDeserializeRoundTripLargeIndent` to assert that indents up to 65535 survive serialization intact.
- Add `TestFsharpScannerCheckpointRoundTripPreservesDeepIndentDedent` to verify end-to-end behavior: a checkpointed indent of 300 correctly triggers a DEDENT when the scanner resumes on a less-indented line, rather than dropping it due to truncation to 44.

## Testing

- `go test ./grammars -run 'TestFsharpScannerSerializeDeserializeRoundTripLargeIndent|TestFsharpScannerCheckpointRoundTripPreservesDeepIndentDedent' -v`
- `bash cgo_harness/docker/run_single_grammar_parity.sh fsharp` to validate full grammar correctness parity