### PR TITLE
Add a pinned GraphQL direct-route fixture

### DIFF
--- a/admission_direct_corpus_test.go
+++ b/admission_direct_corpus_test.go
@@ -1,0 +1,50 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestAdmissionCandidateGraphQLRootFieldsDirect(t *testing.T) {
+	const (
+		fixturePath = "testdata/admission_direct/graphql_root_fields.graphql"
+		// This source comes from hasura/graphql-engine at commit
+		// d769f172d6ba43ecb0254c6be84bb40498608b3d.
+		sourceSHA256 = "12cb6d5c35d2f629cebc8c40738796173d86e93543e50c1138dc7f138c1ff061"
+		wantDetail   = "digest a6a0c3dd54db"
+	)
+
+	source, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read GraphQL admission fixture: %v", err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != sourceSHA256 {
+		t.Fatalf("GraphQL admission fixture SHA-256 = %s, want %s", got, sourceSHA256)
+	}
+
+	var graphql grammars.LangEntry
+	for _, entry := range grammars.AllLanguages() {
+		if entry.Name == "graphql" {
+			graphql = entry
+			break
+		}
+	}
+	if graphql.Name == "" {
+		t.Fatal("GraphQL grammar is not registered")
+	}
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	row := runAdmissionScorecardSource(graphql, source)
+	if row.status != scorecardPass {
+		t.Fatalf("GraphQL RootFields compact route = %s: %s", row.status, row.detail)
+	}
+	if row.detail != wantDetail {
+		t.Fatalf("GraphQL RootFields compact digest = %q, want %q", row.detail, wantDetail)
+	}
+}

--- a/cgo_harness/admission_graphql_direct_parity_test.go
+++ b/cgo_harness/admission_graphql_direct_parity_test.go
@@ -1,0 +1,37 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestAdmissionCandidateGraphQLRootFieldsCOracle(t *testing.T) {
+	source, err := os.ReadFile("../testdata/admission_direct/graphql_root_fields.graphql")
+	if err != nil {
+		t.Fatalf("read GraphQL admission fixture: %v", err)
+	}
+
+	candidateRoute := true
+	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+	runParityCase(t, parityCase{
+		name:           "graphql",
+		source:         string(source),
+		candidateRoute: &candidateRoute,
+	}, "admission-direct", source)
+	afterRouted, afterFallback := gotreesitter.AdmissionCandidateCounters()
+
+	routed := afterRouted - beforeRouted
+	fallback := afterFallback - beforeFallback
+	if routed != 1 || fallback != 0 {
+		t.Fatalf(
+			"candidate route counters = %d/%d, want 1/0; reason=%s",
+			routed,
+			fallback,
+			gotreesitter.AdmissionCandidateLastFallbackReason(),
+		)
+	}
+}

--- a/testdata/admission_direct/graphql_root_fields.graphql
+++ b/testdata/admission_direct/graphql_root_fields.graphql
@@ -1,0 +1,39 @@
+query RootFields {
+  __type(name: "Query") {
+    fields {
+      name
+      type {
+        ...TypeRef
+        fields {
+          name
+          type {
+            ...TypeRef
+          }
+        }
+      }
+      args {
+        name
+        type {
+          ...TypeRef
+        }
+      }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add one pinned GraphQL corpus fixture.
- Require the compact parser to accept the fixture directly.
- Require exact parity with the C parser oracle.

## Why

The committed corpus had only three compact-parser fixtures. This 464-byte witness adds authentic GraphQL coverage without changing runtime policy.

## Provenance

- Repository: `hasura/graphql-engine`
- Commit: `d769f172d6ba43ecb0254c6be84bb40498608b3d`
- Path: `v3/crates/graphql/lang-graphql/benches/validation/introspection/RootFields.graphql`
- SHA-256: `12cb6d5c35d2f629cebc8c40738796173d86e93543e50c1138dc7f138c1ff061`

## Evidence

- The focused compact-route test passes with digest `a6a0c3dd54db`.
- The GraphQL-only Docker parity test passes.
- The candidate records one direct route and no fallback.
- Docker reported no out-of-memory termination.

## Scope

This pull request changes tests and fixture data only. It does not change parser policy or production behavior.
