### PR TITLE
fix(memory-budget): remove soft runtime budget to fix parse determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Parse results no longer depend on garbage-collection timing. The soft
+  per-parse memory budget stopped a parse when `runtime.MemStats.HeapAlloc` or
+  `runtime.MemStats.Sys` grew past the budget. Both values cover the whole
+  process, and the garbage collector paces both, so the stopping point was not
+  a function of the input. The same bytes returned a different tree on each
+  run. Five parses of one 137 KiB C# file returned five different trees, of
+  1, 11048, 19178, 22928 and 31928 nodes. Each tree reported
+  `HasError() == false` over only part of the input. The budget arms at 64 KiB,
+  so every language was exposed above that size. Only the absolute hard ceiling
+  (`GOT_PARSE_MEMORY_HARD_CEILING_MB`) now stops a parse from a runtime memory
+  reading, because that ceiling guards against running out of memory and is not
+  a shaping decision. The arena budget, the scratch budget, and the node and
+  stack limits continue to bound memory. Those layers measure what the parse
+  itself allocated, so they stop the same input at the same place every time.
+  A downstream user reported this behavior in issue #454.
+
 ### Changed
 
 - JavaScript program-end finalization now has one authoritative compatibility

--- a/glr_forest_budget_test.go
+++ b/glr_forest_budget_test.go
@@ -145,9 +145,13 @@ func TestParseForestMemoryBudgetDeclines(t *testing.T) {
 }
 
 func TestForestMemoryBudgetFinalCheckSamplesRuntimeUnmasked(t *testing.T) {
+	// Only the hard ceiling may stop a parse from a runtime.MemStats reading
+	// (issue #454 determinism contract), so arm it to prove the final check
+	// reaches a real, unmasked sample.
 	parser := &Parser{
-		parseRuntimeMemoryBudgetBytes:   1,
-		parseRuntimeMemoryBaselineBytes: 0,
+		parseRuntimeMemoryBudgetBytes:      1,
+		parseRuntimeMemoryHardCeilingBytes: 1,
+		parseRuntimeMemoryBaselineBytes:    0,
 	}
 	arena := acquireNodeArena(arenaClassFull)
 	defer arena.Release()

--- a/parser_memory_budget_merge_test.go
+++ b/parser_memory_budget_merge_test.go
@@ -40,7 +40,11 @@ func TestMergeStacksWithScratchLargeCapPollsMemoryBudgetMidGrind(t *testing.T) {
 	// allocator can reuse spans from earlier package tests. Separate runtime
 	// budget tests cover HeapAlloc/Sys delta accounting; this test's contract is
 	// that the O(n^2) merge reaches its coarse poll and stops mid-grind.
+	// Only the hard ceiling may stop a parse from a runtime.MemStats reading
+	// (issue #454 determinism contract), so this arms the ceiling rather than
+	// the soft budget.
 	parser.parseRuntimeMemoryBudgetBytes = 1
+	parser.parseRuntimeMemoryHardCeilingBytes = 1
 	parser.parseRuntimeMemoryBaselineBytes = 0
 	parser.parseRuntimeMemoryBaselineSys = 0
 	parser.parseMemoryBudgetDiagActive = true

--- a/parser_memory_budget_runtime.go
+++ b/parser_memory_budget_runtime.go
@@ -157,12 +157,38 @@ func runtimeMemoryPollMask(budgetBytes int64) uint64 {
 // used both by the masked poll above once it decides to fire, and directly by
 // the GLR merge survivor loop's coarse-stride poll (mergeStacksWithScratchLargeCap),
 // which has no other route back to a materialization-boundary poll site
-// during its O(survivors^2) grind. The hard ceiling is checked first and is
-// intentionally decoupled from the soft per-parse budget's overshoot
-// tolerance: it fires at a fixed absolute heap-growth regardless of how loose
-// the soft budget's poll cadence is for this parse.
+// during its O(survivors^2) grind.
+//
+// DETERMINISM CONTRACT (issue #454): only the absolute hard ceiling may stop a
+// parse from a runtime.MemStats reading. The soft per-parse budget must not,
+// because HeapAlloc and Sys are process-global quantities:
+//
+//   - HeapAlloc is live heap. A GC cycle mid-parse makes growth appear to
+//     recede, so the same input crosses the budget at a different token on
+//     every run.
+//   - Sys is total memory the runtime has obtained from the OS. It moves in
+//     large steps driven by GC pacing and by allocation from other goroutines
+//     in the host process, which a parse does not control at all.
+//
+// Letting either decide where a parse stops makes the returned tree a function
+// of GC timing rather than of the input. A downstream editor measured the
+// consequence directly: five parses of identical 137 KiB C# bytes returned five
+// different trees (1, 11048, 19178, 22928 and 31928 nodes), each reporting
+// stopReason=memory_budget with HasError()==false over a partial byte range.
+// This repo's own parser_memory_budget_runtime_test.go had already recorded the
+// same instability, accepting either runtime_heap or runtime_sys as the stop
+// source because "pinning runtime_heap alone made this test race-mode-flaky".
+//
+// Footprint is still bounded, and bounded deterministically, by the layers that
+// measure what the parse itself allocated: the arena budget
+// (nodeArena.budgetExhausted), the scratch budget
+// (parserScratch.budgetExhausted), and the node and stack-depth limits. Those
+// stop the same input at the same place every time. The hard ceiling below
+// stays on real memory on purpose: it is an out-of-memory backstop of last
+// resort, not a shaping decision, and a parse that reaches it is already
+// pathological.
 func (p *Parser) runtimeMemoryBudgetStopReasonNow() ParseStopReason {
-	if p == nil || (p.parseRuntimeMemoryBudgetBytes <= 0 && p.parseRuntimeMemoryHardCeilingBytes <= 0) {
+	if p == nil || p.parseRuntimeMemoryHardCeilingBytes <= 0 {
 		return ParseStopNone
 	}
 	var stats runtime.MemStats
@@ -171,15 +197,6 @@ func (p *Parser) runtimeMemoryBudgetStopReasonNow() ParseStopReason {
 	sysGrowth := runtimeMemoryGrowth(stats.Sys, p.parseRuntimeMemoryBaselineSys)
 	if ceiling := p.parseRuntimeMemoryHardCeilingBytes; ceiling > 0 && heapGrowth >= uint64(ceiling) {
 		return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceHardCeiling, heapGrowth, sysGrowth)
-	}
-	if p.parseRuntimeMemoryBudgetBytes > 0 {
-		budget := uint64(p.parseRuntimeMemoryBudgetBytes)
-		if heapGrowth >= budget {
-			return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceRuntimeHeap, heapGrowth, sysGrowth)
-		}
-		if sysGrowth >= budget {
-			return p.noteRuntimeMemoryBudgetStop(parseMemoryBudgetStopSourceRuntimeSys, heapGrowth, sysGrowth)
-		}
 	}
 	return ParseStopNone
 }

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -6,22 +6,50 @@ import (
 	"testing"
 )
 
-func TestRuntimeMemoryBudgetStopReasonSamplesHeapGrowth(t *testing.T) {
+// TestRuntimeMemoryBudgetSoftBudgetNeverStopsParse pins the issue #454
+// determinism contract: the soft per-parse budget must never stop a parse from
+// a runtime.MemStats reading, however far past the budget the process heap has
+// grown. HeapAlloc and Sys are process-global and GC-paced, so a stop derived
+// from them makes the returned tree a function of collector timing instead of
+// the input. Footprint stays bounded by the arena, scratch, node and stack
+// limits, which measure what the parse itself allocated.
+func TestRuntimeMemoryBudgetSoftBudgetNeverStopsParse(t *testing.T) {
+	// A 1-byte soft budget against a zero baseline: every byte the process has
+	// ever put on the heap counts as growth past it. The old soft arms would
+	// trip here immediately.
 	parser := &Parser{
 		parseRuntimeMemoryBudgetBytes:   1,
 		parseRuntimeMemoryBaselineBytes: 0,
+		parseRuntimeMemoryBaselineSys:   0,
 		parseRuntimeMemoryPoll:          parseRuntimeMemoryTightPollMask,
 		parseMemoryBudgetDiagActive:     true,
 	}
-	if got := parser.runtimeMemoryBudgetStopReason(0); got != ParseStopMemoryBudget {
-		t.Fatalf("runtimeMemoryBudgetStopReason(0) = %q, want %q", got, ParseStopMemoryBudget)
+	if got := parser.runtimeMemoryBudgetStopReason(0); got != ParseStopNone {
+		t.Fatalf("runtimeMemoryBudgetStopReason(0) = %q, want %q (soft budget must not stop a parse)", got, ParseStopNone)
 	}
-	// Either runtime source proves the volume trigger reached a real
-	// ReadMemStats check. Under -race the detector's shadow memory inflates
-	// MemStats.Sys, so the sys guard can legitimately fire before the heap
-	// guard; pinning "runtime_heap" alone made this test race-mode-flaky.
-	if got := parser.parseMemoryBudgetDiag.source; got != parseMemoryBudgetStopSourceRuntimeHeap && got != parseMemoryBudgetStopSourceRuntimeSys {
-		t.Fatalf("memory budget stop source = %q, want %q or %q", got, parseMemoryBudgetStopSourceRuntimeHeap, parseMemoryBudgetStopSourceRuntimeSys)
+	if got := parser.runtimeMemoryBudgetStopReasonNow(); got != ParseStopNone {
+		t.Fatalf("runtimeMemoryBudgetStopReasonNow() = %q, want %q (soft budget must not stop a parse)", got, ParseStopNone)
+	}
+	if got := parser.parseMemoryBudgetDiag.source; got != "" {
+		t.Fatalf("memory budget stop source = %q, want empty (no stop recorded)", got)
+	}
+}
+
+// TestRuntimeMemoryHardCeilingStillStopsParse proves the out-of-memory backstop
+// survives the determinism contract above. The hard ceiling stays on real
+// memory on purpose: it is a last-resort guard, not a shaping decision.
+func TestRuntimeMemoryHardCeilingStillStopsParse(t *testing.T) {
+	parser := &Parser{
+		parseRuntimeMemoryHardCeilingBytes: 1,
+		parseRuntimeMemoryBaselineBytes:    0,
+		parseRuntimeMemoryPoll:             parseRuntimeMemoryTightPollMask,
+		parseMemoryBudgetDiagActive:        true,
+	}
+	if got := parser.runtimeMemoryBudgetStopReasonNow(); got != ParseStopMemoryBudget {
+		t.Fatalf("runtimeMemoryBudgetStopReasonNow() = %q, want %q", got, ParseStopMemoryBudget)
+	}
+	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceHardCeiling; got != want {
+		t.Fatalf("memory budget stop source = %q, want %q", got, want)
 	}
 	if parser.parseMemoryBudgetDiag.runtimeHeapGrowthBytes < 1 {
 		t.Fatalf("runtime heap growth = %d, want >= 1", parser.parseMemoryBudgetDiag.runtimeHeapGrowthBytes)
@@ -49,21 +77,24 @@ func TestRuntimeMemoryPollMaskKeepsTightBudgetsResponsive(t *testing.T) {
 	}
 }
 
-func TestRuntimeMemoryBudgetStopReasonSamplesSysGrowth(t *testing.T) {
+// TestRuntimeMemoryBudgetIgnoresSysGrowth pins the specific arm that issue #454
+// tripped in the field. MemStats.Sys is the total memory the runtime has taken
+// from the operating system. It moves in large steps driven by GC pacing and by
+// allocation from other goroutines in the host process, none of which a parse
+// controls, so it must never stop one. A 137 KiB C# corpus stopped on this arm
+// at sysGrowth=512MB and returned a different tree on every run.
+func TestRuntimeMemoryBudgetIgnoresSysGrowth(t *testing.T) {
 	parser := &Parser{
 		parseRuntimeMemoryBudgetBytes:   1,
 		parseRuntimeMemoryBaselineBytes: ^uint64(0),
 		parseRuntimeMemoryBaselineSys:   0,
 		parseMemoryBudgetDiagActive:     true,
 	}
-	if got := parser.runtimeMemoryBudgetStopReasonNow(); got != ParseStopMemoryBudget {
-		t.Fatalf("runtimeMemoryBudgetStopReasonNow() = %q, want %q", got, ParseStopMemoryBudget)
+	if got := parser.runtimeMemoryBudgetStopReasonNow(); got != ParseStopNone {
+		t.Fatalf("runtimeMemoryBudgetStopReasonNow() = %q, want %q (sys growth must not stop a parse)", got, ParseStopNone)
 	}
-	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceRuntimeSys; got != want {
-		t.Fatalf("memory budget stop source = %q, want %q", got, want)
-	}
-	if parser.parseMemoryBudgetDiag.runtimeSysGrowthBytes < 1 {
-		t.Fatalf("runtime sys growth = %d, want >= 1", parser.parseMemoryBudgetDiag.runtimeSysGrowthBytes)
+	if got := parser.parseMemoryBudgetDiag.source; got != "" {
+		t.Fatalf("memory budget stop source = %q, want empty (no stop recorded)", got)
 	}
 }
 
@@ -142,12 +173,17 @@ func TestRuntimeMemoryVolumeTriggerBypassesPollMask(t *testing.T) {
 	}
 	t.Cleanup(func() { runtime.KeepAlive(ballast) })
 
+	// The soft budget still selects the poll mask, but only the hard ceiling can
+	// stop a parse (see the issue #454 determinism contract), so arm the ceiling
+	// at the same size to prove the forced poll reached a real ReadMemStats
+	// comparison rather than being skipped by the mask.
 	parser := &Parser{
-		parseRuntimeMemoryBudgetBytes:   budget,
-		parseRuntimeMemoryBaselineBytes: before.HeapAlloc,
-		parseRuntimeMemoryPoll:          skippedPollCount - 1,
-		parseRuntimeMemoryVolumeAtPoll:  0,
-		parseMemoryBudgetDiagActive:     true,
+		parseRuntimeMemoryBudgetBytes:      budget,
+		parseRuntimeMemoryHardCeilingBytes: budget,
+		parseRuntimeMemoryBaselineBytes:    before.HeapAlloc,
+		parseRuntimeMemoryPoll:             skippedPollCount - 1,
+		parseRuntimeMemoryVolumeAtPoll:     0,
+		parseMemoryBudgetDiagActive:        true,
 	}
 
 	// Below the volume threshold: the mask governs and the poll is skipped.
@@ -160,12 +196,12 @@ func TestRuntimeMemoryVolumeTriggerBypassesPollMask(t *testing.T) {
 	if got := parser.runtimeMemoryBudgetStopReason(parseRuntimeMemoryVolumePollThresholdBytes); got != ParseStopMemoryBudget {
 		t.Fatalf("runtimeMemoryBudgetStopReason(volume >= threshold) = %q, want %q (volume trigger should bypass the mask)", got, ParseStopMemoryBudget)
 	}
-	// Either runtime source proves the volume trigger reached a real
-	// ReadMemStats check. Under -race the detector's shadow memory inflates
-	// MemStats.Sys, so the sys guard can legitimately fire before the heap
-	// guard; pinning "runtime_heap" alone made this test race-mode-flaky.
-	if got := parser.parseMemoryBudgetDiag.source; got != parseMemoryBudgetStopSourceRuntimeHeap && got != parseMemoryBudgetStopSourceRuntimeSys {
-		t.Fatalf("memory budget stop source = %q, want %q or %q", got, parseMemoryBudgetStopSourceRuntimeHeap, parseMemoryBudgetStopSourceRuntimeSys)
+	// The hard ceiling is now the only source that can stop a parse, so it is a
+	// single exact expectation. The old two-source allowance existed because the
+	// heap and sys arms raced each other under -race, which is precisely the
+	// nondeterminism this contract removes.
+	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceHardCeiling; got != want {
+		t.Fatalf("memory budget stop source = %q, want %q", got, want)
 	}
 	runtime.KeepAlive(ballast)
 }

--- a/parser_result_go_compat_memory_budget_test.go
+++ b/parser_result_go_compat_memory_budget_test.go
@@ -92,15 +92,21 @@ func containerStillHasSemicolon(root *Node, c int) bool {
 // newGoCompatBudgetTestParser returns a *Parser configured with a runtime
 // memory budget baselined at the current live heap, mirroring how
 // (*Parser).enterRuntimeMemoryBudget configures a real parse.
+//
+// The hard ceiling is armed at the same size as the soft budget. Since the
+// issue #454 determinism contract, only the hard ceiling may stop a parse from
+// a runtime.MemStats reading, so these compat-walk propagation tests need it
+// armed to have any runtime-sourced stop to propagate at all.
 func newGoCompatBudgetTestParser(budgetBytes int64) *Parser {
 	debug.FreeOSMemory()
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
 	return &Parser{
-		parseRuntimeMemoryBudgetBytes:   budgetBytes,
-		parseRuntimeMemoryBaselineBytes: stats.HeapAlloc,
-		parseRuntimeMemoryBaselineSys:   stats.Sys,
-		parseMemoryBudgetDiagActive:     true,
+		parseRuntimeMemoryBudgetBytes:      budgetBytes,
+		parseRuntimeMemoryHardCeilingBytes: budgetBytes,
+		parseRuntimeMemoryBaselineBytes:    stats.HeapAlloc,
+		parseRuntimeMemoryBaselineSys:      stats.Sys,
+		parseMemoryBudgetDiagActive:        true,
 	}
 }
 


### PR DESCRIPTION
## Summary

Parse results no longer depend on garbage-collection timing. The soft per-parse memory budget stopped a parse based on HeapAlloc and Sys, which are process-global and GC-paced. This caused identical inputs to produce different parse trees on each run. Only the absolute hard ceiling now stops a parse from a runtime memory reading, restoring deterministic behavior.

## Changes

- Remove the soft per-parse memory budget check from runtimeMemoryBudgetStopReasonNow.
- Limit runtime memory stops to the absolute hard ceiling. The ceiling guards against out-of-memory. It does not shape the parse tree, preserving deterministic input-to-output mapping.
- Update test suites to assert that the soft budget never stops a parse. Verify the hard ceiling still triggers correctly.
- Add dedicated tests for Sys growth to verify it no longer triggers stops. This addresses the specific regression reported in issue #454.
- Update CHANGELOG to explain the determinism contract. State clearly why process-global metrics must not affect parse outcomes.

## Testing

- Run go test ./... -run 'MemoryBudget' to verify budget logic and test updates.
- Run parity checks in Docker for a representative 137 KiB C# file to confirm tree stability across repeated runs.

## Related Issues

- Refs #454