### PR TITLE
remove(cooklang): retire the trailing step tail subpass

### DIFF
--- a/parser_result_cooklang.go
+++ b/parser_result_cooklang.go
@@ -17,9 +17,6 @@ func normalizeCooklangCompatibilityWithCensus(
 	lang *Language,
 	census materializationSubpassCensus,
 ) {
-	census.run("dispatch.cooklang.trailing-step-tail", func() {
-		normalizeCooklangTrailingStepTail(root, source, lang)
-	})
 	census.run("dispatch.cooklang.recovered-recipe", func() {
 		normalizeCooklangRecoveredRecipe(root, source, lang)
 	})

--- a/parser_result_misc_spans.go
+++ b/parser_result_misc_spans.go
@@ -1,52 +1,5 @@
 package gotreesitter
 
-func bytesAreCooklangStepTail(b []byte) bool {
-	sawPunctuation := false
-	for _, c := range b {
-		switch c {
-		case '.', '!', '?':
-			if sawPunctuation {
-				return false
-			}
-			sawPunctuation = true
-		case ' ', '\t', '\n', '\r':
-		default:
-			return false
-		}
-	}
-	return sawPunctuation
-}
-
-func normalizeCooklangTrailingStepTail(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "cooklang" || len(source) == 0 {
-		return
-	}
-	if root.Type(lang) != "recipe" || resultChildCount(root) != 1 {
-		return
-	}
-	step := resultChildAt(root, 0)
-	if step == nil || step.Type(lang) != "step" || step.endByte >= uint32(len(source)) {
-		return
-	}
-	tail := source[step.endByte:]
-	if !bytesAreCooklangStepTail(tail) {
-		return
-	}
-	stepEnd := step.endByte
-	for i := int(step.endByte); i < len(source); i++ {
-		switch source[i] {
-		case '.', '!', '?':
-			stepEnd = uint32(i + 1)
-		}
-	}
-	if stepEnd > step.endByte {
-		extendNodeEndTo(step, stepEnd, source)
-	}
-	if root.endByte < uint32(len(source)) {
-		extendNodeEndTo(root, uint32(len(source)), source)
-	}
-}
-
 func normalizeRootEOFNewlineSpan(root *Node, source []byte, lang *Language) {
 	if root == nil || lang == nil || len(source) == 0 || root.endByte >= uint32(len(source)) {
 		return

--- a/parser_result_test/materialization_subpass_census_test.go
+++ b/parser_result_test/materialization_subpass_census_test.go
@@ -337,14 +337,13 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 			},
 		},
 		{
-			name:             "cooklang_trailing_step_tail",
+			name:             "cooklang_punctuation_recipe",
 			language:         grammars.CooklangLanguage,
 			source:           "Add @salt{1%tsp}.\n",
 			wantRawDigest:    "0e6880ec4902576c2a6de014424c3cba7eef99cdc5fd8fded8ceb6382a6df9cd",
 			wantResultDigest: "c6e4535b725516550ca7a0ee4c69974799c2d2d10fed4e5f1ba6b71e43c5ba8a",
 			expectedSubpasses: []string{
 				"dispatch.cooklang",
-				"dispatch.cooklang.trailing-step-tail",
 				"dispatch.cooklang.recovered-recipe",
 			},
 			rewrittenSubpasses: []string{
@@ -365,7 +364,6 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 			wantResultDigest: "814240a8aff9c3e253b37ce1ff535ff2cd96510c6afea40680a270405699967f",
 			expectedSubpasses: []string{
 				"dispatch.cooklang",
-				"dispatch.cooklang.trailing-step-tail",
 				"dispatch.cooklang.recovered-recipe",
 			},
 			rewrittenSubpasses: []string{
@@ -374,14 +372,13 @@ func materializationSubpassProbes() []materializationSubpassProbe {
 			},
 		},
 		{
-			name:             "cooklang_step_tail_without_newline",
+			name:             "cooklang_recovered_recipe_without_newline",
 			language:         grammars.CooklangLanguage,
 			source:           "Add @salt{1%tsp}.",
 			wantRawDigest:    "f49ca1a85a0b2ee7ed7f07993d6bc8b103d66311f83d4a026e085cf2013a69ec",
 			wantResultDigest: "dd3692a1a0e9145af9f2d082126a1e798d60cbe74942427746d3f0e83bd31e1c",
 			expectedSubpasses: []string{
 				"dispatch.cooklang",
-				"dispatch.cooklang.trailing-step-tail",
 				"dispatch.cooklang.recovered-recipe",
 			},
 			rewrittenSubpasses: []string{

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -560,24 +560,9 @@
         "normalizeCooklangCompatibilityWithCensus"
       ],
       "files": [
-        "parser_result_cooklang.go",
-        "parser_result_misc_spans.go"
+        "parser_result_cooklang.go"
       ],
       "subpasses": [
-        {
-          "id": "dispatch.cooklang.trailing-step-tail",
-          "functions": [
-            "normalizeCooklangTrailingStepTail"
-          ],
-          "files": [
-            "parser_result_misc_spans.go"
-          ],
-          "purpose": "Publish the punctuation tail and the complete recipe span.",
-          "authoritative_owner": "scanner_checkpoint_state",
-          "witnesses": [
-            "parser_result_test/materialization_subpass_census_test.go"
-          ]
-        },
         {
           "id": "dispatch.cooklang.recovered-recipe",
           "functions": [
@@ -596,8 +581,8 @@
       "languages": [
         "cooklang"
       ],
-      "purpose": "Reconcile Cooklang returned-tree shape and spans.",
-      "authoritative_owner": "materialization",
+      "purpose": "Construct recovered Cooklang steps, metadata, punctuation errors, and fence comments.",
+      "authoritative_owner": "scheduler_action_semantics",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go"
       ],


### PR DESCRIPTION
## Summary

Retire the inert Cooklang trailing step tail subpass.

The retained recovered recipe subpass still owns Cooklang recovery output.

## Evidence

- The pinned Cooklang corpus contains ten fixtures.
- The aggregate Cooklang arm rewrote 242 nodes before and after this change.
- Three locked probes recorded zero trailing step tail rewrites.
- The recovered recipe pass rewrote 4, 18, and 4 nodes in those probes.
- The compact Cooklang smoke ratchet passed.
- Forest parity dispatched five fixtures and reported zero divergences.
- Fresh and incremental parses matched the C oracle.

## Tests

- `TestDispatcherArmCensusOverRealCorpus`
- `TestMaterializationSubpassCompatibilityFreeProducerProbes`
- `TestCooklang*`
- `TestResultCompatibilityOwnershipRegistry`
- `TestAdmissionCandidateCooklangSmokeRatchet`
- `TestForestCorpusParity`
- `TestParityFreshParse/cooklang`
- `TestParityIncrementalParse/cooklang`
