### PR TITLE
Add source-owned historical provenance

### DIFF
--- a/admission_real_corpus_matrix_test.go
+++ b/admission_real_corpus_matrix_test.go
@@ -215,7 +215,9 @@ func TestAdmissionCandidateRealCorpusMatrix(t *testing.T) {
 			t.Fatal("real-corpus ratchet requires the canonical scope: no language or bucket filters, AWK excluded, and max bytes 16383")
 		}
 		const (
-			minRows     = 110
+			// Pinned Rust has ast.rs at 66,281 bytes and weird-exprs.rs at 6,436 bytes.
+			// This gate excludes ast.rs, so the canonical manifest has 109 rows.
+			minRows     = 109
 			minPass     = 67
 			maxFallback = 33
 			wantSkip    = 10

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -373,6 +373,21 @@ type nodeRecord struct {
 	pathCount  uint64
 }
 
+type nodeLineageRecord struct {
+	owner     uint32
+	lineage   uint16
+	rank      CleanPathRankSelection
+	converged bool
+}
+
+type nodeLineageMutation struct {
+	node      NodeID
+	owner     uint32
+	lineage   uint16
+	rank      CleanPathRankSelection
+	converged bool
+}
+
 type linkRecord struct {
 	scoreDelta int64
 	order      uint64
@@ -574,40 +589,44 @@ type RawSelectedCensus struct {
 // Core is the compact, persistent diagnostic graph. All records are indexes
 // into pointer-free slices; the production parser is unaffected.
 type Core struct {
-	tables              TableView
-	plans               ReductionPlanProvider
-	selectedProvider    SelectedStorePolicyProvider
-	selectedPolicy      *SelectedStorePolicy
-	limits              Limits
-	diagnostics         diagnosticOptions
-	nodes               []nodeRecord
-	nodeCheckpoints     []CheckpointID
-	links               []linkRecord
-	subtrees            []subtreeRecord
-	externalProvenance  []externalPayloadProvenance
-	children            []SubtreeID
-	fields              []FieldMapEntry
-	aliases             []Symbol
-	frontier            uint64
-	checkpoint          CheckpointID
-	checkpoints         checkpointInterner
-	boundaries          boundaryIndex
-	boundaryJournal     []boundaryMutation
-	condenseCandidates  []CondenseCandidate
-	condenseNewNode     NodeID
-	condenseScopeActive bool
-	transactions        []uint64
-	nextTransaction     uint64
-	classificationPhase uint64
-	work                Work
-	popScratch          popEnumerationScratch
-	reductionScratch    reductionOutputScratch
-	cohortHeadScratch   []Head
-	factorLinkScratch   []linkRecord
-	selectedBuild       selectedStoreBuildScratch
-	selectedPoolMu      sync.Mutex
-	selectedPool        selectedStoreBacking
-	schedulerFrame      schedulerTransactionFrame
+	tables                TableView
+	plans                 ReductionPlanProvider
+	selectedProvider      SelectedStorePolicyProvider
+	selectedPolicy        *SelectedStorePolicy
+	limits                Limits
+	diagnostics           diagnosticOptions
+	nodes                 []nodeRecord
+	nodeLineages          []nodeLineageRecord
+	nodeCheckpoints       []CheckpointID
+	links                 []linkRecord
+	subtrees              []subtreeRecord
+	externalProvenance    []externalPayloadProvenance
+	children              []SubtreeID
+	fields                []FieldMapEntry
+	aliases               []Symbol
+	frontier              uint64
+	checkpoint            CheckpointID
+	checkpoints           checkpointInterner
+	boundaries            boundaryIndex
+	boundaryJournal       []boundaryMutation
+	nodeLineageJournal    []nodeLineageMutation
+	condenseCandidates    []CondenseCandidate
+	condenseNewNode       NodeID
+	condenseScopeActive   bool
+	reductionSourceOwner  uint32
+	transactions          []uint64
+	nextTransaction       uint64
+	classificationPhase   uint64
+	work                  Work
+	popScratch            popEnumerationScratch
+	reductionScratch      reductionOutputScratch
+	historicalNodeScratch []NodeID
+	cohortHeadScratch     []Head
+	factorLinkScratch     []linkRecord
+	selectedBuild         selectedStoreBuildScratch
+	selectedPoolMu        sync.Mutex
+	selectedPool          selectedStoreBacking
+	schedulerFrame        schedulerTransactionFrame
 	// metadataConstructionAuthenticated remains true only while every compact
 	// subtree was published through the authenticated shift/reduction seams.
 	// Diagnostic generic publication clears it monotonically until Reset.
@@ -684,14 +703,15 @@ type diagnosticOptions struct {
 }
 
 type checkpoint struct {
-	nodes, nodeCheckpoints, links, subtrees, externalProvenance int
-	children, fields, aliases                                   int
-	frontier                                                    uint64
-	checkpoint                                                  CheckpointID
-	boundaryIndex                                               boundaryIndexSnapshot
-	journal                                                     int
-	transaction                                                 uint64
-	work                                                        Work
+	nodes, nodeLineages, nodeCheckpoints, links, subtrees, externalProvenance int
+	children, fields, aliases                                                 int
+	frontier                                                                  uint64
+	checkpoint                                                                CheckpointID
+	boundaryIndex                                                             boundaryIndexSnapshot
+	journal                                                                   int
+	nodeLineageJournal                                                        int
+	transaction                                                               uint64
+	work                                                                      Work
 }
 
 // SchedulerTransactionToken is an opaque capability for one active
@@ -729,14 +749,17 @@ func (c *Core) markInto(mark *checkpoint) {
 	}
 	c.nextTransaction++
 	*mark = checkpoint{
-		nodes: len(c.nodes), links: len(c.links), subtrees: len(c.subtrees),
+		nodes: len(c.nodes), nodeLineages: len(c.nodeLineages),
+		links: len(c.links), subtrees: len(c.subtrees),
 		nodeCheckpoints:    len(c.nodeCheckpoints),
 		externalProvenance: len(c.externalProvenance),
 		children:           len(c.children), fields: len(c.fields), aliases: len(c.aliases),
 		frontier: c.frontier, checkpoint: c.checkpoint,
-		boundaryIndex: c.boundaries.snapshot(),
-		journal:       len(c.boundaryJournal), transaction: c.nextTransaction,
-		work: c.work,
+		boundaryIndex:      c.boundaries.snapshot(),
+		journal:            len(c.boundaryJournal),
+		nodeLineageJournal: len(c.nodeLineageJournal),
+		transaction:        c.nextTransaction,
+		work:               c.work,
 	}
 	c.transactions = append(c.transactions, mark.transaction)
 	parent := uint64(0)
@@ -763,6 +786,7 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 	}
 	c.classificationPhase++
 	c.nodes = c.nodes[:mark.nodes]
+	c.nodeLineages = c.nodeLineages[:mark.nodeLineages]
 	c.nodeCheckpoints = c.nodeCheckpoints[:mark.nodeCheckpoints]
 	c.links = c.links[:mark.links]
 	c.subtrees = c.subtrees[:mark.subtrees]
@@ -777,9 +801,22 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 		mutation := c.boundaryJournal[index]
 		mutation.slots[mutation.index] = mutation.previous
 	}
+	for index := len(c.nodeLineageJournal) - 1; index >= mark.nodeLineageJournal; index-- {
+		mutation := c.nodeLineageJournal[index]
+		nodeIndex := int(mutation.node) - 1
+		if nodeIndex < 0 || nodeIndex >= len(c.nodes) {
+			continue
+		}
+		c.nodeLineages[nodeIndex].owner = mutation.owner
+		c.nodeLineages[nodeIndex].lineage = mutation.lineage
+		c.nodeLineages[nodeIndex].rank = mutation.rank
+		c.nodeLineages[nodeIndex].converged = mutation.converged
+	}
 	c.boundaries.restore(mark.boundaryIndex)
 	clear(c.boundaryJournal[mark.journal:])
 	c.boundaryJournal = c.boundaryJournal[:mark.journal]
+	clear(c.nodeLineageJournal[mark.nodeLineageJournal:])
+	c.nodeLineageJournal = c.nodeLineageJournal[:mark.nodeLineageJournal]
 	phase0AObserveRollback(c, mark.transaction, phase0ATakeRollbackCause(c))
 	c.finishTransaction()
 }
@@ -809,6 +846,8 @@ func (c *Core) finishTransaction() {
 	if len(c.transactions) == 0 {
 		clear(c.boundaryJournal)
 		c.boundaryJournal = c.boundaryJournal[:0]
+		clear(c.nodeLineageJournal)
+		c.nodeLineageJournal = c.nodeLineageJournal[:0]
 	}
 }
 
@@ -1062,6 +1101,7 @@ func (c *Core) Reset() error {
 	}
 	c.classificationPhase++
 	c.nodes = c.nodes[:0]
+	c.nodeLineages = c.nodeLineages[:0]
 	c.nodeCheckpoints = c.nodeCheckpoints[:0]
 	c.links = c.links[:0]
 	c.subtrees = c.subtrees[:0]
@@ -1075,13 +1115,17 @@ func (c *Core) Reset() error {
 	c.boundaries.reset()
 	clear(c.boundaryJournal)
 	c.boundaryJournal = c.boundaryJournal[:0]
+	clear(c.nodeLineageJournal)
+	c.nodeLineageJournal = c.nodeLineageJournal[:0]
 	c.clearLiveCondenseCandidates()
+	c.reductionSourceOwner = 0
 	c.transactions = c.transactions[:0]
 	c.nextTransaction = 0
 	c.schedulerFrame.clearInactive()
 	c.work = Work{}
 	c.popScratch.resetLogical()
 	c.reductionScratch.finish()
+	c.historicalNodeScratch = c.historicalNodeScratch[:0]
 	c.metadataConstructionAuthenticated = true
 	c.reduceConflictContext = false
 	c.reduceNoLookaheadContext = false
@@ -1189,6 +1233,7 @@ func (c *Core) Seed(state StateID, byteOffset uint32) (Head, error) {
 	}
 	if err := c.publishBoundary(probe, id); err != nil {
 		c.nodes = c.nodes[:len(c.nodes)-1]
+		c.nodeLineages = c.nodeLineages[:len(c.nodeLineages)-1]
 		if !c.externalPayloadsQuiescent {
 			c.nodeCheckpoints = c.nodeCheckpoints[:len(c.nodeCheckpoints)-1]
 		}
@@ -1487,25 +1532,42 @@ const (
 	CleanPathRankUnknown
 )
 
+// HistoricalBoundaryProvenance classifies one retired boundary version.
+// Deterministic versions contain no fragile or converged forest. Converged
+// versions retain selected-lineage provenance. Unproved versions fail closed.
+type HistoricalBoundaryProvenance uint8
+
+const (
+	HistoricalBoundaryNone HistoricalBoundaryProvenance = iota
+	HistoricalBoundaryDeterministic
+	HistoricalBoundaryConverged
+	HistoricalBoundaryUnproved
+)
+
 // ReductionOutput is one final canonical boundary and its aggregate freshness
-// relative to the boundary map at entry to ReduceOutputs. HistoricalBoundarySplit
-// reports a stale canonical boundary that live scoping excluded.
+// relative to the boundary map at entry to ReduceOutputs.
 type ReductionOutput struct {
-	Head                    Head
-	Freshness               ReductionFreshness
-	CleanPathRank           CleanPathRankSelection
-	MultiplePopPaths        bool
-	HistoricalBoundarySplit bool
+	Head                         Head
+	Freshness                    ReductionFreshness
+	CleanPathRank                CleanPathRankSelection
+	MultiplePopPaths             bool
+	HistoricalBoundaryProvenance HistoricalBoundaryProvenance
+	HistoricalCleanPathRank      CleanPathRankSelection
+	HistoricalCleanPathLineage   uint16
 }
 
 const inlineReductionBoundaryOutputs = 2
 
 type reductionBoundaryOutput struct {
-	key                     boundaryKey
-	head                    Head
-	freshness               ReductionFreshness
-	cleanPathRank           CleanPathRankSelection
-	historicalBoundarySplit bool
+	key                           boundaryKey
+	head                          Head
+	freshness                     ReductionFreshness
+	cleanPathRank                 CleanPathRankSelection
+	historicalBoundarySplit       bool
+	historicalConvergedSplit      bool
+	historicalForestDeterministic bool
+	historicalCleanPathRank       CleanPathRankSelection
+	historicalLineage             uint16
 }
 
 // reductionOutputScratch owns the ephemeral aggregation state for one
@@ -1946,9 +2008,13 @@ const (
 )
 
 type condenseOutcome struct {
-	head                    Head
-	change                  condenseChange
-	historicalBoundarySplit bool
+	head                          Head
+	change                        condenseChange
+	historicalBoundarySplit       bool
+	historicalConvergedSplit      bool
+	historicalForestDeterministic bool
+	historicalCleanPathRank       CleanPathRankSelection
+	historicalLineage             uint16
 }
 
 func (c *Core) condense(key boundaryKey, in linkInput) (Head, error) {
@@ -1983,8 +2049,28 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	}
 	probe, oldID := c.boundaries.probe(boundaryIdentityFromKey(key))
 	historicalBoundarySplit := false
+	var historicalCleanPathRank CleanPathRankSelection
+	var historicalLineage uint16
+	historicalConvergedSplit := false
+	historicalForestDeterministic := false
 	if probe.found && !c.condenseNodeIsLive(oldID) {
 		historicalBoundarySplit = true
+		old, oldErr := c.nodeLineage(oldID)
+		if oldErr != nil {
+			return condenseOutcome{}, oldErr
+		}
+		if old.owner != 0 && old.owner == c.reductionSourceOwner {
+			historicalForestDeterministic = true
+		} else {
+			deterministic, deterministicErr := c.historicalForestIsDeterministic(oldID, in)
+			if deterministicErr != nil {
+				return condenseOutcome{}, deterministicErr
+			}
+			historicalForestDeterministic = deterministic
+			historicalCleanPathRank = old.rank
+			historicalLineage = old.lineage
+			historicalConvergedSplit = old.converged
+		}
 		oldID = 0
 	}
 	var old nodeRecord
@@ -2013,7 +2099,11 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				}
 				return condenseOutcome{
 					head: Head{Node: oldID}, change: condenseUnchanged,
-					historicalBoundarySplit: historicalBoundarySplit,
+					historicalBoundarySplit:       historicalBoundarySplit,
+					historicalConvergedSplit:      historicalConvergedSplit,
+					historicalForestDeterministic: historicalForestDeterministic,
+					historicalCleanPathRank:       historicalCleanPathRank,
+					historicalLineage:             historicalLineage,
 				}, nil
 			}
 		}
@@ -2213,13 +2303,88 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	}
 	return condenseOutcome{
 		head: Head{Node: id}, change: change,
-		historicalBoundarySplit: historicalBoundarySplit,
+		historicalBoundarySplit:       historicalBoundarySplit,
+		historicalConvergedSplit:      historicalConvergedSplit,
+		historicalForestDeterministic: historicalForestDeterministic,
+		historicalCleanPathRank:       historicalCleanPathRank,
+		historicalLineage:             historicalLineage,
 	}, nil
 }
 
 func (c *Core) linkEqualInput(link linkRecord, in linkInput) (bool, error) {
 	return link.prev == in.prev && link.payload == in.payload && link.scoreDelta == in.scoreDelta &&
 		link.hasOrder() == in.order.Present && (!link.hasOrder() || link.order == in.order.Value), nil
+}
+
+func (c *Core) historicalForestIsDeterministic(oldID NodeID, in linkInput) (bool, error) {
+	incomingPayload, err := c.subtree(in.payload)
+	if err != nil {
+		return false, err
+	}
+	if incomingPayload.fragile {
+		return false, nil
+	}
+	oldDeterministic, err := c.graphVersionIsDeterministic(oldID)
+	if err != nil || !oldDeterministic {
+		return oldDeterministic, err
+	}
+	return c.graphVersionIsDeterministic(in.prev)
+}
+
+func (c *Core) graphVersionIsDeterministic(root NodeID) (bool, error) {
+	stack := c.historicalNodeScratch[:0]
+	stack = append(stack, root)
+	defer func() {
+		clear(stack)
+		c.historicalNodeScratch = stack[:0]
+	}()
+	var visits uint64
+	for len(stack) != 0 {
+		if visits >= uint64(c.limits.MaxNodes) {
+			return false, nil
+		}
+		visits++
+		last := len(stack) - 1
+		id := stack[last]
+		stack = stack[:last]
+		node, err := c.node(id)
+		if err != nil {
+			return false, err
+		}
+		provenance, err := c.nodeLineage(id)
+		if err != nil {
+			return false, err
+		}
+		if provenance.converged {
+			return false, nil
+		}
+		linkID := LinkID(node.firstLink)
+		for count := uint32(0); count < node.linkCount; count++ {
+			if linkID == 0 || uint64(linkID) > uint64(len(c.links)) {
+				return false, errors.New("parser-core phase zero: historical forest has an invalid link")
+			}
+			link := c.links[linkID-1]
+			payload, err := c.subtree(link.payload)
+			if err != nil {
+				return false, err
+			}
+			if payload.fragile {
+				return false, nil
+			}
+			if link.prev >= id {
+				return false, errors.New("parser-core phase zero: historical forest predecessor is not earlier than its node")
+			}
+			stack = append(stack, link.prev)
+			linkID = link.next
+		}
+		if linkID != 0 {
+			return false, errors.New("parser-core phase zero: historical forest has excess links")
+		}
+		if node.linkCount == 0 && node.firstLink != 0 {
+			return false, errors.New("parser-core phase zero: empty historical forest node has a link")
+		}
+	}
+	return true, nil
 }
 
 type shallowPayloadClass struct {
@@ -3862,6 +4027,7 @@ func (c *Core) appendNodeAt(r nodeRecord, checkpoint CheckpointID) (NodeID, erro
 		return 0, err
 	}
 	c.nodes = append(c.nodes, r)
+	c.nodeLineages = append(c.nodeLineages, nodeLineageRecord{})
 	if !c.externalPayloadsQuiescent {
 		c.nodeCheckpoints = append(c.nodeCheckpoints, checkpoint)
 	}
@@ -3996,6 +4162,13 @@ func (c *Core) node(id NodeID) (*nodeRecord, error) {
 		return nil, fmt.Errorf("parser-core phase zero: invalid node id %d", id)
 	}
 	return &c.nodes[id-1], nil
+}
+
+func (c *Core) nodeLineage(id NodeID) (*nodeLineageRecord, error) {
+	if id == 0 || uint64(id) > uint64(len(c.nodeLineages)) {
+		return nil, fmt.Errorf("parser-core phase zero: invalid node lineage id %d", id)
+	}
+	return &c.nodeLineages[id-1], nil
 }
 
 func (c *Core) subtree(id SubtreeID) (*subtreeRecord, error) {

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -376,7 +376,7 @@ func TestLiveCondenseCandidatesDropsSequentialVersionHistory(t *testing.T) {
 	key := compact.boundaryKey(2, 1)
 	var first, second Head
 	var secondOutcome condenseOutcome
-	err := compact.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
 		var err error
 		first, err = compact.condense(key, linkInput{prev: seed.Node, payload: payload, scoreDelta: 1})
 		if err != nil {
@@ -384,6 +384,11 @@ func TestLiveCondenseCandidatesDropsSequentialVersionHistory(t *testing.T) {
 		}
 		first, err = compact.condense(key, linkInput{prev: seed.Node, payload: payload, scoreDelta: 2})
 		if err != nil {
+			return err
+		}
+		if err := compact.RecordReductionLineageOwned(owner, []ReductionOutput{{
+			Head: first, CleanPathRank: CleanPathRankSelected, MultiplePopPaths: true,
+		}}, 7); err != nil {
 			return err
 		}
 		return compact.runLiveCondenseCandidates(nil, func() error {
@@ -401,12 +406,224 @@ func TestLiveCondenseCandidatesDropsSequentialVersionHistory(t *testing.T) {
 	if !secondOutcome.historicalBoundarySplit {
 		t.Fatal("sequential version replacement lost historical boundary split provenance")
 	}
+	if !secondOutcome.historicalConvergedSplit {
+		t.Fatal("historical converged version lost its split provenance")
+	}
+	if secondOutcome.historicalCleanPathRank != CleanPathRankSelected ||
+		secondOutcome.historicalLineage != 7 {
+		t.Fatalf(
+			"historical lineage = (%v,%d), want (%v,7)",
+			secondOutcome.historicalCleanPathRank,
+			secondOutcome.historicalLineage,
+			CleanPathRankSelected,
+		)
+	}
 	record, err := compact.node(second.Node)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if record.linkCount != 1 {
 		t.Fatalf("second sequential version links = %d, want 1", record.linkCount)
+	}
+}
+
+func TestReductionLineageRollsBackWithSchedulerTransaction(t *testing.T) {
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs := []ReductionOutput{{
+		Head: head, CleanPathRank: CleanPathRankUnselected, MultiplePopPaths: true,
+	}}
+	sentinel := errors.New("rollback lineage")
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordReductionLineageOwned(owner, outputs, 11); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback error = %v, want %v", err, sentinel)
+	}
+	provenance, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *provenance != (nodeLineageRecord{}) {
+		t.Fatalf("rolled-back lineage = %+v, want zero", *provenance)
+	}
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordReductionLineageOwned(owner, outputs, 12)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provenance, err = compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provenance.rank != CleanPathRankUnselected || provenance.lineage != 12 || !provenance.converged {
+		t.Fatalf("committed lineage = %+v, want unselected lineage 12", *provenance)
+	}
+}
+
+func TestHeadOwnerRollsBackWithSchedulerTransaction(t *testing.T) {
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sentinel := errors.New("rollback owner")
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordHeadOwnerOwned(owner, head, 7); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback error = %v, want %v", err, sentinel)
+	}
+	provenance, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provenance.owner != 0 {
+		t.Fatalf("rolled-back owner = %d, want zero", provenance.owner)
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordHeadOwnerOwned(owner, head, 8)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if provenance.owner != 8 {
+		t.Fatalf("committed owner = %d, want 8", provenance.owner)
+	}
+}
+
+func TestHistoricalBoundaryDoesNotInventConvergence(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxLinksPerBoundary: 2})
+	compact.diagnostics.foldSamePredecessorShallowPayloads = false
+	seed, _ := compact.Seed(1, 0)
+	payload, _ := compact.appendSubtree(subtreeRecord{symbol: 1, terminal: true, endByte: 1}, nil, nil, nil)
+	key := compact.boundaryKey(2, 1)
+	var outcome condenseOutcome
+	err := compact.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+		if _, err := compact.condense(key, linkInput{prev: seed.Node, payload: payload, scoreDelta: 1}); err != nil {
+			return err
+		}
+		return compact.runLiveCondenseCandidates(nil, func() error {
+			var err error
+			outcome, err = compact.condenseWithOutcome(key, linkInput{
+				prev: seed.Node, payload: payload, scoreDelta: 2,
+			})
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.historicalBoundarySplit {
+		t.Fatal("sequential replacement lost its historical boundary marker")
+	}
+	if outcome.historicalConvergedSplit {
+		t.Fatal("single-path historical boundary invented convergence")
+	}
+	if !outcome.historicalForestDeterministic {
+		t.Fatal("non-fragile historical forest was not marked deterministic")
+	}
+	if outcome.historicalCleanPathRank != CleanPathRankNotApplicable || outcome.historicalLineage != 0 {
+		t.Fatalf("single-path historical provenance = (%v,%d), want none", outcome.historicalCleanPathRank, outcome.historicalLineage)
+	}
+}
+
+func TestHistoricalBoundaryProvesDeterministicForest(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxLinksPerBoundary: 2})
+	seed, _ := compact.Seed(1, 0)
+	payload, _ := compact.appendSubtree(subtreeRecord{symbol: 1, terminal: true, endByte: 1}, nil, nil, nil)
+	key := compact.boundaryKey(2, 1)
+	input := linkInput{prev: seed.Node, payload: payload, scoreDelta: 1}
+	var outcome condenseOutcome
+	err := compact.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+		if _, err := compact.condense(key, input); err != nil {
+			return err
+		}
+		return compact.runLiveCondenseCandidates(nil, func() error {
+			var err error
+			outcome, err = compact.condenseWithOutcome(key, input)
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.historicalBoundarySplit || !outcome.historicalForestDeterministic {
+		t.Fatalf("historical replacement provenance = %+v, want deterministic split", outcome)
+	}
+	if outcome.historicalConvergedSplit {
+		t.Fatal("exact single-path replacement invented convergence")
+	}
+}
+
+func TestHistoricalBoundaryKeepsFragileForestUnproved(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxLinksPerBoundary: 2})
+	seed, _ := compact.Seed(1, 0)
+	payload, _ := compact.appendSubtree(subtreeRecord{
+		symbol: 1, terminal: true, endByte: 1, fragile: true,
+	}, nil, nil, nil)
+	key := compact.boundaryKey(2, 1)
+	input := linkInput{prev: seed.Node, payload: payload}
+	var outcome condenseOutcome
+	err := compact.ApplySchedulerAtomic(func(_ SchedulerTransactionToken) error {
+		if _, err := compact.condense(key, input); err != nil {
+			return err
+		}
+		return compact.runLiveCondenseCandidates(nil, func() error {
+			var err error
+			outcome, err = compact.condenseWithOutcome(key, input)
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.historicalBoundarySplit || outcome.historicalForestDeterministic {
+		t.Fatalf("fragile historical provenance = %+v, want unproved split", outcome)
+	}
+}
+
+func TestHistoricalBoundaryProvesSourceSelfOwnership(t *testing.T) {
+	compact := newTinyCoreWithLimits(t, Limits{MaxLinksPerBoundary: 2})
+	seed, _ := compact.Seed(1, 0)
+	payload, _ := compact.appendSubtree(subtreeRecord{
+		symbol: 1, terminal: true, endByte: 1, fragile: true,
+	}, nil, nil, nil)
+	key := compact.boundaryKey(2, 1)
+	input := linkInput{prev: seed.Node, payload: payload}
+	var outcome condenseOutcome
+	err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		retired, err := compact.condense(key, input)
+		if err != nil {
+			return err
+		}
+		if err := compact.RecordHeadOwnerOwned(owner, retired, 7); err != nil {
+			return err
+		}
+		compact.reductionSourceOwner = 7
+		defer func() { compact.reductionSourceOwner = 0 }()
+		return compact.runLiveCondenseCandidates(nil, func() error {
+			outcome, err = compact.condenseWithOutcome(key, input)
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.historicalBoundarySplit || !outcome.historicalForestDeterministic {
+		t.Fatalf("source-self historical provenance = %+v, want deterministic", outcome)
+	}
+	if outcome.historicalConvergedSplit {
+		t.Fatal("source-self historical replacement invented convergence")
 	}
 }
 
@@ -2437,6 +2654,7 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	}
 	for name, typ := range map[string]reflect.Type{
 		"node":                reflect.TypeFor[nodeRecord](),
+		"node-lineage":        reflect.TypeFor[nodeLineageRecord](),
 		"link":                reflect.TypeFor[linkRecord](),
 		"subtree":             reflect.TypeFor[subtreeRecord](),
 		"external-provenance": reflect.TypeFor[externalPayloadProvenance](),
@@ -2451,11 +2669,14 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	if got := unsafe.Sizeof(nodeRecord{}); got != 24 {
 		t.Fatalf("nodeRecord size = %d, want 24", got)
 	}
+	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 8 {
+		t.Fatalf("nodeLineageRecord size = %d, want 8", got)
+	}
 	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
 		t.Fatalf("linkRecord size = %d, want 32", got)
 	}
-	if got := unsafe.Sizeof(ReductionOutput{}); got != 8 {
-		t.Fatalf("ReductionOutput size = %d, want 8", got)
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 12 {
+		t.Fatalf("ReductionOutput size = %d, want 12", got)
 	}
 	if got := unsafe.Sizeof(popPath{}); got != 88 {
 		t.Fatalf("popPath size = %d, want 88", got)

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -15,6 +15,114 @@ func (c *Core) ReindexCondenseCandidatesOwned(owner SchedulerTransactionToken, c
 	})
 }
 
+// RecordReductionLineageOwned attaches exact scheduler lineage to compact graph
+// versions. The journal restores prior provenance if the scheduler transaction
+// rolls back.
+func (c *Core) RecordReductionLineageOwned(owner SchedulerTransactionToken, outputs []ReductionOutput, lineage uint16) error {
+	return c.RunSchedulerOwned(owner, func() error {
+		if lineage == 0 {
+			return errors.New("parser-core phase zero: zero reduction lineage")
+		}
+		for _, output := range outputs {
+			if !output.MultiplePopPaths {
+				return errors.New("parser-core phase zero: lineage requires multiple pop paths")
+			}
+			if err := c.recordNodeLineage(output.Head, output.CleanPathRank, lineage); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// RecordHeadLineageOwned persists inherited scheduler lineage on one graph
+// version. Unknown lineage invalidates an earlier exact record conservatively.
+func (c *Core) RecordHeadLineageOwned(
+	owner SchedulerTransactionToken,
+	head Head,
+	rank CleanPathRankSelection,
+	lineage uint16,
+) error {
+	return c.RunSchedulerOwned(owner, func() error {
+		if rank != CleanPathRankSelected && rank != CleanPathRankUnselected || lineage == 0 {
+			rank = CleanPathRankUnknown
+			lineage = 0
+		}
+		return c.recordNodeLineage(head, rank, lineage)
+	})
+}
+
+func (c *Core) recordNodeLineage(head Head, rank CleanPathRankSelection, lineage uint16) error {
+	node, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return err
+	}
+	nextRank := rank
+	nextLineage := lineage
+	nextConverged := true
+	switch rank {
+	case CleanPathRankSelected, CleanPathRankUnselected:
+	case CleanPathRankUnknown:
+		nextLineage = 0
+	case CleanPathRankNotApplicable:
+		return nil
+	default:
+		return errors.New("parser-core phase zero: invalid clean path rank")
+	}
+	switch {
+	case node.rank == CleanPathRankNotApplicable && node.lineage == 0:
+	case node.lineage == nextLineage:
+		nextRank = mergeCleanPathRank(node.rank, nextRank)
+		if nextRank == CleanPathRankUnknown {
+			nextLineage = 0
+		}
+	case node.rank == CleanPathRankUnknown && node.lineage == 0:
+		nextRank = CleanPathRankUnknown
+		nextLineage = 0
+	default:
+		nextRank = CleanPathRankUnknown
+		nextLineage = 0
+	}
+	if node.rank == nextRank && node.lineage == nextLineage && node.converged == nextConverged {
+		return nil
+	}
+	if len(c.transactions) != 0 {
+		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+			node: head.Node, owner: node.owner, lineage: node.lineage, rank: node.rank, converged: node.converged,
+		})
+	}
+	node.rank = nextRank
+	node.lineage = nextLineage
+	node.converged = nextConverged
+	return nil
+}
+
+// RecordHeadOwnerOwned binds one compact head to its scheduler lineage.
+func (c *Core) RecordHeadOwnerOwned(owner SchedulerTransactionToken, head Head, lineage uint32) error {
+	return c.RunSchedulerOwned(owner, func() error {
+		if lineage == 0 {
+			return errors.New("parser-core phase zero: zero scheduler lineage")
+		}
+		node, err := c.nodeLineage(head.Node)
+		if err != nil {
+			return err
+		}
+		if node.owner == lineage {
+			return nil
+		}
+		if node.owner != 0 {
+			return errors.New("parser-core phase zero: compact head has multiple scheduler owners")
+		}
+		if len(c.transactions) != 0 {
+			c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+				node: head.Node, owner: node.owner, lineage: node.lineage, rank: node.rank, converged: node.converged,
+			})
+		}
+		node.owner = lineage
+		return nil
+	})
+}
+
 func (c *Core) runSchedulerMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, fn func() error) error {
 	return c.RunSchedulerOwned(owner, func() error {
 		if !liveScoped {
@@ -392,6 +500,15 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 	if act.Type != ActionReduce {
 		return nil, fmt.Errorf("parser-core phase zero: action %d is %v, not reduce", actionOrdinal, act.Type)
 	}
+	source, err := c.nodeLineage(boundary.head.Node)
+	if err != nil {
+		return nil, err
+	}
+	previousSourceOwner := c.reductionSourceOwner
+	c.reductionSourceOwner = source.owner
+	defer func() {
+		c.reductionSourceOwner = previousSourceOwner
+	}()
 	plan, err := c.reductionPlan(*act)
 	if err != nil {
 		return nil, err
@@ -482,6 +599,33 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		freshness := previous.freshness
 		cleanPathRank := mergeCleanPathRank(previous.cleanPathRank, path.cleanPathRank)
 		historicalBoundarySplit := previous.historicalBoundarySplit || outcome.historicalBoundarySplit
+		historicalConvergedSplit := previous.historicalConvergedSplit
+		historicalForestDeterministic := previous.historicalForestDeterministic
+		historicalCleanPathRank := previous.historicalCleanPathRank
+		historicalLineage := previous.historicalLineage
+		if outcome.historicalBoundarySplit {
+			switch {
+			case !previous.historicalBoundarySplit:
+				historicalConvergedSplit = outcome.historicalConvergedSplit
+				historicalForestDeterministic = outcome.historicalForestDeterministic
+				historicalCleanPathRank = outcome.historicalCleanPathRank
+				historicalLineage = outcome.historicalLineage
+			case !historicalConvergedSplit && outcome.historicalConvergedSplit:
+				historicalConvergedSplit = true
+				historicalCleanPathRank = outcome.historicalCleanPathRank
+				historicalLineage = outcome.historicalLineage
+			case historicalConvergedSplit && !outcome.historicalConvergedSplit:
+				// Keep the exact provenance from the converged historical version.
+			case historicalCleanPathRank != outcome.historicalCleanPathRank ||
+				historicalLineage != outcome.historicalLineage:
+				historicalCleanPathRank = CleanPathRankUnknown
+				historicalLineage = 0
+			}
+			if previous.historicalBoundarySplit {
+				historicalForestDeterministic =
+					historicalForestDeterministic && outcome.historicalForestDeterministic
+			}
+		}
 		switch outcome.change {
 		case condenseUnchanged:
 			if !seen {
@@ -496,16 +640,31 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		}
 		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{
 			key: key, head: out, freshness: freshness, cleanPathRank: cleanPathRank,
-			historicalBoundarySplit: historicalBoundarySplit,
+			historicalBoundarySplit:       historicalBoundarySplit,
+			historicalConvergedSplit:      historicalConvergedSplit,
+			historicalForestDeterministic: historicalForestDeterministic,
+			historicalCleanPathRank:       historicalCleanPathRank,
+			historicalLineage:             historicalLineage,
 		})
 	}
 	for _, output := range scratch.boundaries {
+		historicalProvenance := HistoricalBoundaryNone
+		switch {
+		case output.historicalConvergedSplit:
+			historicalProvenance = HistoricalBoundaryConverged
+		case output.historicalBoundarySplit && output.historicalForestDeterministic:
+			historicalProvenance = HistoricalBoundaryDeterministic
+		case output.historicalBoundarySplit:
+			historicalProvenance = HistoricalBoundaryUnproved
+		}
 		frontier = append(frontier, ReductionOutput{
-			Head:                    output.head,
-			Freshness:               output.freshness,
-			CleanPathRank:           output.cleanPathRank,
-			MultiplePopPaths:        multiPop,
-			HistoricalBoundarySplit: output.historicalBoundarySplit,
+			Head:                         output.head,
+			Freshness:                    output.freshness,
+			CleanPathRank:                output.cleanPathRank,
+			MultiplePopPaths:             multiPop,
+			HistoricalBoundaryProvenance: historicalProvenance,
+			HistoricalCleanPathRank:      output.historicalCleanPathRank,
+			HistoricalCleanPathLineage:   output.historicalLineage,
 		})
 	}
 	phase0AFinishReductionConstruction(c)

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -921,13 +921,45 @@ func applyDiagnosticParserCoreCleanPathOutput(
 	header.cleanPathLineage = lineage
 }
 
-func markDiagnosticParserCoreExternalLineage(header *diagnosticParserCoreHeader, token Token) {
+func markDiagnosticParserCoreExternalLineage(
+	header *diagnosticParserCoreHeader,
+	token Token,
+) {
 	if header == nil || !token.ExternalScannerToken ||
 		header.cleanPathRank == core.CleanPathRankNotApplicable {
 		return
 	}
 	header.cleanPathRank = core.CleanPathRankUnknown
 	header.cleanPathLineage = 0
+}
+
+func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
+	owner core.SchedulerTransactionToken,
+) error {
+	for _, header := range s.headers {
+		if header.creationSeq >= math.MaxUint32 {
+			return errors.New("parser-core phase zero: scheduler lineage overflow")
+		}
+		if err := s.compact.RecordHeadOwnerOwned(
+			owner,
+			header.head,
+			uint32(header.creationSeq)+1,
+		); err != nil {
+			return err
+		}
+		if !header.convergedReductionSplit {
+			continue
+		}
+		if err := s.compact.RecordHeadLineageOwned(
+			owner,
+			header.head,
+			header.cleanPathRank,
+			header.cleanPathLineage,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func diagnosticParserCoreCheckpointDigest(compact *core.Core, id core.CheckpointID) ([32]byte, error) {
@@ -2064,6 +2096,9 @@ func executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 			return compact.RunFreshSchedulerSession(func(owner core.SchedulerTransactionToken) error {
 				scheduler.freshSessionOwner = &owner
 				defer func() { scheduler.freshSessionOwner = nil }()
+				if err := scheduler.persistHeaderLineageOwned(owner); err != nil {
+					return err
+				}
 				return scheduler.run()
 			})
 		}
@@ -3265,17 +3300,20 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	if err != nil {
 		return err
 	}
-	hasConvergedHistory := false
+	hasMultiplePopPaths := false
 	for _, output := range outputs {
-		if output.MultiplePopPaths || output.HistoricalBoundarySplit {
-			hasConvergedHistory = true
+		if output.MultiplePopPaths {
+			hasMultiplePopPaths = true
 			break
 		}
 	}
-	var cleanPathLineage uint16
-	if hasConvergedHistory {
-		cleanPathLineage, err = nextDiagnosticParserCoreCleanPathLineage(&s.nextCleanPathLineage)
+	var reductionLineage uint16
+	if hasMultiplePopPaths {
+		reductionLineage, err = nextDiagnosticParserCoreCleanPathLineage(&s.nextCleanPathLineage)
 		if err != nil {
+			return err
+		}
+		if err := s.compact.RecordReductionLineageOwned(owner, outputs, reductionLineage); err != nil {
 			return err
 		}
 	}
@@ -3284,15 +3322,24 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	replacements := s.reductionReplacements
 	madeFreshProgress := false
 	for _, output := range outputs {
-		convergedHistory := output.MultiplePopPaths || output.HistoricalBoundarySplit
+		convergedHistory := output.MultiplePopPaths ||
+			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged ||
+			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryUnproved
+		rank := output.CleanPathRank
+		lineage := reductionLineage
+		if !output.MultiplePopPaths &&
+			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged {
+			rank = output.HistoricalCleanPathRank
+			lineage = output.HistoricalCleanPathLineage
+		}
 		switch output.Freshness {
 		case core.ReductionUnchanged:
 			if convergedHistory {
 				if _, err := s.adoptUpdatedReductionSibling(
 					cell.headerIndex,
 					output.Head,
-					output.CleanPathRank,
-					cleanPathLineage,
+					rank,
+					lineage,
 					true,
 				); err != nil {
 					return err
@@ -3308,8 +3355,8 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			adopted, err := s.adoptUpdatedReductionSibling(
 				cell.headerIndex,
 				output.Head,
-				output.CleanPathRank,
-				cleanPathLineage,
+				rank,
+				lineage,
 				convergedHistory,
 			)
 			if err != nil {
@@ -3324,7 +3371,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacement.paused = false
 		replacement.shifted = token.NoLookahead
 		replacement.convergedReductionSplit = replacement.convergedReductionSplit || convergedHistory
-		applyDiagnosticParserCoreCleanPathOutput(&replacement, output.CleanPathRank, cleanPathLineage)
+		applyDiagnosticParserCoreCleanPathOutput(&replacement, rank, lineage)
 		if len(replacements) > 0 {
 			if s.nextSeq == math.MaxUint64 {
 				return errors.New("parser-core phase zero: reduction creation sequence overflow")
@@ -3355,6 +3402,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	s.work.Reductions++
 	s.work.Dispatches++
 	if err := s.canonicalize(); err != nil {
+		return err
+	}
+	if err := s.persistHeaderLineageOwned(owner); err != nil {
 		return err
 	}
 	if s.fullReceipts() {
@@ -3603,6 +3653,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	if err := s.canonicalize(); err != nil {
 		return err
 	}
+	if err := s.persistHeaderLineageOwned(owner); err != nil {
+		return err
+	}
 	roundIndex := -1
 	if s.fullReceipts() {
 		primaryReceipts, err := diagnosticParserCoreHeaderReceipts(s.compact, primaries)
@@ -3747,6 +3800,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericShiftsOwned(owner cor
 	if err := s.canonicalize(); err != nil {
 		return err
 	}
+	if err := s.persistHeaderLineageOwned(owner); err != nil {
+		return err
+	}
 	roundIndex := -1
 	if s.fullReceipts() {
 		actions := make([]DiagnosticParserCoreRoundAction, len(cells))
@@ -3834,6 +3890,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericExtraShifts(before []
 		}
 		s.work.Dispatches += uint64(len(cells))
 		if err := s.canonicalize(); err != nil {
+			return err
+		}
+		if err := s.persistHeaderLineageOwned(owner); err != nil {
 			return err
 		}
 		roundIndex := -1
@@ -4326,6 +4385,9 @@ func applyParserCoreConflictActionInto(
 	if len(outputs) != 0 && outputs[0].MultiplePopPaths {
 		lineage, err = nextDiagnosticParserCoreCleanPathLineage(nextCleanPathLineage)
 		if err != nil {
+			return nil, outputs, err
+		}
+		if err := compact.RecordReductionLineageOwned(owner, outputs, lineage); err != nil {
 			return nil, outputs, err
 		}
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1028,6 +1028,10 @@ func diagnosticParserCoreHeaderReceipts(compact *core.Core, headers []diagnostic
 }
 
 func validateDiagnosticParserCoreCell(token Token, actions core.ActionRow) error {
+	return validateDiagnosticParserCoreCellWithRepetitionFork(token, actions, false)
+}
+
+func validateDiagnosticParserCoreCellWithRepetitionFork(token Token, actions core.ActionRow, allowRepetitionFork bool) error {
 	if token.NoLookahead {
 		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreRoute, detail: "no-lookahead tokens require production recovery semantics"}
 	}
@@ -1037,6 +1041,9 @@ func validateDiagnosticParserCoreCell(token Token, actions core.ActionRow) error
 	for ordinal := 0; ordinal < actions.Len(); ordinal++ {
 		action := actions.At(ordinal)
 		if action.Repetition {
+			if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); allowRepetitionFork && ok {
+				continue
+			}
 			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreRoute, detail: "repetition shifts require production frontier suppression semantics"}
 		}
 		if action.ExtraChain {
@@ -1150,6 +1157,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	classified core.ClassifiedBoundary,
 	branchOrder uint64,
 	nextCleanPathLineage *uint16,
+	allowRepetitionFork bool,
 	collectReceipts bool,
 	scratch *diagnosticParserCoreConflictScratch,
 ) (diagnosticParserCoreConflictExecution, error) {
@@ -1165,7 +1173,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			return diagnosticParserCoreConflictExecution{}, err
 		}
 	}
-	if err := validateDiagnosticParserCoreCell(token, actions); err != nil {
+	if err := validateDiagnosticParserCoreCellWithRepetitionFork(token, actions, allowRepetitionFork); err != nil {
 		return diagnosticParserCoreConflictExecution{}, err
 	}
 	if actions.Len() < 2 {
@@ -1760,6 +1768,7 @@ const (
 	diagnosticParserCoreCellSelectionNone diagnosticParserCoreCellSelection = iota
 	diagnosticParserCoreCellSelectionConflictPolicy
 	diagnosticParserCoreCellSelectionRepetitionFold
+	diagnosticParserCoreCellSelectionRepetitionFork
 )
 
 type diagnosticParserCoreGenericCell struct {
@@ -1794,6 +1803,9 @@ func (cell *diagnosticParserCoreGenericCell) kind() core.ActionRowKind {
 	if cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFold {
 		return core.ActionRowReduce
 	}
+	if cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork {
+		return core.ActionRowConflict
+	}
 	return cell.descriptor().Kind()
 }
 func (cell *diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
@@ -1805,6 +1817,7 @@ func (cell *diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
 
 func (cell *diagnosticParserCoreGenericCell) selectsConflictReduction() bool {
 	return cell.selectedBy != diagnosticParserCoreCellSelectionNone &&
+		cell.selectedBy != diagnosticParserCoreCellSelectionRepetitionFork &&
 		cell.actions().At(cell.selectedActionOrdinal()).Type == core.ActionReduce
 }
 
@@ -1835,6 +1848,12 @@ func diagnosticParserCoreRepetitionFoldOrdinal(language *Language, actions core.
 		diagnosticParserCoreRepetitionFoldOptOut[language.Name] {
 		return 0, false
 	}
+	return diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions)
+}
+
+// diagnosticParserCoreSingleReduceRepetitionShiftOrdinal identifies the exact
+// two-arm row that production either folds or keeps as one conflict fork.
+func diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions core.ActionRow) (int, bool) {
 	reduceOrdinal := -1
 	shiftFound := false
 	for ordinal := 0; ordinal < actions.Len(); ordinal++ {
@@ -2807,6 +2826,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions); ok {
 					cell.selectedOrdinal = ordinal
 					cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFold
+				} else if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); ok &&
+					cRepetitionSkipOptOut[s.tokenSource.language.Name] {
+					// Production keeps both arms for a language with a proven
+					// fold counterexample. Use the existing conflict executor.
+					cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFork
 				}
 			}
 		}
@@ -3557,7 +3581,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
 		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
-		s.branchOrder, &s.nextCleanPathLineage, s.fullReceipts(), &s.conflictScratch,
+		s.branchOrder, &s.nextCleanPathLineage,
+		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
+		s.fullReceipts(), &s.conflictScratch,
 	)
 	if err != nil {
 		return err

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -129,6 +129,58 @@ func TestDiagnosticParserCoreGenericRepetitionFoldReducesWithoutFork(t *testing.
 	}
 }
 
+func TestDiagnosticParserCoreGenericRepetitionForkMatchesProductionOptOut(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 9}: {
+				{Type: core.ActionShift, State: 3, Repetition: true},
+				{Type: core.ActionReduce, Symbol: 4},
+			},
+		},
+		gotos: map[genericConflictCell]core.StateID{
+			{state: 1, symbol: 4}: 2,
+		},
+	}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: &dfaTokenSource{language: &Language{Name: "haskell"}},
+		headers:     []diagnosticParserCoreHeader{{head: head}},
+		token:       Token{Symbol: 9, EndByte: 1},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches: 8,
+			ReceiptMode:   DiagnosticParserCoreReceiptFull,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	stop, err := scheduler.dispatchPass()
+	if err != nil || stop != nil {
+		t.Fatalf("repetition fork stop=%+v err=%v", stop, err)
+	}
+	if len(scheduler.headers) != 2 || scheduler.work.Conflicts != 1 ||
+		scheduler.work.Forks != 1 || scheduler.work.RepetitionFolds != 0 {
+		t.Fatalf("repetition fork headers=%d work=%+v", len(scheduler.headers), scheduler.work)
+	}
+	got := make(map[StateID]uint32, 2)
+	for _, header := range scheduler.headers {
+		state, byteOffset, err := compact.Boundary(header.head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got[StateID(state)] = byteOffset
+	}
+	if got[2] != 0 || got[3] != 1 {
+		t.Fatalf("repetition fork boundaries=%v, want reduce state 2 at byte 0 and shift state 3 at byte 1", got)
+	}
+}
+
 func TestDiagnosticParserCoreGenericConflictPolicySelectsRepetitionReduce(t *testing.T) {
 	table := &genericConflictTable{
 		cells: map[genericConflictCell][]core.Action{

--- a/parsercore_phase0_generic_freshness_internal_test.go
+++ b/parsercore_phase0_generic_freshness_internal_test.go
@@ -33,21 +33,18 @@ func TestDiagnosticParserCoreGenericReductionPauseIsFinite(t *testing.T) {
 		cells: map[genericConflictCell][]core.Action{
 			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
 			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1}},
-			{state: 8, symbol: 9}: {{Type: core.ActionShift, State: 10}},
+			{state: 4, symbol: 9}: {{Type: core.ActionShift, State: 10}},
 		},
 		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 2}: 4},
 	}
 	compact, source := newGenericFreshnessSource(t, table)
-	if outputs, err := compact.ReduceOutputs(source, 9, 0, core.ForkOrder{}); err != nil || len(outputs) != 1 || outputs[0].Freshness != core.ReductionNew {
+	outputs, err := compact.ReduceOutputs(source, 9, 0, core.ForkOrder{})
+	if err != nil || len(outputs) != 1 || outputs[0].Freshness != core.ReductionNew {
 		t.Fatalf("prepopulate outputs=%+v err=%v", outputs, err)
-	}
-	sibling, err := compact.Seed(8, 1)
-	if err != nil {
-		t.Fatal(err)
 	}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
-		headers: []diagnosticParserCoreHeader{{head: source, creationSeq: 3}, {head: sibling, creationSeq: 7}},
+		headers: []diagnosticParserCoreHeader{{head: source, creationSeq: 3}, {head: outputs[0].Head, creationSeq: 7}},
 		token:   Token{Symbol: 9, StartByte: 1, EndByte: 2},
 		options: DiagnosticParserCorePrefixOptions{MaxDispatches: 20},
 		receipt: &DiagnosticParserCoreGenericScheduler{},
@@ -74,14 +71,9 @@ func TestDiagnosticParserCoreGenericReductionPauseIsFinite(t *testing.T) {
 	}
 
 	sole := &diagnosticParserCoreGenericScheduler{
-		compact: compact, headers: []diagnosticParserCoreHeader{{head: source}},
+		compact: compact, headers: []diagnosticParserCoreHeader{{head: source, paused: true}},
 		token:   Token{Symbol: 9, StartByte: 1, EndByte: 2},
 		options: DiagnosticParserCorePrefixOptions{MaxDispatches: 20}, receipt: &DiagnosticParserCoreGenericScheduler{},
-	}
-	soleBefore, _ := diagnosticParserCoreHeaderReceipts(compact, sole.headers)
-	soleCell := mustDiagnosticParserCoreGenericCell(t, compact, 0, sole.headers[0], 9)
-	if err := sole.applyGenericReduction(soleBefore, soleCell); err != nil {
-		t.Fatal(err)
 	}
 	stop, err := sole.dispatchPass()
 	if err != nil || stop == nil || stop.boundary != DiagnosticParserCoreNoAction ||
@@ -177,7 +169,7 @@ func TestDiagnosticParserCoreUpdatedReductionAdoptsActiveSibling(t *testing.T) {
 	}
 	scheduler := &diagnosticParserCoreGenericScheduler{
 		compact: compact,
-		headers: []diagnosticParserCoreHeader{{head: high, creationSeq: 3}, {head: lowOutputs[0].Head, creationSeq: 11, paused: true}},
+		headers: []diagnosticParserCoreHeader{{head: high, creationSeq: 3}, {head: lowOutputs[0].Head, creationSeq: 11}},
 		token:   Token{Symbol: 9, StartByte: 1, EndByte: 2}, nextSeq: math.MaxUint64,
 		options: DiagnosticParserCorePrefixOptions{MaxDispatches: 20}, receipt: &DiagnosticParserCoreGenericScheduler{},
 	}


### PR DESCRIPTION
## Summary

- Add a rollback-safe lineage sidecar for compact graph nodes.
- Record each scheduler header owner after canonicalization.
- Classify source-owned historical boundaries as deterministic replacements.
- Keep different-owner recovered history behind selected-lineage proof.

## Evidence

- The parser-core package test passes in Docker.
- The focused lineage and Julia containment tests pass in Docker.
- The authoritative matrix reports 71 PASS, 30 FALLBACK, 10 SKIP, and zero divergence.
- The focused Kotlin witness changes from fallback to direct.
- Perl changes from one direct route to two direct routes across three files.
- Rust completes 25 of 25 cases and matches 24 of 25 cases exactly.

## Baseline constraints

- Kotlin grammar generation reports 16 of 25 exact cases.
- Perl grammar generation reports zero of 25 exact cases.
- Rust keeps one known closure-pattern mismatch.
- The clean base reproduces the scheduler snapshot drift outside this patch.

## Review

Use BuckBot as the review authority for this campaign patch.
