### PR TITLE
fix(parser): split adjacent Swift generic closers by parser state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The DFA lexer now splits adjacent Swift generic closers by parser state.
+  It preserves `>>` when the active state accepts the shift operator.
+  The pinned C oracle now matches without divergence.
+  This fixes [#543](https://github.com/odvcencio/gotreesitter/issues/543).
+
 - Native `grammar.js` import now ignores comments in semantic AST children.
   All 206 pinned grammars show import coverage increasing from 62 to 70.
 

--- a/cgo_harness/parity_swift_generic_closer_regression_test.go
+++ b/cgo_harness/parity_swift_generic_closer_regression_test.go
@@ -1,0 +1,22 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import "testing"
+
+func TestParitySwiftAdjacentGenericClosers(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "nested-generic-call", source: "let v = X<Y<Z>>()\n"},
+		{name: "right-shift", source: "let v = x >> y\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			runParityCase(t, parityCase{name: "swift", source: test.source}, test.name, source)
+		})
+	}
+}

--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -66,6 +66,75 @@ func TestSwiftMemberKeywordSelfAfterDotStaysNavigable(t *testing.T) {
 	}
 }
 
+func TestSwiftNestedGenericCallAdjacentClosers(t *testing.T) {
+	lang := SwiftLanguage()
+	for _, route := range []struct {
+		name    string
+		compact bool
+	}{
+		{name: "production"},
+		{name: "compact", compact: true},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			src := []byte("let v = X<Y<Z>>()\n")
+			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(route.compact)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse nested generic call: %v", err)
+			}
+			defer tree.Release()
+
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("nested generic call has parse errors: %s", root.SExpr(lang))
+			}
+			sexpr := root.SExpr(lang)
+			if got, want := strings.Count(sexpr, "(type_arguments"), 2; got != want {
+				t.Fatalf("type argument count = %d, want %d; tree: %s", got, want, sexpr)
+			}
+			if !strings.Contains(sexpr, "(constructor_expression") ||
+				!strings.Contains(sexpr, "(constructor_suffix") {
+				t.Fatalf("nested generic call has no constructor call: %s", sexpr)
+			}
+		})
+	}
+}
+
+func TestSwiftRightShiftOperatorUnaffected(t *testing.T) {
+	lang := SwiftLanguage()
+	for _, route := range []struct {
+		name    string
+		compact bool
+	}{
+		{name: "production"},
+		{name: "compact", compact: true},
+	} {
+		t.Run(route.name, func(t *testing.T) {
+			src := []byte("let v = x >> y\n")
+			parser := gotreesitter.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(route.compact)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse right shift: %v", err)
+			}
+			defer tree.Release()
+
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("right shift has parse errors: %s", root.SExpr(lang))
+			}
+			sexpr := root.SExpr(lang)
+			if !strings.Contains(sexpr, "(bitwise_operation") {
+				t.Fatalf("right shift has no bitwise_operation: %s", sexpr)
+			}
+			if strings.Contains(sexpr, "(type_arguments") {
+				t.Fatalf("right shift became type arguments: %s", sexpr)
+			}
+		})
+	}
+}
+
 // TestSwiftStringLiteralEndingInDotDoesNotCorruptFollowingToken guards against
 // a regression in shouldDemoteSwiftMemberKeyword/isAfterSwiftMemberDot: a
 // string literal whose last content character is '.' immediately before the

--- a/parser.go
+++ b/parser.go
@@ -5341,7 +5341,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				result.lastReduceDepth = stopActionDiag.lastReduceStackDepth
 			}
 			if s != nil && !s.dead && !s.accepted && !s.shifted && s.depth() > 0 {
-				actionIdx := p.lookupActionIndex(s.top().state, tok.Symbol)
+				actionIdx := p.contextualActionIndex(source, s.top().state, tok)
 				if actionIdx != 0 && p.language != nil && int(actionIdx) < len(p.language.ParseActions) {
 					frontierActions := p.language.ParseActions[actionIdx].Actions
 					result.terminalCount = len(frontierActions)
@@ -5519,7 +5519,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 			if phaseTiming {
 				actionStart = time.Now()
 			}
-			actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+			actionIdx := p.contextualActionIndex(source, currentState, tok)
 			var actions []ParseAction
 			if actionIdx != 0 && int(actionIdx) < len(parseActions) {
 				actions = parseActions[actionIdx].Actions
@@ -6361,7 +6361,7 @@ func (p *Parser) parseInternal(source []byte, ts TokenSource, reuse *reuseCursor
 				if s.dead || s.accepted || s.shifted || s.cPaused || s.depth() == 0 {
 					continue
 				}
-				actionIdx := p.lookupActionIndex(s.top().state, tok.Symbol)
+				actionIdx := p.contextualActionIndex(source, s.top().state, tok)
 				if actionIdx == 0 || int(actionIdx) >= len(parseActions) {
 					terminalFrontierOK = false
 					break

--- a/parser_dfa_token_source.go
+++ b/parser_dfa_token_source.go
@@ -2164,9 +2164,7 @@ func (d *dfaTokenSource) splitCompactCloseAngleToken(tok Token) (Token, int, uin
 	if d == nil || d.language == nil || d.lookupActionIndex == nil {
 		return tok, 0, 0, 0, false
 	}
-	switch d.language.Name {
-	case "dart", "java", "tsx", "typescript":
-	default:
+	if !supportsContextualCloseAngleSplit(d.language.Name) {
 		return tok, 0, 0, 0, false
 	}
 	if d.symbolName(tok.Symbol) != ">>" {
@@ -2192,6 +2190,85 @@ func (d *dfaTokenSource) splitCompactCloseAngleToken(tok Token) (Token, int, uin
 		tok.Text = tok.Text[:1]
 	}
 	return tok, int(tok.EndByte), tok.EndPoint.Row, tok.EndPoint.Column, true
+}
+
+func supportsContextualCloseAngleSplit(languageName string) bool {
+	switch languageName {
+	case "dart", "java", "swift", "tsx", "typescript":
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Parser) contextualActionIndex(source []byte, state StateID, tok Token) uint16 {
+	actionIdx := p.lookupActionIndex(state, tok.Symbol)
+	if actionIdx != 0 && p.shouldDeferContextualCloseAngleAction(source, state, tok) {
+		return 0
+	}
+	return actionIdx
+}
+
+// shouldDeferContextualCloseAngleAction reports that this stack's lex mode
+// reads an adjacent pair as one operator. Another live stack selected the
+// single close-angle prefix, so this stack must not consume that prefix.
+func (p *Parser) shouldDeferContextualCloseAngleAction(source []byte, state StateID, tok Token) bool {
+	lang := p.language
+	if lang == nil || !supportsContextualCloseAngleSplit(lang.Name) ||
+		int(tok.Symbol) >= len(lang.SymbolNames) || lang.SymbolNames[tok.Symbol] != ">" ||
+		tok.EndByte != tok.StartByte+1 ||
+		tok.EndPoint.Row != tok.StartPoint.Row {
+		return false
+	}
+	start := int(tok.StartByte)
+	if start < 0 || start+1 >= len(source) || source[start] != '>' || source[start+1] != '>' ||
+		int(state) >= len(lang.LexModes) {
+		return false
+	}
+	lexState := lang.LexModes[state].LexStateIndex()
+	if lexState == noLookaheadLexState || int(lexState) >= len(lang.LexStates) {
+		return false
+	}
+
+	probe := &p.relexProbeLexer
+	*probe = Lexer{
+		states:          lang.LexStates,
+		asciiTable:      lang.LexAsciiTable(),
+		source:          source,
+		pos:             start,
+		row:             tok.StartPoint.Row,
+		col:             tok.StartPoint.Column,
+		immediateTokens: lang.ImmediateTokens,
+		zeroWidthTokens: lang.ZeroWidthTokens,
+	}
+	stateToken, ok := probe.scan(uint32(lexState), probe.pos, probe.row, probe.col)
+	if !ok || int(stateToken.Symbol) >= len(lang.SymbolNames) {
+		return false
+	}
+	if lang.SymbolNames[stateToken.Symbol] != ">>" ||
+		stateToken.StartByte != tok.StartByte ||
+		stateToken.EndByte != tok.StartByte+2 ||
+		!p.stateHasActionForSymbol(state, stateToken.Symbol) {
+		return false
+	}
+	closeIdx := p.lookupActionIndex(state, tok.Symbol)
+	shiftIdx := p.lookupActionIndex(state, stateToken.Symbol)
+	if closeIdx != 0 && closeIdx == shiftIdx && int(closeIdx) < len(lang.ParseActions) {
+		actions := lang.ParseActions[closeIdx].Actions
+		if len(actions) > 0 {
+			reduceOnly := true
+			for _, action := range actions {
+				if action.Type != ParseActionReduce {
+					reduceOnly = false
+					break
+				}
+			}
+			if reduceOnly {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (d *dfaTokenSource) shouldSplitCompactCloseAngleToken(tok Token, gtSym, shiftSym Symbol, shiftOK bool) bool {

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -871,7 +871,7 @@ func (p *Parser) completeConflictReduceFrontier(source []byte, s *glrStack, tok 
 		if s.dead || s.accepted || s.shifted || s.cPaused || s.depth() == 0 {
 			return
 		}
-		actionIdx := p.lookupActionIndex(s.top().state, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, s.top().state, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(p.language.ParseActions) {
 			return
 		}
@@ -1972,7 +1972,7 @@ func (p *Parser) chainSingleReduceActions(source []byte, s *glrStack, tok Token,
 	for chainLen < maxInlineReduceChain {
 		currentState := s.top().state
 		currentDepth := s.depth()
-		actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, currentState, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(parseActions) {
 			return false
 		}
@@ -2085,7 +2085,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedHinted(source []byte, s *glrS
 	steps := 0
 	for steps < int(hint.maxSteps) {
 		currentState := s.top().state
-		actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, currentState, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(actions) {
 			if reduceChainHintTerminalMatches(hint, currentState, classifiedParseActionNoAction) {
 				if perfCountersEnabled {
@@ -2161,7 +2161,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedDefault(source []byte, s *glr
 	for chainLen < maxInlineReduceChain {
 		currentState := s.top().state
 		currentDepth := s.depth()
-		actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, currentState, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(actions) {
 			return false
 		}
@@ -2214,7 +2214,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedBenchmarkOnly(source []byte, 
 	const maxInlineReduceChain = 256
 	actions := p.classifiedActions
 	for chainLen := 0; chainLen < maxInlineReduceChain; {
-		actionIdx := p.lookupActionIndex(s.top().state, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, s.top().state, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(actions) {
 			return false
 		}
@@ -2265,7 +2265,7 @@ func (p *Parser) chainSingleReduceActionsProfiled(source []byte, s *glrStack, to
 	for chainLen < maxInlineReduceChain {
 		currentState := s.top().state
 		currentDepth := s.depth()
-		actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, currentState, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(parseActions) {
 			p.ambiguityProfile.recordReduceChainRun(chainStartState, tok.Symbol, currentState, classifiedParseActionNoAction, chainLen, chainLen, classHits, time.Since(chainStart).Nanoseconds(), reduceChainStopNoAction)
 			return false
@@ -2360,7 +2360,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedHintedProfiled(source []byte,
 	chainStart := time.Now()
 	for chainLen < int(hint.maxSteps) {
 		currentState := s.top().state
-		actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, currentState, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(actions) {
 			if reduceChainHintTerminalMatches(hint, currentState, classifiedParseActionNoAction) {
 				if perfCountersEnabled {
@@ -2452,7 +2452,7 @@ func (p *Parser) chainSingleReduceActionsClassifiedProfiledDefault(source []byte
 	for chainLen < maxInlineReduceChain {
 		currentState := s.top().state
 		currentDepth := s.depth()
-		actionIdx := p.lookupActionIndex(currentState, tok.Symbol)
+		actionIdx := p.contextualActionIndex(source, currentState, tok)
 		if actionIdx == 0 || int(actionIdx) >= len(actions) {
 			p.ambiguityProfile.recordReduceChainRun(chainStartState, tok.Symbol, currentState, classifiedParseActionNoAction, chainLen, chainLen, classHits, time.Since(chainStart).Nanoseconds(), reduceChainStopNoAction)
 			return false


### PR DESCRIPTION
## Summary

Split adjacent Swift generic closers according to each active parser state.
Preserve `>>` when that state expects the shift operator.
The minimal witness now matches the pinned C oracle exactly.

## Changes

- Add Swift to the existing close-angle split path.
- Route parser and reduction action lookups through one contextual gate.
- Keep shared reduce-only actions until their parser states diverge.
- Add production, compact-admission, operator-control, and C-oracle tests.
- Add the fix to the unreleased changelog.

## Correctness

- `TestSwiftNestedGenericCallAdjacentClosers` passes.
- `TestSwiftRightShiftOperatorUnaffected` passes.
- `TestParitySwiftAdjacentGenericClosers` matches the C oracle.
- Swift fresh, incremental, and no-error Docker parity passes.

The C oracle uses Swift commit `41d6e5fe811ec94229ee71771174a8cce558dfee`.
Its generated parser uses Application Binary Interface version 14.

## Performance

The focused benchmark parses 128 adjacent nested generic calls.

| Metric | Main | This change |
| --- | ---: | ---: |
| Time | 17.499 ms | 6.270 ms |
| Bytes per parse | 8.47 MiB | 34.38 KiB |
| Allocations per parse | 9,401 | 270 |

The standard Swift full-parse benchmark shows no significant time change.
Its bytes and allocation count stay unchanged.

Fixes #543.
