### PR TITLE
release: Release v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ for tags and release notes while still in `0.x`.
 - **Incremental memo-cache growth is now input-deterministic.** Growth used
   to depend on prior parser history, not only the current parse. Identical
   (source, edit) pairs could take different growth paths depending on
-  earlier use. A new adaptive threshold, `cNodeMemoThrash`, now triggers
-  growth from the collision count of the current parse alone (PR #392,
+  earlier use. A new adaptive trigger, driven by the `cNodeMemoThrash`
+  collision count of the current parse alone, now controls growth (PR #392,
   issue #380 follow-up). Clean, non-pathological parses still stay at the
   small 128-entry default.
 - **Incremental reuse is now barred for trees built by the phase-zero
@@ -51,7 +51,7 @@ for tags and release notes while still in `0.x`.
   `ParseIncremental` now forces a full fresh parse when the old tree is
   compact-materialized (PR #393). A new top-down ParseState table-replay
   mechanism reconstructs parser states over the full compact derivation. It
-  runs before hidden-node elision and grammar aliasing. It abstains to a
+  runs before hidden-node elision and grammar aliasing. It falls back to a
   sentinel state when a state cannot be reliably reconstructed, for example
   for extra or comment leaves.
 
@@ -61,7 +61,7 @@ for tags and release notes while still in `0.x`.
   tree.** A fragility-gated top-level sibling block-splice replaces the old
   cmake/css name allowlist (PR #395, campaign O(edit) workstream W1).
   Admission is now per node: a fragility bit plus byte equality, not a
-  language name. On a CSS editor-edit benchmark, `rootNonLeafChanged`
+  language name. On a CSS editor-edit measurement, `rootNonLeafChanged`
   rejections near the top of the tree drop from 1,379 to 14. Node reuse
   rises from 63.8% to 99.5%. Go incremental node reuse does not improve in
   this release. A deeper, pre-existing engine gap blocks it: the reuse check
@@ -79,8 +79,8 @@ for tags and release notes while still in `0.x`.
 - Refresh documentation prose to the ASD-STE100 style guide across
   README.md, BENCH.md, AGENTS.md, and the authoring-languages and
   external-scanners guides (PR #385).
-- Correct a stale release-status paragraph and clarify the GLR stack cap
-  default in AGENTS.md (PR #394).
+- Clarify the GLR stack cap default in AGENTS.md (PR #394). This release
+  also corrects the stale release-status paragraph in README.md.
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,86 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-07-20
+
 ### Fixed
 
 - **Swift's `Language()` call no longer exceeds the 256 MB CI memory
-  ceiling.** grammargen's `buildLexDFA` rebuilt an independent lexer DFA per
-  lex mode with no sharing across modes; Swift's ~331 lex modes rebuilt the
-  same ~190-state identifier/operator/comment automaton from scratch each
-  time. A new post-construction minimization pass
-  (`grammargen/dfa_minimize.go`) merges observationally-equivalent DFA
-  states across lex-mode boundaries. Swift's LexStates table drops from
-  63,150 to 2,067 entries; its `Language()` call now retains about 25 MB,
-  down from about 490 MB. `swift.bin` is regenerated and recertified against
-  the Swift regression suite and corpus. The known-exception entry for
-  Swift is removed from the CI memory-ceiling gate.
+  ceiling.** This closes the known issue noted in v0.43.1. grammargen's
+  `buildLexDFA` rebuilt an independent lexer DFA per lex mode, with no
+  sharing across modes. Swift's about 331 lex modes each rebuilt the same
+  about 190-state identifier, operator, and comment automaton from scratch.
+  A new post-construction minimization pass, `grammargen/dfa_minimize.go`,
+  merges observationally-equivalent DFA states across lex-mode boundaries
+  (PR #396). Swift's LexStates table drops from 63,150 to 2,067 entries.
+  Its `Language()` call now retains about 25 MB, down from about 490 MB.
+  `swift.bin` is regenerated and recertified against the Swift regression
+  suite and corpus, shrinking from 7,474,360 to 373,401 bytes. Byte-identical
+  lexing is proven across a 10-grammar parity corpus. The blob format is
+  unchanged. The known-exception entry for Swift is removed from the CI
+  memory-ceiling gate.
+- **grammargen's C code emitter** had several defects. This release fixes:
+  - duplicate C identifiers for anonymous tokens, a compile error;
+  - infinite lexer loops at EOF on negated character classes;
+  - wrong re-lex targets for multi-character skips (CRLF, backslash-newline);
+  - an alias-stride bound sized from the wrong table, causing out-of-bounds
+    reads.
+
+  A new C-runtime parity harness compiles the emitted `parser.c` against the
+  tree-sitter v0.25.0 runtime (PR #391). It byte-compares the resulting AST
+  against the pure-Go oracle.
+- **Incremental memo-cache growth is now input-deterministic.** Growth used
+  to depend on prior parser history, not only the current parse. Identical
+  (source, edit) pairs could take different growth paths depending on
+  earlier use. A new adaptive threshold, `cNodeMemoThrash`, now triggers
+  growth from the collision count of the current parse alone (PR #392,
+  issue #380 follow-up). Clean, non-pathological parses still stay at the
+  small 128-entry default.
+- **Incremental reuse is now barred for trees built by the phase-zero
+  compact parser.** This closes reuse holes on three entry points:
+  - the DFA entry point;
+  - the custom-token-source entry point;
+  - the token-invariant-leaf-fastpath entry point.
+
+  `ParseIncremental` now forces a full fresh parse when the old tree is
+  compact-materialized (PR #393). A new top-down ParseState table-replay
+  mechanism reconstructs parser states over the full compact derivation. It
+  runs before hidden-node elision and grammar aliasing. It abstains to a
+  sentinel state when a state cannot be reliably reconstructed, for example
+  for extra or comment leaves.
+
+### Improved
+
+- **CSS editor-style incremental edits now reuse far more of the unchanged
+  tree.** A fragility-gated top-level sibling block-splice replaces the old
+  cmake/css name allowlist (PR #395, campaign O(edit) workstream W1).
+  Admission is now per node: a fragility bit plus byte equality, not a
+  language name. On a CSS editor-edit benchmark, `rootNonLeafChanged`
+  rejections near the top of the tree drop from 1,379 to 14. Node reuse
+  rises from 63.8% to 99.5%. Go incremental node reuse does not improve in
+  this release. A deeper, pre-existing engine gap blocks it: the reuse check
+  runs before the eager reduce chain settles state. Work on that gap
+  continues.
+
+### Added
+
+- A rollback safety valve: the `GTS_GRAMMARGEN_DISABLE_LEX_MINIMIZE`
+  environment flag falls back to the raw, per-mode lexer tables. Use it only
+  if a correctness question comes up (PR #396).
+
+### Docs
+
+- Refresh documentation prose to the ASD-STE100 style guide across
+  README.md, BENCH.md, AGENTS.md, and the authoring-languages and
+  external-scanners guides (PR #385).
+- Correct a stale release-status paragraph and clarify the GLR stack cap
+  default in AGENTS.md (PR #394).
+
+### Known Issues
+
+- Go incremental node reuse is unchanged by the W1 fragility-gated splice
+  (PR #395). The reuse check runs before the eager reduce chain settles
+  state, blocking admission. A fix is tracked.
 
 ## [0.43.1] - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -744,16 +744,15 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.43.1**. It fixes TypeScript and TSX bare
-default parameters that previously collapsed to `ERROR`. It also reduces
-allocation churn during grammar-blob decoding by about 32% and peak
-memory by about 11%, across all 206 grammars. A CI test now enforces a
-memory ceiling and fails any `Language()` load above 256 MB. Swift is
-the sole documented exception, at about 491 MB. The prior release,
-v0.43.0, lets incremental length-changing edits reuse the unchanged
-suffix instead of re-lexing the whole tail. It also adds a default-on
-incremental-invariant correctness gate that checks `ParseIncremental`
-against a fresh `Parse`.
+The current release is **v0.44.0**. It fixes Swift's `Language()` memory
+ceiling breach. A cross-mode DFA minimization pass cuts Swift's retained
+memory from about 490 MB to about 25 MB, closing the sole documented CI
+memory-ceiling exception. It also replaces the cmake/css reuse allowlist
+with a fragility-gated top-level sibling block-splice; CSS editor-edit
+node reuse rises from 63.8% to 99.5%. Go node reuse is unchanged, pending
+a deeper engine fix. The prior release, v0.43.1, fixes TypeScript and TSX
+bare default parameters that previously collapsed to `ERROR` and reduces
+grammar-blob decoding allocation churn by about 32%.
 The authenticated production receipt at tag target `1935a42c` measures
 public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
 **5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst


### PR DESCRIPTION
## Summary

Bumps the version to v0.44.0 and updates release documentation. This drop enables cross-mode DFA minimization to fix a Swift CI memory ceiling breach, corrects several C code emitter defects, and improves incremental reuse for CSS edits. It also aligns all agent-written prose with the ASD-STE100 style guide.

## Changes

- Added a cross-mode DFA minimization pass to merge equivalent lexer DFA states across lex-mode boundaries.
- Reduced Swift LexStates table entries from 63,150 to 2,067 and cut retained memory from approximately 490 MB to 25 MB.
- Recertified swift.bin against the Swift regression suite and removed the Swift exception from the CI memory-ceiling gate.
- Corrected C code emitter defects including duplicate identifiers, infinite EOF loops on negated classes, wrong re-lex targets, and alias-stride bounds.
- Added a C-runtime parity harness to compile generated parser.c against tree-sitter v0.25.0 and compare ASTs against the pure-Go oracle.
- Made incremental memo-cache growth input-deterministic by triggering growth from current parse collision counts alone.
- Barred incremental reuse for trees built by the phase-zero compact parser and added a top-down table-replay mechanism.
- Replaced the cmake and css reuse allowlist with a fragility-gated sibling block-splice to raise CSS node reuse to 99.5 percent.
- Added the GTS_GRAMMARGEN_DISABLE_LEX_MINIMIZE flag as a rollback safety valve.
- Updated documentation files to follow the ASD-STE100 style profile and fixed stale release notes.