### PR TITLE
Certify bounded HTML incremental reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,25 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **HTML external-scanner reuse is checkpoint-certified for clean old trees.**
+  The complete open-tag stack now serializes exactly or returns an absent
+  checkpoint; oversized depth, custom names, and buffer exhaustion can no
+  longer truncate or alias state. Malformed checkpoint bytes are rejected,
+  failed scans preserve state, and token relexing rejects absent start or live
+  checkpoints. Changed-length edit witnesses at three positions plus a 137 KiB
+  lane require real reuse and fresh-tree equality. Error-bearing old HTML trees
+  remain an explicit fresh-parse fallback while recovery ownership is still
+  uncertified.
+
 - **SQL external-scanner reuse is now checkpoint-certified.** The runtime's
   checkpoint and checkpointless-reuse gates are capability based rather than
   language-name allowlists. SQL records a complete dollar-quote-tag state
   whenever it fits the checkpoint buffer (including an explicit empty-state
   checkpoint), preserves that state on failed scans, and fails closed only for
   incremental reuse when a valid tag is too large to restore exactly; full
-  parsing continues to accept the tag, matching C semantics. Svelte now opts
-  out of changed-edit reuse because its bounded HTML-tag encoding is not yet a
-  collision-free checkpoint proof.
+  parsing continues to accept the tag, matching C semantics. Svelte remains
+  opted out of changed-edit reuse pending certification of its scanner-wide
+  raw-text and expression-block behavior.
   Clean and recovered insert/delete/replace witnesses at the start, middle,
   and end of roughly 20 KiB and 137 KiB files enforce fresh-tree equality,
   full-span coverage, deterministic work, and bounded memory; an opt-in tier

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -312,9 +312,16 @@ numbering, use the public remapper:
   zero means "checkpoint absent" and reuse fails closed at that boundary. The
   empty payload itself must have a non-empty encoding so it is distinguishable
   from absence. Reuse compares the live start state and restores the recorded
-  end state. SQL and CMake use this route; Python, Mojo, and Starlark record
-  checkpoints but still opt out of reuse. Svelte also opts out because its
-  bounded HTML-tag encoding can truncate depth and custom names.
+  end state. SQL, CMake, and HTML use this route; Python, Mojo, and Starlark
+  record checkpoints but still opt out of reuse. The shared HTML-family tag
+  encoding is exact and fails closed when depth, custom-name length, or buffer
+  capacity cannot represent the complete state; Svelte still opts out pending
+  certification of its additional raw-text and expression-block behavior.
+- `ErrorTreeIncrementalReuseExternalScanner`
+  (`SupportsIncrementalReuseFromErrorTree() bool`): an optional narrower gate
+  for a scanner whose clean-tree checkpoints are certified but whose recovery
+  ownership is not. HTML currently returns false, so changed edits over an
+  error-bearing old HTML tree take a fresh-parse fallback.
 - `CheckpointlessExternalScannerReuse`
   (`AllowsIncrementalReuseWithoutCheckpoint() bool`): an exceptional second
   proof that a checkpoint-enabled scanner can safely reuse a node whose
@@ -335,9 +342,11 @@ the built-in registry. It is derived from the registration files under
   `IncrementalReuseExternalScanner` and returns true. A changed edit may
   enter old-tree subtree reuse, subject to the normal dirty-span,
   fragility, byte-equality, and scanner-boundary gates.
-- **bounded reuse** is Dart's certified route for sources up to 256 KiB.
-  Larger Dart sources use the fresh production parse with reason
-  `dart_large_external_scanner_unsupported`.
+- **bounded reuse** records a narrower certified route. Dart is source-bounded
+  to 256 KiB; larger sources fall back with
+  `dart_large_external_scanner_unsupported`. HTML is clean-old-tree bounded;
+  error-bearing old trees fall back with
+  `external_scanner_error_tree_unsupported`.
 - **fallback (explicit opt-out)** means the scanner implements the
   interface and returns false.
 - **fallback (uncertified)** means the scanner does not implement the
@@ -352,13 +361,13 @@ The token-invariant leaf exception is intentionally narrow: on a production
 tree, a same-length edit that independently reauthenticates the same leaf
 token may return before the scanner gate. That is not certification for
 general scanner-dependent subtree reuse. Likewise, scanner checkpoints do
-not certify a scanner by themselves: CMake and SQL opt in, while Python,
+not certify a scanner by themselves: CMake, SQL, and HTML opt in, while Python,
 Mojo, Starlark, and Svelte explicitly opt out. Custom
 `TokenSource` implementations have their own
 `IncrementalReuseTokenSource` contract and are outside this registry matrix.
-The registered HTML, Markdown, and Markdown Inline scanners remain
-uncertified, so changed-token or shape-changing edits take the production
-full-parse fallback rather than scanner-dependent reuse.
+The registered Markdown and Markdown Inline scanners remain uncertified, so
+changed-token or shape-changing edits take the production full-parse fallback
+rather than scanner-dependent reuse.
 
 PowerShell's scanner is stateless: it recognizes one zero-width statement
 terminator from the current lookahead and valid-symbol set, carries no payload,
@@ -384,6 +393,19 @@ source-linear resource ceilings; it does not claim O(edit). The latest 1 MiB
 run reached about 1.07 GiB maximum RSS (an earlier run reached about 1.39 GiB),
 so allocation/RSS scaling remains an open performance residual rather than
 part of #430's sound-admission closure.
+
+HTML's state proof is the complete open-tag stack. The inherited wire format
+retains its two-count header, but serialization now preflights the entire state
+and returns zero instead of truncating excessive depth, custom names longer
+than 255 bytes, or a stack that exceeds the 4096-byte checkpoint buffer.
+Deserialization rejects unequal counts, invalid tag types, truncated entries,
+and trailing bytes. Failed scans preserve the tag stack. Clean-tree
+certification crosses insert/delete/changed-length replace edits at the start,
+middle, and end of a roughly 4 KiB stateful document plus a representative
+137 KiB edit, requiring actual old-tree reuse and deep equality with a fresh
+parse. A recovery witness exposed unresolved error-tree ownership, so that
+route explicitly fails closed pending its own certification rather than
+silently widening HTML admission.
 
 | Language | Changed-edit contract |
 |---|---|
@@ -439,7 +461,7 @@ part of #430's sound-admission closure.
 | `haxe` | fallback (uncertified) |
 | `hcl` | fallback (uncertified) |
 | `hlsl` | fallback (uncertified) |
-| `html` | fallback (uncertified) |
+| `html` | bounded reuse (clean old trees) |
 | `janet` | fallback (uncertified) |
 | `javascript` | certified reuse |
 | `jsdoc` | fallback (uncertified) |

--- a/grammars/blade_external_scanner.go
+++ b/grammars/blade_external_scanner.go
@@ -1,0 +1,127 @@
+//go:build !grammar_subset || grammar_subset_blade
+
+package grammars
+
+import (
+	"sync"
+	"unicode"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// External token indexes for the Blade grammar.
+const (
+	bladeTokStartTagName        = 0
+	bladeTokScriptStartTagName  = 1
+	bladeTokStyleStartTagName   = 2
+	bladeTokEndTagName          = 3
+	bladeTokErroneousEndTagName = 4
+	bladeTokSelfClosingTagDelim = 5
+	bladeTokImplicitEndTag      = 6
+	bladeTokRawText             = 7
+	bladeTokComment             = 8
+)
+
+// bladeSyms caches resolved external symbol IDs for the blade grammar.
+var bladeSyms struct {
+	once                sync.Once
+	startTagName        gotreesitter.Symbol
+	scriptStartTagName  gotreesitter.Symbol
+	styleStartTagName   gotreesitter.Symbol
+	endTagName          gotreesitter.Symbol
+	erroneousEndTagName gotreesitter.Symbol
+	selfClosingTagDelim gotreesitter.Symbol
+	implicitEndTag      gotreesitter.Symbol
+	rawText             gotreesitter.Symbol
+	comment             gotreesitter.Symbol
+}
+
+func resolveBladeSyms() {
+	bladeSyms.once.Do(func() {
+		lang := BladeLanguage()
+		bladeSyms.startTagName = lang.ExternalSymbols[bladeTokStartTagName]
+		bladeSyms.scriptStartTagName = lang.ExternalSymbols[bladeTokScriptStartTagName]
+		bladeSyms.styleStartTagName = lang.ExternalSymbols[bladeTokStyleStartTagName]
+		bladeSyms.endTagName = lang.ExternalSymbols[bladeTokEndTagName]
+		bladeSyms.erroneousEndTagName = lang.ExternalSymbols[bladeTokErroneousEndTagName]
+		bladeSyms.selfClosingTagDelim = lang.ExternalSymbols[bladeTokSelfClosingTagDelim]
+		bladeSyms.implicitEndTag = lang.ExternalSymbols[bladeTokImplicitEndTag]
+		bladeSyms.rawText = lang.ExternalSymbols[bladeTokRawText]
+		bladeSyms.comment = lang.ExternalSymbols[bladeTokComment]
+	})
+}
+
+type bladeState struct {
+	tags []htmlTag
+}
+
+// BladeExternalScanner handles HTML tag tracking for Blade templates.
+type BladeExternalScanner struct{}
+
+func (BladeExternalScanner) Create() any         { return &bladeState{} }
+func (BladeExternalScanner) Destroy(payload any) {}
+
+func (BladeExternalScanner) Serialize(payload any, buf []byte) int {
+	s := payload.(*bladeState)
+	return htmlSerializeTags(s.tags, buf)
+}
+
+func (BladeExternalScanner) Deserialize(payload any, buf []byte) {
+	s := payload.(*bladeState)
+	s.tags = htmlDeserializeTagsInto(s.tags, buf)
+}
+
+func (BladeExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+	s := payload.(*bladeState)
+	lx := &goLexerAdapter{lexer}
+	resolveBladeSyms()
+
+	// Raw text in script/style tags
+	if bladeValid(validSymbols, bladeTokRawText) && !bladeValid(validSymbols, bladeTokStartTagName) &&
+		!bladeValid(validSymbols, bladeTokEndTagName) {
+		return htmlScanRawText(lx, s.tags, bladeSyms.rawText, lexer)
+	}
+
+	// Skip whitespace
+	for unicode.IsSpace(lexer.Lookahead()) {
+		lexer.Advance(true)
+	}
+
+	switch lexer.Lookahead() {
+	case '<':
+		lexer.MarkEnd()
+		lexer.Advance(false)
+
+		if lexer.Lookahead() == '!' {
+			lexer.Advance(false)
+			return htmlScanComment(lx, bladeSyms.comment, lexer)
+		}
+
+		if bladeValid(validSymbols, bladeTokImplicitEndTag) {
+			return htmlScanImplicitEndTag(lx, &s.tags, bladeSyms.implicitEndTag, lexer)
+		}
+
+	case 0:
+		if bladeValid(validSymbols, bladeTokImplicitEndTag) {
+			return htmlScanImplicitEndTag(lx, &s.tags, bladeSyms.implicitEndTag, lexer)
+		}
+
+	case '/':
+		if bladeValid(validSymbols, bladeTokSelfClosingTagDelim) {
+			return htmlScanSelfClosingDelim(lx, &s.tags, bladeSyms.selfClosingTagDelim, lexer)
+		}
+
+	default:
+		if (bladeValid(validSymbols, bladeTokStartTagName) || bladeValid(validSymbols, bladeTokEndTagName)) &&
+			!bladeValid(validSymbols, bladeTokRawText) {
+			if bladeValid(validSymbols, bladeTokStartTagName) {
+				return htmlScanStartTagName(lx, &s.tags, bladeSyms.startTagName, bladeSyms.scriptStartTagName, bladeSyms.styleStartTagName, 0, lexer)
+			}
+			return htmlScanEndTagName(lx, &s.tags, bladeSyms.endTagName, bladeSyms.erroneousEndTagName, lexer)
+		}
+	}
+
+	return false
+}
+
+func bladeValid(vs []bool, i int) bool { return i < len(vs) && vs[i] }

--- a/grammars/blade_scanner.go
+++ b/grammars/blade_scanner.go
@@ -1,130 +1,8 @@
-//go:build !grammar_subset || grammar_subset_blade
+//go:build !grammar_subset || grammar_subset_angular || grammar_subset_astro || grammar_subset_blade || grammar_subset_html || grammar_subset_svelte || grammar_subset_vue
 
 package grammars
 
-import (
-	"sync"
-	"unicode"
-
-	gotreesitter "github.com/odvcencio/gotreesitter"
-)
-
-// External token indexes for the Blade grammar.
-const (
-	bladeTokStartTagName        = 0
-	bladeTokScriptStartTagName  = 1
-	bladeTokStyleStartTagName   = 2
-	bladeTokEndTagName          = 3
-	bladeTokErroneousEndTagName = 4
-	bladeTokSelfClosingTagDelim = 5
-	bladeTokImplicitEndTag      = 6
-	bladeTokRawText             = 7
-	bladeTokComment             = 8
-)
-
-// bladeSyms caches resolved external symbol IDs for the blade grammar.
-var bladeSyms struct {
-	once                sync.Once
-	startTagName        gotreesitter.Symbol
-	scriptStartTagName  gotreesitter.Symbol
-	styleStartTagName   gotreesitter.Symbol
-	endTagName          gotreesitter.Symbol
-	erroneousEndTagName gotreesitter.Symbol
-	selfClosingTagDelim gotreesitter.Symbol
-	implicitEndTag      gotreesitter.Symbol
-	rawText             gotreesitter.Symbol
-	comment             gotreesitter.Symbol
-}
-
-func resolveBladeSyms() {
-	bladeSyms.once.Do(func() {
-		lang := BladeLanguage()
-		bladeSyms.startTagName = lang.ExternalSymbols[bladeTokStartTagName]
-		bladeSyms.scriptStartTagName = lang.ExternalSymbols[bladeTokScriptStartTagName]
-		bladeSyms.styleStartTagName = lang.ExternalSymbols[bladeTokStyleStartTagName]
-		bladeSyms.endTagName = lang.ExternalSymbols[bladeTokEndTagName]
-		bladeSyms.erroneousEndTagName = lang.ExternalSymbols[bladeTokErroneousEndTagName]
-		bladeSyms.selfClosingTagDelim = lang.ExternalSymbols[bladeTokSelfClosingTagDelim]
-		bladeSyms.implicitEndTag = lang.ExternalSymbols[bladeTokImplicitEndTag]
-		bladeSyms.rawText = lang.ExternalSymbols[bladeTokRawText]
-		bladeSyms.comment = lang.ExternalSymbols[bladeTokComment]
-	})
-}
-
-type bladeState struct {
-	tags []htmlTag
-}
-
-// BladeExternalScanner handles HTML tag tracking for Blade templates.
-type BladeExternalScanner struct{}
-
-func (BladeExternalScanner) Create() any         { return &bladeState{} }
-func (BladeExternalScanner) Destroy(payload any) {}
-
-func (BladeExternalScanner) Serialize(payload any, buf []byte) int {
-	s := payload.(*bladeState)
-	return htmlSerializeTags(s.tags, buf)
-}
-
-func (BladeExternalScanner) Deserialize(payload any, buf []byte) {
-	s := payload.(*bladeState)
-	s.tags = htmlDeserializeTagsInto(s.tags, buf)
-}
-
-func (BladeExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
-	s := payload.(*bladeState)
-	lx := &goLexerAdapter{lexer}
-	resolveBladeSyms()
-
-	// Raw text in script/style tags
-	if bladeValid(validSymbols, bladeTokRawText) && !bladeValid(validSymbols, bladeTokStartTagName) &&
-		!bladeValid(validSymbols, bladeTokEndTagName) {
-		return htmlScanRawText(lx, s.tags, bladeSyms.rawText, lexer)
-	}
-
-	// Skip whitespace
-	for unicode.IsSpace(lexer.Lookahead()) {
-		lexer.Advance(true)
-	}
-
-	switch lexer.Lookahead() {
-	case '<':
-		lexer.MarkEnd()
-		lexer.Advance(false)
-
-		if lexer.Lookahead() == '!' {
-			lexer.Advance(false)
-			return htmlScanComment(lx, bladeSyms.comment, lexer)
-		}
-
-		if bladeValid(validSymbols, bladeTokImplicitEndTag) {
-			return htmlScanImplicitEndTag(lx, &s.tags, bladeSyms.implicitEndTag, lexer)
-		}
-
-	case 0:
-		if bladeValid(validSymbols, bladeTokImplicitEndTag) {
-			return htmlScanImplicitEndTag(lx, &s.tags, bladeSyms.implicitEndTag, lexer)
-		}
-
-	case '/':
-		if bladeValid(validSymbols, bladeTokSelfClosingTagDelim) {
-			return htmlScanSelfClosingDelim(lx, &s.tags, bladeSyms.selfClosingTagDelim, lexer)
-		}
-
-	default:
-		if (bladeValid(validSymbols, bladeTokStartTagName) || bladeValid(validSymbols, bladeTokEndTagName)) &&
-			!bladeValid(validSymbols, bladeTokRawText) {
-			if bladeValid(validSymbols, bladeTokStartTagName) {
-				return htmlScanStartTagName(lx, &s.tags, bladeSyms.startTagName, bladeSyms.scriptStartTagName, bladeSyms.styleStartTagName, 0, lexer)
-			}
-			return htmlScanEndTagName(lx, &s.tags, bladeSyms.endTagName, bladeSyms.erroneousEndTagName, lexer)
-		}
-	}
-
-	return false
-}
-
-func bladeValid(vs []bool, i int) bool { return i < len(vs) && vs[i] }
+import gotreesitter "github.com/odvcencio/gotreesitter"
 
 // --- Shared HTML scanning helpers ---
 
@@ -138,48 +16,47 @@ func (a *goLexerAdapter) markEnd()          { a.l.MarkEnd() }
 func (a *goLexerAdapter) eof() bool         { return a.l.Lookahead() == 0 }
 
 func htmlSerializeTags(tags []htmlTag, buf []byte) int {
-	if len(buf) < 4 {
+	if len(buf) < 4 || len(tags) > 0xFFFF {
 		return 0
 	}
-	tagCount := len(tags)
-	if tagCount > 0xFFFF {
-		tagCount = 0xFFFF
+	size := 4
+	for i := range tags {
+		tag := &tags[i]
+		if tag.tagType > htmlTagInterpolation {
+			return 0
+		}
+		size++
+		if tag.tagType == htmlTagCustom {
+			if len(tag.customName) > 255 {
+				return 0
+			}
+			size += 1 + len(tag.customName)
+		}
+		if size > len(buf) {
+			return 0
+		}
 	}
-	// Write tag count twice (serialized_count then total_count)
+
+	tagCount := len(tags)
+	// A non-empty result is always the complete state. Keeping both counts in
+	// the inherited wire format lets the decoder reject old partial snapshots.
 	buf[0] = byte(tagCount)
 	buf[1] = byte(tagCount >> 8)
 	buf[2] = byte(tagCount)
 	buf[3] = byte(tagCount >> 8)
-	size := 4
-	serialized := 0
+	offset := 4
 	for i := 0; i < tagCount; i++ {
 		tag := tags[i]
+		buf[offset] = byte(tag.tagType)
+		offset++
 		if tag.tagType == htmlTagCustom {
 			nameLen := len(tag.customName)
-			if nameLen > 255 {
-				nameLen = 255
-			}
-			if size+2+nameLen >= len(buf) {
-				break
-			}
-			buf[size] = byte(tag.tagType)
-			size++
-			buf[size] = byte(nameLen)
-			size++
-			copy(buf[size:], tag.customName[:nameLen])
-			size += nameLen
-		} else {
-			if size+1 >= len(buf) {
-				break
-			}
-			buf[size] = byte(tag.tagType)
-			size++
+			buf[offset] = byte(nameLen)
+			offset++
+			copy(buf[offset:], tag.customName)
+			offset += nameLen
 		}
-		serialized++
 	}
-	// Update serialized count
-	buf[0] = byte(serialized)
-	buf[1] = byte(serialized >> 8)
 	return size
 }
 
@@ -188,23 +65,47 @@ func htmlDeserializeTagsInto(dst []htmlTag, buf []byte) []htmlTag {
 		return nil
 	}
 	serializedCount := int(buf[0]) | int(buf[1])<<8
-	size := 4
+	totalCount := int(buf[2]) | int(buf[3])<<8
+	if serializedCount != totalCount {
+		return nil
+	}
+	offset := 4
+	for i := 0; i < serializedCount; i++ {
+		if offset >= len(buf) {
+			return nil
+		}
+		tagType := htmlTagType(buf[offset])
+		offset++
+		if tagType > htmlTagInterpolation {
+			return nil
+		}
+		if tagType == htmlTagCustom {
+			if offset >= len(buf) {
+				return nil
+			}
+			nameLen := int(buf[offset])
+			offset++
+			if offset+nameLen > len(buf) {
+				return nil
+			}
+			offset += nameLen
+		}
+	}
+	if offset != len(buf) {
+		return nil
+	}
+
 	clear(dst)
 	tags := dst[:0]
-	for i := 0; i < serializedCount && size < len(buf); i++ {
-		tagType := htmlTagType(buf[size])
-		size++
+	offset = 4
+	for i := 0; i < serializedCount; i++ {
+		tagType := htmlTagType(buf[offset])
+		offset++
 		if tagType == htmlTagCustom {
-			if size >= len(buf) {
-				break
-			}
-			nameLen := int(buf[size])
-			size++
-			if size+nameLen > len(buf) {
-				break
-			}
-			name := string(buf[size : size+nameLen])
-			size += nameLen
+			nameLen := int(buf[offset])
+			offset++
+			name := string(buf[offset : offset+nameLen])
+			offset += nameLen
 			tags = append(tags, htmlTag{tagType: htmlTagCustom, customName: name})
 		} else {
 			tags = append(tags, htmlTag{tagType: tagType})

--- a/grammars/html_scanner.go
+++ b/grammars/html_scanner.go
@@ -44,6 +44,21 @@ func (HTMLExternalScanner) Deserialize(payload any, buf []byte) {
 	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
+// SupportsIncrementalReuse certifies HTML's scanner state for changed edits.
+func (HTMLExternalScanner) SupportsIncrementalReuse() bool { return true }
+
+// SupportsIncrementalReuseFromErrorTree remains closed until HTML recovery
+// ownership is certified independently of the scanner's exact state proof.
+func (HTMLExternalScanner) SupportsIncrementalReuseFromErrorTree() bool { return false }
+
+// UsesExternalScannerCheckpoints selects exact tag-stack checkpoints. States
+// that do not fit the runtime buffer serialize to zero and fail closed.
+func (HTMLExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+
+// PreservesStateOnScanFailure holds because tag-stack mutations occur only on
+// the successful implicit-end, self-closing, start-tag, and end-tag routes.
+func (HTMLExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (HTMLExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	s := payload.(*htmlScannerState)
 	lx := &goLexerAdapter{lexer}

--- a/grammars/html_tags_test.go
+++ b/grammars/html_tags_test.go
@@ -2,7 +2,13 @@
 
 package grammars
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+)
 
 func TestHTMLDeserializeTagsIntoReusesBackingArray(t *testing.T) {
 	tags := []htmlTag{
@@ -28,5 +34,114 @@ func TestHTMLDeserializeTagsIntoReusesBackingArray(t *testing.T) {
 		if !htmlTagEq(&got[i], &tags[i]) {
 			t.Fatalf("tag %d = %#v, want %#v", i, got[i], tags[i])
 		}
+	}
+}
+
+func TestHTMLTagCheckpointIsExactAndFailClosed(t *testing.T) {
+	t.Run("empty_state_is_present", func(t *testing.T) {
+		buf := make([]byte, 4)
+		if n := htmlSerializeTags(nil, buf); n != 4 {
+			t.Fatalf("empty checkpoint size = %d, want 4", n)
+		}
+		if got := htmlDeserializeTagsInto([]htmlTag{{tagType: htmlTagDiv}}, buf); len(got) != 0 || got == nil {
+			t.Fatalf("empty checkpoint decoded as %#v, want non-nil empty state", got)
+		}
+	})
+
+	tags := []htmlTag{
+		{tagType: htmlTagHtml},
+		{tagType: htmlTagCustom, customName: "CUSTOM-ELEMENT"},
+		{tagType: htmlTagInterpolation},
+	}
+	required := 4 + 1 + 2 + len(tags[1].customName) + 1
+	t.Run("exact_capacity", func(t *testing.T) {
+		buf := make([]byte, required)
+		if n := htmlSerializeTags(tags, buf); n != required {
+			t.Fatalf("checkpoint size = %d, want %d", n, required)
+		}
+		got := htmlDeserializeTagsInto(nil, buf)
+		if len(got) != len(tags) {
+			t.Fatalf("decoded tag count = %d, want %d", len(got), len(tags))
+		}
+		for i := range tags {
+			if !htmlTagEq(&got[i], &tags[i]) {
+				t.Fatalf("decoded tag %d = %#v, want %#v", i, got[i], tags[i])
+			}
+		}
+	})
+
+	t.Run("insufficient_capacity", func(t *testing.T) {
+		buf := bytes.Repeat([]byte{0xa5}, required-1)
+		before := append([]byte(nil), buf...)
+		if n := htmlSerializeTags(tags, buf); n != 0 {
+			t.Fatalf("short buffer serialized %d bytes, want absent checkpoint", n)
+		}
+		if !bytes.Equal(buf, before) {
+			t.Fatal("failed serialization partially modified the destination")
+		}
+	})
+
+	t.Run("custom_name_too_long", func(t *testing.T) {
+		prefix := strings.Repeat("X", 255)
+		left := []htmlTag{{tagType: htmlTagCustom, customName: prefix + "A"}}
+		right := []htmlTag{{tagType: htmlTagCustom, customName: prefix + "B"}}
+		buf := make([]byte, 4096)
+		if n := htmlSerializeTags(left, buf); n != 0 {
+			t.Fatalf("left colliding state serialized %d bytes, want absent", n)
+		}
+		if n := htmlSerializeTags(right, buf); n != 0 {
+			t.Fatalf("right colliding state serialized %d bytes, want absent", n)
+		}
+	})
+
+	t.Run("tag_depth_too_large", func(t *testing.T) {
+		deep := make([]htmlTag, 1<<16)
+		if n := htmlSerializeTags(deep, make([]byte, len(deep)+4)); n != 0 {
+			t.Fatalf("unrepresentable depth serialized %d bytes, want absent", n)
+		}
+	})
+}
+
+func TestHTMLTagCheckpointRejectsMalformedEncodings(t *testing.T) {
+	valid := make([]byte, 16)
+	n := htmlSerializeTags([]htmlTag{{tagType: htmlTagDiv}}, valid)
+	valid = valid[:n]
+
+	cases := map[string][]byte{
+		"short_header":            {0, 0, 0},
+		"partial_count":           {0, 0, 1, 0},
+		"truncated_tag":           {1, 0, 1, 0},
+		"truncated_custom_length": {1, 0, 1, 0, byte(htmlTagCustom)},
+		"truncated_custom_name":   {1, 0, 1, 0, byte(htmlTagCustom), 2, 'X'},
+		"invalid_tag_type":        {1, 0, 1, 0, byte(htmlTagInterpolation + 1)},
+		"trailing_bytes":          append(append([]byte(nil), valid...), 0),
+	}
+	for name, snapshot := range cases {
+		t.Run(name, func(t *testing.T) {
+			dst := []htmlTag{{tagType: htmlTagDiv}}
+			if got := htmlDeserializeTagsInto(dst, snapshot); got != nil {
+				t.Fatalf("malformed checkpoint decoded as %#v, want nil state", got)
+			}
+		})
+	}
+}
+
+func TestHTMLScannerIncrementalCapabilities(t *testing.T) {
+	var scanner gts.ExternalScanner = HTMLExternalScanner{}
+	reuse, ok := scanner.(gts.IncrementalReuseExternalScanner)
+	if !ok || !reuse.SupportsIncrementalReuse() {
+		t.Fatal("HTML scanner is not certified for incremental reuse")
+	}
+	errorTreeReuse, ok := scanner.(gts.ErrorTreeIncrementalReuseExternalScanner)
+	if !ok || errorTreeReuse.SupportsIncrementalReuseFromErrorTree() {
+		t.Fatal("HTML scanner did not retain its error-tree fail-closed boundary")
+	}
+	checkpointed, ok := scanner.(gts.CheckpointedExternalScanner)
+	if !ok || !checkpointed.UsesExternalScannerCheckpoints() {
+		t.Fatal("HTML scanner does not advertise checkpointed state")
+	}
+	failurePreserving, ok := scanner.(gts.FailurePreservingExternalScanner)
+	if !ok || !failurePreserving.PreservesStateOnScanFailure() {
+		t.Fatal("HTML scanner does not advertise failed-scan state preservation")
 	}
 }

--- a/grammars/svelte_scanner.go
+++ b/grammars/svelte_scanner.go
@@ -70,9 +70,9 @@ func (SvelteExternalScanner) Deserialize(payload any, buf []byte) {
 	s.tags = htmlDeserializeTagsInto(s.tags, buf)
 }
 
-// htmlSerializeTags bounds both tag depth and custom-name length. Until Svelte
-// has a collision-free checkpoint encoding for its full tag stack, incremental
-// edits must take the conservative full-parse fallback.
+// The shared tag encoding is exact and fail-closed, but Svelte's additional
+// raw-text and expression-block behavior has not completed the scanner-wide
+// checkpoint certification matrix. Changed edits remain conservative.
 func (SvelteExternalScanner) SupportsIncrementalReuse() bool { return false }
 
 func (SvelteExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/language.go
+++ b/language.go
@@ -194,6 +194,17 @@ type IncrementalReuseExternalScanner interface {
 	SupportsIncrementalReuse() bool
 }
 
+// ErrorTreeIncrementalReuseExternalScanner is an optional refinement for a
+// scanner whose checkpoints are certified on clean old trees but whose parser
+// recovery ownership has not yet been certified. Returning false makes a
+// changed edit over an error-bearing old tree take the fresh-parse fallback.
+// Independently reauthenticated token-invariant leaf edits may still return
+// before this gate.
+type ErrorTreeIncrementalReuseExternalScanner interface {
+	ExternalScanner
+	SupportsIncrementalReuseFromErrorTree() bool
+}
+
 // CheckpointedExternalScanner is implemented by stateful external scanners
 // whose non-empty serialized payload is a complete checkpoint of every value
 // that can affect a later Scan call. The runtime records that checkpoint at

--- a/parser.go
+++ b/parser.go
@@ -2992,6 +2992,14 @@ func (p *Parser) parseIncrementalInternalWithMergePerKeyOverride(source []byte, 
 		}
 		return p.incrementalTokenSourceFreshFullParse(source, ts, timing)
 	}
+	if tokenSourceUsesLanguageExternalScanner(ts) && oldTree != nil && oldTree.RootNode() != nil && oldTree.RootNode().HasError() &&
+		!languageSupportsIncrementalReuseFromErrorTree(p.language) {
+		if timing != nil {
+			timing.reuseUnsupported = true
+			timing.reuseUnsupportedReason = "external_scanner_error_tree_unsupported"
+		}
+		return p.incrementalTokenSourceFreshFullParse(source, ts, timing)
+	}
 
 	// Subtree reuse is safe for DFA token sources without external scanners
 	// and for custom token sources that explicitly opt in.
@@ -3103,6 +3111,27 @@ func languageSupportsIncrementalReuse(lang *Language) bool {
 		return reusable.SupportsIncrementalReuse()
 	}
 	return false
+}
+
+func tokenSourceUsesLanguageExternalScanner(ts TokenSource) bool {
+	switch source := ts.(type) {
+	case *dfaTokenSource:
+		return source != nil && source.hasExternalScanner
+	case *includedRangeTokenSource:
+		return source != nil && tokenSourceUsesLanguageExternalScanner(source.base)
+	default:
+		return false
+	}
+}
+
+func languageSupportsIncrementalReuseFromErrorTree(lang *Language) bool {
+	if lang == nil || lang.ExternalScanner == nil {
+		return true
+	}
+	if reusable, ok := lang.ExternalScanner.(ErrorTreeIncrementalReuseExternalScanner); ok {
+		return reusable.SupportsIncrementalReuseFromErrorTree()
+	}
+	return true
 }
 
 func incrementalReuseUnavailableReason(ts TokenSource) string {

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2693,7 +2693,9 @@ func (d *dfaTokenSource) CanRelexFromTokenStart(tok Token) bool {
 		if d.usesExternalCheckpoints {
 			if !d.lastExternalTokenValid ||
 				d.lastExternalTokenStartByte != tok.StartByte ||
-				d.lastExternalTokenEndByte != tok.EndByte {
+				d.lastExternalTokenEndByte != tok.EndByte ||
+				len(d.externalTokenStart) == 0 ||
+				len(d.captureExternalScannerStateInto(&d.externalCompare)) == 0 {
 				return false
 			}
 		} else if len(d.captureExternalScannerStateInto(&d.externalCompare)) != 0 {

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -86,6 +86,59 @@ func (rawTextExternalScanner) Scan(payload any, lexer *ExternalLexer, valid []bo
 	return true
 }
 
+type checkpointByteExternalScanner struct{}
+
+func (checkpointByteExternalScanner) Create() any         { state := byte(0); return &state }
+func (checkpointByteExternalScanner) Destroy(payload any) {}
+func (checkpointByteExternalScanner) Serialize(payload any, buf []byte) int {
+	state := *payload.(*byte)
+	if state == 0xff || len(buf) == 0 {
+		return 0
+	}
+	buf[0] = state
+	return 1
+}
+func (checkpointByteExternalScanner) Deserialize(payload any, buf []byte) {
+	state := payload.(*byte)
+	*state = 0
+	if len(buf) > 0 {
+		*state = buf[0]
+	}
+}
+func (checkpointByteExternalScanner) Scan(payload any, lexer *ExternalLexer, valid []bool) bool {
+	return false
+}
+func (checkpointByteExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+
+func TestCanRelexCheckpointScannerRequiresRepresentableStartAndLiveState(t *testing.T) {
+	scanner := checkpointByteExternalScanner{}
+	lang := &Language{ExternalScanner: scanner}
+	state := scanner.Create()
+	ts := &dfaTokenSource{
+		lexer:                      NewLexer(nil, []byte("x")),
+		language:                   lang,
+		hasExternalScanner:         true,
+		usesExternalCheckpoints:    true,
+		externalPayload:            state,
+		lastExternalTokenValid:     true,
+		lastExternalTokenStartByte: 0,
+		lastExternalTokenEndByte:   1,
+	}
+	tok := Token{StartByte: 0, EndByte: 1}
+
+	if ts.CanRelexFromTokenStart(tok) {
+		t.Fatal("relex accepted an absent start checkpoint")
+	}
+	ts.externalTokenStart = []byte{0}
+	if !ts.CanRelexFromTokenStart(tok) {
+		t.Fatal("relex rejected representable start and live states")
+	}
+	*state.(*byte) = 0xff
+	if ts.CanRelexFromTokenStart(tok) {
+		t.Fatal("relex accepted an unrepresentable live state")
+	}
+}
+
 type skipPrefixExternalScanner struct{}
 
 func (skipPrefixExternalScanner) Create() any                           { return nil }

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -155,13 +155,6 @@ func TestUncertifiedExternalScannerLengthChangingEditFallsBack(t *testing.T) {
 			replacement: []byte("hello world"),
 		},
 		{
-			name:        "html",
-			lang:        grammars.HtmlLanguage,
-			source:      []byte("<main><p>hello</p></main>\n"),
-			oldText:     []byte("hello"),
-			replacement: []byte("hello world"),
-		},
-		{
 			name:        "markdown",
 			lang:        grammars.MarkdownLanguage,
 			source:      []byte("# Title\n\nParagraph text.\n"),

--- a/parser_html_incremental_certification_test.go
+++ b/parser_html_incremental_certification_test.go
@@ -1,0 +1,222 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestHTMLIncrementalScannerCertification proves that HTML's exact tag-stack
+// checkpoints support changed-length edits without sacrificing fresh-parse
+// equality. The ordinary lane crosses a clean 4 KiB document at three
+// positions; the 137 KiB lane guards admission and useful reuse at the macro
+// size without claiming O(edit) work. Error trees have a separate fail-closed
+// witness below.
+func TestHTMLIncrementalScannerCertification(t *testing.T) {
+	plans := []struct {
+		name      string
+		size      int
+		positions []string
+		classes   []htmlCertificationEditClass
+	}{
+		{
+			name:      "4KiB",
+			size:      4 << 10,
+			positions: []string{"start", "middle", "end"},
+			classes:   []htmlCertificationEditClass{htmlCertificationInsert, htmlCertificationDelete, htmlCertificationReplace},
+		},
+		{
+			name:      "137KiB",
+			size:      137 << 10,
+			positions: []string{"middle"},
+			classes:   []htmlCertificationEditClass{htmlCertificationReplace},
+		},
+	}
+
+	for _, plan := range plans {
+		source, sites := makeHTMLCertificationSource(plan.size, false)
+		for _, position := range plan.positions {
+			var site int
+			switch position {
+			case "start":
+				site = sites[1]
+			case "middle":
+				site = sites[len(sites)/2]
+			case "end":
+				site = sites[len(sites)-2]
+			default:
+				t.Fatalf("unknown HTML certification position %q", position)
+			}
+			for _, class := range plan.classes {
+				t.Run(fmt.Sprintf("%s/%s/%s", plan.name, class, position), func(t *testing.T) {
+					edited, edit := applyHTMLCertificationEdit(source, site, class)
+					profile := runHTMLCertificationSample(t, source, edited, edit)
+					if plan.size >= 137<<10 && profile.ReusedBytes*100 < uint64(len(edited))*25 {
+						t.Fatalf("HTML certification reused only %d/%d bytes (<25%%): %+v", profile.ReusedBytes, len(edited), profile)
+					}
+				})
+			}
+		}
+	}
+}
+
+type htmlCertificationEditClass uint8
+
+const (
+	htmlCertificationInsert htmlCertificationEditClass = iota
+	htmlCertificationDelete
+	htmlCertificationReplace
+)
+
+func (c htmlCertificationEditClass) String() string {
+	switch c {
+	case htmlCertificationInsert:
+		return "insert"
+	case htmlCertificationDelete:
+		return "delete"
+	case htmlCertificationReplace:
+		return "replace"
+	default:
+		return "unknown"
+	}
+}
+
+func makeHTMLCertificationSource(target int, recovered bool) ([]byte, []int) {
+	var source strings.Builder
+	source.Grow(target + 256)
+	source.WriteString("<!doctype html><html><body><main>\n")
+	sites := make([]int, 0, target/96)
+	for i := 0; source.Len() < target || len(sites) < 4; i++ {
+		source.WriteString("<section><custom-widget data-value=\"")
+		sites = append(sites, source.Len())
+		fmt.Fprintf(&source, "%06d\">payload_%06d</custom-widget></section>\n", i, i)
+	}
+	if recovered {
+		// An empty tag name forces a local recovery after the stateful scanner
+		// has carried the non-empty html/body/main stack across every edit site.
+		source.WriteString("<section><></section>\n")
+	}
+	source.WriteString("</main></body></html>\n")
+	return []byte(source.String()), sites
+}
+
+func applyHTMLCertificationEdit(source []byte, offset int, class htmlCertificationEditClass) ([]byte, gts.InputEdit) {
+	oldEnd := offset
+	replacement := []byte{'9'}
+	switch class {
+	case htmlCertificationDelete:
+		oldEnd = offset + 1
+		replacement = nil
+	case htmlCertificationReplace:
+		oldEnd = offset + 1
+		replacement = []byte("88")
+	}
+	edited := make([]byte, 0, len(source)-(oldEnd-offset)+len(replacement))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	return edited, gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, oldEnd),
+		NewEndPoint: pointForOffset(edited, offset+len(replacement)),
+	}
+}
+
+func runHTMLCertificationSample(t *testing.T, source, edited []byte, edit gts.InputEdit) gts.IncrementalParseProfile {
+	t.Helper()
+	lang := grammars.HtmlLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("initial HTML parse: %v", err)
+	}
+	defer oldTree.Release()
+	initialRoot := requireCompleteParse(t, oldTree, source, lang, "initial HTML certification")
+	requireHTMLAcceptedFullSource(t, oldTree, source, "initial HTML certification")
+	if initialRoot.HasError() {
+		t.Fatalf("initial HTML parse produced ERROR: %s", initialRoot.SExpr(lang))
+	}
+
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental HTML parse: %v", err)
+	}
+	defer incremental.Release()
+	incrementalRoot := requireCompleteParse(t, incremental, edited, lang, "incremental HTML certification")
+	requireHTMLAcceptedFullSource(t, incremental, edited, "incremental HTML certification")
+	if profile.ReuseUnsupported {
+		t.Fatalf("certified HTML scanner fell back: reason=%q", profile.ReuseUnsupportedReason)
+	}
+	if !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("certified HTML scanner did not reuse old syntax: %+v", profile)
+	}
+	if incrementalRoot.HasError() {
+		t.Fatalf("incremental HTML parse produced ERROR: %s", incrementalRoot.SExpr(lang))
+	}
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh HTML parse: %v", err)
+	}
+	defer fresh.Release()
+	requireCompleteParse(t, fresh, edited, lang, "fresh HTML certification")
+	requireHTMLAcceptedFullSource(t, fresh, edited, "fresh HTML certification")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+	return profile
+}
+
+func TestHTMLErrorTreeIncrementalReuseFailsClosed(t *testing.T) {
+	source, sites := makeHTMLCertificationSource(4<<10, true)
+	edited, edit := applyHTMLCertificationEdit(source, sites[1], htmlCertificationInsert)
+	lang := grammars.HtmlLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("initial recovered HTML parse: %v", err)
+	}
+	defer oldTree.Release()
+	oldRoot := requireCompleteParse(t, oldTree, source, lang, "initial recovered HTML")
+	if !oldRoot.HasError() {
+		t.Fatalf("recovery witness did not produce an error tree: %s", oldRoot.SExpr(lang))
+	}
+	oldTree.Edit(edit)
+
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("recovered HTML incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_error_tree_unsupported" ||
+		profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("HTML error tree did not fail closed: %+v", profile)
+	}
+
+	fresh, err := gts.NewParser(lang).Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh recovered HTML parse: %v", err)
+	}
+	defer fresh.Release()
+	requireCompleteParse(t, incremental, edited, lang, "incremental recovered HTML fallback")
+	requireCompleteParse(t, fresh, edited, lang, "fresh recovered HTML")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+}
+
+func requireHTMLAcceptedFullSource(t *testing.T, tree *gts.Tree, source []byte, phase string) {
+	t.Helper()
+	rt := tree.ParseRuntime()
+	if tree.ParseStoppedEarly() || rt.StopReason != gts.ParseStopAccepted || rt.Truncated ||
+		rt.ExpectedEOFByte != uint32(len(source)) {
+		t.Fatalf("%s: parse was not accepted, non-truncated, and full-source: %s", phase, rt.Summary())
+	}
+}


### PR DESCRIPTION
## Summary

- make HTML-family tag-stack checkpoints exact and fail closed on unrepresentable state
- certify changed-length incremental reuse for clean HTML trees while explicitly falling back for error-bearing old trees
- reject checkpoint relex when start or live scanner state is absent
- restore standalone grammar_subset_html portability by separating the Blade-specific scanner from shared HTML-family helpers

## Verification

- focused HTML scanner, registry, relex, incremental, and fallback tests in Docker
- HTML incremental matrix: 4 KiB insert/delete/replace at start/middle/end plus 137 KiB changed-length replace
- grammar_subset_html package build in Docker
- isolated HTML real-corpus C parity: 25/25 no-error, S-expression parity, and deep parity

Advances #432 without claiming recovery-tree admission or O(edit) performance.