### PR TITLE
optimize(parser): keep short GSS hash walks on stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- Graph-structured stack hashing now selects inline or pooled walk storage
+  before it collects nodes.
+  The 235,626-byte Go fixture allocates 24.84 KiB instead of 110.34 KiB.
+  Allocations fall from 511 to 169 per parse.
+  Parse time and maximum resident set size remain unchanged.
+
 - Outer parser-state re-lex transactions now reuse one 4 KiB scanner-state
   buffer.
   The 235,626-byte Go fixture allocates 7.583 MiB instead of 48.073 MiB.

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -398,29 +398,47 @@ func gssNodeHash(n *gssNode) uint64 {
 		return n.hash
 	}
 
-	var local [32]*gssNode
-	pending := local[:0]
-	var pooled *[]*gssNode
-	for cur := n; cur != nil && cur.hash == 0; cur = cur.prev {
-		if pooled == nil && len(pending) == len(local) {
-			// The chain outgrew the inline array. Move to a pooled buffer so a
-			// deep walk reuses one allocation instead of growing a fresh slice
-			// on every call.
-			pooled = gssNodeHashPendingPool.Get().(*[]*gssNode)
-			*pooled = append((*pooled)[:0], pending...)
-			pending = *pooled
-		}
-		pending = append(pending, cur)
-		if pooled != nil {
-			*pooled = pending
-		}
+	const inlineCap = 32
+	count := 0
+	for ancestor := n; ancestor != nil && ancestor.hash == 0 && count <= inlineCap; ancestor = ancestor.prev {
+		count++
 	}
-	prevHash := gssHashSeed
-	if len(pending) < int(n.depth) {
-		prev := pending[len(pending)-1].prev
-		if prev != nil {
-			prevHash = prev.hash
-		}
+	if count <= inlineCap {
+		return gssNodeHashInline(n, count)
+	}
+
+	// The chain outgrew the inline array. Use pooled storage directly.
+	// This keeps the inline array on the stack for ordinary walks.
+	pooled := gssNodeHashPendingPool.Get().(*[]*gssNode)
+	pending := (*pooled)[:0]
+	for cur := n; cur != nil && cur.hash == 0; cur = cur.prev {
+		pending = append(pending, cur)
+	}
+	*pooled = pending
+	hash := gssNodeHashPending(pending)
+	// Released explicitly rather than with defer: this is a hot path and the
+	// function has a single exit once the walk buffer exists.
+	if resetGSSNodeHashPendingForPool(pooled) {
+		gssNodeHashPendingPool.Put(pooled)
+	}
+	return hash
+}
+
+func gssNodeHashInline(n *gssNode, count int) uint64 {
+	var local [32]*gssNode
+	pending := local[:count]
+	cur := n
+	for i := range pending {
+		pending[i] = cur
+		cur = cur.prev
+	}
+	return gssNodeHashPending(pending)
+}
+
+func gssNodeHashPending(pending []*gssNode) uint64 {
+	prevHash := uint64(gssHashSeed)
+	if prev := pending[len(pending)-1].prev; prev != nil {
+		prevHash = prev.hash
 	}
 	for i := len(pending) - 1; i >= 0; i-- {
 		h := gssEntryHash(prevHash, pending[i].entry)
@@ -430,14 +448,7 @@ func gssNodeHash(n *gssNode) uint64 {
 		pending[i].hash = h
 		prevHash = h
 	}
-	// Released explicitly rather than with defer: this is a hot path and the
-	// function has a single exit once the walk buffer exists.
-	if pooled != nil {
-		if resetGSSNodeHashPendingForPool(pooled) {
-			gssNodeHashPendingPool.Put(pooled)
-		}
-	}
-	return n.hash
+	return pending[0].hash
 }
 
 func newGSSStack(initial StateID, scratch *gssScratch) gssStack {

--- a/glr_gss_test.go
+++ b/glr_gss_test.go
@@ -1,6 +1,7 @@
 package gotreesitter
 
 import (
+	"fmt"
 	"testing"
 	"unsafe"
 )
@@ -146,6 +147,57 @@ func TestGSSNodeHashComputedLazilyForSingleStackNodes(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("lazy hash = %d, want %d", got, want)
+	}
+}
+
+func TestGSSNodeHashMatchesAcrossInlineBoundary(t *testing.T) {
+	for _, length := range []int{1, 31, 32, 33, 64} {
+		t.Run(fmt.Sprintf("length_%d", length), func(t *testing.T) {
+			nodes := make([]gssNode, length)
+			want := uint64(gssHashSeed)
+			for i := range nodes {
+				nodes[i].entry.state = StateID(i + 1)
+				nodes[i].depth = uint32(i + 1)
+				if i > 0 {
+					nodes[i].prev = &nodes[i-1]
+				}
+				want = gssEntryHash(want, nodes[i].entry)
+				if want == 0 {
+					want = 1
+				}
+			}
+			if got := gssNodeHash(&nodes[len(nodes)-1]); got != want {
+				t.Fatalf("hash = %d, want %d", got, want)
+			}
+			for i := range nodes {
+				if nodes[i].hash == 0 {
+					t.Fatalf("node %d hash remains zero", i)
+				}
+			}
+		})
+	}
+}
+
+func TestGSSNodeHashInlineWalkDoesNotAllocate(t *testing.T) {
+	var nodes [32]gssNode
+	for i := range nodes {
+		nodes[i].entry.state = StateID(i + 1)
+		nodes[i].depth = uint32(i + 1)
+		if i > 0 {
+			nodes[i].prev = &nodes[i-1]
+		}
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		for i := range nodes {
+			nodes[i].hash = 0
+		}
+		if got := gssNodeHash(&nodes[len(nodes)-1]); got == 0 {
+			t.Fatal("inline hash walk returned zero")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("inline hash walk allocated %.0f objects, want 0", allocs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Select stack or pooled hash-walk storage before node collection.
- Keep walks of 32 nodes or fewer on the stack.
- Preserve pooled storage and its clearing contract for deeper walks.
- Add exact boundary and allocation regression tests.

## Performance

The authenticated 235,626-byte `grammargen_lr` fixture shows:

- Parse time: 159.9 ms to 161.5 ms. This change is not significant (`p=0.796`).
- Allocated bytes: 110.34 KiB to 24.84 KiB (`-77.49%`, `p=0.000`).
- Allocations: 511 to 169 (`-66.93%`, `p=0.000`).

The primary benchmark trio retains its allocation counts of 8, 0, and 0.
Full-parse time and allocated bytes do not change significantly.

Process-isolated maximum resident set size remains unchanged within noise.
The baseline range is 127,252 to 127,520 KiB.
The changed range is 127,040 to 127,680 KiB.

## Correctness

- The focused hash and pooled-buffer tests pass ten consecutive runs.
- The exact 1, 31, 32, 33, and 64-node hash boundaries pass.
- Go Docker parity passes 25 of 25 cases for clean, S-expression, and deep parity.
- The optional PHP sweep matches the unchanged baseline.
  Both revisions report 7 clean, 6 S-expression, and 6 deep parity cases from 25.
  Neither run reports an out-of-memory failure.

## Commands

```sh
go test . -run '^(TestGSSNodeHashComputedLazilyForSingleStackNodes|TestGSSNodeHashMatchesAcrossInlineBoundary|TestGSSNodeHashInlineWalkDoesNotAllocate|TestResetGSSNodeHashPendingForPoolClearsExactBacking|TestGSSNodeHashPooledFallbackRealPHPTransientErrorChain)$' -count=10

bash cgo_harness/docker/run_single_grammar_parity.sh go

GOMAXPROCS=1 go test . -run '^$' -bench '^(BenchmarkGoParseFullDFA|BenchmarkGoParseIncrementalSingleByteEditDFA|BenchmarkGoParseIncrementalNoEditDFA)$' -benchmem -count=10 -benchtime=750ms
```
