### PR TITLE
add(swift): Add Swift corpus regression test suite

### DIFF
--- a/grammars/swift_corpus_test.go
+++ b/grammars/swift_corpus_test.go
@@ -38,9 +38,17 @@ type swiftCorpusExpectation struct {
 // have exactly one row here; TestSwiftCorpusManifestComplete enforces that.
 //
 // Populated by running gotreesitter's Swift grammar against each corpus file
-// at the branch point (main @ 96671b92, before PRs #566-#570 land) and, for
+// at the branch point (main @ 96671b92, before PRs #566-#571 land) and, for
 // every failure, locating the first ERROR/MISSING node and matching its
 // construct against the open issue that describes it.
+//
+// Ratcheted forward after #566, #567, #568, #569, #570, and #571 merged:
+// swift-algorithms_AdjacentPairsTests.swift and swift-algorithms_Windows.swift
+// now parse cleanly. swift-algorithms_Chunked.swift,
+// swift-algorithms_FlattenCollection.swift, and swift-algorithms_Stride.swift
+// still fail, but not for their original #558/#560 causes; each carries a
+// residual, uncovered variant of the same trailing-closure-ambiguity family.
+// See each row's comment for the isolated minimal repro.
 var swiftCorpusExpectations = map[string]swiftCorpusExpectation{
 	"stdlib_ASCII.swift": {
 		status: swiftCorpusKnownFailing,
@@ -120,46 +128,82 @@ var swiftCorpusExpectations = map[string]swiftCorpusExpectation{
 		issue: "new: associatedtype with a comma-separated multi-conformance constraint list",
 	},
 	"swift-algorithms_AdjacentPairsTests.swift": {
-		status: swiftCorpusKnownFailing,
-		// Two independent causes, per issue #561's own text: the
-		// triple-nested generic `IndexValidator<AdjacentPairsCollection<
-		// Range<Int>>>()` on line 73 (issue #559), and the `for n in
-		// 4...100 { }` loops on lines 37 and 66 each followed by another
-		// test method inside the class body (issue #561). Either one
-		// alone is sufficient to break this file.
-		issue: "#559, #561",
+		status: swiftCorpusClean,
+		// Ratcheted after #559 and #561 merged: the triple-nested generic
+		// `IndexValidator<AdjacentPairsCollection<Range<Int>>>()` on line 73
+		// (issue #559, fixed by #567) and the `for n in 4...100 { }` loops
+		// on lines 37 and 66 each followed by another test method inside
+		// the class body (issue #561, fixed by #570) both now parse clean.
 	},
 	"swift-algorithms_Chunked.swift": {
 		status: swiftCorpusKnownFailing,
-		// makeOffsetIndex's nested `if let limit = limit { if baseDistance
-		// > 0 && limit == endIndex { if self.distance(from: i, to: limit)
-		// < distance { ... } } }` is the repro 2 shape #558 names
-		// verbatim for this file.
-		issue: "#558",
+		// #558's own repro 2 (makeOffsetIndex's 4-level-deep nested if-let
+		// chain) is fixed as of #571 and no longer the cause. The file
+		// still fails: makeOffsetIndex's outer `if let limit = limit { ...
+		// }` block contains the fixed nested-if chain as its first
+		// statement, followed by a SIBLING `if limitFn(baseStartIdx,
+		// limit.baseRange.lowerBound) { return nil }` inside that same
+		// if-let scope. Minimal repro (isolated by bisection):
+		//   func f() {
+		//     if let limit = limit {
+		//       if a == nil {
+		//         if b > 0 && limit == c {
+		//           if d < e { return }
+		//         }
+		//       }
+		//       if g(h, i) { return }
+		//     }
+		//   }
+		// A sibling statement after a nested if-chain, still inside the
+		// enclosing if-let, is a distinct trailing-closure-ambiguity shape
+		// #571's fix does not cover.
+		issue: "new: sibling statement after a nested if-chain inside the same if-let scope (residual after #571)",
 	},
 	"swift-algorithms_FlattenCollection.swift": {
 		status: swiftCorpusKnownFailing,
-		// Contains the nested-if-let shape #558 describes as repro 1
-		// (`if let indexInner = index.inner { ... if let inner =
-		// element.index(...) { ... } ... }` in the index-arithmetic
-		// helpers), and #558 names this file explicitly.
-		issue: "#558",
+		// #558's own repro 1 (a bare nested if-let) is fixed as of #571 and
+		// no longer the cause. The file still fails: offsetForward's
+		// `if index.outer == limit.outer { if let indexInner = ...,
+		// let limitInner = ... { return chain.method(...).map { inner in
+		// Index(outer: ..., inner: inner) } } else { return nil } }` is
+		// followed by further statements in the same function. Minimal
+		// repro (isolated by bisection):
+		//   func f() -> Index? {
+		//     if let a = a, let b = b {
+		//       return chain.method(a, b).map { x in Index(outer: a, inner: x) }
+		//     } else {
+		//       return nil
+		//     }
+		//     return nil
+		//   }
+		// A `.map { ... }` trailing closure whose body is itself a
+		// labelled-argument constructor call, followed by a statement
+		// after the enclosing if/else, is a distinct trailing-closure-
+		// ambiguity shape not covered by #571's fix.
+		issue: "new: .map{} trailing closure with a labelled-call body, followed by a statement after if/else (residual after #571)",
 	},
 	"swift-algorithms_Stride.swift": {
 		status: swiftCorpusKnownFailing,
-		// offsetForward/offsetBackward's `if limit < i { if let idx =
-		// base.index(...) { ... } else { ... } } else if let idx =
-		// base.index(...) { ... }` is the exact shape #560 names for this
-		// file, at the exact function names (offsetForward,
-		// offsetBackward) #560 cites.
-		issue: "#560",
+		// #560's own repro (a comparison if/else whose then-branch has a
+		// parenthesised member access) is fixed as of #569 and no longer
+		// the cause. The file still fails: offsetForward's
+		// `if limit < i { if let idx = ... { ... } else { ... } } else if
+		// let idx = ... { ... } else { ... }` has a comparison-conditioned
+		// first branch whose then-block is itself a nested if/else,
+		// followed by an `else if` whose own condition is an optional
+		// binding (`if let`), not a comparison. Issue #560 itself flagged
+		// this as an open sharp edge: "only a non-comparison else-if
+		// condition fails." #569's fix targets the comparison-condition
+		// case and does not extend to this else-if-with-if-let-condition
+		// variant.
+		issue: "new: else-if with a non-comparison (if-let) condition after a comparison-conditioned if whose then-block is a nested if/else (residual after #569)",
 	},
 	"swift-algorithms_Windows.swift": {
-		status: swiftCorpusKnownFailing,
-		// `index(before:)`'s `if index == endIndex { return Index(...) }
-		// else { return Index(...) }` is the verbatim repro #560 quotes
-		// for this file.
-		issue: "#560",
+		status: swiftCorpusClean,
+		// Ratcheted after #560 (fixed by #569): `index(before:)`'s
+		// `if index == endIndex { return Index(...) } else { return
+		// Index(...) }`, the verbatim repro #560 quoted for this file, now
+		// parses clean.
 	},
 }
 

--- a/grammars/swift_corpus_test.go
+++ b/grammars/swift_corpus_test.go
@@ -1,0 +1,279 @@
+package grammars
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter"
+)
+
+// swiftCorpusStatus records the expected parse outcome for one corpus file.
+type swiftCorpusStatus int
+
+const (
+	// swiftCorpusClean means the file must parse with HasError() == false.
+	// A file in this state that starts reporting an error is a regression.
+	swiftCorpusClean swiftCorpusStatus = iota
+	// swiftCorpusKnownFailing means the file currently reports a parse
+	// error from a known, tracked cause. A file in this state that starts
+	// parsing cleanly means the underlying bug got fixed — the test forces
+	// a ratchet: update the row to swiftCorpusClean.
+	swiftCorpusKnownFailing
+)
+
+// swiftCorpusExpectation is one row of the corpus ratchet table.
+type swiftCorpusExpectation struct {
+	status swiftCorpusStatus
+	// issue names the open GitHub issue(s) whose construct explains the
+	// failure, for example "#558". Empty for clean rows. For a failure
+	// that matches no open issue, this holds a "new:" prefixed note
+	// describing the construct instead of an issue number.
+	issue string
+}
+
+// swiftCorpusExpectations is the ratchet table for
+// grammars/testdata/swift_corpus. Every *.swift file in that directory must
+// have exactly one row here; TestSwiftCorpusManifestComplete enforces that.
+//
+// Populated by running gotreesitter's Swift grammar against each corpus file
+// at the branch point (main @ 96671b92, before PRs #566-#570 land) and, for
+// every failure, locating the first ERROR/MISSING node and matching its
+// construct against the open issue that describes it.
+var swiftCorpusExpectations = map[string]swiftCorpusExpectation{
+	"stdlib_ASCII.swift": {
+		status: swiftCorpusKnownFailing,
+		// Matches no open issue. Minimal repro: `let x = 1&<<7`. The
+		// masking left-shift operator `&<<` (and, presumably, the rest of
+		// the overflow-operator family `&+`, `&-`, `&*`, `&>>`) breaks the
+		// surrounding infix_expression, leaving an ERROR node in place of
+		// the right operand. See stdlib_ASCII.swift's `encode(_:)`:
+		// `guard source.value < (1&<<7) else { return nil }`.
+		issue: "new: masking left-shift operator &<< breaks the enclosing infix_expression",
+	},
+	"stdlib_Collection.swift": {
+		status: swiftCorpusKnownFailing,
+		// Matches no open issue. Minimal repro:
+		//   protocol P {
+		//     associatedtype Iterator
+		//     override __consuming func makeIterator() -> Iterator
+		//   }
+		// The `override` modifier combined with the `__consuming`
+		// parameter-passing modifier on a protocol function requirement
+		// produces an ERROR node covering `__consuming`. See
+		// stdlib_Collection.swift's Sequence protocol requirement
+		// `override __consuming func makeIterator() -> Iterator`.
+		issue: "new: `override __consuming func` modifier combination on a protocol requirement",
+	},
+	"stdlib_CollectionAlgorithms.swift": {
+		status: swiftCorpusKnownFailing,
+		// Same root cause as stdlib_FloatingPointToString.swift: the
+		// `unsafe` expression-prefix keyword. Verified by bisection: the
+		// file parses clean through the `_halfStablePartition` function
+		// (byte 13232) and only starts failing once `partition(by:)`
+		// appears, which contains `try unsafe
+		// withContiguousMutableStorageIfAvailable { ... }`.
+		issue: "new: `unsafe` expression-prefix keyword (see stdlib_FloatingPointToString.swift)",
+	},
+	"stdlib_FloatingPointToString.swift": {
+		status: swiftCorpusKnownFailing,
+		// Matches no open issue. Minimal repro: `let x = unsafe bar()`.
+		// The `unsafe` keyword used as an expression prefix (Swift's
+		// strict-memory-safety opt-in, used throughout this file as
+		// `unsafe buffer.storeBytes(...)`, `let x = unsafe
+		// utf8Buffer.mutableBytes`, etc.) is not recognized; it leaves an
+		// ERROR node in place of the wrapped expression.
+		issue: "new: `unsafe` expression-prefix keyword is not recognized",
+	},
+	"stdlib_Optional.swift": {
+		status: swiftCorpusKnownFailing,
+		// Matches no open issue. Minimal repro:
+		//   struct S {
+		//     @lifetime(copy value)
+		//     public init(_ value: Int) {}
+		//   }
+		// The `@lifetime(copy value)` / `@lifetime(borrow x)` lifetime-
+		// dependency attribute argument is misparsed: HasError() is true
+		// with NO ERROR node anywhere in the tree, only a zero-width
+		// MISSING `integer_literal` inside the attribute's argument list
+		// (same "phantom failure" shape #559 documents for a different
+		// construct). See stdlib_Optional.swift's noncopyable-Optional
+		// initializer `@lifetime(copy value) public init(_ value:
+		// consuming Wrapped)`.
+		issue: "new: `@lifetime(copy/borrow x)` attribute argument syntax produces a phantom MISSING node",
+	},
+	"stdlib_Repeat.swift": {
+		status: swiftCorpusClean,
+	},
+	"stdlib_Stride.swift": {
+		status: swiftCorpusKnownFailing,
+		// Matches no open issue. Minimal repro:
+		//   protocol P {
+		//     associatedtype Stride: SignedNumeric, Comparable
+		//   }
+		// An associated type with more than one comma-separated
+		// conformance constraint produces an ERROR node spanning the
+		// first constraint and the comma. See stdlib_Stride.swift's
+		// `associatedtype Stride: SignedNumeric, Comparable` in the
+		// `Strideable` protocol.
+		issue: "new: associatedtype with a comma-separated multi-conformance constraint list",
+	},
+	"swift-algorithms_AdjacentPairsTests.swift": {
+		status: swiftCorpusKnownFailing,
+		// Two independent causes, per issue #561's own text: the
+		// triple-nested generic `IndexValidator<AdjacentPairsCollection<
+		// Range<Int>>>()` on line 73 (issue #559), and the `for n in
+		// 4...100 { }` loops on lines 37 and 66 each followed by another
+		// test method inside the class body (issue #561). Either one
+		// alone is sufficient to break this file.
+		issue: "#559, #561",
+	},
+	"swift-algorithms_Chunked.swift": {
+		status: swiftCorpusKnownFailing,
+		// makeOffsetIndex's nested `if let limit = limit { if baseDistance
+		// > 0 && limit == endIndex { if self.distance(from: i, to: limit)
+		// < distance { ... } } }` is the repro 2 shape #558 names
+		// verbatim for this file.
+		issue: "#558",
+	},
+	"swift-algorithms_FlattenCollection.swift": {
+		status: swiftCorpusKnownFailing,
+		// Contains the nested-if-let shape #558 describes as repro 1
+		// (`if let indexInner = index.inner { ... if let inner =
+		// element.index(...) { ... } ... }` in the index-arithmetic
+		// helpers), and #558 names this file explicitly.
+		issue: "#558",
+	},
+	"swift-algorithms_Stride.swift": {
+		status: swiftCorpusKnownFailing,
+		// offsetForward/offsetBackward's `if limit < i { if let idx =
+		// base.index(...) { ... } else { ... } } else if let idx =
+		// base.index(...) { ... }` is the exact shape #560 names for this
+		// file, at the exact function names (offsetForward,
+		// offsetBackward) #560 cites.
+		issue: "#560",
+	},
+	"swift-algorithms_Windows.swift": {
+		status: swiftCorpusKnownFailing,
+		// `index(before:)`'s `if index == endIndex { return Index(...) }
+		// else { return Index(...) }` is the verbatim repro #560 quotes
+		// for this file.
+		issue: "#560",
+	},
+}
+
+// TestSwiftCorpusManifestComplete ensures every *.swift file under
+// testdata/swift_corpus has exactly one row in swiftCorpusExpectations, and
+// that no stale rows point at files that no longer exist.
+func TestSwiftCorpusManifestComplete(t *testing.T) {
+	dir := "testdata/swift_corpus"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+
+	var onDisk []string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".swift" {
+			onDisk = append(onDisk, e.Name())
+		}
+	}
+	sort.Strings(onDisk)
+
+	var expected []string
+	for name := range swiftCorpusExpectations {
+		expected = append(expected, name)
+	}
+	sort.Strings(expected)
+
+	onDiskSet := make(map[string]bool, len(onDisk))
+	for _, name := range onDisk {
+		onDiskSet[name] = true
+	}
+	for _, name := range expected {
+		if !onDiskSet[name] {
+			t.Errorf("swiftCorpusExpectations has a row for %q, but that file does not exist under %s", name, dir)
+		}
+	}
+
+	expectedSet := make(map[string]bool, len(expected))
+	for _, name := range expected {
+		expectedSet[name] = true
+	}
+	for _, name := range onDisk {
+		if !expectedSet[name] {
+			t.Errorf("%s has no row in swiftCorpusExpectations; add one (clean or known_failing)", name)
+		}
+	}
+}
+
+// TestSwiftCorpus parses every file in grammars/testdata/swift_corpus and
+// checks the outcome against swiftCorpusExpectations. A "clean" file that
+// starts erroring is a regression. A "known_failing" file that starts
+// parsing cleanly means the underlying bug got fixed, so the test fails on
+// purpose to force the expectations table to ratchet forward.
+func TestSwiftCorpus(t *testing.T) {
+	dir := "testdata/swift_corpus"
+	lang := SwiftLanguage()
+
+	for name, exp := range swiftCorpusExpectations {
+		name, exp := name, exp
+		t.Run(name, func(t *testing.T) {
+			src, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("reading corpus file: %v", err)
+			}
+
+			parser := gotreesitter.NewParser(lang)
+			tree, err := parser.Parse(src)
+			if err != nil {
+				t.Fatalf("parsing corpus file: %v", err)
+			}
+			defer tree.Release()
+
+			root := tree.RootNode()
+			hasErr := root.HasError()
+
+			switch exp.status {
+			case swiftCorpusClean:
+				if hasErr {
+					t.Fatalf("regression: %s now reports a parse error but the expectations table marks it clean; "+
+						"first bad node: %s", name, describeFirstSwiftCorpusFailure(root, lang))
+				}
+			case swiftCorpusKnownFailing:
+				if !hasErr {
+					t.Fatalf("ratchet needed: %s now parses cleanly, but the expectations table marks it "+
+						"known_failing (%s); update its row in swiftCorpusExpectations to swiftCorpusClean", name, exp.issue)
+				}
+			default:
+				t.Fatalf("%s has an unrecognized status", name)
+			}
+		})
+	}
+}
+
+// describeFirstSwiftCorpusFailure narrows down from the root to the
+// smallest descendant whose subtree still reports an error, then returns a
+// short description of that node for failure messages.
+func describeFirstSwiftCorpusFailure(root *gotreesitter.Node, lang *gotreesitter.Language) string {
+	n := root
+	for {
+		if n.IsError() || n.IsMissing() {
+			break
+		}
+		var next *gotreesitter.Node
+		for i := 0; i < n.ChildCount(); i++ {
+			c := n.Child(i)
+			if c != nil && c.HasError() {
+				next = c
+				break
+			}
+		}
+		if next == nil {
+			break
+		}
+		n = next
+	}
+	return n.Type(lang)
+}

--- a/grammars/testdata/swift_corpus/MANIFEST.md
+++ b/grammars/testdata/swift_corpus/MANIFEST.md
@@ -1,0 +1,94 @@
+# Swift corpus manifest
+
+This corpus holds real-world Swift files for gotreesitter's Swift grammar
+tests. Each file comes from a reputable, pinned upstream source. Every file
+passes `swiftc -parse` before it enters the corpus. The validation command
+and result appear per file below.
+
+Total corpus size: 322065 bytes (about 314 KB), across 12 files.
+
+## Sources
+
+- **swiftlang/swift** at tag `swift-6.3-RELEASE` (commit
+  `aa782beb23b8bd83bd16fca831532a05dd6cea39`). The Swift language
+  implementation itself. Files come from `stdlib/public/core/`.
+- **apple/swift-algorithms** at tag `1.2.1` (commit
+  `87e50f483c54e6efd60e885f7f5aa946cee68023`), the latest release tag at
+  fetch time. Files come from `Sources/Algorithms/` and
+  `Tests/SwiftAlgorithmsTests/`. Several open gotreesitter issues (#556,
+  #558, #559, #560, #561) cite files from this repository as real-world
+  parse failures, so this corpus includes those exact files.
+
+All files carry the Apache License v2.0 with Runtime Library Exception, as
+stated in each file's own header. Headers are unmodified.
+
+## Files
+
+| File | Origin repo | Pinned ref | Upstream path | Size (bytes) | Size band |
+|---|---|---|---|---|---|
+| `stdlib_ASCII.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/ASCII.swift` | 3115 | small |
+| `stdlib_Repeat.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/Repeat.swift` | 3812 | small |
+| `swift-algorithms_AdjacentPairsTests.swift` | apple/swift-algorithms | `1.2.1` | `Tests/SwiftAlgorithmsTests/AdjacentPairsTests.swift` | 2580 | small |
+| `swift-algorithms_Stride.swift` | apple/swift-algorithms | `1.2.1` | `Sources/Algorithms/Stride.swift` | 7887 | small |
+| `swift-algorithms_FlattenCollection.swift` | apple/swift-algorithms | `1.2.1` | `Sources/Algorithms/FlattenCollection.swift` | 9196 | small |
+| `swift-algorithms_Windows.swift` | apple/swift-algorithms | `1.2.1` | `Sources/Algorithms/Windows.swift` | 11706 | medium |
+| `stdlib_CollectionAlgorithms.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/CollectionAlgorithms.swift` | 24056 | medium |
+| `stdlib_Stride.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/Stride.swift` | 26410 | medium |
+| `swift-algorithms_Chunked.swift` | apple/swift-algorithms | `1.2.1` | `Sources/Algorithms/Chunked.swift` | 27814 | medium |
+| `stdlib_Optional.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/Optional.swift` | 33867 | medium |
+| `stdlib_Collection.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/Collection.swift` | 66941 | medium-large |
+| `stdlib_FloatingPointToString.swift` | swiftlang/swift | `swift-6.3-RELEASE` | `stdlib/public/core/FloatingPointToString.swift` | 104681 | large |
+
+Note: the task brief named `stdlib/public/core/Collection.swift` as an
+example "100 KB+" file. Its actual pinned size is 66941 bytes (about 65 KB),
+so it lands in the medium-large band instead. `FloatingPointToString.swift`
+(104681 bytes) supplies the genuine 100 KB+ sample.
+
+Two files share a base name across the two source repositories
+(`Stride.swift` from stdlib and from swift-algorithms). Each carries a
+`stdlib_` or `swift-algorithms_` prefix to keep them distinct on disk.
+
+## Fetch method
+
+Every file was fetched with:
+
+```
+curl -fsSL https://raw.githubusercontent.com/<repo>/<tag>/<path> -o <name>
+```
+
+using the pinned tag for each repository, listed above.
+
+## Validation
+
+Every file was checked with:
+
+```
+swiftc -parse <file>
+```
+
+All 12 files exit 0 (no diagnostics). Run from
+`grammars/testdata/swift_corpus/`:
+
+```
+$ for f in *.swift; do swiftc -parse "$f" || echo "FAIL: $f"; done
+```
+
+reports no failures.
+
+## Why these files
+
+- The five `swift-algorithms` files match the exact real-world failure
+  sites the open issues cite:
+  - `Chunked.swift` and `FlattenCollection.swift`: issue #558 (nested
+    `if let` plus nested comparisons).
+  - `Windows.swift` and `Stride.swift` (swift-algorithms): issue #560
+    (`if`/`else` with a comparison condition and a parenthesised member
+    access in the then-branch).
+  - `AdjacentPairsTests.swift`: issues #559 (triple-nested generic type
+    arguments) and #561 (a `for...in <range>` method followed by another
+    method inside a type body).
+- The seven `stdlib` files supply size variety (3 KB to 105 KB) from
+  idiomatic, heavily-reviewed Swift, independent of the algorithms
+  repository's known failure modes. They exercise generics, protocol
+  extensions, operators, and string formatting at a scale the inline test
+  snippets cannot reach.

--- a/grammars/testdata/swift_corpus/stdlib_ASCII.swift
+++ b/grammars/testdata/swift_corpus/stdlib_ASCII.swift
@@ -1,0 +1,98 @@
+//===--- ASCII.swift ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+extension Unicode {
+  @frozen
+  public enum ASCII {}
+}
+
+extension Unicode.ASCII: Unicode.Encoding {
+  public typealias CodeUnit = UInt8
+  public typealias EncodedScalar = CollectionOfOne<CodeUnit>
+
+  @inlinable
+  public static var encodedReplacementCharacter: EncodedScalar {
+    return EncodedScalar(0x1a) // U+001A SUBSTITUTE; best we can do for ASCII
+  }
+
+  /// Returns whether the given code unit represents an ASCII scalar
+  @_alwaysEmitIntoClient
+  public static func isASCII(_ x: CodeUnit) -> Bool { return UTF8.isASCII(x) }
+
+  @inline(__always)
+  @inlinable
+  public static func _isScalar(_ x: CodeUnit) -> Bool {
+    return true
+  }
+
+  @inline(__always)
+  @inlinable
+  public static func decode(_ source: EncodedScalar) -> Unicode.Scalar {
+    return Unicode.Scalar(_unchecked: UInt32(
+        source.first._unsafelyUnwrappedUnchecked))
+  }
+  
+  @inline(__always)
+  @inlinable
+  public static func encode(
+    _ source: Unicode.Scalar
+  ) -> EncodedScalar? {
+    guard source.value < (1&<<7) else { return nil }
+    return EncodedScalar(UInt8(truncatingIfNeeded: source.value))
+  }
+
+  @inline(__always)
+  @inlinable
+  public static func transcode<FromEncoding: Unicode.Encoding>(
+    _ content: FromEncoding.EncodedScalar, from _: FromEncoding.Type
+  ) -> EncodedScalar? {
+    if _fastPath(FromEncoding.self == UTF16.self) {
+      let c = _identityCast(content, to: UTF16.EncodedScalar.self)
+      guard (c._storage & 0xFF80 == 0) else { return nil }
+      return EncodedScalar(CodeUnit(c._storage & 0x7f))
+    }
+    else if _fastPath(FromEncoding.self == UTF8.self) {
+      let c = _identityCast(content, to: UTF8.EncodedScalar.self)
+      let first = unsafe c.first.unsafelyUnwrapped
+      guard (first < 0x80) else { return nil }
+      return EncodedScalar(CodeUnit(first))
+    }
+    return encode(FromEncoding.decode(content))
+  }
+
+  @frozen
+  public struct Parser {
+    @inlinable
+    public init() { }
+  }
+  
+  public typealias ForwardParser = Parser
+  public typealias ReverseParser = Parser
+}
+
+extension Unicode.ASCII.Parser: Unicode.Parser {
+  public typealias Encoding = Unicode.ASCII
+
+  /// Parses a single Unicode scalar value from `input`.
+  @inlinable
+  public mutating func parseScalar<I: IteratorProtocol>(
+    from input: inout I
+  ) -> Unicode.ParseResult<Encoding.EncodedScalar>
+  where I.Element == Encoding.CodeUnit {
+    let n = input.next()
+    if _fastPath(n != nil), let x = n {
+      guard _fastPath(Int8(truncatingIfNeeded: x) >= 0)
+      else { return .error(length: 1) }
+      return .valid(Unicode.ASCII.EncodedScalar(x))
+    }
+    return .emptyInput
+  }
+}

--- a/grammars/testdata/swift_corpus/stdlib_Collection.swift
+++ b/grammars/testdata/swift_corpus/stdlib_Collection.swift
@@ -1,0 +1,1695 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A type that iterates over a collection using its indices.
+///
+/// The `IndexingIterator` type is the default iterator for any collection that
+/// doesn't declare its own. It acts as an iterator by using a collection's
+/// indices to step over each value in the collection. Most collections in the
+/// standard library use `IndexingIterator` as their iterator.
+///
+/// By default, any custom collection type you create will inherit a
+/// `makeIterator()` method that returns an `IndexingIterator` instance,
+/// making it unnecessary to declare your own. When creating a custom
+/// collection type, add the minimal requirements of the `Collection`
+/// protocol: starting and ending indices and a subscript for accessing
+/// elements. With those elements defined, the inherited `makeIterator()`
+/// method satisfies the requirements of the `Sequence` protocol.
+///
+/// Here's an example of a type that declares the minimal requirements for a
+/// collection. The `CollectionOfTwo` structure is a fixed-size collection
+/// that always holds two elements of a specific type.
+///
+///     struct CollectionOfTwo<Element>: Collection {
+///         let elements: (Element, Element)
+///
+///         init(_ first: Element, _ second: Element) {
+///             self.elements = (first, second)
+///         }
+///
+///         var startIndex: Int { return 0 }
+///         var endIndex: Int   { return 2 }
+///
+///         subscript(index: Int) -> Element {
+///             switch index {
+///             case 0: return elements.0
+///             case 1: return elements.1
+///             default: fatalError("Index out of bounds.")
+///             }
+///         }
+///         
+///         func index(after i: Int) -> Int {
+///             precondition(i < endIndex, "Can't advance beyond endIndex")
+///             return i + 1
+///         }
+///     }
+///
+/// Because `CollectionOfTwo` doesn't define its own `makeIterator()`
+/// method or `Iterator` associated type, it uses the default iterator type,
+/// `IndexingIterator`. This example shows how a `CollectionOfTwo` instance
+/// can be created holding the values of a point, and then iterated over
+/// using a `for`-`in` loop.
+///
+///     let point = CollectionOfTwo(15.0, 20.0)
+///     for element in point {
+///         print(element)
+///     }
+///     // Prints "15.0"
+///     // Prints "20.0"
+@frozen
+public struct IndexingIterator<Elements: Collection> {
+  @usableFromInline
+  internal let _elements: Elements
+  @usableFromInline
+  internal var _position: Elements.Index
+
+  /// Creates an iterator over the given collection.
+  @inlinable
+  @inline(__always)
+  public /// @testable
+  init(_elements: Elements) {
+    self._elements = _elements
+    self._position = _elements.startIndex
+  }
+
+  /// Creates an iterator over the given collection.
+  @inlinable
+  @inline(__always)
+  public /// @testable
+  init(_elements: Elements, _position: Elements.Index) {
+    self._elements = _elements
+    self._position = _position
+  }
+}
+
+extension IndexingIterator: IteratorProtocol, Sequence {
+  public typealias Element = Elements.Element
+  public typealias Iterator = IndexingIterator<Elements>
+  public typealias SubSequence = AnySequence<Element>
+
+  /// Advances to the next element and returns it, or `nil` if no next element
+  /// exists.
+  ///
+  /// Repeatedly calling this method returns all the elements of the underlying
+  /// sequence in order. As soon as the sequence has run out of elements, all
+  /// subsequent calls return `nil`.
+  ///
+  /// This example shows how an iterator can be used explicitly to emulate a
+  /// `for`-`in` loop. First, retrieve a sequence's iterator, and then call
+  /// the iterator's `next()` method until it returns `nil`.
+  ///
+  ///     let numbers = [2, 3, 5, 7]
+  ///     var numbersIterator = numbers.makeIterator()
+  ///
+  ///     while let num = numbersIterator.next() {
+  ///         print(num)
+  ///     }
+  ///     // Prints "2"
+  ///     // Prints "3"
+  ///     // Prints "5"
+  ///     // Prints "7"
+  ///
+  /// - Returns: The next element in the underlying sequence if a next element
+  ///   exists; otherwise, `nil`.
+  @inlinable
+  @inline(__always)
+  public mutating func next() -> Elements.Element? {
+    if _position == _elements.endIndex { return nil }
+    let element = _elements[_position]
+    _elements.formIndex(after: &_position)
+    return element
+  }
+}
+
+extension IndexingIterator: Sendable
+  where Elements: Sendable, Elements.Index: Sendable { }
+
+/// A sequence whose elements can be traversed multiple times,
+/// nondestructively, and accessed by an indexed subscript.
+///
+/// Collections are used extensively throughout the standard library. When you
+/// use arrays, dictionaries, and other collections, you benefit from the
+/// operations that the `Collection` protocol declares and implements. In
+/// addition to the operations that collections inherit from the `Sequence`
+/// protocol, you gain access to methods that depend on accessing an element
+/// at a specific position in a collection.
+///
+/// For example, if you want to print only the first word in a string, you can
+/// search for the index of the first space, and then create a substring up to
+/// that position.
+///
+///     let text = "Buffalo buffalo buffalo buffalo."
+///     if let firstSpace = text.firstIndex(of: " ") {
+///         print(text[..<firstSpace])
+///     }
+///     // Prints "Buffalo"
+///
+/// The `firstSpace` constant is an index into the `text` string---the position
+/// of the first space in the string. You can store indices in variables, and
+/// pass them to collection algorithms or use them later to access the
+/// corresponding element. In the example above, `firstSpace` is used to
+/// extract the prefix that contains elements up to that index.
+///
+/// Accessing Individual Elements
+/// =============================
+///
+/// You can access an element of a collection through its subscript by using
+/// any valid index except the collection's `endIndex` property. This property
+/// is a "past the end" index that does not correspond with any element of the
+/// collection.
+///
+/// Here's an example of accessing the first character in a string through its
+/// subscript:
+///
+///     let firstChar = text[text.startIndex]
+///     print(firstChar)
+///     // Prints "B"
+///
+/// The `Collection` protocol declares and provides default implementations for
+/// many operations that depend on elements being accessible by their
+/// subscript. For example, you can also access the first character of `text`
+/// using the `first` property, which has the value of the first element of
+/// the collection, or `nil` if the collection is empty.
+///
+///     print(text.first)
+///     // Prints "Optional("B")"
+///
+/// You can pass only valid indices to collection operations. You can find a
+/// complete set of a collection's valid indices by starting with the
+/// collection's `startIndex` property and finding every successor up to, and
+/// including, the `endIndex` property. All other values of the `Index` type,
+/// such as the `startIndex` property of a different collection, are invalid
+/// indices for this collection.
+///
+/// Saved indices may become invalid as a result of mutating operations. For
+/// more information about index invalidation in mutable collections, see the
+/// reference for the `MutableCollection` and `RangeReplaceableCollection`
+/// protocols, as well as for the specific type you're using.
+///
+/// Accessing Slices of a Collection
+/// ================================
+///
+/// You can access a slice of a collection through its ranged subscript or by
+/// calling methods like `prefix(while:)` or `suffix(_:)`. A slice of a
+/// collection can contain zero or more of the original collection's elements
+/// and shares the original collection's semantics.
+///
+/// The following example creates a `firstWord` constant by using the
+/// `prefix(while:)` method to get a slice of the `text` string.
+///
+///     let firstWord = text.prefix(while: { $0 != " " })
+///     print(firstWord)
+///     // Prints "Buffalo"
+///
+/// You can retrieve the same slice using the string's ranged subscript, which
+/// takes a range expression.
+///
+///     if let firstSpace = text.firstIndex(of: " ") {
+///         print(text[..<firstSpace])
+///         // Prints "Buffalo"
+///     }
+///
+/// The retrieved slice of `text` is equivalent in each of these cases.
+///
+/// Slices Share Indices
+/// --------------------
+///
+/// A collection and its slices share the same indices. An element of a
+/// collection is located under the same index in a slice as in the base
+/// collection, as long as neither the collection nor the slice has been
+/// mutated since the slice was created.
+///
+/// For example, suppose you have an array holding the number of absences from
+/// each class during a session.
+///
+///     var absences = [0, 2, 0, 4, 0, 3, 1, 0]
+///
+/// You're tasked with finding the day with the most absences in the second
+/// half of the session. To find the index of the day in question, follow
+/// these steps:
+///
+/// 1) Create a slice of the `absences` array that holds the second half of the
+///    days.
+/// 2) Use the `max(by:)` method to determine the index of the day with the
+///    most absences.
+/// 3) Print the result using the index found in step 2 on the original
+///    `absences` array.
+///
+/// Here's an implementation of those steps:
+///
+///     let secondHalf = absences.suffix(absences.count / 2)
+///     if let i = secondHalf.indices.max(by: { secondHalf[$0] < secondHalf[$1] }) {
+///         print("Highest second-half absences: \(absences[i])")
+///     }
+///     // Prints "Highest second-half absences: 3"
+///
+/// Slices Inherit Collection Semantics
+/// -----------------------------------
+///
+/// A slice inherits the value or reference semantics of its base collection.
+/// That is, when working with a slice of a mutable collection that has value
+/// semantics, such as an array, mutating the original collection triggers a
+/// copy of that collection and does not affect the contents of the slice.
+///
+/// For example, if you update the last element of the `absences` array from
+/// `0` to `2`, the `secondHalf` slice is unchanged.
+///
+///     absences[7] = 2
+///     print(absences)
+///     // Prints "[0, 2, 0, 4, 0, 3, 1, 2]"
+///     print(secondHalf)
+///     // Prints "[0, 3, 1, 0]"
+///
+/// Traversing a Collection
+/// =======================
+///
+/// Although a sequence can be consumed as it is traversed, a collection is
+/// guaranteed to be *multipass*: Any element can be repeatedly accessed by
+/// saving its index. Moreover, a collection's indices form a finite range of
+/// the positions of the collection's elements. The fact that all collections
+/// are finite guarantees the safety of many sequence operations, such as
+/// using the `contains(_:)` method to test whether a collection includes an
+/// element.
+///
+/// Iterating over the elements of a collection by their positions yields the
+/// same elements in the same order as iterating over that collection using
+/// its iterator. This example demonstrates that the `characters` view of a
+/// string returns the same characters in the same order whether the view's
+/// indices or the view itself is being iterated.
+///
+///     let word = "Swift"
+///     for character in word {
+///         print(character)
+///     }
+///     // Prints "S"
+///     // Prints "w"
+///     // Prints "i"
+///     // Prints "f"
+///     // Prints "t"
+///
+///     for i in word.indices {
+///         print(word[i])
+///     }
+///     // Prints "S"
+///     // Prints "w"
+///     // Prints "i"
+///     // Prints "f"
+///     // Prints "t"
+///
+/// Conforming to the Collection Protocol
+/// =====================================
+///
+/// If you create a custom sequence that can provide repeated access to its
+/// elements, make sure that its type conforms to the `Collection` protocol in
+/// order to give a more useful and more efficient interface for sequence and
+/// collection operations. To add `Collection` conformance to your type, you
+/// must declare at least the following requirements:
+///
+/// - The `startIndex` and `endIndex` properties
+/// - A subscript that provides at least read-only access to your type's
+///   elements
+/// - The `index(after:)` method for advancing an index into your collection
+///
+/// Expected Performance
+/// ====================
+///
+/// Types that conform to `Collection` are expected to provide the `startIndex`
+/// and `endIndex` properties and subscript access to elements as O(1)
+/// operations. Types that are not able to guarantee this performance must
+/// document the departure, because many collection operations depend on O(1)
+/// subscripting performance for their own performance guarantees.
+///
+/// The performance of some collection operations depends on the type of index
+/// that the collection provides. For example, a random-access collection,
+/// which can measure the distance between two indices in O(1) time, can
+/// calculate its `count` property in O(1) time. Conversely, because a forward
+/// or bidirectional collection must traverse the entire collection to count
+/// the number of contained elements, accessing its `count` property is an
+/// O(*n*) operation.
+public protocol Collection<Element>: Sequence {
+  // FIXME: ideally this would be in MigrationSupport.swift, but it needs
+  // to be on the protocol instead of as an extension
+  @available(*, deprecated/*, obsoleted: 5.0*/, message: "all index distances are now of type Int")
+  typealias IndexDistance = Int  
+
+  // FIXME: Associated type inference requires this.
+  override associatedtype Element
+
+  // FIXME: <rdar://problem/34142121>
+  // This typealias should be removed as it predates the source compatibility
+  // guarantees of Swift 3, but it cannot due to a bug.
+  @available(swift, deprecated: 3.2, obsoleted: 5.0, renamed: "Element")
+  typealias _Element = Element
+
+  /// A type that represents a position in the collection.
+  ///
+  /// Valid indices consist of the position of every element and a
+  /// "past the end" position that's not valid for use as a subscript
+  /// argument.
+  associatedtype Index: Comparable
+
+  /// The position of the first element in a nonempty collection.
+  ///
+  /// If the collection is empty, `startIndex` is equal to `endIndex`.
+  var startIndex: Index { get }
+ 
+  /// The collection's "past the end" position---that is, the position one
+  /// greater than the last valid subscript argument.
+  ///
+  /// When you need a range that includes the last element of a collection, use
+  /// the half-open range operator (`..<`) with `endIndex`. The `..<` operator
+  /// creates a range that doesn't include the upper bound, so it's always
+  /// safe to use with `endIndex`. For example:
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50]
+  ///     if let index = numbers.firstIndex(of: 30) {
+  ///         print(numbers[index ..< numbers.endIndex])
+  ///     }
+  ///     // Prints "[30, 40, 50]"
+  ///
+  /// If the collection is empty, `endIndex` is equal to `startIndex`.
+  var endIndex: Index { get }
+
+  /// A type that provides the collection's iteration interface and
+  /// encapsulates its iteration state.
+  ///
+  /// By default, a collection conforms to the `Sequence` protocol by
+  /// supplying `IndexingIterator` as its associated `Iterator`
+  /// type.
+  associatedtype Iterator = IndexingIterator<Self>
+
+  // FIXME: Only needed for associated type inference. Otherwise,
+  // we get an `IndexingIterator` rather than properly deducing the
+  // Iterator type from makeIterator(). <rdar://problem/21539115>
+  /// Returns an iterator over the elements of the collection.
+  override __consuming func makeIterator() -> Iterator
+
+  /// A collection representing a contiguous subrange of this collection's
+  /// elements. The subsequence shares indices with the original collection.
+  ///
+  /// The default subsequence type for collections that don't define their own
+  /// is `Slice`.
+  associatedtype SubSequence: Collection = Slice<Self>
+  where SubSequence.Index == Index,
+        Element == SubSequence.Element,
+        SubSequence.SubSequence == SubSequence
+
+  /// Accesses the element at the specified position.
+  ///
+  /// The following example accesses an element of an array through its
+  /// subscript to print its value:
+  ///
+  ///     var streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
+  ///     print(streets[1])
+  ///     // Prints "Bryant"
+  ///
+  /// You can subscript a collection with any valid index other than the
+  /// collection's end index. The end index refers to the position one past
+  /// the last element of a collection, so it doesn't correspond with an
+  /// element.
+  ///
+  /// - Parameter position: The position of the element to access. `position`
+  ///   must be a valid index of the collection that is not equal to the
+  ///   `endIndex` property.
+  ///
+  /// - Complexity: O(1)
+  @_borrowed
+  subscript(position: Index) -> Element { get }
+
+  /// Accesses a contiguous subrange of the collection's elements.
+  ///
+  /// For example, using a `PartialRangeFrom` range expression with an array
+  /// accesses the subrange from the start of the range expression until the
+  /// end of the array.
+  ///
+  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
+  ///     let streetsSlice = streets[2..<5]
+  ///     print(streetsSlice)
+  ///     // ["Channing", "Douglas", "Evarts"]
+  ///
+  /// The accessed slice uses the same indices for the same elements as the
+  /// original collection. This example searches `streetsSlice` for one of the
+  /// strings in the slice, and then uses that index in the original array.
+  ///
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")!    // 4
+  ///     print(streets[index])
+  ///     // "Evarts"
+  ///
+  /// Always use the slice's `startIndex` property instead of assuming that its
+  /// indices start at a particular value. Attempting to access an element by
+  /// using an index outside the bounds of the slice may result in a runtime
+  /// error, even if that index is valid for the original collection.
+  ///
+  ///     print(streetsSlice.startIndex)
+  ///     // 2
+  ///     print(streetsSlice[2])
+  ///     // "Channing"
+  ///
+  ///     print(streetsSlice[0])
+  ///     // error: Index out of bounds
+  ///
+  /// - Parameter bounds: A range of the collection's indices. The bounds of
+  ///   the range must be valid indices of the collection.
+  ///
+  /// - Complexity: O(1)
+  subscript(bounds: Range<Index>) -> SubSequence { get }
+
+  /// A type that represents the indices that are valid for subscripting the
+  /// collection, in ascending order.
+  associatedtype Indices: Collection = DefaultIndices<Self>
+    where Indices.Element == Index, 
+          Indices.Index == Index,
+          Indices.SubSequence == Indices
+        
+  /// The indices that are valid for subscripting the collection, in ascending
+  /// order.
+  ///
+  /// A collection's `indices` property can hold a strong reference to the
+  /// collection itself, causing the collection to be nonuniquely referenced.
+  /// If you mutate the collection while iterating over its indices, a strong
+  /// reference can result in an unexpected copy of the collection. To avoid
+  /// the unexpected copy, use the `index(after:)` method starting with
+  /// `startIndex` to produce indices instead.
+  ///
+  ///     var c = MyFancyCollection([10, 20, 30, 40, 50])
+  ///     var i = c.startIndex
+  ///     while i != c.endIndex {
+  ///         c[i] /= 5
+  ///         i = c.index(after: i)
+  ///     }
+  ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
+  var indices: Indices { get }
+
+  /// A Boolean value indicating whether the collection is empty.
+  ///
+  /// When you need to check whether your collection is empty, use the
+  /// `isEmpty` property instead of checking that the `count` property is
+  /// equal to zero. For collections that don't conform to
+  /// `RandomAccessCollection`, accessing the `count` property iterates
+  /// through the elements of the collection.
+  ///
+  ///     let horseName = "Silver"
+  ///     if horseName.isEmpty {
+  ///         print("My horse has no name.")
+  ///     } else {
+  ///         print("Hi ho, \(horseName)!")
+  ///     }
+  ///     // Prints "Hi ho, Silver!"
+  ///
+  /// - Complexity: O(1)
+  var isEmpty: Bool { get }
+
+  /// The number of elements in the collection.
+  ///
+  /// To check whether a collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Unless the collection guarantees
+  /// random-access performance, calculating `count` can be an O(*n*)
+  /// operation.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
+  ///   of the collection.
+  var count: Int { get }
+  
+  // The following requirements enable dispatching for firstIndex(of:) and
+  // lastIndex(of:) when the element type is Equatable.
+
+  /// Returns `Optional(Optional(index))` if an element was found
+  /// or `Optional(nil)` if an element was determined to be missing;
+  /// otherwise, `nil`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  func _customIndexOfEquatableElement(_ element: Element) -> Index??
+
+  /// Customization point for `Collection.lastIndex(of:)`.
+  ///
+  /// Define this method if the collection can find an element in less than
+  /// O(*n*) by exploiting collection-specific knowledge.
+  ///
+  /// - Returns: `nil` if a linear search should be attempted instead,
+  ///   `Optional(nil)` if the element was not found, or
+  ///   `Optional(Optional(index))` if an element was found.
+  ///
+  /// - Complexity: Hopefully less than O(`count`).
+  func _customLastIndexOfEquatableElement(_ element: Element) -> Index??
+
+  /// Returns an index that is the specified distance from the given index.
+  ///
+  /// The following example obtains an index advanced four positions from a
+  /// string's starting index and then prints the character at that position.
+  ///
+  ///     let s = "Swift"
+  ///     let i = s.index(s.startIndex, offsetBy: 4)
+  ///     print(s[i])
+  ///     // Prints "t"
+  ///
+  /// The value passed as `distance` must not offset `i` beyond the bounds of
+  /// the collection.
+  ///
+  /// - Parameters:
+  ///   - i: A valid index of the collection.
+  ///   - distance: The distance to offset `i`. `distance` must not be negative
+  ///     unless the collection conforms to the `BidirectionalCollection`
+  ///     protocol.
+  /// - Returns: An index offset by `distance` from the index `i`. If
+  ///   `distance` is positive, this is the same value as the result of
+  ///   `distance` calls to `index(after:)`. If `distance` is negative, this
+  ///   is the same value as the result of `abs(distance)` calls to
+  ///   `index(before:)`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
+  func index(_ i: Index, offsetBy distance: Int) -> Index
+
+  /// Returns an index that is the specified distance from the given index,
+  /// unless that distance is beyond a given limiting index.
+  ///
+  /// The following example obtains an index advanced four positions from a
+  /// string's starting index and then prints the character at that position.
+  /// The operation doesn't require going beyond the limiting `s.endIndex`
+  /// value, so it succeeds.
+  ///
+  ///     let s = "Swift"
+  ///     if let i = s.index(s.startIndex, offsetBy: 4, limitedBy: s.endIndex) {
+  ///         print(s[i])
+  ///     }
+  ///     // Prints "t"
+  ///
+  /// The next example attempts to retrieve an index six positions from
+  /// `s.startIndex` but fails, because that distance is beyond the index
+  /// passed as `limit`.
+  ///
+  ///     let j = s.index(s.startIndex, offsetBy: 6, limitedBy: s.endIndex)
+  ///     print(j)
+  ///     // Prints "nil"
+  ///
+  /// The value passed as `distance` must not offset `i` beyond the bounds of
+  /// the collection, unless the index passed as `limit` prevents offsetting
+  /// beyond those bounds.
+  ///
+  /// - Parameters:
+  ///   - i: A valid index of the collection.
+  ///   - distance: The distance to offset `i`. `distance` must not be negative
+  ///     unless the collection conforms to the `BidirectionalCollection`
+  ///     protocol.
+  ///   - limit: A valid index of the collection to use as a limit. If
+  ///     `distance > 0`, a limit that is less than `i` has no effect.
+  ///     Likewise, if `distance < 0`, a limit that is greater than `i` has no
+  ///     effect.
+  /// - Returns: An index offset by `distance` from the index `i`, unless that
+  ///   index would be beyond `limit` in the direction of movement. In that
+  ///   case, the method returns `nil`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
+  func index(
+    _ i: Index, offsetBy distance: Int, limitedBy limit: Index
+  ) -> Index?
+
+  /// Returns the distance between two indices.
+  ///
+  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
+  /// `start` must be less than or equal to `end`.
+  ///
+  /// - Parameters:
+  ///   - start: A valid index of the collection.
+  ///   - end: Another valid index of the collection. If `end` is equal to
+  ///     `start`, the result is zero.
+  /// - Returns: The distance between `start` and `end`. The result can be
+  ///   negative only if the collection conforms to the
+  ///   `BidirectionalCollection` protocol.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the
+  ///   resulting distance.
+  func distance(from start: Index, to end: Index) -> Int
+
+  /// Performs a range check in O(1), or a no-op when a range check is not
+  /// implementable in O(1).
+  ///
+  /// The range check, if performed, is equivalent to:
+  ///
+  ///     precondition(bounds.contains(index))
+  ///
+  /// Use this function to perform a cheap range check for QoI purposes when
+  /// memory safety is not a concern.  Do not rely on this range check for
+  /// memory safety.
+  ///
+  /// The default implementation for forward and bidirectional indices is a
+  /// no-op.  The default implementation for random access indices performs a
+  /// range check.
+  ///
+  /// - Complexity: O(1).
+  func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>)
+
+  func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>)
+
+  /// Performs a range check in O(1), or a no-op when a range check is not
+  /// implementable in O(1).
+  ///
+  /// The range check, if performed, is equivalent to:
+  ///
+  ///     precondition(
+  ///       bounds.contains(range.lowerBound) ||
+  ///       range.lowerBound == bounds.upperBound)
+  ///     precondition(
+  ///       bounds.contains(range.upperBound) ||
+  ///       range.upperBound == bounds.upperBound)
+  ///
+  /// Use this function to perform a cheap range check for QoI purposes when
+  /// memory safety is not a concern.  Do not rely on this range check for
+  /// memory safety.
+  ///
+  /// The default implementation for forward and bidirectional indices is a
+  /// no-op.  The default implementation for random access indices performs a
+  /// range check.
+  ///
+  /// - Complexity: O(1).
+  func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>)
+
+  /// Returns the position immediately after the given index.
+  ///
+  /// The successor of an index must be well defined. For an index `i` into a
+  /// collection `c`, calling `c.index(after: i)` returns the same index every
+  /// time.
+  ///
+  /// - Parameter i: A valid index of the collection. `i` must be less than
+  ///   `endIndex`.
+  /// - Returns: The index value immediately after `i`.
+  func index(after i: Index) -> Index
+
+  /// Replaces the given index with its successor.
+  ///
+  /// - Parameter i: A valid index of the collection. `i` must be less than
+  ///   `endIndex`.
+  func formIndex(after i: inout Index)
+}
+
+/// Default implementation for forward collections.
+extension Collection {
+  /// Replaces the given index with its successor.
+  ///
+  /// - Parameter i: A valid index of the collection. `i` must be less than
+  ///   `endIndex`.
+  @inlinable // protocol-only
+  @inline(__always)
+  public func formIndex(after i: inout Index) {
+    i = index(after: i)
+  }
+
+  @inlinable
+  public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
+    // FIXME: swift-3-indexing-model: tests.
+    _precondition(
+      bounds.lowerBound <= index && index < bounds.upperBound,
+      "Index out of bounds")
+  }
+
+  @inlinable
+  public func _failEarlyRangeCheck(_ index: Index, bounds: ClosedRange<Index>) {
+    // FIXME: swift-3-indexing-model: tests.
+    _precondition(
+      bounds.lowerBound <= index && index <= bounds.upperBound,
+      "Index out of bounds")
+  }
+
+  @inlinable
+  public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
+    // FIXME: swift-3-indexing-model: tests.
+    _precondition(
+      bounds.lowerBound <= range.lowerBound &&
+      range.upperBound <= bounds.upperBound,
+      "Range out of bounds")
+  }
+
+  /// Returns an index that is the specified distance from the given index.
+  ///
+  /// The following example obtains an index advanced four positions from a
+  /// string's starting index and then prints the character at that position.
+  ///
+  ///     let s = "Swift"
+  ///     let i = s.index(s.startIndex, offsetBy: 4)
+  ///     print(s[i])
+  ///     // Prints "t"
+  ///
+  /// The value passed as `distance` must not offset `i` beyond the bounds of
+  /// the collection.
+  ///
+  /// - Parameters:
+  ///   - i: A valid index of the collection.
+  ///   - distance: The distance to offset `i`. `distance` must not be negative
+  ///     unless the collection conforms to the `BidirectionalCollection`
+  ///     protocol.
+  /// - Returns: An index offset by `distance` from the index `i`. If
+  ///   `distance` is positive, this is the same value as the result of
+  ///   `distance` calls to `index(after:)`. If `distance` is negative, this
+  ///   is the same value as the result of `abs(distance)` calls to
+  ///   `index(before:)`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    return self._advanceForward(i, by: distance)
+  }
+
+  /// Returns an index that is the specified distance from the given index,
+  /// unless that distance is beyond a given limiting index.
+  ///
+  /// The following example obtains an index advanced four positions from a
+  /// string's starting index and then prints the character at that position.
+  /// The operation doesn't require going beyond the limiting `s.endIndex`
+  /// value, so it succeeds.
+  ///
+  ///     let s = "Swift"
+  ///     if let i = s.index(s.startIndex, offsetBy: 4, limitedBy: s.endIndex) {
+  ///         print(s[i])
+  ///     }
+  ///     // Prints "t"
+  ///
+  /// The next example attempts to retrieve an index six positions from
+  /// `s.startIndex` but fails, because that distance is beyond the index
+  /// passed as `limit`.
+  ///
+  ///     let j = s.index(s.startIndex, offsetBy: 6, limitedBy: s.endIndex)
+  ///     print(j)
+  ///     // Prints "nil"
+  ///
+  /// The value passed as `distance` must not offset `i` beyond the bounds of
+  /// the collection, unless the index passed as `limit` prevents offsetting
+  /// beyond those bounds.
+  ///
+  /// - Parameters:
+  ///   - i: A valid index of the collection.
+  ///   - distance: The distance to offset `i`. `distance` must not be negative
+  ///     unless the collection conforms to the `BidirectionalCollection`
+  ///     protocol.
+  ///   - limit: A valid index of the collection to use as a limit. If
+  ///     `distance > 0`, a limit that is less than `i` has no effect.
+  ///     Likewise, if `distance < 0`, a limit that is greater than `i` has no
+  ///     effect.
+  /// - Returns: An index offset by `distance` from the index `i`, unless that
+  ///   index would be beyond `limit` in the direction of movement. In that
+  ///   case, the method returns `nil`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
+  @inlinable
+  public func index(
+    _ i: Index, offsetBy distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    return self._advanceForward(i, by: distance, limitedBy: limit)
+  }
+
+  /// Offsets the given index by the specified distance.
+  ///
+  /// The value passed as `distance` must not offset `i` beyond the bounds of
+  /// the collection.
+  ///
+  /// - Parameters:
+  ///   - i: A valid index of the collection.
+  ///   - distance: The distance to offset `i`. `distance` must not be negative
+  ///     unless the collection conforms to the `BidirectionalCollection`
+  ///     protocol.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
+  @inlinable
+  public func formIndex(_ i: inout Index, offsetBy distance: Int) {
+    i = index(i, offsetBy: distance)
+  }
+
+  /// Offsets the given index by the specified distance, or so that it equals
+  /// the given limiting index.
+  ///
+  /// The value passed as `distance` must not offset `i` beyond the bounds of
+  /// the collection, unless the index passed as `limit` prevents offsetting
+  /// beyond those bounds.
+  ///
+  /// - Parameters:
+  ///   - i: A valid index of the collection.
+  ///   - distance: The distance to offset `i`. `distance` must not be negative
+  ///     unless the collection conforms to the `BidirectionalCollection`
+  ///     protocol.
+  ///   - limit: A valid index of the collection to use as a limit. If
+  ///     `distance > 0`, a limit that is less than `i` has no effect.
+  ///     Likewise, if `distance < 0`, a limit that is greater than `i` has no
+  ///     effect.
+  /// - Returns: `true` if `i` has been offset by exactly `distance` steps
+  ///   without going beyond `limit`; otherwise, `false`. When the return
+  ///   value is `false`, the value of `i` is equal to `limit`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the absolute
+  ///   value of `distance`.
+  @inlinable
+  public func formIndex(
+    _ i: inout Index, offsetBy distance: Int, limitedBy limit: Index
+  ) -> Bool {
+    if let advancedIndex = index(i, offsetBy: distance, limitedBy: limit) {
+      i = advancedIndex
+      return true
+    }
+    i = limit
+    return false
+  }
+
+  /// Returns the distance between two indices.
+  ///
+  /// Unless the collection conforms to the `BidirectionalCollection` protocol,
+  /// `start` must be less than or equal to `end`.
+  ///
+  /// - Parameters:
+  ///   - start: A valid index of the collection.
+  ///   - end: Another valid index of the collection. If `end` is equal to
+  ///     `start`, the result is zero.
+  /// - Returns: The distance between `start` and `end`. The result can be
+  ///   negative only if the collection conforms to the
+  ///   `BidirectionalCollection` protocol.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the
+  ///   resulting distance.
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    _precondition(start <= end,
+      "Only BidirectionalCollections can have end come before start")
+
+    var start = start
+    var count = 0
+    while start != end {
+      count = count + 1
+      formIndex(after: &start)
+    }
+    return count
+  }
+
+  /// Returns a random element of the collection, using the given generator as
+  /// a source for randomness.
+  ///
+  /// Call `randomElement(using:)` to select a random element from an array or
+  /// another collection when you are using a custom random number generator.
+  /// This example picks a name at random from an array:
+  ///
+  ///     let names = ["Zoey", "Chloe", "Amani", "Amaia"]
+  ///     let randomName = names.randomElement(using: &myGenerator)!
+  ///     // randomName == "Amani"
+  ///
+  /// - Parameter generator: The random number generator to use when choosing a
+  ///   random element.
+  /// - Returns: A random element from the collection. If the collection is
+  ///   empty, the method returns `nil`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
+  ///   of the collection.
+  /// - Note: The algorithm used to select a random element may change in a
+  ///   future version of Swift. If you're passing a generator that results in
+  ///   the same sequence of elements each time you run your program, that
+  ///   sequence may change when your program is compiled using a different
+  ///   version of Swift.
+  @inlinable
+  public func randomElement<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> Element? {
+    guard !isEmpty else { return nil }
+    let random = Int.random(in: 0 ..< count, using: &generator)
+    let idx = index(startIndex, offsetBy: random)
+    return self[idx]
+  }
+
+  /// Returns a random element of the collection.
+  ///
+  /// Call `randomElement()` to select a random element from an array or
+  /// another collection. This example picks a name at random from an array:
+  ///
+  ///     let names = ["Zoey", "Chloe", "Amani", "Amaia"]
+  ///     let randomName = names.randomElement()!
+  ///     // randomName == "Amani"
+  ///
+  /// This method is equivalent to calling `randomElement(using:)`, passing in
+  /// the system's default random generator.
+  ///
+  /// - Returns: A random element from the collection. If the collection is
+  ///   empty, the method returns `nil`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
+  ///   of the collection.
+  @inlinable
+  public func randomElement() -> Element? {
+    var g = SystemRandomNumberGenerator()
+    return randomElement(using: &g)
+  }
+
+  /// Do not use this method directly; call advanced(by: n) instead.
+  @inlinable
+  @inline(__always)
+  internal func _advanceForward(_ i: Index, by n: Int) -> Index {
+    _precondition(n >= 0,
+      "Only BidirectionalCollections can be advanced by a negative amount")
+
+    var i = i
+    for _ in stride(from: 0, to: n, by: 1) {
+      formIndex(after: &i)
+    }
+    return i
+  }
+
+  /// Do not use this method directly; call advanced(by: n, limit) instead.
+  @inlinable
+  @inline(__always)
+  internal func _advanceForward(
+    _ i: Index, by n: Int, limitedBy limit: Index
+  ) -> Index? {
+    _precondition(n >= 0,
+      "Only BidirectionalCollections can be advanced by a negative amount")
+
+    var i = i
+    for _ in stride(from: 0, to: n, by: 1) {
+      if i == limit {
+        return nil
+      }
+      formIndex(after: &i)
+    }
+    return i
+  }
+}
+
+/// Supply the default `makeIterator()` method for `Collection` models
+/// that accept the default associated `Iterator`,
+/// `IndexingIterator<Self>`.
+extension Collection where Iterator == IndexingIterator<Self> {
+  /// Returns an iterator over the elements of the collection.
+  @inlinable // trivial-implementation
+  @inline(__always)
+  public __consuming func makeIterator() -> IndexingIterator<Self> {
+    return IndexingIterator(_elements: self)
+  }
+}
+
+/// Supply the default "slicing" `subscript` for `Collection` models
+/// that accept the default associated `SubSequence`, `Slice<Self>`.
+extension Collection where SubSequence == Slice<Self> {
+  /// Accesses a contiguous subrange of the collection's elements.
+  ///
+  /// The accessed slice uses the same indices for the same elements as the
+  /// original collection. Always use the slice's `startIndex` property
+  /// instead of assuming that its indices start at a particular value.
+  ///
+  /// This example demonstrates getting a slice of an array of strings, finding
+  /// the index of one of the strings in the slice, and then using that index
+  /// in the original array.
+  ///
+  ///     let streets = ["Adams", "Bryant", "Channing", "Douglas", "Evarts"]
+  ///     let streetsSlice = streets[2 ..< streets.endIndex]
+  ///     print(streetsSlice)
+  ///     // Prints "["Channing", "Douglas", "Evarts"]"
+  ///
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
+  ///     print(streets[index!])
+  ///     // Prints "Evarts"
+  ///
+  /// - Parameter bounds: A range of the collection's indices. The bounds of
+  ///   the range must be valid indices of the collection.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public subscript(bounds: Range<Index>) -> Slice<Self> {
+    _failEarlyRangeCheck(bounds, bounds: startIndex..<endIndex)
+    return Slice(base: self, bounds: bounds)
+  }
+}
+
+extension Collection {
+  // This unavailable default implementation of `subscript(bounds: Range<_>)`
+  // prevents incomplete Collection implementations from satisfying the
+  // protocol through the use of the generic convenience implementation
+  // `subscript<R: RangeExpression>(r: R)`. If that were the case, at
+  // runtime the generic implementation would call itself
+  // in an infinite recursion because of the absence of a better option.
+  @available(*, unavailable)
+  @_alwaysEmitIntoClient
+  public subscript(bounds: Range<Index>) -> SubSequence { fatalError() }
+}
+
+extension Collection where SubSequence == Self {
+  /// Removes and returns the first element of the collection.
+  ///
+  /// - Returns: The first element of the collection if the collection is
+  ///   not empty; otherwise, `nil`.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public mutating func popFirst() -> Element? {
+    // TODO: swift-3-indexing-model - review the following
+    guard !isEmpty else { return nil }
+    let element = first!
+    self = self[index(after: startIndex)..<endIndex]
+    return element
+  }
+}
+
+/// Default implementations of core requirements
+extension Collection {
+  /// A Boolean value indicating whether the collection is empty.
+  ///
+  /// When you need to check whether your collection is empty, use the
+  /// `isEmpty` property instead of checking that the `count` property is
+  /// equal to zero. For collections that don't conform to
+  /// `RandomAccessCollection`, accessing the `count` property iterates
+  /// through the elements of the collection.
+  ///
+  ///     let horseName = "Silver"
+  ///     if horseName.isEmpty {
+  ///         print("My horse has no name.")
+  ///     } else {
+  ///         print("Hi ho, \(horseName)!")
+  ///     }
+  ///     // Prints "Hi ho, Silver!")
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public var isEmpty: Bool {
+    return startIndex == endIndex
+  }
+
+  /// The first element of the collection.
+  ///
+  /// If the collection is empty, the value of this property is `nil`.
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50]
+  ///     if let firstNumber = numbers.first {
+  ///         print(firstNumber)
+  ///     }
+  ///     // Prints "10"
+  @inlinable
+  public var first: Element? {
+    let start = startIndex
+    if start != endIndex { return self[start] }
+    else { return nil }
+  }
+
+  /// A value less than or equal to the number of elements in the collection.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
+  ///   of the collection.
+  @inlinable
+  public var underestimatedCount: Int {
+    // TODO: swift-3-indexing-model - review the following
+    return count
+  }
+
+  /// The number of elements in the collection.
+  ///
+  /// To check whether a collection is empty, use its `isEmpty` property
+  /// instead of comparing `count` to zero. Unless the collection guarantees
+  /// random-access performance, calculating `count` can be an O(*n*)
+  /// operation.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
+  ///   of the collection.
+  @inlinable
+  public var count: Int {
+    return distance(from: startIndex, to: endIndex)
+  }
+
+  // TODO: swift-3-indexing-model - rename the following to _customIndexOfEquatable(element)?
+  /// Customization point for `Collection.firstIndex(of:)`.
+  ///
+  /// Define this method if the collection can find an element in less than
+  /// O(*n*) by exploiting collection-specific knowledge.
+  ///
+  /// - Returns: `nil` if a linear search should be attempted instead,
+  ///   `Optional(nil)` if the element was not found, or
+  ///   `Optional(Optional(index))` if an element was found.
+  ///
+  /// - Complexity: Hopefully less than O(`count`).
+  @inlinable
+  @inline(__always)
+  public // dispatching
+  func _customIndexOfEquatableElement(_: Element) -> Index?? {
+    return nil
+  }
+
+  /// Customization point for `Collection.lastIndex(of:)`.
+  ///
+  /// Define this method if the collection can find an element in less than
+  /// O(*n*) by exploiting collection-specific knowledge.
+  ///
+  /// - Returns: `nil` if a linear search should be attempted instead,
+  ///   `Optional(nil)` if the element was not found, or
+  ///   `Optional(Optional(index))` if an element was found.
+  ///
+  /// - Complexity: Hopefully less than O(`count`).
+  @inlinable
+  @inline(__always)
+  public // dispatching
+  func _customLastIndexOfEquatableElement(_ element: Element) -> Index?? {
+    return nil
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Default implementations for Collection
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns an array containing the results of mapping the given closure
+  /// over the sequence's elements.
+  ///
+  /// In this example, `map` is used first to convert the names in the array
+  /// to lowercase strings and then to count their characters.
+  ///
+  ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
+  ///     let lowercaseNames = cast.map { $0.lowercased() }
+  ///     // 'lowercaseNames' == ["vivien", "marlon", "kim", "karl"]
+  ///     let letterCounts = cast.map { $0.count }
+  ///     // 'letterCounts' == [6, 6, 3, 4]
+  ///
+  /// - Parameter transform: A mapping closure. `transform` accepts an
+  ///   element of this sequence as its parameter and returns a transformed
+  ///   value of the same or of a different type.
+  /// - Returns: An array containing the transformed elements of this
+  ///   sequence.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func map<T, E>(
+    _ transform: (Element) throws(E) -> T
+  ) throws(E) -> [T] {
+    // TODO: swift-3-indexing-model - review the following
+    let n = self.count
+    if n == 0 {
+      return []
+    }
+
+    var result = ContiguousArray<T>()
+    result.reserveCapacity(n)
+
+    var i = self.startIndex
+
+    for _ in 0..<n {
+      result.append(try transform(self[i]))
+      formIndex(after: &i)
+    }
+
+    _expectEnd(of: self, is: i)
+    return Array(result)
+  }
+
+#if !$Embedded
+  // ABI-only entrypoint for the rethrows version of map, which has been
+  // superseded by the typed-throws version. Expressed as "throws", which is
+  // ABI-compatible with "rethrows".
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  @_silgen_name("$sSlsE3mapySayqd__Gqd__7ElementQzKXEKlF")
+  func __rethrows_map<T>(
+    _ transform: (Element) throws -> T
+  ) throws -> [T] {
+    try map(transform)
+  }
+#endif
+
+  /// Returns a subsequence containing all but the given number of initial
+  /// elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in
+  /// the collection, the result is an empty subsequence.
+  ///
+  ///     let numbers = [1, 2, 3, 4, 5]
+  ///     print(numbers.dropFirst(2))
+  ///     // Prints "[3, 4, 5]"
+  ///     print(numbers.dropFirst(10))
+  ///     // Prints "[]"
+  ///
+  /// - Parameter k: The number of elements to drop from the beginning of
+  ///   the collection. `k` must be greater than or equal to zero.
+  /// - Returns: A subsequence starting after the specified number of
+  ///   elements.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the number of
+  ///   elements to drop from the beginning of the collection.
+  @inlinable
+  public __consuming func dropFirst(_ k: Int = 1) -> SubSequence {
+    _precondition(k >= 0, "Can't drop a negative number of elements from a collection")
+    let start = index(startIndex, offsetBy: k, limitedBy: endIndex) ?? endIndex
+    return self[start..<endIndex]
+  }
+
+  /// Returns a subsequence containing all but the specified number of final
+  /// elements.
+  ///
+  /// If the number of elements to drop exceeds the number of elements in the
+  /// collection, the result is an empty subsequence.
+  ///
+  ///     let numbers = [1, 2, 3, 4, 5]
+  ///     print(numbers.dropLast(2))
+  ///     // Prints "[1, 2, 3]"
+  ///     print(numbers.dropLast(10))
+  ///     // Prints "[]"
+  ///
+  /// - Parameter k: The number of elements to drop off the end of the
+  ///   collection. `k` must be greater than or equal to zero.
+  /// - Returns: A subsequence that leaves off the specified number of elements
+  ///   at the end.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length of
+  ///   the collection.
+  @inlinable
+  public __consuming func dropLast(_ k: Int = 1) -> SubSequence {
+    _precondition(
+      k >= 0, "Can't drop a negative number of elements from a collection")
+    let amount = Swift.max(0, count - k)
+    let end = index(startIndex,
+      offsetBy: amount, limitedBy: endIndex) ?? endIndex
+    return self[startIndex..<end]
+  }
+    
+  /// Returns a subsequence by skipping elements while `predicate` returns
+  /// `true` and returning the remaining elements.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the
+  ///   sequence as its argument and returns `true` if the element should
+  ///   be skipped or `false` if it should be included. Once the predicate
+  ///   returns `false` it will not be called again.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public __consuming func drop(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> SubSequence {
+    var start = startIndex
+    while try start != endIndex && predicate(self[start]) {
+      formIndex(after: &start)
+    } 
+    return self[start..<endIndex]
+  }
+
+  /// Returns a subsequence, up to the specified maximum length, containing
+  /// the initial elements of the collection.
+  ///
+  /// If the maximum length exceeds the number of elements in the collection,
+  /// the result contains all the elements in the collection.
+  ///
+  ///     let numbers = [1, 2, 3, 4, 5]
+  ///     print(numbers.prefix(2))
+  ///     // Prints "[1, 2]"
+  ///     print(numbers.prefix(10))
+  ///     // Prints "[1, 2, 3, 4, 5]"
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return.
+  ///   `maxLength` must be greater than or equal to zero.
+  /// - Returns: A subsequence starting at the beginning of this collection
+  ///   with at most `maxLength` elements.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the number of
+  ///   elements to select from the beginning of the collection.
+  @inlinable
+  public __consuming func prefix(_ maxLength: Int) -> SubSequence {
+    _precondition(
+      maxLength >= 0,
+      "Can't take a prefix of negative length from a collection")
+    let end = index(startIndex,
+      offsetBy: maxLength, limitedBy: endIndex) ?? endIndex
+    return self[startIndex..<end]
+  }
+  
+  /// Returns a subsequence containing the initial elements until `predicate`
+  /// returns `false` and skipping the remaining elements.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the
+  ///   sequence as its argument and returns `true` if the element should
+  ///   be included or `false` if it should be excluded. Once the predicate
+  ///   returns `false` it will not be called again.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public __consuming func prefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> SubSequence {
+    var end = startIndex
+    while try end != endIndex && predicate(self[end]) {
+      formIndex(after: &end)
+    }
+    return self[startIndex..<end]
+  }
+
+  /// Returns a subsequence, up to the given maximum length, containing the
+  /// final elements of the collection.
+  ///
+  /// If the maximum length exceeds the number of elements in the collection,
+  /// the result contains all the elements in the collection.
+  ///
+  ///     let numbers = [1, 2, 3, 4, 5]
+  ///     print(numbers.suffix(2))
+  ///     // Prints "[4, 5]"
+  ///     print(numbers.suffix(10))
+  ///     // Prints "[1, 2, 3, 4, 5]"
+  ///
+  /// - Parameter maxLength: The maximum number of elements to return. The
+  ///   value of `maxLength` must be greater than or equal to zero.
+  /// - Returns: A subsequence terminating at the end of the collection with at
+  ///   most `maxLength` elements.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length of
+  ///   the collection.
+  @inlinable
+  public __consuming func suffix(_ maxLength: Int) -> SubSequence {
+    _precondition(
+      maxLength >= 0,
+      "Can't take a suffix of negative length from a collection")
+    let amount = Swift.max(0, count - maxLength)
+    let start = index(startIndex,
+      offsetBy: amount, limitedBy: endIndex) ?? endIndex
+    return self[start..<endIndex]
+  }
+
+  /// Returns a subsequence from the start of the collection up to, but not
+  /// including, the specified position.
+  ///
+  /// The resulting subsequence *does not include* the element at the position
+  /// `end`. The following example searches for the index of the number `40`
+  /// in an array of integers, and then prints the prefix of the array up to,
+  /// but not including, that index:
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50, 60]
+  ///     if let i = numbers.firstIndex(of: 40) {
+  ///         print(numbers.prefix(upTo: i))
+  ///     }
+  ///     // Prints "[10, 20, 30]"
+  ///
+  /// Passing the collection's starting index as the `end` parameter results in
+  /// an empty subsequence.
+  ///
+  ///     print(numbers.prefix(upTo: numbers.startIndex))
+  ///     // Prints "[]"
+  ///
+  /// Using the `prefix(upTo:)` method is equivalent to using a partial
+  /// half-open range as the collection's subscript. The subscript notation is
+  /// preferred over `prefix(upTo:)`.
+  ///
+  ///     if let i = numbers.firstIndex(of: 40) {
+  ///         print(numbers[..<i])
+  ///     }
+  ///     // Prints "[10, 20, 30]"
+  ///
+  /// - Parameter end: The "past the end" index of the resulting subsequence.
+  ///   `end` must be a valid index of the collection.
+  /// - Returns: A subsequence up to, but not including, the `end` position.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public __consuming func prefix(upTo end: Index) -> SubSequence {
+    return self[startIndex..<end]
+  }
+
+  /// Returns a subsequence from the specified position to the end of the
+  /// collection.
+  ///
+  /// The following example searches for the index of the number `40` in an
+  /// array of integers, and then prints the suffix of the array starting at
+  /// that index:
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50, 60]
+  ///     if let i = numbers.firstIndex(of: 40) {
+  ///         print(numbers.suffix(from: i))
+  ///     }
+  ///     // Prints "[40, 50, 60]"
+  ///
+  /// Passing the collection's `endIndex` as the `start` parameter results in
+  /// an empty subsequence.
+  ///
+  ///     print(numbers.suffix(from: numbers.endIndex))
+  ///     // Prints "[]"
+  ///
+  /// Using the `suffix(from:)` method is equivalent to using a partial range
+  /// from the index as the collection's subscript. The subscript notation is
+  /// preferred over `suffix(from:)`.
+  ///
+  ///     if let i = numbers.firstIndex(of: 40) {
+  ///         print(numbers[i...])
+  ///     }
+  ///     // Prints "[40, 50, 60]"
+  ///
+  /// - Parameter start: The index at which to start the resulting subsequence.
+  ///   `start` must be a valid index of the collection.
+  /// - Returns: A subsequence starting at the `start` position.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public __consuming func suffix(from start: Index) -> SubSequence {
+    return self[start..<endIndex]
+  }
+
+  /// Returns a subsequence from the start of the collection through the
+  /// specified position.
+  ///
+  /// The resulting subsequence *includes* the element at the position
+  /// specified by the `through` parameter.
+  /// The following example searches for the index of the number `40` in an
+  /// array of integers, and then prints the prefix of the array up to, and
+  /// including, that index:
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50, 60]
+  ///     if let i = numbers.firstIndex(of: 40) {
+  ///         print(numbers.prefix(through: i))
+  ///     }
+  ///     // Prints "[10, 20, 30, 40]"
+  ///
+  /// Using the `prefix(through:)` method is equivalent to using a partial
+  /// closed range as the collection's subscript. The subscript notation is
+  /// preferred over `prefix(through:)`.
+  ///
+  ///     if let i = numbers.firstIndex(of: 40) {
+  ///         print(numbers[...i])
+  ///     }
+  ///     // Prints "[10, 20, 30, 40]"
+  ///
+  /// - Parameter position: The index of the last element to include in the
+  ///   resulting subsequence. `position` must be a valid index of the collection
+  ///   that is not equal to the `endIndex` property.
+  /// - Returns: A subsequence up to, and including, the given position.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public __consuming func prefix(through position: Index) -> SubSequence {
+    return prefix(upTo: index(after: position))
+  }
+
+  /// Returns the longest possible subsequences of the collection, in order,
+  /// that don't contain elements satisfying the given predicate.
+  ///
+  /// The resulting array consists of at most `maxSplits + 1` subsequences.
+  /// Elements that are used to split the sequence are not returned as part of
+  /// any subsequence.
+  ///
+  /// The following examples show the effects of the `maxSplits` and
+  /// `omittingEmptySubsequences` parameters when splitting a string using a
+  /// closure that matches spaces. The first use of `split` returns each word
+  /// that was originally separated by one or more spaces.
+  ///
+  ///     let line = "BLANCHE:   I don't want realism. I want magic!"
+  ///     print(line.split(whereSeparator: { $0 == " " }))
+  ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
+  ///
+  /// The second example passes `1` for the `maxSplits` parameter, so the
+  /// original string is split just once, into two new strings.
+  ///
+  ///     print(line.split(maxSplits: 1, whereSeparator: { $0 == " " }))
+  ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
+  ///
+  /// The final example passes `false` for the `omittingEmptySubsequences`
+  /// parameter, so the returned array contains empty strings where spaces
+  /// were repeated.
+  ///
+  ///     print(line.split(omittingEmptySubsequences: false, whereSeparator: { $0 == " " }))
+  ///     // Prints "["BLANCHE:", "", "", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
+  ///
+  /// - Parameters:
+  ///   - maxSplits: The maximum number of times to split the collection, or
+  ///     one less than the number of subsequences to return. If
+  ///     `maxSplits + 1` subsequences are returned, the last one is a suffix
+  ///     of the original collection containing the remaining elements.
+  ///     `maxSplits` must be greater than or equal to zero. The default value
+  ///     is `Int.max`.
+  ///   - omittingEmptySubsequences: If `false`, an empty subsequence is
+  ///     returned in the result for each pair of consecutive elements
+  ///     satisfying the `isSeparator` predicate and for each element at the
+  ///     start or end of the collection satisfying the `isSeparator`
+  ///     predicate. The default value is `true`.
+  ///   - isSeparator: A closure that takes an element as an argument and
+  ///     returns a Boolean value indicating whether the collection should be
+  ///     split at that element.
+  /// - Returns: An array of subsequences, split from this collection's
+  ///   elements.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public __consuming func split(
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true,
+    whereSeparator isSeparator: (Element) throws -> Bool
+  ) rethrows -> [SubSequence] {
+    // TODO: swift-3-indexing-model - review the following
+    _precondition(maxSplits >= 0, "Must take zero or more splits")
+
+    var result: [SubSequence] = []
+    var subSequenceStart: Index = startIndex
+
+    func appendSubsequence(end: Index) -> Bool {
+      if subSequenceStart == end && omittingEmptySubsequences {
+        return false
+      }
+      result.append(self[subSequenceStart..<end])
+      return true
+    }
+
+    if maxSplits == 0 || isEmpty {
+      _ = appendSubsequence(end: endIndex)
+      return result
+    }
+
+    var subSequenceEnd = subSequenceStart
+    let cachedEndIndex = endIndex
+    while subSequenceEnd != cachedEndIndex {
+      if try isSeparator(self[subSequenceEnd]) {
+        let didAppend = appendSubsequence(end: subSequenceEnd)
+        formIndex(after: &subSequenceEnd)
+        subSequenceStart = subSequenceEnd
+        if didAppend && result.count == maxSplits {
+          break
+        }
+        continue
+      }
+      formIndex(after: &subSequenceEnd)
+    }
+
+    if subSequenceStart != cachedEndIndex || !omittingEmptySubsequences {
+      result.append(self[subSequenceStart..<cachedEndIndex])
+    }
+
+    return result
+  }
+}
+
+extension Collection where Element: Equatable {
+  /// Returns the longest possible subsequences of the collection, in order,
+  /// around elements equal to the given element.
+  ///
+  /// The resulting array consists of at most `maxSplits + 1` subsequences.
+  /// Elements that are used to split the collection are not returned as part
+  /// of any subsequence.
+  ///
+  /// The following examples show the effects of the `maxSplits` and
+  /// `omittingEmptySubsequences` parameters when splitting a string at each
+  /// space character (" "). The first use of `split` returns each word that
+  /// was originally separated by one or more spaces.
+  ///
+  ///     let line = "BLANCHE:   I don't want realism. I want magic!"
+  ///     print(line.split(separator: " "))
+  ///     // Prints "["BLANCHE:", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
+  ///
+  /// The second example passes `1` for the `maxSplits` parameter, so the
+  /// original string is split just once, into two new strings.
+  ///
+  ///     print(line.split(separator: " ", maxSplits: 1))
+  ///     // Prints "["BLANCHE:", "  I don\'t want realism. I want magic!"]"
+  ///
+  /// The final example passes `false` for the `omittingEmptySubsequences`
+  /// parameter, so the returned array contains empty strings where spaces
+  /// were repeated.
+  ///
+  ///     print(line.split(separator: " ", omittingEmptySubsequences: false))
+  ///     // Prints "["BLANCHE:", "", "", "I", "don\'t", "want", "realism.", "I", "want", "magic!"]"
+  ///
+  /// - Parameters:
+  ///   - separator: The element that should be split upon.
+  ///   - maxSplits: The maximum number of times to split the collection, or
+  ///     one less than the number of subsequences to return. If
+  ///     `maxSplits + 1` subsequences are returned, the last one is a suffix
+  ///     of the original collection containing the remaining elements.
+  ///     `maxSplits` must be greater than or equal to zero. The default value
+  ///     is `Int.max`.
+  ///   - omittingEmptySubsequences: If `false`, an empty subsequence is
+  ///     returned in the result for each consecutive pair of `separator`
+  ///     elements in the collection and for each instance of `separator` at
+  ///     the start or end of the collection. If `true`, only nonempty
+  ///     subsequences are returned. The default value is `true`.
+  /// - Returns: An array of subsequences, split from this collection's
+  ///   elements.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public __consuming func split(
+    separator: Element,
+    maxSplits: Int = Int.max,
+    omittingEmptySubsequences: Bool = true
+  ) -> [SubSequence] {
+    // TODO: swift-3-indexing-model - review the following
+    return split(
+      maxSplits: maxSplits,
+      omittingEmptySubsequences: omittingEmptySubsequences,
+      whereSeparator: { $0 == separator })
+  }
+}
+
+extension Collection where SubSequence == Self {
+  /// Removes and returns the first element of the collection.
+  ///
+  /// The collection must not be empty.
+  ///
+  /// - Returns: The first element of the collection.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @discardableResult
+  public mutating func removeFirst() -> Element {
+    // TODO: swift-3-indexing-model - review the following
+    _precondition(!isEmpty, "Can't remove items from an empty collection")
+    let element = first!
+    self = self[index(after: startIndex)..<endIndex]
+    return element
+  }
+
+  /// Removes the specified number of elements from the beginning of the
+  /// collection.
+  ///
+  /// - Parameter k: The number of elements to remove. `k` must be greater than
+  ///   or equal to zero, and must be less than or equal to the number of
+  ///   elements in the collection.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the specified
+  ///   number of elements.
+  @inlinable
+  public mutating func removeFirst(_ k: Int) {
+    if k == 0 { return }
+    _precondition(k >= 0, "Number of elements to remove should be non-negative")
+    guard let idx = index(startIndex, offsetBy: k, limitedBy: endIndex) else {
+      _preconditionFailure(
+        "Can't remove more items from a collection than it contains")
+    }
+    self = self[idx..<endIndex]
+  }
+}

--- a/grammars/testdata/swift_corpus/stdlib_CollectionAlgorithms.swift
+++ b/grammars/testdata/swift_corpus/stdlib_CollectionAlgorithms.swift
@@ -1,0 +1,637 @@
+//===--- CollectionAlgorithms.swift ---------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// last
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection {
+  /// The last element of the collection.
+  ///
+  /// If the collection is empty, the value of this property is `nil`.
+  ///
+  ///     let numbers = [10, 20, 30, 40, 50]
+  ///     if let lastNumber = numbers.last {
+  ///         print(lastNumber)
+  ///     }
+  ///     // Prints "50"
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  public var last: Element? {
+    return isEmpty ? nil : self[index(before: endIndex)]
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// firstIndex(of:)/firstIndex(where:)
+//===----------------------------------------------------------------------===//
+
+extension Collection where Element: Equatable {
+  /// Returns the first index where the specified value appears in the
+  /// collection.
+  ///
+  /// After using `firstIndex(of:)` to find the position of a particular element
+  /// in a collection, you can use it to access the element by subscripting.
+  /// This example shows how you can modify one of the names in an array of
+  /// students.
+  ///
+  ///     var students = ["Ben", "Ivy", "Jordell", "Maxime"]
+  ///     if let i = students.firstIndex(of: "Maxime") {
+  ///         students[i] = "Max"
+  ///     }
+  ///     print(students)
+  ///     // Prints "["Ben", "Ivy", "Jordell", "Max"]"
+  ///
+  /// - Parameter element: An element to search for in the collection.
+  /// - Returns: The first index where `element` is found. If `element` is not
+  ///   found in the collection, returns `nil`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func firstIndex(of element: Element) -> Index? {
+    if let result = _customIndexOfEquatableElement(element) {
+      return result
+    }
+
+    var i = self.startIndex
+    while i != self.endIndex {
+      if self[i] == element {
+        return i
+      }
+      self.formIndex(after: &i)
+    }
+    return nil
+  }
+}
+
+extension Collection {
+  /// Returns the first index in which an element of the collection satisfies
+  /// the given predicate.
+  ///
+  /// You can use the predicate to find an element of a type that doesn't
+  /// conform to the `Equatable` protocol or to find an element that matches
+  /// particular criteria. Here's an example that finds a student name that
+  /// begins with the letter "A":
+  ///
+  ///     let students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
+  ///     if let i = students.firstIndex(where: { $0.hasPrefix("A") }) {
+  ///         print("\(students[i]) starts with 'A'!")
+  ///     }
+  ///     // Prints "Abena starts with 'A'!"
+  ///
+  /// - Parameter predicate: A closure that takes an element as its argument
+  ///   and returns a Boolean value that indicates whether the passed element
+  ///   represents a match.
+  /// - Returns: The index of the first element for which `predicate` returns
+  ///   `true`. If no elements in the collection satisfy the given predicate,
+  ///   returns `nil`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func firstIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    var i = self.startIndex
+    while i != self.endIndex {
+      if try predicate(self[i]) {
+        return i
+      }
+      self.formIndex(after: &i)
+    }
+    return nil
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// lastIndex(of:)/lastIndex(where:)
+//===----------------------------------------------------------------------===//
+
+extension BidirectionalCollection {
+  /// Returns the last element of the sequence that satisfies the given
+  /// predicate.
+  ///
+  /// This example uses the `last(where:)` method to find the last
+  /// negative number in an array of integers:
+  ///
+  ///     let numbers = [3, 7, 4, -2, 9, -6, 10, 1]
+  ///     if let lastNegative = numbers.last(where: { $0 < 0 }) {
+  ///         print("The last negative number is \(lastNegative).")
+  ///     }
+  ///     // Prints "The last negative number is -6."
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence as
+  ///   its argument and returns a Boolean value indicating whether the
+  ///   element is a match.
+  /// - Returns: The last element of the sequence that satisfies `predicate`,
+  ///   or `nil` if there is no element that satisfies `predicate`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func last(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Element? {
+    return try lastIndex(where: predicate).map { self[$0] }
+  }
+
+  /// Returns the index of the last element in the collection that matches the
+  /// given predicate.
+  ///
+  /// You can use the predicate to find an element of a type that doesn't
+  /// conform to the `Equatable` protocol or to find an element that matches
+  /// particular criteria. This example finds the index of the last name that
+  /// begins with the letter *A:*
+  ///
+  ///     let students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
+  ///     if let i = students.lastIndex(where: { $0.hasPrefix("A") }) {
+  ///         print("\(students[i]) starts with 'A'!")
+  ///     }
+  ///     // Prints "Akosua starts with 'A'!"
+  ///
+  /// - Parameter predicate: A closure that takes an element as its argument
+  ///   and returns a Boolean value that indicates whether the passed element
+  ///   represents a match.
+  /// - Returns: The index of the last element in the collection that matches
+  ///   `predicate`, or `nil` if no elements match.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func lastIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    var i = endIndex
+    while i != startIndex {
+      formIndex(before: &i)
+      if try predicate(self[i]) {
+        return i
+      }
+    }
+    return nil
+  }
+}
+
+extension BidirectionalCollection where Element: Equatable {
+  /// Returns the last index where the specified value appears in the
+  /// collection.
+  ///
+  /// After using `lastIndex(of:)` to find the position of the last instance of
+  /// a particular element in a collection, you can use it to access the
+  /// element by subscripting. This example shows how you can modify one of
+  /// the names in an array of students.
+  ///
+  ///     var students = ["Ben", "Ivy", "Jordell", "Ben", "Maxime"]
+  ///     if let i = students.lastIndex(of: "Ben") {
+  ///         students[i] = "Benjamin"
+  ///     }
+  ///     print(students)
+  ///     // Prints "["Ben", "Ivy", "Jordell", "Benjamin", "Max"]"
+  ///
+  /// - Parameter element: An element to search for in the collection.
+  /// - Returns: The last index where `element` is found. If `element` is not
+  ///   found in the collection, this method returns `nil`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func lastIndex(of element: Element) -> Index? {
+    if let result = _customLastIndexOfEquatableElement(element) {
+      return result
+    }
+    return lastIndex(where: { $0 == element })
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// indices(where:) / indices(of:)
+//===----------------------------------------------------------------------===//
+
+#if !$Embedded
+extension Collection {
+  /// Returns the indices of all the elements that match the given predicate.
+  ///
+  /// For example, you can use this method to find all the places that a
+  /// vowel occurs in a string.
+  ///
+  ///     let str = "Fresh cheese in a breeze"
+  ///     let vowels: Set<Character> = ["a", "e", "i", "o", "u"]
+  ///     let allTheVowels = str.indices(where: { vowels.contains($0) })
+  ///     // str[allTheVowels].count == 9
+  ///
+  /// - Parameter predicate: A closure that takes an element as its argument
+  ///   and returns a Boolean value that indicates whether the passed element
+  ///   represents a match.
+  /// - Returns: A set of the indices of the elements for which `predicate`
+  ///   returns `true`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @available(SwiftStdlib 6.0, *)
+  @inlinable
+  public func indices(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> RangeSet<Index> {
+    var result: [Range<Index>] = []
+    var end = startIndex
+    while let begin = try self[end...].firstIndex(where: predicate) {
+      end = try self[begin...].prefix(while: predicate).endIndex
+      result.append(begin ..< end)
+
+      guard end < self.endIndex else {
+        break
+      }
+      self.formIndex(after: &end)
+    }
+
+    return RangeSet(_orderedRanges: result)
+  }
+}
+
+extension Collection where Element: Equatable {
+  /// Returns the indices of all the elements that are equal to the given
+  /// element.
+  ///
+  /// For example, you can use this method to find all the places that a
+  /// particular letter occurs in a string.
+  ///
+  ///     let str = "Fresh cheese in a breeze"
+  ///     let allTheEs = str.indices(of: "e")
+  ///     // str[allTheEs].count == 7
+  ///
+  /// - Parameter element: An element to look for in the collection.
+  /// - Returns: A set of the indices of the elements that are equal to
+  ///   `element`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @available(SwiftStdlib 6.0, *)
+  @inlinable
+  public func indices(of element: Element) -> RangeSet<Index> {
+    indices(where: { $0 == element })
+  }
+}
+#endif
+
+//===----------------------------------------------------------------------===//
+// partition(by:)
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection {
+  /// Reorders the elements of the collection such that all the elements
+  /// that match the given predicate are after all the elements that don't
+  /// match.
+  ///
+  /// After partitioning a collection, there is a pivot index `p` where
+  /// no element before `p` satisfies the `belongsInSecondPartition`
+  /// predicate and every element at or after `p` satisfies
+  /// `belongsInSecondPartition`. This operation isn't guaranteed to be
+  /// stable, so the relative ordering of elements within the partitions might
+  /// change.
+  ///
+  /// In the following example, an array of numbers is partitioned by a
+  /// predicate that matches elements greater than 30.
+  ///
+  ///     var numbers = [30, 40, 20, 30, 30, 60, 10]
+  ///     let p = numbers.partition(by: { $0 > 30 })
+  ///     // p == 5
+  ///     // numbers == [30, 10, 20, 30, 30, 60, 40]
+  ///
+  /// The `numbers` array is now arranged in two partitions. The first
+  /// partition, `numbers[..<p]`, is made up of the elements that
+  /// are not greater than 30. The second partition, `numbers[p...]`,
+  /// is made up of the elements that *are* greater than 30.
+  ///
+  ///     let first = numbers[..<p]
+  ///     // first == [30, 10, 20, 30, 30]
+  ///     let second = numbers[p...]
+  ///     // second == [60, 40]
+  ///
+  /// Note that the order of elements in both partitions changed.
+  /// That is, `40` appears before `60` in the original collection,
+  /// but, after calling `partition(by:)`, `60` appears before `40`.
+  ///
+  /// - Parameter belongsInSecondPartition: A predicate used to partition
+  ///   the collection. All elements satisfying this predicate are ordered
+  ///   after all elements not satisfying it.
+  /// - Returns: The index of the first element in the reordered collection
+  ///   that matches `belongsInSecondPartition`. If no elements in the
+  ///   collection match `belongsInSecondPartition`, the returned index is
+  ///   equal to the collection's `endIndex`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public mutating func partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index {
+    return try _halfStablePartition(isSuffixElement: belongsInSecondPartition)
+  }
+
+  /// Moves all elements satisfying `isSuffixElement` into a suffix of the
+  /// collection, returning the start position of the resulting suffix.
+  ///
+  /// - Complexity: O(*n*) where n is the length of the collection.
+  @inlinable
+  internal mutating func _halfStablePartition(
+    isSuffixElement: (Element) throws -> Bool
+  ) rethrows -> Index {
+    guard var i = try firstIndex(where: isSuffixElement)
+    else { return endIndex }
+    
+    var j = index(after: i)
+    while j != endIndex {
+      if try !isSuffixElement(self[j]) { swapAt(i, j); formIndex(after: &i) }
+      formIndex(after: &j)
+    }
+    return i
+  }  
+}
+
+extension MutableCollection where Self: BidirectionalCollection {
+  /// Reorders the elements of the collection such that all the elements
+  /// that match the given predicate are after all the elements that don't
+  /// match.
+  ///
+  /// After partitioning a collection, there is a pivot index `p` where
+  /// no element before `p` satisfies the `belongsInSecondPartition`
+  /// predicate and every element at or after `p` satisfies
+  /// `belongsInSecondPartition`. This operation isn't guaranteed to be
+  /// stable, so the relative ordering of elements within the partitions might
+  /// change.
+  ///
+  /// In the following example, an array of numbers is partitioned by a
+  /// predicate that matches elements greater than 30.
+  ///
+  ///     var numbers = [30, 40, 20, 30, 30, 60, 10]
+  ///     let p = numbers.partition(by: { $0 > 30 })
+  ///     // p == 5
+  ///     // numbers == [30, 10, 20, 30, 30, 60, 40]
+  ///
+  /// The `numbers` array is now arranged in two partitions. The first
+  /// partition, `numbers[..<p]`, is made up of the elements that
+  /// are not greater than 30. The second partition, `numbers[p...]`,
+  /// is made up of the elements that *are* greater than 30.
+  ///
+  ///     let first = numbers[..<p]
+  ///     // first == [30, 10, 20, 30, 30]
+  ///     let second = numbers[p...]
+  ///     // second == [60, 40]
+  ///
+  /// Note that the order of elements in both partitions changed.
+  /// That is, `40` appears before `60` in the original collection,
+  /// but, after calling `partition(by:)`, `60` appears before `40`.
+  ///
+  /// - Parameter belongsInSecondPartition: A predicate used to partition
+  ///   the collection. All elements satisfying this predicate are ordered
+  ///   after all elements not satisfying it.
+  /// - Returns: The index of the first element in the reordered collection
+  ///   that matches `belongsInSecondPartition`. If no elements in the
+  ///   collection match `belongsInSecondPartition`, the returned index is
+  ///   equal to the collection's `endIndex`.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public mutating func partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index {
+    let maybeOffset = try unsafe withContiguousMutableStorageIfAvailable {
+      (bufferPointer) -> Int in
+      let unsafeBufferPivot = try unsafe bufferPointer._partitionImpl(
+        by: belongsInSecondPartition)
+      return unsafeBufferPivot - bufferPointer.startIndex
+    }
+    if let offset = maybeOffset {
+      return index(startIndex, offsetBy: offset)
+    } else {
+      return try _partitionImpl(by: belongsInSecondPartition)
+    }
+  }
+
+  @inlinable
+  internal mutating func _partitionImpl(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var lo = startIndex
+    var hi = endIndex
+    while true {
+      // Invariants at this point:
+      //
+      // * `lo <= hi`
+      // * all elements in `startIndex ..< lo` belong in the first partition
+      // * all elements in `hi ..< endIndex` belong in the second partition
+
+      // Find next element from `lo` that may not be in the right place.
+      while true {
+        guard lo < hi else { return lo }
+        if try belongsInSecondPartition(self[lo]) { break }
+        formIndex(after: &lo)
+      }
+
+      // Find next element down from `hi` that we can swap `lo` with.
+      while true {
+        formIndex(before: &hi)
+        guard lo < hi else { return lo }
+        if try !belongsInSecondPartition(self[hi]) { break }
+      }
+
+      swapAt(lo, hi)
+      formIndex(after: &lo)
+    }
+    fatalError()
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// _indexedStablePartition / _partitioningIndex
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection {
+  /// Moves all elements at the indices satisfying `belongsInSecondPartition`
+  /// into a suffix of the collection, preserving their relative order, and
+  /// returns the start of the resulting suffix.
+  ///
+  /// - Complexity: O(*n* log *n*) where *n* is the number of elements.
+  /// - Precondition:
+  ///   `n == distance(from: range.lowerBound, to: range.upperBound)`
+  internal mutating func _indexedStablePartition(
+    count n: Int,
+    range: Range<Index>,
+    by belongsInSecondPartition: (Index) throws-> Bool
+  ) rethrows -> Index {
+    if n == 0 { return range.lowerBound }
+    if n == 1 {
+      return try belongsInSecondPartition(range.lowerBound)
+        ? range.lowerBound
+        : range.upperBound
+    }
+    let h = n / 2, i = index(range.lowerBound, offsetBy: h)
+    let j = try _indexedStablePartition(
+      count: h,
+      range: range.lowerBound..<i,
+      by: belongsInSecondPartition)
+    let k = try _indexedStablePartition(
+      count: n - h,
+      range: i..<range.upperBound,
+      by: belongsInSecondPartition)
+    return _rotate(in: j..<k, shiftingToStart: i)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// _partitioningIndex(where:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns the index of the first element in the collection that matches
+  /// the predicate.
+  ///
+  /// The collection must already be partitioned according to the predicate.
+  /// That is, there should be an index `i` where for every element in
+  /// `collection[..<i]` the predicate is `false`, and for every element
+  /// in `collection[i...]` the predicate is `true`.
+  ///
+  /// - Parameter predicate: A predicate that partitions the collection.
+  /// - Returns: The index of the first element in the collection for which
+  ///   `predicate` returns `true`.
+  ///
+  /// - Complexity: O(log *n*), where *n* is the length of this collection if
+  ///   the collection conforms to `RandomAccessCollection`, otherwise O(*n*).
+  internal func _partitioningIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var n = count
+    var l = startIndex
+    
+    while n > 0 {
+      let half = n / 2
+      let mid = index(l, offsetBy: half)
+      if try predicate(self[mid]) {
+        n = half
+      } else {
+        l = index(after: mid)
+        n -= half + 1
+      }
+    }
+    return l
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// shuffled()/shuffle()
+//===----------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Returns the elements of the sequence, shuffled using the given generator
+  /// as a source for randomness.
+  ///
+  /// You use this method to randomize the elements of a sequence when you are
+  /// using a custom random number generator. For example, you can shuffle the
+  /// numbers between `0` and `9` by calling the `shuffled(using:)` method on
+  /// that range:
+  ///
+  ///     let numbers = 0...9
+  ///     let shuffledNumbers = numbers.shuffled(using: &myGenerator)
+  ///     // shuffledNumbers == [8, 9, 4, 3, 2, 6, 7, 0, 5, 1]
+  ///
+  /// - Parameter generator: The random number generator to use when shuffling
+  ///   the sequence.
+  /// - Returns: An array of this sequence's elements in a shuffled order.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the sequence.
+  /// - Note: The algorithm used to shuffle a sequence may change in a future
+  ///   version of Swift. If you're passing a generator that results in the
+  ///   same shuffled order each time you run your program, that sequence may
+  ///   change when your program is compiled using a different version of
+  ///   Swift.
+  @inlinable
+  public func shuffled<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) -> [Element] {
+    var result = ContiguousArray(self)
+    result.shuffle(using: &generator)
+    return Array(result)
+  }
+  
+  /// Returns the elements of the sequence, shuffled.
+  ///
+  /// For example, you can shuffle the numbers between `0` and `9` by calling
+  /// the `shuffled()` method on that range:
+  ///
+  ///     let numbers = 0...9
+  ///     let shuffledNumbers = numbers.shuffled()
+  ///     // shuffledNumbers == [1, 7, 6, 2, 8, 9, 4, 3, 5, 0]
+  ///
+  /// This method is equivalent to calling `shuffled(using:)`, passing in the
+  /// system's default random generator.
+  ///
+  /// - Returns: A shuffled array of this sequence's elements.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the sequence.
+  @inlinable
+  public func shuffled() -> [Element] {
+    var g = SystemRandomNumberGenerator()
+    return shuffled(using: &g)
+  }
+}
+
+extension MutableCollection where Self: RandomAccessCollection {
+  /// Shuffles the collection in place, using the given generator as a source
+  /// for randomness.
+  ///
+  /// You use this method to randomize the elements of a collection when you
+  /// are using a custom random number generator. For example, you can use the
+  /// `shuffle(using:)` method to randomly reorder the elements of an array.
+  ///
+  ///     var names = ["Alejandro", "Camila", "Diego", "Luciana", "Luis", "Sofía"]
+  ///     names.shuffle(using: &myGenerator)
+  ///     // names == ["Sofía", "Alejandro", "Camila", "Luis", "Diego", "Luciana"]
+  ///
+  /// - Parameter generator: The random number generator to use when shuffling
+  ///   the collection.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  /// - Note: The algorithm used to shuffle a collection may change in a future
+  ///   version of Swift. If you're passing a generator that results in the
+  ///   same shuffled order each time you run your program, that sequence may
+  ///   change when your program is compiled using a different version of
+  ///   Swift.
+  @inlinable
+  public mutating func shuffle<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) {
+    guard count > 1 else { return }
+    var amount = count
+    var currentIndex = startIndex
+    while amount > 1 {
+      let random = Int.random(in: 0 ..< amount, using: &generator)
+      amount -= 1
+      swapAt(
+        currentIndex,
+        index(currentIndex, offsetBy: random)
+      )
+      formIndex(after: &currentIndex)
+    }
+  }
+  
+  /// Shuffles the collection in place.
+  ///
+  /// Use the `shuffle()` method to randomly reorder the elements of an array.
+  ///
+  ///     var names = ["Alejandro", "Camila", "Diego", "Luciana", "Luis", "Sofía"]
+  ///     names.shuffle()
+  ///     // names == ["Luis", "Camila", "Luciana", "Sofía", "Alejandro", "Diego"]
+  ///
+  /// This method is equivalent to calling `shuffle(using:)`, passing in the
+  /// system's default random generator.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public mutating func shuffle() {
+    var g = SystemRandomNumberGenerator()
+    shuffle(using: &g)
+  }
+}

--- a/grammars/testdata/swift_corpus/stdlib_FloatingPointToString.swift
+++ b/grammars/testdata/swift_corpus/stdlib_FloatingPointToString.swift
@@ -1,0 +1,2571 @@
+//===--- FloatingPointToString.swift -------------------------*- Swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===---------------------------------------------------------------------===//
+//
+// Converts floating-point types to "optimal" text formats.
+//
+// The "optimal" form is one with a minimum number of significant
+// digits which will parse to exactly the original value.  This form
+// is ideal for JSON serialization and general printing where you
+// don't have specific requirements on the number of significant
+// digits.
+//
+//===---------------------------------------------------------------------===//
+///
+/// For binary16, this code uses a simple approach that is normally
+/// implemented with variable-length arithmetic.  However, due to the
+/// limited range of binary16, this can be implemented with only
+/// 32-bit integer arithmetic.
+///
+/// For other formats, we use a modified form of the Grisu2
+/// algorithm from Florian Loitsch; "Printing Floating-Point Numbers
+/// Quickly and Accurately with Integers", 2010.
+/// https://doi.org/10.1145/1806596.1806623
+///
+/// Some of the Grisu2 modifications were suggested by the "Errol
+/// paper": Marc Andrysco, Ranjit Jhala, Sorin Lerner; "Printing
+/// Floating-Point Numbers: A Faster, Always Correct Method", 2016.
+/// https://doi.org/10.1145/2837614.2837654
+/// In particular, the Errol paper explored the impact of higher-precision
+/// fixed-width arithmetic on Grisu2 and showed a way to rapidly test
+/// the correctness of Grisu-style algorithms.
+///
+/// A few further improvements were inspired by the Ryu algorithm
+/// from Ulf Anders; "Ryū: fast float-to-string conversion", 2018.
+/// https://doi.org/10.1145/3296979.3192369
+///
+/// The full algorithm is extensively commented in the Float64 version
+/// below; refer to that for details.
+///
+/// In summary, this implementation is:
+///
+/// * Fast.  It uses only fixed-width integer arithmetic and has
+///   constant memory requirements.  For double-precision values on
+///   64-bit processors, it is competitive with Ryu. For double-precision
+///   values on 32-bit processors, and higher-precision values on all
+///   processors, it is considerably faster.
+///
+/// * Always Accurate. Except for NaNs, converting the decimal form
+///   back to binary will always yield an equal value. For the IEEE
+///   754 formats, the round trip will produce exactly the same bit
+///   pattern in memory. This assumes, of course, that the conversion
+///   from text to binary uses a correctly-rounded algorithm such as
+///   Clinger 1990 or Eisel-Lemire 2021.
+///
+/// * Always Short.  This always selects an accurate result with the
+///   minimum number of significant digits.
+///
+/// * Always Close.  Among all accurate, short results, this always
+///   chooses the result that is closest to the exact floating-point
+///   value. (In case of an exact tie, it rounds the last digit even.)
+///
+/// Beyond the requirements above, the precise text form has been
+/// tuned to try to maximize readability:
+/// * Always include a '.' or an 'e' so the result is obviously
+///   a floating-point value
+/// * Exponential form always has 1 digit before the decimal point
+/// * When present, a '.' is never the first or last character
+/// * There is a consecutive range of integer values that can be
+///   represented in any particular type (-2^54...2^54 for double).
+///   We do not use exponential form for integral numbers in this
+///   range.
+/// * Generally follow existing practice: Don't use use exponential
+///   form for fractional values bigger than 10^-4; always write at
+///   least 2 digits for an exponent.
+/// * Apart from the above, we do prefer shorter output.
+
+/// Note: If you want to compare performance of this implementation
+/// versus some others, keep in mind that this implementation does
+/// deliberately sacrifice some performance.  Any attempt to compare
+/// the performance of this implementation to others should
+/// try to compensate for the following:
+/// * The output ergonomics described above do take some time.
+///   It would be faster to always emit the form "123456e-78"
+//    (See `finishFormatting()`)
+/// * The implementations in published papers generally include
+///   large tables with every power of 10 computed out.  We've
+///   factored these tables down to conserve code size, which
+///   requires some additional work to reconstruct the needed power
+///   of 10. (See the `intervalContainingPowerOf10_*` functions)
+
+///
+/// This Swift implementation was ported from an earlier C version;
+/// the output is exactly the same in all cases.
+/// A few notes on the Swift transcription:
+/// * We use MutableSpan<UTF8.CodeUnit> and MutableRawSpan to
+///   identify blocks of working memory.
+/// * We use unsafe/unchecked operations extensively, supported by
+///   several years of analysis and testing of the original C
+///   implementation to ensure that no unsafety actually occurs.  For
+///   Float32, that testing was exhaustive -- we verified all 4
+///   billion possible Float32 values.
+/// * The Swift code uses an idiom of building up to 8 digit characters
+///   in a UInt64 and then writing the whole block to memory.
+/// * The Swift version is slightly faster than the C version;
+///   mostly thanks to various minor algorithmic tweaks that were
+///   found during the translation process.
+///
+// ----------------------------------------------------------------------------
+
+
+// ================================================================
+//
+// Float16
+//
+// ================================================================
+
+#if (os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64)
+
+// Float16 is not currently supported on Intel x86_64 macOS,
+// (including macCatalyst on x86_64) but this symbol somehow got
+// exported there.
+// This preserves that export.
+
+// Note: Other platforms that don't support Float16 should
+// NOT export this.
+@available(SwiftStdlib 5.3, *)
+@_silgen_name("swift_float16ToString")
+public func _float16ToStringImpl(
+  _ textBuffer: UnsafeMutablePointer<UTF8.CodeUnit>,
+  _ bufferLength: UInt,
+  _ value: Float,
+  _ debug: Bool
+) -> UInt64 {
+  fatalError()
+}
+
+#else
+
+// Support Legacy ABI on top of new implementation
+@available(SwiftStdlib 5.3, *)
+@_silgen_name("swift_float16ToString")
+public func _float16ToStringImpl(
+  _ textBuffer: UnsafeMutablePointer<UTF8.CodeUnit>,
+  _ bufferLength: UInt,
+  _ value: Float16,
+  _ debug: Bool
+) -> UInt64 {
+  // Code below works with raw memory.
+  var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
+    _unchecked: textBuffer,
+    count: Int(bufferLength))
+  let textRange = _Float16ToASCII(value: value, buffer: &buffer)
+  let textLength = textRange.upperBound - textRange.lowerBound
+
+  // Move the text to the start of the buffer
+  if textRange.lowerBound != 0 {
+    unsafe _memmove(
+      dest: textBuffer,
+      src: textBuffer + textRange.lowerBound,
+      size: UInt(truncatingIfNeeded: textLength))
+  }
+  return UInt64(truncatingIfNeeded: textLength)
+}
+
+// Convert a Float16 to an optimal ASCII representation.
+// See notes above for comments on the output format here.
+// Inputs:
+// * `value`: Float16 input
+// * `buffer`: Buffer to place the result
+// Returns: Range of bytes within `buffer` that contain the result
+//
+// Buffer must be at least 32 bytes long and must be pre-filled
+// with "0" characters, e.g., via
+// `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
+
+@available(SwiftStdlib 5.3, *)
+internal func _Float16ToASCII(
+  value f: Float16,
+  buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
+) -> Range<Int> {
+  // We need a MutableRawSpan in order to use wide store/load operations
+  // TODO: Tune this value down to the actual minimum for Float16
+  precondition(utf8Buffer.count >= 32)
+  var buffer = unsafe utf8Buffer.mutableBytes
+
+  // Step 1: Handle various input cases:
+  let binaryExponent: Int
+  let significand: Float16.RawSignificand
+  let exponentBias = (1 << (Float16.exponentBitCount - 1)) - 2 // 14
+  if (f.exponentBitPattern == 0x1f) { // NaN or Infinity
+    if (f.isInfinite) {
+      return _infinity(buffer: &buffer, sign: f.sign)
+    } else { // f.isNaN
+      let quietBit =
+        (f.significandBitPattern >> (Float16.significandBitCount - 1)) & 1
+      let payloadMask = UInt16(1 &<< (Float16.significandBitCount - 2)) - 1
+      let payload16 = f.significandBitPattern & payloadMask
+      return nan_details(
+        buffer: &buffer,
+        sign: f.sign,
+        quiet: quietBit != 0,
+        payloadHigh: 0,
+        payloadLow: UInt64(truncatingIfNeeded:payload16))
+    }
+  } else if (f.exponentBitPattern == 0) {
+    if (f.isZero) {
+      return _zero(buffer: &buffer, sign: f.sign)
+    } else { // Subnormal
+      binaryExponent = 1 - exponentBias
+      significand = f.significandBitPattern &<< 2
+    }
+  } else { // normal
+    binaryExponent = Int(f.exponentBitPattern) &- exponentBias
+    let hiddenBit = Float16.RawSignificand(1) << Float16.significandBitCount
+    significand = (f.significandBitPattern &+ hiddenBit) &<< 2
+  }
+
+  // Step 2: Determine the exact target interval
+  let halfUlp: Float16.RawSignificand = 2
+  let quarterUlp = halfUlp >> 1
+  let upperMidpointExact =
+    significand &+ halfUlp
+  let lowerMidpointExact =
+    significand &- ((f.significandBitPattern == 0) ? quarterUlp : halfUlp)
+
+  var firstDigit = 1
+  var nextDigit = firstDigit
+
+  // Emit the text form differently depending on what range it's in.
+  // We use `storeBytes(of:toUncheckedByteOffset:as:)` for most of
+  // the output, but are careful to use the checked/safe form
+  // `storeBytes(of:toByteOffset:as:)` for the last byte so that we
+  // reliably crash if we overflow the provided buffer.
+
+  // Step 3: If it's < 10^-5, format as exponential form
+  if binaryExponent < -13 || (binaryExponent == -13 && significand < 0x1a38) {
+    var decimalExponent = -5
+    var u =
+      (UInt32(upperMidpointExact) << (28 - 13 &+ binaryExponent)) &* 100000
+    var l =
+      (UInt32(lowerMidpointExact) << (28 - 13 &+ binaryExponent)) &* 100000
+    var t =
+      (UInt32(significand) << (28 - 13 &+ binaryExponent)) &* 100000
+    let mask = (UInt32(1) << 28) - 1
+    if t < ((1 << 28) / 10) {
+      u &*= 100
+      l &*= 100
+      t &*= 100
+      decimalExponent &-= 2
+    }
+    if t < (1 << 28) {
+      u &*= 10
+      l &*= 10
+      t &*= 10
+      decimalExponent &-= 1
+    }
+    let uDigit = u >> 28
+    if uDigit == (l >> 28) {
+      // More than one digit, so write first digit, ".", then the rest
+      unsafe buffer.storeBytes(
+        of: 0x30 + UInt8(truncatingIfNeeded: uDigit),
+        toUncheckedByteOffset: nextDigit,
+        as: UInt8.self)
+      nextDigit &+= 1
+      unsafe buffer.storeBytes(
+        of: 0x2e,
+        toUncheckedByteOffset: nextDigit,
+        as: UInt8.self)
+      nextDigit &+= 1
+      while true {
+        u = (u & mask) &* 10
+        l = (l & mask) &* 10
+        t = (t & mask) &* 10
+        let uDigit = u >> 28
+        if uDigit != (l >> 28) {
+          // Stop before emitting the last digit
+          break
+        }
+        unsafe buffer.storeBytes(
+          of: 0x30 &+ UInt8(truncatingIfNeeded: uDigit),
+          toUncheckedByteOffset: nextDigit,
+          as: UInt8.self)
+        nextDigit &+= 1
+      }
+    }
+    let digit = 0x30 &+ (t &+ (1 << 27)) >> 28
+    unsafe buffer.storeBytes(
+      of: UInt8(truncatingIfNeeded: digit),
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    unsafe buffer.storeBytes(
+      of: 0x65, // "e"
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    unsafe buffer.storeBytes(
+      of: 0x2d, // "-"
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    unsafe buffer.storeBytes(
+      of: UInt8(truncatingIfNeeded: -decimalExponent / 10 &+ 0x30),
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    // Last write on this branch, so use a safe checked store
+    buffer.storeBytes(
+      of: UInt8(truncatingIfNeeded: -decimalExponent % 10 &+ 0x30),
+      toByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+  } else {
+
+    // Step 4: Greater than 10^-5, so use decimal format "123.45"
+    // (Note: Float16 is never big enough to need exponential for
+    // positive exponents)
+    // First, split into integer and fractional parts:
+
+    let intPart : Float16.RawSignificand
+    let fractionPart : Float16.RawSignificand
+    if binaryExponent < 13 {
+      intPart = significand >> (13 &- binaryExponent)
+      fractionPart = significand &- (intPart &<< (13 &- binaryExponent))
+    } else {
+      intPart = significand &<< (binaryExponent &- 13)
+      fractionPart = significand &- (intPart >> (binaryExponent &- 13))
+    }
+
+    // Step 5: Emit the integer part
+    let text = _intToEightDigits(UInt32(intPart))
+    unsafe buffer.storeBytes(
+      of: text,
+      toUncheckedByteOffset: nextDigit,
+      as: UInt64.self)
+    nextDigit &+= 8
+
+    // Skip leading zeros
+    if intPart < 10 {
+      firstDigit &+= 7
+    } else if intPart < 100 {
+      firstDigit &+= 6
+    } else if intPart < 1000 {
+      firstDigit &+= 5
+    } else if intPart < 10000 {
+      firstDigit &+= 4
+    } else {
+      firstDigit &+= 3
+    }
+
+    // After the integer part comes a period...
+    unsafe buffer.storeBytes(
+      of: 0x2e,
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+
+    if fractionPart == 0 {
+      // Step 6: No fraction, so ".0" and we're done
+      // "0" write is free since buffer is pre-initialized
+      nextDigit &+= 1
+    } else {
+      // Step 7: Emit the fractional part by repeatedly
+      // multiplying by 10 to produce successive digits:
+      var u = UInt32(upperMidpointExact) &<< (28 - 13 &+ binaryExponent)
+      var l = UInt32(lowerMidpointExact) &<< (28 - 13 &+ binaryExponent)
+      var t = UInt32(fractionPart) &<< (28 - 13 &+ binaryExponent)
+      let mask = (UInt32(1) << 28) - 1
+      var uDigit: UInt8 = 0
+      var lDigit: UInt8 = 0
+      while true {
+        u = (u & mask) &* 10
+        l = (l & mask) &* 10
+        uDigit = UInt8(truncatingIfNeeded: u >> 28)
+        lDigit = UInt8(truncatingIfNeeded: l >> 28)
+        if uDigit != lDigit {
+          t = (t & mask) &* 10
+          break
+        }
+        // This overflows, but we don't care at this point.
+        t &*= 10
+        unsafe buffer.storeBytes(
+          of: 0x30 &+ uDigit,
+          toUncheckedByteOffset: nextDigit,
+          as: UInt8.self)
+        nextDigit &+= 1
+      }
+      t &+= 1 << 27
+      if (t & mask) == 0 { // Exactly 1/2
+        t = (t >> 28) & ~1 // Round last digit even
+        // Rounding `t` even can end up moving `t` below
+        // `l`.  Detect and correct for this possibility.
+        // Exhaustive testing shows that the only input value
+        // affected by this is 0.015625 == 2^-6, which
+        // incorrectly prints as "0.01562" without this fix.
+        // With this, it prints correctly as "0.01563"
+        if t < lDigit || (t == lDigit && l > 0) {
+	        t += 1
+        }
+      } else {
+        t >>= 28
+      }
+      // Last write on this branch, so use a checked store
+      buffer.storeBytes(
+        of: UInt8(truncatingIfNeeded: 0x30 + t),
+        toByteOffset: nextDigit,
+        as: UInt8.self)
+      nextDigit &+= 1
+    }
+  }
+  if f.sign == .minus {
+    buffer.storeBytes(
+      of: 0x2d,
+      toByteOffset: firstDigit &- 1,
+      as: UInt8.self) // "-"
+    firstDigit &-= 1
+  }
+  return firstDigit..<nextDigit
+}
+#endif
+
+// ================================================================
+//
+// Float32
+//
+// ================================================================
+
+// Support Legacy ABI on top of new implementation
+@_silgen_name("swift_float32ToString")
+@usableFromInline
+internal func _float32ToStringImpl(
+  _ textBuffer: UnsafeMutablePointer<UTF8.CodeUnit>,
+  _ bufferLength: UInt,
+  _ value: Float32,
+  _ debug: Bool
+) -> UInt64 {
+  // Code below works with raw memory.
+  var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
+    _unchecked: textBuffer,
+    count: Int(bufferLength))
+  let textRange = _Float32ToASCII(value: value, buffer: &buffer)
+  let textLength = textRange.upperBound - textRange.lowerBound
+
+  // Move the text to the start of the buffer
+  if textRange.lowerBound != 0 {
+    unsafe _memmove(
+      dest: textBuffer,
+      src: textBuffer + textRange.lowerBound,
+      size: UInt(truncatingIfNeeded: textLength))
+  }
+  return UInt64(truncatingIfNeeded: textLength)
+}
+
+// Convert a Float32 to an optimal ASCII representation.
+// See notes above for comments on the output format here.
+// See _Float64ToASCII for comments on the algorithm.
+// Inputs:
+// * `value`: Float32 input
+// * `buffer`: Buffer to place the result
+// Returns: Range of bytes within `buffer` that contain the result
+//
+// Buffer must be at least 32 bytes long and must be pre-filled
+// with "0" characters, e.g., via
+// `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
+internal func _Float32ToASCII(
+  value f: Float32,
+  buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
+) -> Range<Int> {
+  // Note: The algorithm here is the same as for Float64, only
+  // with narrower arithmetic.  Refer to `_Float64ToASCII` for
+  // more detailed comments and explanation.
+
+  // We need a MutableRawSpan in order to use wide store/load operations
+  // TODO: Tune this limit down to the actual minimum we need here
+  // TODO: `assert` that the buffer is filled with 0x30 bytes (in debug builds)
+  precondition(utf8Buffer.count >= 32)
+  var buffer = unsafe utf8Buffer.mutableBytes
+
+  // Step 1: Handle the special cases, decompose the input
+
+  let binaryExponent: Int
+  let significand: Float.RawSignificand
+  let exponentBias = (1 << (Float.exponentBitCount - 1)) - 2 // 126
+  if (f.exponentBitPattern == 0xff) {
+    if (f.isInfinite) {
+      return _infinity(buffer: &buffer, sign: f.sign)
+    } else { // f.isNaN
+      let quietBit =
+        (f.significandBitPattern >> (Float.significandBitCount - 1)) & 1
+      let payloadMask = UInt32(1 << (Float.significandBitCount - 2)) - 1
+      let payload32 = f.significandBitPattern & payloadMask
+      return nan_details(
+        buffer: &buffer,
+        sign: f.sign,
+        quiet: quietBit != 0,
+        payloadHigh: 0,
+        payloadLow: UInt64(truncatingIfNeeded:payload32))
+    }
+  } else if (f.exponentBitPattern == 0) {
+    if (f.isZero) {
+      return _zero(buffer: &buffer, sign: f.sign)
+    } else { // f.isSubnormal
+      binaryExponent = 1 - exponentBias
+      significand = f.significandBitPattern &<< Float.exponentBitCount
+    }
+  } else {
+    binaryExponent = Int(f.exponentBitPattern) &- exponentBias
+    significand =
+      ((f.significandBitPattern &+ (1 << Float.significandBitCount))
+         &<< Float.exponentBitCount)
+  }
+
+  // Step 2: Determine the exact unscaled target interval
+
+  let halfUlp: Float.RawSignificand = 1 << (Float.exponentBitCount - 1)
+  let quarterUlp = halfUlp >> 1
+  let upperMidpointExact =
+    significand &+ halfUlp
+  let lowerMidpointExact =
+    significand &- ((f.significandBitPattern == 0) ? quarterUlp : halfUlp)
+  let isOddSignificand = ((f.significandBitPattern & 1) != 0)
+
+  // Step 3: Estimate the base 10 exponent
+
+  var base10Exponent = decimalExponentFor2ToThe(binaryExponent)
+
+  // Step 4: Compute power-of-10 scale factor
+
+  var powerOfTenRoundedDown: UInt64 = 0
+  var powerOfTenRoundedUp: UInt64 = 0
+
+  let bulkFirstDigits = 1
+  let powerOfTenExponent = _intervalContainingPowerOf10_Binary32(
+    p: -base10Exponent &+ bulkFirstDigits &- 1,
+    lower: &powerOfTenRoundedDown,
+    upper: &powerOfTenRoundedUp)
+  let extraBits = binaryExponent &+ powerOfTenExponent
+
+  // Step 5: Scale the interval (with rounding)
+
+  // Experimentally, 11 is as large as we can go here without
+  // introducing errors.
+  // We need 7 to generate 2 digits at a time below.
+  // 11 should allow us to generate 3 digits at a time, but
+  // that doesn't seem to be any faster.
+  let integerBits = 11
+  let fractionBits = 64 - integerBits
+  var u: UInt64
+  var l: UInt64
+  if isOddSignificand {
+    // Narrow the interval (odd significand)
+    let u1 = _multiply64x32RoundingDown(
+      powerOfTenRoundedDown,
+      upperMidpointExact)
+    u = u1 >> (integerBits - extraBits)
+    let l1 = _multiply64x32RoundingUp(
+      powerOfTenRoundedUp,
+      lowerMidpointExact)
+    let bias = UInt64((1 &<< (integerBits &- extraBits)) &- 1)
+    l = (l1 &+ bias) >> (integerBits &- extraBits)
+  } else {
+    // Widen the interval (even significand)
+    let u1 = _multiply64x32RoundingUp(
+      powerOfTenRoundedUp,
+      upperMidpointExact)
+    let bias = UInt64((1 &<< (integerBits &- extraBits)) &- 1)
+    u = (u1 &+ bias) >> (integerBits &- extraBits)
+    let l1 = _multiply64x32RoundingDown(
+      powerOfTenRoundedDown,
+      lowerMidpointExact)
+    l = l1 >> (integerBits &- extraBits)
+  }
+
+  // Step 6: Align first digit, adjust exponent
+
+  while u < (UInt64(1) &<< fractionBits) {
+    base10Exponent &-= 1
+    l &*= 10
+    u &*= 10
+  }
+
+  // Step 7: Generate decimal digits into the destination buffer
+
+  var t = u
+  var delta = u &- l
+  let fractionMask: UInt64 = (1 << fractionBits) - 1
+
+  // Overwrite the first digit at index 7:
+  let firstDigit = 7
+  let digit = (t >> fractionBits) &+ 0x30
+  t &= fractionMask
+  unsafe buffer.storeBytes(
+    of: UInt8(truncatingIfNeeded: digit),
+    toUncheckedByteOffset: firstDigit,
+    as: UInt8.self)
+  var nextDigit = firstDigit &+ 1
+
+  // Generate 2 digits at a time...
+  while (delta &* 10) < ((t &* 10) & fractionMask) {
+    delta &*= 100
+    t &*= 100
+    let d12 = Int(truncatingIfNeeded: t >> fractionBits)
+    let text = unsafe asciiDigitTable[unchecked: d12]
+    unsafe buffer.storeBytes(
+      of: text,
+      toUncheckedByteOffset: nextDigit,
+      as: UInt16.self)
+    nextDigit &+= 2
+    t &= fractionMask
+  }
+
+  // ... and a final single digit, if necessary
+  if delta < t {
+    delta &*= 10
+    t &*= 10
+    let text = 0x30 + UInt8(truncatingIfNeeded: t >> fractionBits)
+    unsafe buffer.storeBytes(
+      of: text,
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    t &= fractionMask
+  }
+
+  // Adjust the final digit to be closer to the original value
+  let isBoundary = (f.significandBitPattern == 0)
+  if delta > t &+ (1 << fractionBits) {
+    let skew: UInt64
+    if isBoundary {
+      skew = delta &- delta / 3 &- t
+    } else {
+      skew = delta / 2 &- t
+    }
+    let one = UInt64(1) << (64 - integerBits)
+    let lastAccurateBit = UInt64(1) << 24
+    let fractionMask = (one - 1) & ~(lastAccurateBit - 1)
+    let oneHalf = one >> 1
+    var lastDigit = unsafe buffer.unsafeLoad(
+      fromUncheckedByteOffset: nextDigit &- 1,
+      as: UInt8.self)
+    if ((skew &+ (lastAccurateBit >> 1)) & fractionMask) == oneHalf {
+      // Skew is integer + 1/2, round even after adjustment
+      let adjust = skew >> (64 - integerBits)
+      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
+      lastDigit &= ~1
+    } else {
+      // Round nearest
+      let adjust = (skew &+ oneHalf) >> (64 - integerBits)
+      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
+    }
+    unsafe buffer.storeBytes(
+      of: lastDigit,
+      toUncheckedByteOffset: nextDigit &- 1,
+      as: UInt8.self)
+  }
+
+  // Step 8: Finish formatting
+  let forceExponential =
+    ((binaryExponent > 25)
+       || (binaryExponent == 25 && !isBoundary))
+  return _finishFormatting(
+    buffer: &buffer,
+    sign: f.sign,
+    firstDigit: firstDigit,
+    nextDigit: nextDigit,
+    forceExponential: forceExponential,
+    base10Exponent: base10Exponent)
+}
+
+// ================================================================
+//
+// Float64
+//
+// ================================================================
+
+// Support Legacy ABI on top of new implementation
+@_silgen_name("swift_float64ToString")
+@usableFromInline
+internal func _float64ToStringImpl(
+  _ textBuffer: UnsafeMutablePointer<UTF8.CodeUnit>,
+  _ bufferLength: UInt,
+  _ value: Float64,
+  _ debug: Bool
+) -> UInt64 {
+  // Code below works with raw memory.
+  var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
+    _unchecked: textBuffer,
+    count: Int(bufferLength))
+  let textRange = _Float64ToASCII(value: value, buffer: &buffer)
+  let textLength = textRange.upperBound - textRange.lowerBound
+
+  // Move the text to the start of the buffer
+  if textRange.lowerBound != 0 {
+    unsafe _memmove(
+      dest: textBuffer,
+      src: textBuffer + textRange.lowerBound,
+      size: UInt(truncatingIfNeeded: textLength))
+  }
+  return UInt64(truncatingIfNeeded: textLength)
+}
+
+// Convert a Float64 to an optimal ASCII representation.
+// See notes above for comments on the output format here.
+// The algorithm is extensively commented inline; the comments
+// at the top of this source file give additional context.
+// Inputs:
+// * `value`: Float64 input
+// * `buffer`: Buffer to place the result
+// Returns: Range of bytes within `buffer` that contain the result
+//
+// Buffer must be at least 32 bytes long and must be pre-filled
+// with "0" characters, e.g., via
+// `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
+internal func _Float64ToASCII(
+  value d: Float64,
+  buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
+) -> Range<Int> {
+  // We need a MutableRawSpan in order to use wide store/load operations
+  precondition(utf8Buffer.count >= 32)
+  var buffer = unsafe utf8Buffer.mutableBytes
+
+  //
+  // Step 1: Handle the special cases, decompose the input
+  //
+  let binaryExponent: Int
+  let significand: Double.RawSignificand
+  let exponentBias = 1022 // (1 << (Double.exponentBitCount - 1)) - 2
+
+  if (d.exponentBitPattern == 0x7ff) {
+    if (d.isInfinite) {
+      return _infinity(buffer: &buffer, sign: d.sign)
+    } else { // d.isNaN
+      let quietBit =
+        (d.significandBitPattern >> (Double.significandBitCount - 1)) & 1
+      let payloadMask = (UInt64(1) &<< (Double.significandBitCount - 2)) - 1
+      let payload64 = d.significandBitPattern & payloadMask
+      return nan_details(
+        buffer: &buffer,
+        sign: d.sign,
+        quiet: quietBit != 0,
+        payloadHigh: 0,
+        payloadLow: UInt64(truncatingIfNeeded:payload64))
+    }
+  } else if (d.exponentBitPattern == 0) {
+    if (d.isZero) {
+      return _zero(buffer: &buffer, sign: d.sign)
+    } else { // d.isSubnormal
+      binaryExponent = 1 - exponentBias
+      significand = d.significandBitPattern &<< Double.exponentBitCount
+    }
+  } else {
+    binaryExponent = Int(d.exponentBitPattern) &- exponentBias
+    significand =
+      ((d.significandBitPattern &+ (1 << Double.significandBitCount))
+         &<< Double.exponentBitCount)
+  }
+  // The input has been decomposed as significand * 2^binaryExponent,
+  // where `significand` is a 64-bit fraction with the binary
+  // point at the far left.
+
+  // Step 2: Determine the exact unscaled target interval
+
+  // Grisu-style algorithms construct the shortest decimal digit
+  // sequence within a specific interval.  To build the appropriate
+  // interval, we start by computing the midpoints between this
+  // floating-point value and the adjacent ones.  Note that this
+  // step is an exact computation.
+
+  let halfUlp: Double.RawSignificand = 1 << (Double.exponentBitCount - 1)
+  let quarterUlp = halfUlp >> 1
+  let upperMidpointExact = significand &+ halfUlp
+  let lowerMidpointExact =
+    significand &- ((d.significandBitPattern == 0) ? quarterUlp : halfUlp)
+  let isOddSignificand = ((d.significandBitPattern & 1) != 0)
+
+  // Step 3: Estimate the base 10 exponent
+
+  // Grisu algorithms are based in part on a simple technique for
+  // generating a base-10 form for a binary floating-point number.
+  // Start with a binary floating-point number `f * 2^e` and then
+  // estimate the decimal exponent `p`. You can then rewrite your
+  // original number as:
+  //
+  // ```
+  //     f * 2^e * 10^-p * 10^p
+  // ```
+  //
+  // The last term is part of our output, and a good estimate for
+  // `p` will ensure that `2^e * 10^-p` is close to 1.  Multiplying
+  // the first three terms then yields a fraction suitable for
+  // producing the decimal digits.  Here we use a very fast estimate
+  // of `p` that is never off by more than 1; we'll have
+  // opportunities later to correct any error.
+
+  var base10Exponent = decimalExponentFor2ToThe(binaryExponent)
+
+  // Step 4: Compute power-of-10 scale factor
+
+  // Compute `10^-p` to 128-bit precision.  We generate
+  // both over- and under-estimates to ensure we can exactly
+  // bound the later use of these values.
+  // The `powerOfTenRounded{Up,Down}` values are 128-bit
+  // pure fractions with the decimal point at the far left.
+
+  var powerOfTenRoundedDown: _UInt128 = 0
+  var powerOfTenRoundedUp: _UInt128 = 0
+
+  // Note the extra factor of 10^bulkFirstDigits -- that will give
+  // us a headstart on digit generation later on.  (In contrast, Ryu
+  // uses an extra factor of 10^17 here to get all the digits up
+  // front, but then has to back out any extra digits.  Doing that
+  // with a 17-digit value requires 64-bit division, which is the
+  // root cause of Ryu's poor performance on 32-bit processors.  We
+  // also might have to back out extra digits if 7 is too many, but
+  // will only need 32-bit division in that case.)
+
+  let bulkFirstDigits = 7
+  let bulkFirstDigitFactor: UInt32 = 1000000 // 10^(bulkFirstDigits - 1)
+
+  let powerOfTenExponent = _intervalContainingPowerOf10_Binary64(
+    p: -base10Exponent &+ bulkFirstDigits &- 1,
+    lower: &powerOfTenRoundedDown,
+    upper: &powerOfTenRoundedUp)
+
+  let extraBits = binaryExponent + powerOfTenExponent
+
+  // Step 5: Scale the interval (with rounding)
+
+  // As mentioned above, the final digit generation works
+  // with an interval, so we actually apply the scaling
+  // to the upper and lower midpoint values separately.
+
+  // As part of the scaling here, we'll switch from a pure
+  // fraction with zero bit integer portion and 128-bit fraction
+  // to a fixed-point form with 32 bits in the integer portion.
+
+  let integerBits = 32
+  let roundingBias =
+    _UInt128((1 &<< UInt64(truncatingIfNeeded: integerBits &- extraBits)) &- 1)
+  var u: _UInt128
+  var l: _UInt128
+  if isOddSignificand {
+    // Case A: Narrow the interval (odd significand)
+
+    // Loitsch' original Grisu2 always rounds so as to narrow the
+    // interval.  Since our digit generation will select a value
+    // within the scaled interval, narrowing the interval
+    // guarantees that we will find a digit sequence that converts
+    // back to the original value.
+
+    // This ensures accuracy but, as explained in Loitsch' paper,
+    // this carries a risk that there will be a shorter digit
+    // sequence outside of our narrowed interval that we will
+    // miss. This risk obviously gets lower with increased
+    // precision, but it wasn't until the Errol paper that anyone
+    // had a good way to test whether a particular implementation
+    // had sufficient precision. That paper shows a way to enumerate
+    // the worst-case numbers; those numbers that are extremely close
+    // to the mid-points between adjacent floating-point values.
+    // These are the values that might sit just outside of the
+    // narrowed interval. By testing these values, we can verify
+    // the correctness of our implementation.
+
+    // Multiply out the upper midpoint, rounding down...
+    let u1 = _multiply128x64RoundingDown(
+      powerOfTenRoundedDown,
+      upperMidpointExact)
+    // Account for residual binary exponent and adjust
+    // to the fixed-point format
+    u = u1 >> (integerBits - extraBits)
+
+    // Conversely for the lower midpoint...
+    let l1 = _multiply128x64RoundingUp(
+      powerOfTenRoundedUp,
+      lowerMidpointExact)
+    l = (l1 + roundingBias) >> (integerBits - extraBits)
+  } else {
+    // Case B: Widen the interval (even significand)
+
+    // As explained in Errol Theorem 6, in certain cases there is
+    // a short decimal representation at the exact boundary of the
+    // scaled interval.  When such a number is converted back to
+    // binary, it will get rounded to the adjacent even
+    // significand.
+
+    // So when the significand is even, we round so as to widen
+    // the interval in order to ensure that the exact midpoints
+    // are considered.  Of couse, this ensures that we find a
+    // short result but carries a risk of selecting a result
+    // outside of the exact scaled interval (which would be
+    // inaccurate).
+    // (This technique of rounding differently for even/odd significands
+    // seems to be new; I've not seen it described in any of the
+    // papers on floating-point printing.)
+
+    // The same testing approach described above (based on results
+    // in the Errol paper) also applies
+    // to this case.
+
+    let u1 = _multiply128x64RoundingUp(
+      powerOfTenRoundedUp,
+      upperMidpointExact)
+    u = (u1 &+ roundingBias) >> (integerBits - extraBits)
+    let l1 = _multiply128x64RoundingDown(
+      powerOfTenRoundedDown,
+      lowerMidpointExact)
+    l = l1 >> (integerBits - extraBits)
+  }
+
+  // Step 6: Align the first digit, adjust exponent
+
+  // Calculations above used an estimate for the power-of-ten scale.
+  // Here, we compensate for any error in that estimate by testing
+  // whether we have the expected number of digits in the integer
+  // portion and correcting as necessary.  This also serves to
+  // prune leading zeros from subnormals.
+
+  // Except for subnormals, this loop never runs more than once.
+  // For subnormals, this might run as many as 16 times.
+  let minimumU = _UInt128(bulkFirstDigitFactor) << (128 - integerBits)
+  while u < minimumU {
+    base10Exponent -= 1
+    l &*= 10
+    u &*= 10
+  }
+
+  // Step 7: Produce decimal digits
+
+  // One standard approach generates digits for the scaled upper and
+  // lower boundaries and stops at the first digit that
+  // differs. For example, note that 0.1234 is the shortest decimal
+  // between u = 0.123456 and l = 0.123345.
+
+  // Grisu optimizes this by generating digits for the upper bound
+  // (multiplying by 10 to isolate each digit) while simultaneously
+  // scaling the interval width `delta`.  As we remove each digit
+  // from the upper bound, the remainder is the difference between
+  // the base-10 value generated so far and the true upper bound.
+  // When that remainder is less than the scaled width of the
+  // interval, we know the current digits specify a value within the
+  // target interval.
+
+  // The logic below actually blends three different digit-generation
+  // strategies:
+  // * The first digits are already in the integer portion of the
+  //   fixed-point value, thanks to the `bulkFirstDigits` factor above.
+  //   We can just break those down and write them out.
+  // * If we generated too many digits, we use a Ryu-inspired technique
+  //   to backtrack.
+  // * If we generated too few digits (the usual case), we use an
+  //   optimized form of the Grisu2 method to produce the remaining
+  //   values.
+
+  //
+  // Generate digits and build the output.
+  //
+
+  // Generate digits for `t` with interval width `delta = u - l`
+  // As above, these are fixed-point with 32-bit integer, 96-bit fraction
+  var t = u
+  var delta = u &- l
+  let fractionMask = (_UInt128(1) << 96) - 1
+
+  var nextDigit = 5
+  var firstDigit = nextDigit
+
+  // Our initial scaling gave us the first 7 digits already:
+  let d12345678 = UInt32(truncatingIfNeeded: t._high >> 32)
+  t &= fractionMask
+
+  if delta >= t {
+    // Oops!  We have too many digits.  Back out the extra ones to
+    // get the right answer.  This is similar to Ryu, but since
+    // we've only produced seven digits, we only need 32-bit
+    // arithmetic here.  (Ryu needs 64-bit arithmetic to back out
+    // digits, which severely compromises performance on 32-bit
+    // processors.  The same problem occurs with Ryu for 128-bit
+    // floats on 64-bit processors.)
+    // A few notes:
+    // * Our target hardware always supports 32-bit hardware division,
+    //   so this should be reasonably fast.
+    // * For small integers (like "2.0"), Ryu would have to back out 16
+    //   digits; we only have to back out 6.
+    // * Very few double-precision values actually need fewer than 7
+    //   digits.  So this is rarely used except in workloads that
+    //   specifically use double for small integers.
+
+    // Why this is critical for performance: In order to use the
+    // 8-digits-at-a-time optimization below, we need at least 30
+    // bits in the integer part of our fixed-point format above.
+    // If we only use bulkDigits = 1, that leaves only 128 - 30 =
+    // 98 bit accuracy for our scaling step, which isn't enough
+    // (experiments suggest that binary64 needs ~110 bits for
+    // correctness).  So we have to use a large bulkDigits value
+    // to make full use of the 128-bit scaling above, which forces
+    // us to have some form of logic to handle the case of too
+    // many digits.  The alternatives are either to use >128 bit
+    // arithmetic, or to back up and repeat the original scaling
+    // with bulkDigits = 1.
+
+    let uHigh = u._high
+    let lHigh = (l &+ _UInt128(UInt64.max))._high
+    let tHigh: UInt64
+    if d.significand == 0 {
+      tHigh = (uHigh &+ lHigh &* 2) / 3
+    } else {
+      tHigh = (uHigh &+ lHigh) / 2
+    }
+    var u0 = UInt32(truncatingIfNeeded: uHigh >> (64 - integerBits))
+    var l0 = UInt32(truncatingIfNeeded: lHigh >> (64 - integerBits))
+    if lHigh & ((1 << (64 - integerBits)) - 1) != 0 {
+      l0 &+= 1
+    }
+    var t0 = UInt32(truncatingIfNeeded: tHigh >> (64 - integerBits))
+    var t0digits = 8
+
+    var u1 = u0 / 10
+    var l1 = (l0 &+ 9) / 10
+    var trailingZeros = (t == 0)
+    var droppedDigit = UInt32(
+      truncatingIfNeeded: ((tHigh &* 10) >> (64 - integerBits)) % 10)
+    while u1 >= l1 && u1 != 0 {
+      u0 = u1
+      l0 = l1
+      trailingZeros = trailingZeros && (droppedDigit == 0)
+      droppedDigit = t0 % 10
+      t0 /= 10
+      t0digits -= 1
+      u1 = u0 / 10
+      l1 = (l0 &+ 9) / 10
+    }
+    // Correct the final digit
+    if droppedDigit > 5 || (droppedDigit == 5 && !trailingZeros) { // > 0.5000
+      t0 &+= 1
+    } else if droppedDigit == 5 && trailingZeros { // == 0.5000
+      t0 &+= 1
+      t0 &= ~1
+    }
+    // t0 has t0digits digits.  Write them out
+    let text = _intToEightDigits(t0)
+    buffer.storeBytes(
+      of: text,
+      toByteOffset: nextDigit,
+      as: UInt64.self)
+    nextDigit &+= 8
+    // Skip the leading zeros
+    firstDigit &+= 9 - t0digits
+  } else {
+    // Our initial scaling did not produce too many digits.  The
+    // `d12345678` value holds the first 7 digits (plus a leading
+    // zero).  The remainder of this algorithm is basically just a
+    // heavily-optimized variation of Grisu2.
+
+    // Write out exactly 8 digits, assuming little-endian.
+    let chars = _intToEightDigits(d12345678)
+    unsafe buffer.storeBytes(
+      of: chars,
+      toUncheckedByteOffset: nextDigit,
+      as: UInt64.self)
+    nextDigit &+= 8
+    firstDigit &+= 1
+
+    // >90% of random binary64 values need at least 15 digits.
+    // We have seven so there's probably at least 8 more, which
+    // we can grab all at once.
+    let TenToTheEighth = 100000000 as _UInt128 // 10^(15-bulkFirstDigits)
+    let d0 = delta * TenToTheEighth
+    var t0 = t * TenToTheEighth
+    // The integer part of t0 is the next 8 digits
+    let next8Digits = UInt32(truncatingIfNeeded: t0._high >> 32)
+    t0 &= fractionMask
+    if d0 < t0 {
+      // We got 8 more digits! (So number is at least 15 digits)
+      // Write them out:
+      let chars = _intToEightDigits(next8Digits)
+      unsafe buffer.storeBytes(
+        of: chars,
+        toUncheckedByteOffset: nextDigit,
+        as: UInt64.self)
+      nextDigit &+= 8
+      t = t0
+      delta = d0
+    }
+
+    // Generate remaining digits one at a time, following Grisu:
+    while (delta < t) {
+      delta &*= 10
+      t &*= 10
+      unsafe buffer.storeBytes(
+        of: UInt8(truncatingIfNeeded: t._high >> 32) &+ 0x30,
+        toUncheckedByteOffset: nextDigit,
+        as: UInt8.self)
+      nextDigit &+= 1
+      t &= fractionMask
+    }
+
+    // Adjust the final digit to be closer to the original value.
+    // This accounts for the fact that sometimes there is more than
+    // one shortest digit sequence.
+
+    // For example, consider how the above would work if you had the
+    // value 0.1234 and computed u = 0.1257, l = 0.1211.  The above
+    // digit generation works with `u`, so produces 0.125.  But the
+    // values 0.122, 0.123, and 0.124 are just as short and 0.123 is
+    // therefore the best choice, since it's closest to the original
+    // value.
+
+    // We know delta and t are both less than 10.0 here, so we can
+    // shed some excess integer bits to simplify the following:
+    let adjustIntegerBits = 4 // Integer bits for "adjust" phase
+    let deltaHigh64 = UInt64(
+      truncatingIfNeeded: delta >> (64 - integerBits + adjustIntegerBits))
+    let tHigh64 = UInt64(
+      truncatingIfNeeded: t >> (64 - integerBits + adjustIntegerBits))
+
+    let one = UInt64(1) << (64 - adjustIntegerBits)
+    let adjustFractionMask = one - 1
+    let oneHalf = one >> 1
+    if deltaHigh64 >= tHigh64 &+ one {
+      // The `skew` is the difference between our
+      // computed digits and the original exact value.
+      var skew: UInt64
+      if (d.significandBitPattern == 0) {
+        skew = deltaHigh64 &- deltaHigh64 / 3 &- tHigh64
+      } else {
+        skew = deltaHigh64 / 2 &- tHigh64
+      }
+
+      var lastDigit = unsafe buffer.unsafeLoad(
+        fromUncheckedByteOffset: nextDigit - 1,
+        as: UInt8.self)
+
+      // We use the `skew` to figure out whether there's
+      // a better base-10 value than our current one.
+      if (skew & adjustFractionMask) == oneHalf {
+        // Difference is an integer + exactly 1/2, so ...
+        let adjust = skew >> (64 - adjustIntegerBits)
+        lastDigit &-= UInt8(truncatingIfNeeded: adjust)
+        // ... we round the last digit even.
+        lastDigit &= ~1
+      } else {
+        let adjust = (skew + oneHalf) >> (64 - adjustIntegerBits)
+        lastDigit &-= UInt8(truncatingIfNeeded: adjust)
+      }
+      buffer.storeBytes(
+        of: lastDigit,
+        toByteOffset: nextDigit - 1,
+        as: UInt8.self)
+    }
+  }
+
+  // Step 8: Finalize formatting by rearranging
+  // the digits and filling in decimal points,
+  // exponents, and zero padding.
+  let isBoundary = (d.significandBitPattern == 0)
+  let forceExponential =
+    ((binaryExponent > 54) || (binaryExponent == 54 && !isBoundary))
+  return _finishFormatting(
+    buffer: &buffer,
+    sign: d.sign,
+    firstDigit: firstDigit,
+    nextDigit: nextDigit,
+    forceExponential: forceExponential,
+    base10Exponent: base10Exponent)
+}
+
+
+// ================================================================
+//
+// Float80
+//
+// ================================================================
+
+// Float80 is only available on Intel x86/x86_64 processors on certain operating systems
+// This matches the condition for the Float80 type
+
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+// Support Legacy ABI on top of new implementation
+@_silgen_name("swift_float80ToString")
+@usableFromInline
+internal func _float80ToStringImpl(
+  _ textBuffer: UnsafeMutablePointer<UTF8.CodeUnit>,
+  _ bufferLength: UInt,
+  _ value: Float80,
+  _ debug: Bool
+) -> UInt64 {
+  // Code below works with raw memory.
+  var buffer = unsafe MutableSpan<UTF8.CodeUnit>(
+    _unchecked: textBuffer,
+    count: Int(bufferLength))
+  let textRange = _Float80ToASCII(value: value, buffer: &buffer)
+  let textLength = textRange.upperBound - textRange.lowerBound
+
+  // Move the text to the start of the buffer
+  if textRange.lowerBound != 0 {
+    unsafe _memmove(
+      dest: textBuffer,
+      src: textBuffer + textRange.lowerBound,
+      size: UInt(truncatingIfNeeded: textLength))
+  }
+  return UInt64(truncatingIfNeeded: textLength)
+}
+
+// Convert a Float80 to an optimal ASCII representation.
+// See notes above for comments on the output format here.
+// See _Float64ToASCII for comments on the algorithm.
+// Inputs:
+// * `value`: Float80 input
+// * `buffer`: Buffer to place the result
+// Returns: Range of bytes within `buffer` that contain the result
+//
+// Buffer must be at least 32 bytes long and must be pre-filled
+// with "0" characters, e.g., via
+// `InlineArray<32,UTF8.CodeUnit>(repeating:0x30)`
+internal func _Float80ToASCII(
+  value f: Float80,
+  buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
+) -> Range<Int> {
+  // We need a MutableRawSpan in order to use wide store/load operations
+  precondition(utf8Buffer.count >= 32)
+  var buffer = unsafe utf8Buffer.mutableBytes
+
+  // Step 1: Handle special cases, decompose the input
+
+  // The Intel 80-bit floating point format has some quirks that
+  // make this a lot more complex than the corresponding logic for
+  // the IEEE 754 portable formats.
+
+  // f.significandBitPattern is processed to try to mimic the
+  // semantics of IEEE portable formats.  But for the following,
+  // we need the actual raw bits:
+  let rawSignificand = f._representation.explicitSignificand
+  let binaryExponent: Int
+  let significand: Float80.RawSignificand
+  let exponentBias = (1 << (Float80.exponentBitCount - 1)) - 2 // 16382
+  let isBoundary = f.significandBitPattern == 0
+  if f.exponentBitPattern == 0x7fff { // NaN or Infinity
+    // 80387 semantics and 80287 semantics differ somewhat;
+    // we follow 80387 semantics here.
+    // See: Wikipedia.org "Extended Precision"
+    // See: Intel's "Floating Point Reference Sheet"
+    // https://software.intel.com/content/dam/develop/external/us/en/documents/floating-point-reference-sheet.pdf
+    let selector = rawSignificand >> 62
+    let payload = rawSignificand & ((1 << 62) - 1)
+    switch selector {
+    case 0: // ∞ or snan on 287, invalid on 387
+      fallthrough
+    case 1: // Pseudo-NaN: snan on 287, invalid on 387
+      // Invalid patterns treated as plain "nan"
+      return nan_details(
+        buffer: &buffer,
+        sign: .plus,
+        quiet: true,
+        payloadHigh: 0,
+        payloadLow: payload)
+    case 2:
+      if payload == 0 {  // snan on 287, ∞ on 387
+        return _infinity(buffer: &buffer, sign: f.sign)
+      } else { // snan on 287 and 387
+        return nan_details(
+          buffer: &buffer,
+          sign: f.sign,
+          quiet: false,
+          payloadHigh: 0,
+          payloadLow: payload)
+      }
+    case 3:
+      // Zero payload and sign bit set is "indefinite" (treated as qNaN here),
+      // otherwise qNaN on 387, sNaN on 287
+      return nan_details(
+        buffer: &buffer,
+        sign: f.sign,
+        quiet: true,
+        payloadHigh: 0,
+        payloadLow: payload)
+    default:
+      fatalError()
+    }
+  } else if f.exponentBitPattern == 0 {
+    if rawSignificand == 0 { // Zero
+      return _zero(buffer: &buffer, sign: f.sign)
+    } else { // subnormal
+      binaryExponent = 1 - exponentBias
+      significand = rawSignificand
+    }
+  } else if rawSignificand >> 63 == 1 { // Normal
+    binaryExponent = Int(bitPattern:f.exponentBitPattern) - exponentBias
+    significand = rawSignificand
+  } else {
+    return nan_details(
+      buffer: &buffer,
+      sign: .plus,
+      quiet: true,
+      payloadHigh: 0,
+      payloadLow: 0)
+  }
+
+  // Step 2: Determine the exact unscaled target interval
+  let halfUlp = UInt64(1) << 63
+  let quarterUlp = halfUlp >> 1
+  let threeQuarterUlp = halfUlp + quarterUlp
+  // Significand is the upper 64 bits of our 128-bit franction
+  // Upper midpoint adds 1/2 ULP:
+  let upperMidpointExact = _UInt128(_low: halfUlp, _high: significand)
+  // Lower midpoint subtracts 1 ULP and then adds 1/2 or 3/4 ULP:
+  let lowerMidpointExact = _UInt128(
+    _low: isBoundary ? threeQuarterUlp : halfUlp,
+    _high: significand - 1)
+
+  let forceExponential =
+    (binaryExponent > 65
+       || (binaryExponent == 65 && !isBoundary))
+  return _backend_256bit(
+    buffer: &buffer,
+    upperMidpointExact: upperMidpointExact,
+    lowerMidpointExact: lowerMidpointExact,
+    sign: f.sign,
+    isBoundary: isBoundary,
+    isOddSignificand: (f.significandBitPattern & 1) != 0,
+    binaryExponent: binaryExponent,
+    forceExponential: forceExponential)
+}
+#endif
+
+// ================================================================
+//
+// Float128
+//
+// ================================================================
+
+#if false
+// Note: We don't need _float128ToStringImpl, since that's only for
+// backwards compatibility, and the legacy ABI never supported
+// Float128.
+
+internal func _Float128ToASCII(
+  value d: Float128,
+  buffer utf8Buffer: inout MutableSpan<UTF8.CodeUnit>
+) -> Range<Int> {
+  // TODO:  Write Me!
+
+  // Note: All the interesting parts are already implemented in _backend_256bit(...),
+  // so this can easily be implemented someday by just copyihng _Float80ToASCII
+  // and making the obvious changes.  (See the introductory parts of
+  // _Float64ToASCII for the structure common to all IEEE 754 formats.)
+}
+#endif
+
+// ================================================================
+//
+// Float80/Float128 common backend
+//
+// This uses 256-bit fixed-width arithmetic to efficiently compute the
+// optimal form for a decomposed float80 or binary128 value.  It is
+// less heavily commented than the 128-bit Double implementation
+// above; see that implementation for detailed explanation of the
+// logic here.
+//
+// Float80 could be handled more efficiently with 192-bit fixed-width
+// arithmetic.  But the code size savings from sharing this logic
+// between float80 and binary128 are substantial, and the resulting
+// float80 performance is still much better than competing
+// implementations.
+//
+// Also in the interest of code size savings, this eschews some of the
+// optimizations used by the 128-bit Double implementation above.
+// Those optimizations are simple to reintroduce if you're interested
+// in further performance improvements.
+//
+// If you are interested in extreme code size, you can also use this
+// backend for binary32 and binary64, eliminating the separate 128-bit
+// implementation. That variation offers surprisingly reasonable
+// performance overall.
+//
+// ================================================================
+
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
+
+fileprivate func _backend_256bit(
+  buffer: inout MutableRawSpan,
+  upperMidpointExact: _UInt128,
+  lowerMidpointExact: _UInt128,
+  sign: FloatingPointSign,
+  isBoundary: Bool,
+  isOddSignificand: Bool,
+  binaryExponent: Int,
+  forceExponential: Bool
+) -> Range<Int> {
+
+  // Step 3: Estimate the base 10 exponent
+  var base10Exponent = decimalExponentFor2ToThe(binaryExponent)
+
+  // Step 4: Compute a power-of-10 scale factor
+  var powerOfTenRoundedDown = _UInt256()
+  var powerOfTenRoundedUp = _UInt256()
+  let powerOfTenExponent = _intervalContainingPowerOf10_Binary128(
+    p: -base10Exponent,
+    lower: &powerOfTenRoundedDown,
+    upper: &powerOfTenRoundedUp)
+  let extraBits = binaryExponent &+ powerOfTenExponent
+
+  // Step 5: Scale the interval (with rounding)
+  let integerBits = 14
+  let high64FractionBits = 64 - integerBits
+  var u: _UInt256
+  var l: _UInt256
+  if isOddSignificand {
+    // Narrow the interval (odd significand)
+    u = powerOfTenRoundedDown
+    u.multiplyRoundingDown(by: upperMidpointExact)
+    u.shiftRightRoundingDown(by: integerBits &- extraBits)
+
+    l = powerOfTenRoundedUp
+    l.multiplyRoundingUp(by: lowerMidpointExact)
+    l.shiftRightRoundingUp(by: integerBits &- extraBits)
+  } else {
+    // Widen the interval (even significand)
+    u = powerOfTenRoundedUp
+    u.multiplyRoundingUp(by: upperMidpointExact)
+    u.shiftRightRoundingUp(by: integerBits &- extraBits)
+
+    l = powerOfTenRoundedDown
+    l.multiplyRoundingDown(by: lowerMidpointExact)
+    l.shiftRightRoundingDown(by: integerBits &- extraBits)
+  }
+
+  // Step 6: Align first digit, adjust exponent
+  while u.high._high < (UInt64(1) << high64FractionBits) {
+    base10Exponent &-= 1
+    l.multiply(by: UInt32(10))
+    u.multiply(by: UInt32(10))
+  }
+  var t = u
+  var delta = u &- l
+
+  // Step 7: Generate digits
+
+  // Leave 8 bytes at the beginning for finishFormatting to use
+  let firstDigit = 8
+  var nextDigit = firstDigit
+  buffer.storeBytes(
+    of: 0x30 + UInt8(truncatingIfNeeded: t.extractIntegerPart(integerBits)),
+    toByteOffset: nextDigit,
+    as: UInt8.self)
+  nextDigit &+= 1
+
+  // It would be nice to generate 8 digits at a time and take
+  // advantage of intToEightDigits, but our integer portion has only
+  // 14 bits.  We can't make that bigger without either sacrificing
+  // too much precision for correct Float128 or folding the first
+  // digits into the scaling (as we do with Double) which would
+  // require a back-out phase here (as we do with Double).
+
+  // If there is at least one more digit possible...
+  if delta < t {
+
+    // Try grabbing four digits at a time
+    var d0 = delta
+    var t0 = t
+    d0.multiply(by: 10000)
+    t0.multiply(by: 10000)
+    var d1234 = t0.extractIntegerPart(integerBits)
+    while d0 < t0 {
+      let d12 = d1234 / 100
+      let d34 = d1234 % 100
+      unsafe buffer.storeBytes(
+        of: asciiDigitTable[Int(bitPattern:d12)],
+        toUncheckedByteOffset: nextDigit,
+        as: UInt16.self)
+      unsafe buffer.storeBytes(
+        of: asciiDigitTable[Int(bitPattern:d34)],
+        toUncheckedByteOffset: nextDigit &+ 2,
+        as: UInt16.self)
+      nextDigit &+= 4
+      t = t0
+      delta = d0
+      d0.multiply(by: 10000)
+      t0.multiply(by: 10000)
+      d1234 = t0.extractIntegerPart(integerBits)
+    }
+
+    // Finish by generating one digit at a time...
+    while delta < t {
+      delta.multiply(by: UInt32(10))
+      t.multiply(by: UInt32(10))
+      let digit = UInt8(truncatingIfNeeded: t.extractIntegerPart(integerBits))
+      unsafe buffer.storeBytes(
+        of: 0x30 &+ digit,
+        toUncheckedByteOffset: nextDigit,
+        as: UInt8.self)
+      nextDigit &+= 1
+    }
+  }
+
+  // Adjust the final digit to be closer to the original value
+  // We've already consumed most of our available precision, and only
+  // need a couple of integer bits, so we can narrow down to
+  // 64 bits here.
+  let deltaHigh64 = delta.high._high
+  let tHigh64 = t.high._high
+  if deltaHigh64 >= tHigh64 &+ (UInt64(1) << high64FractionBits) {
+    let skew: UInt64
+    if isBoundary {
+      skew = deltaHigh64 &- deltaHigh64 / 3 &- tHigh64
+    } else {
+      skew = deltaHigh64 / 2 &- tHigh64
+    }
+    let one = UInt64(1) << high64FractionBits
+    let fractionMask = one - 1
+    let oneHalf = one >> 1
+    var lastDigit = unsafe buffer.unsafeLoad(
+      fromUncheckedByteOffset: nextDigit &- 1,
+      as: UInt8.self)
+    if (skew & fractionMask) == oneHalf {
+      let adjust = skew >> high64FractionBits
+      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
+      lastDigit &= ~1
+    } else {
+      let adjust = (skew + oneHalf) >> high64FractionBits
+      lastDigit &-= UInt8(truncatingIfNeeded: adjust)
+    }
+    buffer.storeBytes(
+      of: lastDigit,
+      toByteOffset: nextDigit &- 1,
+      as: UInt8.self)
+  }
+
+  return _finishFormatting(
+    buffer: &buffer,
+    sign: sign,
+    firstDigit: firstDigit,
+    nextDigit: nextDigit,
+    forceExponential: forceExponential,
+    base10Exponent: base10Exponent)
+}
+#endif
+
+// ================================================================
+//
+// Common Helper functions
+//
+// ================================================================
+
+// Code above computes the appropriate significant digits and stores
+// them in `buffer` between `firstDigit` and `nextDigit`.
+// `finishFormatting` converts this into the final text form,
+// inserting decimal points, minus signs, exponents, etc, as
+// necessary.  To minimize the work here, this assumes that there are
+// at least 5 unused bytes at the beginning of `buffer` before
+// `firstDigit` and that all unused bytes are filled with `"0"` (0x30)
+// characters.
+
+fileprivate func _finishFormatting(
+  buffer: inout MutableRawSpan,
+  sign: FloatingPointSign,
+  firstDigit: Int,
+  nextDigit: Int,
+  forceExponential: Bool,
+  base10Exponent: Int
+) -> Range<Int> {
+  // Performance note: This could be made noticeably faster by
+  // writing the output consistently in exponential form with no
+  // decimal point, e.g., "31415926e-07".  But the extra cost seems
+  // worthwhile to achieve "3.1415926" instead.
+  var firstDigit = firstDigit
+  var nextDigit = nextDigit
+
+  let digitCount = nextDigit &- firstDigit
+  if base10Exponent < -4 || forceExponential {
+    // Exponential form: "-1.23456789e+123"
+    // Rewrite "123456789" => "1.23456789" by moving the first
+    // digit to the left one byte and overwriting a period.
+    // (This is one reason we left empty space to the left of the digits.)
+    // We don't do this for single-digit significands: "1e+78", "5e-324"
+    if digitCount > 1 {
+      let t = unsafe buffer.unsafeLoad(
+        fromUncheckedByteOffset: firstDigit,
+        as: UInt8.self)
+      unsafe buffer.storeBytes(
+        of: 0x2e,
+        toUncheckedByteOffset: firstDigit,
+        as: UInt8.self)
+      firstDigit &-= 1
+      unsafe buffer.storeBytes(
+        of: t,
+        toUncheckedByteOffset: firstDigit,
+        as: UInt8.self)
+    }
+    // Append the exponent:
+    unsafe buffer.storeBytes(
+      of: 0x65, // "e"
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    var e = base10Exponent
+    let expSign: UInt8
+    if base10Exponent < 0 {
+      expSign = 0x2d // "-"
+      e = 0 &- e
+    } else {
+      expSign = 0x2b // "+"
+    }
+    unsafe buffer.storeBytes(
+      of: expSign,
+      toUncheckedByteOffset: nextDigit,
+      as: UInt8.self)
+    nextDigit &+= 1
+    if e > 99 {
+      if e > 999 {
+        let d = asciiDigitTable[e / 100]
+        unsafe buffer.storeBytes(
+          of: d,
+          toUncheckedByteOffset: nextDigit,
+          as: UInt16.self)
+        nextDigit &+= 2
+      } else {
+        let d = 0x30 &+ UInt8(truncatingIfNeeded: (e / 100))
+        unsafe buffer.storeBytes(
+          of: d,
+          toUncheckedByteOffset: nextDigit,
+          as: UInt8.self)
+        nextDigit &+= 1
+      }
+      e = e % 100
+    }
+    let d = unsafe asciiDigitTable[unchecked: e]
+    buffer.storeBytes(
+      of: d,
+      toByteOffset: nextDigit,
+      as: UInt16.self)
+    nextDigit &+= 2
+    } else if base10Exponent < 0 {
+    // "-0.000123456789"
+    // We need up to 5 leading characters before the digits.
+    // Note that the formatters above all insert extra leading "0" characters
+    // to the beginning of the buffer, so we don't need to memset() here,
+    // just back up the start to include them...
+    firstDigit &+= base10Exponent - 1
+    // ... and then overwrite a decimal point to get "0." at the beginning
+    buffer.storeBytes(
+      of: 0x2e, // "."
+      toByteOffset: firstDigit &+ 1,
+      as: UInt8.self)
+  } else if base10Exponent &+ 1 < digitCount {
+    // "123456.789"
+    // We move the first digits forward one position
+    // so we can insert a decimal point in the middle.
+    // Note: This is the only case where we actually move
+    // more than one digit around in the buffer.
+    // TODO: Find out how to use C memmove() here
+    firstDigit &-= 1
+    for i in 0...(base10Exponent &+ 1) {
+      let t = unsafe buffer.unsafeLoad(
+        fromUncheckedByteOffset: firstDigit &+ i &+ 1,
+        as: UInt8.self)
+      unsafe buffer.storeBytes(
+        of: t,
+        toUncheckedByteOffset: firstDigit &+ i,
+        as: UInt8.self)
+    }
+    buffer.storeBytes(
+      of: 0x2e,
+      toByteOffset: firstDigit &+ base10Exponent &+ 1,
+      as: UInt8.self)
+  } else {
+    // "12345678900.0"
+    // Fill trailing zeros, put ".0" at the end
+    // so the result is obviously floating-point.
+    // Remember buffer was initialized with "0"
+    nextDigit = firstDigit &+ base10Exponent &+ 3
+    buffer.storeBytes(
+      of: 0x2e,
+      toByteOffset: nextDigit &- 2,
+      as: UInt8.self)
+  }
+  if sign == .minus {
+    buffer.storeBytes(
+      of: 0x2d, // "-"
+      toByteOffset: firstDigit &- 1,
+      as: UInt8.self)
+    firstDigit &-= 1
+  }
+
+  return unsafe Range(_uncheckedBounds: (lower: firstDigit, upper: nextDigit))
+}
+
+// Table with ASCII strings for all 2-digit decimal numbers.
+// Stored as little-endian UInt16s for efficiency
+fileprivate let asciiDigitTable: _InlineArray<100, UInt16> = [
+  0x3030, 0x3130, 0x3230, 0x3330, 0x3430,
+  0x3530, 0x3630, 0x3730, 0x3830, 0x3930,
+  0x3031, 0x3131, 0x3231, 0x3331, 0x3431,
+  0x3531, 0x3631, 0x3731, 0x3831, 0x3931,
+  0x3032, 0x3132, 0x3232, 0x3332, 0x3432,
+  0x3532, 0x3632, 0x3732, 0x3832, 0x3932,
+  0x3033, 0x3133, 0x3233, 0x3333, 0x3433,
+  0x3533, 0x3633, 0x3733, 0x3833, 0x3933,
+  0x3034, 0x3134, 0x3234, 0x3334, 0x3434,
+  0x3534, 0x3634, 0x3734, 0x3834, 0x3934,
+  0x3035, 0x3135, 0x3235, 0x3335, 0x3435,
+  0x3535, 0x3635, 0x3735, 0x3835, 0x3935,
+  0x3036, 0x3136, 0x3236, 0x3336, 0x3436,
+  0x3536, 0x3636, 0x3736, 0x3836, 0x3936,
+  0x3037, 0x3137, 0x3237, 0x3337, 0x3437,
+  0x3537, 0x3637, 0x3737, 0x3837, 0x3937,
+  0x3038, 0x3138, 0x3238, 0x3338, 0x3438,
+  0x3538, 0x3638, 0x3738, 0x3838, 0x3938,
+  0x3039, 0x3139, 0x3239, 0x3339, 0x3439,
+  0x3539, 0x3639, 0x3739, 0x3839, 0x3939
+]
+
+// The constants below assume we're on a little-endian processor
+fileprivate func _infinity(
+  buffer: inout MutableRawSpan,
+  sign: FloatingPointSign
+) -> Range<Int> {
+  if sign == .minus {
+    buffer.storeBytes(
+      of: 0x666e692d, // "-inf"
+      toByteOffset: 0,
+      as: UInt32.self)
+    return 0..<4
+  } else {
+    buffer.storeBytes(
+      of: 0x00666e69, // "inf\0"
+      toByteOffset: 0,
+      as: UInt32.self)
+    return 0..<3
+  }
+}
+
+fileprivate func _zero(
+  buffer: inout MutableRawSpan,
+  sign: FloatingPointSign
+) -> Range<Int> {
+  if sign == .minus {
+    buffer.storeBytes(
+      of: 0x302e302d, // "-0.0"
+      toByteOffset: 0,
+      as: UInt32.self)
+    return 0..<4
+  } else {
+    buffer.storeBytes(
+      of: 0x00302e30, // "0.0\0"
+      toByteOffset: 0,
+      as: UInt32.self)
+    return 0..<3
+  }
+}
+
+fileprivate let hexdigits: _InlineArray<16, UInt8> = [
+  0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+  0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66
+]
+
+fileprivate func _hexWithoutLeadingZeros(
+  buffer: inout MutableRawSpan,
+  offset: inout Int,
+  value: UInt64
+) {
+  var shift = 60
+  while (shift > 0) && ((value >> shift) & 0xf == 0) {
+    shift -= 4
+  }
+  while shift >= 0 {
+    let d = hexdigits[Int(truncatingIfNeeded: (value >> shift) & 0xf)]
+    shift -= 4
+    buffer.storeBytes(
+      of: d,
+      toByteOffset: offset,
+      as: UInt8.self)
+    offset += 1
+  }
+}
+
+fileprivate func _hexWithLeadingZeros(
+  buffer: inout MutableRawSpan,
+  offset: inout Int,
+  value: UInt64
+) {
+  var shift = 60
+  while shift >= 0 {
+    let d = hexdigits[Int(truncatingIfNeeded: (value >> shift) & 0xf)]
+    shift -= 4
+    buffer.storeBytes(
+      of: d,
+      toByteOffset: offset,
+      as: UInt8.self)
+    offset += 1
+  }
+}
+
+fileprivate func nan_details(
+  buffer: inout MutableRawSpan,
+  sign: FloatingPointSign,
+  quiet: Bool,
+  payloadHigh: UInt64,
+  payloadLow: UInt64
+) -> Range<Int> {
+  // value is a NaN of some sort
+  var i = 0
+  if sign == .minus {
+    buffer.storeBytes(
+      of: 0x2d, // "-"
+      toByteOffset: 0,
+      as: UInt8.self)
+    i = 1
+  }
+  if !quiet {
+    buffer.storeBytes(
+      of: 0x73, // "s"
+      toByteOffset: i,
+      as: UInt8.self)
+    i += 1
+  }
+  buffer.storeBytes(of: 0x6e, toByteOffset: i, as: UInt8.self) // "n"
+  buffer.storeBytes(of: 0x61, toByteOffset: i + 1, as: UInt8.self) // "a"
+  buffer.storeBytes(of: 0x6e, toByteOffset: i + 2, as: UInt8.self) // "n"
+  i += 3
+  if payloadHigh != 0 || payloadLow != 0 {
+    buffer.storeBytes(of: 0x28, toByteOffset: i, as: UInt8.self) // "("
+    i += 1
+    buffer.storeBytes(of: 0x30, toByteOffset: i, as: UInt8.self) // "0"
+    i += 1
+    buffer.storeBytes(of: 0x78, toByteOffset: i, as: UInt8.self) // "x"
+    i += 1
+    if payloadHigh == 0 {
+      _hexWithoutLeadingZeros(buffer: &buffer, offset: &i, value: payloadLow)
+    } else {
+      _hexWithoutLeadingZeros(buffer: &buffer, offset: &i, value: payloadHigh)
+      _hexWithLeadingZeros(buffer: &buffer, offset: &i, value: payloadLow)
+    }
+    buffer.storeBytes(of: 0x29, toByteOffset: i, as: UInt8.self) // ")"
+    i += 1
+  }
+  return 0..<i
+}
+
+// Convert an integer less than 10^8 into exactly 8 ASCII digits in a
+// UInt64.  Assuming little-endian, the resulting UInt64 can be stored
+// directly to memory.
+//
+// This implementation is based on work by Paul Khuong:
+// https://pvk.ca/Blog/2017/12/22/appnexus-common-framework-its-out-also-how-to-print-integers-faster/
+@inline(__always)
+fileprivate func _intToEightDigits(_ n: UInt32) -> UInt64 {
+  // Break into two numbers of 4 decimal digits each
+  let div8 = n / 10000
+  let mod8 = n &- div8 &* 10000
+  let fours = UInt64(div8) | (UInt64(mod8) << 32)
+
+  // Break into 4 numbers of 2 decimal digits each
+  let mask100: UInt64 = 0x0000007f0000007f
+  let div4 = ((fours &* 10486) >> 20) & mask100
+  let mod4 = fours &- 100 &* div4
+  let pairs = div4 | (mod4 &<< 16)
+
+  // Break into 8 numbers of a single decimal digit each
+  let mask10: UInt64 = 0x000f000f000f000f
+  let div2 = ((pairs &* 103) >> 10) & mask10
+  let mod2 = pairs &- 10 &* div2
+  let singles = div2 | (mod2 &<< 8)
+
+  // Convert 8 digits to ASCII characters
+  return singles &+ 0x3030303030303030
+}
+
+// ================================================================
+//
+// Arithmetic Helpers
+//
+// The code above works with fixed-point values.  Standard
+// addition/subtraction/comparison works fine, but we need rounding
+// control when multiplying such values.
+//
+// For exmaple, `multiply128x64RoundingDown` multiplies a 0.128
+// fixed-point value by a 0.64 fixed-point fraction, returning a 0.128
+// value that's been rounded down from the exact 192-bit result.
+//
+// ================================================================
+
+@inline(__always)
+fileprivate func _multiply64x32RoundingDown(
+  _ lhs: UInt64,
+  _ rhs: UInt32
+) -> UInt64 {
+  let mask32 = UInt64(UInt32.max)
+  let t = ((lhs & mask32) * UInt64(rhs)) >> 32
+  return t + (lhs >> 32) * UInt64(rhs)
+}
+
+@inline(__always)
+fileprivate func _multiply64x32RoundingUp(
+  _ lhs: UInt64,
+  _ rhs: UInt32
+) -> UInt64 {
+  let mask32 = UInt64(UInt32.max)
+  let t = (((lhs & mask32) * UInt64(rhs)) + mask32) >> 32
+  return t + (lhs >> 32) * UInt64(rhs)
+}
+
+@inline(__always)
+fileprivate func _multiply128x64RoundingDown(
+  _ lhs: _UInt128,
+  _ rhs: UInt64
+) -> _UInt128 {
+  let lhsHigh = _UInt128(truncatingIfNeeded: lhs._high)
+  let lhsLow = _UInt128(truncatingIfNeeded: lhs._low)
+  let rhs128 = _UInt128(truncatingIfNeeded: rhs)
+  return (lhsHigh &* rhs128) &+ ((lhsLow &* rhs128) >> 64)
+}
+
+@inline(__always)
+fileprivate func _multiply128x64RoundingUp(
+  _ lhs: _UInt128,
+  _ rhs: UInt64
+) -> _UInt128 {
+  let lhsHigh = _UInt128(truncatingIfNeeded: lhs._high)
+  let lhsLow = _UInt128(truncatingIfNeeded: lhs._low)
+  let rhs128 = _UInt128(truncatingIfNeeded: rhs)
+  let h = lhsHigh &* rhs128
+  let l = lhsLow &* rhs128
+  let bias = (_UInt128(1) << 64) &- 1
+  return h + ((l &+ bias) &>> 64)
+}
+
+// Custom 256-bit unsigned integer type, with various arithmetic
+// helpers as methods.
+// Used by 80- and 128-bit floating point formatting logic above...
+fileprivate struct _UInt256 {
+  var high: _UInt128
+  var low: _UInt128
+
+  init() {
+    self.high = 0
+    self.low = 0
+  }
+
+  init(high: UInt64, _ midHigh: UInt64, _ midLow: UInt64, low: UInt64) {
+    self.high = _UInt128(_low: midHigh, _high: high)
+    self.low = _UInt128(_low: low, _high: midLow)
+  }
+
+  init(high: _UInt128, low: _UInt128) {
+    self.high = high
+    self.low = low
+  }
+
+  mutating func shiftRightRoundingDown(by shift: Int) {
+    assert(shift < 32 && shift >= 0)
+    var t = _UInt128(low._low >> shift)
+    t |= _UInt128(low._high) &<< (64 - shift)
+    let newlow = t._low
+    t = _UInt128(t._high)
+    t |= _UInt128(high._low) &<< (64 - shift)
+    low = _UInt128(_low: newlow, _high: t._low)
+    t = _UInt128(t._high)
+    t |= _UInt128(high._high) &<< (64 - shift)
+    high = t
+  }
+
+  mutating func shiftRightRoundingUp(by shift: Int) {
+    assert(shift < 32 && shift >= 0)
+    let bias = (UInt64(1) &<< shift) - 1
+    var t = _UInt128((low._low + bias) >> shift)
+    t |= _UInt128(low._high) &<< (64 - shift)
+    let newlow = t._low
+    t = _UInt128(t._high)
+    t |= _UInt128(high._low) &<< (64 - shift)
+    low = _UInt128(_low: newlow, _high: t._low)
+    t = _UInt128(t._high)
+    t |= _UInt128(high._high) &<< (64 - shift)
+    high = t
+  }
+
+  mutating func multiply(by rhs: UInt32) {
+    var t = _UInt128(low._low) &* _UInt128(rhs)
+    let newlow = t._low
+    t = _UInt128(t._high) &+ _UInt128(low._high) &* _UInt128(rhs)
+    low = _UInt128(_low: newlow, _high: t._low)
+    t = _UInt128(t._high) &+ _UInt128(high._low) &* _UInt128(rhs)
+    let newmidhigh = t._low
+    t = _UInt128(t._high) &+ _UInt128(high._high) &* _UInt128(rhs)
+    high = _UInt128(_low: newmidhigh, _high: t._low)
+    assert(t._high == 0)
+  }
+
+  mutating func multiplyRoundingDown(by rhs: _UInt128) {
+    var current = _UInt128(low._low) * _UInt128(rhs._low)
+
+    current = _UInt128(current._high)
+    var t = _UInt128(low._low) &* _UInt128(rhs._high)
+    current += _UInt128(t._low)
+    var next = _UInt128(t._high)
+    t = _UInt128(low._high) &* _UInt128(rhs._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(low._high) &* _UInt128(rhs._high)
+    current += _UInt128(t._low)
+    next = _UInt128(t._high)
+    t = _UInt128(high._low) &* _UInt128(rhs._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    let newlow = current._low
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(high._low) &* _UInt128(rhs._high)
+    current += _UInt128(t._low)
+    next = _UInt128(t._high)
+    t = _UInt128(high._high) &* _UInt128(rhs._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    low = _UInt128(_low: newlow, _high: current._low)
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(high._high) &* _UInt128(rhs._high)
+    high = current + t
+  }
+
+  mutating func multiplyRoundingUp(by rhs: _UInt128) {
+    var current = _UInt128(low._low) &* _UInt128(rhs._low)
+    current += _UInt128(UInt64.max)
+
+    current = _UInt128(current._high)
+    var t = _UInt128(low._low) &* _UInt128(rhs._high)
+    current += _UInt128(t._low)
+    var next = _UInt128(t._high)
+    t = _UInt128(low._high) &* _UInt128(rhs._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    current += _UInt128(UInt64.max)
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(low._high) &* _UInt128(rhs._high)
+    current += _UInt128(t._low)
+    next = _UInt128(t._high)
+    t = _UInt128(high._low) &* _UInt128(rhs._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    let newlow = current._low
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(high._low) &* _UInt128(rhs._high)
+    current += _UInt128(t._low)
+    next = _UInt128(t._high)
+    t = _UInt128(high._high) &* _UInt128(rhs._low)
+    current += _UInt128(t._low)
+    next += _UInt128(t._high)
+    low = _UInt128(_low: newlow, _high: current._low)
+
+    current = next + _UInt128(current._high)
+    t = _UInt128(high._high) &* _UInt128(rhs._high)
+    high = current + t
+  }
+
+  mutating func extractIntegerPart(_ bits: Int) -> UInt {
+    assert(bits < 16)
+    let integral = high._high >> (64 &- bits)
+    high = _UInt128(
+      _low: high._low,
+      _high: high._high &- (integral &<< (64 &- bits)))
+    return UInt(truncatingIfNeeded: integral)
+  }
+
+  static func &- (lhs: _UInt256, rhs: _UInt256) -> _UInt256 {
+    var t = _UInt128(lhs.low._low) &+ _UInt128(~rhs.low._low) &+ 1
+    let newlowlow = t._low
+    t = _UInt128(t._high) &+ _UInt128(lhs.low._high) &+ _UInt128(~rhs.low._high)
+    let newlow = _UInt128(_low: newlowlow, _high: t._low)
+    t = _UInt128(t._high) &+ _UInt128(lhs.high._low) &+ _UInt128(~rhs.high._low)
+    let newhigh = _UInt128(
+      _low: t._low,
+      _high: t._high &+ lhs.high._high &+ ~rhs.high._high)
+    return _UInt256(high: newhigh, low: newlow)
+  }
+
+  static func < (lhs: _UInt256, rhs: _UInt256) -> Bool {
+    return (lhs.high < rhs.high)
+      || (lhs.high == rhs.high
+            && lhs.low < rhs.low)
+  }
+}
+
+// ================================================================
+//
+// Powers of 10
+//
+// ================================================================
+
+@inline(__always)
+fileprivate func _intervalContainingPowerOf10_Binary32(
+  p: Int,
+  lower: inout UInt64,
+  upper: inout UInt64
+) -> Int {
+  if p >= 0 {
+    let base = powersOf10_Exact128[p &* 2 &+ 1]
+    lower = base
+    if p < 28 {
+      upper = base
+    } else {
+      upper = base &+ 1
+    }
+  } else {
+    let base = powersOf10_negativeBinary32[p &+ 40]
+    lower = base
+    upper = base &+ 1
+  }
+  return binaryExponentFor10ToThe(p)
+}
+
+@inline(__always)
+fileprivate func _intervalContainingPowerOf10_Binary64(
+  p: Int,
+  lower: inout _UInt128,
+  upper: inout _UInt128
+) -> Int {
+  if p >= 0 && p <= 55 {
+    let upper64 = powersOf10_Exact128[p &* 2 &+ 1]
+    let lower64 = powersOf10_Exact128[p &* 2]
+    upper = _UInt128(_low: lower64, _high: upper64)
+    lower = upper
+    return binaryExponentFor10ToThe(p)
+  }
+
+  let index = p &+ 400
+  let mainPower = index / 28
+  let baseHigh = powersOf10_Binary64[mainPower &* 2 &+ 1]
+  let baseLow = powersOf10_Binary64[mainPower &* 2]
+  let extraPower = index &- mainPower &* 28
+  let baseExponent = binaryExponentFor10ToThe(p &- extraPower)
+
+  if extraPower == 0 {
+    lower = _UInt128(_low: baseLow, _high: baseHigh)
+    upper = lower &+ 1
+    return baseExponent
+  } else {
+    let extra = powersOf10_Exact128[extraPower &* 2 &+ 1]
+    lower = ((_UInt128(truncatingIfNeeded:baseHigh)
+                &* _UInt128(truncatingIfNeeded:extra))
+               &+ ((_UInt128(truncatingIfNeeded:baseLow)
+                      &* _UInt128(truncatingIfNeeded:extra)) &>> 64))
+    upper = lower &+ 2
+    return baseExponent &+ binaryExponentFor10ToThe(extraPower)
+  }
+}
+
+@inline(__always)
+fileprivate func binaryExponentFor10ToThe(_ p: Int) -> Int {
+  return Int(((Int64(p) &* 55732705) >> 24) &+ 1)
+}
+
+@inline(__always)
+fileprivate func decimalExponentFor2ToThe(_ p: Int) -> Int {
+  return Int((Int64(p) &* 20201781) >> 26)
+}
+
+// Each of the constant values here have an implicit binary point at
+// the extreme left and when not exact, are rounded _down_ from the
+// exact values.  For example, the first row of the first table says
+// that:
+//
+//   0x0.8b61313bbabce2c6 x 2^-132
+//
+// is the result of rounding down the exact binary value of 10^-40 to
+// 64 significant bits.  The logic above uses these tables to compute
+// bounds for the exact value of the power of 10.
+
+// Note the binary exponent is not stored; it is computed by the
+// `binaryExponentFor10ToThe(p)` function.
+
+// This covers the negative powers of 10 for Float32.
+// Positive powers of 10 come from the next table below.
+// Table size: 320 bytes
+fileprivate let powersOf10_negativeBinary32: _InlineArray<_, UInt64> = [
+  0x8b61313bbabce2c6, // x 2^-132 ~= 10^-40
+  0xae397d8aa96c1b77, // x 2^-129 ~= 10^-39
+  0xd9c7dced53c72255, // x 2^-126 ~= 10^-38
+  0x881cea14545c7575, // x 2^-122 ~= 10^-37
+  0xaa242499697392d2, // x 2^-119 ~= 10^-36
+  0xd4ad2dbfc3d07787, // x 2^-116 ~= 10^-35
+  0x84ec3c97da624ab4, // x 2^-112 ~= 10^-34
+  0xa6274bbdd0fadd61, // x 2^-109 ~= 10^-33
+  0xcfb11ead453994ba, // x 2^-106 ~= 10^-32
+  0x81ceb32c4b43fcf4, // x 2^-102 ~= 10^-31
+  0xa2425ff75e14fc31, // x 2^-99 ~= 10^-30
+  0xcad2f7f5359a3b3e, // x 2^-96 ~= 10^-29
+  0xfd87b5f28300ca0d, // x 2^-93 ~= 10^-28
+  0x9e74d1b791e07e48, // x 2^-89 ~= 10^-27
+  0xc612062576589dda, // x 2^-86 ~= 10^-26
+  0xf79687aed3eec551, // x 2^-83 ~= 10^-25
+  0x9abe14cd44753b52, // x 2^-79 ~= 10^-24
+  0xc16d9a0095928a27, // x 2^-76 ~= 10^-23
+  0xf1c90080baf72cb1, // x 2^-73 ~= 10^-22
+  0x971da05074da7bee, // x 2^-69 ~= 10^-21
+  0xbce5086492111aea, // x 2^-66 ~= 10^-20
+  0xec1e4a7db69561a5, // x 2^-63 ~= 10^-19
+  0x9392ee8e921d5d07, // x 2^-59 ~= 10^-18
+  0xb877aa3236a4b449, // x 2^-56 ~= 10^-17
+  0xe69594bec44de15b, // x 2^-53 ~= 10^-16
+  0x901d7cf73ab0acd9, // x 2^-49 ~= 10^-15
+  0xb424dc35095cd80f, // x 2^-46 ~= 10^-14
+  0xe12e13424bb40e13, // x 2^-43 ~= 10^-13
+  0x8cbccc096f5088cb, // x 2^-39 ~= 10^-12
+  0xafebff0bcb24aafe, // x 2^-36 ~= 10^-11
+  0xdbe6fecebdedd5be, // x 2^-33 ~= 10^-10
+  0x89705f4136b4a597, // x 2^-29 ~= 10^-9
+  0xabcc77118461cefc, // x 2^-26 ~= 10^-8
+  0xd6bf94d5e57a42bc, // x 2^-23 ~= 10^-7
+  0x8637bd05af6c69b5, // x 2^-19 ~= 10^-6
+  0xa7c5ac471b478423, // x 2^-16 ~= 10^-5
+  0xd1b71758e219652b, // x 2^-13 ~= 10^-4
+  0x83126e978d4fdf3b, // x 2^-9 ~= 10^-3
+  0xa3d70a3d70a3d70a, // x 2^-6 ~= 10^-2
+  0xcccccccccccccccc, // x 2^-3 ~= 10^-1
+]
+
+// All the powers of 10 that can be represented exactly
+// in 128 bits, represented as binary floating-point values
+// using the same convention as in the previous table, only
+// with 128 bit significands.
+
+// This table is used in four places:
+// * The high order 64 bits are used for positive powers of 10
+//   when converting Float32.
+// * The full 128-bit value is used for 10^0 through 10^55 for Float64.
+// * The first 28 entries are combined with the next table for
+//   all other Float64 values.
+// * This is combined with the 256-bit table below for Float80/Float128
+//   support.
+
+// Table size: 896 bytes
+fileprivate let powersOf10_Exact128: _InlineArray<_, UInt64> = [
+  // Low order ... high order
+  0x0000000000000000, 0x8000000000000000, // x 2^1 == 10^0 exactly
+  0x0000000000000000, 0xa000000000000000, // x 2^4 == 10^1 exactly
+  0x0000000000000000, 0xc800000000000000, // x 2^7 == 10^2 exactly
+  0x0000000000000000, 0xfa00000000000000, // x 2^10 == 10^3 exactly
+  0x0000000000000000, 0x9c40000000000000, // x 2^14 == 10^4 exactly
+  0x0000000000000000, 0xc350000000000000, // x 2^17 == 10^5 exactly
+  0x0000000000000000, 0xf424000000000000, // x 2^20 == 10^6 exactly
+  0x0000000000000000, 0x9896800000000000, // x 2^24 == 10^7 exactly
+  0x0000000000000000, 0xbebc200000000000, // x 2^27 == 10^8 exactly
+  0x0000000000000000, 0xee6b280000000000, // x 2^30 == 10^9 exactly
+  0x0000000000000000, 0x9502f90000000000, // x 2^34 == 10^10 exactly
+  0x0000000000000000, 0xba43b74000000000, // x 2^37 == 10^11 exactly
+  0x0000000000000000, 0xe8d4a51000000000, // x 2^40 == 10^12 exactly
+  0x0000000000000000, 0x9184e72a00000000, // x 2^44 == 10^13 exactly
+  0x0000000000000000, 0xb5e620f480000000, // x 2^47 == 10^14 exactly
+  0x0000000000000000, 0xe35fa931a0000000, // x 2^50 == 10^15 exactly
+  0x0000000000000000, 0x8e1bc9bf04000000, // x 2^54 == 10^16 exactly
+  0x0000000000000000, 0xb1a2bc2ec5000000, // x 2^57 == 10^17 exactly
+  0x0000000000000000, 0xde0b6b3a76400000, // x 2^60 == 10^18 exactly
+  0x0000000000000000, 0x8ac7230489e80000, // x 2^64 == 10^19 exactly
+  0x0000000000000000, 0xad78ebc5ac620000, // x 2^67 == 10^20 exactly
+  0x0000000000000000, 0xd8d726b7177a8000, // x 2^70 == 10^21 exactly
+  0x0000000000000000, 0x878678326eac9000, // x 2^74 == 10^22 exactly
+  0x0000000000000000, 0xa968163f0a57b400, // x 2^77 == 10^23 exactly
+  0x0000000000000000, 0xd3c21bcecceda100, // x 2^80 == 10^24 exactly
+  0x0000000000000000, 0x84595161401484a0, // x 2^84 == 10^25 exactly
+  0x0000000000000000, 0xa56fa5b99019a5c8, // x 2^87 == 10^26 exactly
+  0x0000000000000000, 0xcecb8f27f4200f3a, // x 2^90 == 10^27 exactly
+  0x4000000000000000, 0x813f3978f8940984, // x 2^94 == 10^28 exactly
+  0x5000000000000000, 0xa18f07d736b90be5, // x 2^97 == 10^29 exactly
+  0xa400000000000000, 0xc9f2c9cd04674ede, // x 2^100 == 10^30 exactly
+  0x4d00000000000000, 0xfc6f7c4045812296, // x 2^103 == 10^31 exactly
+  0xf020000000000000, 0x9dc5ada82b70b59d, // x 2^107 == 10^32 exactly
+  0x6c28000000000000, 0xc5371912364ce305, // x 2^110 == 10^33 exactly
+  0xc732000000000000, 0xf684df56c3e01bc6, // x 2^113 == 10^34 exactly
+  0x3c7f400000000000, 0x9a130b963a6c115c, // x 2^117 == 10^35 exactly
+  0x4b9f100000000000, 0xc097ce7bc90715b3, // x 2^120 == 10^36 exactly
+  0x1e86d40000000000, 0xf0bdc21abb48db20, // x 2^123 == 10^37 exactly
+  0x1314448000000000, 0x96769950b50d88f4, // x 2^127 == 10^38 exactly
+  0x17d955a000000000, 0xbc143fa4e250eb31, // x 2^130 == 10^39 exactly
+  0x5dcfab0800000000, 0xeb194f8e1ae525fd, // x 2^133 == 10^40 exactly
+  0x5aa1cae500000000, 0x92efd1b8d0cf37be, // x 2^137 == 10^41 exactly
+  0xf14a3d9e40000000, 0xb7abc627050305ad, // x 2^140 == 10^42 exactly
+  0x6d9ccd05d0000000, 0xe596b7b0c643c719, // x 2^143 == 10^43 exactly
+  0xe4820023a2000000, 0x8f7e32ce7bea5c6f, // x 2^147 == 10^44 exactly
+  0xdda2802c8a800000, 0xb35dbf821ae4f38b, // x 2^150 == 10^45 exactly
+  0xd50b2037ad200000, 0xe0352f62a19e306e, // x 2^153 == 10^46 exactly
+  0x4526f422cc340000, 0x8c213d9da502de45, // x 2^157 == 10^47 exactly
+  0x9670b12b7f410000, 0xaf298d050e4395d6, // x 2^160 == 10^48 exactly
+  0x3c0cdd765f114000, 0xdaf3f04651d47b4c, // x 2^163 == 10^49 exactly
+  0xa5880a69fb6ac800, 0x88d8762bf324cd0f, // x 2^167 == 10^50 exactly
+  0x8eea0d047a457a00, 0xab0e93b6efee0053, // x 2^170 == 10^51 exactly
+  0x72a4904598d6d880, 0xd5d238a4abe98068, // x 2^173 == 10^52 exactly
+  0x47a6da2b7f864750, 0x85a36366eb71f041, // x 2^177 == 10^53 exactly
+  0x999090b65f67d924, 0xa70c3c40a64e6c51, // x 2^180 == 10^54 exactly
+  0xfff4b4e3f741cf6d, 0xd0cf4b50cfe20765, // x 2^183 == 10^55 exactly
+]
+
+// Every 28th power of 10 across the full range of Double.
+// Combined with a 64-bit exact power of 10 from the previous
+// table, this lets us reconstruct a 128-bit lower bound for
+// any power of 10 across the full range of double with a single
+// 64-bit by 128-bit multiplication.
+
+// The published algorithms generally use a full table here of
+// 800 128-bit values (6400 bytes).  Breaking it into two tables
+// gives a significant code-size savings for a modest performance
+// penalty.
+
+// Table size: 464 bytes
+fileprivate let powersOf10_Binary64: _InlineArray<_, UInt64> = [
+  // low-order half, high-order half
+  0x3931b850df08e738, 0x95fe7e07c91efafa, // x 2^-1328 ~= 10^-400
+  0xba954f8e758fecb3, 0x9774919ef68662a3, // x 2^-1235 ~= 10^-372
+  0x9028bed2939a635c, 0x98ee4a22ecf3188b, // x 2^-1142 ~= 10^-344
+  0x47b233c92125366e, 0x9a6bb0aa55653b2d, // x 2^-1049 ~= 10^-316
+  0x4ee367f9430aec32, 0x9becce62836ac577, // x 2^-956 ~= 10^-288
+  0x6f773fc3603db4a9, 0x9d71ac8fada6c9b5, // x 2^-863 ~= 10^-260
+  0xc47bc5014a1a6daf, 0x9efa548d26e5a6e1, // x 2^-770 ~= 10^-232
+  0x80e8a40eccd228a4, 0xa086cfcd97bf97f3, // x 2^-677 ~= 10^-204
+  0xb8ada00e5a506a7c, 0xa21727db38cb002f, // x 2^-584 ~= 10^-176
+  0xc13e60d0d2e0ebba, 0xa3ab66580d5fdaf5, // x 2^-491 ~= 10^-148
+  0xc2974eb4ee658828, 0xa54394fe1eedb8fe, // x 2^-398 ~= 10^-120
+  0xcb4ccd500f6bb952, 0xa6dfbd9fb8e5b88e, // x 2^-305 ~= 10^-92
+  0x3f2398d747b36224, 0xa87fea27a539e9a5, // x 2^-212 ~= 10^-64
+  0xdde50bd1d5d0b9e9, 0xaa242499697392d2, // x 2^-119 ~= 10^-36
+  0xfdc20d2b36ba7c3d, 0xabcc77118461cefc, // x 2^-26 ~= 10^-8
+  0x0000000000000000, 0xad78ebc5ac620000, // x 2^67 == 10^20 exactly
+  0x9670b12b7f410000, 0xaf298d050e4395d6, // x 2^160 == 10^48 exactly
+  0x3b25a55f43294bcb, 0xb0de65388cc8ada8, // x 2^253 ~= 10^76
+  0x58edec91ec2cb657, 0xb2977ee300c50fe7, // x 2^346 ~= 10^104
+  0x29babe4598c311fb, 0xb454e4a179dd1877, // x 2^439 ~= 10^132
+  0x577b986b314d6009, 0xb616a12b7fe617aa, // x 2^532 ~= 10^160
+  0x0c11ed6d538aeb2f, 0xb7dcbf5354e9bece, // x 2^625 ~= 10^188
+  0x6d953e2bd7173692, 0xb9a74a0637ce2ee1, // x 2^718 ~= 10^216
+  0x9d6d1ad41abe37f1, 0xbb764c4ca7a4440f, // x 2^811 ~= 10^244
+  0x4b2d8644d8a74e18, 0xbd49d14aa79dbc82, // x 2^904 ~= 10^272
+  0xe0470a63e6bd56c3, 0xbf21e44003acdd2c, // x 2^997 ~= 10^300
+  0x505f522e53053ff2, 0xc0fe908895cf3b44, // x 2^1090 ~= 10^328
+  0xcca845ab2beafa9a, 0xc2dfe19c8c055535, // x 2^1183 ~= 10^356
+  0x1027fff56784f444, 0xc4c5e310aef8aa17, // x 2^1276 ~= 10^384
+]
+
+// Needed by 80- and 128-bit formatters above
+
+// We could cut this in half by keeping only the positive powers and doing
+// a single additional 256-bit multiplication by 10^-4984 to recover the negative powers.
+
+// Table size: 5728 bytes
+fileprivate let powersOf10_Binary128: _InlineArray<_, UInt64> = [
+  // Low-order ... high-order
+  0xaec2e6aff96b46ae, 0xf91044c2eff84750, 0x2b55c9e70e00c557, 0xb6536903bf8f2bda, // x 2^-16556 ~= 10^-4984
+  0xda1b3c3dd3889587, 0x73a7380aba84a6b1, 0xbddb2dfde3f8a6e3, 0xb9e5428330737362, // x 2^-16370 ~= 10^-4928
+  0xa2d23c57cfebb9ec, 0x9f165c039ead6d77, 0x88227fdfc13ab53d, 0xbd89006346a9a34d, // x 2^-16184 ~= 10^-4872
+  0x0333d510cf27e5a5, 0x4e3cc383eaa17b7b, 0xe05fe4207ca3d508, 0xc13efc51ade7df64, // x 2^-15998 ~= 10^-4816
+  0xff242c569bc1f539, 0x5c67ba58680c4cce, 0x3c55f3f947fef0e9, 0xc50791bd8dd72edb, // x 2^-15812 ~= 10^-4760
+  0xe4b75ae27bec50bf, 0x25b0419765fdfcdb, 0x0915564d8ab057ee, 0xc8e31de056f89c19, // x 2^-15626 ~= 10^-4704
+  0x548b1e80a94f3434, 0xe418e9217ce83755, 0x801e38463183fc88, 0xccd1ffc6bba63e21, // x 2^-15440 ~= 10^-4648
+  0x541950a0fdc2b4d9, 0xeea173da1f0eb7b4, 0xcfadf6b2aa7c4f43, 0xd0d49859d60d40a3, // x 2^-15254 ~= 10^-4592
+  0x7e64501be95ad76b, 0x451e855d8acef835, 0x9e601e707a2c3488, 0xd4eb4a687c0253e8, // x 2^-15068 ~= 10^-4536
+  0xdadd9645f360cb51, 0xf290163350ecb3eb, 0xa8edffdccfe4db4b, 0xd9167ab0c1965798, // x 2^-14882 ~= 10^-4480
+  0x7e447db3018ffbdf, 0x4fa1860c08a85923, 0xb17cd86e7fcece75, 0xdd568fe9ab559344, // x 2^-14696 ~= 10^-4424
+  0x61cd4655bf64d265, 0xb19fd88fe285b3bc, 0x1151250681d59705, 0xe1abf2cd11206610, // x 2^-14510 ~= 10^-4368
+  0xa5703f5ce7a619ec, 0x361243a84b55574d, 0x025a8e1e5dbb41d6, 0xe6170e21b2910457, // x 2^-14324 ~= 10^-4312
+  0xb93897a6cf5d3e61, 0x18746fcc6a190db9, 0x66e849253e5da0c2, 0xea984ec57de69f13, // x 2^-14138 ~= 10^-4256
+  0x309043d12ab5b0ac, 0x79c93cff11f09319, 0xf5a7800f23ef67b8, 0xef3023b80a732d93, // x 2^-13952 ~= 10^-4200
+  0xa3baa84c049b52b9, 0xbec466ee1b586342, 0x0e85fc7f4edbd3ca, 0xf3defe25478e074a, // x 2^-13766 ~= 10^-4144
+  0xd1f4628316b15c7a, 0xae16192410d3135e, 0x4268a54f70bd28c4, 0xf8a551706112897c, // x 2^-13580 ~= 10^-4088
+  0x9eb9296cc5749dba, 0x48324e275376dfdd, 0x5052e9289f0f2333, 0xfd83933eda772c0b, // x 2^-13394 ~= 10^-4032
+  0xff6aae669a5a0d8a, 0x24fed95087b9006e, 0x01b02378a405b421, 0x813d1dc1f0c754d6, // x 2^-13207 ~= 10^-3976
+  0xf993f18de00dc89b, 0x15617da021b89f92, 0xb782db1fc6aba49b, 0x83c4e245ed051dc1, // x 2^-13021 ~= 10^-3920
+  0xc6a0d64a712172b1, 0x2217669197ac1504, 0x4250be2eeba87d15, 0x86595584116caf3c, // x 2^-12835 ~= 10^-3864
+  0x0bdc0c67a220687b, 0x44a66a6d6fd6537b, 0x3f1f93f1943ca9b6, 0x88fab70d8b44952a, // x 2^-12649 ~= 10^-3808
+  0xb60b57164ad28122, 0xde5bd4572c25a830, 0x2c87f18b39478aa2, 0x8ba947b223e5783e, // x 2^-12463 ~= 10^-3752
+  0xbd59568efdb9bfee, 0x292f8f2c98d7f44c, 0x4054f5360249ebd1, 0x8e6549867da7d11a, // x 2^-12277 ~= 10^-3696
+  0x9fa0721e66791acc, 0x1789061d717d454c, 0xc1187fa0c18adbbe, 0x912effea7015b2c5, // x 2^-12091 ~= 10^-3640
+  0x982b64e953ac4e27, 0x45efb05f20cf48b3, 0x4b4de34e0ebc3e06, 0x9406af8f83fd6265, // x 2^-11905 ~= 10^-3584
+  0xa53f5950eec21dca, 0x3bd8754763bdbca1, 0xac73f0226eff5ea1, 0x96ec9e7f9004839b, // x 2^-11719 ~= 10^-3528
+  0x320e19f88f1161b7, 0x72e93fe0cce7cfd9, 0x2184706ea46a4c38, 0x99e11423765ec1d0, // x 2^-11533 ~= 10^-3472
+  0x491aba48dfc0e36e, 0xd3de560ee34022b2, 0xddadb80577b906bd, 0x9ce4594a044e0f1b, // x 2^-11347 ~= 10^-3416
+  0x06789d038697142f, 0x7a466a75be73db21, 0x60dbd8aa443b560f, 0x9ff6b82ef415d222, // x 2^-11161 ~= 10^-3360
+  0x40ed8056af76ac43, 0x08251c601e346456, 0x7401c6f091f87727, 0xa3187c82120dace6, // x 2^-10975 ~= 10^-3304
+  0x8c643ee307bffec6, 0xf369a11c6f66c05a, 0x4d5b32f713d7f476, 0xa649f36e8583e81a, // x 2^-10789 ~= 10^-3248
+  0xe32f5e080e36b4be, 0x3adf30ff2eb163d4, 0xb4b39dd9ddb8d317, 0xa98b6ba23e2300c7, // x 2^-10603 ~= 10^-3192
+  0x6b9d538c192cfb1b, 0x1c5af3bd4d2c60b5, 0xec41c1793d69d0d1, 0xacdd3555869159d1, // x 2^-10417 ~= 10^-3136
+  0x1adadaeedf7d699c, 0x71043692494aa743, 0x3ca5a7540d9d56c9, 0xb03fa252bd05a815, // x 2^-10231 ~= 10^-3080
+  0xec3e4e5fc6b03617, 0x47c9b16afe8fdf74, 0x92e1bc1fbb33f18d, 0xb3b305fe328e571f, // x 2^-10045 ~= 10^-3024
+  0x1d42fa68b12bdb23, 0xac46a7b3f2b4b34e, 0xa908fd4a88728b6a, 0xb737b55e31cdde04, // x 2^-9859 ~= 10^-2968
+  0x887dede507f2b618, 0x359a8fa0d014b9a7, 0x7c4c65d15c614c56, 0xbace07232df1c802, // x 2^-9673 ~= 10^-2912
+  0x504708e718b4b669, 0xfb4d9440822af452, 0xef84cc99cb4c5d17, 0xbe7653b01aae13e5, // x 2^-9487 ~= 10^-2856
+  0x5b7977525516bff0, 0x75913092420c9b35, 0xcfc147ade4843a24, 0xc230f522ee0a7fc2, // x 2^-9301 ~= 10^-2800
+  0xad5d11883cc1302b, 0x860a754894b9a0bc, 0x4668677d5f46c29b, 0xc5fe475d4cd35cff, // x 2^-9115 ~= 10^-2744
+  0x42032f9f971bfc07, 0x9fb576046ab35018, 0x474b3cb1fe1d6a7f, 0xc9dea80d6283a34c, // x 2^-8929 ~= 10^-2688
+  0xd3e7fbb72403a4dd, 0x8ca223055819af54, 0xd6ea3b733029ef0b, 0xcdd276b6e582284f, // x 2^-8743 ~= 10^-2632
+  0xba2431d885f2b7d9, 0xc9879fc42869f610, 0x3736730a9e47fef8, 0xd1da14bc489025ea, // x 2^-8557 ~= 10^-2576
+  0xa11edbcd65dd1844, 0xcb8edae81a295887, 0x3d24e68dc1027246, 0xd5f5e5681a4b9285, // x 2^-8371 ~= 10^-2520
+  0xa0f076652f69ad08, 0x9d19c341f5f42f2a, 0x742ab8f3864562c8, 0xda264df693ac3e30, // x 2^-8185 ~= 10^-2464
+  0x29f760ef115f2824, 0xe0ee47c041c9de0f, 0x8c119f3680212413, 0xde6bb59f56672cda, // x 2^-7999 ~= 10^-2408
+  0x8b90230b3409c9d3, 0x9d76eef2c1543e65, 0x43190b523f872b9c, 0xe2c6859f5c284230, // x 2^-7813 ~= 10^-2352
+  0xd44ce9993bc6611e, 0x777c9b2dfbede079, 0x2a0969bf88679396, 0xe7372943179706fc, // x 2^-7627 ~= 10^-2296
+  0xe8c5f5a63fd0fbd1, 0x0ccc12293f1d7a58, 0x131565be33dda91a, 0xebbe0df0c8201ac5, // x 2^-7441 ~= 10^-2240
+  0xdb97988dd6b776f4, 0xeb2106f435f7e1d5, 0xccfb1cc2ef1f44de, 0xf05ba3330181c750, // x 2^-7255 ~= 10^-2184
+  0x2fcbc8df94a1d54b, 0x796d0a8120801513, 0x5f8385b3a882ff4c, 0xf5105ac3681f2716, // x 2^-7069 ~= 10^-2128
+  0xc8700c11071a40f5, 0x23cb9e9df9331fe4, 0x166c15f456786c27, 0xf9dca895a3226409, // x 2^-6883 ~= 10^-2072
+  0x9589f4637a50cbb5, 0xea8242b0030e4a51, 0x6c656c3b1f2c9d91, 0xfec102e2857bc1f9, // x 2^-6697 ~= 10^-2016
+  0xc4be56c83349136c, 0x6188db81ac8e775d, 0xfa70b9a2ca60b004, 0x81def119b76837c8, // x 2^-6510 ~= 10^-1960
+  0xb85d39054658b363, 0xe7df06bc613fda21, 0x6a22490e8e9ec98b, 0x8469e0b6f2b8bd9b, // x 2^-6324 ~= 10^-1904
+  0x800b1e1349fef248, 0x469cfd2e6ca32a77, 0x69138459b0fa72d4, 0x87018eefb53c6325, // x 2^-6138 ~= 10^-1848
+  0xb62593291c768919, 0xc098e6ed0bfbd6f6, 0x6c83ad1260ff20f4, 0x89a63ba4c497b50e, // x 2^-5952 ~= 10^-1792
+  0x92ee7fce474479d3, 0xe02017175bf040c6, 0xd82ef2860273de8d, 0x8c5827f711735b46, // x 2^-5766 ~= 10^-1736
+  0x7b0e6375ca8c77d9, 0x5f07e1e10097d47f, 0x416d7f9ab1e67580, 0x8f17964dfc3961f2, // x 2^-5580 ~= 10^-1680
+  0xc8d869ed561af1ce, 0x8b6648e941de779b, 0x56700866b85d57fe, 0x91e4ca5db93dbfec, // x 2^-5394 ~= 10^-1624
+  0xfc04df783488a410, 0x64d1f15da2c146b1, 0x43cf71d5c4fd7868, 0x94c0092dd4ef9511, // x 2^-5208 ~= 10^-1568
+  0xfbaf03b48a965a64, 0x9b6122aa2b72a13c, 0x387898a6e22f821b, 0x97a9991fd8b3afc0, // x 2^-5022 ~= 10^-1512
+  0x50f7f7c13119aadd, 0xe415d8b25694250a, 0x8f8857e875e7774e, 0x9aa1c1f6110c0dd0, // x 2^-4836 ~= 10^-1456
+  0xce214403545fd685, 0xf36d1ad779b90e09, 0xa5c58d5f91a476d7, 0x9da8ccda75b341b5, // x 2^-4650 ~= 10^-1400
+  0x63ddfb68f971b0c5, 0x2822e38faf74b26e, 0x6e1f7f1642ebaac8, 0xa0bf0465b455e921, // x 2^-4464 ~= 10^-1344
+  0xf0d00cec9daf7444, 0x6bf3eea6f661a32a, 0xfad2be1679765f27, 0xa3e4b4a65e97b76a, // x 2^-4278 ~= 10^-1288
+  0x463b4ab4bd478f57, 0x6f6583b5b36d5426, 0x800cfab80c4e2eb1, 0xa71a2b283c14fba6, // x 2^-4092 ~= 10^-1232
+  0xef163df2fa96e983, 0xa825f32bc8f6b080, 0x850b0c5976b21027, 0xaa5fb6fbc115010b, // x 2^-3906 ~= 10^-1176
+  0x7db1b3f8e100eb43, 0x2862b1f61d64ddc3, 0x61363686961a41e5, 0xadb5a8bdaaa53051, // x 2^-3720 ~= 10^-1120
+  0xfd349cf00ba1e09a, 0x6d282fe1b7112879, 0xc6f075c4b81fc72d, 0xb11c529ec0d87268, // x 2^-3534 ~= 10^-1064
+  0xf7221741b221cf6f, 0x3739f15b06ac3c76, 0xb4e4be5b6455ef96, 0xb494086bbfea00c3, // x 2^-3348 ~= 10^-1008
+  0xc4e5a2f864c403bb, 0x6e33cdcda4367276, 0x24d256c540a50309, 0xb81d1f9569068d8e, // x 2^-3162 ~= 10^-952
+  0x276e3f0f67f0553b, 0x00de73d9d5be6974, 0x6d4aa5b50bb5dc0d, 0xbbb7ef38bb827f2d, // x 2^-2976 ~= 10^-896
+  0x51a34a3e674484ed, 0x1fb6069f8b26f840, 0x925624c0d7d93317, 0xbf64d0275747de70, // x 2^-2790 ~= 10^-840
+  0xcc775c8cb6de1dbc, 0x6d60d02eac6309ee, 0x8e5a2e5116baf191, 0xc3241cf0094a8e70, // x 2^-2604 ~= 10^-784
+  0x6023c8fa17d7b105, 0x069cf8f51d2e5e65, 0xb0560c246f90e9e8, 0xc6f631e782d57096, // x 2^-2418 ~= 10^-728
+  0x92c17acb2d08d5fd, 0xc26ffb8e81532725, 0x2ffff1289a804c5a, 0xcadb6d313c8736fc, // x 2^-2232 ~= 10^-672
+  0x47df78ab9e92897a, 0xc02b302a892b81dc, 0xa855e127113c887b, 0xced42ec885d9dbbe, // x 2^-2046 ~= 10^-616
+  0xdaf2dec03ec0c322, 0x72db3bc15b0c7014, 0xe00bad8dfc0d8c8e, 0xd2e0d889c213fd60, // x 2^-1860 ~= 10^-560
+  0xd3a04799e4473ac8, 0xa116409a2fdf1e9e, 0xc654d07271e6c39f, 0xd701ce3bd387bf47, // x 2^-1674 ~= 10^-504
+  0x5c8a5dc65d745a24, 0x2726c48a85389fa7, 0x84c663cee6b86e7c, 0xdb377599b6074244, // x 2^-1488 ~= 10^-448
+  0xd7ebc61ba77a9e66, 0x8bf77d4bc59b35b1, 0xcb285ceb2fed040d, 0xdf82365c497b5453, // x 2^-1302 ~= 10^-392
+  0x744ce999bfed213a, 0x363b1f2c568dc3e2, 0xfd1b1b2308169b25, 0xe3e27a444d8d98b7, // x 2^-1116 ~= 10^-336
+  0x6a40608fe10de7e7, 0xf910f9f648232f14, 0xd1b3400f8f9cff68, 0xe858ad248f5c22c9, // x 2^-930 ~= 10^-280
+  0x9bdbfc21260dd1ad, 0x4609ac5c7899ca36, 0xa4f8bf5635246428, 0xece53cec4a314ebd, // x 2^-744 ~= 10^-224
+  0xd88181aad19d7454, 0xf80f36174730ca34, 0xdc44e6c3cb279ac1, 0xf18899b1bc3f8ca1, // x 2^-558 ~= 10^-168
+  0xee19bfa6947f8e02, 0xaa09501d5954a559, 0x4d4617b5ff4a16d5, 0xf64335bcf065d37d, // x 2^-372 ~= 10^-112
+  0xebbc75a03b4d60e6, 0xac2e4f162cfad40a, 0xeed6e2f0f0d56712, 0xfb158592be068d2e, // x 2^-186 ~= 10^-56
+  0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x8000000000000000, // x 2^1 == 10^0 exactly
+  0x0000000000000000, 0x2000000000000000, 0xbff8f10e7a8921a4, 0x82818f1281ed449f, // x 2^187 == 10^56 exactly
+  0x51775f71e92bf2f2, 0x74a7ef0198791097, 0x03e2cf6bc604ddb0, 0x850fadc09923329e, // x 2^373 ~= 10^112
+  0xb204b3d9686f55b5, 0xfb118fc9c217a1d2, 0x90fb44d2f05d0842, 0x87aa9aff79042286, // x 2^559 ~= 10^168
+  0xd7924bff833149fa, 0xbc10c5c5cda97c8d, 0x82bd6b70d99aaa6f, 0x8a5296ffe33cc92f, // x 2^745 ~= 10^224
+  0xa67d072d3c7fa14b, 0x7ec63730f500b406, 0xdb0b487b6423e1e8, 0x8d07e33455637eb2, // x 2^931 ~= 10^280
+  0x546f2a35dc367e47, 0x949063d8a46f0c0e, 0x213a4f0aa5e8a7b1, 0x8fcac257558ee4e6, // x 2^1117 ~= 10^336
+  0x50611a621c0ee3ae, 0x202d895116aa96be, 0x1c306f5d1b0b5fdf, 0x929b7871de7f22b9, // x 2^1303 ~= 10^392
+  0xffa6738a27dcf7a3, 0x3c11d8430d5c4802, 0xa7ea9c8838ce9437, 0x957a4ae1ebf7f3d3, // x 2^1489 ~= 10^448
+  0x5bf36c0f40bde99d, 0x284ba600ee9f6303, 0xbf1d49cacccd5e68, 0x9867806127ece4f4, // x 2^1675 ~= 10^504
+  0xa6e937834ed12e58, 0x73f26eb82f6b8066, 0x655494c5c95d77f2, 0x9b63610bb9243e46, // x 2^1861 ~= 10^560
+  0x0cd4b7660adc6930, 0x8f868688f8eb79eb, 0x02e008393fd60b55, 0x9e6e366733f85561, // x 2^2047 ~= 10^616
+  0x3efb9807d86d3c6a, 0x84c10a1d22f5adc5, 0x55e04dba4b3bd4dd, 0xa1884b69ade24964, // x 2^2233 ~= 10^672
+  0xf065089401df33b4, 0x1fc02370c451a755, 0x44b222741eb1ebbf, 0xa4b1ec80f47c84ad, // x 2^2419 ~= 10^728
+  0xa62d0da836fce7d5, 0x75933380ceb5048c, 0x1cf4a5c3bc09fa6f, 0xa7eb6799e8aec999, // x 2^2605 ~= 10^784
+  0x7a400df820f096c2, 0x802c4085068d2dd5, 0x3c4a575151b294dc, 0xab350c27feb90acc, // x 2^2791 ~= 10^840
+  0xf48b51375df06e86, 0x412fe9e72afd355e, 0x870a8d87239d8f35, 0xae8f2b2ce3d5dbe9, // x 2^2977 ~= 10^896
+  0x881883521930127c, 0xe53fd3fcb5b4df25, 0xdd929f09c3eff5ac, 0xb1fa17404a30e5e8, // x 2^3163 ~= 10^952
+  0x270cd9f1348eb326, 0x37ed82fe9c75fccf, 0x1931b583a9431d7e, 0xb5762497dbf17a9e, // x 2^3349 ~= 10^1008
+  0x8919b01a5b3d9ec1, 0x6a7669bdfc6f699c, 0xe30db03e0f8dd286, 0xb903a90f561d25e2, // x 2^3535 ~= 10^1064
+  0xf0461526b4201aa5, 0x7fe40defe17e55f5, 0x9eb5cb19647508c5, 0xbca2fc30cc19f090, // x 2^3721 ~= 10^1120
+  0xd67bf35422978bbf, 0x0dbb1c416ebe661f, 0x24bd4c00042ad125, 0xc054773d149bf26b, // x 2^3907 ~= 10^1176
+  0xdd093192ef5508d0, 0x6eac3085943ccc0f, 0x7ea30dbd7ea479e3, 0xc418753460cdcca9, // x 2^4093 ~= 10^1232
+  0xfe4ff20db6d25dc2, 0x5d5d5a9519e34a42, 0x764f4cf916b4dece, 0xc7ef52defe87b751, // x 2^4279 ~= 10^1288
+  0xd8adfb2e00494c5e, 0x72435286baf0e84e, 0xbeb7fbdc1cbe8b37, 0xcbd96ed6466cf081, // x 2^4465 ~= 10^1344
+  0xe07c1e4384f594af, 0x0c6b90b8874d5189, 0xdce472c619aa3f63, 0xcfd7298db6cb9672, // x 2^4651 ~= 10^1400
+  0x5dd902c68fa448cf, 0xea8d16bd9544e48e, 0xe47defc14a406e4f, 0xd3e8e55c3c1f43d0, // x 2^4837 ~= 10^1456
+  0x1223d79357bedca8, 0xeae6c2843752ac35, 0xb7157c60a24a0569, 0xd80f0685a81b2a81, // x 2^5023 ~= 10^1512
+  0xcff72d64bc79e429, 0xccc52c236decd778, 0xfb0b98f6bbc4f0cb, 0xdc49f3445824e360, // x 2^5209 ~= 10^1568
+  0x3731f76b905dffbb, 0x5e2bddd7d12a9e42, 0xc6c6c1764e047e15, 0xe09a13d30c2dba62, // x 2^5395 ~= 10^1624
+  0xeb58d8ef2ada7c09, 0xbc1a3b726b789947, 0x87e8dcfc09dbc33a, 0xe4ffd276eedce658, // x 2^5581 ~= 10^1680
+  0x249a5c06dc5d5db7, 0xa8f09440be97bfe6, 0xb1a3642a8da3cf4f, 0xe97b9b89d001dab3, // x 2^5767 ~= 10^1736
+  0xbf34ff7963028cd9, 0xc20578fa3851488b, 0x2d4070f33b21ab7b, 0xee0ddd84924ab88c, // x 2^5953 ~= 10^1792
+  0x002d0511317361d5, 0xd6919e041129a1a7, 0xa2bf0c63a814e04e, 0xf2b70909cd3fd35c, // x 2^6139 ~= 10^1848
+  0x1fa87f28acf1dcd2, 0xe7a0a88981d1a0f9, 0x08f13995cf9c2747, 0xf77790f0a48a45ce, // x 2^6325 ~= 10^1904
+  0x1b6ff8afbe589b72, 0xc851bb3f9aeb1211, 0x7a37993eb21444fa, 0xfc4fea4fd590b40a, // x 2^6511 ~= 10^1960
+  0xef23a4cbc039f0c2, 0xbb3f8498a972f18e, 0xb7b1ada9cdeba84d, 0x80a046447e3d49f1, // x 2^6698 ~= 10^2016
+  0x2cc44f2b602b6231, 0xf231f4b7996b7278, 0x0cc6866c5d69b2cb, 0x8324f8aa08d7d411, // x 2^6884 ~= 10^2072
+  0x822c97629a3a4c69, 0x8a9afcdbc940e6f9, 0x7fe2b4308dcbf1a3, 0x85b64a659077660e, // x 2^7070 ~= 10^2128
+  0xf66cfcf42d4896b0, 0x1f11852a20ed33c5, 0x1d73ef3eaac3c964, 0x88547abb1d8e5bd9, // x 2^7256 ~= 10^2184
+  0x63093ad0caadb06c, 0x31be1482014cdaf0, 0x1e34291b1ef566c7, 0x8affca2bd1f88549, // x 2^7442 ~= 10^2240
+  0xab50f69048738e9a, 0xa126c32ff4882be8, 0x9e9383d73d486881, 0x8db87a7c1e56d873, // x 2^7628 ~= 10^2296
+  0xe57e659432b0a73e, 0x47a0e15dfc7986b8, 0x9cc5ee51962c011a, 0x907eceba168949b3, // x 2^7814 ~= 10^2352
+  0x8a6ff950599f8ae5, 0xd1cbbb7d005a76d3, 0x413407cfeeac9743, 0x93530b43e5e2c129, // x 2^8000 ~= 10^2408
+  0xd4e6b6e847550caa, 0x56a3106227b87706, 0x7efa7d29c44e11b7, 0x963575ce63b6332d, // x 2^8186 ~= 10^2464
+  0xd835c90b09842263, 0xb69f01a641da2a42, 0x5a848859645d1c6f, 0x9926556bc8defe43, // x 2^8372 ~= 10^2520
+  0x9b0ae73c204ecd61, 0x0794fd5e5a51ac2f, 0x51edea897b34601f, 0x9c25f29286e9ddb6, // x 2^8558 ~= 10^2576
+  0x3130484fb0a61d89, 0x32b7105223a27365, 0xb50008d92529e91f, 0x9f3497244186fca4, // x 2^8744 ~= 10^2632
+  0x8cd036553f38a1e8, 0x5e997e9f45d7897d, 0xf09e780bcc8238d9, 0xa2528e74eaf101fc, // x 2^8930 ~= 10^2688
+  0xe1f8b43b08b5d0ef, 0xa0eaf3f62dc1777c, 0x3a5828869701a165, 0xa580255203f84b47, // x 2^9116 ~= 10^2744
+  0x3c7f62e3154fa708, 0x5786f3927eb15bd5, 0x8b231a70eb5444ce, 0xa8bdaa0a0064fa44, // x 2^9302 ~= 10^2800
+  0x1ebc24a19cd70a2a, 0x843fddd10c7006b8, 0xfa1bde1f473556a4, 0xac0b6c73d065f8cc, // x 2^9488 ~= 10^2856
+  0x46b6aae34cfd26fc, 0x00db7d919b136c68, 0x7730e00421da4d55, 0xaf69bdf68fc6a740, // x 2^9674 ~= 10^2912
+  0x1c4edcb83fc4c49d, 0x61c0edd56bbcb3e8, 0x7f959cb702329d14, 0xb2d8f1915ba88ca5, // x 2^9860 ~= 10^2968
+  0x428c840d247382fe, 0x9cc3b1569b1325a4, 0x40c3a071220f5567, 0xb6595be34f821493, // x 2^10046 ~= 10^3024
+  0xbeb82e734787ec63, 0xbeff12280d5a1676, 0x11c48d02b8326bd3, 0xb9eb5333aa272e9b, // x 2^10232 ~= 10^3080
+  0x302349e12f45c73f, 0xb494bcc96d53e49c, 0x566765461bd2f61b, 0xbd8f2f7a1ba47d6d, // x 2^10418 ~= 10^3136
+  0x5704ebf5f16946ce, 0x431388ec68ac7a26, 0xb889018e4f6e9a52, 0xc1454a673cb9b1ce, // x 2^10604 ~= 10^3192
+  0x5a30431166af9b23, 0x132d031fc1d1fec0, 0xf85333a94848659f, 0xc50dff6d30c3aefc, // x 2^10790 ~= 10^3248
+  0x7573d4b3ffe4ba3b, 0xf888498a40220657, 0x1a1aeae7cf8a9d3d, 0xc8e9abc872eb2bc1, // x 2^10976 ~= 10^3304
+  0xb5eaef7441511eb9, 0xc9cf998035a91664, 0x12e29f09d9061609, 0xccd8ae88cf70ad84, // x 2^11162 ~= 10^3360
+  0x73aed4f1908f4d01, 0x8c53e7beeca4578f, 0xdf7601457ca20b35, 0xd0db689a89f2f9b1, // x 2^11348 ~= 10^3416
+  0x5adbd55696e1cdd9, 0x4949d09424b87626, 0xcbdcd02f23cc7690, 0xd4f23ccfb1916df5, // x 2^11534 ~= 10^3472
+  0x3f500ccf4ea03593, 0x9b80aac81b50762a, 0x44289dd21b589d7a, 0xd91d8fe9a3d019cc, // x 2^11720 ~= 10^3528
+  0x134ca67a679b84ae, 0x8909e424a112a3cd, 0x95aa118ec1d08317, 0xdd5dc8a2bf27f3f7, // x 2^11906 ~= 10^3584
+  0xe89e3cf733d9ff40, 0x014344660a175c36, 0x72c4d2cad73b0a7b, 0xe1b34fb846321d04, // x 2^12092 ~= 10^3640
+  0x68c0a2c6c02dae9a, 0x0b11160a6edb5f57, 0xe20a88f1134f906d, 0xe61e8ff47461cda9, // x 2^12278 ~= 10^3696
+  0x47fa54906741561a, 0xaa13acba1e5511f5, 0xc7c91d5c341ed39d, 0xea9ff638c54554e1, // x 2^12464 ~= 10^3752
+  0x365460ed91271c24, 0xabe33496aff629b4, 0xf659ede2159a45ec, 0xef37f1886f4b6690, // x 2^12650 ~= 10^3808
+  0xe4cbf4acc7fba37f, 0x350e915f7055b1b8, 0x78d946bab954b82f, 0xf3e6f313130ef0ef, // x 2^12836 ~= 10^3864
+  0xe692accdfa5bd859, 0xf4d4d3202379829e, 0xc9b1474d8f89c269, 0xf8ad6e3fa030bd15, // x 2^13022 ~= 10^3920
+  0xeca0018ea3b8d1b4, 0xe878edb67072c26d, 0x6b1d2745340e7b14, 0xfd8bd8b770cb469e, // x 2^13208 ~= 10^3976
+  0xce5fec949ab87cf7, 0x0151dcd7a53488c3, 0xf22e502fcdd4bca2, 0x81415538ce493bd5, // x 2^13395 ~= 10^4032
+  0x5e1731fbff8c032e, 0xe752f53c2f8fa6c1, 0x7c1735fc3b813c8c, 0x83c92edf425b292d, // x 2^13581 ~= 10^4088
+  0xb552102ea83f47e6, 0xdf0fd2002ff6b3a3, 0x0367500a8e9a178f, 0x865db7a9ccd2839e, // x 2^13767 ~= 10^4144
+  0x76507bafe00ec873, 0x71b256ecd954434c, 0xc9ac50475e25293a, 0x88ff2f2bade74531, // x 2^13953 ~= 10^4200
+  0x5e2075ba289a360b, 0xac376f28b45e5acc, 0x0879b2e5f6ee8b1c, 0x8badd636cc48b341, // x 2^14139 ~= 10^4256
+  0xab87d85e6311e801, 0xb7f786d14d58173d, 0x2f33c652bd12fab7, 0x8e69eee1f23f2be5, // x 2^14325 ~= 10^4312
+  0x7fed9b68d77255be, 0x35dc241819de7182, 0xad6a6308a8e8b557, 0x9133bc8f2a130fe5, // x 2^14511 ~= 10^4368
+  0x728ae72899d4bd12, 0xe5413d9414142a55, 0x9dbaa465efe141a0, 0x940b83f23a55842a, // x 2^14697 ~= 10^4424
+  0x0f7740145246fb8f, 0x186ef2c39acb4103, 0x888c9ab2fc5b3437, 0x96f18b1742aad751, // x 2^14883 ~= 10^4480
+  0xd8bb0fba2183c6ef, 0xbf66d66cc34f0197, 0xba00864671d1053f, 0x99e6196979b978f1, // x 2^15069 ~= 10^4536
+  0x9b71ed2ceb790e49, 0x6faac32d59cc1f5d, 0x61d59d402aae4fea, 0x9ce977ba0ce3a0bd, // x 2^15255 ~= 10^4592
+  0xa0aa6d5e63991cfb, 0x19482fa0ac45669c, 0x803c1cd864033781, 0x9ffbf04722750449, // x 2^15441 ~= 10^4648
+  0x95a9949e04b8bff3, 0x900aa3c2f02ac9d4, 0xa28a151725a55e10, 0xa31dcec2fef14b30, // x 2^15627 ~= 10^4704
+  0x3acf9496dade0ce9, 0xbd8ecf923d23bec0, 0x5b8452af2302fe13, 0xa64f605b4e3352cd, // x 2^15813 ~= 10^4760
+  0x6204425d2b58e822, 0xdee162a8a1248550, 0x82b84cabc828bf93, 0xa990f3c09110c544, // x 2^15999 ~= 10^4816
+  0x091a2658e0639f32, 0x66fa2184cee0b861, 0x8d29dd5122e4278d, 0xace2d92db0390b59, // x 2^16185 ~= 10^4872
+  0x80acda113324758a, 0xded179c26d9ab828, 0x58f8fde02c03a6c6, 0xb045626fb50a35e7, // x 2^16371 ~= 10^4928
+  0x7128a8aad239ce8f, 0x8737bd250290cd5b, 0xd950102978dbd0ff, 0xb3b8e2eda91a232d, // x 2^16557 ~= 10^4984
+]
+
+fileprivate func _intervalContainingPowerOf10_Binary128(
+  p: Int,
+  lower: inout _UInt256,
+  upper: inout _UInt256
+) -> Int {
+  if p >= 0 && p <= 55 {
+    let exactLow = powersOf10_Exact128[p * 2]
+    let exactHigh = powersOf10_Exact128[p * 2 + 1]
+    lower = _UInt256(high: exactHigh, exactLow, 0, low: 0)
+    upper = lower
+    return binaryExponentFor10ToThe(p)
+  }
+
+  let index = p + 4984
+  let offset = (index / 56) * 4
+  lower = _UInt256(
+    high: powersOf10_Binary128[offset + 3],
+    powersOf10_Binary128[offset + 2],
+    powersOf10_Binary128[offset + 1],
+    low: powersOf10_Binary128[offset + 0])
+  let extraPower = index % 56
+  var e = binaryExponentFor10ToThe(p - extraPower)
+
+  if extraPower > 0 {
+    let extra = _UInt128(
+      _low: powersOf10_Exact128[extraPower * 2],
+      _high: powersOf10_Exact128[extraPower * 2 + 1])
+    lower.multiplyRoundingDown(by: extra)
+    e += binaryExponentFor10ToThe(extraPower)
+  }
+  upper = lower
+  upper.low += 2
+  return e
+}

--- a/grammars/testdata/swift_corpus/stdlib_Optional.swift
+++ b/grammars/testdata/swift_corpus/stdlib_Optional.swift
@@ -1,0 +1,1018 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A type that represents either a wrapped value or the absence of a value.
+///
+/// You use the `Optional` type whenever you use optional values, even if you
+/// never type the word `Optional`. Swift's type system usually shows the
+/// wrapped type's name with a trailing question mark (`?`) instead of showing
+/// the full type name. For example, if a variable has the type `Int?`, that's
+/// just another way of writing `Optional<Int>`. The shortened form is
+/// preferred for ease of reading and writing code.
+///
+/// The types of `shortForm` and `longForm` in the following code sample are
+/// the same:
+///
+///     let shortForm: Int? = Int("42")
+///     let longForm: Optional<Int> = Int("42")
+///
+/// The `Optional` type is an enumeration with two cases. `Optional.none` is
+/// equivalent to the `nil` literal. `Optional.some(Wrapped)` stores a wrapped
+/// value. For example:
+///
+///     let number: Int? = Optional.some(42)
+///     let noNumber: Int? = Optional.none
+///     print(noNumber == nil)
+///     // Prints "true"
+///
+/// You must unwrap the value of an `Optional` instance before you can use it
+/// in many contexts. Because Swift provides several ways to safely unwrap
+/// optional values, you can choose the one that helps you write clear,
+/// concise code.
+///
+/// The following examples use this dictionary of image names and file paths:
+///
+///     let imagePaths = ["star": "/glyphs/star.png",
+///                       "portrait": "/images/content/portrait.jpg",
+///                       "spacer": "/images/shared/spacer.gif"]
+///
+/// Getting a dictionary's value using a key returns an optional value, so
+/// `imagePaths["star"]` has type `Optional<String>` or, written in the
+/// preferred manner, `String?`.
+///
+/// Optional Binding
+/// ----------------
+///
+/// To conditionally bind the wrapped value of an `Optional` instance to a new
+/// variable, use one of the optional binding control structures, including
+/// `if let`, `guard let`, and `switch`.
+///
+///     if let starPath = imagePaths["star"] {
+///         print("The star image is at '\(starPath)'")
+///     } else {
+///         print("Couldn't find the star image")
+///     }
+///     // Prints "The star image is at '/glyphs/star.png'"
+///
+/// Optional Chaining
+/// -----------------
+///
+/// To safely access the properties and methods of a wrapped instance, use the
+/// postfix optional chaining operator (postfix `?`). The following example uses
+/// optional chaining to access the `hasSuffix(_:)` method on a `String?`
+/// instance.
+///
+///     if imagePaths["star"]?.hasSuffix(".png") == true {
+///         print("The star image is in PNG format")
+///     }
+///     // Prints "The star image is in PNG format"
+///
+/// Using the Nil-Coalescing Operator
+/// ---------------------------------
+///
+/// Use the nil-coalescing operator (`??`) to supply a default value in case
+/// the `Optional` instance is `nil`. Here a default path is supplied for an
+/// image that is missing from `imagePaths`.
+///
+///     let defaultImagePath = "/images/default.png"
+///     let heartPath = imagePaths["heart"] ?? defaultImagePath
+///     print(heartPath)
+///     // Prints "/images/default.png"
+///
+/// The `??` operator also works with another `Optional` instance on the
+/// right-hand side. As a result, you can chain multiple `??` operators
+/// together.
+///
+///     let shapePath = imagePaths["cir"] ?? imagePaths["squ"] ?? defaultImagePath
+///     print(shapePath)
+///     // Prints "/images/default.png"
+///
+/// Unconditional Unwrapping
+/// ------------------------
+///
+/// When you're certain that an instance of `Optional` contains a value, you
+/// can unconditionally unwrap the value by using the forced
+/// unwrap operator (postfix `!`). For example, the result of the failable `Int`
+/// initializer is unconditionally unwrapped in the example below.
+///
+///     let number = Int("42")!
+///     print(number)
+///     // Prints "42"
+///
+/// You can also perform unconditional optional chaining by using the postfix
+/// `!` operator.
+///
+///     let isPNG = imagePaths["star"]!.hasSuffix(".png")
+///     print(isPNG)
+///     // Prints "true"
+///
+/// Unconditionally unwrapping a `nil` instance with `!` triggers a runtime
+/// error.
+@frozen
+public enum Optional<Wrapped: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {
+  // The compiler has special knowledge of Optional<Wrapped>, including the fact
+  // that it is an `enum` with cases named `none` and `some`.
+
+  /// The absence of a value.
+  ///
+  /// In code, the absence of a value is typically written using the `nil`
+  /// literal rather than the explicit `.none` enumeration case.
+  case none
+
+  /// The presence of a value, stored as `Wrapped`.
+  case some(Wrapped)
+}
+
+extension Optional: Copyable where Wrapped: Copyable & ~Escapable {}
+
+extension Optional: Escapable where Wrapped: Escapable & ~Copyable {}
+
+extension Optional: BitwiseCopyable
+where Wrapped: BitwiseCopyable & ~Escapable {}
+
+extension Optional: Sendable where Wrapped: ~Copyable & ~Escapable & Sendable {}
+
+
+@_preInverseGenerics
+extension Optional: ExpressibleByNilLiteral
+where Wrapped: ~Copyable & ~Escapable {
+  /// Creates an instance initialized with `nil`.
+  ///
+  /// Do not call this initializer directly. It is used by the compiler when you
+  /// initialize an `Optional` instance with a `nil` literal. For example:
+  ///
+  ///     var i: Index? = nil
+  ///
+  /// In this example, the assignment to the `i` variable calls this
+  /// initializer behind the scenes.
+  @_transparent
+  @_preInverseGenerics
+  @lifetime(immortal)
+  public init(nilLiteral: ()) {
+    self = .none
+  }
+}
+
+extension Optional where Wrapped: ~Copyable {
+  /// Creates an instance that stores the given value.
+  @_transparent
+  @_preInverseGenerics
+  public init(_ value: consuming Wrapped) {
+    // FIXME: Merge this with the generalization below.
+    // This is the original initializer, preserved to avoid breaking source
+    // compatibility with clients that use the `Optional.init` syntax to create
+    // a function reference. The ~Escapable generalization is currently breaking
+    // that. (rdar://147533059)
+    self = .some(value)
+  }
+}
+
+extension Optional where Wrapped: ~Copyable & ~Escapable {
+  /// Creates an instance that stores the given value.
+  @_transparent
+  @_alwaysEmitIntoClient
+  @lifetime(copy value)
+  public init(_ value: consuming Wrapped) {
+    // FIXME: Merge this into the original entry above.
+    self = .some(value)
+  }
+}
+
+extension Optional {
+  /// Evaluates the given closure when this `Optional` instance is not `nil`,
+  /// passing the unwrapped value as a parameter.
+  ///
+  /// Use the `map` method with a closure that returns a non-optional value.
+  /// This example performs an arithmetic operation on an
+  /// optional integer.
+  ///
+  ///     let possibleNumber: Int? = Int("42")
+  ///     let possibleSquare = possibleNumber.map { $0 * $0 }
+  ///     print(possibleSquare)
+  ///     // Prints "Optional(1764)"
+  ///
+  ///     let noNumber: Int? = nil
+  ///     let noSquare = noNumber.map { $0 * $0 }
+  ///     print(noSquare)
+  ///     // Prints "nil"
+  ///
+  /// - Parameter transform: A closure that takes the unwrapped value
+  ///   of the instance.
+  /// - Returns: The result of the given closure. If this instance is `nil`,
+  ///   returns `nil`.
+  @_alwaysEmitIntoClient
+  public func map<E: Error, U: ~Copyable>(
+    _ transform: (Wrapped) throws(E) -> U
+  ) throws(E) -> U? {
+    switch self {
+    case .some(let y):
+      return .some(try transform(y))
+    case .none:
+      return .none
+    }
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  internal func map<U>(
+    _ transform: (Wrapped) throws -> U
+  ) rethrows -> U? {
+    switch self {
+    case .some(let y):
+      return .some(try transform(y))
+    case .none:
+      return .none
+    }
+  }
+}
+
+extension Optional where Wrapped: ~Copyable {
+  // FIXME(NCG): Make this public.
+  @_alwaysEmitIntoClient
+  public consuming func _consumingMap<U: ~Copyable, E: Error>(
+    _ transform: (consuming Wrapped) throws(E) -> U
+  ) throws(E) -> U? {
+    switch consume self {
+    case .some(let y):
+      return .some(try transform(y))
+    case .none:
+      return .none
+    }
+  }
+
+  // FIXME(NCG): Make this public.
+  @_alwaysEmitIntoClient
+  public borrowing func _borrowingMap<U: ~Copyable, E: Error>(
+    _ transform: (borrowing Wrapped) throws(E) -> U
+  ) throws(E) -> U? {
+    switch self {
+    case .some(let y):
+      return .some(try transform(y))
+    case .none:
+      return .none
+    }
+  }
+}
+
+extension Optional {
+  /// Evaluates the given closure when this `Optional` instance is not `nil`,
+  /// passing the unwrapped value as a parameter.
+  ///
+  /// Use the `flatMap` method with a closure that returns an optional value.
+  /// This example performs an arithmetic operation with an optional result on
+  /// an optional integer.
+  ///
+  ///     let possibleNumber: Int? = Int("42")
+  ///     let nonOverflowingSquare = possibleNumber.flatMap { x -> Int? in
+  ///         let (result, overflowed) = x.multipliedReportingOverflow(by: x)
+  ///         return overflowed ? nil : result
+  ///     }
+  ///     print(nonOverflowingSquare)
+  ///     // Prints "Optional(1764)"
+  ///
+  /// - Parameter transform: A closure that takes the unwrapped value
+  ///   of the instance.
+  /// - Returns: The result of the given closure. If this instance is `nil`,
+  ///   returns `nil`.
+  @_alwaysEmitIntoClient
+  public func flatMap<E: Error, U: ~Copyable>(
+    _ transform: (Wrapped) throws(E) -> U?
+  ) throws(E) -> U? {
+    switch self {
+    case .some(let y):
+      return try transform(y)
+    case .none:
+      return .none
+    }
+  }
+
+  @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+  @usableFromInline
+  internal func flatMap<U>(
+    _ transform: (Wrapped) throws -> U?
+  ) rethrows -> U? {
+    switch self {
+    case .some(let y):
+      return try transform(y)
+    case .none:
+      return .none
+    }
+  }
+}
+
+extension Optional where Wrapped: ~Copyable {
+  // FIXME(NCG): Make this public.
+  @_alwaysEmitIntoClient
+  public consuming func _consumingFlatMap<U: ~Copyable, E: Error>(
+    _ transform: (consuming Wrapped) throws(E) -> U?
+  ) throws(E) -> U? {
+    switch consume self {
+    case .some(let y):
+      return try transform(consume y)
+    case .none:
+      return .none
+    }
+  }
+
+  // FIXME(NCG): Make this public.
+  @_alwaysEmitIntoClient
+  public func _borrowingFlatMap<U: ~Copyable, E: Error>(
+    _ transform: (borrowing Wrapped) throws(E) -> U?
+  ) throws(E) -> U? {
+    switch self {
+    case .some(let y):
+      return try transform(y)
+    case .none:
+      return .none
+    }
+  }
+}
+
+extension Optional where Wrapped: ~Escapable {
+  /// The wrapped value of this instance, unwrapped without checking whether
+  /// the instance is `nil`.
+  ///
+  /// The `unsafelyUnwrapped` property provides the same value as the forced
+  /// unwrap operator (postfix `!`). However, in optimized builds (`-O`), no
+  /// check is performed to ensure that the current instance actually has a
+  /// value. Accessing this property in the case of a `nil` value is a serious
+  /// programming error and could lead to undefined behavior or a runtime
+  /// error.
+  ///
+  /// In debug builds (`-Onone`), the `unsafelyUnwrapped` property has the same
+  /// behavior as using the postfix `!` operator and triggers a runtime error
+  /// if the instance is `nil`.
+  ///
+  /// The `unsafelyUnwrapped` property is recommended over calling the
+  /// `unsafeBitCast(_:)` function because the property is more restrictive
+  /// and because accessing the property still performs checking in debug
+  /// builds.
+  ///
+  /// - Warning: This property trades safety for performance.  Use
+  ///   `unsafelyUnwrapped` only when you are confident that this instance
+  ///   will never be equal to `nil` and only after you've tried using the
+  ///   postfix `!` operator.
+  @inlinable
+  @_preInverseGenerics
+  @unsafe
+  public var unsafelyUnwrapped: Wrapped {
+    // FIXME: Generalize this for ~Copyable wrapped types. Note that the current
+    // implementation is copying the value, so that generalization will need to
+    // be emitted into clients -- `@_preInverseGenerics` will not cut it.
+    @inline(__always)
+    @lifetime(copy self)
+    get {
+      if let x = self {
+        return x
+      }
+      _debugPreconditionFailure("unsafelyUnwrapped of nil optional")
+    }
+  }
+}
+
+extension Optional where Wrapped: ~Copyable & ~Escapable {
+  // FIXME(NCG): Do we want this? It seems like we do. Make this public.
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public consuming func _consumingUnsafelyUnwrap() -> Wrapped {
+    switch consume self {
+    case .some(let x):
+      return x
+    case .none:
+      _debugPreconditionFailure("consumingUsafelyUnwrap of nil optional")
+    }
+  }
+}
+
+extension Optional where Wrapped: ~Escapable {
+  /// - Returns: `unsafelyUnwrapped`.
+  ///
+  /// This version is for internal stdlib use; it avoids any checking
+  /// overhead for users, even in Debug builds.
+  @inlinable
+  @_preInverseGenerics
+  internal var _unsafelyUnwrappedUnchecked: Wrapped {
+    @inline(__always)
+    @lifetime(copy self)
+    get {
+      if let x = self {
+        return x
+      }
+      _internalInvariantFailure("_unsafelyUnwrappedUnchecked of nil optional")
+    }
+  }
+}
+
+extension Optional where Wrapped: ~Copyable & ~Escapable {
+  /// - Returns: `unsafelyUnwrapped`.
+  ///
+  /// This version is for internal stdlib use; it avoids any checking
+  /// overhead for users, even in Debug builds.
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  internal consuming func _consumingUncheckedUnwrapped() -> Wrapped {
+    if let x = self {
+      return x
+    }
+    _internalInvariantFailure("_uncheckedUnwrapped of nil optional")
+  }
+}
+
+extension Optional where Wrapped: ~Copyable & ~Escapable {
+  /// Takes the wrapped value being stored in this instance and returns it while
+  /// also setting the instance to `nil`. If there is no value being stored in
+  /// this instance, this returns `nil` instead.
+  ///
+  ///     var numberOfShoes: Int? = 34
+  ///
+  ///     if let numberOfShoes = numberOfShoes.take() {
+  ///       print(numberOfShoes)
+  ///       // Prints "34"
+  ///     }
+  ///
+  ///     print(numberOfShoes)
+  ///     // Prints "nil"
+  ///
+  /// - Returns: The wrapped value being stored in this instance. If this
+  ///   instance is `nil`, returns `nil`.
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public mutating func take() -> Self {
+    let result = consume self
+    self = nil
+    return result
+  }
+}
+
+@_unavailableInEmbedded
+extension Optional: CustomDebugStringConvertible {
+  /// A textual representation of this instance, suitable for debugging.
+  public var debugDescription: String {
+    switch self {
+    case .some(let value):
+#if !SWIFT_STDLIB_STATIC_PRINT
+      var result = "Optional("
+      #if !$Embedded
+      debugPrint(value, terminator: "", to: &result)
+      #else
+      _ = value
+      "(cannot print value in embedded Swift)".write(to: &result)
+      #endif
+      result += ")"
+      return result
+#else
+    return "(optional printing not available)"
+#endif
+    case .none:
+      return "nil"
+    }
+  }
+}
+
+#if SWIFT_ENABLE_REFLECTION
+extension Optional: CustomReflectable {
+  public var customMirror: Mirror {
+    switch self {
+    case .some(let value):
+      return Mirror(
+        self,
+        children: [ "some": value ],
+        displayStyle: .optional)
+    case .none:
+      return Mirror(self, children: [:], displayStyle: .optional)
+    }
+  }
+}
+#endif
+
+@_transparent
+public // COMPILER_INTRINSIC
+func _diagnoseUnexpectedNilOptional(
+  _filenameStart: Builtin.RawPointer,
+  _filenameLength: Builtin.Word,
+  _filenameIsASCII: Builtin.Int1,
+  _line: Builtin.Word,
+  _isImplicitUnwrap: Builtin.Int1
+) {
+  // Cannot use _preconditionFailure as the file and line info would not be
+  // printed.
+  if Bool(_isImplicitUnwrap) {
+    _preconditionFailure(
+      "Unexpectedly found nil while implicitly unwrapping an Optional value",
+      file: StaticString(_start: _filenameStart,
+                         utf8CodeUnitCount: _filenameLength,
+                         isASCII: _filenameIsASCII),
+      line: UInt(_line))
+  } else {
+    _preconditionFailure(
+      "Unexpectedly found nil while unwrapping an Optional value",
+      file: StaticString(_start: _filenameStart,
+                         utf8CodeUnitCount: _filenameLength,
+                         isASCII: _filenameIsASCII),
+      line: UInt(_line))
+  }
+}
+
+extension Optional: Equatable where Wrapped: Equatable {
+  /// Returns a Boolean value indicating whether two optional instances are
+  /// equal.
+  ///
+  /// Use this equal-to operator (`==`) to compare any two optional instances of
+  /// a type that conforms to the `Equatable` protocol. The comparison returns
+  /// `true` if both arguments are `nil` or if the two arguments wrap values
+  /// that are equal. Conversely, the comparison returns `false` if only one of
+  /// the arguments is `nil` or if the two arguments wrap values that are not
+  /// equal.
+  ///
+  ///     let group1 = [1, 2, 3, 4, 5]
+  ///     let group2 = [1, 3, 5, 7, 9]
+  ///     if group1.first == group2.first {
+  ///         print("The two groups start the same.")
+  ///     }
+  ///     // Prints "The two groups start the same."
+  ///
+  /// You can also use this operator to compare a non-optional value to an
+  /// optional that wraps the same type. The non-optional value is wrapped as an
+  /// optional before the comparison is made. In the following example, the
+  /// `numberToMatch` constant is wrapped as an optional before comparing to the
+  /// optional `numberFromString`:
+  ///
+  ///     let numberToMatch: Int = 23
+  ///     let numberFromString: Int? = Int("23")      // Optional(23)
+  ///     if numberToMatch == numberFromString {
+  ///         print("It's a match!")
+  ///     }
+  ///     // Prints "It's a match!"
+  ///
+  /// An instance that is expressed as a literal can also be used with this
+  /// operator. In the next example, an integer literal is compared with the
+  /// optional integer `numberFromString`. The literal `23` is inferred as an
+  /// `Int` instance and then wrapped as an optional before the comparison is
+  /// performed.
+  ///
+  ///     if 23 == numberFromString {
+  ///         print("It's a match!")
+  ///     }
+  ///     // Prints "It's a match!"
+  ///
+  /// - Parameters:
+  ///   - lhs: An optional value to compare.
+  ///   - rhs: Another optional value to compare.
+  @_transparent
+  public static func ==(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
+    switch (lhs, rhs) {
+    case let (l?, r?):
+      return l == r
+    case (nil, nil):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension Optional: Hashable where Wrapped: Hashable {
+  /// Hashes the essential components of this value by feeding them into the
+  /// given hasher.
+  ///
+  /// - Parameter hasher: The hasher to use when combining the components
+  ///   of this instance.
+  @inlinable
+  public func hash(into hasher: inout Hasher) {
+    switch self {
+    case .none:
+      hasher.combine(0 as UInt8)
+    case .some(let wrapped):
+      hasher.combine(1 as UInt8)
+      hasher.combine(wrapped)
+    }
+  }
+}
+
+// Enable pattern matching against the nil literal, even if the element type
+// isn't equatable.
+@frozen
+public struct _OptionalNilComparisonType: ExpressibleByNilLiteral {
+  /// Create an instance initialized with `nil`.
+  @_transparent
+  public init(nilLiteral: ()) {
+  }
+}
+
+extension Optional where Wrapped: ~Copyable & ~Escapable {
+  /// Returns a Boolean value indicating whether an argument matches `nil`.
+  ///
+  /// You can use the pattern-matching operator (`~=`) to test whether an
+  /// optional instance is `nil` even when the wrapped value's type does not
+  /// conform to the `Equatable` protocol. The pattern-matching operator is used
+  /// internally in `case` statements for pattern matching.
+  ///
+  /// The following example declares the `stream` variable as an optional
+  /// instance of a hypothetical `DataStream` type, and then uses a `switch`
+  /// statement to determine whether the stream is `nil` or has a configured
+  /// value. When evaluating the `nil` case of the `switch` statement, this
+  /// operator is called behind the scenes.
+  ///
+  ///     var stream: DataStream? = nil
+  ///     switch stream {
+  ///     case nil:
+  ///         print("No data stream is configured.")
+  ///     case let x?:
+  ///         print("The data stream has \(x.availableBytes) bytes available.")
+  ///     }
+  ///     // Prints "No data stream is configured."
+  ///
+  /// - Note: To test whether an instance is `nil` in an `if` statement, use the
+  ///   equal-to operator (`==`) instead of the pattern-matching operator. The
+  ///   pattern-matching operator is primarily intended to enable `case`
+  ///   statement pattern matching.
+  ///
+  /// - Parameters:
+  ///   - lhs: A `nil` literal.
+  ///   - rhs: A value to match against `nil`.
+  @_transparent
+  @_preInverseGenerics
+  public static func ~=(
+    lhs: _OptionalNilComparisonType,
+    rhs: borrowing Wrapped?
+  ) -> Bool {
+    switch rhs {
+    case .some:
+      return false
+    case .none:
+      return true
+    }
+  }
+
+  // Enable equality comparisons against the nil literal, even if the
+  // element type isn't equatable
+
+  /// Returns a Boolean value indicating whether the left-hand-side argument is
+  /// `nil`.
+  ///
+  /// You can use this equal-to operator (`==`) to test whether an optional
+  /// instance is `nil` even when the wrapped value's type does not conform to
+  /// the `Equatable` protocol.
+  ///
+  /// The following example declares the `stream` variable as an optional
+  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+  /// an `Equatable` type, this operator allows checking whether `stream` is
+  /// `nil`.
+  ///
+  ///     var stream: DataStream? = nil
+  ///     if stream == nil {
+  ///         print("No data stream is configured.")
+  ///     }
+  ///     // Prints "No data stream is configured."
+  ///
+  /// - Parameters:
+  ///   - lhs: A value to compare to `nil`.
+  ///   - rhs: A `nil` literal.
+  @_transparent
+  @_preInverseGenerics
+  public static func ==(
+    lhs: borrowing Wrapped?,
+    rhs: _OptionalNilComparisonType
+  ) -> Bool {
+    switch lhs {
+    case .some:
+      return false
+    case .none:
+      return true
+    }
+  }
+
+  /// Returns a Boolean value indicating whether the left-hand-side argument is
+  /// not `nil`.
+  ///
+  /// You can use this not-equal-to operator (`!=`) to test whether an optional
+  /// instance is not `nil` even when the wrapped value's type does not conform
+  /// to the `Equatable` protocol.
+  ///
+  /// The following example declares the `stream` variable as an optional
+  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+  /// an `Equatable` type, this operator allows checking whether `stream` wraps
+  /// a value and is therefore not `nil`.
+  ///
+  ///     var stream: DataStream? = fetchDataStream()
+  ///     if stream != nil {
+  ///         print("The data stream has been configured.")
+  ///     }
+  ///     // Prints "The data stream has been configured."
+  ///
+  /// - Parameters:
+  ///   - lhs: A value to compare to `nil`.
+  ///   - rhs: A `nil` literal.
+  @_transparent
+  @_preInverseGenerics
+  public static func !=(
+    lhs: borrowing Wrapped?,
+    rhs: _OptionalNilComparisonType
+  ) -> Bool {
+    switch lhs {
+    case .some:
+      return true
+    case .none:
+      return false
+    }
+  }
+
+  /// Returns a Boolean value indicating whether the right-hand-side argument is
+  /// `nil`.
+  ///
+  /// You can use this equal-to operator (`==`) to test whether an optional
+  /// instance is `nil` even when the wrapped value's type does not conform to
+  /// the `Equatable` protocol.
+  ///
+  /// The following example declares the `stream` variable as an optional
+  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+  /// an `Equatable` type, this operator allows checking whether `stream` is
+  /// `nil`.
+  ///
+  ///     var stream: DataStream? = nil
+  ///     if nil == stream {
+  ///         print("No data stream is configured.")
+  ///     }
+  ///     // Prints "No data stream is configured."
+  ///
+  /// - Parameters:
+  ///   - lhs: A `nil` literal.
+  ///   - rhs: A value to compare to `nil`.
+  @_transparent
+  @_preInverseGenerics
+  public static func ==(
+    lhs: _OptionalNilComparisonType,
+    rhs: borrowing Wrapped?
+  ) -> Bool {
+    switch rhs {
+    case .some:
+      return false
+    case .none:
+      return true
+    }
+  }
+
+  /// Returns a Boolean value indicating whether the right-hand-side argument is
+  /// not `nil`.
+  ///
+  /// You can use this not-equal-to operator (`!=`) to test whether an optional
+  /// instance is not `nil` even when the wrapped value's type does not conform
+  /// to the `Equatable` protocol.
+  ///
+  /// The following example declares the `stream` variable as an optional
+  /// instance of a hypothetical `DataStream` type. Although `DataStream` is not
+  /// an `Equatable` type, this operator allows checking whether `stream` wraps
+  /// a value and is therefore not `nil`.
+  ///
+  ///     var stream: DataStream? = fetchDataStream()
+  ///     if nil != stream {
+  ///         print("The data stream has been configured.")
+  ///     }
+  ///     // Prints "The data stream has been configured."
+  ///
+  /// - Parameters:
+  ///   - lhs: A `nil` literal.
+  ///   - rhs: A value to compare to `nil`.
+  @_transparent
+  @_preInverseGenerics
+  public static func !=(
+    lhs: _OptionalNilComparisonType,
+    rhs: borrowing Wrapped?
+  ) -> Bool {
+    switch rhs {
+    case .some:
+      return true
+    case .none:
+      return false
+    }
+  }
+}
+
+/// Performs a nil-coalescing operation, returning the wrapped value of an
+/// `Optional` instance or a default value.
+///
+/// A nil-coalescing operation unwraps the left-hand side if it has a value, or
+/// it returns the right-hand side as a default. The result of this operation
+/// will have the non-optional type of the left-hand side's `Wrapped` type.
+///
+/// This operator uses short-circuit evaluation: `optional` is checked first,
+/// and `defaultValue` is evaluated only if `optional` is `nil`. For example:
+///
+///     func getDefault() -> Int {
+///         print("Calculating default...")
+///         return 42
+///     }
+///
+///     let goodNumber = Int("100") ?? getDefault()
+///     // goodNumber == 100
+///
+///     let notSoGoodNumber = Int("invalid-input") ?? getDefault()
+///     // Prints "Calculating default..."
+///     // notSoGoodNumber == 42
+///
+/// In this example, `goodNumber` is assigned a value of `100` because
+/// `Int("100")` succeeded in returning a non-`nil` result. When
+/// `notSoGoodNumber` is initialized, `Int("invalid-input")` fails and returns
+/// `nil`, and so the `getDefault()` method is called to supply a default
+/// value.
+///
+/// - Parameters:
+///   - optional: An optional value.
+///   - defaultValue: A value to use as a default. `defaultValue` is the same
+///     type as the `Wrapped` type of `optional`.
+@_transparent
+@_alwaysEmitIntoClient
+public func ?? <T: ~Copyable>(
+  optional: consuming T?,
+  defaultValue: @autoclosure () throws -> T // FIXME: typed throws
+) rethrows -> T {
+  // FIXME: We want this to support nonescapable `T` types.
+  // To implement that, we need to be able to express that the result's lifetime
+  // is limited to the intersection of `optional` and the result of
+  // `defaultValue`:
+  //    @lifetime(optional, defaultValue.result)
+  switch consume optional {
+  case .some(let value):
+    return value
+  case .none:
+    return try defaultValue()
+  }
+}
+
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@_silgen_name("$ss2qqoiyxxSg_xyKXKtKlF")
+@usableFromInline
+internal func _legacy_abi_optionalNilCoalescingOperator <T>(
+  optional: T?,
+  defaultValue: @autoclosure () throws -> T
+) rethrows -> T {
+  switch optional {
+  case .some(let value):
+    return value
+  case .none:
+    return try defaultValue()
+  }
+}
+
+/// Performs a nil-coalescing operation, returning the wrapped value of an
+/// `Optional` instance or a default `Optional` value.
+///
+/// A nil-coalescing operation unwraps the left-hand side if it has a value, or
+/// returns the right-hand side as a default. The result of this operation
+/// will be the same type as its arguments.
+///
+/// This operator uses short-circuit evaluation: `optional` is checked first,
+/// and `defaultValue` is evaluated only if `optional` is `nil`. For example:
+///
+///     let goodNumber = Int("100") ?? Int("42")
+///     print(goodNumber)
+///     // Prints "Optional(100)"
+///
+///     let notSoGoodNumber = Int("invalid-input") ?? Int("42")
+///     print(notSoGoodNumber)
+///     // Prints "Optional(42)"
+///
+/// In this example, `goodNumber` is assigned a value of `100` because
+/// `Int("100")` succeeds in returning a non-`nil` result. When
+/// `notSoGoodNumber` is initialized, `Int("invalid-input")` fails and returns
+/// `nil`, and so `Int("42")` is called to supply a default value.
+///
+/// Because the result of this nil-coalescing operation is itself an optional
+/// value, you can chain default values by using `??` multiple times. The
+/// first optional value that isn't `nil` stops the chain and becomes the
+/// result of the whole expression. The next example tries to find the correct
+/// text for a greeting in two separate dictionaries before falling back to a
+/// static default.
+///
+///     let greeting = userPrefs[greetingKey] ??
+///         defaults[greetingKey] ?? "Greetings!"
+///
+/// If `userPrefs[greetingKey]` has a value, that value is assigned to
+/// `greeting`. If not, any value in `defaults[greetingKey]` will succeed, and
+/// if not that, `greeting` will be set to the non-optional default value,
+/// `"Greetings!"`.
+///
+/// - Parameters:
+///   - optional: An optional value.
+///   - defaultValue: A value to use as a default. `defaultValue` and
+///     `optional` have the same type.
+@_transparent
+@_alwaysEmitIntoClient
+public func ?? <T: ~Copyable>(
+  optional: consuming T?,
+  defaultValue: @autoclosure () throws -> T? // FIXME: typed throws
+) rethrows -> T? {
+  // FIXME: We want this to support nonescapable `T` types.
+  // To implement that, we need to be able to express that the result's lifetime
+  // is limited to the intersection of `optional` and the result of
+  // `defaultValue`:
+  //    @lifetime(optional, defaultValue.result)
+  switch consume optional {
+  case .some(let value):
+    return value
+  case .none:
+    return try defaultValue()
+  }
+}
+
+@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+@usableFromInline
+internal func ?? <T>(
+  optional: T?,
+  defaultValue: @autoclosure () throws -> T?
+) rethrows -> T? {
+  switch optional {
+  case .some(let value):
+    return value
+  case .none:
+    return try defaultValue()
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Bridging
+//===----------------------------------------------------------------------===//
+
+#if _runtime(_ObjC)
+extension Optional: _ObjectiveCBridgeable {
+  // The object that represents `none` for an Optional of this type.
+  internal static var _nilSentinel: AnyObject {
+    @_silgen_name("_swift_Foundation_getOptionalNilSentinelObject")
+    get
+  }
+
+  public func _bridgeToObjectiveC() -> AnyObject {
+    // Bridge a wrapped value by unwrapping.
+    if let value = self {
+      return _bridgeAnythingToObjectiveC(value)
+    }
+    // Bridge nil using a sentinel.
+    return type(of: self)._nilSentinel
+  }
+
+  public static func _forceBridgeFromObjectiveC(
+    _ source: AnyObject,
+    result: inout Optional<Wrapped>?
+  ) {
+    // Map the nil sentinel back to .none.
+    // NB that the signature of _forceBridgeFromObjectiveC adds another level
+    // of optionality, so we need to wrap the immediate result of the conversion
+    // in `.some`.
+    if source === _nilSentinel {
+      result = .some(.none)
+      return
+    }
+    // Otherwise, force-bridge the underlying value.
+    let unwrappedResult = source as! Wrapped
+    result = .some(.some(unwrappedResult))
+  }
+
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: AnyObject,
+    result: inout Optional<Wrapped>?
+  ) -> Bool {
+    // Map the nil sentinel back to .none.
+    // NB that the signature of _forceBridgeFromObjectiveC adds another level
+    // of optionality, so we need to wrap the immediate result of the conversion
+    // in `.some` to indicate success of the bridging operation, with a nil
+    // result.
+    if source === _nilSentinel {
+      result = .some(.none)
+      return true
+    }
+    // Otherwise, try to bridge the underlying value.
+    if let unwrappedResult = source as? Wrapped {
+      result = .some(.some(unwrappedResult))
+      return true
+    } else {
+      result = .none
+      return false
+    }
+  }
+
+  @_effects(readonly)
+  public static func _unconditionallyBridgeFromObjectiveC(_ source: AnyObject?)
+      -> Optional<Wrapped> {
+    if let nonnullSource = source {
+      // Map the nil sentinel back to none.
+      if nonnullSource === _nilSentinel {
+        return .none
+      } else {
+        return .some(nonnullSource as! Wrapped)
+      }
+    } else {
+      // If we unexpectedly got nil, just map it to `none` too.
+      return .none
+    }
+  }
+}
+#endif

--- a/grammars/testdata/swift_corpus/stdlib_Repeat.swift
+++ b/grammars/testdata/swift_corpus/stdlib_Repeat.swift
@@ -1,0 +1,111 @@
+//===--- Repeat.swift - A Collection that repeats a value N times ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A collection whose elements are all identical.
+///
+/// You create an instance of the `Repeated` collection by calling the
+/// `repeatElement(_:count:)` function. The following example creates a
+/// collection containing the name "Humperdinck" repeated five times:
+///
+///     let repeatedName = repeatElement("Humperdinck", count: 5)
+///     for name in repeatedName {
+///         print(name)
+///     }
+///     // "Humperdinck"
+///     // "Humperdinck"
+///     // "Humperdinck"
+///     // "Humperdinck"
+///     // "Humperdinck"
+@frozen
+public struct Repeated<Element> {
+  /// The number of elements in this collection.
+  public let count: Int
+
+  /// The value of every element in this collection.
+  public let repeatedValue: Element
+
+  /// Creates an instance that contains `count` elements having the
+  /// value `repeatedValue`.
+  @inlinable // trivial-implementation
+  internal init(_repeating repeatedValue: Element, count: Int) {
+    _precondition(count >= 0, "Repetition count should be non-negative")
+    self.count = count
+    self.repeatedValue = repeatedValue
+  }
+}
+
+extension Repeated: RandomAccessCollection {
+  public typealias Indices = Range<Int>
+
+  /// A type that represents a valid position in the collection.
+  ///
+  /// Valid indices consist of the position of every element and a "past the
+  /// end" position that's not valid for use as a subscript.
+  public typealias Index = Int
+
+  /// The position of the first element in a nonempty collection.
+  ///
+  /// In a `Repeated` collection, `startIndex` is always equal to zero. If the
+  /// collection is empty, `startIndex` is equal to `endIndex`.
+  @inlinable // trivial-implementation
+  public var startIndex: Index {
+    return 0
+  }
+
+  /// The collection's "past the end" position---that is, the position one
+  /// greater than the last valid subscript argument.
+  ///
+  /// In a `Repeated` collection, `endIndex` is always equal to `count`. If the
+  /// collection is empty, `endIndex` is equal to `startIndex`.
+  @inlinable // trivial-implementation
+  public var endIndex: Index {
+    return count
+  }
+
+  /// Accesses the element at the specified position.
+  ///
+  /// - Parameter position: The position of the element to access. `position`
+  ///   must be a valid index of the collection that is not equal to the
+  ///   `endIndex` property.
+  @inlinable // trivial-implementation
+  public subscript(position: Int) -> Element {
+    _precondition(position >= 0 && position < count, "Index out of range")
+    return repeatedValue
+  }
+}
+
+/// Creates a collection containing the specified number of the given element.
+///
+/// The following example creates a `Repeated<Int>` collection containing five
+/// zeroes:
+///
+///     let zeroes = repeatElement(0, count: 5)
+///     for x in zeroes {
+///         print(x)
+///     }
+///     // 0
+///     // 0
+///     // 0
+///     // 0
+///     // 0
+///
+/// - Parameters:
+///   - element: The element to repeat.
+///   - count: The number of times to repeat `element`.
+/// - Returns: A collection that contains `count` elements that are all
+///   `element`.
+@inlinable // trivial-implementation
+public func repeatElement<T>(_ element: T, count n: Int) -> Repeated<T> {
+  return Repeated(_repeating: element, count: n)
+}
+
+extension Repeated: Sendable where Element: Sendable { }

--- a/grammars/testdata/swift_corpus/stdlib_Stride.swift
+++ b/grammars/testdata/swift_corpus/stdlib_Stride.swift
@@ -1,0 +1,752 @@
+//===--- Stride.swift - Components for stride(...) iteration --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A type representing continuous, one-dimensional values that can be offset
+/// and measured.
+///
+/// You can use a type that conforms to the `Strideable` protocol with the
+/// `stride(from:to:by:)` and `stride(from:through:by:)` functions. For
+/// example, you can use `stride(from:to:by:)` to iterate over an
+/// interval of floating-point values:
+///
+///     for radians in stride(from: 0.0, to: .pi * 2, by: .pi / 2) {
+///         let degrees = Int(radians * 180 / .pi)
+///         print("Degrees: \(degrees), radians: \(radians)")
+///     }
+///     // Degrees: 0, radians: 0.0
+///     // Degrees: 90, radians: 1.5707963267949
+///     // Degrees: 180, radians: 3.14159265358979
+///     // Degrees: 270, radians: 4.71238898038469
+///
+/// The last parameter of these functions is of the associated `Stride`
+/// type---the type that represents the distance between any two instances of
+/// the `Strideable` type.
+///
+/// Types that have an integer `Stride` can be used as the boundaries of a
+/// countable range or as the lower bound of an iterable one-sided range. For
+/// example, you can iterate over a range of `Int` and use sequence and
+/// collection methods.
+///
+///     var sum = 0
+///     for x in 1...100 {
+///         sum += x
+///     }
+///     // sum == 5050
+///
+///     let digits = (0..<10).map(String.init)
+///     // ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+///
+/// Conforming to the Strideable Protocol
+/// =====================================
+///
+/// To add `Strideable` conformance to a custom type, choose a `Stride` type
+/// that can represent the distance between two instances and implement the
+/// `advanced(by:)` and `distance(to:)` methods. For example, this
+/// hypothetical `Date` type stores its value as the number of days before or
+/// after January 1, 2000:
+///
+///     struct Date: Equatable, CustomStringConvertible {
+///         var daysAfterY2K: Int
+///
+///         var description: String {
+///             // ...
+///         }
+///     }
+///
+/// The `Stride` type for `Date` is `Int`, inferred from the parameter and
+/// return types of `advanced(by:)` and `distance(to:)`:
+///
+///     extension Date: Strideable {
+///         func advanced(by n: Int) -> Date {
+///             var result = self
+///             result.daysAfterY2K += n
+///             return result
+///         }
+///
+///         func distance(to other: Date) -> Int {
+///             return other.daysAfterY2K - self.daysAfterY2K
+///         }
+///     }
+///
+/// The `Date` type can now be used with the `stride(from:to:by:)` and
+/// `stride(from:through:by:)` functions and as the bounds of an iterable
+/// range.
+///
+///     let startDate = Date(daysAfterY2K: 0)   // January 1, 2000
+///     let endDate = Date(daysAfterY2K: 15)    // January 16, 2000
+///
+///     for date in stride(from: startDate, to: endDate, by: 7) {
+///         print(date)
+///     }
+///     // January 1, 2000
+///     // January 8, 2000
+///     // January 15, 2000
+///
+/// - Important: The `Strideable` protocol provides default implementations for
+///   the equal-to (`==`) and less-than (`<`) operators that depend on the
+///   `Stride` type's implementations. If a type conforming to `Strideable` is
+///   its own `Stride` type, it must provide concrete implementations of the
+///   two operators to avoid infinite recursion.
+public protocol Strideable<Stride>: Comparable {
+  /// A type that represents the distance between two values.
+  associatedtype Stride: SignedNumeric, Comparable
+
+  /// Returns the distance from this value to the given value, expressed as a 
+  /// stride.
+  ///
+  /// If this type's `Stride` type conforms to `BinaryInteger`, then for two
+  /// values `x` and `y`, and a distance `n = x.distance(to: y)`,
+  /// `x.advanced(by: n) == y`. Using this method with types that have a
+  /// noninteger `Stride` may result in an approximation.
+  ///
+  /// - Parameter other: The value to calculate the distance to.
+  /// - Returns: The distance from this value to `other`.
+  ///
+  /// - Complexity: O(1)
+  func distance(to other: Self) -> Stride
+
+  /// Returns a value that is offset the specified distance from this value.
+  ///
+  /// Use the `advanced(by:)` method in generic code to offset a value by a
+  /// specified distance. If you're working directly with numeric values, use
+  /// the addition operator (`+`) instead of this method.
+  ///
+  ///     func addOne<T: Strideable>(to x: T) -> T
+  ///         where T.Stride: ExpressibleByIntegerLiteral
+  ///     {
+  ///         return x.advanced(by: 1)
+  ///     }
+  ///
+  ///     let x = addOne(to: 5)
+  ///     // x == 6
+  ///     let y = addOne(to: 3.5)
+  ///     // y = 4.5
+  ///
+  /// If this type's `Stride` type conforms to `BinaryInteger`, then for a
+  /// value `x`, a distance `n`, and a value `y = x.advanced(by: n)`,
+  /// `x.distance(to: y) == n`. Using this method with types that have a
+  /// noninteger `Stride` may result in an approximation. If the result of
+  /// advancing by `n` is not representable as a value of this type, then a
+  /// runtime error may occur.
+  ///
+  /// - Parameter n: The distance to advance this value.
+  /// - Returns: A value that is offset from this value by `n`.
+  ///
+  /// - Complexity: O(1)
+  func advanced(by n: Stride) -> Self
+
+  /// Returns the next result of striding by a specified distance.
+  ///
+  /// This method is an implementation detail of `Strideable`; do not call it
+  /// directly.
+  ///
+  /// While striding, `_step(after:from:by:)` is called at each step to
+  /// determine the next result. At the first step, the value of `current` is
+  /// `(index: 0, value: start)`. At each subsequent step, the value of
+  /// `current` is the result returned by this method in the immediately
+  /// preceding step.
+  ///
+  /// If the result of advancing by a given `distance` is not representable as a
+  /// value of this type, then a runtime error may occur.
+  ///
+  /// Implementing `_step(after:from:by:)` to Customize Striding Behavior
+  /// ===================================================================
+  ///
+  /// The default implementation of this method calls `advanced(by:)` to offset
+  /// `current.value` by a specified `distance`. No attempt is made to count the
+  /// number of prior steps, and the result's `index` is always `nil`.
+  ///
+  /// To avoid incurring runtime errors that arise from advancing past
+  /// representable bounds, a conforming type can signal that the result of
+  /// advancing by a given `distance` is not representable by using `Int.min` as
+  /// a sentinel value for the result's `index`. In that case, the result's
+  /// `value` must be either the minimum representable value of this type if
+  /// `distance` is less than zero or the maximum representable value of this
+  /// type otherwise. Fixed-width integer types make use of arithmetic
+  /// operations reporting overflow to implement this customization.
+  ///
+  /// A conforming type may use any positive value for the result's `index` as
+  /// an opaque state that is private to that type. For example, floating-point
+  /// types increment `index` with each step so that the corresponding `value`
+  /// can be computed by multiplying the number of steps by the specified
+  /// `distance`. Serially calling `advanced(by:)` would accumulate
+  /// floating-point rounding error at each step, which is avoided by this
+  /// customization.
+  ///
+  /// - Parameters:
+  ///   - current: The result returned by this method in the immediately
+  ///     preceding step while striding, or `(index: 0, value: start)` if there
+  ///     have been no preceding steps.
+  ///   - start: The starting value used for the striding sequence.
+  ///   - distance: The amount to step by with each iteration of the striding
+  ///     sequence.
+  /// - Returns: A tuple of `index` and `value`; `index` may be `nil`, any
+  ///   positive value as an opaque state private to the conforming type, or
+  ///   `Int.min` to signal that the notional result of advancing by `distance`
+  ///   is unrepresentable, and `value` is the next result after `current.value`
+  ///   while striding from `start` by `distance`.
+  ///
+  /// - Complexity: O(1)
+  static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self)
+}
+
+extension Strideable {
+  @inlinable
+  public static func < (x: Self, y: Self) -> Bool {
+    return x.distance(to: y) > 0
+  }
+
+  @inlinable
+  public static func == (x: Self, y: Self) -> Bool {
+    return x.distance(to: y) == 0
+  }
+}
+
+extension Strideable {
+  @inlinable // protocol-only
+  public static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self) {
+    return (nil, current.value.advanced(by: distance))
+  }
+}
+
+extension Strideable where Self: FixedWidthInteger & SignedInteger {
+  @_alwaysEmitIntoClient
+  public static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self) {
+    let value = current.value
+    let (partialValue, overflow) =
+      Self.bitWidth >= Self.Stride.bitWidth ||
+        (value < (0 as Self)) == (distance < (0 as Self.Stride))
+          ? value.addingReportingOverflow(Self(distance))
+          : (Self(Self.Stride(value) + distance), false)
+    return overflow
+      ? (.min, distance < (0 as Self.Stride) ? .min : .max)
+      : (nil, partialValue)
+  }
+}
+
+extension Strideable where Self: FixedWidthInteger & UnsignedInteger {
+  @_alwaysEmitIntoClient
+  public static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self) {
+    let (partialValue, overflow) = distance < (0 as Self.Stride)
+      ? current.value.subtractingReportingOverflow(Self(-distance))
+      : current.value.addingReportingOverflow(Self(distance))
+    return overflow
+      ? (.min, distance < (0 as Self.Stride) ? .min : .max)
+      : (nil, partialValue)
+  }
+}
+
+extension Strideable where Stride: FloatingPoint {
+  @inlinable // protocol-only
+  public static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self) {
+    if let i = current.index {
+      // When Stride is a floating-point type, we should avoid accumulating
+      // rounding error from repeated addition.
+      return (i + 1, start.advanced(by: Stride(i + 1) * distance))
+    }
+    return (nil, current.value.advanced(by: distance))
+  }
+}
+
+extension Strideable where Self: FloatingPoint, Self == Stride {
+  @inlinable // protocol-only
+  public static func _step(
+    after current: (index: Int?, value: Self),
+    from start: Self, by distance: Self.Stride
+  ) -> (index: Int?, value: Self) {
+    if let i = current.index {
+      // When both Self and Stride are the same floating-point type, we should
+      // take advantage of fused multiply-add (where supported) to eliminate
+      // intermediate rounding error.
+      return (i + 1, start.addingProduct(Stride(i + 1), distance))
+    }
+    return (nil, current.value.advanced(by: distance))
+  }
+}
+
+/// An iterator for a `StrideTo` instance.
+@frozen
+public struct StrideToIterator<Element: Strideable> {
+  @usableFromInline
+  internal let _start: Element
+
+  @usableFromInline
+  internal let _end: Element
+
+  @usableFromInline
+  internal let _stride: Element.Stride
+
+  @usableFromInline
+  internal var _current: (index: Int?, value: Element)
+
+  @inlinable
+  internal init(_start: Element, end: Element, stride: Element.Stride) {
+    self._start = _start
+    _end = end
+    _stride = stride
+    _current = (0, _start)
+  }
+}
+
+extension StrideToIterator: IteratorProtocol {
+  /// Advances to the next element and returns it, or `nil` if no next element
+  /// exists.
+  ///
+  /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @inlinable
+  public mutating func next() -> Element? {
+    let result = _current.value
+    if _stride > 0 ? result >= _end : result <= _end {
+      return nil
+    }
+    _current = Element._step(after: _current, from: _start, by: _stride)
+    return result
+  }
+}
+
+// FIXME: should really be a Collection, as it is multipass
+/// A sequence of values formed by striding over a half-open interval.
+///
+/// Use the `stride(from:to:by:)` function to create `StrideTo` instances.
+@frozen
+public struct StrideTo<Element: Strideable> {
+  @usableFromInline
+  internal let _start: Element
+
+  @usableFromInline
+  internal let _end: Element
+
+  @usableFromInline
+  internal let _stride: Element.Stride
+
+  @inlinable
+  internal init(_start: Element, end: Element, stride: Element.Stride) {
+    _precondition(stride != 0, "Stride size must not be zero")
+    // At start, striding away from end is allowed; it just makes for an
+    // already-empty Sequence.
+    self._start = _start
+    self._end = end
+    self._stride = stride
+  }
+}
+
+extension StrideTo: Sequence {
+  /// Returns an iterator over the elements of this sequence.
+  ///
+  /// - Complexity: O(1).
+  @inlinable
+  public __consuming func makeIterator() -> StrideToIterator<Element> {
+    return StrideToIterator(_start: _start, end: _end, stride: _stride)
+  }
+
+  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
+  // here until a proper Collection conformance is possible
+  @inlinable
+  public var underestimatedCount: Int {
+    var it = self.makeIterator()
+    var count = 0
+    while it.next() != nil {
+      count += 1
+    }
+    return count
+  }
+
+  @inlinable
+  public func _customContainsEquatableElement(
+    _ element: Element
+  ) -> Bool? {
+    if _stride < 0 {
+      if element <= _end || _start < element { return false }
+    } else {
+      if element < _start || _end <= element { return false }
+    }
+    // TODO: Additional implementation work will avoid always falling back to the
+    // predicate version of `contains` when the sequence *does* contain `element`.
+    return nil
+  }
+}
+
+#if SWIFT_ENABLE_REFLECTION
+extension StrideTo: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: ["from": _start, "to": _end, "by": _stride])
+  }
+}
+#endif
+
+// FIXME(conditional-conformances): This does not yet compile (https://github.com/apple/swift/issues/49024).
+#if false
+extension StrideTo: RandomAccessCollection
+where Element.Stride: BinaryInteger {
+  public typealias Index = Int
+  public typealias SubSequence = Slice<StrideTo<Element>>
+  public typealias Indices = Range<Int>
+
+  @inlinable
+  public var startIndex: Index { return 0 }
+
+  @inlinable
+  public var endIndex: Index { return count }
+
+  @inlinable
+  public var count: Int {
+    let distance = _start.distance(to: _end)
+    guard distance != 0 && (distance < 0) == (_stride < 0) else { return 0 }
+    return Int((distance - 1) / _stride) + 1
+  }
+
+  public subscript(position: Index) -> Element {
+    _failEarlyRangeCheck(position, bounds: startIndex..<endIndex)
+    return _start.advanced(by: Element.Stride(position) * _stride)
+  }
+
+  public subscript(bounds: Range<Index>) -> Slice<StrideTo<Element>> {
+    _failEarlyRangeCheck(bounds, bounds: startIndex ..< endIndex)
+    return Slice(base: self, bounds: bounds)
+  }
+
+  @inlinable
+  public func index(before i: Index) -> Index {
+    _failEarlyRangeCheck(i, bounds: startIndex + 1...endIndex)
+    return i - 1
+  }
+
+  @inlinable
+  public func index(after i: Index) -> Index {
+    _failEarlyRangeCheck(i, bounds: startIndex - 1..<endIndex)
+    return i + 1
+  }
+}
+#endif
+
+/// Returns a sequence from a starting value to, but not including, an end
+/// value, stepping by the specified amount.
+///
+/// You can use this function to stride over values of any type that conforms
+/// to the `Strideable` protocol, such as integers or floating-point types.
+/// Starting with `start`, each successive value of the sequence adds `stride`
+/// until the next value would be equal to or beyond `end`.
+///
+///     for radians in stride(from: 0.0, to: .pi * 2, by: .pi / 2) {
+///         let degrees = Int(radians * 180 / .pi)
+///         print("Degrees: \(degrees), radians: \(radians)")
+///     }
+///     // Degrees: 0, radians: 0.0
+///     // Degrees: 90, radians: 1.5707963267949
+///     // Degrees: 180, radians: 3.14159265358979
+///     // Degrees: 270, radians: 4.71238898038469
+///
+/// You can use `stride(from:to:by:)` to create a sequence that strides upward
+/// or downward. Pass a negative value as `stride` to create a sequence from a
+/// higher start to a lower end:
+///
+///     for countdown in stride(from: 3, to: 0, by: -1) {
+///         print("\(countdown)...")
+///     }
+///     // 3...
+///     // 2...
+///     // 1...
+///
+/// If you pass a value as `stride` that moves away from `end`, the sequence
+/// contains no values.
+///
+///     for x in stride(from: 0, to: 10, by: -1) {
+///         print(x)
+///     }
+///     // Nothing is printed.
+///
+/// - Parameters:
+///   - start: The starting value to use for the sequence. If the sequence
+///     contains any values, the first one is `start`.
+///   - end: An end value to limit the sequence. `end` is never an element of
+///     the resulting sequence.
+///   - stride: The amount to step by with each iteration. A positive `stride`
+///     iterates upward; a negative `stride` iterates downward.
+/// - Returns: A sequence from `start` toward, but not including, `end`. Each
+///   value in the sequence steps by `stride`.
+@inlinable
+public func stride<T>(
+  from start: T, to end: T, by stride: T.Stride
+) -> StrideTo<T> {
+  return StrideTo(_start: start, end: end, stride: stride)
+}
+
+/// An iterator for a `StrideThrough` instance.
+@frozen
+public struct StrideThroughIterator<Element: Strideable> {
+  @usableFromInline
+  internal let _start: Element
+
+  @usableFromInline
+  internal let _end: Element
+
+  @usableFromInline
+  internal let _stride: Element.Stride
+
+  @usableFromInline
+  internal var _current: (index: Int?, value: Element)
+
+  @usableFromInline
+  internal var _didReturnEnd: Bool = false
+
+  @inlinable
+  internal init(_start: Element, end: Element, stride: Element.Stride) {
+    self._start = _start
+    _end = end
+    _stride = stride
+    _current = (0, _start)
+  }
+}
+
+extension StrideThroughIterator: IteratorProtocol {
+  /// Advances to the next element and returns it, or `nil` if no next element
+  /// exists.
+  ///
+  /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @inlinable
+  public mutating func next() -> Element? {
+    let result = _current.value
+    if _stride > 0 ? result >= _end : result <= _end {
+      // Note the `>=` and `<=` operators above. When `result == _end`, the
+      // following check is needed to prevent advancing `_current` past the
+      // representable bounds of the `Strideable` type unnecessarily.
+      //
+      // If the `Strideable` type is a fixed-width integer, overflowed results
+      // are represented using a sentinel value for `_current.index`, `Int.min`.
+      if result == _end && !_didReturnEnd && _current.index != .min {
+        _didReturnEnd = true
+        return result
+      }
+      return nil
+    }
+    _current = Element._step(after: _current, from: _start, by: _stride)
+    return result
+  }
+}
+
+// FIXME: should really be a Collection, as it is multipass
+/// A sequence of values formed by striding over a closed interval.
+///
+/// Use the `stride(from:through:by:)` function to create `StrideThrough` 
+/// instances.
+@frozen
+public struct StrideThrough<Element: Strideable> {
+  @usableFromInline
+  internal let _start: Element
+  @usableFromInline
+  internal let _end: Element
+  @usableFromInline
+  internal let _stride: Element.Stride
+  
+  @inlinable
+  internal init(_start: Element, end: Element, stride: Element.Stride) {
+    _precondition(stride != 0, "Stride size must not be zero")
+    self._start = _start
+    self._end = end
+    self._stride = stride
+  }
+}
+
+extension StrideThrough: Sequence {
+  /// Returns an iterator over the elements of this sequence.
+  ///
+  /// - Complexity: O(1).
+  @inlinable
+  public __consuming func makeIterator() -> StrideThroughIterator<Element> {
+    return StrideThroughIterator(_start: _start, end: _end, stride: _stride)
+  }
+
+  // FIXME(conditional-conformances): this is O(N) instead of O(1), leaving it
+  // here until a proper Collection conformance is possible
+  @inlinable
+  public var underestimatedCount: Int {
+    var it = self.makeIterator()
+    var count = 0
+    while it.next() != nil {
+      count += 1
+    }
+    return count
+  }
+
+  @inlinable
+  public func _customContainsEquatableElement(
+    _ element: Element
+  ) -> Bool? {
+    if _stride < 0 {
+      if element < _end || _start < element { return false }
+    } else {
+      if element < _start || _end < element { return false }
+    }
+    // TODO: Additional implementation work will avoid always falling back to the
+    // predicate version of `contains` when the sequence *does* contain `element`.
+    return nil
+  }
+}
+
+#if SWIFT_ENABLE_REFLECTION
+extension StrideThrough: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self,
+      children: ["from": _start, "through": _end, "by": _stride])
+  }
+}
+#endif
+
+// FIXME(conditional-conformances): This does not yet compile (https://github.com/apple/swift/issues/49024).
+#if false
+extension StrideThrough: RandomAccessCollection
+where Element.Stride: BinaryInteger {
+  public typealias Index = ClosedRangeIndex<Int>
+  public typealias SubSequence = Slice<StrideThrough<Element>>
+
+  @inlinable
+  public var startIndex: Index {
+    let distance = _start.distance(to: _end)
+    return distance == 0 || (distance < 0) == (_stride < 0)
+      ? ClosedRangeIndex(0)
+      : ClosedRangeIndex()
+  }
+
+  @inlinable
+  public var endIndex: Index { return ClosedRangeIndex() }
+
+  @inlinable
+  public var count: Int {
+    let distance = _start.distance(to: _end)
+    guard distance != 0 else { return 1 }
+    guard (distance < 0) == (_stride < 0) else { return 0 }
+    return Int(distance / _stride) + 1
+  }
+
+  public subscript(position: Index) -> Element {
+    let offset = Element.Stride(position._dereferenced) * _stride
+    return _start.advanced(by: offset)
+  }
+
+  public subscript(bounds: Range<Index>) -> Slice<StrideThrough<Element>> {
+    return Slice(base: self, bounds: bounds)
+  }
+
+  @inlinable
+  public func index(before i: Index) -> Index {
+    switch i._value {
+    case .inRange(let n):
+      _precondition(n > 0, "Incrementing past start index")
+      return ClosedRangeIndex(n - 1)
+    case .pastEnd:
+      _precondition(_end >= _start, "Incrementing past start index")
+      return ClosedRangeIndex(count - 1)
+    }
+  }
+
+  @inlinable
+  public func index(after i: Index) -> Index {
+    switch i._value {
+    case .inRange(let n):
+      return n == (count - 1)
+        ? ClosedRangeIndex()
+        : ClosedRangeIndex(n + 1)
+    case .pastEnd:
+      _preconditionFailure("Incrementing past end index")
+    }
+  }
+}
+#endif
+
+/// Returns a sequence from a starting value toward, and possibly including, an end
+/// value, stepping by the specified amount.
+///
+/// You can use this function to stride over values of any type that conforms
+/// to the `Strideable` protocol, such as integers or floating-point types.
+/// Starting with `start`, each successive value of the sequence adds `stride`
+/// until the next value would be beyond `end`.
+///
+///     for radians in stride(from: 0.0, through: .pi * 2, by: .pi / 2) {
+///         let degrees = Int(radians * 180 / .pi)
+///         print("Degrees: \(degrees), radians: \(radians)")
+///     }
+///     // Degrees: 0, radians: 0.0
+///     // Degrees: 90, radians: 1.5707963267949
+///     // Degrees: 180, radians: 3.14159265358979
+///     // Degrees: 270, radians: 4.71238898038469
+///     // Degrees: 360, radians: 6.28318530717959
+///
+/// You can use `stride(from:through:by:)` to create a sequence that strides 
+/// upward or downward. Pass a negative value as `stride` to create a sequence 
+/// from a higher start to a lower end:
+///
+///     for countdown in stride(from: 3, through: 1, by: -1) {
+///         print("\(countdown)...")
+///     }
+///     // 3...
+///     // 2...
+///     // 1...
+///
+/// The value you pass as `end` is not guaranteed to be included in the 
+/// sequence. If stepping from `start` by `stride` does not produce `end`, 
+/// the last value in the sequence will be one step before going beyond `end`.
+///
+///     for multipleOfThree in stride(from: 3, through: 10, by: 3) {
+///         print(multipleOfThree)
+///     }
+///     // 3
+///     // 6
+///     // 9
+///
+/// If you pass a value as `stride` that moves away from `end`, the sequence 
+/// contains no values.
+///
+///     for x in stride(from: 0, through: 10, by: -1) {
+///         print(x)
+///     }
+///     // Nothing is printed.
+///
+/// - Parameters:
+///   - start: The starting value to use for the sequence. If the sequence
+///     contains any values, the first one is `start`.
+///   - end: An end value to limit the sequence. `end` is an element of
+///     the resulting sequence if and only if it can be produced from `start` 
+///     using steps of `stride`.
+///   - stride: The amount to step by with each iteration. A positive `stride`
+///     iterates upward; a negative `stride` iterates downward.
+/// - Returns: A sequence from `start` toward, and possibly including, `end`. 
+///   Each value in the sequence is separated by `stride`.
+@inlinable
+public func stride<T>(
+  from start: T, through end: T, by stride: T.Stride
+) -> StrideThrough<T> {
+  return StrideThrough(_start: start, end: end, stride: stride)
+}
+
+extension StrideToIterator: Sendable
+  where Element: Sendable, Element.Stride: Sendable { }
+extension StrideTo: Sendable
+  where Element: Sendable, Element.Stride: Sendable { }
+extension StrideThroughIterator: Sendable
+  where Element: Sendable, Element.Stride: Sendable { }
+extension StrideThrough: Sendable
+  where Element: Sendable, Element.Stride: Sendable { }

--- a/grammars/testdata/swift_corpus/swift-algorithms_AdjacentPairsTests.swift
+++ b/grammars/testdata/swift_corpus/swift-algorithms_AdjacentPairsTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import Algorithms
+
+final class AdjacentPairsTests: XCTestCase {
+  func testEmptySequence() {
+    let pairs = (0...).prefix(0).adjacentPairs()
+    XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+  
+  func testOneElementSequence() {
+    let pairs = (0...).prefix(1).adjacentPairs()
+    XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+  
+  func testTwoElementSequence() {
+    let pairs = (0...).prefix(2).adjacentPairs()
+    XCTAssertEqualSequences(pairs, [(0, 1)], by: ==)
+  }
+  
+  func testThreeElementSequence() {
+    let pairs = (0...).prefix(3).adjacentPairs()
+    XCTAssertEqualSequences(pairs, [(0, 1), (1, 2)], by: ==)
+  }
+  
+  func testManySequences() {
+    for n in 4...100 {
+      let pairs = (0...).prefix(n).adjacentPairs()
+      XCTAssertEqualSequences(pairs, zip(0..., 1...).prefix(n - 1), by: ==)
+    }
+  }
+  
+  func testZeroElements() {
+    let pairs = (0..<0).adjacentPairs()
+    XCTAssertEqual(pairs.startIndex, pairs.endIndex)
+    XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+
+  func testOneElement() {
+    let pairs = (0..<1).adjacentPairs()
+    XCTAssertEqual(pairs.startIndex, pairs.endIndex)
+    XCTAssertEqualSequences(pairs, [], by: ==)
+  }
+
+  func testTwoElements() {
+    let pairs = (0..<2).adjacentPairs()
+    XCTAssertEqualSequences(pairs, [(0, 1)], by: ==)
+  }
+
+  func testThreeElements() {
+    let pairs = (0..<3).adjacentPairs()
+    XCTAssertEqualSequences(pairs, [(0, 1), (1, 2)], by: ==)
+  }
+
+  func testManyElements() {
+    for n in 4...100 {
+      let pairs = (0..<n).adjacentPairs()
+      XCTAssertEqualSequences(pairs, zip(0..., 1...).prefix(n - 1), by: ==)
+    }
+  }
+
+  func testIndexTraversals() {
+    let validator = IndexValidator<AdjacentPairsCollection<Range<Int>>>()
+    validator.validate((0..<0).adjacentPairs(), expectedCount: 0)
+    validator.validate((0..<1).adjacentPairs(), expectedCount: 0)
+    validator.validate((0..<2).adjacentPairs(), expectedCount: 1)
+    validator.validate((0..<5).adjacentPairs(), expectedCount: 4)
+  }
+  
+  func testLaziness() {
+    XCTAssertLazySequence((0...).lazy.adjacentPairs())
+    XCTAssertLazyCollection((0..<100).lazy.adjacentPairs())
+  }
+}

--- a/grammars/testdata/swift_corpus/swift-algorithms_Chunked.swift
+++ b/grammars/testdata/swift_corpus/swift-algorithms_Chunked.swift
@@ -1,0 +1,874 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A collection wrapper that breaks a collection into chunks based on a
+/// predicate.
+///
+/// Call `lazy.chunked(by:)` on a collection to create an instance of this type.
+public struct ChunkedByCollection<Base: Collection, Subject> {
+  /// The collection that this instance provides a view onto.
+  @usableFromInline
+  internal let base: Base
+  
+  /// The projection function.
+  @usableFromInline
+  internal let projection: (Base.Element) -> Subject
+  
+  /// The predicate.
+  @usableFromInline
+  internal let belongInSameGroup: (Subject, Subject) -> Bool
+  
+  /// The end index of the first chunk.
+  @usableFromInline
+  internal var endOfFirstChunk: Base.Index
+  
+  @inlinable
+  internal init(
+    base: Base,
+    projection: @escaping (Base.Element) -> Subject,
+    belongInSameGroup: @escaping (Subject, Subject) -> Bool
+  ) {
+    self.base = base
+    self.projection = projection
+    self.belongInSameGroup = belongInSameGroup
+    self.endOfFirstChunk = base.startIndex
+    
+    if !base.isEmpty {
+      endOfFirstChunk = endOfChunk(startingAt: base.startIndex)
+    }
+  }
+}
+
+extension ChunkedByCollection: Collection {
+  /// A position in a chunked collection.
+  public struct Index: Comparable {
+    /// The range corresponding to the chunk at this position.
+    @usableFromInline
+    internal var baseRange: Range<Base.Index>
+    
+    @inlinable
+    internal init(_ baseRange: Range<Base.Index>) {
+      self.baseRange = baseRange
+    }
+    
+    @inlinable
+    public static func == (lhs: Index, rhs: Index) -> Bool {
+      // Since each index represents the range of a disparate chunk, no two
+      // unique indices will have the same lower bound.
+      lhs.baseRange.lowerBound == rhs.baseRange.lowerBound
+    }
+    
+    @inlinable
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      // Only use the lower bound to test for ordering, as above.
+      lhs.baseRange.lowerBound < rhs.baseRange.lowerBound
+    }
+  }
+
+  /// Returns the index in the base collection of the end of the chunk starting
+  /// at the given index.
+  @inlinable
+  internal func endOfChunk(startingAt start: Base.Index) -> Base.Index {
+    var subject = projection(base[start])
+    
+    return base[base.index(after: start)...].endOfPrefix(while: { element in
+      let nextSubject = projection(element)
+      defer { subject = nextSubject }
+      return belongInSameGroup(subject, nextSubject)
+    })
+  }
+  
+  @inlinable
+  public var startIndex: Index {
+    Index(base.startIndex..<endOfFirstChunk)
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(base.endIndex..<base.endIndex)
+  }
+  
+  @inlinable
+  public func index(after i: Index) -> Index {
+    precondition(i != endIndex, "Can't advance past endIndex")
+    let upperBound = i.baseRange.upperBound
+    guard upperBound != base.endIndex else { return endIndex }
+    let end = endOfChunk(startingAt: upperBound)
+    return Index(upperBound..<end)
+  }
+  
+  @inlinable
+  public subscript(position: Index) -> Base.SubSequence {
+    precondition(position != endIndex, "Can't subscript using endIndex")
+    return base[position.baseRange]
+  }
+}
+
+extension ChunkedByCollection.Index: Hashable where Base.Index: Hashable {}
+
+extension ChunkedByCollection: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  /// Returns the index in the base collection of the start of the chunk ending
+  /// at the given index.
+  @inlinable
+  internal func startOfChunk(endingAt end: Base.Index) -> Base.Index {
+    let indexBeforeEnd = base.index(before: end)
+    var subject = projection(base[indexBeforeEnd])
+    
+    return base[..<indexBeforeEnd].startOfSuffix(while: { element in
+      let nextSubject = projection(element)
+      defer { subject = nextSubject }
+      return belongInSameGroup(nextSubject, subject)
+    })
+  }
+
+  @inlinable
+  public func index(before i: Index) -> Index {
+    precondition(i != startIndex, "Can't advance before startIndex")
+    let start = startOfChunk(endingAt: i.baseRange.lowerBound)
+    return Index(start..<i.baseRange.lowerBound)
+  }
+}
+
+extension ChunkedByCollection: LazyCollectionProtocol {}
+
+/// A collection wrapper that breaks a collection into chunks based on a
+/// predicate.
+///
+/// Call `lazy.chunked(on:)` on a collection to create an instance of this type.
+public struct ChunkedOnCollection<Base: Collection, Subject: Equatable> {
+  @usableFromInline
+  internal var chunked: ChunkedByCollection<Base, Subject>
+  
+  @inlinable
+  internal init(
+    base: Base,
+    projection: @escaping (Base.Element) -> Subject
+  ) {
+    self.chunked = ChunkedByCollection(
+      base: base,
+      projection: projection,
+      belongInSameGroup: ==)
+  }
+}
+
+extension ChunkedOnCollection: Collection {
+  public typealias Index = ChunkedByCollection<Base, Subject>.Index
+  
+  @inlinable
+  public var startIndex: Index {
+    chunked.startIndex
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    chunked.endIndex
+  }
+  
+  @inlinable
+  public subscript(position: Index) -> (Subject, Base.SubSequence) {
+    let subsequence = chunked[position]
+    let subject = chunked.projection(subsequence.first!)
+    return (subject, subsequence)
+  }
+  
+  @inlinable
+  public func index(after i: Index) -> Index {
+    chunked.index(after: i)
+  }
+}
+
+extension ChunkedOnCollection: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  @inlinable
+  public func index(before i: Index) -> Index {
+    chunked.index(before: i)
+  }
+}
+
+extension ChunkedOnCollection: LazyCollectionProtocol {}
+
+/// A collection wrapper that evenly breaks a collection into a given number of
+/// chunks.
+public struct EvenlyChunkedCollection<Base: Collection> {
+  /// The base collection.
+  @usableFromInline
+  internal let base: Base
+  
+  /// The number of equal chunks the base collection is divided into.
+  @usableFromInline
+  internal let numberOfChunks: Int
+  
+  /// The count of the base collection.
+  @usableFromInline
+  internal let baseCount: Int
+  
+  /// The upper bound of the first chunk.
+  @usableFromInline
+  internal var firstUpperBound: Base.Index
+  
+  @inlinable
+  internal init(base: Base, numberOfChunks: Int) {
+    self.base = base
+    self.numberOfChunks = numberOfChunks
+    self.baseCount = base.count
+    self.firstUpperBound = base.startIndex
+    
+    if numberOfChunks > 0 {
+      firstUpperBound = endOfChunk(startingAt: base.startIndex, offset: 0)
+    }
+  }
+}
+
+extension EvenlyChunkedCollection {
+  /// Returns the number of chunks with size `smallChunkSize + 1` at the start
+  /// of this collection.
+  @inlinable
+  internal var numberOfLargeChunks: Int {
+    baseCount % numberOfChunks
+  }
+  
+  /// Returns the size of a chunk at a given offset.
+  @inlinable
+  internal func sizeOfChunk(offset: Int) -> Int {
+    let isLargeChunk = offset < numberOfLargeChunks
+    return baseCount / numberOfChunks + (isLargeChunk ? 1 : 0)
+  }
+  
+  /// Returns the index in the base collection of the end of the chunk starting
+  /// at the given index.
+  @inlinable
+  internal func endOfChunk(startingAt start: Base.Index, offset: Int) -> Base.Index {
+    base.index(start, offsetBy: sizeOfChunk(offset: offset))
+  }
+  
+  /// Returns the index in the base collection of the start of the chunk ending
+  /// at the given index.
+  @inlinable
+  internal func startOfChunk(endingAt end: Base.Index, offset: Int) -> Base.Index {
+    base.index(end, offsetBy: -sizeOfChunk(offset: offset))
+  }
+  
+  /// Returns the index that corresponds to the chunk that starts at the given
+  /// base index.
+  @inlinable
+  internal func indexOfChunk(startingAt start: Base.Index, offset: Int) -> Index {
+    guard offset != numberOfChunks else { return endIndex }
+    let end = endOfChunk(startingAt: start, offset: offset)
+    return Index(start..<end, offset: offset)
+  }
+  
+  /// Returns the index that corresponds to the chunk that ends at the given
+  /// base index.
+  @inlinable
+  internal func indexOfChunk(endingAt end: Base.Index, offset: Int) -> Index {
+    let start = startOfChunk(endingAt: end, offset: offset)
+    return Index(start..<end, offset: offset)
+  }
+}
+
+extension EvenlyChunkedCollection: Collection {
+  public struct Index: Comparable {
+    /// The range corresponding to the chunk at this position.
+    @usableFromInline
+    internal var baseRange: Range<Base.Index>
+    
+    /// The offset corresponding to the chunk at this position. The first chunk
+    /// has offset `0` and all other chunks have an offset `1` greater than the
+    /// previous.
+    @usableFromInline
+    internal var offset: Int
+    
+    @inlinable
+    internal init(_ baseRange: Range<Base.Index>, offset: Int) {
+      self.baseRange = baseRange
+      self.offset = offset
+    }
+    
+    @inlinable
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.offset == rhs.offset
+    }
+    
+    @inlinable
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.offset < rhs.offset
+    }
+  }
+  
+  public typealias Element = Base.SubSequence
+
+  @inlinable
+  public var startIndex: Index {
+    Index(base.startIndex..<firstUpperBound, offset: 0)
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(base.endIndex..<base.endIndex, offset: numberOfChunks)
+  }
+  
+  @inlinable
+  public func index(after i: Index) -> Index {
+    precondition(i != endIndex, "Can't advance past endIndex")
+    let start = i.baseRange.upperBound
+    return indexOfChunk(startingAt: start, offset: i.offset + 1)
+  }
+  
+  @inlinable
+  public subscript(position: Index) -> Element {
+    precondition(position != endIndex)
+    return base[position.baseRange]
+  }
+  
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    /// Returns the base distance between two `EvenChunksCollection` indices
+    /// from the end of one to the start of the other, when given their offsets.
+    func baseDistance(from offsetA: Int, to offsetB: Int) -> Int {
+      let smallChunkSize = baseCount / numberOfChunks
+      let numberOfChunks = (offsetB - offsetA) - 1
+      
+      let largeChunksEnd = Swift.min(self.numberOfLargeChunks, offsetB)
+      let largeChunksStart = Swift.min(self.numberOfLargeChunks, offsetA + 1)
+      let numberOfLargeChunks = largeChunksEnd - largeChunksStart
+      
+      return smallChunkSize * numberOfChunks + numberOfLargeChunks
+    }
+    
+    if distance == 0 {
+      return i
+    } else if distance > 0 {
+      let offset = i.offset + distance
+      let baseOffset = baseDistance(from: i.offset, to: offset)
+      let start = base.index(i.baseRange.upperBound, offsetBy: baseOffset)
+      return indexOfChunk(startingAt: start, offset: offset)
+    } else {
+      let offset = i.offset + distance
+      let baseOffset = baseDistance(from: offset, to: i.offset)
+      let end = base.index(i.baseRange.lowerBound, offsetBy: -baseOffset)
+      return indexOfChunk(endingAt: end, offset: offset)
+    }
+  }
+  
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int, limitedBy limit: Index) -> Index? {
+    if distance >= 0 {
+      if (0..<distance).contains(self.distance(from: i, to: limit)) {
+        return nil
+      }
+    } else {
+      if (0..<(-distance)).contains(self.distance(from: limit, to: i)) {
+        return nil
+      }
+    }
+    return index(i, offsetBy: distance)
+  }
+  
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    end.offset - start.offset
+  }
+}
+
+extension EvenlyChunkedCollection.Index: Hashable where Base.Index: Hashable {}
+
+extension EvenlyChunkedCollection: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  @inlinable
+  public func index(before i: Index) -> Index {
+    precondition(i != startIndex, "Can't advance before startIndex")
+    return indexOfChunk(endingAt: i.baseRange.lowerBound, offset: i.offset - 1)
+  }
+}
+
+extension EvenlyChunkedCollection: RandomAccessCollection
+  where Base: RandomAccessCollection {}
+
+extension EvenlyChunkedCollection: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+
+extension EvenlyChunkedCollection: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol {}
+
+//===----------------------------------------------------------------------===//
+// lazy.chunked(by:) / lazy.chunked(on:)
+//===----------------------------------------------------------------------===//
+
+extension LazySequenceProtocol where Self: Collection, Elements: Collection {
+  /// Returns a lazy collection of subsequences of this collection, chunked by
+  /// the given predicate.
+  ///
+  /// - Parameter belongInSameGroup: A closure that takes two adjacent elements
+  /// of the sequence and returns whether or not they belong in the same group.
+  ///
+  /// - Complexity: O(*n*), because the start index is pre-computed.
+  @inlinable
+  public func chunked(
+    by belongInSameGroup: @escaping (Element, Element) -> Bool
+  ) -> ChunkedByCollection<Elements, Element> {
+    ChunkedByCollection(
+      base: elements,
+      projection: { $0 },
+      belongInSameGroup: belongInSameGroup)
+  }
+  
+  /// Returns a lazy collection of subsequences of this collection, chunked by
+  /// grouping elements that project to equal values.
+  ///
+  /// - Parameter projection: A closure that takes an element in the sequence
+  /// and returns an `Equatable` value that can be used to determine if adjacent
+  /// elements belong in the same group.
+  ///
+  /// - Complexity: O(*n*), because the start index is pre-computed.
+  @inlinable
+  public func chunked<Subject>(
+    on projection: @escaping (Element) -> Subject
+  ) -> ChunkedOnCollection<Elements, Subject> {
+    ChunkedOnCollection(
+      base: elements,
+      projection: projection)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// chunked(by:) / chunked(on:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns a collection of subsequences of this collection, chunked by the
+  /// given predicate.
+  ///
+  /// - Parameter belongInSameGroup: A closure that takes two adjacent elements
+  /// of the collection and returns whether or not they belong in the same
+  /// group.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  @inlinable
+  public func chunked(
+    by belongInSameGroup: (Element, Element) throws -> Bool
+  ) rethrows -> [SubSequence] {
+    guard !isEmpty else { return [] }
+    var result: [SubSequence] = []
+    
+    var start = startIndex
+    var current = self[start]
+    
+    for (index, element) in indexed().dropFirst() {
+      if try !belongInSameGroup(current, element) {
+        result.append(self[start..<index])
+        start = index
+      }
+      current = element
+    }
+    
+    if start != endIndex {
+      result.append(self[start...])
+    }
+    
+    return result
+  }
+
+  /// Returns a collection of subsequences of this collection, chunked by
+  /// grouping elements that project to equal values.
+  ///
+  /// - Parameter projection: A closure that takes an element in the collection
+  /// and returns an `Equatable` value that can be used to determine if adjacent
+  /// elements belong in the same group.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  @inlinable
+  public func chunked<Subject: Equatable>(
+    on projection: (Element) throws -> Subject
+  ) rethrows -> [(Subject, SubSequence)] {
+    guard !isEmpty else { return [] }
+    var result: [(Subject, SubSequence)] = []
+    
+    var start = startIndex
+    var subject = try projection(self[start])
+    
+    for (index, element) in indexed().dropFirst() {
+      let nextSubject = try projection(element)
+      if subject != nextSubject {
+        result.append((subject, self[start..<index]))
+        start = index
+        subject = nextSubject
+      }
+    }
+    
+    if start != endIndex {
+      result.append((subject, self[start...]))
+    }
+    
+    return result
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// chunks(ofCount:)
+//===----------------------------------------------------------------------===//
+
+/// A collection that presents the elements of its base collection in
+/// `SubSequence` chunks of any given count.
+///
+/// A `ChunksOfCountCollection` is a lazy view on the base `Collection`, but it
+/// does not implicitly confer laziness on algorithms applied to its result. In
+/// other words, for ordinary collections `c`:
+///
+/// * `c.chunks(ofCount: 3)` does not create new storage
+/// * `c.chunks(ofCount: 3).map(f)` maps eagerly and returns a new array
+/// * `c.lazy.chunks(ofCount: 3).map(f)` maps lazily and returns a
+///   `LazyMapCollection`
+public struct ChunksOfCountCollection<Base: Collection> {
+  public typealias Element = Base.SubSequence
+  
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let chunkCount: Int
+  
+  @usableFromInline
+  internal var endOfFirstChunk: Base.Index
+
+  ///  Creates a view instance that presents the elements of `base` in
+  ///  `SubSequence` chunks of the given count.
+  ///
+  /// - Complexity: O(*n*), because the start index is pre-computed.
+  @inlinable
+  internal init(_base: Base, _chunkCount: Int) {
+    self.base = _base
+    self.chunkCount = _chunkCount
+    
+    // Compute the start index upfront in order to make start index a O(1)
+    // lookup.
+    self.endOfFirstChunk = _base.index(
+      _base.startIndex, offsetBy: _chunkCount,
+      limitedBy: _base.endIndex
+    ) ?? _base.endIndex
+  }
+}
+
+extension ChunksOfCountCollection: Collection {
+  public struct Index {
+    @usableFromInline
+    internal let baseRange: Range<Base.Index>
+    
+    @inlinable
+    internal init(_baseRange: Range<Base.Index>) {
+      self.baseRange = _baseRange
+    }
+  }
+
+  /// - Complexity: O(1)
+  @inlinable
+  public var startIndex: Index {
+    Index(_baseRange: base.startIndex..<endOfFirstChunk)
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(_baseRange: base.endIndex..<base.endIndex)
+  }
+  
+  /// - Complexity: O(1)
+  @inlinable
+  public subscript(i: Index) -> Element {
+    precondition(i != endIndex, "Index out of range")
+    return base[i.baseRange]
+  }
+  
+  @inlinable
+  public func index(after i: Index) -> Index {
+    precondition(i != endIndex, "Advancing past end index")
+    let baseIdx = base.index(
+      i.baseRange.upperBound, offsetBy: chunkCount,
+      limitedBy: base.endIndex
+    ) ?? base.endIndex
+    return Index(_baseRange: i.baseRange.upperBound..<baseIdx)
+  }
+}
+
+extension ChunksOfCountCollection.Index: Comparable {
+  @inlinable
+  public static func == (lhs: ChunksOfCountCollection.Index,
+                         rhs: ChunksOfCountCollection.Index) -> Bool {
+    lhs.baseRange.lowerBound == rhs.baseRange.lowerBound
+  }
+  
+  @inlinable
+  public static func < (lhs: ChunksOfCountCollection.Index,
+                        rhs: ChunksOfCountCollection.Index) -> Bool {
+    lhs.baseRange.lowerBound < rhs.baseRange.lowerBound
+  }
+}
+
+extension ChunksOfCountCollection:
+  BidirectionalCollection, RandomAccessCollection
+where Base: RandomAccessCollection {
+  @inlinable
+  public func index(before i: Index) -> Index {
+    precondition(i != startIndex, "Advancing past start index")
+    
+    var offset = chunkCount
+    if i.baseRange.lowerBound == base.endIndex {
+      let remainder = base.count % chunkCount
+      if remainder != 0 {
+        offset = remainder
+      }
+    }
+    
+    let baseIdx = base.index(
+      i.baseRange.lowerBound, offsetBy: -offset,
+      limitedBy: base.startIndex
+    ) ?? base.startIndex
+    return Index(_baseRange: baseIdx..<i.baseRange.lowerBound)
+  }
+}
+
+extension ChunksOfCountCollection {
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    let distance =
+      base.distance(from: start.baseRange.lowerBound,
+                    to: end.baseRange.lowerBound)
+    let (quotient, remainder) =
+      distance.quotientAndRemainder(dividingBy: chunkCount)
+    return quotient + remainder.signum()
+  }
+
+  @inlinable
+  public var count: Int {
+    let (quotient, remainder) =
+      base.count.quotientAndRemainder(dividingBy: chunkCount)
+    return quotient + remainder.signum()
+  }
+  
+  @inlinable
+  public func index(
+    _ i: Index, offsetBy offset: Int, limitedBy limit: Index
+  ) -> Index? {
+    guard offset != 0 else { return i }
+    guard limit != i else { return nil }
+    
+    if offset > 0 {
+      return limit > i
+        ? offsetForward(i, offsetBy: offset, limit: limit)
+        : offsetForward(i, offsetBy: offset)
+    } else {
+      return limit < i
+        ? offsetBackward(i, offsetBy: offset, limit: limit)
+        : offsetBackward(i, offsetBy: offset)
+    }
+  }
+
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    guard distance != 0 else { return i }
+    
+    let idx = distance > 0
+        ? offsetForward(i, offsetBy: distance)
+        : offsetBackward(i, offsetBy: distance)
+    guard let index = idx else {
+      fatalError("Out of bounds")
+    }
+    return index
+  }
+  
+  @inlinable
+  internal func offsetForward(
+    _ i: Index, offsetBy distance: Int, limit: Index? = nil
+  ) -> Index? {
+    assert(distance > 0)
+
+    return makeOffsetIndex(
+      from: i, baseBound: base.endIndex,
+      distance: distance, baseDistance: distance * chunkCount,
+      limit: limit, by: >
+    )
+  }
+  
+  // Convenience to compute offset backward base distance.
+  @inlinable
+  internal func computeOffsetBackwardBaseDistance(
+    _ i: Index, _ distance: Int
+  ) -> Int {
+    if i == endIndex {
+      let remainder = base.count % chunkCount
+      // We have to take it into account when calculating offsets.
+      if remainder != 0 {
+        // Distance "minus" one (at this point distance is negative) because we
+        // need to adjust for the last position that have a variadic (remainder)
+        // number of elements.
+        return ((distance + 1) * chunkCount) - remainder
+      }
+    }
+    return distance * chunkCount
+  }
+  
+  @inlinable
+  internal func offsetBackward(
+    _ i: Index, offsetBy distance: Int, limit: Index? = nil
+  ) -> Index? {
+    assert(distance < 0)
+    let baseDistance =
+        computeOffsetBackwardBaseDistance(i, distance)
+    return makeOffsetIndex(
+      from: i, baseBound: base.startIndex,
+      distance: distance, baseDistance: baseDistance,
+      limit: limit, by: <
+    )
+  }
+  
+  // Helper to compute `index(offsetBy:)` index.
+  @inlinable
+  internal func makeOffsetIndex(
+    from i: Index, baseBound: Base.Index, distance: Int, baseDistance: Int,
+    limit: Index?, by limitFn: (Base.Index, Base.Index) -> Bool
+  ) -> Index? {
+    let baseIdx = base.index(
+      i.baseRange.lowerBound, offsetBy: baseDistance,
+      limitedBy: baseBound
+    )
+    
+    if let limit = limit {
+      if baseIdx == nil {
+        // If we passed the bounds while advancing forward, and the limit is the
+        // `endIndex`, since the computation on `base` don't take into account
+        // the remainder, we have to make sure that passing the bound was
+        // because of the distance not just because of a remainder. Special
+        // casing is less expensive than always using `count` (which could be
+        // O(n) for non-random access collection base) to compute the base
+        // distance taking remainder into account.
+        if baseDistance > 0 && limit == endIndex {
+          if self.distance(from: i, to: limit) < distance {
+            return nil
+          }
+        } else {
+          return nil
+        }
+      }
+
+      // Checks for the limit.
+      let baseStartIdx = baseIdx ?? baseBound
+      if limitFn(baseStartIdx, limit.baseRange.lowerBound) {
+        return nil
+      }
+    }
+    
+    let baseStartIdx = baseIdx ?? baseBound
+    let baseEndIdx = base.index(
+      baseStartIdx, offsetBy: chunkCount, limitedBy: base.endIndex
+    ) ?? base.endIndex
+    
+    return Index(_baseRange: baseStartIdx..<baseEndIdx)
+  }
+}
+
+extension Collection {
+  /// Returns a collection of subsequences, each with up to the specified
+  /// length.
+  ///
+  /// If the number of elements in the collection is evenly divided by `count`,
+  /// then every chunk will have a length equal to `count`. Otherwise, every
+  /// chunk but the last will have a length equal to `count`, with the
+  /// remaining elements in the last chunk.
+  ///
+  ///     let numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  ///     for chunk in numbers.chunks(ofCount: 5) {
+  ///         print(chunk)
+  ///     }
+  ///     // [1, 2, 3, 4, 5]
+  ///     // [6, 7, 8, 9, 10]
+  ///
+  ///     for chunk in numbers.chunks(ofCount: 3) {
+  ///         print(chunk)
+  ///     }
+  ///     // [1, 2, 3]
+  ///     // [4, 5, 5]
+  ///     // [7, 8, 9]
+  ///     // [10]
+  ///
+  /// - Parameter count: The desired size of each chunk.
+  /// - Returns: A collection of consescutive, non-overlapping subseqeunces of
+  ///   this collection, where each subsequence (except possibly the last) has
+  ///   the length `count`.
+  ///
+  /// - Complexity: O(1) if the collection conforms to `RandomAccessCollection`;
+  ///   otherwise, O(*k*), where *k* is equal to `count`.
+  ///
+  @inlinable
+  public func chunks(ofCount count: Int) -> ChunksOfCountCollection<Self> {
+    precondition(count > 0, "Cannot chunk with count <= 0!")
+    return ChunksOfCountCollection(_base: self, _chunkCount: count)
+  }
+}
+
+extension ChunksOfCountCollection.Index: Hashable where Base.Index: Hashable {}
+
+extension ChunksOfCountCollection: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+
+extension ChunksOfCountCollection: LazyCollectionProtocol
+  where Base: LazyCollectionProtocol {}
+
+//===----------------------------------------------------------------------===//
+// evenlyChunked(in:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns a collection of evenly divided consecutive subsequences of this
+  /// collection.
+  ///
+  /// This method divides the collection into a given number of evenly sized
+  /// chunks. If the length of the collection is not divisible by `count`, the
+  /// chunks at the start will be longer than the chunks at the end, like in
+  /// this example:
+  ///
+  ///     for chunk in "Hello, world!".evenlyChunked(in: 5) {
+  ///         print(chunk)
+  ///     }
+  ///     // "Hel"
+  ///     // "lo,"
+  ///     // " wo"
+  ///     // "rl"
+  ///     // "d!"
+  ///
+  /// If the number passed as `count` is greater than the number of elements in
+  /// the collection, the result will include one or more empty subsequences.
+  ///
+  ///     for chunk in "Hi!".evenlyChunked(in: 5) {
+  ///         print(chunk)
+  ///     }
+  ///     // "H"
+  ///     // "i"
+  ///     // "!"
+  ///     // ""
+  ///     // ""
+  ///
+  /// - Parameter count: The number of chunks to evenly divide this collection
+  ///   into. If this collection is non-empty, `count` must be greater than
+  ///   zero; otherwise, `count` may be zero or greater.
+  /// - Returns: A collection of `count` subsequences of this collection,
+  ///   divided as evenly as possible.
+  ///
+  /// - Complexity: O(1) if the collection conforms to `RandomAccessCollection`;
+  ///   otherwise, O(*n*), where *n* is the length of the collection.
+  @inlinable
+  public func evenlyChunked(in count: Int) -> EvenlyChunkedCollection<Self> {
+    precondition(count >= 0, "Can't divide into a negative number of chunks")
+    precondition(count > 0 || isEmpty, "Can't divide a non-empty collection into 0 chunks")
+    return EvenlyChunkedCollection(base: self, numberOfChunks: count)
+  }
+}

--- a/grammars/testdata/swift_corpus/swift-algorithms_FlattenCollection.swift
+++ b/grammars/testdata/swift_corpus/swift-algorithms_FlattenCollection.swift
@@ -1,0 +1,311 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A collection consisting of all the elements contained in a collection of
+/// collections.
+@usableFromInline
+internal struct FlattenCollection<Base: Collection>
+  where Base.Element: Collection
+{
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let indexOfFirstNonEmptyElement: Base.Index
+  
+  @inlinable
+  internal init(base: Base) {
+    self.base = base
+    self.indexOfFirstNonEmptyElement = base.endOfPrefix(while: { $0.isEmpty })
+  }
+}
+
+extension FlattenCollection: Collection {
+  @usableFromInline
+  internal struct Index: Comparable {
+    @usableFromInline
+    internal let outer: Base.Index
+    
+    @usableFromInline
+    internal let inner: Base.Element.Index?
+    
+    @inlinable
+    init(outer: Base.Index, inner: Base.Element.Index?) {
+      self.outer = outer
+      self.inner = inner
+    }
+    
+    @inlinable
+    internal static func < (lhs: Self, rhs: Self) -> Bool {
+      guard lhs.outer == rhs.outer else { return lhs.outer < rhs.outer }
+      return lhs.inner == nil ? false : lhs.inner! < rhs.inner!
+    }
+  }
+  
+  @inlinable
+  internal var startIndex: Index {
+    let outer = indexOfFirstNonEmptyElement
+    let inner = outer == base.endIndex ? nil : base[outer].startIndex
+    return Index(outer: outer, inner: inner)
+  }
+  
+  @inlinable
+  internal var endIndex: Index {
+    Index(outer: base.endIndex, inner: nil)
+  }
+  
+  /// Forms an index from a pair of base indices, normalizing
+  /// `(i, base2.endIndex)` to `(base1.index(after: i), base2.startIndex)` if
+  /// necessary.
+  @inlinable
+  internal func normalizeIndex(
+    outer: Base.Index,
+    inner: Base.Element.Index
+  ) -> Index {
+    if inner == base[outer].endIndex {
+      let outer = base[base.index(after: outer)...]
+        .endOfPrefix(while: { $0.isEmpty })
+      let inner = outer == base.endIndex ? nil : base[outer].startIndex
+      return Index(outer: outer, inner: inner)
+    } else {
+      return Index(outer: outer, inner: inner)
+    }
+  }
+  
+  @inlinable
+  internal func index(after index: Index) -> Index {
+    let element = base[index.outer]
+    let nextInner = element.index(after: index.inner!)
+    return normalizeIndex(outer: index.outer, inner: nextInner)
+  }
+  
+  @inlinable
+  internal subscript(position: Index) -> Base.Element.Element {
+    base[position.outer][position.inner!]
+  }
+  
+  @inlinable
+  internal func distance(from start: Index, to end: Index) -> Int {
+    guard start.outer <= end.outer
+      else { return -distance(from: end, to: start) }
+    guard let startInner = start.inner
+      else { return 0 }
+    guard start.outer != end.outer
+      else {
+        return base[start.outer].distance(from: startInner, to: end.inner!)
+      }
+    
+    let firstPart = base[start.outer][startInner...].count
+    let middlePart = base[start.outer..<end.outer].dropFirst()
+      .reduce(0, { $0 + $1.count })
+    let lastPart = end.inner.map { base[end.outer][..<$0].count } ?? 0
+    
+    return firstPart + middlePart + lastPart
+  }
+  
+  @inlinable
+  internal func index(_ index: Index, offsetBy distance: Int) -> Index {
+    guard distance != 0 else { return index }
+    
+    return distance > 0
+      ? offsetForward(index, by: distance)
+      : offsetBackward(index, by: -distance)
+  }
+  
+  @inlinable
+  internal func index(
+    _ index: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    guard distance != 0 else { return index }
+    
+    if distance > 0 {
+      return limit >= index
+        ? offsetForward(index, by: distance, limitedBy: limit)
+        : offsetForward(index, by: distance)
+    } else {
+      return limit <= index
+        ? offsetBackward(index, by: -distance, limitedBy: limit)
+        : offsetBackward(index, by: -distance)
+    }
+  }
+  
+  @inlinable
+  internal func offsetForward(_ i: Index, by distance: Int) -> Index {
+    guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
+  }
+  
+  @inlinable
+  internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
+    guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
+  }
+  
+  @inlinable
+  internal func offsetForward(
+    _ index: Index, by distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    assert(distance > 0)
+    assert(limit >= index)
+    
+    if index.outer == limit.outer {
+      if let indexInner = index.inner, let limitInner = limit.inner {
+        return base[index.outer]
+          .index(indexInner, offsetBy: distance, limitedBy: limitInner)
+          .map { inner in Index(outer: index.outer, inner: inner) }
+      } else {
+        // `index` and `limit` are both `endIndex`
+        return nil
+      }
+    }
+    
+    // `index <= limit` and `index.outer != limit.outer`, so `index != endIndex`
+    let indexInner = index.inner!
+    let element = base[index.outer]
+    
+    if let inner = element.index(
+        indexInner,
+        offsetBy: distance,
+        limitedBy: element.endIndex
+    ) {
+      return normalizeIndex(outer: index.outer, inner: inner)
+    }
+    
+    var remainder = distance - element[indexInner...].count
+    var outer = base.index(after: index.outer)
+    
+    while outer != limit.outer {
+      let element = base[outer]
+      
+      if let inner = element.index(
+          element.startIndex,
+          offsetBy: remainder,
+          limitedBy: element.endIndex
+      ) {
+        return normalizeIndex(outer: outer, inner: inner)
+      }
+      
+      remainder -= element.count
+      base.formIndex(after: &outer)
+    }
+    
+    if let limitInner = limit.inner {
+      let element = base[outer]
+      return element.index(
+        element.startIndex,
+        offsetBy: remainder,
+        limitedBy: limitInner)
+        .map { inner in Index(outer: outer, inner: inner) }
+    } else {
+      return nil
+    }
+  }
+  
+  @inlinable
+  internal func offsetBackward(
+    _ index: Index, by distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    assert(distance > 0)
+    assert(limit <= index)
+    
+    if index.outer == limit.outer {
+      if let indexInner = index.inner, let limitInner = limit.inner {
+        return base[index.outer]
+          .index(indexInner, offsetBy: -distance, limitedBy: limitInner)
+          .map { inner in Index(outer: index.outer, inner: inner) }
+      } else {
+        // `index` and `limit` are both `endIndex`
+        return nil
+      }
+    }
+    
+    var remainder = distance
+    
+    if let indexInner = index.inner {
+      let element = base[index.outer]
+      
+      if let inner = element.index(
+          indexInner,
+          offsetBy: -remainder,
+          limitedBy: element.startIndex
+      ) {
+        return Index(outer: index.outer, inner: inner)
+      }
+      
+      remainder -= element[..<indexInner].count
+    }
+    
+    var outer = base.index(index.outer, offsetBy: -1)
+    
+    while outer != limit.outer {
+      let element = base[outer]
+      
+      if let inner = element.index(
+          element.endIndex,
+          offsetBy: -remainder,
+          limitedBy: element.startIndex
+      ) {
+        return Index(outer: outer, inner: inner)
+      }
+      
+      remainder -= element.count
+      base.formIndex(&outer, offsetBy: -1)
+    }
+    
+    let element = base[outer]
+    return element.index(
+      element.endIndex,
+      offsetBy: -remainder,
+      limitedBy: limit.inner!
+    ).map { inner in Index(outer: outer, inner: inner) }
+  }
+}
+
+extension FlattenCollection: BidirectionalCollection
+  where Base: BidirectionalCollection, Base.Element: BidirectionalCollection
+{
+  @inlinable
+  internal func index(before index: Index) -> Index {
+    if let inner = index.inner {
+      let element = base[index.outer]
+      
+      if inner != element.startIndex {
+        let previousInner = element.index(before: inner)
+        return Index(outer: index.outer, inner: previousInner)
+      }
+    }
+    
+    let previousOuter = base[..<index.outer].lastIndex(where: { !$0.isEmpty })!
+    let element = base[previousOuter]
+    let previousInner = element.index(before: element.endIndex)
+    return Index(outer: previousOuter, inner: previousInner)
+  }
+}
+
+extension FlattenCollection: LazySequenceProtocol, LazyCollectionProtocol
+  where Base: LazySequenceProtocol, Base.Element: LazySequenceProtocol {}
+
+//===----------------------------------------------------------------------===//
+// joined()
+//===----------------------------------------------------------------------===//
+
+extension Collection where Element: Collection {
+  /// Returns the concatenation of the elements in this collection of
+  /// collections.
+  @inlinable
+  internal func joined() -> FlattenCollection<Self> {
+    FlattenCollection(base: self)
+  }
+}

--- a/grammars/testdata/swift_corpus/swift-algorithms_Stride.swift
+++ b/grammars/testdata/swift_corpus/swift-algorithms_Stride.swift
@@ -1,0 +1,283 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// striding(by:)
+//===----------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Returns a sequence stepping through the elements every `step` starting at
+  /// the first value. Any remainders of the stride will be trimmed.
+  ///
+  ///     (0...10).striding(by: 2) // == [0, 2, 4, 6, 8, 10]
+  ///     (0...10).striding(by: 3) // == [0, 3, 6, 9]
+  ///
+  /// - Complexity: O(1). Access to successive values is O(k) where _k_ is the
+  ///   striding `step`.
+  ///
+  /// - Parameter step: The amount to step with each iteration.
+  /// - Returns: Returns a sequence for stepping through the elements by the
+  ///   specified amount.
+  @inlinable
+  public func striding(by step: Int) -> StridingSequence<Self> {
+    StridingSequence(base: self, stride: step)
+  }
+}
+
+extension Collection {
+  /// Returns a sequence stepping through the elements every `step` starting at
+  /// the first value. Any remainders of the stride will be trimmed.
+  ///
+  ///     (0...10).striding(by: 2) // == [0, 2, 4, 6, 8, 10]
+  ///     (0...10).striding(by: 3) // == [0, 3, 6, 9]
+  ///
+  /// - Complexity: O(1). Access to successive values is O(1) if the collection
+  ///   conforms to `RandomAccessCollection`; otherwise, O(_k_), where _k_ is
+  ///   the striding `step`.
+  ///
+  /// - Parameter step: The amount to step with each iteration.
+  /// - Returns: Returns a collection for stepping through the elements by the
+  ///   specified amount.
+  @inlinable
+  public func striding(by step: Int) -> StridingCollection<Self> {
+    StridingCollection(base: self, stride: step)
+  }
+}
+
+/// A wrapper that strides over a base sequence.
+public struct StridingSequence<Base: Sequence> {
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let stride: Int
+  
+  @inlinable
+  internal init(base: Base, stride: Int) {
+    precondition(stride > 0, "Stride must be greater than zero")
+    self.base = base
+    self.stride = stride
+  }
+}
+
+extension StridingSequence {
+  @inlinable
+  public func striding(by step: Int) -> Self {
+    Self(base: base, stride: stride * step)
+  }
+}
+
+extension StridingSequence: Sequence {
+  /// An iterator over a `StridingSequence` instance.
+  public struct Iterator: IteratorProtocol {
+    @usableFromInline
+    internal var iterator: Base.Iterator
+    
+    @usableFromInline
+    internal let stride: Int
+    
+    @usableFromInline
+    internal var striding: Bool = false
+    
+    @inlinable
+    internal init(iterator: Base.Iterator, stride: Int) {
+      self.iterator = iterator
+      self.stride = stride
+    }
+    
+    @inlinable
+    public mutating func next() -> Base.Element? {
+      guard striding else {
+        striding = true
+        return iterator.next()
+      }
+      for _ in 0..<stride - 1 {
+        guard iterator.next() != nil else { break }
+      }
+      return iterator.next()
+    }
+  }
+  
+  @inlinable
+  public func makeIterator() -> Iterator {
+    Iterator(iterator: base.makeIterator(), stride: stride)
+  }
+}
+
+extension StridingSequence: LazySequenceProtocol
+  where Base: LazySequenceProtocol {}
+
+/// A wrapper that strides over a base collection.
+public struct StridingCollection<Base: Collection> {
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let stride: Int
+  
+  @inlinable
+  internal init(base: Base, stride: Int) {
+    precondition(stride > 0, "striding must be greater than zero")
+    self.base = base
+    self.stride = stride
+  }
+}
+
+extension StridingCollection {
+  @inlinable
+  public func striding(by step: Int) -> Self {
+    Self(base: base, stride: stride * step)
+  }
+}
+
+extension StridingCollection: Collection {
+  /// A position in a `StridingCollection` instance.
+  public struct Index: Comparable {
+    @usableFromInline
+    internal let base: Base.Index
+    
+    @usableFromInline
+    internal init(_ base: Base.Index) {
+      self.base = base
+    }
+    
+    @inlinable
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      lhs.base < rhs.base
+    }
+  }
+  
+  @inlinable
+  public var startIndex: Index {
+    Index(base.startIndex)
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(base.endIndex)
+  }
+  
+  @inlinable
+  public subscript(i: Index) -> Base.Element {
+    base[i.base]
+  }
+  
+  @inlinable
+  public func index(after i: Index) -> Index {
+    precondition(i.base != base.endIndex, "Advancing past end index")
+    return index(i, offsetBy: 1)
+  }
+  
+  @inlinable
+  public func index(
+    _ i: Index,
+    offsetBy n: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    guard n != 0 else { return i }
+    guard limit != i else { return nil }
+    
+    return n > 0
+      ? offsetForward(i, offsetBy: n, limitedBy: limit)
+      : offsetBackward(i, offsetBy: -n, limitedBy: limit)
+  }
+  
+  @inlinable
+  internal func offsetForward(
+    _ i: Index,
+    offsetBy n: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    if limit < i {
+      if let idx = base.index(
+        i.base,
+        offsetBy: n * stride,
+        limitedBy: base.endIndex
+      ) {
+        return Index(idx)
+      } else {
+        assert(distance(from: i, to: endIndex) == n, "Advancing past end index")
+        return endIndex
+      }
+    } else if let idx = base.index(
+      i.base,
+      offsetBy: n * stride,
+      limitedBy: limit.base
+    ) {
+      return Index(idx)
+    } else {
+      return distance(from: i, to: limit) == n
+        ? endIndex
+        : nil
+    }
+  }
+  
+  @inlinable
+  internal func offsetBackward(
+    _ i: Index,
+    offsetBy n: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    // We typically use the ternary operator but this significantly increases
+    // compile times when using Swift 5.3.2
+    // https://github.com/apple/swift-algorithms/issues/146
+    let distance: Int
+    if i == endIndex {
+      distance = -((base.count - 1) % stride + 1) + (n - 1) * -stride
+    } else {
+      distance = n * -stride
+    }
+    return base.index(
+        i.base,
+        offsetBy: distance,
+        limitedBy: limit.base
+    ).map(Index.init)
+  }
+  
+  @inlinable
+  public var count: Int {
+    base.isEmpty ? 0 : (base.count - 1) / stride + 1
+  }
+  
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    let distance = base.distance(from: start.base, to: end.base)
+    return distance / stride + (distance % stride).signum()
+  }
+  
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    precondition(distance <= 0 || i.base != base.endIndex, "Advancing past end index")
+    precondition(distance >= 0 || i.base != base.startIndex, "Incrementing past start index")
+    let limit = distance > 0 ? endIndex : startIndex
+    let idx = index(i, offsetBy: distance, limitedBy: limit)
+    precondition(idx != nil, "The distance \(distance) is not valid for this collection")
+    return idx!
+  }
+}
+
+extension StridingCollection: BidirectionalCollection
+  where Base: RandomAccessCollection {
+  
+  @inlinable
+  public func index(before i: Index) -> Index {
+    precondition(i.base != base.startIndex, "Incrementing past start index")
+    return index(i, offsetBy: -1)
+  }
+}
+
+extension StridingCollection: RandomAccessCollection
+  where Base: RandomAccessCollection {}
+
+extension StridingCollection: LazySequenceProtocol, LazyCollectionProtocol
+  where Base: LazySequenceProtocol {}
+
+extension StridingCollection.Index: Hashable where Base.Index: Hashable {}

--- a/grammars/testdata/swift_corpus/swift-algorithms_Windows.swift
+++ b/grammars/testdata/swift_corpus/swift-algorithms_Windows.swift
@@ -1,0 +1,360 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Algorithms open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// windows(ofCount:)
+//===----------------------------------------------------------------------===//
+
+extension Collection {
+  /// Returns a collection of all the overlapping slices of a given size.
+  ///
+  /// Use this method to iterate over overlapping subsequences of this
+  /// collection. This example prints every five character substring of `str`:
+  ///
+  ///     let str = "Hello, world!"
+  ///     for substring in str.windows(ofCount: 5) {
+  ///         print(substring)
+  ///     }
+  ///     // "Hello"
+  ///     // "ello,"
+  ///     // "llo, "
+  ///     // "lo, W"
+  ///     // ...
+  ///     // "orld!"
+  ///
+  /// - Parameter count: The number of elements in each window subsequence.
+  /// - Returns: A collection of subsequences of this collection, each with
+  ///   length `count`. If this collection is shorter than `count`, the
+  ///   resulting collection is empty.
+  ///
+  /// - Complexity: O(1) if the collection conforms to
+  ///   `RandomAccessCollection`, otherwise O(*k*) where `k` is `count`.
+  ///   Access to successive windows is O(1).
+  @inlinable
+  public func windows(ofCount count: Int) -> WindowsOfCountCollection<Self> {
+    WindowsOfCountCollection(base: self, windowSize: count)
+  }
+}
+
+/// A collection wrapper that presents a sliding window over the elements of
+/// a collection.
+public struct WindowsOfCountCollection<Base: Collection> {
+  @usableFromInline
+  internal let base: Base
+  
+  @usableFromInline
+  internal let windowSize: Int
+  
+  @usableFromInline
+  internal var endOfFirstWindow: Base.Index?
+
+  @inlinable
+  internal init(base: Base, windowSize: Int) {
+    precondition(windowSize > 0, "Windows size must be greater than zero")
+    self.base = base
+    self.windowSize = windowSize
+    self.endOfFirstWindow =
+      base.index(base.startIndex, offsetBy: windowSize, limitedBy: base.endIndex)
+  }
+}
+
+extension WindowsOfCountCollection: Collection {
+  /// A position in a `WindowsOfCountCollection` instance.
+  public struct Index: Comparable {
+    @usableFromInline
+    internal var lowerBound: Base.Index
+    
+    @usableFromInline
+    internal var upperBound: Base.Index
+    
+    @inlinable
+    internal init(lowerBound: Base.Index, upperBound: Base.Index) {
+      self.lowerBound = lowerBound
+      self.upperBound = upperBound
+    }
+    
+    @inlinable
+    public static func == (lhs: Index, rhs: Index) -> Bool {
+      lhs.lowerBound == rhs.lowerBound
+    }
+    
+    @inlinable
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      lhs.lowerBound < rhs.lowerBound
+    }
+  }
+  
+  @inlinable
+  public var startIndex: Index {
+    if let upperBound = endOfFirstWindow {
+      return Index(lowerBound: base.startIndex, upperBound: upperBound)
+    } else {
+      return endIndex
+    }
+  }
+  
+  @inlinable
+  public var endIndex: Index {
+    Index(lowerBound: base.endIndex, upperBound: base.endIndex)
+  }
+  
+  @inlinable
+  public subscript(index: Index) -> Base.SubSequence {
+    precondition(
+      index.lowerBound != index.upperBound,
+      "Windows index is out of range")
+    return base[index.lowerBound..<index.upperBound]
+  }
+  
+  @inlinable
+  public func index(after index: Index) -> Index {
+    precondition(index != endIndex, "Advancing past end index")
+    guard index.upperBound < base.endIndex else { return endIndex }
+    
+    let lowerBound = windowSize == 1
+      ? index.upperBound
+      : base.index(after: index.lowerBound)
+    let upperBound = base.index(after: index.upperBound)
+    return Index(lowerBound: lowerBound, upperBound: upperBound)
+  }
+  
+  @inlinable
+  public func index(_ i: Index, offsetBy distance: Int) -> Index {
+    guard distance != 0 else { return i }
+    
+    return distance > 0
+      ? offsetForward(i, by: distance)
+      : offsetBackward(i, by: -distance)
+  }
+  
+  @inlinable
+  public func index(
+    _ i: Index,
+    offsetBy distance: Int,
+    limitedBy limit: Index
+  ) -> Index? {
+    guard distance != 0 else { return i }
+    guard limit != i else { return nil }
+    
+    if distance > 0 {
+      return limit > i
+        ? offsetForward(i, by: distance, limitedBy: limit)
+        : offsetForward(i, by: distance)
+    } else {
+      return limit < i
+        ? offsetBackward(i, by: -distance, limitedBy: limit)
+        : offsetBackward(i, by: -distance)
+    }
+  }
+  
+  @inlinable
+  internal func offsetForward(_ i: Index, by distance: Int) -> Index {
+    guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
+  }
+  
+  @inlinable
+  internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
+    guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
+      else { fatalError("Index is out of bounds") }
+    return index
+  }
+  
+  @inlinable
+  internal func offsetForward(
+    _ i: Index, by distance: Int, limitedBy limit: Index
+  ) -> Index? {
+    assert(distance > 0)
+    assert(limit > i)
+    
+    // `endIndex` and the index before it both have `base.endIndex` as their
+    // upper bound, so we first advance to the base index _before_ the upper
+    // bound of the output, in order to avoid advancing past the end of `base`
+    // when advancing to `endIndex`.
+    //
+    // Advancing by 4:
+    //
+    //  input: [x|x x x x x|x x x x]        [x x|x x x x x|x x x]
+    //                     |> > >|>|   or                 |> > >|
+    // output: [x x x x x|x x x x x]        [x x x x x x x x x x]  (`endIndex`)
+    
+    if distance >= windowSize {
+      // Avoid traversing `self[i.lowerBound..<i.upperBound]` when the lower
+      // bound of the output is greater than or equal to the upper bound of the
+      // input.
+      
+      //  input: [x|x x x x|x x x x x x x]
+      //                   |> >|> > >|>|
+      // output: [x x x x x x x|x x x x|x]
+      
+      guard limit.lowerBound >= i.upperBound,
+            let lowerBound = base.index(
+              i.upperBound,
+              offsetBy: distance - windowSize,
+              limitedBy: limit.lowerBound),
+            let indexBeforeUpperBound = base.index(
+              lowerBound,
+              offsetBy: windowSize - 1,
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      // If `indexBeforeUpperBound` equals `base.endIndex`, we're advancing to
+      // `endIndex`.
+      guard indexBeforeUpperBound != base.endIndex else { return endIndex }
+      
+      return Index(
+        lowerBound: lowerBound,
+        upperBound: base.index(after: indexBeforeUpperBound))
+    } else {
+      //  input: [x|x x x x x x|x x x x x]
+      //           |> > > >|   |> > >|>|
+      // output: [x x x x x|x x x x x x|x]
+      
+      guard let indexBeforeUpperBound = base.index(
+              i.upperBound,
+              offsetBy: distance - 1,
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      // If `indexBeforeUpperBound` equals the limit, the upper bound itself
+      // exceeds it.
+      guard indexBeforeUpperBound != limit.upperBound || limit == endIndex
+        else { return nil }
+      
+      // If `indexBeforeUpperBound` equals `base.endIndex`, we're advancing to
+      // `endIndex`.
+      guard indexBeforeUpperBound != base.endIndex else { return endIndex }
+      
+      return Index(
+        lowerBound: base.index(i.lowerBound, offsetBy: distance),
+        upperBound: base.index(after: indexBeforeUpperBound))
+    }
+  }
+  
+  @inlinable
+  internal func offsetBackward(
+      _ i: Index, by distance: Int, limitedBy limit: Index
+    ) -> Index? {
+    assert(distance > 0)
+    assert(limit < i)
+    
+    if i == endIndex {
+      // Advance `base.endIndex` by `distance - 1`, because the index before
+      // `endIndex` also has `base.endIndex` as its upper bound.
+      //
+      // Advancing by 4:
+      //
+      //  input: [x x x x x x x x x x]  (`endIndex`)
+      //             |< < < < <|< < <|
+      // output: [x x|x x x x x|x x x]
+      
+      guard let upperBound = base.index(
+              base.endIndex,
+              offsetBy: -(distance - 1),
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      return Index(
+        lowerBound: base.index(upperBound, offsetBy: -windowSize),
+        upperBound: upperBound)
+    } else if distance >= windowSize {
+      // Avoid traversing `self[i.lowerBound..<i.upperBound]` when the upper
+      // bound of the output is less than or equal to the lower bound of the
+      // input.
+      //
+      //  input: [x x x x x x x|x x x x|x]
+      //           |< < < <|< <|
+      // output: [x|x x x x|x x x x x x x]
+      
+      guard limit.upperBound <= i.lowerBound,
+            let upperBound = base.index(
+              i.lowerBound,
+              offsetBy: -(distance - windowSize),
+              limitedBy: limit.upperBound)
+      else { return nil }
+      
+      return Index(
+        lowerBound: base.index(upperBound, offsetBy: -windowSize),
+        upperBound: upperBound)
+    } else {
+      //  input: [x x x x x|x x x x x x|x]
+      //           |< < < <|   |< < < <|
+      // output: [x|x x x x x x|x x x x x]
+      
+      guard let lowerBound = base.index(
+              i.lowerBound,
+              offsetBy: -distance,
+              limitedBy: limit.lowerBound)
+      else { return nil }
+      
+      return Index(
+        lowerBound: lowerBound,
+        upperBound: base.index(i.lowerBound, offsetBy: -distance))
+    }
+  }
+  
+  @inlinable
+  public func distance(from start: Index, to end: Index) -> Int {
+    guard start <= end else { return -distance(from: end, to: start) }
+    guard start != end else { return 0 }
+    guard end != endIndex else {
+      // We add 1 here because the index before `endIndex` also has
+      // `base.endIndex` as its upper bound.
+      return base[start.upperBound...].count + 1
+    }
+
+    if start.upperBound <= end.lowerBound {
+      // The distance between `start.lowerBound` and `start.upperBound` is
+      // already known.
+      //
+      // start: [x|x x x x|x x x x x x x]
+      //          |- - - -|> >|
+      //   end: [x x x x x x x|x x x x|x]
+      
+      return windowSize + base[start.upperBound..<end.lowerBound].count
+    } else {
+      // start: [x|x x x x x x|x x x x x]
+      //          |> > > >|
+      //   end: [x x x x x|x x x x x x|x]
+      
+      return base[start.lowerBound..<end.lowerBound].count
+    }
+  }
+}
+
+extension WindowsOfCountCollection: BidirectionalCollection
+  where Base: BidirectionalCollection
+{
+  @inlinable
+  public func index(before index: Index) -> Index {
+    precondition(index != startIndex, "Incrementing past start index")
+    if index == endIndex {
+      return Index(
+        lowerBound: base.index(index.lowerBound, offsetBy: -windowSize),
+        upperBound: index.upperBound
+      )
+    } else {
+      return Index(
+        lowerBound: base.index(before: index.lowerBound),
+        upperBound: base.index(before: index.upperBound)
+      )
+    }
+  }
+}
+
+extension WindowsOfCountCollection: RandomAccessCollection
+  where Base: RandomAccessCollection {}
+
+extension WindowsOfCountCollection: LazySequenceProtocol, LazyCollectionProtocol
+  where Base: LazySequenceProtocol {}
+
+extension WindowsOfCountCollection.Index: Hashable where Base.Index: Hashable {}


### PR DESCRIPTION
## Summary

Add a regression test suite that parses real-world Swift standard library and algorithm files against the gotreesitter Swift grammar. The test tracks known failures linked to open issues and uses a ratchet pattern to prompt updates when previously failing files parse cleanly.

## Changes

- Add `grammars/swift_corpus_test.go` with `TestSwiftCorpus` and `TestSwiftCorpusManifestComplete`.
- Add 12 Swift source files to `grammars/testdata/swift_corpus/` from pinned upstream `swiftlang/swift` and `apple/swift-algorithms` releases.
- Define a ratchet expectations table mapping each corpus file to a `clean` or `known_failing` status and an associated issue or failure description.
- Enforce manifest completeness to ensure every corpus file has an expectation row and no stale rows reference missing files.
- Document corpus sources, pin versions, fetch method, and validation script results in `MANIFEST.md`.

## Testing

- go test ./grammars -run '^TestSwiftCorpus$|^TestSwiftCorpusManifestComplete$' -v