### PR TITLE
update(docs): Update GLR stack cap documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Perf preset (stable settings):
 
 Full-parse non-truncation probe:
 - `GOT_PARSE_NODE_LIMIT_SCALE=3` may be used for diagnostic full-parse runs when default node budget truncates benchmark/parity cases.
-- `GOT_GLR_MAX_STACKS=...` overrides the default GLR stack cap (default 8).
+- `GOT_GLR_MAX_STACKS=...` overrides the default GLR stack cap of 8.
 
 ### 8) Prose Standard: ASD-STE100
 All agent-written prose in this repo follows the ASD-STE100 rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Perf preset (stable settings):
 
 Full-parse non-truncation probe:
 - `GOT_PARSE_NODE_LIMIT_SCALE=3` may be used for diagnostic full-parse runs when default node budget truncates benchmark/parity cases.
-- `GOT_GLR_MAX_STACKS=...` overrides the default GLR stack cap (default 6).
+- `GOT_GLR_MAX_STACKS=...` overrides the default GLR stack cap (default 8).
 
 ### 8) Prose Standard: ASD-STE100
 All agent-written prose in this repo follows the ASD-STE100 rules


### PR DESCRIPTION
## Summary

Update the development guidelines to reflect the new default GLR stack cap value.

## Changes

- Update the default GLR stack cap from 6 to 8 in the full-parse probe section.