### PR TITLE
fix(parser): preserve deferred parent links during recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,9 @@ for tags and release notes while still in `0.x`.
 - The parser covers every byte in each recovered EBNF source.
   This change removes the EBNF compatibility arm.
 
-- Result materialization now rejects a transient replacement that points back
-  to its current parent.
-  The parser returns an acyclic invariant error tree before it creates a
-  self-edge.
+- Recovery reductions now preserve deferred parent links during fresh parses.
+  This keeps valid Go files complete during final result materialization.
+  The invariant guard still rejects invalid transient replacements.
 
 - Native visible-wrapper election now owns D storage classes.
   This retires the matching result-normalization subpass.

--- a/parser_go_regression_test.go
+++ b/parser_go_regression_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
-func TestGoRepeatedCoreTestFragmentProducesAcyclicTree(t *testing.T) {
+func TestIssue490GoGrammarRegression(t *testing.T) {
 	data, err := os.ReadFile("internal/parsercorephase0/core_test.go")
 	if err != nil {
 		t.Fatal(err)
@@ -30,8 +30,21 @@ func TestGoRepeatedCoreTestFragmentProducesAcyclicTree(t *testing.T) {
 	}
 	t.Cleanup(tree.Release)
 
+	if tree.ParseStoppedEarly() {
+		t.Fatalf("Go parse stopped early: %s", tree.ParseRuntime().Summary())
+	}
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("Go parse returned no root")
+	}
+	if root.HasError() {
+		t.Fatal("Go parse returned an error tree")
+	}
+	if root.EndByte() != uint32(len(source)) {
+		t.Fatalf("Go root ends at %d, want %d", root.EndByte(), len(source))
+	}
 	if !publicResultTreeAcyclic(tree.RootNode()) {
-		t.Fatal("Go parse returned a cyclic result tree")
+		t.Fatal("Go parse returned an invalid result tree")
 	}
 }
 

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -2627,7 +2627,8 @@ func (p *Parser) cReductionCandidatesForAction(source []byte, start glrStack, ac
 	fork := start.cloneWithScratch(gssScratch)
 	fork.cRec = start.cRec.clone()
 	var dummy bool
-	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, false, trackChildErrors)
+	deferParentLinks := p.reduceScratch != nil && p.reduceScratch.transientParents != nil
+	p.applyAction(source, &fork, act, tok, &dummy, nodeCount, arena, entryScratch, gssScratch, nil, deferParentLinks, trackChildErrors)
 	if reason := p.resultMaterializationStopReason(arena); resultMaterializationShouldStop(reason) {
 		return nil, reason
 	}

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -1146,6 +1146,55 @@ func newCRecoverySyntheticReduceParser() *Parser {
 	return &Parser{language: lang, denseLimit: len(lang.ParseTable)}
 }
 
+func TestCRecoveryReductionPreservesTransientParentState(t *testing.T) {
+	parser := newCRecoverySyntheticReduceParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+
+	var scratch parserScratch
+	scratch.reduce.transientParents = &scratch.transientParents
+	parser.reduceScratch = &scratch.reduce
+	defer func() {
+		parser.reduceScratch = nil
+	}()
+
+	leaf := newLeafNodeInArena(arena, 1, true, 0, 1, Point{}, Point{Column: 1})
+	transient := scratch.transientParents.allocParent(
+		arena,
+		1,
+		true,
+		[]*Node{leaf},
+		0,
+		true,
+	)
+	right := newLeafNodeInArena(arena, 2, true, 1, 2, Point{Column: 1}, Point{Column: 2})
+	start := newGLRStack(1)
+	start.pushEntry(newStackEntryNode(2, transient), &scratch.entries, &scratch.gss)
+	start.pushEntry(newStackEntryNode(3, right), &scratch.entries, &scratch.gss)
+
+	nodeCount := 0
+	candidates, reason := parser.cReductionCandidatesForAction(
+		nil,
+		start,
+		ParseAction{Type: ParseActionReduce, Symbol: 4, ChildCount: 2},
+		Token{},
+		&nodeCount,
+		arena,
+		&scratch.entries,
+		&scratch.gss,
+		nil,
+	)
+	if reason != ParseStopNone {
+		t.Fatalf("recovery reduction stop reason = %v, want none", reason)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("recovery reduction candidates = %d, want 1", len(candidates))
+	}
+	if transient.parent != nil {
+		t.Fatal("recovery reduction replaced transient parent state")
+	}
+}
+
 // TestCDoAllPotentialReductionsKeepsShiftableOriginalWithReductionFork pins
 // C's version bookkeeping (parser.c ts_parser__do_all_potential_reductions):
 // a version whose state has a non-extra shift action for SOME token is KEPT


### PR DESCRIPTION
## Summary

Recovery reductions now preserve deferred parent links. The parser passes a `deferParentLinks` flag to `applyAction` when transient parent state is present. This change keeps valid Go files complete during final result materialization. The invariant guard still rejects invalid transient replacements.

## Changes

- Passes `deferParentLinks` to `applyAction` during C recovery reductions. This preserves parent links when transient parent state is active.
- Adds `TestCRecoveryReductionPreservesTransientParentState` to verify that recovery reductions maintain transient parent state.
- Expands the Go grammar regression test with assertions for parse completion, valid root, and zero errors.
- Renames `parser_go_cycle_regression_test.go` to `parser_go_regression_test.go` to match the broadened scope.
- Updates `CHANGELOG.md` to document the new preservation behavior.