### PR TITLE
add(normalization): census the per-language result-compat dispatcher arms

### DIFF
--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -110,6 +110,11 @@ found that table or engine fixes can leave old normalizers behind.
    out of dead-code PRs; they belong to materialization and recovered-forest
    work respectively.
 
+The tracked CI ratchet in `testdata/dispatcher_census_tracked_v1.json` pins
+source hashes, arm identities, and exact census totals for a small source set.
+It does not replace the full authenticated corpus, which remains an external
+release gate.
+
 Exit: no compatibility pass is retained solely because an old fixture calls
 it directly.
 

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -373,6 +373,18 @@ func (p *Parser) ParseForestExperimental(source []byte) (*Tree, bool) {
 	p.finalizeForestRoot(root, source)
 	tree := newTreeWithArenas(root, source, p.language, arena, nil)
 	tree.setParseRuntime(forestAcceptedRuntime(root, source))
+	// Diagnostic-only: mirrors the copyNormalizationStats call every other
+	// route makes (parser.go's parseInternal tail; tree.go's
+	// ensureResultCompatibility). forestAcceptedRuntime above deliberately
+	// builds a minimal ParseRuntime and does not itself carry normalization
+	// stats, so without this the dispatcher-arm census
+	// (GTS_DISPATCHER_CENSUS, parser_result_compat.go) would see every
+	// forest-fast-path language as having never run its normalizer, even
+	// though finalizeForestRoot (above) already ran it. p.normalizationStats
+	// is only ever non-empty when that census flag is set (see
+	// dispatcherArmCensus), so this is a no-op field copy in every ordinary
+	// parse.
+	p.copyNormalizationStats(tree.rawParseRuntime())
 	tree.forestFastPath = true
 	if !incrementalReuseProven {
 		tree.incrementalReuseDisabled = true
@@ -669,6 +681,15 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 		progress.beginDetail(time.Now(), "forest_normalize_begin", "forest_normalize_end", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")
 	}
 	p.normalizeReturnedTreeForParse(tree, source)
+	// Diagnostic-only: see the matching comment in ParseForestExperimental.
+	// finalizeForestRoot (above, via finalizeResultRoot) and
+	// normalizeReturnedTreeForParse (immediately above) can each run the
+	// dispatcher-arm census's per-language normalizer once, but
+	// forestAcceptedRuntime's ParseRuntime never carries normalization
+	// stats, so this copy has to happen after both calls, not just once
+	// up front. No-op unless GTS_DISPATCHER_CENSUS populated
+	// p.normalizationStats.
+	p.copyNormalizationStats(tree.rawParseRuntime())
 	if progress.enabled {
 		progress.endDetail(time.Now(), "forest_normalize_end", 0, 0, Token{}, false, nil, 0, 0, 0, false, 0, 0, fmt.Sprintf("root_end=%d", root.EndByte()))
 		progress.emit(time.Now(), "forest_try_success", 0, 0, Token{}, false, nil, 0, 0, 0, false, 0, 0, fmt.Sprintf("root_end=%d", root.EndByte()))

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -359,6 +359,7 @@ func (p *Parser) ParseForestExperimental(source []byte) (*Tree, bool) {
 	// an already-budgeted Parse() (were that ever wired up) would not reset it.
 	endBudget := p.enterParseBudget()
 	defer endBudget()
+	p.resetNormalizationStats()
 	arena := acquireNodeArena(arenaClassFull)
 	incrementalReuseProven := forestIncrementalReuseProven(p.language)
 	// A forest tree whose scanner class is not admitted can never consume
@@ -599,6 +600,7 @@ func (p *Parser) tryForestFastPath(source []byte) *Tree {
 	if p.forestDeclineMemoHit(source) {
 		return nil
 	}
+	p.resetNormalizationStats()
 	progress := newParseProgressTelemetry(p, len(source), uint32(len(source)), time.Now())
 	if progress.enabled {
 		progress.emit(time.Now(), "forest_try_begin", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")

--- a/glr_forest_normalization_stats_test.go
+++ b/glr_forest_normalization_stats_test.go
@@ -1,0 +1,82 @@
+package gotreesitter
+
+import "testing"
+
+func parseRuntimeHasNormalizationPass(rt ParseRuntime, name string) bool {
+	if rt.NormalizationPasses == nil {
+		return false
+	}
+	for _, pass := range *rt.NormalizationPasses {
+		if pass.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func seedStaleForestNormalizationStats(parser *Parser) {
+	parser.recordNormalizationMetric("stale.before-forest-attempt", 1, 1, 7, 3)
+}
+
+func TestForestAttemptResetsNormalizationStatsOnParserReuse(t *testing.T) {
+	previous := glrForestEnabled
+	glrForestEnabled = true
+	t.Cleanup(func() { glrForestEnabled = previous })
+
+	t.Run("success", func(t *testing.T) {
+		lang := loadBlobForDecode(t, "json")
+		lang.WantsForest = true
+		parser := NewParser(lang)
+		seedStaleForestNormalizationStats(parser)
+
+		tree, err := parser.Parse([]byte(`[1, 2, 3]`))
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		defer tree.Release()
+		rt := tree.ParseRuntime()
+		if !rt.ForestFastPath {
+			t.Fatalf("parse did not use the forest path: %s", rt.Summary())
+		}
+		if parseRuntimeHasNormalizationPass(rt, "stale.before-forest-attempt") {
+			t.Fatal("successful forest parse published stale normalization stats")
+		}
+	})
+
+	t.Run("decline", func(t *testing.T) {
+		lang := loadBlobForDecode(t, "json")
+		parser := NewParser(lang)
+		seedStaleForestNormalizationStats(parser)
+
+		tree, ok := parser.ParseForestExperimental([]byte(`[`))
+		if tree != nil {
+			tree.Release()
+		}
+		if ok {
+			t.Fatal("invalid JSON unexpectedly produced an experimental forest tree")
+		}
+		if len(parser.normalizationStats.namedPasses) != 0 {
+			t.Fatalf("declined forest attempt retained normalization stats: %+v", parser.normalizationStats.namedPasses)
+		}
+	})
+
+	t.Run("fallback", func(t *testing.T) {
+		lang := loadBlobForDecode(t, "json")
+		lang.WantsForest = true
+		parser := NewParser(lang)
+		seedStaleForestNormalizationStats(parser)
+
+		tree, err := parser.Parse([]byte(`[`))
+		if err != nil {
+			t.Fatalf("fallback parse: %v", err)
+		}
+		defer tree.Release()
+		rt := tree.ParseRuntime()
+		if rt.ForestFastPath {
+			t.Fatalf("invalid JSON unexpectedly returned a forest tree: %s", rt.Summary())
+		}
+		if parseRuntimeHasNormalizationPass(rt, "stale.before-forest-attempt") {
+			t.Fatal("forest fallback published stale normalization stats")
+		}
+	})
+}

--- a/parser_memory_budget_runtime_test.go
+++ b/parser_memory_budget_runtime_test.go
@@ -1,10 +1,6 @@
 package gotreesitter
 
-import (
-	"runtime"
-	"runtime/debug"
-	"testing"
-)
+import "testing"
 
 // TestRuntimeMemoryBudgetSoftBudgetNeverStopsParse pins the issue #454
 // determinism contract: the soft per-parse budget must never stop a parse from
@@ -151,36 +147,13 @@ func TestRuntimeMemoryVolumeTriggerBypassesPollMask(t *testing.T) {
 		t.Fatalf("test setup invariant broken: poll count %d not actually masked", skippedPollCount)
 	}
 
-	// Disable GC for the measured window: this package's full test binary
-	// allocates heavily elsewhere, and a concurrent GC cycle reclaiming that
-	// unrelated garbage can otherwise offset this test's own ballast growth
-	// enough that HeapAlloc undercounts it relative to Sys, flipping which
-	// source (runtime_heap vs runtime_sys) the check attributes the stop to.
-	oldGC := debug.SetGCPercent(-1)
-	defer debug.SetGCPercent(oldGC)
-
-	// A loose-mask-selecting budget (255 mask, > parseRuntimeMemoryTightBudget)
-	// is itself at least ~64MiB, so proving "heapGrowth >= budget" needs a real
-	// allocation of that scale rather than relying on ambient process heap
-	// size. Capture a real baseline, then deliberately grow the live heap past
-	// the budget so runtimeMemoryBudgetStopReasonNow's comparison is genuine.
-	var before runtime.MemStats
-	runtime.ReadMemStats(&before)
-	const budget = parseRuntimeMemoryTightBudget + 8<<20 // ~72MiB: > tight threshold, selects mask 255
-	ballast := make([]byte, budget+(16<<20))             // guarantee >= budget bytes of real growth
-	for i := range ballast {
-		ballast[i] = byte(i)
-	}
-	t.Cleanup(func() { runtime.KeepAlive(ballast) })
-
-	// The soft budget still selects the poll mask, but only the hard ceiling can
-	// stop a parse (see the issue #454 determinism contract), so arm the ceiling
-	// at the same size to prove the forced poll reached a real ReadMemStats
-	// comparison rather than being skipped by the mask.
+	// Select the loose mask with the soft budget. Arm a deterministic hard
+	// ceiling so a real sample stops without process-global ballast.
+	const looseBudget = parseRuntimeMemoryTightBudget + 1
 	parser := &Parser{
-		parseRuntimeMemoryBudgetBytes:      budget,
-		parseRuntimeMemoryHardCeilingBytes: budget,
-		parseRuntimeMemoryBaselineBytes:    before.HeapAlloc,
+		parseRuntimeMemoryBudgetBytes:      looseBudget,
+		parseRuntimeMemoryHardCeilingBytes: 1,
+		parseRuntimeMemoryBaselineBytes:    0,
 		parseRuntimeMemoryPoll:             skippedPollCount - 1,
 		parseRuntimeMemoryVolumeAtPoll:     0,
 		parseMemoryBudgetDiagActive:        true,
@@ -196,14 +169,9 @@ func TestRuntimeMemoryVolumeTriggerBypassesPollMask(t *testing.T) {
 	if got := parser.runtimeMemoryBudgetStopReason(parseRuntimeMemoryVolumePollThresholdBytes); got != ParseStopMemoryBudget {
 		t.Fatalf("runtimeMemoryBudgetStopReason(volume >= threshold) = %q, want %q (volume trigger should bypass the mask)", got, ParseStopMemoryBudget)
 	}
-	// The hard ceiling is now the only source that can stop a parse, so it is a
-	// single exact expectation. The old two-source allowance existed because the
-	// heap and sys arms raced each other under -race, which is precisely the
-	// nondeterminism this contract removes.
 	if got, want := parser.parseMemoryBudgetDiag.source, parseMemoryBudgetStopSourceHardCeiling; got != want {
 		t.Fatalf("memory budget stop source = %q, want %q", got, want)
 	}
-	runtime.KeepAlive(ballast)
 }
 
 // TestParseMemoryHardCeilingStopsIndependentlyOfSoftBudget exercises the

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -1,5 +1,7 @@
 package gotreesitter
 
+import "os"
+
 type resultCompatibilityContext struct {
 	root      *Node
 	source    []byte
@@ -92,180 +94,360 @@ func (ctx resultCompatibilityContext) stopReason() ParseStopReason {
 
 func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompatibilityResult {
 	if isCobolLanguage(ctx.lang) {
-		normalizeCobolCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "predicate.cobol-exact", func() {
+			normalizeCobolCompatibility(ctx.root, ctx.source, ctx.lang)
+		})
 		return resultCompatibilityResult{stopReason: ctx.stopReason()}
 	}
 
 	switch ctx.lang.Name {
 	case "ada":
-		normalizeAdaCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ada", func() { normalizeAdaCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "angular":
-		normalizeAngularCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.angular", func() { normalizeAngularCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "apex":
-		normalizeApexCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.apex", func() { normalizeApexCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "authzed":
-		normalizeAuthzedCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.authzed", func() { normalizeAuthzedCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "awk":
-		normalizeAwkCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.awk", func() { normalizeAwkCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "bibtex":
-		normalizeBibtexCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.bibtex", func() { normalizeBibtexCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "bash":
-		normalizeBashProgramVariableAssignments(ctx.root, ctx.lang)
-		normalizeBashGeneratedCommandAssignments(ctx.root, ctx.source, ctx.lang)
-		normalizeBashCommandNameArguments(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.bash", func() {
+			normalizeBashProgramVariableAssignments(ctx.root, ctx.lang)
+			normalizeBashGeneratedCommandAssignments(ctx.root, ctx.source, ctx.lang)
+			normalizeBashCommandNameArguments(ctx.root, ctx.lang)
+		})
 	case "bitbake":
-		normalizeBitbakeCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.bitbake", func() { normalizeBitbakeCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "chatito":
-		normalizeChatitoCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.chatito", func() { normalizeChatitoCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "arduino":
-		normalizeArduinoBuiltinPrimitiveTypes(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.arduino", func() { normalizeArduinoBuiltinPrimitiveTypes(ctx.root, ctx.source, ctx.lang) })
 	case "c", "cpp":
-		normalizeCCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.c_cpp", func() { normalizeCCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "c_sharp":
-		normalizeCSharpCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.c_sharp", func() { normalizeCSharpCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "caddy", "comment", "fortran", "nim", "pug", "rst":
-		normalizeResultTrailingSpanCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.shared_trailing_span", func() { normalizeResultTrailingSpanCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "cooklang":
-		normalizeCooklangCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.cooklang", func() { normalizeCooklangCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "corn":
-		normalizeCornCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.corn", func() { normalizeCornCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "crystal":
-		normalizeCrystalCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.crystal", func() { normalizeCrystalCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "cpon":
-		normalizeCPONCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.cpon", func() { normalizeCPONCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "cue":
-		normalizeCueCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.cue", func() { normalizeCueCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "d":
-		normalizeDCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.d", func() { normalizeDCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "dart":
-		normalizeDartCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.dart", func() { normalizeDartCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "doxygen":
-		normalizeDoxygenCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.doxygen", func() { normalizeDoxygenCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "jsdoc":
-		normalizeJsdocCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.jsdoc", func() { normalizeJsdocCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "dtd":
-		normalizeDTDCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.dtd", func() { normalizeDTDCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "elixir":
-		normalizeElixirCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.elixir", func() { normalizeElixirCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "enforce":
-		normalizeEnforceCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.enforce", func() { normalizeEnforceCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "ebnf":
-		normalizeEBNFCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ebnf", func() { normalizeEBNFCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "eds":
-		normalizeEDSCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.eds", func() { normalizeEDSCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "erlang":
-		normalizeErlangSourceFileForms(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.erlang", func() { normalizeErlangSourceFileForms(ctx.root, ctx.lang) })
 	case "fsharp":
-		normalizeFSharpCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.fsharp", func() { normalizeFSharpCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "forth":
-		normalizeForthCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.forth", func() { normalizeForthCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "fidl":
-		normalizeFIDLCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.fidl", func() { normalizeFIDLCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "go":
-		return resultCompatibilityResult{stopReason: normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang, ctx.incrementalRanges)}
+		var stopReason ParseStopReason
+		dispatcherArmCensus(ctx, "dispatch.go", func() {
+			stopReason = normalizeGoReturnedTreeCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang, ctx.incrementalRanges)
+		})
+		return resultCompatibilityResult{stopReason: stopReason}
 	case "gitcommit":
-		normalizeGitcommitCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.gitcommit", func() { normalizeGitcommitCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "haskell":
-		normalizeHaskellCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.haskell", func() { normalizeHaskellCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "hcl":
-		normalizeHCLConfigFileRoot(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.hcl", func() { normalizeHCLConfigFileRoot(ctx.root, ctx.source, ctx.lang) })
 	case "html":
-		normalizeHTMLCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.html", func() { normalizeHTMLCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "http":
-		normalizeHTTPCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.http", func() { normalizeHTTPCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "hurl":
-		normalizeHurlCompatibility(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.hurl", func() { normalizeHurlCompatibility(ctx.root, ctx.lang) })
 	case "hlsl":
-		normalizeHLSLCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.hlsl", func() { normalizeHLSLCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "hyprlang":
-		normalizeHyprlangCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.hyprlang", func() { normalizeHyprlangCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "ini":
-		return normalizeIniCompatibility(ctx.root, ctx.source, ctx.lang)
+		var res resultCompatibilityResult
+		dispatcherArmCensus(ctx, "dispatch.ini", func() {
+			res = normalizeIniCompatibility(ctx.root, ctx.source, ctx.lang)
+		})
+		return res
 	case "javascript":
-		return resultCompatibilityResult{stopReason: normalizeJavaScriptCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)}
+		var stopReason ParseStopReason
+		dispatcherArmCensus(ctx, "dispatch.javascript", func() {
+			stopReason = normalizeJavaScriptCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		})
+		return resultCompatibilityResult{stopReason: stopReason}
 	case "julia":
-		normalizeJuliaCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.julia", func() { normalizeJuliaCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "just":
-		normalizeJustTopLevelTrailingLineBreakSpans(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.just", func() { normalizeJustTopLevelTrailingLineBreakSpans(ctx.root, ctx.source, ctx.lang) })
 	case "ledger":
-		normalizeLedgerCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ledger", func() { normalizeLedgerCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "linkerscript":
-		normalizeLinkerscriptCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.linkerscript", func() { normalizeLinkerscriptCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "kotlin":
-		normalizeKotlinCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.kotlin", func() { normalizeKotlinCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "lua":
-		normalizeLuaChunkLocalDeclarationFields(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.lua", func() { normalizeLuaChunkLocalDeclarationFields(ctx.root, ctx.source, ctx.lang) })
 	case "luau":
-		normalizeLuauCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.luau", func() { normalizeLuauCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "make":
-		normalizeMakeConditionalConsequenceFields(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.make", func() { normalizeMakeConditionalConsequenceFields(ctx.root, ctx.lang) })
 	case "objc":
-		normalizeObjcCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.objc", func() { normalizeObjcCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "nginx":
-		normalizeNginxAttributeLineBreaks(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.nginx", func() { normalizeNginxAttributeLineBreaks(ctx.root, ctx.source, ctx.lang) })
 	case "ninja":
-		normalizeNinjaCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ninja", func() { normalizeNinjaCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "ocaml":
-		normalizeOCamlCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ocaml", func() { normalizeOCamlCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "pascal":
-		normalizePascalTopLevelProgramEnd(ctx.root, ctx.source, ctx.lang)
-		normalizePascalTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.pascal", func() {
+			normalizePascalTopLevelProgramEnd(ctx.root, ctx.source, ctx.lang)
+			normalizePascalTrailingExtraTrivia(ctx.root, ctx.source, ctx.lang)
+		})
 	case "perl":
-		normalizePerlCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.perl", func() { normalizePerlCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "php":
-		normalizePHPCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.php", func() { normalizePHPCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "powershell":
-		normalizePowerShellProgramShape(ctx.root, ctx.source, ctx.lang)
-		normalizePowerShellErrorProgramRoot(ctx.root, ctx.lang)
-		normalizePowerShellAssignmentOperatorTokens(ctx.root, ctx.source, ctx.lang)
-		normalizePowerShellPathCommandNameVariables(ctx.root, ctx.source, ctx.lang)
-		normalizePowerShellEnumStatementKeywordSpans(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.powershell", func() {
+			normalizePowerShellProgramShape(ctx.root, ctx.source, ctx.lang)
+			normalizePowerShellErrorProgramRoot(ctx.root, ctx.lang)
+			normalizePowerShellAssignmentOperatorTokens(ctx.root, ctx.source, ctx.lang)
+			normalizePowerShellPathCommandNameVariables(ctx.root, ctx.source, ctx.lang)
+			normalizePowerShellEnumStatementKeywordSpans(ctx.root, ctx.source, ctx.lang)
+		})
 	case "ql":
-		normalizeQLCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ql", func() { normalizeQLCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "r":
-		normalizeRCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.r", func() { normalizeRCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "python":
-		normalizePythonCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.python", func() { normalizePythonCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "rescript":
-		normalizeRescriptCompatibility(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.rescript", func() { normalizeRescriptCompatibility(ctx.root, ctx.lang) })
 	case "robot":
-		normalizeRobotCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.robot", func() { normalizeRobotCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "rust":
-		normalizeRustCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.rust", func() { normalizeRustCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "ruby":
-		normalizeRubyTopLevelModuleBounds(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.ruby", func() { normalizeRubyTopLevelModuleBounds(ctx.root, ctx.source, ctx.lang) })
 	case "scala":
-		normalizeScalaCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.scala", func() { normalizeScalaCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "scheme":
-		normalizeSchemeCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.scheme", func() { normalizeSchemeCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "solidity":
-		normalizeSolidityMemberObjectWrappers(ctx.root, ctx.lang)
-		normalizeSolidityCallExpressionAliases(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.solidity", func() {
+			normalizeSolidityMemberObjectWrappers(ctx.root, ctx.lang)
+			normalizeSolidityCallExpressionAliases(ctx.root, ctx.lang)
+		})
 	case "sql":
-		normalizeSQLRecoveredSelectRoot(ctx.root, ctx.lang)
-		normalizeSQLTrailingSelectListError(ctx.root, ctx.lang)
-		if ctx.parser != nil && !ctx.parser.skipRecoveryReparse {
-			normalizeSQLRecoveredTopLevelSelectStatements(ctx.root, ctx.source, ctx.parser, ctx.lang)
-		}
-		normalizeSQLSelectClauseBodyIntoFields(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.sql", func() {
+			normalizeSQLRecoveredSelectRoot(ctx.root, ctx.lang)
+			normalizeSQLTrailingSelectListError(ctx.root, ctx.lang)
+			if ctx.parser != nil && !ctx.parser.skipRecoveryReparse {
+				normalizeSQLRecoveredTopLevelSelectStatements(ctx.root, ctx.source, ctx.parser, ctx.lang)
+			}
+			normalizeSQLSelectClauseBodyIntoFields(ctx.root, ctx.lang)
+		})
 	case "squirrel":
-		normalizeSquirrelCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.squirrel", func() { normalizeSquirrelCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "swift":
-		normalizeSwiftCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.swift", func() { normalizeSwiftCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "templ":
-		normalizeTemplCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.templ", func() { normalizeTemplCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "wgsl":
-		normalizeWGSLCompatibility(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.wgsl", func() { normalizeWGSLCompatibility(ctx.root, ctx.lang) })
 	case "wolfram":
-		normalizeWolframCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.wolfram", func() { normalizeWolframCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "tsx", "typescript":
-		return resultCompatibilityResult{stopReason: normalizeTypeScriptTreeCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)}
+		var stopReason ParseStopReason
+		dispatcherArmCensus(ctx, "dispatch.typescript", func() {
+			stopReason = normalizeTypeScriptTreeCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang)
+		})
+		return resultCompatibilityResult{stopReason: stopReason}
 	case "typst":
-		normalizeTypstCompatibility(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.typst", func() { normalizeTypstCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "yaml":
-		normalizeYAMLRecoveredRoot(ctx.root, ctx.source, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.yaml", func() { normalizeYAMLRecoveredRoot(ctx.root, ctx.source, ctx.lang) })
 	case "zig":
-		normalizeZigEmptyInitListFields(ctx.root, ctx.lang)
+		dispatcherArmCensus(ctx, "dispatch.zig", func() { normalizeZigEmptyInitListFields(ctx.root, ctx.lang) })
 	}
 	return resultCompatibilityResult{stopReason: ctx.stopReason()}
+}
+
+// --- R2 dispatcher-arm census (docs/root-normalization-retirement.md) ---
+//
+// runLanguageResultCompatibility's switch is the per-language dispatcher arm
+// registry described in testdata/result_compat_ownership_v1.json
+// ("dispatcher_arms"). Most arms return nothing: whether a given call ever
+// actually rewrites the tree has never been measured in production, only
+// asserted by unit fixtures that construct the triggering shape by hand. R2
+// requires a census before any retirement.
+//
+// dispatcherArmCensus is the uniform, zero-per-function-surgery probe: it
+// snapshots a full structural fingerprint of ctx.root immediately before and
+// after the arm's closure runs and diffs the two snapshots. This needs no
+// changes to any of the ~80 normalizeXCompatibility functions themselves and
+// covers every arm identically, including the multi-function arms (bash,
+// pascal, powershell, solidity, sql) where "the arm" is the whole case body,
+// matching the registry's one-entry-per-language granularity.
+//
+// It is gated behind GTS_DISPATCHER_CENSUS=1 so the fingerprint walk (which
+// is a full O(n) tree traversal, run twice) costs nothing on an ordinary
+// parse: dispatcherCensusEnabled's os.Getenv check is the only overhead paid
+// when the flag is unset, and every dispatcher arm already performs at least
+// one full-tree walk of its own, so even the closure indirection paid when
+// the flag is set is in the noise relative to the arm's own cost.
+func dispatcherCensusEnabled() bool {
+	return os.Getenv("GTS_DISPATCHER_CENSUS") != ""
+}
+
+// dispatcherArmCensus runs fn (the body of one dispatcher-arm switch case)
+// and, only when census instrumentation is enabled, records whether fn
+// changed ctx.root's structural fingerprint under armID via
+// (*Parser).recordNormalizationMetric. armID matches the corresponding
+// "dispatch.<name>" / "predicate.<name>" id in
+// testdata/result_compat_ownership_v1.json so census receipts trace directly
+// back to the registry entry they measure.
+func dispatcherArmCensus(ctx resultCompatibilityContext, armID string, fn func()) {
+	if !dispatcherCensusEnabled() {
+		fn()
+		return
+	}
+	before := captureDispatcherFingerprint(ctx.root)
+	fn()
+	after := captureDispatcherFingerprint(ctx.root)
+	visited, rewritten := diffDispatcherFingerprint(before, after)
+	if ctx.parser != nil {
+		ctx.parser.recordNormalizationMetric(armID, 1, 1, visited, rewritten)
+	}
+}
+
+// dispatcherNodeSignature captures exactly the observable-from-outside-the-
+// package surface of one Node: its type (symbol), its span, its child
+// structure (child count), the field name assigned to it in its parent's
+// child slot, and the content-relevant flags a caller can query (IsNamed,
+// IsMissing, IsExtra, HasError, external-scanner-token). It deliberately
+// excludes purely internal bookkeeping bits (dirty, fragile-left/right,
+// field-ID cache-computed) that are incremental-reuse or GLR-disambiguation
+// housekeeping, not tree content, and could otherwise churn independently of
+// whatever the dispatcher arm itself did.
+//
+// This is the full set of fields Node exposes that can differ between two
+// trees built from the same source: if every signature in a preorder walk is
+// identical before and after an arm runs, nothing the arm could have done is
+// observable through the public Node API, so "no rewrite" is a sound
+// conclusion, not merely a hash coincidence (there is no hashing here at
+// all -- fields are compared for exact equality).
+type dispatcherNodeSignature struct {
+	symbol     Symbol
+	startByte  uint32
+	endByte    uint32
+	childCount int32
+	fieldID    FieldID
+	flags      nodeFlags
+}
+
+// dispatcherCensusContentFlagMask selects the nodeFlags bits that are part of
+// a node's observable content (see dispatcherNodeSignature) and excludes
+// internal-only bookkeeping bits.
+const dispatcherCensusContentFlagMask = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError | nodeFlagExternalScannerToken
+
+// captureDispatcherFingerprint walks root in preorder (iteratively, to avoid
+// recursion-depth limits on deep or adversarial trees) and returns one
+// signature per node. The walk order itself is part of the fingerprint: a
+// normalizer that reorders, inserts, removes, or reparents nodes shifts later
+// positions even when the individual node contents are byte-identical, so a
+// structural edit is still detected even when no single node's own fields
+// changed.
+func captureDispatcherFingerprint(root *Node) []dispatcherNodeSignature {
+	if root == nil {
+		return nil
+	}
+	type pending struct {
+		node    *Node
+		fieldID FieldID
+	}
+	out := make([]dispatcherNodeSignature, 0, 64)
+	stack := make([]pending, 0, 64)
+	stack = append(stack, pending{node: root})
+	for len(stack) > 0 {
+		top := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		n := top.node
+		if n == nil {
+			continue
+		}
+		childCount := n.ChildCount()
+		out = append(out, dispatcherNodeSignature{
+			symbol:     n.symbol,
+			startByte:  n.startByte,
+			endByte:    n.endByte,
+			childCount: int32(childCount),
+			fieldID:    top.fieldID,
+			flags:      n.flags & dispatcherCensusContentFlagMask,
+		})
+		for i := childCount - 1; i >= 0; i-- {
+			stack = append(stack, pending{node: n.Child(i), fieldID: nodeFieldIDAt(n, i)})
+		}
+	}
+	return out
+}
+
+// diffDispatcherFingerprint compares two preorder signature snapshots of the
+// same root captured immediately before and after a dispatcher arm ran.
+// visited is the node count of the "before" snapshot (what the probe had to
+// look at). rewritten is a position-wise difference count: it is exact when
+// nothing structural changed (same length, same content at every position
+// yields rewritten == 0, an exact, hash-free equality check), but it is only
+// an approximation of "how many nodes changed" when a node was inserted or
+// removed near the root, because every following node's preorder position
+// shifts by one and each shifted position then also compares unequal even
+// though its own content did not change. Callers should treat rewritten == 0
+// as an exact "no rewrite" receipt and rewritten > 0 as an exact "the arm
+// changed something" receipt, but should not treat the magnitude of a
+// nonzero rewritten count as a precise edit distance.
+func diffDispatcherFingerprint(before, after []dispatcherNodeSignature) (visited, rewritten uint64) {
+	visited = uint64(len(before))
+	shorter := len(before)
+	if len(after) < shorter {
+		shorter = len(after)
+	}
+	var changed uint64
+	for i := 0; i < shorter; i++ {
+		if before[i] != after[i] {
+			changed++
+		}
+	}
+	lengthDelta := len(before) - len(after)
+	if lengthDelta < 0 {
+		lengthDelta = -lengthDelta
+	}
+	changed += uint64(lengthDelta)
+	return visited, changed
 }

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -324,7 +324,7 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 // one full-tree walk of its own, so even the closure indirection paid when
 // the flag is set is in the noise relative to the arm's own cost.
 func dispatcherCensusEnabled() bool {
-	return os.Getenv("GTS_DISPATCHER_CENSUS") != ""
+	return os.Getenv("GTS_DISPATCHER_CENSUS") == "1"
 }
 
 // dispatcherArmCensus runs fn (the body of one dispatcher-arm switch case)
@@ -348,15 +348,9 @@ func dispatcherArmCensus(ctx resultCompatibilityContext, armID string, fn func()
 	}
 }
 
-// dispatcherNodeSignature captures exactly the observable-from-outside-the-
-// package surface of one Node: its type (symbol), its span, its child
-// structure (child count), the field name assigned to it in its parent's
-// child slot, and the content-relevant flags a caller can query (IsNamed,
-// IsMissing, IsExtra, HasError, external-scanner-token). It deliberately
-// excludes purely internal bookkeeping bits (dirty, fragile-left/right,
-// field-ID cache-computed) that are incremental-reuse or GLR-disambiguation
-// housekeeping, not tree content, and could otherwise churn independently of
-// whatever the dispatcher arm itself did.
+// dispatcherNodeSignature captures the observable surface of one Node. It
+// includes the parser states because callers can query them and incremental
+// reuse consumes them. It excludes internal caches and GLR bookkeeping.
 //
 // This is the full set of fields Node exposes that can differ between two
 // trees built from the same source: if every signature in a preorder walk is
@@ -365,18 +359,54 @@ func dispatcherArmCensus(ctx resultCompatibilityContext, armID string, fn func()
 // conclusion, not merely a hash coincidence (there is no hashing here at
 // all -- fields are compared for exact equality).
 type dispatcherNodeSignature struct {
-	symbol     Symbol
-	startByte  uint32
-	endByte    uint32
-	childCount int32
-	fieldID    FieldID
-	flags      nodeFlags
+	symbol       Symbol
+	startByte    uint32
+	endByte      uint32
+	startPoint   Point
+	endPoint     Point
+	parseState   StateID
+	preGotoState StateID
+	childCount   int32
+	fieldID      FieldID
+	flags        nodeFlags
 }
 
 // dispatcherCensusContentFlagMask selects the nodeFlags bits that are part of
 // a node's observable content (see dispatcherNodeSignature) and excludes
 // internal-only bookkeeping bits.
-const dispatcherCensusContentFlagMask = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError | nodeFlagExternalScannerToken
+const dispatcherCensusContentFlagMask = nodeFlagNamed | nodeFlagExtra | nodeFlagMissing | nodeFlagHasError | nodeFlagDirty | nodeFlagExternalScannerToken
+
+func dispatcherFingerprintEntryFlags(entry stackEntry) nodeFlags {
+	if node := stackEntryNode(entry); node != nil {
+		return node.flags & dispatcherCensusContentFlagMask
+	}
+	if node := stackEntryNoTreeNode(entry); node != nil {
+		return node.flags & dispatcherCensusContentFlagMask
+	}
+	if node := stackEntryCompactFullLeaf(entry); node != nil {
+		return node.flags & dispatcherCensusContentFlagMask
+	}
+	if node := stackEntryPendingParent(entry); node != nil {
+		return node.flags & dispatcherCensusContentFlagMask
+	}
+	return 0
+}
+
+func dispatcherFingerprintChild(entry stackEntry, arena *nodeArena, i int) (stackEntry, *nodeArena, FieldID, bool) {
+	child, ok := stackEntryPendingChildAt(arena, entry, i)
+	if !ok || !stackEntryHasNode(child) {
+		return stackEntry{}, nil, 0, false
+	}
+	fieldID, _, fieldOK := stackEntryPendingFieldMetadataAt(arena, entry, i)
+	if !fieldOK {
+		fieldID = 0
+	}
+	childArena := arena
+	if node := stackEntryNode(child); node != nil {
+		childArena = node.ownerArena
+	}
+	return child, childArena, fieldID, true
+}
 
 // captureDispatcherFingerprint walks root in preorder (iteratively, to avoid
 // recursion-depth limits on deep or adversarial trees) and returns one
@@ -390,30 +420,41 @@ func captureDispatcherFingerprint(root *Node) []dispatcherNodeSignature {
 		return nil
 	}
 	type pending struct {
-		node    *Node
+		entry   stackEntry
+		arena   *nodeArena
 		fieldID FieldID
 	}
 	out := make([]dispatcherNodeSignature, 0, 64)
 	stack := make([]pending, 0, 64)
-	stack = append(stack, pending{node: root})
+	stack = append(stack, pending{
+		entry: newStackEntryNode(root.parseState, root),
+		arena: root.ownerArena,
+	})
 	for len(stack) > 0 {
 		top := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		n := top.node
-		if n == nil {
+		if !stackEntryHasNode(top.entry) {
 			continue
 		}
-		childCount := n.ChildCount()
+		childCount := stackEntryNodeChildCount(top.entry)
 		out = append(out, dispatcherNodeSignature{
-			symbol:     n.symbol,
-			startByte:  n.startByte,
-			endByte:    n.endByte,
-			childCount: int32(childCount),
-			fieldID:    top.fieldID,
-			flags:      n.flags & dispatcherCensusContentFlagMask,
+			symbol:       stackEntryNodeSymbol(top.entry),
+			startByte:    stackEntryNodeStartByte(top.entry),
+			endByte:      stackEntryNodeEndByte(top.entry),
+			startPoint:   stackEntryNodeStartPoint(top.entry),
+			endPoint:     stackEntryNodeEndPoint(top.entry),
+			parseState:   stackEntryNodeParseState(top.entry),
+			preGotoState: stackEntryNodePreGotoState(top.entry),
+			childCount:   int32(childCount),
+			fieldID:      top.fieldID,
+			flags:        dispatcherFingerprintEntryFlags(top.entry),
 		})
 		for i := childCount - 1; i >= 0; i-- {
-			stack = append(stack, pending{node: n.Child(i), fieldID: nodeFieldIDAt(n, i)})
+			child, childArena, fieldID, ok := dispatcherFingerprintChild(top.entry, top.arena, i)
+			if !ok {
+				continue
+			}
+			stack = append(stack, pending{entry: child, arena: childArena, fieldID: fieldID})
 		}
 	}
 	return out

--- a/parser_result_make_ini_zig_test.go
+++ b/parser_result_make_ini_zig_test.go
@@ -42,6 +42,69 @@ func TestNormalizeMakeConditionalConsequenceFieldsExtendsAcrossLeadingTabs(t *te
 	}
 }
 
+// TestDispatcherArmCensusProbeIsWiredForMake is the production-wiring
+// positive control the R2 dispatcher-arm census requires
+// (docs/root-normalization-retirement.md; see
+// parser_result_test/dispatcher_census_test.go for the census itself). It
+// reuses the exact fixture from
+// TestNormalizeMakeConditionalConsequenceFieldsExtendsAcrossLeadingTabs
+// above, which independently proves normalizeMakeConditionalConsequenceFields
+// rewrites root.fieldIDs()[1] from 0 to 1 on this input, but drives it
+// through the real production entry point (normalizeResultCompatibility) and
+// the real "make" switch case instead of calling the normalizer directly.
+// This proves the census counters observe what production actually runs, so
+// a zero-rewrite census result for some OTHER language is a claim about that
+// language, not evidence the probe never fires.
+func TestDispatcherArmCensusProbeIsWiredForMake(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	lang := &Language{
+		Name:        "make",
+		SymbolNames: []string{"EOF", "conditional", "ifneq_directive", "\t", "recipe_line", "else_directive", "endif"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "conditional", Visible: true, Named: true},
+			{Name: "ifneq_directive", Visible: true, Named: true},
+			{Name: "\t", Visible: true, Named: false},
+			{Name: "recipe_line", Visible: true, Named: true},
+			{Name: "else_directive", Visible: true, Named: true},
+			{Name: "endif", Visible: true, Named: false},
+		},
+		FieldNames: []string{"", "consequence"},
+	}
+
+	arena := newNodeArena(arenaClassFull)
+	directive := newLeafNodeInArena(arena, 2, true, 0, 5, Point{}, Point{Column: 5})
+	tab := newLeafNodeInArena(arena, 3, false, 5, 6, Point{Column: 5}, Point{Column: 6})
+	recipe := newLeafNodeInArena(arena, 4, true, 6, 12, Point{Column: 6}, Point{Column: 12})
+	elseDir := newLeafNodeInArena(arena, 5, true, 12, 16, Point{Column: 12}, Point{Column: 16})
+	endif := newLeafNodeInArena(arena, 6, false, 16, 21, Point{Column: 16}, Point{Column: 21})
+	root := newParentNodeInArena(arena, 1, true, []*Node{directive, tab, recipe, elseDir, endif}, []FieldID{0, 0, 1, 1, 0}, 0)
+	root.setFieldSources([]uint8{0, 0, fieldSourceDirect, fieldSourceDirect, 0})
+
+	source := make([]byte, 21)
+	parser := &Parser{language: lang}
+
+	normalizeResultCompatibility(root, source, parser, nil)
+
+	var pass *normalizationNamedPassStats
+	for i := range parser.normalizationStats.namedPasses {
+		if parser.normalizationStats.namedPasses[i].name == "dispatch.make" {
+			pass = &parser.normalizationStats.namedPasses[i]
+		}
+	}
+	if pass == nil {
+		t.Fatal("dispatch.make census was never recorded: the probe is not wired to the production dispatcher, so any zero-rewrite census result for another language would be vacuous")
+	}
+	if pass.checked == 0 || pass.run == 0 {
+		t.Fatalf("dispatch.make census checked=%d run=%d, want both > 0", pass.checked, pass.run)
+	}
+	if pass.nodesRewritten == 0 {
+		t.Fatal("dispatch.make census recorded zero rewrites on an input known to mutate a field (see TestNormalizeMakeConditionalConsequenceFieldsExtendsAcrossLeadingTabs): the fingerprint probe did not observe a change it should have caught")
+	}
+	t.Logf("probe caught a real production rewrite: visited=%d rewritten=%d", pass.nodesVisited, pass.nodesRewritten)
+}
+
 func TestNormalizeIniSectionStartsSnapToFirstChild(t *testing.T) {
 	lang := &Language{
 		Name:        "ini",

--- a/parser_result_python_repair_test.go
+++ b/parser_result_python_repair_test.go
@@ -290,6 +290,61 @@ func TestRepairPythonRootNodeNoopKeepsFinalChildRefsLazy(t *testing.T) {
 	}
 }
 
+func TestDispatcherArmCensusKeepsPythonFinalChildRefsLazy(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	lang := &Language{
+		Name:        "python",
+		SymbolNames: []string{"EOF", "module", "comment", "import_statement", "_simple_statements"},
+	}
+	arena := newNodeArena(arenaClassFull)
+	arena.finalChildRefs = true
+	comment := newCompactFullLeafInArena(arena, 2, true, 0, 5, Point{}, Point{Column: 5})
+	comment.parseState = 11
+	comment.setExtra(true)
+	stmt := newCompactFullLeafInArena(arena, 3, true, 6, 15, Point{Row: 1}, Point{Row: 1, Column: 9})
+	stmt.parseState = 12
+	parent := newPendingParentInArena(arena, 1, true, 13, []stackEntry{
+		newStackEntryCompactFullLeaf(comment.parseState, comment),
+		newStackEntryCompactFullLeaf(stmt.parseState, stmt),
+	}, 0, 15, Point{}, Point{Row: 1, Column: 9}, false)
+	parent.parseState = 14
+	entry := newStackEntryPendingParent(parent.parseState, parent)
+	root := materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
+	if root == nil || !nodeHasFinalChildRefs(root) {
+		t.Fatal("fixture did not retain Python final-child refs")
+	}
+
+	parser := NewParser(lang)
+	runLanguageResultCompatibility(resultCompatibilityContext{
+		root:   root,
+		parser: parser,
+		lang:   lang,
+	})
+
+	var pass *normalizationNamedPassStats
+	for i := range parser.normalizationStats.namedPasses {
+		if parser.normalizationStats.namedPasses[i].name == "dispatch.python" {
+			pass = &parser.normalizationStats.namedPasses[i]
+			break
+		}
+	}
+	if pass == nil || pass.run != 1 || pass.nodesVisited == 0 || pass.nodesRewritten != 0 {
+		t.Fatalf("Python dispatcher census pass = %+v, want one observed no-op", pass)
+	}
+	if got := arena.finalChildRefsMaterializedParents; got != 0 {
+		t.Fatalf("census materialized final-child parent ranges = %d, want 0", got)
+	}
+	if got := arena.finalChildRefsSingleChildAccesses; got != 0 {
+		t.Fatalf("census accessed final-child refs through materialization = %d, want 0", got)
+	}
+	if got := arena.finalChildRefsSingleChildMaterializedChildren; got != 0 {
+		t.Fatalf("census materialized Python children = %d, want 0", got)
+	}
+	if !nodeHasFinalChildRefs(root) {
+		t.Fatal("census drained Python final-child refs")
+	}
+}
+
 func TestRepairPythonRootNodeClearsErrorWithoutDrainingFinalRefs(t *testing.T) {
 	lang := &Language{
 		Name:        "python",

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -664,3 +664,78 @@ func TestGenericTerminalLeafCensusMultiLanguage(t *testing.T) {
 		t.Fatal("multi-language census covered no language: the result is vacuous")
 	}
 }
+
+// TestDispatcherArmCensusFingerprintDetectsEveryObservableChange is the
+// mechanism-level positive control for the R2 dispatcher-arm census
+// (docs/root-normalization-retirement.md; see parser_result_compat.go's
+// captureDispatcherFingerprint/diffDispatcherFingerprint). Before trusting a
+// per-language "INERT" receipt from the census, this proves the probe itself
+// is sound: a no-op comparison reports zero rewrites, and each of the
+// distinct kinds of tree mutation a result-compatibility normalizer can make
+// (span edit, flag edit, field edit, and structural insertion) is caught.
+// A production-wiring control (that the probe observes a REAL normalizer's
+// REAL rewrite) lives alongside the Make fixture in
+// TestDispatcherArmCensusProbeIsWiredForMake
+// (parser_result_make_ini_zig_test.go).
+func TestDispatcherArmCensusFingerprintDetectsEveryObservableChange(t *testing.T) {
+	build := func() (*Node, *Node) {
+		arena := newNodeArena(arenaClassFull)
+		leaf1 := newLeafNodeInArena(arena, 10, true, 0, 3, Point{Column: 0}, Point{Column: 3})
+		leaf2 := newLeafNodeInArena(arena, 11, true, 3, 6, Point{Column: 3}, Point{Column: 6})
+		root := newParentNodeInArena(arena, 1, true, []*Node{leaf1, leaf2}, []FieldID{0, 0}, 0)
+		return root, leaf2
+	}
+
+	root, _ := build()
+	before := captureDispatcherFingerprint(root)
+	if len(before) != 3 {
+		t.Fatalf("captureDispatcherFingerprint visited %d nodes, want 3 (root + 2 leaves)", len(before))
+	}
+
+	// No-op: capturing twice without any mutation must show no rewrite.
+	if visited, rewritten := diffDispatcherFingerprint(before, captureDispatcherFingerprint(root)); rewritten != 0 || visited == 0 {
+		t.Fatalf("identical snapshots reported visited=%d rewritten=%d, want visited>0 rewritten=0", visited, rewritten)
+	}
+
+	// Span edit: the most common shape of a result-compatibility rewrite
+	// (extending or trimming a node's byte range).
+	root2, leaf2b := build()
+	before2 := captureDispatcherFingerprint(root2)
+	leaf2b.endByte = 9
+	if visited, rewritten := diffDispatcherFingerprint(before2, captureDispatcherFingerprint(root2)); rewritten == 0 {
+		t.Fatalf("span edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
+	// Flag edit: some normalizers mark a node MISSING/EXTRA without touching
+	// its span at all.
+	root3, leaf2c := build()
+	before3 := captureDispatcherFingerprint(root3)
+	leaf2c.setFlag(nodeFlagExtra, true)
+	if visited, rewritten := diffDispatcherFingerprint(before3, captureDispatcherFingerprint(root3)); rewritten == 0 {
+		t.Fatalf("flag edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
+	// Field edit: some normalizers (e.g. normalizeMakeConditionalConsequenceFields)
+	// only reassign which field a child fills, changing neither its span nor
+	// its symbol.
+	root4, _ := build()
+	before4 := captureDispatcherFingerprint(root4)
+	root4.setFieldIDs([]FieldID{0, 7})
+	if visited, rewritten := diffDispatcherFingerprint(before4, captureDispatcherFingerprint(root4)); rewritten == 0 {
+		t.Fatalf("field edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
+	// Structural edit: some normalizers insert a synthesized/recovered node.
+	root5, _ := build()
+	before5 := captureDispatcherFingerprint(root5)
+	arena := newNodeArena(arenaClassFull)
+	extra := newLeafNodeInArena(arena, 12, true, 6, 9, Point{Column: 6}, Point{Column: 9})
+	root5.children = append(root5.children, extra)
+	after5 := captureDispatcherFingerprint(root5)
+	if len(after5) != len(before5)+1 {
+		t.Fatalf("captureDispatcherFingerprint after insertion visited %d nodes, want %d", len(after5), len(before5)+1)
+	}
+	if visited, rewritten := diffDispatcherFingerprint(before5, after5); rewritten == 0 {
+		t.Fatalf("structural insertion went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+}

--- a/parser_result_terminal_leaf_test.go
+++ b/parser_result_terminal_leaf_test.go
@@ -706,6 +706,30 @@ func TestDispatcherArmCensusFingerprintDetectsEveryObservableChange(t *testing.T
 		t.Fatalf("span edit went undetected: visited=%d rewritten=%d", visited, rewritten)
 	}
 
+	// Point edit: a normalizer can repair row and column positions while the
+	// byte range stays unchanged.
+	rootPoint, leafPoint := build()
+	beforePoint := captureDispatcherFingerprint(rootPoint)
+	leafPoint.endPoint = Point{Row: 2, Column: 1}
+	if visited, rewritten := diffDispatcherFingerprint(beforePoint, captureDispatcherFingerprint(rootPoint)); rewritten == 0 {
+		t.Fatalf("point edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
+	// Parser-state edits are public and affect later incremental reuse.
+	rootParseState, leafParseState := build()
+	beforeParseState := captureDispatcherFingerprint(rootParseState)
+	leafParseState.parseState = 41
+	if visited, rewritten := diffDispatcherFingerprint(beforeParseState, captureDispatcherFingerprint(rootParseState)); rewritten == 0 {
+		t.Fatalf("parse-state edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
+	rootPreGotoState, leafPreGotoState := build()
+	beforePreGotoState := captureDispatcherFingerprint(rootPreGotoState)
+	leafPreGotoState.preGotoState = 42
+	if visited, rewritten := diffDispatcherFingerprint(beforePreGotoState, captureDispatcherFingerprint(rootPreGotoState)); rewritten == 0 {
+		t.Fatalf("pre-goto-state edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
 	// Flag edit: some normalizers mark a node MISSING/EXTRA without touching
 	// its span at all.
 	root3, leaf2c := build()
@@ -713,6 +737,13 @@ func TestDispatcherArmCensusFingerprintDetectsEveryObservableChange(t *testing.T
 	leaf2c.setFlag(nodeFlagExtra, true)
 	if visited, rewritten := diffDispatcherFingerprint(before3, captureDispatcherFingerprint(root3)); rewritten == 0 {
 		t.Fatalf("flag edit went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+
+	rootDirty, leafDirty := build()
+	beforeDirty := captureDispatcherFingerprint(rootDirty)
+	leafDirty.setDirty(true)
+	if visited, rewritten := diffDispatcherFingerprint(beforeDirty, captureDispatcherFingerprint(rootDirty)); rewritten == 0 {
+		t.Fatalf("dirty-flag edit went undetected: visited=%d rewritten=%d", visited, rewritten)
 	}
 
 	// Field edit: some normalizers (e.g. normalizeMakeConditionalConsequenceFields)
@@ -737,5 +768,58 @@ func TestDispatcherArmCensusFingerprintDetectsEveryObservableChange(t *testing.T
 	}
 	if visited, rewritten := diffDispatcherFingerprint(before5, after5); rewritten == 0 {
 		t.Fatalf("structural insertion went undetected: visited=%d rewritten=%d", visited, rewritten)
+	}
+}
+
+func TestDispatcherArmCensusFingerprintPreservesCompactFinalChildRefs(t *testing.T) {
+	arena := newNodeArena(arenaClassFull)
+	arena.finalChildRefs = true
+	leaf := newCompactFullLeafInArena(arena, 2, true, 0, 4, Point{}, Point{Column: 4})
+	leaf.parseState = 12
+	leaf.preGotoState = 11
+	parent := newPendingParentInArena(arena, 1, true, 0, []stackEntry{
+		newStackEntryCompactFullLeaf(leaf.parseState, leaf),
+	}, 0, 4, Point{}, Point{Column: 4}, false)
+	parent.parseState = 14
+	parent.preGotoState = 13
+	entry := newStackEntryPendingParent(parent.parseState, parent)
+	root := materializeStackEntryPendingParent(arena, &entry, pendingParentMaterializeForFinalTree)
+	if root == nil || !nodeHasFinalChildRefs(root) {
+		t.Fatal("fixture did not retain compact final-child refs")
+	}
+
+	lazy := captureDispatcherFingerprint(root)
+	if got := arena.finalChildRefsMaterializedParents; got != 0 {
+		t.Fatalf("fingerprint materialized final-child parent ranges = %d, want 0", got)
+	}
+	if got := arena.finalChildRefsSingleChildAccesses; got != 0 {
+		t.Fatalf("fingerprint accessed final-child refs through materialization = %d, want 0", got)
+	}
+	if got := arena.finalChildRefsSingleChildMaterializedChildren; got != 0 {
+		t.Fatalf("fingerprint materialized compact children = %d, want 0", got)
+	}
+	if !nodeHasFinalChildRefs(root) {
+		t.Fatal("fingerprint drained final-child refs")
+	}
+
+	if child := root.Child(0); child == nil {
+		t.Fatal("explicit materialization returned nil child")
+	}
+	eager := captureDispatcherFingerprint(root)
+	if visited, rewritten := diffDispatcherFingerprint(lazy, eager); rewritten != 0 || visited == 0 {
+		t.Fatalf("lazy and materialized fingerprints differ: visited=%d rewritten=%d", visited, rewritten)
+	}
+}
+
+func TestDispatcherCensusRequiresExactOne(t *testing.T) {
+	for _, value := range []string{"", "0", "false", "2"} {
+		t.Setenv("GTS_DISPATCHER_CENSUS", value)
+		if dispatcherCensusEnabled() {
+			t.Fatalf("GTS_DISPATCHER_CENSUS=%q enabled the census", value)
+		}
+	}
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+	if !dispatcherCensusEnabled() {
+		t.Fatal("GTS_DISPATCHER_CENSUS=1 did not enable the census")
 	}
 }

--- a/parser_result_test/dispatcher_census_test.go
+++ b/parser_result_test/dispatcher_census_test.go
@@ -1,0 +1,286 @@
+package parserresult_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// This file implements the R2 "census and remove inert language passes" step
+// of docs/root-normalization-retirement.md for the per-language
+// result-normalization dispatcher (runLanguageResultCompatibility's switch in
+// parser_result_compat.go), which is registered as "dispatcher_arm" /
+// "dispatcher_predicate" entries in testdata/result_compat_ownership_v1.json.
+//
+// KNOWN COVERAGE CHOICE. The generic.terminal-leaf census
+// (parser_result_terminal_leaf_test.go, TestGenericTerminalLeafCensusMultiLanguage)
+// documented that loading grammars with the root package's raw LoadLanguage
+// attaches no external scanner (the root package cannot import
+// gotreesitter/grammars without an import cycle), so many grammars parsed to
+// an error root and their census was vacuous. This package
+// (parser_result_test, package parserresult_test) is an external test package
+// that CAN import gotreesitter/grammars, so this census uses the same
+// grammars.LangEntry.Language() + grammars.AuditParseSupport() production
+// loading path every real parser caller uses (see helpers_test.go's
+// parseByLanguageName), closing that gap rather than reporting it as a limit.
+
+// dispatcherOwnershipEntry mirrors the fields of
+// testdata/result_compat_ownership_v1.json's entries this census needs. It is
+// intentionally a minimal projection, not a full schema type, so this census
+// stays a read-only consumer of the mechanically checked registry.
+type dispatcherOwnershipEntry struct {
+	ID        string   `json:"id"`
+	Kind      string   `json:"kind"`
+	Languages []string `json:"languages"`
+}
+
+type dispatcherOwnershipRegistry struct {
+	Entries []dispatcherOwnershipEntry `json:"entries"`
+}
+
+// dispatcherArmLanguages returns every language name the ownership registry
+// lists under a "dispatcher_arm" or "dispatcher_predicate" entry, and maps
+// each such language to a display arm ID (a language can only ever match one
+// arm, per runLanguageResultCompatibility's switch, so this is a 1:1 map).
+// Languages absent from this set have no dispatcher arm at all: the switch in
+// parser_result_compat.go has no case for them, so they are out of scope for
+// this census, not a coverage failure.
+func dispatcherArmLanguages(t *testing.T) map[string]string {
+	t.Helper()
+	raw, readErr := os.ReadFile(filepath.Join("..", "testdata", "result_compat_ownership_v1.json"))
+	if readErr != nil {
+		t.Fatalf("read result_compat_ownership_v1.json: %v", readErr)
+	}
+	var reg dispatcherOwnershipRegistry
+	if err := json.Unmarshal(raw, &reg); err != nil {
+		t.Fatalf("parse result_compat_ownership_v1.json: %v", err)
+	}
+	langToArm := map[string]string{}
+	for _, e := range reg.Entries {
+		if e.Kind != "dispatcher_arm" && e.Kind != "dispatcher_predicate" {
+			continue
+		}
+		for _, lang := range e.Languages {
+			langToArm[strings.ToLower(lang)] = e.ID
+		}
+	}
+	if len(langToArm) == 0 {
+		t.Fatal("ownership registry listed zero dispatcher_arm/dispatcher_predicate languages: the registry read is broken, not that there are no arms")
+	}
+	return langToArm
+}
+
+// dispatcherLangCensus accumulates the per-language receipt this test
+// reports: how many corpus files were parsed, whether the registered arm
+// actually ran (checked/run counts from (*Parser).recordNormalizationMetric),
+// and the fingerprint-diff visited/rewritten totals.
+type dispatcherLangCensus struct {
+	armID      string
+	files      int
+	checked    uint64
+	run        uint64
+	visited    uint64
+	rewritten  uint64
+	rewriteIn  map[string]uint64 // file -> rewritten, only when > 0
+	errorRoots int
+}
+
+// parseRealCorpusFile parses one real-corpus source file the same way
+// production callers do: through grammars.LangEntry.Language() (attaches the
+// language's external scanner) and the backend
+// grammars.AuditParseSupport() reports for it (DFA vs. token-source).
+func parseRealCorpusFile(entry grammars.LangEntry, backend grammars.ParseBackend, lang *gotreesitter.Language, src []byte) (*gotreesitter.Tree, error) {
+	parser := gotreesitter.NewParser(lang)
+	switch backend {
+	case grammars.ParseBackendTokenSource:
+		if entry.TokenSourceFactory == nil {
+			return nil, fmt.Errorf("token source backend without factory")
+		}
+		return parser.ParseWithTokenSource(src, entry.TokenSourceFactory(src, lang))
+	case grammars.ParseBackendDFA, grammars.ParseBackendDFAPartial:
+		return parser.Parse(src)
+	default:
+		return nil, fmt.Errorf("unsupported backend %q", backend)
+	}
+}
+
+// TestDispatcherArmCensusOverRealCorpus is the R2 census itself. It parses
+// every file in cgo_harness/corpus_real under GTS_DISPATCHER_CENSUS=1 and
+// reports, per language with a registered dispatcher arm, whether the arm
+// ever rewrote the tree.
+//
+// This is a receipt, not a gate: it does not assert zero rewrites, and it
+// does not delete anything. Turning an INERT receipt into a deletion needs
+// the production, compact, forest, incremental, and C-oracle route parity
+// the retirement plan requires (docs/root-normalization-retirement.md, R2).
+func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	const corpusRoot = "../cgo_harness/corpus_real"
+	dirEntries, err := os.ReadDir(corpusRoot)
+	if err != nil {
+		t.Skipf("real corpus unavailable: %v", err)
+	}
+
+	armLanguages := dispatcherArmLanguages(t)
+
+	langEntries := map[string]grammars.LangEntry{}
+	for _, e := range grammars.AllLanguages() {
+		langEntries[e.Name] = e
+	}
+	backends := map[string]grammars.ParseBackend{}
+	for _, report := range grammars.AuditParseSupport() {
+		backends[report.Name] = report.Backend
+	}
+
+	results := map[string]*dispatcherLangCensus{}
+	var uncovered []string     // has a registered arm, but the probe never observed a pass record
+	var notApplicable []string // corpus dir has no registered dispatcher arm at all
+	var noLangEntry []string
+	var parseFailed []string
+
+	for _, dirEntry := range dirEntries {
+		if !dirEntry.IsDir() {
+			continue
+		}
+		name := dirEntry.Name()
+
+		armID, hasArm := armLanguages[name]
+
+		langEntry, ok := langEntries[name]
+		if !ok {
+			noLangEntry = append(noLangEntry, name)
+			continue
+		}
+		backend, ok := backends[name]
+		if !ok {
+			noLangEntry = append(noLangEntry, name)
+			continue
+		}
+
+		files, err := os.ReadDir(filepath.Join(corpusRoot, name))
+		if err != nil {
+			continue
+		}
+
+		lang := langEntry.Language()
+		census := &dispatcherLangCensus{armID: armID, rewriteIn: map[string]uint64{}}
+		filesParsed := 0
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			src, err := os.ReadFile(filepath.Join(corpusRoot, name, f.Name()))
+			if err != nil || len(src) == 0 {
+				continue
+			}
+			tree, err := parseRealCorpusFile(langEntry, backend, lang, src)
+			if err != nil {
+				parseFailed = append(parseFailed, name+"/"+f.Name()+": "+err.Error())
+				continue
+			}
+			if tree == nil || tree.RootNode() == nil {
+				parseFailed = append(parseFailed, name+"/"+f.Name()+": nil tree/root")
+				continue
+			}
+			filesParsed++
+			if tree.RootNode().HasError() {
+				census.errorRoots++
+			}
+			rt := tree.ParseRuntime()
+			if rt.NormalizationPasses == nil {
+				continue
+			}
+			for _, pass := range *rt.NormalizationPasses {
+				if pass.Name != armID {
+					continue
+				}
+				census.checked += pass.Checked
+				census.run += pass.Run
+				census.visited += pass.NodesVisited
+				census.rewritten += pass.NodesRewritten
+				if pass.NodesRewritten > 0 {
+					census.rewriteIn[f.Name()] = pass.NodesRewritten
+				}
+			}
+		}
+		census.files = filesParsed
+		if filesParsed == 0 {
+			continue
+		}
+
+		if !hasArm {
+			notApplicable = append(notApplicable, fmt.Sprintf("%s(files=%d)", name, filesParsed))
+			continue
+		}
+		if census.run == 0 {
+			uncovered = append(uncovered, fmt.Sprintf("%s(files=%d,errorRoots=%d,arm=%s)", name, filesParsed, census.errorRoots, armID))
+			continue
+		}
+		results[name] = census
+	}
+
+	var inert, active []string
+	for name, c := range results {
+		if c.rewritten > 0 {
+			active = append(active, name)
+		} else {
+			inert = append(inert, name)
+		}
+	}
+	sort.Strings(inert)
+	sort.Strings(active)
+	sort.Strings(uncovered)
+	sort.Strings(notApplicable)
+	sort.Strings(noLangEntry)
+	sort.Strings(parseFailed)
+
+	t.Logf("dispatcher-arm census: languages_censused=%d inert=%d active=%d uncovered=%d not_applicable=%d",
+		len(results), len(inert), len(active), len(uncovered), len(notApplicable))
+
+	t.Logf("INERT (ran, changed nothing) [%d]:", len(inert))
+	for _, name := range inert {
+		c := results[name]
+		t.Logf("  %-14s arm=%-28s files=%d checked=%d run=%d visited=%d rewritten=0",
+			name, c.armID, c.files, c.checked, c.run, c.visited)
+	}
+
+	t.Logf("ACTIVE (changed something) [%d]:", len(active))
+	for _, name := range active {
+		c := results[name]
+		t.Logf("  %-14s arm=%-28s files=%d checked=%d run=%d visited=%d rewritten=%d",
+			name, c.armID, c.files, c.checked, c.run, c.visited, c.rewritten)
+		shown := 0
+		for file, n := range c.rewriteIn {
+			if shown >= 5 {
+				break
+			}
+			t.Logf("      rewrote %d position(s) in %s", n, file)
+			shown++
+		}
+	}
+
+	if len(uncovered) > 0 {
+		t.Logf("UNCOVERED (registered arm, probe never observed a pass record) [%d]: %s", len(uncovered), strings.Join(uncovered, " "))
+	}
+	if len(notApplicable) > 0 {
+		t.Logf("NOT APPLICABLE (no dispatcher arm registered for this language) [%d]: %s", len(notApplicable), strings.Join(notApplicable, " "))
+	}
+	if len(noLangEntry) > 0 {
+		t.Logf("no grammars.LangEntry/backend found [%d]: %s", len(noLangEntry), strings.Join(noLangEntry, " "))
+	}
+	if len(parseFailed) > 0 {
+		t.Logf("parse errors [%d]: %s", len(parseFailed), strings.Join(parseFailed, " "))
+	}
+
+	if len(results) == 0 {
+		t.Fatal("dispatcher-arm census covered zero languages: the result is vacuous")
+	}
+}

--- a/parser_result_test/dispatcher_census_test.go
+++ b/parser_result_test/dispatcher_census_test.go
@@ -1,6 +1,7 @@
 package parserresult_test
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -68,7 +69,11 @@ func dispatcherArmLanguages(t *testing.T) map[string]string {
 			continue
 		}
 		for _, lang := range e.Languages {
-			langToArm[strings.ToLower(lang)] = e.ID
+			name := strings.ToLower(lang)
+			if previous, exists := langToArm[name]; exists && previous != e.ID {
+				t.Fatalf("ownership registry assigns language %q to both %q and %q", name, previous, e.ID)
+			}
+			langToArm[name] = e.ID
 		}
 	}
 	if len(langToArm) == 0 {
@@ -92,12 +97,12 @@ type dispatcherLangCensus struct {
 	errorRoots int
 }
 
-// parseRealCorpusFile parses one real-corpus source file the same way
-// production callers do: through grammars.LangEntry.Language() (attaches the
-// language's external scanner) and the backend
-// grammars.AuditParseSupport() reports for it (DFA vs. token-source).
+// parseRealCorpusFile uses the production language loader and backend. It
+// disables the admission candidate so the receipt measures the production
+// parser lane.
 func parseRealCorpusFile(entry grammars.LangEntry, backend grammars.ParseBackend, lang *gotreesitter.Language, src []byte) (*gotreesitter.Tree, error) {
 	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
 	switch backend {
 	case grammars.ParseBackendTokenSource:
 		if entry.TokenSourceFactory == nil {
@@ -141,7 +146,7 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 	}
 
 	results := map[string]*dispatcherLangCensus{}
-	var uncovered []string     // has a registered arm, but the probe never observed a pass record
+	uncoveredByLanguage := map[string]string{}
 	var notApplicable []string // corpus dir has no registered dispatcher arm at all
 	var noLangEntry []string
 	var parseFailed []string
@@ -188,6 +193,9 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 			}
 			if tree == nil || tree.RootNode() == nil {
 				parseFailed = append(parseFailed, name+"/"+f.Name()+": nil tree/root")
+				if tree != nil {
+					tree.Release()
+				}
 				continue
 			}
 			filesParsed++
@@ -195,6 +203,7 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 				census.errorRoots++
 			}
 			rt := tree.ParseRuntime()
+			tree.Release()
 			if rt.NormalizationPasses == nil {
 				continue
 			}
@@ -213,6 +222,9 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 		}
 		census.files = filesParsed
 		if filesParsed == 0 {
+			if hasArm {
+				uncoveredByLanguage[name] = fmt.Sprintf("%s(files=0,errorRoots=0,arm=%s,reason=no-parsed-files)", name, armID)
+			}
 			continue
 		}
 
@@ -221,10 +233,20 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 			continue
 		}
 		if census.run == 0 {
-			uncovered = append(uncovered, fmt.Sprintf("%s(files=%d,errorRoots=%d,arm=%s)", name, filesParsed, census.errorRoots, armID))
+			uncoveredByLanguage[name] = fmt.Sprintf("%s(files=%d,errorRoots=%d,arm=%s,reason=no-pass-record)", name, filesParsed, census.errorRoots, armID)
 			continue
 		}
 		results[name] = census
+	}
+
+	for name, armID := range armLanguages {
+		if _, covered := results[name]; covered {
+			continue
+		}
+		if _, recorded := uncoveredByLanguage[name]; recorded {
+			continue
+		}
+		uncoveredByLanguage[name] = fmt.Sprintf("%s(files=0,errorRoots=0,arm=%s,reason=no-corpus-directory)", name, armID)
 	}
 
 	var inert, active []string
@@ -234,6 +256,10 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 		} else {
 			inert = append(inert, name)
 		}
+	}
+	uncovered := make([]string, 0, len(uncoveredByLanguage))
+	for _, detail := range uncoveredByLanguage {
+		uncovered = append(uncovered, detail)
 	}
 	sort.Strings(inert)
 	sort.Strings(active)
@@ -257,13 +283,17 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 		c := results[name]
 		t.Logf("  %-14s arm=%-28s files=%d checked=%d run=%d visited=%d rewritten=%d",
 			name, c.armID, c.files, c.checked, c.run, c.visited, c.rewritten)
-		shown := 0
-		for file, n := range c.rewriteIn {
-			if shown >= 5 {
+		rewriteFiles := make([]string, 0, len(c.rewriteIn))
+		for file := range c.rewriteIn {
+			rewriteFiles = append(rewriteFiles, file)
+		}
+		sort.Strings(rewriteFiles)
+		for i, file := range rewriteFiles {
+			if i >= 5 {
 				break
 			}
+			n := c.rewriteIn[file]
 			t.Logf("      rewrote %d position(s) in %s", n, file)
-			shown++
 		}
 	}
 
@@ -282,5 +312,119 @@ func TestDispatcherArmCensusOverRealCorpus(t *testing.T) {
 
 	if len(results) == 0 {
 		t.Fatal("dispatcher-arm census covered zero languages: the result is vacuous")
+	}
+}
+
+type trackedDispatcherCensusFixture struct {
+	Language       string `json:"language"`
+	Path           string `json:"path"`
+	SHA256         string `json:"sha256"`
+	ArmID          string `json:"arm_id"`
+	Checked        uint64 `json:"checked"`
+	Run            uint64 `json:"run"`
+	NodesVisited   uint64 `json:"nodes_visited"`
+	NodesRewritten uint64 `json:"nodes_rewritten"`
+	ErrorRoot      bool   `json:"error_root"`
+}
+
+type trackedDispatcherCensusReceipt struct {
+	Schema     string                           `json:"schema"`
+	Limitation string                           `json:"limitation"`
+	Fixtures   []trackedDispatcherCensusFixture `json:"fixtures"`
+}
+
+// TestDispatcherArmCensusTrackedReceipt validates a small tracked corpus on
+// every run. The full authenticated corpus remains an external release gate.
+func TestDispatcherArmCensusTrackedReceipt(t *testing.T) {
+	t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+
+	raw, err := os.ReadFile(filepath.Join("..", "testdata", "dispatcher_census_tracked_v1.json"))
+	if err != nil {
+		t.Fatalf("read tracked dispatcher census receipt: %v", err)
+	}
+	var receipt trackedDispatcherCensusReceipt
+	if err := json.Unmarshal(raw, &receipt); err != nil {
+		t.Fatalf("parse tracked dispatcher census receipt: %v", err)
+	}
+	if receipt.Schema != "gts-dispatcher-census-tracked/v1" {
+		t.Fatalf("tracked dispatcher census schema = %q", receipt.Schema)
+	}
+	if strings.TrimSpace(receipt.Limitation) == "" || len(receipt.Fixtures) == 0 {
+		t.Fatal("tracked dispatcher census receipt lacks its limitation or fixtures")
+	}
+
+	armLanguages := dispatcherArmLanguages(t)
+	langEntries := map[string]grammars.LangEntry{}
+	for _, entry := range grammars.AllLanguages() {
+		langEntries[entry.Name] = entry
+	}
+	backends := map[string]grammars.ParseBackend{}
+	for _, report := range grammars.AuditParseSupport() {
+		backends[report.Name] = report.Backend
+	}
+
+	previousKey := ""
+	for _, fixture := range receipt.Fixtures {
+		key := fixture.Language + "\x00" + fixture.Path
+		if key <= previousKey {
+			t.Fatalf("tracked dispatcher census fixtures are not strictly sorted at %q", key)
+		}
+		previousKey = key
+		if fixture.Checked == 0 || fixture.Run == 0 || fixture.NodesVisited == 0 {
+			t.Fatalf("%s has a vacuous tracked census receipt", fixture.Path)
+		}
+		armID, ok := armLanguages[fixture.Language]
+		if !ok || armID != fixture.ArmID {
+			t.Fatalf("%s arm = %q, want %q", fixture.Language, armID, fixture.ArmID)
+		}
+		entry, ok := langEntries[fixture.Language]
+		if !ok {
+			t.Fatalf("%s has no grammar entry", fixture.Language)
+		}
+		backend, ok := backends[fixture.Language]
+		if !ok {
+			t.Fatalf("%s has no parse backend", fixture.Language)
+		}
+		src, err := os.ReadFile(filepath.Join("..", filepath.FromSlash(fixture.Path)))
+		if err != nil {
+			t.Fatalf("read %s: %v", fixture.Path, err)
+		}
+		if got := fmt.Sprintf("%x", sha256.Sum256(src)); got != fixture.SHA256 {
+			t.Fatalf("%s SHA-256 = %s, want %s", fixture.Path, got, fixture.SHA256)
+		}
+
+		tree, err := parseRealCorpusFile(entry, backend, entry.Language(), src)
+		if err != nil {
+			t.Fatalf("%s parse: %v", fixture.Path, err)
+		}
+		if tree == nil || tree.RootNode() == nil {
+			if tree != nil {
+				tree.Release()
+			}
+			t.Fatalf("%s returned a nil tree or root", fixture.Path)
+		}
+		errorRoot := tree.RootNode().HasError()
+		rt := tree.ParseRuntime()
+		tree.Release()
+
+		var checked, run, visited, rewritten uint64
+		if rt.NormalizationPasses != nil {
+			for _, pass := range *rt.NormalizationPasses {
+				if pass.Name != fixture.ArmID {
+					continue
+				}
+				checked += pass.Checked
+				run += pass.Run
+				visited += pass.NodesVisited
+				rewritten += pass.NodesRewritten
+			}
+		}
+		if checked != fixture.Checked || run != fixture.Run ||
+			visited != fixture.NodesVisited || rewritten != fixture.NodesRewritten ||
+			errorRoot != fixture.ErrorRoot {
+			t.Errorf("%s census = checked:%d run:%d visited:%d rewritten:%d error_root:%t, want checked:%d run:%d visited:%d rewritten:%d error_root:%t",
+				fixture.Path, checked, run, visited, rewritten, errorRoot,
+				fixture.Checked, fixture.Run, fixture.NodesVisited, fixture.NodesRewritten, fixture.ErrorRoot)
+		}
 	}
 }

--- a/testdata/dispatcher_census_tracked_v1.json
+++ b/testdata/dispatcher_census_tracked_v1.json
@@ -1,0 +1,83 @@
+{
+  "schema": "gts-dispatcher-census-tracked/v1",
+  "limitation": "This tracked corpus is a CI ratchet. The full authenticated corpus remains an external release gate.",
+  "fixtures": [
+    {
+      "language": "c_sharp",
+      "path": "testdata/parser_result/csharp/jsontextreader_excerpt.cs",
+      "sha256": "d76fd62cfc90076c11d86cb7d7a0058df181231aa3b34f30e549f650b5294d4a",
+      "arm_id": "dispatch.c_sharp",
+      "checked": 1,
+      "run": 1,
+      "nodes_visited": 2093,
+      "nodes_rewritten": 2085,
+      "error_root": false
+    },
+    {
+      "language": "caddy",
+      "path": "testdata/caddy/security-header.Caddyfile",
+      "sha256": "d8b46d494010164bf3e600259fd7d175c2dabdcd8652accfe361b8f123810391",
+      "arm_id": "dispatch.shared_trailing_span",
+      "checked": 1,
+      "run": 1,
+      "nodes_visited": 47,
+      "nodes_rewritten": 0,
+      "error_root": true
+    },
+    {
+      "language": "go",
+      "path": "cgo_harness/corpus_structural/go_sample.go",
+      "sha256": "262c7b8359a364b56db8549f65f4f2e01ed43de096e607dd05f50b94bd45efb0",
+      "arm_id": "dispatch.go",
+      "checked": 1,
+      "run": 1,
+      "nodes_visited": 768,
+      "nodes_rewritten": 0,
+      "error_root": false
+    },
+    {
+      "language": "javascript",
+      "path": "cgo_harness/corpus_structural/javascript_sample.js",
+      "sha256": "d84deac86ad03c7f23ef4a257aba49ca1ad40e4fd89a5a501e461b45bd099faa",
+      "arm_id": "dispatch.javascript",
+      "checked": 2,
+      "run": 2,
+      "nodes_visited": 2444,
+      "nodes_rewritten": 0,
+      "error_root": false
+    },
+    {
+      "language": "python",
+      "path": "cgo_harness/corpus_structural/python_sample.py",
+      "sha256": "3de858b73ba43ad3c2d43b9cfc08426f62dd4ae7bcf1358e3989ed311b435157",
+      "arm_id": "dispatch.python",
+      "checked": 1,
+      "run": 1,
+      "nodes_visited": 1547,
+      "nodes_rewritten": 0,
+      "error_root": false
+    },
+    {
+      "language": "rust",
+      "path": "testdata/incremental_gate/rust_ast.rs",
+      "sha256": "43fc2344174da29bb3c032b260a009828e4636965c1ab8cfff62b651caf91b92",
+      "arm_id": "dispatch.rust",
+      "checked": 1,
+      "run": 1,
+      "nodes_visited": 17506,
+      "nodes_rewritten": 0,
+      "error_root": false
+    },
+    {
+      "language": "typescript",
+      "path": "cgo_harness/corpus_structural/typescript_sample.ts",
+      "sha256": "40b4a7a06fde353d8c2b726acb16f59aab44d49d1b6257c37345c2a1f56b9fb7",
+      "arm_id": "dispatch.typescript",
+      "checked": 1,
+      "run": 1,
+      "nodes_visited": 1462,
+      "nodes_rewritten": 20,
+      "error_root": false
+    }
+  ]
+}

--- a/tree.go
+++ b/tree.go
@@ -2357,9 +2357,19 @@ func (t *Tree) ensureResultCompatibility() {
 			return
 		}
 		if !parsePhaseTimingEnabled() {
-			result := normalizeResultCompatibility(t.root, t.source, &Parser{language: t.language}, nil)
+			parser := &Parser{language: t.language}
+			result := normalizeResultCompatibility(t.root, t.source, parser, nil)
 			t.resultErrorSummary = result.errorSummary
 			t.resultCompatibilityApplied = !parseStopReasonIsActive(result.stopReason)
+			// Diagnostic-only, mirrors the timing-enabled branch below: without
+			// this, every deferred-compatibility language (ini always;
+			// typescript/tsx by default, see shouldDeferResultCompatibility) would
+			// look UNCOVERED to the dispatcher-arm census
+			// (GTS_DISPATCHER_CENSUS, parser_result_compat.go) even though its
+			// normalizer just ran on the line above. parser.normalizationStats is
+			// only ever non-empty when that census flag is set, so this is a
+			// no-op field copy in every ordinary parse.
+			parser.copyNormalizationStats(&t.parseRuntime)
 			t.finishDeferredResultCompatibility(result)
 			return
 		}


### PR DESCRIPTION
Receipt-only census machinery for R2 of `docs/root-normalization-retirement.md`, plus two normalization-stats wiring gaps it depends on.

## What it does

Wraps every arm of `runLanguageResultCompatibility` in an exact structural-fingerprint diff. The non-materializing preorder signature covers symbols, byte and point ranges, children, fields, public states, content flags, and change state. Only `GTS_DISPATCHER_CENSUS=1` enables the probe. The probe preserves compact final-child references. Multi-function arms remain one census unit.

Also closes two routes that built a `ParseRuntime` without calling `copyNormalizationStats` — the forest fast path (`tryForestFastPath`, `ParseForestExperimental`) and the deferred/lazy path (`ensureResultCompatibility`). Without these, javascript (forest) and typescript/tsx/ini (deferred) reported as uncovered even though their arms genuinely ran.

## Controls

The controls required by the plan pass:
- **Mechanism**: the fingerprint catches point, state, span, flag, field, change-state, and structural edits.
- **Representation**: compact and Python controls prove that the snapshot does not materialize lazy children.
- **Production wiring**: `dispatch.make` records `rewritten=1` through the real compatibility entry point.
- **Forest reuse**: success, decline, and fallback tests reject stale normalization counters.

## Verification

- Flag unset is byte-identical: 12 languages × 20 sources × 2 parses, zero structural mismatches.
- No hidden cost when disabled: `BenchmarkSelfParse` 210–220M ns/op baseline vs 206–212M patched, allocs within noise.
- Overwrite risk traced: each route writes the `Normalization*` fields exactly once — no route clobbers another's stats.
- `sync.Once` race checked: 96-goroutine concurrent-reader stress under `-race`, 10×, zero races.
- Full root suite passes twice at 167s. Root `.go` count unchanged at 527 (census lives in `parser_result_test/`).

## Reading the results

`rewritten == 0` is an exact INERT receipt; `rewritten > 0` is an exact ACTIVE receipt. **The magnitude is a positional-diff approximation** and must not be read as edit distance — an insertion near the root shifts every later preorder index.

The full corpus test derives coverage from the ownership registry. It reports each registered language as censused, uncovered, or explicitly exempt.

A tracked seven-language receipt runs in CI and checks exact counts. The full authenticated corpus remains external and optional.