### PR TITLE
feat(parser): admit certified stateless scanner reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **Stateless external-scanner reuse now covers Cue, D, Elixir, and Erlang.**
+  Capability markers replace language-name admission, while a strict recorded
+  pre-goto ownership check prevents stale whole-sibling transfer for the
+  certified stateless class. A shared differential matrix covers
+  insert/delete/replace edits across 4 KiB fixtures and a 137 KiB macro lane,
+  requiring real reuse and exact fresh-tree identity. Checkpointed reuse also
+  authenticates scanner state at the current lookahead's start rather than its
+  post-lex live state. Stateful scanners without a complete proof remain
+  fail-closed.
+
 - **HTML external-scanner reuse is checkpoint-certified for clean old trees.**
   The complete open-tag stack now serializes exactly or returns an absent
   checkpoint; oversized depth, custom names, and buffer exhaustion can no

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -372,13 +372,23 @@ rather than scanner-dependent reuse.
 PowerShell's scanner is stateless: it recognizes one zero-width statement
 terminator from the current lookahead and valid-symbol set, carries no payload,
 and has no stateful here-string handling. It therefore uses the same stateless
-quiescence proof as Go rather than the checkpoint route. Focused certification
-crosses changed-length edits at multiple positions and requires incremental
-trees to match fresh production parses. The representative 137 KiB near-top
-insert currently ratchets a conservative 5% reused-byte floor: scanner
+quiescence proof as Go rather than the checkpoint route. Its focused
+certification crosses changed-length edits at multiple positions and requires
+incremental trees to match fresh production parses. The representative 137 KiB
+near-top insert currently ratchets a conservative 5% reused-byte floor: scanner
 admission is solved, but source-wide non-leaf ownership and stale-boundary
 rejections remain a separate performance frontier rather than an O(edit)
 claim.
+
+The same capability proof now applies to Cue, D, Elixir, and Erlang. Each
+scanner has a nil payload, empty serialization, and reads only local lookahead
+plus parser-provided valid symbols. Their shared fresh-oracle matrix covers
+changed-length insert/delete/replace edits at the start, middle, and end of a
+4 KiB clean corpus, plus a 137 KiB macro witness with measured reuse floors.
+Because that wave exposed stale top-level reduction ownership in Cue, newly
+admitted stateless scanners additionally require an exact recorded pre-goto
+frontier before whole-sibling transfer; legacy scanner lanes retain their
+existing measured contract until the broader ownership proof is complete.
 
 SQL's state proof is explicit: the payload is either empty or exactly one
 active PostgreSQL dollar-quote tag. The empty state has a one-byte marker;
@@ -430,8 +440,8 @@ silently widening HTML admission.
 | `crystal` | fallback (uncertified) |
 | `css` | certified reuse |
 | `cuda` | fallback (uncertified) |
-| `cue` | fallback (uncertified) |
-| `d` | fallback (uncertified) |
+| `cue` | certified reuse |
+| `d` | certified reuse |
 | `dart` | bounded reuse (up to 256 KiB) |
 | `dhall` | fallback (uncertified) |
 | `disassembly` | fallback (uncertified) |
@@ -441,9 +451,9 @@ silently widening HTML admission.
 | `dtd` | fallback (uncertified) |
 | `earthfile` | fallback (uncertified) |
 | `editorconfig` | fallback (uncertified) |
-| `elixir` | fallback (uncertified) |
+| `elixir` | certified reuse |
 | `elm` | fallback (uncertified) |
-| `erlang` | fallback (uncertified) |
+| `erlang` | certified reuse |
 | `fennel` | fallback (uncertified) |
 | `firrtl` | fallback (uncertified) |
 | `fish` | fallback (uncertified) |

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -271,6 +271,10 @@ func currentExternalScannerCheckpoint(ts TokenSource) (externalScannerCheckpoint
 }
 
 func canReuseNodeWithExternalScannerCheckpoint(ts TokenSource, startState StateID, node *Node) (externalScannerCheckpointRef, bool) {
+	return canReuseNodeWithExternalScannerCheckpointAtLookahead(ts, startState, node, ^uint32(0))
+}
+
+func canReuseNodeWithExternalScannerCheckpointAtLookahead(ts TokenSource, startState StateID, node *Node, lookaheadStart uint32) (externalScannerCheckpointRef, bool) {
 	dts := underlyingDFATokenSource(ts)
 	if dts == nil {
 		return externalScannerCheckpointRef{}, true
@@ -278,10 +282,10 @@ func canReuseNodeWithExternalScannerCheckpoint(ts TokenSource, startState StateI
 	if !languageUsesExternalScannerCheckpoints(dts.language) {
 		// Non-checkpoint external-scanner path. The W4 scanner-quiescence
 		// classifier is the per-boundary authority here (campaign O(edit),
-		// spec.campaign.oedit). A stateless scanner (Go's automatic-semicolon
-		// scanner, proven in external_scanner_quiescence.go) is quiescent at
-		// every boundary, so reuse is sound and returns a zero checkpoint the
-		// non-checkpoint reuse path never reads. A scanner that opts out of
+		// spec.campaign.oedit). A scanner satisfying the stateless proof in
+		// external_scanner_quiescence.go is quiescent at every boundary, so
+		// reuse is sound and returns a zero checkpoint the non-checkpoint reuse
+		// path never reads. A scanner that opts out of
 		// incremental reuse is refuted, and the caller fails closed. Every
 		// other language keeps the legacy blanket admission, so this stays
 		// neutral for production languages today.
@@ -294,7 +298,8 @@ func canReuseNodeWithExternalScannerCheckpoint(ts TokenSource, startState StateI
 	if !ok {
 		return externalScannerCheckpointRef{}, languageAllowsCheckpointlessExternalReuse(dts.language)
 	}
-	if !dts.externalScannerStateMatches(node.ownerArena.externalScannerSnapshotBytes(cp.start)) {
+	want := node.ownerArena.externalScannerSnapshotBytes(cp.start)
+	if !dts.externalScannerStateAtLookaheadStartMatches(want, lookaheadStart) {
 		return externalScannerCheckpointRef{}, false
 	}
 	return cp, true

--- a/external_scanner_quiescence.go
+++ b/external_scanner_quiescence.go
@@ -17,7 +17,15 @@ package gotreesitter
 // argument, not from a curated language list.
 //
 // -----------------------------------------------------------------------
-// Go proof obligations (backed by grammars/go_scanner.go).
+// Stateless-scanner proof obligations.
+//
+// Go is the reference proof below (backed by grammars/go_scanner.go). Other
+// scanners may implement StatelessExternalScanner only when the same core
+// obligations hold: no persisted payload, Scan depends only on local
+// lookahead plus the parser-provided valid-symbol set, and a failed Scan
+// preserves the empty state. The production admission matrix and fresh-tree
+// differential tests live in docs/external-scanners.md and
+// parser_stateless_scanner_incremental_certification_test.go.
 //
 // Go's only external token is `_automatic_semicolon` (ASI). The scanner that
 // resolves it is GoExternalScanner. The proof that every Go reuse boundary is
@@ -107,8 +115,9 @@ func classifyExternalScannerQuiescence(lang *Language) externalScannerQuiescence
 		return scannerQuiescenceProven
 	}
 	if stateless, ok := lang.ExternalScanner.(StatelessExternalScanner); ok && stateless.ExternalScannerIsStateless() {
-		// A stateless scanner (Go's ASI scanner) is quiescent at every
-		// boundary. See the proof obligations at the top of this file.
+		// A scanner satisfying the stateless proof is quiescent at every
+		// boundary. See the proof obligations at the top of this file and the
+		// per-scanner certification matrix.
 		return scannerQuiescenceProven
 	}
 	if reusable, ok := lang.ExternalScanner.(IncrementalReuseExternalScanner); ok && !reusable.SupportsIncrementalReuse() {

--- a/grammars/cue_scanner.go
+++ b/grammars/cue_scanner.go
@@ -32,6 +32,13 @@ func (CueExternalScanner) Destroy(payload any)                   {}
 func (CueExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (CueExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (CueExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (CueExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (CueExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (CueExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if cueValid(validSymbols, cueTokMultiStrContent) {
 		return cueScanMultiline(lexer, '"', cueSymMultiStrContent)

--- a/grammars/d_scanner.go
+++ b/grammars/d_scanner.go
@@ -29,6 +29,13 @@ func (DExternalScanner) Destroy(payload any)                   {}
 func (DExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (DExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (DExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (DExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (DExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (DExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	lang := DLanguage()
 	c := lexer.Lookahead()

--- a/grammars/elixir_scanner.go
+++ b/grammars/elixir_scanner.go
@@ -79,6 +79,13 @@ func (ElixirExternalScanner) Destroy(payload any)                   {}
 func (ElixirExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (ElixirExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (ElixirExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (ElixirExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (ElixirExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (ElixirExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	return scanElixir(lexer, validSymbols)
 }

--- a/grammars/erlang_scanner.go
+++ b/grammars/erlang_scanner.go
@@ -33,6 +33,13 @@ func (ErlangExternalScanner) Destroy(payload any)                   {}
 func (ErlangExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (ErlangExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (ErlangExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (ErlangExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (ErlangExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (ErlangExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !erlangValid(validSymbols, erlangTokTQString) && !erlangValid(validSymbols, erlangTokTQSigilString) {
 		return false

--- a/incremental.go
+++ b/incremental.go
@@ -78,11 +78,12 @@ type reuseCursor struct {
 	// scanner checkpoint/quiescence gate (canReuseNodeWithExternalScannerCheck
 	// point) -- either a checkpoint state mismatch or a refuted quiescence
 	// proof (campaign O(edit) W4, external_scanner_quiescence.go). It stays 0
-	// for stateless-scanner languages such as Go, whose every boundary is
+	// for certified stateless-scanner languages, whose every boundary is
 	// proven quiescent. See the Parser.ReuseRejectScannerUnquiescent field.
 	rejectScannerUnquiescent uint64
 	forestFastPath           bool
 	languageName             string // cached for language-specific reuse safety policies
+	strictTopLevelOwnership  bool   // newly certified stateless scanners require the recorded normal-dispatch frontier
 }
 
 // reuseScratch holds reusable buffers for incremental reuse traversal.
@@ -132,8 +133,12 @@ func (c *reuseCursor) reset(oldTree *Tree, source []byte, scratch *reuseScratch)
 	c.rejectScannerUnquiescent = 0
 	c.forestFastPath = oldTree.forestFastPath
 	c.languageName = ""
+	c.strictTopLevelOwnership = false
 	if oldTree.language != nil {
 		c.languageName = oldTree.language.Name
+		if stateless, ok := oldTree.language.ExternalScanner.(StatelessExternalScanner); ok {
+			c.strictTopLevelOwnership = stateless.ExternalScannerIsStateless()
+		}
 	}
 
 	root := oldTree.RootNode()
@@ -640,14 +645,18 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 				idx.rejectRootNonLeafChanged++
 				continue
 			}
-			// Record ownership-frontier mismatches without changing the established
-			// admission decision. The current block path historically admits by
-			// goto target + fragility; #432 owns replacing that empirical contract
-			// with a complete normal-dispatch ownership proof. This diagnostic tells
-			// us exactly where that proof is still required while preserving the
-			// existing Go/CSS performance ratchets.
+			// A compatible goto target does not prove that this old reduction was
+			// owned by the live normal-dispatch frontier. Newly admitted stateless
+			// scanners require their recorded pre-goto state before transfer;
+			// otherwise repeated top-level constructs can retain stale ownership
+			// and diverge from a fresh tree even when bytes and scanner state match.
+			// Legacy lanes retain their measured contract until #432 replaces it
+			// without regressing the established editor-latency ratchets.
 			if !fullRootUndo && !topLevelCandidateOwnsCurrentFrontier(n, state) {
 				idx.observedPreGotoStateMismatch++
+				if idx.strictTopLevelOwnership {
+					continue
+				}
 			}
 		}
 		nextState, ok := p.reuseTargetState(state, n, lookahead)
@@ -657,7 +666,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 		if !reuseSubtreeGapIsParserPadding(idx.newSource, s.byteOffset, n.StartByte()) {
 			continue
 		}
-		cp, ok := canReuseNodeWithExternalScannerCheckpoint(ts, state, n)
+		cp, ok := canReuseNodeWithExternalScannerCheckpointAtLookahead(ts, state, n, lookahead.StartByte)
 		if !ok {
 			idx.rejectScannerUnquiescent++
 			continue
@@ -749,7 +758,7 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			}
 		}
 		startState := s.top().state
-		cp, ok := canReuseNodeWithExternalScannerCheckpoint(ts, startState, n)
+		cp, ok := canReuseNodeWithExternalScannerCheckpointAtLookahead(ts, startState, n, lookahead.StartByte)
 		if !ok {
 			idx.rejectScannerUnquiescent++
 			continue

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -3595,6 +3595,22 @@ func (d *dfaTokenSource) externalScannerStateMatches(snapshot []byte) bool {
 	return bytes.Equal(current, snapshot)
 }
 
+// externalScannerStateAtLookaheadStartMatches authenticates a reuse boundary
+// against the scanner state before the current lookahead was lexed. Parser
+// reuse runs after fetching that lookahead, so comparing with the live payload
+// would instead compare the candidate's start against the token's end state.
+// Scanners such as YAML update position state on nearly every token and make
+// that distinction observable.
+func (d *dfaTokenSource) externalScannerStateAtLookaheadStartMatches(snapshot []byte, lookaheadStart uint32) bool {
+	if d == nil {
+		return len(snapshot) == 0
+	}
+	if d.lastExternalTokenValid && d.lastExternalTokenStartByte == lookaheadStart {
+		return bytes.Equal(d.externalTokenStart, snapshot)
+	}
+	return d.externalScannerStateMatches(snapshot)
+}
+
 func (d *dfaTokenSource) externalSymbolIndex(sym Symbol) int {
 	if d == nil || d.language == nil {
 		return -1

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -139,6 +139,28 @@ func TestCanRelexCheckpointScannerRequiresRepresentableStartAndLiveState(t *test
 	}
 }
 
+func TestExternalScannerReuseAuthenticatesLookaheadStartState(t *testing.T) {
+	scanner := checkpointByteExternalScanner{}
+	state := scanner.Create()
+	*state.(*byte) = 9 // live payload is already at the lookahead token's end
+	ts := &dfaTokenSource{
+		language:                   &Language{ExternalScanner: scanner},
+		externalPayload:            state,
+		lastExternalTokenValid:     true,
+		lastExternalTokenStartByte: 12,
+		externalTokenStart:         []byte{3},
+	}
+	if !ts.externalScannerStateAtLookaheadStartMatches([]byte{3}, 12) {
+		t.Fatal("reuse boundary compared against live lookahead-end state instead of recorded start state")
+	}
+	if ts.externalScannerStateAtLookaheadStartMatches([]byte{4}, 12) {
+		t.Fatal("reuse boundary accepted a different recorded lookahead-start state")
+	}
+	if ts.externalScannerStateAtLookaheadStartMatches([]byte{3}, 13) {
+		t.Fatal("reuse boundary used a start snapshot from a different token")
+	}
+}
+
 type skipPrefixExternalScanner struct{}
 
 func (skipPrefixExternalScanner) Create() any                           { return nil }

--- a/parser_stateless_scanner_incremental_certification_test.go
+++ b/parser_stateless_scanner_incremental_certification_test.go
@@ -1,0 +1,168 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestStatelessScannerIncrementalCertification certifies a capability class,
+// not a name-based runtime allowlist. Each scanner has a nil payload, empty
+// serialization, and a Scan decision derived only from lookahead plus the
+// parser-provided valid-symbol set. The fresh oracle still crosses every
+// grammar independently so parser ownership remains part of admission.
+func TestStatelessScannerIncrementalCertification(t *testing.T) {
+	cases := []struct {
+		name                 string
+		lang                 func() *gts.Language
+		line                 func(int) string
+		minMacroReusePercent uint64
+		minMacroReuseBytes   uint64
+	}{
+		{name: "cue", lang: grammars.CueLanguage, line: func(i int) string { return fmt.Sprintf("field_%06d: %d\n", i, i) }, minMacroReusePercent: 15},
+		{name: "d", lang: grammars.DLanguage, line: func(i int) string { return fmt.Sprintf("int value_%06d = %d;\n", i, i) }, minMacroReusePercent: 15},
+		{name: "elixir", lang: grammars.ElixirLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d = %d\n", i, i) }, minMacroReuseBytes: 16},
+		{name: "erlang", lang: grammars.ErlangLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d() -> %d.\n", i, i) }, minMacroReusePercent: 25},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plans := []struct {
+				name      string
+				size      int
+				positions []string
+				classes   []statelessScannerEditClass
+			}{
+				{name: "4KiB", size: 4 << 10, positions: []string{"start", "middle", "end"}, classes: []statelessScannerEditClass{statelessScannerInsert, statelessScannerDelete, statelessScannerReplace}},
+				{name: "137KiB", size: 137 << 10, positions: []string{"middle"}, classes: []statelessScannerEditClass{statelessScannerReplace}},
+			}
+			for _, plan := range plans {
+				source, sites := makeStatelessScannerCertificationSource(plan.size, tc.line)
+				for _, position := range plan.positions {
+					var site int
+					switch position {
+					case "start":
+						site = sites[1]
+					case "middle":
+						site = sites[len(sites)/2]
+					case "end":
+						site = sites[len(sites)-2]
+					}
+					for _, class := range plan.classes {
+						t.Run(fmt.Sprintf("%s/%s/%s", plan.name, class, position), func(t *testing.T) {
+							edited, edit := applyStatelessScannerCertificationEdit(source, site, class)
+							profile := runStatelessScannerCertificationSample(t, tc.lang(), source, edited, edit)
+							if plan.size >= 137<<10 && profile.ReusedBytes*100 < uint64(len(edited))*tc.minMacroReusePercent {
+								t.Fatalf("stateless scanner reused only %d/%d bytes (<%d%%): %+v", profile.ReusedBytes, len(edited), tc.minMacroReusePercent, profile)
+							}
+							if plan.size >= 137<<10 && profile.ReusedBytes < tc.minMacroReuseBytes {
+								t.Fatalf("stateless scanner reused only %d bytes (<%d): %+v", profile.ReusedBytes, tc.minMacroReuseBytes, profile)
+							}
+						})
+					}
+				}
+			}
+		})
+	}
+}
+
+type statelessScannerEditClass uint8
+
+const (
+	statelessScannerInsert statelessScannerEditClass = iota
+	statelessScannerDelete
+	statelessScannerReplace
+)
+
+func (c statelessScannerEditClass) String() string {
+	switch c {
+	case statelessScannerInsert:
+		return "insert"
+	case statelessScannerDelete:
+		return "delete"
+	case statelessScannerReplace:
+		return "replace"
+	default:
+		return "unknown"
+	}
+}
+
+func makeStatelessScannerCertificationSource(target int, line func(int) string) ([]byte, []int) {
+	var source strings.Builder
+	source.Grow(target + 128)
+	sites := make([]int, 0, target/24)
+	for i := 0; source.Len() < target || len(sites) < 4; i++ {
+		entry := line(i)
+		underscore := strings.IndexByte(entry, '_')
+		if underscore < 0 {
+			panic("stateless scanner certification line lacks marker")
+		}
+		marker := underscore + 1
+		sites = append(sites, source.Len()+marker)
+		source.WriteString(entry)
+	}
+	return []byte(source.String()), sites
+}
+
+func applyStatelessScannerCertificationEdit(source []byte, offset int, class statelessScannerEditClass) ([]byte, gts.InputEdit) {
+	oldEnd := offset
+	replacement := []byte{'8'}
+	switch class {
+	case statelessScannerDelete:
+		oldEnd = offset + 1
+		replacement = nil
+	case statelessScannerReplace:
+		oldEnd = offset + 1
+		replacement = []byte("88")
+	}
+	edited := make([]byte, 0, len(source)-(oldEnd-offset)+len(replacement))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	return edited, gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, oldEnd),
+		NewEndPoint: pointForOffset(edited, offset+len(replacement)),
+	}
+}
+
+func runStatelessScannerCertificationSample(t *testing.T, lang *gts.Language, source, edited []byte, edit gts.InputEdit) gts.IncrementalParseProfile {
+	t.Helper()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("initial parse: %v", err)
+	}
+	defer oldTree.Release()
+	oldRoot := requireCompleteParse(t, oldTree, source, lang, "initial stateless-scanner certification")
+	if oldRoot.HasError() {
+		t.Fatalf("initial fixture produced ERROR: %s", oldRoot.SExpr(lang))
+	}
+	oldTree.Edit(edit)
+
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	requireCompleteParse(t, incremental, edited, lang, "incremental stateless-scanner certification")
+	if profile.ReuseUnsupported || !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("stateless scanner did not enter useful reuse: %+v", profile)
+	}
+
+	fresh, err := gts.NewParser(lang).Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	requireCompleteParse(t, fresh, edited, lang, "fresh stateless-scanner certification")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+	return profile
+}

--- a/w1_sibling_splice_test.go
+++ b/w1_sibling_splice_test.go
@@ -97,9 +97,12 @@ func buildTopLevelListLanguage() *Language {
 // trailing unaffected sibling run (topLevelResumeByte == stmt0.EndByte()).
 // fragile marks stmt1's fragility bits, mirroring markReduceFragility's
 // output for a reduce that ran under GLR ambiguity.
-func topLevelSpliceFixture(t *testing.T, fragile bool) (*Parser, *reuseCursor, []byte) {
+func topLevelSpliceFixture(t *testing.T, fragile, stateless bool) (*Parser, *reuseCursor, []byte) {
 	t.Helper()
 	lang := buildTopLevelListLanguage()
+	if stateless {
+		lang.ExternalScanner = quiescenceStatelessScanner{}
+	}
 	parser := NewParser(lang)
 
 	// 6 bytes: "aa" (stmt0) + "bb" (stmt1) + "cc" (stmt2).
@@ -154,7 +157,7 @@ func topLevelSpliceFixture(t *testing.T, fragile bool) (*Parser, *reuseCursor, [
 // lane (or fail entirely, as the retired allowlist gate would have refused
 // it before ever trying).
 func TestTopLevelSiblingBlockSpliceAdmitsNonForestNonCSSLanguage(t *testing.T) {
-	parser, reuse, newSource := topLevelSpliceFixture(t, false)
+	parser, reuse, newSource := topLevelSpliceFixture(t, false, false)
 	if reuse.forestFastPath {
 		t.Fatal("fixture invariant: forestFastPath must be false to prove the allowlist gate is gone")
 	}
@@ -189,6 +192,33 @@ func TestTopLevelSiblingBlockSpliceAdmitsNonForestNonCSSLanguage(t *testing.T) {
 	}
 }
 
+// TestTopLevelSiblingBlockSpliceRequiresOwnershipForStatelessAdmission locks
+// down the ownership half of the stateless-scanner proof. Scanner quiescence
+// alone is insufficient: a whole old reduction may have a compatible goto
+// from the live state without having been reduced from that state. Newly
+// certified stateless scanners therefore reject this fabricated mismatch,
+// while the preceding legacy-lane test preserves the measured W1 contract.
+func TestTopLevelSiblingBlockSpliceRequiresOwnershipForStatelessAdmission(t *testing.T) {
+	parser, reuse, newSource := topLevelSpliceFixture(t, false, true)
+	if !reuse.strictTopLevelOwnership {
+		t.Fatal("stateless scanner did not enable strict top-level ownership")
+	}
+
+	var entryScratch glrEntryScratch
+	var gssScratch gssScratch
+	stack := newGLRStackWithScratch(1, &entryScratch)
+	stack.byteOffset = 2
+	lookahead := Token{Symbol: 2, StartByte: 2, EndByte: 2}
+	ts := &stubTokenSource{tokens: []Token{{Symbol: 0, StartByte: uint32(len(newSource)), EndByte: uint32(len(newSource))}}}
+
+	if _, _, ok := parser.tryReuseSubtree(&stack, lookahead, ts, reuse, &entryScratch, &gssScratch); ok {
+		t.Fatal("stateless admission reused a top-level node owned by a different pre-goto state")
+	}
+	if reuse.observedPreGotoStateMismatch == 0 {
+		t.Fatal("expected the ownership mismatch to be observed")
+	}
+}
+
 // TestTopLevelSiblingBlockSpliceRejectsFragileCandidate is the fixture-level
 // control: the identical position, but stmt1 carries the fragility bits a
 // real reduce-under-ambiguity would set. The fragility gate must bar it from
@@ -199,7 +229,7 @@ func TestTopLevelSiblingBlockSpliceAdmitsNonForestNonCSSLanguage(t *testing.T) {
 // splicing a fragile subtree just because it sits at a top-level boundary
 // with byte-identical text.
 func TestTopLevelSiblingBlockSpliceRejectsFragileCandidate(t *testing.T) {
-	parser, reuse, newSource := topLevelSpliceFixture(t, true)
+	parser, reuse, newSource := topLevelSpliceFixture(t, true, false)
 
 	var entryScratch glrEntryScratch
 	var gssScratch gssScratch


### PR DESCRIPTION
## Summary
- certify Cue, D, Elixir, and Erlang for incremental reuse through a shared stateless-scanner capability proof
- authenticate checkpoint state at the current lookahead start and require recorded pre-goto ownership for the certified stateless class
- add fresh-tree differential coverage across insert, delete, and replace edits at 4 KiB and a 137 KiB macro lane

## Validation
- focused Docker correctness plus full W5 latency and determinism gate
- focused Docker race gate
- external-scanner documentation contract
- Cue, D, Elixir, and Erlang grammar-subset builds
- Canopy structural review

## Notes
- stacked on PR #443; retarget to main after that lands
- YAML remains fail-closed: its exact-checkpoint prototype exposed unresolved ownership/materialization divergence and was fully reverted
- D real-corpus parity remains at its known non-strict baseline rather than full C parity; this patch does not modify scanner behavior, only admission capability and runtime guards