### PR TITLE
fix(compat-registry): restore rescript/linkerscript retired entries, harden generic-pass ratchet

### DIFF
--- a/compat_ownership_test.go
+++ b/compat_ownership_test.go
@@ -641,11 +641,32 @@ func assertDispatcherRegistry(t *testing.T, denominator resultCompatDenominator,
 	}
 }
 
+// assertGenericPassRegistry ratchets unconditional ("generic") normalize
+// calls: calls that run for every language instead of behind a registered
+// dispatcher arm or predicate. normalizeResultCompatibility now only
+// delegates to applyResultCompatibility, so this inspects all three layers
+// of the delegation chain. Calls inside the COBOL predicate branch and inside
+// the language switch of runLanguageResultCompatibility are excluded because
+// assertDispatcherRegistry already ratchets those against the registry; a
+// generic call added anywhere else in the chain must still surface here.
 func assertGenericPassRegistry(t *testing.T, denominator resultCompatDenominator, byKind map[string][]resultCompatOwnershipEntry) {
 	t.Helper()
 	file := parseOwnershipGoFile(t, "parser_result_compat.go")
-	fn := findOwnershipFunction(t, file, "normalizeResultCompatibility")
-	sourceFunctions := sortedStrings(ownershipNormalizeCalls(fn.Body))
+	entrypoint := findOwnershipFunction(t, file, "normalizeResultCompatibility")
+	applied := findOwnershipFunction(t, file, "applyResultCompatibility")
+	dispatcher := findOwnershipFunction(t, file, "runLanguageResultCompatibility")
+
+	seen := make(map[string]bool)
+	for _, name := range ownershipNormalizeCallOccurrences(entrypoint.Body) {
+		seen[name] = true
+	}
+	for _, name := range ownershipNormalizeCallOccurrences(applied.Body) {
+		seen[name] = true
+	}
+	for _, name := range ownershipUndispatchedNormalizeCalls(dispatcher.Body) {
+		seen[name] = true
+	}
+	sourceFunctions := sortedMapKeys(seen)
 
 	var registryFunctions []string
 	for _, entry := range byKind["generic_pass"] {
@@ -661,6 +682,39 @@ func assertGenericPassRegistry(t *testing.T, denominator resultCompatDenominator
 	if !equalStrings(sourceFunctions, registryFunctions) {
 		t.Errorf("generic normalization calls = %v, registry = %v", sourceFunctions, registryFunctions)
 	}
+}
+
+// ownershipUndispatchedNormalizeCalls returns the normalize-prefixed calls in
+// runLanguageResultCompatibility's body that sit outside every if-statement
+// and switch-statement it contains. Today that means outside the COBOL
+// predicate branch and outside the language switch: both are already
+// ratcheted call-by-call in assertDispatcherRegistry. Skipping their subtrees
+// here keeps this function honest about only reporting calls neither ratchet
+// already covers, instead of double-counting the 40 dispatcher arms.
+func ownershipUndispatchedNormalizeCalls(body ast.Node) []string {
+	var calls []string
+	ast.Inspect(body, func(node ast.Node) bool {
+		switch node.(type) {
+		case *ast.IfStmt, *ast.SwitchStmt:
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch function := call.Fun.(type) {
+		case *ast.Ident:
+			name = function.Name
+		case *ast.SelectorExpr:
+			name = function.Sel.Name
+		}
+		if strings.HasPrefix(name, "normalize") {
+			calls = append(calls, name)
+		}
+		return true
+	})
+	return calls
 }
 
 func assertPostFinalizationRegistry(t *testing.T, denominator resultCompatDenominator, byKind map[string][]resultCompatOwnershipEntry) {

--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -21,7 +21,7 @@ The v1 registry freezes the current source and registry:
 - zero generic passes after language dispatch;
 - zero post-finalization second-pass fixpoint arms.
 
-That is 41 live registry entries and 42 retired entries. These counts backfill
+That is 41 live registry entries and 44 retired entries. These counts backfill
 earlier retirements. This field repair change does not remove a dispatcher arm.
 The registry covers
 only this documented internal result-compatibility tier. Scheduler experiments

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -9,7 +9,7 @@
     "post_finalization_arms": 0,
     "post_finalization_languages": 0,
     "live_entries": 41,
-    "retired_entries": 42
+    "retired_entries": 44
   },
   "live_evidence_baseline": {
     "scope": "baseline_corpus_wide_only",
@@ -1563,6 +1563,39 @@
       "evidence_scope": "baseline_corpus_wide_only"
     },
     {
+      "id": "dispatch.linkerscript",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeLinkerscriptCompatibility"
+      ],
+      "files": [
+        "parser_result_linkerscript.go"
+      ],
+      "languages": [
+        "linkerscript"
+      ],
+      "purpose": "Historical: reconciled Linker Script recovery and returned-tree shape.",
+      "authoritative_owner": "scheduler_action_semantics",
+      "witnesses": [
+        "grammars/linkerscript_native_regression_test.go",
+        "cgo_harness/linkerscript_retirement_parity_test.go"
+      ],
+      "retirement_condition": "Satisfied: native parsing emits named ERROR nodes and covers the full source span without a compatibility pass. Production, compact, forest, and incremental routes return the same digest for the clean and recovered fixtures. The C-oracle receipt reports zero divergences.",
+      "route_coverage": {
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
+      },
+      "status": "retired",
+      "retired_commit": "4ac19d4446b4b41daa236465a5316d624214343c",
+      "receipt_refs": [
+        "grammars/linkerscript_native_regression_test.go",
+        "cgo_harness/linkerscript_retirement_parity_test.go"
+      ]
+    },
+    {
       "id": "dispatch.kotlin",
       "kind": "dispatcher_arm",
       "functions": [
@@ -2038,6 +2071,39 @@
       },
       "status": "live",
       "evidence_scope": "baseline_corpus_wide_only"
+    },
+    {
+      "id": "dispatch.rescript",
+      "kind": "dispatcher_arm",
+      "functions": [
+        "normalizeRescriptCompatibility"
+      ],
+      "files": [
+        "parser_result_rescript.go"
+      ],
+      "languages": [
+        "rescript"
+      ],
+      "purpose": "Historical: reconciled ReScript aliases and returned-tree shape.",
+      "authoritative_owner": "materialization",
+      "witnesses": [
+        "grammars/rescript_native_regression_test.go",
+        "cgo_harness/rescript_retirement_parity_test.go"
+      ],
+      "retirement_condition": "Satisfied: native materialization emits value_identifier_path nodes directly. Production, compact, forest, and incremental routes return the same digest for the alias and control fixtures. The C-oracle receipt reports zero divergences.",
+      "route_coverage": {
+        "production": "retired_exact_receipt",
+        "compact": "retired_exact_or_fail_closed_receipt",
+        "forest": "retired_exact_receipt",
+        "incremental": "retired_exact_receipt",
+        "c_oracle": "retired_exact_receipt"
+      },
+      "status": "retired",
+      "retired_commit": "c73670f0a4af1c6d9ba9572fb04eef2795bdfd26",
+      "receipt_refs": [
+        "grammars/rescript_native_regression_test.go",
+        "cgo_harness/rescript_retirement_parity_test.go"
+      ]
     },
     {
       "id": "dispatch.robot",


### PR DESCRIPTION
## Summary

Two prior commits deleted dispatcher-arm registry entries instead of
retiring them. Commit c73670f0 removed `dispatch.rescript`. Commit
4ac19d44 removed `dispatch.linkerscript`. Both commits deleted the arm
from `testdata/result_compat_ownership_v1.json` after removing the
source normalizer, instead of keeping the entry with `status: retired`.
`docs/compat-tier.md` states the rule this violated: "A retired entry
remains in the registry with its commit and receipt references;
deleting the historical record is not retirement."

This PR restores both entries as `status: retired` records, reusing the
retirement receipts each original commit already added
(`grammars/linkerscript_native_regression_test.go`,
`cgo_harness/linkerscript_retirement_parity_test.go`,
`grammars/rescript_native_regression_test.go`,
`cgo_harness/rescript_retirement_parity_test.go`). It also hardens a
ratchet gap found while restoring these entries.

## Changes

- Restore `dispatch.linkerscript` and `dispatch.rescript` as `status:
  retired` registry entries, each with its original retirement commit
  and receipt references. No source code changes; both normalizers
  were already deleted.
- Bump `denominator.retired_entries` from 42 to 44 and update the
  matching count in `docs/compat-tier.md`.
- Harden `assertGenericPassRegistry` in `compat_ownership_test.go`. It
  previously inspected only `normalizeResultCompatibility`, which now
  just delegates to `applyResultCompatibility`. A new unconditional
  `normalize*` call added to `applyResultCompatibility` or
  `runLanguageResultCompatibility` outside the language switch would
  have evaded the ratchet. The hardened version inspects all three
  functions and excludes only the subtrees `assertDispatcherRegistry`
  already verifies (the COBOL predicate branch and the language
  switch).
- Add `ownershipUndispatchedNormalizeCalls`, a helper that walks a
  function body and skips `if`/`switch` subtrees, to support the
  hardening above.

## Testing

- `go build ./...`
- `go test . -run '^TestResultCompatibilityOwnershipRegistry$' -count=1 -v`
- Manually verified the hardened ratchet fails: temporarily added an
  unconditional `normalize*` call inside `applyResultCompatibility`
  and confirmed the test caught it, then reverted the change.

## Freeze note

freeze-safe: tests only. This PR touches the result-compat registry, a
test helper, and one doc line. It does not change parser or runtime
behavior. The repository is frozen until 2026-08-05.
