### PR TITLE
cgo_harness: Gate compact T3 witnesses against the C oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,7 @@ jobs:
       - parity_report
       - perf_scan_budget
       - exhaustive_parity_scope
+      - compact-t3-oracle-cgo
       - parity-cgo-exhaustive
     if: always()
     runs-on: ubuntu-latest
@@ -505,6 +506,7 @@ jobs:
           PERF_SCAN_BUDGET_RESULT: ${{ needs.perf_scan_budget.result }}
           EXHAUSTIVE_PARITY_SCOPE_RESULT: ${{ needs.exhaustive_parity_scope.result }}
           EXHAUSTIVE_PARITY_SCOPE: ${{ needs.exhaustive_parity_scope.outputs.run_exhaustive }}
+          COMPACT_T3_ORACLE_CGO_RESULT: ${{ needs.compact-t3-oracle-cgo.result }}
           EXHAUSTIVE_PARITY_RESULT: ${{ needs.parity-cgo-exhaustive.result }}
         run: |
           set -euo pipefail
@@ -539,6 +541,7 @@ jobs:
           require_success "compact_admission_ratchet" "$COMPACT_ADMISSION_RATCHET_RESULT"
           require_success "parity_report" "$PARITY_REPORT_RESULT"
           require_success "perf_scan_budget" "$PERF_SCAN_BUDGET_RESULT"
+          require_success "compact-t3-oracle-cgo" "$COMPACT_T3_ORACLE_CGO_RESULT"
 
           if [ "$IS_DRAFT" = "true" ]; then
             require_success "draft_focused_tests" "$DRAFT_FOCUSED_RESULT"
@@ -688,6 +691,34 @@ jobs:
             echo "::error::Count mismatch — lock: $lock_count, blobs: $blob_count, gen: $gen_count"
             exit 1
           fi
+
+  compact-t3-oracle-cgo:
+    needs: exhaustive_parity_scope
+    if: needs.exhaustive_parity_scope.outputs.run_code_ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Compact T3 C-oracle witness contract
+        run: |
+          GTS_PARITY_MODE=smoke \
+          GTS_PARITY_C_REF_BUILD_CACHE=0 \
+          bash cgo_harness/docker/run_parity_in_docker.sh \
+            --label ci-compact-t3-oracle \
+            --memory 8g \
+            --cpus 2 \
+            --pids 4096 \
+            --gomemlimit 6GiB \
+            --goflags -p=1 \
+            --test-parallel 1 \
+            --c-ref-build-jobs 1 \
+            --timeout 20m \
+            --run '^TestCompactT3OracleAdjudication$'
 
   parity-cgo:
     needs: exhaustive_parity_scope

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -1,0 +1,187 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+// Tranche T3: C-oracle adjudication of the compact-vs-production route
+// divergence witnesses collected by the differential fuzz harness (98
+// witnesses: html 88, javascript 8, swift 2). Every witness in this fixture
+// showed prodHasError=true, compactHasError=false in the fuzz logs.
+//
+// This suite parses each witness with the locked C oracle (upstream
+// tree-sitter runtime f5afe475deb7c0bae6407fb776c76824f717bb61, grammar
+// commits from grammars/languages.lock, -O2 shared object via dlopen; see
+// COracleBuildIdentity in parity_c_loader_cgo.go) and adjudicates which Go
+// route matches it.
+//
+// The suite asserts production's HasError matches the C oracle's HasError:
+// that boolean is the exact signal the fuzz harness used to collect these
+// witnesses (prodHasError=true, compactHasError=false), so it is the
+// load-bearing adjudication claim. A HasError divergence here is a
+// production bug, not a compact-route issue, and fails this test loudly.
+//
+// The suite only logs (never asserts) full node-by-node structural parity
+// and the compact route's outcome. Full structural parity between
+// gotreesitter's and the C runtime's error-recovery trees is a documented,
+// currently-passing invariant only for clean/well-formed input (see
+// TestParityFreshParse and TestParityHasNoErrors on the smoke corpus); it is
+// not an established invariant for malformed-input recovery paths, and this
+// suite's own run against these witnesses shows production's recovered tree
+// shape diverging from the C oracle's on essentially every witness even
+// though the HasError flag agrees. That shape divergence is a distinct,
+// secondary finding from the has_error adjudication and is logged, not
+// asserted, here. Fixing the compact admission route's false-clean
+// acceptance is a separate workstream from this adjudication.
+//
+// Run with:
+//   go test . -tags treesitter_c_parity -run '^TestCompactT3OracleAdjudication$' -v
+
+import (
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type compactT3Witness struct {
+	id     string
+	class  string
+	lang   string
+	load   func() *gotreesitter.Language
+	source string
+}
+
+var compactT3Witnesses = []compactT3Witness{
+	// HTML erroneous_end_tag class. The first two are the reported minimal
+	// reductions; the rest are drawn directly from the fuzz logs
+	// (hemlock-fuzz-main.txt / hemlock-fuzz-main2.txt).
+	{id: "html_min_a", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<a></a^>"},
+	{id: "html_min_html", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html></html^>"},
+	{id: "html_log_1", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html>/<body>Hello</body^></html>\n"},
+	{id: "html_log_2", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><bod\">Hello</body></html>\n"},
+	{id: "html_log_3", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>Hello</bo^y>:</html>\n"},
+	{id: "html_log_4", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>H}llo</boy></h!tml>\n"},
+	{id: "html_log_5", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>Hello /bod></html>\n"},
+	{id: "html_log_6", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>Hell</body>y></html>\n"},
+	{id: "html_log_7", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><bodyHello</body></html>\n"},
+	{id: "html_log_8", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html> body>Hello</body></html>\n"},
+
+	// JavaScript arrow-parameter recovery class: all 8 logged witnesses.
+	{id: "js_log_1", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f() { return 1; }\nconst x = ()? => x + 1;\n"},
+	{id: "js_log_2", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f()^{ return 1; }\nconstx = () => x + 1;\n"},
+	{id: "js_log_3", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) => a + 1;\nclass  A { m() { return 1 } )}\n"},
+	{id: "js_log_4", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f()&{ return 1; }\nconst x = () => x + 1;\n"},
+	{id: "js_log_5", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) =. + + 1;\nclass A { m() { return 1 } }\n\n"},
+	{id: "js_log_6", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n"},
+	{id: "js_log_7", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) => a + 1;\nclass A ?{ m() { return 1 } }\n"},
+	{id: "js_log_8", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f() { return 1; ^}\ncon\nconst x = () => x + 1;\n"},
+
+	// Swift bitwise-shift-vs-comparison class: both logged witnesses.
+	{id: "swift_log_1", class: "swift_shift_comparison", lang: "swift", load: grammars.SwiftLanguage, source: "let v = x >> y>>"},
+	{id: "swift_log_2", class: "swift_shift_comparison", lang: "swift", load: grammars.SwiftLanguage, source: "letv = x >> \n"},
+}
+
+// TestCompactT3OracleAdjudicationProvenance records the exact C-oracle build
+// identity (runtime commit, grammar commit, compile flags, artifact hash) for
+// every language this adjudication touches.
+func TestCompactT3OracleAdjudicationProvenance(t *testing.T) {
+	for _, lang := range []string{"html", "javascript", "swift"} {
+		lang := lang
+		t.Run(lang, func(t *testing.T) {
+			id, err := COracleIdentity(lang)
+			if err != nil {
+				t.Fatalf("%s: C oracle identity unavailable: %v", lang, err)
+			}
+			t.Logf("contract=%s runtime_commit=%s grammar_repo=%s grammar_commit=%s flags=%s compiler=%s (%s) artifact=%s sha256=%s",
+				id.Contract, id.RuntimeCommit, id.GrammarRepo, id.GrammarCommit, id.GrammarCompileFlags,
+				id.CompilerPath, id.CompilerVersion, id.GrammarArtifactPath, id.GrammarArtifactSHA256)
+		})
+	}
+}
+
+// TestCompactT3OracleAdjudication adjudicates each route-divergence witness
+// class against the locked C oracle. See package doc comment above.
+func TestCompactT3OracleAdjudication(t *testing.T) {
+	for _, w := range compactT3Witnesses {
+		w := w
+		t.Run(w.class+"/"+w.id, func(t *testing.T) {
+			src := []byte(w.source)
+
+			cLang, err := ParityCLanguage(w.lang)
+			if err != nil {
+				t.Fatalf("%s: C oracle unavailable: %v", w.lang, err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatalf("C SetLanguage: %v", err)
+			}
+			cTree := cParser.Parse(src, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("C oracle parse returned no root")
+			}
+			defer cTree.Close()
+			cHasError := cTree.RootNode().HasError()
+
+			lang := w.load()
+
+			production := gotreesitter.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(src)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+			prodHasError := productionTree.RootNode().HasError()
+
+			candidate := gotreesitter.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(src)
+			if err != nil {
+				t.Fatalf("compact parse: %v", err)
+			}
+			defer candidateTree.Release()
+			compHasError := candidateTree.RootNode().HasError()
+
+			t.Logf("src=%q", w.source)
+			t.Logf("C oracle:   HasError=%v sexpr=%s", cHasError, cTree.RootNode().ToSexp())
+			t.Logf("production: HasError=%v sexpr=%s", prodHasError, productionTree.RootNode().SExpr(lang))
+			t.Logf("compact:    HasError=%v sexpr=%s", compHasError, candidateTree.RootNode().SExpr(lang))
+
+			// The adjudication itself: production's HasError must match the C
+			// oracle's HasError -- the exact boolean the fuzz harness used to
+			// collect this witness. Any failure here is a PRODUCTION bug,
+			// distinct from the known compact admission gap this fixture
+			// documents.
+			if prodHasError != cHasError {
+				t.Fatalf("PRODUCTION-VS-C HAS-ERROR DIVERGENCE (production bug, not compact): production HasError=%v, C oracle HasError=%v", prodHasError, cHasError)
+			}
+
+			// Documentary only: full node-by-node structural parity is a
+			// currently-passing invariant for clean input (see
+			// TestParityFreshParse on the smoke corpus) but is not established
+			// for malformed-input error-recovery paths. Log the shape
+			// divergence for evidence without failing the fixture on it.
+			var structuralErrs []string
+			compareNodes(productionTree.RootNode(), lang, cTree.RootNode(), "root", &structuralErrs)
+			if len(structuralErrs) > 0 {
+				shown := structuralErrs
+				if len(shown) > 5 {
+					shown = shown[:5]
+				}
+				t.Logf("structural shape divergence from C oracle (%d node-level diffs, informational only):\n%s", len(structuralErrs), strings.Join(shown, "\n"))
+			}
+
+			// Documentary only: record whether the compact route's known
+			// false-clean acceptance is still present. Fixing it is a separate
+			// workstream, so this fixture never fails on it.
+			if compHasError == cHasError {
+				t.Logf("NOTE: compact route now agrees with the C oracle for this witness (regression check: confirm the compact-route fix landed)")
+			} else {
+				t.Logf("KNOWN COMPACT DIVERGENCE (tracked, not asserted here): compact HasError=%v, C oracle HasError=%v", compHasError, cHasError)
+			}
+		})
+	}
+}

--- a/cgo_harness/compact_t3_oracle_adjudication_test.go
+++ b/cgo_harness/compact_t3_oracle_adjudication_test.go
@@ -2,42 +2,18 @@
 
 package cgoharness
 
-// Tranche T3: C-oracle adjudication of the compact-vs-production route
-// divergence witnesses collected by the differential fuzz harness (98
-// witnesses: html 88, javascript 8, swift 2). Every witness in this fixture
-// showed prodHasError=true, compactHasError=false in the fuzz logs.
-//
-// This suite parses each witness with the locked C oracle (upstream
-// tree-sitter runtime f5afe475deb7c0bae6407fb776c76824f717bb61, grammar
-// commits from grammars/languages.lock, -O2 shared object via dlopen; see
-// COracleBuildIdentity in parity_c_loader_cgo.go) and adjudicates which Go
-// route matches it.
-//
-// The suite asserts production's HasError matches the C oracle's HasError:
-// that boolean is the exact signal the fuzz harness used to collect these
-// witnesses (prodHasError=true, compactHasError=false), so it is the
-// load-bearing adjudication claim. A HasError divergence here is a
-// production bug, not a compact-route issue, and fails this test loudly.
-//
-// The suite only logs (never asserts) full node-by-node structural parity
-// and the compact route's outcome. Full structural parity between
-// gotreesitter's and the C runtime's error-recovery trees is a documented,
-// currently-passing invariant only for clean/well-formed input (see
-// TestParityFreshParse and TestParityHasNoErrors on the smoke corpus); it is
-// not an established invariant for malformed-input recovery paths, and this
-// suite's own run against these witnesses shows production's recovered tree
-// shape diverging from the C oracle's on essentially every witness even
-// though the HasError flag agrees. That shape divergence is a distinct,
-// secondary finding from the has_error adjudication and is logged, not
-// asserted, here. Fixing the compact admission route's false-clean
-// acceptance is a separate workstream from this adjudication.
-//
-// Run with:
-//   go test . -tags treesitter_c_parity -run '^TestCompactT3OracleAdjudication$' -v
-
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
 
@@ -45,143 +21,348 @@ import (
 	"github.com/odvcencio/gotreesitter/grammars"
 )
 
+const (
+	compactT3WitnessManifestPath    = "testdata/compact_t3_oracle_witnesses_v1.json"
+	compactT3WitnessManifestSchema  = "compact-t3-c-oracle-witnesses-v1"
+	compactT3WitnessManifestVersion = 1
+	compactT3WitnessParityScope     = "has_error_only"
+	compactT3WitnessTrackingIssue   = "https://github.com/odvcencio/gotreesitter/issues/587"
+	compactT3WitnessCount           = 20
+)
+
+var compactT3WitnessLanguageCounts = map[string]int{
+	"html":       10,
+	"javascript": 8,
+	"swift":      2,
+}
+
+type compactT3WitnessManifest struct {
+	Schema         string             `json:"schema"`
+	Version        int                `json:"version"`
+	ParityScope    string             `json:"parity_scope"`
+	TrackingIssue  string             `json:"tracking_issue"`
+	WitnessCount   int                `json:"witness_count"`
+	LanguageCounts map[string]int     `json:"language_counts"`
+	Witnesses      []compactT3Witness `json:"witnesses"`
+}
+
 type compactT3Witness struct {
-	id     string
-	class  string
-	lang   string
-	load   func() *gotreesitter.Language
-	source string
+	ID               string                     `json:"id"`
+	Language         string                     `json:"language"`
+	FailureClass     string                     `json:"failure_class"`
+	SourceProvenance compactT3SourceProvenance  `json:"source_provenance"`
+	SourceUTF8       string                     `json:"source_utf8"`
+	SourceSHA256     string                     `json:"source_sha256"`
+	COracle          compactT3COracleProvenance `json:"c_oracle"`
+	Expected         compactT3ExpectedOutcome   `json:"expected"`
 }
 
-var compactT3Witnesses = []compactT3Witness{
-	// HTML erroneous_end_tag class. The first two are the reported minimal
-	// reductions; the rest are drawn directly from the fuzz logs
-	// (hemlock-fuzz-main.txt / hemlock-fuzz-main2.txt).
-	{id: "html_min_a", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<a></a^>"},
-	{id: "html_min_html", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html></html^>"},
-	{id: "html_log_1", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html>/<body>Hello</body^></html>\n"},
-	{id: "html_log_2", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><bod\">Hello</body></html>\n"},
-	{id: "html_log_3", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>Hello</bo^y>:</html>\n"},
-	{id: "html_log_4", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>H}llo</boy></h!tml>\n"},
-	{id: "html_log_5", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>Hello /bod></html>\n"},
-	{id: "html_log_6", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><body>Hell</body>y></html>\n"},
-	{id: "html_log_7", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html><bodyHello</body></html>\n"},
-	{id: "html_log_8", class: "html_erroneous_end_tag", lang: "html", load: grammars.HtmlLanguage, source: "<html> body>Hello</body></html>\n"},
-
-	// JavaScript arrow-parameter recovery class: all 8 logged witnesses.
-	{id: "js_log_1", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f() { return 1; }\nconst x = ()? => x + 1;\n"},
-	{id: "js_log_2", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f()^{ return 1; }\nconstx = () => x + 1;\n"},
-	{id: "js_log_3", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) => a + 1;\nclass  A { m() { return 1 } )}\n"},
-	{id: "js_log_4", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f()&{ return 1; }\nconst x = () => x + 1;\n"},
-	{id: "js_log_5", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) =. + + 1;\nclass A { m() { return 1 } }\n\n"},
-	{id: "js_log_6", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n"},
-	{id: "js_log_7", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "const f = (a) => a + 1;\nclass A ?{ m() { return 1 } }\n"},
-	{id: "js_log_8", class: "js_arrow_param_recovery", lang: "javascript", load: grammars.JavascriptLanguage, source: "function f() { return 1; ^}\ncon\nconst x = () => x + 1;\n"},
-
-	// Swift bitwise-shift-vs-comparison class: both logged witnesses.
-	{id: "swift_log_1", class: "swift_shift_comparison", lang: "swift", load: grammars.SwiftLanguage, source: "let v = x >> y>>"},
-	{id: "swift_log_2", class: "swift_shift_comparison", lang: "swift", load: grammars.SwiftLanguage, source: "letv = x >> \n"},
+type compactT3SourceProvenance struct {
+	Origin string `json:"origin"`
+	Record string `json:"record"`
 }
 
-// TestCompactT3OracleAdjudicationProvenance records the exact C-oracle build
-// identity (runtime commit, grammar commit, compile flags, artifact hash) for
-// every language this adjudication touches.
-func TestCompactT3OracleAdjudicationProvenance(t *testing.T) {
-	for _, lang := range []string{"html", "javascript", "swift"} {
-		lang := lang
-		t.Run(lang, func(t *testing.T) {
-			id, err := COracleIdentity(lang)
+type compactT3COracleProvenance struct {
+	Contract              string `json:"contract"`
+	BindingCommit         string `json:"binding_commit"`
+	RuntimeCommit         string `json:"runtime_commit"`
+	GrammarRepository     string `json:"grammar_repository"`
+	GrammarCommit         string `json:"grammar_commit"`
+	CompilerPath          string `json:"compiler_path"`
+	CompilerVersion       string `json:"compiler_version"`
+	GrammarCompileFlags   string `json:"grammar_compile_flags"`
+	GrammarArtifactSHA256 string `json:"grammar_artifact_sha256"`
+}
+
+type compactT3ExpectedOutcome struct {
+	CHasError          *bool `json:"c_has_error"`
+	ProductionHasError *bool `json:"production_has_error"`
+	CompactHasError    *bool `json:"compact_has_error"`
+}
+
+// TestCompactT3OracleAdjudication verifies each committed false-clean witness.
+// It compares only HasError. It does not assert recovery-tree structure.
+func TestCompactT3OracleAdjudication(t *testing.T) {
+	manifest := loadCompactT3WitnessManifest(t)
+	for _, language := range compactT3WitnessLanguages(manifest) {
+		language := language
+		t.Run(language, func(t *testing.T) {
+			cLanguage, err := ParityCLanguage(language)
 			if err != nil {
-				t.Fatalf("%s: C oracle identity unavailable: %v", lang, err)
+				t.Fatalf("load C oracle: %v", err)
 			}
-			t.Logf("contract=%s runtime_commit=%s grammar_repo=%s grammar_commit=%s flags=%s compiler=%s (%s) artifact=%s sha256=%s",
-				id.Contract, id.RuntimeCommit, id.GrammarRepo, id.GrammarCommit, id.GrammarCompileFlags,
-				id.CompilerPath, id.CompilerVersion, id.GrammarArtifactPath, id.GrammarArtifactSHA256)
+			identity, err := COracleIdentity(language)
+			if err != nil {
+				t.Fatalf("read C oracle identity: %v", err)
+			}
+			goLanguage, ok := compactT3GoLanguage(language)
+			if !ok {
+				t.Fatalf("manifest uses unsupported language %q", language)
+			}
+
+			for _, witness := range compactT3WitnessesForLanguage(manifest, language) {
+				witness := witness
+				t.Run(witness.FailureClass+"/"+witness.ID, func(t *testing.T) {
+					assertCompactT3COracleProvenance(t, witness, identity)
+					source := []byte(witness.SourceUTF8)
+					cHasError := compactT3CHasError(t, cLanguage, source)
+					productionHasError := compactT3GoHasError(t, goLanguage, source, false)
+					compactHasError := compactT3GoHasError(t, goLanguage, source, true)
+
+					assertCompactT3Outcome(t, witness, "C oracle", witness.Expected.CHasError, cHasError)
+					assertCompactT3Outcome(t, witness, "production", witness.Expected.ProductionHasError, productionHasError)
+					assertCompactT3Outcome(t, witness, "compact", witness.Expected.CompactHasError, compactHasError)
+				})
+			}
 		})
 	}
 }
 
-// TestCompactT3OracleAdjudication adjudicates each route-divergence witness
-// class against the locked C oracle. See package doc comment above.
-func TestCompactT3OracleAdjudication(t *testing.T) {
-	for _, w := range compactT3Witnesses {
-		w := w
-		t.Run(w.class+"/"+w.id, func(t *testing.T) {
-			src := []byte(w.source)
+func loadCompactT3WitnessManifest(t *testing.T) compactT3WitnessManifest {
+	t.Helper()
+	raw, err := os.ReadFile(compactT3WitnessManifestPath)
+	if err != nil {
+		t.Fatalf("read witness manifest: %v", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var manifest compactT3WitnessManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatalf("decode witness manifest: %v", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("decode trailing witness manifest content: %v", err)
+	}
+	if err := validateCompactT3WitnessManifest(manifest); err != nil {
+		t.Fatalf("validate witness manifest: %v", err)
+	}
+	return manifest
+}
 
-			cLang, err := ParityCLanguage(w.lang)
-			if err != nil {
-				t.Fatalf("%s: C oracle unavailable: %v", w.lang, err)
-			}
-			cParser := sitter.NewParser()
-			defer cParser.Close()
-			if err := cParser.SetLanguage(cLang); err != nil {
-				t.Fatalf("C SetLanguage: %v", err)
-			}
-			cTree := cParser.Parse(src, nil)
-			if cTree == nil || cTree.RootNode() == nil {
-				t.Fatal("C oracle parse returned no root")
-			}
-			defer cTree.Close()
-			cHasError := cTree.RootNode().HasError()
+func validateCompactT3WitnessManifest(manifest compactT3WitnessManifest) error {
+	if manifest.Schema != compactT3WitnessManifestSchema {
+		return fmt.Errorf("schema=%q, want %q", manifest.Schema, compactT3WitnessManifestSchema)
+	}
+	if manifest.Version != compactT3WitnessManifestVersion {
+		return fmt.Errorf("version=%d, want %d", manifest.Version, compactT3WitnessManifestVersion)
+	}
+	if manifest.ParityScope != compactT3WitnessParityScope {
+		return fmt.Errorf("parity_scope=%q, want %q", manifest.ParityScope, compactT3WitnessParityScope)
+	}
+	if manifest.TrackingIssue != compactT3WitnessTrackingIssue {
+		return fmt.Errorf("tracking_issue=%q, want %q", manifest.TrackingIssue, compactT3WitnessTrackingIssue)
+	}
+	if manifest.WitnessCount != compactT3WitnessCount {
+		return fmt.Errorf("witness_count=%d, want %d", manifest.WitnessCount, compactT3WitnessCount)
+	}
+	if len(manifest.Witnesses) != compactT3WitnessCount {
+		return fmt.Errorf("decoded witness count=%d, want %d", len(manifest.Witnesses), compactT3WitnessCount)
+	}
+	if err := validateCompactT3LanguageCounts(manifest.LanguageCounts); err != nil {
+		return err
+	}
 
-			lang := w.load()
+	seenIDs := make(map[string]struct{}, len(manifest.Witnesses))
+	actualLanguageCounts := make(map[string]int, len(compactT3WitnessLanguageCounts))
+	for _, witness := range manifest.Witnesses {
+		if strings.TrimSpace(witness.ID) == "" {
+			return errorsForCompactT3Witness(witness, "id is empty")
+		}
+		if _, exists := seenIDs[witness.ID]; exists {
+			return errorsForCompactT3Witness(witness, "id is duplicated")
+		}
+		seenIDs[witness.ID] = struct{}{}
+		if _, ok := compactT3WitnessLanguageCounts[witness.Language]; !ok {
+			return errorsForCompactT3Witness(witness, "language is not in the exact witness set")
+		}
+		actualLanguageCounts[witness.Language]++
+		if strings.TrimSpace(witness.FailureClass) == "" {
+			return errorsForCompactT3Witness(witness, "failure_class is empty")
+		}
+		if strings.TrimSpace(witness.SourceProvenance.Origin) == "" || strings.TrimSpace(witness.SourceProvenance.Record) == "" {
+			return errorsForCompactT3Witness(witness, "source_provenance is incomplete")
+		}
+		if witness.SourceUTF8 == "" || !utf8.ValidString(witness.SourceUTF8) {
+			return errorsForCompactT3Witness(witness, "source_utf8 is empty or invalid")
+		}
+		if err := validateCompactT3SourceDigest(witness); err != nil {
+			return err
+		}
+		if err := validateCompactT3ExpectedOutcome(witness); err != nil {
+			return err
+		}
+		if err := validateCompactT3COracleProvenance(witness.COracle); err != nil {
+			return errorsForCompactT3Witness(witness, err.Error())
+		}
+	}
+	if err := validateCompactT3LanguageCounts(actualLanguageCounts); err != nil {
+		return fmt.Errorf("actual %w", err)
+	}
+	return nil
+}
 
-			production := gotreesitter.NewParser(lang)
-			production.SetAdmissionCandidateRoute(false)
-			productionTree, err := production.Parse(src)
-			if err != nil {
-				t.Fatalf("production parse: %v", err)
-			}
-			defer productionTree.Release()
-			prodHasError := productionTree.RootNode().HasError()
+func validateCompactT3LanguageCounts(counts map[string]int) error {
+	if len(counts) != len(compactT3WitnessLanguageCounts) {
+		return fmt.Errorf("language count entries=%d, want %d", len(counts), len(compactT3WitnessLanguageCounts))
+	}
+	for language, want := range compactT3WitnessLanguageCounts {
+		if got := counts[language]; got != want {
+			return fmt.Errorf("language=%q count=%d, want %d", language, got, want)
+		}
+	}
+	return nil
+}
 
-			candidate := gotreesitter.NewParser(lang)
-			candidate.SetAdmissionCandidateRoute(true)
-			candidateTree, err := candidate.Parse(src)
-			if err != nil {
-				t.Fatalf("compact parse: %v", err)
-			}
-			defer candidateTree.Release()
-			compHasError := candidateTree.RootNode().HasError()
+func validateCompactT3SourceDigest(witness compactT3Witness) error {
+	if len(witness.SourceSHA256) != sha256.Size*2 {
+		return errorsForCompactT3Witness(witness, "source_sha256 has an invalid length")
+	}
+	if _, err := hex.DecodeString(witness.SourceSHA256); err != nil {
+		return errorsForCompactT3Witness(witness, "source_sha256 is not hexadecimal")
+	}
+	sum := sha256.Sum256([]byte(witness.SourceUTF8))
+	if got := hex.EncodeToString(sum[:]); got != witness.SourceSHA256 {
+		return errorsForCompactT3Witness(witness, fmt.Sprintf("source_sha256=%s, want %s", witness.SourceSHA256, got))
+	}
+	return nil
+}
 
-			t.Logf("src=%q", w.source)
-			t.Logf("C oracle:   HasError=%v sexpr=%s", cHasError, cTree.RootNode().ToSexp())
-			t.Logf("production: HasError=%v sexpr=%s", prodHasError, productionTree.RootNode().SExpr(lang))
-			t.Logf("compact:    HasError=%v sexpr=%s", compHasError, candidateTree.RootNode().SExpr(lang))
+func validateCompactT3ExpectedOutcome(witness compactT3Witness) error {
+	if witness.Expected.CHasError == nil {
+		return errorsForCompactT3Witness(witness, "expected.c_has_error is absent")
+	}
+	if witness.Expected.ProductionHasError == nil {
+		return errorsForCompactT3Witness(witness, "expected.production_has_error is absent")
+	}
+	if witness.Expected.CompactHasError == nil {
+		return errorsForCompactT3Witness(witness, "expected.compact_has_error is absent")
+	}
+	return nil
+}
 
-			// The adjudication itself: production's HasError must match the C
-			// oracle's HasError -- the exact boolean the fuzz harness used to
-			// collect this witness. Any failure here is a PRODUCTION bug,
-			// distinct from the known compact admission gap this fixture
-			// documents.
-			if prodHasError != cHasError {
-				t.Fatalf("PRODUCTION-VS-C HAS-ERROR DIVERGENCE (production bug, not compact): production HasError=%v, C oracle HasError=%v", prodHasError, cHasError)
-			}
+func validateCompactT3COracleProvenance(provenance compactT3COracleProvenance) error {
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{"contract", provenance.Contract},
+		{"binding_commit", provenance.BindingCommit},
+		{"runtime_commit", provenance.RuntimeCommit},
+		{"grammar_repository", provenance.GrammarRepository},
+		{"grammar_commit", provenance.GrammarCommit},
+		{"compiler_path", provenance.CompilerPath},
+		{"compiler_version", provenance.CompilerVersion},
+		{"grammar_compile_flags", provenance.GrammarCompileFlags},
+		{"grammar_artifact_sha256", provenance.GrammarArtifactSHA256},
+	}
+	for _, field := range fields {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("c_oracle.%s is empty", field.name)
+		}
+	}
+	if len(provenance.GrammarArtifactSHA256) != sha256.Size*2 {
+		return fmt.Errorf("c_oracle.grammar_artifact_sha256 has an invalid length")
+	}
+	if _, err := hex.DecodeString(provenance.GrammarArtifactSHA256); err != nil {
+		return fmt.Errorf("c_oracle.grammar_artifact_sha256 is not hexadecimal")
+	}
+	return nil
+}
 
-			// Documentary only: full node-by-node structural parity is a
-			// currently-passing invariant for clean input (see
-			// TestParityFreshParse on the smoke corpus) but is not established
-			// for malformed-input error-recovery paths. Log the shape
-			// divergence for evidence without failing the fixture on it.
-			var structuralErrs []string
-			compareNodes(productionTree.RootNode(), lang, cTree.RootNode(), "root", &structuralErrs)
-			if len(structuralErrs) > 0 {
-				shown := structuralErrs
-				if len(shown) > 5 {
-					shown = shown[:5]
-				}
-				t.Logf("structural shape divergence from C oracle (%d node-level diffs, informational only):\n%s", len(structuralErrs), strings.Join(shown, "\n"))
-			}
+func errorsForCompactT3Witness(witness compactT3Witness, message string) error {
+	return fmt.Errorf("witness %q (%s): %s", witness.ID, witness.Language, message)
+}
 
-			// Documentary only: record whether the compact route's known
-			// false-clean acceptance is still present. Fixing it is a separate
-			// workstream, so this fixture never fails on it.
-			if compHasError == cHasError {
-				t.Logf("NOTE: compact route now agrees with the C oracle for this witness (regression check: confirm the compact-route fix landed)")
-			} else {
-				t.Logf("KNOWN COMPACT DIVERGENCE (tracked, not asserted here): compact HasError=%v, C oracle HasError=%v", compHasError, cHasError)
-			}
-		})
+func compactT3WitnessLanguages(manifest compactT3WitnessManifest) []string {
+	languages := make([]string, 0, len(manifest.LanguageCounts))
+	for language := range manifest.LanguageCounts {
+		languages = append(languages, language)
+	}
+	sort.Strings(languages)
+	return languages
+}
+
+func compactT3WitnessesForLanguage(manifest compactT3WitnessManifest, language string) []compactT3Witness {
+	var witnesses []compactT3Witness
+	for _, witness := range manifest.Witnesses {
+		if witness.Language == language {
+			witnesses = append(witnesses, witness)
+		}
+	}
+	return witnesses
+}
+
+func compactT3GoLanguage(name string) (*gotreesitter.Language, bool) {
+	switch name {
+	case "html":
+		return grammars.HtmlLanguage(), true
+	case "javascript":
+		return grammars.JavascriptLanguage(), true
+	case "swift":
+		return grammars.SwiftLanguage(), true
+	default:
+		return nil, false
+	}
+}
+
+func assertCompactT3COracleProvenance(t *testing.T, witness compactT3Witness, actual COracleBuildIdentity) {
+	t.Helper()
+	want := witness.COracle
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"contract", actual.Contract, want.Contract},
+		{"binding_commit", actual.BindingCommit, want.BindingCommit},
+		{"runtime_commit", actual.RuntimeCommit, want.RuntimeCommit},
+		{"grammar_repository", actual.GrammarRepo, want.GrammarRepository},
+		{"grammar_commit", actual.GrammarCommit, want.GrammarCommit},
+		{"compiler_path", actual.CompilerPath, want.CompilerPath},
+		{"compiler_version", actual.CompilerVersion, want.CompilerVersion},
+		{"grammar_compile_flags", actual.GrammarCompileFlags, want.GrammarCompileFlags},
+		{"grammar_artifact_sha256", actual.GrammarArtifactSHA256, want.GrammarArtifactSHA256},
+	}
+	for _, check := range checks {
+		if check.got != check.want {
+			t.Fatalf("witness %q: C oracle %s=%q, want %q", witness.ID, check.name, check.got, check.want)
+		}
+	}
+}
+
+func compactT3CHasError(t *testing.T, language *sitter.Language, source []byte) bool {
+	t.Helper()
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(language); err != nil {
+		t.Fatalf("set C oracle language: %v", err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("C oracle parse returned no root")
+	}
+	defer tree.Close()
+	return tree.RootNode().HasError()
+}
+
+func compactT3GoHasError(t *testing.T, language *gotreesitter.Language, source []byte, compact bool) bool {
+	t.Helper()
+	parser := gotreesitter.NewParser(language)
+	parser.SetAdmissionCandidateRoute(compact)
+	tree, err := parser.Parse(source)
+	if err != nil {
+		t.Fatalf("parse compact=%t: %v", compact, err)
+	}
+	defer tree.Release()
+	return tree.RootNode().HasError()
+}
+
+func assertCompactT3Outcome(t *testing.T, witness compactT3Witness, route string, want *bool, got bool) {
+	t.Helper()
+	if want == nil {
+		t.Fatalf("witness %q: %s expectation is absent", witness.ID, route)
+	}
+	if got != *want {
+		t.Fatalf("witness %q: %s HasError=%t, want %t", witness.ID, route, got, *want)
 	}
 }

--- a/cgo_harness/parity_c_loader_cgo.go
+++ b/cgo_harness/parity_c_loader_cgo.go
@@ -93,7 +93,7 @@ const (
 	COracleBindingCommit   = "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3"
 	COracleRuntimeVersion  = "0.25.1"
 	COracleRuntimeCommit   = "f5afe475deb7c0bae6407fb776c76824f717bb61"
-	COracleGrammarCFlags   = "-O2 -fPIC"
+	COracleGrammarCFlags   = "-std=c11 -fPIC -O2 -I ."
 )
 
 // COracleBuildIdentity describes the in-process cgo parity transport. The
@@ -960,19 +960,21 @@ func compileParserShared(entry parityLockEntry, repoDir, outSO, objDir string) e
 	for _, source := range sources {
 		ext := strings.ToLower(filepath.Ext(source))
 		obj := filepath.Join(objDir, paritySafeName(filepath.Base(source))+".o")
+		// Use a relative source name so __FILE__ does not contain a temp path.
+		sourceName := filepath.Base(source)
 		switch ext {
 		case ".cc", ".cpp", ".cxx":
 			hasCXX = true
 			if err := runCommand(
-				"",
+				srcDir,
 				"c++",
 				"-std=c++17",
 				"-fPIC",
 				"-O2",
 				"-I",
-				srcDir,
+				".",
 				"-c",
-				source,
+				sourceName,
 				"-o",
 				obj,
 			); err != nil {
@@ -980,15 +982,15 @@ func compileParserShared(entry parityLockEntry, repoDir, outSO, objDir string) e
 			}
 		default:
 			if err := runCommand(
-				"",
+				srcDir,
 				"cc",
 				"-std=c11",
 				"-fPIC",
 				"-O2",
 				"-I",
-				srcDir,
+				".",
 				"-c",
-				source,
+				sourceName,
 				"-o",
 				obj,
 			); err != nil {

--- a/cgo_harness/testdata/compact_t3_oracle_witnesses_v1.json
+++ b/cgo_harness/testdata/compact_t3_oracle_witnesses_v1.json
@@ -1,0 +1,554 @@
+{
+  "schema": "compact-t3-c-oracle-witnesses-v1",
+  "version": 1,
+  "parity_scope": "has_error_only",
+  "tracking_issue": "https://github.com/odvcencio/gotreesitter/issues/587",
+  "witness_count": 20,
+  "language_counts": {
+    "html": 10,
+    "javascript": 8,
+    "swift": 2
+  },
+  "witnesses": [
+    {
+      "id": "html_min_a",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "reported_minimum"
+      },
+      "source_utf8": "<a></a^>",
+      "source_sha256": "80334c0dad68b2a2d87ff7081b667a289704d8447467bdd60c09ae5abb9a70c0",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_min_html",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "reported_minimum"
+      },
+      "source_utf8": "<html></html^>",
+      "source_sha256": "c4f99da2c8a2e0c00f16c586259ec5c0d79be77a9fbdda718e2cbe8291b7b792",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_1",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html>/<body>Hello</body^></html>\n",
+      "source_sha256": "d49eab8aa2c058e9e402a4a99e13e4c542aae0e2dd975d205fcfdc4984ac4901",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_2",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html><bod\">Hello</body></html>\n",
+      "source_sha256": "efbe5dbd55e7cbea08b6874731c537569b62ac3f51bfcb7344355ac2c7d5e881",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_3",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html><body>Hello</bo^y>:</html>\n",
+      "source_sha256": "a298ea9116d1423906f8337944a5d0a4a778c5f784a7f921e8140e3b529d5103",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_4",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html><body>H}llo</boy></h!tml>\n",
+      "source_sha256": "49707ad1af00e841f05bb768ff56f9dd940215091f7b74ad2fdce53c52123111",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_5",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html><body>Hello /bod></html>\n",
+      "source_sha256": "d8bb11ac98460d06cf08b24339cb1e4c2413e4a38621b29f97f0074c4e64f6d3",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_6",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html><body>Hell</body>y></html>\n",
+      "source_sha256": "e06052f41c8e1ff1d043e3ecda32b7b5aecc019874940cc5915c0af30351ca61",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_7",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html><bodyHello</body></html>\n",
+      "source_sha256": "5ee9bc39f8551cd889db66b5d9b79c76f60e2b03c3604ec16d7e7949a8b26df7",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "html_log_8",
+      "language": "html",
+      "failure_class": "html_erroneous_end_tag",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "<html> body>Hello</body></html>\n",
+      "source_sha256": "090792a0c50532aae4e6f176bfecf56df24c1ec6258c9a88bc54acf79dd47996",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-html",
+        "grammar_commit": "73a3947324f6efddf9e17c0ea58d454843590cc0",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "f8a5b35b517fc5dd2c6706d62efcf6a9a2787e3dd1e4dcc70775d2c588e801c3"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_1",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "function f() { return 1; }\nconst x = ()? => x + 1;\n",
+      "source_sha256": "69ad18e272af9b48b0e4ad143391a722951174d09cb85a66949e4345bf2566e7",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_2",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "function f()^{ return 1; }\nconstx = () => x + 1;\n",
+      "source_sha256": "6e2506b2f9200fbdc67318a5683bba163aa568d62cfce55fe62d4b0c27abecd8",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_3",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "const f = (a) => a + 1;\nclass  A { m() { return 1 } )}\n",
+      "source_sha256": "f6d80e87368d55d4e8d63e138db22d2183ed7f1099430aad6c8aa1b6196cd6ad",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_4",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "function f()&{ return 1; }\nconst x = () => x + 1;\n",
+      "source_sha256": "131abc98a4feed3aaddd88c577ad35a92dbb44bda6c6e925cdc671bc64d1fa33",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_5",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "const f = (a) =. + + 1;\nclass A { m() { return 1 } }\n\n",
+      "source_sha256": "100746f1daa0724a53dd53b9356dd1480a407c065c4bf88dca6fa776020ac946",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_6",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "const f = (a) => a + 1;&\nclass A { m() { return 1 } }\n\n",
+      "source_sha256": "dcd98da448ad19b90a575fd8fe5e4b875f4aff7633318b89bc8aa877011ce750",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_7",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "const f = (a) => a + 1;\nclass A ?{ m() { return 1 } }\n",
+      "source_sha256": "8e03fa43f2c7f82f1e26742a64626fc0447f356b25441c8e63f0049538626651",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "js_log_8",
+      "language": "javascript",
+      "failure_class": "js_arrow_param_recovery",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "function f() { return 1; ^}\ncon\nconst x = () => x + 1;\n",
+      "source_sha256": "644cf11a9a181aa0877b823ec7ec640a686b06cf8907a6d470dcc27c8696a531",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/tree-sitter/tree-sitter-javascript",
+        "grammar_commit": "58404d8cf191d69f2674a8fd507bd5776f46cb11",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "dd450343dbf6ff1542a20e413e01a3ef08d543e8bb5b9f0c4697b05d2ef0f096"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "swift_log_1",
+      "language": "swift",
+      "failure_class": "swift_shift_comparison",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "let v = x >> y>>",
+      "source_sha256": "f4df50494533761a596b3eb5255f8adf1fe108108419317897ba91cd77026f8e",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/alex-pinkus/tree-sitter-swift",
+        "grammar_commit": "41d6e5fe811ec94229ee71771174a8cce558dfee",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "2a9f14046d4ca88b6db1316ee5f48b876aea1700e3c09811b3c87257fe827c5c"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    },
+    {
+      "id": "swift_log_2",
+      "language": "swift",
+      "failure_class": "swift_shift_comparison",
+      "source_provenance": {
+        "origin": "compact_route_differential_fuzz",
+        "record": "retained_fuzz_log_witness"
+      },
+      "source_utf8": "letv = x >> \n",
+      "source_sha256": "62adf7e4fde458d44c25d50214d9f6ee82770a336dbe58c807f2e2271a443944",
+      "c_oracle": {
+        "contract": "tree-sitter-c-v1",
+        "binding_commit": "adc13ffd8b2c0b01b878fda9f7c422ce0df5fad3",
+        "runtime_commit": "f5afe475deb7c0bae6407fb776c76824f717bb61",
+        "grammar_repository": "https://github.com/alex-pinkus/tree-sitter-swift",
+        "grammar_commit": "41d6e5fe811ec94229ee71771174a8cce558dfee",
+        "compiler_path": "/usr/bin/cc",
+        "compiler_version": "cc (Debian 12.2.0-14+deb12u1) 12.2.0",
+        "grammar_compile_flags": "-std=c11 -fPIC -O2 -I .",
+        "grammar_artifact_sha256": "2a9f14046d4ca88b6db1316ee5f48b876aea1700e3c09811b3c87257fe827c5c"
+      },
+      "expected": {
+        "c_has_error": true,
+        "production_has_error": true,
+        "compact_has_error": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a versioned manifest for 20 compact-route witnesses.
- Verify source digests and C-oracle provenance.
- Fail when C, production, or compact results differ.
- Add a Docker C-oracle gate to the build gate.
- Normalize C compilation to stabilize artifact hashes.

## Scope

This contract compares `HasError` only.
It does not assert recovery-tree structure.

Tracks #587.

## Validation

- Run `actionlint .github/workflows/ci.yml`.
- Run the tagged Docker contract test for all 20 witnesses.
- Run the focused Docker TypeScript C++ scanner test.