### PR TITLE
fix(glr): Fix GLR parse failure on state-dependent tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- A GLR stack that needs a different tokenization of the same bytes now gets
+  one. tree-sitter C lexes once per parse version, so two versions in different
+  states can receive different symbols for the same characters. This engine
+  lexes one token for every stack, which is cheaper and correct while all live
+  stacks accept that token. Where one stack's state required a different symbol,
+  that stack found no parse action, paused, and the condense step dropped it
+  because an unpaused rival was still alive. The rival then reached a dead end
+  and the whole file became one `ERROR` node. Scala shows the failure most
+  clearly, because `+`, `-`, `!` and `~` are its only prefix operators: in
+  `if (a) c + 2` the correct derivation needs `+` as the generic
+  `operator_identifier`, while the rival needs the dedicated `+` token that
+  exists so `prefix_expression` can spell unary plus. `while (a) c + 2` failed
+  the same way, and `if (a) c * 2` always worked because `*` is not a prefix
+  operator. The parser now re-lexes at the stack's own byte offset with the
+  stack's own lex mode before pausing it. It adopts the result only when the new
+  token covers the same byte span, which keeps every version at the same offset,
+  and only when the stack's state has a real action for the new symbol. The
+  re-lex reads the internal lexer only, so no external scanner state changes.
+  Clean parses are unaffected, because the probe runs only where a stack would
+  otherwise pause. Any grammar whose characters lex differently by state gains
+  the same protection.
+
 - Parse results no longer depend on garbage-collection timing. The soft
   per-parse memory budget stopped a parse when `runtime.MemStats.HeapAlloc` or
   `runtime.MemStats.Sys` grew past the budget. Both values cover the whole

--- a/parser.go
+++ b/parser.go
@@ -5444,8 +5444,20 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				}
 			}
 		}
+		// stackRelexRestoreTok holds the shared lookahead while one stack
+		// dispatches on its own re-lexed tokenization of the same bytes (see
+		// relexTokenForStackLexState). The re-lex is scoped to that stack: the
+		// shared token is restored before the next stack dispatches, and again
+		// after the loop, so a sibling that does accept the original symbol is
+		// never handed a token it cannot use.
+		stackRelexRestoreTok := Token{}
+		stackRelexActive := false
 		for si := 0; si < numStacks; si++ {
 			s := &stacks[si]
+			if stackRelexActive {
+				tok = stackRelexRestoreTok
+				stackRelexActive = false
+			}
 			// reduceActionConflict is scoped to a single stack's dispatch; a
 			// fresh iteration must not inherit the previous stack's conflict
 			// context (see the "if len(actions) > 1" block below, which is
@@ -5732,6 +5744,29 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 				}
 				if p.errorCostCompetitionEnabled() {
+					// C lexes once per version, so a version whose state needs
+					// a different tokenization of these exact bytes gets it.
+					// This engine shares one token across all stacks, so give
+					// this stack its own lex mode before pausing it. See
+					// relexTokenForStackLexState (issue #454): the re-lex is
+					// span-exact, action-verified, and DFA-only, so the token
+					// loop stays in lockstep and the external scanner is never
+					// re-entered. Restored for the next stack at the top of the
+					// dispatch loop so the shared token never leaks sideways.
+					if reTok, ok := p.relexTokenForStackLexState(source, currentState, tok); ok {
+						if p.glrTrace {
+							fmt.Printf("  stack[%d] C-STACK-RELEX: sym=%d -> sym=%d [%d-%d] in state=%d\n",
+								si, tok.Symbol, reTok.Symbol, reTok.StartByte, reTok.EndByte, currentState)
+						}
+						stackRelexRestoreTok = tok
+						stackRelexActive = true
+						tok = reTok
+						if actionTiming != nil {
+							ns := recordNoActionTiming()
+							actionTiming.actionNoActionRelexNanos += ns
+						}
+						goto retryAction
+					}
 					// Faithful C recovery port: no action for the lookahead —
 					// pause the version (C detect_error / ts_stack_pause) and
 					// let the post-pass condense step resume or remove it.
@@ -6168,6 +6203,13 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					}
 				}
 			}
+		}
+		// The last stack in the loop may have dispatched on its own re-lexed
+		// tokenization; restore the shared lookahead before anything after the
+		// dispatch loop reads it.
+		if stackRelexActive {
+			tok = stackRelexRestoreTok
+			stackRelexActive = false
 		}
 		if phaseTiming {
 			actionDispatchNanos += time.Since(dispatchStart).Nanoseconds()

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -4504,3 +4504,97 @@ func (p *Parser) newRecoveryParentNodeInArena(arena *nodeArena, sym Symbol, name
 	}
 	return newParentNodeInArena(arena, sym, named, children, nil, productionID)
 }
+
+// relexTokenForStackLexState re-lexes the current lookahead using one GLR
+// stack's own lex mode.
+//
+// Background (issue #454 Scala investigation). tree-sitter C lexes once per
+// parse version, so two versions sitting in different states can legitimately
+// receive different tokenizations of the same bytes. This engine lexes once for
+// all stacks (see updateParserStateTokenSource), which is cheaper and correct
+// whenever every live stack accepts the shared token. It starves a stack when
+// the same bytes must lex as a different symbol in that stack's state.
+//
+// Scala is the witness. In `if (a) c + 2` the correct derivation reduces `(a)`
+// to _if_condition and then needs `+` as the grammar's generic
+// operator_identifier. The rival derivation, which treats `(a)` as a plain
+// expression, needs the dedicated `+` token that exists so prefix_expression
+// can spell unary plus. The shared lexer emits the dedicated `+`, the correct
+// stack finds no action for it, pauses, and the condense step drops it because
+// the rival is still unpaused. The rival then dead-ends and the whole file
+// becomes one ERROR. The C oracle parses the same input cleanly.
+//
+// This is not Scala-specific. Any grammar where one byte sequence lexes as
+// different symbols depending on parse state has the same exposure: `+ - ! ~`
+// as unary or binary, `/` as divide or regex start, `<` as comparison or type
+// bracket.
+//
+// The re-lex is deliberately narrow, so it cannot disturb the lockstep token
+// loop the rest of the engine relies on:
+//
+//   - It only runs where the stack would otherwise pause with no action, so a
+//     parse in which every stack accepts the shared token pays nothing.
+//   - It requires the re-lexed token to cover exactly the shared token's byte
+//     span. Same span means a stack that adopts it advances to the same offset
+//     as every stack that took the shared token, so the versions stay in
+//     lockstep and no caller has to reason about a ragged frontier.
+//   - It requires the stack's state to have a real action for the re-lexed
+//     symbol, so a failed probe leaves the existing pause path untouched.
+//   - It runs the internal DFA only. The external scanner is never re-entered,
+//     so no scanner state is mutated or needs restoring.
+func (p *Parser) relexTokenForStackLexState(source []byte, state StateID, tok Token) (Token, bool) {
+	lang := p.language
+	if lang == nil || len(lang.LexStates) == 0 || int(state) >= len(lang.LexModes) {
+		return tok, false
+	}
+	// Zero-width, missing, error-run and EOF lookaheads have no alternative
+	// tokenization to find; they are handled by the paths above the pause.
+	if tok.Symbol == 0 || tok.Symbol == errorSymbol || tok.Missing || tok.NoLookahead {
+		return tok, false
+	}
+	if tok.StartByte >= tok.EndByte || int(tok.StartByte) >= len(source) {
+		return tok, false
+	}
+	ls := lang.LexModes[state].LexStateIndex()
+	if ls == noLookaheadLexState || int(ls) >= len(lang.LexStates) {
+		return tok, false
+	}
+	probe := Lexer{
+		states:          lang.LexStates,
+		asciiTable:      lang.LexAsciiTable(),
+		source:          source,
+		pos:             int(tok.StartByte),
+		row:             tok.StartPoint.Row,
+		col:             tok.StartPoint.Column,
+		immediateTokens: lang.ImmediateTokens,
+		zeroWidthTokens: lang.ZeroWidthTokens,
+	}
+	relexed, ok := probe.scan(uint32(ls), probe.pos, probe.row, probe.col)
+	if !ok || relexed.Symbol == 0 || relexed.Symbol == tok.Symbol {
+		return tok, false
+	}
+	// Exact-span requirement: this is what keeps the shared-token loop in
+	// lockstep. A shorter or longer re-lex would leave this stack at a
+	// different byte offset than its siblings.
+	if relexed.StartByte != tok.StartByte || relexed.EndByte != tok.EndByte {
+		return tok, false
+	}
+	if !p.stateHasActionForSymbol(state, relexed.Symbol) {
+		return tok, false
+	}
+	return relexed, true
+}
+
+// stateHasActionForSymbol reports whether state carries at least one real parse
+// action for sym. It mirrors the action-lookup guard in the dispatch loop.
+func (p *Parser) stateHasActionForSymbol(state StateID, sym Symbol) bool {
+	if p.language == nil {
+		return false
+	}
+	parseActions := p.language.ParseActions
+	idx := p.lookupActionIndex(state, sym)
+	if idx == 0 || int(idx) >= len(parseActions) {
+		return false
+	}
+	return len(parseActions[idx].Actions) > 0
+}

--- a/parser_result_test/parser_result_state_dependent_relex_test.go
+++ b/parser_result_test/parser_result_state_dependent_relex_test.go
@@ -1,0 +1,108 @@
+package parserresult_test
+
+import (
+	"testing"
+)
+
+// TestStateDependentRelexKeepsCorrectDerivationAlive is the regression witness
+// for the shared-lookahead starvation found while investigating issue #454.
+//
+// tree-sitter C lexes once per parse version, so two versions in different
+// states can receive different tokenizations of the same bytes. This engine
+// lexes once for every stack. Where one stack's state requires a different
+// symbol for the same bytes, that stack used to find no action, pause, and get
+// dropped by the condense step while an unpaused rival survived — and the rival
+// then dead-ended, turning the whole file into one ERROR.
+//
+// Scala is the sharpest witness because `+ - ! ~` are its only prefix
+// operators. In `if (a) c + 2` the correct derivation reduces `(a)` to
+// _if_condition and needs `+` as the generic operator_identifier, while the
+// rival derivation needs the dedicated `+` token that exists so that
+// prefix_expression can spell unary plus. The shared lexer emitted the
+// dedicated token and starved the correct derivation.
+//
+// The control cases matter as much as the failures: `*` and `/` are not prefix
+// operators, a literal left operand cannot be an infix operator name, and a
+// braced body removes the ambiguity entirely. Those parsed correctly before the
+// fix and must keep doing so.
+func TestStateDependentRelexKeepsCorrectDerivationAlive(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		// Regressions: unbraced control body, bare-identifier left operand,
+		// operator that can also be prefix. Every one of these returned a
+		// whole-file ERROR before the per-stack re-lex.
+		{"if_then_plus", "object O { val x = if (a) c + 2 }"},
+		{"if_then_else_plus", "object O { val x = if (a) c + 2 else d }"},
+		{"if_then_else_minus", "object O { val x = if (a) c - 2 else d }"},
+		{"if_then_bang", "object O { val x = if (a) c ! 2 }"},
+		{"if_then_tilde", "object O { val x = if (a) c ~ 2 }"},
+		{"if_then_plus_identifier_rhs", "object O { val x = if (a) c + d }"},
+		{"if_then_plus_no_space", "object O { val x = if (a) c+2 }"},
+		// Not if-specific: any unbraced control body has the same exposure.
+		{"while_body_plus", "object O { def f = while (a) c + 2 }"},
+
+		// Controls that already worked and must not regress.
+		{"if_then_star", "object O { val x = if (a) c * 2 else d }"},
+		{"if_then_slash", "object O { val x = if (a) c / 2 }"},
+		{"if_then_literal_left", "object O { val x = if (a) 1 + 2 }"},
+		{"if_then_field_left", "object O { val x = if (a) c.f + 2 }"},
+		{"braced_body_plus", "object O { val x = if (a) { c + 2 } else d }"},
+		{"plain_infix_no_if", "object O { val x = c + 2 }"},
+		{"parenthesized_if_then_plus", "object O { val x = (if (a) c) + 2 }"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, lang := parseByLanguageName(t, "scala", tc.src)
+			root := tree.RootNode()
+			if got, want := root.Type(lang), "compilation_unit"; got != want {
+				t.Fatalf("root type = %q, want %q: %s", got, want, root.SExpr(lang))
+			}
+			if root.HasError() {
+				t.Fatalf("parse of %q produced an error tree: %s", tc.src, root.SExpr(lang))
+			}
+			if got, want := root.EndByte(), uint32(len(tc.src)); got != want {
+				t.Fatalf("root endByte = %d, want %d (%s)", got, want, root.SExpr(lang))
+			}
+		})
+	}
+}
+
+// TestStateDependentRelexProducesOperatorIdentifier pins the shape, not just
+// the absence of an error. The C oracle lexes `+` here as the grammar's generic
+// operator_identifier — the same token it uses for `*` — and the Go tree must
+// agree, otherwise we could satisfy the error check above with some other
+// derivation that merely happens to avoid ERROR.
+func TestStateDependentRelexProducesOperatorIdentifier(t *testing.T) {
+	plusTree, lang := parseByLanguageName(t, "scala", "object O { val x = if (a) c + 2 }")
+	starTree, _ := parseByLanguageName(t, "scala", "object O { val x = if (a) c * 2 }")
+
+	plus := plusTree.RootNode().SExpr(lang)
+	star := starTree.RootNode().SExpr(lang)
+	if plus != star {
+		t.Fatalf("additive and multiplicative bodies must share one shape.\n  plus: %s\n  star: %s", plus, star)
+	}
+	for _, want := range []string{"if_expression", "infix_expression", "operator_identifier"} {
+		if !containsSubstring(plus, want) {
+			t.Fatalf("expected %q in parse shape: %s", want, plus)
+		}
+	}
+	if containsSubstring(plus, "prefix_expression") {
+		t.Fatalf("`+` was lexed as a prefix operator rather than an infix operator_identifier: %s", plus)
+	}
+}
+
+func containsSubstring(haystack, needle string) bool {
+	return len(needle) == 0 || len(haystack) >= len(needle) && indexOfSubstring(haystack, needle) >= 0
+}
+
+func indexOfSubstring(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

A shared lookahead starved a correct derivation when another stack accepted the same symbol. This patch adds a per-stack re-lex probe that replaces the shared token with one matching the stack's lex mode. The probe verifies the byte span and checks for a valid parse action. It runs the internal DFA only and never re-enters external scanners.

## Changes

- Add `relexTokenForStackLexState` to re-lex the current lookahead using a stack's lex mode. The probe runs only when a stack would otherwise pause.
- Add `stateHasActionForSymbol` helper to check for a valid parse action in the stack state.
- Manage shared lookahead restoration in the stack dispatch loop. New flags prevent token leakage between stacks.
- Insert the re-lex probe in the no-action path. The stack advances when the re-lexed token spans the exact bytes and unlocks a valid action.
- Add regression test `TestStateDependentRelexKeepsCorrectDerivationAlive`. It covers Scala expressions where operators act as prefixes. It also covers control cases that must not regress.

## Testing

- Run the new regression test: `go test ./parser_result_test -run 'TestStateDependentRelex'`
- Verify Scala parity in Docker: `bash cgo_harness/docker/run_single_grammar_parity.sh scala`
- Run the standard performance loop: `GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms`

## Review Focus

Focus on the re-lex probe logic in `parser_recover_c.go` and the restoration guards in `parser.go` to verify lockstep safety.