### PR TITLE
fix(swift): Handle for-range in type bodies with trailing closure absorption

### DIFF
--- a/grammars/swift_parse_regression_test.go
+++ b/grammars/swift_parse_regression_test.go
@@ -385,6 +385,99 @@ func TestSwiftForRangeIterableRecoversFunction(t *testing.T) {
 	}
 }
 
+// TestSwiftForRangeThenMethodRecoversFunction covers issue #561: a for…in loop
+// over a range, nested in a type body, followed by another method. The #123 fix
+// only detects a total collapse (the `for` token left with no for_statement
+// parent); here a for_statement node still forms — its own closing brace is
+// still absorbed as a trailing closure on the range's upper bound, but the
+// method that follows keeps the parser from collapsing cleanly, so it hits an
+// ERROR instead. That ERROR still needs the same iterable-bracketing recovery.
+func TestSwiftForRangeThenMethodRecoversFunction(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"class-closed-range", "class T {\n  func a() {\n    for n in 4...100 {\n    }\n  }\n  func b() {\n  }\n}\n"},
+		{"struct-closed-range", "struct T {\n  func a() {\n    for n in 4...100 {\n    }\n  }\n  func b() {\n  }\n}\n"},
+		{"extension-closed-range", "extension T {\n  func a() {\n    for n in 4...100 {\n    }\n  }\n  func b() {\n  }\n}\n"},
+		{"half-open-range", "class T {\n  func a() {\n    for n in 0..<10 {\n    }\n  }\n  func b() {\n  }\n}\n"},
+		{"identifier-operands", "class T {\n  func a() {\n    for n in a...b {\n    }\n  }\n  func b() {\n  }\n}\n"},
+		{"non-empty-bodies", "class T {\n  func a() {\n    for n in 4...100 { g(n) }\n  }\n  func b() { h() }\n}\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("recovered tree still reports error: %s", root.SExpr(lang))
+			}
+			if got, want := root.EndByte(), uint32(len(src)); got != want {
+				t.Fatalf("root end = %d, want %d (span not byte-faithful): %s", got, want, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "function_declaration"); got != 2 {
+				t.Fatalf("function_declaration count = %d, want 2: %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "for_statement"); got != 1 {
+				t.Fatalf("for_statement count = %d, want 1: %s", got, root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "lambda_literal"); got != 0 {
+				t.Fatalf("range upper bound absorbed a trailing closure: %s", root.SExpr(lang))
+			}
+			if got := countSwiftNodeType(lang, root, "tuple_expression"); got != 0 {
+				t.Fatalf("synthetic parenthesis leaked as tuple_expression: %s", root.SExpr(lang))
+			}
+		})
+	}
+}
+
+// TestSwiftForRangeThenMethodCleanVariantsUnaffected guards the shapes from
+// issue #561 that already parse cleanly, so the broadened #561 detection (any
+// for_statement with an ERROR descendant, not just a totally collapsed `for`
+// token) doesn't start rewriting sources that don't need it.
+func TestSwiftForRangeThenMethodCleanVariantsUnaffected(t *testing.T) {
+	lang := SwiftLanguage()
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"no-enclosing-type", "func a() { for n in 4...100 { } }\nfunc b() { }\n"},
+		{"only-one-method", "class T { func a() { for n in 4...100 { } } }\n"},
+		{"iterable-not-a-range", "class T {\n  func a() { for n in xs { } }\n  func b() { }\n}\nlet xs = [1, 2, 3]\n"},
+		{"following-member-is-a-property", "class T {\n  func a() { for n in 4...100 { } }\n  var b = 1\n}\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			defer tree.Release()
+			root := tree.RootNode()
+			if root.HasError() {
+				t.Fatalf("clean source reported error: %s", root.SExpr(lang))
+			}
+			if got, want := root.EndByte(), uint32(len(src)); got != want {
+				t.Fatalf("root end = %d, want %d (span not byte-faithful): %s", got, want, root.SExpr(lang))
+			}
+			if countSwiftNodeType(lang, root, "for_statement") != 1 {
+				t.Fatalf("expected exactly one for_statement: %s", root.SExpr(lang))
+			}
+			if countSwiftNodeType(lang, root, "tuple_expression") != 0 {
+				t.Fatalf("recovery pass wrapped a clean iterable in tuple_expression: %s", root.SExpr(lang))
+			}
+		})
+	}
+}
+
 // TestSwiftForBareIdentifierUnaffected guards against the recovery pass disturbing
 // a for…in over a bare identifier, which already parses correctly.
 func TestSwiftForBareIdentifierUnaffected(t *testing.T) {

--- a/parser_result_swift_conditions.go
+++ b/parser_result_swift_conditions.go
@@ -1,6 +1,6 @@
 package gotreesitter
 
-// Swift control-flow trailing-closure ambiguity recovery (issues #118, #123).
+// Swift control-flow trailing-closure ambiguity recovery (issues #118, #123, #561).
 //
 // The Swift grammar misparses a control-flow header whose expression ends in a
 // value that can take a trailing closure, because the following statement body
@@ -15,6 +15,14 @@ package gotreesitter
 //     function silently collapses to _modifierless_function_declaration_no_body
 //     with the body statements re-homed as siblings — and *without* an ERROR
 //     node, so it can't even be detected as a parse failure.
+//   - for…in with a range iterable, inside a type body, followed by another
+//     method (#561): `class T { func a() { for n in 4...100 { } } func b() {} }`
+//     hits the same trailing-closure absorption, but this time a for_statement
+//     node still forms (nesting the `for` token), so the #123 detection — which
+//     only looks for a `for` token with no for_statement parent — misses it. The
+//     absorption still leaves an ERROR somewhere in the for_statement's subtree
+//     (the swallowed loop body plus whatever the parser glued the next member
+//     onto), so this case is detected by that for_statement's HasError() bit.
 //
 // Swift's real grammar forbids trailing closures in both positions; wrapping the
 // condition / iterable in parentheses removes the ambiguity (`if (x > 0) {…}`,
@@ -94,8 +102,9 @@ func normalizeSwiftRecoveredTrailingClosureConditions(root *Node, source []byte,
 
 // swiftCollectConditionParenInserts walks the (broken) tree with explicit parent
 // tracking and, for every `if`/`while` keyword that failed to form its statement
-// (#118) and every `for` keyword whose loop failed to form a for_statement
-// (#123), computes a `(`/`)` insertion pair around the trailing-closure-ambiguous
+// (#118), every `for` keyword whose loop failed to form a for_statement (#123),
+// and every `for` keyword whose for_statement formed but still carries an ERROR
+// (#561), computes a `(`/`)` insertion pair around the trailing-closure-ambiguous
 // expression (the condition, or the for…in iterable). The body brace is located
 // by scanning the source forward to the first top-level `{`, skipping comments,
 // strings and bracketed/parenthesised groups.
@@ -130,9 +139,15 @@ func swiftCollectConditionParenInserts(root *Node, source []byte, lang *Language
 				swiftCollectIfChainParens(source, n.endByte, add)
 			}
 		case typ == "for" && resultChildCount(n) == 0:
-			// A well-formed loop nests the `for` token inside a for_statement;
-			// a collapsed one leaves it dangling under source_file/ERROR/etc.
-			if parentType != "for_statement" {
+			// A well-formed loop nests the `for` token inside an error-free
+			// for_statement. Two broken shapes both need the same iterable
+			// bracketing: a total collapse leaves the `for` token dangling
+			// under source_file/ERROR/etc (#123), while a partial collapse
+			// (#561) still nests it inside a for_statement, but the loop's
+			// own closing brace was greedily consumed as a trailing closure
+			// on the iterable's upper bound, so the for_statement (and
+			// everything the parser glued on after it) carries an ERROR.
+			if parentType != "for_statement" || (parent != nil && parent.HasError()) {
 				lp, rp, ok := swiftForIterableParenPositions(source, n.endByte)
 				add(lp, rp, ok)
 			}


### PR DESCRIPTION
## Summary

Update the trailing-closure ambiguity recovery to detect and fix for…in loops where the loop closing brace was greedily consumed by the range iterable, leaving an ERROR in the tree. The fix expands detection in swiftCollectConditionParenInserts to catch for_statement nodes that still carry an ERROR, alongside the existing detection for collapsed for tokens. Adds regression tests for the fixed cases and verifies that already-correct for-loops remain unaffected.

## Changes

- Expand swiftCollectConditionParenInserts to bracket the iterable in parentheses when a for_statement forms but carries an ERROR, indicating greedy trailing-closure absorption on the range.
- Extend the for-keyword detection logic to check parent.HasError() alongside the previous dangling-token check.
- Document the new recovery case in parser_result_swift_conditions.go and reference issue #561.
- Add TestSwiftForRangeThenMethodRecoversFunction to verify the fix covers classes, structs, extensions, range types, and body shapes.
- Add TestSwiftForRangeThenMethodCleanVariantsUnaffected to ensure the broader detection does not modify sources that already parse cleanly.

## Testing

- Run go test ./grammars -run TestSwiftForRangeThenMethod -count=1 to verify the new regression tests pass.
- Run go test ./grammars -run TestSwiftForBareIdentifierUnaffected -count=1 to confirm unaffected variants still parse without error.
- Run bash cgo_harness/docker/run_single_grammar_parity.sh swift to verify full parse parity.

## Related Issues

- Refs #561