### PR TITLE
optimize(parsercore-phase0): reduce allocation overhead in cohort and frontier operations

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1233,6 +1233,8 @@ func (c *Core) ShiftClassified(boundary ClassifiedBoundary, actionOrdinal int, t
 // Missing, no-lookahead, reused, and scanner-checkpoint identity remain
 // caller-visible concerns. External provenance is one compact identity bit;
 // scanner state remains outside this layer.
+// The returned slice is transient scheduler-owned scratch. It stays valid
+// only until the next cohort shift on this Core; clone it to retain it.
 func (c *Core) ShiftOrdinaryCohort(inputs []OrdinaryCohortShiftInput, lookahead Symbol, token Token) (out []Head, err error) {
 	if len(inputs) == 0 {
 		return nil, errors.New("parser-core phase zero: empty ordinary shift cohort")
@@ -1253,6 +1255,8 @@ func (c *Core) ShiftOrdinaryCohort(inputs []OrdinaryCohortShiftInput, lookahead 
 
 // ShiftOrdinaryClassifiedCohort is the classified scheduler form of
 // ShiftOrdinaryCohort. Every boundary must select one ordinary shift.
+// The returned slice is transient scheduler-owned scratch. It stays valid
+// only until the next cohort shift on this Core; clone it to retain it.
 func (c *Core) ShiftOrdinaryClassifiedCohort(boundaries []ClassifiedBoundary, token Token) (out []Head, err error) {
 	var inlineTargets [inlineSchedulerCohortTargets]StateID
 	targets := inlineTargets[:]
@@ -1277,6 +1281,8 @@ func (c *Core) ShiftOrdinaryClassifiedCohort(boundaries []ClassifiedBoundary, to
 // payload. Every selected cell must contain one undecorated extra shift. A
 // target state of zero retains that head's current state, matching production
 // extraShiftTargetState semantics.
+// The returned slice is transient scheduler-owned scratch. It stays valid
+// only until the next cohort shift on this Core; clone it to retain it.
 func (c *Core) ShiftExtraCohort(inputs []ExtraCohortShiftInput, lookahead Symbol, token Token) (out []Head, err error) {
 	if len(inputs) == 0 {
 		return nil, errors.New("parser-core phase zero: empty extra shift cohort")
@@ -1297,6 +1303,8 @@ func (c *Core) ShiftExtraCohort(inputs []ExtraCohortShiftInput, lookahead Symbol
 
 // ShiftExtraClassifiedCohort is the classified scheduler form of
 // ShiftExtraCohort. Every boundary must select one extra shift.
+// The returned slice is transient scheduler-owned scratch. It stays valid
+// only until the next cohort shift on this Core; clone it to retain it.
 func (c *Core) ShiftExtraClassifiedCohort(boundaries []ClassifiedBoundary, token Token) (out []Head, err error) {
 	var inlineTargets [inlineSchedulerCohortTargets]StateID
 	targets := inlineTargets[:]

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -581,6 +581,8 @@ type Core struct {
 	work                Work
 	popScratch          popEnumerationScratch
 	reductionScratch    reductionOutputScratch
+	cohortHeadScratch   []Head
+	factorLinkScratch   []linkRecord
 	selectedBuild       selectedStoreBuildScratch
 	selectedPoolMu      sync.Mutex
 	selectedPool        selectedStoreBacking
@@ -2057,50 +2059,65 @@ func (c *Core) factorExactPredecessor(key boundaryKey, probe boundaryProbe, oldI
 			return condenseOutcome{}, true, errors.New("parser-core phase zero: exact recursive edge is not a clean shallow payload")
 		}
 
-		handled = true
-		mark := c.mark()
-		defer c.completeTransaction(mark, &err)
-		if phase0AEnabled {
-			phase0ABeginPredecessorMerge(c, incumbent.prev, in.prev)
-		}
-		merged, changed, mergeErr := c.mergePredecessorsOneLayer(incumbent.prev, in.prev)
-		if mergeErr != nil {
-			if phase0AEnabled {
-				phase0AAbortPredecessorMerge(c)
-			}
-			return condenseOutcome{}, true, mergeErr
-		}
-		if !changed {
-			if phase0AEnabled {
-				phase0AAbortPredecessorMerge(c)
-				phase0AObserveFactorNoChange(c, key, in, oldID, index)
-			}
-			return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, true, nil
-		}
-		if phase0AEnabled {
-			phase0AObserveAdjacencyPublished(c, merged)
-		}
-		rebuilt := slices.Clone(oldLinks)
-		rebuilt[index].prev = merged
-		if phase0AEnabled {
-			phase0APrepareFactorOuter(c, key, in, oldID, index, merged)
-		}
-		id, appendErr := c.appendAdjacencyNode(key.state, key.byteOffset, rebuilt)
-		if appendErr != nil {
-			return condenseOutcome{}, true, appendErr
-		}
-		if phase0AEnabled {
-			phase0AObserveAdjacencyPublished(c, id)
-		}
-		if err := c.publishBoundary(probe, id); err != nil {
-			return condenseOutcome{}, true, err
-		}
-		if phase0AEnabled {
-			phase0AObserveFactorPublished(c, oldID, id)
-		}
-		return condenseOutcome{head: Head{Node: id}, change: condenseUpdated}, true, nil
+		// The merge-and-republish body owns a bounded transaction. It lives in a
+		// dedicated method so its completion defer is open-coded, not heap-
+		// allocated once per exact-predecessor factor by a loop-scoped defer.
+		return c.factorExactPredecessorMerge(key, probe, oldID, oldLinks, index, incumbent, in)
 	}
 	return condenseOutcome{}, false, nil
+}
+
+// factorExactPredecessorMerge merges one incumbent predecessor with the
+// incoming edge and republishes the boundary. Callers pass the matched
+// incumbent link and its index. The transaction completion runs through a
+// single function-scoped defer, so it is open-coded and does not allocate.
+func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe, oldID NodeID, oldLinks []linkRecord, index int, incumbent linkRecord, in linkInput) (out condenseOutcome, handled bool, err error) {
+	handled = true
+	mark := c.mark()
+	defer c.completeTransaction(mark, &err)
+	if phase0AEnabled {
+		phase0ABeginPredecessorMerge(c, incumbent.prev, in.prev)
+	}
+	merged, changed, mergeErr := c.mergePredecessorsOneLayer(incumbent.prev, in.prev)
+	if mergeErr != nil {
+		if phase0AEnabled {
+			phase0AAbortPredecessorMerge(c)
+		}
+		return condenseOutcome{}, true, mergeErr
+	}
+	if !changed {
+		if phase0AEnabled {
+			phase0AAbortPredecessorMerge(c)
+			phase0AObserveFactorNoChange(c, key, in, oldID, index)
+		}
+		return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, true, nil
+	}
+	if phase0AEnabled {
+		phase0AObserveAdjacencyPublished(c, merged)
+	}
+	// appendAdjacencyNode copies every link into the arena, so the rebuilt set
+	// is transient and reuses a scheduler-owned scratch buffer instead of
+	// cloning oldLinks on every exact-predecessor factor.
+	rebuilt := append(c.factorLinkScratch[:0], oldLinks...)
+	c.factorLinkScratch = rebuilt
+	rebuilt[index].prev = merged
+	if phase0AEnabled {
+		phase0APrepareFactorOuter(c, key, in, oldID, index, merged)
+	}
+	id, appendErr := c.appendAdjacencyNode(key.state, key.byteOffset, rebuilt)
+	if appendErr != nil {
+		return condenseOutcome{}, true, appendErr
+	}
+	if phase0AEnabled {
+		phase0AObserveAdjacencyPublished(c, id)
+	}
+	if err := c.publishBoundary(probe, id); err != nil {
+		return condenseOutcome{}, true, err
+	}
+	if phase0AEnabled {
+		phase0AObserveFactorPublished(c, oldID, id)
+	}
+	return condenseOutcome{head: Head{Node: id}, change: condenseUpdated}, true, nil
 }
 
 func (c *Core) mergePredecessorsOneLayer(leftID, rightID NodeID) (NodeID, bool, error) {

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -85,15 +85,13 @@ func (c *Core) prepareOrdinaryClassifiedCohortInto(boundaries []ClassifiedBounda
 	if shifted.Extra || shifted.EndByte <= shifted.StartByte {
 		return errors.New("parser-core phase zero: cohort token is not an ordinary positive-width terminal")
 	}
-	seen := make(map[NodeID]struct{}, len(boundaries))
 	for index, boundary := range boundaries {
 		if shifted.Symbol != boundary.lookahead {
 			return fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", shifted.Symbol, boundary.lookahead)
 		}
-		if _, duplicate := seen[boundary.head.Node]; duplicate {
+		if cohortHasDuplicateHead(boundaries, index) {
 			return fmt.Errorf("parser-core phase zero: duplicate ordinary cohort head %d", boundary.head.Node)
 		}
-		seen[boundary.head.Node] = struct{}{}
 		action, err := c.classifiedActionRef(boundary, 0)
 		if err != nil {
 			return err
@@ -106,6 +104,19 @@ func (c *Core) prepareOrdinaryClassifiedCohortInto(boundaries []ClassifiedBounda
 	return nil
 }
 
+// cohortHasDuplicateHead reports whether boundaries[index] repeats a head node
+// already present earlier in the cohort. Cohort widths are bounded by the live
+// frontier, so this linear back-scan replaces a per-shift map allocation.
+func cohortHasDuplicateHead(boundaries []ClassifiedBoundary, index int) bool {
+	head := boundaries[index].head.Node
+	for prior := 0; prior < index; prior++ {
+		if boundaries[prior].head.Node == head {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Core) shiftOrdinaryClassifiedCohortUncheckpointed(boundaries []ClassifiedBoundary, targets []StateID, shifted Token) ([]Head, error) {
 	payload, err := c.appendAuthenticatedTerminal(subtreeRecord{
 		symbol: shifted.Symbol, startByte: shifted.StartByte, endByte: shifted.EndByte,
@@ -115,7 +126,7 @@ func (c *Core) shiftOrdinaryClassifiedCohortUncheckpointed(boundaries []Classifi
 		return nil, err
 	}
 	phase0AObserveTerminalCohortShift(c, payload, boundaries, targets, shifted.EndByte, false)
-	out := make([]Head, len(boundaries))
+	out := c.cohortHeads(len(boundaries))
 	for index, boundary := range boundaries {
 		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targets[index], shifted.EndByte), linkInput{
 			prev: boundary.head.Node, payload: payload,
@@ -127,6 +138,21 @@ func (c *Core) shiftOrdinaryClassifiedCohortUncheckpointed(boundaries []Classifi
 	}
 	c.addWork(&c.work.Shifts, uint64(len(boundaries)))
 	return out, nil
+}
+
+// cohortHeads returns a reused scratch slice of exactly width heads. The
+// caller consumes the result before the next cohort shift, so one scheduler-
+// owned buffer serves both the ordinary and extra cohort paths without
+// allocating one head slice per shift.
+func (c *Core) cohortHeads(width int) []Head {
+	out := c.cohortHeadScratch
+	if cap(out) < width {
+		out = make([]Head, width, max(width, 2*cap(out)))
+	} else {
+		out = out[:width]
+	}
+	c.cohortHeadScratch = out
+	return out
 }
 
 // ShiftExtraClassifiedCohortOwned authenticates the scheduler owner, then
@@ -160,15 +186,13 @@ func (c *Core) prepareExtraClassifiedCohortInto(boundaries []ClassifiedBoundary,
 	if !shifted.Extra || shifted.EndByte <= shifted.StartByte {
 		return errors.New("parser-core phase zero: cohort token is not a positive-width extra terminal")
 	}
-	seen := make(map[NodeID]struct{}, len(boundaries))
 	for index, boundary := range boundaries {
 		if shifted.Symbol != boundary.lookahead {
 			return fmt.Errorf("parser-core phase zero: token symbol %d != lookahead %d", shifted.Symbol, boundary.lookahead)
 		}
-		if _, duplicate := seen[boundary.head.Node]; duplicate {
+		if cohortHasDuplicateHead(boundaries, index) {
 			return fmt.Errorf("parser-core phase zero: duplicate extra cohort head %d", boundary.head.Node)
 		}
-		seen[boundary.head.Node] = struct{}{}
 		action, err := c.classifiedActionRef(boundary, 0)
 		if err != nil {
 			return err
@@ -193,7 +217,7 @@ func (c *Core) shiftExtraClassifiedCohortUncheckpointed(boundaries []ClassifiedB
 		return nil, err
 	}
 	phase0AObserveTerminalCohortShift(c, payload, boundaries, targets, shifted.EndByte, true)
-	out := make([]Head, len(boundaries))
+	out := c.cohortHeads(len(boundaries))
 	for index, boundary := range boundaries {
 		outcome, err := c.condenseWithOutcomeAtomic(c.shiftedBoundaryKey(targets[index], shifted.EndByte), linkInput{
 			prev: boundary.head.Node, payload: payload,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1298,6 +1298,8 @@ type diagnosticParserCoreGenericScheduler struct {
 	reductionOutputs           []core.ReductionOutput
 	reductionReplacements      []diagnosticParserCoreHeader
 	classifiedBoundaries       []core.ClassifiedBoundary
+	electStates                []StateID
+	electGLRStates             []StateID
 	work                       DiagnosticParserCoreGenericWork
 	epochProgress              bool
 	acceptedHead               core.Head
@@ -2191,57 +2193,74 @@ func compactDerivationsForAcceptance(compact *core.Core, head core.Head) ([]core
 	return paths, err
 }
 
+// diagnosticParserCoreGenericNoActionDropEligible reports whether at least one
+// non-paused sibling head is still live (shifted or accepted). noActionIndices
+// is ascending and unique (dispatch-pass order), so the paused set is matched
+// with a two-pointer walk rather than an allocated map.
 func diagnosticParserCoreGenericNoActionDropEligible(headers []diagnosticParserCoreHeader, noActionIndices []int, epochProgress bool) bool {
 	if !epochProgress || len(noActionIndices) == 0 || len(noActionIndices) >= len(headers) {
 		return false
 	}
-	noAction := make(map[int]struct{}, len(noActionIndices))
+	prev := -1
 	for _, index := range noActionIndices {
-		if index < 0 || index >= len(headers) {
+		if index <= prev || index >= len(headers) {
 			return false
 		}
-		noAction[index] = struct{}{}
+		prev = index
 	}
-	for index, header := range headers {
-		if _, paused := noAction[index]; paused {
+	next := 0
+	for index := range headers {
+		if next < len(noActionIndices) && noActionIndices[next] == index {
+			next++
 			continue
 		}
-		if header.shifted || header.accepted {
+		if headers[index].shifted || headers[index].accepted {
 			return true
 		}
 	}
 	return false
 }
 
+// dropGenericNoActionHeads removes the paused/no-action heads named by indices.
+// indices is produced in ascending, unique header order by the dispatch pass,
+// so the surviving frontier is compacted in place with no allocation. The drop
+// runs outside any rollback transaction, so mutating the s.headers backing is
+// safe.
 func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices []int) error {
-	paused := make(map[int]struct{}, len(indices))
-	for _, index := range indices {
-		paused[index] = struct{}{}
+	if len(indices) == 0 || len(indices) >= len(s.headers) {
+		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
-	var pathReceipts []DiagnosticParserCoreHeaderPathReceipt
 	if s.fullReceipts() {
-		var err error
-		pathReceipts, err = diagnosticParserCoreHeaderPathReceipts(s.compact, s.headers)
+		pathReceipts, err := diagnosticParserCoreHeaderPathReceipts(s.compact, s.headers)
 		if err != nil {
 			return err
 		}
-	}
-	kept := make([]diagnosticParserCoreHeader, 0, len(s.headers)-len(indices))
-	for index, header := range s.headers {
-		if _, drop := paused[index]; !drop {
-			kept = append(kept, header)
-			continue
-		}
-		if s.fullReceipts() {
+		for _, index := range indices {
+			if index < 0 || index >= len(pathReceipts) {
+				return errors.New("parser-core phase zero: no-action drop index is out of range")
+			}
 			s.receipt.NoActionDrops = append(s.receipt.NoActionDrops, DiagnosticParserCoreGenericNoActionDrop{
 				ElectionIndex: s.electionIndex, Token: s.token, Header: pathReceipts[index],
 			})
 		}
 	}
-	if len(kept) == 0 {
+	write := 0
+	next := 0
+	for read := range s.headers {
+		if next < len(indices) && indices[next] == read {
+			next++
+			continue
+		}
+		if write != read {
+			s.headers[write] = s.headers[read]
+		}
+		write++
+	}
+	if write == 0 {
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
-	s.headers = kept
+	clear(s.headers[write:])
+	s.headers = s.headers[:write]
 	s.work.NoActionDrops += uint64(len(indices))
 	return nil
 }
@@ -2874,11 +2893,27 @@ func diagnosticParserCoreGenericUnsupportedToken(token Token) *diagnosticParserC
 	}
 }
 
+// replaceDiagnosticParserCoreHeader replaces headers[index] with replacements.
+// It reuses the headers backing array when its capacity allows, so multi-output
+// reductions no longer allocate a fresh frontier slice on every reduction. The
+// replacements slice is a distinct scheduler buffer, so it never aliases
+// headers. Reusing the headers backing is safe: canonicalization always copies
+// its input before use, and the rollback scratch snapshots a separate copy, so
+// no other frontier owner observes the reused storage. Go's copy is memmove-
+// safe, so the overlapping tail shift is correct for both growth and shrink.
 func replaceDiagnosticParserCoreHeader(headers []diagnosticParserCoreHeader, index int, replacements []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
-	out := make([]diagnosticParserCoreHeader, 0, len(headers)-1+len(replacements))
-	out = append(out, headers[:index]...)
-	out = append(out, replacements...)
-	out = append(out, headers[index+1:]...)
+	oldLen := len(headers)
+	newLen := oldLen - 1 + len(replacements)
+	if newLen <= cap(headers) {
+		headers = headers[:newLen]
+		copy(headers[index+len(replacements):], headers[index+1:oldLen])
+		copy(headers[index:index+len(replacements)], replacements)
+		return headers
+	}
+	out := make([]diagnosticParserCoreHeader, newLen, max(newLen, 2*cap(headers)))
+	copy(out, headers[:index])
+	copy(out[index:index+len(replacements)], replacements)
+	copy(out[index+len(replacements):], headers[index+1:oldLen])
 	return out
 }
 
@@ -2907,8 +2942,16 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 	if s.tokens >= s.options.MaxTokens {
 		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreCap, detail: "generic scheduler token cap"}
 	}
-	states := make([]StateID, len(s.headers))
-	for index, header := range s.headers {
+	// states is scheduler-owned scratch, rebuilt every election. It feeds
+	// SetParserState, a separate reused GLR buffer, and currentElection.States
+	// (read only within this round for summary receipts; cloned below when full
+	// receipts retain the election). This collapses one slice allocation per
+	// election without changing the frontier order or work graph.
+	states := s.electStates[:0]
+	if cap(states) < len(s.headers) {
+		states = make([]StateID, 0, max(len(s.headers), 2*cap(states)))
+	}
+	for _, header := range s.headers {
 		receipt, err := s.headerReceipt(header)
 		if err != nil {
 			return err
@@ -2917,8 +2960,9 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 		if !shiftIdentity || receipt.Accepted || header.checkpoint != s.checkpointID {
 			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler election frontier is not closed and checkpoint-continuous"}
 		}
-		states[index] = receipt.State
+		states = append(states, receipt.State)
 	}
+	s.electStates = states
 	if s.observer.beforeElection != nil {
 		if err := s.observer.beforeElection(s); err != nil {
 			return err
@@ -2928,7 +2972,12 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 	if len(states) == 1 {
 		s.tokenSource.SetGLRStates(nil)
 	} else {
-		s.tokenSource.SetGLRStates(append([]StateID(nil), states...))
+		// The token source retains the passed slice only until the next
+		// election reassigns it, so a second reused buffer keeps the copy
+		// semantics without allocating.
+		glr := append(s.electGLRStates[:0], states...)
+		s.electGLRStates = glr
+		s.tokenSource.SetGLRStates(glr)
 	}
 	beforeBytes := s.tokenSource.captureExternalScannerStateInto(s.scannerScratch)
 	beforeID, before, err := diagnosticParserCoreInternCheckpoint(s.compact, beforeBytes)
@@ -2964,8 +3013,15 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 	s.checkpoint = after
 	s.checkpointID = afterID
 	s.epochProgress = false
+	// Summary receipts read currentElection.States only within this round, so
+	// the reused scratch is safe. Full receipts retain the election, so clone
+	// the states into an owned slice before appending it.
+	electionStates := states
+	if s.fullReceipts() {
+		electionStates = append([]StateID(nil), states...)
+	}
 	election := DiagnosticParserCoreElection{
-		States: states, Token: token, ScannerBefore: before, ScannerAfter: after,
+		States: electionStates, Token: token, ScannerBefore: before, ScannerAfter: after,
 		CurrentCheckpointValid: currentValid,
 		CurrentCheckpointStart: parserCoreCheckpoint(current.start),
 		CurrentCheckpointEnd:   parserCoreCheckpoint(current.end),


### PR DESCRIPTION
## Summary

Replace map-based lookups and per-operation slice allocations in the parser core phase 0 engine with reusable scratch buffers and in-place compaction. This optimizes cohort processing, frontier dropping, and election state tracking to lower memory pressure and improve allocation throughput without changing parsing logic.

## Changes

- factorExactPredecessor: Extracted merge-and-republish logic into factorExactPredecessorMerge to move its defer out of the loop, preventing a heap-allocated stack frame. Added factorLinkScratch to Core and reused it instead of slices.Clone(oldLinks).
- prepareOrdinaryClassifiedCohortInto and prepareExtraClassifiedCohortInto: Replaced map-based duplicate head checks with cohortHasDuplicateHead, which uses a linear back-scan bounded by cohort width. Added cohortHeads to reuse c.cohortHeadScratch for output head slices.
- diagnosticParserCoreGenericNoActionDropEligible: Replaced map allocation with a sorted two-pointer walk over noActionIndices, removing map allocation during eligibility checks.
- dropGenericNoActionHeads: Replaced map-based filtering and reallocation with an in-place two-pointer compaction that shifts surviving headers back to their original slice without allocating a new frontier.
- replaceDiagnosticParserCoreHeader: Optimized multi-output reduction replacement to reuse the headers backing array when capacity allows, falling back to allocation only when growth exceeds current capacity.
- elect: Added electStates and electGLRStates scratch buffers. Replaced per-election slice allocation with reused buffers, keeping a second buffer to preserve copy semantics when passing state to the GLR token source.

## Testing

- Run bash cgo_harness/docker/run_single_grammar_parity.sh go to validate correctness parity on the Go grammar.
- Run GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms to verify performance metrics and allocation counts.