### PR TITLE
fix(parsercorephase0): propagate historical provenance on all condense returns

### DIFF
--- a/internal/parsercorephase0/condense_outcome_provenance_ratchet_test.go
+++ b/internal/parsercorephase0/condense_outcome_provenance_ratchet_test.go
@@ -1,0 +1,128 @@
+package parsercorephase0
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCondenseWithOutcomeAtomicProvenanceRatchet is a structural regression
+// test for the historical-provenance-propagation fix in
+// condenseWithOutcomeAtomic (core.go). It parses the package's own source
+// and asserts that condenseWithOutcomeAtomic constructs every non-empty
+// condenseOutcome result through the buildOutcome closure, never through a
+// second, ad hoc condenseOutcome{...} literal that could silently omit the
+// historicalBoundarySplit / historicalConvergedSplit /
+// historicalForestDeterministic / historicalCleanPathRank /
+// historicalLineage fields buildOutcome carries.
+//
+// This exists because the defect this fix addresses is not observable
+// behaviorally through any input reachable via the public Core API: a live
+// incumbent (needed to reach the shallow-fold early returns this fix
+// touches) and a historical predecessor are mutually exclusive within one
+// condenseWithOutcomeAtomic call, since the historical branch
+// unconditionally zeroes oldID before the duplicate/shallow-fold logic ever
+// runs. link_fold_provenance_test.go's TestFold*PropagatesProvenance tests
+// confirm the fold paths do not fabricate history, but (confirmed by
+// reverting the fix locally and re-running them) they cannot by themselves
+// catch a regression back to the pre-fix bare literals, because the
+// discarded fields are always the zero value at those call sites either
+// way. This ratchet is what actually catches that regression: it fails if a
+// future edit reintroduces a bare `condenseOutcome{head: ..., change:
+// ...}` literal instead of routing through buildOutcome.
+func TestCondenseWithOutcomeAtomicProvenanceRatchet(t *testing.T) {
+	const targetFunction = "condenseWithOutcomeAtomic"
+	const targetType = "condenseOutcome"
+	const builder = "buildOutcome"
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	var fn *ast.FuncDecl
+	var fnFile string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Clean(name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil || function.Name.Name != targetFunction {
+				continue
+			}
+			if fn != nil {
+				t.Fatalf("%s declared more than once (in %s and %s)", targetFunction, fnFile, name)
+			}
+			fn = function
+			fnFile = name
+		}
+	}
+	if fn == nil {
+		t.Fatalf("%s not found in package source", targetFunction)
+	}
+
+	// Locate buildOutcome's own closure body so the walk below can skip it:
+	// that is the one legitimate place a full condenseOutcome{...} literal
+	// with the historical fields is constructed.
+	var buildOutcomeBody ast.Node
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		ident, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok || ident.Name != builder {
+			return true
+		}
+		literal, ok := assign.Rhs[0].(*ast.FuncLit)
+		if !ok {
+			return true
+		}
+		buildOutcomeBody = literal.Body
+		return false
+	})
+	if buildOutcomeBody == nil {
+		t.Fatalf("%s: %s closure not found", targetFunction, builder)
+	}
+
+	violations := 0
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if node == buildOutcomeBody {
+			return false
+		}
+		composite, ok := node.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		ident, ok := composite.Type.(*ast.Ident)
+		if !ok || ident.Name != targetType {
+			return true
+		}
+		if len(composite.Elts) == 0 {
+			// condenseOutcome{} is the zero value used on error returns;
+			// there is no head/provenance to propagate there.
+			return true
+		}
+		violations++
+		t.Errorf(
+			"%s: %s constructs a non-empty %s{...} literal at %s outside %s -- "+
+				"this bypasses historical provenance propagation; route it through "+
+				"%s(head, change) instead",
+			fnFile, targetFunction, targetType, fset.Position(composite.Pos()), builder, builder,
+		)
+		return true
+	})
+	if violations != 0 {
+		t.Fatalf("%d %s literal(s) in %s bypass %s", violations, targetType, targetFunction, builder)
+	}
+}

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -2073,6 +2073,23 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		}
 		oldID = 0
 	}
+	// buildOutcome stamps a returned condenseOutcome with the historical
+	// provenance snapshot captured above. Every return below resolves the
+	// same boundary key, so a historical split discovered above belongs on
+	// whichever path this call actually takes, not only on the path that
+	// happens to run first. This applies the duplicate-drop path's existing
+	// propagation uniformly instead of letting the other early returns
+	// silently drop it.
+	buildOutcome := func(head Head, change condenseChange) condenseOutcome {
+		return condenseOutcome{
+			head: head, change: change,
+			historicalBoundarySplit:       historicalBoundarySplit,
+			historicalConvergedSplit:      historicalConvergedSplit,
+			historicalForestDeterministic: historicalForestDeterministic,
+			historicalCleanPathRank:       historicalCleanPathRank,
+			historicalLineage:             historicalLineage,
+		}
+	}
 	var old nodeRecord
 	var oldLinks []linkRecord
 	if oldID != 0 {
@@ -2097,14 +2114,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				if phase0AEnabled {
 					phase0AObserveCandidateDrop(c, key, in, oldID, index, phase0ATransitionDuplicateDrop)
 				}
-				return condenseOutcome{
-					head: Head{Node: oldID}, change: condenseUnchanged,
-					historicalBoundarySplit:       historicalBoundarySplit,
-					historicalConvergedSplit:      historicalConvergedSplit,
-					historicalForestDeterministic: historicalForestDeterministic,
-					historicalCleanPathRank:       historicalCleanPathRank,
-					historicalLineage:             historicalLineage,
-				}, nil
+				return buildOutcome(Head{Node: oldID}, condenseUnchanged), nil
 			}
 		}
 		if c.diagnostics.foldSamePredecessorShallowPayloads {
@@ -2161,7 +2171,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 				if phase0AEnabled {
 					phase0AObserveCandidateDrop(c, key, in, oldID, structuralMatch, phase0ATransitionPrecedenceDrop)
 				}
-				return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, nil
+				return buildOutcome(Head{Node: oldID}, condenseUnchanged), nil
 			case shallowCount == 1:
 				// Exactly one shallow-class incumbent, structurally different. Rank
 				// the two by dynamic precedence, production's primary disambiguation
@@ -2184,7 +2194,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 					if phase0AEnabled {
 						phase0AObserveCandidateDrop(c, key, in, oldID, incumbent, phase0ATransitionPrecedenceDrop)
 					}
-					return condenseOutcome{head: Head{Node: oldID}, change: condenseUnchanged}, nil
+					return buildOutcome(Head{Node: oldID}, condenseUnchanged), nil
 				case incomingPrecedence > incumbentPrecedence:
 					// The incoming payload strictly dominates; replace the incumbent.
 					if phase0AEnabled {
@@ -2196,7 +2206,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 					} else {
 						c.recordLinkUnionPrecedenceReplaced()
 					}
-					return condenseOutcome{head: head, change: condenseUpdated}, err
+					return buildOutcome(head, condenseUpdated), err
 				default:
 					// A precedence tie between two structurally different same-span
 					// payloads. Dynamic precedence cannot rank them, and the compact
@@ -2301,14 +2311,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		change = condenseUpdated
 		c.recordLinkUnionAlternateAppended()
 	}
-	return condenseOutcome{
-		head: Head{Node: id}, change: change,
-		historicalBoundarySplit:       historicalBoundarySplit,
-		historicalConvergedSplit:      historicalConvergedSplit,
-		historicalForestDeterministic: historicalForestDeterministic,
-		historicalCleanPathRank:       historicalCleanPathRank,
-		historicalLineage:             historicalLineage,
-	}, nil
+	return buildOutcome(Head{Node: id}, change), nil
 }
 
 func (c *Core) linkEqualInput(link linkRecord, in linkInput) (bool, error) {

--- a/internal/parsercorephase0/link_fold_provenance_test.go
+++ b/internal/parsercorephase0/link_fold_provenance_test.go
@@ -1,0 +1,208 @@
+package parsercorephase0
+
+import "testing"
+
+// This file targets condenseWithOutcomeAtomic's three shallow-fold early
+// returns (structural match, precedence-drop, precedence-replace, all in
+// core.go's foldSamePredecessorShallowPayloads block) and the buildOutcome
+// helper that now backs every return in that function, including the
+// duplicate-drop return above it and the freshly-published-node return below
+// it. Before this change, only the duplicate-drop and freshly-published
+// returns copied the boundary's historical provenance snapshot
+// (historicalBoundarySplit / historicalConvergedSplit /
+// historicalForestDeterministic / historicalCleanPathRank /
+// historicalLineage) into the returned condenseOutcome; the three fold
+// returns discarded it.
+//
+// historicalFoldFixture below reaches condenseWithOutcomeAtomic through the
+// same live-condensation setup the historical-boundary tests in
+// core_test.go use (TestHistoricalBoundaryProvesDeterministicForest et al.):
+// it records real reduction lineage on a pre-scope incumbent, then folds a
+// historical-split replacement for it inside runLiveCondenseCandidates. That
+// replacement call resolves through the freshly-published-node return
+// (oldID is reset to 0 by the historical-split branch), so it is the one
+// carrying genuine non-zero provenance in this fixture.
+//
+// The fold call under test then targets that live survivor. Reaching the
+// live survivor's own links makes condenseWithOutcomeAtomic's boundary probe
+// see it as live, so *that* call's own historicalBoundarySplit computation
+// is false by construction -- a live incumbent and a historical predecessor
+// are mutually exclusive within one condenseWithOutcomeAtomic invocation,
+// because the historical branch unconditionally zeroes oldID before the
+// duplicate/shallow-fold logic ever runs (core.go, condenseWithOutcomeAtomic).
+// So the fold call's own outcome is expected to carry zero-value historical
+// fields here: the assertions below confirm buildOutcome propagates the
+// caller's actual (here: empty) snapshot rather than fabricating the nearby
+// but unrelated historical signal from the fixture's setup call. That is the
+// "merge, never invent" contract buildOutcome exists to enforce uniformly.
+//
+// If a future change ever lets a live incumbent and a historical
+// predecessor coexist in one call (for example, by making the historical
+// reset conditional), these three returns going through buildOutcome is
+// what makes that newly-reachable provenance propagate correctly instead of
+// silently reproducing the bug this change fixes.
+func historicalFoldFixture(t *testing.T, foldOnSurvivor func(core *Core, key boundaryKey, prev NodeID) (condenseOutcome, error)) (setup, fold condenseOutcome) {
+	t.Helper()
+	core, seed := newDiagnosticShallowFoldCore(t, Limits{MaxDerivations: 8, MaxLinksPerBoundary: 4})
+	incumbent := appendShallowPayload(t, core, shallowPayloadSpec{
+		symbol: 20, productionID: 1, startByte: 12, endByte: 17, childSymbols: []Symbol{30},
+	})
+	key := core.boundaryKey(2, 17)
+	input := linkInput{prev: seed.Node, payload: incumbent, scoreDelta: 5, order: ForkOrder{Present: true, Value: 1}}
+	err := core.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		preScope, err := core.condense(key, input)
+		if err != nil {
+			return err
+		}
+		if err := core.RecordReductionLineageOwned(owner, []ReductionOutput{{
+			Head: preScope, CleanPathRank: CleanPathRankSelected, MultiplePopPaths: true,
+		}}, 7); err != nil {
+			return err
+		}
+		return core.runLiveCondenseCandidates(nil, func() error {
+			setup, err = core.condenseWithOutcome(key, input)
+			if err != nil {
+				return err
+			}
+			// The fold call under test must share the survivor's own link
+			// predecessor (seed.Node), not the survivor node itself: prev is
+			// the edge target for the new link, and shallowPayloadClassEqual
+			// / linkEqualInput require it to match the incumbent link's prev
+			// for the shallow-fold search to consider it at all.
+			fold, err = foldOnSurvivor(core, key, seed.Node)
+			return err
+		})
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Confirm the fixture actually captured non-trivial historical
+	// provenance, so the fold call's zero-value assertions below are proving
+	// something (the fold did not merely inherit an already-empty
+	// snapshot).
+	if !setup.historicalBoundarySplit || !setup.historicalConvergedSplit ||
+		setup.historicalCleanPathRank != CleanPathRankSelected || setup.historicalLineage != 7 {
+		t.Fatalf("fixture did not establish historical provenance on the survivor: setup=%+v", setup)
+	}
+	return setup, fold
+}
+
+func assertNoFabricatedHistory(t *testing.T, outcome condenseOutcome) {
+	t.Helper()
+	if outcome.historicalBoundarySplit || outcome.historicalConvergedSplit || outcome.historicalForestDeterministic ||
+		outcome.historicalCleanPathRank != CleanPathRankNotApplicable || outcome.historicalLineage != 0 {
+		t.Fatalf("fold outcome invented historical provenance it was never given: %+v", outcome)
+	}
+}
+
+func TestFoldStructuralMatchPropagatesProvenanceWithoutFabrication(t *testing.T) {
+	_, fold := historicalFoldFixture(t, func(core *Core, key boundaryKey, prev NodeID) (condenseOutcome, error) {
+		// A second, distinct SubtreeID with the exact same shape as the
+		// survivor's own payload: reaches the structuralMatch >= 0 branch.
+		duplicate := appendShallowPayload(t, core, shallowPayloadSpec{
+			symbol: 20, productionID: 1, startByte: 12, endByte: 17, childSymbols: []Symbol{30},
+		})
+		return core.condenseWithOutcome(key, linkInput{
+			prev: prev, payload: duplicate, scoreDelta: 99, order: ForkOrder{Present: true, Value: 2},
+		})
+	})
+	if fold.change != condenseUnchanged {
+		t.Fatalf("structural-match change=%v, want condenseUnchanged", fold.change)
+	}
+	assertNoFabricatedHistory(t, fold)
+}
+
+func TestFoldPrecedenceDropPropagatesProvenanceWithoutFabrication(t *testing.T) {
+	_, fold := historicalFoldFixture(t, func(core *Core, key boundaryKey, prev NodeID) (condenseOutcome, error) {
+		// Shallow-class-equal (same symbol/padding/size/childCount) but
+		// structurally distinct (different production/child), with a
+		// strictly lower aggregate score: reaches the
+		// incomingPrecedence < incumbentPrecedence branch.
+		dominated := appendShallowPayload(t, core, shallowPayloadSpec{
+			symbol: 20, productionID: 2, startByte: 12, endByte: 17, childSymbols: []Symbol{31},
+		})
+		return core.condenseWithOutcome(key, linkInput{
+			prev: prev, payload: dominated, scoreDelta: 1, order: ForkOrder{Present: true, Value: 2},
+		})
+	})
+	if fold.change != condenseUnchanged {
+		t.Fatalf("precedence-drop change=%v, want condenseUnchanged", fold.change)
+	}
+	assertNoFabricatedHistory(t, fold)
+}
+
+func TestFoldPrecedenceReplacePropagatesProvenanceWithoutFabrication(t *testing.T) {
+	setup, fold := historicalFoldFixture(t, func(core *Core, key boundaryKey, prev NodeID) (condenseOutcome, error) {
+		// Shallow-class-equal but structurally distinct, with a strictly
+		// higher aggregate score: reaches the
+		// incomingPrecedence > incumbentPrecedence replacement branch, which
+		// republishes a brand-new node id via replaceBoundaryLink.
+		dominant := appendShallowPayload(t, core, shallowPayloadSpec{
+			symbol: 20, productionID: 3, startByte: 12, endByte: 17, childSymbols: []Symbol{32},
+		})
+		return core.condenseWithOutcome(key, linkInput{
+			prev: prev, payload: dominant, scoreDelta: 99, order: ForkOrder{Present: true, Value: 2},
+		})
+	})
+	if fold.change != condenseUpdated {
+		t.Fatalf("precedence-replace change=%v, want condenseUpdated", fold.change)
+	}
+	if fold.head == setup.head {
+		t.Fatalf("precedence-replace kept the historical survivor head %+v instead of republishing", setup.head)
+	}
+	assertNoFabricatedHistory(t, fold)
+}
+
+// TestDiagnosticShallowFoldStructuralMatchKeepsIncumbent is the plain
+// (non-historical) counterpart of the fixture-based tests above: it proves
+// the structuralMatch >= 0 branch itself -- survivor identity, no mutation
+// of the incumbent's stored links, and the duplicate genuinely dropped
+// rather than kept as a coexisting alternate. link_fold_test.go already
+// covers the sibling precedence-drop/precedence-replace/tie branches
+// (TestDiagnosticShallowFoldChildBearingParentSelectsHigherAggregateScore);
+// this fills the one gap.
+func TestDiagnosticShallowFoldStructuralMatchKeepsIncumbent(t *testing.T) {
+	core, seed := newDiagnosticShallowFoldCore(t, Limits{MaxDerivations: 4})
+	spec := shallowPayloadSpec{symbol: 20, productionID: 1, startByte: 12, endByte: 17, childSymbols: []Symbol{30}}
+	incumbent := appendShallowPayload(t, core, spec)
+	duplicate := appendShallowPayload(t, core, spec)
+	if incumbent == duplicate {
+		t.Fatalf("fixture reused one subtree id for two structurally-equal payloads")
+	}
+	key := core.boundaryKey(2, 17)
+	oldHead, err := core.condense(key, linkInput{
+		prev: seed.Node, payload: incumbent, scoreDelta: 5, order: ForkOrder{Present: true, Value: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := core.Stats(oldHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := core.condenseWithOutcome(key, linkInput{
+		prev: seed.Node, payload: duplicate, scoreDelta: 9, order: ForkOrder{Present: true, Value: 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.change != condenseUnchanged || outcome.head != oldHead {
+		t.Fatalf("structural-match outcome=%+v, want unchanged head %+v", outcome, oldHead)
+	}
+	after, err := core.Stats(oldHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != before {
+		t.Fatalf("structural-match mutated incumbent storage: before=%+v after=%+v", before, after)
+	}
+	paths, err := core.Derivations(oldHead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Derivation{{Payloads: []SubtreeID{incumbent}, Score: 5, BranchOrder: 1, HasBranchOrder: true}}
+	if len(paths) != 1 || paths[0].Score != want[0].Score || paths[0].BranchOrder != want[0].BranchOrder ||
+		len(paths[0].Payloads) != 1 || paths[0].Payloads[0] != incumbent {
+		t.Fatalf("structural-match derivations=%#v, want %#v (duplicate must not survive as an alternate)", paths, want)
+	}
+}


### PR DESCRIPTION
## Summary

condenseWithOutcomeAtomic previously built some returned condenseOutcome values with inline struct literals. Those paths dropped historical provenance fields. This branch extracts a buildOutcome closure so every return uses it. The fix guarantees that boundary provenance propagates uniformly across all control paths.

## Changes

- Add buildOutcome(head, change) closure inside condenseWithOutcomeAtomic. It stamps the returned struct with the complete provenance state.
- Replace inline condenseOutcome literals in the duplicate-drop, precedence-drop, precedence-replace, and final-path branches with calls to buildOutcome.
- Add condense_outcome_provenance_ratchet_test.go. This structural test walks the AST of condenseWithOutcomeAtomic. It fails if any non-empty condenseOutcome literal appears outside the buildOutcome closure. This blocks future regressions.
- Add link_fold_provenance_test.go. These unit tests exercise the shallow-fold early returns. They verify that provenance propagates correctly and the helper never invents unrelated historical signals.

## Testing

- cd internal/parsercorephase0 && go test -v -run 'TestCondenseWithOutcomeAtomicProvenanceRatchet|TestFold.*PropagatesProvenance|TestDiagnosticShallowFoldStructuralMatchKeepsIncumbent'
- Run parity suites for affected grammars: bash cgo_harness/docker/run_single_grammar_parity.sh <grammar>

## Verification gates

The gates below ran for this change. Results follow.

- `go build ./...`: clean.
- `go test ./internal/parsercorephase0/ -count=1`: pass. The run includes three new behavioral tests and one new structural ratchet test.
- Zero-alloc pin (`TestDiagnosticParserCoreSelectedLineageProofAllocations`, tag `gts_parsercorephase0`): pass, zero allocations.
- Work-count identity (`TestParserCoreWorkCountChild`, tags `gts_parsercorephase0 gts_workcount`): the test exists. It skips in this environment. The skip message reads "parser-core work-count child protocol is not configured." No counters ran, so none changed.
- Admission scorecard (`TestAdmissionCandidateScorecard206`, env `GTS_ADMISSION_SCORECARD=1 GTS_ADMISSION_SCORECARD_RATCHET=1`): PASS=200, DIVERGE=0, FALLBACK=1, SKIP=5, ERROR=0, total=206. This matches the frozen 200/1/5/0 ratchet exactly. The scorecard did not move. Two runs produced the same counts.
- Canonical fixture digests (`TestDiagnosticParserCoreCanonicalAdmissions`): pass for all four fixtures — rewrite, query_compile, language, grammargen_lr. Compact and production trees stay byte-identical.

## Performance

This change carries no performance claim. The retain gate here is correctness only. The local noise floor for this environment runs 7.4 to 10.8 percent. No benchmark number in this environment can support a decision.

## Why the scorecard did not move

The three fixed returns sit on one path inside `condenseWithOutcomeAtomic`. Reaching that path needs a live incumbent at the boundary. The historical-provenance branch always resets the incumbent to zero first. A live incumbent and a historical predecessor cannot occur together in one call today.

I confirmed this three ways: a static control-flow proof, an empirical probe test, and a revert-and-rerun check. The revert-and-rerun check restored the pre-fix bare literals and re-ran the full package suite. The suite, including the new fold-path tests, still passed.

This fix removes a real code-level asymmetry. It also guards against a future change that could make the combination reachable. It changes no observable behavior today. The new test `TestCondenseWithOutcomeAtomicProvenanceRatchet` catches a real regression. It parses the function's AST. It fails when a future edit reintroduces a bare literal outside `buildOutcome`.

## Freeze

freeze-held: engine provenance fix, do not merge before 2026-08-05.
