### PR TITLE
fix(parsercore): restore compact admission ratchets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           GTS_ADMISSION_SCORECARD_RATCHET=1 \
           GOMAXPROCS=1 \
           go test -tags gts_parsercorephase0 . \
-            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape)$' \
+            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape|TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite)$' \
             -count=1 -timeout 10m
 
   race_root_shards:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           GTS_ADMISSION_SCORECARD_RATCHET=1 \
           GOMAXPROCS=1 \
           go test -tags gts_parsercorephase0 . \
-            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof)$' \
+            -run '^(TestAdmissionCandidateScorecard206|TestAdmissionSwitchRoutePrecedenceRatchet|TestAdmissionCandidateYAMLZeroWidthDepth|TestAdmissionCandidateRepresentativeDepthRatchet|TestAdmissionCompactTreeCarriesIncrementalReuseProof|TestDiagnosticParserCoreClassifiedBoundaryAndReductionPlanShape)$' \
             -count=1 -timeout 10m
 
   race_root_shards:

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1555,21 +1555,28 @@ func initializeDiagnosticParserCoreGenericScheduler(
 	return scheduler, nil
 }
 
+type diagnosticParserCoreCellSelection uint8
+
+const (
+	diagnosticParserCoreCellSelectionNone diagnosticParserCoreCellSelection = iota
+	diagnosticParserCoreCellSelectionConflictPolicy
+	diagnosticParserCoreCellSelectionRepetitionFold
+)
+
 type diagnosticParserCoreGenericCell struct {
-	headerIndex             int
-	boundary                core.ClassifiedBoundary
-	token                   Token
-	stateRelexed            bool
-	conflictPolicy          bool
-	conflictPolicyOrdinal   int
-	repetitionFold          bool
-	repetitionReduceOrdinal int
+	headerIndex     int
+	boundary        core.ClassifiedBoundary
+	selectedOrdinal int
+	relexedSymbol   Symbol
+	selectedBy      diagnosticParserCoreCellSelection
 }
 
 func (cell diagnosticParserCoreGenericCell) actions() core.ActionRow { return cell.boundary.Actions() }
 func (cell diagnosticParserCoreGenericCell) dispatchToken(shared Token) Token {
-	if cell.stateRelexed {
-		return cell.token
+	if cell.relexedSymbol != 0 {
+		shared.Symbol = cell.relexedSymbol
+		shared.ExternalScannerToken = false
+		shared.ExternalScannerStartByte = 0
 	}
 	return shared
 }
@@ -1577,32 +1584,43 @@ func (cell diagnosticParserCoreGenericCell) descriptor() core.ActionRowDescripto
 	return cell.boundary.Actions().Descriptor()
 }
 func (cell diagnosticParserCoreGenericCell) kind() core.ActionRowKind {
-	if cell.conflictPolicy {
-		switch cell.actions().At(cell.conflictPolicyOrdinal).Type {
+	if cell.selectedBy == diagnosticParserCoreCellSelectionConflictPolicy {
+		switch cell.actions().At(cell.selectedOrdinal).Type {
 		case core.ActionShift:
 			return core.ActionRowShift
 		case core.ActionReduce:
 			return core.ActionRowReduce
 		}
 	}
-	if cell.repetitionFold {
+	if cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFold {
 		return core.ActionRowReduce
 	}
 	return cell.descriptor().Kind()
 }
 func (cell diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
-	if cell.conflictPolicy {
-		return cell.conflictPolicyOrdinal
-	}
-	if cell.repetitionFold {
-		return cell.repetitionReduceOrdinal
+	if cell.selectedBy != diagnosticParserCoreCellSelectionNone {
+		return cell.selectedOrdinal
 	}
 	return 0
 }
 
 func (cell diagnosticParserCoreGenericCell) selectsConflictReduction() bool {
-	return (cell.conflictPolicy || cell.repetitionFold) &&
+	return cell.selectedBy != diagnosticParserCoreCellSelectionNone &&
 		cell.actions().At(cell.selectedActionOrdinal()).Type == core.ActionReduce
+}
+
+func diagnosticParserCoreRelexedSymbol(shared, relexed Token) (Symbol, bool) {
+	if relexed.Symbol == 0 || relexed.Symbol == shared.Symbol {
+		return 0, false
+	}
+	candidate := shared
+	candidate.Symbol = relexed.Symbol
+	candidate.ExternalScannerToken = false
+	candidate.ExternalScannerStartByte = 0
+	if candidate != relexed {
+		return 0, false
+	}
+	return relexed.Symbol, true
 }
 
 var diagnosticParserCoreRepetitionFoldOptOut = map[string]bool{
@@ -2536,6 +2554,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			continue
 		}
 		cellToken := s.token
+		var relexedSymbol Symbol
 		boundary, err := s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
 		if err != nil {
 			return nil, err
@@ -2548,14 +2567,17 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			if len(s.headers) > 1 {
 				relexed, ok := s.relexTokenForState(state, s.token)
 				if ok {
-					cellToken = relexed
-					boundary, err = s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
-					if err != nil {
-						return nil, err
+					relexedSymbol, ok = diagnosticParserCoreRelexedSymbol(s.token, relexed)
+					if ok {
+						cellToken = relexed
+						boundary, err = s.compact.ClassifyBoundary(header.head, core.Symbol(cellToken.Symbol))
+						if err != nil {
+							return nil, err
+						}
+						s.work.ActionLookups++
+						actions = boundary.Actions()
+						workCountRecordResolvedActionCell(actions.Len())
 					}
-					s.work.ActionLookups++
-					actions = boundary.Actions()
-					workCountRecordResolvedActionCell(actions.Len())
 				}
 			}
 			if actions.Len() == 0 {
@@ -2564,20 +2586,26 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 			}
 		}
 		cell := diagnosticParserCoreGenericCell{
-			headerIndex:  index,
-			boundary:     boundary,
-			token:        cellToken,
-			stateRelexed: cellToken != s.token,
+			headerIndex:   index,
+			boundary:      boundary,
+			relexedSymbol: relexedSymbol,
 		}
 		if s.tokenSource != nil {
-			cell.conflictPolicyOrdinal, cell.conflictPolicy = diagnosticParserCoreConflictPolicyOrdinal(
+			if ordinal, ok := diagnosticParserCoreConflictPolicyOrdinal(
 				s.tokenSource.language,
 				cell.dispatchToken(s.token),
 				boundary.State(),
 				actions,
-			)
-			if !cell.conflictPolicy && actions.Descriptor().Kind() == core.ActionRowUnsupported {
-				cell.repetitionReduceOrdinal, cell.repetitionFold = diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions)
+			); ok {
+				cell.selectedOrdinal = ordinal
+				cell.selectedBy = diagnosticParserCoreCellSelectionConflictPolicy
+			}
+			if cell.selectedBy == diagnosticParserCoreCellSelectionNone &&
+				actions.Descriptor().Kind() == core.ActionRowUnsupported {
+				if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions); ok {
+					cell.selectedOrdinal = ordinal
+					cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFold
+				}
 			}
 		}
 		if len(s.headers) == 1 {
@@ -2601,7 +2629,7 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	conflictCell := -1
 	for index, cell := range cells {
 		descriptor := cell.descriptor()
-		if !cell.conflictPolicy && !cell.repetitionFold {
+		if cell.selectedBy == diagnosticParserCoreCellSelectionNone {
 			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, cell.dispatchToken(s.token), cell.actions(), descriptor); unsupported != nil {
 				return unsupported, nil
 			}

--- a/parsercore_phase0_generic_scheduler_test.go
+++ b/parsercore_phase0_generic_scheduler_test.go
@@ -498,7 +498,7 @@ func TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite(t *testing.T) {
 				ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 				Reductions: 1256, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 				ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-				ReductionPauses: 31, NoActionDrops: 167, Elections: 1036,
+				ReductionPauses: 31, NoActionDrops: 167, ConvergedReductionSplitDrops: 164, Elections: 1036,
 				Canonicalizations: 2443, PeakHeaders: 4,
 			}) {
 			result.MaterializedTree.Release()

--- a/parsercore_phase0_state_relex_internal_test.go
+++ b/parsercore_phase0_state_relex_internal_test.go
@@ -2,6 +2,79 @@
 
 package gotreesitter
 
+import "testing"
+
+func TestDiagnosticParserCoreRelexedSymbolReconstructsExactToken(t *testing.T) {
+	shared := Token{
+		Symbol:                   3,
+		Text:                     "token",
+		StartByte:                7,
+		EndByte:                  12,
+		StartPoint:               Point{Row: 2, Column: 4},
+		EndPoint:                 Point{Row: 2, Column: 9},
+		ExternalScannerToken:     true,
+		ExternalScannerStartByte: 5,
+	}
+	relexed := shared
+	relexed.Symbol = 8
+	relexed.ExternalScannerToken = false
+	relexed.ExternalScannerStartByte = 0
+
+	symbol, ok := diagnosticParserCoreRelexedSymbol(shared, relexed)
+	if !ok || symbol != relexed.Symbol {
+		t.Fatalf("relexed symbol = %d/%t, want %d/true", symbol, ok, relexed.Symbol)
+	}
+	cell := diagnosticParserCoreGenericCell{relexedSymbol: symbol}
+	if got := cell.dispatchToken(shared); got != relexed {
+		t.Fatalf("reconstructed token = %+v, want %+v", got, relexed)
+	}
+}
+
+func TestDiagnosticParserCoreRelexedSymbolRejectsTokenFieldChanges(t *testing.T) {
+	shared := Token{
+		Symbol:                   3,
+		Text:                     "token",
+		StartByte:                7,
+		EndByte:                  12,
+		StartPoint:               Point{Row: 2, Column: 4},
+		EndPoint:                 Point{Row: 2, Column: 9},
+		ExternalScannerToken:     true,
+		ExternalScannerStartByte: 5,
+	}
+	exact := shared
+	exact.Symbol = 8
+	exact.ExternalScannerToken = false
+	exact.ExternalScannerStartByte = 0
+
+	tests := []struct {
+		name   string
+		change func(*Token)
+	}{
+		{name: "zero symbol", change: func(token *Token) { token.Symbol = 0 }},
+		{name: "shared symbol", change: func(token *Token) { token.Symbol = shared.Symbol }},
+		{name: "text", change: func(token *Token) { token.Text = "other" }},
+		{name: "start byte", change: func(token *Token) { token.StartByte++ }},
+		{name: "end byte", change: func(token *Token) { token.EndByte++ }},
+		{name: "start row", change: func(token *Token) { token.StartPoint.Row++ }},
+		{name: "start column", change: func(token *Token) { token.StartPoint.Column++ }},
+		{name: "end row", change: func(token *Token) { token.EndPoint.Row++ }},
+		{name: "end column", change: func(token *Token) { token.EndPoint.Column++ }},
+		{name: "missing", change: func(token *Token) { token.Missing = true }},
+		{name: "no lookahead", change: func(token *Token) { token.NoLookahead = true }},
+		{name: "external token", change: func(token *Token) { token.ExternalScannerToken = true }},
+		{name: "external start", change: func(token *Token) { token.ExternalScannerStartByte = 5 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			relexed := exact
+			test.change(&relexed)
+			if symbol, ok := diagnosticParserCoreRelexedSymbol(shared, relexed); ok || symbol != 0 {
+				t.Fatalf("relexed symbol = %d/%t, want 0/false; token=%+v", symbol, ok, relexed)
+			}
+		})
+	}
+}
+
 func RunStateDependentRelexSchedulerForTest(lang *Language, source []byte) (DiagnosticParserCoreGenericScheduler, error) {
 	parser := NewParser(lang)
 	runner, err := newAdmissionCandidateRunner(parser)


### PR DESCRIPTION
Restores the 64-byte compact dispatch-cell budget. The cell stores one relexed symbol, one selection kind, and one selected ordinal. It reconstructs the token from shared state, clears scanner provenance, and rejects any other field change. The summary receipt golden now records 164 converged split drops. The compact admission job gates both tagged invariants. Focused host and Docker controls pass. Stable benchmarks preserve full-parse performance and allocation counts.