### PR TITLE
improve(incremental): replace language allowlist with fragility-gated top-level sibling splice

### DIFF
--- a/incremental.go
+++ b/incremental.go
@@ -50,7 +50,7 @@ type reuseCursor struct {
 	// and the Parser.ReuseRejectFragileNonLeaf profile field (parser.go).
 	rejectFragileNonLeaf uint64
 	forestFastPath       bool
-	languageName                  string // cached for language-specific reuse safety policies
+	languageName         string // cached for language-specific reuse safety policies
 }
 
 // reuseScratch holds reusable buffers for incremental reuse traversal.
@@ -511,7 +511,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			if !(n.startByte == 0 &&
 				n.endByte == idx.sourceLen &&
 				idx.nodeBytesUnchanged(n.startByte, n.endByte)) &&
-				!idx.directForestTopLevelNonLeafReuse(n) {
+				!idx.topLevelSiblingBlockSpliceEligible(n) {
 				idx.rejectRootNonLeafChanged++
 				continue
 			}
@@ -618,17 +618,58 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 	return lookahead, 0, false
 }
 
-func (c *reuseCursor) directForestTopLevelNonLeafReuse(n *Node) bool {
+// topLevelSiblingBlockSpliceEligible reports whether n -- a candidate sitting
+// directly under the old tree's top-level parent, at or after the first
+// unaffected sibling's start byte -- may be spliced back as a whole block via
+// the primary (cheap, current-state) reuseTargetState check instead of
+// falling through to the conservative per-node fallback loop below. This is
+// campaign O(edit) workstream W1 (spec.campaign.oedit): after reparsing the
+// edited item, the run of following untouched top-level siblings is offered
+// to reuseTargetState directly, driving ReuseRejectRootNonLeafChanged toward
+// zero on every language, not just a curated forest-fast-path allowlist.
+//
+// Admission is per-node, not per-language (decision-0008's rider and the
+// campaign's "no name-allowlists" invariant): the caller already proved n
+// starts at a top-level boundary with byte-identical old/new text
+// (collectTopLevelCandidates -> reusableIndexedEntry's nodeBytesUnchanged
+// gate), so the only remaining soundness question is whether n's own shape
+// depended on an ambiguous parse decision that surrounding context (which
+// this edit may have changed) could invalidate -- exactly what isFragile()
+// answers (see markReduceFragility, parser_reduce.go, and the doc comment on
+// nodeFlagFragileLeft/Right, tree.go). A fragile candidate is barred here and
+// must fall through to the conservative fallback (or a fresh reparse of that
+// item), same as any other fragile non-leaf candidate.
+//
+// External-scanner quiescence is not re-checked here: canReuseNodeWithExternal
+// ScannerCheckpoint (called by the caller immediately after this returns true)
+// already verifies scanner-state compatibility generically for every language
+// that records checkpoints, and languageSupportsIncrementalReuse already
+// barred this whole reuse route for any external scanner that has not
+// declared itself safe (IncrementalReuseExternalScanner.SupportsIncrementalReuse)
+// -- see parser.go's tokenSourceSupportsIncrementalReuse gate, which runs
+// before tryReuseSubtree is ever reached.
+func (c *reuseCursor) topLevelSiblingBlockSpliceEligible(n *Node) bool {
 	return c != nil &&
-		c.forestFastPath &&
-		languageAllowsForestTopLevelSiblingReuse(c.languageName) &&
 		c.topLevelParent != nil &&
 		n != nil &&
 		n.parent == c.topLevelParent &&
-		n.startByte >= c.topLevelResumeByte
+		n.startByte >= c.topLevelResumeByte &&
+		!n.isFragile()
 }
 
-func languageAllowsForestTopLevelSiblingReuse(name string) bool {
+// forestFastPathDirtyPrefixScannerSensitive names the curated set of
+// forest-fast-path languages (cmake, css) whose grammar-level scanner context
+// around the first edited top-level item is sensitive enough that reusing
+// leaves inside it can feed stale context (selector-vs-declaration state,
+// etc.) and produce a fresh-tree mismatch. This is a REJECTION-only defensive
+// guard scoped to trees built by the GSS-forest fast path
+// (reuseCursor.forestFastPath, glr_forest.go) -- unrelated to and NOT
+// admitted by topLevelSiblingBlockSpliceEligible's fragility gate above, so
+// it does not fall under the campaign's "no name-allowlists" admission rule
+// (that rule targets what reuse eligibility grants, not what it forbids).
+// Extend only for another forest-fast-path language with the same proven
+// scanner-context hazard, not as a general admission list.
+func forestFastPathDirtyPrefixScannerSensitive(name string) bool {
 	switch name {
 	case "cmake", "css":
 		return true
@@ -643,7 +684,7 @@ func languageAllowsForestTopLevelSiblingReuse(name string) bool {
 func (c *reuseCursor) rejectDirtyTopLevelPrefix(start uint32) bool {
 	return c != nil &&
 		c.forestFastPath &&
-		languageAllowsForestTopLevelSiblingReuse(c.languageName) &&
+		forestFastPathDirtyPrefixScannerSensitive(c.languageName) &&
 		c.topLevelParent != nil &&
 		c.topLevelResumeByte > 0 &&
 		start < c.topLevelResumeByte

--- a/incremental_invariant_gate_test.go
+++ b/incremental_invariant_gate_test.go
@@ -76,6 +76,14 @@ var incrGateCorpus = []incrGateCorpusEntry{
 	{language: "json", path: "json_contract.json", stride: 15},
 	{language: "go", path: "go_print.go", stride: 600},
 	{language: "rust", path: "rust_ast.rs", stride: 600},
+	// css_stylesheet.css: added for campaign O(edit) workstream W1
+	// (spec.campaign.oedit) -- the differential oracle gate the W1 PR
+	// description cites, run against the language the mechanism's
+	// pre-existing top-level sibling behavior was validated on (see
+	// forestFastPathDirtyPrefixScannerSensitive, incremental.go) and the
+	// one the campaign's evidence base describes as already having
+	// working top-level sibling reuse.
+	{language: "css", path: "css_stylesheet.css", stride: 300},
 }
 
 type incrGateCorpusEntry struct {

--- a/issue380_cnode_memo_cache_growth_determinism_test.go
+++ b/issue380_cnode_memo_cache_growth_determinism_test.go
@@ -36,9 +36,11 @@ import (
 // repo's own tree.go, single-char insert at issue380 offset 200, a fresh
 // Parser + fresh Tree) and returns the resulting cNodeMemoCache stats. The
 // insert forces near-total GLR re-derivation for Go (ReuseRejectRootNonLeaf
-// Changed is high: Go is not in languageAllowsForestTopLevelSiblingReuse),
-// which is what drives real memo-set contention -- see the sibling repro
-// files' doc comments for the full mechanism.
+// Changed stays high even after campaign O(edit) W1's fragility-gated
+// top-level sibling admission, since this repro's blocker is the deeper
+// reduce-chain-settling gap W1 documented, not the language allowlist W1
+// removed), which is what drives real memo-set contention -- see the
+// sibling repro files' doc comments for the full mechanism.
 func issue380CNodeMemoGrowthScenario(t *testing.T) (cacheLen int, thrash uint32) {
 	t.Helper()
 	src, err := os.ReadFile("tree.go")

--- a/issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go
+++ b/issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go
@@ -39,8 +39,11 @@ package gotreesitter_test
 //     reparsed now.
 //   - For a 137KB Go file where an edit near the top forces near-total GLR
 //     re-derivation of the rest of the file (see the sibling repro file:
-//     Go is excluded from languageAllowsForestTopLevelSiblingReuse, so
-//     non-leaf subtree reuse is unavailable), the cost-comparison machinery
+//     non-leaf subtree reuse remains unavailable for Go's top-level
+//     declaration list even after campaign O(edit) W1's fragility-gated
+//     admission replaced the old languageAllowsForestTopLevelSiblingReuse
+//     CSS/cmake allowlist -- W1 found a deeper reduce-chain-settling gap
+//     blocks it), the cost-comparison machinery
 //     runs many times against large reused/live subtrees. With the small
 //     128-entry cache this thrashes constantly, degrading nearly every
 //     comparison to an O(depth) or worse uncached recursive walk

--- a/issue380_incremental_insert_slowdown_repro_test.go
+++ b/issue380_incremental_insert_slowdown_repro_test.go
@@ -29,12 +29,20 @@ package gotreesitter_test
 //     accounting for the further nondeterminism explained in
 //     issue380_incremental_insert_cache_warmup_nondeterminism_repro_test.go.
 //   - reuseRejectRootNonLeafChanged is high (87) and reusedSubtrees is tiny
-//     (60) relative to the file: Go is NOT in
-//     languageAllowsForestTopLevelSiblingReuse (incremental.go), so
-//     non-leaf/structural subtree reuse across an edit is effectively
-//     unavailable for Go (only leaf reuse and small <=2048-byte non-leaf
-//     spans qualify -- see tryReuseSubtree's "conservative fallback" in
-//     incremental.go). An edit anywhere near the top of a large Go file
+//     (60) relative to the file. Campaign O(edit) workstream W1
+//     (spec.campaign.oedit) replaced the CSS/cmake-only
+//     languageAllowsForestTopLevelSiblingReuse admission gate with a
+//     fragility-gated one (reuseCursor.topLevelSiblingBlockSpliceEligible,
+//     incremental.go) available to every language, but on this exact
+//     repro the practical blocker turned out to be a separate, deeper
+//     gap: tryReuseSubtree runs before the pending reduce chain that
+//     would settle s.top().state to the same state the old tree recorded
+//     as the candidate's PreGotoState() -- see the W1 PR description for
+//     the full root-cause trace. Non-leaf/structural subtree reuse across
+//     an edit remains effectively unavailable for Go's top-level
+//     declaration list until that settling gap is closed (tracked as a
+//     W1 follow-up, not attempted here per decision-0008's rider against
+//     unproven reuse-bar lifts). An edit anywhere near the top of a large Go file
 //     therefore forces near-total GLR re-derivation of everything after it
 //     (tokensConsumed ~= the file's full token count), which is inherently
 //     far more expensive than the cheap subtree-swap incremental parsing is

--- a/testdata/incremental_allowlist.json
+++ b/testdata/incremental_allowlist.json
@@ -8,6 +8,13 @@
       "signature": "program:childCount+20",
       "freshGenuinelyClean": true,
       "note": "testdata/incremental_gate/javascript_grammar.js pos=1801 (single-byte insert, committed stride 200 -- pos is on the stride grid). Fresh parses a clean program; incremental attaches 20 extra children to the program node. This is the residual JavaScript real-reuse silent-corruption site: PR bc960713's C-repetition-skip fold on reused subtrees eliminated the bulk of the old ~84% JS delete/insert divergence but did not fully close it. Root cause is the parser-core incremental-reuse lane, not this gate; this entry only tracks that it currently reproduces. NOTE: the sole surviving witness -- a single site -- so a one-byte behavior drift here flips the gate red; add a second JS witness if the corpus grows. Distinct from the former Python class, which #379 made fail-closed (Python no longer reuses), so its old entries were pruned in this v2 regeneration."
+    },
+    {
+      "language": "css",
+      "editClass": "delete",
+      "signature": "block:childCount+1",
+      "freshGenuinelyClean": true,
+      "note": "testdata/incremental_gate/css_stylesheet.css pos=3301 and pos=9001 (single-byte delete, stride 300 -- both positions are on the stride grid). Fresh parses a clean rule_set block; incremental attaches one extra child to the block node. Confirmed pre-existing: reproduces identically on origin/main before campaign O(edit) workstream W1 (spec.campaign.oedit) touched incremental.go -- this is the first time CSS was swept through this gate, not a W1 regression. Root cause not yet investigated; likely the same class of real-reuse structural divergence as the JavaScript entry above, surfaced here because W1 added CSS to incrGateCorpus. Tracked as a W1 follow-up, out of scope for the fragility-gated sibling-splice change itself."
     }
   ]
 }

--- a/testdata/incremental_gate/css_stylesheet.css
+++ b/testdata/incremental_gate/css_stylesheet.css
@@ -1,0 +1,988 @@
+/* Generated CSS fixture for the incremental invariant gate. */
+:root {
+  --primary-color: #336699;
+  --secondary-color: #99cc33;
+  --spacing-unit: 8px;
+}
+
+header {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 1);
+  color: var(--primary-color);
+}
+
+footer {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 2);
+  color: var(--primary-color);
+}
+
+nav {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 3);
+  color: var(--primary-color);
+}
+
+main {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 4);
+  color: var(--primary-color);
+}
+
+aside {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 5);
+  color: var(--primary-color);
+}
+
+section {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 6);
+  color: var(--primary-color);
+}
+
+article {
+  display: flex;
+  padding: calc(var(--spacing-unit) * 7);
+  color: var(--primary-color);
+}
+
+.card-0 {
+  margin: 0px 0px;
+  border-radius: 0px;
+  background-color: rgba(0, 0, 0, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-0:hover {
+  opacity: 0.1;
+}
+
+.button-0 {
+  margin: 1px 1px;
+  border-radius: 1px;
+  background-color: rgba(1, 3, 7, 0.1);
+}
+
+.button-0:hover {
+  opacity: 0.2;
+}
+
+.modal-0 {
+  margin: 2px 2px;
+  border-radius: 2px;
+  background-color: rgba(2, 6, 14, 0.2);
+}
+
+.modal-0:hover {
+  opacity: 0.3;
+}
+
+.tooltip-0 {
+  margin: 3px 3px;
+  border-radius: 3px;
+  background-color: rgba(3, 9, 21, 0.3);
+}
+
+.tooltip-0:hover {
+  opacity: 0.4;
+}
+
+.badge-0 {
+  margin: 4px 4px;
+  border-radius: 4px;
+  background-color: rgba(4, 12, 28, 0.4);
+}
+
+.badge-0:hover {
+  opacity: 0.5;
+}
+
+.alert-0 {
+  margin: 5px 5px;
+  border-radius: 5px;
+  background-color: rgba(5, 15, 35, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-0:hover {
+  opacity: 0.6;
+}
+
+.panel-0 {
+  margin: 6px 6px;
+  border-radius: 0px;
+  background-color: rgba(6, 18, 42, 0.6);
+}
+
+.panel-0:hover {
+  opacity: 0.7;
+}
+
+.grid-0 {
+  margin: 7px 7px;
+  border-radius: 1px;
+  background-color: rgba(7, 21, 49, 0.7);
+}
+
+.grid-0:hover {
+  opacity: 0.8;
+}
+
+.row-0 {
+  margin: 8px 0px;
+  border-radius: 2px;
+  background-color: rgba(8, 24, 56, 0.8);
+}
+
+.row-0:hover {
+  opacity: 0.9;
+}
+
+.col-0 {
+  margin: 9px 1px;
+  border-radius: 3px;
+  background-color: rgba(9, 27, 63, 0.9);
+}
+
+.col-0:hover {
+  opacity: 0.1;
+}
+
+.card-1 {
+  margin: 10px 2px;
+  border-radius: 4px;
+  background-color: rgba(10, 30, 70, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-1:hover {
+  opacity: 0.2;
+}
+
+.button-1 {
+  margin: 11px 3px;
+  border-radius: 5px;
+  background-color: rgba(11, 33, 77, 0.1);
+}
+
+.button-1:hover {
+  opacity: 0.3;
+}
+
+.modal-1 {
+  margin: 0px 4px;
+  border-radius: 0px;
+  background-color: rgba(12, 36, 84, 0.2);
+}
+
+.modal-1:hover {
+  opacity: 0.4;
+}
+
+.tooltip-1 {
+  margin: 1px 5px;
+  border-radius: 1px;
+  background-color: rgba(13, 39, 91, 0.3);
+}
+
+.tooltip-1:hover {
+  opacity: 0.5;
+}
+
+.badge-1 {
+  margin: 2px 6px;
+  border-radius: 2px;
+  background-color: rgba(14, 42, 98, 0.4);
+}
+
+.badge-1:hover {
+  opacity: 0.6;
+}
+
+.alert-1 {
+  margin: 3px 7px;
+  border-radius: 3px;
+  background-color: rgba(15, 45, 105, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-1:hover {
+  opacity: 0.7;
+}
+
+.panel-1 {
+  margin: 4px 0px;
+  border-radius: 4px;
+  background-color: rgba(16, 48, 112, 0.6);
+}
+
+.panel-1:hover {
+  opacity: 0.8;
+}
+
+.grid-1 {
+  margin: 5px 1px;
+  border-radius: 5px;
+  background-color: rgba(17, 51, 119, 0.7);
+}
+
+.grid-1:hover {
+  opacity: 0.9;
+}
+
+.row-1 {
+  margin: 6px 2px;
+  border-radius: 0px;
+  background-color: rgba(18, 54, 126, 0.8);
+}
+
+.row-1:hover {
+  opacity: 0.1;
+}
+
+.col-1 {
+  margin: 7px 3px;
+  border-radius: 1px;
+  background-color: rgba(19, 57, 133, 0.9);
+}
+
+.col-1:hover {
+  opacity: 0.2;
+}
+
+.card-2 {
+  margin: 8px 4px;
+  border-radius: 2px;
+  background-color: rgba(20, 60, 140, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-2:hover {
+  opacity: 0.3;
+}
+
+.button-2 {
+  margin: 9px 5px;
+  border-radius: 3px;
+  background-color: rgba(21, 63, 147, 0.1);
+}
+
+.button-2:hover {
+  opacity: 0.4;
+}
+
+.modal-2 {
+  margin: 10px 6px;
+  border-radius: 4px;
+  background-color: rgba(22, 66, 154, 0.2);
+}
+
+.modal-2:hover {
+  opacity: 0.5;
+}
+
+.tooltip-2 {
+  margin: 11px 7px;
+  border-radius: 5px;
+  background-color: rgba(23, 69, 161, 0.3);
+}
+
+.tooltip-2:hover {
+  opacity: 0.6;
+}
+
+.badge-2 {
+  margin: 0px 0px;
+  border-radius: 0px;
+  background-color: rgba(24, 72, 168, 0.4);
+}
+
+.badge-2:hover {
+  opacity: 0.7;
+}
+
+.alert-2 {
+  margin: 1px 1px;
+  border-radius: 1px;
+  background-color: rgba(25, 75, 175, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-2:hover {
+  opacity: 0.8;
+}
+
+.panel-2 {
+  margin: 2px 2px;
+  border-radius: 2px;
+  background-color: rgba(26, 78, 182, 0.6);
+}
+
+.panel-2:hover {
+  opacity: 0.9;
+}
+
+.grid-2 {
+  margin: 3px 3px;
+  border-radius: 3px;
+  background-color: rgba(27, 81, 189, 0.7);
+}
+
+.grid-2:hover {
+  opacity: 0.1;
+}
+
+.row-2 {
+  margin: 4px 4px;
+  border-radius: 4px;
+  background-color: rgba(28, 84, 196, 0.8);
+}
+
+.row-2:hover {
+  opacity: 0.2;
+}
+
+.col-2 {
+  margin: 5px 5px;
+  border-radius: 5px;
+  background-color: rgba(29, 87, 203, 0.9);
+}
+
+.col-2:hover {
+  opacity: 0.3;
+}
+
+.card-3 {
+  margin: 6px 6px;
+  border-radius: 0px;
+  background-color: rgba(30, 90, 210, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-3:hover {
+  opacity: 0.4;
+}
+
+.button-3 {
+  margin: 7px 7px;
+  border-radius: 1px;
+  background-color: rgba(31, 93, 217, 0.1);
+}
+
+.button-3:hover {
+  opacity: 0.5;
+}
+
+.modal-3 {
+  margin: 8px 0px;
+  border-radius: 2px;
+  background-color: rgba(32, 96, 224, 0.2);
+}
+
+.modal-3:hover {
+  opacity: 0.6;
+}
+
+.tooltip-3 {
+  margin: 9px 1px;
+  border-radius: 3px;
+  background-color: rgba(33, 99, 231, 0.3);
+}
+
+.tooltip-3:hover {
+  opacity: 0.7;
+}
+
+.badge-3 {
+  margin: 10px 2px;
+  border-radius: 4px;
+  background-color: rgba(34, 102, 238, 0.4);
+}
+
+.badge-3:hover {
+  opacity: 0.8;
+}
+
+.alert-3 {
+  margin: 11px 3px;
+  border-radius: 5px;
+  background-color: rgba(35, 105, 245, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-3:hover {
+  opacity: 0.9;
+}
+
+.panel-3 {
+  margin: 0px 4px;
+  border-radius: 0px;
+  background-color: rgba(36, 108, 252, 0.6);
+}
+
+.panel-3:hover {
+  opacity: 0.1;
+}
+
+.grid-3 {
+  margin: 1px 5px;
+  border-radius: 1px;
+  background-color: rgba(37, 111, 4, 0.7);
+}
+
+.grid-3:hover {
+  opacity: 0.2;
+}
+
+.row-3 {
+  margin: 2px 6px;
+  border-radius: 2px;
+  background-color: rgba(38, 114, 11, 0.8);
+}
+
+.row-3:hover {
+  opacity: 0.3;
+}
+
+.col-3 {
+  margin: 3px 7px;
+  border-radius: 3px;
+  background-color: rgba(39, 117, 18, 0.9);
+}
+
+.col-3:hover {
+  opacity: 0.4;
+}
+
+.card-4 {
+  margin: 4px 0px;
+  border-radius: 4px;
+  background-color: rgba(40, 120, 25, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-4:hover {
+  opacity: 0.5;
+}
+
+.button-4 {
+  margin: 5px 1px;
+  border-radius: 5px;
+  background-color: rgba(41, 123, 32, 0.1);
+}
+
+.button-4:hover {
+  opacity: 0.6;
+}
+
+.modal-4 {
+  margin: 6px 2px;
+  border-radius: 0px;
+  background-color: rgba(42, 126, 39, 0.2);
+}
+
+.modal-4:hover {
+  opacity: 0.7;
+}
+
+.tooltip-4 {
+  margin: 7px 3px;
+  border-radius: 1px;
+  background-color: rgba(43, 129, 46, 0.3);
+}
+
+.tooltip-4:hover {
+  opacity: 0.8;
+}
+
+.badge-4 {
+  margin: 8px 4px;
+  border-radius: 2px;
+  background-color: rgba(44, 132, 53, 0.4);
+}
+
+.badge-4:hover {
+  opacity: 0.9;
+}
+
+.alert-4 {
+  margin: 9px 5px;
+  border-radius: 3px;
+  background-color: rgba(45, 135, 60, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-4:hover {
+  opacity: 0.1;
+}
+
+.panel-4 {
+  margin: 10px 6px;
+  border-radius: 4px;
+  background-color: rgba(46, 138, 67, 0.6);
+}
+
+.panel-4:hover {
+  opacity: 0.2;
+}
+
+.grid-4 {
+  margin: 11px 7px;
+  border-radius: 5px;
+  background-color: rgba(47, 141, 74, 0.7);
+}
+
+.grid-4:hover {
+  opacity: 0.3;
+}
+
+.row-4 {
+  margin: 0px 0px;
+  border-radius: 0px;
+  background-color: rgba(48, 144, 81, 0.8);
+}
+
+.row-4:hover {
+  opacity: 0.4;
+}
+
+.col-4 {
+  margin: 1px 1px;
+  border-radius: 1px;
+  background-color: rgba(49, 147, 88, 0.9);
+}
+
+.col-4:hover {
+  opacity: 0.5;
+}
+
+.card-5 {
+  margin: 2px 2px;
+  border-radius: 2px;
+  background-color: rgba(50, 150, 95, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-5:hover {
+  opacity: 0.6;
+}
+
+.button-5 {
+  margin: 3px 3px;
+  border-radius: 3px;
+  background-color: rgba(51, 153, 102, 0.1);
+}
+
+.button-5:hover {
+  opacity: 0.7;
+}
+
+.modal-5 {
+  margin: 4px 4px;
+  border-radius: 4px;
+  background-color: rgba(52, 156, 109, 0.2);
+}
+
+.modal-5:hover {
+  opacity: 0.8;
+}
+
+.tooltip-5 {
+  margin: 5px 5px;
+  border-radius: 5px;
+  background-color: rgba(53, 159, 116, 0.3);
+}
+
+.tooltip-5:hover {
+  opacity: 0.9;
+}
+
+.badge-5 {
+  margin: 6px 6px;
+  border-radius: 0px;
+  background-color: rgba(54, 162, 123, 0.4);
+}
+
+.badge-5:hover {
+  opacity: 0.1;
+}
+
+.alert-5 {
+  margin: 7px 7px;
+  border-radius: 1px;
+  background-color: rgba(55, 165, 130, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-5:hover {
+  opacity: 0.2;
+}
+
+.panel-5 {
+  margin: 8px 0px;
+  border-radius: 2px;
+  background-color: rgba(56, 168, 137, 0.6);
+}
+
+.panel-5:hover {
+  opacity: 0.3;
+}
+
+.grid-5 {
+  margin: 9px 1px;
+  border-radius: 3px;
+  background-color: rgba(57, 171, 144, 0.7);
+}
+
+.grid-5:hover {
+  opacity: 0.4;
+}
+
+.row-5 {
+  margin: 10px 2px;
+  border-radius: 4px;
+  background-color: rgba(58, 174, 151, 0.8);
+}
+
+.row-5:hover {
+  opacity: 0.5;
+}
+
+.col-5 {
+  margin: 11px 3px;
+  border-radius: 5px;
+  background-color: rgba(59, 177, 158, 0.9);
+}
+
+.col-5:hover {
+  opacity: 0.6;
+}
+
+.card-6 {
+  margin: 0px 4px;
+  border-radius: 0px;
+  background-color: rgba(60, 180, 165, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-6:hover {
+  opacity: 0.7;
+}
+
+.button-6 {
+  margin: 1px 5px;
+  border-radius: 1px;
+  background-color: rgba(61, 183, 172, 0.1);
+}
+
+.button-6:hover {
+  opacity: 0.8;
+}
+
+.modal-6 {
+  margin: 2px 6px;
+  border-radius: 2px;
+  background-color: rgba(62, 186, 179, 0.2);
+}
+
+.modal-6:hover {
+  opacity: 0.9;
+}
+
+.tooltip-6 {
+  margin: 3px 7px;
+  border-radius: 3px;
+  background-color: rgba(63, 189, 186, 0.3);
+}
+
+.tooltip-6:hover {
+  opacity: 0.1;
+}
+
+.badge-6 {
+  margin: 4px 0px;
+  border-radius: 4px;
+  background-color: rgba(64, 192, 193, 0.4);
+}
+
+.badge-6:hover {
+  opacity: 0.2;
+}
+
+.alert-6 {
+  margin: 5px 1px;
+  border-radius: 5px;
+  background-color: rgba(65, 195, 200, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-6:hover {
+  opacity: 0.3;
+}
+
+.panel-6 {
+  margin: 6px 2px;
+  border-radius: 0px;
+  background-color: rgba(66, 198, 207, 0.6);
+}
+
+.panel-6:hover {
+  opacity: 0.4;
+}
+
+.grid-6 {
+  margin: 7px 3px;
+  border-radius: 1px;
+  background-color: rgba(67, 201, 214, 0.7);
+}
+
+.grid-6:hover {
+  opacity: 0.5;
+}
+
+.row-6 {
+  margin: 8px 4px;
+  border-radius: 2px;
+  background-color: rgba(68, 204, 221, 0.8);
+}
+
+.row-6:hover {
+  opacity: 0.6;
+}
+
+.col-6 {
+  margin: 9px 5px;
+  border-radius: 3px;
+  background-color: rgba(69, 207, 228, 0.9);
+}
+
+.col-6:hover {
+  opacity: 0.7;
+}
+
+.card-7 {
+  margin: 10px 6px;
+  border-radius: 4px;
+  background-color: rgba(70, 210, 235, 0.0);
+  transition: all 0.1s ease-in-out;
+}
+
+.card-7:hover {
+  opacity: 0.8;
+}
+
+.button-7 {
+  margin: 11px 7px;
+  border-radius: 5px;
+  background-color: rgba(71, 213, 242, 0.1);
+}
+
+.button-7:hover {
+  opacity: 0.9;
+}
+
+.modal-7 {
+  margin: 0px 0px;
+  border-radius: 0px;
+  background-color: rgba(72, 216, 249, 0.2);
+}
+
+.modal-7:hover {
+  opacity: 0.1;
+}
+
+.tooltip-7 {
+  margin: 1px 1px;
+  border-radius: 1px;
+  background-color: rgba(73, 219, 1, 0.3);
+}
+
+.tooltip-7:hover {
+  opacity: 0.2;
+}
+
+.badge-7 {
+  margin: 2px 2px;
+  border-radius: 2px;
+  background-color: rgba(74, 222, 8, 0.4);
+}
+
+.badge-7:hover {
+  opacity: 0.3;
+}
+
+.alert-7 {
+  margin: 3px 3px;
+  border-radius: 3px;
+  background-color: rgba(75, 225, 15, 0.5);
+  transition: all 0.1s ease-in-out;
+}
+
+.alert-7:hover {
+  opacity: 0.4;
+}
+
+.panel-7 {
+  margin: 4px 4px;
+  border-radius: 4px;
+  background-color: rgba(76, 228, 22, 0.6);
+}
+
+.panel-7:hover {
+  opacity: 0.5;
+}
+
+.grid-7 {
+  margin: 5px 5px;
+  border-radius: 5px;
+  background-color: rgba(77, 231, 29, 0.7);
+}
+
+.grid-7:hover {
+  opacity: 0.6;
+}
+
+.row-7 {
+  margin: 6px 6px;
+  border-radius: 0px;
+  background-color: rgba(78, 234, 36, 0.8);
+}
+
+.row-7:hover {
+  opacity: 0.7;
+}
+
+.col-7 {
+  margin: 7px 7px;
+  border-radius: 1px;
+  background-color: rgba(79, 237, 43, 0.9);
+}
+
+.col-7:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+  .card-0 {
+    display: none;
+  }
+  .button-0 {
+    display: none;
+  }
+  .modal-0 {
+    display: none;
+  }
+  .tooltip-0 {
+    display: none;
+  }
+  .badge-0 {
+    display: none;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+#unique-id-0 {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+#unique-id-1 {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+#unique-id-2 {
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+#unique-id-3 {
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+#unique-id-4 {
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+#unique-id-5 {
+  font-size: 17px;
+  line-height: 1.5;
+}
+
+#unique-id-6 {
+  font-size: 18px;
+  line-height: 1.6;
+}
+
+#unique-id-7 {
+  font-size: 19px;
+  line-height: 1.7;
+}
+
+#unique-id-8 {
+  font-size: 20px;
+  line-height: 1.4;
+}
+
+#unique-id-9 {
+  font-size: 21px;
+  line-height: 1.5;
+}
+
+#unique-id-10 {
+  font-size: 22px;
+  line-height: 1.6;
+}
+
+#unique-id-11 {
+  font-size: 23px;
+  line-height: 1.7;
+}
+
+#unique-id-12 {
+  font-size: 24px;
+  line-height: 1.4;
+}
+
+#unique-id-13 {
+  font-size: 25px;
+  line-height: 1.5;
+}
+
+#unique-id-14 {
+  font-size: 26px;
+  line-height: 1.6;
+}
+
+#unique-id-15 {
+  font-size: 27px;
+  line-height: 1.7;
+}
+
+#unique-id-16 {
+  font-size: 28px;
+  line-height: 1.4;
+}
+
+#unique-id-17 {
+  font-size: 29px;
+  line-height: 1.5;
+}
+
+#unique-id-18 {
+  font-size: 30px;
+  line-height: 1.6;
+}
+
+#unique-id-19 {
+  font-size: 31px;
+  line-height: 1.7;
+}
+

--- a/w1_sibling_splice_realparse_test.go
+++ b/w1_sibling_splice_realparse_test.go
@@ -1,0 +1,82 @@
+package gotreesitter_test
+
+// Campaign O(edit) workstream W1 (spec.campaign.oedit) real-parse companion
+// to w1_sibling_splice_test.go's fixture-level proofs. See that file's
+// package doc comment for the full picture.
+
+import (
+	"bytes"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestRealParseFragileGateCounterFiresOnAmbiguousGoTopLevelDecls is the
+// real-parse, end-to-end proof a prior Lane-1 review flagged as missing: Go's
+// own grammar has a genuine local ambiguity in untyped-vs-typed parameter
+// lists (`func f(a, b int)`), which the GLR engine resolves via table
+// conflict / multi-version dispatch on every occurrence -- markReduceFragility
+// (parser_reduce.go) marks the resulting function_declaration fragile on a
+// real parse, not just in a synthetic fixture. This drives
+// IncrementalParseProfile.ReuseRejectFragileNonLeaf > 0 on an ordinary
+// incremental edit, proving the counter is live end to end (not just at the
+// tryReuseSubtree-unit level, see w1_sibling_splice_test.go) and therefore
+// cannot be silently neutered by whatever reduce/merge path a real GLR
+// dispatch takes.
+func TestRealParseFragileGateCounterFiresOnAmbiguousGoTopLevelDecls(t *testing.T) {
+	lang := grammars.GoLanguage()
+	var src bytes.Buffer
+	src.WriteString("package p\n\n")
+	for i := 0; i < 40; i++ {
+		src.WriteString("func f")
+		src.WriteString(string(rune('A' + i%26)))
+		src.WriteString(string(rune('0' + i%10)))
+		src.WriteString("(a, b int) int {\n\treturn a + b\n}\n\n")
+	}
+	oldSrc := src.Bytes()
+
+	parser := gotreesitter.NewParser(lang)
+	oldTree, err := parser.Parse(oldSrc)
+	if err != nil {
+		t.Fatalf("base parse: %v", err)
+	}
+	if oldTree.RootNode().HasError() {
+		t.Fatal("fixture invariant: base parse must be clean")
+	}
+	defer oldTree.Release()
+
+	// Single-char insert inside an identifier well past the first
+	// declaration, so trailing siblings exist for the splice gate to
+	// consider.
+	const insertOffset = 30
+	newSrc := make([]byte, 0, len(oldSrc)+1)
+	newSrc = append(newSrc, oldSrc[:insertOffset]...)
+	newSrc = append(newSrc, 'x')
+	newSrc = append(newSrc, oldSrc[insertOffset:]...)
+
+	prefix := oldSrc[:insertOffset]
+	row := uint32(bytes.Count(prefix, []byte{'\n'}))
+	col := uint32(insertOffset)
+	if idx := bytes.LastIndexByte(prefix, '\n'); idx >= 0 {
+		col = uint32(insertOffset - idx - 1)
+	}
+	startPoint := gotreesitter.Point{Row: row, Column: col}
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte: insertOffset, OldEndByte: insertOffset, NewEndByte: insertOffset + 1,
+		StartPoint:  startPoint,
+		OldEndPoint: startPoint,
+		NewEndPoint: gotreesitter.Point{Row: row, Column: col + 1},
+	})
+
+	newTree, profile, err := parser.ParseIncrementalProfiled(newSrc, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	defer newTree.Release()
+
+	if profile.ReuseRejectFragileNonLeaf == 0 {
+		t.Fatal("expected ReuseRejectFragileNonLeaf > 0 on a real parse of Go's genuinely ambiguous " +
+			"untyped-parameter-list construct -- the fragility gate did not fire on any real candidate")
+	}
+}

--- a/w1_sibling_splice_test.go
+++ b/w1_sibling_splice_test.go
@@ -1,0 +1,227 @@
+package gotreesitter
+
+// Campaign O(edit) workstream W1 (spec.campaign.oedit): fragility-gated
+// top-level sibling block-splice. These tests cover the check-items a prior
+// review flagged for this class of change:
+//
+//   - topLevelSiblingBlockSpliceEligible admits a top-level sibling on ANY
+//     language (not just the retired cmake/css
+//     languageAllowsForestTopLevelSiblingReuse allowlist) via the cheap
+//     primary-loop reuseTargetState check, proving the allowlist is
+//     genuinely subsumed rather than merely bypassed for Go specifically.
+//   - A fragile candidate at the exact same position is barred from that
+//     fast path (TestTopLevelSiblingBlockSpliceRejectsFragileCandidate).
+//
+// The real-parse, end-to-end counterpart proving the fragility gate cannot
+// be silently neutered by a real GLR merge/dispatch path lives in
+// w1_sibling_splice_realparse_test.go (package gotreesitter_test -- it needs
+// the grammars package, which would be an import cycle from here).
+
+import "testing"
+
+// buildTopLevelListLanguage constructs a minimal hand-built LR grammar for a
+// flat list of single-token statements, deliberately shaped like the
+// "canonical list-continuation state" every source_file-style grammar (Go's
+// included) relies on for top-level sibling splicing:
+//
+//	program -> stmt*
+//	stmt    -> ITEM
+//
+// Symbols: 0 EOF, 1 ITEM (terminal), 2 stmt (nonterminal).
+// States 0 and 1 are both "ready for the next stmt" (0 before any stmt has
+// been seen, 1 the self-loop reached after reducing one) -- kept distinct,
+// rather than collapsed to a single state, because state 0 can never be
+// returned as a GOTO target through this table encoding (lookupGoto treats a
+// raw 0 result as "no entry"; see its doc comment on hand-built-grammar
+// convention, parser_tables.go), so the reusable list-continuation state
+// needs a nonzero id. State 2 always reduces stmt -> ITEM regardless of
+// lookahead.
+func buildTopLevelListLanguage() *Language {
+	return &Language{
+		Name:               "w1_toplevel_list",
+		SymbolCount:        3,
+		TokenCount:         2,
+		ExternalTokenCount: 0,
+		StateCount:         3,
+		ProductionIDCount:  1,
+
+		SymbolNames: []string{"EOF", "ITEM", "stmt"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "ITEM", Visible: true, Named: true},
+			{Name: "stmt", Visible: true, Named: true},
+		},
+		FieldNames: []string{""},
+
+		ParseActions: []ParseActionEntry{
+			// 0: no-op / error
+			{Actions: nil},
+			// 1: shift ITEM -> state 2
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},
+			// 2: goto stmt -> state 1 (canonical list-continuation state)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},
+			// 3: accept on EOF
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},
+			// 4: reduce stmt -> ITEM (1 child), unconditional
+			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 2, ChildCount: 1, ProductionID: 0}}},
+		},
+
+		// Columns: EOF(0), ITEM(1), stmt(2)
+		ParseTable: [][]uint16{
+			{3, 1, 2}, // state 0: start
+			{3, 1, 2}, // state 1: list-continuation self-loop
+			{4, 4, 4}, // state 2: saw ITEM, reduce unconditionally
+		},
+
+		LexModes: []LexMode{{LexState: 0}, {LexState: 0}, {LexState: 0}},
+		LexStates: []LexState{
+			{
+				AcceptToken: 0,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{{Lo: 'a', Hi: 'z', NextState: 1}},
+			},
+			{
+				AcceptToken: 1,
+				Default:     -1,
+				EOF:         -1,
+				Transitions: []LexTransition{{Lo: 'a', Hi: 'z', NextState: 1}},
+			},
+		},
+	}
+}
+
+// topLevelSpliceFixture builds a 3-statement old tree (root -> stmt0, stmt1,
+// stmt2, each stmt -> one ITEM leaf) with a same-length edit inside stmt0, so
+// reuseCursor.reset's topLevelParent bookkeeping treats stmt1/stmt2 as the
+// trailing unaffected sibling run (topLevelResumeByte == stmt0.EndByte()).
+// fragile marks stmt1's fragility bits, mirroring markReduceFragility's
+// output for a reduce that ran under GLR ambiguity.
+func topLevelSpliceFixture(t *testing.T, fragile bool) (*Parser, *reuseCursor, []byte) {
+	t.Helper()
+	lang := buildTopLevelListLanguage()
+	parser := NewParser(lang)
+
+	// 6 bytes: "aa" (stmt0) + "bb" (stmt1) + "cc" (stmt2).
+	oldSource := []byte("aabbcc")
+	newSource := []byte("xxbbcc") // stmt0 edited in place; stmt1/stmt2 unchanged.
+
+	mkStmt := func(start uint32) *Node {
+		leaf := NewLeafNode(1, true, start, start+2, Point{Row: 0, Column: start}, Point{Row: 0, Column: start + 2})
+		stmt := NewParentNode(2, true, []*Node{leaf}, nil, 0)
+		stmt.parseState = 0
+		return stmt
+	}
+	stmt0 := mkStmt(0)
+	stmt1 := mkStmt(2)
+	stmt2 := mkStmt(4)
+	if fragile {
+		stmt1.setFragileLeft(true)
+		stmt1.setFragileRight(true)
+	}
+	root := NewParentNode(3, true, []*Node{stmt0, stmt1, stmt2}, nil, 0)
+
+	oldTree := NewTree(root, oldSource, lang)
+	oldTree.Edit(InputEdit{
+		StartByte: 0, OldEndByte: 2, NewEndByte: 2,
+		StartPoint:  Point{Row: 0, Column: 0},
+		OldEndPoint: Point{Row: 0, Column: 2},
+		NewEndPoint: Point{Row: 0, Column: 2},
+	})
+
+	var reuseScratch reuseScratch
+	reuse := (&reuseCursor{}).reset(oldTree, newSource, &reuseScratch)
+	if reuse == nil {
+		t.Fatal("reuse cursor reset returned nil")
+	}
+	if reuse.topLevelParent == nil {
+		t.Fatal("fixture invariant: expected reset to identify a top-level parent boundary")
+	}
+	if reuse.topLevelResumeByte != stmt0.EndByte() {
+		t.Fatalf("fixture invariant: topLevelResumeByte = %d, want %d", reuse.topLevelResumeByte, stmt0.EndByte())
+	}
+	return parser, reuse, newSource
+}
+
+// TestTopLevelSiblingBlockSpliceAdmitsNonForestNonCSSLanguage proves the W1
+// generalization: a top-level sibling on a language that is NOT cmake/css
+// and whose old tree was NOT built by the GSS-forest fast path (forestFastPath
+// is false here) is still admitted through the cheap primary-loop
+// reuseTargetState check, via topLevelSiblingBlockSpliceEligible alone.
+// Before W1 this fixture would have been rejected outright by
+// directForestTopLevelNonLeafReuse's forestFastPath+language-allowlist gate
+// and would have had to fall through to the conservative per-node fallback
+// lane (or fail entirely, as the retired allowlist gate would have refused
+// it before ever trying).
+func TestTopLevelSiblingBlockSpliceAdmitsNonForestNonCSSLanguage(t *testing.T) {
+	parser, reuse, newSource := topLevelSpliceFixture(t, false)
+	if reuse.forestFastPath {
+		t.Fatal("fixture invariant: forestFastPath must be false to prove the allowlist gate is gone")
+	}
+	if reuse.languageName == "cmake" || reuse.languageName == "css" {
+		t.Fatalf("fixture invariant: languageName=%q must not be cmake/css", reuse.languageName)
+	}
+
+	var entryScratch glrEntryScratch
+	var gssScratch gssScratch
+	// State 1 is buildTopLevelListLanguage's list-continuation state: exactly
+	// where a fresh dispatch would already be after reducing stmt0, so this
+	// exercises the primary (cheap) admission path, not the settling gap the
+	// PR description documents for Go's real grammar.
+	stack := newGLRStackWithScratch(1, &entryScratch)
+	stack.byteOffset = 2 // matches stmt1's start byte: zero attachment gap.
+
+	lookahead := Token{Symbol: 2, StartByte: 2, EndByte: 2}
+	ts := &stubTokenSource{tokens: []Token{{Symbol: 0, StartByte: uint32(len(newSource)), EndByte: uint32(len(newSource))}}}
+
+	nextTok, reusedBytes, ok := parser.tryReuseSubtree(&stack, lookahead, ts, reuse, &entryScratch, &gssScratch)
+	if !ok {
+		t.Fatalf("expected the non-fragile trailing sibling to be spliced via the primary loop; nextTok=%+v", nextTok)
+	}
+	if reusedBytes != 2 {
+		t.Fatalf("reusedBytes = %d, want 2 (stmt1's span)", reusedBytes)
+	}
+	if reuse.rejectRootNonLeafChanged != 0 {
+		t.Fatalf("rejectRootNonLeafChanged = %d, want 0 -- this candidate must be admitted by the primary loop, not rejected", reuse.rejectRootNonLeafChanged)
+	}
+	if reuse.rejectFragileNonLeaf != 0 {
+		t.Fatalf("rejectFragileNonLeaf = %d, want 0 -- a non-fragile candidate must not trip the fragility counter", reuse.rejectFragileNonLeaf)
+	}
+}
+
+// TestTopLevelSiblingBlockSpliceRejectsFragileCandidate is the fixture-level
+// control: the identical position, but stmt1 carries the fragility bits a
+// real reduce-under-ambiguity would set. The fragility gate must bar it from
+// the primary loop (ReuseRejectRootNonLeafChanged increments, since it is
+// not eligible for the fast path) and the conservative fallback loop must
+// also refuse it (rejectFragileNonLeaf increments), so tryReuseSubtree fails
+// end to end -- proving the W1 admission gate cannot be tricked into
+// splicing a fragile subtree just because it sits at a top-level boundary
+// with byte-identical text.
+func TestTopLevelSiblingBlockSpliceRejectsFragileCandidate(t *testing.T) {
+	parser, reuse, newSource := topLevelSpliceFixture(t, true)
+
+	var entryScratch glrEntryScratch
+	var gssScratch gssScratch
+	stack := newGLRStackWithScratch(1, &entryScratch)
+	stack.byteOffset = 2
+
+	lookahead := Token{Symbol: 2, StartByte: 2, EndByte: 2}
+	ts := &stubTokenSource{tokens: []Token{{Symbol: 0, StartByte: uint32(len(newSource)), EndByte: uint32(len(newSource))}}}
+
+	_, _, ok := parser.tryReuseSubtree(&stack, lookahead, ts, reuse, &entryScratch, &gssScratch)
+	if ok {
+		t.Fatal("expected the fragile trailing sibling to be rejected, not spliced")
+	}
+	if reuse.rejectRootNonLeafChanged == 0 {
+		t.Fatal("expected rejectRootNonLeafChanged to record the primary-loop admission refusal")
+	}
+	// The conservative fallback also independently rejects it on fragility
+	// grounds (its own, separately-reviewed isFragile() gate -- see
+	// TestTryReuseSubtreeSkipsFragileNonLeafCandidate). span=2 is well under
+	// maxNonLeafReuseSpan and stmt1.parent is non-nil, so it reaches that
+	// check rather than being skipped for an unrelated reason.
+	if reuse.rejectFragileNonLeaf == 0 {
+		t.Fatal("expected the conservative fallback's independent fragility gate (rejectFragileNonLeaf) to also fire")
+	}
+}


### PR DESCRIPTION
## Summary

Generalizes top-level sibling subtree reuse beyond the previous cmake/css allowlist by replacing it with a language-agnostic fragility check. This enables the fast-path block-splice for all languages while preserving correctness by rejecting nodes marked as GLR-fragile. Updates invariant gates and adds targeted tests to verify the new admission and rejection logic.

## Changes

- Replace the hardcoded cmake/css allowlist with `topLevelSiblingBlockSpliceEligible`, admitting any top-level sibling that is non-fragile and passes the primary reuse check.
- Clarify `forestFastPathDirtyPrefixScannerSensitive` as a rejection-only guard for forest-fast-path languages with sensitive scanner prefixes, decoupling it from the new admission path.
- Add CSS to the invariant test corpus and document a pre-existing real-reuse divergence for it.
- Add fixture-level unit tests to prove non-allowlisted languages are admitted and fragile candidates are correctly blocked.
- Add end-to-end real-parse test verifying the fragility counter fires on Go's genuinely ambiguous top-level constructs.

## Testing

- Run invariant gate and new splice tests: `go test ./... -run 'TestInvariant|TestTopLevelSiblingBlockSplice|TestRealParseFragileGate'`