### PR TITLE
compact scheduler: L1 deterministic single-head frontier fast paths

### DIFF
--- a/benchmark_admission_candidate_route_test.go
+++ b/benchmark_admission_candidate_route_test.go
@@ -1,0 +1,63 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+)
+
+// BenchmarkAdmissionCandidateGoQueryCompileWarmRoute measures the public,
+// warmed compact admission route on a fixed Go source. The route counters are
+// reported after the timed loop. They prove every measured parse used the
+// compact scheduler and that no parse fell back to production.
+func BenchmarkAdmissionCandidateGoQueryCompileWarmRoute(b *testing.B) {
+	fixtures, err := benchfixtures.LoadGoFullParseFixtures()
+	if err != nil {
+		b.Fatal(err)
+	}
+	var source []byte
+	for _, fixture := range fixtures {
+		if fixture.Fixture.ID == "query_compile" {
+			source = fixture.Source
+			break
+		}
+	}
+	if len(source) == 0 {
+		b.Fatal("query_compile benchmark fixture is missing")
+	}
+
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	parser.SetAdmissionCandidateRoute(true)
+	gotreesitter.ResetAdmissionCandidateCountersForTest()
+	warm, err := parser.Parse(source)
+	if err != nil || warm == nil || warm.RootNode() == nil {
+		b.Fatalf("compact warm parse failed: tree=%v err=%v", warm != nil, err)
+	}
+	warm.Release()
+	if routed, fallback := gotreesitter.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+		b.Fatalf("compact warm parse did not route: routed=%d fallback=%d reason=%q", routed, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+
+	gotreesitter.ResetAdmissionCandidateCountersForTest()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(source)))
+	b.ResetTimer()
+	for range b.N {
+		tree, parseErr := parser.Parse(source)
+		if parseErr != nil || tree == nil || tree.RootNode() == nil {
+			b.Fatalf("compact timed parse failed: tree=%v err=%v", tree != nil, parseErr)
+		}
+		tree.Release()
+	}
+	b.StopTimer()
+	routed, fallback := gotreesitter.AdmissionCandidateCounters()
+	if routed != uint64(b.N) || fallback != 0 {
+		b.Fatalf("compact timed loop changed route: routed=%d want=%d fallback=%d reason=%q", routed, b.N, fallback, gotreesitter.AdmissionCandidateLastFallbackReason())
+	}
+	b.ReportMetric(float64(routed)/float64(b.N), "candidate-routes/op")
+	b.ReportMetric(float64(fallback)/float64(b.N), "candidate-fallbacks/op")
+}

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -349,6 +349,28 @@ func TestDiagnosticParserCoreCanonicalScratchSteadyStateDoesNotAllocate(t *testi
 	}
 }
 
+// TestDiagnosticParserCoreCanonicalScratchSteadyStateSingleHeaderDoesNotAllocate
+// pins the single-header fast path in canonicalize (the len(normalized) == 1
+// branch), which skips the key-slice sizing and key-struct build that the
+// two-header case above still exercises. Both cases must independently stay
+// at zero steady-state allocations.
+func TestDiagnosticParserCoreCanonicalScratchSteadyStateSingleHeaderDoesNotAllocate(t *testing.T) {
+	compact, first, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	input := []diagnosticParserCoreHeader{{head: first, creationSeq: 3}}
+	var scratch diagnosticParserCoreCanonicalScratch
+	for range 4 {
+		if _, err := scratch.canonicalize(compact, input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var runErr error
+	if allocs := testing.AllocsPerRun(1000, func() {
+		_, runErr = scratch.canonicalize(compact, input)
+	}); allocs != 0 || runErr != nil {
+		t.Fatalf("steady single-header canonicalization allocs=%v err=%v", allocs, runErr)
+	}
+}
+
 func TestDiagnosticParserCoreCanonicalScratchMappedSpillPreservesSemantics(t *testing.T) {
 	compact, err := core.New(&genericConflictTable{}, core.Limits{})
 	if err != nil {

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -3,6 +3,7 @@
 package gotreesitter
 
 import (
+	"errors"
 	"reflect"
 	"runtime"
 	"testing"
@@ -94,6 +95,201 @@ func TestDiagnosticParserCoreCanonicalScratchCollapsesCanonicalHeads(t *testing.
 	})
 	if err != nil || len(out) != 1 || out[0].head != canonical || out[0].creationSeq != 3 {
 		t.Fatalf("canonical collapse output=%+v canonical=%+v err=%v", out, canonical, err)
+	}
+}
+
+// TestDiagnosticParserCoreCanonicalScratchSingleHeaderRemapsAndPublishesFresh
+// exercises the compact scheduler's single-header shortcut. It keeps the
+// canonical boundary remap, clears reduction freshness, and preserves the
+// double-buffer publication rule.
+func TestDiagnosticParserCoreCanonicalScratchSingleHeaderRemapsAndPublishesFresh(t *testing.T) {
+	table := &genericConflictTable{
+		cells: map[genericConflictCell][]core.Action{
+			{state: 1, symbol: 7}: {{Type: core.ActionShift, State: 5}},
+			{state: 1, symbol: 8}: {{Type: core.ActionShift, State: 3}},
+			{state: 5, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1, DynamicPrecedence: 1}},
+			{state: 3, symbol: 9}: {{Type: core.ActionReduce, Symbol: 2, ChildCount: 1, DynamicPrecedence: 2}},
+		},
+		gotos: map[genericConflictCell]core.StateID{{state: 1, symbol: 2}: 4},
+	}
+	compact, err := core.New(table, core.Limits{MaxDerivations: 8, MaxPopPaths: 8})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	low, err := compact.Shift(seed, 7, 0, core.Token{Symbol: 7, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	high, err := compact.Shift(seed, 8, 0, core.Token{Symbol: 8, EndByte: 1}, core.ForkOrder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lowOutputs, err := compact.ReduceOutputs(low, 9, 0, core.ForkOrder{})
+	if err != nil || len(lowOutputs) != 1 {
+		t.Fatalf("low reduction outputs=%+v err=%v", lowOutputs, err)
+	}
+	highOutputs, err := compact.ReduceOutputs(high, 9, 0, core.ForkOrder{})
+	if err != nil || len(highOutputs) != 1 || highOutputs[0].Head == lowOutputs[0].Head {
+		t.Fatalf("high reduction outputs=%+v low=%+v err=%v", highOutputs, lowOutputs, err)
+	}
+	stale := lowOutputs[0].Head
+	canonical := highOutputs[0].Head
+	staleState, staleByte, err := compact.Boundary(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalState, canonicalByte, err := compact.Boundary(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if staleState != canonicalState || staleByte != canonicalByte {
+		t.Fatalf("fixture does not share a canonical boundary: stale=%d/%d canonical=%d/%d", staleState, staleByte, canonicalState, canonicalByte)
+	}
+
+	input := []diagnosticParserCoreHeader{{
+		head: stale, creationSeq: 3, freshness: core.ReductionNew,
+	}}
+	var scratch diagnosticParserCoreCanonicalScratch
+	first, err := scratch.canonicalize(compact, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 1 || first[0].head != canonical || first[0].freshness != 0 {
+		t.Fatalf("single-header remap/freshness=%+v canonical=%+v", first, canonical)
+	}
+	if gotState, gotByte, boundaryErr := compact.Boundary(first[0].head); boundaryErr != nil || gotState != staleState || gotByte != staleByte {
+		t.Fatalf("remapped boundary=%d/%d err=%v, want=%d/%d", gotState, gotByte, boundaryErr, staleState, staleByte)
+	}
+	if &first[0] == &input[0] {
+		t.Fatal("single-header canonicalization aliased caller input")
+	}
+	firstSnapshot := append([]diagnosticParserCoreHeader(nil), first...)
+	second, err := scratch.canonicalize(compact, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 1 || &second[0] == &first[0] {
+		t.Fatal("single-header canonicalization did not alternate published buffers")
+	}
+	second[0].creationSeq = 11
+	if !reflect.DeepEqual(first, firstSnapshot) {
+		t.Fatalf("next single-header output mutated prior publication: got=%+v want=%+v", first, firstSnapshot)
+	}
+}
+
+// TestDiagnosticParserCoreCanonicalScratchSingleHeaderFailureDoesNotPublish
+// keeps an invalid head from advancing the publication buffer or mutating the
+// last valid single-header result.
+func TestDiagnosticParserCoreCanonicalScratchSingleHeaderFailureDoesNotPublish(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	var scratch diagnosticParserCoreCanonicalScratch
+	published, err := scratch.canonicalize(compact, []diagnosticParserCoreHeader{{head: head, freshness: core.ReductionNew}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publishedSnapshot := append([]diagnosticParserCoreHeader(nil), published...)
+	nextBefore := scratch.nextBuffer
+	_, err = scratch.canonicalize(compact, []diagnosticParserCoreHeader{{
+		head: core.Head{Node: 1 << 30}, freshness: core.ReductionNew,
+	}})
+	if err == nil {
+		t.Fatal("invalid single header unexpectedly canonicalized")
+	}
+	if scratch.nextBuffer != nextBefore || !reflect.DeepEqual(published, publishedSnapshot) {
+		t.Fatalf("failed single-header run published scratch: next=%d want=%d current=%+v want=%+v", scratch.nextBuffer, nextBefore, published, publishedSnapshot)
+	}
+}
+
+// TestDiagnosticParserCoreElectionSummaryMatchesFullReceipt proves that the
+// summary election path produces the same closed-frontier result as the full
+// receipt path. The modes retain different diagnostic detail only.
+func TestDiagnosticParserCoreElectionSummaryMatchesFullReceipt(t *testing.T) {
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "rewrite")
+	target := uint32(919)
+	run := func(mode DiagnosticParserCoreReceiptMode) DiagnosticParserCorePrefixResult {
+		result, err := DiagnosticParseParserCorePrefix(
+			parserCoreWarmGoScanner,
+			fixture.Source,
+			DiagnosticParserCorePrefixOptions{
+				ReceiptMode: mode, GenericStopAtClosedByte: &target,
+				MaxTokens: 300000, MaxDispatches: 600000,
+				Limits: diagnosticParserCoreCanonicalLimits(),
+			},
+		)
+		if err != nil {
+			t.Fatalf("%v receipt route declined: result=%+v err=%v", mode, result, err)
+		}
+		return result
+	}
+	full := run(DiagnosticParserCoreReceiptFull)
+	summary := run(DiagnosticParserCoreReceiptSummary)
+	if full.GenericScheduler == nil || summary.GenericScheduler == nil || full.GenericScheduler.Completion == nil || summary.GenericScheduler.Completion == nil {
+		t.Fatalf("missing completion: full=%+v summary=%+v", full.GenericScheduler, summary.GenericScheduler)
+	}
+	if full.Boundary != summary.Boundary || full.Detail != summary.Detail || full.Tokens != summary.Tokens ||
+		full.Dispatches != summary.Dispatches || full.State != summary.State || full.Lookahead != summary.Lookahead ||
+		full.LastBranchOrder != summary.LastBranchOrder || full.Completed != summary.Completed || full.Materialized != summary.Materialized {
+		t.Fatalf("summary/full result drift: full=%+v summary=%+v", full, summary)
+	}
+	fullCompletion := full.GenericScheduler.Completion
+	summaryCompletion := summary.GenericScheduler.Completion
+	if fullCompletion.TargetByte != summaryCompletion.TargetByte || fullCompletion.ElectionIndex != summaryCompletion.ElectionIndex ||
+		fullCompletion.LastToken != summaryCompletion.LastToken || fullCompletion.State != summaryCompletion.State ||
+		fullCompletion.Stats != summaryCompletion.Stats || fullCompletion.Work != summaryCompletion.Work {
+		t.Fatalf("summary/full completion drift: full=%+v summary=%+v", fullCompletion, summaryCompletion)
+	}
+	if len(full.GenericScheduler.Elections) == 0 || len(summary.GenericScheduler.Elections) != 0 ||
+		len(full.Elections) == 0 || len(summary.Elections) != 0 || len(fullCompletion.Headers) == 0 || len(summaryCompletion.Headers) != 0 {
+		t.Fatalf("receipt retention drift: full=%+v summary=%+v", full.GenericScheduler, summary.GenericScheduler)
+	}
+}
+
+// TestDiagnosticParserCoreElectionPreservesInvalidCheckpointDeclines proves
+// the direct summary state read preserves malformed-checkpoint errors and
+// known-checkpoint identity declines in both receipt modes.
+func TestDiagnosticParserCoreElectionPreservesInvalidCheckpointDeclines(t *testing.T) {
+	compact, head, _ := newDiagnosticParserCoreCanonicalTestCore(t)
+	foreign := mustDiagnosticCheckpointID(t, compact, []byte{1})
+	for _, mode := range []DiagnosticParserCoreReceiptMode{
+		DiagnosticParserCoreReceiptFull,
+		DiagnosticParserCoreReceiptSummary,
+	} {
+		for _, test := range []struct {
+			name          string
+			checkpoint    core.CheckpointID
+			wantMalformed bool
+		}{
+			{name: "known-mismatch", checkpoint: foreign},
+			{name: "unknown", checkpoint: core.CheckpointID(99), wantMalformed: true},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				scheduler := &diagnosticParserCoreGenericScheduler{
+					compact: compact,
+					headers: []diagnosticParserCoreHeader{{
+						head: head, shifted: true, checkpoint: test.checkpoint,
+					}},
+					checkpointID: 0,
+					options:      DiagnosticParserCorePrefixOptions{ReceiptMode: mode, MaxTokens: 1},
+				}
+				err := scheduler.elect(false)
+				var decline *diagnosticParserCoreDecline
+				if test.wantMalformed {
+					if err == nil || errors.As(err, &decline) || err.Error() != "parser-core phase zero: header references unknown checkpoint identity" {
+						t.Fatalf("invalid checkpoint err=%v decline=%+v", err, decline)
+					}
+				} else if !errors.As(err, &decline) || decline.boundary != DiagnosticParserCoreIdentity ||
+					decline.detail != "generic scheduler election frontier is not closed and checkpoint-continuous" {
+					t.Fatalf("mismatched checkpoint err=%v decline=%+v", err, decline)
+				}
+				if scheduler.tokens != 0 || scheduler.work.Elections != 0 || len(scheduler.electStates) != 0 || scheduler.headers[0].checkpoint != test.checkpoint {
+					t.Fatalf("checkpoint rejection mutated scheduler: %+v", scheduler)
+				}
+			})
+		}
 	}
 }
 

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4191,13 +4191,22 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 		states = make([]StateID, 0, max(len(s.headers), 2*cap(states)))
 	}
 	for _, header := range s.headers {
-		shiftIdentity := header.shifted || first && !header.shifted
-		if !shiftIdentity || header.accepted || header.checkpoint != s.checkpointID {
-			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler election frontier is not closed and checkpoint-continuous"}
-		}
 		state, err := s.electHeaderState(header)
 		if err != nil {
 			return err
+		}
+		shiftIdentity := header.shifted || first && !header.shifted
+		if !shiftIdentity || header.accepted || header.checkpoint != s.checkpointID {
+			// Full receipts already validated the checkpoint while reading the
+			// header. Summary mode skips that digest lookup on the healthy hot
+			// path, but keeps the legacy invalid-checkpoint error when this cold
+			// identity gate rejects a malformed header.
+			if !s.fullReceipts() {
+				if _, _, ok := s.compact.CheckpointReceipt(header.checkpoint); !ok {
+					return errors.New("parser-core phase zero: header references unknown checkpoint identity")
+				}
+			}
+			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler election frontier is not closed and checkpoint-continuous"}
 		}
 		states = append(states, state)
 	}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -962,10 +962,16 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 	return nil
 }
 
+// errDiagnosticParserCoreUnknownCheckpointIdentity is the shared sentinel for
+// a header (or a cold-path identity-gate reject) that names a checkpoint the
+// compact core never interned. Both callers below return it unwrapped, so
+// callers may compare with errors.Is.
+var errDiagnosticParserCoreUnknownCheckpointIdentity = errors.New("parser-core phase zero: header references unknown checkpoint identity")
+
 func diagnosticParserCoreCheckpointDigest(compact *core.Core, id core.CheckpointID) ([32]byte, error) {
 	_, digest, ok := compact.CheckpointReceipt(id)
 	if !ok {
-		return [32]byte{}, errors.New("parser-core phase zero: header references unknown checkpoint identity")
+		return [32]byte{}, errDiagnosticParserCoreUnknownCheckpointIdentity
 	}
 	return digest, nil
 }
@@ -4196,6 +4202,10 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 			return err
 		}
 		shiftIdentity := header.shifted || first && !header.shifted
+		// Precondition: s.checkpointID always holds a value produced by
+		// diagnosticParserCoreInternCheckpoint, set only at its two writer sites
+		// (the scheduler seed above and the election afterID assignment below), so
+		// this raw identity comparison is a sound substitute for a digest lookup.
 		if !shiftIdentity || header.accepted || header.checkpoint != s.checkpointID {
 			// Full receipts already validated the checkpoint while reading the
 			// header. Summary mode skips that digest lookup on the healthy hot
@@ -4203,7 +4213,7 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 			// identity gate rejects a malformed header.
 			if !s.fullReceipts() {
 				if _, _, ok := s.compact.CheckpointReceipt(header.checkpoint); !ok {
-					return errors.New("parser-core phase zero: header references unknown checkpoint identity")
+					return errDiagnosticParserCoreUnknownCheckpointIdentity
 				}
 			}
 			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler election frontier is not closed and checkpoint-continuous"}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -1316,6 +1316,27 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 	}
 	copy(normalized, headers)
 	s.headerBuffers[target] = normalized
+	// Single-head frontiers never reach canonicalizeLinear/canonicalizeMapped,
+	// so the per-header canonical group key they group by carries no
+	// semantics here -- only the canonical remap (the compact.Boundary +
+	// CanonicalBoundary probe) and the freshness reset do. Skip the key-slice
+	// sizing and key-struct build entirely on this path; the double-buffer
+	// copy above still runs unchanged, since the aliasing check above and on
+	// the next call depends on the returned slice living in s.headerBuffers.
+	if len(normalized) == 1 {
+		header := normalized[0]
+		state, byteOffset, err := compact.Boundary(header.head)
+		if err != nil {
+			return nil, err
+		}
+		if canonical, ok := compact.CanonicalBoundary(state, byteOffset, header.shifted, header.checkpoint); ok {
+			header.head = canonical
+		}
+		header.freshness = 0
+		normalized[0] = header
+		s.nextBuffer = uint8(target ^ 1)
+		return normalized, nil
+	}
 	if cap(s.keys) < len(headers) {
 		if len(headers) <= len(s.inlineKeys) {
 			s.keys = s.inlineKeys[:len(headers)]
@@ -1340,9 +1361,6 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 	var out []diagnosticParserCoreHeader
 	switch {
 	case len(normalized) == 0:
-		out = normalized
-	case len(normalized) == 1:
-		normalized[0].freshness = 0
 		out = normalized
 	case len(normalized) <= diagnosticParserCoreLinearCanonicalLimit:
 		out = s.canonicalizeLinear(normalized)
@@ -1637,6 +1655,28 @@ func (s *diagnosticParserCoreGenericScheduler) headerReceipt(header diagnosticPa
 		return diagnosticParserCoreHeaderReceipt(s.compact, header)
 	}
 	return diagnosticParserCoreHeaderSummary(s.compact, header)
+}
+
+// electHeaderState resolves only what one election round needs from a
+// header: its authentic StateID. Shifted/Accepted are read directly off the
+// header by the caller, so this skips the checkpoint-digest lookup that
+// diagnosticParserCoreHeaderSummary otherwise pays on every header on every
+// election — that digest has no reader on this path. Full-receipt mode keeps
+// paying it, since diagnosticParserCoreHeaderReceipt is also what tests and
+// diagnostics observe and must stay byte-identical there.
+func (s *diagnosticParserCoreGenericScheduler) electHeaderState(header diagnosticParserCoreHeader) (StateID, error) {
+	if s.fullReceipts() {
+		receipt, err := diagnosticParserCoreHeaderReceipt(s.compact, header)
+		if err != nil {
+			return 0, err
+		}
+		return receipt.State, nil
+	}
+	state, _, err := s.compact.Boundary(header.head)
+	if err != nil {
+		return 0, err
+	}
+	return StateID(state), nil
 }
 
 func (s *diagnosticParserCoreGenericScheduler) headerReceipts(headers []diagnosticParserCoreHeader) ([]DiagnosticParserCoreHeaderReceipt, error) {
@@ -4151,15 +4191,15 @@ func (s *diagnosticParserCoreGenericScheduler) elect(first bool) error {
 		states = make([]StateID, 0, max(len(s.headers), 2*cap(states)))
 	}
 	for _, header := range s.headers {
-		receipt, err := s.headerReceipt(header)
+		shiftIdentity := header.shifted || first && !header.shifted
+		if !shiftIdentity || header.accepted || header.checkpoint != s.checkpointID {
+			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler election frontier is not closed and checkpoint-continuous"}
+		}
+		state, err := s.electHeaderState(header)
 		if err != nil {
 			return err
 		}
-		shiftIdentity := receipt.Shifted || first && !receipt.Shifted
-		if !shiftIdentity || receipt.Accepted || header.checkpoint != s.checkpointID {
-			return &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreIdentity, detail: "generic scheduler election frontier is not closed and checkpoint-continuous"}
-		}
-		states = append(states, receipt.State)
+		states = append(states, state)
 	}
 	s.electStates = states
 	if s.observer.beforeElection != nil {


### PR DESCRIPTION
## Summary

This draft reduces work in the compact scheduler single-header path.

It makes two changes:

- It skips canonical-group key work for a single header.
- It reads the election state without a checkpoint digest on the healthy summary path.

The cold identity path keeps the legacy error for an unknown checkpoint.

Validation used `main` at `ba71701a0e41e126521124d204c9f4188cf9f264`. The pull request base remains `main`.

## Correctness and route tests

- Single-header tests check boundary remap, freshness reset, buffer isolation, and failure isolation.
- Election tests compare summary and full-receipt results.
- Checkpoint tests distinguish an invalid checkpoint error from a known mismatch decline.
- The public route benchmark checks compact routing and production fallback counts.

## Evidence

- Focused Docker tests: pass.
- Candidate scorecard: `PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0 total=206`.
- CSS direct C/cgo parity: `eligible=20 no_error=20 tree_parity=20 divergences=0`.
- Local scheduler benchmark with `GOMAXPROCS=1`, 20 samples, 750 ms samples, collected on this local development host (not a quiet host):
  - Main: 9.491 ms/op ±3%.
  - Candidate: 9.305 ms/op ±3%.
  - Local delta: -1.96%, p=0.011. This is a provisional, non-banking observation, not a timing receipt.
  - The local noise floor is 7.4%-10.8% on repeated same-revision A/B runs. It exceeds the observed delta.
  - The Phase-3 admission bar needs at least 2% canonical equal-fixture improvement, measured on a quiet host. This local run cannot satisfy that bar.
  - The 2% retain-gate measurement is deferred to the quiet-host/enclave re-seal, per the campaign measurement protocol (`docs/phase3-admission-timing-runbook.md`).
  - Memory: 208 B/op and 6 allocs/op on both revisions.
- Public compact-route benchmark:
  - `candidate-routes/op=1.000`.
  - `candidate-fallbacks/op=0`.
  - 280 B/op and 8 allocs/op.
- [Manual full CI/race run](https://github.com/odvcencio/gotreesitter/actions/runs/30695863034):
  - 36 successful jobs.
  - Four expected skipped jobs.
  - Zero failed jobs.

## Status

This pull request remains a draft. The manual CI/race gate passed on `43613159a458b0f2563024bc6e573a5d1795b30b`.

The final Buckley Codex review reported a B grade, no findings, and no blockers. It requests discussion because its restricted review snapshot had no Canopy structural evidence.
