### PR TITLE
fix(incremental): preserve parity across scanner reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ for tags and release notes while still in `0.x`.
   incrementally reusable syntax. Python deletion edits that previously returned
   a complete but structurally divergent tree now match fresh parsing and the
   locked C oracle across a systematic minimal-witness sweep.
-- Fail closed to a fresh parse for Python edits that require external-scanner
-  checkpoint reuse until indentation-state restoration is certified exact.
-  Same-length token-invariant leaf validation still reuses the complete old
-  tree without reparsing. Included-range token-source wrappers now preserve the
-  underlying scanner's fallback reason in incremental profiles.
+- Fail closed to a fresh parse for Python-derived external scanners (Python,
+  Mojo, and Starlark) when edits require checkpoint reuse, until each
+  indentation-state restoration path is certified exact. Same-length
+  token-invariant leaf validation still reuses the complete old tree without
+  reparsing. Included-range token-source wrappers preserve the underlying
+  scanner's fallback reason in incremental profiles.
 
 ## [0.42.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ for tags and release notes while still in `0.x`.
 - Fail closed to a fresh parse for Python edits that require external-scanner
   checkpoint reuse until indentation-state restoration is certified exact.
   Same-length token-invariant leaf validation still reuses the complete old
-  tree without reparsing.
+  tree without reparsing. Included-range token-source wrappers now preserve the
+  underlying scanner's fallback reason in incremental profiles.
 
 ## [0.42.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ for tags and release notes while still in `0.x`.
   incrementally reusable syntax. Python deletion edits that previously returned
   a complete but structurally divergent tree now match fresh parsing and the
   locked C oracle across a systematic minimal-witness sweep.
+- Fail closed to a fresh parse for Python edits that require external-scanner
+  checkpoint reuse until indentation-state restoration is certified exact.
+  Same-length token-invariant leaf validation still reuses the complete old
+  tree without reparsing.
 
 ## [0.42.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ for tags and release notes while still in `0.x`.
 
 - Restore F# external-scanner checkpoints to the locked grammar's byte layout,
   keeping incremental scanner state compatible with the reference runtime.
+- Apply the upstream-C repetition-skip conflict fold while dispatching around
+  incrementally reusable syntax. Python deletion edits that previously returned
+  a complete but structurally divergent tree now match fresh parsing and the
+  locked C oracle across a systematic minimal-witness sweep.
 
 ## [0.42.0] - 2026-07-18
 

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -30,6 +30,10 @@ type parityMeta struct {
 	skipReason string // non-empty = skip with this message
 }
 
+type parityPythonTestIncrementalReuseScanner struct{ gotreesitter.ExternalScanner }
+
+func (parityPythonTestIncrementalReuseScanner) SupportsIncrementalReuse() bool { return true }
+
 var paritySkips = map[string]parityMeta{
 	// Keep this map for explicitly known structural mismatches.
 	// Parse-support-specific skips (e.g. missing scanners) should not live here.
@@ -1005,8 +1009,12 @@ func TestParityPythonIncrementalRepetitionFoldDelete(t *testing.T) {
 	edited = append(edited, source[:offset]...)
 	edited = append(edited, source[offset+1:]...)
 
-	tc := parityCase{name: "python", source: string(source)}
-	oldTree, _, err := parseWithGo(tc, source, nil)
+	base := grammars.PythonLanguage()
+	goLangValue := *base
+	goLangValue.ExternalScanner = parityPythonTestIncrementalReuseScanner{ExternalScanner: base.ExternalScanner}
+	goLang := &goLangValue
+	goParser := gotreesitter.NewParser(goLang)
+	oldTree, err := goParser.Parse(source)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1015,6 +1023,58 @@ func TestParityPythonIncrementalRepetitionFoldDelete(t *testing.T) {
 		StartByte:   uint32(offset),
 		OldEndByte:  uint32(offset + 1),
 		NewEndByte:  uint32(offset),
+		StartPoint:  pointAtOffset(source, offset),
+		OldEndPoint: pointAtOffset(source, offset+1),
+		NewEndPoint: pointAtOffset(edited, offset),
+	})
+	goTree, err := goParser.ParseIncremental(edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C reference parser returned nil tree")
+	}
+	defer cTree.Close()
+
+	var errs []string
+	compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+	if len(errs) > 0 {
+		t.Fatalf("Python incremental tree differs from locked C oracle: %s", errs[0])
+	}
+}
+
+func TestParityPythonIncrementalDedentCheckpointFallback(t *testing.T) {
+	source, err := os.ReadFile("corpus_structural/python_sample.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const offset = 500
+	if source[offset] != 'n' {
+		t.Fatalf("locked Python DEDENT witness changed at byte %d: got %q, want n", offset, source[offset])
+	}
+	edited := append(append([]byte(nil), source[:offset]...), source[offset+1:]...)
+	tc := parityCase{name: "python", source: string(source)}
+	oldTree, _, err := parseWithGo(tc, source, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(oldTree)
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   offset,
+		OldEndByte:  offset + 1,
+		NewEndByte:  offset,
 		StartPoint:  pointAtOffset(source, offset),
 		OldEndPoint: pointAtOffset(source, offset+1),
 		NewEndPoint: pointAtOffset(edited, offset),
@@ -1043,7 +1103,7 @@ func TestParityPythonIncrementalRepetitionFoldDelete(t *testing.T) {
 	var errs []string
 	compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
 	if len(errs) > 0 {
-		t.Fatalf("Python incremental tree differs from locked C oracle: %s", errs[0])
+		t.Fatalf("Python incremental DEDENT fallback differs from locked C oracle: %s", errs[0])
 	}
 }
 

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -12,6 +12,7 @@ package cgoharness
 // test suite zero-CGo.
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"runtime"
@@ -1105,6 +1106,218 @@ func TestParityPythonIncrementalDedentCheckpointFallback(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("Python incremental DEDENT fallback differs from locked C oracle: %s", errs[0])
 	}
+}
+
+func TestParityPythonDerivedScannerFallback(t *testing.T) {
+	cases := []struct {
+		name   string
+		lang   func() *gotreesitter.Language
+		source []byte
+	}{
+		{name: "python", lang: grammars.PythonLanguage, source: []byte("value = 1\n")},
+		{name: "mojo", lang: grammars.MojoLanguage, source: []byte("fn main():\n    print(1)\n")},
+		{name: "starlark", lang: grammars.StarlarkLanguage, source: []byte("value = 1\n")},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			offset := bytes.IndexByte(tc.source, '1')
+			if offset < 0 {
+				t.Fatalf("locked %s scanner-fallback witness is malformed", tc.name)
+			}
+			edited := append([]byte(nil), tc.source...)
+			edited[offset] = 'x'
+			edit := gotreesitter.InputEdit{
+				StartByte:   uint32(offset),
+				OldEndByte:  uint32(offset + 1),
+				NewEndByte:  uint32(offset + 1),
+				StartPoint:  pointAtOffset(tc.source, offset),
+				OldEndPoint: pointAtOffset(tc.source, offset+1),
+				NewEndPoint: pointAtOffset(edited, offset+1),
+			}
+
+			goLang := tc.lang()
+			goParser := gotreesitter.NewParser(goLang)
+			oldTree, err := goParser.Parse(tc.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer releaseGoTree(oldTree)
+			oldTree.Edit(edit)
+			goTree, profile, err := goParser.ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer releaseGoTree(goTree)
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" ||
+				profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("%s scanner fallback profile is not fail-closed: %+v", tc.name, profile)
+			}
+
+			cLang, err := ParityCLanguage(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(edited, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C reference parser returned nil tree")
+			}
+			defer cTree.Close()
+
+			var errs []string
+			compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+			if len(errs) > 0 {
+				t.Fatalf("%s scanner fallback differs from locked C oracle: %s", tc.name, errs[0])
+			}
+		})
+	}
+}
+
+func TestParityJavaScriptIncrementalRepetitionFoldControl(t *testing.T) {
+	// JavaScript is automatically forest-routed for fresh parses. This isolated
+	// parity process disables that route so the test exercises the production
+	// incremental dispatcher whose reuse behavior changed.
+	restoreForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	gotreesitter.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(restoreForest) })
+	t.Setenv("GOT_PARSE_ACTION_TIMING", "1")
+	gotreesitter.ResetParseEnvConfigCacheForTests()
+	t.Cleanup(gotreesitter.ResetParseEnvConfigCacheForTests)
+
+	source := []byte("function alpha() { return 1; }\n" +
+		"function beta() { return 2; }\n" +
+		"function gamma() { return 3; }\n" +
+		"function delta() { return 4; }\n" +
+		"function epsilon() { return 5; }\n")
+	offset := strings.Index(string(source), "return 1") + len("return ")
+	if offset < len("return ") || source[offset] != '1' {
+		t.Fatal("locked JavaScript incremental control witness is malformed")
+	}
+	edited := append([]byte(nil), source...)
+	edited[offset] = 'z'
+	edit := gotreesitter.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset + 1),
+		StartPoint:  pointAtOffset(source, offset),
+		OldEndPoint: pointAtOffset(source, offset+1),
+		NewEndPoint: pointAtOffset(edited, offset+1),
+	}
+
+	goLang := grammars.JavascriptLanguage()
+	goParser := gotreesitter.NewParser(goLang)
+	oldTree, err := goParser.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(oldTree)
+	oldTree.Edit(edit)
+	ambiguity := gotreesitter.NewAmbiguityProfile()
+	goParser.SetAmbiguityProfile(ambiguity)
+	goTree, incrementalProfile, err := goParser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goTree)
+	if incrementalProfile.ReuseUnsupported || !incrementalProfile.OldTreeReuseRoute || incrementalProfile.ReusedSubtrees == 0 {
+		t.Fatalf("JavaScript control did not exercise old-tree reuse: %+v", incrementalProfile)
+	}
+	if !ambiguityProfileHasUnprofiledRepetitionReduceChoice(ambiguity, goLang) {
+		for _, stat := range ambiguity.SnapshotTop(-1) {
+			t.Logf("ambiguity state=%d lookahead=%d actions=%+v hits=%d forks=%d choice_ns=%d fork_ns=%d", stat.State, stat.Lookahead, stat.Actions, stat.Hits, stat.Forks, stat.ConflictChoiceNanos, stat.ConflictForkNanos)
+		}
+		t.Fatal("JavaScript incremental control did not exercise the global C repetition-skip fold")
+	}
+
+	goFresh, err := goParser.Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goFresh)
+	var goErrs []string
+	compareGoNodes(goTree.RootNode(), goLang, goFresh.RootNode(), "root", &goErrs)
+	if len(goErrs) > 0 {
+		t.Fatalf("JavaScript incremental tree differs from fresh Go: %s", goErrs[0])
+	}
+
+	cLang, err := ParityCLanguage("javascript")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cOld := cParser.Parse(source, nil)
+	if cOld == nil || cOld.RootNode() == nil {
+		t.Fatal("C reference parser returned nil old tree")
+	}
+	cEdit := realCorpusCInputEdit(edit)
+	cOld.Edit(&cEdit)
+	cIncremental := cParser.Parse(edited, cOld)
+	cOld.Close()
+	if cIncremental == nil || cIncremental.RootNode() == nil {
+		t.Fatal("C reference parser returned nil incremental tree")
+	}
+	defer cIncremental.Close()
+	cFresh := cParser.Parse(edited, nil)
+	if cFresh == nil || cFresh.RootNode() == nil {
+		t.Fatal("C reference parser returned nil fresh tree")
+	}
+	defer cFresh.Close()
+	if got, want := canonicalCTreeDigest(t, cIncremental, "JavaScript incremental C"), canonicalCTreeDigest(t, cFresh, "JavaScript fresh C"); got != want {
+		t.Fatalf("JavaScript incremental C differs from fresh C: got=%s want=%s", got, want)
+	}
+
+	var errs []string
+	compareNodes(goTree.RootNode(), goLang, cIncremental.RootNode(), "root", &errs)
+	if len(errs) > 0 {
+		t.Fatalf("JavaScript incremental tree differs from locked incremental C oracle: %s", errs[0])
+	}
+}
+
+func ambiguityProfileHasUnprofiledRepetitionReduceChoice(profile *gotreesitter.AmbiguityProfile, lang *gotreesitter.Language) bool {
+	if profile == nil || lang == nil {
+		return false
+	}
+	for _, stat := range profile.SnapshotTop(-1) {
+		if stat.ConflictChoiceNanos == 0 || len(stat.Actions) != 2 {
+			continue
+		}
+		var repetitionShifts, reductions int
+		for _, action := range stat.Actions {
+			switch action.Type {
+			case gotreesitter.ParseActionShift:
+				if action.Repetition {
+					repetitionShifts++
+				}
+			case gotreesitter.ParseActionReduce:
+				reductions++
+			}
+		}
+		if repetitionShifts != 1 || reductions != 1 {
+			continue
+		}
+		profiled := false
+		for _, policy := range lang.ConflictPolicies {
+			stateMatch := policy.State == stat.State || policy.State == gotreesitter.ConflictPolicyAnyState
+			lookaheadMatch := policy.Lookahead == stat.Lookahead || policy.Lookahead == gotreesitter.ConflictPolicyAnyLookahead
+			if stateMatch && lookaheadMatch {
+				profiled = true
+				break
+			}
+		}
+		if !profiled {
+			return true
+		}
+	}
+	return false
 }
 
 // TestParityHasNoErrors checks that well-formed inputs for CI-gated languages

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -991,6 +991,62 @@ func TestParityIncrementalParse(t *testing.T) {
 	}
 }
 
+func TestParityPythonIncrementalRepetitionFoldDelete(t *testing.T) {
+	source := []byte("from contextlib import suppress\n" +
+		"from copy import deepcopy\n" +
+		"from enum import Enum\n" +
+		"from errno import EACCES\n" +
+		"from functools import partial\n")
+	offset := strings.LastIndex(string(source), "import partial") + len("impor")
+	if offset < len("impor") || source[offset] != 't' {
+		t.Fatal("locked Python incremental witness missing final import byte")
+	}
+	edited := make([]byte, 0, len(source)-1)
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, source[offset+1:]...)
+
+	tc := parityCase{name: "python", source: string(source)}
+	oldTree, _, err := parseWithGo(tc, source, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(oldTree)
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset),
+		StartPoint:  pointAtOffset(source, offset),
+		OldEndPoint: pointAtOffset(source, offset+1),
+		NewEndPoint: pointAtOffset(edited, offset),
+	})
+	goTree, goLang, err := parseWithGo(tc, edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLang, err := ParityCLanguage("python")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C reference parser returned nil tree")
+	}
+	defer cTree.Close()
+
+	var errs []string
+	compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+	if len(errs) > 0 {
+		t.Fatalf("Python incremental tree differs from locked C oracle: %s", errs[0])
+	}
+}
+
 // TestParityHasNoErrors checks that well-formed inputs for CI-gated languages
 // do not produce error nodes.
 func TestParityHasNoErrors(t *testing.T) {

--- a/conflict_policy.go
+++ b/conflict_policy.go
@@ -235,11 +235,10 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 			return next, true
 		}
 	}
-	if reuse != nil {
-		return ParseAction{}, false
-	}
-	if chosen, ok := conflictPolicyChoiceForDispatch(p.language, s, tok, currentState, actions); ok {
-		return chosen, true
+	if reuse == nil {
+		if chosen, ok := conflictPolicyChoiceForDispatch(p.language, s, tok, currentState, actions); ok {
+			return chosen, true
+		}
 	}
 	// C's global repetition-skip fold. Runs after explicit generated
 	// ConflictPolicies (per-state directives outrank the default) but before
@@ -247,9 +246,13 @@ func (p *Parser) deterministicConflictChoiceForDispatch(source []byte, s *glrSta
 	// exists to keep hand-written SHIFT-preferring shortcuts away from
 	// grammars they were never tuned for, whereas this fold is C's own
 	// dispatch semantics and applies to every grammar whose tables carry
-	// repetition-marked shifts.
+	// repetition-marked shifts. Unlike language-scoped compatibility choices,
+	// the C fold is also valid while dispatching around reused subtrees.
 	if next, ok := p.cRepetitionSkipConflictChoice(s, actions); ok {
 		return next, true
+	}
+	if reuse != nil {
+		return ParseAction{}, false
 	}
 	if generatedRepeatBoundaryConflict(p.language, actions) {
 		return ParseAction{}, false

--- a/conflict_policy_test.go
+++ b/conflict_policy_test.go
@@ -461,8 +461,25 @@ func TestRecoveredRepetitionReducePolicyAppliesOnlyToIdleRecoveredLineage(t *tes
 	if chosen.Type != ParseActionReduce || chosen.Symbol != 68 {
 		t.Fatalf("recovered policy picked %+v, want reduce symbol 68", chosen)
 	}
-	if chosen, ok := parser.deterministicConflictChoiceForDispatch(nil, recovered, tok, 86, actions, 2, &reuseCursor{}); ok {
-		t.Fatalf("incremental-reuse dispatch picked %+v, want ordinary reuse path", chosen)
+	chosen, ok = parser.deterministicConflictChoiceForDispatch(nil, recovered, tok, 86, actions, 2, &reuseCursor{})
+	if !ok || chosen.Type != ParseActionReduce || chosen.Symbol != 68 {
+		t.Fatalf("incremental-reuse dispatch picked %+v, want global C repetition reduce", chosen)
+	}
+
+	// Keep the two mechanisms distinct: c_sharp opts out of the global C fold,
+	// so this otherwise identical recovery policy must still be gated off while
+	// dispatching around reused syntax.
+	optOutLang := &Language{
+		Name:             "c_sharp",
+		ConflictPolicies: lang.ConflictPolicies,
+	}
+	optOutParser := NewParser(optOutLang)
+	chosen, ok = optOutParser.deterministicConflictChoiceForDispatch(nil, recovered, tok, 86, actions, 2, nil)
+	if !ok || chosen.Type != ParseActionReduce || chosen.Symbol != 68 {
+		t.Fatalf("opt-out fresh dispatch picked %+v, want recovery-scoped reduce", chosen)
+	}
+	if chosen, ok := optOutParser.deterministicConflictChoiceForDispatch(nil, recovered, tok, 86, actions, 2, &reuseCursor{}); ok {
+		t.Fatalf("opt-out incremental-reuse dispatch picked recovery-scoped policy %+v", chosen)
 	}
 
 	activeRecovery := []*glrStack{

--- a/grammars/mojo_scanner.go
+++ b/grammars/mojo_scanner.go
@@ -59,7 +59,10 @@ func (MojoExternalScanner) Deserialize(payload any, buf []byte) {
 	PythonExternalScanner{}.Deserialize(payload, buf)
 }
 
-func (MojoExternalScanner) SupportsIncrementalReuse() bool { return true }
+// SupportsIncrementalReuse remains disabled with Python's scanner: Mojo shares
+// the same serialized indentation state and checkpoint restoration semantics.
+// Re-enable only after Mojo's DEDENT behavior is independently certified.
+func (MojoExternalScanner) SupportsIncrementalReuse() bool { return false }
 
 func (MojoExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	s := payload.(*pythonScannerState)

--- a/grammars/python_scanner.go
+++ b/grammars/python_scanner.go
@@ -219,7 +219,11 @@ func (PythonExternalScanner) Deserialize(payload any, buf []byte) {
 	}
 }
 
-func (PythonExternalScanner) SupportsIncrementalReuse() bool { return true }
+// SupportsIncrementalReuse remains disabled until checkpoint restoration can
+// prove that indentation stacks preserve every class-closing DEDENT. The
+// token-invariant leaf fast path is validated before this capability check and
+// remains available for edits that do not depend on scanner state.
+func (PythonExternalScanner) SupportsIncrementalReuse() bool { return false }
 
 func (PythonExternalScanner) PreservesStateOnScanFailure() bool { return true }
 

--- a/grammars/starlark_scanner.go
+++ b/grammars/starlark_scanner.go
@@ -51,7 +51,11 @@ func (StarlarkExternalScanner) Deserialize(payload any, buf []byte) {
 	PythonExternalScanner{}.Deserialize(payload, buf)
 }
 
-func (StarlarkExternalScanner) SupportsIncrementalReuse() bool { return true }
+// SupportsIncrementalReuse remains disabled with Python's scanner: Starlark
+// shares the same serialized indentation state and checkpoint restoration
+// semantics. Re-enable only after Starlark's DEDENT behavior is independently
+// certified.
+func (StarlarkExternalScanner) SupportsIncrementalReuse() bool { return false }
 
 func (StarlarkExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	s := payload.(*pythonScannerState)

--- a/included_ranges.go
+++ b/included_ranges.go
@@ -92,13 +92,14 @@ func (s *includedRangeTokenSource) SupportsIncrementalReuse() bool {
 	if s == nil || s.base == nil {
 		return false
 	}
-	if dts, ok := s.base.(*dfaTokenSource); ok {
-		return languageSupportsIncrementalReuse(dts.language)
+	return tokenSourceSupportsIncrementalReuse(s.base)
+}
+
+func (s *includedRangeTokenSource) IncrementalReuseUnsupportedReason() string {
+	if s == nil || s.base == nil {
+		return "token_source_nil"
 	}
-	if reusable, ok := s.base.(IncrementalReuseTokenSource); ok {
-		return reusable.SupportsIncrementalReuse()
-	}
-	return false
+	return incrementalReuseUnavailableReason(s.base)
 }
 
 func (s *includedRangeTokenSource) Reset(source []byte) {

--- a/parser.go
+++ b/parser.go
@@ -2953,6 +2953,11 @@ func incrementalReuseUnavailableReason(ts TokenSource) string {
 	if ts == nil {
 		return "token_source_nil"
 	}
+	if reasoner, ok := ts.(incrementalReuseUnsupportedReasoner); ok {
+		if reason := reasoner.IncrementalReuseUnsupportedReason(); reason != "" {
+			return reason
+		}
+	}
 	if dts, ok := ts.(*dfaTokenSource); ok {
 		if dts.language == nil {
 			return "dfa_token_source_no_language"

--- a/parser_api.go
+++ b/parser_api.go
@@ -877,6 +877,14 @@ type IncrementalReuseTokenSource interface {
 	SupportsIncrementalReuse() bool
 }
 
+// incrementalReuseUnsupportedReasoner is an optional token-source extension
+// used by wrappers to preserve the concrete reason an underlying source
+// declined incremental reuse. Wrappers should delegate the reason instead of
+// replacing it with a generic wrapper-level refusal.
+type incrementalReuseUnsupportedReasoner interface {
+	IncrementalReuseUnsupportedReason() string
+}
+
 type parserStateTokenSource interface {
 	SetParserState(state StateID)
 	// SetGLRStates provides all active GLR stack states so the token source

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -212,6 +212,10 @@ func TestDeterministicConflictChoiceUsesCRepetitionFoldOnRecoveryLineages(t *tes
 	if chosen.Type != ParseActionReduce || chosen.Symbol != 6 {
 		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v, want program_repeat1 reduce (C repetition-skip fold)", chosen)
 	}
+	chosen, ok = parser.deterministicConflictChoiceForDispatch(nil, cleanStack, Token{Symbol: 1}, 2, actions, 2, &reuseCursor{})
+	if !ok || chosen.Type != ParseActionReduce || chosen.Symbol != 6 {
+		t.Fatalf("deterministicConflictChoiceForDispatch picked %+v during incremental reuse, want C repetition reduce", chosen)
+	}
 	erroredStack := &glrStack{cEverErrored: true}
 	chosen, ok = parser.deterministicConflictChoiceForDispatch(nil, erroredStack, Token{Symbol: 1}, 2, actions, 2, nil)
 	if !ok || chosen.Type != ParseActionReduce || chosen.Symbol != 6 {

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
@@ -17,9 +18,16 @@ func (pythonTestIncrementalReuseScanner) SupportsIncrementalReuse() bool { retur
 
 func pythonLanguageWithTestIncrementalScannerReuse() *gotreesitter.Language {
 	base := grammars.PythonLanguage()
-	clone := *base
+	src := reflect.ValueOf(base).Elem()
+	dst := reflect.New(src.Type()).Elem()
+	for i := 0; i < src.NumField(); i++ {
+		if src.Type().Field(i).IsExported() {
+			dst.Field(i).Set(src.Field(i))
+		}
+	}
+	clone := dst.Addr().Interface().(*gotreesitter.Language)
 	clone.ExternalScanner = pythonTestIncrementalReuseScanner{ExternalScanner: base.ExternalScanner}
-	return &clone
+	return clone
 }
 
 func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -3,12 +3,24 @@ package gotreesitter_test
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
+
+type pythonTestIncrementalReuseScanner struct{ gotreesitter.ExternalScanner }
+
+func (pythonTestIncrementalReuseScanner) SupportsIncrementalReuse() bool { return true }
+
+func pythonLanguageWithTestIncrementalScannerReuse() *gotreesitter.Language {
+	base := grammars.PythonLanguage()
+	clone := *base
+	clone.ExternalScanner = pythonTestIncrementalReuseScanner{ExternalScanner: base.ExternalScanner}
+	return &clone
+}
 
 func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
 	// Five consecutive from-imports are the smallest stable shape found from
@@ -20,7 +32,10 @@ func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
 		"from enum import Enum\n" +
 		"from errno import EACCES\n" +
 		"from functools import partial\n")
-	lang := grammars.PythonLanguage()
+	// This witness carries no indentation state, so enable scanner reuse in the
+	// test to exercise the conflict-fold path even while production Python
+	// scanner checkpoint reuse remains conservatively disabled.
+	lang := pythonLanguageWithTestIncrementalScannerReuse()
 
 	for offset := range source {
 		t.Run(fmt.Sprintf("delete_%03d", offset), func(t *testing.T) {
@@ -71,6 +86,63 @@ func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
 			incremental.Release()
 			oldTree.Release()
 		})
+	}
+}
+
+func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *testing.T) {
+	source, err := os.ReadFile("cgo_harness/corpus_structural/python_sample.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const offset = 500
+	if source[offset] != 'n' {
+		t.Fatalf("locked Python DEDENT witness changed at byte %d: got %q, want n", offset, source[offset])
+	}
+	edited := append(append([]byte(nil), source[:offset]...), source[offset+1:]...)
+	lang := grammars.PythonLanguage()
+	oldTree, err := gotreesitter.NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer oldTree.Release()
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   offset,
+		OldEndByte:  offset + 1,
+		NewEndByte:  offset,
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, offset+1),
+		NewEndPoint: pointForOffset(edited, offset),
+	})
+
+	incremental, profile, err := gotreesitter.NewParser(lang).ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer incremental.Release()
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
+		t.Fatalf("Python length-changing edit did not use the conservative scanner fallback: %+v", profile)
+	}
+	if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("Python scanner fallback reported old-tree reuse: %+v", profile)
+	}
+
+	fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	requireCompleteParse(t, incremental, edited, lang, "incremental fallback")
+	requireCompleteParse(t, fresh, edited, lang, "fresh")
+	incrementalInspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshInspection, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incrementalInspection.SHA256 != freshInspection.SHA256 {
+		t.Fatalf("Python conservative fallback differs from fresh parse: incremental=%s fresh=%s", incrementalInspection.SHA256, freshInspection.SHA256)
 	}
 }
 

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -2,12 +2,77 @@ package gotreesitter_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
+
+func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
+	// Five consecutive from-imports are the smallest stable shape found from
+	// the cloud-init schema.py witness. Before the incremental conflict-fold
+	// fix, deleting the final byte of "import" in the fifth line silently
+	// produced six root children incrementally and five from a fresh parse.
+	source := []byte("from contextlib import suppress\n" +
+		"from copy import deepcopy\n" +
+		"from enum import Enum\n" +
+		"from errno import EACCES\n" +
+		"from functools import partial\n")
+	lang := grammars.PythonLanguage()
+
+	for offset := range source {
+		t.Run(fmt.Sprintf("delete_%03d", offset), func(t *testing.T) {
+			edited := make([]byte, 0, len(source)-1)
+			edited = append(edited, source[:offset]...)
+			edited = append(edited, source[offset+1:]...)
+
+			oldTree, err := gotreesitter.NewParser(lang).Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(offset),
+				OldEndByte:  uint32(offset + 1),
+				NewEndByte:  uint32(offset),
+				StartPoint:  pointForOffset(source, offset),
+				OldEndPoint: pointForOffset(source, offset+1),
+				NewEndPoint: pointForOffset(edited, offset),
+			})
+
+			incremental, _, err := gotreesitter.NewParser(lang).ParseIncrementalProfiled(edited, oldTree)
+			if err != nil {
+				oldTree.Release()
+				t.Fatal(err)
+			}
+			fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+			if err != nil {
+				incremental.Release()
+				oldTree.Release()
+				t.Fatal(err)
+			}
+
+			requireCompleteParse(t, incremental, edited, lang, "incremental")
+			requireCompleteParse(t, fresh, edited, lang, "fresh")
+			incrementalInspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+			if err != nil {
+				t.Fatal(err)
+			}
+			freshInspection, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if incrementalInspection.SHA256 != freshInspection.SHA256 {
+				t.Fatalf("incremental/fresh deep tree mismatch after deleting byte %d (%q): incremental=%s fresh=%s", offset, source[offset], incrementalInspection.SHA256, freshInspection.SHA256)
+			}
+
+			fresh.Release()
+			incremental.Release()
+			oldTree.Release()
+		})
+	}
+}
 
 func TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh(t *testing.T) {
 	fixtures, err := benchfixtures.LoadGoFullParseFixtures()

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 func TestExternalScannerIncrementalReusePolicy(t *testing.T) {
@@ -108,67 +109,170 @@ func TestExternalScannerIncrementalReusePolicy(t *testing.T) {
 	}
 }
 
-func TestPythonSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
-	source := []byte("value = 1\n")
-	next := []byte("value = x\n")
-	offset := bytes.IndexByte(source, '1')
-	if offset < 0 || next[offset] != 'x' {
-		t.Fatal("locked Python token-change witness is malformed")
+type pythonDerivedIncrementalCase struct {
+	name   string
+	lang   func() *gotreesitter.Language
+	source []byte
+	marker byte
+}
+
+func pythonDerivedIncrementalCases() []pythonDerivedIncrementalCase {
+	return []pythonDerivedIncrementalCase{
+		{name: "python", lang: grammars.PythonLanguage, source: []byte("value = 1\n"), marker: '1'},
+		{name: "mojo", lang: grammars.MojoLanguage, source: []byte("fn main():\n    print(1)\n"), marker: '1'},
+		{name: "starlark", lang: grammars.StarlarkLanguage, source: []byte("value = 1\n"), marker: '1'},
 	}
+}
 
-	for _, tc := range []struct {
-		name           string
-		includedRanges bool
-	}{
-		{name: "direct"},
-		{name: "included_range", includedRanges: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			lang := grammars.PythonLanguage()
-			parser := gotreesitter.NewParser(lang)
-			if tc.includedRanges {
-				parser.SetIncludedRanges([]gotreesitter.Range{{
-					StartByte: 0,
-					EndByte:   uint32(len(source)),
-					EndPoint:  pointForOffset(source, len(source)),
-				}})
-			}
-			oldTree, err := parser.Parse(source)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer oldTree.Release()
-			oldTree.Edit(gotreesitter.InputEdit{
-				StartByte:   uint32(offset),
-				OldEndByte:  uint32(offset + 1),
-				NewEndByte:  uint32(offset + 1),
-				StartPoint:  pointForOffset(source, offset),
-				OldEndPoint: pointForOffset(source, offset+1),
-				NewEndPoint: pointForOffset(next, offset+1),
-			})
+func requireIncrementalDeepTreeMatchesFresh(t *testing.T, incremental, fresh *gotreesitter.Tree, lang *gotreesitter.Language) {
+	t.Helper()
+	incrementalInspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshInspection, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incrementalInspection.SHA256 != freshInspection.SHA256 {
+		t.Fatalf("incremental/fresh deep tree mismatch: incremental=%s fresh=%s", incrementalInspection.SHA256, freshInspection.SHA256)
+	}
+}
 
-			incremental, profile, err := parser.ParseIncrementalProfiled(next, oldTree)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer incremental.Release()
-			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
-				t.Fatalf("same-length token change did not preserve Python scanner refusal: %+v", profile)
-			}
-			if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
-				t.Fatalf("same-length token change reused old Python syntax: %+v", profile)
-			}
-			if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
-				t.Fatalf("same-length token change did not execute a full parse: %+v", profile)
-			}
+func TestPythonDerivedSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
+	for _, languageCase := range pythonDerivedIncrementalCases() {
+		languageCase := languageCase
+		t.Run(languageCase.name, func(t *testing.T) {
+			for _, route := range []struct {
+				name           string
+				includedRanges bool
+			}{
+				{name: "direct"},
+				{name: "included_range", includedRanges: true},
+			} {
+				route := route
+				t.Run(route.name, func(t *testing.T) {
+					source := languageCase.source
+					next := append([]byte(nil), source...)
+					offset := bytes.IndexByte(source, languageCase.marker)
+					if offset < 0 {
+						t.Fatalf("locked %s token-change witness is malformed", languageCase.name)
+					}
+					next[offset] = 'x'
 
-			fresh, err := parser.Parse(next)
-			if err != nil {
-				t.Fatal(err)
+					lang := languageCase.lang()
+					parser := gotreesitter.NewParser(lang)
+					if route.includedRanges {
+						parser.SetIncludedRanges([]gotreesitter.Range{{
+							StartByte: 0,
+							EndByte:   uint32(len(source)),
+							EndPoint:  pointForOffset(source, len(source)),
+						}})
+					}
+					oldTree, err := parser.Parse(source)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer oldTree.Release()
+					oldTree.Edit(gotreesitter.InputEdit{
+						StartByte:   uint32(offset),
+						OldEndByte:  uint32(offset + 1),
+						NewEndByte:  uint32(offset + 1),
+						StartPoint:  pointForOffset(source, offset),
+						OldEndPoint: pointForOffset(source, offset+1),
+						NewEndPoint: pointForOffset(next, offset+1),
+					})
+
+					incremental, profile, err := parser.ParseIncrementalProfiled(next, oldTree)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer incremental.Release()
+					if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
+						t.Fatalf("same-length token change did not preserve %s scanner refusal: %+v", languageCase.name, profile)
+					}
+					if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+						t.Fatalf("same-length token change reused old %s syntax: %+v", languageCase.name, profile)
+					}
+					if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
+						t.Fatalf("same-length token change did not execute a full parse: %+v", profile)
+					}
+
+					fresh, err := parser.Parse(next)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer fresh.Release()
+					requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+				})
 			}
-			defer fresh.Release()
-			if got, want := incremental.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang); got != want {
-				t.Fatalf("Python scanner fallback differs from fresh parse\n got: %s\nwant: %s", got, want)
+		})
+	}
+}
+
+func TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback(t *testing.T) {
+	for _, languageCase := range pythonDerivedIncrementalCases() {
+		languageCase := languageCase
+		t.Run(languageCase.name, func(t *testing.T) {
+			for _, route := range []struct {
+				name           string
+				includedRanges bool
+			}{
+				{name: "direct"},
+				{name: "included_range", includedRanges: true},
+			} {
+				route := route
+				t.Run(route.name, func(t *testing.T) {
+					source := languageCase.source
+					next := append([]byte(nil), source...)
+					offset := bytes.IndexByte(source, languageCase.marker)
+					if offset < 0 {
+						t.Fatalf("locked %s token-invariant witness is malformed", languageCase.name)
+					}
+					next[offset] = '2'
+
+					lang := languageCase.lang()
+					parser := gotreesitter.NewParser(lang)
+					if route.includedRanges {
+						parser.SetIncludedRanges([]gotreesitter.Range{{
+							StartByte: 0,
+							EndByte:   uint32(len(source)),
+							EndPoint:  pointForOffset(source, len(source)),
+						}})
+					}
+					oldTree, err := parser.Parse(source)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer oldTree.Release()
+					oldTree.Edit(gotreesitter.InputEdit{
+						StartByte:   uint32(offset),
+						OldEndByte:  uint32(offset + 1),
+						NewEndByte:  uint32(offset + 1),
+						StartPoint:  pointForOffset(source, offset),
+						OldEndPoint: pointForOffset(source, offset+1),
+						NewEndPoint: pointForOffset(next, offset+1),
+					})
+
+					incremental, profile, err := parser.ParseIncrementalProfiled(next, oldTree)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer incremental.Release()
+					if profile.ReuseUnsupported {
+						t.Fatalf("token-invariant edit fell through to %s scanner fallback: %+v", languageCase.name, profile)
+					}
+					if profile.ReparseNanos != 0 || profile.ReusedSubtrees == 0 {
+						t.Fatalf("token-invariant edit did not reuse the old %s tree: %+v", languageCase.name, profile)
+					}
+
+					fresh, err := parser.Parse(next)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer fresh.Release()
+					requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+				})
 			}
 		})
 	}

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -108,6 +108,72 @@ func TestExternalScannerIncrementalReusePolicy(t *testing.T) {
 	}
 }
 
+func TestPythonSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
+	source := []byte("value = 1\n")
+	next := []byte("value = x\n")
+	offset := bytes.IndexByte(source, '1')
+	if offset < 0 || next[offset] != 'x' {
+		t.Fatal("locked Python token-change witness is malformed")
+	}
+
+	for _, tc := range []struct {
+		name           string
+		includedRanges bool
+	}{
+		{name: "direct"},
+		{name: "included_range", includedRanges: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := grammars.PythonLanguage()
+			parser := gotreesitter.NewParser(lang)
+			if tc.includedRanges {
+				parser.SetIncludedRanges([]gotreesitter.Range{{
+					StartByte: 0,
+					EndByte:   uint32(len(source)),
+					EndPoint:  pointForOffset(source, len(source)),
+				}})
+			}
+			oldTree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldTree.Release()
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(offset),
+				OldEndByte:  uint32(offset + 1),
+				NewEndByte:  uint32(offset + 1),
+				StartPoint:  pointForOffset(source, offset),
+				OldEndPoint: pointForOffset(source, offset+1),
+				NewEndPoint: pointForOffset(next, offset+1),
+			})
+
+			incremental, profile, err := parser.ParseIncrementalProfiled(next, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer incremental.Release()
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
+				t.Fatalf("same-length token change did not preserve Python scanner refusal: %+v", profile)
+			}
+			if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("same-length token change reused old Python syntax: %+v", profile)
+			}
+			if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
+				t.Fatalf("same-length token change did not execute a full parse: %+v", profile)
+			}
+
+			fresh, err := parser.Parse(next)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fresh.Release()
+			if got, want := incremental.RootNode().SExpr(lang), fresh.RootNode().SExpr(lang); got != want {
+				t.Fatalf("Python scanner fallback differs from fresh parse\n got: %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
 func TestExternalScannerTokenInvariantLeafReuse(t *testing.T) {
 	cases := []struct {
 		name           string


### PR DESCRIPTION
## Summary

- apply the C repetition-skip fold while dispatching around reused subtrees
- fall back to a fresh parse when Python-derived scanner checkpoints are not certified for reuse
- preserve token-invariant leaf reuse and propagate scanner refusal reasons through included-range wrappers
- add exact incremental/fresh and locked-C controls for Python, Mojo, Starlark, and JavaScript

## Validation

- focused root and scanner tests
- isolated Python, Mojo, Starlark, and JavaScript Docker parity lanes
- independent review with no findings
