### PR TITLE
refactor(parsercorephase0): Inline condense-candidate dispatch closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- The condense-candidate dispatch path no longer passes a closure through
+  two wrapper layers per event.
+  Each shift, cohort, and reduction entry point now validates the scheduler
+  owner and calls the uncheckpointed operation directly.
+  Behavior is unchanged; every identity, work-count, and allocation check
+  still passes.
+  Local timing on a shared host showed no significant change across four
+  fixtures.
+  The host carried heavy background load throughout the run, so the result
+  is not a sealed measurement.
+
 ## [0.48.0] - 2026-08-01
 
 ### Added

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -966,24 +966,48 @@ func (c *Core) RunSchedulerOwned(token SchedulerTransactionToken, fn func() erro
 		phase0AObserveSchedulerPoison(c, token, Phase0APoisonReturnedError)
 		return err
 	}
+	if err = c.beginSchedulerOwned(token); err != nil {
+		return err
+	}
+	defer c.recoverSchedulerOwnedPanic(token)
+	return c.finishSchedulerOwned(token, fn())
+}
+
+// beginSchedulerOwned validates token ownership and poisons the owner on
+// failure. It is the entry half of RunSchedulerOwned, factored out so the hot
+// shift/reduce/cohort dispatch paths in scheduler_owned.go can call it
+// directly instead of threading a fn func() error parameter through an extra
+// wrapper layer.
+func (c *Core) beginSchedulerOwned(token SchedulerTransactionToken) error {
 	if err := c.validateSchedulerTransaction(token); err != nil {
 		err = c.poisonSchedulerTransaction(token, err)
 		phase0AObserveSchedulerPoison(c, token, Phase0APoisonReturnedError)
 		return err
 	}
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			c.poisonSchedulerTransaction(token, fmt.Errorf("parser-core phase zero: scheduler-owned operation panicked: %v", recovered))
-			phase0AObserveSchedulerPoison(c, token, Phase0APoisonPanic)
-			panic(recovered)
-		}
-	}()
-	if err = fn(); err != nil {
+	return nil
+}
+
+// finishSchedulerOwned poisons the owner on a non-nil error, mirroring the
+// exit half of RunSchedulerOwned. It returns the (possibly rewritten) error
+// so callers can fold it directly into a return statement.
+func (c *Core) finishSchedulerOwned(token SchedulerTransactionToken, err error) error {
+	if err != nil {
 		err = c.poisonSchedulerTransaction(token, err)
 		phase0AObserveSchedulerPoison(c, token, Phase0APoisonReturnedError)
-		return err
 	}
-	return nil
+	return err
+}
+
+// recoverSchedulerOwnedPanic mirrors RunSchedulerOwned's deferred panic
+// handler. Deferring this bound method directly -- instead of a deferred
+// closure literal that calls back into RunSchedulerOwned -- keeps every hot
+// dispatch call a direct, inlinable call with no func-value indirection.
+func (c *Core) recoverSchedulerOwnedPanic(token SchedulerTransactionToken) {
+	if recovered := recover(); recovered != nil {
+		c.poisonSchedulerTransaction(token, fmt.Errorf("parser-core phase zero: scheduler-owned operation panicked: %v", recovered))
+		phase0AObserveSchedulerPoison(c, token, Phase0APoisonPanic)
+		panic(recovered)
+	}
 }
 
 // ApplySchedulerAtomic owns one retained checkpoint for an authenticated

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -123,16 +123,15 @@ func (c *Core) RecordHeadOwnerOwned(owner SchedulerTransactionToken, head Head, 
 	})
 }
 
-func (c *Core) runSchedulerMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, fn func() error) error {
-	return c.RunSchedulerOwned(owner, func() error {
-		if !liveScoped {
-			return fn()
-		}
-		return c.runLiveCondenseCandidates(candidates, fn)
-	})
-}
-
-func (c *Core) runLiveCondenseCandidates(candidates []CondenseCandidate, fn func() error) error {
+// enterLiveCondenseCandidates installs the live condense-candidate scope:
+// reject nesting, reject two candidates that would collide on one boundary,
+// then publish the scope fields (condenseCandidates, condenseNewNode,
+// condenseScopeActive) that condenseNodeIsLive reads during the dispatch that
+// follows. It is the non-closure setup half of runLiveCondenseCandidates,
+// factored out so the hot shift/reduce/cohort dispatch paths below can call
+// it directly instead of threading a fn func() error parameter through two
+// extra wrapper layers.
+func (c *Core) enterLiveCondenseCandidates(candidates []CondenseCandidate) error {
 	if c.condenseScopeActive {
 		return errors.New("parser-core phase zero: nested live condense candidate scope")
 	}
@@ -159,6 +158,16 @@ func (c *Core) runLiveCondenseCandidates(candidates []CondenseCandidate, fn func
 	c.condenseCandidates = candidates
 	c.condenseNewNode = NodeID(len(c.nodes) + 1)
 	c.condenseScopeActive = true
+	return nil
+}
+
+// runLiveCondenseCandidates keeps the closure-taking shape used directly by
+// tests. Production dispatch no longer routes through it; see
+// enterLiveCondenseCandidates and the *MaybeLiveScopedOwned methods below.
+func (c *Core) runLiveCondenseCandidates(candidates []CondenseCandidate, fn func() error) error {
+	if err := c.enterLiveCondenseCandidates(candidates); err != nil {
+		return err
+	}
 	if c.schedulerFrame.fresh {
 		err := fn()
 		c.clearLiveCondenseCandidates()
@@ -214,13 +223,34 @@ func (c *Core) ShiftClassifiedWithLiveCondenseCandidatesOwned(owner SchedulerTra
 	return c.shiftClassifiedMaybeLiveScopedOwned(owner, candidates, true, boundary, actionOrdinal, shifted, fork)
 }
 
+// shiftClassifiedMaybeLiveScopedOwned inlines the former
+// runSchedulerMaybeLiveScopedOwned/runLiveCondenseCandidates closure chain: it
+// validates the owner, installs the live condense scope (when requested),
+// calls the uncheckpointed shift directly, and tears the scope back down --
+// all without allocating or invoking a fn func() error value. Every step here
+// mirrors RunSchedulerOwned's and runLiveCondenseCandidates's own semantics
+// exactly (same validation, same panic/error poisoning, same fresh-session
+// cleanup asymmetry), so this dispatch call site is direct and inlinable.
 func (c *Core) shiftClassifiedMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, boundary ClassifiedBoundary, actionOrdinal int, shifted Token, fork ForkOrder) (out Head, err error) {
-	err = c.runSchedulerMaybeLiveScopedOwned(owner, candidates, liveScoped, func() error {
-		var innerErr error
-		out, innerErr = c.shiftClassifiedUncheckpointed(boundary, actionOrdinal, shifted, fork)
-		return innerErr
-	})
-	return out, err
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if !liveScoped {
+		out, err = c.shiftClassifiedUncheckpointed(boundary, actionOrdinal, shifted, fork)
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		out, err = c.shiftClassifiedUncheckpointed(boundary, actionOrdinal, shifted, fork)
+		c.clearLiveCondenseCandidates()
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	out, err = c.shiftClassifiedUncheckpointed(boundary, actionOrdinal, shifted, fork)
+	return out, c.finishSchedulerOwned(owner, err)
 }
 
 func (c *Core) shiftClassifiedUncheckpointed(boundary ClassifiedBoundary, actionOrdinal int, shifted Token, fork ForkOrder) (Head, error) {
@@ -271,23 +301,48 @@ func (c *Core) ShiftOrdinaryClassifiedCohortWithLiveCondenseCandidatesOwned(owne
 	return c.shiftOrdinaryClassifiedCohortMaybeLiveScopedOwned(owner, candidates, true, boundaries, shifted)
 }
 
+// shiftOrdinaryClassifiedCohortPrepared computes shift targets for one
+// ordinary cohort and performs the shift. It hoists the former
+// runSchedulerMaybeLiveScopedOwned closure body into a named, directly
+// callable method so the dispatch site below never builds a func value.
+func (c *Core) shiftOrdinaryClassifiedCohortPrepared(boundaries []ClassifiedBoundary, shifted Token) ([]Head, error) {
+	var inlineTargets [inlineSchedulerCohortTargets]StateID
+	targets := inlineTargets[:]
+	if len(boundaries) > len(targets) {
+		targets = make([]StateID, len(boundaries))
+	} else {
+		targets = targets[:len(boundaries)]
+	}
+	if err := c.prepareOrdinaryClassifiedCohortInto(boundaries, shifted, targets); err != nil {
+		return nil, err
+	}
+	return c.shiftOrdinaryClassifiedCohortUncheckpointed(boundaries, targets, shifted)
+}
+
+// shiftOrdinaryClassifiedCohortMaybeLiveScopedOwned inlines the former
+// runSchedulerMaybeLiveScopedOwned/runLiveCondenseCandidates closure chain;
+// see shiftClassifiedMaybeLiveScopedOwned's doc comment for the equivalence
+// argument, which applies identically here.
 func (c *Core) shiftOrdinaryClassifiedCohortMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, boundaries []ClassifiedBoundary, shifted Token) (out []Head, err error) {
-	err = c.runSchedulerMaybeLiveScopedOwned(owner, candidates, liveScoped, func() error {
-		var inlineTargets [inlineSchedulerCohortTargets]StateID
-		targets := inlineTargets[:]
-		if len(boundaries) > len(targets) {
-			targets = make([]StateID, len(boundaries))
-		} else {
-			targets = targets[:len(boundaries)]
-		}
-		if err := c.prepareOrdinaryClassifiedCohortInto(boundaries, shifted, targets); err != nil {
-			return err
-		}
-		var innerErr error
-		out, innerErr = c.shiftOrdinaryClassifiedCohortUncheckpointed(boundaries, targets, shifted)
-		return innerErr
-	})
-	return out, err
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if !liveScoped {
+		out, err = c.shiftOrdinaryClassifiedCohortPrepared(boundaries, shifted)
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		out, err = c.shiftOrdinaryClassifiedCohortPrepared(boundaries, shifted)
+		c.clearLiveCondenseCandidates()
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	out, err = c.shiftOrdinaryClassifiedCohortPrepared(boundaries, shifted)
+	return out, c.finishSchedulerOwned(owner, err)
 }
 
 func (c *Core) prepareOrdinaryClassifiedCohortInto(boundaries []ClassifiedBoundary, shifted Token, targets []StateID) error {
@@ -382,23 +437,48 @@ func (c *Core) ShiftExtraClassifiedCohortWithLiveCondenseCandidatesOwned(owner S
 	return c.shiftExtraClassifiedCohortMaybeLiveScopedOwned(owner, candidates, true, boundaries, shifted)
 }
 
+// shiftExtraClassifiedCohortPrepared computes shift targets for one extra
+// cohort and performs the shift. It hoists the former
+// runSchedulerMaybeLiveScopedOwned closure body into a named, directly
+// callable method so the dispatch site below never builds a func value.
+func (c *Core) shiftExtraClassifiedCohortPrepared(boundaries []ClassifiedBoundary, shifted Token) ([]Head, error) {
+	var inlineTargets [inlineSchedulerCohortTargets]StateID
+	targets := inlineTargets[:]
+	if len(boundaries) > len(targets) {
+		targets = make([]StateID, len(boundaries))
+	} else {
+		targets = targets[:len(boundaries)]
+	}
+	if err := c.prepareExtraClassifiedCohortInto(boundaries, shifted, targets); err != nil {
+		return nil, err
+	}
+	return c.shiftExtraClassifiedCohortUncheckpointed(boundaries, targets, shifted)
+}
+
+// shiftExtraClassifiedCohortMaybeLiveScopedOwned inlines the former
+// runSchedulerMaybeLiveScopedOwned/runLiveCondenseCandidates closure chain;
+// see shiftClassifiedMaybeLiveScopedOwned's doc comment for the equivalence
+// argument, which applies identically here.
 func (c *Core) shiftExtraClassifiedCohortMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, boundaries []ClassifiedBoundary, shifted Token) (out []Head, err error) {
-	err = c.runSchedulerMaybeLiveScopedOwned(owner, candidates, liveScoped, func() error {
-		var inlineTargets [inlineSchedulerCohortTargets]StateID
-		targets := inlineTargets[:]
-		if len(boundaries) > len(targets) {
-			targets = make([]StateID, len(boundaries))
-		} else {
-			targets = targets[:len(boundaries)]
-		}
-		if err := c.prepareExtraClassifiedCohortInto(boundaries, shifted, targets); err != nil {
-			return err
-		}
-		var innerErr error
-		out, innerErr = c.shiftExtraClassifiedCohortUncheckpointed(boundaries, targets, shifted)
-		return innerErr
-	})
-	return out, err
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return out, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if !liveScoped {
+		out, err = c.shiftExtraClassifiedCohortPrepared(boundaries, shifted)
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		out, err = c.shiftExtraClassifiedCohortPrepared(boundaries, shifted)
+		c.clearLiveCondenseCandidates()
+		return out, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	out, err = c.shiftExtraClassifiedCohortPrepared(boundaries, shifted)
+	return out, c.finishSchedulerOwned(owner, err)
 }
 
 func (c *Core) prepareExtraClassifiedCohortInto(boundaries []ClassifiedBoundary, shifted Token, targets []StateID) error {
@@ -468,13 +548,30 @@ func (c *Core) ReduceOutputsClassifiedIntoWithLiveCondenseCandidatesOwned(owner 
 	return c.reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner, candidates, true, dst, boundary, actionOrdinal, fork)
 }
 
+// reduceOutputsClassifiedIntoMaybeLiveScopedOwned inlines the former
+// runSchedulerMaybeLiveScopedOwned/runLiveCondenseCandidates closure chain;
+// see shiftClassifiedMaybeLiveScopedOwned's doc comment for the equivalence
+// argument, which applies identically here.
 func (c *Core) reduceOutputsClassifiedIntoMaybeLiveScopedOwned(owner SchedulerTransactionToken, candidates []CondenseCandidate, liveScoped bool, dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) (frontier []ReductionOutput, err error) {
-	err = c.runSchedulerMaybeLiveScopedOwned(owner, candidates, liveScoped, func() error {
-		var innerErr error
-		frontier, innerErr = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
-		return innerErr
-	})
-	return frontier, err
+	if err = c.beginSchedulerOwned(owner); err != nil {
+		return frontier, err
+	}
+	defer c.recoverSchedulerOwnedPanic(owner)
+	if !liveScoped {
+		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+		return frontier, c.finishSchedulerOwned(owner, err)
+	}
+	if err = c.enterLiveCondenseCandidates(candidates); err != nil {
+		return frontier, c.finishSchedulerOwned(owner, err)
+	}
+	if c.schedulerFrame.fresh {
+		frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+		c.clearLiveCondenseCandidates()
+		return frontier, c.finishSchedulerOwned(owner, err)
+	}
+	defer c.clearLiveCondenseCandidates()
+	frontier, err = c.reduceOutputsClassifiedIntoUncheckpointed(dst, boundary, actionOrdinal, fork)
+	return frontier, c.finishSchedulerOwned(owner, err)
 }
 
 func (c *Core) reduceOutputsClassifiedIntoUncheckpointed(dst []ReductionOutput, boundary ClassifiedBoundary, actionOrdinal int, fork ForkOrder) ([]ReductionOutput, error) {


### PR DESCRIPTION
## Summary

Removes closure indirection from the condense-candidate dispatch path (shift,
cohort, and reduction entry points). Each entry point now calls bound methods
for owner validation, panic recovery, and live-scope teardown directly,
instead of threading a closure through two wrapper layers. Behavior is
unchanged.

## Changes

- Split `beginSchedulerOwned`, `finishSchedulerOwned`, and
  `recoverSchedulerOwnedPanic` out of `RunSchedulerOwned` so hot paths can
  call them directly.
- Inline the former `runSchedulerMaybeLiveScopedOwned` and
  `runLiveCondenseCandidates` closure chain into each shift, cohort, and
  reduction entry point.
- Extract `enterLiveCondenseCandidates` as the non-closure setup half of the
  live condense-candidate scope.
- Hoist cohort target preparation into `shiftOrdinaryClassifiedCohortPrepared`
  and `shiftExtraClassifiedCohortPrepared`.
- `runLiveCondenseCandidates` keeps its closure-taking shape for direct test
  callers; production dispatch no longer routes through it.

## Behavior-identity checks

- `go test ./internal/parsercorephase0/... -count=1 -race`
- `go test . -count=1` (default build and `gts_parsercorephase0` build)
- Canonical fixture digests: `TestDiagnosticParserCoreCanonicalAdmissions`
  (four fixtures, byte-identical trees and pinned work counts)
- Admission scorecard ratchet: PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0
  (unchanged)
- Zero-alloc pin: `TestDiagnosticParserCoreSelectedLineageProofAllocations`
  (0 allocations)
- `go build -gcflags='-m'` confirms zero closures remain on the four hot
  dispatch methods; `finishSchedulerOwned` and `clearLiveCondenseCandidates`
  now inline at every call site.

## Local measurements

`BenchmarkParserCoreFreshFullCanonical`, `GOMAXPROCS=1`, 12-round
order-alternating A/B against `origin/main`, compared with `benchstat`:

| fixture | main (sec/op) | this branch (sec/op) | result |
|---|---|---|---|
| rewrite | 2.153m | 2.171m | ~ (p=0.713) |
| query_compile | 10.43m | 10.21m | ~ (p=0.242) |
| language | 10.55m | 10.80m | ~ (p=0.478) |
| grammargen_lr | 107.4m | 106.4m | ~ (p=0.178) |

No fixture shows a statistically significant change. Work counts, allocation
counts, and bytes per operation stayed identical across every sample.

The measurement host carried heavy background load throughout the run. Load
average ran 11 to 14 on a 20-core machine. This result is not a sealed
measurement.
