### PR TITLE
document(parsercorephase0): Document parsercorephase0 as admitted parser core

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1,16 +1,20 @@
-// Package parsercorephase0 contains a diagnostic-only parser-core prototype.
+// Package parsercorephase0 contains the admitted compact parser core.
 //
-// It deliberately is not imported by the production parser. The prototype
-// consumes a dependency-neutral TableView, but it does not own a lexer, an
-// external-scanner election, recovery, retries, included ranges, or
-// incremental parsing. A future build-tagged diagnostic driver in the root
-// package may adapt canonical production tables while independently scheduling
-// against the exact root lexer/scanner election; the ordinary production
-// parser does not import this package. Differential replay is debugging
-// evidence, not the execution route. Exact scanner/election integration remains
-// required before any full-parse timing claim. Callers must treat a decline as
-// a request to use the production parser; this package never silently
-// substitutes partial work.
+// The root package routes every fresh full parse of a source under 64 KiB
+// through this engine by default. The admission switch in
+// admission_switch.go controls this routing.
+//
+// The engine consumes a dependency-neutral TableView. It does not own a
+// lexer, an external-scanner election, recovery, retries, or included
+// ranges. Incremental parsing stays on the production engine.
+//
+// The engine fails closed. A decline at any eligibility check, or during
+// the engine run, sends the parse to the production lane. This package
+// never substitutes partial work.
+//
+// Build with -tags gts_no_parsercorephase0 as the emergency opt-out. This
+// tag removes the engine. Every full parse then runs on the production
+// lane.
 package parsercorephase0
 
 import (


### PR DESCRIPTION
## Summary

Updates the package documentation for parsercorephase0 to reflect its current role as the admitted parser core for files under 64 KiB. It clarifies execution boundaries, failure-closed routing, and the emergency build-tag opt-out.

## Changes

- Replace prototype description with current production routing rules.
- Document admission switch logic and size threshold for full parses.
- Clarify that incremental parsing remains on the production engine.
- Note the -tags gts_no_parsercorephase0 flag for emergency opt-out.

## Freeze

freeze-safe: documentation only. Do not merge before 2026-08-05.

## Staleness sweep

I swept the repository for other "diagnostic-only", "prototype", "shadow", or "not routed in production" claims about the compact core's current shipped state. Only `internal/parsercorephase0/core.go` needed a fix.

Everything else fell into one of three groups, and I left all of them unchanged:

- Unrelated diagnostic-only text. Several files use "diagnostic-only" for a different, genuinely diagnostic feature: `work_count_diagnostic.go`, `admission_census.go`, `work_count_semantic_phase_trace.go`, `parser_result_javascript_typescript.go`, `tree.go`, `glr_forest.go`, and two narrow claims inside `core.go` itself (`ErrDerivationEnumerationCap`, a map-scan comment). Each claim is accurate on its own terms.
- Historical receipts and spec history. `CHANGELOG.md`, `BENCH.md`, `docs/compact-route-coverage-census.md`, `docs/compact-route-real-corpus-matrix.md`, and `docs/phase3-admission-timing-runbook.md` are dated, pinned-revision receipts or a completed v6.7 admission-campaign runbook. Task scope excludes historical documents.
- False-positive grep hits. `grammars/perl_scanner.go` ("prototype" is a Perl language construct), `grammargen/normalize.go` ("shadow" is alias shadowing during grammar normalization), and `docs/authoring-languages.md` ("shadow" means overriding a built-in grammar by name).

Borderline, left unchanged (listing per task instructions instead of editing): `docs/repository-map.md` calls the package the "Compact parser candidate" / "Internal compact-parser implementation." That term does not match the four flagged phrases and mirrors the code's own `admissionCandidateRoute` naming, so I judged it in scope for a naming-consistency pass, not this hygiene fix.

## Other findings (informational, no action taken)

- `cgo_harness/manifest.json`: not tracked by git and not present in this worktree (`git ls-files` empty, file absent on disk). No stray to remove here.
- `.codex/`: not present in this worktree, and not covered by `.gitignore` (`git check-ignore` exit 1, no `codex` pattern in `.gitignore`). Per task instructions I did not add an ignore rule myself. Flagging for an owner decision: if `.codex/` is meant to hold local/ephemeral agent state (as `.claude/` already is), add a `.codex/` line to `.gitignore` alongside the existing `.claude/` entry.

## Verification

- `go build ./...`: clean, no output.
- `go vet ./internal/parsercorephase0/`: clean, no output.
- Grep confirms no remaining "diagnostic-only" claim describes the compact core's shipped production status outside the historical docs listed above.
