### PR TITLE
add(parsercore): prove selected-lineage split drops

### DIFF
--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -40,15 +40,16 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		return nil, errors.New("admission candidate route: parser has no language")
 	}
 	options := DiagnosticParserCorePrefixOptions{
-		ReceiptMode:                    DiagnosticParserCoreReceiptSummary,
-		MaxTokens:                      1 << 24,
-		MaxDispatches:                  1 << 24,
-		Limits:                         admissionCandidateLimits(),
-		freshSchedulerSession:          true,
-		allowEOFAcceptNoActionSiblings: p.language.CompactEOFAcceptNoActionSiblingsCertified,
-		allowPrimaryAcceptDerivation:   p.language.CompactPrimaryAcceptanceDerivationCertified,
-		noLookaheadRootSymbol:          p.rootSymbol,
-		hasNoLookaheadRootSymbol:       p.hasRootSymbol,
+		ReceiptMode:                     DiagnosticParserCoreReceiptSummary,
+		MaxTokens:                       1 << 24,
+		MaxDispatches:                   1 << 24,
+		Limits:                          admissionCandidateLimits(),
+		freshSchedulerSession:           true,
+		allowEOFAcceptNoActionSiblings:  p.language.CompactEOFAcceptNoActionSiblingsCertified,
+		allowPrimaryAcceptDerivation:    p.language.CompactPrimaryAcceptanceDerivationCertified,
+		allowConvergedSplitDropArtifact: p.language.CompactConvergedReductionSplitDropsCertified,
+		noLookaheadRootSymbol:           p.rootSymbol,
+		hasNoLookaheadRootSymbol:        p.hasRootSymbol,
 	}
 	tables, err := newParserCoreRootTables(p)
 	if err != nil {

--- a/admission_switch_converged_path_test.go
+++ b/admission_switch_converged_path_test.go
@@ -124,6 +124,70 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 	}
 }
 
+func TestAdmissionCandidateSelectedLineageSplitsMatchProduction(t *testing.T) {
+	tests := []struct {
+		name string
+		load func() *gts.Language
+	}{
+		{name: "dart", load: grammars.DartLanguage},
+		{name: "elixir", load: grammars.ElixirLanguage},
+		{name: "perl", load: grammars.PerlLanguage},
+		{name: "scala", load: grammars.ScalaLanguage},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(grammars.ParseSmokeSample(test.name))
+			lang := test.load()
+			if lang.CompactConvergedReductionSplitDropsCertified {
+				t.Fatal("selected-lineage witness unexpectedly has an artifact certificate")
+			}
+
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candidateTree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 1 || fallback != 0 {
+				t.Fatalf(
+					"candidate route counters = %d/%d, want 1/0; reason=%s",
+					routed,
+					fallback,
+					gts.AdmissionCandidateLastFallbackReason(),
+				)
+			}
+			candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), lang)
+			if err != nil {
+				t.Fatalf("inspect candidate tree: %v", err)
+			}
+			productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), lang)
+			if err != nil {
+				t.Fatalf("inspect production tree: %v", err)
+			}
+			if candidateInspection.SHA256 != productionInspection.SHA256 {
+				t.Fatalf(
+					"candidate digest %s differs from production %s",
+					candidateInspection.SHA256,
+					productionInspection.SHA256,
+				)
+			}
+		})
+	}
+}
+
 // TestAdmissionCandidateConvergedPathSplitFailsClosed covers a compact-route
 // divergence found by the refreshed Kotlin corpus. The visibility-modifier and
 // identifier conflict paths merge, then split during a later reduction.
@@ -163,5 +227,63 @@ func TestAdmissionCandidateConvergedPathSplitFailsClosed(t *testing.T) {
 	}
 	if candidateSExpr := candidateTree.RootNode().SExpr(lang); candidateSExpr != productionSExpr {
 		t.Fatalf("fallback tree diverged:\nproduction=%s\ncandidate=%s", productionSExpr, candidateSExpr)
+	}
+}
+
+func TestAdmissionCandidateSelectedLineageJuliaFailsClosed(t *testing.T) {
+	const (
+		sourcePath   = "testdata/compact_selected_lineage/julia_utils.jl"
+		sourceSHA256 = "d81017a2d640f6c84f2ca2a7030687049b7334bdb75ad5c50302b29052ecf79c"
+	)
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read Julia selected-lineage witness: %v", err)
+	}
+	if got := fmt.Sprintf("%x", sha256.Sum256(source)); got != sourceSHA256 {
+		t.Fatalf("Julia selected-lineage witness SHA-256 = %s, want %s", got, sourceSHA256)
+	}
+	lang := grammars.JuliaLanguage()
+	if lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("Julia unexpectedly has an artifact certificate")
+	}
+
+	production := gts.NewParser(lang)
+	production.SetAdmissionCandidateRoute(false)
+	productionTree, err := production.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer productionTree.Release()
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidate := gts.NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	candidateTree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	defer candidateTree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 0 || fallback != 1 {
+		t.Fatalf("Julia selected-lineage witness did not fail closed: routed=%d fallback=%d", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "converged-path reduction split") {
+		t.Fatalf("fallback reason=%q", reason)
+	}
+	productionInspection, err := benchfixtures.InspectGoTree(productionTree.RootNode(), lang)
+	if err != nil {
+		t.Fatalf("inspect production tree: %v", err)
+	}
+	candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), lang)
+	if err != nil {
+		t.Fatalf("inspect fallback tree: %v", err)
+	}
+	if candidateInspection.SHA256 != productionInspection.SHA256 {
+		t.Fatalf(
+			"fallback digest %s differs from production %s",
+			candidateInspection.SHA256,
+			productionInspection.SHA256,
+		)
 	}
 }

--- a/internal/parsercorephase0/clean_path_rank_test.go
+++ b/internal/parsercorephase0/clean_path_rank_test.go
@@ -10,6 +10,7 @@ type cleanPathRankBranch struct {
 	prefixScore []int64
 	windowScore int64
 	gotoState   StateID
+	external    bool
 }
 
 func newCleanPathRankFixture(tb testing.TB, branches []cleanPathRankBranch) (*Core, Head) {
@@ -65,7 +66,7 @@ func newCleanPathRankFixture(tb testing.TB, branches []cleanPathRankBranch) (*Co
 		}
 		child, err := compact.appendSubtree(subtreeRecord{
 			symbol: 10, startByte: 0, endByte: 1,
-			terminal: true,
+			terminal: true, external: branch.external,
 		}, nil, nil, nil)
 		if err != nil {
 			tb.Fatal(err)
@@ -251,6 +252,39 @@ func TestCleanPathRankPrefixCapIsUnknown(t *testing.T) {
 		if output.CleanPathRank != CleanPathRankUnknown {
 			t.Fatalf("capped ranked output=%+v, want unknown", output)
 		}
+	}
+}
+
+func TestCleanPathRankExternalPayloadIsUnknown(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60, external: true},
+		{predecessor: 2, prefixScore: []int64{2}, gotoState: 61},
+	})
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, output := range outputs {
+		if output.CleanPathRank != CleanPathRankUnknown {
+			t.Fatalf("external ranked output=%+v, want unknown", output)
+		}
+	}
+}
+
+func TestCleanPathRankExternalPayloadSteadyStateDoesNotAllocate(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60, external: true},
+		{predecessor: 2, prefixScore: []int64{2}, gotoState: 61},
+	})
+	paths, err := compact.popPaths(head.Node, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compact.markCleanProductionRank(paths)
+	if got := testing.AllocsPerRun(100, func() {
+		compact.markCleanProductionRank(paths)
+	}); got != 0 {
+		t.Fatalf("external clean path rank allocations/run=%f, want 0", got)
 	}
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2908,6 +2908,7 @@ type popEnumerationScratch struct {
 	revScores  []int64
 	revOrders  []ForkOrder
 	trailing   []pathPayload
+	external   []SubtreeID
 	paths      []popPath
 }
 
@@ -2919,6 +2920,7 @@ func (s *popEnumerationScratch) begin() {
 	s.revScores = s.revScores[:0]
 	s.revOrders = s.revOrders[:0]
 	s.trailing = s.trailing[:0]
+	s.external = s.external[:0]
 	s.paths = s.paths[:0]
 }
 
@@ -2930,6 +2932,7 @@ func (s *popEnumerationScratch) finishTraversal() {
 	s.revScores = s.revScores[:0]
 	s.revOrders = s.revOrders[:0]
 	s.trailing = s.trailing[:0]
+	s.external = s.external[:0]
 }
 
 func (s *popEnumerationScratch) resetLogical() {
@@ -3025,6 +3028,20 @@ func (c *Core) markCleanProductionRank(paths []popPath) {
 	var rank cleanPathRankAccumulator
 	for index := range paths {
 		path := &paths[index]
+		for _, payload := range path.children {
+			hasExternal, err := c.cleanPathPayloadHasExternal(payload)
+			if err != nil || hasExternal {
+				markCleanPathRankUnknown(paths)
+				return
+			}
+		}
+		for _, trailing := range path.trailing {
+			hasExternal, err := c.cleanPathPayloadHasExternal(trailing.payload)
+			if err != nil || hasExternal {
+				markCleanPathRankUnknown(paths)
+				return
+			}
+		}
 		prefix, err := c.node(path.prev)
 		if err != nil || prefix.pathCount == math.MaxUint64 ||
 			prefix.pathCount > c.limits.MaxDerivations {
@@ -3053,6 +3070,48 @@ func markCleanPathRankUnknown(paths []popPath) {
 	for index := range paths {
 		paths[index].cleanPathRank = CleanPathRankUnknown
 	}
+}
+
+func (c *Core) cleanPathPayloadHasExternal(root SubtreeID) (bool, error) {
+	if c.externalPayloadsQuiescent {
+		return false, nil
+	}
+	if root == 0 {
+		return false, errors.New("parser-core phase zero: clean path has no payload")
+	}
+	stack := c.popScratch.external[:0]
+	stack = append(stack, root)
+	c.popScratch.external = stack
+	visited := uint64(0)
+	for len(stack) != 0 {
+		last := len(stack) - 1
+		id := stack[last]
+		stack = stack[:last]
+		record, err := c.subtree(id)
+		if err != nil {
+			c.popScratch.external = stack[:0]
+			return false, err
+		}
+		visited++
+		if visited > uint64(c.limits.MaxSubtrees) {
+			c.popScratch.external = stack[:0]
+			return false, errors.New("parser-core phase zero: clean path external payload walk cap")
+		}
+		if record.external {
+			c.popScratch.external = stack[:0]
+			return true, nil
+		}
+		for _, child := range c.children[record.firstChild : record.firstChild+record.childCount] {
+			if child == 0 || child >= id {
+				c.popScratch.external = stack[:0]
+				return false, errors.New("parser-core phase zero: clean path subtree order is invalid")
+			}
+			stack = append(stack, child)
+		}
+		c.popScratch.external = stack
+	}
+	c.popScratch.external = stack[:0]
+	return false, nil
 }
 
 // walkCleanPrefixRanks visits each retained prefix derivation without a map.
@@ -3085,6 +3144,10 @@ descend:
 			link := c.links[node.firstLink-1]
 			if link.next != 0 {
 				return false, errors.New("parser-core phase zero: clean path single link has a successor")
+			}
+			hasExternal, err := c.cleanPathPayloadHasExternal(link.payload)
+			if err != nil || hasExternal {
+				return false, err
 			}
 			score, err = checkedAddScore(score, link.scoreDelta)
 			if err != nil {
@@ -3134,6 +3197,10 @@ descend:
 		link := frame[cursor]
 		scratch.revOrders[frameIndex].Value++
 		var err error
+		hasExternal, err := c.cleanPathPayloadHasExternal(link.payload)
+		if err != nil || hasExternal {
+			return false, err
+		}
 		score, err = checkedAddScore(scratch.revScores[frameIndex*2], link.scoreDelta)
 		if err != nil {
 			return false, nil

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -683,6 +683,7 @@ func DiagnosticParseParserCorePrefix(scanner ExternalScanner, source []byte, opt
 	result.Grammar = lang.Name
 	result.ExactRootDFA = true
 	result.GrammarBlobSHA256 = sha256.Sum256(parserCoreCertifiedGoBlob)
+	options.allowConvergedSplitDropArtifact = lang.CompactConvergedReductionSplitDropsCertified
 	if options.Recovery || options.Retry || options.Incremental || options.IncludedRanges {
 		result.Boundary, result.Detail = DiagnosticParserCoreRoute, "recovery/retry/incremental/included-range routes decline"
 		return result, &diagnosticParserCoreDecline{boundary: result.Boundary, detail: result.Detail}
@@ -4227,6 +4228,7 @@ func authenticatedParserCoreGoLanguage(scanner ExternalScanner) (*Language, erro
 	}
 	decoded.Name = "go"
 	decoded.ExternalScanner = scanner
+	decoded.CompactConvergedReductionSplitDropsCertified = true
 	CertifyCRecoveryCostCompetition(decoded)
 	return decoded, nil
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -57,10 +57,11 @@ type DiagnosticParserCorePrefixOptions struct {
 	freshSchedulerSession bool
 	// These acceptance options require exact artifact certification. Diagnostic
 	// callers retain the conservative false defaults.
-	allowEOFAcceptNoActionSiblings bool
-	allowPrimaryAcceptDerivation   bool
-	noLookaheadRootSymbol          Symbol
-	hasNoLookaheadRootSymbol       bool
+	allowEOFAcceptNoActionSiblings  bool
+	allowPrimaryAcceptDerivation    bool
+	allowConvergedSplitDropArtifact bool
+	noLookaheadRootSymbol           Symbol
+	hasNoLookaheadRootSymbol        bool
 }
 
 type DiagnosticParserCoreScannerCheckpoint struct {
@@ -148,19 +149,22 @@ type DiagnosticParserCoreGenericWork struct {
 	// ConvergedReductionSplitDrops counts no-action drops descended from a
 	// reduction that split multiple compact predecessor paths into live heads.
 	ConvergedReductionSplitDrops uint64
-	RepetitionFolds              uint64
-	Reductions                   uint64
-	OrdinaryShifts               uint64
-	OrdinaryCohorts              uint64
-	ExtraShifts                  uint64
-	ExtraCohorts                 uint64
-	Accepts                      uint64
-	ReductionPauses              uint64
-	NoActionDrops                uint64
-	Elections                    uint64
-	Canonicalizations            uint64
-	PeakHeaders                  uint64
-	Overflow                     bool
+	// SelectedLineageDrops counts converged split drops whose unselected rank
+	// matched one surviving selected header from the same reduction.
+	SelectedLineageDrops uint64
+	RepetitionFolds      uint64
+	Reductions           uint64
+	OrdinaryShifts       uint64
+	OrdinaryCohorts      uint64
+	ExtraShifts          uint64
+	ExtraCohorts         uint64
+	Accepts              uint64
+	ReductionPauses      uint64
+	NoActionDrops        uint64
+	Elections            uint64
+	Canonicalizations    uint64
+	PeakHeaders          uint64
+	Overflow             bool
 }
 
 func (w *DiagnosticParserCoreGenericWork) add(counter *uint64, delta uint64) {
@@ -857,6 +861,72 @@ type diagnosticParserCoreHeader struct {
 	accepted                bool
 	paused                  bool
 	convergedReductionSplit bool
+	cleanPathRank           core.CleanPathRankSelection
+	cleanPathLineage        uint16
+}
+
+func nextDiagnosticParserCoreCleanPathLineage(next *uint16) (uint16, error) {
+	if next == nil || *next == 0 {
+		return 0, &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreCap,
+			detail:   "clean multi-pop lineage identity cap",
+		}
+	}
+	lineage := *next
+	if lineage == math.MaxUint16 {
+		*next = 0
+	} else {
+		(*next)++
+	}
+	return lineage, nil
+}
+
+func mergeDiagnosticParserCoreCleanPathLineage(
+	leftRank core.CleanPathRankSelection,
+	leftLineage uint16,
+	rightRank core.CleanPathRankSelection,
+	rightLineage uint16,
+) (core.CleanPathRankSelection, uint16) {
+	if leftRank == core.CleanPathRankUnknown || rightRank == core.CleanPathRankUnknown {
+		return core.CleanPathRankUnknown, 0
+	}
+	if leftRank == core.CleanPathRankNotApplicable || leftLineage == 0 {
+		return rightRank, rightLineage
+	}
+	if rightRank == core.CleanPathRankNotApplicable || rightLineage == 0 {
+		return leftRank, leftLineage
+	}
+	if leftLineage != rightLineage {
+		return core.CleanPathRankUnknown, 0
+	}
+	if leftRank == core.CleanPathRankSelected || rightRank == core.CleanPathRankSelected {
+		return core.CleanPathRankSelected, leftLineage
+	}
+	return core.CleanPathRankUnselected, leftLineage
+}
+
+func applyDiagnosticParserCoreCleanPathOutput(
+	header *diagnosticParserCoreHeader,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+) {
+	if header == nil || header.cleanPathRank == core.CleanPathRankUnknown {
+		return
+	}
+	if rank == core.CleanPathRankNotApplicable || lineage == 0 {
+		return
+	}
+	header.cleanPathRank = rank
+	header.cleanPathLineage = lineage
+}
+
+func markDiagnosticParserCoreExternalLineage(header *diagnosticParserCoreHeader, token Token) {
+	if header == nil || !token.ExternalScannerToken ||
+		header.cleanPathRank == core.CleanPathRankNotApplicable {
+		return
+	}
+	header.cleanPathRank = core.CleanPathRankUnknown
+	header.cleanPathLineage = 0
 }
 
 func diagnosticParserCoreCheckpointDigest(compact *core.Core, id core.CheckpointID) ([32]byte, error) {
@@ -1032,8 +1102,10 @@ func (s *diagnosticParserCoreConflictScratch) finish() {
 }
 
 type diagnosticParserCoreActionOutput struct {
-	head      core.Head
-	freshness core.ReductionFreshness
+	head             core.Head
+	freshness        core.ReductionFreshness
+	cleanPathRank    core.CleanPathRankSelection
+	cleanPathLineage uint16
 }
 
 func executeDiagnosticParserCoreGenericConflictDetailed(
@@ -1044,6 +1116,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	token Token,
 	classified core.ClassifiedBoundary,
 	branchOrder uint64,
+	nextCleanPathLineage *uint16,
 	collectReceipts bool,
 	scratch *diagnosticParserCoreConflictScratch,
 ) (diagnosticParserCoreConflictExecution, error) {
@@ -1085,7 +1158,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			var applyErr error
 			scratch.actionOutputs, scratch.reductionOutputs, applyErr = applyParserCoreConflictActionInto(
 				scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
-				action, ordinal, core.ForkOrder{Present: true, Value: trialOrder},
+				action, ordinal, core.ForkOrder{Present: true, Value: trialOrder}, nextCleanPathLineage,
 			)
 			if applyErr != nil {
 				return applyErr
@@ -1096,6 +1169,11 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 				secondary.head = output.head
 				secondary.shifted = action.Type == core.ActionShift
 				secondary.freshness = output.freshness
+				secondary.convergedReductionSplit = secondary.convergedReductionSplit || output.cleanPathLineage != 0
+				applyDiagnosticParserCoreCleanPathOutput(&secondary, output.cleanPathRank, output.cleanPathLineage)
+				if action.Type == core.ActionShift {
+					markDiagnosticParserCoreExternalLineage(&secondary, token)
+				}
 				scratch.outputs = append(scratch.outputs, secondary)
 			}
 			scratch.armRanges[ordinal] = diagnosticParserCoreConflictArmRange{start: start, end: len(scratch.outputs)}
@@ -1110,7 +1188,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 		var applyErr error
 		scratch.actionOutputs, scratch.reductionOutputs, applyErr = applyParserCoreConflictActionInto(
 			scratch.actionOutputs[:0], scratch.reductionOutputs[:0], compact, owner, classified, token,
-			primaryAction, 0, core.ForkOrder{},
+			primaryAction, 0, core.ForkOrder{}, nextCleanPathLineage,
 		)
 		if applyErr != nil {
 			return applyErr
@@ -1121,6 +1199,11 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			primary.head = output.head
 			primary.shifted = primaryAction.Type == core.ActionShift
 			primary.freshness = output.freshness
+			primary.convergedReductionSplit = primary.convergedReductionSplit || output.cleanPathLineage != 0
+			applyDiagnosticParserCoreCleanPathOutput(&primary, output.cleanPathRank, output.cleanPathLineage)
+			if primaryAction.Type == core.ActionShift {
+				markDiagnosticParserCoreExternalLineage(&primary, token)
+			}
 			scratch.outputs = append(scratch.outputs, primary)
 		}
 		scratch.armRanges[0] = diagnosticParserCoreConflictArmRange{start: start, end: len(scratch.outputs)}
@@ -1166,6 +1249,8 @@ type diagnosticParserCoreCanonicalGroup struct {
 	winner                  int
 	runnable                bool
 	convergedReductionSplit bool
+	cleanPathRank           core.CleanPathRankSelection
+	cleanPathLineage        uint16
 }
 
 const diagnosticParserCoreLinearCanonicalLimit = 8
@@ -1249,6 +1334,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 				diagnosticParserCoreCanonicalGroup: diagnosticParserCoreCanonicalGroup{
 					winner: index, runnable: !header.paused,
 					convergedReductionSplit: header.convergedReductionSplit,
+					cleanPathRank:           header.cleanPathRank, cleanPathLineage: header.cleanPathLineage,
 				},
 			}
 			groupCount++
@@ -1257,6 +1343,12 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 		group := &groups[groupIndex].diagnosticParserCoreCanonicalGroup
 		group.runnable = group.runnable || !header.paused
 		group.convergedReductionSplit = group.convergedReductionSplit || header.convergedReductionSplit
+		group.cleanPathRank, group.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
+			group.cleanPathRank,
+			group.cleanPathLineage,
+			header.cleanPathRank,
+			header.cleanPathLineage,
+		)
 		if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
 			group.winner = index
 		}
@@ -1271,6 +1363,8 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 			header.paused = !group.runnable
 			header.freshness = 0
 			header.convergedReductionSplit = group.convergedReductionSplit
+			header.cleanPathRank = group.cleanPathRank
+			header.cleanPathLineage = group.cleanPathLineage
 			normalized[write] = header
 			write++
 			break
@@ -1295,6 +1389,12 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(normalized []d
 		}
 		group.runnable = group.runnable || !header.paused
 		group.convergedReductionSplit = group.convergedReductionSplit || header.convergedReductionSplit
+		group.cleanPathRank, group.cleanPathLineage = mergeDiagnosticParserCoreCleanPathLineage(
+			group.cleanPathRank,
+			group.cleanPathLineage,
+			header.cleanPathRank,
+			header.cleanPathLineage,
+		)
 		s.groups[key] = group
 	}
 	write := 0
@@ -1306,6 +1406,8 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(normalized []d
 		header.paused = !group.runnable
 		header.freshness = 0
 		header.convergedReductionSplit = group.convergedReductionSplit
+		header.cleanPathRank = group.cleanPathRank
+		header.cleanPathLineage = group.cleanPathLineage
 		normalized[write] = header
 		write++
 	}
@@ -1399,6 +1501,7 @@ type diagnosticParserCoreGenericScheduler struct {
 	dispatches                    uint64
 	branchOrder                   uint64
 	nextSeq                       uint64
+	nextCleanPathLineage          uint16
 	options                       DiagnosticParserCorePrefixOptions
 	receiptBacking                DiagnosticParserCoreGenericScheduler
 	receipt                       *DiagnosticParserCoreGenericScheduler
@@ -1586,6 +1689,7 @@ func initializeDiagnosticParserCoreGenericScheduler(
 	scheduler.checkpointID = checkpointID
 	scheduler.electionIndex = -1
 	scheduler.nextSeq = 1
+	scheduler.nextCleanPathLineage = 1
 	scheduler.options = options
 	scheduler.observer = observer
 	// Public diagnostic results retain their receipt after the scheduler returns.
@@ -3015,6 +3119,42 @@ func diagnosticParserCoreGenericNoActionDropEligible(headers []diagnosticParserC
 	return false
 }
 
+func diagnosticParserCoreSelectedLineageDrops(
+	headers []diagnosticParserCoreHeader,
+	indices []int,
+) (uint64, bool) {
+	var proved uint64
+	for _, index := range indices {
+		if index < 0 || index >= len(headers) {
+			return 0, false
+		}
+		dropped := headers[index]
+		if !dropped.convergedReductionSplit {
+			continue
+		}
+		if dropped.cleanPathRank != core.CleanPathRankUnselected || dropped.cleanPathLineage == 0 {
+			return 0, false
+		}
+		matched := false
+		for survivorIndex, survivor := range headers {
+			dropIndex := sort.SearchInts(indices, survivorIndex)
+			if dropIndex < len(indices) && indices[dropIndex] == survivorIndex {
+				continue
+			}
+			if survivor.cleanPathRank == core.CleanPathRankSelected &&
+				survivor.cleanPathLineage == dropped.cleanPathLineage {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return 0, false
+		}
+		proved++
+	}
+	return proved, true
+}
+
 // dropGenericNoActionHeads removes the paused/no-action heads named by indices.
 // indices is produced in ascending, unique header order by the dispatch pass,
 // so the surviving frontier is compacted in place with no allocation. The drop
@@ -3023,6 +3163,13 @@ func diagnosticParserCoreGenericNoActionDropEligible(headers []diagnosticParserC
 func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices []int) error {
 	if len(indices) == 0 || len(indices) >= len(s.headers) {
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
+	}
+	selectedLineageDrops, proved := diagnosticParserCoreSelectedLineageDrops(s.headers, indices)
+	if !proved && !s.options.allowConvergedSplitDropArtifact {
+		return &diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreNoAction,
+			detail:   "converged-path reduction split no-action drop lacks one exact unselected-to-selected lineage",
+		}
 	}
 	if s.fullReceipts() {
 		pathReceipts, err := diagnosticParserCoreHeaderPathReceipts(s.compact, s.headers)
@@ -3063,6 +3210,7 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	s.headers = s.headers[:write]
 	s.work.NoActionDrops += uint64(len(indices))
 	s.work.add(&s.work.ConvergedReductionSplitDrops, convergedReductionSplitDrops)
+	s.work.add(&s.work.SelectedLineageDrops, selectedLineageDrops)
 	return nil
 }
 
@@ -3074,6 +3222,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 		return err
 	}
 	dispatchesBefore, nextSeqBefore := s.dispatches, s.nextSeq
+	nextCleanPathLineageBefore := s.nextCleanPathLineage
 	workBefore, epochProgressBefore := s.work, s.epochProgress
 	roundsBefore := len(s.receipt.Rounds)
 	defer func() {
@@ -3082,6 +3231,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReduction(before []Di
 			return
 		}
 		s.dispatches, s.nextSeq = dispatchesBefore, nextSeqBefore
+		s.nextCleanPathLineage = nextCleanPathLineageBefore
 		s.work, s.epochProgress = workBefore, epochProgressBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 	}()
@@ -3108,7 +3258,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	if err != nil {
 		return err
 	}
-	convergedReductionSplit := len(outputs) > 1 && outputs[0].MultiplePopPaths
+	var cleanPathLineage uint16
+	if len(outputs) != 0 && outputs[0].MultiplePopPaths {
+		cleanPathLineage, err = nextDiagnosticParserCoreCleanPathLineage(&s.nextCleanPathLineage)
+		if err != nil {
+			return err
+		}
+	}
 	s.reductionOutputs = outputs
 	s.reductionReplacements = s.reductionReplacements[:0]
 	replacements := s.reductionReplacements
@@ -3116,6 +3272,17 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	for _, output := range outputs {
 		switch output.Freshness {
 		case core.ReductionUnchanged:
+			if output.MultiplePopPaths {
+				if _, err := s.adoptUpdatedReductionSibling(
+					cell.headerIndex,
+					output.Head,
+					output.CleanPathRank,
+					cleanPathLineage,
+					true,
+				); err != nil {
+					return err
+				}
+			}
 			continue
 		case core.ReductionNew, core.ReductionUpdated:
 		default:
@@ -3123,7 +3290,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		}
 		madeFreshProgress = true
 		if output.Freshness == core.ReductionUpdated {
-			adopted, err := s.adoptUpdatedReductionSibling(cell.headerIndex, output.Head)
+			adopted, err := s.adoptUpdatedReductionSibling(
+				cell.headerIndex,
+				output.Head,
+				output.CleanPathRank,
+				cleanPathLineage,
+				output.MultiplePopPaths,
+			)
 			if err != nil {
 				return err
 			}
@@ -3135,7 +3308,8 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacement.head = output.Head
 		replacement.paused = false
 		replacement.shifted = token.NoLookahead
-		replacement.convergedReductionSplit = replacement.convergedReductionSplit || convergedReductionSplit
+		replacement.convergedReductionSplit = replacement.convergedReductionSplit || output.MultiplePopPaths
+		applyDiagnosticParserCoreCleanPathOutput(&replacement, output.CleanPathRank, cleanPathLineage)
 		if len(replacements) > 0 {
 			if s.nextSeq == math.MaxUint64 {
 				return errors.New("parser-core phase zero: reduction creation sequence overflow")
@@ -3192,7 +3366,13 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 // adoptUpdatedReductionSibling updates an already-active canonical sibling in
 // place. The sibling keeps its scheduler slot and creation sequence; a paused
 // copy becomes runnable because the canonical boundary materially changed.
-func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(source int, head core.Head) (bool, error) {
+func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
+	source int,
+	head core.Head,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+	convergedReductionSplit bool,
+) (bool, error) {
 	for index := range s.headers {
 		if index == source {
 			continue
@@ -3208,6 +3388,9 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(sour
 		}
 		s.headers[index].head = head
 		s.headers[index].paused = false
+		s.headers[index].convergedReductionSplit =
+			s.headers[index].convergedReductionSplit || convergedReductionSplit
+		applyDiagnosticParserCoreCleanPathOutput(&s.headers[index], rank, lineage)
 		return true, nil
 	}
 	return false, nil
@@ -3217,13 +3400,22 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(s
 	kept := outputs[:0]
 	adopted := 0
 	for _, output := range outputs {
-		if output.freshness == core.ReductionUpdated {
-			ok, err := s.adoptUpdatedReductionSibling(source, output.head)
+		if output.freshness == core.ReductionUpdated || output.freshness == core.ReductionUnchanged {
+			ok, err := s.adoptUpdatedReductionSibling(
+				source,
+				output.head,
+				output.cleanPathRank,
+				output.cleanPathLineage,
+				output.cleanPathLineage != 0,
+			)
 			if err != nil {
 				return nil, 0, err
 			}
 			if ok {
 				adopted++
+				continue
+			}
+			if output.freshness == core.ReductionUnchanged {
 				continue
 			}
 		}
@@ -3240,6 +3432,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 		return err
 	}
 	dispatchesBefore, branchOrderBefore, nextSeqBefore := s.dispatches, s.branchOrder, s.nextSeq
+	nextCleanPathLineageBefore := s.nextCleanPathLineage
 	workBefore, epochProgressBefore := s.work, s.epochProgress
 	roundsBefore, conflictsBefore := len(s.receipt.Rounds), len(s.receipt.Conflicts)
 	externalShiftsBefore := len(s.receipt.ExternalShifts)
@@ -3249,6 +3442,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflict(before []Dia
 			return
 		}
 		s.dispatches, s.branchOrder, s.nextSeq = dispatchesBefore, branchOrderBefore, nextSeqBefore
+		s.nextCleanPathLineage = nextCleanPathLineageBefore
 		s.work, s.epochProgress = workBefore, epochProgressBefore
 		s.receipt.Rounds = s.receipt.Rounds[:roundsBefore]
 		s.receipt.Conflicts = s.receipt.Conflicts[:conflictsBefore]
@@ -3275,7 +3469,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
 		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
-		s.branchOrder, s.fullReceipts(), &s.conflictScratch,
+		s.branchOrder, &s.nextCleanPathLineage, s.fullReceipts(), &s.conflictScratch,
 	)
 	if err != nil {
 		return err
@@ -3482,6 +3676,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			cell := &cells[index]
 			s.headers[cell.headerIndex].head = heads[index]
 			s.headers[cell.headerIndex].shifted = true
+			markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
 		}
 		s.work.OrdinaryCohorts++
 	} else {
@@ -3501,6 +3696,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 			}
 			s.headers[cell.headerIndex].head = head
 			s.headers[cell.headerIndex].shifted = true
+			markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
 		}
 	}
 	s.epochProgress = true
@@ -3582,6 +3778,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 			cell := &cells[index]
 			s.headers[cell.headerIndex].head = heads[index]
 			s.headers[cell.headerIndex].shifted = true
+			markDiagnosticParserCoreExternalLineage(&s.headers[cell.headerIndex], token)
 		}
 		if s.extraPostExecutionFault != nil {
 			if err := s.extraPostExecutionFault(); err != nil {
@@ -4060,6 +4257,7 @@ func applyParserCoreConflictActionInto(
 	action core.Action,
 	ordinal int,
 	fork core.ForkOrder,
+	nextCleanPathLineage *uint16,
 ) ([]diagnosticParserCoreActionOutput, []core.ReductionOutput, error) {
 	if action.Type != core.ActionReduce {
 		switch action.Type {
@@ -4081,11 +4279,25 @@ func applyParserCoreConflictActionInto(
 	if err != nil {
 		return nil, outputs, err
 	}
+	var lineage uint16
+	if len(outputs) != 0 && outputs[0].MultiplePopPaths {
+		lineage, err = nextDiagnosticParserCoreCleanPathLineage(nextCleanPathLineage)
+		if err != nil {
+			return nil, outputs, err
+		}
+	}
 	for _, output := range outputs {
 		switch output.Freshness {
 		case core.ReductionUnchanged:
+			dst = append(dst, diagnosticParserCoreActionOutput{
+				head: output.Head, freshness: output.Freshness,
+				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage,
+			})
 		case core.ReductionNew, core.ReductionUpdated:
-			dst = append(dst, diagnosticParserCoreActionOutput{head: output.Head, freshness: output.Freshness})
+			dst = append(dst, diagnosticParserCoreActionOutput{
+				head: output.Head, freshness: output.Freshness,
+				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage,
+			})
 		default:
 			return nil, outputs, errors.New("parser-core phase zero: reduction returned invalid freshness")
 		}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -60,6 +60,7 @@ func newParserCoreFreshFullRunner(scanner ExternalScanner, options DiagnosticPar
 		options.MaxTokens = 100000
 	}
 	options.freshSchedulerSession = true
+	options.allowConvergedSplitDropArtifact = true
 
 	lang, err := authenticatedParserCoreGoLanguage(scanner)
 	if err != nil {
@@ -141,12 +142,14 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 		return fmt.Errorf("parser-core fresh-full runner acceptance is not sole exact EOF: token=%+v header=%+v accepts=%d/%d",
 			acceptance.Token, acceptance.Header.Header, acceptance.Accepts, acceptance.Work.Accepts)
 	}
-	if acceptance.Work.ConvergedReductionSplitDrops != 0 && !allowConvergedReductionSplitDrops {
+	if !allowConvergedReductionSplitDrops &&
+		acceptance.Work.ConvergedReductionSplitDrops != acceptance.Work.SelectedLineageDrops {
 		return &diagnosticParserCoreDecline{
 			boundary: DiagnosticParserCoreAccept,
 			detail: fmt.Sprintf(
-				"accepted frontier followed %d converged-path reduction split drops",
+				"accepted frontier followed %d converged-path reduction split drops with %d exact selected-lineage proofs",
 				acceptance.Work.ConvergedReductionSplitDrops,
+				acceptance.Work.SelectedLineageDrops,
 			),
 		}
 	}

--- a/parsercore_phase0_generic_freshness_internal_test.go
+++ b/parsercore_phase0_generic_freshness_internal_test.go
@@ -362,7 +362,7 @@ func TestDiagnosticParserCoreConflictPostExecutionFailureRollsBack(t *testing.T)
 	source, _ := compact.Seed(1, 0)
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact, headers: []diagnosticParserCoreHeader{{head: source, creationSeq: 4}},
-		token: Token{Symbol: 9, EndByte: 1}, branchOrder: 7, nextSeq: 10,
+		token: Token{Symbol: 9, EndByte: 1}, branchOrder: 7, nextSeq: 10, nextCleanPathLineage: 11,
 		options: DiagnosticParserCorePrefixOptions{MaxDispatches: 20}, receipt: &DiagnosticParserCoreGenericScheduler{},
 		conflictPostExecutionFault: func() error { return errors.New("post-execution fault") },
 	}
@@ -375,7 +375,7 @@ func TestDiagnosticParserCoreConflictPostExecutionFailureRollsBack(t *testing.T)
 		t.Fatal("post-execution fault unexpectedly succeeded")
 	}
 	afterStats, _ := compact.Stats(source)
-	if beforeStats != afterStats || !reflect.DeepEqual(scheduler.headers, beforeHeaders) || scheduler.branchOrder != 7 || scheduler.nextSeq != 10 || scheduler.dispatches != 0 || scheduler.work != (DiagnosticParserCoreGenericWork{}) || !reflect.DeepEqual(scheduler.receipt, &DiagnosticParserCoreGenericScheduler{}) {
+	if beforeStats != afterStats || !reflect.DeepEqual(scheduler.headers, beforeHeaders) || scheduler.branchOrder != 7 || scheduler.nextSeq != 10 || scheduler.nextCleanPathLineage != 11 || scheduler.dispatches != 0 || scheduler.work != (DiagnosticParserCoreGenericWork{}) || !reflect.DeepEqual(scheduler.receipt, &DiagnosticParserCoreGenericScheduler{}) {
 		t.Fatalf("post-execution rollback leaked: before=%+v after=%+v scheduler=%+v", beforeStats, afterStats, scheduler)
 	}
 	for _, state := range []core.StateID{2, 3} {

--- a/parsercore_phase0_generic_scheduler_test.go
+++ b/parsercore_phase0_generic_scheduler_test.go
@@ -369,6 +369,9 @@ func TestDiagnosticParserCoreGenericSchedulerCrossesMultiHeadExtraCohort(t *test
 
 func TestDiagnosticParserCoreGenericSchedulerAcceptsAndMaterializesExactRewrite(t *testing.T) {
 	source := parserCoreGenericRewriteSource(t)
+	if !grammars.GoLanguage().CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("authenticated Go diagnostic lost its exact-blob split-drop certificate")
+	}
 	result, routeErr := gotreesitter.DiagnosticParseParserCorePrefix(
 		grammars.GoExternalScanner{}, source,
 		gotreesitter.DiagnosticParserCorePrefixOptions{},
@@ -399,7 +402,7 @@ func TestDiagnosticParserCoreGenericSchedulerAcceptsAndMaterializesExactRewrite(
 			ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 			Reductions: 1256, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 			ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-			ReductionPauses: 31, NoActionDrops: 167, ConvergedReductionSplitDrops: 164, Elections: 1036,
+			ReductionPauses: 31, NoActionDrops: 167, ConvergedReductionSplitDrops: 165, SelectedLineageDrops: 1, Elections: 1036,
 			Canonicalizations: 2443, PeakHeaders: 4,
 		}) || len(result.GenericScheduler.Elections) != 1036 || len(result.GenericScheduler.Rounds) != 2443 || len(result.GenericScheduler.NoActionDrops) != 167 || len(result.GenericScheduler.ExternalShifts) != 83 {
 		t.Fatalf("acceptance receipt drifted: result=%+v acceptance=%+v", result, acceptance)
@@ -498,7 +501,7 @@ func TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite(t *testing.T) {
 				ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 				Reductions: 1256, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 				ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-				ReductionPauses: 31, NoActionDrops: 167, ConvergedReductionSplitDrops: 164, Elections: 1036,
+				ReductionPauses: 31, NoActionDrops: 167, ConvergedReductionSplitDrops: 165, SelectedLineageDrops: 1, Elections: 1036,
 				Canonicalizations: 2443, PeakHeaders: 4,
 			}) {
 			result.MaterializedTree.Release()

--- a/parsercore_phase0_selected_lineage_internal_test.go
+++ b/parsercore_phase0_selected_lineage_internal_test.go
@@ -1,0 +1,87 @@
+//go:build gts_parsercorephase0 && !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+func TestDiagnosticParserCoreSelectedLineageDropProof(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []diagnosticParserCoreHeader
+		indices []int
+		count   uint64
+		proved  bool
+	}{
+		{
+			name: "unselected-to-selected",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7},
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankUnselected, cleanPathLineage: 7},
+			},
+			indices: []int{1}, count: 1, proved: true,
+		},
+		{
+			name: "selected-drop",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7},
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankUnselected, cleanPathLineage: 7},
+			},
+			indices: []int{0},
+		},
+		{
+			name: "unknown-drop",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7},
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankUnknown},
+			},
+			indices: []int{1},
+		},
+		{
+			name: "different-lineage",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 8},
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankUnselected, cleanPathLineage: 7},
+			},
+			indices: []int{1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			count, proved := diagnosticParserCoreSelectedLineageDrops(test.headers, test.indices)
+			if count != test.count || proved != test.proved {
+				t.Fatalf("proof = %d/%t, want %d/%t", count, proved, test.count, test.proved)
+			}
+		})
+	}
+}
+
+func TestDiagnosticParserCoreSelectedLineageProofAllocations(t *testing.T) {
+	headers := []diagnosticParserCoreHeader{
+		{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7},
+		{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankUnselected, cleanPathLineage: 7},
+	}
+	indices := []int{1}
+	if allocations := testing.AllocsPerRun(1000, func() {
+		count, proved := diagnosticParserCoreSelectedLineageDrops(headers, indices)
+		if count != 1 || !proved {
+			panic("selected-lineage proof failed")
+		}
+	}); allocations != 0 {
+		t.Fatalf("warm selected-lineage proof allocations = %g, want 0", allocations)
+	}
+}
+
+func TestDiagnosticParserCoreExternalShiftInvalidatesLineage(t *testing.T) {
+	header := diagnosticParserCoreHeader{
+		cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7,
+	}
+	markDiagnosticParserCoreExternalLineage(&header, Token{ExternalScannerToken: true})
+	if header.cleanPathRank != core.CleanPathRankUnknown || header.cleanPathLineage != 0 {
+		t.Fatalf("external shift retained selected lineage: %+v", header)
+	}
+}

--- a/testdata/compact_selected_lineage/julia_utils.jl
+++ b/testdata/compact_selected_lineage/julia_utils.jl
@@ -1,0 +1,28 @@
+# Reduced from JuliaLang/julia at a176dec25429b497e304120acaff491639edab1b.
+# Source path: base/ryu/utils.jl.
+# Full source SHA-256: 51a8d2279c45469fe5d6e01d77125381c3884a57d0c8d5156e1f290014154e3f.
+const BIG_MASK = (big(1) << 64) - 1
+
+function generateinversetables()
+    POW10_OFFSET_2 = Vector{UInt16}(undef, 68 + 1)
+    MIN_BLOCK_2 = fill(0xff, 68 + 1)
+    POW10_SPLIT_2 = Tuple{UInt64, UInt64, UInt64}[]
+    lowerCutoff = big(1) << (54 + 8)
+    for idx = 0:67
+        POW10_OFFSET_2[idx + 1] = length(POW10_SPLIT_2)
+        i = 0
+        while true
+            v = ((big(10)^(9 * (i + 1)) >> (-(120 - 16 * idx))) % (big(10)^9) << (120 + 16))
+            if MIN_BLOCK_2[idx + 1] == 0xff && ((v * lowerCutoff) >> 128) == 0
+                i += 1
+                continue
+            end
+            if MIN_BLOCK_2[idx + 1] == 0xff
+                MIN_BLOCK_2[idx + 1] = i
+            end
+            v == 0 && break
+            push!(POW10_SPLIT_2, ((v & BIG_MASK) % UInt64, ((v >> 64) & BIG_MASK) % UInt64, ((v >> 128) & BIG_MASK) % UInt64))
+            i += 1
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Track one bounded lineage identity for each clean multi-pop reduction.

Drop an unselected no-action head only when one selected sibling keeps the same lineage.

Keep the existing artifact certificate as a compatibility escape. Remove it in a later tranche.

Invalidate the proof for:

- Exact ties.
- Unknown ranks.
- External payloads.
- External scanner shifts.
- Missing selected siblings.
- Lineage identity exhaustion.

## Coverage

The exact proof adds direct compact admission for these smoke witnesses:

- Dart.
- Elixir.
- Perl.
- Scala.

The artifact escape preserves these certified witnesses:

- Bash.
- Erlang.
- Haskell.
- JavaScript.
- Python.

Kotlin and Julia remain fail closed. The Julia fixture derives from a pinned upstream source.

## Validation

- Focused core rank, external payload, scheduler proof, layout, allocation, and rollback tests passed.
- The 206-language Docker scorecard reported 200 PASS, 0 DIVERGE, 1 FALLBACK, and 5 SKIP.
- The bounded Docker corpus reported 67 PASS, 33 FALLBACK, 10 SKIP, 0 DIVERGE, and 0 ERROR.
- The corpus used 110 files below 16,384 bytes and excluded the documented slow AWK case.
- Canopy indexed 1,890 files with no parse errors or stale files.

Stable settings:

- `GOMAXPROCS=1`
- `-count=10`
- `-benchtime=750ms`
- `-benchmem`

The full parse median improved from approximately 7.85 ms to 7.45 ms.

The incremental edit median changed from approximately 1.021 microseconds to 1.047 microseconds.

The no-edit median improved from approximately 4.062 ns to 4.010 ns.

Allocation counts stayed at 8, 0, and 0.

Base: `b34cc797401fae70b95bcb6d91e73e2a258ffc9b`.
