### PR TITLE
fix(swift): recover else clause when condition swallows then-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- Swift now recovers an `if`/`else` whose comparison condition ends with a
+  parenthesised member access in the then-branch (a call argument or a
+  parenthesised negation). The then-block no longer swallows the trailing
+  `else` as a call's trailing closure.
+  This fixes [#560](https://github.com/odvcencio/gotreesitter/issues/560).
+
 - Raw error-cost walks now retain each captured child shape reference.
   A later mutable node update cannot create a recursive shape cycle.
   The Rust aggressive corpus completes all 25 bounded parses without a crash.

--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -584,3 +584,130 @@ func TestSwiftTernaryFieldsAndShape(t *testing.T) {
 		t.Fatalf("ternary end = %d, want %d", got, want)
 	}
 }
+
+// issue #560: an if/else whose condition is a comparison and whose then-branch
+// contains a member access inside a parenthesised context (a call argument or
+// a parenthesised negation) makes the condition's last operand absorb the
+// then-block as a trailing closure. The real `else` keyword that follows can
+// no longer close the if_statement, so it lands in an ERROR node instead —
+// with the block after it reinterpreted as the if_statement's own body.
+func TestSwiftComparisonThenBranchMemberAccessRecoversElse(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"top-level-minimal", "if a == b { f(c.d) } else {}\n"},
+		{"no-call-negated-paren", "func f() {\n  if i == e {\n    d = -(a.b)\n  } else {\n  }\n}\n"},
+		{"literal-on-left", "func f() { if 0 == i { d = -(a.b) } else {} }\n"},
+		{"less-than", "func f() { if a < b { f(c.d) } else {} }\n"},
+		{"statement-form-no-return", "func f() { if i == e { g(base.x) } else { g(0) } }\n"},
+		{"deeper-member-path", "func f() { if i == e { g(a.b.c) } else {} }\n"},
+		{"else-if-non-comparison", "func f() { if i == e { d = -(a.b) } else if x { } }\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("recovered tree still reports error: %s", root.SExpr(lang))
+			}
+			if got, want := root.EndByte(), uint32(len(src)); got != want {
+				t.Fatalf("root end = %d, want %d (span not byte-faithful): %s", got, want, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "if_statement"); got < 1 {
+				t.Fatalf("if_statement count = %d, want >= 1: %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "lambda_literal"); got != 0 {
+				t.Fatalf("then-branch misparsed as trailing-closure lambda_literal: %s", root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "tuple_expression"); got != 0 {
+				t.Fatalf("synthetic parenthesis leaked as tuple_expression: %s", root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "else"); got < 1 {
+				t.Fatalf("else keyword count = %d, want >= 1 (else clause not reconstructed): %s", got, root.SExpr(lang))
+			}
+		})
+	}
+}
+
+// TestSwiftComparisonThenBranchMemberAccessTreeIsFaithful checks the recovered
+// tree for the 28-byte repro is structurally correct: a proper if_statement
+// whose condition is the bare equality_expression (the synthetic parenthesis
+// used during recovery is stripped), with the then-branch call and the else
+// block both preserved as ordinary siblings of the if_statement.
+func TestSwiftComparisonThenBranchMemberAccessTreeIsFaithful(t *testing.T) {
+	lang := SwiftLanguage()
+	src := []byte("if a == b { f(c.d) } else {}\n")
+	parser := gotreesitter.NewParser(lang)
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	root := tree.RootNode()
+	sexpr := root.SExpr(lang)
+	for _, want := range []string{"(if_statement", "(equality_expression", "(call_expression", "(navigation_expression"} {
+		if !strings.Contains(sexpr, want) {
+			t.Fatalf("missing %s in recovered tree: %s", want, sexpr)
+		}
+	}
+	if countSwiftNodeType(lang, root, "constructor_expression") != 0 {
+		t.Fatalf("condition operand misparsed as constructor_expression: %s", sexpr)
+	}
+	if countSwiftNodeType(lang, root, "lambda_literal") != 0 {
+		t.Fatalf("then-block misparsed as trailing-closure lambda_literal: %s", sexpr)
+	}
+	if countSwiftNodeType(lang, root, "ERROR") != 0 {
+		t.Fatalf("ERROR node present after recovery: %s", sexpr)
+	}
+}
+
+// TestSwiftComparisonThenBranchGuardVariantsUnaffected guards the ingredients
+// the #560 report identified as individually necessary: each variant below
+// drops exactly one ingredient (comparison, member access, parenthesised
+// context) and must keep parsing clean, both before and after this fix.
+func TestSwiftComparisonThenBranchGuardVariantsUnaffected(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"not-a-comparison", "func f() -> Int { if x { return g(base.x) } else { return 0 } }\n"},
+		{"arg-not-member-access", "func f() -> Int { if i == e { return g(x) } else { return 0 } }\n"},
+		{"no-parenthesised-context", "func f() -> Int { if i == e { return base.x } else { return 0 } }\n"},
+		{"subscript-not-member-access", "func f() -> Int { if i == e { return g(a[j]) } else { return 0 } }\n"},
+		{"parens-without-member-access", "func f() { if i == e { d = -(a - 1) } else {} }\n"},
+		{"member-access-without-parens", "func f() { if i == e { d = -a.b } else {} }\n"},
+		{"no-else-branch", "func f() -> Int {\n  if i == e {\n    return g(base.x)\n  }\n  return 0\n}\n"},
+		{"literal-on-right", "func f() { if i == 0 { d = -(a.b) } else {} }\n"},
+		{"else-if-comparison", "func f() { if i == e { d = -(a.b) } else if j == k { } }\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("clean source reported error: %s", root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "lambda_literal"); got != 0 {
+				t.Fatalf("clean source misparsed a trailing-closure lambda_literal: %s", root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "tuple_expression"); got != 0 {
+				t.Fatalf("recovery pass wrapped a clean condition in tuple_expression: %s", root.SExpr(lang))
+			}
+		})
+	}
+}

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -94,11 +94,14 @@ func normalizeSwiftRecoveredTrailingClosureConditions(root *Node, source []byte,
 
 // swiftCollectConditionParenInserts walks the (broken) tree with explicit parent
 // tracking and, for every `if`/`while` keyword that failed to form its statement
-// (#118) and every `for` keyword whose loop failed to form a for_statement
-// (#123), computes a `(`/`)` insertion pair around the trailing-closure-ambiguous
-// expression (the condition, or the for…in iterable). The body brace is located
-// by scanning the source forward to the first top-level `{`, skipping comments,
-// strings and bracketed/parenthesised groups.
+// (#118), every `if_statement` whose then-block was swallowed as a trailing
+// closure and whose real `else` landed in an ERROR node instead of the
+// else-clause (#560), and every `for` keyword whose loop failed to form a
+// for_statement (#123), computes a `(`/`)` insertion pair around the
+// trailing-closure-ambiguous expression (the condition, or the for…in
+// iterable). The body brace is located by scanning the source forward to the
+// first top-level `{`, skipping comments, strings and bracketed/parenthesised
+// groups.
 func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language) []swiftParenInsert {
 	var inserts []swiftParenInsert
 	seen := make(map[uint32]bool)
@@ -129,6 +132,16 @@ func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language
 				// the body's matching close brace.
 				swiftCollectIfChainParens(source, n.endByte, add)
 			}
+		case typ == "if_statement":
+			if keywordEnd, ok := swiftIfStatementSwallowedThenBlockKeywordEnd(n, lang); ok {
+				// The condition's last operand absorbed the then-block as a
+				// trailing closure (#560), so the real `else` that follows could
+				// not close this if_statement and was wrapped in an ERROR node
+				// instead — with the block after it reinterpreted as this
+				// if_statement's own body. Bracket the condition the same way as
+				// the orphaned-`if` case above.
+				swiftCollectIfChainParens(source, keywordEnd, add)
+			}
 		case typ == "for" && resultChildCount(n) == 0:
 			// A well-formed loop nests the `for` token inside a for_statement;
 			// a collapsed one leaves it dangling under source_file/ERROR/etc.
@@ -143,6 +156,35 @@ func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language
 	}
 	walk(root, nil)
 	return inserts
+}
+
+// swiftIfStatementSwallowedThenBlockKeywordEnd reports whether if_statement n
+// suffers the #560 collapse: a comparison condition whose last operand takes a
+// parenthesised-member-access argument absorbs the then-block as a trailing
+// closure, so the real `else` keyword that follows cannot close this
+// if_statement and is wrapped in an ERROR node instead — with the block after
+// that ERROR node reinterpreted as this if_statement's own body. On success it
+// returns the byte offset just past this if_statement's own `if` keyword,
+// ready for swiftCollectIfChainParens.
+func swiftIfStatementSwallowedThenBlockKeywordEnd(n *Node, lang *Language) (uint32, bool) {
+	childCount := resultChildCount(n)
+	if childCount == 0 {
+		return 0, false
+	}
+	first := resultChildAt(n, 0)
+	if first == nil || first.Type(lang) != "if" {
+		return 0, false
+	}
+	for i := 1; i < childCount; i++ {
+		child := resultChildAt(n, i)
+		if child == nil || child.Type(lang) != "ERROR" || resultChildCount(child) == 0 {
+			continue
+		}
+		if errFirst := resultChildAt(child, 0); errFirst != nil && errFirst.Type(lang) == "else" {
+			return first.endByte, true
+		}
+	}
+	return 0, false
 }
 
 // swiftCollectIfChainParens brackets the condition of an `if`/`while` header that


### PR DESCRIPTION
## Summary

The parser misinterprets an if / else statement as a trailing closure when the comparison condition contains a member access inside a parenthesised call argument or negation. This prevents the real else keyword from closing the if_statement. The fix identifies this collapsed tree shape and brackets the condition to restore proper parsing.

## Changes

- Detect if_statement nodes where the then-block was absorbed as a trailing closure and the else keyword was pushed into an ERROR node.
- Apply conditional parenthesis insertion around the condition for these collapsed statements to unblock the trailing else clause.
- Add regression tests covering minimal, negated, and deeper member access patterns that trigger the bug.
- Add guard tests to verify that other variants remain unaffected by the new recovery logic.
- Update the CHANGELOG with the recovery details for Swift control-flow statements.
- Update the comment on swiftCollectConditionParenInserts to reflect the new detection case.

## Testing

- Run `go test ./grammars -run 'TestSwiftComparisonThenBranchMemberAccess|TestSwiftComparisonThenBranchGuardVariantsUnaffected' -count=1` to verify new and guard tests pass.
- Run `go test ./grammars -run 'TestSwift' -count=1` to ensure no regressions in the Swift regression suite.

## Related Issues

- Refs #560

## Review Focus

Check the new `swiftIfStatementSwallowedThenBlockKeywordEnd` helper and the added paren-insertion branch. Ensure the guard variants in the regression test stay clean to prevent accidental over-correction.