### PR TITLE
optimize(parsercore): store common rollback frontier inline in scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- The compact scheduler now stores its common rollback frontier inline.
+  This removes one allocation from a fresh full parse.
+
 - The fresh compact runner now reuses its scheduler storage across parses.
   Full-parse allocations fall from 15 to 14 per operation.
   Parse time and allocated bytes remain statistically unchanged.

--- a/parsercore_phase0_dispatch_scratch_internal_test.go
+++ b/parsercore_phase0_dispatch_scratch_internal_test.go
@@ -225,6 +225,9 @@ func TestDiagnosticParserCoreHeaderRollbackScratchRestoresAndReuses(t *testing.T
 	if err := scratch.begin(current); err != nil {
 		t.Fatal(err)
 	}
+	if len(scratch.headers) == 0 || &scratch.headers[0] != &scratch.inline[0] {
+		t.Fatal("initial rollback snapshot did not use inline storage")
+	}
 	current[0] = diagnosticParserCoreHeader{head: core.Head{Node: 9}, accepted: true}
 	current = current[:1]
 	scratch.finish(&current, true)
@@ -258,4 +261,14 @@ func TestDiagnosticParserCoreHeaderRollbackScratchRestoresAndReuses(t *testing.T
 	if scratch.busy || scratch.headers != nil {
 		t.Fatalf("reset rollback scratch=%+v", scratch)
 	}
+
+	wide := make([]diagnosticParserCoreHeader, len(scratch.inline)+1)
+	if err := scratch.begin(wide); err != nil {
+		t.Fatal(err)
+	}
+	if cap(scratch.headers) < len(wide) {
+		t.Fatalf("wide rollback capacity=%d want at least %d", cap(scratch.headers), len(wide))
+	}
+	scratch.finish(&wide, false)
+	scratch.reset()
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1738,11 +1738,14 @@ type diagnosticParserCoreDispatchScratch struct {
 // frontier while one scheduler mutation is in flight. Scheduler operations are
 // deliberately non-reentrant, so one bounded buffer can serve every accept,
 // reduction, conflict, ordinary-shift, and extra-shift transaction in a parse.
+// The inline buffer covers the common one-to-eight-header frontier. Wider
+// frontiers retain the existing heap-backed growth path.
 //
 // diagnosticParserCoreHeader is pointer-free today. reset nevertheless clears
 // the retained capacity at the end of the scheduler lifecycle so adding a
 // pointer-bearing field later cannot make this scratch retain parse state.
 type diagnosticParserCoreHeaderRollbackScratch struct {
+	inline  [8]diagnosticParserCoreHeader
 	busy    bool
 	headers []diagnosticParserCoreHeader
 }
@@ -1756,8 +1759,12 @@ func (scratch *diagnosticParserCoreHeaderRollbackScratch) begin(headers []diagno
 	}
 	scratch.busy = true
 	if cap(scratch.headers) < len(headers) {
-		capacity := max(len(headers), cap(scratch.headers)*2)
-		scratch.headers = make([]diagnosticParserCoreHeader, len(headers), capacity)
+		if len(headers) <= len(scratch.inline) {
+			scratch.headers = scratch.inline[:len(headers)]
+		} else {
+			capacity := max(len(headers), cap(scratch.headers)*2)
+			scratch.headers = make([]diagnosticParserCoreHeader, len(headers), capacity)
+		}
 	} else {
 		scratch.headers = scratch.headers[:len(headers)]
 	}


### PR DESCRIPTION
## Summary

Store the common rollback frontier in the compact scheduler.

The scheduler uses inline storage for one to eight headers. Wider frontiers use the existing heap growth path.

## Evidence

- Run the tagged rollback and fresh-runner tests.
- Run ten Go smoke corpus cases against the C parser.
- Record at most 1,119,692 KiB of resident memory during isolated parity.
- Run narrow Canopy checks. Both changed Go files parse without errors.

Use these stable full-parse benchmark settings:

- Pin one CPU.
- Set `GOMAXPROCS=1`.
- Use 10 samples.
- Set the test time to 750 ms.

The change reduces allocations from 13 to 12 per operation. Parse time improves by 7.62 percent.

Allocated bytes improve by 8.50 percent. Both incremental benchmarks remain at zero allocations.

## Commands

```text
go test . -tags gts_parsercorephase0 -run TestDiagnosticParserCoreHeaderRollbackScratchRestoresAndReuses -count=1
go test . -tags gts_parsercorephase0 -run TestParserCoreFreshFullRunner -count=1
bash cgo_harness/docker/run_single_grammar_parity.sh --no-build --profile smoke --max-cases 10 go_lang
```
