### PR TITLE
fix: fix coordinate mapping for incremental suffix reuse

### DIFF
--- a/incremental.go
+++ b/incremental.go
@@ -269,7 +269,10 @@ func (c *reuseCursor) reusableIndexedEntry(entry stackEntry) bool {
 		return false
 	}
 	dirtyHere := stackEntryNodeDirty(entry)
-	if dirtyHere && c.nodeBytesUnchanged(start, end) {
+	// A dirty entry was marked dirty by TRUE OVERLAP with an edit (its start was
+	// clamped). Only same-coordinate byte equality can safely clear that dirty
+	// bit -- reverse-mapping a clamped coordinate is unsound here (#382 review).
+	if dirtyHere && c.nodeBytesEqualSameCoord(start, end) {
 		setStackEntryDirty(entry, false)
 		dirtyHere = false
 	}
@@ -324,8 +327,12 @@ func (c *reuseCursor) advance() *Node {
 
 		dirtyHere := cur.dirty()
 		if dirtyHere {
-			if c.nodeBytesUnchanged(cur.startByte, cur.endByte) {
-				// Undo edit path: unchanged bytes can be reused safely.
+			// Same-coordinate comparison only: a dirty node overlapped the edit
+			// (its start was clamped), so reverse-mapping it would read a
+			// coincidentally-equal suffix tail and unsoundly clear the dirty bit
+			// (#382 review). Same-coord clears it only on a genuine net-zero
+			// shift (edit + inverse), which is exactly the undo case this serves.
+			if c.nodeBytesEqualSameCoord(cur.startByte, cur.endByte) {
 				cur.setDirty(false)
 				dirtyHere = false
 			}
@@ -435,6 +442,27 @@ func (c *reuseCursor) nodeBytesUnchanged(start, end uint32) bool {
 		return false
 	}
 	return bytes.Equal(c.oldSource[oldStart:oldEnd], c.newSource[start:end])
+}
+
+// nodeBytesEqualSameCoord compares a node's bytes at the SAME (post-edit)
+// coordinates in both oldSource and newSource, WITHOUT reverse-mapping. It is
+// the correct "is this text unchanged" test for a node that Tree.Edit marked
+// dirty by TRUE OVERLAP with an edit (editNodeWithDelta clamps such a node's
+// start to the edit's NewEndByte). Reverse-mapping a clamped start
+// (nodeBytesUnchanged) resolves it to OldEndByte and then compares only the
+// node's surviving suffix tail, which is byte-identical to the shifted new text
+// by construction -- so it would wrongly declare a genuinely-changed node
+// unchanged and reuse a stale subtree (silent corruption; the #382 review found
+// this on CSS length-changing replace edits). Same-coordinate comparison
+// instead reports "unchanged" only when the bytes at the identical offsets
+// match: true exactly for the net-zero-shift case the un-dirty optimization
+// exists for (an edit and its inverse), and correctly false for any node whose
+// text actually shifted or changed under a length-changing edit.
+func (c *reuseCursor) nodeBytesEqualSameCoord(start, end uint32) bool {
+	if end < start || end > uint32(len(c.oldSource)) || end > uint32(len(c.newSource)) {
+		return false
+	}
+	return bytes.Equal(c.oldSource[start:end], c.newSource[start:end])
 }
 
 func reuseSubtreeGapIsParserPadding(source []byte, stackByteOffset, nodeStart uint32) bool {

--- a/incremental.go
+++ b/incremental.go
@@ -15,6 +15,12 @@ type reuseCursor struct {
 	newSource []byte
 	minEditAt uint32
 	hasEdits  bool
+	// edits is the old tree's recorded edit list (post-parse Tree.Edit calls),
+	// in application order. It is needed to reverse-map a node's post-edit
+	// (shifted) byte coordinates back to its pre-edit coordinates in oldSource
+	// so the reuse byte-equality guard reads the correct old-source bytes. See
+	// oldByteForNew / nodeBytesUnchanged.
+	edits []InputEdit
 
 	stack []reuseFrame
 	next  *Node
@@ -62,6 +68,7 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.newSource = source
 	c.minEditAt = 0
 	c.hasEdits = len(oldTree.edits) > 0
+	c.edits = oldTree.edits
 	if c.hasEdits {
 		c.minEditAt = oldTree.edits[0].StartByte
 		for i := 1; i < len(oldTree.edits); i++ {
@@ -137,6 +144,7 @@ func (c *reuseCursor) releaseNodeRefs() {
 	c.topLevelParent = nil
 	c.oldSource = nil
 	c.newSource = nil
+	c.edits = nil
 	c.forestFastPath = false
 	c.languageName = ""
 	if cap(c.stack) > 0 {
@@ -256,12 +264,12 @@ func (c *reuseCursor) reusableIndexedEntry(entry stackEntry) bool {
 		c.rejectDirty++
 		return false
 	}
-	if c.hasEdits && !nodeBytesEqual(start, end, c.oldSource, c.newSource) {
+	if c.hasEdits && !c.nodeBytesUnchanged(start, end) {
 		c.rejectDirty++
 		return false
 	}
 	dirtyHere := stackEntryNodeDirty(entry)
-	if dirtyHere && nodeBytesEqual(start, end, c.oldSource, c.newSource) {
+	if dirtyHere && c.nodeBytesUnchanged(start, end) {
 		setStackEntryDirty(entry, false)
 		dirtyHere = false
 	}
@@ -316,7 +324,7 @@ func (c *reuseCursor) advance() *Node {
 
 		dirtyHere := cur.dirty()
 		if dirtyHere {
-			if nodeBytesEqual(cur.startByte, cur.endByte, c.oldSource, c.newSource) {
+			if c.nodeBytesUnchanged(cur.startByte, cur.endByte) {
 				// Undo edit path: unchanged bytes can be reused safely.
 				cur.setDirty(false)
 				dirtyHere = false
@@ -346,7 +354,7 @@ func (c *reuseCursor) advance() *Node {
 		}
 
 		if frame.underDirty && c.hasEdits &&
-			!nodeBytesEqual(cur.startByte, cur.endByte, c.oldSource, c.newSource) {
+			!c.nodeBytesUnchanged(cur.startByte, cur.endByte) {
 			c.rejectAncestorDirtyBeforeEdit++
 			continue
 		}
@@ -375,14 +383,58 @@ func (c *reuseCursor) advance() *Node {
 	return nil
 }
 
-func nodeBytesEqual(start, end uint32, oldSource, newSource []byte) bool {
+// oldByteForNew reverse-maps a post-edit (shifted) byte position in the new
+// source back to its position in the old (pre-edit) source, undoing the
+// coordinate shifts Tree.Edit applied for each recorded edit. Edits are undone
+// in reverse application order. It returns ok=false if p falls inside an edited
+// region (its old position is not well-defined) — callers treat that as "cannot
+// verify, do not reuse".
+//
+// For a single edit e (byteDelta = NewEndByte - OldEndByte):
+//   - p <= e.StartByte : unchanged (position precedes the edit)
+//   - p >= e.NewEndByte : in the shifted suffix; old = p - byteDelta
+//   - otherwise         : inside the new edited region; not mappable
+func (c *reuseCursor) oldByteForNew(p uint32) (uint32, bool) {
+	cur := int64(p)
+	for i := len(c.edits) - 1; i >= 0; i-- {
+		e := c.edits[i]
+		if cur <= int64(e.StartByte) {
+			continue
+		}
+		if cur >= int64(e.NewEndByte) {
+			cur -= int64(e.NewEndByte) - int64(e.OldEndByte)
+			continue
+		}
+		return 0, false
+	}
+	if cur < 0 || cur > int64(len(c.oldSource)) {
+		return 0, false
+	}
+	return uint32(cur), true
+}
+
+// nodeBytesUnchanged reports whether the node spanning [start,end) in the NEW
+// source has byte-identical text to the same node in the OLD source. The node's
+// coordinates are post-edit (Tree.Edit already shifted them), so the old-source
+// slice must be taken at the reverse-mapped coordinates — comparing oldSource at
+// the post-shift coordinates (the historical bug, issue #380) makes every
+// length-changed suffix node spuriously "differ" and blocks all suffix reuse.
+// A node that straddles or is contained in an edited region reverse-maps to a
+// different-length old span (or fails to map), so bytes.Equal correctly reports
+// it changed — the guard stays sound, it just now reads the right old bytes.
+func (c *reuseCursor) nodeBytesUnchanged(start, end uint32) bool {
 	if end < start {
 		return false
 	}
-	if end > uint32(len(oldSource)) || end > uint32(len(newSource)) {
+	if end > uint32(len(c.newSource)) {
 		return false
 	}
-	return bytes.Equal(oldSource[start:end], newSource[start:end])
+	oldStart, ok1 := c.oldByteForNew(start)
+	oldEnd, ok2 := c.oldByteForNew(end)
+	if !ok1 || !ok2 || oldEnd < oldStart {
+		return false
+	}
+	return bytes.Equal(c.oldSource[oldStart:oldEnd], c.newSource[start:end])
 }
 
 func reuseSubtreeGapIsParserPadding(source []byte, stackByteOffset, nodeStart uint32) bool {
@@ -425,7 +477,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			// Preserve full-root reuse on undo when bytes are identical.
 			if !(n.startByte == 0 &&
 				n.endByte == idx.sourceLen &&
-				nodeBytesEqual(n.startByte, n.endByte, idx.oldSource, idx.newSource)) &&
+				idx.nodeBytesUnchanged(n.startByte, n.endByte)) &&
 				!idx.directForestTopLevelNonLeafReuse(n) {
 				idx.rejectRootNonLeafChanged++
 				continue

--- a/incremental_clamp_replace_test.go
+++ b/incremental_clamp_replace_test.go
@@ -1,0 +1,164 @@
+package gotreesitter_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// serializeNodeStructure renders a node as (type[start-end] child ...) so an
+// incremental tree can be compared to a fresh tree for EXACT structural
+// equality -- catching a mistyped leaf/value that an equal node COUNT would
+// miss (the weakness the #382 review flagged in the original regression test).
+func serializeNodeStructure(n *gts.Node, lang *gts.Language) string {
+	if n == nil {
+		return "<nil>"
+	}
+	var b strings.Builder
+	var walk func(*gts.Node)
+	walk = func(nd *gts.Node) {
+		fmt.Fprintf(&b, "(%s[%d-%d]", nd.Type(lang), nd.StartByte(), nd.EndByte())
+		for i := 0; i < int(nd.ChildCount()); i++ {
+			b.WriteByte(' ')
+			walk(nd.Child(i))
+		}
+		b.WriteByte(')')
+	}
+	walk(n)
+	return b.String()
+}
+
+// clampReplaceEdit replaces the first occurrence of oldSub with newSub and
+// returns the edited buffer plus the corresponding InputEdit. A same-position,
+// length-changing replace whose old text straddles a token boundary clamps the
+// straddled node's start -- the exact shape the #382 review exploited.
+func clampReplaceEdit(src []byte, oldSub, newSub string) ([]byte, gts.InputEdit, bool) {
+	i := bytes.Index(src, []byte(oldSub))
+	if i < 0 {
+		return nil, gts.InputEdit{}, false
+	}
+	edited := make([]byte, 0, len(src)-len(oldSub)+len(newSub))
+	edited = append(edited, src[:i]...)
+	edited = append(edited, newSub...)
+	edited = append(edited, src[i+len(oldSub):]...)
+	return edited, gts.InputEdit{
+		StartByte:   uint32(i),
+		OldEndByte:  uint32(i + len(oldSub)),
+		NewEndByte:  uint32(i + len(newSub)),
+		StartPoint:  suffixReusePointAt(src, i),
+		OldEndPoint: suffixReusePointAt(src, i+len(oldSub)),
+		NewEndPoint: suffixReusePointAt(edited, i+len(newSub)),
+	}, true
+}
+
+// TestIncrementalLengthChangingReplaceMatchesFresh is the regression guard for
+// the #382 review's BLOCKING finding: a length-changing replace whose edited
+// range clamps a node's start must not let the reuse "un-dirty" optimization
+// reverse-map the clamped coordinate and reuse a stale (genuinely-changed)
+// subtree -- which produced a structurally-wrong incremental tree with
+// HasError()==false (silent corruption). Asserts EXACT structural equality
+// (full serialization) between incremental and fresh, not just node count.
+func TestIncrementalLengthChangingReplaceMatchesFresh(t *testing.T) {
+	cases := []struct {
+		name, lang, base, oldSub, newSub string
+	}{
+		{
+			// The review's exact repro: "margin: 14px;" -> "margin:px;". The
+			// integer_value(unit) node for "14px" is clamped; a stale reuse
+			// mistypes "px" as integer_value instead of plain_value.
+			name: "css_integer_value_clamp", lang: "css",
+			base:   "h1 {\n  color: red;\n  margin: 14px;\n  padding: 0;\n}\n",
+			oldSub: ": 14", newSub: ":",
+		},
+		{
+			// Delete-a-digit-inside-a-number variant, still a clamp-start replace.
+			name: "css_shrink_number", lang: "css",
+			base:   "a {\n  width: 1234px;\n  height: 5px;\n}\n",
+			oldSub: "1234", newSub: "1",
+		},
+		{
+			// Go: replace inside a composite-literal / call region near the top.
+			name: "go_replace_ident", lang: "go",
+			base:   "package main\n\nfunc main() {\n\tx := Thing{Val: 100}\n\t_ = x\n}\n",
+			oldSub: "100", newSub: "7",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := grammars.DetectLanguageByName(tc.lang)
+			if e == nil {
+				t.Skipf("language %q unavailable", tc.lang)
+			}
+			lang := e.Language()
+			src := []byte(tc.base)
+			base, err := gts.NewParser(lang).Parse(src)
+			if err != nil || base == nil || base.RootNode() == nil {
+				t.Fatalf("baseline parse failed: %v", err)
+			}
+			edited, edit, ok := clampReplaceEdit(src, tc.oldSub, tc.newSub)
+			if !ok {
+				t.Fatalf("substring %q not found in base", tc.oldSub)
+			}
+			fresh, _ := gts.NewParser(lang).Parse(edited)
+			if fresh == nil || fresh.RootNode() == nil {
+				t.Fatal("fresh parse of edited text failed")
+			}
+			old := base.Copy()
+			old.Edit(edit)
+			incr, _, err := gts.NewParser(lang).ParseIncrementalProfiled(edited, old)
+			if err != nil || incr == nil || incr.RootNode() == nil {
+				t.Fatalf("incremental parse failed: %v", err)
+			}
+			freshS := serializeNodeStructure(fresh.RootNode(), lang)
+			incrS := serializeNodeStructure(incr.RootNode(), lang)
+			if freshS != incrS {
+				t.Errorf("incremental tree diverges from fresh (silent corruption):\n  fresh: %s\n  incr:  %s", freshS, incrS)
+			}
+		})
+	}
+}
+
+// TestIncrementalMultiEditSequenceMatchesFresh exercises the multi-edit
+// reverse-map composition (oldByteForNew's loop) end-to-end -- applying several
+// length-changing edits to the same tree in sequence and asserting the
+// incremental result stays structurally identical to a fresh parse of the final
+// text at every step. The #382 review noted the headline multi-edit capability
+// shipped with no test.
+func TestIncrementalMultiEditSequenceMatchesFresh(t *testing.T) {
+	e := grammars.DetectLanguageByName("go")
+	if e == nil {
+		t.Skip("go unavailable")
+	}
+	lang := e.Language()
+	src := []byte("package main\n\nfunc f(aa, bb int) int {\n\treturn aa + bb + 1234\n}\n\nfunc g() int { return f(10, 20) }\n")
+	tree, err := gts.NewParser(lang).Parse(src)
+	if err != nil || tree == nil {
+		t.Fatalf("baseline parse failed: %v", err)
+	}
+	edits := []struct{ oldSub, newSub string }{
+		{"1234", "5"},   // shrink a literal (clamp)
+		{"aa", "alpha"}, // grow an identifier
+		{"return f(10, 20)", "return f(1, 2)"}, // shrink args
+	}
+	cur := src
+	for i, ed := range edits {
+		edited, edit, ok := clampReplaceEdit(cur, ed.oldSub, ed.newSub)
+		if !ok {
+			t.Fatalf("edit %d: substring %q not found", i, ed.oldSub)
+		}
+		tree.Edit(edit)
+		incr, _, err := gts.NewParser(lang).ParseIncrementalProfiled(edited, tree)
+		if err != nil || incr == nil || incr.RootNode() == nil {
+			t.Fatalf("edit %d: incremental parse failed: %v", i, err)
+		}
+		fresh, _ := gts.NewParser(lang).Parse(edited)
+		if s1, s2 := serializeNodeStructure(fresh.RootNode(), lang), serializeNodeStructure(incr.RootNode(), lang); s1 != s2 {
+			t.Fatalf("edit %d (%q->%q): incremental != fresh\n  fresh: %s\n  incr:  %s", i, ed.oldSub, ed.newSub, s1, s2)
+		}
+		tree, cur = incr, edited
+	}
+}

--- a/incremental_suffix_reuse_test.go
+++ b/incremental_suffix_reuse_test.go
@@ -1,0 +1,182 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// suffixReuseGoFile builds a valid Go source file with nFuncs top-level
+// functions, large enough that a single-byte edit near the top leaves almost
+// the entire file as an unchanged suffix.
+func suffixReuseGoFile(nFuncs int) []byte {
+	var b strings.Builder
+	b.WriteString("package main\n\n")
+	for i := 0; i < nFuncs; i++ {
+		fmt.Fprintf(&b, "func f%d(x int) int {\n\treturn x + %d\n}\n\n", i, i)
+	}
+	return []byte(b.String())
+}
+
+func suffixReusePointAt(src []byte, off int) gts.Point {
+	row, col := 0, 0
+	for i := 0; i < off && i < len(src); i++ {
+		if src[i] == '\n' {
+			row++
+			col = 0
+		} else {
+			col++
+		}
+	}
+	return gts.Point{Row: uint32(row), Column: uint32(col)}
+}
+
+func suffixReuseCountNodes(n *gts.Node) int {
+	if n == nil {
+		return 0
+	}
+	c := 1
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c += suffixReuseCountNodes(n.Child(i))
+	}
+	return c
+}
+
+func suffixReuseHasError(n *gts.Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.IsError() || n.IsMissing() {
+		return true
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if suffixReuseHasError(n.Child(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIncrementalSuffixReuseOnLengthChangingEdit is the regression guard for
+// GitHub issue #380: a length-changing edit (insert or delete) must reuse the
+// unchanged suffix subtrees rather than re-lexing the whole tail.
+//
+// Before the coordinate fix, the reuse byte-equality guard (nodeBytesEqual)
+// sliced the pre-edit oldSource at the node's POST-edit (shifted) coordinates.
+// For any edit that changed byte length, every suffix node's bytes therefore
+// spuriously "differed", the node was rejected as ancestor-dirty
+// (ReuseRejectAncestorDirtyBeforeEdit), and the parser re-lexed the entire
+// suffix (ReusedBytes collapsed to the tiny pre-edit prefix). This asserts both
+// halves of the fix: correctness (incremental == fresh) AND that reuse actually
+// engages (no ancestor-dirty rejections, a macroscopic ReusedBytes).
+func TestIncrementalSuffixReuseOnLengthChangingEdit(t *testing.T) {
+	e := grammars.DetectLanguageByName("go")
+	if e == nil {
+		t.Fatal("go language unavailable")
+	}
+	lang := e.Language()
+
+	const nFuncs = 2000
+	src := suffixReuseGoFile(nFuncs)
+	base := gts.NewParser(lang)
+	baseTree, err := base.Parse(src)
+	if err != nil || baseTree == nil || baseTree.RootNode() == nil {
+		t.Fatalf("baseline parse failed: %v", err)
+	}
+	if suffixReuseHasError(baseTree.RootNode()) {
+		t.Fatal("baseline parse has errors")
+	}
+
+	// Edit point in the leading whitespace right after "package main\n"
+	// (offset 13) — nearly the whole file is unchanged suffix.
+	const ip = 13
+
+	cases := []struct {
+		name  string
+		build func() ([]byte, gts.InputEdit)
+	}{
+		{
+			name: "insert", // OldEndByte != NewEndByte, +1 byte
+			build: func() ([]byte, gts.InputEdit) {
+				edited := make([]byte, 0, len(src)+1)
+				edited = append(edited, src[:ip]...)
+				edited = append(edited, ' ')
+				edited = append(edited, src[ip:]...)
+				return edited, gts.InputEdit{
+					StartByte: ip, OldEndByte: ip, NewEndByte: ip + 1,
+					StartPoint: suffixReusePointAt(src, ip), OldEndPoint: suffixReusePointAt(src, ip), NewEndPoint: suffixReusePointAt(edited, ip+1),
+				}
+			},
+		},
+		{
+			name: "delete", // OldEndByte != NewEndByte, -1 byte (negative delta)
+			build: func() ([]byte, gts.InputEdit) {
+				edited := make([]byte, 0, len(src)-1)
+				edited = append(edited, src[:ip]...)
+				edited = append(edited, src[ip+1:]...)
+				return edited, gts.InputEdit{
+					StartByte: ip, OldEndByte: ip + 1, NewEndByte: ip,
+					StartPoint: suffixReusePointAt(src, ip), OldEndPoint: suffixReusePointAt(src, ip+1), NewEndPoint: suffixReusePointAt(src, ip),
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			edited, edit := tc.build()
+
+			// Fresh parse of the edited text = ground truth.
+			fresh, _ := gts.NewParser(lang).Parse(edited)
+			if fresh == nil || fresh.RootNode() == nil {
+				t.Fatal("fresh parse of edited text failed")
+			}
+			if suffixReuseHasError(fresh.RootNode()) {
+				t.Fatal("fresh parse of edited text has errors (bad fixture)")
+			}
+			wantNodes := suffixReuseCountNodes(fresh.RootNode())
+
+			old := baseTree.Copy()
+			old.Edit(edit)
+			incrParser := gts.NewParser(lang)
+			incr, prof, err := incrParser.ParseIncrementalProfiled(edited, old)
+			if err != nil || incr == nil || incr.RootNode() == nil {
+				t.Fatalf("incremental parse failed: %v", err)
+			}
+
+			// (a) Correctness: incremental must equal fresh.
+			if suffixReuseHasError(incr.RootNode()) {
+				t.Errorf("incremental tree has errors that fresh parse does not")
+			}
+			if got := suffixReuseCountNodes(incr.RootNode()); got != wantNodes {
+				t.Errorf("node count mismatch: incremental=%d fresh=%d", got, wantNodes)
+			}
+			if incr.RootNode().Type(lang) != fresh.RootNode().Type(lang) {
+				t.Errorf("root type mismatch: incremental=%q fresh=%q", incr.RootNode().Type(lang), fresh.RootNode().Type(lang))
+			}
+			if int(incr.RootNode().EndByte()) != len(edited) {
+				t.Errorf("incremental root does not span edited buffer: end=%d len=%d", incr.RootNode().EndByte(), len(edited))
+			}
+
+			// (b) The suffix must actually be reused — this is the #380 bug
+			// signature. Pre-fix, the coordinate mismatch rejected ~every
+			// suffix node: ancestorDirtyBeforeEdit ≈ node count (thousands) and
+			// reusedBytes collapsed to the tiny pre-edit prefix. Post-fix only a
+			// few genuinely-changed boundary nodes at the edit site may reject,
+			// so the count must be a small constant, nowhere near node count.
+			if prof.ReuseRejectAncestorDirtyBeforeEdit > 50 {
+				t.Errorf("suffix reuse rejected as ancestor-dirty (%d rejections, node count %d) — coordinate reverse-map regressed",
+					prof.ReuseRejectAncestorDirtyBeforeEdit, wantNodes)
+			}
+			if prof.ReusedBytes < uint64(len(edited)/4) {
+				t.Errorf("suffix not reused: reusedBytes=%d for a %d-byte edited file (edit changed 1 byte near the top)",
+					prof.ReusedBytes, len(edited))
+			}
+			t.Logf("%s: reusedBytes=%d reusedSubtrees=%d ancestorDirtyBeforeEdit=%d nodes=%d",
+				tc.name, prof.ReusedBytes, prof.ReusedSubtrees, prof.ReuseRejectAncestorDirtyBeforeEdit, wantNodes)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a coordinate mapping bug in the incremental parser's reusable subtree guard that prevented suffix reuse after length-changing edits (inserts or deletes). The old source was historically sliced at post-edit (shifted) coordinates, causing spurious byte mismatches. Now reverse-maps coordinates correctly so unchanged suffixes can be safely reused.

## Changes

- Added edits list to reuseCursor to hold the old tree's recorded edits for coordinate reverse-mapping.
- Implemented oldByteForNew to translate post-edit byte positions back to their pre-edit offsets.
- Replaced nodeBytesEqual with nodeBytesUnchanged, which now correctly slices oldSource at reverse-mapped coordinates.
- Updated all reuse-guard call sites in reuseCursor and tryReuseSubtree to use the new coordinate-aware check.
- Added regression test TestIncrementalSuffixReuseOnLengthChangingEdit asserting that length-changing edits correctly reuse the unchanged suffix instead of re-parsing the file.

## Testing

- Run the new regression test: go test -run TestIncrementalSuffixReuseOnLengthChangingEdit -v ./...

## Related Issues

- Refs #380