### PR TITLE
add governed Thursday release train

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,480 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact vX.Y.Z release version
+        required: true
+        type: string
+      candidate_sha:
+        description: Exact lowercase 40-character main commit hash
+        required: true
+        type: string
+      release_kind:
+        description: Governed release route
+        required: true
+        type: choice
+        options:
+          - planned-minor
+          - urgent-patch
+      receipt_uri:
+        description: Governing Hyphae release receipt
+        required: true
+        type: string
+      incident:
+        description: Urgent patch incident
+        required: false
+        type: string
+      why_waiting_is_worse:
+        description: Reason that an urgent patch cannot wait
+        required: false
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  ARBITER_VERSION: "1.9.0"
+  ARBITER_LINUX_AMD64_SHA256: c6c5c6c069d33cc39b689201f30d4561472d6ed59731e3ba395b44079e53af38
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      VERSION: ${{ inputs.version }}
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      RELEASE_KIND: ${{ inputs.release_kind }}
+      RECEIPT_URI: ${{ inputs.receipt_uri }}
+      INCIDENT: ${{ inputs.incident }}
+      WHY_WAITING_IS_WORSE: ${{ inputs.why_waiting_is_worse }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Require a main workflow revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_SHA" = "$CANDIDATE_SHA"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install the pinned Arbiter CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/arbiter.tar.gz"
+          bin_dir="$RUNNER_TEMP/arbiter-bin"
+          url="https://github.com/odvcencio/arbiter/releases/download/v$ARBITER_VERSION/arbiter_${ARBITER_VERSION}_linux_amd64.tar.gz"
+          curl --fail --silent --show-error --location "$url" --output "$archive"
+          echo "$ARBITER_LINUX_AMD64_SHA256  $archive" | sha256sum --check -
+          mkdir -p "$bin_dir"
+          tar --extract --gzip --file "$archive" --directory "$bin_dir" arbiter
+          chmod 0755 "$bin_dir/arbiter"
+          echo "$bin_dir" >> "$GITHUB_PATH"
+
+      - name: Test the release policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          arbiter check policy/release.arb
+          arbiter fmt --check policy/release.arb policy/release.test.arb
+          arbiter test policy/release.test.arb
+
+      - id: facts
+        name: Collect main and hosted check facts
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          main_exact_candidate=false
+          if test "$main_sha" = "$CANDIDATE_SHA"; then
+            main_exact_candidate=true
+          fi
+
+          latest_tag="$(git tag --list --sort=-version:refname |
+            awk '$0 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ && first == "" { first=$0 } END { print first }')"
+          test -n "$latest_tag"
+
+          response="$RUNNER_TEMP/ci-runs.json"
+          url="https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$CANDIDATE_SHA&status=completed&event=workflow_dispatch&per_page=100"
+          if ! status="$(curl --silent --show-error --location \
+            --output "$response" --write-out '%{http_code}' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "$url")"; then
+            echo "The hosted check query failed." >&2
+            exit 1
+          fi
+          if test "$status" != "200"; then
+            jq -r '.message // "The hosted check query returned an error."' "$response" >&2
+            exit 1
+          fi
+
+          jq --arg sha "$CANDIDATE_SHA" \
+            '[.workflow_runs[] | select(
+              .head_sha == $sha
+              and .status == "completed"
+              and .event == "workflow_dispatch"
+            )] | sort_by([.run_number, .run_attempt]) | last' \
+            "$response" > "$RUNNER_TEMP/ci-run.json"
+
+          ci_run_id=""
+          ci_run_url=""
+          ci_event=""
+          ci_sha=""
+          ci_conclusion=""
+          ci_completed_at=""
+          if jq -e '. != null' "$RUNNER_TEMP/ci-run.json" >/dev/null; then
+            ci_run_id="$(jq -r '.id | tostring' "$RUNNER_TEMP/ci-run.json")"
+            ci_run_url="$(jq -r '.html_url // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_event="$(jq -r '.event // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_sha="$(jq -r '.head_sha // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_conclusion="$(jq -r '.conclusion // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_completed_at="$(jq -r '.updated_at // ""' "$RUNNER_TEMP/ci-run.json")"
+          fi
+
+          {
+            echo "main_exact_candidate=$main_exact_candidate"
+            echo "latest_tag=$latest_tag"
+            echo "ci_run_id=$ci_run_id"
+            echo "ci_run_url=$ci_run_url"
+            echo "ci_event=$ci_event"
+            echo "ci_sha=$ci_sha"
+            echo "ci_conclusion=$ci_conclusion"
+            echo "ci_completed_at=$ci_completed_at"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: presence
+        name: Collect tag and release facts
+        shell: bash
+        run: |
+          set -euo pipefail
+          query_absence() {
+            local label="$1"
+            local url="$2"
+            local body="$RUNNER_TEMP/${label}.json"
+            local status
+            if ! status="$(curl --silent --show-error --location \
+              --output "$body" --write-out '%{http_code}' \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$url")"; then
+              echo "The $label query failed." >&2
+              exit 1
+            fi
+            if test "$status" = "404"; then
+              echo "true"
+              return
+            fi
+            if test "$status" = "200"; then
+              echo "false"
+              return
+            fi
+            jq -r '.message // "The GitHub query returned an error."' "$body" >&2
+            exit 1
+          }
+
+          api="https://api.github.com/repos/$GITHUB_REPOSITORY"
+          tag_absent="$(query_absence "tag" "$api/git/ref/tags/$VERSION")"
+          release_absent="$(query_absence "release" "$api/releases/tags/$VERSION")"
+          {
+            echo "tag_absent=$tag_absent"
+            echo "release_absent=$release_absent"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Test the release validator
+        run: go test ./cmd/releasegate -count=1
+
+      - name: Validate release evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/releasegate-verify"
+          go run ./cmd/releasegate \
+            -version "$VERSION" \
+            -candidate-sha "$CANDIDATE_SHA" \
+            -release-kind "$RELEASE_KIND" \
+            -receipt-uri "$RECEIPT_URI" \
+            -incident "$INCIDENT" \
+            -why-waiting-is-worse "$WHY_WAITING_IS_WORSE" \
+            -latest-tag "${{ steps.facts.outputs.latest_tag }}" \
+            -ci-run-id "${{ steps.facts.outputs.ci_run_id }}" \
+            -ci-run-url "${{ steps.facts.outputs.ci_run_url }}" \
+            -ci-event "${{ steps.facts.outputs.ci_event }}" \
+            -ci-sha "${{ steps.facts.outputs.ci_sha }}" \
+            -ci-conclusion "${{ steps.facts.outputs.ci_conclusion }}" \
+            -ci-completed-at "${{ steps.facts.outputs.ci_completed_at }}" \
+            -main-exact-candidate="${{ steps.facts.outputs.main_exact_candidate }}" \
+            -tag-absent="${{ steps.presence.outputs.tag_absent }}" \
+            -release-absent="${{ steps.presence.outputs.release_absent }}" \
+            -output-directory "$output"
+
+      - name: Decide release publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/releasegate-verify"
+          arbiter strategy policy/release.arb \
+            --name ReleasePublication \
+            --data "$(jq --compact-output . "$output/policy-facts.json")" \
+            > "$output/policy-decision.json"
+          jq -r '"- Arbiter decision: `\(.selected)`\n- Arbiter reason: \(.params.reason)"' \
+            "$output/policy-decision.json" >> "$output/summary.md"
+          jq -e '.selected == "Allow" and .params.action == "allow"' \
+            "$output/policy-decision.json" >/dev/null
+
+      - name: Preserve verification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-gate-${{ inputs.version }}
+          path: ${{ runner.temp }}/releasegate-verify
+          if-no-files-found: error
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+      contents: write
+    env:
+      VERSION: ${{ inputs.version }}
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      RELEASE_KIND: ${{ inputs.release_kind }}
+      RECEIPT_URI: ${{ inputs.receipt_uri }}
+      INCIDENT: ${{ inputs.incident }}
+      WHY_WAITING_IS_WORSE: ${{ inputs.why_waiting_is_worse }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Require the original main workflow revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$GITHUB_SHA" = "$CANDIDATE_SHA"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.candidate_sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install the pinned Arbiter CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/arbiter.tar.gz"
+          bin_dir="$RUNNER_TEMP/arbiter-bin"
+          url="https://github.com/odvcencio/arbiter/releases/download/v$ARBITER_VERSION/arbiter_${ARBITER_VERSION}_linux_amd64.tar.gz"
+          curl --fail --silent --show-error --location "$url" --output "$archive"
+          echo "$ARBITER_LINUX_AMD64_SHA256  $archive" | sha256sum --check -
+          mkdir -p "$bin_dir"
+          tar --extract --gzip --file "$archive" --directory "$bin_dir" arbiter
+          chmod 0755 "$bin_dir/arbiter"
+          echo "$bin_dir" >> "$GITHUB_PATH"
+
+      - id: facts
+        name: Recollect main and hosted check facts
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --force --tags origin refs/heads/main:refs/remotes/origin/main
+          main_sha="$(git rev-parse refs/remotes/origin/main)"
+          main_exact_candidate=false
+          if test "$main_sha" = "$CANDIDATE_SHA"; then
+            main_exact_candidate=true
+          fi
+
+          latest_tag="$(git tag --list --sort=-version:refname |
+            awk '$0 ~ /^v[0-9]+\.[0-9]+\.[0-9]+$/ && first == "" { first=$0 } END { print first }')"
+          test -n "$latest_tag"
+
+          response="$RUNNER_TEMP/ci-runs.json"
+          url="https://api.github.com/repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$CANDIDATE_SHA&status=completed&event=workflow_dispatch&per_page=100"
+          if ! status="$(curl --silent --show-error --location \
+            --output "$response" --write-out '%{http_code}' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "$url")"; then
+            echo "The hosted check query failed." >&2
+            exit 1
+          fi
+          if test "$status" != "200"; then
+            jq -r '.message // "The hosted check query returned an error."' "$response" >&2
+            exit 1
+          fi
+
+          jq --arg sha "$CANDIDATE_SHA" \
+            '[.workflow_runs[] | select(
+              .head_sha == $sha
+              and .status == "completed"
+              and .event == "workflow_dispatch"
+            )] | sort_by([.run_number, .run_attempt]) | last' \
+            "$response" > "$RUNNER_TEMP/ci-run.json"
+
+          ci_run_id=""
+          ci_run_url=""
+          ci_event=""
+          ci_sha=""
+          ci_conclusion=""
+          ci_completed_at=""
+          if jq -e '. != null' "$RUNNER_TEMP/ci-run.json" >/dev/null; then
+            ci_run_id="$(jq -r '.id | tostring' "$RUNNER_TEMP/ci-run.json")"
+            ci_run_url="$(jq -r '.html_url // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_event="$(jq -r '.event // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_sha="$(jq -r '.head_sha // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_conclusion="$(jq -r '.conclusion // ""' "$RUNNER_TEMP/ci-run.json")"
+            ci_completed_at="$(jq -r '.updated_at // ""' "$RUNNER_TEMP/ci-run.json")"
+          fi
+
+          {
+            echo "main_exact_candidate=$main_exact_candidate"
+            echo "latest_tag=$latest_tag"
+            echo "ci_run_id=$ci_run_id"
+            echo "ci_run_url=$ci_run_url"
+            echo "ci_event=$ci_event"
+            echo "ci_sha=$ci_sha"
+            echo "ci_conclusion=$ci_conclusion"
+            echo "ci_completed_at=$ci_completed_at"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: presence
+        name: Recollect tag and release facts
+        shell: bash
+        run: |
+          set -euo pipefail
+          query_absence() {
+            local label="$1"
+            local url="$2"
+            local body="$RUNNER_TEMP/${label}.json"
+            local status
+            if ! status="$(curl --silent --show-error --location \
+              --output "$body" --write-out '%{http_code}' \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$url")"; then
+              echo "The $label query failed." >&2
+              exit 1
+            fi
+            if test "$status" = "404"; then
+              echo "true"
+              return
+            fi
+            if test "$status" = "200"; then
+              echo "false"
+              return
+            fi
+            jq -r '.message // "The GitHub query returned an error."' "$body" >&2
+            exit 1
+          }
+
+          api="https://api.github.com/repos/$GITHUB_REPOSITORY"
+          tag_absent="$(query_absence "tag" "$api/git/ref/tags/$VERSION")"
+          release_absent="$(query_absence "release" "$api/releases/tags/$VERSION")"
+          {
+            echo "tag_absent=$tag_absent"
+            echo "release_absent=$release_absent"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Revalidate release evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/releasegate-publish"
+          go run ./cmd/releasegate \
+            -version "$VERSION" \
+            -candidate-sha "$CANDIDATE_SHA" \
+            -release-kind "$RELEASE_KIND" \
+            -receipt-uri "$RECEIPT_URI" \
+            -incident "$INCIDENT" \
+            -why-waiting-is-worse "$WHY_WAITING_IS_WORSE" \
+            -latest-tag "${{ steps.facts.outputs.latest_tag }}" \
+            -ci-run-id "${{ steps.facts.outputs.ci_run_id }}" \
+            -ci-run-url "${{ steps.facts.outputs.ci_run_url }}" \
+            -ci-event "${{ steps.facts.outputs.ci_event }}" \
+            -ci-sha "${{ steps.facts.outputs.ci_sha }}" \
+            -ci-conclusion "${{ steps.facts.outputs.ci_conclusion }}" \
+            -ci-completed-at "${{ steps.facts.outputs.ci_completed_at }}" \
+            -main-exact-candidate="${{ steps.facts.outputs.main_exact_candidate }}" \
+            -tag-absent="${{ steps.presence.outputs.tag_absent }}" \
+            -release-absent="${{ steps.presence.outputs.release_absent }}" \
+            -output-directory "$output"
+
+      - name: Reevaluate release publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/releasegate-publish"
+          arbiter strategy policy/release.arb \
+            --name ReleasePublication \
+            --data "$(jq --compact-output . "$output/policy-facts.json")" \
+            > "$output/policy-decision.json"
+          jq -r '"- Arbiter decision: `\(.selected)`\n- Arbiter reason: \(.params.reason)"' \
+            "$output/policy-decision.json" >> "$output/summary.md"
+          jq -e '.selected == "Allow" and .params.action == "allow"' \
+            "$output/policy-decision.json" >/dev/null
+
+      - name: Publish the immutable tag and release
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/releasegate-publish"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --force origin refs/heads/main:refs/remotes/origin/main
+          test "$(git rev-parse refs/remotes/origin/main)" = "$CANDIDATE_SHA"
+          git tag --annotate "$VERSION" "$CANDIDATE_SHA" --message "gotreesitter $VERSION"
+          git push origin "refs/tags/$VERSION:refs/tags/$VERSION"
+          gh release create "$VERSION" \
+            --verify-tag \
+            --title "$(cat "$output/title.txt")" \
+            --notes-file "$output/notes.md"
+
+      - name: Verify the published release
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/releasegate-publish"
+          peeled_sha="$(git ls-remote --tags origin "refs/tags/$VERSION^{}" | awk '{print $1}')"
+          test "$peeled_sha" = "$CANDIDATE_SHA"
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$VERSION" > "$RUNNER_TEMP/release.json"
+          jq -e --arg version "$VERSION" \
+            '.tag_name == $version and .draft == false and .prerelease == false' \
+            "$RUNNER_TEMP/release.json" >/dev/null
+          {
+            echo
+            echo "- Verified remote tag commit: \`$peeled_sha\`"
+            echo "- Verified GitHub release: \`$VERSION\`"
+          } >> "$output/summary.md"
+
+      - name: Preserve publication evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-publication-${{ inputs.version }}
+          path: ${{ runner.temp }}/releasegate-publish
+          if-no-files-found: error

--- a/cmd/releasegate/main.go
+++ b/cmd/releasegate/main.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const losAngelesZone = "America/Los_Angeles"
+
+var (
+	releaseVersionPattern = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+	shaPattern            = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
+type releaseVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+type validationInput struct {
+	Version            string
+	CandidateSHA       string
+	ReleaseKind        string
+	ReceiptURI         string
+	Incident           string
+	WhyWaitingIsWorse  string
+	LatestTag          string
+	CIRunID            string
+	CIRunURL           string
+	CIEvent            string
+	CISHA              string
+	CIConclusion       string
+	CICompletedAt      string
+	MainExactCandidate bool
+	TagAbsent          bool
+	ReleaseAbsent      bool
+	RepositoryRoot     string
+	Now                time.Time
+}
+
+type releasePolicyFacts struct {
+	Kind                  string `json:"kind"`
+	VersionIncrement      string `json:"version_increment"`
+	LosAngelesThursday    bool   `json:"los_angeles_thursday"`
+	SoakSeconds           int64  `json:"soak_seconds"`
+	IncidentPresent       bool   `json:"incident_present"`
+	DelayRationalePresent bool   `json:"delay_rationale_present"`
+}
+
+type evidencePolicyFacts struct {
+	MainExactCandidate      bool `json:"main_exact_candidate"`
+	CIExactCandidate        bool `json:"ci_exact_candidate"`
+	CIFullDispatch          bool `json:"ci_full_dispatch"`
+	CISuccessful            bool `json:"ci_successful"`
+	CICompletionNotFuture   bool `json:"ci_completion_not_future"`
+	TagAbsent               bool `json:"tag_absent"`
+	ReleaseAbsent           bool `json:"release_absent"`
+	ReceiptValid            bool `json:"receipt_valid"`
+	ChangelogSectionPresent bool `json:"changelog_section_present"`
+	ChangelogNotesPresent   bool `json:"changelog_notes_present"`
+	ChangelogDateMatches    bool `json:"changelog_date_matches"`
+	ReadmeMatches           bool `json:"readme_matches"`
+	UnreleasedLinkMatches   bool `json:"unreleased_link_matches"`
+	VersionLinkMatches      bool `json:"version_link_matches"`
+}
+
+type policyFacts struct {
+	Release  releasePolicyFacts  `json:"release"`
+	Evidence evidencePolicyFacts `json:"evidence"`
+}
+
+type ciRunEvidence struct {
+	RunID       string `json:"run_id"`
+	URL         string `json:"url"`
+	Event       string `json:"event"`
+	SHA         string `json:"sha"`
+	Conclusion  string `json:"conclusion"`
+	CompletedAt string `json:"completed_at"`
+}
+
+type validationResult struct {
+	Title       string
+	Notes       string
+	Summary     string
+	PolicyFacts policyFacts
+	CIRun       ciRunEvidence
+}
+
+func main() {
+	var input validationInput
+	var outputDirectory string
+
+	flag.StringVar(&input.Version, "version", "", "release version")
+	flag.StringVar(&input.CandidateSHA, "candidate-sha", "", "release candidate commit")
+	flag.StringVar(&input.ReleaseKind, "release-kind", "", "release route")
+	flag.StringVar(&input.ReceiptURI, "receipt-uri", "", "Hyphae release receipt")
+	flag.StringVar(&input.Incident, "incident", "", "urgent patch incident")
+	flag.StringVar(&input.WhyWaitingIsWorse, "why-waiting-is-worse", "", "urgent patch delay rationale")
+	flag.StringVar(&input.LatestTag, "latest-tag", "", "latest stable tag")
+	flag.StringVar(&input.CIRunID, "ci-run-id", "", "hosted check run identifier")
+	flag.StringVar(&input.CIRunURL, "ci-run-url", "", "hosted check run URL")
+	flag.StringVar(&input.CIEvent, "ci-event", "", "hosted check run event")
+	flag.StringVar(&input.CISHA, "ci-sha", "", "hosted check commit")
+	flag.StringVar(&input.CIConclusion, "ci-conclusion", "", "hosted check conclusion")
+	flag.StringVar(&input.CICompletedAt, "ci-completed-at", "", "hosted check completion time")
+	flag.BoolVar(&input.MainExactCandidate, "main-exact-candidate", false, "current main matches the candidate")
+	flag.BoolVar(&input.TagAbsent, "tag-absent", false, "remote tag is absent")
+	flag.BoolVar(&input.ReleaseAbsent, "release-absent", false, "GitHub release is absent")
+	flag.StringVar(&input.RepositoryRoot, "repository-root", ".", "repository root")
+	flag.StringVar(&outputDirectory, "output-directory", "", "artifact output directory")
+	flag.Parse()
+
+	input.Now = time.Now()
+	result, err := collectReleaseEvidence(input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "release evidence failed: %v\n", err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(outputDirectory) == "" {
+		fmt.Fprintln(os.Stderr, "release evidence failed: output directory is required")
+		os.Exit(1)
+	}
+	if err := writeResult(outputDirectory, result); err != nil {
+		fmt.Fprintf(os.Stderr, "release evidence failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func collectReleaseEvidence(input validationInput) (validationResult, error) {
+	version, err := parseReleaseVersion(input.Version)
+	if err != nil {
+		return validationResult{}, err
+	}
+	latest, err := parseReleaseVersion(input.LatestTag)
+	if err != nil {
+		return validationResult{}, fmt.Errorf("latest stable tag: %w", err)
+	}
+	if !shaPattern.MatchString(input.CandidateSHA) {
+		return validationResult{}, errors.New("candidate commit must contain 40 lowercase hexadecimal characters")
+	}
+
+	location, err := time.LoadLocation(losAngelesZone)
+	if err != nil {
+		return validationResult{}, fmt.Errorf("load release time zone: %w", err)
+	}
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	localNow := now.In(location)
+
+	completedAt, completionErr := time.Parse(time.RFC3339, input.CICompletedAt)
+	actualSoak := time.Duration(0)
+	if completionErr == nil {
+		actualSoak = now.Sub(completedAt)
+	}
+
+	changelog, err := os.ReadFile(filepath.Join(input.RepositoryRoot, "CHANGELOG.md"))
+	if err != nil {
+		return validationResult{}, fmt.Errorf("read changelog: %w", err)
+	}
+	readme, err := os.ReadFile(filepath.Join(input.RepositoryRoot, "README.md"))
+	if err != nil {
+		return validationResult{}, fmt.Errorf("read README: %w", err)
+	}
+
+	notes, date, sectionPresent, notesPresent := extractVersionNotes(string(changelog), input.Version)
+	unreleasedLink := "[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/" + input.Version + "...HEAD"
+	versionLink := "[" + strings.TrimPrefix(input.Version, "v") + "]: https://github.com/odvcencio/gotreesitter/compare/" +
+		input.LatestTag + "..." + input.Version
+	receipt := strings.TrimSpace(input.ReceiptURI)
+
+	facts := policyFacts{
+		Release: releasePolicyFacts{
+			Kind:                  input.ReleaseKind,
+			VersionIncrement:      classifyVersionIncrement(version, latest),
+			LosAngelesThursday:    localNow.Weekday() == time.Thursday,
+			SoakSeconds:           int64(actualSoak / time.Second),
+			IncidentPresent:       strings.TrimSpace(input.Incident) != "",
+			DelayRationalePresent: strings.TrimSpace(input.WhyWaitingIsWorse) != "",
+		},
+		Evidence: evidencePolicyFacts{
+			MainExactCandidate:      input.MainExactCandidate,
+			CIExactCandidate:        input.CISHA == input.CandidateSHA,
+			CIFullDispatch:          input.CIEvent == "workflow_dispatch",
+			CISuccessful:            input.CIConclusion == "success",
+			CICompletionNotFuture:   completionErr == nil && !now.Before(completedAt),
+			TagAbsent:               input.TagAbsent,
+			ReleaseAbsent:           input.ReleaseAbsent,
+			ReceiptValid:            strings.HasPrefix(receipt, "hypha://") && len(receipt) > len("hypha://"),
+			ChangelogSectionPresent: sectionPresent,
+			ChangelogNotesPresent:   notesPresent,
+			ChangelogDateMatches:    sectionPresent && date == localNow.Format("2006-01-02"),
+			ReadmeMatches:           strings.Contains(string(readme), "The current release is **"+input.Version+"**."),
+			UnreleasedLinkMatches:   containsLine(string(changelog), unreleasedLink),
+			VersionLinkMatches:      containsLine(string(changelog), versionLink),
+		},
+	}
+
+	return validationResult{
+		Title:       "gotreesitter " + input.Version,
+		Notes:       notes,
+		Summary:     buildSummary(input, localNow, completedAt, completionErr == nil, actualSoak, facts),
+		PolicyFacts: facts,
+		CIRun: ciRunEvidence{
+			RunID:       input.CIRunID,
+			URL:         input.CIRunURL,
+			Event:       input.CIEvent,
+			SHA:         input.CISHA,
+			Conclusion:  input.CIConclusion,
+			CompletedAt: input.CICompletedAt,
+		},
+	}, nil
+}
+
+func classifyVersionIncrement(version, latest releaseVersion) string {
+	if version.major == latest.major && version.minor == latest.minor+1 && version.patch == 0 {
+		return "next-minor"
+	}
+	if version.major == latest.major && version.minor == latest.minor && version.patch == latest.patch+1 {
+		return "next-patch"
+	}
+	return "other"
+}
+
+func parseReleaseVersion(value string) (releaseVersion, error) {
+	match := releaseVersionPattern.FindStringSubmatch(value)
+	if match == nil {
+		return releaseVersion{}, fmt.Errorf("version %q must use vX.Y.Z", value)
+	}
+	var version releaseVersion
+	if _, err := fmt.Sscanf(value, "v%d.%d.%d", &version.major, &version.minor, &version.patch); err != nil {
+		return releaseVersion{}, fmt.Errorf("parse version %q: %w", value, err)
+	}
+	return version, nil
+}
+
+func extractVersionNotes(changelog, version string) (notes, date string, sectionPresent, notesPresent bool) {
+	number := strings.TrimPrefix(version, "v")
+	header := regexp.MustCompile(`(?m)^## \[` + regexp.QuoteMeta(number) + `\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})[ \t]*$`)
+	match := header.FindStringSubmatchIndex(changelog)
+	if match == nil {
+		return "", "", false, false
+	}
+	notesStart := match[1]
+	notesEnd := len(changelog)
+	if next := strings.Index(changelog[notesStart:], "\n## "); next >= 0 {
+		notesEnd = notesStart + next
+	}
+	notes = strings.TrimSpace(changelog[notesStart:notesEnd])
+	if notes != "" {
+		notes += "\n"
+	}
+	date = changelog[match[2]:match[3]]
+	return notes, date, true, notes != ""
+}
+
+func containsLine(text, expected string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func buildSummary(
+	input validationInput,
+	localNow time.Time,
+	completedAt time.Time,
+	completionValid bool,
+	actualSoak time.Duration,
+	facts policyFacts,
+) string {
+	var summary strings.Builder
+	fmt.Fprintln(&summary, "# Release evidence summary")
+	fmt.Fprintln(&summary)
+	fmt.Fprintf(&summary, "- Version: `%s`\n", input.Version)
+	fmt.Fprintf(&summary, "- Candidate commit: `%s`\n", input.CandidateSHA)
+	fmt.Fprintf(&summary, "- Release route: `%s`\n", input.ReleaseKind)
+	fmt.Fprintf(&summary, "- Version increment: `%s`\n", facts.Release.VersionIncrement)
+	fmt.Fprintf(&summary, "- Release receipt: `%s`\n", input.ReceiptURI)
+	fmt.Fprintf(&summary, "- Release time: `%s`\n", localNow.Format(time.RFC3339))
+	fmt.Fprintf(&summary, "- Hosted CI run ID: `%s`\n", input.CIRunID)
+	fmt.Fprintf(&summary, "- Hosted CI run URL: `%s`\n", input.CIRunURL)
+	fmt.Fprintf(&summary, "- Hosted CI event: `%s`\n", input.CIEvent)
+	fmt.Fprintf(&summary, "- Hosted CI commit: `%s`\n", input.CISHA)
+	fmt.Fprintf(&summary, "- Hosted CI conclusion: `%s`\n", input.CIConclusion)
+	if completionValid {
+		fmt.Fprintf(&summary, "- Hosted CI completion: `%s`\n", completedAt.Format(time.RFC3339))
+	} else {
+		fmt.Fprintln(&summary, "- Hosted CI completion: `missing`")
+	}
+	fmt.Fprintf(&summary, "- Soak duration: `%s`\n", actualSoak.Round(time.Second))
+	fmt.Fprintln(&summary, "- Policy facts: `policy-facts.json`")
+	if input.ReleaseKind == "urgent-patch" {
+		fmt.Fprintf(&summary, "- Incident: %s\n", strings.TrimSpace(input.Incident))
+		fmt.Fprintf(&summary, "- Delay rationale: %s\n", strings.TrimSpace(input.WhyWaitingIsWorse))
+	}
+	return summary.String()
+}
+
+func writeResult(directory string, result validationResult) error {
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	policyJSON, err := json.MarshalIndent(result.PolicyFacts, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode policy facts: %w", err)
+	}
+	ciRunJSON, err := json.MarshalIndent(result.CIRun, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode CI run evidence: %w", err)
+	}
+	files := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "title.txt", content: []byte(result.Title + "\n")},
+		{name: "notes.md", content: []byte(result.Notes)},
+		{name: "summary.md", content: []byte(result.Summary)},
+		{name: "policy-facts.json", content: append(policyJSON, '\n')},
+		{name: "ci-run.json", content: append(ciRunJSON, '\n')},
+	}
+	for _, file := range files {
+		if err := os.WriteFile(filepath.Join(directory, file.name), file.content, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", file.name, err)
+		}
+	}
+	return nil
+}

--- a/cmd/releasegate/main_test.go
+++ b/cmd/releasegate/main_test.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlannedMinorFactsUseLosAngelesThursdayAcrossUTCBoundary(t *testing.T) {
+	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+	result := collect(t, input)
+	if !result.PolicyFacts.Release.LosAngelesThursday {
+		t.Fatal("Los Angeles Thursday fact is false")
+	}
+	if result.PolicyFacts.Release.VersionIncrement != "next-minor" {
+		t.Fatalf("version increment = %q", result.PolicyFacts.Release.VersionIncrement)
+	}
+}
+
+func TestPlannedMinorFactsMarkOtherWeekdays(t *testing.T) {
+	tests := []struct {
+		name string
+		now  time.Time
+	}{
+		{name: "Wednesday", now: time.Date(2026, 7, 30, 2, 0, 0, 0, time.UTC)},
+		{name: "Friday", now: time.Date(2026, 8, 1, 2, 0, 0, 0, time.UTC)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := plannedInput(t, test.now)
+			writeReleaseFiles(t, input.RepositoryRoot, input.Version, localDate(t, test.now), input.LatestTag, "### Changed\n\n- Release notes.\n")
+			result := collect(t, input)
+			if result.PolicyFacts.Release.LosAngelesThursday {
+				t.Fatal("Los Angeles Thursday fact is true")
+			}
+		})
+	}
+}
+
+func TestUrgentPatchFactsOutsideThursday(t *testing.T) {
+	input := urgentInput(t, time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC))
+	result := collect(t, input)
+	facts := result.PolicyFacts.Release
+	if facts.LosAngelesThursday {
+		t.Fatal("Los Angeles Thursday fact is true")
+	}
+	if facts.VersionIncrement != "next-patch" {
+		t.Fatalf("version increment = %q", facts.VersionIncrement)
+	}
+	if !facts.IncidentPresent || !facts.DelayRationalePresent {
+		t.Fatal("urgent patch exception facts are false")
+	}
+}
+
+func TestUrgentPatchReasonFactsAreIndependent(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*validationInput)
+		check  func(releasePolicyFacts) bool
+	}{
+		{
+			name: "missing incident",
+			mutate: func(input *validationInput) {
+				input.Incident = ""
+			},
+			check: func(facts releasePolicyFacts) bool {
+				return !facts.IncidentPresent && facts.DelayRationalePresent
+			},
+		},
+		{
+			name: "missing delay rationale",
+			mutate: func(input *validationInput) {
+				input.WhyWaitingIsWorse = ""
+			},
+			check: func(facts releasePolicyFacts) bool {
+				return facts.IncidentPresent && !facts.DelayRationalePresent
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := urgentInput(t, time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC))
+			test.mutate(&input)
+			result := collect(t, input)
+			if !test.check(result.PolicyFacts.Release) {
+				t.Fatalf("unexpected exception facts: %+v", result.PolicyFacts.Release)
+			}
+		})
+	}
+}
+
+func TestVersionIncrementFactsDoNotChooseARoute(t *testing.T) {
+	t.Run("minor increment on urgent input", func(t *testing.T) {
+		input := urgentInput(t, time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC))
+		input.Version = "v0.48.0"
+		writeReleaseFiles(t, input.RepositoryRoot, input.Version, localDate(t, input.Now), input.LatestTag, "### Changed\n\n- Release notes.\n")
+		result := collect(t, input)
+		if result.PolicyFacts.Release.VersionIncrement != "next-minor" {
+			t.Fatalf("version increment = %q", result.PolicyFacts.Release.VersionIncrement)
+		}
+	})
+
+	t.Run("patch increment on planned input", func(t *testing.T) {
+		input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+		input.Version = "v0.47.1"
+		writeReleaseFiles(t, input.RepositoryRoot, input.Version, localDate(t, input.Now), input.LatestTag, "### Fixed\n\n- Release notes.\n")
+		result := collect(t, input)
+		if result.PolicyFacts.Release.VersionIncrement != "next-patch" {
+			t.Fatalf("version increment = %q", result.PolicyFacts.Release.VersionIncrement)
+		}
+	})
+}
+
+func TestSoakFactsPreserveBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		soak        time.Duration
+		wantSeconds int64
+	}{
+		{name: "47 hours 59 minutes", soak: 47*time.Hour + 59*time.Minute, wantSeconds: 172740},
+		{name: "exactly 48 hours", soak: 48 * time.Hour, wantSeconds: 172800},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+			input.CICompletedAt = input.Now.Add(-test.soak).Format(time.RFC3339)
+			result := collect(t, input)
+			if got := result.PolicyFacts.Release.SoakSeconds; got != test.wantSeconds {
+				t.Fatalf("soak seconds = %d, want %d", got, test.wantSeconds)
+			}
+		})
+	}
+}
+
+func TestHostedCheckFactsAreIndependent(t *testing.T) {
+	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+	input.CIEvent = "push"
+	input.CISHA = ""
+	input.CIConclusion = "failure"
+	input.CICompletedAt = input.Now.Add(time.Hour).Format(time.RFC3339)
+	result := collect(t, input)
+	facts := result.PolicyFacts.Evidence
+	if facts.CIExactCandidate || facts.CIFullDispatch || facts.CISuccessful || facts.CICompletionNotFuture {
+		t.Fatalf("unexpected hosted check facts: %+v", facts)
+	}
+}
+
+func TestHostedCheckFullDispatchFactRequiresManualEvent(t *testing.T) {
+	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+	if facts := collect(t, input).PolicyFacts.Evidence; !facts.CIFullDispatch {
+		t.Fatalf("manual event facts = %+v", facts)
+	}
+
+	input.CIEvent = "push"
+	if facts := collect(t, input).PolicyFacts.Evidence; facts.CIFullDispatch {
+		t.Fatalf("push event facts = %+v", facts)
+	}
+}
+
+func TestSummaryIncludesExactHostedRunIdentity(t *testing.T) {
+	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+	summary := collect(t, input).Summary
+	for _, expected := range []string{
+		input.CIRunID,
+		input.CIRunURL,
+		input.CIEvent,
+		input.CISHA,
+		input.CIConclusion,
+		input.CICompletedAt,
+	} {
+		if !strings.Contains(summary, expected) {
+			t.Fatalf("summary does not contain %q:\n%s", expected, summary)
+		}
+	}
+}
+
+func TestMutableGitHubFactsReachThePolicy(t *testing.T) {
+	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+	input.MainExactCandidate = false
+	input.TagAbsent = false
+	input.ReleaseAbsent = false
+	result := collect(t, input)
+	facts := result.PolicyFacts.Evidence
+	if facts.MainExactCandidate || facts.TagAbsent || facts.ReleaseAbsent {
+		t.Fatalf("unexpected mutable GitHub facts: %+v", facts)
+	}
+}
+
+func TestReleaseDocumentFacts(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*validationInput)
+		check  func(validationResult) bool
+	}{
+		{
+			name: "README mismatch",
+			mutate: func(input *validationInput) {
+				writeFile(t, filepath.Join(input.RepositoryRoot, "README.md"), "The current release is **v0.47.0**.\n")
+			},
+			check: func(result validationResult) bool {
+				return !result.PolicyFacts.Evidence.ReadmeMatches
+			},
+		},
+		{
+			name: "missing changelog section",
+			mutate: func(input *validationInput) {
+				writeFile(t, filepath.Join(input.RepositoryRoot, "CHANGELOG.md"),
+					"[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.48.0...HEAD\n")
+			},
+			check: func(result validationResult) bool {
+				facts := result.PolicyFacts.Evidence
+				return !facts.ChangelogSectionPresent && !facts.ChangelogNotesPresent && result.Notes == ""
+			},
+		},
+		{
+			name: "bad comparison base",
+			mutate: func(input *validationInput) {
+				path := filepath.Join(input.RepositoryRoot, "CHANGELOG.md")
+				content, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeFile(t, path, strings.ReplaceAll(string(content), "compare/v0.48.0...HEAD", "compare/v0.47.0...HEAD"))
+			},
+			check: func(result validationResult) bool {
+				return !result.PolicyFacts.Evidence.UnreleasedLinkMatches
+			},
+		},
+		{
+			name: "empty notes",
+			mutate: func(input *validationInput) {
+				writeReleaseFiles(t, input.RepositoryRoot, input.Version, localDate(t, input.Now), input.LatestTag, "")
+			},
+			check: func(result validationResult) bool {
+				facts := result.PolicyFacts.Evidence
+				return facts.ChangelogSectionPresent && !facts.ChangelogNotesPresent
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+			test.mutate(&input)
+			result := collect(t, input)
+			if !test.check(result) {
+				t.Fatalf("unexpected release facts: %+v", result.PolicyFacts)
+			}
+		})
+	}
+}
+
+func TestMalformedEvidenceStopsFactCollection(t *testing.T) {
+	t.Run("invalid version", func(t *testing.T) {
+		input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+		input.Version = "0.48.0"
+		if _, err := collectReleaseEvidence(input); err == nil {
+			t.Fatal("fact collection succeeded with an invalid version")
+		}
+	})
+
+	t.Run("invalid completion time becomes deny evidence", func(t *testing.T) {
+		input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+		input.CICompletedAt = "not-a-time"
+		result := collect(t, input)
+		if result.PolicyFacts.Evidence.CICompletionNotFuture {
+			t.Fatal("invalid completion time produced valid evidence")
+		}
+	})
+}
+
+func TestWriteResultEmitsDeterministicPolicyFactsAndCIRun(t *testing.T) {
+	directory := t.TempDir()
+	input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+	result := collect(t, input)
+	if err := writeResult(directory, result); err != nil {
+		t.Fatalf("write result: %v", err)
+	}
+	for _, name := range []string{"title.txt", "notes.md", "summary.md", "policy-facts.json", "ci-run.json"} {
+		content, err := os.ReadFile(filepath.Join(directory, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if len(content) == 0 {
+			t.Fatalf("%s is empty", name)
+		}
+	}
+	content, err := os.ReadFile(filepath.Join(directory, "policy-facts.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded policyFacts
+	if err := json.Unmarshal(content, &decoded); err != nil {
+		t.Fatalf("decode policy facts: %v", err)
+	}
+	if decoded.Release.Kind != "planned-minor" || !decoded.Evidence.CIExactCandidate || !decoded.Evidence.CIFullDispatch {
+		t.Fatalf("decoded policy facts = %+v", decoded)
+	}
+	content, err = os.ReadFile(filepath.Join(directory, "ci-run.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ciRun ciRunEvidence
+	if err := json.Unmarshal(content, &ciRun); err != nil {
+		t.Fatalf("decode CI run evidence: %v", err)
+	}
+	if ciRun != result.CIRun {
+		t.Fatalf("decoded CI run evidence = %+v", ciRun)
+	}
+}
+
+func collect(t *testing.T, input validationInput) validationResult {
+	t.Helper()
+	result, err := collectReleaseEvidence(input)
+	if err != nil {
+		t.Fatalf("collect release evidence: %v", err)
+	}
+	return result
+}
+
+func plannedInput(t *testing.T, now time.Time) validationInput {
+	t.Helper()
+	root := t.TempDir()
+	input := validationInput{
+		Version:            "v0.48.0",
+		CandidateSHA:       strings.Repeat("a", 40),
+		ReleaseKind:        "planned-minor",
+		ReceiptURI:         "hypha://m31labs/gotreesitter/release/v0.48.0",
+		LatestTag:          "v0.47.0",
+		CIRunID:            "29892922471",
+		CIRunURL:           "https://github.com/odvcencio/gotreesitter/actions/runs/29892922471",
+		CIEvent:            "workflow_dispatch",
+		CISHA:              strings.Repeat("a", 40),
+		CIConclusion:       "success",
+		CICompletedAt:      now.Add(-48 * time.Hour).Format(time.RFC3339),
+		MainExactCandidate: true,
+		TagAbsent:          true,
+		ReleaseAbsent:      true,
+		RepositoryRoot:     root,
+		Now:                now,
+	}
+	writeReleaseFiles(t, root, input.Version, localDate(t, now), input.LatestTag, "### Changed\n\n- Release notes.\n")
+	return input
+}
+
+func urgentInput(t *testing.T, now time.Time) validationInput {
+	t.Helper()
+	root := t.TempDir()
+	input := validationInput{
+		Version:            "v0.47.1",
+		CandidateSHA:       strings.Repeat("b", 40),
+		ReleaseKind:        "urgent-patch",
+		ReceiptURI:         "hypha://m31labs/gotreesitter/release/v0.47.1",
+		Incident:           "The parser returns a wrong tree.",
+		WhyWaitingIsWorse:  "Users receive incorrect parse results.",
+		LatestTag:          "v0.47.0",
+		CIRunID:            "29892922471",
+		CIRunURL:           "https://github.com/odvcencio/gotreesitter/actions/runs/29892922471",
+		CIEvent:            "workflow_dispatch",
+		CISHA:              strings.Repeat("b", 40),
+		CIConclusion:       "success",
+		CICompletedAt:      now.Add(-time.Hour).Format(time.RFC3339),
+		MainExactCandidate: true,
+		TagAbsent:          true,
+		ReleaseAbsent:      true,
+		RepositoryRoot:     root,
+		Now:                now,
+	}
+	writeReleaseFiles(t, root, input.Version, localDate(t, now), input.LatestTag, "### Fixed\n\n- Urgent correction.\n")
+	return input
+}
+
+func writeReleaseFiles(t *testing.T, root, version, date, previousTag, notes string) {
+	t.Helper()
+	number := strings.TrimPrefix(version, "v")
+	changelog := "# Changelog\n\n## [Unreleased]\n\n" +
+		"## [" + number + "] - " + date + "\n\n" + notes + "\n" +
+		"## [" + strings.TrimPrefix(previousTag, "v") + "] - 2026-07-23\n\n- Previous release.\n\n" +
+		"[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/" + version + "...HEAD\n" +
+		"[" + number + "]: https://github.com/odvcencio/gotreesitter/compare/" + previousTag + "..." + version + "\n"
+	writeFile(t, filepath.Join(root, "CHANGELOG.md"), changelog)
+	readme := "# gotreesitter\n\nThe current release is **" + version + "**.\n"
+	writeFile(t, filepath.Join(root, "README.md"), readme)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func localDate(t *testing.T, value time.Time) string {
+	t.Helper()
+	location, err := time.LoadLocation(losAngelesZone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value.In(location).Format("2006-01-02")
+}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,6 +6,10 @@ Planned minor releases are cut on Thursdays in `America/Los_Angeles`. A
 Thursday without a coherent, green release is skipped; the schedule is a
 batching boundary, not a reason to ship unfinished work.
 
+Planned releases require a 48-hour soak after the exact commit completes the
+hosted continuous integration (CI) workflow in `ci.yml`. Keep this conservative
+rule until the project reviews a risk classifier.
+
 Patch releases may happen outside the cadence for urgent correctness,
 security, or packaging regressions. Ordinary maintenance waits for the next
 Thursday. Release planning and in-progress campaign notes live in the private
@@ -20,18 +24,60 @@ the next eligible Thursday after v0.47.0.
    queue; do not release from a feature branch.
 2. Move the accumulated changelog entries from `Unreleased` into a dated
    version section. Update the comparison links and the README release status.
-3. Require the release commit's hosted CI to be green. Keep correctness,
-   parity, race, and performance evidence distinct; do not substitute a broad
-   host test sweep for the isolated gates.
-4. Fetch `main`, verify the worktree is clean, verify the version tag does not
-   already exist, and record the exact release commit SHA.
-5. Create an annotated `vX.Y.Z` tag at that SHA, push only that tag, and create
-   the GitHub release from the versioned changelog section.
-6. Verify the GitHub release and tag resolve to the recorded SHA and that the
-   module can be fetched at the new version.
-7. Checkpoint the version, SHA, gate results, and any intentionally deferred
-   work in Hyphae. Close campaign issues only when the release contains their
-   documented acceptance evidence.
+3. Dispatch the full hosted `ci.yml` workflow for the exact commit on `main`.
+   Require its successful completion. Keep correctness, parity, race, and
+   performance evidence distinct.
+4. Wait at least 48 hours after hosted CI completes for a planned minor
+   release. Record the actual soak for an urgent patch.
+5. Dispatch the manual `release.yml` workflow from `main`. Supply the version,
+   candidate commit hash, release route, and governing Hyphae receipt.
+6. For an urgent patch, also supply the incident and explain why waiting is
+   worse. Do not use this route for ordinary maintenance.
+7. Review the verification evidence. Approve the protected `release`
+   environment only when Arbiter selects `Allow`.
+8. Let the workflow repeat the mutable checks. Arbiter reevaluates the
+   resulting facts before the workflow creates the tag and GitHub release.
+9. Verify that the module proxy can fetch the new version.
+10. Checkpoint the version, commit hash, gate results, and any intentionally
+   deferred work in Hyphae. Close campaign issues only when the release
+   contains their documented acceptance evidence.
 
 Tags are immutable. If a release is wrong, preserve its tag and publish a
 follow-up version.
+
+The workflow has no schedule. The Go evidence collector writes deterministic
+facts to `policy-facts.json`. It does not choose the release route.
+
+The `policy/release.arb` strategy is the authoritative publication decision.
+It selects exactly one `Allow` or `Deny` outcome. The workflow installs Arbiter
+v1.9.0 from its digest-pinned release archive.
+
+The strategy denies a release when a fact does not satisfy the release receipt.
+These facts include:
+
+- the weekday;
+- the current `main` commit;
+- the exact manual CI run, result, and soak;
+- the document state;
+- the tag and release state;
+- the GitHub service result.
+
+The evidence artifacts record the CI run ID, URL, event, commit, conclusion,
+and completion time.
+
+## External activation gates
+
+Keep the release workflow inactive until repository owners confirm these
+controls:
+
+- Create the protected `release` environment.
+- Require one owner reviewer for that environment.
+- Restrict that environment to `main`.
+- Set the default workflow permission to read-only.
+- Add a `v*` tag ruleset before publication.
+- Block tag updates and deletions.
+- Restrict tag creation to the governed release workflow when GitHub supports
+  that actor rule.
+
+Treat an unsupported tag actor rule as an external blocker. Do not weaken the
+local workflow to compensate for it.

--- a/policy/release.arb
+++ b/policy/release.arb
@@ -1,0 +1,46 @@
+outcome ReleaseDecision {
+    action: string
+    reason: string
+}
+
+# Select one publication decision from deterministic release facts.
+strategy ReleasePublication returns ReleaseDecision {
+    when {
+        evidence.main_exact_candidate
+        and evidence.ci_exact_candidate
+        and evidence.ci_full_dispatch
+        and evidence.ci_successful
+        and evidence.ci_completion_not_future
+        and evidence.tag_absent
+        and evidence.release_absent
+        and evidence.receipt_valid
+        and evidence.changelog_section_present
+        and evidence.changelog_notes_present
+        and evidence.changelog_date_matches
+        and evidence.readme_matches
+        and evidence.unreleased_link_matches
+        and evidence.version_link_matches
+        and (
+            (
+                release.kind == "planned-minor"
+                and release.version_increment == "next-minor"
+                and release.los_angeles_thursday
+                and release.soak_seconds >= 172800
+            )
+            or (
+                release.kind == "urgent-patch"
+                and release.version_increment == "next-patch"
+                and release.incident_present
+                and release.delay_rationale_present
+            )
+        )
+    } then Allow {
+        action: "allow",
+        reason: "all release policy requirements are satisfied",
+    }
+
+    else Deny {
+        action: "deny",
+        reason: "release facts do not satisfy the publication policy",
+    }
+}

--- a/policy/release.test.arb
+++ b/policy/release.test.arb
@@ -1,0 +1,259 @@
+test "planned minor passes on Thursday after 48 hours" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Allow { action: "allow" }
+}
+
+test "urgent patch passes outside Thursday without a minimum soak" {
+    given {
+        release.kind: "urgent-patch"
+        release.version_increment: "next-patch"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.incident_present: true
+        release.delay_rationale_present: true
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Allow { action: "allow" }
+}
+
+test "planned minor fails outside Thursday" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "planned minor fails before 48 hours" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172740
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "urgent patch fails without both exception reasons" {
+    given {
+        release.kind: "urgent-patch"
+        release.version_increment: "next-patch"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.incident_present: true
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "planned route fails with a patch increment" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-patch"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "failed hosted checks select the deny fallback" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: false
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "incoherent documents select the deny fallback" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: false
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "mutable GitHub conflicts select the deny fallback" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: false
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: false
+        evidence.release_absent: false
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "push CI event selects the deny fallback" {
+    given {
+        release.kind: "planned-minor"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: true
+        release.soak_seconds: 172800
+        release.incident_present: false
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: false
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}


### PR DESCRIPTION
## Summary

- Add a manual Thursday release workflow.
- Require exact manual CI evidence and a 48-hour soak for planned minor releases.
- Govern planned minor and urgent patch routes with Arbiter.
- Recheck `main`, tag, release, and CI facts before publication.

## Evidence

- `go test ./cmd/releasegate -count=1`
- `go vet ./cmd/releasegate`
- Arbiter check, format, and 10 policy tests
- Explicit Allow and Deny evaluations
- actionlint 1.7.7
- `git diff --check`
- Hosted PR CI run 30220864219: green

## Buckbot

Buckbot used `qwen/qwen3.7-plus`. The uncommitted review timed out during snapshot revalidation. The clean branch review reached its 15-minute guard during analysis and returned no verdict or findings. The focused local gates and hosted CI remain the evidence for this draft.

## Activation blockers

Keep this pull request in draft state. Before merge, create the protected `release` environment, require an owner reviewer, restrict it to `main`, set default workflow permissions to read-only, and add the `v*` tag ruleset. No tag or release was created.