### PR TITLE
add(parser, incremental): Add fragility tracking for safe incremental reuse

### DIFF
--- a/incremental.go
+++ b/incremental.go
@@ -45,7 +45,11 @@ type reuseCursor struct {
 	rejectRootNonLeafChanged      uint64
 	rejectLargeNonLeaf            uint64
 	rejectStaleNonLeafBoundary    uint64
-	forestFastPath                bool
+	// rejectFragileNonLeaf counts interior-reuse candidates rejected by
+	// Node.isFragile() -- see tryReuseSubtree's non-leaf fallback lane below
+	// and the Parser.ReuseRejectFragileNonLeaf profile field (parser.go).
+	rejectFragileNonLeaf uint64
+	forestFastPath       bool
 	languageName                  string // cached for language-specific reuse safety policies
 }
 
@@ -90,6 +94,7 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.rejectRootNonLeafChanged = 0
 	c.rejectLargeNonLeaf = 0
 	c.rejectStaleNonLeafBoundary = 0
+	c.rejectFragileNonLeaf = 0
 	c.forestFastPath = oldTree.forestFastPath
 	c.languageName = ""
 	if oldTree.language != nil {
@@ -525,10 +530,23 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		return reuseNode(p, s, n, nextState, state, lookahead, ts, idx, entryScratch, gssScratch, cp)
 	}
 
-	// Conservative fallback: try small non-root non-leaf nodes. This increases
-	// reuse surface without jumping to large ancestor nodes that can trigger
-	// expensive recovery behavior.
-	const maxNonLeafReuseSpan = 2048
+	// Conservative fallback: try non-root non-leaf nodes. This increases reuse
+	// surface without jumping to reuse candidates that can trigger expensive
+	// recovery behavior.
+	//
+	// maxNonLeafReuseSpan was originally a small (2048-byte) safety cap
+	// standing in for a real soundness proof: C tree-sitter's
+	// ts_parser__reuse_node never reuses a subtree whose reduce happened
+	// under an LR-table conflict, a GSS multi-pop, or concurrent GLR stack
+	// versions (its is_fragile check -- see markReduceFragility,
+	// parser_reduce.go, and Node.isFragile, tree.go). This codebase had no
+	// equivalent metadata, so span was the only cheap proxy for "probably
+	// simple enough to be safe" available, and interior reuse for large
+	// subtrees stayed off (see issue #380). Now that every reduce marks
+	// fragility precisely, the isFragile() check below is the actual
+	// soundness gate and span is just a sanity backstop against pathological
+	// candidates, so it can be raised far past the old byte-count heuristic.
+	const maxNonLeafReuseSpan = 1 << 20
 	for _, n := range candidates {
 		if n == nil || n.ChildCount() == 0 || n.parent == nil {
 			continue
@@ -538,6 +556,16 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			if span > maxNonLeafReuseSpan {
 				idx.rejectLargeNonLeaf++
 			}
+			continue
+		}
+		// C-equivalent soundness gate (see the maxNonLeafReuseSpan comment
+		// above): never splice a fragile subtree into a fresh parse. A
+		// fragile n may look byte-identical to what a clean reparse would
+		// produce, but its shape depended on which ambiguous derivation won
+		// at parse time -- surrounding context this edit may have changed --
+		// so reusing it here would silently corrode structural correctness.
+		if n.isFragile() {
+			idx.rejectFragileNonLeaf++
 			continue
 		}
 		// A node's span always starts where its leftmost descendant leaf

--- a/incremental_test.go
+++ b/incremental_test.go
@@ -504,10 +504,16 @@ func TestReuseNodePreservesFreshDynamicPrecedenceSelection(t *testing.T) {
 	}
 }
 
-func TestTryReuseSubtreeSkipsLargeNonLeafCandidate(t *testing.T) {
+// nonLeafReuseSpanFixture builds the shared oldTree/newSource/parser fixture
+// used by TestTryReuseSubtreeSkipsLargeNonLeafCandidate and
+// TestTryReuseSubtreeSkipsFragileNonLeafCandidate: a two-level tree
+// (root -> large -> leaf) spanning sourceLen bytes, with a single edit at
+// byte 0 so the reuse cursor has something to walk past.
+func nonLeafReuseSpanFixture(t *testing.T, sourceLen int, markFragile bool) (*Parser, *reuseCursor, []byte) {
+	t.Helper()
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
-	oldSource := make([]byte, 3000)
+	oldSource := make([]byte, sourceLen)
 	newSource := make([]byte, len(oldSource))
 	copy(newSource, oldSource)
 	newSource[0] = 1
@@ -518,6 +524,10 @@ func TestTryReuseSubtreeSkipsLargeNonLeafCandidate(t *testing.T) {
 	large.parseState = 2
 	large.endByte = uint32(len(oldSource))
 	large.endPoint = Point{Row: 0, Column: uint32(len(oldSource))}
+	if markFragile {
+		large.setFragileLeft(true)
+		large.setFragileRight(true)
+	}
 	root := NewParentNode(3, true, []*Node{large}, nil, 0)
 	root.parseState = 2
 	root.endByte = uint32(len(oldSource))
@@ -529,9 +539,24 @@ func TestTryReuseSubtreeSkipsLargeNonLeafCandidate(t *testing.T) {
 	if reuse == nil {
 		t.Fatal("reuse cursor reset returned nil")
 	}
+	return parser, reuse, newSource
+}
+
+// TestTryReuseSubtreeSkipsLargeNonLeafCandidate proves the non-leaf reuse
+// lane (reuseNonLeafTargetStateOnStack, incremental.go) still rejects
+// candidates whose span exceeds maxNonLeafReuseSpan. maxNonLeafReuseSpan was
+// raised from 2048 to 1<<20 once fragility marking (markReduceFragility,
+// parser_reduce.go) became the real soundness gate for interior reuse -- see
+// TestTryReuseSubtreeSkipsFragileNonLeafCandidate for that gate -- so this
+// candidate must be sized just over the new bound to still exercise the span
+// cutoff specifically, independent of fragility.
+func TestTryReuseSubtreeSkipsLargeNonLeafCandidate(t *testing.T) {
+	const overCap = (1 << 20) + 4096
+	parser, reuse, newSource := nonLeafReuseSpanFixture(t, overCap, false)
+
 	var entryScratch glrEntryScratch
 	var gssScratch gssScratch
-	stack := newGLRStackWithScratch(lang.InitialState, &entryScratch)
+	stack := newGLRStackWithScratch(parser.language.InitialState, &entryScratch)
 
 	lookahead := Token{
 		Symbol:     2,
@@ -547,6 +572,54 @@ func TestTryReuseSubtreeSkipsLargeNonLeafCandidate(t *testing.T) {
 	}
 	if stackEntryNode(stack.top()) != nil {
 		t.Fatal("stack should remain unchanged when reuse fails")
+	}
+	if reuse.rejectLargeNonLeaf == 0 {
+		t.Fatal("expected rejectLargeNonLeaf to record the span-cutoff rejection")
+	}
+}
+
+// TestTryReuseSubtreeSkipsFragileNonLeafCandidate proves the non-leaf reuse
+// lane rejects a candidate marked fragile (Node.isFragile(), tree.go) even
+// though it is well within maxNonLeafReuseSpan -- the actual soundness gate
+// issue #380 required before the span cap could be safely raised. See
+// markReduceFragility (parser_reduce.go) for how a real parse sets these
+// bits, and the maxNonLeafReuseSpan comment (incremental.go) for why span
+// alone is no longer the gate.
+func TestTryReuseSubtreeSkipsFragileNonLeafCandidate(t *testing.T) {
+	const smallSpan = 64
+	parser, reuse, newSource := nonLeafReuseSpanFixture(t, smallSpan, true)
+
+	var entryScratch glrEntryScratch
+	var gssScratch gssScratch
+	stack := newGLRStackWithScratch(parser.language.InitialState, &entryScratch)
+
+	lookahead := Token{
+		Symbol:     2,
+		StartByte:  0,
+		EndByte:    1,
+		StartPoint: Point{Row: 0, Column: 0},
+		EndPoint:   Point{Row: 0, Column: 1},
+	}
+	ts := &stubTokenSource{tokens: []Token{{Symbol: 0, StartByte: uint32(len(newSource)), EndByte: uint32(len(newSource))}}}
+	nextTok, reusedBytes, ok := parser.tryReuseSubtree(&stack, lookahead, ts, reuse, &entryScratch, &gssScratch)
+	if ok {
+		t.Fatalf("expected fragile non-leaf candidate to be rejected, reusedBytes=%d nextTok=%+v", reusedBytes, nextTok)
+	}
+	if stackEntryNode(stack.top()) != nil {
+		t.Fatal("stack should remain unchanged when reuse fails")
+	}
+	if reuse.rejectFragileNonLeaf == 0 {
+		t.Fatal("expected rejectFragileNonLeaf to record the fragility rejection")
+	}
+
+	// Control: the same fixture with the fragile bits unset must actually be
+	// reused, so the rejection above is proven to come from fragility and not
+	// some other property of the fixture.
+	parser2, reuse2, newSource2 := nonLeafReuseSpanFixture(t, smallSpan, false)
+	stack2 := newGLRStackWithScratch(parser2.language.InitialState, &entryScratch)
+	ts2 := &stubTokenSource{tokens: []Token{{Symbol: 0, StartByte: uint32(len(newSource2)), EndByte: uint32(len(newSource2))}}}
+	if _, _, ok := parser2.tryReuseSubtree(&stack2, lookahead, ts2, reuse2, &entryScratch, &gssScratch); !ok {
+		t.Fatal("expected non-fragile control candidate to be reused")
 	}
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -401,6 +401,19 @@ type subtreeRecord struct {
 	extra             bool
 	external          bool
 	terminal          bool
+	// fragile mirrors gotreesitter.Node's fragileLeft/fragileRight bits
+	// (tree.go), collapsed to one conservative flag here: set whenever the
+	// record was produced by a reduce/conflict-arm decision that ran under
+	// ambiguity (see the conflict executor, parsercore_phase0_driver.go,
+	// and Core.Reduce/ReduceOutputs, core.go). It is monotone set-only (only
+	// ever flipped false->true), which is safe on shared/deduped records:
+	// a record reachable via both a clean and an ambiguous derivation must
+	// be treated as fragile, since the ambiguous derivation proves its
+	// shape was not uniquely determined. Not yet consumed by any reuse gate
+	// in this package -- laid down for a later lane, mirroring
+	// gotreesitter's own production fragility metadata (see PHASE-3 LANE 1,
+	// tree.go/parser_reduce.go).
+	fragile bool
 }
 
 // pathMeta is stored on a graph link. ScoreDelta includes the contributions
@@ -571,6 +584,30 @@ type Core struct {
 	// subtree was published through the authenticated shift/reduction seams.
 	// Diagnostic generic publication clears it monotonically until Reset.
 	metadataConstructionAuthenticated bool
+	// reduceConflictContext is a transient, non-sticky fragility signal: the
+	// conflict executor (executeDiagnosticParserCoreGenericConflictDetailed,
+	// parsercore_phase0_driver.go) sets it for the duration of applying every
+	// arm of a >=2-action conflict (both the fork.Present secondaries and the
+	// fork.Present==false primary), mirroring how markReduceFragility's
+	// action-conflict trigger works in the production Go parser
+	// (parser_reduce.go). Combined with the local len(paths) > 1 (multi-pop)
+	// signal in reduceOutputsClassifiedIntoActive, this feeds subtreeRecord's
+	// fragile bit. Core is used through a single-owner
+	// (SchedulerTransactionToken) access-control model, not concurrently,
+	// so a plain field is safe here -- see Parser.reduceActionConflict
+	// (parser.go) for the identical pattern and its safety argument.
+	reduceConflictContext bool
+}
+
+// SetReduceConflictContext sets/clears the transient conflict-context
+// fragility signal; see the reduceConflictContext field doc comment. Callers
+// outside this package (the conflict executor) must always pair a true set
+// with a deferred false reset, even on early-return error paths.
+func (c *Core) SetReduceConflictContext(v bool) {
+	if c == nil {
+		return
+	}
+	c.reduceConflictContext = v
 }
 
 // inlineAdjacencyCapacity covers the production default without forcing a
@@ -1448,16 +1485,27 @@ func (c *Core) reductionParentForPath(
 	path popPath,
 	key boundaryKey,
 	fork ForkOrder,
+	multiPop bool,
 	scratch *reductionOutputScratch,
 ) (SubtreeID, int64, ForkOrder, error) {
 	fields, aliases, err := c.remapReductionPlan(path.children, plan, scratch)
 	if err != nil {
 		return 0, 0, ForkOrder{}, err
 	}
+	// fragile mirrors markReduceFragility's non-propagation trigger in the
+	// production Go parser (parser_reduce.go): this reduce is fragile when
+	// more than one pop path was retained for it (multiPop, the pop.size > 1
+	// condition -- see reduceOutputsClassifiedIntoActive) or it is one arm of
+	// an authenticated >=2-action conflict (c.reduceConflictContext, set by
+	// the conflict executor for every arm including the primary). See the
+	// subtreeRecord.fragile field doc comment (above) for the monotone
+	// set-only contract on dedup below.
+	fragile := multiPop || c.reduceConflictContext
 	parent := subtreeRecord{
 		symbol: act.Symbol, productionID: act.ProductionID,
 		dynamicPrecedence: act.DynamicPrecedence,
 		startByte:         path.startByte, endByte: path.structuralEnd,
+		fragile: fragile,
 	}
 	order := path.order
 	if fork.Present {
@@ -1494,6 +1542,16 @@ func (c *Core) reductionParentForPath(
 		}
 		if len(path.trailing) == 0 {
 			scratch.batchParents = append(scratch.batchParents, payload)
+		}
+	} else if fragile {
+		// found reused an existing (deduped) record instead of publishing
+		// parent above; its fragile bit must still be OR'd in -- a record
+		// reachable via both a clean and an ambiguous/multi-pop derivation
+		// is fragile, since the ambiguous derivation proves the shape was
+		// not uniquely determined. Monotone set-only, safe on a shared
+		// record (see the field doc comment).
+		if rec, err := c.subtree(payload); err == nil && rec != nil && !rec.fragile {
+			rec.fragile = true
 		}
 	}
 	return payload, scoreDelta, order, nil
@@ -1648,6 +1706,12 @@ func reductionParentIdentityEqual(
 	right.firstChild, right.childCount = 0, uint32(len(rightChildren))
 	right.firstField, right.fieldCount = 0, uint32(len(rightFields))
 	right.firstAlias, right.aliasCount = 0, uint32(len(rightAliases))
+	// fragile is derivation history, not structural identity: two
+	// structurally-identical records must still dedup to one record even if
+	// one arrived via an ambiguous/multi-pop derivation and the other did
+	// not. The caller (reductionParentForPath) is responsible for OR-ing the
+	// bit into whichever record survives the dedup -- see its doc comment.
+	left.fragile, right.fragile = false, false
 	return left == right && slices.Equal(leftChildren, rightChildren) && slices.Equal(leftFields, rightFields) && slices.Equal(leftAliases, rightAliases)
 }
 

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -263,6 +263,13 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		c.addWork(&c.work.EmittedPopPayloads, uint64(len(path.children)+len(path.trailing)))
 	}
 	scratch := &c.reductionScratch
+	// len(paths) > 1 is this reduce's pop.size > 1 (a GSS multi-pop / diamond
+	// merge): more than one distinct way to pop act.ChildCount entries was
+	// found, one per path below -- mirrors the production Go parser's
+	// applyReduceActionForked len(forks) > 1 check (parser_reduce.go). Every
+	// parent reductionParentForPath builds in this loop is fragile in that
+	// case; see its doc comment.
+	multiPop := len(paths) > 1
 	for _, path := range paths {
 		prev, err := c.node(path.prev)
 		if err != nil {
@@ -276,7 +283,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			return nil, fmt.Errorf("parser-core phase zero: no goto from state %d for reduced symbol %d", prev.state, act.Symbol)
 		}
 		key := c.boundaryKey(gotoState, path.structuralEnd)
-		payload, scoreDelta, order, err := c.reductionParentForPath(*act, &plan, path, key, fork, scratch)
+		payload, scoreDelta, order, err := c.reductionParentForPath(*act, &plan, path, key, fork, multiPop, scratch)
 		if err != nil {
 			return nil, err
 		}

--- a/no_tree_node.go
+++ b/no_tree_node.go
@@ -163,6 +163,21 @@ func (n *noTreeNode) setExternalScannerToken(v bool) { n.setFlag(nodeFlagExterna
 func (n *noTreeNode) dirty() bool                    { return n.hasFlag(nodeFlagDirty) }
 func (n *noTreeNode) setDirty(v bool)                { n.setFlag(nodeFlagDirty, v) }
 
+// setFragileLeft/setFragileRight/isFragileLeft/isFragileRight mirror the
+// Node methods of the same name (tree.go); see markReduceFragility
+// (parser_reduce.go). Promoted onto compactCheckpointLeaf, compactFullLeaf,
+// and pendingParent (all embed noTreeNode), so a single definition here
+// covers every non-Node reduce-time payload representation.
+func (n *noTreeNode) setFragileLeft(v bool)  { n.setFlag(nodeFlagFragileLeft, v) }
+func (n *noTreeNode) setFragileRight(v bool) { n.setFlag(nodeFlagFragileRight, v) }
+func (n *noTreeNode) isFragileLeft() bool {
+	return n != nil && (n.hasFlag(nodeFlagFragileLeft) || n.isMissing() || n.symbol == errorSymbol)
+}
+func (n *noTreeNode) isFragileRight() bool {
+	return n != nil && (n.hasFlag(nodeFlagFragileRight) || n.isMissing() || n.symbol == errorSymbol)
+}
+func (n *noTreeNode) isFragile() bool { return n.isFragileLeft() || n.isFragileRight() }
+
 func noTreeNodeBytesForCap(n int) int64 {
 	if n <= 0 {
 		return 0
@@ -467,6 +482,45 @@ func stackEntryNodeDirty(e stackEntry) bool {
 	}
 	if n := stackEntryPendingParent(e); n != nil {
 		return n.dirty()
+	}
+	return false
+}
+
+// stackEntryNodeIsFragileLeft/Right dispatch over every stack-entry payload
+// kind (see markReduceFragility, parser_reduce.go), for reduce call sites
+// that hold a raw entries window rather than a materialized []*Node children
+// slice (the pending-parent lanes). Flattening a nested pendingParent's
+// children into its own child range does not change which entry is
+// syntactically leftmost/rightmost, so checking the boundary raw entry's own
+// isFragileLeft/Right is equivalent to checking the flattened boundary leaf.
+func stackEntryNodeIsFragileLeft(e stackEntry) bool {
+	if n := stackEntryNode(e); n != nil {
+		return n.isFragileLeft()
+	}
+	if n := stackEntryNoTreeNode(e); n != nil {
+		return n.isFragileLeft()
+	}
+	if n := stackEntryCompactFullLeaf(e); n != nil {
+		return n.isFragileLeft()
+	}
+	if n := stackEntryPendingParent(e); n != nil {
+		return n.isFragileLeft()
+	}
+	return false
+}
+
+func stackEntryNodeIsFragileRight(e stackEntry) bool {
+	if n := stackEntryNode(e); n != nil {
+		return n.isFragileRight()
+	}
+	if n := stackEntryNoTreeNode(e); n != nil {
+		return n.isFragileRight()
+	}
+	if n := stackEntryCompactFullLeaf(e); n != nil {
+		return n.isFragileRight()
+	}
+	if n := stackEntryPendingParent(e); n != nil {
+		return n.isFragileRight()
 	}
 	return false
 }

--- a/parser.go
+++ b/parser.go
@@ -46,6 +46,29 @@ type Parser struct {
 	rootSymbol                    Symbol
 	hasRootSymbol                 bool
 
+	// reduceMultiVersion/reduceActionConflict are transient, non-sticky
+	// fragility signals for the reduce(s) about to run. Parser is documented
+	// single-goroutine (see the doc comment above), so plain mutable fields
+	// are safe here; unlike gssScratch.everForked (which latches permanently
+	// once a parse ever forks), these are recomputed every dispatch pass /
+	// conflict decision so fragility marking (tree.go markReduceFragility)
+	// stays scoped to the reduces that actually happened under ambiguity,
+	// mirroring C tree-sitter's live action_count/version_count checks
+	// rather than a whole-parse latch.
+	//
+	// reduceMultiVersion mirrors C's "ts_stack_version_count > 1": set once
+	// per token-dispatch pass, before the per-stack loop, to numStacks > 1
+	// (see parseInternal). It stays constant for every stack dispatched
+	// against the current token.
+	reduceMultiVersion bool
+	// reduceActionConflict mirrors C's "action_count > 1": true only while
+	// the "if len(actions) > 1" conflict-dispatch block (parseInternal) is
+	// applying one of the conflicting actions (deterministic choice,
+	// depth-cap fallback, or an explicit fork) and its immediate
+	// conflict-reduce-frontier / pending-fork follow-through. Reset to false
+	// at the top of every per-stack dispatch iteration.
+	reduceActionConflict bool
+
 	// Forest-decline diagnostics: the experimental forest fast path records
 	// WHERE and WHY it last declined (fell back to production) so the language
 	// burndown can triage dead-ends without re-instrumenting. Set on the parser
@@ -1146,7 +1169,16 @@ type IncrementalParseProfile struct {
 	ReuseRejectRootNonLeafChanged       uint64
 	ReuseRejectLargeNonLeaf             uint64
 	ReuseRejectStaleNonLeafBoundary     uint64
-	RecoverSearches                     uint64
+	// ReuseRejectFragileNonLeaf counts interior (non-leaf) reuse candidates
+	// rejected because Node.isFragile() reported the candidate was built
+	// under an ambiguous parse decision (LR-table conflict, GSS multi-pop, or
+	// concurrent GLR stack versions) or is itself an ERROR/MISSING node -- see
+	// markReduceFragility (parser_reduce.go) and reuseNonLeafTargetStateOnStack
+	// (incremental.go). A nonzero count on a conflict-heavy grammar (e.g. js)
+	// is expected and correct: it is exactly the unsound reuse this gate is
+	// designed to prevent.
+	ReuseRejectFragileNonLeaf uint64
+	RecoverSearches           uint64
 	RecoverStateChecks                  uint64
 	RecoverStateSkips                   uint64
 	RecoverSymbolSkips                  uint64
@@ -1243,6 +1275,7 @@ type incrementalParseTiming struct {
 	reuseRejectRootNonLeafChanged       uint64
 	reuseRejectLargeNonLeaf             uint64
 	reuseRejectStaleNonLeafBoundary     uint64
+	reuseRejectFragileNonLeaf           uint64
 	recoverSearches                     uint64
 	recoverStateChecks                  uint64
 	recoverStateSkips                   uint64
@@ -2892,6 +2925,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 			timing.reuseRejectRootNonLeafChanged += reuse.rejectRootNonLeafChanged
 			timing.reuseRejectLargeNonLeaf += reuse.rejectLargeNonLeaf
 			timing.reuseRejectStaleNonLeafBoundary += reuse.rejectStaleNonLeafBoundary
+			timing.reuseRejectFragileNonLeaf += reuse.rejectFragileNonLeaf
 		}
 		if timing != nil {
 			reuseStart := time.Now()
@@ -4787,6 +4821,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		}
 
 		numStacks := len(stacks)
+		// See the Parser.reduceMultiVersion doc comment: live, non-sticky
+		// "ts_stack_version_count > 1" signal for every reduce that can run
+		// against the current token, including the external-default-reduce
+		// pre-dispatch step below (which runs before the per-stack loop).
+		// Re-synced at every numStacks reassignment in that pre-dispatch step.
+		p.reduceMultiVersion = numStacks > 1
 		if progress.enabled {
 			dispatchTrace = make([]dispatchStackSurvivorTrace, len(stacks))
 			for i := range dispatchTrace {
@@ -4992,12 +5032,14 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					anyReduced = true
 					drainPendingForkStacks()
 					numStacks = len(stacks)
+					p.reduceMultiVersion = numStacks > 1
 					if !p.canApplyExternalNoActionDefaultReduce(tok, stacks) {
 						break
 					}
 				}
 				if preDispatchDefaultReduced {
 					numStacks = len(stacks)
+					p.reduceMultiVersion = numStacks > 1
 					if !p.externalNoActionDefaultReducesStable(tok, stacks) {
 						if parseEagerDefaultReduceDebugEnabled() {
 							fmt.Printf("  EXTERNAL-DEFAULT-RELEX-DEFER old=%d[%d-%d]\n",
@@ -5043,6 +5085,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		}
 		for si := 0; si < numStacks; si++ {
 			s := &stacks[si]
+			// reduceActionConflict is scoped to a single stack's dispatch; a
+			// fresh iteration must not inherit the previous stack's conflict
+			// context (see the "if len(actions) > 1" block below, which is
+			// the only place this is set true).
+			p.reduceActionConflict = false
 			if s.dead || s.shifted {
 				continue
 			}
@@ -5462,6 +5509,13 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				// including the actions[0] continuation applied to the
 				// original stack later in this same iteration.
 				scratch.gss.everForked = true
+				// C's action_count > 1: this dispatch point had more than one
+				// viable parse-table action, so every node any of the paths
+				// below build (deterministic choice, depth-cap fallback, or
+				// an explicit fork, plus their conflict-reduce-frontier /
+				// pending-fork follow-through) is born fragile. Reset to
+				// false at the top of every per-stack iteration above.
+				p.reduceActionConflict = true
 				conflictStart := time.Time{}
 				if actionTiming != nil {
 					conflictStart = time.Now()

--- a/parser_incremental_support.go
+++ b/parser_incremental_support.go
@@ -54,6 +54,7 @@ func (t *incrementalParseTiming) toProfile() IncrementalParseProfile {
 		ReuseRejectRootNonLeafChanged:       t.reuseRejectRootNonLeafChanged,
 		ReuseRejectLargeNonLeaf:             t.reuseRejectLargeNonLeaf,
 		ReuseRejectStaleNonLeafBoundary:     t.reuseRejectStaleNonLeafBoundary,
+		ReuseRejectFragileNonLeaf:           t.reuseRejectFragileNonLeaf,
 		RecoverSearches:                     t.recoverSearches,
 		RecoverStateChecks:                  t.recoverStateChecks,
 		RecoverStateSkips:                   t.recoverStateSkips,
@@ -156,6 +157,7 @@ func (t *incrementalParseTiming) addAttempt(other *incrementalParseTiming) {
 	t.reuseRejectRootNonLeafChanged += other.reuseRejectRootNonLeafChanged
 	t.reuseRejectLargeNonLeaf += other.reuseRejectLargeNonLeaf
 	t.reuseRejectStaleNonLeafBoundary += other.reuseRejectStaleNonLeafBoundary
+	t.reuseRejectFragileNonLeaf += other.reuseRejectFragileNonLeaf
 	t.recoverSearches += other.recoverSearches
 	t.recoverStateChecks += other.recoverStateChecks
 	t.recoverStateSkips += other.recoverStateSkips

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -3654,6 +3654,7 @@ func (p *Parser) tryFastVisibleReduceActionFromGSS(s *glrStack, act ParseAction,
 	}
 	parent.preGotoState = topState
 	parent.parseState = targetState
+	markReduceFragility(parent, children, p.reduceUnderConflictContext())
 	if !s.truncateBeforePush(targetDepth) {
 		s.dead = true
 		if tmpEntries != nil {
@@ -3765,6 +3766,81 @@ func (p *Parser) applyNoTreeReduceActionFromGSS(s *glrStack, act ParseAction, to
 	}
 	markReduceApplied(s, act, anyReduced)
 	releaseReduceWindowEntries(tmpEntries, windowEntries)
+}
+
+// reduceUnderConflictContext reports whether any reduce dispatched right now
+// should have its produced parent(s) marked fragile per C tree-sitter's
+// fragility rule (mirrors the non-pop.size conditions of ts_subtree's fragile
+// marking): an LR-table conflict was live at this dispatch
+// (reduceActionConflict, i.e. C's action_count > 1) or more than one GLR
+// stack was concurrently live (reduceMultiVersion, i.e. C's
+// version_count > 1). Both fields are transient, single-goroutine Parser
+// state set by parseInternal (parser.go) -- see their doc comments there.
+//
+// The third C condition, pop.size > 1 (a GSS multi-pop / diamond merge), can
+// only occur inside applyReduceActionForked (the only caller that pops a
+// non-linear GSS span) and is evaluated locally there via len(forks) > 1;
+// it is intentionally not folded into this helper.
+func (p *Parser) reduceUnderConflictContext() bool {
+	return p != nil && (p.reduceMultiVersion || p.reduceActionConflict)
+}
+
+// markReduceFragility sets parent's fragileLeft/fragileRight after a reduce,
+// mirroring C tree-sitter's ts_subtree fragility: reduceItselfFragile marks
+// both edges when the reduce that produced parent happened under ambiguity
+// (see reduceUnderConflictContext and applyReduceActionForked's
+// len(forks) > 1 pop check); independently, each edge also inherits
+// fragility from the corresponding boundary child (fragileLeft from the
+// first child, fragileRight from the last), matching C's propagation so a
+// fragile descendant poisons every ancestor up to the nearest edge that
+// truly does not touch it. Every "parent.parseState = targetState" reduce
+// set-point in this file that constructs a *Node parent must call this
+// (see markPendingParentReduceFragility for the pendingParent lanes, and
+// collapse/extra reduce set-points, which reuse an existing node and need no
+// call here since that node's own fragility is already correct).
+func markReduceFragility(parent *Node, children []*Node, reduceItselfFragile bool) {
+	if parent == nil {
+		return
+	}
+	left := reduceItselfFragile
+	right := reduceItselfFragile
+	if n := len(children); n > 0 {
+		if c := children[0]; c != nil && c.isFragileLeft() {
+			left = true
+		}
+		if c := children[n-1]; c != nil && c.isFragileRight() {
+			right = true
+		}
+	}
+	parent.setFragileLeft(left)
+	parent.setFragileRight(right)
+}
+
+// markPendingParentReduceFragility is markReduceFragility for the
+// pendingParent reduce lanes (tryPushPendingNoFieldParent /
+// tryPushPendingDirectFieldParent), which hold a raw stackEntry window
+// instead of a materialized []*Node children slice. See
+// stackEntryNodeIsFragileLeft/Right (no_tree_node.go) for why checking the
+// boundary raw entries is equivalent to checking the flattened boundary
+// leaf. publicPendingParentNodeFlags (pending_parent.go) must keep
+// nodeFlagFragileLeft/Right so these bits survive materialization into the
+// final Node.
+func markPendingParentReduceFragility(parent *pendingParent, entries []stackEntry, start, end int, reduceItselfFragile bool) {
+	if parent == nil {
+		return
+	}
+	left := reduceItselfFragile
+	right := reduceItselfFragile
+	if end > start {
+		if stackEntryNodeIsFragileLeft(entries[start]) {
+			left = true
+		}
+		if stackEntryNodeIsFragileRight(entries[end-1]) {
+			right = true
+		}
+	}
+	parent.setFragileLeft(left)
+	parent.setFragileRight(right)
 }
 
 func (p *Parser) applyReduceActionFromGSS(source []byte, s *glrStack, act ParseAction, tok Token, anyReduced *bool, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, tmpEntries *[]stackEntry, tmp []stackEntry, deferParentLinks bool, trackChildErrors bool) {
@@ -3918,6 +3994,7 @@ func (p *Parser) applyReduceActionFromGSS(source []byte, s *glrStack, act ParseA
 	}
 	parent.preGotoState = window.topState
 	parent.parseState = targetState
+	markReduceFragility(parent, children, p.reduceUnderConflictContext())
 	p.pushStackNode(s, targetState, parent, entryScratch, gssScratch)
 	for i := window.reducedEnd; i < window.actualEnd; i++ {
 		extra := stackEntryNode(windowEntries[i])
@@ -3948,6 +4025,15 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 	}
 
 	named := p.isNamedSymbol(act.Symbol)
+	// C's pop.size > 1: this function only runs when the GSS span being
+	// reduced is non-linear (see the gssSpanIsLinear callers), and
+	// selectedReduceWindowsFromGSS returning more than one fork is exactly
+	// the ambiguous-pop case -- multiple distinct ways to pop childCount
+	// entries off the GSS were found, one per fork below. Every parent this
+	// closure builds is therefore fragile in that case, in addition to
+	// whatever reduceUnderConflictContext (action_count/version_count)
+	// already contributes.
+	multiPop := len(forks) > 1
 	applyForkToStack := func(target *glrStack, fork reduceFork) {
 		window := fork.window
 		reducedEnd := reducedEndBeforeTrailingExtras(window)
@@ -4005,6 +4091,7 @@ func (p *Parser) applyReduceActionForked(source []byte, s *glrStack, act ParseAc
 		}
 		parent.preGotoState = fork.topState
 		parent.parseState = targetState
+		markReduceFragility(parent, children, multiPop || p.reduceUnderConflictContext())
 		p.pushStackNode(target, targetState, parent, entryScratch, gssScratch)
 		for i := reducedEnd; i < actualEnd; i++ {
 			extra := stackEntryNode(window[i])
@@ -4182,6 +4269,7 @@ func (p *Parser) tryFastVisibleReduceActionFromGSSTransientParents(s *glrStack, 
 	}
 	parent.preGotoState = topState
 	parent.parseState = targetState
+	markReduceFragility(parent, children, p.reduceUnderConflictContext())
 	if !s.truncateBeforePush(targetDepth) {
 		s.dead = true
 		if tmpEntries != nil {
@@ -4377,6 +4465,7 @@ func (p *Parser) applyReduceActionFromGSSTransientParents(source []byte, s *glrS
 	}
 	parent.preGotoState = topState
 	parent.parseState = targetState
+	markReduceFragility(parent, children, p.reduceUnderConflictContext())
 	p.pushStackNode(s, targetState, parent, entryScratch, gssScratch)
 	for i := reducedEnd; i < actualEnd; i++ {
 		extra := stackEntryNode(windowEntries[i])
@@ -4728,6 +4817,7 @@ func (p *Parser) tryPushPendingNoFieldParent(s *glrStack, act ParseAction, tok T
 	}
 	parent.preGotoState = topState
 	parent.parseState = targetState
+	markPendingParentReduceFragility(parent, entries, start, reducedEnd, p.reduceUnderConflictContext())
 	if !s.truncateBeforePush(truncateDepth) {
 		s.dead = true
 		return true
@@ -4844,6 +4934,7 @@ func (p *Parser) tryPushPendingDirectFieldParent(s *glrStack, act ParseAction, t
 	}
 	parent.preGotoState = topState
 	parent.parseState = targetState
+	markPendingParentReduceFragility(parent, entries, start, reducedEnd, p.reduceUnderConflictContext())
 	if !s.truncateBeforePush(truncateDepth) {
 		s.dead = true
 		return true
@@ -7098,6 +7189,7 @@ func (p *Parser) applyReduceAction(source []byte, s *glrStack, act ParseAction, 
 	}
 	parent.preGotoState = window.topState
 	parent.parseState = targetState
+	markReduceFragility(parent, children, p.reduceUnderConflictContext())
 	p.pushStackNode(s, targetState, parent, entryScratch, gssScratch)
 	for i := trailingStart; i < trailingEnd; i++ {
 		extra := stackEntryNode(entries[i])
@@ -7277,6 +7369,7 @@ func (p *Parser) applyReduceActionTransientParents(source []byte, s *glrStack, a
 	}
 	parent.preGotoState = window.topState
 	parent.parseState = targetState
+	markReduceFragility(parent, children, p.reduceUnderConflictContext())
 	p.pushStackNode(s, targetState, parent, entryScratch, gssScratch)
 	for i := trailingStart; i < trailingEnd; i++ {
 		extra := stackEntryNode(entries[i])

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -968,6 +968,13 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	if actions.Len() < 2 {
 		return diagnosticParserCoreConflictExecution{}, errors.New("parser-core phase zero: conflict executor requires multiple actions")
 	}
+	// See Core.reduceConflictContext (core.go): every arm applied below --
+	// both the fork.Present secondaries and the fork.Present==false primary
+	// -- runs while this dispatch point had more than one viable action, so
+	// every subtreeRecord any of them reduce is fragile. Reset unconditionally
+	// on every exit path, including error returns from RunSchedulerOwned.
+	compact.SetReduceConflictContext(true)
+	defer compact.SetReduceConflictContext(false)
 	secondaryCount := uint64(actions.Len() - 1)
 	if secondaryCount > math.MaxUint64-branchOrder {
 		return diagnosticParserCoreConflictExecution{}, errors.New("parser-core phase zero: conflict branch order overflow")

--- a/pending_parent.go
+++ b/pending_parent.go
@@ -48,7 +48,20 @@ const (
 	pendingParentFlagFieldEntries         nodeFlags = 1 << 5
 	pendingParentFlagDirectFieldEntry     nodeFlags = 1 << 6
 
-	publicPendingParentNodeFlags nodeFlags = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError | nodeFlagDirty
+	// publicPendingParentNodeFlags is the mask applied when a pendingParent's
+	// flags are copied onto the Node produced at materialization (see
+	// materializeStackEntryPendingParentEntryWithParser, below): it strips
+	// the pending-only scratch bits (pendingParentFlagFieldEntries /
+	// pendingParentFlagDirectFieldEntry, which alias
+	// nodeFlagFieldIDCacheComputed / nodeFlagFieldIDCacheHasFieldIDs -- see
+	// tree.go) that only have meaning before materialization.
+	// nodeFlagFragileLeft/Right MUST stay in this mask: they are set on the
+	// pendingParent by markReduceFragility (parser_reduce.go) at the same
+	// "parent.parseState = targetState" reduce set-point as every other
+	// reduce lane, and silently dropping them here would let a fragile
+	// subtree survive materialization looking safe to incremental non-leaf
+	// reuse (reuseNonLeafTargetStateOnStack, incremental.go).
+	publicPendingParentNodeFlags nodeFlags = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError | nodeFlagDirty | nodeFlagFragileLeft | nodeFlagFragileRight
 )
 
 type pendingParentMaterializeReason = materializeReason

--- a/tree.go
+++ b/tree.go
@@ -41,7 +41,15 @@ type Node struct {
 	subtreeHeight     uint8 // forest dedup tie-break cache (0 = uncomputed); see nodeCachedHeight
 }
 
-type nodeFlags uint8
+// nodeFlags is uint16, not uint8: Node has exactly one byte of trailing
+// padding under the 104-byte layout budget (TestNodeLayoutSizeBudget), and
+// the original 8 flag bits below were already fully packed. Widening by one
+// byte spends that padding on the fragileLeft/fragileRight bits without
+// changing Node's size. nodeFlags is never serialized/blob-encoded (grep for
+// "nodeFlags" before adding more bits, or before touching any blob-encode
+// path) -- fragility in particular is runtime-only and must never be
+// persisted, since it is recomputed fresh every parse.
+type nodeFlags uint16
 
 const (
 	nodeFlagNamed nodeFlags = 1 << iota
@@ -59,6 +67,27 @@ const (
 	nodeFlagFieldIDCacheComputed
 	nodeFlagFieldIDCacheHasFieldIDs
 	nodeFlagExternalScannerToken
+	// nodeFlagFragileLeft / nodeFlagFragileRight mirror C tree-sitter's
+	// Subtree.fragile_left / fragile_right (subtree.h): a subtree is fragile
+	// on a given edge when the reduce that produced it happened under an
+	// ambiguous parse decision (LR-table conflict, GSS multi-pop, or
+	// concurrent GLR stack versions -- see markReduceFragility,
+	// parser_reduce.go), or when that edge's boundary child is itself
+	// fragile on the same side (propagation). Query via isFragileLeft /
+	// isFragileRight / isFragile, which also fold in isMissing()/IsError()
+	// (error/missing nodes are always fragile, regardless of these bits).
+	// Fragile subtrees must never be spliced into a fresh parse by
+	// incremental non-leaf reuse (reuseNonLeafTargetStateOnStack,
+	// incremental.go) -- see ts_parser__reuse_node's is_fragile rejection in
+	// C. These two bits are pending-parent-domain-safe: pendingParent reuses
+	// bits 5/6 (pendingParentFlagFieldEntries/DirectFieldEntry) as
+	// pending-only scratch that publicPendingParentNodeFlags masks away
+	// before a pendingParent's flags are copied onto a materialized Node;
+	// fragileLeft/fragileRight live above that reused range and must be
+	// added to publicPendingParentNodeFlags (pending_parent.go) so they
+	// survive materialization.
+	nodeFlagFragileLeft
+	nodeFlagFragileRight
 )
 
 func (n *Node) hasFlag(flag nodeFlags) bool {
@@ -87,6 +116,57 @@ func (n *Node) isExternalScannerToken() bool {
 func (n *Node) setExternalScannerToken(v bool) { n.setFlag(nodeFlagExternalScannerToken, v) }
 func (n *Node) dirty() bool {
 	return n != nil && n.hasFlag(nodeFlagDirty)
+}
+
+// setFragileLeft/setFragileRight set the raw fragility bits. Reduce-time
+// callers should use markReduceFragility (parser_reduce.go) instead of
+// calling these directly, so left/right propagation from boundary children
+// stays consistent everywhere a parent node is built.
+func (n *Node) setFragileLeft(v bool) {
+	if n == nil {
+		return
+	}
+	n.setFlag(nodeFlagFragileLeft, v)
+}
+
+func (n *Node) setFragileRight(v bool) {
+	if n == nil {
+		return
+	}
+	n.setFlag(nodeFlagFragileRight, v)
+}
+
+// isFragileLeft/isFragileRight/isFragile report whether n's subtree is
+// unsafe to splice into a fresh parse via incremental non-leaf reuse, on the
+// given edge. Besides the raw fragileLeft/fragileRight bits (set by
+// markReduceFragility for reduces that ran under ambiguity, and propagated
+// from boundary children), any node that is itself missing or an ERROR node
+// is unconditionally fragile on both edges -- mirroring C tree-sitter, which
+// never reuses an is_missing/is_error subtree regardless of its fragile
+// bits. This is computed from isMissing()/IsError() rather than set at
+// construction time so every existing and future construction site (there
+// are dozens across the per-grammar parser_result_*.go shaping helpers)
+// is covered automatically, with no risk of a missed setFragileLeft/Right
+// call silently under-marking a repair/recovery node.
+func (n *Node) isFragileLeft() bool {
+	if n == nil {
+		return false
+	}
+	return n.hasFlag(nodeFlagFragileLeft) || n.isMissing() || n.symbol == errorSymbol
+}
+
+func (n *Node) isFragileRight() bool {
+	if n == nil {
+		return false
+	}
+	return n.hasFlag(nodeFlagFragileRight) || n.isMissing() || n.symbol == errorSymbol
+}
+
+// isFragile is the coarse (edge-agnostic) query used by the interior
+// non-leaf incremental-reuse gate: reject the whole candidate if either edge
+// is fragile. See reuseNonLeafTargetStateOnStack (incremental.go).
+func (n *Node) isFragile() bool {
+	return n.isFragileLeft() || n.isFragileRight()
 }
 
 func (n *Node) setDirty(v bool) {


### PR DESCRIPTION
## Summary

Introduces precise `fragileLeft`/`fragileRight` metadata mirroring C tree-sitter, marking subtrees produced under ambiguous parse decisions (LR-table conflicts, GSS multi-pops, or concurrent GLR stacks). This metadata powers the actual soundness gate in incremental non-leaf reuse, replacing the old span-only safety proxy and allowing `maxNonLeafReuseSpan` to be safely raised from 2048 to 1MB. The change spans the full reduce chain (GLR phases and Phase-0 parser-core), ensures bits survive pending-parent materialization, and adds metrics and parity tests.

## Changes

- Add `nodeFlagFragileLeft` / `nodeFlagFragileRight` to `Node` and `noTreeNode`, with propagation and query methods (`isFragile*`), widening `nodeflags` to `uint16` using existing struct padding.
- Mark nodes fragile at every reduce set-point (`parser_reduce.go`) when the reduce occurs under action conflicts (`reduceActionConflict`), multiple concurrent stacks (`reduceMultiVersion`), or GSS multi-pops (`len(forks) > 1`).
- Extend fragility tracking to Phase-0 parser-core (`core.go`, `parsercore_phase0_driver.go`), setting `reduceConflictContext` during conflict execution and monotone OR-ing `fragile` on dedup.
- Protect incremental non-leaf reuse (`incremental.go`) with `n.isFragile()` rejection, removing the need for the old 2048-byte span proxy and raising the cap to `1 << 20`.
- Ensure fragility bits survive materialization by updating `publicPendingParentNodeFlags` (`pending_parent.go`).
- Expose `ReuseRejectFragileNonLeaf` in `IncrementalParseProfile` and `incrementalParseTiming` for diagnostic tracking during incremental parses.
- Add tests verifying fragile candidates are rejected and non-fragile controls are reused, and update existing span-cap test to match the new threshold.

## Testing

- bash cgo_harness/docker/run_single_grammar_parity.sh js
- GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms
- go test ./... -run 'TestTryReuseSubtreeSkipsFragileNonLeafCandidate|TestTryReuseSubtreeSkipsLargeNonLeafCandidate'