### PR TITLE
remove(parser): retire the Scala returned-tree fixpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,9 @@ for tags and release notes while still in `0.x`.
 
 - **The Scala returned-tree span repair subfamily.** A language-neutral
   in-place rewrite refresh now preserves a valid producer-owned span and can
-  widen it. The Scala function-end and case-clause helpers are deleted. The
-  second-pass root-end call and its duplicate case-clause block are also
-  removed. Production, compact, forest, changed incremental, fresh, and
+  widen it. This change deletes the Scala function-end and case-clause helpers.
+  It also removes the second-pass root-end call and its duplicate case-clause
+  block. Production, compact, forest, changed incremental, fresh, and
   locked C routes return the exact ranges and points. Scala incremental reuse
   remains unsupported and reports zero reuse.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ for tags and release notes while still in `0.x`.
   Mandatory fixtures and the authenticated corpus report zero mutations when
   the deleted calls run again.
 
+- **The shared returned-tree fixpoint.** The last Scala arm became inert after
+  checkpoints A and B. The publication paths no longer call a repeated
+  post-finalization normalizer.
+
 - **The HTML returned-tree range fixup.** Materialization now extends recovered
   custom elements through each structural `_implicit_end_tag` child.
   Production, compact, forest, and incremental routes return the exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ for tags and release notes while still in `0.x`.
   locked C routes return the exact ranges and points. Scala incremental reuse
   remains unsupported and reports zero reuse.
 
+- **The duplicate Scala returned-tree repair calls.** Recovery, field, and
+  annotation repair now runs only in the canonical compatibility pass.
+  Mandatory fixtures and the authenticated corpus report zero mutations when
+  the deleted calls run again.
+
 - **The HTML returned-tree range fixup.** Materialization now extends recovered
   custom elements through each structural `_implicit_end_tag` child.
   Production, compact, forest, and incremental routes return the exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,14 @@ for tags and release notes while still in `0.x`.
 
 ### Removed
 
+- **The Scala returned-tree span repair subfamily.** A language-neutral
+  in-place rewrite refresh now preserves a valid producer-owned span and can
+  widen it. The Scala function-end and case-clause helpers are deleted. The
+  second-pass root-end call and its duplicate case-clause block are also
+  removed. Production, compact, forest, changed incremental, fresh, and
+  locked C routes return the exact ranges and points. Scala incremental reuse
+  remains unsupported and reports zero reuse.
+
 - **The HTML returned-tree range fixup.** Materialization now extends recovered
   custom elements through each structural `_implicit_end_tag` child.
   Production, compact, forest, and incremental routes return the exact

--- a/cgo_harness/scala_span_ownership_parity_test.go
+++ b/cgo_harness/scala_span_ownership_parity_test.go
@@ -1,0 +1,154 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestScalaSpanOwnershipCOracleParity(t *testing.T) {
+	scheduleParityMemoryScavenge(t)
+
+	const sourceText = `object SpanReceipt {
+  def first =
+    val value = 1
+    value
+
+  def second = 2
+
+  def choose(n: Int) =
+    n match {
+      case 0 =>
+        "zero"
+      case _ =>
+        "other"
+    }
+}
+`
+	source := []byte(sourceText)
+	test := parityCase{name: "scala", source: sourceText}
+	goTree, goLanguage, err := parseWithGo(test, source, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLanguage, err := ParityCLanguage(test.name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLanguage); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C reference parser returned a nil tree")
+	}
+	defer cTree.Close()
+
+	var divergences []string
+	compareNodes(goTree.RootNode(), goLanguage, cTree.RootNode(), "root", &divergences)
+	if len(divergences) != 0 {
+		t.Fatalf("C-oracle divergences = %v", divergences)
+	}
+
+	spans := []struct {
+		name       string
+		kind       string
+		startByte  uint32
+		startPoint gotreesitter.Point
+		endByte    uint32
+		endPoint   gotreesitter.Point
+	}{
+		{
+			name:       "compilation root",
+			kind:       "compilation_unit",
+			startPoint: gotreesitter.Point{},
+			endByte:    190,
+			endPoint:   gotreesitter.Point{Row: 15},
+		},
+		{
+			name:       "first function",
+			kind:       "function_definition",
+			startByte:  23,
+			startPoint: gotreesitter.Point{Row: 1, Column: 2},
+			endByte:    66,
+			endPoint:   gotreesitter.Point{Row: 5, Column: 2},
+		},
+		{
+			name:       "first indented block",
+			kind:       "indented_block",
+			startByte:  39,
+			startPoint: gotreesitter.Point{Row: 2, Column: 4},
+			endByte:    66,
+			endPoint:   gotreesitter.Point{Row: 5, Column: 2},
+		},
+		{
+			name:       "first case clause",
+			kind:       "case_clause",
+			startByte:  125,
+			startPoint: gotreesitter.Point{Row: 9, Column: 6},
+			endByte:    156,
+			endPoint:   gotreesitter.Point{Row: 11, Column: 6},
+		},
+		{
+			name:       "second case clause",
+			kind:       "case_clause",
+			startByte:  156,
+			startPoint: gotreesitter.Point{Row: 11, Column: 6},
+			endByte:    186,
+			endPoint:   gotreesitter.Point{Row: 13, Column: 4},
+		},
+	}
+	for _, want := range spans {
+		goNode := findGoNodeByTypeAndStart(goTree.RootNode(), goLanguage, want.kind, want.startByte)
+		if goNode == nil {
+			t.Fatalf("Go tree is missing %s at byte %d", want.name, want.startByte)
+		}
+		cNode := findCNodeByKindAndStart(cTree.RootNode(), want.kind, uint(want.startByte))
+		if cNode == nil {
+			t.Fatalf("C tree is missing %s at byte %d", want.name, want.startByte)
+		}
+		if goNode.StartByte() != want.startByte || goNode.StartPoint() != want.startPoint ||
+			goNode.EndByte() != want.endByte || goNode.EndPoint() != want.endPoint {
+			t.Fatalf(
+				"Go %s range = %d:%#v-%d:%#v, want %d:%#v-%d:%#v",
+				want.name,
+				goNode.StartByte(),
+				goNode.StartPoint(),
+				goNode.EndByte(),
+				goNode.EndPoint(),
+				want.startByte,
+				want.startPoint,
+				want.endByte,
+				want.endPoint,
+			)
+		}
+		cStart := cNode.StartPosition()
+		cEnd := cNode.EndPosition()
+		if cNode.StartByte() != uint(want.startByte) ||
+			uint32(cStart.Row) != want.startPoint.Row ||
+			uint32(cStart.Column) != want.startPoint.Column ||
+			cNode.EndByte() != uint(want.endByte) ||
+			uint32(cEnd.Row) != want.endPoint.Row ||
+			uint32(cEnd.Column) != want.endPoint.Column {
+			t.Fatalf(
+				"C %s range = %d:%#v-%d:%#v, want %d:%#v-%d:%#v",
+				want.name,
+				cNode.StartByte(),
+				cStart,
+				cNode.EndByte(),
+				cEnd,
+				want.startByte,
+				want.startPoint,
+				want.endByte,
+				want.endPoint,
+			)
+		}
+	}
+}

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -417,6 +417,29 @@ func assertGenericPassRegistry(t *testing.T, denominator resultCompatDenominator
 func assertPostFinalizationRegistry(t *testing.T, denominator resultCompatDenominator, byKind map[string][]resultCompatOwnershipEntry) {
 	t.Helper()
 	entries := byKind["second_pass_fixpoint"]
+	if denominator.PostFinalizationArms == 0 && denominator.PostFinalizationLanguages == 0 {
+		if len(entries) != 0 {
+			t.Fatalf("live second_pass_fixpoint entries = %d, want 0", len(entries))
+		}
+		file := parseOwnershipGoFile(t, "parser_api.go")
+		for _, removed := range []string{"normalizeReturnedTree", "normalizePostFinalizationReturnedTree"} {
+			for _, declaration := range file.Decls {
+				function, ok := declaration.(*ast.FuncDecl)
+				if ok && function.Name.Name == removed &&
+					(removed != "normalizeReturnedTree" || function.Recv == nil) {
+					t.Errorf("retired post-finalization function %s still exists", removed)
+				}
+			}
+		}
+		return
+	}
+	if denominator.PostFinalizationArms == 0 || denominator.PostFinalizationLanguages == 0 {
+		t.Fatalf(
+			"post-finalization denominator is inconsistent: arms=%d languages=%d",
+			denominator.PostFinalizationArms,
+			denominator.PostFinalizationLanguages,
+		)
+	}
 	if len(entries) != 1 {
 		t.Fatalf("live second_pass_fixpoint entries = %d, want 1", len(entries))
 	}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -131,8 +131,8 @@ Checkpoint A removed the span calls and their two exclusive helpers.
 Checkpoint B removed the four duplicate recovery, field, and annotation calls.
 The final checkpoint deletes the marker and the shared fixpoint.
 
-An in-place child rewrite now preserves a valid producer-owned span. The
-rewrite can widen that span but cannot shrink it. This language-neutral rule
+Child rewrites preserve a valid producer-owned span. A rewrite can widen the
+span but cannot shrink it. This language-neutral rule
 replaces the Scala function, block, case-clause, and root span repairs.
 
 The route receipt covers production, compact, forest, changed incremental,

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -19,10 +19,9 @@ The v1 registry freezes the current surface:
   language names;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
 - zero generic passes after language dispatch;
-- one retained post-finalization second-pass fixpoint with one Scala switch
-  arm.
+- zero post-finalization second-pass fixpoint arms.
 
-That is 77 live registry entries and 8 retired entries. The registry covers
+That is 76 live registry entries and 9 retired entries. The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.
 
@@ -59,8 +58,6 @@ The route fields use a closed vocabulary enforced by the registry test:
 - live dispatcher, predicate, and generic entries use
   `shared_result_compatibility_tail` for production/compact/forest/incremental
   and `curated_single_grammar_parity` for the C oracle;
-- the live fixpoint uses `post_finalization_fixpoint` for those four parser
-  routes and `language_witnesses_required` for the C oracle; and
 - retired entries use `retired_exact_receipt` for all four native routes.
   The C oracle uses `retired_exact_receipt` or
   `retired_known_divergence_receipt`. Each retired entry must include a
@@ -128,12 +125,11 @@ Error roots retain their recovery extra, and lazy final-child references are
 filtered without draining the compact range. Real RST and Comment fixtures are
 exact against their C oracles. The generic trailing-extra pass is retired.
 
-## The retained second pass
+## The retired second pass
 
-`normalizePostFinalizationReturnedTree` now runs one inert marker for Scala.
 Checkpoint A removed the span calls and their two exclusive helpers.
 Checkpoint B removed the four duplicate recovery, field, and annotation calls.
-The marker keeps the registry bisectable until the shared fixpoint is deleted.
+The final checkpoint deletes the marker and the shared fixpoint.
 
 An in-place child rewrite now preserves a valid producer-owned span. The
 rewrite can widen that span but cannot shrink it. This language-neutral rule
@@ -160,7 +156,7 @@ arm and its production, compact-final-ref, forest, and incremental receipts.
 
 The authenticated Scala corpus reports zero second-pass mutations.
 The mandatory fixture witness also reports zero mutations.
-The next commit can delete the marker and the shared fixpoint.
+No post-finalization fixpoint remains.
 
 ## Editing and validation
 

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -130,11 +130,10 @@ exact against their C oracles. The generic trailing-extra pass is retired.
 
 ## The retained second pass
 
-`normalizePostFinalizationReturnedTree` deliberately runs a bounded second
-pass for Scala. Four recovery, field, and annotation repairs remain live.
-Checkpoint A removes the three span calls and their two exclusive helpers.
-It keeps one inert marker until the checkpoint commit becomes a retirement
-receipt. The marker does not mutate the tree.
+`normalizePostFinalizationReturnedTree` now runs one inert marker for Scala.
+Checkpoint A removed the span calls and their two exclusive helpers.
+Checkpoint B removed the four duplicate recovery, field, and annotation calls.
+The marker keeps the registry bisectable until the shared fixpoint is deleted.
 
 An in-place child rewrite now preserves a valid producer-owned span. The
 rewrite can widen that span but cannot shrink it. This language-neutral rule
@@ -159,8 +158,9 @@ optional parent-link wiring. Neither can shorten or reclassify the root.
 The registry retains a retired historical entry for the deleted JavaScript
 arm and its production, compact-final-ref, forest, and incremental receipts.
 
-Removing the remaining Scala second pass now would reopen four known repairs.
-Its registry retirement condition remains the deletion gate.
+The authenticated Scala corpus reports zero second-pass mutations.
+The mandatory fixture witness also reports zero mutations.
+The next commit can delete the marker and the shared fixpoint.
 
 ## Editing and validation
 

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -131,9 +131,19 @@ exact against their C oracles. The generic trailing-extra pass is retired.
 ## The retained second pass
 
 `normalizePostFinalizationReturnedTree` deliberately runs a bounded second
-pass for Scala. It remains live because the first pass can expose information
-needed by later normalization. Scala must emit its final annotations and spans
-in one pass before this arm can retire.
+pass for Scala. Four recovery, field, and annotation repairs remain live.
+Checkpoint A removes the three span calls and their two exclusive helpers.
+It keeps one inert marker until the checkpoint commit becomes a retirement
+receipt. The marker does not mutate the tree.
+
+An in-place child rewrite now preserves a valid producer-owned span. The
+rewrite can widen that span but cannot shrink it. This language-neutral rule
+replaces the Scala function, block, case-clause, and root span repairs.
+
+The route receipt covers production, compact, forest, changed incremental,
+and fresh parsing. Scala incremental reuse is unsupported because its
+external scanner lacks reuse support. The receipt records zero reused
+subtrees and bytes. It does not claim incremental reuse.
 
 HTML no longer participates in this fixpoint. Materialization extends each
 recovered custom element through its structural `_implicit_end_tag` child.
@@ -149,7 +159,7 @@ optional parent-link wiring. Neither can shorten or reclassify the root.
 The registry retains a retired historical entry for the deleted JavaScript
 arm and its production, compact-final-ref, forest, and incremental receipts.
 
-Removing the Scala second pass now would reopen known fixpoint behavior.
+Removing the remaining Scala second pass now would reopen four known repairs.
 Its registry retirement condition remains the deletion gate.
 
 ## Editing and validation

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -88,10 +88,11 @@ Status: complete.
 3. Retire the remaining generic terminal-leaf pass by moving the invariant
    into construction/materialization. This must cover lazy compact child
    references without forcing them.
-4. Retire the HTML and Scala second-pass arms independently. The HTML arm is
-   retired with exact range receipts. Scala span repairs are removed.
+4. Retire the HTML and Scala second-pass arms independently. Exact range
+   receipts support the HTML arm retirement. This change removes Scala span
+   repairs.
    Scala recovery, field, and annotation repairs now run once.
-   The shared fixpoint is deleted.
+   This change deletes the shared fixpoint.
    Delete the shared fixpoint only after the Scala arm retires.
 
 Exit: zero generic compatibility passes and zero post-finalization fixpoint

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -90,7 +90,8 @@ Status: in progress.
    references without forcing them.
 4. Retire the HTML and Scala second-pass arms independently. The HTML arm is
    retired with exact range receipts. Scala span repairs are removed.
-   Four Scala shape and field repairs remain.
+   Scala recovery, field, and annotation repairs now run once.
+   One inert registry marker remains.
    Delete the shared fixpoint only after the Scala arm retires.
 
 Exit: zero generic compatibility passes and zero post-finalization fixpoint
@@ -220,7 +221,8 @@ there.
 | R2 dead dispatcher arms (OCaml, Ruby, half of HTML) | merged in PR #463 | 78 dispatcher arms | 75 | real-corpus census, native-parse regression tests per language, `TestResultCompatibilityOwnershipRegistry` |
 | Generic terminal-leaf mutation | merged in PR #465 | 1 tree mutation | 0 | production, compact, forest, incremental, scanner-aware corpus, and Go C-oracle receipts |
 | HTML returned-tree range arm | retirement commit `22f506d9b633b9b83f405ca1d7d2770527b9a8cd` on branch `codex/retire-html-fixpoint-20260726`; not merged | 2 fixpoint arms | 1 | producer unit, absolute production/compact/forest/incremental ranges and points, nonzero incremental reuse, and exact C ranges and points |
-| Scala returned-tree span repairs | checkpoint A pending | 7 Scala calls | 4 shape and field calls plus one inert marker | producer controls, exact production, compact, forest, incremental, fresh, and C ranges and points |
+| Scala returned-tree span repairs | checkpoint A commit `c334bace7da734d40e481ee236f5293b37db9a38` | 7 Scala calls | 4 duplicate calls plus one inert marker | producer controls, exact production, compact, forest, incremental, fresh, and C ranges and points |
+| Scala returned-tree duplicate calls | checkpoint B pending | 4 duplicate calls plus one inert marker | one inert marker | mandatory fixtures, authenticated corpus census, and canonical first-pass fingerprint |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -79,7 +79,7 @@ Status: complete.
 
 ### R1 — eliminate shared tail and fixpoint scaffolding
 
-Status: in progress.
+Status: complete.
 
 1. Land the clean-root trailing-trivia owner and delete the generic
    trailing-extra compatibility pass.
@@ -91,7 +91,7 @@ Status: in progress.
 4. Retire the HTML and Scala second-pass arms independently. The HTML arm is
    retired with exact range receipts. Scala span repairs are removed.
    Scala recovery, field, and annotation repairs now run once.
-   One inert registry marker remains.
+   The shared fixpoint is deleted.
    Delete the shared fixpoint only after the Scala arm retires.
 
 Exit: zero generic compatibility passes and zero post-finalization fixpoint
@@ -220,9 +220,10 @@ there.
 | JavaScript returned-tree arm | merged in PR #459 | 3 fixpoint arms | 2 | pre-second-pass root-span witness, JavaScript real-corpus parity, and 30/30 valid incremental/fresh edits |
 | R2 dead dispatcher arms (OCaml, Ruby, half of HTML) | merged in PR #463 | 78 dispatcher arms | 75 | real-corpus census, native-parse regression tests per language, `TestResultCompatibilityOwnershipRegistry` |
 | Generic terminal-leaf mutation | merged in PR #465 | 1 tree mutation | 0 | production, compact, forest, incremental, scanner-aware corpus, and Go C-oracle receipts |
-| HTML returned-tree range arm | retirement commit `22f506d9b633b9b83f405ca1d7d2770527b9a8cd` on branch `codex/retire-html-fixpoint-20260726`; not merged | 2 fixpoint arms | 1 | producer unit, absolute production/compact/forest/incremental ranges and points, nonzero incremental reuse, and exact C ranges and points |
+| HTML returned-tree range arm | merged in PR #467 | 2 fixpoint arms | 1 | producer unit, absolute production/compact/forest/incremental ranges and points, nonzero incremental reuse, and exact C ranges and points |
 | Scala returned-tree span repairs | checkpoint A commit `c334bace7da734d40e481ee236f5293b37db9a38` | 7 Scala calls | 4 duplicate calls plus one inert marker | producer controls, exact production, compact, forest, incremental, fresh, and C ranges and points |
-| Scala returned-tree duplicate calls | checkpoint B pending | 4 duplicate calls plus one inert marker | one inert marker | mandatory fixtures, authenticated corpus census, and canonical first-pass fingerprint |
+| Scala returned-tree duplicate calls | retirement commit `d82f9c2cadb81242cb324ba751aa2805038d4b60` | 4 duplicate calls plus one inert marker | one inert marker | mandatory fixtures, authenticated corpus census, and canonical first-pass fingerprint |
+| Shared returned-tree fixpoint | deleted on branch `codex/generalize-scala-produced-spans-20260726` | 1 inert arm | 0 | ownership denominator, focused route tests, and exact Scala C-oracle receipt |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -89,7 +89,8 @@ Status: in progress.
    into construction/materialization. This must cover lazy compact child
    references without forcing them.
 4. Retire the HTML and Scala second-pass arms independently. The HTML arm is
-   retired with exact range receipts. The Scala arm remains.
+   retired with exact range receipts. Scala span repairs are removed.
+   Four Scala shape and field repairs remain.
    Delete the shared fixpoint only after the Scala arm retires.
 
 Exit: zero generic compatibility passes and zero post-finalization fixpoint
@@ -219,6 +220,7 @@ there.
 | R2 dead dispatcher arms (OCaml, Ruby, half of HTML) | merged in PR #463 | 78 dispatcher arms | 75 | real-corpus census, native-parse regression tests per language, `TestResultCompatibilityOwnershipRegistry` |
 | Generic terminal-leaf mutation | merged in PR #465 | 1 tree mutation | 0 | production, compact, forest, incremental, scanner-aware corpus, and Go C-oracle receipts |
 | HTML returned-tree range arm | retirement commit `22f506d9b633b9b83f405ca1d7d2770527b9a8cd` on branch `codex/retire-html-fixpoint-20260726`; not merged | 2 fixpoint arms | 1 | producer unit, absolute production/compact/forest/incremental ranges and points, nonzero incremental reuse, and exact C ranges and points |
+| Scala returned-tree span repairs | checkpoint A pending | 7 Scala calls | 4 shape and field calls plus one inert marker | producer controls, exact production, compact, forest, incremental, fresh, and C ranges and points |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -88,8 +88,8 @@ Status: complete.
 3. Retire the remaining generic terminal-leaf pass by moving the invariant
    into construction/materialization. This must cover lazy compact child
    references without forcing them.
-4. Retire the HTML and Scala second-pass arms independently. Exact range
-   receipts support the HTML arm retirement. This change removes Scala span
+4. Retire HTML and Scala second-pass arms independently. Use exact range
+   receipts to retire the HTML arm. This change removes Scala span
    repairs.
    Scala recovery, field, and annotation repairs now run once.
    This change deletes the shared fixpoint.

--- a/grammars/scala_span_ownership_test.go
+++ b/grammars/scala_span_ownership_test.go
@@ -1,0 +1,164 @@
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestScalaSpanOwnershipRoutes(t *testing.T) {
+	const baseSourceText = `object SpanReceipt {
+  def first =
+    val value = 1
+    value
+
+  def second = 2
+
+  def choose(n: Int) =
+    n match {
+      case 0 =>
+        "zero"
+      case _ =>
+        "other"
+    }
+}`
+	lang := ScalaLanguage()
+	receipts := retiredDispatchRouteReceipts(t, lang, []byte(baseSourceText))
+
+	source := append([]byte(baseSourceText), '\n')
+	fresh, err := gotreesitter.NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatalf("fresh parse failed: %v", err)
+	}
+	t.Cleanup(fresh.Release)
+	receipts = append(receipts, retiredDispatchRouteReceipt{name: "fresh", tree: fresh})
+
+	productionInspection, err := benchfixtures.InspectGoTree(receipts[0].tree.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freshInspection, err := benchfixtures.InspectGoTree(fresh.RootNode(), lang)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if freshInspection.SHA256 != productionInspection.SHA256 {
+		t.Fatalf(
+			"fresh digest = %s, want production %s",
+			freshInspection.SHA256,
+			productionInspection.SHA256,
+		)
+	}
+
+	spans := []struct {
+		name       string
+		kind       string
+		startByte  uint32
+		startPoint gotreesitter.Point
+		endByte    uint32
+		endPoint   gotreesitter.Point
+	}{
+		{
+			name:       "compilation root",
+			kind:       "compilation_unit",
+			startPoint: gotreesitter.Point{},
+			endByte:    190,
+			endPoint:   gotreesitter.Point{Row: 15},
+		},
+		{
+			name:       "first function",
+			kind:       "function_definition",
+			startByte:  23,
+			startPoint: gotreesitter.Point{Row: 1, Column: 2},
+			endByte:    66,
+			endPoint:   gotreesitter.Point{Row: 5, Column: 2},
+		},
+		{
+			name:       "first indented block",
+			kind:       "indented_block",
+			startByte:  39,
+			startPoint: gotreesitter.Point{Row: 2, Column: 4},
+			endByte:    66,
+			endPoint:   gotreesitter.Point{Row: 5, Column: 2},
+		},
+		{
+			name:       "first case clause",
+			kind:       "case_clause",
+			startByte:  125,
+			startPoint: gotreesitter.Point{Row: 9, Column: 6},
+			endByte:    156,
+			endPoint:   gotreesitter.Point{Row: 11, Column: 6},
+		},
+		{
+			name:       "second case clause",
+			kind:       "case_clause",
+			startByte:  156,
+			startPoint: gotreesitter.Point{Row: 11, Column: 6},
+			endByte:    186,
+			endPoint:   gotreesitter.Point{Row: 13, Column: 4},
+		},
+	}
+	for _, receipt := range receipts {
+		root := receipt.tree.RootNode()
+		for _, want := range spans {
+			node := scalaSpanOwnershipNode(root, lang, want.kind, want.startByte)
+			if node == nil {
+				t.Fatalf(
+					"%s route is missing %s at byte %d: %s",
+					receipt.name,
+					want.name,
+					want.startByte,
+					root.SExpr(lang),
+				)
+			}
+			if node.StartByte() != want.startByte || node.StartPoint() != want.startPoint ||
+				node.EndByte() != want.endByte || node.EndPoint() != want.endPoint {
+				t.Fatalf(
+					"%s %s range = %d:%#v-%d:%#v, want %d:%#v-%d:%#v",
+					receipt.name,
+					want.name,
+					node.StartByte(),
+					node.StartPoint(),
+					node.EndByte(),
+					node.EndPoint(),
+					want.startByte,
+					want.startPoint,
+					want.endByte,
+					want.endPoint,
+				)
+			}
+		}
+		if receipt.name != "incremental" {
+			continue
+		}
+		profile := receipt.incrementalProfile
+		if !profile.ReuseUnsupported ||
+			profile.ReuseUnsupportedReason != "external_scanner_unsupported" ||
+			profile.OldTreeReuseRoute ||
+			profile.ReusedSubtrees != 0 ||
+			profile.ReusedBytes != 0 {
+			t.Fatalf("incremental Scala reuse receipt = %+v", profile)
+		}
+	}
+}
+
+func scalaSpanOwnershipNode(
+	node *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	kind string,
+	startByte uint32,
+) *gotreesitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Type(lang) == kind && node.StartByte() == startByte {
+		return node
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		found := scalaSpanOwnershipNode(node.Child(index), lang, kind, startByte)
+		if found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/parser_api.go
+++ b/parser_api.go
@@ -77,20 +77,6 @@ const (
 // ParserLogger receives parser debug logs when configured via SetLogger.
 type ParserLogger func(kind ParserLogType, message string)
 
-func normalizeReturnedTree(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil {
-		return
-	}
-	switch lang.Name {
-	case "scala":
-		normalizeScalaProducedSpanRetirementPending(root, source, lang)
-	}
-}
-
-// normalizeScalaProducedSpanRetirementPending keeps the live registry
-// bisectable until the returned-tree fixpoint is deleted. It does not mutate.
-func normalizeScalaProducedSpanRetirementPending(_ *Node, _ []byte, _ *Language) {}
-
 func shouldNormalizeIncrementalReturnedTree(tree, oldTree *Tree) bool {
 	if tree == nil {
 		return false
@@ -119,10 +105,6 @@ func (p *Parser) normalizeReturnedIncrementalTree(tree, oldTree *Tree, source []
 			return
 		}
 		tree.resultCompatibilityApplied = true
-	}
-	if reason := p.normalizePostFinalizationReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
-		tree.setParseStopReason(reason)
-		return
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }
@@ -157,10 +139,6 @@ func (p *Parser) normalizeReturnedTreeForParse(tree *Tree, source []byte) {
 			return
 		}
 		tree.resultCompatibilityApplied = true
-	}
-	if reason := p.normalizePostFinalizationReturnedTree(rawRootOrNil(tree), source); parseStopReasonIsTerminal(reason) {
-		tree.setParseStopReason(reason)
-		return
 	}
 	finalizeReturnedTreeRootSpan(tree, source)
 }
@@ -385,17 +363,6 @@ func (p *Parser) normalizeReturnedTree(root *Node, source []byte, incrementalRan
 		return reason
 	}
 	normalizeResultCompatibility(root, source, p, incrementalRanges)
-	return p.parseStopReasonNow()
-}
-
-func (p *Parser) normalizePostFinalizationReturnedTree(root *Node, source []byte) ParseStopReason {
-	if p == nil || p.language == nil || root == nil || p.noResultCompatibilityBenchmarkOnly {
-		return ParseStopNone
-	}
-	if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
-		return reason
-	}
-	normalizeReturnedTree(root, source, p.language)
 	return p.parseStopReasonNow()
 }
 

--- a/parser_api.go
+++ b/parser_api.go
@@ -83,16 +83,12 @@ func normalizeReturnedTree(root *Node, source []byte, lang *Language) {
 	}
 	switch lang.Name {
 	case "scala":
-		normalizeScalaTemplateBodyObjectFragments(root, source, nil, lang)
-		normalizeScalaRecoveredObjectTemplateBodies(root, source, nil, lang)
-		normalizeScalaDefinitionFields(root, source, lang)
-		normalizeScalaTemplateBodyFunctionAnnotations(root, source, nil, lang)
 		normalizeScalaProducedSpanRetirementPending(root, source, lang)
 	}
 }
 
 // normalizeScalaProducedSpanRetirementPending keeps the live registry
-// bisectable until the span retirement commit exists. It does not mutate.
+// bisectable until the returned-tree fixpoint is deleted. It does not mutate.
 func normalizeScalaProducedSpanRetirementPending(_ *Node, _ []byte, _ *Language) {}
 
 func shouldNormalizeIncrementalReturnedTree(tree, oldTree *Tree) bool {

--- a/parser_api.go
+++ b/parser_api.go
@@ -87,11 +87,13 @@ func normalizeReturnedTree(root *Node, source []byte, lang *Language) {
 		normalizeScalaRecoveredObjectTemplateBodies(root, source, nil, lang)
 		normalizeScalaDefinitionFields(root, source, lang)
 		normalizeScalaTemplateBodyFunctionAnnotations(root, source, nil, lang)
-		normalizeScalaTemplateBodyFunctionEnds(root, source, lang)
-		normalizeScalaCaseClauseEnds(root, source, lang)
-		normalizeRootEOFNewlineSpan(root, source, lang)
+		normalizeScalaProducedSpanRetirementPending(root, source, lang)
 	}
 }
+
+// normalizeScalaProducedSpanRetirementPending keeps the live registry
+// bisectable until the span retirement commit exists. It does not mutate.
+func normalizeScalaProducedSpanRetirementPending(_ *Node, _ []byte, _ *Language) {}
 
 func shouldNormalizeIncrementalReturnedTree(tree, oldTree *Tree) bool {
 	if tree == nil {

--- a/parser_reduce_span_test.go
+++ b/parser_reduce_span_test.go
@@ -63,6 +63,44 @@ func TestRewriteRefreshCanWidenProducedSpan(t *testing.T) {
 	}
 }
 
+func TestRewriteRefreshPreservesProducedSpanAcrossMultipleChildren(t *testing.T) {
+	original := NewLeafNode(2, true, 10, 24, Point{Column: 10}, Point{Row: 1, Column: 2})
+	parent := NewParentNode(3, true, []*Node{original}, nil, 7)
+	parent.endByte = 30
+	parent.endPoint = Point{Row: 1, Column: 8}
+
+	first := NewLeafNode(2, true, 12, 16, Point{Column: 12}, Point{Column: 16})
+	second := NewLeafNode(2, true, 18, 22, Point{Column: 18}, Point{Column: 22})
+	second.setHasError(true)
+	third := NewLeafNode(2, true, 24, 26, Point{Row: 1, Column: 2}, Point{Row: 1, Column: 4})
+	parent.children = []*Node{first, second, third}
+	refreshRewrittenParentPreservingProducedSpan(parent, parent.children)
+
+	if got, want := parent.startByte, uint32(10); got != want {
+		t.Fatalf("parent start byte = %d, want %d", got, want)
+	}
+	if got, want := parent.endByte, uint32(30); got != want {
+		t.Fatalf("parent end byte = %d, want %d", got, want)
+	}
+	if got, want := parent.endPoint, (Point{Row: 1, Column: 8}); got != want {
+		t.Fatalf("parent end point = %#v, want %#v", got, want)
+	}
+	for index, child := range parent.children {
+		if child.parent != parent || child.childIndex != int32(index) {
+			t.Fatalf("child %d link = (%p, %d), want (%p, %d)", index, child.parent, child.childIndex, parent, index)
+		}
+	}
+	if !parent.hasError() {
+		t.Fatal("rewrite refresh did not collect the error state from all children")
+	}
+
+	second.setHasError(false)
+	refreshRewrittenParentPreservingProducedSpan(parent, parent.children)
+	if parent.hasError() {
+		t.Fatal("rewrite refresh retained a stale child error state")
+	}
+}
+
 func TestExtendParentSpanCoversInvisibleLeafChild(t *testing.T) {
 	// Invisible non-extra leaf child [20-22] dropped by buildReduceChildren
 	// should extend parent endByte from 20 to 22 (contiguous), but leading

--- a/parser_reduce_span_test.go
+++ b/parser_reduce_span_test.go
@@ -11,6 +11,58 @@ func extendParentSpanToWindowForSourceTest(parent *Node, entries []stackEntry, s
 	extendParentSpanToWindow(parent, entries, start, reducedEnd, symbolMeta, spanExtending, nonSpanExtending, source)
 }
 
+func TestRewriteRefreshPreservesProducedSpan(t *testing.T) {
+	visible := NewLeafNode(2, true, 10, 20, Point{Column: 10}, Point{Column: 20})
+	parent := NewParentNode(3, true, []*Node{visible}, nil, 7)
+	parent.endByte = 24
+	parent.endPoint = Point{Row: 1, Column: 2}
+
+	replacement := NewLeafNode(2, true, 10, 18, Point{Column: 10}, Point{Column: 18})
+	replacement.setHasError(true)
+	parent.children = []*Node{replacement}
+	refreshRewrittenParentPreservingProducedSpan(parent, parent.children)
+
+	if got, want := parent.startByte, uint32(10); got != want {
+		t.Fatalf("parent start byte = %d, want %d", got, want)
+	}
+	if got, want := parent.endByte, uint32(24); got != want {
+		t.Fatalf("parent end byte = %d, want %d", got, want)
+	}
+	if got, want := parent.endPoint, (Point{Row: 1, Column: 2}); got != want {
+		t.Fatalf("parent end point = %#v, want %#v", got, want)
+	}
+	if replacement.parent != parent || replacement.childIndex != 0 {
+		t.Fatal("rewrite refresh did not restore the child link")
+	}
+	if !parent.hasError() {
+		t.Fatal("rewrite refresh did not update the parent error state")
+	}
+}
+
+func TestRewriteRefreshCanWidenProducedSpan(t *testing.T) {
+	visible := NewLeafNode(2, true, 10, 20, Point{Column: 10}, Point{Column: 20})
+	parent := NewParentNode(3, true, []*Node{visible}, nil, 7)
+	parent.endByte = 24
+	parent.endPoint = Point{Row: 1, Column: 2}
+
+	replacement := NewLeafNode(2, true, 8, 30, Point{Column: 8}, Point{Row: 1, Column: 8})
+	parent.children = []*Node{replacement}
+	refreshRewrittenParentPreservingProducedSpan(parent, parent.children)
+
+	if got, want := parent.startByte, uint32(8); got != want {
+		t.Fatalf("parent start byte = %d, want %d", got, want)
+	}
+	if got, want := parent.startPoint, (Point{Column: 8}); got != want {
+		t.Fatalf("parent start point = %#v, want %#v", got, want)
+	}
+	if got, want := parent.endByte, uint32(30); got != want {
+		t.Fatalf("parent end byte = %d, want %d", got, want)
+	}
+	if got, want := parent.endPoint, (Point{Row: 1, Column: 8}); got != want {
+		t.Fatalf("parent end point = %#v, want %#v", got, want)
+	}
+}
+
 func TestExtendParentSpanCoversInvisibleLeafChild(t *testing.T) {
 	// Invisible non-extra leaf child [20-22] dropped by buildReduceChildren
 	// should extend parent endByte from 20 to 22 (contiguous), but leading

--- a/parser_result_javascript_typescript_compat_test.go
+++ b/parser_result_javascript_typescript_compat_test.go
@@ -422,14 +422,16 @@ func TestDeferredResultCompatibilityStateScrubbedAcrossTreePoolLifecycle(t *test
 	tree.Release()
 }
 
-func TestReturnedTreeNormalizationUsesRawRootForDeferredTypeScriptCompatibility(t *testing.T) {
+func TestRawRootAccessKeepsDeferredTypeScriptCompatibility(t *testing.T) {
 	lang, root, stmt := newDeferredCompatDynamicImportFixture()
 	tree := newTreeWithArenas(root, []byte("import"), lang, root.ownerArena, nil)
 	tree.deferResultCompatibility()
 
-	normalizeReturnedTree(rawRootOrNil(tree), []byte("import"), lang)
+	if got := rawRootOrNil(tree); got != root {
+		t.Fatalf("raw root = %p, want %p", got, root)
+	}
 	if got := resultChildCount(stmt); got != 0 {
-		t.Fatalf("import child count after returned-tree normalization = %d, want deferred", got)
+		t.Fatalf("import child count after raw root access = %d, want deferred", got)
 	}
 	_ = tree.RootNode()
 	if got, want := resultChildCount(stmt), 1; got != want {

--- a/parser_result_javascript_typescript_test.go
+++ b/parser_result_javascript_typescript_test.go
@@ -176,7 +176,7 @@ func TestNormalizeJavaScriptProgramEndExtendsErrorRootTerminatorTail(t *testing.
 	}
 }
 
-func TestFinalizeResultRootOwnsJavaScriptProgramEndBeforeReturnedTreePass(t *testing.T) {
+func TestFinalizeResultRootOwnsJavaScriptProgramEndWithoutReturnedTreePass(t *testing.T) {
 	lang := &Language{
 		Name:        "javascript",
 		SymbolNames: []string{"EOF", "program", "call_expression"},
@@ -226,14 +226,6 @@ func TestFinalizeResultRootOwnsJavaScriptProgramEndBeforeReturnedTreePass(t *tes
 
 			if got, want := root.EndByte(), uint32(len(source)); got != want {
 				t.Fatalf("root end byte after canonical finalization = %d, want %d", got, want)
-			}
-			before := root.EndPoint()
-			normalizeReturnedTree(root, source, lang)
-			if got := root.EndByte(); got != uint32(len(source)) {
-				t.Fatalf("root end byte after returned-tree pass = %d, want %d", got, len(source))
-			}
-			if got := root.EndPoint(); got != before {
-				t.Fatalf("root end point changed after returned-tree pass: got %+v want %+v", got, before)
 			}
 			if tc.name == "compact-final-child-refs" && !nodeHasFinalChildRefs(root) {
 				t.Fatal("canonical JavaScript finalization drained compact final-child refs")

--- a/parser_result_scala_compilation.go
+++ b/parser_result_scala_compilation.go
@@ -13,11 +13,9 @@ func normalizeScalaCompatibility(root *Node, source []byte, parser *Parser, lang
 	normalizeScalaDefinitionFields(root, source, lang)
 	normalizeScalaTemplateBodyFunctionAnnotations(root, source, parser, lang)
 	normalizeScalaImportPathFields(root, lang)
-	normalizeScalaTemplateBodyFunctionEnds(root, source, lang)
 	normalizeScalaTrailingCommentOwnership(root, source, lang)
 	normalizeScalaFunctionModifierFields(root, lang)
 	normalizeScalaInterpolatedStringTail(root, source, lang)
-	normalizeScalaCaseClauseEnds(root, source, lang)
 	normalizeRootEOFNewlineSpan(root, source, lang)
 }
 
@@ -344,7 +342,7 @@ func normalizeScalaImportPathFields(root *Node, lang *Language) {
 	})
 }
 
-func normalizeScalaDefinitionFields(root *Node, source []byte, lang *Language) {
+func normalizeScalaDefinitionFields(root *Node, _ []byte, lang *Language) {
 	if root == nil || lang == nil || lang.Name != "scala" {
 		return
 	}
@@ -512,25 +510,6 @@ func normalizeScalaDefinitionFields(root *Node, source []byte, lang *Language) {
 					n.fieldSources()[i] = fieldSourceDirect
 				}
 			}
-		case "case_block":
-			for i := 0; i+1 < len(n.children); i++ {
-				curr := n.children[i]
-				if curr == nil || curr.Type(lang) != "case_clause" {
-					continue
-				}
-				next := scalaNextCaseClauseBoundaryNode(n.children, i, lang)
-				if next == nil {
-					continue
-				}
-				if curr.endByte >= next.startByte {
-					continue
-				}
-				gap := source[curr.endByte:next.startByte]
-				if !bytesAreTrivia(gap) || !bytesContainLineBreak(gap) {
-					continue
-				}
-				extendNodeEndTo(curr, next.startByte, source)
-			}
 		}
 	})
 }
@@ -589,86 +568,10 @@ func normalizeScalaTemplateBodyFunctionAnnotations(root *Node, source []byte, pa
 				if metadataChanged {
 					child.setFieldMetadata(childFieldIDs, childFieldSources)
 				}
-				populateParentNode(child, child.children)
+				refreshRewrittenParentPreservingProducedSpan(child, child.children)
 			}
 		}
 	})
-}
-
-func normalizeScalaCaseClauseEnds(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "scala" || len(source) == 0 {
-		return
-	}
-	walkResultTree(root, func(n *Node) {
-		if n.Type(lang) == "case_block" {
-			for i := 0; i+1 < len(n.children); i++ {
-				curr := n.children[i]
-				if curr == nil || curr.Type(lang) != "case_clause" {
-					continue
-				}
-				next := scalaNextCaseClauseBoundaryNode(n.children, i, lang)
-				if next == nil {
-					continue
-				}
-				if curr.endByte >= next.startByte || int(next.startByte) > len(source) {
-					continue
-				}
-				gap := source[curr.endByte:next.startByte]
-				if !bytesAreTrivia(gap) || !bytesContainLineBreak(gap) {
-					continue
-				}
-				extendNodeEndTo(curr, next.startByte, source)
-			}
-		}
-	})
-}
-
-func normalizeScalaTemplateBodyFunctionEnds(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "scala" || len(source) == 0 {
-		return
-	}
-	walkResultTree(root, func(n *Node) {
-		if n.Type(lang) == "template_body" {
-			for i := 0; i+1 < len(n.children); i++ {
-				curr := n.children[i]
-				next := n.children[i+1]
-				if curr == nil || next == nil || curr.Type(lang) != "function_definition" || next.IsExtra() {
-					continue
-				}
-				if len(curr.children) == 0 {
-					continue
-				}
-				last := curr.children[len(curr.children)-1]
-				if last == nil || last.Type(lang) != "indented_block" {
-					continue
-				}
-				if curr.endByte >= next.startByte || int(next.startByte) > len(source) {
-					continue
-				}
-				gap := source[curr.endByte:next.startByte]
-				if !bytesAreTrivia(gap) || !bytesContainLineBreak(gap) {
-					continue
-				}
-				extendNodeEndTo(last, next.startByte, source)
-				extendNodeEndTo(curr, next.startByte, source)
-			}
-		}
-	})
-}
-
-func scalaNextCaseClauseBoundaryNode(children []*Node, start int, lang *Language) *Node {
-	for i := start + 1; i < len(children); i++ {
-		child := children[i]
-		if child == nil {
-			continue
-		}
-		switch child.Type(lang) {
-		case "_automatic_semicolon":
-			continue
-		}
-		return child
-	}
-	return nil
 }
 
 func rootLooksLikeScalaCompilationUnit(root *Node, lang *Language) bool {

--- a/parser_result_scala_fixpoint_retirement_test.go
+++ b/parser_result_scala_fixpoint_retirement_test.go
@@ -1,0 +1,146 @@
+package gotreesitter
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScalaFormerSecondPassIsInertAfterCanonicalCompatibility(t *testing.T) {
+	lang := loadScalaLanguageForFixpointRetirementTest(t)
+	fixtures := map[string][]byte{
+		"object_fragments": []byte(`object Outer {
+  object Inner {
+    val value = 1
+  }
+}`),
+		"block_comment": []byte(`object Outer {
+  /* comment */
+  val value = 1
+}`),
+		"definition_fields": []byte(`object Outer {
+  def choose(value: Int): Int =
+    if value == 0 then 1 else 2
+}`),
+		"annotation": []byte(`object Outer {
+  @deprecated
+  def value = 1
+}`),
+	}
+
+	for name, source := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			assertScalaFormerSecondPassIsInert(t, lang, source)
+		})
+	}
+}
+
+func TestScalaFormerSecondPassIsInertOverRealCorpus(t *testing.T) {
+	const corpusRoot = "cgo_harness/corpus_real/scala"
+	info, err := os.Stat(corpusRoot)
+	if os.IsNotExist(err) {
+		t.Skipf("optional authenticated Scala corpus is absent: %s", corpusRoot)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("authenticated Scala corpus path is not a directory: %s", corpusRoot)
+	}
+
+	lang := loadScalaLanguageForFixpointRetirementTest(t)
+	files := 0
+	err = filepath.Walk(corpusRoot, func(path string, fileInfo os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if fileInfo.IsDir() || !strings.HasSuffix(path, ".scala") {
+			return nil
+		}
+		source, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			assertScalaFormerSecondPassIsInert(t, lang, source)
+		})
+		files++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if files == 0 {
+		t.Fatalf("authenticated Scala corpus is empty: %s", corpusRoot)
+	}
+}
+
+func assertScalaFormerSecondPassIsInert(t *testing.T, lang *Language, source []byte) {
+	t.Helper()
+	tree, err := NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+
+	root := rawRootOrNil(tree)
+	before := scalaFixpointRetirementTreeFingerprint(root)
+	normalizeScalaTemplateBodyObjectFragments(root, source, nil, lang)
+	normalizeScalaRecoveredObjectTemplateBodies(root, source, nil, lang)
+	normalizeScalaDefinitionFields(root, source, lang)
+	normalizeScalaTemplateBodyFunctionAnnotations(root, source, nil, lang)
+	after := scalaFixpointRetirementTreeFingerprint(root)
+	if after != before {
+		t.Fatalf("former Scala second pass mutated the canonical tree: %x -> %x", before, after)
+	}
+}
+
+func loadScalaLanguageForFixpointRetirementTest(t *testing.T) *Language {
+	t.Helper()
+	blob, err := os.ReadFile("grammars/grammar_blobs/scala.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lang, err := LoadLanguage(blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lang
+}
+
+func scalaFixpointRetirementTreeFingerprint(root *Node) [32]byte {
+	hash := sha256.New()
+	var walk func(*Node)
+	walk = func(node *Node) {
+		if node == nil {
+			fmt.Fprint(hash, "nil;")
+			return
+		}
+		fmt.Fprintf(
+			hash,
+			"%d:%d:%d:%d:%d:%d:%d:%t:%t:%t:%d:%v;",
+			node.symbol,
+			node.startByte,
+			node.endByte,
+			node.startPoint.Row,
+			node.startPoint.Column,
+			node.endPoint.Row,
+			node.endPoint.Column,
+			node.isNamed(),
+			node.IsExtra(),
+			node.HasError(),
+			node.productionID,
+			node.fieldIDs(),
+		)
+		for _, child := range node.children {
+			walk(child)
+		}
+	}
+	walk(root)
+	var fingerprint [32]byte
+	copy(fingerprint[:], hash.Sum(nil))
+	return fingerprint
+}

--- a/parser_result_scala_produced_span_test.go
+++ b/parser_result_scala_produced_span_test.go
@@ -1,0 +1,120 @@
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestScalaProducedSpanBeforeCompatibility(t *testing.T) {
+	const sourceText = `object SpanReceipt {
+  def first =
+    val value = 1
+    value
+
+  def second = 2
+
+  def choose(n: Int) =
+    n match {
+      case 0 =>
+        "zero"
+      case _ =>
+        "other"
+    }
+}
+`
+	source := []byte(sourceText)
+	lang := grammars.ScalaLanguage()
+	tree, err := gotreesitter.NewParser(lang).ParseNoResultCompatibilityBenchmarkOnly(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	if root == nil || root.HasError() {
+		t.Fatalf("compatibility-free Scala parse returned an invalid tree: %v", root)
+	}
+
+	// The C parser pinned in grammars/languages.lock produced these ranges.
+	receipt := []struct {
+		name       string
+		kind       string
+		startByte  uint32
+		startPoint gotreesitter.Point
+		endByte    uint32
+		endPoint   gotreesitter.Point
+	}{
+		{
+			name:       "first function",
+			kind:       "function_definition",
+			startByte:  23,
+			startPoint: gotreesitter.Point{Row: 1, Column: 2},
+			endByte:    66,
+			endPoint:   gotreesitter.Point{Row: 5, Column: 2},
+		},
+		{
+			name:       "first indented block",
+			kind:       "indented_block",
+			startByte:  39,
+			startPoint: gotreesitter.Point{Row: 2, Column: 4},
+			endByte:    66,
+			endPoint:   gotreesitter.Point{Row: 5, Column: 2},
+		},
+		{
+			name:       "first case clause",
+			kind:       "case_clause",
+			startByte:  125,
+			startPoint: gotreesitter.Point{Row: 9, Column: 6},
+			endByte:    156,
+			endPoint:   gotreesitter.Point{Row: 11, Column: 6},
+		},
+		{
+			name:       "second case clause",
+			kind:       "case_clause",
+			startByte:  156,
+			startPoint: gotreesitter.Point{Row: 11, Column: 6},
+			endByte:    186,
+			endPoint:   gotreesitter.Point{Row: 13, Column: 4},
+		},
+	}
+	for _, want := range receipt {
+		node := findScalaProducedSpanNode(root, lang, want.kind, want.startByte)
+		if node == nil {
+			t.Fatalf("%s is missing at byte %d: %s", want.name, want.startByte, root.SExpr(lang))
+		}
+		if got := node.StartByte(); got != want.startByte {
+			t.Fatalf("%s start byte = %d, want %d", want.name, got, want.startByte)
+		}
+		if got := node.StartPoint(); got != want.startPoint {
+			t.Fatalf("%s start point = %#v, want %#v", want.name, got, want.startPoint)
+		}
+		if got := node.EndByte(); got != want.endByte {
+			t.Fatalf("%s end byte = %d, want %d", want.name, got, want.endByte)
+		}
+		if got := node.EndPoint(); got != want.endPoint {
+			t.Fatalf("%s end point = %#v, want %#v", want.name, got, want.endPoint)
+		}
+	}
+}
+
+func findScalaProducedSpanNode(
+	node *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	kind string,
+	startByte uint32,
+) *gotreesitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Type(lang) == kind && node.StartByte() == startByte {
+		return node
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		if found := findScalaProducedSpanNode(node.Child(index), lang, kind, startByte); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -2397,16 +2397,10 @@
       "functions": [
         "normalizeReturnedTree",
         "normalizePostFinalizationReturnedTree",
-        "normalizeScalaTemplateBodyObjectFragments",
-        "normalizeScalaRecoveredObjectTemplateBodies",
-        "normalizeScalaDefinitionFields",
-        "normalizeScalaTemplateBodyFunctionAnnotations",
         "normalizeScalaProducedSpanRetirementPending"
       ],
       "files": [
-        "parser_api.go",
-        "parser_result_scala_template.go",
-        "parser_result_scala_compilation.go"
+        "parser_api.go"
       ],
       "languages": [
         "scala"
@@ -2420,24 +2414,21 @@
             "scala"
           ],
           "functions": [
-            "normalizeScalaTemplateBodyObjectFragments",
-            "normalizeScalaRecoveredObjectTemplateBodies",
-            "normalizeScalaDefinitionFields",
-            "normalizeScalaTemplateBodyFunctionAnnotations",
             "normalizeScalaProducedSpanRetirementPending"
           ]
         }
       ],
-      "purpose": "Retain the bounded second pass for four Scala recovery, field, and annotation repairs. The inert span marker keeps checkpoint A bisectable until its commit can become the retirement receipt.",
+      "purpose": "Retain one inert marker so the registry stays bisectable until the returned-tree fixpoint scaffolding is deleted.",
       "authoritative_owner": "materialization",
       "witnesses": [
         "parser_result_test/parser_result_scala_comment_attachment_test.go",
         "parser_result_scala_produced_span_test.go",
+        "parser_result_scala_fixpoint_retirement_test.go",
         "parser_reduce_span_test.go",
         "grammars/scala_span_ownership_test.go",
         "cgo_harness/scala_span_ownership_parity_test.go"
       ],
-      "retirement_condition": "Delete the inert span marker after checkpoint A records its commit. Delete the remaining arm only after the Scala producer emits the four retained repairs before finalization.",
+      "retirement_condition": "Delete the inert marker and shared fixpoint after checkpoint B records the zero-mutation census and canonical first-pass witness.",
       "route_coverage": {
         "production": "post_finalization_fixpoint",
         "compact": "post_finalization_fixpoint",

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -2401,15 +2401,12 @@
         "normalizeScalaRecoveredObjectTemplateBodies",
         "normalizeScalaDefinitionFields",
         "normalizeScalaTemplateBodyFunctionAnnotations",
-        "normalizeScalaTemplateBodyFunctionEnds",
-        "normalizeScalaCaseClauseEnds",
-        "normalizeRootEOFNewlineSpan"
+        "normalizeScalaProducedSpanRetirementPending"
       ],
       "files": [
         "parser_api.go",
         "parser_result_scala_template.go",
-        "parser_result_scala_compilation.go",
-        "parser_result_misc_spans.go"
+        "parser_result_scala_compilation.go"
       ],
       "languages": [
         "scala"
@@ -2427,18 +2424,20 @@
             "normalizeScalaRecoveredObjectTemplateBodies",
             "normalizeScalaDefinitionFields",
             "normalizeScalaTemplateBodyFunctionAnnotations",
-            "normalizeScalaTemplateBodyFunctionEnds",
-            "normalizeScalaCaseClauseEnds",
-            "normalizeRootEOFNewlineSpan"
+            "normalizeScalaProducedSpanRetirementPending"
           ]
         }
       ],
-      "purpose": "Retain the bounded second pass that reaches a returned-tree fixpoint after finalization for Scala annotations and bounds.",
+      "purpose": "Retain the bounded second pass for four Scala recovery, field, and annotation repairs. The inert span marker keeps checkpoint A bisectable until its commit can become the retirement receipt.",
       "authoritative_owner": "materialization",
       "witnesses": [
-        "parser_result_test/parser_result_scala_comment_attachment_test.go"
+        "parser_result_test/parser_result_scala_comment_attachment_test.go",
+        "parser_result_scala_produced_span_test.go",
+        "parser_reduce_span_test.go",
+        "grammars/scala_span_ownership_test.go",
+        "cgo_harness/scala_span_ownership_parity_test.go"
       ],
-      "retirement_condition": "Delete only after the Scala producer emits final annotations and spans in one pass. Require exact production, compact, forest, incremental, and C-oracle receipts.",
+      "retirement_condition": "Delete the inert span marker after checkpoint A records its commit. Delete the remaining arm only after the Scala producer emits the four retained repairs before finalization.",
       "route_coverage": {
         "production": "post_finalization_fixpoint",
         "compact": "post_finalization_fixpoint",

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -6,8 +6,8 @@
     "dispatcher_languages": 82,
     "dispatcher_predicates": 1,
     "generic_passes": 0,
-    "post_finalization_arms": 1,
-    "post_finalization_languages": 1
+    "post_finalization_arms": 0,
+    "post_finalization_languages": 0
   },
   "owner_categories": [
     "scheduler_action_semantics",
@@ -2397,10 +2397,19 @@
       "functions": [
         "normalizeReturnedTree",
         "normalizePostFinalizationReturnedTree",
-        "normalizeScalaProducedSpanRetirementPending"
+        "normalizeScalaTemplateBodyObjectFragments",
+        "normalizeScalaRecoveredObjectTemplateBodies",
+        "normalizeScalaDefinitionFields",
+        "normalizeScalaTemplateBodyFunctionAnnotations",
+        "normalizeScalaTemplateBodyFunctionEnds",
+        "normalizeScalaCaseClauseEnds",
+        "normalizeRootEOFNewlineSpan"
       ],
       "files": [
-        "parser_api.go"
+        "parser_api.go",
+        "parser_result_scala_template.go",
+        "parser_result_scala_compilation.go",
+        "parser_result_misc_spans.go"
       ],
       "languages": [
         "scala"
@@ -2414,11 +2423,17 @@
             "scala"
           ],
           "functions": [
-            "normalizeScalaProducedSpanRetirementPending"
+            "normalizeScalaTemplateBodyObjectFragments",
+            "normalizeScalaRecoveredObjectTemplateBodies",
+            "normalizeScalaDefinitionFields",
+            "normalizeScalaTemplateBodyFunctionAnnotations",
+            "normalizeScalaTemplateBodyFunctionEnds",
+            "normalizeScalaCaseClauseEnds",
+            "normalizeRootEOFNewlineSpan"
           ]
         }
       ],
-      "purpose": "Retain one inert marker so the registry stays bisectable until the returned-tree fixpoint scaffolding is deleted.",
+      "purpose": "Historical Scala arm of the returned-tree second-pass fixpoint. It repeated recovery, field, annotation, and span repairs after finalization.",
       "authoritative_owner": "materialization",
       "witnesses": [
         "parser_result_test/parser_result_scala_comment_attachment_test.go",
@@ -2428,16 +2443,23 @@
         "grammars/scala_span_ownership_test.go",
         "cgo_harness/scala_span_ownership_parity_test.go"
       ],
-      "retirement_condition": "Delete the inert marker and shared fixpoint after checkpoint B records the zero-mutation census and canonical first-pass witness.",
+      "retirement_condition": "Satisfied: canonical compatibility owns recovery, fields, and annotations. Materialization and rewrite refresh own final spans.",
       "route_coverage": {
-        "production": "post_finalization_fixpoint",
-        "compact": "post_finalization_fixpoint",
-        "forest": "post_finalization_fixpoint",
-        "incremental": "post_finalization_fixpoint",
-        "c_oracle": "language_witnesses_required"
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
       },
-      "status": "live",
-      "receipt_refs": []
+      "status": "retired",
+      "retired_commit": "d82f9c2cadb81242cb324ba751aa2805038d4b60",
+      "receipt_refs": [
+        "parser_result_scala_fixpoint_retirement_test.go",
+        "parser_result_scala_produced_span_test.go",
+        "parser_reduce_span_test.go",
+        "grammars/scala_span_ownership_test.go",
+        "cgo_harness/scala_span_ownership_parity_test.go"
+      ]
     },
     {
       "id": "fixpoint.returned-tree-second-pass.html",

--- a/tree.go
+++ b/tree.go
@@ -1987,13 +1987,14 @@ func populateParentNode(n *Node, children []*Node) {
 		n.startPoint = first.startPoint
 		n.endPoint = last.endPoint
 
+		hasError := false
 		for i, c := range children {
 			setNodeParentLink(c, n, i)
 			if c.hasError() {
-				n.setHasError(true)
-				break
+				hasError = true
 			}
 		}
+		n.setHasError(hasError)
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -1997,6 +1997,34 @@ func populateParentNode(n *Node, children []*Node) {
 	}
 }
 
+// refreshRewrittenParentPreservingProducedSpan refreshes an existing parent
+// after an in-place child rewrite. A produced span can widen but cannot shrink.
+func refreshRewrittenParentPreservingProducedSpan(n *Node, children []*Node) {
+	if n == nil {
+		return
+	}
+	oldStartByte := n.startByte
+	oldEndByte := n.endByte
+	oldStartPoint := n.startPoint
+	oldEndPoint := n.endPoint
+	preserveProducedSpan := n.productionID != 0 &&
+		oldStartByte <= oldEndByte &&
+		!pointLessThan(oldEndPoint, oldStartPoint)
+
+	populateParentNode(n, children)
+	if !preserveProducedSpan {
+		return
+	}
+	if n.startByte >= oldStartByte {
+		n.startByte = oldStartByte
+		n.startPoint = oldStartPoint
+	}
+	if n.endByte <= oldEndByte {
+		n.endByte = oldEndByte
+		n.endPoint = oldEndPoint
+	}
+}
+
 // populateParentNodeNoLinks computes parent span/error metadata from children
 // without wiring child.parent/childIndex links. Used on deferred-link paths.
 func populateParentNodeNoLinks(n *Node, children []*Node, trackChildErrors bool) {


### PR DESCRIPTION
## Summary

- Preserve producer-owned spans during shared child rewrites.
- Link every rewritten child and recompute the parent error state.
- Remove the Scala returned-tree span repairs.
- Remove duplicate Scala recovery, field, and annotation calls.
- Remove the last post-finalization fixpoint.

The post-finalization registry now contains no normalization arm.

## Correctness

Focused Docker tests passed for these areas:

- Shared rewrite span preservation.
- Multi-child parent links and error state.
- Scala producer-owned spans.
- Scala fixpoint inertness.
- Scala route ownership.

The exact Scala C oracle passed with `treesitter_c_parity`.
Focused race tests passed for the shared rewrite and Scala route.

The isolated Scala parity run completed without a crash or memory failure.
It passed its Go test command in 52 seconds.
Its aggressive floor reported 10 of 25 clean cases and five deep parity cases.
That floor remains diagnostic and does not require parity.

## Performance

The benchmark used one processor, ten samples, and 750 milliseconds per sample.
The comparison used current `origin/main`.

- Full parse increased by 1.37 percent.
- Incremental single-byte edit time decreased by 1.29 percent.
- Incremental no-edit time did not change.
- Bytes and allocations per operation did not change.

The full-parse change is small but measurable.
The generalized child-link fix performs required work after an error child.

## Review

Qwen 3.7 Plus completed the bounded branch review in three minutes and 27 seconds.
The review required package evidence that was not present in that session.
It also requested the multi-child test and documentation edits included here.

## Release

Queue this unreleased behavior for the Thursday release train.
