### PR TITLE
improve(admission): distinguish no-table-action from paused frontiers and label error trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The compact admission census now separates runnable no-table-action stops
+  from paused frontiers.
+  The real-corpus matrix labels production error trees.
+  Clean graduation coverage no longer counts recovery fixtures as parser gaps.
+
 - Native C-style recovery now owns Angular, BibTeX, Chatito, and Electronic Data
   Sheet materialization for every registered recovery witness.
   This removes four inert result-compatibility dispatcher arms.

--- a/admission_census.go
+++ b/admission_census.go
@@ -152,7 +152,7 @@ func admissionCensusClassify(boundary DiagnosticParserCoreBoundaryKind, detail s
 			return censusMechanismSchedulerShape
 		}
 	case DiagnosticParserCoreNoAction:
-		if strings.Contains(detail, "no table action") {
+		if detail == diagnosticParserCoreNoTableActionDetail {
 			return censusMechanismNoTableAction
 		}
 		return censusMechanismSchedulerShape

--- a/admission_census.go
+++ b/admission_census.go
@@ -86,6 +86,10 @@ const (
 	// example a trailing extra/whitespace token attached outside the
 	// accepted derivation).
 	censusMechanismEOFByteShort admissionCensusMechanism = "eof-byte-short-frontier"
+	// censusMechanismNoTableAction: every runnable frontier head lacks an
+	// action for the elected token. This often marks an input that needs
+	// recovery. A clean production tree can instead reveal a scheduler gap.
+	censusMechanismNoTableAction admissionCensusMechanism = "no-table-action"
 	// censusMechanismSchedulerShape: the generic scheduler's structural
 	// invariants (sole runnable head, homogeneous accept frontier, no mixed
 	// accepted/shifted heads, closed-and-checkpoint-continuous election) were
@@ -147,7 +151,12 @@ func admissionCensusClassify(boundary DiagnosticParserCoreBoundaryKind, detail s
 		default:
 			return censusMechanismSchedulerShape
 		}
-	case DiagnosticParserCoreNoAction, DiagnosticParserCoreAccept, DiagnosticParserCoreGenericClosed:
+	case DiagnosticParserCoreNoAction:
+		if strings.Contains(detail, "no table action") {
+			return censusMechanismNoTableAction
+		}
+		return censusMechanismSchedulerShape
+	case DiagnosticParserCoreAccept, DiagnosticParserCoreGenericClosed:
 		return censusMechanismSchedulerShape
 	case censusBoundaryMultiDerivation:
 		return censusMechanismMultiDerivation

--- a/admission_census_internal_test.go
+++ b/admission_census_internal_test.go
@@ -7,7 +7,7 @@ import "testing"
 func TestAdmissionCensusSeparatesNoTableActionFromPausedFrontier(t *testing.T) {
 	if got := admissionCensusClassify(
 		DiagnosticParserCoreNoAction,
-		"generic scheduler has no table action for the elected token",
+		diagnosticParserCoreNoTableActionDetail,
 	); got != censusMechanismNoTableAction {
 		t.Fatalf("no-table-action mechanism=%q", got)
 	}

--- a/admission_census_internal_test.go
+++ b/admission_census_internal_test.go
@@ -1,0 +1,20 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import "testing"
+
+func TestAdmissionCensusSeparatesNoTableActionFromPausedFrontier(t *testing.T) {
+	if got := admissionCensusClassify(
+		DiagnosticParserCoreNoAction,
+		"generic scheduler has no table action for the elected token",
+	); got != censusMechanismNoTableAction {
+		t.Fatalf("no-table-action mechanism=%q", got)
+	}
+	if got := admissionCensusClassify(
+		DiagnosticParserCoreNoAction,
+		"generic scheduler has only paused heads for the elected token",
+	); got != censusMechanismSchedulerShape {
+		t.Fatalf("paused-frontier mechanism=%q", got)
+	}
+}

--- a/admission_real_corpus_matrix_test.go
+++ b/admission_real_corpus_matrix_test.go
@@ -149,19 +149,26 @@ func TestAdmissionCandidateRealCorpusMatrix(t *testing.T) {
 	})
 
 	counts := map[string]int{}
+	parseClassCounts := map[string]int{}
 	languageCounts := map[string]map[string]int{}
 	for _, row := range rows {
 		counts[row.status]++
+		parseClass := "clean"
+		if row.productionHasError {
+			parseClass = "error-tree"
+		}
+		parseClassCounts[row.status+"/"+parseClass]++
 		if languageCounts[row.name] == nil {
 			languageCounts[row.name] = map[string]int{}
 		}
 		languageCounts[row.name][row.status]++
 		t.Logf(
-			"%-9s %-12s %-6s %7d %-5s %s",
+			"%-9s %-12s %-6s %7d %-10s %-5s %s",
 			row.status,
 			row.name,
 			row.backend,
 			row.bytes,
+			parseClass,
 			row.bucket,
 			row.detail,
 		)
@@ -174,6 +181,13 @@ func TestAdmissionCandidateRealCorpusMatrix(t *testing.T) {
 		counts[scorecardSkip],
 		counts[scorecardError],
 		len(rows),
+	)
+	t.Logf(
+		"--- parse class: FALLBACK clean=%d error-tree=%d; PASS clean=%d error-tree=%d ---",
+		parseClassCounts[scorecardFallback+"/clean"],
+		parseClassCounts[scorecardFallback+"/error-tree"],
+		parseClassCounts[scorecardPass+"/clean"],
+		parseClassCounts[scorecardPass+"/error-tree"],
 	)
 
 	names := make([]string, 0, len(languageCounts))

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -49,10 +49,11 @@ const (
 )
 
 type scorecardRow struct {
-	name    string
-	backend string
-	status  string
-	detail  string
+	name               string
+	backend            string
+	status             string
+	detail             string
+	productionHasError bool
 }
 
 // admissionScorecardRequiredCompactPasses is the frozen per-language admission
@@ -241,6 +242,23 @@ func TestAdmissionCandidateCooklangSmokeRatchet(t *testing.T) {
 	}
 }
 
+func TestAdmissionScorecardLabelsProductionErrorTree(t *testing.T) {
+	var goEntry grammars.LangEntry
+	for _, entry := range grammars.AllLanguages() {
+		if entry.Name == "go" {
+			goEntry = entry
+			break
+		}
+	}
+	if goEntry.Name == "" {
+		t.Fatal("go is missing from the grammar registry")
+	}
+	row := runAdmissionScorecardSource(goEntry, []byte("package p\nfunc"))
+	if row.status != scorecardFallback || !row.productionHasError {
+		t.Fatalf("invalid Go route=%s production_error_tree=%t: %s", row.status, row.productionHasError, row.detail)
+	}
+}
+
 // TestAdmissionSwitchRoutePrecedenceRatchet pins the three dispatch outcomes
 // that release admission relies on. A certified forest policy owns the default
 // route; an explicit compact request intentionally overrides it; with neither
@@ -354,6 +372,7 @@ func runAdmissionScorecardSource(entry grammars.LangEntry, source []byte) (row s
 		return row
 	}
 	defer productionTree.Release()
+	row.productionHasError = productionTree.RootNode().HasError()
 	productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), lang)
 	if err != nil {
 		row.detail = "production digest failed: " + err.Error()

--- a/parsercore_phase0_dispatch_scratch_internal_test.go
+++ b/parsercore_phase0_dispatch_scratch_internal_test.go
@@ -153,7 +153,7 @@ func TestDiagnosticParserCoreDispatchScratchCleansNoActionReturn(t *testing.T) {
 	scheduler, _ := newDiagnosticParserCoreDispatchProbeScheduler(t, &genericConflictTable{})
 	stop, err := scheduler.dispatchPass()
 	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction || stop.headerIndex != 0 ||
-		stop.detail != "generic scheduler has no table action for the elected token" {
+		stop.detail != diagnosticParserCoreNoTableActionDetail {
 		t.Fatalf("no-action stop=%+v err=%v", stop, err)
 	}
 	if cap(scheduler.dispatchScratch.noActionIndices) == 0 {

--- a/parsercore_phase0_dispatch_scratch_internal_test.go
+++ b/parsercore_phase0_dispatch_scratch_internal_test.go
@@ -152,7 +152,8 @@ func TestDiagnosticParserCoreDispatchScratchDoesNotAliasFullReceipts(t *testing.
 func TestDiagnosticParserCoreDispatchScratchCleansNoActionReturn(t *testing.T) {
 	scheduler, _ := newDiagnosticParserCoreDispatchProbeScheduler(t, &genericConflictTable{})
 	stop, err := scheduler.dispatchPass()
-	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction || stop.headerIndex != 0 {
+	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction || stop.headerIndex != 0 ||
+		stop.detail != "generic scheduler has no table action for the elected token" {
 		t.Fatalf("no-action stop=%+v err=%v", stop, err)
 	}
 	if cap(scheduler.dispatchScratch.noActionIndices) == 0 {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2375,6 +2375,8 @@ type diagnosticParserCoreGenericUnsupported struct {
 	headerIndex int
 }
 
+const diagnosticParserCoreNoTableActionDetail = "generic scheduler has no table action for the elected token"
+
 func (s *diagnosticParserCoreGenericScheduler) dispatchPass() (*diagnosticParserCoreGenericUnsupported, error) {
 	if err := s.dispatchScratch.begin(); err != nil {
 		return nil, err
@@ -2494,7 +2496,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
-			detail := "generic scheduler has no table action for the elected token"
+			detail := diagnosticParserCoreNoTableActionDetail
 			if pausedNoActionHeads == len(noActionIndices) {
 				detail = "generic scheduler has only paused heads for the elected token"
 			} else if pausedNoActionHeads != 0 {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2409,12 +2409,14 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	var singletonCells [1]diagnosticParserCoreGenericCell
 	cells := singletonCells[:0]
 	scratchCells := s.dispatchScratch.cells
+	pausedNoActionHeads := 0
 	for index, header := range s.headers {
 		if header.shifted || header.accepted {
 			continue
 		}
 		if header.paused {
 			s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
+			pausedNoActionHeads++
 			continue
 		}
 		boundary, err := s.compact.ClassifyBoundary(header.head, core.Symbol(s.token.Symbol))
@@ -2492,9 +2494,15 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			return nil, s.dropGenericNoActionHeads(noActionIndices)
 		}
 		if len(noActionIndices) != 0 {
+			detail := "generic scheduler has no table action for the elected token"
+			if pausedNoActionHeads == len(noActionIndices) {
+				detail = "generic scheduler has only paused heads for the elected token"
+			} else if pausedNoActionHeads != 0 {
+				detail = "generic scheduler has only paused or no-action heads for the elected token"
+			}
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary:    DiagnosticParserCoreNoAction,
-				detail:      "generic scheduler has only paused no-action heads for the elected token",
+				detail:      detail,
 				headerIndex: noActionIndices[0],
 			}, nil
 		}

--- a/parsercore_phase0_generic_freshness_internal_test.go
+++ b/parsercore_phase0_generic_freshness_internal_test.go
@@ -84,7 +84,8 @@ func TestDiagnosticParserCoreGenericReductionPauseIsFinite(t *testing.T) {
 		t.Fatal(err)
 	}
 	stop, err := sole.dispatchPass()
-	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction || !sole.headers[0].paused {
+	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction ||
+		stop.detail != "generic scheduler has only paused heads for the elected token" || !sole.headers[0].paused {
 		t.Fatalf("all-paused stop=%+v err=%v headers=%+v", stop, err, sole.headers)
 	}
 }
@@ -346,7 +347,8 @@ func TestDiagnosticParserCoreConflictAllUnchangedPauses(t *testing.T) {
 		t.Fatalf("all-unchanged conflict receipt=%+v", conflict)
 	}
 	stop, err := scheduler.dispatchPass()
-	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction {
+	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction ||
+		stop.detail != "generic scheduler has only paused heads for the elected token" {
 		t.Fatalf("all-unchanged conflict stop=%+v err=%v", stop, err)
 	}
 }


### PR DESCRIPTION
## Summary

Separate runnable no-table-action stops from paused frontiers.
Label each real-corpus row as a clean tree or an error tree.
This keeps recovery fixtures out of the clean graduation gap.

## Changes

- Add a `no-table-action` census mechanism.
- Preserve the scheduler-frontier mechanism for paused heads.
- Report clean and error-tree corpus totals.
- Add exact tests for both stop classes and the production error-tree label.
- Document the diagnostic change in the unreleased changelog.

The patch changes diagnostic text and test reporting only.
It does not widen compact-parser admission.

## Evidence

Focused tests passed:

```text
go test . -tags gts_parsercorephase0 -run '^(TestAdmissionCensusSeparatesNoTableActionFromPausedFrontier|TestAdmissionCandidateCooklangSmokeRatchet|TestAdmissionScorecardLabelsProductionErrorTree|TestDiagnosticParserCoreDispatchScratchCleansNoActionReturn|TestDiagnosticParserCoreGenericReductionPauseIsFinite|TestDiagnosticParserCoreConflictAllUnchangedPauses)$' -count=1
```

The bounded real-corpus gate passed with these totals:

```text
PASS=66 DIVERGE=0 FALLBACK=33 SKIP=10 ERROR=0 total=109
FALLBACK clean=18 error-tree=15
PASS clean=66 error-tree=0
```

The stable performance trio used `GOMAXPROCS=1`, ten samples, a 750 ms duration, and memory reporting.
The full-parse median was about 8.16 ms, 85 KB, and 14 allocations.
Both incremental lanes retained zero allocations.
The host timing spread was wide, so this evidence supports only a no-regression claim.

Direct no-cache Canopy searches parsed every changed Go file successfully.
