### PR TITLE
add(incremental): introduce scanner quiescence proof for incremental reuse

### DIFF
--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -277,8 +277,20 @@ func currentExternalScannerCheckpoint(ts TokenSource) (externalScannerCheckpoint
 
 func canReuseNodeWithExternalScannerCheckpoint(ts TokenSource, startState StateID, node *Node) (externalScannerCheckpointRef, bool) {
 	dts := underlyingDFATokenSource(ts)
-	if dts == nil || !languageUsesExternalScannerCheckpoints(dts.language) {
+	if dts == nil {
 		return externalScannerCheckpointRef{}, true
+	}
+	if !languageUsesExternalScannerCheckpoints(dts.language) {
+		// Non-checkpoint external-scanner path. The W4 scanner-quiescence
+		// classifier is the per-boundary authority here (campaign O(edit),
+		// spec.campaign.oedit). A stateless scanner (Go's automatic-semicolon
+		// scanner, proven in external_scanner_quiescence.go) is quiescent at
+		// every boundary, so reuse is sound and returns a zero checkpoint the
+		// non-checkpoint reuse path never reads. A scanner that opts out of
+		// incremental reuse is refuted, and the caller fails closed. Every
+		// other language keeps the legacy blanket admission, so this stays
+		// neutral for production languages today.
+		return externalScannerCheckpointRef{}, externalScannerBoundaryQuiescentWithoutCheckpoint(dts.language)
 	}
 	if node == nil || startState != node.PreGotoState() {
 		return externalScannerCheckpointRef{}, false

--- a/external_scanner_quiescence.go
+++ b/external_scanner_quiescence.go
@@ -1,0 +1,137 @@
+package gotreesitter
+
+// External-scanner quiescence proof (campaign O(edit) workstream W4,
+// spec.campaign.oedit; shared artifact with campaign v6.7 Lane 4).
+//
+// Incremental subtree reuse skips the lexer forward to a reused node's end
+// byte and resumes parsing there. For a language with an external scanner,
+// this is sound only when the scanner state a fresh parse would hold at the
+// reuse boundary matches the state the reuse path resumes with. We call a
+// boundary "quiescent" when that match is provable. This file holds the
+// per-boundary quiescence predicate. It fails CLOSED: a boundary it cannot
+// prove quiescent is refuted, and the reuse admission counts it as
+// ReuseRejectScannerUnquiescent and skips reuse.
+//
+// The predicate replaces a name-allowlist with a proof (invariant 2 of the
+// campaign): reuse eligibility is decided per boundary from a scanner-state
+// argument, not from a curated language list.
+//
+// -----------------------------------------------------------------------
+// Go proof obligations (backed by grammars/go_scanner.go).
+//
+// Go's only external token is `_automatic_semicolon` (ASI). The scanner that
+// resolves it is GoExternalScanner. The proof that every Go reuse boundary is
+// quiescent rests on five obligations, each verified against the scanner
+// source:
+//
+//  1. No persisted state. Create returns nil, Serialize writes nothing and
+//     returns 0, and Deserialize is a no-op (go_scanner.go). The scanner
+//     therefore holds no payload and no cross-token state. There is nothing
+//     for a reused subtree to invalidate.
+//
+//  2. Scan is a pure function of the local byte stream and the valid-symbol
+//     set. Scan reads lexer.Lookahead() from the current position, advances
+//     over horizontal whitespace only, then branches on '\n', on 0 (end of
+//     file), or on any other byte (go_scanner.go). The valid-symbol set is
+//     itself a pure function of the LR parser state. Scan reads no other
+//     mutable state.
+//
+//  3. Terminator legality is grammar-gated, not history-gated. Scan runs only
+//     in LR states where `_automatic_semicolon` is a valid external symbol.
+//     grammargen places the terminator directly after a completed statement,
+//     declaration, or spec, so the scanner never needs to remember whether the
+//     previous token was an identifier, a literal, or a keyword (go_scanner.go
+//     doc, plus the terminator placement in grammargen's Go grammar).
+//
+//  4. Raw strings never induce scanner state. A Go raw string literal is
+//     delimited by back quotes and may span newlines. The DFA lexes it as one
+//     raw_string_literal token; the external terminator symbol is never valid
+//     between the opening and closing back quote, so Scan never runs inside a
+//     raw string. A raw string that spans a newline therefore creates no ASI
+//     state and no cross-boundary dependency. A boundary inside a raw string
+//     is never a top-level declaration boundary, so reuse never offers it as a
+//     candidate. When an edit changes back-quote balance, the byte-equality,
+//     stale-boundary, and fragility gates in tryReuseSubtree reject the
+//     affected subtree; that hazard is tokenization, not scanner state.
+//
+//  5. Comments before a declaration never induce scanner state. When Scan
+//     meets a comment start, it declines through the default branch; the token
+//     source resets the lexer to the start byte, the DFA matches the comment
+//     as an extra, and the parser retries the scanner past it. Extras do not
+//     change the LR state, so the valid-symbol set at the following boundary
+//     is unchanged (go_scanner.go).
+//
+// From obligations 1 and 2, the Go scanner state at any position is the empty
+// state, which equals the state a fresh parse holds at that position.
+// Obligations 3 to 5 confirm that the boundaries reuse actually considers --
+// top-level declaration boundaries, possibly preceded by comments or by raw
+// strings that span newlines -- do not smuggle in hidden state. Therefore
+// every Go reuse boundary is quiescent. QED.
+//
+// GoExternalScanner encodes this proof by implementing StatelessExternalScanner
+// and returning true; the classifier below reads that marker and returns
+// scannerQuiescenceProven.
+// -----------------------------------------------------------------------
+
+// externalScannerQuiescence is the per-boundary classification result.
+type externalScannerQuiescence uint8
+
+const (
+	// scannerQuiescenceProven: the scanner state a fresh parse holds at the
+	// boundary is provably identical to the state the reuse path resumes with.
+	// Reuse across the scanner is sound.
+	scannerQuiescenceProven externalScannerQuiescence = iota
+
+	// scannerQuiescenceUnknown: the W4 classifier neither proves nor refutes
+	// quiescence. The legacy per-language admission
+	// (languageSupportsIncrementalReuse, checked before tryReuseSubtree runs)
+	// stays the authority. This keeps the predicate neutral for every
+	// production external-scanner language that has not yet migrated to a
+	// per-boundary proof.
+	scannerQuiescenceUnknown
+
+	// scannerQuiescenceRefuted: the scanner carries cross-token state and this
+	// boundary has no matching checkpoint, so reuse is unsound. The caller
+	// fails closed: it rejects reuse and counts ReuseRejectScannerUnquiescent.
+	scannerQuiescenceRefuted
+)
+
+// classifyExternalScannerQuiescence decides, from the language's scanner alone,
+// whether reuse across the scanner is provably sound, provably unsound, or
+// undecided. Checkpoint languages are reported as undecided here; the
+// checkpoint match in canReuseNodeWithExternalScannerCheckpoint decides them
+// per boundary from recorded state.
+func classifyExternalScannerQuiescence(lang *Language) externalScannerQuiescence {
+	if lang == nil || lang.ExternalScanner == nil {
+		// No external scanner means no scanner state to reconstruct.
+		return scannerQuiescenceProven
+	}
+	if stateless, ok := lang.ExternalScanner.(StatelessExternalScanner); ok && stateless.ExternalScannerIsStateless() {
+		// A stateless scanner (Go's ASI scanner) is quiescent at every
+		// boundary. See the proof obligations at the top of this file.
+		return scannerQuiescenceProven
+	}
+	if reusable, ok := lang.ExternalScanner.(IncrementalReuseExternalScanner); ok && !reusable.SupportsIncrementalReuse() {
+		// The scanner opts out of incremental reuse because it holds serialized
+		// mutable state, such as Python's indentation stack. Refute per boundary
+		// as a fail-closed backstop behind the language-level gate.
+		return scannerQuiescenceRefuted
+	}
+	if languageUsesExternalScannerCheckpoints(lang) {
+		// A checkpoint match decides these boundaries, not this classifier.
+		return scannerQuiescenceUnknown
+	}
+	// A scanner the classifier cannot decide keeps the legacy blanket
+	// admission. This branch is neutral: the language-level gate already
+	// vetted the scanner before reuse could reach this point.
+	return scannerQuiescenceUnknown
+}
+
+// externalScannerBoundaryQuiescentWithoutCheckpoint reports whether a
+// non-checkpoint external-scanner language may reuse a subtree at a candidate
+// boundary. It returns false only when the classifier refutes quiescence, so a
+// caller that rejects on false is fail-closed while staying neutral for every
+// language the classifier reports as proven or undecided.
+func externalScannerBoundaryQuiescentWithoutCheckpoint(lang *Language) bool {
+	return classifyExternalScannerQuiescence(lang) != scannerQuiescenceRefuted
+}

--- a/external_scanner_quiescence_test.go
+++ b/external_scanner_quiescence_test.go
@@ -1,0 +1,83 @@
+package gotreesitter
+
+import "testing"
+
+// quiescenceOptOutScanner models a genuinely stateful scanner (Python's
+// indentation stack is the production example): it implements
+// IncrementalReuseExternalScanner and opts out. The classifier must refute it.
+type quiescenceOptOutScanner struct {
+	parserTestUnsafeExternalScanner
+}
+
+func (quiescenceOptOutScanner) SupportsIncrementalReuse() bool { return false }
+
+// quiescenceStatelessScanner models Go's automatic-semicolon scanner: it
+// carries no cross-token state and declares itself stateless. The classifier
+// must prove it quiescent.
+type quiescenceStatelessScanner struct {
+	parserTestUnsafeExternalScanner
+}
+
+func (quiescenceStatelessScanner) ExternalScannerIsStateless() bool { return true }
+
+func TestClassifyExternalScannerQuiescence(t *testing.T) {
+	cases := []struct {
+		name string
+		lang *Language
+		want externalScannerQuiescence
+	}{
+		{"nil language", nil, scannerQuiescenceProven},
+		{"no scanner", &Language{}, scannerQuiescenceProven},
+		{"stateless scanner", &Language{ExternalScanner: quiescenceStatelessScanner{}}, scannerQuiescenceProven},
+		{"opt-out scanner", &Language{ExternalScanner: quiescenceOptOutScanner{}}, scannerQuiescenceRefuted},
+		{"undecided scanner", &Language{ExternalScanner: parserTestUnsafeExternalScanner{}}, scannerQuiescenceUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyExternalScannerQuiescence(tc.lang); got != tc.want {
+				t.Fatalf("classifyExternalScannerQuiescence = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExternalScannerBoundaryQuiescentFailsClosed proves the predicate rejects
+// a boundary it cannot prove quiescent. A stateful opt-out scanner is the
+// "deliberately unprovable boundary" the W4 hard gate requires (an edit inside
+// a raw string, or any state a fresh parse could not reconstruct, lands here).
+func TestExternalScannerBoundaryQuiescentFailsClosed(t *testing.T) {
+	if externalScannerBoundaryQuiescentWithoutCheckpoint(&Language{ExternalScanner: quiescenceOptOutScanner{}}) {
+		t.Fatal("opt-out scanner admitted: predicate must fail closed on a refuted boundary")
+	}
+	if !externalScannerBoundaryQuiescentWithoutCheckpoint(&Language{ExternalScanner: quiescenceStatelessScanner{}}) {
+		t.Fatal("stateless scanner rejected: predicate must admit a proven boundary")
+	}
+	if !externalScannerBoundaryQuiescentWithoutCheckpoint(&Language{}) {
+		t.Fatal("no-scanner language rejected: predicate must admit a proven boundary")
+	}
+}
+
+// TestCanReuseNodeFailsClosedOnRefutedScanner drives the actual reuse-admission
+// hook with a refuted scanner and proves it rejects, without reading the node.
+// The language-level gate blocks such scanners upstream in production, so this
+// is the fail-closed backstop that keeps the hook itself sound.
+func TestCanReuseNodeFailsClosedOnRefutedScanner(t *testing.T) {
+	ts := &dfaTokenSource{language: &Language{ExternalScanner: quiescenceOptOutScanner{}}}
+	if _, ok := canReuseNodeWithExternalScannerCheckpoint(ts, 0, nil); ok {
+		t.Fatal("canReuseNodeWithExternalScannerCheckpoint admitted a refuted scanner")
+	}
+}
+
+// TestCanReuseNodeAdmitsStatelessScanner proves the hook admits a proven
+// (stateless) boundary, returning a zero checkpoint the non-checkpoint reuse
+// path never reads.
+func TestCanReuseNodeAdmitsStatelessScanner(t *testing.T) {
+	ts := &dfaTokenSource{language: &Language{ExternalScanner: quiescenceStatelessScanner{}}}
+	cp, ok := canReuseNodeWithExternalScannerCheckpoint(ts, 0, nil)
+	if !ok {
+		t.Fatal("canReuseNodeWithExternalScannerCheckpoint rejected a proven stateless scanner")
+	}
+	if cp != (externalScannerCheckpointRef{}) {
+		t.Fatal("proven stateless boundary returned a non-zero checkpoint")
+	}
+}

--- a/grammars/go_scanner.go
+++ b/grammars/go_scanner.go
@@ -60,6 +60,28 @@ func (GoExternalScanner) Deserialize(payload any, buf []byte)   {}
 // returns nil), so incremental subtree reuse is always safe.
 func (GoExternalScanner) SupportsIncrementalReuse() bool { return true }
 
+// ExternalScannerIsStateless discharges the campaign O(edit) W4 scanner-
+// quiescence proof for Go (spec.campaign.oedit). It reports that the scanner
+// holds no cross-token state, so its state at any boundary equals the state a
+// fresh parse holds there and every reuse boundary is quiescent. The five
+// proof obligations, each verified against this file, live in the package doc
+// of external_scanner_quiescence.go:
+//
+//  1. No persisted state: Create returns nil, Serialize returns 0, Deserialize
+//     is a no-op (above).
+//  2. Scan is a pure function of the local lookahead and the valid-symbol set
+//     (Scan below reads only lexer.Lookahead() and validSymbols).
+//  3. Terminator legality is grammar-gated, not history-gated (the scanner
+//     runs only where the grammar makes _automatic_semicolon valid).
+//  4. Raw strings never induce scanner state (the DFA lexes raw_string_literal
+//     as one token; the terminator symbol is never valid inside it).
+//  5. Comments before a declaration never induce scanner state (Scan declines,
+//     the DFA matches the comment as an extra, and extras keep the LR state).
+//
+// The classifier reads this marker as a proof, so an incorrect true is silent
+// incremental corruption. Keep the marker in lockstep with the scanner.
+func (GoExternalScanner) ExternalScannerIsStateless() bool { return true }
+
 // PreservesStateOnScanFailure: Scan never mutates any persisted payload
 // before returning false (there is no payload), so the token source can
 // skip the snapshot/restore it would otherwise do around a failed scan.

--- a/incremental.go
+++ b/incremental.go
@@ -49,8 +49,15 @@ type reuseCursor struct {
 	// Node.isFragile() -- see tryReuseSubtree's non-leaf fallback lane below
 	// and the Parser.ReuseRejectFragileNonLeaf profile field (parser.go).
 	rejectFragileNonLeaf uint64
-	forestFastPath       bool
-	languageName         string // cached for language-specific reuse safety policies
+	// rejectScannerUnquiescent counts reuse candidates rejected by the external
+	// scanner checkpoint/quiescence gate (canReuseNodeWithExternalScannerCheck
+	// point) -- either a checkpoint state mismatch or a refuted quiescence
+	// proof (campaign O(edit) W4, external_scanner_quiescence.go). It stays 0
+	// for stateless-scanner languages such as Go, whose every boundary is
+	// proven quiescent. See the Parser.ReuseRejectScannerUnquiescent field.
+	rejectScannerUnquiescent uint64
+	forestFastPath           bool
+	languageName             string // cached for language-specific reuse safety policies
 }
 
 // reuseScratch holds reusable buffers for incremental reuse traversal.
@@ -95,6 +102,7 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.rejectLargeNonLeaf = 0
 	c.rejectStaleNonLeafBoundary = 0
 	c.rejectFragileNonLeaf = 0
+	c.rejectScannerUnquiescent = 0
 	c.forestFastPath = oldTree.forestFastPath
 	c.languageName = ""
 	if oldTree.language != nil {
@@ -547,6 +555,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		}
 		cp, ok := canReuseNodeWithExternalScannerCheckpoint(ts, state, n)
 		if !ok {
+			idx.rejectScannerUnquiescent++
 			continue
 		}
 		return reuseNode(p, s, n, nextState, state, lookahead, ts, idx, entryScratch, gssScratch, cp)
@@ -632,6 +641,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		startState := s.top().state
 		cp, ok := canReuseNodeWithExternalScannerCheckpoint(ts, startState, n)
 		if !ok {
+			idx.rejectScannerUnquiescent++
 			continue
 		}
 		return reuseNode(p, s, n, nextState, startState, lookahead, ts, idx, entryScratch, gssScratch, cp)

--- a/language.go
+++ b/language.go
@@ -194,6 +194,23 @@ type IncrementalReuseExternalScanner interface {
 	SupportsIncrementalReuse() bool
 }
 
+// StatelessExternalScanner is implemented by external scanners that carry no
+// serialized state across tokens. Their Scan decision is a pure function of the
+// byte stream at the lexer position and the valid-symbol set, and the
+// valid-symbol set is itself a pure function of the LR parser state. For such a
+// scanner the state at any boundary equals the state a fresh parse holds there,
+// so the scanner-quiescence proof obligation (campaign O(edit) workstream W4)
+// is discharged at every boundary. Go's automatic-semicolon scanner is the
+// reference example; see external_scanner_quiescence.go for the proof.
+//
+// A scanner implements this only when it can meet every quiescence obligation.
+// The classifier reads the marker as a proof, so an incorrect true is silent
+// incremental corruption.
+type StatelessExternalScanner interface {
+	ExternalScanner
+	ExternalScannerIsStateless() bool
+}
+
 // FailurePreservingExternalScanner is implemented by external scanners whose
 // Scan method does not mutate serialized scanner payload state before returning
 // false. The token source can defer snapshotting until retry is actually needed.

--- a/parser.go
+++ b/parser.go
@@ -1199,7 +1199,16 @@ type IncrementalParseProfile struct {
 	// (incremental.go). A nonzero count on a conflict-heavy grammar (e.g. js)
 	// is expected and correct: it is exactly the unsound reuse this gate is
 	// designed to prevent.
-	ReuseRejectFragileNonLeaf           uint64
+	ReuseRejectFragileNonLeaf uint64
+	// ReuseRejectScannerUnquiescent counts reuse candidates the external
+	// scanner checkpoint/quiescence gate rejected -- a checkpoint state
+	// mismatch on a checkpoint language, or a refuted quiescence proof on an
+	// opt-out scanner (campaign O(edit) workstream W4, spec.campaign.oedit).
+	// It is 0 for stateless-scanner languages such as Go, whose ASI scanner
+	// carries no cross-token state and is proven quiescent at every boundary
+	// (external_scanner_quiescence.go). A nonzero count marks boundaries where
+	// scanner state, not fragility or byte drift, is the binding constraint.
+	ReuseRejectScannerUnquiescent       uint64
 	RecoverSearches                     uint64
 	RecoverStateChecks                  uint64
 	RecoverStateSkips                   uint64
@@ -1298,6 +1307,7 @@ type incrementalParseTiming struct {
 	reuseRejectLargeNonLeaf             uint64
 	reuseRejectStaleNonLeafBoundary     uint64
 	reuseRejectFragileNonLeaf           uint64
+	reuseRejectScannerUnquiescent       uint64
 	recoverSearches                     uint64
 	recoverStateChecks                  uint64
 	recoverStateSkips                   uint64
@@ -2973,6 +2983,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 			timing.reuseRejectLargeNonLeaf += reuse.rejectLargeNonLeaf
 			timing.reuseRejectStaleNonLeafBoundary += reuse.rejectStaleNonLeafBoundary
 			timing.reuseRejectFragileNonLeaf += reuse.rejectFragileNonLeaf
+			timing.reuseRejectScannerUnquiescent += reuse.rejectScannerUnquiescent
 		}
 		if timing != nil {
 			reuseStart := time.Now()

--- a/parser_go_scanner_quiescence_test.go
+++ b/parser_go_scanner_quiescence_test.go
@@ -1,0 +1,323 @@
+package gotreesitter_test
+
+// Campaign O(edit) workstream W4 (spec.campaign.oedit): the Go external-scanner
+// quiescence proof. Go's automatic-semicolon scanner carries no cross-token
+// state (grammars/go_scanner.go, external_scanner_quiescence.go), so every
+// reuse boundary is quiescent. These real-parse tests enforce two things the
+// W4 hard gate requires:
+//
+//   - Oracle equality on adversarial ASI edges. For every byte offset in each
+//     fixture, for insert / delete / same-length replace, where the fresh
+//     parse of the edited text is genuinely clean, ParseIncremental must be
+//     byte-identical to Parse (a full-fidelity walk over type, span, named,
+//     missing, error, and every child including anonymous ones). The fixtures
+//     target the exact edges the proof reasons about: statements that end at a
+//     newline versus a semicolon, raw strings that span a boundary, and
+//     comments before a declaration.
+//
+//   - The scanner gate is never the binding constraint for Go. Across the whole
+//     sweep, ReuseUnsupported stays false and ReuseRejectScannerUnquiescent
+//     stays 0, while some site actually reuses subtrees. Go reuse is admitted
+//     by the scanner gate; the constraint lives elsewhere (fragility and
+//     root-non-leaf), which is the honest W4 finding.
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Compile-time proof that Go's scanner encodes the quiescence marker.
+var _ gts.StatelessExternalScanner = grammars.GoExternalScanner{}
+
+// w4GoAdversarialFixtures target the ASI edges the quiescence proof reasons
+// about. Each has several top-level declarations so trailing-sibling reuse is
+// available for the sweep to exercise.
+func w4GoAdversarialFixtures() map[string][]byte {
+	backtick := "`"
+	return map[string][]byte{
+		// Statements ending at a newline versus a semicolon (mixed ASI).
+		"asi_newline_vs_semicolon": []byte(
+			"package p\n\n" +
+				"func a() int {\n\tx := 1\n\ty := 2; z := 3\n\treturn x + y + z\n}\n\n" +
+				"func b() int {\n\treturn 7\n}\n\n" +
+				"var c = 4\n"),
+		// Raw string literals that span a boundary (newlines inside back quotes).
+		"raw_string_spanning": []byte(
+			"package p\n\n" +
+				"var doc = " + backtick + "line one\nline two\nline three" + backtick + "\n\n" +
+				"func d() string {\n\treturn " + backtick + "inner\nraw" + backtick + "\n}\n\n" +
+				"var tail = 9\n"),
+		// Comments (line and block) before a declaration.
+		"comment_before_decl": []byte(
+			"package p\n\n" +
+				"// leading line comment\nfunc e() int {\n\treturn 1\n}\n\n" +
+				"/* leading block comment */\nfunc f() int {\n\treturn 2\n}\n\n" +
+				"var g = 3 // trailing\n"),
+		// A dense top-level declaration list, the reuse workhorse. The bodies
+		// are deliberately parameterless: a typed parameter list such as
+		// (a, b int) degenerates into Go's untyped-parameter-list ambiguity
+		// under a single-byte delete, which is a fragility-gate hazard, not a
+		// scanner-quiescence one, and would confound this scanner-focused sweep.
+		"many_top_level": func() []byte {
+			var b bytes.Buffer
+			b.WriteString("package p\n\n")
+			for i := 0; i < 12; i++ {
+				fmt.Fprintf(&b, "func h%d() int {\n\treturn %d\n}\n\n", i, i)
+			}
+			return b.Bytes()
+		}(),
+	}
+}
+
+// w4FullFidelityDiff returns the first structural difference between fresh and
+// incr, or "" when they are byte-identical trees. It walks every child,
+// including anonymous ones, and every attribute the oracle contract covers.
+func w4FullFidelityDiff(lang *gts.Language, fresh, incr *gts.Node, path string) string {
+	if fresh == nil || incr == nil {
+		if fresh == incr {
+			return ""
+		}
+		return fmt.Sprintf("%s: nil mismatch fresh=%v incr=%v", path, fresh != nil, incr != nil)
+	}
+	ft, it := fresh.Type(lang), incr.Type(lang)
+	if ft != it {
+		return fmt.Sprintf("%s: type %q != %q", path, ft, it)
+	}
+	cur := path + ">" + ft
+	if fresh.StartByte() != incr.StartByte() || fresh.EndByte() != incr.EndByte() {
+		return fmt.Sprintf("%s: span [%d,%d) != [%d,%d)", cur, fresh.StartByte(), fresh.EndByte(), incr.StartByte(), incr.EndByte())
+	}
+	if fresh.IsNamed() != incr.IsNamed() {
+		return fmt.Sprintf("%s: named %v != %v", cur, fresh.IsNamed(), incr.IsNamed())
+	}
+	if fresh.IsMissing() != incr.IsMissing() {
+		return fmt.Sprintf("%s: missing %v != %v", cur, fresh.IsMissing(), incr.IsMissing())
+	}
+	if fresh.IsError() != incr.IsError() {
+		return fmt.Sprintf("%s: error %v != %v", cur, fresh.IsError(), incr.IsError())
+	}
+	if fresh.ChildCount() != incr.ChildCount() {
+		return fmt.Sprintf("%s: childCount %d != %d", cur, fresh.ChildCount(), incr.ChildCount())
+	}
+	for i := 0; i < fresh.ChildCount(); i++ {
+		if d := w4FullFidelityDiff(lang, fresh.Child(i), incr.Child(i), cur); d != "" {
+			return d
+		}
+	}
+	return ""
+}
+
+func w4TreeIsGenuinelyClean(root *gts.Node, editedLen int) bool {
+	if root == nil {
+		return false
+	}
+	if root.StartByte() != 0 || int(root.EndByte()) != editedLen {
+		return false
+	}
+	errN, missN := incrGateTreeStats(root)
+	return errN == 0 && missN == 0
+}
+
+// TestGoScannerQuiescenceOracleSweep is the adversarial sweep. It proves
+// incremental == fresh byte-for-byte on every freshly-clean ASI-edge site and
+// that the scanner gate never blocks or rejects Go reuse.
+func TestGoScannerQuiescenceOracleSweep(t *testing.T) {
+	lang := grammars.GoLanguage()
+	editClasses := []string{"insert", "delete", "replace"}
+
+	var totalSites, cleanSites, reusedSites int
+	var maxReused uint64
+
+	for name, src := range w4GoAdversarialFixtures() {
+		// A clean base parse is a fixture invariant.
+		baseParser := gts.NewParser(lang)
+		baseTree, err := baseParser.Parse(src)
+		if err != nil {
+			t.Fatalf("%s: base parse: %v", name, err)
+		}
+		if errN, missN := incrGateTreeStats(baseTree.RootNode()); errN != 0 || missN != 0 {
+			t.Fatalf("%s: fixture base parse not clean (err=%d miss=%d)", name, errN, missN)
+		}
+		baseTree.Release()
+
+		for _, class := range editClasses {
+			for off := 0; off < len(src); off++ {
+				if class != "insert" && off >= len(src) {
+					continue
+				}
+				edited, edit := incrGateBuildEdit(src, off, class)
+
+				// Fresh parse of the edited text.
+				freshParser := gts.NewParser(lang)
+				freshTree, err := freshParser.Parse(edited)
+				if err != nil {
+					t.Fatalf("%s/%s@%d: fresh parse: %v", name, class, off, err)
+				}
+				freshClean := w4TreeIsGenuinelyClean(freshTree.RootNode(), len(edited))
+
+				// Incremental parse from the edited old tree.
+				incrParser := gts.NewParser(lang)
+				oldTree, err := incrParser.Parse(src)
+				if err != nil {
+					t.Fatalf("%s/%s@%d: old parse: %v", name, class, off, err)
+				}
+				oldTree.Edit(edit)
+				incrTree, prof, err := incrParser.ParseIncrementalProfiled(edited, oldTree)
+				if err != nil {
+					t.Fatalf("%s/%s@%d: incremental parse: %v", name, class, off, err)
+				}
+
+				totalSites++
+				if prof.ReusedSubtrees > 0 {
+					reusedSites++
+					if prof.ReusedSubtrees > maxReused {
+						maxReused = prof.ReusedSubtrees
+					}
+				}
+
+				// The scanner gate must never block or reject Go reuse, at any
+				// site, clean or not.
+				if prof.ReuseUnsupported {
+					t.Fatalf("%s/%s@%d: Go reuse unexpectedly unsupported: %q",
+						name, class, off, prof.ReuseUnsupportedReason)
+				}
+				if prof.ReuseRejectScannerUnquiescent != 0 {
+					t.Fatalf("%s/%s@%d: ReuseRejectScannerUnquiescent=%d, want 0 (Go is quiescent everywhere)",
+						name, class, off, prof.ReuseRejectScannerUnquiescent)
+				}
+
+				// Oracle equality on freshly-clean sites.
+				if freshClean {
+					cleanSites++
+					if d := w4FullFidelityDiff(lang, freshTree.RootNode(), incrTree.RootNode(), name+"/"+class); d != "" {
+						t.Fatalf("%s/%s@%d: incremental != fresh: %s\n--- edited ---\n%s",
+							name, class, off, d, string(edited))
+					}
+				}
+
+				incrTree.Release()
+				oldTree.Release()
+				freshTree.Release()
+			}
+		}
+	}
+
+	if reusedSites == 0 || maxReused == 0 {
+		t.Fatalf("sweep reused no subtrees (reusedSites=%d maxReused=%d): the quiescence assertion is vacuous",
+			reusedSites, maxReused)
+	}
+	t.Logf("sweep: sites=%d freshClean=%d reusedSites=%d maxReusedSubtrees=%d", totalSites, cleanSites, reusedSites, maxReused)
+}
+
+// TestGoNearTopInsertScannerGateNotBinding proves, on a representative
+// multi-declaration Go file, that a near-top single-char insert reuses
+// subtrees with the scanner gate fully open: ReuseUnsupported is false and
+// ReuseRejectScannerUnquiescent is 0. This is the measured basis for the W4
+// binding-constraint verdict.
+func TestGoNearTopInsertScannerGateNotBinding(t *testing.T) {
+	lang := grammars.GoLanguage()
+	var b bytes.Buffer
+	b.WriteString("package p\n\n")
+	for i := 0; i < 60; i++ {
+		fmt.Fprintf(&b, "func f%d(a, b int) int {\n\treturn a + b\n}\n\n", i)
+	}
+	src := b.Bytes()
+
+	parser := gts.NewParser(lang)
+	oldTree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("base parse: %v", err)
+	}
+	if oldTree.RootNode().HasError() {
+		t.Fatal("fixture base parse not clean")
+	}
+
+	const off = 40 // inside the first func's identifier, well past the package clause
+	edited := make([]byte, 0, len(src)+1)
+	edited = append(edited, src[:off]...)
+	edited = append(edited, 'q')
+	edited = append(edited, src[off:]...)
+	p := incrGatePointAt(src, off)
+	oldTree.Edit(gts.InputEdit{
+		StartByte: off, OldEndByte: off, NewEndByte: off + 1,
+		StartPoint: p, OldEndPoint: p, NewEndPoint: incrGatePointAt(edited, off+1),
+	})
+
+	incrTree, prof, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	defer incrTree.Release()
+	defer oldTree.Release()
+
+	if prof.ReuseUnsupported {
+		t.Fatalf("Go reuse unsupported: %q", prof.ReuseUnsupportedReason)
+	}
+	if prof.ReuseRejectScannerUnquiescent != 0 {
+		t.Fatalf("ReuseRejectScannerUnquiescent=%d, want 0", prof.ReuseRejectScannerUnquiescent)
+	}
+	if prof.ReusedSubtrees == 0 {
+		t.Fatal("expected Go reuse to take some subtrees with the scanner gate open")
+	}
+
+	// Oracle equality with a fresh parse of the edited text.
+	freshParser := gts.NewParser(lang)
+	freshTree, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh parse: %v", err)
+	}
+	defer freshTree.Release()
+	if d := w4FullFidelityDiff(lang, freshTree.RootNode(), incrTree.RootNode(), "nearTop"); d != "" {
+		t.Fatalf("incremental != fresh: %s", d)
+	}
+}
+
+// TestScannerUnquiescentCounterSurfacesForCheckpointLanguage drives the
+// ReuseRejectScannerUnquiescent counter above 0 through the full profile
+// pipeline on a real parse. CMake is a checkpoint-scanner language: a mid-file
+// insert leaves some reuse candidates with a scanner checkpoint the live state
+// cannot validate, and the gate rejects them. This keeps the counter honest --
+// it can never be silently neutered -- and proves the plumbing surfaces real
+// values, not a hard-wired 0 (the W5 gate-counter residual, applied to W4).
+func TestScannerUnquiescentCounterSurfacesForCheckpointLanguage(t *testing.T) {
+	lang := grammars.CmakeLanguage()
+	if lang == nil {
+		t.Skip("cmake language not built into this binary")
+	}
+	var b bytes.Buffer
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&b, "set(VAR%d value%d)\nmessage(STATUS \"item%d\")\n", i, i, i)
+	}
+	src := b.Bytes()
+
+	parser := gts.NewParser(lang)
+	oldTree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("base parse: %v", err)
+	}
+	off := len(src) / 2
+	edited := make([]byte, 0, len(src)+1)
+	edited = append(edited, src[:off]...)
+	edited = append(edited, 'X')
+	edited = append(edited, src[off:]...)
+	p := incrGatePointAt(src, off)
+	oldTree.Edit(gts.InputEdit{
+		StartByte: uint32(off), OldEndByte: uint32(off), NewEndByte: uint32(off + 1),
+		StartPoint: p, OldEndPoint: p, NewEndPoint: incrGatePointAt(edited, off+1),
+	})
+	incrTree, prof, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	defer incrTree.Release()
+	defer oldTree.Release()
+
+	if prof.ReuseRejectScannerUnquiescent == 0 {
+		t.Fatal("ReuseRejectScannerUnquiescent stayed 0 for a checkpoint-scanner language: " +
+			"the counter is dead plumbing or the gate was neutered")
+	}
+}

--- a/parser_incremental_support.go
+++ b/parser_incremental_support.go
@@ -55,6 +55,7 @@ func (t *incrementalParseTiming) toProfile() IncrementalParseProfile {
 		ReuseRejectLargeNonLeaf:             t.reuseRejectLargeNonLeaf,
 		ReuseRejectStaleNonLeafBoundary:     t.reuseRejectStaleNonLeafBoundary,
 		ReuseRejectFragileNonLeaf:           t.reuseRejectFragileNonLeaf,
+		ReuseRejectScannerUnquiescent:       t.reuseRejectScannerUnquiescent,
 		RecoverSearches:                     t.recoverSearches,
 		RecoverStateChecks:                  t.recoverStateChecks,
 		RecoverStateSkips:                   t.recoverStateSkips,
@@ -158,6 +159,7 @@ func (t *incrementalParseTiming) addAttempt(other *incrementalParseTiming) {
 	t.reuseRejectLargeNonLeaf += other.reuseRejectLargeNonLeaf
 	t.reuseRejectStaleNonLeafBoundary += other.reuseRejectStaleNonLeafBoundary
 	t.reuseRejectFragileNonLeaf += other.reuseRejectFragileNonLeaf
+	t.reuseRejectScannerUnquiescent += other.reuseRejectScannerUnquiescent
 	t.recoverSearches += other.recoverSearches
 	t.recoverStateChecks += other.recoverStateChecks
 	t.recoverStateSkips += other.recoverStateSkips


### PR DESCRIPTION
## Summary

Replace the allowlist for external-scanner incremental reuse with a per-boundary quiescence classifier. The classifier proves reuse soundness for stateless scanners, refutes stateful opt-out scanners, and leaves checkpoint-based scanners to their checkpoint match. This change adds a new profiling counter to track scanner rejections. It also formalizes the Go ASI scanner proof obligations.

## Changes

- Add `external_scanner_quiescence.go`. The classifier proves quiescence for stateless scanners, refutes opt-out stateful scanners, and defers to checkpoints otherwise.
- Route non-checkpoint languages through the new classifier. This enables fail-closed reuse admission without checkpoint state.
- Add `StatelessExternalScanner` interface to `language.go`.
- Make `GoExternalScanner` implement the new interface. The code documents five proof obligations. These obligations ensure no cross-token state leaks into reuse boundaries.
- Add `rejectScannerUnquiescent` counter to `reuseCursor`, `incrementalParseTiming`, and `IncrementalParseProfile` to track boundaries rejected by the scanner gate.
- Add unit tests. The tests verify the classifier classifies nil, stateless, opt-out, and undecided scanners correctly. The tests also enforce fail-closed behavior.
- Add an adversarial oracle sweep for Go. The sweep proves byte-identical incremental and fresh parses across newlines, raw strings, and comments. The sweep confirms the scanner gate never blocks Go reuse.
- Verify the new counter surfaces correctly for checkpoint-scanner languages. This ensures the plumbing remains active.

## Testing

- go test ./... -run 'TestClassifyExternalScannerQuiescence|TestExternalScannerBoundaryQuiescentFailsClosed|TestCanReuseNodeFailsClosedOnRefutedScanner|TestCanReuseNodeAdmitsStatelessScanner|TestGoScannerQuiescenceOracleSweep|TestGoNearTopInsertScannerGateNotBinding|TestScannerUnquiescentCounterSurfacesForCheckpointLanguage' -count=1