### PR TITLE
add(admission): record token-source DFA shadow evidence

### DIFF
--- a/admission_token_source_shadow_test.go
+++ b/admission_token_source_shadow_test.go
@@ -1,0 +1,110 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+var admissionTokenSourceShadowLanguages = map[string]struct{}{
+	"authzed": {},
+	"c":       {},
+	"cpp":     {},
+	"java":    {},
+	"json":    {},
+}
+
+func TestAdmissionCandidateTokenSourceEntriesExposeDFASmoke(t *testing.T) {
+	wanted := make(map[string]struct{}, len(admissionTokenSourceShadowLanguages))
+	for name := range admissionTokenSourceShadowLanguages {
+		wanted[name] = struct{}{}
+	}
+	for _, entry := range grammars.AllLanguages() {
+		if _, ok := wanted[entry.Name]; !ok {
+			continue
+		}
+		entry := entry
+		t.Run(entry.Name, func(t *testing.T) {
+			lang := entry.Language()
+			support := grammars.EvaluateParseSupport(entry, lang)
+			if support.Backend != grammars.ParseBackendTokenSource {
+				t.Fatalf("preferred backend = %q, want token_source", support.Backend)
+			}
+			if !support.HasDFALexer {
+				t.Fatal("embedded language has no DFA lexer")
+			}
+			if support.RequiresExternalScanner && !support.HasExternalScanner {
+				t.Fatal("embedded language requires an external scanner, but none is attached")
+			}
+
+			// This copy tests latent DFA capability. It does not change the
+			// preferred production backend or the scorecard SKIP count.
+			dfaEntry := entry
+			dfaEntry.TokenSourceFactory = nil
+			row := runAdmissionScorecardLanguage(dfaEntry)
+			if row.status != scorecardPass {
+				t.Fatalf("DFA compact smoke = %s: %s", row.status, row.detail)
+			}
+		})
+		delete(wanted, entry.Name)
+	}
+	for name := range wanted {
+		t.Errorf("missing registry entry %q", name)
+	}
+}
+
+func TestAdmissionCandidateDFASmokeMatchesPreferredTokenSource(t *testing.T) {
+	wanted := make(map[string]struct{}, len(admissionTokenSourceShadowLanguages))
+	for name := range admissionTokenSourceShadowLanguages {
+		wanted[name] = struct{}{}
+	}
+	for _, entry := range grammars.AllLanguages() {
+		if _, ok := wanted[entry.Name]; !ok {
+			continue
+		}
+		entry := entry
+		t.Run(entry.Name, func(t *testing.T) {
+			lang := entry.Language()
+			source := []byte(grammars.ParseSmokeSample(entry.Name))
+
+			tokenTree, err := gts.NewParser(lang).ParseWithTokenSource(source, entry.TokenSourceFactory(source, lang))
+			if err != nil {
+				t.Fatalf("token-source parse: %v", err)
+			}
+			defer tokenTree.Release()
+			tokenInspection, err := benchfixtures.InspectGoTree(tokenTree.RootNode(), lang)
+			if err != nil {
+				t.Fatalf("token-source digest: %v", err)
+			}
+
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			defer candidateTree.Release()
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 1 || fallback != 0 {
+				t.Fatalf("compact route counters = routed %d, fallback %d", routed, fallback)
+			}
+			candidateInspection, err := benchfixtures.InspectGoTree(candidateTree.RootNode(), lang)
+			if err != nil {
+				t.Fatalf("compact digest: %v", err)
+			}
+			if candidateInspection.SHA256 != tokenInspection.SHA256 {
+				first := firstAdmissionTreeDivergence(candidateTree.RootNode(), tokenTree.RootNode(), lang, "root")
+				t.Fatalf("compact tree differs from preferred token-source tree: %s", first)
+			}
+		})
+		delete(wanted, entry.Name)
+	}
+	for name := range wanted {
+		t.Errorf("missing registry entry %q", name)
+	}
+}

--- a/docs/compact-route-coverage-census.md
+++ b/docs/compact-route-coverage-census.md
@@ -316,6 +316,43 @@ requirements, svelte, tcl, templ, tmux, twig, uxntal, v, vimdoc, xml
 
 authzed, c, cpp, java, json
 
+### Preferred token-source DFA shadow audit
+
+The five SKIP entries still use token sources through the grammar registry.
+Each embedded language also has DFA tables. C++ also has its required scanner.
+
+`TestAdmissionCandidateTokenSourceEntriesExposeDFASmoke` records the latent DFA
+capability. It does not change the preferred backend or the SKIP ratchet.
+
+`TestAdmissionCandidateDFASmokeMatchesPreferredTokenSource` adds a separate
+backend-equivalence receipt. The field-aware digest includes:
+
+- Node types and fields.
+- Byte and point spans.
+- Named, extra, missing, and error flags.
+- Child counts and structure.
+
+All five smoke fixtures route through the compact parser. Each result matches
+the preferred token-source tree.
+
+The bounded real-corpus audit used files of 16,383 bytes or less:
+
+- C: both files declined the compact route. Their DFA fallback matched the
+  token-source tree.
+- C++: all three files declined. The DFA fallback differed from the
+  token-source tree on two files.
+- Java: one file routed and matched. One file declined, and its DFA fallback
+  matched.
+- JSON: all three files routed and matched.
+- Authzed: the corpus has no fixture. The canonical smoke fixture is the only
+  current receipt.
+
+Keep all five rows as SKIP. Production promotion needs one public shadow route.
+That route must try compact DFA parsing and use the token source after a
+decline. It must not expose the ordinary DFA fallback.
+
+Add a small canonical Authzed corpus fixture before a depth promotion.
+
 ## Follow-up
 
 - The top-2 real-world burn-down items by this census are


### PR DESCRIPTION
## Summary

- Record latent DFA capability for the five token-source SKIP languages.
- Compare each compact smoke tree with the preferred token-source tree.
- Keep the production backend and the five-row SKIP ratchet unchanged.
- Document the bounded corpus results and the required public shadow route.

The deep digest covers fields, spans, structure, and node flags.

## Validation

- Ran both focused tests on the host.
- Ran the Authzed receipt in Docker.
- Ran the C receipt in Docker.
- Ran the C++ receipt in Docker.
- Ran the Java receipt in Docker.
- Ran the JSON receipt in Docker.

All focused checks pass. Each Docker run used one grammar.