### PR TITLE
Skip duplicate GSS shape cache lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ for tags and release notes while still in `0.x`.
 
 ### Performance
 
+- The graph-structured stack shape walk now skips a duplicate cache lookup
+  after a known head miss.
+  The standard full-parse benchmark improves by 5.12 percent across 20 samples.
+  Allocations remain at nine per parse.
+
 - Graph-structured stack hashing now selects inline or pooled walk storage
   before it collects nodes.
   The 235,626-byte Go fixture allocates 24.84 KiB instead of 110.34 KiB.

--- a/glr.go
+++ b/glr.go
@@ -1015,9 +1015,9 @@ func gssMaterializingShapePrefix(scratch *glrMergeScratch, n *gssNode) glrMateri
 		return cached
 	}
 	var local [32]*gssNode
-	pending := local[:0]
+	pending := append(local[:0], n)
 	prefix := glrMaterializingShapeHash{hash: gssHashSeed}
-	for cur := n; cur != nil; cur = cur.prev {
+	for cur := n.prev; cur != nil; cur = cur.prev {
 		if cached, ok := lookupShapePrefixCache(scratch, cur); ok {
 			prefix = cached
 			break


### PR DESCRIPTION
## Summary

- Skip the second cache lookup after the head lookup misses.
- Preserve the existing stack buffer and node order.
- Improve FullDFA by 5.12 percent across 20 samples.

## Tests

- Four shape-prefix tests, 10 runs each
- Go parity, 25 of 25 cases
- Standard benchmark trio, 20 samples