### PR TITLE
Preserve repetition forks in the compact scheduler

### DIFF
--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1028,6 +1028,10 @@ func diagnosticParserCoreHeaderReceipts(compact *core.Core, headers []diagnostic
 }
 
 func validateDiagnosticParserCoreCell(token Token, actions core.ActionRow) error {
+	return validateDiagnosticParserCoreCellWithRepetitionFork(token, actions, false)
+}
+
+func validateDiagnosticParserCoreCellWithRepetitionFork(token Token, actions core.ActionRow, allowRepetitionFork bool) error {
 	if token.NoLookahead {
 		return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreRoute, detail: "no-lookahead tokens require production recovery semantics"}
 	}
@@ -1037,6 +1041,9 @@ func validateDiagnosticParserCoreCell(token Token, actions core.ActionRow) error
 	for ordinal := 0; ordinal < actions.Len(); ordinal++ {
 		action := actions.At(ordinal)
 		if action.Repetition {
+			if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); allowRepetitionFork && ok {
+				continue
+			}
 			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreRoute, detail: "repetition shifts require production frontier suppression semantics"}
 		}
 		if action.ExtraChain {
@@ -1150,6 +1157,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 	classified core.ClassifiedBoundary,
 	branchOrder uint64,
 	nextCleanPathLineage *uint16,
+	allowRepetitionFork bool,
 	collectReceipts bool,
 	scratch *diagnosticParserCoreConflictScratch,
 ) (diagnosticParserCoreConflictExecution, error) {
@@ -1165,7 +1173,7 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			return diagnosticParserCoreConflictExecution{}, err
 		}
 	}
-	if err := validateDiagnosticParserCoreCell(token, actions); err != nil {
+	if err := validateDiagnosticParserCoreCellWithRepetitionFork(token, actions, allowRepetitionFork); err != nil {
 		return diagnosticParserCoreConflictExecution{}, err
 	}
 	if actions.Len() < 2 {
@@ -1760,6 +1768,7 @@ const (
 	diagnosticParserCoreCellSelectionNone diagnosticParserCoreCellSelection = iota
 	diagnosticParserCoreCellSelectionConflictPolicy
 	diagnosticParserCoreCellSelectionRepetitionFold
+	diagnosticParserCoreCellSelectionRepetitionFork
 )
 
 type diagnosticParserCoreGenericCell struct {
@@ -1794,6 +1803,9 @@ func (cell *diagnosticParserCoreGenericCell) kind() core.ActionRowKind {
 	if cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFold {
 		return core.ActionRowReduce
 	}
+	if cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork {
+		return core.ActionRowConflict
+	}
 	return cell.descriptor().Kind()
 }
 func (cell *diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
@@ -1805,6 +1817,7 @@ func (cell *diagnosticParserCoreGenericCell) selectedActionOrdinal() int {
 
 func (cell *diagnosticParserCoreGenericCell) selectsConflictReduction() bool {
 	return cell.selectedBy != diagnosticParserCoreCellSelectionNone &&
+		cell.selectedBy != diagnosticParserCoreCellSelectionRepetitionFork &&
 		cell.actions().At(cell.selectedActionOrdinal()).Type == core.ActionReduce
 }
 
@@ -1835,6 +1848,12 @@ func diagnosticParserCoreRepetitionFoldOrdinal(language *Language, actions core.
 		diagnosticParserCoreRepetitionFoldOptOut[language.Name] {
 		return 0, false
 	}
+	return diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions)
+}
+
+// diagnosticParserCoreSingleReduceRepetitionShiftOrdinal identifies the exact
+// two-arm row that production either folds or keeps as one conflict fork.
+func diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions core.ActionRow) (int, bool) {
 	reduceOrdinal := -1
 	shiftFound := false
 	for ordinal := 0; ordinal < actions.Len(); ordinal++ {
@@ -2807,6 +2826,11 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 				if ordinal, ok := diagnosticParserCoreRepetitionFoldOrdinal(s.tokenSource.language, actions); ok {
 					cell.selectedOrdinal = ordinal
 					cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFold
+				} else if _, ok := diagnosticParserCoreSingleReduceRepetitionShiftOrdinal(actions); ok &&
+					cRepetitionSkipOptOut[s.tokenSource.language.Name] {
+					// Production keeps both arms for a language with a proven
+					// fold counterexample. Use the existing conflict executor.
+					cell.selectedBy = diagnosticParserCoreCellSelectionRepetitionFork
 				}
 			}
 		}
@@ -3557,7 +3581,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericConflictOwned(owner c
 	defer s.conflictScratch.finish()
 	execution, err := executeDiagnosticParserCoreGenericConflictDetailed(
 		s.compact, owner, s.headers[cell.headerIndex], cell.headerIndex, cell.dispatchToken(s.token), cell.boundary,
-		s.branchOrder, &s.nextCleanPathLineage, s.fullReceipts(), &s.conflictScratch,
+		s.branchOrder, &s.nextCleanPathLineage,
+		cell.selectedBy == diagnosticParserCoreCellSelectionRepetitionFork,
+		s.fullReceipts(), &s.conflictScratch,
 	)
 	if err != nil {
 		return err

--- a/parsercore_phase0_generic_conflict_internal_test.go
+++ b/parsercore_phase0_generic_conflict_internal_test.go
@@ -129,6 +129,58 @@ func TestDiagnosticParserCoreGenericRepetitionFoldReducesWithoutFork(t *testing.
 	}
 }
 
+func TestDiagnosticParserCoreGenericRepetitionForkMatchesProductionOptOut(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 9}: {
+				{Type: core.ActionShift, State: 3, Repetition: true},
+				{Type: core.ActionReduce, Symbol: 4},
+			},
+		},
+		gotos: map[genericConflictCell]core.StateID{
+			{state: 1, symbol: 4}: 2,
+		},
+	}
+	compact, err := core.New(table, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := &diagnosticParserCoreGenericScheduler{
+		compact:     compact,
+		tokenSource: &dfaTokenSource{language: &Language{Name: "haskell"}},
+		headers:     []diagnosticParserCoreHeader{{head: head}},
+		token:       Token{Symbol: 9, EndByte: 1},
+		options: DiagnosticParserCorePrefixOptions{
+			MaxDispatches: 8,
+			ReceiptMode:   DiagnosticParserCoreReceiptFull,
+		},
+		receipt: &DiagnosticParserCoreGenericScheduler{},
+	}
+	stop, err := scheduler.dispatchPass()
+	if err != nil || stop != nil {
+		t.Fatalf("repetition fork stop=%+v err=%v", stop, err)
+	}
+	if len(scheduler.headers) != 2 || scheduler.work.Conflicts != 1 ||
+		scheduler.work.Forks != 1 || scheduler.work.RepetitionFolds != 0 {
+		t.Fatalf("repetition fork headers=%d work=%+v", len(scheduler.headers), scheduler.work)
+	}
+	got := make(map[StateID]uint32, 2)
+	for _, header := range scheduler.headers {
+		state, byteOffset, err := compact.Boundary(header.head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got[StateID(state)] = byteOffset
+	}
+	if got[2] != 0 || got[3] != 1 {
+		t.Fatalf("repetition fork boundaries=%v, want reduce state 2 at byte 0 and shift state 3 at byte 1", got)
+	}
+}
+
 func TestDiagnosticParserCoreGenericConflictPolicySelectsRepetitionReduce(t *testing.T) {
 	table := &genericConflictTable{
 		cells: map[genericConflictCell][]core.Action{


### PR DESCRIPTION
## Summary

Preserve both conflict arms for fold opt-out languages.
Apply this only to one reduce and one repetition shift.
Keep all other repetition rows fail-closed.

## Evidence

- Focused repetition-fold and repetition-fork tests pass.
- The parser-core phase-zero package passes.
- The canonical 109-row gate passes.
- Results remain 70 passes, 29 fallbacks, 10 skips, and zero divergences or errors.
- Two clean Haskell rows cross the repetition boundary.
- They fail closed at the next recursive-insertion boundary.
- The Haskell Docker run completed without an out-of-memory failure.
- The wrapper reports the known generated-grammar mismatch.

## Scope

This pull request is stacked on PR #564.
It does not change production parser selection.
It does not add language-specific row policies.

Receipt: `hypha-receipt:2026-07-30:compact-repetition-fork`