### PR TITLE
update(compat): Update Ada aggregate owner to derivation_election_selection

### DIFF
--- a/docs/compat-tier.md
+++ b/docs/compat-tier.md
@@ -87,8 +87,13 @@ post-parse normalization tail.
 
 ## Materialization subpass census
 
-Four live arms still use `materialization` as their aggregate owner.
-Each arm now declares its distinct subpasses in the registry.
+Two live arms, Apex and Bash, still use `materialization` as their aggregate
+owner. Ada's entry now aggregates under `derivation_election_selection`. Two
+of its three subpasses pick a winning derivation from source text. They
+choose between grammatically distinct productions. The entry-level owner now
+matches that majority. The association-choice subpass still builds its own
+wrapper. It keeps `materialization` at the subpass level. Each arm declares
+its distinct subpasses in the registry.
 
 Set `GTS_DISPATCHER_CENSUS=1` to record each subpass and its aggregate arm.
 The census does not change parser output when it is disabled.

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -99,7 +99,7 @@
         "ada"
       ],
       "purpose": "Reconcile Ada returned-tree fields, aliases, and spans.",
-      "authoritative_owner": "materialization",
+      "authoritative_owner": "derivation_election_selection",
       "witnesses": [
         "cgo_harness/parity_cgo_test.go"
       ],


### PR DESCRIPTION
## Summary

Reclassifies the aggregate owner for Ada from `materialization` to `derivation_election_selection`. This aligns the compatibility metadata with actual subpass behavior, where the majority of Ada subpasses select winning derivations from source text rather than materializing trees.

## Changes

- Reclassify Ada's authoritative owner to `derivation_election_selection` in the compat tier registry.
- Adjust the materialization census documentation to track only Apex and Bash under `materialization`, and note Ada's derivation-focused subpass structure.
- Sync `testdata/result_compat_ownership_v1.json` to reflect the new classification.

---

only the ada metadata fix. The apex fix stopped; see below.

### Ada re-attribution (shipped, one commit)

`dispatch.ada`'s entry-level `authoritative_owner` said `materialization`.
Two of its three subpasses already said `derivation_election_selection`:
`constraint-kind-election` and `aggregate-kind-election`. Both subpasses
pick a winning derivation with unbounded source-text heuristics
(`bytes.Contains` scans for `=>`, `'`, `,` across a whole sub-tree span).
They choose between grammatically distinct Ada productions. Only the
third subpass, `association-choice-materialization`, builds leaf and
wrapper structure. The entry-level owner now matches the majority. No
source file changed; `parser_result_ada.go` is untouched.

Registry deltas (`testdata/result_compat_ownership_v1.json`):

- `dispatch.ada.authoritative_owner`: `materialization` →
  `derivation_election_selection`.
- Subpass owners unchanged (2× `derivation_election_selection`, 1×
  `materialization`).
- Live-entry owner distribution: `materialization` 3 → 2,
  `derivation_election_selection` 11 → 12. Totals unchanged: 41 live, 44
  retired, 40 dispatcher arms, 42 dispatcher languages.

`docs/compat-tier.md` updated to match: "Two live arms, Apex and Bash"
replaces "Four live arms". The subpass table itself is unchanged.

### Apex (stopped, no commit)

Studied `parser_result_apex.go`'s single subpass:
`dispatch.apex.class-literal-alias`. It relabels a 3-child shape from
`class_literal` (raw) to `field_access` (normalized). It gates the
relabel on the `type_identifier`/`.`/`class` child types, plus one
text-equality check on the last child.

**Raw-vs-normalized shape** (`Object t = RecordPage.class;`):

- Raw (`ParseNoResultCompatibilityBenchmarkOnly`):
  `(class_literal (type_identifier))`
- Normalized (`Parse`): `(field_access (identifier) (identifier))`
- Census: `NodesVisited=31 NodesRewritten=3` (root plus both leaves
  relabeled).

**Root-fix attempt.** The trailing text-equality check
(`apexNodeTextEquals`) is redundant. gotreesitter's own per-stack
keyword-promotion invariant (`parser_dfa_token_source.go`) guarantees a
node typed `"class"` can only ever hold the text `"class"`. So the
relabel can run purely on table-derived symbol identity. That redundant
check is not the real blocker.

**C-parity result: red, confirmed in Docker.** Added a
`class_literal_alias` case to `TestApexCloseAngleRawCOracleParity`
(`cgo_harness/apex_generic_local_parity_test.go`, not committed here; see
the filed issue for the exact case to reproduce). Apex is absent from
`cgo_harness/docker/run_single_grammar_parity.sh`'s grammar list, so that
script cannot target apex; ran the case directly instead, first locally
(`GTS_PARITY_ALLOW_HOST=1`) then inside the real
`gotreesitter/cgo-harness:go1.25-local` container via
`cgo_harness/docker/run_parity_in_docker.sh --no-build -- "cd
/workspace/cgo_harness && go test . -tags 'cgo treesitter_c_parity' -run
'^TestApexCloseAngleRawCOracleParity$' -count=1 -v"`. Both runs agree.
Docker run: the 2 pre-existing cases pass; `class_literal_alias` fails
identically. Result:

```
root[0][3][1][3][1][1][2]: Type go="class_literal" c="field_access"
root[0][3][1][3][1][1][2][0]: Type go="type_identifier" c="identifier"
root[0][3][1][3][1][1][2][2]: Type go="class" c="identifier"
root[0][3][1][3][1][1][2][2]: IsNamed go=false c=true
```

The real C grammar (locked commit `3597575a4297`) emits `field_access`
**natively** for this input. gotreesitter's own LALR/GLR table emits
`class_literal` instead. `class_literal` and `field_access` are
grammar-declared sibling alternatives inside `primary_expression`. A
declared `conflicts` pair ties them together
(`[$._unannotated_type, $.primary_expression]`), with no `prec.dynamic`
tie-break. Each engine resolves the tie deterministically from its own
generated tables. Neither reads source text to decide. The two engines
simply disagree on the winner. The filed issue carries the full grammar
excerpt and analysis.

This is a parser-table conflict-resolution divergence upstream of
materialization. It is not a materialization gap. No alias, supertype, or
field-projection table property inside the compat tail can fix it: the
wrong derivation is already chosen before the compatibility pass runs. A
real fix needs one of two changes, neither in scope here: a GLR/LALR
tie-break correction in gotreesitter's table generator (parser-core,
cross-grammar blast radius), or a local grammar-source patch that adds an
explicit `prec.dynamic` (the same mechanism as
`grammars/patches/tree-sitter-typescript-import-type.patch`, which needs
a full grammargen real-corpus re-run). Both need their own scoped
which bars routing and table changes.

Per the stop rule, no apex commit ships. `dispatch.apex` stays live and
unmodified; `authoritative_owner: materialization` is unchanged. Filed as
issue #601 with full reproduction steps, grammar excerpts, and two
candidate root-fix directions. The investigation also found that apex's
own `authoritative_owner` is likely misattributed, the same way ada's
was. Its true fix mechanism is derivation election, not materialization.
Re-attributing it belongs in its own reviewed change, not bundled here.

### Verification

- `go build ./...` — clean.
- `go test . -count=1` — pass (235s).
- `go test ./parser_result_test/... -count=1` — pass, including
  `TestMaterializationSubpassCompatibilityFreeProducerProbes/apex_*` (run
  before any change, as a positive control) and `/ada_*`.
- `go test . -run '^TestResultCompatibilityOwnershipRegistry$' -count=1`
  — pass.
- `GTS_ADMISSION_SCORECARD=1 GTS_ADMISSION_SCORECARD_RATCHET=1 go test
  -tags gts_parsercorephase0 . -run TestAdmissionCandidateScorecard206`
  — unchanged: `PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0 total=206`.
- Apex C-oracle raw-shape parity (`cgo && treesitter_c_parity`): the
  existing 2 cases pass, both locally (`GTS_PARITY_ALLOW_HOST=1`) and in
  the `gotreesitter/cgo-harness:go1.25-local` Docker container. The new
  `class_literal_alias` case fails identically both ways, as documented
  above. It is not committed.

### Freeze note

result-compat registry and one doc section. It does not change parser or
runtime behavior. No apex code ships.
