### PR TITLE
test(admission): ratchet compact real-corpus breadth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ for tags and release notes while still in `0.x`.
   It imports the temporary canonical `grammar.json` through the existing path.
   The explicit flag warns that grammar evaluation executes JavaScript.
 
+- The canonical compact real-corpus matrix now enforces 67 direct routes,
+  at most 33 fallbacks, exactly 10 skips, and no divergence or error.
+  A lock-pinned Elm highlight fixture protects the refreshed 110-row corpus.
+
 ### Performance
 
 - The compact scheduler now stores its common rollback frontier inline.

--- a/admission_direct_corpus_test.go
+++ b/admission_direct_corpus_test.go
@@ -89,3 +89,46 @@ func TestAdmissionCandidateSvelteButtonDirect(t *testing.T) {
 		t.Fatalf("Svelte Button compact digest = %q, want %q", row.detail, wantDetail)
 	}
 }
+
+func TestAdmissionCandidateElmHighlightDirect(t *testing.T) {
+	const (
+		fixturePath = "testdata/admission_direct/elm_highlight_basic.elm"
+		// This source comes from elm-tooling/tree-sitter-elm at commit
+		// 6d9511c28181db66daee4e883f811f6251220943.
+		// Its path is test/highlight/basic.elm.
+		sourceBytes  = 1231
+		sourceSHA256 = "8fca87bd8cc2735e83704acd8d06ffbc6cf04e386505de45596218d7fb72642c"
+		wantDetail   = "digest 67329ce8b319"
+	)
+
+	source, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read Elm admission fixture: %v", err)
+	}
+	if len(source) != sourceBytes {
+		t.Fatalf("Elm admission fixture bytes = %d, want %d", len(source), sourceBytes)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != sourceSHA256 {
+		t.Fatalf("Elm admission fixture SHA-256 = %s, want %s", got, sourceSHA256)
+	}
+
+	var elm grammars.LangEntry
+	for _, entry := range grammars.AllLanguages() {
+		if entry.Name == "elm" {
+			elm = entry
+			break
+		}
+	}
+	if elm.Name == "" {
+		t.Fatal("Elm grammar is not registered")
+	}
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	row := runAdmissionScorecardSource(elm, source)
+	if row.status != scorecardPass {
+		t.Fatalf("Elm highlight compact route = %s: %s", row.status, row.detail)
+	}
+	if row.detail != wantDetail {
+		t.Fatalf("Elm highlight compact digest = %q, want %q", row.detail, wantDetail)
+	}
+}

--- a/admission_real_corpus_matrix_test.go
+++ b/admission_real_corpus_matrix_test.go
@@ -208,6 +208,40 @@ func TestAdmissionCandidateRealCorpusMatrix(t *testing.T) {
 		)
 	}
 
+	if os.Getenv("GTS_ADMISSION_REAL_CORPUS_RATCHET") == "1" {
+		if len(selectedLanguages) != 0 || len(selectedBuckets) != 0 ||
+			len(excludedLanguages) != 1 || !excludedLanguages["awk"] ||
+			maxBytes != 16_383 {
+			t.Fatal("real-corpus ratchet requires the canonical scope: no language or bucket filters, AWK excluded, and max bytes 16383")
+		}
+		const (
+			minRows     = 110
+			minPass     = 67
+			maxFallback = 33
+			wantSkip    = 10
+		)
+		if len(rows) < minRows ||
+			counts[scorecardPass] < minPass ||
+			counts[scorecardFallback] > maxFallback ||
+			counts[scorecardSkip] != wantSkip ||
+			counts[scorecardDiverge] != 0 ||
+			counts[scorecardError] != 0 {
+			t.Fatalf(
+				"real-corpus breadth ratchet failed: PASS=%d (min %d) DIVERGE=%d FALLBACK=%d (max %d) SKIP=%d (want %d) ERROR=%d total=%d (min %d)",
+				counts[scorecardPass],
+				minPass,
+				counts[scorecardDiverge],
+				counts[scorecardFallback],
+				maxFallback,
+				counts[scorecardSkip],
+				wantSkip,
+				counts[scorecardError],
+				len(rows),
+				minRows,
+			)
+		}
+	}
+
 	if counts[scorecardDiverge] != 0 || counts[scorecardError] != 0 {
 		t.Fatalf(
 			"real-corpus matrix has DIVERGE=%d ERROR=%d",

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,6 +1,6 @@
 # Compact route real-corpus matrix
 
-Date: 2026-07-28. Base commit: `f639fbaa` from `main`.
+Date: 2026-07-29. Base commit: `382080a3` from `main`.
 
 ## Result
 
@@ -8,18 +8,18 @@ The bounded matrix completed with no silent divergence.
 
 | Status | Files |
 |---|---:|
-| PASS | 61 |
-| FALLBACK | 38 |
+| PASS | 67 |
+| FALLBACK | 33 |
 | SKIP | 10 |
 | DIVERGE | 0 |
 | ERROR | 0 |
-| Total | 109 |
+| Total | 110 |
 
-The corpus manifest contains 146 verified files across 50 languages.
+The corpus manifest contains 147 verified files across 50 languages.
 This run selected files smaller than 16,384 bytes and excluded AWK.
 The AWK medium file needs a separate slow-path budget.
 
-The direct route served 56 percent of the selected files.
+The direct route served 61 percent of the selected files.
 Production served every fallback and every ineligible file.
 
 The current 206-language smoke scorecard reports:
@@ -101,6 +101,37 @@ The Cooklang field-aware C-oracle run passed:
 
 - `harness_out/docker/20260728T064513Z-compact-clean-smoke-cooklang-c-oracle-fields`
 
+## Lock-pinned corpus refresh
+
+The previous 109-file matrix used a stale generated corpus directory.
+The current builder selects one additional Elm highlight source.
+Two independent rebuilds produced the same normalized manifest hash.
+After volatile fields are removed, the hash is
+`1e9998f1e4282c3c3397f518638a8779e016a0038064903f8de90f48b781661e`.
+
+| Field | Value |
+|---|---|
+| Repository | `elm-tooling/tree-sitter-elm` |
+| Commit | `6d9511c28181db66daee4e883f811f6251220943` |
+| Source path | `test/highlight/basic.elm` |
+| Bytes | 1,231 |
+| SHA-256 | `8fca87bd8cc2735e83704acd8d06ffbc6cf04e386505de45596218d7fb72642c` |
+| Compact result | PASS |
+
+The tracked [Elm fixture](../testdata/admission_direct/elm_highlight_basic.elm)
+protects this source when the generated corpus directory is absent.
+
+The canonical matrix now enforces these bounds:
+
+- At least 110 selected rows.
+- At least 67 direct PASS rows.
+- At most 33 FALLBACK rows.
+- Exactly 10 SKIP rows.
+- No DIVERGE or ERROR rows.
+
+Ratchet mode rejects noncanonical language, bucket, AWK, and byte filters.
+Manifest order does not affect the aggregate bounds.
+
 ## Rejected C# convergence candidate
 
 The cap-one GSS convergence candidate did not preserve C# parity.
@@ -160,6 +191,7 @@ Run this command from the repository root:
 
 ```sh
 GTS_ADMISSION_REAL_CORPUS=1 \
+GTS_ADMISSION_REAL_CORPUS_RATCHET=1 \
 GTS_ADMISSION_REAL_CORPUS_EXCLUDE_LANGS=awk \
 GTS_ADMISSION_REAL_CORPUS_MAX_BYTES=16383 \
 go test . \
@@ -193,10 +225,10 @@ Use these optional filters:
 | d | 1 | 1 | 0 |
 | dart | 0 | 2 | 0 |
 | elixir | 2 | 1 | 0 |
-| elm | 2 | 0 | 0 |
+| elm | 3 | 0 | 0 |
 | erlang | 2 | 0 | 0 |
 | go | 2 | 0 | 0 |
-| gomod | 0 | 3 | 0 |
+| gomod | 1 | 2 | 0 |
 | graphql | 3 | 0 | 0 |
 | haskell | 0 | 2 | 0 |
 | hcl | 2 | 0 | 0 |
@@ -206,9 +238,9 @@ Use these optional filters:
 | javascript | 1 | 0 | 0 |
 | json | 0 | 0 | 3 |
 | json5 | 2 | 0 | 0 |
-| julia | 0 | 2 | 0 |
+| julia | 1 | 1 | 0 |
 | kotlin | 0 | 2 | 0 |
-| lua | 0 | 2 | 0 |
+| lua | 2 | 0 | 0 |
 | make | 1 | 1 | 0 |
 | markdown | 1 | 1 | 0 |
 | nix | 3 | 0 | 0 |
@@ -219,7 +251,7 @@ Use these optional filters:
 | powershell | 1 | 1 | 0 |
 | python | 2 | 0 | 0 |
 | r | 3 | 0 | 0 |
-| ruby | 1 | 1 | 0 |
+| ruby | 2 | 0 | 0 |
 | rust | 0 | 1 | 0 |
 | scala | 0 | 2 | 0 |
 | scss | 2 | 0 | 0 |
@@ -269,7 +301,7 @@ The refreshed manifest has these properties:
 
 - 50 declared languages
 - 50 languages with selected files
-- 146 files
+- 147 files
 - No missing files
 - No size mismatches
 - No SHA-256 mismatches

--- a/docs/root-normalization-retirement.md
+++ b/docs/root-normalization-retirement.md
@@ -328,6 +328,7 @@ there.
 | D variable-type qualifiers | retirement change | 1 D subpass | 0 | compatibility-free producer, production, compact fallback, forest, incremental reuse, and isolated C-oracle parity |
 | D call-expression targets | retirement commit `6a650454e5698d64a0148629cfa444b3dbce6877` | 2 D subpasses / 1 dispatcher arm | 0 | compatibility-free producer, production, compact fallback, forest, incremental, and three isolated C-oracle receipts |
 | Certified unary named wrappers | retirement change | 1 dispatcher arm | 0 | exact-profile census, compatibility-free producer, production, compact fallback, forest fail-closed behavior, incremental, parent links, deterministic digest, and isolated C-oracle parity |
+| Scala and SQL field projection | merged in PR #522 | 4 local field repairs | 0 | native reduction, production, compact fallback, forest, incremental reuse, and isolated Scala and SQL parity |
 | Dart and Elixir inherited fields | retirement change | 2 language-local field repairs | 0 | compatibility-free producer, refreshed corpus, production, compact, forest, incremental, and isolated C-oracle receipts |
 
 Mark a row merged only after CI and merge evidence exist. Detailed per-entry

--- a/testdata/admission_direct/elm_highlight_basic.elm
+++ b/testdata/admission_direct/elm_highlight_basic.elm
@@ -1,0 +1,50 @@
+module Main exposing (Msg(..), main, update, view)
+-- ^ keyword.other.elm
+--              ^ keyword.other.elm
+
+import Browser
+-- ^ meta.import.elm
+import Html exposing (Html, button, div, text)
+-- ^ meta.import.elm
+import Html.Events exposing (onClick)
+-- ^ meta.import.elm
+
+
+main =
+    Browser.sandbox { init = 0, update = update, view = view }
+
+
+type Msg
+-- <- @keyword.type.elm
+--    ^ @storage.type.elm
+    = Increment
+    -- ^ union.elm
+    | Decrement
+    -- ^ union.elm
+
+update : Msg -> Model
+-- <- function.elm
+--     ^ keyword.other.elm
+--            ^ keyword.operator.arrow.elm
+
+update msg model =
+    case msg of
+    --       ^ keyword.control.elm
+        Increment ->
+                -- ^ keyword.operator.arrow.elm
+            model + 1
+            --    ^ keyword.operator.elm
+
+        Decrement ->
+            model - 1
+            --      ^ constant.numeric.elm
+
+view model =
+    --     ^ keyword.operator.assignment.elm
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        --                                    ^ string.elm
+        --                                     ^ string.elm
+        , div [] [ text (String.fromInt model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]


### PR DESCRIPTION
## Summary

- Refresh the compact real-corpus matrix from 61 PASS and 38 FALLBACK to 67 PASS and 33 FALLBACK.
- Keep 10 SKIP rows and zero DIVERGE or ERROR rows.
- Pin the additional Elm highlight source with its commit, size, SHA-256, and compact digest.
- Add an order-independent canonical breadth ratchet.
- Record the merged Scala and SQL field projection retirement.

## Corpus evidence

A fresh lock-pinned top50 rebuild selected 147 entries across 50 languages. The prior 109-row and 66-PASS artifact was stale because it omitted the Elm highlight source.

A second independent rebuild produced the same normalized manifest SHA-256: 1e9998f1e4282c3c3397f518638a8779e016a0038064903f8de90f48b781661e.

## Validation

- The focused Docker manifest quality test passed.
- The tracked Elm direct-route test passed with digest 67329ce8b319.
- The focused Docker canonical matrix passed at 67 PASS, 33 FALLBACK, 10 SKIP, zero DIVERGE, and zero ERROR.
- The Docker run reported oom_killed=false.
- Narrow Canopy 0.16.2 symbol checks passed.
- The staged diff check passed.

## Risk

This PR changes tests, a tracked fixture, and documentation. It does not change runtime parser behavior.