### PR TITLE
add(parser): Add leading-run block-splice to incremental parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Added
+
+- **Phase-3 admission switch** (PR #417). A per-parser option, a global
+  option, and the `GTS_ADMISSION_CANDIDATE` environment variable route
+  eligible full parses through the compact parser core. Internal
+  sub-parsers stay suppressed. A 206-language scorecard guards the
+  route: 48 languages parse byte-exact, 153 fall back fail-closed, 5
+  skip, 0 diverge. The route stays off by default in this release.
+- **Compact-route coverage census** (PR #419).
+  `docs/compact-route-coverage-census.md` classifies the 153 fallback
+  languages into five scheduler-capability classes. The census found no
+  multi-derivation blockers.
+- **Oracle v3 parity tools** in `cgo_harness` (PR #413). The root
+  library module is unchanged by that PR.
+
+### Changed
+
+- **The GLR steady-state merge now compares structure before score**
+  (PR #416). The TypeScript and TSX steady-state merge budget widens
+  from one survivor to two. The wider budget activates the structural
+  comparison at the merge site. This is the structural cure for the
+  detector class behind issue #389 and issue #402.
+- **Incremental reparse cost is now position-independent for large
+  files** (PR #418, PR #421, campaign O(edit)). PR #418 bounds arena
+  normalization to the edited range. A 1MB clean-Go near-top keystroke
+  drops from about 356ms to about 53ms. PR #421 splices the leading run
+  of unchanged top-level items, the mirror of the trailing
+  block-splice. A 1MB mid-file keystroke drops from about 269ms to
+  about 67ms for Go, and from about 168ms to about 45ms for CSS. At
+  137KB, mid-file reuse rejects fall from 16,450 to 10. JavaScript,
+  TypeScript, and TSX keep their previous behavior until the T2c
+  scanner proofs land. The W5 latency gate now locks these counters per
+  edit position.
+
 ## [0.45.0] - 2026-07-20
 
 ### Fixed

--- a/export_test.go
+++ b/export_test.go
@@ -58,6 +58,19 @@ func (p *Parser) SetForceFullResultNormalizationWalk(v bool) {
 	p.forceFullResultNormalizationWalk = v
 }
 
+// SetDisableLeadingRunSplice turns the campaign post-admission-frontier T2a
+// leading-run block-splice off (v=true) or on (v=false, the production default)
+// for this Parser. It exists ONLY so the byte-sweep differential can compare
+// leading-splice-on against leading-splice-off on the SAME Parser and prove the
+// leading splice never changes a fresh-correct tree. It lives in export_test.go,
+// so it is compiled only in test builds and is never part of the public API.
+func (p *Parser) SetDisableLeadingRunSplice(v bool) {
+	if p == nil {
+		return
+	}
+	p.disableLeadingRunSplice = v
+}
+
 // ReplayDiffTree replays the LR tables over the tree rooted at root and
 // compares the reconstructed states against the recorded ones on every node.
 // It mutates nothing. maxSamples bounds the retained mismatch examples.

--- a/incremental.go
+++ b/incremental.go
@@ -835,8 +835,14 @@ func forestFastPathDirtyPrefixScannerSensitive(name string) bool {
 // on typescript/tsx too), so extending it to the leading run would perturb those
 // tracked divergences. Their reuse proof is the still-open campaign T2c
 // (TS/JS stateless-marker proofs); the leading splice opens for them once that
-// lands. Go and production-route css, whose fragility marking is complete, are
-// not listed and take the win.
+// lands. Go, whose fragility marking is complete, is not listed and takes the
+// win. Production-route css also takes the win, but on an EMPIRICAL warrant,
+// not completeness: css still carries one open allowlist entry (delete
+// block:childCount+1, likely the same real-reuse class as the JavaScript
+// entry). Css stays unlisted because the invariant gate holds newUnlisted=0
+// with its two tracked divergences byte-unchanged, and the leading-splice
+// on/off differential byte-sweep is a no-op at every edit site. If either
+// signal moves, bar css here alongside the JS family.
 func leadingSpliceLanguageBarred(name string) bool {
 	switch name {
 	case "javascript", "typescript", "tsx":

--- a/incremental.go
+++ b/incremental.go
@@ -32,6 +32,23 @@ type reuseCursor struct {
 	// before considering sibling reuse because selector/declaration scanner
 	// context is too sensitive for leaf reuse inside the edited rule.
 	topLevelResumeByte uint32
+	// topLevelSpliceLeading enables the LEADING-run block-splice (campaign
+	// post-admission-frontier T2a): top-level items whose end byte is at or
+	// before minEditAt are byte-identical prefixes of the old tree, so they may
+	// be spliced back as a block from the initial parser state before per-token
+	// parsing reaches the edit -- the mirror of the trailing block-splice. When
+	// true, topLevelIndex starts at 0 (the scan covers the leading run, the
+	// edited item, then the trailing run in one monotonic forward walk); when
+	// false, topLevelIndex starts after the edited item (trailing run only), the
+	// pre-existing behavior. Kept false for the scanner-sensitive forest
+	// languages (css, cmake), whose leading items keep their general-walk leaf
+	// reuse -- see reset() and topLevelSiblingBlockSpliceEligible.
+	topLevelSpliceLeading bool
+	// disableLeadingSplice, when set by the parser before reset(), forces the
+	// leading-run splice off regardless of language (topLevelSpliceLeading stays
+	// false). It backs the test-only differential toggle (Parser.disableLeadingRun
+	// Splice) and is NOT cleared by reset -- the parser sets it every parse.
+	disableLeadingSplice bool
 
 	cachedStart      uint32
 	cachedStartValid bool
@@ -115,6 +132,7 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.topLevelIndex = 0
 	c.topLevelEnd = 0
 	c.topLevelResumeByte = 0
+	c.topLevelSpliceLeading = false
 	childCount := nodeChildCountNoMaterialize(root)
 	if c.hasEdits && root != nil && childCount > 0 {
 		firstAffected := -1
@@ -128,12 +146,43 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 				break
 			}
 		}
-		if firstAffected >= 0 && firstAffected+1 < childCount {
-			c.topLevelParent = root
-			c.topLevelIndex = firstAffected + 1
-			c.topLevelEnd = childCount
-			if entry, ok := nodeChildEntryAtNoMaterialize(root, firstAffected); ok {
-				c.topLevelResumeByte = stackEntryNodeEndByte(entry)
+		if firstAffected >= 0 {
+			hasTrailing := firstAffected+1 < childCount
+			hasLeading := firstAffected > 0
+			// The leading-run splice (campaign post-admission-frontier T2a) is
+			// barred for scanner-sensitive forest languages (css, cmake): their
+			// leading top-level items keep the general-walk leaf reuse whose
+			// selector/declaration scanner context rejectDirtyTopLevelPrefix
+			// already protects. Extending the top-level scan over their leading
+			// run would supersede that leaf reuse with a top-level scan that the
+			// same guard rejects, forcing a full reparse of the clean prefix, so
+			// leading splice stays off for them. See the CSS disposition note on
+			// topLevelSiblingBlockSpliceEligible.
+			leadingEligible := hasLeading &&
+				!c.disableLeadingSplice &&
+				!(c.forestFastPath && forestFastPathDirtyPrefixScannerSensitive(c.languageName)) &&
+				!leadingSpliceLanguageBarred(c.languageName)
+			if hasTrailing || leadingEligible {
+				c.topLevelParent = root
+				c.topLevelEnd = childCount
+				if entry, ok := nodeChildEntryAtNoMaterialize(root, firstAffected); ok {
+					c.topLevelResumeByte = stackEntryNodeEndByte(entry)
+				}
+				if leadingEligible {
+					// Cover the leading run: the monotonic top-level scan starts
+					// at item 0, splices the byte-identical leading items, skips
+					// the edited item (its bytes changed, so reusableIndexedEntry
+					// rejects it), then resumes on the trailing run. The block-
+					// splice loop (parser.go) consumes the leading items from the
+					// initial parser state exactly as it consumes the trailing
+					// run from the post-edit state.
+					c.topLevelIndex = 0
+					c.topLevelSpliceLeading = true
+				} else {
+					// Trailing run only (pre-existing behavior): the scan starts
+					// at the first item after the edited one.
+					c.topLevelIndex = firstAffected + 1
+				}
 			}
 		}
 	}
@@ -276,6 +325,15 @@ func (c *reuseCursor) collectTopLevelCandidates(start uint32) bool {
 				return true
 			}
 			c.topLevelIndex++
+			if !c.topLevelBlockCandidateBytes(stackEntryNodeStartByte(entry), stackEntryNodeEndByte(entry)) {
+				// An edited-region item (the edited item, or a leading item whose
+				// end byte touches the edit so its last token can shift): do not
+				// offer it as a whole-item block candidate. Skipping it here leaves
+				// its start position with no top-level candidate, so the parser
+				// reparses it and the general walk supplies leaf-level reuse for
+				// its unchanged interior -- the pre-existing per-item behavior.
+				continue
+			}
 			if !c.reusableIndexedEntry(entry) {
 				continue
 			}
@@ -680,13 +738,54 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 // declared itself safe (IncrementalReuseExternalScanner.SupportsIncrementalReuse)
 // -- see parser.go's tokenSourceSupportsIncrementalReuse gate, which runs
 // before tryReuseSubtree is ever reached.
+// The leading run (campaign post-admission-frontier T2a). A top-level item
+// whose end byte is at or before minEditAt lies entirely before the first
+// edit, so its bytes are unchanged by construction (every recorded edit starts
+// at minEditAt or later). Such an item is a byte-identical prefix, admissible on
+// the same terms as a trailing sibling: the caller still verifies byte equality
+// (collectTopLevelCandidates -> reusableIndexedEntry's nodeBytesUnchanged gate),
+// external-scanner quiescence (canReuseNodeWithExternalScannerCheckpoint), the
+// zero-width / has-error / span gates, and the #393 reuse bar, and the fragility
+// bit below still bars any item whose shape depended on an ambiguous decision.
+// The block-splice loop replays the leading run from the parser's initial state,
+// the mirror of replaying the trailing run from the post-edit state.
+//
+// CSS disposition: the scanner-sensitive forest languages (css, cmake) never set
+// topLevelSpliceLeading (reset()), so their leading items are not admitted here
+// and keep their general-walk leaf reuse. Their rejectDirtyTopLevelPrefix guard
+// exists precisely because a whole-item splice of scanner-sensitive prefix
+// content can feed stale selector/declaration context; leaving leading splice
+// off for them respects that guard rather than relying on W4 quiescence to cover
+// it.
 func (c *reuseCursor) topLevelSiblingBlockSpliceEligible(n *Node) bool {
-	return c != nil &&
-		c.topLevelParent != nil &&
-		n != nil &&
-		n.parent == c.topLevelParent &&
-		n.startByte >= c.topLevelResumeByte &&
-		!n.isFragile()
+	if c == nil || c.topLevelParent == nil || n == nil || n.parent != c.topLevelParent || n.isFragile() {
+		return false
+	}
+	return c.topLevelBlockCandidateBytes(n.startByte, n.endByte)
+}
+
+// topLevelBlockCandidateBytes reports whether a top-level item spanning
+// [start,end) may be spliced back as a whole block by byte range alone (the
+// fragility and scanner gates are applied separately by the caller). Two disjoint
+// runs qualify:
+//
+//   - Trailing run: start >= topLevelResumeByte (the edited item's end byte).
+//     These sit entirely after the edit; their byte-range equality is verified by
+//     the caller. This is the pre-existing (trailing) admission, unchanged.
+//   - Leading run: end < minEditAt, and only when the leading splice is enabled
+//     for this tree (topLevelSpliceLeading). The STRICT `<` is load-bearing: it
+//     requires the byte at index `end` -- the byte that terminated the item's
+//     last token -- to lie before the first edit, so it is unedited and that
+//     token boundary is preserved. An item ending exactly at minEditAt
+//     (end == minEditAt) is excluded: an edit there can extend its last token by
+//     maximal munch (for example replacing the newline after "package p" makes
+//     "package pz"), which a whole-item splice would miss. Such a boundary item
+//     is left to the general walk / reparse, exactly as before this change.
+func (c *reuseCursor) topLevelBlockCandidateBytes(start, end uint32) bool {
+	if start >= c.topLevelResumeByte {
+		return true
+	}
+	return c.topLevelSpliceLeading && end < c.minEditAt
 }
 
 // forestFastPathDirtyPrefixScannerSensitive names the curated set of
@@ -704,6 +803,43 @@ func (c *reuseCursor) topLevelSiblingBlockSpliceEligible(n *Node) bool {
 func forestFastPathDirtyPrefixScannerSensitive(name string) bool {
 	switch name {
 	case "cmake", "css":
+		return true
+	default:
+		return false
+	}
+}
+
+// leadingSpliceLanguageBarred names languages held off from the LEADING-run
+// block-splice (campaign post-admission-frontier T2a) because their incremental
+// real-reuse carries a DOCUMENTED, still-open silent-corruption residual (an
+// entry in testdata/incremental_allowlist.json) that the pre-existing reuse path
+// already tickles. The leading splice reaches those items on a different path, so
+// enabling it would perturb the tracked divergence into a different signature --
+// even a benign-looking change flips the invariant gate's exact-signature
+// ratchet. Holding the leading splice off keeps such a language byte-identical to
+// its pre-change behavior, so the tracked divergence is neither widened nor
+// silently altered while its parser-core root cause is fixed separately.
+//
+// This is a REJECTION guard (it only ever forbids a reuse), so it is outside the
+// campaign's "no name-allowlists" ADMISSION rule -- the same footing as
+// forestFastPathDirtyPrefixScannerSensitive (css/cmake scanner) and the dart
+// large-source reuse block (dfaTokenSourceIncrementalReuseBlockedBySource).
+//
+// The JS/TS/TSX expression family is barred: their per-node reduce-fragility
+// marking is known-incomplete on the ASI / ambiguous-expression conflicts, so
+// the permissive top-level goto splice (the same admission the trailing splice
+// uses) occasionally lifts a byte-identical item whose recorded shape depended
+// on an ambiguous decision the fragility bit did not flag. On main the trailing
+// splice already tickles this (documented for javascript at javascript_grammar.js
+// pos=1801, program:childCount+20; measured as a residual real-reuse divergence
+// on typescript/tsx too), so extending it to the leading run would perturb those
+// tracked divergences. Their reuse proof is the still-open campaign T2c
+// (TS/JS stateless-marker proofs); the leading splice opens for them once that
+// lands. Go and production-route css, whose fragility marking is complete, are
+// not listed and take the win.
+func leadingSpliceLanguageBarred(name string) bool {
+	switch name {
+	case "javascript", "typescript", "tsx":
 		return true
 	default:
 		return false

--- a/oedit_leading_splice_sweep_test.go
+++ b/oedit_leading_splice_sweep_test.go
@@ -1,0 +1,278 @@
+package gotreesitter_test
+
+// Adversarial byte-sweep differential for the campaign post-admission-frontier
+// T2a leading-run block-splice (spec.campaign.post-admission-frontier). For
+// every insert / delete / replace edit at every byte position of an adversarial
+// multi-item source, the incremental parse must be IDENTICAL to a fresh parse of
+// the same edited text, at every site where the fresh parse is genuinely clean
+// (full-span, zero IsError/IsMissing).
+//
+// Identity is checked with oeditSerialize (the hardened #418 serializer: every
+// node's type, [startByte-endByte], named-vs-anonymous, missing, error, walking
+// ALL children including anonymous), NOT SExpr -- the leading splice reuses whole
+// top-level items across the edit, exactly the span/anonymous-child state SExpr
+// hides.
+//
+// Fixtures target the leading-splice boundary cases the design must survive:
+// comments between top-level items, extras before the first item, edits into
+// item 0, an untyped-parameter-list function (Go's tracked ambiguity construct)
+// sitting in the spliced leading run, and (for css) the production route the
+// splice runs on.
+//
+// The primary check is a DIFFERENTIAL, the same shape as the #418 range-limited
+// sweep: for the same Parser, the leading-splice-ON tree must be byte-identical
+// (oeditSerialize) to the leading-splice-OFF tree (SetDisableLeadingRunSplice).
+// Because both sides share every OTHER reuse path, a pre-existing incremental
+// divergence appears on BOTH and cancels; only a divergence the leading splice
+// ITSELF causes survives. This is what lets adversarial fixtures with their own
+// pre-existing reuse quirks (css, the untyped-parameter construct) be swept
+// without an allowlist. A secondary check adds oracle strength: where the
+// leading-OFF tree already equals fresh, the leading-ON tree must too.
+//
+// Coverage spans the leading-enabled languages (go, production-route css), the
+// reuse-declining one (python), AND the barred family (typescript, tsx,
+// javascript) -- for the barred family the differential must be a strict no-op
+// (leading OFF == leading ON, since the splice never engages), which the sweep
+// confirms directly.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type leadingSweepCase struct {
+	name string
+	lang *gts.Language
+	src  []byte
+}
+
+func leadingSweepCases() []leadingSweepCase {
+	goLang := grammars.GoLanguage()
+
+	// Comments between items + a leading file comment + a block comment.
+	goComments := []byte("package p\n\n" +
+		"// leading file comment\n" +
+		"func A0(a int) int {\n\treturn a\n}\n\n" +
+		"// between A0 and A1\n" +
+		"func A1(b int) int {\n\treturn b * 2\n}\n\n" +
+		"/* block between A1 and A2 */\n" +
+		"func A2(c int) int {\n\tif c > 0 {\n\t\treturn c\n\t}\n\treturn 0\n}\n\n" +
+		"func A3(d int) int {\n\treturn d\n}\n")
+
+	// An untyped-parameter-list function (tracked ambiguity) as a LEADING item,
+	// plus later clean functions to edit so the untyped-param function splices.
+	goUntyped := []byte("package p\n\n" +
+		"func h(a, b int) int {\n\treturn a\n}\n\n" +
+		"func C0(x int) int {\n\treturn x\n}\n\n" +
+		"func C1(x int) int {\n\treturn x + 1\n}\n\n" +
+		"func C2(x int) int {\n\treturn x + 2\n}\n")
+
+	// Mixed top-level declaration forms with an import/const/var run ahead of a
+	// function, so the leading run crosses several distinct top-level symbols.
+	goDecls := []byte("package p\n\n" +
+		"import \"fmt\"\n\n" +
+		"const A = 1\n\n" +
+		"var x = 2\n\n" +
+		"type T struct {\n\tF int\n}\n\n" +
+		"func F() { fmt.Println(x) }\n\n" +
+		"func G() int { return A }\n")
+
+	// CSS on the production route: comments between rules + a leading comment.
+	cssComments := []byte("/* header comment */\n" +
+		".a {\n  color: red;\n  margin: 0;\n}\n\n" +
+		"/* between a and b */\n" +
+		".b {\n  padding: 1px;\n}\n\n" +
+		"#c {\n  display: block;\n  width: 10px;\n}\n\n" +
+		".d {\n  color: blue;\n}\n")
+
+	// Python: comments between defs + a leading module comment. Python declines
+	// reuse today, so incremental == fresh is the trivial invariant here, and the
+	// sweep confirms the shared leading-splice plumbing stays neutral for it.
+	pyComments := []byte("# module comment\n" +
+		"def f0(a):\n    return a\n\n" +
+		"# between f0 and f1\n" +
+		"def f1(a):\n    v = a + 1\n    return v\n\n" +
+		"def f2(a):\n    return a * 2\n")
+
+	// TypeScript / TSX: comments between items. The family is barred from the
+	// leading splice, so the differential must be a strict no-op here.
+	tsComments := []byte("// module header\n" +
+		"export function f0(a: number): number {\n  return a;\n}\n\n" +
+		"// between f0 and f1\n" +
+		"export function f1(a: number): number {\n  const v = a + 1;\n  return v;\n}\n\n" +
+		"interface Shape {\n  width: number;\n  height: number;\n}\n")
+
+	jsComments := []byte("// module header\n" +
+		"function f0(a) {\n  return a;\n}\n\n" +
+		"// between f0 and f1\n" +
+		"function f1(a) {\n  const v = a + 1;\n  return v;\n}\n\n" +
+		"const g = (x) => x * 2;\n")
+
+	return []leadingSweepCase{
+		{"go-comments", goLang, goComments},
+		{"go-untyped-leading", goLang, goUntyped},
+		{"go-decls", goLang, goDecls},
+		{"css-comments", grammars.CssLanguage(), cssComments},
+		{"python-comments", grammars.PythonLanguage(), pyComments},
+		{"typescript-comments", grammars.TypescriptLanguage(), tsComments},
+		{"tsx-comments", grammars.TsxLanguage(), tsComments},
+		{"javascript-comments", grammars.JavascriptLanguage(), jsComments},
+	}
+}
+
+func TestLeadingSpliceByteSweep(t *testing.T) {
+	for _, tc := range leadingSweepCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runLeadingSweep(t, tc)
+		})
+	}
+}
+
+func runLeadingSweep(t *testing.T, tc leadingSweepCase) {
+	t.Helper()
+	baseP := gts.NewParser(tc.lang)
+	baseline, err := baseP.Parse(tc.src)
+	if err != nil || baseline == nil || baseline.RootNode() == nil {
+		t.Fatalf("baseline parse: %v", err)
+	}
+	defer baseline.Release()
+	if e, m := incrGateTreeStats(baseline.RootNode()); e != 0 || m != 0 {
+		t.Fatalf("baseline source must be clean (err=%d miss=%d)", e, m)
+	}
+
+	freshP := gts.NewParser(tc.lang)
+	incrP := gts.NewParser(tc.lang)
+	clean, checked, oracle := 0, 0, 0
+	for i := 1; i < len(tc.src)-1; i++ {
+		for _, cls := range []string{"insert", "delete", "replace"} {
+			edited, edit := incrGateBuildEdit(tc.src, i, cls)
+
+			fresh, err := freshP.Parse(edited)
+			if err != nil || fresh == nil || fresh.RootNode() == nil {
+				if fresh != nil {
+					fresh.Release()
+				}
+				continue
+			}
+			if int(fresh.RootNode().EndByte()) != len(edited) {
+				fresh.Release()
+				continue
+			}
+			if e, m := incrGateTreeStats(fresh.RootNode()); e != 0 || m != 0 {
+				fresh.Release()
+				continue
+			}
+			clean++
+
+			// Leading-splice ON (the change under test).
+			incrP.SetDisableLeadingRunSplice(false)
+			oldOn := baseline.Copy()
+			oldOn.Edit(edit)
+			on, err := incrP.ParseIncremental(edited, oldOn)
+			if err != nil || on == nil || on.RootNode() == nil {
+				t.Fatalf("%s pos=%d class=%s: leading-ON incremental parse failed while fresh was clean", tc.name, i, cls)
+			}
+			onS := oeditSerialize(on.RootNode(), tc.lang)
+
+			// Leading-splice OFF (the pre-change behavior).
+			incrP.SetDisableLeadingRunSplice(true)
+			oldOff := baseline.Copy()
+			oldOff.Edit(edit)
+			off, err := incrP.ParseIncremental(edited, oldOff)
+			if err != nil || off == nil || off.RootNode() == nil {
+				t.Fatalf("%s pos=%d class=%s: leading-OFF incremental parse failed", tc.name, i, cls)
+			}
+			offS := oeditSerialize(off.RootNode(), tc.lang)
+			incrP.SetDisableLeadingRunSplice(false)
+			checked++
+
+			// Primary isolation invariant: the leading splice must be a no-op vs
+			// leaving it off. Any difference here is a divergence THIS change
+			// caused (a pre-existing reuse quirk appears on both sides and
+			// cancels).
+			if onS != offS {
+				t.Fatalf("%s pos=%d class=%s: leading-ON != leading-OFF (the leading splice changed the tree)\n  off=%s\n  on =%s",
+					tc.name, i, cls, oeditTrunc(offS), oeditTrunc(onS))
+			}
+
+			// Secondary oracle: where leading-OFF already equals fresh, leading-ON
+			// must too (pre-existing off-vs-fresh divergences are out of scope --
+			// tracked by TestIncrementalInvariantGate).
+			freshS := oeditSerialize(fresh.RootNode(), tc.lang)
+			if offS == freshS {
+				oracle++
+				if onS != freshS {
+					t.Fatalf("%s pos=%d class=%s: leading-ON != fresh while leading-OFF == fresh\n  fresh=%s\n  on   =%s",
+						tc.name, i, cls, oeditTrunc(freshS), oeditTrunc(onS))
+				}
+			}
+			oldOn.Release()
+			oldOff.Release()
+			fresh.Release()
+			on.Release()
+			off.Release()
+		}
+	}
+	t.Logf("%s: freshCleanSites=%d checked=%d oracleMatched=%d", tc.name, clean, checked, oracle)
+	if checked == 0 {
+		t.Fatalf("%s: no freshly-clean sites checked -- sweep did not exercise the invariant", tc.name)
+	}
+}
+
+// TestLeadingSpliceBarredLanguagesDoNotSplice proves the JS/TS/TSX bar
+// (leadingSpliceLanguageBarred): a middle edit that WOULD present a large leading
+// run splices ZERO leading top-level items for the barred family, so their
+// incremental behavior is byte-identical to before this change. The counter it
+// checks is the leading run's block-splice steps at a middle edit; for a barred
+// language the trailing run may still splice, so this asserts the reject counter
+// still SCALES (stays large / O(file)) at a middle edit -- the signature of "the
+// leading run was NOT block-spliced".
+func TestLeadingSpliceBarredLanguagesDoNotSplice(t *testing.T) {
+	build := func(fmtStr string, n int) []byte {
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, fmtStr, i, i)
+		}
+		return []byte(b.String())
+	}
+	cases := []struct {
+		name string
+		lang *gts.Language
+		src  []byte
+		mark string
+	}{
+		{"typescript", grammars.TypescriptLanguage(),
+			build("export function f%d(a: number): number {\n  const v = a + %d;\n  return v;\n}\n\n", 200), "f100("},
+		{"tsx", grammars.TsxLanguage(),
+			build("export function f%d(a: number): number {\n  const v = a + %d;\n  return v;\n}\n\n", 200), "f100("},
+		{"javascript", grammars.JavascriptLanguage(),
+			build("function f%d(a) {\n  const v = a + %d;\n  return v;\n}\n\n", 200), "f100("},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mi := strings.Index(string(tc.src), tc.mark)
+			if mi < 0 {
+				t.Fatalf("marker %q not found", tc.mark)
+			}
+			off := mi + len(tc.mark) - 2 // a digit inside the index literal
+			fresh, incr, prof, edited := leadingParseAt(t, tc.lang, tc.src, off, "insert")
+			_ = fresh
+			if int(incr.EndByte()) != len(edited) {
+				t.Fatalf("incremental root span %d does not cover edited buffer %d", incr.EndByte(), len(edited))
+			}
+			// The barred family did NOT block-splice the leading run: with a
+			// middle edit and thousands of leading items, the reject counter must
+			// still be large (O(leading items)), the pre-T2a signature. A leading
+			// splice would have collapsed it to a small constant.
+			if prof.ReuseRejectRootNonLeafChanged < 1000 {
+				t.Fatalf("%s: reject counter %d is small -- the leading run was block-spliced, but this language is barred",
+					tc.name, prof.ReuseRejectRootNonLeafChanged)
+			}
+		})
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -358,6 +358,14 @@ type Parser struct {
 	// range-limited walk against the full walk on one Parser (see
 	// SetForceFullResultNormalizationWalk). Production leaves it false.
 	forceFullResultNormalizationWalk    bool
+	// disableLeadingRunSplice turns off the campaign post-admission-frontier T2a
+	// leading-run block-splice for this Parser (the trailing splice and every
+	// other reuse path stay on). It exists ONLY so the byte-sweep differential
+	// can compare leading-splice-on against leading-splice-off on the SAME Parser
+	// and prove the leading splice is a no-op on trees where it should be (it
+	// never changes a fresh-correct result). Production leaves it false; the
+	// setter lives in export_test.go.
+	disableLeadingRunSplice             bool
 	currentExternalTokenCheckpoint      externalScannerCheckpoint
 	currentExternalTokenCheckpointStart uint32
 	currentExternalTokenCheckpointEnd   uint32
@@ -2994,6 +3002,7 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 	defer p.reuseMu.Unlock()
 
 	var reuse *reuseCursor
+	p.reuseCursor.disableLeadingSplice = p.disableLeadingRunSplice
 	if timing != nil {
 		reuseStart := time.Now()
 		reuse = p.reuseCursor.reset(oldTree, source, &p.reuseScratch)

--- a/parser_big3_incremental_correctness_test.go
+++ b/parser_big3_incremental_correctness_test.go
@@ -216,8 +216,16 @@ func TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh(t *testing.T) {
 			rt.IncrementalAcceptedErrorRetryMergePerKey != 3 {
 			t.Fatalf("forward retry runtime = %+v", rt)
 		}
-		if profile.MaxStacksSeen != 24 || rt.MaxStacksSeen != 18 {
-			t.Fatalf("forward stack attribution profile=%d selected_runtime=%d, want aggregate=24 selected=18", profile.MaxStacksSeen, rt.MaxStacksSeen)
+		// Stack attribution: profile.MaxStacksSeen aggregates across every retry
+		// attempt; rt.MaxStacksSeen reflects only the selected (final) parse. The
+		// property under test is that the aggregate exceeds the selected value.
+		// The selected value dropped 18 -> 15 with campaign post-admission-frontier
+		// T2a: this edit is mid-file (byte 32063), so the leading run before it is
+		// now block-spliced instead of GLR-parsed, and the selected parse reaches a
+		// lower peak stack count. The aggregate (24) is unchanged and the tree is
+		// still byte-identical to fresh (the locked-hash assertion above).
+		if profile.MaxStacksSeen != 24 || rt.MaxStacksSeen != 15 {
+			t.Fatalf("forward stack attribution profile=%d selected_runtime=%d, want aggregate=24 selected=15", profile.MaxStacksSeen, rt.MaxStacksSeen)
 		}
 		if profile.TokensConsumed <= rt.TokensConsumed {
 			t.Fatalf("forward token attribution profile=%d selected_runtime=%d, want aggregate profile", profile.TokensConsumed, rt.TokensConsumed)

--- a/w1_leading_splice_test.go
+++ b/w1_leading_splice_test.go
@@ -1,0 +1,284 @@
+package gotreesitter_test
+
+// Campaign post-admission-frontier T2a (spec.campaign.post-admission-frontier):
+// the LEADING-run block-splice. A mid-file or bottom edit no longer pays
+// O(preceding top-level items): the whole run of byte-identical top-level items
+// BEFORE the edit is spliced back as a block from the initial parser state, the
+// mirror of the trailing block-splice (w1_block_splice_test.go). These tests are
+// real-parse and enforce the campaign invariants for the leading path:
+//
+//   - Oracle equality: the incremental tree is structurally identical to a fresh
+//     parse of the same final text, for edits at the top, middle, and bottom of
+//     the file, and for the boundary cases (item 0, comments between items,
+//     extras before the first item, an edit in the last item with no trailing
+//     run).
+//   - The leading splice fires and is O(edit): ReuseRejectRootNonLeafChanged
+//     stays a small size-independent constant for a MIDDLE edit, not O(leading
+//     item count) as it was before T2a.
+//   - Determinism: two independent fresh Parsers on the same (source, edit)
+//     produce identical trees and identical counters.
+//   - The untyped-parameter ambiguity divergence (tracked, pre-existing) is not
+//     widened: a clean untyped-param function sitting in the spliced leading run
+//     stays fresh-identical.
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// leadingParseAt runs a single-byte edit of the given class at off and returns
+// the fresh root, incremental root, profile, and edited buffer. The base parse
+// must be clean.
+func leadingParseAt(t *testing.T, lang *gts.Language, src []byte, off int, class string) (fresh, incr *gts.Node, prof gts.IncrementalParseProfile, edited []byte) {
+	t.Helper()
+	parser := gts.NewParser(lang)
+	oldTree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("base parse: %v", err)
+	}
+	if oldTree.RootNode().HasError() {
+		t.Fatal("fixture invariant: base parse must be clean")
+	}
+	edited, edit := incrGateBuildEdit(src, off, class)
+
+	freshTree, err := gts.NewParser(lang).Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh parse of edited: %v", err)
+	}
+	if e, m := incrGateTreeStats(freshTree.RootNode()); e != 0 || m != 0 {
+		t.Fatalf("fixture invariant: fresh parse of edited must be clean (err=%d miss=%d)", e, m)
+	}
+
+	oldTree.Edit(edit)
+	incrTree, p, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	t.Cleanup(func() {
+		freshTree.Release()
+		incrTree.Release()
+		oldTree.Release()
+	})
+	return freshTree.RootNode(), incrTree.RootNode(), p, edited
+}
+
+func leadingCleanGo(n int) []byte {
+	var b strings.Builder
+	b.WriteString("package p\n\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "func G%d(a int) int {\n\tx := a + %d\n\treturn x\n}\n\n", i, i)
+	}
+	return []byte(b.String())
+}
+
+// TestLeadingSpliceOracleEqualityMiddleBottom is the non-negotiable oracle: an
+// edit deep in the file (a large leading run precedes it) must produce a tree
+// structurally identical to a fresh parse, even though the whole leading run is
+// spliced back as a block.
+func TestLeadingSpliceOracleEqualityMiddleBottom(t *testing.T) {
+	lang := grammars.GoLanguage()
+	src := leadingCleanGo(400)
+	for _, pos := range []string{"middle", "bottom"} {
+		var marker string
+		switch pos {
+		case "middle":
+			marker = "func G200("
+		case "bottom":
+			marker = "func G396("
+		}
+		off := bytes.Index(src, []byte(marker)) + len("func G200(")
+		if off < len("func G200(") {
+			t.Fatalf("marker %q not found", marker)
+		}
+		fresh, incr, prof, edited := leadingParseAt(t, lang, src, off, "insert")
+		if incr.HasError() {
+			t.Fatalf("%s: incremental tree unexpectedly has errors", pos)
+		}
+		if int(incr.EndByte()) != len(edited) {
+			t.Fatalf("%s: incremental root span %d does not cover edited buffer %d", pos, incr.EndByte(), len(edited))
+		}
+		if d := w1bStructuralDiff(lang, fresh, incr, "root"); d != "" {
+			t.Fatalf("%s: oracle divergence (incremental != fresh) with leading splice: %s", pos, d)
+		}
+		if prof.BlockSpliceSteps == 0 {
+			t.Fatalf("%s: leading splice did not fire (no block splice steps)", pos)
+		}
+	}
+}
+
+// TestLeadingSpliceIsBoundedNotFileSized proves the T2a win: for a MIDDLE edit,
+// ReuseRejectRootNonLeafChanged stays a small constant as the leading item count
+// grows 4x, instead of scaling with it (the pre-T2a O(preceding items) cost).
+func TestLeadingSpliceIsBoundedNotFileSized(t *testing.T) {
+	lang := grammars.GoLanguage()
+	small := leadingCleanGo(150)
+	large := leadingCleanGo(600)
+	// Edit the middle item of each file, so a large leading run precedes it.
+	offS := bytes.Index(small, []byte("func G75(")) + len("func G75(")
+	offL := bytes.Index(large, []byte("func G300(")) + len("func G300(")
+
+	_, incrS, profS, editedS := leadingParseAt(t, lang, small, offS, "insert")
+	_, incrL, profL, editedL := leadingParseAt(t, lang, large, offL, "insert")
+
+	if incrS.HasError() || incrL.HasError() {
+		t.Fatal("incremental tree unexpectedly has errors")
+	}
+	if int(incrS.EndByte()) != len(editedS) || int(incrL.EndByte()) != len(editedL) {
+		t.Fatal("incremental root span does not cover the edited buffer")
+	}
+	if profS.BlockSpliceSteps == 0 || profL.BlockSpliceSteps == 0 {
+		t.Fatalf("leading splice did not fire (small=%d large=%d)", profS.BlockSpliceSteps, profL.BlockSpliceSteps)
+	}
+	// The counter must stay a small constant even though the leading run
+	// quadrupled. Before T2a it scaled ~1:1 with the leading item count
+	// (thousands at this size). A generous constant bound with headroom.
+	const bound = 64
+	if profS.ReuseRejectRootNonLeafChanged > bound || profL.ReuseRejectRootNonLeafChanged > bound {
+		t.Fatalf("leading reuse is O(preceding items), not O(edit): rootNonLeafChanged small=%d large=%d (bound %d)",
+			profS.ReuseRejectRootNonLeafChanged, profL.ReuseRejectRootNonLeafChanged, bound)
+	}
+	// And it must not grow materially with the 4x-larger leading run.
+	if profL.ReuseRejectRootNonLeafChanged > profS.ReuseRejectRootNonLeafChanged+16 {
+		t.Fatalf("leading reuse counter grew with file size (small=%d large=%d) -- O(file), not O(edit)",
+			profS.ReuseRejectRootNonLeafChanged, profL.ReuseRejectRootNonLeafChanged)
+	}
+}
+
+// TestLeadingSpliceIsDeterministic runs the identical (source, edit) on two
+// independent fresh Parsers and requires identical trees AND identical counters.
+func TestLeadingSpliceIsDeterministic(t *testing.T) {
+	lang := grammars.GoLanguage()
+	src := leadingCleanGo(250)
+	off := bytes.Index(src, []byte("func G125(")) + len("func G125(")
+
+	run := func() (*gts.Node, uint64, uint64) {
+		fresh, incr, prof, _ := leadingParseAt(t, lang, src, off, "insert")
+		_ = fresh
+		return incr, prof.BlockSpliceSteps, prof.ReuseRejectRootNonLeafChanged
+	}
+	aNode, aSteps, aRej := run()
+	bNode, bSteps, bRej := run()
+	if d := w1bStructuralDiff(lang, aNode, bNode, "root"); d != "" {
+		t.Fatalf("leading splice non-determinism: two fresh Parsers produced different trees: %s", d)
+	}
+	if aSteps != bSteps || aRej != bRej {
+		t.Fatalf("leading splice non-determinism: counters differ (steps %d!=%d, rej %d!=%d)", aSteps, bSteps, aRej, bRej)
+	}
+	if aSteps == 0 {
+		t.Fatal("leading splice did not fire")
+	}
+}
+
+// TestLeadingSpliceBoundaryCases covers the boundary cases the leading splice
+// must handle: an edit into item 0 (no leading run), comments between items,
+// leading extras before the first item, and an edit in the LAST item (a leading
+// run with no trailing run). Every one must stay fresh-identical.
+func TestLeadingSpliceBoundaryCases(t *testing.T) {
+	goLang := grammars.GoLanguage()
+
+	item0 := leadingCleanGo(60)
+	comments := []byte("package p\n\n" +
+		"// leading file comment\n" +
+		"func A0(a int) int { return a }\n\n" +
+		"// between A0 and A1\n" +
+		"func A1(a int) int { return a }\n\n" +
+		"/* block comment */\n" +
+		"func A2(a int) int { return a }\n\n" +
+		"func A3(a int) int { return a }\n\n" +
+		"func A4(a int) int { return a }\n")
+
+	cases := []struct {
+		name   string
+		lang   *gts.Language
+		src    []byte
+		marker string // substring; edit lands just after it
+		class  string
+	}{
+		{"go-item0-insert", goLang, item0, "func G0(", "insert"},
+		{"go-item0-delete", goLang, item0, "func G0(a", "delete"},
+		{"go-last-item-insert", goLang, item0, "func G59(", "insert"},
+		{"go-comments-middle", goLang, comments, "func A2(", "insert"},
+		{"go-comments-between-edit", goLang, comments, "func A3(", "delete"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mi := bytes.Index(tc.src, []byte(tc.marker))
+			if mi < 0 {
+				t.Fatalf("marker %q not found", tc.marker)
+			}
+			off := mi + len(tc.marker)
+			fresh, incr, _, edited := leadingParseAt(t, tc.lang, tc.src, off, tc.class)
+			if int(incr.EndByte()) != len(edited) {
+				t.Fatalf("incremental root span %d does not cover edited buffer %d", incr.EndByte(), len(edited))
+			}
+			if d := w1bStructuralDiff(tc.lang, fresh, incr, "root"); d != "" {
+				t.Fatalf("oracle divergence (incremental != fresh): %s", d)
+			}
+		})
+	}
+}
+
+// TestLeadingSpliceConfinesUntypedParamAmbiguity guards the tracked untyped-
+// parameter ambiguity divergence (a Go construct, pre-existing, NOT fixed here).
+// A CLEAN untyped-param function sitting in the LEADING run that the block
+// splices back must stay structurally identical to fresh -- the leading splice
+// reuses it byte-for-byte, never re-deriving the ambiguity. The edit lands in a
+// LATER function so the untyped-param function is a spliced leading item.
+func TestLeadingSpliceConfinesUntypedParamAmbiguity(t *testing.T) {
+	lang := grammars.GoLanguage()
+	var b strings.Builder
+	b.WriteString("package p\n\n")
+	// An untyped-parameter-list function early in the file (the tracked construct).
+	b.WriteString("func h(a, b int) int {\n\treturn a\n}\n\n")
+	for i := 0; i < 80; i++ {
+		fmt.Fprintf(&b, "func C%d(x int) int {\n\treturn x\n}\n\n", i)
+	}
+	src := []byte(b.String())
+
+	// Edit a function far AFTER h, so h is in the spliced leading run.
+	off := bytes.Index(src, []byte("func C60(")) + len("func C60(")
+	fresh, incr, prof, edited := leadingParseAt(t, lang, src, off, "insert")
+
+	if int(incr.EndByte()) != len(edited) {
+		t.Fatalf("incremental root span %d does not cover edited buffer %d", incr.EndByte(), len(edited))
+	}
+	if d := w1bStructuralDiff(lang, fresh, incr, "root"); d != "" {
+		t.Fatalf("leading splice widened the untyped-param hole: %s", d)
+	}
+	if prof.BlockSpliceSteps == 0 {
+		t.Fatal("leading splice did not fire on the clean leading run")
+	}
+}
+
+// TestLeadingSpliceCSSProductionRoute proves the production (non-forest) css
+// route -- which the campaign's evidence base describes as already having
+// top-level sibling reuse -- gets the leading win: a middle-rule edit is
+// fresh-identical and splices the leading run.
+func TestLeadingSpliceCSSProductionRoute(t *testing.T) {
+	lang := grammars.CssLanguage()
+	var b strings.Builder
+	for i := 0; i < 120; i++ {
+		fmt.Fprintf(&b, ".item-%d {\n  color: #112233;\n  margin: %dpx;\n}\n\n", i, i%16)
+	}
+	src := []byte(b.String())
+	off := bytes.Index(src, []byte(".item-60 ")) + len(".item-6")
+	fresh, incr, prof, edited := leadingParseAt(t, lang, src, off, "insert")
+
+	if int(incr.EndByte()) != len(edited) {
+		t.Fatalf("incremental root span %d does not cover edited buffer %d", incr.EndByte(), len(edited))
+	}
+	if d := w1bStructuralDiff(lang, fresh, incr, "root"); d != "" {
+		t.Fatalf("css leading splice oracle divergence: %s", d)
+	}
+	if prof.BlockSpliceSteps == 0 {
+		t.Fatal("css leading splice did not fire")
+	}
+	if prof.ReuseRejectRootNonLeafChanged > 32 {
+		t.Fatalf("css leading reuse is not O(edit): rootNonLeafChanged=%d", prof.ReuseRejectRootNonLeafChanged)
+	}
+}

--- a/w5_editor_latency_gate_test.go
+++ b/w5_editor_latency_gate_test.go
@@ -23,24 +23,34 @@ package gotreesitter_test
 // classes, two size tiers) surfaced two things a single near-top fixture
 // cannot:
 //
-//  1. ReuseRejectRootNonLeafChanged is NOT flat "regardless of position in
-//     file" -- only "regardless of file size AT A FIXED near-the-very-start
-//     position" (exactly what TestW1BSettleReuseIsBoundedNotFileSized in
-//     w1b_reduce_settle_test.go tests: it holds the edit at the FIRST
-//     top-level item and varies trailing-sibling count). Today's mechanism
-//     (topLevelSiblingBlockSpliceEligible) only fast-paths the TRAILING run
-//     after the edit; content BEFORE the edit is still walked one top-level
-//     item at a time, and each leading item currently costs a small but
-//     nonzero, consistent number of rejected candidates (empirically ~10-17
-//     per language, constant per item, independent of file size) before
-//     falling through to a slower reuse path. For a "middle" or "bottom"
-//     position edit that consistent per-item cost multiplies by the leading
-//     item count, which IS proportional to file size. This is a real,
-//     currently open scope limit -- not a regression this gate enforces on
-//     -- and it matches the campaign's own success-metric wording exactly:
-//     "Go 137KB NEAR-TOP single-char insert" (W1's Workstreams section).
-//     Consequently MaxRootNonLeafChangedAtTop below is only asserted at the
-//     "top" position.
+//  1. ReuseRejectRootNonLeafChanged used to be flat only "regardless of file
+//     size AT A FIXED near-the-very-start position", NOT "regardless of
+//     position in file". The original mechanism
+//     (topLevelSiblingBlockSpliceEligible) fast-pathed only the TRAILING run
+//     after the edit; content BEFORE the edit was walked one top-level item at
+//     a time (~10-17 rejected candidates per leading item), so a "middle" or
+//     "bottom" edit multiplied that per-item cost by the leading-item count,
+//     which is proportional to file size.
+//
+//     Campaign post-admission-frontier T2a (the leading-run block-splice, this
+//     change) closed that gap for the languages whose per-node fragility
+//     marking is complete: go and the production (non-forest) css route now
+//     splice the whole run of byte-identical leading top-level items as a block
+//     from the initial parser state, the mirror of the trailing splice. Their
+//     mid-file reject counter dropped to the near-top constant -- go 16450 ->
+//     10 (middle) and 32854 -> 10 (bottom) at 137KB; css 15598 -> 3 and 31163
+//     -> 3 -- and byte reuse rose to ~96% at every position. So go and css now
+//     carry a per-position MaxRootNonLeafChanged bound (w5PositionCeiling),
+//     not only the top-position one, and their middle/bottom byte-reuse floors
+//     ratchet up accordingly.
+//
+//     typescript, tsx, and javascript are NOT flattened: they share the
+//     ambiguous-expression / ASI grammar whose reduce-fragility marking is
+//     known-incomplete, so the leading splice is held off for them
+//     (leadingSpliceLanguageBarred, incremental.go) until the campaign T2c
+//     reuse proof lands, and their mid-file counters still scale with size --
+//     they keep the top-only ceiling. python still declines reuse entirely
+//     (W4 indent-stack proof open).
 //  2. ReusedBytes / len(editedSource), unlike the rejection counter, IS
 //     input-deterministic AND size-independent when position is expressed
 //     as a FRACTION of the file (not an absolute byte offset): a "middle"
@@ -80,11 +90,17 @@ package gotreesitter_test
 // linux/amd64, GOMAXPROCS default, measured via this harness) minus modest
 // slack for cross-hardware noise, not an aspirational target.
 //
-//	language    | topRootNonLeafChanged ceiling | MinByteReusePercent (top / middle / bottom)
-//	go          | 16  (measured 10-11)          | 88 / 60 / 35  (measured ~96 / ~70 / ~44)
-//	typescript  | 20  (measured 13-14)          | 90 / 70 / 55  (measured ~97 / ~81 / ~65)
-//	css         | 12  (measured 3-6)            | 88 / 75 / 65  (measured ~96 / ~85 / ~75)
-//	python      | 8   (measured 0)               | 0  / 0  / 0   (measured 0 -- see below)
+// After campaign post-admission-frontier T2a (the leading-run block-splice):
+//
+//	language    | RootNonLeafChanged ceiling (top / mid / bot) | MinByteReusePercent (top / mid / bot)
+//	go          | 16 / 16 / 16  (measured 9-10 flat)           | 90 / 90 / 90  (measured ~96 flat)
+//	typescript  | 20 / -  / -   (mid/bot scale, barred T2c)    | 90 / 70 / 55  (measured ~97 / ~81 / ~65)
+//	css         | 12 / 12 / 12  (measured 3-7 flat)            | 90 / 90 / 90  (measured ~96 flat)
+//	python      | 8  / -  / -   (declines reuse, W4 open)      | 0  / 0  / 0   (measured 0 -- see below)
+//
+// A "-" mid/bot ceiling means the cell's reject counter still scales with file
+// size (that language is not flattened), so no fixed bound is asserted there --
+// exactly the pre-T2a behavior, retained for the barred / non-reusing languages.
 //
 //   - go: topRootNonLeafChanged=16. The campaign Status section
 //     (hypha://m31labs/gotreesitter spec.campaign.oedit) records W1b's
@@ -456,6 +472,16 @@ func w5ByteReusePercent(p gts.IncrementalParseProfile, editedLen int) float64 {
 // cell, applied to insert/delete classes.
 type w5PositionCeiling struct {
 	MinByteReusePercent float64
+	// MaxRootNonLeafChanged bounds ReuseRejectRootNonLeafChanged at THIS
+	// position. Zero means "not asserted here" (the pre-T2a default for every
+	// non-top cell: a position whose reject counter still scales with file size
+	// cannot carry a fixed, size-independent ceiling). It is set nonzero only
+	// for a (language, position) the block-splice has FLATTENED -- made
+	// size-independent -- so a fixed bound is meaningful and locks the win.
+	// Campaign post-admission-frontier T2a (the leading-run splice) flattened
+	// go and production-route css at middle and bottom, so those cells now carry
+	// this bound; see w5Ceilings.
+	MaxRootNonLeafChanged uint64
 }
 
 // w5Ceiling is the ratchet floor for one language. See the file doc comment
@@ -481,23 +507,45 @@ const w5ReplaceMinByteReusePercent = 95
 // (language, position), minus modest slack. See the file doc comment for
 // full provenance of every value here.
 var w5Ceilings = map[string]w5Ceiling{
+	// go: campaign post-admission-frontier T2a (the leading-run block-splice)
+	// flattened the mid-file reject counter and byte reuse to the near-top
+	// constant. Measured on this box (137KB and 20KB agree, the counter is
+	// size-independent): ReuseRejectRootNonLeafChanged 9-10 and byte reuse
+	// ~95.8-96.1% at EVERY position (was middle 16450 / 70.7% and bottom 32854 /
+	// 45.4% at 137KB before T2a). MaxRootNonLeafChanged=16 at every position
+	// keeps that as a small constant with box slack; the byte-reuse floors ratchet
+	// from the old 88/60/35 to 90/90/90 to lock the flattening.
 	"go": {
 		MaxRootNonLeafChangedAtTop: 16,
-		Top:                        w5PositionCeiling{MinByteReusePercent: 88},
-		Middle:                     w5PositionCeiling{MinByteReusePercent: 60},
-		Bottom:                     w5PositionCeiling{MinByteReusePercent: 35},
+		Top:                        w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 16},
+		Middle:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 16},
+		Bottom:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 16},
 	},
+	// typescript: NOT flattened by T2a. typescript (with tsx and javascript)
+	// shares the ambiguous-expression / ASI grammar whose per-node reduce-
+	// fragility marking is known-incomplete, so the leading-run splice is held
+	// off for it (leadingSpliceLanguageBarred, incremental.go) until the campaign
+	// T2c reuse proof lands. Its mid-file cells therefore still scale with size,
+	// exactly as before this change, so they keep the top-only counter ceiling
+	// and the pre-T2a byte-reuse floors -- no MaxRootNonLeafChanged at
+	// middle/bottom (a scaling counter cannot carry a fixed bound).
 	"typescript": {
 		MaxRootNonLeafChangedAtTop: 20,
-		Top:                        w5PositionCeiling{MinByteReusePercent: 90},
+		Top:                        w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 20},
 		Middle:                     w5PositionCeiling{MinByteReusePercent: 70},
 		Bottom:                     w5PositionCeiling{MinByteReusePercent: 55},
 	},
+	// css: flattened by T2a on the production (non-forest) route, the same as go.
+	// Measured ~95.8-95.9% byte reuse and ReuseRejectRootNonLeafChanged 3-7 at
+	// every position (was middle 15598 / 85.8% and bottom 31163 / 75.7% at 137KB).
+	// MaxRootNonLeafChanged=12 at every position; byte-reuse floors ratchet from
+	// 88/75/65 to 90/90/90. (Forest-route css keeps its leading-prefix scanner
+	// guard and is unaffected -- see forestFastPathDirtyPrefixScannerSensitive.)
 	"css": {
 		MaxRootNonLeafChangedAtTop: 12,
-		Top:                        w5PositionCeiling{MinByteReusePercent: 88},
-		Middle:                     w5PositionCeiling{MinByteReusePercent: 75},
-		Bottom:                     w5PositionCeiling{MinByteReusePercent: 65},
+		Top:                        w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 12},
+		Middle:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 12},
+		Bottom:                     w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 12},
 	},
 	// python: an honest negative, not a placeholder -- see the file doc
 	// comment's python bullet. Insert/delete measure 0% byte reuse today
@@ -550,6 +598,16 @@ func w5Check(t *testing.T, s w5Sample) {
 	if s.Position == w5Top && s.Profile.ReuseRejectRootNonLeafChanged > ceiling.MaxRootNonLeafChangedAtTop {
 		t.Fatalf("%s/%s/%s/%s: ReuseRejectRootNonLeafChanged=%d exceeds top-position ceiling %d -- O(edit) near-top reuse regressed toward O(file)",
 			s.Lang, s.Size, s.Class, s.Position, s.Profile.ReuseRejectRootNonLeafChanged, ceiling.MaxRootNonLeafChangedAtTop)
+	}
+	// Per-position flat ceiling (campaign post-admission-frontier T2a): where the
+	// leading-run splice flattened the reject counter (go, css at every
+	// position), assert it stays a small size-independent constant so a future
+	// change cannot silently reopen O(preceding-items) mid-file reparse cost. A
+	// zero bound means the cell is not flattened (still scales with size) and is
+	// left unasserted, exactly as before T2a.
+	if posMax := ceiling.forPosition(s.Position).MaxRootNonLeafChanged; posMax > 0 && s.Profile.ReuseRejectRootNonLeafChanged > posMax {
+		t.Fatalf("%s/%s/%s/%s: ReuseRejectRootNonLeafChanged=%d exceeds flattened position ceiling %d -- the T2a leading-run block-splice regressed toward O(file) mid-file",
+			s.Lang, s.Size, s.Class, s.Position, s.Profile.ReuseRejectRootNonLeafChanged, posMax)
 	}
 
 	minReuse := w5ReplaceMinByteReusePercent


### PR DESCRIPTION
## Summary

Introduce the leading-run block-splice (campaign T2a) to the incremental parser. Edits in the middle or bottom of a file now splice back the entire run of unchanged top-level items before the edit from the initial parser state. This mirrors the existing trailing-run splice and flattens mid-file performance for Go and CSS. The change temporarily bars JS, TypeScript, and TSX to avoid altering tracked reuse divergences.

## Changes

- Enable leading-run block-splice in `reuseCursor` when items end strictly before the first edit.
- Refactor `topLevelSiblingBlockSpliceEligible` and `topLevelBlockCandidateBytes` to enforce strict byte-range checks for leading items.
- Add `leadingSpliceLanguageBarred` to hold back JS, TypeScript, and TSX until reduce-fragility marking is complete.
- Expose `SetDisableLeadingRunSplice` in test exports for differential byte-sweep comparisons.
- Raise performance gate ceilings and byte-reuse floors for Go and CSS mid-file and bottom edits.
- Update stack attribution expectations to account for reduced stack depth during leading splice.
- Add adversarial byte-sweep and oracle equality tests to validate correctness and deterministic behavior across all edit types.

## Testing

- go test -run 'TestLeadingSplice|TestLeadingSpliceByteSweep|TestLeadingSpliceBarredLanguages'
- go test -run 'TestGoLanguageFixtureLengthChangeIncrementalMatchesFresh|TestW5EditorLatency'
- GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseIncrementalSingleByteEditDFA' -benchmem -count=10 -benchtime=750ms