### PR TITLE
optimize(dfa-relex): Remove redundant nested transaction in direct re-lex probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Direct parser-state re-lex probes now use their existing outer transaction.
+  This removes a redundant scanner-state snapshot.
+  The 235,626-byte Go fixture allocates 48.07 MiB instead of 86.69 MiB.
+  Allocations fall from 20,290 to 10,400 per parse.
+  Three stable benchmark pairs improve parse time by 10.90 to 15.26 percent.
+
 - The compact scheduler now stores its common rollback frontier inline.
   This removes one allocation from a fresh full parse.
 

--- a/dfa_relex_transaction_test.go
+++ b/dfa_relex_transaction_test.go
@@ -2,6 +2,69 @@ package gotreesitter
 
 import "testing"
 
+func TestDFARelexFailureRestoresThroughOuterTransaction(t *testing.T) {
+	lang := &Language{
+		ExternalScanner: byteStateExternalScanner{},
+		LexStates: []LexState{
+			{
+				Default: -1,
+				EOF:     -1,
+				Transitions: []LexTransition{
+					{Lo: ' ', Hi: ' ', NextState: 0, Skip: true},
+					{Lo: 'a', Hi: 'a', NextState: 1},
+				},
+			},
+			{AcceptToken: 1, Default: -1, EOF: -1},
+		},
+		LexModes: []LexMode{{LexState: 0}},
+	}
+	payload := lang.ExternalScanner.Create()
+	*payload.(*byte) = 9
+	ts := &dfaTokenSource{
+		lexer:              NewLexer(lang.LexStates, []byte(" a")),
+		language:           lang,
+		externalPayload:    payload,
+		hasExternalScanner: true,
+		extZeroPos:         5,
+		extZeroState:       7,
+		extZeroTried:       []bool{true, false},
+		zeroWidthPos:       9,
+		zeroWidthCount:     3,
+	}
+	ts.lexer.pos = 2
+	ts.lexer.row = 4
+	ts.lexer.col = 6
+	tok := Token{
+		Symbol:     1,
+		StartByte:  0,
+		EndByte:    1,
+		StartPoint: Point{},
+		EndPoint:   Point{Column: 1},
+	}
+
+	snapshot := ts.snapshotRelexState()
+	if got, ok := ts.relexFromTokenStartInTransaction(tok); ok {
+		t.Fatalf("relexFromTokenStartInTransaction = (%+v, true), want false for skipped-start token", got)
+	}
+	if ts.lexer.pos == 2 && ts.lexer.row == 4 && ts.lexer.col == 6 {
+		t.Fatal("failed probe restored itself; want the outer transaction to own rollback")
+	}
+	snapshot.restore(ts)
+
+	if ts.lexer.pos != 2 || ts.lexer.row != 4 || ts.lexer.col != 6 {
+		t.Fatalf("lexer = pos %d row %d col %d, want restored 2/4/6", ts.lexer.pos, ts.lexer.row, ts.lexer.col)
+	}
+	if got := *ts.externalPayload.(*byte); got != 9 {
+		t.Fatalf("external payload = %d, want restored state 9", got)
+	}
+	if ts.extZeroPos != 5 || ts.extZeroState != 7 || len(ts.extZeroTried) != 2 || !ts.extZeroTried[0] || ts.extZeroTried[1] {
+		t.Fatalf("external zero-width guard = pos %d state %d tried %v, want 5/7/[true false]", ts.extZeroPos, ts.extZeroState, ts.extZeroTried)
+	}
+	if ts.zeroWidthPos != 9 || ts.zeroWidthCount != 3 {
+		t.Fatalf("zero-width guard = pos %d count %d, want 9/3", ts.zeroWidthPos, ts.zeroWidthCount)
+	}
+}
+
 func TestDFATokenSourceRelexFailureRestoresProgressAndBookkeeping(t *testing.T) {
 	lang := &Language{
 		Name:            "python",

--- a/parser.go
+++ b/parser.go
@@ -7556,7 +7556,17 @@ func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSou
 	}
 	stateful.SetParserState(state)
 	clearGLRStateTokenSource(stateful, scratch)
-	next, ok := relexer.RelexFromTokenStart(tok)
+	var (
+		next Token
+		ok   bool
+	)
+	if ts == dts {
+		// The outer snapshot already owns rollback for the direct source.
+		// Do not start a redundant nested transaction.
+		next, ok = dts.relexFromTokenStartInTransaction(tok)
+	} else {
+		next, ok = relexer.RelexFromTokenStart(tok)
+	}
 	actionIndex := p.lookupActionIndex(state, next.Symbol)
 	if !ok || !next.ExternalScannerToken || next.StartByte != tok.StartByte || next.EndByte != next.StartByte || (next.Symbol == tok.Symbol && next.StartByte == tok.StartByte && next.EndByte == tok.EndByte) || actionIndex == 0 || int(actionIndex) >= len(p.language.ParseActions) {
 		restoreRejectedProbe()

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2792,6 +2792,16 @@ func (d *dfaTokenSource) RelexFromTokenStart(tok Token) (Token, bool) {
 		return Token{}, false
 	}
 	snapshot := d.snapshotRelexState()
+	next, ok := d.relexFromTokenStartInTransaction(tok)
+	if !ok {
+		snapshot.restore(d)
+	}
+	return next, ok
+}
+
+// relexFromTokenStartInTransaction re-reads tok without starting a transaction.
+// The caller must restore its transaction when it rejects the result.
+func (d *dfaTokenSource) relexFromTokenStartInTransaction(tok Token) (Token, bool) {
 	target := int(tok.StartByte)
 	d.lexer.pos = target
 	d.lexer.row = tok.StartPoint.Row
@@ -2818,7 +2828,6 @@ func (d *dfaTokenSource) RelexFromTokenStart(tok Token) (Token, bool) {
 	}
 	next := d.Next()
 	if next.StartByte != tok.StartByte || next.StartPoint != tok.StartPoint {
-		snapshot.restore(d)
 		return Token{}, false
 	}
 	if tok.ExternalScannerToken && next.ExternalScannerToken &&


### PR DESCRIPTION
## Summary

Direct parser-state re-lex probes now reuse their existing outer transaction.
This removes one redundant scanner-state snapshot from each direct probe.
The public re-lex method keeps its independent rollback contract.

## Changes

- Split the probe body from the public transaction wrapper.
- Reuse the parser-owned outer transaction for a direct DFA token source.
- Keep wrapped token sources on the public transaction path.
- Prove failed direct probes restore all tracked state.
- Record the measured result in the changelog.

## Correctness

- `go test . -count=1`
- Focused re-lex and authenticated Go fixture tests in Docker
- One-language Go Docker parity:
  - 25 of 25 sources parse without errors.
  - 25 of 25 S-expressions match.
  - 25 of 25 deep trees match.
  - No out-of-memory event occurred.

## Performance

Settings: `GOMAXPROCS=1`, `-count=10`, `-benchtime=750ms`, and `-benchmem`.

The exact 235,626-byte `grammargen_lr` fixture changed as follows:

- Parse time: 242.4 ms to 205.5 ms, or 15.26 percent faster.
- Allocated bytes: 86.69 MiB to 48.07 MiB, or 44.55 percent lower.
- Allocations: 20,290 to 10,400 per parse, or 48.73 percent lower.
- Maximum resident set size: 268,012 KiB to 231,776 KiB.

Three alternating pairs improved parse time by 10.90 to 15.26 percent.
The stable compact benchmark trio remained statistically unchanged.

Base: `4c6ef6bdf1b0c8e6f8467ebf935104434f944621`
