### PR TITLE
Optimize GLR negative-path memoization

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -233,8 +233,7 @@ type glrMergeScratch struct {
 	cleanZeroCache   map[*gssNode]gssCleanZeroErrorCacheEntry
 	cleanZeroFront   []glrCleanZeroFrontCacheEntry
 	cleanZeroBytes   int64
-	cleanZeroStack   []*gssNode
-	cleanZeroVisited []*gssNode
+	cleanZeroFrames  []gssCleanZeroFrame
 	// childErrors points at parseInternal's sticky proof for fresh full parses.
 	// false means no ERROR, MISSING, or has-error payload has been constructed
 	// anywhere in this parse, so every GSS path has zero subtree error cost and
@@ -270,6 +269,11 @@ type glrMergeScratch struct {
 	// at the top of every mergeStacksWithScratch call so a stale flag from a
 	// previous merge in the same pooled scratch can never leak forward.
 	mergeBudgetStopReason ParseStopReason
+}
+
+type gssCleanZeroFrame struct {
+	node     *gssNode
+	nextLink int
 }
 
 func (s *glrMergeScratch) provesNoChildErrors() bool {
@@ -1144,13 +1148,9 @@ func (s *glrMergeScratch) invalidateGSSPointersForReuse() {
 	if len(s.cleanZeroCache) > 0 {
 		clear(s.cleanZeroCache)
 	}
-	if cap(s.cleanZeroStack) > 0 {
-		clear(s.cleanZeroStack[:cap(s.cleanZeroStack)])
-		s.cleanZeroStack = s.cleanZeroStack[:0]
-	}
-	if cap(s.cleanZeroVisited) > 0 {
-		clear(s.cleanZeroVisited[:cap(s.cleanZeroVisited)])
-		s.cleanZeroVisited = s.cleanZeroVisited[:0]
+	if cap(s.cleanZeroFrames) > 0 {
+		clear(s.cleanZeroFrames[:cap(s.cleanZeroFrames)])
+		s.cleanZeroFrames = s.cleanZeroFrames[:0]
 	}
 	if cap(s.spineVisit) > 0 {
 		clear(s.spineVisit[:cap(s.spineVisit)])
@@ -3502,53 +3502,59 @@ func gssNodeCleanZeroErrorAllLinksWithScratch(scratch *glrMergeScratch, n *gssNo
 	}
 	scratch.cleanZeroScan++
 	scanEpoch := scratch.cleanZeroScan
-	stack := scratch.cleanZeroStack[:0]
-	visited := scratch.cleanZeroVisited[:0]
-	stack = append(stack, n)
-	for len(stack) > 0 {
-		last := len(stack) - 1
-		cur := stack[last]
-		stack = stack[:last]
-		if cur == nil {
-			continue
-		}
-		entry, ok := scratch.cleanZeroCache[cur]
-		if ok && entry.resultEpoch == scratch.cleanZeroEpoch {
-			if !entry.clean {
-				scratch.cleanZeroCache[n] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: false}
-				storeCleanZeroFrontCache(scratch, n, false)
-				scratch.cleanZeroStack = stack[:0]
-				scratch.cleanZeroVisited = visited[:0]
-				return false
+	frames := scratch.cleanZeroFrames[:0]
+	frames = append(frames, gssCleanZeroFrame{node: n})
+	cacheFailure := func() bool {
+		for _, frame := range frames {
+			scratch.cleanZeroCache[frame.node] = gssCleanZeroErrorCacheEntry{
+				resultEpoch: scratch.cleanZeroEpoch,
+				clean:       false,
 			}
-			continue
 		}
-		if ok && entry.scanEpoch == scanEpoch {
-			continue
-		}
-		entry.scanEpoch = scanEpoch
-		scratch.cleanZeroCache[cur] = entry
-		visited = append(visited, cur)
-		for i := 0; i < cur.linkCount(); i++ {
-			prev, linkEntry := cur.link(i)
-			if stackEntryHasNode(linkEntry) &&
-				(stackEntryNodeHasError(linkEntry) || stackEntryNodeIsMissing(linkEntry) || stackEntryNodeSymbol(linkEntry) == errorSymbol) {
-				scratch.cleanZeroCache[cur] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: false}
-				scratch.cleanZeroCache[n] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: false}
-				storeCleanZeroFrontCache(scratch, n, false)
-				scratch.cleanZeroStack = stack[:0]
-				scratch.cleanZeroVisited = visited[:0]
-				return false
-			}
-			stack = append(stack, prev)
-		}
+		storeCleanZeroFrontCache(scratch, n, false)
+		scratch.cleanZeroFrames = frames[:0]
+		return false
 	}
-	for _, node := range visited {
-		scratch.cleanZeroCache[node] = gssCleanZeroErrorCacheEntry{resultEpoch: scratch.cleanZeroEpoch, clean: true}
+	for len(frames) > 0 {
+		last := len(frames) - 1
+		frame := &frames[last]
+		cur := frame.node
+		if frame.nextLink == 0 {
+			entry, ok := scratch.cleanZeroCache[cur]
+			if ok && entry.resultEpoch == scratch.cleanZeroEpoch {
+				if !entry.clean {
+					return cacheFailure()
+				}
+				frames = frames[:last]
+				continue
+			}
+			if ok && entry.scanEpoch == scanEpoch {
+				frames = frames[:last]
+				continue
+			}
+			entry.scanEpoch = scanEpoch
+			scratch.cleanZeroCache[cur] = entry
+		}
+		if frame.nextLink == cur.linkCount() {
+			scratch.cleanZeroCache[cur] = gssCleanZeroErrorCacheEntry{
+				resultEpoch: scratch.cleanZeroEpoch,
+				clean:       true,
+			}
+			frames = frames[:last]
+			continue
+		}
+		prev, linkEntry := cur.link(frame.nextLink)
+		frame.nextLink++
+		if stackEntryHasNode(linkEntry) &&
+			(stackEntryNodeHasError(linkEntry) || stackEntryNodeIsMissing(linkEntry) || stackEntryNodeSymbol(linkEntry) == errorSymbol) {
+			return cacheFailure()
+		}
+		if prev != nil {
+			frames = append(frames, gssCleanZeroFrame{node: prev})
+		}
 	}
 	storeCleanZeroFrontCache(scratch, n, true)
-	scratch.cleanZeroStack = stack[:0]
-	scratch.cleanZeroVisited = visited[:0]
+	scratch.cleanZeroFrames = frames[:0]
 	return true
 }
 
@@ -5464,17 +5470,11 @@ func (s *glrMergeScratch) reset() {
 	if len(s.cleanZeroCache) > 0 {
 		clear(s.cleanZeroCache)
 	}
-	if cap(s.cleanZeroStack) > maxRetainedMergeResultCap {
-		s.cleanZeroStack = nil
-	} else if cap(s.cleanZeroStack) > 0 {
-		clear(s.cleanZeroStack[:cap(s.cleanZeroStack)])
-		s.cleanZeroStack = s.cleanZeroStack[:0]
-	}
-	if cap(s.cleanZeroVisited) > maxRetainedMergeResultCap {
-		s.cleanZeroVisited = nil
-	} else if cap(s.cleanZeroVisited) > 0 {
-		clear(s.cleanZeroVisited[:cap(s.cleanZeroVisited)])
-		s.cleanZeroVisited = s.cleanZeroVisited[:0]
+	if cap(s.cleanZeroFrames) > maxRetainedMergeResultCap {
+		s.cleanZeroFrames = nil
+	} else if cap(s.cleanZeroFrames) > 0 {
+		clear(s.cleanZeroFrames[:cap(s.cleanZeroFrames)])
+		s.cleanZeroFrames = s.cleanZeroFrames[:0]
 	}
 	s.cleanZeroScan = 0
 	s.childErrors = nil

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -1030,8 +1030,7 @@ func TestParserRecycleDemotedGSSInvalidatesPointerHolders(t *testing.T) {
 	stacks := scratch.merge.result[:1]
 	scratch.merge.cPrefixPath = append(scratch.merge.cPrefixPath, oldHead)
 	scratch.merge.cleanZeroCache = map[*gssNode]gssCleanZeroErrorCacheEntry{oldHead: {clean: true}}
-	scratch.merge.cleanZeroStack = append(scratch.merge.cleanZeroStack, oldHead)
-	scratch.merge.cleanZeroVisited = append(scratch.merge.cleanZeroVisited, oldHead)
+	scratch.merge.cleanZeroFrames = append(scratch.merge.cleanZeroFrames, gssCleanZeroFrame{node: oldHead})
 	scratch.merge.spineVisit = append(scratch.merge.spineVisit, spinePairKey{a: oldHead, b: oldHead.prev})
 	scratch.merge.mergeSeen = map[gssMergePair]bool{{a: oldHead, b: oldHead.prev}: true}
 	scratch.merge.preflight = newGSSMainPreflight(nil)

--- a/glr_test.go
+++ b/glr_test.go
@@ -3867,6 +3867,41 @@ func TestGSSCleanZeroAllLinksRejectsErrorBearingPackedPredecessor(t *testing.T) 
 	}
 }
 
+func TestGSSCleanZeroAllLinksCachesFailureForEveryActiveAncestor(t *testing.T) {
+	var nodes gssScratch
+	var scratch glrMergeScratch
+	scratch.beginEquivEpoch()
+
+	cleanSibling := nodes.allocNode(stackEntry{state: 8}, nil, 1)
+	errorPrev := nodes.allocNode(stackEntry{state: 9}, nil, 1)
+	errorEntry := newStackEntryNode(10, NewLeafNode(errorSymbol, true, 0, 1, Point{}, Point{Column: 1}))
+	stackEntryNode(errorEntry).setHasError(true)
+	bad := nodes.allocNode(stackEntry{state: 3}, nil, 1)
+	bad.appendExtraLink(gssMainLink{prev: errorPrev, entry: errorEntry})
+	middle := nodes.allocNode(stackEntry{state: 2}, bad, 2)
+	head := nodes.allocNode(stackEntry{state: 1}, cleanSibling, 3)
+	head.appendExtraLink(gssMainLink{prev: middle, entry: stackEntry{state: 2}})
+
+	if gssNodeCleanZeroErrorAllLinksWithScratch(&scratch, head) {
+		t.Fatal("clean-zero scan accepted an error-bearing ancestor path")
+	}
+	for _, node := range []*gssNode{head, middle, bad} {
+		entry := scratch.cleanZeroCache[node]
+		if entry.resultEpoch != scratch.cleanZeroEpoch || entry.clean {
+			t.Fatalf("ancestor cache = %#v, want current-epoch failure", entry)
+		}
+	}
+	if entry := scratch.cleanZeroCache[cleanSibling]; entry.resultEpoch != scratch.cleanZeroEpoch || !entry.clean {
+		t.Fatalf("clean sibling cache = %#v, want current-epoch success", entry)
+	}
+	if gssNodeCleanZeroErrorAllLinksWithScratch(&scratch, middle) {
+		t.Fatal("cached ancestor failure returned clean")
+	}
+	if len(scratch.cleanZeroFrames) != 0 {
+		t.Fatalf("clean-zero frames after cached failure = %d, want 0", len(scratch.cleanZeroFrames))
+	}
+}
+
 func TestGSSCleanZeroAllLinksFreshParseProofFallsBackAfterError(t *testing.T) {
 	var gssScratch gssScratch
 	childErrors := false
@@ -3885,6 +3920,32 @@ func TestGSSCleanZeroAllLinksFreshParseProofFallsBackAfterError(t *testing.T) {
 	childErrors = true
 	if gssNodeCleanZeroErrorAllLinksWithScratch(&mergeScratch, head) {
 		t.Fatal("clean-zero proof did not fall back after an error was recorded")
+	}
+}
+
+func BenchmarkGSSCleanZeroAllLinksNegativeAncestorCache(b *testing.B) {
+	var nodes gssScratch
+	errorEntry := newStackEntryNode(10, NewLeafNode(errorSymbol, true, 0, 1, Point{}, Point{Column: 1}))
+	stackEntryNode(errorEntry).setHasError(true)
+	bad := nodes.allocNode(stackEntry{state: 3}, nil, 1)
+	bad.appendExtraLink(gssMainLink{entry: errorEntry})
+
+	head := bad
+	const chainLen = 1000
+	for i := 1; i < chainLen; i++ {
+		head = nodes.allocNode(stackEntry{state: StateID(i%17 + 1)}, head, uint32(i+1))
+	}
+
+	var scratch glrMergeScratch
+	scratch.ensureMergeHotCaches()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scratch.beginCleanZeroEpoch()
+		for node := head; node != nil; node = node.prev {
+			if gssNodeCleanZeroErrorAllLinksWithScratch(&scratch, node) {
+				b.Fatal("negative ancestor returned clean")
+			}
+		}
 	}
 }
 

--- a/parser_scratch_reset_test.go
+++ b/parser_scratch_reset_test.go
@@ -43,8 +43,7 @@ func TestGLRMergeScratchResetPreservesCleanZeroEpochAndRejectsReusedAddress(t *t
 	scratch.cleanZeroCache = map[*gssNode]gssCleanZeroErrorCacheEntry{
 		old: {resultEpoch: scratch.cleanZeroEpoch, clean: true},
 	}
-	scratch.cleanZeroStack = append(scratch.cleanZeroStack, old)
-	scratch.cleanZeroVisited = append(scratch.cleanZeroVisited, old)
+	scratch.cleanZeroFrames = append(scratch.cleanZeroFrames, gssCleanZeroFrame{node: old})
 
 	epochBefore := scratch.cleanZeroEpoch
 	scratch.reset()
@@ -57,14 +56,11 @@ func TestGLRMergeScratchResetPreservesCleanZeroEpochAndRejectsReusedAddress(t *t
 	if len(scratch.cleanZeroCache) != 0 {
 		t.Fatalf("clean-zero map retained %d GSS pointers", len(scratch.cleanZeroCache))
 	}
-	if len(scratch.cleanZeroStack) != 0 || len(scratch.cleanZeroVisited) != 0 {
-		t.Fatalf("clean-zero traversal scratch not reset: stack=%d visited=%d", len(scratch.cleanZeroStack), len(scratch.cleanZeroVisited))
+	if len(scratch.cleanZeroFrames) != 0 {
+		t.Fatalf("clean-zero traversal scratch not reset: frames=%d", len(scratch.cleanZeroFrames))
 	}
-	if cap(scratch.cleanZeroStack) > 0 && scratch.cleanZeroStack[:cap(scratch.cleanZeroStack)][0] != nil {
-		t.Fatal("clean-zero stack backing retained a GSS pointer")
-	}
-	if cap(scratch.cleanZeroVisited) > 0 && scratch.cleanZeroVisited[:cap(scratch.cleanZeroVisited)][0] != nil {
-		t.Fatal("clean-zero visited backing retained a GSS pointer")
+	if cap(scratch.cleanZeroFrames) > 0 && scratch.cleanZeroFrames[:cap(scratch.cleanZeroFrames)][0].node != nil {
+		t.Fatal("clean-zero frame backing retained a GSS pointer")
 	}
 
 	nodes.recycleForParse()


### PR DESCRIPTION
## Purpose

Cache a failed clean-zero result for each active graph-structured stack ancestor. This change removes repeated depth-first searches along the same negative path.

Refs #454.

## Change

- Replace two traversal slices with one iterative postorder frame stack.
- Cache failure for each active ancestor.
- Keep completed clean siblings cached as clean.
- Clear all retained graph-structured stack pointers during scratch reset.
- Add focused regression and benchmark coverage.

## Correctness evidence

- Focused graph-structured stack tests passed in Docker.
- Focused race tests passed in Docker.
- PHP fresh-parse and error-state C parity passed.
- The 140,302-byte PHP probe kept identical parser metrics and stop reason.

## Performance evidence

The 1,000-node negative-path benchmark improved from 6106.29 microseconds to 34.43 microseconds. This is a 99.44 percent reduction.

The PHP macro probe improved from 5.854 seconds to 2.752 seconds. Maximum resident set size fell from 747,884 KiB to 734,532 KiB.

The primary full-parse and incremental benchmark trio showed no significant regression.

## Review note

A Buckbot Qwen dry run reached its 4 minute 45 second limit after 58,737 tokens. It returned no completed findings or verdict. Host validation supplies the evidence above.

This merge does not publish a release. Unreleased features ship on Thursday only.