### PR TITLE
Retire the D module-bound result repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ for tags and release notes while still in `0.x`.
 
 ### Removed
 
+- **The D module-bound result repair.** Native reduction already excludes
+  leading comments and trailing trivia from each `module_def` span.
+  Production, compact, forest, incremental, and C-oracle routes match.
+  Incremental parsing reuses the old tree.
+  The D dispatcher remains live for unrelated shape repairs.
+
 - **The HCL root normalization pass.** Shared root finalization now removes
   hidden whitespace extras at every root position.
   Native reduction already produces each exact HCL body span.

--- a/cgo_harness/retired_dispatch_arm_parity_test.go
+++ b/cgo_harness/retired_dispatch_arm_parity_test.go
@@ -120,6 +120,11 @@ func TestRetiredDispatchArmCOracleParity(t *testing.T) {
 			source:   "\nmodule m;\nint main() { return 0; }\n",
 		},
 		{
+			name:     "d_module_bounds",
+			language: "d",
+			source:   "// license\n\nmodule test;\nimport std.stdio;\n",
+		},
+		{
 			name:     "forth_leading_trivia_root",
 			language: "forth",
 			source:   "\n: square dup * ;\n",

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -187,6 +187,8 @@ Shared root finalization now removes hidden whitespace extras at every root
 position. The rule preserves visible extras, fields, spans, and lazy child
 references. Native HCL reduction already owns each body span.
 The HCL dispatcher arm is retired.
+Native reduction already owns D `module_def` bounds.
+The D dispatcher remains live for unrelated shape repairs.
 
 Group by invariant, not language:
 
@@ -256,6 +258,7 @@ there.
 | Zero-width artifact repairs | merged in PR #480 | 2 language walks | 0 | Haskell scanner control-token and Typst historical repetition-fold witnesses |
 | Haskell section spans | retirement commit `aadc2fed64f072499f8cc9485f7cd86db2a274c3` | 1 dispatcher arm | 0 | zero-rewrite real-corpus census, native production, compact, incremental, forest-limit, and isolated C-oracle receipts |
 | Hidden root trivia | retirement commit `49d776674b2f599fa162874bbf74dc119fa9e7d4` | 1 dispatcher arm | 0 | generalized root finalization, 114 native HCL body spans, four result routes, and isolated C-oracle parity |
+| D module bounds | retirement change | 1 language-local span walk | 0 | compatibility-free producer, production, compact, forest, incremental reuse, and isolated C-oracle receipts |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/grammars/d_module_span_native_regression_test.go
+++ b/grammars/d_module_span_native_regression_test.go
@@ -1,0 +1,85 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+const dModuleSpanRetirementSource = "// license\n\nmodule test;\nimport std.stdio;"
+
+func TestDModuleSpanNeedsNoResultCompatibility(t *testing.T) {
+	source := []byte(dModuleSpanRetirementSource)
+	language := DLanguage()
+	tree, err := gotreesitter.NewParser(language).
+		ParseNoResultCompatibilityBenchmarkOnly(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tree.Release)
+
+	assertDModuleSpan(t, "compatibility-free", tree, language, source)
+}
+
+func TestDModuleSpanRoutes(t *testing.T) {
+	source := []byte(dModuleSpanRetirementSource + "\n")
+	language := DLanguage()
+	for _, receipt := range retiredDispatchRouteReceipts(
+		t,
+		language,
+		[]byte(dModuleSpanRetirementSource),
+	) {
+		assertDModuleSpan(t, receipt.name, receipt.tree, language, source)
+		if receipt.name != "incremental" {
+			continue
+		}
+		profile := receipt.incrementalProfile
+		if !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 ||
+			profile.ReusedBytes == 0 {
+			t.Fatalf("incremental route did not reuse the old tree: %+v", profile)
+		}
+	}
+}
+
+func assertDModuleSpan(
+	t *testing.T,
+	route string,
+	tree *gotreesitter.Tree,
+	language *gotreesitter.Language,
+	source []byte,
+) {
+	t.Helper()
+	root := tree.RootNode()
+	if root == nil || root.HasError() {
+		t.Fatalf("%s root = %v, want a clean tree", route, root)
+	}
+	var moduleDef *gotreesitter.Node
+	for index := 0; index < root.NamedChildCount(); index++ {
+		child := root.NamedChild(index)
+		if child != nil && child.Type(language) == "module_def" {
+			moduleDef = child
+			break
+		}
+	}
+	if moduleDef == nil {
+		t.Fatalf("%s has no module_def: %s", route, root.SExpr(language))
+	}
+	if got, want := moduleDef.StartByte(), uint32(12); got != want {
+		t.Fatalf("%s module_def start = %d, want %d", route, got, want)
+	}
+	wantEnd := len(source)
+	if wantEnd > 0 && source[wantEnd-1] == '\n' {
+		wantEnd--
+	}
+	if got, want := moduleDef.EndByte(), uint32(wantEnd); got != want {
+		t.Fatalf("%s module_def end = %d, want %d", route, got, want)
+	}
+	if got, want := moduleDef.StartPoint(), (gotreesitter.Point{Row: 2}); got != want {
+		t.Fatalf("%s module_def start point = %#v, want %#v", route, got, want)
+	}
+	if got, want := moduleDef.EndPoint(), (gotreesitter.Point{Row: 3, Column: 17}); got != want {
+		t.Fatalf("%s module_def end point = %#v, want %#v", route, got, want)
+	}
+}

--- a/parser_result_d.go
+++ b/parser_result_d.go
@@ -1,29 +1,11 @@
 package gotreesitter
 
 func normalizeDCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeDModuleDefinitionBounds(root, lang)
 	normalizeDCallExpressionTemplateTypes(root, lang)
 	normalizeDCallExpressionPropertyTypes(root, lang)
 	normalizeDCallExpressionSimpleTypeCallees(root, lang)
 	normalizeDVariableTypeQualifiers(root, lang)
 	normalizeDVariableStorageClassWrappers(root, lang)
-}
-func normalizeDModuleDefinitionBounds(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "d" {
-		return
-	}
-	walkResultTree(root, func(n *Node) {
-		if n.Type(lang) == "module_def" {
-			if first := pythonBlockStartAnchor(n.children, lang); first != nil && n.startByte < first.startByte {
-				n.startByte = first.startByte
-				n.startPoint = first.startPoint
-			}
-			if last := pythonBlockEndAnchor(n.children); last != nil && n.endByte > last.endByte {
-				n.endByte = last.endByte
-				n.endPoint = last.endPoint
-			}
-		}
-	})
 }
 
 func normalizeDVariableStorageClassWrappers(root *Node, lang *Language) {

--- a/parser_result_d_test.go
+++ b/parser_result_d_test.go
@@ -2,43 +2,6 @@ package gotreesitter
 
 import "testing"
 
-func TestNormalizeDModuleDefinitionBoundsSnapToStructuralChildren(t *testing.T) {
-	lang := &Language{
-		Name:        "d",
-		SymbolNames: []string{"EOF", "module_def", "module_declaration", "import_declaration"},
-		SymbolMetadata: []SymbolMetadata{
-			{Name: "EOF", Visible: false, Named: false},
-			{Name: "module_def", Visible: true, Named: true},
-			{Name: "module_declaration", Visible: true, Named: true},
-			{Name: "import_declaration", Visible: true, Named: true},
-		},
-	}
-
-	arena := newNodeArena(arenaClassFull)
-	moduleDecl := newLeafNodeInArena(arena, 2, true, 133, 178, Point{Row: 4}, Point{Row: 4, Column: 45})
-	importDecl := newLeafNodeInArena(arena, 3, true, 179, 9486, Point{Row: 5}, Point{Row: 319, Column: 1})
-	moduleDef := newParentNodeInArena(arena, 1, true, []*Node{moduleDecl, importDecl}, nil, 0)
-	moduleDef.startByte = 0
-	moduleDef.startPoint = Point{}
-	moduleDef.endByte = 9487
-	moduleDef.endPoint = Point{Row: 319, Column: 2}
-
-	normalizeDModuleDefinitionBounds(moduleDef, lang)
-
-	if got, want := moduleDef.startByte, uint32(133); got != want {
-		t.Fatalf("moduleDef.startByte = %d, want %d", got, want)
-	}
-	if got, want := moduleDef.startPoint, moduleDecl.startPoint; got != want {
-		t.Fatalf("moduleDef.startPoint = %#v, want %#v", got, want)
-	}
-	if got, want := moduleDef.endByte, uint32(9486); got != want {
-		t.Fatalf("moduleDef.endByte = %d, want %d", got, want)
-	}
-	if got, want := moduleDef.endPoint, importDecl.endPoint; got != want {
-		t.Fatalf("moduleDef.endPoint = %#v, want %#v", got, want)
-	}
-}
-
 func TestNormalizeDVariableStorageClassWrappersWrapsStaticLeaf(t *testing.T) {
 	lang := &Language{
 		Name:        "d",

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -565,10 +565,12 @@
       "languages": [
         "d"
       ],
-      "purpose": "Reconcile D returned-tree fields, aliases, and spans.",
+      "purpose": "Reconcile D returned-tree fields and aliases. Native reduction owns module_def bounds.",
       "authoritative_owner": "materialization",
       "witnesses": [
-        "cgo_harness/parity_cgo_test.go"
+        "cgo_harness/parity_cgo_test.go",
+        "grammars/d_module_span_native_regression_test.go",
+        "cgo_harness/retired_dispatch_arm_parity_test.go"
       ],
       "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
       "route_coverage": {
@@ -579,7 +581,10 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "receipt_refs": [
+        "grammars/d_module_span_native_regression_test.go",
+        "cgo_harness/retired_dispatch_arm_parity_test.go"
+      ]
     },
     {
       "id": "dispatch.dart",


### PR DESCRIPTION
## Summary

- Remove the D module-bound result walk.
- Keep native reduction as the span owner.
- Add compatibility-free route and C-oracle receipts.

## Correctness

- Production, compact, forest, and incremental routes match.
- The incremental route reuses old-tree subtrees and bytes.
- The exact D module-bound C oracle passes in Docker.
- The ownership registry and focused D tests pass.

## Performance

The stable Go benchmark trio completes with the required settings. This D-only removal does not change the Go parser path.

## Known D corpus baseline

The isolated 25-case D corpus completes without an out-of-memory failure. It reports the same unrelated D shape backlog: two clean-reference errors and one template-argument type mismatch. The exact module-bound oracle is green.

## Release

Do not tag or release this change before Thursday.