### PR TITLE
add: Add CPU profile attribution board tool

### DIFF
--- a/cgo_harness/attribution/attribute.go
+++ b/cgo_harness/attribution/attribute.go
@@ -1,0 +1,73 @@
+package main
+
+import "sort"
+
+// attributionResult is one profile's fully-mapped receipt row: total sampled
+// CPU nanoseconds, the per-component share of that total, and every
+// unclassified function the walk had to fall through to ComponentOther for
+// (a nonzero, non-runtime entry here is a signal the classify.go table has a
+// gap and should grow).
+type attributionResult struct {
+	TotalSampleNS   int64
+	ComponentNS     map[Component]int64
+	UnclassifiedTop []unclassifiedEntry // largest-first, runtime/GC excluded
+}
+
+type unclassifiedEntry struct {
+	Function string
+	NS       int64
+}
+
+// attributeProfile walks every sample's call stack leaf-to-root, assigning
+// the sample's full value to the first frame classify.go recognizes. Frames
+// classify.go marks as shared/transparent (or does not recognize at all) are
+// skipped over; the walk continues toward the root. A sample with no
+// recognized frame anywhere on its stack is ComponentOther.
+func attributeProfile(profile *pbProfile) attributionResult {
+	result := attributionResult{ComponentNS: map[Component]int64{}}
+	unclassified := map[string]int64{}
+
+	for _, sample := range profile.Samples {
+		result.TotalSampleNS += sample.ValueNS
+		component := ComponentOther
+		matched := false
+		for _, frame := range sample.Stack {
+			if c, ok := classifyFunction(frame); ok {
+				component = c
+				matched = true
+				break
+			}
+		}
+		result.ComponentNS[component] += sample.ValueNS
+		if !matched {
+			leaf := "<empty stack>"
+			if len(sample.Stack) > 0 {
+				leaf = sample.Stack[0].Function
+			}
+			if !isRuntimeFrame(leaf) {
+				unclassified[leaf] += sample.ValueNS
+			}
+		}
+	}
+
+	for fn, ns := range unclassified {
+		result.UnclassifiedTop = append(result.UnclassifiedTop, unclassifiedEntry{Function: fn, NS: ns})
+	}
+	sort.Slice(result.UnclassifiedTop, func(i, j int) bool {
+		return result.UnclassifiedTop[i].NS > result.UnclassifiedTop[j].NS
+	})
+	return result
+}
+
+// isRuntimeFrame reports whether a leaf function name is Go runtime/GC/
+// scheduler bookkeeping with no gotreesitter-domain meaning -- the expected,
+// legitimate content of ComponentOther, not a classification gap.
+func isRuntimeFrame(name string) bool {
+	prefixes := []string{"runtime.", "gc", "sync.", "sync/atomic."}
+	for _, p := range prefixes {
+		if len(name) >= len(p) && name[:len(p)] == p {
+			return true
+		}
+	}
+	return false
+}

--- a/cgo_harness/attribution/classify.go
+++ b/cgo_harness/attribution/classify.go
@@ -1,0 +1,445 @@
+package main
+
+import "strings"
+
+// Component is one leaf of the campaign v7 C0 attribution tree. The set is
+// mutually exclusive and collectively exhaustive: classify assigns exactly
+// one component to every CPU-profile sample. See docs/perf-attribution.md for
+// the prose methodology this table implements.
+type Component string
+
+const (
+	ComponentSchedulerDispatch Component = "scheduler-dispatch"
+	ComponentElections         Component = "elections"
+	ComponentReductionsAndPops Component = "reductions-and-pops"
+	ComponentCanonicalization  Component = "canonicalization"
+	ComponentLexing            Component = "lexing"
+	ComponentMaterialization   Component = "materialization"
+	ComponentCompatTail        Component = "compat-tail"
+	ComponentOther             Component = "other"
+)
+
+// ComponentOrder is the fixed display and receipt order for all eight
+// components.
+var ComponentOrder = []Component{
+	ComponentSchedulerDispatch,
+	ComponentElections,
+	ComponentReductionsAndPops,
+	ComponentCanonicalization,
+	ComponentLexing,
+	ComponentMaterialization,
+	ComponentCompatTail,
+	ComponentOther,
+}
+
+// classifyFunction maps one fully-qualified pprof function name (as written
+// by the Go runtime, e.g. "github.com/odvcencio/gotreesitter.(*Type).Method")
+// to a component, or returns ("", false) when the function is either a shared
+// primitive (transparent -- the walk continues to its caller) or genuinely
+// unrecognized (the walk keeps looking further up the stack; if nothing
+// matches anywhere, the sample lands in ComponentOther).
+//
+// This function is the single source of truth for the attribution boundary
+// rules. docs/perf-attribution.md names the primary anchors in prose; this
+// table is the byte-exact implementation.
+func classifyFunction(fn pbFrame) (Component, bool) {
+	name := fn.Function
+	file := fn.File
+
+	// --- Shared / unclassified primitives (explicit, checked first) ---
+	// These functions exist to serve more than one component (generic
+	// transaction bookkeeping, checkpoint identity, or pure counters). A
+	// sample landing in one of these frames is NOT attributed here -- the
+	// walk continues to the next frame up the stack, which is always the
+	// specific call site that decided to use the shared primitive.
+	if isSharedPrimitive(name) {
+		return "", false
+	}
+
+	// --- Whole-file components (a file with exactly one job) ---
+	switch {
+	case strings.HasSuffix(file, "/parser_dfa_token_source.go"), strings.HasSuffix(file, "/lexer.go"):
+		return ComponentLexing, true
+	case strings.HasSuffix(file, "/admission_switch.go"), strings.HasSuffix(file, "/admission_switch_candidate.go"):
+		return ComponentCompatTail, true
+	case strings.HasSuffix(file, "/parsestate_replay_compact.go"),
+		strings.HasSuffix(file, "/materialization_postorder_scratch.go"),
+		strings.HasSuffix(file, "/materialization_replay.go"),
+		strings.HasSuffix(file, "/selected_store.go"),
+		strings.HasSuffix(file, "/selected_store_builder_onepass.go"),
+		strings.HasSuffix(file, "/selected_store_builder_staged.go"),
+		strings.HasSuffix(file, "/phase0a_diagnostic_run.go"),
+		strings.HasSuffix(file, "/phase0a_factor_provenance.go"),
+		strings.HasSuffix(file, "/phase0a_identity.go"),
+		strings.HasSuffix(file, "/phase0a_observer_off.go"),
+		strings.HasSuffix(file, "/phase0a_routes.go"),
+		strings.HasSuffix(file, "/phase0a_selected_occurrences.go"):
+		// Not on the profiled diagnostic-lane or shipped-route call paths for
+		// this receipt (Phase0AEnabled is false; SelectedStore is a separate
+		// entry point runner.parse never calls). Classified conservatively as
+		// materialization in case a shared helper is ever reached; expected
+		// near-zero.
+		return ComponentMaterialization, true
+	}
+
+	// --- Explicit function-name overrides (the two mixed files: the driver's
+	// scheduler and the core package's transactional structures, plus a
+	// handful of specific cross-file exceptions). Matching is by Contains
+	// against the full pprof symbol (package path + receiver + method), using
+	// the longest matching entry so a more specific override (e.g. an
+	// "...Owned" variant) beats a shorter one that happens to also match.
+	if component, ok := lookupFunctionOverride(name); ok {
+		return component, true
+	}
+
+	return "", false
+}
+
+func lookupFunctionOverride(name string) (Component, bool) {
+	bestLen := -1
+	var best Component
+	found := false
+	for _, entry := range functionOverrideTable {
+		if strings.Contains(name, entry.substr) && len(entry.substr) > bestLen {
+			bestLen = len(entry.substr)
+			best = entry.component
+			found = true
+		}
+	}
+	return best, found
+}
+
+// isSharedPrimitive reports whether name is a generic building block reused
+// by more than one component, so a sample resting in its own frames should be
+// attributed to whichever specific caller reached it instead.
+//
+// Worked examples (see docs/perf-attribution.md):
+//   - condense / condenseWithOutcome / condenseWithOutcomeAtomic run from both
+//     Shift (scheduler-dispatch) and reduction-output application
+//     (reductions-and-pops); the walk finds the caller's frame instead.
+//   - ApplySchedulerAtomic / RunSchedulerOwned wrap shift, reduce, conflict,
+//     and extra-shift appliers alike; same rule.
+//   - checkpoint interning and external-scanner-state capture run both nested
+//     inside dfaTokenSource.Next (lexing) and directly from elect() for
+//     checkpoint-continuity proof (elections); the walk finds whichever is
+//     the nearer ancestor on that particular stack.
+func isSharedPrimitive(name string) bool {
+	for _, prefix := range sharedPrimitivePrefixes {
+		if strings.Contains(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// sharedPrimitivePrefixes match on unqualified method/function names (using
+// Contains against the full symbol, which already includes the package and
+// receiver) so one entry covers a method regardless of receiver formatting.
+var sharedPrimitivePrefixes = []string{
+	// Scheduler transaction bookkeeping (core.go): wraps shift, reduce,
+	// conflict, and extra-shift appliers uniformly.
+	").ApplySchedulerAtomic",
+	").RunSchedulerOwned",
+	").RunFreshSchedulerSession",
+	").ApplyAtomic",
+	").markInto",
+	").mark(",
+	").restoreCheckpoint",
+	").restore(",
+	").commit(",
+	").assertTopTransaction",
+	").finishTransaction",
+	").completeTransaction",
+	").validateSchedulerTransaction",
+	").poisonSchedulerTransaction",
+	").runSchedulerMaybeLiveScopedOwned",
+	// GSS graph condense/merge: shared by shift and reduce application.
+	").condense(",
+	").condenseWithOutcome(",
+	").condenseWithOutcomeAtomic",
+	").condenseInputExists",
+	// Checkpoint identity: shared by lexing-nested capture (inside Next) and
+	// direct election-time capture (elect's continuity proof).
+	"diagnosticParserCoreInternCheckpoint",
+	").InternCheckpoint",
+	").CheckpointReceipt",
+	").CheckpointInternerStats",
+	"checkpointInterner)",
+	"parserCoreCheckpoint(",
+	"diagnosticParserCoreCheckpointDigest",
+	// Boundary hash index: shared by shift's and condense's boundary lookups.
+	"boundaryIndex)",
+	"boundaryIdentityFromKey",
+	"boundaryIdentityHash",
+	// Pure bookkeeping/counters: negligible cost, no domain meaning of their
+	// own, invoked from every component.
+	").Work(",
+	").addWork(",
+	").recordLinkUnion",
+	").publishTotals",
+	// Arena/session construction: once per parse, outside any one dispatch
+	// action; New/Reset overlap the fixed per-parse entry cost that this
+	// receipt intentionally treats as unattributed rather than guessing which
+	// downstream component "owns" allocator setup.
+	").Reset(",
+	"parsercorephase0.New(",
+}
+
+// functionOverrideTable lists specific functions in the two mixed-purpose
+// files (parsercore_phase0_driver.go in the root package, and core.go /
+// scheduler_owned.go in internal/parsercorephase0) plus a small number of
+// named cross-file exceptions. Matching is by Contains against the pprof
+// function symbol (see lookupFunctionOverride), so receiver formatting
+// differences do not matter.
+type functionOverrideEntry struct {
+	substr    string
+	component Component
+}
+
+var functionOverrideTable = buildFunctionOverride()
+
+func buildFunctionOverride() []functionOverrideEntry {
+	var table []functionOverrideEntry
+	add := func(component Component, names ...string) {
+		for _, n := range names {
+			table = append(table, functionOverrideEntry{substr: n, component: component})
+		}
+	}
+
+	add(ComponentSchedulerDispatch,
+		"GenericScheduler).run",
+		"GenericScheduler).dispatchPass",
+		"GenericScheduler).dispatchPassActive",
+		"GenericScheduler).zeroWidthExtraShiftWithoutProgress",
+		"GenericScheduler).applyGenericAccept",
+		"GenericScheduler).applyGenericShifts",
+		"GenericScheduler).applyGenericShiftsOwned",
+		"GenericScheduler).applyGenericExtraShifts",
+		"GenericScheduler).applyGenericExtraShiftsOwned",
+		"GenericScheduler).genericExternalStats",
+		"GenericScheduler).recordGenericExternalShift",
+		"GenericScheduler).relexTokenForState",
+		"diagnosticParserCoreRelexedSymbol",
+		"GenericScheduler).validateGenericNoLookaheadReduction",
+		"diagnosticParserCoreGenericUnsupportedCell",
+		"diagnosticParserCoreGenericUnsupportedToken",
+		"GenericScheduler).reserveDispatches",
+		"GenericScheduler).finish",
+		"GenericScheduler).completeAtClosedByte",
+		"GenericScheduler).headerReceipt",
+		"GenericScheduler).fullReceipts",
+		"newDiagnosticParserCoreGenericScheduler",
+		"initializeDiagnosticParserCoreGenericScheduler",
+		"executeDiagnosticParserCoreGenericSchedulerFromSeed",
+		"DispatchScratch).begin",
+		"DispatchScratch).finish",
+		"HeaderRollbackScratch).begin",
+		"HeaderRollbackScratch).finish",
+		"HeaderRollbackScratch).reset",
+		// core.go / scheduler_owned.go: shift execution (GSS append for a
+		// shifted token) is scheduler-dispatch, not a reduction.
+		"Core).Shift(",
+		"Core).ShiftClassified",
+		"Core).ShiftOrdinaryCohort",
+		"Core).ShiftOrdinaryClassifiedCohort",
+		"Core).ShiftExtraCohort",
+		"Core).ShiftExtraClassifiedCohort",
+		"Core).Actions(",
+		"Core).ClassifyBoundary",
+		"validateClassification",
+		"classifiedActionRef",
+		"Core).appendDiagnosticPayload",
+		"Core).Seed(",
+		"Core).Boundary(",
+		"Core).BeginFrontier",
+		"Core).SetPhaseCheckpoint",
+		"Core).SetPhaseExternalTokenScannerCheckpoints",
+		"cohortHasDuplicateHead",
+		"Core).cohortHeads",
+		"Core).prepareOrdinaryClassifiedCohortInto",
+		"Core).prepareExtraClassifiedCohortInto",
+		"Core).shiftClassifiedMaybeLiveScopedOwned",
+		"Core).shiftClassifiedUncheckpointed",
+		"Core).shiftOrdinaryClassifiedCohortMaybeLiveScopedOwned",
+		"Core).shiftOrdinaryClassifiedCohortUncheckpointed",
+		"Core).shiftExtraClassifiedCohortMaybeLiveScopedOwned",
+		"Core).shiftExtraClassifiedCohortUncheckpointed",
+		"ShiftClassifiedOwned",
+		"ShiftClassifiedWithLiveCondenseCandidatesOwned",
+		"ShiftOrdinaryClassifiedCohortOwned",
+		"ShiftOrdinaryClassifiedCohortWithLiveCondenseCandidatesOwned",
+		"ShiftExtraClassifiedCohortOwned",
+		"ShiftExtraClassifiedCohortWithLiveCondenseCandidatesOwned",
+		// runner-level scheduler entry and its accepted-tail cleanliness
+		// check (distinct from the compat-tail component -- see doc).
+		"FreshFullRunner).executeSchedulerOpen",
+		"requireParserCoreFreshFullAcceptance",
+		"parserCoreFreshFullAcceptedTailIsClean",
+		"parserTailAllowsCleanAcceptance",
+		"FreshFullRunner).parse(",
+		"FreshFullRunner).parseSelectedStore",
+	)
+
+	add(ComponentElections,
+		"GenericScheduler).elect",
+		"executeDiagnosticParserCoreGenericConflictDetailed",
+		"GenericScheduler).applyGenericConflict",
+		"GenericScheduler).applyGenericConflictOwned",
+		"GenericScheduler).reconcileGenericConflictOutputs",
+		"ConflictScratch).begin",
+		"ConflictScratch).finish",
+		"ConflictExecution).arm",
+		"diagnosticParserCoreConflictPolicyOrdinal",
+		"diagnosticParserCoreRepetitionFoldOrdinal",
+		"diagnosticParserCoreSingleReduceRepetitionShiftOrdinal",
+		"validateDiagnosticParserCoreCell",
+	)
+
+	add(ComponentReductionsAndPops,
+		"GenericScheduler).applyGenericReduction",
+		"GenericScheduler).applyGenericReductionOwned",
+		"GenericScheduler).dropGenericNoActionHeads",
+		"diagnosticParserCoreGenericNoActionDropEligible",
+		"diagnosticParserCoreSelectedLineageDrops",
+		"GenericScheduler).adoptUpdatedReductionSibling",
+		"GenericScheduler).collectCondenseCandidates",
+		"GenericScheduler).reindexCondenseCandidatesOwned",
+		"Core).Reduce(",
+		"Core).ReduceOutputs",
+		"reductionParentForPath",
+		"Core).reductionPlan",
+		"remapReductionPlan",
+		"Core).popPaths",
+		"Core).popSingleLinkPath",
+		"popEnumerationScratch)",
+		"Core).findReductionBatchParent",
+		"reductionParentIdentityEqual",
+		"Core).appendPrivate",
+		"Core).factorExactPredecessor",
+		"factorExactPredecessorMerge",
+		"Core).mergePredecessorsBounded",
+		"Core).insertLinkBounded",
+		"Core).replaceBoundaryLink",
+		"Core).linkEqualInput",
+		"Core).historicalForestIsDeterministic",
+		"Core).graphVersionIsDeterministic",
+		"Core).shallowPayloadClassEqual",
+		"Core).effectivePayloadPrecedence",
+		"Core).subtreeExternalProvenance",
+		"Core).externalPayloadScannerProvenance",
+		"Core).predecessorBoundariesMatch",
+		"Core).nodeScannerCheckpoint",
+		"Core).shallowPayloadsEqual",
+		"Core).linkEdgeEqualInput",
+		"Core).linkEdgesEqual",
+		"Core).linkRecordsEqual",
+		"Core).nodesAncestryRelated",
+		"Core).nodeReaches",
+		"Core).appendAdjacencyNode",
+		"Core).subtreesStructurallyEqual",
+		"Core).shallowPayloadClass",
+		"Core).walkCleanPrefixRanks",
+		"Core).markCleanProductionRank",
+		"markCleanPathRankUnknown",
+		"cleanPathRankAccumulator).observe",
+		"compareCleanPathRank",
+		"mergeCleanPathRank",
+		"Core).cleanPathPayloadHasExternal",
+		"Core).appendNode",
+		"validatePublishedNodeDAG",
+		"Core).appendSubtree",
+		"Core).appendAuthenticatedTerminal",
+		"Core).appendSubtreeRecord",
+		"Core).nodeLinks",
+		"Core).publishedNodeLinksInto",
+		"Core).boundaryKey",
+		"Core).shiftedBoundaryKey",
+		"Core).CanonicalBoundary",
+		"Core).condenseNodeIsLive",
+		"Core).node(",
+		"Core).nodeLineage",
+		"Core).subtree(",
+		"reductionOutputScratch)",
+		"Core).reductionPlanForPair",
+		// scheduler_owned.go reduce-side and condense-candidate core methods.
+		"Core).reduceOutputsClassifiedIntoActive",
+		"Core).reduceOutputsClassifiedIntoUncheckpointed",
+		"Core).reduceOutputsClassifiedIntoMaybeLiveScopedOwned",
+		"ReduceOutputsClassifiedIntoOwned",
+		"ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned",
+		"Core).runLiveCondenseCandidates",
+		"Core).clearLiveCondenseCandidates",
+		"Core).reindexCondenseCandidatesUncheckpointed",
+		"ReindexCondenseCandidatesOwned",
+	)
+
+	add(ComponentCanonicalization,
+		"GenericScheduler).canonicalize",
+		"canonicalizeDiagnosticParserCoreHeaders",
+		"CanonicalScratch).canonicalize",
+		"CanonicalScratch).canonicalizeLinear",
+		"CanonicalScratch).canonicalizeMapped",
+		"diagnosticParserCoreCanonicalCandidateWins",
+		"mergeDiagnosticParserCoreCleanPathLineage",
+		"nextDiagnosticParserCoreCleanPathLineage",
+		"applyDiagnosticParserCoreCleanPathOutput",
+		"markDiagnosticParserCoreExternalLineage",
+		"GenericScheduler).persistHeaderLineageOwned",
+		"replaceDiagnosticParserCoreHeader",
+		// scheduler_owned.go lineage/rank persistence backing canonicalize's
+		// tie-breaking: same intrinsic job regardless of caller.
+		"RecordReductionLineageOwned",
+		"RecordHeadLineageOwned",
+		"Core).recordNodeLineage",
+		"RecordHeadOwnerOwned",
+	)
+
+	add(ComponentMaterialization,
+		"GenericScheduler).completeAcceptance",
+		"selectCompactAcceptanceDerivation",
+		"compactDerivationsForAcceptance",
+		"Core).Derivations",
+		"saturatingAddPaths",
+		"Core).Stats(",
+		"materializeDiagnosticParserCoreAcceptedTree",
+		"materializeDiagnosticParserCoreAcceptedSelection",
+		"finalizeDiagnosticParserCoreAcceptedRootSpan",
+		"Parser).replayCompactDerivation",
+		"newDiagnosticParserCorePointIndex",
+		"PointIndex).point",
+		"parserCoreNodeSlice",
+		"clearNodeScratch",
+		"RunnerScratch).resetTreeBuffers",
+		"withDiagnosticParserCoreMaterializationScratch",
+		"withProvidedMaterializationScratch",
+		"MaterializationScratch).entriesFor",
+		"MaterializationScratch).reset",
+		"Core).Subtree(",
+		"Core).MaterializationOrder",
+		"Core).VisitMaterializationPostorder",
+		"Core).MaterializationView",
+		"validateMaterializationMetadata",
+		"validateGenericMaterializationMetadata",
+		"Core).SubtreeArenaLen",
+		"diagnosticParserCoreSelectedNodeCensus",
+		"FreshFullRunner).materialize",
+		"FreshFullRunner).materializeSelection",
+		"Core).RawSelectedSubtreeCensus",
+	)
+
+	add(ComponentCompatTail,
+		"Parser).normalizeReturnedTreeForParse",
+		"Parser).resolveCRecoverySwallowedError",
+		"Parser).maybeCompactReturnedFullTree",
+		"Parser).tryCompactFullParseRoute",
+		"Parser).attemptAdmissionCandidateFullParse",
+		"Parser).admissionCandidateFullParseEligible",
+		"admissionCandidateInputSizeEligible",
+		"Parser).acquireAdmissionCandidateRunner",
+		"newAdmissionCandidateRunner",
+		"Parser).hasActiveParseObservability",
+		"admissionCandidateDeclineReason",
+	)
+
+	return table
+}

--- a/cgo_harness/attribution/main.go
+++ b/cgo_harness/attribution/main.go
@@ -1,0 +1,518 @@
+// Command attribution is campaign v7 tranche C0's attribution board tool. It
+// is measurement infrastructure only: it builds and runs existing test
+// binaries in the repository under existing, already-committed build tags and
+// entry points, and never edits parser code, routing, or shipped behavior.
+//
+// It produces one boundary-defined attribution receipt (a markdown table and
+// a JSON file) over the compact parser core's fresh-full-parse CPU, plus a
+// noise floor and a cost-per-event join. See docs/perf-attribution.md for the
+// methodology this tool implements and the first published receipt.
+//
+// Usage (from the repository root):
+//
+//	go run ./cgo_harness/attribution
+//
+// All flags are optional; see -help. The command builds both required test
+// binaries first, extracts the four pinned canonical fixtures, then runs
+// every measurement in one final pass, and finally writes the receipt.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "attribution: error:", err)
+		os.Exit(1)
+	}
+}
+
+type config struct {
+	repoRoot        string
+	outDir          string
+	captureDuration time.Duration
+	noiseSamples    int
+	noiseBenchtime  time.Duration
+	core            string
+}
+
+func run() error {
+	var cfg config
+	var repoFlag, outFlag, durationFlag, noiseBenchtimeFlag string
+	var reanalyze bool
+	flag.StringVar(&repoFlag, "repo", "", "repository root (default: current directory)")
+	flag.StringVar(&outFlag, "out", "", "output directory (default: <repo>/harness_out/perf_attribution/<timestamp>)")
+	flag.StringVar(&durationFlag, "duration", "800ms", "per-fixture CPU-profile capture duration (wall clock floor; a 5-iteration minimum always applies)")
+	flag.IntVar(&cfg.noiseSamples, "noise-samples", 10, "interleaved A/A pairs for the noise floor (n>=10 required)")
+	flag.StringVar(&noiseBenchtimeFlag, "noise-benchtime", "700ms", "benchtime per noise-floor sample")
+	flag.StringVar(&cfg.core, "core", "", "optional CPU to pin with taskset (default: no pinning)")
+	flag.BoolVar(&reanalyze, "reanalyze", false, "skip build and measurement; recompute the receipt from an existing -out directory's artifacts")
+	flag.Parse()
+
+	if repoFlag == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getwd: %w", err)
+		}
+		repoFlag = wd
+	}
+	repoRoot, err := filepath.Abs(repoFlag)
+	if err != nil {
+		return err
+	}
+	if err := verifyRepoRoot(repoRoot); err != nil {
+		return err
+	}
+	cfg.repoRoot = repoRoot
+
+	duration, err := time.ParseDuration(durationFlag)
+	if err != nil || duration <= 0 {
+		return fmt.Errorf("-duration must be a positive Go duration, got %q", durationFlag)
+	}
+	cfg.captureDuration = duration
+
+	noiseBenchtime, err := time.ParseDuration(noiseBenchtimeFlag)
+	if err != nil || noiseBenchtime <= 0 {
+		return fmt.Errorf("-noise-benchtime must be a positive Go duration, got %q", noiseBenchtimeFlag)
+	}
+	cfg.noiseBenchtime = noiseBenchtime
+	if cfg.noiseSamples < 10 {
+		return fmt.Errorf("-noise-samples must be >= 10, got %d", cfg.noiseSamples)
+	}
+
+	if outFlag == "" {
+		outFlag = filepath.Join(repoRoot, "harness_out", "perf_attribution", time.Now().UTC().Format("20060102T150405Z"))
+	}
+	outDir, err := filepath.Abs(outFlag)
+	if err != nil {
+		return err
+	}
+	cfg.outDir = outDir
+
+	for _, sub := range []string{"bin", "fixtures", "profiles", "workcount", "noise"} {
+		if err := os.MkdirAll(filepath.Join(outDir, sub), 0o755); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("attribution: repo       =", cfg.repoRoot)
+	fmt.Println("attribution: out        =", cfg.outDir)
+	fmt.Println("attribution: duration   =", cfg.captureDuration)
+	fmt.Println("attribution: noise pairs=", cfg.noiseSamples)
+
+	var captureManifest *captureManifest
+	var workcounts map[string]workCountResult
+	var noiseSamples []noiseSample
+
+	if reanalyze {
+		// Recompute the receipt from an existing -out directory's already-
+		// captured artifacts. Skips build and every timed measurement -- use
+		// this only to iterate on classify.go/receipt.go against a
+		// measurement pass that already ran, never to fabricate a new
+		// measurement without rerunning the timed phase.
+		fmt.Println("attribution: [reanalyze] loading existing artifacts from", outDir)
+		var err error
+		captureManifest, err = loadCaptureManifest(outDir)
+		if err != nil {
+			return fmt.Errorf("reanalyze: load capture manifest: %w", err)
+		}
+		workcounts, err = loadWorkCounts(outDir)
+		if err != nil {
+			return fmt.Errorf("reanalyze: load work counts: %w", err)
+		}
+		noiseSamples, err = loadNoiseSamples(outDir)
+		if err != nil {
+			return fmt.Errorf("reanalyze: load noise samples: %w", err)
+		}
+	} else {
+		// ---- Build phase: everything is built and written first, before any
+		// timed measurement runs, per the campaign's noise-sequencing rule. ----
+		fmt.Println("attribution: [build] extracting canonical fixtures")
+		fixturePaths, err := extractFixtures(cfg)
+		if err != nil {
+			return fmt.Errorf("extract fixtures: %w", err)
+		}
+
+		fmt.Println("attribution: [build] compiling capture test binary (tags gts_parsercorephase0)")
+		captureBin := filepath.Join(outDir, "bin", "capture.test")
+		if err := goTestBuild(cfg.repoRoot, "gts_parsercorephase0", captureBin); err != nil {
+			return fmt.Errorf("build capture binary: %w", err)
+		}
+
+		fmt.Println("attribution: [build] compiling work-count test binary (tags gts_parsercorephase0,gts_workcount)")
+		workcountBin := filepath.Join(outDir, "bin", "workcount.test")
+		if err := goTestBuild(cfg.repoRoot, "gts_parsercorephase0,gts_workcount", workcountBin); err != nil {
+			return fmt.Errorf("build workcount binary: %w", err)
+		}
+
+		// ---- Measurement phase: one final pass. ----
+		fmt.Println("attribution: [measure] capturing CPU profiles (diagnostic lane x4, shipped route x3)")
+		captureManifest, err = runCapture(cfg, captureBin)
+		if err != nil {
+			return fmt.Errorf("run capture: %w", err)
+		}
+
+		fmt.Println("attribution: [measure] running work-count children (event counts per fixture)")
+		workcounts, err = runWorkCounts(cfg, workcountBin, fixturePaths)
+		if err != nil {
+			return fmt.Errorf("run work counts: %w", err)
+		}
+
+		fmt.Println("attribution: [measure] running interleaved A/A noise floor")
+		noiseSamples, err = runNoiseFloor(cfg, captureBin)
+		if err != nil {
+			return fmt.Errorf("run noise floor: %w", err)
+		}
+	}
+
+	// ---- Analysis phase. ----
+	fmt.Println("attribution: [analyze] mapping CPU profiles to the attribution tree")
+	receipt, err := buildReceipt(cfg, captureManifest, workcounts, noiseSamples)
+	if err != nil {
+		return fmt.Errorf("build receipt: %w", err)
+	}
+
+	jsonPath := filepath.Join(outDir, "receipt.json")
+	if err := writeJSON(jsonPath, receipt); err != nil {
+		return err
+	}
+	mdPath := filepath.Join(outDir, "receipt.md")
+	if err := os.WriteFile(mdPath, []byte(renderMarkdown(receipt)), 0o644); err != nil {
+		return err
+	}
+	fmt.Println("attribution: wrote", jsonPath)
+	fmt.Println("attribution: wrote", mdPath)
+	fmt.Println(renderMarkdown(receipt))
+	return nil
+}
+
+func verifyRepoRoot(root string) error {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return fmt.Errorf("-repo %s does not look like the gotreesitter repository root: %w", root, err)
+	}
+	if !strings.Contains(string(data), "module github.com/odvcencio/gotreesitter\n") {
+		return fmt.Errorf("-repo %s go.mod is not the gotreesitter root module", root)
+	}
+	return nil
+}
+
+// ---- Build helpers ----
+
+type fixtureSpec struct {
+	ID           string
+	Asset        string
+	Bytes        int
+	SourceSHA256 string
+}
+
+// fixtureSpecs mirrors the same four pinned canonical fixtures already
+// authenticated in diagnosticParserCoreCanonicalAdmissions (root package) and
+// cgo_harness/pure_c/run_canonical_go_full_parse.sh. Triple-pinning identity
+// constants across independent tools is this repository's existing
+// convention for these fixtures.
+var fixtureSpecs = []fixtureSpec{
+	{ID: "rewrite", Asset: "rewrite.go.gz", Bytes: 5116, SourceSHA256: "74c0705f8729670559492fb5460a01b2a1a2a109928e1aeb52736e485e8ff097"},
+	{ID: "query_compile", Asset: "query_compile.go.gz", Bytes: 20168, SourceSHA256: "b788ee19b0075f0b9b567a9f93ea657e715bc8a6a40a99d3ca5c761404e71894"},
+	{ID: "language", Asset: "language.go.gz", Bytes: 41387, SourceSHA256: "009aa9fd5352c712f3839670c7df8a9b00ae878ee20dc88131a438b2d5edfd9a"},
+	{ID: "grammargen_lr", Asset: "grammargen_lr.go.gz", Bytes: 235626, SourceSHA256: "a7e4a1a64b25a60aea36183b9d6d53dcd9240942cdb10e67a3cf9e6ce30f95b2"},
+}
+
+func extractFixtures(cfg config) (map[string]string, error) {
+	paths := map[string]string{}
+	for _, spec := range fixtureSpecs {
+		assetPath := filepath.Join(cfg.repoRoot, "internal", "benchfixtures", "testdata", spec.Asset)
+		data, err := gunzipFile(assetPath)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", spec.ID, err)
+		}
+		if len(data) != spec.Bytes {
+			return nil, fmt.Errorf("%s: got %d bytes, want %d", spec.ID, len(data), spec.Bytes)
+		}
+		if got := sha256Hex(data); got != spec.SourceSHA256 {
+			return nil, fmt.Errorf("%s: source sha256=%s want=%s", spec.ID, got, spec.SourceSHA256)
+		}
+		outPath := filepath.Join(cfg.outDir, "fixtures", spec.ID+".go")
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			return nil, err
+		}
+		paths[spec.ID] = outPath
+	}
+	return paths, nil
+}
+
+func goTestBuild(repoRoot, tags, outBin string) error {
+	cmd := exec.Command("go", "test", "-tags", tags, "-c", "-o", outBin, ".")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v\n%s", err, out)
+	}
+	return nil
+}
+
+// ---- Capture phase ----
+
+type captureRow struct {
+	Label       string  `json:"label"`
+	Fixture     string  `json:"fixture"`
+	SourceBytes int     `json:"source_bytes"`
+	Iterations  int     `json:"iterations"`
+	ElapsedNS   int64   `json:"elapsed_ns"`
+	NSPerOp     float64 `json:"ns_per_op"`
+	ProfilePath string  `json:"profile_path"`
+}
+
+type captureManifest struct {
+	SchemaVersion string       `json:"schema_version"`
+	GeneratedUTC  string       `json:"generated_utc"`
+	DurationParam string       `json:"duration_param"`
+	Rows          []captureRow `json:"rows"`
+}
+
+func runCapture(cfg config, captureBin string) (*captureManifest, error) {
+	profilesDir := filepath.Join(cfg.outDir, "profiles")
+	args := []string{"-test.run", "^TestParserCoreAttributionCapture$", "-test.v"}
+	cmd := commandWithCore(cfg, captureBin, args...)
+	cmd.Dir = cfg.repoRoot
+	cmd.Env = append(os.Environ(),
+		"GOMAXPROCS=1",
+		"GTS_ATTRIBUTION_OUT="+profilesDir,
+		"GTS_ATTRIBUTION_DURATION="+cfg.captureDuration.String(),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("%v\n%s", err, out)
+	}
+	data, err := os.ReadFile(filepath.Join(profilesDir, "capture_manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	var manifest captureManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+// loadCaptureManifest re-reads a prior run's capture_manifest.json for
+// -reanalyze, without invoking the capture binary again.
+func loadCaptureManifest(outDir string) (*captureManifest, error) {
+	data, err := os.ReadFile(filepath.Join(outDir, "profiles", "capture_manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	var manifest captureManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+// ---- Work-count phase ----
+
+type workCountResult struct {
+	Fixture     string `json:"fixture"`
+	SourceBytes uint32 `json:"source_bytes"`
+	CoreWork    struct {
+		Shifts               uint64 `json:"shifts"`
+		Reductions           uint64 `json:"reductions"`
+		ReductionPopRequests uint64 `json:"reduction_pop_requests"`
+		EmittedPopPaths      uint64 `json:"emitted_pop_paths"`
+		EmittedPopPayloads   uint64 `json:"emitted_pop_payloads"`
+	} `json:"core_work"`
+	SchedulerWork struct {
+		ActionLookups     uint64 `json:"action_lookups"`
+		Elections         uint64 `json:"elections"`
+		Conflicts         uint64 `json:"conflicts"`
+		Canonicalizations uint64 `json:"canonicalizations"`
+		PeakHeaders       uint64 `json:"peak_headers"`
+	} `json:"scheduler_work"`
+}
+
+func runWorkCounts(cfg config, workcountBin string, fixturePaths map[string]string) (map[string]workCountResult, error) {
+	results := map[string]workCountResult{}
+	for _, spec := range fixtureSpecs {
+		resultPath := filepath.Join(cfg.outDir, "workcount", spec.ID+".json")
+		cmd := commandWithCore(cfg, workcountBin, "-test.run", "^TestParserCoreWorkCountChild$", "-test.v")
+		cmd.Dir = cfg.repoRoot
+		cmd.Env = append(os.Environ(),
+			"GOMAXPROCS=1",
+			"GTS_WORK_COUNT_FIXTURE="+spec.ID,
+			"GTS_WORK_COUNT_SOURCE="+fixturePaths[spec.ID],
+			"GTS_WORK_COUNT_RESULT="+resultPath,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("%s: %v\n%s", spec.ID, err, out)
+		}
+		data, err := os.ReadFile(resultPath)
+		if err != nil {
+			return nil, err
+		}
+		var result workCountResult
+		if err := json.Unmarshal(data, &result); err != nil {
+			return nil, err
+		}
+		results[spec.ID] = result
+	}
+	return results, nil
+}
+
+// loadWorkCounts re-reads a prior run's per-fixture work-count JSON files for
+// -reanalyze, without invoking the work-count binary again.
+func loadWorkCounts(outDir string) (map[string]workCountResult, error) {
+	results := map[string]workCountResult{}
+	for _, spec := range fixtureSpecs {
+		data, err := os.ReadFile(filepath.Join(outDir, "workcount", spec.ID+".json"))
+		if err != nil {
+			return nil, err
+		}
+		var result workCountResult
+		if err := json.Unmarshal(data, &result); err != nil {
+			return nil, err
+		}
+		results[spec.ID] = result
+	}
+	return results, nil
+}
+
+// ---- Noise floor phase ----
+
+type noiseSample struct {
+	Series  string // "A" or "B"
+	Fixture string
+	NSPerOp float64
+}
+
+// The "-N" GOMAXPROCS suffix only appears when the binary is invoked with
+// -test.cpu specifying multiple CPU counts; a plain run (this tool's case)
+// omits it, so the suffix is optional here.
+var benchLineRe = regexp.MustCompile(`^BenchmarkParserCoreFreshFullCanonical/([A-Za-z0-9_]+)(?:-[0-9]+)?\s+([0-9]+)\s+([0-9.]+)\s+ns/op`)
+
+func runNoiseFloor(cfg config, captureBin string) ([]noiseSample, error) {
+	var samples []noiseSample
+	for i := 0; i < cfg.noiseSamples; i++ {
+		for _, series := range []string{"A", "B"} {
+			raw, err := runBenchOnce(cfg, captureBin, i, series)
+			if err != nil {
+				return nil, err
+			}
+			perFixture := parseBenchOutput(raw)
+			if len(perFixture) != len(fixtureSpecs) {
+				return nil, fmt.Errorf("noise floor pair %d series %s: got %d fixture results, want %d\n%s", i, series, len(perFixture), len(fixtureSpecs), raw)
+			}
+			for fixture, ns := range perFixture {
+				samples = append(samples, noiseSample{Series: series, Fixture: fixture, NSPerOp: ns})
+			}
+		}
+	}
+	return samples, nil
+}
+
+func runBenchOnce(cfg config, captureBin string, pairIndex int, series string) (string, error) {
+	rawPath := filepath.Join(cfg.outDir, "noise", fmt.Sprintf("pair%02d_%s.txt", pairIndex, series))
+	cmd := commandWithCore(cfg, captureBin,
+		"-test.run", "^$",
+		"-test.bench", "^BenchmarkParserCoreFreshFullCanonical$",
+		"-test.benchtime", cfg.noiseBenchtime.String(),
+		"-test.count=1",
+	)
+	cmd.Dir = cfg.repoRoot
+	cmd.Env = append(os.Environ(), "GOMAXPROCS=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("bench pair %d series %s: %v\n%s", pairIndex, series, err, out)
+	}
+	if err := os.WriteFile(rawPath, out, 0o644); err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// loadNoiseSamples re-parses a prior run's saved noise-floor raw benchmark
+// output files for -reanalyze, without invoking the capture binary again.
+func loadNoiseSamples(outDir string) ([]noiseSample, error) {
+	var samples []noiseSample
+	for _, series := range []string{"A", "B"} {
+		matches, err := filepath.Glob(filepath.Join(outDir, "noise", "pair*_"+series+".txt"))
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(matches)
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no saved noise-floor series %s files under %s", series, outDir)
+		}
+		for _, path := range matches {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			perFixture := parseBenchOutput(string(data))
+			if len(perFixture) != len(fixtureSpecs) {
+				return nil, fmt.Errorf("%s: got %d fixture results, want %d", path, len(perFixture), len(fixtureSpecs))
+			}
+			for fixture, ns := range perFixture {
+				samples = append(samples, noiseSample{Series: series, Fixture: fixture, NSPerOp: ns})
+			}
+		}
+	}
+	return samples, nil
+}
+
+func parseBenchOutput(output string) map[string]float64 {
+	result := map[string]float64{}
+	for _, line := range strings.Split(output, "\n") {
+		m := benchLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ns, err := strconv.ParseFloat(m[3], 64)
+		if err != nil {
+			continue
+		}
+		result[m[1]] = ns
+	}
+	return result
+}
+
+// commandWithCore optionally wraps the command with taskset -c <core>.
+func commandWithCore(cfg config, bin string, args ...string) *exec.Cmd {
+	if cfg.core != "" {
+		full := append([]string{"-c", cfg.core, bin}, args...)
+		return exec.Command("taskset", full...)
+	}
+	return exec.Command(bin, args...)
+}
+
+// ---- small helpers ----
+
+func writeJSON(path string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func sortedFixtureIDs() []string {
+	ids := make([]string, len(fixtureSpecs))
+	for i, spec := range fixtureSpecs {
+		ids[i] = spec.ID
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/cgo_harness/attribution/pprofdecode.go
+++ b/cgo_harness/attribution/pprofdecode.go
@@ -1,0 +1,477 @@
+package main
+
+// A minimal, read-only decoder for the pprof profile.proto wire format
+// (https://github.com/google/pprof/blob/main/proto/profile.proto). This tool
+// deliberately does not depend on github.com/google/pprof: the root module
+// and the cgo_harness module both keep a minimal dependency footprint, and
+// attribution measurement infrastructure should not widen it. The decoder
+// only reads the handful of fields the attribution mapper needs: sample
+// values, sample call stacks (location IDs), locations (function IDs and
+// line numbers), functions (name and filename string-table indices), and the
+// string table itself. It ignores every other field via generic wire-type
+// skipping, so it stays correct across pprof profile.proto's optional fields.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// pbFrame is one resolved stack frame: a function name and its defining file,
+// in the profile's string table.
+type pbFrame struct {
+	Function string
+	File     string
+	Line     int64
+}
+
+// pbSample is one CPU-profile sample: a leaf-to-root call stack and the
+// sampled value (nanoseconds of on-CPU time for a Go CPU profile).
+type pbSample struct {
+	Stack   []pbFrame // index 0 is the leaf (innermost, currently executing) frame.
+	ValueNS int64
+}
+
+// pbProfile is the decoded subset of a pprof CPU profile this tool needs.
+type pbProfile struct {
+	Samples []pbSample
+}
+
+type pbLine struct {
+	FunctionID uint64
+	LineNo     int64
+}
+
+type pbLocation struct {
+	ID    uint64
+	Lines []pbLine
+}
+
+type pbFunction struct {
+	ID          uint64
+	NameIdx     int64
+	FilenameIdx int64
+}
+
+type pbValueType struct {
+	TypeIdx int64
+	UnitIdx int64
+}
+
+type pbRawSample struct {
+	LocationIDs []uint64
+	Values      []int64
+}
+
+// decodePProfCPUProfile reads a gzip-compressed pprof CPU profile from path
+// and resolves it into leaf-to-root frame stacks with their CPU-nanosecond
+// value, using the sample_type entry named "cpu".
+func decodePProfCPUProfile(path string) (*pbProfile, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%s: gzip: %w", path, err)
+	}
+	data, err := io.ReadAll(reader)
+	if closeErr := reader.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s: decompress: %w", path, err)
+	}
+
+	dec := &pbReader{buf: data}
+	var stringTable []string
+	var valueTypes []pbValueType
+	var rawSamples []pbRawSample
+	locations := map[uint64]pbLocation{}
+	functions := map[uint64]pbFunction{}
+
+	for !dec.done() {
+		field, wireType, err := dec.tag()
+		if err != nil {
+			return nil, fmt.Errorf("%s: tag: %w", path, err)
+		}
+		switch {
+		case field == 1 && wireType == 2: // sample_type
+			body, err := dec.bytes()
+			if err != nil {
+				return nil, fmt.Errorf("%s: sample_type: %w", path, err)
+			}
+			vt, err := decodeValueType(body)
+			if err != nil {
+				return nil, fmt.Errorf("%s: sample_type: %w", path, err)
+			}
+			valueTypes = append(valueTypes, vt)
+		case field == 2 && wireType == 2: // sample
+			body, err := dec.bytes()
+			if err != nil {
+				return nil, fmt.Errorf("%s: sample: %w", path, err)
+			}
+			sample, err := decodeRawSample(body)
+			if err != nil {
+				return nil, fmt.Errorf("%s: sample: %w", path, err)
+			}
+			rawSamples = append(rawSamples, sample)
+		case field == 4 && wireType == 2: // location
+			body, err := dec.bytes()
+			if err != nil {
+				return nil, fmt.Errorf("%s: location: %w", path, err)
+			}
+			loc, err := decodeLocation(body)
+			if err != nil {
+				return nil, fmt.Errorf("%s: location: %w", path, err)
+			}
+			locations[loc.ID] = loc
+		case field == 5 && wireType == 2: // function
+			body, err := dec.bytes()
+			if err != nil {
+				return nil, fmt.Errorf("%s: function: %w", path, err)
+			}
+			fn, err := decodeFunction(body)
+			if err != nil {
+				return nil, fmt.Errorf("%s: function: %w", path, err)
+			}
+			functions[fn.ID] = fn
+		case field == 6 && wireType == 2: // string_table entry
+			body, err := dec.bytes()
+			if err != nil {
+				return nil, fmt.Errorf("%s: string_table: %w", path, err)
+			}
+			stringTable = append(stringTable, string(body))
+		default:
+			if err := dec.skip(wireType); err != nil {
+				return nil, fmt.Errorf("%s: skip field %d: %w", path, field, err)
+			}
+		}
+	}
+
+	str := func(idx int64) string {
+		if idx < 0 || int(idx) >= len(stringTable) {
+			return ""
+		}
+		return stringTable[idx]
+	}
+
+	valueIndex := -1
+	for i, vt := range valueTypes {
+		if str(vt.TypeIdx) == "cpu" {
+			valueIndex = i
+			break
+		}
+	}
+	if valueIndex == -1 {
+		if len(valueTypes) >= 2 {
+			valueIndex = 1 // runtime/pprof CPU profiles: [0]=samples/count, [1]=cpu/nanoseconds.
+		} else {
+			return nil, fmt.Errorf("%s: no \"cpu\" sample_type found (have %d)", path, len(valueTypes))
+		}
+	}
+
+	resolveFrame := func(functionID uint64, lineNo int64) pbFrame {
+		fn, ok := functions[functionID]
+		if !ok {
+			return pbFrame{Function: fmt.Sprintf("<unknown function %d>", functionID), Line: lineNo}
+		}
+		return pbFrame{Function: str(fn.NameIdx), File: str(fn.FilenameIdx), Line: lineNo}
+	}
+
+	profile := &pbProfile{}
+	for _, raw := range rawSamples {
+		if valueIndex >= len(raw.Values) {
+			return nil, fmt.Errorf("%s: sample has %d values, want index %d", path, len(raw.Values), valueIndex)
+		}
+		sample := pbSample{ValueNS: raw.Values[valueIndex]}
+		for _, locID := range raw.LocationIDs {
+			loc, ok := locations[locID]
+			if !ok {
+				sample.Stack = append(sample.Stack, pbFrame{Function: fmt.Sprintf("<unknown location %d>", locID)})
+				continue
+			}
+			// Line[0] is the innermost inlined frame; keep that order (leaf-first).
+			for _, line := range loc.Lines {
+				sample.Stack = append(sample.Stack, resolveFrame(line.FunctionID, line.LineNo))
+			}
+			if len(loc.Lines) == 0 {
+				sample.Stack = append(sample.Stack, pbFrame{Function: fmt.Sprintf("<no line info, location %d>", locID)})
+			}
+		}
+		profile.Samples = append(profile.Samples, sample)
+	}
+	return profile, nil
+}
+
+func decodeValueType(body []byte) (pbValueType, error) {
+	dec := &pbReader{buf: body}
+	var vt pbValueType
+	for !dec.done() {
+		field, wireType, err := dec.tag()
+		if err != nil {
+			return vt, err
+		}
+		switch {
+		case field == 1 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return vt, err
+			}
+			vt.TypeIdx = int64(v)
+		case field == 2 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return vt, err
+			}
+			vt.UnitIdx = int64(v)
+		default:
+			if err := dec.skip(wireType); err != nil {
+				return vt, err
+			}
+		}
+	}
+	return vt, nil
+}
+
+func decodeRawSample(body []byte) (pbRawSample, error) {
+	dec := &pbReader{buf: body}
+	var sample pbRawSample
+	for !dec.done() {
+		field, wireType, err := dec.tag()
+		if err != nil {
+			return sample, err
+		}
+		switch {
+		case field == 1: // location_id: repeated uint64, packed or unpacked.
+			ids, err := decodeVarintList(dec, wireType)
+			if err != nil {
+				return sample, err
+			}
+			for _, id := range ids {
+				sample.LocationIDs = append(sample.LocationIDs, id)
+			}
+		case field == 2: // value: repeated int64, packed or unpacked.
+			values, err := decodeVarintList(dec, wireType)
+			if err != nil {
+				return sample, err
+			}
+			for _, v := range values {
+				sample.Values = append(sample.Values, int64(v))
+			}
+		default:
+			if err := dec.skip(wireType); err != nil {
+				return sample, err
+			}
+		}
+	}
+	return sample, nil
+}
+
+func decodeLocation(body []byte) (pbLocation, error) {
+	dec := &pbReader{buf: body}
+	var loc pbLocation
+	for !dec.done() {
+		field, wireType, err := dec.tag()
+		if err != nil {
+			return loc, err
+		}
+		switch {
+		case field == 1 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return loc, err
+			}
+			loc.ID = v
+		case field == 4 && wireType == 2: // line (repeated Line message)
+			lineBody, err := dec.bytes()
+			if err != nil {
+				return loc, err
+			}
+			line, err := decodeLine(lineBody)
+			if err != nil {
+				return loc, err
+			}
+			loc.Lines = append(loc.Lines, line)
+		default:
+			if err := dec.skip(wireType); err != nil {
+				return loc, err
+			}
+		}
+	}
+	return loc, nil
+}
+
+func decodeLine(body []byte) (pbLine, error) {
+	dec := &pbReader{buf: body}
+	var line pbLine
+	for !dec.done() {
+		field, wireType, err := dec.tag()
+		if err != nil {
+			return line, err
+		}
+		switch {
+		case field == 1 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return line, err
+			}
+			line.FunctionID = v
+		case field == 2 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return line, err
+			}
+			line.LineNo = int64(v)
+		default:
+			if err := dec.skip(wireType); err != nil {
+				return line, err
+			}
+		}
+	}
+	return line, nil
+}
+
+func decodeFunction(body []byte) (pbFunction, error) {
+	dec := &pbReader{buf: body}
+	var fn pbFunction
+	for !dec.done() {
+		field, wireType, err := dec.tag()
+		if err != nil {
+			return fn, err
+		}
+		switch {
+		case field == 1 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return fn, err
+			}
+			fn.ID = v
+		case field == 2 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return fn, err
+			}
+			fn.NameIdx = int64(v)
+		case field == 4 && wireType == 0:
+			v, err := dec.varint()
+			if err != nil {
+				return fn, err
+			}
+			fn.FilenameIdx = int64(v)
+		default:
+			if err := dec.skip(wireType); err != nil {
+				return fn, err
+			}
+		}
+	}
+	return fn, nil
+}
+
+// decodeVarintList reads a repeated varint field's value(s) starting after the
+// tag has already been consumed. wireType 2 means packed (a length-delimited
+// blob of back-to-back varints); wireType 0 means one unpacked varint.
+func decodeVarintList(dec *pbReader, wireType int) ([]uint64, error) {
+	switch wireType {
+	case 2:
+		body, err := dec.bytes()
+		if err != nil {
+			return nil, err
+		}
+		sub := &pbReader{buf: body}
+		var out []uint64
+		for !sub.done() {
+			v, err := sub.varint()
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, v)
+		}
+		return out, nil
+	case 0:
+		v, err := dec.varint()
+		if err != nil {
+			return nil, err
+		}
+		return []uint64{v}, nil
+	default:
+		return nil, fmt.Errorf("unsupported wire type %d for varint list", wireType)
+	}
+}
+
+// pbReader is a minimal forward-only protobuf wire-format cursor.
+type pbReader struct {
+	buf []byte
+	pos int
+}
+
+func (r *pbReader) done() bool { return r.pos >= len(r.buf) }
+
+func (r *pbReader) varint() (uint64, error) {
+	var x uint64
+	var shift uint
+	for {
+		if r.pos >= len(r.buf) {
+			return 0, io.ErrUnexpectedEOF
+		}
+		b := r.buf[r.pos]
+		r.pos++
+		if shift >= 64 {
+			return 0, errors.New("pbreader: varint too long")
+		}
+		x |= uint64(b&0x7f) << shift
+		if b < 0x80 {
+			return x, nil
+		}
+		shift += 7
+	}
+}
+
+func (r *pbReader) tag() (field int, wireType int, err error) {
+	v, err := r.varint()
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(v >> 3), int(v & 0x7), nil
+}
+
+func (r *pbReader) bytes() ([]byte, error) {
+	n, err := r.varint()
+	if err != nil {
+		return nil, err
+	}
+	if n > uint64(len(r.buf)-r.pos) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	out := r.buf[r.pos : r.pos+int(n)]
+	r.pos += int(n)
+	return out, nil
+}
+
+func (r *pbReader) skip(wireType int) error {
+	switch wireType {
+	case 0:
+		_, err := r.varint()
+		return err
+	case 1:
+		if len(r.buf)-r.pos < 8 {
+			return io.ErrUnexpectedEOF
+		}
+		r.pos += 8
+		return nil
+	case 2:
+		_, err := r.bytes()
+		return err
+	case 5:
+		if len(r.buf)-r.pos < 4 {
+			return io.ErrUnexpectedEOF
+		}
+		r.pos += 4
+		return nil
+	default:
+		return fmt.Errorf("pbreader: unsupported wire type %d", wireType)
+	}
+}

--- a/cgo_harness/attribution/receipt.go
+++ b/cgo_harness/attribution/receipt.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ---- gzip / hash helpers ----
+
+func gunzipFile(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return io.ReadAll(reader)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// ---- Receipt model ----
+
+type ReceiptComponentShare struct {
+	Component   Component `json:"component"`
+	NS          int64     `json:"ns"`
+	SharePct    float64   `json:"share_pct"` // rounded to 1 decimal for display
+	RawSharePct float64   `json:"raw_share_pct"`
+}
+
+type ReceiptRow struct {
+	Label           string                  `json:"label"` // "diagnostic lane" | "shipped route"
+	Fixture         string                  `json:"fixture"`
+	SourceBytes     int                     `json:"source_bytes"`
+	Iterations      int                     `json:"iterations"`
+	WallNSPerOp     float64                 `json:"wall_ns_per_op"`
+	ProfiledTotalNS int64                   `json:"profiled_total_ns"`
+	ProfiledWallNS  int64                   `json:"profiled_wall_ns"`
+	CoveragePct     float64                 `json:"profile_coverage_pct"` // profiled_total_ns / profiled_wall_ns
+	Components      []ReceiptComponentShare `json:"components"`
+	RoundedShareSum float64                 `json:"rounded_share_sum_pct"`
+	WithinTolerance bool                    `json:"within_tolerance"`
+	UnclassifiedTop []unclassifiedEntry     `json:"unclassified_top,omitempty"`
+}
+
+type ReceiptNoiseFloorRow struct {
+	Fixture        string  `json:"fixture"`
+	Pairs          int     `json:"pairs"`
+	MedianNSPerOp  float64 `json:"median_ns_per_op"`
+	P95AbsDeltaNS  float64 `json:"p95_abs_delta_ns"`
+	P95PctOfMedian float64 `json:"p95_pct_of_median"`
+}
+
+type ReceiptCostPerEventClass struct {
+	Class     string  `json:"class"`
+	Count     uint64  `json:"count"`
+	NSPerUnit float64 `json:"ns_per_event"`
+}
+
+type ReceiptCostPerEventRow struct {
+	Fixture     string                     `json:"fixture"`
+	WallNSPerOp float64                    `json:"wall_ns_per_op"`
+	Classes     []ReceiptCostPerEventClass `json:"classes"`
+}
+
+type Receipt struct {
+	SchemaVersion    string                   `json:"schema_version"`
+	GeneratedUTC     string                   `json:"generated_utc"`
+	GitCommit        string                   `json:"git_commit"`
+	HostClass        string                   `json:"host_class"`
+	ToleranceNote    string                   `json:"tolerance_note"`
+	AttributionRows  []ReceiptRow             `json:"attribution_rows"`
+	NoiseFloor       []ReceiptNoiseFloorRow   `json:"noise_floor"`
+	NoiseFloorMethod string                   `json:"noise_floor_method"`
+	CostPerEvent     []ReceiptCostPerEventRow `json:"cost_per_event"`
+	CostPerEventNote string                   `json:"cost_per_event_note"`
+}
+
+const attributionTolerancePP = 0.2 // percentage points; see docs/perf-attribution.md.
+
+func buildReceipt(cfg config, capture *captureManifest, workcounts map[string]workCountResult, noise []noiseSample) (*Receipt, error) {
+	receipt := &Receipt{
+		SchemaVersion: "gts-perf-attribution-receipt/v1",
+		GeneratedUTC:  time.Now().UTC().Format(time.RFC3339),
+		GitCommit:     gitHead(cfg.repoRoot),
+		HostClass:     "shared WSL2 development host, background load uncontrolled (local-development floor, not quiet-host or enclave)",
+		ToleranceNote: fmt.Sprintf("component shares are computed to sum to exactly 100%% of attributed samples by construction (ComponentOther absorbs the remainder); the displayed 1-decimal rows are checked to sum to 100%% within +/-%.1f percentage points of rounding tolerance", attributionTolerancePP),
+	}
+
+	for _, row := range capture.Rows {
+		profile, err := decodePProfCPUProfile(row.ProfilePath)
+		if err != nil {
+			return nil, fmt.Errorf("%s %s: decode profile: %w", row.Label, row.Fixture, err)
+		}
+		attribution := attributeProfile(profile)
+		receiptRow := ReceiptRow{
+			Label: row.Label, Fixture: row.Fixture, SourceBytes: row.SourceBytes,
+			Iterations: row.Iterations, WallNSPerOp: row.NSPerOp,
+			ProfiledTotalNS: attribution.TotalSampleNS, ProfiledWallNS: row.ElapsedNS,
+		}
+		if row.ElapsedNS > 0 {
+			receiptRow.CoveragePct = 100 * float64(attribution.TotalSampleNS) / float64(row.ElapsedNS)
+		}
+		var roundedSum float64
+		for _, component := range ComponentOrder {
+			ns := attribution.ComponentNS[component]
+			var raw float64
+			if attribution.TotalSampleNS > 0 {
+				raw = 100 * float64(ns) / float64(attribution.TotalSampleNS)
+			}
+			rounded := math.Round(raw*10) / 10
+			roundedSum += rounded
+			receiptRow.Components = append(receiptRow.Components, ReceiptComponentShare{
+				Component: component, NS: ns, SharePct: rounded, RawSharePct: raw,
+			})
+		}
+		receiptRow.RoundedShareSum = math.Round(roundedSum*10) / 10
+		// A tiny epsilon absorbs float64 representation noise (e.g. 99.8 is not
+		// exactly representable), so a sum that is exactly at the stated
+		// tolerance boundary is not spuriously marked as a miss.
+		const toleranceEpsilon = 1e-9
+		receiptRow.WithinTolerance = math.Abs(receiptRow.RoundedShareSum-100) <= attributionTolerancePP+toleranceEpsilon
+		if len(attribution.UnclassifiedTop) > 0 {
+			top := attribution.UnclassifiedTop
+			if len(top) > 8 {
+				top = top[:8]
+			}
+			receiptRow.UnclassifiedTop = top
+		}
+		receipt.AttributionRows = append(receipt.AttributionRows, receiptRow)
+	}
+
+	receipt.NoiseFloorMethod = "BenchmarkParserCoreFreshFullCanonical, identical prebuilt binary invoked twice per pair (series A and series B), interleaved A,B,A,B,...; GOMAXPROCS=1; delta_i = |A_i - B_i| per fixture per pair; p95 by linear interpolation over sorted deltas"
+	receipt.NoiseFloor = buildNoiseFloorRows(noise)
+
+	receipt.CostPerEventNote = "average attribution, not a causal model: wall ns/op for the diagnostic lane divided by the gts_workcount event count for the same fixture and lifecycle"
+	receipt.CostPerEvent = buildCostPerEventRows(capture, workcounts)
+
+	return receipt, nil
+}
+
+func buildNoiseFloorRows(samples []noiseSample) []ReceiptNoiseFloorRow {
+	byFixture := map[string]map[int]map[string]float64{} // fixture -> pairIndex -> series -> ns
+	// We do not have the pair index directly on noiseSample (by design it is
+	// order-independent); reconstruct pairing by stable per-fixture, per-series
+	// arrival order instead (A_1..A_n paired positionally with B_1..B_n).
+	seriesValues := map[string]map[string][]float64{} // fixture -> series -> values in arrival order
+	for _, s := range samples {
+		if seriesValues[s.Fixture] == nil {
+			seriesValues[s.Fixture] = map[string][]float64{}
+		}
+		seriesValues[s.Fixture][s.Series] = append(seriesValues[s.Fixture][s.Series], s.NSPerOp)
+	}
+	_ = byFixture
+
+	var rows []ReceiptNoiseFloorRow
+	fixtures := make([]string, 0, len(seriesValues))
+	for fixture := range seriesValues {
+		fixtures = append(fixtures, fixture)
+	}
+	sort.Strings(fixtures)
+	for _, fixture := range fixtures {
+		aValues := seriesValues[fixture]["A"]
+		bValues := seriesValues[fixture]["B"]
+		n := len(aValues)
+		if len(bValues) < n {
+			n = len(bValues)
+		}
+		var deltas []float64
+		var all []float64
+		for i := 0; i < n; i++ {
+			deltas = append(deltas, math.Abs(aValues[i]-bValues[i]))
+			all = append(all, aValues[i], bValues[i])
+		}
+		sort.Float64s(deltas)
+		sort.Float64s(all)
+		median := percentile(all, 50)
+		p95 := percentile(deltas, 95)
+		row := ReceiptNoiseFloorRow{
+			Fixture: fixture, Pairs: n, MedianNSPerOp: median, P95AbsDeltaNS: p95,
+		}
+		if median > 0 {
+			row.P95PctOfMedian = 100 * p95 / median
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func percentile(sortedAsc []float64, p float64) float64 {
+	n := len(sortedAsc)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sortedAsc[0]
+	}
+	rank := p / 100 * float64(n-1)
+	lo := int(math.Floor(rank))
+	hi := int(math.Ceil(rank))
+	if lo == hi {
+		return sortedAsc[lo]
+	}
+	frac := rank - float64(lo)
+	return sortedAsc[lo] + (sortedAsc[hi]-sortedAsc[lo])*frac
+}
+
+func buildCostPerEventRows(capture *captureManifest, workcounts map[string]workCountResult) []ReceiptCostPerEventRow {
+	wallByFixture := map[string]float64{}
+	for _, row := range capture.Rows {
+		if row.Label == "diagnostic lane" {
+			wallByFixture[row.Fixture] = row.NSPerOp
+		}
+	}
+	var rows []ReceiptCostPerEventRow
+	for _, spec := range fixtureSpecs {
+		wall, ok := wallByFixture[spec.ID]
+		if !ok {
+			continue
+		}
+		wc, ok := workcounts[spec.ID]
+		if !ok {
+			continue
+		}
+		row := ReceiptCostPerEventRow{Fixture: spec.ID, WallNSPerOp: wall}
+		classes := []struct {
+			name  string
+			count uint64
+		}{
+			{"shifts", wc.CoreWork.Shifts},
+			{"reductions", wc.CoreWork.Reductions},
+			{"emitted_pop_paths", wc.CoreWork.EmittedPopPaths},
+			{"emitted_pop_payloads", wc.CoreWork.EmittedPopPayloads},
+			{"canonicalizations", wc.SchedulerWork.Canonicalizations},
+			{"elections", wc.SchedulerWork.Elections},
+			{"action_lookups", wc.SchedulerWork.ActionLookups},
+		}
+		for _, c := range classes {
+			var nsPer float64
+			if c.count > 0 {
+				nsPer = wall / float64(c.count)
+			}
+			row.Classes = append(row.Classes, ReceiptCostPerEventClass{Class: c.name, Count: c.count, NSPerUnit: nsPer})
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func gitHead(repoRoot string) string {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// ---- Markdown rendering ----
+
+func renderMarkdown(r *Receipt) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Generated %s, git %s.\n\n", r.GeneratedUTC, r.GitCommit)
+	fmt.Fprintf(&b, "Host class: %s.\n\n", r.HostClass)
+	fmt.Fprintf(&b, "%s.\n\n", r.ToleranceNote)
+
+	fmt.Fprintln(&b, "### Attribution shares")
+	fmt.Fprintln(&b)
+	header := []string{"lane", "fixture", "wall ns/op", "coverage %"}
+	for _, c := range ComponentOrder {
+		header = append(header, string(c))
+	}
+	header = append(header, "sum %")
+	fmt.Fprintln(&b, "| "+strings.Join(header, " | ")+" |")
+	fmt.Fprintln(&b, "|"+strings.Repeat("---|", len(header)))
+	for _, row := range r.AttributionRows {
+		cells := []string{
+			row.Label, row.Fixture,
+			formatNS(row.WallNSPerOp),
+			fmt.Sprintf("%.1f", row.CoveragePct),
+		}
+		for _, comp := range row.Components {
+			cells = append(cells, fmt.Sprintf("%.1f", comp.SharePct))
+		}
+		cells = append(cells, fmt.Sprintf("%.1f%s", row.RoundedShareSum, toleranceMark(row.WithinTolerance)))
+		fmt.Fprintln(&b, "| "+strings.Join(cells, " | ")+" |")
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "### Noise floor (interleaved A/A, identical binary)")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| fixture | pairs | median ns/op | p95 \\|delta\\| ns | p95 \\|delta\\| % of median |")
+	fmt.Fprintln(&b, "|---|---|---|---|---|")
+	for _, row := range r.NoiseFloor {
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | %.2f%% |\n",
+			row.Fixture, row.Pairs, formatNS(row.MedianNSPerOp), formatNS(row.P95AbsDeltaNS), row.P95PctOfMedian)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "### Cost per event (diagnostic lane; average attribution, not causal)")
+	fmt.Fprintln(&b)
+	if len(r.CostPerEvent) > 0 {
+		classNames := make([]string, 0, len(r.CostPerEvent[0].Classes))
+		for _, c := range r.CostPerEvent[0].Classes {
+			classNames = append(classNames, c.Class)
+		}
+		header := append([]string{"fixture", "wall ns/op"}, classNames...)
+		fmt.Fprintln(&b, "| "+strings.Join(header, " | ")+" |")
+		fmt.Fprintln(&b, "|"+strings.Repeat("---|", len(header)))
+		for _, row := range r.CostPerEvent {
+			cells := []string{row.Fixture, formatNS(row.WallNSPerOp)}
+			for _, c := range row.Classes {
+				cells = append(cells, fmt.Sprintf("%.1f (n=%d)", c.NSPerUnit, c.Count))
+			}
+			fmt.Fprintln(&b, "| "+strings.Join(cells, " | ")+" |")
+		}
+	}
+	return b.String()
+}
+
+func toleranceMark(within bool) string {
+	if within {
+		return ""
+	}
+	return " (!)"
+}
+
+func formatNS(ns float64) string {
+	switch {
+	case ns >= 1e9:
+		return fmt.Sprintf("%.3fs", ns/1e9)
+	case ns >= 1e6:
+		return fmt.Sprintf("%.3fms", ns/1e6)
+	case ns >= 1e3:
+		return fmt.Sprintf("%.3fus", ns/1e3)
+	default:
+		return fmt.Sprintf("%.1fns", ns)
+	}
+}

--- a/docs/perf-attribution-receipt.json
+++ b/docs/perf-attribution-receipt.json
@@ -1,0 +1,659 @@
+{
+  "schema_version": "gts-perf-attribution-receipt/v1",
+  "generated_utc": "2026-08-01T11:12:22Z",
+  "git_commit": "f91e9c8cc7d2c8830c973cfa28b658c70dd0d0ba",
+  "host_class": "shared WSL2 development host, background load uncontrolled (local-development floor, not quiet-host or enclave)",
+  "tolerance_note": "component shares are computed to sum to exactly 100% of attributed samples by construction (ComponentOther absorbs the remainder); the displayed 1-decimal rows are checked to sum to 100% within +/-0.2 percentage points of rounding tolerance",
+  "attribution_rows": [
+    {
+      "label": "diagnostic lane",
+      "fixture": "rewrite",
+      "source_bytes": 5116,
+      "iterations": 374,
+      "wall_ns_per_op": 2674275.7406417113,
+      "profiled_total_ns": 1050000000,
+      "profiled_wall_ns": 1000179127,
+      "profile_coverage_pct": 104.98119503347723,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 240000000,
+          "share_pct": 22.9,
+          "raw_share_pct": 22.857142857142858
+        },
+        {
+          "component": "elections",
+          "ns": 100000000,
+          "share_pct": 9.5,
+          "raw_share_pct": 9.523809523809524
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 350000000,
+          "share_pct": 33.3,
+          "raw_share_pct": 33.333333333333336
+        },
+        {
+          "component": "canonicalization",
+          "ns": 50000000,
+          "share_pct": 4.8,
+          "raw_share_pct": 4.761904761904762
+        },
+        {
+          "component": "lexing",
+          "ns": 150000000,
+          "share_pct": 14.3,
+          "raw_share_pct": 14.285714285714286
+        },
+        {
+          "component": "materialization",
+          "ns": 140000000,
+          "share_pct": 13.3,
+          "raw_share_pct": 13.333333333333334
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 20000000,
+          "share_pct": 1.9,
+          "raw_share_pct": 1.9047619047619047
+        }
+      ],
+      "rounded_share_sum_pct": 100,
+      "within_tolerance": true,
+      "unclassified_top": [
+        {
+          "Function": "github.com/odvcencio/gotreesitter.(*nodeArena).reset",
+          "NS": 10000000
+        }
+      ]
+    },
+    {
+      "label": "diagnostic lane",
+      "fixture": "query_compile",
+      "source_bytes": 20168,
+      "iterations": 82,
+      "wall_ns_per_op": 12340118.609756097,
+      "profiled_total_ns": 1060000000,
+      "profiled_wall_ns": 1011889726,
+      "profile_coverage_pct": 104.75449772478468,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 220000000,
+          "share_pct": 20.8,
+          "raw_share_pct": 20.754716981132077
+        },
+        {
+          "component": "elections",
+          "ns": 50000000,
+          "share_pct": 4.7,
+          "raw_share_pct": 4.716981132075472
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 320000000,
+          "share_pct": 30.2,
+          "raw_share_pct": 30.18867924528302
+        },
+        {
+          "component": "canonicalization",
+          "ns": 90000000,
+          "share_pct": 8.5,
+          "raw_share_pct": 8.49056603773585
+        },
+        {
+          "component": "lexing",
+          "ns": 210000000,
+          "share_pct": 19.8,
+          "raw_share_pct": 19.81132075471698
+        },
+        {
+          "component": "materialization",
+          "ns": 170000000,
+          "share_pct": 16,
+          "raw_share_pct": 16.037735849056602
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        }
+      ],
+      "rounded_share_sum_pct": 100,
+      "within_tolerance": true
+    },
+    {
+      "label": "diagnostic lane",
+      "fixture": "language",
+      "source_bytes": 41387,
+      "iterations": 76,
+      "wall_ns_per_op": 13195339.881578946,
+      "profiled_total_ns": 1060000000,
+      "profiled_wall_ns": 1002845831,
+      "profile_coverage_pct": 105.69919794581068,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 240000000,
+          "share_pct": 22.6,
+          "raw_share_pct": 22.641509433962263
+        },
+        {
+          "component": "elections",
+          "ns": 80000000,
+          "share_pct": 7.5,
+          "raw_share_pct": 7.547169811320755
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 350000000,
+          "share_pct": 33,
+          "raw_share_pct": 33.0188679245283
+        },
+        {
+          "component": "canonicalization",
+          "ns": 80000000,
+          "share_pct": 7.5,
+          "raw_share_pct": 7.547169811320755
+        },
+        {
+          "component": "lexing",
+          "ns": 140000000,
+          "share_pct": 13.2,
+          "raw_share_pct": 13.20754716981132
+        },
+        {
+          "component": "materialization",
+          "ns": 170000000,
+          "share_pct": 16,
+          "raw_share_pct": 16.037735849056602
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        }
+      ],
+      "rounded_share_sum_pct": 99.8,
+      "within_tolerance": true
+    },
+    {
+      "label": "diagnostic lane",
+      "fixture": "grammargen_lr",
+      "source_bytes": 235626,
+      "iterations": 8,
+      "wall_ns_per_op": 126019230.875,
+      "profiled_total_ns": 1070000000,
+      "profiled_wall_ns": 1008153847,
+      "profile_coverage_pct": 106.13459475297722,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 270000000,
+          "share_pct": 25.2,
+          "raw_share_pct": 25.233644859813083
+        },
+        {
+          "component": "elections",
+          "ns": 80000000,
+          "share_pct": 7.5,
+          "raw_share_pct": 7.4766355140186915
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 240000000,
+          "share_pct": 22.4,
+          "raw_share_pct": 22.429906542056074
+        },
+        {
+          "component": "canonicalization",
+          "ns": 60000000,
+          "share_pct": 5.6,
+          "raw_share_pct": 5.607476635514018
+        },
+        {
+          "component": "lexing",
+          "ns": 210000000,
+          "share_pct": 19.6,
+          "raw_share_pct": 19.626168224299064
+        },
+        {
+          "component": "materialization",
+          "ns": 190000000,
+          "share_pct": 17.8,
+          "raw_share_pct": 17.757009345794394
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 20000000,
+          "share_pct": 1.9,
+          "raw_share_pct": 1.8691588785046729
+        }
+      ],
+      "rounded_share_sum_pct": 100,
+      "within_tolerance": true,
+      "unclassified_top": [
+        {
+          "Function": "github.com/odvcencio/gotreesitter.hiddenTreeHasFieldIDs",
+          "NS": 10000000
+        }
+      ]
+    },
+    {
+      "label": "shipped route",
+      "fixture": "rewrite",
+      "source_bytes": 5116,
+      "iterations": 370,
+      "wall_ns_per_op": 2707025.3756756755,
+      "profiled_total_ns": 1050000000,
+      "profiled_wall_ns": 1001599389,
+      "profile_coverage_pct": 104.8323323208417,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 230000000,
+          "share_pct": 21.9,
+          "raw_share_pct": 21.904761904761905
+        },
+        {
+          "component": "elections",
+          "ns": 80000000,
+          "share_pct": 7.6,
+          "raw_share_pct": 7.619047619047619
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 300000000,
+          "share_pct": 28.6,
+          "raw_share_pct": 28.571428571428573
+        },
+        {
+          "component": "canonicalization",
+          "ns": 100000000,
+          "share_pct": 9.5,
+          "raw_share_pct": 9.523809523809524
+        },
+        {
+          "component": "lexing",
+          "ns": 200000000,
+          "share_pct": 19,
+          "raw_share_pct": 19.047619047619047
+        },
+        {
+          "component": "materialization",
+          "ns": 120000000,
+          "share_pct": 11.4,
+          "raw_share_pct": 11.428571428571429
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 20000000,
+          "share_pct": 1.9,
+          "raw_share_pct": 1.9047619047619047
+        }
+      ],
+      "rounded_share_sum_pct": 99.9,
+      "within_tolerance": true,
+      "unclassified_top": [
+        {
+          "Function": "github.com/odvcencio/gotreesitter.maxRetainedNodeCapacityForClass",
+          "NS": 10000000
+        }
+      ]
+    },
+    {
+      "label": "shipped route",
+      "fixture": "query_compile",
+      "source_bytes": 20168,
+      "iterations": 77,
+      "wall_ns_per_op": 13026168.636363637,
+      "profiled_total_ns": 1050000000,
+      "profiled_wall_ns": 1003014985,
+      "profile_coverage_pct": 104.68437817008287,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 320000000,
+          "share_pct": 30.5,
+          "raw_share_pct": 30.476190476190474
+        },
+        {
+          "component": "elections",
+          "ns": 40000000,
+          "share_pct": 3.8,
+          "raw_share_pct": 3.8095238095238093
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 230000000,
+          "share_pct": 21.9,
+          "raw_share_pct": 21.904761904761905
+        },
+        {
+          "component": "canonicalization",
+          "ns": 10000000,
+          "share_pct": 1,
+          "raw_share_pct": 0.9523809523809523
+        },
+        {
+          "component": "lexing",
+          "ns": 210000000,
+          "share_pct": 20,
+          "raw_share_pct": 20
+        },
+        {
+          "component": "materialization",
+          "ns": 240000000,
+          "share_pct": 22.9,
+          "raw_share_pct": 22.857142857142858
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        }
+      ],
+      "rounded_share_sum_pct": 100.1,
+      "within_tolerance": true
+    },
+    {
+      "label": "shipped route",
+      "fixture": "language",
+      "source_bytes": 41387,
+      "iterations": 86,
+      "wall_ns_per_op": 11752825.895348838,
+      "profiled_total_ns": 1070000000,
+      "profiled_wall_ns": 1010743027,
+      "profile_coverage_pct": 105.8627140051494,
+      "components": [
+        {
+          "component": "scheduler-dispatch",
+          "ns": 270000000,
+          "share_pct": 25.2,
+          "raw_share_pct": 25.233644859813083
+        },
+        {
+          "component": "elections",
+          "ns": 50000000,
+          "share_pct": 4.7,
+          "raw_share_pct": 4.672897196261682
+        },
+        {
+          "component": "reductions-and-pops",
+          "ns": 330000000,
+          "share_pct": 30.8,
+          "raw_share_pct": 30.8411214953271
+        },
+        {
+          "component": "canonicalization",
+          "ns": 70000000,
+          "share_pct": 6.5,
+          "raw_share_pct": 6.542056074766355
+        },
+        {
+          "component": "lexing",
+          "ns": 170000000,
+          "share_pct": 15.9,
+          "raw_share_pct": 15.88785046728972
+        },
+        {
+          "component": "materialization",
+          "ns": 180000000,
+          "share_pct": 16.8,
+          "raw_share_pct": 16.822429906542055
+        },
+        {
+          "component": "compat-tail",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        },
+        {
+          "component": "other",
+          "ns": 0,
+          "share_pct": 0,
+          "raw_share_pct": 0
+        }
+      ],
+      "rounded_share_sum_pct": 99.9,
+      "within_tolerance": true
+    }
+  ],
+  "noise_floor": [
+    {
+      "fixture": "grammargen_lr",
+      "pairs": 12,
+      "median_ns_per_op": 123099285.5,
+      "p95_abs_delta_ns": 9069220.999999998,
+      "p95_pct_of_median": 7.367403444433475
+    },
+    {
+      "fixture": "language",
+      "pairs": 12,
+      "median_ns_per_op": 12020049.5,
+      "p95_abs_delta_ns": 1298574.7999999998,
+      "p95_pct_of_median": 10.803406425239762
+    },
+    {
+      "fixture": "query_compile",
+      "pairs": 12,
+      "median_ns_per_op": 11771807,
+      "p95_abs_delta_ns": 1165298.8499999999,
+      "p95_pct_of_median": 9.899065198741365
+    },
+    {
+      "fixture": "rewrite",
+      "pairs": 12,
+      "median_ns_per_op": 2400545,
+      "p95_abs_delta_ns": 255969.14999999994,
+      "p95_pct_of_median": 10.662959869529624
+    }
+  ],
+  "noise_floor_method": "BenchmarkParserCoreFreshFullCanonical, identical prebuilt binary invoked twice per pair (series A and series B), interleaved A,B,A,B,...; GOMAXPROCS=1; delta_i = |A_i - B_i| per fixture per pair; p95 by linear interpolation over sorted deltas",
+  "cost_per_event": [
+    {
+      "fixture": "rewrite",
+      "wall_ns_per_op": 2674275.7406417113,
+      "classes": [
+        {
+          "class": "shifts",
+          "count": 1348,
+          "ns_per_event": 1983.8840805947414
+        },
+        {
+          "class": "reductions",
+          "count": 1504,
+          "ns_per_event": 1778.1088701075207
+        },
+        {
+          "class": "emitted_pop_paths",
+          "count": 1646,
+          "ns_per_event": 1624.7118715927772
+        },
+        {
+          "class": "emitted_pop_payloads",
+          "count": 2993,
+          "ns_per_event": 893.5101037894124
+        },
+        {
+          "class": "canonicalizations",
+          "count": 2446,
+          "ns_per_event": 1093.3261409001273
+        },
+        {
+          "class": "elections",
+          "count": 1036,
+          "ns_per_event": 2581.3472400016517
+        },
+        {
+          "class": "action_lookups",
+          "count": 3551,
+          "ns_per_event": 753.1049677954693
+        }
+      ]
+    },
+    {
+      "fixture": "query_compile",
+      "wall_ns_per_op": 12340118.609756097,
+      "classes": [
+        {
+          "class": "shifts",
+          "count": 6685,
+          "ns_per_event": 1845.9414524691244
+        },
+        {
+          "class": "reductions",
+          "count": 7509,
+          "ns_per_event": 1643.3770954529361
+        },
+        {
+          "class": "emitted_pop_paths",
+          "count": 8108,
+          "ns_per_event": 1521.9682547799823
+        },
+        {
+          "class": "emitted_pop_payloads",
+          "count": 14730,
+          "ns_per_event": 837.7541486596128
+        },
+        {
+          "class": "canonicalizations",
+          "count": 12371,
+          "ns_per_event": 997.5037272456631
+        },
+        {
+          "class": "elections",
+          "count": 5126,
+          "ns_per_event": 2407.3582929684153
+        },
+        {
+          "class": "action_lookups",
+          "count": 17431,
+          "ns_per_event": 707.9409448543455
+        }
+      ]
+    },
+    {
+      "fixture": "language",
+      "wall_ns_per_op": 13195339.881578946,
+      "classes": [
+        {
+          "class": "shifts",
+          "count": 6512,
+          "ns_per_event": 2026.311406876374
+        },
+        {
+          "class": "reductions",
+          "count": 7564,
+          "ns_per_event": 1744.4923164435413
+        },
+        {
+          "class": "emitted_pop_paths",
+          "count": 8377,
+          "ns_per_event": 1575.1868069212064
+        },
+        {
+          "class": "emitted_pop_payloads",
+          "count": 15816,
+          "ns_per_event": 834.3032297407022
+        },
+        {
+          "class": "canonicalizations",
+          "count": 12322,
+          "ns_per_event": 1070.8764714801937
+        },
+        {
+          "class": "elections",
+          "count": 5058,
+          "ns_per_event": 2608.8058287028366
+        },
+        {
+          "class": "action_lookups",
+          "count": 18674,
+          "ns_per_event": 706.615608952498
+        }
+      ]
+    },
+    {
+      "fixture": "grammargen_lr",
+      "wall_ns_per_op": 126019230.875,
+      "classes": [
+        {
+          "class": "shifts",
+          "count": 66115,
+          "ns_per_event": 1906.0611188837631
+        },
+        {
+          "class": "reductions",
+          "count": 76310,
+          "ns_per_event": 1651.411753046783
+        },
+        {
+          "class": "emitted_pop_paths",
+          "count": 83658,
+          "ns_per_event": 1506.3619842095197
+        },
+        {
+          "class": "emitted_pop_payloads",
+          "count": 151917,
+          "ns_per_event": 829.5268526563848
+        },
+        {
+          "class": "canonicalizations",
+          "count": 122052,
+          "ns_per_event": 1032.5044315127977
+        },
+        {
+          "class": "elections",
+          "count": 49912,
+          "ns_per_event": 2524.8283153349894
+        },
+        {
+          "class": "action_lookups",
+          "count": 184287,
+          "ns_per_event": 683.8205129770413
+        }
+      ]
+    }
+  ],
+  "cost_per_event_note": "average attribution, not a causal model: wall ns/op for the diagnostic lane divided by the gts_workcount event count for the same fixture and lifecycle"
+}

--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -1,0 +1,410 @@
+# Compact-lane perf attribution board
+
+This document defines one boundary-exact attribution tree over the compact
+parser core's fresh-full-parse CPU. It states the disambiguation rule for
+every function that more than one component could otherwise claim. It
+records the noise floor of the local measurement host, and the first
+published receipt.
+
+This is measurement infrastructure only. It changes no parser code, no
+routing, and no shipped behavior.
+
+## Why this document exists
+
+Three prior estimates put the compact scheduler's share of full-parse CPU at
+77-79%, at approximately 50%, and at 78-82%. Each estimate used a different,
+undocumented attribution boundary: one drew the scheduler boundary wide
+(covering shift, reduce, and election together), one drew it narrow, and one
+used a different profiling method. The three numbers do not contradict each
+other once you know their boundaries, but no one had written the boundaries
+down, so the campaign could not tell whether a proposed perf lever targeted
+77% of parse CPU or 50% of it.
+
+Campaign v7 tranche C0 (`spec.campaign.v7`, `hypha://m31labs/gotreesitter`)
+blocks new perf-lever bets until one receipt exists with a named boundary for
+every component, a documented noise floor, and a cost-per-event model. This
+document is that receipt's home. The attached tool
+(`cgo_harness/attribution`) regenerates the receipt from one command.
+
+## Scope
+
+The receipt covers the compact parser core's fresh, non-incremental full
+parse: the default route for eligible full parses below the 64 KiB compact
+admission floor (`parseRuntimeMemoryMinSourceBytes`,
+`admission_switch.go`), and the diagnostic runner path
+(`parserCoreFreshFullRunner`) that exercises the same scheduler and
+materialization code above that floor.
+
+It does not cover: incremental reparse, error recovery, retry passes, the
+production (non-compact) GLR engine, or any language other than the four
+pinned Go canonical fixtures.
+
+## The compact lane, by file
+
+| Area | File(s) | Key entry points |
+|---|---|---|
+| Scheduler driver (root package) | `parsercore_phase0_driver.go` | `run`, `dispatchPass`, `dispatchPassActive`, `elect`, `canonicalize` |
+| Core structures (`internal/parsercorephase0`) | `core.go`, `scheduler_owned.go`, `boundary_index.go`, `checkpoint_interner.go` | `ApplySchedulerAtomic`, `condenseWithOutcomeAtomic`, `popPaths`, `Derivations`, `MaterializationOrder` |
+| Lexing | `parser_dfa_token_source.go`, `lexer.go` | `(*dfaTokenSource).Next` |
+| Runner glue | `parsercore_phase0_fresh_full_runner.go` | `executeSchedulerOpen`, `parse`, `materialize` |
+| Shipped-route fidelity tail | `admission_switch.go`, `admission_switch_candidate.go` | `normalizeReturnedTreeForParse`, `resolveCRecoverySwallowedError`, `maybeCompactReturnedFullTree` |
+
+The four canonical fixtures are SHA-256-pinned in
+`internal/benchfixtures/testdata` and authenticated the same way
+`cgo_harness/pure_c/run_canonical_go_full_parse.sh` and
+`diagnosticParserCoreCanonicalAdmissions` authenticate them:
+
+| Fixture | Bytes | Below 64 KiB floor |
+|---|---:|---|
+| `rewrite.go` | 5,116 | yes |
+| `query_compile.go` | 20,168 | yes |
+| `language.go` | 41,387 | yes |
+| `grammargen/lr.go` | 235,626 | no |
+
+`grammargen/lr.go` never takes the shipped `Parser.Parse` route: it is
+diagnostic-lane only. The other three fixtures run through both lanes.
+
+## Two lanes, one methodology
+
+Every fixture profiles under one or both of two lanes. Both lanes time an
+identical, already-committed lifecycle; the tool never adds new parser calls.
+
+- **Diagnostic lane.** `runner.parse`, shallow completeness validation, and
+  `Tree.Release` — the exact timed region of
+  `BenchmarkParserCoreFreshFullCanonical` (build tag
+  `gts_parsercorephase0`). Runs for all four fixtures.
+- **Shipped route.** `Parser.Parse` and `Tree.Release` — the exact timed
+  region of `BenchmarkDiagnosticParserCoreWarmProductionParseQueryCompile`,
+  generalized to all three fixtures under the 64 KiB floor. Every sample is
+  verified, by the admission-candidate routed/fallback counters, to have
+  actually taken the compact route rather than falling back to production.
+
+The tool labels every row with its lane so a reader never mixes shipped-route
+public-API overhead into the diagnostic lane's scheduler-only numbers, or
+vice versa.
+
+## The attribution tree
+
+Eight components, mutually exclusive and collectively exhaustive. Every
+CPU-profile sample lands in exactly one.
+
+1. **scheduler-dispatch** — the scheduler loop, per-token boundary
+   classification, and the mechanical application of shift and accept
+   actions. Owning functions: `run`, `dispatchPass`, `dispatchPassActive`,
+   `applyGenericShifts(Owned)`, `applyGenericExtraShifts(Owned)`,
+   `applyGenericAccept`, `finish`, `Core.Shift*`, `Core.ClassifyBoundary`,
+   `Core.Actions`, scheduler construction and seeding, and the accepted-tail
+   cleanliness check (`requireParserCoreFreshFullAcceptance`,
+   `parserCoreFreshFullAcceptedTailIsClean` — see the naming-collision note
+   below).
+2. **elections** — choosing among competing alternatives: which GSS heads
+   advance each round (frontier election), and which action wins at an
+   ambiguous cell (GLR conflict resolution / dynamic precedence). Owning
+   functions: `elect`, `executeDiagnosticParserCoreGenericConflictDetailed`,
+   `applyGenericConflict(Owned)`, `diagnosticParserCoreConflictPolicyOrdinal`,
+   `diagnosticParserCoreRepetitionFoldOrdinal`.
+3. **reductions-and-pops** — applying a reduce action: enumerating GSS pop
+   paths back to a production's children, building the parent subtree, and
+   merging (condensing) the result into the derivation graph. Owning
+   functions: `applyGenericReduction(Owned)`, `Core.Reduce`,
+   `Core.ReduceOutputs*`, `Core.popPaths`, `Core.popSingleLinkPath`,
+   `Core.factorExactPredecessor`, `Core.mergePredecessorsBounded`,
+   `Core.insertLinkBounded`, `Core.appendNode`, `Core.appendSubtree`,
+   `Core.walkCleanPrefixRanks`.
+4. **canonicalization** — post-step header-lineage deduplication: merging
+   headers that reconverge to the same `(state, byte-offset)` boundary after
+   any dispatch action. Owning functions: `canonicalize`,
+   `canonicalizeDiagnosticParserCoreHeaders`,
+   `diagnosticParserCoreCanonicalScratch.canonicalize(Linear|Mapped)`,
+   `mergeDiagnosticParserCoreCleanPathLineage`,
+   `persistHeaderLineageOwned`, `RecordReductionLineageOwned`,
+   `RecordHeadLineageOwned`.
+5. **lexing** — producing the next token from source bytes. Owning function:
+   `(*dfaTokenSource).Next`, and every function defined in
+   `parser_dfa_token_source.go` or `lexer.go` (a whole-file rule, since both
+   files exist for exactly this one job).
+6. **materialization** — turning the accepted derivation into the returned
+   public `*Tree`: selecting the canonical derivation when more than one
+   exists, building nodes, attaching parent/sibling links, replaying parser
+   states, and finalizing the root span. Owning functions:
+   `completeAcceptance`, `selectCompactAcceptanceDerivation`,
+   `Core.Derivations`, `materializeDiagnosticParserCoreAcceptedTree`,
+   `materializeDiagnosticParserCoreAcceptedSelection`,
+   `finalizeDiagnosticParserCoreAcceptedRootSpan`, `Core.MaterializationOrder`,
+   `Core.VisitMaterializationPostorder`, `(*Parser).replayCompactDerivation`.
+7. **compat-tail** — the shipped-route-only public-API fidelity tail that
+   runs after the compact tree exists, so every `Parser.Parse` return matches
+   production's API surface exactly. Not reachable from the diagnostic
+   runner path. Owning functions: `normalizeReturnedTreeForParse`,
+   `resolveCRecoverySwallowedError`, `maybeCompactReturnedFullTree`,
+   `tryCompactFullParseRoute`, `attemptAdmissionCandidateFullParse`,
+   `admissionCandidateFullParseEligible` (the whole of `admission_switch.go`
+   and `admission_switch_candidate.go` — a whole-file rule).
+8. **other** — every sample the walk cannot attribute to a named component:
+   Go runtime, garbage collection, and goroutine-scheduling frames with no
+   gotreesitter-domain ancestor, plus any genuinely unclassified function.
+   The tool separately reports the largest unclassified, non-runtime
+   functions it saw; a nonzero entry there is a signal this table has a gap,
+   not a license to guess.
+
+### A naming collision to avoid
+
+`parserCoreFreshFullAcceptedTailIsClean` checks that no real source byte
+follows the accepted head (only parser padding may remain) before the
+scheduler declares acceptance. This is **not** the compat-tail component. It
+is a scheduler-dispatch acceptance check that runs on both lanes. The English
+word "tail" names two unrelated things here: an accepted-frontier byte-range
+check (scheduler-dispatch), and a post-parse public-API fidelity pass
+(compat-tail, shipped route only). The classifier and this document both use
+the full function name, never the bare word "tail", to keep them apart.
+
+## The disambiguation rule
+
+Every named function belongs to at most one component's owned set, chosen by
+its primary job, not by which caller happens to invoke it. A handful of
+low-level primitives exist purely to serve more than one component
+(transaction bookkeeping, checkpoint identity, and pure counters). Those
+primitives are explicitly marked shared and are **not** classified directly.
+
+A CPU-profile sample is a full call stack, leaf (currently executing frame)
+to root. Attribution walks the stack from the leaf toward the root and
+assigns the sample's entire value to the first frame the table recognizes.
+A shared primitive is transparent to this walk: the sample "sees through" it
+to the nearer ancestor frame, which is always the specific call site that
+decided to use the primitive. A sample with no recognized frame anywhere on
+its stack is `other`.
+
+This single rule resolves every case where the same function serves two
+components:
+
+- **`condense` / `condenseWithOutcomeAtomic`** run from both `Core.Shift*`
+  (scheduler-dispatch, appending a shifted GSS node) and reduction-output
+  application (reductions-and-pops, appending a reduced parent node). Marked
+  shared; the walk finds whichever caller reached it.
+- **`ApplySchedulerAtomic` / `RunSchedulerOwned`** wrap the shift, reduce,
+  conflict, and extra-shift appliers uniformly (four call sites in
+  `parsercore_phase0_driver.go`). Marked shared for the same reason.
+- **Checkpoint interning and external-scanner-state capture**
+  (`diagnosticParserCoreInternCheckpoint`,
+  `captureExternalScannerStateInto`) run both nested inside a live call to
+  `dfaTokenSource.Next` (lexing) and directly from `elect` for the
+  election's checkpoint-continuity proof (elections). Marked shared; the
+  walk finds `Next` when the capture is nested inside token production, and
+  finds `elect` when it is not, without any special case.
+- **`canonicalize`** is called from inside every applier (accept, shift,
+  reduce, conflict, extra-shift) as a post-step. It is deliberately **not**
+  marked shared: its job (header-lineage deduplication) is the same
+  regardless of caller, so it is classified directly as canonicalization.
+  The walk finds `canonicalize`'s own frame before it would reach the
+  calling applier's frame, so canonicalization is correctly separated from
+  whichever action triggered it.
+
+## The tool
+
+`cgo_harness/attribution` is a small, dependency-free Go program (it lives in
+the `cgo_harness` module and imports nothing beyond the standard library,
+including its own minimal pprof-profile reader, so this measurement
+infrastructure does not widen either module's dependency footprint). It:
+
+1. Extracts and SHA-256-verifies the four canonical fixtures.
+2. Builds two test binaries: one tagged `gts_parsercorephase0` (capture and
+   noise floor), one tagged `gts_parsercorephase0,gts_workcount` (event
+   counts). Building happens once, before any timed measurement, so
+   compilation never contends with the host for CPU during a timed sample.
+3. Runs `TestParserCoreAttributionCapture` (added in
+   `parsercore_phase0_attribution_capture_internal_test.go`, inert unless
+   `GTS_ATTRIBUTION_OUT` is set) to collect one gzip'd pprof CPU profile per
+   lane per fixture. Every one-time warm pass, digest check, and GC/arena
+   drain happens outside `pprof.StartCPUProfile`/`StopCPUProfile`, so the
+   profile is not diluted by non-representative setup cost.
+4. Runs the existing `TestParserCoreWorkCountChild` (already committed,
+   `work_count_parsercore_child_internal_test.go`) once per fixture for
+   event counts.
+5. Runs the noise floor (see below).
+6. Decodes every profile with a minimal, read-only pprof protobuf reader,
+   classifies every sample by the rule above, and emits `receipt.json` and
+   `receipt.md`.
+
+Reproduce the whole receipt with one command from the repository root:
+
+```sh
+(cd cgo_harness && go run ./attribution -repo .. -duration 800ms -noise-samples 10 -noise-benchtime 750ms)
+```
+
+Add `-out <dir>` to choose the output directory (default:
+`harness_out/perf_attribution/<UTC timestamp>`, already git-ignored). Add
+`-core <cpu>` to pin every subprocess with `taskset`; the published receipt
+below did not pin a core (see host class, next section).
+
+## Noise floor
+
+**Protocol.** Using the pinned local proxy benchmark
+`BenchmarkParserCoreFreshFullCanonical`, the tool builds one test binary and
+invokes that identical binary twice per pair, labeled A and B, interleaved
+A,B,A,B,... for n pairs (n >= 10). Each invocation runs with `GOMAXPROCS=1`
+and times all four fixtures in one process. For each fixture and pair `i`,
+`delta_i = |A_i - B_i|`. The noise floor is the 95th percentile (linear
+interpolation over the sorted deltas) of `delta_i`, reported both in
+nanoseconds and as a percentage of the fixture's median ns/op across the
+combined A and B samples.
+
+**Host class.** Shared WSL2 development host, background load uncontrolled.
+This is the local-development floor, not the quiet-host or enclave floor
+that `BENCH.md`'s sealed epoch uses. Treat every ns/op number in this
+document as wall-clock on a busy, shared machine (other agents were active
+on the same host during this run), not as a publication-grade performance
+claim. The relative component-share percentages are far less sensitive to
+this noise than the absolute ns/op and ns-per-event numbers are, because Go's
+CPU profiler samples on-CPU (SIGPROF/`ITIMER_PROF`) time, not wall time: host
+contention stretches wall-clock ns/op without changing which component a
+given on-CPU sample belongs to.
+
+## Cost-per-event join
+
+For each fixture, the tool divides the diagnostic lane's measured wall
+ns/op by the `gts_workcount` build's authenticated event counts for that
+same fixture and lifecycle (`TestParserCoreWorkCountChild`, schema
+`gts-work-count-parsercore-child/v3`): shifts, reductions, emitted pop
+paths, emitted pop payloads, canonicalizations, elections, and action
+lookups.
+
+This is an **average attribution, not a causal model**. Dividing total wall
+time by an event count says nothing about which event class actually causes
+the most CPU per occurrence; it says how the average work per fixture spread
+across event classes on this run, on this host. Two events of the same class
+can cost very different amounts (a pop path over a clean linear GSS chain is
+far cheaper than one over a branching, ambiguous chain), and the classes are
+not independent (an election's checkpoint-continuity proof is not free, but
+it has no "count" of its own in this join).
+
+## Results — first receipt
+
+Generated 2026-08-01T11:12:22Z. Host: shared WSL2 development host,
+background load uncontrolled. Other agents were active on the same host
+throughout this session (22 registered at session start). Git commit
+`f91e9c8cc7d2c8830c973cfa28b658c70dd0d0ba`. Full machine-readable receipt:
+`docs/perf-attribution-receipt.json`. Regenerate both (and the larger raw
+pprof profiles, which are not committed) with the one command above.
+
+Component shares are computed to sum to exactly 100% of attributed samples
+by construction (`other` absorbs the remainder); the displayed 1-decimal
+rows are checked to sum to 100% within +/-0.2 percentage points of rounding
+tolerance. Every row below is within that tolerance.
+
+### Attribution shares
+
+| lane | fixture | wall ns/op | coverage % | scheduler-dispatch | elections | reductions-and-pops | canonicalization | lexing | materialization | compat-tail | other | sum % |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| diagnostic lane | rewrite | 2.674ms | 105.0 | 22.9 | 9.5 | 33.3 | 4.8 | 14.3 | 13.3 | 0.0 | 1.9 | 100.0 |
+| diagnostic lane | query_compile | 12.340ms | 104.8 | 20.8 | 4.7 | 30.2 | 8.5 | 19.8 | 16.0 | 0.0 | 0.0 | 100.0 |
+| diagnostic lane | language | 13.195ms | 105.7 | 22.6 | 7.5 | 33.0 | 7.5 | 13.2 | 16.0 | 0.0 | 0.0 | 99.8 |
+| diagnostic lane | grammargen_lr | 126.019ms | 106.1 | 25.2 | 7.5 | 22.4 | 5.6 | 19.6 | 17.8 | 0.0 | 1.9 | 100.0 |
+| shipped route | rewrite | 2.707ms | 104.8 | 21.9 | 7.6 | 28.6 | 9.5 | 19.0 | 11.4 | 0.0 | 1.9 | 99.9 |
+| shipped route | query_compile | 13.026ms | 104.7 | 30.5 | 3.8 | 21.9 | 1.0 | 20.0 | 22.9 | 0.0 | 0.0 | 100.1 |
+| shipped route | language | 11.753ms | 105.9 | 25.2 | 4.7 | 30.8 | 6.5 | 15.9 | 16.8 | 0.0 | 0.0 | 99.9 |
+
+`coverage %` is profiled CPU time divided by measured wall time on this
+single-core-bound (`GOMAXPROCS=1`) run. It runs 105-106% here, not 100%,
+because the Go runtime's background workers (GC assist, sweep) can add a
+small amount of concurrent on-CPU time beyond the profiled goroutine's own
+wall-clock window. A coverage figure far below 100% would mean too few
+samples landed to trust the percentages; every row here is comfortably
+above that concern.
+
+`grammargen_lr` has no shipped-route row: it is above the 64 KiB floor, so
+`Parser.Parse` never routes it through the compact candidate. `compat-tail`
+measures zero on every shipped-route row: for these four fixtures every
+parse is clean (no error nodes, no C-recovery-swallowed error to resolve),
+so the shipped-route fidelity tail's conditional work never fires. This is
+a genuine finding, not a classifier gap: the compat-tail functions exist for
+correctness parity on error/recovery paths this receipt does not exercise,
+not for cost on the clean path.
+
+`other` stays at 0.0-1.9% on every row. Where it is nonzero, the largest
+non-runtime contributors are `(*nodeArena).reset` (arena-pool bookkeeping
+inside `Tree.Release`), `hiddenTreeHasFieldIDs`, and
+`maxRetainedNodeCapacityForClass` — each under 1% of one profile's samples.
+None of them changes the qualitative picture; they are recorded as a known
+small residual rather than folded into a component that would overstate its
+weight.
+
+### Noise floor (interleaved A/A, identical binary, 12 pairs per fixture)
+
+| fixture | median ns/op | p95 \|delta\| | p95 \|delta\| as % of median |
+|---|---:|---:|---:|
+| `grammargen_lr` | 123.099ms | 9.069ms | 7.4% |
+| `language` | 12.020ms | 1.299ms | 10.8% |
+| `query_compile` | 11.772ms | 1.165ms | 9.9% |
+| `rewrite` | 2.401ms | 0.256ms | 10.7% |
+
+Read this as: on this shared, uncontrolled host, two runs of the literal
+same binary can disagree by roughly 7-11% before you have measured any real
+difference. Any comparison this receipt states below that floor is not a
+finding; it is noise.
+
+### Cost per event (diagnostic lane; average, not causal)
+
+| fixture | wall ns/op | ns/shift | ns/reduction | ns/pop path | ns/pop payload | ns/canonicalization | ns/election | ns/action lookup |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `rewrite` | 2.674ms | 1984 | 1778 | 1625 | 894 | 1093 | 2581 | 753 |
+| `query_compile` | 12.340ms | 1846 | 1643 | 1522 | 838 | 998 | 2407 | 708 |
+| `language` | 13.195ms | 2026 | 1745 | 1575 | 834 | 1071 | 2609 | 707 |
+| `grammargen_lr` | 126.019ms | 1906 | 1651 | 1506 | 830 | 1033 | 2525 | 684 |
+
+The top-3 most expensive classes, by ns/event and consistent across all four
+fixtures, are elections (2,407-2,609 ns), shifts (1,846-2,026 ns), and
+reductions (1,643-1,778 ns). Elections costing more per event than shifts or
+reductions is consistent with the shares table: on the diagnostic lane,
+elections is the smallest of the four scheduler-family CPU shares
+(4.7-9.5%) but fires the fewest times per fixture (1,036 on `rewrite`
+versus 3,551 action lookups), so each election carries relatively more
+weight. Full JSON: `docs/perf-attribution-receipt.json`.
+
+### Which historical figure this receipt speaks to
+
+Sum the four diagnostic-lane scheduler-family components
+(scheduler-dispatch + elections + reductions-and-pops + canonicalization)
+without lexing: 70.5% (`rewrite`), 64.2% (`query_compile`), 70.8%
+(`language`), 60.7% (`grammargen_lr`) — average 66.5%. That number, on its
+own, matches none of the three historical figures well.
+
+Add lexing to that sum (scheduler-dispatch + elections +
+reductions-and-pops + canonicalization + lexing): 84.8%, 84.0%, 84.0%,
+80.3% — average 83.3%. This closely reproduces the **77-79% and 78-82%**
+figures. Read literally, this means those two historical estimates most
+likely counted token production as part of "scheduler cost per event" —
+a defensible reading, since a shift cannot happen without first lexing the
+token it shifts, but one this document did not previously state.
+
+Sum only scheduler-dispatch and reductions-and-pops, the two components that
+directly apply a table-driven action (excluding election/conflict overhead,
+canonicalization bookkeeping, and lexing): 56.2%, 50.9%, 55.7%, 47.7% —
+average 52.6%. This closely reproduces the **approximately-50%** figure. That
+estimate most likely measured only the two dominant mechanical appliers and
+implicitly folded election, canonicalization, and lexing cost into
+"overhead" it did not separately name.
+
+**Call: this receipt retires all three historical figures as decision
+inputs**, not because any of them was numerically wrong, but because none of
+them stated a boundary a later reader could reproduce or falsify. Each is a
+reasonable reading of a different implicit boundary that this receipt now
+makes explicit. From this tranche forward, campaign v7 should cite the
+eight-component table above — with its stated boundary and disambiguation
+rule — instead of any of the three legacy percentages.
+
+## Caveats
+
+- This is one run, on one noisy shared host, not a sealed-epoch,
+  quiet-host, or enclave receipt. Treat the noise floor as a floor, not a
+  ceiling: a quiet or enclave host would very likely show tighter deltas.
+- The classifier's function table
+  (`cgo_harness/attribution/classify.go`) is the single source of truth for
+  every boundary rule in this document. If the two ever disagree, the code
+  is authoritative; file a follow-up to reconcile the prose.
+- `other` includes Go runtime and GC frames by design (a legitimate,
+  expected component), not only classification gaps. The tool reports the
+  largest non-runtime unclassified functions separately so a real gap is
+  visible rather than silently absorbed.
+- Cost-per-event numbers are an average, not a causal attribution (see
+  above). Do not use them alone to justify a specific optimization target;
+  pair them with the component shares.

--- a/parsercore_phase0_attribution_capture_internal_test.go
+++ b/parsercore_phase0_attribution_capture_internal_test.go
@@ -1,0 +1,253 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file is campaign v7 tranche C0 measurement infrastructure (attribution
+// board). It changes no parser code, routing, or shipped behavior: it only
+// captures CPU profiles of the existing compact lane for offline attribution.
+// See docs/perf-attribution.md and cgo_harness/attribution for the one
+// documented command that drives it end to end.
+
+// attributionCaptureRow is one profiled sample series: either the diagnostic
+// runner path (all four canonical fixtures) or the shipped Parser.Parse route
+// (the three fixtures under the 64 KiB admission floor).
+type attributionCaptureRow struct {
+	Label       string  `json:"label"`
+	Fixture     string  `json:"fixture"`
+	SourceBytes int     `json:"source_bytes"`
+	Iterations  int     `json:"iterations"`
+	ElapsedNS   int64   `json:"elapsed_ns"`
+	NSPerOp     float64 `json:"ns_per_op"`
+	ProfilePath string  `json:"profile_path"`
+}
+
+type attributionCaptureManifest struct {
+	SchemaVersion string                  `json:"schema_version"`
+	GeneratedUTC  string                  `json:"generated_utc"`
+	DurationParam string                  `json:"duration_param"`
+	Rows          []attributionCaptureRow `json:"rows"`
+}
+
+// TestParserCoreAttributionCapture is the campaign v7 C0 attribution capture
+// endpoint. It is inert unless GTS_ATTRIBUTION_OUT names a writable directory,
+// so it never adds cost to a normal `go test` run.
+//
+// Each captured CPU profile brackets exactly one pinned lifecycle:
+//
+//   - "diagnostic lane": runner.parse, shallow completeness validation, and
+//     Tree.Release -- the same timed region BenchmarkParserCoreFreshFullCanonical
+//     measures, for all four canonical fixtures (so grammargen_lr is included).
+//   - "shipped route": Parser.Parse and Tree.Release -- the timed region
+//     BenchmarkDiagnosticParserCoreWarmProductionParseQueryCompile measures, for
+//     the three fixtures under the 64 KiB compact-admission floor
+//     (parseRuntimeMemoryMinSourceBytes). grammargen_lr never takes this route
+//     (it is not eligible), so it is diagnostic-lane only.
+//
+// Every one-time preflight, warm pass, and digest check happens outside
+// pprof.StartCPUProfile/StopCPUProfile so the profile is not diluted by
+// non-representative setup cost the pinned benchmarks themselves exclude.
+func TestParserCoreAttributionCapture(t *testing.T) {
+	outDir := strings.TrimSpace(os.Getenv("GTS_ATTRIBUTION_OUT"))
+	if outDir == "" {
+		t.Skip("parser-core attribution capture is not configured (set GTS_ATTRIBUTION_OUT)")
+	}
+	duration := 800 * time.Millisecond
+	if raw := strings.TrimSpace(os.Getenv("GTS_ATTRIBUTION_DURATION")); raw != "" {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil || parsed <= 0 {
+			t.Fatalf("GTS_ATTRIBUTION_DURATION must be a positive Go duration, got %q", raw)
+		}
+		duration = parsed
+	}
+	const minIterations = 5
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("create attribution output dir: %v", err)
+	}
+
+	var rows []attributionCaptureRow
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+		requireDiagnosticParserCoreCanonicalFixtureIdentity(t, fixture, row)
+		rows = append(rows, captureAttributionDiagnosticLane(t, outDir, fixture, row, duration, minIterations))
+	}
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		if row.bytes >= parseRuntimeMemoryMinSourceBytes {
+			continue // ineligible for the shipped route; stays production-only.
+		}
+		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+		requireDiagnosticParserCoreCanonicalFixtureIdentity(t, fixture, row)
+		rows = append(rows, captureAttributionShippedRoute(t, outDir, fixture, row, duration, minIterations))
+	}
+
+	manifest := attributionCaptureManifest{
+		SchemaVersion: "gts-perf-attribution-capture/v1",
+		GeneratedUTC:  time.Now().UTC().Format(time.RFC3339),
+		DurationParam: duration.String(),
+		Rows:          rows,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal capture manifest: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(outDir, "capture_manifest.json"), data, 0o644); err != nil {
+		t.Fatalf("write capture manifest: %v", err)
+	}
+}
+
+func captureAttributionDiagnosticLane(
+	t *testing.T,
+	outDir string,
+	fixture DiagnosticParserCoreCanonicalFixtureForTest,
+	row diagnosticParserCoreCanonicalAdmission,
+	duration time.Duration,
+	minIterations int,
+) attributionCaptureRow {
+	t.Helper()
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatalf("%s diagnostic lane: build runner: %v", row.id, err)
+	}
+
+	// Warm pass, outside profiling.
+	warmTree, err := runner.parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("%s diagnostic lane: warm parse: %v", row.id, err)
+	}
+	if err := validateParserCoreFreshFullCanonicalTree(warmTree, len(fixture.Source)); err != nil {
+		warmTree.Release()
+		t.Fatalf("%s diagnostic lane: warm parse: %v", row.id, err)
+	}
+	if work := runner.compact.Work(); work != row.work || work.Overflow {
+		warmTree.Release()
+		t.Fatalf("%s diagnostic lane: warm work=%+v want=%+v", row.id, work, row.work)
+	}
+	warmTree.Release()
+	runtime.GC()
+	DrainArenaPools()
+
+	profilePath := filepath.Join(outDir, "diagnostic_"+row.id+".pprof")
+	profileFile, err := os.Create(profilePath)
+	if err != nil {
+		t.Fatalf("%s diagnostic lane: create profile file: %v", row.id, err)
+	}
+	defer profileFile.Close()
+	if err := pprof.StartCPUProfile(profileFile); err != nil {
+		t.Fatalf("%s diagnostic lane: start cpu profile: %v", row.id, err)
+	}
+	start := time.Now()
+	iterations := 0
+	for iterations < minIterations || time.Since(start) < duration {
+		tree, err := runner.parse(fixture.Source)
+		if err != nil {
+			pprof.StopCPUProfile()
+			t.Fatalf("%s diagnostic lane: timed parse: %v", row.id, err)
+		}
+		if err := validateParserCoreFreshFullCanonicalTree(tree, len(fixture.Source)); err != nil {
+			tree.Release()
+			pprof.StopCPUProfile()
+			t.Fatalf("%s diagnostic lane: timed parse: %v", row.id, err)
+		}
+		tree.Release()
+		iterations++
+	}
+	elapsed := time.Since(start)
+	pprof.StopCPUProfile()
+
+	if work := runner.compact.Work(); work != row.work || work.Overflow {
+		t.Fatalf("%s diagnostic lane: timed work=%+v want=%+v", row.id, work, row.work)
+	}
+
+	return attributionCaptureRow{
+		Label: "diagnostic lane", Fixture: row.id, SourceBytes: len(fixture.Source),
+		Iterations: iterations, ElapsedNS: elapsed.Nanoseconds(),
+		NSPerOp:     float64(elapsed.Nanoseconds()) / float64(iterations),
+		ProfilePath: profilePath,
+	}
+}
+
+func captureAttributionShippedRoute(
+	t *testing.T,
+	outDir string,
+	fixture DiagnosticParserCoreCanonicalFixtureForTest,
+	row diagnosticParserCoreCanonicalAdmission,
+	duration time.Duration,
+	minIterations int,
+) attributionCaptureRow {
+	t.Helper()
+	runner, err := newParserCoreFreshFullRunner(parserCoreWarmGoScanner, parserCoreFreshFullCanonicalOptions())
+	if err != nil {
+		t.Fatalf("%s shipped route: build runner: %v", row.id, err)
+	}
+	parser := runner.parser
+	parser.SetAdmissionCandidateRoute(true)
+	defer parser.ClearAdmissionCandidateRoute()
+
+	routedBefore, fallbackBefore := AdmissionCandidateCounters()
+	warmTree, err := parser.Parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("%s shipped route: warm parse: %v", row.id, err)
+	}
+	if err := validateParserCoreFreshFullCanonicalTree(warmTree, len(fixture.Source)); err != nil {
+		warmTree.Release()
+		t.Fatalf("%s shipped route: warm parse: %v", row.id, err)
+	}
+	warmTree.Release()
+	routedAfterWarm, fallbackAfterWarm := AdmissionCandidateCounters()
+	if routedAfterWarm != routedBefore+1 || fallbackAfterWarm != fallbackBefore {
+		t.Fatalf("%s shipped route: warm parse did not take the compact route: routed %d->%d fallback %d->%d reason=%q",
+			row.id, routedBefore, routedAfterWarm, fallbackBefore, fallbackAfterWarm, AdmissionCandidateLastFallbackReason())
+	}
+	runtime.GC()
+	DrainArenaPools()
+
+	profilePath := filepath.Join(outDir, "shipped_"+row.id+".pprof")
+	profileFile, err := os.Create(profilePath)
+	if err != nil {
+		t.Fatalf("%s shipped route: create profile file: %v", row.id, err)
+	}
+	defer profileFile.Close()
+	if err := pprof.StartCPUProfile(profileFile); err != nil {
+		t.Fatalf("%s shipped route: start cpu profile: %v", row.id, err)
+	}
+	start := time.Now()
+	iterations := 0
+	for iterations < minIterations || time.Since(start) < duration {
+		tree, err := parser.Parse(fixture.Source)
+		if err != nil {
+			pprof.StopCPUProfile()
+			t.Fatalf("%s shipped route: timed parse: %v", row.id, err)
+		}
+		tree.Release()
+		iterations++
+	}
+	elapsed := time.Since(start)
+	pprof.StopCPUProfile()
+
+	routedAfter, fallbackAfter := AdmissionCandidateCounters()
+	if routedAfter != routedAfterWarm+uint64(iterations) || fallbackAfter != fallbackAfterWarm {
+		t.Fatalf("%s shipped route: timed loop did not stay on the compact route: routed %d->%d (want +%d) fallback %d->%d reason=%q",
+			row.id, routedAfterWarm, routedAfter, iterations, fallbackAfterWarm, fallbackAfter, AdmissionCandidateLastFallbackReason())
+	}
+
+	return attributionCaptureRow{
+		Label: "shipped route", Fixture: row.id, SourceBytes: len(fixture.Source),
+		Iterations: iterations, ElapsedNS: elapsed.Nanoseconds(),
+		NSPerOp:     float64(elapsed.Nanoseconds()) / float64(iterations),
+		ProfilePath: profilePath,
+	}
+}


### PR DESCRIPTION
## Summary

Introduce the `cgo_harness/attribution` tool to measure and publish CPU usage distribution across the compact parser core. The tool profiles both the diagnostic runner path and the shipped parse route, classifies frames against a fixed component tree, and generates a structured JSON and Markdown receipt.

## Changes

- Add `cgo_harness/attribution` main package with build, capture, work-count, noise-floor, and receipt-generation phases.
- Ship a minimal, zero-dependency pprof protobuf decoder to avoid widening the module dependency graph.
- Implement `classify.go`, the source-of-truth function-to-component mapper that defines transparency rules for shared primitives like scheduler bookkeeping and checkpoint interning.
- Add `parsercore_phase0_attribution_capture_internal_test.go`, an opt-in test that activates under `GTS_ATTRIBUTION_OUT` to profile `runner.parse` and `Parser.Parse` for the four canonical fixtures.
- Publish `docs/perf-attribution.md` detailing the attribution methodology and tolerance boundaries.
- Commit a baseline `docs/perf-attribution-receipt.json` reflecting current performance distribution.

## Testing

- Run `go run ./cgo_harness/attribution -reanalyze` pointing to an existing output directory to validate parsing and markdown rendering.
- Set `GTS_ATTRIBUTION_OUT=/tmp/attr_out && go test ./... -run '^TestParserCoreAttributionCapture$' -tags gts_parsercorephase0` to verify the capture harness executes cleanly.
- Confirm `docs/perf-attribution.md` renders correctly and `receipt.json` contains valid component rows summing to 100%.

## Freeze status

Do not merge before 2026-08-05. This PR adds a profiling tool, one opt-in test file, and two docs files. It does not touch any parser, scheduler, or routing source file. `git diff --stat` against `main` shows zero modified lines in an existing file, only new files.

First receipt, generated 2026-08-01, on a shared WSL2 development host with background load uncontrolled (local-development floor, not quiet-host or enclave; see `docs/perf-attribution.md` for the full host-class caveat).

- Noise floor (interleaved A/A, 12 pairs per fixture): p95 |delta| runs 7.4-10.8% of median ns/op across the four fixtures.
- Diagnostic-lane scheduler-family share (scheduler-dispatch + elections + reductions-and-pops + canonicalization + lexing): 80-85% of full-parse CPU. This range reproduces the historical 77-79% and 78-82% figures once lexing is included in the boundary.
- Scheduler-dispatch + reductions-and-pops alone (excluding elections, canonicalization, and lexing): 48-56%. This range reproduces the historical approximately-50% figure.

Full methodology, disambiguation rule, and reproduction command: `docs/perf-attribution.md`.
