### PR TITLE
fix(parser): require exact collapsed-child ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- **Collapsed named-leaf ownership now covers exact adapted artifacts.**
+  The 23 registered parent/raw-child pairs compile into the native reduction,
+  alias, forest, and compact-materialization policy for exact built-ins as well
+  as true adapted clones retaining the exact-profile receipt and exact named
+  parent/raw-child metadata identities; display-name or pair-level metadata
+  matches do not admit arbitrary custom grammars. Focused adapted
+  incremental/fresh witnesses require exact
+  deep-tree equality and zero safety-net rewrites. The generic pass remains
+  fail-closed for a quantified synthetic lost-identity residual whose live
+  construction provenance is still unknown; no language-specific normalizer
+  was added.
+
 ## [0.46.0] - 2026-07-21
 
 ### Added

--- a/cgo_harness/collapsed_child_occurrence_parity_test.go
+++ b/cgo_harness/collapsed_child_occurrence_parity_test.go
@@ -1,0 +1,130 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type collapsedChildParityRow struct {
+	parent     string
+	child      string
+	childNamed bool
+}
+
+// TestCollapsedChildOccurrenceParity pins the exact C-tree shape for every
+// language represented by the collapsed named-leaf occurrence ledger. The
+// fixtures collectively exercise all 23 registered parent/raw-child pairs;
+// run subtests one language at a time in Docker.
+func TestCollapsedChildOccurrenceParity(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		rows   []collapsedChildParityRow
+	}{
+		{name: "ruby", source: "%w(foo)\n%i(bar)\n", rows: []collapsedChildParityRow{
+			{parent: "bare_string", child: "string_content", childNamed: true},
+			{parent: "bare_symbol", child: "string_content", childNamed: true},
+		}},
+		{name: "kotlin", source: "package a\nimport d.*\n", rows: []collapsedChildParityRow{
+			{parent: "identifier", child: "simple_identifier", childNamed: true},
+		}},
+		{name: "hack", source: "<?hh function f(): void { $a = true; $b = false; $c = null; }\n", rows: []collapsedChildParityRow{
+			{parent: "true", child: "true"}, {parent: "false", child: "false"}, {parent: "null", child: "null"},
+		}},
+		{name: "dart", source: "class A { void f(){ this.f(); } } class B extends A { B(): super(); }\n", rows: []collapsedChildParityRow{
+			{parent: "this", child: "this"}, {parent: "super", child: "super"},
+		}},
+		{name: "elixir", source: "nil\n", rows: []collapsedChildParityRow{{parent: "nil", child: "nil"}}},
+		{name: "apex", source: `trigger T on Account (before insert, before update, before delete, after insert, after update, after delete, after undelete) { System.debug(UserInfo.getUserId()); }
+public class C { public C(){ super(); } void f(Account a, User u) { insert a; delete a; undelete a; upsert a; insert as user a; update as system a; System.runAs(u) { } } }
+`, rows: []collapsedChildParityRow{
+			{parent: "after_delete", child: "after_delete"}, {parent: "after_insert", child: "after_insert"},
+			{parent: "after_undelete", child: "after_undelete"}, {parent: "after_update", child: "after_update"},
+			{parent: "before_delete", child: "before_delete"}, {parent: "before_insert", child: "before_insert"},
+			{parent: "before_update", child: "before_update"}, {parent: "delete", child: "delete"},
+			{parent: "insert", child: "insert"}, {parent: "super", child: "super"},
+			{parent: "system", child: "system"}, {parent: "undelete", child: "undelete"},
+			{parent: "upsert", child: "upsert"}, {parent: "user", child: "user"},
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			runParityCase(t, parityCase{name: test.name}, "collapsed-child-occurrence", source)
+			assertCollapsedChildOccurrenceCensus(t, test.name, source, test.rows)
+		})
+	}
+}
+
+func assertCollapsedChildOccurrenceCensus(t *testing.T, language string, source []byte, rows []collapsedChildParityRow) {
+	t.Helper()
+	goTree, goLang, err := parseWithGo(parityCase{name: language}, source, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLang, err := ParityCLanguage(language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C oracle returned nil tree")
+	}
+	defer cTree.Close()
+
+	for _, row := range rows {
+		goCount := countGoCollapsedChildOccurrences(goTree.RootNode(), goLang, row)
+		cCount := countCCollapsedChildOccurrences(cTree.RootNode(), row)
+		if goCount == 0 || cCount == 0 {
+			t.Fatalf("%s/%s pair occurrence census go=%d c=%d; fixture no longer exercises the ledger row", row.parent, row.child, goCount, cCount)
+		}
+		if goCount != cCount {
+			t.Fatalf("%s/%s pair occurrence census go=%d c=%d", row.parent, row.child, goCount, cCount)
+		}
+	}
+}
+
+func countGoCollapsedChildOccurrences(node *gts.Node, lang *gts.Language, row collapsedChildParityRow) int {
+	if node == nil {
+		return 0
+	}
+	count := 0
+	if node.IsNamed() && node.Type(lang) == row.parent && node.ChildCount() == 1 {
+		child := node.Child(0)
+		if child != nil && child.Type(lang) == row.child && child.IsNamed() == row.childNamed {
+			count++
+		}
+	}
+	for i := 0; i < node.ChildCount(); i++ {
+		count += countGoCollapsedChildOccurrences(node.Child(i), lang, row)
+	}
+	return count
+}
+
+func countCCollapsedChildOccurrences(node *sitter.Node, row collapsedChildParityRow) int {
+	if node == nil {
+		return 0
+	}
+	count := 0
+	if node.IsNamed() && node.Kind() == row.parent && node.ChildCount() == 1 {
+		child := node.Child(0)
+		if child != nil && child.Kind() == row.child && child.IsNamed() == row.childNamed {
+			count++
+		}
+	}
+	for i := uint(0); i < node.ChildCount(); i++ {
+		count += countCCollapsedChildOccurrences(node.Child(i), row)
+	}
+	return count
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -76,12 +76,22 @@ make the exported API surface worse without changing its ownership.
 ## Current progress: collapsed named leaves
 
 All 23 registered collapsed named-leaf rows for the six affected built-in
-languages now produce their child shape natively when an exact SHA-pinned
-runtime profile grants the capability. The generic walk remains live: it is a
-zero-rewrite safety receipt for those certified artifacts and the repair path
-for caller-built, adapted, and other custom languages that do not carry the
-capability. Retirement still requires exact route receipts with zero rewrites
-and a documented decision for custom-language compatibility.
+languages now produce their child shape natively. The occurrence policy is
+admitted by the exact-profile receipt and compiled from exact named parent and
+raw-child metadata identities, so true adapted clones retaining both take the
+same upstream construction path. A display-name or pair-level metadata match
+alone does not admit a caller-built or custom artifact. Focused production,
+compact, forest, and incremental witnesses keep the generic pass at zero
+rewrites on those routes.
+
+The generic walk remains live as fail-closed coverage for childless results
+whose raw child identity has already been lost. Its synthetic residual witness
+is intentionally one rewrite for each of the 23 registered rows, but does not
+identify a live recovery, election, or other construction route. Retirement
+first requires finding and retaining the occurrence at every live provenance,
+followed by exact route receipts (including a nonzero per-pair C-oracle
+occurrence census) and an actual retirement commit recorded in the ownership
+registry.
 
 ## The retained second pass
 

--- a/export_test.go
+++ b/export_test.go
@@ -346,12 +346,12 @@ func ParserRetainsCollapsedChildOccurrenceForTest(p *Parser, parent, child Symbo
 
 // NormalizeCollapsedNamedLeafForTest exercises the legacy safety-net matcher
 // and returns its exact traversal/rewrite counters.
-func NormalizeCollapsedNamedLeafForTest(root *Node, source []byte, lang *Language, parentName, childName string, bySource bool) (visited, rewritten uint64) {
+func NormalizeCollapsedNamedLeafForTest(root *Node, source []byte, lang *Language, parentName, childName string, childNamed, bySource bool) (visited, rewritten uint64) {
 	var counters normalizationPassCounters
 	if bySource {
-		counters = normalizeCollapsedNamedLeafChildrenBySourceWithStats(root, source, lang, parentName, childName)
+		counters = normalizeCollapsedNamedLeafChildrenBySourceAndNamednessWithStats(root, source, lang, parentName, childNamed, childName)
 	} else {
-		counters = normalizeCollapsedNamedLeafChildrenWithStats(root, lang, parentName, childName)
+		counters = normalizeCollapsedNamedLeafChildrenAndNamednessWithStats(root, lang, parentName, childName, childNamed)
 	}
 	return counters.nodesVisited, counters.nodesRewritten
 }

--- a/grammargen/apex_collapsed_child_alias_collision_test.go
+++ b/grammargen/apex_collapsed_child_alias_collision_test.go
@@ -1,0 +1,88 @@
+package grammargen
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+)
+
+// TestGeneratedApexCollapsedChildAliasCollisionDoesNotRecurse covers the real
+// Apex grammar's generated alias surface: every ledger display name is shared
+// by one named wrapper and one anonymous raw token. Exact namedness-aware
+// ownership must select the raw-token pair without recursively wrapping the
+// same-named alias in the generated result.
+func TestGeneratedApexCollapsedChildAliasCollisionDoesNotRecurse(t *testing.T) {
+	const grammarJSON = "/tmp/grammar_parity/apex/apex/src/grammar.json"
+	source, err := os.ReadFile(grammarJSON)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Skipf("Apex grammar checkout unavailable: %s", grammarJSON)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	grammar, err := ImportGrammarJSON(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang, err := GenerateLanguage(grammar)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"after_delete", "after_insert", "after_undelete", "after_update", "before_delete", "before_insert", "before_update", "delete", "insert", "super", "system", "undelete", "upsert", "user"} {
+		named, anonymous := generatedApexSymbolsNamed(lang, name)
+		if named != 1 || anonymous != 1 {
+			t.Fatalf("generated Apex alias-collision inventory %s named=%d anonymous=%d, want 1/1", name, named, anonymous)
+		}
+	}
+
+	tree, err := gts.NewParser(lang).Parse([]byte("public class C { public C(){ super(); } }\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("generated Apex parse returned nil root")
+	}
+	if nodes, depth, ok := boundedGeneratedApexTree(root, 0); !ok {
+		t.Fatalf("generated Apex result exceeded finite alias bound: nodes=%d depth=%d", nodes, depth)
+	}
+}
+
+func generatedApexSymbolsNamed(lang *gts.Language, name string) (named, anonymous int) {
+	for i, symbolName := range lang.SymbolNames {
+		if symbolName != name || i >= len(lang.SymbolMetadata) {
+			continue
+		}
+		if lang.SymbolMetadata[i].Named {
+			named++
+		} else {
+			anonymous++
+		}
+	}
+	return named, anonymous
+}
+
+func boundedGeneratedApexTree(node *gts.Node, depth int) (nodes, maxDepth int, ok bool) {
+	if node == nil {
+		return 0, depth, true
+	}
+	if depth > 512 {
+		return 1, depth, false
+	}
+	nodes, maxDepth = 1, depth
+	for i := 0; i < node.ChildCount(); i++ {
+		childNodes, childDepth, childOK := boundedGeneratedApexTree(node.Child(i), depth+1)
+		nodes += childNodes
+		if childDepth > maxDepth {
+			maxDepth = childDepth
+		}
+		if !childOK || nodes > 1_000_000 {
+			return nodes, maxDepth, false
+		}
+	}
+	return nodes, maxDepth, true
+}

--- a/grammars/collapsed_child_native_regression_test.go
+++ b/grammars/collapsed_child_native_regression_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
 )
 
 func TestCollapsedChildLedgerRealLanguagesNeedNoSafetyNetRewrite(t *testing.T) {
@@ -151,7 +152,76 @@ public class C { public C(){ super(); } void f(Account a, User u) { insert a; de
 				}
 				tree.Release()
 			}
+
+			// A true adapted clone retains the exact built-in profile receipt and
+			// parent/raw-child metadata identities, including after an incremental edit.
+			adapted := *test.lang()
+			adaptedParser := gotreesitter.NewParser(&adapted)
+			adaptedParser.SetAdmissionCandidateRoute(false)
+			oldSource := []byte(test.src)
+			oldTree, err := adaptedParser.Parse(oldSource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertCollapsedChildRouteTree(t, "adapted-production", oldTree, &adapted, test.want)
+
+			nextSource := append(append([]byte(nil), oldSource...), '\n')
+			endPoint := collapsedChildEndPoint(oldSource)
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(oldSource)),
+				OldEndByte:  uint32(len(oldSource)),
+				NewEndByte:  uint32(len(nextSource)),
+				StartPoint:  endPoint,
+				OldEndPoint: endPoint,
+				NewEndPoint: gotreesitter.Point{Row: endPoint.Row + 1},
+			})
+			incremental, _, err := adaptedParser.ParseIncrementalProfiled(nextSource, oldTree)
+			if err != nil {
+				oldTree.Release()
+				t.Fatal(err)
+			}
+			assertCollapsedChildRouteTree(t, "adapted-incremental", incremental, &adapted, test.want)
+			freshParser := gotreesitter.NewParser(&adapted)
+			freshParser.SetAdmissionCandidateRoute(false)
+			fresh, err := freshParser.Parse(nextSource)
+			if err != nil {
+				incremental.Release()
+				oldTree.Release()
+				t.Fatal(err)
+			}
+			assertCollapsedChildDeepTreeEqual(t, incremental, fresh, &adapted)
+			fresh.Release()
+			incremental.Release()
+			oldTree.Release()
 		})
+	}
+}
+
+func collapsedChildEndPoint(source []byte) gotreesitter.Point {
+	var point gotreesitter.Point
+	for _, b := range source {
+		if b == '\n' {
+			point.Row++
+			point.Column = 0
+			continue
+		}
+		point.Column++
+	}
+	return point
+}
+
+func assertCollapsedChildDeepTreeEqual(t *testing.T, incremental, fresh *gotreesitter.Tree, lang *gotreesitter.Language) {
+	t.Helper()
+	incrementalInspection, err := benchfixtures.InspectGoTree(incremental.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshInspection, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incrementalInspection.SHA256 != freshInspection.SHA256 {
+		t.Fatalf("adapted incremental/fresh deep tree mismatch: incremental=%s fresh=%s", incrementalInspection.SHA256, freshInspection.SHA256)
 	}
 }
 
@@ -178,8 +248,16 @@ func assertCollapsedChildRouteTree(t *testing.T, route string, tree *gotreesitte
 		if runtime.NormalizationPassesChecked != 0 || runtime.NormalizationPassesRun != 0 || runtime.NormalizationNodesVisited != 0 || runtime.NormalizationNodesRewritten != 0 {
 			t.Fatalf("%s normalization checked/run/visited/rewritten=%d/%d/%d/%d", route, runtime.NormalizationPassesChecked, runtime.NormalizationPassesRun, runtime.NormalizationNodesVisited, runtime.NormalizationNodesRewritten)
 		}
-	} else if runtime.NormalizationPassesChecked == 0 || runtime.NormalizationPassesRun == 0 || runtime.NormalizationNodesVisited == 0 || runtime.NormalizationNodesRewritten != 0 {
-		t.Fatalf("%s normalization checked/run/visited/rewritten=%d/%d/%d/%d", route, runtime.NormalizationPassesChecked, runtime.NormalizationPassesRun, runtime.NormalizationNodesVisited, runtime.NormalizationNodesRewritten)
+	} else {
+		if runtime.NormalizationPassesChecked == 0 || runtime.NormalizationPassesRun == 0 ||
+			runtime.NormalizationNodesVisited == 0 || runtime.NormalizationNodesRewritten != 0 {
+			t.Fatalf("%s normalization checked/run/visited/rewritten=%d/%d/%d/%d", route,
+				runtime.NormalizationPassesChecked, runtime.NormalizationPassesRun,
+				runtime.NormalizationNodesVisited, runtime.NormalizationNodesRewritten)
+		}
+		if pass, ok := collapsedChildNormalizationPass(runtime); ok && pass.NodesRewritten != 0 {
+			t.Fatalf("%s collapsed-child pass rewrote nodes: %+v", route, pass)
+		}
 	}
 	for parentType, want := range wants {
 		parents := collapsedChildRegressionNodes(root, lang, parentType)
@@ -196,6 +274,18 @@ func assertCollapsedChildRouteTree(t *testing.T, route string, tree *gotreesitte
 			}
 		}
 	}
+}
+
+func collapsedChildNormalizationPass(runtime gotreesitter.ParseRuntime) (gotreesitter.NormalizationPassRuntime, bool) {
+	if runtime.NormalizationPasses == nil {
+		return gotreesitter.NormalizationPassRuntime{}, false
+	}
+	for _, pass := range *runtime.NormalizationPasses {
+		if pass.Name == "collapsed_named_leaf_children" {
+			return pass, true
+		}
+	}
+	return gotreesitter.NormalizationPassRuntime{}, false
 }
 
 func collapsedChildRegressionNodes(root *gotreesitter.Node, lang *gotreesitter.Language, typ string) []*gotreesitter.Node {

--- a/language.go
+++ b/language.go
@@ -359,10 +359,12 @@ const (
 	ResultCompatibilityCSharpNativeScopedLambdaStatements ResultCompatibilityCapability = 1 << 2
 	ResultCompatibilityCSharpNativeScopedLambdaBlocks     ResultCompatibilityCapability = 1 << 3
 	ResultCompatibilityCSharpNativeQueryExpressions       ResultCompatibilityCapability = 1 << 4
-	// ResultCompatibilityNativeCollapsedChildren certifies that the exact
-	// SHA-pinned built-in artifact may use the compiled native retention policy
-	// for collapsed-child compatibility rows. Same-name caller-built and adapted
-	// languages retain the zero value and stay on the legacy post-pass path.
+	// ResultCompatibilityNativeCollapsedChildren records the v0.46 exact-profile
+	// certification receipt for collapsed-child rows. It admits exact built-ins
+	// and true adapted clones; native retention then keys off exact registered
+	// parent/raw-child metadata identities. A matching display name or pair-level
+	// metadata alone is insufficient. Keep the bit append-only because Language
+	// blobs encode capability values.
 	ResultCompatibilityNativeCollapsedChildren ResultCompatibilityCapability = 1 << 5
 )
 

--- a/parser_collapsed_child_policy.go
+++ b/parser_collapsed_child_policy.go
@@ -2,7 +2,9 @@ package gotreesitter
 
 // collapsedChildSymbolPair is one exact public-wrapper/raw-child identity that
 // C tree-sitter retains as a unary node. The policy is compiled once per Parser
-// only after the exact SHA-pinned built-in runtime profile authenticates it.
+// from the registered occurrence ledger after an exact runtime profile admits
+// the artifact. Within that profile, exact named parent and raw-child metadata
+// identities select the occurrence; display-name fallback is never sufficient.
 type collapsedChildSymbolPair struct {
 	parent Symbol
 	child  Symbol
@@ -24,15 +26,9 @@ func compileCollapsedChildOccurrencePolicy(lang *Language) ([]collapsedChildSymb
 		}
 		parent, ok := lang.symbolByNameAndNamed(rule.parentName, true)
 		if !ok {
-			parent, ok = symbolByName(lang, rule.parentName)
-		}
-		if !ok {
 			continue
 		}
-		child, ok := lang.symbolByNameAndNamed(rule.childName, false)
-		if !ok {
-			child, ok = symbolByName(lang, rule.childName)
-		}
+		child, ok := lang.symbolByNameAndNamed(rule.childName, rule.childNamed)
 		if !ok {
 			continue
 		}
@@ -50,7 +46,7 @@ func compileCollapsedChildOccurrencePolicy(lang *Language) ([]collapsedChildSymb
 }
 
 // retainsCollapsedChildOccurrence is the single native keep/wrap decision.
-// Its authenticated (parent, raw-child) domain is strictly narrower than the
+// Its registered (parent, raw-child) domain is strictly narrower than the
 // legacy safety net, which may repair a collapsed parent leaf (and, for some
 // rows, verify source text) after the raw child identity has been lost.
 func (p *Parser) retainsCollapsedChildOccurrence(parent, rawChild Symbol) bool {

--- a/parser_collapsed_child_policy_external_test.go
+++ b/parser_collapsed_child_policy_external_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-type collapsedChildStrictSubsetRow struct {
+type collapsedChildOccurrenceRow struct {
 	language   string
 	load       func() *gotreesitter.Language
 	parent     string
@@ -16,8 +16,8 @@ type collapsedChildStrictSubsetRow struct {
 	bySource   bool
 }
 
-func TestCollapsedChildNativePolicyIsStrictSubsetOfLegacyRepair(t *testing.T) {
-	rows := []collapsedChildStrictSubsetRow{
+func TestCollapsedChildOccurrencePolicyCoversExactAndAdaptedArtifacts(t *testing.T) {
+	rows := []collapsedChildOccurrenceRow{
 		{language: "ruby", load: grammars.RubyLanguage, parent: "bare_string", child: "string_content", childNamed: true},
 		{language: "ruby", load: grammars.RubyLanguage, parent: "bare_symbol", child: "string_content", childNamed: true},
 		{language: "apex", load: grammars.ApexLanguage, parent: "after_delete", child: "after_delete"},
@@ -43,8 +43,9 @@ func TestCollapsedChildNativePolicyIsStrictSubsetOfLegacyRepair(t *testing.T) {
 		{language: "elixir", load: grammars.ElixirLanguage, parent: "nil", child: "nil", bySource: true},
 	}
 	if len(rows) != 23 {
-		t.Fatalf("strict-subset rows=%d, want 23", len(rows))
+		t.Fatalf("collapsed-child occurrence rows=%d, want 23", len(rows))
 	}
+	var residualRewrites uint64
 	for _, row := range rows {
 		row := row
 		t.Run(row.language+"/"+row.parent, func(t *testing.T) {
@@ -57,13 +58,24 @@ func TestCollapsedChildNativePolicyIsStrictSubsetOfLegacyRepair(t *testing.T) {
 			if !parentOK || !childOK {
 				t.Fatalf("could not resolve exact pair %s/%s", row.parent, row.child)
 			}
-			parser := gotreesitter.NewParser(lang)
-			if !gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, child) {
-				t.Fatal("native predicate rejected exact authenticated pair")
-			}
-			if gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, 0) ||
-				gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, 0, child) {
-				t.Fatal("native predicate accepted a parent/raw-child mismatch")
+			// A true adapted clone retains the exact built-in profile receipt and
+			// symbol table; display-name-compatible caller artifacts are not covered.
+			adapted := *lang
+			for _, artifact := range []struct {
+				name string
+				lang *gotreesitter.Language
+			}{
+				{name: "exact", lang: lang},
+				{name: "adapted", lang: &adapted},
+			} {
+				parser := gotreesitter.NewParser(artifact.lang)
+				if !gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, child) {
+					t.Fatalf("%s occurrence policy rejected registered pair", artifact.name)
+				}
+				if gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, 0) ||
+					gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, 0, child) {
+					t.Fatalf("%s occurrence policy accepted a parent/raw-child mismatch", artifact.name)
+				}
 			}
 
 			if row.bySource {
@@ -75,23 +87,31 @@ func TestCollapsedChildNativePolicyIsStrictSubsetOfLegacyRepair(t *testing.T) {
 
 			end := uint32(len(row.child))
 			collapsed := gotreesitter.NewLeafNode(parent, true, 0, end, gotreesitter.Point{}, gotreesitter.Point{Column: end})
+			// A caller can still hand the compatibility matcher a childless result
+			// after raw occurrence identity has already been lost. This quantifies
+			// the residual but does not establish whether recovery, election, or
+			// another live construction route produced it; provenance stays unknown.
 			visited, rewritten := gotreesitter.NormalizeCollapsedNamedLeafForTest(
-				collapsed, []byte(row.child), lang, row.parent, row.child, row.bySource,
+				collapsed, []byte(row.child), lang, row.parent, row.child, row.childNamed, row.bySource,
 			)
 			if visited == 0 || rewritten != 1 || collapsed.ChildCount() != 1 ||
 				collapsed.Child(0).Symbol() != child || collapsed.Child(0).IsNamed() != row.childNamed {
 				t.Fatalf("legacy repair visited=%d rewritten=%d shape=%s", visited, rewritten, collapsed.SExpr(lang))
 			}
+			residualRewrites += rewritten
 			if row.bySource {
 				wrongSource := gotreesitter.NewLeafNode(parent, true, 0, end, gotreesitter.Point{}, gotreesitter.Point{Column: end})
 				_, rewritten = gotreesitter.NormalizeCollapsedNamedLeafForTest(
-					wrongSource, []byte("xxxxxx")[:len(row.child)], lang, row.parent, row.child, true,
+					wrongSource, []byte("xxxxxx")[:len(row.child)], lang, row.parent, row.child, row.childNamed, true,
 				)
 				if rewritten != 0 || wrongSource.ChildCount() != 0 {
 					t.Fatal("source-verified legacy repair accepted a different literal")
 				}
 			}
 		})
+	}
+	if residualRewrites != uint64(len(rows)) {
+		t.Fatalf("synthetic lost-identity residual rewrites=%d, want %d", residualRewrites, len(rows))
 	}
 }
 

--- a/parser_collapsed_child_policy_external_test.go
+++ b/parser_collapsed_child_policy_external_test.go
@@ -60,13 +60,19 @@ func TestCollapsedChildOccurrencePolicyCoversExactAndAdaptedArtifacts(t *testing
 			}
 			// A true adapted clone retains the exact built-in profile receipt and
 			// symbol table; display-name-compatible caller artifacts are not covered.
-			adapted := *lang
+			adapted := &gotreesitter.Language{
+				Name:                      lang.Name,
+				TokenCount:                lang.TokenCount,
+				NativeResultCompatibility: lang.NativeResultCompatibility,
+				SymbolNames:               lang.SymbolNames,
+				SymbolMetadata:            lang.SymbolMetadata,
+			}
 			for _, artifact := range []struct {
 				name string
 				lang *gotreesitter.Language
 			}{
 				{name: "exact", lang: lang},
-				{name: "adapted", lang: &adapted},
+				{name: "adapted", lang: adapted},
 			} {
 				parser := gotreesitter.NewParser(artifact.lang)
 				if !gotreesitter.ParserRetainsCollapsedChildOccurrenceForTest(parser, parent, child) {

--- a/parser_collapsed_child_policy_test.go
+++ b/parser_collapsed_child_policy_test.go
@@ -3,7 +3,6 @@ package gotreesitter
 import "testing"
 
 func collapsedChildPolicyTestLanguage(rule collapsedNamedLeafRule) (*Language, Symbol, Symbol) {
-	childNamed := rule.languageName == "ruby" || rule.languageName == "kotlin"
 	lang := &Language{
 		Name:                      rule.languageName,
 		TokenCount:                4,
@@ -13,7 +12,7 @@ func collapsedChildPolicyTestLanguage(rule collapsedNamedLeafRule) (*Language, S
 			{Name: "EOF"},
 			{Name: "root", Visible: true, Named: true},
 			{Name: rule.parentName, Visible: true, Named: true},
-			{Name: rule.childName, Visible: true, Named: childNamed},
+			{Name: rule.childName, Visible: true, Named: rule.childNamed},
 		},
 	}
 	return lang, 2, 3
@@ -73,31 +72,8 @@ func TestCollapsedChildOccurrencePolicyNativelyRetainsAllLedgerRows(t *testing.T
 			if parent.ChildCount() != 1 || parent.Child(0).symbol != childSymbol {
 				t.Fatalf("native shape parent=%d children=%d child=%v", parent.symbol, parent.ChildCount(), parent.Child(0))
 			}
-			parser.resetNormalizationStats()
-			parser.materializationTiming = &parseMaterializationTiming{}
-			parser.runNamedNormalizationPass("collapsed_named_leaf_children", func() bool { return true }, func() normalizationPassCounters {
-				return normalizeResultCollapsedNamedLeafChildren(parent, []byte(rule.childName), lang)
-			})
-			var runtime ParseRuntime
-			parser.copyNormalizationStats(&runtime)
-			pass, ok := normalizationRuntimePass(runtime, "collapsed_named_leaf_children")
-			if !ok || pass.Checked != 1 || pass.Run != 1 || pass.NodesVisited == 0 || pass.NodesRewritten != 0 {
-				t.Fatalf("native safety-net pass=%+v found=%t runtime=%+v", pass, ok, runtime)
-			}
 		})
 	}
-}
-
-func normalizationRuntimePass(runtime ParseRuntime, name string) (NormalizationPassRuntime, bool) {
-	if runtime.NormalizationPasses == nil {
-		return NormalizationPassRuntime{}, false
-	}
-	for _, pass := range *runtime.NormalizationPasses {
-		if pass.Name == name {
-			return pass, true
-		}
-	}
-	return NormalizationPassRuntime{}, false
 }
 
 func TestCollapsedChildOccurrencePolicyNegativeControls(t *testing.T) {
@@ -138,7 +114,7 @@ func TestCollapsedChildOccurrencePolicyNegativeControls(t *testing.T) {
 	})
 
 	t.Run("inherited-field-is-not-promoted-to-direct", func(t *testing.T) {
-		rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content"}
+		rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content", childNamed: true}
 		lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
 		lang.FieldMapSlices = [][2]uint16{{0, 1}}
 		lang.FieldMapEntries = []FieldMapEntry{{FieldID: 1, ChildIndex: 0, Inherited: true}}
@@ -169,7 +145,7 @@ func TestCollapsedChildOccurrencePolicyNegativeControls(t *testing.T) {
 		{name: "error", mark: func(n *Node) { n.setHasError(true) }, check: func(n *Node) bool { return n.hasError() }},
 	} {
 		t.Run("flagged-alias-fails-closed-"+test.name, func(t *testing.T) {
-			rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content"}
+			rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content", childNamed: true}
 			lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
 			lang.AliasSequences = [][]Symbol{{parentSymbol}}
 			parser := NewParser(lang)
@@ -189,7 +165,7 @@ func TestCollapsedChildOccurrencePolicyNegativeControls(t *testing.T) {
 	}
 
 	t.Run("extra-skips-aliasing-on-live-child-build-path", func(t *testing.T) {
-		rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content"}
+		rule := collapsedNamedLeafRule{languageName: "ruby", parentName: "bare_string", childName: "string_content", childNamed: true}
 		lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
 		lang.AliasSequences = [][]Symbol{{parentSymbol}}
 		parser := NewParser(lang)
@@ -204,27 +180,57 @@ func TestCollapsedChildOccurrencePolicyNegativeControls(t *testing.T) {
 		}
 	})
 
-	t.Run("same-name-custom-artifacts-stay-on-safety-net", func(t *testing.T) {
+	t.Run("uncertified-exact-metadata-identities-do-not-opt-in", func(t *testing.T) {
 		for _, rule := range []collapsedNamedLeafRule{
 			{languageName: "apex", parentName: "super", childName: "super"},
-			{languageName: "ruby", parentName: "bare_string", childName: "string_content"},
+			{languageName: "ruby", parentName: "bare_string", childName: "string_content", childNamed: true},
 		} {
 			lang, parentSymbol, childSymbol := collapsedChildPolicyTestLanguage(rule)
 			lang.NativeResultCompatibility = 0
 			parser := NewParser(lang)
 			if parser.retainsCollapsedChildOccurrence(parentSymbol, childSymbol) {
-				t.Fatalf("same-name custom %s artifact compiled native policy", rule.languageName)
+				t.Fatalf("uncertified exact-metadata %s artifact compiled native policy", rule.languageName)
 			}
-			arena := newNodeArena(arenaClassFull)
-			leaf := newLeafNodeInArena(arena, childSymbol, symbolIsNamed(lang, childSymbol), 0, 5, Point{}, Point{Column: 5})
-			collapsed := aliasedNodeInArena(arena, lang, leaf, parentSymbol)
-			if collapsed.ChildCount() != 0 {
-				t.Fatal("legacy custom path unexpectedly retained child")
-			}
-			stats := normalizeCollapsedNamedLeafChildrenWithStats(collapsed, lang, rule.parentName, rule.childName)
-			if stats.nodesRewritten != 1 || collapsed.ChildCount() != 1 || collapsed.Child(0).symbol != childSymbol {
-				t.Fatalf("custom safety-net stats=%+v shape=%s", stats, collapsed.SExpr(lang))
-			}
+		}
+	})
+
+	t.Run("registered-name-with-wrong-child-namedness-does-not-opt-in", func(t *testing.T) {
+		lang := &Language{
+			Name:                      "apex",
+			TokenCount:                4,
+			NativeResultCompatibility: ResultCompatibilityNativeCollapsedChildren,
+			SymbolNames:               []string{"EOF", "root", "super", "super"},
+			SymbolMetadata: []SymbolMetadata{
+				{Name: "EOF"}, {Name: "root", Visible: true, Named: true},
+				{Name: "super", Visible: true, Named: true},
+				{Name: "super", Visible: true, Named: true},
+			},
+		}
+		parser := NewParser(lang)
+		if parser.retainsCollapsedChildOccurrence(2, 3) || parser.retainsCollapsedChildOccurrence(2, 2) {
+			t.Fatal("named alias collision compiled anonymous-child ownership")
+		}
+		arena := newNodeArena(arenaClassFull)
+		collapsed := newLeafNodeInArena(arena, 2, true, 0, 5, Point{}, Point{Column: 5})
+		stats := normalizeResultCollapsedNamedLeafChildren(collapsed, []byte("super"), lang)
+		if stats.nodesRewritten != 0 || collapsed.ChildCount() != 0 {
+			t.Fatalf("named alias collision entered anonymous safety net: stats=%+v shape=%s", stats, collapsed.SExpr(lang))
+		}
+	})
+
+	t.Run("unregistered-custom-artifact-does-not-opt-in", func(t *testing.T) {
+		lang := &Language{
+			Name:        "custom",
+			TokenCount:  4,
+			SymbolNames: []string{"EOF", "root", "super", "super"},
+			SymbolMetadata: []SymbolMetadata{
+				{Name: "EOF"}, {Name: "root", Visible: true, Named: true},
+				{Name: "super", Visible: true, Named: true}, {Name: "super", Visible: true},
+			},
+		}
+		parser := NewParser(lang)
+		if parser.retainsCollapsedChildOccurrence(2, 3) {
+			t.Fatal("unregistered custom language compiled collapsed-child policy")
 		}
 	})
 }

--- a/parser_result_collapsed_helpers.go
+++ b/parser_result_collapsed_helpers.go
@@ -16,6 +16,11 @@ type collapsedNamedLeafRule struct {
 	languageName string
 	parentName   string
 	childName    string
+	// childNamed is part of the raw occurrence identity. Ruby and Kotlin keep
+	// named grammar children; the keyword-wrapper rows keep anonymous tokens.
+	// Ownership admission must not fall back across this boundary because a
+	// generated alias may expose the same display name with different metadata.
+	childNamed bool
 	// bySource selects the source-verified matcher
 	// (normalizeCollapsedNamedLeafChildrenBySource) instead of the plain
 	// structural matcher (normalizeCollapsedNamedLeafChildren). Use this when
@@ -31,8 +36,8 @@ var resultCollapsedNamedLeafRules = []collapsedNamedLeafRule{
 	// into a leaf; C keeps the single named string_content child over the same
 	// span. Only fires when Go's node has zero children (i.e. no escapes /
 	// interpolation, which would already materialize children in both trees).
-	{languageName: "ruby", parentName: "bare_string", childName: "string_content"},
-	{languageName: "ruby", parentName: "bare_symbol", childName: "string_content"},
+	{languageName: "ruby", parentName: "bare_string", childName: "string_content", childNamed: true},
+	{languageName: "ruby", parentName: "bare_symbol", childName: "string_content", childNamed: true},
 	// Apex wraps its contextual / DML / trigger-event keywords as a named node
 	// over the anonymous keyword token (`keyword -> 'keyword'`). Go collapses
 	// these single-token wrappers to a leaf; C keeps the anonymous token child.
@@ -55,7 +60,7 @@ var resultCollapsedNamedLeafRules = []collapsedNamedLeafRule{
 	// Kotlin's `identifier` is sep1 of `simple_identifier` by "."; a
 	// single-element identifier (e.g. `import benchmarks.*`) collapses to a
 	// leaf in Go but C always materializes the simple_identifier child.
-	{languageName: "kotlin", parentName: "identifier", childName: "simple_identifier"},
+	{languageName: "kotlin", parentName: "identifier", childName: "simple_identifier", childNamed: true},
 	// Hack's true/false/null literals wrap the identically-named anonymous
 	// keyword token (`true -> 'true'`, etc.); Go collapses the lone child.
 	{languageName: "hack", parentName: "true", childName: "true", bySource: true},
@@ -79,12 +84,12 @@ func normalizeResultCollapsedNamedLeafChildren(root *Node, source []byte, lang *
 			continue
 		}
 		if rule.bySource {
-			stats := normalizeCollapsedNamedLeafChildrenBySourceWithStats(root, source, lang, rule.parentName, rule.childName)
+			stats := normalizeCollapsedNamedLeafChildrenBySourceAndNamednessWithStats(root, source, lang, rule.parentName, rule.childNamed, rule.childName)
 			total.nodesVisited += stats.nodesVisited
 			total.nodesRewritten += stats.nodesRewritten
 			continue
 		}
-		stats := normalizeCollapsedNamedLeafChildrenWithStats(root, lang, rule.parentName, rule.childName)
+		stats := normalizeCollapsedNamedLeafChildrenAndNamednessWithStats(root, lang, rule.parentName, rule.childName, rule.childNamed)
 		total.nodesVisited += stats.nodesVisited
 		total.nodesRewritten += stats.nodesRewritten
 	}
@@ -92,25 +97,22 @@ func normalizeResultCollapsedNamedLeafChildren(root *Node, source []byte, lang *
 }
 
 func normalizeCollapsedNamedLeafChildrenWithStats(root *Node, lang *Language, parentName, childName string) normalizationPassCounters {
+	return normalizeCollapsedNamedLeafChildrenAndNamednessWithStats(root, lang, parentName, childName, false)
+}
+
+func normalizeCollapsedNamedLeafChildrenAndNamednessWithStats(root *Node, lang *Language, parentName, childName string, childNamed bool) normalizationPassCounters {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil {
 		return counters
 	}
 	parentSym, ok := lang.symbolByNameAndNamed(parentName, true)
 	if !ok {
-		parentSym, ok = symbolByName(lang, parentName)
-	}
-	if !ok {
 		return counters
 	}
-	childSym, childOk := lang.symbolByNameAndNamed(childName, false)
+	childSym, childOk := lang.symbolByNameAndNamed(childName, childNamed)
 	if !childOk {
-		childSym, childOk = symbolByName(lang, childName)
-		if !childOk {
-			return counters
-		}
+		return counters
 	}
-	childNamed := symbolIsNamed(lang, childSym)
 	if lang.Name == "rust" {
 		walkResultTreeSidecarFirst(root, func(n *Node) {
 			counters.nodesVisited++
@@ -140,26 +142,24 @@ func normalizeCollapsedNamedLeafChildrenWithStats(root *Node, lang *Language, pa
 }
 
 func normalizeCollapsedNamedLeafChildrenBySourceWithStats(root *Node, source []byte, lang *Language, parentName string, childNames ...string) normalizationPassCounters {
+	return normalizeCollapsedNamedLeafChildrenBySourceAndNamednessWithStats(root, source, lang, parentName, false, childNames...)
+}
+
+func normalizeCollapsedNamedLeafChildrenBySourceAndNamednessWithStats(root *Node, source []byte, lang *Language, parentName string, expectedChildNamed bool, childNames ...string) normalizationPassCounters {
 	var counters normalizationPassCounters
 	if root == nil || lang == nil || len(source) == 0 || len(childNames) == 0 {
 		return counters
 	}
 	parentSym, ok := lang.symbolByNameAndNamed(parentName, true)
 	if !ok {
-		parentSym, ok = symbolByName(lang, parentName)
-	}
-	if !ok {
 		return counters
 	}
 	childSyms := make(map[string]Symbol, len(childNames))
 	childNamed := make(map[Symbol]bool, len(childNames))
 	for _, childName := range childNames {
-		childSym, ok := lang.symbolByNameAndNamed(childName, false)
+		childSym, ok := lang.symbolByNameAndNamed(childName, expectedChildNamed)
 		if !ok {
-			childSym, ok = symbolByName(lang, childName)
-			if !ok {
-				continue
-			}
+			continue
 		}
 		childSyms[childName] = childSym
 		childNamed[childSym] = symbolIsNamed(lang, childSym)

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -2319,16 +2319,17 @@
       "languages": [
         "*"
       ],
-      "purpose": "Retain generic collapsed named-leaf child compatibility as a safety net for uncertified and custom languages and as a zero-rewrite receipt for exact-profile built-ins that now produce the shape natively.",
+      "purpose": "Retain fail-closed collapsed named-leaf repair for childless results after raw child identity is lost; exact-profile built-ins and true adapted clones retaining the exact-profile receipt plus exact parent/raw-child metadata identities now retain registered occurrences natively. The synthetic residual's live construction provenance is unknown.",
       "authoritative_owner": "materialization",
       "witnesses": [
         "parser_result_collapsed_helpers_test.go",
         "parser_collapsed_child_policy_test.go",
         "parser_collapsed_child_policy_external_test.go",
+        "cgo_harness/collapsed_child_occurrence_parity_test.go",
         "grammars/collapsed_child_native_regression_test.go",
         "internal/parsercorephase0/selected_store_test.go"
       ],
-      "retirement_condition": "Delete only after materialization emits the same tree natively with zero rewrites for every registered witness, production, compact, forest, incremental, and C-oracle route receipts are exact, and the compatibility policy for caller-built, adapted, and other custom languages is explicitly documented.",
+      "retirement_condition": "Delete only after every live provenance for the 23 quantified synthetic residual rows is identified and preserves raw child identity upstream, every registered exact built-in and exact-profile adapted witness reports zero rewrites, production, compact, forest, and incremental route receipts are exact, the C oracle reports a nonzero equal occurrence census for every pair, and the retirement commit is recorded.",
       "route_coverage": {
         "production": "shared_result_compatibility_tail",
         "compact": "shared_result_compatibility_tail",


### PR DESCRIPTION
## What does this PR do?

Moves collapsed named-leaf ownership into the native parser for the 23 certified language/pair rows using exact profile and namedness-aware symbol identity. It also narrows the retained compatibility fallback so display-name collisions cannot recurse or manufacture children under the wrong symbol.

Advances #431; it intentionally does not close it. The generic traversal remains live until real rewrite provenance is discovered and every residual route has an ownership proof.

## Why this approach?

Exact identity is the smallest safe ownership boundary. Same language names or display-name matches are insufficient for caller-built grammars and can alias a named wrapper to its anonymous token.

## Correctness

- [x] Focused package or unit tests ran for the touched behavior
- [x] Affected parity validation ran in Docker, one language or grammar at a time
- [x] If grammargen or parity logic changed, ran the smallest relevant focus target in Docker
- [x] Documented anything intentionally left unvalidated in this PR

Evidence:

- Focused root and grammar gate: `20260722T082418Z`
- Exact C parity plus nonzero occurrence census: Ruby `082447Z`, Kotlin `082501Z`, Hack `082509Z`, Dart `082516Z`, Elixir `082521Z`, Apex `082525Z`
- Generated Apex named/anonymous alias-collision finite-parse regression: `20260722T082543Z`
- Independent second review repeated core routes, compact contract, all six C censuses, and the Apex recursion witness; no blocking findings

The generated-Apex regression skips when its pinned external grammar checkout is unavailable; direct self-contained negative controls still cover wrong namedness and uncertified/custom artifacts.

## Performance

- [ ] If perf-relevant, used the stable bench settings (`GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, `-benchmem`)
- [x] Included before and after numbers, or explicitly said perf is not the goal of this PR
- [x] If large-grammar behavior changed, checked bounded RSS, timeout, or OOM behavior under Docker

Performance is not the goal of this correctness/ownership slice. Docker parity completed without OOM.

## Maintainability

- [x] No unnecessary abstractions or speculative cleanup outside the PR's scope
- [x] Generated files or harness changes are only here because they are required by the change
- [x] No new dependencies without justification

The registry and docs now distinguish quantified synthetic fallback rewrites from unknown live recovery/election provenance.

## Self-review

- [x] Reviewed my own diff end to end
- [x] Left comments on notable sections or the crux of the solution
- [x] Called out anything I'm unsure about or want a second opinion on

## Due diligence

- [x] Read the code you're changing before changing it
- [x] Checked that similar patterns exist elsewhere in the codebase and stayed consistent
- [x] If touching the parser or lexer: validated against diverse affected grammars
- [x] If adding a grammar or scanner: verified against upstream C output
