### PR TITLE
fix(recovery): mark recovered ERROR leaf as named in C recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ for tags and release notes while still in `0.x`.
   This removes both compatibility dispatcher arms as one defect class.
   Compact and forest routes retain fail-closed behavior.
 
+- C-style recovery now marks an absorbed `ERROR` token as named.
+  Recovered INI trees now match the pinned C parser at this node boundary.
+
 - The tracked dispatcher census now includes the locked JavaScript
   convergence fixture.
   The receipt exposes seven active compatibility rewrites on a direct route.

--- a/parser_recover_c.go
+++ b/parser_recover_c.go
@@ -3761,7 +3761,7 @@ func (p *Parser) cAbsorbTokenIntoError(v *glrStack, tok Token, nodeCount *int, a
 	leafVisible := p.cSymbolVisible(tok.Symbol)
 	var leaf *Node
 	if leafVisible {
-		leaf = newLeafNodeInArena(arena, tok.Symbol, p.isNamedSymbol(tok.Symbol),
+		leaf = newLeafNodeInArena(arena, tok.Symbol, tok.Symbol == errorSymbol || p.isNamedSymbol(tok.Symbol),
 			tok.StartByte, tok.EndByte, tok.StartPoint, tok.EndPoint)
 		leaf.setHasError(true)
 		// C: if the token shifts as extra in state 1, mark it extra so it is

--- a/parser_recover_c_test.go
+++ b/parser_recover_c_test.go
@@ -167,6 +167,52 @@ func TestCRecoveryCostCompetitionDisabledInNoTreeModes(t *testing.T) {
 	}
 }
 
+func TestCAbsorbErrorRunKeepsErrorLeafNamed(t *testing.T) {
+	parser := cRecoveryElectionTestParser()
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+
+	openErr := newParentNodeInArena(arena, errorSymbol, true, nil, nil, 0)
+	cSetNodeSpan(openErr, 10, 10, Point{Column: 10}, Point{Column: 10})
+	openErr.setHasError(true)
+	stack := newGLRStack(1)
+	stack.pushEntry(newStackEntryNode(cErrorState, openErr), nil, nil)
+	stack.byteOffset = 10
+	stack.cRec = &cRecoverState{group: &cRecGroup{}, openErr: openErr}
+	nodeCount := 0
+
+	parser.cAbsorbTokenIntoError(
+		&stack,
+		Token{
+			Symbol:    errorSymbol,
+			StartByte: 10,
+			EndByte:   18,
+			StartPoint: Point{
+				Column: 10,
+			},
+			EndPoint: Point{
+				Column: 18,
+			},
+		},
+		&nodeCount,
+		arena,
+		nil,
+		nil,
+		nil,
+	)
+
+	if got, want := openErr.ChildCount(), 1; got != want {
+		t.Fatalf("open error ChildCount = %d, want %d", got, want)
+	}
+	child := openErr.Child(0)
+	if !child.IsError() {
+		t.Fatalf("absorbed child type = %q, want ERROR", child.Type(parser.language))
+	}
+	if !child.IsNamed() {
+		t.Fatal("absorbed ERROR leaf is not named")
+	}
+}
+
 func TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken(t *testing.T) {
 	parser := cRecoveryElectionTestParser()
 	arena := acquireNodeArena(arenaClassFull)


### PR DESCRIPTION
## Summary

C recovery absorbed visible `ERROR` tokens as anonymous leaves. The pinned C parser marks those leaves as named.

This change applies the C invariant when recovery appends an `ERROR` token to an open error node. It does not change recovery selection.

The INI real-corpus probe now matches the pinned C parser exactly at both affected leaves.

## Changes

- Mark an absorbed `ERROR` leaf as named.
- Preserve the grammar symbol lookup for all other tokens.
- Add a focused recovery regression test.
- Add an Unreleased changelog entry.

## Exact parity evidence

The Docker probe used the pinned C oracle and exhaustive comparison mode.

```text
GOMAXPROCS=1 GOFLAGS=-p=1 GTS_PARITY_MODE=exhaustive \
  go test . -tags treesitter_c_parity \
  -run TestOrdinaryNoActionCOracleProbe/ini -count=1 -v -timeout 10m
```

Result:

```text
--- PASS: TestOrdinaryNoActionCOracleProbe/ini
PASS
```

Before this change, INI had two differences. Both recovered `ERROR` leaves were anonymous in Go and named in C.

## Focused tests

Both Docker tests passed:

```text
go test . -run TestCAbsorbErrorRunKeepsErrorLeafNamed -count=1 -v
go test . -run '^TestCRecoverDispatchInErrorAdvancesZeroWidthSkippedToken$' -count=1 -v
```

Neither run exceeded its memory limit. Neither container reported an out-of-memory termination.

## Falsified broader change

A broader experiment invoked shared recovery for each unpaused head with no action. The experiment fixed INI, but it changed GoMod incorrectly.

GoMod had a valid `module` lookahead after two newlines. The broader experiment replaced that path with recovery, so we rejected it.

This PR does not include that dispatch change. It changes only the named flag on an already absorbed `ERROR` leaf.

The GoMod comparison remains unchanged before and after this fix. It retains the same three unrelated differences from byte 88 through byte 112:

- Root child type: `ERROR` versus `go_directive`.
- Root child end byte: 110 versus 112.
- Root child count: one versus four.

This stable result confirms that the narrow fix does not alter GoMod recovery behavior.