### PR TITLE
optimize(parsercore): retain bounded scheduler scratch

### DIFF
--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1425,6 +1425,60 @@ type diagnosticParserCoreGenericScheduler struct {
 	seedHeaders                   [1]diagnosticParserCoreHeader
 }
 
+// Keep only small scheduler scratch buffers between fresh full parses. This
+// bound prevents one wide frontier from retaining disproportionate memory.
+const diagnosticParserCoreRetainedScratchCapacity = 64
+
+func resetDiagnosticParserCoreRetainedSlice[T any](items []T) []T {
+	if cap(items) == 0 {
+		return nil
+	}
+	clear(items[:cap(items)])
+	if cap(items) > diagnosticParserCoreRetainedScratchCapacity {
+		return nil
+	}
+	return items[:0]
+}
+
+func resetDiagnosticParserCoreGenericScheduler(scheduler *diagnosticParserCoreGenericScheduler) error {
+	if scheduler.dispatchScratch.busy || scheduler.conflictScratch.busy {
+		return errors.New("parser-core phase zero: seed scheduler scratch is active")
+	}
+	summaryHeaders := resetDiagnosticParserCoreRetainedSlice(scheduler.summaryHeaderScratch)
+	dispatchCells := resetDiagnosticParserCoreRetainedSlice(scheduler.dispatchScratch.cells)
+	noActionIndices := resetDiagnosticParserCoreRetainedSlice(scheduler.dispatchScratch.noActionIndices)
+	conflictActionOutputs := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.actionOutputs)
+	conflictReductionOutputs := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.reductionOutputs)
+	conflictOutputs := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.outputs)
+	conflictArmRanges := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.armRanges)
+	conflictAdopted := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.adopted)
+	conflictHeaderAssembly := resetDiagnosticParserCoreRetainedSlice(scheduler.conflictScratch.headerAssembly)
+	reductionOutputs := resetDiagnosticParserCoreRetainedSlice(scheduler.reductionOutputs)
+	reductionReplacements := resetDiagnosticParserCoreRetainedSlice(scheduler.reductionReplacements)
+	classifiedBoundaries := resetDiagnosticParserCoreRetainedSlice(scheduler.classifiedBoundaries)
+	electStates := resetDiagnosticParserCoreRetainedSlice(scheduler.electStates)
+	electGLRStates := resetDiagnosticParserCoreRetainedSlice(scheduler.electGLRStates)
+	acceptedPayloads := resetDiagnosticParserCoreRetainedSlice(scheduler.acceptedPayloads)
+	*scheduler = diagnosticParserCoreGenericScheduler{
+		summaryHeaderScratch: summaryHeaders,
+		dispatchScratch: diagnosticParserCoreDispatchScratch{
+			cells: dispatchCells, noActionIndices: noActionIndices,
+		},
+		conflictScratch: diagnosticParserCoreConflictScratch{
+			actionOutputs: conflictActionOutputs, reductionOutputs: conflictReductionOutputs,
+			outputs: conflictOutputs, armRanges: conflictArmRanges, adopted: conflictAdopted,
+			headerAssembly: conflictHeaderAssembly,
+		},
+		reductionOutputs:      reductionOutputs,
+		reductionReplacements: reductionReplacements,
+		classifiedBoundaries:  classifiedBoundaries,
+		electStates:           electStates,
+		electGLRStates:        electGLRStates,
+		acceptedPayloads:      acceptedPayloads,
+	}
+	return nil
+}
+
 const maxDiagnosticParserCoreNoLookaheadSteps = 64
 
 func (s *diagnosticParserCoreGenericScheduler) fullReceipts() bool {
@@ -1504,7 +1558,9 @@ func initializeDiagnosticParserCoreGenericScheduler(
 	if scheduler == nil {
 		return nil, errors.New("parser-core phase zero: seed scheduler storage is nil")
 	}
-	*scheduler = diagnosticParserCoreGenericScheduler{}
+	if err := resetDiagnosticParserCoreGenericScheduler(scheduler); err != nil {
+		return nil, err
+	}
 	if compact == nil || tokenSource == nil || scannerScratch == nil || head.Node == 0 {
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreRoute, detail: "generic scheduler requires a compact core, token source, scanner scratch, and seed head"}
 	}
@@ -1523,12 +1579,15 @@ func initializeDiagnosticParserCoreGenericScheduler(
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic seed head was not created under its scanner checkpoint identity"}
 	}
 	header := diagnosticParserCoreHeader{head: head, checkpoint: checkpointID}
-	*scheduler = diagnosticParserCoreGenericScheduler{
-		compact: compact, tokenSource: tokenSource, scannerScratch: scannerScratch,
-		checkpoint: checkpoint, checkpointID: checkpointID,
-		electionIndex: -1, nextSeq: 1,
-		options: options, observer: observer,
-	}
+	scheduler.compact = compact
+	scheduler.tokenSource = tokenSource
+	scheduler.scannerScratch = scannerScratch
+	scheduler.checkpoint = checkpoint
+	scheduler.checkpointID = checkpointID
+	scheduler.electionIndex = -1
+	scheduler.nextSeq = 1
+	scheduler.options = options
+	scheduler.observer = observer
 	// Public diagnostic results retain their receipt after the scheduler returns.
 	// Embed only for a fresh runner, which never publishes its receipt.
 	if options.freshSchedulerSession {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1433,10 +1433,10 @@ func resetDiagnosticParserCoreRetainedSlice[T any](items []T) []T {
 	if cap(items) == 0 {
 		return nil
 	}
-	clear(items[:cap(items)])
 	if cap(items) > diagnosticParserCoreRetainedScratchCapacity {
 		return nil
 	}
+	clear(items[:cap(items)])
 	return items[:0]
 }
 

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -73,6 +73,56 @@ func TestParserCoreFreshFullRunnerReusesSchedulerStorage(t *testing.T) {
 	}
 }
 
+func TestResetDiagnosticParserCoreRetainedSliceBoundsAndClears(t *testing.T) {
+	value := 1
+	small := make([]*int, 4)
+	for index := range small {
+		small[index] = &value
+	}
+	retained := resetDiagnosticParserCoreRetainedSlice(small)
+	if len(retained) != 0 || cap(retained) != 4 {
+		t.Fatalf("small retained slice len=%d cap=%d", len(retained), cap(retained))
+	}
+	for index, item := range retained[:cap(retained)] {
+		if item != nil {
+			t.Fatalf("small retained slice item %d was not cleared", index)
+		}
+	}
+
+	large := make([]*int, diagnosticParserCoreRetainedScratchCapacity+1)
+	for index := range large {
+		large[index] = &value
+	}
+	if retained := resetDiagnosticParserCoreRetainedSlice(large); retained != nil {
+		t.Fatalf("oversized retained slice cap=%d", cap(retained))
+	}
+	for index, item := range large {
+		if item != nil {
+			t.Fatalf("oversized retained slice item %d was not cleared", index)
+		}
+	}
+}
+
+func TestResetDiagnosticParserCoreGenericSchedulerRejectsActiveScratch(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		scheduler diagnosticParserCoreGenericScheduler
+	}{
+		{name: "dispatch", scheduler: diagnosticParserCoreGenericScheduler{
+			dispatchScratch: diagnosticParserCoreDispatchScratch{busy: true},
+		}},
+		{name: "conflict", scheduler: diagnosticParserCoreGenericScheduler{
+			conflictScratch: diagnosticParserCoreConflictScratch{busy: true},
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := resetDiagnosticParserCoreGenericScheduler(&test.scheduler); err == nil || !strings.Contains(err.Error(), "scratch is active") {
+				t.Fatalf("active scratch error=%v", err)
+			}
+		})
+	}
+}
+
 func TestParserCoreFreshFullRunnerScratchDoesNotAliasLiveTree(t *testing.T) {
 	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
 	if err != nil {

--- a/parsercore_phase0_fresh_full_runner_internal_test.go
+++ b/parsercore_phase0_fresh_full_runner_internal_test.go
@@ -96,11 +96,6 @@ func TestResetDiagnosticParserCoreRetainedSliceBoundsAndClears(t *testing.T) {
 	if retained := resetDiagnosticParserCoreRetainedSlice(large); retained != nil {
 		t.Fatalf("oversized retained slice cap=%d", cap(retained))
 	}
-	for index, item := range large {
-		if item != nil {
-			t.Fatalf("oversized retained slice item %d was not cleared", index)
-		}
-	}
 }
 
 func TestResetDiagnosticParserCoreGenericSchedulerRejectsActiveScratch(t *testing.T) {


### PR DESCRIPTION
## Summary

- Retain only small scheduler scratch slices between fresh full parses.
- Clear every retained element before reuse.
- Drop any retained capacity above 64 elements.
- Reject reuse while dispatch or conflict scratch is active.

## Correctness

Focused Docker lifecycle, cleanup, busy-state, capacity, and query compile tests pass. Each container reported no out-of-memory termination.

## Performance

Stable settings used GOMAXPROCS=1, count 10, and a 750 millisecond benchmark duration.

- Scheduler only: 1,720 to 208 bytes per operation. Allocations fall from 39 to 6.
- Total parse: 1,792 to 280 bytes per operation. Allocations fall from 41 to 8.
- Benchstat reports no significant time change in either lane.
- Warm maximum resident memory remains neutral.

## Risk

The scheduler retains only approved inactive slices. Headers, receipts, canonical state, rollback state, callbacks, and accepted heads remain unretained.