### PR TITLE
release: prepare v0.47.0 and establish Thursday cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- Nothing yet.
+
+## [0.47.0] - 2026-07-22
+
+### Changed
+
 - **Stateful GSS forest trees now enter incremental reuse through exact
   checkpoint receipts.** Admission requires the scanner's generic checkpoint
   and incremental-reuse capabilities, then authenticates non-empty start and
@@ -3612,7 +3618,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.46.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.47.0...HEAD
+[0.47.0]: https://github.com/odvcencio/gotreesitter/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/odvcencio/gotreesitter/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/odvcencio/gotreesitter/compare/v0.44.1...v0.45.0
 [0.44.1]: https://github.com/odvcencio/gotreesitter/compare/v0.44.0...v0.44.1

--- a/README.md
+++ b/README.md
@@ -750,33 +750,16 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.45.0**. It fixes TypeScript arrow functions
-with a return-type annotation, which previously collapsed to `ERROR` as
-a `const`/`let` initializer (issue #402). It also fixes Go
-`new(pkg.Type)`, `new(*T)`, and parenthesized type arguments to
-byte-match the C oracle (issue #375 class). Unchanged top-level
-siblings now splice back as a single block. A clean-Go, near-top, 1MB
-edit measures about 82-88ms, down from about 148ms. The campaign's
-60ms target is not yet met; residual cost sits in result
-materialization outside the splice path. GLR-heavy files with genuine
-ambiguity still see little change, since settling and block-splice run
-on a single stack only. The prior release, v0.44.1, restored Swift's
-retry-ladder optimizations and introduced clean-file Go suffix and
-top-level-sibling reuse. Length-changing edits still include linear
-trailing-coordinate maintenance in `Tree.Edit`.
-The authenticated production receipt at tag target `1935a42c` measures
-public `Parser.Parse` at **4.851050x C** by equal-fixture geomean,
-**5.472406x C** by fixed-suite sum, and **5.608320x C** on the worst
-fixture against the locked static `-O2` C oracle. Its 0.716% geomean
-improvement over v0.39.0 is below the reproducible 2% win threshold. The
-latest build-tagged selected-store candidate, measured at `ba1ed1bf`,
-remains outside public `Parser.Parse` despite its lower authenticated
-ratio.
-The 206-grammar curated parity milestone is banked, the invalid historical
-1.895x headline stays withdrawn, and the incremental matrix is a
-correctness/work-classification receipt rather than a representative
-comparative speed headline. Detailed history lives in
-[CHANGELOG.md](CHANGELOG.md).
+The current release is **v0.47.0**. It closes the generalized incremental
+correctness campaign with capability-based scanner admission, exact stateful
+checkpoint receipts, GSS forest ownership proof, and bounded JavaScript-family
+recovery scheduling. Uncertified scanners continue to fail closed; their
+individual serialization audits are independent language certification work,
+not exceptions in the parser engine.
+
+Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
+releases are batched on Thursdays; the immutable-tag process and exceptions are
+documented in [docs/releasing.md](docs/releasing.md).
 
 ### Now — cleanup, ownership, and explainability
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,37 @@
+# Releasing gotreesitter
+
+## Cadence
+
+Planned minor releases are cut on Thursdays in `America/Los_Angeles`. A
+Thursday without a coherent, green release is skipped; the schedule is a
+batching boundary, not a reason to ship unfinished work.
+
+Patch releases may happen outside the cadence for urgent correctness,
+security, or packaging regressions. Ordinary maintenance waits for the next
+Thursday. Release planning and in-progress campaign notes live in the private
+`hypha://m31labs/gotreesitter` space rather than a public release-train issue.
+
+v0.47.0 is the final planned off-cadence minor. The first cadence release is
+the next eligible Thursday after v0.47.0.
+
+## Release checklist
+
+1. Freeze a coherent scope. Merge its pull requests and clear the pull-request
+   queue; do not release from a feature branch.
+2. Move the accumulated changelog entries from `Unreleased` into a dated
+   version section. Update the comparison links and the README release status.
+3. Require the release commit's hosted CI to be green. Keep correctness,
+   parity, race, and performance evidence distinct; do not substitute a broad
+   host test sweep for the isolated gates.
+4. Fetch `main`, verify the worktree is clean, verify the version tag does not
+   already exist, and record the exact release commit SHA.
+5. Create an annotated `vX.Y.Z` tag at that SHA, push only that tag, and create
+   the GitHub release from the versioned changelog section.
+6. Verify the GitHub release and tag resolve to the recorded SHA and that the
+   module can be fetched at the new version.
+7. Checkpoint the version, SHA, gate results, and any intentionally deferred
+   work in Hyphae. Close campaign issues only when the release contains their
+   documented acceptance evidence.
+
+Tags are immutable. If a release is wrong, preserve its tag and publish a
+follow-up version.


### PR DESCRIPTION
## Outcome

Prepare v0.47.0 as the final planned off-cadence minor, then establish Thursday (`America/Los_Angeles`) as the canonical planned minor-release day.

## Changes

- version the accumulated incremental-correctness campaign as v0.47.0
- reset `Unreleased` and repair changelog comparison links
- replace the stale README release narrative with the current campaign status
- add an immutable-tag release checklist and Thursday batching policy
- keep release planning in private Hyphae rather than a public release-train issue

## Validation

- `git diff --check`
- documentation/release metadata only; parser CI is inherited from fully green #451 and will run again on this branch

After this PR merges and the tag/release are verified, #432 can close with the shipped evidence. Scanner-specific audits for currently uncertified languages remain fail-closed and are not engine exceptions.