### PR TITLE
add: report materialization subpasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for tags and release notes while still in `0.x`.
 
 ### Added
 
+- The dispatcher census now reports distinct Ada, Apex, Bash, Cooklang, and
+  HTTP materialization subpasses.
+  Compatibility-free probes record active and inert producer behavior.
+
 - `grammargen -js-cli` now resolves `grammar.js` with Tree-sitter 0.26 or newer.
   It imports the temporary canonical `grammar.json` through the existing path.
   The explicit flag warns that grammar evaluation executes JavaScript.

--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -41,6 +41,7 @@ type resultCompatOwnershipEntry struct {
 	Kind                string                    `json:"kind"`
 	Functions           []string                  `json:"functions"`
 	Files               []string                  `json:"files"`
+	Subpasses           []resultCompatSubpass     `json:"subpasses,omitempty"`
 	Languages           []string                  `json:"languages"`
 	MatchPredicate      string                    `json:"match_predicate,omitempty"`
 	EntrypointCalls     []string                  `json:"entrypoint_calls,omitempty"`
@@ -53,6 +54,15 @@ type resultCompatOwnershipEntry struct {
 	Status              string                    `json:"status"`
 	ReceiptRefs         []string                  `json:"receipt_refs,omitempty"`
 	RetiredCommit       string                    `json:"retired_commit,omitempty"`
+}
+
+type resultCompatSubpass struct {
+	ID                 string   `json:"id"`
+	Functions          []string `json:"functions"`
+	Files              []string `json:"files"`
+	Purpose            string   `json:"purpose"`
+	AuthoritativeOwner string   `json:"authoritative_owner"`
+	Witnesses          []string `json:"witnesses"`
 }
 
 type resultCompatSwitchArm struct {
@@ -137,6 +147,7 @@ func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 		if entry.Status == "live" {
 			assertRegistryFunctionsExist(t, entry)
 		}
+		assertRegistrySubpasses(t, entry, allowedOwners)
 		if entry.Status != "retired" {
 			entriesByKind[entry.Kind] = append(entriesByKind[entry.Kind], entry)
 		}
@@ -145,6 +156,93 @@ func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 	assertDispatcherRegistry(t, registry.Denominator, entriesByKind)
 	assertGenericPassRegistry(t, registry.Denominator, entriesByKind)
 	assertPostFinalizationRegistry(t, registry.Denominator, entriesByKind)
+}
+
+func assertRegistrySubpasses(
+	t *testing.T,
+	entry resultCompatOwnershipEntry,
+	allowedOwners map[string]bool,
+) {
+	t.Helper()
+	if entry.Status == "live" && entry.AuthoritativeOwner == "materialization" &&
+		len(entry.Subpasses) == 0 {
+		t.Errorf("%s must classify its materialization subpasses", entry.ID)
+	}
+	seen := make(map[string]bool)
+	for _, subpass := range entry.Subpasses {
+		if subpass.ID == "" || seen[subpass.ID] {
+			t.Errorf("%s has an empty or duplicate subpass id %q", entry.ID, subpass.ID)
+			continue
+		}
+		seen[subpass.ID] = true
+		if !strings.HasPrefix(subpass.ID, entry.ID+".") {
+			t.Errorf("%s subpass id %q must use the parent id prefix", entry.ID, subpass.ID)
+		}
+		if !allowedOwners[subpass.AuthoritativeOwner] {
+			t.Errorf(
+				"%s authoritative_owner = %q, want registered owner category",
+				subpass.ID,
+				subpass.AuthoritativeOwner,
+			)
+		}
+		if subpass.Purpose == "" || len(subpass.Functions) == 0 ||
+			len(subpass.Files) == 0 || len(subpass.Witnesses) == 0 {
+			t.Errorf(
+				"%s must declare functions, files, purpose, and witnesses",
+				subpass.ID,
+			)
+		}
+		if ownershipHasDuplicateStrings(subpass.Functions) {
+			t.Errorf("%s functions must be a duplicate-free set: %v", subpass.ID, subpass.Functions)
+		}
+		for _, path := range append(append([]string{}, subpass.Files...), subpass.Witnesses...) {
+			if _, err := os.Stat(filepath.Clean(path)); err != nil {
+				t.Errorf("%s references missing path %q: %v", subpass.ID, path, err)
+			}
+		}
+		assertRegistryFunctionsInFiles(t, subpass.ID, subpass.Functions, subpass.Files)
+		sourceFiles := append([]string{"parser_result_compat.go"}, entry.Files...)
+		if !ownershipSubpassCensusIDExists(t, sourceFiles, subpass.ID) {
+			t.Errorf("%s has no census.run call in %v", subpass.ID, sourceFiles)
+		}
+	}
+}
+
+func ownershipSubpassCensusIDExists(t *testing.T, files []string, want string) bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	for _, path := range files {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Errorf("parse %s for subpass census ids: %v", path, err)
+			continue
+		}
+		found := false
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || selector.Sel.Name != "run" {
+				return true
+			}
+			literal, ok := call.Args[0].(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(literal.Value)
+			if err == nil && value == want {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
 }
 
 func loadResultCompatOwnershipRegistry(t *testing.T) resultCompatOwnershipRegistry {
@@ -254,12 +352,22 @@ func assertOwnershipStatusAndRoutes(t *testing.T, entry resultCompatOwnershipEnt
 
 func assertRegistryFunctionsExist(t *testing.T, entry resultCompatOwnershipEntry) {
 	t.Helper()
+	assertRegistryFunctionsInFiles(t, entry.ID, entry.Functions, entry.Files)
+}
+
+func assertRegistryFunctionsInFiles(
+	t *testing.T,
+	entryID string,
+	functions []string,
+	files []string,
+) {
+	t.Helper()
 	declared := make(map[string]bool)
 	fset := token.NewFileSet()
-	for _, path := range entry.Files {
+	for _, path := range files {
 		file, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
-			t.Errorf("%s parse %s: %v", entry.ID, path, err)
+			t.Errorf("%s parse %s: %v", entryID, path, err)
 			continue
 		}
 		for _, decl := range file.Decls {
@@ -268,9 +376,9 @@ func assertRegistryFunctionsExist(t *testing.T, entry resultCompatOwnershipEntry
 			}
 		}
 	}
-	for _, function := range entry.Functions {
+	for _, function := range functions {
 		if !declared[function] {
-			t.Errorf("%s live function %s is absent from registered files %v", entry.ID, function, entry.Files)
+			t.Errorf("%s function %s is absent from registered files %v", entryID, function, files)
 		}
 	}
 }

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -85,6 +85,39 @@ These are evidence labels, not claims that all five engines have independent
 implementations. The shared-tail value means that route reaches the same
 post-parse normalization tail.
 
+## Materialization subpass census
+
+Five live arms still use `materialization` as their aggregate owner.
+Each arm now declares its distinct subpasses in the registry.
+
+Set `GTS_DISPATCHER_CENSUS=1` to record each subpass and its aggregate arm.
+The census does not change parser output when it is disabled.
+
+| Arm | Subpass | Upstream owner |
+|---|---|---|
+| Ada | constraint kind election | `derivation_election_selection` |
+| Ada | aggregate kind election | `derivation_election_selection` |
+| Ada | association choice construction | `materialization` |
+| Apex | generic local declaration | `derivation_election_selection` |
+| Apex | class literal alias | `materialization` |
+| Bash | assignment wrapper flattening | `materialization` |
+| Bash | generated command assignment | `scheduler_action_semantics` |
+| Bash | command name concatenation | `materialization` |
+| Bash | `if` condition field projection | `materialization` |
+| Cooklang | trailing step tail | `scanner_checkpoint_state` |
+| Cooklang | recovered recipe | `scheduler_action_semantics` |
+| HTTP | document section coalescing | `scheduler_action_semantics` |
+
+Cooklang calls its trailing-tail subpass from `parser_result_misc_spans.go`.
+The registry now includes that function and file.
+
+The probes parse each source without result compatibility.
+They also compare census-enabled output with normal production output.
+Each digest matches base commit
+`4f077315d3aa5dcec4f5392c7eb17a1bbc27a455`.
+The locked Ada probes come from tree-sitter-ada commit
+`6b58259a08b1a22ba0247a7ce30be384db618da6`.
+
 ## Why it exists
 
 Two GLR parsers can accept the same input and still return different trees

--- a/parser_result_ada.go
+++ b/parser_result_ada.go
@@ -3,6 +3,15 @@ package gotreesitter
 import "bytes"
 
 func normalizeAdaCompatibility(root *Node, source []byte, lang *Language) {
+	normalizeAdaCompatibilityWithCensus(root, source, lang, materializationSubpassCensus{})
+}
+
+func normalizeAdaCompatibilityWithCensus(
+	root *Node,
+	source []byte,
+	lang *Language,
+	census materializationSubpassCensus,
+) {
 	if root == nil || lang == nil || lang.Name != "ada" || len(source) == 0 {
 		return
 	}
@@ -91,61 +100,67 @@ func normalizeAdaCompatibility(root *Node, source []byte, lang *Language) {
 		text := adaTrimmedNodeText(mid, source)
 		switch n.symbol {
 		case discriminantConstraintSym:
-			if mid.symbol == discriminantAssociationSym && bytes.Contains(text, []byte("'")) {
-				assocChildren := resultChildSliceForMutation(mid)
-				if len(assocChildren) == 0 {
-					return
-				}
-				if len(assocChildren) == 1 && assocChildren[0] != nil && assocChildren[0].symbol == expressionSym {
-					if rebuilt := adaAttributeReferenceChildren(n.ownerArena, source, assocChildren[0], selectedComponentSym, selectedComponentNamed, tickSym, tickNamed, attributeDesignatorSym, attributeDesignatorNamed, identifierSym, identifierNamed, dotSym, dotNamed, accessSym, accessNamed); len(rebuilt) > 0 {
-						assocChildren = rebuilt
-					} else if exprChildren := resultChildSliceForMutation(assocChildren[0]); len(exprChildren) > 0 {
-						assocChildren = exprChildren
+			census.run("dispatch.ada.constraint-kind-election", func() {
+				if mid.symbol == discriminantAssociationSym && bytes.Contains(text, []byte("'")) {
+					assocChildren := resultChildSliceForMutation(mid)
+					if len(assocChildren) == 0 {
+						return
 					}
+					if len(assocChildren) == 1 && assocChildren[0] != nil && assocChildren[0].symbol == expressionSym {
+						if rebuilt := adaAttributeReferenceChildren(n.ownerArena, source, assocChildren[0], selectedComponentSym, selectedComponentNamed, tickSym, tickNamed, attributeDesignatorSym, attributeDesignatorNamed, identifierSym, identifierNamed, dotSym, dotNamed, accessSym, accessNamed); len(rebuilt) > 0 {
+							assocChildren = rebuilt
+						} else if exprChildren := resultChildSliceForMutation(assocChildren[0]); len(exprChildren) > 0 {
+							assocChildren = exprChildren
+						}
+					}
+					out := make([]*Node, 0, len(assocChildren)+2)
+					out = append(out, children[0])
+					out = append(out, assocChildren...)
+					out = append(out, children[2])
+					n.symbol = indexConstraintSym
+					n.setNamed(indexConstraintNamed)
+					replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
+					nodeInitEquivVersion(n)
 				}
-				out := make([]*Node, 0, len(assocChildren)+2)
-				out = append(out, children[0])
-				out = append(out, assocChildren...)
-				out = append(out, children[2])
-				n.symbol = indexConstraintSym
-				n.setNamed(indexConstraintNamed)
-				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
-				nodeInitEquivVersion(n)
-			}
+			})
 		case namedArrayAggSym:
-			if mid.symbol == arrayAssocSym && bytes.Contains(text, []byte("=>")) && !adaAggregateTextStartsOthers(text) {
-				n.symbol = recordAggSym
-				n.setNamed(recordAggNamed)
-				mid.symbol = recordAssocListSym
-				mid.setNamed(recordAssocListNamed)
-				normalizeAdaRecordAssociationChoices(mid, componentChoiceListSym, componentChoiceListNamed, discreteChoiceListSym, discreteChoiceSym, expressionSym)
-				nodeInitEquivVersion(n)
-				nodeInitEquivVersion(mid)
-			}
-		case recordAggSym:
-			switch {
-			case mid.symbol == recordAssocListSym && bytes.Contains(text, []byte("=>")) && adaAggregateTextStartsOthers(text):
-				n.symbol = namedArrayAggSym
-				n.setNamed(namedArrayAggNamed)
-				mid.symbol = arrayAssocSym
-				mid.setNamed(arrayAssocNamed)
-				normalizeAdaArrayAssociationChoices(mid, componentChoiceListSym, discreteChoiceListSym, discreteChoiceListNamed, discreteChoiceSym, discreteChoiceNamed)
-				nodeInitEquivVersion(n)
-				nodeInitEquivVersion(mid)
-			case mid.symbol == recordAssocListSym && !bytes.Contains(text, []byte("=>")) && bytes.Contains(text, []byte(",")):
-				listChildren := resultChildSliceForMutation(mid)
-				if len(listChildren) == 0 {
-					return
+			census.run("dispatch.ada.aggregate-kind-election", func() {
+				if mid.symbol == arrayAssocSym && bytes.Contains(text, []byte("=>")) && !adaAggregateTextStartsOthers(text) {
+					n.symbol = recordAggSym
+					n.setNamed(recordAggNamed)
+					mid.symbol = recordAssocListSym
+					mid.setNamed(recordAssocListNamed)
+					normalizeAdaRecordAssociationChoicesWithCensus(mid, componentChoiceListSym, componentChoiceListNamed, discreteChoiceListSym, discreteChoiceSym, expressionSym, census)
+					nodeInitEquivVersion(n)
+					nodeInitEquivVersion(mid)
 				}
-				out := make([]*Node, 0, len(listChildren)+2)
-				out = append(out, children[0])
-				out = append(out, listChildren...)
-				out = append(out, children[2])
-				n.symbol = positionalArrayAggSym
-				n.setNamed(positionalArrayAggNamed)
-				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
-				nodeInitEquivVersion(n)
-			}
+			})
+		case recordAggSym:
+			census.run("dispatch.ada.aggregate-kind-election", func() {
+				switch {
+				case mid.symbol == recordAssocListSym && bytes.Contains(text, []byte("=>")) && adaAggregateTextStartsOthers(text):
+					n.symbol = namedArrayAggSym
+					n.setNamed(namedArrayAggNamed)
+					mid.symbol = arrayAssocSym
+					mid.setNamed(arrayAssocNamed)
+					normalizeAdaArrayAssociationChoicesWithCensus(mid, componentChoiceListSym, discreteChoiceListSym, discreteChoiceListNamed, discreteChoiceSym, discreteChoiceNamed, census)
+					nodeInitEquivVersion(n)
+					nodeInitEquivVersion(mid)
+				case mid.symbol == recordAssocListSym && !bytes.Contains(text, []byte("=>")) && bytes.Contains(text, []byte(",")):
+					listChildren := resultChildSliceForMutation(mid)
+					if len(listChildren) == 0 {
+						return
+					}
+					out := make([]*Node, 0, len(listChildren)+2)
+					out = append(out, children[0])
+					out = append(out, listChildren...)
+					out = append(out, children[2])
+					n.symbol = positionalArrayAggSym
+					n.setNamed(positionalArrayAggNamed)
+					replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, out))
+					nodeInitEquivVersion(n)
+				}
+			})
 		}
 	})
 }
@@ -195,21 +210,43 @@ func adaSelectedComponentNode(arena *nodeArena, source []byte, start, end uint32
 }
 
 func normalizeAdaRecordAssociationChoices(assoc *Node, componentChoiceListSym Symbol, componentChoiceListNamed bool, discreteChoiceListSym, discreteChoiceSym, expressionSym Symbol) {
+	normalizeAdaRecordAssociationChoicesWithCensus(
+		assoc,
+		componentChoiceListSym,
+		componentChoiceListNamed,
+		discreteChoiceListSym,
+		discreteChoiceSym,
+		expressionSym,
+		materializationSubpassCensus{},
+	)
+}
+
+func normalizeAdaRecordAssociationChoicesWithCensus(
+	assoc *Node,
+	componentChoiceListSym Symbol,
+	componentChoiceListNamed bool,
+	discreteChoiceListSym Symbol,
+	discreteChoiceSym Symbol,
+	expressionSym Symbol,
+	census materializationSubpassCensus,
+) {
 	walkResultTree(assoc, func(n *Node) {
 		if n == nil || n.symbol != discreteChoiceListSym {
 			return
 		}
-		n.symbol = componentChoiceListSym
-		n.setNamed(componentChoiceListNamed)
-		children := resultChildSliceForMutation(n)
-		if len(children) == 1 && children[0] != nil && children[0].symbol == discreteChoiceSym {
-			innerChildren := resultChildSliceForMutation(children[0])
-			if len(innerChildren) == 1 && innerChildren[0] != nil {
-				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{innerChildren[0]}))
+		census.run("dispatch.ada.association-choice-materialization", func() {
+			n.symbol = componentChoiceListSym
+			n.setNamed(componentChoiceListNamed)
+			children := resultChildSliceForMutation(n)
+			if len(children) == 1 && children[0] != nil && children[0].symbol == discreteChoiceSym {
+				innerChildren := resultChildSliceForMutation(children[0])
+				if len(innerChildren) == 1 && innerChildren[0] != nil {
+					replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{innerChildren[0]}))
+				}
 			}
-		}
-		adaCollapseSingleChildChoiceWrappers(n, expressionSym)
-		nodeInitEquivVersion(n)
+			adaCollapseSingleChildChoiceWrappers(n, expressionSym)
+			nodeInitEquivVersion(n)
+		})
 	})
 }
 
@@ -237,18 +274,40 @@ func adaCollapseSingleChildChoiceWrappers(choiceList *Node, firstWrapperSym Symb
 }
 
 func normalizeAdaArrayAssociationChoices(assoc *Node, componentChoiceListSym, discreteChoiceListSym Symbol, discreteChoiceListNamed bool, discreteChoiceSym Symbol, discreteChoiceNamed bool) {
+	normalizeAdaArrayAssociationChoicesWithCensus(
+		assoc,
+		componentChoiceListSym,
+		discreteChoiceListSym,
+		discreteChoiceListNamed,
+		discreteChoiceSym,
+		discreteChoiceNamed,
+		materializationSubpassCensus{},
+	)
+}
+
+func normalizeAdaArrayAssociationChoicesWithCensus(
+	assoc *Node,
+	componentChoiceListSym Symbol,
+	discreteChoiceListSym Symbol,
+	discreteChoiceListNamed bool,
+	discreteChoiceSym Symbol,
+	discreteChoiceNamed bool,
+	census materializationSubpassCensus,
+) {
 	walkResultTree(assoc, func(n *Node) {
 		if n == nil || n.symbol != componentChoiceListSym {
 			return
 		}
-		n.symbol = discreteChoiceListSym
-		n.setNamed(discreteChoiceListNamed)
-		children := resultChildSliceForMutation(n)
-		if len(children) == 1 && children[0] != nil && children[0].symbol != discreteChoiceSym {
-			wrapper := newParentNodeInArena(n.ownerArena, discreteChoiceSym, discreteChoiceNamed, []*Node{children[0]}, nil, 0)
-			replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{wrapper}))
-		}
-		nodeInitEquivVersion(n)
+		census.run("dispatch.ada.association-choice-materialization", func() {
+			n.symbol = discreteChoiceListSym
+			n.setNamed(discreteChoiceListNamed)
+			children := resultChildSliceForMutation(n)
+			if len(children) == 1 && children[0] != nil && children[0].symbol != discreteChoiceSym {
+				wrapper := newParentNodeInArena(n.ownerArena, discreteChoiceSym, discreteChoiceNamed, []*Node{children[0]}, nil, 0)
+				replaceNodeChildrenUnfielded(n, cloneNodeSliceIfArena(n.ownerArena, []*Node{wrapper}))
+			}
+			nodeInitEquivVersion(n)
+		})
 	})
 }
 

--- a/parser_result_bash.go
+++ b/parser_result_bash.go
@@ -53,22 +53,24 @@ func normalizeBashVariableAssignmentsInNodeWithCensus(
 		}
 		out = append(out, child)
 	}
-	if changed {
-		census.run("dispatch.bash.variable-assignment-wrapper-flattening", func() {
-			if node.ownerArena != nil {
-				buf := node.ownerArena.allocNodeSlice(len(out))
-				copy(buf, out)
-				out = buf
-			}
-			node.children = out
-			node.clearFieldMetadata()
-		})
-	}
-	if node.Type(lang) == "if_statement" {
+	if !changed {
 		census.run("dispatch.bash.if-condition-field-projection", func() {
 			assignBashIfConditionField(node, lang)
 		})
+		return
 	}
+	census.run("dispatch.bash.variable-assignment-wrapper-flattening", func() {
+		if node.ownerArena != nil {
+			buf := node.ownerArena.allocNodeSlice(len(out))
+			copy(buf, out)
+			out = buf
+		}
+		node.children = out
+		node.clearFieldMetadata()
+	})
+	census.run("dispatch.bash.if-condition-field-projection", func() {
+		assignBashIfConditionField(node, lang)
+	})
 }
 
 func normalizeBashGeneratedCommandAssignments(root *Node, source []byte, lang *Language) {

--- a/parser_result_bash.go
+++ b/parser_result_bash.go
@@ -1,19 +1,43 @@
 package gotreesitter
 
 func normalizeBashProgramVariableAssignments(root *Node, lang *Language) {
+	normalizeBashProgramVariableAssignmentsWithCensus(
+		root,
+		lang,
+		materializationSubpassCensus{},
+	)
+}
+
+func normalizeBashProgramVariableAssignmentsWithCensus(
+	root *Node,
+	lang *Language,
+	census materializationSubpassCensus,
+) {
 	if root == nil || lang == nil || lang.Name != "bash" || root.Type(lang) != "program" || len(root.children) == 0 {
 		return
 	}
-	normalizeBashVariableAssignmentsInNode(root, lang)
+	normalizeBashVariableAssignmentsInNodeWithCensus(root, lang, census)
 }
 
 func normalizeBashVariableAssignmentsInNode(node *Node, lang *Language) {
+	normalizeBashVariableAssignmentsInNodeWithCensus(
+		node,
+		lang,
+		materializationSubpassCensus{},
+	)
+}
+
+func normalizeBashVariableAssignmentsInNodeWithCensus(
+	node *Node,
+	lang *Language,
+	census materializationSubpassCensus,
+) {
 	if node == nil || lang == nil || len(node.children) == 0 {
 		return
 	}
 	for _, child := range node.children {
 		if child != nil {
-			normalizeBashVariableAssignmentsInNode(child, lang)
+			normalizeBashVariableAssignmentsInNodeWithCensus(child, lang, census)
 		}
 	}
 	out := make([]*Node, 0, len(node.children))
@@ -29,18 +53,22 @@ func normalizeBashVariableAssignmentsInNode(node *Node, lang *Language) {
 		}
 		out = append(out, child)
 	}
-	if !changed {
-		assignBashIfConditionField(node, lang)
-		return
+	if changed {
+		census.run("dispatch.bash.variable-assignment-wrapper-flattening", func() {
+			if node.ownerArena != nil {
+				buf := node.ownerArena.allocNodeSlice(len(out))
+				copy(buf, out)
+				out = buf
+			}
+			node.children = out
+			node.clearFieldMetadata()
+		})
 	}
-	if node.ownerArena != nil {
-		buf := node.ownerArena.allocNodeSlice(len(out))
-		copy(buf, out)
-		out = buf
+	if node.Type(lang) == "if_statement" {
+		census.run("dispatch.bash.if-condition-field-projection", func() {
+			assignBashIfConditionField(node, lang)
+		})
 	}
-	node.children = out
-	node.clearFieldMetadata()
-	assignBashIfConditionField(node, lang)
 }
 
 func normalizeBashGeneratedCommandAssignments(root *Node, source []byte, lang *Language) {

--- a/parser_result_compat.go
+++ b/parser_result_compat.go
@@ -110,18 +110,31 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 
 	switch ctx.lang.Name {
 	case "ada":
-		dispatcherArmCensus(ctx, "dispatch.ada", func() { normalizeAdaCompatibility(ctx.root, ctx.source, ctx.lang) })
+		dispatcherArmSubpassCensus(ctx, "dispatch.ada", func(census materializationSubpassCensus) {
+			normalizeAdaCompatibilityWithCensus(ctx.root, ctx.source, ctx.lang, census)
+		})
 	case "apex":
-		dispatcherArmCensus(ctx, "dispatch.apex", func() { normalizeApexCompatibility(ctx.root, ctx.source, ctx.lang) })
+		dispatcherArmSubpassCensus(ctx, "dispatch.apex", func(census materializationSubpassCensus) {
+			census.run("dispatch.apex.generic-local-declaration", func() {
+				normalizeApexGenericLocalDeclarations(ctx.root, ctx.source, ctx.lang)
+			})
+			census.run("dispatch.apex.class-literal-alias", func() {
+				normalizeApexClassLiteralAccess(ctx.root, ctx.source, ctx.lang)
+			})
+		})
 	case "authzed":
 		dispatcherArmCensus(ctx, "dispatch.authzed", func() { normalizeAuthzedCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "awk":
 		dispatcherArmCensus(ctx, "dispatch.awk", func() { normalizeAwkCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "bash":
-		dispatcherArmCensus(ctx, "dispatch.bash", func() {
-			normalizeBashProgramVariableAssignments(ctx.root, ctx.lang)
-			normalizeBashGeneratedCommandAssignments(ctx.root, ctx.source, ctx.lang)
-			normalizeBashCommandNameArguments(ctx.root, ctx.lang)
+		dispatcherArmSubpassCensus(ctx, "dispatch.bash", func(census materializationSubpassCensus) {
+			normalizeBashProgramVariableAssignmentsWithCensus(ctx.root, ctx.lang, census)
+			census.run("dispatch.bash.generated-command-assignment", func() {
+				normalizeBashGeneratedCommandAssignments(ctx.root, ctx.source, ctx.lang)
+			})
+			census.run("dispatch.bash.command-name-concatenation", func() {
+				normalizeBashCommandNameArguments(ctx.root, ctx.lang)
+			})
 		})
 	case "bitbake":
 		dispatcherArmCensus(ctx, "dispatch.bitbake", func() { normalizeBitbakeCompatibility(ctx.root, ctx.source, ctx.lang) })
@@ -130,7 +143,9 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 	case "c_sharp":
 		dispatcherArmCensus(ctx, "dispatch.c_sharp", func() { normalizeCSharpCompatibility(ctx.root, ctx.source, ctx.parser, ctx.lang) })
 	case "cooklang":
-		dispatcherArmCensus(ctx, "dispatch.cooklang", func() { normalizeCooklangCompatibility(ctx.root, ctx.source, ctx.lang) })
+		dispatcherArmSubpassCensus(ctx, "dispatch.cooklang", func(census materializationSubpassCensus) {
+			normalizeCooklangCompatibilityWithCensus(ctx.root, ctx.source, ctx.lang, census)
+		})
 	case "corn":
 		dispatcherArmCensus(ctx, "dispatch.corn", func() { normalizeCornCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "dart":
@@ -154,7 +169,11 @@ func runLanguageResultCompatibility(ctx resultCompatibilityContext) resultCompat
 		})
 		return resultCompatibilityResult{stopReason: stopReason}
 	case "http":
-		dispatcherArmCensus(ctx, "dispatch.http", func() { normalizeHTTPCompatibility(ctx.root, ctx.source, ctx.lang) })
+		dispatcherArmSubpassCensus(ctx, "dispatch.http", func(census materializationSubpassCensus) {
+			census.run("dispatch.http.document-section-coalescing", func() {
+				normalizeHTTPCompatibility(ctx.root, ctx.source, ctx.lang)
+			})
+		})
 	case "hlsl":
 		dispatcherArmCensus(ctx, "dispatch.hlsl", func() { normalizeHLSLCompatibility(ctx.root, ctx.source, ctx.lang) })
 	case "hyprlang":

--- a/parser_result_cooklang.go
+++ b/parser_result_cooklang.go
@@ -3,8 +3,26 @@ package gotreesitter
 import "bytes"
 
 func normalizeCooklangCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeCooklangTrailingStepTail(root, source, lang)
-	normalizeCooklangRecoveredRecipe(root, source, lang)
+	normalizeCooklangCompatibilityWithCensus(
+		root,
+		source,
+		lang,
+		materializationSubpassCensus{},
+	)
+}
+
+func normalizeCooklangCompatibilityWithCensus(
+	root *Node,
+	source []byte,
+	lang *Language,
+	census materializationSubpassCensus,
+) {
+	census.run("dispatch.cooklang.trailing-step-tail", func() {
+		normalizeCooklangTrailingStepTail(root, source, lang)
+	})
+	census.run("dispatch.cooklang.recovered-recipe", func() {
+		normalizeCooklangRecoveredRecipe(root, source, lang)
+	})
 }
 
 func normalizeCooklangRecoveredRecipe(root *Node, source []byte, lang *Language) {

--- a/parser_result_test/materialization_subpass_census_test.go
+++ b/parser_result_test/materialization_subpass_census_test.go
@@ -1,0 +1,415 @@
+//go:build !grammar_subset
+
+package parserresult_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+type materializationSubpassProbe struct {
+	name               string
+	language           func() *gotreesitter.Language
+	source             string
+	wantRawDigest      string
+	wantResultDigest   string
+	expectedSubpasses  []string
+	rewrittenSubpasses []string
+}
+
+func TestMaterializationSubpassCompatibilityFreeProducerProbes(t *testing.T) {
+	for _, probe := range materializationSubpassProbes() {
+		probe := probe
+		t.Run(probe.name, func(t *testing.T) {
+			language := probe.language()
+			source := []byte(probe.source)
+
+			t.Setenv("GTS_DISPATCHER_CENSUS", "")
+			rawDigest, _ := materializationSubpassParseDigest(
+				t,
+				language,
+				source,
+				true,
+			)
+			resultDigest, _ := materializationSubpassParseDigest(
+				t,
+				language,
+				source,
+				false,
+			)
+
+			t.Setenv("GTS_DISPATCHER_CENSUS", "1")
+			censusDigest, runtime := materializationSubpassParseDigest(
+				t,
+				language,
+				source,
+				false,
+			)
+			if censusDigest != resultDigest {
+				t.Fatalf(
+					"census changed production output: got %s, want %s",
+					censusDigest,
+					resultDigest,
+				)
+			}
+			if probe.wantRawDigest != "" && rawDigest != probe.wantRawDigest {
+				t.Fatalf("raw digest = %s, want %s", rawDigest, probe.wantRawDigest)
+			}
+			if probe.wantResultDigest != "" && resultDigest != probe.wantResultDigest {
+				t.Fatalf(
+					"result digest = %s, want %s",
+					resultDigest,
+					probe.wantResultDigest,
+				)
+			}
+			assertMaterializationSubpassReceipts(
+				t,
+				runtime,
+				probe.expectedSubpasses,
+				probe.rewrittenSubpasses,
+			)
+			t.Logf("raw=%s result=%s", rawDigest, resultDigest)
+		})
+	}
+}
+
+func materializationSubpassParseDigest(
+	t *testing.T,
+	language *gotreesitter.Language,
+	source []byte,
+	withoutCompatibility bool,
+) (string, gotreesitter.ParseRuntime) {
+	t.Helper()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(false)
+	var (
+		tree *gotreesitter.Tree
+		err  error
+	)
+	if withoutCompatibility {
+		tree, err = parser.ParseNoResultCompatibilityBenchmarkOnly(source)
+	} else {
+		tree, err = parser.Parse(source)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("parse returned no tree")
+	}
+	defer tree.Release()
+	inspection, err := benchfixtures.InspectGoTree(tree.RootNode(), language)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return inspection.SHA256, tree.ParseRuntime()
+}
+
+func assertMaterializationSubpassReceipts(
+	t *testing.T,
+	runtime gotreesitter.ParseRuntime,
+	expected []string,
+	rewritten []string,
+) {
+	t.Helper()
+	if runtime.NormalizationPasses == nil {
+		t.Fatal("census recorded no normalization passes")
+	}
+	passes := make(map[string]gotreesitter.NormalizationPassRuntime)
+	for _, pass := range *runtime.NormalizationPasses {
+		passes[pass.Name] = pass
+	}
+	wantRewritten := make(map[string]bool, len(rewritten))
+	for _, name := range rewritten {
+		wantRewritten[name] = true
+	}
+	for _, name := range expected {
+		pass, ok := passes[name]
+		if !ok {
+			t.Errorf("census did not record %s: %+v", name, passes)
+			continue
+		}
+		if pass.Checked == 0 || pass.Run == 0 || pass.NodesVisited == 0 {
+			t.Errorf("%s has a vacuous census receipt: %+v", name, pass)
+		}
+		if got := pass.NodesRewritten > 0; got != wantRewritten[name] {
+			t.Errorf(
+				"%s rewrite state = %t, want %t: %+v",
+				name,
+				got,
+				wantRewritten[name],
+				pass,
+			)
+		}
+		t.Logf("%s: %+v", name, pass)
+	}
+}
+
+func materializationSubpassProbes() []materializationSubpassProbe {
+	return []materializationSubpassProbe{
+		{
+			name:     "ada_locked_named_array_aggregate",
+			language: grammars.AdaLanguage,
+			// tree-sitter-ada test/corpus/arrays.txt, commit 6b58259a.
+			source: "package P is\n" +
+				"   type A is array (1 .. 2) of Boolean;\n" +
+				"   V : constant A := (1 => True, 2 => False);\n" +
+				"   V2 : constant A := (1 => True, others => False);\n" +
+				"end P;\n",
+			wantRawDigest:    "728491faf7df326e0557c468af03e026a9b4461b86f9de9f28da9162f9510c71",
+			wantResultDigest: "728491faf7df326e0557c468af03e026a9b4461b86f9de9f28da9162f9510c71",
+			expectedSubpasses: []string{
+				"dispatch.ada",
+			},
+		},
+		{
+			name:     "ada_locked_positional_array_aggregate",
+			language: grammars.AdaLanguage,
+			// tree-sitter-ada test/corpus/arrays.txt, commit 6b58259a.
+			source: "package P is\n" +
+				"   type A is array (1 .. 3) of Boolean;\n" +
+				"   V : constant A := (1, 2, 3);\n" +
+				"end;\n",
+			wantRawDigest:    "2548948d4cac86cf3b438642ac347917b72371467fd928be0de7437210e98a50",
+			wantResultDigest: "c056e4222c7e642fbf23054a75b40f3ff186ff687eb49e8bcd5a36c513d10f14",
+			expectedSubpasses: []string{
+				"dispatch.ada",
+				"dispatch.ada.aggregate-kind-election",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.ada",
+				"dispatch.ada.aggregate-kind-election",
+			},
+		},
+		{
+			name:     "ada_locked_record_aggregate",
+			language: grammars.AdaLanguage,
+			// tree-sitter-ada test/corpus/records.txt, commit 6b58259a.
+			source: "procedure P is\n" +
+				"begin\n" +
+				"   A := (F1 => 1, F2 => 2);\n" +
+				"end;\n",
+			wantRawDigest:    "ef26cc01b0dee3da50728dbfa242162ba837798c34450674d8b3ce3ed06955d6",
+			wantResultDigest: "ef26cc01b0dee3da50728dbfa242162ba837798c34450674d8b3ce3ed06955d6",
+			expectedSubpasses: []string{
+				"dispatch.ada",
+			},
+		},
+		{
+			name:     "ada_array_others_choice",
+			language: grammars.AdaLanguage,
+			source: "procedure P is\n" +
+				"begin\n" +
+				"   A := (others => 0);\n" +
+				"end;\n",
+			wantRawDigest:    "436a2b8ebb3e7d0a6ebad2fddaae9bd3a1f7a040a91741581109fa3d59558f7e",
+			wantResultDigest: "67f7351db255e847be4172f69a33cd349b2883c693b837eebb32979ccaf4b9a7",
+			expectedSubpasses: []string{
+				"dispatch.ada",
+				"dispatch.ada.aggregate-kind-election",
+				"dispatch.ada.association-choice-materialization",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.ada",
+				"dispatch.ada.aggregate-kind-election",
+				"dispatch.ada.association-choice-materialization",
+			},
+		},
+		{
+			name:     "ada_attribute_constraint",
+			language: grammars.AdaLanguage,
+			source: "procedure P is\n" +
+				"begin\n" +
+				"   A := new T (F => Pkg.Obj'Access);\n" +
+				"end;\n",
+			wantRawDigest:    "a35538112ad4ae10df6d5544c7f0a58f3e6a3ecb5fd5fb842808d0e31ac27ac2",
+			wantResultDigest: "d0006efd9f34dce85ac48330642b378dc2b5f995004c9c11a20aee98ac6be8a2",
+			expectedSubpasses: []string{
+				"dispatch.ada",
+				"dispatch.ada.constraint-kind-election",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.ada",
+				"dispatch.ada.constraint-kind-election",
+			},
+		},
+		{
+			name:     "apex_generic_local_declaration",
+			language: grammars.ApexLanguage,
+			source: "public class C {\n" +
+				"  void m() {\n" +
+				"    List<List<SObject>> searchResults = [FIND :keyword IN ALL FIELDS];\n" +
+				"  }\n" +
+				"}\n",
+			wantRawDigest:    "84ea02bcd332e4fea9eb6d7f7e13102b489c8e1fa002cc1dfbea938c2e1d25a7",
+			wantResultDigest: "35ec351ac90dcccd197a426a9f4d0d663aa9df54c5612157b95352c3943f8a4a",
+			expectedSubpasses: []string{
+				"dispatch.apex",
+				"dispatch.apex.generic-local-declaration",
+				"dispatch.apex.class-literal-alias",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.apex",
+				"dispatch.apex.generic-local-declaration",
+			},
+		},
+		{
+			name:     "apex_class_literal_alias",
+			language: grammars.ApexLanguage,
+			source: "public class C {\n" +
+				"  void m() {\n" +
+				"    Object t = RecordPage.class;\n" +
+				"  }\n" +
+				"}\n",
+			wantRawDigest:    "a7ce1bb2fb703f6c85a85bac1116a31f9d14f03cd4560f8fe81f518b19d36f33",
+			wantResultDigest: "691872382855aafce9519a115ca30ac191c4a118d4ab7170e88e0193fd2f5bb6",
+			expectedSubpasses: []string{
+				"dispatch.apex",
+				"dispatch.apex.generic-local-declaration",
+				"dispatch.apex.class-literal-alias",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.apex",
+				"dispatch.apex.class-literal-alias",
+			},
+		},
+		{
+			name:             "bash_assignment_wrapper",
+			language:         grammars.BashLanguage,
+			source:           "a=1 b=2 c=3",
+			wantRawDigest:    "acf5436fdf47d1af14d387f9bc7ebc30ec09b4874d6a9e9caf452678e387c9f6",
+			wantResultDigest: "81ace1f9c8a394d177e5ea909ff3012329ec78b255e45a235fc8a3eea4a67a16",
+			expectedSubpasses: []string{
+				"dispatch.bash",
+				"dispatch.bash.variable-assignment-wrapper-flattening",
+				"dispatch.bash.generated-command-assignment",
+				"dispatch.bash.command-name-concatenation",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.bash",
+				"dispatch.bash.variable-assignment-wrapper-flattening",
+			},
+		},
+		{
+			name:             "bash_generated_command_assignment",
+			language:         grammars.BashLanguage,
+			source:           "zipname=npm-$(node ../cli.js -v).zip",
+			wantRawDigest:    "a2dac68ad605a69720f13549488b1519627653226bb252bd89db912ae1558e8b",
+			wantResultDigest: "a2dac68ad605a69720f13549488b1519627653226bb252bd89db912ae1558e8b",
+			expectedSubpasses: []string{
+				"dispatch.bash",
+				"dispatch.bash.generated-command-assignment",
+				"dispatch.bash.command-name-concatenation",
+			},
+		},
+		{
+			name:             "bash_command_name_concatenation",
+			language:         grammars.BashLanguage,
+			source:           "${0%/*}/check-unsafe-assertions.sh",
+			wantRawDigest:    "a5b4479ddfaa21239153effb0ee7b1f886155c25e2ea6ba43d56c5087a211819",
+			wantResultDigest: "a5b4479ddfaa21239153effb0ee7b1f886155c25e2ea6ba43d56c5087a211819",
+			expectedSubpasses: []string{
+				"dispatch.bash",
+				"dispatch.bash.generated-command-assignment",
+				"dispatch.bash.command-name-concatenation",
+			},
+		},
+		{
+			name:     "bash_if_condition_field",
+			language: grammars.BashLanguage,
+			source: "if [ $ret -eq 0 ]; then\n" +
+				"  (exit 0)\n" +
+				"else\n" +
+				"  rm npm-install-$$.sh\n" +
+				"  echo \"Failed to download script\" >&2\n" +
+				"  exit $ret\n" +
+				"fi\n",
+			wantRawDigest:    "7d110bcd4998cf43995020d6ee6326ef0e060b587ce44fa75943d95d86156cd5",
+			wantResultDigest: "7d110bcd4998cf43995020d6ee6326ef0e060b587ce44fa75943d95d86156cd5",
+			expectedSubpasses: []string{
+				"dispatch.bash",
+				"dispatch.bash.if-condition-field-projection",
+				"dispatch.bash.generated-command-assignment",
+				"dispatch.bash.command-name-concatenation",
+			},
+		},
+		{
+			name:             "cooklang_trailing_step_tail",
+			language:         grammars.CooklangLanguage,
+			source:           "Add @salt{1%tsp}.\n",
+			wantRawDigest:    "0e6880ec4902576c2a6de014424c3cba7eef99cdc5fd8fded8ceb6382a6df9cd",
+			wantResultDigest: "c6e4535b725516550ca7a0ee4c69974799c2d2d10fed4e5f1ba6b71e43c5ba8a",
+			expectedSubpasses: []string{
+				"dispatch.cooklang",
+				"dispatch.cooklang.trailing-step-tail",
+				"dispatch.cooklang.recovered-recipe",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.cooklang",
+				"dispatch.cooklang.recovered-recipe",
+			},
+		},
+		{
+			name:     "cooklang_recovered_recipe",
+			language: grammars.CooklangLanguage,
+			source: "---\n" +
+				"servings: 4\n" +
+				"emoji: 🥟\n" +
+				"tags: warm, fried, starter\n" +
+				"---\n\n" +
+				"Serve hot.\n",
+			wantRawDigest:    "896d9f79d941c3869dca7b855bae45738392d02519f0fbe3ac45cc2623fcfa2f",
+			wantResultDigest: "814240a8aff9c3e253b37ce1ff535ff2cd96510c6afea40680a270405699967f",
+			expectedSubpasses: []string{
+				"dispatch.cooklang",
+				"dispatch.cooklang.trailing-step-tail",
+				"dispatch.cooklang.recovered-recipe",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.cooklang",
+				"dispatch.cooklang.recovered-recipe",
+			},
+		},
+		{
+			name:             "cooklang_step_tail_without_newline",
+			language:         grammars.CooklangLanguage,
+			source:           "Add @salt{1%tsp}.",
+			wantRawDigest:    "f49ca1a85a0b2ee7ed7f07993d6bc8b103d66311f83d4a026e085cf2013a69ec",
+			wantResultDigest: "dd3692a1a0e9145af9f2d082126a1e798d60cbe74942427746d3f0e83bd31e1c",
+			expectedSubpasses: []string{
+				"dispatch.cooklang",
+				"dispatch.cooklang.trailing-step-tail",
+				"dispatch.cooklang.recovered-recipe",
+			},
+			rewrittenSubpasses: []string{
+				"dispatch.cooklang",
+				"dispatch.cooklang.recovered-recipe",
+			},
+		},
+		{
+			name:             "http_blank_section",
+			language:         grammars.HttpLanguage,
+			source:           "# c\n\n### next\n",
+			wantRawDigest:    "12c900585dc7ecae3a5dc6c3a7072b927a56d0c5dd7f9f699eb8169acceb948b",
+			wantResultDigest: "12c900585dc7ecae3a5dc6c3a7072b927a56d0c5dd7f9f699eb8169acceb948b",
+			expectedSubpasses: []string{
+				"dispatch.http",
+				"dispatch.http.document-section-coalescing",
+			},
+		},
+		{
+			name:             "http_content_sections",
+			language:         grammars.HttpLanguage,
+			source:           "### a\n# c\nGET /\n### b\n",
+			wantRawDigest:    "e67faf42a5f1da1b558a4b40acc86c011ad900b6aa573713729ee1a7bcf43e7e",
+			wantResultDigest: "e67faf42a5f1da1b558a4b40acc86c011ad900b6aa573713729ee1a7bcf43e7e",
+			expectedSubpasses: []string{
+				"dispatch.http",
+				"dispatch.http.document-section-coalescing",
+			},
+		},
+	}
+}

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -22,10 +22,55 @@
       "id": "dispatch.ada",
       "kind": "dispatcher_arm",
       "functions": [
-        "normalizeAdaCompatibility"
+        "normalizeAdaCompatibilityWithCensus"
       ],
       "files": [
         "parser_result_ada.go"
+      ],
+      "subpasses": [
+        {
+          "id": "dispatch.ada.constraint-kind-election",
+          "functions": [
+            "normalizeAdaCompatibilityWithCensus"
+          ],
+          "files": [
+            "parser_result_ada.go"
+          ],
+          "purpose": "Select an index constraint and construct its attribute-reference children when the selected Ada derivation has the discriminant shape.",
+          "authoritative_owner": "derivation_election_selection",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.ada.aggregate-kind-election",
+          "functions": [
+            "normalizeAdaCompatibilityWithCensus"
+          ],
+          "files": [
+            "parser_result_ada.go"
+          ],
+          "purpose": "Select the record, named-array, or positional-array aggregate type.",
+          "authoritative_owner": "derivation_election_selection",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.ada.association-choice-materialization",
+          "functions": [
+            "normalizeAdaArrayAssociationChoicesWithCensus",
+            "normalizeAdaRecordAssociationChoicesWithCensus"
+          ],
+          "files": [
+            "parser_result_ada.go"
+          ],
+          "purpose": "Construct the selected record or array association-choice wrappers.",
+          "authoritative_owner": "materialization",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        }
       ],
       "languages": [
         "ada"
@@ -83,10 +128,41 @@
       "id": "dispatch.apex",
       "kind": "dispatcher_arm",
       "functions": [
-        "normalizeApexCompatibility"
+        "normalizeApexClassLiteralAccess",
+        "normalizeApexGenericLocalDeclarations"
       ],
       "files": [
         "parser_result_apex.go"
+      ],
+      "subpasses": [
+        {
+          "id": "dispatch.apex.generic-local-declaration",
+          "functions": [
+            "normalizeApexGenericLocalDeclarations"
+          ],
+          "files": [
+            "parser_result_apex.go"
+          ],
+          "purpose": "Select and construct a generic local-variable declaration from the parsed expression shape.",
+          "authoritative_owner": "derivation_election_selection",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.apex.class-literal-alias",
+          "functions": [
+            "normalizeApexClassLiteralAccess"
+          ],
+          "files": [
+            "parser_result_apex.go"
+          ],
+          "purpose": "Materialize the field-access aliases for an Apex class literal.",
+          "authoritative_owner": "materialization",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        }
       ],
       "languages": [
         "apex"
@@ -200,12 +276,70 @@
       "id": "dispatch.bash",
       "kind": "dispatcher_arm",
       "functions": [
-        "normalizeBashProgramVariableAssignments",
+        "normalizeBashProgramVariableAssignmentsWithCensus",
         "normalizeBashGeneratedCommandAssignments",
         "normalizeBashCommandNameArguments"
       ],
       "files": [
         "parser_result_bash.go"
+      ],
+      "subpasses": [
+        {
+          "id": "dispatch.bash.variable-assignment-wrapper-flattening",
+          "functions": [
+            "normalizeBashVariableAssignmentsInNodeWithCensus"
+          ],
+          "files": [
+            "parser_result_bash.go"
+          ],
+          "purpose": "Materialize assignment siblings without a generated variable-assignments wrapper.",
+          "authoritative_owner": "materialization",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.bash.generated-command-assignment",
+          "functions": [
+            "normalizeBashGeneratedCommandAssignments"
+          ],
+          "files": [
+            "parser_result_bash.go"
+          ],
+          "purpose": "Select an assignment action instead of a generated command action.",
+          "authoritative_owner": "scheduler_action_semantics",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.bash.command-name-concatenation",
+          "functions": [
+            "normalizeBashCommandNameArguments"
+          ],
+          "files": [
+            "parser_result_bash.go"
+          ],
+          "purpose": "Construct one command-name concatenation from adjacent command children.",
+          "authoritative_owner": "materialization",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.bash.if-condition-field-projection",
+          "functions": [
+            "assignBashIfConditionField"
+          ],
+          "files": [
+            "parser_result_bash.go"
+          ],
+          "purpose": "Project the condition field from the Bash reduction metadata.",
+          "authoritative_owner": "materialization",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        }
       ],
       "languages": [
         "bash"
@@ -423,10 +557,41 @@
       "id": "dispatch.cooklang",
       "kind": "dispatcher_arm",
       "functions": [
-        "normalizeCooklangCompatibility"
+        "normalizeCooklangCompatibilityWithCensus"
       ],
       "files": [
-        "parser_result_cooklang.go"
+        "parser_result_cooklang.go",
+        "parser_result_misc_spans.go"
+      ],
+      "subpasses": [
+        {
+          "id": "dispatch.cooklang.trailing-step-tail",
+          "functions": [
+            "normalizeCooklangTrailingStepTail"
+          ],
+          "files": [
+            "parser_result_misc_spans.go"
+          ],
+          "purpose": "Publish the punctuation tail and the complete recipe span.",
+          "authoritative_owner": "scanner_checkpoint_state",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        },
+        {
+          "id": "dispatch.cooklang.recovered-recipe",
+          "functions": [
+            "normalizeCooklangRecoveredRecipe"
+          ],
+          "files": [
+            "parser_result_cooklang.go"
+          ],
+          "purpose": "Select and construct recovered steps, metadata, punctuation errors, and fence comments.",
+          "authoritative_owner": "scheduler_action_semantics",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        }
       ],
       "languages": [
         "cooklang"
@@ -1155,6 +1320,22 @@
       ],
       "files": [
         "parser_result_http.go"
+      ],
+      "subpasses": [
+        {
+          "id": "dispatch.http.document-section-coalescing",
+          "functions": [
+            "normalizeHTTPDocumentSections"
+          ],
+          "files": [
+            "parser_result_http.go"
+          ],
+          "purpose": "Select and construct one section from adjacent recovered document sections.",
+          "authoritative_owner": "scheduler_action_semantics",
+          "witnesses": [
+            "parser_result_test/materialization_subpass_census_test.go"
+          ]
+        }
       ],
       "languages": [
         "http"


### PR DESCRIPTION
## Summary

- Report distinct subpasses for the five live materialization arms.
- Classify each subpass by its earliest upstream owner.
- Add raw producer probes with exact output digests.
- Add locked Ada aggregate fixtures.
- Correct Cooklang function and file coverage.

This change does not remove a normalizer or change parser output.

## Evidence

- The raw and production digests match base commit `4f077315d3aa5dcec4f5392c7eb17a1bbc27a455`.
- Census-enabled output matches normal production output.
- The probe suite passes ten repeated host runs.
- Focused Docker C parity passes for Ada, Apex, Bash, Cooklang, and HTTP.
- Focused Docker unit and probe tests pass.
- Canopy finds exactly five dispatcher calls to `dispatcherArmSubpassCensus`.

## Next step

Use the inert receipts to test HTTP retirement first. Keep the active repairs until their upstream owners emit the exact tree.