### PR TITLE
optimize(parser): Limit incremental result normalization to O(edit)

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -45,6 +45,19 @@ type ReplayDiffReport struct {
 	Samples             []ReplayMismatchSample
 }
 
+// SetForceFullResultNormalizationWalk forces the full-tree result-normalization
+// walk, disabling the incremental range-limited walk (campaign O(edit),
+// spec.campaign.oedit). It exists ONLY so the byte-sweep differential can
+// compare the range-limited walk against the full walk on the SAME Parser and
+// prove they produce identical trees. It lives in export_test.go, so it is
+// compiled only in test builds and is never part of the public API.
+func (p *Parser) SetForceFullResultNormalizationWalk(v bool) {
+	if p == nil {
+		return
+	}
+	p.forceFullResultNormalizationWalk = v
+}
+
 // ReplayDiffTree replays the LR tables over the tree rooted at root and
 // compares the reconstructed states against the recorded ones on every node.
 // It mutates nothing. maxSamples bounds the retained mismatch examples.

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -673,7 +673,9 @@ func forestRootMustDecline(root *Node) bool {
 }
 
 func (p *Parser) finalizeForestRoot(root *Node, source []byte) {
-	p.finalizeResultRoot(root, source, nil, false, false)
+	// The forest fast path builds every node fresh (no subtree reuse), so
+	// range-limited normalization does not apply; pass nil to keep the full walk.
+	p.finalizeResultRoot(root, source, nil, false, false, nil)
 	extendRootToAcceptedCleanTail(root, source, uint32(len(source)), nil)
 }
 

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -1151,6 +1151,12 @@ func reuseTreeWithNewSource(oldTree *Tree, source []byte, dirtyNode *Node, clear
 	tree.forestFastPath = oldTree.forestFastPath
 	tree.incrementalReuseDisabled = oldTree.incrementalReuseDisabled
 	tree.compactMaterialized = oldTree.compactMaterialized
+	// This tree shares the old root, so shouldNormalizeIncrementalReturnedTree
+	// skips result normalization for it (same root). Even if a range-limited
+	// pass ever ran here, incrementalReparsedTopLevelRanges would read this
+	// shared tree's arenas rather than any freshly reparsed span, but the walk
+	// stays sound: the shared tree is already normalized and the range-limited Go
+	// normalizers are idempotent, so re-running them changes nothing.
 	return tree
 }
 

--- a/oedit_range_normalize_bench_test.go
+++ b/oedit_range_normalize_bench_test.go
@@ -1,0 +1,105 @@
+package gotreesitter_test
+
+// Measurement harness for campaign O(edit) range-limited result normalization
+// (spec.campaign.oedit). Reports the clean-Go near-top single-byte insert
+// incremental reparse latency with the range-limited walk ON vs the full walk
+// (SetForceFullResultNormalizationWalk), best-of-N warm iterations, at 137KB and
+// 1MB, plus a CSS neutrality control. Run with:
+//
+//	go test -run TestOEditRangeNormalizeMeasure -v -timeout 20m
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func oeditMeasureGo(funcs int) []byte {
+	var b strings.Builder
+	b.WriteString("package p\n\n")
+	for i := 0; i < funcs; i++ {
+		fmt.Fprintf(&b, "func F%d(a int) int {\n\tx := a + %d\n\treturn x\n}\n\n", i, i)
+	}
+	return []byte(b.String())
+}
+
+func oeditMeasureCSS(rules int) []byte {
+	var b strings.Builder
+	for i := 0; i < rules; i++ {
+		fmt.Fprintf(&b, ".r%d {\n  color: red;\n  margin: %dpx;\n  padding: 1px;\n}\n\n", i, i)
+	}
+	return []byte(b.String())
+}
+
+func oeditBestOf(t *testing.T, lang *gts.Language, src []byte, off int, iters int, fullWalk bool) time.Duration {
+	t.Helper()
+	edited := make([]byte, 0, len(src)+1)
+	edited = append(edited, src[:off]...)
+	edited = append(edited, 'z')
+	edited = append(edited, src[off:]...)
+	edit := gts.InputEdit{StartByte: uint32(off), OldEndByte: uint32(off), NewEndByte: uint32(off + 1)}
+
+	parser := gts.NewParser(lang)
+	parser.SetForceFullResultNormalizationWalk(fullWalk)
+
+	best := time.Duration(1<<62 - 1)
+	for it := 0; it < iters; it++ {
+		base, err := parser.Parse(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		base.Edit(edit)
+		start := time.Now()
+		incr, err := parser.ParseIncremental(edited, base)
+		el := time.Since(start)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if incr.RootNode().HasError() {
+			t.Fatal("incremental tree has error")
+		}
+		if el < best {
+			best = el
+		}
+		incr.Release()
+	}
+	return best
+}
+
+func TestOEditRangeNormalizeMeasure(t *testing.T) {
+	if os.Getenv("OEDIT_MEASURE") == "" {
+		t.Skip("measurement harness; set OEDIT_MEASURE=1 to run")
+	}
+	goLang := grammars.GoLanguage()
+	cssLang := grammars.CssLanguage()
+
+	type fixture struct {
+		name  string
+		lang  *gts.Language
+		src   []byte
+		mark  string
+		iters int
+	}
+	fixtures := []fixture{
+		{"go-137KB", goLang, oeditMeasureGo(2805), "func F0(a", 25},
+		{"go-1MB", goLang, oeditMeasureGo(20971), "func F0(a", 15},
+		{"css-neutral", cssLang, oeditMeasureCSS(6000), ".r0 {", 25},
+	}
+	for _, f := range fixtures {
+		off := bytes.Index(f.src, []byte(f.mark)) + len(f.mark) - 1
+		if off < 0 {
+			t.Fatalf("%s: mark %q not found", f.name, f.mark)
+		}
+		full := oeditBestOf(t, f.lang, f.src, off, f.iters, true)
+		limited := oeditBestOf(t, f.lang, f.src, off, f.iters, false)
+		delta := full - limited
+		t.Logf("%-14s bytes=%-8d fullWalk=%-8v rangeLimited=%-8v reduction=%-8v",
+			f.name, len(f.src), full.Round(time.Microsecond), limited.Round(time.Microsecond), delta.Round(time.Microsecond))
+	}
+}

--- a/oedit_range_normalize_bench_test.go
+++ b/oedit_range_normalize_bench_test.go
@@ -59,14 +59,18 @@ func oeditBestOf(t *testing.T, lang *gts.Language, src []byte, off int, iters in
 		incr, err := parser.ParseIncremental(edited, base)
 		el := time.Since(start)
 		if err != nil {
+			base.Release()
 			t.Fatal(err)
 		}
 		if incr.RootNode().HasError() {
+			base.Release()
+			incr.Release()
 			t.Fatal("incremental tree has error")
 		}
 		if el < best {
 			best = el
 		}
+		base.Release()
 		incr.Release()
 	}
 	return best

--- a/oedit_range_normalize_sweep_test.go
+++ b/oedit_range_normalize_sweep_test.go
@@ -2,16 +2,26 @@ package gotreesitter_test
 
 // Byte-sweep differential for campaign O(edit) range-limited result
 // normalization (spec.campaign.oedit). For every insert / delete / replace edit
-// at every byte position of a multi-item source, ParseIncremental must produce a
-// tree byte-identical (SExpr, spans included) to a fresh Parse of the same
-// edited text -- at every site where the fresh parse is genuinely clean
-// (full-span, zero IsError/IsMissing). This proves the range-limited Go walk is
-// sound (reused siblings skipped == re-walked) and that the shared plumbing is
-// neutral for the non-range-limited normalizer-bearing languages
-// (scala/php/c_sharp) and the reference language (css).
+// at every byte position of a multi-item source, the range-limited incremental
+// parse must produce a tree IDENTICAL to the full-walk incremental parse -- and,
+// where the full walk matches a fresh parse, identical to fresh too -- at every
+// site where the fresh parse is genuinely clean (full-span, zero
+// IsError/IsMissing).
+//
+// Identity is checked with oeditSerialize, NOT Node.SExpr: the three
+// range-limited Go normalizers mutate exactly the things SExpr hides -- node
+// byte spans (endByte adjustments) and anonymous children (dropped `;`). The
+// serializer therefore records every node's type, [startByte-endByte], named vs
+// anonymous, and missing flag, and walks ALL children (anonymous included).
+//
+// This proves the range-limited Go walk is sound (reused siblings skipped ==
+// re-walked) and that the shared plumbing is neutral for the non-range-limited
+// normalizer-bearing languages (scala/php/c_sharp) and the reference language
+// (css).
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -31,6 +41,41 @@ func oeditSweepCases() []oeditSweepCase {
 		"func C(c int) int {\n\tif c > 0 {\n\t\treturn c\n\t}\n\treturn 0\n}\n\n" +
 		"type T struct {\n\tF int\n\tG string\n}\n\n" +
 		"var V = 3\n"
+
+	// Adversarial Go sources targeting the exact mutation class of the three
+	// range-limited normalizers: auto-semicolon container drops, statement-list
+	// and case sibling boundaries, and statement-list trailing extras (comments).
+	goSwitch := "package p\n\n" +
+		"func S(x int) int {\n" +
+		"\tswitch x {\n" +
+		"\tcase 1:\n\t\treturn 10 // one\n" +
+		"\tcase 2:\n\t\treturn 20\n" +
+		"\tdefault:\n\t\treturn 0\n" +
+		"\t}\n}\n\n" +
+		"func T(y int) int {\n\treturn y\n}\n"
+
+	goComments := "package p\n\n" +
+		"// leading\nfunc A() {\n" +
+		"\ta := 1 // trailing a\n" +
+		"\t// between\n" +
+		"\tb := 2\n" +
+		"\treturn\n}\n\n" +
+		"/* block */\nfunc B() {}\n"
+
+	goDecls := "package p\n\n" +
+		"import (\n\t\"fmt\"\n\t\"os\"\n)\n\n" +
+		"const (\n\tA = 1\n\tB = 2\n)\n\n" +
+		"var (\n\tx = 1\n\ty = 2\n)\n\n" +
+		"type (\n\tI int\n\tS string\n)\n\n" +
+		"func F() { fmt.Println(os.Args) }\n"
+
+	goSelect := "package p\n\n" +
+		"func R(c chan int) {\n" +
+		"\tselect {\n" +
+		"\tcase v := <-c:\n\t\t_ = v\n" +
+		"\tdefault:\n" +
+		"\t}\n}\n\n" +
+		"func Q() {}\n"
 
 	scalaSrc := "object M {\n" +
 		"  def a(x: Int): Int = x + 1\n" +
@@ -59,8 +104,13 @@ func oeditSweepCases() []oeditSweepCase {
 		".b {\n  padding: 1px;\n}\n\n" +
 		"#c {\n  display: block;\n  width: 10px;\n}\n"
 
+	goLang := grammars.GoLanguage()
 	return []oeditSweepCase{
-		{"go", grammars.GoLanguage(), []byte(goSrc)},
+		{"go", goLang, []byte(goSrc)},
+		{"go-switch", goLang, []byte(goSwitch)},
+		{"go-comments", goLang, []byte(goComments)},
+		{"go-decls", goLang, []byte(goDecls)},
+		{"go-select", goLang, []byte(goSelect)},
 		{"scala", grammars.ScalaLanguage(), []byte(scalaSrc)},
 		{"php", grammars.PhpLanguage(), []byte(phpSrc)},
 		{"c_sharp", grammars.CSharpLanguage(), []byte(csharpSrc)},
@@ -87,6 +137,7 @@ func runOEditSweep(t *testing.T, tc oeditSweepCase) {
 	if err != nil || baseline == nil || baseline.RootNode() == nil {
 		t.Fatalf("baseline parse: %v", err)
 	}
+	defer baseline.Release()
 	if e, m := oeditTreeStats(baseline.RootNode()); e != 0 || m != 0 {
 		t.Fatalf("baseline source must be clean (err=%d miss=%d)", e, m)
 	}
@@ -98,12 +149,17 @@ func runOEditSweep(t *testing.T, tc oeditSweepCase) {
 
 			fresh, err := freshP.Parse(edited)
 			if err != nil || fresh == nil || fresh.RootNode() == nil {
+				if fresh != nil {
+					fresh.Release()
+				}
 				continue
 			}
 			if int(fresh.RootNode().EndByte()) != len(edited) {
+				fresh.Release()
 				continue
 			}
 			if e, m := oeditTreeStats(fresh.RootNode()); e != 0 || m != 0 {
+				fresh.Release()
 				continue
 			}
 			clean++
@@ -116,7 +172,7 @@ func runOEditSweep(t *testing.T, tc oeditSweepCase) {
 			if err != nil || incr == nil || incr.RootNode() == nil {
 				t.Fatalf("%s pos=%d class=%s: incremental parse failed while fresh was clean", tc.name, i, cls)
 			}
-			incrS := incr.RootNode().SExpr(tc.lang)
+			incrS := oeditSerialize(incr.RootNode(), tc.lang)
 
 			// Full-walk incremental parse (main behavior, range-limiting off).
 			incrP.SetForceFullResultNormalizationWalk(true)
@@ -126,7 +182,7 @@ func runOEditSweep(t *testing.T, tc oeditSweepCase) {
 			if err != nil || full == nil || full.RootNode() == nil {
 				t.Fatalf("%s pos=%d class=%s: full-walk incremental parse failed", tc.name, i, cls)
 			}
-			fullS := full.RootNode().SExpr(tc.lang)
+			fullS := oeditSerialize(full.RootNode(), tc.lang)
 			incrP.SetForceFullResultNormalizationWalk(false)
 			checked++
 
@@ -140,7 +196,7 @@ func runOEditSweep(t *testing.T, tc oeditSweepCase) {
 			// Secondary: where the full walk already matches fresh, the
 			// range-limited walk must too (pre-existing full-walk vs fresh
 			// divergences are out of scope -- tracked by the invariant gate).
-			freshS := fresh.RootNode().SExpr(tc.lang)
+			freshS := oeditSerialize(fresh.RootNode(), tc.lang)
 			if fullS == freshS && incrS != freshS {
 				t.Fatalf("%s pos=%d class=%s: incremental != fresh while full-walk == fresh\n  fresh=%s\n  incr =%s",
 					tc.name, i, cls, oeditTrunc(freshS), oeditTrunc(incrS))
@@ -156,6 +212,43 @@ func runOEditSweep(t *testing.T, tc oeditSweepCase) {
 	if checked == 0 {
 		t.Fatalf("%s: no freshly-clean sites checked -- sweep did not exercise the invariant", tc.name)
 	}
+}
+
+// oeditSerialize records every node's type, byte span, named/anonymous status,
+// and missing flag, and walks ALL children (anonymous included). Unlike SExpr it
+// captures exactly the state the range-limited normalizers mutate: endByte
+// span adjustments and dropped anonymous `;` children.
+func oeditSerialize(n *gts.Node, lang *gts.Language) string {
+	var b strings.Builder
+	var walk func(*gts.Node)
+	walk = func(x *gts.Node) {
+		if x == nil {
+			b.WriteString("<nil>")
+			return
+		}
+		b.WriteByte('(')
+		b.WriteString(x.Type(lang))
+		fmt.Fprintf(&b, ":%d-%d", x.StartByte(), x.EndByte())
+		if x.IsNamed() {
+			b.WriteString(":n")
+		} else {
+			b.WriteString(":a")
+		}
+		if x.IsMissing() {
+			b.WriteString(":miss")
+		}
+		if x.IsError() {
+			b.WriteString(":err")
+		}
+		cc := x.ChildCount()
+		for i := 0; i < cc; i++ {
+			b.WriteByte(' ')
+			walk(x.Child(i))
+		}
+		b.WriteByte(')')
+	}
+	walk(n)
+	return b.String()
 }
 
 func oeditTreeStats(n *gts.Node) (errN, missN int) {

--- a/oedit_range_normalize_sweep_test.go
+++ b/oedit_range_normalize_sweep_test.go
@@ -1,0 +1,171 @@
+package gotreesitter_test
+
+// Byte-sweep differential for campaign O(edit) range-limited result
+// normalization (spec.campaign.oedit). For every insert / delete / replace edit
+// at every byte position of a multi-item source, ParseIncremental must produce a
+// tree byte-identical (SExpr, spans included) to a fresh Parse of the same
+// edited text -- at every site where the fresh parse is genuinely clean
+// (full-span, zero IsError/IsMissing). This proves the range-limited Go walk is
+// sound (reused siblings skipped == re-walked) and that the shared plumbing is
+// neutral for the non-range-limited normalizer-bearing languages
+// (scala/php/c_sharp) and the reference language (css).
+
+import (
+	"fmt"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type oeditSweepCase struct {
+	name string
+	lang *gts.Language
+	src  []byte
+}
+
+func oeditSweepCases() []oeditSweepCase {
+	goSrc := "package p\n\n" +
+		"func A(a int) int {\n\tx := a + 1\n\treturn x\n}\n\n" +
+		"func B(b int) int {\n\ty := b * 2\n\treturn y\n}\n\n" +
+		"func C(c int) int {\n\tif c > 0 {\n\t\treturn c\n\t}\n\treturn 0\n}\n\n" +
+		"type T struct {\n\tF int\n\tG string\n}\n\n" +
+		"var V = 3\n"
+
+	scalaSrc := "object M {\n" +
+		"  def a(x: Int): Int = x + 1\n" +
+		"  def b(y: Int): Int = y * 2\n" +
+		"  val c = 3\n" +
+		"}\n\n" +
+		"class K(n: Int) {\n" +
+		"  def m: Int = n\n" +
+		"}\n"
+
+	phpSrc := "<?php\n" +
+		"function a($x) {\n  return $x + 1;\n}\n\n" +
+		"function b($y) {\n  return $y * 2;\n}\n\n" +
+		"class K {\n  public $f = 1;\n  function m() { return $this->f; }\n}\n"
+
+	csharpSrc := "class A {\n" +
+		"    int F = 1;\n" +
+		"    int M(int x) { return x + 1; }\n" +
+		"    int N(int y) { return y * 2; }\n" +
+		"}\n\n" +
+		"class B {\n" +
+		"    string S = \"hi\";\n" +
+		"}\n"
+
+	cssSrc := ".a {\n  color: red;\n  margin: 0;\n}\n\n" +
+		".b {\n  padding: 1px;\n}\n\n" +
+		"#c {\n  display: block;\n  width: 10px;\n}\n"
+
+	return []oeditSweepCase{
+		{"go", grammars.GoLanguage(), []byte(goSrc)},
+		{"scala", grammars.ScalaLanguage(), []byte(scalaSrc)},
+		{"php", grammars.PhpLanguage(), []byte(phpSrc)},
+		{"c_sharp", grammars.CSharpLanguage(), []byte(csharpSrc)},
+		{"css", grammars.CssLanguage(), []byte(cssSrc)},
+	}
+}
+
+func TestOEditRangeNormalizeByteSweep(t *testing.T) {
+	for _, tc := range oeditSweepCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runOEditSweep(t, tc)
+		})
+	}
+}
+
+func runOEditSweep(t *testing.T, tc oeditSweepCase) {
+	t.Helper()
+	freshP := gts.NewParser(tc.lang)
+	baseP := gts.NewParser(tc.lang)
+	incrP := gts.NewParser(tc.lang)
+
+	baseline, err := baseP.Parse(tc.src)
+	if err != nil || baseline == nil || baseline.RootNode() == nil {
+		t.Fatalf("baseline parse: %v", err)
+	}
+	if e, m := oeditTreeStats(baseline.RootNode()); e != 0 || m != 0 {
+		t.Fatalf("baseline source must be clean (err=%d miss=%d)", e, m)
+	}
+
+	clean, checked := 0, 0
+	for i := 1; i < len(tc.src)-1; i++ {
+		for _, cls := range []string{"insert", "delete", "replace"} {
+			edited, edit := incrGateBuildEdit(tc.src, i, cls)
+
+			fresh, err := freshP.Parse(edited)
+			if err != nil || fresh == nil || fresh.RootNode() == nil {
+				continue
+			}
+			if int(fresh.RootNode().EndByte()) != len(edited) {
+				continue
+			}
+			if e, m := oeditTreeStats(fresh.RootNode()); e != 0 || m != 0 {
+				continue
+			}
+			clean++
+
+			// Range-limited incremental parse (the change under test).
+			incrP.SetForceFullResultNormalizationWalk(false)
+			oldCopy := baseline.Copy()
+			oldCopy.Edit(edit)
+			incr, err := incrP.ParseIncremental(edited, oldCopy)
+			if err != nil || incr == nil || incr.RootNode() == nil {
+				t.Fatalf("%s pos=%d class=%s: incremental parse failed while fresh was clean", tc.name, i, cls)
+			}
+			incrS := incr.RootNode().SExpr(tc.lang)
+
+			// Full-walk incremental parse (main behavior, range-limiting off).
+			incrP.SetForceFullResultNormalizationWalk(true)
+			oldCopyFull := baseline.Copy()
+			oldCopyFull.Edit(edit)
+			full, err := incrP.ParseIncremental(edited, oldCopyFull)
+			if err != nil || full == nil || full.RootNode() == nil {
+				t.Fatalf("%s pos=%d class=%s: full-walk incremental parse failed", tc.name, i, cls)
+			}
+			fullS := full.RootNode().SExpr(tc.lang)
+			incrP.SetForceFullResultNormalizationWalk(false)
+			checked++
+
+			// Primary isolation invariant: range-limiting must be a no-op vs the
+			// full walk. Any difference here is a regression THIS change caused.
+			if incrS != fullS {
+				t.Fatalf("%s pos=%d class=%s: range-limited != full-walk (regression)\n  full=%s\n  incr=%s",
+					tc.name, i, cls, oeditTrunc(fullS), oeditTrunc(incrS))
+			}
+
+			// Secondary: where the full walk already matches fresh, the
+			// range-limited walk must too (pre-existing full-walk vs fresh
+			// divergences are out of scope -- tracked by the invariant gate).
+			freshS := fresh.RootNode().SExpr(tc.lang)
+			if fullS == freshS && incrS != freshS {
+				t.Fatalf("%s pos=%d class=%s: incremental != fresh while full-walk == fresh\n  fresh=%s\n  incr =%s",
+					tc.name, i, cls, oeditTrunc(freshS), oeditTrunc(incrS))
+			}
+			oldCopy.Release()
+			oldCopyFull.Release()
+			fresh.Release()
+			incr.Release()
+			full.Release()
+		}
+	}
+	t.Logf("%s: freshCleanSites=%d checked=%d", tc.name, clean, checked)
+	if checked == 0 {
+		t.Fatalf("%s: no freshly-clean sites checked -- sweep did not exercise the invariant", tc.name)
+	}
+}
+
+func oeditTreeStats(n *gts.Node) (errN, missN int) {
+	return incrGateTreeStats(n)
+}
+
+func oeditTrunc(s string) string {
+	const max = 400
+	if len(s) <= max {
+		return s
+	}
+	return fmt.Sprintf("%s...(%d more)", s[:max], len(s)-max)
+}

--- a/parser.go
+++ b/parser.go
@@ -323,19 +323,25 @@ type Parser struct {
 	mergeScratch *glrMergeScratch
 	// goCompatFrames points at the active parser scratch's reusable result-tree
 	// traversal stack. It is nil outside parseInternal.
-	goCompatFrames                      *[]goCompatSubtreeFrame
-	noTreeBenchmarkOnly                 bool
-	noTreeCheckpointBenchmarkOnly       bool
-	compactNoTreeShiftLeaves            bool
-	compactFullShiftLeaves              bool
-	eagerDefaultReduces                 []eagerDefaultReduceAction
-	pendingFullParents                  bool
-	finalChildRefs                      bool
-	skipInvisibleFullLeafCheckpoints    bool
-	transientReduceChildren             bool
-	transientReduceScratchNoAlias       bool
-	transientChildren                   *transientChildScratch
-	noResultCompatibilityBenchmarkOnly  bool
+	goCompatFrames                     *[]goCompatSubtreeFrame
+	noTreeBenchmarkOnly                bool
+	noTreeCheckpointBenchmarkOnly      bool
+	compactNoTreeShiftLeaves           bool
+	compactFullShiftLeaves             bool
+	eagerDefaultReduces                []eagerDefaultReduceAction
+	pendingFullParents                 bool
+	finalChildRefs                     bool
+	skipInvisibleFullLeafCheckpoints   bool
+	transientReduceChildren            bool
+	transientReduceScratchNoAlias      bool
+	transientChildren                  *transientChildScratch
+	noResultCompatibilityBenchmarkOnly bool
+	// forceFullResultNormalizationWalk disables incremental range-limited result
+	// normalization for this Parser, forcing the full-tree walk. It exists only
+	// so the campaign O(edit) byte-sweep differential can compare the
+	// range-limited walk against the full walk on one Parser (see
+	// SetForceFullResultNormalizationWalk). Production leaves it false.
+	forceFullResultNormalizationWalk    bool
 	currentExternalTokenCheckpoint      externalScannerCheckpoint
 	currentExternalTokenCheckpointStart uint32
 	currentExternalTokenCheckpointEnd   uint32

--- a/parser_api.go
+++ b/parser_api.go
@@ -119,7 +119,8 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 		return
 	}
 	if !tree.resultCompatibilityApplied {
-		if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
+		ranges := p.incrementalResultCompatibilityRanges(tree)
+		if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source, ranges); parseStopReasonIsTerminal(reason) {
 			tree.setParseStopReason(reason)
 			return
 		}
@@ -130,6 +131,18 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 		return
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
+}
+
+// incrementalResultCompatibilityRanges returns the reparsed byte spans that
+// range-limit result normalization for an incremental reparse, or nil when the
+// tree's language is not proven eligible for range-limiting. It is called ONLY
+// from the incremental normalization path, so a fresh parse never computes a
+// range and its full-tree normalization is byte-identical to before.
+func (p *Parser) incrementalResultCompatibilityRanges(tree *Tree) []Range {
+	if p == nil || p.language == nil || tree == nil || p.forceFullResultNormalizationWalk || !languageUsesRangeLimitedResultCompatibility(p.language) {
+		return nil
+	}
+	return incrementalReparsedTopLevelRanges(rawRootOrNil(tree), tree.arena, len(tree.borrowedArena) > 0)
 }
 
 func shouldNormalizeReturnedTree(tree *Tree) bool {
@@ -145,7 +158,7 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 		return
 	}
 	if !tree.resultCompatibilityApplied {
-		if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
+		if reason := p.normalizeReturnedTree(rawRootOrNil(tree), source, nil); parseStopReasonIsTerminal(reason) {
 			tree.setParseStopReason(reason)
 			return
 		}
@@ -334,14 +347,14 @@ func profileFreshParseFallback(start time.Time, tree *Tree, reason string) Incre
 	return profile
 }
 
-func (p *Parser) normalizeReturnedTree(root *Node, source []byte) ParseStopReason {
+func (p *Parser) normalizeReturnedTree(root *Node, source []byte, incrementalRanges []Range) ParseStopReason {
 	if p == nil || p.language == nil || root == nil || p.noResultCompatibilityBenchmarkOnly {
 		return ParseStopNone
 	}
 	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
 		return reason
 	}
-	normalizeResultCompatibility(root, source, p)
+	normalizeResultCompatibility(root, source, p, incrementalRanges)
 	return p.parseStopReasonNow()
 }
 
@@ -1254,6 +1267,19 @@ func (p *Parser) ParseNoResultCompatibilityBenchmarkOnly(source []byte) (*Tree, 
 		p.noResultCompatibilityBenchmarkOnly = prevNoResult
 	}()
 	return p.Parse(source)
+}
+
+// SetForceFullResultNormalizationWalk forces the full-tree result-normalization
+// walk, disabling the incremental range-limited walk (campaign O(edit),
+// spec.campaign.oedit). It exists so a differential test can compare the
+// range-limited walk against the full walk on the SAME Parser and prove they
+// produce identical trees. Production never calls it (the default is false, the
+// range-limited walk).
+func (p *Parser) SetForceFullResultNormalizationWalk(v bool) {
+	if p == nil {
+		return
+	}
+	p.forceFullResultNormalizationWalk = v
 }
 
 // ParseUTF16 parses UTF-16 source represented as Go UTF-16 code units.

--- a/parser_api.go
+++ b/parser_api.go
@@ -1269,19 +1269,6 @@ func (p *Parser) ParseNoResultCompatibilityBenchmarkOnly(source []byte) (*Tree, 
 	return p.Parse(source)
 }
 
-// SetForceFullResultNormalizationWalk forces the full-tree result-normalization
-// walk, disabling the incremental range-limited walk (campaign O(edit),
-// spec.campaign.oedit). It exists so a differential test can compare the
-// range-limited walk against the full walk on the SAME Parser and prove they
-// produce identical trees. Production never calls it (the default is false, the
-// range-limited walk).
-func (p *Parser) SetForceFullResultNormalizationWalk(v bool) {
-	if p == nil {
-		return
-	}
-	p.forceFullResultNormalizationWalk = v
-}
-
 // ParseUTF16 parses UTF-16 source represented as Go UTF-16 code units.
 //
 // The parser core uses a canonical UTF-8 view internally so existing byte-based

--- a/parser_result_c_go_cobol_test.go
+++ b/parser_result_c_go_cobol_test.go
@@ -120,7 +120,7 @@ func TestNormalizeResultCompatibilityDispatchesUppercaseCobol(t *testing.T) {
 	root.startByte = 0
 	root.endByte = uint32(len(source))
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.StartByte(), uint32(7); got != want {
 		t.Fatalf("root.StartByte = %d, want %d", got, want)
@@ -162,7 +162,7 @@ func TestNormalizeCobolLeadingCommentBannerKeepsProgramStartAtFirstCode(t *testi
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.StartByte(), uint32(6); got != want {
 		t.Fatalf("root.StartByte = %d, want %d", got, want)
@@ -264,7 +264,7 @@ func TestNormalizeCobolRecoveredRootProgramDefinitionSplitsTailError(t *testing.
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 4; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; root=%s", got, want, root.SExpr(lang))
@@ -393,7 +393,7 @@ func TestNormalizeCobolAcceptedRootProgramDefinitionSplitsTailError(t *testing.T
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 4; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; root=%s", got, want, root.SExpr(lang))
@@ -499,7 +499,7 @@ func TestNormalizeCobolProcedureRootRecoveryHoistsComments(t *testing.T) {
 	// Real recovered COBOL roots can be under-marked even when an adjacent
 	// ERROR child is present; the recovery must key off the child shape.
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 5; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; root=%s", got, want, root.SExpr(lang))
@@ -592,7 +592,7 @@ func TestNormalizeCobolProcedureRootRecoveryMovesStatements(t *testing.T) {
 	root.endPoint = err.endPoint
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 5; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; root=%s", got, want, root.SExpr(lang))
@@ -668,7 +668,7 @@ func TestNormalizeCobolRootErrorLeadingComments(t *testing.T) {
 	root.endPoint = err.endPoint
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 5; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; root=%s", got, want, root.SExpr(lang))
@@ -782,7 +782,7 @@ func TestNormalizeCobolZLiteralDataRootRecovery(t *testing.T) {
 	root.endPoint = err.endPoint
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := program.EndByte(), end("01  OK PIC X."); got != want {
 		t.Fatalf("program.EndByte = %d, want %d", got, want)
@@ -882,7 +882,7 @@ func TestNormalizeCobolRootProgramDefinitionStopsBeforeCopySibling(t *testing.T)
 	root.endPoint = advancePointByBytes(Point{}, source)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	clampedEnd := end("01  WS-COMMAREA PIC X.")
 	if got, want := program.EndByte(), clampedEnd; got != want {
@@ -1031,7 +1031,7 @@ func TestNormalizeCobolRootProcedurePrefixErrorMovesCleanPrefix(t *testing.T) {
 	root.endPoint = advancePointByBytes(Point{}, source)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 2; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
@@ -1152,7 +1152,7 @@ func TestNormalizeCobolRootProcedurePrefixErrorSkipsMoveLedPrefix(t *testing.T) 
 	root.endPoint = advancePointByBytes(Point{}, source)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 3; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
@@ -1255,7 +1255,7 @@ func TestNormalizeCobolRootProcedureEvaluateErrorMovesCleanBody(t *testing.T) {
 	root.endPoint = advancePointByBytes(Point{}, source)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 1; got != want {
 		t.Fatalf("root.ChildCount = %d, want %d; tree=%s", got, want, root.SExpr(lang))
@@ -1347,7 +1347,7 @@ func TestNormalizeCobolProcedureLooseIfHeader(t *testing.T) {
 	root.endPoint = advancePointByBytes(Point{}, source)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	procedure := root.Child(0).Child(0)
 	if got, want := procedure.ChildCount(), 2; got != want {
@@ -1522,7 +1522,7 @@ func TestNormalizeCobolRecoveredErrorAddsMissingCommentEntryGap(t *testing.T) {
 	root.endPoint = err.endPoint
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := err.ChildCount(), 6; got != want {
 		t.Fatalf("ERROR ChildCount = %d, want %d; err=%s", got, want, err.SExpr(lang))
@@ -1649,7 +1649,7 @@ func TestNormalizeCobolFixedFormatProgramIDStopsBeforeTrailingJunk(t *testing.T)
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.StartByte(), uint32(6); got != want {
 		t.Fatalf("root.StartByte = %d, want %d", got, want)
@@ -1718,7 +1718,7 @@ func TestNormalizeCobolTrimsStatementTrailingTriviaSpans(t *testing.T) {
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := perform.EndByte(), performEnd; got != want {
 		t.Fatalf("perform_statement_loop.EndByte = %d, want %d", got, want)
@@ -1780,7 +1780,7 @@ func TestNormalizeCobolTrimsGotoTrailingTriviaSpan(t *testing.T) {
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := gotoStmt.EndByte(), gotoEnd; got != want {
 		t.Fatalf("goto_statement.EndByte = %d, want %d", got, want)
@@ -1838,7 +1838,7 @@ func TestNormalizeCobolSectionSiblingEndsBeforeCopySibling(t *testing.T) {
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := working.EndByte(), workingEnd; got != want {
 		t.Fatalf("working_storage_section.EndByte = %d, want %d", got, want)
@@ -2009,7 +2009,7 @@ func TestNormalizeCobolRecoveredParagraphHeader(t *testing.T) {
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if root.HasError() {
 		t.Fatalf("root.HasError = true, want false")
@@ -2107,7 +2107,7 @@ func TestNormalizeCobolRecoveredParagraphHeaderPreservesOtherErrors(t *testing.T
 	root.endByte = uint32(len(source))
 	root.endPoint = advancePointByBytes(Point{}, source)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if !root.HasError() {
 		t.Fatalf("root.HasError = false, want true for retained non-header error")

--- a/parser_result_collapsed_helpers_test.go
+++ b/parser_result_collapsed_helpers_test.go
@@ -59,7 +59,7 @@ func TestNormalizeResultCompatibilityRestoresOCamlBooleanChild(t *testing.T) {
 	orOperator := newLeafNodeInArena(arena, 5, true, 5, 7, Point{Column: 5}, Point{Column: 7})
 	root := newParentNodeInArena(arena, 1, true, []*Node{boolean, orOperator}, nil, 0)
 
-	normalizeResultCompatibility(root, []byte("true ||"), &Parser{language: lang})
+	normalizeResultCompatibility(root, []byte("true ||"), &Parser{language: lang}, nil)
 
 	child := boolean.Child(0)
 	if child == nil {

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -6,6 +6,13 @@ type resultCompatibilityContext struct {
 	parser    *Parser
 	lang      *Language
 	stopCheck parseStopCheck
+	// incrementalRanges confines range-capable result normalizers to the
+	// reparsed spans of an incremental parse (campaign O(edit),
+	// spec.campaign.oedit). It is nil on every fresh parse and on any
+	// incremental parse without reuse, which restores the full-tree walk. Only
+	// languages proven node-local for range-limiting consume it; every other
+	// language ignores it and keeps its full walk (fail-closed).
+	incrementalRanges []Range
 }
 
 type resultCompatibilityResult struct {
@@ -19,7 +26,7 @@ type resultCompatibilityResult struct {
 // normalizeResultCompatibility applies narrow post-build tree rewrites that
 // keep gotreesitter output aligned with C tree-sitter and existing recovery
 // expectations for grammars with known normalization gaps.
-func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCompatibilityResult {
+func normalizeResultCompatibility(root *Node, source []byte, p *Parser, incrementalRanges []Range) resultCompatibilityResult {
 	var lang *Language
 	if p != nil {
 		lang = p.language
@@ -28,11 +35,12 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser) resultCo
 		return resultCompatibilityResult{}
 	}
 	ctx := resultCompatibilityContext{
-		root:      root,
-		source:    source,
-		parser:    p,
-		lang:      lang,
-		stopCheck: p.activeParseStopCheck(),
+		root:              root,
+		source:            source,
+		parser:            p,
+		lang:              lang,
+		stopCheck:         p.activeParseStopCheck(),
+		incrementalRanges: incrementalRanges,
 	}
 	if reason := ctx.stopReason(); parseStopReasonIsActive(reason) {
 		return resultCompatibilityResult{stopReason: reason}
@@ -154,7 +162,7 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 	case "fidl":
 		normalizeFIDLCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "go":
-		return resultCompatibilityResult{stopReason: normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)}
+		return resultCompatibilityResult{stopReason: normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang, ctx.incrementalRanges)}
 	case "gitcommit":
 		normalizeGitcommitCompatibility(ctx.root, ctx.source, ctx.lang)
 	case "haskell":

--- a/parser_result_crystal_test.go
+++ b/parser_result_crystal_test.go
@@ -105,7 +105,7 @@ func TestNormalizeResultCompatibilityDispatchesCrystal(t *testing.T) {
 	hash.endPoint = Point{Column: 6}
 	root := newParentNodeInArena(arena, 1, true, []*Node{hash}, nil, 0)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := hash.StartByte(), uint32(5); got != want {
 		t.Fatalf("hash.StartByte = %d, want %d", got, want)
@@ -139,7 +139,7 @@ func TestParserNormalizeReturnedTreeDispatchesCrystalCompatibility(t *testing.T)
 	root := newParentNodeInArena(arena, 1, true, []*Node{hash}, nil, 0)
 	parser := &Parser{language: lang}
 
-	if reason := parser.normalizeReturnedTree(root, source); reason != ParseStopNone {
+	if reason := parser.normalizeReturnedTree(root, source, nil); reason != ParseStopNone {
 		t.Fatalf("normalizeReturnedTree stop reason = %q, want %q", reason, ParseStopNone)
 	}
 	if got, want := hash.StartByte(), uint32(5); got != want {

--- a/parser_result_go.go
+++ b/parser_result_go.go
@@ -11,7 +11,15 @@ import "bytes"
 // normalizing a partial tree that carries no C-faithful normalization
 // guarantee. This mirrors the existing timeout/cancellation semantics at the
 // same call sites (see the 2026-07-12 gocompat-walk-containment-gap finding).
-func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, lang *Language) ParseStopReason {
+// incrementalRanges, when non-nil, confines the O(nodes) Go compat walk to the
+// reparsed spans of an incremental parse (campaign O(edit), spec.campaign.oedit).
+// Reused (byte-identical) top-level siblings outside the ranges keep the
+// normalization they were built with, so the walk skips their subtrees and
+// becomes O(edit) instead of O(file). Nil (every fresh parse, and any
+// incremental parse without reuse) keeps the full walk. Only the range-capable
+// walk stage consumes it; the surrounding root/EOF/new-make stages are already
+// bounded or guarded and stay full-tree.
+func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, lang *Language, incrementalRanges []Range) ParseStopReason {
 	var arena *nodeArena
 	if root != nil {
 		arena = root.ownerArena
@@ -29,7 +37,7 @@ func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, 
 	if reason := p.goCompatMemoryBudgetStopReason(arena); reason == ParseStopMemoryBudget {
 		return reason
 	}
-	if reason := normalizeGoCompatibilityWithParser(root, source, lang, p); resultMaterializationShouldStop(reason) {
+	if reason := normalizeGoCompatibilityInRangesWithParser(root, source, lang, incrementalRanges, p); resultMaterializationShouldStop(reason) {
 		return reason
 	}
 	if reason := p.activeParseStopReason(); parseStopReasonIsActive(reason) {

--- a/parser_result_incremental_range.go
+++ b/parser_result_incremental_range.go
@@ -1,0 +1,95 @@
+package gotreesitter
+
+// languageUsesRangeLimitedResultCompatibility reports whether a language's
+// result-compatibility normalizers are proven node-local and therefore safe to
+// confine to the reparsed spans of an incremental parse (campaign O(edit),
+// spec.campaign.oedit). It is fail-closed: only languages whose every normalizer
+// reached from normalizeResultCompatibility reads inside a single node (never a
+// parent/sibling relationship the edit could change) are listed. Every other
+// language keeps the full-tree walk unchanged.
+//
+// Go qualifies: its walk normalizers (semicolon-container drop, adjacent-sibling
+// boundary, statement-list trailing extras) each read only a node's own children
+// and source span, and the root — which always overlaps any range — re-runs the
+// only cross-sibling boundary work at the top level. See the normalizer
+// classification in the campaign report.
+func languageUsesRangeLimitedResultCompatibility(lang *Language) bool {
+	if lang == nil {
+		return false
+	}
+	return lang.Name == "go"
+}
+
+// incrementalReparsedTopLevelRanges computes the reparsed byte span(s) of an
+// incremental parse for range-limited result normalization (campaign O(edit),
+// spec.campaign.oedit).
+//
+// A reused subtree keeps its original (borrowed) arena; a node built fresh in
+// THIS parse lives in the primary arena that also owns the freshly-built root.
+// So a top-level child whose ownerArena is the primary arena was rebuilt this
+// pass, and one in a borrowed arena is a byte-identical subtree lifted from the
+// old tree (already normalized when the old tree was built with the same code).
+// The reparsed range is the envelope of each contiguous run of freshly-built
+// top-level children.
+//
+// The result is a SOUND SUPERSET of every freshly-built node. The root always
+// overlaps any range (it spans the whole file) so its own child-boundary
+// normalization runs in full; every other freshly-built node descends from a
+// freshly-built top-level child, because reuse is subtree-atomic (a reused
+// top-level child has no freshly-built descendant), so it lies inside a returned
+// range. Reused top-level children outside the ranges are skipped, which is the
+// O(edit) win.
+//
+// Returns nil when no reuse happened (hasReuse false) or nothing at the top
+// level was reused; nil restores the full walk, so the fallback is always safe.
+func incrementalReparsedTopLevelRanges(root *Node, primary *nodeArena, hasReuse bool) []Range {
+	if root == nil || primary == nil || !hasReuse {
+		return nil
+	}
+	childCount := resultChildCount(root)
+	if childCount == 0 {
+		return nil
+	}
+	var ranges []Range
+	runActive := false
+	reusedSeen := false
+	var runLo, runHi uint32
+	closeRun := func() {
+		if runActive {
+			ranges = append(ranges, Range{StartByte: runLo, EndByte: runHi})
+			runActive = false
+		}
+	}
+	for i := 0; i < childCount; i++ {
+		c := resultChildAt(root, i)
+		if c == nil {
+			continue
+		}
+		if c.ownerArena == primary {
+			if !runActive {
+				runLo, runHi = c.startByte, c.endByte
+				runActive = true
+			} else {
+				if c.startByte < runLo {
+					runLo = c.startByte
+				}
+				if c.endByte > runHi {
+					runHi = c.endByte
+				}
+			}
+			continue
+		}
+		// A reused (borrowed-arena) child ends the current fresh run and proves
+		// there is content the walk may skip.
+		reusedSeen = true
+		closeRun()
+	}
+	closeRun()
+	if !reusedSeen {
+		// Every top-level child was rebuilt this pass: a full walk is already
+		// O(edit) == O(file) and range-limiting can only add cost. Keep the
+		// unchanged full walk.
+		return nil
+	}
+	return ranges
+}

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -763,7 +763,19 @@ func (b *resultRootBuild) finishTree(root *Node, wireParentLinks, extendTrailing
 }
 
 func (b *resultRootBuild) finalizeRoot(root *Node, wireParentLinks, extendTrailing bool) (resultErrorSummary, bool) {
-	return b.parser.finalizeResultRoot(root, b.source, b.linkScratch, wireParentLinks, extendTrailing)
+	return b.parser.finalizeResultRoot(root, b.source, b.linkScratch, wireParentLinks, extendTrailing, b.incrementalResultCompatibilityRanges(root))
+}
+
+// incrementalResultCompatibilityRanges returns the reparsed byte spans that
+// range-limit result normalization for THIS parse, or nil when the language is
+// not range-limit-eligible or no subtree was reused. A fresh parse reuses
+// nothing, so it always gets nil and keeps its unchanged full-tree walk.
+func (b *resultRootBuild) incrementalResultCompatibilityRanges(root *Node) []Range {
+	if b.parser == nil || b.lang == nil || b.parser.forceFullResultNormalizationWalk || !languageUsesRangeLimitedResultCompatibility(b.lang) {
+		return nil
+	}
+	hasReuse := b.reuseState != nil && b.reuseState.reusedAny
+	return incrementalReparsedTopLevelRanges(root, b.arena, hasReuse)
 }
 
 // finalizeWrappedSubtree applies subtree compatibility normalization to a node
@@ -778,7 +790,7 @@ func (b *resultRootBuild) finalizeWrappedSubtree(root *Node) {
 		return
 	}
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
-		if compat := normalizeResultCompatibility(root, b.source, p); parseStopReasonIsActive(compat.stopReason) && p != nil {
+		if compat := normalizeResultCompatibility(root, b.source, p, nil); parseStopReasonIsActive(compat.stopReason) && p != nil {
 			p.markActiveParseStopped(compat.stopReason)
 		}
 	}
@@ -938,7 +950,7 @@ func extendResultRootRangeToExtras(root *Node, extras []*Node) {
 	}
 }
 
-func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*Node, wireParentLinks, extendTrailing bool) (resultErrorSummary, bool) {
+func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*Node, wireParentLinks, extendTrailing bool, incrementalRanges []Range) (resultErrorSummary, bool) {
 	errorSummary := resultErrorSummaryUnknown
 	compatibilityApplied := false
 	if root == nil {
@@ -973,7 +985,7 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 	}
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
 		start = materializationTimingStart(timing)
-		compat := normalizeResultCompatibility(root, source, p)
+		compat := normalizeResultCompatibility(root, source, p, incrementalRanges)
 		errorSummary = compat.errorSummary
 		// resultMaterializationShouldStop (not parseStopReasonIsActive): Go's
 		// normalizer can now report ParseStopMemoryBudget (see

--- a/parser_result_rust_test.go
+++ b/parser_result_rust_test.go
@@ -161,7 +161,7 @@ func TestNormalizeRustDotRangePreservesAssignmentExpression(t *testing.T) {
 			root := newParentNodeInArena(arena, 1, true, []*Node{assignment}, nil, 0)
 			parser := &Parser{language: lang}
 
-			normalizeResultCompatibility(root, source, parser)
+			normalizeResultCompatibility(root, source, parser, nil)
 
 			got := root.Child(0)
 			if got == nil {
@@ -203,7 +203,7 @@ func TestNormalizeRustDotRangeSkipsStructuredRangeExpression(t *testing.T) {
 	root := newParentNodeInArena(arena, 1, true, []*Node{rangeExpr}, nil, 0)
 	parser := &Parser{language: lang}
 
-	normalizeResultCompatibility(root, source, parser)
+	normalizeResultCompatibility(root, source, parser, nil)
 
 	got := root.Child(0)
 	if got == nil || got.Type(lang) != "range_expression" {
@@ -362,7 +362,7 @@ func TestNormalizeRustRecoveredFunctionItems(t *testing.T) {
 	root.endPoint = advancePointByBytes(Point{}, source[:35])
 	populateParentNode(root, root.children)
 
-	normalizeResultCompatibility(root, source, parser)
+	normalizeResultCompatibility(root, source, parser, nil)
 
 	if got, want := root.Type(lang), "source_file"; got != want {
 		t.Fatalf("root type = %q, want %q", got, want)

--- a/parser_result_trailing_extra_compat_test.go
+++ b/parser_result_trailing_extra_compat_test.go
@@ -12,7 +12,7 @@ func TestNormalizeResultCompatibilityTrimsCleanRootTrailingExtraTrivia(t *testin
 	trivia.setExtra(true)
 	root := newParentNodeInArena(arena, 1, true, []*Node{body, trivia}, nil, 0)
 
-	parser.finalizeResultRoot(root, source, nil, false, true)
+	parser.finalizeResultRoot(root, source, nil, false, true, nil)
 
 	if got, want := root.ChildCount(), 1; got != want {
 		t.Fatalf("root child count = %d, want %d", got, want)
@@ -38,7 +38,7 @@ func TestNormalizeResultCompatibilityKeepsErrorRootTrailingExtraTrivia(t *testin
 	root := newParentNodeInArena(arena, 1, true, []*Node{body, trivia}, nil, 0)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang})
+	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
 
 	if got, want := root.ChildCount(), 2; got != want {
 		t.Fatalf("root child count = %d, want %d", got, want)

--- a/tree.go
+++ b/tree.go
@@ -2364,7 +2364,7 @@ func (t *Tree) ensureResultCompatibility() {
 			return
 		}
 		if !parsePhaseTimingEnabled() {
-			result := normalizeResultCompatibility(t.root, t.source, &Parser{language: t.language})
+			result := normalizeResultCompatibility(t.root, t.source, &Parser{language: t.language}, nil)
 			t.resultErrorSummary = result.errorSummary
 			t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
 			t.finishDeferredResultCompatibility(result)
@@ -2376,7 +2376,7 @@ func (t *Tree) ensureResultCompatibility() {
 			materializationTiming: timing,
 		}
 		start := materializationTimingStart(timing)
-		result := normalizeResultCompatibility(t.root, t.source, parser)
+		result := normalizeResultCompatibility(t.root, t.source, parser, nil)
 		t.resultErrorSummary = result.errorSummary
 		t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
 		timing.addResultCompatibility(start)

--- a/tree_test.go
+++ b/tree_test.go
@@ -370,7 +370,7 @@ func TestFinalizeResultRootDefersSelectedLanguageParentLinks(t *testing.T) {
 			root := newParentNodeInArenaNoLinksWithFieldSources(arena, Symbol(2), true, children, nil, nil, 0, false)
 			parser := NewParser(&Language{Name: name})
 
-			parser.finalizeResultRoot(root, []byte("x"), nil, true, false)
+			parser.finalizeResultRoot(root, []byte("x"), nil, true, false, nil)
 
 			if !arena.parentLinksDeferred.Load() {
 				t.Fatalf("expected %s finalization to defer parent links", name)


### PR DESCRIPTION
## Summary

This branch optimizes Go tree post-processing by skipping result compatibility normalization on unchanged top-level siblings during incremental reparses. A new range-based walk restricts the Go normalizer to only reparsed byte spans, reducing complexity from O(file) to O(edit). It includes a byte-sweep differential to prove incremental and full-walk normalization produce identical trees, plus a measurement benchmark to quantify latency gains.

## Changes

- Introduce incrementalResultCompatibilityRanges to detect rebuilt versus reused top-level children based on arena ownership.
- Thread computed ranges through the result normalization pipeline until they reach the Go compatibility normalizer.
- Skip the normalization walk on reused subtrees outside reparsed ranges to achieve O(edit) complexity.
- Add SetForceFullResultNormalizationWalk test toggle to compare range-limited and full-tree walks on one Parser instance.
- Add oedit_range_normalize_sweep_test.go for byte-level correctness across Go, Scala, PHP, C#, and CSS.
- Update all call sites and test files to accept the new incrementalRanges parameter.

## Testing

- Run go test -run TestOEditRangeNormalizeByteSweep -v to verify range-limited normalization matches full-walk and fresh parse output.
- Run OEDIT_MEASURE=1 go test -run TestOEditRangeNormalizeMeasure -v -timeout 20m to benchmark latency reduction.
- Run standard perf preset: GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms