### PR TITLE
release: authorize one-time v0.48.0 owner waiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,21 @@ on:
         options:
           - planned-minor
           - urgent-patch
+          - owner-waived-minor
       receipt_uri:
         description: Governing Hyphae release receipt
         required: true
         type: string
       incident:
-        description: Urgent patch incident
+        description: Urgent patch or owner-waiver incident
         required: false
         type: string
       why_waiting_is_worse:
-        description: Reason that an urgent patch cannot wait
+        description: Urgent patch or owner-waiver delay rationale
+        required: false
+        type: string
+      owner_waiver_reason:
+        description: Owner reason for the one-time v0.48.0 minor waiver
         required: false
         type: string
 
@@ -50,6 +55,7 @@ jobs:
       CANDIDATE_SHA: ${{ inputs.candidate_sha }}
       RELEASE_KIND: ${{ inputs.release_kind }}
       RECEIPT_URI: ${{ inputs.receipt_uri }}
+      OWNER_WAIVER_REASON: ${{ inputs.owner_waiver_reason }}
       INCIDENT: ${{ inputs.incident }}
       WHY_WAITING_IS_WORSE: ${{ inputs.why_waiting_is_worse }}
       GH_TOKEN: ${{ github.token }}
@@ -211,6 +217,7 @@ jobs:
             -candidate-sha "$CANDIDATE_SHA" \
             -release-kind "$RELEASE_KIND" \
             -receipt-uri "$RECEIPT_URI" \
+            -owner-waiver-reason "$OWNER_WAIVER_REASON" \
             -incident "$INCIDENT" \
             -why-waiting-is-worse "$WHY_WAITING_IS_WORSE" \
             -latest-tag "${{ steps.facts.outputs.latest_tag }}" \
@@ -259,6 +266,7 @@ jobs:
       CANDIDATE_SHA: ${{ inputs.candidate_sha }}
       RELEASE_KIND: ${{ inputs.release_kind }}
       RECEIPT_URI: ${{ inputs.receipt_uri }}
+      OWNER_WAIVER_REASON: ${{ inputs.owner_waiver_reason }}
       INCIDENT: ${{ inputs.incident }}
       WHY_WAITING_IS_WORSE: ${{ inputs.why_waiting_is_worse }}
       GH_TOKEN: ${{ github.token }}
@@ -409,6 +417,7 @@ jobs:
             -candidate-sha "$CANDIDATE_SHA" \
             -release-kind "$RELEASE_KIND" \
             -receipt-uri "$RECEIPT_URI" \
+            -owner-waiver-reason "$OWNER_WAIVER_REASON" \
             -incident "$INCIDENT" \
             -why-waiting-is-worse "$WHY_WAITING_IS_WORSE" \
             -latest-tag "${{ steps.facts.outputs.latest_tag }}" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-## [0.48.0] - 2026-08-06
+## [0.48.0] - 2026-07-31
 
 ### Added
 
@@ -468,6 +468,12 @@ for tags and release notes while still in `0.x`.
   stack limits continue to bound memory. Those layers measure what the parse
   itself allocated, so they stop the same input at the same place every time.
   A downstream user reported this behavior in issue #454.
+
+### Changed
+
+- v0.48.0 adds fields to `FullParseAcceptedErrorRetryProfile`, `ParseRuntime`,
+  and `DiagnosticParserCoreGenericWork`. Change unkeyed literals to keyed
+  literals before you upgrade.
 
 ### Removed
 

--- a/cmd/releasegate/main.go
+++ b/cmd/releasegate/main.go
@@ -30,6 +30,7 @@ type validationInput struct {
 	CandidateSHA       string
 	ReleaseKind        string
 	ReceiptURI         string
+	OwnerWaiverReason  string
 	Incident           string
 	WhyWaitingIsWorse  string
 	LatestTag          string
@@ -47,12 +48,14 @@ type validationInput struct {
 }
 
 type releasePolicyFacts struct {
-	Kind                  string `json:"kind"`
-	VersionIncrement      string `json:"version_increment"`
-	LosAngelesThursday    bool   `json:"los_angeles_thursday"`
-	SoakSeconds           int64  `json:"soak_seconds"`
-	IncidentPresent       bool   `json:"incident_present"`
-	DelayRationalePresent bool   `json:"delay_rationale_present"`
+	Kind                     string `json:"kind"`
+	Version                  string `json:"version"`
+	VersionIncrement         string `json:"version_increment"`
+	LosAngelesThursday       bool   `json:"los_angeles_thursday"`
+	SoakSeconds              int64  `json:"soak_seconds"`
+	OwnerWaiverReasonPresent bool   `json:"owner_waiver_reason_present"`
+	IncidentPresent          bool   `json:"incident_present"`
+	DelayRationalePresent    bool   `json:"delay_rationale_present"`
 }
 
 type evidencePolicyFacts struct {
@@ -102,6 +105,7 @@ func main() {
 	flag.StringVar(&input.CandidateSHA, "candidate-sha", "", "release candidate commit")
 	flag.StringVar(&input.ReleaseKind, "release-kind", "", "release route")
 	flag.StringVar(&input.ReceiptURI, "receipt-uri", "", "Hyphae release receipt")
+	flag.StringVar(&input.OwnerWaiverReason, "owner-waiver-reason", "", "owner reason for the one-time minor release waiver")
 	flag.StringVar(&input.Incident, "incident", "", "urgent patch incident")
 	flag.StringVar(&input.WhyWaitingIsWorse, "why-waiting-is-worse", "", "urgent patch delay rationale")
 	flag.StringVar(&input.LatestTag, "latest-tag", "", "latest stable tag")
@@ -180,12 +184,14 @@ func collectReleaseEvidence(input validationInput) (validationResult, error) {
 
 	facts := policyFacts{
 		Release: releasePolicyFacts{
-			Kind:                  input.ReleaseKind,
-			VersionIncrement:      classifyVersionIncrement(version, latest),
-			LosAngelesThursday:    localNow.Weekday() == time.Thursday,
-			SoakSeconds:           int64(actualSoak / time.Second),
-			IncidentPresent:       strings.TrimSpace(input.Incident) != "",
-			DelayRationalePresent: strings.TrimSpace(input.WhyWaitingIsWorse) != "",
+			Kind:                     input.ReleaseKind,
+			Version:                  input.Version,
+			VersionIncrement:         classifyVersionIncrement(version, latest),
+			LosAngelesThursday:       localNow.Weekday() == time.Thursday,
+			SoakSeconds:              int64(actualSoak / time.Second),
+			OwnerWaiverReasonPresent: strings.TrimSpace(input.OwnerWaiverReason) != "",
+			IncidentPresent:          strings.TrimSpace(input.Incident) != "",
+			DelayRationalePresent:    strings.TrimSpace(input.WhyWaitingIsWorse) != "",
 		},
 		Evidence: evidencePolicyFacts{
 			MainExactCandidate:      input.MainExactCandidate,
@@ -301,9 +307,12 @@ func buildSummary(
 	}
 	fmt.Fprintf(&summary, "- Soak duration: `%s`\n", actualSoak.Round(time.Second))
 	fmt.Fprintln(&summary, "- Policy facts: `policy-facts.json`")
-	if input.ReleaseKind == "urgent-patch" {
+	if input.ReleaseKind == "urgent-patch" || input.ReleaseKind == "owner-waived-minor" {
 		fmt.Fprintf(&summary, "- Incident: %s\n", strings.TrimSpace(input.Incident))
 		fmt.Fprintf(&summary, "- Delay rationale: %s\n", strings.TrimSpace(input.WhyWaitingIsWorse))
+	}
+	if input.ReleaseKind == "owner-waived-minor" {
+		fmt.Fprintf(&summary, "- Owner waiver reason: %s\n", strings.TrimSpace(input.OwnerWaiverReason))
 	}
 	return summary.String()
 }

--- a/cmd/releasegate/main_test.go
+++ b/cmd/releasegate/main_test.go
@@ -92,6 +92,74 @@ func TestUrgentPatchReasonFactsAreIndependent(t *testing.T) {
 	}
 }
 
+func TestOwnerWaivedMinorFactsCaptureRequiredInputs(t *testing.T) {
+	input := ownerWaivedMinorInput(t, time.Date(2026, 8, 1, 2, 0, 0, 0, time.UTC))
+	result := collect(t, input)
+	facts := result.PolicyFacts.Release
+	if facts.Kind != "owner-waived-minor" || facts.Version != "v0.48.0" {
+		t.Fatalf("owner waiver route facts = %+v", facts)
+	}
+	if facts.VersionIncrement != "next-minor" {
+		t.Fatalf("version increment = %q", facts.VersionIncrement)
+	}
+	if facts.LosAngelesThursday || facts.SoakSeconds >= 172800 {
+		t.Fatalf("owner waiver did not exercise the cadence exception: %+v", facts)
+	}
+	if !facts.OwnerWaiverReasonPresent || !facts.IncidentPresent || !facts.DelayRationalePresent {
+		t.Fatalf("owner waiver reason facts = %+v", facts)
+	}
+	for _, expected := range []string{input.OwnerWaiverReason, input.Incident, input.WhyWaitingIsWorse} {
+		if !strings.Contains(result.Summary, expected) {
+			t.Fatalf("summary does not contain %q:\n%s", expected, result.Summary)
+		}
+	}
+}
+
+func TestOwnerWaivedMinorReasonFactsAreIndependent(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*validationInput)
+		check  func(releasePolicyFacts) bool
+	}{
+		{
+			name: "missing owner waiver reason",
+			mutate: func(input *validationInput) {
+				input.OwnerWaiverReason = ""
+			},
+			check: func(facts releasePolicyFacts) bool {
+				return !facts.OwnerWaiverReasonPresent && facts.IncidentPresent && facts.DelayRationalePresent
+			},
+		},
+		{
+			name: "missing incident",
+			mutate: func(input *validationInput) {
+				input.Incident = ""
+			},
+			check: func(facts releasePolicyFacts) bool {
+				return facts.OwnerWaiverReasonPresent && !facts.IncidentPresent && facts.DelayRationalePresent
+			},
+		},
+		{
+			name: "missing delay rationale",
+			mutate: func(input *validationInput) {
+				input.WhyWaitingIsWorse = ""
+			},
+			check: func(facts releasePolicyFacts) bool {
+				return facts.OwnerWaiverReasonPresent && facts.IncidentPresent && !facts.DelayRationalePresent
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := ownerWaivedMinorInput(t, time.Date(2026, 8, 1, 2, 0, 0, 0, time.UTC))
+			test.mutate(&input)
+			if facts := collect(t, input).PolicyFacts.Release; !test.check(facts) {
+				t.Fatalf("unexpected owner waiver facts: %+v", facts)
+			}
+		})
+	}
+}
+
 func TestVersionIncrementFactsDoNotChooseARoute(t *testing.T) {
 	t.Run("minor increment on urgent input", func(t *testing.T) {
 		input := urgentInput(t, time.Date(2026, 7, 29, 19, 0, 0, 0, time.UTC))
@@ -369,6 +437,34 @@ func urgentInput(t *testing.T, now time.Time) validationInput {
 		Now:                now,
 	}
 	writeReleaseFiles(t, root, input.Version, localDate(t, now), input.LatestTag, "### Fixed\n\n- Urgent correction.\n")
+	return input
+}
+
+func ownerWaivedMinorInput(t *testing.T, now time.Time) validationInput {
+	t.Helper()
+	root := t.TempDir()
+	input := validationInput{
+		Version:            "v0.48.0",
+		CandidateSHA:       strings.Repeat("c", 40),
+		ReleaseKind:        "owner-waived-minor",
+		ReceiptURI:         "hypha://m31labs/gotreesitter/release/v0.48.0",
+		OwnerWaiverReason:  "The planned release was missed.",
+		Incident:           "The release was not published on its scheduled date.",
+		WhyWaitingIsWorse:  "Users need the verified release now.",
+		LatestTag:          "v0.47.0",
+		CIRunID:            "29892922471",
+		CIRunURL:           "https://github.com/odvcencio/gotreesitter/actions/runs/29892922471",
+		CIEvent:            "workflow_dispatch",
+		CISHA:              strings.Repeat("c", 40),
+		CIConclusion:       "success",
+		CICompletedAt:      now.Add(-time.Hour).Format(time.RFC3339),
+		MainExactCandidate: true,
+		TagAbsent:          true,
+		ReleaseAbsent:      true,
+		RepositoryRoot:     root,
+		Now:                now,
+	}
+	writeReleaseFiles(t, root, input.Version, localDate(t, now), input.LatestTag, "### Changed\n\n- Owner waiver route.\n")
 	return input
 }
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,6 +10,10 @@ Planned releases require a 48-hour soak after the exact commit completes the
 hosted continuous integration (CI) workflow in `ci.yml`. Keep this conservative
 rule until the project reviews a risk classifier.
 
+The one-time `owner-waived-minor` route applies only to v0.48.0. It waives the
+Thursday and soak rules. It requires an owner waiver reason, an incident, and a
+delay rationale. Remove the route after the v0.48.0 tag exists.
+
 Patch releases may happen outside the cadence for urgent correctness,
 security, or packaging regressions. Ordinary maintenance waits for the next
 Thursday. Release planning and in-progress campaign notes live in the private
@@ -33,12 +37,14 @@ the next eligible Thursday after v0.47.0.
    candidate commit hash, release route, and governing Hyphae receipt.
 6. For an urgent patch, also supply the incident and explain why waiting is
    worse. Do not use this route for ordinary maintenance.
-7. Review the verification evidence. Approve the protected `release`
+7. For the v0.48.0 waiver, supply an owner reason, incident, and delay rationale.
+   This route waives only the Thursday and soak rules.
+8. Review the verification evidence. Approve the protected `release`
    environment only when Arbiter selects `Allow`.
-8. Let the workflow repeat the mutable checks. Arbiter reevaluates the
+9. Let the workflow repeat the mutable checks. Arbiter reevaluates the
    resulting facts before the workflow creates the tag and GitHub release.
-9. Verify that the module proxy can fetch the new version.
-10. Checkpoint the version, commit hash, gate results, and any intentionally
+10. Verify that the module proxy can fetch the new version.
+11. Checkpoint the version, commit hash, gate results, and any intentionally
    deferred work in Hyphae. Close campaign issues only when the release
    contains their documented acceptance evidence.
 
@@ -56,6 +62,7 @@ The strategy denies a release when a fact does not satisfy the release receipt.
 These facts include:
 
 - the weekday;
+- the one-time waiver route and its required reasons;
 - the current `main` commit;
 - the exact manual CI run, result, and soak;
 - the document state;

--- a/policy/release.arb
+++ b/policy/release.arb
@@ -33,6 +33,14 @@ strategy ReleasePublication returns ReleaseDecision {
                 and release.incident_present
                 and release.delay_rationale_present
             )
+            or (
+                release.kind == "owner-waived-minor"
+                and release.version == "v0.48.0"
+                and release.version_increment == "next-minor"
+                and release.owner_waiver_reason_present
+                and release.incident_present
+                and release.delay_rationale_present
+            )
         )
     } then Allow {
         action: "allow",

--- a/policy/release.test.arb
+++ b/policy/release.test.arb
@@ -257,3 +257,143 @@ test "push CI event selects the deny fallback" {
     }
     expect strategy ReleasePublication selected Deny { action: "deny" }
 }
+
+test "owner-waived v0.48.0 minor passes without Thursday or soak" {
+    given {
+        release.kind: "owner-waived-minor"
+        release.version: "v0.48.0"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.owner_waiver_reason_present: true
+        release.incident_present: true
+        release.delay_rationale_present: true
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Allow { action: "allow" }
+}
+
+test "owner waiver route denies a different minor version" {
+    given {
+        release.kind: "owner-waived-minor"
+        release.version: "v0.48.1"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.owner_waiver_reason_present: true
+        release.incident_present: true
+        release.delay_rationale_present: true
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "owner waiver route denies missing waiver reason" {
+    given {
+        release.kind: "owner-waived-minor"
+        release.version: "v0.48.0"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.owner_waiver_reason_present: false
+        release.incident_present: true
+        release.delay_rationale_present: true
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "owner waiver route denies missing incident" {
+    given {
+        release.kind: "owner-waived-minor"
+        release.version: "v0.48.0"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.owner_waiver_reason_present: true
+        release.incident_present: false
+        release.delay_rationale_present: true
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}
+
+test "owner waiver route denies missing delay rationale" {
+    given {
+        release.kind: "owner-waived-minor"
+        release.version: "v0.48.0"
+        release.version_increment: "next-minor"
+        release.los_angeles_thursday: false
+        release.soak_seconds: 3600
+        release.owner_waiver_reason_present: true
+        release.incident_present: true
+        release.delay_rationale_present: false
+        evidence.main_exact_candidate: true
+        evidence.ci_exact_candidate: true
+        evidence.ci_full_dispatch: true
+        evidence.ci_successful: true
+        evidence.ci_completion_not_future: true
+        evidence.tag_absent: true
+        evidence.release_absent: true
+        evidence.receipt_valid: true
+        evidence.changelog_section_present: true
+        evidence.changelog_notes_present: true
+        evidence.changelog_date_matches: true
+        evidence.readme_matches: true
+        evidence.unreleased_link_matches: true
+        evidence.version_link_matches: true
+    }
+    expect strategy ReleasePublication selected Deny { action: "deny" }
+}


### PR DESCRIPTION
## Summary

- Add the one-time `owner-waived-minor` route for v0.48.0.
- Require an owner reason, an incident, and a delay rationale.
- Limit the route to the next v0.48.0 minor release.
- Record keyed-literal guidance for the new exported fields.
- Document removal after the public tag exists.

## Verification

- `go test ./cmd/releasegate -count=1`
- `arbiter check policy/release.arb`
- `arbiter fmt --check policy/release.arb policy/release.test.arb`
- `arbiter test policy/release.test.arb`

## Risk and follow-up

- The route waives only the Thursday and 48-hour soak requirements.
- The protected release environment still needs owner approval.
- Remove this route after the v0.48.0 tag is public.