### PR TITLE
optimize(parser): fuse error summary with parent links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,12 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Fresh parse finalization now computes the retry error summary while it wires
+  parent links. This removes one complete tree traversal.
+  Deferred and incremental paths retain their separate summary walk.
+  Under-flagged errors and stop polling keep their existing behavior.
+  The pinned Go full-parse benchmark improves 0.81 percent.
+
 - Parser retry policy now snapshots override presence with each parsed value.
   This removes repeated environment lookups from the incremental hot path.
   The pinned edited incremental benchmark improves 1.28 percent with zero

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -29,6 +29,25 @@ type resultCompatibilityResult struct {
 // keep gotreesitter output aligned with C tree-sitter and existing recovery
 // expectations for grammars with known normalization gaps.
 func normalizeResultCompatibility(root *Node, source []byte, p *Parser, incrementalRanges []Range) resultCompatibilityResult {
+	return applyResultCompatibility(root, source, p, incrementalRanges, true)
+}
+
+func applyResultCompatibilityForParentLinkSummary(
+	root *Node,
+	source []byte,
+	p *Parser,
+	incrementalRanges []Range,
+) resultCompatibilityResult {
+	return applyResultCompatibility(root, source, p, incrementalRanges, false)
+}
+
+func applyResultCompatibility(
+	root *Node,
+	source []byte,
+	p *Parser,
+	incrementalRanges []Range,
+	summarizeErrors bool,
+) resultCompatibilityResult {
 	var lang *Language
 	if p != nil {
 		lang = p.language
@@ -60,6 +79,9 @@ func normalizeResultCompatibility(root *Node, source []byte, p *Parser, incremen
 	}
 	if reason := ctx.stopReason(); parseStopReasonIsActive(reason) {
 		result.stopReason = reason
+		return result
+	}
+	if !summarizeErrors {
 		return result
 	}
 	result.stopReason, result.errorSummary = summarizeResultErrorsWithStop(root, ctx.stopCheck)

--- a/parser_result_root_build.go
+++ b/parser_result_root_build.go
@@ -1015,9 +1015,18 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 			extendNodeToTrailingWhitespace(root, source)
 		}
 	}
+	summarizeDuringParentLinks := false
 	if p == nil || (!p.noResultCompatibilityBenchmarkOnly && !p.shouldDeferResultCompatibility(root)) {
 		start = materializationTimingStart(timing)
-		compat := normalizeResultCompatibility(root, source, p, incrementalRanges)
+		summarizeDuringParentLinks = p != nil &&
+			wireParentLinks &&
+			!p.shouldDeferResultParentLinks(root)
+		var compat resultCompatibilityResult
+		if summarizeDuringParentLinks {
+			compat = applyResultCompatibilityForParentLinkSummary(root, source, p, incrementalRanges)
+		} else {
+			compat = normalizeResultCompatibility(root, source, p, incrementalRanges)
+		}
 		errorSummary = compat.errorSummary
 		// resultMaterializationShouldStop (not parseStopReasonIsActive): Go's
 		// normalizer can now report ParseStopMemoryBudget (see
@@ -1047,7 +1056,11 @@ func (p *Parser) finalizeResultRoot(root *Node, source []byte, linkScratch *[]*N
 		if p != nil && p.shouldDeferResultParentLinks(root) {
 			root.ownerArena.deferParentLinks(root)
 		} else {
-			if !wireParentLinksWithScratchUntil(root, linkScratch, p) && root.ownerArena != nil {
+			var summaryTarget *resultErrorSummary
+			if summarizeDuringParentLinks {
+				summaryTarget = &errorSummary
+			}
+			if !wireParentLinksWithScratchUntil(root, linkScratch, p, summaryTarget) && root.ownerArena != nil {
 				root.ownerArena.deferParentLinks(root)
 			}
 		}

--- a/parser_retry_summary_test.go
+++ b/parser_retry_summary_test.go
@@ -1,6 +1,9 @@
 package gotreesitter
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestSummarizeResultErrorsStopsOnActiveParseBudget(t *testing.T) {
 	arena := newNodeArena(arenaClassFull)
@@ -83,6 +86,78 @@ func TestSummarizeResultErrorsFindsUnderFlaggedErrorRoot(t *testing.T) {
 	}
 	if summary != resultErrorSummaryPresent {
 		t.Fatalf("error summary = %d, want present", summary)
+	}
+}
+
+func TestFinalizeResultRootSummarizesErrorsWithAndWithoutParentWiring(t *testing.T) {
+	for _, wireParentLinks := range []bool{false, true} {
+		t.Run(fmt.Sprintf("wire_parent_links_%t", wireParentLinks), func(t *testing.T) {
+			language := buildArithmeticLanguage()
+			parser := NewParser(language)
+			arena := newNodeArena(arenaClassFull)
+			errNode := newLeafNodeInArena(arena, errorSymbol, true, 0, 1, Point{}, Point{Column: 1})
+			errNode.setHasError(true)
+			root := newParentNodeInArena(arena, 1, true, []*Node{errNode}, nil, 0)
+			root.setHasError(false)
+			errNode.parent = nil
+			errNode.childIndex = -1
+
+			summary, compatibilityApplied := parser.finalizeResultRoot(
+				root,
+				[]byte("x"),
+				nil,
+				wireParentLinks,
+				false,
+				nil,
+			)
+
+			if summary != resultErrorSummaryPresent {
+				t.Fatalf("error summary = %d, want present", summary)
+			}
+			if !compatibilityApplied {
+				t.Fatal("result compatibility was not recorded as applied")
+			}
+			if root.HasError() {
+				t.Fatal("test setup changed root HasError to true")
+			}
+			wantParent := (*Node)(nil)
+			if wireParentLinks {
+				wantParent = root
+			}
+			if errNode.Parent() != wantParent {
+				t.Fatalf("parent = %p, want %p", errNode.Parent(), wantParent)
+			}
+		})
+	}
+}
+
+func TestWireParentLinksSummaryPreservesKnownErrorOnStop(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		rootHasError bool
+		want         resultErrorSummary
+	}{
+		{name: "clean_is_unknown", want: resultErrorSummaryUnknown},
+		{name: "known_error_stays_present", rootHasError: true, want: resultErrorSummaryPresent},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			arena := newNodeArena(arenaClassFull)
+			root := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+			root.setHasError(test.rootHasError)
+			cancelled := uint32(1)
+			parser := NewParser(buildArithmeticLanguage())
+			parser.SetCancellationFlag(&cancelled)
+			summary := resultErrorSummaryUnknown
+
+			complete := wireParentLinksWithScratchUntil(root, nil, parser, &summary)
+
+			if complete {
+				t.Fatal("parent-link walk completed after cancellation")
+			}
+			if summary != test.want {
+				t.Fatalf("error summary = %d, want %d", summary, test.want)
+			}
+		})
 	}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -2072,14 +2072,28 @@ func populateParentNodeNoLinks(n *Node, children []*Node, trackChildErrors bool)
 }
 
 func wireParentLinksWithScratch(root *Node, scratch *[]*Node) {
-	wireParentLinksWithScratchUntil(root, scratch, nil)
+	wireParentLinksWithScratchUntil(root, scratch, nil, nil)
 }
 
-func wireParentLinksWithScratchUntil(root *Node, scratch *[]*Node, p *Parser) bool {
+func wireParentLinksWithScratchUntil(
+	root *Node,
+	scratch *[]*Node,
+	p *Parser,
+	errorSummary *resultErrorSummary,
+) bool {
 	if root == nil {
+		if errorSummary != nil {
+			*errorSummary = resultErrorSummaryUnknown
+		}
 		return true
 	}
 	setNodeRootLink(root)
+	if errorSummary != nil {
+		*errorSummary = resultErrorSummaryClean
+		if root.IsError() || root.hasError() {
+			*errorSummary = resultErrorSummaryPresent
+		}
+	}
 
 	var stack []*Node
 	if scratch != nil {
@@ -2094,10 +2108,16 @@ func wireParentLinksWithScratchUntil(root *Node, scratch *[]*Node, p *Parser) bo
 			if scratch != nil {
 				*scratch = stack[:0]
 			}
+			if errorSummary != nil && *errorSummary != resultErrorSummaryPresent {
+				*errorSummary = resultErrorSummaryUnknown
+			}
 			return false
 		}
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
+		if errorSummary != nil && (n.IsError() || n.hasError()) {
+			*errorSummary = resultErrorSummaryPresent
+		}
 		childCount := nodeChildCountNoMaterialize(n)
 		for i := 0; i < childCount; i++ {
 			c := nodeChildAtForReason(n, i, materializeForParentAPI)
@@ -2110,6 +2130,14 @@ func wireParentLinksWithScratchUntil(root *Node, scratch *[]*Node, p *Parser) bo
 	}
 	if scratch != nil {
 		*scratch = stack[:0]
+	}
+	if errorSummary != nil {
+		if reason := p.parseStopReasonNow(); parseStopReasonIsTerminal(reason) {
+			if *errorSummary != resultErrorSummaryPresent {
+				*errorSummary = resultErrorSummaryUnknown
+			}
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
## Summary

- Compute the fresh result error summary during the parent-link walk.
- Remove one full-tree walk from fresh finalization.
- Preserve deferred and incremental summary behavior.
- Preserve cancellation, retry, and under-flagged error rules.

## Root cause

The fresh finalization path ran two complete tree walks.
One walk wired parent links.
The other walk computed the error summary.
Both walks used compatible stop and error rules.

## Correctness evidence

- Focused summary, retry, cancellation, and ownership tests pass.
- The complete root package and grammar package tests pass.
- A focused Docker gate passes without an out-of-memory event.
- Go passes 25 of 25 isolated C-oracle cases with exact deep parity.
- Canopy passes with zero violations and reports blast radius 35.

## Performance evidence

The pinned long Go full-parse benchmark improves from 5.261 to 5.212 milliseconds.
This result shows a 0.94 percent improvement with p=0.003.
Throughput improves 0.95 percent with p=0.007.
Allocation counts stay exact.

The complete standard trio also finishes with unchanged allocation counts.
One full-parse sample had an environmental outlier.
That sample does not support an additional claim.

## Release train

Keep this change unreleased until the Thursday release train.