### PR TITLE
perf(incremental): certify Markdown scanner reuse

### DIFF
--- a/docs/external-scanners.md
+++ b/docs/external-scanners.md
@@ -527,7 +527,7 @@ silently widening HTML admission.
 | `liquid` | certified reuse |
 | `lua` | fallback (uncertified) |
 | `luau` | fallback (uncertified) |
-| `markdown` | fallback (uncertified) |
+| `markdown` | certified reuse |
 | `markdown_inline` | fallback (uncertified) |
 | `matlab` | fallback (uncertified) |
 | `mojo` | fallback (explicit opt-out) |

--- a/external_scanner_checkpoints.go
+++ b/external_scanner_checkpoints.go
@@ -143,6 +143,82 @@ func externalScannerCheckpointRefForNode(node *Node) (externalScannerCheckpointR
 	return cp, true
 }
 
+// copyExternalScannerCheckpointToNode preserves checkpoint ownership when
+// parser shaping clones or relabels a node. Checkpoints are arena sidecars, so
+// copying a Node header alone cannot carry them to the new arena slot.
+func copyExternalScannerCheckpointToNode(dst, src *Node) bool {
+	if dst == nil || src == nil || dst.ownerArena == nil || src.ownerArena == nil {
+		return false
+	}
+	cp, ok := externalScannerCheckpointRefForNode(src)
+	if !ok {
+		return false
+	}
+	if dst.ownerArena != src.ownerArena {
+		cp, ok = cloneExternalScannerCheckpointRef(src.ownerArena, dst.ownerArena, cp)
+		if !ok {
+			return false
+		}
+	}
+	if !dst.ownerArena.setExternalScannerCheckpoint(dst, cp) {
+		return false
+	}
+	dst.ownerArena.externalScannerCheckpointRecords++
+	return true
+}
+
+// recordExternalScannerCheckpointForParent derives a reduction receipt from
+// checkpoints already owned by its shaped children. It deliberately performs
+// direct sidecar lookups rather than recursively rebuilding descendants: parse
+// construction is bottom-up, so recursion here would make deep reductions
+// quadratic.
+func recordExternalScannerCheckpointForParent(parent *Node, children []*Node) bool {
+	if parent == nil || parent.ownerArena == nil || len(children) == 0 {
+		return false
+	}
+	var start externalScannerSnapshotRef
+	var end externalScannerSnapshotRef
+	startOK := false
+	endOK := false
+	for _, child := range children {
+		cp, ok := externalScannerCheckpointRefForNode(child)
+		if !ok {
+			continue
+		}
+		start = copyExternalScannerSnapshotRefBetweenArenas(child.ownerArena, parent.ownerArena, cp.start)
+		startOK = start.len != 0
+		break
+	}
+	for i := len(children) - 1; i >= 0; i-- {
+		child := children[i]
+		cp, ok := externalScannerCheckpointRefForNode(child)
+		if !ok {
+			continue
+		}
+		end = copyExternalScannerSnapshotRefBetweenArenas(child.ownerArena, parent.ownerArena, cp.end)
+		endOK = end.len != 0
+		break
+	}
+	if !startOK || !endOK {
+		return false
+	}
+	if !parent.ownerArena.setExternalScannerCheckpoint(parent, externalScannerCheckpointRef{start: start, end: end}) {
+		return false
+	}
+	parent.ownerArena.externalScannerCheckpointRecords++
+	return true
+}
+
+func copyExternalScannerSnapshotRefBetweenArenas(src, dst *nodeArena, ref externalScannerSnapshotRef) externalScannerSnapshotRef {
+	if src == nil || dst == nil || ref.len == 0 {
+		return externalScannerSnapshotRef{}
+	}
+	if src == dst {
+		return ref
+	}
+	return dst.copyExternalScannerSnapshotRef(src.externalScannerSnapshotBytes(ref))
+}
+
 func rebuildExternalScannerCheckpoints(root *Node, lang *Language) {
 	if root == nil || !languageUsesExternalScannerCheckpoints(lang) {
 		return

--- a/external_scanner_checkpoints_test.go
+++ b/external_scanner_checkpoints_test.go
@@ -240,6 +240,29 @@ func TestExternalScannerCheckpointSparseLookupHandlesOutOfOrderWrites(t *testing
 	}
 }
 
+func TestExternalScannerCheckpointSurvivesShapingCloneAndParent(t *testing.T) {
+	sourceArena := acquireNodeArena(arenaClassFull)
+	defer sourceArena.Release()
+	targetArena := acquireNodeArena(arenaClassIncremental)
+	defer targetArena.Release()
+
+	left := newLeafNodeInArena(sourceArena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	sourceArena.recordExternalScannerLeafCheckpoint(left, []byte{1}, []byte{2})
+	cloned := cloneNodeInArena(targetArena, left)
+	gotClone, ok := externalScannerCheckpointForNode(cloned)
+	if !ok || !bytes.Equal(gotClone.start, []byte{1}) || !bytes.Equal(gotClone.end, []byte{2}) {
+		t.Fatalf("cloned checkpoint = (%v, %v, %v), want ([1], [2], true)", gotClone.start, gotClone.end, ok)
+	}
+
+	right := newLeafNodeInArena(targetArena, 1, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	targetArena.recordExternalScannerLeafCheckpoint(right, []byte{3}, []byte{4})
+	parent := newParentNodeInArena(targetArena, 2, true, []*Node{cloned, right}, nil, 0)
+	gotParent, ok := externalScannerCheckpointForNode(parent)
+	if !ok || !bytes.Equal(gotParent.start, []byte{1}) || !bytes.Equal(gotParent.end, []byte{4}) {
+		t.Fatalf("parent checkpoint = (%v, %v, %v), want ([1], [4], true)", gotParent.start, gotParent.end, ok)
+	}
+}
+
 func TestRebuildExternalScannerCheckpointsUsesLazyFinalChildRefs(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
 	arena.finalChildRefs = true

--- a/grammars/markdown_scanner.go
+++ b/grammars/markdown_scanner.go
@@ -183,6 +183,12 @@ func mdListItemIndentation(b mdBlock) uint8 {
 // MarkdownExternalScanner handles block-level markdown parsing.
 type MarkdownExternalScanner struct{}
 
+func (MarkdownExternalScanner) SupportsIncrementalReuse() bool { return true }
+
+func (MarkdownExternalScanner) SupportsIncrementalReuseFromErrorTree() bool { return false }
+
+func (MarkdownExternalScanner) UsesExternalScannerCheckpoints() bool { return true }
+
 func (MarkdownExternalScanner) Create() any {
 	return &mdState{}
 }

--- a/grammars/markdown_scanner_checkpoint_test.go
+++ b/grammars/markdown_scanner_checkpoint_test.go
@@ -1,0 +1,78 @@
+package grammars
+
+import (
+	"bytes"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+)
+
+var (
+	_ gts.IncrementalReuseExternalScanner          = MarkdownExternalScanner{}
+	_ gts.ErrorTreeIncrementalReuseExternalScanner = MarkdownExternalScanner{}
+	_ gts.CheckpointedExternalScanner              = MarkdownExternalScanner{}
+)
+
+func TestMarkdownScannerCheckpointRoundTrip(t *testing.T) {
+	scanner := MarkdownExternalScanner{}
+	original := &mdState{
+		openBlocks: []mdBlock{
+			mdBlockQuote,
+			mdListItem3Indent,
+			mdFencedCodeBlock,
+			mdAnonymous,
+		},
+		state:                          mdStateMatching | mdStateWasSoftLineBreak | mdStateCloseBlock,
+		matched:                        2,
+		indentation:                    3,
+		column:                         1,
+		fencedCodeBlockDelimiterLength: 5,
+		simulate:                       true,
+	}
+	buf := make([]byte, 64)
+	n := scanner.Serialize(original, buf)
+	if n != 5+len(original.openBlocks) {
+		t.Fatalf("serialized size = %d, want %d", n, 5+len(original.openBlocks))
+	}
+	if n == 0 {
+		t.Fatal("reachable Markdown scanner state serialized as absent")
+	}
+
+	restored := scanner.Create().(*mdState)
+	scanner.Deserialize(restored, buf[:n])
+	roundTrip := make([]byte, 64)
+	roundTripN := scanner.Serialize(restored, roundTrip)
+	if roundTripN != n || !bytes.Equal(roundTrip[:roundTripN], buf[:n]) {
+		t.Fatalf("checkpoint round trip = %v, want %v", roundTrip[:roundTripN], buf[:n])
+	}
+	if restored.simulate {
+		t.Fatal("transient per-scan simulation flag survived checkpoint restore")
+	}
+}
+
+func TestMarkdownScannerCheckpointCapacityFailsClosed(t *testing.T) {
+	scanner := MarkdownExternalScanner{}
+	state := &mdState{openBlocks: make([]mdBlock, 12)}
+	exact := make([]byte, 5+len(state.openBlocks))
+	if got := scanner.Serialize(state, exact); got != len(exact) {
+		t.Fatalf("exact-capacity serialization = %d, want %d", got, len(exact))
+	}
+	if got := scanner.Serialize(state, exact[:len(exact)-1]); got != 0 {
+		t.Fatalf("undersized serialization = %d, want absent checkpoint", got)
+	}
+}
+
+func TestMarkdownScannerInitialCheckpointIsRepresentable(t *testing.T) {
+	scanner := MarkdownExternalScanner{}
+	state := scanner.Create()
+	buf := make([]byte, 5)
+	if got := scanner.Serialize(state, buf); got != 5 {
+		t.Fatalf("initial checkpoint size = %d, want 5", got)
+	}
+	restored := scanner.Create()
+	scanner.Deserialize(restored, buf)
+	again := make([]byte, 5)
+	if got := scanner.Serialize(restored, again); got != 5 || !bytes.Equal(again, buf) {
+		t.Fatalf("initial checkpoint round trip = %v/%d, want %v/5", again, got, buf)
+	}
+}

--- a/incremental.go
+++ b/incremental.go
@@ -700,26 +700,18 @@ func (p *Parser) tryReuseSubtree(s *glrStack, lookahead Token, ts TokenSource, i
 			idx.rejectStaleNonLeafBoundary++
 			continue
 		}
-		// A node's span always starts where its leftmost descendant leaf
-		// starts, so n's leftmost leaf is the OLD-tree token that was lexed
-		// at this position before the edit. reuseNonLeafTargetStateOnStack
-		// below only checks goto-table/stack-depth compatibility for n's
-		// *symbol* - it never consults the lookahead token at all - so a
-		// stale tokenization boundary inside n (e.g. a thin single-token
-		// wrapper non-terminal whose child token's maximal-munch decision no
-		// longer holds after the edit) would otherwise be silently reused.
-		// Compare the leftmost leaf's stored (stale) EndByte against the
-		// freshly lexed lookahead's EndByte: if they differ, the subtree
-		// under n was built from a token boundary that doesn't exist in the
-		// new source, so reject reuse. Note we deliberately do NOT compare
-		// symbols here - the leaf's symbol can differ from the fresh
-		// lookahead's symbol even when reuse is unsafe, so a symbol check
-		// would miss the bug this guards against.
-		if leaf := leftmostLeaf(n); leaf == nil || leaf.EndByte() != lookahead.EndByte {
-			idx.rejectStaleNonLeafBoundary++
-			continue
+		// Without an exact scanner checkpoint, retain the conservative token
+		// boundary proof: a fresh lookahead ending elsewhere means the old
+		// subtree's maximal-munch boundary is stale. Checkpointed scanners use
+		// the stronger proof below instead: exact live pre-goto ownership plus
+		// an exact serialized scanner state at the candidate boundary.
+		if !languageUsesExternalScannerCheckpoints(p.language) {
+			if leaf := leftmostLeaf(n); leaf == nil || leaf.EndByte() != lookahead.EndByte {
+				idx.rejectStaleNonLeafBoundary++
+				continue
+			}
 		}
-		nextState, truncateDepth, ok := p.reuseNonLeafTargetStateOnStack(s, n, lookahead.StartByte, entryScratch)
+		nextState, truncateDepth, ok := p.reuseNonLeafTargetStateOnStack(s, n)
 		if !ok {
 			continue
 		}
@@ -1120,26 +1112,7 @@ func leftmostLeaf(n *Node) *Node {
 	return n
 }
 
-func reuseStackDepthForPreGoto(entries []stackEntry, startByte uint32, preGoto StateID) int {
-	if len(entries) == 0 {
-		return 0
-	}
-	for i := len(entries) - 1; i >= 0; i-- {
-		if entries[i].state != preGoto {
-			continue
-		}
-		frontier := uint32(0)
-		if n := stackEntryNode(entries[i]); n != nil {
-			frontier = n.endByte
-		}
-		if frontier <= startByte {
-			return i + 1
-		}
-	}
-	return 0
-}
-
-func (p *Parser) reuseNonLeafTargetStateOnStack(s *glrStack, n *Node, startByte uint32, entryScratch *glrEntryScratch) (StateID, int, bool) {
+func (p *Parser) reuseNonLeafTargetStateOnStack(s *glrStack, n *Node) (StateID, int, bool) {
 	if s == nil || n == nil || n.ChildCount() == 0 {
 		return 0, 0, false
 	}
@@ -1148,6 +1121,16 @@ func (p *Parser) reuseNonLeafTargetStateOnStack(s *glrStack, n *Node, startByte 
 	}
 
 	preGoto := n.PreGotoState()
+	// The recorded pre-goto state identifies the parser frontier that owned
+	// this reduction. Finding the same state deeper in the stack is not
+	// sufficient: truncating back to it can discard newly reparsed syntax and
+	// transfer ownership across a recovery or scanner boundary.
+	if s.top().state != preGoto {
+		if perfCountersEnabled {
+			perfRecordReuseNonLeafStateMiss()
+		}
+		return 0, 0, false
+	}
 
 	gotoState := p.lookupGoto(preGoto, n.Symbol())
 	if gotoState == 0 {
@@ -1168,14 +1151,5 @@ func (p *Parser) reuseNonLeafTargetStateOnStack(s *glrStack, n *Node, startByte 
 		return 0, 0, false
 	}
 
-	entries := s.ensureEntries(entryScratch)
-	depth := reuseStackDepthForPreGoto(entries, startByte, preGoto)
-	if depth == 0 {
-		if perfCountersEnabled {
-			perfRecordReuseNonLeafStateMiss()
-		}
-		return 0, 0, false
-	}
-
-	return gotoState, depth, true
+	return gotoState, s.depth(), true
 }

--- a/incremental_test.go
+++ b/incremental_test.go
@@ -699,24 +699,6 @@ func TestConfigureIncrementalParseCapsPreservesConfiguredWidth(t *testing.T) {
 	}
 }
 
-func TestReuseStackDepthForPreGoto(t *testing.T) {
-	entries := []stackEntry{
-		{state: 1},
-		newStackEntryNode(10, &Node{endByte: 4}),
-		newStackEntryNode(20, &Node{endByte: 8}),
-		newStackEntryNode(10, &Node{endByte: 12}),
-	}
-	if got := reuseStackDepthForPreGoto(entries, 8, 10); got != 2 {
-		t.Fatalf("depth at start=8/pre=10 = %d, want 2", got)
-	}
-	if got := reuseStackDepthForPreGoto(entries, 12, 10); got != 4 {
-		t.Fatalf("depth at start=12/pre=10 = %d, want 4", got)
-	}
-	if got := reuseStackDepthForPreGoto(entries, 8, 99); got != 0 {
-		t.Fatalf("depth at missing state = %d, want 0", got)
-	}
-}
-
 func TestReuseNonLeafTargetStateOnStackUsesPreGoto(t *testing.T) {
 	lang := buildArithmeticLanguage()
 	parser := NewParser(lang)
@@ -750,16 +732,16 @@ func TestReuseNonLeafTargetStateOnStackUsesPreGoto(t *testing.T) {
 	stackWithPre := glrStack{
 		entries: []stackEntry{
 			{state: lang.InitialState},
-			newStackEntryNode(pre, &Node{endByte: start}),
 			newStackEntryNode(pre+1, &Node{endByte: start}),
+			newStackEntryNode(pre, &Node{endByte: start}),
 		},
 	}
-	nextState, depth, ok := parser.reuseNonLeafTargetStateOnStack(&stackWithPre, target, start, nil)
+	nextState, depth, ok := parser.reuseNonLeafTargetStateOnStack(&stackWithPre, target)
 	if !ok {
 		t.Fatal("expected non-leaf stack-context match success")
 	}
-	if depth != 2 {
-		t.Fatalf("truncate depth = %d, want 2", depth)
+	if depth != stackWithPre.depth() {
+		t.Fatalf("reuse depth = %d, want live depth %d", depth, stackWithPre.depth())
 	}
 	if nextState == 0 {
 		t.Fatal("expected non-zero goto state for matched pre-goto state")
@@ -771,7 +753,18 @@ func TestReuseNonLeafTargetStateOnStackUsesPreGoto(t *testing.T) {
 			newStackEntryNode(pre+2, &Node{endByte: start}),
 		},
 	}
-	if _, _, ok := parser.reuseNonLeafTargetStateOnStack(&stackMissingPre, target, start, nil); ok {
-		t.Fatal("expected failure when stack does not contain candidate pre-goto state")
+	if _, _, ok := parser.reuseNonLeafTargetStateOnStack(&stackMissingPre, target); ok {
+		t.Fatal("expected failure when live stack does not own candidate pre-goto state")
+	}
+
+	stackWithOlderPre := glrStack{
+		entries: []stackEntry{
+			{state: lang.InitialState},
+			newStackEntryNode(pre, &Node{endByte: start}),
+			newStackEntryNode(pre+1, &Node{endByte: start}),
+		},
+	}
+	if _, _, ok := parser.reuseNonLeafTargetStateOnStack(&stackWithOlderPre, target); ok {
+		t.Fatal("expected failure when only an older stack entry owns candidate pre-goto state")
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -4511,6 +4511,15 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 		stopDiagHaveToken = true
 		stopDiagToken = t
 	}
+	recordCurrentLookahead := func(t Token) {
+		noteStopDiagnosticToken(t)
+		lastTokenEndByte = t.EndByte
+		lastTokenSymbol = t.Symbol
+		lastTokenWasEOF = t.Symbol == 0 && t.StartByte == t.EndByte && !t.NoLookahead
+		if lastTokenWasEOF && t.EndByte < expectedEOFByte {
+			tokenSourceEOFEarly = true
+		}
+	}
 	computeStopDiagnosticRecoverAction := func() bool {
 		if stopDiagRecoverActionAvailable || !stopDiagHaveToken {
 			return stopDiagRecoverActionAvailable
@@ -5008,13 +5017,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				p.logf(ParserLogLex, "token sym=%d start=%d end=%d", tok.Symbol, tok.StartByte, tok.EndByte)
 			}
 			perfTokensConsumed++
-			noteStopDiagnosticToken(tok)
-			lastTokenEndByte = tok.EndByte
-			lastTokenSymbol = tok.Symbol
-			lastTokenWasEOF = tok.Symbol == 0 && tok.StartByte == tok.EndByte && !tok.NoLookahead
-			if lastTokenWasEOF && tok.EndByte < expectedEOFByte {
-				tokenSourceEOFEarly = true
-			}
+			recordCurrentLookahead(tok)
 			for si := range stacks {
 				stacks[si].shifted = false
 			}
@@ -5171,6 +5174,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				}
 			} else if reusedAnySibling {
 				workCountRefreshConvergenceLookahead(tok)
+				// Reuse can advance the token source across an entire block and
+				// synthesize EOF without returning through token acquisition.
+				// Keep public runtime completion evidence aligned with the
+				// lookahead that actually governs the accepted frontier.
+				recordCurrentLookahead(tok)
 				needToken = false
 				consecutiveReduces = 0
 				consecutiveNoTokenDispatches = 0
@@ -5427,14 +5435,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 						}
 						tok = nextTok
 						workCountRefreshConvergenceLookahead(tok)
-						noteStopDiagnosticToken(tok)
+						recordCurrentLookahead(tok)
 						p.updateCurrentExternalTokenCheckpoint(ts, tok)
-						lastTokenEndByte = tok.EndByte
-						lastTokenSymbol = tok.Symbol
-						lastTokenWasEOF = tok.Symbol == 0 && tok.StartByte == tok.EndByte && !tok.NoLookahead
-						if lastTokenWasEOF && tok.EndByte < expectedEOFByte {
-							tokenSourceEOFEarly = true
-						}
 						if p.logger != nil {
 							p.logf(ParserLogLex, "relex token sym=%d start=%d end=%d", tok.Symbol, tok.StartByte, tok.EndByte)
 						}
@@ -6281,14 +6283,8 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 							}
 							tok = nextTok
 							workCountRefreshConvergenceLookahead(tok)
-							noteStopDiagnosticToken(tok)
+							recordCurrentLookahead(tok)
 							p.updateCurrentExternalTokenCheckpoint(ts, tok)
-							lastTokenEndByte = tok.EndByte
-							lastTokenSymbol = tok.Symbol
-							lastTokenWasEOF = tok.Symbol == 0 && tok.StartByte == tok.EndByte && !tok.NoLookahead
-							if lastTokenWasEOF && tok.EndByte < expectedEOFByte {
-								tokenSourceEOFEarly = true
-							}
 							if p.logger != nil {
 								p.logf(ParserLogLex, "relex token sym=%d start=%d end=%d", tok.Symbol, tok.StartByte, tok.EndByte)
 							}

--- a/parser.go
+++ b/parser.go
@@ -5102,6 +5102,11 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					break
 				}
 				tok = nextTok
+				// Reuse advances the token source without returning through
+				// ordinary acquisition. Publish that lookahead immediately so
+				// EOF, fork, timeout, and block-stop exits all report the
+				// frontier that actually governs the parse.
+				recordCurrentLookahead(tok)
 				reusedAnySibling = true
 				if timing != nil {
 					timing.blockSpliceSteps++
@@ -5174,11 +5179,6 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				}
 			} else if reusedAnySibling {
 				workCountRefreshConvergenceLookahead(tok)
-				// Reuse can advance the token source across an entire block and
-				// synthesize EOF without returning through token acquisition.
-				// Keep public runtime completion evidence aligned with the
-				// lookahead that actually governs the accepted frontier.
-				recordCurrentLookahead(tok)
 				needToken = false
 				consecutiveReduces = 0
 				consecutiveNoTokenDispatches = 0

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -155,13 +155,6 @@ func TestUncertifiedExternalScannerLengthChangingEditFallsBack(t *testing.T) {
 			replacement: []byte("hello world"),
 		},
 		{
-			name:        "markdown",
-			lang:        grammars.MarkdownLanguage,
-			source:      []byte("# Title\n\nParagraph text.\n"),
-			oldText:     []byte("Title"),
-			replacement: []byte("Longer Title"),
-		},
-		{
 			name:        "markdown_inline",
 			lang:        grammars.MarkdownInlineLanguage,
 			source:      []byte("Hello *world*.\n"),

--- a/parser_markdown_incremental_certification_test.go
+++ b/parser_markdown_incremental_certification_test.go
@@ -1,0 +1,253 @@
+package gotreesitter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestMarkdownIncrementalScannerCertification(t *testing.T) {
+	plans := []struct {
+		name      string
+		size      int
+		positions []string
+		classes   []markdownCertificationEditClass
+	}{
+		{
+			name:      "8KiB",
+			size:      8 << 10,
+			positions: []string{"start", "middle", "end"},
+			classes: []markdownCertificationEditClass{
+				markdownCertificationInsert,
+				markdownCertificationDelete,
+				markdownCertificationReplace,
+			},
+		},
+		{
+			name:      "256KiB",
+			size:      256 << 10,
+			positions: []string{"middle"},
+			classes:   []markdownCertificationEditClass{markdownCertificationReplace},
+		},
+	}
+
+	for _, plan := range plans {
+		source, sites := makeMarkdownCertificationSource(plan.size)
+		for _, position := range plan.positions {
+			var site int
+			switch position {
+			case "start":
+				site = sites[1]
+			case "middle":
+				site = sites[len(sites)/2]
+			case "end":
+				site = sites[len(sites)-2]
+			default:
+				t.Fatalf("unknown Markdown certification position %q", position)
+			}
+			for _, class := range plan.classes {
+				t.Run(fmt.Sprintf("%s/%s/%s", plan.name, class, position), func(t *testing.T) {
+					edited, edit := applyMarkdownCertificationEdit(source, site, class)
+					profile := runMarkdownCertificationSample(t, source, edited, edit)
+					if plan.size >= 256<<10 && profile.ReusedBytes*100 < uint64(len(edited))*25 {
+						t.Fatalf("Markdown certification reused only %d/%d bytes (<25%%): %+v", profile.ReusedBytes, len(edited), profile)
+					}
+					if plan.size >= 256<<10 {
+						t.Logf("Markdown reuse: %d/%d bytes, %d subtrees", profile.ReusedBytes, len(edited), profile.ReusedSubtrees)
+					}
+				})
+			}
+		}
+	}
+}
+
+type markdownCertificationEditClass uint8
+
+const (
+	markdownCertificationInsert markdownCertificationEditClass = iota
+	markdownCertificationDelete
+	markdownCertificationReplace
+)
+
+func (c markdownCertificationEditClass) String() string {
+	switch c {
+	case markdownCertificationInsert:
+		return "insert"
+	case markdownCertificationDelete:
+		return "delete"
+	case markdownCertificationReplace:
+		return "replace"
+	default:
+		return "unknown"
+	}
+}
+
+func makeMarkdownCertificationSource(target int) ([]byte, []int) {
+	var source strings.Builder
+	source.Grow(target + 1024)
+	source.WriteString("# Incremental Markdown editing\n\n")
+	sites := make([]int, 0, target/320)
+	for i := 0; source.Len() < target || len(sites) < 4; i++ {
+		fmt.Fprintf(&source, "## Section %06d\n\n", i)
+		fmt.Fprintf(&source, "> Quoted context for section %06d.\n", i)
+		fmt.Fprintf(&source, "> - nested item %06d\n", i)
+		fmt.Fprintf(&source, "> - second nested item %06d\n\n", i)
+		source.WriteString("Paragraph with **emphasis**, a [link](https://example.com), and edit token_")
+		sites = append(sites, source.Len())
+		fmt.Fprintf(&source, "%06d for incremental reuse.\n\n", i)
+		fmt.Fprintf(&source, "```go\nfmt.Printf(\"section %%d\", %d)\n```\n\n", i)
+	}
+	return []byte(source.String()), sites
+}
+
+func applyMarkdownCertificationEdit(source []byte, offset int, class markdownCertificationEditClass) ([]byte, gts.InputEdit) {
+	oldEnd := offset
+	replacement := []byte{'x'}
+	switch class {
+	case markdownCertificationDelete:
+		oldEnd = offset + 1
+		replacement = nil
+	case markdownCertificationReplace:
+		oldEnd = offset + 1
+		replacement = []byte("xy")
+	}
+	edited := make([]byte, 0, len(source)-(oldEnd-offset)+len(replacement))
+	edited = append(edited, source[:offset]...)
+	edited = append(edited, replacement...)
+	edited = append(edited, source[oldEnd:]...)
+	return edited, gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(oldEnd),
+		NewEndByte:  uint32(offset + len(replacement)),
+		StartPoint:  pointForOffset(source, offset),
+		OldEndPoint: pointForOffset(source, oldEnd),
+		NewEndPoint: pointForOffset(edited, offset+len(replacement)),
+	}
+}
+
+func runMarkdownCertificationSample(t *testing.T, source, edited []byte, edit gts.InputEdit) gts.IncrementalParseProfile {
+	t.Helper()
+	lang := grammars.MarkdownLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	oldTree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("initial Markdown parse: %v", err)
+	}
+	defer oldTree.Release()
+	requireMarkdownAcceptedFullSource(t, oldTree, source, "initial Markdown certification")
+	if oldTree.RootNode().HasError() {
+		t.Fatalf("initial Markdown parse produced ERROR: %s", oldTree.RootNode().SExpr(lang))
+	}
+	initialRuntime := oldTree.ParseRuntime()
+	if initialRuntime.ExternalScannerCheckpointRecords == 0 ||
+		initialRuntime.ExternalScannerCheckpointBytesAllocated == 0 {
+		t.Fatalf("initial Markdown parse did not record scanner checkpoints: %s", initialRuntime.Summary())
+	}
+
+	oldTree.Edit(edit)
+	incremental, profile, err := parser.ParseIncrementalProfiled(edited, oldTree)
+	if err != nil {
+		t.Fatalf("incremental Markdown parse: %v", err)
+	}
+	defer incremental.Release()
+	requireMarkdownAcceptedFullSource(t, incremental, edited, "incremental Markdown certification")
+	if profile.ReuseUnsupported {
+		t.Fatalf("certified Markdown scanner fell back: reason=%q", profile.ReuseUnsupportedReason)
+	}
+	if !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 || profile.ReusedBytes == 0 {
+		t.Fatalf("certified Markdown scanner did not reuse old syntax: %+v", profile)
+	}
+	if incremental.RootNode().HasError() {
+		t.Fatalf("incremental Markdown parse produced ERROR: %s", incremental.RootNode().SExpr(lang))
+	}
+
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	fresh, err := freshParser.Parse(edited)
+	if err != nil {
+		t.Fatalf("fresh Markdown parse: %v", err)
+	}
+	defer fresh.Release()
+	requireMarkdownAcceptedFullSource(t, fresh, edited, "fresh Markdown certification")
+	requireIncrementalDeepTreeMatchesFresh(t, incremental, fresh, lang)
+	return profile
+}
+
+func requireMarkdownAcceptedFullSource(t *testing.T, tree *gts.Tree, source []byte, phase string) {
+	t.Helper()
+	rt := tree.ParseRuntime()
+	if tree.ParseStoppedEarly() || rt.StopReason != gts.ParseStopAccepted || rt.Truncated ||
+		rt.ExpectedEOFByte != uint32(len(source)) {
+		t.Fatalf("%s: parse was not accepted, non-truncated, and full-source: %s", phase, rt.Summary())
+	}
+}
+
+func BenchmarkMarkdownParseFull256KiB(b *testing.B) {
+	source, _ := makeMarkdownCertificationSource(256 << 10)
+	lang := grammars.MarkdownLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(source)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tree, err := parser.Parse(source)
+		if err != nil {
+			b.Fatal(err)
+		}
+		tree.Release()
+	}
+}
+
+func BenchmarkMarkdownParseIncrementalInsertDelete256KiB(b *testing.B) {
+	sourceA, sites := makeMarkdownCertificationSource(256 << 10)
+	offset := sites[len(sites)/2]
+	sourceB, insert := applyMarkdownCertificationEdit(sourceA, offset, markdownCertificationInsert)
+	deleteEdit := gts.InputEdit{
+		StartByte:   uint32(offset),
+		OldEndByte:  uint32(offset + 1),
+		NewEndByte:  uint32(offset),
+		StartPoint:  pointForOffset(sourceB, offset),
+		OldEndPoint: pointForOffset(sourceB, offset+1),
+		NewEndPoint: pointForOffset(sourceA, offset),
+	}
+
+	lang := grammars.MarkdownLanguage()
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(sourceA)
+	if err != nil {
+		b.Fatal(err)
+	}
+	currentA := true
+	b.Cleanup(func() {
+		if tree != nil {
+			tree.Release()
+		}
+	})
+	b.ReportAllocs()
+	b.SetBytes(int64(len(sourceA)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var next []byte
+		edit := insert
+		if currentA {
+			next = sourceB
+		} else {
+			next = sourceA
+			edit = deleteEdit
+		}
+		tree.Edit(edit)
+		nextTree, parseErr := parser.ParseIncremental(next, tree)
+		if parseErr != nil {
+			b.Fatal(parseErr)
+		}
+		tree.Release()
+		tree = nextTree
+		currentA = !currentA
+	}
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -8394,6 +8394,7 @@ func aliasedNodeInArena(arena *nodeArena, lang *Language, n *Node, alias Symbol)
 		cloned.setNamed(lang.SymbolMetadata[alias].Named)
 	}
 	cloned.ownerArena = arena
+	copyExternalScannerCheckpointToNode(cloned, n)
 	return cloned
 }
 
@@ -8425,6 +8426,7 @@ func retainedAliasChildWrapperInArena(arena *nodeArena, lang *Language, n *Node,
 	wrapper.parseState, wrapper.preGotoState = n.parseState, n.preGotoState
 	wrapper.rawShape = n.rawShape
 	wrapper.dynamicPrecedence = n.dynamicPrecedence
+	copyExternalScannerCheckpointToNode(wrapper, n)
 	return wrapper
 }
 
@@ -8464,6 +8466,7 @@ func materializeAnonymousLeafAliasWrapper(arena *nodeArena, lang *Language, n *N
 	wrapper.preGotoState = n.preGotoState
 	wrapper.rawShape = n.rawShape
 	wrapper.dynamicPrecedence = n.dynamicPrecedence
+	copyExternalScannerCheckpointToNode(wrapper, n)
 	return wrapper
 }
 
@@ -8571,6 +8574,7 @@ func cloneNodeInArena(arena *nodeArena, n *Node) *Node {
 	cloned.errorRankCache = 0
 	cloned.ownerArena = arena
 	cloneNodeFieldMetadataHeaderInto(cloned, n, arena)
+	copyExternalScannerCheckpointToNode(cloned, n)
 	if nodeHasFinalChildRefs(n) {
 		childCount := nodeChildCountNoMaterialize(n)
 		if childCount > 0 {

--- a/tree.go
+++ b/tree.go
@@ -2499,6 +2499,9 @@ func newParentNodeInArenaWithFieldSources(arena *nodeArena, sym Symbol, named bo
 	}
 	populateParentNode(n, children)
 	nodeInitEquivVersion(n)
+	if arena.externalScannerCheckpointRecords > 0 {
+		recordExternalScannerCheckpointForParent(n, children)
+	}
 	if arena.audit != nil {
 		arena.audit.recordNodeAlloc(n, runtimeAuditNodeKindParent)
 	}
@@ -2532,6 +2535,9 @@ func newParentNodeInArenaNoLinksWithFieldSources(arena *nodeArena, sym Symbol, n
 	}
 	populateParentNodeNoLinks(n, children, trackChildErrors)
 	nodeInitEquivVersion(n)
+	if arena.externalScannerCheckpointRecords > 0 {
+		recordExternalScannerCheckpointForParent(n, children)
+	}
 	if arena.audit != nil {
 		arena.audit.recordNodeAlloc(n, runtimeAuditNodeKindParent)
 	}


### PR DESCRIPTION
## Summary

- preserve external-scanner checkpoint receipts through generalized clone, alias, and parent-shaping paths
- require exact live pre-goto ownership before interior non-leaf reuse
- certify the Markdown block scanner for checkpoint-authenticated incremental reuse
- keep public runtime EOF/lookahead evidence aligned when block reuse advances directly to a synthesized EOF
- add insert/delete/replace correctness coverage and a 25% reused-byte floor on a 256 KiB editor workload

## Performance

On the stable 256 KiB Markdown benchmark (`GOMAXPROCS=1`, five samples, `750ms`):

- full parse: ~84–89 ms
- incremental insert/delete: ~89–95 ms
- middle replace certification: 73,424 / 262,341 bytes reused (28%)

The previous checkpointless admission path reused only 5,106 bytes and incremental parsing was roughly 3x full-parse time.

## Validation

- focused scanner/checkpoint and Markdown certification tests pass
- Docker-isolated focused Markdown and SQL tests pass
- Docker-isolated focused race tests pass
- SQL's clean matrix and long-dollar-tag fail-closed witness pass with block-reuse EOF accounting
- standard Go full/no-edit metrics are neutral; single-byte edit is ~3% slower in exchange for removing unsafe backward stack truncation
- the broader generated-Markdown suite still reports its existing wrapper-normalization divergences; the canonical single-grammar/direct-C harness does not currently execute `markdown`, so that coverage hole remains separate
