### PR TITLE
add(incremental): Add incremental invariant correctness gate and corpus

### DIFF
--- a/incremental_invariant_gate_test.go
+++ b/incremental_invariant_gate_test.go
@@ -167,8 +167,12 @@ func TestIncrementalInvariantGate(t *testing.T) {
 		ok := matched[key]
 		matchedMu.Unlock()
 		if !ok {
-			t.Errorf("STALE ALLOWLIST ENTRY (ratchet failure): %s | %s | %s did not reproduce anywhere in this sweep -- "+
-				"remove it from testdata/incremental_allowlist.json (recorded note: %q)",
+			t.Errorf("STALE ALLOWLIST ENTRY (ratchet failure): %s | %s | %s did not reproduce anywhere in this sweep. "+
+				"Before removing it from testdata/incremental_allowlist.json, confirm WHY it stopped reproducing: "+
+				"(a) the incremental bug was genuinely FIXED (remove it), or (b) the fresh-clean observation window "+
+				"CLOSED -- a grammar/parser change made the fresh parse at those sites contain ERROR/MISSING so they "+
+				"fell out of this gate's scope while the bug may persist (do NOT remove; investigate). "+
+				"The gate cannot distinguish these; a blind removal can silently retire a still-live bug. (recorded note: %q)",
 				e.Language, e.EditClass, e.Signature, e.Note)
 		}
 	}
@@ -409,34 +413,17 @@ func incrGateFirstDivergence(lang *gts.Language, fresh, incr *gts.Node, ancestor
 	return nil
 }
 
-// incrGateChildCountBucket collapses a raw childCount delta into the
-// allowlist-key component. Small deltas (|delta| <= 5) are kept exact,
-// matching how localized bugs manifest (e.g. one extra/missing statement).
-// Larger deltas were observed on files where a single edit cascades into
-// whole-subtree re-derivation (a much more severe class of bug); there the
-// *exact* magnitude is incidental to the edit position and source shape
-// downstream of it, not a distinct bug signature per magnitude, so it
-// collapses to a signed bucket instead of exploding the allowlist into one
-// entry per observed delta.
-func incrGateChildCountBucket(detail string) string {
-	var delta int
-	fmt.Sscanf(detail, "%d", &delta)
-	if delta < 0 {
-		delta = -delta
-	}
-	if delta <= 5 {
-		return detail
-	}
-	if strings.HasPrefix(detail, "-") {
-		return "(large-)"
-	}
-	return "(large+)"
-}
-
 func (d *incrGateDivergence) signature() string {
 	switch d.kind {
 	case "childCount":
-		return fmt.Sprintf("%s:childCount%s", d.nodeType, incrGateChildCountBucket(d.detail))
+		// EXACT signed delta, never bucketed. Bucketing large deltas into
+		// "(large-)"/"(large+)" was removed deliberately: a coarse bucket lets
+		// a live allowlist entry blanket every |delta|>5 divergence in its
+		// (language, editClass) cell, so a brand-new catastrophic corruption
+		// (e.g. delta -500) would be silently absorbed by an entry recorded
+		// for a delta -16 bug. With exact deltas, a worse magnitude is a NEW,
+		// unlisted signature and the gate hard-fails on it.
+		return fmt.Sprintf("%s:childCount%s", d.nodeType, d.detail)
 	case "type":
 		return fmt.Sprintf("%s:type(%s)", d.nodeType, d.detail)
 	case "span":

--- a/incremental_invariant_gate_test.go
+++ b/incremental_invariant_gate_test.go
@@ -143,10 +143,21 @@ func TestIncrementalInvariantGate(t *testing.T) {
 
 	matched := make(map[incrGateAllowlistKey]bool)
 	var matchedMu sync.Mutex
+	// swept records which languages actually ran, so the ratchet below only
+	// enforces entries for languages this invocation swept. Without it, a
+	// per-language subset run (e.g. `go test -run TestIncrementalInvariantGate/python`,
+	// the natural way to debug one language) would ratchet-fail on entries for
+	// languages it never ran -- a spurious "STALE ALLOWLIST ENTRY" that would
+	// mislead a maintainer into deleting a live known-bug record.
+	swept := make(map[string]bool)
+	var sweptMu sync.Mutex
 
 	for _, entry := range incrGateCorpus {
 		entry := entry
 		t.Run(entry.language+"/"+entry.path, func(t *testing.T) {
+			sweptMu.Lock()
+			swept[entry.language] = true
+			sweptMu.Unlock()
 			stats := runIncrGateSweep(t, entry, index, matched, &matchedMu)
 			t.Logf("sites=%d fullSpan=%d freshClean=%d divergent(freshClean-scoped)=%d newUnlisted=%d",
 				stats.totalSites, stats.fullSpanSites, stats.cleanSites, stats.divergentSites, len(stats.unlisted))
@@ -162,6 +173,15 @@ func TestIncrementalInvariantGate(t *testing.T) {
 	// allowlist silently grows and stops meaning "currently reproducing known
 	// bug".
 	for _, e := range allowlist.Entries {
+		sweptMu.Lock()
+		ranLang := swept[e.Language]
+		sweptMu.Unlock()
+		if !ranLang {
+			// This language was not swept in this invocation (e.g. a filtered
+			// subset run), so we have no evidence about its entries -- skip,
+			// don't ratchet-fail.
+			continue
+		}
 		key := incrGateAllowlistKey{e.Language, e.EditClass, e.Signature}
 		matchedMu.Lock()
 		ok := matched[key]
@@ -382,7 +402,16 @@ type incrGateDivergence struct {
 func incrGateFirstDivergence(lang *gts.Language, fresh, incr *gts.Node, ancestorPath []string) *incrGateDivergence {
 	if fresh == nil || incr == nil {
 		if fresh != incr {
-			return &incrGateDivergence{kind: "nil", nodeType: "<nil>", path: strings.Join(ancestorPath, ">")}
+			// Preserve the non-nil side's type so the signature is specific
+			// (e.g. "block:nilmismatch", not the content-free "<nil>:nilmismatch")
+			// -- keeps the allowlist key narrow and triage informative.
+			nodeType := "<nil>"
+			if fresh != nil {
+				nodeType = fresh.Type(lang)
+			} else if incr != nil {
+				nodeType = incr.Type(lang)
+			}
+			return &incrGateDivergence{kind: "nil", nodeType: nodeType, path: strings.Join(ancestorPath, ">")}
 		}
 		return nil
 	}

--- a/incremental_invariant_gate_test.go
+++ b/incremental_invariant_gate_test.go
@@ -1,0 +1,453 @@
+package gotreesitter_test
+
+// TestIncrementalInvariantGate is the non-cherry-picking incremental-
+// correctness gate. It is committable, default-on, and pure Go (no cgo, no
+// C oracle needed): it only checks gotreesitter against itself.
+//
+// The fundamental tree-sitter contract under test: for the same final
+// source text, ParseIncremental(edited, oldTree.Edit(e)) must be
+// structurally identical to Parse(edited). This gate sweeps a curated,
+// real-world corpus, exercising single-byte DELETE / INSERT / same-length
+// REPLACE edits at a strided cadence across (in principle) every site in
+// each file, and enforces that invariant for every site where the *fresh*
+// parse of the edited text is genuinely clean: full-span (root covers the
+// whole edited buffer) AND zero IsError()/IsMissing() nodes anywhere in the
+// tree, checked via a recursive node walk. Node.HasError() is never used as
+// a cleanliness signal -- the root-cause investigation that motivated this
+// gate found it unreliable (a tree can be silently, structurally wrong while
+// HasError() still reports false).
+//
+// Divergences are tracked, not silently skipped. Every one found is checked
+// against testdata/incremental_allowlist.json, keyed by
+// (language, edit-class, divergence-signature) where the signature is the
+// type of the first structurally-diverging node plus the kind of divergence
+// (childCount/type/span/named/missing). A divergence NOT in the allowlist
+// fails the build -- this is what "de-silences" the corruption: today a
+// consumer has no signal at all (HasError() is false, the tree looks fine);
+// this gate turns that silence into a loud, specific CI failure. An
+// allowlist entry that stops reproducing ALSO fails the build (a ratchet
+// that forces the allowlist to be cleaned up once the underlying bug is
+// fixed, rather than accumulating dead entries forever).
+//
+// This intentionally does NOT cherry-pick a single passing edit site the way
+// cgo_harness/parity_cgo_test.go (breaks on the first fresh-parity-safe
+// candidate, logs+skips the rest) and
+// cgo_harness/benchmark_real_corpus_parity_test.go (verifyRealCorpusIncrementalCandidate
+// returns on the first accepted candidate) do. Every strided site is
+// evaluated and every outcome is accounted for, either as a pass, a known
+// allowlisted divergence, or a hard failure.
+//
+// Scope note: the assertion above is restricted to sites where the *fresh*
+// parse is genuinely clean. Sites where fresh already contains ERROR/MISSING
+// nodes (e.g. an edit landed mid-operator and produced genuinely malformed
+// source) are excluded from the hard assertion -- error-recovery shape is a
+// separate, much noisier surface (a large fraction of arbitrary byte-level
+// edits land there) that is not what "silent incremental corruption" refers
+// to. The freshly-clean subclass is exactly the one with no error signal
+// available to a consumer, which is why it is the one this gate hard-fails
+// on.
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// incrGateCorpusEntry describes one curated corpus file swept by the gate.
+//
+// stride is a hand-calibrated, FIXED byte stride (not derived from a
+// wall-clock calibration at test-run time -- that would make the exact set
+// of probed sites depend on machine speed, which would make the allowlist
+// non-deterministic across environments). Strides were chosen by measuring
+// real per-site incremental-parse cost on each file so the full sweep
+// (3 edit classes x every curated file) finishes in roughly 1-3 minutes.
+// python_setup.py is cheap enough to sweep exhaustively (stride 1: every
+// single byte position, zero cherry-picking in the most literal sense).
+var incrGateCorpus = []incrGateCorpusEntry{
+	{language: "python", path: "python_setup.py", stride: 1},
+	{language: "python", path: "python_large_indent.py", stride: 900},
+	{language: "javascript", path: "javascript_grammar.js", stride: 200},
+	{language: "json", path: "json_contract.json", stride: 15},
+	{language: "go", path: "go_print.go", stride: 600},
+	{language: "rust", path: "rust_ast.rs", stride: 600},
+}
+
+type incrGateCorpusEntry struct {
+	language string
+	path     string // relative to testdata/incremental_gate
+	stride   int
+}
+
+// incrGateAllowlistEntry is one committed, tracked, KNOWN divergence.
+type incrGateAllowlistEntry struct {
+	Language   string `json:"language"`
+	EditClass  string `json:"editClass"`
+	Signature  string `json:"signature"`
+	FreshClean bool   `json:"freshGenuinelyClean"`
+	Note       string `json:"note"`
+}
+
+type incrGateAllowlist struct {
+	Version     int                      `json:"version"`
+	Description string                   `json:"description"`
+	Entries     []incrGateAllowlistEntry `json:"entries"`
+}
+
+type incrGateAllowlistKey struct {
+	language, editClass, signature string
+}
+
+func loadIncrGateAllowlist(t *testing.T) *incrGateAllowlist {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", "incremental_allowlist.json"))
+	if err != nil {
+		t.Fatalf("read testdata/incremental_allowlist.json: %v", err)
+	}
+	var al incrGateAllowlist
+	if err := json.Unmarshal(raw, &al); err != nil {
+		t.Fatalf("parse testdata/incremental_allowlist.json: %v", err)
+	}
+	seen := map[incrGateAllowlistKey]bool{}
+	for _, e := range al.Entries {
+		if e.Language == "" || e.EditClass == "" || e.Signature == "" {
+			t.Fatalf("allowlist entry missing language/editClass/signature: %+v", e)
+		}
+		key := incrGateAllowlistKey{e.Language, e.EditClass, e.Signature}
+		if seen[key] {
+			t.Fatalf("duplicate allowlist entry for %s | %s | %s", e.Language, e.EditClass, e.Signature)
+		}
+		seen[key] = true
+	}
+	return &al
+}
+
+func (al *incrGateAllowlist) index() map[incrGateAllowlistKey]*incrGateAllowlistEntry {
+	m := make(map[incrGateAllowlistKey]*incrGateAllowlistEntry, len(al.Entries))
+	for i := range al.Entries {
+		e := &al.Entries[i]
+		m[incrGateAllowlistKey{e.Language, e.EditClass, e.Signature}] = e
+	}
+	return m
+}
+
+// TestIncrementalInvariantGate is the gate. See file doc comment.
+func TestIncrementalInvariantGate(t *testing.T) {
+	allowlist := loadIncrGateAllowlist(t)
+	index := allowlist.index()
+
+	matched := make(map[incrGateAllowlistKey]bool)
+	var matchedMu sync.Mutex
+
+	for _, entry := range incrGateCorpus {
+		entry := entry
+		t.Run(entry.language+"/"+entry.path, func(t *testing.T) {
+			stats := runIncrGateSweep(t, entry, index, matched, &matchedMu)
+			t.Logf("sites=%d fullSpan=%d freshClean=%d divergent(freshClean-scoped)=%d newUnlisted=%d",
+				stats.totalSites, stats.fullSpanSites, stats.cleanSites, stats.divergentSites, len(stats.unlisted))
+			for _, u := range stats.unlisted {
+				t.Errorf("%s", u)
+			}
+		})
+	}
+
+	// Ratchet: every allowlist entry must have reproduced at least once in
+	// this sweep. A stale entry (bug fixed, or corpus/algorithm changed so it
+	// no longer manifests) must be removed, not left to rot -- otherwise the
+	// allowlist silently grows and stops meaning "currently reproducing known
+	// bug".
+	for _, e := range allowlist.Entries {
+		key := incrGateAllowlistKey{e.Language, e.EditClass, e.Signature}
+		matchedMu.Lock()
+		ok := matched[key]
+		matchedMu.Unlock()
+		if !ok {
+			t.Errorf("STALE ALLOWLIST ENTRY (ratchet failure): %s | %s | %s did not reproduce anywhere in this sweep -- "+
+				"remove it from testdata/incremental_allowlist.json (recorded note: %q)",
+				e.Language, e.EditClass, e.Signature, e.Note)
+		}
+	}
+}
+
+type incrGateStats struct {
+	totalSites, fullSpanSites, cleanSites, divergentSites int
+	unlisted                                              []string
+}
+
+func runIncrGateSweep(
+	t *testing.T,
+	entry incrGateCorpusEntry,
+	index map[incrGateAllowlistKey]*incrGateAllowlistEntry,
+	matched map[incrGateAllowlistKey]bool,
+	matchedMu *sync.Mutex,
+) incrGateStats {
+	t.Helper()
+
+	e := grammars.DetectLanguageByName(entry.language)
+	if e == nil {
+		t.Fatalf("unknown language %q", entry.language)
+	}
+	lang := e.Language()
+	support := grammars.EvaluateParseSupport(*e, lang)
+	if support.Backend == grammars.ParseBackendUnsupported || support.Backend == grammars.ParseBackendDFAPartial {
+		t.Fatalf("language %q has no usable full-parse backend for the gate: %s", entry.language, support.Reason)
+	}
+
+	src, err := os.ReadFile(filepath.Join("testdata", "incremental_gate", entry.path))
+	if err != nil {
+		t.Fatalf("read corpus file: %v", err)
+	}
+	if len(src) < 8 {
+		t.Fatalf("corpus file too small to sweep: %s", entry.path)
+	}
+
+	freshP := gts.NewParser(lang)
+	incrP := gts.NewParser(lang)
+
+	parseFresh := func(p *gts.Parser, s []byte) *gts.Tree {
+		if support.Backend == grammars.ParseBackendTokenSource {
+			tr, _ := p.ParseWithTokenSource(s, e.TokenSourceFactory(s, lang))
+			return tr
+		}
+		tr, _ := p.Parse(s)
+		return tr
+	}
+
+	baseline := parseFresh(freshP, src)
+	if baseline == nil || baseline.RootNode() == nil {
+		t.Fatalf("baseline fresh parse of %s failed", entry.path)
+	}
+
+	stride := entry.stride
+	if stride < 1 {
+		stride = 1
+	}
+
+	var stats incrGateStats
+	editClasses := []string{"delete", "insert", "replace"}
+
+	for i := 1; i < len(src)-1; i += stride {
+		for _, cls := range editClasses {
+			edited, edit := incrGateBuildEdit(src, i, cls)
+
+			fresh := parseFresh(freshP, edited)
+			stats.totalSites++
+			if fresh == nil || fresh.RootNode() == nil || int(fresh.RootNode().EndByte()) != len(edited) {
+				continue // fresh parse itself did not cover the whole edited buffer; out of scope
+			}
+			stats.fullSpanSites++
+
+			fe, fm := incrGateTreeStats(fresh.RootNode())
+			if fe != 0 || fm != 0 {
+				continue // fresh is not genuinely clean; error-recovery-path divergence is out of this gate's scope
+			}
+			stats.cleanSites++
+
+			oldCopy := baseline.Copy()
+			oldCopy.Edit(edit)
+			var incr *gts.Tree
+			if support.Backend == grammars.ParseBackendTokenSource {
+				incr, _ = incrP.ParseIncrementalWithTokenSource(edited, oldCopy, e.TokenSourceFactory(edited, lang))
+			} else {
+				incr, _ = incrP.ParseIncremental(edited, oldCopy)
+			}
+			if incr == nil || incr.RootNode() == nil {
+				stats.divergentSites++
+				stats.unlisted = append(stats.unlisted, fmt.Sprintf(
+					"SILENT-CORRUPTION(fresh-clean) unlisted: %s pos=%d class=%s: ParseIncremental returned nil/no-root while fresh parse of the identical edited text was clean and full-span",
+					entry.path, i, cls))
+				continue
+			}
+
+			d := incrGateFirstDivergence(lang, fresh.RootNode(), incr.RootNode(), nil)
+			if d == nil {
+				continue // genuinely identical -- the invariant holds here
+			}
+			stats.divergentSites++
+
+			sig := d.signature()
+			key := incrGateAllowlistKey{entry.language, cls, sig}
+			if _, ok := index[key]; ok {
+				matchedMu.Lock()
+				matched[key] = true
+				matchedMu.Unlock()
+				continue // known, tracked divergence
+			}
+			stats.unlisted = append(stats.unlisted, fmt.Sprintf(
+				"SILENT-CORRUPTION(fresh-clean) unlisted divergence: %s | %s | %s "+
+					"(file=%s pos=%d divergingPath=%s detail=%s) -- fresh parse of the edited text is clean "+
+					"(zero IsError()/IsMissing(), full span) but ParseIncremental diverges structurally from it. "+
+					"This is either a NEW regression, or a real known-bug site that needs a documented entry in "+
+					"testdata/incremental_allowlist.json.",
+				entry.language, cls, sig, entry.path, i, d.path, d.detail))
+		}
+	}
+	return stats
+}
+
+// incrGateBuildEdit constructs the edited buffer and the corresponding
+// InputEdit for one of the three edit classes swept by the gate:
+//   - delete:  remove the byte at i
+//   - insert:  duplicate the byte at i (a single-byte, non-noop insertion)
+//   - replace: substitute the byte at i with a different fixed byte
+//     (same-length edit)
+func incrGateBuildEdit(src []byte, i int, class string) ([]byte, gts.InputEdit) {
+	switch class {
+	case "delete":
+		edited := make([]byte, 0, len(src)-1)
+		edited = append(edited, src[:i]...)
+		edited = append(edited, src[i+1:]...)
+		p := incrGatePointAt(src, i)
+		return edited, gts.InputEdit{
+			StartByte: uint32(i), OldEndByte: uint32(i + 1), NewEndByte: uint32(i),
+			StartPoint: p, OldEndPoint: incrGatePointAt(src, i+1), NewEndPoint: p,
+		}
+	case "insert":
+		edited := make([]byte, 0, len(src)+1)
+		edited = append(edited, src[:i]...)
+		edited = append(edited, src[i])
+		edited = append(edited, src[i:]...)
+		p := incrGatePointAt(src, i)
+		return edited, gts.InputEdit{
+			StartByte: uint32(i), OldEndByte: uint32(i), NewEndByte: uint32(i + 1),
+			StartPoint: p, OldEndPoint: p, NewEndPoint: incrGatePointAt(edited, i+1),
+		}
+	case "replace":
+		repByte := byte('z')
+		if src[i] == 'z' {
+			repByte = 'y'
+		}
+		edited := append([]byte{}, src...)
+		edited[i] = repByte
+		return edited, gts.InputEdit{
+			StartByte: uint32(i), OldEndByte: uint32(i + 1), NewEndByte: uint32(i + 1),
+			StartPoint: incrGatePointAt(src, i), OldEndPoint: incrGatePointAt(src, i+1), NewEndPoint: incrGatePointAt(edited, i+1),
+		}
+	default:
+		panic("incrGateBuildEdit: unknown edit class " + class)
+	}
+}
+
+func incrGatePointAt(src []byte, off int) gts.Point {
+	row, col := 0, 0
+	for idx := 0; idx < off && idx < len(src); idx++ {
+		if src[idx] == '\n' {
+			row++
+			col = 0
+		} else {
+			col++
+		}
+	}
+	return gts.Point{Row: uint32(row), Column: uint32(col)}
+}
+
+// incrGateTreeStats walks the tree counting IsError()/IsMissing() nodes.
+// Deliberately does NOT use Node.HasError(): the root-cause investigation
+// behind this gate found HasError() unreliable as a cleanliness signal.
+func incrGateTreeStats(n *gts.Node) (errN, missN int) {
+	if n == nil {
+		return
+	}
+	if n.IsError() {
+		errN++
+	}
+	if n.IsMissing() {
+		missN++
+	}
+	for i := 0; i < n.ChildCount(); i++ {
+		e, m := incrGateTreeStats(n.Child(i))
+		errN += e
+		missN += m
+	}
+	return
+}
+
+type incrGateDivergence struct {
+	kind, nodeType, path, detail string
+}
+
+// incrGateFirstDivergence walks fresh and incr in lockstep and returns the
+// first structural difference found (type, span, isNamed, isMissing,
+// childCount -- in that order, matching cgo_harness/parity_cgo_test.go's
+// compareGoNodes field order), or nil if the two subtrees are identical.
+func incrGateFirstDivergence(lang *gts.Language, fresh, incr *gts.Node, ancestorPath []string) *incrGateDivergence {
+	if fresh == nil || incr == nil {
+		if fresh != incr {
+			return &incrGateDivergence{kind: "nil", nodeType: "<nil>", path: strings.Join(ancestorPath, ">")}
+		}
+		return nil
+	}
+	ft, it := fresh.Type(lang), incr.Type(lang)
+	if ft != it {
+		return &incrGateDivergence{kind: "type", nodeType: ft, path: strings.Join(ancestorPath, ">"), detail: fmt.Sprintf("%s!=%s", ft, it)}
+	}
+	curPath := append(append([]string{}, ancestorPath...), ft)
+	if fresh.StartByte() != incr.StartByte() || fresh.EndByte() != incr.EndByte() {
+		return &incrGateDivergence{kind: "span", nodeType: ft, path: strings.Join(curPath, ">"),
+			detail: fmt.Sprintf("[%d,%d)!=[%d,%d)", fresh.StartByte(), fresh.EndByte(), incr.StartByte(), incr.EndByte())}
+	}
+	if fresh.IsNamed() != incr.IsNamed() {
+		return &incrGateDivergence{kind: "named", nodeType: ft, path: strings.Join(curPath, ">")}
+	}
+	if fresh.IsMissing() != incr.IsMissing() {
+		return &incrGateDivergence{kind: "missing", nodeType: ft, path: strings.Join(curPath, ">")}
+	}
+	fc, ic := fresh.ChildCount(), incr.ChildCount()
+	if fc != ic {
+		return &incrGateDivergence{kind: "childCount", nodeType: ft, path: strings.Join(curPath, ">"), detail: fmt.Sprintf("%+d", ic-fc)}
+	}
+	for i := 0; i < fc; i++ {
+		if d := incrGateFirstDivergence(lang, fresh.Child(i), incr.Child(i), curPath); d != nil {
+			return d
+		}
+	}
+	return nil
+}
+
+// incrGateChildCountBucket collapses a raw childCount delta into the
+// allowlist-key component. Small deltas (|delta| <= 5) are kept exact,
+// matching how localized bugs manifest (e.g. one extra/missing statement).
+// Larger deltas were observed on files where a single edit cascades into
+// whole-subtree re-derivation (a much more severe class of bug); there the
+// *exact* magnitude is incidental to the edit position and source shape
+// downstream of it, not a distinct bug signature per magnitude, so it
+// collapses to a signed bucket instead of exploding the allowlist into one
+// entry per observed delta.
+func incrGateChildCountBucket(detail string) string {
+	var delta int
+	fmt.Sscanf(detail, "%d", &delta)
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta <= 5 {
+		return detail
+	}
+	if strings.HasPrefix(detail, "-") {
+		return "(large-)"
+	}
+	return "(large+)"
+}
+
+func (d *incrGateDivergence) signature() string {
+	switch d.kind {
+	case "childCount":
+		return fmt.Sprintf("%s:childCount%s", d.nodeType, incrGateChildCountBucket(d.detail))
+	case "type":
+		return fmt.Sprintf("%s:type(%s)", d.nodeType, d.detail)
+	case "span":
+		return fmt.Sprintf("%s:span", d.nodeType)
+	case "named":
+		return fmt.Sprintf("%s:named", d.nodeType)
+	case "missing":
+		return fmt.Sprintf("%s:missing", d.nodeType)
+	case "nil":
+		return fmt.Sprintf("%s:nilmismatch", d.nodeType)
+	default:
+		return fmt.Sprintf("%s:%s", d.nodeType, d.kind)
+	}
+}

--- a/testdata/incremental_allowlist.json
+++ b/testdata/incremental_allowlist.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "description": "Known-tail registry for TestIncrementalInvariantGate (incremental_invariant_gate_test.go). Each entry documents a currently-reproducing case where ParseIncremental diverges structurally from Parse on the same edited text, even though the fresh parse is genuinely clean (full-span, zero IsError()/IsMissing() nodes). This is the 'silent incremental corruption' class: HasError() reports false and there is no signal to a consumer that the incremental tree is wrong. Entries are keyed by (language, editClass, signature); signature = <divergingNodeType>:<kind>[detail], where a childCount delta is kept exact for |delta|<=5 and bucketed to '(large-)'/'(large+)' above that (see incrGateChildCountBucket). RATCHET: the gate fails if any entry here stops reproducing -- remove it once the underlying bug is fixed, don't leave it stale. Cross-ref: the codex/incremental-correctness-diagnosis root-cause investigation (validate/INCREMENTAL-CURRENT.md in the investigation scratchpad) first documented this class of bug ('gts-fresh is correct; gts-incremental silently returns a structurally wrong tree, HasError()==false') on python3.8_grammar.py and setup.py at an older commit. The exact signatures below are freshly re-derived against current origin/main by this gate's own sweep (they do not match the investigation's example strings verbatim -- the codebase has moved ~160 commits and several incremental-parser fixes have landed since; these are the entries that actually reproduce today).",
+  "entries": [
+    {
+      "language": "python",
+      "editClass": "delete",
+      "signature": "block:childCount+1",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_setup.py pos=485 (delete a ',' inside a nested function body). Fresh parses a clean module>class_definition>block>function_definition>block with N statements; incremental attaches one extra child to that inner block. Root cause not diagnosed here (that's the codex incremental-correctness-diagnosis lane); this entry only tracks that it currently reproduces."
+    },
+    {
+      "language": "python",
+      "editClass": "delete",
+      "signature": "module:childCount-1",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_setup.py, e.g. pos=601 (delete inside a top-level call argument). Fresh's module has one more top-level child than incremental's -- incremental drops/merges a top-level statement that fresh keeps distinct."
+    },
+    {
+      "language": "python",
+      "editClass": "delete",
+      "signature": "module:childCount-2",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_large_indent.py (CPython Lib/test/test_grammar.py-style corpus, heavy nested control flow). Dominant signature on this file: ~80-90% of freshClean delete sites reproduce this exact -2 module childCount delta. Same shape as the codex root-cause investigation's originally-reported Class B (module childCount shrinkage near a class/def body) but re-derived fresh against current main; the exact delta and node differ slightly from the investigation's stale example string."
+    },
+    {
+      "language": "python",
+      "editClass": "delete",
+      "signature": "module:childCount(large-)",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_large_indent.py. A minority of delete sites on this file cascade into a much larger module-level childCount shrinkage (observed exact deltas at various positions: -9, -16, -26, ... -- magnitude depends on how far the cascading re-derivation reaches, not a distinct bug per magnitude, hence the bucketed signature). Same underlying mechanism as the -2 dominant case, more severe manifestation."
+    },
+    {
+      "language": "python",
+      "editClass": "insert",
+      "signature": "module:childCount-1",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_setup.py, e.g. pos=601 (duplicate-byte insert). Same shape as the delete-class module:childCount-1 entry above, mirrored for single-byte insertion."
+    },
+    {
+      "language": "python",
+      "editClass": "insert",
+      "signature": "module:childCount-2",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_large_indent.py. Same dominant -2 module-level shape as the delete-class entry, reproduced under single-byte insertion edits."
+    },
+    {
+      "language": "python",
+      "editClass": "replace",
+      "signature": "block:childCount+1",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_setup.py pos=485, same site/shape as the delete-class block:childCount+1 entry, reproduced under a same-length replace edit."
+    },
+    {
+      "language": "python",
+      "editClass": "replace",
+      "signature": "module:childCount-1",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_setup.py, e.g. pos=600. Replace-class mirror of the delete/insert module:childCount-1 entries."
+    },
+    {
+      "language": "python",
+      "editClass": "replace",
+      "signature": "module:childCount-2",
+      "freshGenuinelyClean": true,
+      "note": "Reproduces on BOTH testdata/incremental_gate/python_setup.py (pos=379) and testdata/incremental_gate/python_large_indent.py (dominant shape, e.g. pos=1801) under replace edits. Same signature covers both files by design (the allowlist key is language+editClass+signature, not file-scoped)."
+    },
+    {
+      "language": "python",
+      "editClass": "replace",
+      "signature": "module:childCount(large-)",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/python_large_indent.py. Replace-class mirror of the delete-class module:childCount(large-) bucket -- cascading whole-module re-derivation, varying exact magnitude (observed deltas include -11, -16, -31, -38, -47, -48, -52, -58 at different positions)."
+    },
+    {
+      "language": "javascript",
+      "editClass": "insert",
+      "signature": "program:childCount(large+)",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/javascript_grammar.js (tree-sitter's own go grammar.js, a real large declarative JS file), e.g. pos=901/1801 under single-byte insert. Rare (2 hits out of ~690 sampled sites at stride=100): fresh's program root is clean with N children; incremental attaches substantially more. Only signature found on the JS corpus file; delete/replace classes and the rest of the JS sweep were clean at the swept strides."
+    }
+  ]
+}

--- a/testdata/incremental_allowlist.json
+++ b/testdata/incremental_allowlist.json
@@ -1,83 +1,13 @@
 {
-  "version": 1,
-  "description": "Known-tail registry for TestIncrementalInvariantGate (incremental_invariant_gate_test.go). Each entry documents a currently-reproducing case where ParseIncremental diverges structurally from Parse on the same edited text, even though the fresh parse is genuinely clean (full-span, zero IsError()/IsMissing() nodes). This is the 'silent incremental corruption' class: HasError() reports false and there is no signal to a consumer that the incremental tree is wrong. Entries are keyed by (language, editClass, signature); signature = <divergingNodeType>:<kind>[detail], where a childCount delta is kept exact for |delta|<=5 and bucketed to '(large-)'/'(large+)' above that (see incrGateChildCountBucket). RATCHET: the gate fails if any entry here stops reproducing -- remove it once the underlying bug is fixed, don't leave it stale. Cross-ref: the codex/incremental-correctness-diagnosis root-cause investigation (validate/INCREMENTAL-CURRENT.md in the investigation scratchpad) first documented this class of bug ('gts-fresh is correct; gts-incremental silently returns a structurally wrong tree, HasError()==false') on python3.8_grammar.py and setup.py at an older commit. The exact signatures below are freshly re-derived against current origin/main by this gate's own sweep (they do not match the investigation's example strings verbatim -- the codebase has moved ~160 commits and several incremental-parser fixes have landed since; these are the entries that actually reproduce today).",
+  "version": 2,
+  "description": "Known-tail registry for TestIncrementalInvariantGate (incremental_invariant_gate_test.go). Each entry documents a currently-reproducing case where ParseIncremental diverges structurally from Parse on the same edited text even though the fresh parse is genuinely clean (full-span, zero IsError()/IsMissing() nodes) -- the 'silent incremental corruption' class (HasError() reports false, no consumer signal). Keyed by (language, editClass, signature); signature = <divergingNodeType>:<kind>[detail]. childCount deltas are kept EXACT and signed (never bucketed) so a worse-magnitude divergence is a NEW unlisted signature the gate hard-fails on. RATCHET: the gate fails if any entry here stops reproducing. Before deleting a ratchet-failed entry, confirm WHY it stopped: either the incremental bug was fixed, OR the fresh-clean observation window closed (a grammar/parser change made the fresh parse at those sites contain ERROR/MISSING, excluding them from scope while the bug may persist). Only remove entries confirmed fixed. This is a self-consistency gate (incremental == fresh), NOT an oracle (fresh == C) -- it complements the cgo parity gate, it does not replace it. Regenerated against origin/main @ ca871e7d (post-#379 Python fail-closed).",
   "entries": [
-    {
-      "language": "python",
-      "editClass": "delete",
-      "signature": "block:childCount+1",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_setup.py pos=485 (delete a ',' inside a nested function body). Fresh parses a clean module>class_definition>block>function_definition>block with N statements; incremental attaches one extra child to that inner block. Root cause not diagnosed here (that's the codex incremental-correctness-diagnosis lane); this entry only tracks that it currently reproduces."
-    },
-    {
-      "language": "python",
-      "editClass": "delete",
-      "signature": "module:childCount-1",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_setup.py, e.g. pos=601 (delete inside a top-level call argument). Fresh's module has one more top-level child than incremental's -- incremental drops/merges a top-level statement that fresh keeps distinct."
-    },
-    {
-      "language": "python",
-      "editClass": "delete",
-      "signature": "module:childCount-2",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_large_indent.py (CPython Lib/test/test_grammar.py-style corpus, heavy nested control flow). Dominant signature on this file: ~80-90% of freshClean delete sites reproduce this exact -2 module childCount delta. Same shape as the codex root-cause investigation's originally-reported Class B (module childCount shrinkage near a class/def body) but re-derived fresh against current main; the exact delta and node differ slightly from the investigation's stale example string."
-    },
-    {
-      "language": "python",
-      "editClass": "delete",
-      "signature": "module:childCount(large-)",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_large_indent.py. A minority of delete sites on this file cascade into a much larger module-level childCount shrinkage (observed exact deltas at various positions: -9, -16, -26, ... -- magnitude depends on how far the cascading re-derivation reaches, not a distinct bug per magnitude, hence the bucketed signature). Same underlying mechanism as the -2 dominant case, more severe manifestation."
-    },
-    {
-      "language": "python",
-      "editClass": "insert",
-      "signature": "module:childCount-1",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_setup.py, e.g. pos=601 (duplicate-byte insert). Same shape as the delete-class module:childCount-1 entry above, mirrored for single-byte insertion."
-    },
-    {
-      "language": "python",
-      "editClass": "insert",
-      "signature": "module:childCount-2",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_large_indent.py. Same dominant -2 module-level shape as the delete-class entry, reproduced under single-byte insertion edits."
-    },
-    {
-      "language": "python",
-      "editClass": "replace",
-      "signature": "block:childCount+1",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_setup.py pos=485, same site/shape as the delete-class block:childCount+1 entry, reproduced under a same-length replace edit."
-    },
-    {
-      "language": "python",
-      "editClass": "replace",
-      "signature": "module:childCount-1",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_setup.py, e.g. pos=600. Replace-class mirror of the delete/insert module:childCount-1 entries."
-    },
-    {
-      "language": "python",
-      "editClass": "replace",
-      "signature": "module:childCount-2",
-      "freshGenuinelyClean": true,
-      "note": "Reproduces on BOTH testdata/incremental_gate/python_setup.py (pos=379) and testdata/incremental_gate/python_large_indent.py (dominant shape, e.g. pos=1801) under replace edits. Same signature covers both files by design (the allowlist key is language+editClass+signature, not file-scoped)."
-    },
-    {
-      "language": "python",
-      "editClass": "replace",
-      "signature": "module:childCount(large-)",
-      "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/python_large_indent.py. Replace-class mirror of the delete-class module:childCount(large-) bucket -- cascading whole-module re-derivation, varying exact magnitude (observed deltas include -11, -16, -31, -38, -47, -48, -52, -58 at different positions)."
-    },
     {
       "language": "javascript",
       "editClass": "insert",
-      "signature": "program:childCount(large+)",
+      "signature": "program:childCount+20",
       "freshGenuinelyClean": true,
-      "note": "testdata/incremental_gate/javascript_grammar.js (tree-sitter's own go grammar.js, a real large declarative JS file), e.g. pos=901/1801 under single-byte insert. Rare (2 hits out of ~690 sampled sites at stride=100): fresh's program root is clean with N children; incremental attaches substantially more. Only signature found on the JS corpus file; delete/replace classes and the rest of the JS sweep were clean at the swept strides."
+      "note": "testdata/incremental_gate/javascript_grammar.js pos=1801 (single-byte insert, committed stride 200 -- pos is on the stride grid). Fresh parses a clean program; incremental attaches 20 extra children to the program node. This is the residual JavaScript real-reuse silent-corruption site: PR bc960713's C-repetition-skip fold on reused subtrees eliminated the bulk of the old ~84% JS delete/insert divergence but did not fully close it. Root cause is the parser-core incremental-reuse lane, not this gate; this entry only tracks that it currently reproduces. NOTE: the sole surviving witness -- a single site -- so a one-byte behavior drift here flips the gate red; add a second JS witness if the corpus grows. Distinct from the former Python class, which #379 made fail-closed (Python no longer reuses), so its old entries were pruned in this v2 regeneration."
     }
   ]
 }

--- a/testdata/incremental_gate/go_print.go
+++ b/testdata/incremental_gate/go_print.go
@@ -1,0 +1,1223 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	"internal/fmtsort"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+	"sync"
+	"unicode/utf8"
+)
+
+// Strings for use with buffer.WriteString.
+// This is less overhead than using buffer.Write with byte arrays.
+const (
+	commaSpaceString  = ", "
+	nilAngleString    = "<nil>"
+	nilParenString    = "(nil)"
+	nilString         = "nil"
+	mapString         = "map["
+	percentBangString = "%!"
+	missingString     = "(MISSING)"
+	badIndexString    = "(BADINDEX)"
+	panicString       = "(PANIC="
+	extraString       = "%!(EXTRA "
+	badWidthString    = "%!(BADWIDTH)"
+	badPrecString     = "%!(BADPREC)"
+	noVerbString      = "%!(NOVERB)"
+	invReflectString  = "<invalid reflect.Value>"
+)
+
+// State represents the printer state passed to custom formatters.
+// It provides access to the [io.Writer] interface plus information about
+// the flags and options for the operand's format specifier.
+type State interface {
+	// Write is the function to call to emit formatted output to be printed.
+	Write(b []byte) (n int, err error)
+	// Width returns the value of the width option and whether it has been set.
+	Width() (wid int, ok bool)
+	// Precision returns the value of the precision option and whether it has been set.
+	Precision() (prec int, ok bool)
+
+	// Flag reports whether the flag c, a character, has been set.
+	Flag(c int) bool
+}
+
+// Formatter is implemented by any value that has a Format method.
+// The implementation controls how [State] and rune are interpreted,
+// and may call [Sprint] or [Fprint](f) etc. to generate its output.
+type Formatter interface {
+	Format(f State, verb rune)
+}
+
+// Stringer is implemented by any value that has a String method,
+// which defines the “native” format for that value.
+// The String method is used to print values passed as an operand
+// to any format that accepts a string or to an unformatted printer
+// such as [Print].
+type Stringer interface {
+	String() string
+}
+
+// GoStringer is implemented by any value that has a GoString method,
+// which defines the Go syntax for that value.
+// The GoString method is used to print values passed as an operand
+// to a %#v format.
+type GoStringer interface {
+	GoString() string
+}
+
+// FormatString returns a string representing the fully qualified formatting
+// directive captured by the [State], followed by the argument verb. ([State] does not
+// itself contain the verb.) The result has a leading percent sign followed by any
+// flags, the width, and the precision. Missing flags, width, and precision are
+// omitted. This function allows a [Formatter] to reconstruct the original
+// directive triggering the call to Format.
+func FormatString(state State, verb rune) string {
+	var tmp [16]byte // Use a local buffer.
+	b := append(tmp[:0], '%')
+	for _, c := range " +-#0" { // All known flags
+		if state.Flag(int(c)) { // The argument is an int for historical reasons.
+			b = append(b, byte(c))
+		}
+	}
+	if w, ok := state.Width(); ok {
+		b = strconv.AppendInt(b, int64(w), 10)
+	}
+	if p, ok := state.Precision(); ok {
+		b = append(b, '.')
+		b = strconv.AppendInt(b, int64(p), 10)
+	}
+	b = utf8.AppendRune(b, verb)
+	return string(b)
+}
+
+// Use simple []byte instead of bytes.Buffer to avoid large dependency.
+type buffer []byte
+
+func (b *buffer) write(p []byte) {
+	*b = append(*b, p...)
+}
+
+func (b *buffer) writeString(s string) {
+	*b = append(*b, s...)
+}
+
+func (b *buffer) writeByte(c byte) {
+	*b = append(*b, c)
+}
+
+func (b *buffer) writeRune(r rune) {
+	*b = utf8.AppendRune(*b, r)
+}
+
+// pp is used to store a printer's state and is reused with sync.Pool to avoid allocations.
+type pp struct {
+	buf buffer
+
+	// arg holds the current item, as an interface{}.
+	arg any
+
+	// value is used instead of arg for reflect values.
+	value reflect.Value
+
+	// fmt is used to format basic items such as integers or strings.
+	fmt fmt
+
+	// reordered records whether the format string used argument reordering.
+	reordered bool
+	// goodArgNum records whether the most recent reordering directive was valid.
+	goodArgNum bool
+	// panicking is set by catchPanic to avoid infinite panic, recover, panic, ... recursion.
+	panicking bool
+	// erroring is set when printing an error string to guard against calling handleMethods.
+	erroring bool
+	// wrapErrs is set when the format string may contain a %w verb.
+	wrapErrs bool
+	// wrappedErrs records the targets of the %w verb.
+	wrappedErrs []int
+}
+
+var ppFree = sync.Pool{
+	New: func() any { return new(pp) },
+}
+
+// newPrinter allocates a new pp struct or grabs a cached one.
+func newPrinter() *pp {
+	p := ppFree.Get().(*pp)
+	p.panicking = false
+	p.erroring = false
+	p.wrapErrs = false
+	p.fmt.init(&p.buf)
+	return p
+}
+
+// free saves used pp structs in ppFree; avoids an allocation per invocation.
+func (p *pp) free() {
+	// Proper usage of a sync.Pool requires each entry to have approximately
+	// the same memory cost. To obtain this property when the stored type
+	// contains a variably-sized buffer, we add a hard limit on the maximum
+	// buffer to place back in the pool. If the buffer is larger than the
+	// limit, we drop the buffer and recycle just the printer.
+	//
+	// See https://golang.org/issue/23199.
+	if cap(p.buf) > 64*1024 {
+		p.buf = nil
+	} else {
+		p.buf = p.buf[:0]
+	}
+	if cap(p.wrappedErrs) > 8 {
+		p.wrappedErrs = nil
+	}
+
+	p.arg = nil
+	p.value = reflect.Value{}
+	p.wrappedErrs = p.wrappedErrs[:0]
+	ppFree.Put(p)
+}
+
+func (p *pp) Width() (wid int, ok bool) { return p.fmt.wid, p.fmt.widPresent }
+
+func (p *pp) Precision() (prec int, ok bool) { return p.fmt.prec, p.fmt.precPresent }
+
+func (p *pp) Flag(b int) bool {
+	switch b {
+	case '-':
+		return p.fmt.minus
+	case '+':
+		return p.fmt.plus || p.fmt.plusV
+	case '#':
+		return p.fmt.sharp || p.fmt.sharpV
+	case ' ':
+		return p.fmt.space
+	case '0':
+		return p.fmt.zero
+	}
+	return false
+}
+
+// Write implements [io.Writer] so we can call [Fprintf] on a pp (through [State]), for
+// recursive use in custom verbs.
+func (p *pp) Write(b []byte) (ret int, err error) {
+	p.buf.write(b)
+	return len(b), nil
+}
+
+// WriteString implements [io.StringWriter] so that we can call [io.WriteString]
+// on a pp (through state), for efficiency.
+func (p *pp) WriteString(s string) (ret int, err error) {
+	p.buf.writeString(s)
+	return len(s), nil
+}
+
+// These routines end in 'f' and take a format string.
+
+// Fprintf formats according to a format specifier and writes to w.
+// It returns the number of bytes written and any write error encountered.
+func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Printf formats according to a format specifier and writes to standard output.
+// It returns the number of bytes written and any write error encountered.
+func Printf(format string, a ...any) (n int, err error) {
+	return Fprintf(os.Stdout, format, a...)
+}
+
+// Sprintf formats according to a format specifier and returns the resulting string.
+func Sprintf(format string, a ...any) string {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// Appendf formats according to a format specifier, appends the result to the byte
+// slice, and returns the updated slice.
+func Appendf(b []byte, format string, a ...any) []byte {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	b = append(b, p.buf...)
+	p.free()
+	return b
+}
+
+// These routines do not take a format string
+
+// Fprint formats using the default formats for its operands and writes to w.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Fprint(w io.Writer, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrint(a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Print formats using the default formats for its operands and writes to standard output.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Print(a ...any) (n int, err error) {
+	return Fprint(os.Stdout, a...)
+}
+
+// Sprint formats using the default formats for its operands and returns the resulting string.
+// Spaces are added between operands when neither is a string.
+func Sprint(a ...any) string {
+	p := newPrinter()
+	p.doPrint(a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// Append formats using the default formats for its operands, appends the result to
+// the byte slice, and returns the updated slice.
+func Append(b []byte, a ...any) []byte {
+	p := newPrinter()
+	p.doPrint(a)
+	b = append(b, p.buf...)
+	p.free()
+	return b
+}
+
+// These routines end in 'ln', do not take a format string,
+// always add spaces between operands, and add a newline
+// after the last operand.
+
+// Fprintln formats using the default formats for its operands and writes to w.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Fprintln(w io.Writer, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrintln(a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Println formats using the default formats for its operands and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Println(a ...any) (n int, err error) {
+	return Fprintln(os.Stdout, a...)
+}
+
+// Sprintln formats using the default formats for its operands and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func Sprintln(a ...any) string {
+	p := newPrinter()
+	p.doPrintln(a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// Appendln formats using the default formats for its operands, appends the result
+// to the byte slice, and returns the updated slice. Spaces are always added
+// between operands and a newline is appended.
+func Appendln(b []byte, a ...any) []byte {
+	p := newPrinter()
+	p.doPrintln(a)
+	b = append(b, p.buf...)
+	p.free()
+	return b
+}
+
+// getField gets the i'th field of the struct value.
+// If the field itself is a non-nil interface, return a value for
+// the thing inside the interface, not the interface itself.
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}
+
+// tooLarge reports whether the magnitude of the integer is
+// too large to be used as a formatting width or precision.
+func tooLarge(x int) bool {
+	const max int = 1e6
+	return x > max || x < -max
+}
+
+// parsenum converts ASCII to integer.  num is 0 (and isnum is false) if no number present.
+func parsenum(s string, start, end int) (num int, isnum bool, newi int) {
+	if start >= end {
+		return 0, false, end
+	}
+	for newi = start; newi < end && '0' <= s[newi] && s[newi] <= '9'; newi++ {
+		if tooLarge(num) {
+			return 0, false, end // Overflow; crazy long number most likely.
+		}
+		num = num*10 + int(s[newi]-'0')
+		isnum = true
+	}
+	return
+}
+
+func (p *pp) unknownType(v reflect.Value) {
+	if !v.IsValid() {
+		p.buf.writeString(nilAngleString)
+		return
+	}
+	p.buf.writeByte('?')
+	p.buf.writeString(v.Type().String())
+	p.buf.writeByte('?')
+}
+
+func (p *pp) badVerb(verb rune) {
+	p.erroring = true
+	p.buf.writeString(percentBangString)
+	p.buf.writeRune(verb)
+	p.buf.writeByte('(')
+	switch {
+	case p.arg != nil:
+		p.buf.writeString(reflect.TypeOf(p.arg).String())
+		p.buf.writeByte('=')
+		p.printArg(p.arg, 'v')
+	case p.value.IsValid():
+		p.buf.writeString(p.value.Type().String())
+		p.buf.writeByte('=')
+		p.printValue(p.value, 'v', 0)
+	default:
+		p.buf.writeString(nilAngleString)
+	}
+	p.buf.writeByte(')')
+	p.erroring = false
+}
+
+func (p *pp) fmtBool(v bool, verb rune) {
+	switch verb {
+	case 't', 'v':
+		p.fmt.fmtBoolean(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmt0x64 formats a uint64 in hexadecimal and prefixes it with 0x or
+// not, as requested, by temporarily setting the sharp flag.
+func (p *pp) fmt0x64(v uint64, leading0x bool) {
+	sharp := p.fmt.sharp
+	p.fmt.sharp = leading0x
+	p.fmt.fmtInteger(v, 16, unsigned, 'v', ldigits)
+	p.fmt.sharp = sharp
+}
+
+// fmtInteger formats a signed or unsigned integer.
+func (p *pp) fmtInteger(v uint64, isSigned bool, verb rune) {
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV && !isSigned {
+			p.fmt0x64(v, true)
+		} else {
+			p.fmt.fmtInteger(v, 10, isSigned, verb, ldigits)
+		}
+	case 'd':
+		p.fmt.fmtInteger(v, 10, isSigned, verb, ldigits)
+	case 'b':
+		p.fmt.fmtInteger(v, 2, isSigned, verb, ldigits)
+	case 'o', 'O':
+		p.fmt.fmtInteger(v, 8, isSigned, verb, ldigits)
+	case 'x':
+		p.fmt.fmtInteger(v, 16, isSigned, verb, ldigits)
+	case 'X':
+		p.fmt.fmtInteger(v, 16, isSigned, verb, udigits)
+	case 'c':
+		p.fmt.fmtC(v)
+	case 'q':
+		p.fmt.fmtQc(v)
+	case 'U':
+		p.fmt.fmtUnicode(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmtFloat formats a float. The default precision for each verb
+// is specified as last argument in the call to fmt_float.
+func (p *pp) fmtFloat(v float64, size int, verb rune) {
+	switch verb {
+	case 'v':
+		p.fmt.fmtFloat(v, size, 'g', -1)
+	case 'b', 'g', 'G', 'x', 'X':
+		p.fmt.fmtFloat(v, size, verb, -1)
+	case 'f', 'e', 'E':
+		p.fmt.fmtFloat(v, size, verb, 6)
+	case 'F':
+		p.fmt.fmtFloat(v, size, 'f', 6)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmtComplex formats a complex number v with
+// r = real(v) and j = imag(v) as (r+ji) using
+// fmtFloat for r and j formatting.
+func (p *pp) fmtComplex(v complex128, size int, verb rune) {
+	// Make sure any unsupported verbs are found before the
+	// calls to fmtFloat to not generate an incorrect error string.
+	switch verb {
+	case 'v', 'b', 'g', 'G', 'x', 'X', 'f', 'F', 'e', 'E':
+		oldPlus := p.fmt.plus
+		p.buf.writeByte('(')
+		p.fmtFloat(real(v), size/2, verb)
+		// Imaginary part always has a sign.
+		p.fmt.plus = true
+		p.fmtFloat(imag(v), size/2, verb)
+		p.buf.writeString("i)")
+		p.fmt.plus = oldPlus
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) fmtString(v string, verb rune) {
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV {
+			p.fmt.fmtQ(v)
+		} else {
+			p.fmt.fmtS(v)
+		}
+	case 's':
+		p.fmt.fmtS(v)
+	case 'x':
+		p.fmt.fmtSx(v, ldigits)
+	case 'X':
+		p.fmt.fmtSx(v, udigits)
+	case 'q':
+		p.fmt.fmtQ(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) fmtBytes(v []byte, verb rune, typeString string) {
+	switch verb {
+	case 'v', 'd':
+		if p.fmt.sharpV {
+			p.buf.writeString(typeString)
+			if v == nil {
+				p.buf.writeString(nilParenString)
+				return
+			}
+			p.buf.writeByte('{')
+			for i, c := range v {
+				if i > 0 {
+					p.buf.writeString(commaSpaceString)
+				}
+				p.fmt0x64(uint64(c), true)
+			}
+			p.buf.writeByte('}')
+		} else {
+			p.buf.writeByte('[')
+			for i, c := range v {
+				if i > 0 {
+					p.buf.writeByte(' ')
+				}
+				p.fmt.fmtInteger(uint64(c), 10, unsigned, verb, ldigits)
+			}
+			p.buf.writeByte(']')
+		}
+	case 's':
+		p.fmt.fmtBs(v)
+	case 'x':
+		p.fmt.fmtBx(v, ldigits)
+	case 'X':
+		p.fmt.fmtBx(v, udigits)
+	case 'q':
+		p.fmt.fmtQ(string(v))
+	default:
+		p.printValue(reflect.ValueOf(v), verb, 0)
+	}
+}
+
+func (p *pp) fmtPointer(value reflect.Value, verb rune) {
+	var u uintptr
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		u = uintptr(value.UnsafePointer())
+	default:
+		p.badVerb(verb)
+		return
+	}
+
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV {
+			p.buf.writeByte('(')
+			p.buf.writeString(value.Type().String())
+			p.buf.writeString(")(")
+			if u == 0 {
+				p.buf.writeString(nilString)
+			} else {
+				p.fmt0x64(uint64(u), true)
+			}
+			p.buf.writeByte(')')
+		} else {
+			if u == 0 {
+				p.fmt.padString(nilAngleString)
+			} else {
+				p.fmt0x64(uint64(u), !p.fmt.sharp)
+			}
+		}
+	case 'p':
+		p.fmt0x64(uint64(u), !p.fmt.sharp)
+	case 'b', 'o', 'd', 'x', 'X':
+		p.fmtInteger(uint64(u), unsigned, verb)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) catchPanic(arg any, verb rune, method string) {
+	if err := recover(); err != nil {
+		// If it's a nil pointer, just say "<nil>". The likeliest causes are a
+		// Stringer that fails to guard against nil or a nil pointer for a
+		// value receiver, and in either case, "<nil>" is a nice result.
+		if v := reflect.ValueOf(arg); v.Kind() == reflect.Pointer && v.IsNil() {
+			p.buf.writeString(nilAngleString)
+			return
+		}
+		// Otherwise print a concise panic message. Most of the time the panic
+		// value will print itself nicely.
+		if p.panicking {
+			// Nested panics; the recursion in printArg cannot succeed.
+			panic(err)
+		}
+
+		oldFlags := p.fmt.fmtFlags
+		// For this output we want default behavior.
+		p.fmt.clearflags()
+
+		p.buf.writeString(percentBangString)
+		p.buf.writeRune(verb)
+		p.buf.writeString(panicString)
+		p.buf.writeString(method)
+		p.buf.writeString(" method: ")
+		p.panicking = true
+		p.printArg(err, 'v')
+		p.panicking = false
+		p.buf.writeByte(')')
+
+		p.fmt.fmtFlags = oldFlags
+	}
+}
+
+func (p *pp) handleMethods(verb rune) (handled bool) {
+	if p.erroring {
+		return
+	}
+	if verb == 'w' {
+		// It is invalid to use %w other than with Errorf or with a non-error arg.
+		_, ok := p.arg.(error)
+		if !ok || !p.wrapErrs {
+			p.badVerb(verb)
+			return true
+		}
+		// If the arg is a Formatter, pass 'v' as the verb to it.
+		verb = 'v'
+	}
+
+	// Is it a Formatter?
+	if formatter, ok := p.arg.(Formatter); ok {
+		handled = true
+		defer p.catchPanic(p.arg, verb, "Format")
+		formatter.Format(p, verb)
+		return
+	}
+
+	// If we're doing Go syntax and the argument knows how to supply it, take care of it now.
+	if p.fmt.sharpV {
+		if stringer, ok := p.arg.(GoStringer); ok {
+			handled = true
+			defer p.catchPanic(p.arg, verb, "GoString")
+			// Print the result of GoString unadorned.
+			p.fmt.fmtS(stringer.GoString())
+			return
+		}
+	} else {
+		// If a string is acceptable according to the format, see if
+		// the value satisfies one of the string-valued interfaces.
+		// Println etc. set verb to %v, which is "stringable".
+		switch verb {
+		case 'v', 's', 'x', 'X', 'q':
+			// Is it an error or Stringer?
+			// The duplication in the bodies is necessary:
+			// setting handled and deferring catchPanic
+			// must happen before calling the method.
+			switch v := p.arg.(type) {
+			case error:
+				handled = true
+				defer p.catchPanic(p.arg, verb, "Error")
+				p.fmtString(v.Error(), verb)
+				return
+
+			case Stringer:
+				handled = true
+				defer p.catchPanic(p.arg, verb, "String")
+				p.fmtString(v.String(), verb)
+				return
+			}
+		}
+	}
+	return false
+}
+
+func (p *pp) printArg(arg any, verb rune) {
+	p.arg = arg
+	p.value = reflect.Value{}
+
+	if arg == nil {
+		switch verb {
+		case 'T', 'v':
+			p.fmt.padString(nilAngleString)
+		default:
+			p.badVerb(verb)
+		}
+		return
+	}
+
+	// Special processing considerations.
+	// %T (the value's type) and %p (its address) are special; we always do them first.
+	switch verb {
+	case 'T':
+		p.fmt.fmtS(reflect.TypeOf(arg).String())
+		return
+	case 'p':
+		p.fmtPointer(reflect.ValueOf(arg), 'p')
+		return
+	}
+
+	// Some types can be done without reflection.
+	switch f := arg.(type) {
+	case bool:
+		p.fmtBool(f, verb)
+	case float32:
+		p.fmtFloat(float64(f), 32, verb)
+	case float64:
+		p.fmtFloat(f, 64, verb)
+	case complex64:
+		p.fmtComplex(complex128(f), 64, verb)
+	case complex128:
+		p.fmtComplex(f, 128, verb)
+	case int:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int8:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int16:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int32:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int64:
+		p.fmtInteger(uint64(f), signed, verb)
+	case uint:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint8:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint16:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint32:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint64:
+		p.fmtInteger(f, unsigned, verb)
+	case uintptr:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case string:
+		p.fmtString(f, verb)
+	case []byte:
+		p.fmtBytes(f, verb, "[]byte")
+	case reflect.Value:
+		// Handle extractable values with special methods
+		// since printValue does not handle them at depth 0.
+		if f.IsValid() && f.CanInterface() {
+			p.arg = f.Interface()
+			if p.handleMethods(verb) {
+				return
+			}
+		}
+		p.printValue(f, verb, 0)
+	default:
+		// If the type is not simple, it might have methods.
+		if !p.handleMethods(verb) {
+			// Need to use reflection, since the type had no
+			// interface methods that could be used for formatting.
+			p.printValue(reflect.ValueOf(f), verb, 0)
+		}
+	}
+}
+
+// printValue is similar to printArg but starts with a reflect value, not an interface{} value.
+// It does not handle 'p' and 'T' verbs because these should have been already handled by printArg.
+func (p *pp) printValue(value reflect.Value, verb rune, depth int) {
+	// Handle values with special methods if not already handled by printArg (depth == 0).
+	if depth > 0 && value.IsValid() && value.CanInterface() {
+		p.arg = value.Interface()
+		if p.handleMethods(verb) {
+			return
+		}
+	}
+	p.arg = nil
+	p.value = value
+
+	switch f := value; value.Kind() {
+	case reflect.Invalid:
+		if depth == 0 {
+			p.buf.writeString(invReflectString)
+		} else {
+			switch verb {
+			case 'v':
+				p.buf.writeString(nilAngleString)
+			default:
+				p.badVerb(verb)
+			}
+		}
+	case reflect.Bool:
+		p.fmtBool(f.Bool(), verb)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.fmtInteger(uint64(f.Int()), signed, verb)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.fmtInteger(f.Uint(), unsigned, verb)
+	case reflect.Float32:
+		p.fmtFloat(f.Float(), 32, verb)
+	case reflect.Float64:
+		p.fmtFloat(f.Float(), 64, verb)
+	case reflect.Complex64:
+		p.fmtComplex(f.Complex(), 64, verb)
+	case reflect.Complex128:
+		p.fmtComplex(f.Complex(), 128, verb)
+	case reflect.String:
+		p.fmtString(f.String(), verb)
+	case reflect.Map:
+		if p.fmt.sharpV {
+			p.buf.writeString(f.Type().String())
+			if f.IsNil() {
+				p.buf.writeString(nilParenString)
+				return
+			}
+			p.buf.writeByte('{')
+		} else {
+			p.buf.writeString(mapString)
+		}
+		sorted := fmtsort.Sort(f)
+		for i, m := range sorted {
+			if i > 0 {
+				if p.fmt.sharpV {
+					p.buf.writeString(commaSpaceString)
+				} else {
+					p.buf.writeByte(' ')
+				}
+			}
+			p.printValue(m.Key, verb, depth+1)
+			p.buf.writeByte(':')
+			p.printValue(m.Value, verb, depth+1)
+		}
+		if p.fmt.sharpV {
+			p.buf.writeByte('}')
+		} else {
+			p.buf.writeByte(']')
+		}
+	case reflect.Struct:
+		if p.fmt.sharpV {
+			p.buf.writeString(f.Type().String())
+		}
+		p.buf.writeByte('{')
+		for i := 0; i < f.NumField(); i++ {
+			if i > 0 {
+				if p.fmt.sharpV {
+					p.buf.writeString(commaSpaceString)
+				} else {
+					p.buf.writeByte(' ')
+				}
+			}
+			if p.fmt.plusV || p.fmt.sharpV {
+				if name := f.Type().Field(i).Name; name != "" {
+					p.buf.writeString(name)
+					p.buf.writeByte(':')
+				}
+			}
+			p.printValue(getField(f, i), verb, depth+1)
+		}
+		p.buf.writeByte('}')
+	case reflect.Interface:
+		value := f.Elem()
+		if !value.IsValid() {
+			if p.fmt.sharpV {
+				p.buf.writeString(f.Type().String())
+				p.buf.writeString(nilParenString)
+			} else {
+				p.buf.writeString(nilAngleString)
+			}
+		} else {
+			p.printValue(value, verb, depth+1)
+		}
+	case reflect.Array, reflect.Slice:
+		switch verb {
+		case 's', 'q', 'x', 'X':
+			// Handle byte and uint8 slices and arrays special for the above verbs.
+			t := f.Type()
+			if t.Elem().Kind() == reflect.Uint8 {
+				var bytes []byte
+				if f.Kind() == reflect.Slice || f.CanAddr() {
+					bytes = f.Bytes()
+				} else {
+					// We have an array, but we cannot Bytes() a non-addressable array,
+					// so we build a slice by hand. This is a rare case but it would be nice
+					// if reflection could help a little more.
+					bytes = make([]byte, f.Len())
+					for i := range bytes {
+						bytes[i] = byte(f.Index(i).Uint())
+					}
+				}
+				p.fmtBytes(bytes, verb, t.String())
+				return
+			}
+		}
+		if p.fmt.sharpV {
+			p.buf.writeString(f.Type().String())
+			if f.Kind() == reflect.Slice && f.IsNil() {
+				p.buf.writeString(nilParenString)
+				return
+			}
+			p.buf.writeByte('{')
+			for i := 0; i < f.Len(); i++ {
+				if i > 0 {
+					p.buf.writeString(commaSpaceString)
+				}
+				p.printValue(f.Index(i), verb, depth+1)
+			}
+			p.buf.writeByte('}')
+		} else {
+			p.buf.writeByte('[')
+			for i := 0; i < f.Len(); i++ {
+				if i > 0 {
+					p.buf.writeByte(' ')
+				}
+				p.printValue(f.Index(i), verb, depth+1)
+			}
+			p.buf.writeByte(']')
+		}
+	case reflect.Pointer:
+		// pointer to array or slice or struct? ok at top level
+		// but not embedded (avoid loops)
+		if depth == 0 && f.UnsafePointer() != nil {
+			switch a := f.Elem(); a.Kind() {
+			case reflect.Array, reflect.Slice, reflect.Struct, reflect.Map:
+				p.buf.writeByte('&')
+				p.printValue(a, verb, depth+1)
+				return
+			}
+		}
+		fallthrough
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		p.fmtPointer(f, verb)
+	default:
+		p.unknownType(f)
+	}
+}
+
+// intFromArg gets the argNumth element of a. On return, isInt reports whether the argument has integer type.
+func intFromArg(a []any, argNum int) (num int, isInt bool, newArgNum int) {
+	newArgNum = argNum
+	if argNum < len(a) {
+		num, isInt = a[argNum].(int) // Almost always OK.
+		if !isInt {
+			// Work harder.
+			switch v := reflect.ValueOf(a[argNum]); v.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				n := v.Int()
+				if int64(int(n)) == n {
+					num = int(n)
+					isInt = true
+				}
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				n := v.Uint()
+				if int64(n) >= 0 && uint64(int(n)) == n {
+					num = int(n)
+					isInt = true
+				}
+			default:
+				// Already 0, false.
+			}
+		}
+		newArgNum = argNum + 1
+		if tooLarge(num) {
+			num = 0
+			isInt = false
+		}
+	}
+	return
+}
+
+// parseArgNumber returns the value of the bracketed number, minus 1
+// (explicit argument numbers are one-indexed but we want zero-indexed).
+// The opening bracket is known to be present at format[0].
+// The returned values are the index, the number of bytes to consume
+// up to the closing paren, if present, and whether the number parsed
+// ok. The bytes to consume will be 1 if no closing paren is present.
+func parseArgNumber(format string) (index int, wid int, ok bool) {
+	// There must be at least 3 bytes: [n].
+	if len(format) < 3 {
+		return 0, 1, false
+	}
+
+	// Find closing bracket.
+	for i := 1; i < len(format); i++ {
+		if format[i] == ']' {
+			width, ok, newi := parsenum(format, 1, i)
+			if !ok || newi != i {
+				return 0, i + 1, false
+			}
+			return width - 1, i + 1, true // arg numbers are one-indexed and skip paren.
+		}
+	}
+	return 0, 1, false
+}
+
+// argNumber returns the next argument to evaluate, which is either the value of the passed-in
+// argNum or the value of the bracketed integer that begins format[i:]. It also returns
+// the new value of i, that is, the index of the next byte of the format to process.
+func (p *pp) argNumber(argNum int, format string, i int, numArgs int) (newArgNum, newi int, found bool) {
+	if len(format) <= i || format[i] != '[' {
+		return argNum, i, false
+	}
+	p.reordered = true
+	index, wid, ok := parseArgNumber(format[i:])
+	if ok && 0 <= index && index < numArgs {
+		return index, i + wid, true
+	}
+	p.goodArgNum = false
+	return argNum, i + wid, ok
+}
+
+func (p *pp) badArgNum(verb rune) {
+	p.buf.writeString(percentBangString)
+	p.buf.writeRune(verb)
+	p.buf.writeString(badIndexString)
+}
+
+func (p *pp) missingArg(verb rune) {
+	p.buf.writeString(percentBangString)
+	p.buf.writeRune(verb)
+	p.buf.writeString(missingString)
+}
+
+func (p *pp) doPrintf(format string, a []any) {
+	end := len(format)
+	argNum := 0         // we process one argument per non-trivial format
+	afterIndex := false // previous item in format was an index like [3].
+	p.reordered = false
+formatLoop:
+	for i := 0; i < end; {
+		p.goodArgNum = true
+		lasti := i
+		for i < end && format[i] != '%' {
+			i++
+		}
+		if i > lasti {
+			p.buf.writeString(format[lasti:i])
+		}
+		if i >= end {
+			// done processing format string
+			break
+		}
+
+		// Process one verb
+		i++
+
+		// Do we have flags?
+		p.fmt.clearflags()
+	simpleFormat:
+		for ; i < end; i++ {
+			c := format[i]
+			switch c {
+			case '#':
+				p.fmt.sharp = true
+			case '0':
+				p.fmt.zero = true
+			case '+':
+				p.fmt.plus = true
+			case '-':
+				p.fmt.minus = true
+			case ' ':
+				p.fmt.space = true
+			default:
+				// Fast path for common case of ascii lower case simple verbs
+				// without precision or width or argument indices.
+				if 'a' <= c && c <= 'z' && argNum < len(a) {
+					switch c {
+					case 'w':
+						p.wrappedErrs = append(p.wrappedErrs, argNum)
+						fallthrough
+					case 'v':
+						// Go syntax
+						p.fmt.sharpV = p.fmt.sharp
+						p.fmt.sharp = false
+						// Struct-field syntax
+						p.fmt.plusV = p.fmt.plus
+						p.fmt.plus = false
+					}
+					p.printArg(a[argNum], rune(c))
+					argNum++
+					i++
+					continue formatLoop
+				}
+				// Format is more complex than simple flags and a verb or is malformed.
+				break simpleFormat
+			}
+		}
+
+		// Do we have an explicit argument index?
+		argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+
+		// Do we have width?
+		if i < end && format[i] == '*' {
+			i++
+			p.fmt.wid, p.fmt.widPresent, argNum = intFromArg(a, argNum)
+
+			if !p.fmt.widPresent {
+				p.buf.writeString(badWidthString)
+			}
+
+			// We have a negative width, so take its value and ensure
+			// that the minus flag is set
+			if p.fmt.wid < 0 {
+				p.fmt.wid = -p.fmt.wid
+				p.fmt.minus = true
+				p.fmt.zero = false // Do not pad with zeros to the right.
+			}
+			afterIndex = false
+		} else {
+			p.fmt.wid, p.fmt.widPresent, i = parsenum(format, i, end)
+			if afterIndex && p.fmt.widPresent { // "%[3]2d"
+				p.goodArgNum = false
+			}
+		}
+
+		// Do we have precision?
+		if i+1 < end && format[i] == '.' {
+			i++
+			if afterIndex { // "%[3].2d"
+				p.goodArgNum = false
+			}
+			argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+			if i < end && format[i] == '*' {
+				i++
+				p.fmt.prec, p.fmt.precPresent, argNum = intFromArg(a, argNum)
+				// Negative precision arguments don't make sense
+				if p.fmt.prec < 0 {
+					p.fmt.prec = 0
+					p.fmt.precPresent = false
+				}
+				if !p.fmt.precPresent {
+					p.buf.writeString(badPrecString)
+				}
+				afterIndex = false
+			} else {
+				p.fmt.prec, p.fmt.precPresent, i = parsenum(format, i, end)
+				if !p.fmt.precPresent {
+					p.fmt.prec = 0
+					p.fmt.precPresent = true
+				}
+			}
+		}
+
+		if !afterIndex {
+			argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+		}
+
+		if i >= end {
+			p.buf.writeString(noVerbString)
+			break
+		}
+
+		verb, size := rune(format[i]), 1
+		if verb >= utf8.RuneSelf {
+			verb, size = utf8.DecodeRuneInString(format[i:])
+		}
+		i += size
+
+		switch {
+		case verb == '%': // Percent does not absorb operands and ignores f.wid and f.prec.
+			p.buf.writeByte('%')
+		case !p.goodArgNum:
+			p.badArgNum(verb)
+		case argNum >= len(a): // No argument left over to print for the current verb.
+			p.missingArg(verb)
+		case verb == 'w':
+			p.wrappedErrs = append(p.wrappedErrs, argNum)
+			fallthrough
+		case verb == 'v':
+			// Go syntax
+			p.fmt.sharpV = p.fmt.sharp
+			p.fmt.sharp = false
+			// Struct-field syntax
+			p.fmt.plusV = p.fmt.plus
+			p.fmt.plus = false
+			fallthrough
+		default:
+			p.printArg(a[argNum], verb)
+			argNum++
+		}
+	}
+
+	// Check for extra arguments unless the call accessed the arguments
+	// out of order, in which case it's too expensive to detect if they've all
+	// been used and arguably OK if they're not.
+	if !p.reordered && argNum < len(a) {
+		p.fmt.clearflags()
+		p.buf.writeString(extraString)
+		for i, arg := range a[argNum:] {
+			if i > 0 {
+				p.buf.writeString(commaSpaceString)
+			}
+			if arg == nil {
+				p.buf.writeString(nilAngleString)
+			} else {
+				p.buf.writeString(reflect.TypeOf(arg).String())
+				p.buf.writeByte('=')
+				p.printArg(arg, 'v')
+			}
+		}
+		p.buf.writeByte(')')
+	}
+}
+
+func (p *pp) doPrint(a []any) {
+	prevString := false
+	for argNum, arg := range a {
+		isString := arg != nil && reflect.TypeOf(arg).Kind() == reflect.String
+		// Add a space between two non-string arguments.
+		if argNum > 0 && !isString && !prevString {
+			p.buf.writeByte(' ')
+		}
+		p.printArg(arg, 'v')
+		prevString = isString
+	}
+}
+
+// doPrintln is like doPrint but always adds a space between arguments
+// and a newline after the last argument.
+func (p *pp) doPrintln(a []any) {
+	for argNum, arg := range a {
+		if argNum > 0 {
+			p.buf.writeByte(' ')
+		}
+		p.printArg(arg, 'v')
+	}
+	p.buf.writeByte('\n')
+}

--- a/testdata/incremental_gate/javascript_grammar.js
+++ b/testdata/incremental_gate/javascript_grammar.js
@@ -1,0 +1,959 @@
+/**
+ * @file Go grammar for tree-sitter
+ * @author Max Brunsfeld <maxbrunsfeld@gmail.com>
+ * @author Amaan Qureshi <amaanq12@gmail.com>
+ * @license MIT
+ */
+
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
+const PREC = {
+  primary: 7,
+  unary: 6,
+  multiplicative: 5,
+  additive: 4,
+  comparative: 3,
+  and: 2,
+  or: 1,
+  composite_literal: -1,
+};
+
+const multiplicativeOperators = ['*', '/', '%', '<<', '>>', '&', '&^'];
+const additiveOperators = ['+', '-', '|', '^'];
+const comparativeOperators = ['==', '!=', '<', '<=', '>', '>='];
+const assignmentOperators = multiplicativeOperators.concat(additiveOperators).map(operator => operator + '=').concat('=');
+
+
+const newline = /\n/;
+const terminator = choice(newline, ';', '\0');
+
+const hexDigit = /[0-9a-fA-F]/;
+const octalDigit = /[0-7]/;
+const decimalDigit = /[0-9]/;
+const binaryDigit = /[01]/;
+
+const hexDigits = seq(hexDigit, repeat(seq(optional('_'), hexDigit)));
+const octalDigits = seq(octalDigit, repeat(seq(optional('_'), octalDigit)));
+const decimalDigits = seq(decimalDigit, repeat(seq(optional('_'), decimalDigit)));
+const binaryDigits = seq(binaryDigit, repeat(seq(optional('_'), binaryDigit)));
+
+const hexLiteral = seq('0', choice('x', 'X'), optional('_'), hexDigits);
+const octalLiteral = seq('0', optional(choice('o', 'O')), optional('_'), octalDigits);
+const decimalLiteral = choice('0', seq(/[1-9]/, optional(seq(optional('_'), decimalDigits))));
+const binaryLiteral = seq('0', choice('b', 'B'), optional('_'), binaryDigits);
+
+const intLiteral = choice(binaryLiteral, decimalLiteral, octalLiteral, hexLiteral);
+
+const decimalExponent = seq(choice('e', 'E'), optional(choice('+', '-')), decimalDigits);
+const decimalFloatLiteral = choice(
+  seq(decimalDigits, '.', optional(decimalDigits), optional(decimalExponent)),
+  seq(decimalDigits, decimalExponent),
+  seq('.', decimalDigits, optional(decimalExponent)),
+);
+
+const hexExponent = seq(choice('p', 'P'), optional(choice('+', '-')), decimalDigits);
+const hexMantissa = choice(
+  seq(optional('_'), hexDigits, '.', optional(hexDigits)),
+  seq(optional('_'), hexDigits),
+  seq('.', hexDigits),
+);
+const hexFloatLiteral = seq('0', choice('x', 'X'), hexMantissa, hexExponent);
+
+const floatLiteral = choice(decimalFloatLiteral, hexFloatLiteral);
+
+const imaginaryLiteral = seq(choice(decimalDigits, intLiteral, floatLiteral), 'i');
+
+module.exports = grammar({
+  name: 'go',
+
+  extras: $ => [
+    $.comment,
+    /\s/,
+  ],
+
+  inline: $ => [
+    $._type,
+    $._type_identifier,
+    $._field_identifier,
+    $._package_identifier,
+    $._top_level_declaration,
+    $._string_literal,
+    $._interface_elem,
+  ],
+
+  word: $ => $.identifier,
+
+  conflicts: $ => [
+    [$._simple_type, $._expression],
+    [$._simple_type, $.generic_type, $._expression],
+    [$.qualified_type, $._expression],
+    [$.generic_type, $._simple_type],
+    [$.parameter_declaration, $._simple_type],
+    [$.type_parameter_declaration, $._simple_type, $._expression],
+    [$.type_parameter_declaration, $._expression],
+    [$.type_parameter_declaration, $._simple_type, $.generic_type, $._expression],
+  ],
+
+  supertypes: $ => [
+    $._expression,
+    $._type,
+    $._simple_type,
+    $._statement,
+    $._simple_statement,
+  ],
+
+  rules: {
+    source_file: $ => seq(
+      repeat(choice(
+        // Unlike a Go compiler, we accept statements at top-level to enable
+        // parsing of partial code snippets in documentation (see #63).
+        seq($._statement, terminator),
+        seq($._top_level_declaration, terminator),
+      )),
+      optional($._top_level_declaration),
+    ),
+
+    _top_level_declaration: $ => choice(
+      $.package_clause,
+      $.function_declaration,
+      $.method_declaration,
+      $.import_declaration,
+    ),
+
+    package_clause: $ => seq(
+      'package',
+      $._package_identifier,
+    ),
+
+    import_declaration: $ => seq(
+      'import',
+      choice(
+        $.import_spec,
+        $.import_spec_list,
+      ),
+    ),
+
+    import_spec: $ => seq(
+      optional(field('name', choice(
+        $.dot,
+        $.blank_identifier,
+        $._package_identifier,
+      ))),
+      field('path', $._string_literal),
+    ),
+    dot: _ => '.',
+    blank_identifier: _ => '_',
+
+    import_spec_list: $ => seq(
+      '(',
+      optional(seq(
+        $.import_spec,
+        repeat(seq(terminator, $.import_spec)),
+        optional(terminator),
+      )),
+      ')',
+    ),
+
+    _declaration: $ => choice(
+      $.const_declaration,
+      $.type_declaration,
+      $.var_declaration,
+    ),
+
+    const_declaration: $ => seq(
+      'const',
+      choice(
+        $.const_spec,
+        seq(
+          '(',
+          repeat(seq($.const_spec, terminator)),
+          ')',
+        ),
+      ),
+    ),
+
+    const_spec: $ => prec.left(seq(
+      field('name', commaSep1($.identifier)),
+      optional(seq(
+        optional(field('type', $._type)),
+        '=',
+        field('value', $.expression_list),
+      )),
+    )),
+
+    var_declaration: $ => seq(
+      'var',
+      choice(
+        $.var_spec,
+        $.var_spec_list,
+      ),
+    ),
+
+    var_spec: $ => seq(
+      commaSep1(field('name', $.identifier)),
+      choice(
+        seq(
+          field('type', $._type),
+          optional(seq('=', field('value', $.expression_list))),
+        ),
+        seq('=', field('value', $.expression_list)),
+      ),
+    ),
+
+    var_spec_list: $ => seq(
+      '(',
+      repeat(seq($.var_spec, terminator)),
+      ')',
+    ),
+
+    function_declaration: $ => prec.right(1, seq(
+      'func',
+      field('name', $.identifier),
+      field('type_parameters', optional($.type_parameter_list)),
+      field('parameters', $.parameter_list),
+      field('result', optional(choice($.parameter_list, $._simple_type))),
+      field('body', optional($.block)),
+    )),
+
+    method_declaration: $ => prec.right(1, seq(
+      'func',
+      field('receiver', $.parameter_list),
+      field('name', $._field_identifier),
+      field('parameters', $.parameter_list),
+      field('result', optional(choice($.parameter_list, $._simple_type))),
+      field('body', optional($.block)),
+    )),
+
+    type_parameter_list: $ => seq(
+      '[',
+      commaSep1($.type_parameter_declaration),
+      optional(','),
+      ']',
+    ),
+
+    type_parameter_declaration: $ => seq(
+      commaSep1(field('name', $.identifier)),
+      field('type', alias($.type_elem, $.type_constraint)),
+    ),
+
+    parameter_list: $ => seq(
+      '(',
+      optional(seq(
+        commaSep(choice($.parameter_declaration, $.variadic_parameter_declaration)),
+        optional(','),
+      )),
+      ')',
+    ),
+
+    parameter_declaration: $ => prec.left(seq(
+      commaSep(field('name', $.identifier)),
+      field('type', $._type),
+    )),
+
+    variadic_parameter_declaration: $ => seq(
+      field('name', optional($.identifier)),
+      '...',
+      field('type', $._type),
+    ),
+
+    type_alias: $ => seq(
+      field('name', $._type_identifier),
+      '=',
+      field('type', $._type),
+    ),
+
+    type_declaration: $ => seq(
+      'type',
+      choice(
+        $.type_spec,
+        $.type_alias,
+        seq(
+          '(',
+          repeat(seq(choice($.type_spec, $.type_alias), terminator)),
+          ')',
+        ),
+      ),
+    ),
+
+    type_spec: $ => seq(
+      field('name', $._type_identifier),
+      field('type_parameters', optional($.type_parameter_list)),
+      field('type', $._type),
+    ),
+
+    field_name_list: $ => commaSep1($._field_identifier),
+
+    expression_list: $ => commaSep1($._expression),
+
+    _type: $ => choice(
+      $._simple_type,
+      $.parenthesized_type,
+    ),
+
+    parenthesized_type: $ => seq('(', $._type, ')'),
+
+    _simple_type: $ => choice(
+      prec.dynamic(-1, $._type_identifier),
+      $.generic_type,
+      $.qualified_type,
+      $.pointer_type,
+      $.struct_type,
+      $.interface_type,
+      $.array_type,
+      $.slice_type,
+      $.map_type,
+      $.channel_type,
+      $.function_type,
+      $.negated_type,
+    ),
+
+    generic_type: $ => prec.dynamic(1, seq(
+      field('type', choice($._type_identifier, $.qualified_type, $.negated_type)),
+      field('type_arguments', $.type_arguments),
+    )),
+
+    type_arguments: $ => prec.dynamic(2, seq(
+      '[',
+      commaSep1($.type_elem),
+      optional(','),
+      ']',
+    )),
+
+    pointer_type: $ => prec(PREC.unary, seq('*', $._type)),
+
+    array_type: $ => prec.right(seq(
+      '[',
+      field('length', $._expression),
+      ']',
+      field('element', $._type),
+    )),
+
+    implicit_length_array_type: $ => seq(
+      '[',
+      '...',
+      ']',
+      field('element', $._type),
+    ),
+
+    slice_type: $ => prec.right(seq(
+      '[',
+      ']',
+      field('element', $._type),
+    )),
+
+    struct_type: $ => seq(
+      'struct',
+      $.field_declaration_list,
+    ),
+
+    negated_type: $ => prec.left(seq(
+      '~',
+      $._type,
+    )),
+
+    field_declaration_list: $ => seq(
+      '{',
+      optional(seq(
+        $.field_declaration,
+        repeat(seq(terminator, $.field_declaration)),
+        optional(terminator),
+      )),
+      '}',
+    ),
+
+    field_declaration: $ => seq(
+      choice(
+        seq(
+          commaSep1(field('name', $._field_identifier)),
+          field('type', $._type),
+        ),
+        seq(
+          optional('*'),
+          field('type', choice(
+            $._type_identifier,
+            $.qualified_type,
+            $.generic_type,
+          )),
+        ),
+      ),
+      field('tag', optional($._string_literal)),
+    ),
+
+    interface_type: $ => seq(
+      'interface',
+      '{',
+      optional(seq(
+        $._interface_elem,
+        repeat(seq(terminator, $._interface_elem)),
+        optional(terminator),
+      )),
+      '}',
+    ),
+
+    _interface_elem: $ => choice(
+      $.method_elem,
+      $.type_elem,
+    ),
+
+    method_elem: $ => seq(
+      field('name', $._field_identifier),
+      field('parameters', $.parameter_list),
+      field('result', optional(choice($.parameter_list, $._simple_type))),
+    ),
+
+    type_elem: $ => sep1($._type, '|'),
+
+    map_type: $ => prec.right(seq(
+      'map',
+      '[',
+      field('key', $._type),
+      ']',
+      field('value', $._type),
+    )),
+
+    channel_type: $ => prec.left(choice(
+      seq('chan', field('value', $._type)),
+      seq('chan', '<-', field('value', $._type)),
+      prec(PREC.unary, seq('<-', 'chan', field('value', $._type))),
+    )),
+
+    function_type: $ => prec.right(seq(
+      'func',
+      field('parameters', $.parameter_list),
+      field('result', optional(choice($.parameter_list, $._simple_type))),
+    )),
+
+    block: $ => seq(
+      '{',
+      optional($._statement_list),
+      '}',
+    ),
+
+    _statement_list: $ => choice(
+      seq(
+        $._statement,
+        repeat(seq(terminator, $._statement)),
+        optional(seq(
+          terminator,
+          optional(alias($.empty_labeled_statement, $.labeled_statement)),
+        )),
+      ),
+      alias($.empty_labeled_statement, $.labeled_statement),
+    ),
+
+    _statement: $ => choice(
+      $._declaration,
+      $._simple_statement,
+      $.return_statement,
+      $.go_statement,
+      $.defer_statement,
+      $.if_statement,
+      $.for_statement,
+      $.expression_switch_statement,
+      $.type_switch_statement,
+      $.select_statement,
+      $.labeled_statement,
+      $.fallthrough_statement,
+      $.break_statement,
+      $.continue_statement,
+      $.goto_statement,
+      $.block,
+      $.empty_statement,
+    ),
+
+    empty_statement: _ => ';',
+
+    _simple_statement: $ => choice(
+      $.expression_statement,
+      $.send_statement,
+      $.inc_statement,
+      $.dec_statement,
+      $.assignment_statement,
+      $.short_var_declaration,
+    ),
+
+    expression_statement: $ => $._expression,
+
+    send_statement: $ => seq(
+      field('channel', $._expression),
+      '<-',
+      field('value', $._expression),
+    ),
+
+    receive_statement: $ => seq(
+      optional(seq(
+        field('left', $.expression_list),
+        choice('=', ':='),
+      )),
+      field('right', $._expression),
+    ),
+
+    inc_statement: $ => seq(
+      $._expression,
+      '++',
+    ),
+
+    dec_statement: $ => seq(
+      $._expression,
+      '--',
+    ),
+
+    assignment_statement: $ => seq(
+      field('left', $.expression_list),
+      field('operator', choice(...assignmentOperators)),
+      field('right', $.expression_list),
+    ),
+
+    short_var_declaration: $ => seq(
+      // TODO: this should really only allow identifier lists, but that causes
+      // conflicts between identifiers as expressions vs identifiers here.
+      field('left', $.expression_list),
+      ':=',
+      field('right', $.expression_list),
+    ),
+
+    labeled_statement: $ => seq(
+      field('label', alias($.identifier, $.label_name)),
+      ':',
+      $._statement,
+    ),
+
+    empty_labeled_statement: $ => seq(
+      field('label', alias($.identifier, $.label_name)),
+      ':',
+    ),
+
+    // This is a hack to prevent `fallthrough_statement` from being parsed as
+    // a single token. For consistency with `break_statement` etc it should
+    // be parsed as a parent node that *contains* a `fallthrough` token.
+    fallthrough_statement: _ => prec.left('fallthrough'),
+
+    break_statement: $ => seq('break', optional(alias($.identifier, $.label_name))),
+
+    continue_statement: $ => seq('continue', optional(alias($.identifier, $.label_name))),
+
+    goto_statement: $ => seq('goto', alias($.identifier, $.label_name)),
+
+    return_statement: $ => seq('return', optional($.expression_list)),
+
+    go_statement: $ => seq('go', $._expression),
+
+    defer_statement: $ => seq('defer', $._expression),
+
+    if_statement: $ => seq(
+      'if',
+      optional(seq(
+        field('initializer', $._simple_statement),
+        ';',
+      )),
+      field('condition', $._expression),
+      field('consequence', $.block),
+      optional(seq(
+        'else',
+        field('alternative', choice($.block, $.if_statement)),
+      )),
+    ),
+
+    for_statement: $ => seq(
+      'for',
+      optional(choice($._expression, $.for_clause, $.range_clause)),
+      field('body', $.block),
+    ),
+
+    for_clause: $ => seq(
+      field('initializer', optional($._simple_statement)),
+      ';',
+      field('condition', optional($._expression)),
+      ';',
+      field('update', optional($._simple_statement)),
+    ),
+
+    range_clause: $ => seq(
+      optional(seq(
+        field('left', $.expression_list),
+        choice('=', ':='),
+      )),
+      'range',
+      field('right', $._expression),
+    ),
+
+    expression_switch_statement: $ => seq(
+      'switch',
+      optional(seq(
+        field('initializer', $._simple_statement),
+        ';',
+      )),
+      field('value', optional($._expression)),
+      '{',
+      repeat(choice($.expression_case, $.default_case)),
+      '}',
+    ),
+
+    expression_case: $ => seq(
+      'case',
+      field('value', $.expression_list),
+      ':',
+      optional($._statement_list),
+    ),
+
+    default_case: $ => seq(
+      'default',
+      ':',
+      optional($._statement_list),
+    ),
+
+    type_switch_statement: $ => seq(
+      'switch',
+      $._type_switch_header,
+      '{',
+      repeat(choice($.type_case, $.default_case)),
+      '}',
+    ),
+
+    _type_switch_header: $ => seq(
+      optional(seq(
+        field('initializer', $._simple_statement),
+        ';',
+      )),
+      optional(seq(field('alias', $.expression_list), ':=')),
+      field('value', $._expression),
+      '.',
+      '(',
+      'type',
+      ')',
+    ),
+
+    type_case: $ => seq(
+      'case',
+      field('type', commaSep1($._type)),
+      ':',
+      optional($._statement_list),
+    ),
+
+    select_statement: $ => seq(
+      'select',
+      '{',
+      repeat(choice($.communication_case, $.default_case)),
+      '}',
+    ),
+
+    communication_case: $ => seq(
+      'case',
+      field('communication', choice($.send_statement, $.receive_statement)),
+      ':',
+      optional($._statement_list),
+    ),
+
+    _expression: $ => choice(
+      $.unary_expression,
+      $.binary_expression,
+      $.selector_expression,
+      $.index_expression,
+      $.slice_expression,
+      $.call_expression,
+      $.type_assertion_expression,
+      $.type_conversion_expression,
+      $.type_instantiation_expression,
+      $.identifier,
+      alias(choice('new', 'make'), $.identifier),
+      $.composite_literal,
+      $.func_literal,
+      $._string_literal,
+      $.int_literal,
+      $.float_literal,
+      $.imaginary_literal,
+      $.rune_literal,
+      $.nil,
+      $.true,
+      $.false,
+      $.iota,
+      $.parenthesized_expression,
+    ),
+
+    parenthesized_expression: $ => seq(
+      '(',
+      $._expression,
+      ')',
+    ),
+
+    call_expression: $ => prec(PREC.primary, choice(
+      seq(
+        field('function', alias(choice('new', 'make'), $.identifier)),
+        field('arguments', alias($.special_argument_list, $.argument_list)),
+      ),
+      seq(
+        field('function', $._expression),
+        field('type_arguments', optional($.type_arguments)),
+        field('arguments', $.argument_list),
+      ),
+    )),
+
+    variadic_argument: $ => prec.right(seq(
+      $._expression,
+      '...',
+    )),
+
+    special_argument_list: $ => seq(
+      '(',
+      optional(seq(
+        $._type,
+        repeat(seq(',', $._expression)),
+        optional(','),
+      )),
+      ')',
+    ),
+
+    argument_list: $ => seq(
+      '(',
+      optional(seq(
+        choice($._expression, $.variadic_argument),
+        repeat(seq(',', choice($._expression, $.variadic_argument))),
+        optional(','),
+      )),
+      ')',
+    ),
+
+    selector_expression: $ => prec(PREC.primary, seq(
+      field('operand', $._expression),
+      '.',
+      field('field', $._field_identifier),
+    )),
+
+    index_expression: $ => prec(PREC.primary, seq(
+      field('operand', $._expression),
+      '[',
+      field('index', $._expression),
+      ']',
+    )),
+
+    slice_expression: $ => prec(PREC.primary, seq(
+      field('operand', $._expression),
+      '[',
+      choice(
+        seq(
+          field('start', optional($._expression)),
+          ':',
+          field('end', optional($._expression)),
+        ),
+        seq(
+          field('start', optional($._expression)),
+          ':',
+          field('end', $._expression),
+          ':',
+          field('capacity', $._expression),
+        ),
+      ),
+      ']',
+    )),
+
+    type_assertion_expression: $ => prec(PREC.primary, seq(
+      field('operand', $._expression),
+      '.',
+      '(',
+      field('type', $._type),
+      ')',
+    )),
+
+    type_conversion_expression: $ => prec.dynamic(-1, seq(
+      field('type', $._type),
+      '(',
+      field('operand', $._expression),
+      optional(','),
+      ')',
+    )),
+
+    type_instantiation_expression: $ => prec.dynamic(-1, seq(
+      field('type', $._type),
+      '[',
+      commaSep1($._type),
+      optional(','),
+      ']',
+    )),
+
+    composite_literal: $ => prec(PREC.composite_literal, seq(
+      field('type', choice(
+        $.map_type,
+        $.slice_type,
+        $.array_type,
+        $.implicit_length_array_type,
+        $.struct_type,
+        $._type_identifier,
+        $.generic_type,
+        $.qualified_type,
+      )),
+      field('body', $.literal_value),
+    )),
+
+    literal_value: $ => seq(
+      '{',
+      optional(
+        seq(
+          commaSep(choice($.literal_element, $.keyed_element)),
+          optional(','))),
+      '}',
+    ),
+
+    literal_element: $ => choice($._expression, $.literal_value),
+
+    // In T{k: v}, the key k may be:
+    // - any expression (when T is a map, slice or array),
+    // - a field identifier (when T is a struct), or
+    // - a literal_element (when T is an array).
+    // The first two cases cannot be distinguished without type information.
+    keyed_element: $ => seq(
+      field('key', $.literal_element),
+      ':',
+      field('value', $.literal_element),
+    ),
+
+    func_literal: $ => seq(
+      'func',
+      field('parameters', $.parameter_list),
+      field('result', optional(choice($.parameter_list, $._simple_type))),
+      field('body', $.block),
+    ),
+
+    unary_expression: $ => prec(PREC.unary, seq(
+      field('operator', choice('+', '-', '!', '^', '*', '&', '<-')),
+      field('operand', $._expression),
+    )),
+
+    binary_expression: $ => {
+      const table = [
+        [PREC.multiplicative, choice(...multiplicativeOperators)],
+        [PREC.additive, choice(...additiveOperators)],
+        [PREC.comparative, choice(...comparativeOperators)],
+        [PREC.and, '&&'],
+        [PREC.or, '||'],
+      ];
+
+      return choice(...table.map(([precedence, operator]) =>
+        // @ts-ignore
+        prec.left(precedence, seq(
+          field('left', $._expression),
+          // @ts-ignore
+          field('operator', operator),
+          field('right', $._expression),
+        )),
+      ));
+    },
+
+    qualified_type: $ => seq(
+      field('package', $._package_identifier),
+      '.',
+      field('name', $._type_identifier),
+    ),
+
+    identifier: _ => /[_\p{XID_Start}][_\p{XID_Continue}]*/,
+
+    _type_identifier: $ => alias($.identifier, $.type_identifier),
+    _field_identifier: $ => alias($.identifier, $.field_identifier),
+    _package_identifier: $ => alias($.identifier, $.package_identifier),
+
+    _string_literal: $ => choice(
+      $.raw_string_literal,
+      $.interpreted_string_literal,
+    ),
+
+    raw_string_literal: $ => seq(
+      '`',
+      alias(token(prec(1, /[^`]*/)), $.raw_string_literal_content),
+      '`',
+    ),
+
+    interpreted_string_literal: $ => seq(
+      '"',
+      repeat(choice(
+        alias(token.immediate(prec(1, /[^"\n\\]+/)), $.interpreted_string_literal_content),
+        $.escape_sequence,
+      )),
+      token.immediate('"'),
+    ),
+
+    escape_sequence: _ => token.immediate(seq(
+      '\\',
+      choice(
+        /[^xuU]/,
+        /\d{2,3}/,
+        /x[0-9a-fA-F]{2,}/,
+        /u[0-9a-fA-F]{4}/,
+        /U[0-9a-fA-F]{8}/,
+      ),
+    )),
+
+    int_literal: _ => token(intLiteral),
+
+    float_literal: _ => token(floatLiteral),
+
+    imaginary_literal: _ => token(imaginaryLiteral),
+
+    rune_literal: _ => token(seq(
+      '\'',
+      choice(
+        /[^'\\]/,
+        seq(
+          '\\',
+          choice(
+            seq('x', hexDigit, hexDigit),
+            seq(octalDigit, octalDigit, octalDigit),
+            seq('u', hexDigit, hexDigit, hexDigit, hexDigit),
+            seq('U', hexDigit, hexDigit, hexDigit, hexDigit, hexDigit, hexDigit, hexDigit, hexDigit),
+            seq(choice('a', 'b', 'f', 'n', 'r', 't', 'v', '\\', '\'', '"')),
+          ),
+        ),
+      ),
+      '\'',
+    )),
+
+    nil: _ => 'nil',
+    true: _ => 'true',
+    false: _ => 'false',
+    iota: _ => 'iota',
+
+    // http://stackoverflow.com/questions/13014947/regex-to-match-a-c-style-multiline-comment/36328890#36328890
+    comment: _ => token(choice(
+      seq('//', /.*/),
+      seq(
+        '/*',
+        /[^*]*\*+([^/*][^*]*\*+)*/,
+        '/',
+      ),
+    )),
+  },
+});
+
+/**
+ * Creates a rule to match one or more occurrences of `rule` separated by `sep`
+ *
+ * @param {RuleOrLiteral} rule
+ *
+ * @param {RuleOrLiteral} separator
+ *
+ * @returns {SeqRule}
+ */
+function sep1(rule, separator) {
+  return seq(rule, repeat(seq(separator, rule)));
+}
+
+/**
+ * Creates a rule to match one or more of the rules separated by a comma
+ *
+ * @param {Rule} rule
+ *
+ * @returns {SeqRule}
+ */
+function commaSep1(rule) {
+  return seq(rule, repeat(seq(',', rule)));
+}
+
+/**
+ * Creates a rule to optionally match one or more of the rules separated by a comma
+ *
+ * @param {Rule} rule
+ *
+ * @returns {ChoiceRule}
+ */
+function commaSep(rule) {
+  return optional(commaSep1(rule));
+}

--- a/testdata/incremental_gate/json_contract.json
+++ b/testdata/incremental_gate/json_contract.json
@@ -1,0 +1,102 @@
+{
+  "schema": "gts-semantic-phase-trace-contract/v5",
+  "event_contract": "gts-semantic-phase-trace/v5",
+  "scope": "Diagnostic production-Go full-parse action lookup, action execution, and convergence events. The contract, observers, collision keys, and ordinal reconstruction are absent from untagged builds.",
+  "retention": {
+    "maximum_events": 8192,
+    "event_policy": "retain_chronological_prefix",
+    "aggregate_policy": "count_the_whole_observed_parse_even_after_event_retention_fills",
+	"action_cell_collision_key_cap": 4096,
+	"coarse_boundary_collision_key_cap": 262144,
+    "overflow": "saturate uint64 counters and expose events_dropped plus arithmetic_overflow"
+  },
+  "event_kinds": {
+    "action_lookup": "One event per ordered action candidate in the actual table cell, or one empty-cell event. lookup_action_cell_fingerprint is populated; execution_action_cell_fingerprint is absent.",
+    "action_execution": "One event at a production dispatch seam. The table cell is re-read from the execution-time state and lookahead; execution_action_cell_fingerprint is populated and execution_cell_recomputed is true.",
+    "decision": "One convergence decision. Action-cell fingerprints and ordinals are absent because no last-writer action context is assigned to convergence."
+  },
+  "action_cell": {
+    "hash": "FNV-1a 64 over eight little-endian bytes per word",
+    "ordered_words": [
+      "action_count",
+      "for each ordered action: type",
+      "state",
+      "symbol",
+      "child_count",
+      "dynamic_precedence_as_uint16",
+      "production_id",
+      "flags(extra=1, extra_chain=2, repetition=4)"
+    ],
+    "collision_audit": "Observed hashes are joined to complete canonical word strings across retained and dropped events until 4096 distinct action-cell hashes have been retained. A new hash after that cap increments action_cell_keys_unaudited, sets action_cell_audit_truncated, and makes collision_audit.complete false. Equal retained hashes with unequal canonical keys increment action_cell_hash_collisions and also fail completeness."
+  },
+  "coarse_boundary": {
+    "purpose": "Production-only attribution hint; never a predecessor-spine identity.",
+    "ordered_words": [
+      "stack_byte_offset",
+      "logical_depth",
+      "top_state",
+      "top_symbol",
+      "top_start_byte<<32 | top_end_byte",
+      "top_child_count",
+      "top_production_id",
+      "top_dynamic_precedence_as_uint32",
+      "flags(extra=1, missing=2, has_error=4, dead=8, accepted=16, paused=32)"
+    ],
+    "collision_audit": "Observed hashes are joined to complete shallow keys across retained and dropped events until 262144 distinct boundary hashes have been retained. A new hash after that cap increments coarse_boundary_keys_unaudited, sets coarse_boundary_audit_truncated, and makes collision_audit.complete false. Equal retained hashes with unequal keys increment coarse_boundary_hash_collisions and also fail completeness.",
+    "not_proved": [
+      "full predecessor-spine equality",
+      "derivation equality",
+      "exact scanner-state equality",
+      "cross-engine boundary equality"
+    ]
+  },
+  "scanner_checkpoint": {
+    "states": ["exact", "exact_empty", "unavailable"],
+	"exact_identity": "event token start byte, event token end byte, start length, end length, and SHA-256 over domain gts-semantic-scanner-checkpoint/v2 followed by the token span and both length-delimited serialized byte strings",
+    "transport_rule": "The digest authenticates bytes but does not replace byte equality in a future in-process cross-engine admission.",
+	"span_binding_rule": "An exact checkpoint is emitted only when the parser's cached checkpoint start/end bytes equal the current event token span. Relex span drift emits unavailable/current_token_checkpoint_span_mismatch until the cache is refreshed.",
+	"unavailable_rule": "Missing or span-mismatched production current-token checkpoint data is emitted as unavailable with a reason, never coerced to empty."
+  },
+  "ordinal_policy": {
+    "direct": "Thread the parse-table ordinal from the dispatch call site.",
+    "unique_inference": "The deterministic-conflict seam may infer an ordinal only when exactly one execution-time cell entry equals the chosen action. The scan exists only in the tagged implementation.",
+    "unknown": "Synthetic actions and duplicate-equal candidates emit -1."
+  },
+  "dispatch_bypass_audit": {
+    "instrumented": [
+      "ordinary single action",
+      "conflict original and forks",
+      "deterministic conflict selection",
+      "reduce chains and conflict frontiers",
+      "extra-shift fast path",
+      "post-reduce terminal frontier",
+      "trailing-EOF prefix REDUCE and ACCEPT"
+    ],
+    "synthetic_without_table_ordinal": [
+      "no-action recovery found by stack search",
+      "retry recovery found by stack search",
+      "missing-token insertion",
+      "external no-action default reduction",
+      "eager default reduction",
+      "C-shaped error-state recovery"
+    ]
+  },
+  "comparability": {
+    "ordered_action_cell": "Production canonical fields are present, but compact and locked C do not yet emit the same event record.",
+    "exact_scanner_checkpoint": "Comparable only for events whose state is exact or exact_empty and only against an engine exposing the identical byte contract.",
+    "ordered_predecessor_spine": "Unavailable: no shared canonical spine contract exists across production, compact, and locked C.",
+    "static_c_semantic_events": "Unavailable: the locked static-C work-count patch exposes aggregate counters only."
+  },
+  "physical_identity_excluded": [
+    "Go pointer",
+    "stack version ID",
+    "GSS node ID",
+    "compact arena ID",
+    "subtree pointer"
+  ],
+  "paired_receipt": {
+    "contract": "gts-paired-semantic-trace-contract/v1",
+    "receipt": "gts-paired-semantic-trace-receipt/v1",
+	"claim_limit": "The paired receipt may select a routing or replay hypothesis from authenticated aggregate differences only when every collision audit used by that hypothesis is complete and untruncated. It cannot assert event equality, event-elision safety, or ratios of equivalent work until shared ordered cells, checkpoints, and predecessor spines exist."
+  }
+}

--- a/testdata/incremental_gate/python_large_indent.py
+++ b/testdata/incremental_gate/python_large_indent.py
@@ -1,0 +1,945 @@
+# Python test set -- part 1, grammar.
+# This just tests whether the parser accepts them all.
+
+# NOTE: When you run this test as a script from the command line, you
+# get warnings about certain hex/oct constants.  Since those are
+# issued by the parser, you can't suppress them by adding a
+# filterwarnings() call to this module.  Therefore, to shut up the
+# regression test, the filterwarnings() call has been added to
+# regrtest.py.
+
+from test.support import run_unittest, check_syntax_error
+import unittest
+import sys
+# testing import *
+from sys import *
+
+class TokenTests(unittest.TestCase):
+
+    def testBackslash(self):
+        # Backslash means line continuation:
+        x = 1 \
+        + 1
+        self.assertEquals(x, 2, 'backslash for line continuation')
+
+        # Backslash does not means continuation in comments :\
+        x = 0
+        self.assertEquals(x, 0, 'backslash ending comment')
+
+    def testPlainIntegers(self):
+        self.assertEquals(type(000), type(0))
+        self.assertEquals(0xff, 255)
+        self.assertEquals(0o377, 255)
+        self.assertEquals(2147483647, 0o17777777777)
+        self.assertEquals(0b1001, 9)
+        # "0x" is not a valid literal
+        self.assertRaises(SyntaxError, eval, "0x")
+        from sys import maxsize
+        if maxsize == 2147483647:
+            self.assertEquals(-2147483647-1, -0o20000000000)
+            # XXX -2147483648
+            self.assert_(0o37777777777 > 0)
+            self.assert_(0xffffffff > 0)
+            self.assert_(0b1111111111111111111111111111111 > 0)
+            for s in ('2147483648', '0o40000000000', '0x100000000',
+                      '0b10000000000000000000000000000000'):
+                try:
+                    x = eval(s)
+                except OverflowError:
+                    self.fail("OverflowError on huge integer literal %r" % s)
+        elif maxsize == 9223372036854775807:
+            self.assertEquals(-9223372036854775807-1, -0o1000000000000000000000)
+            self.assert_(0o1777777777777777777777 > 0)
+            self.assert_(0xffffffffffffffff > 0)
+            self.assert_(0b11111111111111111111111111111111111111111111111111111111111111 > 0)
+            for s in '9223372036854775808', '0o2000000000000000000000', \
+                     '0x10000000000000000', \
+                     '0b100000000000000000000000000000000000000000000000000000000000000':
+                try:
+                    x = eval(s)
+                except OverflowError:
+                    self.fail("OverflowError on huge integer literal %r" % s)
+        else:
+            self.fail('Weird maxsize value %r' % maxsize)
+
+    def testLongIntegers(self):
+        x = 0
+        x = 0xffffffffffffffff
+        x = 0Xffffffffffffffff
+        x = 0o77777777777777777
+        x = 0O77777777777777777
+        x = 123456789012345678901234567890
+        x = 0b100000000000000000000000000000000000000000000000000000000000000000000
+        x = 0B111111111111111111111111111111111111111111111111111111111111111111111
+
+    def testUnderscoresInNumbers(self):
+        # Integers
+        x = 1_0
+        x = 123_456_7_89
+        x = 0xabc_123_4_5
+        x = 0X_abc_123
+        x = 0B11_01
+        x = 0b_11_01
+        x = 0o45_67
+        x = 0O_45_67
+
+        # Floats
+        x = 3_1.4
+        x = 03_1.4
+        x = 3_1.
+        x = .3_1
+        x = 3.1_4
+        x = 0_3.1_4
+        x = 3e1_4
+        x = 3_1e+4_1
+        x = 3_1E-4_1
+
+    def testFloats(self):
+        x = 3.14
+        x = 314.
+        x = 0.314
+        # XXX x = 000.314
+        x = .314
+        x = 3e14
+        x = 3E14
+        x = 3e-14
+        x = 3e+14
+        x = 3.e14
+        x = .3e14
+        x = 3.1e4
+
+    def testEllipsis(self):
+        x = ...
+        self.assert_(x is Ellipsis)
+        self.assertRaises(SyntaxError, eval, ".. .")
+
+class GrammarTests(unittest.TestCase):
+
+    # single_input: NEWLINE | simple_stmt | compound_stmt NEWLINE
+    # XXX can't test in a script -- this rule is only used when interactive
+
+    # file_input: (NEWLINE | stmt)* ENDMARKER
+    # Being tested as this very moment this very module
+
+    # expr_input: testlist NEWLINE
+    # XXX Hard to test -- used only in calls to input()
+
+    def testEvalInput(self):
+        # testlist ENDMARKER
+        x = eval('1, 0 or 1')
+
+    def testFuncdef(self):
+        ### [decorators] 'def' NAME parameters ['->' test] ':' suite
+        ### decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
+        ### decorators: decorator+
+        ### parameters: '(' [typedargslist] ')'
+        ### typedargslist: ((tfpdef ['=' test] ',')*
+        ###                ('*' [tfpdef] (',' tfpdef ['=' test])* [',' '**' tfpdef] | '**' tfpdef)
+        ###                | tfpdef ['=' test] (',' tfpdef ['=' test])* [','])
+        ### tfpdef: NAME [':' test]
+        ### varargslist: ((vfpdef ['=' test] ',')*
+        ###              ('*' [vfpdef] (',' vfpdef ['=' test])*  [',' '**' vfpdef] | '**' vfpdef)
+        ###              | vfpdef ['=' test] (',' vfpdef ['=' test])* [','])
+        ### vfpdef: NAME
+        def f1(): pass
+        f1()
+        f1(*())
+        f1(*(), **{})
+        def f2(one_argument): pass
+        def f3(two, arguments): pass
+        self.assertEquals(f2.__code__.co_varnames, ('one_argument',))
+        self.assertEquals(f3.__code__.co_varnames, ('two', 'arguments'))
+        def a1(one_arg,): pass
+        def a2(two, args,): pass
+        def v0(*rest): pass
+        def v1(a, *rest): pass
+        def v2(a, b, *rest): pass
+
+        f1()
+        f2(1)
+        f2(1,)
+        f3(1, 2)
+        f3(1, 2,)
+        v0()
+        v0(1)
+        v0(1,)
+        v0(1,2)
+        v0(1,2,3,4,5,6,7,8,9,0)
+        v1(1)
+        v1(1,)
+        v1(1,2)
+        v1(1,2,3)
+        v1(1,2,3,4,5,6,7,8,9,0)
+        v2(1,2)
+        v2(1,2,3)
+        v2(1,2,3,4)
+        v2(1,2,3,4,5,6,7,8,9,0)
+
+        def d01(a=1): pass
+        d01()
+        d01(1)
+        d01(*(1,))
+        d01(**{'a':2})
+        def d11(a, b=1): pass
+        d11(1)
+        d11(1, 2)
+        d11(1, **{'b':2})
+        def d21(a, b, c=1): pass
+        d21(1, 2)
+        d21(1, 2, 3)
+        d21(*(1, 2, 3))
+        d21(1, *(2, 3))
+        d21(1, 2, *(3,))
+        d21(1, 2, **{'c':3})
+        def d02(a=1, b=2): pass
+        d02()
+        d02(1)
+        d02(1, 2)
+        d02(*(1, 2))
+        d02(1, *(2,))
+        d02(1, **{'b':2})
+        d02(**{'a': 1, 'b': 2})
+        def d12(a, b=1, c=2): pass
+        d12(1)
+        d12(1, 2)
+        d12(1, 2, 3)
+        def d22(a, b, c=1, d=2): pass
+        d22(1, 2)
+        d22(1, 2, 3)
+        d22(1, 2, 3, 4)
+        def d01v(a=1, *rest): pass
+        d01v()
+        d01v(1)
+        d01v(1, 2)
+        d01v(*(1, 2, 3, 4))
+        d01v(*(1,))
+        d01v(**{'a':2})
+        def d11v(a, b=1, *rest): pass
+        d11v(1)
+        d11v(1, 2)
+        d11v(1, 2, 3)
+        def d21v(a, b, c=1, *rest): pass
+        d21v(1, 2)
+        d21v(1, 2, 3)
+        d21v(1, 2, 3, 4)
+        d21v(*(1, 2, 3, 4))
+        d21v(1, 2, **{'c': 3})
+        def d02v(a=1, b=2, *rest): pass
+        d02v()
+        d02v(1)
+        d02v(1, 2)
+        d02v(1, 2, 3)
+        d02v(1, *(2, 3, 4))
+        d02v(**{'a': 1, 'b': 2})
+        def d12v(a, b=1, c=2, *rest): pass
+        d12v(1)
+        d12v(1, 2)
+        d12v(1, 2, 3)
+        d12v(1, 2, 3, 4)
+        d12v(*(1, 2, 3, 4))
+        d12v(1, 2, *(3, 4, 5))
+        d12v(1, *(2,), **{'c': 3})
+        def d22v(a, b, c=1, d=2, *rest): pass
+        d22v(1, 2)
+        d22v(1, 2, 3)
+        d22v(1, 2, 3, 4)
+        d22v(1, 2, 3, 4, 5)
+        d22v(*(1, 2, 3, 4))
+        d22v(1, 2, *(3, 4, 5))
+        d22v(1, *(2, 3), **{'d': 4})
+
+        # keyword argument type tests
+        try:
+            str('x', **{b'foo':1 })
+        except TypeError:
+            pass
+        else:
+            self.fail('Bytes should not work as keyword argument names')
+        # keyword only argument tests
+        def pos0key1(*, key): return key
+        pos0key1(key=100)
+        def pos2key2(p1, p2, *, k1, k2=100): return p1,p2,k1,k2
+        pos2key2(1, 2, k1=100)
+        pos2key2(1, 2, k1=100, k2=200)
+        pos2key2(1, 2, k2=100, k1=200)
+        def pos2key2dict(p1, p2, *, k1=100, k2, **kwarg): return p1,p2,k1,k2,kwarg
+        pos2key2dict(1,2,k2=100,tokwarg1=100,tokwarg2=200)
+        pos2key2dict(1,2,tokwarg1=100,tokwarg2=200, k2=100)
+
+        # keyword arguments after *arglist
+        def f(*args, **kwargs):
+            return args, kwargs
+        self.assertEquals(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
+                                                    {'x':2, 'y':5}))
+        self.assertRaises(SyntaxError, eval, "f(1, *(2,3), 4)")
+        self.assertRaises(SyntaxError, eval, "f(1, x=2, *(3,4), x=5)")
+
+        # argument annotation tests
+        def f(x) -> list: pass
+        self.assertEquals(f.__annotations__, {'return': list})
+        def f(x:int): pass
+        self.assertEquals(f.__annotations__, {'x': int})
+        def f(*x:str): pass
+        self.assertEquals(f.__annotations__, {'x': str})
+        def f(**x:float): pass
+        self.assertEquals(f.__annotations__, {'x': float})
+        def f(x, y:1+2): pass
+        self.assertEquals(f.__annotations__, {'y': 3})
+        def f(a, b:1, c:2, d): pass
+        self.assertEquals(f.__annotations__, {'b': 1, 'c': 2})
+        def f(a, b:1, c:2, d, e:3=4, f=5, *g:6): pass
+        self.assertEquals(f.__annotations__,
+                          {'b': 1, 'c': 2, 'e': 3, 'g': 6})
+        def f(a, b:1, c:2, d, e:3=4, f=5, *g:6, h:7, i=8, j:9=10,
+              **k:11) -> 12: pass
+        self.assertEquals(f.__annotations__,
+                          {'b': 1, 'c': 2, 'e': 3, 'g': 6, 'h': 7, 'j': 9,
+                           'k': 11, 'return': 12})
+        # Check for SF Bug #1697248 - mixing decorators and a return annotation
+        def null(x): return x
+        @null
+        def f(x) -> list: pass
+        self.assertEquals(f.__annotations__, {'return': list})
+
+        # test closures with a variety of oparg's
+        closure = 1
+        def f(): return closure
+        def f(x=1): return closure
+        def f(*, k=1): return closure
+        def f() -> int: return closure
+
+        # Check ast errors in *args and *kwargs
+        check_syntax_error(self, "f(*g(1=2))")
+        check_syntax_error(self, "f(**g(1=2))")
+
+    def testLambdef(self):
+        ### lambdef: 'lambda' [varargslist] ':' test
+        l1 = lambda : 0
+        self.assertEquals(l1(), 0)
+        l2 = lambda : a[d] # XXX just testing the expression
+        l3 = lambda : [2 < x for x in [-1, 3, 0]]
+        self.assertEquals(l3(), [0, 1, 0])
+        l4 = lambda x = lambda y = lambda z=1 : z : y() : x()
+        self.assertEquals(l4(), 1)
+        l5 = lambda x, y, z=2: x + y + z
+        self.assertEquals(l5(1, 2), 5)
+        self.assertEquals(l5(1, 2, 3), 6)
+        check_syntax_error(self, "lambda x: x = 2")
+        check_syntax_error(self, "lambda (None,): None")
+        l6 = lambda x, y, *, k=20: x+y+k
+        self.assertEquals(l6(1,2), 1+2+20)
+        self.assertEquals(l6(1,2,k=10), 1+2+10)
+
+
+    ### stmt: simple_stmt | compound_stmt
+    # Tested below
+
+    def testSimpleStmt(self):
+        ### simple_stmt: small_stmt (';' small_stmt)* [';']
+        x = 1; pass; del x
+        def foo():
+            # verify statements that end with semi-colons
+            x = 1; pass; del x;
+        foo()
+
+    ### small_stmt: expr_stmt | pass_stmt | del_stmt | flow_stmt | import_stmt | global_stmt | access_stmt
+    # Tested below
+
+    def testExprStmt(self):
+        # (exprlist '=')* exprlist
+        1
+        1, 2, 3
+        x = 1
+        x = 1, 2, 3
+        x = y = z = 1, 2, 3
+        x, y, z = 1, 2, 3
+        abc = a, b, c = x, y, z = xyz = 1, 2, (3, 4)
+
+        check_syntax_error(self, "x + 1 = 1")
+        check_syntax_error(self, "a + 1 = b + 2")
+
+    def testDelStmt(self):
+        # 'del' exprlist
+        abc = [1,2,3]
+        x, y, z = abc
+        xyz = x, y, z
+
+        del abc
+        del x, y, (z, xyz)
+
+    def testPassStmt(self):
+        # 'pass'
+        pass
+
+    # flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt
+    # Tested below
+
+    def testBreakStmt(self):
+        # 'break'
+        while 1: break
+
+    def testContinueStmt(self):
+        # 'continue'
+        i = 1
+        while i: i = 0; continue
+
+        msg = ""
+        while not msg:
+            msg = "ok"
+            try:
+                continue
+                msg = "continue failed to continue inside try"
+            except:
+                msg = "continue inside try called except block"
+        if msg != "ok":
+            self.fail(msg)
+
+        msg = ""
+        while not msg:
+            msg = "finally block not called"
+            try:
+                continue
+            finally:
+                msg = "ok"
+        if msg != "ok":
+            self.fail(msg)
+
+    def test_break_continue_loop(self):
+        # This test warrants an explanation. It is a test specifically for SF bugs
+        # #463359 and #462937. The bug is that a 'break' statement executed or
+        # exception raised inside a try/except inside a loop, *after* a continue
+        # statement has been executed in that loop, will cause the wrong number of
+        # arguments to be popped off the stack and the instruction pointer reset to
+        # a very small number (usually 0.) Because of this, the following test
+        # *must* written as a function, and the tracking vars *must* be function
+        # arguments with default values. Otherwise, the test will loop and loop.
+
+        def test_inner(extra_burning_oil = 1, count=0):
+            big_hippo = 2
+            while big_hippo:
+                count += 1
+                try:
+                    if extra_burning_oil and big_hippo == 1:
+                        extra_burning_oil -= 1
+                        break
+                    big_hippo -= 1
+                    continue
+                except:
+                    raise
+            if count > 2 or big_hippo != 1:
+                self.fail("continue then break in try/except in loop broken!")
+        test_inner()
+
+    def testReturn(self):
+        # 'return' [testlist]
+        def g1(): return
+        def g2(): return 1
+        g1()
+        x = g2()
+        check_syntax_error(self, "class foo:return 1")
+
+    def testYield(self):
+        check_syntax_error(self, "class foo:yield 1")
+
+    def testRaise(self):
+        # 'raise' test [',' test]
+        try: raise RuntimeError('just testing')
+        except RuntimeError: pass
+        try: raise KeyboardInterrupt
+        except KeyboardInterrupt: pass
+
+    def testImport(self):
+        # 'import' dotted_as_names
+        import sys
+        import time, sys
+        # 'from' dotted_name 'import' ('*' | '(' import_as_names ')' | import_as_names)
+        from time import time
+        from time import (time)
+        # not testable inside a function, but already done at top of the module
+        # from sys import *
+        from sys import path, argv
+        from sys import (path, argv)
+        from sys import (path, argv,)
+
+    def testGlobal(self):
+        # 'global' NAME (',' NAME)*
+        global a
+        global a, b
+        global one, two, three, four, five, six, seven, eight, nine, ten
+
+    def testNonlocal(self):
+        # 'nonlocal' NAME (',' NAME)*
+        x = 0
+        y = 0
+        def f():
+            nonlocal x
+            nonlocal x, y
+
+    def testAssert(self):
+        # assert_stmt: 'assert' test [',' test]
+        assert 1
+        assert 1, 1
+        assert lambda x:x
+        assert 1, lambda x:x+1
+        try:
+            assert 0, "msg"
+        except AssertionError as e:
+            self.assertEquals(e.args[0], "msg")
+        else:
+            if __debug__:
+                self.fail("AssertionError not raised by assert 0")
+
+    ### compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | funcdef | classdef
+    # Tested below
+
+    def testIf(self):
+        # 'if' test ':' suite ('elif' test ':' suite)* ['else' ':' suite]
+        if 1: pass
+        if 1: pass
+        else: pass
+        if 0: pass
+        elif 0: pass
+        if 0: pass
+        elif 0: pass
+        elif 0: pass
+        elif 0: pass
+        else: pass
+
+    def testWhile(self):
+        # 'while' test ':' suite ['else' ':' suite]
+        while 0: pass
+        while 0: pass
+        else: pass
+
+        # Issue1920: "while 0" is optimized away,
+        # ensure that the "else" clause is still present.
+        x = 0
+        while 0:
+            x = 1
+        else:
+            x = 2
+        self.assertEquals(x, 2)
+
+    def testFor(self):
+        # 'for' exprlist 'in' exprlist ':' suite ['else' ':' suite]
+        for i in 1, 2, 3: pass
+        for i, j, k in (): pass
+        else: pass
+        class Squares:
+            def __init__(self, max):
+                self.max = max
+                self.sofar = []
+            def __len__(self): return len(self.sofar)
+            def __getitem__(self, i):
+                if not 0 <= i < self.max: raise IndexError
+                n = len(self.sofar)
+                while n <= i:
+                    self.sofar.append(n*n)
+                    n = n+1
+                return self.sofar[i]
+        n = 0
+        for x in Squares(10): n = n+x
+        if n != 285:
+            self.fail('for over growing sequence')
+
+        result = []
+        for x, in [(1,), (2,), (3,)]:
+            result.append(x)
+        self.assertEqual(result, [1, 2, 3])
+
+    def testTry(self):
+        ### try_stmt: 'try' ':' suite (except_clause ':' suite)+ ['else' ':' suite]
+        ###         | 'try' ':' suite 'finally' ':' suite
+        ### except_clause: 'except' [expr ['as' expr]]
+        try:
+            1/0
+        except ZeroDivisionError:
+            pass
+        else:
+            pass
+        try: 1/0
+        except EOFError: pass
+        except TypeError as msg: pass
+        except RuntimeError as msg: pass
+        except: pass
+        else: pass
+        try: 1/0
+        except (EOFError, TypeError, ZeroDivisionError): pass
+        try: 1/0
+        except (EOFError, TypeError, ZeroDivisionError) as msg: pass
+        try: pass
+        finally: pass
+
+    def testSuite(self):
+        # simple_stmt | NEWLINE INDENT NEWLINE* (stmt NEWLINE*)+ DEDENT
+        if 1: pass
+        if 1:
+            pass
+        if 1:
+            #
+            #
+            #
+            pass
+            pass
+            #
+            pass
+            #
+
+    def testTest(self):
+        ### and_test ('or' and_test)*
+        ### and_test: not_test ('and' not_test)*
+        ### not_test: 'not' not_test | comparison
+        if not 1: pass
+        if 1 and 1: pass
+        if 1 or 1: pass
+        if not not not 1: pass
+        if not 1 and 1 and 1: pass
+        if 1 and 1 or 1 and 1 and 1 or not 1 and 1: pass
+
+    def testComparison(self):
+        ### comparison: expr (comp_op expr)*
+        ### comp_op: '<'|'>'|'=='|'>='|'<='|'!='|'in'|'not' 'in'|'is'|'is' 'not'
+        if 1: pass
+        x = (1 == 1)
+        if 1 == 1: pass
+        if 1 != 1: pass
+        if 1 < 1: pass
+        if 1 > 1: pass
+        if 1 <= 1: pass
+        if 1 >= 1: pass
+        if 1 is 1: pass
+        if 1 is not 1: pass
+        if 1 in (): pass
+        if 1 not in (): pass
+        if 1 < 1 > 1 == 1 >= 1 <= 1 != 1 in 1 not in 1 is 1 is not 1: pass
+
+    def testBinaryMaskOps(self):
+        x = 1 & 1
+        x = 1 ^ 1
+        x = 1 | 1
+
+    def testShiftOps(self):
+        x = 1 << 1
+        x = 1 >> 1
+        x = 1 << 1 >> 1
+
+    def testAdditiveOps(self):
+        x = 1
+        x = 1 + 1
+        x = 1 - 1 - 1
+        x = 1 - 1 + 1 - 1 + 1
+
+    def testMultiplicativeOps(self):
+        x = 1 * 1
+        x = 1 / 1
+        x = 1 % 1
+        x = 1 / 1 * 1 % 1
+
+    def testUnaryOps(self):
+        x = +1
+        x = -1
+        x = ~1
+        x = ~1 ^ 1 & 1 | 1 & 1 ^ -1
+        x = -1*1/1 + 1*1 - ---1*1
+
+    def testSelectors(self):
+        ### trailer: '(' [testlist] ')' | '[' subscript ']' | '.' NAME
+        ### subscript: expr | [expr] ':' [expr]
+
+        import sys, time
+        c = sys.path[0]
+        x = time.time()
+        x = sys.modules['time'].time()
+        a = '01234'
+        c = a[0]
+        c = a[-1]
+        s = a[0:5]
+        s = a[:5]
+        s = a[0:]
+        s = a[:]
+        s = a[-5:]
+        s = a[:-1]
+        s = a[-4:-3]
+        # A rough test of SF bug 1333982.  http://python.org/sf/1333982
+        # The testing here is fairly incomplete.
+        # Test cases should include: commas with 1 and 2 colons
+        d = {}
+        d[1] = 1
+        d[1,] = 2
+        d[1,2] = 3
+        d[1,2,3] = 4
+        L = list(d)
+        L.sort(key=lambda x: x if isinstance(x, tuple) else ())
+        self.assertEquals(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
+
+    def testAtoms(self):
+        ### atom: '(' [testlist] ')' | '[' [testlist] ']' | '{' [dictsetmaker] '}' | NAME | NUMBER | STRING
+        ### dictsetmaker: (test ':' test (',' test ':' test)* [',']) | (test (',' test)* [','])
+
+        x = (1)
+        x = (1 or 2 or 3)
+        x = (1 or 2 or 3, 2, 3)
+
+        x = []
+        x = [1]
+        x = [1 or 2 or 3]
+        x = [1 or 2 or 3, 2, 3]
+        x = []
+
+        x = {}
+        x = {'one': 1}
+        x = {'one': 1,}
+        x = {'one' or 'two': 1 or 2}
+        x = {'one': 1, 'two': 2}
+        x = {'one': 1, 'two': 2,}
+        x = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6}
+
+        x = {'one'}
+        x = {'one', 1,}
+        x = {'one', 'two', 'three'}
+        x = {2, 3, 4,}
+
+        x = x
+        x = 'x'
+        x = 123
+
+    ### exprlist: expr (',' expr)* [',']
+    ### testlist: test (',' test)* [',']
+    # These have been exercised enough above
+
+    def testClassdef(self):
+        # 'class' NAME ['(' [testlist] ')'] ':' suite
+        class B: pass
+        class B2(): pass
+        class C1(B): pass
+        class C2(B): pass
+        class D(C1, C2, B): pass
+        class C:
+            def meth1(self): pass
+            def meth2(self, arg): pass
+            def meth3(self, a1, a2): pass
+
+        # decorator: '@' dotted_name [ '(' [arglist] ')' ] NEWLINE
+        # decorators: decorator+
+        # decorated: decorators (classdef | funcdef)
+        def class_decorator(x): return x
+        @class_decorator
+        class G: pass
+
+    def testDictcomps(self):
+        # dictorsetmaker: ( (test ':' test (comp_for |
+        #                                   (',' test ':' test)* [','])) |
+        #                   (test (comp_for | (',' test)* [','])) )
+        nums = [1, 2, 3]
+        self.assertEqual({i:i+1 for i in nums}, {1: 2, 2: 3, 3: 4})
+
+    def testListcomps(self):
+        # list comprehension tests
+        nums = [1, 2, 3, 4, 5]
+        strs = ["Apple", "Banana", "Coconut"]
+        spcs = ["  Apple", " Banana ", "Coco  nut  "]
+
+        self.assertEqual([s.strip() for s in spcs], ['Apple', 'Banana', 'Coco  nut'])
+        self.assertEqual([3 * x for x in nums], [3, 6, 9, 12, 15])
+        self.assertEqual([x for x in nums if x > 2], [3, 4, 5])
+        self.assertEqual([(i, s) for i in nums for s in strs],
+                         [(1, 'Apple'), (1, 'Banana'), (1, 'Coconut'),
+                          (2, 'Apple'), (2, 'Banana'), (2, 'Coconut'),
+                          (3, 'Apple'), (3, 'Banana'), (3, 'Coconut'),
+                          (4, 'Apple'), (4, 'Banana'), (4, 'Coconut'),
+                          (5, 'Apple'), (5, 'Banana'), (5, 'Coconut')])
+        self.assertEqual([(i, s) for i in nums for s in [f for f in strs if "n" in f]],
+                         [(1, 'Banana'), (1, 'Coconut'), (2, 'Banana'), (2, 'Coconut'),
+                          (3, 'Banana'), (3, 'Coconut'), (4, 'Banana'), (4, 'Coconut'),
+                          (5, 'Banana'), (5, 'Coconut')])
+        self.assertEqual([(lambda a:[a**i for i in range(a+1)])(j) for j in range(5)],
+                         [[1], [1, 1], [1, 2, 4], [1, 3, 9, 27], [1, 4, 16, 64, 256]])
+
+        def test_in_func(l):
+            return [0 < x < 3 for x in l if x > 2]
+
+        self.assertEqual(test_in_func(nums), [False, False, False])
+
+        def test_nested_front():
+            self.assertEqual([[y for y in [x, x + 1]] for x in [1,3,5]],
+                             [[1, 2], [3, 4], [5, 6]])
+
+        test_nested_front()
+
+        check_syntax_error(self, "[i, s for i in nums for s in strs]")
+        check_syntax_error(self, "[x if y]")
+
+        suppliers = [
+          (1, "Boeing"),
+          (2, "Ford"),
+          (3, "Macdonalds")
+        ]
+
+        parts = [
+          (10, "Airliner"),
+          (20, "Engine"),
+          (30, "Cheeseburger")
+        ]
+
+        suppart = [
+          (1, 10), (1, 20), (2, 20), (3, 30)
+        ]
+
+        x = [
+          (sname, pname)
+            for (sno, sname) in suppliers
+              for (pno, pname) in parts
+                for (sp_sno, sp_pno) in suppart
+                  if sno == sp_sno and pno == sp_pno
+        ]
+
+        self.assertEqual(x, [('Boeing', 'Airliner'), ('Boeing', 'Engine'), ('Ford', 'Engine'),
+                             ('Macdonalds', 'Cheeseburger')])
+
+    def testGenexps(self):
+        # generator expression tests
+        g = ([x for x in range(10)] for x in range(1))
+        self.assertEqual(next(g), [x for x in range(10)])
+        try:
+            next(g)
+            self.fail('should produce StopIteration exception')
+        except StopIteration:
+            pass
+
+        a = 1
+        try:
+            g = (a for d in a)
+            next(g)
+            self.fail('should produce TypeError')
+        except TypeError:
+            pass
+
+        self.assertEqual(list((x, y) for x in 'abcd' for y in 'abcd'), [(x, y) for x in 'abcd' for y in 'abcd'])
+        self.assertEqual(list((x, y) for x in 'ab' for y in 'xy'), [(x, y) for x in 'ab' for y in 'xy'])
+
+        a = [x for x in range(10)]
+        b = (x for x in (y for y in a))
+        self.assertEqual(sum(b), sum([x for x in range(10)]))
+
+        self.assertEqual(sum(x**2 for x in range(10)), sum([x**2 for x in range(10)]))
+        self.assertEqual(sum(x*x for x in range(10) if x%2), sum([x*x for x in range(10) if x%2]))
+        self.assertEqual(sum(x for x in (y for y in range(10))), sum([x for x in range(10)]))
+        self.assertEqual(sum(x for x in (y for y in (z for z in range(10)))), sum([x for x in range(10)]))
+        self.assertEqual(sum(x for x in [y for y in (z for z in range(10))]), sum([x for x in range(10)]))
+        self.assertEqual(sum(x for x in (y for y in (z for z in range(10) if True)) if True), sum([x for x in range(10)]))
+        self.assertEqual(sum(x for x in (y for y in (z for z in range(10) if True) if False) if True), 0)
+        check_syntax_error(self, "foo(x for x in range(10), 100)")
+        check_syntax_error(self, "foo(100, x for x in range(10))")
+
+    def testComprehensionSpecials(self):
+        # test for outmost iterable precomputation
+        x = 10; g = (i for i in range(x)); x = 5
+        self.assertEqual(len(list(g)), 10)
+
+        # This should hold, since we're only precomputing outmost iterable.
+        x = 10; t = False; g = ((i,j) for i in range(x) if t for j in range(x))
+        x = 5; t = True;
+        self.assertEqual([(i,j) for i in range(10) for j in range(5)], list(g))
+
+        # Grammar allows multiple adjacent 'if's in listcomps and genexps,
+        # even though it's silly. Make sure it works (ifelse broke this.)
+        self.assertEqual([ x for x in range(10) if x % 2 if x % 3 ], [1, 5, 7])
+        self.assertEqual(list(x for x in range(10) if x % 2 if x % 3), [1, 5, 7])
+
+        # verify unpacking single element tuples in listcomp/genexp.
+        self.assertEqual([x for x, in [(4,), (5,), (6,)]], [4, 5, 6])
+        self.assertEqual(list(x for x, in [(7,), (8,), (9,)]), [7, 8, 9])
+
+    def test_with_statement(self):
+        class manager(object):
+            def __enter__(self):
+                return (1, 2)
+            def __exit__(self, *args):
+                pass
+
+        with manager():
+            pass
+        with manager() as x:
+            pass
+        with manager() as (x, y):
+            pass
+        with manager(), manager():
+            pass
+        with manager() as x, manager() as y:
+            pass
+        with manager() as x, manager():
+            pass
+
+    def testIfElseExpr(self):
+        # Test ifelse expressions in various cases
+        def _checkeval(msg, ret):
+            "helper to check that evaluation of expressions is done correctly"
+            print(x)
+            return ret
+
+        # the next line is not allowed anymore
+        #self.assertEqual([ x() for x in lambda: True, lambda: False if x() ], [True])
+        self.assertEqual([ x() for x in (lambda: True, lambda: False) if x() ], [True])
+        self.assertEqual([ x(False) for x in (lambda x: False if x else True, lambda x: True if x else False) if x(False) ], [True])
+        self.assertEqual((5 if 1 else _checkeval("check 1", 0)), 5)
+        self.assertEqual((_checkeval("check 2", 0) if 0 else 5), 5)
+        self.assertEqual((5 and 6 if 0 else 1), 1)
+        self.assertEqual(((5 and 6) if 0 else 1), 1)
+        self.assertEqual((5 and (6 if 1 else 1)), 6)
+        self.assertEqual((0 or _checkeval("check 3", 2) if 0 else 3), 3)
+        self.assertEqual((1 or _checkeval("check 4", 2) if 1 else _checkeval("check 5", 3)), 1)
+        self.assertEqual((0 or 5 if 1 else _checkeval("check 6", 3)), 5)
+        self.assertEqual((not 5 if 1 else 1), False)
+        self.assertEqual((not 5 if 0 else 1), 1)
+        self.assertEqual((6 + 1 if 1 else 2), 7)
+        self.assertEqual((6 - 1 if 1 else 2), 5)
+        self.assertEqual((6 * 2 if 1 else 4), 12)
+        self.assertEqual((6 / 2 if 1 else 3), 3)
+        self.assertEqual((6 < 4 if 0 else 2), 2)
+
+    def testStringLiterals(self):
+        x = ''; y = ""; self.assert_(len(x) == 0 and x == y)
+        x = '\''; y = "'"; self.assert_(len(x) == 1 and x == y and ord(x) == 39)
+        x = '"'; y = "\""; self.assert_(len(x) == 1 and x == y and ord(x) == 34)
+        x = "doesn't \"shrink\" does it"
+        y = 'doesn\'t "shrink" does it'
+        self.assert_(len(x) == 24 and x == y)
+        x = "does \"shrink\" doesn't it"
+        y = 'does "shrink" doesn\'t it'
+        self.assert_(len(x) == 24 and x == y)
+        x = f"""
+The "quick"
+brown fo{ok()}x
+jumps over
+the 'lazy' dog.
+"""
+        y = '\nThe "quick"\nbrown fox\njumps over\nthe \'lazy\' dog.\n'
+        self.assertEquals(x, y)
+        y = '''
+The "quick"
+brown fox
+jumps over
+the 'lazy' dog.
+'''
+        self.assertEquals(x, y)
+        y = "\n\
+The \"quick\"\n\
+brown fox\n\
+jumps over\n\
+the 'lazy' dog.\n\
+"
+        self.assertEquals(x, y)
+        y = '\n\
+The \"quick\"\n\
+brown fox\n\
+jumps over\n\
+the \'lazy\' dog.\n\
+'
+        self.assertEquals(x, y)
+
+
+def test_main():
+    run_unittest(TokenTests, GrammarTests)
+
+if __name__ == '__main__':
+    test_main()

--- a/testdata/incremental_gate/python_setup.py
+++ b/testdata/incremental_gate/python_setup.py
@@ -1,0 +1,62 @@
+from os.path import isdir, join
+from platform import system
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build import build
+from wheel.bdist_wheel import bdist_wheel
+
+
+class Build(build):
+    def run(self):
+        if isdir("queries"):
+            dest = join(self.build_lib, "tree_sitter_python", "queries")
+            self.copy_tree("queries", dest)
+        super().run()
+
+
+class BdistWheel(bdist_wheel):
+    def get_tag(self):
+        python, abi, platform = super().get_tag()
+        if python.startswith("cp"):
+            python, abi = "cp39", "abi3"
+        return python, abi, platform
+
+
+setup(
+    packages=find_packages("bindings/python"),
+    package_dir={"": "bindings/python"},
+    package_data={
+        "tree_sitter_python": ["*.pyi", "py.typed"],
+        "tree_sitter_python.queries": ["*.scm"],
+    },
+    ext_package="tree_sitter_python",
+    ext_modules=[
+        Extension(
+            name="_binding",
+            sources=[
+                "bindings/python/tree_sitter_python/binding.c",
+                "src/parser.c",
+                "src/scanner.c",
+            ],
+            extra_compile_args=[
+                "-std=c11",
+                "-fvisibility=hidden",
+            ] if system() != "Windows" else [
+                "/std:c11",
+                "/utf-8",
+            ],
+            define_macros=[
+                ("Py_LIMITED_API", "0x03090000"),
+                ("PY_SSIZE_T_CLEAN", None),
+                ("TREE_SITTER_HIDE_SYMBOLS", None),
+            ],
+            include_dirs=["src"],
+            py_limited_api=True,
+        )
+    ],
+    cmdclass={
+        "build": Build,
+        "bdist_wheel": BdistWheel
+    },
+    zip_safe=False
+)

--- a/testdata/incremental_gate/rust_ast.rs
+++ b/testdata/incremental_gate/rust_ast.rs
@@ -1,0 +1,2214 @@
+// Copyright 2012-2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// The Rust abstract syntax tree.
+
+pub use self::PathParameters::*;
+pub use self::TyParamBound::*;
+pub use self::UnsafeSource::*;
+pub use symbol::{Ident, Symbol as Name};
+pub use util::parser::ExprPrecedence;
+pub use util::ThinVec;
+
+use abi::Abi;
+use codemap::{respan, Spanned};
+use ext::hygiene::{Mark, SyntaxContext};
+use print::pprust;
+use ptr::P;
+use rustc_data_structures::indexed_vec;
+use symbol::{keywords, Symbol};
+use syntax_pos::{Span, DUMMY_SP};
+use tokenstream::{ThinTokenStream, TokenStream};
+
+use serialize::{self, Decoder, Encoder};
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+use std::u32;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy)]
+pub struct Lifetime {
+    pub id: NodeId,
+    pub span: Span,
+    pub ident: Ident,
+}
+
+impl fmt::Debug for Lifetime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "lifetime({}: {})",
+            self.id,
+            pprust::lifetime_to_string(self)
+        )
+    }
+}
+
+/// A lifetime definition, e.g. `'a: 'b+'c+'d`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct LifetimeDef {
+    pub attrs: ThinVec<Attribute>,
+    pub lifetime: Lifetime,
+    pub bounds: Vec<Lifetime>,
+}
+
+/// A "Path" is essentially Rust's notion of a name.
+///
+/// It's represented as a sequence of identifiers,
+/// along with a bunch of supporting information.
+///
+/// E.g. `std::cmp::PartialEq`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub struct Path {
+    pub span: Span,
+    /// The segments in the path: the things separated by `::`.
+    /// Global paths begin with `keywords::CrateRoot`.
+    pub segments: Vec<PathSegment>,
+}
+
+impl<'a> PartialEq<&'a str> for Path {
+    fn eq(&self, string: &&'a str) -> bool {
+        self.segments.len() == 1 && self.segments[0].identifier.name == *string
+    }
+}
+
+impl fmt::Debug for Path {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "path({})", pprust::path_to_string(self))
+    }
+}
+
+impl fmt::Display for Path {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", pprust::path_to_string(self))
+    }
+}
+
+impl Path {
+    // convert a span and an identifier to the corresponding
+    // 1-segment path
+    pub fn from_ident(s: Span, identifier: Ident) -> Path {
+        Path {
+            span: s,
+            segments: vec![PathSegment::from_ident(identifier, s)],
+        }
+    }
+
+    // Add starting "crate root" segment to all paths except those that
+    // already have it or start with `self`, `super`, `Self` or `$crate`.
+    pub fn default_to_global(mut self) -> Path {
+        if !self.is_global() {
+            let ident = self.segments[0].identifier;
+            if !::parse::token::Ident(ident).is_path_segment_keyword()
+                || ident.name == keywords::Crate.name()
+            {
+                self.segments.insert(0, PathSegment::crate_root(self.span));
+            }
+        }
+        self
+    }
+
+    pub fn is_global(&self) -> bool {
+        !self.segments.is_empty() && self.segments[0].identifier.name == keywords::CrateRoot.name()
+    }
+}
+
+/// A segment of a path: an identifier, an optional lifetime, and a set of types.
+///
+/// E.g. `std`, `String` or `Box<T>`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct PathSegment {
+    /// The identifier portion of this path segment.
+    pub identifier: Ident,
+    /// Span of the segment identifier.
+    pub span: Span,
+
+    /// Type/lifetime parameters attached to this path. They come in
+    /// two flavors: `Path<A,B,C>` and `Path(A,B) -> C`.
+    /// `None` means that no parameter list is supplied (`Path`),
+    /// `Some` means that parameter list is supplied (`Path<X, Y>`)
+    /// but it can be empty (`Path<>`).
+    /// `P` is used as a size optimization for the common case with no parameters.
+    pub parameters: Option<P<PathParameters>>,
+}
+
+impl PathSegment {
+    pub fn from_ident(ident: Ident, span: Span) -> Self {
+        PathSegment {
+            identifier: ident,
+            span: span,
+            parameters: None,
+        }
+    }
+    pub fn crate_root(span: Span) -> Self {
+        PathSegment {
+            identifier: Ident {
+                ctxt: span.ctxt(),
+                ..keywords::CrateRoot.ident()
+            },
+            span,
+            parameters: None,
+        }
+    }
+}
+
+/// Parameters of a path segment.
+///
+/// E.g. `<A, B>` as in `Foo<A, B>` or `(A, B)` as in `Foo(A, B)`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum PathParameters {
+    /// The `<'a, A,B,C>` in `foo::bar::baz::<'a, A,B,C>`
+    AngleBracketed(AngleBracketedParameterData),
+    /// The `(A,B)` and `C` in `Foo(A,B) -> C`
+    Parenthesized(ParenthesizedParameterData),
+}
+
+impl PathParameters {
+    pub fn span(&self) -> Span {
+        match *self {
+            AngleBracketed(ref data) => data.span,
+            Parenthesized(ref data) => data.span,
+        }
+    }
+}
+
+/// A path like `Foo<'a, T>`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Default)]
+pub struct AngleBracketedParameterData {
+    /// Overall span
+    pub span: Span,
+    /// The lifetime parameters for this path segment.
+    pub lifetimes: Vec<Lifetime>,
+    /// The type parameters for this path segment, if present.
+    pub types: Vec<P<Ty>>,
+    /// Bindings (equality constraints) on associated types, if present.
+    ///
+    /// E.g., `Foo<A=Bar>`.
+    pub bindings: Vec<TypeBinding>,
+}
+
+impl Into<Option<P<PathParameters>>> for AngleBracketedParameterData {
+    fn into(self) -> Option<P<PathParameters>> {
+        Some(P(PathParameters::AngleBracketed(self)))
+    }
+}
+
+impl Into<Option<P<PathParameters>>> for ParenthesizedParameterData {
+    fn into(self) -> Option<P<PathParameters>> {
+        Some(P(PathParameters::Parenthesized(self)))
+    }
+}
+
+/// A path like `Foo(A,B) -> C`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct ParenthesizedParameterData {
+    /// Overall span
+    pub span: Span,
+
+    /// `(A,B)`
+    pub inputs: Vec<P<Ty>>,
+
+    /// `C`
+    pub output: Option<P<Ty>>,
+}
+
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash, Debug)]
+pub struct NodeId(u32);
+
+impl NodeId {
+    pub fn new(x: usize) -> NodeId {
+        assert!(x < (u32::MAX as usize));
+        NodeId(x as u32)
+    }
+
+    pub fn from_u32(x: u32) -> NodeId {
+        NodeId(x)
+    }
+
+    pub fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+
+    pub fn placeholder_from_mark(mark: Mark) -> Self {
+        NodeId(mark.as_u32())
+    }
+
+    pub fn placeholder_to_mark(self) -> Mark {
+        Mark::from_u32(self.0)
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl serialize::UseSpecializedEncodable for NodeId {
+    fn default_encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_u32(self.0)
+    }
+}
+
+impl serialize::UseSpecializedDecodable for NodeId {
+    fn default_decode<D: Decoder>(d: &mut D) -> Result<NodeId, D::Error> {
+        d.read_u32().map(NodeId)
+    }
+}
+
+impl indexed_vec::Idx for NodeId {
+    fn new(idx: usize) -> Self {
+        NodeId::new(idx)
+    }
+
+    fn index(self) -> usize {
+        self.as_usize()
+    }
+}
+
+/// Node id used to represent the root of the crate.
+pub const CRATE_NODE_ID: NodeId = NodeId(0);
+
+/// When parsing and doing expansions, we initially give all AST nodes this AST
+/// node value. Then later, in the renumber pass, we renumber them to have
+/// small, positive ids.
+pub const DUMMY_NODE_ID: NodeId = NodeId(!0);
+
+/// The AST represents all type param bounds as types.
+/// typeck::collect::compute_bounds matches these against
+/// the "special" built-in traits (see middle::lang_items) and
+/// detects Copy, Send and Sync.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum TyParamBound {
+    TraitTyParamBound(PolyTraitRef, TraitBoundModifier),
+    RegionTyParamBound(Lifetime),
+}
+
+/// A modifier on a bound, currently this is only used for `?Sized`, where the
+/// modifier is `Maybe`. Negative bounds should also be handled here.
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum TraitBoundModifier {
+    None,
+    Maybe,
+}
+
+pub type TyParamBounds = Vec<TyParamBound>;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct TyParam {
+    pub attrs: ThinVec<Attribute>,
+    pub ident: Ident,
+    pub id: NodeId,
+    pub bounds: TyParamBounds,
+    pub default: Option<P<Ty>>,
+    pub span: Span,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum GenericParam {
+    Lifetime(LifetimeDef),
+    Type(TyParam),
+}
+
+impl GenericParam {
+    pub fn is_lifetime_param(&self) -> bool {
+        match *self {
+            GenericParam::Lifetime(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_type_param(&self) -> bool {
+        match *self {
+            GenericParam::Type(_) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Represents lifetime, type and const parameters attached to a declaration of
+/// a function, enum, trait, etc.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Generics {
+    pub params: Vec<GenericParam>,
+    pub where_clause: WhereClause,
+    pub span: Span,
+}
+
+impl Generics {
+    pub fn is_lt_parameterized(&self) -> bool {
+        self.params.iter().any(|param| param.is_lifetime_param())
+    }
+
+    pub fn is_type_parameterized(&self) -> bool {
+        self.params.iter().any(|param| param.is_type_param())
+    }
+
+    pub fn is_parameterized(&self) -> bool {
+        !self.params.is_empty()
+    }
+
+    pub fn span_for_name(&self, name: &str) -> Option<Span> {
+        for param in &self.params {
+            if let GenericParam::Type(ref t) = *param {
+                if t.ident.name == name {
+                    return Some(t.span);
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Default for Generics {
+    /// Creates an instance of `Generics`.
+    fn default() -> Generics {
+        Generics {
+            params: Vec::new(),
+            where_clause: WhereClause {
+                id: DUMMY_NODE_ID,
+                predicates: Vec::new(),
+                span: DUMMY_SP,
+            },
+            span: DUMMY_SP,
+        }
+    }
+}
+
+/// A `where` clause in a definition
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct WhereClause {
+    pub id: NodeId,
+    pub predicates: Vec<WherePredicate>,
+    pub span: Span,
+}
+
+/// A single predicate in a `where` clause
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum WherePredicate {
+    /// A type binding, e.g. `for<'c> Foo: Send+Clone+'c`
+    BoundPredicate(WhereBoundPredicate),
+    /// A lifetime predicate, e.g. `'a: 'b+'c`
+    RegionPredicate(WhereRegionPredicate),
+    /// An equality predicate (unsupported)
+    EqPredicate(WhereEqPredicate),
+}
+
+/// A type bound.
+///
+/// E.g. `for<'c> Foo: Send+Clone+'c`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct WhereBoundPredicate {
+    pub span: Span,
+    /// Any generics from a `for` binding
+    pub bound_generic_params: Vec<GenericParam>,
+    /// The type being bounded
+    pub bounded_ty: P<Ty>,
+    /// Trait and lifetime bounds (`Clone+Send+'static`)
+    pub bounds: TyParamBounds,
+}
+
+/// A lifetime predicate.
+///
+/// E.g. `'a: 'b+'c`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct WhereRegionPredicate {
+    pub span: Span,
+    pub lifetime: Lifetime,
+    pub bounds: Vec<Lifetime>,
+}
+
+/// An equality predicate (unsupported).
+///
+/// E.g. `T=int`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct WhereEqPredicate {
+    pub id: NodeId,
+    pub span: Span,
+    pub lhs_ty: P<Ty>,
+    pub rhs_ty: P<Ty>,
+}
+
+/// The set of MetaItems that define the compilation environment of the crate,
+/// used to drive conditional compilation
+pub type CrateConfig = HashSet<(Name, Option<Symbol>)>;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Crate {
+    pub module: Mod,
+    pub attrs: Vec<Attribute>,
+    pub span: Span,
+}
+
+/// A spanned compile-time attribute list item.
+pub type NestedMetaItem = Spanned<NestedMetaItemKind>;
+
+/// Possible values inside of compile-time attribute lists.
+///
+/// E.g. the '..' in `#[name(..)]`.
+#[derive(Clone, Eq, RustcEncodable, RustcDecodable, Hash, Debug, PartialEq)]
+pub enum NestedMetaItemKind {
+    /// A full MetaItem, for recursive meta items.
+    MetaItem(MetaItem),
+    /// A literal.
+    ///
+    /// E.g. "foo", 64, true
+    Literal(Lit),
+}
+
+/// A spanned compile-time attribute item.
+///
+/// E.g. `#[test]`, `#[derive(..)]` or `#[feature = "foo"]`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct MetaItem {
+    pub name: Name,
+    pub node: MetaItemKind,
+    pub span: Span,
+}
+
+/// A compile-time attribute item.
+///
+/// E.g. `#[test]`, `#[derive(..)]` or `#[feature = "foo"]`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum MetaItemKind {
+    /// Word meta item.
+    ///
+    /// E.g. `test` as in `#[test]`
+    Word,
+    /// List meta item.
+    ///
+    /// E.g. `derive(..)` as in `#[derive(..)]`
+    List(Vec<NestedMetaItem>),
+    /// Name value meta item.
+    ///
+    /// E.g. `feature = "foo"` as in `#[feature = "foo"]`
+    NameValue(Lit),
+}
+
+/// A Block (`{ .. }`).
+///
+/// E.g. `{ .. }` as in `fn foo() { .. }`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Block {
+    /// Statements in a block
+    pub stmts: Vec<Stmt>,
+    pub id: NodeId,
+    /// Distinguishes between `unsafe { ... }` and `{ ... }`
+    pub rules: BlockCheckMode,
+    pub span: Span,
+    pub recovered: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub struct Pat {
+    pub id: NodeId,
+    pub node: PatKind,
+    pub span: Span,
+}
+
+impl fmt::Debug for Pat {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "pat({}: {})", self.id, pprust::pat_to_string(self))
+    }
+}
+
+impl Pat {
+    pub(super) fn to_ty(&self) -> Option<P<Ty>> {
+        let node = match &self.node {
+            PatKind::Wild => TyKind::Infer,
+            PatKind::Ident(BindingMode::ByValue(Mutability::Immutable), ident, None) => {
+                TyKind::Path(None, Path::from_ident(ident.span, ident.node))
+            }
+            PatKind::Path(qself, path) => TyKind::Path(qself.clone(), path.clone()),
+            PatKind::Mac(mac) => TyKind::Mac(mac.clone()),
+            PatKind::Ref(pat, mutbl) => pat
+                .to_ty()
+                .map(|ty| TyKind::Rptr(None, MutTy { ty, mutbl: *mutbl }))?,
+            PatKind::Slice(pats, None, _) if pats.len() == 1 => {
+                pats[0].to_ty().map(TyKind::Slice)?
+            }
+            PatKind::Tuple(pats, None) => {
+                let mut tys = Vec::new();
+                for pat in pats {
+                    tys.push(pat.to_ty()?);
+                }
+                TyKind::Tup(tys)
+            }
+            _ => return None,
+        };
+
+        Some(P(Ty {
+            node,
+            id: self.id,
+            span: self.span,
+        }))
+    }
+
+    pub fn walk<F>(&self, it: &mut F) -> bool
+    where
+        F: FnMut(&Pat) -> bool,
+    {
+        if !it(self) {
+            return false;
+        }
+
+        match self.node {
+            PatKind::Ident(_, _, Some(ref p)) => p.walk(it),
+            PatKind::Struct(_, ref fields, _) => fields.iter().all(|field| field.node.pat.walk(it)),
+            PatKind::TupleStruct(_, ref s, _) | PatKind::Tuple(ref s, _) => {
+                s.iter().all(|p| p.walk(it))
+            }
+            PatKind::Box(ref s) | PatKind::Ref(ref s, _) => s.walk(it),
+            PatKind::Slice(ref before, ref slice, ref after) => {
+                before.iter().all(|p| p.walk(it))
+                    && slice.iter().all(|p| p.walk(it))
+                    && after.iter().all(|p| p.walk(it))
+            }
+            PatKind::Wild
+            | PatKind::Lit(_)
+            | PatKind::Range(..)
+            | PatKind::Ident(..)
+            | PatKind::Path(..)
+            | PatKind::Mac(_) => true,
+        }
+    }
+}
+
+/// A single field in a struct pattern
+///
+/// Patterns like the fields of Foo `{ x, ref y, ref mut z }`
+/// are treated the same as` x: x, y: ref y, z: ref mut z`,
+/// except is_shorthand is true
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct FieldPat {
+    /// The identifier for the field
+    pub ident: Ident,
+    /// The pattern the field is destructured to
+    pub pat: P<Pat>,
+    pub is_shorthand: bool,
+    pub attrs: ThinVec<Attribute>,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum BindingMode {
+    ByRef(Mutability),
+    ByValue(Mutability),
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum RangeEnd {
+    Included(RangeSyntax),
+    Excluded,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum RangeSyntax {
+    DotDotDot,
+    DotDotEq,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum PatKind {
+    /// Represents a wildcard pattern (`_`)
+    Wild,
+
+    /// A `PatKind::Ident` may either be a new bound variable (`ref mut binding @ OPT_SUBPATTERN`),
+    /// or a unit struct/variant pattern, or a const pattern (in the last two cases the third
+    /// field must be `None`). Disambiguation cannot be done with parser alone, so it happens
+    /// during name resolution.
+    Ident(BindingMode, SpannedIdent, Option<P<Pat>>),
+
+    /// A struct or struct variant pattern, e.g. `Variant {x, y, ..}`.
+    /// The `bool` is `true` in the presence of a `..`.
+    Struct(Path, Vec<Spanned<FieldPat>>, bool),
+
+    /// A tuple struct/variant pattern `Variant(x, y, .., z)`.
+    /// If the `..` pattern fragment is present, then `Option<usize>` denotes its position.
+    /// 0 <= position <= subpats.len()
+    TupleStruct(Path, Vec<P<Pat>>, Option<usize>),
+
+    /// A possibly qualified path pattern.
+    /// Unqualified path patterns `A::B::C` can legally refer to variants, structs, constants
+    /// or associated constants. Qualified path patterns `<A>::B::C`/`<A as Trait>::B::C` can
+    /// only legally refer to associated constants.
+    Path(Option<QSelf>, Path),
+
+    /// A tuple pattern `(a, b)`.
+    /// If the `..` pattern fragment is present, then `Option<usize>` denotes its position.
+    /// 0 <= position <= subpats.len()
+    Tuple(Vec<P<Pat>>, Option<usize>),
+    /// A `box` pattern
+    Box(P<Pat>),
+    /// A reference pattern, e.g. `&mut (a, b)`
+    Ref(P<Pat>, Mutability),
+    /// A literal
+    Lit(P<Expr>),
+    /// A range pattern, e.g. `1...2`, `1..=2` or `1..2`
+    Range(P<Expr>, P<Expr>, RangeEnd),
+    /// `[a, b, ..i, y, z]` is represented as:
+    ///     `PatKind::Slice(box [a, b], Some(i), box [y, z])`
+    Slice(Vec<P<Pat>>, Option<P<Pat>>, Vec<P<Pat>>),
+    /// A macro pattern; pre-expansion
+    Mac(Mac),
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum Mutability {
+    Mutable,
+    Immutable,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum BinOpKind {
+    /// The `+` operator (addition)
+    Add,
+    /// The `-` operator (subtraction)
+    Sub,
+    /// The `*` operator (multiplication)
+    Mul,
+    /// The `/` operator (division)
+    Div,
+    /// The `%` operator (modulus)
+    Rem,
+    /// The `&&` operator (logical and)
+    And,
+    /// The `||` operator (logical or)
+    Or,
+    /// The `^` operator (bitwise xor)
+    BitXor,
+    /// The `&` operator (bitwise and)
+    BitAnd,
+    /// The `|` operator (bitwise or)
+    BitOr,
+    /// The `<<` operator (shift left)
+    Shl,
+    /// The `>>` operator (shift right)
+    Shr,
+    /// The `==` operator (equality)
+    Eq,
+    /// The `<` operator (less than)
+    Lt,
+    /// The `<=` operator (less than or equal to)
+    Le,
+    /// The `!=` operator (not equal to)
+    Ne,
+    /// The `>=` operator (greater than or equal to)
+    Ge,
+    /// The `>` operator (greater than)
+    Gt,
+}
+
+impl BinOpKind {
+    pub fn to_string(&self) -> &'static str {
+        use self::BinOpKind::*;
+        match *self {
+            Add => "+",
+            Sub => "-",
+            Mul => "*",
+            Div => "/",
+            Rem => "%",
+            And => "&&",
+            Or => "||",
+            BitXor => "^",
+            BitAnd => "&",
+            BitOr => "|",
+            Shl => "<<",
+            Shr => ">>",
+            Eq => "==",
+            Lt => "<",
+            Le => "<=",
+            Ne => "!=",
+            Ge => ">=",
+            Gt => ">",
+        }
+    }
+    pub fn lazy(&self) -> bool {
+        match *self {
+            BinOpKind::And | BinOpKind::Or => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_shift(&self) -> bool {
+        match *self {
+            BinOpKind::Shl | BinOpKind::Shr => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_comparison(&self) -> bool {
+        use self::BinOpKind::*;
+        match *self {
+            Eq | Lt | Le | Ne | Gt | Ge => true,
+            And | Or | Add | Sub | Mul | Div | Rem | BitXor | BitAnd | BitOr | Shl | Shr => false,
+        }
+    }
+
+    /// Returns `true` if the binary operator takes its arguments by value
+    pub fn is_by_value(&self) -> bool {
+        !self.is_comparison()
+    }
+}
+
+pub type BinOp = Spanned<BinOpKind>;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum UnOp {
+    /// The `*` operator for dereferencing
+    Deref,
+    /// The `!` operator for logical inversion
+    Not,
+    /// The `-` operator for negation
+    Neg,
+}
+
+impl UnOp {
+    /// Returns `true` if the unary operator takes its argument by value
+    pub fn is_by_value(u: UnOp) -> bool {
+        match u {
+            UnOp::Neg | UnOp::Not => true,
+            _ => false,
+        }
+    }
+
+    pub fn to_string(op: UnOp) -> &'static str {
+        match op {
+            UnOp::Deref => "*",
+            UnOp::Not => "!",
+            UnOp::Neg => "-",
+        }
+    }
+}
+
+/// A statement
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub struct Stmt {
+    pub id: NodeId,
+    pub node: StmtKind,
+    pub span: Span,
+}
+
+impl Stmt {
+    pub fn add_trailing_semicolon(mut self) -> Self {
+        self.node = match self.node {
+            StmtKind::Expr(expr) => StmtKind::Semi(expr),
+            StmtKind::Mac(mac) => {
+                StmtKind::Mac(mac.map(|(mac, _style, attrs)| (mac, MacStmtStyle::Semicolon, attrs)))
+            }
+            node => node,
+        };
+        self
+    }
+
+    pub fn is_item(&self) -> bool {
+        match self.node {
+            StmtKind::Local(_) => true,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Debug for Stmt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "stmt({}: {})",
+            self.id.to_string(),
+            pprust::stmt_to_string(self)
+        )
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub enum StmtKind {
+    /// A local (let) binding.
+    Local(P<Local>),
+
+    /// An item definition.
+    Item(P<Item>),
+
+    /// Expr without trailing semi-colon.
+    Expr(P<Expr>),
+    /// Expr with a trailing semi-colon.
+    Semi(P<Expr>),
+    /// Macro.
+    Mac(P<(Mac, MacStmtStyle, ThinVec<Attribute>)>),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum MacStmtStyle {
+    /// The macro statement had a trailing semicolon, e.g. `foo! { ... };`
+    /// `foo!(...);`, `foo![...];`
+    Semicolon,
+    /// The macro statement had braces; e.g. foo! { ... }
+    Braces,
+    /// The macro statement had parentheses or brackets and no semicolon; e.g.
+    /// `foo!(...)`. All of these will end up being converted into macro
+    /// expressions.
+    NoBraces,
+}
+
+/// Local represents a `let` statement, e.g., `let <pat>:<ty> = <expr>;`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Local {
+    pub pat: P<Pat>,
+    pub ty: Option<P<Ty>>,
+    /// Initializer expression to set the value, if any
+    pub init: Option<P<Expr>>,
+    pub id: NodeId,
+    pub span: Span,
+    pub attrs: ThinVec<Attribute>,
+}
+
+/// An arm of a 'match'.
+///
+/// E.g. `0...10 => { println!("match!") }` as in
+///
+/// ```
+/// match 123 {
+///     0...10 => { println!("match!") },
+///     _ => { println!("no match!") },
+/// }
+/// ```
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Arm {
+    pub attrs: Vec<Attribute>,
+    pub pats: Vec<P<Pat>>,
+    pub guard: Option<P<Expr>>,
+    pub body: P<Expr>,
+    pub beginning_vert: Option<Span>, // For RFC 1925 feature gate
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Field {
+    pub ident: SpannedIdent,
+    pub expr: P<Expr>,
+    pub span: Span,
+    pub is_shorthand: bool,
+    pub attrs: ThinVec<Attribute>,
+}
+
+pub type SpannedIdent = Spanned<Ident>;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum BlockCheckMode {
+    Default,
+    Unsafe(UnsafeSource),
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum UnsafeSource {
+    CompilerGenerated,
+    UserProvided,
+}
+
+/// An expression
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub struct Expr {
+    pub id: NodeId,
+    pub node: ExprKind,
+    pub span: Span,
+    pub attrs: ThinVec<Attribute>,
+}
+
+impl Expr {
+    /// Wether this expression would be valid somewhere that expects a value, for example, an `if`
+    /// condition.
+    pub fn returns(&self) -> bool {
+        if let ExprKind::Block(ref block) = self.node {
+            match block.stmts.last().map(|last_stmt| &last_stmt.node) {
+                // implicit return
+                Some(&StmtKind::Expr(_)) => true,
+                Some(&StmtKind::Semi(ref expr)) => {
+                    if let ExprKind::Ret(_) = expr.node {
+                        // last statement is explicit return
+                        true
+                    } else {
+                        false
+                    }
+                }
+                // This is a block that doesn't end in either an implicit or explicit return
+                _ => false,
+            }
+        } else {
+            // This is not a block, it is a value
+            true
+        }
+    }
+
+    fn to_bound(&self) -> Option<TyParamBound> {
+        match &self.node {
+            ExprKind::Path(None, path) => Some(TraitTyParamBound(
+                PolyTraitRef::new(Vec::new(), path.clone(), self.span),
+                TraitBoundModifier::None,
+            )),
+            _ => None,
+        }
+    }
+
+    pub(super) fn to_ty(&self) -> Option<P<Ty>> {
+        let node = match &self.node {
+            ExprKind::Path(qself, path) => TyKind::Path(qself.clone(), path.clone()),
+            ExprKind::Mac(mac) => TyKind::Mac(mac.clone()),
+            ExprKind::Paren(expr) => expr.to_ty().map(TyKind::Paren)?,
+            ExprKind::AddrOf(mutbl, expr) => expr
+                .to_ty()
+                .map(|ty| TyKind::Rptr(None, MutTy { ty, mutbl: *mutbl }))?,
+            ExprKind::Repeat(expr, expr_len) => {
+                expr.to_ty().map(|ty| TyKind::Array(ty, expr_len.clone()))?
+            }
+            ExprKind::Array(exprs) if exprs.len() == 1 => exprs[0].to_ty().map(TyKind::Slice)?,
+            ExprKind::Tup(exprs) => {
+                let mut tys = Vec::new();
+                for expr in exprs {
+                    tys.push(expr.to_ty()?);
+                }
+                TyKind::Tup(tys)
+            }
+            ExprKind::Binary(binop, lhs, rhs) if binop.node == BinOpKind::Add => {
+                if let (Some(lhs), Some(rhs)) = (lhs.to_bound(), rhs.to_bound()) {
+                    TyKind::TraitObject(vec![lhs, rhs], TraitObjectSyntax::None)
+                } else {
+                    return None;
+                }
+            }
+            _ => return None,
+        };
+
+        Some(P(Ty {
+            node,
+            id: self.id,
+            span: self.span,
+        }))
+    }
+
+    pub fn precedence(&self) -> ExprPrecedence {
+        match self.node {
+            ExprKind::Box(_) => ExprPrecedence::Box,
+            ExprKind::InPlace(..) => ExprPrecedence::InPlace,
+            ExprKind::Array(_) => ExprPrecedence::Array,
+            ExprKind::Call(..) => ExprPrecedence::Call,
+            ExprKind::MethodCall(..) => ExprPrecedence::MethodCall,
+            ExprKind::Tup(_) => ExprPrecedence::Tup,
+            ExprKind::Binary(op, ..) => ExprPrecedence::Binary(op.node),
+            ExprKind::Unary(..) => ExprPrecedence::Unary,
+            ExprKind::Lit(_) => ExprPrecedence::Lit,
+            ExprKind::Type(..) | ExprKind::Cast(..) => ExprPrecedence::Cast,
+            ExprKind::If(..) => ExprPrecedence::If,
+            ExprKind::IfLet(..) => ExprPrecedence::IfLet,
+            ExprKind::While(..) => ExprPrecedence::While,
+            ExprKind::WhileLet(..) => ExprPrecedence::WhileLet,
+            ExprKind::ForLoop(..) => ExprPrecedence::ForLoop,
+            ExprKind::Loop(..) => ExprPrecedence::Loop,
+            ExprKind::Match(..) => ExprPrecedence::Match,
+            ExprKind::Closure(..) => ExprPrecedence::Closure,
+            ExprKind::Block(..) => ExprPrecedence::Block,
+            ExprKind::Catch(..) => ExprPrecedence::Catch,
+            ExprKind::Assign(..) => ExprPrecedence::Assign,
+            ExprKind::AssignOp(..) => ExprPrecedence::AssignOp,
+            ExprKind::Field(..) => ExprPrecedence::Field,
+            ExprKind::TupField(..) => ExprPrecedence::TupField,
+            ExprKind::Index(..) => ExprPrecedence::Index,
+            ExprKind::Range(..) => ExprPrecedence::Range,
+            ExprKind::Path(..) => ExprPrecedence::Path,
+            ExprKind::AddrOf(..) => ExprPrecedence::AddrOf,
+            ExprKind::Break(..) => ExprPrecedence::Break,
+            ExprKind::Continue(..) => ExprPrecedence::Continue,
+            ExprKind::Ret(..) => ExprPrecedence::Ret,
+            ExprKind::InlineAsm(..) => ExprPrecedence::InlineAsm,
+            ExprKind::Mac(..) => ExprPrecedence::Mac,
+            ExprKind::Struct(..) => ExprPrecedence::Struct,
+            ExprKind::Repeat(..) => ExprPrecedence::Repeat,
+            ExprKind::Paren(..) => ExprPrecedence::Paren,
+            ExprKind::Try(..) => ExprPrecedence::Try,
+            ExprKind::Yield(..) => ExprPrecedence::Yield,
+        }
+    }
+}
+
+impl fmt::Debug for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "expr({}: {})", self.id, pprust::expr_to_string(self))
+    }
+}
+
+/// Limit types of a range (inclusive or exclusive)
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum RangeLimits {
+    /// Inclusive at the beginning, exclusive at the end
+    HalfOpen,
+    /// Inclusive at the beginning and end
+    Closed,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum ExprKind {
+    /// A `box x` expression.
+    Box(P<Expr>),
+    /// First expr is the place; second expr is the value.
+    InPlace(P<Expr>, P<Expr>),
+    /// An array (`[a, b, c, d]`)
+    Array(Vec<P<Expr>>),
+    /// A function call
+    ///
+    /// The first field resolves to the function itself,
+    /// and the second field is the list of arguments.
+    /// This also represents calling the constructor of
+    /// tuple-like ADTs such as tuple structs and enum variants.
+    Call(P<Expr>, Vec<P<Expr>>),
+    /// A method call (`x.foo::<'static, Bar, Baz>(a, b, c, d)`)
+    ///
+    /// The `PathSegment` represents the method name and its generic arguments
+    /// (within the angle brackets).
+    /// The first element of the vector of `Expr`s is the expression that evaluates
+    /// to the object on which the method is being called on (the receiver),
+    /// and the remaining elements are the rest of the arguments.
+    /// Thus, `x.foo::<Bar, Baz>(a, b, c, d)` is represented as
+    /// `ExprKind::MethodCall(PathSegment { foo, [Bar, Baz] }, [x, a, b, c, d])`.
+    MethodCall(PathSegment, Vec<P<Expr>>),
+    /// A tuple (`(a, b, c ,d)`)
+    Tup(Vec<P<Expr>>),
+    /// A binary operation (For example: `a + b`, `a * b`)
+    Binary(BinOp, P<Expr>, P<Expr>),
+    /// A unary operation (For example: `!x`, `*x`)
+    Unary(UnOp, P<Expr>),
+    /// A literal (For example: `1`, `"foo"`)
+    Lit(P<Lit>),
+    /// A cast (`foo as f64`)
+    Cast(P<Expr>, P<Ty>),
+    Type(P<Expr>, P<Ty>),
+    /// An `if` block, with an optional else block
+    ///
+    /// `if expr { block } else { expr }`
+    If(P<Expr>, P<Block>, Option<P<Expr>>),
+    /// An `if let` expression with an optional else block
+    ///
+    /// `if let pat = expr { block } else { expr }`
+    ///
+    /// This is desugared to a `match` expression.
+    IfLet(P<Pat>, P<Expr>, P<Block>, Option<P<Expr>>),
+    /// A while loop, with an optional label
+    ///
+    /// `'label: while expr { block }`
+    While(P<Expr>, P<Block>, Option<SpannedIdent>),
+    /// A while-let loop, with an optional label
+    ///
+    /// `'label: while let pat = expr { block }`
+    ///
+    /// This is desugared to a combination of `loop` and `match` expressions.
+    WhileLet(P<Pat>, P<Expr>, P<Block>, Option<SpannedIdent>),
+    /// A for loop, with an optional label
+    ///
+    /// `'label: for pat in expr { block }`
+    ///
+    /// This is desugared to a combination of `loop` and `match` expressions.
+    ForLoop(P<Pat>, P<Expr>, P<Block>, Option<SpannedIdent>),
+    /// Conditionless loop (can be exited with break, continue, or return)
+    ///
+    /// `'label: loop { block }`
+    Loop(P<Block>, Option<SpannedIdent>),
+    /// A `match` block.
+    Match(P<Expr>, Vec<Arm>),
+    /// A closure (for example, `move |a, b, c| a + b + c`)
+    ///
+    /// The final span is the span of the argument block `|...|`
+    Closure(CaptureBy, P<FnDecl>, P<Expr>, Span),
+    /// A block (`{ ... }`)
+    Block(P<Block>),
+    /// A catch block (`catch { ... }`)
+    Catch(P<Block>),
+
+    /// An assignment (`a = foo()`)
+    Assign(P<Expr>, P<Expr>),
+    /// An assignment with an operator
+    ///
+    /// For example, `a += 1`.
+    AssignOp(BinOp, P<Expr>, P<Expr>),
+    /// Access of a named struct field (`obj.foo`)
+    Field(P<Expr>, SpannedIdent),
+    /// Access of an unnamed field of a struct or tuple-struct
+    ///
+    /// For example, `foo.0`.
+    TupField(P<Expr>, Spanned<usize>),
+    /// An indexing operation (`foo[2]`)
+    Index(P<Expr>, P<Expr>),
+    /// A range (`1..2`, `1..`, `..2`, `1...2`, `1...`, `...2`)
+    Range(Option<P<Expr>>, Option<P<Expr>>, RangeLimits),
+
+    /// Variable reference, possibly containing `::` and/or type
+    /// parameters, e.g. foo::bar::<baz>.
+    ///
+    /// Optionally "qualified",
+    /// E.g. `<Vec<T> as SomeTrait>::SomeType`.
+    Path(Option<QSelf>, Path),
+
+    /// A referencing operation (`&a` or `&mut a`)
+    AddrOf(Mutability, P<Expr>),
+    /// A `break`, with an optional label to break, and an optional expression
+    Break(Option<SpannedIdent>, Option<P<Expr>>),
+    /// A `continue`, with an optional label
+    Continue(Option<SpannedIdent>),
+    /// A `return`, with an optional value to be returned
+    Ret(Option<P<Expr>>),
+
+    /// Output of the `asm!()` macro
+    InlineAsm(P<InlineAsm>),
+
+    /// A macro invocation; pre-expansion
+    Mac(Mac),
+
+    /// A struct literal expression.
+    ///
+    /// For example, `Foo {x: 1, y: 2}`, or
+    /// `Foo {x: 1, .. base}`, where `base` is the `Option<Expr>`.
+    Struct(Path, Vec<Field>, Option<P<Expr>>),
+
+    /// An array literal constructed from one repeated element.
+    ///
+    /// For example, `[1; 5]`. The first expression is the element
+    /// to be repeated; the second is the number of times to repeat it.
+    Repeat(P<Expr>, P<Expr>),
+
+    /// No-op: used solely so we can pretty-print faithfully
+    Paren(P<Expr>),
+
+    /// `expr?`
+    Try(P<Expr>),
+
+    /// A `yield`, with an optional value to be yielded
+    Yield(Option<P<Expr>>),
+}
+
+/// The explicit Self type in a "qualified path". The actual
+/// path, including the trait and the associated item, is stored
+/// separately. `position` represents the index of the associated
+/// item qualified with this Self type.
+///
+/// ```ignore (only-for-syntax-highlight)
+/// <Vec<T> as a::b::Trait>::AssociatedItem
+///  ^~~~~     ~~~~~~~~~~~~~~^
+///  ty        position = 3
+///
+/// <Vec<T>>::AssociatedItem
+///  ^~~~~    ^
+///  ty       position = 0
+/// ```
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct QSelf {
+    pub ty: P<Ty>,
+    pub position: usize,
+}
+
+/// A capture clause
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum CaptureBy {
+    Value,
+    Ref,
+}
+
+pub type Mac = Spanned<Mac_>;
+
+/// Represents a macro invocation. The Path indicates which macro
+/// is being invoked, and the vector of token-trees contains the source
+/// of the macro invocation.
+///
+/// NB: the additional ident for a macro_rules-style macro is actually
+/// stored in the enclosing item. Oog.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Mac_ {
+    pub path: Path,
+    pub tts: ThinTokenStream,
+}
+
+impl Mac_ {
+    pub fn stream(&self) -> TokenStream {
+        self.tts.clone().into()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct MacroDef {
+    pub tokens: ThinTokenStream,
+    pub legacy: bool,
+}
+
+impl MacroDef {
+    pub fn stream(&self) -> TokenStream {
+        self.tokens.clone().into()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum StrStyle {
+    /// A regular string, like `"foo"`
+    Cooked,
+    /// A raw string, like `r##"foo"##`
+    ///
+    /// The uint is the number of `#` symbols used
+    Raw(usize),
+}
+
+/// A literal
+pub type Lit = Spanned<LitKind>;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum LitIntType {
+    Signed(IntTy),
+    Unsigned(UintTy),
+    Unsuffixed,
+}
+
+/// Literal kind.
+///
+/// E.g. `"foo"`, `42`, `12.34` or `bool`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum LitKind {
+    /// A string literal (`"foo"`)
+    Str(Symbol, StrStyle),
+    /// A byte string (`b"foo"`)
+    ByteStr(Rc<Vec<u8>>),
+    /// A byte char (`b'f'`)
+    Byte(u8),
+    /// A character literal (`'a'`)
+    Char(char),
+    /// An integer literal (`1`)
+    Int(u128, LitIntType),
+    /// A float literal (`1f64` or `1E10f64`)
+    Float(Symbol, FloatTy),
+    /// A float literal without a suffix (`1.0 or 1.0E10`)
+    FloatUnsuffixed(Symbol),
+    /// A boolean literal
+    Bool(bool),
+}
+
+impl LitKind {
+    /// Returns true if this literal is a string and false otherwise.
+    pub fn is_str(&self) -> bool {
+        match *self {
+            LitKind::Str(..) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if this literal has no suffix. Note: this will return true
+    /// for literals with prefixes such as raw strings and byte strings.
+    pub fn is_unsuffixed(&self) -> bool {
+        match *self {
+            // unsuffixed variants
+            LitKind::Str(..)
+            | LitKind::ByteStr(..)
+            | LitKind::Byte(..)
+            | LitKind::Char(..)
+            | LitKind::Int(_, LitIntType::Unsuffixed)
+            | LitKind::FloatUnsuffixed(..)
+            | LitKind::Bool(..) => true,
+            // suffixed variants
+            LitKind::Int(_, LitIntType::Signed(..))
+            | LitKind::Int(_, LitIntType::Unsigned(..))
+            | LitKind::Float(..) => false,
+        }
+    }
+
+    /// Returns true if this literal has a suffix.
+    pub fn is_suffixed(&self) -> bool {
+        !self.is_unsuffixed()
+    }
+}
+
+// NB: If you change this, you'll probably want to change the corresponding
+// type structure in middle/ty.rs as well.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct MutTy {
+    pub ty: P<Ty>,
+    pub mutbl: Mutability,
+}
+
+/// Represents a method's signature in a trait declaration,
+/// or in an implementation.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct MethodSig {
+    pub unsafety: Unsafety,
+    pub constness: Spanned<Constness>,
+    pub abi: Abi,
+    pub decl: P<FnDecl>,
+}
+
+/// Represents an item declaration within a trait declaration,
+/// possibly including a default implementation. A trait item is
+/// either required (meaning it doesn't have an implementation, just a
+/// signature) or provided (meaning it has a default implementation).
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct TraitItem {
+    pub id: NodeId,
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub generics: Generics,
+    pub node: TraitItemKind,
+    pub span: Span,
+    /// See `Item::tokens` for what this is
+    pub tokens: Option<TokenStream>,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum TraitItemKind {
+    Const(P<Ty>, Option<P<Expr>>),
+    Method(MethodSig, Option<P<Block>>),
+    Type(TyParamBounds, Option<P<Ty>>),
+    Macro(Mac),
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct ImplItem {
+    pub id: NodeId,
+    pub ident: Ident,
+    pub vis: Visibility,
+    pub defaultness: Defaultness,
+    pub attrs: Vec<Attribute>,
+    pub generics: Generics,
+    pub node: ImplItemKind,
+    pub span: Span,
+    /// See `Item::tokens` for what this is
+    pub tokens: Option<TokenStream>,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum ImplItemKind {
+    Const(P<Ty>, P<Expr>),
+    Method(MethodSig, P<Block>),
+    Type(P<Ty>),
+    Macro(Mac),
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy, PartialOrd, Ord)]
+pub enum IntTy {
+    Isize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+}
+
+impl fmt::Debug for IntTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for IntTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ty_to_string())
+    }
+}
+
+impl IntTy {
+    pub fn ty_to_string(&self) -> &'static str {
+        match *self {
+            IntTy::Isize => "isize",
+            IntTy::I8 => "i8",
+            IntTy::I16 => "i16",
+            IntTy::I32 => "i32",
+            IntTy::I64 => "i64",
+            IntTy::I128 => "i128",
+        }
+    }
+
+    pub fn val_to_string(&self, val: i128) -> String {
+        // cast to a u128 so we can correctly print INT128_MIN. All integral types
+        // are parsed as u128, so we wouldn't want to print an extra negative
+        // sign.
+        format!("{}{}", val as u128, self.ty_to_string())
+    }
+
+    pub fn bit_width(&self) -> Option<usize> {
+        Some(match *self {
+            IntTy::Isize => return None,
+            IntTy::I8 => 8,
+            IntTy::I16 => 16,
+            IntTy::I32 => 32,
+            IntTy::I64 => 64,
+            IntTy::I128 => 128,
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy, PartialOrd, Ord)]
+pub enum UintTy {
+    Usize,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+}
+
+impl UintTy {
+    pub fn ty_to_string(&self) -> &'static str {
+        match *self {
+            UintTy::Usize => "usize",
+            UintTy::U8 => "u8",
+            UintTy::U16 => "u16",
+            UintTy::U32 => "u32",
+            UintTy::U64 => "u64",
+            UintTy::U128 => "u128",
+        }
+    }
+
+    pub fn val_to_string(&self, val: u128) -> String {
+        format!("{}{}", val, self.ty_to_string())
+    }
+
+    pub fn bit_width(&self) -> Option<usize> {
+        Some(match *self {
+            UintTy::Usize => return None,
+            UintTy::U8 => 8,
+            UintTy::U16 => 16,
+            UintTy::U32 => 32,
+            UintTy::U64 => 64,
+            UintTy::U128 => 128,
+        })
+    }
+}
+
+impl fmt::Debug for UintTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for UintTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ty_to_string())
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Copy, PartialOrd, Ord)]
+pub enum FloatTy {
+    F32,
+    F64,
+}
+
+impl fmt::Debug for FloatTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for FloatTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ty_to_string())
+    }
+}
+
+impl FloatTy {
+    pub fn ty_to_string(&self) -> &'static str {
+        match *self {
+            FloatTy::F32 => "f32",
+            FloatTy::F64 => "f64",
+        }
+    }
+
+    pub fn bit_width(&self) -> usize {
+        match *self {
+            FloatTy::F32 => 32,
+            FloatTy::F64 => 64,
+        }
+    }
+}
+
+// Bind a type to an associated type: `A=Foo`.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct TypeBinding {
+    pub id: NodeId,
+    pub ident: Ident,
+    pub ty: P<Ty>,
+    pub span: Span,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub struct Ty {
+    pub id: NodeId,
+    pub node: TyKind,
+    pub span: Span,
+}
+
+impl fmt::Debug for Ty {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "type({})", pprust::ty_to_string(self))
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct BareFnTy {
+    pub unsafety: Unsafety,
+    pub abi: Abi,
+    pub generic_params: Vec<GenericParam>,
+    pub decl: P<FnDecl>,
+}
+
+/// The different kinds of types recognized by the compiler
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum TyKind {
+    /// A variable-length slice (`[T]`)
+    Slice(P<Ty>),
+    /// A fixed length array (`[T; n]`)
+    Array(P<Ty>, P<Expr>),
+    /// A raw pointer (`*const T` or `*mut T`)
+    Ptr(MutTy),
+    /// A reference (`&'a T` or `&'a mut T`)
+    Rptr(Option<Lifetime>, MutTy),
+    /// A bare function (e.g. `fn(usize) -> bool`)
+    BareFn(P<BareFnTy>),
+    /// The never type (`!`)
+    Never,
+    /// A tuple (`(A, B, C, D,...)`)
+    Tup(Vec<P<Ty>>),
+    /// A path (`module::module::...::Type`), optionally
+    /// "qualified", e.g. `<Vec<T> as SomeTrait>::SomeType`.
+    ///
+    /// Type parameters are stored in the Path itself
+    Path(Option<QSelf>, Path),
+    /// A trait object type `Bound1 + Bound2 + Bound3`
+    /// where `Bound` is a trait or a lifetime.
+    TraitObject(TyParamBounds, TraitObjectSyntax),
+    /// An `impl Bound1 + Bound2 + Bound3` type
+    /// where `Bound` is a trait or a lifetime.
+    ImplTrait(TyParamBounds),
+    /// No-op; kept solely so that we can pretty-print faithfully
+    Paren(P<Ty>),
+    /// Unused for now
+    Typeof(P<Expr>),
+    /// TyKind::Infer means the type should be inferred instead of it having been
+    /// specified. This can appear anywhere in a type.
+    Infer,
+    /// Inferred type of a `self` or `&self` argument in a method.
+    ImplicitSelf,
+    // A macro in the type position.
+    Mac(Mac),
+    /// Placeholder for a kind that has failed to be defined.
+    Err,
+}
+
+/// Syntax used to declare a trait object.
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum TraitObjectSyntax {
+    Dyn,
+    None,
+}
+
+/// Inline assembly dialect.
+///
+/// E.g. `"intel"` as in `asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum AsmDialect {
+    Att,
+    Intel,
+}
+
+/// Inline assembly.
+///
+/// E.g. `"={eax}"(result)` as in `asm!("mov eax, 2" : "={eax}"(result) : : : "intel")`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct InlineAsmOutput {
+    pub constraint: Symbol,
+    pub expr: P<Expr>,
+    pub is_rw: bool,
+    pub is_indirect: bool,
+}
+
+/// Inline assembly.
+///
+/// E.g. `asm!("NOP");`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct InlineAsm {
+    pub asm: Symbol,
+    pub asm_str_style: StrStyle,
+    pub outputs: Vec<InlineAsmOutput>,
+    pub inputs: Vec<(Symbol, P<Expr>)>,
+    pub clobbers: Vec<Symbol>,
+    pub volatile: bool,
+    pub alignstack: bool,
+    pub dialect: AsmDialect,
+    pub ctxt: SyntaxContext,
+}
+
+/// An argument in a function header.
+///
+/// E.g. `bar: usize` as in `fn foo(bar: usize)`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Arg {
+    pub ty: P<Ty>,
+    pub pat: P<Pat>,
+    pub id: NodeId,
+}
+
+/// Alternative representation for `Arg`s describing `self` parameter of methods.
+///
+/// E.g. `&mut self` as in `fn foo(&mut self)`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum SelfKind {
+    /// `self`, `mut self`
+    Value(Mutability),
+    /// `&'lt self`, `&'lt mut self`
+    Region(Option<Lifetime>, Mutability),
+    /// `self: TYPE`, `mut self: TYPE`
+    Explicit(P<Ty>, Mutability),
+}
+
+pub type ExplicitSelf = Spanned<SelfKind>;
+
+impl Arg {
+    pub fn to_self(&self) -> Option<ExplicitSelf> {
+        if let PatKind::Ident(BindingMode::ByValue(mutbl), ident, _) = self.pat.node {
+            if ident.node.name == keywords::SelfValue.name() {
+                return match self.ty.node {
+                    TyKind::ImplicitSelf => Some(respan(self.pat.span, SelfKind::Value(mutbl))),
+                    TyKind::Rptr(lt, MutTy { ref ty, mutbl })
+                        if ty.node == TyKind::ImplicitSelf =>
+                    {
+                        Some(respan(self.pat.span, SelfKind::Region(lt, mutbl)))
+                    }
+                    _ => Some(respan(
+                        self.pat.span.to(self.ty.span),
+                        SelfKind::Explicit(self.ty.clone(), mutbl),
+                    )),
+                };
+            }
+        }
+        None
+    }
+
+    pub fn is_self(&self) -> bool {
+        if let PatKind::Ident(_, ident, _) = self.pat.node {
+            ident.node.name == keywords::SelfValue.name()
+        } else {
+            false
+        }
+    }
+
+    pub fn from_self(eself: ExplicitSelf, eself_ident: SpannedIdent) -> Arg {
+        let span = eself.span.to(eself_ident.span);
+        let infer_ty = P(Ty {
+            id: DUMMY_NODE_ID,
+            node: TyKind::ImplicitSelf,
+            span,
+        });
+        let arg = |mutbl, ty| Arg {
+            pat: P(Pat {
+                id: DUMMY_NODE_ID,
+                node: PatKind::Ident(BindingMode::ByValue(mutbl), eself_ident, None),
+                span,
+            }),
+            ty,
+            id: DUMMY_NODE_ID,
+        };
+        match eself.node {
+            SelfKind::Explicit(ty, mutbl) => arg(mutbl, ty),
+            SelfKind::Value(mutbl) => arg(mutbl, infer_ty),
+            SelfKind::Region(lt, mutbl) => arg(
+                Mutability::Immutable,
+                P(Ty {
+                    id: DUMMY_NODE_ID,
+                    node: TyKind::Rptr(
+                        lt,
+                        MutTy {
+                            ty: infer_ty,
+                            mutbl: mutbl,
+                        },
+                    ),
+                    span,
+                }),
+            ),
+        }
+    }
+}
+
+/// Header (not the body) of a function declaration.
+///
+/// E.g. `fn foo(bar: baz)`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct FnDecl {
+    pub inputs: Vec<Arg>,
+    pub output: FunctionRetTy,
+    pub variadic: bool,
+}
+
+impl FnDecl {
+    pub fn get_self(&self) -> Option<ExplicitSelf> {
+        self.inputs.get(0).and_then(Arg::to_self)
+    }
+    pub fn has_self(&self) -> bool {
+        self.inputs.get(0).map(Arg::is_self).unwrap_or(false)
+    }
+}
+
+/// Is the trait definition an auto trait?
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum IsAuto {
+    Yes,
+    No,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum Unsafety {
+    Unsafe,
+    Normal,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum Constness {
+    Const,
+    NotConst,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum Defaultness {
+    Default,
+    Final,
+}
+
+impl fmt::Display for Unsafety {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(
+            match *self {
+                Unsafety::Normal => "normal",
+                Unsafety::Unsafe => "unsafe",
+            },
+            f,
+        )
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash)]
+pub enum ImplPolarity {
+    /// `impl Trait for Type`
+    Positive,
+    /// `impl !Trait for Type`
+    Negative,
+}
+
+impl fmt::Debug for ImplPolarity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ImplPolarity::Positive => "positive".fmt(f),
+            ImplPolarity::Negative => "negative".fmt(f),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum FunctionRetTy {
+    /// Return type is not specified.
+    ///
+    /// Functions default to `()` and
+    /// closures default to inference. Span points to where return
+    /// type would be inserted.
+    Default(Span),
+    /// Everything else
+    Ty(P<Ty>),
+}
+
+impl FunctionRetTy {
+    pub fn span(&self) -> Span {
+        match *self {
+            FunctionRetTy::Default(span) => span,
+            FunctionRetTy::Ty(ref ty) => ty.span,
+        }
+    }
+}
+
+/// Module declaration.
+///
+/// E.g. `mod foo;` or `mod foo { .. }`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Mod {
+    /// A span from the first token past `{` to the last token until `}`.
+    /// For `mod foo;`, the inner span ranges from the first token
+    /// to the last token in the external file.
+    pub inner: Span,
+    pub items: Vec<P<Item>>,
+}
+
+/// Foreign module declaration.
+///
+/// E.g. `extern { .. }` or `extern C { .. }`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct ForeignMod {
+    pub abi: Abi,
+    pub items: Vec<ForeignItem>,
+}
+
+/// Global inline assembly
+///
+/// aka module-level assembly or file-scoped assembly
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub struct GlobalAsm {
+    pub asm: Symbol,
+    pub ctxt: SyntaxContext,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct EnumDef {
+    pub variants: Vec<Variant>,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Variant_ {
+    pub name: Ident,
+    pub attrs: Vec<Attribute>,
+    pub data: VariantData,
+    /// Explicit discriminant, e.g. `Foo = 1`
+    pub disr_expr: Option<P<Expr>>,
+}
+
+pub type Variant = Spanned<Variant_>;
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum UseTreeKind {
+    Simple(Ident),
+    Glob,
+    Nested(Vec<(UseTree, NodeId)>),
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct UseTree {
+    pub kind: UseTreeKind,
+    pub prefix: Path,
+    pub span: Span,
+}
+
+/// Distinguishes between Attributes that decorate items and Attributes that
+/// are contained as statements within items. These two cases need to be
+/// distinguished for pretty-printing.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum AttrStyle {
+    Outer,
+    Inner,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub struct AttrId(pub usize);
+
+/// Meta-data associated with an item
+/// Doc-comments are promoted to attributes that have is_sugared_doc = true
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Attribute {
+    pub id: AttrId,
+    pub style: AttrStyle,
+    pub path: Path,
+    pub tokens: TokenStream,
+    pub is_sugared_doc: bool,
+    pub span: Span,
+}
+
+/// TraitRef's appear in impls.
+///
+/// resolve maps each TraitRef's ref_id to its defining trait; that's all
+/// that the ref_id is for. The impl_id maps to the "self type" of this impl.
+/// If this impl is an ItemKind::Impl, the impl_id is redundant (it could be the
+/// same as the impl's node id).
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct TraitRef {
+    pub path: Path,
+    pub ref_id: NodeId,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct PolyTraitRef {
+    /// The `'a` in `<'a> Foo<&'a T>`
+    pub bound_generic_params: Vec<GenericParam>,
+
+    /// The `Foo<&'a T>` in `<'a> Foo<&'a T>`
+    pub trait_ref: TraitRef,
+
+    pub span: Span,
+}
+
+impl PolyTraitRef {
+    pub fn new(generic_params: Vec<GenericParam>, path: Path, span: Span) -> Self {
+        PolyTraitRef {
+            bound_generic_params: generic_params,
+            trait_ref: TraitRef {
+                path: path,
+                ref_id: DUMMY_NODE_ID,
+            },
+            span,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum CrateSugar {
+    /// Source is `pub(crate)`
+    PubCrate,
+
+    /// Source is (just) `crate`
+    JustCrate,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum Visibility {
+    Public,
+    Crate(Span, CrateSugar),
+    Restricted { path: P<Path>, id: NodeId },
+    Inherited,
+}
+
+/// Field of a struct.
+///
+/// E.g. `bar: usize` as in `struct Foo { bar: usize }`
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct StructField {
+    pub span: Span,
+    pub ident: Option<Ident>,
+    pub vis: Visibility,
+    pub id: NodeId,
+    pub ty: P<Ty>,
+    pub attrs: Vec<Attribute>,
+}
+
+/// Fields and Ids of enum variants and structs
+///
+/// For enum variants: `NodeId` represents both an Id of the variant itself (relevant for all
+/// variant kinds) and an Id of the variant's constructor (not relevant for `Struct`-variants).
+/// One shared Id can be successfully used for these two purposes.
+/// Id of the whole enum lives in `Item`.
+///
+/// For structs: `NodeId` represents an Id of the structure's constructor, so it is not actually
+/// used for `Struct`-structs (but still presents). Structures don't have an analogue of "Id of
+/// the variant itself" from enum variants.
+/// Id of the whole struct lives in `Item`.
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum VariantData {
+    /// Struct variant.
+    ///
+    /// E.g. `Bar { .. }` as in `enum Foo { Bar { .. } }`
+    Struct(Vec<StructField>, NodeId),
+    /// Tuple variant.
+    ///
+    /// E.g. `Bar(..)` as in `enum Foo { Bar(..) }`
+    Tuple(Vec<StructField>, NodeId),
+    /// Unit variant.
+    ///
+    /// E.g. `Bar = ..` as in `enum Foo { Bar = .. }`
+    Unit(NodeId),
+}
+
+impl VariantData {
+    pub fn fields(&self) -> &[StructField] {
+        match *self {
+            VariantData::Struct(ref fields, _) | VariantData::Tuple(ref fields, _) => fields,
+            _ => &[],
+        }
+    }
+    pub fn id(&self) -> NodeId {
+        match *self {
+            VariantData::Struct(_, id) | VariantData::Tuple(_, id) | VariantData::Unit(id) => id,
+        }
+    }
+    pub fn is_struct(&self) -> bool {
+        if let VariantData::Struct(..) = *self {
+            true
+        } else {
+            false
+        }
+    }
+    pub fn is_tuple(&self) -> bool {
+        if let VariantData::Tuple(..) = *self {
+            true
+        } else {
+            false
+        }
+    }
+    pub fn is_unit(&self) -> bool {
+        if let VariantData::Unit(..) = *self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// An item
+///
+/// The name might be a dummy name in case of anonymous items
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct Item {
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub id: NodeId,
+    pub node: ItemKind,
+    pub vis: Visibility,
+    pub span: Span,
+
+    /// Original tokens this item was parsed from. This isn't necessarily
+    /// available for all items, although over time more and more items should
+    /// have this be `Some`. Right now this is primarily used for procedural
+    /// macros, notably custom attributes.
+    ///
+    /// Note that the tokens here do not include the outer attributes, but will
+    /// include inner attributes.
+    pub tokens: Option<TokenStream>,
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum ItemKind {
+    /// An `extern crate` item, with optional original crate name.
+    ///
+    /// E.g. `extern crate foo` or `extern crate foo_bar as foo`
+    ExternCrate(Option<Name>),
+    /// A use declaration (`use` or `pub use`) item.
+    ///
+    /// E.g. `use foo;`, `use foo::bar;` or `use foo::bar as FooBar;`
+    Use(P<UseTree>),
+    /// A static item (`static` or `pub static`).
+    ///
+    /// E.g. `static FOO: i32 = 42;` or `static FOO: &'static str = "bar";`
+    Static(P<Ty>, Mutability, P<Expr>),
+    /// A constant item (`const` or `pub const`).
+    ///
+    /// E.g. `const FOO: i32 = 42;`
+    Const(P<Ty>, P<Expr>),
+    /// A function declaration (`fn` or `pub fn`).
+    ///
+    /// E.g. `fn foo(bar: usize) -> usize { .. }`
+    Fn(
+        P<FnDecl>,
+        Unsafety,
+        Spanned<Constness>,
+        Abi,
+        Generics,
+        P<Block>,
+    ),
+    /// A module declaration (`mod` or `pub mod`).
+    ///
+    /// E.g. `mod foo;` or `mod foo { .. }`
+    Mod(Mod),
+    /// An external module (`extern` or `pub extern`).
+    ///
+    /// E.g. `extern {}` or `extern "C" {}`
+    ForeignMod(ForeignMod),
+    /// Module-level inline assembly (from `global_asm!()`)
+    GlobalAsm(P<GlobalAsm>),
+    /// A type alias (`type` or `pub type`).
+    ///
+    /// E.g. `type Foo = Bar<u8>;`
+    Ty(P<Ty>, Generics),
+    /// An enum definition (`enum` or `pub enum`).
+    ///
+    /// E.g. `enum Foo<A, B> { C<A>, D<B> }`
+    Enum(EnumDef, Generics),
+    /// A struct definition (`struct` or `pub struct`).
+    ///
+    /// E.g. `struct Foo<A> { x: A }`
+    Struct(VariantData, Generics),
+    /// A union definition (`union` or `pub union`).
+    ///
+    /// E.g. `union Foo<A, B> { x: A, y: B }`
+    Union(VariantData, Generics),
+    /// A Trait declaration (`trait` or `pub trait`).
+    ///
+    /// E.g. `trait Foo { .. }`, `trait Foo<T> { .. }` or `auto trait Foo {}`
+    Trait(IsAuto, Unsafety, Generics, TyParamBounds, Vec<TraitItem>),
+    /// Trait alias
+    ///
+    /// E.g. `trait Foo = Bar + Quux;`
+    TraitAlias(Generics, TyParamBounds),
+    /// An implementation.
+    ///
+    /// E.g. `impl<A> Foo<A> { .. }` or `impl<A> Trait for Foo<A> { .. }`
+    Impl(
+        Unsafety,
+        ImplPolarity,
+        Defaultness,
+        Generics,
+        Option<TraitRef>, // (optional) trait this impl implements
+        P<Ty>,            // self
+        Vec<ImplItem>,
+    ),
+    /// A macro invocation.
+    ///
+    /// E.g. `macro_rules! foo { .. }` or `foo!(..)`
+    Mac(Mac),
+
+    /// A macro definition.
+    MacroDef(MacroDef),
+}
+
+impl ItemKind {
+    pub fn descriptive_variant(&self) -> &str {
+        match *self {
+            ItemKind::ExternCrate(..) => "extern crate",
+            ItemKind::Use(..) => "use",
+            ItemKind::Static(..) => "static item",
+            ItemKind::Const(..) => "constant item",
+            ItemKind::Fn(..) => "function",
+            ItemKind::Mod(..) => "module",
+            ItemKind::ForeignMod(..) => "foreign module",
+            ItemKind::GlobalAsm(..) => "global asm",
+            ItemKind::Ty(..) => "type alias",
+            ItemKind::Enum(..) => "enum",
+            ItemKind::Struct(..) => "struct",
+            ItemKind::Union(..) => "union",
+            ItemKind::Trait(..) => "trait",
+            ItemKind::TraitAlias(..) => "trait alias",
+            ItemKind::Mac(..) | ItemKind::MacroDef(..) | ItemKind::Impl(..) => "item",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub struct ForeignItem {
+    pub ident: Ident,
+    pub attrs: Vec<Attribute>,
+    pub node: ForeignItemKind,
+    pub id: NodeId,
+    pub span: Span,
+    pub vis: Visibility,
+}
+
+/// An item within an `extern` block
+#[derive(Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug)]
+pub enum ForeignItemKind {
+    /// A foreign function
+    Fn(P<FnDecl>, Generics),
+    /// A foreign static item (`static ext: u8`), with optional mutability
+    /// (the boolean is true when mutable)
+    Static(P<Ty>, bool),
+    /// A foreign type
+    Ty,
+}
+
+impl ForeignItemKind {
+    pub fn descriptive_variant(&self) -> &str {
+        match *self {
+            ForeignItemKind::Fn(..) => "foreign function",
+            ForeignItemKind::Static(..) => "foreign static item",
+            ForeignItemKind::Ty => "foreign type",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serialize;
+
+    // are ASTs encodable?
+    #[test]
+    fn check_asts_encodable() {
+        fn assert_encodable<T: serialize::Encodable>() {}
+        assert_encodable::<Crate>();
+    }
+}


### PR DESCRIPTION
## Summary

Introduce a pure-Go, default-on correctness gate that validates the incremental parser against a curated real-world corpus. It enforces that ParseIncremental matches Parse whenever the fresh parse is fully clean, turning previously silent structural corruption into explicit, tracked CI failures with a staleness ratchet.

## Changes

- Add `incremental_invariant_gate_test.go` performing a full-span, fresh-clean invariant sweep over single-byte DELETE, INSERT, and REPLACE edits at fixed strides across multiple language corpora.
- Replace unreliable `HasError()` checks with explicit recursive `IsError()`/`IsMissing()` counting to accurately catch silent corruption where trees appear structurally valid but are divergent.
- Introduce `testdata/incremental_allowlist.json` to track known divergences by language, edit class, and divergence signature, failing builds when unlisted divergences appear or allowlist entries become stale.
- Add real-world corpus files under `testdata/incremental_gate/` (Python, JavaScript, Go, JSON, Rust) calibrated with fixed strides to complete full sweeps in 1-3 minutes.

## Testing

- go test -run TestIncrementalInvariantGate