### PR TITLE
release(docs): release v0.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,49 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.44.1] - 2026-07-20
+
 ### Fixed
 
-- **Swift's certified runtime profile now attaches again.** PR #396
-  regenerated `swift.bin` for the DFA-minimization fix but did not update
-  the profile's pinned blob digest in `grammars/runtime_profiles.go`. The
-  stale digest silently dropped Swift's external-scanner skip-repeat policy
-  and its accepted-error retry skip. Swift parses still produced correct
-  trees; they ran extra retry passes. This release updates the pinned
-  digest to match the regenerated blob. No other grammar's profile carries
-  a stale digest.
+- **Swift's certified runtime profile now attaches again.** PR #396's
+  `swift.bin` regeneration (the DFA-minimization fix, v0.44.0) did not
+  update the profile's pinned blob digest in
+  `grammars/runtime_profiles.go`. The stale digest silently dropped
+  Swift's external-scanner skip-repeat policy and its accepted-error
+  retry-skip policy (PR #400). The impact was performance-only.
+  Error-bearing Swift parses ran redundant retry ladders. Clean Swift
+  parses, and the v0.44.0 memory win, were unaffected. This release
+  updates the pinned digest to match the regenerated blob. No other
+  grammar's profile carries a stale digest.
+
+### Improved
+
+- **Go clean-file incremental edits are now O(edit), not O(file).** This
+  closes, for clean top-level edits, the Go reuse gap that v0.44.0 listed
+  as a known issue. Before dispatch reaches the reuse check, the parser
+  now applies any pending eager-default reduce chain to the live stack.
+  This is campaign O(edit) workstream W1b (PR #398), and it closes the
+  settling gap that blocked the W1 splice (PR #395) for Go.
+  `ReuseRejectRootNonLeafChanged` now holds at a small constant, 9,
+  regardless of file size. Node allocations drop 11 to 16 times. A 137KB
+  near-top insert now takes about 22ms, down from about 47ms. A 1MB file
+  takes about 162ms, down from about 356ms.
+- **Incremental parses over a provably clean old tree start the C-parity
+  cost-competition flag false**, matching fresh-parse behavior (PR #399,
+  campaign O(edit) workstream W3). Previously every incremental parse
+  started this flag conservatively true, even when the old tree carried
+  no errors. Outputs are proven unchanged: a differential over 8,361
+  edits is byte-identical to the prior behavior. The effect on wall time
+  is small today. It grows as reuse rates rise, particularly once W1b's
+  Go localization compounds with it.
+
+### Known Issues
+
+- The 1MB near-top edit still misses the campaign's 60ms target, at
+  about 162ms (PR #398). Composing the W1b settling fix with the W1
+  block-splice is the tracked follow-up.
+- GLR-heavy files with genuine ambiguity see little wall-time change
+  from W1b (PR #398), because settling runs on a single stack only.
 
 ## [0.44.0] - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -744,15 +744,18 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.44.0**. It fixes Swift's `Language()` memory
-ceiling breach. A cross-mode DFA minimization pass cuts Swift's retained
-memory from about 490 MB to about 25 MB, closing the sole documented CI
-memory-ceiling exception. It also replaces the cmake/css reuse allowlist
-with a fragility-gated top-level sibling block-splice; CSS editor-edit
-node reuse rises from 63.8% to 99.5%. Go node reuse is unchanged, pending
-a deeper engine fix. The prior release, v0.43.1, fixes TypeScript and TSX
-bare default parameters that previously collapsed to `ERROR` and reduces
-grammar-blob decoding allocation churn by about 32%.
+The current release is **v0.44.1**. It closes a fast-follow gap:
+v0.44.0's Swift DFA-minimization fix regenerated `swift.bin` but left a
+stale profile digest, so Swift's retry-ladder optimizations silently
+did not attach. The digest is now correct, and the effect was
+performance-only. It also lands the O(edit) `W1b` settling fix: Go
+clean-file incremental edits now cost O(edit), not O(file).
+`ReuseRejectRootNonLeafChanged` holds at 9 regardless of file size, and
+a 137KB near-top insert drops from about 47ms to about 22ms. GLR-heavy
+files with genuine ambiguity see little change, since settling runs on
+a single stack only. The prior release, v0.44.0, fixed Swift's
+`Language()` memory ceiling breach, from about 490 MB to about 25 MB,
+and raised CSS editor-edit node reuse from 63.8% to 99.5%.
 The authenticated production receipt at tag target `1935a42c` measures
 public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
 **5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst


### PR DESCRIPTION
## Summary

Moves pending changelog entries into the v0.44.1 release. It patches a stale digest for the Swift runtime profile to restore performance optimizations. It also documents the O(edit) settling improvement for Go and adjusts the C-parity flag for clean-tree incremental parses.

## Changes

- Update Swift runtime profile digest to restore external scanner optimizations and retry-skip policies.
- Document the O(edit) settling fix that reduces node allocations and speeds up Go clean-file incremental edits.
- Document the optimization that starts the C-parity cost-competition flag false for provably clean incremental parses.
- Update README to reflect v0.44.1 features and the known performance targets for large near-top edits.