### PR TITLE
improve(parsercorephase0): persist bounded exact predecessor merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ for tags and release notes while still in `0.x`.
   This change removes two inert language-local field repairs.
   The Scala and SQL field corrections remain live.
 
+- Compact graph insertion now persists exact predecessor merges across a
+  bounded 16-level path.
+  Non-exact nested edges and deeper paths still fail closed.
+  Locked C#, Elixir, Perl, and Scala fixtures now reach their next parser gate.
+
 - The compact admission census now separates runnable no-table-action stops
   from paused frontiers.
   The real-corpus matrix labels production error trees.

--- a/admission_recursive_insert_corpus_test.go
+++ b/admission_recursive_insert_corpus_test.go
@@ -1,0 +1,86 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+func TestAdmissionCandidateBoundedRecursiveInsertionCorpus(t *testing.T) {
+	tests := []struct {
+		language   string
+		path       string
+		sha256     string
+		nextReason string
+	}{
+		// tree-sitter-c-sharp@88366631d598, test/highlight/variableDeclarations.cs
+		{
+			language:   "c_sharp",
+			path:       "testdata/admission_direct/recursive_insert/c_sharp.cs",
+			sha256:     "d532120abe52b3af477aa079e33a6998ef6b1a4370cff257277d319cd1912dd1",
+			nextReason: "did not accept EOF",
+		},
+		// tree-sitter-elixir@7937d3b4d65f, test/highlight/module.ex
+		{
+			language:   "elixir",
+			path:       "testdata/admission_direct/recursive_insert/elixir.ex",
+			sha256:     "7977e259f7e718177e568eedbb82ba8df72a149095718f3c563de5ec06db285c",
+			nextReason: "converged-path reduction split drops",
+		},
+		// tree-sitter-perl@ad74e6db234c, test/highlight/statements.pm
+		{
+			language:   "perl",
+			path:       "testdata/admission_direct/recursive_insert/perl.pm",
+			sha256:     "a00caed758e0a58db30454892ef404518228255e34c2e7f2eccc27ffc648f51b",
+			nextReason: "converged-path reduction split drops",
+		},
+		// tree-sitter-scala@97aead18d977, test/tags/basics.scala
+		{
+			language:   "scala",
+			path:       "testdata/admission_direct/recursive_insert/scala.scala",
+			sha256:     "d53a16c04dd1ad917104a5f9ab6bf45c4c779188bafe7044d2fec06217a3b7d9",
+			nextReason: "converged-path reduction split drops",
+		},
+	}
+	entries := make(map[string]grammars.LangEntry)
+	for _, entry := range grammars.AllLanguages() {
+		entries[entry.Name] = entry
+	}
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	for _, test := range tests {
+		t.Run(test.language, func(t *testing.T) {
+			source, err := os.ReadFile(test.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != test.sha256 {
+				t.Fatalf("fixture SHA-256=%s, want %s", got, test.sha256)
+			}
+			entry, ok := entries[test.language]
+			if !ok {
+				t.Fatalf("%s grammar is not registered", test.language)
+			}
+			row := runAdmissionScorecardSource(entry, source)
+			switch row.status {
+			case scorecardPass:
+				return
+			case scorecardFallback:
+				if strings.Contains(row.detail, "recursive insertion") {
+					t.Fatalf("bounded recursive insertion still declined: %s", row.detail)
+				}
+				if !strings.Contains(row.detail, test.nextReason) {
+					t.Fatalf("fallback=%q, want the next blocker %q", row.detail, test.nextReason)
+				}
+			default:
+				t.Fatalf("compact route=%s: %s", row.status, row.detail)
+			}
+		})
+	}
+}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2195,7 +2195,7 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 	if phase0AEnabled {
 		phase0ABeginPredecessorMerge(c, incumbent.prev, in.prev)
 	}
-	merged, changed, mergeErr := c.mergePredecessorsOneLayer(incumbent.prev, in.prev)
+	merged, changed, mergeErr := c.mergePredecessorsBounded(incumbent.prev, in.prev, 0)
 	if mergeErr != nil {
 		if phase0AEnabled {
 			phase0AAbortPredecessorMerge(c)
@@ -2237,7 +2237,15 @@ func (c *Core) factorExactPredecessorMerge(key boundaryKey, probe boundaryProbe,
 	return condenseOutcome{head: Head{Node: id}, change: condenseUpdated}, true, nil
 }
 
-func (c *Core) mergePredecessorsOneLayer(leftID, rightID NodeID) (NodeID, bool, error) {
+// maxRecursiveInsertDepth bounds the persistent counterpart of C's recursive
+// stack-link insertion. Sixteen levels cover the measured clean corpus
+// family while keeping pathological graphs on a small, fixed stack budget.
+const maxRecursiveInsertDepth = 16
+
+func (c *Core) mergePredecessorsBounded(leftID, rightID NodeID, depth int) (NodeID, bool, error) {
+	if depth > maxRecursiveInsertDepth {
+		return 0, false, errors.New("parser-core phase zero: recursive insertion depth limit")
+	}
 	if leftID == rightID {
 		return 0, false, errors.New("parser-core phase zero: recursive insertion self-merge")
 	}
@@ -2273,7 +2281,7 @@ func (c *Core) mergePredecessorsOneLayer(leftID, rightID NodeID) (NodeID, bool, 
 	changed := false
 	for _, incoming := range rightLinks {
 		var inserted bool
-		links, inserted, err = c.insertLinkOneLayer(left.state, left.byteOffset, links, incoming)
+		links, inserted, err = c.insertLinkBounded(left.state, left.byteOffset, links, incoming, depth)
 		if err != nil {
 			return 0, false, err
 		}
@@ -2289,12 +2297,12 @@ func (c *Core) mergePredecessorsOneLayer(leftID, rightID NodeID) (NodeID, bool, 
 	return merged, true, nil
 }
 
-// insertLinkOneLayer mirrors the measured lower-adjacency decisions of
+// insertLinkBounded mirrors the measured lower-adjacency decisions of
 // stack_node_add_link without mutating an existing adjacency. Same-pair
 // shallow payloads select the higher effective subtree precedence; every
-// other clean class remains in stable incumbent-first order. A second
-// different-predecessor merge is outside this tranche and declines.
-func (c *Core) insertLinkOneLayer(state StateID, byteOffset uint32, links []linkRecord, incoming linkRecord) ([]linkRecord, bool, error) {
+// other clean class remains in stable incumbent-first order. Boundary-equal
+// predecessors recurse only when their complete outer edges are exact.
+func (c *Core) insertLinkBounded(state StateID, byteOffset uint32, links []linkRecord, incoming linkRecord, depth int) ([]linkRecord, bool, error) {
 	if len(links) == 0 {
 		return append(slices.Clone(links), incoming), true, nil
 	}
@@ -2367,8 +2375,41 @@ func (c *Core) insertLinkOneLayer(state StateID, byteOffset uint32, links []link
 		if !mergeable {
 			continue
 		}
-		c.recordLinkUnionRejected()
-		return nil, false, errors.New("parser-core phase zero: recursive insertion declined beyond one predecessor layer")
+		if !c.linkEdgesEqual(incumbent, incoming) {
+			c.recordLinkUnionRejected()
+			return nil, false, errors.New("parser-core phase zero: recursive insertion declined non-exact nested edge")
+		}
+		if depth >= maxRecursiveInsertDepth {
+			c.recordLinkUnionRejected()
+			return nil, false, errors.New("parser-core phase zero: recursive insertion depth limit")
+		}
+		if phase0AEnabled {
+			phase0ABeginPredecessorMerge(c, incumbent.prev, incoming.prev)
+		}
+		merged, changed, err := c.mergePredecessorsBounded(incumbent.prev, incoming.prev, depth+1)
+		if err != nil {
+			if phase0AEnabled {
+				phase0AAbortPredecessorMerge(c)
+			}
+			c.recordLinkUnionRejected()
+			return nil, false, err
+		}
+		if !changed {
+			if phase0AEnabled {
+				phase0AAbortPredecessorMerge(c)
+				phase0AMergeDecision(c, index, phase0ATransitionDuplicateDrop)
+			}
+			c.recordLinkUnionDuplicateNoop()
+			return links, false, nil
+		}
+		if phase0AEnabled {
+			phase0AObserveAdjacencyPublished(c, merged)
+			phase0AMergeRecursiveDecision(c, index, merged)
+		}
+		updated := slices.Clone(links)
+		updated[index].prev = merged
+		c.recordLinkUnionRecursiveChanged()
+		return updated, true, nil
 	}
 	if uint32(len(links)) >= c.limits.MaxLinksPerBoundary {
 		c.recordLinkUnionRejected()

--- a/internal/parsercorephase0/phase0a_factor_provenance.go
+++ b/internal/parsercorephase0/phase0a_factor_provenance.go
@@ -682,6 +682,64 @@ func phase0AMergeDecision(core *Core, incumbent int, kind Phase0ATransitionKind)
 	}
 }
 
+func phase0AMergeRecursiveDecision(core *Core, incumbent int, merged NodeID) {
+	phase0AObservers.Lock()
+	defer phase0AObservers.Unlock()
+	observer := phase0AObservers.byCore[core]
+	if observer == nil || !observer.active || observer.failure != nil {
+		return
+	}
+	if len(observer.factor.mergePlans) == 0 {
+		phase0AStickyLocked(observer, &Phase0AError{Kind: Phase0AErrorUnsupportedProof, Namespace: observer.run, Detail: "recursive merge decision has no plan"})
+		return
+	}
+	plan := &observer.factor.mergePlans[len(observer.factor.mergePlans)-1]
+	plan.rightIndex++
+	if plan.rightIndex < 0 || plan.rightIndex >= len(plan.rightIDs) || incumbent < 0 || incumbent >= len(plan.entries) {
+		phase0AStickyLocked(observer, &Phase0AError{Kind: Phase0AErrorUnsupportedProof, Namespace: observer.run, Detail: "recursive merge decision input mismatch"})
+		return
+	}
+	rightExpression, ok := phase0ALiveExpressionLocked(observer, plan.rightIDs[plan.rightIndex])
+	if !ok {
+		return
+	}
+	left := plan.entries[incumbent]
+	if _, ok := phase0ALiveExpressionLocked(observer, left.source); !ok {
+		return
+	}
+	selectorIndex := -1
+	for index := len(observer.factor.selectors) - 1; index >= 0; index-- {
+		selector := observer.factor.selectors[index]
+		if selector.MergedPredecessor == merged && !selector.RolledBack {
+			selectorIndex = index
+			break
+		}
+	}
+	if selectorIndex < 0 {
+		phase0AStickyLocked(observer, &Phase0AError{Kind: Phase0AErrorUnsupportedProof, Namespace: observer.run, Detail: "recursive merge selector is unavailable"})
+		return
+	}
+	if observer.factor.nextExpression == math.MaxUint64 {
+		phase0AStickyLocked(observer, &Phase0AError{Kind: Phase0AErrorCounterOverflow, Namespace: observer.run, Detail: "recursive merge expression serial"})
+		return
+	}
+	if err := phase0AReserveFactorRowsLocked(observer, 0, 1, 0, 0, 0, 0, 0); err != nil {
+		return
+	}
+	selector := observer.factor.selectors[selectorIndex]
+	transaction := phase0ACurrentTransaction(observer)
+	observer.factor.nextExpression++
+	expression := Phase0AExpressionID(observer.factor.nextExpression)
+	observer.factor.expressions = append(observer.factor.expressions, Phase0AExpressionRecord{
+		ID: expression, Kind: Phase0AExpressionFactorChoice, TransactionID: transaction,
+		Selector: selector.ID, Left: left.expression, Right: rightExpression,
+	})
+	plan.entries[incumbent] = phase0AMergeEntry{
+		expression: expression, source: left.source, branch: left.branch,
+		kind: Phase0ATransitionFactorChoice, selector: selector.ID,
+	}
+}
+
 func phase0AAbortPredecessorMerge(core *Core) {
 	phase0AObservers.Lock()
 	defer phase0AObservers.Unlock()

--- a/internal/parsercorephase0/phase0a_factor_provenance_test.go
+++ b/internal/parsercorephase0/phase0a_factor_provenance_test.go
@@ -356,6 +356,54 @@ func TestPhase0AFactorChoiceBindsExactLowerRoutes(t *testing.T) {
 	phase0AObservers.Unlock()
 }
 
+func TestPhase0AFactorChoiceBindsRecursiveLowerRoutes(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 16, MaxPopPaths: 16})
+	run := phase0ABeginShiftProvenanceRun(t, core, Phase0AObserverLimits{
+		MaxCores: 2, MaxRecords: 4096, MaxBytes: 1 << 20, MaxFrames: 32, MaxMutations: 512,
+		MaxOccurrences: 128, MaxOccurrenceBytes: 128 << 10,
+		MaxCandidates: 128, MaxExpressions: 128, MaxBindings: 256, MaxTransitions: 512, MaxSelectors: 32, MaxSelectorRoutes: 128,
+	})
+	rootA, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootB, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftPayload, _ := core.appendSubtree(subtreeRecord{symbol: 20, endByte: 10, terminal: true}, nil, nil, nil)
+	rightPayload, _ := core.appendSubtree(subtreeRecord{symbol: 21, endByte: 10, terminal: true}, nil, nil, nil)
+	wrapper, _ := core.appendSubtree(subtreeRecord{symbol: 30, startByte: 10, endByte: 11, terminal: true}, nil, nil, nil)
+	topPayload, _ := core.appendSubtree(subtreeRecord{symbol: 40, startByte: 11, endByte: 12, terminal: true}, nil, nil, nil)
+	leftLower := phase0AObservedPrivate(t, core, leftPayload, rootA.Node, 7, 10)
+	rightLower := phase0AObservedPrivate(t, core, rightPayload, rootB.Node, 7, 10)
+	leftUpper := phase0AObservedPrivate(t, core, wrapper, leftLower.Node, 8, 11)
+	rightUpper := phase0AObservedPrivate(t, core, wrapper, rightLower.Node, 8, 11)
+	old := phase0AObservedCondense(t, core, topPayload, leftUpper.Node, 9, 12)
+	merged := phase0AObservedCondense(t, core, topPayload, rightUpper.Node, 9, 12)
+	if old.change != condenseNew || merged.change != condenseUpdated || old.head == merged.head {
+		t.Fatalf("recursive factor outcomes old=%+v merged=%+v", old, merged)
+	}
+	proof, err := Phase0AObserverProof(core, run)
+	if err != nil {
+		t.Fatalf("recursive proof=%+v err=%v", proof, err)
+	}
+	factorExpressions := 0
+	for _, expression := range proof.Expressions {
+		if expression.Kind == Phase0AExpressionFactorChoice {
+			factorExpressions++
+		}
+	}
+	if len(proof.Selectors) != 2 || len(proof.SelectorRoutes) != 3 ||
+		proof.Selectors[0].RouteCount != 2 || proof.Selectors[1].RouteCount != 1 ||
+		factorExpressions != 2 {
+		t.Fatalf(
+			"recursive proof selectors=%+v routes=%+v factor expressions=%d expressions=%+v",
+			proof.Selectors, proof.SelectorRoutes, factorExpressions, proof.Expressions,
+		)
+	}
+}
+
 func TestPhase0APhysicalLinkReuseKeepsRollbackTombstone(t *testing.T) {
 	core := newTinyCoreWithLimits(t, Limits{})
 	run := phase0ABeginShiftProvenanceRun(t, core, phase0AShiftProvenanceLimits())

--- a/internal/parsercorephase0/phase0a_observer_off.go
+++ b/internal/parsercorephase0/phase0a_observer_off.go
@@ -88,6 +88,7 @@ func phase0ABeginReplacement(*Core, boundaryKey, linkInput, NodeID, int)        
 func phase0AObserveReplacementPublished(*Core, boundaryKey, linkInput, NodeID, LinkID, int, int)    {}
 func phase0ABeginPredecessorMerge(*Core, NodeID, NodeID)                                            {}
 func phase0AMergeDecision(*Core, int, phase0ATransitionKind)                                        {}
+func phase0AMergeRecursiveDecision(*Core, int, NodeID)                                              {}
 func phase0AAbortPredecessorMerge(*Core)                                                            {}
 func phase0AObserveAdjacencyPublished(*Core, NodeID)                                                {}
 func phase0AObserveFactorNoChange(*Core, boundaryKey, linkInput, NodeID, int)                       {}

--- a/internal/parsercorephase0/recursive_insert_test.go
+++ b/internal/parsercorephase0/recursive_insert_test.go
@@ -368,6 +368,65 @@ func TestRecursiveInsertSamePairPrecedenceAndDistinctClass(t *testing.T) {
 	}
 }
 
+func TestRecursiveInsertPersistsTwoPredecessorLevels(t *testing.T) {
+	core := newTinyCoreWithLimits(t, Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	rootA, err := core.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootB, err := core.Seed(2, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lowerA := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, endByte: 10})
+	lowerB := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 21, endByte: 10})
+	leftLower, err := core.appendAdjacencyNode(7, 10, []linkRecord{{prev: rootA.Node, payload: lowerA}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightLower, err := core.appendAdjacencyNode(7, 10, []linkRecord{{prev: rootB.Node, payload: lowerB}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 30, startByte: 10, endByte: 11})
+	leftUpper, err := core.appendAdjacencyNode(8, 11, []linkRecord{{prev: leftLower, payload: wrapper}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightUpper, err := core.appendAdjacencyNode(8, 11, []linkRecord{{prev: rightLower, payload: wrapper}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	top := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 40, startByte: 11, endByte: 12})
+	key := core.boundaryKey(9, 12)
+	old, err := core.condense(key, linkInput{prev: leftUpper, payload: top})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldPaths, err := core.Derivations(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	merged, err := core.condense(key, linkInput{prev: rightUpper, payload: top})
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := core.Derivations(merged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Derivation{
+		{Payloads: []SubtreeID{lowerA, wrapper, top}},
+		{Payloads: []SubtreeID{lowerB, wrapper, top}},
+	}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("bounded recursive derivations=%#v, want %#v", paths, want)
+	}
+	if got, err := core.Derivations(old); err != nil || !reflect.DeepEqual(got, oldPaths) {
+		t.Fatalf("historical recursive head changed: paths=%#v want=%#v err=%v", got, oldPaths, err)
+	}
+}
+
 func TestRecursiveInsertDeclinesUnsupportedProvenanceAndDepth(t *testing.T) {
 	t.Run("external-top-leaf", func(t *testing.T) {
 		core := newTinyCoreWithLimits(t, Limits{})
@@ -413,23 +472,65 @@ func TestRecursiveInsertDeclinesUnsupportedProvenanceAndDepth(t *testing.T) {
 		}
 	})
 
-	t.Run("second-recursive-layer", func(t *testing.T) {
+	t.Run("non-exact-nested-edge", func(t *testing.T) {
 		core := newTinyCoreWithLimits(t, Limits{})
 		rootA, _ := core.Seed(1, 0)
 		rootBID, _ := core.appendNode(nodeRecord{state: 1, byteOffset: 0, pathCount: 1})
-		lower := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, endByte: 10})
-		left, _ := core.appendAdjacencyNode(7, 10, []linkRecord{{prev: rootA.Node, payload: lower}})
-		right, _ := core.appendAdjacencyNode(7, 10, []linkRecord{{prev: rootBID, payload: lower}})
-		top := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 30, startByte: 10, endByte: 11})
-		key := core.boundaryKey(8, 11)
+		lowerA := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, productionID: 1, endByte: 10})
+		lowerB := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, productionID: 2, endByte: 10})
+		leftLower, _ := core.appendAdjacencyNode(7, 10, []linkRecord{{prev: rootA.Node, payload: lowerA}})
+		rightLower, _ := core.appendAdjacencyNode(7, 10, []linkRecord{{prev: rootBID, payload: lowerB}})
+		wrapper := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 30, startByte: 10, endByte: 11})
+		left, _ := core.appendAdjacencyNode(8, 11, []linkRecord{{prev: leftLower, payload: wrapper}})
+		right, _ := core.appendAdjacencyNode(8, 11, []linkRecord{{prev: rightLower, payload: wrapper}})
+		top := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 40, startByte: 11, endByte: 12})
+		key := core.boundaryKey(9, 12)
 		old, _ := core.condense(key, linkInput{prev: left, payload: top})
 		before, _ := core.Stats(old)
-		if _, err := core.condense(key, linkInput{prev: right, payload: top}); err == nil || !strings.Contains(err.Error(), "beyond one predecessor layer") {
-			t.Fatalf("second-layer error=%v", err)
+		beforeWork := core.Work()
+		if _, err := core.condense(key, linkInput{prev: right, payload: top}); err == nil || !strings.Contains(err.Error(), "non-exact nested edge") {
+			t.Fatalf("non-exact nested edge error=%v", err)
 		}
 		after, _ := core.Stats(old)
-		if after != before {
-			t.Fatalf("second-layer decline mutated storage: before=%+v after=%+v", before, after)
+		if after != before || core.Work() != beforeWork {
+			t.Fatalf("non-exact nested decline mutated storage/work: before=%+v after=%+v work=%+v/%+v", before, after, core.Work(), beforeWork)
+		}
+	})
+
+	t.Run("depth-limit", func(t *testing.T) {
+		core := newTinyCoreWithLimits(t, Limits{})
+		left, _ := core.Seed(1, 0)
+		rightID, _ := core.appendNode(nodeRecord{state: 1, byteOffset: 0, pathCount: 1})
+		right := Head{Node: rightID}
+		for depth := 0; depth <= maxRecursiveInsertDepth; depth++ {
+			offset := uint32(depth + 1)
+			payload := appendShallowPayload(t, core, shallowPayloadSpec{
+				symbol: Symbol(20 + depth), startByte: offset - 1, endByte: offset,
+			})
+			leftID, err := core.appendAdjacencyNode(StateID(10+depth), offset, []linkRecord{{prev: left.Node, payload: payload}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rightID, err := core.appendAdjacencyNode(StateID(10+depth), offset, []linkRecord{{prev: right.Node, payload: payload}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			left, right = Head{Node: leftID}, Head{Node: rightID}
+		}
+		top := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 50, startByte: 17, endByte: 18})
+		key := core.boundaryKey(60, 18)
+		old, err := core.condense(key, linkInput{prev: left.Node, payload: top})
+		if err != nil {
+			t.Fatal(err)
+		}
+		before, _ := core.Stats(old)
+		beforeWork := core.Work()
+		if _, err := core.condense(key, linkInput{prev: right.Node, payload: top}); err == nil || !strings.Contains(err.Error(), "depth limit") {
+			t.Fatalf("recursive depth error=%v", err)
+		}
+		after, _ := core.Stats(old)
+		if after != before || core.Work() != beforeWork {
+			t.Fatalf("recursive depth decline mutated storage/work: before=%+v after=%+v work=%+v/%+v", before, after, core.Work(), beforeWork)
 		}
 	})
 }
@@ -532,13 +633,13 @@ func TestRecursiveInsertCertifiedExternalRollback(t *testing.T) {
 func TestRecursiveInsertDeclinesSelfAndAncestry(t *testing.T) {
 	core := newTinyCoreWithLimits(t, Limits{})
 	seed, _ := core.Seed(1, 0)
-	if _, _, err := core.mergePredecessorsOneLayer(seed.Node, seed.Node); err == nil || !strings.Contains(err.Error(), "self-merge") {
+	if _, _, err := core.mergePredecessorsBounded(seed.Node, seed.Node, 0); err == nil || !strings.Contains(err.Error(), "self-merge") {
 		t.Fatalf("self merge error=%v", err)
 	}
 	payload := appendShallowPayload(t, core, shallowPayloadSpec{symbol: 20, endByte: 1})
 	rightID, _ := core.appendNode(nodeRecord{state: 7, byteOffset: 1, pathCount: 1})
 	leftID, _ := core.appendAdjacencyNode(7, 1, []linkRecord{{prev: rightID, payload: payload}})
-	if _, _, err := core.mergePredecessorsOneLayer(leftID, rightID); err == nil || !strings.Contains(err.Error(), "ancestry-related") {
+	if _, _, err := core.mergePredecessorsBounded(leftID, rightID, 0); err == nil || !strings.Contains(err.Error(), "ancestry-related") {
 		t.Fatalf("ancestry merge error=%v", err)
 	}
 }

--- a/testdata/admission_direct/recursive_insert/c_sharp.cs
+++ b/testdata/admission_direct/recursive_insert/c_sharp.cs
@@ -1,0 +1,25 @@
+class A
+{
+    public void M()
+    {
+        foreach (int i in new[] { 1 })
+        //           ^ variable
+        {
+            int j = i;
+            //  ^ variable
+        }
+
+        var x = from a in sourceA
+        //           ^ variable
+        //                ^ variable
+                join b in sourceB on a.FK equals b.PK
+        //           ^ variable
+        //                ^ variable
+                group a by a.X into g
+        //            ^ variable
+        //                          ^ variable
+                orderby g ascending
+        //              ^ variable
+                select new { A.A, B.B };
+    }
+}

--- a/testdata/admission_direct/recursive_insert/elixir.ex
+++ b/testdata/admission_direct/recursive_insert/elixir.ex
@@ -1,0 +1,319 @@
+defmodule Long.Module.Name do
+# ^ keyword
+#         ^ module
+#             ^ module
+#                          ^ keyword
+
+  @moduledoc "Simple doc"
+  # <- comment.doc
+  # ^ comment.doc.__attribute__
+  #           ^ comment.doc
+
+  @moduledoc false
+  # <- comment.doc
+  # ^ comment.doc.__attribute__
+  #          ^ comment.doc
+
+  @moduledoc """
+  Heredoc doc
+  """
+  # ^ comment.doc
+
+  @moduledoc ~S'''
+  Sigil doc
+  '''
+  # ^ comment.doc
+
+  @moduledoc "With #{1} interpolation"
+  #                ^ punctuation.special
+  #                  ^ number
+  #                   ^ punctuation.special
+
+  @typedoc "Type doc"
+  # <- comment.doc
+
+  @doc "Type doc"
+  # <- comment.doc
+
+  @doc """
+  Multiline docstring
+  "with quotes"
+  and #{ inspect %{"interpolation" => "in" <> "action"} }
+  now with #{ {:a, 'tuple'} }
+  and #{ inspect {
+    :tuple,
+    %{ with: "nested #{ inspect %{ :interpolation => %{} } }" }
+  } }
+  """
+  # <- comment.doc
+
+  @spec func(type, integer()) :: :ok | :fail
+  # <- attribute
+  # ^ attribute
+  #     ^ function
+  #         ^ punctuation.bracket
+  #          ^ variable
+  #              ^ punctuation.delimiter
+  #                ^ function
+  #                       ^ punctuation.bracket
+  #                        ^ punctuation.bracket
+  #                         ^ punctuation.bracket
+  #                           ^ operator
+  #                              ^ string.special.symbol
+  #                                  ^ operator
+  #                                    ^ string.special.symbol
+
+  defstruct items: []
+  # ^ keyword
+  #         ^ string.special.symbol
+  #                ^ punctuation.bracket
+  #                 ^ punctuation.bracket
+
+  defexception [:message]
+  # ^ keyword
+  #            ^ punctuation.bracket
+  #             ^ string.special.symbol
+  #                     ^ punctuation.bracket
+
+  @type item :: String.t()
+  # <- attribute
+  # ^ attribute
+  #     ^ variable
+  #          ^ operator
+  #             ^ module
+  #                   ^ operator
+  #                    ^ function
+  #                     ^ punctuation.bracket
+  #                      ^ punctuation.bracket
+
+  @attr "value"
+  # <- attribute
+  # ^ attribute
+  #     ^ string
+
+  @true
+  # ^ attribute
+
+  @nil
+  # ^ attribute
+
+  def f, do: nil
+  # ^ keyword
+  #   ^ function
+  #    ^ punctuation.delimiter
+  #      ^ string.special.symbol
+  #          ^ constant
+
+  def f(x), do: x
+  # ^ keyword
+  #   ^ function
+  #    ^ punctuation.bracket
+  #     ^ variable
+  #      ^ punctuation.bracket
+  #       ^ punctuation.delimiter
+  #         ^ string.special.symbol
+  #             ^ variable
+
+  def f(10), do: nil
+  # ^ keyword
+  #   ^ function
+  #    ^ punctuation.bracket
+  #       ^ punctuation.bracket
+  #        ^ punctuation.delimiter
+  #          ^ string.special.symbol
+  #              ^ constant
+
+  def f(a, b \\ []), do: nil
+  # <- keyword
+  #   ^ function
+  #    ^ punctuation.bracket
+  #     ^ variable
+  #      ^ punctuation.delimiter
+  #        ^ variable
+  #          ^ operator
+  #             ^ punctuation.bracket
+  #               ^ punctuation.bracket
+  #                ^ punctuation.delimiter
+  #                  ^ string.special.symbol
+  #                      ^ constant
+
+  def __before_compile__(_) do
+  # <- keyword
+  #   ^ function
+  #                     ^ punctuation.bracket
+  #                      ^ comment.unused
+  #                       ^ punctuation.bracket
+  #                         ^ keyword
+  end
+  # <- keyword
+
+  def with_guard(x) when x == 1, do: nil
+  # <- keyword
+  #   ^ function
+  #              ^ variable
+  #                 ^ keyword
+  #                      ^ variable
+  #                        ^ operator
+  #                           ^ number
+  #                              ^ string.special.symbol
+  # <- keyword
+
+  def with_guard when is_integer(1), do: nil
+  # <- keyword
+  #   ^ function
+  #              ^ keyword
+  #                   ^ function
+  #                             ^ punctuation.bracket
+  #                              ^ number
+  #                               ^ punctuation.bracket
+  #                                ^ punctuation.delimiter
+  #                                  ^ string.special.symbol
+  #                                       ^ constant
+
+  def x + y, do: nil
+  # ^ keyword
+  #   ^ variable
+  #     ^ operator
+  #       ^ variable
+  #        ^ punctuation.delimiter
+  #          ^ string.special.symbol
+  #              ^ constant
+
+  def x |> y, do: nil
+  # ^ keyword
+  #   ^ variable
+  #     ^ operator
+  #        ^ variable
+  #         ^ punctuation.delimiter
+  #           ^ string.special.symbol
+  #               ^ constant
+
+  def x and y, do: nil
+  # ^ keyword
+  #   ^ variable
+  #     ^ keyword
+  #         ^ variable
+  #          ^ punctuation.delimiter
+  #            ^ string.special.symbol
+  #                ^ constant
+
+  def unquote(f)(x), do: nil
+  # ^ keyword
+  #   ^ keyword
+  #          ^ punctuation.bracket
+  #           ^ variable
+  #            ^ punctuation.bracket
+  #             ^ punctuation.bracket
+  #              ^ variable
+  #               ^ punctuation.bracket
+  #                ^ punctuation.delimiter
+  #                  ^ string.special.symbol
+  #                      ^ constant
+
+  def unquote(name)(unquote_splicing(args)), do: nil
+  # ^ keyword
+  #   ^ keyword
+  #          ^ punctuation.bracket
+  #           ^ variable
+  #               ^ punctuation.bracket
+  #                ^ punctuation.bracket
+  #                 ^ keyword
+  #                                 ^ punctuation.bracket
+  #                                  ^ variable
+  #                                      ^ punctuation.bracket
+  #                                       ^ punctuation.bracket
+  #                                          ^ string.special.symbol
+  #                                              ^ constant
+
+  def(test(x), do: x)
+  # ^ keyword
+  #  ^ punctuation.bracket
+  #       ^ punctuation.bracket
+  #        ^ variable
+  #         ^ punctuation.bracket
+  #          ^ punctuation.delimiter
+  #            ^ string.special.symbol
+  #                ^ variable
+  #                 ^ punctuation.bracket
+
+  defguard is_something(one), do: one != nil
+  # ^ keyword
+  #        ^ function
+  #                    ^ punctuation.bracket
+  #                     ^ variable
+  #                        ^ punctuation.bracket
+  #                         ^ punctuation.delimiter
+  #                           ^ string.special.symbol
+  #                               ^ variable
+  #                                   ^ operator
+  #                                      ^ constant
+
+  defdelegate empty?(list), to: Enum
+  # ^ keyword
+  #           ^ function
+  #                 ^ punctuation.bracket
+  #                  ^ variable
+  #                      ^ punctuation.bracket
+  #                       ^ punctuation.delimiter
+  #                         ^ string.special.symbol
+  #                             ^ module
+
+  defmacro meta_function(name) do
+  # ^ keyword
+  #        ^ function
+  #                     ^ punctuation.bracket
+  #                      ^ variable
+  #                          ^ punctuation.bracket
+  #                            ^ keyword
+    quote do
+    # ^ keyword
+    #     ^ keyword
+      def unquote(:"#{name}_foo")() do
+      # ^ keyword
+      #   ^ keyword
+      #          ^ punctuation.bracket
+      #           ^ string.special.symbol
+      #             ^ punctuation.special
+      #               ^ variable
+      #                   ^ punctuation.special
+      #                    ^ string.special.symbol
+      #                         ^ punctuation.bracket
+      #                          ^ punctuation.bracket
+      #                           ^ punctuation.bracket
+      #                             ^ keyword
+        unquote("yessir")
+        # ^ keyword
+        #      ^ punctuation.bracket
+        #       ^ string
+        #               ^ punctuation.bracket
+      end
+      # <- keyword
+    end
+    # <- keyword
+  end
+  # <- keyword
+end
+# <- keyword
+
+defprotocol Useless do
+# ^ keyword
+#           ^ module
+#                   ^ keyword
+  def func(this)
+  # ^ keyword
+  #   ^ function
+  #       ^ punctuation.bracket
+  #        ^ variable
+  #            ^ punctuation.bracket
+end
+# <- keyword
+
+defimpl Useless, for: Atom do
+# ^ keyword
+#       ^ module
+#              ^ punctuation.delimiter
+#                ^ string.special.symbol
+#                     ^ module
+#                           ^ keyword
+end
+# <- keyword

--- a/testdata/admission_direct/recursive_insert/perl.pm
+++ b/testdata/admission_direct/recursive_insert/perl.pm
@@ -1,0 +1,125 @@
+use 5.014;
+# <- include
+#   ^ number
+use v5.14;
+# <- include
+#   ^ number
+use v5;
+# <- include
+#   ^ number
+use strict;
+# <- include
+#   ^ type
+use List::Util 1.23;
+# <- include
+#   ^^^^^^^^^^ type
+#              ^ number
+123 if 45;
+#   ^ conditional
+123 unless 45;
+#   ^ conditional
+123 while 45;
+#   ^ repeat
+123 until 45;
+#   ^ repeat
+123 for 45;
+#   ^ repeat
+123 foreach 45;
+#   ^ repeat
+if(1) { 123; } elsif(2) { 456; } else { 789; }
+# <- conditional
+#              ^ conditional
+#                                ^ conditional
+unless(1) { 123; }
+# <- conditional
+while(1) { 123; }
+# <- repeat
+until(1) { 123; }
+# <- repeat
+for (1, 2, 3) { 456; }
+# <- repeat
+foreach (1, 2, 3) { 456; }
+# <- repeat
+for $V (1, 2, 3) { 456; }
+# <- repeat
+#   ^ variable.scalar
+foreach $V (1, 2, 3) { 456; }
+# <- repeat
+#       ^ variable.scalar
+for my $x (1, 2, 3) { 456; }
+# <- repeat
+#   ^ keyword
+#      ^ variable.scalar
+foreach my $x (1, 2, 3) { 456; }
+# <- repeat
+#       ^ keyword
+#          ^ variable.scalar
+for (my $i = 0; $i < 10; $i++) { 123; }
+# <- repeat
+#    ^ keyword
+#       ^ variable.scalar
+#               ^ variable.scalar
+#                        ^ variable.scalar
+use feature 'try';
+try { A(); } catch($e) { B(); }
+# <- exception
+#            ^^^^^ exception
+#                  ^^ variable.scalar
+try { A(); } catch($e) { B(); } finally { C(); }
+#                               ^^^^^^^ exception
+use feature 'defer';
+defer { A(); }
+# <- keyword
+package AAA;
+# <- include
+#       ^ type
+package BBB 1.23;
+# <- include
+#       ^ type
+#           ^ number
+package CCC { }
+# <- include
+#       ^ type
+package DDD 4.56 { }
+# <- include
+#       ^ type
+#           ^ number
+FOO: 123;
+# <- label
+#    ^^^ number
+LOOP: foreach(@list) {
+# <- label
+#     ^ repeat
+   next LOOP;
+#  ^ keyword
+#       ^ label
+}
+ITEM: while(@items) {
+# <- label
+#     ^ repeat
+   last ITEM;
+#  ^ keyword
+#       ^ label
+}
+goto FOO;
+# <- keyword
+#    ^ label
+BEGIN { 123; }
+# <- keyword.phaser
+#       ^ number
+END { 456; }
+# <- keyword.phaser
+#     ^ number
+use feature 'class';
+class Example {
+# <- include
+  field $x = 123;
+# ^^^^^ keyword
+#       ^^ variable.scalar
+  ADJUST { $x++; }
+# ^^^^^^ keyword.phaser
+#          ^^ variable.scalar
+  method y { 456; }
+# ^^^^^^ keyword.function
+#        ^ method
+}

--- a/testdata/admission_direct/recursive_insert/scala.scala
+++ b/testdata/admission_direct/recursive_insert/scala.scala
@@ -1,0 +1,44 @@
+package com.example
+//      ^definition.module
+
+enum Color:
+//   ^definition.enum
+  case Red
+  //   ^definition.class
+  case Green
+  //   ^definition.class
+  case Yellow
+  //   ^definition.class
+
+trait Fruit:
+//    ^definition.interface
+  val color: Color
+//    ^definition.variable
+
+object Fruit:
+//     ^definition.object
+  case object Banana extends Fruit {
+  //          ^definition.object
+  //                         ^reference.class
+    val color = Color.Yellow
+    //  ^definition.variable
+  }
+  case class Apple(c: Color.Red | Color.Green) extends Fruit {
+  //         ^definition.class
+  //               ^definition.property
+  //                                                   ^reference.class
+    val color = c
+  //    ^definition.variable
+  }
+
+  given show: Show[Fruit] = new Show[Fruit] {  }
+  //    ^definition.variable
+  //                            ^reference.interface
+
+  def color(fruit: Fruit): String = ???
+  //  ^definition.function
+
+  var flag: Boolean = true
+  //  ^definition.variable
+
+


### PR DESCRIPTION
## Summary

- Persist exact predecessor merges through at most 16 recursive levels.
- Decline non-exact nested edges and deeper graphs before publication.
- Record nested Phase Zero A (Phase 0A) factor choices.
- Lock four corpus witnesses by source hash.

## Result

The four witnesses no longer stop on the recursive insertion gap.
C# now reaches the end-of-file acceptance gate.
Elixir, Perl, and Scala now reach the joined reduction-path proof.
This change does not alter that proof.

## Validation

- Focused core tests passed with the default and Phase 0A builds.
- Exact Docker fixture tests passed for C#, Elixir, Perl, and Scala.
- Elixir isolated parity reached 25 of 25 exact matches.
- Scala isolated parity passed with its known generated baseline gaps.
- Pinned full parse time stayed statistically unchanged.
- Pinned incremental parse time improved by 2.71 percent.
- Pinned no-edit time improved by 7.14 percent.
- Full parse allocations stayed at 13 allocations per operation.
- Maximum resident set size changed from 558,560 KiB to 555,200 KiB.
