### PR TITLE
release(docs): Publish v0.47.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,6 @@ for tags and release notes while still in `0.x`.
 - The parser covers every byte in each recovered EBNF source.
   This change removes the EBNF compatibility arm.
 
-- Recovery reductions now preserve deferred parent links during fresh parses.
-  This keeps valid Go files complete during final result materialization.
-  The invariant guard still rejects invalid transient replacements.
-
 - Native visible-wrapper election now owns D storage classes.
   This retires the matching result-normalization subpass.
   Native reduction also owns D variable-type qualifiers.
@@ -347,6 +343,14 @@ for tags and release notes while still in `0.x`.
   This removes repeated environment lookups from the incremental hot path.
   The pinned edited incremental benchmark improves 1.28 percent with zero
   allocations.
+
+## [0.47.1] - 2026-07-28
+
+### Fixed
+
+- Recovery reductions preserve deferred parent links during fresh parses.
+  Valid Go files remain complete during final result materialization.
+  The invariant guard still rejects invalid transient replacements.
 
 ## [0.47.0] - 2026-07-22
 
@@ -3954,7 +3958,8 @@ Warm-reuse throughput ~10 % higher. 206-grammar parity green under `GTS_PARITY_M
 - Initial standalone pure-Go runtime module.
 - External scanner VM foundation and base parser/lexer/tree infrastructure.
 
-[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.47.0...HEAD
+[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/v0.47.1...HEAD
+[0.47.1]: https://github.com/odvcencio/gotreesitter/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/odvcencio/gotreesitter/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/odvcencio/gotreesitter/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/odvcencio/gotreesitter/compare/v0.44.1...v0.45.0

--- a/README.md
+++ b/README.md
@@ -752,12 +752,10 @@ Test suite covers: smoke tests (206 grammars), golden S-expression snapshots, hi
 
 ## Roadmap
 
-The current release is **v0.47.0**. It closes the generalized incremental
-correctness campaign with capability-based scanner admission, exact stateful
-checkpoint receipts, GSS forest ownership proof, and bounded JavaScript-family
-recovery scheduling. Uncertified scanners continue to fail closed; their
-individual serialization audits are independent language certification work,
-not exceptions in the parser engine.
+The current release is **v0.47.1**. It fixes a Go grammar parsing regression
+in recovery reductions. Fresh parses preserve deferred parent links during
+final result materialization. Valid Go files remain complete, while the
+invariant guard continues to fail closed.
 
 Detailed shipped evidence lives in [CHANGELOG.md](CHANGELOG.md). Planned minor
 releases are batched on Thursdays; the immutable-tag process and exceptions are


### PR DESCRIPTION
## Summary

Update project documentation for the v0.47.1 release. This version fixes a regression in recovery reductions. The fix preserves deferred parent links during fresh parses. Valid Go files now remain complete during materialization.

## Changes

- Move the recovery reduction fix from the unreleased section to the v0.47.1 release notes.
- Update the version comparison links in CHANGELOG.md.
- Update the roadmap section in README.md to list v0.47.1 as the current release.