### PR TITLE
add(parser): Add Phase-3 dual-route admission switch

### DIFF
--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -20,6 +20,12 @@ import (
 // fell back, or diverged. The compact route had only ever been validated on the
 // four canonical Go fixtures; this run reports how far it reaches.
 //
+// Scope: the per-language fixtures are trivial smoke snippets, so this is
+// reachability reconnaissance -- which grammars the compact route accepts at
+// all -- not a fidelity proof. The byte-exact fidelity evidence is the
+// four-fixture digest test (TestAdmissionSwitchCandidateDigestMatchesProduction).
+// Corpus-scale per-language fixtures are the tracked follow-up.
+//
 // It is a scorecard, not a gate: it never fails on a fallback (a fallback is the
 // fail-closed, correct behavior for an unsupported grammar). It fails only on a
 // DIVERGE — the compact route accepted a clean tree that disagrees with

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -1,0 +1,172 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+// TestAdmissionCandidateScorecard206 is the admission scorecard's missing half:
+// it drives the compact candidate route across all 206 registered languages
+// (one smoke fixture each) through the public Parse API and records, per
+// language, whether the compact route served a byte-exact tree, declined and
+// fell back, or diverged. The compact route had only ever been validated on the
+// four canonical Go fixtures; this run reports how far it reaches.
+//
+// It is a scorecard, not a gate: it never fails on a fallback (a fallback is the
+// fail-closed, correct behavior for an unsupported grammar). It fails only on a
+// DIVERGE — the compact route accepted a clean tree that disagrees with
+// production — because a silent wrong tree is the one outcome the admission
+// contract forbids. Set GTS_ADMISSION_SCORECARD_STRICT=1 to also fail if any
+// DIVERGE is observed even when only logging is wanted otherwise.
+//
+// Statuses:
+//
+//   - PASS     candidate routed and its tree digest equals production's;
+//   - DIVERGE  candidate routed but its tree digest differs from production;
+//   - FALLBACK candidate declined; production served the parse (fail-closed);
+//   - SKIP     language is not routable via the DFA Parse path (token source);
+//   - ERROR    production itself failed or a panic was recovered.
+const (
+	scorecardPass     = "PASS"
+	scorecardDiverge  = "DIVERGE"
+	scorecardFallback = "FALLBACK"
+	scorecardSkip     = "SKIP"
+	scorecardError    = "ERROR"
+)
+
+type scorecardRow struct {
+	name    string
+	backend string
+	status  string
+	detail  string
+}
+
+func TestAdmissionCandidateScorecard206(t *testing.T) {
+	// This scorecard loads every registered grammar, which inflates process heap
+	// enough to disturb the whole-process TestArenaGCRetentionAfterRelease gate.
+	// It is a deliberate diagnostic, so gate it behind an explicit opt-in and
+	// keep the routine suite unaffected. Run it with:
+	//   GTS_ADMISSION_SCORECARD=1 go test -tags gts_parsercorephase0 \
+	//     -run TestAdmissionCandidateScorecard206 -v .
+	if os.Getenv("GTS_ADMISSION_SCORECARD") != "1" {
+		t.Skip("set GTS_ADMISSION_SCORECARD=1 to run the 206-language admission scorecard")
+	}
+	// Purge the embedded grammar cache afterward so it does not inflate process
+	// heap for later suite tests.
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entries := grammars.AllLanguages()
+	rows := make([]scorecardRow, 0, len(entries))
+	for _, entry := range entries {
+		rows = append(rows, runAdmissionScorecardLanguage(entry))
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
+
+	counts := map[string]int{}
+	var divergences []scorecardRow
+	for _, row := range rows {
+		counts[row.status]++
+		if row.status == scorecardDiverge {
+			divergences = append(divergences, row)
+		}
+	}
+
+	t.Logf("=== Phase-3 admission candidate scorecard (%d languages) ===", len(rows))
+	for _, row := range rows {
+		t.Logf("%-9s %-16s %-6s %s", row.status, row.name, row.backend, row.detail)
+	}
+	t.Logf("--- summary: PASS=%d DIVERGE=%d FALLBACK=%d SKIP=%d ERROR=%d total=%d ---",
+		counts[scorecardPass], counts[scorecardDiverge], counts[scorecardFallback],
+		counts[scorecardSkip], counts[scorecardError], len(rows))
+
+	if len(divergences) > 0 {
+		for _, row := range divergences {
+			t.Logf("DIVERGENCE FINDING: %s (%s) %s", row.name, row.backend, row.detail)
+		}
+		if os.Getenv("GTS_ADMISSION_SCORECARD_STRICT") == "1" {
+			t.Fatalf("%d language(s) diverged through the compact route", len(divergences))
+		}
+	}
+}
+
+func runAdmissionScorecardLanguage(entry grammars.LangEntry) (row scorecardRow) {
+	row = scorecardRow{name: entry.Name, status: scorecardError}
+	defer func() {
+		if r := recover(); r != nil {
+			row.status = scorecardError
+			row.detail = fmt.Sprintf("panic: %v", r)
+		}
+	}()
+
+	lang := entry.Language()
+	if lang == nil {
+		row.detail = "nil language"
+		return row
+	}
+	support := grammars.EvaluateParseSupport(entry, lang)
+	row.backend = string(support.Backend)
+
+	// Only the fresh DFA Parse path is routable through the compact candidate.
+	if support.Backend != grammars.ParseBackendDFA {
+		row.status = scorecardSkip
+		row.detail = "not DFA-routable: " + support.Reason
+		return row
+	}
+
+	source := []byte(grammars.ParseSmokeSample(entry.Name))
+
+	production := gts.NewParser(lang)
+	production.SetAdmissionCandidateRoute(false)
+	productionTree, err := production.Parse(source)
+	if err != nil || productionTree == nil || productionTree.RootNode() == nil {
+		row.detail = fmt.Sprintf("production parse failed: %v", err)
+		return row
+	}
+	defer productionTree.Release()
+	productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), lang)
+	if err != nil {
+		row.detail = "production digest failed: " + err.Error()
+		return row
+	}
+
+	candidate := gts.NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidateTree, err := candidate.Parse(source)
+	if err != nil || candidateTree == nil {
+		row.detail = fmt.Sprintf("candidate parse failed: %v", err)
+		return row
+	}
+	defer candidateTree.Release()
+	routed, _ := gts.AdmissionCandidateCounters()
+
+	if routed == 0 {
+		row.status = scorecardFallback
+		row.detail = gts.AdmissionCandidateLastFallbackReason()
+		return row
+	}
+	if candidateTree.RootNode() == nil {
+		row.detail = "candidate routed but produced a nil root"
+		return row
+	}
+	candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), lang)
+	if err != nil {
+		row.detail = "candidate digest failed: " + err.Error()
+		return row
+	}
+	if candidateInspection.SHA256 == productionInspection.SHA256 {
+		row.status = scorecardPass
+		row.detail = "digest " + candidateInspection.SHA256[:12]
+		return row
+	}
+	row.status = scorecardDiverge
+	row.detail = fmt.Sprintf("candidate=%s production=%s", candidateInspection.SHA256[:12], productionInspection.SHA256[:12])
+	return row
+}

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -1,0 +1,236 @@
+package gotreesitter
+
+import (
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+// Phase-3 dual-route admission switch.
+//
+// The switch selects, per full parse, between two engines:
+//
+//   - the production route: the mature GLR engine that Parser.Parse has always
+//     used and that every reuse-consuming path (ParseIncremental and the
+//     token-invariant leaf fast path) uses unconditionally; and
+//   - the compact candidate route: the parsercorephase0 engine measured by
+//     BenchmarkParserCoreFreshFullCanonical, which streams a compact derivation
+//     into a materialized public tree.
+//
+// The switch only ever changes which engine serves a FRESH FULL parse. It never
+// touches a reuse-consuming path: the compact tree carries a hard incremental-
+// reuse bar (decision 0008), so routing it under ParseIncremental would destroy
+// the O(edit) wins. See admissionCandidateFullParseEligible for the fail-closed
+// guard.
+//
+// Precedence, highest to lowest:
+//
+//  1. a per-Parser override set with (*Parser).SetAdmissionCandidateRoute;
+//  2. the process-wide default set with SetAdmissionCandidateRouteDefault;
+//  3. the process-wide default seeded from the GTS_ADMISSION_CANDIDATE
+//     environment variable at package initialization;
+//  4. OFF.
+//
+// The default is OFF. Flipping the default to ON is the admission decision
+// itself and is a separate, one-line change; this mechanism only makes the
+// choice routable and measurable.
+
+// admissionRouteMode is the per-Parser override state. The zero value follows
+// the process-wide default.
+type admissionRouteMode uint8
+
+const (
+	admissionRouteFollowDefault admissionRouteMode = iota
+	admissionRouteCandidateForced
+	admissionRouteProductionForced
+)
+
+// admissionCandidateRouteDefault is the process-wide default the switch applies
+// when a Parser sets no explicit override. init seeds it from the environment;
+// SetAdmissionCandidateRouteDefault changes it at runtime.
+var admissionCandidateRouteDefault atomic.Bool
+
+// admissionCandidateRouted counts full parses served by the compact candidate
+// route. admissionCandidateFallback counts eligible full parses that attempted
+// the compact route, were declined, and fell back to production. A moving
+// fallback counter is the loud, fail-closed signal that the candidate route
+// declined an input rather than silently diverging.
+var (
+	admissionCandidateRouted   atomic.Uint64
+	admissionCandidateFallback atomic.Uint64
+)
+
+// admissionCandidateLastFallbackReason records the most recent decline detail
+// so an operator can triage why a full parse fell back to production.
+var admissionCandidateLastFallbackReason atomic.Value // string
+
+func init() {
+	if admissionCandidateEnvEnabled() {
+		admissionCandidateRouteDefault.Store(true)
+	}
+}
+
+// admissionCandidateEnvEnabled reports whether GTS_ADMISSION_CANDIDATE requests
+// the candidate route by default.
+func admissionCandidateEnvEnabled() bool {
+	switch os.Getenv("GTS_ADMISSION_CANDIDATE") {
+	case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
+		return true
+	default:
+		return false
+	}
+}
+
+// SetAdmissionCandidateRouteDefault sets the process-wide default the Phase-3
+// admission switch applies to Parsers with no explicit override. A per-Parser
+// override still wins.
+func SetAdmissionCandidateRouteDefault(enabled bool) {
+	admissionCandidateRouteDefault.Store(enabled)
+}
+
+// AdmissionCandidateRouteDefault reports the current process-wide default.
+func AdmissionCandidateRouteDefault() bool {
+	return admissionCandidateRouteDefault.Load()
+}
+
+// SetAdmissionCandidateRoute sets a per-Parser override that takes precedence
+// over the process-wide default. enabled=true forces the candidate route on for
+// eligible full parses; enabled=false forces the production route.
+func (p *Parser) SetAdmissionCandidateRoute(enabled bool) {
+	if p == nil {
+		return
+	}
+	if enabled {
+		p.admissionCandidateRoute = admissionRouteCandidateForced
+	} else {
+		p.admissionCandidateRoute = admissionRouteProductionForced
+	}
+}
+
+// ClearAdmissionCandidateRoute drops the per-Parser override so the Parser
+// follows the process-wide default again.
+func (p *Parser) ClearAdmissionCandidateRoute() {
+	if p != nil {
+		p.admissionCandidateRoute = admissionRouteFollowDefault
+	}
+}
+
+// AdmissionCandidateCounters returns the number of full parses the compact
+// candidate route served, and the number of eligible full parses that fell back
+// to production.
+func AdmissionCandidateCounters() (routed, fallbacks uint64) {
+	return admissionCandidateRouted.Load(), admissionCandidateFallback.Load()
+}
+
+// AdmissionCandidateLastFallbackReason returns the most recent candidate-route
+// decline detail, or the empty string if none has been recorded.
+func AdmissionCandidateLastFallbackReason() string {
+	if v, ok := admissionCandidateLastFallbackReason.Load().(string); ok {
+		return v
+	}
+	return ""
+}
+
+// resetAdmissionCandidateCounters clears the counters. Test-only.
+func resetAdmissionCandidateCounters() {
+	admissionCandidateRouted.Store(0)
+	admissionCandidateFallback.Store(0)
+	admissionCandidateLastFallbackReason.Store("")
+}
+
+// admissionCandidateRouteEnabled resolves the switch precedence for p.
+func (p *Parser) admissionCandidateRouteEnabled() bool {
+	if p == nil {
+		return false
+	}
+	switch p.admissionCandidateRoute {
+	case admissionRouteCandidateForced:
+		return true
+	case admissionRouteProductionForced:
+		return false
+	default:
+		return admissionCandidateRouteDefault.Load()
+	}
+}
+
+// admissionCandidateFullParseEligible reports whether a fresh full parse may be
+// routed through the compact candidate. It fails closed for:
+//
+//   - every reuse-consuming path (oldTree != nil), because the compact tree
+//     carries a hard incremental-reuse bar (decision 0008) and routing it under
+//     ParseIncremental or the leaf fast path would destroy the O(edit) wins; and
+//   - any lexer other than the production DFA, because the compact route
+//     reproduces the production DFA token stream and cannot honor a caller-
+//     supplied token source.
+func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProductionDFA bool) bool {
+	if p == nil || oldTree != nil || p.admissionRouteSuppressed > 0 {
+		return false
+	}
+	if !usingProductionDFA {
+		return false
+	}
+	// The compact runner lexes the whole source with its own DFA token source and
+	// does not apply included ranges, so decline when a caller set any. Production
+	// then honors the ranges exactly.
+	if len(p.included) > 0 {
+		return false
+	}
+	// Preserve callback fidelity: the compact route does not emit the parser's
+	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline
+	// (fall back to production) whenever a consumer has attached one. Production
+	// then fires every hook exactly as it does today.
+	if p.hasActiveParseObservability() {
+		return false
+	}
+	// Preserve liveness fidelity: the compact scheduler does not poll an explicit
+	// timeout or cancellation flag, so decline when a caller set one. Production
+	// then honors the deadline exactly. (The automatic large-input memory budget
+	// is a documented boundary, not enforced by the compact scheduler.)
+	if p.timeoutMicros != 0 || p.cancellationFlag != nil {
+		return false
+	}
+	return p.admissionCandidateRouteEnabled()
+}
+
+// hasActiveParseObservability reports whether a consumer attached any parse-time
+// observability hook that the compact route would not emit.
+func (p *Parser) hasActiveParseObservability() bool {
+	if p == nil {
+		return false
+	}
+	if p.logger != nil || p.glrTrace || p.ambiguityProfile != nil {
+		return true
+	}
+	return strings.TrimSpace(os.Getenv("GOT_PARSE_PROGRESS")) == "1"
+}
+
+// suppressAdmissionCandidateRoute forces the production route for the returned
+// function's lifetime. It is nestable: reuse-consuming calls and production-only
+// correctness reparses raise it around any delegated fresh Parse so that a
+// compact tree can never leak out of a path that must stay on production.
+func (p *Parser) suppressAdmissionCandidateRoute() func() {
+	if p == nil {
+		return func() {}
+	}
+	p.admissionRouteSuppressed++
+	return func() { p.admissionRouteSuppressed-- }
+}
+
+// attemptAdmissionCandidateFullParse routes a fresh full parse through the
+// compact candidate when the switch is on and the call is eligible. It returns
+// (tree, true) when the candidate route produced a public tree, and (nil,
+// false) otherwise. On an eligible-but-declined attempt it bumps the fallback
+// counter (fail-closed, loud) so the caller re-runs the production route.
+func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree, usingProductionDFA bool) (*Tree, bool) {
+	if !p.admissionCandidateFullParseEligible(oldTree, usingProductionDFA) {
+		return nil, false
+	}
+	tree, ok, reason := p.tryCompactFullParseRoute(source)
+	if ok && tree != nil {
+		admissionCandidateRouted.Add(1)
+		return tree, true
+	}
+	admissionCandidateFallback.Add(1)
+	admissionCandidateLastFallbackReason.Store(reason)
+	return nil, false
+}

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -84,6 +84,13 @@ func admissionCandidateEnvEnabled() bool {
 // SetAdmissionCandidateRouteDefault sets the process-wide default the Phase-3
 // admission switch applies to Parsers with no explicit override. A per-Parser
 // override still wins.
+//
+// Caveat: the candidate route does not enforce the automatic large-input memory
+// budget at scheduler granularity, so a pathological input that the production
+// route truncates with ParseStopMemoryBudget can instead parse to completion on
+// the candidate route (a byte-correct, non-truncated tree). Explicit timeouts,
+// cancellation flags, included ranges, and observability hooks all keep a parse
+// on production.
 func SetAdmissionCandidateRouteDefault(enabled bool) {
 	admissionCandidateRouteDefault.Store(enabled)
 }
@@ -96,6 +103,13 @@ func AdmissionCandidateRouteDefault() bool {
 // SetAdmissionCandidateRoute sets a per-Parser override that takes precedence
 // over the process-wide default. enabled=true forces the candidate route on for
 // eligible full parses; enabled=false forces the production route.
+//
+// Caveat: the candidate route does not enforce the automatic large-input memory
+// budget at scheduler granularity, so a pathological input that the production
+// route truncates with ParseStopMemoryBudget can instead parse to completion on
+// the candidate route (a byte-correct, non-truncated tree). Explicit timeouts,
+// cancellation flags, included ranges, and observability hooks all keep a parse
+// on production.
 func (p *Parser) SetAdmissionCandidateRoute(enabled bool) {
 	if p == nil {
 		return
@@ -169,17 +183,16 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	if !usingProductionDFA {
 		return false
 	}
+	// Resolve the switch first. This keeps the shipped OFF hot path cheap: none
+	// of the fidelity probes below (including the os.Getenv in the observability
+	// check) run unless the switch is actually on for this parser.
+	if !p.admissionCandidateRouteEnabled() {
+		return false
+	}
 	// The compact runner lexes the whole source with its own DFA token source and
 	// does not apply included ranges, so decline when a caller set any. Production
 	// then honors the ranges exactly.
 	if len(p.included) > 0 {
-		return false
-	}
-	// Preserve callback fidelity: the compact route does not emit the parser's
-	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline
-	// (fall back to production) whenever a consumer has attached one. Production
-	// then fires every hook exactly as it does today.
-	if p.hasActiveParseObservability() {
 		return false
 	}
 	// Preserve liveness fidelity: the compact scheduler does not poll an explicit
@@ -189,7 +202,14 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	if p.timeoutMicros != 0 || p.cancellationFlag != nil {
 		return false
 	}
-	return p.admissionCandidateRouteEnabled()
+	// Preserve callback fidelity: the compact route does not emit the parser's
+	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline
+	// (fall back to production) whenever a consumer has attached one. Production
+	// then fires every hook exactly as it does today.
+	if p.hasActiveParseObservability() {
+		return false
+	}
+	return true
 }
 
 // hasActiveParseObservability reports whether a consumer attached any parse-time
@@ -214,6 +234,20 @@ func (p *Parser) suppressAdmissionCandidateRoute() func() {
 	}
 	p.admissionRouteSuppressed++
 	return func() { p.admissionRouteSuppressed-- }
+}
+
+// pinToProductionRoute permanently forces an internally-created sub-parser onto
+// the production route, independent of the process-wide default. Recovery,
+// snippet, and injection sub-parsers parse fragments that feed recovery splicing
+// or injection subtrees -- contexts the admission scorecard never validated --
+// so they must never route a compact tree even if the global default flips on.
+func (p *Parser) pinToProductionRoute() {
+	if p == nil {
+		return
+	}
+	p.admissionCandidateRoute = admissionRouteProductionForced
+	p.admissionRouteSuppressed = 0
+	p.admissionCandidateRunner = nil
 }
 
 // attemptAdmissionCandidateFullParse routes a fresh full parse through the

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -1,0 +1,114 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"errors"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// This file is the compact candidate route for the Phase-3 admission switch.
+// It is built only under the gts_parsercorephase0 tag, where the compact engine
+// exists. The default build uses the stub in admission_switch_stub.go.
+//
+// The route reuses the fresh-full runner (parsercore_phase0_fresh_full_runner.go)
+// but binds it to the caller's own Parser and Language rather than the certified
+// Go blob, so it can attempt every DFA-lexable grammar. The runner's strict
+// acceptance gate (one accepted head, one exact EOF derivation, a clean full-
+// span root) declines everything it cannot reproduce, so an unsupported grammar
+// or a recovering input fails closed and the caller falls back to production.
+
+// admissionCandidateLimits are generous compact-arena bounds for production-
+// scale full parses. They mirror the canonical admission limits.
+func admissionCandidateLimits() core.Limits {
+	return core.Limits{
+		MaxNodes: 1 << 20, MaxLinks: 1 << 20, MaxSubtrees: 1 << 20,
+		MaxChildren: 4 << 20, MaxMetadata: 2 << 20,
+		MaxLinksPerBoundary: 8, MaxPopPaths: 1 << 16, MaxDerivations: 1 << 16,
+	}
+}
+
+// newAdmissionCandidateRunner builds a fresh-full runner bound to p's own
+// language, external scanner, and DFA tables.
+func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) {
+	if p == nil || p.language == nil {
+		return nil, errors.New("admission candidate route: parser has no language")
+	}
+	options := DiagnosticParserCorePrefixOptions{
+		ReceiptMode:           DiagnosticParserCoreReceiptSummary,
+		MaxTokens:             1 << 24,
+		MaxDispatches:         1 << 24,
+		Limits:                admissionCandidateLimits(),
+		freshSchedulerSession: true,
+	}
+	tables, err := newParserCoreRootTables(p)
+	if err != nil {
+		return nil, err
+	}
+	compact, err := core.New(tables, options.Limits)
+	if err != nil {
+		return nil, err
+	}
+	return &parserCoreFreshFullRunner{
+		lang: p.language, parser: p, tables: tables, compact: compact, options: options,
+	}, nil
+}
+
+// acquireAdmissionCandidateRunner returns p's cached candidate runner, building
+// and caching one on first use or whenever the parser's language changed.
+func (p *Parser) acquireAdmissionCandidateRunner() (*parserCoreFreshFullRunner, error) {
+	if p == nil || p.language == nil {
+		return nil, errors.New("admission candidate route: parser has no language")
+	}
+	if cached, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner); ok &&
+		cached != nil && cached.lang == p.language && cached.parser == p {
+		return cached, nil
+	}
+	runner, err := newAdmissionCandidateRunner(p)
+	if err != nil {
+		return nil, err
+	}
+	p.admissionCandidateRunner = runner
+	return runner, nil
+}
+
+// tryCompactFullParseRoute attempts the compact candidate route for a fresh
+// full parse. It returns (tree, true, "") on success and (nil, false, reason)
+// on any decline, so the caller falls back to production.
+func (p *Parser) tryCompactFullParseRoute(source []byte) (*Tree, bool, string) {
+	runner, err := p.acquireAdmissionCandidateRunner()
+	if err != nil {
+		return nil, false, "runner unavailable: " + err.Error()
+	}
+	endOp := p.beginParseOperationBudget()
+	defer endOp()
+	endParse := p.enterParseBudget()
+	defer endParse()
+	tree, err := runner.parse(source)
+	if err != nil {
+		return nil, false, admissionCandidateDeclineReason(err)
+	}
+	if tree == nil {
+		return nil, false, "compact route produced no tree"
+	}
+	// Apply the exact production Parse tail so every returned-tree API surface
+	// matches production. The compact tree is already deep-equal to a fully
+	// normalized production tree (the canonical admission test proves it), so
+	// this deterministic tail is structure-preserving here; it runs for fidelity
+	// on the shared runtime-flag and root-span finalization steps.
+	p.normalizeReturnedTreeForParse(tree, source)
+	tree = p.resolveCRecoverySwallowedError(source, tree)
+	tree = p.maybeCompactReturnedFullTree(tree, source)
+	return tree, true, ""
+}
+
+// admissionCandidateDeclineReason renders a runner error as a compact,
+// operator-readable fallback reason, surfacing the decline boundary when known.
+func admissionCandidateDeclineReason(err error) string {
+	var decline *diagnosticParserCoreDecline
+	if errors.As(err, &decline) {
+		return "compact route declined at " + string(decline.boundary) + ": " + decline.detail
+	}
+	return "compact route error: " + err.Error()
+}

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -1,0 +1,192 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+// These tests run under the gts_parsercorephase0 tag, where the compact
+// candidate route is compiled in. They prove the switch actually routes a fresh
+// full parse through the compact route, that the routed tree is byte-exact with
+// production on the four canonical fixtures, and that every reuse-consuming path
+// stays on production.
+
+func newAdmissionCandidateGoParser(t testing.TB) *Parser {
+	t.Helper()
+	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
+	if err != nil {
+		t.Fatalf("authenticate certified Go language: %v", err)
+	}
+	return NewParser(lang)
+}
+
+// TestAdmissionSwitchParseRoutesCandidateWhenOn proves Parse serves the compact
+// candidate route for every canonical fixture when the switch is on.
+func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
+	resetAdmissionCandidateCounters()
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+		routed0, fb0 := AdmissionCandidateCounters()
+		tree, err := p.Parse(fixture.Source)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", row.id, err)
+		}
+		routed1, fb1 := AdmissionCandidateCounters()
+		if routed1 != routed0+1 || fb1 != fb0 {
+			t.Fatalf("%s: expected one candidate route, got routed %d->%d fallback %d->%d (last=%q)",
+				row.id, routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
+		}
+		if !tree.compactMaterialized {
+			t.Fatalf("%s: routed tree is not compact-materialized", row.id)
+		}
+		if !tree.incrementalReuseDisabled {
+			t.Fatalf("%s: routed tree must carry the reuse bar", row.id)
+		}
+		tree.Release()
+	}
+}
+
+// TestAdmissionSwitchParseProductionWhenOff proves a forced-off Parser stays on
+// production and never touches the counters, independent of the process default
+// (this test forces off so it is robust to GTS_ADMISSION_CANDIDATE).
+func TestAdmissionSwitchParseProductionWhenOff(t *testing.T) {
+	resetAdmissionCandidateCounters()
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(false) // forced off wins over any default/env
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	routed0, fb0 := AdmissionCandidateCounters()
+	tree, err := p.Parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	routed1, fb1 := AdmissionCandidateCounters()
+	if routed1 != routed0 || fb1 != fb0 {
+		t.Fatalf("switch off must not move counters: routed %d->%d fallback %d->%d", routed0, routed1, fb0, fb1)
+	}
+	if tree.compactMaterialized {
+		t.Fatal("switch off produced a compact-materialized tree")
+	}
+}
+
+// TestAdmissionSwitchCandidateDigestMatchesProduction is the byte-exact fidelity
+// proof: the compact candidate route and production produce the same frozen
+// deep-tree digest on all four canonical fixtures, through the public Parse API.
+func TestAdmissionSwitchCandidateDigestMatchesProduction(t *testing.T) {
+	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
+	if err != nil {
+		t.Fatalf("authenticate certified Go language: %v", err)
+	}
+	candidate := NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	production := NewParser(lang)
+	production.SetAdmissionCandidateRoute(false)
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+		candidateTree, err := candidate.Parse(fixture.Source)
+		if err != nil {
+			t.Fatalf("%s: candidate parse: %v", row.id, err)
+		}
+		productionTree, err := production.Parse(fixture.Source)
+		if err != nil {
+			t.Fatalf("%s: production parse: %v", row.id, err)
+		}
+		candidateDigest := requireDiagnosticParserCoreCanonicalTreeDigest(t, candidateTree, lang)
+		productionDigest := requireDiagnosticParserCoreCanonicalTreeDigest(t, productionTree, lang)
+		if candidateDigest != row.deepTreeSHA256 {
+			t.Fatalf("%s: candidate digest=%s want=%s", row.id, candidateDigest, row.deepTreeSHA256)
+		}
+		if productionDigest != candidateDigest {
+			t.Fatalf("%s: production digest=%s != candidate digest=%s", row.id, productionDigest, candidateDigest)
+		}
+		if !candidateTree.compactMaterialized {
+			t.Fatalf("%s: candidate tree is not compact-materialized", row.id)
+		}
+		candidateTree.Release()
+		productionTree.Release()
+	}
+}
+
+// TestAdmissionSwitchEligibilityFailsClosedForReuse proves the centralized
+// routing policy the three fresh-full-parse entry points share: only a fresh
+// DFA parse is eligible; every reuse-consuming path and every non-DFA lexer is
+// barred, even when the switch is forced on.
+func TestAdmissionSwitchEligibilityFailsClosedForReuse(t *testing.T) {
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	if !p.admissionCandidateFullParseEligible(nil, true) {
+		t.Fatal("a fresh DFA parse must be eligible when the switch is on")
+	}
+	reuse := &Tree{}
+	if p.admissionCandidateFullParseEligible(reuse, true) {
+		t.Fatal("a reuse-consuming path (oldTree != nil) must never be eligible")
+	}
+	if p.admissionCandidateFullParseEligible(nil, false) {
+		t.Fatal("a caller-supplied token source must never be eligible")
+	}
+	p.SetAdmissionCandidateRoute(false)
+	if p.admissionCandidateFullParseEligible(nil, true) {
+		t.Fatal("a forced-off Parser must not be eligible")
+	}
+}
+
+// TestAdmissionSwitchParseIncrementalNeverRoutes proves that even with the
+// switch forced on, ParseIncremental stays on production: the candidate route's
+// routed counter never moves across an incremental reparse.
+func TestAdmissionSwitchParseIncrementalNeverRoutes(t *testing.T) {
+	resetAdmissionCandidateCounters()
+	p := newAdmissionCandidateGoParser(t)
+	p.SetAdmissionCandidateRoute(true)
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	oldTree, err := p.Parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("fresh parse: %v", err)
+	}
+	defer oldTree.Release()
+	routedAfterFresh, _ := AdmissionCandidateCounters()
+
+	// Append a single space at EOF: a clean, minimal edit.
+	edited := append(append([]byte(nil), fixture.Source...), ' ')
+	eofPoint := admissionTestPointAtByte(fixture.Source, len(fixture.Source))
+	edit := InputEdit{
+		StartByte:   uint32(len(fixture.Source)),
+		OldEndByte:  uint32(len(fixture.Source)),
+		NewEndByte:  uint32(len(fixture.Source) + 1),
+		StartPoint:  eofPoint,
+		OldEndPoint: eofPoint,
+		NewEndPoint: Point{Row: eofPoint.Row, Column: eofPoint.Column + 1},
+	}
+	oldTree.Edit(edit)
+	newTree, err := p.ParseIncremental(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	if newTree != nil && newTree != oldTree {
+		defer newTree.Release()
+	}
+	routedAfterIncremental, _ := AdmissionCandidateCounters()
+	if routedAfterIncremental != routedAfterFresh {
+		t.Fatalf("ParseIncremental routed to the candidate: routed %d -> %d", routedAfterFresh, routedAfterIncremental)
+	}
+	if newTree != nil && newTree.compactMaterialized {
+		t.Fatal("ParseIncremental produced a compact-materialized tree")
+	}
+}
+
+// admissionTestPointAtByte returns the row/column point for a byte offset.
+func admissionTestPointAtByte(source []byte, offset int) Point {
+	var row, col uint32
+	if offset > len(source) {
+		offset = len(source)
+	}
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			row++
+			col = 0
+			continue
+		}
+		col++
+	}
+	return Point{Row: row, Column: col}
+}

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -174,6 +174,32 @@ func TestAdmissionSwitchParseIncrementalNeverRoutes(t *testing.T) {
 	}
 }
 
+// TestAdmissionSwitchRecoveryDoesNotLeakCompactTree drives malformed input
+// through the real compact route with the switch forced on. The compact route
+// declines the malformed parse and production recovery runs, so the returned
+// tree must be a production (non-compact) tree, and the pinned recovery
+// sub-parser must never publish a compact fragment.
+func TestAdmissionSwitchRecoveryDoesNotLeakCompactTree(t *testing.T) {
+	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
+	if err != nil {
+		t.Fatalf("authenticate certified Go language: %v", err)
+	}
+	p := NewParser(lang)
+	p.SetAdmissionCandidateRoute(true)
+	malformed := []byte("package main\n\nfunc () {\n\tvar x = \n}\n")
+	tree, err := p.Parse(malformed)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	if tree.compactMaterialized {
+		t.Fatal("malformed/recovery parse leaked a compact-materialized tree")
+	}
+	if root := tree.RootNode(); root == nil || !root.HasError() {
+		t.Fatal("malformed input should recover into an error-bearing production tree")
+	}
+}
+
 // admissionTestPointAtByte returns the row/column point for a byte offset.
 func admissionTestPointAtByte(source []byte, offset int) Point {
 	var row, col uint32

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -1,0 +1,13 @@
+//go:build !gts_parsercorephase0
+
+package gotreesitter
+
+// tryCompactFullParseRoute is the default-build stub for the compact candidate
+// route. The parsercorephase0 engine is only compiled under the
+// gts_parsercorephase0 build tag, so in the default build the candidate route
+// is unavailable: every eligible full parse fails closed and falls back to
+// production. The switch still resolves and its counters still move, so the
+// routing seam is testable without the tag.
+func (p *Parser) tryCompactFullParseRoute(_ []byte) (*Tree, bool, string) {
+	return nil, false, "compact candidate route not compiled in (build with -tags gts_parsercorephase0)"
+}

--- a/admission_switch_stub_test.go
+++ b/admission_switch_stub_test.go
@@ -1,0 +1,43 @@
+//go:build !gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+)
+
+// TestAdmissionSwitchDefaultBuildFallsBackLoudly proves the fail-closed
+// contract in the shipped default build: with the switch on, an eligible fresh
+// full parse attempts the candidate route, is declined (the compact engine is
+// not compiled in), bumps the fallback counter, records a loud reason, and
+// returns the correct production tree.
+func TestAdmissionSwitchDefaultBuildFallsBackLoudly(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(false)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	routedBefore, fallbackBefore := gts.AdmissionCandidateCounters()
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	requireCleanFullTree(t, tree, source, "default-build-fallback")
+
+	routedAfter, fallbackAfter := gts.AdmissionCandidateCounters()
+	if routedAfter != routedBefore {
+		t.Fatalf("default build must not route to the candidate: routed %d -> %d", routedBefore, routedAfter)
+	}
+	if fallbackAfter != fallbackBefore+1 {
+		t.Fatalf("default build must fall back loudly: fallback %d -> %d", fallbackBefore, fallbackAfter)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "not compiled in") {
+		t.Fatalf("fallback reason must name the missing engine, got %q", reason)
+	}
+}

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -1,0 +1,304 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// These tests exercise the Phase-3 admission switch through the public API. They
+// are build-agnostic: they assert routing EVENTS (a full parse either serves the
+// candidate route or falls back), not which engine served the parse, so they
+// hold in both the default and the gts_parsercorephase0 builds. The digest and
+// engine-identity proofs live in the tagged internal tests.
+
+func admissionRoutingEvents(t *testing.T) uint64 {
+	t.Helper()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	return routed + fallback
+}
+
+// newAdmissionDFAParser returns a parser for the first candidate DFA-backed
+// language whose smoke sample parses to a clean, full-span tree in production.
+// The DFA Parse path is the one the admission switch can route.
+func newAdmissionDFAParser(t *testing.T) (*gts.Parser, []byte) {
+	t.Helper()
+	for _, name := range []string{"go", "lua", "toml", "ini", "json5", "css"} {
+		entry := grammars.DetectLanguageByName(name)
+		if entry == nil {
+			continue
+		}
+		lang := entry.Language()
+		if grammars.EvaluateParseSupport(*entry, lang).Backend != grammars.ParseBackendDFA {
+			continue
+		}
+		source := []byte(grammars.ParseSmokeSample(name))
+		probe := gts.NewParser(lang)
+		probe.SetAdmissionCandidateRoute(false)
+		tree, err := probe.Parse(source)
+		if err != nil || tree == nil || tree.RootNode() == nil {
+			continue
+		}
+		clean := tree.RootNode().EndByte() == uint32(len(source)) && !tree.RootNode().HasError()
+		tree.Release()
+		if !clean {
+			continue
+		}
+		return gts.NewParser(lang), source
+	}
+	t.Skip("no clean DFA-backed language available for the routing test")
+	return nil, nil
+}
+
+func requireCleanFullTree(t *testing.T, tree *gts.Tree, source []byte, label string) {
+	t.Helper()
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatalf("%s: nil tree/root", label)
+	}
+	root := tree.RootNode()
+	if root.EndByte() != uint32(len(source)) {
+		t.Fatalf("%s: truncated root end=%d source=%d", label, root.EndByte(), len(source))
+	}
+	if root.HasError() {
+		t.Fatalf("%s: tree has error nodes", label)
+	}
+}
+
+// TestAdmissionSwitchDefaultLeavesParseOnProduction proves the shipped default
+// (off) routes no parse through the candidate and moves no counter.
+func TestAdmissionSwitchDefaultLeavesParseOnProduction(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(false)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	requireCleanFullTree(t, tree, source, "default-off")
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("default-off moved a routing counter: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchPerParserOnRoutesFreshParse proves a per-Parser override
+// makes a fresh DFA Parse consult the candidate route exactly once.
+func TestAdmissionSwitchPerParserOnRoutesFreshParse(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(false)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	parser.SetAdmissionCandidateRoute(true)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	requireCleanFullTree(t, tree, source, "per-parser-on")
+	if got := admissionRoutingEvents(t); got != before+1 {
+		t.Fatalf("per-parser-on expected one routing event: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchPerParserOffOverridesGlobalOn proves precedence: a per-
+// Parser off wins over a global-on default and consults no candidate route.
+func TestAdmissionSwitchPerParserOffOverridesGlobalOn(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	parser.SetAdmissionCandidateRoute(false)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	requireCleanFullTree(t, tree, source, "per-parser-off")
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("per-parser-off must override global-on and move no counter: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchGlobalOnRoutesFreshParse proves the global default alone
+// (no per-Parser override) routes a fresh DFA Parse.
+func TestAdmissionSwitchGlobalOnRoutesFreshParse(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	requireCleanFullTree(t, tree, source, "global-on")
+	if got := admissionRoutingEvents(t); got != before+1 {
+		t.Fatalf("global-on expected one routing event: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchParseIncrementalNeverConsultsCandidate proves that even
+// with the switch forced on, ParseIncremental never consults the candidate
+// route: it is a reuse-consuming path barred from compact trees.
+func TestAdmissionSwitchParseIncrementalNeverConsultsCandidate(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("fresh parse: %v", err)
+	}
+	defer oldTree.Release()
+	before := admissionRoutingEvents(t)
+
+	edited := append(append([]byte(nil), source...), ' ')
+	eof := admissionEOFPoint(source)
+	edit := gts.InputEdit{
+		StartByte:   uint32(len(source)),
+		OldEndByte:  uint32(len(source)),
+		NewEndByte:  uint32(len(source) + 1),
+		StartPoint:  eof,
+		OldEndPoint: eof,
+		NewEndPoint: gts.Point{Row: eof.Row, Column: eof.Column + 1},
+	}
+	oldTree.Edit(edit)
+	newTree, err := parser.ParseIncremental(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	if newTree != nil && newTree != oldTree {
+		defer newTree.Release()
+	}
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("ParseIncremental consulted the candidate route: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchCustomTokenSourceNeverConsultsCandidate proves that a
+// caller-supplied token source is never eligible: the seam declines before any
+// candidate attempt, so no counter moves.
+func TestAdmissionSwitchCustomTokenSourceNeverConsultsCandidate(t *testing.T) {
+	// Find any registered token-source-backed language (json is one).
+	var entry *grammars.LangEntry
+	for _, name := range []string{"json", "go", "typescript", "tsx", "javascript"} {
+		e := grammars.DetectLanguageByName(name)
+		if e != nil && e.TokenSourceFactory != nil {
+			entry = e
+			break
+		}
+	}
+	if entry == nil {
+		t.Skip("no token-source-backed language registered for the custom source test")
+	}
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	lang := entry.Language()
+	source := []byte(grammars.ParseSmokeSample(entry.Name))
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.ParseWithTokenSource(source, entry.TokenSourceFactory(source, lang))
+	if err != nil {
+		t.Fatalf("token-source parse: %v", err)
+	}
+	defer tree.Release()
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("custom token source consulted the candidate route: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchDeclinesWhenIncludedRangesSet proves the candidate route
+// declines when included ranges are configured: the compact runner lexes the
+// whole source and cannot honor ranges, so the parse stays on production.
+func TestAdmissionSwitchDeclinesWhenIncludedRangesSet(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	parser.SetIncludedRanges([]gts.Range{{StartByte: 0, EndByte: uint32(len(source)), EndPoint: admissionEOFPoint(source)}})
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("included ranges must keep the parse on production: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchEnvVarContract proves GTS_ADMISSION_CANDIDATE seeds the
+// process-wide default: init calls this same parser at package load.
+func TestAdmissionSwitchEnvVarContract(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"1", true}, {"true", true}, {"on", true}, {"yes", true}, {"YES", true},
+		{"0", false}, {"false", false}, {"", false}, {"nonsense", false},
+	} {
+		t.Setenv("GTS_ADMISSION_CANDIDATE", tc.value)
+		if got := gts.AdmissionCandidateEnvEnabledForTest(); got != tc.want {
+			t.Fatalf("GTS_ADMISSION_CANDIDATE=%q enabled=%v want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestAdmissionSwitchDeclinesWhenLoggerAttached proves the candidate route
+// preserves callback fidelity: with a logger attached and the switch on, the
+// parse stays on production (no routing event) so every logger callback fires.
+func TestAdmissionSwitchDeclinesWhenLoggerAttached(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	parser.SetLogger(func(gts.ParserLogType, string) {})
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	requireCleanFullTree(t, tree, source, "logger-attached")
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("an attached logger must keep the parse on production: %d -> %d", before, got)
+	}
+}
+
+// admissionEOFPoint returns the row/column point at the end of source.
+func admissionEOFPoint(source []byte) gts.Point {
+	var row, col uint32
+	for _, b := range source {
+		if b == '\n' {
+			row++
+			col = 0
+			continue
+		}
+		col++
+	}
+	return gts.Point{Row: row, Column: col}
+}

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -249,6 +249,109 @@ func TestAdmissionSwitchDeclinesWhenIncludedRangesSet(t *testing.T) {
 	}
 }
 
+// TestAdmissionSwitchDeclinesWhenTimeoutSet proves the candidate route declines
+// when a caller set a timeout: the compact scheduler does not poll deadlines, so
+// the parse stays on production which honors it.
+func TestAdmissionSwitchDeclinesWhenTimeoutSet(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	parser.SetTimeoutMicros(1_000_000)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("a timeout must keep the parse on production: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchDeclinesWhenCancellationFlagSet proves the candidate route
+// declines when a caller set a cancellation flag.
+func TestAdmissionSwitchDeclinesWhenCancellationFlagSet(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+
+	parser, source := newAdmissionDFAParser(t)
+	var flag uint32
+	parser.SetCancellationFlag(&flag)
+	before := admissionRoutingEvents(t)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	if got := admissionRoutingEvents(t); got != before {
+		t.Fatalf("a cancellation flag must keep the parse on production: %d -> %d", before, got)
+	}
+}
+
+// TestAdmissionSwitchInternalSubParsersPinnedToProduction proves that recovery,
+// snippet, and injection sub-parsers are born pinned to the production route:
+// even with the global default forced on, they are ineligible to route a
+// compact fragment into recovery splicing or an injection subtree.
+func TestAdmissionSwitchInternalSubParsersPinnedToProduction(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true) // global ON, the future-flip state
+
+	entry := grammars.DetectLanguageByName("go")
+	if entry == nil {
+		t.Skip("go grammar not registered")
+	}
+	lang := entry.Language()
+
+	snippet := gts.AcquireSnippetParserForTest(lang)
+	defer gts.ReleaseSnippetParserForTest(snippet)
+	if !gts.ParserPinnedToProductionForTest(snippet) {
+		t.Fatal("recovery/snippet parser is not pinned to production")
+	}
+	if gts.ParserAdmissionEligibleForTest(snippet) {
+		t.Fatal("recovery/snippet parser is eligible to route under global ON")
+	}
+
+	child := gts.InjectionChildParserForTest(lang)
+	if !gts.ParserPinnedToProductionForTest(child) {
+		t.Fatal("injection child parser is not pinned to production")
+	}
+	if gts.ParserAdmissionEligibleForTest(child) {
+		t.Fatal("injection child parser is eligible to route under global ON")
+	}
+}
+
+// TestAdmissionSwitchPooledParserScrubsRouteState proves ParserPool.applyDefaults
+// clears the per-Parser override so a pooled parser follows the default again.
+func TestAdmissionSwitchPooledParserScrubsRouteState(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(false)
+
+	entry := grammars.DetectLanguageByName("go")
+	if entry == nil {
+		t.Skip("go grammar not registered")
+	}
+	pool := gts.NewParserPool(entry.Language())
+	// A checked-out parser forced off, then returned, must not leak that override.
+	p1 := gts.ParserPoolCheckoutForTest(pool)
+	p1.SetAdmissionCandidateRoute(false)
+	gts.ParserPoolReleaseForTest(pool, p1)
+
+	gts.SetAdmissionCandidateRouteDefault(true)
+	gts.ResetAdmissionCandidateCountersForTest()
+	p2 := gts.ParserPoolCheckoutForTest(pool)
+	defer gts.ParserPoolReleaseForTest(pool, p2)
+	if !gts.ParserAdmissionEligibleForTest(p2) {
+		t.Fatal("pooled parser did not scrub its route override; a forced-off override leaked across checkouts")
+	}
+}
+
 // TestAdmissionSwitchEnvVarContract proves GTS_ADMISSION_CANDIDATE seeds the
 // process-wide default: init calls this same parser at package load.
 func TestAdmissionSwitchEnvVarContract(t *testing.T) {

--- a/export_test.go
+++ b/export_test.go
@@ -266,3 +266,36 @@ func ResetAdmissionCandidateCountersForTest() {
 func AdmissionCandidateEnvEnabledForTest() bool {
 	return admissionCandidateEnvEnabled()
 }
+
+// AdmissionSubParserProbe bundles internal sub-parser construction so the
+// external test package can prove recovery, snippet, and injection sub-parsers
+// are born pinned to the production route.
+func AcquireSnippetParserForTest(lang *Language) *Parser { return acquireSnippetParser(lang) }
+
+// ReleaseSnippetParserForTest returns a snippet parser to its pool.
+func ReleaseSnippetParserForTest(p *Parser) { releaseSnippetParser(p) }
+
+// InjectionChildParserForTest returns a freshly constructed injection child
+// parser via the same getParser path the injection engine uses.
+func InjectionChildParserForTest(lang *Language) *Parser {
+	ip := NewInjectionParser()
+	return ip.getParser("test", lang)
+}
+
+// ParserPinnedToProductionForTest reports whether p carries the production-only
+// override that pinToProductionRoute installs.
+func ParserPinnedToProductionForTest(p *Parser) bool {
+	return p != nil && p.admissionCandidateRoute == admissionRouteProductionForced
+}
+
+// ParserAdmissionEligibleForTest reports whether p would route a fresh DFA full
+// parse through the compact candidate right now.
+func ParserAdmissionEligibleForTest(p *Parser) bool {
+	return p.admissionCandidateFullParseEligible(nil, true)
+}
+
+// ParserPoolCheckoutForTest checks a parser out of the pool (applying defaults).
+func ParserPoolCheckoutForTest(pp *ParserPool) *Parser { return pp.checkout() }
+
+// ParserPoolReleaseForTest returns a parser to the pool (applying defaults).
+func ParserPoolReleaseForTest(pp *ParserPool, p *Parser) { pp.release(p) }

--- a/export_test.go
+++ b/export_test.go
@@ -252,3 +252,17 @@ func (r ReplayResyncReport) SortedClassStats() []ReplayClassStat {
 	})
 	return out
 }
+
+// ResetAdmissionCandidateCountersForTest zeroes the Phase-3 admission switch
+// counters so the external gotreesitter_test package can assert routing and
+// fallback movements in isolation.
+func ResetAdmissionCandidateCountersForTest() {
+	resetAdmissionCandidateCounters()
+}
+
+// AdmissionCandidateEnvEnabledForTest exposes the GTS_ADMISSION_CANDIDATE
+// parsing that init uses to seed the process-wide default, so the external test
+// package can assert the environment contract deterministically.
+func AdmissionCandidateEnvEnabledForTest() bool {
+	return admissionCandidateEnvEnabled()
+}

--- a/highlight_injections_exec.go
+++ b/highlight_injections_exec.go
@@ -191,6 +191,9 @@ func appendOffsetHighlightRanges(dst []HighlightRange, ranges []HighlightRange, 
 
 func (h *Highlighter) parseInjectedTree(lang *Language, tokenSourceFactory func(source []byte) TokenSource, source []byte) (*Tree, error) {
 	childParser := NewParser(lang)
+	// Injected highlight subtrees are outside the admission scorecard's validated
+	// surface: keep the child parser on production regardless of the default.
+	childParser.pinToProductionRoute()
 	if tokenSourceFactory != nil {
 		return childParser.ParseWithTokenSource(source, tokenSourceFactory(source))
 	}

--- a/injection.go
+++ b/injection.go
@@ -672,6 +672,9 @@ func (ip *InjectionParser) getParser(name string, lang *Language) *Parser {
 		return p
 	}
 	p := NewParser(lang)
+	// Injection child parsers build injection subtrees the admission scorecard
+	// never validated: keep them on production regardless of the global default.
+	p.pinToProductionRoute()
 	ip.parsers[name] = p
 	return p
 }

--- a/parser.go
+++ b/parser.go
@@ -46,6 +46,22 @@ type Parser struct {
 	rootSymbol                    Symbol
 	hasRootSymbol                 bool
 
+	// admissionCandidateRoute is the per-Parser override for the Phase-3
+	// dual-route admission switch (see admission_switch.go). The zero value
+	// follows the process-wide default.
+	admissionCandidateRoute admissionRouteMode
+	// admissionCandidateRunner caches the compact candidate route's reusable
+	// state across full parses on this Parser. It is typed as any because the
+	// concrete runner type only exists under the gts_parsercorephase0 build
+	// tag; the default build never reads or writes it.
+	admissionCandidateRunner any
+	// admissionRouteSuppressed, when greater than zero, forces the production
+	// route regardless of the switch. It is raised while a reuse-consuming call
+	// or a production-only correctness reparse delegates to Parse, so a delegated
+	// fresh parse can never publish a compact tree from a path that must stay on
+	// production.
+	admissionRouteSuppressed int
+
 	// reduceMultiVersion/reduceActionConflict are transient, non-sticky
 	// fragility signals for the reduce(s) about to run. Parser is documented
 	// single-goroutine (see the doc comment above), so plain mutable fields

--- a/parser.go
+++ b/parser.go
@@ -1572,6 +1572,9 @@ func resetSnippetParser(parser *Parser) {
 	parser.parseMemoryBudgetDiag = parseMemoryBudgetDiagnostic{}
 	parser.parseMemoryBudgetDiagActive = false
 	parser.compatMemoryBudgetTripped = false
+	// Recovery and snippet sub-parsers must never route through the compact
+	// candidate: they parse fragments spliced into recovery and reuse.
+	parser.pinToProductionRoute()
 	// Release *Node refs so the arenas from the last incremental parse can be
 	// collected by the GC. Without this, a Parser sitting in a sync.Pool keeps
 	// its reuseCursor.topLevel/*Node alive, preventing arena reclamation.

--- a/parser_api.go
+++ b/parser_api.go
@@ -609,6 +609,15 @@ func (p *Parser) parseWithTokenSource(source []byte, ts TokenSource, reparseFact
 	if ts == nil {
 		return nil, ErrNoTokenSource
 	}
+	// Phase-3 dual-route admission switch (admission_switch.go). This entry
+	// point honors the switch, but a caller-supplied token source is never
+	// eligible: the compact candidate route reproduces the production DFA token
+	// stream and cannot honor arbitrary tokens, so this always declines and
+	// runs production. The seam stays here so the policy is enforced in one
+	// place for every fresh full-parse entry point.
+	if tree, ok := p.attemptAdmissionCandidateFullParse(source, nil, false); ok {
+		return tree, nil
+	}
 	endBudget := p.beginParseOperationBudget()
 	defer endBudget()
 	p.fullParseRetryPassesTaken = 0
@@ -933,6 +942,14 @@ func (p *Parser) Parse(source []byte) (*Tree, error) {
 	if err := p.checkDFALexer(); err != nil {
 		return nil, err
 	}
+	// Phase-3 dual-route admission switch (admission_switch.go). A fresh full
+	// parse on the production DFA lexer is the one shape the compact candidate
+	// route can reproduce. When the switch is on and the candidate route
+	// accepts this input, return its tree; otherwise fall through to production
+	// (the fallback counter records the decline).
+	if tree, ok := p.attemptAdmissionCandidateFullParse(source, nil, true); ok {
+		return tree, nil
+	}
 	endBudget := p.beginParseOperationBudget()
 	defer endBudget()
 	p.fullParseRetryPassesTaken = 0
@@ -1103,6 +1120,9 @@ func (p *Parser) resolveCRecoverySwallowedError(source []byte, tree *Tree) *Tree
 	}()
 	p.errorCostCompetition = false
 	p.crecoverySwallowedErrorCheckActive = true
+	// This reparse is a production-only correctness oracle (the resync engine
+	// with C-recovery disabled): keep it off the compact candidate route.
+	defer p.suppressAdmissionCandidateRoute()()
 	fallback, err := p.Parse(source)
 	if err != nil || fallback == nil {
 		return tree
@@ -1358,6 +1378,9 @@ func (p *Parser) ParseIncremental(source []byte, oldTree *Tree) (*Tree, error) {
 func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
+	// ParseIncremental is a reuse-consuming path: keep the whole call, including
+	// the reuse-disabled fresh-parse fallback to Parse below, on production.
+	defer p.suppressAdmissionCandidateRoute()()
 	p.fullParseRetryPassesTaken = 0
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, nil); ok {
@@ -1512,6 +1535,9 @@ func (p *Parser) ParseIncrementalProfiled(source []byte, oldTree *Tree) (*Tree, 
 func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (*Tree, IncrementalParseProfile, error) {
 	endParseBudget := p.enterParseBudget()
 	defer endParseBudget()
+	// Reuse-consuming path: keep the reuse-disabled fresh-parse fallback below on
+	// production so ParseIncremental never publishes a compact tree.
+	defer p.suppressAdmissionCandidateRoute()()
 	p.fullParseRetryPassesTaken = 0
 	if oldTreeDisablesIncrementalReuse(oldTree) {
 		timing := &incrementalParseTiming{}

--- a/parser_api.go
+++ b/parser_api.go
@@ -1237,6 +1237,9 @@ func (p *Parser) ParseNoTreeBenchmarkOnly(source []byte) (*Tree, error) {
 		p.noTreeBenchmarkOnly = prev
 		p.noTreeCheckpointBenchmarkOnly = prevCheckpoints
 	}()
+	// These are production-loop measurement modes: keep them off the compact
+	// candidate route so a switched-on default cannot skew the attribution.
+	defer p.suppressAdmissionCandidateRoute()()
 	return p.Parse(source)
 }
 
@@ -1256,6 +1259,8 @@ func (p *Parser) ParseNoTreeWithExternalCheckpointsBenchmarkOnly(source []byte) 
 		p.noTreeBenchmarkOnly = prevNoTree
 		p.noTreeCheckpointBenchmarkOnly = prevCheckpoints
 	}()
+	// Production-loop measurement mode: keep it off the compact candidate route.
+	defer p.suppressAdmissionCandidateRoute()()
 	return p.Parse(source)
 }
 
@@ -1273,6 +1278,8 @@ func (p *Parser) ParseNoResultCompatibilityBenchmarkOnly(source []byte) (*Tree, 
 	defer func() {
 		p.noResultCompatibilityBenchmarkOnly = prevNoResult
 	}()
+	// Production-loop measurement mode: keep it off the compact candidate route.
+	defer p.suppressAdmissionCandidateRoute()()
 	return p.Parse(source)
 }
 

--- a/parser_pool.go
+++ b/parser_pool.go
@@ -118,6 +118,12 @@ func (pp *ParserPool) applyDefaults(p *Parser) {
 	p.pendingFullParents = false
 	p.skipInvisibleFullLeafCheckpoints = false
 	p.noResultCompatibilityBenchmarkOnly = false
+	// Scrub the Phase-3 admission switch state so a pooled parser follows the
+	// process-wide default again and never carries a stale override, suppression
+	// depth, or cached compact runner across checkouts.
+	p.admissionCandidateRoute = admissionRouteFollowDefault
+	p.admissionRouteSuppressed = 0
+	p.admissionCandidateRunner = nil
 }
 
 func (pp *ParserPool) checkout() *Parser {


### PR DESCRIPTION
## Summary

Introduces a routing layer to direct fresh full parses between the production GLR engine and a compact candidate route. The switch enforces strict eligibility checks. It fails closed on incremental reuse or non-DFA inputs. It supports per-Parser overrides, process defaults, and environment variables.

## Changes

- Add admission_switch.go with precedence resolution, atomic counters, and fail-closed eligibility gates.
- Add admission_switch_candidate.go to compile the compact runner under the gts_parsercorephase0 tag.
- Add admission_switch_stub.go to return loud fallback reasons when the compact engine is absent.
- Integrate the switch into Parse, ParseWithTokenSource, ParseIncremental, and correctness reparses in parser_api.go.
- Update parser.go fields to track per-Parser overrides, cached compact runners, and nested suppression guards.
- Add admission_scorecard_test.go to evaluate routing outcomes across 206 languages.
- Add unit and integration tests to verify public routing events, engine fidelity, and eligibility contracts.

## Testing

- Run `go test ./...` to verify the stub fallback contract and public API routing events.
- Run `go test -tags gts_parsercorephase0 ./...` to verify compact route routing, tree flags, and digest matches.
- Run `GTS_ADMISSION_SCORECARD=1 go test -tags gts_parsercorephase0 -run TestAdmissionCandidateScorecard206 -v .` to validate routing coverage across the full language registry.

## Flip readiness

The switch ships default OFF. Flipping the process-wide default ON is now a one-line change again: this revision closes the internal sub-parser escape class. Recovery, snippet, and injection sub-parsers are born pinned to the production route (born-suppressed), so a future default flip cannot route a compact fragment into recovery splicing or an injection subtree — contexts the admission scorecard never validated. Before this fix the flip was NOT a bare one-liner, because those separate-instance sub-parsers followed the global default; a test now proves they stay on production even with the default forced ON.

## Scorecard scope

The 206-language scorecard uses trivial per-language smoke snippets: it is reachability reconnaissance (which grammars the compact route accepts at all), not a fidelity proof. The byte-exact fidelity evidence is the four-fixture public-API digest test. Corpus-scale per-language fixtures are the tracked follow-up.
