### PR TITLE
improve(js-cli): report a missing JavaScript runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ for tags and release notes while still in `0.x`.
   It imports the temporary canonical `grammar.json` through the existing path.
   The explicit flag warns that grammar evaluation executes JavaScript.
 
+- `grammargen -js-cli` now identifies a missing JavaScript runtime when
+  Tree-sitter cannot start Node. The command help and README list both
+  prerequisites.
+
 - The canonical compact real-corpus matrix now enforces 67 direct routes,
   at most 33 fallbacks, exactly 10 skips, and no divergence or error.
   A lock-pinned Elm highlight fixture protects the refreshed 110-row corpus.

--- a/cmd/grammargen/commands.go
+++ b/cmd/grammargen/commands.go
@@ -113,7 +113,7 @@ func runEmitCommand(args []string) {
 
 func registerSourceFlags(fs *flag.FlagSet, src *sourceFlags) {
 	fs.StringVar(&src.jsInput, "js", "", "path to a tree-sitter grammar.js file to import")
-	fs.StringVar(&src.jsCLIInput, "js-cli", "", "path to grammar.js to resolve with tree-sitter CLI (executes arbitrary JavaScript)")
+	fs.StringVar(&src.jsCLIInput, "js-cli", "", "path to grammar.js; requires tree-sitter CLI 0.26+ and a JavaScript runtime; executes arbitrary JavaScript")
 	fs.StringVar(&src.jsonInput, "json", "", "path to a resolved tree-sitter grammar.json file to import")
 	fs.StringVar(&src.grammarFile, "grammar", "", "path to a .grammar file to parse")
 	fs.BoolVar(&src.lrSplit, "lr-split", false, "enable LR(1) state splitting before generation")

--- a/cmd/grammargen/grammar_js_cli.go
+++ b/cmd/grammargen/grammar_js_cli.go
@@ -50,7 +50,7 @@ func importGrammarJSWithCLI(path, executable string) (*grammargen.Grammar, error
 	cmd.Dir = filepath.Dir(grammarPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, commandError("tree-sitter generate", err, output)
+		return nil, grammarJSGenerateError(err, output)
 	}
 
 	jsonPath := filepath.Join(outputDir, "grammar.json")
@@ -63,6 +63,17 @@ func importGrammarJSWithCLI(path, executable string) (*grammargen.Grammar, error
 		return nil, fmt.Errorf("import generated grammar.json: %w", err)
 	}
 	return g, nil
+}
+
+func grammarJSGenerateError(err error, output []byte) error {
+	cause := commandError("tree-sitter generate", err, output)
+	if strings.Contains(string(output), "Failed to run `node`") {
+		return fmt.Errorf(
+			"-js-cli requires Tree-sitter CLI 0.26 or newer and a JavaScript runtime such as Node on PATH: %w",
+			cause,
+		)
+	}
+	return cause
 }
 
 func requireTreeSitterCLICapabilities(cli string) error {

--- a/cmd/grammargen/grammar_js_cli_test.go
+++ b/cmd/grammargen/grammar_js_cli_test.go
@@ -129,6 +129,22 @@ func TestImportGrammarJSWithCLIReportsGenerateFailure(t *testing.T) {
 	}
 }
 
+func TestImportGrammarJSWithCLIReportsMissingJavaScriptRuntime(t *testing.T) {
+	tmp := t.TempDir()
+	grammarPath := filepath.Join(tmp, "grammar.js")
+	if err := os.WriteFile(grammarPath, []byte("module.exports = grammar({});\n"), 0o644); err != nil {
+		t.Fatalf("write grammar.js: %v", err)
+	}
+	t.Setenv("FAKE_GENERATE_ERROR", "Failed to load grammar.js -- Failed to run `node` -- No such file or directory")
+	cli := writeFakeTreeSitterCLI(t, tmp, "0.26.6", "", 7)
+	_, err := importGrammarJSWithCLI(grammarPath, cli)
+	if err == nil ||
+		!strings.Contains(err.Error(), "JavaScript runtime such as Node") ||
+		!strings.Contains(err.Error(), "tree-sitter generate") {
+		t.Fatalf("error = %v, want JavaScript runtime requirement and generation context", err)
+	}
+}
+
 func TestImportGrammarJSWithCLIRejectsMissingCapability(t *testing.T) {
 	tmp := t.TempDir()
 	grammarPath := filepath.Join(tmp, "grammar.js")
@@ -160,7 +176,7 @@ fi
 printf '%s\n' "$@" > "${FAKE_ARGS_PATH:-/dev/null}"
 printf '%s\n' "$PWD" > "${FAKE_DIR_PATH:-/dev/null}"
 if test "$FAKE_GENERATE_STATUS" != "0"; then
-  printf 'fake generation failed\n' >&2
+  printf '%s\n' "${FAKE_GENERATE_ERROR:-fake generation failed}" >&2
   exit "$FAKE_GENERATE_STATUS"
 fi
 output=

--- a/cmd/grammargen/main.go
+++ b/cmd/grammargen/main.go
@@ -121,7 +121,7 @@ func parseCLIConfig() cliConfig {
 	flag.StringVar(&cfg.cOut, "c", "", "output path for tree-sitter parser.c")
 	flag.StringVar(&cfg.goOut, "go", "", "output path for grammargen Go DSL source")
 	flag.StringVar(&cfg.jsInput, "js", "", "path to a tree-sitter grammar.js file to import")
-	flag.StringVar(&cfg.jsCLIInput, "js-cli", "", "path to grammar.js to resolve with tree-sitter CLI (executes arbitrary JavaScript)")
+	flag.StringVar(&cfg.jsCLIInput, "js-cli", "", "path to grammar.js; requires tree-sitter CLI 0.26+ and a JavaScript runtime; executes arbitrary JavaScript")
 	flag.StringVar(&cfg.jsonInput, "json", "", "path to a resolved tree-sitter grammar.json file to import")
 	flag.StringVar(&cfg.grammarFile, "grammar", "", "path to a .grammar file to parse")
 	flag.StringVar(&cfg.pkgName, "pkg", "grammargen", "package name for -go output")

--- a/grammargen/README.md
+++ b/grammargen/README.md
@@ -102,9 +102,9 @@ go run ./cmd/grammargen doctor <grammar> -lr-split -sample sample.<ext>
 go run ./cmd/grammargen emit <grammar> -lr-split -bin grammars/grammar_blobs/<grammar>.bin
 ```
 
-`-js-cli` needs Tree-sitter 0.26 or newer on `PATH`. It generates only
-`grammar.json` and `node-types.json` in a temporary directory. It then removes
-that directory.
+`-js-cli` needs Tree-sitter 0.26 or newer on `PATH`. It also needs a JavaScript
+runtime, such as Node, on `PATH`. It generates only `grammar.json` and
+`node-types.json` in a temporary directory. It then removes that directory.
 
 Set `TREE_SITTER_JS_RUNTIME=native` to use the native runtime in Tree-sitter
 0.26 or newer. Install the grammar's required packages before compilation.


### PR DESCRIPTION
## Summary

- Detect Tree-sitter's missing Node error and add one prerequisite hint.
- State the runtime requirement in the command help and grammar generator README.
- Preserve the original Tree-sitter output for diagnostics.

This change does not alter grammar compilation.

## Verification

- `go test ./cmd/grammargen -run '^Test(ImportGrammarJSWithCLI|ParseTreeSitterCLIVersion)' -count=1 -v`
- Reproduced the missing-Node path with Tree-sitter 0.26.6.
- Checked the top-level and `emit` help output.