### PR TITLE
Keep singleton dispatch cells on the stack

### DIFF
--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2394,6 +2394,9 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			return nil, err
 		}
 	}
+	var singletonCells [1]diagnosticParserCoreGenericCell
+	cells := singletonCells[:0]
+	scratchCells := s.dispatchScratch.cells
 	for index, header := range s.headers {
 		if header.shifted || header.accepted {
 			continue
@@ -2425,9 +2428,16 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				cell.repetitionReduceOrdinal, cell.repetitionFold = diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions)
 			}
 		}
-		s.dispatchScratch.cells = append(s.dispatchScratch.cells, cell)
+		if len(s.headers) == 1 {
+			cells = append(cells, cell)
+		} else {
+			scratchCells = append(scratchCells, cell)
+		}
 	}
-	cells := s.dispatchScratch.cells
+	if len(s.headers) != 1 {
+		s.dispatchScratch.cells = scratchCells
+		cells = scratchCells
+	}
 	noActionIndices := s.dispatchScratch.noActionIndices
 	if unsupported := s.validateGenericNoLookaheadReduction(cells, noActionIndices); unsupported != nil {
 		return unsupported, nil


### PR DESCRIPTION
## Summary

- Keep a one-header dispatch cell on the stack.
- Retain reusable scratch storage for multi-header frontiers.
- Preserve the existing classification and action logic.

## Why

Full parses usually dispatch one active header. The prior append allocated one cell for each full parse.

The separate slices are intentional. A merged slice makes the local array escape under Go 1.25.

## Performance

Ten runs used one processor and a 750 millisecond benchmark duration.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Full parse | 12.02 ms | 10.14 ms | -15.57% |
| Full parse bytes | 119.27 KiB | 95.11 KiB | -20.25% |
| Full parse allocations | 19.00 | 17.50 | -7.89% |

Allocation profiling found 65 target allocations across 65 baseline parses. The patched function recorded no flat allocations.

I do not attribute the noisy incremental timing changes to this patch.

## Correctness

- Focused scheduler tests pass on the host.
- The same focused scheduler tests pass in Docker.
- Docker reported no out-of-memory termination.
- Escape analysis keeps `singletonCells` on the stack.

## Scope

This pull request changes one parser-core file. It does not change route policy, conflict policy, receipts, or memory limits.

