### PR TITLE
fix(parser): fix TypeScript arrow functions with return type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **TypeScript arrow functions with a return-type annotation** (`const f =
+  (a: A): B => { ... }`) no longer collapse to `ERROR` when they appear as
+  the value of a `const`/`let` declaration (issue #402). The typed-arrow
+  and destructured-arrow-return-type merge-width detectors added in PR #389
+  did not cover this shape: neither requires the arrow to be immediately
+  preceded by `)` (the destructured-return-type case scans past a
+  return-type annotation, but only accepts a destructured `[`/`{`
+  parameter list). A typed, non-destructured parameter list combined with
+  an explicit return-type annotation fell through both. This fix adds a
+  dedicated detector for that shape and widens the merge budget to two
+  survivors, matching the existing typed-arrow and default-parameter
+  cases. TSX was unaffected; its wider JSX conflict set kept a second
+  survivor alive through the same fork.
+
 ## [0.44.1] - 2026-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,21 @@ for tags and release notes while still in `0.x`.
   dedicated detector for that shape and widens the merge budget to two
   survivors, matching the existing typed-arrow and default-parameter
   cases. TSX was unaffected; its wider JSX conflict set kept a second
-  survivor alive through the same fork.
+  survivor alive through the same fork. The detector's first pass also
+  missed sibling shapes with a parenthesized return type (`(a: A): (B) =>
+  a`, `(a: A): (string | number) => a`, `(a: A): (() => B) => a`); its
+  backward colon scan now balances parens so a colon nested inside the
+  return type is not mistaken for the top-level boundary.
+- This is the **third** source-heuristic merge-width detector guarding the
+  same root cause as the PR #389 default-parameter fix: the GLR engine's
+  steady-state merge budget discards a live fork by score before any
+  structural comparison runs. Each detector treats one shape's symptom.
+  The structural cure -- comparing candidate forks structurally before
+  falling back to score at the merge site -- remains tracked and is in
+  active development on `codex/glr-structure-before-score`. As with its
+  siblings, this detector's backward scans are bounded to 512/2048-byte
+  windows; a return-type expression whose own top-level colon sits past
+  that window silently misses the widening.
 
 ## [0.44.1] - 2026-07-20
 

--- a/parser.go
+++ b/parser.go
@@ -6562,11 +6562,12 @@ func (p *Parser) resolveParseMergePerKeyCap(source []byte, reuse *reuseCursor, m
 	mergePerKeyCap := effectiveParseMergePerKeyCap(p.language, parseMaxMergePerKeyValue(), reuse != nil, len(source))
 	tsNeedsTypedArrow := typeScriptFullParseNeedsTypedArrowMergeWidth(p.language, source, reuse)
 	tsNeedsDefaultParameter := typeScriptFullParseNeedsDefaultParameterMergeWidth(p.language, source, reuse)
+	tsNeedsTypedParameterArrowReturn := typeScriptFullParseNeedsTypedParameterArrowReturnMergeWidth(p.language, source, reuse)
 	if typeScriptFullParseNeedsDestructuredArrowReturnMergeWidth(p.language, source, reuse) {
 		if mergePerKeyCap < maxStacksPerMergeKey {
 			mergePerKeyCap = maxStacksPerMergeKey
 		}
-	} else if (tsNeedsTypedArrow || tsNeedsDefaultParameter) && mergePerKeyCap < 2 {
+	} else if (tsNeedsTypedArrow || tsNeedsDefaultParameter || tsNeedsTypedParameterArrowReturn) && mergePerKeyCap < 2 {
 		mergePerKeyCap = 2
 	}
 	if javaFullParseNeedsAnnotationDeclarationMergeWidth(p.language, source, reuse) && mergePerKeyCap < javaFullParseRetryMaxMergePerKey {

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -2514,6 +2514,35 @@ func TestConfigureParseCapsTypedArrowKeepsTypedArrowWidthOnLargeTypeScript(t *te
 	}
 }
 
+// TestConfigureParseCapsTypedParameterArrowReturnTypeKeepsCapTwoOnLargeTypeScript
+// is the .d.ts-blowup guard for issue #402's fix: a large filler source that
+// also carries the typed-parameter-plus-return-type arrow shape
+// ("(a: A): B => ...") must widen to exactly cap two, the same floor as the
+// existing typed-arrow and default-parameter detectors, never the wide
+// six-survivor destructured-return-type floor. PR #389 established that the
+// six-survivor floor causes an intra-token population explosion on large
+// union-list .d.ts-shaped sources; this guards the new detector against
+// regressing that ceiling.
+func TestConfigureParseCapsTypedParameterArrowReturnTypeKeepsCapTwoOnLargeTypeScript(t *testing.T) {
+	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "")
+	ResetParseEnvConfigCacheForTests()
+	defer ResetParseEnvConfigCacheForTests()
+
+	source := []byte(strings.Repeat("const filler = 1;\n", 8192) + "const f = (a: A): B => { return a; };\n")
+	parser := &Parser{language: &Language{Name: "typescript"}}
+	var scratch parserScratch
+
+	caps := parser.configureParseCaps(source, nil, arenaClassFull, &scratch, 0, 0, 0)
+	if caps.mergePerKeyCap != 2 {
+		t.Fatalf("configureParseCaps(large TypeScript typed-parameter arrow return type) merge cap = %d, want 2", caps.mergePerKeyCap)
+	}
+
+	caps = parser.configureParseCaps(source, nil, arenaClassFull, &scratch, 0, 0, -4)
+	if caps.mergePerKeyCap != 4 {
+		t.Fatalf("configureParseCaps(large TypeScript typed-parameter arrow return type, exact retry cap) merge cap = %d, want 4", caps.mergePerKeyCap)
+	}
+}
+
 func TestEffectiveParseMergePerKeyCapJavaExplicitOverride(t *testing.T) {
 	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "4")
 	t.Setenv("GOT_FAITHFUL_CONDENSE", "1")

--- a/parser_leaf_token_regression_test.go
+++ b/parser_leaf_token_regression_test.go
@@ -789,6 +789,146 @@ func TestParseTypeScriptDestructuredArrowReturnTypeCallArgument(t *testing.T) {
 	}
 }
 
+// TestParseTypeScriptArrowReturnTypeAnnotation guards issue #402: an arrow
+// function with a typed parameter AND an explicit return-type annotation
+// ("(a: A): B => ...") collapsed to a top-level ERROR when it was the value
+// of a const/let declaration. The locked C tree-sitter-typescript oracle's
+// _call_signature production (formal_parameters return_type?) competes, at
+// the identical post-')' state, with reducing the parenthesized parameter
+// list as a plain parenthesized_expression once a top-level ':' follows the
+// ')'; the pattern-reduction derivation was being discarded before the
+// return-type/arrow tokens confirmed it, under the steady-state cap-one
+// merge budget (see typeScriptSourceHasTypedParameterArrowReturnType in
+// parser_retry.go). TSX already parsed this correctly because its wider JSX
+// conflict set keeps a second survivor alive through the fork.
+func TestParseTypeScriptArrowReturnTypeAnnotation(t *testing.T) {
+	src := "const f = (a: A): B => { return a; };\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript arrow return-type annotation root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"lexical_declaration", "arrow_function", "formal_parameters", "required_parameter", "type_annotation", "statement_block"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript arrow return-type annotation missing %s: %s", want, sexpr)
+		}
+	}
+	if strings.Contains(sexpr, "ERROR") {
+		t.Fatalf("typescript arrow return-type annotation retained an ERROR node: %s", sexpr)
+	}
+}
+
+// TestParseTSXArrowReturnTypeAnnotation is the TSX-side companion to
+// TestParseTypeScriptArrowReturnTypeAnnotation: TSX already parsed this
+// shape correctly before the fix, so this pins the s-expression shape to
+// prevent a regression while confirming TypeScript now matches it.
+func TestParseTSXArrowReturnTypeAnnotation(t *testing.T) {
+	src := "const f = (a: A): B => { return a; };\n"
+	tree, lang := parseLanguageSample(t, "tsx", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("tsx arrow return-type annotation root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	want := "(program (lexical_declaration (variable_declarator (identifier) (arrow_function (formal_parameters (required_parameter (identifier) (type_annotation (type_identifier)))) (type_annotation (type_identifier)) (statement_block (return_statement (identifier)))))))"
+	if sexpr != want {
+		t.Fatalf("tsx arrow return-type annotation sexpr = %s, want %s", sexpr, want)
+	}
+}
+
+// TestParseTypeScriptExportArrowReturnTypeAnnotation covers the "export
+// const" variant of issue #402: the export wrapper must not change whether
+// the widening detector fires.
+func TestParseTypeScriptExportArrowReturnTypeAnnotation(t *testing.T) {
+	src := "export const f = (a: A): B => { return a; };\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript export arrow return-type annotation root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"export_statement", "lexical_declaration", "arrow_function", "type_annotation"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript export arrow return-type annotation missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptArrowNoReturnTypeAnnotationControl is the negative
+// control for issue #402: a typed-parameter arrow with no return-type
+// annotation was never affected (the existing typed-arrow-parameters
+// widening already covers it) and must keep parsing cleanly.
+func TestParseTypeScriptArrowNoReturnTypeAnnotationControl(t *testing.T) {
+	src := "const f = (a: A) => { return a; };\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript arrow no-return-type control root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	if strings.Contains(sexpr, "type_annotation") && strings.Count(sexpr, "type_annotation") != 1 {
+		t.Fatalf("typescript arrow no-return-type control unexpected type_annotation count: %s", sexpr)
+	}
+}
+
+// TestParseTypeScriptArrowReturnTypeAnnotationLongerFixture reproduces the
+// reporter's bisect fixture shape for issue #402: several preceding
+// top-level declarations (import, interface, type alias, enum, two classes)
+// followed by a trailing "export const make = (id: ID): User => {...}". The
+// reporter noted this shape happened to parse on v0.21.0 in some
+// larger-file contexts before the v0.22.0 conflict-policy change made it
+// fail consistently, so this fixture guards the fix at realistic file
+// scale, not just the minimal one-liner.
+func TestParseTypeScriptArrowReturnTypeAnnotationLongerFixture(t *testing.T) {
+	src := `import { z } from "zod";
+
+interface Config {
+	name: string;
+}
+
+type ID = string;
+
+enum Status {
+	Active,
+	Inactive,
+}
+
+class Base {
+	id: ID;
+}
+
+class UserStore extends Base {
+	items: Record<ID, unknown> = {};
+}
+
+export const make = (id: ID): User => {
+	return { id, name: "" };
+};
+`
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript arrow return-type annotation longer fixture root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"export_statement", "arrow_function", "formal_parameters", "required_parameter", "statement_block"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript arrow return-type annotation longer fixture missing %s: %s", want, sexpr)
+		}
+	}
+}
+
 func TestParseJavaScriptJSXMultipleAttributesAfterExpression(t *testing.T) {
 	src := "const el = <Foo bar=\"string\" baz={2} data-i8n=\"dialogs.welcome.heading\" bam />\n"
 	tree, lang := parseLanguageSample(t, "javascript", src)

--- a/parser_leaf_token_regression_test.go
+++ b/parser_leaf_token_regression_test.go
@@ -929,6 +929,106 @@ export const make = (id: ID): User => {
 	}
 }
 
+// TestParseTypeScriptArrowParenthesizedReturnType guards a sibling shape of
+// issue #402 found in PR review: a typed-parameter arrow whose return-type
+// annotation is itself parenthesized ("(a: A): (B) => a"). The original
+// fix's backward colon-scan stopped at the first ')' it met, so it never
+// walked past the return type's own closing paren to find the true
+// return-type colon. The scan now balances parens while walking backward so
+// it only accepts a colon seen at paren depth zero.
+func TestParseTypeScriptArrowParenthesizedReturnType(t *testing.T) {
+	src := "const f = (a: A): (B) => a;\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript arrow parenthesized return type root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"arrow_function", "formal_parameters", "required_parameter", "parenthesized_type"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript arrow parenthesized return type missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptArrowUnionInParensReturnType covers a union type inside
+// a parenthesized return-type annotation ("(a: A): (string | number) =>
+// a"), the shape that motivated the balanced-paren backward scan: the union
+// members and the "|" separator sit between the return type's own
+// parentheses, well within the scan's 512-byte window, and must not be
+// mistaken for a top-level colon boundary.
+func TestParseTypeScriptArrowUnionInParensReturnType(t *testing.T) {
+	src := "const f = (a: A): (string | number) => a;\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript arrow union-in-parens return type root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"arrow_function", "parenthesized_type", "union_type"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript arrow union-in-parens return type missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptArrowFunctionTypeReturnType covers a nested
+// function-type return annotation ("(a: A): (() => B) => a"): the return
+// type itself contains an inner "=>" and its own parenthesized empty
+// parameter list. The detector's outer loop tries every "=>" occurrence in
+// source order, so a non-matching inner "=>" (its own backward scan lands
+// on the outer arrow's parameter-list colon, which is not immediately
+// preceded by ')') falls through cleanly to the real, outer arrow.
+func TestParseTypeScriptArrowFunctionTypeReturnType(t *testing.T) {
+	src := "const f = (a: A): (() => B) => a;\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript arrow function-type return type root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	for _, want := range []string{"arrow_function", "parenthesized_type", "function_type"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("typescript arrow function-type return type missing %s: %s", want, sexpr)
+		}
+	}
+}
+
+// TestParseTypeScriptTypeAnnotationArrowValueControl is the negative
+// control for the balanced-paren scan: "const x: (a: A) => B = foo" is a
+// variable's own type annotation (a function_type in type position), not an
+// arrow_function value expression. The scan's backward walk from the
+// declarator's arrow can land on the *declarator's* type-annotation colon
+// (also at paren depth zero) instead of a return-type colon, but that
+// colon is preceded by an identifier byte, not ')', so the subsequent
+// matchingOpenParenBefore check rejects it. This shape must not trigger the
+// merge-width widening: it was never affected by issue #402 (no
+// required_parameter/parenthesized_expression fork here), and it exercises
+// the exact false-positive risk the balanced-paren scan must avoid.
+func TestParseTypeScriptTypeAnnotationArrowValueControl(t *testing.T) {
+	src := "const x: (a: A) => B = foo;\n"
+	tree, lang := parseLanguageSample(t, "typescript", src)
+	t.Cleanup(tree.Release)
+
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	if root.Type(lang) != "program" || root.HasError() {
+		t.Fatalf("typescript type-annotation arrow-value control root = %s hasError=%v; tree=%s", root.Type(lang), root.HasError(), sexpr)
+	}
+	if strings.Contains(sexpr, "arrow_function") {
+		t.Fatalf("typescript type-annotation arrow-value control unexpectedly parsed a value arrow_function: %s", sexpr)
+	}
+	if !strings.Contains(sexpr, "function_type") {
+		t.Fatalf("typescript type-annotation arrow-value control missing function_type: %s", sexpr)
+	}
+}
+
 func TestParseJavaScriptJSXMultipleAttributesAfterExpression(t *testing.T) {
 	src := "const el = <Foo bar=\"string\" baz={2} data-i8n=\"dialogs.welcome.heading\" bam />\n"
 	tree, lang := parseLanguageSample(t, "javascript", src)

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1110,6 +1110,21 @@ func typeScriptFullParseNeedsDestructuredArrowReturnMergeWidth(lang *Language, s
 		typeScriptSourceHasDestructuredArrowReturnType(source)
 }
 
+// typeScriptFullParseNeedsTypedParameterArrowReturnMergeWidth reports whether
+// source needs the cap-two merge width for an arrow function whose formal
+// parameter list carries a parameter type annotation (e.g. "(a: A)") and is
+// itself followed by an explicit return-type annotation before the arrow
+// (e.g. "(a: A): B =>"). See
+// typeScriptSourceHasTypedParameterArrowReturnType for the grammar-fork
+// rationale (issue #402).
+func typeScriptFullParseNeedsTypedParameterArrowReturnMergeWidth(lang *Language, source []byte, reuse *reuseCursor) bool {
+	return lang != nil &&
+		reuse == nil &&
+		!parseMaxMergePerKeyEnvConfigured() &&
+		(lang.Name == "typescript" || lang.Name == "tsx") &&
+		typeScriptSourceHasTypedParameterArrowReturnType(source)
+}
+
 func typeScriptSourceHasTypedArrowParameters(source []byte) bool {
 	if len(source) == 0 || !bytes.Contains(source, []byte(":")) {
 		return false
@@ -1206,6 +1221,76 @@ func typeScriptSourceHasDestructuredArrowReturnType(source []byte) bool {
 				break
 			}
 			if open := matchingOpenParenBefore(source, close, 2048); open >= 0 && bytes.ContainsAny(source[open:close], "[{") {
+				return true
+			}
+		}
+		offset = arrow + len("=>")
+	}
+}
+
+// typeScriptSourceHasTypedParameterArrowReturnType reports whether source
+// contains an arrow function whose parenthesized formal-parameter list
+// carries at least one parameter type annotation (a bare "(a: A)" slot, not
+// a destructured "[" / "{" pattern -- that shape is covered separately by
+// typeScriptSourceHasDestructuredArrowReturnType) and is itself followed by
+// an explicit return-type annotation before the arrow, e.g.
+// "(a: A): B => ...". The locked C grammar's _call_signature production
+// (formal_parameters return_type?) competes, at the identical post-')'
+// state, with reducing the parenthesized parameter list as a plain
+// parenthesized_expression once a top-level ':' follows the ')'. Both
+// derivations are live through the parameter list's own required_parameter
+// reduction (itself only reachable when the parameter carries a
+// type_annotation), so under the steady-state cap-one merge budget (see
+// typescriptFullParseCanUseTightMergeCap) one of the two forks is discarded
+// before the return-type/arrow tokens are seen, collapsing the whole
+// declaration to ERROR (issue #402). An untyped parameter list followed by a
+// return type ("(a): B =>") does not hit this fork: with no type_annotation
+// inside the parameter list, the required_parameter reduction is not itself
+// ambiguous, so the existing steady-state cap is sufficient. The scan reuses
+// the same bounded backward-colon-then-matching-paren technique as
+// typeScriptSourceHasDestructuredArrowReturnType, capped at the same 512 and
+// 2048 byte windows.
+func typeScriptSourceHasTypedParameterArrowReturnType(source []byte) bool {
+	if len(source) == 0 || !bytes.Contains(source, []byte("=>")) {
+		return false
+	}
+	offset := 0
+	for {
+		rel := bytes.Index(source[offset:], []byte("=>"))
+		if rel < 0 {
+			return false
+		}
+		arrow := offset + rel
+		i := arrow - 1
+		for i >= 0 {
+			switch source[i] {
+			case ' ', '\t', '\n', '\r':
+				i--
+				continue
+			}
+			break
+		}
+		colon := -1
+		for j := i; j >= 0 && arrow-j <= 512; j-- {
+			if source[j] == ':' {
+				colon = j
+				break
+			}
+			if source[j] == ')' {
+				break
+			}
+		}
+		if colon >= 0 {
+			close := colon - 1
+			for close >= 0 {
+				switch source[close] {
+				case ' ', '\t', '\n', '\r':
+					close--
+					continue
+				}
+				break
+			}
+			if open := matchingOpenParenBefore(source, close, 2048); open >= 0 && bytes.Contains(source[open:close], []byte(":")) {
 				return true
 			}
 		}

--- a/parser_retry.go
+++ b/parser_retry.go
@@ -1246,10 +1246,31 @@ func typeScriptSourceHasDestructuredArrowReturnType(source []byte) bool {
 // declaration to ERROR (issue #402). An untyped parameter list followed by a
 // return type ("(a): B =>") does not hit this fork: with no type_annotation
 // inside the parameter list, the required_parameter reduction is not itself
-// ambiguous, so the existing steady-state cap is sufficient. The scan reuses
-// the same bounded backward-colon-then-matching-paren technique as
-// typeScriptSourceHasDestructuredArrowReturnType, capped at the same 512 and
-// 2048 byte windows.
+// ambiguous, so the existing steady-state cap is sufficient.
+//
+// This is the third source-heuristic detector guarding the same underlying
+// root cause as typeScriptSourceHasTypedArrowParameters and
+// typeScriptSourceHasBareDefaultParameter: the GLR engine's steady-state
+// merge budget discards a live fork by score before any structural
+// comparison ever runs (stackCompareMergeSmallCapOne). Widening the cap
+// per detected shape treats a symptom, not the defect; the structural cure
+// -- comparing candidate forks structurally before falling back to score at
+// the merge site -- is tracked and in active development on
+// codex/glr-structure-before-score. Detectors like this one should be
+// retired once that lands.
+//
+// The scan walks backward from the arrow, balancing parens so a colon
+// nested inside a parenthesized return type (e.g. "(a: A): (string |
+// number) => a" or "(a: A): (() => B) => a") is not mistaken for the
+// top-level return-type colon; only a colon seen at paren depth zero is a
+// candidate. The walk is bounded to the same 512-byte window as
+// typeScriptSourceHasDestructuredArrowReturnType, and the parameter-list
+// match is bounded to the same 2048-byte window as
+// matchingOpenParenBefore's other callers. A return-type expression whose
+// own top-level colon sits more than 512 bytes before the arrow -- a
+// pathological width no known real-world return-type annotation reaches --
+// silently misses, the same bounded-window trade-off the sibling detectors
+// already accept.
 func typeScriptSourceHasTypedParameterArrowReturnType(source []byte) bool {
 	if len(source) == 0 || !bytes.Contains(source, []byte("=>")) {
 		return false
@@ -1271,13 +1292,19 @@ func typeScriptSourceHasTypedParameterArrowReturnType(source []byte) bool {
 			break
 		}
 		colon := -1
+		parenDepth := 0
+	colonLoop:
 		for j := i; j >= 0 && arrow-j <= 512; j-- {
-			if source[j] == ':' {
-				colon = j
-				break
-			}
-			if source[j] == ')' {
-				break
+			switch source[j] {
+			case ')':
+				parenDepth++
+			case '(':
+				parenDepth--
+			case ':':
+				if parenDepth == 0 {
+					colon = j
+					break colonLoop
+				}
 			}
 		}
 		if colon >= 0 {


### PR DESCRIPTION
## Summary

TypeScript arrow functions with typed parameters followed by an explicit return-type annotation (e.g. `const f = (a: A): B => { ... }`) were collapsing to ERROR. The greedy merge budget discarded one live parse fork before the return-type and arrow tokens confirmed the correct derivation. This fix adds a dedicated detector for this shape and widens the merge budget to two survivors, matching the existing typed-arrow and destructured-return-type cases.

## Changes

- Add `typeScriptSourceHasTypedParameterArrowReturnType` scanner that identifies arrow functions with typed parameters followed by a return-type annotation using a bounded backward scan from the arrow.
- Add `typeScriptFullParseNeedsTypedParameterArrowReturnMergeWidth` gate function to trigger cap-two widening when the new pattern is detected in TypeScript or TSX source.
- Update `resolveParseMergePerKeyCap` in parser.go to include the new detector in the existing cap-two widening path alongside typed-arrow and default-parameter cases.
- Add parity tests for TypeScript and TSX that verify the arrow function with typed parameters+return type parses cleanly without ERROR nodes.
- Add control test for untyped-parameter arrows to confirm they remain unaffected by the change.
- Add regression test with a multi-declaration fixture matching the reporter's bisect result shape.

## Testing

- `bash cgo_harness/docker/run_single_grammar_parity.sh typescript`
- `bash cgo_harness/docker/run_single_grammar_parity.sh tsx`
- `go test ./parser -run 'TestParseTypeScriptArrowReturnTypeAnnotation|TestParseTSXArrowReturnTypeAnnotation|TestParseTypeScriptExportArrowReturnTypeAnnotation|TestParseTypeScriptArrowNoReturnTypeAnnotationControl|TestParseTypeScriptArrowReturnTypeAnnotationLongerFixture'`
- `go test ./parser -run 'TestConfigureParseCapsTypedParameterArrowReturnTypeKeepsCapTwoOnLargeTypeScript'`

## Related Issues

- Refs #402