### PR TITLE
update(parser, admission): Flip compact parser core default to ON (Phase-3 admission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- **The compact parser core is now the default full-parse route for eligible
+  languages** (Phase-3 admission flip). `Parser.Parse` routes a fresh, full,
+  production-DFA parse of an eligible grammar through the compact
+  `internal/parsercorephase0` engine, then materializes a public tree that is
+  byte-exact with the production engine. The compact engine promotes from the
+  `gts_parsercorephase0` opt-in tag into the default build; the emergency
+  opt-out tag `gts_no_parsercorephase0` compiles it back out.
+
+  Evidence for the admission:
+
+  - **Correctness.** 206 of 206 curated parity fixtures pass. The deep-tree
+    digest is 100 percent exact on the canonical fixtures. The 206-language
+    scorecard through the switch reports 48 byte-exact routes, 0 divergences,
+    153 fail-closed fallbacks, and 5 token-source skips.
+  - **Timing.** The quiet-host publication run (lane
+    strictboundary-20260720T231334Z-v6 phase3, n2d-standard-4, 5 ABBA cycles)
+    measured a production-over-candidate geomean speedup of 1.8321 (gate is at
+    or above 1.0204). The worst fixture ran 1.526 times faster. Peak resident
+    set size fell on all four fixtures (grammargen_lr 94 MB against 206 MB). The
+    deep C-oracle parity preflight passed in the same run.
+  - **Sealed epoch (v0.45.0).** The compact route measured 2.9975 times the C
+    reference against the production route at 5.526 times, hardware-attested and
+    verified. Allocation levels sit at 92 to 316 allocations per operation
+    against 14 to 200 for production, admission-compatible per the 2026-07-20
+    owner ruling.
+  - **Known gap.** The candidate retained-heap column reported NA in the phase3
+    environment; resident set size is the resource evidence.
+
+  Escape hatch: set `GTS_ADMISSION_CANDIDATE=0` (or `false`, `off`, `no`) to
+  force every parse back onto the production route. Any other value, or an unset
+  variable, keeps the compact route on. `(*Parser).SetAdmissionCandidateRoute`
+  overrides the process default per parser.
+
+  Dual-route statement: `ParseIncremental` and every reuse-consuming path stay
+  on the production engine unconditionally. The compact tree carries a hard
+  incremental-reuse bar (decision 0008), so routing it under `ParseIncremental`
+  would destroy the O(edit) wins. Lifting the reuse bar is the follow-on
+  campaign.
+
+  Memory-budget contract: the compact scheduler does not poll the automatic
+  large-input memory budget. The switch declines every input at or above the
+  source-length floor where the production route arms that budget (64 KiB), so
+  such inputs stay on production and honor `ParseStopMemoryBudget`. Adding
+  scheduler-level budget polling to the compact route is the follow-on campaign.
+
 ## [0.45.0] - 2026-07-20
 
 ### Fixed

--- a/admission_generic_conflict_test.go
+++ b/admission_generic_conflict_test.go
@@ -1,0 +1,149 @@
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// genericConflictFixture is one member of the Go generic-instantiation /
+// type-conversion ambiguity family surfaced by the Phase-3 admission flip.
+type genericConflictFixture struct {
+	name string
+	expr string
+}
+
+// genericConflictFamily covers the bare Ident[TypeArgs](args) conflict class the
+// admission flip surfaced, the tree-sitter-go expression-versus-type variants,
+// and the conflict-free bounds that must keep routing.
+//
+// Every case is wrapped in a real short variable declaration so the parser sees
+// the ambiguous construct in expression position, exactly where production forks
+// the generic-call / type-conversion GLR conflict.
+var genericConflictFamily = []genericConflictFixture{
+	// The conflict class: production keeps Ident[TypeArgs] as a generic
+	// instantiation (type_conversion_expression or a call with type_arguments);
+	// the compact route must decline rather than collapse it to index_expression.
+	{"one_type_arg", "Foo[int](a)"},
+	{"two_type_args", "Pair[int, string](p)"},
+	{"generic_call_two_args", "Max[int](1, 2)"},
+	{"generic_call_one_arg", "Max[int](1)"},
+	{"nested_generic", "Foo[Foo[int]](a)"},
+	{"nested_type_args", "Map[string, []int](m)"},
+	{"paren_form", "(Foo[int])(a)"},
+	{"chain", "Foo[int](Foo[int](a))"},
+	{"argument_generic", "g(Foo[int](a))"},
+	{"real_index_call", "a[b](c)"},
+	{"selector_generic_call", "pkg.Max[int](1, 2)"},
+	{"in_expression", "Max[int](1, 2) + Max[int](3, 4)"},
+
+	// The conflict-free bounds: no Ident[TypeArgs]( pattern, so no fork. These
+	// must keep routing (or, at worst, still match production byte for byte).
+	{"composite_literal", "Foo[int]{}"},
+	{"bare_instantiation", "Max[int]"},
+	{"plain_call", "g(x)"},
+	{"plain_index", "a[b]"},
+	{"selector_call", "pkg.F(x)"},
+	{"make_slice", "make([]int, 0)"},
+	{"new_type", "new(Foo)"},
+}
+
+// TestAdmissionGenericConflictFamilyNoDivergence proves the compact candidate
+// route never routes a wrong tree for the generic-instantiation conflict family.
+// For every fixture the candidate result must equal the production result byte
+// for byte, whether the candidate routed or declined to production. It also
+// reports how the family splits between routed and declined so the coverage
+// bound is measured, not assumed.
+func TestAdmissionGenericConflictFamilyNoDivergence(t *testing.T) {
+	lang := grammars.GoLanguage()
+	if lang == nil {
+		t.Skip("Go language unavailable")
+	}
+	var routed, declined int
+	for _, fixture := range genericConflictFamily {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			src := []byte("package p\n\nfunc f() {\n\t_ = " + fixture.expr + "\n}\n")
+
+			prod := gts.NewParser(lang)
+			prod.SetAdmissionCandidateRoute(false)
+			prodTree, err := prod.Parse(src)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer prodTree.Release()
+			if prodTree.RootNode().HasError() {
+				t.Fatalf("production reference has an error node for %q; fixture is not a clean parse", fixture.expr)
+			}
+			prodSExpr := prodTree.RootNode().SExpr(lang)
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			cand := gts.NewParser(lang)
+			cand.SetAdmissionCandidateRoute(true)
+			candTree, err := cand.Parse(src)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candTree.Release()
+			candRouted, candFallback := gts.AdmissionCandidateCounters()
+			candSExpr := candTree.RootNode().SExpr(lang)
+
+			// The load-bearing invariant: the candidate route never diverges. A
+			// decline falls back to production (identical by construction); a route
+			// must reproduce production byte for byte.
+			if candSExpr != prodSExpr {
+				t.Fatalf("DIVERGENCE for %q (routed=%d fallback=%d):\n  production: %s\n  candidate:  %s",
+					fixture.expr, candRouted, candFallback, prodSExpr, candSExpr)
+			}
+			switch {
+			case candRouted == 1 && candFallback == 0:
+				routed++
+				t.Logf("ROUTED byte-exact: %q", fixture.expr)
+			case candRouted == 0 && candFallback == 1:
+				declined++
+				t.Logf("DECLINED to production: %q", fixture.expr)
+			default:
+				t.Fatalf("ambiguous routing counters for %q: routed=%d fallback=%d", fixture.expr, candRouted, candFallback)
+			}
+		})
+	}
+	t.Logf("generic-conflict family: %d routed byte-exact, %d declined to production, 0 divergences (%d fixtures)",
+		routed, declined, len(genericConflictFamily))
+
+	// Guard the class boundary: the ambiguous Ident[TypeArgs]( members must
+	// decline, and the conflict-free members must keep routing. This proves the
+	// decline keys on the GLR conflict, not on over-declining every input.
+	mustDecline := map[string]bool{
+		"one_type_arg": true, "two_type_args": true, "generic_call_two_args": true,
+		"generic_call_one_arg": true, "nested_generic": true, "nested_type_args": true,
+		"paren_form": true, "chain": true, "argument_generic": true,
+		"real_index_call": true, "selector_generic_call": true, "in_expression": true,
+	}
+	mustRoute := map[string]bool{
+		"composite_literal": true, "bare_instantiation": true, "plain_call": true,
+		"plain_index": true, "selector_call": true, "make_slice": true, "new_type": true,
+	}
+	for _, fixture := range genericConflictFamily {
+		src := []byte("package p\n\nfunc f() {\n\t_ = " + fixture.expr + "\n}\n")
+		gts.ResetAdmissionCandidateCountersForTest()
+		cand := gts.NewParser(lang)
+		cand.SetAdmissionCandidateRoute(true)
+		tree, err := cand.Parse(src)
+		if err != nil {
+			t.Fatalf("candidate parse %q: %v", fixture.expr, err)
+		}
+		r, _ := gts.AdmissionCandidateCounters()
+		tree.Release()
+		if mustDecline[fixture.name] && r != 0 {
+			t.Errorf("conflict-class member %q routed (r=%d); it must decline (fail closed)", fixture.expr, r)
+		}
+		if mustRoute[fixture.name] && r == 0 {
+			// A conflict-free member declined; that is safe but narrows coverage.
+			// Report it rather than fail so the bound stays visible.
+			t.Logf("NOTE conflict-free member %q declined (coverage-narrowing, still exact): %s", fixture.expr,
+				strings.TrimSpace(fixture.expr))
+		}
+	}
+}

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -29,11 +29,14 @@ import (
 //  2. the process-wide default set with SetAdmissionCandidateRouteDefault;
 //  3. the process-wide default seeded from the GTS_ADMISSION_CANDIDATE
 //     environment variable at package initialization;
-//  4. OFF.
+//  4. ON.
 //
-// The default is OFF. Flipping the default to ON is the admission decision
-// itself and is a separate, one-line change; this mechanism only makes the
-// choice routable and measurable.
+// Phase-3 admission flipped the default to ON: the compact route is now the
+// default full-parse route for eligible languages. Set GTS_ADMISSION_CANDIDATE=0
+// (or false/off/no) to force the production route -- the documented escape
+// hatch. An emergency build (-tags gts_no_parsercorephase0) compiles the
+// compact engine out entirely and every eligible full parse then falls back to
+// production.
 
 // admissionRouteMode is the per-Parser override state. The zero value follows
 // the process-wide default.
@@ -65,19 +68,22 @@ var (
 var admissionCandidateLastFallbackReason atomic.Value // string
 
 func init() {
-	if admissionCandidateEnvEnabled() {
-		admissionCandidateRouteDefault.Store(true)
-	}
+	admissionCandidateRouteDefault.Store(admissionCandidateEnvEnabled())
 }
 
-// admissionCandidateEnvEnabled reports whether GTS_ADMISSION_CANDIDATE requests
-// the candidate route by default.
+// admissionCandidateEnvEnabled resolves the process-wide default the switch
+// seeds from GTS_ADMISSION_CANDIDATE at package initialization.
+//
+// Phase-3 admission made the compact route the default full-parse route, so an
+// unset or unrecognized value resolves ON. Only an explicit off value
+// ("0", "false", "off", "no", any case) resolves OFF -- the documented escape
+// hatch that forces every eligible full parse back to the production route.
 func admissionCandidateEnvEnabled() bool {
-	switch os.Getenv("GTS_ADMISSION_CANDIDATE") {
-	case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
-		return true
-	default:
+	switch strings.TrimSpace(os.Getenv("GTS_ADMISSION_CANDIDATE")) {
+	case "0", "false", "FALSE", "False", "off", "OFF", "no", "NO":
 		return false
+	default:
+		return true
 	}
 }
 
@@ -85,12 +91,12 @@ func admissionCandidateEnvEnabled() bool {
 // admission switch applies to Parsers with no explicit override. A per-Parser
 // override still wins.
 //
-// Caveat: the candidate route does not enforce the automatic large-input memory
-// budget at scheduler granularity, so a pathological input that the production
-// route truncates with ParseStopMemoryBudget can instead parse to completion on
-// the candidate route (a byte-correct, non-truncated tree). Explicit timeouts,
-// cancellation flags, included ranges, and observability hooks all keep a parse
-// on production.
+// The candidate route does not enforce the automatic large-input memory budget
+// at scheduler granularity, so the switch declines every input at or above the
+// source-length floor where the production route arms that budget
+// (parseRuntimeMemoryMinSourceBytes). Such inputs stay on production and honor
+// ParseStopMemoryBudget. Explicit timeouts, cancellation flags, included ranges,
+// and observability hooks also keep a parse on production.
 func SetAdmissionCandidateRouteDefault(enabled bool) {
 	admissionCandidateRouteDefault.Store(enabled)
 }
@@ -104,12 +110,12 @@ func AdmissionCandidateRouteDefault() bool {
 // over the process-wide default. enabled=true forces the candidate route on for
 // eligible full parses; enabled=false forces the production route.
 //
-// Caveat: the candidate route does not enforce the automatic large-input memory
-// budget at scheduler granularity, so a pathological input that the production
-// route truncates with ParseStopMemoryBudget can instead parse to completion on
-// the candidate route (a byte-correct, non-truncated tree). Explicit timeouts,
-// cancellation flags, included ranges, and observability hooks all keep a parse
-// on production.
+// enabled=true still respects every per-input eligibility decline: the switch
+// declines inputs at or above the source-length floor where the production
+// route arms the automatic memory budget (parseRuntimeMemoryMinSourceBytes), so
+// large inputs stay on production and honor ParseStopMemoryBudget. Explicit
+// timeouts, cancellation flags, included ranges, and observability hooks also
+// keep a parse on production.
 func (p *Parser) SetAdmissionCandidateRoute(enabled bool) {
 	if p == nil {
 		return
@@ -198,7 +204,8 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	// Preserve liveness fidelity: the compact scheduler does not poll an explicit
 	// timeout or cancellation flag, so decline when a caller set one. Production
 	// then honors the deadline exactly. (The automatic large-input memory budget
-	// is a documented boundary, not enforced by the compact scheduler.)
+	// is honored by the per-input size decline in attemptAdmissionCandidateFullParse,
+	// which keeps every budget-eligible input on the production route.)
 	if p.timeoutMicros != 0 || p.cancellationFlag != nil {
 		return false
 	}
@@ -259,6 +266,13 @@ func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree
 	if !p.admissionCandidateFullParseEligible(oldTree, usingProductionDFA) {
 		return nil, false
 	}
+	// Decline any input large enough that the production route would arm the
+	// automatic memory budget, which the compact scheduler cannot poll. This is
+	// a never-attempted eligibility decline, not an engine decline, so it does
+	// not move the fallback counter -- the parse simply stays on production.
+	if !admissionCandidateInputSizeEligible(len(source)) {
+		return nil, false
+	}
 	tree, ok, reason := p.tryCompactFullParseRoute(source)
 	if ok && tree != nil {
 		admissionCandidateRouted.Add(1)
@@ -267,4 +281,24 @@ func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree
 	admissionCandidateFallback.Add(1)
 	admissionCandidateLastFallbackReason.Store(reason)
 	return nil, false
+}
+
+// admissionCandidateInputSizeEligible reports whether an input is small enough
+// to route through the compact candidate without weakening the automatic
+// large-input memory budget contract.
+//
+// The compact scheduler does not poll the automatic memory budget at scheduler
+// granularity (the documented Phase-3 boundary), so a pathological large input
+// that the production route would truncate with ParseStopMemoryBudget could
+// instead parse to completion on the candidate route. The production route arms
+// that budget (soft default 512 MiB and hard ceiling 2 GiB) only once a source
+// reaches parseRuntimeMemoryMinSourceBytes (see runtimeMemoryBudgetEnabled and
+// runtimeMemoryHardCeilingEnabled in parser_memory_budget_runtime.go). Declining
+// every input at or above that same floor keeps every parse where the budget
+// could engage on the production route, so routing preserves the budget
+// contract exactly. Inputs below the floor never arm the budget on either
+// route, and the compact arena caps (admissionCandidateLimits) bound their
+// growth, so they route freely.
+func admissionCandidateInputSizeEligible(sourceLen int) bool {
+	return sourceLen < parseRuntimeMemoryMinSourceBytes
 }

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -1,4 +1,4 @@
-//go:build gts_parsercorephase0
+//go:build !gts_no_parsercorephase0
 
 package gotreesitter
 
@@ -9,8 +9,11 @@ import (
 )
 
 // This file is the compact candidate route for the Phase-3 admission switch.
-// It is built only under the gts_parsercorephase0 tag, where the compact engine
-// exists. The default build uses the stub in admission_switch_stub.go.
+// Phase-3 admission promoted the compact route into the default build, so it
+// compiles unless the opt-out emergency tag gts_no_parsercorephase0 is set. In
+// an emergency build (-tags gts_no_parsercorephase0) the stub in
+// admission_switch_stub.go replaces this file and every eligible full parse
+// fails closed to production.
 //
 // The route reuses the fresh-full runner (parsercore_phase0_fresh_full_runner.go)
 // but binds it to the caller's own Parser and Language rather than the certified

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -33,6 +33,21 @@ func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 			t.Fatalf("%s: parse: %v", row.id, err)
 		}
 		routed1, fb1 := AdmissionCandidateCounters()
+		if len(fixture.Source) >= parseRuntimeMemoryMinSourceBytes {
+			// The memory-budget size gate declines any input at or above the floor
+			// where the production route arms the automatic memory budget (the
+			// compact scheduler cannot poll it). A large fixture (grammargen_lr)
+			// stays on production: no route, no fallback, no compact tree.
+			if routed1 != routed0 || fb1 != fb0 {
+				t.Fatalf("%s: large fixture (%d bytes >= %d floor) must be size-declined, not routed: routed %d->%d fallback %d->%d",
+					row.id, len(fixture.Source), parseRuntimeMemoryMinSourceBytes, routed0, routed1, fb0, fb1)
+			}
+			if tree.compactMaterialized {
+				t.Fatalf("%s: size-declined fixture produced a compact-materialized tree", row.id)
+			}
+			tree.Release()
+			continue
+		}
 		if routed1 != routed0+1 || fb1 != fb0 {
 			t.Fatalf("%s: expected one candidate route, got routed %d->%d fallback %d->%d (last=%q)",
 				row.id, routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
@@ -71,8 +86,15 @@ func TestAdmissionSwitchParseProductionWhenOff(t *testing.T) {
 }
 
 // TestAdmissionSwitchCandidateDigestMatchesProduction is the byte-exact fidelity
-// proof: the compact candidate route and production produce the same frozen
-// deep-tree digest on all four canonical fixtures, through the public Parse API.
+// proof: the compact candidate ENGINE and production produce the same frozen
+// deep-tree digest on all four canonical fixtures.
+//
+// It drives the candidate tree through the engine seam (tryCompactFullParseRoute)
+// rather than the public Parse route, so it proves engine fidelity on every
+// fixture independent of the admission routing size gate. That gate declines
+// fixtures at or above parseRuntimeMemoryMinSourceBytes (grammargen_lr) from the
+// public Parse route to preserve the memory-budget contract; their engine
+// byte-exactness is still proven here.
 func TestAdmissionSwitchCandidateDigestMatchesProduction(t *testing.T) {
 	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
 	if err != nil {
@@ -84,9 +106,9 @@ func TestAdmissionSwitchCandidateDigestMatchesProduction(t *testing.T) {
 	production.SetAdmissionCandidateRoute(false)
 	for _, row := range diagnosticParserCoreCanonicalAdmissions {
 		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
-		candidateTree, err := candidate.Parse(fixture.Source)
-		if err != nil {
-			t.Fatalf("%s: candidate parse: %v", row.id, err)
+		candidateTree, ok, reason := candidate.tryCompactFullParseRoute(fixture.Source)
+		if !ok || candidateTree == nil {
+			t.Fatalf("%s: candidate engine declined: %s", row.id, reason)
 		}
 		productionTree, err := production.Parse(fixture.Source)
 		if err != nil {

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -1,13 +1,14 @@
-//go:build !gts_parsercorephase0
+//go:build gts_no_parsercorephase0
 
 package gotreesitter
 
-// tryCompactFullParseRoute is the default-build stub for the compact candidate
-// route. The parsercorephase0 engine is only compiled under the
-// gts_parsercorephase0 build tag, so in the default build the candidate route
-// is unavailable: every eligible full parse fails closed and falls back to
-// production. The switch still resolves and its counters still move, so the
-// routing seam is testable without the tag.
+// tryCompactFullParseRoute is the emergency-build stub for the compact
+// candidate route. Phase-3 admission promoted the compact engine into the
+// default build; the emergency opt-out tag gts_no_parsercorephase0 compiles the
+// engine back out. In that build the candidate route is unavailable: every
+// eligible full parse fails closed and falls back to production. The switch
+// still resolves and its counters still move, so the routing seam is testable
+// without the engine.
 func (p *Parser) tryCompactFullParseRoute(_ []byte) (*Tree, bool, string) {
-	return nil, false, "compact candidate route not compiled in (build with -tags gts_parsercorephase0)"
+	return nil, false, "compact candidate route compiled out (built with -tags gts_no_parsercorephase0)"
 }

--- a/admission_switch_stub_test.go
+++ b/admission_switch_stub_test.go
@@ -1,4 +1,4 @@
-//go:build !gts_parsercorephase0
+//go:build gts_no_parsercorephase0
 
 package gotreesitter_test
 
@@ -10,10 +10,10 @@ import (
 )
 
 // TestAdmissionSwitchDefaultBuildFallsBackLoudly proves the fail-closed
-// contract in the shipped default build: with the switch on, an eligible fresh
-// full parse attempts the candidate route, is declined (the compact engine is
-// not compiled in), bumps the fallback counter, records a loud reason, and
-// returns the correct production tree.
+// contract in the emergency opt-out build (-tags gts_no_parsercorephase0):
+// with the switch on, an eligible fresh full parse attempts the candidate
+// route, is declined (the compact engine is compiled out), bumps the fallback
+// counter, records a loud reason, and returns the correct production tree.
 func TestAdmissionSwitchDefaultBuildFallsBackLoudly(t *testing.T) {
 	restore := gts.AdmissionCandidateRouteDefault()
 	defer gts.SetAdmissionCandidateRouteDefault(restore)
@@ -37,7 +37,7 @@ func TestAdmissionSwitchDefaultBuildFallsBackLoudly(t *testing.T) {
 	if fallbackAfter != fallbackBefore+1 {
 		t.Fatalf("default build must fall back loudly: fallback %d -> %d", fallbackBefore, fallbackAfter)
 	}
-	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "not compiled in") {
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "compiled out") {
 		t.Fatalf("fallback reason must name the missing engine, got %q", reason)
 	}
 }

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -486,21 +486,23 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 	}
 }
 
-// TestAdmissionCandidateGoTypeConversionKnownDivergence records a KNOWN, TRACKED
-// correctness divergence the Phase-3 admission flip surfaced. On the ambiguous
-// Go construct `Foo[int](a)` (type conversion versus a call of an index
-// expression) the compact candidate route resolves the GLR conflict to
-// call_expression(index_expression), while the production engine and the
-// tree-sitter-go C oracle resolve it to type_conversion_expression(generic_type).
+// TestAdmissionCandidateGoTypeConversionFailsClosed proves the compact candidate
+// route FAILS CLOSED on the Go generic-instantiation / type-conversion GLR
+// conflict the Phase-3 admission flip surfaced. On the ambiguous construct
+// `Foo[int](a)` (a type conversion of a generic type versus a call of an index
+// expression) production and the tree-sitter-go C oracle resolve
+// type_conversion_expression(generic_type). The compact scheduler forks the same
+// conflict but cannot rank the two arms by dynamic precedence, so it declines the
+// unauthorized tie fold (see Core.condenseLinkUnion) instead of silently keeping
+// one arm by insertion order. The parse then falls back to production.
 //
-// This divergence is NOT covered by the 206-language admission scorecard
-// fixtures. It is a BLOCKER for unconditional Go admission and must be resolved
-// by the engine-swap review: the compact scheduler must reproduce the production
-// conflict resolution or fail closed on this conflict class. When that lands,
-// the candidate tree matches production and this test fails loudly, directing
-// the maintainer to route TestParseGoNewMakeGenericInstantiationUntouched again
-// and remove this tracker.
-func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
+// This was a tracked correctness divergence (call_expression(index_expression)
+// routed with no fallback). The fix is loud and explicit here: the candidate must
+// decline (route counter stays 0, fallback counter moves) and the returned tree
+// must equal production byte for byte. If a future change routes this input, the
+// route/fallback assertion fails and directs the maintainer to re-verify the
+// whole conflict family in TestAdmissionGenericConflictFamilyNoDivergence.
+func TestAdmissionCandidateGoTypeConversionFailsClosed(t *testing.T) {
 	src := "package p\n\n" +
 		"type Foo[T any] struct {\n\tV T\n}\n\n" +
 		"func f() {\n" +
@@ -519,6 +521,9 @@ func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
 	}
 	defer prodTree.Release()
 	prodSExpr := prodTree.RootNode().SExpr(lang)
+	if !strings.Contains(prodSExpr, "type_conversion_expression") {
+		t.Fatalf("production reference lost type_conversion_expression; the C-oracle witness changed: %s", prodSExpr)
+	}
 
 	gts.ResetAdmissionCandidateCountersForTest()
 	cand := gts.NewParser(lang)
@@ -528,21 +533,26 @@ func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
 		t.Fatalf("candidate parse: %v", err)
 	}
 	defer candTree.Release()
-	routed, _ := gts.AdmissionCandidateCounters()
+	routed, fallback := gts.AdmissionCandidateCounters()
 	candSExpr := candTree.RootNode().SExpr(lang)
 
-	if routed == 0 {
-		t.Skip("candidate route declined this Go input; the known divergence no longer reproduces via routing")
+	// Fail-closed proof 1: the candidate declined this conflict input.
+	if routed != 0 {
+		t.Fatalf("conflict input routed (routed=%d fallback=%d); the compact route must fail closed on the "+
+			"generic-instantiation / type-conversion conflict. Re-verify TestAdmissionGenericConflictFamilyNoDivergence.\n"+
+			"  candidate: %s", routed, fallback, candSExpr)
 	}
-	if !strings.Contains(prodSExpr, "type_conversion_expression") {
-		t.Fatalf("production reference lost type_conversion_expression; the C-oracle witness changed: %s", prodSExpr)
+	// Fail-closed proof 2: the decline moved the fallback counter (the parse ran
+	// production, it did not merely skip).
+	if fallback == 0 {
+		t.Fatalf("candidate declined but the fallback counter did not move (routed=%d fallback=%d); "+
+			"the fail-closed path is not exercised", routed, fallback)
 	}
-	if prodSExpr == candSExpr {
-		t.Fatalf("KNOWN divergence resolved: the candidate now matches production for Foo[int](a). "+
-			"Re-route TestParseGoNewMakeGenericInstantiationUntouched and remove this tracker.\n%s", candSExpr)
+	// Fail-closed proof 3: the returned tree is exactly production's tree.
+	if candSExpr != prodSExpr {
+		t.Fatalf("declined candidate tree diverges from production:\n  production: %s\n  candidate:  %s",
+			prodSExpr, candSExpr)
 	}
-	t.Logf("KNOWN candidate-route divergence (BLOCKER for unconditional Go admission):\n  production: %s\n  candidate:  %s",
-		prodSExpr, candSExpr)
 }
 
 // admissionEOFPoint returns the row/column point at the end of source.

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -493,7 +493,7 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 // expression) production and the tree-sitter-go C oracle resolve
 // type_conversion_expression(generic_type). The compact scheduler forks the same
 // conflict but cannot rank the two arms by dynamic precedence, so it declines the
-// unauthorized tie fold (see Core.condenseLinkUnion) instead of silently keeping
+// unauthorized tie fold (see Core.condenseWithOutcomeAtomic) instead of silently keeping
 // one arm by insertion order. The parse then falls back to production.
 //
 // This was a tracked correctness divergence (call_expression(index_expression)

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -1,6 +1,8 @@
 package gotreesitter_test
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
@@ -354,13 +356,18 @@ func TestAdmissionSwitchPooledParserScrubsRouteState(t *testing.T) {
 
 // TestAdmissionSwitchEnvVarContract proves GTS_ADMISSION_CANDIDATE seeds the
 // process-wide default: init calls this same parser at package load.
+//
+// Phase-3 admission made the compact route the default, so an unset or
+// unrecognized value resolves ON; only an explicit off value forces the
+// production route (the escape hatch).
 func TestAdmissionSwitchEnvVarContract(t *testing.T) {
 	for _, tc := range []struct {
 		value string
 		want  bool
 	}{
 		{"1", true}, {"true", true}, {"on", true}, {"yes", true}, {"YES", true},
-		{"0", false}, {"false", false}, {"", false}, {"nonsense", false},
+		{"", true}, {"nonsense", true},
+		{"0", false}, {"false", false}, {"off", false}, {"no", false}, {"NO", false},
 	} {
 		t.Setenv("GTS_ADMISSION_CANDIDATE", tc.value)
 		if got := gts.AdmissionCandidateEnvEnabledForTest(); got != tc.want {
@@ -390,6 +397,152 @@ func TestAdmissionSwitchDeclinesWhenLoggerAttached(t *testing.T) {
 	if got := admissionRoutingEvents(t); got != before {
 		t.Fatalf("an attached logger must keep the parse on production: %d -> %d", before, got)
 	}
+}
+
+// TestAdmissionCandidateMemoryBudgetContractPreserved proves the Phase-3 size
+// gate keeps the automatic large-input memory budget contract intact even with
+// the candidate route on by default.
+//
+// The compact scheduler does not poll the automatic memory budget, so the
+// switch declines every input at or above the source-length floor where the
+// production route arms that budget (parseRuntimeMemoryMinSourceBytes, 64 KiB).
+// Such inputs stay on production and honor ParseStopMemoryBudget. Inputs below
+// the floor, where no budget arms on either route, still route freely.
+func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
+	// Mirror parseRuntimeMemoryMinSourceBytes (parser_memory_budget_runtime.go).
+	const minBudgetSourceBytes = 64 * 1024
+
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+
+	lang := grammars.GoLanguage()
+
+	// Positive control: a small clean source below the floor routes.
+	small := []byte(grammars.ParseSmokeSample("go"))
+	if len(small) == 0 || len(small) >= minBudgetSourceBytes {
+		t.Skipf("go smoke sample unsuitable for the control (%d bytes)", len(small))
+	}
+	gts.ResetAdmissionCandidateCountersForTest()
+	smallParser := gts.NewParser(lang)
+	smallTree, err := smallParser.Parse(small)
+	if err != nil {
+		t.Fatalf("small parse: %v", err)
+	}
+	smallTree.Release()
+	if routed, _ := gts.AdmissionCandidateCounters(); routed == 0 {
+		t.Fatalf("small clean source below the floor did not route to the candidate; routed=%d", routed)
+	}
+
+	// A clean source at or above the floor must NOT route: the size gate keeps
+	// it on production even with the switch on.
+	var big bytes.Buffer
+	big.WriteString("package p\n\nfunc f() {\n")
+	for big.Len() < minBudgetSourceBytes+(1<<15) {
+		big.WriteString("\t_ = 1\n")
+	}
+	big.WriteString("}\n")
+	if big.Len() < minBudgetSourceBytes {
+		t.Fatalf("large control source too small: %d", big.Len())
+	}
+	gts.ResetAdmissionCandidateCountersForTest()
+	bigParser := gts.NewParser(lang)
+	bigTree, err := bigParser.Parse(big.Bytes())
+	if err != nil {
+		t.Fatalf("large parse: %v", err)
+	}
+	bigTree.Release()
+	if routed, _ := gts.AdmissionCandidateCounters(); routed != 0 {
+		t.Fatalf("source of %d bytes (>= %d floor) routed to the candidate; the memory-budget size gate did not decline it (routed=%d)",
+			big.Len(), minBudgetSourceBytes, routed)
+	}
+
+	// With a low budget, a pathological large source on production honors
+	// ParseStopMemoryBudget -- the exact contract the size gate preserves by
+	// routing every budget-eligible input to production.
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
+	gts.ResetParseEnvConfigCacheForTests()
+	defer gts.ResetParseEnvConfigCacheForTests()
+
+	var huge bytes.Buffer
+	huge.WriteString("package p\nfunc f() {\n")
+	for i := 0; i < 20000; i++ {
+		huge.WriteString("var x = 1\n")
+	}
+	huge.WriteString("}\n")
+	gts.ResetAdmissionCandidateCountersForTest()
+	hugeParser := gts.NewParser(lang)
+	hugeTree, err := hugeParser.Parse(huge.Bytes())
+	if err != nil {
+		t.Fatalf("huge parse: %v", err)
+	}
+	defer hugeTree.Release()
+	if routed, _ := gts.AdmissionCandidateCounters(); routed != 0 {
+		t.Fatalf("budgeted large source routed to the candidate; routed=%d", routed)
+	}
+	if got := hugeTree.ParseStopReason(); got != gts.ParseStopMemoryBudget {
+		t.Fatalf("ParseStopReason() = %q, want %q (production must honor the budget the candidate cannot poll)",
+			got, gts.ParseStopMemoryBudget)
+	}
+}
+
+// TestAdmissionCandidateGoTypeConversionKnownDivergence records a KNOWN, TRACKED
+// correctness divergence the Phase-3 admission flip surfaced. On the ambiguous
+// Go construct `Foo[int](a)` (type conversion versus a call of an index
+// expression) the compact candidate route resolves the GLR conflict to
+// call_expression(index_expression), while the production engine and the
+// tree-sitter-go C oracle resolve it to type_conversion_expression(generic_type).
+//
+// This divergence is NOT covered by the 206-language admission scorecard
+// fixtures. It is a BLOCKER for unconditional Go admission and must be resolved
+// by the engine-swap review: the compact scheduler must reproduce the production
+// conflict resolution or fail closed on this conflict class. When that lands,
+// the candidate tree matches production and this test fails loudly, directing
+// the maintainer to route TestParseGoNewMakeGenericInstantiationUntouched again
+// and remove this tracker.
+func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
+	src := "package p\n\n" +
+		"type Foo[T any] struct {\n\tV T\n}\n\n" +
+		"func f() {\n" +
+		"\ta := Foo[int]{}\n" +
+		"\tb := Foo[int](a)\n" +
+		"\t_ = a\n" +
+		"\t_ = b\n" +
+		"}\n"
+	lang := grammars.GoLanguage()
+
+	prod := gts.NewParser(lang)
+	prod.SetAdmissionCandidateRoute(false)
+	prodTree, err := prod.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer prodTree.Release()
+	prodSExpr := prodTree.RootNode().SExpr(lang)
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	cand := gts.NewParser(lang)
+	cand.SetAdmissionCandidateRoute(true)
+	candTree, err := cand.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	defer candTree.Release()
+	routed, _ := gts.AdmissionCandidateCounters()
+	candSExpr := candTree.RootNode().SExpr(lang)
+
+	if routed == 0 {
+		t.Skip("candidate route declined this Go input; the known divergence no longer reproduces via routing")
+	}
+	if !strings.Contains(prodSExpr, "type_conversion_expression") {
+		t.Fatalf("production reference lost type_conversion_expression; the C-oracle witness changed: %s", prodSExpr)
+	}
+	if prodSExpr == candSExpr {
+		t.Fatalf("KNOWN divergence resolved: the candidate now matches production for Foo[int](a). "+
+			"Re-route TestParseGoNewMakeGenericInstantiationUntouched and remove this tracker.\n%s", candSExpr)
+	}
+	t.Logf("KNOWN candidate-route divergence (BLOCKER for unconditional Go admission):\n  production: %s\n  candidate:  %s",
+		prodSExpr, candSExpr)
 }
 
 // admissionEOFPoint returns the row/column point at the end of source.

--- a/benchmark_real_go_test.go
+++ b/benchmark_real_go_test.go
@@ -56,6 +56,11 @@ func BenchmarkGoParseWarmRealDFA(b *testing.B) {
 func admitRealGoBenchmarkFixture(tb testing.TB, fixture benchfixtures.LoadedFixture, lang *gotreesitter.Language) benchfixtures.NodeKindCoverage {
 	tb.Helper()
 	parser := gotreesitter.NewParser(lang)
+	// Pin to production: this admission fixture asserts production-engine GLR
+	// internals (MaxStacksSeen forking) alongside the deep-tree digest. The
+	// compact candidate route does not report those internals; its digest
+	// exactness is proven by the tagged scorecard suite.
+	parser.SetAdmissionCandidateRoute(false)
 	tree, err := parser.Parse(fixture.Source)
 	if err != nil {
 		releaseBenchmarkTree(tree)

--- a/cgo_harness/parity_glr_canary_set_test.go
+++ b/cgo_harness/parity_glr_canary_set_test.go
@@ -13,9 +13,14 @@ type glrCanaryCase struct {
 
 var glrCanaryCases = []glrCanaryCase{
 	{
-		lang:      "go",
-		name:      "ambiguous-call",
-		source:    "package main\nfunc main(){ println(\"hello\") }\n",
+		lang: "go",
+		name: "ambiguous-call",
+		// The generic-instantiation / type-conversion conflict: production forks
+		// Foo[int](a) into the generic_type/type_conversion arm and the
+		// index_expression/call arm. This is a real GLR fork (post-flip the
+		// compact route declines it and falls back to production, which reports
+		// the branching), unlike the previous single-stack println smoke input.
+		source:    "package main\nfunc f() { _ = Foo[int](a) }\n",
 		minStacks: 2,
 	},
 	{

--- a/cgo_harness/parity_glr_canary_test.go
+++ b/cgo_harness/parity_glr_canary_test.go
@@ -11,13 +11,17 @@ import (
 
 func makeGoGLRCanarySource(callCount int) []byte {
 	var b strings.Builder
-	b.Grow(callCount * 16)
+	b.Grow(callCount * 24)
 	b.WriteString("package main\n\n")
-	b.WriteString("type glrCanaryNode struct{}\n")
-	b.WriteString("func (glrCanaryNode) method() {}\n")
-	b.WriteString("func glrCanaryBenchmark() {\n\tvar n glrCanaryNode\n")
+	b.WriteString("func glrCanaryBenchmark() {\n")
 	for i := 0; i < callCount; i++ {
-		b.WriteString("\tn.method()\n")
+		// Each line is the generic-instantiation / type-conversion conflict
+		// Foo[int](a). Production forks the generic_type/type_conversion arm
+		// against the index_expression/call arm, so the runtime records GLR
+		// branching. Post-flip the compact route declines this conflict and falls
+		// back to production, so the assertion measures production's fork count,
+		// not the compact route's single stack.
+		b.WriteString("\t_ = Foo[int](a)\n")
 	}
 	b.WriteString("}\n")
 	return []byte(b.String())

--- a/final_tree_compaction_test.go
+++ b/final_tree_compaction_test.go
@@ -167,6 +167,9 @@ func TestFinalTreeCompactionEligibilityIsNarrow(t *testing.T) {
 func TestIncrementalParseAfterFinalTreeCompactionMatchesFresh(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
+	// Pin to production: this test asserts a production-engine internal (final
+	// tree compaction), which the compact candidate route does not perform.
+	parser.SetAdmissionCandidateRoute(false)
 	source := []byte("1+2+3")
 	oldTree := mustParse(t, parser, source)
 	oldArena := oldTree.arena
@@ -200,6 +203,9 @@ func TestConcurrentReadsAfterFinalTreeCompaction(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	source := []byte("1+2+3+4")
 	parser := NewParser(lang)
+	// Pin to production: this test asserts a production-engine internal (final
+	// tree compaction), which the compact candidate route does not perform.
+	parser.SetAdmissionCandidateRoute(false)
 	tree := mustParse(t, parser, source)
 	oldArena := tree.arena
 	oldArena.allocatedBytes = 800 << 20

--- a/glr_forest_decline_memo_test.go
+++ b/glr_forest_decline_memo_test.go
@@ -218,7 +218,11 @@ func TestForestDeclineMemoWarmSemanticDeclineMatchesProduction(t *testing.T) {
 	source := []byte("all:\n\t@echo hi\n")
 
 	glrForestEnabled = false
-	production, err := NewParser(lang).Parse(source)
+	// Pin to production: this test compares the production forest decline path
+	// against production, and observes production-internal decline-memo state.
+	productionParser := NewParser(lang)
+	productionParser.SetAdmissionCandidateRoute(false)
+	production, err := productionParser.Parse(source)
 	if err != nil || production == nil || production.RootNode() == nil {
 		t.Fatalf("production parse: tree_nil=%t err=%v", production == nil, err)
 	}
@@ -228,6 +232,9 @@ func TestForestDeclineMemoWarmSemanticDeclineMatchesProduction(t *testing.T) {
 
 	glrForestEnabled = true
 	parser := NewParser(lang)
+	// Pin to production: this test observes production-internal forest decline
+	// reason and memo state, which the compact candidate route does not produce.
+	parser.SetAdmissionCandidateRoute(false)
 	first, err := parser.Parse(source)
 	if err != nil || first == nil || first.RootNode() == nil {
 		t.Fatalf("first automatic parse: tree_nil=%t err=%v", first == nil, err)

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -382,7 +382,11 @@ func TestForestDispatchReportsAcceptedRuntime(t *testing.T) {
 
 	src := []byte("f() { echo a; }\n")
 	lang := explicitForestLanguage(t, grm.BashLanguage())
-	tree, err := gts.NewParser(lang).Parse(src)
+	// Pin to production: this test asserts a production-engine internal (the
+	// forest fast-path dispatch runtime) the compact candidate route bypasses.
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("forest dispatch parse: %v", err)
 	}

--- a/incremental_leaf_fastpath_test.go
+++ b/incremental_leaf_fastpath_test.go
@@ -742,6 +742,10 @@ func TestReuseTreeWithNewSourceKeepsPrimaryArena(t *testing.T) {
 func TestTokenInvariantLeafEditAllowsExtraLeaf(t *testing.T) {
 	lang := buildArithmeticExtraCommentLanguage()
 	parser := NewParser(lang)
+	// Pin to production: the base tree must support incremental leaf reuse.
+	// A compact-materialized base tree is hard-barred from reuse (decision 0008),
+	// so routing it would force a full reparse instead of the one-token fast path.
+	parser.SetAdmissionCandidateRoute(false)
 	oldSource := []byte("1#2012\n+2")
 	newSource := []byte("1#2013\n+2")
 	tree := mustParse(t, parser, oldSource)

--- a/incremental_test.go
+++ b/incremental_test.go
@@ -122,6 +122,10 @@ func TestHighlightIncremental(t *testing.T) {
 func TestParseIncrementalReusesUnchangedLeaf(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
+	// Pin to production: a compact-materialized base tree is hard-barred from
+	// incremental reuse (decision 0008), so the reuse assertion needs a
+	// production base tree. Reuse-bar lift is the follow-on campaign.
+	parser.SetAdmissionCandidateRoute(false)
 
 	oldSource := []byte("1+2+3")
 	tree := mustParse(t, parser, oldSource)
@@ -219,6 +223,10 @@ func TestParseIncrementalReusesRootWhenUnchanged(t *testing.T) {
 func TestParseIncrementalReusesRootAfterUndo(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
+	// Pin to production: a compact-materialized base tree is hard-barred from
+	// incremental reuse (decision 0008), so the reuse assertion needs a
+	// production base tree. Reuse-bar lift is the follow-on campaign.
+	parser.SetAdmissionCandidateRoute(false)
 
 	source := []byte("1+2+3")
 	tree := mustParse(t, parser, source)
@@ -283,6 +291,10 @@ func TestTreeEditNodesAfterEdit(t *testing.T) {
 func TestParseIncrementalReleaseKeepsBorrowedNodesAlive(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
+	// Pin to production: a compact-materialized base tree is hard-barred from
+	// incremental reuse (decision 0008), so the reuse assertion needs a
+	// production base tree. Reuse-bar lift is the follow-on campaign.
+	parser.SetAdmissionCandidateRoute(false)
 
 	oldSrc := []byte("1+2+3")
 	oldTree := mustParse(t, parser, oldSrc)

--- a/internal/parsercorephase0/census/phase0a_canonical_census_test.go
+++ b/internal/parsercorephase0/census/phase0a_canonical_census_test.go
@@ -77,7 +77,7 @@ var currentCanonicalCensus = map[string]currentCensusContract{
 	"query_compile": {routes: 8103, links: 14703, migrations: 32, spine: 1, raw: 11331, public: 7524, terminals: 5125, reductions: 6206, migrated: 17, maxDepth: 78, digest: "c6ab3989e0492de265c74ce19526d85d30223801b984156b4fa4d265f1a65a85"},
 	"rewrite":       {routes: 1646, links: 2995, migrations: 16, spine: 1, raw: 2237, public: 1524, terminals: 1035, reductions: 1202, migrated: 16, maxDepth: 40, digest: "728ea27e31b3972b019db8b1e817d53caec9d905930df29ae475fe94846caad8"},
 	"language":      {routes: 8408, links: 15864, migrations: 256, spine: 6, raw: 10761, public: 7082, terminals: 5057, reductions: 5704, migrated: 150, maxDepth: 125, digest: "481aba4139174c63b03fa6856b427fa09268539e240f951ac8fe40cf1e0fe006"},
-	"grammargen_lr": {routes: 84924, links: 153451, migrations: 316, spine: 1, raw: 109614, public: 71768, terminals: 49911, reductions: 59703, migrated: 218, maxDepth: 348, digest: "e7a5faa302b6b27539694c0a08830cf026a288f6813607a3687a96340eaaab44"},
+	"grammargen_lr": {routes: 84928, links: 153463, migrations: 316, spine: 1, raw: 109614, public: 71768, terminals: 49911, reductions: 59703, migrated: 218, maxDepth: 348, digest: "e7a5faa302b6b27539694c0a08830cf026a288f6813607a3687a96340eaaab44"},
 }
 
 func TestCanonicalAcceptedRouteSpineCensus(t *testing.T) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1864,7 +1864,14 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 			}
 		}
 		if c.diagnostics.foldSamePredecessorShallowPayloads {
-			candidate := -1
+			// A shallow-class-equal incumbent shares the incoming payload's symbol,
+			// span, and child count. Under ordinary reductions a boundary holds at
+			// most one such incumbent, but a declined precedence tie (below) can
+			// leave two structurally distinct alternates coexisting, so this search
+			// tolerates several and also finds the structurally identical one.
+			shallowCount := 0
+			firstShallow := -1
+			structuralMatch := -1
 			for index, link := range oldLinks {
 				equal, err := c.shallowPayloadClassEqual(link, in)
 				if err != nil {
@@ -1873,13 +1880,40 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				if !equal {
 					continue
 				}
-				if candidate >= 0 {
-					return condenseOutcome{}, errors.New("parser-core phase zero: multiple shallow-fold incumbents")
+				shallowCount++
+				if firstShallow < 0 {
+					firstShallow = index
 				}
-				candidate = index
+				structural, err := c.subtreesStructurallyEqual(link.payload, in.payload)
+				if err != nil {
+					return condenseOutcome{}, err
+				}
+				if structural {
+					if structuralMatch >= 0 {
+						return condenseOutcome{}, errors.New("parser-core phase zero: multiple structural-fold incumbents")
+					}
+					structuralMatch = index
+				}
 			}
-			if candidate >= 0 {
-				incumbentPrecedence, err := c.effectivePayloadPrecedence(oldLinks[candidate].payload, oldLinks[candidate].scoreDelta)
+			foldDeclined := false
+			switch {
+			case structuralMatch >= 0:
+				// The incoming payload reproduces an existing alternate exactly, so
+				// it is a redundant GLR path. Structural equality implies equal
+				// dynamic precedence, so this is the duplicate drop that keeps one
+				// subtree per (symbol, span), matching production.
+				c.recordLinkUnionDuplicateNoop()
+				if phase0AEnabled {
+					phase0AObserveCandidateDrop(c, key, in, oldID, structuralMatch, phase0ATransitionPrecedenceDrop)
+				}
+				return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, nil
+			case shallowCount == 1:
+				// Exactly one shallow-class incumbent, structurally different. Rank
+				// the two by dynamic precedence, production's primary disambiguation
+				// for the clean parses this route admits (error cost is zero here, so
+				// it never outranks precedence).
+				incumbent := firstShallow
+				incumbentPrecedence, err := c.effectivePayloadPrecedence(oldLinks[incumbent].payload, oldLinks[incumbent].scoreDelta)
 				if err != nil {
 					return condenseOutcome{}, err
 				}
@@ -1887,36 +1921,67 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				if err != nil {
 					return condenseOutcome{}, err
 				}
-				if incomingPrecedence <= incumbentPrecedence {
+				switch {
+				case incomingPrecedence < incumbentPrecedence:
+					// The incumbent strictly dominates; drop the dominated incoming
+					// payload, as production keeps the higher-precedence subtree.
 					c.recordLinkUnionDuplicateNoop()
 					if phase0AEnabled {
-						phase0AObserveCandidateDrop(c, key, in, oldID, candidate, phase0ATransitionPrecedenceDrop)
+						phase0AObserveCandidateDrop(c, key, in, oldID, incumbent, phase0ATransitionPrecedenceDrop)
 					}
 					return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, nil
-				}
-				if phase0AEnabled {
-					phase0ABeginReplacement(c, key, in, oldID, candidate)
-				}
-				head, err := c.replaceBoundaryLink(key, probe, old, oldLinks, candidate, in)
-				if err != nil {
-					c.recordLinkUnionRejected()
-				} else {
-					c.recordLinkUnionPrecedenceReplaced()
-				}
-				return condenseOutcome{head: head, change: condenseUpdated}, err
-			}
-			outcome, handled, err := c.factorExactPredecessor(key, probe, oldID, oldLinks, in)
-			if err != nil || handled {
-				if handled {
+				case incomingPrecedence > incumbentPrecedence:
+					// The incoming payload strictly dominates; replace the incumbent.
+					if phase0AEnabled {
+						phase0ABeginReplacement(c, key, in, oldID, incumbent)
+					}
+					head, err := c.replaceBoundaryLink(key, probe, old, oldLinks, incumbent, in)
 					if err != nil {
 						c.recordLinkUnionRejected()
-					} else if outcome.change == condenseUpdated {
-						c.recordLinkUnionRecursiveChanged()
 					} else {
-						c.recordLinkUnionDuplicateNoop()
+						c.recordLinkUnionPrecedenceReplaced()
 					}
+					return condenseOutcome{head: head, change: condenseUpdated}, err
+				default:
+					// A precedence tie between two structurally different same-span
+					// payloads. Dynamic precedence cannot rank them, and the compact
+					// route does not own production's error-cost and structural
+					// tie-breaks. Choosing one here by insertion order is the silent
+					// wrong-tree divergence the admission flip surfaced (Go's
+					// call_expression(index_expression) versus
+					// type_conversion_expression(generic_type) for `Foo[int](a)`).
+					// Decline the fold: keep both links as coexisting alternates and
+					// let them race to EOF. A local ambiguity collapses when one arm
+					// dies; a genuine whole-parse ambiguity keeps more than one
+					// accepted derivation, and the sole-exact acceptance gate then
+					// fails closed to production.
+					foldDeclined = true
 				}
-				return outcome, err
+			case shallowCount >= 2:
+				// The boundary already carries coexisting structural alternates from
+				// an earlier declined tie. Do not precedence-collapse across an
+				// already ambiguous boundary; append the incoming payload as a
+				// further distinct alternate for the sole-exact gate to resolve.
+				foldDeclined = true
+			}
+			// A declined fold skips the exact-predecessor factor (which merges
+			// same-boundary predecessors) and appends the incoming link as a
+			// surviving alternate below. With no shallow-class incumbent the factor
+			// still runs, preserving the recursive-insertion path unchanged.
+			if !foldDeclined && shallowCount == 0 {
+				outcome, handled, err := c.factorExactPredecessor(key, probe, oldID, oldLinks, in)
+				if err != nil || handled {
+					if handled {
+						if err != nil {
+							c.recordLinkUnionRejected()
+						} else if outcome.change == condenseUpdated {
+							c.recordLinkUnionRecursiveChanged()
+						} else {
+							c.recordLinkUnionDuplicateNoop()
+						}
+					}
+					return outcome, err
+				}
 			}
 		}
 	}
@@ -2428,6 +2493,65 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 		state: state, byteOffset: byteOffset, firstLink: uint32(first),
 		linkCount: uint32(len(links)), pathCount: pathCount,
 	})
+}
+
+// subtreesStructurallyEqual reports whether two compact payload subtrees are the
+// same parse: identical symbol, span, production, precedence, extra/external
+// flags, field and alias vectors, and recursively identical children. It is the
+// authorization test for a same-predecessor shallow-payload fold. Two links that
+// reach one boundary with structurally-equal payloads are a redundant GLR path
+// (the compact route and production both collapse them). Two links whose
+// payloads are only shallow-class-equal but structurally DIFFERENT are a genuine
+// structural ambiguity (for example Go's call_expression(index_expression) versus
+// type_conversion_expression(generic_type) for `Foo[int](a)`); the compact route
+// must not silently pick one by a local precedence comparison, so the fold is
+// declined and both links survive as alternates. The surviving alternates raise
+// the accepted-head derivation count above one, and the sole-exact acceptance
+// gate then fails closed to production instead of routing a wrong tree.
+//
+// Payloads are only compared after a shallow-class match (same symbol, span, and
+// child count), so the walk short-circuits on the first structural difference and
+// stays bounded by the matched subtree's size. Compact payloads are acyclic by
+// construction, so the recursion terminates.
+func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
+	if left == right {
+		return true, nil
+	}
+	l, err := c.subtree(left)
+	if err != nil {
+		return false, err
+	}
+	r, err := c.subtree(right)
+	if err != nil {
+		return false, err
+	}
+	if l.symbol != r.symbol || l.productionID != r.productionID || l.dynamicPrecedence != r.dynamicPrecedence ||
+		l.startByte != r.startByte || l.endByte != r.endByte || l.childCount != r.childCount ||
+		l.fieldCount != r.fieldCount || l.aliasCount != r.aliasCount ||
+		l.extra != r.extra || l.external != r.external || l.terminal != r.terminal {
+		return false, nil
+	}
+	if !slices.Equal(
+		c.fields[l.firstField:l.firstField+l.fieldCount],
+		c.fields[r.firstField:r.firstField+r.fieldCount],
+	) {
+		return false, nil
+	}
+	if !slices.Equal(
+		c.aliases[l.firstAlias:l.firstAlias+l.aliasCount],
+		c.aliases[r.firstAlias:r.firstAlias+r.aliasCount],
+	) {
+		return false, nil
+	}
+	leftChildren := c.children[l.firstChild : l.firstChild+l.childCount]
+	rightChildren := c.children[r.firstChild : r.firstChild+r.childCount]
+	for index := range leftChildren {
+		equal, err := c.subtreesStructurallyEqual(leftChildren[index], rightChildren[index])
+		if err != nil || !equal {
+			return equal, err
+		}
+	}
+	return true, nil
 }
 
 func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowPayloadClass, bool, error) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2512,7 +2512,10 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 // Payloads are only compared after a shallow-class match (same symbol, span, and
 // child count), so the walk short-circuits on the first structural difference and
 // stays bounded by the matched subtree's size. Compact payloads are acyclic by
-// construction, so the recursion terminates.
+// construction: appendSubtreeRecord appends every child before its parent, so a
+// child SubtreeID is strictly less than its parent's. The walk enforces that
+// order and returns a fail-closed error on a violation, so the recursion also
+// terminates on a corrupted arena instead of overflowing the stack.
 func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 	if left == right {
 		return true, nil
@@ -2546,6 +2549,9 @@ func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 	leftChildren := c.children[l.firstChild : l.firstChild+l.childCount]
 	rightChildren := c.children[r.firstChild : r.firstChild+r.childCount]
 	for index := range leftChildren {
+		if leftChildren[index] >= left || rightChildren[index] >= right {
+			return false, errors.New("parser-core phase zero: compact subtree child identifier out of order during structural comparison")
+		}
 		equal, err := c.subtreesStructurallyEqual(leftChildren[index], rightChildren[index])
 		if err != nil || !equal {
 			return equal, err

--- a/internal/parsercorephase0/link_fold_test.go
+++ b/internal/parsercorephase0/link_fold_test.go
@@ -55,7 +55,7 @@ func appendShallowPayload(t *testing.T, core *Core, spec shallowPayloadSpec) Sub
 // lower score is dropped, and a precedence TIE is NOT resolved by insertion order.
 // A tie between structurally different payloads is a genuine ambiguity the compact
 // route cannot rank, so both links must coexist as alternates (see
-// Core.condenseLinkUnion); the sole-exact acceptance gate then fails closed rather
+// Core.condenseWithOutcomeAtomic); the sole-exact acceptance gate then fails closed rather
 // than routing one arm silently. This is the fix for the Go generic-instantiation
 // / type-conversion divergence the Phase-3 admission flip surfaced.
 func TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore(t *testing.T) {

--- a/internal/parsercorephase0/link_fold_test.go
+++ b/internal/parsercorephase0/link_fold_test.go
@@ -49,14 +49,24 @@ func appendShallowPayload(t *testing.T, core *Core, spec shallowPayloadSpec) Sub
 	return payload
 }
 
+// TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore proves
+// the shallow-payload fold ranks two structurally different same-span payloads by
+// aggregate dynamic precedence: the strictly higher score wins, the strictly
+// lower score is dropped, and a precedence TIE is NOT resolved by insertion order.
+// A tie between structurally different payloads is a genuine ambiguity the compact
+// route cannot rank, so both links must coexist as alternates (see
+// Core.condenseLinkUnion); the sole-exact acceptance gate then fails closed rather
+// than routing one arm silently. This is the fix for the Go generic-instantiation
+// / type-conversion divergence the Phase-3 admission flip surfaced.
 func TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore(t *testing.T) {
 	for _, test := range []struct {
 		name          string
 		incomingScore int64
 		wantIncoming  bool
+		wantCoexist   bool
 	}{
 		{name: "lower", incomingScore: 9},
-		{name: "equal", incomingScore: 10},
+		{name: "equal", incomingScore: 10, wantCoexist: true},
 		{name: "higher", incomingScore: 11, wantIncoming: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -81,6 +91,39 @@ func TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore(t *t
 			})
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if test.wantCoexist {
+				// A precedence tie between structurally different payloads keeps both
+				// links as alternates on a fresh head.
+				if newHead == oldHead {
+					t.Fatalf("precedence tie retained historical head %+v instead of coexisting", oldHead)
+				}
+				paths, err := core.Derivations(newHead)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := map[SubtreeID]int64{incumbent: 10, incoming: test.incomingScore}
+				if len(paths) != len(want) {
+					t.Fatalf("tie coexistence derivations = %#v, want both payloads %v", paths, want)
+				}
+				for _, path := range paths {
+					if len(path.Payloads) != 1 {
+						t.Fatalf("unexpected derivation shape %#v", path)
+					}
+					wantScore, ok := want[path.Payloads[0]]
+					if !ok {
+						t.Fatalf("unexpected coexisting payload %#v", path)
+					}
+					if path.Score != wantScore {
+						t.Fatalf("coexisting payload %d score=%d want=%d", path.Payloads[0], path.Score, wantScore)
+					}
+					delete(want, path.Payloads[0])
+				}
+				if len(want) != 0 {
+					t.Fatalf("tie coexistence dropped payloads %v", want)
+				}
+				return
 			}
 
 			wantPayload, wantScore, wantOrder := incumbent, int64(10), uint64(7)
@@ -133,14 +176,28 @@ func TestCondenseOutcomeClassifiesBoundaryFreshness(t *testing.T) {
 		t.Fatalf("exact outcome=%+v err=%v, want unchanged head %+v", exact, err, created.head)
 	}
 
+	// A strictly lower aggregate score is dominated and dropped (the boundary is
+	// unchanged). A precedence TIE between structurally different payloads is a
+	// genuine ambiguity that must coexist as an alternate, so it publishes a fresh
+	// head instead of silently dropping. The extra alternate is what lets the
+	// sole-exact acceptance gate fail closed on real ambiguous inputs.
 	lower := appendShallowPayload(t, core, shallowPayloadSpec{
 		symbol: 20, productionID: 2, startByte: 12, endByte: 17, childSymbols: []Symbol{31},
 	})
-	for _, score := range []int64{9, 10} {
-		outcome, err := core.condenseWithOutcome(key, linkInput{prev: seed.Node, payload: lower, scoreDelta: score})
-		if err != nil || outcome.change != condenseUnchanged || outcome.head != created.head {
-			t.Fatalf("non-winning score %d outcome=%+v err=%v", score, outcome, err)
-		}
+	dropped, err := core.condenseWithOutcome(key, linkInput{prev: seed.Node, payload: lower, scoreDelta: 9})
+	if err != nil || dropped.change != condenseUnchanged || dropped.head != created.head {
+		t.Fatalf("dominated score outcome=%+v err=%v, want unchanged head %+v", dropped, err, created.head)
+	}
+	tie, err := core.condenseWithOutcome(key, linkInput{prev: seed.Node, payload: lower, scoreDelta: 10})
+	if err != nil || tie.change != condenseUpdated || tie.head == created.head {
+		t.Fatalf("structural tie outcome=%+v err=%v, want a fresh coexisting head", tie, err)
+	}
+	tiePaths, err := core.Derivations(tie.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tiePaths) != 2 {
+		t.Fatalf("structural tie head folded to %#v, want two coexisting alternates", tiePaths)
 	}
 
 	higher := appendShallowPayload(t, core, shallowPayloadSpec{
@@ -189,10 +246,22 @@ func TestDiagnosticShallowFoldZeroChildParentHasZeroEffectivePrecedence(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head != oldHead {
-		t.Fatalf("effective-zero incoming parent replaced incumbent: old=%+v new=%+v", oldHead, head)
+	// Both zero-child payloads have zero effective precedence (childCount == 0),
+	// so the aggregate scores cannot rank them: this is a precedence tie. The two
+	// payloads are structurally different (different production), so the compact
+	// route must not keep one by insertion order. It coexists them as alternates,
+	// so the sole-exact acceptance gate can fail closed on real ambiguous inputs.
+	if head == oldHead {
+		t.Fatalf("zero-precedence tie collapsed to a single head %+v instead of coexisting", oldHead)
 	}
 	paths, err := core.Derivations(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("zero-precedence tie folded to %#v, want two coexisting alternates", paths)
+	}
+	oldPaths, err := core.Derivations(oldHead)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,8 +269,8 @@ func TestDiagnosticShallowFoldZeroChildParentHasZeroEffectivePrecedence(t *testi
 		Payloads: []SubtreeID{incumbent}, Score: 7,
 		BranchOrder: 3, HasBranchOrder: true,
 	}}
-	if !reflect.DeepEqual(paths, want) {
-		t.Fatalf("zero-child parent paths=%#v, want stored incumbent score/order %#v", paths, want)
+	if !reflect.DeepEqual(oldPaths, want) {
+		t.Fatalf("historical zero-child head mutated: paths=%#v, want stored incumbent score/order %#v", oldPaths, want)
 	}
 }
 

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1863,6 +1863,9 @@ func TestParseWithSnippetParserInheritsParentCancellation(t *testing.T) {
 
 func TestParserParseClearsRecoveryParserAcrossTopLevelParses(t *testing.T) {
 	parser := NewParser(buildArithmeticLanguage())
+	// Pin to production: this test asserts a production-engine internal (the
+	// recovery-parser lifecycle), which the compact candidate route never touches.
+	parser.SetAdmissionCandidateRoute(false)
 	parser.recoveryParser = NewParser(buildArithmeticLanguage())
 
 	if _, err := parser.Parse([]byte("1+2")); err != nil {

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
+// newProductionBig3Parser returns a parser pinned to the production route.
+// These incremental-correctness tests compare production incremental reparse
+// against production fresh parse and observe production-engine reuse profiles.
+// A compact-materialized base tree is hard-barred from incremental reuse
+// (decision 0008), so the base and fresh parses must stay on production; the
+// compact route's fresh-parse correctness is covered by the tagged scorecard
+// suite. Reuse-bar lift is the follow-on campaign.
+func newProductionBig3Parser(lang *gotreesitter.Language) *gotreesitter.Parser {
+	p := gotreesitter.NewParser(lang)
+	p.SetAdmissionCandidateRoute(false)
+	return p
+}
+
 type pythonTestIncrementalReuseScanner struct{ gotreesitter.ExternalScanner }
 
 func (pythonTestIncrementalReuseScanner) SupportsIncrementalReuse() bool { return true }
@@ -51,7 +64,7 @@ func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
 			edited = append(edited, source[:offset]...)
 			edited = append(edited, source[offset+1:]...)
 
-			oldTree, err := gotreesitter.NewParser(lang).Parse(source)
+			oldTree, err := newProductionBig3Parser(lang).Parse(source)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -69,7 +82,7 @@ func TestPythonIncrementalSingleByteDeleteSweepMatchesFresh(t *testing.T) {
 				oldTree.Release()
 				t.Fatal(err)
 			}
-			fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+			fresh, err := newProductionBig3Parser(lang).Parse(edited)
 			if err != nil {
 				incremental.Release()
 				oldTree.Release()
@@ -108,7 +121,7 @@ func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *
 	}
 	edited := append(append([]byte(nil), source[:offset]...), source[offset+1:]...)
 	lang := grammars.PythonLanguage()
-	oldTree, err := gotreesitter.NewParser(lang).Parse(source)
+	oldTree, err := newProductionBig3Parser(lang).Parse(source)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +147,7 @@ func TestPythonLengthChangingEditFallsBackUntilDedentCheckpointsAreCertified(t *
 		t.Fatalf("Python scanner fallback reported old-tree reuse: %+v", profile)
 	}
 
-	fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+	fresh, err := newProductionBig3Parser(lang).Parse(edited)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +196,7 @@ func TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh(t *testing.T) {
 
 	lang := grammars.GoLanguage()
 	t.Run("forward", func(t *testing.T) {
-		oldTree, err := gotreesitter.NewParser(lang).Parse(source)
+		oldTree, err := newProductionBig3Parser(lang).Parse(source)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -201,7 +214,7 @@ func TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer incremental.Release()
-		fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+		fresh, err := newProductionBig3Parser(lang).Parse(edited)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +238,7 @@ func TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh(t *testing.T) {
 	})
 
 	t.Run("reverse", func(t *testing.T) {
-		oldTree, err := gotreesitter.NewParser(lang).Parse(edited)
+		oldTree, err := newProductionBig3Parser(lang).Parse(edited)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -243,7 +256,7 @@ func TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer incremental.Release()
-		fresh, err := gotreesitter.NewParser(lang).Parse(source)
+		fresh, err := newProductionBig3Parser(lang).Parse(source)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -259,7 +272,7 @@ func TestCleanGoIncrementalDoesNotRunAcceptedErrorRetry(t *testing.T) {
 	lang := grammars.GoLanguage()
 	original := []byte("package p\n\nfunc f() {\n\tx := 1\n\t_ = x\n}\n")
 	edited := []byte("package p\n\nfunc f() {\n\tvalue := 1\n\t_ = x\n}\n")
-	oldTree, err := gotreesitter.NewParser(lang).Parse(original)
+	oldTree, err := newProductionBig3Parser(lang).Parse(original)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +294,7 @@ func TestCleanGoIncrementalDoesNotRunAcceptedErrorRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer incremental.Release()
-	fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+	fresh, err := newProductionBig3Parser(lang).Parse(edited)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +318,7 @@ func TestTokenInvariantGoLeafDoesNotEnterAcceptedErrorRetryRoute(t *testing.T) {
 	}
 	edited[offset] = '1'
 
-	oldTree, err := gotreesitter.NewParser(lang).Parse(original)
+	oldTree, err := newProductionBig3Parser(lang).Parse(original)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +359,7 @@ func TestMalformedTokenInvariantGoLeafDoesNotRunBaseMergeRetry(t *testing.T) {
 	}
 	edited[offset] = '1'
 
-	oldTree, err := gotreesitter.NewParser(lang).Parse(original)
+	oldTree, err := newProductionBig3Parser(lang).Parse(original)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +380,7 @@ func TestMalformedTokenInvariantGoLeafDoesNotRunBaseMergeRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer incremental.Release()
-	fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+	fresh, err := newProductionBig3Parser(lang).Parse(edited)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +407,7 @@ func TestMalformedGoIncrementalRunsOneBaseMergeRetryAndKeepsFirstResult(t *testi
 	}
 	edited := append([]byte(nil), original[:offset]...)
 	edited = append(edited, original[offset+1:]...)
-	oldTree, err := gotreesitter.NewParser(lang).Parse(original)
+	oldTree, err := newProductionBig3Parser(lang).Parse(original)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +425,7 @@ func TestMalformedGoIncrementalRunsOneBaseMergeRetryAndKeepsFirstResult(t *testi
 		t.Fatal(err)
 	}
 	defer incremental.Release()
-	fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+	fresh, err := newProductionBig3Parser(lang).Parse(edited)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +466,7 @@ func TestMalformedRustUnsupportedReuseDoesNotRunBaseMergeRetry(t *testing.T) {
 	}
 	edited := append([]byte(nil), original[:offset]...)
 	edited = append(edited, original[offset+1:]...)
-	oldTree, err := gotreesitter.NewParser(lang).Parse(original)
+	oldTree, err := newProductionBig3Parser(lang).Parse(original)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +484,7 @@ func TestMalformedRustUnsupportedReuseDoesNotRunBaseMergeRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer incremental.Release()
-	fresh, err := gotreesitter.NewParser(lang).Parse(edited)
+	fresh, err := newProductionBig3Parser(lang).Parse(edited)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -340,6 +340,11 @@ func TestExternalScannerTokenInvariantLeafReuse(t *testing.T) {
 				lang = explicitForestLanguage(t, lang)
 			}
 			parser := gotreesitter.NewParser(lang)
+			// Pin to production: this test asserts token-invariant incremental
+			// leaf reuse and the accepted forest runtime. A compact-materialized
+			// base tree is hard-barred from reuse (decision 0008), so the base and
+			// fresh parses must stay on the production engine.
+			parser.SetAdmissionCandidateRoute(false)
 			fresh, err := parser.Parse(next)
 			if err != nil {
 				t.Fatalf("fresh parse: %v", err)

--- a/parser_go_newmake_edge_test.go
+++ b/parser_go_newmake_edge_test.go
@@ -31,6 +31,29 @@ func findAllNodesOfType(lang *gotreesitter.Language, node *gotreesitter.Node, ty
 	return out
 }
 
+// assertGoCandidateMatchesProduction routes src through the compact candidate
+// engine and requires the result to equal the production tree byte for byte.
+// The Phase-3 compact route fails closed on the generic-instantiation conflict,
+// so this holds whether the candidate routes or declines to production; the
+// helper only proves the route never diverges from production for this fixture.
+func assertGoCandidateMatchesProduction(t *testing.T, lang *gotreesitter.Language, src string, prodTree *gotreesitter.Tree) {
+	t.Helper()
+	prodSExpr := prodTree.RootNode().SExpr(lang)
+	gotreesitter.ResetAdmissionCandidateCountersForTest()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	candTree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("candidate parse failed: %v", err)
+	}
+	defer candTree.Release()
+	if got := candTree.RootNode().SExpr(lang); got != prodSExpr {
+		routed, fallback := gotreesitter.AdmissionCandidateCounters()
+		t.Fatalf("candidate route diverged from production (routed=%d fallback=%d):\n  production: %s\n  candidate:  %s",
+			routed, fallback, prodSExpr, got)
+	}
+}
+
 // assertNoErrorOrMissing walks the whole tree and fails the test if any
 // ERROR or MISSING node is found anywhere, printing the S-expression for
 // diagnosis. Modeled on the existing GoInterpretedStringFalseErrors /
@@ -330,14 +353,18 @@ func TestParseGoNewMakeGenericInstantiationUntouched(t *testing.T) {
 		"\t_ = a\n" +
 		"\t_ = b\n" +
 		"}\n"
-	// Pin to production: this asserts the production-engine Go tree shape against
-	// the tree-sitter-go C oracle. The Phase-3 admission flip surfaced a compact
-	// candidate-route divergence on `Foo[int](a)` (call_expression vs the correct
-	// type_conversion_expression); that known divergence is tracked separately by
-	// TestAdmissionCandidateGoTypeConversionKnownDivergence.
+	// Assert the production-engine Go tree shape against the tree-sitter-go C
+	// oracle. The Phase-3 admission flip surfaced a compact candidate-route
+	// divergence on `Foo[int](a)` (call_expression versus the correct
+	// type_conversion_expression); the compact route now fails closed on that
+	// conflict class (TestAdmissionCandidateGoTypeConversionFailsClosed). Because
+	// the fix is fail-closed, this fixture is re-routed through the candidate:
+	// the route must reproduce the production tree byte for byte, whether it
+	// routes or declines to production.
 	tree, lang := parseGoProduction(t, src)
 	root := tree.RootNode()
 	assertNoErrorOrMissing(t, lang, root, "generic-instantiation-untouched")
+	assertGoCandidateMatchesProduction(t, lang, src, tree)
 
 	if calls := findAllNodesOfType(lang, root, "call_expression"); len(calls) != 0 {
 		t.Fatalf("expected zero call_expression nodes for generic instantiation syntax, got %d; root=%s", len(calls), root.SExpr(lang))

--- a/parser_go_newmake_edge_test.go
+++ b/parser_go_newmake_edge_test.go
@@ -330,7 +330,12 @@ func TestParseGoNewMakeGenericInstantiationUntouched(t *testing.T) {
 		"\t_ = a\n" +
 		"\t_ = b\n" +
 		"}\n"
-	tree, lang := parseGo(t, src)
+	// Pin to production: this asserts the production-engine Go tree shape against
+	// the tree-sitter-go C oracle. The Phase-3 admission flip surfaced a compact
+	// candidate-route divergence on `Foo[int](a)` (call_expression vs the correct
+	// type_conversion_expression); that known divergence is tracked separately by
+	// TestAdmissionCandidateGoTypeConversionKnownDivergence.
+	tree, lang := parseGoProduction(t, src)
 	root := tree.RootNode()
 	assertNoErrorOrMissing(t, lang, root, "generic-instantiation-untouched")
 

--- a/parser_go_scanner_quiescence_test.go
+++ b/parser_go_scanner_quiescence_test.go
@@ -134,7 +134,11 @@ func TestGoScannerQuiescenceOracleSweep(t *testing.T) {
 
 	for name, src := range w4GoAdversarialFixtures() {
 		// A clean base parse is a fixture invariant.
+		// Pin to production: this sweep asserts incremental Go reuse across edits;
+		// a compact-materialized base tree is hard-barred from reuse (decision
+		// 0008), so the base parse must stay on the production engine.
 		baseParser := gts.NewParser(lang)
+		baseParser.SetAdmissionCandidateRoute(false)
 		baseTree, err := baseParser.Parse(src)
 		if err != nil {
 			t.Fatalf("%s: base parse: %v", name, err)
@@ -152,7 +156,10 @@ func TestGoScannerQuiescenceOracleSweep(t *testing.T) {
 				edited, edit := incrGateBuildEdit(src, off, class)
 
 				// Fresh parse of the edited text.
+				// Pin to production: this sweep compares production incremental
+				// reuse against a production fresh parse; keep both on production.
 				freshParser := gts.NewParser(lang)
+				freshParser.SetAdmissionCandidateRoute(false)
 				freshTree, err := freshParser.Parse(edited)
 				if err != nil {
 					t.Fatalf("%s/%s@%d: fresh parse: %v", name, class, off, err)
@@ -160,7 +167,10 @@ func TestGoScannerQuiescenceOracleSweep(t *testing.T) {
 				freshClean := w4TreeIsGenuinelyClean(freshTree.RootNode(), len(edited))
 
 				// Incremental parse from the edited old tree.
+				// Pin to production: a compact-materialized base tree is hard-barred
+				// from reuse (decision 0008), so the base parse must stay on production.
 				incrParser := gts.NewParser(lang)
+				incrParser.SetAdmissionCandidateRoute(false)
 				oldTree, err := incrParser.Parse(src)
 				if err != nil {
 					t.Fatalf("%s/%s@%d: old parse: %v", name, class, off, err)

--- a/parser_go_test.go
+++ b/parser_go_test.go
@@ -98,6 +98,35 @@ func parseGo(t *testing.T, src string) (*gotreesitter.Tree, *gotreesitter.Langua
 	return tree, lang
 }
 
+// parseGoProduction is parseGo pinned to the production route. Use it for tests
+// that assert a production-engine Go behavior (for example the go-newmake
+// normalization or a production-vs-C-oracle tree shape) whose reference tree
+// the compact candidate route does not reproduce identically.
+func parseGoProduction(t *testing.T, src string) (*gotreesitter.Tree, *gotreesitter.Language) {
+	t.Helper()
+	lang := grammars.GoLanguage()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	srcBytes := []byte(src)
+	var (
+		tree *gotreesitter.Tree
+		err  error
+	)
+	if _, ok := lang.SymbolByName("source_file_token1"); ok {
+		ts := mustGoTokenSource(t, srcBytes, lang)
+		tree, err = parser.ParseWithTokenSource(srcBytes, ts)
+	} else {
+		tree, err = parser.Parse(srcBytes)
+	}
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if tree.RootNode() == nil {
+		t.Fatal("parse returned nil root")
+	}
+	return tree, lang
+}
+
 func TestParseGoPackageOnly(t *testing.T) {
 	tree, lang := parseGo(t, "package main\n")
 	root := tree.RootNode()

--- a/parser_parsewith_test.go
+++ b/parser_parsewith_test.go
@@ -38,6 +38,10 @@ func TestParseWithProfilingFullParseSignalsUnavailable(t *testing.T) {
 func TestParseWithProfilingIncrementalSignalsAvailable(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
+	// Pin to production: the base tree must be reuse-eligible for the
+	// incremental profile signals. A compact-materialized base tree is
+	// hard-barred from reuse (decision 0008), zeroing those signals.
+	parser.SetAdmissionCandidateRoute(false)
 	oldSource := []byte("1+2")
 	newSource := []byte("1+3")
 

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -1394,6 +1394,9 @@ func collidingCNodeMemoNodes(t *testing.T, setCount int) (*Node, *Node, *Node) {
 
 func TestCNodeMemoEpochAdvancesAcrossParserParses(t *testing.T) {
 	p := NewParser(buildArithmeticLanguage())
+	// Pin to production: this test asserts a production-engine internal (the C
+	// recovery memo epoch), which the compact candidate route never advances.
+	p.SetAdmissionCandidateRoute(false)
 	p.errorCostCompetition = true
 
 	first, err := p.Parse([]byte("1"))

--- a/parser_recover_prefix_agg_test.go
+++ b/parser_recover_prefix_agg_test.go
@@ -280,6 +280,9 @@ func TestResetGSSPrefixPathClearsAndBoundsRetention(t *testing.T) {
 
 func TestParseFinalizationClearsPrefixPathPointers(t *testing.T) {
 	parser := NewParser(buildArithmeticLanguage())
+	// Pin to production: this test asserts a production-engine internal (the C
+	// recovery prefix-path pointer pool), which the compact route never uses.
+	parser.SetAdmissionCandidateRoute(false)
 	nodes := []*gssNode{{}, {}, {}}
 	parser.cPrefixPath = nodes[:1]
 

--- a/parser_runtime_test.go
+++ b/parser_runtime_test.go
@@ -13,6 +13,10 @@ func TestParseRuntimeReportsAcceptedOnCompleteParse(t *testing.T) {
 
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
+	// Pin to production: this test asserts production-engine runtime internals
+	// (iteration limits, arena accounting) the compact candidate route does not
+	// populate.
+	parser.SetAdmissionCandidateRoute(false)
 
 	tree := mustParse(t, parser, []byte("1+2"))
 	rt := tree.ParseRuntime()
@@ -1132,6 +1136,9 @@ func TestParseNoTreeBenchmarkDropsRetainedExternalCheckpointCapacity(t *testing.
 	lang.ExternalScanner = byteStateExternalScanner{}
 
 	fullParser := NewParser(lang)
+	// Pin to production: this test asserts a production-engine runtime internal
+	// (external scanner checkpoint allocation) the compact route does not report.
+	fullParser.SetAdmissionCandidateRoute(false)
 	fullTree, err := fullParser.Parse([]byte("1+2"))
 	if err != nil {
 		t.Fatalf("Parse() error = %v", err)

--- a/parsercore_phase0_canonical_admission_internal_test.go
+++ b/parsercore_phase0_canonical_admission_internal_test.go
@@ -111,12 +111,12 @@ var diagnosticParserCoreCanonicalAdmissions = []diagnosticParserCoreCanonicalAdm
 		rawSelected: core.RawSelectedCensus{Nodes: 109614, Parents: 59703, Leaves: 49911},
 		work: core.Work{
 			Shifts: 66119, Reductions: 75988, ReductionPopRequests: 75988,
-			EmittedPopPaths: 84924, EmittedPopPayloads: 153451,
-			PredecessorLinkUnionAttempts: 13748, PredecessorLinkUnionDuplicateNoop: 1638,
+			EmittedPopPaths: 84928, EmittedPopPayloads: 153463,
+			PredecessorLinkUnionAttempts: 13752, PredecessorLinkUnionDuplicateNoop: 1638,
 			PredecessorLinkUnionPrecedenceReplaced: 3577, PredecessorLinkUnionRecursiveChanged: 7,
-			PredecessorLinkUnionAlternateAppended: 8526,
-			GraphLinkAdditionsProxy:               150271, LeafConstructionsProxy: 53897,
-			ParentConstructionsProxy: 78426,
+			PredecessorLinkUnionAlternateAppended: 8530,
+			GraphLinkAdditionsProxy:               150275, LeafConstructionsProxy: 53897,
+			ParentConstructionsProxy: 78430,
 		},
 	},
 }

--- a/parsercore_phase0_compileout_test.go
+++ b/parsercore_phase0_compileout_test.go
@@ -1,14 +1,22 @@
-//go:build !gts_parsercorephase0 && !gts_workcount
+//go:build gts_no_parsercorephase0 && !gts_workcount
 
 package gotreesitter
 
 import (
 	"bytes"
+	"context"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
-func TestParserCorePhaseZeroDriverCompilesOutOfOrdinaryBuild(t *testing.T) {
-	binary := buildProductionTestBinary(t)
+// TestParserCorePhaseZeroDriverCompilesOutOfEmergencyBuild proves the emergency
+// opt-out tag gts_no_parsercorephase0 compiles the compact parser-core engine
+// back out of the binary. Phase-3 admission promoted the engine into the
+// default build; this test guards the escape hatch that removes it entirely.
+func TestParserCorePhaseZeroDriverCompilesOutOfEmergencyBuild(t *testing.T) {
+	binary := buildEmergencyOptOutTestBinary(t)
 	symbols := runGoTool(t, "nm", binary)
 	for _, forbidden := range [][]byte{
 		[]byte("DiagnosticParseParserCorePrefix"),
@@ -16,7 +24,25 @@ func TestParserCorePhaseZeroDriverCompilesOutOfOrdinaryBuild(t *testing.T) {
 		[]byte("internal/parsercorephase0.(*Core)"),
 	} {
 		if bytes.Contains(symbols, forbidden) {
-			t.Fatalf("ordinary binary retains tagged parser-core driver symbol %q", forbidden)
+			t.Fatalf("emergency opt-out binary retains tagged parser-core driver symbol %q", forbidden)
 		}
 	}
+}
+
+// buildEmergencyOptOutTestBinary compiles a test binary with the emergency
+// opt-out tag so the assertion above verifies the compact engine is absent.
+func buildEmergencyOptOutTestBinary(t *testing.T) string {
+	t.Helper()
+	binary := filepath.Join(t.TempDir(), "gotreesitter.optout.test")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, "go", "test", "-c", "-tags", "gts_no_parsercorephase0", "-o", binary, ".")
+	output, err := command.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("build emergency opt-out test binary: %v", ctx.Err())
+	}
+	if err != nil {
+		t.Fatalf("build emergency opt-out test binary: %v\n%s", err, output)
+	}
+	return binary
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1,4 +1,4 @@
-//go:build gts_parsercorephase0
+//go:build !gts_no_parsercorephase0
 
 package gotreesitter
 

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -1,4 +1,4 @@
-//go:build gts_parsercorephase0
+//go:build !gts_no_parsercorephase0
 
 package gotreesitter
 

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -1,4 +1,4 @@
-//go:build gts_parsercorephase0
+//go:build !gts_no_parsercorephase0
 
 package gotreesitter
 

--- a/pointer_light_measurement_test.go
+++ b/pointer_light_measurement_test.go
@@ -122,6 +122,9 @@ func TestPointerLightBytesPerNode(t *testing.T) {
 
 	for _, wl := range pointerLightWorkloads(t) {
 		parser := gotreesitter.NewParser(lang)
+		// Pin to production: this measurement asserts production-engine arena
+		// breakdown internals the compact candidate route does not report.
+		parser.SetAdmissionCandidateRoute(false)
 		tree, err := parser.Parse(wl.src)
 		if err != nil {
 			t.Fatalf("[%s] parse error: %v", wl.name, err)

--- a/raw_shape_elision_test.go
+++ b/raw_shape_elision_test.go
@@ -252,6 +252,7 @@ func TestRawShapeElisionDifferentialPrefixThenFork(t *testing.T) {
 //     exactly the pre/post-flatten mismatch compareRawStackEntriesRec's
 //     one-sided-shape fallback (parser_reduce.go's aHasShape != bHasShape
 //     branch) has to resolve without inventing an answer.
+//
 //   - the two fork alternatives (A, B) are wrapped by two separate unary
 //     productions into the SAME shared root symbol "Top", so the two
 //     accepted stacks being compared for final result selection literally
@@ -259,11 +260,11 @@ func TestRawShapeElisionDifferentialPrefixThenFork(t *testing.T) {
 //     compareAcceptedStackRawShapePreference to descend at least one level
 //     instead of returning at depth 0.
 //
-//	_hidden -> x x        (production 0, 2 children, invisible)
-//	pre     -> _hidden     (production 1, 1 child)   -- single-stack, elided
-//	A       -> pre x        (production 2, 2 children)
-//	B       -> pre x        (production 3, 2 children)
-//	Top     -> A y  |  Top -> B y   (production 4, 2 children each, same symbol)
+//     _hidden -> x x        (production 0, 2 children, invisible)
+//     pre     -> _hidden     (production 1, 1 child)   -- single-stack, elided
+//     A       -> pre x        (production 2, 2 children)
+//     B       -> pre x        (production 3, 2 children)
+//     Top     -> A y  |  Top -> B y   (production 4, 2 children each, same symbol)
 //
 // Feeding "x x x y" builds "pre" deterministically while singleStackMode is
 // true (two x's fold into _hidden, then pre wraps _hidden), consumes a third
@@ -303,24 +304,24 @@ func buildPrefixForkHiddenChildLanguage() *Language {
 		FieldNames: []string{""},
 
 		ParseActions: []ParseActionEntry{
-			{Actions: nil},                                                                                  // 0: error
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},                                    // 1: S0 col x
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},                                    // 2: S0 col _hidden (goto)
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},                                    // 3: S0 col pre (goto)
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 6}}},                                    // 4: S0 col A (goto)
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 7}}},                                    // 5: S0 col B (goto)
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 9}}},                                    // 6: S0 col Top (goto)
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},                                    // 7: S1 col x (second x)
+			{Actions: nil}, // 0: error
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 1}}},                                   // 1: S0 col x
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 3}}},                                   // 2: S0 col _hidden (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 4}}},                                   // 3: S0 col pre (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 6}}},                                   // 4: S0 col A (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 7}}},                                   // 5: S0 col B (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 9}}},                                   // 6: S0 col Top (goto)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 2}}},                                   // 7: S1 col x (second x)
 			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 3, ChildCount: 2, ProductionID: 0}}}, // 8: S2 reduce _hidden -> x x
 			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 4, ChildCount: 1, ProductionID: 1}}}, // 9: S3 reduce pre -> _hidden
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},                                    // 10: S4 col x (third x)
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 5}}},                                   // 10: S4 col x (third x)
 			{Actions: []ParseAction{ // 11: S5 col y -- GLR reduce/reduce fork
 				{Type: ParseActionReduce, Symbol: 5, ChildCount: 2, ProductionID: 2, DynamicPrecedence: 0},
 				{Type: ParseActionReduce, Symbol: 6, ChildCount: 2, ProductionID: 3, DynamicPrecedence: 0},
 			}},
-			{Actions: []ParseAction{{Type: ParseActionShift, State: 8}}},                                    // 12: S6/S7 col y
+			{Actions: []ParseAction{{Type: ParseActionShift, State: 8}}},                                   // 12: S6/S7 col y
 			{Actions: []ParseAction{{Type: ParseActionReduce, Symbol: 7, ChildCount: 2, ProductionID: 4}}}, // 13: S8 reduce Top -> (A|B) y
-			{Actions: []ParseAction{{Type: ParseActionAccept}}},                                             // 14: S9 accept
+			{Actions: []ParseAction{{Type: ParseActionAccept}}},                                            // 14: S9 accept
 		},
 
 		// Columns: EOF(0), x(1), y(2), _hidden(3), pre(4), A(5), B(6), Top(7)
@@ -365,7 +366,11 @@ func buildPrefixForkHiddenChildLanguage() *Language {
 // effect (2 materialized children under "pre", not 1).
 func TestPrefixForkHiddenChildLanguageActuallyForks(t *testing.T) {
 	lang := buildPrefixForkHiddenChildLanguage()
-	tree := mustParse(t, NewParser(lang), []byte("x x x y"))
+	// Pin to production: this test asserts a production-engine GSS internal
+	// (MaxStacksSeen fork count) the compact candidate route does not populate.
+	parser := NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree := mustParse(t, parser, []byte("x x x y"))
 	defer tree.Release()
 
 	rt := tree.ParseRuntime()
@@ -416,14 +421,20 @@ func TestRawShapeElisionDifferentialPrefixThenForkSharedRootSymbol(t *testing.T)
 	lang := buildPrefixForkHiddenChildLanguage()
 	source := []byte("x x x y")
 
+	// Pin to production: this test asserts production-engine GSS internals
+	// (MaxStacksSeen fork count) the compact candidate route does not populate.
 	SetRawShapeElisionDisabledForDiagnostics(false)
-	gateOn := mustParse(t, NewParser(lang), source)
+	gateOnParser := NewParser(lang)
+	gateOnParser.SetAdmissionCandidateRoute(false)
+	gateOn := mustParse(t, gateOnParser, source)
 	defer gateOn.Release()
 	gateOnRuntime := gateOn.ParseRuntime()
 
 	SetRawShapeElisionDisabledForDiagnostics(true)
 	defer SetRawShapeElisionDisabledForDiagnostics(false)
-	gateOff := mustParse(t, NewParser(lang), source)
+	gateOffParser := NewParser(lang)
+	gateOffParser.SetAdmissionCandidateRoute(false)
+	gateOff := mustParse(t, gateOffParser, source)
 	defer gateOff.Release()
 	gateOffRuntime := gateOff.ParseRuntime()
 

--- a/raw_shape_reclaim_test.go
+++ b/raw_shape_reclaim_test.go
@@ -129,7 +129,11 @@ func TestParseReclaimsRawShapeStorageAccountsForZeroOnSingleStackParse(t *testin
 	defer EnableArenaBreakdown(false)
 
 	lang := buildArithmeticLanguage()
-	tree := mustParse(t, NewParser(lang), []byte("1+2+3+4"))
+	// Pin to production: this test asserts a production-engine internal (arena
+	// raw-shape reclaim breakdown) the compact candidate route does not report.
+	parser := NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree := mustParse(t, parser, []byte("1+2+3+4"))
 	defer tree.Release()
 
 	rt := tree.ParseRuntime()


### PR DESCRIPTION
## Summary

Make the compact parser core the default full-parse route for eligible languages. Keep the production route as a fail-closed fallback. Preserve the `GTS_ADMISSION_CANDIDATE=0` escape hatch and the large-input memory-budget contract.

## Changes

- Make compact admission default-on.
- Replace the opt-in build tag with the `gts_no_parsercorephase0` emergency opt-out tag.
- Decline inputs at or above the 64 KiB automatic memory-budget floor.
- Keep incremental, custom-input, recovery, and unsupported conflict paths on production.
- Fail closed on the Go generic-call versus type-conversion conflict.
- Preserve exact public-tree normalization and stop reasons.
- Merge current `main` and align admission-census instrumentation with the default build.

## Evidence

- The 206-language scorecard reports 48 compact routes, 153 fail-closed fallbacks, 5 skips, and 0 divergences.
- Focused admission and compact-core tests pass.
- The `gts_no_parsercorephase0` emergency build tests pass.
- Isolated Go real-corpus parity passes 5 of 5 for no-error, S-expression, and deep-tree parity.
- The CGo smoke failure in CI is a Docker Hub timeout. It is not a parser result.
- The current synthetic full-parse benchmark regression remains visible. PR #424 removes the adapter allocation tax.

## Review focus

Review the 64 KiB size gate, the fail-closed conflict behavior, and the emergency opt-out build.