### PR TITLE
update(grammars): Update Swift runtime profile digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Swift's certified runtime profile now attaches again.** PR #396
+  regenerated `swift.bin` for the DFA-minimization fix but did not update
+  the profile's pinned blob digest in `grammars/runtime_profiles.go`. The
+  stale digest silently dropped Swift's external-scanner skip-repeat policy
+  and its accepted-error retry skip. Swift parses still produced correct
+  trees; they ran extra retry passes. This release updates the pinned
+  digest to match the regenerated blob. No other grammar's profile carries
+  a stale digest.
+
 ## [0.44.0] - 2026-07-20
 
 ### Fixed

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -117,7 +117,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	// the retry ladder. High-pressure parses still benefit from the first
 	// ladder, while repeating that ladder for the external scanner does not.
 	"swift": {
-		blobSHA256:                    mustRuntimeProfileSHA256("91c05e1dd93ab285038f1c6b1f6ab9054586f765c2e45c518497ea556e00946e"),
+		blobSHA256:                    mustRuntimeProfileSHA256("d0bb8834f9a93fee2a268c81c04e9a36dde5f725db2e3ebc785ab43f79d2ae6a"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 		fullParseAcceptedErrorRetryProfile: gotreesitter.FullParseAcceptedErrorRetryProfile{
 			SkipCompleteAcceptedErrorRetry:  true,


### PR DESCRIPTION
## Summary

The regenerated Swift DFA profile uses an outdated SHA256 digest. The stale digest silently drops the external scanner skip repeat policy and the accepted error retry policy. This update replaces the hash value to restore the optimized retry ladder for Swift parses. No other grammar profiles require updates.

## Changes

- Update swift blob SHA256 in grammars/runtime_profiles.go to the regenerated hash.
- Add changelog entry to record the stale digest resolution.