### PR TITLE
optimize(parsercore): cache per-language tables and reuse parse buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ for tags and release notes while still in `0.x`.
 - **The compact parser core is now the default full-parse route for eligible
   languages** (Phase-3 admission flip). `Parser.Parse` routes a fresh, full,
   production-DFA parse of an eligible grammar through the compact
-  `internal/parsercorephase0` engine, then materializes a public tree that is
-  byte-exact with the production engine. The compact engine promotes from the
-  `gts_parsercorephase0` opt-in tag into the default build; the emergency
-  opt-out tag `gts_no_parsercorephase0` compiles it back out.
+  `internal/parsercorephase0` engine, then materializes a public tree. The tree
+  is byte-exact with the production engine on the routed, verified surface: the
+  48 byte-exact scorecard routes and the canonical fixtures. The runner's strict
+  acceptance gate fails closed to production on any input it cannot reproduce
+  byte-for-byte. The compact engine promotes from the `gts_parsercorephase0`
+  opt-in tag into the default build; the emergency opt-out tag
+  `gts_no_parsercorephase0` compiles it back out.
 
   Evidence for the admission:
 
@@ -23,12 +26,46 @@ for tags and release notes while still in `0.x`.
     digest is 100 percent exact on the canonical fixtures. The 206-language
     scorecard through the switch reports 48 byte-exact routes, 0 divergences,
     153 fail-closed fallbacks, and 5 token-source skips.
+  - **Known divergence class (generic call versus type conversion).** The
+    scorecard fixtures do not cover every Go conflict. One divergence remains
+    outside them: on the ambiguous construct `Foo[int](a)` the compact scheduler
+    resolves the conflict to `call_expression(index_expression)`, while the
+    production engine and the tree-sitter-go C oracle resolve it to
+    `type_conversion_expression(generic_type)`
+    (`TestAdmissionCandidateGoTypeConversionKnownDivergence`). This is the
+    generic-call conflict class. A companion lane makes the compact scheduler
+    decline this conflict class and fail closed to production, so the routed
+    surface stays byte-exact until the scheduler reproduces the production
+    resolution.
   - **Timing.** The quiet-host publication run (lane
     strictboundary-20260720T231334Z-v6 phase3, n2d-standard-4, 5 ABBA cycles)
     measured a production-over-candidate geomean speedup of 1.8321 (gate is at
-    or above 1.0204). The worst fixture ran 1.526 times faster. Peak resident
-    set size fell on all four fixtures (grammargen_lr 94 MB against 206 MB). The
-    deep C-oracle parity preflight passed in the same run.
+    or above 1.0204) on the warm direct-runner path
+    (`BenchmarkParserCoreFreshFullCanonical`). The worst fixture ran 1.526 times
+    faster. Peak resident set size fell on all four fixtures (grammargen_lr
+    94 MB against 206 MB). The deep C-oracle parity preflight passed in the same
+    run.
+  - **Adapter Parse-path reconciliation.** The 1.8321 geomean was measured on
+    the direct-runner path, not on `Parser.Parse`. The initial adapter regressed
+    time and allocations, because it rebuilt the compact action tables on every
+    fresh `Parser` and did not pool the materialization scratch. Two adapter
+    fixes removed that tax:
+    - a per-`*Language` table cache builds the converted action and reduction
+      tables once per language (about 95 KiB retained) instead of once per parse;
+      and
+    - a per-`Parser` runner reuses the materialization scratch, the public-tree
+      node buffers, and the Go-compatibility walk stack across parses.
+
+    After the fixes, warm route-ON allocations on `BenchmarkGoParseFullDFA` fall
+    from about 71 to about 24 per operation, and bytes per operation from about
+    99 KiB to about 17 KiB. On the human-authored Go fixtures
+    (`BenchmarkGoParseWarmRealDFA`) the routed parses now run about 1.45 to 1.66
+    times faster than production through `Parser.Parse` (geomean of the routed
+    fixtures about 1.57 times). The remaining gap to the 1.8321 direct-runner
+    number is the production Parse tail the adapter still runs. On the synthetic,
+    highly repetitive `BenchmarkGoParseFullDFA` source the routed parse stays
+    slower than production, because the compact scheduler dominates that input;
+    the speedup holds on the human-authored fixtures the sealed number measured.
   - **Sealed epoch (v0.45.0).** The compact route measured 2.9975 times the C
     reference against the production route at 5.526 times, hardware-attested and
     verified. Allocation levels sit at 92 to 316 allocations per operation

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -79,8 +79,8 @@ func init() {
 // ("0", "false", "off", "no", any case) resolves OFF -- the documented escape
 // hatch that forces every eligible full parse back to the production route.
 func admissionCandidateEnvEnabled() bool {
-	switch strings.TrimSpace(os.Getenv("GTS_ADMISSION_CANDIDATE")) {
-	case "0", "false", "FALSE", "False", "off", "OFF", "no", "NO":
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GTS_ADMISSION_CANDIDATE"))) {
+	case "0", "false", "off", "no":
 		return false
 	default:
 		return true

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -366,8 +366,10 @@ func TestAdmissionSwitchEnvVarContract(t *testing.T) {
 		want  bool
 	}{
 		{"1", true}, {"true", true}, {"on", true}, {"yes", true}, {"YES", true},
-		{"", true}, {"nonsense", true},
+		{"", true}, {"nonsense", true}, {"On", true}, {"Yes", true},
 		{"0", false}, {"false", false}, {"off", false}, {"no", false}, {"NO", false},
+		{"Off", false}, {"No", false}, {"False", false}, {"OFF", false},
+		{" off ", false}, {"Off\t", false},
 	} {
 		t.Setenv("GTS_ADMISSION_CANDIDATE", tc.value)
 		if got := gts.AdmissionCandidateEnvEnabledForTest(); got != tc.want {
@@ -409,8 +411,9 @@ func TestAdmissionSwitchDeclinesWhenLoggerAttached(t *testing.T) {
 // Such inputs stay on production and honor ParseStopMemoryBudget. Inputs below
 // the floor, where no budget arms on either route, still route freely.
 func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
-	// Mirror parseRuntimeMemoryMinSourceBytes (parser_memory_budget_runtime.go).
-	const minBudgetSourceBytes = 64 * 1024
+	// Pin the gate to the single source of truth rather than copy the 64 KiB
+	// literal (parseRuntimeMemoryMinSourceBytes, parser_memory_budget_runtime.go).
+	minBudgetSourceBytes := gts.ParseRuntimeMemoryMinSourceBytesForTest()
 
 	restore := gts.AdmissionCandidateRouteDefault()
 	defer gts.SetAdmissionCandidateRouteDefault(restore)
@@ -431,6 +434,15 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 	}
 	smallTree.Release()
 	if routed, _ := gts.AdmissionCandidateCounters(); routed == 0 {
+		// In the emergency opt-out build (-tags gts_no_parsercorephase0) the
+		// compact engine is compiled out, so every eligible parse fails closed and
+		// the routed counter cannot move. The size-gate contract this test proves
+		// (budget-eligible inputs stay on production) still holds, so skip the
+		// positive control rather than fail. The stub records the "compiled out"
+		// fallback reason (admission_switch_stub.go).
+		if reason := gts.AdmissionCandidateLastFallbackReason(); strings.Contains(reason, "compiled out") {
+			t.Skip("compact candidate route compiled out (-tags gts_no_parsercorephase0); the routed counter cannot move")
+		}
 		t.Fatalf("small clean source below the floor did not route to the candidate; routed=%d", routed)
 	}
 
@@ -455,6 +467,48 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 	if routed, _ := gts.AdmissionCandidateCounters(); routed != 0 {
 		t.Fatalf("source of %d bytes (>= %d floor) routed to the candidate; the memory-budget size gate did not decline it (routed=%d)",
 			big.Len(), minBudgetSourceBytes, routed)
+	}
+
+	// Exact-boundary cases pin the gate's strict comparison
+	// (admissionCandidateInputSizeEligible: sourceLen < floor): floor-1 is
+	// eligible and admits, the floor byte is not eligible and declines.
+	for _, bc := range []struct {
+		name       string
+		length     int
+		wantRouted bool
+	}{
+		{"floor_minus_one", minBudgetSourceBytes - 1, true},
+		{"floor_exact", minBudgetSourceBytes, false},
+	} {
+		src := cleanGoSourceOfExactLength(t, bc.length)
+		if len(src) != bc.length {
+			t.Fatalf("%s: built %d bytes, want exactly %d", bc.name, len(src), bc.length)
+		}
+		gts.ResetAdmissionCandidateCountersForTest()
+		boundaryParser := gts.NewParser(lang)
+		boundaryTree, parseErr := boundaryParser.Parse(src)
+		if parseErr != nil {
+			t.Fatalf("%s parse: %v", bc.name, parseErr)
+		}
+		boundaryTree.Release()
+		routed, _ := gts.AdmissionCandidateCounters()
+		if bc.wantRouted {
+			if routed == 0 {
+				// The size gate admitted the input (it is below the floor). Whether the
+				// compact engine then accepts it is a separate concern; in the emergency
+				// opt-out build it is always declined. Only a size-gate failure is a bug.
+				if reason := gts.AdmissionCandidateLastFallbackReason(); strings.Contains(reason, "compiled out") {
+					continue
+				}
+				t.Fatalf("%s (%d bytes, below the %d floor) did not route; the size gate must admit it (routed=%d, reason=%q)",
+					bc.name, bc.length, minBudgetSourceBytes, routed, gts.AdmissionCandidateLastFallbackReason())
+			}
+			continue
+		}
+		if routed != 0 {
+			t.Fatalf("%s (%d bytes, at the %d floor) routed; the size gate must decline it (routed=%d)",
+				bc.name, bc.length, minBudgetSourceBytes, routed)
+		}
 	}
 
 	// With a low budget, a pathological large source on production honors
@@ -484,6 +538,26 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		t.Fatalf("ParseStopReason() = %q, want %q (production must honor the budget the candidate cannot poll)",
 			got, gts.ParseStopMemoryBudget)
 	}
+}
+
+// cleanGoSourceOfExactLength builds a valid Go source of exactly n bytes. It
+// pads the remainder inside a mid-source block comment (trivia the parser
+// skips) and ends with a clean statement, so the source parses cleanly at any
+// exact byte length at or above the minimum without a trailing-trivia EOF edge.
+func cleanGoSourceOfExactLength(t *testing.T, n int) []byte {
+	t.Helper()
+	const prefix = "package p\n/*"   // opens the padding block comment
+	const suffix = "*/\nvar x = 1\n" // closes it, then a clean statement
+	if n < len(prefix)+len(suffix) {
+		t.Fatalf("exact length %d is below the %d-byte minimum valid program", n, len(prefix)+len(suffix))
+	}
+	src := make([]byte, n)
+	copy(src, prefix)
+	for i := len(prefix); i < n-len(suffix); i++ {
+		src[i] = ' '
+	}
+	copy(src[n-len(suffix):], suffix)
+	return src
 }
 
 // TestAdmissionCandidateGoTypeConversionKnownDivergence records a KNOWN, TRACKED

--- a/benchmark_admission_fresh_test.go
+++ b/benchmark_admission_fresh_test.go
@@ -1,0 +1,41 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// BenchmarkGoParseFreshParserPerFileDFA measures the admission Parse path when a
+// caller creates a fresh Parser for every file (a common per-request pattern).
+// It guards the per-*Language table cache: the candidate route must not rebuild
+// the compact action tables on each fresh Parser. Set GTS_ADMISSION_CANDIDATE=0
+// to measure the production route for the same interleaved comparison.
+func BenchmarkGoParseFreshParserPerFileDFA(b *testing.B) {
+	lang := grammars.GoLanguage()
+	src := makeGoBenchmarkSource(benchmarkFuncCount(b))
+
+	// Warm the per-language table cache once so the steady-state per-file cost,
+	// not the one-time first-build, is what the loop measures.
+	warm := gotreesitter.NewParser(lang)
+	if tree, err := warm.Parse(src); err != nil {
+		b.Fatalf("warm parse error: %v", err)
+	} else {
+		tree.Release()
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(src)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		parser := gotreesitter.NewParser(lang)
+		tree, err := parser.Parse(src)
+		if err != nil {
+			b.Fatalf("parse error: %v", err)
+		}
+		requireCompleteParse(b, tree, src, lang, "fresh parser full dfa")
+		tree.Release()
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -267,6 +267,14 @@ func AdmissionCandidateEnvEnabledForTest() bool {
 	return admissionCandidateEnvEnabled()
 }
 
+// ParseRuntimeMemoryMinSourceBytesForTest exposes the source-length floor where
+// the production route arms the automatic memory budget, so the external test
+// package can pin the admission size gate to the single source of truth
+// (parseRuntimeMemoryMinSourceBytes) instead of copying the 64 KiB literal.
+func ParseRuntimeMemoryMinSourceBytesForTest() int {
+	return parseRuntimeMemoryMinSourceBytes
+}
+
 // AdmissionSubParserProbe bundles internal sub-parser construction so the
 // external test package can prove recovery, snippet, and injection sub-parsers
 // are born pinned to the production route.

--- a/language.go
+++ b/language.go
@@ -548,6 +548,22 @@ type Language struct {
 	// invalidate it. See cRecoveryGateCacheKeyFor.
 	cRecoveryGateCache atomic.Pointer[cRecoveryGateCacheEntry]
 
+	// compactTables memoizes the converted compact-parser (parsercorephase0)
+	// action and reduction tables for the Phase-3 admission candidate route. The
+	// conversion reads only immutable language data, so one build serves every
+	// Parser of this Language. compactTables is typed as any because the concrete
+	// type (*parserCoreLanguageTables) only exists under the default build; the
+	// emergency opt-out tag gts_no_parsercorephase0 never touches it.
+	//
+	// The cache lives on the Language rather than in a process-wide map, so it
+	// never outlives the Language it describes. A global identity-keyed map would
+	// pin every Language (and its multi-megabyte decoded grammar and lex tables)
+	// for the process lifetime, which leaks memory for callers that build many
+	// transient languages. See acquireParserCoreLanguageTables.
+	compactTablesOnce sync.Once
+	compactTables     any   // *parserCoreLanguageTables under the default build
+	compactTablesErr  error // the build error, memoized alongside compactTables
+
 	// NonTerminalAliasMap mirrors tree-sitter C's ts_non_terminal_alias_map.
 	// Rows are indexed by nonterminal symbol and contain aliases that require
 	// preserving the wrapper during alias-bearing reductions. This is cold

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -321,20 +321,78 @@ var parserCoreCertifiedGoBlob []byte
 
 func (e *diagnosticParserCoreDecline) Error() string { return string(e.boundary) + ": " + e.detail }
 
-type parserCoreRootTables struct {
-	parser              *Parser
+// parserCoreLanguageTables holds the immutable, language-derived compact-parser
+// action and reduction tables. Its content depends only on the language's
+// ParseActions plus its field and alias metadata, so every Parser of the same
+// *Language shares one instance through the per-language cache below. Sharing
+// the converted tables removes a full action-table rebuild (about 2.5 MB and
+// 3.1k allocations for the Go grammar) from every fresh-Parser candidate parse.
+type parserCoreLanguageTables struct {
 	actionRows          []core.ActionRow
 	reductionPlans      []core.ReductionPlan
 	reductionPlanIndex  []uint16
 	reductionPlanStride int
 }
 
-func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
+// parserCoreRootTables binds one Parser to the shared, immutable language
+// tables. The Parser back-reference resolves only language-derived lookups
+// (action index, goto, and root symbol), which every Parser of the same
+// *Language resolves identically, so the wrapper stays per-Parser while the
+// heavy converted tables stay shared.
+type parserCoreRootTables struct {
+	parser *Parser
+	*parserCoreLanguageTables
+}
+
+// acquireParserCoreLanguageTables returns the converted tables for the parser's
+// language, building them once and caching them on the Language itself.
+//
+// Retention decision -- the cache lives on the Language, so it lives and dies
+// with the Language and pins nothing extra. Each cached table set retains only
+// the converted action rows, reduction plans, and the reduction pair index:
+// about 95 KiB for the Go grammar (measured by
+// TestParserCoreLanguageTablesFootprint). A process-wide identity-keyed map was
+// rejected: its strong key would pin every routed Language, and each Language
+// holds a multi-megabyte decoded grammar and lex tables, so a caller that
+// builds many transient languages would leak hundreds of megabytes. The
+// sync.Once builds the tables exactly once per Language, even under concurrent
+// first use, without holding a process-wide lock across the build.
+func acquireParserCoreLanguageTables(parser *Parser) (*parserCoreLanguageTables, error) {
 	if parser == nil || parser.language == nil {
 		return nil, errors.New("parser-core phase zero: cannot cache actions without a parser language")
 	}
-	rows := make([]core.ActionRow, len(parser.language.ParseActions))
-	for index, entry := range parser.language.ParseActions {
+	lang := parser.language
+	lang.compactTablesOnce.Do(func() {
+		lang.compactTables, lang.compactTablesErr = buildParserCoreLanguageTables(parser)
+	})
+	if lang.compactTablesErr != nil {
+		return nil, lang.compactTablesErr
+	}
+	tables, _ := lang.compactTables.(*parserCoreLanguageTables)
+	return tables, nil
+}
+
+// newParserCoreRootTables binds parser to the shared language tables. It builds
+// the converted tables once per *Language and reuses them for every later
+// Parser of the same language.
+func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
+	langTables, err := acquireParserCoreLanguageTables(parser)
+	if err != nil {
+		return nil, err
+	}
+	return &parserCoreRootTables{parser: parser, parserCoreLanguageTables: langTables}, nil
+}
+
+// buildParserCoreLanguageTables converts the immutable language action table
+// into the compact-parser representation. It reads only language data, so the
+// tables it returns are correct for every Parser of that language.
+func buildParserCoreLanguageTables(parser *Parser) (*parserCoreLanguageTables, error) {
+	if parser == nil || parser.language == nil {
+		return nil, errors.New("parser-core phase zero: cannot cache actions without a parser language")
+	}
+	lang := parser.language
+	rows := make([]core.ActionRow, len(lang.ParseActions))
+	for index, entry := range lang.ParseActions {
 		converted := make([]core.Action, len(entry.Actions))
 		for ordinal, action := range entry.Actions {
 			var err error
@@ -345,7 +403,7 @@ func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
 		}
 		rows[index] = core.NewActionRow(converted)
 	}
-	tables := &parserCoreRootTables{parser: parser, actionRows: rows}
+	tables := &parserCoreLanguageTables{actionRows: rows}
 	maxProductionID, maxChildCount := 0, 0
 	for _, row := range rows {
 		for ordinal := 0; ordinal < row.Len(); ordinal++ {
@@ -374,11 +432,11 @@ func newParserCoreRootTables(parser *Parser) (*parserCoreRootTables, error) {
 			if tables.reductionPlanIndex[pairIndex] != 0 {
 				continue
 			}
-			fields, err := tables.ProductionFields(action.ProductionID, int(action.ChildCount))
+			fields, err := parserCoreProductionFields(lang, action.ProductionID, int(action.ChildCount))
 			if err != nil {
 				return nil, err
 			}
-			aliases, err := tables.ProductionAliases(action.ProductionID, int(action.ChildCount))
+			aliases, err := parserCoreProductionAliases(lang, action.ProductionID, int(action.ChildCount))
 			if err != nil {
 				return nil, err
 			}
@@ -488,8 +546,14 @@ func (a *parserCoreRootTables) Goto(state core.StateID, symbol core.Symbol) (cor
 }
 
 func (a *parserCoreRootTables) ProductionFields(productionID uint16, childCount int) ([]core.FieldMapEntry, error) {
-	p := a.parser
-	fieldIDs, inherited := buildFieldPlanForProduction(p.language, childCount, productionID)
+	return parserCoreProductionFields(a.parser.language, productionID, childCount)
+}
+
+// parserCoreProductionFields converts one production's field plan into compact
+// field-map entries. It reads only language data, so it serves both the shared
+// table build and the per-Parser TableView fallback.
+func parserCoreProductionFields(lang *Language, productionID uint16, childCount int) ([]core.FieldMapEntry, error) {
+	fieldIDs, inherited := buildFieldPlanForProduction(lang, childCount, productionID)
 	var out []core.FieldMapEntry
 	for index, fieldID := range fieldIDs {
 		if fieldID == 0 {
@@ -501,7 +565,13 @@ func (a *parserCoreRootTables) ProductionFields(productionID uint16, childCount 
 }
 
 func (a *parserCoreRootTables) ProductionAliases(productionID uint16, childCount int) ([]core.Symbol, error) {
-	lang := a.parser.language
+	return parserCoreProductionAliases(a.parser.language, productionID, childCount)
+}
+
+// parserCoreProductionAliases converts one production's alias sequence into
+// compact symbols. It reads only language data, so it serves both the shared
+// table build and the per-Parser TableView fallback.
+func parserCoreProductionAliases(lang *Language, productionID uint16, childCount int) ([]core.Symbol, error) {
 	if int(productionID) >= len(lang.AliasSequences) || childCount <= 0 || !languageProductionHasAliasSequence(lang, productionID, childCount) {
 		return nil, nil
 	}
@@ -662,7 +732,7 @@ func diagnosticParseParserCoreGenericFromSeed(
 		return result, &diagnosticParserCoreDecline{boundary: result.Boundary, detail: result.Detail}
 	}
 	return publishDiagnosticParserCoreGenericResult(result, scheduler, func(head core.Head) (*Tree, error) {
-		return materializeDiagnosticParserCoreAcceptedSelection(compact, head, scheduler.acceptedPayloads, parser, source)
+		return materializeDiagnosticParserCoreAcceptedSelection(compact, head, scheduler.acceptedPayloads, parser, source, nil)
 	})
 }
 
@@ -1585,28 +1655,138 @@ func (scratch *diagnosticParserCoreMaterializationScratch) reset() {
 	}
 	clear(scratch.entries[:cap(scratch.entries)])
 	scratch.entries = scratch.entries[:0]
+	// Clear the reduce node backing to its full capacity before the shared reset.
+	// This scratch is retained on the runner across parses, so a stale *Node
+	// beyond len (which reduceBuildScratch.reset leaves in place for the pooled
+	// production path) would pin a released arena slab and defeat GC. Production
+	// discards its per-parse scratch instead, so it never retains these pointers.
+	if cap(scratch.reduce.nodes) > 0 {
+		clear(scratch.reduce.nodes[:cap(scratch.reduce.nodes)])
+	}
 	scratch.reduce.reset()
 }
 
 func withDiagnosticParserCoreMaterializationScratch(parser *Parser, visit func(*diagnosticParserCoreMaterializationScratch) error) (err error) {
-	if parser == nil || visit == nil {
-		return errors.New("parser-core phase zero: materialization scratch requires a parser and visitor")
-	}
 	var scratch diagnosticParserCoreMaterializationScratch
+	return withProvidedMaterializationScratch(parser, &scratch, visit)
+}
+
+// withProvidedMaterializationScratch runs visit with a caller-owned
+// materialization scratch installed as the parser's reduce scratch. It resets
+// the scratch on return so a runner-held scratch is safe to reuse for the next
+// parse. Passing a reused scratch keeps the warm steady state from allocating a
+// fresh reduce-build buffer on every parse.
+func withProvidedMaterializationScratch(parser *Parser, scratch *diagnosticParserCoreMaterializationScratch, visit func(*diagnosticParserCoreMaterializationScratch) error) (err error) {
+	if parser == nil || visit == nil || scratch == nil {
+		return errors.New("parser-core phase zero: materialization scratch requires a parser, scratch, and visitor")
+	}
 	previousReduceScratch := parser.reduceScratch
 	parser.reduceScratch = &scratch.reduce
 	defer func() {
 		parser.reduceScratch = previousReduceScratch
 		scratch.reset()
 	}()
-	return visit(&scratch)
+	return visit(scratch)
+}
+
+// parserCoreMaxRetainedNodeScratch caps the *Node scratch buffers the runner
+// retains between parses so an unusually wide tree cannot pin a multi-megabyte
+// backing array for the parser's whole lifetime. It mirrors production's
+// maxRetainedNodeLinkStack bound in releaseParserScratch.
+const parserCoreMaxRetainedNodeScratch = 256 * 1024
+
+// parserCoreMaxRetainedLineStarts caps the retained line-start buffer.
+const parserCoreMaxRetainedLineStarts = 256 * 1024
+
+// parserCoreRunnerScratch retains the reusable per-Parser materialization
+// buffers for the compact candidate route. The fresh-full runner is per-Parser
+// and single-goroutine (see parserCoreFreshFullRunner), so retaining these
+// buffers on it and resetting them per parse mirrors production's parser-held
+// arena reuse: the warm steady state stops re-allocating the public-tree
+// scratch on every parse.
+type parserCoreRunnerScratch struct {
+	materialization diagnosticParserCoreMaterializationScratch
+	nodesByID       []*Node
+	nodes           []*Node
+	linkScratch     []*Node
+	lineStarts      []uint32
+	goCompatFrames  []goCompatSubtreeFrame
+}
+
+// nodeSlice returns a zeroed length-n *Node slice, reusing buf's capacity when
+// it fits. Clearing every entry prevents a stale node pointer from an earlier
+// parse leaking into this one.
+func parserCoreNodeSlice(buf []*Node, n int) []*Node {
+	if n <= 0 {
+		return buf[:0]
+	}
+	if cap(buf) < n {
+		return make([]*Node, n)
+	}
+	buf = buf[:n]
+	clear(buf)
+	return buf
+}
+
+// clearNodeScratch clears a *Node scratch buffer to its full capacity and
+// resets its length, dropping it when it grew past the retention cap. Clearing
+// the full capacity (not [:len]) matters because tree-wiring leaves live node
+// pointers in the backing array beyond len.
+func clearNodeScratch(buf []*Node) []*Node {
+	if cap(buf) > parserCoreMaxRetainedNodeScratch {
+		return nil
+	}
+	if cap(buf) > 0 {
+		clear(buf[:cap(buf)])
+		return buf[:0]
+	}
+	return buf
+}
+
+// resetTreeBuffers clears the tree-materialization buffers after a parse so the
+// runner never pins arena node pointers between parses. The line-start buffer
+// holds no pointers, so it only resets its length (or drops past the cap). The
+// Go-compatibility frame buffer holds node pointers, so it clears the full
+// capacity before resetting the length, dropping it past its retention cap.
+func (s *parserCoreRunnerScratch) resetTreeBuffers() {
+	if s == nil {
+		return
+	}
+	s.nodesByID = clearNodeScratch(s.nodesByID)
+	s.nodes = clearNodeScratch(s.nodes)
+	s.linkScratch = clearNodeScratch(s.linkScratch)
+	if cap(s.lineStarts) > parserCoreMaxRetainedLineStarts {
+		s.lineStarts = nil
+	} else {
+		s.lineStarts = s.lineStarts[:0]
+	}
+	if cap(s.goCompatFrames) > maxRetainedGoCompatFrames {
+		s.goCompatFrames = nil
+	} else if cap(s.goCompatFrames) > 0 {
+		clear(s.goCompatFrames[:cap(s.goCompatFrames)])
+		s.goCompatFrames = s.goCompatFrames[:0]
+	}
 }
 
 func newDiagnosticParserCorePointIndex(source []byte, poll func() error) (diagnosticParserCorePointIndex, error) {
+	return newDiagnosticParserCorePointIndexInto(source, poll, nil)
+}
+
+// newDiagnosticParserCorePointIndexInto builds the source point index, reusing
+// buf as the line-start backing storage when it has capacity. Reusing the
+// buffer keeps the warm steady state from allocating a fresh line-start slice
+// on every parse.
+func newDiagnosticParserCorePointIndexInto(source []byte, poll func() error, buf []uint32) (diagnosticParserCorePointIndex, error) {
 	if uint64(len(source)) > math.MaxUint32 {
 		return diagnosticParserCorePointIndex{}, errors.New("parser-core phase zero: materialization source exceeds uint32 offsets")
 	}
-	starts := make([]uint32, 1, min(1024, 1+len(source)/32))
+	var starts []uint32
+	if cap(buf) >= 1 {
+		starts = buf[:1]
+		starts[0] = 0
+	} else {
+		starts = make([]uint32, 1, min(1024, 1+len(source)/32))
+	}
 	for index, b := range source {
 		if index&1023 == 0 {
 			if err := poll(); err != nil {
@@ -1664,12 +1844,20 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 	if len(derivations) != 1 {
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreAccept, detail: "materialization requires one exact accepted derivation"}
 	}
-	return materializeDiagnosticParserCoreAcceptedSelection(compact, head, derivations[0].Payloads, parser, source)
+	return materializeDiagnosticParserCoreAcceptedSelection(compact, head, derivations[0].Payloads, parser, source, nil)
 }
 
-func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head core.Head, payloads []core.SubtreeID, parser *Parser, source []byte) (*Tree, error) {
+// materializeDiagnosticParserCoreAcceptedSelection materializes the accepted
+// compact derivation into a public tree. When scratch is non-nil the runner's
+// reusable buffers back the transient materialization storage, so the warm
+// steady state does not re-allocate the public-tree scratch on every parse.
+// scratch is reset on return, so it is safe to reuse for the next parse.
+func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head core.Head, payloads []core.SubtreeID, parser *Parser, source []byte, scratch *parserCoreRunnerScratch) (*Tree, error) {
 	if compact == nil || parser == nil || parser.language == nil || head.Node == 0 || len(payloads) == 0 {
 		return nil, errors.New("parser-core phase zero: incomplete accepted-tree selection input")
+	}
+	if scratch != nil {
+		defer scratch.resetTreeBuffers()
 	}
 	stats, err := compact.Stats(head)
 	if err != nil {
@@ -1690,14 +1878,28 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 		}
 		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreCap, detail: "accepted-tree materialization stopped: " + string(reason)}
 	}
-	points, err := newDiagnosticParserCorePointIndex(source, poll)
+	var lineStartsBuf []uint32
+	if scratch != nil {
+		lineStartsBuf = scratch.lineStarts
+	}
+	points, err := newDiagnosticParserCorePointIndexInto(source, poll, lineStartsBuf)
 	if err != nil {
 		return nil, err
+	}
+	if scratch != nil {
+		scratch.lineStarts = points.lineStarts
 	}
 	// The visitor proves unique ownership, so this is a transient child-build
 	// table rather than a memoization or sharing mechanism: every populated
 	// compact ID owns exactly one public node in this tree.
-	nodesByID := make([]*Node, uint64(stats.Subtrees)+1)
+	nodesByIDLen := uint64(stats.Subtrees) + 1
+	var nodesByID []*Node
+	if scratch != nil && nodesByIDLen <= uint64(math.MaxInt) {
+		scratch.nodesByID = parserCoreNodeSlice(scratch.nodesByID, int(nodesByIDLen))
+		nodesByID = scratch.nodesByID
+	} else {
+		nodesByID = make([]*Node, nodesByIDLen)
+	}
 	if err := poll(); err != nil {
 		return nil, err
 	}
@@ -1756,7 +1958,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 		node.setFragileLeft(true)
 		node.setFragileRight(true)
 	}
-	err = withDiagnosticParserCoreMaterializationScratch(parser, func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
+	materializeVisit := func(materializationScratch *diagnosticParserCoreMaterializationScratch) error {
 		return compact.VisitMaterializationPostorder(payloads, poll, func(id core.SubtreeID, view core.MaterializationSubtreeView) error {
 			if view.EndByte < view.StartByte || view.EndByte > uint32(len(source)) {
 				return errors.New("parser-core phase zero: compact subtree extent is outside source")
@@ -1824,12 +2026,23 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			stamp(id, parent)
 			return nil
 		})
-	})
+	}
+	if scratch != nil {
+		err = withProvidedMaterializationScratch(parser, &scratch.materialization, materializeVisit)
+	} else {
+		err = withDiagnosticParserCoreMaterializationScratch(parser, materializeVisit)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	nodes := make([]*Node, len(payloads))
+	var nodes []*Node
+	if scratch != nil {
+		scratch.nodes = parserCoreNodeSlice(scratch.nodes, len(payloads))
+		nodes = scratch.nodes
+	} else {
+		nodes = make([]*Node, len(payloads))
+	}
 	for index, payload := range payloads {
 		if uint64(payload) >= uint64(len(nodesByID)) || nodesByID[payload] == nil {
 			return nil, errors.New("parser-core phase zero: compact materialization order omitted an accepted payload")
@@ -1839,8 +2052,21 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	if err := poll(); err != nil {
 		return nil, err
 	}
-	var linkScratch []*Node
-	tree := parser.buildResultFromNodes(nodes, source, arena, nil, nil, &linkScratch)
+	linkScratch := new([]*Node)
+	if scratch != nil {
+		linkScratch = &scratch.linkScratch
+	}
+	// buildResultFromNodes runs the returned-tree compatibility normalization
+	// (including the Go-compatibility walk). Install the runner's reusable frame
+	// buffer for that walk so the warm steady state reuses the walk stack instead
+	// of re-growing it every parse, mirroring production's parser-held scratch.
+	// resetTreeBuffers restores and clears it on return.
+	previousGoCompatFrames := parser.goCompatFrames
+	if scratch != nil {
+		parser.goCompatFrames = &scratch.goCompatFrames
+		defer func() { parser.goCompatFrames = previousGoCompatFrames }()
+	}
+	tree := parser.buildResultFromNodes(nodes, source, arena, nil, nil, linkScratch)
 	if tree != nil {
 		owned = false // buildResultFromNodes transfers arena ownership to tree.
 	}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -30,6 +30,11 @@ type parserCoreFreshFullRunner struct {
 	compact        *core.Core
 	options        DiagnosticParserCorePrefixOptions
 	scannerScratch []byte
+	// scratch retains the reusable per-parse materialization buffers. The runner
+	// is per-Parser and single-goroutine, so reusing these buffers across parses
+	// mirrors production's parser-held arena reuse and keeps the warm steady
+	// state from re-allocating the public-tree scratch on every parse.
+	scratch parserCoreRunnerScratch
 }
 
 func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticParserCorePrefixOptions) (*parserCoreFreshFullRunner, error) {
@@ -137,7 +142,7 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	if r == nil || scheduler == nil {
 		return nil, errors.New("parser-core fresh-full selected materialization is incomplete")
 	}
-	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source)
+	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source, &r.scratch)
 }
 
 func (r *parserCoreFreshFullRunner) parse(source []byte) (*Tree, error) {

--- a/parsercore_phase0_language_tables_internal_test.go
+++ b/parsercore_phase0_language_tables_internal_test.go
@@ -1,0 +1,123 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"runtime"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// loadCertifiedGoLanguageForTest decodes the embedded certified Go blob into a
+// full *Language without importing the grammars package (which would form an
+// import cycle for this internal test package).
+func loadCertifiedGoLanguageForTest(t *testing.T) *Language {
+	t.Helper()
+	lang, err := LoadLanguage(parserCoreCertifiedGoBlob)
+	if err != nil {
+		t.Fatalf("decode embedded Go blob: %v", err)
+	}
+	lang.Name = "go"
+	return lang
+}
+
+// TestParserCoreLanguageTablesFootprint measures the retained heap footprint of
+// one language's converted compact tables. It backs the retention decision
+// documented on acquireParserCoreLanguageTables: the per-language footprint is
+// small and fixed, and the cache lives on the Language itself, so it pins
+// nothing beyond the Language it describes.
+func TestParserCoreLanguageTablesFootprint(t *testing.T) {
+	lang := loadCertifiedGoLanguageForTest(t)
+	parser := NewParser(lang)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	tables, err := buildParserCoreLanguageTables(parser)
+	if err != nil {
+		t.Fatalf("build language tables: %v", err)
+	}
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+	footprint := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	runtime.KeepAlive(tables)
+	runtime.KeepAlive(parser)
+
+	t.Logf("go compact language-table footprint: %d bytes (%.1f KiB); actionRows=%d reductionPlans=%d reductionPlanIndex=%d stride=%d",
+		footprint, float64(footprint)/1024,
+		len(tables.actionRows), len(tables.reductionPlans), len(tables.reductionPlanIndex), tables.reductionPlanStride)
+
+	// Guard the retention assumption: one language table set stays small. A large
+	// regression here would invalidate the unbounded-cache decision.
+	if footprint > 4<<20 {
+		t.Fatalf("go compact language-table footprint %d bytes exceeds the 4 MiB retention guard", footprint)
+	}
+}
+
+// TestParserCoreLanguageTablesCacheSharesAcrossParsers proves the per-language
+// cache returns the same immutable table set for every Parser of one *Language,
+// so a fresh Parser per file does not rebuild the action-table conversion.
+func TestParserCoreLanguageTablesCacheSharesAcrossParsers(t *testing.T) {
+	lang := loadCertifiedGoLanguageForTest(t)
+
+	first, err := newParserCoreRootTables(NewParser(lang))
+	if err != nil {
+		t.Fatalf("first tables: %v", err)
+	}
+	second, err := newParserCoreRootTables(NewParser(lang))
+	if err != nil {
+		t.Fatalf("second tables: %v", err)
+	}
+
+	if first == second {
+		t.Fatal("expected distinct per-Parser wrappers")
+	}
+	if first.parser == second.parser {
+		t.Fatal("expected distinct Parser back-references")
+	}
+	// The heavy immutable tables must be the exact shared instance.
+	if first.parserCoreLanguageTables != second.parserCoreLanguageTables {
+		t.Fatal("expected the shared language tables to be reused across Parsers")
+	}
+	if &first.actionRows[0] != &second.actionRows[0] {
+		t.Fatal("expected the action-row backing array to be shared")
+	}
+
+	// Building a wrapper for an already-cached language must not rebuild the
+	// converted action rows: only the tiny per-Parser wrapper allocates.
+	wrapperParser := NewParser(lang)
+	if allocs := testing.AllocsPerRun(100, func() {
+		wrapper, buildErr := newParserCoreRootTables(wrapperParser)
+		if buildErr != nil || wrapper == nil {
+			t.Fatalf("cached wrapper build: %v", buildErr)
+		}
+	}); allocs > 1 {
+		t.Fatalf("cached wrapper build allocated %v objects, expected one tiny fixed wrapper", allocs)
+	}
+
+	// A distinct *Language builds and caches its own table set.
+	other := loadCertifiedGoLanguageForTest(t)
+	otherTables, err := newParserCoreRootTables(NewParser(other))
+	if err != nil {
+		t.Fatalf("other-language tables: %v", err)
+	}
+	if otherTables.parserCoreLanguageTables == first.parserCoreLanguageTables {
+		t.Fatal("distinct languages must not share one converted table set")
+	}
+
+	// The shared tables answer runtime lookups identically through either wrapper.
+	var wantRow core.ActionRow
+	for state := core.StateID(0); state < core.StateID(len(lang.ParseTable)); state++ {
+		row, lookupErr := first.Actions(state, 0)
+		if lookupErr == nil && row.Len() > 0 {
+			wantRow = row
+			otherRow, otherErr := second.Actions(state, 0)
+			if otherErr != nil || otherRow.Len() != wantRow.Len() {
+				t.Fatalf("shared tables disagreed at state %d: %d vs %d err=%v", state, wantRow.Len(), otherRow.Len(), otherErr)
+			}
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Remove adapter overhead from the default compact route. Cache converted parser tables per language and reuse bounded materialization buffers per parser.

## Changes

- Cache immutable action and reduction tables with `sync.Once` on `*Language`.
- Reuse materialization scratch, node buffers, line starts, link scratch, and Go compatibility frames.
- Drop buffers that exceed retention caps.
- Add a fresh-parser benchmark.
- Pin the exact admission size boundary.
- Merge the current #420 parent and preserve its fail-closed generic-call fix.

## Validation

- `go test . -run '^(TestAdmission|TestParserCoreLanguage|TestParserCoreFreshFull|TestDiagnosticParserCoreCanonicalAdmission)' -count=1`
- `go test . -tags gts_no_parsercorephase0 -run '^(TestAdmissionSwitchDefaultBuildFallsBackLoudly|TestParserCorePhaseZeroDriverCompilesOutOfEmergencyBuild)$' -count=1`
- Isolated Go real-corpus parity: 5 of 5 no-error, S-expression, and deep-tree parity.
- `BenchmarkGoParseFreshParserPerFileDFA`: five stable samples recorded.
- GitHub CGo parity and the strict performance regression check pass.

## Review focus

Review cache lifetime, buffer ownership, retention caps, and parser reuse safety.