### PR TITLE
Make compact replay visit each node once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ for tags and release notes while still in `0.x`.
 
 - Compact parse-state replay now visits each derivation node once.
   Its depth-first worklist retains only the active derivation path.
-  The stable full-parse benchmark improves by 7.75 percent without new
-  allocations or incremental regressions.
+  The stable full-parse benchmark improves without new allocations or
+  incremental regressions.
 
 - Clean roots now keep hidden, childless whitespace extras as span coverage.
   They do not publish those extras as children.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Compact parse-state replay now visits each derivation node once.
+  Its depth-first worklist retains only the active derivation path.
+  The stable full-parse benchmark improves by 7.75 percent without new
+  allocations or incremental regressions.
+
 - Clean roots now keep hidden, childless whitespace extras as span coverage.
   They do not publish those extras as children.
   Visible comments and error-root evidence remain unchanged.

--- a/internal/parsercorephase0/materialization_replay.go
+++ b/internal/parsercorephase0/materialization_replay.go
@@ -1,0 +1,46 @@
+package parsercorephase0
+
+// MaterializationReplayChildren is a borrowed compact-child view for one
+// parse-state replay traversal. It remains valid until the Core is reset.
+// Callers must not retain it past that boundary.
+type MaterializationReplayChildren struct {
+	ids []SubtreeID
+}
+
+// Len returns the number of compact children.
+func (c MaterializationReplayChildren) Len() int {
+	return len(c.ids)
+}
+
+// At returns one compact child without copying the child arena.
+func (c MaterializationReplayChildren) At(index int) (SubtreeID, bool) {
+	if index < 0 || index >= len(c.ids) {
+		return 0, false
+	}
+	return c.ids[index], true
+}
+
+// MaterializationReplayView exposes only the compact fields that parse-state
+// replay consumes.
+type MaterializationReplayView struct {
+	Symbol   Symbol
+	Children MaterializationReplayChildren
+	Extra    bool
+	Terminal bool
+}
+
+// MaterializationReplayView returns one borrowed parse-state replay view.
+func (c *Core) MaterializationReplayView(id SubtreeID) (MaterializationReplayView, error) {
+	record, err := c.subtree(id)
+	if err != nil {
+		return MaterializationReplayView{}, err
+	}
+	return MaterializationReplayView{
+		Symbol: record.symbol,
+		Children: MaterializationReplayChildren{
+			ids: c.children[record.firstChild : record.firstChild+record.childCount],
+		},
+		Extra:    record.extra,
+		Terminal: record.terminal,
+	}, nil
+}

--- a/internal/parsercorephase0/materialization_replay.go
+++ b/internal/parsercorephase0/materialization_replay.go
@@ -4,20 +4,25 @@ package parsercorephase0
 // parse-state replay traversal. It remains valid until the Core is reset.
 // Callers must not retain it past that boundary.
 type MaterializationReplayChildren struct {
-	ids []SubtreeID
+	first uint32
+	count uint32
 }
 
 // Len returns the number of compact children.
-func (c MaterializationReplayChildren) Len() int {
-	return len(c.ids)
+func (c MaterializationReplayChildren) Len() uint32 {
+	return c.count
 }
 
 // At returns one compact child without copying the child arena.
-func (c MaterializationReplayChildren) At(index int) (SubtreeID, bool) {
-	if index < 0 || index >= len(c.ids) {
+func (c *Core) MaterializationReplayChild(children MaterializationReplayChildren, index uint32) (SubtreeID, bool) {
+	if c == nil || index >= children.count {
 		return 0, false
 	}
-	return c.ids[index], true
+	childIndex := uint64(children.first) + uint64(index)
+	if childIndex >= uint64(len(c.children)) {
+		return 0, false
+	}
+	return c.children[childIndex], true
 }
 
 // MaterializationReplayView exposes only the compact fields that parse-state
@@ -38,7 +43,8 @@ func (c *Core) MaterializationReplayView(id SubtreeID) (MaterializationReplayVie
 	return MaterializationReplayView{
 		Symbol: record.symbol,
 		Children: MaterializationReplayChildren{
-			ids: c.children[record.firstChild : record.firstChild+record.childCount],
+			first: record.firstChild,
+			count: record.childCount,
 		},
 		Extra:    record.extra,
 		Terminal: record.terminal,

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -67,8 +67,9 @@ func setParserCoreReplayParseStatesForTest(on bool) {
 // replayCompactDerivation to avoid deep Go recursion on pathologically deep
 // derivations.
 type compactReplayFrame struct {
-	id      core.SubtreeID
-	preGoto StateID
+	cursor    StateID
+	children  core.MaterializationReplayChildren
+	nextChild int
 }
 
 // compactReplayStates holds the reconstructed per-derivation-node parser
@@ -111,12 +112,10 @@ func acquireCompactReplayStates(n int) *compactReplayStates {
 		s.preGotoState = s.preGotoState[:n]
 		s.psKnown = s.psKnown[:n]
 		s.preKnown = s.preKnown[:n]
-		for i := 0; i < n; i++ {
-			s.parseState[i] = 0
-			s.preGotoState[i] = 0
-			s.psKnown[i] = false
-			s.preKnown[i] = false
-		}
+		clear(s.parseState)
+		clear(s.preGotoState)
+		clear(s.psKnown)
+		clear(s.preKnown)
 	}
 	return s
 }
@@ -152,67 +151,72 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 	seed := p.replayRootPreGotoState()
 
 	stack := states.frames[:0]
-	for _, root := range roots {
-		stack = append(stack, compactReplayFrame{id: root, preGoto: seed})
+	fail := func(err error) (*compactReplayStates, error) {
+		clear(stack)
+		states.frames = stack[:0]
+		states.release()
+		return nil, err
 	}
-	for len(stack) > 0 {
-		top := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		view, err := compact.MaterializationView(top.id)
+	// Process one root at a time. This bounds the worklist by derivation depth
+	// instead of the width of every sibling cohort.
+	for rootIndex := len(roots) - 1; rootIndex >= 0; rootIndex-- {
+		root := roots[rootIndex]
+		view, err := compact.MaterializationReplayView(root)
 		if err != nil {
-			// Return the pooled state object before bailing so the pool contract
-			// is honoured (otherwise it is dropped and silently reallocated).
-			states.frames = stack[:0]
-			states.release()
-			return nil, err
+			return fail(err)
 		}
-		ps, ok := p.replayTransition(top.preGoto, Symbol(view.Symbol), view.Terminal)
-		if ok && uint64(top.id) < uint64(len(states.parseState)) {
-			// Record an AUTHORITATIVE parseState: replayTransition found a real
-			// shift/goto for this id from top.preGoto. When ok is false the
-			// transition fell back to top.preGoto (a node whose shape is not a
-			// plain shift/goto of its visible symbol); recording that fallback
-			// would stamp a known-wrong trusted state, so we abstain and leave
-			// the id at its zero "unknown -> recompute" sentinel.
-			states.parseState[top.id] = ps
-			states.psKnown[top.id] = true
-			// The preGotoState is authoritative only for non-extra nodes. Extras
-			// (comments) float to a tree position that does not match their
-			// live-parse stack state, so their inherited preGoto is not
-			// reconstructable; abstain on it (leave 0) while keeping the exact
-			// parseState above (Lane 3 review amendment 1).
+		rootParseState, rootStateKnown := p.replayTransition(seed, Symbol(view.Symbol), view.Terminal)
+		if rootStateKnown && uint64(root) < uint64(len(states.parseState)) {
+			states.parseState[root] = rootParseState
+			states.psKnown[root] = true
 			if !view.Extra {
-				states.preGotoState[top.id] = top.preGoto
-				states.preKnown[top.id] = true
+				states.preGotoState[root] = seed
+				states.preKnown[root] = true
 			}
 		}
-		kids := view.Children
-		if len(kids) == 0 {
-			continue
-		}
-		if len(kids) == 1 {
-			stack = append(stack, compactReplayFrame{id: kids[0], preGoto: top.preGoto})
-			continue
-		}
-		base := len(stack)
-		cursor := top.preGoto
-		for _, child := range kids {
-			cview, err := compact.MaterializationView(child)
+		stack = append(stack, compactReplayFrame{
+			cursor: seed, children: view.Children,
+		})
+
+		for len(stack) > 0 {
+			topIndex := len(stack) - 1
+			top := &stack[topIndex]
+			if top.nextChild >= top.children.Len() {
+				// Clear the borrowed child slice before the frame returns to the
+				// global pool. This prevents a transient Core from being retained.
+				stack[topIndex] = compactReplayFrame{}
+				stack = stack[:topIndex]
+				continue
+			}
+
+			child, ok := top.children.At(top.nextChild)
+			if !ok {
+				return fail(errors.New("parser-core phase zero: replay child index is invalid"))
+			}
+			childPreGoto := top.cursor
+			top.nextChild++
+			cview, err := compact.MaterializationReplayView(child)
 			if err != nil {
-				// Return the pooled state object before bailing (see above).
-				states.frames = stack[:0]
-				states.release()
-				return nil, err
+				return fail(err)
 			}
-			stack = append(stack, compactReplayFrame{id: child, preGoto: cursor})
-			cursor, _ = p.replayTransition(cursor, Symbol(cview.Symbol), cview.Terminal)
-		}
-		// Reverse the just-appended child frames so pop order is left-to-right.
-		for i, j := base, len(stack)-1; i < j; i, j = i+1, j-1 {
-			stack[i], stack[j] = stack[j], stack[i]
+			childParseState, childStateKnown := p.replayTransition(childPreGoto, Symbol(cview.Symbol), cview.Terminal)
+			top.cursor = childParseState
+			if childStateKnown && uint64(child) < uint64(len(states.parseState)) {
+				// Record only authoritative transitions. A failed transition
+				// returns childPreGoto as a traversal fallback.
+				states.parseState[child] = childParseState
+				states.psKnown[child] = true
+				if !cview.Extra {
+					states.preGotoState[child] = childPreGoto
+					states.preKnown[child] = true
+				}
+			}
+			stack = append(stack, compactReplayFrame{
+				cursor: childPreGoto, children: cview.Children,
+			})
 		}
 	}
-	// Retain the (possibly grown) worklist backing store for the next parse.
+	// Retain the cleared worklist backing store for the next parse.
 	states.frames = stack[:0]
 	return states, nil
 }

--- a/parsestate_replay_compact.go
+++ b/parsestate_replay_compact.go
@@ -69,7 +69,7 @@ func setParserCoreReplayParseStatesForTest(on bool) {
 type compactReplayFrame struct {
 	cursor    StateID
 	children  core.MaterializationReplayChildren
-	nextChild int
+	nextChild uint32
 }
 
 // compactReplayStates holds the reconstructed per-derivation-node parser
@@ -189,7 +189,7 @@ func (p *Parser) replayCompactDerivation(compact *core.Core, roots []core.Subtre
 				continue
 			}
 
-			child, ok := top.children.At(top.nextChild)
+			child, ok := compact.MaterializationReplayChild(top.children, top.nextChild)
 			if !ok {
 				return fail(errors.New("parser-core phase zero: replay child index is invalid"))
 			}


### PR DESCRIPTION
## Summary

- Visit each compact derivation node once during parse-state replay.
- Bound traversal storage by derivation depth.
- Store each borrowed child cohort as an opaque offset and count.
- Clear pooled frames before release.

## Performance

Local evidence is provisional until the GCP recertification finishes.

- Forty process-isolated alternating pairs compare exact main with head 46c1135a.
- Full parse: 6.172 ms to 5.679 ms, or 7.99 percent faster. The result has p<0.001.
- Full-parse allocations stay at 26 per operation.
- Earlier stable trio runs show no significant incremental edit or no-edit regression.
- Replay CPU attribution fell from 8.20 percent to 5.85 percent before the compact-frame refinement.

The earlier batched workstation result did not reproduce under frequency drift. It is superseded by the alternating result and the GCP gate.

## Correctness

- The complete root package passes in Docker.
- Focused compact replay tests pass.
- The compact core package passes.
- Go real-corpus parity reaches 25 of 25 for no-error, S-expression, and deep parity.
- Canopy reports no violations across all three changed files.

The tagged replay differential reports 252 known collapse-class misses on exact main and this branch. Its stored cap is 251. The treatment and base receipts match exactly, so this is not a change regression.

## Release

Do not tag or release this change before the Thursday release train.