### PR TITLE
Fix arena retention test isolation

### DIFF
--- a/benchmark_warm_reuse_test.go
+++ b/benchmark_warm_reuse_test.go
@@ -121,6 +121,10 @@ func BenchmarkSelfParseWarmReuse(b *testing.B) {
 func TestArenaGCRetentionAfterRelease(t *testing.T) {
 	gotreesitter.DrainArenaPools()
 	t.Cleanup(gotreesitter.DrainArenaPools)
+	// Earlier tests can retain decoded grammar blobs in the package cache.
+	// Those blobs do not belong to this arena test. Purge the cache before the
+	// baseline so the limit measures this parse lifecycle.
+	grammars.PurgeEmbeddedLanguageCache()
 	src, err := os.ReadFile("parser_test.go")
 	if err != nil {
 		t.Fatalf("read parser_test.go: %v", err)


### PR DESCRIPTION
## Summary

- Purge decoded grammar blobs before the arena test reads its heap baseline.
- Keep the existing 60 MiB memory limit.

## Root cause

Earlier tests retained decoded grammar blobs in the embedded-language cache.
The absolute heap check counted that unrelated state.
The heap profile did not show a retained arena slab from this test.

## Validation

- `TestArenaGCRetentionAfterRelease` in the Go 1.25 Docker harness.
- The exact 1,780-test CI-order prefix in the same Docker harness.