### PR TITLE
optimize: Embed receipt in fresh compact scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Fresh compact full parses now store the scheduler receipt inside the
+  scheduler allocation.
+  Full-parse allocations fall from 17 to 16 per operation.
+  Parse time, allocated bytes, and maximum resident set size remain unchanged.
+
 - The compact full-parse receipt now stores its acceptance value in the
   scheduler receipt allocation.
   Full-parse allocations fall from 18 to 17 per operation.

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1400,6 +1400,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	branchOrder                   uint64
 	nextSeq                       uint64
 	options                       DiagnosticParserCorePrefixOptions
+	receiptBacking                DiagnosticParserCoreGenericScheduler
 	receipt                       *DiagnosticParserCoreGenericScheduler
 	summaryHeaderScratch          []DiagnosticParserCoreHeaderReceipt
 	headerRollbackScratch         diagnosticParserCoreHeaderRollbackScratch
@@ -1499,10 +1500,20 @@ func newDiagnosticParserCoreGenericScheduler(
 		checkpoint: checkpoint, checkpointID: checkpointID,
 		electionIndex: -1, nextSeq: 1,
 		options: options, observer: observer,
-		receipt: &DiagnosticParserCoreGenericScheduler{
+	}
+	// Public diagnostic results retain their receipt after the scheduler returns.
+	// Embed only for a fresh runner, which never publishes its receipt.
+	if options.freshSchedulerSession {
+		scheduler.receiptBacking = DiagnosticParserCoreGenericScheduler{
 			ReceiptMode:     options.ReceiptMode,
 			StartCheckpoint: checkpoint,
-		},
+		}
+		scheduler.receipt = &scheduler.receiptBacking
+	} else {
+		scheduler.receipt = &DiagnosticParserCoreGenericScheduler{
+			ReceiptMode:     options.ReceiptMode,
+			StartCheckpoint: checkpoint,
+		}
 	}
 	scheduler.seedHeaders[0] = header
 	scheduler.headers = scheduler.seedHeaders[:]

--- a/parsercore_phase0_seed_scheduler_internal_test.go
+++ b/parsercore_phase0_seed_scheduler_internal_test.go
@@ -101,8 +101,19 @@ func TestDiagnosticParserCoreGenericSeedConstructorFailsClosed(t *testing.T) {
 	}
 	checkpoint := parserCoreCheckpoint(nil)
 	var scratch []byte
-	if _, err := newDiagnosticParserCoreGenericScheduler(compact, &dfaTokenSource{}, &scratch, seed, 0, checkpoint, diagnosticParserCoreSeedObserver{}, DiagnosticParserCorePrefixOptions{}); err != nil {
+	diagnosticScheduler, err := newDiagnosticParserCoreGenericScheduler(compact, &dfaTokenSource{}, &scratch, seed, 0, checkpoint, diagnosticParserCoreSeedObserver{}, DiagnosticParserCorePrefixOptions{})
+	if err != nil {
 		t.Fatalf("valid seed start declined: %v", err)
+	}
+	if diagnosticScheduler.receipt == &diagnosticScheduler.receiptBacking {
+		t.Fatal("public diagnostic scheduler embedded its published receipt")
+	}
+	freshScheduler, err := newDiagnosticParserCoreGenericScheduler(compact, &dfaTokenSource{}, &scratch, seed, 0, checkpoint, diagnosticParserCoreSeedObserver{}, DiagnosticParserCorePrefixOptions{freshSchedulerSession: true})
+	if err != nil {
+		t.Fatalf("fresh seed start declined: %v", err)
+	}
+	if freshScheduler.receipt != &freshScheduler.receiptBacking {
+		t.Fatal("fresh scheduler did not use its embedded receipt")
 	}
 	if _, err := newDiagnosticParserCoreGenericScheduler(nil, &dfaTokenSource{}, &scratch, seed, 0, checkpoint, diagnosticParserCoreSeedObserver{}, DiagnosticParserCorePrefixOptions{}); err == nil {
 		t.Fatal("nil compact core was admitted")


### PR DESCRIPTION
## Summary

Store the private fresh-session receipt inside the compact scheduler allocation.
Public diagnostic sessions retain an independent receipt allocation.

This change removes one allocation from each fresh compact full parse.

## Performance

The interleaved AB/BA run used GOMAXPROCS=1, ten samples, 750ms, and enchmem.

| Metric | Base | Candidate | Result |
| --- | ---: | ---: | --- |
| Full-parse allocations | 17 | 16 | -5.88%, p=0.000 |
| Full-parse time | 10.33 ms | 10.69 ms | unchanged, p=0.481 |
| Full-parse bytes | 104.3 KiB | 109.2 KiB | unchanged, p=0.897 |
| Incremental edit allocations | 0 | 0 | unchanged |
| Incremental no-edit allocations | 0 | 0 | unchanged |

Two maximum resident set size runs overlapped:

- Base: 45,028 KiB and 46,996 KiB.
- Candidate: 46,312 KiB and 47,424 KiB.

The scheduler and receipt occupy the same combined allocator size class.
The candidate removes one allocation without increasing the combined size class.

## Safety

Only fresh and admission runners select embedded storage.
These runners do not publish the diagnostic receipt.
Public diagnostics keep the separate allocation, so they cannot retain the internal scheduler.
A focused test locks both ownership modes.

## Verification

- Four focused scheduler lifecycle tests passed in Docker.
- Go real-corpus parity passed 25 of 25 cases at every depth gate.
- The focused ownership test passed.
- The root package compiled.
- Direct changed-file Canopy checks passed.
- git diff --check passed.
