### PR TITLE
fix(parser, grammars): Fix TS default parameter parsing and reduce grammar decode memory churn

### DIFF
--- a/grammars/embedded_loader.go
+++ b/grammars/embedded_loader.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/gob"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -542,7 +541,15 @@ func decodeLanguageBlobData(blobName string, data []byte) (*gotreesitter.Languag
 	// reader, which would silently swallow the optional LargeStateGotos
 	// trailer (see gotreesitter.DecodeLargeStateGotosTrailer) before we get a
 	// chance to read it.
-	raw, err := io.ReadAll(gzr)
+	//
+	// Pre-size that buffer from the gzip ISIZE trailer instead of a plain
+	// io.ReadAll: for the largest shipped grammars (Swift's ~308 MB
+	// decompressed table is the extreme case) io.ReadAll's repeated buffer
+	// doublings roughly double peak transient allocation on every
+	// Language() call, which is what actually trips container memory
+	// limits. See ReadAllGzipWithSizeHint's doc comment for the full
+	// rationale; this is the same helper gotreesitter.LoadLanguage uses.
+	raw, err := gotreesitter.ReadAllGzipWithSizeHint(gzr, compressed)
 	if err != nil {
 		return nil, fmt.Errorf("read gzip grammar blob %q: %w", blobName, err)
 	}

--- a/grammars/language_memory_ceiling_test.go
+++ b/grammars/language_memory_ceiling_test.go
@@ -1,0 +1,164 @@
+package grammars
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+// languageMemoryCeilingBytes is the maximum HeapAlloc growth permitted for a
+// single Language() call. It is measured across a fresh decode -- the
+// embedded-language cache is purged before and after each language so an
+// earlier language in the sweep cannot mask (or be blamed for) a later one's
+// cost.
+//
+// 256 MB is comfortably above every non-exceptional grammar's cost (as of
+// v0.43.1 the largest non-exceptional grammar's Language() call allocates
+// well under 64 MB) while still being low enough to catch an accidental
+// future blowup -- e.g. a new grammar whose lexer DFA repeats Swift's
+// per-lex-mode fanout (see languageMemoryCeilingKnownExceptions).
+const languageMemoryCeilingBytes = 256 * 1024 * 1024
+
+// languageMemoryCeilingKnownExceptions documents grammars whose Language()
+// call currently exceeds languageMemoryCeilingBytes, with the root cause and
+// what fixing it for real requires. This is a v0.43.1 fast-follow finding,
+// not swept under the rug: do not add entries here casually, and do not grow
+// an entry's budget without also recording why. Each entry left here is a
+// real, un-gated regression risk for that one language.
+var languageMemoryCeilingKnownExceptions = map[string]string{
+	// Swift's Language() allocates ~490 MB HeapAlloc (~1.5-2 GB peak Sys
+	// during decode) versus ~10 MB for a comparably-sized grammar like
+	// Kotlin. Root cause: grammargen's buildLexDFA (grammargen/dfa.go) runs
+	// an independent NFA->DFA subset construction per lex mode with no
+	// cross-mode automaton sharing. Swift's grammar.js has ~331 distinct
+	// lex-mode symbol-set combinations (Kotlin has 17), so nearly the same
+	// ~190-state identifier/operator/comment automaton gets rebuilt from
+	// scratch 331 times, yielding 63,150 total LexStates and 21.16M
+	// LexTransition entries -- a ~308 MB decompressed gob stream that must
+	// be fully materialized on every decode.
+	//
+	// ReadAllGzipWithSizeHint (see ../load_language.go) already removes the
+	// io.ReadAll doubling-growth tax from every grammar's decode path,
+	// cutting Swift's per-call allocation churn by roughly a third; that
+	// mitigation is safe and applies fleet-wide. It does not reduce the
+	// retained ~490 MB, because the LexStates table itself -- not decode
+	// buffering -- is what is oversized.
+	//
+	// A real fix requires memoizing buildLexDFA by a canonical hash of each
+	// mode's (validSymbols, preferredSymbols, skipWhitespace) so structurally
+	// identical modes share one compiled automaton, then regenerating and
+	// re-certifying swift.bin against the full Swift corpus -- deferred as
+	// its own follow-up rather than risked in this pass.
+	"swift": "grammargen builds Swift's lexer DFA independently per lex mode " +
+		"(no cross-mode automaton sharing); ~331 distinct lex modes produce " +
+		"63k+ LexStates / 21M+ LexTransition entries and a ~308 MB " +
+		"decompressed blob. Fix requires per-mode DFA memoization in " +
+		"grammargen/dfa.go (buildLexDFA) plus swift.bin regeneration and " +
+		"recertification; deferred as a follow-up.",
+}
+
+// evaluateLanguageMemoryCeiling applies the gate's pass/known-exception/fail
+// decision to a single (name, delta) measurement. Split out from the sweep
+// test so the decision logic itself has a direct, fast unit test independent
+// of any real grammar's actual size (see
+// TestEvaluateLanguageMemoryCeilingDecisionLogic).
+func evaluateLanguageMemoryCeiling(name string, deltaBytes int64) (fail bool, message string) {
+	if deltaBytes < 0 {
+		deltaBytes = 0
+	}
+	if deltaBytes <= languageMemoryCeilingBytes {
+		return false, ""
+	}
+	megabytes := float64(deltaBytes) / (1024 * 1024)
+	ceilingMB := languageMemoryCeilingBytes / (1024 * 1024)
+	if reason, known := languageMemoryCeilingKnownExceptions[name]; known {
+		return false, fmt.Sprintf("%s: Language() retained %.1f MB (> %d MB ceiling), known exception: %s",
+			name, megabytes, ceilingMB, reason)
+	}
+	return true, fmt.Sprintf("%s: Language() retained %.1f MB, exceeding the %d MB ceiling and not in "+
+		"languageMemoryCeilingKnownExceptions -- this is a new memory regression",
+		name, megabytes, ceilingMB)
+}
+
+// TestLanguageMemoryCeilingAcrossAllGrammars sweeps every registered
+// grammar's Language() call and fails if it retains more than
+// languageMemoryCeilingBytes of heap, unless the language is listed in
+// languageMemoryCeilingKnownExceptions. This is the regression gate for the
+// v0.43.1 Swift memory finding: it does not require Swift to be fixed, but
+// it does require every other grammar to stay bounded, and it requires any
+// future exception to be added deliberately (with a reason) rather than
+// silently.
+func TestLanguageMemoryCeilingAcrossAllGrammars(t *testing.T) {
+	entries := AllLanguages()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+
+	for _, entry := range entries {
+		entry := entry
+		t.Run(entry.Name, func(t *testing.T) {
+			PurgeEmbeddedLanguageCache()
+			runtime.GC()
+			var before runtime.MemStats
+			runtime.ReadMemStats(&before)
+
+			lang := entry.Language()
+			if lang == nil {
+				t.Fatalf("%s: Language() returned nil", entry.Name)
+			}
+
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+
+			delta := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+			if fail, msg := evaluateLanguageMemoryCeiling(entry.Name, delta); msg != "" {
+				if fail {
+					t.Fatal(msg)
+				}
+				t.Log(msg)
+			}
+
+			UnloadEmbeddedLanguage(entry.Name + ".bin")
+		})
+	}
+}
+
+// TestEvaluateLanguageMemoryCeilingDecisionLogic exercises the gate's
+// pass/known-exception/fail branches directly with synthetic deltas, so the
+// control flow is verified without depending on any real grammar's current
+// size (which could drift and silently stop exercising the fail branch).
+func TestEvaluateLanguageMemoryCeilingDecisionLogic(t *testing.T) {
+	if _, known := languageMemoryCeilingKnownExceptions["kotlin"]; known {
+		t.Fatal("test fixture assumes \"kotlin\" is not a known exception")
+	}
+
+	t.Run("under ceiling passes silently", func(t *testing.T) {
+		fail, msg := evaluateLanguageMemoryCeiling("kotlin", 10*1024*1024)
+		if fail || msg != "" {
+			t.Fatalf("fail=%v msg=%q, want fail=false msg=\"\"", fail, msg)
+		}
+	})
+
+	t.Run("over ceiling with no exception fails", func(t *testing.T) {
+		fail, msg := evaluateLanguageMemoryCeiling("kotlin", languageMemoryCeilingBytes+1)
+		if !fail || msg == "" {
+			t.Fatalf("fail=%v msg=%q, want fail=true with a non-empty message", fail, msg)
+		}
+	})
+
+	t.Run("over ceiling with a known exception logs, does not fail", func(t *testing.T) {
+		if _, known := languageMemoryCeilingKnownExceptions["swift"]; !known {
+			t.Fatal("test fixture assumes \"swift\" is a known exception")
+		}
+		fail, msg := evaluateLanguageMemoryCeiling("swift", languageMemoryCeilingBytes+1)
+		if fail || msg == "" {
+			t.Fatalf("fail=%v msg=%q, want fail=false with a non-empty (logged) message", fail, msg)
+		}
+	})
+
+	t.Run("exactly at ceiling passes", func(t *testing.T) {
+		fail, msg := evaluateLanguageMemoryCeiling("kotlin", languageMemoryCeilingBytes)
+		if fail || msg != "" {
+			t.Fatalf("fail=%v msg=%q, want fail=false msg=\"\" at the exact ceiling", fail, msg)
+		}
+	})
+}

--- a/load_language.go
+++ b/load_language.go
@@ -25,35 +25,9 @@ func LoadLanguage(data []byte) (*Language, error) {
 	}
 	defer gzr.Close()
 
-	// Pre-size the decompression buffer using the ISIZE field in the last 4
-	// bytes of the gzip trailer. This avoids io.ReadAll's repeated doublings.
-	// ISIZE is uncompressed size mod 2^32; for grammar blobs (well under 4 GB)
-	// it is exact. Fall back to io.ReadAll if the hint is implausible.
-	var raw []byte
-	if len(compressed) >= 4 {
-		isize := binary.LittleEndian.Uint32(compressed[len(compressed)-4:])
-		if isize > 0 && isize < 256*1024*1024 { // sanity cap at 256 MB
-			raw = make([]byte, 0, isize)
-			var buf [32 * 1024]byte
-			for {
-				n, readErr := gzr.Read(buf[:])
-				if n > 0 {
-					raw = append(raw, buf[:n]...)
-				}
-				if readErr == io.EOF {
-					break
-				}
-				if readErr != nil {
-					return nil, fmt.Errorf("read gzip: %w", readErr)
-				}
-			}
-		}
-	}
-	if raw == nil {
-		raw, err = io.ReadAll(gzr)
-		if err != nil {
-			return nil, fmt.Errorf("read gzip: %w", err)
-		}
+	raw, err := ReadAllGzipWithSizeHint(gzr, compressed)
+	if err != nil {
+		return nil, fmt.Errorf("read gzip: %w", err)
 	}
 
 	var lang Language
@@ -83,4 +57,55 @@ func LoadLanguage(data []byte) (*Language, error) {
 	InferGeneratedRepeatAuxMetadata(&lang)
 
 	return &lang, nil
+}
+
+// gzipSizeHintCap bounds the ISIZE-derived pre-allocation in
+// ReadAllGzipWithSizeHint. It guards against a corrupted or adversarial
+// trailer requesting an unbounded allocation. The bound is set comfortably
+// above the largest known compiled grammar table (Swift's ~308 MB
+// decompressed gob stream, the largest of the 206 shipped grammars as of
+// v0.43.1 — its lexer DFA is compiled per lex-mode with no cross-mode
+// automaton sharing, and Swift's grammar has ~331 distinct lex modes versus
+// single digits to low tens for most languages, so its LexStates table is
+// disproportionately large; see grammars/language_memory_ceiling_test.go)
+// with headroom for grammar growth, while still catching a bogus ISIZE field
+// long before it could request a multi-gigabyte buffer.
+const gzipSizeHintCap = 512 * 1024 * 1024 // 512 MB
+
+// ReadAllGzipWithSizeHint reads all of r — an open gzip.Reader positioned at
+// the start of the member whose raw (still-compressed) bytes are compressed
+// — into memory, pre-sizing the destination buffer from the gzip ISIZE
+// trailer (the last 4 bytes of compressed) instead of letting io.ReadAll grow
+// the buffer by repeated doubling. ISIZE is the uncompressed size mod 2^32,
+// which is exact for every blob under 4 GB; grammar blobs are always far
+// smaller. Falls back to io.ReadAll when the hint is missing, zero, or
+// exceeds gzipSizeHintCap.
+//
+// This matters at grammar-load time: io.ReadAll's doubling growth roughly
+// doubles peak transient allocation versus the final size, and for the
+// largest shipped grammar blobs that transient churn is measured in hundreds
+// of MB to low GB (observed via alloc-space pprof on Language() calls),
+// which is what actually trips container memory limits even though the
+// final retained Language is smaller.
+func ReadAllGzipWithSizeHint(r io.Reader, compressed []byte) ([]byte, error) {
+	if len(compressed) >= 4 {
+		isize := binary.LittleEndian.Uint32(compressed[len(compressed)-4:])
+		if isize > 0 && isize < gzipSizeHintCap {
+			raw := make([]byte, 0, isize)
+			var buf [32 * 1024]byte
+			for {
+				n, readErr := r.Read(buf[:])
+				if n > 0 {
+					raw = append(raw, buf[:n]...)
+				}
+				if readErr == io.EOF {
+					return raw, nil
+				}
+				if readErr != nil {
+					return nil, readErr
+				}
+			}
+		}
+	}
+	return io.ReadAll(r)
 }

--- a/parser.go
+++ b/parser.go
@@ -6369,11 +6369,12 @@ func (p *Parser) configureParseCaps(source []byte, reuse *reuseCursor, arenaClas
 func (p *Parser) resolveParseMergePerKeyCap(source []byte, reuse *reuseCursor, maxMergePerKeyOverride int) int {
 	mergePerKeyCap := effectiveParseMergePerKeyCap(p.language, parseMaxMergePerKeyValue(), reuse != nil, len(source))
 	tsNeedsTypedArrow := typeScriptFullParseNeedsTypedArrowMergeWidth(p.language, source, reuse)
+	tsNeedsDefaultParameter := typeScriptFullParseNeedsDefaultParameterMergeWidth(p.language, source, reuse)
 	if typeScriptFullParseNeedsDestructuredArrowReturnMergeWidth(p.language, source, reuse) {
 		if mergePerKeyCap < maxStacksPerMergeKey {
 			mergePerKeyCap = maxStacksPerMergeKey
 		}
-	} else if tsNeedsTypedArrow && mergePerKeyCap < 2 {
+	} else if (tsNeedsTypedArrow || tsNeedsDefaultParameter) && mergePerKeyCap < 2 {
 		mergePerKeyCap = 2
 	}
 	if javaFullParseNeedsAnnotationDeclarationMergeWidth(p.language, source, reuse) && mergePerKeyCap < javaFullParseRetryMaxMergePerKey {

--- a/parser_leaf_token_regression_test.go
+++ b/parser_leaf_token_regression_test.go
@@ -479,6 +479,91 @@ func TestParseTypeScriptTypedArrowParameters(t *testing.T) {
 	}
 }
 
+// TestParseTypeScriptBareDefaultParameter guards against a v0.43.0 regression
+// where "function f(a = 1) {}" collapsed to a top-level ERROR. The locked C
+// tree-sitter-typescript oracle parses this as
+// "(required_parameter pattern: (identifier) value: (number))"; our GLR
+// engine's steady-state cap-one merge budget was discarding the
+// pattern-reduction derivation in favor of a same-state, lower-precedence
+// assignment_expression derivation before the parse could complete (see
+// typeScriptSourceHasBareDefaultParameter in parser_retry.go).
+func TestParseTypeScriptBareDefaultParameter(t *testing.T) {
+	src := "function f(a = 1) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript bare default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	if !strings.Contains(sexpr, "function_declaration") || !strings.Contains(sexpr, "required_parameter") {
+		t.Fatalf("typescript bare default parameter did not preserve required_parameter: %s", sexpr)
+	}
+	if strings.Contains(sexpr, "ERROR") {
+		t.Fatalf("typescript bare default parameter retained an ERROR node: %s", sexpr)
+	}
+}
+
+func TestParseTSXBareDefaultParameter(t *testing.T) {
+	src := "function f(a = 1) {}\n"
+	tree, lang := parseLanguageSample(t, "tsx", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("tsx bare default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	if !strings.Contains(sexpr, "function_declaration") || !strings.Contains(sexpr, "required_parameter") {
+		t.Fatalf("tsx bare default parameter did not preserve required_parameter: %s", sexpr)
+	}
+	if strings.Contains(sexpr, "ERROR") {
+		t.Fatalf("tsx bare default parameter retained an ERROR node: %s", sexpr)
+	}
+}
+
+// TestParseTypeScriptMultipleBareDefaultParameters guards the multi-parameter
+// shape of the same regression: each default-valued parameter forks and must
+// independently reconverge without losing its required_parameter reduction.
+func TestParseTypeScriptMultipleBareDefaultParameters(t *testing.T) {
+	src := "function f(a = 1, b = 2) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript multiple default parameters root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), root.SExpr(lang))
+	}
+	sexpr := root.SExpr(lang)
+	if got, want := strings.Count(sexpr, "required_parameter"), 2; got != want {
+		t.Fatalf("typescript multiple default parameters required_parameter count = %d, want %d: %s", got, want, sexpr)
+	}
+}
+
+// TestParseTypeScriptArrowAndMethodBareDefaultParameter covers the two other
+// formal_parameters call sites (arrow functions and class methods) that share
+// the same required_parameter production and were equally affected.
+func TestParseTypeScriptArrowAndMethodBareDefaultParameter(t *testing.T) {
+	cases := []string{
+		"const g = (a = 1) => a;\n",
+		"class C { m(a = 1) {} }\n",
+	}
+	for _, src := range cases {
+		tree, lang := parseLanguageSample(t, "typescript", src)
+		root := tree.RootNode()
+		if root.Type(lang) != "program" || root.HasError() {
+			tree.Release()
+			t.Fatalf("typescript %q root = %s hasError=%v; tree=%s", src, root.Type(lang), root.HasError(), root.SExpr(lang))
+		}
+		if sexpr := root.SExpr(lang); !strings.Contains(sexpr, "required_parameter") {
+			tree.Release()
+			t.Fatalf("typescript %q did not preserve required_parameter: %s", src, sexpr)
+		}
+		tree.Release()
+	}
+}
+
 func TestParseTypeScriptNestedDestructuringArrayPattern(t *testing.T) {
 	src := "const { value: [dirPath, { dirName, options, fileNames }] } = result;\n"
 	tree, lang := parseLanguageSample(t, "typescript", src)

--- a/parser_leaf_token_regression_test.go
+++ b/parser_leaf_token_regression_test.go
@@ -564,6 +564,155 @@ func TestParseTypeScriptArrowAndMethodBareDefaultParameter(t *testing.T) {
 	}
 }
 
+// TestParseTypeScriptArrayElementDefaultParameter guards the array-element
+// default parameter shape ("[a = 1]") that the bare-default-parameter
+// detector was widened to cover: unlike a whole-pattern default
+// ("{a} = {}"), the identifier here sits directly before '=', so it hits the
+// same required_parameter/assignment_expression fork as "function f(a = 1)".
+// This is the React-hook tuple pattern ("const [state, setState] = ...")
+// with an initial-value default on the first slot.
+func TestParseTypeScriptArrayElementDefaultParameter(t *testing.T) {
+	src := "function f([a = 1]) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript array-element default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"required_parameter", "array_pattern", "assignment_pattern"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript array-element default parameter missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+func TestParseTSXArrayElementDefaultParameter(t *testing.T) {
+	src := "function f([a = 1]) {}\n"
+	tree, lang := parseLanguageSample(t, "tsx", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("tsx array-element default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"required_parameter", "array_pattern", "assignment_pattern"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("tsx array-element default parameter missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptReactHookTupleDefaultParameter is the flagship
+// real-world shape motivating the array-element widening: a destructured
+// tuple parameter with a default on the state slot, as commonly authored in
+// custom React hook wrappers, e.g. "function useToggle([state = false,
+// setState]) {}".
+func TestParseTypeScriptReactHookTupleDefaultParameter(t *testing.T) {
+	src := "function h([state = 0, setState]) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript react-hook tuple default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	if !strings.Contains(sexpr, "(array_pattern (assignment_pattern (identifier) (number)) (identifier))") {
+		t.Fatalf("typescript react-hook tuple default parameter did not preserve the [state = 0, setState] shape: %s", sexpr)
+	}
+}
+
+// TestParseTypeScriptRenamedPropertyDefaultParameter guards the renamed
+// destructured-property default shape ("{a: b = 1}"): the preceding-context
+// gate widened to accept ':' immediately before the bound identifier for
+// this case.
+func TestParseTypeScriptRenamedPropertyDefaultParameter(t *testing.T) {
+	src := "function f({a: b = 1}) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript renamed-property default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"required_parameter", "object_pattern", "pair_pattern", "assignment_pattern"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript renamed-property default parameter missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptUnicodeIdentifierDefaultParameter guards the unicode
+// identifier byte widening in typeScriptDefaultParamIdentByte: multi-byte
+// UTF-8 identifier bytes (>= 0x80) must still be recognized as part of the
+// identifier directly before '=' so the detector fires.
+func TestParseTypeScriptUnicodeIdentifierDefaultParameter(t *testing.T) {
+	src := "function f(café = 1) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript unicode default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	if !strings.Contains(sexpr, "required_parameter") {
+		t.Fatalf("typescript unicode default parameter did not preserve required_parameter: %s", sexpr)
+	}
+}
+
+// TestParseTypeScriptCommentAdjacentDefaultParameter guards a block comment
+// sitting between the opening '(' and the defaulted identifier: the gate's
+// backward scan must skip over a complete "/* ... */" comment (in addition
+// to whitespace) to still see the '(' context character.
+func TestParseTypeScriptCommentAdjacentDefaultParameter(t *testing.T) {
+	src := "function f(/* c */ a = 1) {}\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript comment-adjacent default parameter root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"comment", "required_parameter"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript comment-adjacent default parameter missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptArrayDestructuringDeclarationDefaultValue documents
+// current behavior for a destructuring DECLARATION (not a parameter list)
+// with an array-element default: "const [a = 1] = arr;". This shares the
+// same required_parameter-shaped fork as the parameter-list case -- '[' is
+// now an accepted preceding-context gate character -- so the widened
+// detector incidentally also fixes this declaration shape even though this
+// pass only targeted parameter lists. This test asserts the actual observed
+// behavior (no error) rather than assuming it is unfixed; if a future change
+// to the detector's gate narrows it back to parameter-list-only contexts,
+// this test will fail and should be revisited rather than silently loosened.
+func TestParseTypeScriptArrayDestructuringDeclarationDefaultValue(t *testing.T) {
+	src := "const [a = 1] = arr;\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript array destructuring declaration default root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"array_pattern", "assignment_pattern"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript array destructuring declaration default missing %s: %s", want, sexpr)
+		}
+	}
+}
+
 func TestParseTypeScriptNestedDestructuringArrayPattern(t *testing.T) {
 	src := "const { value: [dirPath, { dirName, options, fileNames }] } = result;\n"
 	tree, lang := parseLanguageSample(t, "typescript", src)

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1081,9 +1081,10 @@ func typescriptFullParseCanUseTightMergeCap(sourceLen ...int) bool {
 	// allocation over the file). Union-type-list-shaped .d.ts sources crossed
 	// from "parses in milliseconds" at 64KB-epsilon to "memory_budget with
 	// 1548 transient stacks" at 64KB+epsilon. The tight cap is what prevents
-	// those survivors from being retained in the first place; typed-arrow and
-	// destructured-arrow sources still widen through the dedicated gates in
-	// configureParseCaps, and accepted-error retries still widen through
+	// those survivors from being retained in the first place; typed-arrow,
+	// destructured-arrow, and bare-default-parameter sources still widen
+	// through the dedicated gates in (*Parser).resolveParseMergePerKeyCap,
+	// and accepted-error retries still widen through
 	// fullParseRetryMergePerKeyOverride.
 	_ = sourceLen
 	return true
@@ -1221,21 +1222,26 @@ func typeScriptFullParseNeedsDefaultParameterMergeWidth(lang *Language, source [
 }
 
 // typeScriptSourceHasBareDefaultParameter reports whether source contains a
-// parameter-list slot shaped like "(name = value" or ", name = value" with no
-// type annotation and no destructuring pattern before the '='. The locked C
-// grammar's required_parameter production reduces the parameter name through
-// `pattern` before it can accept a default `value`; that reduction competes,
-// at the identical post-shift LR state, with treating the bare name as the
-// start of a plain assignment_expression. Both derivations reach the same
-// state once the default value is shifted, so under the steady-state cap-one
-// merge budget (see typescriptFullParseCanUseTightMergeCap) the
-// pattern-reduction branch -- carrying a lower cumulative dynamic precedence
-// from its extra reduce step -- gets discarded before the parse completes,
-// collapsing the whole declaration to ERROR. Typed ("a: T = v") and
-// destructured ("{a} = {}") defaults are unaffected: the extra grammar
-// content between the parameter name and '=' avoids the fork entirely, so
-// this detector intentionally excludes them and only widens the budget for
-// sources that actually need it.
+// parameter-list slot shaped like "(name = value", ", name = value",
+// "[name = value" (array-element default), or ": name = value"
+// (renamed-property default) with no type annotation before the '='. The
+// locked C grammar's required_parameter production reduces the parameter
+// name through `pattern` before it can accept a default `value`; that
+// reduction competes, at the identical post-shift LR state, with treating
+// the bare name as the start of a plain assignment_expression. Both
+// derivations reach the same state once the default value is shifted, so
+// under the steady-state cap-one merge budget (see
+// typescriptFullParseCanUseTightMergeCap) the pattern-reduction branch --
+// carrying a lower cumulative dynamic precedence from its extra reduce step
+// -- gets discarded before the parse completes, collapsing the whole
+// declaration to ERROR. Only whole-pattern ("{a} = {}") assignment defaults
+// and object-shorthand ("{a = 1}") defaults are unaffected: in both cases
+// the '=' is not directly preceded by an identifier byte (it follows '}' or
+// whitespace after '}'), so neither shape reaches the ambiguous state. Bare
+// identifier defaults nested inside an array element ("[a = 1]") or a
+// renamed destructured property ("{a: b = 1}") still place an identifier
+// directly before '=' and hit the same fork, so the preceding-context gate
+// below also accepts '[' and ':' as valid contexts.
 func typeScriptSourceHasBareDefaultParameter(source []byte) bool {
 	if len(source) == 0 {
 		return false
@@ -1270,7 +1276,16 @@ func typeScriptSourceHasBareDefaultParameter(source []byte) bool {
 			break
 		}
 		idEnd := j
-		for j >= 0 && typeScriptDefaultParamIdentByte(source[j]) {
+		// Bound the backward identifier scan to a 2048-byte window, matching
+		// the sibling typed-arrow detector's matchingOpenParenBefore
+		// convention: this keeps a pathologically long run of identifier
+		// bytes before '=' from making the scan cost proportional to file
+		// size for every '=' occurrence.
+		identMin := idEnd - 2048
+		if identMin < 0 {
+			identMin = 0
+		}
+		for j >= identMin && typeScriptDefaultParamIdentByte(source[j]) {
 			j--
 		}
 		if j == idEnd {
@@ -1279,23 +1294,50 @@ func typeScriptSourceHasBareDefaultParameter(source []byte) bool {
 			// defaults, which already parse cleanly without widening.
 			continue
 		}
-		for j >= 0 {
+		// Skip whitespace and any complete "/* ... */" block comment(s)
+		// directly before the identifier (e.g. "(/* c */ a = 1)"): a
+		// comment is transparent to the grammar fork this detector guards
+		// against, so it must not hide the '(' / ',' / '[' / ':' gate
+		// character behind it. Bounded to the same 2048-byte window as the
+		// identifier scan above.
+		gateMin := j - 2048
+		if gateMin < 0 {
+			gateMin = 0
+		}
+		for j >= gateMin {
 			switch source[j] {
 			case ' ', '\t', '\n', '\r':
 				j--
 				continue
 			}
+			if source[j] == '/' && j-1 >= gateMin && source[j-1] == '*' {
+				opened := -1
+				for k := j - 2; k >= gateMin; k-- {
+					if source[k] == '/' && k+1 <= j && source[k+1] == '*' {
+						opened = k
+						break
+					}
+				}
+				if opened < 0 {
+					break
+				}
+				j = opened - 1
+				continue
+			}
 			break
 		}
-		if j >= 0 && (source[j] == '(' || source[j] == ',') {
-			return true
+		if j >= 0 {
+			switch source[j] {
+			case '(', ',', '[', ':':
+				return true
+			}
 		}
 	}
 	return false
 }
 
 func typeScriptDefaultParamIdentByte(b byte) bool {
-	return b == '_' || b == '$' ||
+	return b == '_' || b == '$' || b >= 0x80 ||
 		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1212,6 +1212,93 @@ func typeScriptSourceHasDestructuredArrowReturnType(source []byte) bool {
 	}
 }
 
+func typeScriptFullParseNeedsDefaultParameterMergeWidth(lang *Language, source []byte, reuse *reuseCursor) bool {
+	return lang != nil &&
+		reuse == nil &&
+		!parseMaxMergePerKeyEnvConfigured() &&
+		(lang.Name == "typescript" || lang.Name == "tsx") &&
+		typeScriptSourceHasBareDefaultParameter(source)
+}
+
+// typeScriptSourceHasBareDefaultParameter reports whether source contains a
+// parameter-list slot shaped like "(name = value" or ", name = value" with no
+// type annotation and no destructuring pattern before the '='. The locked C
+// grammar's required_parameter production reduces the parameter name through
+// `pattern` before it can accept a default `value`; that reduction competes,
+// at the identical post-shift LR state, with treating the bare name as the
+// start of a plain assignment_expression. Both derivations reach the same
+// state once the default value is shifted, so under the steady-state cap-one
+// merge budget (see typescriptFullParseCanUseTightMergeCap) the
+// pattern-reduction branch -- carrying a lower cumulative dynamic precedence
+// from its extra reduce step -- gets discarded before the parse completes,
+// collapsing the whole declaration to ERROR. Typed ("a: T = v") and
+// destructured ("{a} = {}") defaults are unaffected: the extra grammar
+// content between the parameter name and '=' avoids the fork entirely, so
+// this detector intentionally excludes them and only widens the budget for
+// sources that actually need it.
+func typeScriptSourceHasBareDefaultParameter(source []byte) bool {
+	if len(source) == 0 {
+		return false
+	}
+	for i := 0; i < len(source); i++ {
+		if source[i] != '=' {
+			continue
+		}
+		// Exclude '==' and '=>': neither spelling starts a default-value
+		// expression.
+		if i+1 < len(source) {
+			switch source[i+1] {
+			case '=', '>':
+				continue
+			}
+		}
+		// Exclude compound assignment/comparison operators that also end in
+		// a bare '=' (!=, <=, >=, +=, -=, *=, /=, %=, &=, |=, ^=, **=).
+		if i > 0 {
+			switch source[i-1] {
+			case '=', '!', '<', '>', '+', '-', '*', '/', '%', '&', '|', '^', '~':
+				continue
+			}
+		}
+		j := i - 1
+		for j >= 0 {
+			switch source[j] {
+			case ' ', '\t', '\n', '\r':
+				j--
+				continue
+			}
+			break
+		}
+		idEnd := j
+		for j >= 0 && typeScriptDefaultParamIdentByte(source[j]) {
+			j--
+		}
+		if j == idEnd {
+			// No identifier byte directly before '=' (past whitespace): not
+			// a bare "name = value" slot. Covers destructured "} =" / "] ="
+			// defaults, which already parse cleanly without widening.
+			continue
+		}
+		for j >= 0 {
+			switch source[j] {
+			case ' ', '\t', '\n', '\r':
+				j--
+				continue
+			}
+			break
+		}
+		if j >= 0 && (source[j] == '(' || source[j] == ',') {
+			return true
+		}
+	}
+	return false
+}
+
+func typeScriptDefaultParamIdentByte(b byte) bool {
+	return b == '_' || b == '$' ||
+		(b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+}
+
 func fullParseUsesDeterministicExternalConflicts(lang *Language) bool {
 	return lang != nil &&
 		lang.ExternalScanner != nil &&


### PR DESCRIPTION
## Summary

Two independent fixes: (1) TypeScript bare default parameters (including array-destructured `[a = 1]` and renamed-property `{a: b = 1}` forms) were collapsing to parse ERROR due to the steady-state merge-cap discarding the pattern-reduction derivation before completion; the fix detects these shapes and widens the merge-per-key cap in dedicated gates. (2) Grammar blob decompression was using `io.ReadAll`'s doubling-growth allocator, roughly doubling peak transient heap allocation and tripping container memory limits for large grammars like Swift; replaced with `ReadAllGzipWithSizeHint` that pre-sizes from the gzip ISIZE trailer. Added a 256 MB HeapAlloc regression ceiling test across all grammars, with Swift documented as a known exception pending grammargen DFA memoization follow-up.

## Changes

- Widen merge-per-key cap for TypeScript bare default parameters in parameters, arrow functions, and methods by detecting `name = value` patterns preceding `=`, `[`, `:`, or `,` and raising `mergePerKeyCap` to 2 when needed
- Add `typeScriptSourceHasBareDefaultParameter` detector with preceding-context gate supporting parens, commas, brackets, colons, whitespace, block comments, and Unicode identifiers; excludes `==`, `=>`, and compound assignment operators
- Add `typeScriptDefaultParamIdentByte` for inclusive identifier-byte matching
- Extract `ReadAllGzipWithSizeHint` helper in `load_language.go` that reads gzip streams with a pre-sized buffer derived from the ISIZE trailer, capped at 512 MB to guard against bogus hints; falls back to `io.ReadAll` when hint is unavailable or implausible
- Replace inlined decompression logic in `grammars/embedded_loader.go` with `ReadAllGzipWithSizeHint` call, cutting transient allocation churn on every `Language()` call
- Add `grammar/language_memory_ceiling_test.go` with 256 MB HeapAlloc ceiling per `Language()` call; sweep tests all registered grammars and requires deliberate exception handling
- Document Swift as a known exception in `languageMemoryCeilingKnownExceptions` — root cause is grammargen building independent lexer DFA per lex mode (~331 modes, 63k+ LexStates, 21M+ transitions, ~308 MB blob) — deferred to a separate DFA memoization follow-up
- Add comprehensive regression tests in `parser_leaf_token_regression_test.go` for TS/TSX bare defaults, array-element defaults, React-hook tuple patterns, renamed-property defaults, Unicode identifiers, and comment-adjacent defaults

## Testing

- go test ./grammars -run TestLanguageMemoryCeilingAcrossAllGrammars to validate the memory regression gate
- go test ./... -run 'TestParseTypeScript.*DefaultParameter|TestParseTSX.*DefaultParameter' to validate parser fix across all detected shapes
- Optional Docker parity check: `bash cgo_harness/docker/run_single_grammar_parity.sh typescript`

## Review Focus

Reviewers should pay special attention to the `typeScriptSourceHasBareDefaultParameter` detector logic (whitespace/comment/identifier backward scan and gate character matching) for correctness and edge cases. The memory-ceiling test framework and Swift exception documentation should also be reviewed for maintainability.