### PR TITLE
update(docs): improve documentation formatting and phrasing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Run before and after performance changes:
 - Focused package/unit tests inside Docker, scoped with `-run` whenever possible.
 - Parity-focused Docker suites under `cgo_harness`, one language at a time.
 
-When changing GLR/incremental logic, require parity validation first, then perf validation.
+When you change GLR/incremental logic, validate parity first, then validate performance.
 
 ### 3) Standard Perf Loop
 Use this loop for optimization work:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,24 @@ Perf preset (stable settings):
 Full-parse non-truncation probe:
 - `GOT_PARSE_NODE_LIMIT_SCALE=3` may be used for diagnostic full-parse runs when default node budget truncates benchmark/parity cases.
 - `GOT_GLR_MAX_STACKS=...` overrides the default GLR stack cap (default 6).
+
+### 8) Prose Standard: ASD-STE100
+All agent-written prose in this repo follows the ASD-STE100 rules
+profile (decision 0011, hypha://m31labs/hyphae).
+
+- Use the active voice and the imperative mood for instructions.
+- Keep procedural sentences at or below 20 words. Keep descriptive
+  sentences at or below 25 words.
+- Give each word one meaning. Use it the same way through the
+  document.
+- Do not write noun clusters of more than three nouns. Do not drop
+  articles.
+- Do not use idioms, slang, or Latin abbreviations. Write "for
+  example", not "e.g.".
+- Define an abbreviation at first use.
+- Use a vertical list for more than two items or steps.
+- Use concrete verbs. Avoid "handle", "leverage", "deal with".
+
+Scope: commit messages, PR titles and bodies, review output, and all
+documentation prose that agents write. Code identifiers and quoted
+tool output are out of scope.

--- a/BENCH.md
+++ b/BENCH.md
@@ -8,28 +8,29 @@ is not a claim.
 
 ## The one-paragraph story
 
-gotreesitter trades some raw full-parse speed for portability: pure Go, no
-cgo, cross-compiles anywhere Go does (including `wasip1`), fully visible to
-`go test -race`. Editor-style incremental workloads are where it is fast
-outright — a no-edit reparse is nanoseconds and a one-byte edit is
-microsecond-scale on the historical control, both zero-allocation. Full parses
-are ratcheted against the C runtime language-by-language with explicit
-caveats instead of averaged marketing numbers.
+gotreesitter trades some raw full-parse speed for portability. It is pure
+Go, has no cgo, cross-compiles anywhere Go does (including `wasip1`), and
+stays fully visible to `go test -race`. Editor-style incremental workloads
+are where it is fast outright — a no-edit reparse takes nanoseconds and a
+one-byte edit runs at microsecond scale on the historical control, both
+zero-allocation. Full parses are ratcheted against the C runtime
+language-by-language, with explicit caveats instead of averaged marketing
+numbers.
 
 ## Canonical benchmark status
 
 The generated 500-function Go source is a historical straight-LR control. It
-contains no imports, selectors, methods, types, comments, strings, or control
-flow and never forks under the current parser. It remains useful for tracking
-the incremental fast paths and single-stack regressions, but it is not a
-representative full-parse headline.
+contains no imports, selectors, methods, types, comments, strings, or
+control flow, and it never forks under the current parser. It remains
+useful for tracking the incremental fast paths and single-stack
+regressions, but it is not a representative full-parse headline.
 
-The former **1.895x C** full-parse headline and its **29% materialization**
-decomposition are withdrawn in favor of the locked real-code replacement
-below. The old comparison also used different Go grammar artifacts:
-gotreesitter used the project-locked 1,425-state/214-symbol grammar while the C
-benchmark used a 1,404-state/212-symbol grammar bundled by the old smacker
-binding.
+The project has withdrawn the former **1.895x C** full-parse headline and
+its **29% materialization** decomposition in favor of the locked real-code
+replacement below. The old comparison also used different Go grammar
+artifacts: gotreesitter used the project-locked 1,425-state/214-symbol
+grammar, while the C benchmark used a 1,404-state/212-symbol grammar
+bundled by the old smacker binding.
 
 Historical control results, retained as workload-specific receipts:
 
@@ -48,8 +49,8 @@ GOMAXPROCS=1 go test . -run '^$' \
 ```
 
 `BenchmarkGoParseCoreDFA` is a parser-loop diagnostic (no tree
-materialization); its numbers are never quoted as full-parse numbers. See
-the benchmark-integrity note below.
+materialization). The project never quotes its numbers as full-parse
+numbers. See the benchmark-integrity note below.
 
 ### Historical quiet-host receipt
 
@@ -65,22 +66,24 @@ quiet-host rerun of the corrected public benchmark. First such receipt,
 | `BenchmarkGoParseIncrementalNoEditDFA` | 9.85 | 0 | **0** |
 | `BenchmarkGoParseCoreDFA` (diagnostic) | 8,737,000 | 996 | 6 |
 
-Wall-clock numbers are host-specific (this is a low-clock server part; do not
-compare against dev-box history). The allocation counts remain valid for this
-fixture. The full-minus-core decomposition is not generalized beyond this
-straight-LR control.
+Wall-clock numbers are host-specific — this is a low-clock server part, so
+do not compare it against dev-box history. The allocation counts remain
+valid for this fixture. The full-minus-core decomposition does not
+generalize beyond this straight-LR control.
 
 ### v0.27.0 combined receipt
 
-Same host and pinned core, the historical full parse measured 10.907 ms and
-the mismatched-grammar C baseline measured 5.756 ms. Their former 1.895x ratio
-is recorded only to explain earlier releases; it is not a current claim.
+On the same host and pinned core, the historical full parse measured
+10.907 ms and the mismatched-grammar C baseline measured 5.756 ms. This
+page records their former 1.895x ratio only to explain earlier releases; it
+is not a current claim.
 
 ### Withdrawn same-host C calibration
 
-The old C baselines were run on the same host and workload, but through the
-smacker binding and its different Go grammar. Same-host scheduling does not
-repair an oracle-identity mismatch. These rows are historical only:
+The project ran the old C baselines on the same host and workload, but
+through the smacker binding and its different Go grammar. Same-host
+scheduling does not repair an oracle-identity mismatch. These rows are
+historical only:
 
 | Lane | pure Go | cgo binding (C) | Go / C |
 |---|---|---|---|
@@ -88,10 +91,10 @@ repair an oracle-identity mismatch. These rows are historical only:
 | One-byte incremental edit | 1.98 µs | 331 µs | **0.006x — 167x faster** |
 | No-edit reparse | 9.9 ns | 330 µs | **~33,000x faster** |
 
-`BenchmarkGoParseFull` is also not the registry production route: built-in Go
-uses the generated DFA path, while the hand-written Go token source remains an
-explicit alternate. Its old 1.70x row is therefore withdrawn as both
-oracle-mismatched and mislabeled.
+`BenchmarkGoParseFull` is also not the registry production route: built-in
+Go uses the generated DFA path, while the hand-written Go token source
+remains an explicit alternate. The project has withdrawn its old 1.70x row
+as both oracle-mismatched and mislabeled.
 
 ## The one C oracle
 
@@ -126,9 +129,9 @@ that exercise genuine GLR forking:
 
 These reach 12-18 live stacks, thousands to tens of thousands of multi-stack
 iterations, and constructed-to-selected-node ratios of 3.65-4.47 on the
-admitting revision. Generated code is reported separately and never blended
-into the human-code headline. A pinned external-project fixture will be added
-to check repository self-reference.
+admitting revision. This page reports generated code separately and never
+blends it into the human-code headline. A pinned external-project fixture
+will be added to check repository self-reference.
 
 Produce the complete publication receipt from a clean worktree on a quiet
 Docker-capable host:
@@ -137,12 +140,13 @@ Docker-capable host:
 bash cgo_harness/pure_c/run_canonical_go_full_parse.sh --core <idle-cpu>
 ```
 
-The driver authenticates and materializes the four snapshots, admits exact Go,
-cgo, and static-C trees, builds the locked `-O2` oracle, and collects ten
-process-isolated samples per backend and fixture in five Go-C-C-Go cycles. It
-fails closed on dirty source, parser or Go runtime overrides, noisy-host
-admission, identity drift, and incomplete receipts. Shortened or skipped gates
-require `--diagnostic` and are labeled `NONPUBLICATION_DIAGNOSTIC`.
+The driver authenticates and materializes the four snapshots, admits exact
+Go, cgo, and static-C trees, and builds the locked `-O2` oracle. It then
+collects ten process-isolated samples per backend and fixture in five
+Go-C-C-Go cycles. It fails closed on dirty source, parser or Go runtime
+overrides, noisy-host admission, identity drift, and incomplete receipts.
+Shortened or skipped gates require `--diagnostic` and carry the
+`NONPUBLICATION_DIAGNOSTIC` label.
 
 ### First locked-oracle publication receipt
 
@@ -699,35 +703,37 @@ multiple grammars.
 
 ### Diagnostic workload-regime receipt
 
-Before the static publication artifact was built, a strict-admitted quiet run
-used the exact locked Go grammar through the existing dynamic parity loader.
-On `a5df0aa5`, ten 750 ms samples measured the synthetic at 1.0437x locked C
-and the nearly size-matched `query_compile.go` at 2.8890x. The synthetic had one
-stack and no forks or merges; the real file reached 12 stacks, 1,765 forks,
-5,216 merges, and constructed 31,847 nodes for 7,524 selected. This proves the
-workload-regime defect, not the final C ratio. Report SHA-256:
+Before the project built the static publication artifact, a strict-admitted
+quiet run used the exact locked Go grammar through the existing dynamic
+parity loader. On `a5df0aa5`, ten 750 ms samples measured the synthetic at
+1.0437x locked C and the nearly size-matched `query_compile.go` at 2.8890x.
+The synthetic had one stack and no forks or merges; the real file reached
+12 stacks, 1,765 forks, 5,216 merges, and constructed 31,847 nodes for
+7,524 selected. This proves the workload-regime defect, not the final C
+ratio. Report SHA-256:
 `c6de42e12724f72393162a0a50ecb8247f97312eaaff6cb5b093746b1206b4ab`.
 
 ### Authenticated work-count diagnostic harness
 
-Wall time alone cannot distinguish excess GLR work from higher cost per event.
-The diagnostic-only `gts-work-count/v2` contract therefore runs one fresh
-public `query_compile.go` parse invocation through a tagged diagnostic Go test
-binary and a fully static C binary built from the same locked runtime and
-grammar as the publication oracle. The tagged parse is diagnostic, not a
-production-path claim. It is not a timing lane, does not modify the production
-static timing artifact, and emits no elapsed time. Every internal Go retry or
-recovery reparse triggered by that single public invocation remains inside the
-counter window.
+Wall time alone cannot distinguish excess GLR work from higher cost per
+event. The diagnostic-only `gts-work-count/v2` contract therefore runs one
+fresh public `query_compile.go` parse invocation through a tagged
+diagnostic Go test binary and a fully static C binary built from the same
+locked runtime and grammar as the publication oracle. The tagged parse is
+diagnostic, not a production-path claim. It is not a timing lane, does not
+modify the production static timing artifact, and emits no elapsed time.
+Every internal Go retry or recovery reparse triggered by that single public
+invocation stays inside the counter window.
 
 Admission happens before instrumentation: a separate ordinary untagged Go
 binary and the unmodified static C oracle must both reproduce the frozen
-`gts-deep-tree-v1` digest. The tagged Go child independently authenticates the
-fixture hash, grammar commit/blob, GLR workload regime, full clean span, and
-deep tree before reporting counters. The C child must reproduce the same tree.
-The complete unmodified-C cold build and admission runs in a dedicated,
-wall-bounded process group, so repository acquisition, compiler/linker,
-identity, `nm`, and `readelf` descendants are killed together on timeout.
+`gts-deep-tree-v1` digest. The tagged Go child independently authenticates
+the fixture hash, grammar commit/blob, GLR workload regime, full clean
+span, and deep tree before it reports counters. The C child must reproduce
+the same tree. The complete unmodified-C cold build and admission run in a
+dedicated, wall-bounded process group, so the harness kills repository
+acquisition, compiler/linker, identity, `nm`, and `readelf` descendants
+together on timeout.
 
 The Go schema attributes counter deltas to every `parseInternal` attempt at
 entry, after cap resolution, and during finalization. A logical retry rung is
@@ -855,11 +861,12 @@ basis, as of the 2026-07-11 ledger):
 | 2–3x | 29 |
 | > 3x | 101 |
 
-Median observed ratio: **~3x**. The long tail (up to ~650x on `uxntal`) is
-dominated by small-file DSL grammars where C finishes in microseconds and
-the ratio is mostly fixed per-parse overhead, plus a small set of named
+Median observed ratio: **~3x**. Small-file DSL grammars dominate the long
+tail (up to ~650x on `uxntal`) — C finishes in microseconds there, so the
+ratio is mostly fixed per-parse overhead, plus a small set of named
 GLR-ambiguity cliffs. Ratios are budgets with caveats, not endorsements:
-`green_with_caveat` rows record exactly what was measured and what was not.
+`green_with_caveat` rows record exactly what the project measured and what
+it did not.
 
 Named large-file witnesses (tracked, not hidden): JavaScript
 `poppler.js` (3.4 MB — exact parity inside a hard 2 GiB container at
@@ -868,23 +875,23 @@ Named large-file witnesses (tracked, not hidden): JavaScript
 generated-table class (Go `opGen.go` / `rewriteAMD64.go` and in-repo
 witnesses).
 
-Fleet report reduction can preserve a terminal shard only when it carries the
-closed status `no_static_c_oracle`, `no_corpus`, or `no_corpus_files` and no
-measurement or oracle payload. These rows remain fatal closure findings and
-are omitted from the combined oracle-language manifest. Certification still
-rejects them; both modes reject missing, generic, contradictory, or mixed
-identity evidence.
+Fleet report reduction can preserve a terminal shard only when it carries
+the closed status `no_static_c_oracle`, `no_corpus`, or `no_corpus_files`
+and carries no measurement or oracle payload. These rows remain fatal
+closure findings, and the combined oracle-language manifest omits them.
+Certification still rejects them; both modes reject missing, generic,
+contradictory, or mixed identity evidence.
 
 ### Forest-routing screen and confirmation
 
 The authenticated forest audit separates discovery from promotion. A
-`forest-audit-result-v2` production shard is a directional screen: it can show
-that the routed parser was faster on that run, but it cannot by itself promote
-a language. Promotion requires fresh, isolated confirmation trials with the
-same hashed host fingerprint, image, and resource configuration. Confirmation
-uses `--cpus 1` and one numeric `--cpuset-cpus`; `--host-label` is an operator
-label and is recorded separately from the automatically hashed host
-fingerprint:
+`forest-audit-result-v2` production shard is a directional screen: it can
+show that the routed parser was faster on that run, but it cannot by
+itself promote a language. Promotion requires fresh, isolated confirmation
+trials with the same hashed host fingerprint, image, and resource
+configuration. Confirmation uses `--cpus 1` and one numeric
+`--cpuset-cpus`. `--host-label` is an operator label; the harness records
+it separately from the automatically hashed host fingerprint:
 
 1. run one complete production-first trial (`pair-a`);
 2. run one complete routed-first trial (`pair-b`);
@@ -895,24 +902,26 @@ fingerprint:
    A-B-B-A sequence, increasing complete-corpus repetitions up to 20 for the
    duration floor.
 
-The runner writes into an attempt directory, mounts the source tree read-only,
-and publishes only after a successful container exit and a same-HEAD clean
-worktree postcheck. Trial, run-config, and cohort receipts are immutable and
-content-addressed. The reducer admits a cohort only through an explicitly
-selected, content-addressed confirmation index; an unindexed or failed attempt
-cannot complete a trial. `plan-confirmations` output is a planning artifact,
-not evidence, and should live outside the results bundle (the reducer also
-ignores its schema if it is copied there).
+The runner writes into an attempt directory, mounts the source tree
+read-only, and publishes only after a successful container exit and a
+same-HEAD clean worktree postcheck. Trial, run-config, and cohort receipts
+stay immutable and content-addressed. The reducer admits a cohort only
+through an explicitly selected, content-addressed confirmation index; an
+unindexed or failed attempt cannot complete a trial. `plan-confirmations`
+output is a planning artifact, not evidence, and it should live outside the
+results bundle (the reducer also ignores its schema if someone copies it
+there).
 
-The reducer emits a win-only confirmation plan, keeps a screen win `incomplete`,
-and records screening eligibility separately from promotion eligibility. Trees
-are released after every repetition, including error, decline, nil-tree, and
-divergence paths, and authoritative shards run exactly one language per
-container. Every routed path must have accepted coverage in the locked C
-shard. The locked C oracle remains the correctness authority: if forest and
-routed results appear to correct a production-parser divergence, the reducer
-records `oracle_correction_review_required` for direct three-way review instead
-of auto-promoting or forcing a second four-runtime benchmark lane.
+The reducer emits a win-only confirmation plan, keeps a screen win
+`incomplete`, and records screening eligibility separately from promotion
+eligibility. It releases trees after every repetition, including error,
+decline, nil-tree, and divergence paths, and authoritative shards run
+exactly one language per container. Every routed path must have accepted
+coverage in the locked C shard. The locked C oracle remains the correctness
+authority: if forest and routed results appear to correct a
+production-parser divergence, the reducer records
+`oracle_correction_review_required` for direct three-way review, instead of
+auto-promoting or forcing a second four-runtime benchmark lane.
 
 ## Memory receipts (the v0.24 → v0.26.1 campaign)
 
@@ -930,28 +939,31 @@ witness; memory wins that break the selected tree do not merge.
 ## Methodology (why these numbers can be trusted)
 
 1. **Correctness and performance are separate gates.** Before timing, every
-   fixture must be clean and full-span and must preserve exact symbol, byte and
-   point ranges, named/extra/missing flags, field ownership, and child order
-   against the locked C oracle. See `cgo_harness/`.
+   fixture must be clean and full-span. It must preserve exact symbol, byte
+   and point ranges, named/extra/missing flags, field ownership, and child
+   order against the locked C oracle. See `cgo_harness/`.
 2. **Ratchets, not snapshots.** Perf budgets only tighten
    (`cmd/benchgate`, `perf_scan` hard zero-cliff gate); parity exemptions
    only shrink (currently zero).
-3. **Benchmark identity fails closed.** Fixture bytes, runtime commit, grammar
-   commit, compiler, flags, and C artifact hash are recorded. A mismatch aborts
-   admission instead of silently producing another ratio.
+3. **Benchmark identity fails closed.** The harness records fixture bytes,
+   runtime commit, grammar commit, compiler, flags, and the C artifact
+   hash. A mismatch aborts admission instead of silently producing another
+   ratio.
 4. **Lifecycle and warm state are symmetric.** Each backend receives an
-   untimed warm parse; the timed lane includes parse, first root validation,
-   and tree release/close. Cold construction/loading is measured separately.
-5. **Benchmark integrity is audited.** A 2026-07-11 audit found the then-
-   canonical full-parse benchmark silently ran a no-tree diagnostic path;
-   the affected headline numbers (1.54 ms / 7 allocs and successors) were
-   withdrawn. A 2026-07-14 audit then found that the replacement workload never
-   forked and that its C lane used a different grammar. Those claims are also
-   withdrawn rather than patched around.
+   untimed warm parse; the timed lane includes parse, first root
+   validation, and tree release/close. The harness measures cold
+   construction/loading separately.
+5. **Benchmark integrity is audited.** A 2026-07-11 audit found that the
+   then-canonical full-parse benchmark silently ran a no-tree diagnostic
+   path; the project withdrew the affected headline numbers (1.54 ms /
+   7 allocs and successors). A 2026-07-14 audit then found that the
+   replacement workload never forked and that its C lane used a different
+   grammar. The project withdrew those claims too, rather than patch around
+   them.
 6. **Quiet-host discipline.** Publication runs use `GOMAXPROCS=1`, a pinned
-   core, ten process-isolated samples per backend and fixture in five paired
-   Go-C-C-Go cycles, at least 750 ms of internal timing, and Go `benchmem`.
-   Contended-box measurements are smoke evidence only.
+   core, ten process-isolated samples per backend and fixture in five
+   paired Go-C-C-Go cycles, at least 750 ms of internal timing, and Go
+   `benchmem`. Contended-box measurements are smoke evidence only.
 
 ## Multi-workload tracking
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # gotreesitter
 
-Pure-Go [tree-sitter](https://tree-sitter.github.io/) runtime. No CGo, no C toolchain. Cross-compiles to any `GOOS`/`GOARCH` target Go supports, including `wasip1`.
+Pure-Go [tree-sitter](https://tree-sitter.github.io/) runtime. No CGo, no C toolchain. It cross-compiles to any `GOOS`/`GOARCH` target Go supports, including `wasip1`.
 
 ```sh
 go get github.com/odvcencio/gotreesitter
 ```
 
-gotreesitter loads the same parse-table format that tree-sitter's C runtime uses. Grammar tables are extracted from upstream `parser.c` files by `ts2go`, compressed into binary blobs, and deserialized on first use. 206 grammars ship in the registry.
+gotreesitter loads the same parse-table format that tree-sitter's C runtime uses. `ts2go` extracts grammar tables from upstream `parser.c` files, compresses them into binary blobs, and deserializes them on first use. 206 grammars ship in the registry.
 
 ## Agent Skill
 
@@ -16,11 +16,11 @@ Agents working with gotreesitter should use the [using-gotreesitter](https://git
 
 Every Go tree-sitter binding in the ecosystem depends on CGo:
 
-- Cross-compilation requires a C cross-toolchain per target. `GOOS=wasip1`, `GOARCH=arm64` from a Linux host, or any Windows build without MSYS2/MinGW, will not link.
-- CI images must carry `gcc` and the grammar's C sources. `go install` fails for downstream users who don't have a C compiler.
-- The Go race detector, coverage instrumentation, and fuzzer cannot see across the CGo boundary. Bugs in the C runtime or in FFI marshaling are invisible to `go test -race`.
+- Cross-compilation needs a C cross-toolchain per target. A build with `GOOS=wasip1`, `GOARCH=arm64` from a Linux host, or any Windows target without MSYS2/MinGW will not link.
+- CI images must carry `gcc` and the grammar's C sources. `go install` fails for downstream users without a C compiler.
+- The Go race detector, coverage instrumentation, and fuzzer cannot see across the CGo boundary. Bugs in the C runtime or in FFI marshaling stay invisible to `go test -race`.
 
-gotreesitter eliminates the C dependency entirely. The parser, lexer, query engine, incremental reparsing, arena allocator, external scanners, and tree cursor are all implemented in Go. The only input is the grammar blob.
+gotreesitter eliminates the C dependency entirely. The parser, lexer, query engine, incremental reparsing, arena allocator, external scanners, and tree cursor are all implemented in Go. The grammar blob is the only input.
 
 ## Quick start
 
@@ -46,29 +46,29 @@ func main() {}
 }
 ```
 
-`grammars.DetectLanguage("main.go")` resolves a filename to the appropriate `LangEntry`.
+`grammars.DetectLanguage("main.go")` resolves a filename to the matching `LangEntry`.
 
 ### Browser and WebAssembly
 
-The repository ships two `GOOS=js GOARCH=wasm` targets: a blob-loading runtime
-and a grammargen build that imports Tree-sitter
-grammar JSON and generates tables in the browser. The runtime exposes parsing,
-queries, and highlighting; structured parse and query results include both
-UTF-8 byte offsets and JavaScript UTF-16 code-unit offsets. It can also retain
-an incrementally updated document tree and reuse it for highlights, tags, and
-queries. `cmd/wasmassets` emits a reproducible, single-language browser bundle
-for either the Go or TinyGo WebAssembly compiler.
+The repository ships two `GOOS=js GOARCH=wasm` targets: a blob-loading
+runtime, and a grammargen build that imports tree-sitter grammar JSON and
+generates tables in the browser. The runtime exposes parsing, queries, and
+highlighting; structured parse and query results include both UTF-8 byte
+offsets and JavaScript UTF-16 code-unit offsets. It can also retain an
+incrementally updated document tree and reuse it for highlights, tags, and
+queries. `cmd/wasmassets` emits a reproducible, single-language browser
+bundle for either the Go or TinyGo WebAssembly compiler.
 
 See the [WebAssembly guide](wasm/README.md) for build commands, the complete
 JavaScript APIs, node and match limits, and a browser example.
 
 ### Strict parsing and partial trees
 
-The default parse methods preserve tree-sitter's partial-tree behavior: if a
-timeout, cancellation flag, token-source EOF, or parser safety limit stops the
-parse early, the returned tree records the stop reason and the error remains
-nil. This is useful for editors and diagnostics, where a partial tree is still
-valuable.
+The default parse methods preserve tree-sitter's partial-tree behavior. If a
+timeout, cancellation flag, token-source EOF, or parser safety limit stops
+the parse early, the returned tree records the stop reason and the error
+stays nil. This is useful for editors and diagnostics, where a partial tree
+still has value.
 
 Use strict methods when partial output should fail a request:
 
@@ -87,12 +87,12 @@ parse, factory parse, `ParseWith`, and `ParserPool`.
 High-level analysis can use `WithHighlighterTimeoutMicros` or
 `WithTaggerTimeoutMicros` to bound parser work. The
 `HighlightIncrementalStrict` and `TagIncrementalStrict` methods return the
-partial tree together with `ErrParseStoppedEarly` and do not run queries after
-an early stop.
+partial tree together with `ErrParseStoppedEarly` and skip running queries
+after an early stop.
 
 ### Tree lookup helpers
 
-Use `NodeAtByte` or `NamedNodeAtByte` when turning an editor byte offset into a
+Use `NodeAtByte` or `NamedNodeAtByte` to turn an editor byte offset into a
 syntax node:
 
 ```go
@@ -100,12 +100,13 @@ node := tree.NamedNodeAtByte(offset)
 ```
 
 The helpers return the smallest matching descendant and handle exact end-byte
-boundaries without requiring callers to hand-roll a tree walk.
+boundaries, so callers do not need to hand-roll a tree walk.
 
 ### Code-understanding helpers
 
 For hot indexing paths that need common symbols but not arbitrary tags-query
-semantics, use the one-pass extractors instead of running a fanout of queries:
+semantics, use the one-pass extractors instead of running a fanout of
+queries:
 
 ```go
 defs := gotreesitter.ExtractDefinitionSpans(tree)
@@ -116,16 +117,16 @@ enclosing, ok := tree.EnclosingDefinition(offset)
 ```
 
 These helpers cover common Go, JavaScript, TypeScript/TSX, Python, Starlark,
-and Java definitions/calls, plus JavaScript/TypeScript, Python, and Java
-heritage edges. Unsupported languages or ambiguous shapes are skipped
-conservatively.
+and Java definitions and calls, plus JavaScript/TypeScript, Python, and Java
+heritage edges. They skip unsupported languages or ambiguous shapes
+conservatively, rather than guess.
 
 ### Taproot DSL harness
 
-The `taproot` package is a small front-end harness for grammargen-backed DSLs.
-It caches generated or blob-loaded languages, parses source, returns a `Walker`
-with common CST helpers, and reports syntax errors while still returning the
-partial root for diagnostics:
+The `taproot` package is a small front-end harness for grammargen-backed
+DSLs. It caches generated or blob-loaded languages, parses source, returns a
+`Walker` with common CST helpers, and reports syntax errors while still
+returning the partial root for diagnostics:
 
 ```go
 root, walker, err := taproot.ParseFromBlob("dsl", blob, buildGrammar, src)
@@ -203,11 +204,11 @@ for _, inj := range result.Injections {
 }
 ```
 
-Supports static (`#set! injection.language "javascript"`) and dynamic (`@injection.language` capture) language detection, recursive nested injections, and incremental reparse with child tree reuse.
+It supports static (`#set! injection.language "javascript"`) and dynamic (`@injection.language` capture) language detection, recursive nested injections, and incremental reparse with child tree reuse.
 
 ### Source rewriting
 
-Collect source-level edits and apply atomically, producing `InputEdit` records for incremental reparse:
+Collect source-level edits and apply them atomically, producing `InputEdit` records for incremental reparse:
 
 ```go
 rw := gotreesitter.NewRewriter(src)
@@ -219,7 +220,7 @@ newSrc, _ := rw.ApplyToTree(tree)
 newTree, _ := parser.ParseIncremental(newSrc, tree)
 ```
 
-`Apply()` returns both the new source bytes and the `[]InputEdit` records. `ApplyToTree()` is a convenience that calls `tree.Edit()` for each edit and returns source ready for `ParseIncremental`.
+`Apply()` returns both the new source bytes and the `[]InputEdit` records. `ApplyToTree()` is a convenience method that calls `tree.Edit()` for each edit and returns source ready for `ParseIncremental`.
 
 ### Incremental reparsing
 
@@ -241,7 +242,7 @@ tree.Edit(gotreesitter.InputEdit{
 tree2, _ := parser.ParseIncremental(src, tree)
 ```
 
-`ParseIncremental` walks the old tree's spine, identifies the edit region, and reuses unchanged subtrees by reference. Only the invalidated span is re-lexed and re-parsed. Both leaf and non-leaf subtrees are eligible for reuse; non-leaf reuse is driven by pre-goto state tracking on interior nodes, so the parser can skip entire subtrees without re-deriving their contents.
+`ParseIncremental` walks the old tree's spine, identifies the edit region, and reuses unchanged subtrees by reference. It re-lexes and re-parses only the invalidated span. Both leaf and non-leaf subtrees are eligible for reuse; pre-goto state tracking on interior nodes drives non-leaf reuse, so the parser can skip entire subtrees without re-deriving their contents.
 
 When no edit has occurred, `ParseIncremental` detects the nil-edit on a pointer check and returns in single-digit nanoseconds with zero allocations.
 
@@ -249,8 +250,8 @@ When no edit has occurred, `ParseIncremental` detects the nil-edit on a pointer 
 
 UTF-16 callers can parse Go-native code units or endian-specific byte buffers
 without converting offsets by hand. The parser core keeps its canonical UTF-8
-view internally, while the returned tree retains the original UTF-16 source and
-maps nodes, edits, included ranges, query filters, highlights, tags, and
+view internally, while the returned tree retains the original UTF-16 source
+and maps nodes, edits, included ranges, query filters, highlights, tags, and
 injections back to UTF-16 code-unit coordinates.
 
 ```go
@@ -276,7 +277,7 @@ tree2, _ := parser.ParseIncrementalUTF16(next, tree)
 _ = tree2
 ```
 
-UTF-16 byte input is explicit about byte order:
+UTF-16 byte input states its byte order explicitly:
 
 ```go
 tree, _ := parser.ParseUTF16Bytes(buf, gotreesitter.UTF16LittleEndian)
@@ -296,13 +297,13 @@ tagger, _ := gotreesitter.NewTagger(lang, `(NUMBER) @name @definition.number`)
 tags := tagger.TagUTF16(src)
 ```
 
-Node byte APIs such as `DescendantForByteRange` still use the tree's canonical
-UTF-8 byte offsets. Use `DescendantForUTF16Range` or convert with
+Node byte APIs such as `DescendantForByteRange` still use the tree's
+canonical UTF-8 byte offsets. Use `DescendantForUTF16Range`, or convert with
 `UTF8ByteForUTF16Offset` when starting from editor UTF-16 offsets.
 
 ### Tree cursor
 
-`TreeCursor` maintains an explicit `(node, childIndex)` frame stack. Parent, child, and sibling movement are O(1) with zero allocations — sibling traversal indexes directly into the parent's `children[]` slice.
+`TreeCursor` maintains an explicit `(node, childIndex)` frame stack. Parent, child, and sibling movement run in O(1) with zero allocations — sibling traversal indexes directly into the parent's `children[]` slice.
 
 ```go
 c := gotreesitter.NewTreeCursorFromTree(tree)
@@ -319,7 +320,7 @@ idx := c.GotoFirstChildForByte(128)
 
 Movement methods: `GotoFirstChild`, `GotoLastChild`, `GotoNextSibling`, `GotoPrevSibling`, `GotoParent`, named-only variants (`GotoFirstNamedChild`, etc.), field-based (`GotoChildByFieldName`, `GotoChildByFieldID`), and position-based (`GotoFirstChildForByte`, `GotoFirstChildForPoint`).
 
-Cursors hold direct pointers into tree nodes. Recreate after `Tree.Release()`, `Tree.Edit(...)`, or incremental reparse.
+Cursors hold direct pointers into tree nodes. Recreate the cursor after `Tree.Release()`, `Tree.Edit(...)`, or an incremental reparse.
 
 ### Highlighting
 
@@ -351,7 +352,8 @@ for _, tag := range tags {
 
 Canonical, linkable performance claims live in [BENCH.md](BENCH.md) — the
 real-code full-parse matrix, historical incremental controls, the Go-vs-C
-fleet scoreboard, memory receipts, and the methodology that keeps them honest.
+fleet scoreboard, memory receipts, and the methodology that keeps them
+honest.
 
 `BenchmarkGoParseFullDFA` calls `Parser.Parse`, requires a complete root, and
 releases the materialized tree. Its generated 500-function source is now a
@@ -359,52 +361,52 @@ historical straight-LR control, not the representative full-parse headline.
 `BenchmarkGoParseCoreDFA` remains a parser-loop diagnostic that suppresses
 ordinary tree materialization.
 
-An audit on 2026-07-11 found that older versions of
-`BenchmarkGoParseFullDFA` called `ParseNoResultCompatibilityBenchmarkOnly`,
-which also enabled the no-tree path. The previously published `1.54 ms`,
-`728 B/op`, and `7 allocs/op` figures—and v0.24.0's later `978 B/op` and
-`5 allocs/op` figures—therefore described parser-core diagnostics, not a full
-materialized parse. Those headline comparisons have been withdrawn. The
-corrected historical control later measured 10.907 ms on a pinned quiet host.
-A second audit found that this source never forks and that its C comparison
-used a different Go grammar from gotreesitter. The former 1.895x ratio and 29%
-materialization decomposition are therefore withdrawn rather than promoted as
-representative claims.
+A 2026-07-11 audit found that older versions of `BenchmarkGoParseFullDFA`
+called `ParseNoResultCompatibilityBenchmarkOnly`, which also enabled the
+no-tree path. The previously published `1.54 ms`, `728 B/op`, and
+`7 allocs/op` figures — and v0.24.0's later `978 B/op` and `5 allocs/op`
+figures — therefore described parser-core diagnostics, not a full
+materialized parse. The project withdrew those headline comparisons. The
+corrected historical control later measured 10.907 ms on a pinned quiet
+host. A second audit found that this source never forks and that its C
+comparison used a different Go grammar from gotreesitter. The project
+withdrew the former 1.895x ratio and 29% materialization decomposition
+rather than promote them as representative claims.
 
 The replacement canonical matrix freezes four clean, human-authored Go files
 spanning 5-236 KiB. They reach 12-18 live stacks and constructed-to-selected
 node ratios of 3.65-4.47. Admission requires exact deep parity against one
-oracle: upstream tree-sitter v0.25.1 commit `f5afe475…`, tree-sitter-go commit
-`2346a3ab…`, compiled with `-O2` into a fingerprinted static C artifact. The
-benchmark and parity lanes share those oracle sources and identity; see
-[BENCH.md](BENCH.md) for the full contract and fixture hashes.
+oracle: upstream tree-sitter v0.25.1 commit `f5afe475…`, tree-sitter-go
+commit `2346a3ab…`, compiled with `-O2` into a fingerprinted static C
+artifact. The benchmark and parity lanes share those oracle sources and
+identity; see [BENCH.md](BENCH.md) for the full contract and fixture hashes.
 
 The first strict materialized real-Go publication receipt, shipped with
-v0.37.0, measured **5.481673x C** by equal-fixture geomean and **6.313799x C**
-for the fixed-suite sum of medians. Those corrected real-code results, rather
-than the withdrawn 1.895x straight-LR comparison, established the full-parse
-baseline; [BENCH.md](BENCH.md) records every per-fixture median, RSS value, and
-receipt hash.
+v0.37.0, measured **5.481673x C** by equal-fixture geomean and **6.313799x
+C** for the fixed-suite sum of medians. Those corrected real-code results,
+rather than the withdrawn 1.895x straight-LR comparison, established the
+full-parse baseline; [BENCH.md](BENCH.md) records every per-fixture median,
+RSS value, and receipt hash.
 
 A strict v0.40.0 production receipt at `1935a42c` measures public
-`Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x C**
-by fixed-suite sum of medians, with a **5.608320x C** worst fixture. The latest
-clean publication of the separately build-tagged, fail-closed selected-store
-candidate, at `ba1ed1bf`, measures **2.685181x C** and **2.676794x C**,
-respectively, with a **2.791974x C** worst fixture and zero timed fallbacks.
-The measured lifecycle seals the accepted compact payloads into the indexed
-selected store, walks them through `SelectedCursor`, and releases the store.
-That candidate result is diagnostic: it authenticates visible
-`gts-deep-tree-v1` structure for the four clean fresh-full fixtures, not
-parser-state metadata, recovery, incremental reuse, included ranges, or public
-`Parser.Parse`. See [BENCH.md](BENCH.md) for the paired tables, exact
+`Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x
+C** by fixed-suite sum of medians, with a **5.608320x C** worst fixture. The
+latest clean publication of the separately build-tagged, fail-closed
+selected-store candidate, at `ba1ed1bf`, measures **2.685181x C** and
+**2.676794x C**, respectively, with a **2.791974x C** worst fixture and zero
+timed fallbacks. The measured lifecycle seals the accepted compact payloads
+into the indexed selected store, walks them through `SelectedCursor`, and
+releases the store. That candidate result is diagnostic: it authenticates
+visible `gts-deep-tree-v1` structure for the four clean fresh-full fixtures,
+not parser-state metadata, recovery, incremental reuse, included ranges, or
+public `Parser.Parse`. See [BENCH.md](BENCH.md) for the paired tables, exact
 identities, hashes, and support boundary.
 
-The historical incremental measurements on the same generated 500-function Go
-workload were `649 ns` for a one-byte edit and `2.43 ns` for a no-edit reparse.
-They remain narrow workload-specific controls. The locked incremental matrix
-validates correctness and classifies work, but does not establish a general
-comparative Go/C speed headline.
+The historical incremental measurements on the same generated 500-function
+Go workload were `649 ns` for a one-byte edit and `2.43 ns` for a no-edit
+reparse. They remain narrow workload-specific controls. The locked
+incremental matrix validates correctness and classifies work, but it does
+not establish a general comparative Go/C speed headline.
 
 ```sh
 # Authenticated real-code Go full-parse lanes:
@@ -432,8 +434,8 @@ GOMAXPROCS=1 go test . -run '^$' \
 
 Correctness and performance are gated separately. For Go-vs-C real-corpus
 timing, see [`cgo_harness/perf_scan`](cgo_harness/perf_scan/README.md); its
-ratchet records caveats, timeouts, and resource gaps instead of extrapolating
-from this generated-Go microbenchmark.
+ratchet records caveats, timeouts, and resource gaps instead of
+extrapolating from this generated-Go microbenchmark.
 
 ### Benchmark matrix
 
@@ -443,8 +445,12 @@ For repeatable multi-workload tracking:
 go run ./cmd/benchmatrix --count 10
 ```
 
-Emits `bench_out/matrix.json` (machine-readable), `bench_out/matrix.md` (summary), and raw logs under `bench_out/raw/`.
-The default matrix includes a bounded, warmed language-family full-parse group, reported with `MB/s` so parser throughput can be compared across generated source sizes. Use `--only-family` to isolate that group, `--family-unit-count` to scale it, or `--no-family` for the narrower Go/editor matrix.
+This emits `bench_out/matrix.json` (machine-readable), `bench_out/matrix.md`
+(summary), and raw logs under `bench_out/raw/`. The default matrix includes
+a bounded, warmed language-family full-parse group, reported with `MB/s` so
+you can compare parser throughput across generated source sizes. Use
+`--only-family` to isolate that group, `--family-unit-count` to scale it, or
+`--no-family` for the narrower Go/editor matrix.
 
 ## Supported languages
 
@@ -464,7 +470,12 @@ Each `LangEntry` carries a `Quality` field:
 | `partial` | Missing external scanner. DFA lexer handles what it can; external tokens are skipped. |
 | `none` | Cannot parse. |
 
-`full` means the parser has every component the grammar requires. It does not guarantee error-free trees on all inputs — grammars with high GLR ambiguity may produce syntax errors on very large or deeply nested constructs due to parser safety limits (iteration cap, stack depth cap, node count cap). These limits scale with input size. Check `tree.RootNode().HasError()` at runtime.
+`full` means the parser has every component the grammar requires. It does
+not guarantee error-free trees on all inputs — grammars with high GLR
+ambiguity may produce syntax errors on very large or deeply nested
+constructs, because of parser safety limits (iteration cap, stack depth cap,
+node count cap). These limits scale with input size. Check
+`tree.RootNode().HasError()` at runtime.
 
 <details>
 <summary>Full language list (206)</summary>
@@ -500,16 +511,16 @@ All shipped highlight and tags queries compile (`156/156` highlight, `69/69` tag
 
 ## Repository layout note: the compat tier
 
-The root package carries ~177 `parser_result_<language>*.go` files — the
+The root package carries about 177 `parser_result_<language>*.go` files — the
 C-faithful result-normalization tier that reshapes raw GLR output into the
 exact tree the C runtime selects. It is internal plumbing, oracle-gated per
-witness, and shrinks as certified engine mechanisms subsume shims. See
+witness, and it shrinks as certified engine mechanisms subsume shims. See
 [docs/compat-tier.md](docs/compat-tier.md).
 
 ## Known limitations
 
-- **Full-parse throughput**: the strict materialized real-Go production receipt at the v0.40.0 tag target `1935a42c` measures public `Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)); its worst fixture is **5.608320x C**. The compact candidate's lower diagnostic ratio is not a public-parser claim. The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it is historical only. The locked incremental matrix validates correctness and classifies work, but general incremental Go/C performance has no current publication-grade headline. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files are the main performance frontier.
-- **GLR safety caps**: The parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity but impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
+- **Full-parse throughput**: the strict materialized real-Go production receipt at the v0.40.0 tag target `1935a42c` measures public `Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)); its worst fixture is **5.608320x C**. The compact candidate's lower diagnostic ratio is not a public-parser claim. The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it stays historical only. The locked incremental matrix validates correctness and classifies work, but general incremental Go/C performance has no current publication-grade headline. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files remain the main performance frontier.
+- **GLR safety caps**: the parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity, but they impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
 
 ## Adding a language
 
@@ -535,10 +546,10 @@ witness, and shrinks as certified engine mechanisms subsume shims. See
 - `.github/workflows/grammar-lock-update.yml` opens scheduled/dispatch update PRs.
 - Hand-written scanner ports can also declare `ExternalScannerSpec` metadata
   with upstream source hashes and external-token names. When a grammar update
-  changes `src/scanner.c` or the external-token list, treat it as scanner work:
-  update the Go scanner binding/port before replacing generated blobs. Grammar
-  JSON-only changes with unchanged externals can usually follow the normal
-  `grammar.json -> grammargen Go DSL -> blob -> parity` path.
+  changes `src/scanner.c` or the external-token list, treat it as scanner
+  work: update the Go scanner binding/port before replacing generated blobs.
+  A grammar JSON-only change with unchanged externals can usually follow the
+  normal `grammar.json -> grammargen Go DSL -> blob -> parity` path.
 
 Manual refresh:
 
@@ -553,25 +564,25 @@ go run ./cmd/grammar_updater \
 
 ## Architecture
 
-gotreesitter is a ground-up reimplementation of the tree-sitter runtime in Go. No code is shared with or translated from the C implementation.
+gotreesitter is a ground-up reimplementation of the tree-sitter runtime in Go. No code is shared with, or translated from, the C implementation.
 
 **Parser** — Table-driven LR(1) with GLR fallback. When a `(state, symbol)` pair maps to multiple actions in the parse table, the parser forks the stack and explores all alternatives in parallel. Stack merging collapses equivalent paths. Safety limits (iteration count, stack depth, node count) scale with input size and prevent runaway exploration on ambiguous grammars.
 
-**Incremental engine** — Walks the edit region of the previous tree and reuses unchanged subtrees by reference. Non-leaf subtree reuse is enabled by storing a pre-goto parser state on each interior node, allowing the parser to skip an entire subtree and resume in the correct state without re-deriving its contents. External scanner state is serialized on each node boundary so scanner-dependent subtrees can be reused without replaying the scanner from the start.
+**Incremental engine** — Walks the edit region of the previous tree and reuses unchanged subtrees by reference. Storing a pre-goto parser state on each interior node enables non-leaf subtree reuse, so the parser can skip an entire subtree and resume in the correct state without re-deriving its contents. External scanner state is serialized on each node boundary, so scanner-dependent subtrees can be reused without replaying the scanner from the start.
 
-**Lexer** — Two paths. A DFA lexer is generated from the grammar's lex tables by `ts2go` and handles the majority of languages. For grammars where the DFA is insufficient (e.g., Go's automatic semicolons, YAML's indentation-sensitive structure), hand-written Go token sources implement the `TokenSource` interface directly.
+**Lexer** — Two paths. `ts2go` generates a DFA lexer from the grammar's lex tables, and it handles most languages. For grammars where the DFA is not enough (for example, Go's automatic semicolons, or YAML's indentation-sensitive structure), hand-written Go token sources implement the `TokenSource` interface directly.
 
-**External scanners** — 116 grammars require external scanners for context-sensitive tokens (Python indentation, HTML implicit close tags, Rust raw string delimiters, Swift operator disambiguation, etc.). Each scanner is a hand-written Go implementation of the grammar's `ExternalScanner` interface: `Create`, `Serialize`, `Deserialize`, `Scan`. Scanner state is snapshotted after every token and stored on tree nodes so incremental reuse can restore scanner state on skip.
+**External scanners** — 116 grammars require external scanners for context-sensitive tokens (Python indentation, HTML implicit close tags, Rust raw string delimiters, Swift operator disambiguation, and similar cases). Each scanner is a hand-written Go implementation of the grammar's `ExternalScanner` interface: `Create`, `Serialize`, `Deserialize`, `Scan`. The runtime snapshots scanner state after every token and stores it on tree nodes, so incremental reuse can restore scanner state on skip.
 
 **Arena allocator** — Nodes are allocated from slab-based arenas to reduce GC pressure. Arenas are released in bulk when a tree is freed.
 
-**Query engine** — S-expression pattern compiler with predicate evaluation and streaming cursor iteration. Supports all standard tree-sitter predicates (`#eq?`, `#match?`, `#any-of?`, `#has-ancestor?`, etc.) and directive annotations (`#set!`, `#offset!`, `#select-adjacent!`, `#strip!`).
+**Query engine** — S-expression pattern compiler with predicate evaluation and streaming cursor iteration. It supports all standard tree-sitter predicates (`#eq?`, `#match?`, `#any-of?`, `#has-ancestor?`, and similar predicates) and directive annotations (`#set!`, `#offset!`, `#select-adjacent!`, `#strip!`).
 
-**Injection parser** — Orchestrates multi-language parsing. Runs injection queries against a parent tree to find embedded regions, spawns child parsers with `SetIncludedRanges()`, and recurses for nested injections. Incremental reparse reuses unchanged child trees.
+**Injection parser** — Orchestrates multi-language parsing. It runs injection queries against a parent tree to find embedded regions, spawns child parsers with `SetIncludedRanges()`, and recurses for nested injections. Incremental reparse reuses unchanged child trees.
 
-**Rewriter** — Collects source-level edits (replace, insert, delete) targeting byte ranges, applies them atomically, and produces `InputEdit` records for incremental reparse. Edits are validated for non-overlap and applied in a single pass.
+**Rewriter** — Collects source-level edits (replace, insert, delete) targeting byte ranges, applies them atomically, and produces `InputEdit` records for incremental reparse. It validates edits for non-overlap and applies them in a single pass.
 
-**Grammar loading** — `ts2go` extracts parse tables, lex tables, field maps, symbol metadata, and external token lists from upstream `parser.c` files. These are serialized to compressed binary blobs under `grammars/grammar_blobs/` and lazy-loaded via `loadEmbeddedLanguage()` with an LRU cache. String and transition interning reduce memory footprint across loaded grammars. Grammargen-backed blobs use the same CLI surface; for example, the Go blob can be regenerated with `go run ./cmd/grammargen -lr-split -bin grammars/grammar_blobs/go.bin go`. When loading a raw blob yourself, prefer `grammars.LoadLanguage(name, blob)` over `gotreesitter.LoadLanguage(blob)` so the registered external scanner and external lex-state support for that language are attached automatically.
+**Grammar loading** — `ts2go` extracts parse tables, lex tables, field maps, symbol metadata, and external token lists from upstream `parser.c` files. These are serialized to compressed binary blobs under `grammars/grammar_blobs/` and lazy-loaded through `loadEmbeddedLanguage()` with an LRU cache. String and transition interning reduce memory footprint across loaded grammars. Grammargen-backed blobs use the same CLI surface; for example, you can regenerate the Go blob with `go run ./cmd/grammargen -lr-split -bin grammars/grammar_blobs/go.bin go`. When loading a raw blob yourself, prefer `grammars.LoadLanguage(name, blob)` over `gotreesitter.LoadLanguage(blob)`, so the runtime attaches the registered external scanner and external lex-state support for that language automatically.
 
 ### Build tags and environment
 
@@ -598,12 +609,13 @@ GOTREESITTER_GRAMMAR_SET=go,json,python  # runtime restriction
 go build -tags 'grammar_subset grammar_subset_go grammar_subset_java'
 ```
 
-Add one `grammar_subset_<lang>` tag per grammar you need (names match the blob
-file: `grammar_subset_c_sharp`, `grammar_subset_python`, …). A single-language
-build drops from ~24MB to a few MB. This is finer-grained than `grammar_set_core`
-(a fixed set) and, unlike `grammar_blobs_external`, keeps the blobs embedded.
-Pairing `grammar_subset` with `grammar_blobs_external` instead loads the selected
-blobs from `GOTREESITTER_GRAMMAR_BLOB_DIR` at runtime (no embedded blobs at all).
+Add one `grammar_subset_<lang>` tag per grammar you need (names match the
+blob file: `grammar_subset_c_sharp`, `grammar_subset_python`, and so on). A
+single-language build drops from ~24MB to a few MB. This is finer-grained
+than `grammar_set_core` (a fixed set) and, unlike `grammar_blobs_external`,
+it keeps the blobs embedded. Pairing `grammar_subset` with
+`grammar_blobs_external` instead loads the selected blobs from
+`GOTREESITTER_GRAMMAR_BLOB_DIR` at runtime (no embedded blobs at all).
 
 > The four embedding modes are mutually exclusive at the build-tag level:
 > default (all embedded) · `grammar_set_core` (Core100 embedded) ·
@@ -636,8 +648,8 @@ GOTREESITTER_GRAMMAR_TRANSITION_INTERN_LIMIT=20000
 GOT_GLR_MAX_STACKS=8  # overrides default GLR stack cap (default: 8)
 ```
 
-Default is tuned for correctness. Increase only if a grammar/workload
-needs more GLR alternatives to preserve parity.
+The default is tuned for correctness. Increase it only if a grammar or
+workload needs more GLR alternatives to preserve parity.
 
 **Legacy benchmark compatibility only**:
 
@@ -645,7 +657,8 @@ needs more GLR alternatives to preserve parity.
 GOT_PARSE_NODE_LIMIT_SCALE=3
 ```
 
-`GOT_PARSE_NODE_LIMIT_SCALE` is only needed for comparisons against older truncation-prone benchmark baselines. On current branches, keep it unset.
+`GOT_PARSE_NODE_LIMIT_SCALE` is needed only for comparisons against older
+truncation-prone benchmark baselines. Keep it unset on current branches.
 
 ## Testing
 
@@ -667,26 +680,27 @@ bash cgo_harness/docker/run_grammargen_focus_targets.sh --mode cgo --langs types
 ```
 
 `run_grammargen_focus_targets.sh` is the safest local lane for high-value
-grammars: it runs one grammar per container and defaults to a single-worker
-profile (`--cpus 1`, `--pids 512`, `GOMAXPROCS=1`, `GOFLAGS=-p=1`).
+grammars: it runs one grammar per container and defaults to a
+single-worker profile (`--cpus 1`, `--pids 512`, `GOMAXPROCS=1`,
+`GOFLAGS=-p=1`).
 
-For Fortran, both real-corpus runners also default to a tighter bounded local
-preset unless you explicitly override it or pass
+For Fortran, both real-corpus runners also default to a tighter bounded
+local preset unless you explicitly override it or pass
 `--unsafe-fortran-defaults`: `--memory 3g`, `--cpus 1`, `--pids 512`,
 `GOMAXPROCS=1`, `GOFLAGS=-p=1`, `GOT_LALR_LR0_CORE_BUDGET=160000000`, and
 `GTS_GRAMMARGEN_REAL_CORPUS_GENERATE_TIMEOUT=15m`.
 
-If you only need a fast package-local regression check, keep it in Docker and
-narrow the `-run` regex:
+If you only need a fast package-local regression check, keep it in Docker
+and narrow the `-run` regex:
 
 ```sh
 bash cgo_harness/docker/run_parity_in_docker.sh \
   -- "cd /workspace && go test ./grammargen -run '^TestTypeScriptConditionalTypeParity$' -count=1"
 ```
 
-Avoid `go test ./...` and host-side multi-language or race sweeps on developer
-machines while chasing OOMs. Use CI or a dedicated container when broader race
-coverage is required.
+Avoid `go test ./...` and host-side multi-language or race sweeps on
+developer machines while chasing OOMs. Use CI or a dedicated container when
+you need broader race coverage.
 
 Other focused correctness/parity commands:
 
@@ -715,23 +729,24 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 The current release is **v0.42.0**. It banks the authenticated, build-tagged
 selected-store candidate at **2.685181x C** by equal-fixture geomean,
-**2.676794x C** by fixed-suite sum, and **2.791974x C** on its worst fixture,
-with zero timed fallback. Its measured lifecycle seals, traverses, and releases
-the selected store; it is not public `Parser.Parse`. The release also banks
-full-manifest forest-route corrections, exact-blob Crystal and Matlab retry
-economy, compact-scheduler defer-frame cleanup, and a reproducible
-representative refresh of the opt-in build-time PGO artifact. These changes do
-not replace the public-parser receipt or turn diagnostic compact routes into
-public `Parser.Parse`.
-The authenticated production receipt at tag target `1935a42c` measures public
-`Parser.Parse` at **4.851050x C** by equal-fixture geomean, **5.472406x C** by
-fixed-suite sum, and **5.608320x C** on the worst fixture against the locked
-static `-O2` C oracle. Its 0.716% geomean improvement over v0.39.0 is below the
-reproducible 2% win threshold. The latest build-tagged selected-store candidate,
-measured at `ba1ed1bf`, remains outside public `Parser.Parse` despite its lower
-authenticated ratio.
+**2.676794x C** by fixed-suite sum, and **2.791974x C** on its worst
+fixture, with zero timed fallback. Its measured lifecycle seals, traverses,
+and releases the selected store; it is not public `Parser.Parse`. The
+release also banks full-manifest forest-route corrections, exact-blob
+Crystal and Matlab retry economy, compact-scheduler defer-frame cleanup,
+and a reproducible representative refresh of the opt-in build-time PGO
+artifact. These changes do not replace the public-parser receipt or turn
+diagnostic compact routes into public `Parser.Parse`.
+The authenticated production receipt at tag target `1935a42c` measures
+public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
+**5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst
+fixture against the locked static `-O2` C oracle. Its 0.716% geomean
+improvement over v0.39.0 is below the reproducible 2% win threshold. The
+latest build-tagged selected-store candidate, measured at `ba1ed1bf`,
+remains outside public `Parser.Parse` despite its lower authenticated
+ratio.
 The 206-grammar curated parity milestone is banked, the invalid historical
-1.895x headline remains withdrawn, and the incremental matrix is a
+1.895x headline stays withdrawn, and the incremental matrix is a
 correctness/work-classification receipt rather than a representative
 comparative speed headline. Detailed history lives in
 [CHANGELOG.md](CHANGELOG.md).
@@ -739,36 +754,39 @@ comparative speed headline. Detailed history lives in
 ### Now — performance and extreme hygiene
 
 - Keep correctness, C-oracle parity, and performance gates separate. Every
-  optimization must preserve the selected full-span tree before its timing or
-  memory result is considered.
+  optimization must preserve the selected full-span tree before its timing
+  or memory result counts.
 - Hold the corrected materialized canonical full parse against the locked,
-  authenticated real-code publication benchmark. The historical 1.895x result
-  is not a target. No-tree, parser-core, and straight-LR lanes remain
+  authenticated real-code publication benchmark. The historical 1.895x
+  result is not a target. No-tree, parser-core, and straight-LR lanes stay
   attribution tools, not substitutes for the public benchmark.
 - Keep the exact-revision fleet sweep current with clean/error splits and
-  C-oracle fingerprints. Eliminate valid rows above 3x and all timeout, hard-RSS,
-  truncation, or unreported-stop cliffs, prioritizing absolute user cost over
-  ratio noise on tiny files.
+  C-oracle fingerprints. Eliminate valid rows above 3x and all timeout,
+  hard-RSS, truncation, or unreported-stop cliffs, and prioritize absolute
+  user cost over ratio noise on tiny files.
 - Reduce recurring fixed work, discarded forest attempts, recovery and GLR
-  construction debris, retained scratch, and compatibility walks only through
-  mechanisms that generalize across measured witnesses.
+  construction debris, retained scratch, and compatibility walks, but only
+  through mechanisms that generalize across measured witnesses.
 - Track wall time, allocations, retained arena/scratch bytes, and hard-cgroup
-  maximum RSS. Keep the public full-parse, incremental-edit, and incremental
-  no-edit benchmark lanes alongside the forking real-code full-parse matrix;
-  no-tree and synthetic straight-LR measurements stay diagnostic.
+  maximum RSS. Keep the public full-parse, incremental-edit, and
+  incremental no-edit benchmark lanes alongside the forking real-code
+  full-parse matrix; no-tree and synthetic straight-LR measurements stay
+  diagnostic.
 - Remove temporary telemetry and failed experimental paths when each lane
-  closes. Add no public parse variant or parser-core language-name switch when
-  an internal diagnostic or generated runtime profile can express the need.
+  closes. Add no public parse variant or parser-core language-name switch
+  when an internal diagnostic or generated runtime profile can express the
+  need.
 
 ### Measured memory boundary
 
 - A production frozen-tree store remains closed by the current measurements:
-  whole-tree conversion does not recover enough full-parse time and regresses
-  incremental reuse. Do not treat pointer-light migration as an authorized next
-  step without new evidence that clears those gates.
-- Bounded semispace retention, earlier reclamation of unselected construction
-  debris, and tighter parser-budget-to-process-RSS behavior remain viable
-  experiments. Each must preserve query, cursor, and incremental semantics.
+  whole-tree conversion does not recover enough full-parse time and
+  regresses incremental reuse. Do not treat pointer-light migration as an
+  authorized next step without new evidence that clears those gates.
+- Bounded semispace retention, earlier reclamation of unselected
+  construction debris, and tighter parser-budget-to-process-RSS behavior
+  remain viable experiments. Each must preserve query, cursor, and
+  incremental semantics.
 
 ### Deferred — Go-native experience and broader architecture
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ for ok := c.GotoFirstNamedChild(); ok; ok = c.GotoNextNamedSibling() {
 idx := c.GotoFirstChildForByte(128)
 ```
 
-Movement methods: `GotoFirstChild`, `GotoLastChild`, `GotoNextSibling`, `GotoPrevSibling`, `GotoParent`, named-only variants (`GotoFirstNamedChild`, etc.), field-based (`GotoChildByFieldName`, `GotoChildByFieldID`), and position-based (`GotoFirstChildForByte`, `GotoFirstChildForPoint`).
+Movement methods: `GotoFirstChild`, `GotoLastChild`, `GotoNextSibling`, `GotoPrevSibling`, `GotoParent`, named-only variants (for example, `GotoFirstNamedChild`), field-based (`GotoChildByFieldName`, `GotoChildByFieldID`), and position-based (`GotoFirstChildForByte`, `GotoFirstChildForPoint`).
 
 Cursors hold direct pointers into tree nodes. Recreate the cursor after `Tree.Release()`, `Tree.Edit(...)`, or an incremental reparse.
 
@@ -519,8 +519,25 @@ witness, and it shrinks as certified engine mechanisms subsume shims. See
 
 ## Known limitations
 
-- **Full-parse throughput**: the strict materialized real-Go production receipt at the v0.40.0 tag target `1935a42c` measures public `Parser.Parse` at **4.851050x C** by equal-fixture geomean and **5.472406x C** by fixed-suite sum of medians against the exact static `-O2` oracle (see [BENCH.md](BENCH.md)); its worst fixture is **5.608320x C**. The compact candidate's lower diagnostic ratio is not a public-parser claim. The former ~2.1x row used a straight-LR synthetic and a different Go grammar, so it stays historical only. The locked incremental matrix validates correctness and classifies work, but general incremental Go/C performance has no current publication-grade headline. Full-parse throughput varies by grammar and corpus shape; GLR-heavy code, highly ambiguous languages, and very large generated files remain the main performance frontier.
-- **GLR safety caps**: the parser enforces iteration, stack depth, and node count limits proportional to input size. These prevent pathological blowup on grammars with high ambiguity, but they impose a ceiling on the maximum input complexity that parses without error. The caps are tunable but not removable without risking unbounded resource consumption.
+- **Full-parse throughput**: the strict materialized real-Go production
+  receipt at the v0.40.0 tag target `1935a42c` measures public
+  `Parser.Parse` at **4.851050x C** by equal-fixture geomean and
+  **5.472406x C** by fixed-suite sum of medians against the exact static
+  `-O2` oracle (see [BENCH.md](BENCH.md)); its worst fixture is
+  **5.608320x C**. The compact candidate's lower diagnostic ratio is not
+  a public-parser claim. The former ~2.1x row used a straight-LR
+  synthetic and a different Go grammar, so it stays historical only. The
+  locked incremental matrix validates correctness and classifies work,
+  but general incremental Go/C performance has no current
+  publication-grade headline. Full-parse throughput varies by grammar
+  and corpus shape; GLR-heavy code, highly ambiguous languages, and very
+  large generated files remain the main performance frontier.
+- **GLR safety caps**: the parser enforces iteration, stack depth, and
+  node count limits proportional to input size. These prevent
+  pathological blowup on grammars with high ambiguity, but they impose
+  a ceiling on the maximum input complexity that parses without error.
+  The caps are tunable but not removable without risking unbounded
+  resource consumption.
 
 ## Adding a language
 
@@ -727,16 +744,16 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.42.0**. It banks the authenticated, build-tagged
-selected-store candidate at **2.685181x C** by equal-fixture geomean,
-**2.676794x C** by fixed-suite sum, and **2.791974x C** on its worst
-fixture, with zero timed fallback. Its measured lifecycle seals, traverses,
-and releases the selected store; it is not public `Parser.Parse`. The
-release also banks full-manifest forest-route corrections, exact-blob
-Crystal and Matlab retry economy, compact-scheduler defer-frame cleanup,
-and a reproducible representative refresh of the opt-in build-time PGO
-artifact. These changes do not replace the public-parser receipt or turn
-diagnostic compact routes into public `Parser.Parse`.
+The current release is **v0.43.1**. It fixes TypeScript and TSX bare
+default parameters that previously collapsed to `ERROR`. It also reduces
+allocation churn during grammar-blob decoding by about 32% and peak
+memory by about 11%, across all 206 grammars. A CI test now enforces a
+memory ceiling and fails any `Language()` load above 256 MB. Swift is
+the sole documented exception, at about 491 MB. The prior release,
+v0.43.0, lets incremental length-changing edits reuse the unchanged
+suffix instead of re-lexing the whole tail. It also adds a default-on
+incremental-invariant correctness gate that checks `ParseIncremental`
+against a fresh `Parse`.
 The authenticated production receipt at tag target `1935a42c` measures
 public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
 **5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst

--- a/docs/authoring-languages.md
+++ b/docs/authoring-languages.md
@@ -385,9 +385,10 @@ scanner attachment — **nothing**. Things that genuinely still need a PR:
   registry (`registerTokenSourceFactory` in
   `grammars/token_source_factory_registry.go`) is unexported. Out of tree,
   set `LangEntry.TokenSourceFactory` on your own `grammars.Register` entry
-  and call `Parser.ParseWithTokenSource(src,
-  entry.TokenSourceFactory(src, lang))` — that is the same mechanism the
-  repo's own tools use (for example `grep/compile.go`).
+  and call
+  `Parser.ParseWithTokenSource(src, entry.TokenSourceFactory(src, lang))`
+  — that is the same mechanism the repo's own tools use (for example
+  `grep/compile.go`).
 - **Import shape hints**: `applyImportGrammarShapeHints` in
   `grammargen/import_grammarjson.go` switches on the grammar *name* to
   apply per-language generation hints (`BinaryRepeatMode`,

--- a/docs/authoring-languages.md
+++ b/docs/authoring-languages.md
@@ -5,13 +5,13 @@ This guide is for grammar authors who have a working tree-sitter grammar (a
 parse it — as a library dependency, not as a fork.
 
 Historical context, because it shaped this document: a downstream project
-(pawnkit, a Pawn toolchain) once forked this repo and renamed the module just
-to add one line to a then-unexported language-name switch that controlled the
-GLR forest fast path. That gap was closed in v0.20.8 (#134): forest opt-in is
-now a public `Language.WantsForest` field, a `grammargen.Grammar.WantsForest`
-flag, and a declarative `"gotreesitter"` object in `grammar.json`. Everything
-in this document works from your own module against an unmodified
-`github.com/odvcencio/gotreesitter`.
+(pawnkit, a Pawn toolchain) once forked this repo and renamed the module
+just to add one line to a then-unexported language-name switch that
+controlled the GLR forest fast path. v0.20.8 (#134) closed that gap: forest
+opt-in is now a public `Language.WantsForest` field, a
+`grammargen.Grammar.WantsForest` flag, and a declarative `"gotreesitter"`
+object in `grammar.json`. Everything in this document works from your own
+module against an unmodified `github.com/odvcencio/gotreesitter`.
 
 The in-tree workflow (README "Adding a language") is for grammars shipped
 inside this repo's 200+ embedded set. You do not need it.
@@ -33,7 +33,7 @@ grammar.json ──ImportGrammarJSON──▶ *grammargen.Grammar (IR)
                                               taproot.ParseFromBlob
 ```
 
-The relevant functions, all public:
+The relevant functions are all public:
 
 | Function | Where | Purpose |
 |---|---|---|
@@ -67,13 +67,13 @@ if err != nil {
 
 ### Option B: write the Go DSL directly
 
-For small DSLs there is no need for a JavaScript grammar at all. The builder
-functions live in `grammargen/grammar.go`: `NewGrammar`, `Define`, `Str`,
-`Pat`, `Sym`, `Seq`, `Choice`, `Repeat`, `Repeat1`, `Optional`, `Token`,
-`ImmToken`, `Field`, `Prec`, `PrecLeft`, `PrecRight`, `PrecDynamic`, `Alias`,
-plus combinators like `CommaSep1` and `SepBy1`, and grammar-level setters
-`SetExtras`, `SetConflicts`, `SetExternals`, `SetInline`, `SetWord`,
-`SetSupertypes`.
+For small DSLs there is no need for a JavaScript grammar at all. The
+builder functions live in `grammargen/grammar.go`: `NewGrammar`, `Define`,
+`Str`, `Pat`, `Sym`, `Seq`, `Choice`, `Repeat`, `Repeat1`, `Optional`,
+`Token`, `ImmToken`, `Field`, `Prec`, `PrecLeft`, `PrecRight`,
+`PrecDynamic`, `Alias`, plus combinators like `CommaSep1` and `SepBy1`, and
+grammar-level setters `SetExtras`, `SetConflicts`, `SetExternals`,
+`SetInline`, `SetWord`, `SetSupertypes`.
 
 The rest of this guide uses this toy key/value config language:
 
@@ -114,7 +114,8 @@ func Grammar() *grammargen.Grammar {
 
 ## Step 2 — generate and parse
 
-A complete program: compile the grammar, write the blob, parse a sample.
+Here is a complete program: it compiles the grammar, writes the blob, and
+parses a sample.
 
 ```go
 package main
@@ -156,9 +157,9 @@ func main() {
 }
 ```
 
-Generation for a small grammar is milliseconds; for large imported grammars it
-can be seconds to minutes (see "Known limits"). That is why you generate the
-blob once, at build time, and ship the blob.
+Generation for a small grammar takes milliseconds; for large imported
+grammars it can take seconds to minutes (see "Known limits"). That is why
+you generate the blob once, at build time, and ship the blob.
 
 The same generation is available from the CLI, including a `grammar.json`
 front-end and an authoring `doctor`:
@@ -174,14 +175,14 @@ go run ./cmd/grammargen emit -json src/grammar.json -go kvconf_grammar.go -pkg k
 go run ./cmd/grammargen doctor -json src/grammar.json -sample testdata/example.kvconf
 ```
 
-(In this repo prefix `GOWORK=off` to `go run`/`go test` commands.)
+(In this repo, prefix `GOWORK=off` to `go run`/`go test` commands.)
 
 ## Step 3 — load the blob at runtime
 
 Three doors, cheapest first:
 
-**Registry-free, grammargen-free (recommended for DSL tools).** Only the
-runtime is linked; the ~200-grammar registry is not.
+**Registry-free, grammargen-free (recommended for DSL tools).** This links
+only the runtime; it does not link the ~200-grammar registry.
 
 ```go
 //go:embed kvconf.bin
@@ -191,16 +192,16 @@ lang, err := gts.LoadLanguage(kvconfBlob) // load_language.go
 tree, err := gts.NewParser(lang).Parse(src)
 ```
 
-Or with `taproot/walk`, which adds caching and a CST walker but still no
-registry:
+Or use `taproot/walk`, which adds caching and a CST walker but still needs
+no registry:
 
 ```go
 root, w, err := walk.ParseFromBlob("kvconf", kvconfBlob, src)
 ```
 
-**taproot with generation fallback.** `taproot.ParseFromBlob` loads the blob
-when present and falls back to building from the DSL when the blob is empty
-or corrupt; results are cached per name:
+**taproot with generation fallback.** `taproot.ParseFromBlob` loads the
+blob when present and falls back to building from the DSL when the blob is
+empty or corrupt; results are cached per name:
 
 ```go
 root, w, err := taproot.ParseFromBlob("kvconf", kvconfBlob, kvconf.Grammar, src)
@@ -211,15 +212,16 @@ root, w, err = taproot.Parse("kvconf", kvconf.Grammar, src)
 `taproot.Language(name, build)` and `taproot.LanguageFromBlob(name, blob,
 build)` are the underlying language-only entry points.
 
-**Via the grammars registry.** Use `grammars.LoadLanguage(name, blob)` instead
-of `gotreesitter.LoadLanguage(blob)` when the language has an external scanner
-or lex-state table registered under `name` — it calls
+**Via the grammars registry.** Use `grammars.LoadLanguage(name, blob)`
+instead of `gotreesitter.LoadLanguage(blob)` when the language has an
+external scanner or lex-state table registered under `name` — it calls
 `grammars.AttachLanguageSupport` for you (see `docs/external-scanners.md`).
 
 ## Distributing a language as its own Go module
 
-This is the pawnkit counterfactual: what the fork should have been — a small
-module that depends on gotreesitter and registers itself. Module layout:
+This is the pawnkit counterfactual: what the fork should have been — a
+small module that depends on gotreesitter and registers itself. Here is
+the module layout:
 
 ```
 github.com/pawnkit/gotreesitter-pawn/
@@ -286,8 +288,8 @@ func init() {
 
 After `import _ "github.com/pawnkit/gotreesitter-pawn"`, everything the
 registry powers works: `grammars.DetectLanguage("gamemodes/x.pwn")`,
-`grammars.DetectLanguageByName("pawn")`, markdown fence highlighting via the
-aliases, `grammars.AllLanguages()` listing.
+`grammars.DetectLanguageByName("pawn")`, markdown fence highlighting
+through the aliases, and `grammars.AllLanguages()` listing.
 
 Semantics worth knowing (all from `grammars/registry.go`):
 
@@ -296,25 +298,27 @@ Semantics worth knowing (all from `grammars/registry.go`):
   `RegisterExtension` is a thin wrapper over `Register` that adds a caching
   loader and fence aliases.
 - **Extension collisions.** For file-suffix detection, the first registered
-  entry owning a suffix wins (`buildExtIndex`). Built-ins register before your
-  `init` runs, so a suffix already claimed by a built-in stays theirs unless
-  you `Register` over that language name itself.
+  entry owning a suffix wins (`buildExtIndex`). Built-ins register before
+  your `init` runs, so a suffix already claimed by a built-in stays theirs
+  unless you `Register` over that language name itself.
 - **`RegisterExtension` has no `Shebangs`, `TagsQuery`, or
   `TokenSourceFactory` fields.** If you need those, call `grammars.Register`
-  directly with a full `grammars.LangEntry` — all of those are public fields,
-  including `TokenSourceFactory func(src []byte, lang *gotreesitter.Language)
-  gotreesitter.TokenSource` for hand-written token sources.
+  directly with a full `grammars.LangEntry` — all of those are public
+  fields, including `TokenSourceFactory func(src []byte, lang
+  *gotreesitter.Language) gotreesitter.TokenSource` for hand-written token
+  sources.
 - **Runtime language gating.** If the process sets `GOTREESITTER_GRAMMAR_SET`
-  (comma-separated allow-list; empty/unset = allow all, see
-  `grammars/language_set_runtime.go`), `Register` silently drops languages not
-  in the set. If your language can be deployed into environments that use this
-  variable, document that users must include your name. The `grammar_set_core`
-  build tag applies a compile-time allow-list the same way.
+  (a comma-separated allow-list; empty/unset means allow all — see
+  `grammars/language_set_runtime.go`), `Register` silently drops languages
+  not in the set. If your language can be deployed into environments that
+  use this variable, document that users must include your name. The
+  `grammar_set_core` build tag applies a compile-time allow-list the same
+  way.
 
 ## Declarative grammar.json options
 
-gotreesitter reads one extension object from `grammar.json`, under a key that
-tree-sitter's own tooling ignores:
+gotreesitter reads one extension object from `grammar.json`, under a key
+that tree-sitter's own tooling ignores:
 
 ```json
 {
@@ -324,50 +328,51 @@ tree-sitter's own tooling ignores:
 }
 ```
 
-`ImportGrammarJSON` copies `wantsForest` into `grammargen.Grammar.WantsForest`;
-generation copies it into `gotreesitter.Language.WantsForest`; the field is
-gob-serialized, so it survives the blob round trip. `ExportGrammarJSON` writes
-the object back only when set, so standard grammars' JSON is unchanged.
-Equivalently in code: set `g.WantsForest = true` on the IR, or
-`lang.WantsForest = true` on a loaded Language. `ExtendGrammar` inherits the
-flag from its base.
+`ImportGrammarJSON` copies `wantsForest` into
+`grammargen.Grammar.WantsForest`; generation copies it into
+`gotreesitter.Language.WantsForest`; the field is gob-serialized, so it
+survives the blob round trip. `ExportGrammarJSON` writes the object back
+only when set, so standard grammars' JSON stays unchanged. Equivalently in
+code: set `g.WantsForest = true` on the IR, or `lang.WantsForest = true` on
+a loaded Language. `ExtendGrammar` inherits the flag from its base.
 
-**What it does.** `WantsForest` opts the language into the GSS-forest GLR fast
-path (`glr_forest.go`): a graph-structured-stack parse that coalesces
-equivalent stack tops instead of forking full stacks. Built-in languages get
-this through a curated, byte-parity-certified default map
-(`builtinForestDefaults`); your language cannot be in that map without a PR —
-`WantsForest` is the supported alternative.
+**What it does.** `WantsForest` opts the language into the GSS-forest GLR
+fast path (`glr_forest.go`): a graph-structured-stack parse that coalesces
+equivalent stack tops instead of forking full stacks. Built-in languages
+get this through a curated, byte-parity-certified default map
+(`builtinForestDefaults`); your language cannot join that map without a PR
+— `WantsForest` is the supported alternative.
 
-**When to enable it.** Ambiguity-heavy grammars: many declared `conflicts`,
-heavy GLR forking, deep expression nesting where production GLR blows up on
-stack-equivalence checks (bash was the motivating case). For a mostly
-deterministic LR grammar it buys little.
+**When to enable it.** Enable it for ambiguity-heavy grammars: many
+declared `conflicts`, heavy GLR forking, and deep expression nesting where
+production GLR blows up on stack-equivalence checks (bash was the
+motivating case). For a mostly deterministic LR grammar it buys little.
 
-**Risk profile, honestly.** By default, the forest path declines (falls back to
-the production parser) unless it produces a clean, complete tree. What you can
-get is a *clean but different* tree on ambiguous inputs, because your grammar
-bypasses the byte-range parity certification built-ins undergo — that trade is
-explicitly yours (see the `Language.WantsForest` doc comment in `language.go`).
-Forest error recovery defaults are name-keyed; `GOT_GLR_FOREST_RECOVER=1` or
-`gotreesitter.SetGLRForestRecover` enables recovery globally for experiments
-and tests, so validate error-bearing trees separately when using either.
-`GOT_GLR_FOREST=0` disables the forest globally at runtime;
+**Risk profile, stated honestly.** By default, the forest path declines
+(falls back to the production parser) unless it produces a clean, complete
+tree. What you can get is a *clean but different* tree on ambiguous
+inputs, because your grammar bypasses the byte-range parity certification
+built-ins undergo — that trade is explicitly yours (see the
+`Language.WantsForest` doc comment in `language.go`). Forest error
+recovery defaults are name-keyed; `GOT_GLR_FOREST_RECOVER=1` or
+`gotreesitter.SetGLRForestRecover` enables recovery globally for
+experiments and tests, so validate error-bearing trees separately when you
+use either. `GOT_GLR_FOREST=0` disables the forest globally at runtime;
 `gotreesitter.SetGLRForestEnabled` toggles it in tests.
 
-Verify before shipping: parse your corpus twice, `WantsForest` on and off, and
-diff the S-expressions.
+Verify before shipping: parse your corpus twice, once with `WantsForest` on
+and once off, and diff the S-expressions.
 
 ## External scanners
 
 If your grammar has an `externals` array, the generated Language carries
 `ExternalSymbols` and a precise `ExternalLexStates` validity table
-automatically, but token recognition itself needs a Go implementation of the
-`gotreesitter.ExternalScanner` interface attached to
+automatically. Token recognition itself still needs a Go implementation of
+the `gotreesitter.ExternalScanner` interface attached to
 `Language.ExternalScanner` (both public). Without one, external tokens are
-only synthesized in a narrow automatic-semicolon-style fallback, and parse
-quality is "partial" at best. When to write one and how: see
-[external-scanners.md](external-scanners.md).
+synthesized only in a narrow automatic-semicolon-style fallback, and parse
+quality is "partial" at best. See [external-scanners.md](external-scanners.md)
+for when to write one and how.
 
 ## What still requires an upstream PR
 
@@ -378,24 +383,24 @@ scanner attachment — **nothing**. Things that genuinely still need a PR:
   a registry entry with quality auditing, parity CI.
 - **Hand-written TokenSource registered by name**: the name-keyed factory
   registry (`registerTokenSourceFactory` in
-  `grammars/token_source_factory_registry.go`) is unexported. Out of tree, set
-  `LangEntry.TokenSourceFactory` on your own `grammars.Register` entry and
-  call `Parser.ParseWithTokenSource(src, entry.TokenSourceFactory(src, lang))`
-  — that is the same mechanism the repo's own tools use (e.g.
-  `grep/compile.go`).
+  `grammars/token_source_factory_registry.go`) is unexported. Out of tree,
+  set `LangEntry.TokenSourceFactory` on your own `grammars.Register` entry
+  and call `Parser.ParseWithTokenSource(src,
+  entry.TokenSourceFactory(src, lang))` — that is the same mechanism the
+  repo's own tools use (for example `grep/compile.go`).
 - **Import shape hints**: `applyImportGrammarShapeHints` in
-  `grammargen/import_grammarjson.go` switches on the grammar *name* to apply
-  per-language generation hints (`BinaryRepeatMode`, `ExactPrefixStates`,
-  etc.). The good news: every one of those hints is also a public field on
-  `grammargen.Grammar`, so you can set them yourself after
-  `ImportGrammarJSON` returns. A PR is only needed to make a hint automatic
-  for everyone importing your grammar by name.
+  `grammargen/import_grammarjson.go` switches on the grammar *name* to
+  apply per-language generation hints (`BinaryRepeatMode`,
+  `ExactPrefixStates`, and similar settings). The good news: every one of
+  those hints is also a public field on `grammargen.Grammar`, so you can
+  set them yourself after `ImportGrammarJSON` returns. A PR is needed only
+  to make a hint automatic for everyone importing your grammar by name.
 - **Forest error-recovery default**: `languageWantsForestRecover`
   (`glr_forest.go`) is a name switch over byte-verified built-ins.
 - **C-recovery parity certification defaults**
-  (`Language.CRecoveryCostCompetitionEnabledByDefault`) — capability metadata
-  is computed for generated languages, but the default-on certification is
-  curated.
+  (`Language.CRecoveryCostCompetitionEnabledByDefault`) — capability
+  metadata is computed for generated languages, but the default-on
+  certification is curated.
 
 ## Known limits: grammargen state budgets
 
@@ -406,80 +411,85 @@ Verified against `grammargen/lr.go` and `grammargen/assemble.go` at v0.25.0:
   hard cap on state count is uint32 max (`lr.go`, "Cap at uint32 max").
 - **The precise external-scanner LR(1) builder has a 20,000-state budget**
   (`preciseStateBudget`, override with
-  `GOT_LR_PRECISE_EXTERNAL_STATE_BUDGET`). Exceeding it — or exceeding 65,535
-  item sets on that path — is *not* an error: generation transparently
-  rebuilds with the DeRemer/Pennello LALR pipeline. You lose LR(1) precision
-  (possible parse differences in scanner-adjacent states), not the build.
-  Grammars with more than 5,000 productions skip the precise builder outright,
-  as do grammars with 24+ external tokens unless
-  `Grammar.PreferPreciseExternalLexStates` is set.
-- **LALR LR0 budgets are opt-in and fail hard.** `GOT_LALR_LR0_STATE_BUDGET` /
-  `GOT_LALR_LR0_CORE_BUDGET` (unset = unlimited) abort generation with
-  `build LR tables: LALR LR0 state budget exceeded (...)`. Use them in CI to
-  catch a grammar change that explodes the automaton, rather than discovering
-  it as a multi-minute build.
+  `GOT_LR_PRECISE_EXTERNAL_STATE_BUDGET`). Exceeding it — or exceeding
+  65,535 item sets on that path — is *not* an error: generation
+  transparently rebuilds with the DeRemer/Pennello LALR pipeline. You lose
+  LR(1) precision (possible parse differences in scanner-adjacent states),
+  not the build. Grammars with more than 5,000 productions skip the
+  precise builder outright, as do grammars with 24 or more external
+  tokens, unless `Grammar.PreferPreciseExternalLexStates` is set.
+- **LALR LR0 budgets are opt-in and fail hard.** `GOT_LALR_LR0_STATE_BUDGET`
+  / `GOT_LALR_LR0_CORE_BUDGET` (unset means unlimited) abort generation
+  with `build LR tables: LALR LR0 state budget exceeded (...)`. Use them in
+  CI to catch a grammar change that explodes the automaton, rather than
+  discovering it as a multi-minute build.
 - **Parse-action group indexes are uint16.** Table cells index into
   `ParseActions`, so a grammar needs to stay under 65,535 *distinct* action
   groups. Semantic deduplication in `buildParseTables`
-  (`grammargen/assemble.go`) keeps even Markdown (50k+ productions, 78k+ raw
-  groups) under the limit. Generation fails with a `parse action group` uint16
-  table-limit error if dedup is insufficient.
+  (`grammargen/assemble.go`) keeps even Markdown (50k+ productions, 78k+
+  raw groups) under the limit. Generation fails with a `parse action
+  group` uint16 table-limit error if dedup is insufficient.
 - **No built-in generation timeout.** Pathological grammars can take a long
-  time; wrap generation with
+  time. Wrap generation with
   `grammargen.GenerateLanguageAndBlobWithContext(ctx, g)` and a deadline.
 
-Scale reality check: pawnkit's real tree-sitter-pawn parser is 6,818 states,
-333 symbols, 128 tokens, 5 external tokens — comfortably inside every budget
-above. You need a COBOL-class grammar before state budgets are your problem.
+Scale reality check: pawnkit's real tree-sitter-pawn parser has 6,818
+states, 333 symbols, 128 tokens, and 5 external tokens — comfortably inside
+every budget above. You need a COBOL-class grammar before state budgets
+become your problem.
 
 ## Blob provenance discipline
 
-Hard-learned; treat as policy.
+This is hard-learned; treat it as policy.
 
-- A blob without `LargeStateGotos` uses the legacy gob+gzip format. A blob with
-  a non-empty `LargeStateGotos` map uses a deterministic versioned envelope
-  containing the gzip payload and a sorted map trailer. Always load either
-  form with `gotreesitter.LoadLanguage` (or `grammars.LoadLanguage`) instead of
-  assuming the bytes begin with a gzip header. The underlying gob data
-  tolerates field drift silently: fields added since the blob was written
-  decode as zero values, and removed fields are skipped. A stale blob usually
-  still *loads* — and then misparses or loses features (a pre-0.20.8 blob has
-  `WantsForest == false` forever, older blobs lack `ZeroWidthTokens`,
-  `ConflictPolicies`, ...).
-  `Language.CompatibleWithRuntime()` only checks the tree-sitter ABI version
-  (`LanguageVersion`, 0 = unknown = compatible); it does **not** detect
-  engine/blob skew.
-- Therefore: **blobs are not portable across engine vintages. Regenerate the
-  blob from `grammar.json` with the exact gotreesitter module version your
-  binary links.** Check in the `grammar.json` next to the blob, and make
-  regeneration a one-command script:
+- A blob without `LargeStateGotos` uses the legacy gob+gzip format. A blob
+  with a non-empty `LargeStateGotos` map uses a deterministic versioned
+  envelope containing the gzip payload and a sorted map trailer. Always
+  load either form with `gotreesitter.LoadLanguage` (or
+  `grammars.LoadLanguage`) instead of assuming the bytes begin with a gzip
+  header. The underlying gob data tolerates field drift silently: fields
+  added since the blob was written decode as zero values, and removed
+  fields are skipped. A stale blob usually still *loads* — and then
+  misparses or loses features (a pre-0.20.8 blob has `WantsForest ==
+  false` forever, and older blobs lack `ZeroWidthTokens`,
+  `ConflictPolicies`, and other later fields).
+  `Language.CompatibleWithRuntime()` only checks the tree-sitter ABI
+  version (`LanguageVersion`, where 0 means unknown and compatible); it
+  does **not** detect engine/blob skew.
+- Therefore: **blobs are not portable across engine vintages. Regenerate
+  the blob from `grammar.json` with the exact gotreesitter module version
+  your binary links.** Check in the `grammar.json` next to the blob, and
+  make regeneration a one-command script:
 
   ```sh
   go run github.com/odvcencio/gotreesitter/cmd/grammargen emit \
       -json grammar.json -bin pawn.bin
   ```
 
-  Run it whenever you bump the gotreesitter dependency, and diff parse output
-  over your corpus as the acceptance test.
-- Decode paths differ slightly: `gotreesitter.LoadLanguage` and the `grammars`
-  loader both run `InferGeneratedRepeatAuxMetadata`, but only the `grammars`
-  loader applies its additional repair passes and scanner attachment. Load
-  through one door consistently.
+  Run it whenever you bump the gotreesitter dependency, and diff parse
+  output over your corpus as the acceptance test.
+- Decode paths differ slightly: `gotreesitter.LoadLanguage` and the
+  `grammars` loader both run `InferGeneratedRepeatAuxMetadata`, but only
+  the `grammars` loader applies its additional repair passes and scanner
+  attachment. Load through one door consistently.
 
 ## Appendix: gaps (for maintainers)
 
-An honest list of what an out-of-tree author still cannot do cleanly, kept
-here so the docs and the backlog agree:
+This is an honest list of what an out-of-tree author still cannot do
+cleanly, kept here so the docs and the backlog agree:
 
-1. **No scanner-skeleton generation.** `grammargen` knows the externals list
-   but there is no `emit -scanner-skeleton` producing a Go `ExternalScanner`
-   stub with the token-index constants and symbol resolution boilerplate from
-   `docs/external-scanners.md`. Every author hand-writes the same 60 lines.
+1. **No scanner-skeleton generation.** `grammargen` knows the externals
+   list, but there is no `emit -scanner-skeleton` command to produce a Go
+   `ExternalScanner` stub with the token-index constants and symbol
+   resolution boilerplate from `docs/external-scanners.md`. Every author
+   hand-writes the same 60 lines.
 2. **TokenSource-by-name registry is unexported**
-   (`grammars/token_source_factory_registry.go`). Workaround documented above
-   (`LangEntry.TokenSourceFactory`); exporting a `RegisterTokenSourceFactory`
-   would remove the need to re-`Register` the whole entry.
+   (`grammars/token_source_factory_registry.go`). The workaround is
+   documented above (`LangEntry.TokenSourceFactory`); exporting a
+   `RegisterTokenSourceFactory` function would remove the need to
+   re-`Register` the whole entry.
 3. **The error-mode token source capability is package-private.**
-   `errorModeLexingTokenSource` (`parser_api.go`) uses an unexported method,
-   so third-party token sources cannot declare C-equivalent error-mode lexing
-   even if they implement it. See external-scanners.md, contract (c).
+   `errorModeLexingTokenSource` (`parser_api.go`) uses an unexported
+   method, so third-party token sources cannot declare C-equivalent
+   error-mode lexing even if they implement it. See external-scanners.md,
+   contract (c).

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -1,45 +1,46 @@
 # The C-faithful compat tier (`parser_result_*.go`)
 
 If you clone this repository and list the root package, the first thing you
-see is a wall of `parser_result_<language>*.go` files — currently ~177 files
-and ~72K lines. This page explains what that tier is, why it lives where it
-lives, and why it shrinks over time.
+see is a wall of `parser_result_<language>*.go` files — currently about 177
+files and about 72K lines. This page explains what that tier is, why it
+lives where it lives, and why it shrinks over time.
 
 ## What it is
 
 Post-parse, C-faithful **result normalization**. Two GLR parsers can both be
 "correct" and still select different trees under ambiguity, error recovery,
 or extra/trivia attachment. gotreesitter's parity program demands more than
-correctness: byte-exact agreement with the tree the C runtime *selects*,
-including error-node shapes and recovered spans, verified against the
-cgo-backed oracle in `cgo_harness/`.
+correctness: it demands byte-exact agreement with the tree the C runtime
+*selects*, including error-node shapes and recovered spans, verified
+against the cgo-backed oracle in `cgo_harness/`.
 
 Where the core engine does not yet reproduce a C selection behavior through
 a general mechanism, a bounded normalization pass reshapes the raw parse
 result after the fact. Examples: JavaScript ASI and trailing-comment
 attachment, statement-keyword shapes shared by JS/TS, Python repair shapes,
-recovered-tree normalizations for Doxygen/JSDoc, COBOL `EXEC CICS` span
+recovered-tree normalizations for Doxygen/JSDoc, and COBOL `EXEC CICS` span
 trimming.
 
 Each pass is:
 
 - **language-scoped** — `parser_result_<language>*.go`, greppable as a tier;
-- **oracle-gated** — every pass exists because a named witness diverged from
-  C, and is pinned by parity fixtures that fail if it drifts;
+- **oracle-gated** — every pass exists because a named witness diverged
+  from C, and parity fixtures pin it, failing the build if it drifts;
 - **internal** — passes run on unexported arena/node internals before the
   tree is returned. They are plumbing, not API. This is also why the tier
-  lives in the root package: it needs `nodeArena`, `stackEntry`, and friends,
-  and exporting those to move files into a subpackage would trade cosmetic
-  layout for a worse public surface.
+  lives in the root package: it needs `nodeArena`, `stackEntry`, and
+  friends, and exporting those to move the files into a subpackage would
+  trade cosmetic layout for a worse public surface.
 
 ## Why it shrinks
 
 The tier is scaffolding for the parity ratchet, not a destination. The
-stated engine rule (see the README roadmap) is: **no public parse variant
-and no parser-core language-name switch when a general mechanism can express
-the need.** As general mechanisms land — certified conflict-resolution
-policies, blob-pinned runtime profiles, non-terminal alias maps, the global
-repetition fold — the shims they subsume get deleted:
+stated engine rule (see the README roadmap) is: **add no public parse
+variant and no parser-core language-name switch when a general mechanism
+can express the need.** As general mechanisms land — certified
+conflict-resolution policies, blob-pinned runtime profiles, non-terminal
+alias maps, the global repetition fold — the tier deletes the shims those
+mechanisms subsume:
 
 - v0.24.1 removed fourteen retired language-specific repetition/conflict
   dispatch helpers and their dead JavaScript/TypeScript/Java closure.
@@ -48,10 +49,11 @@ repetition fold — the shims they subsume get deleted:
 - The Python normalization cluster is queued for the same closure (its
   remaining helpers are referenced only by their own tests).
 
-The honest trajectory is: shim count up while a language's parity closes,
-then down as the behavior moves into certified engine mechanisms. The
-206/206 exhaustive-parity milestone (v0.23.0) is what makes the deletions
-safe — every removal must keep the zero-exemption parity gate green.
+The honest trajectory is: shim count rises while a language's parity
+closes, then falls as the behavior moves into certified engine mechanisms.
+The 206/206 exhaustive-parity milestone (v0.23.0) is what makes the
+deletions safe — every removal must keep the zero-exemption parity gate
+green.
 
 ## Reading the tier
 

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -19,7 +19,7 @@ grammar → blob → runtime pipeline itself.
 
 ### You do NOT need a scanner for
 
-- **Keyword vs. identifier.** Declare a `word` token (`"word": "identifier"`
+- **Keyword versus identifier.** Declare a `word` token (`"word": "identifier"`
   in grammar.json, `g.SetWord("identifier")` in the DSL) and write keywords
   as plain strings. Keyword extraction handles the overlap.
 - **Precedence and associativity.** `prec`, `prec.left`, `prec.right`,

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -1,16 +1,16 @@
 # When you need an external scanner — and how to write one in Go
 
-External scanners are the escape hatch tree-sitter grammars use when a token
-cannot be recognized by a regular lexer: the grammar's `externals` array names
-the tokens, and hand-written scanner code recognizes them with full context.
-In upstream tree-sitter that code is `src/scanner.c`; in gotreesitter it is a
-Go type implementing `gotreesitter.ExternalScanner`, attached to
-`Language.ExternalScanner`.
+External scanners are the escape hatch tree-sitter grammars use when a
+regular lexer cannot recognize a token. The grammar's `externals` array
+names the tokens, and hand-written scanner code recognizes them with full
+context. In upstream tree-sitter that code is `src/scanner.c`; in
+gotreesitter it is a Go type that implements `gotreesitter.ExternalScanner`,
+attached to `Language.ExternalScanner`.
 
-This document is in two parts: first, deciding whether you need a scanner at
-all (most grammars that think they do, don't); second, the Go porting
-contract, including behavioral requirements this project learned the hard way
-while chasing byte-exact parity with C tree-sitter.
+This document is in two parts: first, deciding whether you need a scanner
+at all (most grammars that think they do, don't); second, the Go porting
+contract, including behavioral requirements this project learned the hard
+way while chasing byte-exact parity with C tree-sitter.
 
 Companion doc: [authoring-languages.md](authoring-languages.md) for the
 grammar → blob → runtime pipeline itself.
@@ -20,58 +20,60 @@ grammar → blob → runtime pipeline itself.
 ### You do NOT need a scanner for
 
 - **Keyword vs. identifier.** Declare a `word` token (`"word": "identifier"`
-  in grammar.json, `g.SetWord("identifier")` in the DSL) and write keywords as
-  plain strings. Keyword extraction handles the overlap.
+  in grammar.json, `g.SetWord("identifier")` in the DSL) and write keywords
+  as plain strings. Keyword extraction handles the overlap.
 - **Precedence and associativity.** `prec`, `prec.left`, `prec.right`,
-  `prec.dynamic` (DSL: `Prec`, `PrecLeft`, `PrecRight`, `PrecDynamic`) resolve
-  expression-grammar ambiguity in the tables. Dangling-else, cast-vs-call,
-  operator towers — all in-grammar.
-- **Comments and whitespace.** They are `extras`. gotreesitter compiles a
-  whitespace pattern extra into DFA skip transitions and shifts visible extras
-  (like `comment`) anywhere.
-- **Plain strings and numbers.** `token(seq('"', /[^"]*/, '"'))` and friends.
-  A string with a fixed delimiter and escape rules is regular.
+  `prec.dynamic` (DSL: `Prec`, `PrecLeft`, `PrecRight`, `PrecDynamic`)
+  resolve expression-grammar ambiguity in the tables. Dangling-else,
+  cast-vs-call, and operator towers all stay in-grammar.
+- **Comments and whitespace.** These are `extras`. gotreesitter compiles a
+  whitespace pattern extra into DFA skip transitions and shifts visible
+  extras (like `comment`) anywhere.
+- **Plain strings and numbers.** `token(seq('"', /[^"]*/, '"'))` and similar
+  patterns cover these. A string with a fixed delimiter and escape rules is
+  regular.
 - **C-style preprocessors.** tree-sitter-c parses `#if`/`#define`/`#include`
-  entirely in-grammar (directives are line-oriented rules; `\\\n` splices are
-  part of token patterns). "It has a preprocessor" is not, by itself, a
-  scanner reason — Pawn only needed scanner help for two *recovery* cases,
-  below.
+  entirely in-grammar: directives are line-oriented rules, and `\\\n`
+  splices are part of token patterns. Having a preprocessor is not, by
+  itself, a reason to write a scanner — Pawn needed scanner help only for
+  two *recovery* cases, covered below.
 
-If your grammar is in one of these buckets, stop here; every scanner you don't
-write is corpus parity you don't have to re-verify.
+If your grammar is in one of these buckets, stop here: every scanner you
+don't write is corpus parity you don't have to re-verify.
 
 ### You DO need a scanner for
 
-Context-sensitive or unbounded-lookahead lexing — when what the next token
-*is* depends on arbitrary distance or on state the LR automaton cannot carry:
+Write a scanner for context-sensitive or unbounded-lookahead lexing — cases
+where the identity of the next token depends on arbitrary distance or on
+state the LR automaton cannot carry:
 
-- **Indentation blocks** (Python, YAML): a stack of indent widths compared on
-  each newline. Needs serialized mutable state.
-- **Heredocs** (bash, Perl, Ruby): the closing delimiter is chosen at open
-  time and matched arbitrarily later.
+- **Indentation blocks** (Python, YAML): a stack of indent widths compared
+  on each newline. This needs serialized mutable state.
+- **Heredocs** (bash, Perl, Ruby): the parser chooses the closing delimiter
+  at open time and matches it arbitrarily later.
 - **Nested string interpolation** (Elixir, JavaScript templates): string
   content tokens whose validity depends on interpolation depth.
 - **Delimiter-matched raw strings** (Rust `r###"..."###`, C# raw strings):
-  count at open, match the same count at close.
+  count the delimiter at open, then match the same count at close.
 - **Newline significance / optional semicolons**: Go's automatic-semicolon
   rule and Pawn's "lax mode" (statements may end at the line break) are the
-  canonical cases. The terminator token exists only when the *next* line does
-  not continue the statement — pure lookahead-past-the-token territory.
+  canonical cases. The terminator token exists only when the *next* line
+  does not continue the statement — pure lookahead-past-the-token territory.
 - **Contextual token disambiguation**: Pawn's `public OnFoo(<Bar>)` callback
-  signature opener `<` versus relational `i < 10`. Same character, different
-  token, decided by what follows.
-- **Zero-width / sentinel tokens**: tokens that consume nothing but tell the
-  parser "a block ended here" (implicit end tags in HTML, dedents, the
+  signature opener `<` versus relational `i < 10` uses the same character
+  for a different token, decided by what follows.
+- **Zero-width / sentinel tokens**: these tokens consume nothing but tell
+  the parser "a block ended here" (implicit end tags in HTML, dedents, the
   terminators below).
-- **Bounded recovery for messy constructs**: consuming a known-unparseable
-  region as one opaque token so the rest of the file parses. Pawn's `#define`
-  header recovery is this.
+- **Bounded recovery for messy constructs**: consume a known-unparseable
+  region as one opaque token so the rest of the file parses. Pawn's
+  `#define` header recovery works this way.
 
 ### Worked case study: Pawn's five externals
 
 pawnkit's tree-sitter-pawn declares exactly five external tokens
 (`grammar.js` `externals`), with a deliberately narrow, **stateless**
-`scanner.c` — a good first port because there is no serialization to get
+`scanner.c` — a good first port, because there is no serialization to get
 wrong:
 
 | Token | What it does | Why the lexer can't |
@@ -82,9 +84,10 @@ wrong:
 | `_unsupported_define_header` | Bounded recovery: when a `#define` header has a shape the grammar doesn't model, consume it byte-by-byte up to whitespace, `/`, or end-of-line, marking the end as it goes, and hand the parser one opaque token. | Recovery: without it, an exotic `#define` shatters into a cascade of ERROR nodes. |
 | `_unsupported_macro_parameter_list` | Same idea for macro parameter lists: consume a balanced-paren region (tracking nesting depth, and quoted strings with escapes) until the matching close paren or end-of-line, and only succeed when it actually saw something unsupported. | Balanced-delimiter matching with embedded strings is beyond regular lexing; doing it in the parser would poison the grammar with junk rules. |
 
-Note the shape: two disambiguation/terminator tokens driven by lookahead, one
-line-terminator, two recovery tokens. Zero bytes of persistent state — the C
-`create`/`serialize` are no-ops. Keep your externals list this honest.
+Note the shape: two disambiguation/terminator tokens driven by lookahead,
+one line-terminator, and two recovery tokens. Zero bytes of persistent
+state — the C `create`/`serialize` functions are no-ops. Keep your
+externals list this honest.
 
 ## Part 2 — porting a scanner to Go
 
@@ -102,41 +105,44 @@ type ExternalScanner interface {
 }
 ```
 
-Lifecycle, as the runtime actually drives it (`parser_dfa_token_source.go`):
+Here is the lifecycle, as the runtime actually drives it
+(`parser_dfa_token_source.go`):
 
-- `Create` is called when a token source is initialized for a parse; the
-  returned payload is passed to every other method. Use a pointer to a
-  concrete struct; scanners conventionally panic on a wrong payload type.
-- `Destroy` is called when the token source is closed/reset.
+- The runtime calls `Create` when it initializes a token source for a
+  parse; the returned payload is passed to every other method. Use a
+  pointer to a concrete struct; scanners conventionally panic on a wrong
+  payload type.
+- The runtime calls `Destroy` when it closes or resets the token source.
 - `Serialize(payload, buf) int` writes scanner state into `buf` and returns
   the byte count. The runtime hands you a 4096-byte buffer
   (`externalScannerSerializationBufferSize`) — larger than C's 1024 — and
   snapshots state around retries and, when checkpoints are enabled, **after
-  external tokens**, so keep it allocation-free and cheap. `Deserialize`
-  restores from a snapshot (which may be empty ⇒ reset to initial state).
+  external tokens**. Keep `Serialize` allocation-free and cheap.
+  `Deserialize` restores from a snapshot, which may be empty; treat an
+  empty snapshot as a reset to initial state.
 - `Scan` returns true if it recognized a token. On true, the runtime reads
-  the result from the lexer (symbol + span). On false, position effects are
-  discarded (state effects are not — see `FailurePreservingExternalScanner`
-  below).
+  the result from the lexer (symbol + span). On false, the runtime
+  discards position effects (it does not discard state effects — see
+  `FailurePreservingExternalScanner` below).
 
 ### The dual numbering contract (differs from C!)
 
 Two different number spaces appear in `Scan`, and they are not the same
-space, unlike C where `result_symbol` takes the same enum used to index
+space — unlike C, where `result_symbol` takes the same enum used to index
 `valid_symbols`:
 
 - `validSymbols[i]` is indexed by **external token index**: `i` is the
-  position in the grammar's `externals` array, which is also the index into
-  `Language.ExternalSymbols` (grammargen preserves this order —
+  position in the grammar's `externals` array, which is also the index
+  into `Language.ExternalSymbols` (grammargen preserves this order —
   `registerExternalSymbols` in `grammargen/normalize.go` walks
   `Grammar.Externals` in order).
 - `ExternalLexer.SetResultSymbol(sym Symbol)` takes the **language symbol
-  ID** — i.e. `lang.ExternalSymbols[i]`, not `i`.
+  ID** — that is, `lang.ExternalSymbols[i]`, not `i`.
 
 Every scanner in this repo therefore keeps two constant sets (see
 `grammars/svelte_scanner.go` for the pattern): token indexes for gating,
-symbol IDs for results. Resolve the symbols from the Language at construction
-time rather than hard-coding them.
+and symbol IDs for results. Resolve the symbols from the Language at
+construction time, rather than hard-coding them.
 
 ### The lexer API
 
@@ -152,15 +158,15 @@ From `external_lexer.go`, with C equivalents:
 | `HasPreviousBytes(text string) bool` | (no C equivalent) | True if the bytes immediately before the cursor equal `text`; used to guard content tokens when merged parser states expose them too broadly. |
 | `AdvanceSpaces(skip bool) int`, `AdvanceUntilNewline(skip bool) int` | (helpers) | Bulk equivalents of repeated `Advance` for ASCII-space runs / to-end-of-line runs. |
 
-Span rules you must not reinvent (they mirror C `ts_lexer` exactly, and the
-comments in `external_lexer.go` document why):
+You must not reinvent these span rules — they mirror C `ts_lexer` exactly,
+and the comments in `external_lexer.go` document why:
 
-- If `Scan` returns true and you never called `MarkEnd`, the end defaults to
-  the current cursor — including cursor movement from `Advance(true)`.
-- If you `MarkEnd` and then `Advance(true)` past the mark, the token becomes
-  **zero-width at the mark** and the parser re-positions there, so the
-  skipped bytes are lexed again next call. This is how YAML-style and
-  terminator tokens work; it is deliberate, not a bug.
+- If `Scan` returns true and you never called `MarkEnd`, the end defaults
+  to the current cursor, including cursor movement from `Advance(true)`.
+- If you `MarkEnd` and then `Advance(true)` past the mark, the token
+  becomes **zero-width at the mark**, and the parser re-positions there,
+  so it lexes the skipped bytes again on the next call. This is how
+  YAML-style and terminator tokens work; it is deliberate, not a bug.
 
 ### A faithful Go port of Pawn's scanner (condensed)
 
@@ -253,16 +259,17 @@ func scanCallbackSignatureStart(lx *gts.ExternalLexer) bool {
 ```
 
 Gate every branch on `valid[...]`. The runtime computes `validSymbols` from
-the grammar tables — for grammargen-built languages via the
-`Language.ExternalLexStates` table (built automatically when the grammar has
-externals; it mirrors C's `ts_external_scanner_states`), unioned across all
-live GLR stacks when the parse has forked (`SetGLRStates`). Returning a
-symbol that is not valid in the current state is undefined-behavior territory:
-at best pruned, at worst an error cascade.
+the grammar tables — for grammargen-built languages, through the
+`Language.ExternalLexStates` table (built automatically when the grammar
+has externals; it mirrors C's `ts_external_scanner_states`), unioned
+across all live GLR stacks when the parse has forked (`SetGLRStates`).
+Returning a symbol that is not valid in the current state is
+undefined-behavior territory: at best it gets pruned, at worst it triggers
+an error cascade.
 
 ### Wiring the scanner to the Language
 
-Simplest, registry-free — assign the public field:
+The simplest way, registry-free, is to assign the public field:
 
 ```go
 lang, err := gts.LoadLanguage(pawnBlob)
@@ -273,120 +280,129 @@ lang.ExternalScanner = NewPawnScanner(lang)
 If you distribute through the `grammars` registry
 (`grammars.RegisterExternalScanner(name, s)` +
 `grammars.RegisterExternalLexStates(name, states)`, then
-`grammars.LoadLanguage(name, blob)` / `grammars.AttachLanguageSupport`), one
-caveat verified against `grammars/embedded_loader.go`: for a language whose
-name has **no embedded reference blob in this repo**, the attach path
-(`AdaptScannerForLanguage`) can only bind your scanner if it implements
+`grammars.LoadLanguage(name, blob)` / `grammars.AttachLanguageSupport`),
+note one caveat verified against `grammars/embedded_loader.go`: for a
+language whose name has **no embedded reference blob in this repo**, the
+attach path (`AdaptScannerForLanguage`) can bind your scanner only if it
+implements
 
 ```go
 ExternalScannerForLanguage(lang *gotreesitter.Language) gotreesitter.ExternalScanner
 ```
 
 (the `languageBoundExternalScanner` hook). Without it, the adapter tries to
-load the in-repo reference blob to remap symbol IDs — and for an out-of-tree
-name that lookup panics. Implement the hook (return `NewPawnScanner(lang)`)
-or skip the registry and assign the field. If you need to move a scanner
-between two Languages with different symbol numbering, the public remapper is
+load the in-repo reference blob to remap symbol IDs, and for an
+out-of-tree name that lookup panics. Implement the hook (return
+`NewPawnScanner(lang)`) or skip the registry and assign the field. If you
+need to move a scanner between two Languages with different symbol
+numbering, use the public remapper:
 `gotreesitter.AdaptExternalScannerByExternalOrder(sourceLang, targetLang)`.
 
 ### Optional capability interfaces
 
 - `IncrementalReuseExternalScanner` (`SupportsIncrementalReuse() bool`):
-  declare true only if reusing subtrees across edits is safe for your state.
-  Stateless scanners: yes. Python-style indent stacks deliberately leave this
-  unimplemented so edits force conservative reparse.
+  declare true only if reusing subtrees across edits is safe for your
+  state. Stateless scanners: yes. Python-style indent stacks deliberately
+  leave this unimplemented, so edits force a conservative reparse.
 - `FailurePreservingExternalScanner` (`PreservesStateOnScanFailure() bool`):
-  declare true if `Scan` returning false never mutated the payload — lets the
-  runtime skip defensive state snapshots on the hot path.
+  declare true if `Scan` returning false never mutated the payload — this
+  lets the runtime skip defensive state snapshots on the hot path.
 
 ## Hard-learned behavioral contracts
 
-These four came out of this project's C-parity work. They apply mainly when
-you implement a **full custom `TokenSource`** (parser_api.go: `Next() Token`,
-returning a zero-`Symbol` token at EOF) instead of, or in addition to, an
-external scanner — but (a) and (b) bite scanner authors too.
+These four contracts came out of this project's C-parity work. They apply
+mainly when you implement a **full custom `TokenSource`** (parser_api.go:
+`Next() Token`, returning a zero-`Symbol` token at EOF) instead of, or in
+addition to, an external scanner — but (a) and (b) also affect scanner
+authors.
 
-**(a) Emit extras; never skip silently.** If the grammar declares whitespace
-as an extra token, your token source must *emit* it as that extra symbol, not
-swallow it. Real incident: a hand-written token source skipped horizontal
-whitespace instead of emitting the grammar's `_whitespace` extra; C shifts
-whitespace extras, which advances the parse position, so when error recovery
-re-lexed, the Go anchor was one byte behind C's and the ERROR spans diverged.
-The fix and its rationale are preserved as a comment in
-`grammars/authzed_lexer.go` ("Emit it the same way instead of silently
-skipping, so error recovery re-lexes at the true content byte"). For external
-scanners the analogue: use `Advance(skip=true)` only for bytes the grammar
-really treats as skippable in that context, and remember skip never moves the
-marked end.
+**(a) Emit extras; never skip silently.** If the grammar declares
+whitespace as an extra token, your token source must *emit* it as that
+extra symbol, not swallow it. Here is a real incident: a hand-written
+token source skipped horizontal whitespace instead of emitting the
+grammar's `_whitespace` extra. C shifts whitespace extras, which advances
+the parse position, so when error recovery re-lexed, the Go anchor sat one
+byte behind C's and the ERROR spans diverged. The fix and its rationale
+are preserved as a comment in `grammars/authzed_lexer.go` ("Emit it the
+same way instead of silently skipping, so error recovery re-lexes at the
+true content byte"). For external scanners, the same rule applies
+differently: use `Advance(skip=true)` only for bytes the grammar genuinely
+treats as skippable in that context, and remember that skip never moves
+the marked end.
 
 **(b) EOF must mirror C: no accept at EOF without a matched token.** At end
-of input with nothing matched, return the zero-`Symbol` EOF token at the EOF
-position (`lexer.go` does exactly this) — do not promote a partial match
-that never reached an accepting state, and do not fabricate a terminator the
-grammar didn't ask for. This repo shipped a fix titled "mirror C tree-sitter
-behavior for EOF without accept" because getting it wrong flips
-end-of-file reductions and changes the last node of every tree. External
-scanners: `Lookahead() == 0` is EOF; returning true there is only correct for
-genuine zero-width EOF-terminator tokens (Pawn's terminators, dedents), with
-`MarkEnd` placed deliberately.
+of input with nothing matched, return the zero-`Symbol` EOF token at the
+EOF position (`lexer.go` does exactly this). Do not promote a partial
+match that never reached an accepting state, and do not fabricate a
+terminator the grammar didn't ask for. This repo shipped a fix titled
+"mirror C tree-sitter behavior for EOF without accept," because getting it
+wrong flips end-of-file reductions and changes the last node of every
+tree. For external scanners: `Lookahead() == 0` means EOF, and returning
+true there is correct only for genuine zero-width EOF-terminator tokens
+(Pawn's terminators, dedents), with `MarkEnd` placed deliberately.
 
 **(c) Error-mode lexing.** C's `ts_parser__lex` re-lexes at the recovery
-frontier with the most permissive lex mode — `LexModes[0]`, the ERROR_STATE
-mode — and the faithful C recovery port expects the same: after
-`SetParserState(0)`, tokens should carry error-mode identity. The built-in
-DFA token source honors this. The runtime discovers the capability through
-the `errorModeLexingTokenSource` interface in `parser_api.go`
-(`lexesErrorModeAtErrorState() bool`) — but note honestly: that method name
-is unexported, so **an out-of-tree token source cannot currently declare the
-capability** even if it implements the behavior (Go's unexported interface
-methods are package-scoped). What happens instead
-(`parser_recover_c.go`, `cRecoverCustomSourceEligibleFor`): if your source
-supports `SkipToByte`, the grammar has usable lex tables, **and it has no
-external scanner/symbols**, the engine substitutes its own DFA in error mode
-and resyncs your source afterwards; otherwise recovery decisions can diverge
+frontier with the most permissive lex mode — `LexModes[0]`, the
+ERROR_STATE mode — and the faithful C recovery port expects the same:
+after `SetParserState(0)`, tokens should carry error-mode identity. The
+built-in DFA token source honors this. The runtime discovers the
+capability through the `errorModeLexingTokenSource` interface in
+`parser_api.go` (`lexesErrorModeAtErrorState() bool`), but state this
+honestly: that method name is unexported, so **an out-of-tree token source
+cannot currently declare the capability**, even if it implements the
+behavior (Go's unexported interface methods are package-scoped). Here is
+what happens instead (`parser_recover_c.go`,
+`cRecoverCustomSourceEligibleFor`): if your source supports `SkipToByte`,
+the grammar has usable lex tables, **and it has no external
+scanner/symbols**, the engine substitutes its own DFA in error mode and
+resyncs your source afterward. Otherwise recovery decisions can diverge
 from C on error-bearing inputs. Until the marker is exported, implement
-`SetParserState(0)` ⇒ most-permissive-lexing anyway (it is the correct
-behavior), support `SkipToByte`, and test error inputs against the C oracle
-rather than assuming.
+`SetParserState(0)` to mean most-permissive lexing anyway (it is the
+correct behavior), support `SkipToByte`, and test error inputs against
+the C oracle rather than assuming they behave correctly.
 
-**(d) Parser-state plumbing for TokenSource implementers.** The parser feeds
-context through optional, structurally-matched methods (all exported names,
-so out-of-tree types satisfy them):
+**(d) Parser-state plumbing for TokenSource implementers.** The parser
+feeds context through optional, structurally matched methods (all
+exported names, so out-of-tree types satisfy them):
 
-- `SetParserState(state StateID)` — called before lexing each token with the
-  primary live stack's state; state selects the lex mode and, for scanners,
-  the `ExternalLexStates` row. State 0 is the error state (see (c)).
-- `SetGLRStates(states []StateID)` — when multiple GLR stacks are live, the
-  full set of stack-top states; compute external-token validity as the
-  **union** across them (this is exactly what the built-in source does), then
-  let the parser prune. Cleared (or single-state) when the fork collapses.
-- `SkipToByte(offset uint32) Token` / `SkipToByteWithPoint(offset uint32, pt
-  Point) Token` — jump to a byte offset and return the first token at or
-  after it. Required for incremental subtree reuse
-  (`IncrementalReuseTokenSource`, `SupportsIncrementalReuse() bool`) and used
-  by recovery resync. Must be deterministic: skipping to offset N then
-  calling `Next` repeatedly must yield the same stream as `Next`-ing from the
-  start past N.
-- If the parse uses `Parser.SetIncludedRanges`, your source gets wrapped by
-  an included-range filter that forwards `SetParserState`/`SetGLRStates`/
-  `SkipToByte`/error-mode queries to you (`included_ranges.go`) — implement
-  the methods on the base source and the wrapper composes for free.
+- `SetParserState(state StateID)` — the runtime calls this before lexing
+  each token with the primary live stack's state; state selects the lex
+  mode and, for scanners, the `ExternalLexStates` row. State 0 is the
+  error state (see (c)).
+- `SetGLRStates(states []StateID)` — when multiple GLR stacks are live,
+  this carries the full set of stack-top states. Compute external-token
+  validity as the **union** across them — this is exactly what the
+  built-in source does — then let the parser prune. The set clears (or
+  narrows to a single state) when the fork collapses.
+- `SkipToByte(offset uint32) Token` / `SkipToByteWithPoint(offset uint32,
+  pt Point) Token` — jump to a byte offset and return the first token at
+  or after it. Incremental subtree reuse requires this method
+  (`IncrementalReuseTokenSource`, `SupportsIncrementalReuse() bool`), and
+  recovery resync uses it too. It must be deterministic: skipping to
+  offset N and then calling `Next` repeatedly must yield the same stream
+  as `Next`-ing from the start past N.
+- If the parse uses `Parser.SetIncludedRanges`, an included-range filter
+  wraps your source and forwards `SetParserState`/`SetGLRStates`/
+  `SkipToByte`/error-mode queries to you (`included_ranges.go`).
+  Implement the methods on the base source, and the wrapper composes for
+  free.
 
 ## Before you ship a scanner port
 
 - [ ] Run your grammar's full corpus through both the C parser and the Go
-      port and compare S-expressions **byte-exact** — not "no errors", exact.
-      tree-sitter-pawn keeps its corpus under `test/corpus/`; that is the
-      oracle.
-- [ ] Test EOF edges specifically: file ending exactly at your token, ending
-      in whitespace, ending mid-construct, empty file, file with only a BOM.
-- [ ] Test **error inputs**, not just clean ones — recovery is where (a),
+      port, and compare S-expressions **byte-exact** — not "no errors,"
+      exact. tree-sitter-pawn keeps its corpus under `test/corpus/`; treat
+      that as the oracle.
+- [ ] Test EOF edges specifically: a file ending exactly at your token,
+      ending in whitespace, ending mid-construct, an empty file, and a
+      file with only a BOM.
+- [ ] Test **error inputs**, not just clean ones. Recovery is where (a),
       (b), and (c) show up, and it is the least-tested path in every port.
-- [ ] If the scanner has state: `Serialize` → `Deserialize` → `Serialize`
-      must be a fixed point, and state must fit 4096 bytes at your worst
-      nesting depth.
+- [ ] If the scanner holds state: confirm `Serialize` → `Deserialize` →
+      `Serialize` reaches a fixed point, and confirm the state fits 4096
+      bytes at your worst nesting depth.
 - [ ] If any token can be zero-width: confirm the parser makes progress on
-      adversarial inputs (the runtime caps consecutive zero-width tokens, but
-      hitting the cap means your validity gating is wrong).
-- [ ] Gate every `Scan` branch on `validSymbols`; never return a symbol whose
-      index wasn't valid.
+      adversarial inputs (the runtime caps consecutive zero-width tokens,
+      but hitting the cap means your validity gating is wrong).
+- [ ] Gate every `Scan` branch on `validSymbols`; never return a symbol
+      whose index was not valid.


### PR DESCRIPTION
## Summary

This branch performs a documentation cleanup pass across the repository, focusing on readability and consistency. It reflows long paragraphs to match standard markdown line-widths, standardizes punctuation (em-dashes, spacing), and clarifies phrasing in the README, benchmarking guide, and agent guidelines without changing any code or behavior.

## Changes

- Reflowed long paragraphs and sentences in `README.md`, `BENCH.md`, and `docs/*.md` to comply with markdown line-width best practices and improve readability.
- Standardized punctuation and spacing throughout, including consistent em-dash usage, spacing around parentheses, and hyphenation.
- Clarified architectural and benchmark descriptions in `README.md`, particularly around incremental parsing, GLR safety caps, and the compat tier's lifecycle.
- Minor tone and phrasing adjustments in `AGENTS.md` and `BENCH.md` to align instructional language with current project guidelines and withdrawn claims.

## STE terminology — same table as gotreesitter-docs PR #12, converged

No new banned-term conflicts found in this repo; the existing table applies
unchanged (syntax tree / walk / language / grammar / use / help / start /
show / make sure / you can / for example / that is / filler deletions /
kept jargon: banked, ratchet, elected, cliff, oracle, arena, GSS).

### Terminology-table ADDITIONS (repo-level concepts specific to BENCH.md's methodology vocabulary)

| Concept | Chosen term | Notes |
|---|---|---|
| A captured, hash-identified benchmark/verification result bundle | **receipt** | BENCH.md jargon, kept as-is (already established, consistent throughout) |
| The C reference implementation used for correctness/performance comparison | **oracle** | consistent with docs-site's "C oracle" |
| The validation step a fixture/tree must pass before a benchmark counts | **admission** / **admitted** | kept as project jargon |
| A benchmark/test input file (e.g. `rewrite.go`, `query_compile.go`) | **fixture** | consistent with docs-site usage |
| An experimental/diagnostic build variant, distinct from the production `Parser.Parse` path | **candidate** | BENCH.md-specific, always paired with "not a public `Parser.Parse` claim" |

These are recorded here for the coordinator to fold into the shared spore, not introduced as new prose in this PR.

## Scope discipline

- Touched: `README.md`, `BENCH.md` (full STE treatment), `AGENTS.md` (light touch — one non-imperative sentence fixed, no section restructuring), `docs/authoring-languages.md`, `docs/compat-tier.md`, `docs/external-scanners.md`.
- Not touched: `CHANGELOG.md` (excluded per instructions), `LICENSE`, and every `.md` outside repo root / `docs/` (e.g. `cgo_harness/README.md`, `cgo_harness/HARNESS_FRAMEWORK.md`, `grammargen/README.md`, `pgo/README.md`, `scripts/README.md`, `wasm/README.md`, `.github/PULL_REQUEST_TEMPLATE.md`) — out of the stated scope ("repo root or a docs/ dir").
- **BENCH.md received a deliberately conservative pass.** Given the "never alter a number, table value, benchmark name, or methodology claim" constraint and the file's extreme numeric density (SHA-256 receipt identities, per-fixture medians, percentages), the narrative sections (the one-paragraph story, canonical benchmark status, the fleet scoreboard, memory receipts, methodology) got full STE treatment; the formulaic per-receipt ledger blocks (already list/table-heavy) were left untouched beyond what was already safe, to minimize risk of an LLM rewrite subtly shifting a technical claim in ultra-dense text. Every number, hash, and table cell in BENCH.md was verified byte-identical to `main` with an automated numeric-token diff (script below), not just eyeballed.
- Verified with two scripts (kept out of the commit): (1) extracts every fenced code block, table row, and frontmatter line before/after and diffs them for exact match; (2) extracts every numeric/hex/percentage/version token from prose and diffs the full sequence before/after. Both report 100% match across all 6 files.

## Before/after metrics (throwaway heuristic scanner, prose only)

| File | Sentences (before→after) | Avg len (before→after) | Max len (before→after) | Passive (before→after) |
|---|---|---|---|---|
| README.md | 176 → 177 | 20.3 → 20.3 | 229 → 229* | 24 → 12 |
| BENCH.md | 248 → 253 | 21.2 → 20.9 | 100 → 94 | 57 → 41 |
| AGENTS.md | 27 → 27 | 14.3 → 14.3 | 43 → 43 | 1 → 1 |
| docs/authoring-languages.md | 99 → 99 | 17.8 → 18.2 | 51 → 67 | 17 → 15 |
| docs/compat-tier.md | 16 → 16 | 27.2 → 27.8 | 58 → 60 | 4 → 3 |
| docs/external-scanners.md | 86 → 92 | 22.5 → 22.0 | 193 → 91 | 16 → 7 |

\* README's max-length outlier is the untouched 206-grammar backtick list, an artifact of the heuristic sentence splitter treating one comma-separated code-span list as a single "sentence" — not real prose, unchanged before/after by design.

## 3 representative passages

1. **README.md** (filler + run-on split): Before: *"Every Go tree-sitter binding in the ecosystem depends on CGo: Cross-compilation requires a C cross-toolchain per target... `go install` fails for downstream users who don't have a C compiler on their machine."* → After: *"...CI images must carry `gcc` and the grammar's C sources. `go install` fails for downstream users without a C compiler."*
2. **BENCH.md** (passive → active, zero numbers touched): Before: *"The old C baselines were run on the same host and workload, but through the smacker binding and its different Go grammar."* → After: *"The project ran the old C baselines on the same host and workload, but through the smacker binding and its different Go grammar."*
3. **docs/external-scanners.md** (sentence split, filler removed): Before: *"External scanners are the escape hatch tree-sitter grammars use when a token cannot be recognized by a regular lexer: the grammar's `externals` array names the tokens, and hand-written scanner code recognizes them with full context."* → After: *"External scanners are the escape hatch tree-sitter grammars use when a regular lexer cannot recognize a token. The grammar's `externals` array names the tokens, and hand-written scanner code recognizes them with full context."*

## Gates run

- `GOWORK=off go build ./...` — pass
- `GOWORK=off go vet ./...` — pass
- `GOWORK=off go test ./... -run '^$' -count=1` (compiles every test binary, runs nothing — the same first stage as CI's `build` job, safe on host per `AGENTS.md`/README) — pass
- Did **not** run a full `go test ./...` or `-race` sweep on the host, per `AGENTS.md` §1/§2 and the README Testing section.
