### PR TITLE
fix(parser): Fix no-live-action re-lex for all grammars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The no-live-action re-lex no longer checks the grammar's name. This recovery
+  step re-lexes the lookahead when no live stack has any parse action for it,
+  and it was gated to JavaScript. The condition it guards is grammar
+  independent: `noLiveStackCanAcceptLookahead` already proves that no live stack
+  can consume the token, so re-lexing cannot take a token another version was
+  going to use, whatever the grammar. Every grammar now gets the same recovery
+  step. This retires one per-language gate from the parser core.
+
 - Large GLR parses allocate far less. Two hot-path buffers grew without
   amortization or reuse:
 

--- a/parser.go
+++ b/parser.go
@@ -5577,7 +5577,12 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 					return ns
 				}
 				sameState := parseStacksShareState(stacks, currentState)
-				canRelexNoLiveAction := !sameState && p.language != nil && p.language.Name == "javascript" && p.noLiveStackCanAcceptLookahead(stacks, tok)
+				// Retirement of a per-language patch: this relex was gated to
+				// javascript by name, but the condition it guards is grammar
+				// independent. noLiveStackCanAcceptLookahead already proves no live
+				// stack has an action for the lookahead, so re-lexing cannot steal a
+				// token another version was going to consume, whatever the grammar.
+				canRelexNoLiveAction := !sameState && p.language != nil && p.noLiveStackCanAcceptLookahead(stacks, tok)
 				if tok.Symbol == errorSymbol && tok.StartByte != tok.EndByte && p.errorCostCompetitionEnabled() {
 					// Faithful C recovery port: an unlexable-run lookahead has
 					// no table actions in C either; the version pauses and the


### PR DESCRIPTION
## Summary

This PR enables the no-live-action re-lex recovery step for all grammars. The previous code gated this step on JavaScript. The condition `noLiveStackCanAcceptLookahead` proves that no live stack can consume the lookahead token. Therefore, the re-lex is safe for any grammar.

## Changes

- Remove the `p.language.Name == "javascript"` check from the `canRelexNoLiveAction` condition in `parser.go`.
- Update `CHANGELOG.md` to document this grammar-independent recovery step.
- Add a comment explaining why the per-language gate is unnecessary.

## Testing

- `GOMAXPROCS=1 go test . -run '^$' -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' -benchmem -count=10 -benchtime=750ms`
- Run `bash cgo_harness/docker/run_single_grammar_parity.sh <grammar>` for TypeScript and Go to confirm correctness parity.