### PR TITLE
optimize(parser): cache override presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,13 @@ for tags and release notes while still in `0.x`.
   retiring a generic compatibility pass while preserving error-root recovery
   extras and lazy compact child references.
 
+### Performance
+
+- Parser retry policy now snapshots override presence with each parsed value.
+  This removes repeated environment lookups from the incremental hot path.
+  The pinned edited incremental benchmark improves 1.28 percent with zero
+  allocations.
+
 ## [0.47.0] - 2026-07-22
 
 ### Changed

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -687,9 +687,11 @@ func TestCertifiedDuplicateWideRetryFallbackScope(t *testing.T) {
 	for _, env := range []string{"GOT_GLR_MAX_STACKS", "GOT_GLR_MAX_MERGE_PER_KEY", "GOT_PARSE_NODE_LIMIT_SCALE"} {
 		t.Run(env, func(t *testing.T) {
 			t.Setenv(env, "2")
+			ResetParseEnvConfigCacheForTests()
 			parser, tree := eligible()
 			assertFallback("explicit "+env, parser, tree, sourceLen, fullParseRetryOriginFresh, 0)
 			t.Setenv(env, "")
+			ResetParseEnvConfigCacheForTests()
 		})
 	}
 }

--- a/parser_config.go
+++ b/parser_config.go
@@ -10,14 +10,17 @@ import (
 var (
 	parseNodeLimitScaleOnce     sync.Once
 	parseNodeLimitScale         int
+	parseNodeLimitScaleEnvSet   bool
 	parseMemoryBudgetOnce       sync.Once
 	parseMemoryBudgetMBVal      int
 	parseMemoryHardCeilingOnce  sync.Once
 	parseMemoryHardCeilingMBVal int
 	parseMaxGLRStacksOnce       sync.Once
 	parseMaxGLRStacks           int
+	parseMaxGLRStacksEnvSet     bool
 	parseMaxMergePerKeyOnce     sync.Once
 	parseMaxMergePerKey         int
+	parseMaxMergePerKeyEnvSet   bool
 	preMaterializationDiagOnce  sync.Once
 	preMaterializationDiag      bool
 	parsePhaseTimingOnce        sync.Once
@@ -49,14 +52,17 @@ var (
 func ResetParseEnvConfigCacheForTests() {
 	parseNodeLimitScaleOnce = sync.Once{}
 	parseNodeLimitScale = 0
+	parseNodeLimitScaleEnvSet = false
 	parseMemoryBudgetOnce = sync.Once{}
 	parseMemoryBudgetMBVal = 0
 	parseMemoryHardCeilingOnce = sync.Once{}
 	parseMemoryHardCeilingMBVal = 0
 	parseMaxGLRStacksOnce = sync.Once{}
 	parseMaxGLRStacks = 0
+	parseMaxGLRStacksEnvSet = false
 	parseMaxMergePerKeyOnce = sync.Once{}
 	parseMaxMergePerKey = 0
+	parseMaxMergePerKeyEnvSet = false
 	preMaterializationDiagOnce = sync.Once{}
 	preMaterializationDiag = false
 	parsePhaseTimingOnce = sync.Once{}
@@ -79,7 +85,8 @@ func parseNodeLimitScaleFactor() int {
 	parseNodeLimitScaleOnce.Do(func() {
 		parseNodeLimitScale = 1
 		raw := strings.TrimSpace(os.Getenv("GOT_PARSE_NODE_LIMIT_SCALE"))
-		if raw == "" {
+		parseNodeLimitScaleEnvSet = raw != ""
+		if !parseNodeLimitScaleEnvSet {
 			return
 		}
 		n, err := strconv.Atoi(raw)
@@ -91,14 +98,16 @@ func parseNodeLimitScaleFactor() int {
 }
 
 func parseNodeLimitScaleEnvConfigured() bool {
-	return strings.TrimSpace(os.Getenv("GOT_PARSE_NODE_LIMIT_SCALE")) != ""
+	_ = parseNodeLimitScaleFactor()
+	return parseNodeLimitScaleEnvSet
 }
 
 func parseMaxGLRStacksValue() int {
 	parseMaxGLRStacksOnce.Do(func() {
 		parseMaxGLRStacks = maxGLRStacks
 		raw := strings.TrimSpace(os.Getenv("GOT_GLR_MAX_STACKS"))
-		if raw == "" {
+		parseMaxGLRStacksEnvSet = raw != ""
+		if !parseMaxGLRStacksEnvSet {
 			return
 		}
 		n, err := strconv.Atoi(raw)
@@ -113,7 +122,8 @@ func parseMaxMergePerKeyValue() int {
 	parseMaxMergePerKeyOnce.Do(func() {
 		parseMaxMergePerKey = maxStacksPerMergeKey
 		raw := strings.TrimSpace(os.Getenv("GOT_GLR_MAX_MERGE_PER_KEY"))
-		if raw == "" {
+		parseMaxMergePerKeyEnvSet = raw != ""
+		if !parseMaxMergePerKeyEnvSet {
 			return
 		}
 		n, err := strconv.Atoi(raw)
@@ -125,7 +135,8 @@ func parseMaxMergePerKeyValue() int {
 }
 
 func parseMaxMergePerKeyEnvConfigured() bool {
-	return strings.TrimSpace(os.Getenv("GOT_GLR_MAX_MERGE_PER_KEY")) != ""
+	_ = parseMaxMergePerKeyValue()
+	return parseMaxMergePerKeyEnvSet
 }
 
 // parseMaxGLRStacksEnvConfigured reports whether GOT_GLR_MAX_STACKS was set
@@ -133,7 +144,8 @@ func parseMaxMergePerKeyEnvConfigured() bool {
 // the retry ladder must treat it as a true ceiling instead of silently
 // widening past it (fullParseRetryMaxStacksOverride).
 func parseMaxGLRStacksEnvConfigured() bool {
-	return strings.TrimSpace(os.Getenv("GOT_GLR_MAX_STACKS")) != ""
+	_ = parseMaxGLRStacksValue()
+	return parseMaxGLRStacksEnvSet
 }
 
 // glrFaithfulCapOneMerge (GOT_FAITHFUL_CONDENSE=1) makes cap-one condense

--- a/parser_config_test.go
+++ b/parser_config_test.go
@@ -22,6 +22,75 @@ func TestResetParseEnvConfigCacheDoesNotOwnFaithfulCondenseMode(t *testing.T) {
 	}
 }
 
+func TestParseLimitEnvPresenceSharesValueSnapshot(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		defaultVal int
+		value      func() int
+		configured func() bool
+	}{
+		{
+			name:       "node_limit_scale",
+			env:        "GOT_PARSE_NODE_LIMIT_SCALE",
+			defaultVal: 1,
+			value:      parseNodeLimitScaleFactor,
+			configured: parseNodeLimitScaleEnvConfigured,
+		},
+		{
+			name:       "max_glr_stacks",
+			env:        "GOT_GLR_MAX_STACKS",
+			defaultVal: maxGLRStacks,
+			value:      parseMaxGLRStacksValue,
+			configured: parseMaxGLRStacksEnvConfigured,
+		},
+		{
+			name:       "max_merge_per_key",
+			env:        "GOT_GLR_MAX_MERGE_PER_KEY",
+			defaultVal: maxStacksPerMergeKey,
+			value:      parseMaxMergePerKeyValue,
+			configured: parseMaxMergePerKeyEnvConfigured,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(test.env, "")
+			ResetParseEnvConfigCacheForTests()
+			t.Cleanup(ResetParseEnvConfigCacheForTests)
+
+			if got := test.value(); got != test.defaultVal {
+				t.Fatalf("default value = %d, want %d", got, test.defaultVal)
+			}
+			if test.configured() {
+				t.Fatal("empty environment reported an explicit override")
+			}
+
+			t.Setenv(test.env, "7")
+			if got := test.value(); got != test.defaultVal {
+				t.Fatalf("cached value = %d, want %d", got, test.defaultVal)
+			}
+			if test.configured() {
+				t.Fatal("presence changed outside the cached value snapshot")
+			}
+
+			ResetParseEnvConfigCacheForTests()
+			if got := test.value(); got != 7 {
+				t.Fatalf("reset value = %d, want 7", got)
+			}
+			if !test.configured() {
+				t.Fatal("reset omitted the explicit override")
+			}
+
+			t.Setenv(test.env, "")
+			if !test.configured() {
+				t.Fatal("presence changed outside the cached value snapshot")
+			}
+		})
+	}
+}
+
 func TestTransientReduceLanguageDefaultsToDisabled(t *testing.T) {
 	t.Setenv("GOT_TRANSIENT_REDUCE_CHILDREN", "")
 	t.Setenv("GOT_TRANSIENT_REDUCE_PARENTS", "")


### PR DESCRIPTION
## Summary

- Snapshot parser override presence with each cached override value.
- Remove repeated environment lookups from retry policy.
- Preserve the existing test reset contract for environment changes.

## Correctness evidence

- The complete root-package test suite passes.
- Focused configuration and retry tests pass in Docker.
- Locked Go fresh and incremental C parity pass in Docker.
- Canopy passes four checks with zero violations and blast radius 1.

## Performance evidence

The pinned edited incremental benchmark improves from 756.0 to 746.3 nanoseconds per operation.
That is a 1.28 percent improvement with `p=0.000` and zero allocations.

The presence helper falls from 3.01 percent to 0.37 percent cumulative CPU time.
Repeated `os.Getenv` work disappears from the profile.

The standard benchmark trio ran with count 10 and a 750 millisecond benchmark time.
Full parse and no-edit results show no consistent regression across both orders.
Allocation counts remain exact.

## Release train

Keep this change unreleased until the Thursday release train.