### PR TITLE
optimize(parser): tighten incremental cost competition gate

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -4022,6 +4022,44 @@ func (p *Parser) guardRealShiftGap(source []byte, s *glrStack, tok Token) bool {
 	return p.guardRealTokenAttachmentGap(source, s, tok, "shift")
 }
 
+// incrementalOldTreeMayCarryErrorCost decides the starting value of
+// crecoveryCostCompetitionRelevant for a parse that may reuse subtrees from
+// oldTree. Neither reuse nor oldTree set means an ordinary fresh full parse,
+// which always starts clean (false), matching pre-existing behavior.
+//
+// When reuse is possible, the question is whether ANY subtree it could
+// splice in already carries error/missing content. oldTree.root.hasError()
+// answers that in O(1): it is the same cached, bottom-up-propagated bit
+// (tree.go populateParentNode/populateParentNodeNoLinks, plus every
+// ERROR/MISSING construction site across the parser_result_*.go /
+// parser_reduce.go / parser_recover_c.go builders) that backs the public
+// Node.HasError() API, and it is exact for every node that ever entered
+// oldTree — a subtree spliced into this parse's stacks by reuse is, by
+// construction, a subtree of oldTree, so it cannot carry error content
+// oldTree's own root bit does not already reflect. Byte-offset edits applied
+// to oldTree shift positions only, never symbols, so the bit stays valid
+// across ApplyEdit calls made before this reparse.
+//
+// A false result is not "assume clean" -- it is "provably clean, so let this
+// pass's own explicit set-true sites (missing-token insertion, error-run
+// leaves, resync recovery, cHandleError, ...) do exactly what they already
+// do for a fresh full parse": the moment this parse constructs its own
+// error/missing content, crecoveryCostCompetitionRelevant flips true from
+// that call site, same as today. A true old tree (or a defensively unknown
+// one) keeps the prior conservative behavior unchanged.
+func incrementalOldTreeMayCarryErrorCost(reuse *reuseCursor, oldTree *Tree) bool {
+	if reuse == nil && oldTree == nil {
+		return false
+	}
+	if oldTree == nil || oldTree.root == nil {
+		// Defensive: reuse should never be non-nil without a rooted oldTree
+		// (reuseCursor.reset returns nil otherwise), but an unknown old tree
+		// keeps the previously-conservative "assume relevant" answer.
+		return true
+	}
+	return oldTree.root.hasError()
+}
+
 // parseInternal is the core GLR parsing loop shared by Parse and
 // ParseWithTokenSource.
 //
@@ -4099,9 +4137,17 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		p.crecoveryEnteredErrorState = false
 		p.crecoveryDroppedErrorForClean = false
 		// Cost walks stay gated off until this pass proves costs can be
-		// nonzero; parses that may reuse old-tree subtrees start relevant
-		// because reused subtrees can already carry error nodes.
-		p.crecoveryCostCompetitionRelevant = reuse != nil || oldTree != nil
+		// nonzero. A fresh full parse starts clean (false). An incremental
+		// parse over an old tree that is itself clean (root.hasError()
+		// false) starts clean too: every subtree reuse can splice in was
+		// already part of that clean tree, so it cannot carry hidden error
+		// content, and any error this pass constructs on its own goes
+		// through the same explicit set-true sites a fresh parse uses (see
+		// incrementalOldTreeMayCarryErrorCost). Only an old tree that is
+		// itself known to have error/missing content anywhere starts the
+		// conservative true (reused subtrees may carry it in without a new
+		// pause this pass).
+		p.crecoveryCostCompetitionRelevant = incrementalOldTreeMayCarryErrorCost(reuse, oldTree)
 		p.cRecoverSharedTokenErrorModeLexed = false
 		p.cRecoverCustomResyncActive = false
 		p.cRecoverCustomResyncByte = 0

--- a/parser.go
+++ b/parser.go
@@ -4029,24 +4029,33 @@ func (p *Parser) guardRealShiftGap(source []byte, s *glrStack, tok Token) bool {
 //
 // When reuse is possible, the question is whether ANY subtree it could
 // splice in already carries error/missing content. oldTree.root.hasError()
-// answers that in O(1): it is the same cached, bottom-up-propagated bit
-// (tree.go populateParentNode/populateParentNodeNoLinks, plus every
-// ERROR/MISSING construction site across the parser_result_*.go /
-// parser_reduce.go / parser_recover_c.go builders) that backs the public
-// Node.HasError() API, and it is exact for every node that ever entered
-// oldTree — a subtree spliced into this parse's stacks by reuse is, by
-// construction, a subtree of oldTree, so it cannot carry error content
-// oldTree's own root bit does not already reflect. Byte-offset edits applied
-// to oldTree shift positions only, never symbols, so the bit stays valid
-// across ApplyEdit calls made before this reparse.
+// answers that in O(1) as a conservative-when-set signal. It is the same
+// cached, bottom-up-propagated bit that backs the public Node.HasError()
+// API. IMPORTANT: the bit can be UNDER-SET. reconcileStaleHasErrorFlags
+// (parser_result.go) is clear-only, and language normalizers call
+// setHasError(false) on repaired regions, so a tree can report a clean
+// root while a descendant is still IsMissing() (observed for python and
+// wgsl). Do not treat a false root bit as an exactness proof.
 //
-// A false result is not "assume clean" -- it is "provably clean, so let this
-// pass's own explicit set-true sites (missing-token insertion, error-run
-// leaves, resync recovery, cHandleError, ...) do exactly what they already
-// do for a fresh full parse": the moment this parse constructs its own
-// error/missing content, crecoveryCostCompetitionRelevant flips true from
-// that call site, same as today. A true old tree (or a defensively unknown
-// one) keeps the prior conservative behavior unchanged.
+// Why a false start stays safe despite under-set trees:
+//  1. Reuse admission checks the per-node hasError()/zero-width gates
+//     (incremental.go), so a MISSING leaf cannot be spliced directly.
+//  2. The languages observed to produce under-set trees carry external
+//     scanners that disable subtree reuse entirely, so their cost-bearing
+//     content never enters this parse.
+//  3. The pair-local backstop in glr.go (cost competition still runs when
+//     either merge candidate is cPaused or has cRec != nil) guards the
+//     residual case. Do not remove that guard on the strength of this
+//     starting flag.
+//
+// A false result is therefore not "assume clean" -- it is "no reusable
+// error content can enter, so let this pass's own explicit set-true sites
+// (missing-token insertion, error-run leaves, resync recovery,
+// cHandleError, ...) do exactly what they already do for a fresh full
+// parse": the moment this parse constructs its own error/missing content,
+// crecoveryCostCompetitionRelevant flips true from that call site, same as
+// today. A true old tree (or a defensively unknown one) keeps the prior
+// conservative behavior unchanged.
 func incrementalOldTreeMayCarryErrorCost(reuse *reuseCursor, oldTree *Tree) bool {
 	if reuse == nil && oldTree == nil {
 		return false
@@ -4138,15 +4147,15 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		p.crecoveryDroppedErrorForClean = false
 		// Cost walks stay gated off until this pass proves costs can be
 		// nonzero. A fresh full parse starts clean (false). An incremental
-		// parse over an old tree that is itself clean (root.hasError()
-		// false) starts clean too: every subtree reuse can splice in was
-		// already part of that clean tree, so it cannot carry hidden error
-		// content, and any error this pass constructs on its own goes
-		// through the same explicit set-true sites a fresh parse uses (see
-		// incrementalOldTreeMayCarryErrorCost). Only an old tree that is
-		// itself known to have error/missing content anywhere starts the
-		// conservative true (reused subtrees may carry it in without a new
-		// pause this pass).
+		// parse over an old tree whose root bit is clean starts clean too.
+		// The root bit can be under-set (see the safety chain documented on
+		// incrementalOldTreeMayCarryErrorCost: per-node reuse-admission
+		// gates + reuse-disabling scanners + the glr.go cPaused/cRec
+		// backstop keep that safe), and any error this pass constructs on
+		// its own goes through the same explicit set-true sites a fresh
+		// parse uses. Only an old tree that is itself known to have
+		// error/missing content anywhere starts the conservative true
+		// (reused subtrees may carry it in without a new pause this pass).
 		p.crecoveryCostCompetitionRelevant = incrementalOldTreeMayCarryErrorCost(reuse, oldTree)
 		p.cRecoverSharedTokenErrorModeLexed = false
 		p.cRecoverCustomResyncActive = false


### PR DESCRIPTION
## Summary

Reduce overhead in incremental parsing by gating recovery cost competition only when an old tree carries errors. Previously, any incremental parse with a reused subtree enabled cost competition unnecessarily.

## Changes

- Add `incrementalOldTreeMayCarryErrorCost` to check if an old tree contains errors using `root.hasError()`.
- Replace the unconditional cost competition gate in `parseInternal` with the new check.
- Skip the cost competition loop when incremental parses reuse subtrees from a clean old tree.

## Testing

- Run parity tests: `bash cgo_harness/docker/run_single_grammar_parity.sh <your_grammar>`
- Run performance benchmarks: `GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms`