### PR TITLE
docs: map repository ownership and protect run receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # Build artifacts
 .canopy/
+/tmp/
+/nul
 /scannertest
 /ts2go
 /tsquery

--- a/README.md
+++ b/README.md
@@ -513,11 +513,15 @@ All shipped highlight and tags queries compile (`156/156` highlight, `69/69` tag
 
 ## Repository layout note: the compat tier
 
-The root package carries about 177 `parser_result_<language>*.go` files — the
+The root package carries roughly 180 `parser_result_<language>*.go` files — the
 C-faithful result-normalization tier that reshapes raw GLR output into the
 exact tree the C runtime selects. It is internal plumbing, oracle-gated per
 witness, and it shrinks as certified engine mechanisms subsume shims. See
 [docs/compat-tier.md](docs/compat-tier.md).
+
+For a maintainer-oriented map of the full root package, ownership seams,
+review-sensitive hotspots, and local artifact policy, see
+[docs/repository-map.md](docs/repository-map.md).
 
 ## Known limitations
 

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -1,0 +1,93 @@
+# Repository map
+
+gotreesitter deliberately keeps the public runtime in one root Go package.
+That makes the import surface simple, but it also means the repository root is
+wide: at this snapshot it contains 214 production Go files and 308 root-package
+test files. Moving those files into cosmetic subdirectories would create new Go
+packages and change ownership or API boundaries, so navigation should follow
+subsystem names rather than directory depth.
+
+## Root-package ownership
+
+| Area | Primary files | Owns |
+| --- | --- | --- |
+| Public parse API | `parser_api.go`, `parser_pool.go`, `language.go`, `tree.go`, `cursor.go` | Stable caller-facing parsing, language, tree, node, and cursor behavior |
+| Parse scheduler | `parser.go`, `parser_retry.go`, `parser_runtime*.go`, `parser_stop*.go` | Parse orchestration, retries, stop reasons, caps, and runtime accounting |
+| Reductions and recovery | `parser_reduce*.go`, `parser_recover*.go`, `parser_recovery.go` | Reduction ownership, recovery election, error costs, spans, and aliases |
+| GLR and forest | `glr*.go`, `glr_forest*.go`, `glr_gss.go`, `pending_parent.go`, `transient_*.go` | Stack/forest identity, merging, materialization, and transient ownership |
+| Lexing and token sources | `lexer.go`, `parser_dfa_token_source.go`, `external*.go`, `external_scanner*.go` | DFA lexing, external-token integration, scanner state, and checkpoints |
+| Incremental parsing | `incremental*.go`, `parser_incremental_support.go`, `parser_relex*.go`, `w1*.go` tests | Edit application, reuse admission, splice/settle paths, and correctness gates |
+| Result compatibility | `parser_result*.go` | Oracle-gated language compatibility that remains after engine-level selection |
+| Queries and analysis | `query*.go`, `highlight*.go`, `tagger*.go`, `injection*.go`, `imports.go`, `understanding.go` | Query compilation/execution and higher-level syntax services |
+| Compact parser candidate | `internal/parsercorephase0/`, root `parsercore_phase0*.go` files | Compact scheduler, selected store, admission, replay, and parity ratchets |
+| Allocation and storage | `arena*.go`, `raw_shape*.go`, `no_tree_node.go`, `node_field_metadata.go` | Arena lifetime, compact/raw node storage, and memory accounting |
+
+The result-compatibility tier has its own retirement rules in
+[compat-tier.md](compat-tier.md). External scanner certification and fallback
+policy live in [external-scanners.md](external-scanners.md). Compact admission
+breadth is tracked in [compact-route-coverage-census.md](compact-route-coverage-census.md).
+
+## Package and tool directories
+
+| Path | Purpose |
+| --- | --- |
+| `grammars/` | Embedded grammar registry, generated blobs, scanners, and runtime profiles |
+| `grammargen/` | Grammar import, table construction, minimization, and blob generation |
+| `internal/parsercorephase0/` | Internal compact-parser implementation |
+| `cgo_harness/` | C oracle, parity, race, corpus, work-count, and certified timing harnesses |
+| `cmd/` | Maintainer and user CLIs such as `ts2go`, `tsquery`, `benchgate`, and `parity_report` |
+| `taproot/`, `grep/` | Higher-level consumers and helper packages |
+| `wasm/` | Browser runtimes and grammargen WebAssembly targets |
+| `scripts/` | Bounded host-side maintenance helpers; heavy correctness work stays in Docker or CI |
+| `testdata/` | Checked-in regression fixtures and ratchet manifests |
+
+## Review-sensitive seams
+
+Canopy's churn/complexity/centrality analysis identifies the parser scheduler,
+reduction engine, DFA token source, recovery election, tree cloning, and GLR
+merge paths as the highest-risk shared seams. In practice, changes around
+`parseInternal`, `completeConflictReduceFrontier`, `mergeStacksWithScratch`,
+`DFATokenSource.Next`, `cRecoverStrategy1Election`, or tree/arena cloning need
+the smallest relevant correctness gate first, followed by the appropriate
+single-grammar parity lane. Performance evidence comes after correctness.
+
+New behavior should live with the subsystem that owns the invariant. Avoid
+adding source-text detectors, language-name allowlists, or new result patches
+when scheduler, recovery, scanner, span, alias, or materialization ownership can
+express the rule directly.
+
+## Test placement
+
+- Put focused unit/regression tests beside the owning root subsystem.
+- Use `parser_result_<language>_test.go` only for compatibility behavior that
+  cannot yet be expressed upstream.
+- Put grammar generation tests under `grammargen/` and registry/scanner tests
+  under `grammars/`.
+- Put C-oracle, corpus, and certification tests under `cgo_harness/`.
+- Keep broad race and parity coverage in CI or one-language Docker lanes; do
+  not use host-wide `go test ./...` as a maintenance shortcut.
+
+## Local artifacts and receipts
+
+Ignored data is local state, not repository structure:
+
+- Root `*.test`, `*.log`, `*.prof`, `benchgate`, `parity_report`, `scannertest`,
+  `ts2go`, `tsquery`, and accidental Windows `nul` files are reproducible build
+  artifacts.
+- `.parity_seed/`, generated corpus directories, and grammar seeds are caches.
+- `harness_out/`, parity outputs, reports, and benchmark-run directories can
+  contain durable correctness, performance, or certified-run receipts.
+- `.gts/`, `.tiller/`, and other private agent state are never cleanup targets.
+
+Run `scripts/prune_harness_artifacts.sh` for a size-labelled dry run.
+`--delete` removes only root build artifacts and reproducible caches. Receipt
+directories require the explicit `--delete-receipts` option so evidence is not
+discarded during ordinary cleanup.
+
+## Maintainer entry points
+
+1. Read `AGENTS.md` for correctness/performance gate discipline.
+2. Use this map to locate the owning subsystem.
+3. Use Canopy for symbol references, impact, and hotspot analysis.
+4. Run the smallest Docker correctness gate that covers the change.
+5. Keep commits scoped and use the repository's Buckley commit flow.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,8 @@ diagnosis.
 work. It forces serial subset builds, wires in external blob loading, and can
 point built-in grammar loaders at local grammargen `.bin` overrides.
 
-`prune_harness_artifacts.sh` reports generated harness artifact directories by
-size and removes them only when run with `--delete`. It intentionally excludes
-private notes and defaults to a dry run.
+`prune_harness_artifacts.sh` reports root build products, reproducible caches,
+and run receipts separately. It defaults to a dry run. `--delete` removes only
+root build products and reproducible caches; durable harness and benchmark
+receipts require the separate `--delete-receipts` opt-in. It never includes
+private `.gts/`, `.tiller/`, or other agent notes.

--- a/scripts/prune_harness_artifacts.sh
+++ b/scripts/prune_harness_artifacts.sh
@@ -3,25 +3,32 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/prune_harness_artifacts.sh [--delete] [--include-golden]
+Usage: scripts/prune_harness_artifacts.sh [--delete] [--delete-receipts] [--include-golden]
 
-Lists repo-local generated harness artifacts by size. With --delete, removes
-the listed paths. The default is a dry run.
+Lists repo-local generated artifacts by category and size. The default is a
+dry run. Ordinary --delete removes only reproducible caches and root build
+artifacts; run receipts require the separate --delete-receipts opt-in.
 
 Options:
-  --delete          Remove matching artifact paths.
-  --include-golden  Also include .golden/ generated golden corpus artifacts.
-  -h, --help        Show this help.
+  --delete           Remove reproducible caches and root build artifacts.
+  --delete-receipts  Also remove local harness/benchmark receipt directories.
+  --include-golden   Also include .golden/ generated golden corpus artifacts.
+  -h, --help         Show this help.
 USAGE
 }
 
 delete=0
+delete_receipts=0
 include_golden=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --delete)
       delete=1
+      ;;
+    --delete-receipts)
+      delete=1
+      delete_receipts=1
       ;;
     --include-golden)
       include_golden=1
@@ -40,41 +47,81 @@ while [[ $# -gt 0 ]]; do
 done
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$script_dir/.." && pwd))"
+repo_root="$(git -C "$script_dir/.." rev-parse --show-toplevel 2>/dev/null || (cd "$script_dir/.." && pwd))"
 cd "$repo_root"
 
-targets=(
-  "harness_out"
-  "parity_out"
-  "cgo_harness/parity_out"
-  "cgo_harness/reports"
+cache_targets=(
   "cgo_harness/corpus_real"
   "cgo_harness/grammar_seed"
   ".parity_seed"
 )
 
+receipt_targets=(
+  "harness_out"
+  "parity_out"
+  "cgo_harness/harness_out"
+  "cgo_harness/parity_out"
+  "cgo_harness/reports"
+  "cgo_harness/bench/runs"
+)
+
 if [[ "$include_golden" -eq 1 ]]; then
-  targets+=(".golden")
+  cache_targets+=(".golden")
 fi
 
-found=0
-for target in "${targets[@]}"; do
-  if [[ ! -e "$target" ]]; then
-    continue
-  fi
-  found=1
-  size="$(du -sh -- "$target" | awk '{print $1}')"
-  if [[ "$delete" -eq 1 ]]; then
-    printf 'removing %8s %s\n' "$size" "$target"
-    rm -rf -- "$target"
-  else
-    printf '%8s %s\n' "$size" "$target"
+root_artifacts=()
+while IFS= read -r -d '' artifact; do
+  root_artifacts+=("${artifact#./}")
+done < <(
+  find . -maxdepth 1 -type f \
+    \( -name '*.test' -o -name '*.log' -o -name '*.prof' \) \
+    -print0
+)
+
+for artifact in scannertest ts2go tsquery parity_report benchgate nul; do
+  if [[ -f "$artifact" ]]; then
+    root_artifacts+=("$artifact")
   fi
 done
 
+found=0
+
+report_group() {
+  local label="$1"
+  local remove="$2"
+  shift 2
+  local target size
+  local printed_header=0
+  for target in "$@"; do
+    if [[ ! -e "$target" ]]; then
+      continue
+    fi
+    found=1
+    if [[ "$printed_header" -eq 0 ]]; then
+      printf '%s:\n' "$label"
+      printed_header=1
+    fi
+    size="$(du -sh -- "$target" | awk '{print $1}')"
+    if [[ "$remove" -eq 1 ]]; then
+      printf '  removing %8s %s\n' "$size" "$target"
+      rm -rf -- "$target"
+    else
+      printf '  %8s %s\n' "$size" "$target"
+    fi
+  done
+}
+
+report_group "root build artifacts" "$delete" "${root_artifacts[@]}"
+report_group "reproducible caches" "$delete" "${cache_targets[@]}"
+report_group "run receipts (preserved without --delete-receipts)" "$delete_receipts" "${receipt_targets[@]}"
+
 if [[ "$found" -eq 0 ]]; then
-  echo "no generated harness artifacts found"
+  echo "no generated local artifacts found"
 elif [[ "$delete" -eq 0 ]]; then
   echo
-  echo "dry run only; rerun with --delete to remove these paths"
+  echo "dry run only; --delete removes root artifacts and caches"
+  echo "run receipts require the separate --delete-receipts opt-in"
+elif [[ "$delete_receipts" -eq 0 ]]; then
+  echo
+  echo "run receipts preserved; use --delete-receipts only after archiving durable evidence"
 fi


### PR DESCRIPTION
## Summary

- add a maintainer-oriented repository map for the wide root package and its ownership seams
- classify local artifacts into disposable build/cache output versus durable run receipts
- make ordinary cleanup preserve certified, parity, and benchmark evidence
- ignore recurring root-local tmp and Windows nul artifacts

## Validation

- bash syntax check
- dry-run and controlled deletion smoke test
- invocation from another repository to verify script-relative root discovery
- git diff --check
- Canopy changed-scope check: pass (0 violations)

No Go behavior changes.