### PR TITLE
improve(parser): admit stateful GSS reuse through exact checkpoint receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- **Stateful GSS forest trees now enter incremental reuse through exact
+  checkpoint receipts.** Admission requires the scanner's generic checkpoint
+  and incremental-reuse capabilities, then authenticates non-empty start and
+  end snapshots at every reachable token boundary. A missing endpoint declines
+  the forest as `scanner_checkpoint_unavailable` instead of letting distinct
+  unrepresentable states collide as empty snapshots. A length-changing
+  stateful witness requires actual subtree reuse and deep fresh-tree equality;
+  a synthetic absent-checkpoint scanner locks the fail-closed path.
+
 - **GSS forest trees now use capability-based incremental admission.** Forest
   construction records exact pre-goto ownership for every reusable subtree,
   and the reuse cursor requires that ownership before transferring top-level
@@ -16,7 +25,7 @@ for tags and release notes while still in `0.x`.
   stateless/failure-preserving proof, can therefore reuse forest-built trees
   without a language-name allowlist. AWK, KDL, Nix, Squirrel, and Uxntal are
   newly admitted through a shared multi-position and 137 KiB fresh-tree
-  differential; stateful scanners remain fail-closed pending checkpoint proof.
+  differential.
 
 - **JavaScript, TypeScript, and TSX leading incremental reuse is admitted.**
   The generic byte-identity, fragility, and scanner gates now govern unchanged

--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -402,8 +402,19 @@ list: clean forest trees must have a quiescence-proven scanner class, and every
 top-level transfer must match the exact `PreGotoState` that owned the original
 reduction. The focused matrix crosses three changed-length edit classes at the
 start, middle, and end of 4 KiB fixtures plus a 137 KiB witness, comparing full
-incremental tree serialization with a fresh parse. Stateful checkpoint-backed
-forest trees remain fail-closed pending a separate boundary-state receipt.
+incremental tree serialization with a fresh parse.
+
+Stateful forest admission uses the same capability rule rather than a second
+language list: the scanner must opt into both incremental reuse and complete
+checkpoints. Forest tokenization requires a non-empty start and end snapshot at
+every reachable non-EOF token boundary. If either serialization is absent, the
+forest declines with `scanner_checkpoint_unavailable`; automatic routing falls
+back to production and the diagnostic forest entry point returns the decline.
+The checkpoint store independently rejects one-sided records, so two
+unrepresentable states can never authenticate by comparing equal empty byte
+slices. A length-changing HTML witness proves useful old-tree reuse and deep
+fresh-tree equality, while a synthetic checkpoint scanner that always returns
+an absent snapshot proves the generalized route fails closed.
 
 The same proof and matrix also admit EditorConfig, Fennel, Fish, GN, Janet,
 Julia, Less, Liquid, Pkl, Racket, TableGen, and Yuck. Their macro witnesses

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -22,6 +22,10 @@ type externalScannerCheckpointRef struct {
 	end   externalScannerSnapshotRef
 }
 
+func externalScannerCheckpointRefComplete(cp externalScannerCheckpointRef) bool {
+	return cp.start.len != 0 && cp.end.len != 0
+}
+
 type externalScannerCheckpointSet struct {
 	indexes []uint32
 	refs    []externalScannerCheckpointRef
@@ -55,7 +59,7 @@ func underlyingDFATokenSource(ts TokenSource) *dfaTokenSource {
 }
 
 func (a *nodeArena) recordExternalScannerLeafCheckpoint(node *Node, start, end []byte) bool {
-	if a == nil || node == nil {
+	if a == nil || node == nil || len(start) == 0 || len(end) == 0 {
 		return false
 	}
 	startRef := a.copyExternalScannerSnapshotRef(start)
@@ -74,7 +78,7 @@ func (a *nodeArena) recordExternalScannerLeafCheckpoint(node *Node, start, end [
 }
 
 func (a *nodeArena) recordExternalScannerCompactCheckpoint(start, end []byte) externalScannerCheckpointRef {
-	if a == nil {
+	if a == nil || len(start) == 0 || len(end) == 0 {
 		return externalScannerCheckpointRef{}
 	}
 	startRef := a.copyExternalScannerSnapshotRef(start)
@@ -133,7 +137,7 @@ func externalScannerCheckpointRefForNode(node *Node) (externalScannerCheckpointR
 		return externalScannerCheckpointRef{}, false
 	}
 	cp, ok := set.lookup(idx)
-	if !ok || (cp.start.len == 0 && cp.end.len == 0) {
+	if !ok || !externalScannerCheckpointRefComplete(cp) {
 		return externalScannerCheckpointRef{}, false
 	}
 	return cp, true
@@ -174,7 +178,7 @@ func rebuildExternalScannerCheckpointForNode(n *Node) (externalScannerCheckpoint
 			break
 		}
 	}
-	if !startOK && !endOK {
+	if !startOK || !endOK {
 		return externalScannerCheckpointRef{}, false
 	}
 	cp := externalScannerCheckpointRef{start: startRef, end: endRef}
@@ -241,7 +245,7 @@ func externalScannerCheckpointRefForPendingParent(arena *nodeArena, parent *pend
 			break
 		}
 	}
-	if !startOK && !endOK {
+	if !startOK || !endOK {
 		return externalScannerCheckpointRef{}, false
 	}
 	return externalScannerCheckpointRef{start: startRef, end: endRef}, true
@@ -310,7 +314,7 @@ func fastForwardWithExternalScannerCheckpoint(ts TokenSource, node *Node, cp ext
 	if dts == nil || !languageUsesExternalScannerCheckpoints(dts.language) {
 		return Token{}, false
 	}
-	if node == nil {
+	if node == nil || !externalScannerCheckpointRefComplete(cp) {
 		return Token{}, false
 	}
 	dts.restoreExternalScannerState(node.ownerArena.externalScannerSnapshotBytes(cp.end))

--- a/external_scanner_checkpoints_test.go
+++ b/external_scanner_checkpoints_test.go
@@ -54,6 +54,34 @@ func TestExternalScannerCheckpointPrimaryLookup(t *testing.T) {
 	}
 }
 
+func TestExternalScannerCheckpointRejectsAbsentEndpoint(t *testing.T) {
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+
+	for name, snapshots := range map[string]struct {
+		start []byte
+		end   []byte
+	}{
+		"missing start": {end: []byte{1}},
+		"missing end":   {start: []byte{1}},
+		"both missing":  {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			node := arena.allocNode()
+			node.ownerArena = arena
+			if arena.recordExternalScannerLeafCheckpoint(node, snapshots.start, snapshots.end) {
+				t.Fatal("recordExternalScannerLeafCheckpoint accepted an incomplete boundary")
+			}
+			if _, ok := externalScannerCheckpointForNode(node); ok {
+				t.Fatal("incomplete boundary remained visible through checkpoint lookup")
+			}
+			if cp := arena.recordExternalScannerCompactCheckpoint(snapshots.start, snapshots.end); externalScannerCheckpointRefComplete(cp) {
+				t.Fatal("compact checkpoint accepted an incomplete boundary")
+			}
+		})
+	}
+}
+
 func TestExternalScannerCheckpointOverflowLookup(t *testing.T) {
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()

--- a/external_scanner_quiescence_test.go
+++ b/external_scanner_quiescence_test.go
@@ -20,6 +20,24 @@ type quiescenceStatelessScanner struct {
 
 func (quiescenceStatelessScanner) ExternalScannerIsStateless() bool { return true }
 
+type quiescenceCheckpointScanner struct {
+	parserTestSafeExternalScanner
+}
+
+func (quiescenceCheckpointScanner) UsesExternalScannerCheckpoints() bool { return true }
+
+type quiescenceCheckpointOptOutScanner struct {
+	parserTestUnsafeExternalScanner
+}
+
+func (quiescenceCheckpointOptOutScanner) SupportsIncrementalReuse() bool {
+	return false
+}
+
+func (quiescenceCheckpointOptOutScanner) UsesExternalScannerCheckpoints() bool {
+	return true
+}
+
 func TestClassifyExternalScannerQuiescence(t *testing.T) {
 	cases := []struct {
 		name string
@@ -50,6 +68,8 @@ func TestForestIncrementalReuseRequiresScannerProof(t *testing.T) {
 		{"nil language", nil, false},
 		{"no scanner", &Language{}, true},
 		{"stateless scanner", &Language{ExternalScanner: quiescenceStatelessScanner{}}, true},
+		{"checkpoint scanner", &Language{ExternalScanner: quiescenceCheckpointScanner{}}, true},
+		{"checkpoint opt-out scanner", &Language{ExternalScanner: quiescenceCheckpointOptOutScanner{}}, false},
 		{"opt-out scanner", &Language{ExternalScanner: quiescenceOptOutScanner{}}, false},
 		{"undecided scanner", &Language{ExternalScanner: parserTestUnsafeExternalScanner{}}, false},
 	}

--- a/forest_incremental_admission_test.go
+++ b/forest_incremental_admission_test.go
@@ -1,13 +1,25 @@
 package gotreesitter_test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	gts "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
+
+type unavailableForestCheckpointScanner struct {
+	gts.ExternalScanner
+}
+
+func (unavailableForestCheckpointScanner) Serialize(any, []byte) int { return 0 }
+
+func (unavailableForestCheckpointScanner) SupportsIncrementalReuse() bool { return true }
+
+func (unavailableForestCheckpointScanner) UsesExternalScannerCheckpoints() bool { return true }
 
 func TestForestIncrementalStatelessAdmission(t *testing.T) {
 	cases := []struct {
@@ -102,6 +114,69 @@ func runForestIncrementalStatelessSample(t *testing.T, lang *gts.Language, sourc
 	defer fresh.Release()
 	requireCompleteParse(t, fresh, edited, lang, "fresh forest admission")
 	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+}
+
+func TestForestIncrementalCheckpointAdmission(t *testing.T) {
+	source := []byte(strings.Repeat("<section><custom-element>value</custom-element></section>\n", 96))
+	middle := len(source) / 2
+	valueOffset := bytes.Index(source[middle:], []byte("value"))
+	if valueOffset < 0 {
+		t.Fatal("checkpoint fixture has no middle edit site")
+	}
+	edit := insertEdit(source, middle+valueOffset)
+	lang := grammars.HtmlLanguage()
+
+	oldParser := gts.NewParser(lang)
+	oldParser.SetAdmissionCandidateRoute(false)
+	oldTree, ok := oldParser.ParseForestExperimental(source)
+	if !ok {
+		_, _, reason, states := oldParser.ForestDeclineInfo()
+		t.Fatalf("checkpoint forest parse declined: reason=%s states=%v", reason, states)
+	}
+	defer oldTree.Release()
+	requireCompleteParse(t, oldTree, source, lang, "initial checkpoint forest admission")
+	oldTree.Edit(edit.inEdit)
+
+	incrementalParser := gts.NewParser(lang)
+	incrementalParser.SetAdmissionCandidateRoute(false)
+	incremental, profile, err := incrementalParser.ParseIncrementalProfiled(edit.edited, oldTree)
+	if err != nil {
+		t.Fatalf("checkpoint incremental parse: %v", err)
+	}
+	defer incremental.Release()
+	requireCompleteParse(t, incremental, edit.edited, lang, "incremental checkpoint forest admission")
+	if profile.ReuseUnsupported || !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("checkpoint forest tree did not enter useful reuse: %+v", profile)
+	}
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edit.edited)
+	if err != nil {
+		t.Fatalf("checkpoint fresh parse: %v", err)
+	}
+	defer fresh.Release()
+	requireCompleteParse(t, fresh, edit.edited, lang, "fresh checkpoint forest admission")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+}
+
+func TestForestCheckpointAdmissionFailsClosedWithoutExactSnapshot(t *testing.T) {
+	lang := *grammars.HtmlLanguage()
+	lang.Name = "synthetic-unavailable-checkpoint"
+	lang.ExternalScanner = unavailableForestCheckpointScanner{ExternalScanner: lang.ExternalScanner}
+
+	parser := gts.NewParser(&lang)
+	tree, ok := parser.ParseForestExperimental([]byte("<div>value</div>"))
+	if tree != nil {
+		tree.Release()
+	}
+	if ok {
+		t.Fatal("forest admitted a scanner boundary without an exact checkpoint")
+	}
+	_, _, reason, _ := parser.ForestDeclineInfo()
+	if reason != "scanner_checkpoint_unavailable" {
+		t.Fatalf("forest decline reason = %q, want scanner_checkpoint_unavailable", reason)
+	}
 }
 
 func TestForestIncrementalOwnershipRegressionGo(t *testing.T) {

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -712,14 +712,21 @@ func forestAcceptedRuntime(root *Node, source []byte) ParseRuntime {
 // (reuseCursor.strictTopLevelOwnership), while the ordinary fragility and
 // stack/goto checks protect interior candidates.
 //
-// The remaining independent obligation is scanner state. This first generic
-// admission class accepts only languages with no external scanner or an
-// explicitly certified stateless scanner. Stateful checkpoint-backed scanners
-// remain disabled until their forest-built boundary snapshots have their own
-// differential receipt. The predicate is intentionally capability-based: a
+// The remaining independent obligation is scanner state. A scanner either
+// proves every boundary quiescent (no scanner or a certified stateless
+// scanner), or supplies complete start/end checkpoints and independently opts
+// into incremental reuse. parseForest verifies the latter receipt at every
+// reachable token boundary and declines before returning a tree if either
+// endpoint is unavailable. The predicate is intentionally capability-based: a
 // grammar name is neither necessary nor sufficient evidence.
 func forestIncrementalReuseProven(lang *Language) bool {
-	return lang != nil && classifyExternalScannerQuiescence(lang) == scannerQuiescenceProven
+	if lang == nil {
+		return false
+	}
+	if classifyExternalScannerQuiescence(lang) == scannerQuiescenceProven {
+		return true
+	}
+	return languageUsesExternalScannerCheckpoints(lang) && languageSupportsIncrementalReuse(lang)
 }
 
 // gssLink is one alternative predecessor in the forest DAG: the subtree consumed
@@ -2984,6 +2991,23 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 		tok := ts.Next()
 		tokens++
 		p.updateCurrentExternalTokenCheckpoint(ts, tok)
+		if captureExternalCheckpoints && tok.Symbol != 0 && !tok.NoLookahead {
+			if _, _, _, ok := ts.lastExternalScannerCheckpoint(); !ok {
+				// A zero-length serialization means this reachable scanner
+				// state has no exact representation. Do not return a forest
+				// tree built after an unauthenticated GLR scanner restore, and
+				// do not silently widen incremental admission. The automatic
+				// route falls back to the production parser; the diagnostic
+				// route reports the decline directly.
+				p.recordForestDecline("scanner_checkpoint_unavailable", tok, glrStates)
+				if progress.enabled {
+					progress.emit(time.Now(), "forest_decline", iter, tokens, tok, false, nil, 0, 0, 0, false, 0, 0,
+						forestProgressExtra(frontier, work, nextFrontier, curIndex, nextIndex, processEpoch, recoverCount, reducer, nil,
+							"decline_reason=scanner_checkpoint_unavailable"))
+				}
+				return nil, false
+			}
+		}
 		// A NoLookahead token is a SYNTHETIC EOF the token source emits to force
 		// the no-lookahead-state reduction (e.g. completing a multi-token comment
 		// extra) — it is NOT real end-of-input. Only Symbol==0 && !NoLookahead is

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -2837,6 +2837,11 @@ func (s *gssForestNodeSlab) retainedBytes() int {
 // external scanners, full GLR-lexing) is layered on this core.
 func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalCheckpoints bool, memoryBudget int64) (*Node, bool) {
 	lang := p.language
+	// Treat capture as a request, not a capability assertion. Internal
+	// diagnostic callers may request capture for any grammar; only a scanner
+	// that implements the checkpoint contract can produce receipts that the
+	// forest is allowed to authenticate.
+	captureExternalCheckpoints = captureExternalCheckpoints && languageUsesExternalScannerCheckpoints(lang)
 	meta := lang.SymbolMetadata
 	named := func(sym Symbol) bool { return int(sym) < len(meta) && meta[sym].Named }
 	p.forestDeclineReason = ""

--- a/parser.go
+++ b/parser.go
@@ -3244,6 +3244,9 @@ func (p *Parser) currentExternalNoTreeLeafCheckpointRef(arena *nodeArena, tok To
 		p.currentExternalTokenCheckpoint.start,
 		p.currentExternalTokenCheckpoint.end,
 	)
+	if !externalScannerCheckpointRefComplete(cp) {
+		return externalScannerCheckpointRef{}, false
+	}
 	arena.compactFullLeafCreated++
 	arena.checkpointLeafFullNodesAvoided++
 	return cp, true
@@ -3266,6 +3269,9 @@ func (p *Parser) currentExternalCompactFullLeafCheckpointRef(arena *nodeArena, t
 		p.currentExternalTokenCheckpoint.start,
 		p.currentExternalTokenCheckpoint.end,
 	)
+	if !externalScannerCheckpointRefComplete(cp) {
+		return externalScannerCheckpointRef{}, false
+	}
 	arena.checkpointLeafFullNodesAvoided++
 	return cp, true
 }

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -3581,6 +3581,13 @@ func (d *dfaTokenSource) lastExternalScannerCheckpoint() (externalScannerCheckpo
 	if d.externalTokenEndSameAsStart {
 		end = d.externalTokenStart
 	}
+	// CheckpointedExternalScanner reserves an empty serialization for an
+	// unavailable state. Both boundary snapshots must be exact: accepting one
+	// missing endpoint would make distinct unrepresentable states compare as
+	// the same empty byte slice during incremental authentication.
+	if len(d.externalTokenStart) == 0 || len(end) == 0 {
+		return externalScannerCheckpoint{}, 0, 0, false
+	}
 	return externalScannerCheckpoint{
 		start: d.externalTokenStart,
 		end:   end,

--- a/parser_dfa_token_source_test.go
+++ b/parser_dfa_token_source_test.go
@@ -772,6 +772,29 @@ func TestLastExternalScannerCheckpointCanUseStartAsEndWithoutAliasingScratch(t *
 	}
 }
 
+func TestLastExternalScannerCheckpointRequiresBothEndpoints(t *testing.T) {
+	for name, ts := range map[string]*dfaTokenSource{
+		"missing start": {
+			externalTokenEnd:       []byte{1},
+			lastExternalTokenValid: true,
+		},
+		"missing end": {
+			externalTokenStart:     []byte{1},
+			lastExternalTokenValid: true,
+		},
+		"missing shared start": {
+			lastExternalTokenValid:      true,
+			externalTokenEndSameAsStart: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, _, ok := ts.lastExternalScannerCheckpoint(); ok {
+				t.Fatal("lastExternalScannerCheckpoint accepted an incomplete boundary")
+			}
+		})
+	}
+}
+
 func TestResetPooledDFATokenSourcePreservesScannerScratch(t *testing.T) {
 	lookup := func(StateID, Symbol) uint16 { return 0 }
 	ts := &dfaTokenSource{


### PR DESCRIPTION
## Summary

- admit stateful GSS forest trees through the existing scanner capability contract, without grammar-name gates
- require exact, non-empty start and end checkpoint receipts at every reachable real token boundary
- fail closed as `scanner_checkpoint_unavailable` when either endpoint cannot be represented
- add a stateful integration witness requiring useful reuse and deep fresh-tree equality, plus a synthetic missing-checkpoint rejection

## Validation

- focused local checkpoint/admission/ownership tests
- focused Docker correctness gate (`3.259s`, no OOM)
- isolated HTML grammar parity smoke: 5/5, including deep-tree parity, no OOM
- stable primary perf trio: edit and no-edit remain 0 B/op and 0 allocs/op
- Canopy index: 1,837 files, 18,431 symbols, 0 errors

This is a generalized incremental-correctness ratchet toward #432; HTML is only the stateful integration witness, not a per-language patch.