### PR TITLE
Validate normalization ownership evidence

### DIFF
--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -15,16 +15,22 @@ import (
 	"testing"
 )
 
-const resultCompatOwnershipRegistryPath = "testdata/result_compat_ownership_v1.json"
+const (
+	resultCompatOwnershipRegistryPath        = "testdata/result_compat_ownership_v1.json"
+	resultCompatDispatcherCensusEvidencePath = "parser_result_test/dispatcher_census_test.go"
+	resultCompatCOracleEvidencePath          = "cgo_harness/parity_cgo_test.go"
+	resultCompatBaselineEvidenceScope        = "baseline_corpus_wide_only"
+)
 
 var resultCompatRetiredCommitPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
 type resultCompatOwnershipRegistry struct {
-	Schema          string                       `json:"schema"`
-	SourceOfTruth   bool                         `json:"source_of_truth"`
-	Denominator     resultCompatDenominator      `json:"denominator"`
-	OwnerCategories []string                     `json:"owner_categories"`
-	Entries         []resultCompatOwnershipEntry `json:"entries"`
+	Schema               string                           `json:"schema"`
+	SourceOfTruth        bool                             `json:"source_of_truth"`
+	Denominator          resultCompatDenominator          `json:"denominator"`
+	LiveEvidenceBaseline resultCompatLiveEvidenceBaseline `json:"live_evidence_baseline"`
+	OwnerCategories      []string                         `json:"owner_categories"`
+	Entries              []resultCompatOwnershipEntry     `json:"entries"`
 }
 
 type resultCompatDenominator struct {
@@ -34,6 +40,8 @@ type resultCompatDenominator struct {
 	GenericPasses             int `json:"generic_passes"`
 	PostFinalizationArms      int `json:"post_finalization_arms"`
 	PostFinalizationLanguages int `json:"post_finalization_languages"`
+	LiveEntries               int `json:"live_entries"`
+	RetiredEntries            int `json:"retired_entries"`
 }
 
 type resultCompatOwnershipEntry struct {
@@ -52,8 +60,20 @@ type resultCompatOwnershipEntry struct {
 	RetirementCondition string                    `json:"retirement_condition"`
 	RouteCoverage       resultCompatRouteCoverage `json:"route_coverage"`
 	Status              string                    `json:"status"`
+	EvidenceScope       string                    `json:"evidence_scope,omitempty"`
 	ReceiptRefs         []string                  `json:"receipt_refs,omitempty"`
 	RetiredCommit       string                    `json:"retired_commit,omitempty"`
+}
+
+type resultCompatLiveEvidenceBaseline struct {
+	Scope       string                       `json:"scope"`
+	Sources     []resultCompatBaselineSource `json:"sources"`
+	Limitations []string                     `json:"limitations"`
+}
+
+type resultCompatBaselineSource struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
 }
 
 type resultCompatSubpass struct {
@@ -80,6 +100,7 @@ type resultCompatRouteCoverage struct {
 
 func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 	registry := loadResultCompatOwnershipRegistry(t)
+	assertLiveOwnershipEvidenceBaseline(t, registry.LiveEvidenceBaseline)
 
 	allowedOwners := map[string]bool{
 		"scheduler_action_semantics":    true,
@@ -95,6 +116,8 @@ func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 
 	entriesByKind := make(map[string][]resultCompatOwnershipEntry)
 	seenIDs := make(map[string]bool)
+	liveEntries := 0
+	retiredEntries := 0
 	allowedKinds := map[string]bool{
 		"dispatcher_arm":       true,
 		"dispatcher_predicate": true,
@@ -124,16 +147,20 @@ func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 		assertOwnershipStatusAndRoutes(t, entry)
 		switch entry.Status {
 		case "live":
+			liveEntries++
 			if len(entry.Functions) == 0 {
 				t.Errorf("%s is live but has no functions", entry.ID)
 			}
+			assertLiveOwnershipEvidenceScope(t, entry, registry.LiveEvidenceBaseline)
 		case "retired":
+			retiredEntries++
 			if !resultCompatRetiredCommitPattern.MatchString(entry.RetiredCommit) {
 				t.Errorf("%s retired_commit = %q, want a lowercase 40-character commit hash", entry.ID, entry.RetiredCommit)
 			}
-			if len(entry.ReceiptRefs) == 0 {
-				t.Errorf("%s is retired but lacks receipt_refs", entry.ID)
+			if entry.EvidenceScope != "" {
+				t.Errorf("%s retired entry has live evidence_scope %q", entry.ID, entry.EvidenceScope)
 			}
+			assertRetiredOwnershipReceiptRefs(t, entry)
 		default:
 			t.Errorf("%s has unsupported status %q", entry.ID, entry.Status)
 		}
@@ -152,10 +179,114 @@ func TestResultCompatibilityOwnershipRegistry(t *testing.T) {
 			entriesByKind[entry.Kind] = append(entriesByKind[entry.Kind], entry)
 		}
 	}
+	if got, want := liveEntries, registry.Denominator.LiveEntries; got != want {
+		t.Errorf("live registry entries = %d, frozen denominator = %d", got, want)
+	}
+	if got, want := retiredEntries, registry.Denominator.RetiredEntries; got != want {
+		t.Errorf("retired registry entries = %d, frozen denominator = %d", got, want)
+	}
 
 	assertDispatcherRegistry(t, registry.Denominator, entriesByKind)
 	assertGenericPassRegistry(t, registry.Denominator, entriesByKind)
 	assertPostFinalizationRegistry(t, registry.Denominator, entriesByKind)
+}
+
+func assertRetiredOwnershipReceiptRefs(t *testing.T, entry resultCompatOwnershipEntry) {
+	t.Helper()
+	assertOwnershipEvidencePaths(t, entry.ID+" retirement receipt_refs", entry.ReceiptRefs)
+}
+
+func assertOwnershipEvidencePaths(t *testing.T, label string, paths []string) {
+	t.Helper()
+	if len(paths) == 0 {
+		t.Errorf("%s lacks evidence paths", label)
+		return
+	}
+	if ownershipHasDuplicateStrings(paths) {
+		t.Errorf("%s paths must be a duplicate-free set: %v", label, paths)
+	}
+	for _, path := range paths {
+		clean := filepath.Clean(path)
+		if filepath.IsAbs(clean) || clean == "." || clean == ".." ||
+			strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			t.Errorf("%s contains unsafe path %q", label, path)
+			continue
+		}
+		info, err := os.Stat(clean)
+		if err != nil {
+			t.Errorf("%s references missing path %q: %v", label, path, err)
+			continue
+		}
+		if info.IsDir() {
+			t.Errorf("%s path %q is a directory", label, path)
+		}
+	}
+}
+
+func assertLiveOwnershipEvidenceBaseline(t *testing.T, baseline resultCompatLiveEvidenceBaseline) {
+	t.Helper()
+	if baseline.Scope != resultCompatBaselineEvidenceScope {
+		t.Errorf("live_evidence_baseline scope = %q, want %q", baseline.Scope, resultCompatBaselineEvidenceScope)
+	}
+	wantSources := map[string]string{
+		resultCompatDispatcherCensusEvidencePath: "dispatcher_census",
+		resultCompatCOracleEvidencePath:          "c_oracle_structural_parity",
+	}
+	paths := make([]string, 0, len(baseline.Sources))
+	seen := make(map[string]bool, len(baseline.Sources))
+	for _, source := range baseline.Sources {
+		paths = append(paths, source.Path)
+		wantKind, known := wantSources[source.Path]
+		if !known {
+			t.Errorf("live_evidence_baseline has unknown source %q", source.Path)
+			continue
+		}
+		if seen[source.Path] {
+			t.Errorf("live_evidence_baseline repeats source %q", source.Path)
+		}
+		seen[source.Path] = true
+		if source.Kind != wantKind {
+			t.Errorf("live_evidence_baseline source %q kind = %q, want %q", source.Path, source.Kind, wantKind)
+		}
+	}
+	if got, want := len(baseline.Sources), len(wantSources); got != want {
+		t.Errorf("live_evidence_baseline sources = %d, want %d", got, want)
+	}
+	for path := range wantSources {
+		if !seen[path] {
+			t.Errorf("live_evidence_baseline lacks source %q", path)
+		}
+	}
+	assertOwnershipEvidencePaths(t, "live_evidence_baseline sources", paths)
+
+	wantLimitations := []string{
+		"no_compact_coverage_floor",
+		"no_exact_field_parity",
+		"no_exact_per_record_parity",
+		"no_exact_point_parity",
+		"no_forest_coverage_floor",
+		"no_incremental_coverage_floor",
+	}
+	if ownershipHasDuplicateStrings(baseline.Limitations) {
+		t.Errorf("live_evidence_baseline limitations must be a duplicate-free set: %v", baseline.Limitations)
+	}
+	if got := sortedStrings(baseline.Limitations); !equalStrings(got, wantLimitations) {
+		t.Errorf("live_evidence_baseline limitations = %v, want %v", got, wantLimitations)
+	}
+}
+
+func assertLiveOwnershipEvidenceScope(
+	t *testing.T,
+	entry resultCompatOwnershipEntry,
+	baseline resultCompatLiveEvidenceBaseline,
+) {
+	t.Helper()
+	if entry.EvidenceScope != baseline.Scope {
+		t.Errorf("%s live evidence_scope = %q, want %q", entry.ID, entry.EvidenceScope, baseline.Scope)
+	}
+	if len(entry.ReceiptRefs) != 0 {
+		t.Errorf("%s live entry declares retirement receipt_refs %v", entry.ID, entry.ReceiptRefs)
+	}
 }
 
 func assertRegistrySubpasses(

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -7,7 +7,30 @@
     "dispatcher_predicates": 1,
     "generic_passes": 0,
     "post_finalization_arms": 0,
-    "post_finalization_languages": 0
+    "post_finalization_languages": 0,
+    "live_entries": 41,
+    "retired_entries": 42
+  },
+  "live_evidence_baseline": {
+    "scope": "baseline_corpus_wide_only",
+    "sources": [
+      {
+        "path": "parser_result_test/dispatcher_census_test.go",
+        "kind": "dispatcher_census"
+      },
+      {
+        "path": "cgo_harness/parity_cgo_test.go",
+        "kind": "c_oracle_structural_parity"
+      }
+    ],
+    "limitations": [
+      "no_compact_coverage_floor",
+      "no_exact_field_parity",
+      "no_exact_per_record_parity",
+      "no_exact_point_parity",
+      "no_forest_coverage_floor",
+      "no_incremental_coverage_floor"
+    ]
   },
   "owner_categories": [
     "scheduler_action_semantics",
@@ -89,7 +112,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.angular",
@@ -166,7 +189,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.authzed",
@@ -194,7 +217,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.awk",
@@ -222,7 +245,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.bibtex",
@@ -328,7 +351,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.bitbake",
@@ -356,7 +379,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.chatito",
@@ -451,7 +474,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.c_sharp",
@@ -479,7 +502,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.shared_trailing_span",
@@ -565,7 +588,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.corn",
@@ -593,7 +616,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.crystal",
@@ -760,7 +783,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.doxygen",
@@ -788,7 +811,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.jsdoc",
@@ -816,7 +839,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.dtd",
@@ -844,7 +867,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.elixir",
@@ -872,7 +895,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.enforce",
@@ -900,7 +923,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.ebnf",
@@ -1094,7 +1117,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.go",
@@ -1122,7 +1145,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.gitcommit",
@@ -1359,7 +1382,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.hyprlang",
@@ -1387,7 +1410,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.ini",
@@ -1448,7 +1471,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.julia",
@@ -1476,7 +1499,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.just",
@@ -1537,7 +1560,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.kotlin",
@@ -1565,7 +1588,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.lua",
@@ -1764,7 +1787,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.ocaml",
@@ -1862,7 +1885,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.php",
@@ -1890,7 +1913,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.powershell",
@@ -1921,7 +1944,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.ql",
@@ -1949,7 +1972,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.r",
@@ -2014,7 +2037,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.robot",
@@ -2075,7 +2098,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.ruby",
@@ -2141,7 +2164,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.scheme",
@@ -2203,7 +2226,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.sql",
@@ -2233,7 +2256,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.squirrel",
@@ -2296,7 +2319,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.templ",
@@ -2324,7 +2347,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.wgsl",
@@ -2352,7 +2375,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.wolfram",
@@ -2380,7 +2403,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.typescript",
@@ -2409,7 +2432,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.typst",
@@ -2470,7 +2493,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "dispatch.zig",
@@ -2534,7 +2557,7 @@
         "c_oracle": "curated_single_grammar_parity"
       },
       "status": "live",
-      "receipt_refs": []
+      "evidence_scope": "baseline_corpus_wide_only"
     },
     {
       "id": "generic.trailing-extra-trivia",


### PR DESCRIPTION
## Summary

- Freeze 41 live and 42 retired normalization records.
- Mark live records as baseline-corpus-only evidence.
- Validate sources, limits, paths, counts, and retired receipt references.

## Verification

- `bash cgo_harness/docker/run_parity_in_docker.sh -- "cd /workspace && go test . -run '^TestResultCompatibilityOwnershipRegistry$' -count=1"`\n- Narrow Canopy symbol and reference queries with `--no-cache`.\n- `jq -e` schema and coverage assertions.\n- `git diff --check`\n\n## Scope\n\nThis change does not claim per-record exact parity. It does not add compact, field, point, forest, or incremental evidence gates.