### PR TITLE
Ratchet compact admission and incremental editor contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,15 +284,14 @@ jobs:
             -budget perf_scan/perf_ratio_budgets.json
 
   # oedit_latency_gate_full runs the full editor-latency gate sweep
-  # (campaign O(edit) workstream W5, spec.campaign.oedit): all four gate
+  # (campaign O(edit) workstream W5, spec.campaign.oedit): all five gate
   # languages at the ~20KB, ~137KB, and ~1MB size tiers, crossed with every
-  # edit class and position. TestW5EditorLatencyGate itself always runs at
-  # the fast ~20KB tier as part of the normal `go test .` run in race_root
-  # above; GTS_W5_FULL_SWEEP and GTS_W5_SLOW_TIER add the slower tiers this
-  # job exists to cover. It is manual (workflow_dispatch only) and not part
-  # of the required `build` gate: the full sweep takes about a minute, which
-  # is cheap enough to keep available on demand without adding wall time to
-  # every PR.
+  # edit class and position. The normal `go test .` run in race_root covers
+  # the ~20KB and ~137KB tiers; GTS_W5_SLOW_TIER adds the ~1MB tier here.
+  # This job also runs the JavaScript/TypeScript transient-error delete gate
+  # at all three sizes. It is manual (workflow_dispatch only) and not part of
+  # the required `build` gate so the slow tier remains available on demand
+  # without adding its wall time to every PR.
   oedit_latency_gate_full:
     needs: exhaustive_parity_scope
     if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true' && github.event_name == 'workflow_dispatch'
@@ -307,8 +306,10 @@ jobs:
 
       - name: Full editor-latency gate sweep (20KB/137KB/1MB)
         run: |
-          GTS_W5_FULL_SWEEP=1 GTS_W5_SLOW_TIER=1 \
-          go test . -run '^TestW5EditorLatencyGate$' -count=1 -v -timeout 8m
+          GTS_W5_SLOW_TIER=1 \
+          go test . \
+            -run '^(TestW5EditorLatencyGate|TestW5JavaScriptTypeScriptTransientErrorDeleteGate)$' \
+            -count=1 -v -timeout 8m
 
   exhaustive_parity_scope:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,28 @@ jobs:
           GOMAXPROCS=1 go test -tags gts_parsercorephase0 . -run "$admission" -count=1
           GOMAXPROCS=1 go test -tags 'gts_parsercorephase0 gts_parsercorephase0_selectedstore_onepass' . -run "$admission" -count=1
 
+  compact_admission_ratchet:
+    needs: exhaustive_parity_scope
+    if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Validate compact admission breadth, depth, and incremental bridge
+        run: |
+          set -euo pipefail
+          GTS_ADMISSION_SCORECARD=1 \
+          GTS_ADMISSION_SCORECARD_RATCHET=1 \
+          GOMAXPROCS=1 \
+          go test -tags gts_parsercorephase0 . \
+            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof)$' \
+            -count=1 -timeout 10m
+
   race_root:
     needs: exhaustive_parity_scope
     if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
@@ -371,6 +393,7 @@ jobs:
     needs:
       - compile
       - selected_store_admission
+      - compact_admission_ratchet
       - race_root
       - race_packages
       - draft_focused_tests
@@ -388,6 +411,7 @@ jobs:
           RUN_CODE_CI: ${{ needs.exhaustive_parity_scope.outputs.run_code_ci }}
           COMPILE_RESULT: ${{ needs.compile.result }}
           SELECTED_STORE_ADMISSION_RESULT: ${{ needs.selected_store_admission.result }}
+          COMPACT_ADMISSION_RATCHET_RESULT: ${{ needs.compact_admission_ratchet.result }}
           RACE_ROOT_RESULT: ${{ needs.race_root.result }}
           RACE_PACKAGES_RESULT: ${{ needs.race_packages.result }}
           DRAFT_FOCUSED_RESULT: ${{ needs.draft_focused_tests.result }}
@@ -426,6 +450,7 @@ jobs:
 
           require_success "compile" "$COMPILE_RESULT"
           require_success "selected_store_admission" "$SELECTED_STORE_ADMISSION_RESULT"
+          require_success "compact_admission_ratchet" "$COMPACT_ADMISSION_RATCHET_RESULT"
           require_success "parity_report" "$PARITY_REPORT_RESULT"
           require_success "perf_scan_budget" "$PERF_SCAN_BUDGET_RESULT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,14 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Validate compact admission breadth, depth, and incremental bridge
+      - name: Validate compact admission breadth, route precedence, depth, and incremental bridge
         run: |
           set -euo pipefail
           GTS_ADMISSION_SCORECARD=1 \
           GTS_ADMISSION_SCORECARD_RATCHET=1 \
           GOMAXPROCS=1 \
           go test -tags gts_parsercorephase0 . \
-            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof)$' \
+            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof)$' \
             -count=1 -timeout 10m
 
   race_root:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **Result compatibility cleanup.** A source-of-truth ownership registry,
+  supporting documentation, and a CI guard now track compatibility passes and
+  their retirement criteria. The dead terminal-normalization wrapper was
+  removed, and recovered-tree cycle repair was replaced by an always-on,
+  non-mutating validator that fails closed with the public
+  `ParseStopInvariantViolation` reason.
+
 - **Compact admission now ratchets breadth, depth, and edit reuse.** The shared
   production clean-tail proof admits compact roots that stop immediately before
   trailing parser padding, raising the 206-language smoke scorecard from 48 to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,14 @@ for tags and release notes while still in `0.x`.
 - **Result compatibility cleanup.** A source-of-truth ownership registry,
   supporting documentation, and a CI guard now track compatibility passes and
   their retirement criteria. The dead terminal-normalization wrapper was
-  removed, and recovered-tree cycle repair was replaced by an always-on,
-  non-mutating validator that fails closed with the public
-  `ParseStopInvariantViolation` reason.
+  removed, along with the unreferenced `walkResultTreePostorderUntil` and
+  `rewriteResultTreeChildrenPostorderWithStats` traversal helpers. Recovered-tree
+  cycle repair was replaced by an always-on, non-mutating validator that fails
+  closed with the public `ParseStopInvariantViolation` reason. The roadmap now
+  puts repository maintenance, explainability, documentation, ownership
+  receipts, and upstream retirement of normalization shims before the next
+  major performance milestone; performance gates remain advisory during this
+  cleanup.
 
 - **Compact admission now ratchets breadth, depth, and edit reuse.** The shared
   production clean-tail proof admits compact roots that stop immediately before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-07-21
+
 ### Added
 
 - **Phase-3 admission switch** (PR #417). A per-parser option, a global
@@ -22,6 +24,18 @@ for tags and release notes while still in `0.x`.
   multi-derivation blockers.
 - **Oracle v3 parity tools** in `cgo_harness` (PR #413). The root
   library module is unchanged by that PR.
+- **The W5 editor-latency matrix now covers five languages.** Go,
+  JavaScript, TypeScript, Python, and CSS run insert, delete, and replace
+  edits at the start, middle, and end of roughly 20 KiB and 137 KiB inputs;
+  the manual full sweep adds 1 MiB. JavaScript and TypeScript also carry a
+  transient-error delete lane with deterministic ceilings for parser work,
+  retries, stack width, and allocator memory, while retaining fresh-parse
+  structural equality as the correctness oracle.
+- **External-scanner incremental-reuse contracts are now published per
+  language.** The 119-language matrix distinguishes certified, bounded,
+  explicit-opt-out, and uncertified scanners. SQL, HTML, and Markdown now
+  document their fail-closed production full-parse fallback for changed edits
+  after the narrow token-invariant leaf exception declines.
 
 ### Changed
 
@@ -35,7 +49,10 @@ for tags and release notes while still in `0.x`.
   puts repository maintenance, explainability, documentation, ownership
   receipts, and upstream retirement of normalization shims before the next
   major performance milestone; performance gates remain advisory during this
-  cleanup.
+  cleanup. All 23 collapsed named-leaf rows for six exact-profile built-in
+  languages now materialize natively across their admitted routes; the generic
+  compatibility walk remains as a zero-rewrite receipt and as the safety path
+  for caller-built, adapted, and other custom languages.
 
 - **Compact admission now ratchets breadth, depth, and edit reuse.** The shared
   production clean-tail proof admits compact roots that stop immediately before
@@ -134,17 +151,18 @@ for tags and release notes while still in `0.x`.
   from one survivor to two. The wider budget activates the structural
   comparison at the merge site. This is the structural cure for the
   detector class behind issue #389 and issue #402.
-- **Incremental reparse cost is now position-independent for large
-  files** (PR #418, PR #421, campaign O(edit)). PR #418 bounds arena
-  normalization to the edited range. A 1MB clean-Go near-top keystroke
-  drops from about 356ms to about 53ms. PR #421 splices the leading run
-  of unchanged top-level items, the mirror of the trailing
-  block-splice. A 1MB mid-file keystroke drops from about 269ms to
-  about 67ms for Go, and from about 168ms to about 45ms for CSS. At
-  137KB, mid-file reuse rejects fall from 16,450 to 10. JavaScript,
-  TypeScript, and TSX keep their previous behavior until the T2c
-  scanner proofs land. The W5 latency gate now locks these counters per
-  edit position.
+- **Admitted clean top-level edits now reuse both leading and trailing
+  sibling runs** (PR #418, PR #421, campaign O(edit)). PR #418 bounds arena
+  normalization to the edited range. A 1MB clean-Go near-top keystroke drops
+  from about 356ms to about 53ms. PR #421 splices the leading run of unchanged
+  top-level items, the mirror of the trailing block-splice. A 1MB mid-file
+  keystroke drops from about 269ms to about 67ms for Go, and from about 168ms
+  to about 45ms for CSS. At 137KB, mid-file reuse rejects fall from 16,450 to
+  10. Length- or point-changing `Tree.Edit` calls still maintain coordinates
+  through affected trailing sibling subtrees, so this is not an absolute
+  whole-call `O(edit)` claim. JavaScript, TypeScript, and TSX keep their
+  previous leading-run behavior until the T2c scanner proofs land. The W5
+  latency gate locks these counters per edit position.
 
 ### Removed
 
@@ -303,10 +321,13 @@ for tags and release notes while still in `0.x`.
 
 ### Improved
 
-- **Go clean-file incremental edits are now O(edit), not O(file).** This
-  closes, for clean top-level edits, the Go reuse gap that v0.44.0 listed
-  as a known issue. Before dispatch reaches the reuse check, the parser
-  now applies any pending eager-default reduce chain to the live stack.
+- **Go clean-file incremental parses now reuse the top-level suffix instead
+  of reparsing it.** This closes, for clean top-level edits, the Go reuse
+  gap that v0.44.0 listed as a known issue. It is not an absolute
+  whole-call `O(edit)` claim: length- or point-changing `Tree.Edit` calls
+  still maintain coordinates through affected trailing sibling subtrees.
+  Before dispatch reaches the reuse check, the parser now applies any
+  pending eager-default reduce chain to the live stack.
   This is campaign O(edit) workstream W1b (PR #398), and it closes the
   settling gap that blocked the W1 splice (PR #395) for Go.
   `ReuseRejectRootNonLeafChanged` now holds at a small constant, 9,
@@ -3489,7 +3510,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.45.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.46.0...HEAD
+[0.46.0]: https://github.com/odvcencio/gotreesitter/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/odvcencio/gotreesitter/compare/v0.44.1...v0.45.0
 [0.44.1]: https://github.com/odvcencio/gotreesitter/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/odvcencio/gotreesitter/compare/v0.43.1...v0.44.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,25 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **Compact admission now ratchets breadth, depth, and edit reuse.** The shared
+  production clean-tail proof admits compact roots that stop immediately before
+  trailing parser padding, raising the 206-language smoke scorecard from 48 to
+  166 byte-exact routes (35 fail-closed fallbacks, 5 token-source skips, 0
+  divergences). Representative multi-line fixtures freeze production and
+  candidate digests, while CI enforces both the breadth floor and routed depth.
+  Admission materialization now carries a per-tree parser-state replay proof:
+  grammars with complete required states and proven scanner quiescence retain
+  incremental subtree reuse; unproven/stateful scanners remain barred, apart
+  from independently re-lexed token-invariant single-leaf edits. Certified or
+  explicitly requested forest routes retain precedence unless the caller
+  explicitly forces the compact candidate.
+
 - **The compact parser core is now the default full-parse route for eligible
   languages** (Phase-3 admission flip). `Parser.Parse` routes a fresh, full,
   production-DFA parse of an eligible grammar through the compact
   `internal/parsercorephase0` engine, then materializes a public tree. The tree
   is byte-exact with the production engine on the routed, verified surface: the
-  48 byte-exact scorecard routes and the canonical fixtures. The runner's strict
+  166 byte-exact scorecard routes and the canonical fixtures. The runner's strict
   acceptance gate fails closed to production on any input it cannot reproduce
   byte-for-byte. The compact engine promotes from the `gts_parsercorephase0`
   opt-in tag into the default build; the emergency opt-out tag
@@ -40,8 +53,8 @@ for tags and release notes while still in `0.x`.
 
   - **Correctness.** 206 of 206 curated parity fixtures pass. The deep-tree
     digest is 100 percent exact on the canonical fixtures. The 206-language
-    scorecard through the switch reports 48 byte-exact routes, 0 divergences,
-    153 fail-closed fallbacks, and 5 token-source skips.
+    scorecard through the switch reports 166 byte-exact routes, 0 divergences,
+    35 fail-closed fallbacks, and 5 token-source skips.
   - **Fail-closed generic-call conflict class.** On the ambiguous Go construct
     `Foo[int](a)`, production and the tree-sitter-go C oracle select
     `type_conversion_expression(generic_type)`. The compact scheduler cannot
@@ -91,11 +104,12 @@ for tags and release notes while still in `0.x`.
   variable, keeps the compact route on. `(*Parser).SetAdmissionCandidateRoute`
   overrides the process default per parser.
 
-  Dual-route statement: `ParseIncremental` and every reuse-consuming path stay
-  on the production engine unconditionally. The compact tree carries a hard
-  incremental-reuse bar (decision 0008), so routing it under `ParseIncremental`
-  would destroy the O(edit) wins. Lifting the reuse bar is the follow-on
-  campaign.
+  Dual-route statement: `ParseIncremental` and every reuse-consuming parser
+  operation stay on the production engine. A compact old tree may now supply
+  reusable subtrees only when its materialization attached the required replay
+  states and its scanner is provably quiescent; otherwise reuse fails closed to
+  a full production parse. Token-invariant single-leaf edits are separately
+  re-lexed and admitted only on exact symbol/span identity.
 
   Memory-budget contract: the compact scheduler does not poll the automatic
   large-input memory budget. The switch declines every input at or above the

--- a/README.md
+++ b/README.md
@@ -771,31 +771,25 @@ correctness/work-classification receipt rather than a representative
 comparative speed headline. Detailed history lives in
 [CHANGELOG.md](CHANGELOG.md).
 
-### Now — performance and extreme hygiene
+### Now — cleanup, ownership, and explainability
 
-- Keep correctness, C-oracle parity, and performance gates separate. Every
-  optimization must preserve the selected full-span tree before its timing
-  or memory result counts.
-- Hold the corrected materialized canonical full parse against the locked,
-  authenticated real-code publication benchmark. The historical 1.895x
-  result is not a target. No-tree, parser-core, and straight-LR lanes stay
-  attribution tools, not substitutes for the public benchmark.
-- Keep the exact-revision fleet sweep current with clean/error splits and
-  C-oracle fingerprints. Eliminate valid rows above 3x and all timeout,
-  hard-RSS, truncation, or unreported-stop cliffs, and prioritize absolute
-  user cost over ratio noise on tiny files.
-- Reduce recurring fixed work, discarded forest attempts, recovery and GLR
-  construction debris, retained scratch, and compatibility walks, but only
-  through mechanisms that generalize across measured witnesses.
-- Track wall time, allocations, retained arena/scratch bytes, and hard-cgroup
-  maximum RSS. Keep the public full-parse, incremental-edit, and
-  incremental no-edit benchmark lanes alongside the forking real-code
-  full-parse matrix; no-tree and synthetic straight-LR measurements stay
-  diagnostic.
-- Remove temporary telemetry and failed experimental paths when each lane
-  closes. Add no public parse variant or parser-core language-name switch
-  when an internal diagnostic or generated runtime profile can express the
-  need.
+- Correctness, portability, and supported parser depth are banked. Preserve
+  their receipts and keep correctness gates distinct from the currently
+  advisory performance gates.
+- Prioritize repository maintenance: remove obsolete experiments and
+  telemetry, reduce duplication, clarify subsystem ownership, improve
+  documentation, and keep ownership receipts current.
+- Retire result-normalization shims only after the authoritative parser,
+  scanner, materializer, or incremental mechanism owns the behavior and the
+  required route receipts prove the shim inert. Follow the
+  [compat-tier retirement guide](docs/compat-tier.md) for the mechanical
+  retirement contract.
+- Keep the authenticated public benchmarks as regression signals and preserve
+  their historical claims. Parser-core, no-tree, compact-candidate, and
+  synthetic lanes remain diagnostic rather than public performance claims.
+- After cleanup, the next major performance milestone is public
+  `Parser.Parse` at no more than **1.5x C** on the locked canonical real-code
+  benchmark. It is a future target, not a current gate or achieved result.
 
 ### Measured memory boundary
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ tree.Edit(gotreesitter.InputEdit{
 tree2, _ := parser.ParseIncremental(src, tree)
 ```
 
-`ParseIncremental` walks the old tree's spine, identifies the edit region, and reuses unchanged content by reference. It re-lexes and re-parses only the invalidated span. Reuse covers leaf nodes, the unchanged suffix, the untouched root, and — on a clean old tree — unchanged top-level siblings after the edit. Admission for top-level sibling reuse is per node: a fragility bit plus byte-range equality, not a language allowlist. This keeps clean edits near the top of the file, and the trailing sibling run after any edit, at O(edit) cost. Edits deeper in the file still pay a cost that grows with the number of preceding top-level items. Interior, non-top-level subtree reuse does not ship yet; it stays on the roadmap.
+`ParseIncremental` walks the old tree's spine, identifies the edit region, and reuses unchanged content by reference. For an admitted clean edit, re-lex/reparse work can stay close to the invalidated region: reuse covers leaf nodes, the unchanged suffix, the untouched root, and unchanged top-level siblings after the edit. Admission for top-level sibling reuse is per node: a fragility bit plus byte-range equality, not a language allowlist.
+
+That parse reuse is not an absolute `O(edit)` guarantee. For a length- or point-changing edit, `Tree.Edit` must also update byte and point coordinates through affected trailing sibling subtrees. The measured cost model is therefore cheap edited-region parse work plus sibling-offset maintenance that grows linearly with the number of trailing nodes or compact entries whose coordinates move. Same-length edits whose points do not move avoid that tail shift. Interior, non-top-level subtree reuse does not ship yet; it stays on the roadmap. A production tree first gets one narrow, independently reauthenticated same-length token-invariant leaf fast path. If that path declines, a language with an external scanner enters general old-tree reuse only when the scanner is certified; otherwise it uses the production full-parse fallback. See the [per-language incremental scanner matrix](docs/external-scanners.md#incremental-reuse-certification-matrix).
 
 When no edit has occurred, `ParseIncremental` detects the nil-edit on a pointer check and returns in single-digit nanoseconds with zero allocations.
 
@@ -456,7 +458,7 @@ you can compare parser throughput across generated source sizes. Use
 
 206 grammars ship in the registry. All 206 produce error-free parse trees on smoke samples. Run `go run ./cmd/parity_report` for current status.
 
-- 116 external scanners (hand-written Go implementations of upstream C scanners)
+- 119 external scanners (hand-written Go implementations of upstream C scanners)
 - 7 hand-written Go token sources (authzed, c, cpp, go, java, json, lua)
 - Remaining languages use the DFA lexer generated from grammar tables
 
@@ -585,11 +587,11 @@ gotreesitter is a ground-up reimplementation of the tree-sitter runtime in Go. N
 
 **Parser** — Table-driven LR(1) with GLR fallback. When a `(state, symbol)` pair maps to multiple actions in the parse table, the parser forks the stack and explores all alternatives in parallel. Stack merging collapses equivalent paths. Safety limits (iteration count, stack depth, node count) scale with input size and prevent runaway exploration on ambiguous grammars.
 
-**Incremental engine** — Walks the edit region of the previous tree and reuses unchanged content by reference. Reuse covers leaf nodes, the unchanged suffix, the untouched root, and — on a clean old tree — unchanged top-level siblings after the edited node. Admission for top-level sibling reuse is per node: a fragility bit plus byte-range equality, not a language allowlist. This splice keeps clean edits near the top of the file, and the trailing sibling run after any edit, at O(edit) cost, Go and CSS alike. Edits deeper in the file still pay a cost that grows with the number of preceding top-level items. Interior, non-top-level subtree reuse does not ship yet; it stays on the roadmap. For languages whose external scanner is reuse-safe, or records a boundary checkpoint, scanner-dependent content can be reused without a scanner replay from the start of the file.
+**Incremental engine** — Walks the edit region of the previous tree and reuses unchanged content by reference. Reuse covers leaf nodes, the unchanged suffix, the untouched root, and — on a clean old tree — unchanged top-level siblings after the edited node. Admission for top-level sibling reuse is per node: a fragility bit plus byte-range equality, not a language allowlist. On admitted clean edits, parse work can stay close to the invalidated region, but a length- or point-changing `Tree.Edit` still performs sibling-offset maintenance proportional to the trailing nodes or compact entries whose coordinates move. This measured model is not an absolute `O(edit)` guarantee. Interior, non-top-level subtree reuse does not ship yet; it stays on the roadmap. A production tree may first take the narrow independently reauthenticated same-length token-invariant leaf fast path. Once that path declines, external-scanner languages use general old-tree reuse only when their scanner explicitly certifies it, with boundary checkpoints where configured; uncertified scanners use the production full-parse fallback documented in the [scanner matrix](docs/external-scanners.md#incremental-reuse-certification-matrix).
 
 **Lexer** — Two paths. `ts2go` generates a DFA lexer from the grammar's lex tables, and it handles most languages. For grammars where the DFA is not enough (for example, Go's automatic semicolons, or YAML's indentation-sensitive structure), hand-written Go token sources implement the `TokenSource` interface directly.
 
-**External scanners** — 116 grammars require external scanners for context-sensitive tokens (Python indentation, HTML implicit close tags, Rust raw string delimiters, Swift operator disambiguation, and similar cases). Each scanner is a hand-written Go implementation of the grammar's `ExternalScanner` interface: `Create`, `Serialize`, `Deserialize`, `Scan`. The runtime snapshots scanner state after every token and stores it on tree nodes, so incremental reuse can restore scanner state on skip.
+**External scanners** — 119 registered grammars require external scanners for context-sensitive tokens (Python indentation, HTML implicit close tags, Rust raw string delimiters, Swift operator disambiguation, and similar cases). Each scanner is a hand-written Go implementation of the grammar's `ExternalScanner` interface: `Create`, `Serialize`, `Deserialize`, `Scan`. Certified checkpoint-enabled scanners snapshot state at external-token boundaries so incremental reuse can restore compatible state. After the narrow independently reauthenticated same-length token-invariant leaf path declines, an uncertified scanner fails closed to a fresh production parse; certification and fallback behavior are explicit in the [per-language matrix](docs/external-scanners.md#incremental-reuse-certification-matrix).
 
 **Arena allocator** — Nodes are allocated from slab-based arenas to reduce GC pressure. Arenas are released in bulk when a tree is freed.
 
@@ -755,8 +757,9 @@ edit measures about 82-88ms, down from about 148ms. The campaign's
 materialization outside the splice path. GLR-heavy files with genuine
 ambiguity still see little change, since settling and block-splice run
 on a single stack only. The prior release, v0.44.1, restored Swift's
-retry-ladder optimizations and made Go clean-file incremental edits
-O(edit).
+retry-ladder optimizations and introduced clean-file Go suffix and
+top-level-sibling reuse. Length-changing edits still include linear
+trailing-coordinate maintenance in `Tree.Edit`.
 The authenticated production receipt at tag target `1935a42c` measures
 public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
 **5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -54,6 +54,45 @@ type scorecardRow struct {
 	detail  string
 }
 
+// admissionScorecardRequiredCompactPasses is the frozen per-language admission
+// manifest from the generalized clean-tail epoch. It intentionally lists only
+// languages that the public compact route currently admits: a FALLBACK -> PASS
+// improvement remains welcome, but a listed PASS -> FALLBACK/DIVERGE/ERROR is a
+// release regression even when another language happens to improve and keeps
+// the aggregate totals unchanged. This is a test-only release ratchet, never a
+// runtime routing allowlist.
+var admissionScorecardRequiredCompactPasses = map[string]struct{}{
+	"ada": {}, "agda": {}, "angular": {}, "apex": {}, "arduino": {},
+	"astro": {}, "awk": {}, "bash": {}, "beancount": {}, "bibtex": {},
+	"bicep": {}, "bitbake": {}, "blade": {}, "brightscript": {}, "c_sharp": {},
+	"caddy": {}, "cairo": {}, "capnp": {}, "chatito": {}, "circom": {},
+	"commonlisp": {}, "corn": {}, "cpon": {}, "crystal": {}, "css": {},
+	"csv": {}, "cuda": {}, "cue": {}, "cylc": {}, "d": {}, "dart": {},
+	"desktop": {}, "devicetree": {}, "dhall": {}, "disassembly": {}, "dockerfile": {},
+	"dot": {}, "dtd": {}, "earthfile": {}, "ebnf": {}, "editorconfig": {},
+	"eds": {}, "elisp": {}, "elixir": {}, "elm": {}, "elsa": {}, "enforce": {},
+	"erlang": {}, "facility": {}, "faust": {}, "fennel": {}, "fidl": {},
+	"firrtl": {}, "fish": {}, "foam": {}, "forth": {}, "fortran": {}, "fsharp": {},
+	"gdscript": {}, "git_config": {}, "git_rebase": {}, "gitcommit": {}, "gleam": {},
+	"glsl": {}, "gn": {}, "go": {}, "godot_resource": {}, "gomod": {}, "graphql": {},
+	"groovy": {}, "hack": {}, "hare": {}, "haxe": {}, "hcl": {}, "heex": {},
+	"hlsl": {}, "html": {}, "hyprlang": {}, "ini": {}, "javascript": {}, "jq": {},
+	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kotlin": {},
+	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
+	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "mojo": {},
+	"move": {}, "nginx": {}, "nickel": {}, "ninja": {}, "nix": {}, "nushell": {},
+	"objc": {}, "ocaml": {}, "odin": {}, "org": {}, "pascal": {}, "pem": {}, "perl": {},
+	"php": {}, "pkl": {}, "powershell": {}, "prisma": {}, "prolog": {}, "promql": {},
+	"proto": {}, "pug": {}, "puppet": {}, "purescript": {}, "python": {}, "ql": {},
+	"r": {}, "regex": {}, "rego": {}, "requirements": {}, "rescript": {}, "ron": {},
+	"rst": {}, "ruby": {}, "rust": {}, "scala": {}, "scss": {}, "smithy": {},
+	"solidity": {}, "sparql": {}, "sql": {}, "squirrel": {}, "starlark": {}, "svelte": {},
+	"swift": {}, "tablegen": {}, "tcl": {}, "teal": {}, "templ": {}, "textproto": {},
+	"thrift": {}, "tlaplus": {}, "tmux": {}, "tsx": {}, "turtle": {}, "twig": {},
+	"typescript": {}, "typst": {}, "uxntal": {}, "v": {}, "verilog": {}, "vimdoc": {},
+	"vue": {}, "wgsl": {}, "wolfram": {}, "xml": {}, "yaml": {}, "zig": {},
+}
+
 func TestAdmissionCandidateScorecard206(t *testing.T) {
 	// This scorecard loads every registered grammar, which inflates process heap
 	// enough to disturb the whole-process TestArenaGCRetentionAfterRelease gate.
@@ -111,6 +150,27 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 			maxFallback = 35
 			wantSkip    = 5
 		)
+		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {
+			t.Fatalf("compact admission manifest has %d entries, want %d", got, minPass)
+		}
+		seen := make(map[string]struct{}, len(admissionScorecardRequiredCompactPasses))
+		for _, row := range rows {
+			if _, required := admissionScorecardRequiredCompactPasses[row.name]; !required {
+				continue
+			}
+			seen[row.name] = struct{}{}
+			if row.status != scorecardPass {
+				t.Errorf("compact admission regression for %q: got %s (%s), want PASS", row.name, row.status, row.detail)
+			}
+		}
+		for name := range admissionScorecardRequiredCompactPasses {
+			if _, found := seen[name]; !found {
+				t.Errorf("compact admission manifest language %q is missing from the scorecard", name)
+			}
+		}
+		if t.Failed() {
+			t.Fatal("per-language compact admission ratchet failed")
+		}
 		if len(rows) != wantTotal || counts[scorecardPass] < minPass ||
 			counts[scorecardFallback] > maxFallback || counts[scorecardSkip] != wantSkip ||
 			counts[scorecardDiverge] != 0 || counts[scorecardError] != 0 {
@@ -119,6 +179,83 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 				counts[scorecardSkip], wantSkip, counts[scorecardError], len(rows), wantTotal)
 		}
 	}
+}
+
+// TestAdmissionSwitchRoutePrecedenceRatchet pins the three dispatch outcomes
+// that release admission relies on. A certified forest policy owns the default
+// route; an explicit compact request intentionally overrides it; with neither
+// feature enabled, the original production route remains the only route.
+func TestAdmissionSwitchRoutePrecedenceRatchet(t *testing.T) {
+	previousDefault := gts.AdmissionCandidateRouteDefault()
+	previousForest := os.Getenv("GOT_GLR_FOREST") != "0"
+	t.Cleanup(func() {
+		gts.SetAdmissionCandidateRouteDefault(previousDefault)
+		gts.SetGLRForestEnabled(previousForest)
+	})
+
+	lang := grammars.AwkLanguage()
+	if !lang.AutomaticForestEnabledByDefault {
+		t.Fatal("awk must retain its exact-artifact certified forest profile")
+	}
+	source := []byte(grammars.ParseSmokeSample("awk"))
+
+	t.Run("default follows certified forest", func(t *testing.T) {
+		gts.SetAdmissionCandidateRouteDefault(true)
+		gts.SetGLRForestEnabled(true)
+		gts.ResetAdmissionCandidateCountersForTest()
+
+		parser := gts.NewParser(lang) // no per-Parser override: forest keeps precedence
+		tree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || fallback != 0 {
+			t.Fatalf("default certified-forest parse consulted compact route: routed=%d fallback=%d", routed, fallback)
+		}
+		if !tree.ParseRuntime().ForestFastPath {
+			_, _, reason, _ := parser.ForestDeclineInfo()
+			if reason == "" {
+				t.Fatal("default parser bypassed both the certified forest route and its recorded decline")
+			}
+		}
+	})
+
+	t.Run("explicit compact override wins", func(t *testing.T) {
+		gts.SetAdmissionCandidateRouteDefault(true)
+		gts.SetGLRForestEnabled(true)
+		gts.ResetAdmissionCandidateCountersForTest()
+
+		parser := gts.NewParser(lang)
+		parser.SetAdmissionCandidateRoute(true)
+		tree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		if routed, fallback := gts.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+			t.Fatalf("explicit compact override did not win: routed=%d fallback=%d", routed, fallback)
+		}
+	})
+
+	t.Run("neither enabled remains production", func(t *testing.T) {
+		gts.SetAdmissionCandidateRouteDefault(false)
+		gts.SetGLRForestEnabled(false)
+		gts.ResetAdmissionCandidateCountersForTest()
+
+		parser := gts.NewParser(lang) // no compact override and no forest master switch
+		tree, err := parser.Parse(source)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || fallback != 0 {
+			t.Fatalf("production-only parse consulted compact route: routed=%d fallback=%d", routed, fallback)
+		}
+		if tree.ParseRuntime().ForestFastPath {
+			t.Fatal("neither-enabled parse escaped production through the forest route")
+		}
+	})
 }
 
 func runAdmissionScorecardLanguage(entry grammars.LangEntry) (row scorecardRow) {

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -20,11 +20,10 @@ import (
 // fell back, or diverged. The compact route had only ever been validated on the
 // four canonical Go fixtures; this run reports how far it reaches.
 //
-// Scope: the per-language fixtures are trivial smoke snippets, so this is
-// reachability reconnaissance -- which grammars the compact route accepts at
-// all -- not a fidelity proof. The byte-exact fidelity evidence is the
-// four-fixture digest test (TestAdmissionSwitchCandidateDigestMatchesProduction).
-// Corpus-scale per-language fixtures are the tracked follow-up.
+// Scope: the per-language fixtures are trivial smoke snippets, so this is the
+// breadth ratchet -- which grammars the compact route accepts at all -- rather
+// than corpus-scale fidelity proof. Frozen canonical and representative-depth
+// digests provide the deeper companion gate.
 //
 // It is a scorecard, not a gate: it never fails on a fallback (a fallback is the
 // fail-closed, correct behavior for an unsupported grammar). It fails only on a
@@ -98,6 +97,26 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		}
 		if os.Getenv("GTS_ADMISSION_SCORECARD_STRICT") == "1" {
 			t.Fatalf("%d language(s) diverged through the compact route", len(divergences))
+		}
+	}
+
+	if os.Getenv("GTS_ADMISSION_SCORECARD_RATCHET") == "1" {
+		// Frozen at the generalized clean-tail admission epoch. Improvements are
+		// welcome (more PASS, fewer FALLBACK); silent correctness failures,
+		// registry drift, or surrendered route coverage require an explicit
+		// review and ratchet update.
+		const (
+			wantTotal   = 206
+			minPass     = 166
+			maxFallback = 35
+			wantSkip    = 5
+		)
+		if len(rows) != wantTotal || counts[scorecardPass] < minPass ||
+			counts[scorecardFallback] > maxFallback || counts[scorecardSkip] != wantSkip ||
+			counts[scorecardDiverge] != 0 || counts[scorecardError] != 0 {
+			t.Fatalf("admission breadth ratchet failed: PASS=%d (min %d) DIVERGE=%d FALLBACK=%d (max %d) SKIP=%d (want %d) ERROR=%d total=%d (want %d)",
+				counts[scorecardPass], minPass, counts[scorecardDiverge], counts[scorecardFallback], maxFallback,
+				counts[scorecardSkip], wantSkip, counts[scorecardError], len(rows), wantTotal)
 		}
 	}
 }

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -17,11 +17,11 @@ import (
 //     BenchmarkParserCoreFreshFullCanonical, which streams a compact derivation
 //     into a materialized public tree.
 //
-// The switch only ever changes which engine serves a FRESH FULL parse. It never
-// touches a reuse-consuming path: the compact tree carries a hard incremental-
-// reuse bar (decision 0008), so routing it under ParseIncremental would destroy
-// the O(edit) wins. See admissionCandidateFullParseEligible for the fail-closed
-// guard.
+// The switch only ever changes which engine serves a FRESH FULL parse. A
+// compact result may later feed incremental reuse only when materialization
+// attached a complete table-replay proof and scanner quiescence is proven;
+// every other compact tree retains the hard fail-closed reuse bar. See
+// admissionCandidateFullParseEligible and the materialization proof gate.
 //
 // Precedence, highest to lowest:
 //
@@ -176,9 +176,9 @@ func (p *Parser) admissionCandidateRouteEnabled() bool {
 // admissionCandidateFullParseEligible reports whether a fresh full parse may be
 // routed through the compact candidate. It fails closed for:
 //
-//   - every reuse-consuming path (oldTree != nil), because the compact tree
-//     carries a hard incremental-reuse bar (decision 0008) and routing it under
-//     ParseIncremental or the leaf fast path would destroy the O(edit) wins; and
+//   - every reuse-consuming call (oldTree != nil), because admission selects a
+//     fresh-full engine only; incremental reuse is decided later from the old
+//     tree's replay/scanner proof; and
 //   - any lexer other than the production DFA, because the compact route
 //     reproduces the production DFA token stream and cannot honor a caller-
 //     supplied token source.
@@ -187,6 +187,13 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 		return false
 	}
 	if !usingProductionDFA {
+		return false
+	}
+	// A language with an enabled, certified/explicit forest route already has a
+	// more specific full-parse policy. Preserve that route's correctness and
+	// incremental contracts instead of letting the generic compact candidate
+	// preempt it merely because both are capable of accepting the same input.
+	if p.admissionCandidateRoute == admissionRouteFollowDefault && glrForestEnabled && parserWantsForest(p) {
 		return false
 	}
 	// Resolve the switch first. This keeps the shipped OFF hot path cheap: none

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -56,6 +56,11 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 	}
 	return &parserCoreFreshFullRunner{
 		lang: p.language, parser: p, tables: tables, compact: compact, options: options,
+		// Incremental reuse is admitted only when materialization can attach the
+		// table-replayed state proof. Diagnostic runners retain their explicit
+		// GTS_REPLAY_PARSESTATE A/B switch; the production candidate always asks
+		// for the proof and still fails closed per tree when it is incomplete.
+		replayParseStates: true,
 	}, nil
 }
 

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -7,8 +7,8 @@ import "testing"
 // These tests run under the gts_parsercorephase0 tag, where the compact
 // candidate route is compiled in. They prove the switch actually routes a fresh
 // full parse through the compact route, that the routed tree is byte-exact with
-// production on the four canonical fixtures, and that every reuse-consuming path
-// stays on production.
+// production on the four canonical fixtures, and that incremental reuse is
+// available only when a routed tree carries the replay/scanner proof.
 
 func newAdmissionCandidateGoParser(t testing.TB) *Parser {
 	t.Helper()
@@ -56,7 +56,7 @@ func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 			t.Fatalf("%s: routed tree is not compact-materialized", row.id)
 		}
 		if !tree.incrementalReuseDisabled {
-			t.Fatalf("%s: routed tree must carry the reuse bar", row.id)
+			requireCompactIncrementalStateProof(t, tree)
 		}
 		tree.Release()
 	}

--- a/admission_zero_width_depth_test.go
+++ b/admission_zero_width_depth_test.go
@@ -1,0 +1,114 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestAdmissionCandidateYAMLZeroWidthDepth(t *testing.T) {
+	fixtures := []struct {
+		name      string
+		source    string
+		wantRoute bool
+	}{
+		{name: "github-actions", wantRoute: true, source: `name: Go
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: go test -v ./...
+`},
+		{name: "docker-compose", source: `services:
+  frontend:
+    build:
+      context: frontend
+      target: development
+    ports:
+      - 3000:3000
+    volumes:
+      - ./frontend:/usr/src/app
+    depends_on:
+      - backend
+  backend:
+    image: example/backend:latest
+    environment:
+      NODE_ENV: production
+`},
+		{name: "kubernetes", source: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              memory: "128Mi"
+`},
+	}
+	lang := grammars.YamlLanguage()
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			source := []byte(fixture.source)
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			want, err := production.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer want.Release()
+			wantInspection, err := benchfixtures.InspectGoTree(want.RootNode(), lang)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			gts.ResetAdmissionCandidateCountersForTest()
+			got, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer got.Release()
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if fixture.wantRoute {
+				if routed != 1 || fallback != 0 {
+					t.Fatalf("candidate did not route: routed=%d fallback=%d reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+				}
+			} else if routed != 0 || fallback != 1 {
+				t.Fatalf("candidate did not fail closed: routed=%d fallback=%d reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+			}
+			gotInspection, err := benchfixtures.InspectGoTree(got.RootNode(), lang)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotInspection.SHA256 != wantInspection.SHA256 {
+				t.Fatalf("candidate digest=%s production=%s", gotInspection.SHA256, wantInspection.SHA256)
+			}
+		})
+	}
+}

--- a/admission_zero_width_depth_test.go
+++ b/admission_zero_width_depth_test.go
@@ -10,13 +10,17 @@ import (
 	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
+type admissionDepthFixture struct {
+	name       string
+	lang       func() *gts.Language
+	source     string
+	wantDigest string
+	mustRoute  bool
+}
+
 func TestAdmissionCandidateYAMLZeroWidthDepth(t *testing.T) {
-	fixtures := []struct {
-		name      string
-		source    string
-		wantRoute bool
-	}{
-		{name: "github-actions", wantRoute: true, source: `name: Go
+	fixtures := []admissionDepthFixture{
+		{name: "github-actions", lang: grammars.YamlLanguage, mustRoute: true, wantDigest: "67d6dbaf8985d9b3e87cf8b09097eabfe63bc902db7863c91e7e061d85ca8cd7", source: `name: Go
 on:
   push:
     branches: [main]
@@ -28,7 +32,7 @@ jobs:
       - name: Test
         run: go test -v ./...
 `},
-		{name: "docker-compose", source: `services:
+		{name: "docker-compose", lang: grammars.YamlLanguage, wantDigest: "2ee78d1baf7420e08673cd262567263f9b2373670125305d0e985aed3df0b54e", source: `services:
   frontend:
     build:
       context: frontend
@@ -44,7 +48,7 @@ jobs:
     environment:
       NODE_ENV: production
 `},
-		{name: "kubernetes", source: `apiVersion: apps/v1
+		{name: "kubernetes", lang: grammars.YamlLanguage, wantDigest: "8d18e5d28f828e2a8b4de34c6c1bdf394ecd57da3290b65450892ab975a2d624", source: `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
@@ -70,10 +74,31 @@ spec:
               memory: "128Mi"
 `},
 	}
-	lang := grammars.YamlLanguage()
+	requireAdmissionDepthRatchet(t, fixtures, 1)
+}
+
+func TestAdmissionCandidateRepresentativeDepthRatchet(t *testing.T) {
+	fixtures := []admissionDepthFixture{
+		{name: "go", lang: grammars.GoLanguage, mustRoute: true, wantDigest: "95760c1ae5d0e46b32df59ef54c88931731093c391edd8786886c49aed739e94", source: "package demo\n\nfunc add(a, b int) int { return a + b }\n"},
+		{name: "javascript", lang: grammars.JavascriptLanguage, mustRoute: true, wantDigest: "3a1225ed47eacdbe9fa6372cbfe2ccbf6550a9d5fbcc2f31a58cc8b56c00b6a0", source: "export function add(a, b) {\n  return a + b;\n}\n"},
+		{name: "python", lang: grammars.PythonLanguage, mustRoute: true, wantDigest: "17d7802770da0f2972f52980a8af01cee4bb274b8cc497184804968ccb1773aa", source: "def greet(name):\n    return f\"hello {name}\"\n\nprint(greet(\"world\"))\n"},
+		{name: "rust", lang: grammars.RustLanguage, wantDigest: "34b82eb28fe0bc3f105ad63604104e7fcdbaf420af12e1ff9696a2640a93a3b2", source: "fn main() {\n    let values = [1, 2, 3];\n    println!(\"{}\", values.len());\n}\n"},
+		{name: "typescript", lang: grammars.TypescriptLanguage, mustRoute: true, wantDigest: "be604fe1d9a6e5430ce2a6ff58b7a7777f9881100d20805a2b2d09952c369729", source: "interface User { id: number; name: string }\nexport const user: User = { id: 1, name: \"Ada\" };\n"},
+		{name: "html", lang: grammars.HtmlLanguage, wantDigest: "e870fad244cda7aa86e5a2ca0e310eb0dbe4be6a2920f791ef788c23786f82b4", source: "<!doctype html>\n<html><body><main><h1>Hello</h1><p>World</p></main></body></html>\n"},
+		{name: "powershell", lang: grammars.PowershellLanguage, mustRoute: true, wantDigest: "874998165753303f1c085af48c1256fdc637c857b8a9b1aed17f2c7010512213", source: "$items = @(1, 2, 3)\nforeach ($item in $items) { Write-Output $item }\n"},
+	}
+	requireAdmissionDepthRatchet(t, fixtures, 5)
+}
+
+func requireAdmissionDepthRatchet(t *testing.T, fixtures []admissionDepthFixture, minRouted int) {
+	t.Helper()
+	routedFixtures := 0
 	for _, fixture := range fixtures {
+		fixture := fixture
 		t.Run(fixture.name, func(t *testing.T) {
+			lang := fixture.lang()
 			source := []byte(fixture.source)
+
 			production := gts.NewParser(lang)
 			production.SetAdmissionCandidateRoute(false)
 			want, err := production.Parse(source)
@@ -85,6 +110,9 @@ spec:
 			if err != nil {
 				t.Fatal(err)
 			}
+			if wantInspection.SHA256 != fixture.wantDigest {
+				t.Fatalf("production digest drifted: got=%s want=%s", wantInspection.SHA256, fixture.wantDigest)
+			}
 
 			candidate := gts.NewParser(lang)
 			candidate.SetAdmissionCandidateRoute(true)
@@ -95,20 +123,25 @@ spec:
 			}
 			defer got.Release()
 			routed, fallback := gts.AdmissionCandidateCounters()
-			if fixture.wantRoute {
-				if routed != 1 || fallback != 0 {
-					t.Fatalf("candidate did not route: routed=%d fallback=%d reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
-				}
-			} else if routed != 0 || fallback != 1 {
-				t.Fatalf("candidate did not fail closed: routed=%d fallback=%d reason=%q", routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+			if routed+fallback != 1 || routed > 1 || fallback > 1 {
+				t.Fatalf("candidate counters are not one exact decision: routed=%d fallback=%d", routed, fallback)
+			}
+			if fixture.mustRoute && routed != 1 {
+				t.Fatalf("candidate route regressed: fallback=%d reason=%q", fallback, gts.AdmissionCandidateLastFallbackReason())
+			}
+			if routed == 1 {
+				routedFixtures++
 			}
 			gotInspection, err := benchfixtures.InspectGoTree(got.RootNode(), lang)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if gotInspection.SHA256 != wantInspection.SHA256 {
-				t.Fatalf("candidate digest=%s production=%s", gotInspection.SHA256, wantInspection.SHA256)
+			if gotInspection.SHA256 != fixture.wantDigest {
+				t.Fatalf("candidate digest drifted: got=%s want=%s", gotInspection.SHA256, fixture.wantDigest)
 			}
 		})
+	}
+	if routedFixtures < minRouted {
+		t.Fatalf("depth coverage regressed: routed=%d want>=%d", routedFixtures, minRouted)
 	}
 }

--- a/cgo_harness/parity_cgo_test.go
+++ b/cgo_harness/parity_cgo_test.go
@@ -51,7 +51,7 @@ var paritySkips = map[string]parityMeta{
 var knownDegradedStructural = map[string]string{
 	// Empty: the last known structural divergence (norg's `_word` alias
 	// hidden-wrapper collapse) was fixed by extending
-	// normalizeResultTerminalLeafNodesWithStopAndErrorSummary's
+	// normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary's
 	// visible-terminal guard to also preserve distinct-named children under
 	// reused alias-target symbol IDs (see parser_result_terminal_leaf.go).
 	// Fresh-parse structural parity is now 206/206 across the curated fleet.

--- a/cgo_harness/parity_glr_canary_test.go
+++ b/cgo_harness/parity_glr_canary_test.go
@@ -30,7 +30,17 @@ func makeGoGLRCanarySource(callCount int) []byte {
 func assertGLRCanaryRuntime(t *testing.T, tc parityCase, src []byte, minStacks int) {
 	t.Helper()
 
-	goTree, goLang, err := parseWithGo(tc, src, nil)
+	entry, ok := parityEntriesByName[tc.name]
+	if !ok {
+		t.Fatalf("[%s/%s] missing gotreesitter registry entry", tc.name, "glr-canary")
+	}
+	goLang := entry.Language()
+	parser := gotreesitter.NewParser(goLang)
+	// This assertion verifies the live production GLR engine's branching
+	// telemetry. Compact admission establishes structural parity in runParityCase
+	// above but intentionally does not reconstruct live stack counters.
+	parser.SetAdmissionCandidateRoute(false)
+	goTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("[%s/%s] gotreesitter parse error: %v", tc.name, "glr-canary", err)
 	}

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -1,0 +1,751 @@
+package gotreesitter
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const resultCompatOwnershipRegistryPath = "testdata/result_compat_ownership_v1.json"
+
+type resultCompatOwnershipRegistry struct {
+	Schema          string                       `json:"schema"`
+	SourceOfTruth   bool                         `json:"source_of_truth"`
+	Denominator     resultCompatDenominator      `json:"denominator"`
+	OwnerCategories []string                     `json:"owner_categories"`
+	Entries         []resultCompatOwnershipEntry `json:"entries"`
+}
+
+type resultCompatDenominator struct {
+	DispatcherArms            int `json:"dispatcher_arms"`
+	DispatcherLanguages       int `json:"dispatcher_languages"`
+	DispatcherPredicates      int `json:"dispatcher_predicates"`
+	GenericPasses             int `json:"generic_passes"`
+	PostFinalizationArms      int `json:"post_finalization_arms"`
+	PostFinalizationLanguages int `json:"post_finalization_languages"`
+}
+
+type resultCompatOwnershipEntry struct {
+	ID                  string                    `json:"id"`
+	Kind                string                    `json:"kind"`
+	Functions           []string                  `json:"functions"`
+	Files               []string                  `json:"files"`
+	Languages           []string                  `json:"languages"`
+	MatchPredicate      string                    `json:"match_predicate,omitempty"`
+	EntrypointCalls     []string                  `json:"entrypoint_calls,omitempty"`
+	SwitchArms          []resultCompatSwitchArm   `json:"switch_arms,omitempty"`
+	Purpose             string                    `json:"purpose"`
+	AuthoritativeOwner  string                    `json:"authoritative_owner"`
+	Witnesses           []string                  `json:"witnesses"`
+	RetirementCondition string                    `json:"retirement_condition"`
+	RouteCoverage       resultCompatRouteCoverage `json:"route_coverage"`
+	Status              string                    `json:"status"`
+	ReceiptRefs         []string                  `json:"receipt_refs,omitempty"`
+	RetiredCommit       string                    `json:"retired_commit,omitempty"`
+}
+
+type resultCompatSwitchArm struct {
+	Languages []string `json:"languages"`
+	Functions []string `json:"functions"`
+}
+
+type resultCompatRouteCoverage struct {
+	Production  string `json:"production"`
+	Compact     string `json:"compact"`
+	Forest      string `json:"forest"`
+	Incremental string `json:"incremental"`
+	COracle     string `json:"c_oracle"`
+}
+
+func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
+	registry := loadResultCompatOwnershipRegistry(t)
+
+	allowedOwners := map[string]bool{
+		"scheduler_action_semantics":    true,
+		"derivation_election_selection": true,
+		"materialization":               true,
+		"scanner_checkpoint_state":      true,
+		"incremental_edit_reuse":        true,
+		"public_compatibility":          true,
+	}
+	if got, want := sortedStrings(registry.OwnerCategories), sortedMapKeys(allowedOwners); !equalStrings(got, want) {
+		t.Fatalf("owner_categories = %v, want %v", got, want)
+	}
+
+	entriesByKind := make(map[string][]resultCompatOwnershipEntry)
+	seenIDs := make(map[string]bool)
+	allowedKinds := map[string]bool{
+		"dispatcher_arm":       true,
+		"dispatcher_predicate": true,
+		"generic_pass":         true,
+		"second_pass_fixpoint": true,
+	}
+	for _, entry := range registry.Entries {
+		if entry.ID == "" || seenIDs[entry.ID] {
+			t.Fatalf("registry entry has empty or duplicate id %q", entry.ID)
+		}
+		seenIDs[entry.ID] = true
+		if !allowedOwners[entry.AuthoritativeOwner] {
+			t.Errorf("%s authoritative_owner = %q, want registered owner category", entry.ID, entry.AuthoritativeOwner)
+		}
+		if !allowedKinds[entry.Kind] {
+			t.Errorf("%s has unsupported kind %q", entry.ID, entry.Kind)
+		}
+		if entry.Purpose == "" || entry.RetirementCondition == "" {
+			t.Errorf("%s must declare purpose and retirement_condition", entry.ID)
+		}
+		if len(entry.Functions) == 0 || len(entry.Files) == 0 || len(entry.Languages) == 0 || len(entry.Witnesses) == 0 {
+			t.Errorf("%s must declare functions, files, languages, and witnesses", entry.ID)
+		}
+		if ownershipHasDuplicateStrings(entry.Functions) {
+			t.Errorf("%s functions must be a duplicate-free set: %v", entry.ID, entry.Functions)
+		}
+		assertOwnershipStatusAndRoutes(t, entry)
+		switch entry.Status {
+		case "live":
+			if len(entry.Functions) == 0 {
+				t.Errorf("%s is live but has no functions", entry.ID)
+			}
+		case "retired":
+			if entry.RetiredCommit == "" || len(entry.ReceiptRefs) == 0 {
+				t.Errorf("%s is retired but lacks retired_commit or receipt_refs", entry.ID)
+			}
+		default:
+			t.Errorf("%s has unsupported status %q", entry.ID, entry.Status)
+		}
+		if entry.Status != "retired" {
+			for _, path := range append(append([]string{}, entry.Files...), entry.Witnesses...) {
+				if _, err := os.Stat(filepath.Clean(path)); err != nil {
+					t.Errorf("%s references missing path %q: %v", entry.ID, path, err)
+				}
+			}
+		}
+		if entry.Status == "live" {
+			assertRegistryFunctionsExist(t, entry)
+		}
+		if entry.Status != "retired" {
+			entriesByKind[entry.Kind] = append(entriesByKind[entry.Kind], entry)
+		}
+	}
+
+	assertDispatcherRegistry(t, registry.Denominator, entriesByKind)
+	assertGenericPassRegistry(t, registry.Denominator, entriesByKind)
+	assertPostFinalizationRegistry(t, registry.Denominator, entriesByKind)
+}
+
+func loadResultCompatOwnershipRegistry(t *testing.T) resultCompatOwnershipRegistry {
+	t.Helper()
+	f, err := os.Open(resultCompatOwnershipRegistryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var registry resultCompatOwnershipRegistry
+	decoder := json.NewDecoder(f)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&registry); err != nil {
+		t.Fatalf("decode %s: %v", resultCompatOwnershipRegistryPath, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("%s has trailing JSON data: %v", resultCompatOwnershipRegistryPath, err)
+	}
+	if registry.Schema != "gotreesitter/result-compat-ownership/v1" || !registry.SourceOfTruth {
+		t.Fatalf("registry schema/source_of_truth = %q/%t", registry.Schema, registry.SourceOfTruth)
+	}
+	return registry
+}
+
+func assertOwnershipStatusAndRoutes(t *testing.T, entry resultCompatOwnershipEntry) {
+	t.Helper()
+	allowedStatuses := map[string]map[string]bool{
+		"dispatcher_arm":       {"live": true, "retired": true},
+		"dispatcher_predicate": {"live": true, "retired": true},
+		"generic_pass":         {"live": true, "retired": true},
+		"second_pass_fixpoint": {"live": true, "retired": true},
+	}
+	if !allowedStatuses[entry.Kind][entry.Status] {
+		t.Errorf("%s kind %q cannot have status %q", entry.ID, entry.Kind, entry.Status)
+		return
+	}
+	if entry.Status == "live" && entry.RetiredCommit != "" {
+		t.Errorf("%s is live but declares retired_commit", entry.ID)
+	}
+
+	var want resultCompatRouteCoverage
+	if entry.Status == "retired" {
+		want = resultCompatRouteCoverage{
+			Production:  "retired_exact_receipt",
+			Compact:     "retired_exact_receipt",
+			Forest:      "retired_exact_receipt",
+			Incremental: "retired_exact_receipt",
+			COracle:     "retired_exact_receipt",
+		}
+	} else {
+		switch entry.Kind {
+		case "dispatcher_arm", "dispatcher_predicate", "generic_pass":
+			want = resultCompatRouteCoverage{
+				Production:  "shared_result_compatibility_tail",
+				Compact:     "shared_result_compatibility_tail",
+				Forest:      "shared_result_compatibility_tail",
+				Incremental: "shared_result_compatibility_tail",
+				COracle:     "curated_single_grammar_parity",
+			}
+		case "second_pass_fixpoint":
+			want = resultCompatRouteCoverage{
+				Production:  "post_finalization_fixpoint",
+				Compact:     "post_finalization_fixpoint",
+				Forest:      "post_finalization_fixpoint",
+				Incremental: "post_finalization_fixpoint",
+				COracle:     "language_witnesses_required",
+			}
+		default:
+			return
+		}
+	}
+	if entry.RouteCoverage != want {
+		t.Errorf("%s route_coverage = %+v, want closed-vocabulary semantics %+v", entry.ID, entry.RouteCoverage, want)
+	}
+
+	switch entry.Kind {
+	case "dispatcher_predicate":
+		if entry.MatchPredicate == "" || len(entry.EntrypointCalls) != 0 || len(entry.SwitchArms) != 0 {
+			t.Errorf("%s dispatcher predicate must declare only match_predicate kind metadata", entry.ID)
+		}
+	case "second_pass_fixpoint":
+		if entry.MatchPredicate != "" || len(entry.EntrypointCalls) == 0 || len(entry.SwitchArms) == 0 {
+			t.Errorf("%s second-pass fixpoint must declare entrypoint_calls and switch_arms", entry.ID)
+		}
+	case "dispatcher_arm", "generic_pass":
+		if entry.MatchPredicate != "" || len(entry.EntrypointCalls) != 0 || len(entry.SwitchArms) != 0 {
+			t.Errorf("%s kind %q has incompatible predicate/fixpoint metadata", entry.ID, entry.Kind)
+		}
+	}
+}
+
+func assertRegistryFunctionsExist(t *testing.T, entry resultCompatOwnershipEntry) {
+	t.Helper()
+	declared := make(map[string]bool)
+	fset := token.NewFileSet()
+	for _, path := range entry.Files {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Errorf("%s parse %s: %v", entry.ID, path, err)
+			continue
+		}
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok {
+				declared[fn.Name.Name] = true
+			}
+		}
+	}
+	for _, function := range entry.Functions {
+		if !declared[function] {
+			t.Errorf("%s live function %s is absent from registered files %v", entry.ID, function, entry.Files)
+		}
+	}
+}
+
+func assertDispatcherRegistry(t *testing.T, denominator resultCompatDenominator, byKind map[string][]resultCompatOwnershipEntry) {
+	t.Helper()
+	file := parseOwnershipGoFile(t, "parser_result_compat.go")
+	dispatcher := findOwnershipFunction(t, file, "runLanguageResultCompatibility")
+	var languageSwitch *ast.SwitchStmt
+	ast.Inspect(dispatcher.Body, func(node ast.Node) bool {
+		if languageSwitch != nil {
+			return false
+		}
+		if sw, ok := node.(*ast.SwitchStmt); ok {
+			languageSwitch = sw
+			return false
+		}
+		return true
+	})
+	if languageSwitch == nil {
+		t.Fatal("runLanguageResultCompatibility has no language switch")
+	}
+
+	sourceArms := make(map[string][]string)
+	sourceLanguages := make(map[string]bool)
+	for _, statement := range languageSwitch.Body.List {
+		clause, ok := statement.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		var languages []string
+		for _, expression := range clause.List {
+			literal, ok := expression.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				t.Fatalf("dispatcher case has non-string expression %T", expression)
+			}
+			language, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if sourceLanguages[language] {
+				t.Fatalf("dispatcher language %q appears in multiple arms", language)
+			}
+			sourceLanguages[language] = true
+			languages = append(languages, language)
+		}
+		if len(languages) == 0 {
+			continue
+		}
+		key := ownershipLanguageKey(languages)
+		sourceArms[key] = ownershipNormalizeCalls(clause)
+	}
+
+	registryArms := make(map[string][]string)
+	for _, entry := range byKind["dispatcher_arm"] {
+		if !strings.HasPrefix(entry.ID, "dispatch.") {
+			t.Errorf("%s dispatcher arm id must have dispatch. prefix", entry.ID)
+		}
+		key := ownershipLanguageKey(entry.Languages)
+		if _, exists := registryArms[key]; exists {
+			t.Fatalf("duplicate dispatcher registry languages %q", key)
+		}
+		registryArms[key] = sortedStrings(entry.Functions)
+	}
+	if got, want := len(sourceArms), denominator.DispatcherArms; got != want {
+		t.Errorf("source dispatcher arms = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := len(sourceLanguages), denominator.DispatcherLanguages; got != want {
+		t.Errorf("source dispatcher languages = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := len(registryArms), denominator.DispatcherArms; got != want {
+		t.Errorf("registered dispatcher arms = %d, frozen denominator = %d", got, want)
+	}
+	for key, sourceFunctions := range sourceArms {
+		registryFunctions, ok := registryArms[key]
+		if !ok {
+			t.Errorf("dispatcher arm %q is not registered", key)
+			continue
+		}
+		if sourceFunctions = sortedStrings(sourceFunctions); !equalStrings(sourceFunctions, registryFunctions) {
+			t.Errorf("dispatcher arm %q functions = %v, registry = %v", key, sourceFunctions, registryFunctions)
+		}
+	}
+	for key := range registryArms {
+		if _, ok := sourceArms[key]; !ok {
+			t.Errorf("registered dispatcher arm %q no longer exists", key)
+		}
+	}
+
+	sourcePredicates := ownershipTopLevelNormalizePredicates(t, dispatcher)
+	predicates := byKind["dispatcher_predicate"]
+	if got, want := len(sourcePredicates), denominator.DispatcherPredicates; got != want {
+		t.Errorf("source dispatcher predicates = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := len(predicates), denominator.DispatcherPredicates; got != want {
+		t.Fatalf("registered dispatcher predicates = %d, frozen denominator = %d", got, want)
+	}
+	registryPredicates := make(map[string]resultCompatOwnershipEntry)
+	for _, entry := range predicates {
+		if entry.MatchPredicate == "" {
+			t.Errorf("%s must declare match_predicate", entry.ID)
+			continue
+		}
+		if _, exists := registryPredicates[entry.MatchPredicate]; exists {
+			t.Fatalf("duplicate dispatcher predicate %q", entry.MatchPredicate)
+		}
+		predicateFunction := findOwnershipFunctionInFiles(t, entry.Files, entry.MatchPredicate)
+		sourceLanguages := ownershipCanonicalPredicateLanguages(t, entry.MatchPredicate, predicateFunction)
+		if got, want := sourceLanguages, sortedStrings(entry.Languages); !equalStrings(got, want) {
+			t.Errorf("%s predicate languages = %v from AST, registry = %v", entry.ID, got, want)
+		}
+		registryPredicates[entry.MatchPredicate] = entry
+	}
+	for predicate, sourceFunctions := range sourcePredicates {
+		entry, ok := registryPredicates[predicate]
+		if !ok {
+			t.Errorf("dispatcher predicate %q is not registered", predicate)
+			continue
+		}
+		registryFunctions := sortedStrings(entry.Functions)
+		if sourceFunctions = sortedStrings(sourceFunctions); !equalStrings(sourceFunctions, registryFunctions) {
+			t.Errorf("dispatcher predicate %q functions = %v, registry = %v", predicate, sourceFunctions, registryFunctions)
+		}
+	}
+	for predicate := range registryPredicates {
+		if _, ok := sourcePredicates[predicate]; !ok {
+			t.Errorf("registered dispatcher predicate %q no longer exists", predicate)
+		}
+	}
+}
+
+func assertGenericPassRegistry(t *testing.T, denominator resultCompatDenominator, byKind map[string][]resultCompatOwnershipEntry) {
+	t.Helper()
+	file := parseOwnershipGoFile(t, "parser_result_compat.go")
+	fn := findOwnershipFunction(t, file, "normalizeResultCompatibility")
+	sourceFunctions := sortedStrings(ownershipNormalizeCalls(fn.Body))
+
+	var registryFunctions []string
+	for _, entry := range byKind["generic_pass"] {
+		registryFunctions = append(registryFunctions, entry.Functions...)
+	}
+	registryFunctions = sortedStrings(registryFunctions)
+	if got, want := len(byKind["generic_pass"]), denominator.GenericPasses; got != want {
+		t.Errorf("registered generic passes = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := len(sourceFunctions), denominator.GenericPasses; got != want {
+		t.Errorf("source generic normalization calls = %d, frozen denominator = %d (%v)", got, want, sourceFunctions)
+	}
+	if !equalStrings(sourceFunctions, registryFunctions) {
+		t.Errorf("generic normalization calls = %v, registry = %v", sourceFunctions, registryFunctions)
+	}
+}
+
+func assertPostFinalizationRegistry(t *testing.T, denominator resultCompatDenominator, byKind map[string][]resultCompatOwnershipEntry) {
+	t.Helper()
+	entries := byKind["second_pass_fixpoint"]
+	if len(entries) != 1 {
+		t.Fatalf("live second_pass_fixpoint entries = %d, want 1", len(entries))
+	}
+	entry := entries[0]
+
+	file := parseOwnershipGoFile(t, "parser_api.go")
+	entrypoint := findOwnershipFunction(t, file, "normalizePostFinalizationReturnedTree")
+	if got, want := sortedStrings(ownershipNormalizeCallOccurrences(entrypoint.Body)), sortedStrings(entry.EntrypointCalls); !equalStrings(got, want) {
+		t.Errorf("post-finalization entrypoint normalize calls = %v, registry = %v", got, want)
+	}
+	if len(entry.EntrypointCalls) != 1 {
+		t.Fatalf("%s entrypoint_calls = %v, want exactly one switch helper", entry.ID, entry.EntrypointCalls)
+	}
+	switchHelper := findOwnershipFunction(t, file, entry.EntrypointCalls[0])
+	languageSwitch := ownershipFirstSwitch(t, switchHelper, entry.EntrypointCalls[0])
+	if !ownershipIsLanguageNameSelector(languageSwitch.Tag) {
+		t.Errorf("%s switch tag is %T, want exact lang.Name selector", entry.EntrypointCalls[0], languageSwitch.Tag)
+	}
+	sourceArms, sourceLanguages := ownershipSwitchNormalizationArms(t, languageSwitch, "post-finalization")
+
+	registryArms := make(map[string][]string)
+	var registrySwitchFunctions []string
+	for _, arm := range entry.SwitchArms {
+		if len(arm.Languages) == 0 || len(arm.Functions) == 0 ||
+			ownershipHasDuplicateStrings(arm.Languages) || ownershipHasDuplicateStrings(arm.Functions) {
+			t.Errorf("%s switch arm must have duplicate-free languages and functions: %+v", entry.ID, arm)
+		}
+		key := ownershipLanguageKey(arm.Languages)
+		if _, exists := registryArms[key]; exists {
+			t.Fatalf("%s has duplicate switch arm %q", entry.ID, key)
+		}
+		registryArms[key] = sortedStrings(arm.Functions)
+		registrySwitchFunctions = append(registrySwitchFunctions, arm.Functions...)
+	}
+	if got, want := len(sourceArms), denominator.PostFinalizationArms; got != want {
+		t.Errorf("post-finalization source arms = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := len(sourceLanguages), denominator.PostFinalizationLanguages; got != want {
+		t.Errorf("post-finalization source languages = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := len(registryArms), denominator.PostFinalizationArms; got != want {
+		t.Errorf("post-finalization registered arms = %d, frozen denominator = %d", got, want)
+	}
+	for key, sourceFunctions := range sourceArms {
+		registryFunctions, ok := registryArms[key]
+		if !ok {
+			t.Errorf("post-finalization arm %q is not registered", key)
+			continue
+		}
+		if sourceFunctions = sortedStrings(sourceFunctions); !equalStrings(sourceFunctions, registryFunctions) {
+			t.Errorf("post-finalization arm %q functions = %v, registry = %v", key, sourceFunctions, registryFunctions)
+		}
+	}
+	for key := range registryArms {
+		if _, ok := sourceArms[key]; !ok {
+			t.Errorf("registered post-finalization arm %q no longer exists", key)
+		}
+	}
+	if got, want := sortedMapKeys(sourceLanguages), sortedStrings(entry.Languages); !equalStrings(got, want) {
+		t.Errorf("post-finalization languages = %v, registry entry languages = %v", got, want)
+	}
+	registrySwitchFunctions = sortedStrings(registrySwitchFunctions)
+	if got := sortedStrings(ownershipNormalizeCallOccurrences(switchHelper.Body)); !equalStrings(got, registrySwitchFunctions) {
+		t.Errorf("post-finalization helper normalize call occurrences = %v, registered non-default clause calls = %v", got, registrySwitchFunctions)
+	}
+	allRegisteredFunctions := append([]string{"normalizePostFinalizationReturnedTree"}, entry.EntrypointCalls...)
+	allRegisteredFunctions = append(allRegisteredFunctions, registrySwitchFunctions...)
+	if got, want := sortedStrings(entry.Functions), sortedStrings(allRegisteredFunctions); !equalStrings(got, want) {
+		t.Errorf("%s functions = %v, exact entrypoint/switch function set = %v", entry.ID, got, want)
+	}
+}
+
+func ownershipFirstSwitch(t *testing.T, fn *ast.FuncDecl, label string) *ast.SwitchStmt {
+	t.Helper()
+	var found *ast.SwitchStmt
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		if statement, ok := node.(*ast.SwitchStmt); ok {
+			found = statement
+			return false
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatalf("%s has no switch", label)
+	}
+	return found
+}
+
+func ownershipSwitchNormalizationArms(t *testing.T, languageSwitch *ast.SwitchStmt, label string) (map[string][]string, map[string]bool) {
+	t.Helper()
+	arms := make(map[string][]string)
+	languages := make(map[string]bool)
+	for _, statement := range languageSwitch.Body.List {
+		clause, ok := statement.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		var armLanguages []string
+		for _, expression := range clause.List {
+			literal, ok := expression.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				t.Fatalf("%s switch case has non-string expression %T", label, expression)
+			}
+			language, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if languages[language] {
+				t.Fatalf("%s language %q appears in multiple arms", label, language)
+			}
+			languages[language] = true
+			armLanguages = append(armLanguages, language)
+		}
+		if len(armLanguages) == 0 {
+			if calls := ownershipNormalizeCallOccurrences(clause); len(calls) != 0 {
+				t.Errorf("%s default clause has unregistered normalize call occurrences %v", label, calls)
+			}
+			continue
+		}
+		arms[ownershipLanguageKey(armLanguages)] = sortedStrings(ownershipNormalizeCallOccurrences(clause))
+	}
+	return arms, languages
+}
+
+func parseOwnershipGoFile(t *testing.T, path string) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return file
+}
+
+func findOwnershipFunction(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+	t.Helper()
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	t.Fatalf("function %s not found", name)
+	return nil
+}
+
+func findOwnershipFunctionInFiles(t *testing.T, paths []string, name string) *ast.FuncDecl {
+	t.Helper()
+	for _, path := range paths {
+		file := parseOwnershipGoFile(t, path)
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == name {
+				return fn
+			}
+		}
+	}
+	t.Fatalf("function %s not found in registered files %v", name, paths)
+	return nil
+}
+
+func ownershipCanonicalPredicateLanguages(t *testing.T, predicate string, fn *ast.FuncDecl) []string {
+	t.Helper()
+	if predicate != "isCobolLanguage" {
+		t.Errorf("dispatcher predicate %q lacks a canonical AST validator", predicate)
+		return nil
+	}
+	if len(fn.Body.List) != 1 {
+		t.Errorf("%s body has %d statements, want one canonical return", predicate, len(fn.Body.List))
+		return nil
+	}
+	returnStatement, ok := fn.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(returnStatement.Results) != 1 {
+		t.Errorf("%s body must be exactly one single-result return", predicate)
+		return nil
+	}
+	guarded, ok := returnStatement.Results[0].(*ast.BinaryExpr)
+	if !ok || guarded.Op != token.LAND || !ownershipIsLangNonNilGuard(guarded.X) {
+		t.Errorf("%s return must start with exact lang != nil && guard", predicate)
+		return nil
+	}
+	parenthesized, ok := guarded.Y.(*ast.ParenExpr)
+	if !ok {
+		t.Errorf("%s guarded language alternatives must be parenthesized", predicate)
+		return nil
+	}
+	alternatives, ok := parenthesized.X.(*ast.BinaryExpr)
+	if !ok || alternatives.Op != token.LOR {
+		t.Errorf("%s parenthesized predicate must be exactly one OR", predicate)
+		return nil
+	}
+	left, leftOK := ownershipExactLanguageNameEquality(alternatives.X)
+	right, rightOK := ownershipExactLanguageNameEquality(alternatives.Y)
+	if !leftOK || !rightOK {
+		t.Errorf("%s OR operands must be exact lang.Name == string equalities", predicate)
+		return nil
+	}
+	languages := sortedStrings([]string{left, right})
+	if want := []string{"COBOL", "cobol"}; !equalStrings(languages, want) {
+		t.Errorf("%s exact equality languages = %v, want %v", predicate, languages, want)
+	}
+	return languages
+}
+
+func ownershipIsLangNonNilGuard(expression ast.Expr) bool {
+	guard, ok := expression.(*ast.BinaryExpr)
+	if !ok || guard.Op != token.NEQ {
+		return false
+	}
+	left, leftOK := guard.X.(*ast.Ident)
+	right, rightOK := guard.Y.(*ast.Ident)
+	return leftOK && rightOK && left.Name == "lang" && right.Name == "nil"
+}
+
+func ownershipExactLanguageNameEquality(expression ast.Expr) (string, bool) {
+	equality, ok := expression.(*ast.BinaryExpr)
+	if !ok || equality.Op != token.EQL || !ownershipIsLanguageNameSelector(equality.X) {
+		return "", false
+	}
+	literal, ok := equality.Y.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	language, err := strconv.Unquote(literal.Value)
+	return language, err == nil
+}
+
+func ownershipIsLanguageNameSelector(expression ast.Expr) bool {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "Name" {
+		return false
+	}
+	identifier, ok := selector.X.(*ast.Ident)
+	return ok && identifier.Name == "lang"
+}
+
+func ownershipTopLevelNormalizePredicates(t *testing.T, fn *ast.FuncDecl) map[string][]string {
+	t.Helper()
+	result := make(map[string][]string)
+	for _, statement := range fn.Body.List {
+		conditional, ok := statement.(*ast.IfStmt)
+		if !ok {
+			continue
+		}
+		functions := ownershipNormalizeCalls(conditional.Body)
+		if len(functions) == 0 {
+			continue
+		}
+		var predicates []string
+		ast.Inspect(conditional.Cond, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if identifier, ok := call.Fun.(*ast.Ident); ok {
+				predicates = append(predicates, identifier.Name)
+			}
+			return true
+		})
+		if len(predicates) != 1 {
+			t.Errorf("normalization-bearing top-level predicate has callable predicates %v, want exactly one registered predicate", predicates)
+			continue
+		}
+		if _, exists := result[predicates[0]]; exists {
+			t.Errorf("normalization-bearing top-level predicate %q appears more than once", predicates[0])
+			continue
+		}
+		result[predicates[0]] = functions
+	}
+	return result
+}
+
+func ownershipNormalizeCalls(root ast.Node) []string {
+	seen := make(map[string]bool)
+	for _, name := range ownershipNormalizeCallOccurrences(root) {
+		seen[name] = true
+	}
+	return sortedMapKeys(seen)
+}
+
+func ownershipNormalizeCallOccurrences(root ast.Node) []string {
+	var calls []string
+	ast.Inspect(root, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch function := call.Fun.(type) {
+		case *ast.Ident:
+			name = function.Name
+		case *ast.SelectorExpr:
+			name = function.Sel.Name
+		}
+		if strings.HasPrefix(name, "normalize") {
+			calls = append(calls, name)
+		}
+		return true
+	})
+	return calls
+}
+
+func ownershipLanguageKey(languages []string) string {
+	return strings.Join(sortedStrings(languages), ",")
+}
+
+func sortedStrings(values []string) []string {
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result
+}
+
+func sortedMapKeys[V any](values map[string]V) []string {
+	result := make([]string, 0, len(values))
+	for key := range values {
+		result = append(result, key)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func ownershipHasDuplicateStrings(values []string) bool {
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if seen[value] {
+			return true
+		}
+		seen[value] = true
+	}
+	return false
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -73,6 +73,16 @@ The tier stays internal because it operates on arena and node internals before
 the tree is returned. Moving it into a package with exported plumbing would
 make the exported API surface worse without changing its ownership.
 
+## Current progress: collapsed named leaves
+
+All 23 registered collapsed named-leaf rows for the six affected built-in
+languages now produce their child shape natively when an exact SHA-pinned
+runtime profile grants the capability. The generic walk remains live: it is a
+zero-rewrite safety receipt for those certified artifacts and the repair path
+for caller-built, adapted, and other custom languages that do not carry the
+capability. Retirement still requires exact route receipts with zero rewrites
+and a documented decision for custom-language compatibility.
+
 ## The retained second pass
 
 `normalizePostFinalizationReturnedTree` deliberately runs a bounded second

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -1,69 +1,117 @@
-# The C-faithful compat tier (`parser_result_*.go`)
+# The C-faithful result-compatibility tier
 
-If you clone this repository and list the root package, the first thing you
-see is a wall of `parser_result_<language>*.go` files — currently about 177
-files and about 72K lines. This page explains what that tier is, why it
-lives where it lives, and why it shrinks over time.
+The root package contains a visible `parser_result_<language>*.go` tier.
+It is post-parse compatibility scaffolding: where the parser does not yet
+reproduce a C tree-selection or materialization behavior through a general
+engine mechanism, a bounded pass reconciles the returned tree with the C
+oracle.
 
-## What it is
+This page is a readable guide. The mechanically checked source of truth is
+[`testdata/result_compat_ownership_v1.json`](../testdata/result_compat_ownership_v1.json).
+Do not update dispatcher coverage, ownership, or retirement state here
+without updating that registry.
 
-Post-parse, C-faithful **result normalization**. Two GLR parsers can both be
-"correct" and still select different trees under ambiguity, error recovery,
-or extra/trivia attachment. gotreesitter's parity program demands more than
-correctness: it demands byte-exact agreement with the tree the C runtime
-*selects*, including error-node shapes and recovered spans, verified
-against the cgo-backed oracle in `cgo_harness/`.
+## Current denominator
 
-Where the core engine does not yet reproduce a C selection behavior through
-a general mechanism, a bounded normalization pass reshapes the raw parse
-result after the fact. Examples: JavaScript ASI and trailing-comment
-attachment, statement-keyword shapes shared by JS/TS, Python repair shapes,
-recovered-tree normalizations for Doxygen/JSDoc, and COBOL `EXEC CICS` span
-trimming.
+The v1 registry freezes the current surface:
 
-Each pass is:
+- 78 explicit `runLanguageResultCompatibility` switch arms covering 85
+  language names;
+- one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
+- three generic passes that run after language dispatch;
+- one retained post-finalization second-pass fixpoint with three switch arms
+  covering Scala, HTML, and JavaScript.
 
-- **language-scoped** — `parser_result_<language>*.go`, greppable as a tier;
-- **oracle-gated** — every pass exists because a named witness diverged
-  from C, and parity fixtures pin it, failing the build if it drifts;
-- **internal** — passes run on unexported arena/node internals before the
-  tree is returned. They are plumbing, not API. This is also why the tier
-  lives in the root package: it needs `nodeArena`, `stackEntry`, and
-  friends, and exporting those to move the files into a subpackage would
-  trade cosmetic layout for a worse public surface.
+That is 83 live registry entries. The registry covers only this documented
+internal result-compatibility tier; scheduler experiments and other engine
+research belong in their owning subsystem's durable traces.
 
-## Why it shrinks
+Each registry entry has a stable ID, functions and files, languages, purpose,
+authoritative owner, witnesses, a retirement condition, coverage fields for
+production/compact/forest/incremental/C-oracle routes, status, and optional
+receipt references. A retired entry remains in the registry with its commit
+and receipt references; deleting the historical record is not retirement.
 
-The tier is scaffolding for the parity ratchet, not a destination. The
-stated engine rule (see the README roadmap) is: **add no public parse
-variant and no parser-core language-name switch when a general mechanism
-can express the need.** As general mechanisms land — certified
-conflict-resolution policies, blob-pinned runtime profiles, non-terminal
-alias maps, the global repetition fold — the tier deletes the shims those
-mechanisms subsume:
+## Ownership
 
-- v0.24.1 removed fourteen retired language-specific repetition/conflict
-  dispatch helpers and their dead JavaScript/TypeScript/Java closure.
-- v0.25.0 removed the retired `no_alias` reduction-attribution lane end to
-  end.
-- The Python normalization cluster is queued for the same closure (its
-  remaining helpers are referenced only by their own tests).
+Compatibility functions describe symptoms. Their `authoritative_owner`
+records the earliest subsystem that must eventually produce the C-faithful
+result:
 
-The honest trajectory is: shim count rises while a language's parity
-closes, then falls as the behavior moves into certified engine mechanisms.
-The 206/206 exhaustive-parity milestone (v0.23.0) is what makes the
-deletions safe — every removal must keep the zero-exemption parity gate
-green.
-
-## Reading the tier
-
-| Convention | Meaning |
+| Owner | Responsibility |
 |---|---|
-| `parser_result_<lang>.go` | primary normalization passes for a language |
-| `parser_result_<lang>_*_test.go` | witness fixtures pinning each pass |
-| `normalize<Lang>Compatibility(...)` | per-language entry point |
-| `parser_result.go` | shared dispatch into per-language entry points |
+| `scheduler_action_semantics` | action ordering, recovery, and work execution |
+| `derivation_election_selection` | ambiguity and winning-derivation choice |
+| `materialization` | node, field, alias, trivia, and span construction |
+| `scanner_checkpoint_state` | external-scanner state and restoration |
+| `incremental_edit_reuse` | edit invalidation and subtree reuse |
+| `public_compatibility` | compatibility intentionally retained at an exported API boundary |
 
-Largest groups today (file count): C# (14), Rust (6), Go (5), Python (4),
-JavaScript/TypeScript (4+), Swift (3), Scala (3), PowerShell (3),
-Kotlin (3), Haskell (3).
+The route fields use a closed vocabulary enforced by the registry test:
+
+- live dispatcher, predicate, and generic entries use
+  `shared_result_compatibility_tail` for production/compact/forest/incremental
+  and `curated_single_grammar_parity` for the C oracle;
+- the live fixpoint uses `post_finalization_fixpoint` for those four parser
+  routes and `language_witnesses_required` for the C oracle; and
+- retired entries use `retired_exact_receipt` for all five fields and must
+  include a retirement commit and receipt reference.
+
+These are evidence labels, not claims that all five engines have independent
+implementations. The shared-tail value means that route reaches the same
+post-parse normalization tail.
+
+## Why it exists
+
+Two GLR parsers can accept the same input and still return different trees
+under ambiguity, error recovery, aliasing, or extra/trivia attachment.
+gotreesitter's parity target is byte-exact agreement with the selected C tree,
+including error shapes and recovered spans. The cgo-backed suites under
+`cgo_harness/` provide that oracle.
+
+The tier stays internal because it operates on arena and node internals before
+the tree is returned. Moving it into a package with exported plumbing would
+make the exported API surface worse without changing its ownership.
+
+## The retained second pass
+
+`normalizePostFinalizationReturnedTree` deliberately runs a bounded second
+pass for Scala, HTML, and JavaScript. It remains live because the first pass
+can expose information needed by later normalization. In particular, it may
+not be retired until the HTML producer/materializer emits final nested custom
+tag ranges without `normalizeHTMLRecoveredNestedCustomTagRanges`. Scala and
+JavaScript producers must likewise emit their final annotations and spans in
+one pass, and all registered route receipts must show the second pass is inert.
+
+Removing the second pass because it looks repetitive would reopen known
+fixpoint behavior; its registry retirement condition is the deletion gate.
+
+## Editing and validation
+
+When adding, moving, or retiring compatibility code:
+
+1. Update the JSON registry in the same change.
+2. Keep dispatcher languages, called functions, ownership, witnesses, routes,
+   and retirement evidence explicit.
+3. For retirement, keep the entry and set `status` to `retired`, with
+   `retired_commit` and at least one `receipt_refs` item.
+4. Run the focused registry gate:
+
+```sh
+go test . -run '^TestResultCompatibilityOwnershipRegistry$' -count=1
+```
+
+The test parses `parser_result_compat.go`, `parser_result_helpers.go`, and
+`parser_api.go` with the Go AST. It fails when a dispatcher arm or predicate
+is unregistered, the exact COBOL predicate language set drifts, a generic pass
+changes without a registry update, a post-finalization language arm or call
+changes, or a live registered function disappears from its declared files.
+The COBOL check requires the canonical nil-guard AND parenthesized two-equality
+OR AST. The fixpoint check counts clause-local call occurrences and rejects
+normalization in default clauses or outside registered cases. The gate also
+enforces kind/status combinations, route vocabulary and semantics, required
+metadata, and referenced witness paths.
+
+This document is hand-maintained explanatory text, not generated output. The
+JSON registry and the focused Go test are the regeneration/validation
+contract.

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -302,11 +302,170 @@ numbering, use the public remapper:
 
 - `IncrementalReuseExternalScanner` (`SupportsIncrementalReuse() bool`):
   declare true only if reusing subtrees across edits is safe for your
-  state. Stateless scanners: yes. Python-style indent stacks deliberately
-  leave this unimplemented, so edits force a conservative reparse.
+  state. Stateless scanners: yes. Returning false is an explicit opt-out;
+  not implementing the interface is also treated as uncertified and fails
+  closed. Python, Mojo, and Starlark currently return false.
 - `FailurePreservingExternalScanner` (`PreservesStateOnScanFailure() bool`):
   declare true if `Scan` returning false never mutated the payload — this
   lets the runtime skip defensive state snapshots on the hot path.
+
+### Incremental-reuse certification matrix
+
+This matrix records the production contract for every external scanner in
+the built-in registry. It is derived from the registration files under
+`grammars/z_subset_scanner_register_*.go` and the runtime gate in
+`languageSupportsIncrementalReuse`:
+
+- **certified reuse** means the registered scanner implements
+  `IncrementalReuseExternalScanner` and returns true. A changed edit may
+  enter old-tree subtree reuse, subject to the normal dirty-span,
+  fragility, byte-equality, and scanner-boundary gates.
+- **bounded reuse** is Dart's certified route for sources up to 256 KiB.
+  Larger Dart sources use the fresh production parse with reason
+  `dart_large_external_scanner_unsupported`.
+- **fallback (explicit opt-out)** means the scanner implements the
+  interface and returns false.
+- **fallback (uncertified)** means the scanner does not implement the
+  interface. For either fallback status, once the preliminary
+  token-invariant leaf fast path declines, `ParseIncremental` ignores the
+  old tree and runs the same production full-parse and retry path as
+  `Parse`. `ParseIncrementalProfiled` reports `ReuseUnsupported=true`,
+  `ReuseUnsupportedReason="external_scanner_unsupported"`, no old-tree
+  reuse route, and no reused bytes or subtrees.
+
+The token-invariant leaf exception is intentionally narrow: on a production
+tree, a same-length edit that independently reauthenticates the same leaf
+token may return before the scanner gate. That is not certification for
+general scanner-dependent subtree reuse. Likewise, scanner checkpoints do
+not certify a scanner by themselves: CMake and Svelte both opt in and use
+checkpoints, while Python, Mojo, and Starlark use checkpoints but explicitly
+opt out. Custom `TokenSource` implementations have their own
+`IncrementalReuseTokenSource` contract and are outside this registry matrix.
+In particular, the registered SQL, HTML, Markdown, and Markdown Inline
+scanners are currently uncertified, so changed-token or shape-changing edits
+take the production full-parse fallback rather than scanner-dependent reuse.
+
+| Language | Changed-edit contract |
+|---|---|
+| `agda` | fallback (uncertified) |
+| `angular` | fallback (uncertified) |
+| `arduino` | fallback (uncertified) |
+| `astro` | fallback (uncertified) |
+| `awk` | fallback (uncertified) |
+| `bash` | fallback (uncertified) |
+| `beancount` | fallback (uncertified) |
+| `bicep` | fallback (uncertified) |
+| `bitbake` | fallback (uncertified) |
+| `blade` | fallback (uncertified) |
+| `c_sharp` | fallback (uncertified) |
+| `caddy` | fallback (uncertified) |
+| `cairo` | fallback (uncertified) |
+| `cmake` | certified reuse |
+| `cobol` | fallback (uncertified) |
+| `comment` | fallback (uncertified) |
+| `cooklang` | fallback (uncertified) |
+| `cpp` | fallback (uncertified) |
+| `crystal` | fallback (uncertified) |
+| `css` | certified reuse |
+| `cuda` | fallback (uncertified) |
+| `cue` | fallback (uncertified) |
+| `d` | fallback (uncertified) |
+| `dart` | bounded reuse (up to 256 KiB) |
+| `dhall` | fallback (uncertified) |
+| `disassembly` | fallback (uncertified) |
+| `djot` | fallback (uncertified) |
+| `dockerfile` | fallback (uncertified) |
+| `doxygen` | fallback (uncertified) |
+| `dtd` | fallback (uncertified) |
+| `earthfile` | fallback (uncertified) |
+| `editorconfig` | fallback (uncertified) |
+| `elixir` | fallback (uncertified) |
+| `elm` | fallback (uncertified) |
+| `erlang` | fallback (uncertified) |
+| `fennel` | fallback (uncertified) |
+| `firrtl` | fallback (uncertified) |
+| `fish` | fallback (uncertified) |
+| `foam` | fallback (uncertified) |
+| `fortran` | fallback (uncertified) |
+| `fsharp` | fallback (uncertified) |
+| `gdscript` | fallback (uncertified) |
+| `gitcommit` | fallback (uncertified) |
+| `gleam` | fallback (uncertified) |
+| `gn` | fallback (uncertified) |
+| `go` | certified reuse |
+| `godot_resource` | fallback (uncertified) |
+| `hack` | fallback (uncertified) |
+| `haskell` | fallback (uncertified) |
+| `haxe` | fallback (uncertified) |
+| `hcl` | fallback (uncertified) |
+| `hlsl` | fallback (uncertified) |
+| `html` | fallback (uncertified) |
+| `janet` | fallback (uncertified) |
+| `javascript` | certified reuse |
+| `jsdoc` | fallback (uncertified) |
+| `jsonnet` | fallback (uncertified) |
+| `julia` | fallback (uncertified) |
+| `just` | fallback (uncertified) |
+| `kconfig` | fallback (uncertified) |
+| `kdl` | fallback (uncertified) |
+| `kotlin` | fallback (uncertified) |
+| `less` | fallback (uncertified) |
+| `liquid` | fallback (uncertified) |
+| `lua` | fallback (uncertified) |
+| `luau` | fallback (uncertified) |
+| `markdown` | fallback (uncertified) |
+| `markdown_inline` | fallback (uncertified) |
+| `matlab` | fallback (uncertified) |
+| `mojo` | fallback (explicit opt-out) |
+| `move` | fallback (uncertified) |
+| `nginx` | fallback (uncertified) |
+| `nickel` | fallback (uncertified) |
+| `nim` | fallback (uncertified) |
+| `nix` | fallback (uncertified) |
+| `norg` | fallback (uncertified) |
+| `nushell` | fallback (uncertified) |
+| `ocaml` | fallback (uncertified) |
+| `odin` | fallback (uncertified) |
+| `org` | fallback (uncertified) |
+| `perl` | fallback (uncertified) |
+| `php` | fallback (uncertified) |
+| `pkl` | fallback (uncertified) |
+| `powershell` | fallback (uncertified) |
+| `properties` | fallback (uncertified) |
+| `pug` | fallback (uncertified) |
+| `purescript` | fallback (uncertified) |
+| `python` | fallback (explicit opt-out) |
+| `r` | fallback (uncertified) |
+| `racket` | fallback (uncertified) |
+| `rescript` | fallback (uncertified) |
+| `ron` | fallback (uncertified) |
+| `rst` | fallback (uncertified) |
+| `ruby` | fallback (uncertified) |
+| `rust` | fallback (uncertified) |
+| `scala` | fallback (uncertified) |
+| `scss` | certified reuse |
+| `sql` | fallback (uncertified) |
+| `squirrel` | fallback (uncertified) |
+| `starlark` | fallback (explicit opt-out) |
+| `svelte` | certified reuse |
+| `swift` | fallback (uncertified) |
+| `tablegen` | fallback (uncertified) |
+| `tcl` | fallback (uncertified) |
+| `teal` | fallback (uncertified) |
+| `templ` | fallback (uncertified) |
+| `tlaplus` | fallback (uncertified) |
+| `toml` | certified reuse |
+| `tsx` | certified reuse |
+| `typescript` | certified reuse |
+| `typst` | fallback (uncertified) |
+| `uxntal` | fallback (uncertified) |
+| `vhdl` | fallback (uncertified) |
+| `vue` | fallback (uncertified) |
+| `wgsl` | fallback (uncertified) |
+| `wolfram` | fallback (uncertified) |
+| `xml` | fallback (uncertified) |
+| `yaml` | fallback (uncertified) |
+| `yuck` | fallback (uncertified) |
 
 ## Hard-learned behavioral contracts
 

--- a/export_test.go
+++ b/export_test.go
@@ -338,6 +338,24 @@ func ParserAdmissionEligibleForTest(p *Parser) bool {
 	return p.admissionCandidateFullParseEligible(nil, true)
 }
 
+// ParserRetainsCollapsedChildOccurrenceForTest exposes the exact native
+// occurrence predicate to external-package artifact tests.
+func ParserRetainsCollapsedChildOccurrenceForTest(p *Parser, parent, child Symbol) bool {
+	return p != nil && p.retainsCollapsedChildOccurrence(parent, child)
+}
+
+// NormalizeCollapsedNamedLeafForTest exercises the legacy safety-net matcher
+// and returns its exact traversal/rewrite counters.
+func NormalizeCollapsedNamedLeafForTest(root *Node, source []byte, lang *Language, parentName, childName string, bySource bool) (visited, rewritten uint64) {
+	var counters normalizationPassCounters
+	if bySource {
+		counters = normalizeCollapsedNamedLeafChildrenBySourceWithStats(root, source, lang, parentName, childName)
+	} else {
+		counters = normalizeCollapsedNamedLeafChildrenWithStats(root, lang, parentName, childName)
+	}
+	return counters.nodesVisited, counters.nodesRewritten
+}
+
 // ParserPoolCheckoutForTest checks a parser out of the pool (applying defaults).
 func ParserPoolCheckoutForTest(pp *ParserPool) *Parser { return pp.checkout() }
 

--- a/external_scanner_dart_docs_contract_test.go
+++ b/external_scanner_dart_docs_contract_test.go
@@ -1,0 +1,29 @@
+package gotreesitter
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var dartScannerMatrixRowRE = regexp.MustCompile("(?m)^\\| `dart` \\| ([^|]+) \\|$")
+
+func TestDartExternalScannerDocumentationBoundMatchesRuntime(t *testing.T) {
+	content, err := os.ReadFile("docs/external-scanners.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := dartScannerMatrixRowRE.FindStringSubmatch(string(content))
+	if len(match) != 2 {
+		t.Fatal("external-scanner matrix is missing the Dart row")
+	}
+	if dartIncrementalReuseMaxSourceBytes%1024 != 0 {
+		t.Fatalf("Dart incremental-reuse bound %d is not an exact KiB value", dartIncrementalReuseMaxSourceBytes)
+	}
+	want := fmt.Sprintf("bounded reuse (up to %d KiB)", dartIncrementalReuseMaxSourceBytes/1024)
+	if got := strings.TrimSpace(match[1]); got != want {
+		t.Fatalf("Dart scanner matrix contract = %q, want %q", got, want)
+	}
+}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2429,6 +2429,9 @@ func (p *Parser) forestCollapsibleNamedKeywordLeaf(act ParseAction, tok Token, a
 	if p.shouldPreserveVisibleUnaryTokenWrapper(act.Symbol) {
 		return nil
 	}
+	if p.shouldKeepVisibleAnonymousTokenChild(act.Symbol, child.symbol) {
+		return nil
+	}
 	if !p.sameSymbolName(act.Symbol, child.symbol) && !forestGapCollapse(p.language, act.Symbol) {
 		return nil
 	}

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -963,6 +963,11 @@ func TestYAMLIncrementalEditScalarTokenInvariantLeafReuseIsCorrect(t *testing.T)
 			}
 
 			parser := gts.NewParser(lang)
+			// This test isolates production incremental leaf reuse. Compact full-
+			// parse trees deliberately carry the decision-0008 reuse bar; as compact
+			// coverage expands, relying on an incidental admission fallback would
+			// silently change what this test exercises.
+			parser.SetAdmissionCandidateRoute(false)
 			oldTree, err := parser.Parse(src)
 			if err != nil {
 				t.Fatalf("initial parse: %v", err)

--- a/grammargen/extra_chain_lexmode_test.go
+++ b/grammargen/extra_chain_lexmode_test.go
@@ -676,7 +676,7 @@ func TestNonterminalExtraChainShiftExtraChainFlagSurvivesAssembly(t *testing.T) 
 		t.Fatal("missing /* symbol")
 	}
 
-	actionIdx := lookupActionIndexForTest(lang, 1, slashStarSym)
+	actionIdx := lookupActionIndexForLanguage(lang, 1, slashStarSym)
 	if actionIdx == 0 || int(actionIdx) >= len(lang.ParseActions) {
 		t.Fatalf("missing parse action for /* in root state: %d", actionIdx)
 	}
@@ -690,55 +690,6 @@ func TestNonterminalExtraChainShiftExtraChainFlagSurvivesAssembly(t *testing.T) 
 	if actions[0].Extra {
 		t.Fatalf("root extra-chain shift for /* should not be treated as a terminal extra: %+v", actions[0])
 	}
-}
-
-func lookupActionIndexForTest(lang *gotreesitter.Language, state gotreesitter.StateID, sym gotreesitter.Symbol) uint16 {
-	if lang == nil {
-		return 0
-	}
-	denseLimit := int(lang.LargeStateCount)
-	if denseLimit == 0 {
-		denseLimit = len(lang.ParseTable)
-	}
-	if int(state) < denseLimit {
-		if int(state) >= len(lang.ParseTable) {
-			return 0
-		}
-		row := lang.ParseTable[state]
-		if int(sym) >= len(row) {
-			return 0
-		}
-		return row[sym]
-	}
-	smallIdx := int(state) - int(lang.LargeStateCount)
-	if smallIdx < 0 || smallIdx >= len(lang.SmallParseTableMap) {
-		return 0
-	}
-	table := lang.SmallParseTable
-	offset := lang.SmallParseTableMap[smallIdx]
-	if int(offset) >= len(table) {
-		return 0
-	}
-	groupCount := table[offset]
-	pos := int(offset) + 1
-	for i := uint16(0); i < groupCount; i++ {
-		if pos+1 >= len(table) {
-			break
-		}
-		sectionValue := table[pos]
-		symbolCount := table[pos+1]
-		pos += 2
-		for j := uint16(0); j < symbolCount; j++ {
-			if pos >= len(table) {
-				break
-			}
-			if gotreesitter.Symbol(table[pos]) == sym {
-				return sectionValue
-			}
-			pos++
-		}
-	}
-	return 0
 }
 
 func TestNonterminalExtraChainSyntheticReduceStatesDoNotInjectNestedExtraStarts(t *testing.T) {

--- a/grammargen/reserved_words_test.go
+++ b/grammargen/reserved_words_test.go
@@ -114,8 +114,8 @@ func TestGenerateLanguageReservedWordSets(t *testing.T) {
 	var reservedState gotreesitter.StateID
 	var keywordState gotreesitter.StateID
 	for state := gotreesitter.StateID(1); int(state) < len(lang.LexModes); state++ {
-		wordAction := lookupActionIndexForTest(lang, state, wordSym)
-		ifAction := lookupActionIndexForTest(lang, state, kwIfSym)
+		wordAction := lookupActionIndexForLanguage(lang, state, wordSym)
+		ifAction := lookupActionIndexForLanguage(lang, state, kwIfSym)
 		if reservedState == 0 && wordAction != 0 && ifAction == 0 {
 			reservedState = state
 		}

--- a/grammars/clean_regression_pins_test.go
+++ b/grammars/clean_regression_pins_test.go
@@ -186,7 +186,7 @@ func TestCleanRegressionPinGitRebasePick(t *testing.T) {
 // visible) as a child (ChildCount==1). Divergence class:
 // accepted_shape_materialization — a terminal-leaf on a NONTERMINAL wrapper.
 //
-// Root cause: normalizeResultTerminalLeafNodesWithStopAndErrorSummary
+// Root cause: normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary
 // (parser_result_terminal_leaf.go) only collapses parents that are visible
 // terminals or visible alias targets.
 // `any_character` is a visible NAMED NONTERMINAL (sym 50) whose sole production

--- a/grammars/collapsed_child_native_regression_test.go
+++ b/grammars/collapsed_child_native_regression_test.go
@@ -1,0 +1,217 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+func TestCollapsedChildLedgerRealLanguagesNeedNoSafetyNetRewrite(t *testing.T) {
+	tests := []struct {
+		name           string
+		lang           func() *gotreesitter.Language
+		src            string
+		compactDecline bool
+		compactSrc     string
+		compactWant    map[string]struct {
+			child string
+			named bool
+			count int
+		}
+		forestEligible bool
+		want           map[string]struct {
+			child string
+			named bool
+			count int
+		}
+	}{
+		{name: "ruby", lang: RubyLanguage, src: "%w(foo)\n%i(bar)\n", forestEligible: true, want: map[string]struct {
+			child string
+			named bool
+			count int
+		}{"bare_string": {child: "string_content", named: true, count: 1}, "bare_symbol": {child: "string_content", named: true, count: 1}}},
+		{name: "kotlin", lang: KotlinLanguage, src: "package a\nimport d.*\n", forestEligible: true, want: map[string]struct {
+			child string
+			named bool
+			count int
+		}{"identifier": {child: "simple_identifier", named: true, count: 2}}},
+		{name: "hack", lang: HackLanguage, src: "<?hh function f(): void { $a = true; $b = false; $c = null; }\n", compactDecline: true, want: map[string]struct {
+			child string
+			named bool
+			count int
+		}{"true": {child: "true", count: 1}, "false": {child: "false", count: 1}, "null": {child: "null", count: 1}}},
+		{name: "dart", lang: DartLanguage, src: "class A { void f(){ this.f(); } } class B extends A { B(): super(); }\n", forestEligible: true, want: map[string]struct {
+			child string
+			named bool
+			count int
+		}{"this": {child: "this", count: 1}, "super": {child: "super", count: 1}}},
+		{name: "elixir", lang: ElixirLanguage, src: "nil\n", forestEligible: true, want: map[string]struct {
+			child string
+			named bool
+			count int
+		}{"nil": {child: "nil", count: 1}}},
+		{name: "apex", lang: ApexLanguage, forestEligible: true,
+			compactSrc: "trigger T on Account (before insert, after delete) { System.debug(UserInfo.getUserId()); }\n",
+			compactWant: map[string]struct {
+				child string
+				named bool
+				count int
+			}{"before_insert": {child: "before_insert", count: 1}, "after_delete": {child: "after_delete", count: 1}},
+			src: `trigger T on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) { System.debug(UserInfo.getUserId()); }
+public class C { public C(){ super(); } void f(Account a, User u) { insert a; delete a; undelete a; upsert a; insert as user a; update as system a; System.runAs(u) { } } }
+`, want: map[string]struct {
+				child string
+				named bool
+				count int
+			}{
+				"after_delete": {child: "after_delete", count: 1}, "after_insert": {child: "after_insert", count: 1},
+				"after_undelete": {child: "after_undelete", count: 1}, "after_update": {child: "after_update", count: 1},
+				"before_delete": {child: "before_delete", count: 1}, "before_insert": {child: "before_insert", count: 1},
+				"before_update": {child: "before_update", count: 1}, "delete": {child: "delete", count: 1},
+				"insert": {child: "insert", count: 2}, "super": {child: "super", count: 1},
+				"system": {child: "system", count: 1}, "undelete": {child: "undelete", count: 1},
+				"upsert": {child: "upsert", count: 1}, "user": {child: "user", count: 1},
+			}},
+	}
+	seenPairs := make(map[string]struct{}, 23)
+	for _, test := range tests {
+		lang := test.lang()
+		if lang.NativeResultCompatibility&gotreesitter.ResultCompatibilityNativeCollapsedChildren == 0 {
+			t.Fatalf("%s exact artifact omitted collapsed-child capability", test.name)
+		}
+		for parentName, want := range test.want {
+			parent, parentOK := collapsedChildRegressionSymbol(lang, parentName, true)
+			child, childOK := collapsedChildRegressionSymbol(lang, want.child, want.named)
+			if !parentOK || !childOK {
+				t.Fatalf("%s route coverage could not resolve %s/%s named=%t", test.name, parentName, want.child, want.named)
+			}
+			key := fmt.Sprintf("%s:%d/%d", test.name, parent, child)
+			if _, duplicate := seenPairs[key]; duplicate {
+				t.Fatalf("duplicate collapsed-child route pair %s", key)
+			}
+			seenPairs[key] = struct{}{}
+		}
+	}
+	if got := len(seenPairs); got != 23 {
+		t.Fatalf("exact-artifact collapsed-child route rows=%d, want 23", got)
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			lang := test.lang()
+			production := gotreesitter.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			tree, err := production.Parse([]byte(test.src))
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertCollapsedChildRouteTree(t, "production", tree, lang, test.want)
+			if tree.ParseRuntime().ForestFastPath {
+				t.Fatal("production-pinned parse reported forest route")
+			}
+			tree.Release()
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compact := gotreesitter.NewParser(lang)
+			compact.SetAdmissionCandidateRoute(true)
+			compactSrc, compactWant := test.compactSrc, test.compactWant
+			if compactSrc == "" {
+				compactSrc, compactWant = test.src, test.want
+			}
+			tree, err = compact.Parse([]byte(compactSrc))
+			if err != nil {
+				t.Fatal(err)
+			}
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if test.compactDecline {
+				assertCollapsedChildRouteTree(t, "compact-fallback", tree, lang, compactWant)
+				if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+					t.Fatalf("compact decline counters routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+				}
+			} else {
+				assertCollapsedChildRouteTree(t, "compact-routed", tree, lang, compactWant)
+				if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+					t.Fatalf("compact route counters routed=%d/%d fallback=%d/%d", routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+				}
+			}
+			tree.Release()
+
+			if test.forestEligible {
+				forest := gotreesitter.NewParser(lang)
+				tree, ok := forest.ParseForestExperimental([]byte(test.src))
+				if !ok || tree == nil {
+					offset, symbol, reason, _ := forest.ForestDeclineInfo()
+					t.Fatalf("eligible forest route declined at %d symbol=%d reason=%s", offset, symbol, reason)
+				}
+				assertCollapsedChildRouteTree(t, "forest", tree, lang, test.want)
+				if !tree.ParseRuntime().ForestFastPath {
+					t.Fatal("forest parse did not report forest route")
+				}
+				tree.Release()
+			}
+		})
+	}
+}
+
+func collapsedChildRegressionSymbol(lang *gotreesitter.Language, name string, named bool) (gotreesitter.Symbol, bool) {
+	for index, symbolName := range lang.SymbolNames {
+		if symbolName == name && index < len(lang.SymbolMetadata) && lang.SymbolMetadata[index].Named == named {
+			return gotreesitter.Symbol(index), true
+		}
+	}
+	return 0, false
+}
+
+func assertCollapsedChildRouteTree(t *testing.T, route string, tree *gotreesitter.Tree, lang *gotreesitter.Language, wants map[string]struct {
+	child string
+	named bool
+	count int
+}) {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil || root.HasError() {
+		t.Fatalf("%s unclean fixture: %v", route, root)
+	}
+	if runtime := tree.ParseRuntime(); route == "compact-routed" || route == "forest" {
+		if runtime.NormalizationPassesChecked != 0 || runtime.NormalizationPassesRun != 0 || runtime.NormalizationNodesVisited != 0 || runtime.NormalizationNodesRewritten != 0 {
+			t.Fatalf("%s normalization checked/run/visited/rewritten=%d/%d/%d/%d", route, runtime.NormalizationPassesChecked, runtime.NormalizationPassesRun, runtime.NormalizationNodesVisited, runtime.NormalizationNodesRewritten)
+		}
+	} else if runtime.NormalizationPassesChecked == 0 || runtime.NormalizationPassesRun == 0 || runtime.NormalizationNodesVisited == 0 || runtime.NormalizationNodesRewritten != 0 {
+		t.Fatalf("%s normalization checked/run/visited/rewritten=%d/%d/%d/%d", route, runtime.NormalizationPassesChecked, runtime.NormalizationPassesRun, runtime.NormalizationNodesVisited, runtime.NormalizationNodesRewritten)
+	}
+	for parentType, want := range wants {
+		parents := collapsedChildRegressionNodes(root, lang, parentType)
+		if len(parents) != want.count {
+			t.Fatalf("%s %s count = %d, want %d; tree=%s", route, parentType, len(parents), want.count, root.SExpr(lang))
+		}
+		for _, parent := range parents {
+			if parent.ChildCount() != 1 {
+				t.Fatalf("%s %s children = %d, want 1", route, parentType, parent.ChildCount())
+			}
+			child := parent.Child(0)
+			if child == nil || child.Type(lang) != want.child || child.IsNamed() != want.named {
+				t.Fatalf("%s %s child = %v, want %s named=%t", route, parentType, child, want.child, want.named)
+			}
+		}
+	}
+}
+
+func collapsedChildRegressionNodes(root *gotreesitter.Node, lang *gotreesitter.Language, typ string) []*gotreesitter.Node {
+	var nodes []*gotreesitter.Node
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		if node.Type(lang) == typ && node.IsNamed() {
+			nodes = append(nodes, node)
+		}
+		for index := 0; index < node.ChildCount(); index++ {
+			walk(node.Child(index))
+		}
+	}
+	walk(root)
+	return nodes
+}

--- a/grammars/external_scanner_docs_contract_test.go
+++ b/grammars/external_scanner_docs_contract_test.go
@@ -1,0 +1,93 @@
+package grammars
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+)
+
+var scannerMatrixRowRE = regexp.MustCompile("(?m)^\\| `([^`]+)` \\| ([^|]+) \\|$")
+
+func TestExternalScannerDocumentationCertificationsMatchAttachedRuntimeRegistry(t *testing.T) {
+	certifications := documentedExternalScannerCertifications(t)
+	if len(certifications) != len(externalScannerRegistry) {
+		t.Fatalf("scanner matrix has %d rows, runtime registry has %d languages", len(certifications), len(externalScannerRegistry))
+	}
+
+	ordinaryRegistry := make(map[string]LangEntry)
+	for _, entry := range AllLanguages() {
+		ordinaryRegistry[entry.Name] = entry
+	}
+	for name := range externalScannerRegistry {
+		entry, ok := ordinaryRegistry[name]
+		if !ok || entry.Language == nil {
+			t.Errorf("runtime external scanner %q has no ordinary language-registry loader", name)
+		}
+
+		probe := &gts.Language{Name: name}
+		if !attachExternalScannerForLanguage(name, probe) || probe.ExternalScanner == nil {
+			t.Errorf("runtime external scanner %q did not attach through the embedded-loader path", name)
+			continue
+		}
+		want := externalScannerCertification(probe.ExternalScanner)
+		got, ok := certifications[name]
+		if !ok {
+			t.Errorf("scanner matrix is missing runtime language %q", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("scanner matrix certification for %q = %q, want %q", name, got, want)
+		}
+	}
+	for name := range certifications {
+		if _, ok := externalScannerRegistry[name]; !ok {
+			t.Errorf("scanner matrix contains language %q with no runtime scanner registration", name)
+		}
+	}
+}
+
+func documentedExternalScannerCertifications(t *testing.T) map[string]string {
+	t.Helper()
+	content, err := os.ReadFile("../docs/external-scanners.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const startHeading = "### Incremental-reuse certification matrix"
+	const endHeading = "## Hard-learned behavioral contracts"
+	start := strings.Index(string(content), startHeading)
+	end := strings.Index(string(content), endHeading)
+	if start < 0 || end < 0 || end <= start {
+		t.Fatalf("external-scanner matrix section is missing or malformed")
+	}
+	matches := scannerMatrixRowRE.FindAllStringSubmatch(string(content[start:end]), -1)
+	certifications := make(map[string]string, len(matches))
+	for _, match := range matches {
+		name := match[1]
+		if _, exists := certifications[name]; exists {
+			t.Fatalf("scanner matrix contains duplicate language %q", name)
+		}
+		contract := strings.TrimSpace(match[2])
+		if strings.HasPrefix(contract, "bounded reuse") {
+			// Bounded reuse is scanner-certified reuse plus a parser-level source
+			// guard. The root runtime test checks the exact bound against its
+			// production constant; this registry test checks scanner certification.
+			contract = "certified reuse"
+		}
+		certifications[name] = contract
+	}
+	return certifications
+}
+
+func externalScannerCertification(scanner gts.ExternalScanner) string {
+	reusable, certified := scanner.(gts.IncrementalReuseExternalScanner)
+	if !certified {
+		return "fallback (uncertified)"
+	}
+	if !reusable.SupportsIncrementalReuse() {
+		return "fallback (explicit opt-out)"
+	}
+	return "certified reuse"
+}

--- a/grammars/python_parse_regression_test.go
+++ b/grammars/python_parse_regression_test.go
@@ -181,6 +181,10 @@ func TestPythonNoTreeBenchmarkSkipsExternalScannerCheckpoints(t *testing.T) {
 	lang := PythonLanguage()
 
 	parser := gotreesitter.NewParser(lang)
+	// The checkpoint counters are production-parser allocation telemetry. Compact
+	// admission validates the same full-tree structure but does not retain live
+	// external-scanner checkpoint records, so measure this contract on production.
+	parser.SetAdmissionCandidateRoute(false)
 	fullTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -49,6 +49,7 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	"dart": {
 		blobSHA256:                    mustRuntimeProfileSHA256("06bac15a9921a2e6af2810fb37ecb29a358b120e137345b9af5fb5f6c6632f59"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		nativeResultCompatibility:     gotreesitter.ResultCompatibilityNativeCollapsedChildren,
 		conflictPolicies: []gotreesitter.ConflictPolicy{
 			{State: 596, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{509}},
 			{State: 602, Lookahead: gotreesitter.ConflictPolicyAnyLookahead, Kind: gotreesitter.ConflictPolicyRepetitionShift, ReduceSymbols: []gotreesitter.Symbol{512}},
@@ -91,6 +92,23 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 	"kotlin": {
 		blobSHA256:                    mustRuntimeProfileSHA256("643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		nativeResultCompatibility:     gotreesitter.ResultCompatibilityNativeCollapsedChildren,
+	},
+	"apex": {
+		blobSHA256:                mustRuntimeProfileSHA256("69fc1b577f1f783a204c98719d55d2f15f329d296b9e227d651056ce878c1bd2"),
+		nativeResultCompatibility: gotreesitter.ResultCompatibilityNativeCollapsedChildren,
+	},
+	"elixir": {
+		blobSHA256:                mustRuntimeProfileSHA256("9889f5f6704ea87f357c8d65ef3194d88fb5865922b45767fe4df0f2eda7e3f0"),
+		nativeResultCompatibility: gotreesitter.ResultCompatibilityNativeCollapsedChildren,
+	},
+	"hack": {
+		blobSHA256:                mustRuntimeProfileSHA256("f7388868d68644eff2ef6aa3dee5d0da1bc4f926ef4a8b04f98274bd471df3e6"),
+		nativeResultCompatibility: gotreesitter.ResultCompatibilityNativeCollapsedChildren,
+	},
+	"ruby": {
+		blobSHA256:                mustRuntimeProfileSHA256("9f1dc301142506249e7ac340372671f1d5e9ae76b7d378fc049635259bf8fc7f"),
+		nativeResultCompatibility: gotreesitter.ResultCompatibilityNativeCollapsedChildren,
 	},
 	// Matlab's external-scanner repeat selects the same tree after the complete
 	// accepted-error retry ladder. Keep the full ladder, but do not run it twice

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -54,10 +54,11 @@ func TestCrystalAndMatlabKeepAcceptedErrorRetryLadder(t *testing.T) {
 }
 
 func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
-	// 28 = the prior 19 plus D and Groovy, whose retry ceilings moved out of
-	// parser-core name switches and onto exact-blob profiles. The prior gomod
-	// and C additions moved hardcoded compat-tier behavior to profiles. Meson
-	// and Enforce add two exact-blob retry policies. JavaScript adds one
+	// 32 = the prior 28 plus Apex, Elixir, Hack, and Ruby, whose collapsed-child
+	// capability is bound to exact blob identity. D and Groovy's retry ceilings
+	// moved out of parser-core name switches and onto exact-blob profiles. The
+	// prior gomod and C additions moved hardcoded compat-tier behavior to profiles.
+	// Meson and Enforce add two exact-blob retry policies. JavaScript adds one
 	// exact-blob automatic-forest memory allowance. The
 	// repetition-conflict helpers were retired in favor of certified
 	// ConflictPolicies rows here. AWK and Uxntal add exact-blob automatic forest
@@ -66,7 +67,7 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// the gomod entry), so it does not add a map entry. Crystal and Matlab add
 	// exact-blob external-scanner repeat suppression while retaining the full
 	// accepted-error retry ladder.
-	if got, want := len(builtinLanguageRuntimeProfiles), 28; got != want {
+	if got, want := len(builtinLanguageRuntimeProfiles), 32; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -684,6 +685,45 @@ func TestCSharpNativeResultCompatibilityRequiresExactBlobIdentity(t *testing.T) 
 	}
 	if got := CSharpLanguage().NativeResultCompatibility; got != want {
 		t.Fatalf("embedded CSharpLanguage NativeResultCompatibility = %#x, want %#x", got, want)
+	}
+}
+
+func TestCollapsedChildNativeCapabilityRequiresExactBlobIdentity(t *testing.T) {
+	want := gotreesitter.ResultCompatibilityNativeCollapsedChildren
+	tests := []struct {
+		name string
+		load func() *gotreesitter.Language
+	}{
+		{name: "apex", load: ApexLanguage},
+		{name: "dart", load: DartLanguage},
+		{name: "elixir", load: ElixirLanguage},
+		{name: "hack", load: HackLanguage},
+		{name: "kotlin", load: KotlinLanguage},
+		{name: "ruby", load: RubyLanguage},
+	}
+	PurgeEmbeddedLanguageCache()
+	t.Cleanup(func() { PurgeEmbeddedLanguageCache() })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrongSHA := &gotreesitter.Language{Name: tt.name}
+			if attachBuiltinLanguageRuntimeProfile(tt.name, sha256.Sum256([]byte("uncertified")), wrongSHA) {
+				t.Fatal("wrong blob SHA reported a runtime-profile attachment")
+			}
+			if wrongSHA.NativeResultCompatibility&want != 0 {
+				t.Fatal("wrong blob SHA attached collapsed-child capability")
+			}
+
+			adapted := &gotreesitter.Language{Name: tt.name}
+			AttachLanguageSupport(tt.name, adapted)
+			if adapted.NativeResultCompatibility&want != 0 {
+				t.Fatal("same-name adapted language attached collapsed-child capability")
+			}
+
+			exact := tt.load()
+			if exact.NativeResultCompatibility&want == 0 {
+				t.Fatal("exact built-in artifact omitted collapsed-child capability")
+			}
+		})
 	}
 }
 

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -6,14 +6,6 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 	if p == nil || oldTree == nil || oldTree.RootNode() == nil || oldTree.language != p.language {
 		return nil, false
 	}
-	// A compact-materialized tree carries table-replayed / abstained per-node
-	// parser states and no scanner checkpoints, so it is barred from every reuse
-	// path -- including this token-invariant leaf reuse -- on ALL entry points
-	// (DFA and custom token source). Force the caller to a full fresh parse
-	// (Phase-3 Lane 3 review).
-	if oldTree.compactMaterialized {
-		return nil, false
-	}
 	if len(oldTree.edits) != 1 {
 		return nil, false
 	}
@@ -64,6 +56,12 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 			timing.singleStackTokens = 0
 		}
 		return tree, true
+	}
+	if oldTree.compactMaterialized && oldTree.incrementalReuseDisabled && node.preGotoState == 0 {
+		// Diagnostic/states-free compact trees retain the original hard bar.
+		// A replayed leaf has an authenticated lexer entry state and may proceed
+		// to the exact symbol/span rescan below even when subtree reuse is barred.
+		return nil, false
 	}
 	leaf := node
 	if leaf == nil || leaf.ChildCount() != 0 || leaf.hasError() || leaf.isMissing() {

--- a/incremental_leaf_fastpath.go
+++ b/incremental_leaf_fastpath.go
@@ -57,17 +57,31 @@ func (p *Parser) tryTokenInvariantLeafEdit(source []byte, oldTree *Tree, ts Toke
 		}
 		return tree, true
 	}
-	if oldTree.compactMaterialized && oldTree.incrementalReuseDisabled && node.preGotoState == 0 {
-		// Diagnostic/states-free compact trees retain the original hard bar.
-		// A replayed leaf has an authenticated lexer entry state and may proceed
-		// to the exact symbol/span rescan below even when subtree reuse is barred.
-		return nil, false
-	}
 	leaf := node
 	if leaf == nil || leaf.ChildCount() != 0 || leaf.hasError() || leaf.isMissing() {
 		return nil, false
 	}
-	tok, ok := p.scanTokenInvariantEditedLeaf(source, ts, leaf)
+	requireScannerCheckpoint := false
+	if oldTree.compactMaterialized && oldTree.incrementalReuseDisabled {
+		// Keep the scanner-proof closure local to the primitive as well as at
+		// admission. Direct callers must not bypass the compact-tree gate and
+		// reauthenticate a leaf with a newly-created stateful scanner payload.
+		if leaf.preGotoState == 0 || !compactLeafScannerReauthenticationProven(p.language, leaf) {
+			return nil, false
+		}
+		requireScannerCheckpoint = compactLeafScannerCheckpointRequired(p.language)
+	}
+	var tok Token
+	var ok bool
+	if requireScannerCheckpoint {
+		// This is intentionally a terminal path: a compact tree whose scanner
+		// proof depends on a checkpoint must authenticate that checkpoint during
+		// the scan. Failure may not fall through to a fresh scanner payload or a
+		// generic token-source skip.
+		tok, ok = scanCompactLeafWithRequiredScannerCheckpoint(ts, leaf)
+	} else {
+		tok, ok = p.scanTokenInvariantEditedLeaf(source, ts, leaf)
+	}
 	if !ok || tok.Symbol != leaf.symbol || tok.StartByte != leaf.startByte || tok.EndByte != leaf.endByte {
 		return nil, false
 	}
@@ -829,6 +843,20 @@ func (p *Parser) scanTokenInvariantEditedLeaf(source []byte, ts TokenSource, lea
 	stateful.SetParserState(leaf.preGotoState)
 	stateful.SetGLRStates(nil)
 	return skipTokenSourceToLeaf(ts, leaf)
+}
+
+// scanCompactLeafWithRequiredScannerCheckpoint performs the only permitted
+// scan for a compact leaf whose scanner proof depends on a recorded checkpoint.
+// It calls scanDFALeafTokenWithExternalCheckpoint directly; that routine
+// restores the start snapshot and verifies both the token identity/span and end
+// snapshot. Any unsupported token source or failed authentication returns
+// false; callers must not retry through a fresh scanner or generic skip path.
+func scanCompactLeafWithRequiredScannerCheckpoint(ts TokenSource, leaf *Node) (Token, bool) {
+	dts, ok := ts.(*dfaTokenSource)
+	if !ok || dts == nil || !languageUsesExternalScannerCheckpoints(dts.language) {
+		return Token{}, false
+	}
+	return scanDFALeafTokenWithExternalCheckpoint(dts, leaf)
 }
 
 func (p *Parser) scanLeafTokenWithFreshSource(source []byte, leaf *Node, allowDFA bool) (Token, bool) {

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1229,7 +1229,9 @@ func (c *Core) ShiftClassified(boundary ClassifiedBoundary, actionOrdinal int, t
 // ShiftOrdinaryCohort applies one ordinary terminal election to distinct
 // scheduler heads while allocating exactly one immutable terminal payload.
 // It is intentionally narrower than Shift: every cell must contain exactly
-// one undecorated non-extra shift and the token must have positive width.
+// one undecorated non-extra shift. The token may have zero width: parser-state
+// movement and scanner-checkpoint identity provide scheduler progress even
+// when the byte offset is unchanged.
 // Missing, no-lookahead, reused, and scanner-checkpoint identity remain
 // caller-visible concerns. External provenance is one compact identity bit;
 // scanner state remains outside this layer.

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -902,6 +902,53 @@ func TestShiftOrdinaryCohortSharesOneTerminalPayload(t *testing.T) {
 	}
 }
 
+func TestShiftOrdinaryCohortSupportsZeroWidthTerminal(t *testing.T) {
+	tables := &fakeTable{actions: map[tableCell][]Action{
+		{state: 1, symbol: 9}: {{Type: ActionShift, State: 3}},
+		{state: 2, symbol: 9}: {{Type: ActionShift, State: 4}},
+	}}
+	compact, err := New(tables, Limits{MaxDerivations: 4, MaxPopPaths: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _ := compact.Seed(1, 4)
+	second, _ := compact.Seed(2, 4)
+
+	shifted, err := compact.ShiftOrdinaryCohort([]OrdinaryCohortShiftInput{
+		{Head: first, ActionOrdinal: 0},
+		{Head: second, ActionOrdinal: 0},
+	}, 9, Token{Symbol: 9, StartByte: 4, EndByte: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(shifted) != 2 {
+		t.Fatalf("shifted cohort length=%d, want 2", len(shifted))
+	}
+	for index, wantState := range []StateID{3, 4} {
+		state, byteOffset, err := compact.Boundary(shifted[index])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state != wantState || byteOffset != 4 {
+			t.Fatalf("shifted boundary %d=(state %d, byte %d), want (state %d, byte 4)", index, state, byteOffset, wantState)
+		}
+		paths, err := compact.Derivations(shifted[index])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(paths) != 1 || len(paths[0].Payloads) != 1 {
+			t.Fatalf("shifted boundary %d paths=%+v, want one terminal derivation", index, paths)
+		}
+		view, err := compact.Subtree(paths[0].Payloads[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if view.Symbol != 9 || view.StartByte != 4 || view.EndByte != 4 || view.Extra || !view.Terminal {
+			t.Fatalf("shifted boundary %d terminal=%+v", index, view)
+		}
+	}
+}
+
 func TestExternalTerminalProvenanceIsPartOfSubtreeIdentity(t *testing.T) {
 	tables := &fakeTable{actions: map[tableCell][]Action{
 		{state: 1, symbol: 9}: {{Type: ActionShift, State: 3}},
@@ -1051,7 +1098,6 @@ func TestShiftOrdinaryCohortValidatesBeforeMutation(t *testing.T) {
 		{name: "extra-chain-action", inputs: []OrdinaryCohortShiftInput{{Head: first}, {Head: extraChain}}, token: Token{Symbol: 9, StartByte: 4, EndByte: 5}},
 		{name: "decorated-shift-action", inputs: []OrdinaryCohortShiftInput{{Head: first}, {Head: decoratedShift}}, token: Token{Symbol: 9, StartByte: 4, EndByte: 5}},
 		{name: "extra-token", inputs: []OrdinaryCohortShiftInput{{Head: first}}, token: Token{Symbol: 9, StartByte: 4, EndByte: 5, Extra: true}},
-		{name: "zero-width-token", inputs: []OrdinaryCohortShiftInput{{Head: first}}, token: Token{Symbol: 9, StartByte: 4, EndByte: 4}},
 		{name: "symbol-mismatch", inputs: []OrdinaryCohortShiftInput{{Head: first}}, token: Token{Symbol: 8, StartByte: 4, EndByte: 5}},
 		{name: "invalid-head", inputs: []OrdinaryCohortShiftInput{{Head: first}, {Head: Head{Node: 999}}}, token: Token{Symbol: 9, StartByte: 4, EndByte: 5}},
 		{name: "nonzero-ordinal", inputs: []OrdinaryCohortShiftInput{{Head: first, ActionOrdinal: 1}}, token: Token{Symbol: 9, StartByte: 4, EndByte: 5}},

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -82,8 +82,8 @@ func (c *Core) prepareOrdinaryClassifiedCohortInto(boundaries []ClassifiedBounda
 	if len(targets) != len(boundaries) {
 		return errors.New("parser-core phase zero: ordinary cohort target storage length mismatch")
 	}
-	if shifted.Extra || shifted.EndByte <= shifted.StartByte {
-		return errors.New("parser-core phase zero: cohort token is not an ordinary positive-width terminal")
+	if shifted.Extra {
+		return errors.New("parser-core phase zero: cohort token is not an ordinary terminal")
 	}
 	for index, boundary := range boundaries {
 		if shifted.Symbol != boundary.lookahead {

--- a/internal/parsercorephase0/selected_store.go
+++ b/internal/parsercorephase0/selected_store.go
@@ -26,17 +26,34 @@ const (
 	SelectedUnaryRenameLeaf
 )
 
+// SelectedAliasChildPair is one compiled occurrence fact requiring an alias to
+// retain its raw child instead of relabeling that child.
+type SelectedAliasChildPair struct {
+	Alias Symbol
+	Child Symbol
+}
+
 // SelectedStorePolicy is the fail-closed compact-to-consumer contract. Unary
 // is a dense parent-major matrix with stride len(Symbols).
 type SelectedStorePolicy struct {
-	Symbols             []SelectedSymbolPolicy
-	Unary               []SelectedUnaryRule
-	ExpectedRoot        Symbol
-	Semicolon           Symbol
-	SemicolonNUL        Symbol
-	SemicolonContainers []bool
-	Cases               []bool
-	StatementLists      []bool
+	Symbols               []SelectedSymbolPolicy
+	Unary                 []SelectedUnaryRule
+	RetainedAliasChildren []SelectedAliasChildPair
+	ExpectedRoot          Symbol
+	Semicolon             Symbol
+	SemicolonNUL          Symbol
+	SemicolonContainers   []bool
+	Cases                 []bool
+	StatementLists        []bool
+}
+
+// SetRetainedAliasChildren installs parser-compiled symbol facts. The compact
+// core deliberately receives no language names or source-text policy.
+func (p *SelectedStorePolicy) SetRetainedAliasChildren(edges []SelectedAliasChildPair) {
+	if p == nil {
+		return
+	}
+	p.RetainedAliasChildren = append(p.RetainedAliasChildren[:0], edges...)
 }
 
 // SelectedStorePolicyProvider lets an authenticated table adapter build the
@@ -90,6 +107,18 @@ func (p SelectedStorePolicy) unary(parent, child Symbol) SelectedUnaryRule {
 	return p.Unary[slot]
 }
 
+func (p SelectedStorePolicy) retainsAliasChild(alias, child Symbol) bool {
+	if alias == 0 {
+		return false
+	}
+	for _, edge := range p.RetainedAliasChildren {
+		if edge.Alias == alias && edge.Child == child {
+			return true
+		}
+	}
+	return false
+}
+
 func (p SelectedStorePolicy) validate() error {
 	if len(p.Symbols) == 0 || int(p.ExpectedRoot) >= len(p.Symbols) {
 		return errors.New("parser-core phase zero: selected-store policy has no authenticated root")
@@ -97,6 +126,11 @@ func (p SelectedStorePolicy) validate() error {
 	width := len(p.Symbols)
 	if width > math.MaxInt/width || len(p.Unary) != width*width {
 		return errors.New("parser-core phase zero: selected-store unary policy width drifted")
+	}
+	for _, pair := range p.RetainedAliasChildren {
+		if pair.Alias == 0 || int(pair.Alias) >= width || int(pair.Child) >= width || !p.Symbols[pair.Alias].Visible {
+			return errors.New("parser-core phase zero: selected-store retained-alias policy is invalid")
+		}
 	}
 	compatWidth := len(p.SemicolonContainers)
 	if compatWidth == 0 {
@@ -428,14 +462,24 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 		return nil, err
 	}
 	defer c.finishSelectedBuildScratch()
+	retainedAliasCount := 0
+	for _, occurrence := range raw {
+		record, recordErr := c.subtree(occurrence.payload)
+		if recordErr != nil {
+			return nil, recordErr
+		}
+		if !record.extra && policy.retainsAliasChild(occurrence.alias, record.symbol) {
+			retainedAliasCount++
+		}
+	}
 	results := resizeSelectedScratch(c.selectedBuild.results, len(raw))
 	c.selectedBuild.results = results
-	wantRetained := uint64(len(raw))*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
-		uint64(len(raw)-len(roots))*uint64(unsafe.Sizeof(SelectedNodeID(0)))
+	wantRetained := uint64(len(raw)+retainedAliasCount)*uint64(unsafe.Sizeof(SelectedNodeRecord{})) +
+		uint64(len(raw)-len(roots)+retainedAliasCount)*uint64(unsafe.Sizeof(SelectedNodeID(0)))
 	if wantRetained > c.limits.MaxSelectedBytes {
 		return nil, errors.New("parser-core phase zero: selected store retained-byte cap")
 	}
-	store := c.acquireSelectedStore(len(raw), len(raw)-len(roots))
+	store := c.acquireSelectedStore(len(raw)+retainedAliasCount, len(raw)-len(roots)+retainedAliasCount)
 	sealed := false
 	defer func() {
 		if !sealed {
@@ -464,8 +508,9 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 		if err != nil {
 			return nil, err
 		}
+		retainAliasChild := !record.extra && policy.retainsAliasChild(occ.alias, record.symbol)
 		symbol := record.symbol
-		if occ.alias != 0 {
+		if occ.alias != 0 && !retainAliasChild {
 			symbol = occ.alias
 		}
 		meta, ok := policy.symbol(symbol)
@@ -504,7 +549,7 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 					child.Symbol = record.symbol
 					child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal())
 				}
-				if occ.alias != 0 {
+				if occ.alias != 0 && !retainAliasChild {
 					child.Symbol = occ.alias
 					child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
 				}
@@ -514,8 +559,14 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 					return nil, err
 				}
 				precedenceDeltas[childID-1] = delta
-				if occ.field != 0 {
+				if occ.field != 0 && !retainAliasChild {
 					child.Field = occ.field
+				}
+				if retainAliasChild {
+					childID, precedenceDeltas, err = appendSelectedRetainedAliasWrapper(store, policy, childID, occ.alias, occ.field, record.productionID, precedenceDeltas)
+					if err != nil {
+						return nil, err
+					}
 				}
 				results[index] = childID
 				continue
@@ -543,9 +594,13 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 				endByte = lastChild.EndByte
 			}
 		}
+		incomingField := occ.field
+		if retainAliasChild {
+			incomingField = 0
+		}
 		store.records = append(store.records, SelectedNodeRecord{
 			FirstChild: first, StartByte: startByte, EndByte: endByte,
-			Symbol: symbol, Field: occ.field,
+			Symbol: symbol, Field: incomingField,
 			ProductionID: record.productionID, DynamicPrecedence: int32(record.dynamicPrecedence),
 			ChildCount: uint16(len(logical)), flags: flags,
 		})
@@ -553,6 +608,12 @@ func (c *Core) buildSelectedStoreStaged(roots []SubtreeID, policy SelectedStoreP
 		for childIndex, childID := range logical {
 			store.records[childID-1].Parent = id
 			store.records[childID-1].ChildIndex = uint16(childIndex)
+		}
+		if retainAliasChild {
+			id, precedenceDeltas, err = appendSelectedRetainedAliasWrapper(store, policy, id, occ.alias, occ.field, record.productionID, precedenceDeltas)
+			if err != nil {
+				return nil, err
+			}
 		}
 		results[index] = id
 	}
@@ -863,6 +924,41 @@ func selectedFlags(meta SelectedSymbolPolicy, extra, external, terminal bool) ui
 		flags |= selectedNodeFlagTerminal
 	}
 	return flags
+}
+
+func appendSelectedRetainedAliasWrapper(
+	store *SelectedStore,
+	policy SelectedStorePolicy,
+	childID SelectedNodeID,
+	alias Symbol,
+	field FieldID,
+	productionID uint16,
+	precedenceDeltas []int32,
+) (SelectedNodeID, []int32, error) {
+	if store == nil || childID == 0 || int(childID) > len(store.records) {
+		return 0, precedenceDeltas, errors.New("parser-core phase zero: retained alias child is invalid")
+	}
+	meta, ok := policy.symbol(alias)
+	if !ok || !meta.Visible {
+		return 0, precedenceDeltas, errors.New("parser-core phase zero: retained alias wrapper is not visible")
+	}
+	if uint64(len(store.records)) >= math.MaxUint32 || uint64(len(store.children)) >= math.MaxUint32 {
+		return 0, precedenceDeltas, errors.New("parser-core phase zero: retained alias wrapper exceeded arena")
+	}
+	child := &store.records[childID-1]
+	id := SelectedNodeID(uint64(len(store.records)) + 1)
+	first := uint32(len(store.children))
+	store.children = append(store.children, childID)
+	store.records = append(store.records, SelectedNodeRecord{
+		FirstChild: first, StartByte: child.StartByte, EndByte: child.EndByte,
+		Symbol: alias, Field: field, ProductionID: productionID, ChildCount: 1,
+		flags: selectedFlags(meta, false, false, false),
+	})
+	precedenceDeltas = append(precedenceDeltas, 0)
+	child = &store.records[childID-1]
+	child.Parent = id
+	child.ChildIndex = 0
+	return id, precedenceDeltas, nil
 }
 
 func (s *SelectedStore) applyDirectField(ids []SelectedNodeID, field FieldID) {

--- a/internal/parsercorephase0/selected_store_builder_onepass.go
+++ b/internal/parsercorephase0/selected_store_builder_onepass.go
@@ -140,8 +140,9 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 			packedEdge := edges[frameIndex]
 			alias := Symbol(packedEdge)
 			field := FieldID(packedEdge >> 16)
+			retainAliasChild := !record.extra && policy.retainsAliasChild(alias, record.symbol)
 			symbol := record.symbol
-			if alias != 0 {
+			if alias != 0 && !retainAliasChild {
 				symbol = alias
 			}
 			meta, ok := policy.symbol(symbol)
@@ -159,7 +160,7 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 						child.Symbol = record.symbol
 						child.flags = selectedFlags(policy.Symbols[record.symbol], child.Extra(), child.External(), child.Terminal())
 					}
-					if alias != 0 {
+					if alias != 0 && !retainAliasChild {
 						child.Symbol = alias
 						child.flags = selectedFlags(meta, child.Extra(), child.External(), child.Terminal())
 					}
@@ -169,13 +170,25 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 						return nil, err
 					}
 					precedenceDeltas[childID-1] = delta
-					if field != 0 {
+					if field != 0 && !retainAliasChild {
 						child.Field = field
 					}
 					logical = logical[:logicalStart+1]
 					logical[logicalStart] = childID
 					folded = true
 				}
+			}
+			if folded && retainAliasChild {
+				if err := ensureSelectedOnePassCapacity(store, len(store.records)+1, len(store.children)+1, c.limits.MaxSelectedBytes, poll); err != nil {
+					return nil, err
+				}
+				childID := logical[logicalStart]
+				var err error
+				childID, precedenceDeltas, err = appendSelectedRetainedAliasWrapper(store, policy, childID, alias, field, record.productionID, precedenceDeltas)
+				if err != nil {
+					return nil, err
+				}
+				logical[logicalStart] = childID
 			}
 
 			if !folded && (meta.Visible || record.extra) {
@@ -202,9 +215,13 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 						endByte = lastChild.EndByte
 					}
 				}
+				incomingField := field
+				if retainAliasChild {
+					incomingField = 0
+				}
 				store.records = append(store.records, SelectedNodeRecord{
 					FirstChild: first, StartByte: startByte, EndByte: endByte,
-					Symbol: symbol, Field: field,
+					Symbol: symbol, Field: incomingField,
 					ProductionID: record.productionID, DynamicPrecedence: int32(record.dynamicPrecedence),
 					ChildCount: uint16(len(children)), flags: flags,
 				})
@@ -215,8 +232,19 @@ func (c *Core) buildSelectedStoreOnePass(roots []SubtreeID, policy SelectedStore
 				}
 				logical = logical[:logicalStart]
 				logical = append(logical, id)
+				if retainAliasChild {
+					if err := ensureSelectedOnePassCapacity(store, len(store.records)+1, len(store.children)+1, c.limits.MaxSelectedBytes, poll); err != nil {
+						return nil, err
+					}
+					var err error
+					id, precedenceDeltas, err = appendSelectedRetainedAliasWrapper(store, policy, id, alias, field, record.productionID, precedenceDeltas)
+					if err != nil {
+						return nil, err
+					}
+					logical[logicalStart] = id
+				}
 			}
-			if field != 0 {
+			if field != 0 && !retainAliasChild {
 				store.applyDirectField(logical[logicalStart:], field)
 			}
 			stack = stack[:frameIndex]

--- a/internal/parsercorephase0/selected_store_test.go
+++ b/internal/parsercorephase0/selected_store_test.go
@@ -69,6 +69,97 @@ func TestSelectedStoreElidesHiddenParentsBeforeSeal(t *testing.T) {
 	}
 }
 
+func TestSelectedStoreRetainsCompiledAliasChildOccurrence(t *testing.T) {
+	for _, folded := range []bool{false, true} {
+		name := "nonfolded"
+		if folded {
+			name = "folded"
+		}
+		t.Run(name, func(t *testing.T) {
+			build := func(limit uint64) (*SelectedStore, error) {
+				compact, err := New(&fakeTable{}, Limits{MaxSelectedBytes: limit})
+				if err != nil {
+					return nil, err
+				}
+				leaf, err := compact.appendSubtree(subtreeRecord{
+					symbol: 1, productionID: 8, dynamicPrecedence: 2, endByte: 1, terminal: true,
+				}, nil, nil, nil)
+				if err != nil {
+					return nil, err
+				}
+				rawChild, childSymbol := leaf, Symbol(1)
+				rootSymbol := Symbol(3)
+				if folded {
+					rawChild, err = compact.appendSubtree(subtreeRecord{
+						symbol: 3, productionID: 9, dynamicPrecedence: 3, endByte: 1,
+					}, []SubtreeID{leaf}, nil, nil)
+					if err != nil {
+						return nil, err
+					}
+					childSymbol = 3
+					rootSymbol = 4
+				}
+				root, err := compact.appendSubtree(
+					subtreeRecord{symbol: rootSymbol, productionID: 7, endByte: 1},
+					[]SubtreeID{rawChild},
+					[]FieldMapEntry{{FieldID: 4, ChildIndex: 0}},
+					[]Symbol{2},
+				)
+				if err != nil {
+					return nil, err
+				}
+				policy := selectedStoreTestPolicy(t, 2, 1)
+				if folded {
+					policy = selectedStoreTestPolicy(t, 2, 1, 3)
+					policy.Unary[int(Symbol(3))*len(policy.Symbols)+int(Symbol(1))] = SelectedUnaryRenameLeaf
+				}
+				policy.SetRetainedAliasChildren([]SelectedAliasChildPair{{Alias: 2, Child: childSymbol}})
+				return compact.BuildSelectedStore([]SubtreeID{root}, policy, []byte("x"), nil)
+			}
+
+			store, err := build(0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			required := store.RetainedBytes()
+			assertSelectedRetainedAliasShape(t, store, folded)
+			store.Release()
+
+			exact, err := build(required)
+			if err != nil {
+				t.Fatalf("exact retained cap %d: %v", required, err)
+			}
+			assertSelectedRetainedAliasShape(t, exact, folded)
+			exact.Release()
+			if required == 0 {
+				t.Fatal("retained alias store reported zero retained bytes")
+			}
+			if below, err := build(required - 1); err == nil || below != nil || !strings.Contains(err.Error(), "retained-byte cap") {
+				t.Fatalf("below-cap store=%v err=%v required=%d", below, err, required)
+			}
+		})
+	}
+}
+
+func assertSelectedRetainedAliasShape(t *testing.T, store *SelectedStore, folded bool) {
+	t.Helper()
+	wrapper, ok := store.Record(store.Root())
+	childID, childOK := store.Child(wrapper, 0)
+	child, recordOK := store.Record(childID)
+	wantChildSymbol := Symbol(1)
+	wantPrecedence := int32(2)
+	if folded {
+		wantChildSymbol = 3
+		wantPrecedence = 5
+	}
+	if !ok || !childOK || !recordOK || store.NodeCount() != 2 || store.ChildCount() != 1 ||
+		wrapper.Symbol != 2 || wrapper.Field != 4 || wrapper.ChildCount != 1 || wrapper.Parent != 0 || wrapper.ChildIndex != 0 ||
+		wrapper.DynamicPrecedence != wantPrecedence || child.Symbol != wantChildSymbol || child.Field != 0 ||
+		child.Parent != store.Root() || child.ChildIndex != 0 || child.DynamicPrecedence != wantPrecedence {
+		t.Fatalf("folded=%t wrapper=%+v child=%+v nodes=%d children=%d", folded, wrapper, child, store.NodeCount(), store.ChildCount())
+	}
+}
+
 func TestSelectedStoreDoesNotCollapseExtraUnaryChild(t *testing.T) {
 	compact, err := New(&fakeTable{}, Limits{})
 	if err != nil {

--- a/language.go
+++ b/language.go
@@ -359,6 +359,11 @@ const (
 	ResultCompatibilityCSharpNativeScopedLambdaStatements ResultCompatibilityCapability = 1 << 2
 	ResultCompatibilityCSharpNativeScopedLambdaBlocks     ResultCompatibilityCapability = 1 << 3
 	ResultCompatibilityCSharpNativeQueryExpressions       ResultCompatibilityCapability = 1 << 4
+	// ResultCompatibilityNativeCollapsedChildren certifies that the exact
+	// SHA-pinned built-in artifact may use the compiled native retention policy
+	// for collapsed-child compatibility rows. Same-name caller-built and adapted
+	// languages retain the zero value and stay on the legacy post-pass path.
+	ResultCompatibilityNativeCollapsedChildren ResultCompatibilityCapability = 1 << 5
 )
 
 // Language holds all data needed to parse a specific language.

--- a/language_result_compatibility_test.go
+++ b/language_result_compatibility_test.go
@@ -8,13 +8,14 @@ import (
 )
 
 func TestResultCompatibilityCapabilityLanguageBlobRoundTrip(t *testing.T) {
-	wantValues := []ResultCompatibilityCapability{1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4}
+	wantValues := []ResultCompatibilityCapability{1 << 0, 1 << 1, 1 << 2, 1 << 3, 1 << 4, 1 << 5}
 	gotValues := []ResultCompatibilityCapability{
 		ResultCompatibilityCSharpNativeNotNull,
 		ResultCompatibilityCSharpNativeUnicodeIdentifiers,
 		ResultCompatibilityCSharpNativeScopedLambdaStatements,
 		ResultCompatibilityCSharpNativeScopedLambdaBlocks,
 		ResultCompatibilityCSharpNativeQueryExpressions,
+		ResultCompatibilityNativeCollapsedChildren,
 	}
 	for i := range wantValues {
 		if gotValues[i] != wantValues[i] {
@@ -26,7 +27,8 @@ func TestResultCompatibilityCapabilityLanguageBlobRoundTrip(t *testing.T) {
 		ResultCompatibilityCSharpNativeUnicodeIdentifiers |
 		ResultCompatibilityCSharpNativeScopedLambdaStatements |
 		ResultCompatibilityCSharpNativeScopedLambdaBlocks |
-		ResultCompatibilityCSharpNativeQueryExpressions
+		ResultCompatibilityCSharpNativeQueryExpressions |
+		ResultCompatibilityNativeCollapsedChildren
 	lang := &Language{
 		Name:                      "result_compatibility_round_trip",
 		NativeResultCompatibility: want,

--- a/parser.go
+++ b/parser.go
@@ -45,6 +45,8 @@ type Parser struct {
 	incrementalGSSHint            uint32
 	rootSymbol                    Symbol
 	hasRootSymbol                 bool
+	collapsedChildOccurrencePairs []collapsedChildSymbolPair
+	collapsedChildOccurrenceSet   map[uint32]struct{}
 
 	// admissionCandidateRoute is the per-Parser override for the Phase-3
 	// dual-route admission switch (see admission_switch.go). The zero value
@@ -1494,6 +1496,7 @@ func NewParser(lang *Language) *Parser {
 		p.hasKeywordState = buildKeywordStates(lang)
 		p.spanExtendingInvisibleSymbols, p.nonSpanExtendingInvisibleSymbols = buildInvisibleSpanSymbolTables(lang.SymbolNames)
 		p.aliasPreservedWrapperSymbols = buildAliasPreservedWrapperSymbols(lang)
+		p.collapsedChildOccurrencePairs, p.collapsedChildOccurrenceSet = compileCollapsedChildOccurrencePolicy(lang)
 		p.initTypeScriptContextualKeywordSymbols(lang)
 		p.initSchemeErrorRecoverySymbols(lang)
 		p.errorCostCompetition = errorCostCompetitionLanguage(lang)

--- a/parser.go
+++ b/parser.go
@@ -357,7 +357,7 @@ type Parser struct {
 	// so the campaign O(edit) byte-sweep differential can compare the
 	// range-limited walk against the full walk on one Parser (see
 	// SetForceFullResultNormalizationWalk). Production leaves it false.
-	forceFullResultNormalizationWalk    bool
+	forceFullResultNormalizationWalk bool
 	// disableLeadingRunSplice turns off the campaign post-admission-frontier T2a
 	// leading-run block-splice for this Parser (the trailing splice and every
 	// other reuse path stay on). It exists ONLY so the byte-sweep differential
@@ -2965,14 +2965,22 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 	// entry (parseIncrementalChanged) already routes a reuse-disabled old tree to
 	// a full fresh parse before reaching here, but the token-source entries
 	// (parseIncrementalWithTokenSourceChanged and its Profiled twin) call in
-	// directly. A reuse-disabled old tree -- forestFastPath, or a
-	// compact-materialized tree whose per-node states are table-replayed /
-	// abstained -- must never feed the reuseCursor subtree splice below, which
-	// trusts old-tree parser states. The only reuse it may take is the
-	// token-invariant leaf edit attempted just above (compact trees are barred
-	// from even that inside tryTokenInvariantLeafEdit); once that declines, force
-	// a full fresh parse over the provided token source.
+	// directly. A reuse-disabled old tree -- forestFastPath, or a compact tree
+	// whose replay/scanner proof is incomplete -- must never feed the reuseCursor
+	// subtree splice below, which trusts old-tree parser states. The only reuse
+	// it may take is the independently re-authenticated token-invariant leaf edit
+	// attempted just above; once that declines, force a full fresh parse over the
+	// provided token source.
 	if oldTreeDisablesIncrementalReuse(oldTree) {
+		if timing != nil {
+			timing.reuseUnsupported = true
+			timing.reuseUnsupportedReason = forestIncrementalReuseUnsupportedReason
+			if oldTree != nil && oldTree.compactMaterialized {
+				if reason := incrementalReuseUnavailableReason(ts); reason != "" {
+					timing.reuseUnsupportedReason = reason
+				}
+			}
+		}
 		return p.incrementalTokenSourceFreshFullParse(source, ts, timing)
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -2898,11 +2898,10 @@ func (p *Parser) trailingEOFNodesFromPrefix(prefix glrStack) []*Node {
 // in-progress, other: arena clone} sentinel. The old eager-link-wiring
 // constructor (newParentNodeInArena → populateParentNode → setNodeParentLink)
 // corrupted that sentinel, so materializeTransientParentNodes then linked this
-// ERROR wrapper under itself — the cyclic-transient-tree defect that
-// stripResultTreeSelfCycles was left to mask. Route through
-// newRecoveryParentNodeInArena, which skips eager wiring while transient parents
-// are active (finalizeResultRoot wires links from the root anyway) and keeps the
-// eager-wiring constructor for incremental parses. See parser_recover_c.go and
+// ERROR wrapper under itself. Route through newRecoveryParentNodeInArena, which
+// skips eager wiring while transient parents are active (finalizeResultRoot wires
+// links from the root anyway) and keeps the eager-wiring constructor for
+// incremental parses. See parser_recover_c.go and
 // parser_recover_cycle_internal_test.go for the mechanism and pins.
 func (p *Parser) appendTrailingEOFRecoveryNodes(nodes []*Node, entries []stackEntry, cut int, tok Token, arena *nodeArena, nodeCount *int) ([]*Node, bool) {
 	recovered := false
@@ -4787,8 +4786,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 			return finalizeTree(errorTreeWithOwnedArena(reason), reason)
 		}
-		for _, n := range nodes {
-			stripResultTreeSelfCycles(n)
+		if invariantTree := recoveredResultInvariantErrorTree(nodes, source, p.language, arena); invariantTree != nil {
+			return finalizeTree(invariantTree, ParseStopInvariantViolation)
 		}
 		tree := p.buildResultFromNodes(nodes, source, arena, oldTree, &reuseState, &scratch.nodeLinks)
 		if root := rawRootOrNil(tree); root != nil {

--- a/parser_api.go
+++ b/parser_api.go
@@ -203,13 +203,6 @@ func (p *Parser) tryTokenInvariantReuseForDisabledOldTree(source []byte, oldTree
 	if !oldTreeDisablesIncrementalReuse(oldTree) {
 		return nil, false
 	}
-	// A compact-materialized tree carries replayed (not live-recorded) parser
-	// states and no scanner checkpoints, so it is barred from even the
-	// token-invariant leaf fast path: force the full fresh parse (Lane 3
-	// review amendment 2).
-	if oldTree != nil && oldTree.compactMaterialized {
-		return nil, false
-	}
 	if p == nil || p.language == nil {
 		return nil, false
 	}
@@ -251,6 +244,13 @@ func (p *Parser) disabledOldTreeTokenInvariantLeafAllowed(source []byte, oldTree
 	}
 	if !tokenInvariantLeafReusable(node) {
 		return false
+	}
+	if oldTree.compactMaterialized {
+		// A compact tree with an unknown/stateful scanner remains barred from
+		// subtree reuse, but a single edited leaf can still be re-authenticated
+		// independently when replay supplied its exact lexer entry state. The
+		// scan below must reproduce the same symbol and byte extent or decline.
+		return node.preGotoState != 0
 	}
 	switch p.language.Name {
 	case "go":
@@ -1406,7 +1406,11 @@ func (p *Parser) parseIncrementalChanged(source []byte, oldTree *Tree) (*Tree, e
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, nil); ok {
 			return tree, nil
 		}
-		return p.Parse(source)
+		if oldTree == nil || !oldTree.compactMaterialized {
+			return p.Parse(source)
+		}
+		// A compact tree needs the incremental token-source fallback below so
+		// scanner refusal and full-reparse work retain normal attribution.
 	}
 	if err := p.checkDFALexer(); err != nil {
 		return nil, err
@@ -1564,9 +1568,13 @@ func (p *Parser) parseIncrementalChangedProfiled(source []byte, oldTree *Tree) (
 		if tree, ok := p.tryTokenInvariantReuseForDisabledOldTree(source, oldTree, timing); ok {
 			return tree, timing.toProfile(), nil
 		}
-		start := time.Now()
-		tree, err := p.Parse(source)
-		return tree, profileFreshParseFallback(start, tree, forestIncrementalReuseUnsupportedReason), err
+		if oldTree == nil || !oldTree.compactMaterialized {
+			start := time.Now()
+			tree, err := p.Parse(source)
+			return tree, profileFreshParseFallback(start, tree, forestIncrementalReuseUnsupportedReason), err
+		}
+		// Continue through the token-source path so a compact-tree decline keeps
+		// the same scanner reason and work attribution as an ordinary fallback.
 	}
 	if err := p.checkDFALexer(); err != nil {
 		return nil, IncrementalParseProfile{}, err

--- a/parser_api.go
+++ b/parser_api.go
@@ -246,11 +246,13 @@ func (p *Parser) disabledOldTreeTokenInvariantLeafAllowed(source []byte, oldTree
 		return false
 	}
 	if oldTree.compactMaterialized {
-		// A compact tree with an unknown/stateful scanner remains barred from
-		// subtree reuse, but a single edited leaf can still be re-authenticated
-		// independently when replay supplied its exact lexer entry state. The
-		// scan below must reproduce the same symbol and byte extent or decline.
-		return node.preGotoState != 0
+		// Replayed parser state alone is not an external-scanner proof. A fresh
+		// DFA source starts with a fresh scanner payload, so a stateful scanner
+		// may only enter the one-leaf re-authentication path when that leaf owns
+		// a checkpoint the scanner-aware rescan will restore and verify. A
+		// stateless scanner is proven quiescent at every boundary. Everything
+		// else fails closed rather than treating preGotoState as scanner state.
+		return node.preGotoState != 0 && compactLeafScannerReauthenticationProven(p.language, node)
 	}
 	switch p.language.Name {
 	case "go":
@@ -262,6 +264,40 @@ func (p *Parser) disabledOldTreeTokenInvariantLeafAllowed(source []byte, oldTree
 	default:
 		return false
 	}
+}
+
+// compactLeafScannerReauthenticationProven reports whether a compact,
+// reuse-disabled tree may re-authenticate one edited leaf without reviving
+// general subtree reuse. The decision is based on scanner proof class, never a
+// language-name allowlist:
+//
+//   - a proven-stateless scanner has no payload to restore;
+//   - an undecided scanner must carry the leaf's serialized checkpoint, which
+//     scanDFALeafTokenWithExternalCheckpoint restores and verifies; and
+//   - a refuted scanner (for example Python's indentation/delimiter scanner)
+//     cannot make this route safe until it has a stronger proof, so it declines.
+//
+// The checkpoint test deliberately happens before creating a fresh DFA source:
+// without it, that source would begin with Create() state and could scan a leaf
+// under a parser state that looks authenticated but a scanner state that is not.
+func compactLeafScannerReauthenticationProven(lang *Language, leaf *Node) bool {
+	switch classifyExternalScannerQuiescence(lang) {
+	case scannerQuiescenceProven:
+		return true
+	case scannerQuiescenceUnknown:
+		_, ok := externalScannerCheckpointForNode(leaf)
+		return ok
+	default:
+		return false
+	}
+}
+
+// compactLeafScannerCheckpointRequired identifies the proof class whose leaf
+// scan must authenticate a recorded external-scanner checkpoint. Proven
+// stateless scanners use the ordinary scanner-free path; refuted scanners are
+// rejected by compactLeafScannerReauthenticationProven before this is queried.
+func compactLeafScannerCheckpointRequired(lang *Language) bool {
+	return classifyExternalScannerQuiescence(lang) == scannerQuiescenceUnknown
 }
 
 func cssDisabledTreeTokenInvariantLeafAllowed(oldTree *Tree, leaf *Node) bool {

--- a/parser_collapsed_child_policy.go
+++ b/parser_collapsed_child_policy.go
@@ -1,0 +1,62 @@
+package gotreesitter
+
+// collapsedChildSymbolPair is one exact public-wrapper/raw-child identity that
+// C tree-sitter retains as a unary node. The policy is compiled once per Parser
+// only after the exact SHA-pinned built-in runtime profile authenticates it.
+type collapsedChildSymbolPair struct {
+	parent Symbol
+	child  Symbol
+}
+
+func collapsedChildPairKey(parent, child Symbol) uint32 {
+	return uint32(parent)<<16 | uint32(child)
+}
+
+func compileCollapsedChildOccurrencePolicy(lang *Language) ([]collapsedChildSymbolPair, map[uint32]struct{}) {
+	if lang == nil || lang.NativeResultCompatibility&ResultCompatibilityNativeCollapsedChildren == 0 {
+		return nil, nil
+	}
+	pairs := make([]collapsedChildSymbolPair, 0, 4)
+	seen := make(map[uint32]struct{})
+	for _, rule := range resultCollapsedNamedLeafRules {
+		if rule.languageName != lang.Name {
+			continue
+		}
+		parent, ok := lang.symbolByNameAndNamed(rule.parentName, true)
+		if !ok {
+			parent, ok = symbolByName(lang, rule.parentName)
+		}
+		if !ok {
+			continue
+		}
+		child, ok := lang.symbolByNameAndNamed(rule.childName, false)
+		if !ok {
+			child, ok = symbolByName(lang, rule.childName)
+		}
+		if !ok {
+			continue
+		}
+		key := collapsedChildPairKey(parent, child)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+		pairs = append(pairs, collapsedChildSymbolPair{parent: parent, child: child})
+	}
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	return pairs, seen
+}
+
+// retainsCollapsedChildOccurrence is the single native keep/wrap decision.
+// Its authenticated (parent, raw-child) domain is strictly narrower than the
+// legacy safety net, which may repair a collapsed parent leaf (and, for some
+// rows, verify source text) after the raw child identity has been lost.
+func (p *Parser) retainsCollapsedChildOccurrence(parent, rawChild Symbol) bool {
+	if p == nil || len(p.collapsedChildOccurrenceSet) == 0 {
+		return false
+	}
+	_, ok := p.collapsedChildOccurrenceSet[collapsedChildPairKey(parent, rawChild)]
+	return ok
+}

--- a/parser_collapsed_child_policy_external_test.go
+++ b/parser_collapsed_child_policy_external_test.go
@@ -1,0 +1,105 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type collapsedChildStrictSubsetRow struct {
+	language   string
+	load       func() *gotreesitter.Language
+	parent     string
+	child      string
+	childNamed bool
+	bySource   bool
+}
+
+func TestCollapsedChildNativePolicyIsStrictSubsetOfLegacyRepair(t *testing.T) {
+	rows := []collapsedChildStrictSubsetRow{
+		{language: "ruby", load: grammars.RubyLanguage, parent: "bare_string", child: "string_content", childNamed: true},
+		{language: "ruby", load: grammars.RubyLanguage, parent: "bare_symbol", child: "string_content", childNamed: true},
+		{language: "apex", load: grammars.ApexLanguage, parent: "after_delete", child: "after_delete"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "after_insert", child: "after_insert"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "after_undelete", child: "after_undelete"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "after_update", child: "after_update"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "before_delete", child: "before_delete"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "before_insert", child: "before_insert"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "before_update", child: "before_update"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "delete", child: "delete"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "insert", child: "insert"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "super", child: "super"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "system", child: "system"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "undelete", child: "undelete"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "upsert", child: "upsert"},
+		{language: "apex", load: grammars.ApexLanguage, parent: "user", child: "user"},
+		{language: "kotlin", load: grammars.KotlinLanguage, parent: "identifier", child: "simple_identifier", childNamed: true},
+		{language: "hack", load: grammars.HackLanguage, parent: "true", child: "true", bySource: true},
+		{language: "hack", load: grammars.HackLanguage, parent: "false", child: "false", bySource: true},
+		{language: "hack", load: grammars.HackLanguage, parent: "null", child: "null", bySource: true},
+		{language: "dart", load: grammars.DartLanguage, parent: "super", child: "super", bySource: true},
+		{language: "dart", load: grammars.DartLanguage, parent: "this", child: "this", bySource: true},
+		{language: "elixir", load: grammars.ElixirLanguage, parent: "nil", child: "nil", bySource: true},
+	}
+	if len(rows) != 23 {
+		t.Fatalf("strict-subset rows=%d, want 23", len(rows))
+	}
+	for _, row := range rows {
+		row := row
+		t.Run(row.language+"/"+row.parent, func(t *testing.T) {
+			lang := row.load()
+			if lang.NativeResultCompatibility&gotreesitter.ResultCompatibilityNativeCollapsedChildren == 0 {
+				t.Fatal("exact artifact omitted native collapsed-child capability")
+			}
+			parent, parentOK := collapsedChildStrictSubsetSymbol(lang, row.parent, true)
+			child, childOK := collapsedChildStrictSubsetSymbol(lang, row.child, row.childNamed)
+			if !parentOK || !childOK {
+				t.Fatalf("could not resolve exact pair %s/%s", row.parent, row.child)
+			}
+			parser := gotreesitter.NewParser(lang)
+			if !gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, child) {
+				t.Fatal("native predicate rejected exact authenticated pair")
+			}
+			if gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, 0) ||
+				gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, 0, child) {
+				t.Fatal("native predicate accepted a parent/raw-child mismatch")
+			}
+
+			if row.bySource {
+				meta := lang.SymbolMetadata[child]
+				if int(child) >= int(lang.TokenCount) || !meta.Visible || meta.Named || lang.SymbolNames[child] != row.child {
+					t.Fatalf("source row child=%d token_count=%d meta=%+v canonical=%q", child, lang.TokenCount, meta, lang.SymbolNames[child])
+				}
+			}
+
+			end := uint32(len(row.child))
+			collapsed := gotreesitter.NewLeafNode(parent, true, 0, end, gotreesitter.Point{}, gotreesitter.Point{Column: end})
+			visited, rewritten := gotreesitter.NormalizeCollapsedNamedLeafForTest(
+				collapsed, []byte(row.child), lang, row.parent, row.child, row.bySource,
+			)
+			if visited == 0 || rewritten != 1 || collapsed.ChildCount() != 1 ||
+				collapsed.Child(0).Symbol() != child || collapsed.Child(0).IsNamed() != row.childNamed {
+				t.Fatalf("legacy repair visited=%d rewritten=%d shape=%s", visited, rewritten, collapsed.SExpr(lang))
+			}
+			if row.bySource {
+				wrongSource := gotreesitter.NewLeafNode(parent, true, 0, end, gotreesitter.Point{}, gotreesitter.Point{Column: end})
+				_, rewritten = gotreesitter.NormalizeCollapsedNamedLeafForTest(
+					wrongSource, []byte("xxxxxx")[:len(row.child)], lang, row.parent, row.child, true,
+				)
+				if rewritten != 0 || wrongSource.ChildCount() != 0 {
+					t.Fatal("source-verified legacy repair accepted a different literal")
+				}
+			}
+		})
+	}
+}
+
+func collapsedChildStrictSubsetSymbol(lang *gotreesitter.Language, name string, named bool) (gotreesitter.Symbol, bool) {
+	for index, symbolName := range lang.SymbolNames {
+		if symbolName == name && index < len(lang.SymbolMetadata) && lang.SymbolMetadata[index].Named == named {
+			return gotreesitter.Symbol(index), true
+		}
+	}
+	return 0, false
+}

--- a/parser_collapsed_child_policy_test.go
+++ b/parser_collapsed_child_policy_test.go
@@ -1,0 +1,230 @@
+package gotreesitter
+
+import "testing"
+
+func collapsedChildPolicyTestLanguage(rule collapsedNamedLeafRule) (*Language, Symbol, Symbol) {
+	childNamed := rule.languageName == "ruby" || rule.languageName == "kotlin"
+	lang := &Language{
+		Name:                      rule.languageName,
+		TokenCount:                4,
+		NativeResultCompatibility: ResultCompatibilityNativeCollapsedChildren,
+		SymbolNames:               []string{"EOF", "root", rule.parentName, rule.childName},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "root", Visible: true, Named: true},
+			{Name: rule.parentName, Visible: true, Named: true},
+			{Name: rule.childName, Visible: true, Named: childNamed},
+		},
+	}
+	return lang, 2, 3
+}
+
+func TestCollapsedChildOccurrencePolicyNativelyRetainsAllLedgerRows(t *testing.T) {
+	if got, want := len(resultCollapsedNamedLeafRules), 23; got != want {
+		t.Fatalf("collapsed-child ledger rows = %d, want %d", got, want)
+	}
+	for _, rule := range resultCollapsedNamedLeafRules {
+		rule := rule
+		t.Run(rule.languageName+"/"+rule.parentName, func(t *testing.T) {
+			lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
+			parser := NewParser(lang)
+			if !parser.retainsCollapsedChildOccurrence(parentSymbol, childSymbol) {
+				t.Fatal("compiled occurrence policy omitted ledger pair")
+			}
+			arena := newNodeArena(arenaClassFull)
+			end := uint32(len(rule.childName))
+			original := newLeafNodeInArena(arena, childSymbol, symbolIsNamed(lang, childSymbol), 0, end, Point{}, Point{Column: end})
+
+			var parent *Node
+			switch rule.languageName {
+			case "ruby", "kotlin":
+				lang.AliasSequences = [][]Symbol{{parentSymbol}}
+				parser = NewParser(lang)
+				children, _, _ := parser.buildReduceChildren(
+					[]stackEntry{newStackEntryNode(0, original)}, 0, 1, 1, 1, 0, arena,
+				)
+				if len(children) != 1 {
+					t.Fatalf("native alias path children = %d", len(children))
+				}
+				parent = children[0]
+				if parent == original || parent == nil || parent.symbol != parentSymbol || parent.ChildCount() != 1 {
+					t.Fatalf("native alias retention = %#v", parent)
+				}
+				child := parent.Child(0)
+				if child == nil || child == original || child.symbol != childSymbol {
+					t.Fatalf("retained alias child = %#v, original=%p", child, original)
+				}
+				if original.parent != nil {
+					t.Fatal("alias retention mutated borrowed child parent")
+				}
+			default:
+				action := ParseAction{Type: ParseActionReduce, Symbol: parentSymbol, ChildCount: 1}
+				entries := []stackEntry{newStackEntryNode(0, original)}
+				if collapsed := parser.collapsibleRawUnarySelfReduction(action, Token{}, arena, entries, 0, 1); collapsed != nil {
+					t.Fatalf("native unary retention collapsed to %p", collapsed)
+				}
+				lang.KeywordCaptureToken = 1
+				if collapsed := parser.forestCollapsibleNamedKeywordLeaf(action, Token{}, arena, entries, 0, 1); collapsed != nil {
+					t.Fatalf("forest native unary retention collapsed to %p", collapsed)
+				}
+				parent = newParentNodeInArena(arena, parentSymbol, true, []*Node{original}, nil, 0)
+			}
+
+			if parent.ChildCount() != 1 || parent.Child(0).symbol != childSymbol {
+				t.Fatalf("native shape parent=%d children=%d child=%v", parent.symbol, parent.ChildCount(), parent.Child(0))
+			}
+			parser.resetNormalizationStats()
+			parser.materializationTiming = &parseMaterializationTiming{}
+			parser.runNamedNormalizationPass("collapsed_named_leaf_children", func() bool { return true }, func() normalizationPassCounters {
+				return normalizeResultCollapsedNamedLeafChildren(parent, []byte(rule.childName), lang)
+			})
+			var runtime ParseRuntime
+			parser.copyNormalizationStats(&runtime)
+			pass, ok := normalizationRuntimePass(runtime, "collapsed_named_leaf_children")
+			if !ok || pass.Checked != 1 || pass.Run != 1 || pass.NodesVisited == 0 || pass.NodesRewritten != 0 {
+				t.Fatalf("native safety-net pass=%+v found=%t runtime=%+v", pass, ok, runtime)
+			}
+		})
+	}
+}
+
+func normalizationRuntimePass(runtime ParseRuntime, name string) (NormalizationPassRuntime, bool) {
+	if runtime.NormalizationPasses == nil {
+		return NormalizationPassRuntime{}, false
+	}
+	for _, pass := range *runtime.NormalizationPasses {
+		if pass.Name == name {
+			return pass, true
+		}
+	}
+	return NormalizationPassRuntime{}, false
+}
+
+func TestCollapsedChildOccurrencePolicyNegativeControls(t *testing.T) {
+	t.Run("go-same-name-still-collapses", func(t *testing.T) {
+		lang := &Language{
+			Name: "go", TokenCount: 4,
+			SymbolNames: []string{"EOF", "root", "true", "true"},
+			SymbolMetadata: []SymbolMetadata{
+				{Name: "EOF"}, {Name: "root", Visible: true, Named: true},
+				{Name: "true", Visible: true, Named: true}, {Name: "true", Visible: true},
+			},
+		}
+		parser := NewParser(lang)
+		arena := newNodeArena(arenaClassFull)
+		child := newLeafNodeInArena(arena, 3, false, 0, 4, Point{}, Point{Column: 4})
+		action := ParseAction{Type: ParseActionReduce, Symbol: 2, ChildCount: 1}
+		if collapsed := parser.collapsibleRawUnarySelfReduction(action, Token{}, arena, []stackEntry{newStackEntryNode(0, child)}, 0, 1); collapsed == nil {
+			t.Fatal("unlisted Go same-name token stopped collapsing")
+		}
+	})
+
+	t.Run("fielded-unary-remains-fielded", func(t *testing.T) {
+		rule := collapsedNamedLeafRule{languageName: "apex", parentName: "super", childName: "super"}
+		lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
+		lang.FieldMapSlices = [][2]uint16{{0, 1}}
+		lang.FieldMapEntries = []FieldMapEntry{{FieldID: 1, ChildIndex: 0}}
+		parser := NewParser(lang)
+		arena := newNodeArena(arenaClassFull)
+		child := newLeafNodeInArena(arena, childSymbol, false, 0, 5, Point{}, Point{Column: 5})
+		action := ParseAction{Type: ParseActionReduce, Symbol: parentSymbol, ChildCount: 1}
+		if collapsed := parser.collapsibleRawUnarySelfReduction(action, Token{}, arena, []stackEntry{newStackEntryNode(0, child)}, 0, 1); collapsed != nil {
+			t.Fatal("fielded unary occurrence collapsed")
+		}
+		parent := newParentNodeInArena(arena, parentSymbol, true, []*Node{child}, []FieldID{1}, 0)
+		if parent.fieldIDs()[0] != 1 {
+			t.Fatal("field metadata was not preserved")
+		}
+	})
+
+	t.Run("inherited-field-is-not-promoted-to-direct", func(t *testing.T) {
+		rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content"}
+		lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
+		lang.FieldMapSlices = [][2]uint16{{0, 1}}
+		lang.FieldMapEntries = []FieldMapEntry{{FieldID: 1, ChildIndex: 0, Inherited: true}}
+		lang.AliasSequences = [][]Symbol{{parentSymbol}}
+		parser := NewParser(lang)
+		arena := newNodeArena(arenaClassFull)
+		original := newLeafNodeInArena(arena, childSymbol, true, 0, 1, Point{}, Point{Column: 1})
+		children, fields, sources := parser.buildReduceChildren(
+			[]stackEntry{newStackEntryNode(0, original)}, 0, 1, 1, 1, 0, arena,
+		)
+		if len(children) != 1 || children[0] == original || children[0].symbol != parentSymbol || children[0].ChildCount() != 1 {
+			t.Fatalf("retained inherited-field child = %#v", children)
+		}
+		if len(fields) != 1 || fields[0] != 0 || fieldSourceAt(sources, 0) != fieldSourceNone {
+			t.Fatalf("inherited alias field was promoted: field=%v source=%v", fields, sources)
+		}
+		if original.parent != nil {
+			t.Fatal("retained inherited-field alias mutated borrowed child")
+		}
+	})
+
+	for _, test := range []struct {
+		name  string
+		mark  func(*Node)
+		check func(*Node) bool
+	}{
+		{name: "missing", mark: func(n *Node) { n.setMissing(true) }, check: func(n *Node) bool { return n.isMissing() }},
+		{name: "error", mark: func(n *Node) { n.setHasError(true) }, check: func(n *Node) bool { return n.hasError() }},
+	} {
+		t.Run("flagged-alias-fails-closed-"+test.name, func(t *testing.T) {
+			rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content"}
+			lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
+			lang.AliasSequences = [][]Symbol{{parentSymbol}}
+			parser := NewParser(lang)
+			arena := newNodeArena(arenaClassFull)
+			original := newLeafNodeInArena(arena, childSymbol, true, 0, 1, Point{}, Point{Column: 1})
+			test.mark(original)
+			children, _, _ := parser.buildReduceChildren(
+				[]stackEntry{newStackEntryNode(0, original)}, 0, 1, 1, 1, 0, arena,
+			)
+			if len(children) != 1 || children[0].symbol != parentSymbol || children[0].ChildCount() != 0 || !test.check(children[0]) {
+				t.Fatalf("flagged alias did not fail closed: %#v", children)
+			}
+			if original.parent != nil {
+				t.Fatal("borrowed flagged child was mutated")
+			}
+		})
+	}
+
+	t.Run("extra-skips-aliasing-on-live-child-build-path", func(t *testing.T) {
+		rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content"}
+		lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
+		lang.AliasSequences = [][]Symbol{{parentSymbol}}
+		parser := NewParser(lang)
+		arena := newNodeArena(arenaClassFull)
+		original := newLeafNodeInArena(arena, childSymbol, true, 0, 1, Point{}, Point{Column: 1})
+		original.setExtra(true)
+		children, _, _ := parser.buildReduceChildren(
+			[]stackEntry{newStackEntryNode(0, original)}, 0, 1, 1, 1, 0, arena,
+		)
+		if len(children) != 1 || children[0] != original || children[0].symbol != childSymbol || !children[0].isExtra() {
+			t.Fatalf("extra alias path = %#v", children)
+		}
+	})
+
+	t.Run("same-name-custom-artifacts-stay-on-safety-net", func(t *testing.T) {
+		for _, rule := range []collapsedNamedLeafRule{
+			{languageName: "apex", parentName: "super", childName: "super"},
+			{languageName: "ruby", parentName: "bare_string", childName: "string_content"},
+		} {
+			lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
+			lang.NativeResultCompatibility = 0
+			parser := NewParser(lang)
+			if parser.retainsCollapsedChildOccurrence(parentSymbol, childSymbol) {
+				t.Fatalf("same-name custom %s artifact compiled native policy", rule.languageName)
+			}
+			arena := newNodeArena(arenaClassFull)
+			leaf := newLeafNodeInArena(arena, childSymbol, symbolIsNamed(lang, childSymbol), 0, 5, Point{}, Point{Column: 5})
+			collapsed := aliasedNodeInArena(arena, lang, leaf, parentSymbol)
+			if collapsed.ChildCount() != 0 {
+				t.Fatal("legacy custom path unexpectedly retained child")
+			}
+			stats := normalizeCollapsedNamedLeafChildrenWithStats(collapsed, lang, rule.parentName, rule.childName)
+			if stats.nodesRewritten != 1 || collapsed.ChildCount() != 1 || collapsed.Child(0).symbol != childSymbol {
+				t.Fatalf("custom safety-net stats=%+v shape=%s", stats, collapsed.SExpr(lang))
+			}
+		}
+	})
+}

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -139,6 +139,112 @@ func requireIncrementalDeepTreeMatchesFresh(t *testing.T, incremental, fresh *go
 	}
 }
 
+func TestUncertifiedExternalScannerLengthChangingEditFallsBack(t *testing.T) {
+	cases := []struct {
+		name        string
+		lang        func() *gotreesitter.Language
+		source      []byte
+		oldText     []byte
+		replacement []byte
+	}{
+		{
+			name:        "sql",
+			lang:        grammars.SqlLanguage,
+			source:      []byte("select id from users;\n"),
+			oldText:     []byte("id"),
+			replacement: []byte("account_id"),
+		},
+		{
+			name:        "html",
+			lang:        grammars.HtmlLanguage,
+			source:      []byte("<main><p>hello</p></main>\n"),
+			oldText:     []byte("hello"),
+			replacement: []byte("hello world"),
+		},
+		{
+			name:        "markdown",
+			lang:        grammars.MarkdownLanguage,
+			source:      []byte("# Title\n\nParagraph text.\n"),
+			oldText:     []byte("Title"),
+			replacement: []byte("Longer Title"),
+		},
+		{
+			name:        "markdown_inline",
+			lang:        grammars.MarkdownInlineLanguage,
+			source:      []byte("Hello *world*.\n"),
+			oldText:     []byte("world"),
+			replacement: []byte("wide world"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := tc.lang()
+			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(false)
+
+			oldTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatalf("old parse: %v", err)
+			}
+			defer oldTree.Release()
+			requireCompleteParse(t, oldTree, tc.source, lang, "old")
+
+			next, edit := replaceExternalScannerWitness(t, tc.source, tc.oldText, tc.replacement)
+			oldTree.Edit(edit)
+			incremental, profile, err := parser.ParseIncrementalProfiled(next, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			defer incremental.Release()
+			if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
+				t.Fatalf("uncertified scanner did not fail closed: %+v", profile)
+			}
+			if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+				t.Fatalf("uncertified scanner fallback reported old-tree reuse: %+v", profile)
+			}
+			if profile.TokensConsumed == 0 || profile.NewNodesAllocated == 0 {
+				t.Fatalf("uncertified scanner fallback did not execute a full parse: %+v", profile)
+			}
+			requireCompleteParse(t, incremental, next, lang, "incremental fallback")
+
+			freshParser := gotreesitter.NewParser(lang)
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(next)
+			if err != nil {
+				t.Fatalf("fresh parse: %v", err)
+			}
+			defer fresh.Release()
+			requireCompleteParse(t, fresh, next, lang, "fresh")
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+		})
+	}
+}
+
+func replaceExternalScannerWitness(t *testing.T, source, oldText, replacement []byte) ([]byte, gotreesitter.InputEdit) {
+	t.Helper()
+	if len(oldText) == len(replacement) {
+		t.Fatalf("fallback witness must change length: old=%q replacement=%q", oldText, replacement)
+	}
+	offset := bytes.Index(source, oldText)
+	if offset < 0 {
+		t.Fatalf("fixture missing edit text %q", oldText)
+	}
+	oldEnd := offset + len(oldText)
+	next := make([]byte, 0, len(source)-len(oldText)+len(replacement))
+	next = append(next, source[:offset]...)
+	next = append(next, replacement...)
+	next = append(next, source[oldEnd:]...)
+	return next, gotreesitter.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, oldEnd),
+		NewEndPoint: pointForOffset(next, offset+len(replacement)),
+	}
+}
+
 func TestPythonDerivedSameLengthTokenChangeDeclinesScannerReuse(t *testing.T) {
 	for _, languageCase := range pythonDerivedIncrementalCases() {
 		languageCase := languageCase

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -233,6 +233,11 @@ func TestPythonDerivedTokenInvariantLeafReusePrecedesScannerFallback(t *testing.
 
 					lang := languageCase.lang()
 					parser := gotreesitter.NewParser(lang)
+					// This test locks the legacy production-tree contract: a
+					// token-invariant leaf edit is reauthenticated before the scanner
+					// opt-out fallback. Reuse-disabled compact stateful scanners are
+					// covered by TestStatefulScannerCompactLeafReauthenticationFailsClosed.
+					parser.SetAdmissionCandidateRoute(false)
 					if route.includedRanges {
 						parser.SetIncludedRanges([]gotreesitter.Range{{
 							StartByte: 0,

--- a/parser_recover_cycle_internal_test.go
+++ b/parser_recover_cycle_internal_test.go
@@ -1,9 +1,6 @@
 package gotreesitter
 
-import (
-	"sync/atomic"
-	"testing"
-)
+import "testing"
 
 // These tests pin the mechanism behind the C-recovery cyclic-transient-tree
 // defect (go zerrors_windows.go truncations; the trailing-EOF shape of issue
@@ -166,36 +163,43 @@ func TestTrailingEOFRecoveryPreservesTransientSentinel(t *testing.T) {
 	}
 }
 
-// TestTrailingEOFEagerWiringSelfLoopWasMaskedByStrip documents the pre-fix
-// corruption shape on the trailing-EOF path and its interaction with the #110
-// band-aid: the old eager-wiring construction of the ERROR wrapper over a
-// transient child self-loops after materialization, and stripResultTreeSelfCycles
-// removed that edge silently. After the band-aid conversion the strip still
-// happens (defense in depth) but now bumps the observable counter, so the masked
-// construction bug can no longer hide.
-func TestTrailingEOFEagerWiringSelfLoopWasMaskedByStrip(t *testing.T) {
+// TestTrailingEOFEagerWiringSelfLoopFailsClosedAsInvariantViolation preserves
+// the historical issue #110 construction path. The old eager-linking wrapper
+// corrupts the transient sentinel and materializes as a self-loop; the result
+// validator must leave that evidence untouched and return a standalone error
+// tree that publicly reports an invariant stop.
+func TestTrailingEOFEagerWiringSelfLoopFailsClosedAsInvariantViolation(t *testing.T) {
 	arena, scratch, transient := newTransientSentinelFixture(t)
 
-	// Pre-fix appendTrailingEOFRecoveryNodes body: wrap the dropped trailing stack
-	// payload with the eager-link constructor, corrupting transient.parent.
 	trailing := stackEntryNode(newStackEntryNode(transient.parseState, transient))
 	wrapper := newParentNodeInArena(arena, errorSymbol, true, []*Node{trailing}, nil, 0)
 	if transient.parent != wrapper {
-		t.Fatal("pre-fix simulation expects eager wiring to set the transient child's parent")
+		t.Fatal("pre-fix simulation expects eager wiring to corrupt the transient sentinel")
 	}
 
 	nodes := []*Node{wrapper}
-	scratch.materializeNodeSliceUntil(nodes, arena, nil, nil)
+	if reason := scratch.materializeNodeSliceUntil(nodes, arena, nil, nil); reason != ParseStopNone {
+		t.Fatalf("materialize stop reason = %v, want none", reason)
+	}
 	if len(wrapper.children) != 1 || wrapper.children[0] != wrapper {
-		t.Fatalf("expected the corrupted sentinel to self-loop the ERROR wrapper; children=%v", wrapper.children)
+		t.Fatalf("expected historical self-loop; children=%v", wrapper.children)
 	}
 
-	before := atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
-	stripResultTreeSelfCycles(wrapper)
-	if len(wrapper.children) != 0 {
-		t.Fatalf("band-aid did not strip the self-edge; children=%v", wrapper.children)
+	tree := recoveredResultInvariantErrorTree(nodes, []byte("x"), &Language{Name: "test"}, arena)
+	if tree == nil {
+		t.Fatal("cyclic recovered result was not contained")
 	}
-	if got := atomic.LoadUint64(&debugResultTreeSelfCyclesStripped); got != before+1 {
-		t.Fatalf("self-cycle strip counter = %d, want %d — the #110 mask is still silent", got, before+1)
+	defer tree.Release()
+	if got := tree.ParseStopReason(); got != ParseStopInvariantViolation {
+		t.Fatalf("stop reason = %q, want %q", got, ParseStopInvariantViolation)
+	}
+	if !tree.ParseStoppedEarly() {
+		t.Fatal("invariant error tree did not report stopped-early")
+	}
+	if root := rawRootOrNil(tree); root == nil || !root.IsError() || root == wrapper {
+		t.Fatalf("fail-closed root = %p, want standalone ERROR distinct from corrupt wrapper %p", root, wrapper)
+	}
+	if len(wrapper.children) != 1 || wrapper.children[0] != wrapper {
+		t.Fatal("validator repaired or mutated the historical self-loop")
 	}
 }

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -6147,7 +6147,7 @@ func (p *Parser) buildReduceChildrenAllVisible(entries []stackEntry, start, end,
 			}
 			if structuralChildIndex < len(aliasSeq) {
 				if alias := aliasSeq[structuralChildIndex]; alias != 0 {
-					n = aliasedNodeInArena(arena, p.language, n, alias)
+					n = p.aliasedNodeInArena(arena, n, alias)
 				}
 			}
 			structuralChildIndex++
@@ -6343,7 +6343,7 @@ type reduceChildBuildItem struct {
 	nextStructuralIndex int
 }
 
-func reduceChildBuildItemForEntry(entry stackEntry, structuralChildIndex int, aliasSeq []Symbol, rawFieldIDs []FieldID, rawInherited []bool, arena *nodeArena, lang *Language) (reduceChildBuildItem, bool) {
+func (p *Parser) reduceChildBuildItemForEntry(entry stackEntry, structuralChildIndex int, aliasSeq []Symbol, rawFieldIDs []FieldID, rawInherited []bool, arena *nodeArena) (reduceChildBuildItem, bool) {
 	n := stackEntryNode(entry)
 	if n == nil {
 		return reduceChildBuildItem{}, false
@@ -6360,7 +6360,7 @@ func reduceChildBuildItemForEntry(entry stackEntry, structuralChildIndex int, al
 	}
 	if structuralChildIndex < len(aliasSeq) {
 		if alias := aliasSeq[structuralChildIndex]; alias != 0 {
-			item.node = aliasedNodeInArena(arena, lang, n, alias)
+			item.node = p.aliasedNodeInArena(arena, n, alias)
 		}
 	}
 	item.nextStructuralIndex = structuralChildIndex + 1
@@ -6374,7 +6374,7 @@ func (p *Parser) appendReduceChildrenToScratch(scratch *reduceBuildScratch, entr
 	var pendingPaddingSource *Node
 	havePendingPadding := false
 	for i := start; i < end; i++ {
-		item, ok := reduceChildBuildItemForEntry(entries[i], structuralChildIndex, aliasSeq, rawFieldIDs, rawInherited, arena, lang)
+		item, ok := p.reduceChildBuildItemForEntry(entries[i], structuralChildIndex, aliasSeq, rawFieldIDs, rawInherited, arena)
 		if !ok {
 			continue
 		}
@@ -8039,6 +8039,9 @@ func (p *Parser) shouldKeepVisibleAnonymousTokenChild(parentSym, childSym Symbol
 	if p == nil || p.language == nil {
 		return true
 	}
+	if p.retainsCollapsedChildOccurrence(parentSym, childSym) {
+		return true
+	}
 	meta := p.language.SymbolMetadata
 	if int(parentSym) < 0 || int(parentSym) >= len(meta) ||
 		int(childSym) < 0 || int(childSym) >= len(meta) {
@@ -8392,6 +8395,37 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 	}
 	cloned.ownerArena = arena
 	return cloned
+}
+
+func (p *Parser) aliasedNodeInArena(arena *nodeArena, n *Node, alias Symbol) *Node {
+	if p != nil && n != nil && alias != 0 && nodeChildCountNoMaterialize(n) == 0 &&
+		!n.isExtra() && !n.isMissing() && !n.hasError() &&
+		p.retainsCollapsedChildOccurrence(alias, n.symbol) {
+		return retainedAliasChildWrapperInArena(arena, p.language, n, alias)
+	}
+	var lang *Language
+	if p != nil {
+		lang = p.language
+	}
+	return aliasedNodeInArena(arena, lang, n, alias)
+}
+
+// retainedAliasChildWrapperInArena preserves the raw child under its visible
+// alias instead of relabeling the borrowed node. Both wrapper and child are
+// arena-owned clones, matching aliasedNodeInArena's nonmutation contract.
+func retainedAliasChildWrapperInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol) *Node {
+	child := cloneNodeInArena(arena, n)
+	named := false
+	if lang != nil && int(alias) < len(lang.SymbolMetadata) {
+		named = lang.SymbolMetadata[alias].Named
+	}
+	wrapper := newParentNodeInArena(arena, alias, named, []*Node{child}, nil, n.productionID)
+	wrapper.startByte, wrapper.endByte = n.startByte, n.endByte
+	wrapper.startPoint, wrapper.endPoint = n.startPoint, n.endPoint
+	wrapper.parseState, wrapper.preGotoState = n.parseState, n.preGotoState
+	wrapper.rawShape = n.rawShape
+	wrapper.dynamicPrecedence = n.dynamicPrecedence
+	return wrapper
 }
 
 func shouldAliasMaterializeInvisibleLeafToAnonymousAlias(n *Node, alias Symbol, lang *Language) bool {

--- a/parser_result.go
+++ b/parser_result.go
@@ -186,7 +186,7 @@ func arenaAllocatedVolume(arena *nodeArena) uint64 {
 }
 
 func resultMaterializationShouldStop(reason ParseStopReason) bool {
-	return parseStopReasonIsActive(reason) || reason == ParseStopMemoryBudget
+	return parseStopReasonIsActive(reason) || reason == ParseStopMemoryBudget || reason == ParseStopInvariantViolation
 }
 
 // hasCleanSiblingAtSamePosition reports whether some other live (non-dead)

--- a/parser_result_collapsed_helpers.go
+++ b/parser_result_collapsed_helpers.go
@@ -69,20 +69,26 @@ var resultCollapsedNamedLeafRules = []collapsedNamedLeafRule{
 	{languageName: "elixir", parentName: "nil", childName: "nil", bySource: true},
 }
 
-func normalizeResultCollapsedNamedLeafChildren(root *Node, source []byte, lang *Language) {
+func normalizeResultCollapsedNamedLeafChildren(root *Node, source []byte, lang *Language) normalizationPassCounters {
+	var total normalizationPassCounters
 	if root == nil || lang == nil {
-		return
+		return total
 	}
 	for _, rule := range resultCollapsedNamedLeafRules {
 		if rule.languageName != lang.Name {
 			continue
 		}
 		if rule.bySource {
-			normalizeCollapsedNamedLeafChildrenBySource(root, source, lang, rule.parentName, rule.childName)
+			stats := normalizeCollapsedNamedLeafChildrenBySourceWithStats(root, source, lang, rule.parentName, rule.childName)
+			total.nodesVisited += stats.nodesVisited
+			total.nodesRewritten += stats.nodesRewritten
 			continue
 		}
-		normalizeCollapsedNamedLeafChildren(root, lang, rule.parentName, rule.childName)
+		stats := normalizeCollapsedNamedLeafChildrenWithStats(root, lang, rule.parentName, rule.childName)
+		total.nodesVisited += stats.nodesVisited
+		total.nodesRewritten += stats.nodesRewritten
 	}
+	return total
 }
 
 func normalizeCollapsedNamedLeafChildrenWithStats(root *Node, lang *Language, parentName, childName string) normalizationPassCounters {

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -67,7 +67,9 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser, incremen
 		result.stopReason = terminalReason
 		return result
 	}
-	normalizeResultCollapsedNamedLeafChildren(root, source, lang)
+	p.runNamedNormalizationPass("collapsed_named_leaf_children", func() bool { return true }, func() normalizationPassCounters {
+		return normalizeResultCollapsedNamedLeafChildren(root, source, lang)
+	})
 	result.stopReason = ctx.stopReason()
 	return result
 }

--- a/parser_result_cycle_guard.go
+++ b/parser_result_cycle_guard.go
@@ -1,146 +1,67 @@
 package gotreesitter
 
-import (
-	"fmt"
-	"os"
-	"sync/atomic"
-)
-
-// stripResultTreeSelfCycles enforces that no node is its own descendant.
-//
-// ROOT CAUSE (now fixed at construction time): trailing-EOF error recovery
-// clones the GSS (sharing node payload pointers), re-reduces, and wraps a
-// dropped stack payload in an ERROR node. On a fresh parse that payload can be a
-// TRANSIENT reduce parent whose .parent field doubles as the result-time
-// materializer's {nil: unvisited, self: in-progress, other: arena clone}
-// sentinel. Wrapping it with the eager-link-wiring constructor corrupted that
-// sentinel, so materializeTransientParentNodes then substituted the child's tree
-// parent for the child and linked the ERROR wrapper under itself. The raw
-// .children slice looked fine while the materialized child view was cyclic, so
-// every later full-tree walk (parent-link wiring, the compat normalizers,
-// recovery trimming) recursed or looped without end: a fatal stack overflow or
-// an indefinite hang (issue #110; the go zerrors_windows.go truncation hang).
-//
-// The construction hazard is now fixed: appendTrailingEOFRecoveryNodes (parser.go)
-// routes through newRecoveryParentNodeInArena (parser_recover_c.go), which skips
-// eager wiring while transient parents are active. The GLR-forest fragment-root
-// sibling site (glr_forest.go collectForestErrorRoot) is proven safe because the
-// forest parse never allocates transient parents. See
-// parser_recover_cycle_internal_test.go for the pins.
-//
-// This pass remains as DEFENSE IN DEPTH. It walks the tree once with an explicit
-// stack and a visited set (so it terminates even on an already-cyclic graph),
-// materializes each node's children (clearing the arena refs so .children
-// becomes authoritative), and drops any child edge that points at the node
-// itself or an ancestor on the current path. It runs only on recovered node
-// trees, so normal parses are untouched. Every dropped edge is now COUNTED (and,
-// under GOT_DEBUG_RECOVERY_CYCLES=1, loudly reported) via
-// reportResultTreeSelfCycleStripped: with the root cause fixed the count must
-// stay zero, so any future construction bug that corrupts the sentinel again
-// surfaces here instead of being silently masked.
-func stripResultTreeSelfCycles(root *Node) {
-	if root == nil {
-		return
-	}
+// recoveredResultNodesAcyclic validates the recovered result forest without
+// materializing or rewriting any child storage. It uses an iterative three-
+// color walk so an already-corrupt graph terminates deterministically instead
+// of recursing forever. Non-node compact/pending payloads are not materialized;
+// they cannot carry a Node back-edge until their normal materialization step.
+func recoveredResultNodesAcyclic(roots []*Node) bool {
+	const (
+		resultNodeGray  = uint8(1)
+		resultNodeBlack = uint8(2)
+	)
 	type frame struct {
-		n   *Node
-		idx int
+		n    *Node
+		next int
 	}
-	black := make(map[*Node]struct{})
-	onPath := map[*Node]struct{}{root: {}}
-	stack := []frame{{root, 0}}
 
-	for len(stack) > 0 {
-		i := len(stack) - 1
-		n := stack[i].n
-		children := nodeChildrenForReason(n, materializeForNormalization)
-
-		descended := false
-		for stack[i].idx < len(children) {
-			c := children[stack[i].idx]
-			if c == nil {
-				stack[i].idx++
-				continue
-			}
-			if _, ancestor := onPath[c]; ancestor {
-				reportResultTreeSelfCycleStripped(n, c)
-				children = removeResultTreeChildAt(n, children, stack[i].idx)
-				continue
-			}
-			if _, done := black[c]; done {
-				stack[i].idx++
-				continue
-			}
-			stack[i].idx++
-			onPath[c] = struct{}{}
-			stack = append(stack, frame{c, 0})
-			descended = true
-			break
-		}
-		if descended {
+	color := make(map[*Node]uint8, len(roots)*4)
+	stack := make([]frame, 0, 64)
+	for _, root := range roots {
+		if root == nil || color[root] == resultNodeBlack {
 			continue
 		}
-		delete(onPath, n)
-		black[n] = struct{}{}
-		stack = stack[:len(stack)-1]
+		color[root] = resultNodeGray
+		stack = append(stack, frame{n: root})
+		for len(stack) > 0 {
+			top := &stack[len(stack)-1]
+			if top.next >= nodeChildCountNoMaterialize(top.n) {
+				color[top.n] = resultNodeBlack
+				stack = stack[:len(stack)-1]
+				continue
+			}
+			entry, ok := nodeChildEntryAtNoMaterialize(top.n, top.next)
+			top.next++
+			if !ok {
+				continue
+			}
+			child := stackEntryNode(entry)
+			if child == nil {
+				continue
+			}
+			switch color[child] {
+			case resultNodeGray:
+				return false
+			case resultNodeBlack:
+				continue
+			default:
+				color[child] = resultNodeGray
+				stack = append(stack, frame{n: child})
+			}
+		}
 	}
+	return true
 }
 
-// debugResultTreeSelfCyclesStripped counts back-edges removed by
-// stripResultTreeSelfCycles across the process. With the sentinel-corruption
-// root cause fixed at construction time it must stay zero; a nonzero value is
-// proof that a recovery construction site is corrupting the transient-parent
-// sentinel again (defense-in-depth kept the tree well-formed, but the bug is
-// real and must be traced, not masked).
-//
-// Parses can run concurrently (multiple *Parser instances across goroutines),
-// so every access goes through sync/atomic: increments use atomic.AddUint64
-// and readers (tests, diagnostics) must use atomic.LoadUint64 rather than a
-// plain read.
-var debugResultTreeSelfCyclesStripped uint64
-
-// reportResultTreeSelfCycleStripped records that the #110 defense-in-depth guard
-// had to drop a self/ancestor back-edge. It always bumps the observable counter;
-// under GOT_DEBUG_RECOVERY_CYCLES=1 it also emits a loud, budgeted stderr line so
-// an env-gated recovery sweep proves the count is zero (or pinpoints the
-// offending node span when it is not). Distinct tag from the construction-time
-// detector (RECOVERY-CYCLE) so the reporting stage is unambiguous.
-func reportResultTreeSelfCycleStripped(parent, child *Node) {
-	atomic.AddUint64(&debugResultTreeSelfCyclesStripped, 1)
-	if !debugRecoveryCycleChecks || debugRecoveryCycleReportsLeft <= 0 {
-		return
+// recoveredResultInvariantErrorTree fails closed when recovered result nodes
+// contain a Node back-edge. The corrupt graph is neither repaired nor exposed:
+// callers receive a standalone ERROR tree whose public stop reason identifies
+// the invariant failure.
+func recoveredResultInvariantErrorTree(nodes []*Node, source []byte, lang *Language, arena *nodeArena) *Tree {
+	if recoveredResultNodesAcyclic(nodes) {
+		return nil
 	}
-	debugRecoveryCycleReportsLeft--
-	var psym, csym Symbol
-	var ps, pe, cs, ce uint32
-	if parent != nil {
-		psym, ps, pe = parent.symbol, parent.startByte, parent.endByte
-	}
-	if child != nil {
-		csym, cs, ce = child.symbol, child.startByte, child.endByte
-	}
-	fmt.Fprintf(os.Stderr,
-		"RESULT-TREE-SELF-CYCLE-STRIP #110 guard dropped back-edge: parent sym=%d [%d-%d] -> descendant/self sym=%d [%d-%d] "+
-			"(transient-parent sentinel corruption regressed at a recovery construction site)\n",
-		psym, ps, pe, csym, cs, ce)
-}
-
-func removeResultTreeChildAt(n *Node, children []*Node, idx int) []*Node {
-	oldLen := len(children)
-	n.children = append(children[:idx], children[idx+1:]...)
-	fieldIDs := n.fieldIDs()
-	fieldSources := n.fieldSources()
-	metadataChanged := false
-	if len(fieldIDs) == oldLen {
-		fieldIDs = append(fieldIDs[:idx], fieldIDs[idx+1:]...)
-		metadataChanged = true
-	}
-	if len(fieldSources) == oldLen {
-		fieldSources = append(fieldSources[:idx], fieldSources[idx+1:]...)
-		metadataChanged = true
-	}
-	if metadataChanged {
-		n.setFieldMetadata(fieldIDs, fieldSources)
-	}
-	return n.children
+	tree := parseErrorTreeWithArena(source, lang, arena)
+	tree.setParseStopReason(ParseStopInvariantViolation)
+	return tree
 }

--- a/parser_result_cycle_guard_test.go
+++ b/parser_result_cycle_guard_test.go
@@ -1,91 +1,37 @@
 package gotreesitter
 
-import (
-	"sync/atomic"
-	"testing"
-)
+import "testing"
 
-func TestStripResultTreeSelfCycles(t *testing.T) {
-	x := &Node{}
-	x.children = []*Node{x}
-	stripResultTreeSelfCycles(x)
-	for _, c := range x.children {
-		if c == x {
-			t.Fatal("self-reference not removed")
-		}
-	}
-
-	a := &Node{}
-	b := &Node{}
-	a.children = []*Node{b}
-	b.children = []*Node{a}
-	stripResultTreeSelfCycles(a)
-	for _, c := range b.children {
-		if c == a {
-			t.Fatal("ancestor back-edge not removed")
-		}
-	}
-
+func TestRecoveredResultNodesAcyclicIsNonMutating(t *testing.T) {
 	leaf := &Node{}
-	mid := &Node{children: []*Node{leaf}}
-	root := &Node{children: []*Node{mid}}
-	stripResultTreeSelfCycles(root)
-	if len(root.children) != 1 || root.children[0] != mid || len(mid.children) != 1 || mid.children[0] != leaf {
-		t.Fatal("clean tree was mutated")
+	left := &Node{children: []*Node{leaf}}
+	right := &Node{children: []*Node{leaf}}
+	root := &Node{children: []*Node{left, right}}
+	if !recoveredResultNodesAcyclic([]*Node{root}) {
+		t.Fatal("shared acyclic result graph rejected")
 	}
-
-	y := &Node{}
-	kept := &Node{}
-	y.children = []*Node{y, kept}
-	y.setFieldMetadata(
-		[]FieldID{1, 2},
-		[]uint8{fieldSourceDirect, fieldSourceInherited},
-	)
-	stripResultTreeSelfCycles(y)
-	if len(y.children) != 1 || y.children[0] != kept {
-		t.Fatalf("children after cycle strip = %v, want only kept child", y.children)
-	}
-	if len(y.fieldIDs()) != 1 || y.fieldIDs()[0] != 2 {
-		t.Fatalf("fieldIDs after cycle strip = %v, want [2]", y.fieldIDs())
-	}
-	if len(y.fieldSources()) != 1 || y.fieldSources()[0] != fieldSourceInherited {
-		t.Fatalf("fieldSources after cycle strip = %v, want inherited source", y.fieldSources())
-	}
-}
-
-// TestStripResultTreeSelfCyclesIsObservable pins the #110 band-aid conversion:
-// the strip is no longer silent. A clean tree leaves the counter untouched;
-// every dropped self/ancestor back-edge bumps debugResultTreeSelfCyclesStripped
-// so a future sentinel-corruption regression surfaces instead of being masked.
-func TestStripResultTreeSelfCyclesIsObservable(t *testing.T) {
-	leaf := &Node{}
-	mid := &Node{children: []*Node{leaf}}
-	root := &Node{children: []*Node{mid}}
-	before := atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
-	stripResultTreeSelfCycles(root)
-	if atomic.LoadUint64(&debugResultTreeSelfCyclesStripped) != before {
-		t.Fatalf("clean tree bumped the strip counter: %d -> %d", before, atomic.LoadUint64(&debugResultTreeSelfCyclesStripped))
+	if len(root.children) != 2 || root.children[0] != left || root.children[1] != right || left.children[0] != leaf || right.children[0] != leaf {
+		t.Fatal("validator mutated a clean result graph")
 	}
 
 	self := &Node{}
 	self.children = []*Node{self}
-	before = atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
-	stripResultTreeSelfCycles(self)
-	if len(self.children) != 0 {
-		t.Fatalf("self-edge not stripped; children=%v", self.children)
+	if recoveredResultNodesAcyclic([]*Node{self}) {
+		t.Fatal("validator accepted self-cycle")
 	}
-	if atomic.LoadUint64(&debugResultTreeSelfCyclesStripped) != before+1 {
-		t.Fatalf("self-cycle strip counter = %d, want %d", atomic.LoadUint64(&debugResultTreeSelfCyclesStripped), before+1)
+	if len(self.children) != 1 || self.children[0] != self {
+		t.Fatal("validator repaired the self-cycle instead of reporting it")
 	}
 
 	a := &Node{}
 	b := &Node{}
 	a.children = []*Node{b}
 	b.children = []*Node{a}
-	before = atomic.LoadUint64(&debugResultTreeSelfCyclesStripped)
-	stripResultTreeSelfCycles(a)
-	if atomic.LoadUint64(&debugResultTreeSelfCyclesStripped) != before+1 {
-		t.Fatalf("ancestor back-edge strip counter = %d, want %d", atomic.LoadUint64(&debugResultTreeSelfCyclesStripped), before+1)
+	if recoveredResultNodesAcyclic([]*Node{a}) {
+		t.Fatal("validator accepted ancestor back-edge")
+	}
+	if len(b.children) != 1 || b.children[0] != a {
+		t.Fatal("validator repaired the ancestor back-edge instead of reporting it")
 	}
 }
 

--- a/parser_result_node_helpers.go
+++ b/parser_result_node_helpers.go
@@ -184,46 +184,6 @@ func walkResultTreePostorder(root *Node, visit func(*Node)) {
 	walk(root)
 }
 
-// walkResultTreePostorderUntil performs a postorder traversal like
-// walkResultTreePostorder, but calls shouldStop before descending into each
-// node's children — not after, since a postorder visit callback only runs
-// once a node's children are already done, which would be too late to avoid
-// doing that work — and aborts the entire walk (propagating the abort up
-// through every recursion level immediately) the moment shouldStop reports
-// true. shouldStop == nil disables the check entirely (equivalent to
-// walkResultTreePostorder). Returns false iff the walk was aborted early
-// rather than completed.
-func walkResultTreePostorderUntil(root *Node, shouldStop func() bool, visit func(*Node)) bool {
-	if visit == nil {
-		return true
-	}
-	var walk func(*Node) bool
-	walk = func(n *Node) bool {
-		if n == nil {
-			return true
-		}
-		if shouldStop != nil && shouldStop() {
-			return false
-		}
-		if n.ownerArena == nil || n.childIndex > finalChildSidecarIndexBase {
-			for _, child := range n.children {
-				if !walk(child) {
-					return false
-				}
-			}
-		} else {
-			for i := 0; i < resultChildCount(n); i++ {
-				if !walk(resultChildAt(n, i)) {
-					return false
-				}
-			}
-		}
-		visit(n)
-		return true
-	}
-	return walk(root)
-}
-
 func walkResultTreeSidecarFirst(root *Node, visit func(*Node)) {
 	if visit == nil {
 		return
@@ -313,37 +273,6 @@ func rewriteResultTreeChildrenPostorder(root *Node, rewrite func(*Node) *Node) {
 			}
 		}
 	})
-}
-
-func rewriteResultTreeChildrenPostorderWithStats(root *Node, rewrite func(*Node) *Node) normalizationPassCounters {
-	var counters normalizationPassCounters
-	if rewrite == nil {
-		return counters
-	}
-	walkResultTreePostorder(root, func(n *Node) {
-		if n == nil {
-			return
-		}
-		counters.nodesVisited++
-		children := n.children
-		if n.ownerArena != nil && n.childIndex <= finalChildSidecarIndexBase {
-			children = resultDenseChildrenFallbackForMutation(n)
-		}
-		for i, child := range children {
-			for {
-				rewritten := rewrite(child)
-				if rewritten == nil {
-					break
-				}
-				counters.nodesRewritten++
-				children[i] = rewritten
-				rewritten.parent = n
-				rewritten.childIndex = int32(i)
-				child = rewritten
-			}
-		}
-	})
-	return counters
 }
 
 func replaceChildRangeWithSingleNode(parent *Node, start, end int, replacement *Node) {

--- a/parser_result_terminal_leaf.go
+++ b/parser_result_terminal_leaf.go
@@ -1,15 +1,11 @@
 package gotreesitter
 
-// normalizeResultTerminalLeafNodesWithStopAndErrorSummary removes redundant
-// terminal payload children that can be introduced by generalized
-// reduction/materialization paths. C tree-sitter exposes terminal and
-// terminal-alias symbols as leaves, so a visible leaf-like parent with one
-// visible anonymous terminal child and no semantic decorations should keep
-// the parent's symbol/flags and adopt the child's token span.
-func normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root *Node, lang *Language, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason, resultErrorSummary) {
-	return normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), stopCheck)
-}
-
+// normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary
+// removes redundant terminal payload children that can be introduced by
+// generalized reduction/materialization paths. C tree-sitter exposes terminal
+// and terminal-alias symbols as leaves, so a visible leaf-like parent with one
+// visible anonymous terminal child and no semantic decorations should keep the
+// parent's symbol/flags and adopt the child's token span.
 func normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root *Node, lang *Language, aliasTargets []bool, stopCheck parseStopCheck) (normalizationPassCounters, ParseStopReason, resultErrorSummary) {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -27,7 +27,7 @@ func TestNormalizeResultTerminalLeafNodesCollapsesRedundantAnonymousTokenChild(t
 	token.endPoint = Point{Row: 0, Column: 12}
 	root := newParentNodeInArena(arena, 3, true, []*Node{token}, nil, 0)
 
-	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if got, want := counters.nodesRewritten, uint64(1); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -83,7 +83,7 @@ func TestNormalizeResultTerminalLeafNodesStopsOnActiveParseBudget(t *testing.T) 
 		return ParseStopNone
 	}
 
-	counters, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, stopCheck)
+	counters, reason, errorSummary := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), stopCheck)
 
 	if reason != ParseStopTimeout {
 		t.Fatalf("stop reason = %q, want %q", reason, ParseStopTimeout)
@@ -120,7 +120,7 @@ func TestNormalizeResultTerminalLeafNodesSummarizesCleanTree(t *testing.T) {
 	leaf := newLeafNodeInArena(arena, 1, false, 0, 1, Point{}, Point{Column: 1})
 	root := newParentNodeInArena(arena, 2, true, []*Node{leaf}, nil, 0)
 
-	_, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	_, reason, errorSummary := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if reason != ParseStopNone {
 		t.Fatalf("stop reason = %q, want none", reason)
@@ -148,7 +148,7 @@ func TestNormalizeResultTerminalLeafNodesFindsUnderFlaggedErrorDescendant(t *tes
 	root := newParentNodeInArena(arena, 1, true, []*Node{errNode}, nil, 0)
 	root.setHasError(false)
 
-	_, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	_, reason, errorSummary := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if reason != ParseStopNone {
 		t.Fatalf("stop reason = %q, want none", reason)
@@ -181,7 +181,7 @@ func TestNormalizeResultTerminalLeafNodesWalksUnderFlaggedErrorRoot(t *testing.T
 	root := newParentNodeInArena(arena, errorSymbol, true, []*Node{token}, nil, 0)
 	root.setHasError(false)
 
-	counters, reason, errorSummary := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	counters, reason, errorSummary := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if reason != ParseStopNone {
 		t.Fatalf("stop reason = %q, want none", reason)
@@ -218,7 +218,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesNonterminalWrapper(t *testing.
 	wrapper := newParentNodeInArena(arena, 2, true, []*Node{child}, nil, 0)
 	root := newParentNodeInArena(arena, 3, true, []*Node{wrapper}, nil, 0)
 
-	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if got, want := counters.nodesRewritten, uint64(0); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -259,7 +259,7 @@ func TestNormalizeResultTerminalLeafNodesCollapsesTerminalAliasTarget(t *testing
 	alias.endPoint = Point{Row: 12, Column: 1}
 	root := newParentNodeInArena(arena, 2, true, []*Node{alias}, nil, 0)
 
-	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if got, want := counters.nodesRewritten, uint64(1); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -348,7 +348,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesDistinctChildUnderReusedAliasT
 	parent.endPoint = Point{Row: 0, Column: 25}
 	root := newParentNodeInArena(arena, 3, true, []*Node{parent}, nil, 0)
 
-	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if got, want := counters.nodesRewritten, uint64(0); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)
@@ -382,7 +382,7 @@ func TestNormalizeResultTerminalLeafNodesPreservesFieldedTerminal(t *testing.T) 
 	token := newParentNodeInArena(arena, 2, true, []*Node{child}, []FieldID{1}, 0)
 	root := newParentNodeInArena(arena, 3, true, []*Node{token}, nil, 0)
 
-	counters, _, _ := normalizeResultTerminalLeafNodesWithStopAndErrorSummary(root, lang, nil)
+	counters, _, _ := normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, buildVisibleAliasTargetSymbols(lang), nil)
 
 	if got, want := counters.nodesRewritten, uint64(0); got != want {
 		t.Fatalf("nodesRewritten = %d, want %d", got, want)

--- a/parser_stop.go
+++ b/parser_stop.go
@@ -9,5 +9,5 @@ func (p *Parser) parseStopReasonNow() ParseStopReason {
 }
 
 func parseStopReasonIsTerminal(reason ParseStopReason) bool {
-	return parseStopReasonIsActive(reason)
+	return parseStopReasonIsActive(reason) || reason == ParseStopInvariantViolation
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -300,14 +300,11 @@ type DiagnosticParserCorePrefixResult struct {
 	Materialized      bool
 	// MaterializedTree is a structural diagnostic owned by the caller and must
 	// be released. It is set only after authenticated EOF acceptance and
-	// one-shot compact-tree materialization succeed. Compact phase zero carries
-	// only table-REPLAYED per-node parser states (exact where reconstructable,
-	// abstained to the 0 "unknown -> recompute" sentinel otherwise) and no
-	// scanner checkpoints, so the tree is HARD-barred from incremental reuse by
-	// its compactMaterialized provenance flag (checked in
-	// tryTokenInvariantReuseForDisabledOldTree): passing it to ParseIncremental
-	// always takes the production parser's full fresh-parse fallback, never even
-	// the token-invariant leaf fast path.
+	// one-shot compact-tree materialization succeed. The diagnostic runner does
+	// not force parser-state replay, so its default tree retains the hard
+	// incremental-reuse bar. The production admission runner separately forces
+	// replay and may clear that bar only when materialization proves the required
+	// states and scanner quiescence per tree.
 	MaterializedTree *Tree
 }
 
@@ -732,7 +729,7 @@ func diagnosticParseParserCoreGenericFromSeed(
 		return result, &diagnosticParserCoreDecline{boundary: result.Boundary, detail: result.Detail}
 	}
 	return publishDiagnosticParserCoreGenericResult(result, scheduler, func(head core.Head) (*Tree, error) {
-		return materializeDiagnosticParserCoreAcceptedSelection(compact, head, scheduler.acceptedPayloads, parser, source, nil)
+		return materializeDiagnosticParserCoreAcceptedSelection(compact, head, scheduler.acceptedPayloads, parser, source, nil, false)
 	})
 }
 
@@ -1833,7 +1830,7 @@ func (index *diagnosticParserCorePointIndex) pointUncached(offset uint32) Point 
 	return Point{Row: uint32(line), Column: offset - index.lineStarts[line]}
 }
 
-func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.Head, parser *Parser, source []byte) (*Tree, error) {
+func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.Head, parser *Parser, source []byte, forceReplayParseStates bool) (*Tree, error) {
 	if compact == nil || parser == nil || parser.language == nil || head.Node == 0 {
 		return nil, errors.New("parser-core phase zero: incomplete accepted-tree materialization input")
 	}
@@ -1844,7 +1841,7 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 	if len(derivations) != 1 {
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreAccept, detail: "materialization requires one exact accepted derivation"}
 	}
-	return materializeDiagnosticParserCoreAcceptedSelection(compact, head, derivations[0].Payloads, parser, source, nil)
+	return materializeDiagnosticParserCoreAcceptedSelection(compact, head, derivations[0].Payloads, parser, source, nil, forceReplayParseStates)
 }
 
 // materializeDiagnosticParserCoreAcceptedSelection materializes the accepted
@@ -1852,7 +1849,7 @@ func materializeDiagnosticParserCoreAcceptedTree(compact *core.Core, head core.H
 // reusable buffers back the transient materialization storage, so the warm
 // steady state does not re-allocate the public-tree scratch on every parse.
 // scratch is reset on return, so it is safe to reuse for the next parse.
-func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head core.Head, payloads []core.SubtreeID, parser *Parser, source []byte, scratch *parserCoreRunnerScratch) (*Tree, error) {
+func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head core.Head, payloads []core.SubtreeID, parser *Parser, source []byte, scratch *parserCoreRunnerScratch, forceReplayParseStates bool) (*Tree, error) {
 	if compact == nil || parser == nil || parser.language == nil || head.Node == 0 || len(payloads) == 0 {
 		return nil, errors.New("parser-core phase zero: incomplete accepted-tree selection input")
 	}
@@ -1909,14 +1906,15 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	// pass elides hidden nodes and applies aliases. Gated so it can be A/B'd
 	// against the states-free compact route.
 	var replayStates *compactReplayStates
-	if parserCoreReplayParseStatesEnabled() {
+	if forceReplayParseStates || parserCoreReplayParseStatesEnabled() {
 		replayStates, err = parser.replayCompactDerivation(compact, payloads)
 		if err != nil {
 			return nil, err
 		}
 		defer replayStates.release()
 	}
-	stamp := func(id core.SubtreeID, node *Node) {
+	incrementalReuseProven := replayStates != nil && classifyExternalScannerQuiescence(parser.language) == scannerQuiescenceProven
+	stamp := func(id core.SubtreeID, node *Node, terminal bool) {
 		// Stamp the reconstructed state for THIS derivation id onto the node
 		// that materializes it. For a unary collapse chain the driver visits the
 		// ids inner-to-outer (postorder) and reuses one node object, so the last
@@ -1935,12 +1933,19 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 		// trusted non-zero state (Phase-3 Lane 3 review amendment 1).
 		if replayStates != nil && node != nil {
 			pre, ps, preOk, psOk := replayStates.get(id)
+			if terminal {
+				incrementalReuseProven = incrementalReuseProven && psOk
+			} else {
+				incrementalReuseProven = incrementalReuseProven && preOk
+			}
 			if psOk {
 				node.parseState = ps
 			}
 			if preOk {
 				node.preGotoState = pre
 			}
+		} else {
+			incrementalReuseProven = false
 		}
 		nodesByID[id] = node
 	}
@@ -1975,7 +1980,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 				// (subtreeRecord.fragile is only ever set on reductions), so a
 				// terminal record is never fragile. The reduce branches below
 				// carry the bit.
-				stamp(id, node)
+				stamp(id, node, true)
 				return nil
 			}
 
@@ -1999,7 +2004,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
 				markFragile(child, view.Fragile)
-				stamp(id, child)
+				stamp(id, child, false)
 				return nil
 			}
 			children, fieldIDs, fieldSources, _ := parser.buildReduceChildrenWithPath(
@@ -2010,7 +2015,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 				child.productionID = view.ProductionID
 				child.dynamicPrecedence += int32(view.DynamicPrecedence)
 				markFragile(child, view.Fragile)
-				stamp(id, child)
+				stamp(id, child, false)
 				return nil
 			}
 			parent := newParentNodeInArenaWithFieldSources(
@@ -2023,7 +2028,7 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 			parent.endPoint = points.point(view.EndByte)
 			parent.setExtra(view.Extra)
 			markFragile(parent, view.Fragile)
-			stamp(id, parent)
+			stamp(id, parent, false)
 			return nil
 		})
 	}
@@ -2087,10 +2092,13 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	}
 	sourceLen := uint32(len(source))
 	root := tree.root
+	if root.startByte == 0 && root.endByte < sourceLen && !root.IsError() && !root.HasError() {
+		extendRootToAcceptedCleanTail(root, source, sourceLen, nil)
+	}
 	if root.startByte != 0 || root.endByte != sourceLen || root.IsError() || root.HasError() {
 		return rejectTree(fmt.Errorf("parser-core phase zero: accepted compact root is incomplete or erroneous: span=%d..%d source=%d error=%t", root.startByte, root.endByte, sourceLen, root.HasError()))
 	}
-	tree.incrementalReuseDisabled = true
+	tree.incrementalReuseDisabled = !incrementalReuseProven
 	tree.compactMaterialized = true
 	tree.setParseRuntime(ParseRuntime{
 		StopReason: ParseStopAccepted, SourceLen: sourceLen, ExpectedEOFByte: sourceLen,

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3053,9 +3053,11 @@ func diagnosticParserCoreGenericUnsupportedCellDescriptor(headerIndex int, token
 	switch descriptor.Kind() {
 	case core.ActionRowEmpty:
 		return unsupported(DiagnosticParserCoreNoAction, "generic scheduler reached an empty action cell")
-	case core.ActionRowShift, core.ActionRowExtraShift:
+	case core.ActionRowShift:
+		return nil
+	case core.ActionRowExtraShift:
 		if token.EndByte <= token.StartByte {
-			return unsupported(DiagnosticParserCoreRoute, "generic scheduler ordinary shift is not positive-width")
+			return unsupported(DiagnosticParserCoreRoute, "generic scheduler extra shift is not positive-width")
 		}
 		return nil
 	case core.ActionRowReduce:
@@ -3066,9 +3068,6 @@ func diagnosticParserCoreGenericUnsupportedCellDescriptor(headerIndex int, token
 		}
 		return nil
 	case core.ActionRowConflict:
-		if descriptor.HasShift() && token.EndByte <= token.StartByte {
-			return unsupported(DiagnosticParserCoreRoute, "generic scheduler ordinary shift is not positive-width")
-		}
 		return nil
 	}
 
@@ -3088,9 +3087,6 @@ func diagnosticParserCoreGenericUnsupportedCellDescriptor(headerIndex int, token
 		switch action.Type {
 		case core.ActionReduce:
 		case core.ActionShift:
-			if token.EndByte <= token.StartByte {
-				return unsupported(DiagnosticParserCoreRoute, "generic scheduler ordinary shift is not positive-width")
-			}
 		case core.ActionRecover:
 			return unsupported(DiagnosticParserCoreRecovery, "generic scheduler reached recovery")
 		case core.ActionAccept:

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -491,6 +491,11 @@ func buildParserCoreSelectedStorePolicy(parser *Parser) (core.SelectedStorePolic
 	if err != nil {
 		return core.SelectedStorePolicy{}, err
 	}
+	retainedAliases := make([]core.SelectedAliasChildPair, 0, len(parser.collapsedChildOccurrencePairs))
+	for _, pair := range parser.collapsedChildOccurrencePairs {
+		retainedAliases = append(retainedAliases, core.SelectedAliasChildPair{Alias: core.Symbol(pair.parent), Child: core.Symbol(pair.child)})
+	}
+	policy.SetRetainedAliasChildren(retainedAliases)
 	syms, _ := goCompatibilitySymbolsForLanguage(lang)
 	containers := make([]bool, width)
 	for _, symbol := range syms.semiContainers[:syms.semiContainerLen] {

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -24,12 +24,13 @@ import (
 // acquiring a production DFA token source, so a declined or capped parse
 // cannot publish state into the next call.
 type parserCoreFreshFullRunner struct {
-	lang           *Language
-	parser         *Parser
-	tables         *parserCoreRootTables
-	compact        *core.Core
-	options        DiagnosticParserCorePrefixOptions
-	scannerScratch []byte
+	lang              *Language
+	parser            *Parser
+	tables            *parserCoreRootTables
+	compact           *core.Core
+	options           DiagnosticParserCorePrefixOptions
+	replayParseStates bool
+	scannerScratch    []byte
 	// scratch retains the reusable per-parse materialization buffers. The runner
 	// is per-Parser and single-goroutine, so reusing these buffers across parses
 	// mirrors production's parser-held arena reuse and keeps the warm steady
@@ -97,14 +98,14 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 		tokenSource.Close()
 		return nil, nil, err
 	}
-	if err := requireParserCoreFreshFullAcceptance(scheduler, len(source)); err != nil {
+	if err := requireParserCoreFreshFullAcceptance(scheduler, source); err != nil {
 		tokenSource.Close()
 		return nil, nil, err
 	}
 	return scheduler, tokenSource, nil
 }
 
-func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGenericScheduler, sourceBytes int) error {
+func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGenericScheduler, source []byte) error {
 	if scheduler == nil || scheduler.receipt == nil || scheduler.receipt.Acceptance == nil || scheduler.acceptedHead.Node == 0 {
 		// GTS_ADMISSION_CENSUS=1 (admission_census.go) re-surfaces the boundary
 		// and detail the scheduler already recorded in scheduler.receipt.Stop
@@ -115,15 +116,16 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 		}
 		return errors.New("parser-core fresh-full runner did not accept EOF")
 	}
-	if sourceBytes < 0 || uint64(sourceBytes) > uint64(^uint32(0)) {
+	if uint64(len(source)) > uint64(^uint32(0)) {
 		return errors.New("parser-core fresh-full runner source exceeds uint32 offsets")
 	}
 	acceptance := scheduler.receipt.Acceptance
-	wantEOF := uint32(sourceBytes)
+	wantEOF := uint32(len(source))
+	header := acceptance.Header.Header
 	if acceptance.Token.Symbol != 0 || acceptance.Token.StartByte != wantEOF || acceptance.Token.EndByte != wantEOF ||
 		acceptance.Token.Missing || acceptance.Token.NoLookahead || acceptance.Token.ExternalScannerToken ||
-		!acceptance.Header.Header.Accepted || acceptance.Header.Header.Paused || acceptance.Header.Header.ExactPaths != 1 ||
-		acceptance.Header.Header.ByteOffset != wantEOF || acceptance.Accepts != 1 || acceptance.Work.Accepts != 1 {
+		!header.Accepted || header.Paused || header.ExactPaths != 1 ||
+		!parserCoreFreshFullAcceptedTailIsClean(source, header.ByteOffset) || acceptance.Accepts != 1 || acceptance.Work.Accepts != 1 {
 		// See the comment above: census classification is opt-in and additive.
 		if admissionCensusEnabled() {
 			return admissionCensusAcceptanceDecline(acceptance, wantEOF)
@@ -132,6 +134,17 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 			acceptance.Token, acceptance.Header.Header, acceptance.Accepts, acceptance.Work.Accepts)
 	}
 	return nil
+}
+
+// parserCoreFreshFullAcceptedTailIsClean applies the production parser's
+// existing accepted-tail proof to compact acceptance. The compact head may
+// end before authenticated EOF only when every remaining byte is parser
+// padding; a real source byte keeps the route fail-closed.
+func parserCoreFreshFullAcceptedTailIsClean(source []byte, headByte uint32) bool {
+	if uint64(len(source)) > uint64(^uint32(0)) || headByte > uint32(len(source)) {
+		return false
+	}
+	return parserTailAllowsCleanAcceptance(source, headByte, uint32(len(source)), nil)
 }
 
 func (r *parserCoreFreshFullRunner) executeScheduler(source []byte, compact *core.Core, reset bool) (*diagnosticParserCoreGenericScheduler, error) {
@@ -146,14 +159,14 @@ func (r *parserCoreFreshFullRunner) materialize(source []byte, compact *core.Cor
 	if r == nil {
 		return nil, errors.New("parser-core fresh-full runner is nil")
 	}
-	return materializeDiagnosticParserCoreAcceptedTree(compact, head, r.parser, source)
+	return materializeDiagnosticParserCoreAcceptedTree(compact, head, r.parser, source, r.replayParseStates)
 }
 
 func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact *core.Core, scheduler *diagnosticParserCoreGenericScheduler) (*Tree, error) {
 	if r == nil || scheduler == nil {
 		return nil, errors.New("parser-core fresh-full selected materialization is incomplete")
 	}
-	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source, &r.scratch)
+	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source, &r.scratch, r.replayParseStates)
 }
 
 func (r *parserCoreFreshFullRunner) parse(source []byte) (*Tree, error) {

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -147,14 +147,6 @@ func parserCoreFreshFullAcceptedTailIsClean(source []byte, headByte uint32) bool
 	return parserTailAllowsCleanAcceptance(source, headByte, uint32(len(source)), nil)
 }
 
-func (r *parserCoreFreshFullRunner) executeScheduler(source []byte, compact *core.Core, reset bool) (*diagnosticParserCoreGenericScheduler, error) {
-	scheduler, tokenSource, err := r.executeSchedulerOpen(source, compact, reset)
-	if tokenSource != nil {
-		tokenSource.Close()
-	}
-	return scheduler, err
-}
-
 func (r *parserCoreFreshFullRunner) materialize(source []byte, compact *core.Core, head core.Head) (*Tree, error) {
 	if r == nil {
 		return nil, errors.New("parser-core fresh-full runner is nil")

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -147,6 +147,28 @@ func TestParserCoreFreshFullRunnerFailsClosedAtConstruction(t *testing.T) {
 	}
 }
 
+func TestParserCoreFreshFullAcceptedTailRequiresParserPadding(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		headByte uint32
+		want     bool
+	}{
+		{name: "exact EOF", source: "value", headByte: 5, want: true},
+		{name: "newline", source: "value\n", headByte: 5, want: true},
+		{name: "mixed padding", source: "value \t\r\n", headByte: 5, want: true},
+		{name: "real tail", source: "value x", headByte: 5},
+		{name: "past EOF", source: "value", headByte: 6},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parserCoreFreshFullAcceptedTailIsClean([]byte(test.source), test.headByte); got != test.want {
+				t.Fatalf("clean accepted tail=%t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 // BenchmarkParserCoreFreshFullCanonical measures the authenticated compact
 // candidate's complete fresh materialized lifecycle. Fixture identity, deep
 // tree equality, exact compact work, arena draining, runner construction, and

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -56,12 +56,12 @@ func TestDiagnosticParserCoreDescriptorPreservesUnsupportedOrdinalOrdering(t *te
 		detail  string
 	}{
 		{
-			name: "dynamic shift precedes static repetition",
+			name: "ordinary shift precedes static repetition",
 			actions: []core.Action{
 				{Type: core.ActionShift, State: 2},
 				{Type: core.ActionReduce, Repetition: true},
 			},
-			detail: "positive-width",
+			detail: "repetition",
 		},
 		{
 			name: "static repetition precedes dynamic shift",
@@ -81,6 +81,25 @@ func TestDiagnosticParserCoreDescriptorPreservesUnsupportedOrdinalOrdering(t *te
 			unsupported := diagnosticParserCoreGenericUnsupportedCell(3, Token{Symbol: 9}, row)
 			if unsupported == nil || unsupported.headerIndex != 3 || !strings.Contains(unsupported.detail, test.detail) {
 				t.Fatalf("unsupported=%+v, want first ordinal detail %q", unsupported, test.detail)
+			}
+		})
+	}
+}
+
+func TestDiagnosticParserCoreDescriptorAdmitsZeroWidthOrdinaryShift(t *testing.T) {
+	token := Token{Symbol: 9, StartByte: 4, EndByte: 4}
+	tests := []struct {
+		name    string
+		actions []core.Action
+	}{
+		{name: "single shift", actions: []core.Action{{Type: core.ActionShift, State: 2}}},
+		{name: "conflict shift", actions: []core.Action{{Type: core.ActionShift, State: 2}, {Type: core.ActionReduce, Symbol: 4}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			row := core.NewActionRow(test.actions)
+			if unsupported := diagnosticParserCoreGenericUnsupportedCell(0, token, row); unsupported != nil {
+				t.Fatalf("zero-width ordinary shift declined: %+v", unsupported)
 			}
 		})
 	}

--- a/parsestate_reuse_bar_test.go
+++ b/parsestate_reuse_bar_test.go
@@ -7,13 +7,10 @@ import (
 	"testing"
 )
 
-// TestCompactMaterializedTreeBarsIncrementalReuse seals Phase-3 Lane 3 review
-// amendment 2 (and the follow-up review's reuse-bar holes): a tree built by the
-// compact route carries table-REPLAYED (not live-recorded) parser states and no
-// scanner checkpoints, so ParseIncremental over it -- on EVERY entry (DFA,
-// custom token source) and even after Tree.Copy -- must fall all the way back to
-// a fresh full parse. It must reuse NO node: not the token-invariant leaf fast
-// path, not the reuseCursor subtree splice.
+// TestCompactMaterializedTreeBarsIncrementalReuse seals the fail-closed half of
+// the compact reuse contract. A diagnostic runner that did not request replay
+// carries no state proof, so every entry (DFA, custom token source, and Copy)
+// must fall back without sharing nodes.
 func TestCompactMaterializedTreeBarsIncrementalReuse(t *testing.T) {
 	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
 	if err != nil {
@@ -143,6 +140,94 @@ func TestCompactMaterializedTreeBarsIncrementalReuse(t *testing.T) {
 		defer got.Release()
 		requireFreshFallback(t, got, treeA)
 	})
+}
+
+// TestAdmissionCompactTreeCarriesIncrementalReuseProof seals the complementary
+// side of the compact provenance contract: the production admission runner
+// requests table replay, and a tree whose replay is complete enough for reuse
+// and whose scanner is provably quiescent must preserve the O(edit) path.
+func TestAdmissionCompactTreeCarriesIncrementalReuseProof(t *testing.T) {
+	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := []byte("package p\n\n// c\nvar x = 1\n")
+	edited := []byte("package p\n\n// c\nvar x = 2\n")
+	pos := bytes.IndexByte(src, '1')
+	if pos < 0 {
+		t.Fatal("fixture invariant: expected digit")
+	}
+
+	parser := NewParser(lang)
+	parser.SetAdmissionCandidateRoute(true)
+	resetAdmissionCandidateCounters()
+	oldTree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("candidate Parse: %v", err)
+	}
+	defer oldTree.Release()
+	routed, fallback := AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("candidate route counters=%d/%d, want 1/0 (reason=%q)", routed, fallback, AdmissionCandidateLastFallbackReason())
+	}
+	if !oldTree.compactMaterialized {
+		t.Fatal("admission tree is missing compact provenance")
+	}
+	if oldTree.incrementalReuseDisabled {
+		t.Fatal("proof-carrying admission tree remained barred from incremental reuse")
+	}
+	requireCompactIncrementalStateProof(t, oldTree)
+
+	oldTree.Edit(InputEdit{
+		StartByte: uint32(pos), OldEndByte: uint32(pos + 1), NewEndByte: uint32(pos + 1),
+		StartPoint: Point{Row: 3, Column: 8}, OldEndPoint: Point{Row: 3, Column: 9}, NewEndPoint: Point{Row: 3, Column: 9},
+	})
+	got, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("ParseIncrementalProfiled: %v", err)
+	}
+	defer got.Release()
+	if profile.ReuseUnsupported {
+		t.Fatalf("proof-carrying compact tree fell back: %s", profile.ReuseUnsupportedReason)
+	}
+	if profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("proof-carrying compact tree reused nothing: %+v", profile)
+	}
+
+	wantParser := NewParser(lang)
+	wantParser.SetAdmissionCandidateRoute(false)
+	want, err := wantParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("production Parse: %v", err)
+	}
+	defer want.Release()
+	parserCoreWarmRequireDeepEqual(t, got, want, lang)
+}
+
+func requireCompactIncrementalStateProof(t *testing.T, tree *Tree) {
+	t.Helper()
+	if tree == nil || tree.root == nil {
+		t.Fatal("compact state proof has no root")
+	}
+	stack := []*Node{tree.root}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		node := stack[last]
+		stack = stack[:last]
+		children := node.ChildCount()
+		if children == 0 {
+			if node.parseState == 0 {
+				t.Fatalf("proof-carrying leaf %s %d..%d abstained from parseState", node.Type(tree.language), node.startByte, node.endByte)
+			}
+			continue
+		}
+		if node != tree.root && node.preGotoState == 0 {
+			t.Fatalf("proof-carrying node %s %d..%d abstained from preGotoState", node.Type(tree.language), node.startByte, node.endByte)
+		}
+		for i := children - 1; i >= 0; i-- {
+			stack = append(stack, node.Child(i))
+		}
+	}
 }
 
 // countSharedNodes returns how many *Node objects are pointer-identical between

--- a/scanner_closure_external_test.go
+++ b/scanner_closure_external_test.go
@@ -1,0 +1,91 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestStatefulScannerCompactLeafReauthenticationFailsClosed exercises the real
+// compact candidate route. Python's scanner retains indentation and delimiter
+// stacks, so its compact tree remains reuse-disabled until scanner checkpoint
+// restoration is certified. A same-length leaf edit must therefore decline the
+// compact reauthentication route and return the exact forced-production tree.
+func TestStatefulScannerCompactLeafReauthenticationFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source []byte
+		old    byte
+		new    byte
+	}{
+		{
+			name:   "indentation_sensitive",
+			source: []byte("def value():\n    item = 1\n    return item\n"),
+			old:    '1',
+			new:    '2',
+		},
+		{
+			name:   "delimiter_sensitive",
+			source: []byte("def value():\n    items = [1, 2]\n    return items[0]\n"),
+			old:    '1',
+			new:    '3',
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lang := grammars.PythonLanguage()
+			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(true)
+			gotreesitter.ResetAdmissionCandidateCountersForTest()
+			oldTree, err := parser.Parse(tc.source)
+			if err != nil {
+				t.Fatalf("compact candidate parse: %v", err)
+			}
+			defer oldTree.Release()
+			if routed, fallback := gotreesitter.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+				t.Fatalf("Python fixture did not produce a real compact tree: routed=%d fallback=%d reason=%q", routed, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+			}
+
+			offset := -1
+			for i, b := range tc.source {
+				if b == tc.old {
+					offset = i
+					break
+				}
+			}
+			if offset < 0 {
+				t.Fatalf("fixture has no %q marker", tc.old)
+			}
+			next := append([]byte(nil), tc.source...)
+			next[offset] = tc.new
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(offset),
+				OldEndByte:  uint32(offset + 1),
+				NewEndByte:  uint32(offset + 1),
+				StartPoint:  pointForOffset(tc.source, offset),
+				OldEndPoint: pointForOffset(tc.source, offset+1),
+				NewEndPoint: pointForOffset(next, offset+1),
+			})
+
+			incremental, profile, err := parser.ParseIncrementalProfiled(next, oldTree)
+			if err != nil {
+				t.Fatalf("incremental parse: %v", err)
+			}
+			defer incremental.Release()
+			if !profile.ReuseUnsupported || profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 || profile.ReparseNanos == 0 {
+				t.Fatalf("stateful compact tree entered reuse despite missing proof: %+v", profile)
+			}
+
+			freshParser := gotreesitter.NewParser(lang)
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(next)
+			if err != nil {
+				t.Fatalf("forced production fresh parse: %v", err)
+			}
+			defer fresh.Release()
+			requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+		})
+	}
+}

--- a/scanner_closure_internal_test.go
+++ b/scanner_closure_internal_test.go
@@ -1,0 +1,30 @@
+package gotreesitter
+
+import "testing"
+
+type scannerClosureFallbackSpy struct {
+	skips int
+}
+
+func (*scannerClosureFallbackSpy) Next() Token               { return Token{} }
+func (*scannerClosureFallbackSpy) Close()                    {}
+func (s *scannerClosureFallbackSpy) SkipToByte(uint32) Token { s.skips++; return Token{Symbol: 1} }
+func (s *scannerClosureFallbackSpy) SkipToByteWithPoint(uint32, Point) Token {
+	s.skips++
+	return Token{Symbol: 1}
+}
+
+// TestCompactLeafRequiredCheckpointDoesNotUseGenericFallback is the P0 closure
+// assertion: when checkpoint proof is mandatory, an unsupported/missing
+// checkpoint fails immediately even if the token source offers generic skip
+// methods that could otherwise manufacture a matching leaf token.
+func TestCompactLeafRequiredCheckpointDoesNotUseGenericFallback(t *testing.T) {
+	spy := &scannerClosureFallbackSpy{}
+	leaf := &Node{symbol: 1, startByte: 4, endByte: 5, preGotoState: 2}
+	if tok, ok := scanCompactLeafWithRequiredScannerCheckpoint(spy, leaf); ok || tok != (Token{}) {
+		t.Fatalf("required-checkpoint scan = (%+v, %v), want zero/false", tok, ok)
+	}
+	if spy.skips != 0 {
+		t.Fatalf("required-checkpoint scan used generic fallback %d times", spy.skips)
+	}
+}

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1,0 +1,2421 @@
+{
+  "schema": "gotreesitter/result-compat-ownership/v1",
+  "source_of_truth": true,
+  "denominator": {
+    "dispatcher_arms": 78,
+    "dispatcher_languages": 85,
+    "dispatcher_predicates": 1,
+    "generic_passes": 3,
+    "post_finalization_arms": 3,
+    "post_finalization_languages": 3
+  },
+  "owner_categories": [
+    "scheduler_action_semantics",
+    "derivation_election_selection",
+    "materialization",
+    "scanner_checkpoint_state",
+    "incremental_edit_reuse",
+    "public_compatibility"
+  ],
+  "entries": [
+    {
+      "id": "dispatch.ada",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeAdaCompatibility"
+      ],
+      "files": [
+        "parser_result_ada.go"
+      ],
+      "languages": [
+        "ada"
+      ],
+      "purpose": "Reconcile Ada returned-tree fields, aliases, and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.angular",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeAngularCompatibility"
+      ],
+      "files": [
+        "parser_result_angular.go"
+      ],
+      "languages": [
+        "angular"
+      ],
+      "purpose": "Reconcile Angular recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.apex",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeApexCompatibility"
+      ],
+      "files": [
+        "parser_result_apex.go"
+      ],
+      "languages": [
+        "apex"
+      ],
+      "purpose": "Reconcile Apex returned-tree aliases, fields, and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.authzed",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeAuthzedCompatibility"
+      ],
+      "files": [
+        "parser_result_authzed.go"
+      ],
+      "languages": [
+        "authzed"
+      ],
+      "purpose": "Reconcile Authzed recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.awk",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeAwkCompatibility"
+      ],
+      "files": [
+        "parser_result_awk.go"
+      ],
+      "languages": [
+        "awk"
+      ],
+      "purpose": "Reconcile AWK recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.bibtex",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeBibtexCompatibility"
+      ],
+      "files": [
+        "parser_result_bibtex.go"
+      ],
+      "languages": [
+        "bibtex"
+      ],
+      "purpose": "Reconcile BibTeX returned-tree shape and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.bash",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeBashProgramVariableAssignments",
+        "normalizeBashGeneratedCommandAssignments",
+        "normalizeBashCommandNameArguments"
+      ],
+      "files": [
+        "parser_result_bash.go"
+      ],
+      "languages": [
+        "bash"
+      ],
+      "purpose": "Reconcile Bash assignment and command-argument materialization.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.bitbake",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeBitbakeCompatibility"
+      ],
+      "files": [
+        "parser_result_bitbake.go"
+      ],
+      "languages": [
+        "bitbake"
+      ],
+      "purpose": "Reconcile BitBake recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.chatito",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeChatitoCompatibility"
+      ],
+      "files": [
+        "parser_result_chatito.go"
+      ],
+      "languages": [
+        "chatito"
+      ],
+      "purpose": "Reconcile Chatito recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.arduino",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeArduinoBuiltinPrimitiveTypes"
+      ],
+      "files": [
+        "parser_result_c.go"
+      ],
+      "languages": [
+        "arduino"
+      ],
+      "purpose": "Reconcile Arduino builtin primitive type materialization.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.c_cpp",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCCompatibilityWithParser"
+      ],
+      "files": [
+        "parser_result_c.go"
+      ],
+      "languages": [
+        "c",
+        "cpp"
+      ],
+      "purpose": "Reconcile C and C++ derivation selection and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.c_sharp",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCSharpCompatibility"
+      ],
+      "files": [
+        "parser_result_csharp.go"
+      ],
+      "languages": [
+        "c_sharp"
+      ],
+      "purpose": "Reconcile C# recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.shared_trailing_span",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeResultTrailingSpanCompatibility"
+      ],
+      "files": [
+        "parser_result_trailing_span_rules.go"
+      ],
+      "languages": [
+        "caddy",
+        "comment",
+        "fortran",
+        "nim",
+        "pug",
+        "rst"
+      ],
+      "purpose": "Reconcile grammar-specific trailing root and trivia spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.cooklang",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCooklangCompatibility"
+      ],
+      "files": [
+        "parser_result_cooklang.go"
+      ],
+      "languages": [
+        "cooklang"
+      ],
+      "purpose": "Reconcile Cooklang returned-tree shape and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.corn",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCornCompatibility"
+      ],
+      "files": [
+        "parser_result_corn.go"
+      ],
+      "languages": [
+        "corn"
+      ],
+      "purpose": "Reconcile Corn recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.crystal",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCrystalCompatibility"
+      ],
+      "files": [
+        "parser_result_crystal.go"
+      ],
+      "languages": [
+        "crystal"
+      ],
+      "purpose": "Reconcile Crystal recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.cpon",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCPONCompatibility"
+      ],
+      "files": [
+        "parser_result_cpon.go"
+      ],
+      "languages": [
+        "cpon"
+      ],
+      "purpose": "Reconcile CPON returned-tree shape and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.cue",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeCueCompatibility"
+      ],
+      "files": [
+        "parser_result_cue.go"
+      ],
+      "languages": [
+        "cue"
+      ],
+      "purpose": "Reconcile CUE returned-tree fields and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.d",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeDCompatibility"
+      ],
+      "files": [
+        "parser_result_d.go"
+      ],
+      "languages": [
+        "d"
+      ],
+      "purpose": "Reconcile D returned-tree fields, aliases, and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.dart",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeDartCompatibility"
+      ],
+      "files": [
+        "parser_result_dart.go"
+      ],
+      "languages": [
+        "dart"
+      ],
+      "purpose": "Reconcile Dart derivation choice and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.doxygen",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeDoxygenCompatibility"
+      ],
+      "files": [
+        "parser_result_doxygen.go"
+      ],
+      "languages": [
+        "doxygen"
+      ],
+      "purpose": "Reconcile Doxygen recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.jsdoc",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeJsdocCompatibility"
+      ],
+      "files": [
+        "parser_result_jsdoc.go"
+      ],
+      "languages": [
+        "jsdoc"
+      ],
+      "purpose": "Reconcile JSDoc recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.dtd",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeDTDCompatibility"
+      ],
+      "files": [
+        "parser_result_dtd.go"
+      ],
+      "languages": [
+        "dtd"
+      ],
+      "purpose": "Reconcile DTD recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.elixir",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeElixirCompatibility"
+      ],
+      "files": [
+        "parser_result_elixir.go"
+      ],
+      "languages": [
+        "elixir"
+      ],
+      "purpose": "Reconcile Elixir recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.enforce",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeEnforceCompatibility"
+      ],
+      "files": [
+        "parser_result_enforce.go"
+      ],
+      "languages": [
+        "enforce"
+      ],
+      "purpose": "Reconcile Enforce recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ebnf",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeEBNFCompatibility"
+      ],
+      "files": [
+        "parser_result_ebnf.go"
+      ],
+      "languages": [
+        "ebnf"
+      ],
+      "purpose": "Reconcile EBNF recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.eds",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeEDSCompatibility"
+      ],
+      "files": [
+        "parser_result_eds.go"
+      ],
+      "languages": [
+        "eds"
+      ],
+      "purpose": "Reconcile EDS recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.erlang",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeErlangSourceFileForms"
+      ],
+      "files": [
+        "parser_result_erlang.go"
+      ],
+      "languages": [
+        "erlang"
+      ],
+      "purpose": "Reconcile Erlang source-file form materialization.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.fsharp",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeFSharpCompatibility"
+      ],
+      "files": [
+        "parser_result_fsharp.go"
+      ],
+      "languages": [
+        "fsharp"
+      ],
+      "purpose": "Reconcile F# returned-tree fields and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.forth",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeForthCompatibility"
+      ],
+      "files": [
+        "parser_result_forth.go"
+      ],
+      "languages": [
+        "forth"
+      ],
+      "purpose": "Reconcile Forth recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.fidl",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeFIDLCompatibility"
+      ],
+      "files": [
+        "parser_result_fidl.go"
+      ],
+      "languages": [
+        "fidl"
+      ],
+      "purpose": "Reconcile FIDL recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.go",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeGoReturnedTreeCompatibility"
+      ],
+      "files": [
+        "parser_result_go.go"
+      ],
+      "languages": [
+        "go"
+      ],
+      "purpose": "Reconcile Go derivation selection, recovery, and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.gitcommit",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeGitcommitCompatibility"
+      ],
+      "files": [
+        "parser_result_gitcommit.go"
+      ],
+      "languages": [
+        "gitcommit"
+      ],
+      "purpose": "Reconcile Git commit returned-tree shape and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.haskell",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHaskellCompatibility"
+      ],
+      "files": [
+        "parser_result_haskell.go"
+      ],
+      "languages": [
+        "haskell"
+      ],
+      "purpose": "Reconcile Haskell returned-tree fields and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.hcl",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHCLConfigFileRoot"
+      ],
+      "files": [
+        "parser_result_hcl.go"
+      ],
+      "languages": [
+        "hcl"
+      ],
+      "purpose": "Reconcile HCL config-file root materialization.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.html",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHTMLCompatibility"
+      ],
+      "files": [
+        "parser_result_html.go"
+      ],
+      "languages": [
+        "html"
+      ],
+      "purpose": "Reconcile HTML recovery and nested-tag returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.http",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHTTPCompatibility"
+      ],
+      "files": [
+        "parser_result_http.go"
+      ],
+      "languages": [
+        "http"
+      ],
+      "purpose": "Reconcile HTTP returned-tree shape and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.hurl",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHurlCompatibility"
+      ],
+      "files": [
+        "parser_result_hurl.go"
+      ],
+      "languages": [
+        "hurl"
+      ],
+      "purpose": "Reconcile Hurl recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.hlsl",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHLSLCompatibility"
+      ],
+      "files": [
+        "parser_result_hlsl.go"
+      ],
+      "languages": [
+        "hlsl"
+      ],
+      "purpose": "Reconcile HLSL recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.hyprlang",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeHyprlangCompatibility"
+      ],
+      "files": [
+        "parser_result_hyprlang.go"
+      ],
+      "languages": [
+        "hyprlang"
+      ],
+      "purpose": "Reconcile Hyprlang recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ini",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeIniCompatibility"
+      ],
+      "files": [
+        "parser_result_ini.go"
+      ],
+      "languages": [
+        "ini"
+      ],
+      "purpose": "Reconcile INI recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.javascript",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeJavaScriptCompatibility"
+      ],
+      "files": [
+        "parser_result_javascript_typescript.go"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "purpose": "Reconcile JavaScript derivation selection, recovery, and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.julia",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeJuliaCompatibility"
+      ],
+      "files": [
+        "parser_result_julia.go"
+      ],
+      "languages": [
+        "julia"
+      ],
+      "purpose": "Reconcile Julia recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.just",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeJustTopLevelTrailingLineBreakSpans"
+      ],
+      "files": [
+        "parser_result_misc_spans.go"
+      ],
+      "languages": [
+        "just"
+      ],
+      "purpose": "Reconcile Just top-level trailing line-break spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ledger",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeLedgerCompatibility"
+      ],
+      "files": [
+        "parser_result_ledger.go"
+      ],
+      "languages": [
+        "ledger"
+      ],
+      "purpose": "Reconcile Ledger recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.linkerscript",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeLinkerscriptCompatibility"
+      ],
+      "files": [
+        "parser_result_linkerscript.go"
+      ],
+      "languages": [
+        "linkerscript"
+      ],
+      "purpose": "Reconcile linker-script recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.kotlin",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeKotlinCompatibility"
+      ],
+      "files": [
+        "parser_result_kotlin.go"
+      ],
+      "languages": [
+        "kotlin"
+      ],
+      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.lua",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeLuaChunkLocalDeclarationFields"
+      ],
+      "files": [
+        "parser_result_lua.go"
+      ],
+      "languages": [
+        "lua"
+      ],
+      "purpose": "Reconcile Lua local-declaration field materialization.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.luau",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeLuauCompatibility"
+      ],
+      "files": [
+        "parser_result_luau.go"
+      ],
+      "languages": [
+        "luau"
+      ],
+      "purpose": "Reconcile Luau recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.make",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeMakeConditionalConsequenceFields"
+      ],
+      "files": [
+        "parser_result_make.go"
+      ],
+      "languages": [
+        "make"
+      ],
+      "purpose": "Reconcile Make conditional consequence fields.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.objc",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeObjcCompatibility"
+      ],
+      "files": [
+        "parser_result_objc.go"
+      ],
+      "languages": [
+        "objc"
+      ],
+      "purpose": "Reconcile Objective-C aliases, fields, and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.nginx",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeNginxAttributeLineBreaks"
+      ],
+      "files": [
+        "parser_result_misc_spans.go"
+      ],
+      "languages": [
+        "nginx"
+      ],
+      "purpose": "Reconcile Nginx attribute line-break spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ninja",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeNinjaCompatibility"
+      ],
+      "files": [
+        "parser_result_ninja.go"
+      ],
+      "languages": [
+        "ninja"
+      ],
+      "purpose": "Reconcile Ninja recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ocaml",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeOCamlCompatibility"
+      ],
+      "files": [
+        "parser_result_ocaml.go"
+      ],
+      "languages": [
+        "ocaml"
+      ],
+      "purpose": "Reconcile OCaml returned-tree fields and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.pascal",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizePascalTopLevelProgramEnd",
+        "normalizePascalTrailingExtraTrivia"
+      ],
+      "files": [
+        "parser_result_misc_spans.go"
+      ],
+      "languages": [
+        "pascal"
+      ],
+      "purpose": "Reconcile Pascal program end and trailing trivia spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.perl",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizePerlCompatibility"
+      ],
+      "files": [
+        "parser_result_perl.go"
+      ],
+      "languages": [
+        "perl"
+      ],
+      "purpose": "Reconcile Perl recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.php",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizePHPCompatibility"
+      ],
+      "files": [
+        "parser_result_php.go"
+      ],
+      "languages": [
+        "php"
+      ],
+      "purpose": "Reconcile PHP recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.powershell",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizePowerShellProgramShape",
+        "normalizePowerShellErrorProgramRoot",
+        "normalizePowerShellAssignmentOperatorTokens",
+        "normalizePowerShellPathCommandNameVariables",
+        "normalizePowerShellEnumStatementKeywordSpans"
+      ],
+      "files": [
+        "parser_result_powershell.go"
+      ],
+      "languages": [
+        "powershell"
+      ],
+      "purpose": "Reconcile PowerShell recovery, tokens, variables, and spans.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ql",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeQLCompatibility"
+      ],
+      "files": [
+        "parser_result_ql.go"
+      ],
+      "languages": [
+        "ql"
+      ],
+      "purpose": "Reconcile QL derivation selection and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.r",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeRCompatibility"
+      ],
+      "files": [
+        "parser_result_r.go"
+      ],
+      "languages": [
+        "r"
+      ],
+      "purpose": "Reconcile R returned-tree fields and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.python",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizePythonCompatibilityWithParser"
+      ],
+      "files": [
+        "parser_result_python.go"
+      ],
+      "languages": [
+        "python"
+      ],
+      "purpose": "Reconcile Python recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.rescript",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeRescriptCompatibility"
+      ],
+      "files": [
+        "parser_result_rescript.go"
+      ],
+      "languages": [
+        "rescript"
+      ],
+      "purpose": "Reconcile ReScript aliases and returned-tree shape.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.robot",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeRobotCompatibility"
+      ],
+      "files": [
+        "parser_result_robot.go"
+      ],
+      "languages": [
+        "robot"
+      ],
+      "purpose": "Reconcile Robot recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.rust",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeRustCompatibility"
+      ],
+      "files": [
+        "parser_result_rust_recovery.go"
+      ],
+      "languages": [
+        "rust"
+      ],
+      "purpose": "Reconcile Rust derivation selection, recovery, and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.ruby",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeRubyTopLevelModuleBounds"
+      ],
+      "files": [
+        "parser_result_ruby.go"
+      ],
+      "languages": [
+        "ruby"
+      ],
+      "purpose": "Reconcile Ruby top-level module bounds.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.scala",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeScalaCompatibility"
+      ],
+      "files": [
+        "parser_result_scala_compilation.go"
+      ],
+      "languages": [
+        "scala"
+      ],
+      "purpose": "Reconcile Scala derivation selection, recovery, and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.scheme",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeSchemeCompatibility"
+      ],
+      "files": [
+        "parser_result_scheme.go"
+      ],
+      "languages": [
+        "scheme"
+      ],
+      "purpose": "Reconcile Scheme recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.solidity",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeSolidityMemberObjectWrappers",
+        "normalizeSolidityCallExpressionAliases"
+      ],
+      "files": [
+        "parser_result_solidity.go"
+      ],
+      "languages": [
+        "solidity"
+      ],
+      "purpose": "Reconcile Solidity member wrappers and call-expression aliases.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.sql",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeSQLRecoveredSelectRoot",
+        "normalizeSQLTrailingSelectListError",
+        "normalizeSQLRecoveredTopLevelSelectStatements",
+        "normalizeSQLSelectClauseBodyIntoFields"
+      ],
+      "files": [
+        "parser_result_sql.go"
+      ],
+      "languages": [
+        "sql"
+      ],
+      "purpose": "Reconcile SQL recovery roots, errors, statements, and fields.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.squirrel",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeSquirrelCompatibility"
+      ],
+      "files": [
+        "parser_result_squirrel.go"
+      ],
+      "languages": [
+        "squirrel"
+      ],
+      "purpose": "Reconcile Squirrel recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.swift",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeSwiftCompatibility"
+      ],
+      "files": [
+        "parser_result_swift.go"
+      ],
+      "languages": [
+        "swift"
+      ],
+      "purpose": "Reconcile Swift recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.templ",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeTemplCompatibility"
+      ],
+      "files": [
+        "parser_result_templ.go"
+      ],
+      "languages": [
+        "templ"
+      ],
+      "purpose": "Reconcile Templ recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.wgsl",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeWGSLCompatibility"
+      ],
+      "files": [
+        "parser_result_wgsl.go"
+      ],
+      "languages": [
+        "wgsl"
+      ],
+      "purpose": "Reconcile WGSL recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.wolfram",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeWolframCompatibility"
+      ],
+      "files": [
+        "parser_result_wolfram.go"
+      ],
+      "languages": [
+        "wolfram"
+      ],
+      "purpose": "Reconcile Wolfram derivation selection and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.typescript",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeTypeScriptTreeCompatibilityWithParser"
+      ],
+      "files": [
+        "parser_result_javascript_typescript.go"
+      ],
+      "languages": [
+        "tsx",
+        "typescript"
+      ],
+      "purpose": "Reconcile TypeScript and TSX derivation selection, recovery, and returned-tree shape.",
+      "authoritative_owner": "derivation_election_selection",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.typst",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeTypstCompatibility"
+      ],
+      "files": [
+        "parser_result_typst.go"
+      ],
+      "languages": [
+        "typst"
+      ],
+      "purpose": "Reconcile Typst returned-tree fields and spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.yaml",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeYAMLRecoveredRoot"
+      ],
+      "files": [
+        "parser_result_yaml.go"
+      ],
+      "languages": [
+        "yaml"
+      ],
+      "purpose": "Reconcile YAML recovered-root selection and shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "dispatch.zig",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeZigEmptyInitListFields"
+      ],
+      "files": [
+        "parser_result_zig.go"
+      ],
+      "languages": [
+        "zig"
+      ],
+      "purpose": "Reconcile Zig empty initializer-list fields.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "predicate.cobol-exact",
+      "kind": "dispatcher_predicate",
+      "functions": [
+        "normalizeCobolCompatibility"
+      ],
+      "files": [
+        "parser_result_cobol.go",
+        "parser_result_helpers.go"
+      ],
+      "languages": [
+        "cobol",
+        "COBOL"
+      ],
+      "match_predicate": "isCobolLanguage",
+      "purpose": "Reconcile recovery, aliases, fields, and returned-tree spans for the exact COBOL name variants accepted by isCobolLanguage.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "cgo_harness/parity_cgo_test.go"
+      ],
+      "retirement_condition": "Delete only after scheduler_action_semantics emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "generic.trailing-extra-trivia",
+      "kind": "generic_pass",
+      "functions": [
+        "normalizeRootTrailingExtraTriviaCompatibility"
+      ],
+      "files": [
+        "parser_result_compat.go"
+      ],
+      "languages": [
+        "*"
+      ],
+      "purpose": "Apply the generic root trailing-extra-trivia compatibility rule.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "parser_result_trailing_extra_compat_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "generic.terminal-leaf",
+      "kind": "generic_pass",
+      "functions": [
+        "normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary"
+      ],
+      "files": [
+        "parser_result_terminal_leaf.go"
+      ],
+      "languages": [
+        "*"
+      ],
+      "purpose": "Apply generic terminal-leaf, alias-target, stop-reason, and error-summary compatibility.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "parser_result_terminal_leaf_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "generic.collapsed-named-leaf",
+      "kind": "generic_pass",
+      "functions": [
+        "normalizeResultCollapsedNamedLeafChildren"
+      ],
+      "files": [
+        "parser_result_collapsed_helpers.go"
+      ],
+      "languages": [
+        "*"
+      ],
+      "purpose": "Apply generic collapsed named-leaf child compatibility.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "parser_result_collapsed_helpers_test.go"
+      ],
+      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "route_coverage": {
+        "production": "shared_result_compatibility_tail",
+        "compact": "shared_result_compatibility_tail",
+        "forest": "shared_result_compatibility_tail",
+        "incremental": "shared_result_compatibility_tail",
+        "c_oracle": "curated_single_grammar_parity"
+      },
+      "status": "live",
+      "receipt_refs": []
+    },
+    {
+      "id": "fixpoint.returned-tree-second-pass",
+      "kind": "second_pass_fixpoint",
+      "functions": [
+        "normalizeReturnedTree",
+        "normalizePostFinalizationReturnedTree",
+        "normalizeScalaTemplateBodyObjectFragments",
+        "normalizeScalaRecoveredObjectTemplateBodies",
+        "normalizeScalaDefinitionFields",
+        "normalizeScalaTemplateBodyFunctionAnnotations",
+        "normalizeScalaTemplateBodyFunctionEnds",
+        "normalizeScalaCaseClauseEnds",
+        "normalizeRootEOFNewlineSpan",
+        "normalizeHTMLRecoveredNestedCustomTagRanges",
+        "normalizeJavaScriptProgramEnd"
+      ],
+      "files": [
+        "parser_api.go",
+        "parser_result_scala_template.go",
+        "parser_result_scala_compilation.go",
+        "parser_result_misc_spans.go",
+        "parser_result_html.go",
+        "parser_result_javascript_typescript.go"
+      ],
+      "languages": [
+        "html",
+        "javascript",
+        "scala"
+      ],
+      "entrypoint_calls": [
+        "normalizeReturnedTree"
+      ],
+      "switch_arms": [
+        {
+          "languages": [
+            "scala"
+          ],
+          "functions": [
+            "normalizeScalaTemplateBodyObjectFragments",
+            "normalizeScalaRecoveredObjectTemplateBodies",
+            "normalizeScalaDefinitionFields",
+            "normalizeScalaTemplateBodyFunctionAnnotations",
+            "normalizeScalaTemplateBodyFunctionEnds",
+            "normalizeScalaCaseClauseEnds",
+            "normalizeRootEOFNewlineSpan"
+          ]
+        },
+        {
+          "languages": [
+            "html"
+          ],
+          "functions": [
+            "normalizeHTMLRecoveredNestedCustomTagRanges"
+          ]
+        },
+        {
+          "languages": [
+            "javascript"
+          ],
+          "functions": [
+            "normalizeJavaScriptProgramEnd"
+          ]
+        }
+      ],
+      "purpose": "Retain the bounded second pass that reaches a returned-tree fixpoint after finalization for Scala annotations and bounds, HTML recovered nested custom-tag ranges, and JavaScript program ends.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "parser_result_html_test.go",
+        "parser_result_javascript_typescript_compat_test.go",
+        "parser_result_test/parser_result_scala_comment_attachment_test.go"
+      ],
+      "retirement_condition": "Delete only after the HTML producer/materializer emits final nested custom-tag ranges without normalizeHTMLRecoveredNestedCustomTagRanges, the Scala and JavaScript producers emit their final spans in one pass, and exact production, compact, forest, incremental, and C-oracle receipts prove the second pass is inert.",
+      "route_coverage": {
+        "production": "post_finalization_fixpoint",
+        "compact": "post_finalization_fixpoint",
+        "forest": "post_finalization_fixpoint",
+        "incremental": "post_finalization_fixpoint",
+        "c_oracle": "language_witnesses_required"
+      },
+      "status": "live",
+      "receipt_refs": []
+    }
+  ]
+}

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -2319,12 +2319,16 @@
       "languages": [
         "*"
       ],
-      "purpose": "Apply generic collapsed named-leaf child compatibility.",
+      "purpose": "Retain generic collapsed named-leaf child compatibility as a safety net for uncertified and custom languages and as a zero-rewrite receipt for exact-profile built-ins that now produce the shape natively.",
       "authoritative_owner": "materialization",
       "witnesses": [
-        "parser_result_collapsed_helpers_test.go"
+        "parser_result_collapsed_helpers_test.go",
+        "parser_collapsed_child_policy_test.go",
+        "parser_collapsed_child_policy_external_test.go",
+        "grammars/collapsed_child_native_regression_test.go",
+        "internal/parsercorephase0/selected_store_test.go"
       ],
-      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "retirement_condition": "Delete only after materialization emits the same tree natively with zero rewrites for every registered witness, production, compact, forest, incremental, and C-oracle route receipts are exact, and the compatibility policy for caller-built, adapted, and other custom languages is explicitly documented.",
       "route_coverage": {
         "production": "shared_result_compatibility_tail",
         "compact": "shared_result_compatibility_tail",
@@ -2333,7 +2337,12 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "receipt_refs": [
+        "parser_collapsed_child_policy_test.go",
+        "parser_collapsed_child_policy_external_test.go",
+        "grammars/collapsed_child_native_regression_test.go",
+        "internal/parsercorephase0/selected_store_test.go"
+      ]
     },
     {
       "id": "fixpoint.returned-tree-second-pass",

--- a/tree.go
+++ b/tree.go
@@ -2743,11 +2743,10 @@ type Tree struct {
 	// exact, extras/unrecoverable nodes deliberately abstain to the 0
 	// "unknown -> recompute" sentinel, and a bounded internal collapse class
 	// carries the principled outer state rather than production's forest-selected
-	// inner one. It also lacks scanner checkpoints. It is therefore HARD-barred
-	// from every incremental reuse path -- including the token-invariant leaf
-	// fast path that forestFastPath trees still take -- so ParseIncremental over
-	// it always falls back to a full fresh parse (Phase-3 Lane 3 review
-	// amendment 2).
+	// inner one. incrementalReuseDisabled remains set unless materialization
+	// proves every required replay state and scanner quiescence for this exact
+	// tree. Barred compact trees may still take an independently re-authenticated
+	// single-leaf edit; all subtree reuse remains fail-closed.
 	compactMaterialized bool
 	// Finalization state avoids repeated retry scans and compatibility passes.
 	// The error summary is not a persistent invariant of a caller-edited tree.

--- a/tree.go
+++ b/tree.go
@@ -657,16 +657,17 @@ func nodeFieldIDAt(n *Node, i int) FieldID {
 type ParseStopReason string
 
 const (
-	ParseStopNone            ParseStopReason = "none"
-	ParseStopAccepted        ParseStopReason = "accepted"
-	ParseStopNoStacksAlive   ParseStopReason = "no_stacks_alive"
-	ParseStopTokenSourceEOF  ParseStopReason = "token_source_eof"
-	ParseStopTimeout         ParseStopReason = "timeout"
-	ParseStopCancelled       ParseStopReason = "cancelled"
-	ParseStopIterationLimit  ParseStopReason = "iteration_limit"
-	ParseStopStackDepthLimit ParseStopReason = "stack_depth_limit"
-	ParseStopNodeLimit       ParseStopReason = "node_limit"
-	ParseStopMemoryBudget    ParseStopReason = "memory_budget"
+	ParseStopNone               ParseStopReason = "none"
+	ParseStopAccepted           ParseStopReason = "accepted"
+	ParseStopNoStacksAlive      ParseStopReason = "no_stacks_alive"
+	ParseStopTokenSourceEOF     ParseStopReason = "token_source_eof"
+	ParseStopTimeout            ParseStopReason = "timeout"
+	ParseStopCancelled          ParseStopReason = "cancelled"
+	ParseStopIterationLimit     ParseStopReason = "iteration_limit"
+	ParseStopStackDepthLimit    ParseStopReason = "stack_depth_limit"
+	ParseStopNodeLimit          ParseStopReason = "node_limit"
+	ParseStopMemoryBudget       ParseStopReason = "memory_budget"
+	ParseStopInvariantViolation ParseStopReason = "invariant_violation"
 )
 
 type PendingParentRejectStats struct {
@@ -3637,7 +3638,7 @@ func (t *Tree) rawParseStopReason() ParseStopReason {
 // It intentionally does not initiate deferred result compatibility.
 func (t *Tree) rawParseStoppedEarly() bool {
 	switch t.rawParseStopReason() {
-	case ParseStopIterationLimit, ParseStopStackDepthLimit, ParseStopNodeLimit, ParseStopMemoryBudget, ParseStopTokenSourceEOF, ParseStopTimeout, ParseStopCancelled:
+	case ParseStopIterationLimit, ParseStopStackDepthLimit, ParseStopNodeLimit, ParseStopMemoryBudget, ParseStopTokenSourceEOF, ParseStopTimeout, ParseStopCancelled, ParseStopInvariantViolation:
 		return true
 	default:
 		return false

--- a/tree.go
+++ b/tree.go
@@ -1741,16 +1741,8 @@ func (n *Node) containsByteRange(startByte, endByte uint32) bool {
 	return startByte >= n.startByte && endByte <= n.endByte
 }
 
-func (n *Node) containsPointRange(startPoint, endPoint Point) bool {
-	return pointLessOrEqual(n.startPoint, startPoint) && pointLessOrEqual(endPoint, n.endPoint)
-}
-
 func stackEntryContainsByteRange(entry stackEntry, startByte, endByte uint32) bool {
 	return startByte >= stackEntryNodeStartByte(entry) && endByte <= stackEntryNodeEndByte(entry)
-}
-
-func stackEntryContainsPointRange(entry stackEntry, startPoint, endPoint Point) bool {
-	return pointLessOrEqual(stackEntryNodeStartPoint(entry), startPoint) && pointLessOrEqual(endPoint, stackEntryNodeEndPoint(entry))
 }
 
 // descendantForByteRange walks to the smallest descendant covering [startByte,

--- a/w5_editor_latency_gate_test.go
+++ b/w5_editor_latency_gate_test.go
@@ -19,7 +19,7 @@ package gotreesitter_test
 //
 // # What this gate actually measured (read before changing ceilings)
 //
-// Building the sweep below (four languages, three positions, three edit
+// Building the sweep below (five languages, three positions, three edit
 // classes, two size tiers) surfaced two things a single near-top fixture
 // cannot:
 //
@@ -60,14 +60,16 @@ package gotreesitter_test
 //     every position, not just at the top, and it is what this gate uses
 //     for MinByteReusePercent below.
 //
-// Coverage: four languages (Go, TypeScript, Python, CSS) at two committed
-// size tiers (~20KB, ~137KB) crossed with three edit classes (insert,
+// Coverage: five languages (Go, JavaScript, TypeScript, Python, CSS) at two
+// committed size tiers (~20KB, ~137KB) crossed with three edit classes (insert,
 // delete, replace) at three file positions (top ~0%, middle ~50%, bottom
-// ~99% through the file) -- 72 samples. A third size tier (~1MB) exists but
-// is gated behind GTS_W5_FULL_SWEEP=1 + GTS_W5_SLOW_TIER=1 (see w5Tiers)
+// ~99% through the file) -- 90 samples. A third size tier (~1MB) exists but
+// is gated behind GTS_W5_SLOW_TIER=1 (see w5Tiers)
 // because it pushes single-run wall time well past a fast local/CI budget;
 // it still asserts the same oracle and counter ceilings, it is just not run
-// on every `go test .`.
+// on every `go test .`. JavaScript and TypeScript additionally carry an
+// explicit delete-that-creates-ERROR lane at all three positions and both
+// committed sizes, matching the remaining issue #380 editor workload.
 //
 // Every sample enforces, unconditionally (the non-negotiable campaign
 // invariant, not a soft check):
@@ -83,6 +85,10 @@ package gotreesitter_test
 //     edited buffer.
 //  3. Per-language, per-position counter ceilings (w5Ceilings), which
 //     regress the build if a change reopens O(file) reparse cost.
+//  4. Source-scaled node-allocation and arena+scratch memory ceilings for
+//     both the incremental result and its independent fresh-parse oracle.
+//  5. For JS/TS transient-error deletes, explicit causal/work ceilings on
+//     tokens, parser iterations, recovery checks, retries, and stack fanout.
 //
 // # Ceiling table and provenance
 //
@@ -94,6 +100,7 @@ package gotreesitter_test
 //
 //	language    | RootNonLeafChanged ceiling (top / mid / bot) | MinByteReusePercent (top / mid / bot)
 //	go          | 16 / 16 / 16  (measured 9-10 flat)           | 90 / 90 / 90  (measured ~96 flat)
+//	javascript  | 20 / -  / -   (mid/bot scale, barred T2c)    | 90 / 70 / 55  (measured ~97 / ~80 / ~64)
 //	typescript  | 20 / -  / -   (mid/bot scale, barred T2c)    | 90 / 70 / 55  (measured ~97 / ~81 / ~65)
 //	css         | 12 / 12 / 12  (measured 3-7 flat)            | 90 / 90 / 90  (measured ~96 flat)
 //	python      | 8  / -  / -   (declines reuse, W4 open)      | 0  / 0  / 0   (measured 0 -- see below)
@@ -111,7 +118,7 @@ package gotreesitter_test
 //     constant with slack for box variance, satisfying the literal
 //     campaign instruction "clean-Go top-level edits rootNonLeafChanged <=
 //     16 regardless of size".
-//   - css top MinByteReusePercent=88 for the SWEEP's synthetic fixture
+//   - css top MinByteReusePercent=90 for the SWEEP's synthetic fixture
 //     (measured ~96 on this box). The campaign's literal instruction ("CSS
 //     near-top reuse >= 95%, today 99.5%") is enforced precisely, not with
 //     this generic sweep's slacker floor, but by a dedicated test using the
@@ -123,9 +130,10 @@ package gotreesitter_test
 //     the same fixture -- both are comfortably >= 95). This is the tracked
 //     "add a committed W1 measurement assertion" follow-up from that
 //     review, now enforced in CI instead of only recorded in a comment.
-//   - typescript, python: measured on this box via this harness (no
-//     campaign-recorded prior figure exists for these languages yet -- W4,
-//     the per-language scanner-quiescence proof, is still open for them).
+//   - javascript, typescript, python: measured on this box via this harness;
+//     no campaign-recorded prior figure exists for these fixture cells.
+//     JavaScript/TypeScript leading reuse awaits the T2c fragility proof,
+//     while Python's W4 indent-stack scanner-quiescence proof remains open.
 //   - python: MinByteReusePercent=0 at every position for insert/delete is
 //     an intentional "honest negative", not a placeholder. Measurement
 //     shows Python's insert/delete incremental parses currently take the
@@ -175,17 +183,9 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-// w5FullSweep reports whether the ~137KB tier should be added to the
-// default ~20KB-only sweep. Unset, only the fast tier runs as part of
-// `go test .`.
-func w5FullSweep() bool {
-	return strings.TrimSpace(os.Getenv("GTS_W5_FULL_SWEEP")) != ""
-}
-
 // w5SlowTier reports whether the ~1MB size tier should be included. Only
-// meaningful when w5FullSweep is also set; the 1MB tier is opt-in even for
-// the full sweep, matching the campaign spec's "1MB env-gated as the slow
-// tier" instruction.
+// the 1MB tier is opt-in, matching the campaign spec's "1MB env-gated as
+// the slow tier" instruction. The 20KB and 137KB tiers are always committed.
 func w5SlowTier() bool {
 	return strings.TrimSpace(os.Getenv("GTS_W5_SLOW_TIER")) != ""
 }
@@ -226,11 +226,11 @@ const (
 func (p w5Position) String() string {
 	switch p {
 	case w5Top:
-		return "top"
+		return "start"
 	case w5Middle:
 		return "middle"
 	case w5Bottom:
-		return "bottom"
+		return "end"
 	default:
 		return "unknown"
 	}
@@ -262,10 +262,11 @@ var (
 // (verified empirically, not just asserted -- see the harness's own probe
 // history).
 type w5LangSpec struct {
-	name   string
-	lang   func() *gts.Language
-	build  func(targetBytes int) (src []byte, itemCount int)
-	marker func(itemIndex int) string // substring ending right after the item's index digits
+	name        string
+	lang        func() *gts.Language
+	build       func(targetBytes int) (src []byte, itemCount int)
+	marker      func(itemIndex int) string // substring ending right after the item's index digits
+	errorMarker func(itemIndex int) string // optional substring whose last byte is required syntax
 }
 
 const w5MinItems = 40
@@ -287,7 +288,18 @@ func w5BuildTypeScript(targetBytes int) ([]byte, int) {
 	b.Grow(targetBytes + 256)
 	n := 0
 	for b.Len() < targetBytes || n < w5MinItems {
-		fmt.Fprintf(&b, "export function f%d(a: number): number {\n  const v = a + %d;\n  return v;\n}\n\n", n, n)
+		fmt.Fprintf(&b, "export function f%d(a: number): number {\n  const v%d = a + %d;\n  return v%d;\n}\n\n", n, n, n, n)
+		n++
+	}
+	return []byte(b.String()), n
+}
+
+func w5BuildJavaScript(targetBytes int) ([]byte, int) {
+	var b strings.Builder
+	b.Grow(targetBytes + 256)
+	n := 0
+	for b.Len() < targetBytes || n < w5MinItems {
+		fmt.Fprintf(&b, "export function j%d(a) {\n  const v%d = a + %d;\n  return v%d;\n}\n\n", n, n, n, n)
 		n++
 	}
 	return []byte(b.String()), n
@@ -317,7 +329,8 @@ func w5BuildCSS(targetBytes int) ([]byte, int) {
 
 var w5Langs = []w5LangSpec{
 	{name: "go", lang: grammars.GoLanguage, build: w5BuildGo, marker: func(i int) string { return fmt.Sprintf("G%d(", i) }},
-	{name: "typescript", lang: grammars.TypescriptLanguage, build: w5BuildTypeScript, marker: func(i int) string { return fmt.Sprintf("f%d(", i) }},
+	{name: "javascript", lang: grammars.JavascriptLanguage, build: w5BuildJavaScript, marker: func(i int) string { return fmt.Sprintf("j%d(", i) }, errorMarker: func(i int) string { return fmt.Sprintf("const v%d =", i) }},
+	{name: "typescript", lang: grammars.TypescriptLanguage, build: w5BuildTypeScript, marker: func(i int) string { return fmt.Sprintf("f%d(", i) }, errorMarker: func(i int) string { return fmt.Sprintf("const v%d =", i) }},
 	{name: "python", lang: grammars.PythonLanguage, build: w5BuildPython, marker: func(i int) string { return fmt.Sprintf("f%d(", i) }},
 	{name: "css", lang: grammars.CssLanguage, build: w5BuildCSS, marker: func(i int) string { return fmt.Sprintf("item-%d ", i) }},
 }
@@ -354,12 +367,23 @@ func w5LastDigitOffset(t *testing.T, src []byte, marker string) int {
 	return idx + len(marker) - 2
 }
 
+// w5LastByteOffset finds the last byte in marker. The JS/TS transient-error
+// lane uses it to delete a required assignment operator from a declaration,
+// guaranteeing the edited fresh parse contains ERROR/MISSING without making
+// recovery consume neighboring top-level declarations.
+func w5LastByteOffset(t *testing.T, src []byte, marker string) int {
+	t.Helper()
+	idx := bytes.Index(src, []byte(marker))
+	if idx < 0 {
+		t.Fatalf("w5 fixture invariant: marker %q not found in generated corpus", marker)
+	}
+	return idx + len(marker) - 1
+}
+
 // w5ApplyEdit builds the edited buffer and the corresponding InputEdit for a
-// single-byte insert/delete/replace at offset, which must be a decimal
-// digit (w5LastDigitOffset's contract): duplicate it (insert), drop it
-// (delete), or replace it with a different decimal digit (replace). All
-// three keep the surrounding token a valid identifier/number suffix in
-// every gate language.
+// single-byte insert/delete/replace at offset. Insert/replace require a decimal
+// digit (w5LastDigitOffset's contract); delete also supports the punctuation
+// offset used by the explicit JS/TS transient-error lane.
 func w5ApplyEdit(src []byte, offset int, class w5EditClass) ([]byte, gts.InputEdit) {
 	startPoint := w1bPointAt(src, offset)
 	switch class {
@@ -396,24 +420,32 @@ func w5ApplyEdit(src []byte, offset int, class w5EditClass) ([]byte, gts.InputEd
 // result, profiled incremental parse of the result, plus the oracle diff
 // and wall time.
 type w5Sample struct {
-	Lang        string
-	Size        string
-	Class       w5EditClass
-	Position    w5Position
-	Profile     gts.IncrementalParseProfile
-	EditedLen   int
-	OracleDiff  string
-	FullSpanOK  bool
-	IncrWallNs  int64
-	FreshWallNs int64
+	Lang         string
+	Size         string
+	Class        w5EditClass
+	Position     w5Position
+	Profile      gts.IncrementalParseProfile
+	FreshRuntime gts.ParseRuntime
+	EditedLen    int
+	OracleDiff   string
+	FullSpanOK   bool
+	FreshError   bool
+	IncrError    bool
+	IncrWallNs   int64
+	FreshWallNs  int64
 }
 
 func w5RunSample(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w5EditClass, pos w5Position) w5Sample {
 	t.Helper()
-	lang := spec.lang()
 	src, itemCount := spec.build(tier.targetSize)
 	sites := w5EditSiteIndices(itemCount)
 	offset := w5LastDigitOffset(t, src, spec.marker(sites[pos]))
+	return w5RunSampleAtOffset(t, spec, tier, class, pos, src, offset)
+}
+
+func w5RunSampleAtOffset(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w5EditClass, pos w5Position, src []byte, offset int) w5Sample {
+	t.Helper()
+	lang := spec.lang()
 
 	parser := gts.NewParser(lang)
 	oldTree, err := parser.Parse(src)
@@ -435,6 +467,7 @@ func w5RunSample(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w5EditCla
 		t.Fatalf("%s/%s fresh parse of edited: %v", spec.name, tier.name, err)
 	}
 	defer freshTree.Release()
+	freshRuntime := freshTree.ParseRuntime()
 
 	oldTree.Edit(edit)
 	incrStart := time.Now()
@@ -450,8 +483,50 @@ func w5RunSample(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w5EditCla
 
 	return w5Sample{
 		Lang: spec.name, Size: tier.name, Class: class, Position: pos,
-		Profile: prof, EditedLen: len(edited), OracleDiff: diff, FullSpanOK: fullSpan,
+		Profile: prof, FreshRuntime: freshRuntime, EditedLen: len(edited), OracleDiff: diff, FullSpanOK: fullSpan,
+		FreshError: freshTree.RootNode().HasError(), IncrError: incrTree.RootNode().HasError(),
 		IncrWallNs: incrWall.Nanoseconds(), FreshWallNs: freshWall.Nanoseconds(),
+	}
+}
+
+const (
+	// Every W5 lane, including its independent fresh oracle, stays within a
+	// deterministic linear allocation envelope. The fixed term covers parser
+	// scratch slabs retained from an earlier 1MiB lane in this same process;
+	// the per-KiB term covers grammar/tree density variation.
+	//
+	// Provenance (combined slow-tier run, all languages sequential): maximum
+	// incremental-or-fresh arena+scratch was <42.0MB at 20KB, <49.5MB at
+	// 137KB, and <162.5MB at 1MiB. The affine ceiling below is approximately
+	// 53.8MB, 72.9MB, and 218.3MB at those generated-source sizes: enough
+	// cross-platform/capacity-rounding slack while still bounding linear growth.
+	w5MaxNodesPerKiB          = 1400
+	w5MemoryFixedBytes  int64 = 48 << 20
+	w5MemoryPerKiBBytes int64 = 160 << 10
+)
+
+func w5CheckMemoryAllocation(t *testing.T, s w5Sample) {
+	t.Helper()
+	kib := int64((s.EditedLen + 1023) / 1024)
+	maxMemory := w5MemoryFixedBytes + kib*w5MemoryPerKiBBytes
+	maxNodes := w5PerKiBCeiling(s.EditedLen, w5MaxNodesPerKiB)
+
+	incrMemory := s.Profile.ArenaBytesAllocated + s.Profile.ScratchBytesAllocated
+	if incrMemory > maxMemory || s.Profile.NewNodesAllocated > maxNodes {
+		t.Fatalf("%s/%s/%s/%s: incremental allocation ceiling exceeded: memory=%d/%d newNodes=%d/%d",
+			s.Lang, s.Size, s.Class, s.Position, incrMemory, maxMemory, s.Profile.NewNodesAllocated, maxNodes)
+	}
+	fresh := s.FreshRuntime
+	if fresh.ArenaBytesAllocated < 0 || fresh.ScratchBytesAllocated < 0 ||
+		fresh.EntryScratchBytesAllocated < 0 || fresh.GSSBytesAllocated < 0 || fresh.NodesAllocated < 0 {
+		t.Fatalf("%s/%s/%s/%s: negative fresh-parse allocation counter: arena=%d scratch=%d entry=%d gss=%d nodes=%d",
+			s.Lang, s.Size, s.Class, s.Position, fresh.ArenaBytesAllocated, fresh.ScratchBytesAllocated,
+			fresh.EntryScratchBytesAllocated, fresh.GSSBytesAllocated, fresh.NodesAllocated)
+	}
+	freshMemory := fresh.ArenaBytesAllocated + fresh.ScratchBytesAllocated
+	if freshMemory > maxMemory || uint64(fresh.NodesAllocated) > maxNodes {
+		t.Fatalf("%s/%s/%s/%s: fresh-oracle allocation ceiling exceeded: memory=%d/%d nodes=%d/%d",
+			s.Lang, s.Size, s.Class, s.Position, freshMemory, maxMemory, fresh.NodesAllocated, maxNodes)
 	}
 }
 
@@ -535,6 +610,15 @@ var w5Ceilings = map[string]w5Ceiling{
 		Middle:                     w5PositionCeiling{MinByteReusePercent: 70},
 		Bottom:                     w5PositionCeiling{MinByteReusePercent: 55},
 	},
+	// javascript shares TypeScript's ASI/ambiguous-expression constraints and
+	// the same measured reuse shape. The dedicated transient-error delete gate
+	// below carries the stricter recovery-work contract for malformed edits.
+	"javascript": {
+		MaxRootNonLeafChangedAtTop: 20,
+		Top:                        w5PositionCeiling{MinByteReusePercent: 90, MaxRootNonLeafChanged: 20},
+		Middle:                     w5PositionCeiling{MinByteReusePercent: 70},
+		Bottom:                     w5PositionCeiling{MinByteReusePercent: 55},
+	},
 	// css: flattened by T2a on the production (non-forest) route, the same as go.
 	// Measured ~95.8-95.9% byte reuse and ReuseRejectRootNonLeafChanged 3-7 at
 	// every position (was middle 15598 / 85.8% and bottom 31163 / 75.7% at 137KB).
@@ -571,8 +655,9 @@ func (c w5Ceiling) forPosition(pos w5Position) w5PositionCeiling {
 	}
 }
 
-// w5Check applies the oracle and counter assertions for one sample.
-func w5Check(t *testing.T, s w5Sample) {
+// w5CheckCommon applies the correctness and resource-observability contract
+// shared by clean and transient-error lanes.
+func w5CheckCommon(t *testing.T, s w5Sample) {
 	t.Helper()
 	if s.OracleDiff != "" {
 		t.Fatalf("%s/%s/%s/%s: oracle divergence (incremental != fresh parse): %s",
@@ -581,15 +666,43 @@ func w5Check(t *testing.T, s w5Sample) {
 	if !s.FullSpanOK {
 		t.Fatalf("%s/%s/%s/%s: incremental root does not cover the full edited buffer", s.Lang, s.Size, s.Class, s.Position)
 	}
+	if s.Profile.ArenaBytesAllocated < 0 || s.Profile.ScratchBytesAllocated < 0 ||
+		s.Profile.EntryScratchBytesAllocated < 0 || s.Profile.GSSBytesAllocated < 0 {
+		t.Fatalf("%s/%s/%s/%s: negative memory counter: arena=%d scratch=%d entry=%d gss=%d",
+			s.Lang, s.Size, s.Class, s.Position, s.Profile.ArenaBytesAllocated,
+			s.Profile.ScratchBytesAllocated, s.Profile.EntryScratchBytesAllocated, s.Profile.GSSBytesAllocated)
+	}
+	if s.Profile.SingleStackIterations < 0 || s.Profile.MultiStackIterations < 0 || s.Profile.MaxStacksSeen < 0 {
+		t.Fatalf("%s/%s/%s/%s: negative causal-work counter: single=%d multi=%d maxStacks=%d",
+			s.Lang, s.Size, s.Class, s.Position, s.Profile.SingleStackIterations,
+			s.Profile.MultiStackIterations, s.Profile.MaxStacksSeen)
+	}
+	if (s.Profile.AcceptedErrorRetryAttempts == 0) != (s.Profile.AcceptedErrorRetryCause == gts.IncrementalRetryCauseNone) ||
+		(s.Profile.AcceptedErrorRetryAdopted && s.Profile.AcceptedErrorRetryAttempts == 0) {
+		t.Fatalf("%s/%s/%s/%s: inconsistent retry causality: attempts=%d adopted=%v cause=%v",
+			s.Lang, s.Size, s.Class, s.Position, s.Profile.AcceptedErrorRetryAttempts,
+			s.Profile.AcceptedErrorRetryAdopted, s.Profile.AcceptedErrorRetryCause)
+	}
+	if s.Profile.ExpectedEOFByte != uint32(s.EditedLen) {
+		t.Fatalf("%s/%s/%s/%s: profile expectedEOF=%d, want editedLen=%d",
+			s.Lang, s.Size, s.Class, s.Position, s.Profile.ExpectedEOFByte, s.EditedLen)
+	}
+	if s.FreshRuntime.ExpectedEOFByte != uint32(s.EditedLen) || s.FreshRuntime.RootEndByte != uint32(s.EditedLen) {
+		t.Fatalf("%s/%s/%s/%s: fresh runtime span mismatch: expectedEOF=%d rootEnd=%d editedLen=%d",
+			s.Lang, s.Size, s.Class, s.Position, s.FreshRuntime.ExpectedEOFByte,
+			s.FreshRuntime.RootEndByte, s.EditedLen)
+	}
 	if s.Profile.ReuseRejectFragileNonLeaf > 0 {
-		// Rejections here are a correctness feature (see
-		// IncrementalParseProfile.ReuseRejectFragileNonLeaf's doc comment),
-		// never a hard failure -- this gate's fixtures are all deliberately
-		// unambiguous, so a nonzero count here is still logged for
-		// visibility rather than silently ignored.
-		t.Logf("%s/%s/%s/%s: ReuseRejectFragileNonLeaf=%d on a fixture expected to be unambiguous (not a failure, but worth investigating)",
+		t.Logf("%s/%s/%s/%s: ReuseRejectFragileNonLeaf=%d (correctness rejection; observable, not a failure)",
 			s.Lang, s.Size, s.Class, s.Position, s.Profile.ReuseRejectFragileNonLeaf)
 	}
+}
+
+// w5Check applies the clean-edit reuse ratchets after the common contract.
+func w5Check(t *testing.T, s w5Sample) {
+	t.Helper()
+	w5CheckCommon(t, s)
+	w5CheckMemoryAllocation(t, s)
 
 	ceiling, ok := w5Ceilings[s.Lang]
 	if !ok {
@@ -620,20 +733,79 @@ func w5Check(t *testing.T, s w5Sample) {
 			s.Lang, s.Size, s.Class, s.Position, rate, minReuse, s.Profile.ReusedBytes, s.EditedLen)
 	}
 
-	t.Logf("%s/%s/%s/%s: rootNonLeafChanged=%d reusedBytes=%d byteReuse=%.1f%% newNodes=%d tokensConsumed=%d incrWall=%s freshWall=%s",
+	t.Logf("%s/%s/%s/%s: rootNonLeafChanged=%d reusedBytes=%d byteReuse=%.1f%% newNodes=%d tokensConsumed=%d singleIters=%d multiIters=%d recoverChecks=%d retries=%d maxStacks=%d arenaBytes=%d scratchBytes=%d freshNodes=%d freshArenaBytes=%d freshScratchBytes=%d incrWall=%s freshWall=%s",
 		s.Lang, s.Size, s.Class, s.Position,
 		s.Profile.ReuseRejectRootNonLeafChanged, s.Profile.ReusedBytes, rate, s.Profile.NewNodesAllocated,
-		s.Profile.TokensConsumed, time.Duration(s.IncrWallNs), time.Duration(s.FreshWallNs))
+		s.Profile.TokensConsumed, s.Profile.SingleStackIterations, s.Profile.MultiStackIterations,
+		s.Profile.RecoverStateChecks, s.Profile.AcceptedErrorRetryAttempts, s.Profile.MaxStacksSeen,
+		s.Profile.ArenaBytesAllocated, s.Profile.ScratchBytesAllocated,
+		s.FreshRuntime.NodesAllocated, s.FreshRuntime.ArenaBytesAllocated, s.FreshRuntime.ScratchBytesAllocated,
+		time.Duration(s.IncrWallNs), time.Duration(s.FreshWallNs))
+}
+
+const (
+	// These are deterministic, source-size-scaled work ceilings, deliberately
+	// not wall-clock thresholds. They are the measured 20KB/137KB maxima rounded
+	// upward: about 1.1K nodes, 220 tokens, and 450 parser iterations per KiB.
+	w5TransientMaxNewNodesPerKiB      = 1200
+	w5TransientMaxTokensPerKiB        = 256
+	w5TransientMaxIterationsPerKiB    = 512
+	w5TransientMaxRecoverChecksPerKiB = 64
+	w5TransientMaxRetryAttempts       = 1
+	w5TransientMaxStacks              = 6
+	// The transient lane remains tighter than the general envelope. Warm-process
+	// maxima were <32.7MB, <40.6MB, and <135.4MB at 20KB/137KB/1MiB; these
+	// constants yield approximately 37.0MB, 56.2MB, and 201.5MB respectively.
+	w5TransientMemoryFixedBytes  int64 = 32 << 20
+	w5TransientMemoryPerKiBBytes int64 = 160 << 10
+)
+
+func w5PerKiBCeiling(editedLen int, perKiB uint64) uint64 {
+	kib := uint64((editedLen + 1023) / 1024)
+	return kib * perKiB
+}
+
+// w5CheckTransientErrorWork turns the issue #380 JS/TS error-delete residual
+// into a reproducible linear-work contract. Wall time remains evidence only.
+func w5CheckTransientErrorWork(t *testing.T, s w5Sample) {
+	t.Helper()
+	p := s.Profile
+	iterations := uint64(p.SingleStackIterations + p.MultiStackIterations)
+	checks := []struct {
+		name string
+		got  uint64
+		max  uint64
+	}{
+		{name: "newNodes", got: p.NewNodesAllocated, max: w5PerKiBCeiling(s.EditedLen, w5TransientMaxNewNodesPerKiB)},
+		{name: "tokensConsumed", got: p.TokensConsumed, max: w5PerKiBCeiling(s.EditedLen, w5TransientMaxTokensPerKiB)},
+		{name: "parserIterations", got: iterations, max: w5PerKiBCeiling(s.EditedLen, w5TransientMaxIterationsPerKiB)},
+		{name: "recoverStateChecks", got: p.RecoverStateChecks, max: w5PerKiBCeiling(s.EditedLen, w5TransientMaxRecoverChecksPerKiB)},
+	}
+	for _, check := range checks {
+		if check.got > check.max {
+			t.Fatalf("%s/%s/delete-transient-error/%s: %s=%d exceeds deterministic linear-work ceiling %d",
+				s.Lang, s.Size, s.Position, check.name, check.got, check.max)
+		}
+	}
+	if p.AcceptedErrorRetryAttempts > w5TransientMaxRetryAttempts || p.MaxStacksSeen > w5TransientMaxStacks {
+		t.Fatalf("%s/%s/delete-transient-error/%s: causal bound exceeded: retries=%d/%d maxStacks=%d/%d",
+			s.Lang, s.Size, s.Position, p.AcceptedErrorRetryAttempts, w5TransientMaxRetryAttempts,
+			p.MaxStacksSeen, w5TransientMaxStacks)
+	}
+	kib := int64((s.EditedLen + 1023) / 1024)
+	memory := p.ArenaBytesAllocated + p.ScratchBytesAllocated
+	maxMemory := w5TransientMemoryFixedBytes + kib*w5TransientMemoryPerKiBBytes
+	if memory > maxMemory {
+		t.Fatalf("%s/%s/delete-transient-error/%s: arena+scratch memory=%d exceeds affine ceiling %d",
+			s.Lang, s.Size, s.Position, memory, maxMemory)
+	}
 }
 
 // w5Tiers returns the size tiers this invocation should sweep.
 func w5Tiers() []w5SizeTier {
-	tiers := []w5SizeTier{w5Tier20KB}
-	if w5FullSweep() {
-		tiers = append(tiers, w5Tier137KB)
-		if w5SlowTier() {
-			tiers = append(tiers, w5Tier1MB)
-		}
+	tiers := []w5SizeTier{w5Tier20KB, w5Tier137KB}
+	if w5SlowTier() {
+		tiers = append(tiers, w5Tier1MB)
 	}
 	return tiers
 }
@@ -643,10 +815,9 @@ func w5Tiers() []w5SizeTier {
 // enforces the oracle + counter ceilings on each one. See the file doc
 // comment for design, coverage, and ceiling provenance.
 //
-// The fast (default, ~20KB-only) subset is a single language x class x
-// position sweep -- 4 x 3 x 3 = 36 samples -- and is well under the
-// campaign's ~60s runtime budget for the normal `go test .` run (each
-// sample is a handful of small parses; see the reported PASS time).
+// The default sweep commits both issue #380 reporter sizes: 5 languages x
+// 2 sizes x 3 classes x 3 positions = 90 samples. The 1MB lane remains
+// explicitly opt-in because it is diagnostic rather than presubmit-sized.
 func TestW5EditorLatencyGate(t *testing.T) {
 	classes := []w5EditClass{w5Insert, w5Delete, w5Replace}
 	positions := []w5Position{w5Top, w5Middle, w5Bottom}
@@ -667,6 +838,50 @@ func TestW5EditorLatencyGate(t *testing.T) {
 									w5Check(t, s)
 								})
 							}
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestW5JavaScriptTypeScriptTransientErrorDeleteGate covers the reporter's
+// remaining Tier-B blocker directly: deleting required syntax while typing
+// creates a temporary ERROR tree. This is separate from the valid delete
+// cells above so the normal reuse floors remain meaningful.
+func TestW5JavaScriptTypeScriptTransientErrorDeleteGate(t *testing.T) {
+	positions := []w5Position{w5Top, w5Middle, w5Bottom}
+	for _, spec := range w5Langs {
+		spec := spec
+		if spec.errorMarker == nil {
+			continue
+		}
+		t.Run(spec.name, func(t *testing.T) {
+			for _, tier := range w5Tiers() {
+				tier := tier
+				t.Run(tier.name, func(t *testing.T) {
+					src, itemCount := spec.build(tier.targetSize)
+					sites := w5EditSiteIndices(itemCount)
+					for _, pos := range positions {
+						pos := pos
+						t.Run(pos.String(), func(t *testing.T) {
+							offset := w5LastByteOffset(t, src, spec.errorMarker(sites[pos]))
+							s := w5RunSampleAtOffset(t, spec, tier, w5Delete, pos, src, offset)
+							w5CheckCommon(t, s)
+							w5CheckMemoryAllocation(t, s)
+							if !s.FreshError || !s.IncrError {
+								t.Fatalf("%s/%s/delete-transient-error/%s: fixture did not produce matching ERROR trees (fresh=%v incremental=%v)",
+									s.Lang, s.Size, s.Position, s.FreshError, s.IncrError)
+							}
+							w5CheckTransientErrorWork(t, s)
+							t.Logf("%s/%s/delete-transient-error/%s: newNodes=%d tokensConsumed=%d singleIters=%d multiIters=%d recoverChecks=%d retries=%d maxStacks=%d arenaBytes=%d scratchBytes=%d freshNodes=%d freshArenaBytes=%d freshScratchBytes=%d incrWall=%s freshWall=%s",
+								s.Lang, s.Size, s.Position, s.Profile.NewNodesAllocated, s.Profile.TokensConsumed,
+								s.Profile.SingleStackIterations, s.Profile.MultiStackIterations, s.Profile.RecoverStateChecks,
+								s.Profile.AcceptedErrorRetryAttempts, s.Profile.MaxStacksSeen,
+								s.Profile.ArenaBytesAllocated, s.Profile.ScratchBytesAllocated,
+								s.FreshRuntime.NodesAllocated, s.FreshRuntime.ArenaBytesAllocated, s.FreshRuntime.ScratchBytesAllocated,
+								time.Duration(s.IncrWallNs), time.Duration(s.FreshWallNs))
 						})
 					}
 				})


### PR DESCRIPTION
## What changed

- broaden compact parser admission to 166 of 206 scorecard fixtures while carrying table-state and scanner-quiescence reuse proof
- retain certified collapsed named leaves natively and record compatibility-pass ownership and retirement criteria
- expand the W5 editor gate to Go, JavaScript, TypeScript, Python, and CSS across insert, delete, and replace edits at start, middle, and end
- bound JavaScript and TypeScript transient-error deletes with deterministic work, stack, retry, node, and memory envelopes
- publish and regression-test all 119 external-scanner reuse contracts, including explicit production fallback for SQL, HTML, and Markdown
- replace absolute O(edit) claims with the measured edited-region plus linear coordinate-maintenance model
- finalize the v0.46.0 changelog

## Why

This makes compact admission, incremental-editor behavior, and compatibility cleanup inspectable and ratcheted. It addresses the formal closure criteria in #380 without presenting certified language results as universal.

## Validation

- focused A1 policy, runtime-profile, and SelectedStore Docker gates
- W5 clean and transient-error 20 KiB, 137 KiB, and 1 MiB sweep in Docker; no OOM
- focused external-scanner fallback, Dart bound, runtime-registry, and ownership tests in Docker
- actionlint, Markdown++ lint, JSON validation, and git diff checks
- required CI and the manual full W5 workflow must pass on final SHA 5230b69f before merge and release

## Issue and release handling

Addresses #380. Keep the issue open through merge; close it only after v0.46.0 is published with final-SHA CI and manual W5 evidence.

## Follow-up

Continue compatibility-shim retirement from the ownership registry and improve certified scanner coverage after the talk. Performance beyond the ratcheted correctness and memory band remains ongoing work, not a release gate.