### PR TITLE
feat(grammars): certify eight more stateless scanners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **Eight additional stateless scanners are certified for changed-edit reuse:**
+  Comment, Dhall, DTD, Foam, Godot Resource, Kconfig, Odin, and RON. Each
+  passes the shared multi-position 4 KiB edit matrix and a 137 KiB
+  changed-length fresh-tree differential with actual subtree reuse. Kconfig's
+  deliberately small 16-byte macro floor keeps its parser-level ownership
+  residual visible without treating performance as a correctness gate.
+
 - **Twelve more stateless scanners are certified for changed-edit reuse:**
   EditorConfig, Fennel, Fish, GN, Janet, Julia, Less, Liquid, Pkl, Racket,
   TableGen, and Yuck. The shared fresh-tree matrix enforces real reuse across

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -406,6 +406,15 @@ Fish retains a 32-byte floor because its scanner is certified but top-level
 ownership rejection still dominates. The low floor is recorded as a parser
 performance residual, not inflated into a scanner-safety blocker.
 
+Comment, Dhall, DTD, Foam, Godot Resource, Kconfig, Odin, and RON complete the
+next stateless certification wave. Their scanners carry nil payloads, emit
+empty checkpoints, and base every scan solely on local lookahead and the
+parser-provided valid-symbol set. The shared fresh-tree matrix covers
+insert/delete/changed-length replacement at three positions in clean 4 KiB
+fixtures plus a representative 137 KiB edit. Macro reuse floors are 3%, 60%,
+90%, 10%, 15%, 16 bytes, 10%, and 70%, respectively. Kconfig's low floor is a
+parser ownership/performance residual; it is not a scanner-safety exception.
+
 SQL's state proof is explicit: the payload is either empty or exactly one
 active PostgreSQL dollar-quote tag. The empty state has a one-byte marker;
 representable non-empty states serialize as the tag plus a trailing NUL. A tag
@@ -450,7 +459,7 @@ silently widening HTML admission.
 | `cairo` | fallback (uncertified) |
 | `cmake` | certified reuse |
 | `cobol` | fallback (uncertified) |
-| `comment` | fallback (uncertified) |
+| `comment` | certified reuse |
 | `cooklang` | fallback (uncertified) |
 | `cpp` | fallback (uncertified) |
 | `crystal` | fallback (uncertified) |
@@ -459,12 +468,12 @@ silently widening HTML admission.
 | `cue` | certified reuse |
 | `d` | certified reuse |
 | `dart` | bounded reuse (up to 256 KiB) |
-| `dhall` | fallback (uncertified) |
+| `dhall` | certified reuse |
 | `disassembly` | fallback (uncertified) |
 | `djot` | fallback (uncertified) |
 | `dockerfile` | fallback (uncertified) |
 | `doxygen` | fallback (uncertified) |
-| `dtd` | fallback (uncertified) |
+| `dtd` | certified reuse |
 | `earthfile` | fallback (uncertified) |
 | `editorconfig` | certified reuse |
 | `elixir` | certified reuse |
@@ -473,7 +482,7 @@ silently widening HTML admission.
 | `fennel` | certified reuse |
 | `firrtl` | fallback (uncertified) |
 | `fish` | certified reuse |
-| `foam` | fallback (uncertified) |
+| `foam` | certified reuse |
 | `fortran` | fallback (uncertified) |
 | `fsharp` | fallback (uncertified) |
 | `gdscript` | fallback (uncertified) |
@@ -481,7 +490,7 @@ silently widening HTML admission.
 | `gleam` | certified reuse |
 | `gn` | certified reuse |
 | `go` | certified reuse |
-| `godot_resource` | fallback (uncertified) |
+| `godot_resource` | certified reuse |
 | `hack` | fallback (uncertified) |
 | `haskell` | fallback (uncertified) |
 | `haxe` | fallback (uncertified) |
@@ -494,7 +503,7 @@ silently widening HTML admission.
 | `jsonnet` | fallback (uncertified) |
 | `julia` | certified reuse |
 | `just` | fallback (uncertified) |
-| `kconfig` | fallback (uncertified) |
+| `kconfig` | certified reuse |
 | `kdl` | fallback (uncertified) |
 | `kotlin` | fallback (uncertified) |
 | `less` | certified reuse |
@@ -513,7 +522,7 @@ silently widening HTML admission.
 | `norg` | fallback (uncertified) |
 | `nushell` | fallback (uncertified) |
 | `ocaml` | fallback (uncertified) |
-| `odin` | fallback (uncertified) |
+| `odin` | certified reuse |
 | `org` | fallback (uncertified) |
 | `perl` | fallback (uncertified) |
 | `php` | fallback (uncertified) |
@@ -526,7 +535,7 @@ silently widening HTML admission.
 | `r` | fallback (uncertified) |
 | `racket` | certified reuse |
 | `rescript` | fallback (uncertified) |
-| `ron` | fallback (uncertified) |
+| `ron` | certified reuse |
 | `rst` | fallback (uncertified) |
 | `ruby` | fallback (uncertified) |
 | `rust` | fallback (uncertified) |

--- a/grammars/comment_scanner.go
+++ b/grammars/comment_scanner.go
@@ -33,6 +33,8 @@ func (CommentExternalScanner) Create() any                           { return ni
 func (CommentExternalScanner) Destroy(payload any)                   {}
 func (CommentExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (CommentExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (CommentExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (CommentExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (CommentExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Upstream treats invalid_token as correction mode. The Go-generated

--- a/grammars/dhall_scanner.go
+++ b/grammars/dhall_scanner.go
@@ -22,6 +22,8 @@ func (DhallExternalScanner) Create() any                           { return nil 
 func (DhallExternalScanner) Destroy(payload any)                   {}
 func (DhallExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (DhallExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (DhallExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (DhallExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (DhallExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !dhallValid(validSymbols, dhallTokBlockCommentContent) {

--- a/grammars/dtd_scanner.go
+++ b/grammars/dtd_scanner.go
@@ -28,6 +28,8 @@ func (DtdExternalScanner) Create() any                           { return nil }
 func (DtdExternalScanner) Destroy(payload any)                   {}
 func (DtdExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (DtdExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (DtdExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (DtdExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (DtdExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Error recovery

--- a/grammars/foam_scanner.go
+++ b/grammars/foam_scanner.go
@@ -31,6 +31,8 @@ func (FoamExternalScanner) Create() any                           { return nil }
 func (FoamExternalScanner) Destroy(payload any)                   {}
 func (FoamExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (FoamExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (FoamExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (FoamExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (FoamExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// Skip whitespace (matching original C scanner behavior).

--- a/grammars/godot_resource_scanner.go
+++ b/grammars/godot_resource_scanner.go
@@ -25,6 +25,8 @@ func (GodotResourceExternalScanner) Create() any                           { ret
 func (GodotResourceExternalScanner) Destroy(payload any)                   {}
 func (GodotResourceExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (GodotResourceExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (GodotResourceExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (GodotResourceExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 // Scan is a line-faithful port of the pinned upstream src/scanner.c
 // (PrestonKnopp/tree-sitter-godot-resource @ 302c1895).

--- a/grammars/kconfig_scanner.go
+++ b/grammars/kconfig_scanner.go
@@ -25,6 +25,8 @@ func (KconfigExternalScanner) Create() any                           { return ni
 func (KconfigExternalScanner) Destroy(payload any)                   {}
 func (KconfigExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (KconfigExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (KconfigExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (KconfigExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (KconfigExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	if !kconfigValid(validSymbols, kconfigTokText) {

--- a/grammars/odin_scanner.go
+++ b/grammars/odin_scanner.go
@@ -35,6 +35,8 @@ func (OdinExternalScanner) Create() any                           { return nil }
 func (OdinExternalScanner) Destroy(payload any)                   {}
 func (OdinExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (OdinExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (OdinExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (OdinExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (OdinExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// FLOAT parsing

--- a/grammars/ron_scanner.go
+++ b/grammars/ron_scanner.go
@@ -31,6 +31,8 @@ func (RonExternalScanner) Create() any                           { return nil }
 func (RonExternalScanner) Destroy(payload any)                   {}
 func (RonExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (RonExternalScanner) Deserialize(payload any, buf []byte)   {}
+func (RonExternalScanner) SupportsIncrementalReuse() bool        { return true }
+func (RonExternalScanner) ExternalScannerIsStateless() bool      { return true }
 
 func (RonExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
 	// String content (inside a "..." string)

--- a/parser_stateless_scanner_incremental_certification_test.go
+++ b/parser_stateless_scanner_incremental_certification_test.go
@@ -18,6 +18,8 @@ func TestStatelessScannerIncrementalCertification(t *testing.T) {
 	cases := []struct {
 		name                 string
 		lang                 func() *gts.Language
+		prefix               string
+		suffix               string
 		line                 func(int) string
 		minMacroReusePercent uint64
 		minMacroReuseBytes   uint64
@@ -48,6 +50,20 @@ func TestStatelessScannerIncrementalCertification(t *testing.T) {
 		}, minMacroReusePercent: 90},
 		{name: "tablegen", lang: grammars.TablegenLanguage, line: func(i int) string { return fmt.Sprintf("class Value_%06d;\n", i) }, minMacroReusePercent: 60},
 		{name: "yuck", lang: grammars.YuckLanguage, line: func(i int) string { return fmt.Sprintf("(defvar value_%06d %d)\n", i, i) }, minMacroReusePercent: 35},
+		{name: "comment", lang: grammars.CommentLanguage, line: func(i int) string { return fmt.Sprintf("TODO_%06d: value %d\n", i, i) }, minMacroReusePercent: 3},
+		{name: "dhall", lang: grammars.DhallLanguage, prefix: "{ ", suffix: "final = 0 }\n", line: func(i int) string { return fmt.Sprintf("value_%06d = %d,\n", i, i) }, minMacroReusePercent: 60},
+		{name: "dtd", lang: grammars.DtdLanguage, line: func(i int) string { return fmt.Sprintf("<!ELEMENT value_%06d (#PCDATA)>\n", i) }, minMacroReusePercent: 90},
+		{name: "foam", lang: grammars.FoamLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d %d;\n", i, i) }, minMacroReusePercent: 10},
+		{name: "godot_resource", lang: grammars.GodotResourceLanguage, line: func(i int) string { return fmt.Sprintf("value_%06d = %d\n", i, i) }, minMacroReusePercent: 15},
+		{name: "kconfig", lang: grammars.KconfigLanguage, line: func(i int) string { return fmt.Sprintf("config VALUE_%06d\n\tint\n\tdefault %d\n", i, i) }, minMacroReuseBytes: 16},
+		{name: "odin", lang: grammars.OdinLanguage, line: func(i int) string {
+			prefix := ""
+			if i == 0 {
+				prefix = "package main\n"
+			}
+			return fmt.Sprintf("%svalue_%06d :: %d\n", prefix, i, i)
+		}, minMacroReusePercent: 10},
+		{name: "ron", lang: grammars.RonLanguage, prefix: "(\n", suffix: ")\n", line: func(i int) string { return fmt.Sprintf("value_%06d: %d,\n", i, i) }, minMacroReusePercent: 70},
 	}
 
 	for _, tc := range cases {
@@ -62,7 +78,7 @@ func TestStatelessScannerIncrementalCertification(t *testing.T) {
 				{name: "137KiB", size: 137 << 10, positions: []string{"middle"}, classes: []statelessScannerEditClass{statelessScannerReplace}},
 			}
 			for _, plan := range plans {
-				source, sites := makeStatelessScannerCertificationSource(plan.size, tc.line)
+				source, sites := makeStatelessScannerCertificationSource(plan.size, tc.prefix, tc.suffix, tc.line)
 				for _, position := range plan.positions {
 					var site int
 					switch position {
@@ -112,9 +128,10 @@ func (c statelessScannerEditClass) String() string {
 	}
 }
 
-func makeStatelessScannerCertificationSource(target int, line func(int) string) ([]byte, []int) {
+func makeStatelessScannerCertificationSource(target int, prefix, suffix string, line func(int) string) ([]byte, []int) {
 	var source strings.Builder
 	source.Grow(target + 128)
+	source.WriteString(prefix)
 	sites := make([]int, 0, target/24)
 	for i := 0; source.Len() < target || len(sites) < 4; i++ {
 		entry := line(i)
@@ -126,6 +143,7 @@ func makeStatelessScannerCertificationSource(target int, line func(int) string) 
 		sites = append(sites, source.Len()+marker)
 		source.WriteString(entry)
 	}
+	source.WriteString(suffix)
 	return []byte(source.String()), sites
 }
 


### PR DESCRIPTION
## Summary
- certify Comment, Dhall, DTD, Foam, Godot Resource, Kconfig, Odin, and RON for changed-edit incremental reuse
- extend the shared clean-tree matrix with valid wrapped Dhall and RON macro fixtures
- ratchet measured 137 KiB reuse floors and document Kconfig's low-floor ownership residual

## Correctness evidence
- each language independently passed the 4 KiB insert/delete/replace matrix at start, middle, and end
- each language independently passed a 137 KiB changed-length middle replacement with real subtree reuse and deep equality against a fresh parse
- all eight focused race runs passed in Docker, one grammar at a time, without OOM
- scanner documentation/runtime contract passed
- exact eight-grammar subset build passed
- Canopy indexed 1,834 files / 18,298 symbols with zero parse errors

## Notes
Kconfig reuses 19 bytes in the current 137 KiB witness, so its floor is conservatively ratcheted at 16 bytes. This is a visible parser ownership/performance residual, not a scanner correctness exception.