### PR TITLE
fix(glr): converge equivalent recovery readings

### DIFF
--- a/cgo_harness/php_issue454_parity_test.go
+++ b/cgo_harness/php_issue454_parity_test.go
@@ -1,0 +1,59 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"bytes"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestParityIssue454PHPWholeTreeFallback(t *testing.T) {
+	source := benchfixtures.Issue454PHPSource()
+	site := bytes.Index(source, []byte("$x0"))
+	if site < 0 {
+		t.Fatal("PHP edit marker is absent")
+	}
+	site++
+	edited := make([]byte, 0, len(source)-1)
+	edited = append(edited, source[:site]...)
+	edited = append(edited, source[site+1:]...)
+
+	goLang := grammars.PhpLanguage()
+	goParser := gotreesitter.NewParser(goLang)
+	goParser.SetAdmissionCandidateRoute(false)
+	goTree, err := goParser.Parse(edited)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseGoTree(goTree)
+	if goTree.ParseStoppedEarly() {
+		t.Fatalf("Go parse stopped early: %s", goTree.ParseRuntime().Summary())
+	}
+
+	cLang, err := ParityCLanguage("php")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatal(err)
+	}
+	cTree := cParser.Parse(edited, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C reference parser returned nil tree")
+	}
+	defer cTree.Close()
+
+	var errs []string
+	compareNodes(goTree.RootNode(), goLang, cTree.RootNode(), "root", &errs)
+	if len(errs) > 0 {
+		t.Fatalf("PHP issue #454 production tree differs from the pinned C oracle: %s", errs[0])
+	}
+}

--- a/glr.go
+++ b/glr.go
@@ -198,25 +198,26 @@ const (
 )
 
 type glrMergeScratch struct {
-	result            []glrStack
-	slots             []glrMergeSlot
-	largeSlots        []glrMergeLargeSlot
-	perKeyCap         int
-	language          *Language
-	arena             *nodeArena
-	faithfulCapOne    bool
-	deferExactDedupe  bool
-	frontierMergeHash bool
-	trace             bool
-	cRecoveryCost     bool
-	audit             *runtimeAudit
-	equivEpoch        uint32
-	gssPointerEpoch   uint32
-	equivCache        []glrNodeEquivCacheEntry
-	stackEquivCache   []glrStackEquivCacheEntry
-	spineEquivCache   []glrSpineEquivCacheEntry
-	frontierHashCache []glrStackFrontierHashCacheEntry
-	cErrorCost        map[*Node]glrCErrorCostEntry
+	result                    []glrStack
+	slots                     []glrMergeSlot
+	largeSlots                []glrMergeLargeSlot
+	perKeyCap                 int
+	language                  *Language
+	arena                     *nodeArena
+	faithfulCapOne            bool
+	recoveryCapOneConvergence bool
+	deferExactDedupe          bool
+	frontierMergeHash         bool
+	trace                     bool
+	cRecoveryCost             bool
+	audit                     *runtimeAudit
+	equivEpoch                uint32
+	gssPointerEpoch           uint32
+	equivCache                []glrNodeEquivCacheEntry
+	stackEquivCache           []glrStackEquivCacheEntry
+	spineEquivCache           []glrSpineEquivCacheEntry
+	frontierHashCache         []glrStackFrontierHashCacheEntry
+	cErrorCost                map[*Node]glrCErrorCostEntry
 	// cPrefixPath is the descent scratch for merge-side GSS prefix-aggregate
 	// fills (cStackPrefixCostForMerge, parser_recover_c.go); the aggregates
 	// live on gssNode, validated against gssPrefixAggGen. reset clears the full
@@ -4452,7 +4453,9 @@ func preserveCapOneStackInSlot(result *[]glrStack, slot *glrMergeSlot, stack glr
 }
 
 func faithfulCapOneMergeEnabled(scratch *glrMergeScratch) bool {
-	return glrFaithfulCapOneMerge || (scratch != nil && scratch.faithfulCapOne)
+	return glrFaithfulCapOneMerge ||
+		(scratch != nil &&
+			(scratch.faithfulCapOne || (scratch.recoveryCapOneConvergence && scratch.cRecoveryCost)))
 }
 
 func mergeSlotTrackedCount(slot *glrMergeSlot) int {
@@ -5518,6 +5521,8 @@ func (s *glrMergeScratch) reset() {
 	s.perKeyCap = 0
 	s.language = nil
 	s.arena = nil
+	s.faithfulCapOne = false
+	s.recoveryCapOneConvergence = false
 	s.trace = false
 	s.cRecoveryCost = false
 	s.audit = nil

--- a/glr_test.go
+++ b/glr_test.go
@@ -3656,31 +3656,52 @@ func TestMergeStacksSmallFaithfulGSSUnionPreservesExtraLinks(t *testing.T) {
 	glrFaithfulCapOneMerge = false
 	t.Cleanup(func() { glrFaithfulCapOneMerge = old })
 
-	var gssScratch gssScratch
-	buildStack := func(sym Symbol) glrStack {
-		node := NewLeafNode(sym, true, 0, 5, Point{}, Point{Column: 5})
-		entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
-		return glrStack{
-			gss:        buildGSSStack(entries, &gssScratch),
-			byteOffset: stackByteOffset(entries),
-		}
+	tests := []struct {
+		name    string
+		scratch glrMergeScratch
+	}{
+		{
+			name: "certified full parse",
+			scratch: glrMergeScratch{
+				faithfulCapOne: true,
+			},
+		},
+		{
+			name: "recovery cost became relevant",
+			scratch: glrMergeScratch{
+				recoveryCapOneConvergence: true,
+				cRecoveryCost:             true,
+			},
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gssScratch gssScratch
+			buildStack := func(sym Symbol) glrStack {
+				node := NewLeafNode(sym, true, 0, 5, Point{}, Point{Column: 5})
+				entries := []stackEntry{{state: 1}, newStackEntryNode(7, node)}
+				return glrStack{
+					gss:        buildGSSStack(entries, &gssScratch),
+					byteOffset: stackByteOffset(entries),
+				}
+			}
 
-	var scratch glrMergeScratch
-	scratch.perKeyCap = 1
-	scratch.faithfulCapOne = true
-	scratch.beginEquivEpoch()
+			scratch := test.scratch
+			scratch.perKeyCap = 1
+			scratch.beginEquivEpoch()
 
-	result := mergeStacksWithScratch([]glrStack{buildStack(11), buildStack(12)}, &scratch)
-	if len(result) != 1 {
-		t.Fatalf("merged stack count = %d, want 1", len(result))
-	}
-	if got := result[0].gss.head.linkCount(); got != 2 {
-		t.Fatalf("merged link count = %d, want 2", got)
-	}
-	_, extra := result[0].gss.head.link(1)
-	if got := stackEntryNodeSymbol(extra); got != 12 {
-		t.Fatalf("extra link symbol = %d, want 12", got)
+			result := mergeStacksWithScratch([]glrStack{buildStack(11), buildStack(12)}, &scratch)
+			if len(result) != 1 {
+				t.Fatalf("merged stack count = %d, want 1", len(result))
+			}
+			if got := result[0].gss.head.linkCount(); got != 2 {
+				t.Fatalf("merged link count = %d, want 2", got)
+			}
+			_, extra := result[0].gss.head.link(1)
+			if got := stackEntryNodeSymbol(extra); got != 12 {
+				t.Fatalf("extra link symbol = %d, want 12", got)
+			}
+		})
 	}
 }
 
@@ -3697,6 +3718,16 @@ func TestFaithfulCapOneMergeEnabledByParsePolicy(t *testing.T) {
 	}
 	if !faithfulCapOneMergeEnabled(scratch) {
 		t.Fatal("active parse did not enable faithful cap-one merge")
+	}
+	recoveryScratch := &glrMergeScratch{
+		recoveryCapOneConvergence: true,
+	}
+	if faithfulCapOneMergeEnabled(recoveryScratch) {
+		t.Fatal("recovery policy activated before error cost became relevant")
+	}
+	recoveryScratch.cRecoveryCost = true
+	if !faithfulCapOneMergeEnabled(recoveryScratch) {
+		t.Fatal("recovery policy did not activate after error cost became relevant")
 	}
 }
 

--- a/grammars/php_issue454_regression_test.go
+++ b/grammars/php_issue454_regression_test.go
@@ -1,0 +1,175 @@
+package grammars_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+func TestIssue454PHPWholeTreeFallbackMatchesFresh(t *testing.T) {
+	lang := grammars.PhpLanguage()
+	source := benchfixtures.Issue454PHPSource()
+	if got := len(source); got != benchfixtures.Issue454PHPFixtureBytes {
+		t.Fatalf("fixture bytes = %d, want %d", got, benchfixtures.Issue454PHPFixtureBytes)
+	}
+
+	baseStart := time.Now()
+	baseShape := issue454PHPFreshShape(t, lang, source)
+	baseDuration := time.Since(baseStart)
+	if baseShape.hasError {
+		t.Fatal("base fresh parse has an error")
+	}
+	for run := 2; run <= 3; run++ {
+		got := issue454PHPFreshShape(t, lang, source)
+		if got != baseShape {
+			t.Fatalf("fresh base parse %d changed: got %+v, want %+v", run, got, baseShape)
+		}
+	}
+
+	site := bytes.Index(source, []byte("$x0"))
+	if site < 0 {
+		t.Fatal("PHP edit marker is absent")
+	}
+	site++
+	edited := make([]byte, 0, len(source)-1)
+	edited = append(edited, source[:site]...)
+	edited = append(edited, source[site+1:]...)
+	if got := edited[site-1 : site+1]; !bytes.Equal(got, []byte("$0")) {
+		t.Fatalf("edited marker = %q, want %q", got, "$0")
+	}
+
+	freshStart := time.Now()
+	want := issue454PHPFreshShape(t, lang, edited)
+	freshDuration := time.Since(freshStart)
+	if !want.hasError {
+		t.Fatal("edited fresh parse did not enter recovery")
+	}
+	for run := 2; run <= 3; run++ {
+		got := issue454PHPFreshShape(t, lang, edited)
+		if got != want {
+			t.Fatalf("fresh edited parse %d changed: got %+v, want %+v", run, got, want)
+		}
+	}
+
+	oldParser := gotreesitter.NewParser(lang)
+	oldParser.SetAdmissionCandidateRoute(false)
+	oldTree, err := oldParser.Parse(source)
+	if err != nil {
+		t.Fatalf("old Parse: %v", err)
+	}
+	defer oldTree.Release()
+	point := issue454PointAt(source, site)
+	editStart := time.Now()
+	oldTree.Edit(gotreesitter.InputEdit{
+		StartByte:   uint32(site),
+		OldEndByte:  uint32(site + 1),
+		NewEndByte:  uint32(site),
+		StartPoint:  point,
+		OldEndPoint: gotreesitter.Point{Row: point.Row, Column: point.Column + 1},
+		NewEndPoint: point,
+	})
+	editDuration := time.Since(editStart)
+
+	incrementalParser := gotreesitter.NewParser(lang)
+	incrementalParser.SetAdmissionCandidateRoute(false)
+	incrementalStart := time.Now()
+	incremental, profile, err := incrementalParser.ParseIncrementalProfiled(edited, oldTree)
+	incrementalDuration := time.Since(incrementalStart)
+	if err != nil {
+		t.Fatalf("ParseIncrementalProfiled: %v", err)
+	}
+	defer incremental.Release()
+	if incremental.ParseStoppedEarly() {
+		t.Fatalf("incremental parse stopped early: %s", incremental.ParseRuntime().Summary())
+	}
+
+	if !profile.ReuseUnsupported || profile.ReuseUnsupportedReason != "external_scanner_unsupported" {
+		t.Fatalf("PHP scanner fallback profile = %+v", profile)
+	}
+	if profile.OldTreeReuseRoute || profile.ReusedSubtrees != 0 || profile.ReusedBytes != 0 {
+		t.Fatalf("PHP scanner fallback reused old syntax: %+v", profile)
+	}
+	got := issue454PHPTreeShape(t, lang, incremental)
+	if got != want {
+		t.Fatalf("incremental shape = %+v, fresh shape = %+v", got, want)
+	}
+	t.Logf(
+		"base_fresh=%s edited_fresh=%s edit=%s incremental=%s ratio_to_base=%.2fx ratio_to_edited_fresh=%.2fx reuse_cursor=%s reparse=%s tokens=%d nodes=%d max_stacks=%d arena=%d scratch=%d parser_loop=%s token_next=%s dispatch=%s merge=%s selection=%s compatibility=%s",
+		baseDuration,
+		freshDuration,
+		editDuration,
+		incrementalDuration,
+		float64(incrementalDuration)/float64(baseDuration),
+		float64(incrementalDuration)/float64(freshDuration),
+		time.Duration(profile.ReuseCursorNanos),
+		time.Duration(profile.ReparseNanos),
+		profile.TokensConsumed,
+		profile.NewNodesAllocated,
+		profile.MaxStacksSeen,
+		profile.ArenaBytesAllocated,
+		profile.ScratchBytesAllocated,
+		time.Duration(profile.ParserLoopNanos),
+		time.Duration(profile.TokenNextNanos),
+		time.Duration(profile.ActionDispatchNanos),
+		time.Duration(profile.GLRMergeNanos),
+		time.Duration(profile.ResultSelectionNanos),
+		time.Duration(profile.ResultCompatibilityNanos),
+	)
+}
+
+type issue454PHPShape struct {
+	digest   string
+	nodes    uint64
+	rootType string
+	hasError bool
+	endByte  uint32
+}
+
+func issue454PHPFreshShape(t *testing.T, lang *gotreesitter.Language, source []byte) issue454PHPShape {
+	t.Helper()
+	parser := gotreesitter.NewParser(lang)
+	parser.SetAdmissionCandidateRoute(false)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("fresh Parse: %v", err)
+	}
+	defer tree.Release()
+	return issue454PHPTreeShape(t, lang, tree)
+}
+
+func issue454PHPTreeShape(
+	t *testing.T,
+	lang *gotreesitter.Language,
+	tree *gotreesitter.Tree,
+) issue454PHPShape {
+	t.Helper()
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("parse returned no root")
+	}
+	if tree.ParseStoppedEarly() {
+		t.Fatalf("parse stopped early: %s", tree.ParseRuntime().Summary())
+	}
+	root := tree.RootNode()
+	if got, want := root.EndByte(), uint32(len(tree.Source())); got != want {
+		t.Fatalf("root end = %d, want %d", got, want)
+	}
+	inspection, err := benchfixtures.InspectGoTree(root, lang)
+	if err != nil {
+		t.Fatalf("inspect tree: %v", err)
+	}
+	var nodes uint64
+	for _, count := range inspection.NodeKinds {
+		nodes += count
+	}
+	return issue454PHPShape{
+		digest:   inspection.SHA256,
+		nodes:    nodes,
+		rootType: root.Type(lang),
+		hasError: root.HasError(),
+		endByte:  root.EndByte(),
+	}
+}

--- a/internal/benchfixtures/issue454_php.go
+++ b/internal/benchfixtures/issue454_php.go
@@ -1,0 +1,33 @@
+package benchfixtures
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Issue454PHPFixtureBytes is the exact size of the downstream PHP edit
+// workload reported in issue #454.
+const Issue454PHPFixtureBytes = 137 * 1024
+
+// Issue454PHPSource builds the deterministic issue #454 PHP workload. The
+// first local variable is the near-top edit site for the $x0 to $0 deletion.
+func Issue454PHPSource() []byte {
+	var source strings.Builder
+	source.Grow(Issue454PHPFixtureBytes)
+	source.WriteString("<?php\n")
+	for i := 0; ; i++ {
+		line := fmt.Sprintf(
+			"function f%d() { $x%d = %d; return $x%d; }\n",
+			i,
+			i,
+			i,
+			i,
+		)
+		if source.Len()+len(line) > Issue454PHPFixtureBytes {
+			break
+		}
+		source.WriteString(line)
+	}
+	source.WriteString(strings.Repeat(" ", Issue454PHPFixtureBytes-source.Len()))
+	return []byte(source.String())
+}

--- a/internal/benchfixtures/issue454_php.go
+++ b/internal/benchfixtures/issue454_php.go
@@ -10,7 +10,7 @@ import (
 const Issue454PHPFixtureBytes = 137 * 1024
 
 // Issue454PHPSource builds the deterministic issue #454 PHP workload. The
-// first local variable is the near-top edit site for the $x0 to $0 deletion.
+// first local variable contains the edit site for the $x0 to $0 deletion.
 func Issue454PHPSource() []byte {
 	var source strings.Builder
 	source.Grow(Issue454PHPFixtureBytes)

--- a/parser.go
+++ b/parser.go
@@ -6816,6 +6816,13 @@ func (p *Parser) configureParseCaps(source []byte, reuse *reuseCursor, arenaClas
 		((p.language != nil && p.language.FullParseGSSConvergenceEnabled) ||
 			parseMaxMergePerKeyEnvConfigured() ||
 			maxMergePerKeyOverride < 0)
+	// C keeps equivalent cap-one recovery readings as links on one graph
+	// stack. Preserve that convergence after recovery makes error cost
+	// relevant. Separate Go stacks otherwise fork each history again at every
+	// clean suffix conflict and can grow quadratically.
+	scratch.merge.recoveryCapOneConvergence = reuse == nil &&
+		mergePerKeyCap == 1 &&
+		p.errorCostCompetitionEnabled()
 
 	maxNodes := parseNodeLimitForLanguage(len(source), p.language)
 	if maxNodesOverride > maxNodes {

--- a/parser.go
+++ b/parser.go
@@ -6818,8 +6818,8 @@ func (p *Parser) configureParseCaps(source []byte, reuse *reuseCursor, arenaClas
 			maxMergePerKeyOverride < 0)
 	// C keeps equivalent cap-one recovery readings as links on one graph
 	// stack. Preserve that convergence after recovery makes error cost
-	// relevant. Otherwise, separate Go stacks fork each history at every clean
-	// suffix and grow quadratically.
+	// relevant. Otherwise, separate Go stacks fork each history at each
+	// conflict in the valid suffix. This behavior can grow quadratically.
 	scratch.merge.recoveryCapOneConvergence = reuse == nil &&
 		mergePerKeyCap == 1 &&
 		p.errorCostCompetitionEnabled()

--- a/parser.go
+++ b/parser.go
@@ -6818,8 +6818,8 @@ func (p *Parser) configureParseCaps(source []byte, reuse *reuseCursor, arenaClas
 			maxMergePerKeyOverride < 0)
 	// C keeps equivalent cap-one recovery readings as links on one graph
 	// stack. Preserve that convergence after recovery makes error cost
-	// relevant. Separate Go stacks otherwise fork each history again at every
-	// clean suffix conflict and can grow quadratically.
+	// relevant. Otherwise, separate Go stacks fork each history at every clean
+	// suffix and grow quadratically.
 	scratch.merge.recoveryCapOneConvergence = reuse == nil &&
 		mergePerKeyCap == 1 &&
 		p.errorCostCompetitionEnabled()

--- a/parser_api_internal_test.go
+++ b/parser_api_internal_test.go
@@ -1043,6 +1043,46 @@ func TestConfigureParseCapsScopesFaithfulGSSConvergenceToFreshCapOne(t *testing.
 		)
 	}
 
+	recoveryParser := &Parser{
+		language:             &Language{Name: "recovery-cap-one"},
+		errorCostCompetition: true,
+	}
+	var recovery parserScratch
+	recoveryCaps := recoveryParser.configureParseCaps(
+		[]byte("source"),
+		nil,
+		arenaClassFull,
+		&recovery,
+		0,
+		0,
+		-1,
+	)
+	if recoveryCaps.mergePerKeyCap != 1 || !recovery.merge.recoveryCapOneConvergence {
+		t.Fatalf(
+			"recovery cap=%d recovery-faithful=%t, want cap=1 recovery-faithful=true",
+			recoveryCaps.mergePerKeyCap,
+			recovery.merge.recoveryCapOneConvergence,
+		)
+	}
+	var recoveryIncremental parserScratch
+	recoveryIncrementalCaps := recoveryParser.configureParseCaps(
+		[]byte("source"),
+		&reuseCursor{},
+		arenaClassIncremental,
+		&recoveryIncremental,
+		0,
+		0,
+		-1,
+	)
+	if recoveryIncrementalCaps.mergePerKeyCap != 1 ||
+		recoveryIncremental.merge.recoveryCapOneConvergence {
+		t.Fatalf(
+			"incremental recovery cap=%d recovery-faithful=%t, want cap=1 recovery-faithful=false",
+			recoveryIncrementalCaps.mergePerKeyCap,
+			recoveryIncremental.merge.recoveryCapOneConvergence,
+		)
+	}
+
 	t.Setenv("GOT_GLR_MAX_MERGE_PER_KEY", "1")
 	ResetParseEnvConfigCacheForTests()
 	var explicitCapOne parserScratch


### PR DESCRIPTION
## Summary

- Keep equivalent recovery readings as links on one graph stack.
- Activate convergence only after error cost becomes relevant during a fresh, cap-one full parse.
- Add an exact 137 KiB PHP regression and a pinned C parser comparison.

## Cause

The parser kept equivalent recovery readings as separate stacks. Each conflict in the valid suffix forked those histories again.

This growth exhausted parse budgets and could return an incorrect `ERROR` root.

## Evidence

Before this change, the exact workload produced these results:

- Incremental parse: 8.55 seconds.
- New nodes: 3,138,444.
- Parser arena and scratch: 823,910,736 bytes.
- Maximum stacks: 20.
- Result: the root differed from the C parser.

After this change, the exact workload produced these results:

- Incremental parse: 98 milliseconds.
- Edited fresh parse: 101 milliseconds.
- New nodes: 185,798.
- Parser arena and scratch: 45,276,824 bytes.
- Maximum stacks: 5.
- Result: the full tree matches fresh Go and pinned C parses.

The change reduces parser memory by 94.5 percent and removes repeated suffix growth. It does not use a language-name gate.

## Validation

- Focused graph-stack merge and policy tests pass in Docker.
- The exact PHP incremental regression passes in Docker.
- The exact pinned C parser comparison passes in Docker.
- All focused PHP grammar tests pass in Docker.
- The standard full, edited, and no-edit parser benchmarks complete without crashes.
- Both incremental benchmarks report zero bytes and zero allocations per operation.

The broader PHP import diagnostic passes 6 of 25 samples with full tree parity. The remaining gap comes from grammar generation.

Part of #454.