### PR TITLE
Add a pinned Svelte direct-route fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
-- Single-header compact dispatch now keeps its cell on the stack.
+- PR #498 moved the single-header compact dispatch cell onto the stack.
   This removes one allocation from the common full-parse path.
   The stable Go benchmark improves full-parse time by 15.57 percent.
   Allocated bytes fall by 20.25 percent.
@@ -37,11 +37,11 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
-- Locked GraphQL and Svelte fixtures now protect direct compact-parser routes.
+- PRs #497 and #500 add locked GraphQL and Svelte direct-route fixtures.
   Each fixture records its source commit and SHA-256 digest.
   Dedicated C-oracle tests require exact trees and zero fallback.
 
-- The native Typst scanner now initializes its indentation stack on creation.
+- PR #499 initializes the native Typst scanner indentation stack on creation.
   Native scanner semantics remove the nested-list comma artifact.
   This retires the remaining Typst compatibility dispatcher arm.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Single-header compact dispatch now keeps its cell on the stack.
+  This removes one allocation from the common full-parse path.
+  The stable Go benchmark improves full-parse time by 15.57 percent.
+  Allocated bytes fall by 20.25 percent.
+  The allocation count falls by 7.89 percent.
+
 - Certified graph-structured stack convergence now merges duplicate C# full-parse
   stacks while it retains their packed alternatives.
   The 137 KiB witness improves from 1.629 seconds to 98.7 milliseconds.
@@ -30,6 +36,14 @@ for tags and release notes while still in `0.x`.
   Parse time remains statistically unchanged.
 
 ### Fixed
+
+- Locked GraphQL and Svelte fixtures now protect direct compact-parser routes.
+  Each fixture records its source commit and SHA-256 digest.
+  Dedicated C-oracle tests require exact trees and zero fallback.
+
+- The native Typst scanner now initializes its indentation stack on creation.
+  Native scanner semantics remove the nested-list comma artifact.
+  This retires the remaining Typst compatibility dispatcher arm.
 
 - Accepted-error C# full parses now retry with a certified merge width after
   cap-one convergence.

--- a/admission_direct_corpus_test.go
+++ b/admission_direct_corpus_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	gts "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
@@ -46,5 +47,50 @@ func TestAdmissionCandidateGraphQLRootFieldsDirect(t *testing.T) {
 	}
 	if row.detail != wantDetail {
 		t.Fatalf("GraphQL RootFields compact digest = %q, want %q", row.detail, wantDetail)
+	}
+}
+
+func TestAdmissionCandidateSvelteButtonDirect(t *testing.T) {
+	const (
+		fixturePath = "testdata/admission_direct/svelte_button.svelte"
+		// This source comes from themesberg/flowbite-svelte at commit
+		// df3404b81aefbd91cb178dd68e4844a4e4e31066.
+		// Its path is src/routes/docs-examples/typography/link/Button.svelte.
+		// The locked Svelte grammar uses commit
+		// ae5199db47757f785e43a14b332118a5474de1a2.
+		sourceSHA256 = "fcbd956e6e07fbd1c2f52da59bcc0d35c9de495e425959a4cfddff2ea74ef7e4"
+		wantDetail   = "digest 7697435b1072"
+	)
+
+	source, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read Svelte admission fixture: %v", err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != sourceSHA256 {
+		t.Fatalf("Svelte admission fixture SHA-256 = %s, want %s", got, sourceSHA256)
+	}
+
+	var svelte grammars.LangEntry
+	for _, entry := range grammars.AllLanguages() {
+		if entry.Name == "svelte" {
+			svelte = entry
+			break
+		}
+	}
+	if svelte.Name == "" {
+		t.Fatal("Svelte grammar is not registered")
+	}
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	row := runAdmissionScorecardSource(svelte, source)
+	if row.status != scorecardPass {
+		t.Fatalf("Svelte Button compact route = %s: %s", row.status, row.detail)
+	}
+	if row.detail != wantDetail {
+		t.Fatalf("Svelte Button compact digest = %q, want %q", row.detail, wantDetail)
+	}
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf("Svelte Button route counters = %d/%d, want 1/0", routed, fallback)
 	}
 }

--- a/admission_direct_corpus_test.go
+++ b/admission_direct_corpus_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	gts "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
@@ -88,9 +87,5 @@ func TestAdmissionCandidateSvelteButtonDirect(t *testing.T) {
 	}
 	if row.detail != wantDetail {
 		t.Fatalf("Svelte Button compact digest = %q, want %q", row.detail, wantDetail)
-	}
-	routed, fallback := gts.AdmissionCandidateCounters()
-	if routed != 1 || fallback != 0 {
-		t.Fatalf("Svelte Button route counters = %d/%d, want 1/0", routed, fallback)
 	}
 }

--- a/cgo_harness/admission_svelte_direct_parity_test.go
+++ b/cgo_harness/admission_svelte_direct_parity_test.go
@@ -1,0 +1,37 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"os"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+func TestAdmissionCandidateSvelteButtonCOracle(t *testing.T) {
+	source, err := os.ReadFile("../testdata/admission_direct/svelte_button.svelte")
+	if err != nil {
+		t.Fatalf("read Svelte admission fixture: %v", err)
+	}
+
+	candidateRoute := true
+	beforeRouted, beforeFallback := gotreesitter.AdmissionCandidateCounters()
+	runParityCase(t, parityCase{
+		name:           "svelte",
+		source:         string(source),
+		candidateRoute: &candidateRoute,
+	}, "admission-direct", source)
+	afterRouted, afterFallback := gotreesitter.AdmissionCandidateCounters()
+
+	routed := afterRouted - beforeRouted
+	fallback := afterFallback - beforeFallback
+	if routed != 1 || fallback != 0 {
+		t.Fatalf(
+			"candidate route counters = %d/%d, want 1/0; reason=%s",
+			routed,
+			fallback,
+			gotreesitter.AdmissionCandidateLastFallbackReason(),
+		)
+	}
+}

--- a/testdata/admission_direct/svelte_button.svelte
+++ b/testdata/admission_direct/svelte_button.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { A } from "flowbite-svelte";
+  let show_full_link = $state(false);
+</script>
+
+<A asButton onclick={() => (show_full_link = !show_full_link)}>view full link</A>
+
+{#if show_full_link}
+  <p>The full link is now visible.</p>
+{/if}


### PR DESCRIPTION
## Summary

- Pin one authentic Svelte component as a direct full-parse fixture.
- Prove that the compact candidate routes without fallback.
- Match the candidate tree against the C parser oracle.

## Provenance

- Repository: `themesberg/flowbite-svelte`
- Commit: `df3404b81aefbd91cb178dd68e4844a4e4e31066`
- Path: `src/routes/docs-examples/typography/link/Button.svelte`
- Source SHA-256: `fcbd956e6e07fbd1c2f52da59bcc0d35c9de495e425959a4cfddff2ea74ef7e4`
- Grammar commit: `ae5199db47757f785e43a14b332118a5474de1a2`

## Validation

- The focused host direct-route test passed.
- The focused Docker C-oracle test passed.
- The compact digest is `7697435b1072`.
- Route counters report one routed parse and no fallback.
- Docker reported exit code zero and no out-of-memory event.
