### PR TITLE
Reduce compact full-parse scheduler allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- The fresh compact runner now reuses its scheduler storage across parses.
+  Full-parse allocations fall from 15 to 14 per operation.
+  Parse time and allocated bytes remain statistically unchanged.
+
 - The parser now reuses its bound stop-check callback across compact full
   parses.
   This removes one allocation and 16 bytes per operation.

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1477,6 +1477,34 @@ func newDiagnosticParserCoreGenericScheduler(
 	observer diagnosticParserCoreSeedObserver,
 	options DiagnosticParserCorePrefixOptions,
 ) (*diagnosticParserCoreGenericScheduler, error) {
+	return initializeDiagnosticParserCoreGenericScheduler(
+		&diagnosticParserCoreGenericScheduler{},
+		compact,
+		tokenSource,
+		scannerScratch,
+		head,
+		checkpointID,
+		checkpoint,
+		observer,
+		options,
+	)
+}
+
+func initializeDiagnosticParserCoreGenericScheduler(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	compact *core.Core,
+	tokenSource *dfaTokenSource,
+	scannerScratch *[]byte,
+	head core.Head,
+	checkpointID core.CheckpointID,
+	checkpoint DiagnosticParserCoreScannerCheckpoint,
+	observer diagnosticParserCoreSeedObserver,
+	options DiagnosticParserCorePrefixOptions,
+) (*diagnosticParserCoreGenericScheduler, error) {
+	if scheduler == nil {
+		return nil, errors.New("parser-core phase zero: seed scheduler storage is nil")
+	}
+	*scheduler = diagnosticParserCoreGenericScheduler{}
 	if compact == nil || tokenSource == nil || scannerScratch == nil || head.Node == 0 {
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreRoute, detail: "generic scheduler requires a compact core, token source, scanner scratch, and seed head"}
 	}
@@ -1495,7 +1523,7 @@ func newDiagnosticParserCoreGenericScheduler(
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic seed head was not created under its scanner checkpoint identity"}
 	}
 	header := diagnosticParserCoreHeader{head: head, checkpoint: checkpointID}
-	scheduler := &diagnosticParserCoreGenericScheduler{
+	*scheduler = diagnosticParserCoreGenericScheduler{
 		compact: compact, tokenSource: tokenSource, scannerScratch: scannerScratch,
 		checkpoint: checkpoint, checkpointID: checkpointID,
 		electionIndex: -1, nextSeq: 1,
@@ -1794,6 +1822,20 @@ func executeDiagnosticParserCoreGenericSchedulerFromSeed(
 	options DiagnosticParserCorePrefixOptions,
 	observer diagnosticParserCoreSeedObserver,
 ) (*diagnosticParserCoreGenericScheduler, error) {
+	return executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
+		nil, compact, tokenSource, scannerScratch, initialState, options, observer,
+	)
+}
+
+func executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
+	scheduler *diagnosticParserCoreGenericScheduler,
+	compact *core.Core,
+	tokenSource *dfaTokenSource,
+	scannerScratch *[]byte,
+	initialState StateID,
+	options DiagnosticParserCorePrefixOptions,
+	observer diagnosticParserCoreSeedObserver,
+) (*diagnosticParserCoreGenericScheduler, error) {
 	if compact == nil || tokenSource == nil || scannerScratch == nil {
 		return nil, errors.New("parser-core phase zero: seed scheduler requires compact core and production token source")
 	}
@@ -1811,9 +1853,15 @@ func executeDiagnosticParserCoreGenericSchedulerFromSeed(
 	if err != nil {
 		return nil, err
 	}
-	scheduler, err := newDiagnosticParserCoreGenericScheduler(
-		compact, tokenSource, scannerScratch, head, initialCheckpointID, initialCheckpointReceipt, observer, options,
-	)
+	if scheduler == nil {
+		scheduler, err = newDiagnosticParserCoreGenericScheduler(
+			compact, tokenSource, scannerScratch, head, initialCheckpointID, initialCheckpointReceipt, observer, options,
+		)
+	} else {
+		scheduler, err = initializeDiagnosticParserCoreGenericScheduler(
+			scheduler, compact, tokenSource, scannerScratch, head, initialCheckpointID, initialCheckpointReceipt, observer, options,
+		)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -36,7 +36,8 @@ type parserCoreFreshFullRunner struct {
 	// is per-Parser and single-goroutine, so reusing these buffers across parses
 	// mirrors production's parser-held arena reuse and keeps the warm steady
 	// state from re-allocating the public-tree scratch on every parse.
-	scratch parserCoreRunnerScratch
+	scratch   parserCoreRunnerScratch
+	scheduler diagnosticParserCoreGenericScheduler
 }
 
 func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticParserCorePrefixOptions) (*parserCoreFreshFullRunner, error) {
@@ -95,8 +96,8 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	if tokenSource == nil {
 		return nil, nil, errors.New("parser-core fresh-full runner: production DFA unavailable")
 	}
-	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeed(
-		compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
+	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
+		&r.scheduler, compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
 		r.options, diagnosticParserCoreSeedObserver{},
 	)
 	if err != nil {

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -49,6 +49,30 @@ func TestParserCoreFreshFullRunnerRepeatedCanonicalLifecycle(t *testing.T) {
 	}
 }
 
+func TestParserCoreFreshFullRunnerReusesSchedulerStorage(t *testing.T) {
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	first, tokenSource, err := runner.executeSchedulerOpen(fixture.Source, runner.compact, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenSource.Close()
+	if first != &runner.scheduler {
+		t.Fatal("fresh-full runner did not use its scheduler storage")
+	}
+	second, tokenSource, err := runner.executeSchedulerOpen(fixture.Source, runner.compact, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenSource.Close()
+	if second != first {
+		t.Fatal("fresh-full runner replaced its scheduler storage")
+	}
+}
+
 func TestParserCoreFreshFullRunnerScratchDoesNotAliasLiveTree(t *testing.T) {
 	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
 	if err != nil {


### PR DESCRIPTION
## Summary

- Reuse the compact scheduler inside the parser-owned fresh runner.
- Keep public diagnostic scheduler allocation unchanged.
- Add a storage-identity regression test and an unreleased changelog entry.

## Performance

The stable interleaved Go full-parse benchmark used ten samples at 750 milliseconds.

- Allocations: 15.00 to 14.00 per operation, down 6.67 percent, p=0.000.
- Time: 10.73 to 10.79 milliseconds, no significant change.
- Bytes: 107.4 to 104.1 KiB, no significant change.
- Incremental benchmarks retain zero allocations.

## Validation

- `go test . -tags gts_parsercorephase0 -run '^TestParserCoreFreshFullRunner' -count=1`
- The same focused test passed in the Docker parity harness.
- The stable benchmark trio passed with ten samples.
- Narrow, uncached Canopy checks passed for the changed scheduler paths.
