### PR TITLE
fix(glr,phase0): close Step 0 safety and finalization defects

### DIFF
--- a/benchmark_warm_reuse_test.go
+++ b/benchmark_warm_reuse_test.go
@@ -1,8 +1,10 @@
 package gotreesitter_test
 
 import (
+	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -107,6 +109,15 @@ func BenchmarkSelfParseWarmReuse(b *testing.B) {
 //
 // This test is intentionally strict: 30 MB is well above the expected ~12 MB
 // but far below the ~545 MB that stale node-pointer retention can cause.
+//
+// NOT COVERAGE FOR THE GSS FALLBACK POOLS. This test parses parser_test.go, a
+// conflict-free Go file, so the parse never forks and never calls
+// gssNodeCanReach or gssNodeHash at all (0.0% coverage of both, verified with
+// -covermode=count). It was previously miscited as justification for the
+// gssCanReachVisitedPool / gssNodeHashPendingPool clearing fix (glr.go,
+// glr_gss.go); it is not. TestGSSNodeCanReachPooledFallbackRealCSharpMergeHeavyAmbiguity
+// and TestGSSNodeHashPooledFallbackRealPHPTransientErrorChain below are the
+// tests that actually exercise those two pooled fallback paths.
 func TestArenaGCRetentionAfterRelease(t *testing.T) {
 	gotreesitter.DrainArenaPools()
 	t.Cleanup(gotreesitter.DrainArenaPools)
@@ -138,6 +149,133 @@ func TestArenaGCRetentionAfterRelease(t *testing.T) {
 			"Hint: arena slab backing arrays may not be fully cleared on reset,\n"+
 			"leaving stale *Node pointers that prevent GC collection.",
 			ms.HeapAlloc/1024/1024, maxRetainedBytes/1024/1024)
+	}
+}
+
+// csharpNestedGenericMethodCallAmbiguitySource builds a C# expression that
+// nests `f(a<b,c>(...))`-shaped calls depth levels deep. Each `identifier <`
+// is ambiguous in C# between a less-than comparison and the start of a
+// generic type-argument list; the parser cannot tell which until it sees
+// whether a matching `>` is followed by `(`. Nesting these keeps multiple GLR
+// interpretations alive simultaneously instead of resolving one token later,
+// which is what makes this construct "merge-heavy" rather than an ordinary,
+// quickly-resolved local ambiguity.
+func csharpNestedGenericMethodCallAmbiguitySource(depth int) []byte {
+	var open, closeParens strings.Builder
+	for i := 0; i < depth; i++ {
+		fmt.Fprintf(&open, "f%d(a%d<b%d,c%d>(", i, i, i, i)
+		closeParens.WriteString("))")
+	}
+	return []byte("class C { void M() {\n" + open.String() + "x" + closeParens.String() + ";\n} }\n")
+}
+
+// TestGSSNodeCanReachPooledFallbackRealCSharpMergeHeavyAmbiguity proves that a
+// real parse -- not a synthetic direct call -- drives gssNodeCanReach
+// (glr.go) into its pooled fallback map. gssCanReachVisitedPool's own doc
+// comment records the original motivation: "profiling a 137 KiB C# corpus
+// attributed 3.47 GB of 4.36 GB total allocation to this one make" on a
+// merge-heavy grammar. This test is a small, fast, self-contained
+// reproduction of that same class of trigger.
+//
+// Measured with `go test -run TestGSSNodeCanReachPooledFallbackRealCSharpMergeHeavyAmbiguity
+// -covermode=count -coverprofile=...` then `go tool cover -func`: gssNodeCanReach
+// reaches 87.8% statement coverage, and line-level inspection of the profile
+// shows glr.go:3382 (the "promote visited set to the pooled map" branch) and
+// glr.go:3401-3404 (the "clear and return the map to the pool" branch) each
+// hit 12 times by this test alone. Depth 20 has margin: depths from 10 to 30
+// all reproduced a nonzero hit count in the same sweep.
+func TestGSSNodeCanReachPooledFallbackRealCSharpMergeHeavyAmbiguity(t *testing.T) {
+	lang := grammars.CSharpLanguage()
+	src := csharpNestedGenericMethodCallAmbiguitySource(20)
+
+	profile := gotreesitter.NewAmbiguityProfile()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAmbiguityProfile(profile)
+	parser.SetTimeoutMicros(20_000_000)
+
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	var totalForks uint64
+	for _, st := range profile.SnapshotTop(64) {
+		totalForks += st.Forks
+	}
+	// A liveness check, not a vacuous receipt: if a future change stopped this
+	// construct from forking at all, gssNodeCanReach would go back to 0%
+	// coverage here exactly as it silently did for TestArenaGCRetentionAfterRelease.
+	if totalForks == 0 {
+		t.Fatal("nested generic-call C# source produced no GLR forks; this test no longer exercises gssNodeCanReach's merge path")
+	}
+	rt := tree.ParseRuntime()
+	if rt.MaxStacksSeen < 2 {
+		t.Fatalf("MaxStacksSeen = %d, want >= 2 (construct must actually fork to exercise gssNodesCanMerge)", rt.MaxStacksSeen)
+	}
+	if tree.RootNode().HasError() {
+		t.Fatalf("nested generic-call ambiguity failed to resolve cleanly: %s", rt.Summary())
+	}
+}
+
+// phpTransientVariableErrorSource builds a PHP function body with n sequential
+// `$xI = I;` assignments, except at index breakAt, where the variable name's
+// leading letter is dropped ("$0" instead of "$x0"). "$0" is not a valid PHP
+// variable token, so this is a transient syntax error surrounded by hundreds
+// of otherwise-clean statements -- the shape of a single mistyped or
+// in-flight-edited character, not a structurally broken file.
+func phpTransientVariableErrorSource(n, breakAt int) []byte {
+	var b strings.Builder
+	b.WriteString("<?php\nfunction f() {\n")
+	for i := 0; i < n; i++ {
+		if i == breakAt {
+			fmt.Fprintf(&b, "$%d = %d;\n", i, i)
+		} else {
+			fmt.Fprintf(&b, "$x%d = %d;\n", i, i)
+		}
+	}
+	b.WriteString("}\n")
+	return []byte(b.String())
+}
+
+// TestGSSNodeHashPooledFallbackRealPHPTransientErrorChain proves that a real
+// parse drives gssNodeHash (glr_gss.go) into its pooled walk buffer.
+// gssNodeHashPendingPool's own doc comment records the original motivation:
+// "Profiling a PHP transient-error edit attributed 124 MB of allocation to
+// this one walk." This test is a small, fast, self-contained reproduction of
+// that same class of trigger: the invalid "$0" token forces error-recovery
+// GSS chains deep enough to blow past the 32-entry inline array gssNodeHash
+// normally uses.
+//
+// Measured with `go test -run TestGSSNodeHashPooledFallbackRealPHPTransientErrorChain
+// -covermode=count -coverprofile=...` then `go tool cover -func`: gssNodeHash
+// reaches 93.8% statement coverage run alone, and line-level inspection of the
+// profile shows glr_gss.go:394-401 (the "chain outgrew the inline array, move
+// to the pooled buffer" branch) and glr_gss.go:424-429 (the "clear and return
+// the buffer to the pool" branch) each hit 725 times by this test alone.
+func TestGSSNodeHashPooledFallbackRealPHPTransientErrorChain(t *testing.T) {
+	lang := grammars.PhpLanguage()
+	src := phpTransientVariableErrorSource(200, 100)
+
+	parser := gotreesitter.NewParser(lang)
+	parser.SetTimeoutMicros(10_000_000)
+
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+
+	rt := tree.ParseRuntime()
+	// Liveness check: the deliberately-invalid "$0" token must still be
+	// reachable as a genuine parse error, and the recovery search around it
+	// must actually fork, or this test stops exercising gssNodeHash's pooled
+	// walk and would silently regress to a vacuous receipt.
+	if !tree.RootNode().HasError() {
+		t.Fatal("expected the invalid \"$0\" token to produce a parse error")
+	}
+	if rt.MaxStacksSeen < 2 {
+		t.Fatalf("MaxStacksSeen = %d, want >= 2 (error recovery must fork to build the deep GSS chains gssNodeHash walks)", rt.MaxStacksSeen)
 	}
 }
 

--- a/glr.go
+++ b/glr.go
@@ -7,8 +7,20 @@ import (
 	"unsafe"
 )
 
+// maxPooledGSSVisitedEntries bounds what gssCanReachVisitedPool will retain.
+// A pathological parse can grow the fallback set to millions of entries; handing
+// that back to the pool would keep the whole allocation alive across GC cycles
+// for the rest of the process.
+const maxPooledGSSVisitedEntries = 1 << 16
+
 // gssCanReachVisitedPool recycles the fallback visited set used by
 // gssNodeCanReach when a link graph outgrows its 64-entry local array.
+//
+// CLEARING CONTRACT: the map keys are *gssNode. A pooled map is reachable from
+// the pool for at least one GC cycle, so returning it populated would keep every
+// node it references alive and defeat collection of the whole GSS graph long
+// after the parse that built it is gone. Entries are therefore released before
+// the map goes back, and oversized maps are dropped instead of pooled.
 //
 // The map used to be allocated per call. That is fine when the fallback is
 // rare, which is what the original comment assumed, but on grammars whose GSS
@@ -3369,7 +3381,6 @@ func gssNodeCanReach(from, target *gssNode) bool {
 		}
 		if len(visited) == cap(visited) && len(visited) >= len(visitedLocal) {
 			visitedMap = gssCanReachVisitedPool.Get().(map[*gssNode]bool)
-			clear(visitedMap)
 			for _, v := range visited {
 				visitedMap[v] = true
 			}
@@ -3382,10 +3393,16 @@ func gssNodeCanReach(from, target *gssNode) bool {
 	// after markVisited may have promoted to the map; the fast path that never
 	// promotes leaves visitedMap nil and does no pool work at all.
 	releaseVisited := func() {
-		if visitedMap != nil {
-			gssCanReachVisitedPool.Put(visitedMap)
-			visitedMap = nil
+		if visitedMap == nil {
+			return
 		}
+		// Drop rather than pool a map that grew pathologically large; pooling it
+		// would retain its whole bucket array process-wide.
+		if len(visitedMap) <= maxPooledGSSVisitedEntries {
+			clear(visitedMap)
+			gssCanReachVisitedPool.Put(visitedMap)
+		}
+		visitedMap = nil
 	}
 	stack = append(stack, from)
 	for len(stack) > 0 {

--- a/glr.go
+++ b/glr.go
@@ -33,6 +33,16 @@ var gssCanReachVisitedPool = sync.Pool{
 	New: func() any { return make(map[*gssNode]bool, 256) },
 }
 
+// resetGSSCanReachVisitedMapForPool removes node references before pool release.
+// It reports false when the map should be dropped instead.
+func resetGSSCanReachVisitedMapForPool(visited map[*gssNode]bool) bool {
+	if visited == nil || len(visited) > maxPooledGSSVisitedEntries {
+		return false
+	}
+	clear(visited)
+	return true
+}
+
 // glrStack is one version of the parse stack in a GLR parser.
 // When the parse table has multiple actions for a (state, symbol) pair,
 // the parser forks: one glrStack per alternative. Stacks that hit errors
@@ -3398,8 +3408,7 @@ func gssNodeCanReach(from, target *gssNode) bool {
 		}
 		// Drop rather than pool a map that grew pathologically large; pooling it
 		// would retain its whole bucket array process-wide.
-		if len(visitedMap) <= maxPooledGSSVisitedEntries {
-			clear(visitedMap)
+		if resetGSSCanReachVisitedMapForPool(visitedMap) {
 			gssCanReachVisitedPool.Put(visitedMap)
 		}
 		visitedMap = nil

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -6,8 +6,18 @@ import (
 	"unsafe"
 )
 
+// maxPooledGSSHashWalkCap bounds what gssNodeHashPendingPool will retain, so a
+// single very deep chain cannot park a huge backing array in the pool for the
+// rest of the process.
+const maxPooledGSSHashWalkCap = 1 << 16
+
 // gssNodeHashPendingPool recycles the walk buffer gssNodeHash uses when an
 // unhashed chain is longer than its 32-entry inline array.
+//
+// CLEARING CONTRACT: the buffer holds *gssNode pointers. A pooled slice stays
+// reachable from the pool for at least one GC cycle, so returning it with live
+// pointers still in its backing array would keep those nodes, and everything
+// they reach, uncollectable. The contents are cleared before it goes back.
 //
 // The buffer used to grow on the heap from scratch on every such call. A chain
 // only needs hashing until it reaches an already-hashed node, so this is cheap
@@ -109,7 +119,7 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 		n.extraLinkCount++
 		workCountRecordGraphLinkAddition()
 		workCountRecordAlternatePredecessorLinkAppended() // work-count-assembly: alternate predecessor append-reuse seam
-		workCountRecordGSSMutation() // work-count-assembly: GSS mutation append-reuse seam
+		workCountRecordGSSMutation()                      // work-count-assembly: GSS mutation append-reuse seam
 		return
 	}
 	newCapacity := 1
@@ -129,7 +139,7 @@ func (n *gssNode) appendExtraLink(link gssMainLink) {
 	n.extraLinkCap = uint8(newCapacity)
 	workCountRecordGraphLinkAddition()
 	workCountRecordAlternatePredecessorLinkAppended() // work-count-assembly: alternate predecessor append-grow seam
-	workCountRecordGSSMutation() // work-count-assembly: GSS mutation append-grow seam
+	workCountRecordGSSMutation()                      // work-count-assembly: GSS mutation append-grow seam
 }
 
 // gssStack is a shared-prefix stack foundation for future GLR work.
@@ -412,7 +422,11 @@ func gssNodeHash(n *gssNode) uint64 {
 	// Released explicitly rather than with defer: this is a hot path and the
 	// function has a single exit once the walk buffer exists.
 	if pooled != nil {
-		gssNodeHashPendingPool.Put(pooled)
+		if cap(*pooled) <= maxPooledGSSHashWalkCap {
+			clear(*pooled)
+			*pooled = (*pooled)[:0]
+			gssNodeHashPendingPool.Put(pooled)
+		}
 	}
 	return n.hash
 }

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -31,6 +31,17 @@ var gssNodeHashPendingPool = sync.Pool{
 	},
 }
 
+// resetGSSNodeHashPendingForPool removes node references before pool release.
+// It reports false when the buffer should be dropped instead.
+func resetGSSNodeHashPendingForPool(pending *[]*gssNode) bool {
+	if pending == nil || cap(*pending) > maxPooledGSSHashWalkCap {
+		return false
+	}
+	clear(*pending)
+	*pending = (*pending)[:0]
+	return true
+}
+
 const (
 	defaultGSSNodeSlabCap      = 4 * 1024
 	fullParseGSSNodeSlabCap    = 32 * 1024
@@ -422,9 +433,7 @@ func gssNodeHash(n *gssNode) uint64 {
 	// Released explicitly rather than with defer: this is a hot path and the
 	// function has a single exit once the walk buffer exists.
 	if pooled != nil {
-		if cap(*pooled) <= maxPooledGSSHashWalkCap {
-			clear(*pooled)
-			*pooled = (*pooled)[:0]
+		if resetGSSNodeHashPendingForPool(pooled) {
 			gssNodeHashPendingPool.Put(pooled)
 		}
 	}

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -149,39 +149,26 @@ func TestGSSNodeHashComputedLazilyForSingleStackNodes(t *testing.T) {
 	}
 }
 
-// TestGSSNodeHashPooledWalkBufferClearedBeforeReturningToPool proves the
-// gssNodeHashPendingPool clearing contract (glr_gss.go, above the pool
-// declaration): a walk buffer handed back to the pool must not carry live
-// *gssNode entries from the call that just released it. Before the fix,
-// gssNodeHash's pooled acquire/release pair mirrored the same acquire-time
-// clearing bug as gssCanReachVisitedPool: pooling a buffer with entries still
-// in its backing array keeps those nodes, and everything they reach,
-// uncollectable for at least one more GC cycle.
-//
-// singleStackMode keeps allocNode's hash lazy (every pushed node starts with
-// hash == 0), so gssNodeHash must actually walk the chain rather than finding
-// an already-hashed node immediately. A 64-deep chain forces gssNodeHash past
-// its 32-entry inline array on both the acquire and the release side.
-func TestGSSNodeHashPooledWalkBufferClearedBeforeReturningToPool(t *testing.T) {
-	var scratch gssScratch
-	scratch.singleStackMode = true
-	var s gssStack
-	const chainDepth = 64 // > gssNodeHash's 32-entry inline walk array.
-	for i := 0; i < chainDepth; i++ {
-		s.push(StateID(i+1), nil, &scratch)
+// TestResetGSSNodeHashPendingForPoolClearsExactBacking proves the slice
+// clearing contract without depending on sync.Pool to return a specific item.
+func TestResetGSSNodeHashPendingForPoolClearsExactBacking(t *testing.T) {
+	const used = 64
+	backing := make([]*gssNode, 96)
+	for i := 0; i < used; i++ {
+		backing[i] = &gssNode{depth: uint32(i + 1)}
 	}
-	if s.head.hash != 0 {
-		t.Fatal("head hash must start at 0 (lazy) for this test to force the pooled walk")
-	}
+	pending := backing[:used]
 
-	if got := gssNodeHash(s.head); got == 0 {
-		t.Fatal("gssNodeHash returned 0 for a real chain")
+	if !resetGSSNodeHashPendingForPool(&pending) {
+		t.Fatal("ordinary hash walk buffer was rejected from the pool")
 	}
-
-	pooled := gssNodeHashPendingPool.Get().(*[]*gssNode)
-	defer gssNodeHashPendingPool.Put(pooled)
-	if got := len(*pooled); got != 0 {
-		t.Fatalf("pooled hash walk buffer returned from Get() with %d stale entr(y/ies), want 0 (clearing contract violated)", got)
+	if len(pending) != 0 {
+		t.Fatalf("released hash walk length = %d, want 0", len(pending))
+	}
+	for i, node := range pending[:cap(pending)] {
+		if node != nil {
+			t.Fatalf("released hash walk backing slot %d retained a node pointer", i)
+		}
 	}
 }
 

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -149,6 +149,42 @@ func TestGSSNodeHashComputedLazilyForSingleStackNodes(t *testing.T) {
 	}
 }
 
+// TestGSSNodeHashPooledWalkBufferClearedBeforeReturningToPool proves the
+// gssNodeHashPendingPool clearing contract (glr_gss.go, above the pool
+// declaration): a walk buffer handed back to the pool must not carry live
+// *gssNode entries from the call that just released it. Before the fix,
+// gssNodeHash's pooled acquire/release pair mirrored the same acquire-time
+// clearing bug as gssCanReachVisitedPool: pooling a buffer with entries still
+// in its backing array keeps those nodes, and everything they reach,
+// uncollectable for at least one more GC cycle.
+//
+// singleStackMode keeps allocNode's hash lazy (every pushed node starts with
+// hash == 0), so gssNodeHash must actually walk the chain rather than finding
+// an already-hashed node immediately. A 64-deep chain forces gssNodeHash past
+// its 32-entry inline array on both the acquire and the release side.
+func TestGSSNodeHashPooledWalkBufferClearedBeforeReturningToPool(t *testing.T) {
+	var scratch gssScratch
+	scratch.singleStackMode = true
+	var s gssStack
+	const chainDepth = 64 // > gssNodeHash's 32-entry inline walk array.
+	for i := 0; i < chainDepth; i++ {
+		s.push(StateID(i+1), nil, &scratch)
+	}
+	if s.head.hash != 0 {
+		t.Fatal("head hash must start at 0 (lazy) for this test to force the pooled walk")
+	}
+
+	if got := gssNodeHash(s.head); got == 0 {
+		t.Fatal("gssNodeHash returned 0 for a real chain")
+	}
+
+	pooled := gssNodeHashPendingPool.Get().(*[]*gssNode)
+	defer gssNodeHashPendingPool.Put(pooled)
+	if got := len(*pooled); got != 0 {
+		t.Fatalf("pooled hash walk buffer returned from Get() with %d stale entr(y/ies), want 0 (clearing contract violated)", got)
+	}
+}
+
 func TestGSSEntryHashMatchesAccessorSemantics(t *testing.T) {
 	node := &Node{
 		children:      []*Node{{symbol: 20, startByte: 1, endByte: 2, preGotoState: 8, fieldMetadata: &nodeFieldMetadata{ids: []FieldID{3}}, flags: nodeFlagNamed}},

--- a/glr_test.go
+++ b/glr_test.go
@@ -3929,37 +3929,19 @@ func TestGSSNodesCanMergeRejectsZeroWidthAncestorDescendantPackedMerge(t *testin
 	}
 }
 
-// TestGSSNodeCanReachPooledVisitedMapClearedBeforeReturningToPool proves the
-// gssCanReachVisitedPool clearing contract (glr.go, above the pool
-// declaration): a map handed back to the pool must not carry live *gssNode
-// entries from the call that just released it. Before the fix, clearing
-// happened on ACQUIRE (right after Get()) rather than on release, so a map
-// went back to the pool still populated -- keeping every node it referenced,
-// and everything each one transitively reached, reachable from the pool for
-// at least one more GC cycle after the parse that built them was gone.
-//
-// The chain built here is a straight line with no branching, so
-// gssNodeCanReach's DFS from the tail must visit every one of its 100
-// ancestors before it can conclude the unrelated node is unreachable --
-// well past the 64-entry inline array, which forces the pooled fallback map
-// on both the acquire and the release side.
-func TestGSSNodeCanReachPooledVisitedMapClearedBeforeReturningToPool(t *testing.T) {
-	var scratch gssScratch
-	var prev *gssNode
-	const chainDepth = 100 // > gssNodeCanReach's 64-entry inline visited array.
-	for i := 0; i < chainDepth; i++ {
-		prev = scratch.allocNode(stackEntry{state: StateID(i + 1)}, prev, uint32(i+1))
-	}
-	unrelated := scratch.allocNode(stackEntry{state: 9999}, nil, 1)
-
-	if gssNodeCanReach(prev, unrelated) {
-		t.Fatal("gssNodeCanReach = true for a node on a disjoint chain")
+// TestResetGSSCanReachVisitedMapForPoolClearsExactMap proves the map clearing
+// contract without depending on sync.Pool to return a specific item.
+func TestResetGSSCanReachVisitedMapForPoolClearsExactMap(t *testing.T) {
+	visited := make(map[*gssNode]bool, 100)
+	for i := 0; i < 100; i++ {
+		visited[&gssNode{depth: uint32(i + 1)}] = true
 	}
 
-	got := gssCanReachVisitedPool.Get().(map[*gssNode]bool)
-	defer gssCanReachVisitedPool.Put(got)
-	if len(got) != 0 {
-		t.Fatalf("pooled visited map returned from Get() with %d stale entr(y/ies), want 0 (clearing contract violated)", len(got))
+	if !resetGSSCanReachVisitedMapForPool(visited) {
+		t.Fatal("ordinary visited map was rejected from the pool")
+	}
+	if len(visited) != 0 {
+		t.Fatalf("released visited map retained %d node pointer(s)", len(visited))
 	}
 }
 

--- a/glr_test.go
+++ b/glr_test.go
@@ -3929,6 +3929,40 @@ func TestGSSNodesCanMergeRejectsZeroWidthAncestorDescendantPackedMerge(t *testin
 	}
 }
 
+// TestGSSNodeCanReachPooledVisitedMapClearedBeforeReturningToPool proves the
+// gssCanReachVisitedPool clearing contract (glr.go, above the pool
+// declaration): a map handed back to the pool must not carry live *gssNode
+// entries from the call that just released it. Before the fix, clearing
+// happened on ACQUIRE (right after Get()) rather than on release, so a map
+// went back to the pool still populated -- keeping every node it referenced,
+// and everything each one transitively reached, reachable from the pool for
+// at least one more GC cycle after the parse that built them was gone.
+//
+// The chain built here is a straight line with no branching, so
+// gssNodeCanReach's DFS from the tail must visit every one of its 100
+// ancestors before it can conclude the unrelated node is unreachable --
+// well past the 64-entry inline array, which forces the pooled fallback map
+// on both the acquire and the release side.
+func TestGSSNodeCanReachPooledVisitedMapClearedBeforeReturningToPool(t *testing.T) {
+	var scratch gssScratch
+	var prev *gssNode
+	const chainDepth = 100 // > gssNodeCanReach's 64-entry inline visited array.
+	for i := 0; i < chainDepth; i++ {
+		prev = scratch.allocNode(stackEntry{state: StateID(i + 1)}, prev, uint32(i+1))
+	}
+	unrelated := scratch.allocNode(stackEntry{state: 9999}, nil, 1)
+
+	if gssNodeCanReach(prev, unrelated) {
+		t.Fatal("gssNodeCanReach = true for a node on a disjoint chain")
+	}
+
+	got := gssCanReachVisitedPool.Get().(map[*gssNode]bool)
+	defer gssCanReachVisitedPool.Put(got)
+	if len(got) != 0 {
+		t.Fatalf("pooled visited map returned from Get() with %d stale entr(y/ies), want 0 (clearing contract violated)", len(got))
+	}
+}
+
 func TestMergeStacksGeneralFaithfulGSSUnionPreservesMoreThanFourStacks(t *testing.T) {
 	old := glrFaithfulCapOneMerge
 	glrFaithfulCapOneMerge = true

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -3,6 +3,7 @@ package gotreesitter
 import (
 	"bytes"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -294,6 +295,85 @@ func TestParserKeepsTypeScriptCompatibilityLazyUntilFirstPublicTreeRead(t *testi
 	_ = tree.RootNode()
 	if got := tree.ParseRuntime().NormalizationPassesRun; got != first.NormalizationPassesRun {
 		t.Fatalf("deferred compatibility ran more than once: first=%d after=%d", first.NormalizationPassesRun, got)
+	}
+}
+
+// TestParseRuntimeNormalizationPassesSurvivesCompactPublicationForIni proves
+// the phase0 runtime-clobber fix in materializeDiagnosticParserCoreAcceptedSelection
+// (parsercore_phase0_driver.go). The compact/phase0 admission route's internal
+// sanity check used to call the PUBLIC tree.ParseRuntime() accessor as a
+// sanity check on the just-materialized tree. That accessor fires the tree's
+// one-shot deferred-compatibility finalizer (ensureResultCompatibility,
+// tree.go), which -- for a deferred-compat language -- writes the
+// normalization counters (NormalizationPasses and friends) into the runtime
+// record. A few lines later, setParseRuntime full-struct-replaced that same
+// record to install the final accepted stop reason, permanently erasing what
+// the finalizer had just written (the finalizer runs at most once). ini is a
+// deferred-compat language (shouldDeferResultCompatibility,
+// parser_result_root_build.go) that always defers, unconditionally, so it
+// needs no feature-flag gate to exercise this.
+//
+// Two preconditions, verified directly rather than assumed:
+//
+//  1. GOT_PARSE_PHASE_TIMING must be enabled for NormalizationPasses to be
+//     populated AT ALL -- ensureResultCompatibility only calls
+//     copyNormalizationStats on the phase-timing branch -- independent of
+//     this bug. Set here, matching
+//     TestDeferredResultCompatibilitySynchronizesConcurrentTreeReaders above.
+//  2. DEFAULT admission settings are sufficient to route this parse through
+//     the compact engine: no SetAdmissionCandidateRoute override is used
+//     below. Confirmed with AdmissionCandidateCounters that a fresh default
+//     Parser already reports routed=1, fallback=0 for this ~23-byte ini
+//     source, because the compact candidate route has been the process
+//     default since Phase-3 admission and this input is far under the 64 KiB
+//     production-memory-budget size-gate floor that would otherwise decline it.
+//
+// Reverting the fix (materializeDiagnosticParserCoreAcceptedSelection calling
+// tree.ParseRuntime() again instead of tree.rawParseRuntime()/rawParseStopReason())
+// reproduces the bug directly: NormalizationPasses goes back to nil below.
+func TestParseRuntimeNormalizationPassesSurvivesCompactPublicationForIni(t *testing.T) {
+	t.Setenv("GOT_PARSE_PHASE_TIMING", "1")
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+	resetAdmissionCandidateCounters()
+
+	blob, err := os.ReadFile("grammars/grammar_blobs/ini.bin")
+	if err != nil {
+		t.Skipf("ini grammar blob unavailable: %v", err)
+	}
+	lang, err := LoadLanguage(blob)
+	if err != nil {
+		t.Fatalf("load ini grammar: %v", err)
+	}
+
+	parser := NewParser(lang)
+	tree, err := parser.Parse([]byte("[section]\nkey = value\n"))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer tree.Release()
+
+	if routed, _ := AdmissionCandidateCounters(); routed == 0 {
+		// Mirrors TestAdmissionCandidateMemoryBudgetContractPreserved
+		// (admission_switch_test.go): in the emergency opt-out build
+		// (-tags gts_no_parsercorephase0) the compact engine is compiled out,
+		// so the routed counter cannot move and this test cannot exercise the
+		// route it claims to. Skip rather than fail in that configuration.
+		if reason := AdmissionCandidateLastFallbackReason(); strings.Contains(reason, "compiled out") {
+			t.Skip("compact candidate route compiled out (-tags gts_no_parsercorephase0); cannot exercise the phase0 route")
+		}
+		t.Fatalf("default admission settings did not route this small, clean ini source through the compact engine; routed=%d", routed)
+	}
+	if !tree.compactMaterialized {
+		t.Fatal("expected the compact/phase0 route to have materialized this tree")
+	}
+
+	rt := tree.ParseRuntime()
+	if rt.StopReason != ParseStopAccepted {
+		t.Fatalf("StopReason = %s, want %s (%s)", rt.StopReason, ParseStopAccepted, rt.Summary())
+	}
+	if rt.NormalizationPasses == nil || len(*rt.NormalizationPasses) == 0 {
+		t.Fatal("NormalizationPasses is nil/empty after a real Parse() through the compact route: the phase0 runtime-clobber regressed")
 	}
 }
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2089,8 +2089,20 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	if tree == nil || tree.root == nil {
 		return rejectTree(errors.New("parser-core phase zero: accepted compact derivation materialized no root"))
 	}
-	if runtime := tree.ParseRuntime(); runtime.StopReason != ParseStopNone || runtime.Truncated || runtime.TokenSourceEOFEarly {
-		return rejectTree(fmt.Errorf("parser-core phase zero: accepted-tree materialization returned an incomplete runtime: %s", runtime.Summary()))
+	// Use the raw (parser-owned) runtime record for this internal sanity check
+	// instead of the public ParseRuntime() accessor. ParseRuntime() fires the
+	// tree's one-shot deferred-compatibility finalizer (ensureResultCompatibility,
+	// which runs for deferred-compat languages such as typescript/tsx/ini via
+	// shouldDeferResultCompatibility). Firing it here would be premature: a few
+	// lines below, setParseRuntime full-struct-replaces the runtime record, which
+	// would permanently erase the normalization counters the finalizer just wrote
+	// (NormalizationPasses and friends), since the finalizer only ever runs once.
+	// rawParseRuntime does not normalize StopReason the way the public accessor
+	// does, so compare with rawParseStopReason, which treats an empty raw
+	// StopReason the same as ParseStopNone.
+	rawRuntime := tree.rawParseRuntime()
+	if reason := tree.rawParseStopReason(); reason != ParseStopNone || rawRuntime.Truncated || rawRuntime.TokenSourceEOFEarly {
+		return rejectTree(fmt.Errorf("parser-core phase zero: accepted-tree materialization returned an incomplete runtime: %s", rawRuntime.Summary()))
 	}
 	if err := poll(); err != nil {
 		return rejectTree(err)


### PR DESCRIPTION
Closes Step 0 of `plan.parser-lever-sequence-2026-07`.

## Two defects

**1. Pooled GSS containers were returned populated.** `gssCanReachVisitedPool` and `gssNodeHashPendingPool` both hold `*gssNode` pointers. A pooled object stays reachable from the pool for at least one GC cycle, so each returned object kept the whole GSS graph of a finished parse alive. Now cleared on release rather than on acquire, with oversized objects dropped instead of pooled.

**2. The compact admission route erased deferred normalization stats.** `materializeDiagnosticParserCoreAcceptedSelection` called the public `ParseRuntime()` as an internal sanity check — firing the tree's one-shot deferred-compatibility finalizer — then `setParseRuntime` full-struct-replaced the record, permanently discarding the counters it had just written. A deferred-compatibility language (typescript, tsx, ini) therefore reported no normalization activity at all. Now uses the parser-owned `rawParseRuntime`, handling that record's unnormalized `StopReason` (`""` where the public accessor reports `ParseStopNone`).

## Coverage evidence

The earlier justification for the pool fix cited `TestArenaGCRetentionAfterRelease`, which has **0.0% coverage** of both pooled functions — it parses a conflict-free Go file that never forks. That claim was withdrawn. Measured coverage from the new tests:

| test | function | coverage | branch hits |
|---|---|---|---|
| C# generic-call ambiguity, depth 20 | `gssNodeCanReach` | 87.8% | promote + clear-and-return, 12 each |
| PHP `$x0`→`$0` transient error, n=200 | `gssNodeHash` | 93.8% | promote + release, 725 each |

Plus two deterministic clearing-contract tests inspect the exact released object. The slice test inspects its full backing capacity for stale pointers. An `ini` regression test proves `NormalizationPasses` survives compact publication.

**All new tests were verified to have teeth**: each fix reverse-applied, failure confirmed with the expected diagnostic, then restored.

## Gate

- Focused tests cover each changed pool path — measured above.
- Deferred-language metrics survive compact publication — `ini` test, verified teeth.
- Docker parity exact — `run_parity_in_docker.sh` one-language Go GLR canary, PASS, no OOM.
- Full root suite `ok` 145.8s. Root `.go` count unchanged at 527.

Caveat: Docker parity ran Go's fork-heavy canary rather than C#/PHP/ini, as no single-language target exists for those.