### PR TITLE
fix(harness): pin phase-3 parser routes

### DIFF
--- a/cgo_harness/pure_c/run_canonical_go_full_parse.sh
+++ b/cgo_harness/pure_c/run_canonical_go_full_parse.sh
@@ -313,25 +313,18 @@ elif [[ "$GO_BACKEND" == "selected-store" ]]; then
 	GO_LIFECYCLE="parserCoreFreshFullRunner.parseSelectedStore+SelectedCursor traversal+SelectedStore.Release"
 	GO_FALLBACK="none_fail_closed"
 else
-  GO_BUILD_TAGS=""
+  GO_BUILD_TAGS="gts_no_parsercorephase0"
   GO_BENCHMARK="BenchmarkGoParseWarmRealDFA"
   GO_PREFLIGHT="TestGoFullParseBenchmarkFixturesParseClean"
   GO_LIFECYCLE="Parser.Parse+shallow_completeness+Tree.Release"
-  GO_FALLBACK="production_parser_policy"
+  GO_FALLBACK="compact_route_compiled_out"
 fi
 
 GO_BIN="$OUT_DIR/bin/gotreesitter.test"
-if [[ "$GO_BACKEND" != "production" ]]; then
-  (
-    cd "$REPO_ROOT"
-    env GOMAXPROCS=1 go test -tags "$GO_BUILD_TAGS" -c -o "$GO_BIN" .
-  ) > "$OUT_DIR/preflight/go_build.txt" 2>&1
-else
-  (
-    cd "$REPO_ROOT"
-    env GOMAXPROCS=1 go test -c -o "$GO_BIN" .
-  ) > "$OUT_DIR/preflight/go_build.txt" 2>&1
-fi
+(
+  cd "$REPO_ROOT"
+  env GOMAXPROCS=1 go test -tags "$GO_BUILD_TAGS" -c -o "$GO_BIN" .
+) > "$OUT_DIR/preflight/go_build.txt" 2>&1
 "$GO_BIN" -test.list "^${GO_BENCHMARK}$" > "$OUT_DIR/preflight/go_benchmark_list.txt"
 grep -qx "$GO_BENCHMARK" "$OUT_DIR/preflight/go_benchmark_list.txt" || die "prebuilt Go test binary does not contain $GO_BENCHMARK"
 "$GO_BIN" -test.run "^${GO_PREFLIGHT}$" -test.count=1 -test.v \
@@ -340,19 +333,11 @@ GO_BIN_SHA="$(sha256sum "$GO_BIN" | awk '{print $1}')"
 go version -m "$GO_BIN" > "$OUT_DIR/preflight/go_binary_modules.txt"
 
 if ((SKIP_CGO_ADMISSION == 0)); then
-  if [[ "$GO_BACKEND" != "production" ]]; then
-    (
-      cd "$REPO_ROOT"
-      bash cgo_harness/docker/run_parity_in_docker.sh -- \
-        "cd /workspace && go test -tags gts_parsercorephase0 . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run '^(TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
-    ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
-  else
-    (
-      cd "$REPO_ROOT"
-      bash cgo_harness/docker/run_parity_in_docker.sh -- \
-        "cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run '^(TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
-    ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
-  fi
+  (
+    cd "$REPO_ROOT"
+    bash cgo_harness/docker/run_parity_in_docker.sh -- \
+      "cd /workspace && go test -tags '$GO_BUILD_TAGS' . -run '^${GO_PREFLIGHT}$' -count=1 -v && cd /workspace/cgo_harness && go test . -tags treesitter_c_parity -run '^(TestCanonicalGoBenchmarkPreflight|TestCOracleStaticDeepParity)$' -count=1 -v"
+  ) > "$OUT_DIR/preflight/cgo_static_deep_admission.txt" 2>&1
   CGO_ADMISSION="PASS"
 else
   CGO_ADMISSION="SKIPPED_NONPUBLICATION_DIAGNOSTIC"

--- a/docs/phase3-admission-timing-runbook.md
+++ b/docs/phase3-admission-timing-runbook.md
@@ -129,6 +129,10 @@ Do not run the production and candidate passes on different revisions.
      --out <receipt-dir>/production
    ```
 
+   The driver compiles this lane with `gts_no_parsercorephase0`, so the
+   compact route is absent even when it is enabled in a normal build. The
+   receipt records that tag as part of the workload identity.
+
 3. Candidate backend, same revision, same pinned core:
 
    ```sh
@@ -137,6 +141,10 @@ Do not run the production and candidate passes on different revisions.
      --core <pinned-cpu> \
      --out <receipt-dir>/candidate
    ```
+
+   The driver compiles this lane with `gts_parsercorephase0`. Keep both
+   explicit tags intact: an untagged build is not an admissible production
+   control now that the compact route is enabled by default.
 
    The script already interleaves Go and C samples in five ABBA cycles
    per backend run (order-balanced within a backend). Running


### PR DESCRIPTION
## Summary

- compile the phase-3 production control with `gts_no_parsercorephase0`
- keep the compact candidate lane explicit with `gts_parsercorephase0`
- run the backend-specific workload preflight in Docker for every lane
- document why an untagged build is no longer an admissible production control

## Why

PR #420 enabled the compact route in normal builds. The phase-3 driver still treated an untagged build as the production control, which could make production and candidate evidence overlap on admitted fixtures. Explicit, recorded build tags restore distinct route identity before the next certified run.

## Validation

- `bash -n cgo_harness/pure_c/run_canonical_go_full_parse.sh`
- Docker: `TestGoFullParseBenchmarkFixturesParseClean` with `gts_no_parsercorephase0`
- Docker: `TestParserCoreFreshFullRunnerRepeatedCanonicalLifecycle` with `gts_parsercorephase0`
- `git diff --check`

Canopy's repository-wide quality gate was attempted but did not complete or emit findings within the bounded review window; it was stopped. The focused route checks above passed.
