### PR TITLE
docs: correct current compact matrix receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ for tags and release notes while still in `0.x`.
   Tree-sitter cannot start Node. The command help and README list both
   prerequisites.
 
-- The canonical compact real-corpus matrix now enforces 67 direct routes,
-  at most 33 fallbacks, exactly 10 skips, and no divergence or error.
-  A lock-pinned Elm highlight fixture protects the refreshed 110-row corpus.
+- The canonical compact real-corpus matrix now records 66 direct routes,
+  33 fallbacks, exactly 10 skips, and no divergence or error.
+  The bounded current receipt covers 109 rows.
 
 ### Performance
 

--- a/docs/compact-route-real-corpus-matrix.md
+++ b/docs/compact-route-real-corpus-matrix.md
@@ -1,7 +1,7 @@
 # Compact route real-corpus matrix
 
 Current evidence date: 2026-07-29.
-Current base commit: `088e6e12` from `main`.
+Current base commit: `50bbcf7e` from `main`.
 
 ## Current bounded result
 


### PR DESCRIPTION
## Summary

- Correct the current compact receipt to 66 direct routes and 109 total rows.
- Record `50bbcf7e` as the current matrix base.
- Preserve the historical 67-route and 110-row receipt.

## Validation

- `git diff --check`
- Focused assertions for the current and historical receipt totals
