### PR TITLE
add(parsercorephase0): expose clean multi-pop path rank

### DIFF
--- a/internal/parsercorephase0/clean_path_rank_test.go
+++ b/internal/parsercorephase0/clean_path_rank_test.go
@@ -1,0 +1,352 @@
+package parsercorephase0
+
+import (
+	"reflect"
+	"testing"
+)
+
+type cleanPathRankBranch struct {
+	predecessor StateID
+	prefixScore []int64
+	windowScore int64
+	gotoState   StateID
+}
+
+func newCleanPathRankFixture(tb testing.TB, branches []cleanPathRankBranch) (*Core, Head) {
+	tb.Helper()
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 50, symbol: 9}: {{
+				Type: ActionReduce, Symbol: 2, ChildCount: 1, ProductionID: 6,
+			}},
+		},
+		gotos: make(map[tableCell]StateID, len(branches)),
+	}
+	for _, branch := range branches {
+		tables.gotos[tableCell{state: branch.predecessor, symbol: 2}] = branch.gotoState
+	}
+	compact, err := New(tables, Limits{MaxDerivations: 16, MaxPopPaths: 16})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	compact.diagnostics.foldSamePredecessorShallowPayloads = false
+
+	var head Head
+	for branchIndex, branch := range branches {
+		baseState := StateID(100 + branchIndex)
+		branchHead, err := compact.Seed(baseState, 0)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		for prefixIndex, score := range branch.prefixScore {
+			payload, err := compact.appendSubtree(subtreeRecord{
+				symbol:   Symbol(100 + prefixIndex),
+				terminal: true,
+			}, nil, nil, nil)
+			if err != nil {
+				tb.Fatal(err)
+			}
+			nextState := StateID(200 + branchIndex*16 + prefixIndex)
+			if prefixIndex == len(branch.prefixScore)-1 {
+				nextState = branch.predecessor
+			}
+			branchHead, err = compact.appendPrivate(nextState, 0, linkInput{
+				prev: branchHead.Node, payload: payload, scoreDelta: score,
+			})
+			if err != nil {
+				tb.Fatal(err)
+			}
+		}
+		if len(branch.prefixScore) == 0 {
+			branchHead, err = compact.Seed(branch.predecessor, 0)
+			if err != nil {
+				tb.Fatal(err)
+			}
+		}
+		child, err := compact.appendSubtree(subtreeRecord{
+			symbol: 10, startByte: 0, endByte: 1,
+			terminal: true,
+		}, nil, nil, nil)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		head, err = compact.condense(compact.boundaryKey(50, 1), linkInput{
+			prev: branchHead.Node, payload: child, scoreDelta: branch.windowScore,
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return compact, head
+}
+
+func cleanPathRankOutputStates(tb testing.TB, compact *Core, outputs []ReductionOutput) map[StateID]CleanPathRankSelection {
+	tb.Helper()
+	got := make(map[StateID]CleanPathRankSelection, len(outputs))
+	for _, output := range outputs {
+		node, err := compact.node(output.Head.Node)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		got[node.state] = output.CleanPathRank
+	}
+	return got
+}
+
+func newAmbiguousPrefixRankFixture(tb testing.TB) (*Core, Head) {
+	tb.Helper()
+	tables := &fakeTable{
+		actions: map[tableCell][]Action{
+			{state: 50, symbol: 9}: {{
+				Type: ActionReduce, Symbol: 2, ChildCount: 1,
+			}},
+		},
+		gotos: map[tableCell]StateID{
+			{state: 1, symbol: 2}: 60,
+			{state: 2, symbol: 2}: 61,
+		},
+	}
+	compact, err := New(tables, Limits{MaxDerivations: 16, MaxPopPaths: 16})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	compact.diagnostics.foldSamePredecessorShallowPayloads = false
+	leftSeed, _ := compact.Seed(10, 0)
+	rightSeed, _ := compact.Seed(11, 0)
+	other, _ := compact.Seed(2, 0)
+	leftPayload, _ := compact.appendSubtree(
+		subtreeRecord{symbol: 20, terminal: true}, nil, nil, nil,
+	)
+	rightPayload, _ := compact.appendSubtree(
+		subtreeRecord{symbol: 21, terminal: true}, nil, nil, nil,
+	)
+	prefix, err := compact.condense(compact.boundaryKey(1, 0), linkInput{
+		prev: leftSeed.Node, payload: leftPayload, scoreDelta: 5,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	prefix, err = compact.condense(compact.boundaryKey(1, 0), linkInput{
+		prev: rightSeed.Node, payload: rightPayload, scoreDelta: 5,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	firstChild, _ := compact.appendSubtree(
+		subtreeRecord{symbol: 10, endByte: 1, terminal: true}, nil, nil, nil,
+	)
+	secondChild, _ := compact.appendSubtree(
+		subtreeRecord{symbol: 11, endByte: 1, terminal: true}, nil, nil, nil,
+	)
+	head, err := compact.condense(compact.boundaryKey(50, 1), linkInput{
+		prev: prefix.Node, payload: firstChild,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	head, err = compact.condense(compact.boundaryKey(50, 1), linkInput{
+		prev: other.Node, payload: secondChild, scoreDelta: 4,
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return compact, head
+}
+
+func TestCleanPathRankUsesScoreBeforeDepth(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60},
+		{predecessor: 2, prefixScore: []int64{2, 2}, gotoState: 61},
+	})
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cleanPathRankOutputStates(t, compact, outputs)
+	want := map[StateID]CleanPathRankSelection{
+		60: CleanPathRankSelected,
+		61: CleanPathRankUnselected,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ranked outputs=%v, want %v", got, want)
+	}
+}
+
+func TestCleanPathRankUsesDepthAfterEqualScore(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{3}, gotoState: 60},
+		{predecessor: 2, prefixScore: []int64{1, 2}, gotoState: 61},
+	})
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cleanPathRankOutputStates(t, compact, outputs)
+	want := map[StateID]CleanPathRankSelection{
+		60: CleanPathRankUnselected,
+		61: CleanPathRankSelected,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ranked outputs=%v, want %v", got, want)
+	}
+}
+
+func TestCleanPathRankExactCrossPathTieIsUnknown(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{3}, gotoState: 60},
+		{predecessor: 2, prefixScore: []int64{3}, gotoState: 61},
+	})
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cleanPathRankOutputStates(t, compact, outputs)
+	want := map[StateID]CleanPathRankSelection{
+		60: CleanPathRankUnknown,
+		61: CleanPathRankUnknown,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ranked outputs=%v, want fail-closed %v", got, want)
+	}
+}
+
+func TestCleanPathRankAggregatesSelectedOccurrence(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60},
+		{predecessor: 2, prefixScore: []int64{4}, gotoState: 60},
+	})
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outputs) != 1 || outputs[0].CleanPathRank != CleanPathRankSelected {
+		t.Fatalf("aggregated outputs=%+v, want one selected output", outputs)
+	}
+}
+
+func TestCleanPathRankKeepsSamePathPrefixTieKnown(t *testing.T) {
+	compact, head := newAmbiguousPrefixRankFixture(t)
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cleanPathRankOutputStates(t, compact, outputs)
+	want := map[StateID]CleanPathRankSelection{
+		60: CleanPathRankSelected,
+		61: CleanPathRankUnselected,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ranked outputs=%v, want %v", got, want)
+	}
+}
+
+func TestCleanPathRankPrefixCapIsUnknown(t *testing.T) {
+	compact, head := newAmbiguousPrefixRankFixture(t)
+	compact.limits.MaxDerivations = 1
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, output := range outputs {
+		if output.CleanPathRank != CleanPathRankUnknown {
+			t.Fatalf("capped ranked output=%+v, want unknown", output)
+		}
+	}
+}
+
+func TestCleanPathRankSteadyStateDoesNotAllocate(t *testing.T) {
+	compact, head := newAmbiguousPrefixRankFixture(t)
+	paths, err := compact.popPaths(head.Node, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.markCleanProductionRank(paths)
+	if got := testing.AllocsPerRun(100, func() {
+		compact.markCleanProductionRank(paths)
+	}); got != 0 {
+		t.Fatalf("clean path rank allocations/run=%f, want 0", got)
+	}
+}
+
+func TestCleanPathRankPanicRollsBackAndRetries(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60},
+		{predecessor: 2, prefixScore: []int64{1, 2}, gotoState: 61},
+	})
+	base, ok := compact.tables.(*fakeTable)
+	if !ok {
+		t.Fatalf("fixture tables type=%T, want *fakeTable", compact.tables)
+	}
+	tables := &panicNthGotoTable{base: base, panicAt: 2}
+	compact.tables = tables
+
+	before, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeBoundaries := cloneBoundaryMap(compact.boundaries)
+	beforeWork := compact.Work()
+	beforeArenas := [...]int{
+		len(compact.nodes), len(compact.links), len(compact.subtrees),
+		len(compact.children), len(compact.fields), len(compact.aliases),
+	}
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != "reduction scratch panic" {
+				t.Fatalf("recovered=%v, want reduction scratch panic", recovered)
+			}
+		}()
+		_, _ = compact.ReduceOutputsInto(make([]ReductionOutput, 0, 2), head, 9, 0, ForkOrder{})
+	}()
+	after, err := compact.Stats(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterArenas := [...]int{
+		len(compact.nodes), len(compact.links), len(compact.subtrees),
+		len(compact.children), len(compact.fields), len(compact.aliases),
+	}
+	if after != before || afterArenas != beforeArenas ||
+		!reflect.DeepEqual(compact.boundaries.logicalMap(), beforeBoundaries) ||
+		compact.Work() != beforeWork {
+		t.Fatalf(
+			"rank rollback drifted: stats=%+v/%+v arenas=%v/%v boundaries=%v/%v work=%+v/%+v",
+			after, before, afterArenas, beforeArenas,
+			compact.boundaries.logicalMap(), beforeBoundaries, compact.Work(), beforeWork,
+		)
+	}
+	if compact.popScratch.busy || len(compact.popScratch.paths) != 0 ||
+		len(compact.popScratch.rev) != 0 || len(compact.popScratch.revScores) != 0 {
+		t.Fatalf("rank rollback retained logical pop scratch: %+v", compact.popScratch)
+	}
+	if compact.reductionScratch.spilled || len(compact.reductionScratch.boundaries) != 0 ||
+		len(compact.reductionScratch.boundaryByKey) != 0 {
+		t.Fatalf("rank rollback retained logical reduction scratch: %+v", compact.reductionScratch)
+	}
+	assertTransactionJournalClean(t, compact)
+
+	tables.calls = 0
+	tables.panicAt = 0
+	outputs, err := compact.ReduceOutputsInto(make([]ReductionOutput, 0, 2), head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cleanPathRankOutputStates(t, compact, outputs)
+	if got[60] != CleanPathRankSelected || got[61] != CleanPathRankUnselected {
+		t.Fatalf("retry ranked outputs=%v", got)
+	}
+}
+
+func BenchmarkCleanPathRankMultiPop(b *testing.B) {
+	compact, head := newAmbiguousPrefixRankFixture(b)
+	paths, err := compact.popPaths(head.Node, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	compact.markCleanProductionRank(paths)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		compact.markCleanProductionRank(paths)
+	}
+}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1444,20 +1444,35 @@ const (
 	ReductionUpdated
 )
 
+// CleanPathRankSelection reports how one output relates to the unique clean
+// path selected by production's same-boundary stack rank. The compact core
+// does not apply this result yet. The scheduler can inspect it in a later
+// admission tranche.
+type CleanPathRankSelection uint8
+
+const (
+	CleanPathRankNotApplicable CleanPathRankSelection = iota
+	CleanPathRankUnselected
+	CleanPathRankSelected
+	CleanPathRankUnknown
+)
+
 // ReductionOutput is one final canonical boundary and its aggregate freshness
 // relative to the boundary map at entry to ReduceOutputs.
 type ReductionOutput struct {
 	Head             Head
 	Freshness        ReductionFreshness
+	CleanPathRank    CleanPathRankSelection
 	MultiplePopPaths bool
 }
 
 const inlineReductionBoundaryOutputs = 2
 
 type reductionBoundaryOutput struct {
-	key       boundaryKey
-	head      Head
-	freshness ReductionFreshness
+	key           boundaryKey
+	head          Head
+	freshness     ReductionFreshness
+	cleanPathRank CleanPathRankSelection
 }
 
 // reductionOutputScratch owns the ephemeral aggregation state for one
@@ -2871,6 +2886,7 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 
 type popPath struct {
 	prev          NodeID
+	cleanPathRank CleanPathRankSelection
 	children      []SubtreeID
 	trailing      []pathPayload
 	score         int64
@@ -2935,6 +2951,211 @@ func (s *popEnumerationScratch) nextPath() *popPath {
 		}
 	}
 	return &s.paths[index]
+}
+
+type cleanPathRank struct {
+	score int64
+	depth uint64
+}
+
+type cleanPathRankAccumulator struct {
+	best       cleanPathRank
+	winner     int
+	found      bool
+	crossTie   bool
+	pathIndex  int
+	windowRank cleanPathRank
+}
+
+func compareCleanPathRank(left, right cleanPathRank) int {
+	if left.score != right.score {
+		if left.score > right.score {
+			return 1
+		}
+		return -1
+	}
+	if left.depth != right.depth {
+		if left.depth > right.depth {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+func (a *cleanPathRankAccumulator) observe(prefixScore int64, prefixDepth uint64) bool {
+	score, err := checkedAddScore(prefixScore, a.windowRank.score)
+	if err != nil {
+		return false
+	}
+	candidate := cleanPathRank{
+		score: score,
+		depth: prefixDepth + a.windowRank.depth,
+	}
+	switch {
+	case !a.found || compareCleanPathRank(candidate, a.best) > 0:
+		a.best = candidate
+		a.winner = a.pathIndex
+		a.found = true
+		a.crossTie = false
+	case compareCleanPathRank(candidate, a.best) == 0 && a.winner != a.pathIndex:
+		a.crossTie = true
+	}
+	return true
+}
+
+// markCleanProductionRank selects one clean multi-pop path by production's
+// same-boundary rank: higher cumulative dynamic precedence, then greater
+// physical stack depth. Accepted and shifted status are equal for paths in one
+// classified reduction. An exact cross-path tie stays unknown.
+//
+// The walk reuses popScratch's existing traversal storage. It does not publish
+// arena data or allocate selector-owned storage.
+func (c *Core) markCleanProductionRank(paths []popPath) {
+	if len(paths) < 2 {
+		return
+	}
+	for index := range paths {
+		paths[index].cleanPathRank = CleanPathRankUnselected
+	}
+	scratch := &c.popScratch
+	scratch.finishTraversal()
+	defer scratch.finishTraversal()
+
+	var rank cleanPathRankAccumulator
+	for index := range paths {
+		path := &paths[index]
+		prefix, err := c.node(path.prev)
+		if err != nil || prefix.pathCount == math.MaxUint64 ||
+			prefix.pathCount > c.limits.MaxDerivations {
+			markCleanPathRankUnknown(paths)
+			return
+		}
+		rank.pathIndex = index
+		rank.windowRank = cleanPathRank{
+			score: path.score,
+			depth: uint64(len(path.children) + len(path.trailing)),
+		}
+		ok, err := c.walkCleanPrefixRanks(path.prev, &rank)
+		if err != nil || !ok {
+			markCleanPathRankUnknown(paths)
+			return
+		}
+	}
+	if !rank.found || rank.crossTie {
+		markCleanPathRankUnknown(paths)
+		return
+	}
+	paths[rank.winner].cleanPathRank = CleanPathRankSelected
+}
+
+func markCleanPathRankUnknown(paths []popPath) {
+	for index := range paths {
+		paths[index].cleanPathRank = CleanPathRankUnknown
+	}
+}
+
+// walkCleanPrefixRanks visits each retained prefix derivation without a map.
+// The persistent graph is an append-only directed acyclic graph. Existing
+// link-frame and score scratch provide the iterative traversal stack.
+func (c *Core) walkCleanPrefixRanks(root NodeID, rank *cleanPathRankAccumulator) (bool, error) {
+	scratch := &c.popScratch
+	scratch.finishTraversal()
+	id := root
+	score := int64(0)
+	depth := uint64(0)
+	active := 0
+
+descend:
+	for {
+		node, err := c.node(id)
+		if err != nil {
+			return false, err
+		}
+		switch node.linkCount {
+		case 0:
+			if !rank.observe(score, depth) {
+				return false, nil
+			}
+			break descend
+		case 1:
+			if node.firstLink == 0 || uint64(node.firstLink) > uint64(len(c.links)) {
+				return false, errors.New("parser-core phase zero: clean path link is out of range")
+			}
+			link := c.links[node.firstLink-1]
+			if link.next != 0 {
+				return false, errors.New("parser-core phase zero: clean path single link has a successor")
+			}
+			score, err = checkedAddScore(score, link.scoreDelta)
+			if err != nil {
+				return false, nil
+			}
+			depth++
+			id = link.prev
+		default:
+			if len(scratch.linkFrames) <= active {
+				scratch.linkFrames = append(scratch.linkFrames, nil)
+			}
+			links, err := c.nodeLinksInto(scratch.linkFrames[active], *node)
+			if err != nil {
+				return false, err
+			}
+			scratch.linkFrames[active] = links
+			if len(scratch.revOrders) == active {
+				scratch.revOrders = append(scratch.revOrders, ForkOrder{})
+			} else {
+				scratch.revOrders[active] = ForkOrder{}
+				scratch.revOrders = scratch.revOrders[:active+1]
+			}
+			scoreIndex := active * 2
+			if len(scratch.revScores) == scoreIndex {
+				scratch.revScores = append(scratch.revScores, score, int64(depth))
+			} else {
+				scratch.revScores[scoreIndex] = score
+				scratch.revScores[scoreIndex+1] = int64(depth)
+				scratch.revScores = scratch.revScores[:scoreIndex+2]
+			}
+			active++
+			break descend
+		}
+	}
+
+	for active != 0 {
+		frameIndex := active - 1
+		frame := scratch.linkFrames[frameIndex]
+		cursor := int(scratch.revOrders[frameIndex].Value)
+		if cursor >= len(frame) {
+			scratch.linkFrames[frameIndex] = frame[:0]
+			scratch.revScores = scratch.revScores[:frameIndex*2]
+			scratch.revOrders = scratch.revOrders[:frameIndex]
+			active--
+			continue
+		}
+		link := frame[cursor]
+		scratch.revOrders[frameIndex].Value++
+		var err error
+		score, err = checkedAddScore(scratch.revScores[frameIndex*2], link.scoreDelta)
+		if err != nil {
+			return false, nil
+		}
+		depth = uint64(scratch.revScores[frameIndex*2+1]) + 1
+		id = link.prev
+		goto descend
+	}
+	return true, nil
+}
+
+func mergeCleanPathRank(left, right CleanPathRankSelection) CleanPathRankSelection {
+	switch {
+	case left == CleanPathRankUnknown || right == CleanPathRankUnknown:
+		return CleanPathRankUnknown
+	case left == CleanPathRankSelected || right == CleanPathRankSelected:
+		return CleanPathRankSelected
+	case left == CleanPathRankUnselected || right == CleanPathRankUnselected:
+		return CleanPathRankUnselected
+	default:
+		return CleanPathRankNotApplicable
+	}
 }
 
 // popPaths returns Core-owned ephemeral storage. ReduceOutputs consumes the

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2344,8 +2344,14 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	if got := unsafe.Sizeof(nodeRecord{}); got != 24 {
 		t.Fatalf("nodeRecord size = %d, want 24", got)
 	}
-	if got := unsafe.Sizeof(linkRecord{}); got > 32 {
-		t.Fatalf("linkRecord size = %d, want <= 32", got)
+	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
+		t.Fatalf("linkRecord size = %d, want 32", got)
+	}
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 8 {
+		t.Fatalf("ReductionOutput size = %d, want 8", got)
+	}
+	if got := unsafe.Sizeof(popPath{}); got != 88 {
+		t.Fatalf("popPath size = %d, want 88", got)
 	}
 	if got := unsafe.Sizeof(subtreeRecord{}); got != 44 {
 		t.Fatalf("subtreeRecord size = %d, want 44", got)

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -294,6 +294,9 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 	// parent reductionParentForPath builds in this loop is fragile in that
 	// case; see its doc comment.
 	multiPop := len(paths) > 1
+	if multiPop {
+		c.markCleanProductionRank(paths)
+	}
 	for _, path := range paths {
 		prev, err := c.node(path.prev)
 		if err != nil {
@@ -350,6 +353,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			previous = scratch.boundaries[boundaryIndex]
 		}
 		freshness := previous.freshness
+		cleanPathRank := mergeCleanPathRank(previous.cleanPathRank, path.cleanPathRank)
 		switch outcome.change {
 		case condenseUnchanged:
 			if !seen {
@@ -362,12 +366,15 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 				freshness = ReductionUpdated
 			}
 		}
-		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{key: key, head: out, freshness: freshness})
+		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{
+			key: key, head: out, freshness: freshness, cleanPathRank: cleanPathRank,
+		})
 	}
 	for _, output := range scratch.boundaries {
 		frontier = append(frontier, ReductionOutput{
 			Head:             output.head,
 			Freshness:        output.freshness,
+			CleanPathRank:    output.cleanPathRank,
 			MultiplePopPaths: multiPop,
 		})
 	}


### PR DESCRIPTION
## Summary

- Rank clean multi-pop paths by cumulative dynamic precedence, then stack depth.
- Mark a unique winner as selected.
- Mark exact cross-path ties and bounded traversal failures as unknown.
- Aggregate the rank into each reduction output.
- Keep the current admission behavior unchanged.

This seam supplies provenance for a later scheduler change. It does not drop or select parser branches.

## Memory and rollback

The selector reuses existing pop scratch. It adds no arena field and allocates no selector-owned storage.

The layout gates remain:

- `nodeRecord`: 24 bytes
- `linkRecord`: 32 bytes
- `ReductionOutput`: 8 bytes
- `popPath`: 88 bytes
- scheduler header: 24 bytes

A panic after selection restores the arenas, boundaries, work counters, journal, and scratch. A retry returns the same rank.

## Correctness gates

- Docker: `go test ./internal/parsercorephase0 -count=1`
- Docker: `go test . -run TestAdmissionCandidate -count=1`
- Host: `go test -tags gts_parsercorephase0 . -run '^TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64$' -count=1`
- Host: `go vet ./internal/parsercorephase0`

The Docker runs completed without an out-of-memory event.

## Performance

The ambiguous-prefix microbenchmark reports 31.4–32.3 ns/op, 0 B/op, and 0 allocations/op.

The standard benchmark trio used `GOMAXPROCS=1`, ten samples, and a 750 ms bench time. Medians stayed neutral against `e2462273acdfea397091885c09ff231b5881bb0e`:

- Full parse: about 7.42 ms to 7.38 ms.
- Single-byte edit: about 1024 ns to 1021 ns.
- No-edit incremental parse: about 4.040 ns to 4.039 ns.

Allocation counts did not change.