### PR TITLE
add(admission): Add leaf-tiling invariant to compact route

### DIFF
--- a/admission_census.go
+++ b/admission_census.go
@@ -111,7 +111,7 @@ const (
 	// This is the false-clean route-equality gate: without it, the accepted
 	// derivation would publish HasError()==false while production and the
 	// locked C oracle both return an error tree for the same input
-	// (cgo_harness/testdata/compact_t3_oracle_witnesses_v1.json).
+	// (cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json).
 	censusMechanismAcceptedLeafTilingGap admissionCensusMechanism = "accepted-leaf-tiling-gap"
 	// censusMechanismOther is the catch-all for a decline this classifier
 	// does not yet recognize. The full original detail is always preserved

--- a/admission_census.go
+++ b/admission_census.go
@@ -103,6 +103,16 @@ const (
 	// accepted/shifted heads, closed-and-checkpoint-continuous election) were
 	// not met, independent of any specific grammar feature.
 	censusMechanismSchedulerShape admissionCensusMechanism = "scheduler-frontier-shape"
+	// censusMechanismAcceptedLeafTilingGap: the scheduler accepted a clean,
+	// full-span root, but diagnosticParserCoreReduceChildrenTilingGap
+	// (parsercore_phase0_driver.go, campaign v7 tranche B1), checked once per
+	// reduce during materialization, found a byte range under some subtree's
+	// declared span with no covering child and no tolerated-trivia excuse.
+	// This is the false-clean route-equality gate: without it, the accepted
+	// derivation would publish HasError()==false while production and the
+	// locked C oracle both return an error tree for the same input
+	// (cgo_harness/testdata/compact_t3_oracle_witnesses_v1.json).
+	censusMechanismAcceptedLeafTilingGap admissionCensusMechanism = "accepted-leaf-tiling-gap"
 	// censusMechanismOther is the catch-all for a decline this classifier
 	// does not yet recognize. The full original detail is always preserved
 	// alongside it.
@@ -164,7 +174,12 @@ func admissionCensusClassify(boundary DiagnosticParserCoreBoundaryKind, detail s
 			return censusMechanismNoTableAction
 		}
 		return censusMechanismSchedulerShape
-	case DiagnosticParserCoreAccept, DiagnosticParserCoreGenericClosed:
+	case DiagnosticParserCoreAccept:
+		if strings.Contains(detail, "accepted-leaf-tiling-gap") {
+			return censusMechanismAcceptedLeafTilingGap
+		}
+		return censusMechanismSchedulerShape
+	case DiagnosticParserCoreGenericClosed:
 		return censusMechanismSchedulerShape
 	case censusBoundaryMultiDerivation:
 		return censusMechanismMultiDerivation

--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -1,0 +1,201 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// compactT3RouteEqualityWitnessManifestPath is the manifest committed by PR
+// #573 and read directly by cgo_harness/compact_t3_oracle_adjudication_test.go
+// (cgo- and Docker-gated, so not runnable here). cgo_harness is a separate Go
+// module (its own go.mod), so this package cannot import its types; it
+// decodes the same committed JSON with a local, minimal struct instead.
+const compactT3RouteEqualityWitnessManifestPath = "cgo_harness/testdata/compact_t3_oracle_witnesses_v1.json"
+
+type routeEqualityWitnessManifest struct {
+	Witnesses []routeEqualityWitness `json:"witnesses"`
+}
+
+type routeEqualityWitness struct {
+	ID         string `json:"id"`
+	Language   string `json:"language"`
+	SourceUTF8 string `json:"source_utf8"`
+	Expected   struct {
+		CHasError          *bool `json:"c_has_error"`
+		ProductionHasError *bool `json:"production_has_error"`
+		CompactHasError    *bool `json:"compact_has_error"`
+	} `json:"expected"`
+}
+
+func loadRouteEqualityWitnesses(t *testing.T) map[string]routeEqualityWitness {
+	t.Helper()
+	raw, err := os.ReadFile(compactT3RouteEqualityWitnessManifestPath)
+	if err != nil {
+		t.Fatalf("read witness manifest: %v", err)
+	}
+	var manifest routeEqualityWitnessManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("decode witness manifest: %v", err)
+	}
+	byID := make(map[string]routeEqualityWitness, len(manifest.Witnesses))
+	for _, w := range manifest.Witnesses {
+		byID[w.ID] = w
+	}
+	return byID
+}
+
+// TestCompactRouteHTMLErroneousEndTagByteGapDeclines pins the B1 reference
+// witness by its literal bytes, independent of the committed manifest file:
+// html "<a></a^>" must decline the compact route because no leaf covers byte
+// 6 (the stray '^' inside the malformed close tag), and production must
+// report HasError()==true for the same bytes. Before the tiling gate, the
+// compact route accepted this input and published document[0:8] clean.
+func TestCompactRouteHTMLErroneousEndTagByteGapDeclines(t *testing.T) {
+	// This loads the html grammar into the process-wide embedded cache; purge
+	// afterward so it does not inflate heap for later whole-process tests
+	// (matches admission_scorecard_test.go's convention).
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	entry := grammars.DetectLanguageByName("html")
+	if entry == nil {
+		t.Fatal("html is not registered")
+	}
+	lang := entry.Language()
+	source := []byte("<a></a^>")
+
+	production := gts.NewParser(lang)
+	production.SetAdmissionCandidateRoute(false)
+	productionTree, err := production.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer productionTree.Release()
+	if !productionTree.RootNode().HasError() {
+		t.Fatal("production HasError=false, want true for <a></a^>")
+	}
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidate := gts.NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	candidateTree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	defer candidateTree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 0 || fallback != 1 {
+		t.Fatalf("route counters routed=%d fallback=%d, want routed=0 fallback=1 (compact must decline)", routed, fallback)
+	}
+	reason := gts.AdmissionCandidateLastFallbackReason()
+	if !strings.Contains(reason, "accepted-leaf-tiling-gap") {
+		t.Fatalf("fallback reason=%q, want it to cite accepted-leaf-tiling-gap", reason)
+	}
+	if !candidateTree.RootNode().HasError() {
+		t.Fatal("production-served (post-fallback) tree HasError=false, want true")
+	}
+}
+
+// TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses pulls a focused
+// subset (3 html, 3 javascript) from the 20-witness committed manifest (10
+// html, 8 javascript, 2 swift). Each entry was, before the B1 tiling gate,
+// accepted by the compact route with HasError()==false while production and
+// the locked C oracle both report an error
+// (compact_t3_oracle_witnesses_v1.json: c_has_error=production_has_error=
+// true, compact_has_error=false for all 20). This asserts the fixed
+// contract: compact declines specifically at the new tiling gate, the
+// caller falls back to production within the same Parse call, and the
+// production-served tree's HasError matches the manifest's adjudicated
+// verdict.
+//
+// Scope note: the manifest's 2 swift entries (swift_log_1, swift_log_2) are
+// NOT in this list. Root-cause (verified by direct tree inspection):
+// swift's witnesses are ambiguous `>>` tokenization (ship-vs-comparison,
+// `x >> y>>`) where the compact generic scheduler's accepted derivation
+// fully tiles the source -- every byte is covered by a leaf, contiguously,
+// with no trivia-excused or non-trivia gap anywhere. Production instead
+// treats the dangling trailing `>` `>` as unparseable and wraps it in an
+// ERROR node. Both derivations are complete and gapless; they simply
+// disagree on which reduction is grammatically valid for the trailing
+// operator. That is a shift/reduce conflict-resolution divergence between
+// the compact scheduler and production's LR tables, a different mechanism
+// from the false-clean coverage gap this tranche closes, so the B1 leaf-
+// tiling invariant correctly does not (and must not be made to) reject it.
+// See TestCompactRouteSwiftShiftComparisonGapIsNotATilingDefect
+// (admission_route_equality_swift_residual_test.go, gts_parsercorephase0-
+// tagged -- loading the swift grammar alone retains roughly 20 MB past a
+// full drain+purge+GC cycle, a pre-existing characteristic reproduced
+// identically on origin/main with none of this tranche's changes present,
+// unrelated to either route; keeping it out of the always-on suite avoids
+// tripping TestArenaGCRetentionAfterRelease's whole-process heap budget),
+// which documents the current, still-open state directly. Filed as an
+// out-of-scope finding for a follow-up tranche rather than folded into this
+// fix (campaign v7 delegation protocol: scope changes route back through
+// the specification, not through an ad hoc widening of one tranche's check).
+func TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses(t *testing.T) {
+	// html and javascript are not otherwise loaded by the always-on (untagged)
+	// suite; purge the process-wide embedded cache afterward so this test does
+	// not inflate heap for later whole-process tests (matches
+	// admission_scorecard_test.go's convention).
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+	witnesses := loadRouteEqualityWitnesses(t)
+	ids := []string{
+		"html_min_a", "html_min_html", "html_log_1",
+		"js_log_1", "js_log_2", "js_log_3",
+	}
+	for _, id := range ids {
+		id := id
+		t.Run(id, func(t *testing.T) {
+			witness, ok := witnesses[id]
+			if !ok {
+				t.Fatalf("witness %q is missing from %s", id, compactT3RouteEqualityWitnessManifestPath)
+			}
+			if witness.Expected.CHasError == nil || witness.Expected.ProductionHasError == nil || witness.Expected.CompactHasError == nil {
+				t.Fatalf("witness %q has an incomplete expected outcome", id)
+			}
+			if *witness.Expected.CompactHasError {
+				t.Fatalf("witness %q manifest compact_has_error=true, want the documented pre-fix false-clean baseline (false)", id)
+			}
+			if *witness.Expected.CHasError != *witness.Expected.ProductionHasError {
+				t.Fatalf("witness %q manifest c_has_error=%t disagrees with production_has_error=%t; adjudication requires the C oracle to side with production",
+					id, *witness.Expected.CHasError, *witness.Expected.ProductionHasError)
+			}
+
+			entry := grammars.DetectLanguageByName(witness.Language)
+			if entry == nil {
+				t.Fatalf("witness %q: language %q is not registered", id, witness.Language)
+			}
+			lang := entry.Language()
+			source := []byte(witness.SourceUTF8)
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(true)
+			tree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("witness %q: parse: %v", id, err)
+			}
+			defer tree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 0 || fallback != 1 {
+				t.Fatalf("witness %q: route counters routed=%d fallback=%d, want routed=0 fallback=1 (compact must decline)", id, routed, fallback)
+			}
+			reason := gts.AdmissionCandidateLastFallbackReason()
+			if !strings.Contains(reason, "accepted-leaf-tiling-gap") {
+				t.Fatalf("witness %q: fallback reason=%q, want it to cite accepted-leaf-tiling-gap", id, reason)
+			}
+
+			if got := tree.RootNode().HasError(); got != *witness.Expected.ProductionHasError {
+				t.Fatalf("witness %q: production-served HasError=%t, want %t (manifest production_has_error, C-adjudicated)",
+					id, got, *witness.Expected.ProductionHasError)
+			}
+		})
+	}
+}

--- a/admission_route_equality_leaf_tiling_test.go
+++ b/admission_route_equality_leaf_tiling_test.go
@@ -13,11 +13,14 @@ import (
 )
 
 // compactT3RouteEqualityWitnessManifestPath is the manifest committed by PR
-// #573 and read directly by cgo_harness/compact_t3_oracle_adjudication_test.go
-// (cgo- and Docker-gated, so not runnable here). cgo_harness is a separate Go
+// #573 (v1) and upgraded to v2 by the B3 stage S1 structural-parity harness,
+// read directly by cgo_harness/compact_t3_oracle_adjudication_test.go (cgo-
+// and Docker-gated, so not runnable here). cgo_harness is a separate Go
 // module (its own go.mod), so this package cannot import its types; it
-// decodes the same committed JSON with a local, minimal struct instead.
-const compactT3RouteEqualityWitnessManifestPath = "cgo_harness/testdata/compact_t3_oracle_witnesses_v1.json"
+// decodes the same committed JSON with a local, minimal struct instead. The
+// v2 manifest adds a top-level "denominator" object this struct does not
+// declare; json.Unmarshal (no DisallowUnknownFields here) ignores it.
+const compactT3RouteEqualityWitnessManifestPath = "cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json"
 
 type routeEqualityWitnessManifest struct {
 	Witnesses []routeEqualityWitness `json:"witnesses"`
@@ -106,12 +109,15 @@ func TestCompactRouteHTMLErroneousEndTagByteGapDeclines(t *testing.T) {
 // subset (3 html, 3 javascript) from the 20-witness committed manifest (10
 // html, 8 javascript, 2 swift). Each entry was, before the B1 tiling gate,
 // accepted by the compact route with HasError()==false while production and
-// the locked C oracle both report an error
-// (compact_t3_oracle_witnesses_v1.json: c_has_error=production_has_error=
-// true, compact_has_error=false for all 20). This asserts the fixed
-// contract: compact declines specifically at the new tiling gate, the
-// caller falls back to production within the same Parse call, and the
-// production-served tree's HasError matches the manifest's adjudicated
+// the locked C oracle both report an error (compact_t3_oracle_witnesses_v2.
+// json: c_has_error=production_has_error=true for all 20; compact_has_error
+// was false for all 20 before this tranche's fix, and is now recorded true
+// for the 18 html/javascript entries this gate closes -- see
+// TestCompactRouteSwiftShiftComparisonGapIsNotATilingDefect for the 2 swift
+// entries, which stay false). This asserts the fixed contract: compact
+// declines specifically at the new tiling gate, the caller falls back to
+// production within the same Parse call, and the production-served tree's
+// HasError matches the manifest's adjudicated
 // verdict.
 //
 // Scope note: the manifest's 2 swift entries (swift_log_1, swift_log_2) are
@@ -159,8 +165,19 @@ func TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses(t *testing.T) {
 			if witness.Expected.CHasError == nil || witness.Expected.ProductionHasError == nil || witness.Expected.CompactHasError == nil {
 				t.Fatalf("witness %q has an incomplete expected outcome", id)
 			}
-			if *witness.Expected.CompactHasError {
-				t.Fatalf("witness %q manifest compact_has_error=true, want the documented pre-fix false-clean baseline (false)", id)
+			// The manifest's compact_has_error records what the compact-routed
+			// Parse() call actually returns, not a fixed pre-adjudication
+			// snapshot. This tranche's fix makes that value match production's
+			// (decline, fall back within the same call), so the manifest now
+			// records compact_has_error=true for these 18 entries -- the same
+			// value as production_has_error, both true. A manifest that still
+			// showed compact_has_error=false here would mean either this
+			// witness's manifest record was not updated for the fix, or the
+			// fix has regressed; both are the same failure from this test's
+			// point of view.
+			if *witness.Expected.CompactHasError != *witness.Expected.ProductionHasError {
+				t.Fatalf("witness %q manifest compact_has_error=%t disagrees with production_has_error=%t; the fixed manifest must record that compact now matches production",
+					id, *witness.Expected.CompactHasError, *witness.Expected.ProductionHasError)
 			}
 			if *witness.Expected.CHasError != *witness.Expected.ProductionHasError {
 				t.Fatalf("witness %q manifest c_has_error=%t disagrees with production_has_error=%t; adjudication requires the C oracle to side with production",

--- a/admission_route_equality_swift_residual_test.go
+++ b/admission_route_equality_swift_residual_test.go
@@ -1,0 +1,88 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// This file is gts_parsercorephase0-tagged (positive opt-in, matching
+// admission_scorecard_test.go and the other large-grammar-loading tests),
+// not !gts_no_parsercorephase0 like admission_route_equality_leaf_tiling_test.go.
+// Loading the swift grammar alone -- regardless of route, verified with the
+// production route too -- retains roughly 20 MB past a full
+// DrainArenaPools+PurgeEmbeddedLanguageCache+runtime.GC() cycle. That is a
+// pre-existing characteristic reproduced identically on origin/main with
+// none of this tranche's changes present; it is unrelated to the B1 tiling
+// fix. No always-on (untagged) test loads swift today, so
+// TestArenaGCRetentionAfterRelease (benchmark_warm_reuse_test.go) has never
+// observed it. Keeping this witness pin out of the untagged suite avoids
+// tripping that whole-process heap budget over an unrelated, pre-existing
+// retention characteristic.
+
+// TestCompactRouteSwiftShiftComparisonGapIsNotATilingDefect documents the
+// manifest's 2 swift witnesses (swift_log_1, swift_log_2) as a deliberately
+// out-of-scope residual for B1. Both are adjudicated false-clean divergences
+// (c_has_error=production_has_error=true, compact_has_error=false), but
+// direct tree inspection shows the compact route's accepted derivation
+// fully tiles the source for both -- there is no byte range left uncovered,
+// so the B1 leaf-tiling invariant this tranche adds does not fire and must
+// not be forced to. The divergence is a shift/reduce conflict-resolution
+// difference: given the ambiguous trailing `>>` in `x >> y>>`, production
+// completes `x >> y` as a bitwise_operation and wraps the dangling `> >` in
+// an ERROR node, while compact's generic scheduler instead reduces `> >` as
+// two more comparison_expression operators onto the same left-hand side --
+// a different, but still fully gapless, derivation. This test pins today's
+// actual (still-open) behavior so a future fix to the scheduler's conflict
+// resolution is visible here (the test starts failing) rather than silently
+// drifting; it is not an endorsement of the outcome. See the campaign
+// finding filed alongside this tranche's spore.
+func TestCompactRouteSwiftShiftComparisonGapIsNotATilingDefect(t *testing.T) {
+	witnesses := loadRouteEqualityWitnesses(t)
+	for _, id := range []string{"swift_log_1", "swift_log_2"} {
+		id := id
+		t.Run(id, func(t *testing.T) {
+			witness, ok := witnesses[id]
+			if !ok {
+				t.Fatalf("witness %q is missing from %s", id, compactT3RouteEqualityWitnessManifestPath)
+			}
+			entry := grammars.DetectLanguageByName(witness.Language)
+			if entry == nil {
+				t.Fatalf("witness %q: language %q is not registered", id, witness.Language)
+			}
+			lang := entry.Language()
+			source := []byte(witness.SourceUTF8)
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			parser := gts.NewParser(lang)
+			parser.SetAdmissionCandidateRoute(true)
+			tree, err := parser.Parse(source)
+			if err != nil {
+				t.Fatalf("witness %q: parse: %v", id, err)
+			}
+			defer tree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed == 0 && fallback == 1 {
+				reason := gts.AdmissionCandidateLastFallbackReason()
+				if strings.Contains(reason, "accepted-leaf-tiling-gap") {
+					t.Fatalf("witness %q now declines at the tiling gate (reason=%q); this contradicts the documented "+
+						"gapless-derivation root cause -- re-verify the finding before removing this pin", id, reason)
+				}
+				t.Skipf("witness %q now declines (reason=%q); the shift/reduce residual appears fixed -- "+
+					"promote it into TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses and delete this pin", id, reason)
+			}
+			if routed != 1 || fallback != 0 {
+				t.Fatalf("witness %q: route counters routed=%d fallback=%d, want the documented still-open routed=1 fallback=0", id, routed, fallback)
+			}
+			if tree.RootNode().HasError() {
+				t.Fatalf("witness %q: compact tree now reports HasError=true; the false-clean residual appears fixed -- "+
+					"re-verify and update this pin", id)
+			}
+		})
+	}
+}

--- a/cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json
+++ b/cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json
@@ -56,7 +56,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -83,7 +83,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -110,7 +110,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -137,7 +137,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -164,7 +164,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -191,7 +191,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -218,7 +218,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -245,7 +245,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -272,7 +272,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -299,7 +299,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -326,7 +326,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -353,7 +353,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -380,7 +380,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -407,7 +407,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -434,7 +434,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -461,7 +461,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -488,7 +488,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {
@@ -515,7 +515,7 @@
       "expected": {
         "c_has_error": true,
         "production_has_error": true,
-        "compact_has_error": false
+        "compact_has_error": true
       }
     },
     {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2460,7 +2460,7 @@ func finalizeDiagnosticParserCoreAcceptedRootSpan(root *Node, source []byte, sou
 // while its three RAW children covered only 3..5, 5..6 and 7..8, leaving
 // byte 6 (the stray '^') completely unaccounted for at every level, not
 // just the final public tree (cgo_harness/testdata/
-// compact_t3_oracle_witnesses_v1.json, witness "html_min_a"; verified by
+// compact_t3_oracle_witnesses_v2.json, witness "html_min_a"; verified by
 // direct inspection of view.Children, not merely the post-materialization
 // node tree -- see the next paragraph for why that distinction matters).
 //

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2437,6 +2437,189 @@ func finalizeDiagnosticParserCoreAcceptedRootSpan(root *Node, source []byte, sou
 	)
 }
 
+// diagnosticParserCoreReduceChildrenTilingGap is the B1 route-equality
+// invariant (campaign v7, tranche B1): a compact subtree's declared span
+// [startByte, endByte) is sound only if its own reduce children -- the RAW
+// list the compact core popped for this subtree, before hidden-node elision
+// -- actually tile it: contiguous coverage, no unaccounted-for non-trivia
+// byte range. Called once per non-terminal from materializeVisit (below),
+// on entries built from view.Children, immediately after they are resolved
+// via nodesByID and before any hidden-node filtering
+// (parser.buildReduceChildrenWithPath) or unary collapse runs.
+//
+// Root cause this closes: the scheduler's acceptance gate
+// (finalizeDiagnosticParserCoreAcceptedRootSpan) checked only the root's own
+// span and error flag, never that the accepted derivation's content actually
+// justified that span. A derivation whose reduce silently skipped real input
+// could still be accepted and materialized: the reduce's own view.StartByte/
+// EndByte (set independently of any child -- see the view construction in
+// materializeVisit) can claim a span wider than any entry actually covers,
+// publishing HasError()==false while production and the locked C oracle
+// both return an error tree for the same input. Reference witness: html
+// `<a></a^>` -- the erroneous end-tag subtree claimed span 3..8 ("</a^>")
+// while its three RAW children covered only 3..5, 5..6 and 7..8, leaving
+// byte 6 (the stray '^') completely unaccounted for at every level, not
+// just the final public tree (cgo_harness/testdata/
+// compact_t3_oracle_witnesses_v1.json, witness "html_min_a"; verified by
+// direct inspection of view.Children, not merely the post-materialization
+// node tree -- see the next paragraph for why that distinction matters).
+//
+// Why RAW children, not the final public Node.children: an earlier version
+// of this gate walked the finalized public tree after materialization and
+// false-positived on legitimate, production-matching shapes -- the
+// certified EOF-accept/primary-accept acceptance frontiers (http, robot,
+// meson; grammars/runtime_profiles.go). Direct inspection proved why: a
+// hidden grammar symbol (symbolMeta[...].Visible == false) can cover real
+// source bytes -- Robot Framework's `keyword` node covers a leading byte its
+// only NAMED child excludes; meson's `string` node covers its quoted
+// content with no child at all -- and parser.buildReduceChildrenWithPath
+// (shared by production and compact) elides that hidden entry from the
+// node's final public children (occasionally repositioning a following
+// ANONYMOUS sibling's start via flattenedHiddenEntryPadding, but never a
+// named one), while the node's own declared span, set once at reduce time,
+// still legitimately includes it. Production exhibits the identical
+// "parent span wider than public children" shape for these inputs (verified
+// by direct comparison), so it is not a defect -- but by the same token it
+// is structurally indistinguishable from the html/js defect at the public-
+// tree level: both are "parent span wider than the children the public API
+// exposes". The only place the two are distinguishable is before hidden
+// filtering, using the RAW popped children: robot's `keyword` and meson's
+// `string` fully tile their own span once their hidden child is counted
+// (verified directly: view.Children for robot's `keyword` [26,29) is two
+// entries, [26,27) hidden + [27,29) name_chunk; meson's `string` [8,15) is
+// three, [8,9) quote + [9,14) hidden content + [14,15) quote); html's
+// erroneous-end-tag subtree does not -- its RAW view.Children already omit
+// byte 6, so no filtering step is discarding evidence there at all. This
+// function therefore runs on entries (RAW, pre-filter) rather than on any
+// node's already-finalized public children.
+//
+// This is the identical defect class the GLR forest already guards against
+// at reduce time: its own coverage rejection (glr_forest.go, "Coverage
+// rejection: a reduction whose children leave a NON-TRIVIA hole skipped
+// real input and is INVALID") scans a reduction's RAW children left to
+// right -- before the same later hidden-filtering step -- and rejects any
+// grouping with a real (non-trivia) gap, using bytesAreInterTokenTrivia to
+// tell a dropped token from ordinary inter-token whitespace. This function
+// is that same, already-proven definition and predicate, applied at the
+// compact route's equivalent point in its pipeline (materialization-time
+// reduce, since the compact scheduler has no forest reduce step of its
+// own), checked uniformly at the leading edge (startByte to the first
+// entry), between every pair of entries, and at the trailing edge (the last
+// entry to endByte) -- one running coverage frontier, so no special case is
+// needed for any position. Checking every non-terminal (not just the root)
+// composes soundly by induction: if every node's own direct (raw) children
+// tile that node's span modulo trivia, then transitively so do the leaves
+// of the whole accepted derivation against the root's span, which is the
+// property the tranche asks for.
+//
+// Deliberately out of scope here: the relationship between the root's own
+// declared span and sourceLen (extendRootToAcceptedCleanTail, a few lines
+// above, using the wider bytesAreParserPadding predicate for trailing
+// padding beyond every reduce). That check runs later, once, only at the
+// root, against a different boundary (the whole source, not a reduce's own
+// declared span) and is unaffected by this one.
+//
+// O(children) per call and allocation-free: entries are the slice
+// materializeVisit already built this call from already-materialized nodes
+// (nodesByID lookups done moments earlier); this only reads existing
+// uint32 spans and does not walk further into any child's own subtree.
+func diagnosticParserCoreReduceChildrenTilingGap(startByte, endByte uint32, entries []stackEntry, source []byte) (gapStart, gapEnd uint32, gapped bool) {
+	lastEnd := startByte
+	for _, entry := range entries {
+		child := stackEntryNode(entry)
+		if child == nil {
+			continue
+		}
+		if child.startByte > lastEnd && !diagnosticParserCoreGapIsTolerated(source[lastEnd:child.startByte]) {
+			return lastEnd, child.startByte, true
+		}
+		if child.endByte > lastEnd {
+			lastEnd = child.endByte
+		}
+	}
+	if lastEnd < endByte && !diagnosticParserCoreGapIsTolerated(source[lastEnd:endByte]) {
+		return lastEnd, endByte, true
+	}
+	return 0, 0, false
+}
+
+// diagnosticParserCoreGapIsTolerated reports whether an apparent coverage
+// gap is not, in fact, a real one: either ordinary inter-token trivia
+// (bytesAreInterTokenTrivia, matching the forest's own reduce-time coverage
+// rejection), or a single decoration byte strictly enclosed by trivia on
+// both sides (bytesAreSingleByteDecorationTrivia).
+func diagnosticParserCoreGapIsTolerated(gap []byte) bool {
+	return bytesAreInterTokenTrivia(gap) || bytesAreSingleByteDecorationTrivia(gap)
+}
+
+// bytesAreSingleByteDecorationTrivia is the second, narrow trivia exception
+// this gate needs, found by directly root-causing a currently-passing
+// smoke-corpus collision (doxygen, jsdoc -- javadoc/doxygen-style
+// "/** ... * @tag ... */" comment bodies): the continuation-line marker
+// "* " that begins every interior comment line is not represented by any
+// node -- hidden or public -- in either engine's tree. Verified by direct
+// inspection of both compact's raw, pre-filter view.Children (the exact
+// input this function receives, gap-for-gap) and production's own raw node
+// children: production's root for the doxygen smoke fixture has no child at
+// all for "/**" or the repeated "* ", only for the @tag content between
+// them. It is legitimate, lexer-level filler that the scanner treats the
+// same way it treats ordinary whitespace between tokens, just with a
+// literal '*' inside it, so the fixed ASCII-whitespace set
+// bytesAreInterTokenTrivia checks does not recognize it, and no
+// per-language exception is available to ask (tree-sitter's compiled DFA
+// transition tables have no queryable "is this byte skippable here"
+// surface at this layer).
+//
+// The rule requires trivia (bytesAreTrivia) strictly BEFORE AND AFTER the
+// one marker byte, never touching either of the gap's own edges. This is
+// deliberately the strict form, not "buffered on at least one side": an
+// earlier, one-sided version of this rule was built and measured against
+// the full 206-language admission scorecard, and it silently re-admitted 5
+// of the 8 already-fixed javascript witnesses (js_log_1, js_log_3, js_log_5,
+// js_log_6, js_log_7 -- their real dropped-byte gaps also happen to touch
+// one edge, e.g. immediately preceding the next real token with only
+// leading trivia), which is exactly the false-clean escape this tranche
+// exists to close. It was reverted; only the two-sided form ships. This
+// fixes doxygen outright (its one gap is interior, buffered on both sides).
+// jsdoc has two such gaps: an interior one this rule also fixes, and a
+// second one where the comment's closing "*/" (no leading space) puts the
+// decoration marker on the gap's own trailing edge -- correctly left
+// unrecognized here, since that exact shape is indistinguishable from a
+// genuine drop (js_log_3 and js_log_7 have the same trailing-edge shape and
+// must stay rejected). jsdoc's remaining root-level gap is instead closed by
+// the separate, narrower isDerivationRootReduce exemption in
+// materializeDiagnosticParserCoreAcceptedSelection's reduce visitor, not by
+// widening this predicate further.
+//
+// The general, language-independent shape that separates the tolerated
+// case from a genuine dropped byte (the html/js defect class this gate
+// exists to catch -- witness html_min_a's gap is the single byte "^",
+// touching both of its own gap edges at once, directly adjacent to real
+// content on both sides with no trivia buffer at all) is: exactly one
+// non-trivia byte, with ordinary trivia on both sides of it within the same
+// gap. A scheduler bug that truly skips real input skips a whole token or a
+// recognizable fragment sitting flush against a neighbor on at least one
+// edge; manufacturing an isolated, symmetrically trivia-padded punctuation
+// byte is not a plausible shape for that defect class. All 18 fixed
+// html/js witnesses were re-verified against this exact rule and none
+// qualify for it (admission_route_equality_leaf_tiling_test.go).
+func bytesAreSingleByteDecorationTrivia(gap []byte) bool {
+	if len(gap) < 3 {
+		return false
+	}
+	marker := -1
+	for i := 0; i < len(gap); i++ {
+		if bytesAreTrivia(gap[i : i+1]) {
+			continue
+		}
+		if marker != -1 {
+			return false
+		}
+		marker = i
+	}
+	return marker > 0 && marker < len(gap)-1
+}
+
 // materializeDiagnosticParserCoreAcceptedSelection materializes the accepted
 // compact derivation into a public tree. When scratch is non-nil the runner's
 // reusable buffers back the transient materialization storage, so the warm
@@ -2587,6 +2770,41 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 				entries[index] = newStackEntryNode(0, child)
 				if !child.isExtra() {
 					structuralChildren++
+				}
+			}
+			// isDerivationRootReduce is true only for the one reduce, per parse,
+			// whose symbol is this language's own inferred grammar root symbol
+			// (parser.rootSymbol / hasRootSymbol -- inferRootSymbol, parser.go: a
+			// grammar-derived property, computed from the language's own tables,
+			// not a per-language name check). It is exempted from this reduce's
+			// OWN tiling requirement for the same reason
+			// finalizeDiagnosticParserCoreAcceptedRootSpan already treats the
+			// root-to-sourceLen boundary as a separately governed special case
+			// (extendRootToAcceptedCleanTail, with its own, more lenient rule): the
+			// root reduce is the one construct with no enclosing reduce to ever
+			// re-validate its own declared span from the outside, so an over-wide
+			// root span (still exactly [expectedStart, sourceLen), already pinned
+			// by finalizeDiagnosticParserCoreAcceptedRootSpan's own checks) is a
+			// materially different, narrower risk than an internal gap anywhere
+			// below it, which every enclosing reduce's own tiling check still
+			// catches. This closes the jsdoc residual left after
+			// bytesAreSingleByteDecorationTrivia: javadoc/doxygen-style comments
+			// that close with "*/" (no leading space) put the decoration marker
+			// on the trailing edge of the root reduce's own gap, indistinguishable
+			// in isolation from a genuine drop (js_log_3 and js_log_7 have the
+			// identical trailing-edge shape and must still be rejected -- verified
+			// directly, byte for byte: both keep declining under this exemption,
+			// since their gaps are not at the root symbol). All 18 fixed html/js
+			// witnesses were re-verified with this exemption active and none sit
+			// at their language's root symbol, so none are affected by it.
+			isDerivationRootReduce := parser.hasRootSymbol && Symbol(view.Symbol) == parser.rootSymbol
+			if gapStart, gapEnd, gapped := diagnosticParserCoreReduceChildrenTilingGap(view.StartByte, view.EndByte, entries, source); !isDerivationRootReduce && gapped {
+				return &diagnosticParserCoreDecline{
+					boundary: DiagnosticParserCoreAccept,
+					detail: fmt.Sprintf(
+						"accepted-leaf-tiling-gap: compact subtree symbol=%d span=%d..%d has an unaccounted byte range %d..%d not covered by any child",
+						view.Symbol, view.StartByte, view.EndByte, gapStart, gapEnd,
+					),
 				}
 			}
 			action := ParseAction{


### PR DESCRIPTION
## Summary

This PR fixes a gap where the compact parser accepted derivations that skipped real input bytes. The parser published a clean tree while production reported errors. It adds a materialization-time tiling check to verify complete byte coverage under every non-terminal. It updates census reporting and validates the fix against known witnesses.

## Changes

- Introduce diagnosticParserCoreReduceChildrenTilingGap to verify contiguous coverage of node spans by their raw children during materialization.
- Add bytesAreSingleByteDecorationTrivia to tolerate harmless comment markers without reintroducing false-clean escapes.
- Gate the admission candidate route on tiling validity in materializeDiagnosticParserCoreAcceptedSelection. Reject invalid spans and fall back to the production parser.
- Exclude the derivation root reduce from the tiling check to preserve existing tail-padding behavior.
- Update admission census reporting to track accepted-leaf-tiling-gap declines.
- Add TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses to assert that six HTML and JavaScript witnesses now decline correctly.
- Add TestCompactRouteSwiftShiftComparisonGapIsNotATilingDefect as an opt-in test documenting a separate shift-reduce conflict.
- Update the committed C-oracle witness manifest so the compact-route expectation for the 18 corrected HTML and JavaScript witnesses matches the fixed behavior.

## Testing

- go test . -run 'TestCompactRoute' -v

## Gate results

- `go build ./...`: pass.
- `go test ./internal/parsercorephase0/ -count=1`: pass.
- `go test . -count=1` (full root package): pass.
- `go test -tags gts_parsercorephase0 . -run TestDiagnosticParserCoreSelectedLineageProofAllocations -count=1`: pass, 0 allocations.
- `GTS_ADMISSION_SCORECARD=1 GTS_ADMISSION_SCORECARD_RATCHET=1 go test -tags gts_parsercorephase0 . -run TestAdmissionCandidateScorecard206 -count=1`: pass, 200 PASS / 0 DIVERGE / 1 FALLBACK / 5 SKIP. No change from baseline.
- `go test -tags gts_parsercorephase0 . -run TestDiagnosticParserCoreCanonicalAdmissions -count=1`: pass, all four canonical fixtures (rewrite, query_compile, language, grammargen_lr) byte-identical.
- `cgo_harness/compact_t3_oracle_adjudication_test.go` (`TestCompactT3OracleAdjudication`, the pinned Docker C-oracle gate): pass, all 20 witnesses, run via the same Docker invocation CI uses.
- Regression suite: `TestCompactRouteHTMLErroneousEndTagByteGapDeclines`, `TestCompactRouteDeclinesAdjudicatedFalseCleanWitnesses`, `TestCompactRouteSwiftShiftComparisonGapIsNotATilingDefect` (`gts_parsercorephase0`-tagged): pass.
- Certified acceptance frontiers (`TestAdmissionCandidateCertifiedAcceptanceFrontiers`: http, robot, meson): pass, unaffected.

## Witness-class table

Source: `cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json`, 20 adjudicated witnesses (10 html, 8 javascript, 2 swift). Each entry, before this fix, held `compact_has_error=false` while `production_has_error=true` and `c_has_error=true`.

| Class | Witnesses | Before this fix | After this fix |
|---|---|---|---|
| html | 10 of 10 | Compact route published a clean tree. `HasError()` was false. | Compact route declines. Reason cites `accepted-leaf-tiling-gap`. Production serves the parse with `HasError()` true. |
| javascript | 8 of 8 | Compact route published a clean tree. `HasError()` was false. | Compact route declines. Reason cites `accepted-leaf-tiling-gap`. Production serves the parse with `HasError()` true. |
| swift | 0 of 2 | Compact route published a clean tree. `HasError()` was false. | Unchanged. The accepted derivation fully tiles the source for both witnesses; the divergence is a shift/reduce conflict-resolution difference (ambiguous `>>` tokenization), a different mechanism from the coverage gap this fix closes. Filed as a separate finding for follow-up work. |

Reference witness `html_min_a`, source `<a></a^>`: the erroneous end-tag subtree claimed span 3..8 while its three raw children covered only 3..5, 5..6, and 7..8. Byte 6, the stray `^`, had no covering child at any level. The gate now declines this subtree and reports the exact byte range.
