### PR TITLE
fix(parser-core, incremental-reuse): enforce compact tree reuse bar and add ParseState table replay

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,254 @@
+package gotreesitter
+
+import (
+	"fmt"
+	"sort"
+)
+
+// This file exposes unexported ParseState-by-table-replay machinery to the
+// external gotreesitter_test package so the differential corpus test
+// (parsestate_replay_diff_test.go) can compare replay-reconstructed states
+// against production-recorded states with full access to node internals.
+
+// ReplayMismatchSample is a single node whose reconstructed state disagreed
+// with the production-recorded state.
+type ReplayMismatchSample struct {
+	Symbol         Symbol
+	SymbolName     string
+	Class          string
+	PreGotoRec     StateID
+	PreGotoReplay  StateID
+	ParseStateRec  StateID
+	ParseStateRep  StateID
+	PreGotoDiff    bool
+	ParseStateDiff bool
+	Depth          int
+}
+
+// ReplayClassStat aggregates match/mismatch counts for one node class.
+type ReplayClassStat struct {
+	Class      string
+	Total      int
+	Mismatched int
+}
+
+// ReplayDiffReport is the result of comparing replay-reconstructed
+// (preGotoState, parseState) against production-recorded values over one tree.
+type ReplayDiffReport struct {
+	TotalNodes          int
+	Mismatched          int
+	PreGotoMismatched   int
+	ParseStateMismatch  int
+	RootPreGotoRecorded StateID
+	RootPreGotoSeed     StateID
+	Classes             map[string]*ReplayClassStat
+	Samples             []ReplayMismatchSample
+}
+
+// ReplayDiffTree replays the LR tables over the tree rooted at root and
+// compares the reconstructed states against the recorded ones on every node.
+// It mutates nothing. maxSamples bounds the retained mismatch examples.
+func ReplayDiffTree(p *Parser, root *Node, maxSamples int) ReplayDiffReport {
+	rep := ReplayDiffReport{
+		Classes: map[string]*ReplayClassStat{},
+	}
+	if p == nil || root == nil {
+		return rep
+	}
+	rep.RootPreGotoRecorded = root.preGotoState
+	rep.RootPreGotoSeed = p.replayRootPreGotoState()
+
+	// depth tracking: recompute via the same worklist shape is awkward, so
+	// track depth by walking parents lazily only for samples.
+	var scratch []replayFrame
+	p.replayParseStates(root, rep.RootPreGotoSeed, func(n *Node, preGoto, parseState StateID) {
+		rep.TotalNodes++
+		class := p.replayNodeClass(n)
+		st := rep.Classes[class]
+		if st == nil {
+			st = &ReplayClassStat{Class: class}
+			rep.Classes[class] = st
+		}
+		st.Total++
+
+		preDiff := preGoto != n.preGotoState
+		psDiff := parseState != n.parseState
+		if !preDiff && !psDiff {
+			return
+		}
+		rep.Mismatched++
+		st.Mismatched++
+		if preDiff {
+			rep.PreGotoMismatched++
+		}
+		if psDiff {
+			rep.ParseStateMismatch++
+		}
+		if len(rep.Samples) < maxSamples {
+			rep.Samples = append(rep.Samples, ReplayMismatchSample{
+				Symbol:         n.symbol,
+				SymbolName:     p.symbolNameForReport(n.symbol),
+				Class:          class,
+				PreGotoRec:     n.preGotoState,
+				PreGotoReplay:  preGoto,
+				ParseStateRec:  n.parseState,
+				ParseStateRep:  parseState,
+				PreGotoDiff:    preDiff,
+				ParseStateDiff: psDiff,
+				Depth:          nodeDepth(n),
+			})
+		}
+	}, &scratch)
+	return rep
+}
+
+// SortedClassStats returns the per-class stats in a stable, mismatch-first order
+// for reporting.
+func (r ReplayDiffReport) SortedClassStats() []ReplayClassStat {
+	out := make([]ReplayClassStat, 0, len(r.Classes))
+	for _, st := range r.Classes {
+		out = append(out, *st)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Mismatched != out[j].Mismatched {
+			return out[i].Mismatched > out[j].Mismatched
+		}
+		return out[i].Class < out[j].Class
+	})
+	return out
+}
+
+// replayNodeClass produces a stable multi-dimensional class key for a node,
+// used to localize which node classes are/are not replay-derivable.
+func (p *Parser) replayNodeClass(n *Node) string {
+	kind := "internal"
+	if p.replaySymbolIsTerminal(n.symbol) {
+		kind = "terminal"
+	}
+	if len(n.children) == 0 && kind == "internal" {
+		kind = "empty-nonterminal"
+	}
+	var mods string
+	if n.symbol == errorSymbol {
+		mods += "+error"
+	}
+	if n.isMissing() {
+		mods += "+missing"
+	}
+	if n.isExtra() {
+		mods += "+extra"
+	}
+	if n.isExternalScannerToken() {
+		mods += "+extscan"
+	}
+	if n.hasError() && n.symbol != errorSymbol {
+		mods += "+haserr"
+	}
+	if mods == "" {
+		return kind
+	}
+	return kind + mods
+}
+
+// symbolNameForReport returns a human-readable symbol name for reporting.
+func (p *Parser) symbolNameForReport(sym Symbol) string {
+	if sym == errorSymbol {
+		return "ERROR"
+	}
+	if p == nil || p.language == nil {
+		return fmt.Sprintf("sym#%d", sym)
+	}
+	if int(sym) < len(p.language.SymbolNames) {
+		if name := p.language.SymbolNames[sym]; name != "" {
+			return name
+		}
+	}
+	return fmt.Sprintf("sym#%d", sym)
+}
+
+func nodeDepth(n *Node) int {
+	d := 0
+	for n != nil && n.parent != nil {
+		d++
+		n = n.parent
+	}
+	return d
+}
+
+// ReplayResyncReport isolates the two error sources in visible-tree replay:
+// (1) whether advance() reproduces parseState GIVEN the recorded preGotoState
+// (tests the goto/shift model in isolation), and (2) whether the first child's
+// preGotoState equals its parent's recorded preGotoState (tests the straight
+// line intra-production chain). preGoto threading across hidden-node boundaries
+// is deliberately NOT threaded here: each node is seeded from its own recorded
+// preGotoState.
+type ReplayResyncReport struct {
+	TotalNodes             int
+	ParseStateExact        int // advance(recordedPre, n) == recordedParseState
+	ParseStateExactByClass map[string]*ReplayClassStat
+	FirstChildPreExact     int // child0.recordedPre == parent.recordedPre
+	FirstChildTotal        int
+	SiblingChainExact      int // child[i].recordedPre == advance(child[i-1].recordedPre, child[i-1])
+	SiblingChainTotal      int
+}
+
+// ReplayDiffResync walks the tree and, for every node, checks whether
+// advance(recordedPreGoto, node) reproduces the recorded parseState, plus the
+// two structural chain invariants. It reveals that parseState IS exactly a
+// table transition of the (correct) preGotoState, and that the ONLY thing the
+// visible tree cannot reconstruct is preGotoState across hidden-node edges.
+func ReplayDiffResync(p *Parser, root *Node) ReplayResyncReport {
+	rep := ReplayResyncReport{ParseStateExactByClass: map[string]*ReplayClassStat{}}
+	if p == nil || root == nil {
+		return rep
+	}
+	var walk func(n *Node)
+	walk = func(n *Node) {
+		rep.TotalNodes++
+		class := p.replayNodeClass(n)
+		st := rep.ParseStateExactByClass[class]
+		if st == nil {
+			st = &ReplayClassStat{Class: class}
+			rep.ParseStateExactByClass[class] = st
+		}
+		st.Total++
+		adv, _ := p.replayAdvance(n.preGotoState, n)
+		if adv == n.parseState {
+			rep.ParseStateExact++
+		} else {
+			st.Mismatched++
+		}
+		if len(n.children) > 0 {
+			rep.FirstChildTotal++
+			if n.children[0].preGotoState == n.preGotoState {
+				rep.FirstChildPreExact++
+			}
+			for i := 1; i < len(n.children); i++ {
+				rep.SiblingChainTotal++
+				prevAdv, _ := p.replayAdvance(n.children[i-1].preGotoState, n.children[i-1])
+				if n.children[i].preGotoState == prevAdv {
+					rep.SiblingChainExact++
+				}
+			}
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(root)
+	return rep
+}
+
+func (r ReplayResyncReport) SortedClassStats() []ReplayClassStat {
+	out := make([]ReplayClassStat, 0, len(r.ParseStateExactByClass))
+	for _, st := range r.ParseStateExactByClass {
+		out = append(out, *st)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Mismatched != out[j].Mismatched {
+			return out[i].Mismatched > out[j].Mismatched
+		}
+		return out[i].Class < out[j].Class
+	})
+	return out
+}

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -6,6 +6,14 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 	if p == nil || oldTree == nil || oldTree.RootNode() == nil || oldTree.language != p.language {
 		return nil, false
 	}
+	// A compact-materialized tree carries table-replayed / abstained per-node
+	// parser states and no scanner checkpoints, so it is barred from every reuse
+	// path -- including this token-invariant leaf reuse -- on ALL entry points
+	// (DFA and custom token source). Force the caller to a full fresh parse
+	// (Phase-3 Lane 3 review).
+	if oldTree.compactMaterialized {
+		return nil, false
+	}
 	if len(oldTree.edits) != 1 {
 		return nil, false
 	}

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -1142,6 +1142,7 @@ func reuseTreeWithNewSource(oldTree *Tree, source []byte, dirtyNode *Node, clear
 	tree := newTreeWithUniqueArenas(oldTree.root, source, oldTree.language, arena, borrowed)
 	tree.forestFastPath = oldTree.forestFastPath
 	tree.incrementalReuseDisabled = oldTree.incrementalReuseDisabled
+	tree.compactMaterialized = oldTree.compactMaterialized
 	return tree
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -501,6 +501,11 @@ type MaterializationSubtreeView struct {
 	Extra             bool
 	External          bool
 	Terminal          bool
+	// Fragile mirrors subtreeRecord.fragile: the record was produced by a
+	// reduce/conflict-arm decision that ran under ambiguity (multiPop or an
+	// authenticated >=2-action conflict). Threaded to the public materializer so
+	// Lane-1 fragility metadata reaches compact-materialized public nodes.
+	Fragile bool
 }
 
 // Stats reports physical storage separately from semantic path counts. It is
@@ -3024,6 +3029,7 @@ func (c *Core) VisitMaterializationPostorder(
 				StartByte:         record.startByte, EndByte: record.endByte,
 				Children: c.children[record.firstChild : record.firstChild+record.childCount],
 				Extra:    record.extra, External: record.external, Terminal: record.terminal,
+				Fragile: record.fragile,
 			}
 			if err := visit(top.id, view); err != nil {
 				return err
@@ -3060,6 +3066,7 @@ func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, er
 		Extra:             record.extra,
 		External:          record.external,
 		Terminal:          record.terminal,
+		Fragile:           record.fragile,
 	}, nil
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -3039,6 +3039,40 @@ func (c *Core) VisitMaterializationPostorder(
 	return poll()
 }
 
+// MaterializationView returns the borrowed materialization view for one
+// subtree id. It is the random-access companion to VisitMaterializationPostorder
+// used by ParseState-by-table-replay (Phase-3 Lane 2): the driver walks the
+// derivation top-down to reconstruct per-node parser states before the
+// postorder pass materializes public nodes. The returned Children slice
+// aliases compact arena storage and must not be retained or mutated.
+func (c *Core) MaterializationView(id SubtreeID) (MaterializationSubtreeView, error) {
+	record, err := c.subtree(id)
+	if err != nil {
+		return MaterializationSubtreeView{}, err
+	}
+	return MaterializationSubtreeView{
+		Symbol:            record.symbol,
+		ProductionID:      record.productionID,
+		DynamicPrecedence: record.dynamicPrecedence,
+		StartByte:         record.startByte,
+		EndByte:           record.endByte,
+		Children:          c.children[record.firstChild : record.firstChild+record.childCount],
+		Extra:             record.extra,
+		External:          record.external,
+		Terminal:          record.terminal,
+	}, nil
+}
+
+// SubtreeArenaLen returns the number of subtree records currently allocated,
+// used to size a per-id replay-state array (ids are 1-based, so callers size
+// SubtreeArenaLen()+1).
+func (c *Core) SubtreeArenaLen() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.subtrees)
+}
+
 func (c *Core) validateMaterializationMetadata(id SubtreeID, record subtreeRecord) error {
 	// Production construction authenticates every terminal and reduction before
 	// publication. Compact arenas are immutable, so repeating the table remap at

--- a/parser.go
+++ b/parser.go
@@ -2857,6 +2857,24 @@ func (p *Parser) parseIncrementalInternal(source []byte, oldTree *Tree, ts Token
 	return p.parseIncrementalInternalWithMergePerKeyOverride(source, oldTree, ts, timing, 0)
 }
 
+// incrementalTokenSourceFreshFullParse performs a full fresh parse over the
+// provided token source with the incremental origin's retry widening. It is the
+// shared fallback for an incremental reparse that must not reuse the old tree:
+// either the token source does not support subtree reuse, or the old tree
+// disables reuse (forestFastPath / compact-materialized). It never touches
+// oldTree, so no replayed/abstained state can leak into the result.
+func (p *Parser) incrementalTokenSourceFreshFullParse(source []byte, ts TokenSource, timing *incrementalParseTiming) *Tree {
+	deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
+	initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
+	workCountSetNextParseAttempt("initial_full", "incremental_token_source_fallback_full_parse")
+	tree := p.parseInternal(source, ts, nil, nil, arenaClassFull, timing, initialMaxStacks, 0, 0, deterministicExternalConflicts)
+	tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
+	if shouldRepeatExternalScannerFullParse(p.language, tree) {
+		tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
+	}
+	return tree
+}
+
 func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, oldTree *Tree, ts TokenSource, timing *incrementalParseTiming, maxMergePerKeyOverride int) *Tree {
 	// Fast path: unchanged source and no recorded edits.
 	if canReuseUnchangedTree(source, oldTree, p.language) {
@@ -2864,6 +2882,21 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 	}
 	if tree, ok := p.tryTokenInvariantLeafEdit(source, oldTree, ts, timing); ok {
 		return tree
+	}
+
+	// One reuse bar for EVERY incremental entry (Phase-3 Lane 3 review). The DFA
+	// entry (parseIncrementalChanged) already routes a reuse-disabled old tree to
+	// a full fresh parse before reaching here, but the token-source entries
+	// (parseIncrementalWithTokenSourceChanged and its Profiled twin) call in
+	// directly. A reuse-disabled old tree -- forestFastPath, or a
+	// compact-materialized tree whose per-node states are table-replayed /
+	// abstained -- must never feed the reuseCursor subtree splice below, which
+	// trusts old-tree parser states. The only reuse it may take is the
+	// token-invariant leaf edit attempted just above (compact trees are barred
+	// from even that inside tryTokenInvariantLeafEdit); once that declines, force
+	// a full fresh parse over the provided token source.
+	if oldTreeDisablesIncrementalReuse(oldTree) {
+		return p.incrementalTokenSourceFreshFullParse(source, ts, timing)
 	}
 
 	// Subtree reuse is safe for DFA token sources without external scanners
@@ -2877,15 +2910,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 		// like ordinary full parses, including retry widening. This keeps
 		// conservative fallback paths for external-scanner languages on the same
 		// correctness footing as Parse.
-		deterministicExternalConflicts := fullParseUsesDeterministicExternalConflicts(p.language)
-		initialMaxStacks := fullParseInitialMaxStacks(p.language, p.maxConflictWidth)
-		workCountSetNextParseAttempt("initial_full", "incremental_token_source_fallback_full_parse")
-		tree := p.parseInternal(source, ts, nil, nil, arenaClassFull, timing, initialMaxStacks, 0, 0, deterministicExternalConflicts)
-		tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
-		if shouldRepeatExternalScannerFullParse(p.language, tree) {
-			tree = p.retryFullParseWithTokenSourceForOrigin(source, ts, initialMaxStacks, deterministicExternalConflicts, tree, fullParseRetryOriginIncremental)
-		}
-		return tree
+		return p.incrementalTokenSourceFreshFullParse(source, ts, timing)
 	}
 	if oldTree != nil {
 		oldTree.ensureParentLinks()

--- a/parser_api.go
+++ b/parser_api.go
@@ -190,6 +190,13 @@ func (p *Parser) tryTokenInvariantReuseForDisabledOldTree(source []byte, oldTree
 	if !oldTreeDisablesIncrementalReuse(oldTree) {
 		return nil, false
 	}
+	// A compact-materialized tree carries replayed (not live-recorded) parser
+	// states and no scanner checkpoints, so it is barred from even the
+	// token-invariant leaf fast path: force the full fresh parse (Lane 3
+	// review amendment 2).
+	if oldTree != nil && oldTree.compactMaterialized {
+		return nil, false
+	}
 	if p == nil || p.language == nil {
 		return nil, false
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -300,10 +300,14 @@ type DiagnosticParserCorePrefixResult struct {
 	Materialized      bool
 	// MaterializedTree is a structural diagnostic owned by the caller and must
 	// be released. It is set only after authenticated EOF acceptance and
-	// one-shot compact-tree materialization succeed. Compact phase zero does not
-	// retain the production parser's per-node reuse state or scanner checkpoints,
-	// so the returned tree is explicitly barred from incremental reuse; passing
-	// it to ParseIncremental takes the production parser's fresh-parse fallback.
+	// one-shot compact-tree materialization succeed. Compact phase zero carries
+	// only table-REPLAYED per-node parser states (exact where reconstructable,
+	// abstained to the 0 "unknown -> recompute" sentinel otherwise) and no
+	// scanner checkpoints, so the tree is HARD-barred from incremental reuse by
+	// its compactMaterialized provenance flag (checked in
+	// tryTokenInvariantReuseForDisabledOldTree): passing it to ParseIncremental
+	// always takes the production parser's full fresh-parse fallback, never even
+	// the token-invariant leaf fast path.
 	MaterializedTree *Tree
 }
 
@@ -1710,22 +1714,45 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	}
 	stamp := func(id core.SubtreeID, node *Node) {
 		// Stamp the reconstructed state for THIS derivation id onto the node
-		// that materializes it. For a unary collapse chain the driver visits
-		// the ids inner-to-outer (postorder) and reuses one node object, so
-		// the last (outermost) stamp wins -- mirroring production's collapse,
-		// which overwrites parseState = goto(topState, outerSymbol) as each
-		// wrapper reduce fires. The residual gap is the small class of chains
-		// where production declines the collapse under a zero-width lookahead
-		// (keeping the inner visible state) but the derivation-time compact
-		// route cannot see that lookahead; see the differential harness.
+		// that materializes it. For a unary collapse chain the driver visits the
+		// ids inner-to-outer (postorder) and reuses one node object, so the last
+		// (outermost) stamp wins -- mirroring production's collapse, which
+		// overwrites parseState = goto(topState, outerSymbol) as each wrapper
+		// reduce fires.
+		//
+		// replayStates.get returns ok=false when the top-down replay could not
+		// find a table transition for this id (an extra/comment leaf whose
+		// floated stack position does not match a live shift, or any node whose
+		// production shape is not a plain shift/goto of its visible symbol). In
+		// that case the reconstructed state is NOT authoritative, so we ABSTAIN:
+		// leave parseState/preGotoState at their zero value. Downstream, a zero
+		// parseState is the "unknown -> recompute" sentinel (incremental
+		// self-healing), which is strictly safer than stamping a known-wrong but
+		// trusted non-zero state (Phase-3 Lane 3 review amendment 1).
 		if replayStates != nil && node != nil {
-			pre, ps, ok := replayStates.get(id)
-			if ok {
-				node.preGotoState = pre
+			pre, ps, preOk, psOk := replayStates.get(id)
+			if psOk {
 				node.parseState = ps
+			}
+			if preOk {
+				node.preGotoState = pre
 			}
 		}
 		nodesByID[id] = node
+	}
+	// markFragile threads the compact record's ambiguity bit (subtreeRecord
+	// .fragile, exposed on MaterializationSubtreeView.Fragile) onto the public
+	// node so Lane-1's isFragile() reuse gate sees compact-materialized trees
+	// the same as production-built ones (Phase-3 Lane 3 review amendment 7). The
+	// compact record collapses production's fragileLeft/fragileRight into one
+	// conservative flag, so both edges are set. Set-only (never clears), matching
+	// the record's monotone contract on shared/deduped records.
+	markFragile := func(node *Node, fragile bool) {
+		if node == nil || !fragile {
+			return
+		}
+		node.setFragileLeft(true)
+		node.setFragileRight(true)
 	}
 	err = withDiagnosticParserCoreMaterializationScratch(parser, func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
 		return compact.VisitMaterializationPostorder(payloads, poll, func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
@@ -1763,6 +1790,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			if child := parser.collapsibleRawUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries)); child != nil {
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
+				markFragile(child, view.Fragile)
 				stamp(id, child)
 				return nil
 			}
@@ -1773,6 +1801,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			if child := parser.collapsibleUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries), children, fieldIDs); child != nil {
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
+				markFragile(child, view.Fragile)
 				stamp(id, child)
 				return nil
 			}
@@ -1785,6 +1814,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			parent.startPoint = points.point(view.StartByte)
 			parent.endPoint = points.point(view.EndByte)
 			parent.setExtra(view.Extra)
+			markFragile(parent, view.Fragile)
 			stamp(id, parent)
 			return nil
 		})
@@ -1829,6 +1859,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 		return rejectTree(fmt.Errorf("parser-core phase zero: accepted compact root is incomplete or erroneous: span=%d..%d source=%d error=%t", root.startByte, root.endByte, sourceLen, root.HasError()))
 	}
 	tree.incrementalReuseDisabled = true
+	tree.compactMaterialized = true
 	tree.setParseRuntime(ParseRuntime{
 		StopReason: ParseStopAccepted, SourceLen: sourceLen, ExpectedEOFByte: sourceLen,
 		RootEndByte: root.endByte, LastTokenEndByte: sourceLen, LastTokenSymbol: 0, LastTokenWasEOF: true,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1695,6 +1695,38 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	if err := poll(); err != nil {
 		return nil, err
 	}
+
+	// Phase-3 Lane 2: reconstruct parser states by top-down table replay over
+	// the full derivation (real symbols + hidden nodes), before the postorder
+	// pass elides hidden nodes and applies aliases. Gated so it can be A/B'd
+	// against the states-free compact route.
+	var replayStates *compactReplayStates
+	if parserCoreReplayParseStatesEnabled() {
+		replayStates, err = parser.replayCompactDerivation(compact, payloads)
+		if err != nil {
+			return nil, err
+		}
+		defer replayStates.release()
+	}
+	stamp := func(id core.SubtreeID, node *Node) {
+		// Stamp the reconstructed state for THIS derivation id onto the node
+		// that materializes it. For a unary collapse chain the driver visits
+		// the ids inner-to-outer (postorder) and reuses one node object, so
+		// the last (outermost) stamp wins -- mirroring production's collapse,
+		// which overwrites parseState = goto(topState, outerSymbol) as each
+		// wrapper reduce fires. The residual gap is the small class of chains
+		// where production declines the collapse under a zero-width lookahead
+		// (keeping the inner visible state) but the derivation-time compact
+		// route cannot see that lookahead; see the differential harness.
+		if replayStates != nil && node != nil {
+			pre, ps, ok := replayStates.get(id)
+			if ok {
+				node.preGotoState = pre
+				node.parseState = ps
+			}
+		}
+		nodesByID[id] = node
+	}
 	err = withDiagnosticParserCoreMaterializationScratch(parser, func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
 		return compact.VisitMaterializationPostorder(payloads, poll, func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
 			if view.EndByte < view.StartByte || view.EndByte > uint32(len(source)) {
@@ -1708,7 +1740,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 				)
 				node.setExtra(view.Extra)
 				node.setExternalScannerToken(view.External)
-				nodesByID[id] = node
+				stamp(id, node)
 				return nil
 			}
 
@@ -1731,7 +1763,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			if child := parser.collapsibleRawUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries)); child != nil {
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
-				nodesByID[id] = child
+				stamp(id, child)
 				return nil
 			}
 			children, fieldIDs, fieldSources, _ := parser.buildReduceChildrenWithPath(
@@ -1741,7 +1773,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			if child := parser.collapsibleUnarySelfReduction(action, Token{}, arena, entries, 0, len(entries), children, fieldIDs); child != nil {
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
-				nodesByID[id] = child
+				stamp(id, child)
 				return nil
 			}
 			parent := newParentNodeInArenaWithFieldSources(
@@ -1753,7 +1785,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			parent.startPoint = points.point(view.StartByte)
 			parent.endPoint = points.point(view.EndByte)
 			parent.setExtra(view.Extra)
-			nodesByID[id] = parent
+			stamp(id, parent)
 			return nil
 		})
 	})

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1767,6 +1767,10 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 				)
 				node.setExtra(view.Extra)
 				node.setExternalScannerToken(view.External)
+				// No markFragile here: fragile is a reduce/conflict-arm property
+				// (subtreeRecord.fragile is only ever set on reductions), so a
+				// terminal record is never fragile. The reduce branches below
+				// carry the bit.
 				stamp(id, node)
 				return nil
 			}

--- a/parsestate_fragile_test.go
+++ b/parsestate_fragile_test.go
@@ -1,0 +1,117 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// TestCompactMaterializedFragileBitReachesPublicNode proves Phase-3 Lane 3
+// review amendment 7 end to end: a compact subtreeRecord marked fragile (the
+// reduce-under-ambiguity path, internal/parsercorephase0/core.go) has its bit
+// threaded through MaterializationSubtreeView.Fragile onto the public node so
+// node.isFragile() reports it. The compact route declines missing/error nodes,
+// so a clean visible fragile record is fragile ONLY if markFragile stamped it
+// (isFragile is otherwise false for a clean node), making this a real proof of
+// the threading rather than the unconditional missing/error fragility.
+func TestCompactMaterializedFragileBitReachesPublicNode(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := runner.parser
+
+	type key struct {
+		sym    Symbol
+		sb, eb uint32
+	}
+
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		t.Run(row.id, func(t *testing.T) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+			scheduler, ts, err := runner.executeSchedulerOpen(fixture.Source, runner.compact, true)
+			if err != nil {
+				t.Fatalf("scheduler: %v", err)
+			}
+			defer ts.Close()
+			compact := runner.compact
+
+			// Collect visible fragile record spans from the derivation.
+			fragileKeys := map[key]bool{}
+			seen := map[core.SubtreeID]bool{}
+			stack := append([]core.SubtreeID{}, scheduler.acceptedPayloads...)
+			for len(stack) > 0 {
+				id := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+				v, _ := compact.MaterializationView(id)
+				if v.Fragile && !v.Terminal && p.isVisibleSymbol(Symbol(v.Symbol)) {
+					fragileKeys[key{Symbol(v.Symbol), v.StartByte, v.EndByte}] = true
+				}
+				stack = append(stack, v.Children...)
+			}
+			if len(fragileKeys) == 0 {
+				t.Skipf("%s: derivation has no visible fragile record", row.id)
+			}
+
+			// Materialize the SAME derivation and index the public nodes.
+			tree, err := runner.materializeSelection(fixture.Source, compact, scheduler)
+			if err != nil {
+				t.Fatalf("materialize: %v", err)
+			}
+			defer tree.Release()
+
+			byKey := map[key]*Node{}
+			cleanNonFragile := 0
+			var walk func(n *Node)
+			walk = func(n *Node) {
+				if n == nil {
+					return
+				}
+				byKey[key{n.symbol, n.startByte, n.endByte}] = n
+				if !n.isFragile() && !n.isMissing() && n.symbol != errorSymbol {
+					cleanNonFragile++
+				}
+				for i := 0; i < n.ChildCount(); i++ {
+					walk(n.Child(i))
+				}
+			}
+			walk(tree.root)
+
+			matched, missing, notFragile := 0, 0, 0
+			for k := range fragileKeys {
+				node, ok := byKey[k]
+				if !ok {
+					// Collapsed-through or aliased away; not a threading failure.
+					missing++
+					continue
+				}
+				if node.isFragile() {
+					matched++
+				} else {
+					notFragile++
+					if notFragile <= 5 {
+						t.Errorf("%s: fragile compact record %s %d..%d did not stamp node.isFragile()",
+							row.id, node.Type(p.language), k.sb, k.eb)
+					}
+				}
+			}
+			if matched == 0 {
+				t.Fatalf("%s: no fragile compact record reached a public node (visible fragile records=%d, missing=%d)",
+					row.id, len(fragileKeys), missing)
+			}
+			// Sanity: the bit is not universally set -- clean non-fragile nodes exist.
+			if cleanNonFragile == 0 {
+				t.Fatalf("%s: every node reported fragile; markFragile is over-marking", row.id)
+			}
+			t.Logf("%s: fragile records matched to public isFragile() nodes=%d (unmatched/collapsed=%d), clean-non-fragile nodes=%d",
+				row.id, matched, missing, cleanNonFragile)
+		})
+	}
+}

--- a/parsestate_replay.go
+++ b/parsestate_replay.go
@@ -12,9 +12,14 @@ package gotreesitter
 // (preGotoState, parseState) pair can be reconstructed top-down by replaying
 // the LR goto/shift tables from the parent's exposed state over the children's
 // symbols. This file implements that reconstruction as a single push-shaped
-// top-down pass over the final tree (no pull-per-edge), and the differential
-// harness (export_test.go + parsestate_replay_diff_test.go) proves it equals
-// the production-recorded values byte-for-byte on the corpus.
+// top-down pass (no pull-per-edge). Replaying over the VISIBLE, materialized
+// tree reconstructs only ~0.30% of nodes (parsestate_replay_diff_test.go): the
+// visible tree has already erased the two things replay needs -- hidden-node
+// goto transitions and pre-alias grammar symbols. Admission-mode reconstruction
+// therefore runs over the FULL compact derivation instead
+// (parsestate_replay_compact.go, before hidden elision and aliasing), where the
+// same push-shaped traversal is exact except for the documented extra-preGoto
+// and internal collapse-class residuals; see the NOTE at the end of this file.
 //
 // The model, derived from the production assignments in parser_reduce.go:
 //

--- a/parsestate_replay.go
+++ b/parsestate_replay.go
@@ -1,0 +1,204 @@
+package gotreesitter
+
+// ParseState-by-table-replay (Phase-3 Lane 2).
+//
+// The compact parser core (internal/parsercorephase0) can build a tree at
+// 0.96-1.01x C work, but it drops the per-node parseState / preGotoState that
+// production consumers (incremental reuse, error recovery, queries, cursors)
+// require. Recording those two StateIDs per node during the compact parse
+// reintroduces the metadata cost the compact route exists to avoid.
+//
+// The Phase-3 insight is that parseState is TABLE-DERIVABLE: for any node its
+// (preGotoState, parseState) pair can be reconstructed top-down by replaying
+// the LR goto/shift tables from the parent's exposed state over the children's
+// symbols. This file implements that reconstruction as a single push-shaped
+// top-down pass over the final tree (no pull-per-edge), and the differential
+// harness (export_test.go + parsestate_replay_diff_test.go) proves it equals
+// the production-recorded values byte-for-byte on the corpus.
+//
+// The model, derived from the production assignments in parser_reduce.go:
+//
+//   * A leaf (terminal) shifted from state s onto the stack gets
+//         leaf.preGotoState = s
+//         leaf.parseState   = extraShiftTargetState(s, shiftAction(s, sym))
+//     where shiftAction(s, sym) is the SHIFT action for sym in state s. For a
+//     normal shift that is the action's target State; for an extra shift whose
+//     action carries State==0 it stays at s (extraShiftTargetState).
+//
+//   * A non-leaf produced by reducing production A -> c0 c1 ... ck exposes the
+//     state topState below the popped children and gets
+//         parent.preGotoState = topState
+//         parent.parseState   = lookupGoto(topState, A)  (or topState if 0)
+//
+//   * The children of a reduce form a state chain: c0 was pushed onto topState
+//     (= parent.preGotoState), and each subsequent ci was pushed onto the state
+//     exposed by c(i-1). Hence
+//         c0.preGotoState = parent.preGotoState
+//         ci.preGotoState = c(i-1).parseState        (i > 0)
+//         ci.parseState   = advance(ci.preGotoState, ci)
+//
+// The root of the tree is the start-symbol node produced by the final reduce;
+// the state below it is the parser's InitialState, so the whole tree is seeded
+// from replayRootPreGotoState(p).
+//
+// advance() is total: terminals use the shift table, non-terminals the goto
+// table, and the "no transition" fall-through keeps the current state (matching
+// the extra / no-goto production branches). Node classes whose production state
+// is NOT a plain shift/goto of the visible symbol (error/missing recovery
+// insertions, and any node whose real derivation differs from its visible
+// shape) are the reconstruction's trouble spots; the differential harness
+// measures exactly which nodes those are.
+
+// replayVisit is invoked once per node during a top-down replay pass with the
+// reconstructed preGotoState and parseState for that node. It must not mutate
+// tree structure; production materialization writes the two states onto the
+// node, and the differential test compares them against recorded values.
+type replayVisit func(n *Node, preGotoState, parseState StateID)
+
+// replayRootPreGotoState returns the state exposed below the tree root, i.e.
+// the seed for the whole top-down replay. It is the parser's initial state:
+// after the final reduce to the start symbol pops that production's children,
+// the state left on the stack is InitialState.
+func (p *Parser) replayRootPreGotoState() StateID {
+	if p == nil || p.language == nil {
+		return 0
+	}
+	return p.language.InitialState
+}
+
+// replaySymbolIsTerminal reports whether sym is a terminal (lexer) symbol, i.e.
+// one that reaches the stack via a SHIFT rather than a reduce GOTO. Symbols
+// below TokenCount are terminals; the rest are non-terminals. The synthetic
+// errorSymbol is treated as a non-terminal (it never shifts).
+func (p *Parser) replaySymbolIsTerminal(sym Symbol) bool {
+	if p == nil || p.language == nil {
+		return false
+	}
+	if sym == errorSymbol {
+		return false
+	}
+	tc := p.language.TokenCount
+	return tc == 0 || uint32(sym) < tc
+}
+
+// replayShiftTarget computes the state a terminal leaf with symbol sym reaches
+// when shifted from state s, mirroring applyShiftAction: it finds the SHIFT
+// action for sym at s and applies extraShiftTargetState. When no shift action
+// exists (the leaf did not arrive by a plain shift from this state) it returns
+// (s, false) so callers can flag the node as non-replayable.
+func (p *Parser) replayShiftTarget(s StateID, sym Symbol) (StateID, bool) {
+	entry := p.lookupAction(s, sym)
+	if entry == nil {
+		return s, false
+	}
+	for i := range entry.Actions {
+		act := entry.Actions[i]
+		if act.Type != ParseActionShift {
+			continue
+		}
+		return extraShiftTargetState(s, act), true
+	}
+	return s, false
+}
+
+// replayTransition computes the parser state reached after a symbol is pushed
+// onto the stack from state s. terminal selects the shift table (lexer tokens)
+// vs the goto table (reduce results). The bool reports whether a table
+// transition was found; false falls back to s (the extra / no-goto branch,
+// valid only when the recorded parseState also equals preGotoState). This is
+// the shared primitive: visible-tree replay guesses terminal from TokenCount,
+// while compact-derivation replay uses the record's authoritative terminal
+// flag and its pre-alias grammar symbol.
+func (p *Parser) replayTransition(s StateID, sym Symbol, terminal bool) (StateID, bool) {
+	if terminal {
+		return p.replayShiftTarget(s, sym)
+	}
+	g := p.lookupGoto(s, sym)
+	if g != 0 {
+		return g, true
+	}
+	return s, false
+}
+
+// replayAdvance computes the parser state after node n (whose preGotoState is
+// s) is pushed onto the stack. The bool result reports whether the transition
+// was found in the tables; false means the node's state is not a plain
+// shift/goto of its visible symbol from s (a trouble-spot node).
+func (p *Parser) replayAdvance(s StateID, n *Node) (StateID, bool) {
+	if n == nil {
+		return s, false
+	}
+	return p.replayTransition(s, n.symbol, p.replaySymbolIsTerminal(n.symbol))
+}
+
+// replayFrame is one entry on the explicit worklist used to avoid deep Go
+// recursion on pathologically deep trees (e.g. long left-recursive chains).
+type replayFrame struct {
+	node    *Node
+	preGoto StateID
+}
+
+// replayParseStates reconstructs (preGotoState, parseState) for every node in
+// the tree rooted at root and reports each via visit. rootPreGoto seeds the
+// root; use replayRootPreGotoState for the production seed.
+//
+// The traversal is push-shaped: a single top-down sweep in which each node's
+// state depends only on its preGotoState and its own symbol, and the sibling
+// state chain is threaded left-to-right. Every node and edge is touched once
+// (the parent computes each child's preGotoState directly, no per-edge pull),
+// giving O(nodes) work with sequential access. scratch, if non-nil, is reused
+// as the worklist backing store to keep the pass allocation-free across calls.
+func (p *Parser) replayParseStates(root *Node, rootPreGoto StateID, visit replayVisit, scratch *[]replayFrame) {
+	if p == nil || root == nil || visit == nil {
+		return
+	}
+	var stack []replayFrame
+	if scratch != nil {
+		stack = (*scratch)[:0]
+	}
+	stack = append(stack, replayFrame{node: root, preGoto: rootPreGoto})
+	for len(stack) > 0 {
+		top := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		n := top.node
+		ps, _ := p.replayAdvance(top.preGoto, n)
+		visit(n, top.preGoto, ps)
+		// Thread the sibling state chain: the first child's preGotoState is
+		// this node's preGotoState (the state exposed below its reduce), and
+		// each subsequent child's preGotoState is the previous child's
+		// parseState. Push children in reverse so the leftmost is processed
+		// first (deterministic pre-order for the differential report).
+		kids := n.children
+		if len(kids) == 0 {
+			continue
+		}
+		if len(kids) == 1 {
+			stack = append(stack, replayFrame{node: kids[0], preGoto: top.preGoto})
+			continue
+		}
+		// Precompute each child's preGotoState left-to-right, then push in
+		// reverse. base indexes the appended child frames.
+		base := len(stack)
+		cursor := top.preGoto
+		for _, c := range kids {
+			stack = append(stack, replayFrame{node: c, preGoto: cursor})
+			cursor, _ = p.replayAdvance(cursor, c)
+		}
+		// Reverse the just-appended frames so pop order is left-to-right.
+		for i, j := base, len(stack)-1; i < j; i, j = i+1, j-1 {
+			stack[i], stack[j] = stack[j], stack[i]
+		}
+	}
+	if scratch != nil {
+		*scratch = stack[:0]
+	}
+}
+
+// NOTE: there is deliberately no "stamp states onto a visible tree" helper.
+// The differential harness (parsestate_replay_diff_test.go) proves that the
+// visible, materialized tree has already lost the information replay needs --
+// hidden-node goto transitions and pre-alias grammar symbols -- so replaying
+// over it reconstructs only ~0.3% of nodes. Admission-mode reconstruction runs
+// over the FULL compact derivation instead (parsestate_replay_compact.go),
+// before hidden elision and aliasing; replayParseStates above is retained as
+// the shared push-shaped traversal used by that differential proof.

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -63,13 +63,38 @@ func setParserCoreReplayParseStatesForTest(on bool) {
 // surviving public nodes (hidden ids are dropped, aliased ids keep the state
 // computed from their real symbol).
 
+// compactReplayFrame is one entry on the explicit worklist used by
+// replayCompactDerivation to avoid deep Go recursion on pathologically deep
+// derivations.
+type compactReplayFrame struct {
+	id      core.SubtreeID
+	preGoto StateID
+}
+
 // compactReplayStates holds the reconstructed per-derivation-node parser
-// states, indexed 1-based by SubtreeID (index 0 unused). The backing slices are
-// pooled across parses so the top-down pass adds no steady-state allocation to
+// states, indexed 1-based by SubtreeID (index 0 unused). The three per-id
+// backing slices AND the traversal worklist (frames) are pooled across parses,
+// so once the pool is warm the top-down pass adds no steady-state allocation to
 // the materialization phase; release() returns them once stamping is done.
 type compactReplayStates struct {
 	parseState   []StateID
 	preGotoState []StateID
+	// psKnown[id] is true only when the top-down replay found an authoritative
+	// shift/goto transition for id's parseState. preKnown[id] additionally
+	// requires that id's preGotoState is authoritative: it is false for extra
+	// (comment) nodes, whose tree position floats away from their live-parse
+	// lex-time stack state, so their inherited preGoto is not reconstructable
+	// even though their parseState is exact. When a flag is false the
+	// corresponding state is NOT written (abstained): get() reports it so the
+	// materializer leaves the node's state at its zero value
+	// ("unknown -> recompute") rather than stamping a known-wrong but trusted
+	// non-zero state (Phase-3 Lane 3 review amendment 1).
+	psKnown  []bool
+	preKnown []bool
+	// frames is the pooled traversal worklist backing store, reused across
+	// parses so the top-down pass is allocation-free once the pool is warm
+	// (Phase-3 Lane 3 review amendment 6).
+	frames []compactReplayFrame
 }
 
 var compactReplayStatePool = sync.Pool{New: func() any { return &compactReplayStates{} }}
@@ -79,12 +104,18 @@ func acquireCompactReplayStates(n int) *compactReplayStates {
 	if cap(s.parseState) < n {
 		s.parseState = make([]StateID, n)
 		s.preGotoState = make([]StateID, n)
+		s.psKnown = make([]bool, n)
+		s.preKnown = make([]bool, n)
 	} else {
 		s.parseState = s.parseState[:n]
 		s.preGotoState = s.preGotoState[:n]
+		s.psKnown = s.psKnown[:n]
+		s.preKnown = s.preKnown[:n]
 		for i := 0; i < n; i++ {
 			s.parseState[i] = 0
 			s.preGotoState[i] = 0
+			s.psKnown[i] = false
+			s.preKnown[i] = false
 		}
 	}
 	return s
@@ -97,11 +128,14 @@ func (s *compactReplayStates) release() {
 	compactReplayStatePool.Put(s)
 }
 
-func (s *compactReplayStates) get(id core.SubtreeID) (pre, ps StateID, ok bool) {
+// get returns the reconstructed states for id and whether each is authoritative.
+// preOk / psOk are independent: an extra leaf has an exact parseState (psOk) but
+// a non-reconstructable, floated preGotoState (preOk=false).
+func (s *compactReplayStates) get(id core.SubtreeID) (pre, ps StateID, preOk, psOk bool) {
 	if s == nil || uint64(id) >= uint64(len(s.parseState)) {
-		return 0, 0, false
+		return 0, 0, false, false
 	}
-	return s.preGotoState[id], s.parseState[id], true
+	return s.preGotoState[id], s.parseState[id], s.preKnown[id], s.psKnown[id]
 }
 
 // replayCompactDerivation reconstructs parser states for every node in the
@@ -117,13 +151,9 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 	states := acquireCompactReplayStates(n)
 	seed := p.replayRootPreGotoState()
 
-	type frame struct {
-		id      core.SubtreeID
-		preGoto StateID
-	}
-	stack := make([]frame, 0, 64)
+	stack := states.frames[:0]
 	for _, root := range roots {
-		stack = append(stack, frame{id: root, preGoto: seed})
+		stack = append(stack, compactReplayFrame{id: root, preGoto: seed})
 	}
 	for len(stack) > 0 {
 		top := stack[len(stack)-1]
@@ -132,17 +162,32 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 		if err != nil {
 			return nil, err
 		}
-		ps, _ := p.replayTransition(top.preGoto, Symbol(view.Symbol), view.Terminal)
-		if uint64(top.id) < uint64(len(states.parseState)) {
-			states.preGotoState[top.id] = top.preGoto
+		ps, ok := p.replayTransition(top.preGoto, Symbol(view.Symbol), view.Terminal)
+		if ok && uint64(top.id) < uint64(len(states.parseState)) {
+			// Record an AUTHORITATIVE parseState: replayTransition found a real
+			// shift/goto for this id from top.preGoto. When ok is false the
+			// transition fell back to top.preGoto (a node whose shape is not a
+			// plain shift/goto of its visible symbol); recording that fallback
+			// would stamp a known-wrong trusted state, so we abstain and leave
+			// the id at its zero "unknown -> recompute" sentinel.
 			states.parseState[top.id] = ps
+			states.psKnown[top.id] = true
+			// The preGotoState is authoritative only for non-extra nodes. Extras
+			// (comments) float to a tree position that does not match their
+			// live-parse stack state, so their inherited preGoto is not
+			// reconstructable; abstain on it (leave 0) while keeping the exact
+			// parseState above (Lane 3 review amendment 1).
+			if !view.Extra {
+				states.preGotoState[top.id] = top.preGoto
+				states.preKnown[top.id] = true
+			}
 		}
 		kids := view.Children
 		if len(kids) == 0 {
 			continue
 		}
 		if len(kids) == 1 {
-			stack = append(stack, frame{id: kids[0], preGoto: top.preGoto})
+			stack = append(stack, compactReplayFrame{id: kids[0], preGoto: top.preGoto})
 			continue
 		}
 		base := len(stack)
@@ -152,7 +197,7 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 			if err != nil {
 				return nil, err
 			}
-			stack = append(stack, frame{id: child, preGoto: cursor})
+			stack = append(stack, compactReplayFrame{id: child, preGoto: cursor})
 			cursor, _ = p.replayTransition(cursor, Symbol(cview.Symbol), cview.Terminal)
 		}
 		// Reverse the just-appended child frames so pop order is left-to-right.
@@ -160,5 +205,7 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 			stack[i], stack[j] = stack[j], stack[i]
 		}
 	}
+	// Retain the (possibly grown) worklist backing store for the next parse.
+	states.frames = stack[:0]
 	return states, nil
 }

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -144,7 +144,7 @@ func (s *compactReplayStates) get(id core.SubtreeID) (pre, ps StateID, preOk, ps
 // exposed below the final reduce). The traversal uses an explicit worklist over
 // SubtreeIDs to avoid deep recursion.
 func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.SubtreeID) (*compactReplayStates, error) {
-	if p == nil || compact == nil {
+	if p == nil || p.language == nil || compact == nil {
 		return nil, errors.New("parser-core phase zero: replay requires parser and core")
 	}
 	n := compact.SubtreeArenaLen() + 1
@@ -160,6 +160,10 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 		stack = stack[:len(stack)-1]
 		view, err := compact.MaterializationView(top.id)
 		if err != nil {
+			// Return the pooled state object before bailing so the pool contract
+			// is honoured (otherwise it is dropped and silently reallocated).
+			states.frames = stack[:0]
+			states.release()
 			return nil, err
 		}
 		ps, ok := p.replayTransition(top.preGoto, Symbol(view.Symbol), view.Terminal)
@@ -195,6 +199,9 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 		for _, child := range kids {
 			cview, err := compact.MaterializationView(child)
 			if err != nil {
+				// Return the pooled state object before bailing (see above).
+				states.frames = stack[:0]
+				states.release()
 				return nil, err
 			}
 			stack = append(stack, compactReplayFrame{id: child, preGoto: cursor})

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -1,0 +1,164 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// parserCoreReplayParseStatesEnabled reports whether the compact route should
+// reconstruct and stamp per-node parser states by table replay. It is gated by
+// GTS_REPLAY_PARSESTATE so the states-free compact route can be A/B'd against
+// the replay-materialized route. The value is latched once for stable A/B runs.
+var (
+	parserCoreReplayParseStatesOnce  int32
+	parserCoreReplayParseStatesValue int32
+)
+
+func parserCoreReplayParseStatesEnabled() bool {
+	if atomic.LoadInt32(&parserCoreReplayParseStatesOnce) == 0 {
+		v := int32(0)
+		switch os.Getenv("GTS_REPLAY_PARSESTATE") {
+		case "1", "true", "on", "yes":
+			v = 1
+		}
+		atomic.StoreInt32(&parserCoreReplayParseStatesValue, v)
+		atomic.StoreInt32(&parserCoreReplayParseStatesOnce, 1)
+	}
+	return atomic.LoadInt32(&parserCoreReplayParseStatesValue) == 1
+}
+
+// setParserCoreReplayParseStatesForTest overrides the gate for differential
+// tests without mutating process environment mid-run.
+func setParserCoreReplayParseStatesForTest(on bool) {
+	v := int32(0)
+	if on {
+		v = 1
+	}
+	atomic.StoreInt32(&parserCoreReplayParseStatesValue, v)
+	atomic.StoreInt32(&parserCoreReplayParseStatesOnce, 1)
+}
+
+// ParseState-by-table-replay over the compact derivation (Phase-3 Lane 2).
+//
+// The visible production tree cannot reconstruct parseState because
+// materialization erases the two things replay needs: hidden-node goto
+// transitions (repeat/supertype aux symbols carry state between visible
+// siblings) and the pre-alias grammar symbol (aliased leaves store the alias,
+// not the terminal that was shifted). The compact derivation retains BOTH --
+// every reduce keeps one record per RHS symbol, including hidden ones, with the
+// real grammar symbol and an authoritative terminal flag -- so replay over the
+// derivation, before hidden elision and aliasing, is exact.
+//
+// The pass is a single push-shaped top-down sweep over the derivation DAG,
+// threading the LR state chain exactly as the parser did: root seeded from
+// InitialState, first child inherits the parent's exposed state, each later
+// child advances from the previous sibling's state. Results are stored per
+// SubtreeID; the postorder materialization then stamps psByID/preByID onto the
+// surviving public nodes (hidden ids are dropped, aliased ids keep the state
+// computed from their real symbol).
+
+// compactReplayStates holds the reconstructed per-derivation-node parser
+// states, indexed 1-based by SubtreeID (index 0 unused). The backing slices are
+// pooled across parses so the top-down pass adds no steady-state allocation to
+// the materialization phase; release() returns them once stamping is done.
+type compactReplayStates struct {
+	parseState   []StateID
+	preGotoState []StateID
+}
+
+var compactReplayStatePool = sync.Pool{New: func() any { return &compactReplayStates{} }}
+
+func acquireCompactReplayStates(n int) *compactReplayStates {
+	s := compactReplayStatePool.Get().(*compactReplayStates)
+	if cap(s.parseState) < n {
+		s.parseState = make([]StateID, n)
+		s.preGotoState = make([]StateID, n)
+	} else {
+		s.parseState = s.parseState[:n]
+		s.preGotoState = s.preGotoState[:n]
+		for i := 0; i < n; i++ {
+			s.parseState[i] = 0
+			s.preGotoState[i] = 0
+		}
+	}
+	return s
+}
+
+func (s *compactReplayStates) release() {
+	if s == nil {
+		return
+	}
+	compactReplayStatePool.Put(s)
+}
+
+func (s *compactReplayStates) get(id core.SubtreeID) (pre, ps StateID, ok bool) {
+	if s == nil || uint64(id) >= uint64(len(s.parseState)) {
+		return 0, 0, false
+	}
+	return s.preGotoState[id], s.parseState[id], true
+}
+
+// replayCompactDerivation reconstructs parser states for every node in the
+// accepted compact derivation rooted at roots. roots are the accepted payload
+// ids in tree order; each is seeded with the parser's InitialState (the state
+// exposed below the final reduce). The traversal uses an explicit worklist over
+// SubtreeIDs to avoid deep recursion.
+func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.SubtreeID) (*compactReplayStates, error) {
+	if p == nil || compact == nil {
+		return nil, errors.New("parser-core phase zero: replay requires parser and core")
+	}
+	n := compact.SubtreeArenaLen() + 1
+	states := acquireCompactReplayStates(n)
+	seed := p.replayRootPreGotoState()
+
+	type frame struct {
+		id      core.SubtreeID
+		preGoto StateID
+	}
+	stack := make([]frame, 0, 64)
+	for _, root := range roots {
+		stack = append(stack, frame{id: root, preGoto: seed})
+	}
+	for len(stack) > 0 {
+		top := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		view, err := compact.MaterializationView(top.id)
+		if err != nil {
+			return nil, err
+		}
+		ps, _ := p.replayTransition(top.preGoto, Symbol(view.Symbol), view.Terminal)
+		if uint64(top.id) < uint64(len(states.parseState)) {
+			states.preGotoState[top.id] = top.preGoto
+			states.parseState[top.id] = ps
+		}
+		kids := view.Children
+		if len(kids) == 0 {
+			continue
+		}
+		if len(kids) == 1 {
+			stack = append(stack, frame{id: kids[0], preGoto: top.preGoto})
+			continue
+		}
+		base := len(stack)
+		cursor := top.preGoto
+		for _, child := range kids {
+			cview, err := compact.MaterializationView(child)
+			if err != nil {
+				return nil, err
+			}
+			stack = append(stack, frame{id: child, preGoto: cursor})
+			cursor, _ = p.replayTransition(cursor, Symbol(cview.Symbol), cview.Terminal)
+		}
+		// Reverse the just-appended child frames so pop order is left-to-right.
+		for i, j := base, len(stack)-1; i < j; i, j = i+1, j-1 {
+			stack[i], stack[j] = stack[j], stack[i]
+		}
+	}
+	return states, nil
+}

--- a/parsestate_replay_compact_diff_test.go
+++ b/parsestate_replay_compact_diff_test.go
@@ -1,0 +1,215 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// TestParseStateReplayCompactDifferential is the go/no-go exactness proof for
+// Phase-3 Lane 2. For each canonical Go fixture it builds the tree TWICE --
+// once through production (which records parseState/preGotoState per node) and
+// once through the compact route with table-replay materialization -- and
+// compares the two states on every node in lockstep. The compact and
+// production trees are already proven structurally byte-identical (deep-tree
+// digest), so any state divergence is a real replay-model gap.
+//
+// This is the artifact the visible-tree differential cannot be: replay runs
+// over the FULL derivation (real grammar symbols + hidden nodes), so aliasing
+// and hidden-node elision -- the two walls the visible tree hit -- are resolved
+// before the states are stamped.
+func TestParseStateReplayCompactDifferential(t *testing.T) {
+	setParserCoreReplayParseStatesForTest(true)
+	defer setParserCoreReplayParseStatesForTest(false)
+
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang := runner.lang
+
+	type classStat struct{ total, mismatch, preMismatch, psMismatch int }
+	corpusClasses := map[string]*classStat{}
+	var corpusNodes, corpusMismatch int
+
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		t.Run(row.id, func(t *testing.T) {
+			fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+			requireDiagnosticParserCoreCanonicalFixtureIdentity(t, fixture, row)
+
+			compactTree, err := runner.parse(fixture.Source)
+			if err != nil {
+				t.Fatalf("compact parse %s: %v", row.id, err)
+			}
+			defer compactTree.Release()
+
+			production, err := NewParser(lang).Parse(fixture.Source)
+			if err != nil {
+				t.Fatalf("production parse %s: %v", row.id, err)
+			}
+			defer production.Release()
+
+			// Structural identity guard: if this fails the lockstep walk is
+			// meaningless, so assert it up front.
+			parserCoreWarmRequireDeepEqual(t, compactTree, production, lang)
+
+			classes := map[string]*classStat{}
+			var nodes, mismatch, preMismatch, psMismatch int
+			var samples []string
+
+			type pair struct{ compact, prod *Node }
+			stack := []pair{{compact: compactTree.root, prod: production.root}}
+			for len(stack) != 0 {
+				last := len(stack) - 1
+				cur := stack[last]
+				stack = stack[:last]
+				a, b := cur.compact, cur.prod
+				if a == nil || b == nil {
+					continue
+				}
+				nodes++
+				class := replayCompactNodeClass(b)
+				st := classes[class]
+				if st == nil {
+					st = &classStat{}
+					classes[class] = st
+				}
+				st.total++
+				preBad := a.preGotoState != b.preGotoState
+				psBad := a.parseState != b.parseState
+				isTerminal := len(b.children) == 0
+				// Invariant 1: parseState is EXACTLY table-derivable for every
+				// terminal (shift reconstruction is exact). A terminal
+				// parseState mismatch would break the go/no-go claim.
+				if psBad && isTerminal {
+					t.Errorf("%s: terminal parseState not table-derivable: %s %d..%d compact=%d prod=%d",
+						row.id, b.Type(lang), b.StartByte(), b.EndByte(), a.parseState, b.parseState)
+				}
+				// Invariant 2: preGotoState is EXACTLY reconstructable for every
+				// NON-extra node. Extras float to a tree position that does not
+				// match their live-parse lex-time stack state, so only their
+				// preGotoState may diverge (their parseState stays exact).
+				if preBad && !b.isExtra() {
+					t.Errorf("%s: non-extra preGotoState not reconstructable: %s %d..%d compact=%d prod=%d",
+						row.id, b.Type(lang), b.StartByte(), b.EndByte(), a.preGotoState, b.preGotoState)
+				}
+				if preBad || psBad {
+					mismatch++
+					st.mismatch++
+					if preBad {
+						preMismatch++
+						st.preMismatch++
+					}
+					if psBad {
+						psMismatch++
+						st.psMismatch++
+					}
+					if len(samples) < 20 {
+						samples = append(samples, fmt.Sprintf(
+							"%s (%s) %d..%d pre compact=%d prod=%d ps compact=%d prod=%d",
+							b.Type(lang), class, b.StartByte(), b.EndByte(),
+							a.preGotoState, b.preGotoState, a.parseState, b.parseState))
+					}
+				}
+				for i := a.ChildCount() - 1; i >= 0; i-- {
+					stack = append(stack, pair{compact: a.Child(i), prod: b.Child(i)})
+				}
+			}
+
+			pct := 100.0
+			if nodes > 0 {
+				pct = 100.0 * float64(nodes-mismatch) / float64(nodes)
+			}
+			t.Logf("%s: nodes=%d exact=%d (%.4f%%) mismatched=%d (preGoto=%d parseState=%d)",
+				row.id, nodes, nodes-mismatch, pct, mismatch, preMismatch, psMismatch)
+			for _, class := range sortedClassKeys(classes) {
+				st := classes[class]
+				if st.mismatch == 0 {
+					continue
+				}
+				t.Logf("  class %-26s total=%-6d mismatched=%-6d (pre=%d ps=%d)",
+					class, st.total, st.mismatch, st.preMismatch, st.psMismatch)
+			}
+			for i, s := range samples {
+				t.Logf("  sample[%d] %s", i, s)
+			}
+
+			corpusNodes += nodes
+			corpusMismatch += mismatch
+			for class, st := range classes {
+				agg := corpusClasses[class]
+				if agg == nil {
+					agg = &classStat{}
+					corpusClasses[class] = agg
+				}
+				agg.total += st.total
+				agg.mismatch += st.mismatch
+				agg.preMismatch += st.preMismatch
+				agg.psMismatch += st.psMismatch
+			}
+		})
+	}
+
+	pct := 100.0
+	if corpusNodes > 0 {
+		pct = 100.0 * float64(corpusNodes-corpusMismatch) / float64(corpusNodes)
+	}
+	t.Logf("COMPACT-REPLAY CORPUS: nodes=%d exact=%d (%.6f%%) mismatched=%d", corpusNodes, corpusNodes-corpusMismatch, pct, corpusMismatch)
+	for _, class := range sortedClassKeys(corpusClasses) {
+		st := corpusClasses[class]
+		if st.mismatch == 0 {
+			continue
+		}
+		t.Logf("  %-28s total=%-7d mismatched=%-7d (pre=%d ps=%d)", class, st.total, st.mismatch, st.preMismatch, st.psMismatch)
+	}
+
+	// Corpus-level go/no-go floor. Per-node invariants above already fail the
+	// test on any terminal parseState or non-extra preGoto divergence; this
+	// bounds the two documented residual classes so a regression that widens
+	// them is caught:
+	//   - preGoto residual == extra (comment) leaves only;
+	//   - parseState residual == the collapse-vs-lookahead divergence, which is
+	//     confined to internal nodes in grammargen_lr today.
+	if corpusNodes == 0 {
+		t.Fatal("compact-replay differential visited no nodes")
+	}
+	if pct < 99.0 {
+		t.Fatalf("compact-replay corpus exactness regressed below 99%%: %.4f%% (mismatched=%d)", pct, corpusMismatch)
+	}
+}
+
+func replayCompactNodeClass(n *Node) string {
+	kind := "internal"
+	if len(n.children) == 0 {
+		kind = "leaf"
+	}
+	var mods string
+	if n.symbol == errorSymbol {
+		mods += "+error"
+	}
+	if n.isMissing() {
+		mods += "+missing"
+	}
+	if n.isExtra() {
+		mods += "+extra"
+	}
+	if n.isExternalScannerToken() {
+		mods += "+extscan"
+	}
+	if n.hasError() && n.symbol != errorSymbol {
+		mods += "+haserr"
+	}
+	return kind + mods
+}
+
+func sortedClassKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/parsestate_replay_compact_diff_test.go
+++ b/parsestate_replay_compact_diff_test.go
@@ -30,7 +30,10 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 	}
 	lang := runner.lang
 
-	type classStat struct{ total, mismatch, preMismatch, psMismatch int }
+	type classStat struct {
+		total, mismatch, preMismatch, psMismatch int
+		preAbstain, psAbstain                    int
+	}
 	corpusClasses := map[string]*classStat{}
 	var corpusNodes, corpusMismatch int
 
@@ -57,7 +60,7 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 			parserCoreWarmRequireDeepEqual(t, compactTree, production, lang)
 
 			classes := map[string]*classStat{}
-			var nodes, mismatch, preMismatch, psMismatch int
+			var nodes, mismatch, preMismatch, psMismatch, preAbstain, psAbstain int
 			var samples []string
 
 			type pair struct{ compact, prod *Node }
@@ -78,23 +81,39 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 					classes[class] = st
 				}
 				st.total++
-				preBad := a.preGotoState != b.preGotoState
-				psBad := a.parseState != b.parseState
+				// A compact state of 0 is the deliberate "unknown -> recompute"
+				// abstention sentinel (parsestate_replay_compact.go): the replay
+				// declined to reconstruct it rather than stamp a known-wrong
+				// trusted value. It is NOT a miss. Only a NON-ZERO compact state
+				// that disagrees with production is a real reconstruction miss.
+				preAbst := a.preGotoState == 0 && b.preGotoState != 0
+				psAbst := a.parseState == 0 && b.parseState != 0
+				preBad := a.preGotoState != 0 && a.preGotoState != b.preGotoState
+				psBad := a.parseState != 0 && a.parseState != b.parseState
 				isTerminal := len(b.children) == 0
-				// Invariant 1: parseState is EXACTLY table-derivable for every
-				// terminal (shift reconstruction is exact). A terminal
-				// parseState mismatch would break the go/no-go claim.
+				// Invariant 1: any NON-abstained terminal parseState is EXACTLY
+				// table-derivable (shift reconstruction is exact). A stamped,
+				// non-zero terminal parseState that disagrees breaks the go/no-go
+				// claim.
 				if psBad && isTerminal {
 					t.Errorf("%s: terminal parseState not table-derivable: %s %d..%d compact=%d prod=%d",
 						row.id, b.Type(lang), b.StartByte(), b.EndByte(), a.parseState, b.parseState)
 				}
-				// Invariant 2: preGotoState is EXACTLY reconstructable for every
-				// NON-extra node. Extras float to a tree position that does not
-				// match their live-parse lex-time stack state, so only their
-				// preGotoState may diverge (their parseState stays exact).
-				if preBad && !b.isExtra() {
-					t.Errorf("%s: non-extra preGotoState not reconstructable: %s %d..%d compact=%d prod=%d",
-						row.id, b.Type(lang), b.StartByte(), b.EndByte(), a.preGotoState, b.preGotoState)
+				// Invariant 2: any NON-abstained preGotoState is EXACTLY
+				// reconstructable. Extras abstain (their floated preGoto is left
+				// 0), so a stamped, non-zero preGoto that disagrees is a real
+				// gap regardless of node class.
+				if preBad {
+					t.Errorf("%s: stamped preGotoState not reconstructable: %s %d..%d compact=%d prod=%d extra=%v",
+						row.id, b.Type(lang), b.StartByte(), b.EndByte(), a.preGotoState, b.preGotoState, b.isExtra())
+				}
+				if preAbst {
+					preAbstain++
+					st.preAbstain++
+				}
+				if psAbst {
+					psAbstain++
+					st.psAbstain++
 				}
 				if preBad || psBad {
 					mismatch++
@@ -123,18 +142,36 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 			if nodes > 0 {
 				pct = 100.0 * float64(nodes-mismatch) / float64(nodes)
 			}
-			t.Logf("%s: nodes=%d exact=%d (%.4f%%) mismatched=%d (preGoto=%d parseState=%d)",
-				row.id, nodes, nodes-mismatch, pct, mismatch, preMismatch, psMismatch)
+			t.Logf("%s: nodes=%d exact=%d (%.4f%%) miss=%d (preGoto=%d parseState=%d) abstained(pre=%d ps=%d)",
+				row.id, nodes, nodes-mismatch, pct, mismatch, preMismatch, psMismatch, preAbstain, psAbstain)
 			for _, class := range sortedClassKeys(classes) {
 				st := classes[class]
-				if st.mismatch == 0 {
+				if st.mismatch == 0 && st.preAbstain == 0 && st.psAbstain == 0 {
 					continue
 				}
-				t.Logf("  class %-26s total=%-6d mismatched=%-6d (pre=%d ps=%d)",
-					class, st.total, st.mismatch, st.preMismatch, st.psMismatch)
+				t.Logf("  class %-26s total=%-6d miss=%-6d (pre=%d ps=%d) abstained(pre=%d ps=%d)",
+					class, st.total, st.mismatch, st.preMismatch, st.psMismatch, st.preAbstain, st.psAbstain)
 			}
 			for i, s := range samples {
 				t.Logf("  sample[%d] %s", i, s)
+			}
+
+			// Per-fixture hard cap: the ONLY authorised parseState wrong-value
+			// residual is the collapse-vs-forest-selection class in grammargen_lr
+			// (internal nodes under a hidden unary wrapper where production's
+			// accepted derivation kept the inner visible node's own reduce state
+			// via its deferred/pendingParent materialisation, an artefact with no
+			// correlate in the compact derivation -- see the file header). Every
+			// other fixture must have zero parseState misses, and preGoto misses
+			// must be zero everywhere (extras abstain).
+			if preMismatch != 0 {
+				t.Errorf("%s: %d preGoto wrong-value misses (want 0; extras must abstain)", row.id, preMismatch)
+			}
+			if row.id != "grammargen_lr" && psMismatch != 0 {
+				t.Errorf("%s: %d parseState wrong-value misses (want 0 outside grammargen_lr)", row.id, psMismatch)
+			}
+			if row.id == "grammargen_lr" && psMismatch > compactReplayCollapseClassCap {
+				t.Errorf("grammargen_lr collapse-class parseState misses grew: %d > cap %d", psMismatch, compactReplayCollapseClassCap)
 			}
 
 			corpusNodes += nodes
@@ -149,6 +186,8 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 				agg.mismatch += st.mismatch
 				agg.preMismatch += st.preMismatch
 				agg.psMismatch += st.psMismatch
+				agg.preAbstain += st.preAbstain
+				agg.psAbstain += st.psAbstain
 			}
 		})
 	}
@@ -157,29 +196,62 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 	if corpusNodes > 0 {
 		pct = 100.0 * float64(corpusNodes-corpusMismatch) / float64(corpusNodes)
 	}
-	t.Logf("COMPACT-REPLAY CORPUS: nodes=%d exact=%d (%.6f%%) mismatched=%d", corpusNodes, corpusNodes-corpusMismatch, pct, corpusMismatch)
+	var corpusPre, corpusPs, corpusPreAbst, corpusPsAbst int
+	for _, st := range corpusClasses {
+		corpusPre += st.preMismatch
+		corpusPs += st.psMismatch
+		corpusPreAbst += st.preAbstain
+		corpusPsAbst += st.psAbstain
+	}
+	t.Logf("COMPACT-REPLAY CORPUS: nodes=%d exact=%d (%.6f%%) miss=%d (preGoto=%d parseState=%d) abstained(pre=%d ps=%d)",
+		corpusNodes, corpusNodes-corpusMismatch, pct, corpusMismatch, corpusPre, corpusPs, corpusPreAbst, corpusPsAbst)
 	for _, class := range sortedClassKeys(corpusClasses) {
 		st := corpusClasses[class]
-		if st.mismatch == 0 {
+		if st.mismatch == 0 && st.preAbstain == 0 && st.psAbstain == 0 {
 			continue
 		}
-		t.Logf("  %-28s total=%-7d mismatched=%-7d (pre=%d ps=%d)", class, st.total, st.mismatch, st.preMismatch, st.psMismatch)
+		t.Logf("  %-28s total=%-7d miss=%-7d (pre=%d ps=%d) abstained(pre=%d ps=%d)",
+			class, st.total, st.mismatch, st.preMismatch, st.psMismatch, st.preAbstain, st.psAbstain)
 	}
 
-	// Corpus-level go/no-go floor. Per-node invariants above already fail the
-	// test on any terminal parseState or non-extra preGoto divergence; this
-	// bounds the two documented residual classes so a regression that widens
-	// them is caught:
-	//   - preGoto residual == extra (comment) leaves only;
-	//   - parseState residual == the collapse-vs-lookahead divergence, which is
-	//     confined to internal nodes in grammargen_lr today.
 	if corpusNodes == 0 {
 		t.Fatal("compact-replay differential visited no nodes")
+	}
+	// Class-granular go/no-go (Lane 3 review amendment 5). The aggregate floor
+	// alone let either residual class grow ~4x unnoticed; assert both directly.
+	//   - preGoto wrong-value misses == 0 corpus-wide: every non-reconstructable
+	//     preGoto (extras) abstains to the 0 sentinel instead of a wrong value.
+	//   - parseState wrong-value misses are bounded to the documented collapse
+	//     class cap and confined to grammargen_lr (asserted per-fixture above).
+	if corpusPre != 0 {
+		t.Fatalf("compact-replay preGoto wrong-value misses must be 0 (extras abstain); got %d", corpusPre)
+	}
+	if corpusPs > compactReplayCollapseClassCap {
+		t.Fatalf("compact-replay parseState collapse-class misses grew beyond cap %d: got %d", compactReplayCollapseClassCap, corpusPs)
 	}
 	if pct < 99.0 {
 		t.Fatalf("compact-replay corpus exactness regressed below 99%%: %.4f%% (mismatched=%d)", pct, corpusMismatch)
 	}
 }
+
+// compactReplayCollapseClassCap bounds the sole authorised parseState
+// wrong-value residual: internal nodes under a hidden unary wrapper chain in
+// grammargen_lr where production's ACCEPTED derivation retained the inner
+// visible node's own reduce state instead of the collapsed outer wrapper state.
+//
+// This is NOT a lookahead-gated decision (empirically the reduce fires under the
+// same _automatic_semicolon lookahead whether production keeps inner or outer),
+// and it is NOT determined by any property of the compact derivation: the same
+// (visible symbol, wrapper symbol, inner/outer state, productionID, fields,
+// alias, fragile, structural position, source lookahead) tuple is observed
+// keeping inner in one occurrence and collapsing to outer in another
+// (return_statement, type_declaration, var_declaration, const_declaration all
+// split both ways with identical structure). It is an artefact of production's
+// GLR deferred / pendingParent materialisation and forest-selection order. The
+// compact route builds one canonical full-wrapper derivation and stamps the
+// principled collapsed (outer) state; the residual is characterised, bounded
+// here, and carried as an admission caveat rather than masked by abstention.
+const compactReplayCollapseClassCap = 251
 
 func replayCompactNodeClass(n *Node) string {
 	kind := "internal"

--- a/parsestate_replay_compact_diff_test.go
+++ b/parsestate_replay_compact_diff_test.go
@@ -229,8 +229,10 @@ func TestParseStateReplayCompactDifferential(t *testing.T) {
 	if corpusPs > compactReplayCollapseClassCap {
 		t.Fatalf("compact-replay parseState collapse-class misses grew beyond cap %d: got %d", compactReplayCollapseClassCap, corpusPs)
 	}
-	if pct < 99.0 {
-		t.Fatalf("compact-replay corpus exactness regressed below 99%%: %.4f%% (mismatched=%d)", pct, corpusMismatch)
+	// The class caps above carry the go/no-go; this floor is a coarse backstop
+	// kept just under the measured 99.714% so it cannot silently trail reality.
+	if pct < 99.7 {
+		t.Fatalf("compact-replay corpus exactness regressed below 99.7%%: %.4f%% (mismatched=%d)", pct, corpusMismatch)
 	}
 }
 

--- a/parsestate_replay_diff_test.go
+++ b/parsestate_replay_diff_test.go
@@ -1,0 +1,273 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+// TestParseStateReplayDifferential is the go/no-go proof for Phase-3 Lane 2:
+// it parses a corpus both ways -- production (which records parseState /
+// preGotoState per node) and replay (which reconstructs them from the LR
+// goto/shift tables + tree shape) -- and reports, per node class, how many
+// nodes the replay model reproduces exactly. Any mismatch localizes a node
+// class whose state is not a plain table transition of its visible symbol.
+//
+// This test is diagnostic-first: it never fails on mismatch, it PRINTS the
+// full breakdown so the exactness of the replay model is measured on real
+// trees. A separate gate test (TestParseStateReplayExactClasses) asserts the
+// classes that must be exact.
+func TestParseStateReplayDifferential(t *testing.T) {
+	for _, c := range replayCorpus(t) {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			parser := gotreesitter.NewParser(c.lang)
+			tree, err := parser.Parse(c.source)
+			if err != nil {
+				t.Fatalf("parse %s: %v", c.name, err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root == nil {
+				t.Fatalf("nil root for %s", c.name)
+			}
+			rep := gotreesitter.ReplayDiffTree(parser, root, 40)
+
+			pct := 100.0
+			if rep.TotalNodes > 0 {
+				pct = 100.0 * float64(rep.TotalNodes-rep.Mismatched) / float64(rep.TotalNodes)
+			}
+			t.Logf("%s: nodes=%d exact=%d (%.4f%%) mismatched=%d (preGoto=%d parseState=%d) rootPreGoto rec=%d seed=%d",
+				c.name, rep.TotalNodes, rep.TotalNodes-rep.Mismatched, pct,
+				rep.Mismatched, rep.PreGotoMismatched, rep.ParseStateMismatch,
+				rep.RootPreGotoRecorded, rep.RootPreGotoSeed)
+
+			for _, st := range rep.SortedClassStats() {
+				if st.Mismatched == 0 {
+					continue
+				}
+				t.Logf("  class %-28s total=%-6d mismatched=%-6d (%.2f%%)",
+					st.Class, st.Total, st.Mismatched,
+					100.0*float64(st.Mismatched)/float64(st.Total))
+			}
+			for i, s := range rep.Samples {
+				if i >= 12 {
+					t.Logf("  ... (%d more samples)", len(rep.Samples)-12)
+					break
+				}
+				t.Logf("  sample[%d] %s (%s) depth=%d pre rec=%d rep=%d ps rec=%d rep=%d",
+					i, s.SymbolName, s.Class, s.Depth,
+					s.PreGotoRec, s.PreGotoReplay, s.ParseStateRec, s.ParseStateRep)
+			}
+		})
+	}
+}
+
+// TestParseStateReplayCorpusSummary prints one aggregate line across the whole
+// corpus so the go/no-go signal is a single readable number.
+func TestParseStateReplayCorpusSummary(t *testing.T) {
+	var totalNodes, totalMismatch int
+	classAgg := map[string]*gotreesitter.ReplayClassStat{}
+	for _, c := range replayCorpus(t) {
+		parser := gotreesitter.NewParser(c.lang)
+		tree, err := parser.Parse(c.source)
+		if err != nil {
+			t.Fatalf("parse %s: %v", c.name, err)
+		}
+		rep := gotreesitter.ReplayDiffTree(parser, tree.RootNode(), 0)
+		tree.Release()
+		totalNodes += rep.TotalNodes
+		totalMismatch += rep.Mismatched
+		for _, st := range rep.SortedClassStats() {
+			agg := classAgg[st.Class]
+			if agg == nil {
+				agg = &gotreesitter.ReplayClassStat{Class: st.Class}
+				classAgg[st.Class] = agg
+			}
+			agg.Total += st.Total
+			agg.Mismatched += st.Mismatched
+		}
+	}
+	pct := 100.0
+	if totalNodes > 0 {
+		pct = 100.0 * float64(totalNodes-totalMismatch) / float64(totalNodes)
+	}
+	t.Logf("CORPUS: nodes=%d exact=%d (%.4f%%) mismatched=%d", totalNodes, totalNodes-totalMismatch, pct, totalMismatch)
+	keys := make([]string, 0, len(classAgg))
+	for k := range classAgg {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return classAgg[keys[i]].Mismatched > classAgg[keys[j]].Mismatched
+	})
+	for _, k := range keys {
+		st := classAgg[k]
+		if st.Total == 0 {
+			continue
+		}
+		t.Logf("  %-30s total=%-7d mismatched=%-7d (%.4f%%)", k, st.Total, st.Mismatched,
+			100.0*float64(st.Mismatched)/float64(st.Total))
+	}
+}
+
+type replayCase struct {
+	name   string
+	lang   *gotreesitter.Language
+	source []byte
+}
+
+func replayCorpus(t *testing.T) []replayCase {
+	t.Helper()
+	cases := []replayCase{
+		{name: "js/basic", lang: grammars.JavascriptLanguage(), source: []byte(jsReplaySource)},
+		{name: "css/basic", lang: grammars.CssLanguage(), source: []byte(cssReplaySource)},
+		{name: "python/basic", lang: grammars.PythonLanguage(), source: []byte(pyReplaySource)},
+		{name: "typescript/basic", lang: grammars.TypescriptLanguage(), source: []byte(tsReplaySource)},
+		{name: "go/basic", lang: grammars.GoLanguage(), source: []byte(goReplaySource)},
+	}
+	// The four campaign fixtures (real Go source).
+	loaded, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		t.Fatalf("load fixtures: %v", err)
+	}
+	goLang := grammars.GoLanguage()
+	for _, lf := range loaded {
+		cases = append(cases, replayCase{
+			name:   fmt.Sprintf("fixture/%s", lf.Fixture.ID),
+			lang:   goLang,
+			source: lf.Source,
+		})
+	}
+	return cases
+}
+
+const goReplaySource = `package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Shape interface {
+	Area() float64
+}
+
+type Rect struct {
+	W, H float64
+}
+
+func (r Rect) Area() float64 { return r.W * r.H }
+
+func Map[T any, U any](xs []T, f func(T) U) []U {
+	out := make([]U, 0, len(xs))
+	for _, x := range xs {
+		out = append(out, f(x))
+	}
+	return out
+}
+
+func main() {
+	shapes := []Shape{Rect{W: 3, H: 4}}
+	for i, s := range shapes {
+		fmt.Printf("%d: %.2f\n", i, s.Area())
+	}
+	_ = strings.ToUpper("hi")
+	switch x := any(1).(type) {
+	case int:
+		_ = x
+	default:
+	}
+}
+`
+
+const jsReplaySource = `const add = (a, b) => a + b;
+
+class Point {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+  norm() {
+    return Math.sqrt(this.x ** 2 + this.y ** 2);
+  }
+}
+
+async function main() {
+  const p = new Point(3, 4);
+  const xs = [1, 2, 3].map((n) => n * 2).filter((n) => n > 2);
+  for (const x of xs) {
+    console.log(x, add(x, 1));
+  }
+  await Promise.resolve(p.norm());
+}
+
+main();
+`
+
+const cssReplaySource = `:root {
+  --main-color: #3366ff;
+}
+
+.container > .item:nth-child(2n+1) {
+  color: var(--main-color);
+  margin: 0 auto;
+  padding: 1em 2em;
+}
+
+@media (max-width: 600px) {
+  .container {
+    display: flex;
+    flex-direction: column;
+  }
+}
+`
+
+const pyReplaySource = `import os
+from typing import List, Optional
+
+
+class Node:
+    def __init__(self, value: int, children: Optional[List["Node"]] = None):
+        self.value = value
+        self.children = children or []
+
+    def total(self) -> int:
+        return self.value + sum(c.total() for c in self.children)
+
+
+def build(depth: int) -> Node:
+    if depth == 0:
+        return Node(1)
+    return Node(depth, [build(depth - 1) for _ in range(2)])
+
+
+if __name__ == "__main__":
+    root = build(3)
+    print(root.total(), os.getpid())
+`
+
+const tsReplaySource = `interface Shape {
+  area(): number;
+}
+
+type Maybe<T> = T | null;
+
+class Circle implements Shape {
+  constructor(private readonly r: number) {}
+  area(): number {
+    return Math.PI * this.r ** 2;
+  }
+}
+
+function firstArea(shapes: Shape[]): Maybe<number> {
+  return shapes.length > 0 ? shapes[0].area() : null;
+}
+
+const shapes: Shape[] = [new Circle(2), new Circle(3)];
+const total = shapes.reduce((acc: number, s: Shape) => acc + s.area(), 0);
+console.log(firstArea(shapes), total);
+`

--- a/parsestate_replay_diff_test.go
+++ b/parsestate_replay_diff_test.go
@@ -18,9 +18,12 @@ import (
 // class whose state is not a plain table transition of its visible symbol.
 //
 // This test is diagnostic-first: it never fails on mismatch, it PRINTS the
-// full breakdown so the exactness of the replay model is measured on real
-// trees. A separate gate test (TestParseStateReplayExactClasses) asserts the
-// classes that must be exact.
+// full breakdown so the exactness of the visible-tree replay model is measured
+// on real trees (it is only ~0.30% exact -- the visible tree has lost the
+// hidden-node gotos and pre-alias symbols replay needs). The authoritative
+// go/no-go gate runs over the FULL compact derivation instead and asserts the
+// classes that must be exact: TestParseStateReplayCompactDifferential
+// (parsestate_replay_compact_diff_test.go).
 func TestParseStateReplayDifferential(t *testing.T) {
 	for _, c := range replayCorpus(t) {
 		c := c

--- a/parsestate_replay_resync_test.go
+++ b/parsestate_replay_resync_test.go
@@ -1,0 +1,78 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// TestParseStateReplayResync isolates the two error sources: whether
+// advance(recordedPreGoto, node) reproduces parseState exactly (goto/shift
+// model), and whether the sibling preGoto chain holds. If the first is ~100%
+// and the second is <100%, the sole obstacle to visible-tree replay is
+// hidden-node goto transitions (Lane 3 coupling), not the transition model.
+func TestParseStateReplayResync(t *testing.T) {
+	var totNodes, totPS, totFC, totFCok, totSC, totSCok int
+	classAgg := map[string]*gotreesitter.ReplayClassStat{}
+	for _, c := range replayCorpus(t) {
+		p := gotreesitter.NewParser(c.lang)
+		tree, err := p.Parse(c.source)
+		if err != nil {
+			t.Fatalf("parse %s: %v", c.name, err)
+		}
+		rep := gotreesitter.ReplayDiffResync(p, tree.RootNode())
+		tree.Release()
+		totNodes += rep.TotalNodes
+		totPS += rep.ParseStateExact
+		totFC += rep.FirstChildTotal
+		totFCok += rep.FirstChildPreExact
+		totSC += rep.SiblingChainTotal
+		totSCok += rep.SiblingChainExact
+		for _, st := range rep.SortedClassStats() {
+			agg := classAgg[st.Class]
+			if agg == nil {
+				agg = &gotreesitter.ReplayClassStat{Class: st.Class}
+				classAgg[st.Class] = agg
+			}
+			agg.Total += st.Total
+			agg.Mismatched += st.Mismatched
+		}
+	}
+	psPct := 100.0 * float64(totPS) / float64(max1(totNodes))
+	fcPct := 100.0 * float64(totFCok) / float64(max1(totFC))
+	scPct := 100.0 * float64(totSCok) / float64(max1(totSC))
+	t.Logf("RESYNC: nodes=%d parseState-exact-given-recorded-preGoto=%d (%.4f%%)", totNodes, totPS, psPct)
+	t.Logf("  first-child preGoto == parent preGoto: %d/%d (%.4f%%)", totFCok, totFC, fcPct)
+	t.Logf("  sibling chain preGoto == prev advance:  %d/%d (%.4f%%)", totSCok, totSC, scPct)
+	t.Logf("  (a low sibling-chain %% with ~100%% parseState-exact proves hidden-node goto is the only gap)")
+	for _, k := range sortedKeysByMismatch(classAgg) {
+		st := classAgg[k]
+		if st.Mismatched == 0 {
+			continue
+		}
+		t.Logf("  parseState-inexact class %-26s total=%-7d inexact=%-7d (%.4f%%)", k, st.Total, st.Mismatched,
+			100.0*float64(st.Mismatched)/float64(st.Total))
+	}
+}
+
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+func sortedKeysByMismatch(m map[string]*gotreesitter.ReplayClassStat) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if m[keys[j]].Mismatched > m[keys[i]].Mismatched {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+	return keys
+}

--- a/parsestate_reuse_bar_test.go
+++ b/parsestate_reuse_bar_test.go
@@ -1,0 +1,79 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestCompactMaterializedTreeBarsIncrementalReuse seals Phase-3 Lane 3 review
+// amendment 2: a tree built by the compact route carries table-REPLAYED (not
+// live-recorded) parser states and no scanner checkpoints, so ParseIncremental
+// over it must fall all the way back to a fresh full parse -- it must NOT reuse
+// any node, including via the token-invariant leaf fast path that a
+// forestFastPath disabled tree would still take.
+func TestCompactMaterializedTreeBarsIncrementalReuse(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang := runner.lang
+
+	src := []byte("package p\n\nvar x = 1\n")
+	treeA, err := runner.parse(src)
+	if err != nil {
+		t.Fatalf("compact parse: %v", err)
+	}
+	defer treeA.Release()
+
+	if !treeA.compactMaterialized {
+		t.Fatal("compact tree is missing the compactMaterialized provenance flag")
+	}
+	if !oldTreeDisablesIncrementalReuse(treeA) {
+		t.Fatal("compact tree must disable incremental reuse")
+	}
+
+	// Same-length, token-invariant edit ('1' -> '2'): a forestFastPath disabled
+	// Go tree WOULD reuse this via the token-invariant leaf path. The compact
+	// tree must refuse it.
+	pos := bytes.IndexByte(src, '1')
+	if pos < 0 {
+		t.Fatal("fixture invariant: expected a '1' digit to edit")
+	}
+	newSrc := []byte("package p\n\nvar x = 2\n")
+	col := uint32(pos - bytes.LastIndexByte(src[:pos], '\n') - 1)
+	edit := InputEdit{
+		StartByte: uint32(pos), OldEndByte: uint32(pos + 1), NewEndByte: uint32(pos + 1),
+		StartPoint:  Point{Row: 2, Column: col},
+		OldEndPoint: Point{Row: 2, Column: col + 1},
+		NewEndPoint: Point{Row: 2, Column: col + 1},
+	}
+	treeA.Edit(edit)
+
+	p := NewParser(lang)
+	// Direct assertion on the reuse gate: it refuses the compact tree.
+	if reused, ok := p.tryTokenInvariantReuseForDisabledOldTree(newSrc, treeA, nil); ok || reused != nil {
+		if reused != nil {
+			reused.Release()
+		}
+		t.Fatal("compact tree was reused via the token-invariant leaf path; reuse bar not enforced")
+	}
+
+	// End-to-end: ParseIncremental over the compact tree yields a tree identical
+	// to a fresh parse of the edited source (the fresh-parse fallback fired).
+	got, err := p.ParseIncremental(newSrc, treeA)
+	if err != nil {
+		t.Fatalf("ParseIncremental over compact tree: %v", err)
+	}
+	defer got.Release()
+	if got == treeA {
+		t.Fatal("ParseIncremental returned the compact old tree unchanged for a real edit")
+	}
+	want, err := NewParser(lang).Parse(newSrc)
+	if err != nil {
+		t.Fatalf("fresh Parse of edited source: %v", err)
+	}
+	defer want.Release()
+	parserCoreWarmRequireDeepEqual(t, got, want, lang)
+}

--- a/parsestate_reuse_bar_test.go
+++ b/parsestate_reuse_bar_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 // TestCompactMaterializedTreeBarsIncrementalReuse seals Phase-3 Lane 3 review
-// amendment 2: a tree built by the compact route carries table-REPLAYED (not
-// live-recorded) parser states and no scanner checkpoints, so ParseIncremental
-// over it must fall all the way back to a fresh full parse -- it must NOT reuse
-// any node, including via the token-invariant leaf fast path that a
-// forestFastPath disabled tree would still take.
+// amendment 2 (and the follow-up review's reuse-bar holes): a tree built by the
+// compact route carries table-REPLAYED (not live-recorded) parser states and no
+// scanner checkpoints, so ParseIncremental over it -- on EVERY entry (DFA,
+// custom token source) and even after Tree.Copy -- must fall all the way back to
+// a fresh full parse. It must reuse NO node: not the token-invariant leaf fast
+// path, not the reuseCursor subtree splice.
 func TestCompactMaterializedTreeBarsIncrementalReuse(t *testing.T) {
 	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
 	if err != nil {
@@ -20,60 +21,162 @@ func TestCompactMaterializedTreeBarsIncrementalReuse(t *testing.T) {
 	}
 	lang := runner.lang
 
-	src := []byte("package p\n\nvar x = 1\n")
-	treeA, err := runner.parse(src)
-	if err != nil {
-		t.Fatalf("compact parse: %v", err)
-	}
-	defer treeA.Release()
-
-	if !treeA.compactMaterialized {
-		t.Fatal("compact tree is missing the compactMaterialized provenance flag")
-	}
-	if !oldTreeDisablesIncrementalReuse(treeA) {
-		t.Fatal("compact tree must disable incremental reuse")
-	}
-
-	// Same-length, token-invariant edit ('1' -> '2'): a forestFastPath disabled
-	// Go tree WOULD reuse this via the token-invariant leaf path. The compact
-	// tree must refuse it.
+	// A source with a comment so the tree has an extra (abstained-preGoto) node,
+	// making an accidental splice observable, plus a digit leaf to edit.
+	src := []byte("package p\n\n// c\nvar x = 1\n")
+	newSrc := []byte("package p\n\n// c\nvar x = 2\n")
 	pos := bytes.IndexByte(src, '1')
 	if pos < 0 {
 		t.Fatal("fixture invariant: expected a '1' digit to edit")
 	}
-	newSrc := []byte("package p\n\nvar x = 2\n")
 	col := uint32(pos - bytes.LastIndexByte(src[:pos], '\n') - 1)
-	edit := InputEdit{
-		StartByte: uint32(pos), OldEndByte: uint32(pos + 1), NewEndByte: uint32(pos + 1),
-		StartPoint:  Point{Row: 2, Column: col},
-		OldEndPoint: Point{Row: 2, Column: col + 1},
-		NewEndPoint: Point{Row: 2, Column: col + 1},
+	editOf := func() InputEdit {
+		return InputEdit{
+			StartByte: uint32(pos), OldEndByte: uint32(pos + 1), NewEndByte: uint32(pos + 1),
+			StartPoint:  Point{Row: 3, Column: col},
+			OldEndPoint: Point{Row: 3, Column: col + 1},
+			NewEndPoint: Point{Row: 3, Column: col + 1},
+		}
 	}
-	treeA.Edit(edit)
 
 	p := NewParser(lang)
-	// Direct assertion on the reuse gate: it refuses the compact tree.
-	if reused, ok := p.tryTokenInvariantReuseForDisabledOldTree(newSrc, treeA, nil); ok || reused != nil {
-		if reused != nil {
-			reused.Release()
-		}
-		t.Fatal("compact tree was reused via the token-invariant leaf path; reuse bar not enforced")
-	}
-
-	// End-to-end: ParseIncremental over the compact tree yields a tree identical
-	// to a fresh parse of the edited source (the fresh-parse fallback fired).
-	got, err := p.ParseIncremental(newSrc, treeA)
-	if err != nil {
-		t.Fatalf("ParseIncremental over compact tree: %v", err)
-	}
-	defer got.Release()
-	if got == treeA {
-		t.Fatal("ParseIncremental returned the compact old tree unchanged for a real edit")
-	}
 	want, err := NewParser(lang).Parse(newSrc)
 	if err != nil {
 		t.Fatalf("fresh Parse of edited source: %v", err)
 	}
 	defer want.Release()
-	parserCoreWarmRequireDeepEqual(t, got, want, lang)
+
+	// requireFreshFallback asserts got is a correct, node-disjoint fresh parse.
+	requireFreshFallback := func(t *testing.T, got, oldTree *Tree) {
+		t.Helper()
+		if got == oldTree {
+			t.Fatal("ParseIncremental returned the old tree unchanged for a real edit")
+		}
+		if n := countSharedNodes(oldTree, got); n != 0 {
+			t.Fatalf("compact old tree was reused: %d node objects shared with the reparse (want 0)", n)
+		}
+		parserCoreWarmRequireDeepEqual(t, got, want, lang)
+	}
+
+	t.Run("dfa_entry", func(t *testing.T) {
+		treeA, err := runner.parse(src)
+		if err != nil {
+			t.Fatalf("compact parse: %v", err)
+		}
+		defer treeA.Release()
+		if !treeA.compactMaterialized {
+			t.Fatal("compact tree is missing the compactMaterialized provenance flag")
+		}
+		if !oldTreeDisablesIncrementalReuse(treeA) {
+			t.Fatal("compact tree must disable incremental reuse")
+		}
+		treeA.Edit(editOf())
+		// The disabled-tree token-invariant gate refuses the compact tree.
+		if reused, ok := p.tryTokenInvariantReuseForDisabledOldTree(newSrc, treeA, nil); ok || reused != nil {
+			if reused != nil {
+				reused.Release()
+			}
+			t.Fatal("compact tree was reused via the token-invariant leaf path")
+		}
+		got, err := p.ParseIncremental(newSrc, treeA)
+		if err != nil {
+			t.Fatalf("ParseIncremental: %v", err)
+		}
+		defer got.Release()
+		requireFreshFallback(t, got, treeA)
+	})
+
+	t.Run("survives_copy", func(t *testing.T) {
+		treeA, err := runner.parse(src)
+		if err != nil {
+			t.Fatalf("compact parse: %v", err)
+		}
+		defer treeA.Release()
+		cp := treeA.Copy()
+		if cp == nil {
+			t.Fatal("Copy returned nil")
+		}
+		defer cp.Release()
+		// Copy must carry the provenance flags -- otherwise the copy becomes
+		// reuse-eligible on the standard DFA path even though its nodes still
+		// hold the replayed/abstained states.
+		if !cp.compactMaterialized {
+			t.Fatal("Tree.Copy dropped the compactMaterialized provenance flag")
+		}
+		if !oldTreeDisablesIncrementalReuse(cp) {
+			t.Fatal("Tree.Copy dropped the incrementalReuseDisabled flag")
+		}
+		cp.Edit(editOf())
+		if reused, ok := p.tryTokenInvariantReuseForDisabledOldTree(newSrc, cp, nil); ok || reused != nil {
+			if reused != nil {
+				reused.Release()
+			}
+			t.Fatal("copied compact tree was reused via the token-invariant leaf path")
+		}
+		got, err := p.ParseIncremental(newSrc, cp)
+		if err != nil {
+			t.Fatalf("ParseIncremental over copy: %v", err)
+		}
+		defer got.Release()
+		requireFreshFallback(t, got, cp)
+	})
+
+	t.Run("token_source_entry", func(t *testing.T) {
+		treeA, err := runner.parse(src)
+		if err != nil {
+			t.Fatalf("compact parse: %v", err)
+		}
+		defer treeA.Release()
+		treeA.Edit(editOf())
+		// A reuse-SUPPORTING token source (the Go DFA source; Go's scanner opts
+		// into reuse): without the bar this path would reach the reuseCursor
+		// subtree splice. The compact provenance must still force a fresh parse.
+		ts := p.acquireParserDFATokenSource(newSrc)
+		if !tokenSourceSupportsIncrementalReuse(ts) {
+			ts.Close()
+			t.Skip("Go DFA token source unexpectedly does not support incremental reuse")
+		}
+		got, err := p.ParseIncrementalWithTokenSource(newSrc, treeA, ts)
+		if err != nil {
+			t.Fatalf("ParseIncrementalWithTokenSource: %v", err)
+		}
+		defer got.Release()
+		requireFreshFallback(t, got, treeA)
+	})
+}
+
+// countSharedNodes returns how many *Node objects are pointer-identical between
+// the two trees. A genuine fresh parse shares zero; any reuse splice shares the
+// reused subtree roots/leaves.
+func countSharedNodes(a, b *Tree) int {
+	if a == nil || b == nil || a.root == nil || b.root == nil {
+		return 0
+	}
+	set := map[*Node]struct{}{}
+	var collect func(n *Node)
+	collect = func(n *Node) {
+		if n == nil {
+			return
+		}
+		set[n] = struct{}{}
+		for i := 0; i < n.ChildCount(); i++ {
+			collect(n.Child(i))
+		}
+	}
+	collect(a.root)
+	shared := 0
+	var scan func(n *Node)
+	scan = func(n *Node) {
+		if n == nil {
+			return
+		}
+		if _, ok := set[n]; ok {
+			shared++
+		}
+		for i := 0; i < n.ChildCount(); i++ {
+			scan(n.Child(i))
+		}
+	}
+	scan(b.root)
+	return shared
 }

--- a/tree.go
+++ b/tree.go
@@ -2737,6 +2737,18 @@ type Tree struct {
 	externalScannerCheckpointsDeferred bool
 	forestFastPath                     bool
 	incrementalReuseDisabled           bool
+	// compactMaterialized marks a tree built by the phase-zero compact route
+	// (parsercore_phase0_driver.go). Such a tree carries table-REPLAYED per-node
+	// parser states (not the production parser's live-recorded ones): most are
+	// exact, extras/unrecoverable nodes deliberately abstain to the 0
+	// "unknown -> recompute" sentinel, and a bounded internal collapse class
+	// carries the principled outer state rather than production's forest-selected
+	// inner one. It also lacks scanner checkpoints. It is therefore HARD-barred
+	// from every incremental reuse path -- including the token-invariant leaf
+	// fast path that forestFastPath trees still take -- so ParseIncremental over
+	// it always falls back to a full fresh parse (Phase-3 Lane 3 review
+	// amendment 2).
+	compactMaterialized bool
 	// Finalization state avoids repeated retry scans and compatibility passes.
 	// The error summary is not a persistent invariant of a caller-edited tree.
 	resultErrorSummary           resultErrorSummary

--- a/tree.go
+++ b/tree.go
@@ -3116,6 +3116,14 @@ func (t *Tree) Copy() *Tree {
 		parseRuntime:               t.parseRuntime,
 		resultErrorSummary:         t.resultErrorSummary,
 		resultCompatibilityApplied: t.resultCompatibilityApplied,
+		// Reuse-provenance flags must survive Copy: cloneNodeHeaderInto keeps the
+		// per-node stamped/replayed states, so a copy that dropped these would
+		// become reuse-eligible on the standard DFA path and splice replayed or
+		// abstained states into a live parse (Phase-3 Lane 3 review). Carry all
+		// three: forestFastPath, incrementalReuseDisabled, and compactMaterialized.
+		forestFastPath:           t.forestFastPath,
+		incrementalReuseDisabled: t.incrementalReuseDisabled,
+		compactMaterialized:      t.compactMaterialized,
 	}
 	if len(t.edits) > 0 {
 		out.edits = make([]InputEdit, len(t.edits))


### PR DESCRIPTION
## Summary

Bars incremental reuse for all entry points on trees built via the phase-zero compact parser and implements a top-down ParseState table-replay mechanism. This prevents replayed or abstained parser states from leaking into live incremental parses, ensuring correctness while enabling future state reuse.

## Changes

- Mark trees built by the compact parser with a new compactMaterialized flag and ensure it survives Tree.Copy().
- Force a full fresh parse for ParseIncremental when the oldTree is compact-materialized, closing reuse holes on DFA, custom token source, and token-invariant leaf fast path entry points.
- Implement ParseState table replay to reconstruct (preGotoState, parseState) top-down over the full compact derivation before hidden-node elision and grammar aliasing.
- Abstain to the 0 sentinel for states that cannot be reliably reconstructed (e.g., extra/comment leaves), avoiding trusted-but-wrong stamped states.
- Thread the fragile bit from compact records to public nodes to maintain consistent reuse gating.
- Extract incrementalTokenSourceFreshFullParse to unify the full-parse fallback and centralize the compact reuse bar.
- Add extensive differential tests proving replay exactness, safe abstention, and zero node sharing on incremental edits.

## Testing

- Run 'go test ./... -run "TestParseStateReplay|TestCompactMaterialized|TestParseStateReplayResync"'
- Run 'go test ./... -run "TestParseStateReplayCompactDifferential" -tags gts_parsercorephase0'
- Run 'go test ./... -run "TestParseStateReplayDiff"' to validate replay diagnostics against real corpora