### PR TITLE
refactor(parser): begin root normalization retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
+- JavaScript program-end finalization now has one authoritative compatibility
+  owner. The redundant returned-tree second pass is retired; production,
+  compact final-child-ref, forest, and incremental publication continue to use
+  the canonical JavaScript compatibility pipeline before the tree is exposed.
+
 - Clean hidden whitespace-only root tails are now owned by root finalization,
   retiring a generic compatibility pass while preserving error-root recovery
   extras and lazy compact child references.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ for tags and release notes while still in `0.x`.
 
 ### Changed
 
-- Nothing yet.
+- Clean hidden whitespace-only root tails are now owned by root finalization,
+  retiring a generic compatibility pass while preserving error-root recovery
+  extras and lazy compact child references.
 
 ## [0.47.0] - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,8 @@ witness, and it shrinks as certified engine mechanisms subsume shims. See
 For a maintainer-oriented map of the full root package, ownership seams,
 review-sensitive hotspots, and local artifact policy, see
 [docs/repository-map.md](docs/repository-map.md).
+The ordered, receipt-driven cleanup program is documented in
+[docs/root-normalization-retirement.md](docs/root-normalization-retirement.md).
 
 ## Known limitations
 

--- a/cgo_harness/trailing_extra_root_parity_test.go
+++ b/cgo_harness/trailing_extra_root_parity_test.go
@@ -1,0 +1,19 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import "testing"
+
+func TestCleanTrailingExtraRootParity(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		source string
+	}{
+		{name: "rst", source: "Title\n=====\n\nbody\n"},
+		{name: "comment", source: "hello\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			runParityCase(t, parityCase{name: test.name}, "clean-trailing-extra-root", []byte(test.source))
+		})
+	}
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -19,8 +19,8 @@ The v1 registry freezes the current surface:
   language names;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
 - one generic pass that runs after language dispatch;
-- one retained post-finalization second-pass fixpoint with three switch arms
-  covering Scala, HTML, and JavaScript.
+- one retained post-finalization second-pass fixpoint with two switch arms
+  covering Scala and HTML.
 
 That is 81 live registry entries. The registry covers only this documented
 internal result-compatibility tier; scheduler experiments and other engine
@@ -101,12 +101,20 @@ exact against their C oracles. The generic trailing-extra pass is retired.
 ## The retained second pass
 
 `normalizePostFinalizationReturnedTree` deliberately runs a bounded second
-pass for Scala, HTML, and JavaScript. It remains live because the first pass
-can expose information needed by later normalization. In particular, it may
-not be retired until the HTML producer/materializer emits final nested custom
-tag ranges without `normalizeHTMLRecoveredNestedCustomTagRanges`. Scala and
-JavaScript producers must likewise emit their final annotations and spans in
-one pass, and all registered route receipts must show the second pass is inert.
+pass for Scala and HTML. It remains live because the first pass can expose
+information needed by later normalization. In particular, it may not be
+retired until the HTML producer/materializer emits final nested custom-tag
+ranges without `normalizeHTMLRecoveredNestedCustomTagRanges`. Scala must
+likewise emit its final annotations and spans in one pass, and all registered
+route receipts must show the second pass is inert.
+
+JavaScript no longer participates in this fixpoint. Its canonical
+compatibility pipeline already extends `program` and recovery-root terminator
+tails after every JavaScript shape and span rewrite. The only intervening work
+before returned-tree publication is terminal-leaf normalization and optional
+parent-link wiring; neither can shorten or reclassify the root. The registry
+retains a retired historical entry for the deleted JavaScript arm and its
+production, compact-final-ref, forest, and incremental span receipts.
 
 Removing the second pass because it looks repetitive would reopen known
 fixpoint behavior; its registry retirement condition is the deletion gate.

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -18,11 +18,11 @@ The v1 registry freezes the current surface:
 - 78 explicit `runLanguageResultCompatibility` switch arms covering 85
   language names;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
-- two generic passes that run after language dispatch;
+- one generic pass that runs after language dispatch;
 - one retained post-finalization second-pass fixpoint with three switch arms
   covering Scala, HTML, and JavaScript.
 
-That is 82 live registry entries. The registry covers only this documented
+That is 81 live registry entries. The registry covers only this documented
 internal result-compatibility tier; scheduler experiments and other engine
 research belong in their owning subsystem's durable traces.
 
@@ -87,6 +87,16 @@ The generic reconstruction walk is therefore retired and deleted. Once raw
 child identity has been lost, a display-name-compatible caller artifact is no
 longer guessed into shape; custom artifacts must carry the explicit native
 capability and exact metadata receipt to opt in.
+
+## Current progress: trailing root trivia
+
+Clean hidden whitespace-only root tails are now finalized as root span coverage
+instead of reconstructed in the shared compatibility tail. The rule applies
+before result compatibility, including compatibility-free production and
+compact parses; forest and incremental routes share the same root finalizer.
+Error roots retain their recovery extra, and lazy final-child references are
+filtered without draining the compact range. Real RST and Comment fixtures are
+exact against their C oracles. The generic trailing-extra pass is retired.
 
 ## The retained second pass
 

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -23,9 +23,11 @@ subsystem names rather than directory depth.
 | Allocation and storage | `arena*.go`, `raw_shape*.go`, `no_tree_node.go`, `node_field_metadata.go` | Arena lifetime, compact/raw node storage, and memory accounting |
 
 The result-compatibility tier has its own retirement rules in
-[compat-tier.md](compat-tier.md). External scanner certification and fallback
-policy live in [external-scanners.md](external-scanners.md). Compact admission
-breadth is tracked in [compact-route-coverage-census.md](compact-route-coverage-census.md).
+[compat-tier.md](compat-tier.md), with the ordered root-cleanup program in
+[root-normalization-retirement.md](root-normalization-retirement.md). External
+scanner certification and fallback policy live in
+[external-scanners.md](external-scanners.md). Compact admission breadth is
+tracked in [compact-route-coverage-census.md](compact-route-coverage-census.md).
 
 ## Package and tool directories
 

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -1,0 +1,174 @@
+# Root and result-normalization retirement plan
+
+The repository root is intentionally the public `gotreesitter` Go package.
+Its width is nevertheless a maintenance liability: at the v0.47.0 boundary it
+contains 214 production Go files and 312 root-package test files. The
+`parser_result*.go` compatibility tier accounts for 114 production files and
+79 test files. This plan reduces that surface without inventing cosmetic
+package boundaries or weakening C-tree parity.
+
+The mechanically checked compatibility inventory remains
+[`testdata/result_compat_ownership_v1.json`](../testdata/result_compat_ownership_v1.json).
+This document defines the retirement program around that inventory.
+
+## End state
+
+The root is clean when all of the following are true:
+
+1. Public API files and parser-engine subsystems have clear ownership in
+   [the repository map](repository-map.md).
+2. No generic returned-tree repair or repeated post-finalization fixpoint
+   remains. Materialization owns generic node, field, alias, trivia, and span
+   invariants before publication.
+3. Every remaining language compatibility entry is either being retired by a
+   named upstream mechanism or is deliberately retained with a documented
+   public/C-oracle boundary reason.
+4. New parser behavior is implemented in scheduler, recovery, derivation
+   election, scanner checkpoints, incremental reuse, or materialization—not
+   as a new language-name patch.
+5. Independent data or policy is extracted from the root only when it can use
+   a narrow internal API without exporting node-arena, stack, or pending-parent
+   internals. File movement alone is not progress.
+6. Generated binaries, corpora, profiles, and run receipts follow the artifact
+   policy in the repository map and do not accumulate as unexplained root
+   clutter.
+
+The primary ratchets are live compatibility entries, live generic/fixpoint
+arms, and production `parser_result*.go` lines. Raw root file count is reported
+but is not a target by itself; splitting one package into arbitrary files or
+directories does not improve ownership.
+
+## Rules for every retirement PR
+
+Each PR retires one ownership mechanism or one proven-inert family:
+
+1. Identify the authoritative upstream owner and the exact registered entries.
+2. Add or strengthen a witness that observes the invariant before the
+   normalizer runs. For suspected dead code, instrument and census first.
+3. Implement the capability or invariant once in the owning subsystem. Do not
+   add a replacement language allowlist, source-text heuristic, or per-language
+   parser patch.
+4. Prove production, compact, forest, and incremental routes. Run C-oracle
+   parity one grammar at a time for every affected language.
+5. Delete the normalizer and its exclusively owned helpers and tests. Preserve
+   useful acceptance assertions at the new owner.
+6. Update the registry, this plan when its schedule changes, the compatibility
+   guide, and the changelog. Retired registry entries remain as historical
+   receipts.
+7. Run Canopy impact and quality checks, review the diff directly, and record
+   the ratchet in Hyphae.
+
+Correctness is the merge gate. Performance measurements may select the next
+candidate, but a performance result cannot substitute for route parity.
+
+## Ordered program
+
+### R0 — inventory and containment
+
+Status: complete.
+
+- The repository map names the root subsystems and local-artifact policy.
+- The ownership registry rejects unregistered dispatcher, predicate, generic,
+  and post-finalization behavior.
+- Collapsed named-leaf reconstruction and previously identified dead
+  compatibility helpers have retirement receipts.
+- The incremental campaign is capability-based; scanner checkpoint admission
+  and GSS ownership no longer depend on language exceptions.
+
+### R1 — eliminate shared tail and fixpoint scaffolding
+
+Status: in progress.
+
+1. Land the clean-root trailing-trivia owner and delete the generic
+   trailing-extra compatibility pass.
+2. Remove JavaScript from the returned-tree second pass after proving its
+   canonical compatibility pipeline already owns the final root span.
+3. Retire the remaining generic terminal-leaf pass by moving the invariant
+   into construction/materialization. This must cover lazy compact child
+   references without forcing them.
+4. Retire the HTML and Scala second-pass arms independently. Each first needs
+   a pre-publication witness showing that a single canonical pass reaches the
+   final tree. The shared fixpoint is deleted only after both arms are gone.
+
+Exit: zero generic compatibility passes and zero post-finalization fixpoint
+arms.
+
+### R2 — census and remove inert language passes
+
+Status: active after R1's first PR.
+
+The mandatory shape is census before migration. Historical audits already
+found that table or engine fixes can leave old normalizers behind.
+
+1. Re-run the Rust dot-range census over the full authenticated Rust corpus.
+   If rewrites remain zero and synthetic controls fire, remove the pass and
+   its exclusive traversal in one PR.
+2. Re-census any pass whose original bug is now covered upstream or whose
+   registered witness no longer reaches it. A zero rewrite count is only
+   actionable when positive controls prove the probe.
+3. Keep live Rust doc-comment behavior and recovery-only token-tree behavior
+   out of dead-code PRs; they belong to materialization and recovered-forest
+   work respectively.
+
+Exit: no compatibility pass is retained solely because an old fixture calls
+it directly.
+
+### R3 — move materialization invariants upstream
+
+Status: queued.
+
+Group by invariant, not language:
+
+1. terminal leaves and hidden trivia;
+2. root and child span ownership;
+3. field and alias projection;
+4. recovered-node construction and parent/child attachment.
+
+A mechanism PR may delete several dispatcher entries. A one-language
+regression is acceptable as a witness, but the implementation must be
+capability- or metadata-driven and apply to every matching grammar.
+
+Exit: materialization-owned compatibility entries are either retired or
+explicitly classified as retained format-boundary behavior.
+
+### R4 — derivation election and scheduler/recovery
+
+Status: mechanism work required.
+
+1. Express ambiguity and dynamic-precedence decisions in certified conflict
+   or derivation policy when the parser actually observes competing actions.
+2. Do not force deterministic post-parse rewrites into conflict policy; the
+   JS/TS census proved that these are different classes.
+3. Build recovered-forest ownership in the parser core before deleting the
+   recovery-heavy families. Validate in increasing risk order:
+   AWK/C/Kotlin/Rust, then COBOL/Scala/Authzed/PowerShell and other
+   oracle-heavy families.
+4. Keep scanner state and incremental invalidation fixes in their own owners;
+   neither is a reason to add result compatibility.
+
+Exit: scheduler/action and derivation/election entries shrink through shared
+engine behavior, with no per-language parser exceptions.
+
+### R5 — extract only stable internal boundaries
+
+Status: last.
+
+After normalization ownership has moved upstream, reconsider package
+extraction for pure policy, immutable generated metadata, or harness support.
+Do not create an `internal/resultcompat` package: it would merely export or
+cycle through `Node`, arenas, stack entries, and pending parents while
+preserving the liability.
+
+Exit: any remaining broad root subsystem is broad because it shares runtime
+ownership, not because unrelated utilities or generated artifacts were left
+there.
+
+## Progress ledger
+
+| Ratchet | Status | Before | After | Evidence |
+| --- | --- | ---: | ---: | --- |
+| Generic trailing-extra pass | pending merge | 2 generic passes | 1 | RST and Comment production/compact/forest/incremental witnesses plus isolated C-oracle parity |
+| JavaScript returned-tree arm | pending merge | 3 fixpoint arms | 2 | pre-second-pass root-span witness, JavaScript real-corpus parity, and 30/30 valid incremental/fresh edits |
+
+Mark a row merged only after CI and merge evidence exist. Detailed per-entry
+receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/forest_incremental_correctness_test.go
+++ b/forest_incremental_correctness_test.go
@@ -154,6 +154,12 @@ func TestForestIncrementalCorrectness(t *testing.T) {
 					continue
 				}
 				tested++
+				if got, want := incTree.RootNode().EndByte(), uint32(len(e.edited)); got != want {
+					t.Errorf("edit %d (%s): incremental root end=%d, want %d", i, e.desc, got, want)
+				}
+				if got, want := freshTree.RootNode().EndByte(), uint32(len(e.edited)); got != want {
+					t.Errorf("edit %d (%s): fresh root end=%d, want %d", i, e.desc, got, want)
+				}
 				got := incTree.RootNode().SExpr(lang)
 				want := freshTree.RootNode().SExpr(lang)
 				if got != want {

--- a/glr_forest_dispatch_test.go
+++ b/glr_forest_dispatch_test.go
@@ -443,6 +443,12 @@ func TestForestDispatchPromotesJavaScript(t *testing.T) {
 	if got, want := tree.RootNode().SExpr(lang), prod.RootNode().SExpr(lang); got != want {
 		t.Fatalf("JavaScript forest dispatch diverged\n got: %s\nwant: %s", got, want)
 	}
+	if got, want := prod.RootNode().EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("JavaScript production root end byte = %d, want %d", got, want)
+	}
+	if got, want := tree.RootNode().EndByte(), uint32(len(src)); got != want {
+		t.Fatalf("JavaScript forest root end byte = %d, want %d", got, want)
+	}
 	rt := tree.ParseRuntime()
 	if rt.StopReason != gts.ParseStopAccepted || !rt.ForestFastPath || !rt.LastTokenWasEOF || rt.TokensConsumed != 0 {
 		t.Fatalf("JavaScript did not use forest accepted runtime: %s", rt.Summary())

--- a/grammars/trailing_extra_native_regression_test.go
+++ b/grammars/trailing_extra_native_regression_test.go
@@ -1,0 +1,43 @@
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestCleanTrailingExtraOwnershipDoesNotNeedResultCompatibility(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		lang   *gotreesitter.Language
+		source string
+	}{
+		{name: "rst", lang: RstLanguage(), source: "Title\n=====\n\nbody\n"},
+		{name: "comment", lang: CommentLanguage(), source: "hello\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			production, err := gotreesitter.NewParser(test.lang).Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer production.Release()
+			native, err := gotreesitter.NewParser(test.lang).ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer native.Release()
+			productionRoot := production.RootNode()
+			nativeRoot := native.RootNode()
+			if got, want := nativeRoot.SExpr(test.lang), productionRoot.SExpr(test.lang); got != want {
+				t.Fatalf("compatibility-free tree = %s, want production %s", got, want)
+			}
+			if nativeRoot.EndByte() != uint32(len(source)) {
+				t.Fatalf("compatibility-free root end = %d, want %d", nativeRoot.EndByte(), len(source))
+			}
+			if count := nativeRoot.ChildCount(); count == 0 || nativeRoot.Child(count-1).IsExtra() {
+				t.Fatalf("compatibility-free root retained trailing extra: %s", nativeRoot.SExpr(test.lang))
+			}
+		})
+	}
+}

--- a/grammars/trailing_extra_native_regression_test.go
+++ b/grammars/trailing_extra_native_regression_test.go
@@ -17,27 +17,80 @@ func TestCleanTrailingExtraOwnershipDoesNotNeedResultCompatibility(t *testing.T)
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			source := []byte(test.source)
-			production, err := gotreesitter.NewParser(test.lang).Parse(source)
+			productionParser := gotreesitter.NewParser(test.lang)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.ParseNoResultCompatibilityBenchmarkOnly(source)
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer production.Release()
-			native, err := gotreesitter.NewParser(test.lang).ParseNoResultCompatibilityBenchmarkOnly(source)
+			assertCleanTrailingExtraTree(t, "production", production, test.lang, source)
+
+			compactParser := gotreesitter.NewParser(test.lang)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.ParseNoResultCompatibilityBenchmarkOnly(source)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer native.Release()
-			productionRoot := production.RootNode()
-			nativeRoot := native.RootNode()
-			if got, want := nativeRoot.SExpr(test.lang), productionRoot.SExpr(test.lang); got != want {
-				t.Fatalf("compatibility-free tree = %s, want production %s", got, want)
+			defer compact.Release()
+			assertCleanTrailingExtraTree(t, "compact", compact, test.lang, source)
+			if got, want := compact.RootNode().SExpr(test.lang), production.RootNode().SExpr(test.lang); got != want {
+				t.Fatalf("compact tree = %s, want production %s", got, want)
 			}
-			if nativeRoot.EndByte() != uint32(len(source)) {
-				t.Fatalf("compatibility-free root end = %d, want %d", nativeRoot.EndByte(), len(source))
+
+			forestParser := gotreesitter.NewParser(test.lang)
+			forest, ok := forestParser.ParseForestExperimental(source)
+			if !ok || forest == nil {
+				offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
+				t.Fatalf("forest route declined at %d symbol=%d reason=%s", offset, symbol, reason)
 			}
-			if count := nativeRoot.ChildCount(); count == 0 || nativeRoot.Child(count-1).IsExtra() {
-				t.Fatalf("compatibility-free root retained trailing extra: %s", nativeRoot.SExpr(test.lang))
+			defer forest.Release()
+			assertCleanTrailingExtraTree(t, "forest", forest, test.lang, source)
+
+			oldTree, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer oldTree.Release()
+			nextSource := append([]byte(nil), source...)
+			nextSource[0] = 'X'
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte: 0, OldEndByte: 1, NewEndByte: 1,
+				StartPoint: gotreesitter.Point{}, OldEndPoint: gotreesitter.Point{Column: 1}, NewEndPoint: gotreesitter.Point{Column: 1},
+			})
+			incremental, _, err := productionParser.ParseIncrementalProfiled(nextSource, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer incremental.Release()
+			assertCleanTrailingExtraTree(t, "incremental", incremental, test.lang, nextSource)
+			fresh, err := gotreesitter.NewParser(test.lang).Parse(nextSource)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer fresh.Release()
+			if got, want := incremental.RootNode().SExpr(test.lang), fresh.RootNode().SExpr(test.lang); got != want {
+				t.Fatalf("incremental tree = %s, want fresh %s", got, want)
 			}
 		})
+	}
+}
+
+func assertCleanTrailingExtraTree(t *testing.T, route string, tree *gotreesitter.Tree, lang *gotreesitter.Language, source []byte) {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil || root.HasError() {
+		t.Fatalf("%s root = %v, want clean tree", route, root)
+	}
+	if root.EndByte() != uint32(len(source)) {
+		t.Fatalf("%s root end = %d, want %d", route, root.EndByte(), len(source))
+	}
+	count := root.ChildCount()
+	if count == 0 {
+		t.Fatalf("%s root has no children", route)
+	}
+	last := root.Child(count - 1)
+	if symbol := int(last.Symbol()); last.IsExtra() && symbol < len(lang.SymbolMetadata) && !lang.SymbolMetadata[symbol].Visible {
+		t.Fatalf("%s retained hidden trailing extra: %s", route, root.SExpr(lang))
 	}
 }

--- a/parser_api.go
+++ b/parser_api.go
@@ -92,8 +92,6 @@ func normalizeReturnedTree(root *Node, source []byte, lang *Language) {
 		normalizeRootEOFNewlineSpan(root, source, lang)
 	case "html":
 		normalizeHTMLRecoveredNestedCustomTagRanges(root, source, lang)
-	case "javascript":
-		normalizeJavaScriptProgramEnd(root, source, lang)
 	}
 }
 

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -52,7 +52,7 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser, incremen
 	// which parseStopReasonIsActive deliberately excludes (many callers rely on
 	// its narrower Timeout/Cancelled-only semantics). Without this, a
 	// budget-stopped Go result would still fall through into the generic
-	// trailing-trivia/terminal-leaf passes below.
+	// terminal-leaf pass below.
 	if resultMaterializationShouldStop(result.stopReason) {
 		return result
 	}
@@ -60,7 +60,6 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser, incremen
 		result.stopReason = reason
 		return result
 	}
-	normalizeRootTrailingExtraTriviaCompatibility(root, source, lang)
 	var terminalReason ParseStopReason
 	_, terminalReason, result.errorSummary = normalizeResultTerminalLeafNodesWithAliasTargetsAndStopAndErrorSummary(root, lang, p.visibleAliasTargetSymbol, ctx.stopCheck)
 	if parseStopReasonIsActive(terminalReason) {
@@ -80,13 +79,6 @@ func (ctx resultCompatibilityContext) stopReason() ParseStopReason {
 		return ParseStopNone
 	}
 	return reason
-}
-
-func normalizeRootTrailingExtraTriviaCompatibility(root *Node, source []byte, lang *Language) {
-	if root == nil || root.hasError() {
-		return
-	}
-	trimTrailingExtraTriviaRoot(root, source, lang)
 }
 
 func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompatibilityResult {

--- a/parser_result_javascript_typescript_test.go
+++ b/parser_result_javascript_typescript_test.go
@@ -176,6 +176,72 @@ func TestNormalizeJavaScriptProgramEndExtendsErrorRootTerminatorTail(t *testing.
 	}
 }
 
+func TestFinalizeResultRootOwnsJavaScriptProgramEndBeforeReturnedTreePass(t *testing.T) {
+	lang := &Language{
+		Name:        "javascript",
+		SymbolNames: []string{"EOF", "program", "call_expression"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF"},
+			{Name: "program", Visible: true, Named: true},
+			{Name: "call_expression", Visible: true, Named: true},
+		},
+	}
+	source := []byte("call;\n")
+	parser := NewParser(lang)
+
+	for _, tc := range []struct {
+		name string
+		root func(*nodeArena) *Node
+	}{
+		{
+			name: "program",
+			root: func(arena *nodeArena) *Node {
+				call := newLeafNodeInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
+				return newParentNodeInArena(arena, 1, true, []*Node{call}, nil, 0)
+			},
+		},
+		{
+			name: "error",
+			root: func(arena *nodeArena) *Node {
+				return newLeafNodeInArena(arena, errorSymbol, true, 0, 4, Point{}, Point{Column: 4})
+			},
+		},
+		{
+			name: "compact-final-child-refs",
+			root: func(arena *nodeArena) *Node {
+				arena.finalChildRefs = true
+				call := newCompactFullLeafInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
+				parent := newPendingParentInArena(arena, 1, true, 0, []stackEntry{
+					newStackEntryCompactFullLeaf(call.parseState, call),
+				}, 0, 4, Point{}, Point{Column: 4}, false)
+				entry := newStackEntryPendingParent(parent.parseState, parent)
+				return materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			arena := newNodeArena(arenaClassFull)
+			root := tc.root(arena)
+			parser.finalizeResultRoot(root, source, nil, false, true, nil)
+
+			if got, want := root.EndByte(), uint32(len(source)); got != want {
+				t.Fatalf("root end byte after canonical finalization = %d, want %d", got, want)
+			}
+			before := root.EndPoint()
+			normalizeReturnedTree(root, source, lang)
+			if got := root.EndByte(); got != uint32(len(source)) {
+				t.Fatalf("root end byte after returned-tree pass = %d, want %d", got, len(source))
+			}
+			if got := root.EndPoint(); got != before {
+				t.Fatalf("root end point changed after returned-tree pass: got %+v want %+v", got, before)
+			}
+			if tc.name == "compact-final-child-refs" && !nodeHasFinalChildRefs(root) {
+				t.Fatal("canonical JavaScript finalization drained compact final-child refs")
+			}
+		})
+	}
+}
+
 func TestNormalizeJavaScriptTrailingContinueCommentSiblings(t *testing.T) {
 	lang := &Language{
 		Name:        "javascript",

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -983,6 +983,17 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 	if reason := p.resultMaterializationStopReason(root.ownerArena); resultMaterializationShouldStop(reason) {
 		return errorSummary, compatibilityApplied
 	}
+	// A clean root owns hidden trailing whitespace as span coverage, not as a
+	// public extra child. Resolve that shape while the root is finalized so
+	// production, compact, forest, deferred, and compatibility-free routes all
+	// observe the same materialized tree. Error roots deliberately retain the
+	// extra for recovery fidelity.
+	if p != nil && p.language != nil && !root.hasError() {
+		trimTrailingExtraTriviaRoot(root, source, p.language)
+		if extendTrailing {
+			extendNodeToTrailingWhitespace(root, source)
+		}
+	}
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
 		start = materializationTimingStart(timing)
 		compat := normalizeResultCompatibility(root, source, p, incrementalRanges)

--- a/parser_result_trailing_extra_compat_test.go
+++ b/parser_result_trailing_extra_compat_test.go
@@ -2,10 +2,11 @@ package gotreesitter
 
 import "testing"
 
-func TestNormalizeResultCompatibilityTrimsCleanRootTrailingExtraTrivia(t *testing.T) {
+func TestFinalizeResultRootNativelyTrimsCleanTrailingExtraTrivia(t *testing.T) {
 	lang := trailingExtraCompatTestLanguage()
 	source := []byte("body\n")
 	parser := NewParser(lang)
+	parser.noResultCompatibilityBenchmarkOnly = true
 	arena := newNodeArena(arenaClassFull)
 	body := newLeafNodeInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
 	trivia := newLeafNodeInArena(arena, 3, false, 4, 5, Point{Column: 4}, Point{Row: 1})
@@ -28,9 +29,11 @@ func TestNormalizeResultCompatibilityTrimsCleanRootTrailingExtraTrivia(t *testin
 	}
 }
 
-func TestNormalizeResultCompatibilityKeepsErrorRootTrailingExtraTrivia(t *testing.T) {
+func TestFinalizeResultRootKeepsErrorTrailingExtraTrivia(t *testing.T) {
 	lang := trailingExtraCompatTestLanguage()
 	source := []byte("body\n")
+	parser := NewParser(lang)
+	parser.noResultCompatibilityBenchmarkOnly = true
 	arena := newNodeArena(arenaClassFull)
 	body := newLeafNodeInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
 	trivia := newLeafNodeInArena(arena, 3, false, 4, 5, Point{Column: 4}, Point{Row: 1})
@@ -38,7 +41,7 @@ func TestNormalizeResultCompatibilityKeepsErrorRootTrailingExtraTrivia(t *testin
 	root := newParentNodeInArena(arena, 1, true, []*Node{body, trivia}, nil, 0)
 	root.setHasError(true)
 
-	normalizeResultCompatibility(root, source, &Parser{language: lang}, nil)
+	parser.finalizeResultRoot(root, source, nil, false, true, nil)
 
 	if got, want := root.ChildCount(), 2; got != want {
 		t.Fatalf("root child count = %d, want %d", got, want)

--- a/parser_result_trailing_extra_native_test.go
+++ b/parser_result_trailing_extra_native_test.go
@@ -3,7 +3,7 @@ package gotreesitter
 import "testing"
 
 func TestFinalizeResultRootNativelyTrimsCleanTrailingExtraTrivia(t *testing.T) {
-	lang := trailingExtraCompatTestLanguage()
+	lang := trailingExtraNativeTestLanguage()
 	source := []byte("body\n")
 	parser := NewParser(lang)
 	parser.noResultCompatibilityBenchmarkOnly = true
@@ -30,7 +30,7 @@ func TestFinalizeResultRootNativelyTrimsCleanTrailingExtraTrivia(t *testing.T) {
 }
 
 func TestFinalizeResultRootKeepsErrorTrailingExtraTrivia(t *testing.T) {
-	lang := trailingExtraCompatTestLanguage()
+	lang := trailingExtraNativeTestLanguage()
 	source := []byte("body\n")
 	parser := NewParser(lang)
 	parser.noResultCompatibilityBenchmarkOnly = true
@@ -51,15 +51,15 @@ func TestFinalizeResultRootKeepsErrorTrailingExtraTrivia(t *testing.T) {
 	}
 }
 
-func trailingExtraCompatTestLanguage() *Language {
+func trailingExtraNativeTestLanguage() *Language {
 	return &Language{
 		Name:        "generic_trivia",
 		SymbolNames: []string{"EOF", "root", "body", "_trailing_trivia"},
 		SymbolMetadata: []SymbolMetadata{
-			{Name: "EOF", Visible: false, Named: false},
+			{Name: "EOF"},
 			{Name: "root", Visible: true, Named: true},
 			{Name: "body", Visible: true, Named: true},
-			{Name: "_trailing_trivia", Visible: false, Named: false},
+			{Name: "_trailing_trivia"},
 		},
 	}
 }

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -6,8 +6,8 @@
     "dispatcher_languages": 85,
     "dispatcher_predicates": 1,
     "generic_passes": 1,
-    "post_finalization_arms": 3,
-    "post_finalization_languages": 3
+    "post_finalization_arms": 2,
+    "post_finalization_languages": 2
   },
   "owner_categories": [
     "scheduler_action_semantics",
@@ -2365,20 +2365,17 @@
         "normalizeScalaTemplateBodyFunctionEnds",
         "normalizeScalaCaseClauseEnds",
         "normalizeRootEOFNewlineSpan",
-        "normalizeHTMLRecoveredNestedCustomTagRanges",
-        "normalizeJavaScriptProgramEnd"
+        "normalizeHTMLRecoveredNestedCustomTagRanges"
       ],
       "files": [
         "parser_api.go",
         "parser_result_scala_template.go",
         "parser_result_scala_compilation.go",
         "parser_result_misc_spans.go",
-        "parser_result_html.go",
-        "parser_result_javascript_typescript.go"
+        "parser_result_html.go"
       ],
       "languages": [
         "html",
-        "javascript",
         "scala"
       ],
       "entrypoint_calls": [
@@ -2406,24 +2403,15 @@
           "functions": [
             "normalizeHTMLRecoveredNestedCustomTagRanges"
           ]
-        },
-        {
-          "languages": [
-            "javascript"
-          ],
-          "functions": [
-            "normalizeJavaScriptProgramEnd"
-          ]
         }
       ],
-      "purpose": "Retain the bounded second pass that reaches a returned-tree fixpoint after finalization for Scala annotations and bounds, HTML recovered nested custom-tag ranges, and JavaScript program ends.",
+      "purpose": "Retain the bounded second pass that reaches a returned-tree fixpoint after finalization for Scala annotations and bounds and HTML recovered nested custom-tag ranges. JavaScript program-end ownership is native to its canonical compatibility pass and needs no returned-tree second pass.",
       "authoritative_owner": "materialization",
       "witnesses": [
         "parser_result_html_test.go",
-        "parser_result_javascript_typescript_compat_test.go",
         "parser_result_test/parser_result_scala_comment_attachment_test.go"
       ],
-      "retirement_condition": "Delete only after the HTML producer/materializer emits final nested custom-tag ranges without normalizeHTMLRecoveredNestedCustomTagRanges, the Scala and JavaScript producers emit their final spans in one pass, and exact production, compact, forest, incremental, and C-oracle receipts prove the second pass is inert.",
+      "retirement_condition": "Delete only after the HTML producer/materializer emits final nested custom-tag ranges without normalizeHTMLRecoveredNestedCustomTagRanges, the Scala producer emits its final annotations and spans in one pass, and exact production, compact, forest, incremental, and C-oracle receipts prove the second pass is inert.",
       "route_coverage": {
         "production": "post_finalization_fixpoint",
         "compact": "post_finalization_fixpoint",
@@ -2433,6 +2421,57 @@
       },
       "status": "live",
       "receipt_refs": []
+    },
+    {
+      "id": "fixpoint.returned-tree-second-pass.javascript",
+      "kind": "second_pass_fixpoint",
+      "functions": [
+        "normalizeReturnedTree",
+        "normalizePostFinalizationReturnedTree",
+        "normalizeJavaScriptProgramEnd"
+      ],
+      "files": [
+        "parser_api.go",
+        "parser_result_javascript_typescript.go"
+      ],
+      "languages": [
+        "javascript"
+      ],
+      "entrypoint_calls": [
+        "normalizeReturnedTree"
+      ],
+      "switch_arms": [
+        {
+          "languages": [
+            "javascript"
+          ],
+          "functions": [
+            "normalizeJavaScriptProgramEnd"
+          ]
+        }
+      ],
+      "purpose": "Historical JavaScript arm of the returned-tree second-pass fixpoint, retired after the canonical JavaScript compatibility pipeline proved authoritative for final program and recovery-root terminator spans.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "parser_result_javascript_typescript_test.go",
+        "glr_forest_dispatch_test.go"
+      ],
+      "retirement_condition": "Satisfied: canonical finalization owns JavaScript program-end spans before returned-tree publication; compact final-child refs remain lazy; production, forest, and 30/30 valid incremental/fresh roots cover the complete source; the second pass is inert.",
+      "route_coverage": {
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
+      },
+      "status": "retired",
+      "retired_commit": "34a224bc6e98f49276bc06235c85c497127d1790",
+      "receipt_refs": [
+        "parser_result_javascript_typescript_test.go",
+        "glr_forest_dispatch_test.go",
+        "forest_incremental_correctness_test.go",
+        "cgo_harness/parity_cgo_test.go"
+      ]
     }
   ]
 }

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -5,7 +5,7 @@
     "dispatcher_arms": 78,
     "dispatcher_languages": 85,
     "dispatcher_predicates": 1,
-    "generic_passes": 2,
+    "generic_passes": 1,
     "post_finalization_arms": 3,
     "post_finalization_languages": 3
   },
@@ -2263,21 +2263,27 @@
       "languages": [
         "*"
       ],
-      "purpose": "Apply the generic root trailing-extra-trivia compatibility rule.",
+      "purpose": "Historical generic clean-root trailing-extra-trivia rule, retired after root finalization took ownership of hidden whitespace-only tail children across all materialization routes.",
       "authoritative_owner": "materialization",
       "witnesses": [
-        "parser_result_trailing_extra_compat_test.go"
+        "parser_result_trailing_extra_native_test.go"
       ],
-      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "retirement_condition": "Satisfied: root finalization owns the clean hidden whitespace-only tail shape; error roots retain recovery extras; production, compact, forest, incremental, lazy-final-ref, and C-oracle receipts are exact.",
       "route_coverage": {
-        "production": "shared_result_compatibility_tail",
-        "compact": "shared_result_compatibility_tail",
-        "forest": "shared_result_compatibility_tail",
-        "incremental": "shared_result_compatibility_tail",
-        "c_oracle": "curated_single_grammar_parity"
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
       },
-      "status": "live",
-      "receipt_refs": []
+      "status": "retired",
+      "retired_commit": "242453ea94d36fc2ee36b87076bcaae9a2ac234e",
+      "receipt_refs": [
+        "parser_result_trailing_extra_native_test.go",
+        "grammars/trailing_extra_native_regression_test.go",
+        "cgo_harness/trailing_extra_root_parity_test.go",
+        "glr_test.go"
+      ]
     },
     {
       "id": "generic.terminal-leaf",


### PR DESCRIPTION
## Summary

- move clean hidden whitespace-only root tails into canonical root finalization
- retire the generic trailing-extra compatibility pass while retaining error-root recovery extras and lazy compact child references
- prove JavaScript program-end ownership before the returned-tree second pass, then delete that redundant arm
- add the ordered root/result-normalization retirement plan and link it from the repository map and README
- preserve retired registry entries and exact route receipts

This is the first PR in the generalized retirement program. It removes shared scaffolding through upstream ownership; it does not add any per-language parser admission or replacement allowlist.

## Ratchets

- live compatibility entries: 82 → 81
- generic compatibility passes: 2 → 1
- returned-tree fixpoint arms: 3 → 2
- returned-tree fixpoint languages: 3 → 2

## Validation

- focused root-finalization, JavaScript-span, and ownership-registry tests: green
- RST and Comment production/compact/forest/incremental route matrix in Docker, one grammar at a time: green
- RST and Comment isolated C-oracle parity, one grammar at a time: green
- JavaScript real-corpus parity: 25/25 no-error, s-expression, and deep parity
- JavaScript isolated forest-incremental matrix on 247,351-byte jquery.js: 30/30 valid edits incremental == fresh with full root spans
- Canopy index: 1,839 files, 18,016 symbols, 0 errors
- Canopy changed-file quality gate: 4 checks, 0 violations
- `git diff --check`: green

## Durable plan

The repository plan is `docs/root-normalization-retirement.md`. The same corrected schedule is canonized in Hyphae as `plan.root-normalization-retirement` (signed graft receipt `hypha-receipt:graft:2026-07-23:782da22e`).