### PR TITLE
remove(field-projection): retire Dart and Elixir field repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Native reduction now owns Dart switch-expression body fields.
+  It also owns target fields for nested Elixir calls.
+  This removes two inert language-local field repairs.
+  Scala and SQL field corrections remain live.
+
 - The compact admission census now separates runnable no-table-action stops
   from paused frontiers.
   The real-corpus matrix labels production error trees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,10 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
-- Native reduction now owns Dart switch-expression body fields.
-  It also owns target fields for nested Elixir calls.
-  This removes two inert language-local field repairs.
-  Scala and SQL field corrections remain live.
+- The native reduction path now sets Dart switch-expression body fields.
+  It now sets the target field for nested Elixir calls.
+  This change removes two inert language-local field repairs.
+  The Scala and SQL field corrections remain live.
 
 - The compact admission census now separates runnable no-table-action stops
   from paused frontiers.

--- a/cgo_harness/inherited_field_projection_retirement_parity_cgo_test.go
+++ b/cgo_harness/inherited_field_projection_retirement_parity_cgo_test.go
@@ -1,0 +1,23 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import "testing"
+
+func TestDartInheritedFieldProjectionLockedCParity(t *testing.T) {
+	runParityCase(
+		t,
+		parityCase{name: "dart"},
+		"switch_expression_body",
+		[]byte("int f(Object value) => switch (value) { int n => n, _ => 0 };\n"),
+	)
+}
+
+func TestElixirInheritedFieldProjectionLockedCParity(t *testing.T) {
+	runParityCase(
+		t,
+		parityCase{name: "elixir"},
+		"nested_call_target",
+		[]byte("def unquote(f)(x), do: nil\n"),
+	)
+}

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -15,13 +15,13 @@ without updating that registry.
 
 The v1 registry freezes the current surface:
 
-- 56 explicit `runLanguageResultCompatibility` switch arms covering 58
+- 42 explicit `runLanguageResultCompatibility` switch arms covering 44
   language names;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-That is 57 live registry entries and 28 retired entries. The registry covers
+That is 43 live registry entries and 40 retired entries. The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.
 
@@ -245,6 +245,11 @@ Reduction also owns the Haskell and Erlang root field shapes.
 The field plan retains each conflicting inherited mapping.
 The reduce path projects a mapping only when a named child matches its field.
 Root acceptance preserves producer fields when it absorbs surrounding trivia.
+
+Reduction also owns Dart switch-expression body fields.
+It owns the target field for nested Elixir calls.
+The two language-local repairs are inert and removed.
+Scala field repair and SQL field cleanup remain live counterexamples.
 
 ## Current progress: Erlang native ownership
 

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -15,13 +15,13 @@ without updating that registry.
 
 The v1 registry freezes the current source and registry:
 
-- 42 explicit `runLanguageResultCompatibility` switch arms covering 44
+- 41 explicit `runLanguageResultCompatibility` switch arms covering 43
   language names;
 - one predicate-dispatched COBOL entry matching exactly `cobol` or `COBOL`;
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-That is 43 live registry entries and 40 retired entries. These counts backfill
+That is 42 live registry entries and 41 retired entries. These counts backfill
 earlier retirements. This field repair change does not remove a dispatcher arm.
 The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -13,7 +13,7 @@ without updating that registry.
 
 ## Current denominator
 
-The v1 registry freezes the current surface:
+The v1 registry freezes the current source and registry:
 
 - 42 explicit `runLanguageResultCompatibility` switch arms covering 44
   language names;
@@ -21,7 +21,9 @@ The v1 registry freezes the current surface:
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-That is 43 live registry entries and 40 retired entries. The registry covers
+That is 43 live registry entries and 40 retired entries. These counts backfill
+earlier retirements. This field repair change does not remove a dispatcher arm.
+The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments
 and other engine research belong in their owning subsystem's durable traces.
 
@@ -246,10 +248,10 @@ The field plan retains each conflicting inherited mapping.
 The reduce path projects a mapping only when a named child matches its field.
 Root acceptance preserves producer fields when it absorbs surrounding trivia.
 
-Reduction also owns Dart switch-expression body fields.
-It owns the target field for nested Elixir calls.
+The native reduction path sets Dart switch-expression body fields.
+It sets the target field for nested Elixir calls.
 The two language-local repairs are inert and removed.
-Scala field repair and SQL field cleanup remain live counterexamples.
+The Scala field repair and SQL field cleanup remain live counterexamples.
 
 ## Current progress: Erlang native ownership
 

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -228,10 +228,10 @@ It selects the C-equivalent expression for an unknown type name.
 This change retires the final Objective-C subpass and its dispatcher arm.
 The parser covers every byte in each recovered EBNF source.
 This change removes the EBNF dispatcher arm.
-Native field projection owns Dart switch-expression body fields.
-It also owns the target field for nested Elixir calls.
+The native reduction path sets Dart switch-expression body fields.
+It sets the target field for nested Elixir calls.
 The Dart and Elixir dispatcher arms remain live for unrelated repairs.
-Scala and SQL field corrections remain live counterexamples.
+The Scala and SQL field corrections remain live counterexamples.
 The field-aware C-oracle receipt is:
 `harness_out/docker/20260728T111158Z-objc-struct-sized-postfilter-final`.
 The method type C-oracle receipt is:

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -228,6 +228,10 @@ It selects the C-equivalent expression for an unknown type name.
 This change retires the final Objective-C subpass and its dispatcher arm.
 The parser covers every byte in each recovered EBNF source.
 This change removes the EBNF dispatcher arm.
+Native field projection owns Dart switch-expression body fields.
+It also owns the target field for nested Elixir calls.
+The Dart and Elixir dispatcher arms remain live for unrelated repairs.
+Scala and SQL field corrections remain live counterexamples.
 The field-aware C-oracle receipt is:
 `harness_out/docker/20260728T111158Z-objc-struct-sized-postfilter-final`.
 The method type C-oracle receipt is:
@@ -321,6 +325,7 @@ there.
 | D variable-type qualifiers | retirement change | 1 D subpass | 0 | compatibility-free producer, production, compact fallback, forest, incremental reuse, and isolated C-oracle parity |
 | D call-expression targets | retirement commit `6a650454e5698d64a0148629cfa444b3dbce6877` | 2 D subpasses / 1 dispatcher arm | 0 | compatibility-free producer, production, compact fallback, forest, incremental, and three isolated C-oracle receipts |
 | Certified unary named wrappers | retirement change | 1 dispatcher arm | 0 | exact-profile census, compatibility-free producer, production, compact fallback, forest fail-closed behavior, incremental, parent links, deterministic digest, and isolated C-oracle parity |
+| Dart and Elixir inherited fields | retirement change | 2 language-local field repairs | 0 | compatibility-free producer, refreshed corpus, production, compact, forest, incremental, and isolated C-oracle receipts |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry
 receipts stay in the JSON registry and durable run findings stay in Hyphae.

--- a/grammars/field_projection_native_regression_test.go
+++ b/grammars/field_projection_native_regression_test.go
@@ -138,6 +138,18 @@ func fieldProjectionRetirementCases() []fieldProjectionRetirementCase {
 			language: ErlangLanguage(),
 			assert:   assertErlangRootFormFields,
 		},
+		{
+			name:     "dart_switch_expression_body",
+			source:   []byte("int f(Object value) => switch (value) { int n => n, _ => 0 };\n"),
+			language: DartLanguage(),
+			assert:   assertDartSwitchExpressionBodyFields,
+		},
+		{
+			name:     "elixir_nested_call_target",
+			source:   []byte("def unquote(f)(x), do: nil\n"),
+			language: ElixirLanguage(),
+			assert:   assertElixirNestedCallTargetField,
+		},
 	}
 }
 
@@ -222,6 +234,61 @@ func assertErlangRootFormFields(t *testing.T, root *gotreesitter.Node, lang *got
 		if got := root.FieldNameForChild(index, lang); got != want {
 			t.Fatalf("Erlang child %d field = %q, want %q", index, got, want)
 		}
+	}
+}
+
+func assertDartSwitchExpressionBodyFields(t *testing.T, root *gotreesitter.Node, lang *gotreesitter.Language) {
+	t.Helper()
+	switchExpression := findFirstNamedDescendantWhere(
+		root,
+		lang,
+		"switch_expression",
+		func(*gotreesitter.Node) bool { return true },
+	)
+	if switchExpression == nil {
+		t.Fatalf("missing Dart switch expression: %s", root.SExpr(lang))
+	}
+	bodyFields := 0
+	bodyStarted := false
+	for index := 0; index < switchExpression.ChildCount(); index++ {
+		child := switchExpression.Child(index)
+		if child == nil {
+			continue
+		}
+		field := switchExpression.FieldNameForChild(index, lang)
+		if field == "body" {
+			bodyFields++
+			bodyStarted = true
+			continue
+		}
+		if bodyStarted {
+			t.Fatalf("Dart switch child %d field = %q after body start", index, field)
+		}
+	}
+	if bodyFields < 2 {
+		t.Fatalf("Dart switch body field count = %d, want at least 2", bodyFields)
+	}
+}
+
+func assertElixirNestedCallTargetField(t *testing.T, root *gotreesitter.Node, lang *gotreesitter.Language) {
+	t.Helper()
+	nested := findFirstNamedDescendantWhere(
+		root,
+		lang,
+		"call",
+		func(node *gotreesitter.Node) bool {
+			return node.ChildCount() >= 2 &&
+				node.Child(0) != nil &&
+				node.Child(0).Type(lang) == "call" &&
+				node.Child(1) != nil &&
+				node.Child(1).Type(lang) == "arguments"
+		},
+	)
+	if nested == nil {
+		t.Fatalf("missing Elixir nested call: %s", root.SExpr(lang))
+	}
+	if got := nested.FieldNameForChild(0, lang); got != "target" {
+		t.Fatalf("Elixir nested call target field = %q, want target", got)
 	}
 }
 

--- a/parser_result_dart.go
+++ b/parser_result_dart.go
@@ -4,7 +4,6 @@ func normalizeDartCompatibility(root *Node, source []byte, lang *Language) {
 	normalizeDartConstructorSignatureKinds(root, source, lang)
 	normalizeDartSingleTypeArgumentFreeCalls(root, lang)
 	normalizeDartComplexTypeArgumentRelationalFreeCalls(root, lang)
-	normalizeDartSwitchExpressionBodyFields(root, lang)
 	normalizeDartNestedComplexTypeArgumentRelationalCalls(root, lang)
 	normalizeDartComplexTypeArgumentFreeCalls(root, source, lang)
 }
@@ -591,40 +590,6 @@ func dartConstructorCandidateSignature(member *Node, lang *Language) *Node {
 	return nil
 }
 
-func normalizeDartSwitchExpressionBodyFields(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "dart" {
-		return
-	}
-	bodyID, ok := lang.FieldByName("body")
-	if !ok {
-		return
-	}
-	walkResultTree(root, func(n *Node) {
-		if n.Type(lang) == "switch_expression" && len(n.children) > 0 {
-			ensureNodeFieldStorage(n, len(n.children))
-			fieldIDs := n.fieldIDs()
-			fieldSources := n.fieldSources()
-			start := -1
-			for i := 0; i < len(n.children); i++ {
-				if fieldIDs[i] == bodyID {
-					start = i
-					break
-				}
-			}
-			if start >= 0 {
-				for i := start; i < len(n.children); i++ {
-					if n.children[i] == nil {
-						continue
-					}
-					fieldIDs[i] = bodyID
-					if len(fieldSources) == len(n.children) {
-						fieldSources[i] = fieldSourceDirect
-					}
-				}
-			}
-		}
-	})
-}
 func rewriteDartSingleTypeArgumentFreeCall(parent *Node, idx int, lang *Language, relExprSym Symbol, relExprNamed bool, relOpSym Symbol, relOpNamed bool, parenSym Symbol, parenNamed bool) bool {
 	if parent == nil || idx < 0 || idx+1 >= len(parent.children) || lang == nil {
 		return false

--- a/parser_result_elixir.go
+++ b/parser_result_elixir.go
@@ -5,7 +5,6 @@ func normalizeElixirCompatibility(root *Node, source []byte, lang *Language) {
 		return
 	}
 	normalizeElixirNewlineBeforeCommentExtras(root, lang)
-	normalizeElixirNestedCallTargetFields(root, lang)
 	normalizeElixirMapContentKeywordPairs(root, lang)
 	normalizeElixirMapContentBinaryOperators(root, lang)
 }
@@ -55,27 +54,6 @@ func normalizeElixirNewlineBeforeCommentExtras(root *Node, lang *Language) {
 		}
 		if changed {
 			replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, filtered))
-		}
-	})
-}
-
-func normalizeElixirNestedCallTargetFields(root *Node, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "elixir" {
-		return
-	}
-	targetID, ok := lang.FieldByName("target")
-	if !ok {
-		return
-	}
-	walkResultTree(root, func(n *Node) {
-		if n.Type(lang) == "call" && len(n.children) >= 2 {
-			first := n.children[0]
-			second := n.children[1]
-			if first != nil && second != nil &&
-				first.Type(lang) == "call" &&
-				second.Type(lang) == "arguments" {
-				setNodeChildFieldInheritedIfEmpty(n, 0, targetID)
-			}
 		}
 	})
 }

--- a/parser_result_misc_compat_test.go
+++ b/parser_result_misc_compat_test.go
@@ -181,39 +181,3 @@ func TestNormalizeSQLTrailingSelectListErrorFoldsRootRecovery(t *testing.T) {
 		t.Fatalf("expected root, select_statement, and body to retain errors")
 	}
 }
-
-func TestNormalizeElixirNestedCallTargetFields(t *testing.T) {
-	lang := &Language{
-		Name:        "elixir",
-		FieldNames:  []string{"", "target", "existing"},
-		SymbolNames: []string{"EOF", "source", "call", "arguments", "identifier"},
-		SymbolMetadata: []SymbolMetadata{
-			{Name: "EOF", Visible: false, Named: false},
-			{Name: "source", Visible: true, Named: true},
-			{Name: "call", Visible: true, Named: true},
-			{Name: "arguments", Visible: true, Named: true},
-			{Name: "identifier", Visible: true, Named: true},
-		},
-	}
-
-	arena := newNodeArena(arenaClassFull)
-	inner := newLeafNodeInArena(arena, 2, true, 0, 3, Point{}, Point{Column: 3})
-	args := newLeafNodeInArena(arena, 3, true, 3, 5, Point{Column: 3}, Point{Column: 5})
-	outer := newParentNodeInArena(arena, 2, true, []*Node{inner, args}, nil, 0)
-	alreadySetInner := newLeafNodeInArena(arena, 2, true, 6, 9, Point{Column: 6}, Point{Column: 9})
-	alreadySetArgs := newLeafNodeInArena(arena, 3, true, 9, 11, Point{Column: 9}, Point{Column: 11})
-	alreadySet := newParentNodeInArena(arena, 2, true, []*Node{alreadySetInner, alreadySetArgs}, []FieldID{2, 0}, 0)
-	root := newParentNodeInArena(arena, 1, true, []*Node{outer, alreadySet}, nil, 0)
-
-	normalizeElixirNestedCallTargetFields(root, lang)
-
-	if got, want := outer.FieldNameForChild(0, lang), "target"; got != want {
-		t.Fatalf("outer.FieldNameForChild(0) = %q, want %q", got, want)
-	}
-	if got := outer.FieldNameForChild(1, lang); got != "" {
-		t.Fatalf("outer.FieldNameForChild(1) = %q, want empty", got)
-	}
-	if got, want := alreadySet.FieldNameForChild(0, lang), "existing"; got != want {
-		t.Fatalf("alreadySet.FieldNameForChild(0) = %q, want %q", got, want)
-	}
-}


### PR DESCRIPTION
## Summary

- Remove the inert Dart switch-expression body-field repair.
- Remove the inert Elixir nested-call target-field repair.
- Add native route tests and locked C-oracle parity tests.

## Evidence

- Compatibility-free probes visited both field shapes and made zero repairs.
- Refreshed real-corpus probes made zero Dart or Elixir repairs.
- Production, compact, forest, and incremental routes passed for both fixtures.
- Isolated Dart C parity passed.
- Isolated Elixir C parity passed.
- The ownership registry test passed.
- Narrow Canopy parsing passed for every changed Go file.

## Scope

The Dart and Elixir dispatcher arms remain live for unrelated repairs. Scala and SQL field corrections remain live counterexamples.

This change removes production code. It does not change the parser core or its scheduler.