### PR TITLE
optimize(parser): cache bound stop-check callback to remove allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- The parser now reuses its bound stop-check callback across compact full
+  parses.
+  This removes one allocation and 16 bytes per operation.
+  Full-parse time and maximum resident set size remain unchanged.
+  Incremental parses retain zero allocations.
+
 - Fresh compact full parses now store the scheduler receipt inside the
   scheduler allocation.
   Full-parse allocations fall from 17 to 16 per operation.

--- a/parser.go
+++ b/parser.go
@@ -106,7 +106,11 @@ type Parser struct {
 	// bound method only captures p (tables are re-read at call time), so one
 	// closure stays valid for the parser's whole lifetime, including language
 	// changes. See lookupActionIndexFunc (parser_tables.go).
-	lookupActionIndexFn                 func(state StateID, sym Symbol) uint16
+	lookupActionIndexFn func(state StateID, sym Symbol) uint16
+	// activeParseStopCheckFn caches the bound stop-check method. Compact
+	// full parses install this callback in a poller. Reusing one closure avoids
+	// one allocation per parse.
+	activeParseStopCheckFn              parseStopCheck
 	typeScriptPropertyIdentifierSymbol  Symbol
 	typeScriptIdentifierSymbol          Symbol
 	typeScriptHasPropertyIdentifier     bool
@@ -1443,6 +1447,7 @@ type parseReuseState struct {
 // NewParser creates a new Parser for the given language.
 func NewParser(lang *Language) *Parser {
 	p := &Parser{language: lang}
+	p.activeParseStopCheckFn = p.activeParseStopReason
 	if lang != nil {
 		p.forceRawSpanAll = lang.Name == "yaml"
 		p.leafInternByLang = languageWantsLeafInterning(lang.Name)

--- a/parser_timeout.go
+++ b/parser_timeout.go
@@ -116,7 +116,10 @@ func (p *Parser) activeParseStopCheck() parseStopCheck {
 	if p == nil {
 		return nil
 	}
-	return p.activeParseStopReason
+	if p.activeParseStopCheckFn == nil {
+		p.activeParseStopCheckFn = p.activeParseStopReason
+	}
+	return p.activeParseStopCheckFn
 }
 
 func (p *Parser) activeParseStopReason() ParseStopReason {

--- a/parser_timeout_cache_test.go
+++ b/parser_timeout_cache_test.go
@@ -1,0 +1,32 @@
+package gotreesitter
+
+import "testing"
+
+func TestActiveParseStopCheckReusesBoundMethod(t *testing.T) {
+	parser := &Parser{parseBudgetDepth: 1}
+	check := parser.activeParseStopCheck()
+	if check == nil {
+		t.Fatal("active parse stop check is nil")
+	}
+
+	parser.parseStoppedReason = ParseStopTimeout
+	if got := check(); got != ParseStopTimeout {
+		t.Fatalf("cached stop check returned %q, want %q", got, ParseStopTimeout)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if parser.activeParseStopCheck() == nil {
+			t.Fatal("cached active parse stop check is nil")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("cached active parse stop check allocated %.2f objects per call", allocs)
+	}
+}
+
+func TestNewParserBindsActiveParseStopCheck(t *testing.T) {
+	parser := NewParser(nil)
+	if parser.activeParseStopCheckFn == nil {
+		t.Fatal("new parser did not bind its active parse stop check")
+	}
+}


### PR DESCRIPTION
## Summary

Cache the parser's bound stop-check callback.
Compact full parses reuse this callback instead of allocating a new method value.

## Change

- Store one `parseStopCheck` callback on each parser.
- Bind the callback in `NewParser`.
- Keep lazy binding for parser literals in internal tests.
- Verify that the callback reads current parser state.
- Verify that repeated callback lookup allocates nothing.

## Correctness

These focused tests pass:

```text
go test . -run '^TestCertifiedDuplicateWideRetryDoesNotBypassTerminalCancellation$|^TestRetryFullParseStopsSchedulingRetriesAfterTimeout$|^TestParseWithSnippetParserInheritsExpiredParentDeadline$|^TestParseWithSnippetParserInheritsParentCancellation$|^TestActiveParseStopCheckReusesBoundMethod$|^TestNewParserBindsActiveParseStopCheck$' -count=1

go test . -tags gts_parsercorephase0 -run '^TestParserCoreFreshFullRunnerRepeatedCanonicalLifecycle$|^TestParserCoreFreshFullRunnerResetsAfterCap$|^TestParserCoreFreshFullSelectedStorePollsCancellation$' -count=1
```

The package compile-only test and `git diff --check` also pass.

Direct Canopy checks parsed all three changed Go files.

## Performance

The prescribed runs used:

- `GOMAXPROCS=1`
- ten samples
- `750ms`
- `benchmem`
- baseline-first and candidate-first order

The full-parse allocation distribution improved in both orders.
Both incremental lanes stayed statistically unchanged and retained zero allocations.

A fixed 100-iteration diagnostic isolates the callback allocation:

| Metric | Base | Candidate | Result |
|---|---:|---:|---:|
| Full parse | 14.43 ms | 14.41 ms | unchanged, `p=0.853` |
| Bytes | 84.83 KiB | 84.82 KiB | minus 16 bytes |
| Allocations | 15 | 14 | minus one |

Precompiled three-second probes measured maximum resident set size:

- Base: 45,232 KiB
- Candidate: 44,880 KiB

The change does not increase retained memory.
