### PR TITLE
feat(grammars): expand certified stateless scanner reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **The stateless-scanner admission matrix now also covers Gleam, Move, Tcl,
+  and WGSL.** Each scanner passes the shared 4 KiB multi-position edit matrix
+  and 137 KiB fresh-tree differential with a measured reuse floor. AWK and
+  Squirrel remain fail-closed because their old trees use the GSS forest fast
+  path; scanner statelessness alone does not bypass that parser-level gate.
+
 - **Stateless external-scanner reuse now covers Cue, D, Elixir, and Erlang.**
   Capability markers replace language-name admission, while a strict recorded
   pre-goto ownership check prevents stale whole-sibling transfer for the

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -390,6 +390,15 @@ admitted stateless scanners additionally require an exact recorded pre-goto
 frontier before whole-sibling transfer; legacy scanner lanes retain their
 existing measured contract until the broader ownership proof is complete.
 
+The next stateless wave admits Gleam, Move, Tcl, and WGSL through the same
+matrix and ownership gate. Their 137 KiB witnesses ratchet conservative reuse
+floors of 3%, 5%, 32 bytes, and 45%, respectively; these are correctness and
+admission floors, not claims that the remaining ownership rejection frontier
+is performant. AWK and Squirrel remain uncertified even though their scanners
+are stateless because their clean witness trees are produced by the GSS forest
+fast path, whose old-tree reuse route is still intentionally disabled. KDL and
+Nix share that parser-level blocker.
+
 SQL's state proof is explicit: the payload is either empty or exactly one
 active PostgreSQL dollar-quote tag. The empty state has a one-byte marker;
 representable non-empty states serialize as the tag plus a trailing NUL. A tag
@@ -462,7 +471,7 @@ silently widening HTML admission.
 | `fsharp` | fallback (uncertified) |
 | `gdscript` | fallback (uncertified) |
 | `gitcommit` | fallback (uncertified) |
-| `gleam` | fallback (uncertified) |
+| `gleam` | certified reuse |
 | `gn` | fallback (uncertified) |
 | `go` | certified reuse |
 | `godot_resource` | fallback (uncertified) |
@@ -489,7 +498,7 @@ silently widening HTML admission.
 | `markdown_inline` | fallback (uncertified) |
 | `matlab` | fallback (uncertified) |
 | `mojo` | fallback (explicit opt-out) |
-| `move` | fallback (uncertified) |
+| `move` | certified reuse |
 | `nginx` | fallback (uncertified) |
 | `nickel` | fallback (uncertified) |
 | `nim` | fallback (uncertified) |
@@ -522,7 +531,7 @@ silently widening HTML admission.
 | `svelte` | fallback (explicit opt-out) |
 | `swift` | fallback (uncertified) |
 | `tablegen` | fallback (uncertified) |
-| `tcl` | fallback (uncertified) |
+| `tcl` | certified reuse |
 | `teal` | fallback (uncertified) |
 | `templ` | fallback (uncertified) |
 | `tlaplus` | fallback (uncertified) |
@@ -533,7 +542,7 @@ silently widening HTML admission.
 | `uxntal` | fallback (uncertified) |
 | `vhdl` | fallback (uncertified) |
 | `vue` | fallback (uncertified) |
-| `wgsl` | fallback (uncertified) |
+| `wgsl` | certified reuse |
 | `wolfram` | fallback (uncertified) |
 | `xml` | fallback (uncertified) |
 | `yaml` | fallback (uncertified) |

--- a/grammars/gleam_scanner.go
+++ b/grammars/gleam_scanner.go
@@ -30,6 +30,13 @@ func (GleamExternalScanner) Destroy(payload any)                   {}
 func (GleamExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (GleamExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (GleamExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (GleamExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (GleamExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (GleamExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if gleamValid(validSymbols, gleamTokQuotedContent) {
 		return scanGleamQuotedContent(lexer)

--- a/grammars/move_scanner.go
+++ b/grammars/move_scanner.go
@@ -30,6 +30,13 @@ func (MoveExternalScanner) Destroy(payload any)                   {}
 func (MoveExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (MoveExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (MoveExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (MoveExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (MoveExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (MoveExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Error recovery state: bail out, exactly like the C scanner.
 	if moveValid(validSymbols, moveTokErrorSentinel) {

--- a/grammars/tcl_scanner.go
+++ b/grammars/tcl_scanner.go
@@ -27,6 +27,13 @@ func (TclExternalScanner) Destroy(payload any)                   {}
 func (TclExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (TclExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (TclExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (TclExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (TclExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (TclExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	ch := lexer.Lookahead()
 

--- a/grammars/wgsl_scanner.go
+++ b/grammars/wgsl_scanner.go
@@ -21,6 +21,13 @@ func (WgslExternalScanner) Destroy(payload any)                   {}
 func (WgslExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (WgslExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (WgslExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (WgslExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (WgslExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (WgslExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !wgslValid(validSymbols, wgslTokBlockComment) {
 		return false

--- a/parser_stateless_scanner_incremental_certification_test.go
+++ b/parser_stateless_scanner_incremental_certification_test.go
@@ -26,6 +26,10 @@ func TestStatelessScannerIncrementalCertification(t *testing.T) {
 		{name: "d", lang: grammars.DLanguage, line: func(i int) string { return fmt.Sprintf("int value_%06d = %d;\n", i, i) }, minMacroReusePercent: 15},
 		{name: "elixir", lang: grammars.ElixirLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d = %d\n", i, i) }, minMacroReuseBytes: 16},
 		{name: "erlang", lang: grammars.ErlangLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d() -> %d.\n", i, i) }, minMacroReusePercent: 25},
+		{name: "gleam", lang: grammars.GleamLanguage, line: func(i int) string { return fmt.Sprintf("const value_%06d = \"%d\"\n", i, i) }, minMacroReusePercent: 3},
+		{name: "move", lang: grammars.MoveLanguage, line: func(i int) string { return fmt.Sprintf("module 0x1::value_%06d { const VALUE: u64 = %d; }\n", i, i) }, minMacroReusePercent: 5},
+		{name: "tcl", lang: grammars.TclLanguage, line: func(i int) string { return fmt.Sprintf("set value_%06d %d\n", i, i) }, minMacroReuseBytes: 32},
+		{name: "wgsl", lang: grammars.WgslLanguage, line: func(i int) string { return fmt.Sprintf("/* value */ fn value_%06d() { let x: i32 = %d; }\n", i, i) }, minMacroReusePercent: 45},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- certify Gleam, Move, Tcl, and WGSL for changed-edit reuse through the shared stateless capability proof
- extend the 4 KiB multi-position and 137 KiB fresh-tree differential matrix with measured reuse floors
- preserve AWK, Squirrel, KDL, and Nix as explicit forest-fast-path negatives

## Validation
- complete stateless certification matrix in Docker
- focused race gate in Docker
- external-scanner documentation contract
- four grammar-subset builds
- fresh Canopy index and structural review

## Stack
- based on fully green PR #444
- PR #444 is based on fully green PR #443
- retarget to main as the preceding waves land