### PR TITLE
add(parsercorephase0): gated one-pass selected store builder with cancellation polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Selected-store lifecycle (staged and one-pass)
+      - name: Selected-store internal package (staged and one-pass)
         run: |
           set -euo pipefail
-          lifecycle='^TestSelectedStore(AuthenticatedPolicyCapability|DeepTraversalIsIterativeAndCancellable|RootMergePreflightsCapAndLaterBuildRemainsBounded|SiblingReleasesAreSynchronized|RealSnapshotsSurviveResetAndReleaseOrders|RootGrowthCopyPollsCancellation|OnePassFinalLogicalSizeGovernsRetainedCap|OnePassCancellationAfterGrowthReusesCleanBacking|OnePassRightSizeCopyPollsCancellation)$'
-          GOMAXPROCS=1 go test -race ./internal/parsercorephase0 -run "$lifecycle" -count=1
-          GOMAXPROCS=1 go test -race -tags gts_parsercorephase0_selectedstore_onepass ./internal/parsercorephase0 -run "$lifecycle" -count=1
+          GOMAXPROCS=1 go test -race ./internal/parsercorephase0 -count=1
+          GOMAXPROCS=1 go test -race -tags gts_parsercorephase0_selectedstore_onepass ./internal/parsercorephase0 -count=1
 
       - name: Selected-store exact admission (staged and one-pass)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,32 @@ jobs:
       - name: Test Compile
         run: go test ./... -run '^$' -count=1
 
+  selected_store_admission:
+    needs: exhaustive_parity_scope
+    if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Selected-store lifecycle (staged and one-pass)
+        run: |
+          set -euo pipefail
+          lifecycle='^TestSelectedStore(AuthenticatedPolicyCapability|DeepTraversalIsIterativeAndCancellable|RootMergePreflightsCapAndLaterBuildRemainsBounded|SiblingReleasesAreSynchronized|RealSnapshotsSurviveResetAndReleaseOrders|RootGrowthCopyPollsCancellation|OnePassFinalLogicalSizeGovernsRetainedCap|OnePassCancellationAfterGrowthReusesCleanBacking|OnePassRightSizeCopyPollsCancellation)$'
+          GOMAXPROCS=1 go test -race ./internal/parsercorephase0 -run "$lifecycle" -count=1
+          GOMAXPROCS=1 go test -race -tags gts_parsercorephase0_selectedstore_onepass ./internal/parsercorephase0 -run "$lifecycle" -count=1
+
+      - name: Selected-store exact admission (staged and one-pass)
+        run: |
+          set -euo pipefail
+          admission='^TestDiagnosticParserCoreSelectedStore(CanonicalAdmissions|CompletenessFailureReleasesBacking|GoHighlightParity|QueryDirectiveParity)$'
+          GOMAXPROCS=1 go test -tags gts_parsercorephase0 . -run "$admission" -count=1
+          GOMAXPROCS=1 go test -tags 'gts_parsercorephase0 gts_parsercorephase0_selectedstore_onepass' . -run "$admission" -count=1
+
   race_root:
     needs: exhaustive_parity_scope
     if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
@@ -318,6 +344,7 @@ jobs:
   build:
     needs:
       - compile
+      - selected_store_admission
       - race_root
       - race_packages
       - draft_focused_tests
@@ -334,6 +361,7 @@ jobs:
           IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
           RUN_CODE_CI: ${{ needs.exhaustive_parity_scope.outputs.run_code_ci }}
           COMPILE_RESULT: ${{ needs.compile.result }}
+          SELECTED_STORE_ADMISSION_RESULT: ${{ needs.selected_store_admission.result }}
           RACE_ROOT_RESULT: ${{ needs.race_root.result }}
           RACE_PACKAGES_RESULT: ${{ needs.race_packages.result }}
           DRAFT_FOCUSED_RESULT: ${{ needs.draft_focused_tests.result }}
@@ -371,6 +399,7 @@ jobs:
           fi
 
           require_success "compile" "$COMPILE_RESULT"
+          require_success "selected_store_admission" "$SELECTED_STORE_ADMISSION_RESULT"
           require_success "parity_report" "$PARITY_REPORT_RESULT"
           require_success "perf_scan_budget" "$PERF_SCAN_BUDGET_RESULT"
 

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -578,7 +578,7 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 			}
 		}
 	}
-	if err := store.finishRoots(rootIDs, policy, c.limits.MaxSelectedBytes); err != nil {
+	if err := store.finishRoots(rootIDs, policy, c.limits.MaxSelectedBytes, poll); err != nil {
 		return nil, err
 	}
 	if err := store.normalizeGoCompatibility(policy, source, poll); err != nil {
@@ -904,7 +904,57 @@ func selectedRootMergeCounts(childCount, rootCount int, realChildCount uint16) (
 	return int(mergedCount), int(finalChildren), nil
 }
 
-func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStorePolicy, retainedCap uint64) error {
+const selectedStoreCopyPollElements = 1024
+
+func copySelectedStoreChunks[T any](destination, source []T, poll func() error) error {
+	if len(destination) < len(source) {
+		return errors.New("parser-core phase zero: selected store copy destination is short")
+	}
+	for start := 0; start < len(source); start += selectedStoreCopyPollElements {
+		if poll != nil {
+			if err := poll(); err != nil {
+				return err
+			}
+		}
+		end := min(start+selectedStoreCopyPollElements, len(source))
+		copy(destination[start:end], source[start:end])
+	}
+	return nil
+}
+
+func moveSelectedStoreChildren(children []SelectedNodeID, destination, source, count int, poll func() error) error {
+	if count < 0 || destination < 0 || source < 0 || destination+count > len(children) || source+count > len(children) {
+		return errors.New("parser-core phase zero: selected child move is outside arena")
+	}
+	if count == 0 || destination == source {
+		return nil
+	}
+	if destination < source {
+		for offset := 0; offset < count; offset += selectedStoreCopyPollElements {
+			if poll != nil {
+				if err := poll(); err != nil {
+					return err
+				}
+			}
+			width := min(selectedStoreCopyPollElements, count-offset)
+			copy(children[destination+offset:destination+offset+width], children[source+offset:source+offset+width])
+		}
+		return nil
+	}
+	for remaining := count; remaining > 0; {
+		if poll != nil {
+			if err := poll(); err != nil {
+				return err
+			}
+		}
+		width := min(selectedStoreCopyPollElements, remaining)
+		remaining -= width
+		copy(children[destination+remaining:destination+remaining+width], children[source+remaining:source+remaining+width])
+	}
+	return nil
+}
+
+func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStorePolicy, retainedCap uint64, poll func() error) error {
 	if len(roots) == 0 {
 		return errors.New("parser-core phase zero: selected store sealed no logical roots")
 	}
@@ -952,15 +1002,25 @@ func (s *SelectedStore) finishRoots(roots []SelectedNodeID, policy SelectedStore
 	oldLength := len(s.children)
 	if cap(s.children) < finalChildren {
 		children := make([]SelectedNodeID, oldLength, finalChildren)
-		copy(children, s.children)
+		if err := copySelectedStoreChunks(children, s.children, poll); err != nil {
+			return err
+		}
 		s.children = children
 	}
 	s.children = s.children[:finalChildren]
-	copy(s.children[oldEnd+uint32(extraCount):], s.children[oldEnd:uint32(oldLength)])
+	if err := moveSelectedStoreChildren(s.children, int(oldEnd)+extraCount, int(oldEnd), oldLength-int(oldEnd), poll); err != nil {
+		return err
+	}
 	before := uint32(realIndex)
-	copy(s.children[oldStart+before:oldEnd+before], s.children[oldStart:oldEnd])
-	copy(s.children[oldStart:oldStart+before], roots[:realIndex])
-	copy(s.children[oldEnd+before:oldEnd+uint32(extraCount)], roots[realIndex+1:])
+	if err := moveSelectedStoreChildren(s.children, int(oldStart+before), int(oldStart), int(real.ChildCount), poll); err != nil {
+		return err
+	}
+	if err := copySelectedStoreChunks(s.children[oldStart:oldStart+before], roots[:realIndex], poll); err != nil {
+		return err
+	}
+	if err := copySelectedStoreChunks(s.children[oldEnd+before:oldEnd+uint32(extraCount)], roots[realIndex+1:], poll); err != nil {
+		return err
+	}
 	for index := range s.records {
 		record := &s.records[index]
 		if SelectedNodeID(index+1) != realID && record.ChildCount != 0 && record.FirstChild >= oldEnd {

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -409,11 +409,7 @@ type selectedRawOccurrence struct {
 	field      FieldID
 }
 
-// BuildSelectedStore seals accepted roots directly from compact immutable
-// payload arenas. It does not enumerate a head, construct public Nodes, or
-// invoke a per-occurrence callback. It borrows Core-owned scratch and therefore
-// must not run concurrently with any other operation on the same Core.
-func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
 	if c == nil || len(roots) == 0 {
 		return nil, errors.New("parser-core phase zero: selected store requires accepted roots")
 	}

--- a/internal/parsercorephase0/selected_store_builder_onepass.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass.go
@@ -10,7 +10,9 @@ import (
 
 // BuildSelectedStore seals accepted roots with the diagnostic one-pass
 // occurrence folder. The tag keeps this candidate out of ordinary builds until
-// its exactness and end-to-end economics are proven.
+// its exactness and end-to-end economics are proven. It borrows Core-owned
+// scratch and therefore must not run concurrently with any other operation on
+// the same Core.
 func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
 	return c.buildSelectedStoreOnePass(roots, policy, source, poll)
 }
@@ -181,7 +183,7 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 				if childCount > math.MaxUint16 || uint64(len(store.children))+uint64(childCount) > math.MaxUint32 || uint64(len(store.records)) >= math.MaxUint32 {
 					return nil, errors.New("parser-core phase zero: selected store exceeded uint32 arena")
 				}
-				if err := ensureSelectedOnePassCapacity(store, len(store.records)+1, len(store.children)+childCount, c.limits.MaxSelectedBytes); err != nil {
+				if err := ensureSelectedOnePassCapacity(store, len(store.records)+1, len(store.children)+childCount, c.limits.MaxSelectedBytes, poll); err != nil {
 					return nil, err
 				}
 				id := SelectedNodeID(uint64(len(store.records)) + 1)
@@ -225,14 +227,14 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 		logical = logical[:rootStart]
 	}
 
-	maxInt := uint64(^uint(0) >> 1)
-	if occurrences > maxInt || rawChildSlots > maxInt {
-		return nil, errors.New("parser-core phase zero: selected store exceeds platform capacity")
-	}
-	if err := rightSizeSelectedOnePassStore(store, int(occurrences), int(rawChildSlots), c.limits.MaxSelectedBytes); err != nil {
+	// Drop record reserve before root merging so its retained-cap preflight is
+	// charged to logical nodes, not hidden/collapsed raw occurrences. Keep the
+	// already-admitted child reserve until the final seal to avoid copying the
+	// edge arena twice when compatibility normalization removes children.
+	if err := rightSizeSelectedOnePassStore(store, len(store.records), cap(store.children), c.limits.MaxSelectedBytes, poll); err != nil {
 		return nil, err
 	}
-	if err := store.finishRoots(rootIDs, policy, c.limits.MaxSelectedBytes); err != nil {
+	if err := store.finishRoots(rootIDs, policy, c.limits.MaxSelectedBytes, poll); err != nil {
 		return nil, err
 	}
 	if err := store.normalizeGoCompatibility(policy, source, poll); err != nil {
@@ -241,8 +243,8 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 	if err := store.recomputePrecedence(precedenceDeltas); err != nil {
 		return nil, err
 	}
-	if store.RetainedBytes() > c.limits.MaxSelectedBytes {
-		return nil, errors.New("parser-core phase zero: selected store retained-byte cap")
+	if err := rightSizeSelectedOnePassStore(store, len(store.records), len(store.children), c.limits.MaxSelectedBytes, poll); err != nil {
+		return nil, err
 	}
 	if err := poll(); err != nil {
 		return nil, err
@@ -257,7 +259,7 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 	return store, nil
 }
 
-func ensureSelectedOnePassCapacity(store *SelectedStore, recordNeed, childNeed int, retainedCap uint64) error {
+func ensureSelectedOnePassCapacity(store *SelectedStore, recordNeed, childNeed int, retainedCap uint64, poll func() error) error {
 	recordCapacity := selectedOnePassGrowth(cap(store.records), recordNeed)
 	childCapacity := selectedOnePassGrowth(cap(store.children), childNeed)
 	if selectedStoreRetainedBytes(recordCapacity, childCapacity) > retainedCap {
@@ -270,12 +272,16 @@ func ensureSelectedOnePassCapacity(store *SelectedStore, recordNeed, childNeed i
 	}
 	if recordCapacity != cap(store.records) {
 		records := make([]SelectedNodeRecord, len(store.records), recordCapacity)
-		copy(records, store.records)
+		if err := copySelectedStoreChunks(records, store.records, poll); err != nil {
+			return err
+		}
 		store.records = records
 	}
 	if childCapacity != cap(store.children) {
 		children := make([]SelectedNodeID, len(store.children), childCapacity)
-		copy(children, store.children)
+		if err := copySelectedStoreChunks(children, store.children, poll); err != nil {
+			return err
+		}
 		store.children = children
 	}
 	return nil
@@ -295,19 +301,23 @@ func selectedOnePassGrowth(capacity, need int) int {
 	return next
 }
 
-func rightSizeSelectedOnePassStore(store *SelectedStore, recordCapacity, childCapacity int, retainedCap uint64) error {
+func rightSizeSelectedOnePassStore(store *SelectedStore, recordCapacity, childCapacity int, retainedCap uint64, poll func() error) error {
 	if recordCapacity < len(store.records) || childCapacity < len(store.children) ||
 		selectedStoreRetainedBytes(recordCapacity, childCapacity) > retainedCap {
 		return errors.New("parser-core phase zero: selected store retained-byte cap")
 	}
 	if cap(store.records) != recordCapacity {
 		records := make([]SelectedNodeRecord, len(store.records), recordCapacity)
-		copy(records, store.records)
+		if err := copySelectedStoreChunks(records, store.records, poll); err != nil {
+			return err
+		}
 		store.records = records
 	}
 	if cap(store.children) != childCapacity {
 		children := make([]SelectedNodeID, len(store.children), childCapacity)
-		copy(children, store.children)
+		if err := copySelectedStoreChunks(children, store.children, poll); err != nil {
+			return err
+		}
 		store.children = children
 	}
 	return nil

--- a/internal/parsercorephase0/selected_store_builder_onepass.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass.go
@@ -1,0 +1,314 @@
+//go:build gts_parsercorephase0_selectedstore_onepass
+
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// BuildSelectedStore seals accepted roots with the diagnostic one-pass
+// occurrence folder. The tag keeps this candidate out of ordinary builds until
+// its exactness and end-to-end economics are proven.
+func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+	return c.buildSelectedStoreOnePass(roots, policy, source, poll)
+}
+
+// buildSelectedStoreOnePass traverses accepted compact occurrences in
+// iterative postorder and emits their logical result directly into the sealed
+// store. The three parallel frame slices are existing Core-owned scratch:
+// stack carries next-child/logical-window state, collect carries payload IDs,
+// and rawRoots carries packed alias/field provenance.
+func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+	if c == nil || len(roots) == 0 {
+		return nil, errors.New("parser-core phase zero: selected store requires accepted roots")
+	}
+	if err := policy.validate(); err != nil {
+		return nil, err
+	}
+	if poll == nil {
+		poll = func() error { return nil }
+	}
+	if err := poll(); err != nil {
+		return nil, err
+	}
+
+	defer c.finishSelectedBuildScratch()
+	store := c.acquireSelectedStore(0, 0)
+	sealed := false
+	defer func() {
+		if !sealed {
+			store.Release()
+		}
+	}()
+
+	precedenceDeltas := c.selectedBuild.precedence[:0]
+	logical := c.selectedBuild.logical[:0]
+	rootIDs := c.selectedBuild.rootIDs[:0]
+	stack := c.selectedBuild.stack[:0]
+	if cap(stack) < 64 {
+		stack = make([]selectedOccurrenceFrame, 0, 64)
+	}
+	payloads := c.selectedBuild.collect[:0]
+	if cap(payloads) < 64 {
+		payloads = make([]uint32, 0, 64)
+	}
+	edges := c.selectedBuild.rawRoots[:0]
+	if cap(edges) < 64 {
+		edges = make([]uint32, 0, 64)
+	}
+	c.selectedBuild.precedence = precedenceDeltas
+	c.selectedBuild.logical = logical
+	c.selectedBuild.rootIDs = rootIDs
+	c.selectedBuild.stack = stack
+	c.selectedBuild.collect = payloads
+	c.selectedBuild.rawRoots = edges
+
+	var occurrences, rawChildSlots, work uint64
+	push := func(payload SubtreeID, alias Symbol, field FieldID) error {
+		record, err := c.subtree(payload)
+		if err != nil {
+			return err
+		}
+		if record.childCount > math.MaxUint16 || occurrences+1 > uint64(c.limits.MaxSelectedOccurrences) ||
+			rawChildSlots+uint64(record.childCount) > uint64(c.limits.MaxSelectedOccurrences) {
+			return errors.New("parser-core phase zero: raw selected occurrence cap")
+		}
+		if occurrences >= math.MaxUint32 || rawChildSlots+uint64(record.childCount) > math.MaxUint32 {
+			return errors.New("parser-core phase zero: raw selected occurrence exceeds arena")
+		}
+		if uint64(len(logical)) > math.MaxUint32 {
+			return errors.New("parser-core phase zero: selected logical output exceeds arena")
+		}
+		occurrences++
+		rawChildSlots += uint64(record.childCount)
+		stack = append(stack, selectedOccurrenceFrame{occurrence: uint32(len(logical))})
+		payloads = append(payloads, uint32(payload))
+		edges = append(edges, uint32(alias)|uint32(field)<<16)
+		return nil
+	}
+
+	for _, root := range roots {
+		rootStart := len(logical)
+		if err := push(root, 0, 0); err != nil {
+			return nil, err
+		}
+		for len(stack) != 0 {
+			work++
+			if work&255 == 0 {
+				if err := poll(); err != nil {
+					return nil, err
+				}
+			}
+			frameIndex := len(stack) - 1
+			frame := &stack[frameIndex]
+			record, err := c.subtree(SubtreeID(payloads[frameIndex]))
+			if err != nil {
+				return nil, err
+			}
+			if frame.next < record.childCount {
+				ordinal := frame.next
+				frame.next++
+				payload := c.children[record.firstChild+ordinal]
+				var alias Symbol
+				if record.aliasCount != 0 {
+					if record.aliasCount != record.childCount {
+						return nil, errors.New("parser-core phase zero: selected alias width drifted")
+					}
+					alias = c.aliases[record.firstAlias+ordinal]
+				}
+				var field FieldID
+				for _, entry := range c.fields[record.firstField : record.firstField+record.fieldCount] {
+					if uint32(entry.ChildIndex) != ordinal {
+						continue
+					}
+					if entry.Inherited || field != 0 {
+						return nil, errors.New("parser-core phase zero: selected field profile is outside admitted direct single-field scope")
+					}
+					field = entry.FieldID
+				}
+				if err := push(payload, alias, field); err != nil {
+					return nil, err
+				}
+				continue
+			}
+
+			logicalStart := int(frame.occurrence)
+			packedEdge := edges[frameIndex]
+			alias := Symbol(packedEdge)
+			field := FieldID(packedEdge >> 16)
+			symbol := record.symbol
+			if alias != 0 {
+				symbol = alias
+			}
+			meta, ok := policy.symbol(symbol)
+			if !ok {
+				return nil, fmt.Errorf("parser-core phase zero: selected symbol %d is outside policy", symbol)
+			}
+
+			folded := false
+			if !record.terminal && record.childCount == 1 && record.fieldCount == 0 && record.aliasCount == 0 && len(logical)-logicalStart == 1 {
+				childID := logical[logicalStart]
+				child := &store.records[childID-1]
+				rule := policy.unary(record.symbol, child.Symbol)
+				if !child.Extra() && (rule == SelectedUnaryPass || rule == SelectedUnaryRenameLeaf && child.ChildCount == 0) {
+					if rule == SelectedUnaryRenameLeaf {
+						child.Symbol = record.symbol
+						child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal())
+					}
+					if alias != 0 {
+						child.Symbol = alias
+						child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
+					}
+					child.ProductionID = record.productionID
+					delta, err := checkedSelectedPrecedence(precedenceDeltas[childID-1], int32(record.dynamicPrecedence))
+					if err != nil {
+						return nil, err
+					}
+					precedenceDeltas[childID-1] = delta
+					if field != 0 {
+						child.Field = field
+					}
+					logical = logical[:logicalStart+1]
+					logical[logicalStart] = childID
+					folded = true
+				}
+			}
+
+			if !folded && (meta.Visible || record.extra) {
+				childCount := len(logical) - logicalStart
+				if childCount > math.MaxUint16 || uint64(len(store.children))+uint64(childCount) > math.MaxUint32 || uint64(len(store.records)) >= math.MaxUint32 {
+					return nil, errors.New("parser-core phase zero: selected store exceeded uint32 arena")
+				}
+				if err := ensureSelectedOnePassCapacity(store, len(store.records)+1, len(store.children)+childCount, c.limits.MaxSelectedBytes); err != nil {
+					return nil, err
+				}
+				id := SelectedNodeID(uint64(len(store.records)) + 1)
+				first := uint32(len(store.children))
+				children := logical[logicalStart:]
+				store.children = append(store.children, children...)
+				flags := selectedFlags(meta, record.extra, record.external, record.terminal)
+				startByte, endByte := record.startByte, record.endByte
+				if len(children) != 0 {
+					firstChild := store.records[children[0]-1]
+					lastChild := store.records[children[len(children)-1]-1]
+					if firstChild.StartByte < startByte {
+						startByte = firstChild.StartByte
+					}
+					if lastChild.EndByte > endByte {
+						endByte = lastChild.EndByte
+					}
+				}
+				store.records = append(store.records, SelectedNodeRecord{
+					FirstChild: first, StartByte: startByte, EndByte: endByte,
+					Symbol: symbol, Field: field,
+					ProductionID: record.productionID, DynamicPrecedence: int32(record.dynamicPrecedence),
+					ChildCount: uint16(len(children)), flags: flags,
+				})
+				precedenceDeltas = append(precedenceDeltas, int32(record.dynamicPrecedence))
+				for childIndex, childID := range children {
+					store.records[childID-1].Parent = id
+					store.records[childID-1].ChildIndex = uint16(childIndex)
+				}
+				logical = logical[:logicalStart]
+				logical = append(logical, id)
+			}
+			if field != 0 {
+				store.applyDirectField(logical[logicalStart:], field)
+			}
+			stack = stack[:frameIndex]
+			payloads = payloads[:frameIndex]
+			edges = edges[:frameIndex]
+		}
+		rootIDs = append(rootIDs, logical[rootStart:]...)
+		logical = logical[:rootStart]
+	}
+
+	maxInt := uint64(^uint(0) >> 1)
+	if occurrences > maxInt || rawChildSlots > maxInt {
+		return nil, errors.New("parser-core phase zero: selected store exceeds platform capacity")
+	}
+	if err := rightSizeSelectedOnePassStore(store, int(occurrences), int(rawChildSlots), c.limits.MaxSelectedBytes); err != nil {
+		return nil, err
+	}
+	if err := store.finishRoots(rootIDs, policy, c.limits.MaxSelectedBytes); err != nil {
+		return nil, err
+	}
+	if err := store.normalizeGoCompatibility(policy, source, poll); err != nil {
+		return nil, err
+	}
+	if err := store.recomputePrecedence(precedenceDeltas); err != nil {
+		return nil, err
+	}
+	if store.RetainedBytes() > c.limits.MaxSelectedBytes {
+		return nil, errors.New("parser-core phase zero: selected store retained-byte cap")
+	}
+	if err := poll(); err != nil {
+		return nil, err
+	}
+	c.selectedBuild.precedence = precedenceDeltas
+	c.selectedBuild.logical = logical
+	c.selectedBuild.rootIDs = rootIDs
+	c.selectedBuild.stack = stack
+	c.selectedBuild.collect = payloads
+	c.selectedBuild.rawRoots = edges
+	sealed = true
+	return store, nil
+}
+
+func ensureSelectedOnePassCapacity(store *SelectedStore, recordNeed, childNeed int, retainedCap uint64) error {
+	recordCapacity := selectedOnePassGrowth(cap(store.records), recordNeed)
+	childCapacity := selectedOnePassGrowth(cap(store.children), childNeed)
+	if selectedStoreRetainedBytes(recordCapacity, childCapacity) > retainedCap {
+		// Tight test/application caps may not admit the normal geometric reserve.
+		// Fall back to exactly the currently required pair before declining.
+		recordCapacity, childCapacity = max(cap(store.records), recordNeed), max(cap(store.children), childNeed)
+		if selectedStoreRetainedBytes(recordCapacity, childCapacity) > retainedCap {
+			return errors.New("parser-core phase zero: selected store retained-byte cap")
+		}
+	}
+	if recordCapacity != cap(store.records) {
+		records := make([]SelectedNodeRecord, len(store.records), recordCapacity)
+		copy(records, store.records)
+		store.records = records
+	}
+	if childCapacity != cap(store.children) {
+		children := make([]SelectedNodeID, len(store.children), childCapacity)
+		copy(children, store.children)
+		store.children = children
+	}
+	return nil
+}
+
+func selectedOnePassGrowth(capacity, need int) int {
+	if capacity >= need {
+		return capacity
+	}
+	next := capacity * 2
+	if next < 64 {
+		next = 64
+	}
+	if next < need {
+		next = need
+	}
+	return next
+}
+
+func rightSizeSelectedOnePassStore(store *SelectedStore, recordCapacity, childCapacity int, retainedCap uint64) error {
+	if recordCapacity < len(store.records) || childCapacity < len(store.children) ||
+		selectedStoreRetainedBytes(recordCapacity, childCapacity) > retainedCap {
+		return errors.New("parser-core phase zero: selected store retained-byte cap")
+	}
+	if cap(store.records) != recordCapacity {
+		records := make([]SelectedNodeRecord, len(store.records), recordCapacity)
+		copy(records, store.records)
+		store.records = records
+	}
+	if cap(store.children) != childCapacity {
+		children := make([]SelectedNodeID, len(store.children), childCapacity)
+		copy(children, store.children)
+		store.children = children
+	}
+	return nil
+}

--- a/internal/parsercorephase0/selected_store_builder_onepass_test.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass_test.go
@@ -1,0 +1,133 @@
+//go:build gts_parsercorephase0_selectedstore_onepass
+
+package parsercorephase0
+
+import (
+	"errors"
+	"testing"
+	"unsafe"
+)
+
+func TestSelectedStoreOnePassFinalLogicalSizeGovernsRetainedCap(t *testing.T) {
+	const depth = 256
+	recordBytes := uint64(unsafe.Sizeof(SelectedNodeRecord{}))
+	compact, err := New(&fakeTable{}, Limits{
+		MaxSubtrees:            depth + 2,
+		MaxChildren:            depth + 2,
+		MaxSelectedOccurrences: depth + 2,
+		MaxSelectedBytes:       recordBytes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < depth; index++ {
+		root, err = compact.appendSubtree(subtreeRecord{symbol: 3, endByte: 1}, []SubtreeID{root}, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, selectedStoreTestPolicy(t, 1), []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Release()
+	if store.NodeCount() != 1 || store.ChildCount() != 0 || store.RetainedBytes() != recordBytes {
+		t.Fatalf("collapsed store nodes=%d children=%d retained=%d want=%d", store.NodeCount(), store.ChildCount(), store.RetainedBytes(), recordBytes)
+	}
+}
+
+func TestSelectedStoreOnePassCancellationAfterGrowthReusesCleanBacking(t *testing.T) {
+	const childCount = 4096
+	compact, err := New(&fakeTable{}, Limits{
+		MaxSubtrees:            4,
+		MaxChildren:            childCount + 1,
+		MaxSelectedOccurrences: childCount + 2,
+		MaxSelectedBytes:       1 << 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := compact.appendSubtree(subtreeRecord{symbol: 1, endByte: 1, terminal: true}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	children := make([]SubtreeID, childCount)
+	for index := range children {
+		children[index] = leaf
+	}
+	root, err := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: 1}, children, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := selectedStoreTestPolicy(t, 2, 1)
+	stop := errors.New("stop after selected-store growth")
+	polls := 0
+	store, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), func() error {
+		polls++
+		if polls == 4 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) || store != nil {
+		t.Fatalf("cancelled store=%v err=%v polls=%d", store, err, polls)
+	}
+	compact.selectedPoolMu.Lock()
+	pooledRecords := cap(compact.selectedPool.records)
+	compact.selectedPoolMu.Unlock()
+	if pooledRecords == 0 {
+		t.Fatal("cancelled grown backing was not returned to the pool")
+	}
+
+	fresh, err := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fresh.Release()
+	if fresh.NodeCount() != childCount+1 || fresh.ChildCount() != childCount {
+		t.Fatalf("fresh store nodes=%d children=%d", fresh.NodeCount(), fresh.ChildCount())
+	}
+	rootRecord, ok := fresh.Record(fresh.Root())
+	firstID, firstOK := fresh.Child(rootRecord, 0)
+	lastID, lastOK := fresh.Child(rootRecord, childCount-1)
+	first, firstRecordOK := fresh.Record(firstID)
+	last, lastRecordOK := fresh.Record(lastID)
+	if !ok || !firstOK || !lastOK || !firstRecordOK || !lastRecordOK || firstID == lastID ||
+		first.Symbol != 1 || last.Symbol != 1 || first.Parent != fresh.Root() || last.Parent != fresh.Root() ||
+		first.ChildIndex != 0 || last.ChildIndex != childCount-1 {
+		t.Fatalf("fresh backing leaked state: root=%+v first=%+v/%d last=%+v/%d ok=%t/%t/%t/%t/%t",
+			rootRecord, first, firstID, last, lastID, ok, firstOK, lastOK, firstRecordOK, lastRecordOK)
+	}
+}
+
+func TestSelectedStoreOnePassRightSizeCopyPollsCancellation(t *testing.T) {
+	compact, err := New(&fakeTable{}, Limits{MaxSelectedBytes: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const length = 3 * selectedStoreCopyPollElements
+	store := &SelectedStore{
+		owner:   compact,
+		records: make([]SelectedNodeRecord, length, 4*selectedStoreCopyPollElements),
+	}
+	defer store.Release()
+	stop := errors.New("stop during selected-store right-size")
+	polls := 0
+	err = rightSizeSelectedOnePassStore(store, len(store.records), 0, compact.limits.MaxSelectedBytes, func() error {
+		polls++
+		if polls == 2 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) || polls != 2 {
+		t.Fatalf("right-size err=%v polls=%d", err, polls)
+	}
+	if cap(store.records) != 4*selectedStoreCopyPollElements {
+		t.Fatalf("cancelled right-size published partial backing cap=%d", cap(store.records))
+	}
+}

--- a/internal/parsercorephase0/selected_store_builder_staged.go
+++ b/internal/parsercorephase0/selected_store_builder_staged.go
@@ -1,0 +1,11 @@
+//go:build !gts_parsercorephase0_selectedstore_onepass
+
+package parsercorephase0
+
+// BuildSelectedStore seals accepted roots directly from compact immutable
+// payload arenas. It does not enumerate a head, construct public Nodes, or
+// invoke a per-occurrence callback. It borrows Core-owned scratch and therefore
+// must not run concurrently with any other operation on the same Core.
+func (c *Core) BuildSelectedStore(roots []SubtreeID, policy SelectedStorePolicy, source []byte, poll func() error) (*SelectedStore, error) {
+	return c.buildSelectedStoreStaged(roots, policy, source, poll)
+}

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -416,6 +416,113 @@ func TestSelectedStoreSiblingReleasesAreSynchronized(t *testing.T) {
 	}
 }
 
+func TestSelectedStoreRealSnapshotsSurviveResetAndReleaseOrders(t *testing.T) {
+	for _, mode := range []string{"first-then-second", "second-then-first", "concurrent"} {
+		t.Run(mode, func(t *testing.T) {
+			compact, err := New(&fakeTable{}, Limits{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			policy := selectedStoreTestPolicy(t, 2, 1)
+			build := func(start, end uint32) *SelectedStore {
+				leaf, appendErr := compact.appendSubtree(subtreeRecord{symbol: 1, startByte: start, endByte: end, terminal: true}, nil, nil, nil)
+				if appendErr != nil {
+					t.Fatal(appendErr)
+				}
+				root, appendErr := compact.appendSubtree(subtreeRecord{symbol: 2, endByte: end}, []SubtreeID{leaf}, nil, nil)
+				if appendErr != nil {
+					t.Fatal(appendErr)
+				}
+				store, buildErr := compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("xx"), nil)
+				if buildErr != nil {
+					t.Fatal(buildErr)
+				}
+				return store
+			}
+			first := build(0, 1)
+			if err := compact.Reset(); err != nil {
+				t.Fatal(err)
+			}
+			second := build(1, 2)
+			validate := func(name string, store *SelectedStore, start, end uint32) {
+				t.Helper()
+				root, ok := store.Record(store.Root())
+				if !ok || root.Symbol != 2 || root.ChildCount != 1 {
+					t.Fatalf("%s root=%+v ok=%t", name, root, ok)
+				}
+				childID, ok := store.Child(root, 0)
+				child, childOK := store.Record(childID)
+				if !ok || !childOK || child.Symbol != 1 || child.StartByte != start || child.EndByte != end || child.Parent != store.Root() {
+					t.Fatalf("%s child=%+v id=%d ok=%t/%t", name, child, childID, ok, childOK)
+				}
+			}
+			validate("first", first, 0, 1)
+			validate("second", second, 1, 2)
+			switch mode {
+			case "first-then-second":
+				first.Release()
+				second.Release()
+			case "second-then-first":
+				second.Release()
+				first.Release()
+			case "concurrent":
+				var wait sync.WaitGroup
+				wait.Add(2)
+				go func() { defer wait.Done(); first.Release() }()
+				go func() { defer wait.Done(); second.Release() }()
+				wait.Wait()
+			}
+			if first.Root() != 0 || second.Root() != 0 || first.RetainedBytes() != 0 || second.RetainedBytes() != 0 {
+				t.Fatalf("released snapshots remained readable: first=%d/%d second=%d/%d", first.Root(), first.RetainedBytes(), second.Root(), second.RetainedBytes())
+			}
+			compact.selectedPoolMu.Lock()
+			retained := selectedStoreRetainedBytes(cap(compact.selectedPool.records), cap(compact.selectedPool.children))
+			compact.selectedPoolMu.Unlock()
+			if retained > compact.limits.MaxSelectedBytes {
+				t.Fatalf("pooled real snapshot backing=%d cap=%d", retained, compact.limits.MaxSelectedBytes)
+			}
+		})
+	}
+}
+
+func TestSelectedStoreRootGrowthCopyPollsCancellation(t *testing.T) {
+	const childCount = 2048
+	compact, err := New(&fakeTable{}, Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	records := make([]SelectedNodeRecord, childCount*2+1)
+	children := make([]SelectedNodeID, childCount)
+	for index := 0; index < childCount; index++ {
+		children[index] = SelectedNodeID(index + 1)
+		records[childCount+index] = SelectedNodeRecord{Symbol: 3, flags: selectedNodeFlagExtra}
+	}
+	realID := SelectedNodeID(len(records))
+	records[realID-1] = SelectedNodeRecord{Symbol: 2, ChildCount: childCount}
+	store := &SelectedStore{owner: compact, records: records, children: children}
+	defer store.Release()
+	roots := make([]SelectedNodeID, 0, childCount+1)
+	for index := 0; index < childCount; index++ {
+		roots = append(roots, SelectedNodeID(childCount+index+1))
+	}
+	roots = append(roots, realID)
+	stop := errors.New("stop during selected root growth")
+	polls := 0
+	err = store.finishRoots(roots, selectedStoreTestPolicy(t, 2, 3), math.MaxUint64, func() error {
+		polls++
+		if polls == 2 {
+			return stop
+		}
+		return nil
+	})
+	if !errors.Is(err, stop) || polls != 2 {
+		t.Fatalf("root growth err=%v polls=%d", err, polls)
+	}
+	if store.Root() != 0 || len(store.children) != childCount || cap(store.children) != childCount {
+		t.Fatalf("cancelled root growth published state: root=%d len=%d cap=%d", store.Root(), len(store.children), cap(store.children))
+	}
+}
+
 func TestSelectedRootMergeCountsPreflightArithmetic(t *testing.T) {
 	tests := []struct {
 		name                          string


### PR DESCRIPTION
## Summary

Introduces a candidate one-pass selected store builder gated behind the `gts_parsercorephase0_selectedstore_onepass` tag, refactors the existing staged builder into a separate implementation file, and injects cancellation polling into all bulk copy/resize operations to prevent long-running allocations from blocking. Includes expanded tests for cancellation safety and snapshot retention.

## Changes

- Extract staged builder to `selected_store_builder_staged.go` behind `!gts_parsercorephase0_selectedstore_onepass` build tag.
- Add `selected_store_builder_onepass.go` implementing a single-pass iterative postorder traversal that folds unaries, allocates records/children, and resizes backing stores without double-copying.
- Add `copySelectedStoreChunks` and `moveSelectedStoreChildren` helpers in `selected_store.go` to poll cancellation before every chunk of a copied array.
- Apply bulk copy polling to `finishRoots` resizing and `ensureSelectedOnePassCapacity`/`rightSizeSelectedOnePassStore`.
- Update CI to run `selected_store_admission` suite covering both staged and one-pass implementations under `-race`.
- Add tests validating cancellation mid-growth, right-size polling, and snapshot lifecycle after reset/release.

## Testing

- Run `GOMAXPROCS=1 go test -race ./internal/parsercorephase0 -count=1` to validate staged builder
- Run `GOMAXPROCS=1 go test -race -tags gts_parsercorephase0_selectedstore_onepass ./internal/parsercorephase0 -count=1` to validate one-pass builder