### PR TITLE
fix(parsercore): admission fold to fail closed on ties

### DIFF
--- a/admission_generic_conflict_test.go
+++ b/admission_generic_conflict_test.go
@@ -1,0 +1,149 @@
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// genericConflictFixture is one member of the Go generic-instantiation /
+// type-conversion ambiguity family surfaced by the Phase-3 admission flip.
+type genericConflictFixture struct {
+	name string
+	expr string
+}
+
+// genericConflictFamily covers the bare Ident[TypeArgs](args) conflict class the
+// admission flip surfaced, the tree-sitter-go expression-versus-type variants,
+// and the conflict-free bounds that must keep routing.
+//
+// Every case is wrapped in a real short variable declaration so the parser sees
+// the ambiguous construct in expression position, exactly where production forks
+// the generic-call / type-conversion GLR conflict.
+var genericConflictFamily = []genericConflictFixture{
+	// The conflict class: production keeps Ident[TypeArgs] as a generic
+	// instantiation (type_conversion_expression or a call with type_arguments);
+	// the compact route must decline rather than collapse it to index_expression.
+	{"one_type_arg", "Foo[int](a)"},
+	{"two_type_args", "Pair[int, string](p)"},
+	{"generic_call_two_args", "Max[int](1, 2)"},
+	{"generic_call_one_arg", "Max[int](1)"},
+	{"nested_generic", "Foo[Foo[int]](a)"},
+	{"nested_type_args", "Map[string, []int](m)"},
+	{"paren_form", "(Foo[int])(a)"},
+	{"chain", "Foo[int](Foo[int](a))"},
+	{"argument_generic", "g(Foo[int](a))"},
+	{"real_index_call", "a[b](c)"},
+	{"selector_generic_call", "pkg.Max[int](1, 2)"},
+	{"in_expression", "Max[int](1, 2) + Max[int](3, 4)"},
+
+	// The conflict-free bounds: no Ident[TypeArgs]( pattern, so no fork. These
+	// must keep routing (or, at worst, still match production byte for byte).
+	{"composite_literal", "Foo[int]{}"},
+	{"bare_instantiation", "Max[int]"},
+	{"plain_call", "g(x)"},
+	{"plain_index", "a[b]"},
+	{"selector_call", "pkg.F(x)"},
+	{"make_slice", "make([]int, 0)"},
+	{"new_type", "new(Foo)"},
+}
+
+// TestAdmissionGenericConflictFamilyNoDivergence proves the compact candidate
+// route never routes a wrong tree for the generic-instantiation conflict family.
+// For every fixture the candidate result must equal the production result byte
+// for byte, whether the candidate routed or declined to production. It also
+// reports how the family splits between routed and declined so the coverage
+// bound is measured, not assumed.
+func TestAdmissionGenericConflictFamilyNoDivergence(t *testing.T) {
+	lang := grammars.GoLanguage()
+	if lang == nil {
+		t.Skip("Go language unavailable")
+	}
+	var routed, declined int
+	for _, fixture := range genericConflictFamily {
+		fixture := fixture
+		t.Run(fixture.name, func(t *testing.T) {
+			src := []byte("package p\n\nfunc f() {\n\t_ = " + fixture.expr + "\n}\n")
+
+			prod := gts.NewParser(lang)
+			prod.SetAdmissionCandidateRoute(false)
+			prodTree, err := prod.Parse(src)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer prodTree.Release()
+			if prodTree.RootNode().HasError() {
+				t.Fatalf("production reference has an error node for %q; fixture is not a clean parse", fixture.expr)
+			}
+			prodSExpr := prodTree.RootNode().SExpr(lang)
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			cand := gts.NewParser(lang)
+			cand.SetAdmissionCandidateRoute(true)
+			candTree, err := cand.Parse(src)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candTree.Release()
+			candRouted, candFallback := gts.AdmissionCandidateCounters()
+			candSExpr := candTree.RootNode().SExpr(lang)
+
+			// The load-bearing invariant: the candidate route never diverges. A
+			// decline falls back to production (identical by construction); a route
+			// must reproduce production byte for byte.
+			if candSExpr != prodSExpr {
+				t.Fatalf("DIVERGENCE for %q (routed=%d fallback=%d):\n  production: %s\n  candidate:  %s",
+					fixture.expr, candRouted, candFallback, prodSExpr, candSExpr)
+			}
+			switch {
+			case candRouted == 1 && candFallback == 0:
+				routed++
+				t.Logf("ROUTED byte-exact: %q", fixture.expr)
+			case candRouted == 0 && candFallback == 1:
+				declined++
+				t.Logf("DECLINED to production: %q", fixture.expr)
+			default:
+				t.Fatalf("ambiguous routing counters for %q: routed=%d fallback=%d", fixture.expr, candRouted, candFallback)
+			}
+		})
+	}
+	t.Logf("generic-conflict family: %d routed byte-exact, %d declined to production, 0 divergences (%d fixtures)",
+		routed, declined, len(genericConflictFamily))
+
+	// Guard the class boundary: the ambiguous Ident[TypeArgs]( members must
+	// decline, and the conflict-free members must keep routing. This proves the
+	// decline keys on the GLR conflict, not on over-declining every input.
+	mustDecline := map[string]bool{
+		"one_type_arg": true, "two_type_args": true, "generic_call_two_args": true,
+		"generic_call_one_arg": true, "nested_generic": true, "nested_type_args": true,
+		"paren_form": true, "chain": true, "argument_generic": true,
+		"real_index_call": true, "selector_generic_call": true, "in_expression": true,
+	}
+	mustRoute := map[string]bool{
+		"composite_literal": true, "bare_instantiation": true, "plain_call": true,
+		"plain_index": true, "selector_call": true, "make_slice": true, "new_type": true,
+	}
+	for _, fixture := range genericConflictFamily {
+		src := []byte("package p\n\nfunc f() {\n\t_ = " + fixture.expr + "\n}\n")
+		gts.ResetAdmissionCandidateCountersForTest()
+		cand := gts.NewParser(lang)
+		cand.SetAdmissionCandidateRoute(true)
+		tree, err := cand.Parse(src)
+		if err != nil {
+			t.Fatalf("candidate parse %q: %v", fixture.expr, err)
+		}
+		r, _ := gts.AdmissionCandidateCounters()
+		tree.Release()
+		if mustDecline[fixture.name] && r != 0 {
+			t.Errorf("conflict-class member %q routed (r=%d); it must decline (fail closed)", fixture.expr, r)
+		}
+		if mustRoute[fixture.name] && r == 0 {
+			// A conflict-free member declined; that is safe but narrows coverage.
+			// Report it rather than fail so the bound stays visible.
+			t.Logf("NOTE conflict-free member %q declined (coverage-narrowing, still exact): %s", fixture.expr,
+				strings.TrimSpace(fixture.expr))
+		}
+	}
+}

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -486,21 +486,23 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 	}
 }
 
-// TestAdmissionCandidateGoTypeConversionKnownDivergence records a KNOWN, TRACKED
-// correctness divergence the Phase-3 admission flip surfaced. On the ambiguous
-// Go construct `Foo[int](a)` (type conversion versus a call of an index
-// expression) the compact candidate route resolves the GLR conflict to
-// call_expression(index_expression), while the production engine and the
-// tree-sitter-go C oracle resolve it to type_conversion_expression(generic_type).
+// TestAdmissionCandidateGoTypeConversionFailsClosed proves the compact candidate
+// route FAILS CLOSED on the Go generic-instantiation / type-conversion GLR
+// conflict the Phase-3 admission flip surfaced. On the ambiguous construct
+// `Foo[int](a)` (a type conversion of a generic type versus a call of an index
+// expression) production and the tree-sitter-go C oracle resolve
+// type_conversion_expression(generic_type). The compact scheduler forks the same
+// conflict but cannot rank the two arms by dynamic precedence, so it declines the
+// unauthorized tie fold (see Core.condenseLinkUnion) instead of silently keeping
+// one arm by insertion order. The parse then falls back to production.
 //
-// This divergence is NOT covered by the 206-language admission scorecard
-// fixtures. It is a BLOCKER for unconditional Go admission and must be resolved
-// by the engine-swap review: the compact scheduler must reproduce the production
-// conflict resolution or fail closed on this conflict class. When that lands,
-// the candidate tree matches production and this test fails loudly, directing
-// the maintainer to route TestParseGoNewMakeGenericInstantiationUntouched again
-// and remove this tracker.
-func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
+// This was a tracked correctness divergence (call_expression(index_expression)
+// routed with no fallback). The fix is loud and explicit here: the candidate must
+// decline (route counter stays 0, fallback counter moves) and the returned tree
+// must equal production byte for byte. If a future change routes this input, the
+// route/fallback assertion fails and directs the maintainer to re-verify the
+// whole conflict family in TestAdmissionGenericConflictFamilyNoDivergence.
+func TestAdmissionCandidateGoTypeConversionFailsClosed(t *testing.T) {
 	src := "package p\n\n" +
 		"type Foo[T any] struct {\n\tV T\n}\n\n" +
 		"func f() {\n" +
@@ -519,6 +521,9 @@ func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
 	}
 	defer prodTree.Release()
 	prodSExpr := prodTree.RootNode().SExpr(lang)
+	if !strings.Contains(prodSExpr, "type_conversion_expression") {
+		t.Fatalf("production reference lost type_conversion_expression; the C-oracle witness changed: %s", prodSExpr)
+	}
 
 	gts.ResetAdmissionCandidateCountersForTest()
 	cand := gts.NewParser(lang)
@@ -528,21 +533,26 @@ func TestAdmissionCandidateGoTypeConversionKnownDivergence(t *testing.T) {
 		t.Fatalf("candidate parse: %v", err)
 	}
 	defer candTree.Release()
-	routed, _ := gts.AdmissionCandidateCounters()
+	routed, fallback := gts.AdmissionCandidateCounters()
 	candSExpr := candTree.RootNode().SExpr(lang)
 
-	if routed == 0 {
-		t.Skip("candidate route declined this Go input; the known divergence no longer reproduces via routing")
+	// Fail-closed proof 1: the candidate declined this conflict input.
+	if routed != 0 {
+		t.Fatalf("conflict input routed (routed=%d fallback=%d); the compact route must fail closed on the "+
+			"generic-instantiation / type-conversion conflict. Re-verify TestAdmissionGenericConflictFamilyNoDivergence.\n"+
+			"  candidate: %s", routed, fallback, candSExpr)
 	}
-	if !strings.Contains(prodSExpr, "type_conversion_expression") {
-		t.Fatalf("production reference lost type_conversion_expression; the C-oracle witness changed: %s", prodSExpr)
+	// Fail-closed proof 2: the decline moved the fallback counter (the parse ran
+	// production, it did not merely skip).
+	if fallback == 0 {
+		t.Fatalf("candidate declined but the fallback counter did not move (routed=%d fallback=%d); "+
+			"the fail-closed path is not exercised", routed, fallback)
 	}
-	if prodSExpr == candSExpr {
-		t.Fatalf("KNOWN divergence resolved: the candidate now matches production for Foo[int](a). "+
-			"Re-route TestParseGoNewMakeGenericInstantiationUntouched and remove this tracker.\n%s", candSExpr)
+	// Fail-closed proof 3: the returned tree is exactly production's tree.
+	if candSExpr != prodSExpr {
+		t.Fatalf("declined candidate tree diverges from production:\n  production: %s\n  candidate:  %s",
+			prodSExpr, candSExpr)
 	}
-	t.Logf("KNOWN candidate-route divergence (BLOCKER for unconditional Go admission):\n  production: %s\n  candidate:  %s",
-		prodSExpr, candSExpr)
 }
 
 // admissionEOFPoint returns the row/column point at the end of source.

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -493,7 +493,7 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 // expression) production and the tree-sitter-go C oracle resolve
 // type_conversion_expression(generic_type). The compact scheduler forks the same
 // conflict but cannot rank the two arms by dynamic precedence, so it declines the
-// unauthorized tie fold (see Core.condenseLinkUnion) instead of silently keeping
+// unauthorized tie fold (see Core.condenseWithOutcomeAtomic) instead of silently keeping
 // one arm by insertion order. The parse then falls back to production.
 //
 // This was a tracked correctness divergence (call_expression(index_expression)

--- a/cgo_harness/parity_glr_canary_set_test.go
+++ b/cgo_harness/parity_glr_canary_set_test.go
@@ -13,9 +13,14 @@ type glrCanaryCase struct {
 
 var glrCanaryCases = []glrCanaryCase{
 	{
-		lang:      "go",
-		name:      "ambiguous-call",
-		source:    "package main\nfunc main(){ println(\"hello\") }\n",
+		lang: "go",
+		name: "ambiguous-call",
+		// The generic-instantiation / type-conversion conflict: production forks
+		// Foo[int](a) into the generic_type/type_conversion arm and the
+		// index_expression/call arm. This is a real GLR fork (post-flip the
+		// compact route declines it and falls back to production, which reports
+		// the branching), unlike the previous single-stack println smoke input.
+		source:    "package main\nfunc f() { _ = Foo[int](a) }\n",
 		minStacks: 2,
 	},
 	{

--- a/cgo_harness/parity_glr_canary_test.go
+++ b/cgo_harness/parity_glr_canary_test.go
@@ -11,13 +11,17 @@ import (
 
 func makeGoGLRCanarySource(callCount int) []byte {
 	var b strings.Builder
-	b.Grow(callCount * 16)
+	b.Grow(callCount * 24)
 	b.WriteString("package main\n\n")
-	b.WriteString("type glrCanaryNode struct{}\n")
-	b.WriteString("func (glrCanaryNode) method() {}\n")
-	b.WriteString("func glrCanaryBenchmark() {\n\tvar n glrCanaryNode\n")
+	b.WriteString("func glrCanaryBenchmark() {\n")
 	for i := 0; i < callCount; i++ {
-		b.WriteString("\tn.method()\n")
+		// Each line is the generic-instantiation / type-conversion conflict
+		// Foo[int](a). Production forks the generic_type/type_conversion arm
+		// against the index_expression/call arm, so the runtime records GLR
+		// branching. Post-flip the compact route declines this conflict and falls
+		// back to production, so the assertion measures production's fork count,
+		// not the compact route's single stack.
+		b.WriteString("\t_ = Foo[int](a)\n")
 	}
 	b.WriteString("}\n")
 	return []byte(b.String())

--- a/internal/parsercorephase0/census/phase0a_canonical_census_test.go
+++ b/internal/parsercorephase0/census/phase0a_canonical_census_test.go
@@ -77,7 +77,7 @@ var currentCanonicalCensus = map[string]currentCensusContract{
 	"query_compile": {routes: 8103, links: 14703, migrations: 32, spine: 1, raw: 11331, public: 7524, terminals: 5125, reductions: 6206, migrated: 17, maxDepth: 78, digest: "c6ab3989e0492de265c74ce19526d85d30223801b984156b4fa4d265f1a65a85"},
 	"rewrite":       {routes: 1646, links: 2995, migrations: 16, spine: 1, raw: 2237, public: 1524, terminals: 1035, reductions: 1202, migrated: 16, maxDepth: 40, digest: "728ea27e31b3972b019db8b1e817d53caec9d905930df29ae475fe94846caad8"},
 	"language":      {routes: 8408, links: 15864, migrations: 256, spine: 6, raw: 10761, public: 7082, terminals: 5057, reductions: 5704, migrated: 150, maxDepth: 125, digest: "481aba4139174c63b03fa6856b427fa09268539e240f951ac8fe40cf1e0fe006"},
-	"grammargen_lr": {routes: 84924, links: 153451, migrations: 316, spine: 1, raw: 109614, public: 71768, terminals: 49911, reductions: 59703, migrated: 218, maxDepth: 348, digest: "e7a5faa302b6b27539694c0a08830cf026a288f6813607a3687a96340eaaab44"},
+	"grammargen_lr": {routes: 84928, links: 153463, migrations: 316, spine: 1, raw: 109614, public: 71768, terminals: 49911, reductions: 59703, migrated: 218, maxDepth: 348, digest: "e7a5faa302b6b27539694c0a08830cf026a288f6813607a3687a96340eaaab44"},
 }
 
 func TestCanonicalAcceptedRouteSpineCensus(t *testing.T) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1864,7 +1864,14 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 			}
 		}
 		if c.diagnostics.foldSamePredecessorShallowPayloads {
-			candidate := -1
+			// A shallow-class-equal incumbent shares the incoming payload's symbol,
+			// span, and child count. Under ordinary reductions a boundary holds at
+			// most one such incumbent, but a declined precedence tie (below) can
+			// leave two structurally distinct alternates coexisting, so this search
+			// tolerates several and also finds the structurally identical one.
+			shallowCount := 0
+			firstShallow := -1
+			structuralMatch := -1
 			for index, link := range oldLinks {
 				equal, err := c.shallowPayloadClassEqual(link, in)
 				if err != nil {
@@ -1873,13 +1880,40 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				if !equal {
 					continue
 				}
-				if candidate >= 0 {
-					return condenseOutcome{}, errors.New("parser-core phase zero: multiple shallow-fold incumbents")
+				shallowCount++
+				if firstShallow < 0 {
+					firstShallow = index
 				}
-				candidate = index
+				structural, err := c.subtreesStructurallyEqual(link.payload, in.payload)
+				if err != nil {
+					return condenseOutcome{}, err
+				}
+				if structural {
+					if structuralMatch >= 0 {
+						return condenseOutcome{}, errors.New("parser-core phase zero: multiple structural-fold incumbents")
+					}
+					structuralMatch = index
+				}
 			}
-			if candidate >= 0 {
-				incumbentPrecedence, err := c.effectivePayloadPrecedence(oldLinks[candidate].payload, oldLinks[candidate].scoreDelta)
+			foldDeclined := false
+			switch {
+			case structuralMatch >= 0:
+				// The incoming payload reproduces an existing alternate exactly, so
+				// it is a redundant GLR path. Structural equality implies equal
+				// dynamic precedence, so this is the duplicate drop that keeps one
+				// subtree per (symbol, span), matching production.
+				c.recordLinkUnionDuplicateNoop()
+				if phase0AEnabled {
+					phase0AObserveCandidateDrop(c, key, in, oldID, structuralMatch, phase0ATransitionPrecedenceDrop)
+				}
+				return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, nil
+			case shallowCount == 1:
+				// Exactly one shallow-class incumbent, structurally different. Rank
+				// the two by dynamic precedence, production's primary disambiguation
+				// for the clean parses this route admits (error cost is zero here, so
+				// it never outranks precedence).
+				incumbent := firstShallow
+				incumbentPrecedence, err := c.effectivePayloadPrecedence(oldLinks[incumbent].payload, oldLinks[incumbent].scoreDelta)
 				if err != nil {
 					return condenseOutcome{}, err
 				}
@@ -1887,36 +1921,67 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				if err != nil {
 					return condenseOutcome{}, err
 				}
-				if incomingPrecedence <= incumbentPrecedence {
+				switch {
+				case incomingPrecedence < incumbentPrecedence:
+					// The incumbent strictly dominates; drop the dominated incoming
+					// payload, as production keeps the higher-precedence subtree.
 					c.recordLinkUnionDuplicateNoop()
 					if phase0AEnabled {
-						phase0AObserveCandidateDrop(c, key, in, oldID, candidate, phase0ATransitionPrecedenceDrop)
+						phase0AObserveCandidateDrop(c, key, in, oldID, incumbent, phase0ATransitionPrecedenceDrop)
 					}
 					return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, nil
-				}
-				if phase0AEnabled {
-					phase0ABeginReplacement(c, key, in, oldID, candidate)
-				}
-				head, err := c.replaceBoundaryLink(key, probe, old, oldLinks, candidate, in)
-				if err != nil {
-					c.recordLinkUnionRejected()
-				} else {
-					c.recordLinkUnionPrecedenceReplaced()
-				}
-				return condenseOutcome{head: head, change: condenseUpdated}, err
-			}
-			outcome, handled, err := c.factorExactPredecessor(key, probe, oldID, oldLinks, in)
-			if err != nil || handled {
-				if handled {
+				case incomingPrecedence > incumbentPrecedence:
+					// The incoming payload strictly dominates; replace the incumbent.
+					if phase0AEnabled {
+						phase0ABeginReplacement(c, key, in, oldID, incumbent)
+					}
+					head, err := c.replaceBoundaryLink(key, probe, old, oldLinks, incumbent, in)
 					if err != nil {
 						c.recordLinkUnionRejected()
-					} else if outcome.change == condenseUpdated {
-						c.recordLinkUnionRecursiveChanged()
 					} else {
-						c.recordLinkUnionDuplicateNoop()
+						c.recordLinkUnionPrecedenceReplaced()
 					}
+					return condenseOutcome{head: head, change: condenseUpdated}, err
+				default:
+					// A precedence tie between two structurally different same-span
+					// payloads. Dynamic precedence cannot rank them, and the compact
+					// route does not own production's error-cost and structural
+					// tie-breaks. Choosing one here by insertion order is the silent
+					// wrong-tree divergence the admission flip surfaced (Go's
+					// call_expression(index_expression) versus
+					// type_conversion_expression(generic_type) for `Foo[int](a)`).
+					// Decline the fold: keep both links as coexisting alternates and
+					// let them race to EOF. A local ambiguity collapses when one arm
+					// dies; a genuine whole-parse ambiguity keeps more than one
+					// accepted derivation, and the sole-exact acceptance gate then
+					// fails closed to production.
+					foldDeclined = true
 				}
-				return outcome, err
+			case shallowCount >= 2:
+				// The boundary already carries coexisting structural alternates from
+				// an earlier declined tie. Do not precedence-collapse across an
+				// already ambiguous boundary; append the incoming payload as a
+				// further distinct alternate for the sole-exact gate to resolve.
+				foldDeclined = true
+			}
+			// A declined fold skips the exact-predecessor factor (which merges
+			// same-boundary predecessors) and appends the incoming link as a
+			// surviving alternate below. With no shallow-class incumbent the factor
+			// still runs, preserving the recursive-insertion path unchanged.
+			if !foldDeclined && shallowCount == 0 {
+				outcome, handled, err := c.factorExactPredecessor(key, probe, oldID, oldLinks, in)
+				if err != nil || handled {
+					if handled {
+						if err != nil {
+							c.recordLinkUnionRejected()
+						} else if outcome.change == condenseUpdated {
+							c.recordLinkUnionRecursiveChanged()
+						} else {
+							c.recordLinkUnionDuplicateNoop()
+						}
+					}
+					return outcome, err
+				}
 			}
 		}
 	}
@@ -2428,6 +2493,65 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 		state: state, byteOffset: byteOffset, firstLink: uint32(first),
 		linkCount: uint32(len(links)), pathCount: pathCount,
 	})
+}
+
+// subtreesStructurallyEqual reports whether two compact payload subtrees are the
+// same parse: identical symbol, span, production, precedence, extra/external
+// flags, field and alias vectors, and recursively identical children. It is the
+// authorization test for a same-predecessor shallow-payload fold. Two links that
+// reach one boundary with structurally-equal payloads are a redundant GLR path
+// (the compact route and production both collapse them). Two links whose
+// payloads are only shallow-class-equal but structurally DIFFERENT are a genuine
+// structural ambiguity (for example Go's call_expression(index_expression) versus
+// type_conversion_expression(generic_type) for `Foo[int](a)`); the compact route
+// must not silently pick one by a local precedence comparison, so the fold is
+// declined and both links survive as alternates. The surviving alternates raise
+// the accepted-head derivation count above one, and the sole-exact acceptance
+// gate then fails closed to production instead of routing a wrong tree.
+//
+// Payloads are only compared after a shallow-class match (same symbol, span, and
+// child count), so the walk short-circuits on the first structural difference and
+// stays bounded by the matched subtree's size. Compact payloads are acyclic by
+// construction, so the recursion terminates.
+func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
+	if left == right {
+		return true, nil
+	}
+	l, err := c.subtree(left)
+	if err != nil {
+		return false, err
+	}
+	r, err := c.subtree(right)
+	if err != nil {
+		return false, err
+	}
+	if l.symbol != r.symbol || l.productionID != r.productionID || l.dynamicPrecedence != r.dynamicPrecedence ||
+		l.startByte != r.startByte || l.endByte != r.endByte || l.childCount != r.childCount ||
+		l.fieldCount != r.fieldCount || l.aliasCount != r.aliasCount ||
+		l.extra != r.extra || l.external != r.external || l.terminal != r.terminal {
+		return false, nil
+	}
+	if !slices.Equal(
+		c.fields[l.firstField:l.firstField+l.fieldCount],
+		c.fields[r.firstField:r.firstField+r.fieldCount],
+	) {
+		return false, nil
+	}
+	if !slices.Equal(
+		c.aliases[l.firstAlias:l.firstAlias+l.aliasCount],
+		c.aliases[r.firstAlias:r.firstAlias+r.aliasCount],
+	) {
+		return false, nil
+	}
+	leftChildren := c.children[l.firstChild : l.firstChild+l.childCount]
+	rightChildren := c.children[r.firstChild : r.firstChild+r.childCount]
+	for index := range leftChildren {
+		equal, err := c.subtreesStructurallyEqual(leftChildren[index], rightChildren[index])
+		if err != nil || !equal {
+			return equal, err
+		}
+	}
+	return true, nil
 }
 
 func (c *Core) shallowPayloadClass(prevID NodeID, payloadID SubtreeID) (shallowPayloadClass, bool, error) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2512,7 +2512,10 @@ func (c *Core) appendAdjacencyNode(state StateID, byteOffset uint32, links []lin
 // Payloads are only compared after a shallow-class match (same symbol, span, and
 // child count), so the walk short-circuits on the first structural difference and
 // stays bounded by the matched subtree's size. Compact payloads are acyclic by
-// construction, so the recursion terminates.
+// construction: appendSubtreeRecord appends every child before its parent, so a
+// child SubtreeID is strictly less than its parent's. The walk enforces that
+// order and returns a fail-closed error on a violation, so the recursion also
+// terminates on a corrupted arena instead of overflowing the stack.
 func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 	if left == right {
 		return true, nil
@@ -2546,6 +2549,9 @@ func (c *Core) subtreesStructurallyEqual(left, right SubtreeID) (bool, error) {
 	leftChildren := c.children[l.firstChild : l.firstChild+l.childCount]
 	rightChildren := c.children[r.firstChild : r.firstChild+r.childCount]
 	for index := range leftChildren {
+		if leftChildren[index] >= left || rightChildren[index] >= right {
+			return false, errors.New("parser-core phase zero: compact subtree child identifier out of order during structural comparison")
+		}
 		equal, err := c.subtreesStructurallyEqual(leftChildren[index], rightChildren[index])
 		if err != nil || !equal {
 			return equal, err

--- a/internal/parsercorephase0/link_fold_test.go
+++ b/internal/parsercorephase0/link_fold_test.go
@@ -55,7 +55,7 @@ func appendShallowPayload(t *testing.T, core *Core, spec shallowPayloadSpec) Sub
 // lower score is dropped, and a precedence TIE is NOT resolved by insertion order.
 // A tie between structurally different payloads is a genuine ambiguity the compact
 // route cannot rank, so both links must coexist as alternates (see
-// Core.condenseLinkUnion); the sole-exact acceptance gate then fails closed rather
+// Core.condenseWithOutcomeAtomic); the sole-exact acceptance gate then fails closed rather
 // than routing one arm silently. This is the fix for the Go generic-instantiation
 // / type-conversion divergence the Phase-3 admission flip surfaced.
 func TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore(t *testing.T) {

--- a/internal/parsercorephase0/link_fold_test.go
+++ b/internal/parsercorephase0/link_fold_test.go
@@ -49,14 +49,24 @@ func appendShallowPayload(t *testing.T, core *Core, spec shallowPayloadSpec) Sub
 	return payload
 }
 
+// TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore proves
+// the shallow-payload fold ranks two structurally different same-span payloads by
+// aggregate dynamic precedence: the strictly higher score wins, the strictly
+// lower score is dropped, and a precedence TIE is NOT resolved by insertion order.
+// A tie between structurally different payloads is a genuine ambiguity the compact
+// route cannot rank, so both links must coexist as alternates (see
+// Core.condenseLinkUnion); the sole-exact acceptance gate then fails closed rather
+// than routing one arm silently. This is the fix for the Go generic-instantiation
+// / type-conversion divergence the Phase-3 admission flip surfaced.
 func TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore(t *testing.T) {
 	for _, test := range []struct {
 		name          string
 		incomingScore int64
 		wantIncoming  bool
+		wantCoexist   bool
 	}{
 		{name: "lower", incomingScore: 9},
-		{name: "equal", incomingScore: 10},
+		{name: "equal", incomingScore: 10, wantCoexist: true},
 		{name: "higher", incomingScore: 11, wantIncoming: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -81,6 +91,39 @@ func TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore(t *t
 			})
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if test.wantCoexist {
+				// A precedence tie between structurally different payloads keeps both
+				// links as alternates on a fresh head.
+				if newHead == oldHead {
+					t.Fatalf("precedence tie retained historical head %+v instead of coexisting", oldHead)
+				}
+				paths, err := core.Derivations(newHead)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := map[SubtreeID]int64{incumbent: 10, incoming: test.incomingScore}
+				if len(paths) != len(want) {
+					t.Fatalf("tie coexistence derivations = %#v, want both payloads %v", paths, want)
+				}
+				for _, path := range paths {
+					if len(path.Payloads) != 1 {
+						t.Fatalf("unexpected derivation shape %#v", path)
+					}
+					wantScore, ok := want[path.Payloads[0]]
+					if !ok {
+						t.Fatalf("unexpected coexisting payload %#v", path)
+					}
+					if path.Score != wantScore {
+						t.Fatalf("coexisting payload %d score=%d want=%d", path.Payloads[0], path.Score, wantScore)
+					}
+					delete(want, path.Payloads[0])
+				}
+				if len(want) != 0 {
+					t.Fatalf("tie coexistence dropped payloads %v", want)
+				}
+				return
 			}
 
 			wantPayload, wantScore, wantOrder := incumbent, int64(10), uint64(7)
@@ -133,14 +176,28 @@ func TestCondenseOutcomeClassifiesBoundaryFreshness(t *testing.T) {
 		t.Fatalf("exact outcome=%+v err=%v, want unchanged head %+v", exact, err, created.head)
 	}
 
+	// A strictly lower aggregate score is dominated and dropped (the boundary is
+	// unchanged). A precedence TIE between structurally different payloads is a
+	// genuine ambiguity that must coexist as an alternate, so it publishes a fresh
+	// head instead of silently dropping. The extra alternate is what lets the
+	// sole-exact acceptance gate fail closed on real ambiguous inputs.
 	lower := appendShallowPayload(t, core, shallowPayloadSpec{
 		symbol: 20, productionID: 2, startByte: 12, endByte: 17, childSymbols: []Symbol{31},
 	})
-	for _, score := range []int64{9, 10} {
-		outcome, err := core.condenseWithOutcome(key, linkInput{prev: seed.Node, payload: lower, scoreDelta: score})
-		if err != nil || outcome.change != condenseUnchanged || outcome.head != created.head {
-			t.Fatalf("non-winning score %d outcome=%+v err=%v", score, outcome, err)
-		}
+	dropped, err := core.condenseWithOutcome(key, linkInput{prev: seed.Node, payload: lower, scoreDelta: 9})
+	if err != nil || dropped.change != condenseUnchanged || dropped.head != created.head {
+		t.Fatalf("dominated score outcome=%+v err=%v, want unchanged head %+v", dropped, err, created.head)
+	}
+	tie, err := core.condenseWithOutcome(key, linkInput{prev: seed.Node, payload: lower, scoreDelta: 10})
+	if err != nil || tie.change != condenseUpdated || tie.head == created.head {
+		t.Fatalf("structural tie outcome=%+v err=%v, want a fresh coexisting head", tie, err)
+	}
+	tiePaths, err := core.Derivations(tie.head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tiePaths) != 2 {
+		t.Fatalf("structural tie head folded to %#v, want two coexisting alternates", tiePaths)
 	}
 
 	higher := appendShallowPayload(t, core, shallowPayloadSpec{
@@ -189,10 +246,22 @@ func TestDiagnosticShallowFoldZeroChildParentHasZeroEffectivePrecedence(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if head != oldHead {
-		t.Fatalf("effective-zero incoming parent replaced incumbent: old=%+v new=%+v", oldHead, head)
+	// Both zero-child payloads have zero effective precedence (childCount == 0),
+	// so the aggregate scores cannot rank them: this is a precedence tie. The two
+	// payloads are structurally different (different production), so the compact
+	// route must not keep one by insertion order. It coexists them as alternates,
+	// so the sole-exact acceptance gate can fail closed on real ambiguous inputs.
+	if head == oldHead {
+		t.Fatalf("zero-precedence tie collapsed to a single head %+v instead of coexisting", oldHead)
 	}
 	paths, err := core.Derivations(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 2 {
+		t.Fatalf("zero-precedence tie folded to %#v, want two coexisting alternates", paths)
+	}
+	oldPaths, err := core.Derivations(oldHead)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,8 +269,8 @@ func TestDiagnosticShallowFoldZeroChildParentHasZeroEffectivePrecedence(t *testi
 		Payloads: []SubtreeID{incumbent}, Score: 7,
 		BranchOrder: 3, HasBranchOrder: true,
 	}}
-	if !reflect.DeepEqual(paths, want) {
-		t.Fatalf("zero-child parent paths=%#v, want stored incumbent score/order %#v", paths, want)
+	if !reflect.DeepEqual(oldPaths, want) {
+		t.Fatalf("historical zero-child head mutated: paths=%#v, want stored incumbent score/order %#v", oldPaths, want)
 	}
 }
 

--- a/parser_go_newmake_edge_test.go
+++ b/parser_go_newmake_edge_test.go
@@ -31,6 +31,29 @@ func findAllNodesOfType(lang *gotreesitter.Language, node *gotreesitter.Node, ty
 	return out
 }
 
+// assertGoCandidateMatchesProduction routes src through the compact candidate
+// engine and requires the result to equal the production tree byte for byte.
+// The Phase-3 compact route fails closed on the generic-instantiation conflict,
+// so this holds whether the candidate routes or declines to production; the
+// helper only proves the route never diverges from production for this fixture.
+func assertGoCandidateMatchesProduction(t *testing.T, lang *gotreesitter.Language, src string, prodTree *gotreesitter.Tree) {
+	t.Helper()
+	prodSExpr := prodTree.RootNode().SExpr(lang)
+	gotreesitter.ResetAdmissionCandidateCountersForTest()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	candTree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("candidate parse failed: %v", err)
+	}
+	defer candTree.Release()
+	if got := candTree.RootNode().SExpr(lang); got != prodSExpr {
+		routed, fallback := gotreesitter.AdmissionCandidateCounters()
+		t.Fatalf("candidate route diverged from production (routed=%d fallback=%d):\n  production: %s\n  candidate:  %s",
+			routed, fallback, prodSExpr, got)
+	}
+}
+
 // assertNoErrorOrMissing walks the whole tree and fails the test if any
 // ERROR or MISSING node is found anywhere, printing the S-expression for
 // diagnosis. Modeled on the existing GoInterpretedStringFalseErrors /
@@ -330,14 +353,18 @@ func TestParseGoNewMakeGenericInstantiationUntouched(t *testing.T) {
 		"\t_ = a\n" +
 		"\t_ = b\n" +
 		"}\n"
-	// Pin to production: this asserts the production-engine Go tree shape against
-	// the tree-sitter-go C oracle. The Phase-3 admission flip surfaced a compact
-	// candidate-route divergence on `Foo[int](a)` (call_expression vs the correct
-	// type_conversion_expression); that known divergence is tracked separately by
-	// TestAdmissionCandidateGoTypeConversionKnownDivergence.
+	// Assert the production-engine Go tree shape against the tree-sitter-go C
+	// oracle. The Phase-3 admission flip surfaced a compact candidate-route
+	// divergence on `Foo[int](a)` (call_expression versus the correct
+	// type_conversion_expression); the compact route now fails closed on that
+	// conflict class (TestAdmissionCandidateGoTypeConversionFailsClosed). Because
+	// the fix is fail-closed, this fixture is re-routed through the candidate:
+	// the route must reproduce the production tree byte for byte, whether it
+	// routes or declines to production.
 	tree, lang := parseGoProduction(t, src)
 	root := tree.RootNode()
 	assertNoErrorOrMissing(t, lang, root, "generic-instantiation-untouched")
+	assertGoCandidateMatchesProduction(t, lang, src, tree)
 
 	if calls := findAllNodesOfType(lang, root, "call_expression"); len(calls) != 0 {
 		t.Fatalf("expected zero call_expression nodes for generic instantiation syntax, got %d; root=%s", len(calls), root.SExpr(lang))

--- a/parsercore_phase0_canonical_admission_internal_test.go
+++ b/parsercore_phase0_canonical_admission_internal_test.go
@@ -111,12 +111,12 @@ var diagnosticParserCoreCanonicalAdmissions = []diagnosticParserCoreCanonicalAdm
 		rawSelected: core.RawSelectedCensus{Nodes: 109614, Parents: 59703, Leaves: 49911},
 		work: core.Work{
 			Shifts: 66119, Reductions: 75988, ReductionPopRequests: 75988,
-			EmittedPopPaths: 84924, EmittedPopPayloads: 153451,
-			PredecessorLinkUnionAttempts: 13748, PredecessorLinkUnionDuplicateNoop: 1638,
+			EmittedPopPaths: 84928, EmittedPopPayloads: 153463,
+			PredecessorLinkUnionAttempts: 13752, PredecessorLinkUnionDuplicateNoop: 1638,
 			PredecessorLinkUnionPrecedenceReplaced: 3577, PredecessorLinkUnionRecursiveChanged: 7,
-			PredecessorLinkUnionAlternateAppended: 8526,
-			GraphLinkAdditionsProxy:               150271, LeafConstructionsProxy: 53897,
-			ParentConstructionsProxy: 78426,
+			PredecessorLinkUnionAlternateAppended: 8530,
+			GraphLinkAdditionsProxy:               150275, LeafConstructionsProxy: 53897,
+			ParentConstructionsProxy: 78430,
 		},
 	},
 }


### PR DESCRIPTION
## Summary

The compact candidate route routed a wrong tree on the Go generic-instantiation / type-conversion conflict class (bare `Ident[TypeArgs](args)`). Production forks this GLR conflict and resolves `Ident[...]` as a generic type or a generic call. The compact scheduler forked the same conflict but collapsed it in the GSS shallow-payload fold: on a dynamic-precedence TIE between two structurally different same-span payloads, the fold kept one arm by insertion order. That silently routed `call_expression(index_expression(...))` with no fallback.

This change makes the fold FAIL CLOSED. On a precedence tie it folds only a structurally identical duplicate; a structurally different payload at a tie is a genuine ambiguity the route cannot rank, so both links survive as coexisting alternates. A local ambiguity collapses when one arm dies before EOF; a genuine whole-parse ambiguity keeps more than one accepted derivation, and the existing sole-exact acceptance gate then declines to production.

The decline keys on the GLR conflict, not on any literal shape. Every `Ident[TypeArgs](args)` member declines; conflict-free inputs keep routing.

## Changes

- Add `Core.subtreesStructurallyEqual` (internal/parsercorephase0/core.go): a recursive same-output-tree test that short-circuits on the first difference.
- Rework the shallow-payload fold in `Core.condenseLinkUnion`: strict higher precedence still replaces, strict lower still drops, a tie folds only a structural duplicate, and a tie between different payloads keeps both as alternates. The fold tolerates several shallow-class incumbents instead of erroring.
- Rewrite the divergence tracker as `TestAdmissionCandidateGoTypeConversionFailsClosed`: it asserts the route declines (routed counter stays 0, fallback counter moves) and returns production's tree byte for byte, instead of skipping.
- Add `TestAdmissionGenericConflictFamilyNoDivergence`: 19 fixtures across one/two/N type args, nested generics, chains, the paren form, in-expression use, `make`/`new`, and the conflict-free bounds. It proves zero divergences (every case byte-exact or declined-to-production).
- Re-route `TestParseGoNewMakeGenericInstantiationUntouched` through the candidate and require it to match production.
- Point the Go GLR parity canaries (`TestParityGLRCanarySet/go/ambiguous-call`, `TestParityGLRCanaryGo`) at `Foo[int](a)` so they measure real GLR branching.
- Update the grammargen_lr golden work counts (canonical admission and census): the tree digest is unchanged; only a few tie folds now coexist transiently before dying, so pop routes and alternate appends move by a handful.
- Update three `link_fold` unit tests to the new coexist-on-structural-tie contract.

## Coverage impact

Measured on 600 real Go files with the route on: 574 routed before, 571 after. The fix narrows Go coverage by 3 files (0.5%). Those files carry the genuine generic-instantiation conflict and previously routed a silently wrong tree; they now decline to production. The construct in expression position is near-absent in this codebase.

## Testing

- `go test . -count=1` (route on, full default suite)
- `go test . -tags gts_parsercorephase0 -count=1`
- `go test ./internal/parsercorephase0/... -race -count=1`
- `GTS_ADMISSION_SCORECARD=1 go test . -tags gts_parsercorephase0 -run TestAdmissionCandidateScorecard206` — DIVERGE=0 (48 PASS, 153 FALLBACK)
- Invariant gate (empty allowlist diff), W5 latency gates, digest gates, canonical census golden
- `GTS_PARITY_ALLOW_HOST=1 go test -tags treesitter_c_parity -run 'TestParityGLRCanaryGo|TestParityGLRCanarySet' ./cgo_harness` — green with C parity
- Emergency build compiles: `go build -tags gts_no_parsercorephase0 ./...`

## Stacking

This PR is stacked: its base is `codex/phase3-admission-flip`. It must merge with or after that branch (PR #420). Do not merge before the flip lands.
