### PR TITLE
release(docs): Release v0.45.0 and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,35 +7,131 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.45.0] - 2026-07-20
+
 ### Fixed
 
-- **TypeScript arrow functions with a return-type annotation** (`const f =
-  (a: A): B => { ... }`) no longer collapse to `ERROR` when they appear as
-  the value of a `const`/`let` declaration (issue #402). The typed-arrow
-  and destructured-arrow-return-type merge-width detectors added in PR #389
-  did not cover this shape: neither requires the arrow to be immediately
-  preceded by `)` (the destructured-return-type case scans past a
-  return-type annotation, but only accepts a destructured `[`/`{`
-  parameter list). A typed, non-destructured parameter list combined with
-  an explicit return-type annotation fell through both. This fix adds a
-  dedicated detector for that shape and widens the merge budget to two
-  survivors, matching the existing typed-arrow and default-parameter
-  cases. TSX was unaffected; its wider JSX conflict set kept a second
-  survivor alive through the same fork. The detector's first pass also
-  missed sibling shapes with a parenthesized return type (`(a: A): (B) =>
-  a`, `(a: A): (string | number) => a`, `(a: A): (() => B) => a`); its
-  backward colon scan now balances parens so a colon nested inside the
-  return type is not mistaken for the top-level boundary.
-- This is the **third** source-heuristic merge-width detector guarding the
-  same root cause as the PR #389 default-parameter fix: the GLR engine's
-  steady-state merge budget discards a live fork by score before any
-  structural comparison runs. Each detector treats one shape's symptom.
-  The structural cure -- comparing candidate forks structurally before
-  falling back to score at the merge site -- remains tracked and is in
-  active development on `codex/glr-structure-before-score`. As with its
-  siblings, this detector's backward scans are bounded to 512/2048-byte
-  windows; a return-type expression whose own top-level colon sits past
-  that window silently misses the widening.
+- **TypeScript arrow functions with a return-type annotation** no longer
+  collapse to `ERROR` as a `const`/`let` initializer (issue #402, PR
+  #409). Example: `const f = (a: A): B => { ... }`. The typed-arrow and
+  destructured-arrow-return-type detectors added in PR #389 did not
+  cover this shape. Neither required the arrow to be immediately
+  preceded by `)`. A typed, non-destructured parameter list combined
+  with an explicit return-type annotation fell through both. This fix
+  adds a dedicated detector for that shape. It widens the merge budget
+  to two survivors, matching the typed-arrow and default-parameter
+  cases. TSX was unaffected; its wider JSX conflict set already kept a
+  second survivor alive. The detector also covers parenthesized return
+  types: `(a: A): (B) => a`, `(a: A): (string | number) => a`, and
+  `(a: A): (() => B) => a`. Its backward colon scan now balances
+  parens, so a colon nested inside the return type is not mistaken for
+  the top-level boundary. This is the **third** source-heuristic
+  merge-width detector guarding the same root cause as the PR #389
+  default-parameter fix: the GLR engine's steady-state merge budget
+  discards a live fork by score before any structural comparison runs.
+  The structural cure — comparing candidate forks structurally before
+  falling back to score at the merge site — remains tracked, in active
+  development on `codex/glr-structure-before-score`. Like its
+  siblings, this detector's backward scan is bounded to a
+  512/2048-byte window; a return-type expression whose own top-level
+  colon sits past that window silently misses the widening.
+- **Go `new(pkg.Type)`, `new(*T)`, `new(**T)`, and parenthesized type
+  arguments** now byte-match the C oracle (issue #375 class, valid
+  forms; PR #408). The parser previously parsed these structured type
+  arguments as expressions, breaking node-for-node parity.
+  `new`/`make` selector, unary, and parenthesized arguments now
+  relabel to the C grammar's type shapes. Byte spans and tree
+  structure are preserved. A composite-literal guard suite locks the
+  boundary: this fix does not touch composite-literal type positions,
+  which already matched.
+
+### Added
+
+- **A per-boundary scanner-quiescence classifier replaces the
+  external-scanner reuse allowlist.** It proves reuse soundness for
+  stateless scanners, refutes stateful opt-out scanners, and defers to
+  the checkpoint match for checkpoint-based scanners (PR #407,
+  campaign O(edit) workstream W4). A new exported
+  `StatelessExternalScanner` interface, in `language.go`, lets a
+  scanner declare itself stateless. `GoExternalScanner` now implements
+  it, under five documented proof obligations that block cross-token
+  state from leaking into reuse boundaries. A new
+  `ReuseRejectScannerUnquiescent` counter, on `IncrementalParseProfile`,
+  tracks boundaries the classifier rejects. An adversarial oracle
+  sweep proves byte-identical incremental and fresh Go parses across
+  newlines, raw strings, and comments; the classifier never blocks Go
+  reuse on that sweep. This change is behavior-neutral groundwork: it
+  does not itself change any parse output.
+- **A new editor-latency CI gate enforces deterministic incremental
+  counters.** It sweeps insert, delete, and replace edits at three
+  file positions, across roughly 20KB, 137KB, and 1MB fixtures in four
+  languages (PR #405, campaign O(edit) workstream W5). The gate checks
+  counter ceilings, byte-reuse floors, and structural parity against a
+  fresh parse, on every default `go test` run. A determinism check
+  runs fresh parsers on identical inputs and asserts the counters
+  match exactly. A manual-dispatch CI job covers the slower 137KB and
+  1MB tiers.
+- **A query silent-wrong witness suite locks four query tranches
+  against the C oracle** (PR #410). D1 range queries, D4 `MISSING`
+  alternation patterns, and D8 `#is?` predicates now match the oracle
+  under committed tests. D3 supertype patterns and D5 quantified
+  captures are tracked, not fixed: their tests are skip-guarded, with
+  the query-engine-scope limitation documented inline.
+
+### Improved
+
+- **Unchanged top-level siblings now splice back as a single block**,
+  inside one parse-loop iteration, instead of one sibling at a time
+  (PR #411, campaign O(edit) workstream W1 block-splice composition).
+  A new scanner-quiescence check lets a quiescent, non-checkpoint
+  external scanner skip re-lexing an unchanged span in O(1), instead
+  of token by token. A new `BlockSpliceSteps` profiling counter tracks
+  block-splice activations. On a clean-Go, near-top, single-byte
+  insert, a 1MB file measures about 148ms on the prior release and
+  about 82-88ms on this one. CSS near-top edits re-lex only 2 tokens.
+  Honest note: the campaign's 60ms target for the 1MB fixture is not
+  met. The residual cost is dominated by O(nodes) result
+  materialization outside the splice path — the Go-compatibility
+  normalization walk, EOF result-selection, and incremental arena
+  zeroing. Threading the edited range through that walk is the
+  tracked next lever.
+- **The diagnostic compact-route materializer allocates far less per
+  operation** (PR #412). Cohort processing, frontier dropping, and
+  election-state tracking now reuse scratch buffers and compact
+  in-place, instead of allocating maps and slices per operation.
+  Measured allocations drop from 1,931-91,341 to 92-316 allocs/op
+  across the fixture set, a 98.5% geomean reduction. The work graph is
+  provably unchanged. This is a diagnostic/candidate-route
+  improvement, not a change to the shipping default parse path.
+
+### Docs
+
+- Publish the sealed run6 benchmark epoch as authoritative in
+  BENCH.md, superseding the v0.40.0 baseline receipt (PR #403).
+- Correct README claims about `ParseIncremental`'s reuse scope, and
+  document the grammargen real-corpus parity floor (PR #404).
+- Add a Phase-3 admission timing runbook, with locked fixtures, host
+  selection paths, and statistical thresholds (PR #406).
+- Sweep remaining documentation prose to the ASD-STE100 style guide
+  (PR #414).
+
+### Known Issues
+
+- The 1MB near-top edit still misses the campaign's 60ms target, at
+  about 82-88ms (PR #411). Threading the edited range through Go's
+  compatibility-normalization walk is the tracked next lever.
+- GLR-heavy files with genuine ambiguity still see little wall-time
+  change from the O(edit) work, because settling and block-splice run
+  on a single stack only (PR #398, PR #411).
+- Query-engine tranches D3 (supertype patterns) and D5 (quantified
+  captures) remain silently wrong against the C oracle. Both are
+  tracked outside query-engine scope, with skip-guarded witness tests
+  (PR #410).
+- The structural merge-policy fix for TypeScript/TSX GLR fork discard
+  is still tracked, in development on
+  `codex/glr-structure-before-score`. This release's arrow-return-type
+  fix (PR #409) is a third source-heuristic detector, not the
+  structural cure.
 
 ## [0.44.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ for tags and release notes while still in `0.x`.
   second survivor alive. The detector also covers parenthesized return
   types: `(a: A): (B) => a`, `(a: A): (string | number) => a`, and
   `(a: A): (() => B) => a`. Its backward colon scan now balances
-  parens, so a colon nested inside the return type is not mistaken for
-  the top-level boundary. This is the **third** source-heuristic
+  parentheses, so a colon nested inside the return type is not mistaken
+  for the top-level boundary. This is the **third** source-heuristic
   merge-width detector guarding the same root cause as the PR #389
-  default-parameter fix: the GLR engine's steady-state merge budget
-  discards a live fork by score before any structural comparison runs.
+  default-parameter fix. That root cause: the GLR engine's steady-state
+  merge budget discards a live fork by score before any structural
+  comparison runs.
   The structural cure — comparing candidate forks structurally before
   falling back to score at the merge site — remains tracked, in active
   development on `codex/glr-structure-before-score`. Like its
@@ -3336,7 +3337,12 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.42.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.45.0...HEAD
+[0.45.0]: https://github.com/odvcencio/gotreesitter/compare/v0.44.1...v0.45.0
+[0.44.1]: https://github.com/odvcencio/gotreesitter/compare/v0.44.0...v0.44.1
+[0.44.0]: https://github.com/odvcencio/gotreesitter/compare/v0.43.1...v0.44.0
+[0.43.1]: https://github.com/odvcencio/gotreesitter/compare/v0.43.0...v0.43.1
+[0.43.0]: https://github.com/odvcencio/gotreesitter/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/odvcencio/gotreesitter/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/odvcencio/gotreesitter/compare/v0.40.0...v0.41.0
 [0.40.0]: https://github.com/odvcencio/gotreesitter/compare/v0.39.0...v0.40.0

--- a/README.md
+++ b/README.md
@@ -538,11 +538,6 @@ witness, and it shrinks as certified engine mechanisms subsume shims. See
   a ceiling on the maximum input complexity that parses without error.
   The caps are tunable but not removable without risking unbounded
   resource consumption.
-- **TypeScript arrow-function return type**: an arrow function with a
-  return-type annotation as a `const`/`let` initializer parses as
-  `ERROR` (TSX is unaffected). See
-  [issue #402](https://github.com/odvcencio/gotreesitter/issues/402).
-  A fix is in progress.
 
 ## Adding a language
 
@@ -749,18 +744,19 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.44.1**. It closes a fast-follow gap:
-v0.44.0's Swift DFA-minimization fix regenerated `swift.bin` but left a
-stale profile digest, so Swift's retry-ladder optimizations silently
-did not attach. The digest is now correct, and the effect was
-performance-only. It also lands the O(edit) `W1b` settling fix: Go
-clean-file incremental edits now cost O(edit), not O(file).
-`ReuseRejectRootNonLeafChanged` holds at 9 regardless of file size, and
-a 137KB near-top insert drops from about 47ms to about 22ms. GLR-heavy
-files with genuine ambiguity see little change, since settling runs on
-a single stack only. The prior release, v0.44.0, fixed Swift's
-`Language()` memory ceiling breach, from about 490 MB to about 25 MB,
-and raised CSS editor-edit node reuse from 63.8% to 99.5%.
+The current release is **v0.45.0**. It fixes TypeScript arrow functions
+with a return-type annotation, which previously collapsed to `ERROR` as
+a `const`/`let` initializer (issue #402). It also fixes Go
+`new(pkg.Type)`, `new(*T)`, and parenthesized type arguments to
+byte-match the C oracle (issue #375 class). Unchanged top-level
+siblings now splice back as a single block. A clean-Go, near-top, 1MB
+edit measures about 82-88ms, down from about 148ms. The campaign's
+60ms target is not yet met; residual cost sits in result
+materialization outside the splice path. GLR-heavy files with genuine
+ambiguity still see little change, since settling and block-splice run
+on a single stack only. The prior release, v0.44.1, restored Swift's
+retry-ladder optimizations and made Go clean-file incremental edits
+O(edit).
 The authenticated production receipt at tag target `1935a42c` measures
 public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
 **5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst


### PR DESCRIPTION
## Summary

Release v0.45.0 and update project documentation. This release documents fixes for TypeScript arrow functions with return-type annotations and Go new() type arguments. It introduces a scanner-quiescence classifier for external-scanner reuse. The documentation tracks incremental performance improvements and known issues.

## Changes

- Add a per-boundary scanner-quiescence classifier to replace the external-scanner reuse allowlist.
- Add an editor-latency CI gate to enforce deterministic incremental counters.
- Add a query silent-wrong witness suite to lock four query tranches against the C oracle.
- Improve block-splice composition. Unchanged top-level siblings now splice back as a single block. The parser skips re-lexing when the scanner is quiescent.
- Improve the diagnostic compact-route materializer. It now reuses scratch buffers to reduce allocations per operation.
- Fix TypeScript arrow functions with a return-type annotation. The parser no longer collapses these expressions to ERROR.
- Fix Go new(pkg.Type), new(*T), and parenthesized type arguments. The parser now byte-matches the C oracle.
- Update BENCH.md with the run6 benchmark epoch. Correct the ParseIncremental reuse scope documentation.
- Sweep remaining documentation prose to the ASD-STE100 style guide. Update the roadmap for v0.45.0.

## Related Issues

- Refs #402
- Refs #375