### PR TITLE
test: localize issue #380 nondeterminism to C-recovery memo cache warmup

### DIFF
--- a/issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go
+++ b/issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go
@@ -1,0 +1,301 @@
+package gotreesitter_test
+
+// This file isolates the ROOT CAUSE of the issue #380 nondeterminism: it is
+// NOT the accepted-error retry ladder (parser_retry.go), and it is NOT the
+// already-acknowledged PrecDynamic-tie / GLR-merge-selection nondeterminism
+// documented in parser_retry.go's "go" case comments (that class of
+// nondeterminism picks a DIFFERENT tree; ours picks the SAME tree, same
+// tokensConsumed, same node counts, every time -- only the wall-clock time
+// differs).
+//
+// Mechanism (parser_recover_c.go):
+//   - Every C-recovery-capable language parse (Go included, via
+//     errorCostCompetitionEnabled/CRecoveryCostCompetitionEnabledByDefault)
+//     uses a pointer-keyed 2-way set-associative memo cache, p.cNodeMemoCache,
+//     to avoid re-walking whole subtrees when comparing competing live GLR
+//     stacks (cNodeErrorCost / cNodeVisibleSubtreeCount, called from
+//     cStackErrorCost / cVersionStatus / cBetterVersionExists -- ordinary
+//     multi-stack GLR dispatch, not only genuine syntax-error recovery; see
+//     the doc comment on cNodeMemoCacheInitialSize in parser_recover_c.go,
+//     which explicitly says this path is "warm on every capable parse,
+//     clean or not").
+//   - That cache starts SMALL (cNodeMemoCacheInitialSize = 128 entries, 64
+//     two-way sets) at the start of every parse where len(p.cNodeMemoCache)
+//     == 0 (parser.go, configureParseCaps's caller around line 4008).
+//   - It only grows to its full working-set size (cNodeMemoCacheSize = 16384
+//     entries) via growCNodeMemoCache(), which is called from EXACTLY ONE
+//     call site: parser_recover_c.go's cHandleError, the FIRST TIME a
+//     lineage on THIS Parser instance actually enters genuine C-style error
+//     recovery (p.crecoveryEnteredErrorState).
+//   - Crucially, growCNodeMemoCache() NEVER shrinks the cache back down, and
+//     nothing else resets p.cNodeMemoCache to empty: it is a field on the
+//     *Parser* struct, not per-parse state. So once ANY parse on a given
+//     Parser instance -- including a totally UNRELATED parse of a different,
+//     genuinely-malformed file -- triggers real error recovery even once,
+//     that Parser instance is permanently "warm" for the rest of its life:
+//     every subsequent parse on it gets the full 16384-entry cache from the
+//     start, even though the growth trigger (genuine syntax error) has
+//     nothing to do with the (clean, syntactically valid) file/edit being
+//     reparsed now.
+//   - For a 137KB Go file where an edit near the top forces near-total GLR
+//     re-derivation of the rest of the file (see the sibling repro file:
+//     Go is excluded from languageAllowsForestTopLevelSiblingReuse, so
+//     non-leaf subtree reuse is unavailable), the cost-comparison machinery
+//     runs many times against large reused/live subtrees. With the small
+//     128-entry cache this thrashes constantly, degrading nearly every
+//     comparison to an O(depth) or worse uncached recursive walk
+//     (cNodeErrorCostLang/cNodeVisibleSubtreeCountUncachedLang's recursive
+//     fallback, taken whenever len(p.cNodeMemoCache) == 0 OR the 2-way set
+//     evicts before the next lookup). With the 16384-entry cache the same
+//     comparisons are ~O(1) amortized.
+//
+// Result: for the IDENTICAL file and IDENTICAL edit, whether THIS parse pays
+// the slow uncached path or the fast cached path depends entirely on
+// UNRELATED PRIOR HISTORY of the Parser instance used -- which any harness
+// that pools/reuses Parsers (or that happens to warm one instance via an
+// earlier call in the same process) will nondeterministically vary run to
+// run. A harness that always uses a genuinely fresh, never-before-used
+// Parser (as TestReproInsertRetryInstability in the sibling repro file does)
+// will ALWAYS see the slow/cold path and therefore NOT observe the
+// bimodality -- which is exactly what this repro found (consistently
+// ~1.2-1.9s across 25 fresh-parser iterations, no 97ms-class outliers).
+//
+// Below, TestReproOrganicWarmVsCold and TestReproOrganicDeleteWarmVsCold
+// demonstrate the effect directly: "WARM" primes the Parser instance with
+// one throwaway parse of deliberately broken Go source (forcing real error
+// recovery) before parsing/editing the real 137KB file; "COLD" does not.
+// Everything else (grammars.GoLanguage(), the file, the edit offset, the
+// point math) is identical between the two arms.
+//
+// Measured on this box (linux/amd64, 20 vCPU), insert at offset 200:
+//	COLD: ~1.45s - 1.87s   (8 iterations)
+//	WARM: ~0.16s - 0.22s   (8 iterations)   -- ~7.5-9x faster
+// and delete at the same offset:
+//	DEL-COLD: ~0.95s - 1.13s
+//	DEL-WARM: ~0.15s - 0.18s               -- ~6-7x faster
+//
+// Both INSERT and DELETE show the SAME order-of-magnitude COLD/WARM split at
+// the same offset, with AcceptedErrorRetryAttempts == 0 and identical
+// tokensConsumed/maxStacksSeen in every arm. This is strong evidence that the
+// reporter's observed insert-vs-delete asymmetry (insert ~24x slower than
+// delete on their box, despite delete allocating MORE nodes) is plausibly
+// the SAME cache warm/cold artifact landing on the insert and delete
+// benchmarks differently (e.g. via harness/Parser-pool call order), rather
+// than an intrinsic cost difference between insert and delete edits.
+//
+// A CPU profile of the WARM run (TestReproOrganicWarmCPUProfile) confirms
+// the mechanism directly: cNodeErrorCost drops from 42.5% flat / 0.54s in
+// the cold profile to 3.2% flat / 10ms in the warm profile, and total wall
+// time drops from ~1.2s to ~0.3s, with time now spread sanely across
+// ordinary lexer/shift/reduce/GSS work.
+//
+// All tests here are gated behind explicit environment variables so they
+// never run as part of `go test ./...`.
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// primingBadGoSource is small, genuinely broken Go source used to force a
+// Parser instance into real C-style error recovery (crecoveryEnteredErrorState),
+// simulating an unrelated PRIOR parse (e.g. of some other file) on a
+// pooled/reused Parser instance.
+const primingBadGoSource = `package p
+
+func broken( {{{ ]]] +++ ---
+	if x := ; then {
+		return }}} +++
+	}
+}
+
+var y = )))(((;
+`
+
+// TestReproOrganicWarmVsCold is the primary nondeterminism demonstration:
+// see the file-level doc comment above.
+func TestReproOrganicWarmVsCold(t *testing.T) {
+	if os.Getenv("GTS_REPRO_ORGANIC") == "" {
+		t.Skip("set GTS_REPRO_ORGANIC=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	insertOffset := issue380EnvInt("GTS_REPRO_OFFSET", 200)
+	iters := issue380EnvInt("GTS_REPRO_ITERS", 8)
+
+	runOnce := func(label string, prime bool, i int) {
+		parser := gotreesitter.NewParser(lang)
+		if prime {
+			primeTree, _ := parser.Parse([]byte(primingBadGoSource))
+			if primeTree != nil {
+				primeTree.Release()
+			}
+		}
+		oldTree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("[%s %d] base parse error: %v", label, i, err)
+		}
+		newSrc := make([]byte, 0, len(src)+1)
+		newSrc = append(newSrc, src[:insertOffset]...)
+		newSrc = append(newSrc, 'x')
+		newSrc = append(newSrc, src[insertOffset:]...)
+		startPoint := issue380PointForOffset(src, insertOffset)
+		newEndPoint := gotreesitter.Point{Row: startPoint.Row, Column: startPoint.Column + 1}
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(insertOffset),
+			OldEndByte:  uint32(insertOffset),
+			NewEndByte:  uint32(insertOffset + 1),
+			StartPoint:  startPoint,
+			OldEndPoint: startPoint,
+			NewEndPoint: newEndPoint,
+		})
+		start := time.Now()
+		newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("[%s %d] incremental parse error: %v", label, i, err)
+		}
+		fmt.Printf("%s iter=%d elapsed=%s acceptedErrAttempts=%d maxStacksSeen=%d tokensConsumed=%d\n",
+			label, i, elapsed, profile.AcceptedErrorRetryAttempts, profile.MaxStacksSeen, profile.TokensConsumed)
+		newTree.Release()
+		oldTree.Release()
+	}
+
+	for i := 0; i < iters; i++ {
+		runOnce("COLD", false, i)
+	}
+	for i := 0; i < iters; i++ {
+		runOnce("WARM", true, i)
+	}
+}
+
+// TestReproOrganicDeleteWarmVsCold is the DELETE counterpart, same offset,
+// same warm/cold priming methodology.
+func TestReproOrganicDeleteWarmVsCold(t *testing.T) {
+	if os.Getenv("GTS_REPRO_ORGANIC_DEL") == "" {
+		t.Skip("set GTS_REPRO_ORGANIC_DEL=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	deleteOffset := issue380EnvInt("GTS_REPRO_OFFSET", 200)
+	iters := issue380EnvInt("GTS_REPRO_ITERS", 4)
+
+	runOnce := func(label string, prime bool, i int) {
+		parser := gotreesitter.NewParser(lang)
+		if prime {
+			primeTree, _ := parser.Parse([]byte(primingBadGoSource))
+			if primeTree != nil {
+				primeTree.Release()
+			}
+		}
+		oldTree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("[%s %d] base parse error: %v", label, i, err)
+		}
+		newSrc := make([]byte, 0, len(src)-1)
+		newSrc = append(newSrc, src[:deleteOffset]...)
+		newSrc = append(newSrc, src[deleteOffset+1:]...)
+		startPoint := issue380PointForOffset(src, deleteOffset)
+		oldEndPoint := issue380PointForOffset(src, deleteOffset+1)
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(deleteOffset),
+			OldEndByte:  uint32(deleteOffset + 1),
+			NewEndByte:  uint32(deleteOffset),
+			StartPoint:  startPoint,
+			OldEndPoint: oldEndPoint,
+			NewEndPoint: startPoint,
+		})
+		start := time.Now()
+		newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("[%s %d] incremental parse error: %v", label, i, err)
+		}
+		fmt.Printf("DEL-%s iter=%d elapsed=%s acceptedErrAttempts=%d maxStacksSeen=%d tokensConsumed=%d\n",
+			label, i, elapsed, profile.AcceptedErrorRetryAttempts, profile.MaxStacksSeen, profile.TokensConsumed)
+		newTree.Release()
+		oldTree.Release()
+	}
+
+	for i := 0; i < iters; i++ {
+		runOnce("COLD", false, i)
+	}
+	for i := 0; i < iters; i++ {
+		runOnce("WARM", true, i)
+	}
+}
+
+// TestReproOrganicWarmCPUProfile captures a CPU profile of a WARM (primed
+// cache) run for direct comparison against TestReproCPUProfile's cold
+// profile: cNodeErrorCost should all but vanish from the top of the profile.
+func TestReproOrganicWarmCPUProfile(t *testing.T) {
+	if os.Getenv("GTS_REPRO_WARM_PROFILE") == "" {
+		t.Skip("set GTS_REPRO_WARM_PROFILE=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	insertOffset := issue380EnvInt("GTS_REPRO_OFFSET", 200)
+
+	parser := gotreesitter.NewParser(lang)
+	primeTree, _ := parser.Parse([]byte(primingBadGoSource))
+	if primeTree != nil {
+		primeTree.Release()
+	}
+	oldTree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("base parse error: %v", err)
+	}
+	newSrc := make([]byte, 0, len(src)+1)
+	newSrc = append(newSrc, src[:insertOffset]...)
+	newSrc = append(newSrc, 'x')
+	newSrc = append(newSrc, src[insertOffset:]...)
+	startPoint := issue380PointForOffset(src, insertOffset)
+	newEndPoint := gotreesitter.Point{Row: startPoint.Row, Column: startPoint.Column + 1}
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   uint32(insertOffset),
+		OldEndByte:  uint32(insertOffset),
+		NewEndByte:  uint32(insertOffset + 1),
+		StartPoint:  startPoint,
+		OldEndPoint: startPoint,
+		NewEndPoint: newEndPoint,
+	})
+
+	out := os.Getenv("GTS_REPRO_PROFILE_OUT")
+	if out == "" {
+		out = "cpu_warm.prof"
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		t.Fatalf("start cpu profile: %v", err)
+	}
+	start := time.Now()
+	newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+	elapsed := time.Since(start)
+	pprof.StopCPUProfile()
+	if err != nil {
+		t.Fatalf("incremental parse error: %v", err)
+	}
+	fmt.Printf("WARM elapsed=%s acceptedErrAttempts=%d maxStacksSeen=%d tokensConsumed=%d\n",
+		elapsed, profile.AcceptedErrorRetryAttempts, profile.MaxStacksSeen, profile.TokensConsumed)
+	newTree.Release()
+	oldTree.Release()
+}

--- a/issue380_incremental_insert_slowdown_repro_test.go
+++ b/issue380_incremental_insert_slowdown_repro_test.go
@@ -1,0 +1,293 @@
+package gotreesitter_test
+
+// Diagnostic reproduction for the issue #380 report: a ~50x nondeterministic
+// wall-clock swing on a single-char INSERT incremental reparse of a ~137KB Go
+// file (reported ~4.6-5.0s, observed once at ~97ms), with a same-file DELETE
+// running ~24x faster despite allocating MORE nodes, and both far slower than
+// a fresh full parse of the same file.
+//
+// All tests here are gated behind explicit environment variables so they
+// never run as part of `go test ./...`. Run individually, e.g.:
+//
+//	GTS_REPRO_INSERT=1 GTS_REPRO_FILE=/path/to/137kb.go GTS_REPRO_ITERS=25 \
+//	  go test -run TestReproInsertRetryInstability -v .
+//
+// Findings (2026-07, this box, linux/amd64):
+//   - Using this repo's own tree.go (137030 bytes, a real Go file, not
+//     synthetic) with a single-char insert near the top (offset ~200, inside
+//     a struct field's type name -- syntactically valid, mirrors an in-place
+//     keystroke), 25 iterations with a FRESH Parser + fresh Tree per
+//     iteration produced a CONSISTENT ~1.2-1.9s per incremental parse -- no
+//     bimodality was observed under pure fresh-parser conditions.
+//   - AcceptedErrorRetryAttempts was 0 in every iteration: the accepted-error
+//     retry rung (retryIncrementalAcceptedErrorWithDFA /
+//     retryIncrementalAcceptedErrorWithBaseMergeCap in parser_retry.go), the
+//     reporter's prime suspect, never fired. It is not implicated in this
+//     reproduction.
+//   - A full fresh Parse() of the same file takes ~90-160ms -- i.e. the
+//     incremental insert is consistently ~10-15x a full parse, even before
+//     accounting for the further nondeterminism explained in
+//     issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go.
+//   - reuseRejectRootNonLeafChanged is high (87) and reusedSubtrees is tiny
+//     (60) relative to the file: Go is NOT in
+//     languageAllowsForestTopLevelSiblingReuse (incremental.go), so
+//     non-leaf/structural subtree reuse across an edit is effectively
+//     unavailable for Go (only leaf reuse and small <=2048-byte non-leaf
+//     spans qualify -- see tryReuseSubtree's "conservative fallback" in
+//     incremental.go). An edit anywhere near the top of a large Go file
+//     therefore forces near-total GLR re-derivation of everything after it
+//     (tokensConsumed ~= the file's full token count), which is inherently
+//     far more expensive than the cheap subtree-swap incremental parsing is
+//     supposed to provide.
+//   - A CPU profile of one slow (~1.2s) run shows the time dominated by
+//     (*Parser).cNodeErrorCost (42.5% flat), cSymbolVisibleLang (20.5%
+//     flat), and (*Parser).cNodeVisibleSubtreeCount (10.2% flat, 35.4%
+//     cumulative) -- the C-parity error-cost/visible-subtree-count cost
+//     model used to compare competing live GLR stacks
+//     (parser_recover_c.go's cStackErrorCost / cVersionStatus /
+//     cBetterVersionExists, invoked from ordinary multi-stack GLR
+//     dispatch/merge, not only from genuine syntax-error recovery -- see the
+//     doc comment on cNodeMemoCacheInitialSize, which explicitly says this
+//     path is "warm on every capable parse, clean or not"). See
+//     issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go
+//     for why this cost model is sometimes O(1)-amortized (fast) and
+//     sometimes O(depth) uncached per call (catastrophically slow) for
+//     otherwise-identical input.
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"testing"
+	"time"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func issue380PointForOffset(src []byte, off int) gotreesitter.Point {
+	prefix := src[:off]
+	row := bytes.Count(prefix, []byte{'\n'})
+	col := off
+	if idx := bytes.LastIndexByte(prefix, '\n'); idx >= 0 {
+		col = off - idx - 1
+	}
+	return gotreesitter.Point{Row: uint32(row), Column: uint32(col)}
+}
+
+func issue380EnvInt(name string, def int) int {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+		return def
+	}
+	return n
+}
+
+// TestReproInsertRetryInstability runs ParseIncrementalProfiled in a loop
+// with a fresh Parser + fresh Tree per iteration for a single-char INSERT
+// near the top of a real ~137KB Go file, printing wall time and the
+// AcceptedErrorRetry*/reuse-reject profile fields the issue points at.
+func TestReproInsertRetryInstability(t *testing.T) {
+	if os.Getenv("GTS_REPRO_INSERT") == "" {
+		t.Skip("set GTS_REPRO_INSERT=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	iterations := issue380EnvInt("GTS_REPRO_ITERS", 20)
+	insertOffset := issue380EnvInt("GTS_REPRO_OFFSET", 200)
+
+	fmt.Printf("file=%d bytes insertOffset=%d iterations=%d\n", len(src), insertOffset, iterations)
+
+	for i := 0; i < iterations; i++ {
+		parser := gotreesitter.NewParser(lang)
+		oldTree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("[%d] base parse error: %v", i, err)
+		}
+
+		newSrc := make([]byte, 0, len(src)+1)
+		newSrc = append(newSrc, src[:insertOffset]...)
+		newSrc = append(newSrc, 'x')
+		newSrc = append(newSrc, src[insertOffset:]...)
+
+		startPoint := issue380PointForOffset(src, insertOffset)
+		newEndPoint := gotreesitter.Point{Row: startPoint.Row, Column: startPoint.Column + 1}
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(insertOffset),
+			OldEndByte:  uint32(insertOffset),
+			NewEndByte:  uint32(insertOffset + 1),
+			StartPoint:  startPoint,
+			OldEndPoint: startPoint,
+			NewEndPoint: newEndPoint,
+		})
+
+		start := time.Now()
+		newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("[%d] incremental parse error: %v", i, err)
+		}
+		hasError := newTree != nil && newTree.RootNode() != nil && newTree.RootNode().HasError()
+		fmt.Printf("iter=%d elapsed=%s hasError=%v acceptedErrAttempts=%d acceptedErrAdopted=%v acceptedErrCause=%v reparseNanos=%d reuseCursorNanos=%d tokensConsumed=%d maxStacksSeen=%d reuseRejectRootNonLeafChanged=%d reusedSubtrees=%d newNodes=%d oldTreeReuseRoute=%v stopReason=%v\n",
+			i, elapsed, hasError,
+			profile.AcceptedErrorRetryAttempts, profile.AcceptedErrorRetryAdopted, profile.AcceptedErrorRetryCause,
+			profile.ReparseNanos, profile.ReuseCursorNanos, profile.TokensConsumed, profile.MaxStacksSeen,
+			profile.ReuseRejectRootNonLeafChanged, profile.ReusedSubtrees, profile.NewNodesAllocated,
+			profile.OldTreeReuseRoute, profile.StopReason,
+		)
+
+		newTree.Release()
+		oldTree.Release()
+	}
+}
+
+// TestReproDeleteAsymmetry is the DELETE counterpart, fresh Parser/Tree per
+// iteration, for direct comparison against the INSERT case above.
+func TestReproDeleteAsymmetry(t *testing.T) {
+	if os.Getenv("GTS_REPRO_DELETE") == "" {
+		t.Skip("set GTS_REPRO_DELETE=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	iterations := issue380EnvInt("GTS_REPRO_ITERS", 20)
+	deleteOffset := issue380EnvInt("GTS_REPRO_OFFSET", 200)
+
+	for i := 0; i < iterations; i++ {
+		parser := gotreesitter.NewParser(lang)
+		oldTree, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("[%d] base parse error: %v", i, err)
+		}
+
+		newSrc := make([]byte, 0, len(src)-1)
+		newSrc = append(newSrc, src[:deleteOffset]...)
+		newSrc = append(newSrc, src[deleteOffset+1:]...)
+
+		startPoint := issue380PointForOffset(src, deleteOffset)
+		oldEndPoint := issue380PointForOffset(src, deleteOffset+1)
+		oldTree.Edit(gotreesitter.InputEdit{
+			StartByte:   uint32(deleteOffset),
+			OldEndByte:  uint32(deleteOffset + 1),
+			NewEndByte:  uint32(deleteOffset),
+			StartPoint:  startPoint,
+			OldEndPoint: oldEndPoint,
+			NewEndPoint: startPoint,
+		})
+
+		start := time.Now()
+		newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("[%d] incremental parse error: %v", i, err)
+		}
+		hasError := newTree != nil && newTree.RootNode() != nil && newTree.RootNode().HasError()
+		fmt.Printf("DEL iter=%d elapsed=%s hasError=%v acceptedErrAttempts=%d acceptedErrAdopted=%v acceptedErrCause=%v reparseNanos=%d reuseCursorNanos=%d tokensConsumed=%d maxStacksSeen=%d reuseRejectRootNonLeafChanged=%d reusedSubtrees=%d newNodes=%d oldTreeReuseRoute=%v stopReason=%v\n",
+			i, elapsed, hasError,
+			profile.AcceptedErrorRetryAttempts, profile.AcceptedErrorRetryAdopted, profile.AcceptedErrorRetryCause,
+			profile.ReparseNanos, profile.ReuseCursorNanos, profile.TokensConsumed, profile.MaxStacksSeen,
+			profile.ReuseRejectRootNonLeafChanged, profile.ReusedSubtrees, profile.NewNodesAllocated,
+			profile.OldTreeReuseRoute, profile.StopReason,
+		)
+
+		newTree.Release()
+		oldTree.Release()
+	}
+}
+
+// TestReproFullParse benchmarks a plain full parse of the same file for a
+// baseline (the issue reports 78ms; the incremental insert above should be
+// far slower than this).
+func TestReproFullParse(t *testing.T) {
+	if os.Getenv("GTS_REPRO_FULL") == "" {
+		t.Skip("set GTS_REPRO_FULL=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	iterations := issue380EnvInt("GTS_REPRO_ITERS", 10)
+	for i := 0; i < iterations; i++ {
+		parser := gotreesitter.NewParser(lang)
+		start := time.Now()
+		tree, err := parser.Parse(src)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("[%d] full parse error: %v", i, err)
+		}
+		fmt.Printf("FULL iter=%d elapsed=%s\n", i, elapsed)
+		tree.Release()
+	}
+}
+
+// TestReproCPUProfile captures a CPU profile of a single slow incremental
+// insert, for `go tool pprof -top`. Set GTS_REPRO_PROFILE_OUT to the output
+// path.
+func TestReproCPUProfile(t *testing.T) {
+	if os.Getenv("GTS_REPRO_PROFILE") == "" {
+		t.Skip("set GTS_REPRO_PROFILE=1 to run")
+	}
+	src, err := os.ReadFile(os.Getenv("GTS_REPRO_FILE"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lang := grammars.GoLanguage()
+	insertOffset := issue380EnvInt("GTS_REPRO_OFFSET", 200)
+
+	newSrc := make([]byte, 0, len(src)+1)
+	newSrc = append(newSrc, src[:insertOffset]...)
+	newSrc = append(newSrc, 'x')
+	newSrc = append(newSrc, src[insertOffset:]...)
+
+	parser := gotreesitter.NewParser(lang)
+	oldTree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("base parse error: %v", err)
+	}
+	startPoint := issue380PointForOffset(src, insertOffset)
+	newEndPoint := gotreesitter.Point{Row: startPoint.Row, Column: startPoint.Column + 1}
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   uint32(insertOffset),
+		OldEndByte:  uint32(insertOffset),
+		NewEndByte:  uint32(insertOffset + 1),
+		StartPoint:  startPoint,
+		OldEndPoint: startPoint,
+		NewEndPoint: newEndPoint,
+	})
+
+	out := os.Getenv("GTS_REPRO_PROFILE_OUT")
+	if out == "" {
+		out = "cpu.prof"
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	defer f.Close()
+	if err := pprof.StartCPUProfile(f); err != nil {
+		t.Fatalf("start cpu profile: %v", err)
+	}
+	start := time.Now()
+	newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+	elapsed := time.Since(start)
+	pprof.StopCPUProfile()
+	if err != nil {
+		t.Fatalf("incremental parse error: %v", err)
+	}
+	fmt.Printf("elapsed=%s acceptedErrAttempts=%d reparseNanos=%d maxStacksSeen=%d tokensConsumed=%d reuseRejectRootNonLeafChanged=%d\n",
+		elapsed, profile.AcceptedErrorRetryAttempts, profile.ReparseNanos, profile.MaxStacksSeen,
+		profile.TokensConsumed, profile.ReuseRejectRootNonLeafChanged)
+	newTree.Release()
+	oldTree.Release()
+}


### PR DESCRIPTION
## Summary

Add diagnostic reproduction tests that isolate the root cause of issue #380's nondeterminism to C-recovery cost-memo cache warmup behavior, not the accepted-error retry ladder. The tests demonstrate that warm vs cold Parser instance cache state produces 7-9x performance differences on the same input.

## Changes

- Add issue380_incremental_insert_slowdown_repro_test.go to reproduce the reported ~50x wall-clock swing on single-char INSERT edits, confirming AcceptedErrorRetryAttempts is always 0 and the accepted-error retry ladder is not implicated
- Add issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go to demonstrate the cache warm/cold mechanism: Parser instances that previously entered C-style error recovery have a warm 16384-entry memo cache, while fresh instances start with a cold 128-entry cache that thrashes on large files
- Both test files use explicit GTS_REPRO_* environment variable gating to avoid running in go test ./...
- Tests confirm the same GLR tree structure is selected every time—only wall-clock time varies depending on cache state

## Testing

- Run insert repro: GTS_REPRO_INSERT=1 GTS_REPRO_FILE=/path/to/137kb.go GTS_REPRO_ITERS=25 go test -run TestReproInsertRetryInstability -v ./
- Run warm vs cold demonstration: GTS_REPRO_ORGANIC=1 GTS_REPRO_FILE=/path/to/137kb.go go test -run TestReproOrganicWarmVsCold -v ./
- Run CPU profile of cold path: GTS_REPRO_PROFILE=1 GTS_REPRO_PROFILE_OUT=cpu.prof go test -run TestReproCPUProfile -v ./
- Run CPU profile of warm path: GTS_REPRO_WARM_PROFILE=1 GTS_REPRO_PROFILE_OUT=cpu_warm.prof go test -run TestReproOrganicWarmCPUProfile -v ./
- Compare profiles with: go tool pprof -top cpu.prof and go tool pprof -top cpu_warm.prof to verify cNodeErrorCost dominates cold runs but vanishes in warm runs

## Related Issues

- Refs #380