### PR TITLE
fix(ci): skip optional real-corpus test when corpus is absent

### DIFF
--- a/parser_result_test/dispatcher_census_test.go
+++ b/parser_result_test/dispatcher_census_test.go
@@ -426,6 +426,16 @@ func TestDispatcherArmCensusTrackedReceipt(t *testing.T) {
 
 func TestTerminalLeafNativeInvariantOverRealCorpus(t *testing.T) {
 	const corpusRoot = "../cgo_harness/corpus_real"
+	corpusInfo, err := os.Stat(corpusRoot)
+	if os.IsNotExist(err) {
+		t.Skipf("real corpus is not available at %s", corpusRoot)
+	}
+	if err != nil {
+		t.Fatalf("inspect real corpus root %s: %v", corpusRoot, err)
+	}
+	if !corpusInfo.IsDir() {
+		t.Fatalf("real corpus root %s is not a directory", corpusRoot)
+	}
 
 	backends := map[string]grammars.ParseBackend{}
 	for _, report := range grammars.AuditParseSupport() {


### PR DESCRIPTION
## Summary

- Skip the optional real-corpus census when its ignored corpus root is absent.
- Fail when the corpus path is unreadable or is not a directory.
- Keep the non-vacuous corpus checks active when the corpus exists.

## Root cause

GitHub Actions checks out tracked files only. The `cgo_harness/corpus_real` directory is ignored.

The parser-result race lane therefore observed zero corpus files. Its failure made the required build gate fail.

## Validation

- Docker focused missing-corpus test: passed with the expected skip.
- Docker 206-language smoke fleet: passed with 2,420 nodes and zero retired shapes.
- Docker parser-result race lane: passed in 71 seconds.
