### PR TITLE
fix(grammargen): fix C emitter symbol collisions, lexer EOF, alias stride

### DIFF
--- a/grammargen/codegen_c.go
+++ b/grammargen/codegen_c.go
@@ -65,22 +65,37 @@ func EmitC(name string, lang *gotreesitter.Language) (string, error) {
 // buildCSymbolNames returns a C identifier for every symbol id, disambiguating
 // collisions the way upstream tree-sitter does: the first symbol to claim a
 // given identifier keeps it, and each subsequent symbol that would sanitize to
-// the same identifier gets a numeric suffix (name, name2, name3, ...). Without
-// this, two distinct anonymous tokens that share the same text — e.g. a plain
-// `"` token and a token.immediate('"'), both of which sanitize to
-// anon_sym_DQUOTE — would emit as the same C enumerator and the generated
-// parser.c would fail to compile with "redeclaration of enumerator".
+// the same identifier gets a numeric suffix (name2, name3, ...), bumped past
+// any suffix already claimed by a DIFFERENT base. That second half matters:
+// with a naive "base + occurrence count" suffix, three same-text-derived
+// tokens — a plain `"` (base anon_sym_DQUOTE), a naturally-suffixed `"2`
+// token (base anon_sym_DQUOTE2, unrelated text, coincidental collision), and
+// token.immediate('"') (also base anon_sym_DQUOTE, occurrence 2 so its naive
+// suffix is also anon_sym_DQUOTE2) — would have two symbols both landing on
+// anon_sym_DQUOTE2, and the generated parser.c would fail to compile with
+// "redeclaration of enumerator". buildCSymbolNames instead tracks every name
+// already claimed by any symbol and keeps incrementing the suffix counter
+// until the candidate is unclaimed, in the same index order the symbols are
+// walked (so output stays deterministic).
 func buildCSymbolNames(lang *gotreesitter.Language) []string {
 	names := make([]string, len(lang.SymbolNames))
 	counts := make(map[string]int, len(lang.SymbolNames))
+	used := make(map[string]bool, len(lang.SymbolNames))
 	for i := range lang.SymbolNames {
 		base := symbolToCName(lang.SymbolNames[i], i, lang)
 		counts[base]++
-		if i == 0 || counts[base] == 1 {
-			names[i] = base
-			continue
+		n := counts[base]
+		candidate := base
+		if n > 1 {
+			candidate = base + strconv.Itoa(n)
 		}
-		names[i] = base + strconv.Itoa(counts[base])
+		for used[candidate] {
+			n++
+			candidate = base + strconv.Itoa(n)
+		}
+		counts[base] = n
+		names[i] = candidate
+		used[candidate] = true
 	}
 	return names
 }
@@ -101,6 +116,31 @@ func mainLexStartStates(lang *gotreesitter.Language) map[int]bool {
 	// State 0 is always a valid lexer entry point.
 	starts[0] = true
 	return starts
+}
+
+// sortedIntKeys returns the keys of m in ascending order.
+func sortedIntKeys(m map[int]bool) []int {
+	out := make([]int, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// modeStartOf returns the mode-start state that owns DFA state i. Each lex
+// mode's states occupy a contiguous, increasing block of indices (buildLexDFA
+// appends every mode's states after the previous mode's), and modeStarts is
+// the sorted list of every such block's starting index (see the call site's
+// use of mainLexStartStates). The owning mode-start is therefore the greatest
+// boundary that is <= i — this holds whether i is itself a mode-start state
+// or an intermediate, mid-token state reached only from within its mode.
+func modeStartOf(modeStarts []int, i int) int {
+	idx := sort.SearchInts(modeStarts, i+1) - 1
+	if idx < 0 {
+		return 0
+	}
+	return modeStarts[idx]
 }
 
 func cParseActionOffsets(lang *gotreesitter.Language) ([]uint16, error) {
@@ -550,6 +590,17 @@ func emitLexFunction(b *strings.Builder, funcName string, states []gotreesitter.
 	fmt.Fprintf(b, "  eof = lexer->eof(lexer);\n")
 	fmt.Fprintf(b, "  switch (state) {\n")
 
+	// Lex modes occupy contiguous, increasing blocks of DFA state indices
+	// (buildLexDFA appends each mode's states after the previous mode's), and
+	// startStates is exactly the set of state indices any parser state can
+	// begin lexing from — i.e. every mode-start offset (see
+	// mainLexStartStates). Sorting that set therefore recovers the ordered
+	// mode-start boundary list without any extra plumbing: for any DFA state
+	// i, the mode that owns it is the one whose boundary is the greatest
+	// entry <= i. modeStartOf uses this to answer "which mode-start state
+	// should SKIP re-lex from" for a state reached mid-token (see below).
+	modeStarts := sortedIntKeys(startStates)
+
 	for i, st := range states {
 		fmt.Fprintf(b, "    case %d:\n", i)
 
@@ -590,30 +641,42 @@ func emitLexFunction(b *strings.Builder, funcName string, states []gotreesitter.
 		}
 
 		// Character transitions. A transition that consumes a skippable extra
-		// (whitespace) must use SKIP so the runtime advances past the character
-		// as trivia and re-lexes for a real token, rather than accepting it.
-		// grammargen models a silent extra two ways: an explicit skip edge
-		// (tr.Skip, already looping back to this mode's start state) or an edge
-		// into a terminal skip-accept state. In the latter case the previous
-		// emission accepted ts_builtin_sym_end there, which told the runtime
-		// EOF had been reached the moment any whitespace appeared; SKIP(i)
-		// consumes the whitespace and re-lexes from this (mode-start) state.
+		// (whitespace, or any other silently-dropped extra) must use SKIP so
+		// the runtime advances past the character as trivia and re-lexes for
+		// a real token, rather than accepting it. grammargen models a silent
+		// extra two ways:
+		//
+		//   - An explicit skip edge (tr.Skip): addWhitespaceSkip only ever
+		//     adds these on a mode's own start state and always targets that
+		//     same start state (tr.NextState), so SKIP(tr.NextState) is
+		//     already correct as written.
+		//   - An edge into a terminal skip-accept state: this fires on
+		//     whichever state currently owns the transition, which for a
+		//     multi-character extra (CRLF, backslash-newline continuations)
+		//     is an intermediate mid-token state, not the mode's start state.
+		//     SKIP's target must still be the mode-start state — re-lexing
+		//     from the intermediate state would resume from a DFA state that
+		//     only recognizes the extra's continuation, not a fresh token —
+		//     so this uses modeStartOf(modeStarts, i), the start state of the
+		//     mode that contains state i, rather than i itself.
 		for _, tr := range st.Transitions {
 			cond := charCondition(tr.Lo, tr.Hi)
 			switch {
 			case tr.Skip:
 				fmt.Fprintf(b, "      if (%s) SKIP(%d);\n", cond, tr.NextState)
 			case tr.NextState >= 0 && tr.NextState < len(states) && states[tr.NextState].Skip:
-				fmt.Fprintf(b, "      if (%s) SKIP(%d);\n", cond, i)
+				fmt.Fprintf(b, "      if (%s) SKIP(%d);\n", cond, modeStartOf(modeStarts, i))
 			default:
 				fmt.Fprintf(b, "      if (%s) ADVANCE(%d);\n", cond, tr.NextState)
 			}
 		}
 
-		// Default transition.
+		// Default transition. Same reasoning as the transition loop above:
+		// a default edge into a skip-accept state must re-lex from that
+		// state's owning mode-start, not from state i itself.
 		if st.Default >= 0 {
 			if st.Default < len(states) && states[st.Default].Skip {
-				fmt.Fprintf(b, "      SKIP(%d);\n", i)
+				fmt.Fprintf(b, "      SKIP(%d);\n", modeStartOf(modeStarts, i))
 			} else {
 				fmt.Fprintf(b, "      ADVANCE(%d);\n", st.Default)
 			}

--- a/grammargen/codegen_c.go
+++ b/grammargen/codegen_c.go
@@ -3,6 +3,7 @@ package grammargen
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/odvcencio/gotreesitter"
@@ -28,32 +29,78 @@ func EmitC(name string, lang *gotreesitter.Language) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Deduplicated C identifiers per symbol id (defect: two distinct
+	// same-text anonymous tokens must not collide into one enumerator).
+	cNames := buildCSymbolNames(lang)
 	var b strings.Builder
 
 	emitHeader(&b, name, lang)
-	emitSymbolEnum(&b, lang)
+	emitSymbolEnum(&b, lang, cNames)
 	emitFieldEnum(&b, lang)
-	emitSymbolNames(&b, lang)
-	emitSymbolMetadata(&b, lang)
+	emitSymbolNames(&b, lang, cNames)
+	emitSymbolMetadata(&b, lang, cNames)
 	emitFieldNames(&b, lang)
 	emitFieldMaps(&b, lang)
-	emitAliasSequences(&b, lang)
-	emitParseActions(&b, lang)
-	emitParseTable(&b, lang, parseActionOffsets)
+	emitAliasSequences(&b, lang, cNames)
+	emitParseActions(&b, lang, cNames)
+	emitParseTable(&b, lang, parseActionOffsets, cNames)
 	emitSmallParseTable(&b, lang, parseActionOffsets)
 	emitLexModes(&b, lang)
-	emitReservedWords(&b, lang)
-	emitSupertypes(&b, lang)
-	emitLexFunction(&b, "ts_lex", lang.LexStates, lang)
+	emitReservedWords(&b, lang, cNames)
+	emitSupertypes(&b, lang, cNames)
+	emitLexFunction(&b, "ts_lex", lang.LexStates, lang, cNames, mainLexStartStates(lang))
 	if len(lang.KeywordLexStates) > 0 {
-		emitLexFunction(&b, "ts_lex_keywords", lang.KeywordLexStates, lang)
+		// The keyword lexer is always invoked with state 0 (see
+		// ts_parser__call_keyword_lex_fn), so state 0 is its only start.
+		emitLexFunction(&b, "ts_lex_keywords", lang.KeywordLexStates, lang, cNames, map[int]bool{0: true})
 	}
 	if len(lang.ExternalSymbols) > 0 {
-		emitExternalScanner(&b, lang)
+		emitExternalScanner(&b, lang, cNames)
 	}
 	emitLanguageExport(&b, name, lang)
 
 	return b.String(), nil
+}
+
+// buildCSymbolNames returns a C identifier for every symbol id, disambiguating
+// collisions the way upstream tree-sitter does: the first symbol to claim a
+// given identifier keeps it, and each subsequent symbol that would sanitize to
+// the same identifier gets a numeric suffix (name, name2, name3, ...). Without
+// this, two distinct anonymous tokens that share the same text — e.g. a plain
+// `"` token and a token.immediate('"'), both of which sanitize to
+// anon_sym_DQUOTE — would emit as the same C enumerator and the generated
+// parser.c would fail to compile with "redeclaration of enumerator".
+func buildCSymbolNames(lang *gotreesitter.Language) []string {
+	names := make([]string, len(lang.SymbolNames))
+	counts := make(map[string]int, len(lang.SymbolNames))
+	for i := range lang.SymbolNames {
+		base := symbolToCName(lang.SymbolNames[i], i, lang)
+		counts[base]++
+		if i == 0 || counts[base] == 1 {
+			names[i] = base
+			continue
+		}
+		names[i] = base + strconv.Itoa(counts[base])
+	}
+	return names
+}
+
+// mainLexStartStates returns the set of lex-DFA states that a parser state can
+// begin lexing from (the lex_state of every TSLexerMode). Only these "start"
+// states synthesize the ts_builtin_sym_end token at end-of-input; a state that
+// is only ever reached mid-token must instead report "no token" at EOF so a
+// partial match becomes an error rather than a spurious end.
+func mainLexStartStates(lang *gotreesitter.Language) map[int]bool {
+	starts := make(map[int]bool, len(lang.LexModes))
+	for _, mode := range lang.LexModes {
+		starts[int(mode.LexState)] = true
+		if mode.AfterWhitespaceLexState != 0 {
+			starts[int(mode.AfterWhitespaceLexState)] = true
+		}
+	}
+	// State 0 is always a valid lexer entry point.
+	starts[0] = true
+	return starts
 }
 
 func cParseActionOffsets(lang *gotreesitter.Language) ([]uint16, error) {
@@ -67,6 +114,39 @@ func cParseActionOffsets(lang *gotreesitter.Language) ([]uint16, error) {
 		offset += 1 + len(entry.Actions)
 	}
 	return offsets, nil
+}
+
+// maxAliasSequenceLength returns the value MAX_ALIAS_SEQUENCE_LENGTH must take:
+// the length of the longest production (its child count), NOT merely the length
+// of the longest alias-sequence row.
+//
+// The tree-sitter runtime reads ts_alias_sequences as a flat
+// [PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] array and indexes it as
+// alias_sequences[production_id * max_alias_sequence_length + structural_child_index]
+// for EVERY production whose production_id is non-zero — including productions
+// that carry a field map but no alias, whose alias-sequence rows are all zeros.
+// structural_child_index runs up to child_count-1, so if the stride is only as
+// wide as the longest ALIAS row, a longer production reads past its own row into
+// the next productions' rows and picks up their aliases as spurious ones (this
+// is why a plain binder in `Rect(w, h)` was rendered as raw_string_literal_content:
+// production 61 with 6 children read alias_sequences[61*3 + 4], which is
+// production 62's aliased child). Sizing the stride to the longest production
+// keeps every row self-contained and zero-padded.
+func maxAliasSequenceLength(lang *gotreesitter.Language) int {
+	maxLen := 0
+	for _, row := range lang.AliasSequences {
+		if len(row) > maxLen {
+			maxLen = len(row)
+		}
+	}
+	for _, entry := range lang.ParseActions {
+		for _, action := range entry.Actions {
+			if action.Type == gotreesitter.ParseActionReduce && int(action.ChildCount) > maxLen {
+				maxLen = int(action.ChildCount)
+			}
+		}
+	}
+	return maxLen
 }
 
 func cParseTableValue(lang *gotreesitter.Language, actionOffsets []uint16, symbol int, value uint16) uint16 {
@@ -126,12 +206,7 @@ func emitHeader(b *strings.Builder, name string, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "#pragma GCC diagnostic ignored \"-Wmissing-field-initializers\"\n")
 	fmt.Fprintf(b, "#endif\n\n")
 
-	maxAliasLen := 0
-	for _, row := range lang.AliasSequences {
-		if len(row) > maxAliasLen {
-			maxAliasLen = len(row)
-		}
-	}
+	maxAliasLen := maxAliasSequenceLength(lang)
 
 	fmt.Fprintf(b, "#define LANGUAGE_VERSION %d\n", lang.LanguageVersion)
 	fmt.Fprintf(b, "#define STATE_COUNT %d\n", lang.StateCount)
@@ -151,14 +226,13 @@ func emitHeader(b *strings.Builder, name string, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "#define PRODUCTION_ID_COUNT %d\n\n", lang.ProductionIDCount)
 }
 
-func emitSymbolEnum(b *strings.Builder, lang *gotreesitter.Language) {
+func emitSymbolEnum(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	fmt.Fprintf(b, "enum ts_symbol_identifiers {\n")
-	for i, name := range lang.SymbolNames {
+	for i := range lang.SymbolNames {
 		if i == 0 {
 			continue // ts_builtin_sym_end is implicit
 		}
-		cname := symbolToCName(name, i, lang)
-		fmt.Fprintf(b, "  %s = %d,\n", cname, i)
+		fmt.Fprintf(b, "  %s = %d,\n", cNames[i], i)
 	}
 	fmt.Fprintf(b, "};\n\n")
 }
@@ -177,20 +251,18 @@ func emitFieldEnum(b *strings.Builder, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitSymbolNames(b *strings.Builder, lang *gotreesitter.Language) {
+func emitSymbolNames(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	fmt.Fprintf(b, "static const char * const ts_symbol_names[] = {\n")
 	for i, name := range lang.SymbolNames {
-		cname := symbolToCName(name, i, lang)
-		fmt.Fprintf(b, "  [%s] = %q,\n", cname, name)
+		fmt.Fprintf(b, "  [%s] = %q,\n", cNames[i], name)
 	}
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitSymbolMetadata(b *strings.Builder, lang *gotreesitter.Language) {
+func emitSymbolMetadata(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	fmt.Fprintf(b, "static const TSSymbolMetadata ts_symbol_metadata[] = {\n")
 	for i, meta := range lang.SymbolMetadata {
-		cname := symbolToCName(lang.SymbolNames[i], i, lang)
-		fmt.Fprintf(b, "  [%s] = {\n", cname)
+		fmt.Fprintf(b, "  [%s] = {\n", cNames[i])
 		fmt.Fprintf(b, "    .visible = %s,\n", boolStr(meta.Visible))
 		fmt.Fprintf(b, "    .named = %s,\n", boolStr(meta.Named))
 		if meta.Supertype {
@@ -221,7 +293,7 @@ func emitFieldMaps(b *strings.Builder, lang *gotreesitter.Language) {
 		return
 	}
 
-	fmt.Fprintf(b, "static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {\n")
+	fmt.Fprintf(b, "static const TSMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {\n")
 	for i, slice := range lang.FieldMapSlices {
 		if slice[0] != 0 || slice[1] != 0 {
 			fmt.Fprintf(b, "  [%d] = {.index = %d, .length = %d},\n", i, slice[0], slice[1])
@@ -238,7 +310,7 @@ func emitFieldMaps(b *strings.Builder, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitAliasSequences(b *strings.Builder, lang *gotreesitter.Language) {
+func emitAliasSequences(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	if len(lang.AliasSequences) == 0 {
 		return
 	}
@@ -271,8 +343,7 @@ func emitAliasSequences(b *strings.Builder, lang *gotreesitter.Language) {
 		fmt.Fprintf(b, "  [%d] = {\n", i)
 		for j, sym := range row {
 			if sym != 0 {
-				cname := symbolToCName(lang.SymbolNames[sym], int(sym), lang)
-				fmt.Fprintf(b, "    [%d] = %s,\n", j, cname)
+				fmt.Fprintf(b, "    [%d] = %s,\n", j, cNames[sym])
 			}
 		}
 		fmt.Fprintf(b, "  },\n")
@@ -280,7 +351,7 @@ func emitAliasSequences(b *strings.Builder, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitParseActions(b *strings.Builder, lang *gotreesitter.Language) {
+func emitParseActions(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	fmt.Fprintf(b, "static const TSParseActionEntry ts_parse_actions[] = {\n")
 	idx := 0
 	for _, entry := range lang.ParseActions {
@@ -298,9 +369,8 @@ func emitParseActions(b *strings.Builder, lang *gotreesitter.Language) {
 					fmt.Fprintf(b, " SHIFT(%d),", action.State)
 				}
 			case gotreesitter.ParseActionReduce:
-				cname := symbolToCName(lang.SymbolNames[action.Symbol], int(action.Symbol), lang)
 				fmt.Fprintf(b, " REDUCE(%s, %d, %d, %d),",
-					cname, action.ChildCount, action.DynamicPrecedence, action.ProductionID)
+					cNames[action.Symbol], action.ChildCount, action.DynamicPrecedence, action.ProductionID)
 			case gotreesitter.ParseActionAccept:
 				fmt.Fprintf(b, " ACCEPT_INPUT(),")
 			case gotreesitter.ParseActionRecover:
@@ -313,7 +383,7 @@ func emitParseActions(b *strings.Builder, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitParseTable(b *strings.Builder, lang *gotreesitter.Language, actionOffsets []uint16) {
+func emitParseTable(b *strings.Builder, lang *gotreesitter.Language, actionOffsets []uint16, cNames []string) {
 	if lang.LargeStateCount == 0 || len(lang.ParseTable) == 0 {
 		return
 	}
@@ -327,8 +397,7 @@ func emitParseTable(b *strings.Builder, lang *gotreesitter.Language, actionOffse
 			if val == 0 {
 				continue
 			}
-			cname := symbolToCName(lang.SymbolNames[j], j, lang)
-			fmt.Fprintf(b, "    [%s] = %d,\n", cname, cParseTableValue(lang, actionOffsets, j, val))
+			fmt.Fprintf(b, "    [%s] = %d,\n", cNames[j], cParseTableValue(lang, actionOffsets, j, val))
 		}
 		fmt.Fprintf(b, "  },\n")
 	}
@@ -415,7 +484,7 @@ func emitLexModes(b *strings.Builder, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitReservedWords(b *strings.Builder, lang *gotreesitter.Language) {
+func emitReservedWords(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	if lang.MaxReservedWordSetSize == 0 || len(lang.ReservedWords) == 0 {
 		return
 	}
@@ -434,15 +503,14 @@ func emitReservedWords(b *strings.Builder, lang *gotreesitter.Language) {
 			if sym == 0 {
 				break
 			}
-			cname := symbolToCName(lang.SymbolNames[sym], int(sym), lang)
-			fmt.Fprintf(b, "    %s,\n", cname)
+			fmt.Fprintf(b, "    %s,\n", cNames[sym])
 		}
 		fmt.Fprintf(b, "  },\n")
 	}
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitSupertypes(b *strings.Builder, lang *gotreesitter.Language) {
+func emitSupertypes(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	if len(lang.SupertypeSymbols) == 0 || len(lang.SupertypeMapEntries) == 0 {
 		return
 	}
@@ -452,7 +520,7 @@ func emitSupertypes(b *strings.Builder, lang *gotreesitter.Language) {
 		if int(sym) >= len(lang.SymbolNames) {
 			continue
 		}
-		fmt.Fprintf(b, "  [%d] = %s,\n", i, symbolToCName(lang.SymbolNames[sym], int(sym), lang))
+		fmt.Fprintf(b, "  [%d] = %s,\n", i, cNames[sym])
 	}
 	fmt.Fprintf(b, "};\n\n")
 
@@ -462,7 +530,7 @@ func emitSupertypes(b *strings.Builder, lang *gotreesitter.Language) {
 			continue
 		}
 		fmt.Fprintf(b, "  [%s] = {.index = %d, .length = %d},\n",
-			symbolToCName(lang.SymbolNames[sym], sym, lang), slice[0], slice[1])
+			cNames[sym], slice[0], slice[1])
 	}
 	fmt.Fprintf(b, "};\n\n")
 
@@ -471,12 +539,12 @@ func emitSupertypes(b *strings.Builder, lang *gotreesitter.Language) {
 		if int(sym) >= len(lang.SymbolNames) {
 			continue
 		}
-		fmt.Fprintf(b, "  %s,\n", symbolToCName(lang.SymbolNames[sym], int(sym), lang))
+		fmt.Fprintf(b, "  %s,\n", cNames[sym])
 	}
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitLexFunction(b *strings.Builder, funcName string, states []gotreesitter.LexState, lang *gotreesitter.Language) {
+func emitLexFunction(b *strings.Builder, funcName string, states []gotreesitter.LexState, lang *gotreesitter.Language, cNames []string, startStates map[int]bool) {
 	fmt.Fprintf(b, "static bool %s(TSLexer *lexer, TSStateId state) {\n", funcName)
 	fmt.Fprintf(b, "  START_LEXER();\n")
 	fmt.Fprintf(b, "  eof = lexer->eof(lexer);\n")
@@ -485,33 +553,70 @@ func emitLexFunction(b *strings.Builder, funcName string, states []gotreesitter.
 	for i, st := range states {
 		fmt.Fprintf(b, "    case %d:\n", i)
 
-		// Accept token.
+		// Accept the real token this state matches, if any. ACCEPT_TOKEN sets
+		// result_symbol and marks the token end at the current position, so it
+		// must run before the EOF/transition logic below (a state that both
+		// accepts and can continue reports the accepted token when lookahead
+		// stops matching).
 		if st.AcceptToken > 0 {
-			cname := symbolToCName(lang.SymbolNames[st.AcceptToken], int(st.AcceptToken), lang)
-			fmt.Fprintf(b, "      ACCEPT_TOKEN(%s);\n", cname)
-		}
-		if st.Skip {
-			fmt.Fprintf(b, "      ACCEPT_TOKEN(ts_builtin_sym_end); /* skip */\n")
+			fmt.Fprintf(b, "      ACCEPT_TOKEN(%s);\n", cNames[st.AcceptToken])
 		}
 
-		// EOF transition.
+		// End-of-input handling.
+		//
+		// grammargen's lexer DFA never populates LexState.EOF (the pure-Go
+		// lexer treats EOF specially: it follows an EOF transition if present,
+		// otherwise it stops without evaluating any character transition). The
+		// emitted C must mirror that: at true EOF we must NOT fall through to
+		// the character transitions below, because a transition range that
+		// includes codepoint 0 (common for negated classes like [^"] and for
+		// `.`-style tokens) would match lookahead==0 at EOF and ADVANCE in
+		// place forever. So we branch on `eof` up front.
+		//
+		// A start state (one a parser state can begin lexing from) that has not
+		// itself accepted a token synthesizes ts_builtin_sym_end at EOF, which
+		// is the end-of-file token tree-sitter's runtime requires; grammargen's
+		// pure-Go runtime synthesizes it in the parser instead, so the emitted
+		// lexer has to produce it here. A non-start (mid-token) state instead
+		// returns whatever it accepted — nothing, for a partial match, which
+		// correctly becomes a lex error rather than a spurious end token.
 		if st.EOF >= 0 {
 			fmt.Fprintf(b, "      if (eof) ADVANCE(%d);\n", st.EOF)
+		} else if startStates[i] && st.AcceptToken == 0 && !st.Skip {
+			fmt.Fprintf(b, "      if (eof) ACCEPT_TOKEN(ts_builtin_sym_end);\n")
+			fmt.Fprintf(b, "      if (eof) END_STATE();\n")
+		} else {
+			fmt.Fprintf(b, "      if (eof) END_STATE();\n")
 		}
 
-		// Character transitions.
+		// Character transitions. A transition that consumes a skippable extra
+		// (whitespace) must use SKIP so the runtime advances past the character
+		// as trivia and re-lexes for a real token, rather than accepting it.
+		// grammargen models a silent extra two ways: an explicit skip edge
+		// (tr.Skip, already looping back to this mode's start state) or an edge
+		// into a terminal skip-accept state. In the latter case the previous
+		// emission accepted ts_builtin_sym_end there, which told the runtime
+		// EOF had been reached the moment any whitespace appeared; SKIP(i)
+		// consumes the whitespace and re-lexes from this (mode-start) state.
 		for _, tr := range st.Transitions {
 			cond := charCondition(tr.Lo, tr.Hi)
-			action := "ADVANCE"
-			if tr.Skip {
-				action = "SKIP"
+			switch {
+			case tr.Skip:
+				fmt.Fprintf(b, "      if (%s) SKIP(%d);\n", cond, tr.NextState)
+			case tr.NextState >= 0 && tr.NextState < len(states) && states[tr.NextState].Skip:
+				fmt.Fprintf(b, "      if (%s) SKIP(%d);\n", cond, i)
+			default:
+				fmt.Fprintf(b, "      if (%s) ADVANCE(%d);\n", cond, tr.NextState)
 			}
-			fmt.Fprintf(b, "      if (%s) %s(%d);\n", cond, action, tr.NextState)
 		}
 
 		// Default transition.
 		if st.Default >= 0 {
-			fmt.Fprintf(b, "      ADVANCE(%d);\n", st.Default)
+			if st.Default < len(states) && states[st.Default].Skip {
+				fmt.Fprintf(b, "      SKIP(%d);\n", i)
+			} else {
+				fmt.Fprintf(b, "      ADVANCE(%d);\n", st.Default)
+			}
 		}
 
 		fmt.Fprintf(b, "      END_STATE();\n")
@@ -523,12 +628,11 @@ func emitLexFunction(b *strings.Builder, funcName string, states []gotreesitter.
 	fmt.Fprintf(b, "}\n\n")
 }
 
-func emitExternalScanner(b *strings.Builder, lang *gotreesitter.Language) {
+func emitExternalScanner(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
 	// External scanner symbol map.
 	fmt.Fprintf(b, "static const uint16_t ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {\n")
 	for i, sym := range lang.ExternalSymbols {
-		cname := symbolToCName(lang.SymbolNames[sym], int(sym), lang)
-		fmt.Fprintf(b, "  [%d] = %s,\n", i, cname)
+		fmt.Fprintf(b, "  [%d] = %s,\n", i, cNames[sym])
 	}
 	fmt.Fprintf(b, "};\n\n")
 

--- a/grammargen/codegen_c.go
+++ b/grammargen/codegen_c.go
@@ -350,18 +350,31 @@ func emitFieldMaps(b *strings.Builder, lang *gotreesitter.Language) {
 	fmt.Fprintf(b, "};\n\n")
 }
 
-func emitAliasSequences(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
-	if len(lang.AliasSequences) == 0 {
-		return
-	}
+// emitAliasSequencesEnabled reports whether the grammar's alias-sequence
+// surface should be emitted at all. emitAliasSequences (the array
+// definition) and emitLanguageExport (the .alias_sequences reference) MUST
+// share this exact predicate: upstream tree-sitter omits both the
+// ts_alias_sequences array and the .alias_sequences field together when a
+// grammar has no aliases anywhere (ts2go's extractor treats a missing array
+// as "grammars without aliases omit this table"), and the runtime tolerates
+// the resulting NULL .alias_sequences. Gating the two emissions on different
+// predicates — as a prior version of this file did, checking only
+// len(lang.AliasSequences) > 0 for the reference but requiring a non-empty
+// ROW for the definition — let a table that is non-empty at the outer level
+// but has only empty/zero rows (a grammar with productions but literally no
+// alias content) emit the reference without ever declaring the array,
+// producing a C "use of undeclared identifier ts_alias_sequences" error.
+// maxAliasSequenceLength(lang), not a private per-row scan, is the correct
+// second half of the predicate: it already accounts for production child
+// counts (see its doc comment), and the array's declared stride
+// (MAX_ALIAS_SEQUENCE_LENGTH) is that same value, so an all-empty-row table
+// still emits correctly as a zero-initialized array under this gate.
+func emitAliasSequencesEnabled(lang *gotreesitter.Language) bool {
+	return len(lang.AliasSequences) > 0 && maxAliasSequenceLength(lang) > 0
+}
 
-	maxLen := 0
-	for _, row := range lang.AliasSequences {
-		if len(row) > maxLen {
-			maxLen = len(row)
-		}
-	}
-	if maxLen == 0 {
+func emitAliasSequences(b *strings.Builder, lang *gotreesitter.Language, cNames []string) {
+	if !emitAliasSequencesEnabled(lang) {
 		return
 	}
 
@@ -749,7 +762,7 @@ func emitLanguageExport(b *strings.Builder, name string, lang *gotreesitter.Lang
 		fmt.Fprintf(b, "    .field_map_entries = ts_field_map_entries,\n")
 	}
 
-	if len(lang.AliasSequences) > 0 {
+	if emitAliasSequencesEnabled(lang) {
 		fmt.Fprintf(b, "    .alias_sequences = &ts_alias_sequences[0][0],\n")
 	}
 

--- a/grammargen/emitc_lexer_parity_test.go
+++ b/grammargen/emitc_lexer_parity_test.go
@@ -9,7 +9,7 @@ package grammargen
 // parse of the SAME generated tables. The pure-Go parser is the oracle: any
 // divergence here is a bug in EmitC, not in the grammar or tables.
 //
-// They target three EmitC defects the goala C-parity harness isolated:
+// They target five EmitC defects the goala C-parity harness isolated:
 //
 //  1a. ts_lex failed to tokenize an anonymous keyword string that overlaps the
 //      identifier character class: `let x` parsed as (ERROR) under C because
@@ -21,6 +21,19 @@ package grammargen
 //  2.  Two distinct same-text anonymous tokens (plain `"` and
 //      token.immediate('"')) both emitted as anon_sym_DQUOTE — a C
 //      "redeclaration of enumerator".
+//  3.  A multi-character silent extra (CRLF, backslash-newline continuation)
+//      emits SKIP(i) where i is the transition's SOURCE state — correct only
+//      for single-character extras. For a multi-character extra the skip
+//      edge fires from an intermediate DFA state that only recognizes the
+//      extra's continuation, not a fresh token, so the next real token after
+//      the extra errors under C while pure-Go parses it fine.
+//  4.  Three anonymous tokens whose sanitized names collide in a chain (a
+//      base name, a token that naturally sanitizes to that base's first
+//      numeric suffix, and a same-text duplicate of the base that would
+//      naively suffix to the SAME already-claimed name) produced a duplicate
+//      C enumerator even after defect 2's fix, because the old dedup only
+//      checked occurrence count per base, not the full set of names already
+//      claimed by every other symbol.
 //
 // The harness skips gracefully when a C compiler or the runtime module is
 // unavailable, so `go test ./grammargen/...` stays green in minimal
@@ -279,6 +292,159 @@ func TestEmitCDuplicateAnonToken(t *testing.T) {
 	// The decisive test: the C compiles without a
 	// "redeclaration of enumerator" error.
 	_ = cWalker(t, "emitc_dupquote", lang)
+}
+
+// TestEmitCAnonTokenCollisionChain is the regression for defect 4: a chain of
+// three anonymous tokens whose sanitized C names collide must all end up
+// distinct, even when the natural (unsuffixed) name for one of them equals
+// the suffix another collision would naively produce. `"` sanitizes to
+// anon_sym_DQUOTE; `"2` naturally sanitizes to anon_sym_DQUOTE2 (unrelated
+// text, coincidental collision with the suffix numbering); and
+// token.immediate('"') is a same-text duplicate of `"`, so its naive
+// occurrence-count suffix is ALSO anon_sym_DQUOTE2 — already claimed by `"2`.
+// A dedup pass that only tracks "how many times has this base been seen"
+// (rather than the full set of already-claimed names) emits two
+// anon_sym_DQUOTE2 enumerators and the parser.c fails to compile.
+func TestEmitCAnonTokenCollisionChain(t *testing.T) {
+	g := NewGrammar("emitc_dquote_chain")
+	g.Define("source_file", Repeat(Sym("item")))
+	g.Define("item", Choice(
+		Seq(Str(`"`), Optional(Sym("inner"))),
+		Str(`"2`),
+	))
+	g.Define("inner", Seq(ImmToken(Str(`"`)), Sym("word")))
+	g.Define("word", Pat(`[a-z]+`))
+	g.SetExtras(Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+
+	code, err := EmitC("emitc_dquote_chain", lang)
+	if err != nil {
+		t.Fatalf("EmitC: %v", err)
+	}
+	assertNoDuplicateCIdentifiers(t, code)
+
+	// The decisive test: the C compiles without a
+	// "redeclaration of enumerator" error.
+	_ = cWalker(t, "emitc_dquote_chain", lang)
+}
+
+// assertNoDuplicateCIdentifiers parses the emitted ts_symbol_identifiers enum
+// and fails if any C identifier is declared more than once — the shape of a
+// "redeclaration of enumerator" compile error.
+func assertNoDuplicateCIdentifiers(t *testing.T, code string) {
+	t.Helper()
+	start := strings.Index(code, "enum ts_symbol_identifiers")
+	if start < 0 {
+		t.Fatalf("missing enum ts_symbol_identifiers in emitted code")
+	}
+	block := code[start:]
+	end := strings.Index(block, "};")
+	if end < 0 {
+		t.Fatalf("unterminated enum ts_symbol_identifiers")
+	}
+	block = block[:end]
+
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		eq := strings.Index(line, " = ")
+		if eq < 0 {
+			continue
+		}
+		name := strings.TrimSpace(line[:eq])
+		if name == "" {
+			continue
+		}
+		if seen[name] {
+			t.Fatalf("duplicate C identifier %q in emitted enum:\n%s", name, block)
+		}
+		seen[name] = true
+	}
+}
+
+// TestEmitCMultiCharSkipCRLF is the regression for defect 3 (multi-character
+// extra): a CRLF extra (`\r\n`) is recognized by a two-transition DFA path —
+// state on '\r' to an intermediate state, then '\n' to the skip-accept state.
+// The intermediate state is not a mode-start state, so SKIP must still
+// re-lex from the mode's start, not from the intermediate state itself.
+func TestEmitCMultiCharSkipCRLF(t *testing.T) {
+	g := NewGrammar("emitc_crlf")
+	g.Define("source_file", Repeat(Sym("word")))
+	g.Define("word", Pat(`[a-z]+`))
+	g.SetExtras(Pat("\r\n"))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	parseC := cWalker(t, "emitc_crlf", lang)
+
+	inputs := []string{
+		"hello\r\nworld",
+		"hello\r\nworld\r\n",
+		"a\r\nb\r\nc",
+		"solo",
+	}
+	for _, in := range inputs {
+		in := in
+		name := strings.NewReplacer("\r", "CR", "\n", "LF").Replace(in)
+		t.Run(name, func(t *testing.T) {
+			want := goSExpr(t, lang, in)
+			got := parseC(t, in)
+			if got != want {
+				t.Fatalf("C/Go divergence for %q\n C: %s\nGo: %s", in, got, want)
+			}
+			if strings.Contains(got, "ERROR") {
+				t.Fatalf("unexpected ERROR for %q: %s", in, got)
+			}
+		})
+	}
+}
+
+// TestEmitCMultiCharSkipBackslashNewline is a second regression for defect 3,
+// covering an AWK-style backslash-newline line continuation extra alongside a
+// separate single-character whitespace extra — two invisible extras of
+// different lengths sharing the same lex mode. The backslash-newline extra's
+// intermediate (post-backslash) state must SKIP back to the mode start, the
+// same as the CRLF case, not to itself.
+func TestEmitCMultiCharSkipBackslashNewline(t *testing.T) {
+	g := NewGrammar("emitc_bslashnl")
+	g.Define("source_file", Repeat(Sym("word")))
+	g.Define("word", Pat(`[a-z]+`))
+	// Pattern text `\\` + newline: an escaped (literal) backslash followed by
+	// a literal newline — the two-character AWK continuation sequence.
+	g.SetExtras(Pat("\\\\\n"), Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	parseC := cWalker(t, "emitc_bslashnl", lang)
+
+	inputs := []string{
+		"a\\\nb",
+		"a\\\nb\\\nc",
+		"a b",
+		"solo",
+	}
+	for _, in := range inputs {
+		in := in
+		name := strings.NewReplacer("\\", "BS", "\n", "LF", " ", "SP").Replace(in)
+		t.Run(name, func(t *testing.T) {
+			want := goSExpr(t, lang, in)
+			got := parseC(t, in)
+			if got != want {
+				t.Fatalf("C/Go divergence for %q\n C: %s\nGo: %s", in, got, want)
+			}
+			if strings.Contains(got, "ERROR") {
+				t.Fatalf("unexpected ERROR for %q: %s", in, got)
+			}
+		})
+	}
 }
 
 // TestEmitCAliasSequenceStride guards the alias-sequence stride defect: the

--- a/grammargen/emitc_lexer_parity_test.go
+++ b/grammargen/emitc_lexer_parity_test.go
@@ -9,7 +9,7 @@ package grammargen
 // parse of the SAME generated tables. The pure-Go parser is the oracle: any
 // divergence here is a bug in EmitC, not in the grammar or tables.
 //
-// They target five EmitC defects the goala C-parity harness isolated:
+// They target six EmitC defects the goala C-parity harness isolated:
 //
 //  1a. ts_lex failed to tokenize an anonymous keyword string that overlaps the
 //      identifier character class: `let x` parsed as (ERROR) under C because
@@ -34,6 +34,13 @@ package grammargen
 //      C enumerator even after defect 2's fix, because the old dedup only
 //      checked occurrence count per base, not the full set of names already
 //      claimed by every other symbol.
+//  5.  emitAliasSequences (the ts_alias_sequences array definition) and
+//      emitLanguageExport (the .alias_sequences reference) were gated on two
+//      DIFFERENT predicates: the definition required a non-empty ROW, the
+//      reference only required a non-empty outer table. A table that is
+//      non-empty at the outer level but has only empty/zero rows emitted the
+//      reference without ever declaring the array it points at — "use of
+//      undeclared identifier ts_alias_sequences".
 //
 // The harness skips gracefully when a C compiler or the runtime module is
 // unavailable, so `go test ./grammargen/...` stays green in minimal
@@ -495,6 +502,85 @@ func TestEmitCAliasSequenceStride(t *testing.T) {
 
 	parseC := cWalker(t, "emitc_stride", lang)
 	for _, in := range []string{"k a b c d e ;", "`x`", "k a b c d e ; `y` k p q r s t ;"} {
+		in := in
+		t.Run(strings.ReplaceAll(in, " ", "_"), func(t *testing.T) {
+			want := goSExpr(t, lang, in)
+			got := parseC(t, in)
+			if got != want {
+				t.Fatalf("C/Go divergence for %q\n C: %s\nGo: %s", in, got, want)
+			}
+		})
+	}
+}
+
+// TestEmitCAliasSequencesGateMismatch is the regression for defect 5: the
+// ts_alias_sequences array definition and the .alias_sequences reference in
+// the exported TSLanguage must be gated on the SAME predicate.
+//
+// The base grammar here (a production with a field map, zero aliases
+// anywhere) is the shape the defect was found against, but grammargen's own
+// buildAliasSequences already leaves Language.AliasSequences completely nil
+// for a zero-alias grammar (it bails out before ever touching the field), so
+// this shape alone does not exercise the bug through GenerateLanguage's
+// current pipeline — both old and new predicates agree it's empty. To pin
+// the actual GATE MISMATCH the review found (rather than one specific
+// codepath that happens not to reach it today), this test forces the exact
+// shape onto the generated Language directly: an AliasSequences table that
+// is non-empty at the outer (per-production) level with every row empty,
+// which is what emitAliasSequences's old private per-row length scan (0)
+// disagreed with emitLanguageExport's outer len()>0 check on. EmitC is a
+// public function over *gotreesitter.Language and must stay correct for any
+// value satisfying its contract, not just ones grammargen's own assemble.go
+// happens to produce today — the same reasoning as
+// TestEmitCRejectsMalformedSupertypeSurfaces.
+//
+// Forcing all rows to nil is safe for the pure-Go comparison:
+// languageProductionHasAliasSequence (parser_result.go) clamps childCount to
+// len(seq) before indexing, so a nil/empty row behaves identically to no
+// AliasSequences at all — the S-expression is unaffected.
+func TestEmitCAliasSequencesGateMismatch(t *testing.T) {
+	g := NewGrammar("emitc_aliasgate")
+	g.Define("source_file", Repeat(Sym("item")))
+	g.Define("item", Seq(
+		Field("a", Sym("identifier")),
+		Field("b", Sym("identifier")),
+	))
+	g.Define("identifier", Pat(`[a-z]+`))
+	g.SetExtras(Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	if len(lang.FieldMapEntries) == 0 {
+		t.Fatal("test grammar must produce a non-empty field map")
+	}
+	if len(lang.AliasSequences) != 0 {
+		t.Fatalf("test grammar must naturally have zero AliasSequences, got %d rows", len(lang.AliasSequences))
+	}
+
+	// Force the exact gate-mismatch shape: a non-empty outer table (matching
+	// production_id_count) whose every row is empty.
+	n := int(lang.ProductionIDCount)
+	if n == 0 {
+		n = 1
+	}
+	lang.AliasSequences = make([][]gotreesitter.Symbol, n)
+
+	code, err := EmitC("emitc_aliasgate", lang)
+	if err != nil {
+		t.Fatalf("EmitC: %v", err)
+	}
+	hasDef := strings.Contains(code, "ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH]")
+	hasRef := strings.Contains(code, ".alias_sequences = &ts_alias_sequences[0][0],")
+	if hasRef != hasDef {
+		t.Fatalf("alias_sequences definition/reference gates disagree: hasDef=%v hasRef=%v", hasDef, hasRef)
+	}
+
+	// The decisive test: the C compiles (no "undeclared identifier
+	// ts_alias_sequences") and byte-matches pure-Go.
+	parseC := cWalker(t, "emitc_aliasgate", lang)
+	for _, in := range []string{"a b", "a b a b"} {
 		in := in
 		t.Run(strings.ReplaceAll(in, " ", "_"), func(t *testing.T) {
 			want := goSExpr(t, lang, in)

--- a/grammargen/emitc_lexer_parity_test.go
+++ b/grammargen/emitc_lexer_parity_test.go
@@ -1,0 +1,382 @@
+package grammargen
+
+// C-runtime parity tests for grammargen's EmitC lexer emission.
+//
+// These compile the emitted parser.c against a real tree-sitter C runtime
+// (github.com/tree-sitter/go-tree-sitter v0.25.0 — the runtime gotreesitter's
+// own C-oracle parity work verifies against), parse an input with the C
+// runtime, and byte-compare its named-node S-expression against the pure-Go
+// parse of the SAME generated tables. The pure-Go parser is the oracle: any
+// divergence here is a bug in EmitC, not in the grammar or tables.
+//
+// They target three EmitC defects the goala C-parity harness isolated:
+//
+//  1a. ts_lex failed to tokenize an anonymous keyword string that overlaps the
+//      identifier character class: `let x` parsed as (ERROR) under C because
+//      the whitespace skip-state accepted ts_builtin_sym_end (symbol 0 = EOF),
+//      so the parser believed input ended right after `let`.
+//  1b. ts_lex infinite-looped at true end-of-input for tokens whose DFA has a
+//      transition range covering codepoint 0 (negated classes like [^"], `.`):
+//      at EOF lookahead is 0, the range matched, and ADVANCE spun in place.
+//  2.  Two distinct same-text anonymous tokens (plain `"` and
+//      token.immediate('"')) both emitted as anon_sym_DQUOTE — a C
+//      "redeclaration of enumerator".
+//
+// The harness skips gracefully when a C compiler or the runtime module is
+// unavailable, so `go test ./grammargen/...` stays green in minimal
+// environments.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+const emitcWalkerMainC = `#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tree_sitter/api.h>
+
+const TSLanguage *LANG_FN(void);
+
+// walk prints the S-expression of named nodes only, matching gotreesitter's
+// Node.SExpr format exactly: "(" type ( " " child )* ")".
+static void walk(TSNode n, FILE *out) {
+  if (!ts_node_is_named(n)) return;
+  fputc('(', out);
+  fputs(ts_node_type(n), out);
+  uint32_t c = ts_node_named_child_count(n);
+  for (uint32_t i = 0; i < c; i++) {
+    fputc(' ', out);
+    walk(ts_node_named_child(n, i), out);
+  }
+  fputc(')', out);
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) { fprintf(stderr, "usage: walker <file>\n"); return 2; }
+  FILE *f = fopen(argv[1], "rb");
+  if (!f) { fprintf(stderr, "open %s\n", argv[1]); return 2; }
+  fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
+  char *buf = malloc(sz > 0 ? sz : 1);
+  size_t got = fread(buf, 1, sz, f); fclose(f);
+  TSParser *p = ts_parser_new();
+  if (!ts_parser_set_language(p, LANG_FN())) { fprintf(stderr, "set_language\n"); return 3; }
+  TSTree *t = ts_parser_parse_string(p, NULL, buf, (uint32_t)got);
+  TSNode root = ts_tree_root_node(t);
+  walk(root, stdout);
+  fputc('\n', stdout);
+  ts_tree_delete(t); ts_parser_delete(p); free(buf);
+  return 0;
+}
+`
+
+// cWalker compiles the language's EmitC output against the v0.25 runtime and
+// returns a function that parses an input string and yields the C runtime's
+// named-node S-expression. It skips the test when cc or the runtime module is
+// unavailable, and fails (rather than hangs) when the C parser loops.
+func cWalker(t *testing.T, name string, lang *gotreesitter.Language) func(t *testing.T, input string) string {
+	t.Helper()
+	cc, err := exec.LookPath("cc")
+	if err != nil {
+		t.Skip("no C compiler")
+	}
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}",
+		"github.com/tree-sitter/go-tree-sitter@v0.25.0").CombinedOutput()
+	runtimeDir := strings.TrimSpace(string(out))
+	if err != nil || runtimeDir == "" {
+		t.Skipf("tree-sitter C runtime unavailable: %v\n%s", err, out)
+	}
+
+	parserC, err := EmitC(name, lang)
+	if err != nil {
+		t.Fatalf("EmitC: %v", err)
+	}
+
+	tmp := t.TempDir()
+	incDir := filepath.Join(tmp, "include", "tree_sitter")
+	if err := os.MkdirAll(incDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parserH, err := os.ReadFile(filepath.Join(runtimeDir, "src", "parser.h"))
+	if err != nil {
+		t.Fatalf("read runtime parser.h: %v", err)
+	}
+	mustWrite(t, filepath.Join(incDir, "parser.h"), parserH)
+	parserPath := filepath.Join(tmp, "parser.c")
+	mustWrite(t, parserPath, []byte(parserC))
+	mainC := strings.ReplaceAll(emitcWalkerMainC, "LANG_FN", "tree_sitter_"+name)
+	mainPath := filepath.Join(tmp, "walker.c")
+	mustWrite(t, mainPath, []byte(mainC))
+
+	compile, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	objParser := filepath.Join(tmp, "parser.o")
+	objLib := filepath.Join(tmp, "lib.o")
+	objMain := filepath.Join(tmp, "walker.o")
+	walker := filepath.Join(tmp, "walker")
+	steps := [][]string{
+		{"-std=c11", "-O0", "-D_DEFAULT_SOURCE",
+			"-I" + filepath.Join(tmp, "include"), "-c", parserPath, "-o", objParser},
+		{"-std=c11", "-O0", "-D_DEFAULT_SOURCE",
+			"-I" + filepath.Join(runtimeDir, "include"), "-I" + filepath.Join(runtimeDir, "src"),
+			"-c", filepath.Join(runtimeDir, "src", "lib.c"), "-o", objLib},
+		{"-std=c11", "-O0", "-I" + filepath.Join(runtimeDir, "include"),
+			"-c", mainPath, "-o", objMain},
+		{objParser, objLib, objMain, "-pthread", "-o", walker},
+	}
+	for i, args := range steps {
+		cmdOut, err := exec.CommandContext(compile, cc, args...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("compile step %d failed: %v\n%s", i, err, cmdOut)
+		}
+	}
+
+	return func(t *testing.T, input string) string {
+		t.Helper()
+		srcPath := filepath.Join(t.TempDir(), "input")
+		mustWrite(t, srcPath, []byte(input))
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		runOut, err := exec.CommandContext(ctx, walker, srcPath).Output()
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf("C parser hung (>15s) on %q — EmitC lexer EOF loop", input)
+		}
+		if err != nil {
+			t.Fatalf("run C walker on %q: %v", input, err)
+		}
+		return strings.TrimRight(string(runOut), "\n")
+	}
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func goSExpr(t *testing.T, lang *gotreesitter.Language, input string) string {
+	t.Helper()
+	tree, err := gotreesitter.NewParser(lang).Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("pure-Go parse %q: %v", input, err)
+	}
+	return tree.RootNode().SExpr(lang)
+}
+
+// TestEmitCKeywordOverIdentifier is the regression for defect 1a: an anonymous
+// keyword token (`let`) that overlaps the identifier class, plus 1b: EOF that
+// does not end in an extra. Every input must byte-match pure-Go, and no input
+// may hang (the walker has a hard timeout).
+func TestEmitCKeywordOverIdentifier(t *testing.T) {
+	g := NewGrammar("emitc_let")
+	g.Define("source_file", Repeat(Sym("statement")))
+	g.Define("statement", Seq(Str("let"), Sym("identifier")))
+	g.Define("identifier", Pat(`[a-z]+`))
+	g.SetExtras(Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	parseC := cWalker(t, "emitc_let", lang)
+
+	inputs := []string{
+		"let x",   // 1a: keyword over identifier, EOF not an extra
+		"let x\n", // trailing extra
+		"let x let y",
+		"let x\nlet y\n",
+		"let letters", // identifier that has the keyword as a prefix
+	}
+	for _, in := range inputs {
+		in := in
+		t.Run(strings.ReplaceAll(in, "\n", "_"), func(t *testing.T) {
+			want := goSExpr(t, lang, in)
+			got := parseC(t, in)
+			if got != want {
+				t.Fatalf("C/Go divergence for %q\n C: %s\nGo: %s", in, got, want)
+			}
+			if strings.Contains(got, "ERROR") {
+				t.Fatalf("unexpected ERROR for %q: %s", in, got)
+			}
+		})
+	}
+}
+
+// TestEmitCNegatedClassEOFLoop is the focused regression for defect 1b: a token
+// whose DFA has a transition range that includes codepoint 0 (a negated
+// character class). At true EOF lookahead is 0; the pre-fix emission ADVANCEd
+// in place forever. The walker's timeout turns a regression into a failure.
+func TestEmitCNegatedClassEOFLoop(t *testing.T) {
+	g := NewGrammar("emitc_str")
+	g.Define("source_file", Repeat(Sym("string")))
+	g.Define("string", Seq(Str(`"`), Repeat(Pat(`[^"]`)), Str(`"`)))
+	g.SetExtras(Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+	parseC := cWalker(t, "emitc_str", lang)
+
+	inputs := []string{
+		`"hello"`, // complete string, EOF not an extra
+		`"hello world"`,
+		`"a" "b"`,
+		`"unterminated`, // negated-class run hits true EOF — must not hang
+	}
+	for _, in := range inputs {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			want := goSExpr(t, lang, in)
+			got := parseC(t, in)
+			if got != want {
+				t.Fatalf("C/Go divergence for %q\n C: %s\nGo: %s", in, got, want)
+			}
+		})
+	}
+}
+
+// TestEmitCDuplicateAnonToken is the regression for defect 2: two distinct
+// anonymous tokens with identical text must emit distinct C enumerators
+// (anon_sym_DQUOTE / anon_sym_DQUOTE2) so the parser.c compiles.
+func TestEmitCDuplicateAnonToken(t *testing.T) {
+	g := NewGrammar("emitc_dupquote")
+	// A plain `"` and an immediate `"` are distinct tokens with identical text.
+	g.Define("source_file", Repeat(Sym("item")))
+	g.Define("item", Seq(Str(`"`), Optional(Sym("inner"))))
+	g.Define("inner", Seq(ImmToken(Str(`"`)), Sym("word")))
+	g.Define("word", Pat(`[a-z]+`))
+	g.SetExtras(Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+
+	code, err := EmitC("emitc_dupquote", lang)
+	if err != nil {
+		t.Fatalf("EmitC: %v", err)
+	}
+	// If two distinct same-text DQUOTE tokens exist, the second must be
+	// disambiguated rather than redeclaring the first enumerator.
+	if strings.Contains(code, "anon_sym_DQUOTE = ") {
+		enumBlock := code[strings.Index(code, "enum ts_symbol_identifiers"):]
+		enumBlock = enumBlock[:strings.Index(enumBlock, "};")]
+		if strings.Count(enumBlock, "anon_sym_DQUOTE") >= 2 && !strings.Contains(enumBlock, "anon_sym_DQUOTE2 = ") {
+			t.Fatalf("duplicate anon token not disambiguated:\n%s", enumBlock)
+		}
+	}
+
+	// The decisive test: the C compiles without a
+	// "redeclaration of enumerator" error.
+	_ = cWalker(t, "emitc_dupquote", lang)
+}
+
+// TestEmitCAliasSequenceStride guards the alias-sequence stride defect: the
+// tree-sitter runtime indexes ts_alias_sequences as a flat
+// [PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] array by structural child
+// index for every production with a non-zero production_id. If
+// MAX_ALIAS_SEQUENCE_LENGTH is sized to the longest alias row rather than the
+// longest production, a long production's index runs past its own row into a
+// later production's aliased entries and renders an unrelated child under a
+// spurious alias. This grammar pairs a short aliased production with a long
+// unaliased one; MAX_ALIAS_SEQUENCE_LENGTH must cover the long production, and
+// the C parse must byte-match pure-Go.
+func TestEmitCAliasSequenceStride(t *testing.T) {
+	g := NewGrammar("emitc_stride")
+	g.Define("source_file", Repeat(Choice(Sym("long_rule"), Sym("aliased"))))
+	// A long production (7 structural children) with a field, so it carries a
+	// non-zero production_id whose alias row is all zeros.
+	g.Define("long_rule", Seq(
+		Str("k"),
+		Field("a", Sym("identifier")),
+		Field("b", Sym("identifier")),
+		Field("c", Sym("identifier")),
+		Field("d", Sym("identifier")),
+		Field("e", Sym("identifier")),
+		Str(";"),
+	))
+	// A short production whose child 1 is aliased.
+	g.Define("aliased", Seq(Str("`"), Alias(Sym("identifier"), "aliased_content", true), Str("`")))
+	g.Define("identifier", Pat(`[a-z]+`))
+	g.SetExtras(Pat(`\s`))
+
+	lang, err := GenerateLanguage(g)
+	if err != nil {
+		t.Fatalf("GenerateLanguage: %v", err)
+	}
+
+	code, err := EmitC("emitc_stride", lang)
+	if err != nil {
+		t.Fatalf("EmitC: %v", err)
+	}
+	// The declared stride must cover the longest production, not the longest
+	// alias row.
+	stride := headerDefineInt(t, code, "MAX_ALIAS_SEQUENCE_LENGTH")
+	maxChild := maxReduceChildCount(code)
+	if stride < maxChild {
+		t.Fatalf("MAX_ALIAS_SEQUENCE_LENGTH=%d < max reduce child_count=%d: long productions read past their alias row", stride, maxChild)
+	}
+
+	parseC := cWalker(t, "emitc_stride", lang)
+	for _, in := range []string{"k a b c d e ;", "`x`", "k a b c d e ; `y` k p q r s t ;"} {
+		in := in
+		t.Run(strings.ReplaceAll(in, " ", "_"), func(t *testing.T) {
+			want := goSExpr(t, lang, in)
+			got := parseC(t, in)
+			if got != want {
+				t.Fatalf("C/Go divergence for %q\n C: %s\nGo: %s", in, got, want)
+			}
+		})
+	}
+}
+
+func headerDefineInt(t *testing.T, code, name string) int {
+	t.Helper()
+	marker := "#define " + name + " "
+	i := strings.Index(code, marker)
+	if i < 0 {
+		t.Fatalf("missing #define %s", name)
+	}
+	line := code[i+len(marker):]
+	line = line[:strings.IndexByte(line, '\n')]
+	n, err := strconv.Atoi(strings.TrimSpace(line))
+	if err != nil {
+		t.Fatalf("bad #define %s value %q: %v", name, line, err)
+	}
+	return n
+}
+
+// maxReduceChildCount scans emitted REDUCE(...) macros for the largest
+// child-count argument (the second macro argument).
+func maxReduceChildCount(code string) int {
+	max := 0
+	for i := 0; ; {
+		j := strings.Index(code[i:], "REDUCE(")
+		if j < 0 {
+			break
+		}
+		i += j + len("REDUCE(")
+		rest := code[i:]
+		close := strings.IndexByte(rest, ')')
+		if close < 0 {
+			break
+		}
+		args := strings.Split(rest[:close], ",")
+		if len(args) >= 2 {
+			if n, err := strconv.Atoi(strings.TrimSpace(args[1])); err == nil && n > max {
+				max = n
+			}
+		}
+	}
+	return max
+}


### PR DESCRIPTION
## Summary

Fixes several correctness defects in grammargen's C code emitter that caused compiler errors, infinite lexer loops at EOF, incorrect multi-char trivia skipping, and AST divergence due to a stride miscalculation. Also introduces a C-runtime parity test harness to catch regressions.

## Changes

- Fix symbol name collisions by deduplicating C identifiers per symbol ID, preventing 'redeclaration of enumerator' errors for duplicate anonymous tokens.
- Correct lexer EOF handling to prevent infinite ADVANCE loops on negated character classes (lookahead 0) and properly synthesize/end tokens at mode-start vs mid-token states.
- Fix multi-character skip targets (CRLF, backslash-newline) to re-lex from the owning lexer mode's start state instead of an intermediate DFA state.
- Size MAX_ALIAS_SEQUENCE_LENGTH to the longest production's child count rather than the longest alias row, preventing stride-based off-by-bounds reads into adjacent alias data.
- Precompute C symbol names and thread them through emit functions for consistent, collision-free identifier generation.
- Add C-runtime parity tests that compile the emitted parser.c against the tree-sitter v0.25.0 runtime and byte-compare the resulting AST against the pure-Go oracle.

## Testing

- go test ./grammargen -run '^TestEmitC' -count=1
- bash cgo_harness/docker/run_single_grammar_parity.sh c