### PR TITLE
feat(grammars): certify twelve stateless scanners for incremental reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **Twelve more stateless scanners are certified for changed-edit reuse:**
+  EditorConfig, Fennel, Fish, GN, Janet, Julia, Less, Liquid, Pkl, Racket,
+  TableGen, and Yuck. The shared fresh-tree matrix enforces real reuse across
+  edit classes and positions, with measured 137 KiB floors that preserve low
+  ownership-reuse cases as visible performance residuals.
+
 - **The stateless-scanner admission matrix now also covers Gleam, Move, Tcl,
   and WGSL.** Each scanner passes the shared 4 KiB multi-position edit matrix
   and 137 KiB fresh-tree differential with a measured reuse floor. AWK and

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -399,6 +399,13 @@ are stateless because their clean witness trees are produced by the GSS forest
 fast path, whose old-tree reuse route is still intentionally disabled. KDL and
 Nix share that parser-level blocker.
 
+The same proof and matrix also admit EditorConfig, Fennel, Fish, GN, Janet,
+Julia, Less, Liquid, Pkl, Racket, TableGen, and Yuck. Their macro witnesses
+carry measured floors from 20% to 90% where ownership reuse is broad;
+Fish retains a 32-byte floor because its scanner is certified but top-level
+ownership rejection still dominates. The low floor is recorded as a parser
+performance residual, not inflated into a scanner-safety blocker.
+
 SQL's state proof is explicit: the payload is either empty or exactly one
 active PostgreSQL dollar-quote tag. The empty state has a one-byte marker;
 representable non-empty states serialize as the tag plus a trailing NUL. A tag
@@ -459,20 +466,20 @@ silently widening HTML admission.
 | `doxygen` | fallback (uncertified) |
 | `dtd` | fallback (uncertified) |
 | `earthfile` | fallback (uncertified) |
-| `editorconfig` | fallback (uncertified) |
+| `editorconfig` | certified reuse |
 | `elixir` | certified reuse |
 | `elm` | fallback (uncertified) |
 | `erlang` | certified reuse |
-| `fennel` | fallback (uncertified) |
+| `fennel` | certified reuse |
 | `firrtl` | fallback (uncertified) |
-| `fish` | fallback (uncertified) |
+| `fish` | certified reuse |
 | `foam` | fallback (uncertified) |
 | `fortran` | fallback (uncertified) |
 | `fsharp` | fallback (uncertified) |
 | `gdscript` | fallback (uncertified) |
 | `gitcommit` | fallback (uncertified) |
 | `gleam` | certified reuse |
-| `gn` | fallback (uncertified) |
+| `gn` | certified reuse |
 | `go` | certified reuse |
 | `godot_resource` | fallback (uncertified) |
 | `hack` | fallback (uncertified) |
@@ -481,17 +488,17 @@ silently widening HTML admission.
 | `hcl` | fallback (uncertified) |
 | `hlsl` | fallback (uncertified) |
 | `html` | bounded reuse (clean old trees) |
-| `janet` | fallback (uncertified) |
+| `janet` | certified reuse |
 | `javascript` | certified reuse |
 | `jsdoc` | fallback (uncertified) |
 | `jsonnet` | fallback (uncertified) |
-| `julia` | fallback (uncertified) |
+| `julia` | certified reuse |
 | `just` | fallback (uncertified) |
 | `kconfig` | fallback (uncertified) |
 | `kdl` | fallback (uncertified) |
 | `kotlin` | fallback (uncertified) |
-| `less` | fallback (uncertified) |
-| `liquid` | fallback (uncertified) |
+| `less` | certified reuse |
+| `liquid` | certified reuse |
 | `lua` | fallback (uncertified) |
 | `luau` | fallback (uncertified) |
 | `markdown` | fallback (uncertified) |
@@ -510,14 +517,14 @@ silently widening HTML admission.
 | `org` | fallback (uncertified) |
 | `perl` | fallback (uncertified) |
 | `php` | fallback (uncertified) |
-| `pkl` | fallback (uncertified) |
+| `pkl` | certified reuse |
 | `powershell` | certified reuse |
 | `properties` | fallback (uncertified) |
 | `pug` | fallback (uncertified) |
 | `purescript` | fallback (uncertified) |
 | `python` | fallback (explicit opt-out) |
 | `r` | fallback (uncertified) |
-| `racket` | fallback (uncertified) |
+| `racket` | certified reuse |
 | `rescript` | fallback (uncertified) |
 | `ron` | fallback (uncertified) |
 | `rst` | fallback (uncertified) |
@@ -530,7 +537,7 @@ silently widening HTML admission.
 | `starlark` | fallback (explicit opt-out) |
 | `svelte` | fallback (explicit opt-out) |
 | `swift` | fallback (uncertified) |
-| `tablegen` | fallback (uncertified) |
+| `tablegen` | certified reuse |
 | `tcl` | certified reuse |
 | `teal` | fallback (uncertified) |
 | `templ` | fallback (uncertified) |
@@ -546,7 +553,7 @@ silently widening HTML admission.
 | `wolfram` | fallback (uncertified) |
 | `xml` | fallback (uncertified) |
 | `yaml` | fallback (uncertified) |
-| `yuck` | fallback (uncertified) |
+| `yuck` | certified reuse |
 
 ## Hard-learned behavioral contracts
 

--- a/grammars/editorconfig_scanner.go
+++ b/grammars/editorconfig_scanner.go
@@ -23,6 +23,13 @@ func (EditorconfigExternalScanner) Destroy(payload any)                   {}
 func (EditorconfigExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (EditorconfigExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (EditorconfigExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (EditorconfigExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (EditorconfigExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (EditorconfigExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	eofValid := editorconfigValid(validSymbols, editorconfigTokEndOfFile)
 	intValid := editorconfigValid(validSymbols, editorconfigTokIntegerRangeStart)

--- a/grammars/fennel_scanner.go
+++ b/grammars/fennel_scanner.go
@@ -43,6 +43,13 @@ func (FennelExternalScanner) Destroy(payload any)                   {}
 func (FennelExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (FennelExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (FennelExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (FennelExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (FennelExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (FennelExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Error recovery guard: if the error sentinel is valid, bail out.
 	if fennelValid(validSymbols, fennelTokCount) {

--- a/grammars/fish_scanner.go
+++ b/grammars/fish_scanner.go
@@ -32,6 +32,13 @@ func (FishExternalScanner) Destroy(payload any)                   {}
 func (FishExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (FishExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (FishExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (FishExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (FishExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (FishExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// BEGIN_BRACE: { followed by whitespace or ;
 	if fishValid(validSymbols, fishTokBeginBrace) {

--- a/grammars/gn_scanner.go
+++ b/grammars/gn_scanner.go
@@ -23,6 +23,13 @@ func (GnExternalScanner) Destroy(payload any)                   {}
 func (GnExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (GnExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (GnExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (GnExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (GnExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 // Scan is a line-faithful port of the pinned upstream src/scanner.c
 // (tree-sitter-grammars/tree-sitter-gn @ bc06955b).
 func (GnExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {

--- a/grammars/janet_scanner.go
+++ b/grammars/janet_scanner.go
@@ -27,6 +27,13 @@ func (JanetExternalScanner) Destroy(payload any)                   {}
 func (JanetExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (JanetExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (JanetExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (JanetExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (JanetExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (JanetExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	bufValid := janetValid(validSymbols, janetTokLongBufLit)
 	strValid := janetValid(validSymbols, janetTokLongStrLit)

--- a/grammars/julia_scanner.go
+++ b/grammars/julia_scanner.go
@@ -51,6 +51,13 @@ func (JuliaExternalScanner) Destroy(payload any)                   {}
 func (JuliaExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (JuliaExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (JuliaExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (JuliaExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (JuliaExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (JuliaExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Immediate tokens: no whitespace consumed, just check current char.
 	if juliaValid(validSymbols, juliaTokImmediateParen) && lexer.Lookahead() == '(' {

--- a/grammars/less_scanner.go
+++ b/grammars/less_scanner.go
@@ -26,6 +26,13 @@ func (LessExternalScanner) Destroy(payload any)                   {}
 func (LessExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (LessExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (LessExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (LessExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (LessExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (LessExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !lessValid(validSymbols, lessTokDescendantOp) {
 		return false

--- a/grammars/liquid_scanner.go
+++ b/grammars/liquid_scanner.go
@@ -35,6 +35,13 @@ func (LiquidExternalScanner) Destroy(payload any)                   {}
 func (LiquidExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (LiquidExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (LiquidExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (LiquidExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (LiquidExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (LiquidExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Error recovery
 	if liquidValid(validSymbols, liquidTokErrorSentinel) {

--- a/grammars/pkl_scanner.go
+++ b/grammars/pkl_scanner.go
@@ -67,6 +67,13 @@ func (PklExternalScanner) Destroy(payload any)                   {}
 func (PklExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (PklExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (PklExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (PklExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (PklExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (PklExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Error recovery: if all string tokens valid, bail out.
 	if pklValid(validSymbols, pklTokSlStringChars) && pklValid(validSymbols, pklTokSl1StringChars) &&

--- a/grammars/racket_scanner.go
+++ b/grammars/racket_scanner.go
@@ -23,6 +23,13 @@ func (RacketExternalScanner) Destroy(payload any)                   {}
 func (RacketExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (RacketExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (RacketExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (RacketExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (RacketExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (RacketExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !racketValid(validSymbols, racketTokHereStringBody) {
 		return false

--- a/grammars/tablegen_scanner.go
+++ b/grammars/tablegen_scanner.go
@@ -25,6 +25,13 @@ func (TablegenExternalScanner) Destroy(payload any)                   {}
 func (TablegenExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (TablegenExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (TablegenExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (TablegenExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (TablegenExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (TablegenExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !tablegenValid(validSymbols, tablegenTokMultilineComment) {
 		return false

--- a/grammars/yuck_scanner.go
+++ b/grammars/yuck_scanner.go
@@ -27,6 +27,13 @@ func (YuckExternalScanner) Destroy(payload any)                   {}
 func (YuckExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (YuckExternalScanner) Deserialize(payload any, buf []byte)   {}
 
+// The scanner carries no payload and derives every result from local
+// lookahead plus validSymbols, so every incremental boundary is quiescent and
+// failed scans cannot mutate persistent state.
+func (YuckExternalScanner) SupportsIncrementalReuse() bool    { return true }
+func (YuckExternalScanner) ExternalScannerIsStateless() bool  { return true }
+func (YuckExternalScanner) PreservesStateOnScanFailure() bool { return true }
+
 func (YuckExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if yuckValid(validSymbols, yuckTokUnescapedDoubleQuote) {
 		if yuckScanStringFragment(lexer, '"') {

--- a/parser_stateless_scanner_incremental_certification_test.go
+++ b/parser_stateless_scanner_incremental_certification_test.go
@@ -30,6 +30,24 @@ func TestStatelessScannerIncrementalCertification(t *testing.T) {
 		{name: "move", lang: grammars.MoveLanguage, line: func(i int) string { return fmt.Sprintf("module 0x1::value_%06d { const VALUE: u64 = %d; }\n", i, i) }, minMacroReusePercent: 5},
 		{name: "tcl", lang: grammars.TclLanguage, line: func(i int) string { return fmt.Sprintf("set value_%06d %d\n", i, i) }, minMacroReuseBytes: 32},
 		{name: "wgsl", lang: grammars.WgslLanguage, line: func(i int) string { return fmt.Sprintf("/* value */ fn value_%06d() { let x: i32 = %d; }\n", i, i) }, minMacroReusePercent: 45},
+		{name: "editorconfig", lang: grammars.EditorconfigLanguage, line: func(i int) string { return fmt.Sprintf("[value_%06d]\nkey = %d\n", i, i) }, minMacroReusePercent: 30},
+		{name: "fennel", lang: grammars.FennelLanguage, line: func(i int) string { return fmt.Sprintf("(local value_%06d %d)\n", i, i) }, minMacroReusePercent: 85},
+		{name: "fish", lang: grammars.FishLanguage, line: func(i int) string { return fmt.Sprintf("set value_%06d %d\n", i, i) }, minMacroReuseBytes: 32},
+		{name: "gn", lang: grammars.GnLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d = %d\n", i, i) }, minMacroReusePercent: 20},
+		{name: "janet", lang: grammars.JanetLanguage, line: func(i int) string { return fmt.Sprintf("(def value_%06d %d)\n", i, i) }, minMacroReusePercent: 60},
+		{name: "julia", lang: grammars.JuliaLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d = %d\n", i, i) }, minMacroReusePercent: 90},
+		{name: "less", lang: grammars.LessLanguage, line: func(i int) string { return fmt.Sprintf(".value_%06d { width: %dpx; }\n", i, i) }, minMacroReusePercent: 40},
+		{name: "liquid", lang: grammars.LiquidLanguage, line: func(i int) string { return fmt.Sprintf("{%% assign value_%06d = %d %%}\n", i, i) }, minMacroReusePercent: 90},
+		{name: "pkl", lang: grammars.PklLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d = %d\n", i, i) }, minMacroReusePercent: 20},
+		{name: "racket", lang: grammars.RacketLanguage, line: func(i int) string {
+			prefix := ""
+			if i == 0 {
+				prefix = "#lang racket\n"
+			}
+			return fmt.Sprintf("%s(define value_%06d %d)\n", prefix, i, i)
+		}, minMacroReusePercent: 90},
+		{name: "tablegen", lang: grammars.TablegenLanguage, line: func(i int) string { return fmt.Sprintf("class Value_%06d;\n", i) }, minMacroReusePercent: 60},
+		{name: "yuck", lang: grammars.YuckLanguage, line: func(i int) string { return fmt.Sprintf("(defvar value_%06d %d)\n", i, i) }, minMacroReusePercent: 35},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- certify EditorConfig, Fennel, Fish, GN, Janet, Julia, Less, Liquid, Pkl, Racket, TableGen, and Yuck through the shared stateless-scanner proof
- extend the common fresh-tree differential matrix with measured 137 KiB reuse floors
- keep low-ownership-reuse behavior visible as a performance residual instead of blocking scanner correctness admission

## Validation
- complete twenty-language stateless certification matrix in Docker
- focused Docker race gate: 66 seconds, no OOM
- external-scanner documentation contract
- twelve grammar-subset builds
- fresh Canopy index: 1,834 files, zero errors, structural review clean

## Stack
- based on PR #445
- PR #445 is based on fully green PR #444
- retarget to main as preceding waves land