### PR TITLE
Require signed Hyphae receipt IDs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
           - urgent-patch
           - owner-waived-minor
       receipt_uri:
-        description: Signed Hyphae receipt ID: hypha-receipt:YYYY-MM-DD:<short-id>
+        description: "Signed Hyphae receipt ID: hypha-receipt:YYYY-MM-DD:<short-id>"
         required: true
         type: string
       incident:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
           - urgent-patch
           - owner-waived-minor
       receipt_uri:
-        description: Governing Hyphae release receipt
+        description: Signed Hyphae receipt ID: hypha-receipt:YYYY-MM-DD:<short-id>
         required: true
         type: string
       incident:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
-## [0.48.0] - 2026-07-31
+## [0.48.0] - 2026-08-01
 
 ### Added
 

--- a/cmd/releasegate/main.go
+++ b/cmd/releasegate/main.go
@@ -15,8 +15,9 @@ import (
 const losAngelesZone = "America/Los_Angeles"
 
 var (
-	releaseVersionPattern = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
-	shaPattern            = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	releaseVersionPattern       = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
+	shaPattern                  = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	signedSporeReceiptIDPattern = regexp.MustCompile(`^hypha-receipt:([0-9]{4}-[0-9]{2}-[0-9]{2}):([a-z0-9][a-z0-9-]*)$`)
 )
 
 type releaseVersion struct {
@@ -180,7 +181,7 @@ func collectReleaseEvidence(input validationInput) (validationResult, error) {
 	unreleasedLink := "[Unreleased]: https://github.com/odvcencio/gotreesitter/compare/" + input.Version + "...HEAD"
 	versionLink := "[" + strings.TrimPrefix(input.Version, "v") + "]: https://github.com/odvcencio/gotreesitter/compare/" +
 		input.LatestTag + "..." + input.Version
-	receipt := strings.TrimSpace(input.ReceiptURI)
+	receiptID := strings.TrimSpace(input.ReceiptURI)
 
 	facts := policyFacts{
 		Release: releasePolicyFacts{
@@ -201,7 +202,7 @@ func collectReleaseEvidence(input validationInput) (validationResult, error) {
 			CICompletionNotFuture:   completionErr == nil && !now.Before(completedAt),
 			TagAbsent:               input.TagAbsent,
 			ReleaseAbsent:           input.ReleaseAbsent,
-			ReceiptValid:            strings.HasPrefix(receipt, "hypha://") && len(receipt) > len("hypha://"),
+			ReceiptValid:            validSignedSporeReceiptID(receiptID),
 			ChangelogSectionPresent: sectionPresent,
 			ChangelogNotesPresent:   notesPresent,
 			ChangelogDateMatches:    sectionPresent && date == localNow.Format("2006-01-02"),
@@ -247,6 +248,15 @@ func parseReleaseVersion(value string) (releaseVersion, error) {
 		return releaseVersion{}, fmt.Errorf("parse version %q: %w", value, err)
 	}
 	return version, nil
+}
+
+func validSignedSporeReceiptID(value string) bool {
+	match := signedSporeReceiptIDPattern.FindStringSubmatch(value)
+	if match == nil {
+		return false
+	}
+	_, err := time.Parse("2006-01-02", match[1])
+	return err == nil
 }
 
 func extractVersionNotes(changelog, version string) (notes, date string, sectionPresent, notesPresent bool) {

--- a/cmd/releasegate/main_test.go
+++ b/cmd/releasegate/main_test.go
@@ -257,6 +257,49 @@ func TestMutableGitHubFactsReachThePolicy(t *testing.T) {
 	}
 }
 
+func TestReceiptFactRequiresASignedSporeReceiptID(t *testing.T) {
+	tests := []struct {
+		name    string
+		receipt string
+		want    bool
+	}{
+		{
+			name:    "signed spore receipt",
+			receipt: "hypha-receipt:2026-08-01:v048-release",
+			want:    true,
+		},
+		{
+			name:    "legacy Hyphae URI",
+			receipt: "hypha://m31labs/gotreesitter/release/v0.48.0",
+			want:    false,
+		},
+		{
+			name:    "invalid receipt date",
+			receipt: "hypha-receipt:2026-02-30:v048-release",
+			want:    false,
+		},
+		{
+			name:    "missing short ID",
+			receipt: "hypha-receipt:2026-08-01:",
+			want:    false,
+		},
+		{
+			name:    "non-spore receipt",
+			receipt: "hypha-receipt:graft:2026-08-01:7f3a",
+			want:    false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := plannedInput(t, time.Date(2026, 7, 31, 2, 0, 0, 0, time.UTC))
+			input.ReceiptURI = test.receipt
+			if got := collect(t, input).PolicyFacts.Evidence.ReceiptValid; got != test.want {
+				t.Fatalf("receipt valid = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestReleaseDocumentFacts(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -395,7 +438,7 @@ func plannedInput(t *testing.T, now time.Time) validationInput {
 		Version:            "v0.48.0",
 		CandidateSHA:       strings.Repeat("a", 40),
 		ReleaseKind:        "planned-minor",
-		ReceiptURI:         "hypha://m31labs/gotreesitter/release/v0.48.0",
+		ReceiptURI:         "hypha-receipt:2026-08-01:v048-release",
 		LatestTag:          "v0.47.0",
 		CIRunID:            "29892922471",
 		CIRunURL:           "https://github.com/odvcencio/gotreesitter/actions/runs/29892922471",
@@ -420,7 +463,7 @@ func urgentInput(t *testing.T, now time.Time) validationInput {
 		Version:            "v0.47.1",
 		CandidateSHA:       strings.Repeat("b", 40),
 		ReleaseKind:        "urgent-patch",
-		ReceiptURI:         "hypha://m31labs/gotreesitter/release/v0.47.1",
+		ReceiptURI:         "hypha-receipt:2026-07-29:v0471-patch",
 		Incident:           "The parser returns a wrong tree.",
 		WhyWaitingIsWorse:  "Users receive incorrect parse results.",
 		LatestTag:          "v0.47.0",
@@ -447,7 +490,7 @@ func ownerWaivedMinorInput(t *testing.T, now time.Time) validationInput {
 		Version:            "v0.48.0",
 		CandidateSHA:       strings.Repeat("c", 40),
 		ReleaseKind:        "owner-waived-minor",
-		ReceiptURI:         "hypha://m31labs/gotreesitter/release/v0.48.0",
+		ReceiptURI:         "hypha-receipt:2026-08-01:v048-release",
 		OwnerWaiverReason:  "The planned release was missed.",
 		Incident:           "The release was not published on its scheduled date.",
 		WhyWaitingIsWorse:  "Users need the verified release now.",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,7 +34,7 @@ the next eligible Thursday after v0.47.0.
 4. Wait at least 48 hours after hosted CI completes for a planned minor
    release. Record the actual soak for an urgent patch.
 5. Dispatch the manual `release.yml` workflow from `main`. Supply the version,
-   candidate commit hash, release route, and governing Hyphae receipt.
+   candidate commit hash, release route, and signed Hyphae receipt ID.
 6. For an urgent patch, also supply the incident and explain why waiting is
    worse. Do not use this route for ordinary maintenance.
 7. For the v0.48.0 waiver, supply an owner reason, incident, and delay rationale.
@@ -50,6 +50,10 @@ the next eligible Thursday after v0.47.0.
 
 Tags are immutable. If a release is wrong, preserve its tag and publish a
 follow-up version.
+
+Keep the `receipt_uri` input name for workflow dispatch compatibility. Supply a
+signed Hyphae receipt ID, not a `hypha://` URI. Use
+`hypha-receipt:YYYY-MM-DD:<short-id>`.
 
 The workflow has no schedule. The Go evidence collector writes deterministic
 facts to `policy-facts.json`. It does not choose the release route.


### PR DESCRIPTION
## Summary

- Require the signed Hyphae spore receipt ID format.
- Reject Hyphae space URIs and non-spore receipts.
- Correct the v0.48.0 release date to 2026-08-01.

## Verification

- `actionlint .github/workflows/release.yml`
- `go test ./cmd/releasegate -count=1`