### PR TITLE
test(grammars): skip swift recovery probe under race detector

### DIFF
--- a/grammars/swift_recovery_probe_test.go
+++ b/grammars/swift_recovery_probe_test.go
@@ -79,6 +79,9 @@ func TestSwiftCleanRecoveryProbeMatchesLegacyTree(t *testing.T) {
 }
 
 func TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe(t *testing.T) {
+	if raceEnabled {
+		t.Skip("this witness drives full error recovery twice with the dispatcher census enabled; its cost under the race detector exceeds the CI shard budget; the witness runs in every non-race lane")
+	}
 	lang := SwiftLanguage()
 	source, err := os.ReadFile(filepath.Join("testdata", "swift_corpus", "stdlib_FloatingPointToString.swift"))
 	if err != nil {


### PR DESCRIPTION
## Summary

Skip TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe when the race detector is active. The test runs two full error recoveries. These steps exceed the CI shard time limit with race instrumentation enabled. The test continues to run in all standard lanes.

## Changes

- Add an early skip check for the race detector in TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe.
- Document the runtime cost and execution context in the skip message.

## Testing

- Run `go test ./grammars -run '^TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe$' -v -race` and verify the test skips immediately.
- Run `go test ./grammars -run '^TestSwiftUnsafeWitnessKeepsCurrentGoTreeAcrossRecoveryProbe$' -v` without the race flag to confirm normal execution.