### PR TITLE
fix(parser): Re-lex compact branches by parser state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,11 @@ for tags and release notes while still in `0.x`.
   The real-corpus matrix labels production error trees.
   Clean graduation coverage no longer counts recovery fixtures as parser gaps.
 
-- Compact graph-structured stack dispatch now re-lexes an exact token span for
-  a no-action header's own Deterministic Finite Automaton state.
+- Compact graph branches now re-lex one exact token span for each parser state
+  when the shared symbol has no action.
   Each alternative keeps the shared byte range and scanner checkpoint.
   The medium Scala corpus now reaches compact acceptance.
-  The existing converged-path proof still controls direct publication.
+  A separate proof for joined reduction paths still gates direct publication.
 
 - Native C-style recovery now owns Angular, BibTeX, Chatito, and Electronic Data
   Sheet materialization for every registered recovery witness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ for tags and release notes while still in `0.x`.
   The real-corpus matrix labels production error trees.
   Clean graduation coverage no longer counts recovery fixtures as parser gaps.
 
+- Compact graph-structured stack dispatch now re-lexes an exact token span for
+  a no-action header's own Deterministic Finite Automaton state.
+  Each alternative keeps the shared byte range and scanner checkpoint.
+  The medium Scala corpus now reaches compact acceptance.
+  The existing converged-path proof still controls direct publication.
+
 - Native C-style recovery now owns Angular, BibTeX, Chatito, and Electronic Data
   Sheet materialization for every registered recovery witness.
   This removes four inert result-compatibility dispatcher arms.

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -107,6 +107,11 @@ type dfaTokenSource struct {
 	// reference) but keeps the allocation for the next pooled acquire. Callers
 	// that pass their own lexer simply leave it unused.
 	ownedLexer *Lexer
+
+	// relexProbeLexer is a private Lexer for parser-state-specific DFA probes.
+	// Keep it outside the compact scheduler so ordinary parses do not enlarge
+	// each scheduler allocation. Close drops its source reference.
+	relexProbeLexer *Lexer
 }
 
 const maxConsecutiveZeroWidthTokens = 4
@@ -270,6 +275,7 @@ func resetPooledDFATokenSource(ts *dfaTokenSource) {
 	savedSQLKeywordScratch := ts.sqlKeywordScratch[:0]
 	savedExtZeroTried := ts.extZeroTried[:0]
 	savedOwnedLexer := ts.ownedLexer
+	savedRelexProbeLexer := ts.relexProbeLexer
 	var savedGLRUnionScanScratch []glrUnionDFAScan
 	if cap(ts.glrUnionScanScratch) > len(ts.glrUnionScanInline) {
 		// Close clears every Token before the source enters the pool. Preserve
@@ -283,6 +289,7 @@ func resetPooledDFATokenSource(ts *dfaTokenSource) {
 		bashArithmeticCachePos: -1,
 	}
 	ts.ownedLexer = savedOwnedLexer
+	ts.relexProbeLexer = savedRelexProbeLexer
 	ts.externalValid = savedExternalValid
 	ts.externalTokenStart = savedExternalTokenStart
 	ts.externalTokenEnd = savedExternalTokenEnd
@@ -421,6 +428,9 @@ func (d *dfaTokenSource) Close() {
 		// contents so no source bytes or table slices stay pinned while the
 		// token source sits in the pool.
 		*d.ownedLexer = Lexer{}
+	}
+	if d.relexProbeLexer != nil {
+		*d.relexProbeLexer = Lexer{}
 	}
 	d.lexer = nil
 	d.language = nil

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -108,9 +108,10 @@ type dfaTokenSource struct {
 	// that pass their own lexer simply leave it unused.
 	ownedLexer *Lexer
 
-	// relexProbeLexer is a private Lexer for parser-state-specific DFA probes.
-	// Keep it outside the compact scheduler so ordinary parses do not enlarge
-	// each scheduler allocation. Close drops its source reference.
+	// relexProbeLexer is a private Lexer.
+	// It probes the deterministic finite automaton for one parser state.
+	// Keep it outside the compact scheduler to limit each scheduler allocation.
+	// Close drops its source reference.
 	relexProbeLexer *Lexer
 }
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1649,7 +1649,7 @@ func diagnosticParserCoreConflictPolicyOrdinal(
 	return 0, false
 }
 
-// relexTokenForState mirrors the production parser's span-exact DFA probe.
+// relexTokenForState mirrors the production parser's span-exact lexer probe.
 // It gives one no-action header the tokenization required by its current state.
 func (s *diagnosticParserCoreGenericScheduler) relexTokenForState(state StateID, tok Token) (Token, bool) {
 	if s == nil || s.tokenSource == nil || s.tokenSource.lexer == nil {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1530,6 +1530,8 @@ func newDiagnosticParserCoreGenericScheduler(
 type diagnosticParserCoreGenericCell struct {
 	headerIndex             int
 	boundary                core.ClassifiedBoundary
+	token                   Token
+	stateRelexed            bool
 	conflictPolicy          bool
 	conflictPolicyOrdinal   int
 	repetitionFold          bool
@@ -1537,6 +1539,12 @@ type diagnosticParserCoreGenericCell struct {
 }
 
 func (cell diagnosticParserCoreGenericCell) actions() core.ActionRow { return cell.boundary.Actions() }
+func (cell diagnosticParserCoreGenericCell) dispatchToken(shared Token) Token {
+	if cell.stateRelexed {
+		return cell.token
+	}
+	return shared
+}
 func (cell diagnosticParserCoreGenericCell) descriptor() core.ActionRowDescriptor {
 	return cell.boundary.Actions().Descriptor()
 }
@@ -1639,6 +1647,57 @@ func diagnosticParserCoreConflictPolicyOrdinal(
 		}
 	}
 	return 0, false
+}
+
+// relexTokenForState mirrors the production parser's span-exact DFA probe.
+// It gives one no-action header the tokenization required by its current state.
+func (s *diagnosticParserCoreGenericScheduler) relexTokenForState(state StateID, tok Token) (Token, bool) {
+	if s == nil || s.tokenSource == nil || s.tokenSource.lexer == nil {
+		return tok, false
+	}
+	lang := s.tokenSource.language
+	source := s.tokenSource.lexer.source
+	if lang == nil || len(lang.LexStates) == 0 || int(state) >= len(lang.LexModes) {
+		return tok, false
+	}
+	// A stateless external scanner has no checkpoint identity for this probe.
+	// Keep that route unchanged until each header can own its scanner state.
+	if lang.ExternalScanner != nil && s.checkpoint.Length == 0 {
+		return tok, false
+	}
+	if tok.Symbol == 0 || tok.Symbol == errorSymbol || tok.Missing || tok.NoLookahead ||
+		tok.StartByte >= tok.EndByte || int(tok.StartByte) >= len(source) {
+		return tok, false
+	}
+	lexState := lang.LexModes[state].LexStateIndex()
+	if lexState == noLookaheadLexState || int(lexState) >= len(lang.LexStates) {
+		return tok, false
+	}
+	// Match Parser.relexTokenForStackLexState. Lexer.scan reads only these
+	// DFA fields, so this probe does not need parser or scanner state.
+	probe := s.tokenSource.relexProbeLexer
+	if probe == nil {
+		probe = &Lexer{}
+		s.tokenSource.relexProbeLexer = probe
+	}
+	*probe = Lexer{
+		states:          lang.LexStates,
+		asciiTable:      lang.LexAsciiTable(),
+		source:          source,
+		pos:             int(tok.StartByte),
+		row:             tok.StartPoint.Row,
+		col:             tok.StartPoint.Column,
+		immediateTokens: lang.ImmediateTokens,
+		zeroWidthTokens: lang.ZeroWidthTokens,
+	}
+	relexed, ok := probe.scan(uint32(lexState), probe.pos, probe.row, probe.col)
+	if !ok || relexed.Symbol == 0 || relexed.Symbol == tok.Symbol {
+		return tok, false
+	}
+	if relexed.StartByte != tok.StartByte || relexed.EndByte != tok.EndByte {
+		return tok, false
+	}
+	return relexed, true
 }
 
 type diagnosticParserCoreDispatchScratch struct {
@@ -2421,7 +2480,8 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			pausedNoActionHeads++
 			continue
 		}
-		boundary, err := s.compact.ClassifyBoundary(header.head, core.Symbol(s.token.Symbol))
+		cellToken := s.token
+		boundary, err := s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
 		if err != nil {
 			return nil, err
 		}
@@ -2429,14 +2489,35 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 		actions := boundary.Actions()
 		workCountRecordResolvedActionCell(actions.Len())
 		if actions.Len() == 0 {
-			s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
-			continue
+			state := StateID(boundary.State())
+			if len(s.headers) > 1 {
+				relexed, ok := s.relexTokenForState(state, s.token)
+				if ok {
+					cellToken = relexed
+					boundary, err = s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
+					if err != nil {
+						return nil, err
+					}
+					s.work.ActionLookups++
+					actions = boundary.Actions()
+					workCountRecordResolvedActionCell(actions.Len())
+				}
+			}
+			if actions.Len() == 0 {
+				s.dispatchScratch.noActionIndices = append(s.dispatchScratch.noActionIndices, index)
+				continue
+			}
 		}
-		cell := diagnosticParserCoreGenericCell{headerIndex: index, boundary: boundary}
+		cell := diagnosticParserCoreGenericCell{
+			headerIndex:  index,
+			boundary:     boundary,
+			token:        cellToken,
+			stateRelexed: cellToken != s.token,
+		}
 		if s.tokenSource != nil {
 			cell.conflictPolicyOrdinal, cell.conflictPolicy = diagnosticParserCoreConflictPolicyOrdinal(
 				s.tokenSource.language,
-				s.token,
+				cell.dispatchToken(s.token),
 				boundary.State(),
 				actions,
 			)
@@ -2466,7 +2547,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	for index, cell := range cells {
 		descriptor := cell.descriptor()
 		if !cell.conflictPolicy && !cell.repetitionFold {
-			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, s.token, cell.actions(), descriptor); unsupported != nil {
+			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, cell.dispatchToken(s.token), cell.actions(), descriptor); unsupported != nil {
 				return unsupported, nil
 			}
 		}
@@ -2552,6 +2633,13 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				boundary: DiagnosticParserCoreExtra, detail: "generic scheduler requires a homogeneous all-runnable extra cohort", headerIndex: cells[0].headerIndex,
 			}, nil
 		}
+		for _, cell := range cells[1:] {
+			if cell.dispatchToken(s.token) != cells[0].dispatchToken(s.token) {
+				return &diagnosticParserCoreGenericUnsupported{
+					boundary: DiagnosticParserCoreExtra, detail: "generic scheduler extra cohort requires one tokenization", headerIndex: cell.headerIndex,
+				}, nil
+			}
+		}
 		if unsupported := s.zeroWidthExtraShiftWithoutProgress(cells); unsupported != nil {
 			return unsupported, nil
 		}
@@ -2574,18 +2662,21 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 }
 
 func (s *diagnosticParserCoreGenericScheduler) zeroWidthExtraShiftWithoutProgress(cells []diagnosticParserCoreGenericCell) *diagnosticParserCoreGenericUnsupported {
-	if s.token.EndByte != s.token.StartByte ||
-		s.currentElection.ScannerAfter != s.currentElection.ScannerBefore {
+	if s.currentElection.ScannerAfter != s.currentElection.ScannerBefore {
 		return nil
 	}
 	for _, cell := range cells {
+		token := cell.dispatchToken(s.token)
+		if token.EndByte != token.StartByte {
+			continue
+		}
 		action := cell.actions().At(0)
 		target := action.State
 		if target == 0 {
 			target = cell.boundary.State()
 		}
 		if target == cell.boundary.State() &&
-			s.token.EndByte <= cell.boundary.ByteOffset() {
+			token.EndByte <= cell.boundary.ByteOffset() {
 			return &diagnosticParserCoreGenericUnsupported{
 				boundary:    DiagnosticParserCoreRoute,
 				detail:      "generic scheduler zero-width extra shift has no scanner or parser-state progress",
@@ -2613,7 +2704,8 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericAccept(before []Diagn
 	if cell.actions().Len() != 1 || cell.actions().At(0).Type != core.ActionAccept {
 		return errors.New("parser-core phase zero: generic accept requires one accept action")
 	}
-	if s.token.Symbol != 0 || s.token.StartByte != s.token.EndByte || s.token.Missing || s.token.NoLookahead || s.token.ExternalScannerToken {
+	token := cell.dispatchToken(s.token)
+	if token.Symbol != 0 || token.StartByte != token.EndByte || token.Missing || token.NoLookahead || token.ExternalScannerToken {
 		return errors.New("parser-core phase zero: generic accept requires authenticated zero-width EOF")
 	}
 	if err := s.reserveDispatches(1); err != nil {
@@ -2862,7 +2954,8 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		s.compact.SetReduceConflictContext(true)
 		defer s.compact.SetReduceConflictContext(false)
 	}
-	if s.token.NoLookahead {
+	token := cell.dispatchToken(s.token)
+	if token.NoLookahead {
 		s.compact.SetReduceNoLookaheadContext(true)
 		defer s.compact.SetReduceNoLookaheadContext(false)
 	}
@@ -2896,7 +2989,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacement := s.headers[cell.headerIndex]
 		replacement.head = output.Head
 		replacement.paused = false
-		replacement.shifted = s.token.NoLookahead
+		replacement.shifted = token.NoLookahead
 		replacement.convergedReductionSplit = replacement.convergedReductionSplit || convergedReductionSplit
 		if len(replacements) > 0 {
 			if s.nextSeq == math.MaxUint64 {
@@ -2944,7 +3037,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			After: after,
 		})
 	}
-	if s.token.NoLookahead &&
+	if token.NoLookahead &&
 		Symbol(cell.actions().At(ordinal).Symbol) == s.options.noLookaheadRootSymbol {
 		s.requireEOFPostNoLookaheadRoot = true
 	}
@@ -3036,7 +3129,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	}
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
-		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, s.token, cell.boundary,
+		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
 		s.branchOrder, s.fullReceipts(), &s.conflictScratch,
 	)
 	if err != nil {
@@ -3171,7 +3264,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		roundIndex = round.Index
 		s.receipt.Rounds = append(s.receipt.Rounds, round)
 		conflict := DiagnosticParserCoreGenericConflict{
-			ElectionIndex: s.electionIndex, Token: s.token, HeaderIndex: cell.headerIndex,
+			ElectionIndex: s.electionIndex, Token: cell.dispatchToken(s.token), HeaderIndex: cell.headerIndex,
 			BranchOrderBefore: branchOrderBefore, BranchOrderAfter: s.branchOrder,
 			NextCreationSeqBefore: nextSeqBefore, NextCreationSeqAfter: s.nextSeq,
 			Round: round, Prefix: prefixReceipts,
@@ -3221,7 +3314,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 	}
 	ordinaryCohort := len(cells) > 1
 	for _, cell := range cells {
-		if cell.selectedActionOrdinal() != 0 {
+		if cell.selectedActionOrdinal() != 0 || cell.dispatchToken(s.token) != cells[0].dispatchToken(s.token) {
 			ordinaryCohort = false
 			break
 		}
@@ -3231,8 +3324,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 		for _, cell := range cells {
 			s.classifiedBoundaries = append(s.classifiedBoundaries, cell.boundary)
 		}
+		token := cells[0].dispatchToken(s.token)
 		heads, err := s.compact.ShiftOrdinaryClassifiedCohortOwned(owner, s.classifiedBoundaries, core.Token{
-			Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte, External: s.token.ExternalScannerToken,
+			Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, External: token.ExternalScannerToken,
 		})
 		if err != nil {
 			return err
@@ -3249,8 +3343,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			if action.Type != core.ActionShift || action.Extra {
 				return errors.New("parser-core phase zero: ordinary shift selection is not an ordinary shift")
 			}
+			token := cell.dispatchToken(s.token)
 			head, err := s.compact.ShiftClassifiedOwned(owner, cell.boundary, ordinal, core.Token{
-				Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte, External: s.token.ExternalScannerToken,
+				Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte, External: token.ExternalScannerToken,
 			}, core.ForkOrder{})
 			if err != nil {
 				return err
@@ -3323,9 +3418,10 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		for _, cell := range cells {
 			s.classifiedBoundaries = append(s.classifiedBoundaries, cell.boundary)
 		}
+		token := cells[0].dispatchToken(s.token)
 		heads, err := s.compact.ShiftExtraClassifiedCohortOwned(owner, s.classifiedBoundaries, core.Token{
-			Symbol: core.Symbol(s.token.Symbol), StartByte: s.token.StartByte, EndByte: s.token.EndByte,
-			Extra: true, External: s.token.ExternalScannerToken,
+			Symbol: core.Symbol(token.Symbol), StartByte: token.StartByte, EndByte: token.EndByte,
+			Extra: true, External: token.ExternalScannerToken,
 		})
 		if err != nil {
 			return err

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -1,0 +1,29 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+func RunStateDependentRelexSchedulerForTest(lang *Language, source []byte) (DiagnosticParserCoreGenericScheduler, error) {
+	parser := NewParser(lang)
+	runner, err := newAdmissionCandidateRunner(parser)
+	if err != nil {
+		return DiagnosticParserCoreGenericScheduler{}, err
+	}
+	runner.options.ReceiptMode = DiagnosticParserCoreReceiptFull
+	tokenSource := parser.acquireParserDFATokenSource(source)
+	if tokenSource == nil {
+		return DiagnosticParserCoreGenericScheduler{}, nil
+	}
+	defer tokenSource.Close()
+	scheduler, runErr := executeDiagnosticParserCoreGenericSchedulerFromSeed(
+		runner.compact,
+		tokenSource,
+		&runner.scannerScratch,
+		lang.InitialState,
+		runner.options,
+		diagnosticParserCoreSeedObserver{},
+	)
+	if scheduler == nil || scheduler.receipt == nil {
+		return DiagnosticParserCoreGenericScheduler{}, runErr
+	}
+	return *scheduler.receipt, runErr
+}

--- a/parsercore_phase0_state_relex_test.go
+++ b/parsercore_phase0_state_relex_test.go
@@ -1,0 +1,62 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestDiagnosticParserCoreStateDependentRelexKeepsExactSpanBranch(t *testing.T) {
+	source := []byte(`object X {
+  val EOL = "\n"
+  def f(t: TraversableOnce[String], c: Boolean): String = {
+    val space = " "
+    val sep = if (c) EOL + space * 2 else EOL
+    val (a, b) = if (c) (space + "{", EOL + "}") else ("", "")
+    t.mkString(a + sep, sep, b + EOL)
+  }
+}`)
+	var entry grammars.LangEntry
+	found := false
+	for _, candidate := range grammars.AllLanguages() {
+		if candidate.Name == "scala" {
+			entry = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("scala is absent from the language registry")
+	}
+	lang := entry.Language()
+
+	production, err := gts.NewParser(lang).Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer production.Release()
+	if production.RootNode().HasError() {
+		t.Fatal("production witness has an error")
+	}
+
+	receipt, err := gts.RunStateDependentRelexSchedulerForTest(lang, source)
+	if err != nil {
+		t.Fatalf("compact scheduler: %v", err)
+	}
+	if receipt.Acceptance == nil {
+		t.Fatalf("compact scheduler stopped at %+v", receipt.Stop)
+	}
+
+	certifiedLang := *lang
+	certifiedLang.CompactConvergedReductionSplitDropsCertified = true
+	entry.Language = func() *gts.Language {
+		return &certifiedLang
+	}
+	row := runAdmissionScorecardSource(entry, source)
+	if row.status != scorecardPass {
+		t.Fatalf("certified compact result = %s: %s", row.status, row.detail)
+	}
+}


### PR DESCRIPTION
Summary: Compact graph branches now re-lex the shared span with each parser state when the shared symbol has no action. The probe preserves the byte range and scanner checkpoint. Unsupported tokenizations still fail closed. The medium Scala witness now reaches compact acceptance.

Validation: Focused tagged tests and the focused race test pass in Docker. Scala completed its isolated corpus run without an out-of-memory failure. The stable benchmark trio shows no allocation regression.