### PR TITLE
Retire native type-projection compatibility repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- DFA keyword promotion now owns Arduino primitive types before compatibility.
+  Native materialization owns Objective-C protocol type identifiers.
+  This retires Arduino's dispatcher arm and the matching Objective-C subpass.
+
 - Erlang macro replacement election now stays in the parser.
   It distinguishes function clauses from case and receive clauses.
   Reduction already emits exact top-level form spans.

--- a/cgo_harness/docker/Dockerfile
+++ b/cgo_harness/docker/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     time \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm --global --loglevel=warn install tree-sitter-cli@0.24.7

--- a/cgo_harness/docker/Dockerfile
+++ b/cgo_harness/docker/Dockerfile
@@ -1,3 +1,5 @@
+FROM node:22-bookworm AS node-runtime
+
 FROM golang:1.25-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -10,10 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     time \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    nodejs \
-    npm \
-    && rm -rf /var/lib/apt/lists/*
+COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 RUN npm --global --loglevel=warn install tree-sitter-cli@0.24.7
 

--- a/cgo_harness/type_projection_retirement_parity_test.go
+++ b/cgo_harness/type_projection_retirement_parity_test.go
@@ -1,0 +1,69 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func TestTypeProjectionRetirementCOracleParity(t *testing.T) {
+	tests := []parityCase{
+		{
+			name:   "arduino",
+			source: "int f(void) { char c = 0; return c; }\n",
+		},
+		{
+			name:   "objc",
+			source: "@interface CallbackClient : NSObject <ClientProtocol>\n@end\n",
+		},
+	}
+	for index, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%s_%d", test.name, index), func(t *testing.T) {
+			scheduleParityMemoryScavenge(t)
+			source := []byte(test.source)
+			entry, ok := parityEntriesByName[test.name]
+			if !ok {
+				t.Fatalf("missing grammar entry for %s", test.name)
+			}
+			language := entry.Language()
+			goTree, err := gotreesitter.NewParser(language).
+				ParseNoResultCompatibilityBenchmarkOnly(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer goTree.Release()
+
+			cLanguage, err := ParityCLanguage(test.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLanguage); err != nil {
+				t.Fatal(err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle returned a nil tree")
+			}
+			defer cTree.Close()
+
+			var divergences []string
+			compareNodes(
+				goTree.RootNode(),
+				language,
+				cTree.RootNode(),
+				"root",
+				&divergences,
+			)
+			if len(divergences) != 0 {
+				t.Fatalf("C-oracle divergences: %v", divergences)
+			}
+		})
+	}
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -15,13 +15,13 @@ without updating that registry.
 
 The v1 registry freezes the current surface:
 
-- 60 explicit `runLanguageResultCompatibility` switch arms covering 62
+- 59 explicit `runLanguageResultCompatibility` switch arms covering 61
   language names;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-That is 61 live registry entries and 24 retired entries. The registry covers
+That is 60 live registry entries and 25 retired entries. The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.
 
@@ -31,6 +31,11 @@ shrink, and half of HTML's arm (the ERROR-root nested-custom-tag
 reconstruction). At that checkpoint, HTML's range function stayed live.
 R1 later retired that separate second-pass function. The registry keeps both
 retired mechanisms as distinct historical receipts.
+
+R3 also retires Arduino's primitive-type arm.
+DFA keyword promotion now emits those types before compatibility.
+Native Objective-C projection also owns protocol type identifiers.
+Other Objective-C repairs remain live.
 
 The exact collapsed-child policy retains a bare Rust `..` token.
 The merged-left-side conflict rule selects chained dot-range shifts.

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -192,6 +192,10 @@ The D dispatcher remains live for unrelated shape repairs.
 Native derivation election chooses the correct Erlang macro replacement.
 Native reduction owns Erlang top-level form spans.
 The Erlang dispatcher arm is retired.
+The DFA keyword path now owns Arduino primitive-type projection.
+Native Objective-C materialization owns protocol type identifiers.
+This change retires Arduino's arm and one Objective-C subpass.
+Other Objective-C repairs remain live.
 
 Group by invariant, not language:
 

--- a/grammars/type_projection_native_regression_test.go
+++ b/grammars/type_projection_native_regression_test.go
@@ -1,0 +1,241 @@
+//go:build !grammar_subset
+
+package grammars
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+type typeProjectionRetirementCase struct {
+	name                   string
+	source                 []byte
+	language               *gotreesitter.Language
+	assert                 func(*testing.T, *gotreesitter.Node, *gotreesitter.Language, []byte)
+	reuseUnsupportedReason string
+	compactDecline         bool
+}
+
+func TestTypeProjectionNeedsNoResultCompatibility(t *testing.T) {
+	for _, test := range typeProjectionRetirementCases() {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			tree, err := gotreesitter.NewParser(test.language).
+				ParseNoResultCompatibilityBenchmarkOnly(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(tree.Release)
+			test.assert(t, tree.RootNode(), test.language, test.source)
+		})
+	}
+}
+
+func TestTypeProjectionRoutes(t *testing.T) {
+	gotreesitter.SetGLRForestEnabled(false)
+	t.Cleanup(func() { gotreesitter.SetGLRForestEnabled(true) })
+
+	for _, test := range typeProjectionRetirementCases() {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			source := append(append([]byte(nil), test.source...), '\n')
+
+			productionParser := gotreesitter.NewParser(test.language)
+			productionParser.SetAdmissionCandidateRoute(false)
+			production, err := productionParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(production.Release)
+			test.assert(t, production.RootNode(), test.language, source)
+
+			routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+			compactParser := gotreesitter.NewParser(test.language)
+			compactParser.SetAdmissionCandidateRoute(true)
+			compact, err := compactParser.Parse(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(compact.Release)
+			test.assert(t, compact.RootNode(), test.language, source)
+			routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+			if test.compactDecline {
+				if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+					t.Fatalf(
+						"compact decline counters routed=%d/%d fallback=%d/%d",
+						routedBefore,
+						routedAfter,
+						fallbackBefore,
+						fallbackAfter,
+					)
+				}
+			} else if routedAfter != routedBefore+1 || fallbackAfter != fallbackBefore {
+				t.Fatalf(
+					"compact route counters routed=%d/%d fallback=%d/%d",
+					routedBefore,
+					routedAfter,
+					fallbackBefore,
+					fallbackAfter,
+				)
+			}
+
+			gotreesitter.SetGLRForestEnabled(true)
+			forestParser := gotreesitter.NewParser(test.language)
+			forest, ok := forestParser.ParseForestExperimental(source)
+			gotreesitter.SetGLRForestEnabled(false)
+			if !ok || forest == nil {
+				offset, symbol, reason, _ := forestParser.ForestDeclineInfo()
+				t.Fatalf("forest declined at %d symbol=%d reason=%s", offset, symbol, reason)
+			}
+			t.Cleanup(forest.Release)
+			test.assert(t, forest.RootNode(), test.language, source)
+			if !forest.ParseRuntime().ForestFastPath {
+				t.Fatal("forest parse did not report the forest route")
+			}
+
+			incrementalParser := gotreesitter.NewParser(test.language)
+			incrementalParser.SetAdmissionCandidateRoute(false)
+			oldTree, err := incrementalParser.Parse(test.source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(oldTree.Release)
+			endPoint := retiredDispatchPointAtByte(test.source, len(test.source))
+			oldTree.Edit(gotreesitter.InputEdit{
+				StartByte:   uint32(len(test.source)),
+				OldEndByte:  uint32(len(test.source)),
+				NewEndByte:  uint32(len(source)),
+				StartPoint:  endPoint,
+				OldEndPoint: endPoint,
+				NewEndPoint: gotreesitter.Point{Row: endPoint.Row + 1},
+			})
+			incremental, profile, err := incrementalParser.ParseIncrementalProfiled(source, oldTree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(incremental.Release)
+			test.assert(t, incremental.RootNode(), test.language, source)
+			if test.reuseUnsupportedReason != "" {
+				if !profile.ReuseUnsupported ||
+					profile.ReuseUnsupportedReason != test.reuseUnsupportedReason {
+					t.Fatalf("incremental reuse status = %+v", profile)
+				}
+			} else if !profile.OldTreeReuseRoute || profile.ReusedSubtrees == 0 ||
+				profile.ReusedBytes == 0 {
+				t.Fatalf("incremental route did not reuse the old tree: %+v", profile)
+			}
+
+			want := typeProjectionTreeDigest(t, production, test.language)
+			for route, tree := range map[string]*gotreesitter.Tree{
+				"compact":     compact,
+				"forest":      forest,
+				"incremental": incremental,
+			} {
+				if got := typeProjectionTreeDigest(t, tree, test.language); got != want {
+					t.Fatalf("%s digest = %s, want %s", route, got, want)
+				}
+			}
+		})
+	}
+}
+
+func typeProjectionRetirementCases() []typeProjectionRetirementCase {
+	return []typeProjectionRetirementCase{
+		{
+			name:                   "arduino_builtin_primitive_types",
+			source:                 []byte("int f(void) { char c = 0; return c; }"),
+			language:               ArduinoLanguage(),
+			assert:                 assertArduinoBuiltinPrimitiveTypes,
+			reuseUnsupportedReason: "external_scanner_unsupported",
+		},
+		{
+			name:           "objc_protocol_type_identifier",
+			source:         []byte("@interface CallbackClient : NSObject <ClientProtocol>\n@end"),
+			language:       ObjcLanguage(),
+			assert:         assertObjcProtocolTypeIdentifier,
+			compactDecline: true,
+		},
+	}
+}
+
+func typeProjectionTreeDigest(
+	t *testing.T,
+	tree *gotreesitter.Tree,
+	language *gotreesitter.Language,
+) string {
+	t.Helper()
+	receipt, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt.SHA256
+}
+
+func assertArduinoBuiltinPrimitiveTypes(
+	t *testing.T,
+	root *gotreesitter.Node,
+	language *gotreesitter.Language,
+	source []byte,
+) {
+	t.Helper()
+	for _, text := range []string{"int", "void", "char"} {
+		node := findTypeProjectionNode(root, language, source, "primitive_type", text)
+		if node == nil || !node.IsNamed() || node.ChildCount() != 0 {
+			t.Fatalf("Arduino primitive %q = %v: %s", text, node, root.SExpr(language))
+		}
+	}
+}
+
+func assertObjcProtocolTypeIdentifier(
+	t *testing.T,
+	root *gotreesitter.Node,
+	language *gotreesitter.Language,
+	source []byte,
+) {
+	t.Helper()
+	assertTypeProjectionLeaf(t, root, language, source, "type_identifier", "ClientProtocol")
+}
+
+func assertTypeProjectionLeaf(
+	t *testing.T,
+	root *gotreesitter.Node,
+	language *gotreesitter.Language,
+	source []byte,
+	nodeType string,
+	text string,
+) {
+	t.Helper()
+	node := findTypeProjectionNode(root, language, source, nodeType, text)
+	if node == nil || !node.IsNamed() || node.ChildCount() != 0 {
+		t.Fatalf("%s %q = %v: %s", nodeType, text, node, root.SExpr(language))
+	}
+}
+
+func findTypeProjectionNode(
+	node *gotreesitter.Node,
+	language *gotreesitter.Language,
+	source []byte,
+	nodeType string,
+	text string,
+) *gotreesitter.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Type(language) == nodeType && node.Text(source) == text {
+		return node
+	}
+	for index := 0; index < node.ChildCount(); index++ {
+		if found := findTypeProjectionNode(
+			node.Child(index),
+			language,
+			source,
+			nodeType,
+			text,
+		); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/parser_result_c.go
+++ b/parser_result_c.go
@@ -918,38 +918,6 @@ func setCRewriteChildren(n *Node, symbol Symbol, named bool, children []*Node, f
 	populateParentNode(n, n.children)
 }
 
-// normalizeArduinoBuiltinPrimitiveTypes promotes type_identifier leaves whose
-// text is a builtin C primitive type name (e.g. void, int, char) into
-// primitive_type nodes. The Arduino grammar is a superset of C and inherits the
-// same primitive_type token set, but in a handful of syntactic positions (most
-// notably the explicit empty parameter list `(void)`) the parser tags the
-// keyword as a user type_identifier. tree-sitter-c performs the same promotion;
-// applying it here keeps Arduino byte-faithful to the C oracle without routing
-// Arduino through the heavier C recovery passes.
-func normalizeArduinoBuiltinPrimitiveTypes(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil {
-		return
-	}
-	primitiveTypeSym, ok := lang.SymbolByName("primitive_type")
-	if !ok {
-		return
-	}
-	typeIdentifierSym, ok := lang.SymbolByName("type_identifier")
-	if !ok {
-		return
-	}
-	primitiveTypeNamed := symbolIsNamed(lang, primitiveTypeSym)
-	walkResultTree(root, func(n *Node) {
-		if n.symbol != typeIdentifierSym {
-			return
-		}
-		if isCBuiltinPrimitiveTypeName(canonicalCTypeName(n.Text(source))) {
-			n.symbol = primitiveTypeSym
-			n.setNamed(primitiveTypeNamed)
-		}
-	})
-}
-
 func isCBuiltinPrimitiveTypeName(name string) bool {
 	switch name {
 	case "char", "int", "float", "double", "void", "_Bool", "_Complex", "bool", "__int128",

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -134,8 +134,6 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		dispatcherArmCensus(ctx, "dispatch.bitbake", func() { normalizeBitbakeCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "chatito":
 		dispatcherArmCensus(ctx, "dispatch.chatito", func() { normalizeChatitoCompatibility(ctx.root, ctx.source, ctx.lang) })
-	case "arduino":
-		dispatcherArmCensus(ctx, "dispatch.arduino", func() { normalizeArduinoBuiltinPrimitiveTypes(ctx.root, ctx.source, ctx.lang) })
 	case "c", "cpp":
 		dispatcherArmCensus(ctx, "dispatch.c_cpp", func() { normalizeCCompatibilityWithParser(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "c_sharp":

--- a/parser_result_go.go
+++ b/parser_result_go.go
@@ -88,9 +88,8 @@ func normalizeGoReturnedTreeCompatibility(root *Node, source []byte, p *Parser, 
 // retags node symbols/named-ness and child field labels (never bytes, never
 // node count, never parent/child structure) and only for the one syntactic
 // position the owner-confirmed divergence covers — the sole/leading argument
-// of a literal `new`/`make` call. It mirrors the existing precedent for this
-// class of fix (see normalizeArduinoBuiltinPrimitiveTypes in
-// parser_result_c.go).
+// of a literal `new`/`make` call. It follows the same bounded symbol-retagging
+// pattern as the other result-compatibility repairs.
 //
 // The base case retags a bare identifier (`new(dirInfo)`) to type_identifier.
 // goNewMakeTypeRetagCtx.relabel extends the same retag to the three other

--- a/parser_result_objc.go
+++ b/parser_result_objc.go
@@ -2,7 +2,6 @@ package gotreesitter
 
 func normalizeObjcCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeObjcMethodTypeIdentifiers(root, lang)
-	normalizeObjcParameterizedArgumentTypeIdentifiers(root, lang)
 	normalizeObjcSizeofTypeIdentifierOperands(root, lang)
 	normalizeObjcAtStringLiterals(root, lang)
 	normalizeObjcStructSizedTypeSpecifiers(root, lang)
@@ -24,38 +23,6 @@ func normalizeObjcMethodTypeIdentifiers(root *Node, lang *Language) {
 	typeIdentifierNamed := symbolIsNamed(lang, typeIdentifierSym)
 	walkResultTree(root, func(n *Node) {
 		if n == nil || n.symbol != methodTypeSym {
-			return
-		}
-		for i := 0; i < resultChildCount(n); i++ {
-			typeName := resultChildAt(n, i)
-			if typeName == nil || typeName.symbol != typeNameSym {
-				continue
-			}
-			for j := 0; j < resultChildCount(typeName); j++ {
-				child := resultChildAt(typeName, j)
-				if child != nil && child.symbol == identifierSym {
-					child.symbol = typeIdentifierSym
-					child.setNamed(typeIdentifierNamed)
-				}
-			}
-		}
-	})
-}
-
-func normalizeObjcParameterizedArgumentTypeIdentifiers(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "objc" {
-		return
-	}
-	parameterizedArgumentsSym, ok1 := symbolByName(lang, "parameterized_arguments")
-	typeNameSym, ok2 := symbolByName(lang, "type_name")
-	identifierSym, ok3 := symbolByName(lang, "identifier")
-	typeIdentifierSym, ok4 := symbolByName(lang, "type_identifier")
-	if !ok1 || !ok2 || !ok3 || !ok4 {
-		return
-	}
-	typeIdentifierNamed := symbolIsNamed(lang, typeIdentifierSym)
-	walkResultTree(root, func(n *Node) {
-		if n == nil || n.symbol != parameterizedArgumentsSym {
 			return
 		}
 		for i := 0; i < resultChildCount(n); i++ {

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -2,8 +2,8 @@
   "schema": "gotreesitter/result-compat-ownership/v1",
   "source_of_truth": true,
   "denominator": {
-    "dispatcher_arms": 60,
-    "dispatcher_languages": 62,
+    "dispatcher_arms": 59,
+    "dispatcher_languages": 61,
     "dispatcher_predicates": 1,
     "generic_passes": 0,
     "post_finalization_arms": 0,
@@ -284,21 +284,26 @@
       "languages": [
         "arduino"
       ],
-      "purpose": "Reconcile Arduino builtin primitive type materialization.",
+      "purpose": "Historical: reconcile Arduino builtin primitive type materialization. DFA keyword promotion now emits each primitive_type before compatibility.",
       "authoritative_owner": "materialization",
       "witnesses": [
-        "cgo_harness/parity_cgo_test.go"
+        "grammars/type_projection_native_regression_test.go",
+        "cgo_harness/type_projection_retirement_parity_test.go"
       ],
-      "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
+      "retirement_condition": "Satisfied: DFA keyword promotion emits each primitive_type natively. Compatibility-free, production, compact, forest, incremental, and C-oracle receipts return the same tree.",
       "route_coverage": {
-        "production": "shared_result_compatibility_tail",
-        "compact": "shared_result_compatibility_tail",
-        "forest": "shared_result_compatibility_tail",
-        "incremental": "shared_result_compatibility_tail",
-        "c_oracle": "curated_single_grammar_parity"
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
       },
-      "status": "live",
-      "receipt_refs": []
+      "status": "retired",
+      "retired_commit": "d9c712131e152529b2e21e048c792db0a5b358c1",
+      "receipt_refs": [
+        "grammars/type_projection_native_regression_test.go",
+        "cgo_harness/type_projection_retirement_parity_test.go"
+      ]
     },
     {
       "id": "dispatch.c_cpp",
@@ -1522,10 +1527,12 @@
       "languages": [
         "objc"
       ],
-      "purpose": "Reconcile Objective-C aliases, fields, and spans.",
+      "purpose": "Reconcile Objective-C method types, sizeof operands, literals, sized types, encode types, function pointers, fields, and spans. Native projection now owns protocol type identifiers.",
       "authoritative_owner": "materialization",
       "witnesses": [
-        "cgo_harness/parity_cgo_test.go"
+        "cgo_harness/parity_cgo_test.go",
+        "grammars/type_projection_native_regression_test.go",
+        "cgo_harness/type_projection_retirement_parity_test.go"
       ],
       "retirement_condition": "Delete only after materialization emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
       "route_coverage": {


### PR DESCRIPTION
## Summary

- Retire Arduino’s full result-compatibility dispatcher arm.
- Retire Objective-C protocol type retagging from its live arm.
- Keep the remaining Objective-C repairs.
- Record exact route receipts in the ownership registry.

## General owner

DFA keyword promotion already emits Arduino primitive types before compatibility.
Native grammar projection already emits Objective-C protocol type identifiers.
This change removes redundant consumers of those parser-owned results.

## Evidence

- Production, compact, forest, and incremental routes return one tree digest.
- The compatibility-free route returns each required type.
- The locked C oracle matches both representative grammars.
- The ownership registry and dispatcher census pass.
- Canopy found no remaining code reference to either removed function.

## Scope controls

F# grouping still differs from the C oracle, so its repair remains live.
Other Objective-C repairs still change real parses, so they remain live.

## Issue 454

This change advances the normalization campaign. Issue #454 remains open.
That issue still needs GLR latency, flat-root, Python, and JavaScript certification work.