### PR TITLE
Add explicit grammar.js CLI import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Added
+
+- `grammargen -js-cli` now resolves `grammar.js` with Tree-sitter 0.26 or newer.
+  It imports the temporary canonical `grammar.json` through the existing path.
+  The explicit flag warns that grammar evaluation executes JavaScript.
+
 ### Performance
 
 - The fresh compact runner now reuses its scheduler storage across parses.

--- a/cmd/grammargen/commands.go
+++ b/cmd/grammargen/commands.go
@@ -15,6 +15,7 @@ import (
 
 type sourceFlags struct {
 	jsInput     string
+	jsCLIInput  string
 	jsonInput   string
 	grammarFile string
 	lrSplit     bool
@@ -112,6 +113,7 @@ func runEmitCommand(args []string) {
 
 func registerSourceFlags(fs *flag.FlagSet, src *sourceFlags) {
 	fs.StringVar(&src.jsInput, "js", "", "path to a tree-sitter grammar.js file to import")
+	fs.StringVar(&src.jsCLIInput, "js-cli", "", "path to grammar.js to resolve with tree-sitter CLI (executes arbitrary JavaScript)")
 	fs.StringVar(&src.jsonInput, "json", "", "path to a resolved tree-sitter grammar.json file to import")
 	fs.StringVar(&src.grammarFile, "grammar", "", "path to a .grammar file to parse")
 	fs.BoolVar(&src.lrSplit, "lr-split", false, "enable LR(1) state splitting before generation")
@@ -134,6 +136,7 @@ func registerParseOptionFlags(fs *flag.FlagSet, opts *parseOptions) {
 func loadCommandGrammar(src sourceFlags) (*grammargen.Grammar, string) {
 	cfg := cliConfig{
 		jsInput:     src.jsInput,
+		jsCLIInput:  src.jsCLIInput,
 		jsonInput:   src.jsonInput,
 		grammarFile: src.grammarFile,
 		lrSplit:     src.lrSplit,
@@ -737,6 +740,8 @@ func sourceSpecifier(name string, src sourceFlags) string {
 		return "-grammar " + commandArg(src.grammarFile)
 	case src.jsonInput != "":
 		return "-json " + commandArg(src.jsonInput)
+	case src.jsCLIInput != "":
+		return "-js-cli " + commandArg(src.jsCLIInput)
 	case src.jsInput != "":
 		return "-js " + commandArg(src.jsInput)
 	case name != "":
@@ -794,6 +799,7 @@ func normalizeSubcommandArgs(args []string) []string {
 		"func":         true,
 		"go":           true,
 		"js":           true,
+		"js-cli":       true,
 		"json":         true,
 		"json-out":     true,
 		"grammar":      true,

--- a/cmd/grammargen/commands_test.go
+++ b/cmd/grammargen/commands_test.go
@@ -28,6 +28,7 @@ func TestNormalizeSubcommandArgsHandlesAuthoringValueFlags(t *testing.T) {
 		"-expect", "want.sexpr",
 		"-write-expect", "got.sexpr",
 		"-json-out", "grammar.json",
+		"-js-cli", "grammar.js",
 		"-conflicts", "2",
 	})
 	want := []string{
@@ -35,6 +36,7 @@ func TestNormalizeSubcommandArgsHandlesAuthoringValueFlags(t *testing.T) {
 		"-expect", "want.sexpr",
 		"-write-expect", "got.sexpr",
 		"-json-out", "grammar.json",
+		"-js-cli", "grammar.js",
 		"-conflicts", "2",
 		"calc",
 	}

--- a/cmd/grammargen/grammar_js_cli.go
+++ b/cmd/grammargen/grammar_js_cli.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/odvcencio/gotreesitter/grammargen"
+)
+
+const minimumTreeSitterCLIMinor = 26
+
+func importGrammarJSWithCLI(path, executable string) (*grammargen.Grammar, error) {
+	cli, err := exec.LookPath(executable)
+	if err != nil {
+		return nil, fmt.Errorf("find tree-sitter CLI: %w", err)
+	}
+	if err := requireTreeSitterCLIVersion(cli); err != nil {
+		return nil, err
+	}
+	if err := requireTreeSitterCLICapabilities(cli); err != nil {
+		return nil, err
+	}
+
+	grammarPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve grammar.js path: %w", err)
+	}
+	if info, err := os.Stat(grammarPath); err != nil {
+		return nil, fmt.Errorf("read grammar.js: %w", err)
+	} else if info.IsDir() {
+		return nil, fmt.Errorf("read grammar.js: %s is a directory", grammarPath)
+	}
+
+	outputDir, err := os.MkdirTemp("", "gotreesitter-grammar-js-")
+	if err != nil {
+		return nil, fmt.Errorf("create grammar.json output directory: %w", err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	cmd := exec.Command(cli,
+		"generate",
+		"--no-parser",
+		"--output", outputDir,
+		filepath.Base(grammarPath),
+	)
+	cmd.Dir = filepath.Dir(grammarPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, commandError("tree-sitter generate", err, output)
+	}
+
+	jsonPath := filepath.Join(outputDir, "grammar.json")
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		return nil, fmt.Errorf("read generated grammar.json: %w", err)
+	}
+	g, err := grammargen.ImportGrammarJSON(data)
+	if err != nil {
+		return nil, fmt.Errorf("import generated grammar.json: %w", err)
+	}
+	return g, nil
+}
+
+func requireTreeSitterCLICapabilities(cli string) error {
+	output, err := exec.Command(cli, "generate", "--help").CombinedOutput()
+	if err != nil {
+		return commandError("tree-sitter generate --help", err, output)
+	}
+	var missing []string
+	for _, flag := range []string{"--no-parser", "--output"} {
+		if !strings.Contains(string(output), flag) {
+			missing = append(missing, flag)
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf(
+			"tree-sitter CLI lacks required generate flags for -js-cli: %s",
+			strings.Join(missing, ", "),
+		)
+	}
+	return nil
+}
+
+func requireTreeSitterCLIVersion(cli string) error {
+	output, err := exec.Command(cli, "--version").CombinedOutput()
+	if err != nil {
+		return commandError("tree-sitter --version", err, output)
+	}
+	major, minor, err := parseTreeSitterCLIVersion(string(output))
+	if err != nil {
+		return err
+	}
+	if major == 0 && minor < minimumTreeSitterCLIMinor {
+		return fmt.Errorf(
+			"tree-sitter CLI 0.%d or newer is required for -js-cli; found %d.%d",
+			minimumTreeSitterCLIMinor,
+			major,
+			minor,
+		)
+	}
+	return nil
+}
+
+func parseTreeSitterCLIVersion(output string) (int, int, error) {
+	for _, field := range strings.Fields(output) {
+		version := strings.TrimPrefix(field, "v")
+		parts := strings.Split(version, ".")
+		if len(parts) < 2 {
+			continue
+		}
+		major, majorErr := strconv.Atoi(parts[0])
+		minor, minorErr := strconv.Atoi(parts[1])
+		if majorErr == nil && minorErr == nil {
+			return major, minor, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("parse tree-sitter CLI version from %q", strings.TrimSpace(output))
+}
+
+func commandError(operation string, err error, output []byte) error {
+	message := strings.TrimSpace(string(output))
+	if message == "" {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+	return fmt.Errorf("%s: %w: %s", operation, err, message)
+}

--- a/cmd/grammargen/grammar_js_cli_test.go
+++ b/cmd/grammargen/grammar_js_cli_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const fakeGeneratedGrammarJSON = `{
+  "name": "cli_test",
+  "rules": {
+    "source_file": {"type": "STRING", "value": "ok"}
+  },
+  "extras": [],
+  "conflicts": [],
+  "externals": [
+    {"type": "SYMBOL", "name": "indent"}
+  ],
+  "inline": [],
+  "supertypes": []
+}`
+
+func TestParseTreeSitterCLIVersion(t *testing.T) {
+	tests := []struct {
+		output string
+		major  int
+		minor  int
+	}{
+		{output: "tree-sitter 0.26.6\n", major: 0, minor: 26},
+		{output: "tree-sitter v1.2.0", major: 1, minor: 2},
+	}
+	for _, test := range tests {
+		major, minor, err := parseTreeSitterCLIVersion(test.output)
+		if err != nil {
+			t.Fatalf("parseTreeSitterCLIVersion(%q): %v", test.output, err)
+		}
+		if major != test.major || minor != test.minor {
+			t.Fatalf(
+				"parseTreeSitterCLIVersion(%q) = %d.%d, want %d.%d",
+				test.output,
+				major,
+				minor,
+				test.major,
+				test.minor,
+			)
+		}
+	}
+}
+
+func TestImportGrammarJSWithCLIUsesCanonicalJSON(t *testing.T) {
+	tmp := t.TempDir()
+	grammarPath := filepath.Join(tmp, "grammar.js")
+	if err := os.WriteFile(grammarPath, []byte("module.exports = grammar({});\n"), 0o644); err != nil {
+		t.Fatalf("write grammar.js: %v", err)
+	}
+	argsPath := filepath.Join(tmp, "args")
+	dirPath := filepath.Join(tmp, "dir")
+	outputPath := filepath.Join(tmp, "output")
+	t.Setenv("FAKE_ARGS_PATH", argsPath)
+	t.Setenv("FAKE_DIR_PATH", dirPath)
+	t.Setenv("FAKE_OUTPUT_PATH", outputPath)
+
+	cli := writeFakeTreeSitterCLI(t, tmp, "0.26.6", fakeGeneratedGrammarJSON, 0)
+	g, err := importGrammarJSWithCLI(grammarPath, cli)
+	if err != nil {
+		t.Fatalf("importGrammarJSWithCLI: %v", err)
+	}
+	if g.Name != "cli_test" {
+		t.Fatalf("grammar name = %q, want cli_test", g.Name)
+	}
+	if len(g.Externals) != 1 || g.Externals[0].Value != "indent" {
+		t.Fatalf("external tokens = %#v, want indent", g.Externals)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read fake arguments: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(args)), "\n")
+	wantPrefix := []string{"generate", "--no-parser", "--output"}
+	if len(lines) != 5 || !reflect.DeepEqual(lines[:3], wantPrefix) || lines[4] != "grammar.js" {
+		t.Fatalf("tree-sitter arguments = %#v", lines)
+	}
+	if dir, err := os.ReadFile(dirPath); err != nil {
+		t.Fatalf("read fake working directory: %v", err)
+	} else if strings.TrimSpace(string(dir)) != tmp {
+		t.Fatalf("tree-sitter directory = %q, want %q", strings.TrimSpace(string(dir)), tmp)
+	}
+	if output, err := os.ReadFile(outputPath); err != nil {
+		t.Fatalf("read fake output directory: %v", err)
+	} else {
+		outputDir := strings.TrimSpace(string(output))
+		if lines[3] != outputDir {
+			t.Fatalf("argument output = %q, recorded output = %q", lines[3], outputDir)
+		}
+		if _, err := os.Stat(outputDir); !os.IsNotExist(err) {
+			t.Fatalf("temporary output still exists: %v", err)
+		}
+	}
+}
+
+func TestImportGrammarJSWithCLIRejectsOldVersion(t *testing.T) {
+	tmp := t.TempDir()
+	grammarPath := filepath.Join(tmp, "grammar.js")
+	if err := os.WriteFile(grammarPath, []byte("module.exports = grammar({});\n"), 0o644); err != nil {
+		t.Fatalf("write grammar.js: %v", err)
+	}
+	cli := writeFakeTreeSitterCLI(t, tmp, "0.25.10", fakeGeneratedGrammarJSON, 0)
+	_, err := importGrammarJSWithCLI(grammarPath, cli)
+	if err == nil || !strings.Contains(err.Error(), "0.26 or newer") {
+		t.Fatalf("error = %v, want minimum version error", err)
+	}
+}
+
+func TestImportGrammarJSWithCLIReportsGenerateFailure(t *testing.T) {
+	tmp := t.TempDir()
+	grammarPath := filepath.Join(tmp, "grammar.js")
+	if err := os.WriteFile(grammarPath, []byte("module.exports = grammar({});\n"), 0o644); err != nil {
+		t.Fatalf("write grammar.js: %v", err)
+	}
+	cli := writeFakeTreeSitterCLI(t, tmp, "0.26.6", "", 7)
+	_, err := importGrammarJSWithCLI(grammarPath, cli)
+	if err == nil || !strings.Contains(err.Error(), "tree-sitter generate") ||
+		!strings.Contains(err.Error(), "fake generation failed") {
+		t.Fatalf("error = %v, want generation output", err)
+	}
+}
+
+func TestImportGrammarJSWithCLIRejectsMissingCapability(t *testing.T) {
+	tmp := t.TempDir()
+	grammarPath := filepath.Join(tmp, "grammar.js")
+	if err := os.WriteFile(grammarPath, []byte("module.exports = grammar({});\n"), 0o644); err != nil {
+		t.Fatalf("write grammar.js: %v", err)
+	}
+	cli := writeFakeTreeSitterCLI(t, tmp, "0.26.6", fakeGeneratedGrammarJSON, 0)
+	t.Setenv("FAKE_GENERATE_HELP", "--no-parser")
+	_, err := importGrammarJSWithCLI(grammarPath, cli)
+	if err == nil || !strings.Contains(err.Error(), "lacks required generate flags") ||
+		!strings.Contains(err.Error(), "--output") {
+		t.Fatalf("error = %v, want missing --output error", err)
+	}
+}
+
+func writeFakeTreeSitterCLI(t *testing.T, dir, version, grammarJSON string, generateStatus int) string {
+	t.Helper()
+	path := filepath.Join(dir, "tree-sitter")
+	script := `#!/bin/sh
+set -eu
+if test "$1" = "--version"; then
+  printf 'tree-sitter %s\n' "$FAKE_VERSION"
+  exit 0
+fi
+if test "$1" = "generate" && test "$2" = "--help"; then
+  printf '%s\n' "$FAKE_GENERATE_HELP"
+  exit 0
+fi
+printf '%s\n' "$@" > "${FAKE_ARGS_PATH:-/dev/null}"
+printf '%s\n' "$PWD" > "${FAKE_DIR_PATH:-/dev/null}"
+if test "$FAKE_GENERATE_STATUS" != "0"; then
+  printf 'fake generation failed\n' >&2
+  exit "$FAKE_GENERATE_STATUS"
+fi
+output=
+while test "$#" -gt 0; do
+  if test "$1" = "--output"; then
+    output=$2
+    break
+  fi
+  shift
+done
+test -n "$output"
+printf '%s\n' "$output" > "${FAKE_OUTPUT_PATH:-/dev/null}"
+mkdir -p "$output"
+printf '%s' "$FAKE_GRAMMAR_JSON" > "$output/grammar.json"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tree-sitter CLI: %v", err)
+	}
+	t.Setenv("FAKE_VERSION", version)
+	t.Setenv("FAKE_GENERATE_HELP", "--no-parser\n--output")
+	t.Setenv("FAKE_GRAMMAR_JSON", grammarJSON)
+	t.Setenv("FAKE_GENERATE_STATUS", strconv.Itoa(generateStatus))
+	return path
+}

--- a/cmd/grammargen/main.go
+++ b/cmd/grammargen/main.go
@@ -8,6 +8,7 @@
 //
 //	<name>          Built-in grammar (json, calc, glr, go, js, ts, tsx, fortran, etc.)
 //	-js <path>      Import a tree-sitter grammar.js file
+//	-js-cli <path>  Resolve grammar.js with tree-sitter, then import grammar.json
 //	-json <path>    Import a resolved tree-sitter grammar.json file
 //	-grammar <path> Parse a portable .grammar file
 //
@@ -68,6 +69,7 @@ type cliConfig struct {
 	cOut        string
 	goOut       string
 	jsInput     string
+	jsCLIInput  string
 	jsonInput   string
 	grammarFile string
 	pkgName     string
@@ -119,6 +121,7 @@ func parseCLIConfig() cliConfig {
 	flag.StringVar(&cfg.cOut, "c", "", "output path for tree-sitter parser.c")
 	flag.StringVar(&cfg.goOut, "go", "", "output path for grammargen Go DSL source")
 	flag.StringVar(&cfg.jsInput, "js", "", "path to a tree-sitter grammar.js file to import")
+	flag.StringVar(&cfg.jsCLIInput, "js-cli", "", "path to grammar.js to resolve with tree-sitter CLI (executes arbitrary JavaScript)")
 	flag.StringVar(&cfg.jsonInput, "json", "", "path to a resolved tree-sitter grammar.json file to import")
 	flag.StringVar(&cfg.grammarFile, "grammar", "", "path to a .grammar file to parse")
 	flag.StringVar(&cfg.pkgName, "pkg", "grammargen", "package name for -go output")
@@ -142,10 +145,16 @@ func runListMode() {
 
 func loadGrammar(cfg cliConfig) (*grammargen.Grammar, string) {
 	switch {
-	case cfg.jsInput != "" && cfg.jsonInput != "":
-		exitf("use only one of -js or -json")
+	case countImportInputs(cfg) > 1:
+		exitf("use only one of -js, -js-cli, or -json")
 	case cfg.jsonInput != "":
 		return loadImportedGrammar(cfg.jsonInput, grammargen.ImportGrammarJSON)
+	case cfg.jsCLIInput != "":
+		g, err := importGrammarJSWithCLI(cfg.jsCLIInput, "tree-sitter")
+		if err != nil {
+			exitf("import %s: %v", cfg.jsCLIInput, err)
+		}
+		return g, grammarDisplayName(g, cfg.jsCLIInput)
 	case cfg.jsInput != "":
 		return loadImportedGrammar(cfg.jsInput, grammargen.ImportGrammarJS)
 	case cfg.grammarFile != "":
@@ -154,6 +163,16 @@ func loadGrammar(cfg cliConfig) (*grammargen.Grammar, string) {
 		return loadBuiltinGrammar(cfg.args)
 	}
 	return nil, ""
+}
+
+func countImportInputs(cfg cliConfig) int {
+	count := 0
+	for _, input := range []string{cfg.jsInput, cfg.jsCLIInput, cfg.jsonInput} {
+		if input != "" {
+			count++
+		}
+	}
+	return count
 }
 
 func loadImportedGrammar(path string, importGrammar func([]byte) (*grammargen.Grammar, error)) (*grammargen.Grammar, string) {
@@ -307,6 +326,7 @@ func writeCOutput(path string, g *grammargen.Grammar) {
 func printUsageError() {
 	fmt.Fprintln(os.Stderr, "usage: grammargen [flags] <grammar-name>")
 	fmt.Fprintln(os.Stderr, "       grammargen -js <grammar.js> [flags]")
+	fmt.Fprintln(os.Stderr, "       grammargen -js-cli <grammar.js> [flags]")
 	fmt.Fprintln(os.Stderr, "       grammargen -json <grammar.json> [flags]")
 	fmt.Fprintln(os.Stderr, "       grammargen -grammar <file.grammar> [flags]")
 	fmt.Fprintln(os.Stderr, "       grammargen emit [flags] <grammar-name>")

--- a/docs/authoring-languages.md
+++ b/docs/authoring-languages.md
@@ -19,7 +19,9 @@ inside this repo's 200+ embedded set. You do not need it.
 ## The pipeline
 
 ```
-grammar.json ──ImportGrammarJSON──▶ *grammargen.Grammar (IR)
+grammar.js ──grammargen -js-cli──▶ temporary grammar.json
+                                      │
+grammar.json ──ImportGrammarJSON──────┴──▶ *grammargen.Grammar (IR)
                                           │
                               GenerateLanguageAndBlob
                                           │
@@ -65,7 +67,34 @@ if err != nil {
 }
 ```
 
-### Option B: write the Go DSL directly
+### Option B: resolve grammar.js with Tree-sitter
+
+Use `-js-cli` when the repository does not contain a resolved `grammar.json`.
+This explicit mode needs Tree-sitter 0.26 or newer on `PATH`.
+
+> **Warning:** This command evaluates `grammar.js` and its imports as
+> JavaScript. Use it only with code that you trust.
+
+```sh
+go run ./cmd/grammargen doctor \
+  -js-cli ./grammar.js \
+  -sample ./examples/example.txt
+
+go run ./cmd/grammargen emit \
+  -js-cli ./grammar.js \
+  -bin ./language.bin
+```
+
+The command asks Tree-sitter to generate only its structured files. It imports
+the temporary `grammar.json` through `ImportGrammarJSON`, then removes it.
+
+The grammar's external token declarations stay in the imported grammar. You
+must still register a compatible Go external scanner for runtime parsing.
+
+The older `-js` flag remains a best-effort pure-Go importer. It does not execute
+JavaScript, but it cannot resolve all helpers or `require()` calls.
+
+### Option C: write the Go DSL directly
 
 For small DSLs there is no need for a JavaScript grammar at all. The
 builder functions live in `grammargen/grammar.go`: `NewGrammar`, `Define`,

--- a/grammargen/README.md
+++ b/grammargen/README.md
@@ -13,9 +13,12 @@ The authoring surface is intentionally input-neutral:
 - `.grammar` files, a compact ecosystem-agnostic grammar format that parses
   into the same IR and can emit Go DSL.
 
-`grammar.js` import also exists, but `grammar.json` is usually more reliable
-because helper functions, `require()` calls, and JavaScript evaluation have
-already been resolved by tree-sitter.
+Two `grammar.js` paths exist. The `-js` flag uses the best-effort pure-Go
+importer. The `-js-cli` flag uses Tree-sitter 0.26 or newer to resolve helpers
+and imports before it imports the generated `grammar.json`.
+
+> **Warning:** `-js-cli` evaluates the grammar as JavaScript. Use it only with
+> code that you trust. The `-js` and `-json` flags do not execute JavaScript.
 
 ## Authoring Commands
 
@@ -26,6 +29,7 @@ next command.
 ```sh
 go run ./cmd/grammargen doctor calc -text '1+2*3'
 go run ./cmd/grammargen doctor -json /tmp/grammar_parity/go/src/grammar.json -sample sample.go
+go run ./cmd/grammargen doctor -js-cli ./grammar.js -sample sample.txt
 go run ./cmd/grammargen doctor -grammar ./mini.grammar -text '123'
 go run ./cmd/grammargen doctor calc -text '1+2*3' -conflicts 3
 go run ./cmd/grammargen doctor calc -text '1+2*3' -format json
@@ -52,6 +56,11 @@ go run ./cmd/grammargen emit \
   -go grammargen/go_grammar.go \
   -pkg grammargen \
   -func GoGrammar
+
+# Resolve grammar.js through canonical grammar.json
+go run ./cmd/grammargen emit \
+  -js-cli ./grammar.js \
+  -bin ./language.bin
 
 # Go DSL source from a .grammar file
 go run ./cmd/grammargen emit -grammar ./mini.grammar -go ./mini_grammar.go -pkg grammargen
@@ -92,6 +101,16 @@ For grammars that benefit from local LR(1) state splitting, pass `-lr-split`:
 go run ./cmd/grammargen doctor <grammar> -lr-split -sample sample.<ext>
 go run ./cmd/grammargen emit <grammar> -lr-split -bin grammars/grammar_blobs/<grammar>.bin
 ```
+
+`-js-cli` needs Tree-sitter 0.26 or newer on `PATH`. It generates only
+`grammar.json` and `node-types.json` in a temporary directory. It then removes
+that directory.
+
+Set `TREE_SITTER_JS_RUNTIME=native` to use the native runtime in Tree-sitter
+0.26 or newer. Install the grammar's required packages before compilation.
+
+The canonical JSON keeps external token declarations. Register a compatible Go
+external scanner when you load the generated blob.
 
 Go's blob is generated without `-lr-split`:
 


### PR DESCRIPTION
## Summary

- Add the explicit `-js-cli` grammar input.
- Resolve `grammar.js` with Tree-sitter 0.26 or newer.
- Probe `generate --help` for both required flags.
- Import the temporary `grammar.json` through the existing importer.
- Keep the best-effort pure-Go `-js` path unchanged.

## Safety

- Run JavaScript only after the user selects `-js-cli`.
- Warn users that the grammar can execute arbitrary JavaScript.
- Generate only structured files in a temporary directory.
- Remove the temporary directory after every return.
- Preserve external token declarations in the imported grammar.

## Verification

- `go test ./cmd/grammargen -count=1`
- `go test ./grammargen -run 'TestImportGrammar(JS|JSON)|TestExportGrammarJSON' -count=1`
- `bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test ./cmd/grammargen -count=1"`
- A trusted live grammar passed with Tree-sitter 0.26.6.
- The live run left no temporary output directory.
