### PR TITLE
optimize(parser): Reuse DFA re-lex snapshot buffer across outer transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ for tags and release notes while still in `0.x`.
   buffer.
   The 235,626-byte Go fixture allocates 7.583 MiB instead of 48.073 MiB.
   Allocations fall from 10,404 to 513 per parse.
-  Stable parse time improves by 15.46 percent.
+  Two stable pairs improve parse time by 9.52 to 15.46 percent.
   Maximum resident set size falls from 228,272 KiB to 176,612 KiB.
 
 - Direct parser-state re-lex probes now use their existing outer transaction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Outer parser-state re-lex transactions now reuse one 4 KiB scanner-state
+  buffer.
+  The 235,626-byte Go fixture allocates 7.583 MiB instead of 48.073 MiB.
+  Allocations fall from 10,404 to 513 per parse.
+  Stable parse time improves by 15.46 percent.
+  Maximum resident set size falls from 228,272 KiB to 176,612 KiB.
+
 - Direct parser-state re-lex probes now use their existing outer transaction.
   This removes a redundant scanner-state snapshot.
   The 235,626-byte Go fixture allocates 48.07 MiB instead of 86.69 MiB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ for tags and release notes while still in `0.x`.
   The 235,626-byte Go fixture allocates 7.583 MiB instead of 48.073 MiB.
   Allocations fall from 10,404 to 513 per parse.
   Two stable pairs improve parse time by 9.52 to 15.46 percent.
-  Maximum resident set size falls from 228,272 KiB to 176,612 KiB.
+  Maximum resident set size falls from 220,236 KiB to 185,920 KiB.
 
 - Direct parser-state re-lex probes now use their existing outer transaction.
   This removes a redundant scanner-state snapshot.

--- a/dfa_relex_transaction_test.go
+++ b/dfa_relex_transaction_test.go
@@ -42,7 +42,34 @@ func TestDFARelexFailureRestoresThroughOuterTransaction(t *testing.T) {
 		EndPoint:   Point{Column: 1},
 	}
 
-	snapshot := ts.snapshotRelexState()
+	scratch := &parserScratch{
+		relexSnapshotBuffer: make([]byte, externalScannerSerializationBufferSize),
+	}
+	for i := range scratch.relexSnapshotBuffer {
+		scratch.relexSnapshotBuffer[i] = 0xff
+	}
+	snapshot, retained := scratch.snapshotDFARelexState(ts)
+	if !retained || !scratch.relexSnapshotInUse {
+		t.Fatal("outer re-lex snapshot did not retain parser scratch")
+	}
+	if got := cap(scratch.relexSnapshotBuffer); got != externalScannerSerializationBufferSize {
+		t.Fatalf("retained buffer capacity = %d, want %d", got, externalScannerSerializationBufferSize)
+	}
+	for i, b := range scratch.relexSnapshotBuffer[:cap(scratch.relexSnapshotBuffer)] {
+		if i == 0 {
+			continue
+		}
+		if b != 0 {
+			t.Fatalf("retained buffer byte %d = %d, want cleared before reuse", i, b)
+		}
+	}
+	nested, nestedRetained := scratch.snapshotDFARelexState(ts)
+	if nestedRetained {
+		t.Fatal("nested re-lex snapshot reused the active outer buffer")
+	}
+	if &nested.externalPayload[0] == &snapshot.externalPayload[0] {
+		t.Fatal("nested re-lex snapshot aliases the active outer buffer")
+	}
 	if got, ok := ts.relexFromTokenStartInTransaction(tok); ok {
 		t.Fatalf("relexFromTokenStartInTransaction = (%+v, true), want false for skipped-start token", got)
 	}
@@ -50,6 +77,7 @@ func TestDFARelexFailureRestoresThroughOuterTransaction(t *testing.T) {
 		t.Fatal("failed probe restored itself; want the outer transaction to own rollback")
 	}
 	snapshot.restore(ts)
+	scratch.releaseDFARelexSnapshot(retained)
 
 	if ts.lexer.pos != 2 || ts.lexer.row != 4 || ts.lexer.col != 6 {
 		t.Fatalf("lexer = pos %d row %d col %d, want restored 2/4/6", ts.lexer.pos, ts.lexer.row, ts.lexer.col)
@@ -62,6 +90,75 @@ func TestDFARelexFailureRestoresThroughOuterTransaction(t *testing.T) {
 	}
 	if ts.zeroWidthPos != 9 || ts.zeroWidthCount != 3 {
 		t.Fatalf("zero-width guard = pos %d count %d, want 9/3", ts.zeroWidthPos, ts.zeroWidthCount)
+	}
+	if scratch.relexSnapshotInUse {
+		t.Fatal("outer re-lex snapshot remains active after rollback")
+	}
+	for i, b := range scratch.relexSnapshotBuffer[:cap(scratch.relexSnapshotBuffer)] {
+		if b != 0 {
+			t.Fatalf("released buffer byte %d = %d, want zero", i, b)
+		}
+	}
+}
+
+func TestParserScratchDropsOversizedDFARelexSnapshotBuffer(t *testing.T) {
+	oversized := make([]byte, externalScannerSerializationBufferSize+1)
+	for i := range oversized {
+		oversized[i] = 0xff
+	}
+	scratch := &parserScratch{
+		relexSnapshotBuffer: oversized,
+		relexSnapshotInUse:  true,
+	}
+	scratch.releaseDFARelexSnapshot(true)
+	if scratch.relexSnapshotBuffer != nil {
+		t.Fatalf("oversized re-lex buffer capacity = %d, want dropped", cap(scratch.relexSnapshotBuffer))
+	}
+	if scratch.relexSnapshotInUse {
+		t.Fatal("oversized re-lex buffer remains active after release")
+	}
+	for i, b := range oversized {
+		if b != 0 {
+			t.Fatalf("dropped buffer byte %d = %d, want zero", i, b)
+		}
+	}
+}
+
+func TestParserScratchReusesDFARelexSnapshotBufferAfterCommit(t *testing.T) {
+	lang := &Language{ExternalScanner: byteStateExternalScanner{}}
+	payload := lang.ExternalScanner.Create()
+	*payload.(*byte) = 9
+	ts := &dfaTokenSource{
+		lexer:              NewLexer(nil, nil),
+		language:           lang,
+		externalPayload:    payload,
+		hasExternalScanner: true,
+	}
+	scratch := &parserScratch{}
+
+	first, firstRetained := scratch.snapshotDFARelexState(ts)
+	if !firstRetained || len(first.externalPayload) != 1 {
+		t.Fatalf("first snapshot = retained %t payload %v, want true/[9]", firstRetained, first.externalPayload)
+	}
+	firstBuffer := &first.externalPayload[0]
+	*payload.(*byte) = 7
+	scratch.releaseDFARelexSnapshot(firstRetained)
+	if got := *payload.(*byte); got != 7 {
+		t.Fatalf("committed scanner state = %d, want 7", got)
+	}
+
+	second, secondRetained := scratch.snapshotDFARelexState(ts)
+	if !secondRetained || len(second.externalPayload) != 1 {
+		t.Fatalf("second snapshot = retained %t payload %v, want true/[7]", secondRetained, second.externalPayload)
+	}
+	if &second.externalPayload[0] != firstBuffer {
+		t.Fatal("completed outer transaction did not reuse its retained buffer")
+	}
+	*payload.(*byte) = 3
+	second.restore(ts)
+	scratch.releaseDFARelexSnapshot(secondRetained)
+	if got := *payload.(*byte); got != 7 {
+		t.Fatalf("rolled-back scanner state = %d, want 7", got)
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -7545,11 +7545,12 @@ func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSou
 	if !statefulOK || !relexerOK || dts == nil || !relexer.CanRelexFromTokenStart(tok) {
 		return Token{}, false
 	}
-	snapshot := dts.snapshotRelexState()
+	snapshot, retainedSnapshot := scratch.snapshotDFARelexState(dts)
 	savedState := dts.state
 	savedGLRStates := dts.glrStates
 	restoreRejectedProbe := func() {
 		snapshot.restore(dts)
+		scratch.releaseDFARelexSnapshot(retainedSnapshot)
 		dts.state = savedState
 		dts.glrStates = savedGLRStates
 		p.updateCurrentRelexParserStateTokenSource(ts, stacks, scratch)
@@ -7580,6 +7581,7 @@ func (p *Parser) tryRelexSingleParserState(tok Token, state StateID, ts TokenSou
 	// The returned token and committed scanner checkpoint belong to this parser
 	// state. Keep the source isolated through dispatch; the outer loop refreshes
 	// the live frontier before its next read, and same-pass re-lex paths set it.
+	scratch.releaseDFARelexSnapshot(retainedSnapshot)
 	return next, true
 }
 

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2740,6 +2740,11 @@ type dfaRelexSnapshot struct {
 }
 
 func (d *dfaTokenSource) snapshotRelexState() dfaRelexSnapshot {
+	snapshot, _ := d.snapshotRelexStateWithExternalBuffer(nil)
+	return snapshot
+}
+
+func (d *dfaTokenSource) snapshotRelexStateWithExternalBuffer(buf []byte) (dfaRelexSnapshot, []byte) {
 	s := dfaRelexSnapshot{
 		lexerPos:                    d.lexer.pos,
 		lexerRow:                    d.lexer.row,
@@ -2758,12 +2763,20 @@ func (d *dfaTokenSource) snapshotRelexState() dfaRelexSnapshot {
 		zeroWidthCount:              d.zeroWidthCount,
 	}
 	if d.hasExternalScanner && d.language != nil && d.language.ExternalScanner != nil {
-		buf := make([]byte, externalScannerSerializationBufferSize)
+		if cap(buf) != externalScannerSerializationBufferSize {
+			if cap(buf) > 0 {
+				clear(buf[:cap(buf)])
+			}
+			buf = make([]byte, externalScannerSerializationBufferSize)
+		} else {
+			buf = buf[:externalScannerSerializationBufferSize]
+			clear(buf)
+		}
 		if n := d.language.ExternalScanner.Serialize(d.externalPayload, buf); n > 0 {
 			s.externalPayload = buf[:n]
 		}
 	}
-	return s
+	return s, buf
 }
 
 func (s dfaRelexSnapshot) restore(d *dfaTokenSource) {

--- a/parser_scratch.go
+++ b/parser_scratch.go
@@ -23,6 +23,8 @@ type parserScratch struct {
 	transientParents         transientParentScratch
 	transientCheckpointBytes int64
 	transientCheckpoints     uint64
+	relexSnapshotBuffer      []byte
+	relexSnapshotInUse       bool
 	trackChildErrors         bool
 	budgetBytes              int64
 	budgetBaselineBytes      int64
@@ -75,6 +77,31 @@ func (s *parserScratch) budgetExhausted() bool {
 		used = 0
 	}
 	return used >= s.budgetBytes
+}
+
+func (s *parserScratch) snapshotDFARelexState(d *dfaTokenSource) (dfaRelexSnapshot, bool) {
+	if s == nil || s.relexSnapshotInUse {
+		return d.snapshotRelexState(), false
+	}
+	s.relexSnapshotInUse = true
+	snapshot, buf := d.snapshotRelexStateWithExternalBuffer(s.relexSnapshotBuffer)
+	s.relexSnapshotBuffer = buf[:0]
+	return snapshot, true
+}
+
+func (s *parserScratch) releaseDFARelexSnapshot(retained bool) {
+	if s == nil || !retained {
+		return
+	}
+	if cap(s.relexSnapshotBuffer) > 0 {
+		clear(s.relexSnapshotBuffer[:cap(s.relexSnapshotBuffer)])
+	}
+	if cap(s.relexSnapshotBuffer) == externalScannerSerializationBufferSize {
+		s.relexSnapshotBuffer = s.relexSnapshotBuffer[:0]
+	} else {
+		s.relexSnapshotBuffer = nil
+	}
+	s.relexSnapshotInUse = false
 }
 
 func releaseParserScratch(s *parserScratch, skipGSSClear bool) {
@@ -150,6 +177,15 @@ func releaseParserScratch(s *parserScratch, skipGSSClear bool) {
 	s.transientParents.resetForRelease()
 	s.transientCheckpointBytes = 0
 	s.transientCheckpoints = 0
+	if cap(s.relexSnapshotBuffer) > 0 {
+		clear(s.relexSnapshotBuffer[:cap(s.relexSnapshotBuffer)])
+	}
+	if cap(s.relexSnapshotBuffer) != externalScannerSerializationBufferSize {
+		s.relexSnapshotBuffer = nil
+	} else {
+		s.relexSnapshotBuffer = s.relexSnapshotBuffer[:0]
+	}
+	s.relexSnapshotInUse = false
 	s.trackChildErrors = false
 	s.entries.reset()
 	s.gss.skipClear = skipGSSClear


### PR DESCRIPTION
## Summary

- Reuse one 4 KiB scanner-state buffer for outer parser re-lex transactions.
- Keep public snapshot behavior independent for non-parser and nested callers.
- Give reentrant parser probes an independent buffer while the retained buffer is active.
- Clear the full buffer before reuse and after each completed transaction.
- Retain exactly 4,096 bytes and drop all other capacities.

## Performance

The current comparison uses base `344a14b0cb3ab436eb0ee9a6552c86bf7de7f415`.
The head is `3bc764377c9bad466f44fd488c5f3fa37b56ff93`.
The fixture contains 235,626 bytes and has SHA-256 `a7e4a1a64b25a60aea36183b9d6d53dcd9240942cdb10e67a3cf9e6ce30f95b2`.

- The standard benchmark improves from 209.2 ms to 189.3 ms.
  This is a 9.52 percent improvement with `p=0.000`.
- A fixed five-iteration run improves time by 14.62 percent.
- Fixed-iteration allocated bytes fall from 46.205 MiB to 7.583 MiB.
- Fixed-iteration allocations fall from 10,404 to 513 per parse.
- Maximum resident set size falls from 220,236 KiB to 185,920 KiB.
- Earlier stable evidence measured a 15.46 percent time improvement.
- The compact full-parse and single-edit benchmarks remain statistically unchanged.
- The compact no-edit benchmark improves by 4.62 percent.
- The retained-snapshot allocation disappears from the allocation profile.

All workload counters remain exact:

- 330,478 nodes
- 49,912 tokens
- 53,125 multi-stack iterations
- 47,976 multi-stack tokens
- 18 maximum stacks
- 58 maximum depth
- zero normalization runs

## Correctness

- The focused host and Docker transaction tests pass after the rebase.
- The root package passes in 140.428 seconds.
- Go real-corpus parity passes all 25 cases after the rebase.
- All 25 syntax trees and deep-tree digests match.
- Docker reports no out-of-memory failure.

The tests prove these conditions:

- A nested probe cannot alias an active outer buffer.
- A successful commit preserves the new scanner state.
- A failed probe restores the exact scanner state and token-source fields.
- The parser reuses the retained buffer only after commit or rollback.
- The parser clears retained and dropped buffers.
- The parser drops buffers whose capacity is not 4,096 bytes.

## Reproduction

```sh
GOMAXPROCS=1 go test . -run '^$' \
  -bench '^BenchmarkGoParseWarmRealDFA/grammargen_lr$' \
  -benchmem -count=10 -benchtime=750ms
```

```sh
GOMAXPROCS=1 go test . -run '^$' \
  -bench '^BenchmarkGoParseWarmRealDFA/grammargen_lr$' \
  -benchmem -count=10 -benchtime=5x
```

```sh
GOMAXPROCS=1 go test . -run '^$' \
  -bench 'BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA' \
  -benchmem -count=10 -benchtime=750ms
```

```sh
go test . -run '^Test(DFARelexFailureRestoresThroughOuterTransaction|ParserScratchDropsOversizedDFARelexSnapshotBuffer|ParserScratchReusesDFARelexSnapshotBufferAfterCommit|DFATokenSourceRelexFailureRestoresProgressAndBookkeeping)$' -count=1
```

```sh
bash cgo_harness/docker/run_single_grammar_parity.sh go
```
