### PR TITLE
Prove shared selected-forest ownership

### DIFF
--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -48,6 +48,7 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowEOFAcceptNoActionSiblings:  p.language.CompactEOFAcceptNoActionSiblingsCertified,
 		allowPrimaryAcceptDerivation:    p.language.CompactPrimaryAcceptanceDerivationCertified,
 		allowConvergedSplitDropArtifact: p.language.CompactConvergedReductionSplitDropsCertified,
+		allowLineageDestinationProof:    true,
 		noLookaheadRootSymbol:           p.rootSymbol,
 		hasNoLookaheadRootSymbol:        p.hasRootSymbol,
 	}

--- a/internal/parsercorephase0/clean_path_rank_test.go
+++ b/internal/parsercorephase0/clean_path_rank_test.go
@@ -11,6 +11,7 @@ type cleanPathRankBranch struct {
 	windowScore int64
 	gotoState   StateID
 	external    bool
+	exact       bool
 }
 
 func newCleanPathRankFixture(tb testing.TB, branches []cleanPathRankBranch) (*Core, Head) {
@@ -64,10 +65,29 @@ func newCleanPathRankFixture(tb testing.TB, branches []cleanPathRankBranch) (*Co
 				tb.Fatal(err)
 			}
 		}
-		child, err := compact.appendSubtree(subtreeRecord{
+		if branch.external && branch.exact {
+			start, err := compact.InternCheckpoint([]byte{1, 2})
+			if err != nil {
+				tb.Fatal(err)
+			}
+			end, err := compact.InternCheckpoint([]byte{3, 4})
+			if err != nil {
+				tb.Fatal(err)
+			}
+			if err := compact.SetPhaseExternalTokenScannerCheckpoints(start, end); err != nil {
+				tb.Fatal(err)
+			}
+		}
+		childRecord := subtreeRecord{
 			symbol: 10, startByte: 0, endByte: 1,
 			terminal: true, external: branch.external,
-		}, nil, nil, nil)
+		}
+		var child SubtreeID
+		if branch.exact {
+			child, err = compact.appendAuthenticatedTerminal(childRecord)
+		} else {
+			child, err = compact.appendSubtree(childRecord, nil, nil, nil)
+		}
 		if err != nil {
 			tb.Fatal(err)
 		}
@@ -268,6 +288,40 @@ func TestCleanPathRankExternalPayloadIsUnknown(t *testing.T) {
 		if output.CleanPathRank != CleanPathRankUnknown {
 			t.Fatalf("external ranked output=%+v, want unknown", output)
 		}
+	}
+}
+
+func TestExactExternalPayloadRanksOnlyLineageDestination(t *testing.T) {
+	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
+		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60, external: true, exact: true},
+		{predecessor: 2, prefixScore: []int64{2}, gotoState: 61},
+	})
+	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotScheduler := cleanPathRankOutputStates(t, compact, outputs)
+	wantScheduler := map[StateID]CleanPathRankSelection{
+		60: CleanPathRankUnknown,
+		61: CleanPathRankUnknown,
+	}
+	if !reflect.DeepEqual(gotScheduler, wantScheduler) {
+		t.Fatalf("scheduler ranks=%v, want %v", gotScheduler, wantScheduler)
+	}
+	gotDestination := make(map[StateID]CleanPathRankSelection, len(outputs))
+	for _, output := range outputs {
+		record, err := compact.node(output.Head.Node)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotDestination[record.state] = output.LineageDestinationRank
+	}
+	wantDestination := map[StateID]CleanPathRankSelection{
+		60: CleanPathRankSelected,
+		61: CleanPathRankUnselected,
+	}
+	if !reflect.DeepEqual(gotDestination, wantDestination) {
+		t.Fatalf("destination ranks=%v, want %v", gotDestination, wantDestination)
 	}
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1550,6 +1550,7 @@ type ReductionOutput struct {
 	Head                         Head
 	Freshness                    ReductionFreshness
 	CleanPathRank                CleanPathRankSelection
+	LineageDestinationRank       CleanPathRankSelection
 	MultiplePopPaths             bool
 	HistoricalBoundaryProvenance HistoricalBoundaryProvenance
 	HistoricalCleanPathRank      CleanPathRankSelection
@@ -1563,6 +1564,7 @@ type reductionBoundaryOutput struct {
 	head                          Head
 	freshness                     ReductionFreshness
 	cleanPathRank                 CleanPathRankSelection
+	lineageDestinationRank        CleanPathRankSelection
 	historicalBoundarySplit       bool
 	historicalConvergedSplit      bool
 	historicalForestDeterministic bool
@@ -3095,14 +3097,15 @@ func (c *Core) replaceBoundaryLink(key boundaryKey, probe boundaryProbe, old nod
 }
 
 type popPath struct {
-	prev          NodeID
-	cleanPathRank CleanPathRankSelection
-	children      []SubtreeID
-	trailing      []pathPayload
-	score         int64
-	order         ForkOrder
-	startByte     uint32
-	structuralEnd uint32
+	prev                   NodeID
+	cleanPathRank          CleanPathRankSelection
+	lineageDestinationRank CleanPathRankSelection
+	children               []SubtreeID
+	trailing               []pathPayload
+	score                  int64
+	order                  ForkOrder
+	startByte              uint32
+	structuralEnd          uint32
 }
 
 type pathPayload struct {
@@ -3225,11 +3228,34 @@ func (a *cleanPathRankAccumulator) observe(prefixScore int64, prefixDepth uint64
 // The walk reuses popScratch's existing traversal storage. It does not publish
 // arena data or allocate selector-owned storage.
 func (c *Core) markCleanProductionRank(paths []popPath) {
+	c.markProductionRank(paths, false, false)
+}
+
+// markReductionProductionRanks keeps the scheduler rank conservative. It
+// publishes exact external scanner evidence only through the destination
+// channel, which cannot change scheduler selection.
+func (c *Core) markReductionProductionRanks(paths []popPath) {
+	c.markProductionRank(paths, false, false)
+	allUnknown := true
+	for index := range paths {
+		paths[index].lineageDestinationRank = paths[index].cleanPathRank
+		allUnknown = allUnknown && paths[index].cleanPathRank == CleanPathRankUnknown
+	}
+	if allUnknown {
+		c.markProductionRank(paths, true, true)
+	}
+}
+
+func (c *Core) markProductionRank(
+	paths []popPath,
+	allowExactExternal bool,
+	destinationOnly bool,
+) {
 	if len(paths) < 2 {
 		return
 	}
 	for index := range paths {
-		paths[index].cleanPathRank = CleanPathRankUnselected
+		setProductionRank(&paths[index], destinationOnly, CleanPathRankUnselected)
 	}
 	scratch := &c.popScratch
 	scratch.finishTraversal()
@@ -3239,23 +3265,23 @@ func (c *Core) markCleanProductionRank(paths []popPath) {
 	for index := range paths {
 		path := &paths[index]
 		for _, payload := range path.children {
-			hasExternal, err := c.cleanPathPayloadHasExternal(payload)
+			hasExternal, err := c.cleanPathPayloadHasExternal(payload, allowExactExternal)
 			if err != nil || hasExternal {
-				markCleanPathRankUnknown(paths)
+				markProductionRankUnknown(paths, destinationOnly)
 				return
 			}
 		}
 		for _, trailing := range path.trailing {
-			hasExternal, err := c.cleanPathPayloadHasExternal(trailing.payload)
+			hasExternal, err := c.cleanPathPayloadHasExternal(trailing.payload, allowExactExternal)
 			if err != nil || hasExternal {
-				markCleanPathRankUnknown(paths)
+				markProductionRankUnknown(paths, destinationOnly)
 				return
 			}
 		}
 		prefix, err := c.node(path.prev)
 		if err != nil || prefix.pathCount == math.MaxUint64 ||
 			prefix.pathCount > c.limits.MaxDerivations {
-			markCleanPathRankUnknown(paths)
+			markProductionRankUnknown(paths, destinationOnly)
 			return
 		}
 		rank.pathIndex = index
@@ -3263,26 +3289,37 @@ func (c *Core) markCleanProductionRank(paths []popPath) {
 			score: path.score,
 			depth: uint64(len(path.children) + len(path.trailing)),
 		}
-		ok, err := c.walkCleanPrefixRanks(path.prev, &rank)
+		ok, err := c.walkCleanPrefixRanks(path.prev, &rank, allowExactExternal)
 		if err != nil || !ok {
-			markCleanPathRankUnknown(paths)
+			markProductionRankUnknown(paths, destinationOnly)
 			return
 		}
 	}
 	if !rank.found || rank.crossTie {
-		markCleanPathRankUnknown(paths)
+		markProductionRankUnknown(paths, destinationOnly)
 		return
 	}
-	paths[rank.winner].cleanPathRank = CleanPathRankSelected
+	setProductionRank(&paths[rank.winner], destinationOnly, CleanPathRankSelected)
 }
 
-func markCleanPathRankUnknown(paths []popPath) {
+func setProductionRank(path *popPath, destinationOnly bool, rank CleanPathRankSelection) {
+	if destinationOnly {
+		path.lineageDestinationRank = rank
+		return
+	}
+	path.cleanPathRank = rank
+}
+
+func markProductionRankUnknown(paths []popPath, destinationOnly bool) {
 	for index := range paths {
-		paths[index].cleanPathRank = CleanPathRankUnknown
+		setProductionRank(&paths[index], destinationOnly, CleanPathRankUnknown)
 	}
 }
 
-func (c *Core) cleanPathPayloadHasExternal(root SubtreeID) (bool, error) {
+func (c *Core) cleanPathPayloadHasExternal(
+	root SubtreeID,
+	allowExactExternal bool,
+) (bool, error) {
 	if c.externalPayloadsQuiescent {
 		return false, nil
 	}
@@ -3308,8 +3345,24 @@ func (c *Core) cleanPathPayloadHasExternal(root SubtreeID) (bool, error) {
 			return false, errors.New("parser-core phase zero: clean path external payload walk cap")
 		}
 		if record.external {
-			c.popScratch.external = stack[:0]
-			return true, nil
+			if !allowExactExternal {
+				c.popScratch.external = stack[:0]
+				return true, nil
+			}
+			provenance, exact := c.externalPayloadScannerProvenance(id)
+			if !record.terminal || !exact {
+				c.popScratch.external = stack[:0]
+				return true, nil
+			}
+			for _, checkpoint := range [...]CheckpointID{provenance.start, provenance.end} {
+				if checkpoint == 0 {
+					continue
+				}
+				if _, ok := c.checkpoints.record(checkpoint); !ok {
+					c.popScratch.external = stack[:0]
+					return true, nil
+				}
+			}
 		}
 		for _, child := range c.children[record.firstChild : record.firstChild+record.childCount] {
 			if child == 0 || child >= id {
@@ -3327,7 +3380,11 @@ func (c *Core) cleanPathPayloadHasExternal(root SubtreeID) (bool, error) {
 // walkCleanPrefixRanks visits each retained prefix derivation without a map.
 // The persistent graph is an append-only directed acyclic graph. Existing
 // link-frame and score scratch provide the iterative traversal stack.
-func (c *Core) walkCleanPrefixRanks(root NodeID, rank *cleanPathRankAccumulator) (bool, error) {
+func (c *Core) walkCleanPrefixRanks(
+	root NodeID,
+	rank *cleanPathRankAccumulator,
+	allowExactExternal bool,
+) (bool, error) {
 	scratch := &c.popScratch
 	scratch.finishTraversal()
 	id := root
@@ -3355,7 +3412,7 @@ descend:
 			if link.next != 0 {
 				return false, errors.New("parser-core phase zero: clean path single link has a successor")
 			}
-			hasExternal, err := c.cleanPathPayloadHasExternal(link.payload)
+			hasExternal, err := c.cleanPathPayloadHasExternal(link.payload, allowExactExternal)
 			if err != nil || hasExternal {
 				return false, err
 			}
@@ -3407,7 +3464,7 @@ descend:
 		link := frame[cursor]
 		scratch.revOrders[frameIndex].Value++
 		var err error
-		hasExternal, err := c.cleanPathPayloadHasExternal(link.payload)
+		hasExternal, err := c.cleanPathPayloadHasExternal(link.payload, allowExactExternal)
 		if err != nil || hasExternal {
 			return false, err
 		}

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -539,7 +539,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 	// case; see its doc comment.
 	multiPop := len(paths) > 1
 	if multiPop {
-		c.markCleanProductionRank(paths)
+		c.markReductionProductionRanks(paths)
 	}
 	for _, path := range paths {
 		prev, err := c.node(path.prev)
@@ -598,6 +598,10 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		}
 		freshness := previous.freshness
 		cleanPathRank := mergeCleanPathRank(previous.cleanPathRank, path.cleanPathRank)
+		lineageDestinationRank := mergeCleanPathRank(
+			previous.lineageDestinationRank,
+			path.lineageDestinationRank,
+		)
 		historicalBoundarySplit := previous.historicalBoundarySplit || outcome.historicalBoundarySplit
 		historicalConvergedSplit := previous.historicalConvergedSplit
 		historicalForestDeterministic := previous.historicalForestDeterministic
@@ -640,6 +644,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		}
 		scratch.store(boundaryIndex, seen, reductionBoundaryOutput{
 			key: key, head: out, freshness: freshness, cleanPathRank: cleanPathRank,
+			lineageDestinationRank:        lineageDestinationRank,
 			historicalBoundarySplit:       historicalBoundarySplit,
 			historicalConvergedSplit:      historicalConvergedSplit,
 			historicalForestDeterministic: historicalForestDeterministic,
@@ -661,6 +666,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			Head:                         output.head,
 			Freshness:                    output.freshness,
 			CleanPathRank:                output.cleanPathRank,
+			LineageDestinationRank:       output.lineageDestinationRank,
 			MultiplePopPaths:             multiPop,
 			HistoricalBoundaryProvenance: historicalProvenance,
 			HistoricalCleanPathRank:      output.historicalCleanPathRank,

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -97,6 +97,77 @@ func TestDiagnosticParserCoreCanonicalScratchCollapsesCanonicalHeads(t *testing.
 	}
 }
 
+func TestDiagnosticParserCoreSelectedForestOwnershipDropsSharedBranch(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 7}: {{Type: core.ActionShift, State: 5}},
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 5}},
+		},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected, err := compact.Shift(
+		seed,
+		7,
+		0,
+		core.Token{Symbol: 7, EndByte: 1},
+		core.ForkOrder{Present: true, Value: 6},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	survivor, err := compact.Shift(
+		seed,
+		8,
+		0,
+		core.Token{Symbol: 8, EndByte: 1},
+		core.ForkOrder{Present: true, Value: 3},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headers := []diagnosticParserCoreHeader{
+		{
+			head: selected, creationSeq: 7, convergedReductionSplit: true,
+			cleanPathRank:    core.CleanPathRankUnknown,
+			cleanPathLineage: diagnosticParserCoreSelectedForestOrderMarker | 7,
+		},
+		{
+			head: survivor, creationSeq: 3, convergedReductionSplit: true,
+			cleanPathRank: core.CleanPathRankUnknown,
+		},
+	}
+	proved, ok := diagnosticParserCoreSelectedForestOwnershipDrops(
+		compact,
+		headers,
+		[]int{0},
+	)
+	if !ok || proved != 1 {
+		t.Fatalf("shared selected forest proof = (%d,%t), want (1,true)", proved, ok)
+	}
+	if proved, ok := diagnosticParserCoreSelectedForestOwnershipDrops(
+		compact,
+		headers,
+		[]int{1},
+	); ok || proved != 0 {
+		t.Fatalf("unproved survivor drop = (%d,%t), want (0,false)", proved, ok)
+	}
+	headers[0].cleanPathLineage = 0
+	if proved, ok := diagnosticParserCoreSelectedForestOwnershipDrops(
+		compact,
+		headers,
+		[]int{0},
+	); ok || proved != 0 {
+		t.Fatalf("missing order proof = (%d,%t), want (0,false)", proved, ok)
+	}
+}
+
 func TestDiagnosticParserCoreCanonicalScratchDoesNotAliasPublishedOutput(t *testing.T) {
 	compact, firstHead, secondHead := newDiagnosticParserCoreCanonicalTestCore(t)
 	var scratch diagnosticParserCoreCanonicalScratch

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -60,6 +60,7 @@ type DiagnosticParserCorePrefixOptions struct {
 	allowEOFAcceptNoActionSiblings  bool
 	allowPrimaryAcceptDerivation    bool
 	allowConvergedSplitDropArtifact bool
+	allowLineageDestinationProof    bool
 	noLookaheadRootSymbol           Symbol
 	hasNoLookaheadRootSymbol        bool
 }
@@ -921,6 +922,76 @@ func applyDiagnosticParserCoreCleanPathOutput(
 	header.cleanPathLineage = lineage
 }
 
+func applyDiagnosticParserCoreLineageDestination(
+	header *diagnosticParserCoreHeader,
+	rank core.CleanPathRankSelection,
+	lineage uint16,
+	order uint64,
+) {
+	if header == nil || lineage == 0 {
+		return
+	}
+	if header.cleanPathRank != core.CleanPathRankUnknown {
+		return
+	}
+	switch rank {
+	case core.CleanPathRankSelected:
+		header.cleanPathLineage = diagnosticParserCoreEncodeSelectedForestOrder(order)
+	case core.CleanPathRankUnselected:
+		header.cleanPathLineage = 0
+	}
+}
+
+// Unknown-rank headers do not carry scalar lineage. Reuse that field for one
+// authenticated selected branch order without increasing the header size.
+const diagnosticParserCoreSelectedForestOrderMarker uint16 = 1 << 15
+
+func diagnosticParserCoreEncodeSelectedForestOrder(order uint64) uint16 {
+	if order == 0 || order >= uint64(diagnosticParserCoreSelectedForestOrderMarker) {
+		return 0
+	}
+	return diagnosticParserCoreSelectedForestOrderMarker | uint16(order)
+}
+
+func diagnosticParserCoreSelectedForestOrder(
+	header diagnosticParserCoreHeader,
+) (uint64, bool) {
+	if header.cleanPathRank != core.CleanPathRankUnknown ||
+		header.cleanPathLineage&diagnosticParserCoreSelectedForestOrderMarker == 0 {
+		return 0, false
+	}
+	order := header.cleanPathLineage &^ diagnosticParserCoreSelectedForestOrderMarker
+	return uint64(order), order != 0
+}
+
+func diagnosticParserCoreExactHeadBranchOrder(
+	compact *core.Core,
+	head core.Head,
+) uint64 {
+	if compact == nil {
+		return 0
+	}
+	derivations, err := compact.Derivations(head)
+	if err != nil || len(derivations) == 0 {
+		return 0
+	}
+	var encoded uint64
+	for _, derivation := range derivations {
+		if !derivation.HasBranchOrder || derivation.BranchOrder == math.MaxUint64 {
+			return 0
+		}
+		next := derivation.BranchOrder + 1
+		if encoded == 0 {
+			encoded = next
+			continue
+		}
+		if encoded != next {
+			return 0
+		}
+	}
+	return encoded
+}
+
 func markDiagnosticParserCoreExternalLineage(
 	header *diagnosticParserCoreHeader,
 	token Token,
@@ -1142,10 +1213,12 @@ func (s *diagnosticParserCoreConflictScratch) finish() {
 }
 
 type diagnosticParserCoreActionOutput struct {
-	head             core.Head
-	freshness        core.ReductionFreshness
-	cleanPathRank    core.CleanPathRankSelection
-	cleanPathLineage uint16
+	head                    core.Head
+	freshness               core.ReductionFreshness
+	cleanPathRank           core.CleanPathRankSelection
+	cleanPathLineage        uint16
+	lineageDestinationRank  core.CleanPathRankSelection
+	lineageDestinationOrder uint64
 }
 
 func executeDiagnosticParserCoreGenericConflictDetailed(
@@ -1159,6 +1232,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	nextCleanPathLineage *uint16,
 	allowRepetitionFork bool,
 	collectReceipts bool,
+	allowLineageDestinationProof bool,
 	scratch *diagnosticParserCoreConflictScratch,
 ) (diagnosticParserCoreConflictExecution, error) {
 	actions := classified.Actions()
@@ -1212,6 +1286,14 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 				secondary.freshness = output.freshness
 				secondary.convergedReductionSplit = secondary.convergedReductionSplit || output.cleanPathLineage != 0
 				applyDiagnosticParserCoreCleanPathOutput(&secondary, output.cleanPathRank, output.cleanPathLineage)
+				if allowLineageDestinationProof {
+					applyDiagnosticParserCoreLineageDestination(
+						&secondary,
+						output.lineageDestinationRank,
+						output.cleanPathLineage,
+						output.lineageDestinationOrder,
+					)
+				}
 				if action.Type == core.ActionShift {
 					markDiagnosticParserCoreExternalLineage(&secondary, token)
 				}
@@ -1242,6 +1324,14 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			primary.freshness = output.freshness
 			primary.convergedReductionSplit = primary.convergedReductionSplit || output.cleanPathLineage != 0
 			applyDiagnosticParserCoreCleanPathOutput(&primary, output.cleanPathRank, output.cleanPathLineage)
+			if allowLineageDestinationProof {
+				applyDiagnosticParserCoreLineageDestination(
+					&primary,
+					output.lineageDestinationRank,
+					output.cleanPathLineage,
+					output.lineageDestinationOrder,
+				)
+			}
 			if primaryAction.Type == core.ActionShift {
 				markDiagnosticParserCoreExternalLineage(&primary, token)
 			}
@@ -3182,6 +3272,92 @@ func diagnosticParserCoreGenericNoActionDropEligible(headers []diagnosticParserC
 	return false
 }
 
+func diagnosticParserCoreSelectedLineageDestinationDrops(
+	compact *core.Core,
+	headers []diagnosticParserCoreHeader,
+	indices []int,
+) (uint64, bool) {
+	if proved, ok := diagnosticParserCoreSelectedLineageDrops(headers, indices); ok {
+		return proved, true
+	}
+	return diagnosticParserCoreSelectedForestOwnershipDrops(compact, headers, indices)
+}
+
+func diagnosticParserCoreSelectedForestOwnershipDrops(
+	compact *core.Core,
+	headers []diagnosticParserCoreHeader,
+	indices []int,
+) (uint64, bool) {
+	if compact == nil {
+		return 0, false
+	}
+	var proved uint64
+	for _, index := range indices {
+		if index < 0 || index >= len(headers) {
+			return 0, false
+		}
+		dropped := headers[index]
+		if !dropped.convergedReductionSplit {
+			continue
+		}
+		selectedOrder, exact := diagnosticParserCoreSelectedForestOrder(dropped)
+		if !exact {
+			return 0, false
+		}
+		if !diagnosticParserCoreHeadOwnsBranchOrder(
+			compact,
+			dropped.head,
+			selectedOrder,
+		) {
+			return 0, false
+		}
+		matched := false
+		for survivorIndex, survivor := range headers {
+			dropIndex := sort.SearchInts(indices, survivorIndex)
+			if dropIndex < len(indices) && indices[dropIndex] == survivorIndex {
+				continue
+			}
+			if diagnosticParserCoreHeadOwnsBranchOrder(
+				compact,
+				survivor.head,
+				selectedOrder,
+			) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return 0, false
+		}
+		proved++
+	}
+	return proved, true
+}
+
+func diagnosticParserCoreHeadOwnsBranchOrder(
+	compact *core.Core,
+	head core.Head,
+	encodedOrder uint64,
+) bool {
+	if compact == nil || encodedOrder == 0 {
+		return false
+	}
+	derivations, err := compact.Derivations(head)
+	if err != nil || len(derivations) == 0 {
+		return false
+	}
+	matched := false
+	for _, derivation := range derivations {
+		if !derivation.HasBranchOrder || derivation.BranchOrder == math.MaxUint64 {
+			return false
+		}
+		if derivation.BranchOrder+1 == encodedOrder {
+			matched = true
+		}
+	}
+	return matched
+}
+
 func diagnosticParserCoreSelectedLineageDrops(
 	headers []diagnosticParserCoreHeader,
 	indices []int,
@@ -3228,6 +3404,13 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
 	selectedLineageDrops, proved := diagnosticParserCoreSelectedLineageDrops(s.headers, indices)
+	if s.options.allowLineageDestinationProof && !proved {
+		selectedLineageDrops, proved = diagnosticParserCoreSelectedLineageDestinationDrops(
+			s.compact,
+			s.headers,
+			indices,
+		)
+	}
 	if !proved && !s.options.allowConvergedSplitDropArtifact {
 		return &diagnosticParserCoreDecline{
 			boundary: DiagnosticParserCoreNoAction,
@@ -3346,6 +3529,10 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 	replacements := s.reductionReplacements
 	madeFreshProgress := false
 	for _, output := range outputs {
+		destinationOrder := diagnosticParserCoreExactHeadBranchOrder(
+			s.compact,
+			output.Head,
+		)
 		convergedHistory := output.MultiplePopPaths ||
 			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged ||
 			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryUnproved
@@ -3364,6 +3551,10 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 					output.Head,
 					rank,
 					lineage,
+					output.LineageDestinationRank,
+					reductionLineage,
+					destinationOrder,
+					0,
 					true,
 				); err != nil {
 					return err
@@ -3381,6 +3572,10 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 				output.Head,
 				rank,
 				lineage,
+				output.LineageDestinationRank,
+				reductionLineage,
+				destinationOrder,
+				0,
 				convergedHistory,
 			)
 			if err != nil {
@@ -3396,6 +3591,14 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacement.shifted = token.NoLookahead
 		replacement.convergedReductionSplit = replacement.convergedReductionSplit || convergedHistory
 		applyDiagnosticParserCoreCleanPathOutput(&replacement, rank, lineage)
+		if s.options.allowLineageDestinationProof {
+			applyDiagnosticParserCoreLineageDestination(
+				&replacement,
+				output.LineageDestinationRank,
+				reductionLineage,
+				destinationOrder,
+			)
+		}
 		if len(replacements) > 0 {
 			if s.nextSeq == math.MaxUint64 {
 				return errors.New("parser-core phase zero: reduction creation sequence overflow")
@@ -3480,6 +3683,10 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 	head core.Head,
 	rank core.CleanPathRankSelection,
 	lineage uint16,
+	destinationRank core.CleanPathRankSelection,
+	destinationLineage uint16,
+	destinationOrder uint64,
+	selectedForestOrder uint64,
 	convergedReductionSplit bool,
 ) (bool, error) {
 	for index := range s.headers {
@@ -3500,22 +3707,44 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 		s.headers[index].convergedReductionSplit =
 			s.headers[index].convergedReductionSplit || convergedReductionSplit
 		applyDiagnosticParserCoreCleanPathOutput(&s.headers[index], rank, lineage)
+		if s.options.allowLineageDestinationProof {
+			applyDiagnosticParserCoreLineageDestination(
+				&s.headers[index],
+				destinationRank,
+				destinationLineage,
+				destinationOrder,
+			)
+		}
+		if s.options.allowLineageDestinationProof &&
+			selectedForestOrder != 0 &&
+			s.headers[index].cleanPathRank == core.CleanPathRankUnknown {
+			s.headers[index].cleanPathLineage =
+				diagnosticParserCoreEncodeSelectedForestOrder(selectedForestOrder)
+		}
 		return true, nil
 	}
 	return false, nil
 }
 
-func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(source int, outputs []diagnosticParserCoreHeader) ([]diagnosticParserCoreHeader, int, error) {
+func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(
+	source int,
+	outputs []diagnosticParserCoreHeader,
+) ([]diagnosticParserCoreHeader, int, error) {
 	kept := outputs[:0]
 	adopted := 0
 	for _, output := range outputs {
 		if output.freshness == core.ReductionUpdated || output.freshness == core.ReductionUnchanged {
+			destinationOrder, _ := diagnosticParserCoreSelectedForestOrder(output)
 			ok, err := s.adoptUpdatedReductionSibling(
 				source,
 				output.head,
 				output.cleanPathRank,
 				output.cleanPathLineage,
-				output.cleanPathLineage != 0,
+				core.CleanPathRankUnknown,
+				0,
+				0,
+				destinationOrder,
+				output.convergedReductionSplit,
 			)
 			if err != nil {
 				return nil, 0, err
@@ -3583,7 +3812,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
 		s.branchOrder, &s.nextCleanPathLineage,
 		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
-		s.fullReceipts(), &s.conflictScratch,
+		s.fullReceipts(),
+		s.options.allowLineageDestinationProof,
+		&s.conflictScratch,
 	)
 	if err != nil {
 		return err
@@ -4423,11 +4654,21 @@ func applyParserCoreConflictActionInto(
 			dst = append(dst, diagnosticParserCoreActionOutput{
 				head: output.Head, freshness: output.Freshness,
 				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage,
+				lineageDestinationRank: output.LineageDestinationRank,
+				lineageDestinationOrder: diagnosticParserCoreExactHeadBranchOrder(
+					compact,
+					output.Head,
+				),
 			})
 		case core.ReductionNew, core.ReductionUpdated:
 			dst = append(dst, diagnosticParserCoreActionOutput{
 				head: output.Head, freshness: output.Freshness,
 				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage,
+				lineageDestinationRank: output.LineageDestinationRank,
+				lineageDestinationOrder: diagnosticParserCoreExactHeadBranchOrder(
+					compact,
+					output.Head,
+				),
 			})
 		default:
 			return nil, outputs, errors.New("parser-core phase zero: reduction returned invalid freshness")


### PR DESCRIPTION
## Summary

- Keep the scheduler clean-path rank conservative for external scanner payloads.
- Add a destination-only rank for exact authenticated scanner payloads.
- Pack one selected branch order into an unknown-rank header.
- Drop a recovered head only when its selected branch also exists in a survivor forest.

## Validation

- Internal parser-core package passes.
- Selected-forest proof and compact-layout tests pass.
- Perl and Scala admission corpus: PASS=2, FALLBACK=3, DIVERGE=0, ERROR=0.
- Canonical admission corpus: PASS=70, FALLBACK=29, SKIP=10, DIVERGE=0, ERROR=0, total=109.
- Canopy changed-file review reports a 37-symbol blast radius.
- Perl Docker grammar oracle reproduces its known generated-grammar mismatch. It reports no out-of-memory event.

## Containment

The proof fails closed when an order is missing, unauthenticated, too large, absent from the dropped forest, or absent from all survivor forests.