### PR TITLE
Admit C repetition folds in the compact scheduler

### DIFF
--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -79,7 +79,7 @@ var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"hlsl": {}, "html": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {},
 	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
-	"luau": {}, "make": {}, "markdown": {}, "markdown_inline": {}, "matlab": {}, "mermaid": {}, "mojo": {},
+	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "mojo": {},
 	"move": {}, "nginx": {}, "nickel": {}, "nim": {}, "ninja": {}, "nix": {}, "norg": {}, "nushell": {},
 	"objc": {}, "ocaml": {}, "odin": {}, "org": {}, "pascal": {}, "pem": {}, "perl": {},
 	"php": {}, "pkl": {}, "powershell": {}, "prisma": {}, "prolog": {}, "promql": {},
@@ -146,8 +146,8 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// review and ratchet update.
 		const (
 			wantTotal   = 206
-			minPass     = 193
-			maxFallback = 8
+			minPass     = 192
+			maxFallback = 9
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -63,34 +63,34 @@ type scorecardRow struct {
 // runtime routing allowlist.
 var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"ada": {}, "agda": {}, "angular": {}, "apex": {}, "arduino": {},
-	"astro": {}, "awk": {}, "bash": {}, "beancount": {}, "bibtex": {},
+	"asm": {}, "astro": {}, "awk": {}, "bash": {}, "bass": {}, "beancount": {}, "bibtex": {},
 	"bicep": {}, "bitbake": {}, "blade": {}, "brightscript": {}, "c_sharp": {},
 	"caddy": {}, "cairo": {}, "capnp": {}, "chatito": {}, "circom": {},
-	"commonlisp": {}, "corn": {}, "cpon": {}, "crystal": {}, "css": {},
+	"clojure": {}, "cmake": {}, "comment": {}, "commonlisp": {}, "corn": {}, "cpon": {}, "crystal": {}, "css": {},
 	"csv": {}, "cuda": {}, "cue": {}, "cylc": {}, "d": {}, "dart": {},
-	"desktop": {}, "devicetree": {}, "dhall": {}, "disassembly": {}, "dockerfile": {},
+	"desktop": {}, "devicetree": {}, "dhall": {}, "diff": {}, "disassembly": {}, "djot": {}, "dockerfile": {},
 	"dot": {}, "dtd": {}, "earthfile": {}, "ebnf": {}, "editorconfig": {},
-	"eds": {}, "elisp": {}, "elixir": {}, "elm": {}, "elsa": {}, "enforce": {},
+	"eds": {}, "eex": {}, "elisp": {}, "elixir": {}, "elm": {}, "elsa": {}, "embedded_template": {}, "enforce": {},
 	"erlang": {}, "facility": {}, "faust": {}, "fennel": {}, "fidl": {},
 	"firrtl": {}, "fish": {}, "foam": {}, "forth": {}, "fortran": {}, "fsharp": {},
-	"gdscript": {}, "git_config": {}, "git_rebase": {}, "gitcommit": {}, "gleam": {},
+	"gdscript": {}, "git_config": {}, "git_rebase": {}, "gitattributes": {}, "gitcommit": {}, "gitignore": {}, "gleam": {},
 	"glsl": {}, "gn": {}, "go": {}, "godot_resource": {}, "gomod": {}, "graphql": {},
-	"groovy": {}, "hack": {}, "hare": {}, "haxe": {}, "hcl": {}, "heex": {},
-	"hlsl": {}, "html": {}, "hyprlang": {}, "ini": {}, "javascript": {}, "jq": {},
-	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kotlin": {},
+	"groovy": {}, "hack": {}, "hare": {}, "haskell": {}, "haxe": {}, "hcl": {}, "heex": {},
+	"hlsl": {}, "html": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {},
+	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
-	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "mojo": {},
-	"move": {}, "nginx": {}, "nickel": {}, "ninja": {}, "nix": {}, "nushell": {},
+	"luau": {}, "make": {}, "markdown": {}, "markdown_inline": {}, "matlab": {}, "mermaid": {}, "mojo": {},
+	"move": {}, "nginx": {}, "nickel": {}, "nim": {}, "ninja": {}, "nix": {}, "norg": {}, "nushell": {},
 	"objc": {}, "ocaml": {}, "odin": {}, "org": {}, "pascal": {}, "pem": {}, "perl": {},
 	"php": {}, "pkl": {}, "powershell": {}, "prisma": {}, "prolog": {}, "promql": {},
-	"proto": {}, "pug": {}, "puppet": {}, "purescript": {}, "python": {}, "ql": {},
-	"r": {}, "regex": {}, "rego": {}, "requirements": {}, "rescript": {}, "ron": {},
-	"rst": {}, "ruby": {}, "rust": {}, "scala": {}, "scss": {}, "smithy": {},
+	"properties": {}, "proto": {}, "pug": {}, "puppet": {}, "purescript": {}, "python": {}, "ql": {},
+	"r": {}, "racket": {}, "regex": {}, "rego": {}, "requirements": {}, "rescript": {}, "ron": {},
+	"rst": {}, "ruby": {}, "rust": {}, "scala": {}, "scheme": {}, "scss": {}, "smithy": {},
 	"solidity": {}, "sparql": {}, "sql": {}, "squirrel": {}, "starlark": {}, "svelte": {},
-	"swift": {}, "tablegen": {}, "tcl": {}, "teal": {}, "templ": {}, "textproto": {},
-	"thrift": {}, "tlaplus": {}, "tmux": {}, "tsx": {}, "turtle": {}, "twig": {},
+	"ssh_config": {}, "swift": {}, "tablegen": {}, "tcl": {}, "teal": {}, "templ": {}, "textproto": {},
+	"thrift": {}, "tlaplus": {}, "tmux": {}, "todotxt": {}, "toml": {}, "tsx": {}, "turtle": {}, "twig": {},
 	"typescript": {}, "typst": {}, "uxntal": {}, "v": {}, "verilog": {}, "vimdoc": {},
-	"vue": {}, "wgsl": {}, "wolfram": {}, "xml": {}, "yaml": {}, "zig": {},
+	"vue": {}, "wat": {}, "wgsl": {}, "wolfram": {}, "xml": {}, "yaml": {}, "yuck": {}, "zig": {},
 }
 
 func TestAdmissionCandidateScorecard206(t *testing.T) {
@@ -146,8 +146,8 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// review and ratchet update.
 		const (
 			wantTotal   = 206
-			minPass     = 166
-			maxFallback = 35
+			minPass     = 193
+			maxFallback = 8
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {

--- a/grammars/collapsed_child_native_regression_test.go
+++ b/grammars/collapsed_child_native_regression_test.go
@@ -40,7 +40,7 @@ func TestCollapsedChildLedgerRealLanguagesNeedNoSafetyNetRewrite(t *testing.T) {
 			named bool
 			count int
 		}{"identifier": {child: "simple_identifier", named: true, count: 2}}},
-		{name: "hack", lang: HackLanguage, src: "<?hh function f(): void { $a = true; $b = false; $c = null; }\n", compactDecline: true, want: map[string]struct {
+		{name: "hack", lang: HackLanguage, src: "<?hh function f(): void { $a = true; $b = false; $c = null; }\n", want: map[string]struct {
 			child string
 			named bool
 			count int

--- a/grammars/collapsed_token_native_regression_test.go
+++ b/grammars/collapsed_token_native_regression_test.go
@@ -158,11 +158,10 @@ func TestCollapsedTokenRetirementRoutes(t *testing.T) {
 func collapsedTokenRetirementCases() []collapsedTokenRetirementCase {
 	return []collapsedTokenRetirementCase{
 		{
-			name:           "hcl",
-			language:       HclLanguage,
-			source:         []byte("a {\n b = true\n c = [false]\n d = {}\n}"),
-			compactDecline: true,
-			assert:         assertHCLCollapsedTokens,
+			name:     "hcl",
+			language: HclLanguage,
+			source:   []byte("a {\n b = true\n c = [false]\n d = {}\n}"),
+			assert:   assertHCLCollapsedTokens,
 		},
 		{
 			name:     "cpon",

--- a/grammars/gomod_parse_regression_test.go
+++ b/grammars/gomod_parse_regression_test.go
@@ -51,6 +51,7 @@ func TestGomodRequireListStaysSingleStack(t *testing.T) {
 	src := []byte("module example.com/m\n\ngo 1.26.0\n\nrequire (\n\texample.com/a v1.2.3\n\texample.com/b v1.2.4\n\texample.com/c v1.2.5\n)\n")
 	lang := GomodLanguage()
 	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
 	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)

--- a/parser_external_scanner_incremental_test.go
+++ b/parser_external_scanner_incremental_test.go
@@ -52,6 +52,7 @@ func TestExternalScannerIncrementalReusePolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			lang := tc.lang()
 			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(false)
 			src := tc.source(128)
 			sites := makeBenchmarkEditSites(src, tc.marker)
 			if len(sites) == 0 {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -139,6 +139,7 @@ type DiagnosticParserCoreGenericWork struct {
 	ConflictActionArmsAdmitted uint64
 	CausalConflictForks        uint64
 	ConflictHeads              uint64
+	RepetitionFolds            uint64
 	Reductions                 uint64
 	OrdinaryShifts             uint64
 	OrdinaryCohorts            uint64
@@ -1472,13 +1473,58 @@ func newDiagnosticParserCoreGenericScheduler(
 }
 
 type diagnosticParserCoreGenericCell struct {
-	headerIndex int
-	boundary    core.ClassifiedBoundary
+	headerIndex             int
+	boundary                core.ClassifiedBoundary
+	repetitionFold          bool
+	repetitionReduceOrdinal int
 }
 
 func (cell diagnosticParserCoreGenericCell) actions() core.ActionRow { return cell.boundary.Actions() }
 func (cell diagnosticParserCoreGenericCell) descriptor() core.ActionRowDescriptor {
 	return cell.boundary.Actions().Descriptor()
+}
+func (cell diagnosticParserCoreGenericCell) kind() core.ActionRowKind {
+	if cell.repetitionFold {
+		return core.ActionRowReduce
+	}
+	return cell.descriptor().Kind()
+}
+func (cell diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
+	if cell.repetitionFold {
+		return cell.repetitionReduceOrdinal
+	}
+	return 0
+}
+
+// diagnosticParserCoreRepetitionFoldOrdinal mirrors the production parser's
+// certified single-reduce repetition fold for a clean compact lineage.
+func diagnosticParserCoreRepetitionFoldOrdinal(language *Language, actions core.ActionRow) (int, bool) {
+	if actions.Len() < 2 || language == nil || cRepetitionSkipOptOut[language.Name] {
+		return 0, false
+	}
+	reduceOrdinal := -1
+	shiftFound := false
+	for ordinal := 0; ordinal < actions.Len(); ordinal++ {
+		action := actions.At(ordinal)
+		switch action.Type {
+		case core.ActionReduce:
+			if reduceOrdinal >= 0 {
+				return 0, false
+			}
+			reduceOrdinal = ordinal
+		case core.ActionShift:
+			if !action.Repetition || shiftFound {
+				return 0, false
+			}
+			shiftFound = true
+		default:
+			return 0, false
+		}
+	}
+	if reduceOrdinal < 0 || !shiftFound {
+		return 0, false
+	}
+	return reduceOrdinal, true
 }
 
 type diagnosticParserCoreDispatchScratch struct {
@@ -2259,7 +2305,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
 			continue
 		}
-		s.dispatchScratch.cells = append(s.dispatchScratch.cells, diagnosticParserCoreGenericCell{headerIndex: index, boundary: boundary})
+		cell := diagnosticParserCoreGenericCell{headerIndex: index, boundary: boundary}
+		if actions.Descriptor().Kind() == core.ActionRowUnsupported && s.tokenSource != nil {
+			cell.repetitionReduceOrdinal, cell.repetitionFold = diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions)
+		}
+		s.dispatchScratch.cells = append(s.dispatchScratch.cells, cell)
 	}
 	cells := s.dispatchScratch.cells
 	noActionIndices := s.dispatchScratch.noActionIndices
@@ -2270,10 +2320,12 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	conflictCell := -1
 	for index, cell := range cells {
 		descriptor := cell.descriptor()
-		if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, s.token, cell.actions(), descriptor); unsupported != nil {
-			return unsupported, nil
+		if !cell.repetitionFold {
+			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, s.token, cell.actions(), descriptor); unsupported != nil {
+				return unsupported, nil
+			}
 		}
-		switch descriptor.Kind() {
+		switch cell.kind() {
 		case core.ActionRowAccept:
 			if acceptCell < 0 {
 				acceptCell = index
@@ -2586,7 +2638,8 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	if err := s.reserveDispatches(1); err != nil {
 		return err
 	}
-	outputs, err := s.compact.ReduceOutputsClassifiedIntoOwned(owner, s.reductionOutputs, cell.boundary, 0, core.ForkOrder{})
+	ordinal := cell.selectedActionOrdinal()
+	outputs, err := s.compact.ReduceOutputsClassifiedIntoOwned(owner, s.reductionOutputs, cell.boundary, ordinal, core.ForkOrder{})
 	if err != nil {
 		return err
 	}
@@ -2639,6 +2692,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	if madeFreshProgress {
 		s.epochProgress = true
 	}
+	if cell.repetitionFold {
+		s.work.add(&s.work.RepetitionFolds, 1)
+	}
 	s.work.Reductions++
 	s.work.Dispatches++
 	if err := s.canonicalize(); err != nil {
@@ -2653,7 +2709,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			Index: len(s.receipt.Rounds), Before: before,
 			Actions: []DiagnosticParserCoreRoundAction{{
 				HeaderIndex: cell.headerIndex, State: StateID(cell.boundary.State()), ByteOffset: cell.boundary.ByteOffset(),
-				Ordinal: 0, Action: rootParserCoreAction(cell.actions().At(0)),
+				Ordinal: ordinal, Action: rootParserCoreAction(cell.actions().At(ordinal)),
 			}},
 			After: after,
 		})

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1496,10 +1496,17 @@ func (cell diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
 	return 0
 }
 
+var diagnosticParserCoreRepetitionFoldOptOut = map[string]bool{
+	// The compact reduction frontier splits an attribute-bearing HTML tag.
+	// TestMarkdownInlineAttributeHTMLTagStaysWhole protects the production shape.
+	"markdown_inline": true,
+}
+
 // diagnosticParserCoreRepetitionFoldOrdinal mirrors the production parser's
 // certified single-reduce repetition fold for a clean compact lineage.
 func diagnosticParserCoreRepetitionFoldOrdinal(language *Language, actions core.ActionRow) (int, bool) {
-	if actions.Len() < 2 || language == nil || cRepetitionSkipOptOut[language.Name] {
+	if actions.Len() < 2 || language == nil || cRepetitionSkipOptOut[language.Name] ||
+		diagnosticParserCoreRepetitionFoldOptOut[language.Name] {
 		return 0, false
 	}
 	reduceOrdinal := -1
@@ -2639,6 +2646,10 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		return err
 	}
 	ordinal := cell.selectedActionOrdinal()
+	if cell.repetitionFold {
+		s.compact.SetReduceConflictContext(true)
+		defer s.compact.SetReduceConflictContext(false)
+	}
 	outputs, err := s.compact.ReduceOutputsClassifiedIntoOwned(owner, s.reductionOutputs, cell.boundary, ordinal, core.ForkOrder{})
 	if err != nil {
 		return err

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -16,11 +16,99 @@ func TestDiagnosticParserCoreGenericWorkSaturatesCausalCounters(t *testing.T) {
 	work := DiagnosticParserCoreGenericWork{
 		ConflictActionArmsAdmitted: math.MaxUint64 - 1,
 		CausalConflictForks:        math.MaxUint64 - 2,
+		RepetitionFolds:            math.MaxUint64,
 	}
 	work.add(&work.ConflictActionArmsAdmitted, 2)
 	work.add(&work.CausalConflictForks, 3)
-	if work.ConflictActionArmsAdmitted != math.MaxUint64 || work.CausalConflictForks != math.MaxUint64 || !work.Overflow {
+	work.add(&work.RepetitionFolds, 1)
+	if work.ConflictActionArmsAdmitted != math.MaxUint64 || work.CausalConflictForks != math.MaxUint64 ||
+		work.RepetitionFolds != math.MaxUint64 || !work.Overflow {
 		t.Fatalf("scheduler causal saturation=%+v", work)
+	}
+}
+
+func TestDiagnosticParserCoreGenericRepetitionFoldMatchesProductionScope(t *testing.T) {
+	actions := core.NewActionRow([]core.Action{
+		{Type: core.ActionShift, State: 2, Repetition: true},
+		{Type: core.ActionReduce, Symbol: 4},
+	})
+	if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "bash"}, actions); !ok || ordinal != 1 {
+		t.Fatalf("bash repetition fold ordinal=%d ok=%t, want 1 true", ordinal, ok)
+	}
+	if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "dart"}, actions); ok {
+		t.Fatal("dart repetition fold bypassed the production opt-out")
+	}
+	if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(nil, actions); ok {
+		t.Fatal("nil-language repetition fold was admitted")
+	}
+	malformed := []core.ActionRow{
+		core.NewActionRow([]core.Action{{Type: core.ActionShift, State: 2, Repetition: true}}),
+		core.NewActionRow([]core.Action{
+			{Type: core.ActionShift, State: 2},
+			{Type: core.ActionReduce, Symbol: 4},
+		}),
+		core.NewActionRow([]core.Action{
+			{Type: core.ActionShift, State: 2, Repetition: true},
+			{Type: core.ActionReduce, Symbol: 4},
+			{Type: core.ActionReduce, Symbol: 5},
+		}),
+	}
+	for index, row := range malformed {
+		if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "bash"}, row); ok {
+			t.Fatalf("malformed repetition row %d was admitted", index)
+		}
+	}
+}
+
+func TestDiagnosticParserCoreGenericRepetitionFoldReducesWithoutFork(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 9}: {
+				{Type: core.ActionShift, State: 3, Repetition: true},
+				{Type: core.ActionReduce, Symbol: 4},
+			},
+		},
+		gotos: map[genericConflictCell]core.StateID{
+			{state: 1, symbol: 4}: 2,
+		},
+	}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: &dfaTokenSource{language: &Language{Name: "bash"}},
+		headers:     []diagnosticParserCoreHeader{{head: head}},
+		token:       Token{Symbol: 9, EndByte: 1},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches: 8,
+			ReceiptMode:   DiagnosticParserCoreReceiptFull,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	stop, err := scheduler.dispatchPass()
+	if err != nil || stop != nil {
+		t.Fatalf("repetition fold stop=%+v err=%v", stop, err)
+	}
+	state, _, err := compact.Boundary(scheduler.headers[0].head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != 2 || scheduler.dispatches != 1 || scheduler.work.RepetitionFolds != 1 ||
+		scheduler.work.Reductions != 1 || scheduler.work.Conflicts != 0 || scheduler.work.Forks != 0 {
+		t.Fatalf("repetition fold state=%d dispatches=%d work=%+v", state, scheduler.dispatches, scheduler.work)
+	}
+	if len(scheduler.receipt.Rounds) != 1 || len(scheduler.receipt.Rounds[0].Actions) != 1 {
+		t.Fatalf("repetition fold rounds=%+v", scheduler.receipt.Rounds)
+	}
+	action := scheduler.receipt.Rounds[0].Actions[0]
+	if action.Ordinal != 1 || action.Action.Type != ParseActionReduce {
+		t.Fatalf("repetition fold action=%+v, want reduction ordinal 1", action)
 	}
 }
 

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -38,6 +38,9 @@ func TestDiagnosticParserCoreGenericRepetitionFoldMatchesProductionScope(t *test
 	if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "dart"}, actions); ok {
 		t.Fatal("dart repetition fold bypassed the production opt-out")
 	}
+	if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(&Language{Name: "markdown_inline"}, actions); ok {
+		t.Fatal("Markdown Inline repetition fold bypassed the compact frontier opt-out")
+	}
 	if _, ok := diagnosticParserCoreRepetitionFoldOrdinal(nil, actions); ok {
 		t.Fatal("nil-language repetition fold was admitted")
 	}
@@ -109,6 +112,20 @@ func TestDiagnosticParserCoreGenericRepetitionFoldReducesWithoutFork(t *testing.
 	action := scheduler.receipt.Rounds[0].Actions[0]
 	if action.Ordinal != 1 || action.Action.Type != ParseActionReduce {
 		t.Fatalf("repetition fold action=%+v, want reduction ordinal 1", action)
+	}
+	derivations, err := compact.Derivations(scheduler.headers[0].head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(derivations) != 1 || len(derivations[0].Payloads) != 1 {
+		t.Fatalf("repetition fold derivations=%+v, want one reduced payload", derivations)
+	}
+	view, err := compact.MaterializationView(derivations[0].Payloads[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Fragile {
+		t.Fatal("repetition fold reduction lost its conflict fragility")
 	}
 }
 

--- a/w1_leading_splice_test.go
+++ b/w1_leading_splice_test.go
@@ -37,6 +37,7 @@ import (
 func leadingParseAt(t *testing.T, lang *gts.Language, src []byte, off int, class string) (fresh, incr *gts.Node, prof gts.IncrementalParseProfile, edited []byte) {
 	t.Helper()
 	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
 	oldTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("base parse: %v", err)
@@ -46,7 +47,9 @@ func leadingParseAt(t *testing.T, lang *gts.Language, src []byte, off int, class
 	}
 	edited, edit := incrGateBuildEdit(src, off, class)
 
-	freshTree, err := gts.NewParser(lang).Parse(edited)
+	freshParser := gts.NewParser(lang)
+	freshParser.SetAdmissionCandidateRoute(false)
+	freshTree, err := freshParser.Parse(edited)
 	if err != nil {
 		t.Fatalf("fresh parse of edited: %v", err)
 	}

--- a/w5_editor_latency_gate_test.go
+++ b/w5_editor_latency_gate_test.go
@@ -440,6 +440,14 @@ type w5Sample struct {
 	FreshWallNs  int64
 }
 
+// w5ProductionParser keeps this incremental reuse gate on its certified route.
+// Compact-tree incremental reuse remains barred by decision 0008.
+func w5ProductionParser(lang *gts.Language) *gts.Parser {
+	parser := gts.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	return parser
+}
+
 func w5RunSample(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w5EditClass, pos w5Position) w5Sample {
 	t.Helper()
 	src, itemCount := spec.build(tier.targetSize)
@@ -452,7 +460,7 @@ func w5RunSampleAtOffset(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w
 	t.Helper()
 	lang := spec.lang()
 
-	parser := gts.NewParser(lang)
+	parser := w5ProductionParser(lang)
 	oldTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("%s/%s base parse: %v", spec.name, tier.name, err)
@@ -464,7 +472,7 @@ func w5RunSampleAtOffset(t *testing.T, spec w5LangSpec, tier w5SizeTier, class w
 
 	edited, edit := w5ApplyEdit(src, offset, class)
 
-	freshParser := gts.NewParser(lang)
+	freshParser := w5ProductionParser(lang)
 	freshStart := time.Now()
 	freshTree, err := freshParser.Parse(edited)
 	freshWall := time.Since(freshStart)
@@ -928,7 +936,7 @@ func TestW5CSSNearTopReuseAssertion(t *testing.T) {
 	}
 	offset := braceIdx - 1
 
-	parser := gts.NewParser(lang)
+	parser := w5ProductionParser(lang)
 	oldTree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("base parse: %v", err)
@@ -940,7 +948,7 @@ func TestW5CSSNearTopReuseAssertion(t *testing.T) {
 
 	edited, edit := w5ApplyEdit(src, offset, w5Insert)
 
-	freshParser := gts.NewParser(lang)
+	freshParser := w5ProductionParser(lang)
 	freshTree, err := freshParser.Parse(edited)
 	if err != nil {
 		t.Fatalf("fresh parse of edited: %v", err)
@@ -992,7 +1000,7 @@ func TestW5DeterminismAcrossFreshParsers(t *testing.T) {
 					offset := w5LastDigitOffset(t, src, spec.marker(sites[w5Middle]))
 
 					run := func() gts.IncrementalParseProfile {
-						parser := gts.NewParser(spec.lang())
+						parser := w5ProductionParser(spec.lang())
 						oldTree, err := parser.Parse(src)
 						if err != nil {
 							t.Fatalf("base parse: %v", err)


### PR DESCRIPTION
## Summary

- Apply the certified C repetition fold in the compact scheduler.
- Reuse the production parser opt-out set.
- Preserve conflict fragility on every folded reduction.
- Keep Markdown Inline on production after a deeper fixture disproved compact equivalence.
- Keep incremental reuse gates on production until decision 0008 permits compact-tree reuse.

## Result

The 206-language admission census improved from 168 to 192 passing languages. Divergence remains zero.

Twenty-four languages moved from repetition fallback to exact digest parity. Nine fallbacks remain.

This generalized parser fix does not remove a normalizer. It expands the route proof needed for safe retirement.

## Correctness evidence

- Focused repetition and frontier tests pass.
- The internal compact-core package passes.
- The strict scorecard reports PASS=192, DIVERGE=0, FALLBACK=9, SKIP=5.
- The release ratchet pins all 192 passes and caps fallbacks at nine.
- The Markdown Inline HTML-tag fixture passes through the fail-closed production route.
- Focused incremental W1, W5, and scanner-policy gates pass on production.
- TOML and Scheme each report 25/25 deep parity in isolated Docker runs.
- Comment reports 2/3 deep parity on both base and treatment.

## Performance evidence

The first local A/B run was not valid. Host load reached 14.7 during unrelated jobs.

Base and treatment both selected the compact route. The change avoids the new policy lookup on normal action rows.

Run exact-head timing on a quiet host or the enabled GCP path before publishing performance claims.

## Remaining families

- No-lookahead tokens: Doxygen, JSDoc, and VHDL.
- EOF frontier selection: HTTP, Meson, and Robot.
- Stalled progress: COBOL and Cooklang.
- Compact repetition frontier: Markdown Inline.

## Review

Run Buckbot against the exact head with the API backend and Qwen 3.7 Plus. Require Grade A before merge.
