### PR TITLE
Add a locked JavaScript compatibility receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The tracked dispatcher census now includes the locked JavaScript
+  convergence fixture.
+  The receipt exposes seven active compatibility rewrites on a direct route.
+
 - Native Crystal scanner lookahead now skips whitespace after hash and
   named-tuple openers.
   Exact token boundaries retire the Crystal compatibility dispatcher arm.

--- a/admission_switch_converged_path_test.go
+++ b/admission_switch_converged_path_test.go
@@ -3,6 +3,8 @@
 package gotreesitter_test
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,6 +20,8 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 		name       string
 		corpusPath string
 		source     string
+		sourceSHA  string
+		treeSHA    string
 		load       func() *gts.Language
 	}{
 		{
@@ -38,7 +42,11 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 		{
 			name:       "javascript",
 			corpusPath: filepath.Join("testdata", "compact_converged_split", "javascript.js"),
-			load:       grammars.JavascriptLanguage,
+			// Source repository: https://github.com/tree-sitter/tree-sitter-javascript
+			// Source commit/path: 58404d8cf191d69f2674a8fd507bd5776f46cb11 test/tags/functions.js.
+			sourceSHA: "0bbd2cdb0a0492055e442c44b533797386ec9c8aeb7ce8a4d0f5f5a4681e3b90",
+			treeSHA:   "75429585a56be767f37a5ea2ee5de028a9947c34ae38d35d9699bb1f2d0133fd",
+			load:      grammars.JavascriptLanguage,
 		},
 		{
 			name:   "python",
@@ -55,6 +63,11 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 				source, err = os.ReadFile(test.corpusPath)
 				if err != nil {
 					t.Fatalf("read compact certification witness: %v", err)
+				}
+			}
+			if test.sourceSHA != "" {
+				if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != test.sourceSHA {
+					t.Fatalf("source SHA-256 = %s, want %s", got, test.sourceSHA)
 				}
 			}
 
@@ -103,6 +116,9 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 					candidateInspection.SHA256,
 					productionInspection.SHA256,
 				)
+			}
+			if test.treeSHA != "" && candidateInspection.SHA256 != test.treeSHA {
+				t.Fatalf("candidate digest = %s, want %s", candidateInspection.SHA256, test.treeSHA)
 			}
 		})
 	}

--- a/testdata/dispatcher_census_tracked_v1.json
+++ b/testdata/dispatcher_census_tracked_v1.json
@@ -36,6 +36,17 @@
       "error_root": false
     },
     {
+      "language": "javascript",
+      "path": "testdata/compact_converged_split/javascript.js",
+      "sha256": "0bbd2cdb0a0492055e442c44b533797386ec9c8aeb7ce8a4d0f5f5a4681e3b90",
+      "arm_id": "dispatch.javascript",
+      "checked": 2,
+      "run": 2,
+      "nodes_visited": 202,
+      "nodes_rewritten": 7,
+      "error_root": false
+    },
+    {
       "language": "python",
       "path": "cgo_harness/corpus_structural/python_sample.py",
       "sha256": "3de858b73ba43ad3c2d43b9cfc08426f62dd4ae7bcf1358e3989ed311b435157",


### PR DESCRIPTION
## Summary

Track an authentic JavaScript fixture that exercises seven live compatibility rewrites.
Reuse the existing direct-route fixture and add no fixture bytes.

## Changes

- Pin the upstream repository, commit, path, and source digest.
- Pin the expected deep-tree digest.
- Add the active JavaScript dispatcher census receipt.
- Record the coverage change in the Unreleased changelog.

## Verification

- Focused direct-route test: passed with one route and zero fallbacks.
- Focused tracked dispatcher census: passed.
- Focused Docker JavaScript C parity: passed.
- Docker exit code: `0`.
- Docker out-of-memory status: `false`.
- Artifact: `/home/draco/work/gts-corpus-gap-after500/harness_out/docker/20260728T223800Z`

The receipt records two checks, two runs, 202 visited nodes, and seven rewritten nodes.