### PR TITLE
Remove one compact full-parse allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- The compact full-parse receipt now stores its acceptance value in the
+  scheduler receipt allocation.
+  Full-parse allocations fall from 18 to 17 per operation.
+  Parse time and allocated bytes remain statistically unchanged.
+
 - PR #498 moved the single-header compact dispatch cell onto the stack.
   This removes one allocation from the common full-parse path.
   The stable Go benchmark improves full-parse time by 15.57 percent.

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -285,6 +285,7 @@ type DiagnosticParserCoreGenericScheduler struct {
 	NoActionDrops     []DiagnosticParserCoreGenericNoActionDrop
 	Completion        *DiagnosticParserCoreGenericCompletion
 	Acceptance        *DiagnosticParserCoreGenericAcceptance
+	acceptanceBacking DiagnosticParserCoreGenericAcceptance
 	Stop              DiagnosticParserCoreGenericStop
 	Tokens            uint64
 	Dispatches        uint64
@@ -2675,12 +2676,13 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 	}
 	s.acceptedHead = s.headers[0].head
 	s.acceptedPayloads = append(s.acceptedPayloads[:0], path.Payloads...)
-	s.receipt.Acceptance = &DiagnosticParserCoreGenericAcceptance{
+	s.receipt.acceptanceBacking = DiagnosticParserCoreGenericAcceptance{
 		ElectionIndex: s.electionIndex, Token: s.token, Header: header,
 		Payloads: payloads, Score: path.Score, BranchOrder: path.BranchOrder,
 		HasBranchOrder: path.HasBranchOrder, CoreWork: s.compact.Work(),
 		Accepts: s.work.Accepts, Stats: stats, Work: s.work,
 	}
+	s.receipt.Acceptance = &s.receipt.acceptanceBacking
 	s.publishTotals()
 	return nil
 }


### PR DESCRIPTION
## Summary

- Store the compact acceptance value inside the scheduler receipt.
- Remove one allocation from the full-parse path.
- Add the result to the Unreleased performance section.

## Performance evidence

Ten interleaved AB and BA samples used `GOMAXPROCS=1`, `750ms`, and `benchmem`.

- Full parse: 18 to 17 allocations per operation, `p=0.005`.
- Full-parse time remained unchanged, `p=0.315`.
- Allocated bytes remained unchanged, `p=0.669`.
- Both incremental controls remained unchanged.

## Correctness evidence

- The focused parser-core lifecycle test passed on the host.
- The same focused lifecycle test passed in Docker.
- `git diff --check` passed.
- A direct Canopy query inspected the changed acceptance path.