### PR TITLE
parser: certify stateless PowerShell scanner reuse

### DIFF
--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -360,6 +360,17 @@ The registered HTML, Markdown, and Markdown Inline scanners remain
 uncertified, so changed-token or shape-changing edits take the production
 full-parse fallback rather than scanner-dependent reuse.
 
+PowerShell's scanner is stateless: it recognizes one zero-width statement
+terminator from the current lookahead and valid-symbol set, carries no payload,
+and has no stateful here-string handling. It therefore uses the same stateless
+quiescence proof as Go rather than the checkpoint route. Focused certification
+crosses changed-length edits at multiple positions and requires incremental
+trees to match fresh production parses. The representative 137 KiB near-top
+insert currently ratchets a conservative 5% reused-byte floor: scanner
+admission is solved, but source-wide non-leaf ownership and stale-boundary
+rejections remain a separate performance frontier rather than an O(edit)
+claim.
+
 SQL's state proof is explicit: the payload is either empty or exactly one
 active PostgreSQL dollar-quote tag. The empty state has a one-byte marker;
 representable non-empty states serialize as the tag plus a trailing NUL. A tag
@@ -459,7 +470,7 @@ part of #430's sound-admission closure.
 | `perl` | fallback (uncertified) |
 | `php` | fallback (uncertified) |
 | `pkl` | fallback (uncertified) |
-| `powershell` | fallback (uncertified) |
+| `powershell` | certified reuse |
 | `properties` | fallback (uncertified) |
 | `pug` | fallback (uncertified) |
 | `purescript` | fallback (uncertified) |

--- a/grammars/powershell_scanner.go
+++ b/grammars/powershell_scanner.go
@@ -27,6 +27,21 @@ func (PowershellExternalScanner) Destroy(payload any)                   {}
 func (PowershellExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (PowershellExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// SupportsIncrementalReuse certifies changed-edit subtree reuse. The scanner
+// has no payload and recognizes only a statement terminator from the current
+// lookahead and parser-provided valid-symbol set.
+func (PowershellExternalScanner) SupportsIncrementalReuse() bool { return true }
+
+// ExternalScannerIsStateless discharges the scanner-quiescence proof: Create
+// returns nil, serialization is empty, and Scan reads no parse history or
+// mutable package state. Skipped whitespace is local lexer input, not scanner
+// state, so every reuse boundary begins from the same state as a fresh parse.
+func (PowershellExternalScanner) ExternalScannerIsStateless() bool { return true }
+
+// PreservesStateOnScanFailure is true because there is no persisted payload to
+// mutate. This also lets scanner retries avoid a pointless snapshot attempt.
+func (PowershellExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (PowershellExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !powershellValid(validSymbols, powershellTokStatementTerminator) {
 		return false

--- a/parser_powershell_incremental_certification_test.go
+++ b/parser_powershell_incremental_certification_test.go
@@ -1,0 +1,162 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestPowerShellIncrementalScannerCertification(t *testing.T) {
+	for _, plan := range []struct {
+		name      string
+		size      int
+		positions []string
+		classes   []powerShellCertificationEditClass
+	}{
+		{
+			name:      "4KiB",
+			size:      4 << 10,
+			positions: []string{"start", "middle", "end"},
+			classes:   []powerShellCertificationEditClass{powerShellCertificationInsert, powerShellCertificationDelete, powerShellCertificationReplace},
+		},
+		{
+			name:      "137KiB",
+			size:      137 << 10,
+			positions: []string{"start"},
+			classes:   []powerShellCertificationEditClass{powerShellCertificationInsert},
+		},
+	} {
+		source, sites := makePowerShellCertificationSource(plan.size)
+		for _, position := range plan.positions {
+			var site int
+			switch position {
+			case "start":
+				site = sites[1]
+			case "middle":
+				site = sites[len(sites)/2]
+			case "end":
+				site = sites[len(sites)-2]
+			default:
+				t.Fatalf("unknown PowerShell certification position %q", position)
+			}
+			for _, class := range plan.classes {
+				t.Run(fmt.Sprintf("%s/%s/%s", plan.name, class, position), func(t *testing.T) {
+					edited, edit := applyPowerShellCertificationEdit(source, site, class)
+					profile := runPowerShellCertificationSample(t, source, edited, edit)
+					if plan.size >= 137<<10 && profile.ReusedBytes*100 < uint64(len(edited))*5 {
+						t.Fatalf("PowerShell certification reused only %d/%d bytes (<5%%): %+v", profile.ReusedBytes, len(edited), profile)
+					}
+				})
+			}
+		}
+	}
+}
+
+type powerShellCertificationEditClass uint8
+
+const (
+	powerShellCertificationInsert powerShellCertificationEditClass = iota
+	powerShellCertificationDelete
+	powerShellCertificationReplace
+)
+
+func (c powerShellCertificationEditClass) String() string {
+	switch c {
+	case powerShellCertificationInsert:
+		return "insert"
+	case powerShellCertificationDelete:
+		return "delete"
+	case powerShellCertificationReplace:
+		return "replace"
+	default:
+		return "unknown"
+	}
+}
+
+func makePowerShellCertificationSource(target int) ([]byte, []int) {
+	var source strings.Builder
+	source.Grow(target + 128)
+	sites := make([]int, 0, target/48)
+	for i := 0; source.Len() < target || len(sites) < 4; i++ {
+		fmt.Fprintf(&source, "$value%06d = ", i)
+		sites = append(sites, source.Len())
+		source.WriteString("100\n")
+		fmt.Fprintf(&source, "Write-Output $value%06d\n", i)
+	}
+	return []byte(source.String()), sites
+}
+
+func applyPowerShellCertificationEdit(source []byte, offset int, class powerShellCertificationEditClass) ([]byte, gts.InputEdit) {
+	oldEnd := offset
+	replacement := []byte{'9'}
+	switch class {
+	case powerShellCertificationDelete:
+		oldEnd = offset + 1
+		replacement = nil
+	case powerShellCertificationReplace:
+		oldEnd = offset + 1
+		replacement = []byte("88")
+	}
+	edited := make([]byte, 0, len(source)-(oldEnd-offset)+len(replacement))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	return edited, gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, oldEnd),
+		NewEndPoint: pointForOffset(edited, offset+len(replacement)),
+	}
+}
+
+func runPowerShellCertificationSample(t *testing.T, source, edited []byte, edit gts.InputEdit) gts.IncrementalParseProfile {
+	t.Helper()
+	lang := grammars.PowershellLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("initial PowerShell parse: %v", err)
+	}
+	defer oldTree.Release()
+	initialRoot := requireCompleteParse(t, oldTree, source, lang, "initial PowerShell certification")
+	if initialRoot.HasError() {
+		t.Fatalf("initial PowerShell parse produced ERROR: %s", initialRoot.SExpr(lang))
+	}
+
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental PowerShell parse: %v", err)
+	}
+	defer incremental.Release()
+	incrementalRoot := requireCompleteParse(t, incremental, edited, lang, "incremental PowerShell certification")
+	if profile.ReuseUnsupported {
+		t.Fatalf("certified PowerShell scanner fell back: reason=%q", profile.ReuseUnsupportedReason)
+	}
+	if !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("certified PowerShell scanner did not reuse old syntax: %+v", profile)
+	}
+	if incrementalRoot.HasError() {
+		t.Fatalf("incremental PowerShell parse produced ERROR: %s", incrementalRoot.SExpr(lang))
+	}
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh PowerShell parse: %v", err)
+	}
+	defer fresh.Release()
+	freshRoot := requireCompleteParse(t, fresh, edited, lang, "fresh PowerShell certification")
+	if freshRoot.HasError() {
+		t.Fatalf("fresh PowerShell parse produced ERROR: %s", freshRoot.SExpr(lang))
+	}
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+	return profile
+}


### PR DESCRIPTION
## Summary

- certify PowerShell's actual external scanner as stateless and failure-preserving
- remove the conservative external-scanner fallback for changed-length edits
- add a production-route certification over insert/delete/replace at start, middle, and end
- ratchet the observed 137 KiB near-top reuse floor at 5% without claiming O(edit)
- document root-nonleaf/stale-boundary rejection as the remaining performance frontier

Closes the PowerShell scanner-admission portion of #432.

## Validation

- focused scanner documentation/registry contract in Docker
- focused PowerShell incremental certification in Docker: pass in 0.55s
- PowerShell fresh and incremental C-oracle parity: pass in 2.47s test time / 10.9s isolated wall time
- Canopy changed-scope check: pass (0 violations)
- git diff --check

## Review note

Buckbot was routed to Kimi K3 through OpenRouter twice. The reviewer transport ignored its configured timeout and returned no findings; both attempts were interrupted without modifying the worktree. The local and C-oracle gates above are authoritative for this slice.