### PR TITLE
fix(parser): Preserve projected hidden fields

### DIFF
--- a/cgo_harness/parity_swift_field_projection_regression_test.go
+++ b/cgo_harness/parity_swift_field_projection_regression_test.go
@@ -1,0 +1,184 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/internal/benchfixtures"
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// TestParitySwiftHiddenFieldProjectionDeepDigest keeps the full structural
+// contract for field projection through hidden Swift grammar symbols. The
+// deep digest includes field names and byte and point ranges.
+func TestParitySwiftHiddenFieldProjectionDeepDigest(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		wantError bool
+	}{
+		{
+			name:   "clean-parameter",
+			source: "func f(_ value: Int) {}\n",
+		},
+		{
+			name:   "clean-associatedtype",
+			source: "protocol P {\n  associatedtype Stride: SignedNumeric\n}\n",
+		},
+		{
+			name:      "issue-577-lifetime-attribute",
+			source:    "struct S {\n  @lifetime(copy value)\n  public init(_ value: Int) {}\n}\n",
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := []byte(test.source)
+			goTree, goLang, err := parseWithGo(parityCase{name: "swift", source: test.source}, source, nil)
+			if err != nil {
+				t.Fatalf("parse Swift with Go: %v", err)
+			}
+			defer releaseGoTree(goTree)
+
+			cLang, err := ParityCLanguage("swift")
+			if err != nil {
+				t.Fatalf("load locked Swift C parser: %v", err)
+			}
+			cParser := sitter.NewParser()
+			defer cParser.Close()
+			if err := cParser.SetLanguage(cLang); err != nil {
+				t.Fatalf("set locked Swift C parser language: %v", err)
+			}
+			cTree := cParser.Parse(source, nil)
+			if cTree == nil || cTree.RootNode() == nil {
+				t.Fatal("locked Swift C parser returned no tree")
+			}
+			defer cTree.Close()
+
+			goRoot := goTree.RootNode()
+			cRoot := cTree.RootNode()
+			if got, want := goRoot.HasError(), cRoot.HasError(); got != want {
+				t.Fatalf("HasError() Go=%v C=%v", got, want)
+			}
+			if got := cRoot.HasError(); got != test.wantError {
+				t.Fatalf("locked C HasError()=%v, want %v", got, test.wantError)
+			}
+
+			goInspection, err := benchfixtures.InspectGoTree(goRoot, goLang)
+			if err != nil {
+				t.Fatalf("inspect Go gts-deep-tree-v1 tree: %v", err)
+			}
+			cDigest, err := COracleDeepDigest(cTree)
+			if err != nil {
+				t.Fatalf("inspect locked C gts-deep-tree-v1 tree: %v", err)
+			}
+			if goInspection.SHA256 == cDigest {
+				return
+			}
+
+			diff := FirstDivergenceDumpV1(goRoot, goLang, cRoot)
+			t.Fatalf("gts-deep-tree-v1 digest Go=%s C=%s first_difference=%+v", goInspection.SHA256, cDigest, diff)
+		})
+	}
+}
+
+// TestParitySwiftAssociatedtypeFieldProjectionAfterRecovery checks the #578
+// field label. A separate repair must correct its ERROR range.
+func TestParitySwiftAssociatedtypeFieldProjectionAfterRecovery(t *testing.T) {
+	const sourceText = "protocol P {\n  associatedtype Stride: SignedNumeric, Comparable\n}\n"
+	source := []byte(sourceText)
+	typeStart := strings.Index(sourceText, "SignedNumeric")
+	if typeStart < 0 {
+		t.Fatal("find SignedNumeric in Swift source")
+	}
+
+	goTree, goLang, err := parseWithGo(parityCase{name: "swift", source: sourceText}, source, nil)
+	if err != nil {
+		t.Fatalf("parse Swift with Go: %v", err)
+	}
+	defer releaseGoTree(goTree)
+
+	cLang, err := ParityCLanguage("swift")
+	if err != nil {
+		t.Fatalf("load locked Swift C parser: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set locked Swift C parser language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("locked Swift C parser returned no tree")
+	}
+	defer cTree.Close()
+
+	goRoot := goTree.RootNode()
+	cRoot := cTree.RootNode()
+	if got, want := goRoot.HasError(), cRoot.HasError(); got != want {
+		t.Fatalf("HasError() Go=%v C=%v", got, want)
+	}
+	if !cRoot.HasError() {
+		t.Fatal("locked Swift C parser did not report the expected recovery error")
+	}
+
+	goField, ok := swiftGoIncomingFieldAt(goRoot, goLang, "user_type", uint32(typeStart))
+	if !ok {
+		t.Fatal("Go Swift tree has no user_type for SignedNumeric")
+	}
+	cField, ok := swiftCIncomingFieldAt(cRoot, "user_type", uint32(typeStart))
+	if !ok {
+		t.Fatal("locked Swift C tree has no user_type for SignedNumeric")
+	}
+	if got, want := goField, "name"; got != want {
+		t.Fatalf("Go incoming field for SignedNumeric = %q, want %q", got, want)
+	}
+	if got, want := cField, "name"; got != want {
+		t.Fatalf("locked C incoming field for SignedNumeric = %q, want %q", got, want)
+	}
+	if goField != cField {
+		t.Fatalf("incoming field for SignedNumeric Go=%q C=%q", goField, cField)
+	}
+}
+
+func swiftGoIncomingFieldAt(node *gotreesitter.Node, lang *gotreesitter.Language, typ string, startByte uint32) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	for i := 0; i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child == nil {
+			continue
+		}
+		if child.Type(lang) == typ && child.StartByte() == startByte {
+			return node.FieldNameForChild(i, lang), true
+		}
+		if field, ok := swiftGoIncomingFieldAt(child, lang, typ, startByte); ok {
+			return field, true
+		}
+	}
+	return "", false
+}
+
+func swiftCIncomingFieldAt(node *sitter.Node, typ string, startByte uint32) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		child := node.Child(uint(i))
+		if child == nil {
+			continue
+		}
+		if child.Kind() == typ && uint32(child.StartByte()) == startByte {
+			return node.FieldNameForChild(uint32(i)), true
+		}
+		if field, ok := swiftCIncomingFieldAt(child, typ, startByte); ok {
+			return field, true
+		}
+	}
+	return "", false
+}

--- a/parser_reduce.go
+++ b/parser_reduce.go
@@ -5793,6 +5793,9 @@ const (
 	fieldSourceDeferredDirect
 	fieldSourceDeferredInherited
 	fieldSourceDeferredInheritedLater
+	// A projected direct field keeps its hidden-parent provenance until the
+	// visible reduction resolves competing parent fields.
+	fieldSourceProjectedDirect
 )
 
 func deferredFieldSource(inherited, appearsLater bool) uint8 {
@@ -5819,7 +5822,9 @@ func decodeDeferredFieldSource(source uint8) (inherited, appearsLater, ok bool) 
 }
 
 func fieldSourceIsDirect(source uint8) bool {
-	return source == fieldSourceDirect || source == fieldSourceDeferredDirect
+	return source == fieldSourceDirect ||
+		source == fieldSourceDeferredDirect ||
+		source == fieldSourceProjectedDirect
 }
 
 func fieldSourceAt(fieldSources []uint8, i int) uint8 {
@@ -6082,7 +6087,7 @@ func appendFlattenedHiddenChildrenWithFieldScratch(scratch *reduceBuildScratch, 
 			source = fieldSourceDirect
 		}
 		applyFieldToFlattenedSpan(scratch.nodes, scratch.fieldIDs, scratch.fieldSources, spanStart, spanEnd, fieldIDs[i], source, false)
-		if source == fieldSourceDirect {
+		if fieldSourceIsDirect(source) {
 			scratch.recordRepeatedField(repeatEpoch, fieldIDs[i], source)
 		}
 	}
@@ -6270,6 +6275,9 @@ func (p *Parser) buildReduceChildrenWithPath(entries []stackEntry, start, end, c
 	p.appendReduceChildrenToScratch(scratch, entries, start, end, productionID, aliasSeq, rawFieldIDs, rawInherited, rawConflictedInherited, parentVisible, symbolMeta, arena, lang)
 	if scratch.trackFields {
 		p.suppressReducedChildFields(scratch.nodes, scratch.fieldIDs, scratch.fieldSources)
+		if parentVisible {
+			normalizeProjectedDirectFieldSources(scratch.fieldSources)
+		}
 	}
 	if perfCountersEnabled {
 		perfRecordReduceScratchGeneral(len(scratch.nodes))
@@ -6676,11 +6684,20 @@ func resolveDeferredParentField(children []*Node, fieldIDs []FieldID, fieldSourc
 	if !deferred {
 		return false, false
 	}
+	if !inherited {
+		applyDeferredDirectFieldToFlattenedSpan(children, fieldIDs, fieldSources, spanStart, fieldEnd, fid)
+		return true, true
+	}
 	applyParentFieldToFlattenedHiddenSpan(
 		children, fieldIDs, fieldSources, hiddenParent,
 		spanStart, fieldEnd, fid, inherited, appearsLater,
 	)
-	return !inherited, true
+	return false, true
+}
+
+func applyDeferredDirectFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID) {
+	applyFieldToFlattenedSpan(children, fieldIDs, fieldSources, start, end, fid, fieldSourceProjectedDirect, true)
+	normalizeMixedSourceFieldSpan(fieldIDs, fieldSources, start, end)
 }
 
 func fieldSourceForInheritance(inherited bool) uint8 {
@@ -6827,7 +6844,7 @@ func appendFlattenedHiddenChildrenWithFields(dst []*Node, fieldDst []FieldID, fi
 				source = fieldSourceDirect
 			}
 			applyFieldToFlattenedSpan(dst, fieldDst, fieldSrcDst, spanStart, out, fieldIDs[i], source, false)
-			if source == fieldSourceDirect && spanStart < out {
+			if fieldSourceIsDirect(source) && spanStart < out {
 				if repeated == nil {
 					repeated = make(map[FieldID]hiddenFieldSpan)
 				}
@@ -6944,7 +6961,7 @@ func normalizeMixedSourceFieldSpan(fieldIDs []FieldID, fieldSources []uint8, sta
 			continue
 		}
 		source := fieldSourceAt(fieldSources, i)
-		if source != fieldSourceDirect && source != fieldSourceInherited {
+		if !fieldSourceIsDirect(source) && source != fieldSourceInherited {
 			continue
 		}
 		idx := -1
@@ -6965,14 +6982,14 @@ func normalizeMixedSourceFieldSpan(fieldIDs []FieldID, fieldSources []uint8, sta
 			idx = len(spans) - 1
 		}
 		span := &spans[idx].span
-		switch source {
-		case fieldSourceDirect:
+		switch {
+		case fieldSourceIsDirect(source):
 			if !span.hasDirect {
 				span.firstDirect = i
 			}
 			span.lastDirect = i
 			span.hasDirect = true
-		case fieldSourceInherited:
+		case source == fieldSourceInherited:
 			span.hasInherited = true
 		}
 	}
@@ -6994,6 +7011,14 @@ func normalizeMixedSourceFieldSpan(fieldIDs []FieldID, fieldSources []uint8, sta
 	}
 }
 
+func normalizeProjectedDirectFieldSources(fieldSources []uint8) {
+	for i, source := range fieldSources {
+		if source == fieldSourceProjectedDirect {
+			fieldSources[i] = fieldSourceDirect
+		}
+	}
+}
+
 func applyFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID, source uint8, preferNamed bool) {
 	if fid == 0 || fieldIDs == nil || start >= end {
 		return
@@ -7001,11 +7026,11 @@ func applyFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSource
 	inherited := source == fieldSourceInherited
 	conflictCount, multipleKinds := flattenedSpanConflictSummary(children, fieldIDs, start, end, fid)
 	if !multipleKinds && conflictCount >= 2 {
-		assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, inherited, false, false)
+		assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, false, false)
 		return
 	}
 	if !multipleKinds && conflictCount == 1 && preferNamed {
-		if assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, inherited, true, true) {
+		if assignFieldToFlattenedSpanTargets(children, fieldIDs, fieldSources, start, end, fid, source, true, true) {
 			return
 		}
 	}
@@ -7017,20 +7042,22 @@ func applyFieldToFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSource
 			return
 		}
 	}
-	if source == fieldSourceDirect {
+	if fieldSourceIsDirect(source) {
 		applyDirectFieldToUnassignedFlattenedSpan(children, fieldIDs, fieldSources, start, end, fid, source, preferNamed)
 		return
 	}
 	assignFirstInheritedFieldToFlattenedSpan(children, fieldIDs, fieldSources, start, end, fid, source, preferNamed, inherited)
 }
 
-func assignFieldToFlattenedSpanTargets(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID, source uint8, inherited, requireNamed, firstOnly bool) bool {
+func assignFieldToFlattenedSpanTargets(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID, source uint8, requireNamed, firstOnly bool) bool {
 	assigned := false
 	for j := start; j < end; j++ {
 		if !flattenedFieldTargetEligible(children[j], requireNamed) {
 			continue
 		}
-		if inherited && fieldIDs[j] != 0 && fieldIDs[j] != fid && fieldSourceAt(fieldSources, j) == fieldSourceDirect {
+		existingSource := fieldSourceAt(fieldSources, j)
+		if fieldIDs[j] != 0 && fieldIDs[j] != fid &&
+			fieldAssignmentKeepsExistingDirect(source, existingSource) {
 			continue
 		}
 		assignFlattenedField(fieldIDs, fieldSources, j, fid, source)
@@ -7040,6 +7067,16 @@ func assignFieldToFlattenedSpanTargets(children []*Node, fieldIDs []FieldID, fie
 		}
 	}
 	return assigned
+}
+
+func fieldAssignmentKeepsExistingDirect(incomingSource, existingSource uint8) bool {
+	if !fieldSourceIsDirect(existingSource) {
+		return false
+	}
+	if incomingSource == fieldSourceInherited || incomingSource == fieldSourceProjectedDirect {
+		return true
+	}
+	return existingSource == fieldSourceProjectedDirect
 }
 
 func applyDirectFieldToUnassignedFlattenedSpan(children []*Node, fieldIDs []FieldID, fieldSources []uint8, start, end int, fid FieldID, source uint8, preferNamed bool) {

--- a/parser_reduce_fields_test.go
+++ b/parser_reduce_fields_test.go
@@ -497,6 +497,46 @@ func TestBuildReduceChildrenDirectFieldOverridesSingleIndirectNamedChild(t *test
 	}
 }
 
+func TestBuildReduceChildrenDirectFieldKeepsInnerHiddenProjection(t *testing.T) {
+	lang := &Language{
+		SymbolNames: []string{"EOF", "_inner", "type_identifier", "user_type", "visible_parent"},
+		SymbolMetadata: []SymbolMetadata{
+			{Name: "EOF", Visible: false, Named: false},
+			{Name: "_inner", Visible: false, Named: false},
+			{Name: "type_identifier", Visible: true, Named: true},
+			{Name: "user_type", Visible: true, Named: true},
+			{Name: "visible_parent", Visible: true, Named: true},
+		},
+		FieldNames: []string{"", "name", "type"},
+		FieldMapSlices: [][2]uint16{
+			{0, 1},
+		},
+		FieldMapEntries: []FieldMapEntry{
+			{FieldID: 2, ChildIndex: 0, Inherited: false},
+		},
+	}
+
+	parser := NewParser(lang)
+	arena := newNodeArena(arenaClassFull)
+	typeIdentifier := newLeafNodeInArena(arena, 2, true, 0, 3, Point{}, Point{Column: 3})
+	userType := newParentNodeInArena(arena, 3, true, []*Node{typeIdentifier}, nil, 0)
+	inner := newParentNodeInArena(arena, 1, false, []*Node{userType}, []FieldID{1}, 0)
+	inner.setFieldSources([]uint8{fieldSourceDeferredDirect})
+
+	children, fieldIDs, fieldSources := parser.buildReduceChildren(
+		[]stackEntry{newStackEntryNode(0, inner)}, 0, 1, 1, 4, 0, arena,
+	)
+	if got, want := len(children), 1; got != want {
+		t.Fatalf("len(children) = %d, want %d", got, want)
+	}
+	if got, want := fieldIDs[0], FieldID(1); got != want {
+		t.Fatalf("fieldIDs[0] = %d, want %d", got, want)
+	}
+	if got, want := fieldSourceAt(fieldSources, 0), uint8(fieldSourceDirect); got != want {
+		t.Fatalf("fieldSources[0] = %d, want %d", got, want)
+	}
+}
+
 func TestBuildReduceChildrenInheritedFieldDoesNotBlanketSpanWithoutConflict(t *testing.T) {
 	lang := &Language{
 		SymbolNames: []string{"EOF", "_hidden_inner", "identifier", ".", "namespace_wildcard", "visible_parent"},


### PR DESCRIPTION
## Summary

- Preserve direct-field provenance through hidden reductions.
- Match locked C field labels for Swift parameters and associated types.
- Add exact C digest checks for clean Swift and #577.
- Add a recovered-field check for #578.

## Scope

This PR does not fix the #578 ERROR range.
A separate recovery repair must correct that range.

## Validation

- `go test . -run "^TestBuild(FieldIDs|ReduceChildren)" -count=1`
- Docker locked-C Swift field digest suite.
- Docker Swift fresh and incremental parity with field comparison.