### PR TITLE
add(parsercorephase0): Add alternative-set tracking and shadow proof for converged splits

### DIFF
--- a/internal/parsercorephase0/alternative_set_test.go
+++ b/internal/parsercorephase0/alternative_set_test.go
@@ -1,0 +1,444 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"slices"
+	"testing"
+)
+
+func alternativeSetMembersForTest(t *testing.T, compact *Core, set AlternativeSet) []uint16 {
+	t.Helper()
+	members, ok := compact.alternativeSetMembers(set)
+	if !ok {
+		t.Fatalf("alternativeSetMembers: unresolvable spill reference for %+v", set)
+	}
+	out := make([]uint16, len(members))
+	copy(out, members)
+	return out
+}
+
+func TestNewAlternativeSetMember(t *testing.T) {
+	if got := NewAlternativeSetMember(0); got != (AlternativeSet{}) {
+		t.Fatalf("NewAlternativeSetMember(0) = %+v, want empty set", got)
+	}
+	compact := &Core{}
+	set := NewAlternativeSetMember(7)
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint16{7}) {
+		t.Fatalf("members = %v, want [7]", got)
+	}
+	if set.Len() != 1 || set.Overflowed() {
+		t.Fatalf("singleton set = %+v, want len 1 not overflowed", set)
+	}
+}
+
+func TestAlternativeSetInsertAscendingStaysInline(t *testing.T) {
+	compact := &Core{}
+	var set AlternativeSet
+	for _, member := range []uint16{2, 5, 9, 20} {
+		if !compact.alternativeSetInsert(&set, member) {
+			t.Fatalf("insert(%d) reported no change", member)
+		}
+	}
+	if set.spilled() {
+		t.Fatalf("four ascending inserts spilled: %+v", set)
+	}
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint16{2, 5, 9, 20}) {
+		t.Fatalf("members = %v, want [2 5 9 20]", got)
+	}
+	// Duplicate and zero are no-ops.
+	if compact.alternativeSetInsert(&set, 9) {
+		t.Fatal("duplicate insert reported a change")
+	}
+	if compact.alternativeSetInsert(&set, 0) {
+		t.Fatal("zero-member insert reported a change")
+	}
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint16{2, 5, 9, 20}) {
+		t.Fatalf("members after no-ops = %v, want [2 5 9 20]", got)
+	}
+}
+
+func TestAlternativeSetFifthMemberSpills(t *testing.T) {
+	compact := &Core{}
+	var set AlternativeSet
+	for _, member := range []uint16{1, 2, 3, 4} {
+		compact.alternativeSetInsert(&set, member)
+	}
+	if set.spilled() {
+		t.Fatal("four members already spilled")
+	}
+	if !compact.alternativeSetInsert(&set, 5) {
+		t.Fatal("fifth insert reported no change")
+	}
+	if !set.spilled() {
+		t.Fatal("fifth member did not spill")
+	}
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint16{1, 2, 3, 4, 5}) {
+		t.Fatalf("members after spill = %v, want [1 2 3 4 5]", got)
+	}
+	if len(compact.alternativeSpillArena) != 5 {
+		t.Fatalf("spill arena length = %d, want 5", len(compact.alternativeSpillArena))
+	}
+}
+
+// TestAlternativeSetAscendingGrowthExtendsSpillSegmentInPlace pins the O(1)
+// amortized fast path: once spilled, a further ascending (tail) insert that
+// is still this set's live arena tail extends by exactly one element instead
+// of copying the whole segment to a fresh one. Without this, a set that
+// accumulates many members in ascending order (the common case: a header or
+// node's own establishment/union history is temporally, hence ascending,
+// ordered -- spec.b4b-alternative-set.v1 section 3.1) would cost O(n^2)
+// copying across its growth instead of O(n).
+func TestAlternativeSetAscendingGrowthExtendsSpillSegmentInPlace(t *testing.T) {
+	compact := &Core{}
+	var set AlternativeSet
+	for member := uint16(1); member <= 5; member++ {
+		compact.alternativeSetInsert(&set, member)
+	}
+	if !set.spilled() {
+		t.Fatal("five ascending inserts did not spill")
+	}
+	spillRefAfterFifth := set.spillRef
+	arenaLenAfterFifth := len(compact.alternativeSpillArena)
+	for member := uint16(6); member <= 32; member++ {
+		before := len(compact.alternativeSpillArena)
+		if !compact.alternativeSetInsert(&set, member) {
+			t.Fatalf("insert(%d) reported no change", member)
+		}
+		if set.spillRef != spillRefAfterFifth {
+			t.Fatalf("insert(%d) moved to a fresh segment (spillRef %d != %d): the in-place extend path did not fire",
+				member, set.spillRef, spillRefAfterFifth)
+		}
+		if got := len(compact.alternativeSpillArena) - before; got != 1 {
+			t.Fatalf("insert(%d) grew the arena by %d elements, want 1 (in-place extend)", member, got)
+		}
+	}
+	if got := len(compact.alternativeSpillArena) - arenaLenAfterFifth; got != 27 {
+		t.Fatalf("arena grew by %d elements across members 6..32, want 27 (one per insert, no re-copy)", got)
+	}
+	want := make([]uint16, 32)
+	for i := range want {
+		want[i] = uint16(i + 1)
+	}
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, want) {
+		t.Fatalf("members = %v, want 1..32", got)
+	}
+}
+
+// TestAlternativeSetOrphanedSegmentFallsBackToFreshCopy verifies that once a
+// set's spill segment is no longer the arena's live tail (another set grew
+// after it), a further insert correctly falls back to a fresh-segment copy
+// rather than corrupting the arena.
+func TestAlternativeSetOrphanedSegmentFallsBackToFreshCopy(t *testing.T) {
+	compact := &Core{}
+	var first AlternativeSet
+	for _, member := range []uint16{1, 2, 3, 4, 5} {
+		compact.alternativeSetInsert(&first, member)
+	}
+	var second AlternativeSet
+	for _, member := range []uint16{100, 101, 102, 103, 104} {
+		compact.alternativeSetInsert(&second, member)
+	}
+	// first's segment is no longer the arena tail; growing it must not
+	// silently corrupt second's segment.
+	if !compact.alternativeSetInsert(&first, 6) {
+		t.Fatal("orphaned-segment insert reported no change")
+	}
+	if got := alternativeSetMembersForTest(t, compact, first); !slices.Equal(got, []uint16{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("first members = %v, want [1 2 3 4 5 6]", got)
+	}
+	if got := alternativeSetMembersForTest(t, compact, second); !slices.Equal(got, []uint16{100, 101, 102, 103, 104}) {
+		t.Fatalf("second members = %v, want [100 101 102 103 104] (must survive first's re-spill untouched)", got)
+	}
+}
+
+func TestAlternativeSetOutOfOrderInsertForcesSpillAndStaysSorted(t *testing.T) {
+	compact := &Core{}
+	var set AlternativeSet
+	compact.alternativeSetInsert(&set, 5)
+	compact.alternativeSetInsert(&set, 9)
+	if set.spilled() {
+		t.Fatal("two ascending inserts already spilled")
+	}
+	// 2 is not the new maximum: inserting it in the middle cannot stay a pure
+	// inline tail append, so this must spill even though the result has only
+	// three members (spec.b4b-alternative-set.v1 section 3.3's append-only
+	// byte-level invariant).
+	if !compact.alternativeSetInsert(&set, 2) {
+		t.Fatal("out-of-order insert reported no change")
+	}
+	if !set.spilled() {
+		t.Fatal("out-of-order insert of a non-maximum member did not spill")
+	}
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint16{2, 5, 9}) {
+		t.Fatalf("members = %v, want [2 5 9]", got)
+	}
+}
+
+func TestAlternativeSetHardCapOverflows(t *testing.T) {
+	compact := &Core{}
+	var set AlternativeSet
+	for member := uint16(1); member <= alternativeSetHardCap; member++ {
+		if !compact.alternativeSetInsert(&set, member) {
+			t.Fatalf("insert(%d) reported no change", member)
+		}
+	}
+	if set.Overflowed() {
+		t.Fatal("set overflowed before exceeding the hard cap")
+	}
+	if set.Len() != alternativeSetHardCap {
+		t.Fatalf("len = %d, want %d", set.Len(), alternativeSetHardCap)
+	}
+	if !compact.alternativeSetInsert(&set, alternativeSetHardCap+1) {
+		t.Fatal("first over-cap insert did not report a change (the overflow flag itself)")
+	}
+	if !set.Overflowed() {
+		t.Fatal("set did not report Overflowed after exceeding the hard cap")
+	}
+	if set.Len() != alternativeSetHardCap {
+		t.Fatalf("len after overflow = %d, want %d (recorded members stay a subset)", set.Len(), alternativeSetHardCap)
+	}
+	if compact.alternativeSetInsert(&set, alternativeSetHardCap+2) {
+		t.Fatal("second over-cap insert reported a change; overflow flag should already be set")
+	}
+}
+
+func TestAlternativeSetUnion(t *testing.T) {
+	compact := &Core{}
+	var dst AlternativeSet
+	compact.alternativeSetInsert(&dst, 1)
+	compact.alternativeSetInsert(&dst, 2)
+	var src AlternativeSet
+	compact.alternativeSetInsert(&src, 2)
+	compact.alternativeSetInsert(&src, 3)
+	if !compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("union reported no change")
+	}
+	if got := alternativeSetMembersForTest(t, compact, dst); !slices.Equal(got, []uint16{1, 2, 3}) {
+		t.Fatalf("union members = %v, want [1 2 3]", got)
+	}
+	// Union with a subset is a no-op.
+	if compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("re-union of an already-contained set reported a change")
+	}
+	// Empty union is a no-op.
+	if compact.alternativeSetUnion(&dst, AlternativeSet{}) {
+		t.Fatal("union with the empty set reported a change")
+	}
+}
+
+// TestAlternativeSetUnionEmptyDestinationAliasesSourceSafely pins the O(1)
+// empty-destination fast path: unioning into an empty set copies src's value
+// (including its spill reference, if any) directly. This aliases the two
+// sets' spill storage, which is only safe if neither set's later growth can
+// disturb the other's already-recorded view; this test grows both sides
+// after the alias and checks each set's own membership stays exact.
+func TestAlternativeSetUnionEmptyDestinationAliasesSourceSafely(t *testing.T) {
+	compact := &Core{}
+	var src AlternativeSet
+	for _, member := range []uint16{1, 2, 3, 4, 5} {
+		compact.alternativeSetInsert(&src, member)
+	}
+	if !src.spilled() {
+		t.Fatal("setup did not spill src")
+	}
+	var dst AlternativeSet
+	if !compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("union into empty destination reported no change")
+	}
+	if dst.spillRef != src.spillRef || dst.count != src.count {
+		t.Fatalf("empty-destination union did not alias src: dst=%+v src=%+v", dst, src)
+	}
+	// Grow dst: must not disturb src's recorded members.
+	compact.alternativeSetInsert(&dst, 6)
+	if got := alternativeSetMembersForTest(t, compact, src); !slices.Equal(got, []uint16{1, 2, 3, 4, 5}) {
+		t.Fatalf("src members after growing the aliased dst = %v, want [1 2 3 4 5]", got)
+	}
+	if got := alternativeSetMembersForTest(t, compact, dst); !slices.Equal(got, []uint16{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("dst members = %v, want [1 2 3 4 5 6]", got)
+	}
+	// Grow src too (now orphaned, since dst's growth moved the arena tail):
+	// must not disturb dst's already-recorded members.
+	compact.alternativeSetInsert(&src, 7)
+	if got := alternativeSetMembersForTest(t, compact, src); !slices.Equal(got, []uint16{1, 2, 3, 4, 5, 7}) {
+		t.Fatalf("src members after growing = %v, want [1 2 3 4 5 7]", got)
+	}
+	if got := alternativeSetMembersForTest(t, compact, dst); !slices.Equal(got, []uint16{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("dst members after src regrew = %v, want [1 2 3 4 5 6] (must survive src's re-spill untouched)", got)
+	}
+}
+
+func TestAlternativeSetUnionPropagatesOverflow(t *testing.T) {
+	compact := &Core{}
+	var src AlternativeSet
+	for member := uint16(1); member <= alternativeSetHardCap+1; member++ {
+		compact.alternativeSetInsert(&src, member)
+	}
+	if !src.Overflowed() {
+		t.Fatal("source set did not overflow in setup")
+	}
+	var dst AlternativeSet
+	compact.alternativeSetInsert(&dst, 1000)
+	if !compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("union with an overflowed source reported no change")
+	}
+	if !dst.Overflowed() {
+		t.Fatal("overflow did not propagate through union")
+	}
+}
+
+func TestAlternativeSetMembersRejectsUnresolvableSpill(t *testing.T) {
+	compact := &Core{}
+	bad := AlternativeSet{}
+	// Force the spilled representation with a spill reference beyond the
+	// (empty) arena: alternativeSetMembers must fail closed, not panic or
+	// silently truncate.
+	bad.flags |= alternativeSetFlagSpilled
+	bad.spillRef = 1
+	bad.count = 1
+	if _, ok := compact.alternativeSetMembers(bad); ok {
+		t.Fatal("alternativeSetMembers resolved an out-of-range spill reference")
+	}
+}
+
+// TestAlternativeSetJournalRestoresExactMembershipAcrossSpill exercises the
+// journal-correctness property spec.b4b-alternative-set.v1 section 3.3
+// claims: restoring count/flags/spillRef alone reconstructs the exact prior
+// set, even across an out-of-order union that forces a fresh spill segment
+// mid-transaction.
+func TestAlternativeSetJournalRestoresExactMembershipAcrossSpill(t *testing.T) {
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(5))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSet := before.set
+	if got := alternativeSetMembersForTest(t, compact, beforeSet); !slices.Equal(got, []uint16{5}) {
+		t.Fatalf("baseline members = %v, want [5]", got)
+	}
+
+	sentinel := errors.New("rollback alternative set")
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		// 2 is smaller than the recorded maximum (5): this union cannot be a
+		// pure tail append and must spill.
+		if err := compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(2)); err != nil {
+			return err
+		}
+		mid, err := compact.nodeLineage(head.Node)
+		if err != nil {
+			return err
+		}
+		if !mid.set.spilled() {
+			return errors.New("mid-transaction union did not spill")
+		}
+		if got, _ := compact.alternativeSetMembers(mid.set); !slices.Equal(got, []uint16{2, 5}) {
+			return errors.New("mid-transaction members are not [2 5]")
+		}
+		// A second union within the same transaction, also out of order.
+		if err := compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(1)); err != nil {
+			return err
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback err = %v, want %v", err, sentinel)
+	}
+	after, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.set != beforeSet {
+		t.Fatalf("rolled-back set = %+v, want %+v", after.set, beforeSet)
+	}
+	if got := alternativeSetMembersForTest(t, compact, after.set); !slices.Equal(got, []uint16{5}) {
+		t.Fatalf("rolled-back members = %v, want [5]", got)
+	}
+
+	// Commit the same mutation this time; membership should now include both.
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(2))
+	}); err != nil {
+		t.Fatal(err)
+	}
+	committed, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := alternativeSetMembersForTest(t, compact, committed.set); !slices.Equal(got, []uint16{2, 5}) {
+		t.Fatalf("committed members = %v, want [2 5]", got)
+	}
+}
+
+// TestAlternativeSetEstablishmentInsertsMemberAlongsideScalar verifies that
+// RecordReductionLineageOwned's set insert never changes the existing scalar
+// merge outcome (stage 1: no behavior change) while also recording the
+// member.
+func TestAlternativeSetEstablishmentInsertsMemberAlongsideScalar(t *testing.T) {
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs := []ReductionOutput{{
+		Head: head, CleanPathRank: CleanPathRankUnselected, MultiplePopPaths: true,
+	}}
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordReductionLineageOwned(owner, outputs, 9)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.rank != CleanPathRankUnselected || record.lineage != 9 || !record.converged {
+		t.Fatalf("scalar record = %+v, want unselected lineage 9 converged", *record)
+	}
+	if got := alternativeSetMembersForTest(t, compact, record.set); !slices.Equal(got, []uint16{9}) {
+		t.Fatalf("established members = %v, want [9]", got)
+	}
+}
+
+// TestAlternativeSetWarmInsertAllocations pins the warm insert/union path at
+// zero allocations, mirroring
+// TestDiagnosticParserCoreSelectedLineageProofAllocations
+// (parsercore_phase0_selected_lineage_internal_test.go). The arena and set
+// storage warm to their high-water mark on the first iteration (a spill, an
+// allocation) and must not allocate again once retained capacity covers the
+// steady-state shape (spec.b4b-alternative-set.v1 section 3.4).
+func TestAlternativeSetWarmInsertAllocations(t *testing.T) {
+	compact := &Core{}
+	// Warm the arena once outside the timed loop.
+	warm := func() {
+		var set AlternativeSet
+		compact.alternativeSetInsert(&set, 5)
+		compact.alternativeSetInsert(&set, 9)
+		compact.alternativeSetInsert(&set, 2)
+		compact.alternativeSetInsert(&set, 20)
+		compact.alternativeSetInsert(&set, 30)
+	}
+	warm()
+	compact.alternativeSpillArena = compact.alternativeSpillArena[:0]
+	if allocations := testing.AllocsPerRun(1000, func() {
+		var set AlternativeSet
+		compact.alternativeSetInsert(&set, 5)
+		compact.alternativeSetInsert(&set, 9)
+		compact.alternativeSetInsert(&set, 2)
+		compact.alternativeSetInsert(&set, 20)
+		compact.alternativeSetInsert(&set, 30)
+		compact.alternativeSpillArena = compact.alternativeSpillArena[:0]
+		if set.Len() != 5 {
+			panic("warm alternative-set insert lost a member")
+		}
+	}); allocations != 0 {
+		t.Fatalf("warm alternative-set insert allocations = %g, want 0", allocations)
+	}
+}

--- a/internal/parsercorephase0/alternative_set_test.go
+++ b/internal/parsercorephase0/alternative_set_test.go
@@ -21,6 +21,13 @@ func TestNewAlternativeSetMember(t *testing.T) {
 	if got := NewAlternativeSetMember(0); got != (AlternativeSet{}) {
 		t.Fatalf("NewAlternativeSetMember(0) = %+v, want empty set", got)
 	}
+	// The recording gate defaults to off (GTS_B4B_SHADOW_CENSUS unset): a
+	// nonzero member still returns the empty set until recording is
+	// enabled.
+	if got := NewAlternativeSetMember(7); got != (AlternativeSet{}) {
+		t.Fatalf("NewAlternativeSetMember(7) with recording disabled = %+v, want empty set", got)
+	}
+	defer SetAlternativeSetRecordingEnabledForTest(true)()
 	compact := &Core{}
 	set := NewAlternativeSetMember(7)
 	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint16{7}) {
@@ -306,6 +313,7 @@ func TestAlternativeSetMembersRejectsUnresolvableSpill(t *testing.T) {
 // set, even across an out-of-order union that forces a fresh spill segment
 // mid-transaction.
 func TestAlternativeSetJournalRestoresExactMembershipAcrossSpill(t *testing.T) {
+	defer SetAlternativeSetRecordingEnabledForTest(true)()
 	compact := newTinyCore(t, 4)
 	head, err := compact.Seed(1, 0)
 	if err != nil {
@@ -382,6 +390,7 @@ func TestAlternativeSetJournalRestoresExactMembershipAcrossSpill(t *testing.T) {
 // merge outcome (stage 1: no behavior change) while also recording the
 // member.
 func TestAlternativeSetEstablishmentInsertsMemberAlongsideScalar(t *testing.T) {
+	defer SetAlternativeSetRecordingEnabledForTest(true)()
 	compact := newTinyCore(t, 4)
 	head, err := compact.Seed(1, 0)
 	if err != nil {
@@ -404,6 +413,39 @@ func TestAlternativeSetEstablishmentInsertsMemberAlongsideScalar(t *testing.T) {
 	}
 	if got := alternativeSetMembersForTest(t, compact, record.set); !slices.Equal(got, []uint16{9}) {
 		t.Fatalf("established members = %v, want [9]", got)
+	}
+}
+
+// TestAlternativeSetRecordingDisabledByDefaultLeavesSetEmptyButScalarIntact
+// pins the always-off-by-default recording gate (GTS_B4B_SHADOW_CENSUS):
+// with no override, establishment records no member at all, while the
+// existing scalar rank/lineage mechanism is completely unaffected.
+func TestAlternativeSetRecordingDisabledByDefaultLeavesSetEmptyButScalarIntact(t *testing.T) {
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputs := []ReductionOutput{{
+		Head: head, CleanPathRank: CleanPathRankUnselected, MultiplePopPaths: true,
+	}}
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordReductionLineageOwned(owner, outputs, 9)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.rank != CleanPathRankUnselected || record.lineage != 9 || !record.converged {
+		t.Fatalf("scalar record with recording disabled = %+v, want unselected lineage 9 converged (unaffected by the gate)", *record)
+	}
+	if record.set.Len() != 0 {
+		t.Fatalf("set with recording disabled = %+v (len %d), want empty", record.set, record.set.Len())
+	}
+	if len(compact.alternativeSpillArena) != 0 {
+		t.Fatalf("spill arena grew with recording disabled: len=%d, want 0", len(compact.alternativeSpillArena))
 	}
 }
 
@@ -440,5 +482,54 @@ func TestAlternativeSetWarmInsertAllocations(t *testing.T) {
 		}
 	}); allocations != 0 {
 		t.Fatalf("warm alternative-set insert allocations = %g, want 0", allocations)
+	}
+}
+
+// TestRecordHeadLineageOwnedSetDirtyFalseSkipsSetButKeepsScalar pins
+// RecordHeadLineageOwned's setDirty parameter: false must skip the set
+// union entirely (the node's recorded set is untouched, even though the
+// call passes a set argument), while the scalar rank/lineage merge still
+// runs unconditionally, since a rank flip on an already-recorded lineage id
+// changes the scalar pair without adding a member.
+func TestRecordHeadLineageOwnedSetDirtyFalseSkipsSetButKeepsScalar(t *testing.T) {
+	defer SetAlternativeSetRecordingEnabledForTest(true)()
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unrelated := NewAlternativeSetMember(99)
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordHeadLineageOwned(owner, head, CleanPathRankUnselected, 7, unrelated, false)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.rank != CleanPathRankUnselected || record.lineage != 7 || !record.converged {
+		t.Fatalf("scalar record with setDirty=false = %+v, want unselected lineage 7 converged", *record)
+	}
+	if record.set.Len() != 0 {
+		t.Fatalf("set = %+v (len %d), want untouched/empty: setDirty=false must skip the union", record.set, record.set.Len())
+	}
+	// setDirty=true now unions the same set: scalar re-merges (rank flips to
+	// Selected on the same lineage, matching applyDiagnosticParserCoreCleanPathOutput's
+	// overwrite rule) and the set gains the member.
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordHeadLineageOwned(owner, head, CleanPathRankSelected, 7, unrelated, true)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, err = compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.rank != CleanPathRankSelected {
+		t.Fatalf("scalar rank after setDirty=true = %v, want Selected", record.rank)
+	}
+	if got := alternativeSetMembersForTest(t, compact, record.set); !slices.Equal(got, []uint16{99}) {
+		t.Fatalf("set members after setDirty=true = %v, want [99]", got)
 	}
 }

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"slices"
 	"sync"
 )
@@ -428,12 +429,54 @@ type AlternativeSet struct {
 	spillRef uint32 // 1-based start index into Core.alternativeSpillArena
 }
 
-// NewAlternativeSetMember returns the singleton set {member}. member==0 (the
-// reserved "no event" identity) returns the empty set. Never allocates: a
-// single fresh member always fits inline.
+// alternativeSetRecordingEnabledOnce and alternativeSetRecordingEnabledVal
+// cache GTS_B4B_SHADOW_CENSUS, the same switch that gates the shadow census
+// itself. No production or stage-1 diagnostic decision reads a recorded
+// AlternativeSet except that census, so recording is off by default and
+// only turns on with it -- this package has no way to reach the census's
+// own copy of the flag (parsercorephase0 has no dependency on the higher
+// package that defines it), so it caches an independent read of the same
+// environment variable; both settle on the same cached value for the life
+// of a process.
+var (
+	alternativeSetRecordingEnabledOnce sync.Once
+	alternativeSetRecordingEnabledVal  bool
+)
+
+func alternativeSetRecordingEnabled() bool {
+	alternativeSetRecordingEnabledOnce.Do(func() {
+		switch os.Getenv("GTS_B4B_SHADOW_CENSUS") {
+		case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
+			alternativeSetRecordingEnabledVal = true
+		}
+	})
+	return alternativeSetRecordingEnabledVal
+}
+
+// SetAlternativeSetRecordingEnabledForTest overrides the recording gate for
+// one test process, mirroring the census's own ForTest override. Restore
+// the previous value (the returned func) when done.
+func SetAlternativeSetRecordingEnabledForTest(on bool) func() {
+	alternativeSetRecordingEnabledOnce.Do(func() {})
+	previous := alternativeSetRecordingEnabledVal
+	alternativeSetRecordingEnabledVal = on
+	return func() { alternativeSetRecordingEnabledVal = previous }
+}
+
+// NewAlternativeSetMember returns the singleton set {member}, or the empty
+// set when member==0 (the reserved "no event" identity) or when the
+// recording gate is off. Every driver-side alternative-set value not
+// copied or unioned from an existing header/node set originates here, so
+// gating this one construction point -- together with
+// recordNodeLineageMember, the only other place a member is ever inserted
+// -- keeps every set in the system at its zero value for the life of the
+// parse when recording is disabled: every downstream union or insert then
+// sees an empty source and no-ops through its own existing zero-cost guard,
+// with no further gating needed at any of those call sites. Never
+// allocates: a single fresh member always fits inline.
 func NewAlternativeSetMember(member uint16) AlternativeSet {
 	var set AlternativeSet
-	if member == 0 {
+	if member == 0 || !alternativeSetRecordingEnabled() {
 		return set
 	}
 	set.inline[0] = member
@@ -4475,8 +4518,19 @@ func (c *Core) alternativeSetUnion(dst *AlternativeSet, src AlternativeSet) bool
 // alternativeSetSortedContainsAll reports whether every member of needle is
 // present in haystack. Both slices are sorted ascending (AlternativeSet's
 // section 3.2 invariant), so this is a single merge-scan, never allocating.
+// A cheap O(1) range check on the first and last elements proves
+// non-containment (and so skips the O(len(needle)+len(haystack)) scan
+// entirely) whenever needle reaches outside haystack's covered range --
+// sound in both directions, since haystack sorted implies every member of
+// needle must fall within [haystack[0], haystack[len-1]] to be contained.
 func alternativeSetSortedContainsAll(needle, haystack []uint16) bool {
 	if len(needle) > len(haystack) {
+		return false
+	}
+	if len(needle) == 0 {
+		return true
+	}
+	if needle[0] < haystack[0] || needle[len(needle)-1] > haystack[len(haystack)-1] {
 		return false
 	}
 	haystackIndex := 0

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -378,19 +378,80 @@ type nodeRecord struct {
 }
 
 type nodeLineageRecord struct {
-	owner     uint32
+	owner uint32
+	set   AlternativeSet
+	// transition only, deleted at stage 3 cleanup (spec.b4b-alternative-set.v1
+	// section 3.2):
 	lineage   uint16
 	rank      CleanPathRankSelection
 	converged bool
 }
 
 type nodeLineageMutation struct {
-	node      NodeID
-	owner     uint32
-	lineage   uint16
-	rank      CleanPathRankSelection
-	converged bool
+	node        NodeID
+	owner       uint32
+	setCount    uint8
+	setFlags    uint8
+	setSpillRef uint32
+	lineage     uint16
+	rank        CleanPathRankSelection
+	converged   bool
 }
+
+// alternativeSetInlineCapacity is the fixed inline member width of
+// AlternativeSet before it spills into Core.alternativeSpillArena.
+// alternativeSetHardCap is the total recorded-member ceiling; a set that
+// would exceed it stops recording new members and reports Overflowed.
+// spec.b4b-alternative-set.v1 section 3.2, open question 5.
+const (
+	alternativeSetInlineCapacity = 4
+	alternativeSetHardCap        = 32
+)
+
+const (
+	alternativeSetFlagOverflowed uint8 = 1 << iota
+	alternativeSetFlagSpilled
+)
+
+// AlternativeSet is a sorted, deduplicated set of converged-split-event
+// lineage identities ("members"; spec.b4b-alternative-set.v1 section 3.1). A
+// member is established once, at multi-pop reduction time, and the set only
+// ever grows by insertion or union -- it is never invalidated. Beyond
+// alternativeSetInlineCapacity members it spills into Core's shared arena;
+// beyond alternativeSetHardCap members it stops recording new members and
+// sets Overflowed, so the recorded set stays a genuine subset of the true
+// membership. The zero value is the empty set.
+type AlternativeSet struct {
+	inline   [alternativeSetInlineCapacity]uint16
+	count    uint8
+	flags    uint8
+	spillRef uint32 // 1-based start index into Core.alternativeSpillArena
+}
+
+// NewAlternativeSetMember returns the singleton set {member}. member==0 (the
+// reserved "no event" identity) returns the empty set. Never allocates: a
+// single fresh member always fits inline.
+func NewAlternativeSetMember(member uint16) AlternativeSet {
+	var set AlternativeSet
+	if member == 0 {
+		return set
+	}
+	set.inline[0] = member
+	set.count = 1
+	return set
+}
+
+func (s AlternativeSet) spilled() bool { return s.flags&alternativeSetFlagSpilled != 0 }
+
+// Overflowed reports whether this set declined at least one member at the
+// hard cap. An overflowed set's recorded members remain a genuine subset of
+// the true membership; only completeness is lost, so containment proofs
+// against an overflowed dropped-side set must fail closed.
+func (s AlternativeSet) Overflowed() bool { return s.flags&alternativeSetFlagOverflowed != 0 }
+
+// Len reports the recorded member count (inline plus spilled), which may be
+// less than the true member count when Overflowed.
+func (s AlternativeSet) Len() int { return int(s.count) }
 
 type linkRecord struct {
 	scoreDelta int64
@@ -614,6 +675,13 @@ type Core struct {
 	boundaries            boundaryIndex
 	boundaryJournal       []boundaryMutation
 	nodeLineageJournal    []nodeLineageMutation
+	// alternativeSpillArena backs every AlternativeSet beyond
+	// alternativeSetInlineCapacity members, shared by nodeLineages and every
+	// diagnosticParserCoreHeader.altSet (parsercore_phase0_driver.go). It
+	// resets to length zero (capacity retained) only on Reset, matching
+	// nodeLineageJournal; a rolled-back or superseded segment leaks arena
+	// space until then, bounded by alternativeSetHardCap per record.
+	alternativeSpillArena []uint16
 	condenseCandidates    []CondenseCandidate
 	condenseNewNode       NodeID
 	condenseScopeActive   bool
@@ -812,6 +880,9 @@ func (c *Core) restoreCheckpoint(mark *checkpoint) {
 			continue
 		}
 		c.nodeLineages[nodeIndex].owner = mutation.owner
+		c.nodeLineages[nodeIndex].set.count = mutation.setCount
+		c.nodeLineages[nodeIndex].set.flags = mutation.setFlags
+		c.nodeLineages[nodeIndex].set.spillRef = mutation.setSpillRef
 		c.nodeLineages[nodeIndex].lineage = mutation.lineage
 		c.nodeLineages[nodeIndex].rank = mutation.rank
 		c.nodeLineages[nodeIndex].converged = mutation.converged
@@ -1145,6 +1216,7 @@ func (c *Core) Reset() error {
 	c.boundaryJournal = c.boundaryJournal[:0]
 	clear(c.nodeLineageJournal)
 	c.nodeLineageJournal = c.nodeLineageJournal[:0]
+	c.alternativeSpillArena = c.alternativeSpillArena[:0]
 	c.clearLiveCondenseCandidates()
 	c.reductionSourceOwner = 0
 	c.transactions = c.transactions[:0]
@@ -1582,6 +1654,13 @@ type ReductionOutput struct {
 	HistoricalBoundaryProvenance HistoricalBoundaryProvenance
 	HistoricalCleanPathRank      CleanPathRankSelection
 	HistoricalCleanPathLineage   uint16
+	// HistoricalAlternativeSet is the union of every dead predecessor's
+	// recorded alternative set discovered while producing this boundary
+	// (spec.b4b-alternative-set.v1 section 4, "Dead-node historical
+	// import"). Unlike HistoricalCleanPathRank/Lineage, multiple historical
+	// versions union here instead of poisoning to Unknown/0, because
+	// membership is never invalidated.
+	HistoricalAlternativeSet AlternativeSet
 }
 
 const inlineReductionBoundaryOutputs = 2
@@ -1596,6 +1675,7 @@ type reductionBoundaryOutput struct {
 	historicalForestDeterministic bool
 	historicalCleanPathRank       CleanPathRankSelection
 	historicalLineage             uint16
+	historicalSet                 AlternativeSet
 }
 
 // reductionOutputScratch owns the ephemeral aggregation state for one
@@ -2043,6 +2123,14 @@ type condenseOutcome struct {
 	historicalForestDeterministic bool
 	historicalCleanPathRank       CleanPathRankSelection
 	historicalLineage             uint16
+	// historicalNode is the dead predecessor's NodeID, captured before
+	// condenseWithOutcomeAtomic clears oldID below. Its nodeLineage record
+	// (and alternative set) persists for the rest of the parse, so callers
+	// can read it back through NodeLineageAlternativeSet for dead-node
+	// import (spec.b4b-alternative-set.v1 section 4). Populated whenever
+	// historicalBoundarySplit is true, regardless of which branch below
+	// computed the scalar historical fields.
+	historicalNode NodeID
 }
 
 func (c *Core) condense(key boundaryKey, in linkInput) (Head, error) {
@@ -2079,10 +2167,12 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 	historicalBoundarySplit := false
 	var historicalCleanPathRank CleanPathRankSelection
 	var historicalLineage uint16
+	var historicalNode NodeID
 	historicalConvergedSplit := false
 	historicalForestDeterministic := false
 	if probe.found && !c.condenseNodeIsLive(oldID) {
 		historicalBoundarySplit = true
+		historicalNode = oldID
 		old, oldErr := c.nodeLineage(oldID)
 		if oldErr != nil {
 			return condenseOutcome{}, oldErr
@@ -2116,6 +2206,7 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 			historicalForestDeterministic: historicalForestDeterministic,
 			historicalCleanPathRank:       historicalCleanPathRank,
 			historicalLineage:             historicalLineage,
+			historicalNode:                historicalNode,
 		}
 	}
 	var old nodeRecord
@@ -4200,6 +4291,222 @@ func (c *Core) nodeLineage(id NodeID) (*nodeLineageRecord, error) {
 		return nil, fmt.Errorf("parser-core phase zero: invalid node lineage id %d", id)
 	}
 	return &c.nodeLineages[id-1], nil
+}
+
+// NodeLineageAlternativeSet returns the currently recorded alternative set
+// for id. A dead (superseded) node keeps its lineage record for the rest of
+// the parse, so this also resolves historical membership for dead-node
+// import (spec.b4b-alternative-set.v1 section 4, "Dead-node historical
+// import").
+func (c *Core) NodeLineageAlternativeSet(id NodeID) (AlternativeSet, error) {
+	record, err := c.nodeLineage(id)
+	if err != nil {
+		return AlternativeSet{}, err
+	}
+	return record.set, nil
+}
+
+// alternativeSetMembers resolves set's sorted member slice, reading through
+// the shared spill arena when set has spilled. The returned slice aliases
+// Core-owned storage and is invalidated by the next mutation to any set; it
+// never allocates and never writes.
+func (c *Core) alternativeSetMembers(set AlternativeSet) ([]uint16, bool) {
+	if !set.spilled() {
+		return set.inline[:set.count], true
+	}
+	if set.spillRef == 0 {
+		return nil, set.count == 0
+	}
+	start := int(set.spillRef) - 1
+	end := start + int(set.count)
+	if start < 0 || end > len(c.alternativeSpillArena) {
+		return nil, false
+	}
+	return c.alternativeSpillArena[start:end], true
+}
+
+// AlternativeSetMembers is the exported form of alternativeSetMembers for
+// cross-package readers (the shadow predicate and census in
+// parsercore_phase0_driver.go). ok is false only when set's spill reference
+// is out of range for the current arena; every recording path in this
+// package keeps that from happening, so callers treat !ok as a fail-closed
+// signal, not a recoverable case.
+func (c *Core) AlternativeSetMembers(set AlternativeSet) ([]uint16, bool) {
+	return c.alternativeSetMembers(set)
+}
+
+// searchAlternativeSetMembers returns the sorted insertion position for
+// member within the already-sorted, deduplicated members, and whether member
+// is already present. Linear scan is deliberate: members is bounded by
+// alternativeSetHardCap (32), where a branch-predictable scan outperforms a
+// callback-based binary search and never allocates.
+func searchAlternativeSetMembers(members []uint16, member uint16) (int, bool) {
+	for index, existing := range members {
+		if existing == member {
+			return index, true
+		}
+		if existing > member {
+			return index, false
+		}
+	}
+	return len(members), false
+}
+
+// alternativeSetInsert inserts one member into set in place and reports
+// whether the set changed. It is a no-op for member==0 (reserved) or an
+// already-present member. Every mutation is append-only at the byte level:
+// positions below the pre-call count are never rewritten. Three cases, from
+// cheapest to most expensive:
+//
+//  1. Pure ascending tail append while still inline: writes only the new
+//     inline slot.
+//  2. Pure ascending tail append while spilled, and this set's segment is
+//     still the live tail of Core.alternativeSpillArena (nothing else has
+//     grown the arena since): extends the segment and the arena together
+//     with one appended element, O(1) amortized. This is the common case --
+//     a header or node accumulating its own establishment/union history in
+//     temporal (hence ascending) order, spec.b4b-alternative-set.v1 section
+//     3.1's monotonic lineage-id allocation -- and is what keeps repeated
+//     per-dispatch persistence (persistHeaderLineageOwned) cheap on a long
+//     parse instead of re-copying a growing segment on every call.
+//  3. Anything else (inline growth beyond capacity, an insertion that is not
+//     the new maximum, or a spilled segment that is no longer the arena's
+//     tail): writes a complete fresh sorted copy to a new segment at the
+//     current end of the arena, leaving prior storage untouched and unread
+//     from then on.
+//
+// Case 3's untouched-prior-storage property (shared with cases 1 and 2) is
+// what lets the journal restore an exact prior set by truncating
+// count/flags/spillRef alone (section 3.3); a superseded segment simply
+// leaks arena space until the next Reset, bounded by alternativeSetHardCap
+// per record.
+func (c *Core) alternativeSetInsert(set *AlternativeSet, member uint16) bool {
+	if member == 0 {
+		return false
+	}
+	current, ok := c.alternativeSetMembers(*set)
+	if !ok {
+		return false
+	}
+	position, found := searchAlternativeSetMembers(current, member)
+	if found {
+		return false
+	}
+	if int(set.count) >= alternativeSetHardCap {
+		if set.flags&alternativeSetFlagOverflowed == 0 {
+			set.flags |= alternativeSetFlagOverflowed
+			return true
+		}
+		return false
+	}
+	if position == len(current) {
+		switch {
+		case !set.spilled() && len(current) < alternativeSetInlineCapacity:
+			set.inline[len(current)] = member
+			set.count++
+			return true
+		case set.spilled() && int(set.spillRef)-1+len(current) == len(c.alternativeSpillArena):
+			c.alternativeSpillArena = append(c.alternativeSpillArena, member)
+			set.count++
+			return true
+		}
+	}
+	start := len(c.alternativeSpillArena)
+	c.alternativeSpillArena = append(c.alternativeSpillArena, current[:position]...)
+	c.alternativeSpillArena = append(c.alternativeSpillArena, member)
+	c.alternativeSpillArena = append(c.alternativeSpillArena, current[position:]...)
+	set.spillRef = uint32(start) + 1
+	set.count = uint8(len(current) + 1)
+	set.flags |= alternativeSetFlagSpilled
+	return true
+}
+
+// alternativeSetUnion unions src's recorded members into *dst in place and
+// reports whether dst changed. An overflowed source propagates its overflow
+// flag: a union whose source is overflowed marks the destination overflowed
+// (spec.b4b-alternative-set.v1 section 4, "Overflow propagation").
+//
+// Header-to-node persistence (persistHeaderLineageOwned,
+// parsercore_phase0_driver.go) re-unions every convergedReductionSplit
+// header's accumulated set into its node on every dispatch, mirroring the
+// existing scalar RecordHeadLineageOwned call at the same frequency, and
+// header.head moves to a freshly allocated node on most dispatches -- so the
+// destination is empty far more often than it already equals src. Two fast
+// paths keep that pattern cheap:
+//
+//  1. dst is empty: *dst = src, an O(1) value copy. This aliases src's spill
+//     segment (if any) rather than copying it, which is safe: every further
+//     mutation to either set only ever appends past its own recorded count
+//     (alternativeSetInsert's append-only invariant), so neither set's
+//     existing view is ever disturbed by growth on the other.
+//  2. dst already contains every member of src (the steady state once a
+//     header's set stops growing): one O(len(src)+len(dst)) merge-scan
+//     (containsAll) instead of insert's O(len(src)) x O(len(dst))
+//     member-by-member scan.
+func (c *Core) alternativeSetUnion(dst *AlternativeSet, src AlternativeSet) bool {
+	if src.count == 0 {
+		return c.alternativeSetPropagateOverflow(dst, src)
+	}
+	if dst.count == 0 {
+		*dst = src
+		return true
+	}
+	srcMembers, ok := c.alternativeSetMembers(src)
+	if !ok {
+		return c.alternativeSetPropagateOverflow(dst, src)
+	}
+	if dstMembers, dstOK := c.alternativeSetMembers(*dst); dstOK &&
+		(!src.Overflowed() || dst.Overflowed()) &&
+		alternativeSetSortedContainsAll(srcMembers, dstMembers) {
+		return false
+	}
+	changed := false
+	for _, member := range srcMembers {
+		if c.alternativeSetInsert(dst, member) {
+			changed = true
+		}
+	}
+	if c.alternativeSetPropagateOverflow(dst, src) {
+		changed = true
+	}
+	return changed
+}
+
+// alternativeSetSortedContainsAll reports whether every member of needle is
+// present in haystack. Both slices are sorted ascending (AlternativeSet's
+// section 3.2 invariant), so this is a single merge-scan, never allocating.
+func alternativeSetSortedContainsAll(needle, haystack []uint16) bool {
+	if len(needle) > len(haystack) {
+		return false
+	}
+	haystackIndex := 0
+	for _, member := range needle {
+		for haystackIndex < len(haystack) && haystack[haystackIndex] < member {
+			haystackIndex++
+		}
+		if haystackIndex >= len(haystack) || haystack[haystackIndex] != member {
+			return false
+		}
+		haystackIndex++
+	}
+	return true
+}
+
+func (c *Core) alternativeSetPropagateOverflow(dst *AlternativeSet, src AlternativeSet) bool {
+	if src.Overflowed() && dst.flags&alternativeSetFlagOverflowed == 0 {
+		dst.flags |= alternativeSetFlagOverflowed
+		return true
+	}
+	return false
+}
+
+// UnionAlternativeSet is the exported form of alternativeSetUnion for
+// cross-package writers (parsercore_phase0_driver.go's header-scratch
+// propagation sites: canonicalize fold, sibling adoption, dead-node import).
+// Zero-alloc once c's shared spill arena has warmed to the parse's
+// high-water mark, matching nodeLineageJournal and popScratch.
+func (c *Core) UnionAlternativeSet(dst *AlternativeSet, src AlternativeSet) bool {
+	return c.alternativeSetUnion(dst, src)
 }
 
 func (c *Core) subtree(id SubtreeID) (*subtreeRecord, error) {

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -450,7 +450,12 @@ func TestReductionLineageRollsBackWithSchedulerTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *provenance != (nodeLineageRecord{}) {
+	// The alternative set's rollback restores count/flags/spillRef only
+	// (spec.b4b-alternative-set.v1 section 3.3); an inline slot the rolled-
+	// back insert wrote is deliberately left as unread stale data beyond the
+	// restored count, so compare membership (Len), not raw struct equality.
+	if provenance.owner != 0 || provenance.lineage != 0 || provenance.rank != CleanPathRankNotApplicable ||
+		provenance.converged || provenance.set.Len() != 0 {
 		t.Fatalf("rolled-back lineage = %+v, want zero", *provenance)
 	}
 	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
@@ -2669,14 +2674,22 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	if got := unsafe.Sizeof(nodeRecord{}); got != 24 {
 		t.Fatalf("nodeRecord size = %d, want 24", got)
 	}
-	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 8 {
-		t.Fatalf("nodeLineageRecord size = %d, want 8", got)
+	// spec.b4b-alternative-set.v1 section 3.2: nodeLineageRecord grew from 8
+	// bytes to the transition size of 24 (owner uint32 + AlternativeSet's 16
+	// bytes + the still-present transition scalars lineage/rank/converged);
+	// stage 3 deletes the transition scalars for a final 20-byte record. The
+	// grown field (AlternativeSet) stays pointer-free, checked above.
+	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 24 {
+		t.Fatalf("nodeLineageRecord size = %d, want 24", got)
 	}
 	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
 		t.Fatalf("linkRecord size = %d, want 32", got)
 	}
-	if got := unsafe.Sizeof(ReductionOutput{}); got != 12 {
-		t.Fatalf("ReductionOutput size = %d, want 12", got)
+	// spec.b4b-alternative-set.v1 section 4: ReductionOutput grew from 12
+	// bytes to 28 with the added HistoricalAlternativeSet field (dead-node
+	// historical import), which stays pointer-free, checked above.
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 28 {
+		t.Fatalf("ReductionOutput size = %d, want 28", got)
 	}
 	if got := unsafe.Sizeof(popPath{}); got != 88 {
 		t.Fatalf("popPath size = %d, want 88", got)

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -41,19 +41,27 @@ func (c *Core) RecordReductionLineageOwned(owner SchedulerTransactionToken, outp
 // RecordHeadLineageOwned persists inherited scheduler lineage on one graph
 // version, and unions set into its recorded alternative set in the same
 // scheduler-owned operation. Unknown lineage invalidates an earlier exact
-// scalar record conservatively; set is never invalidated (union only), so
-// its update always runs, independent of the scalar outcome
-// (spec.b4b-alternative-set.v1 section 4). Sharing one RunSchedulerOwned
-// call for both halves -- rather than a second Owned call for the set --
-// halves the per-header token-validation cost of
-// persistHeaderLineageOwned's per-dispatch persistence loop
+// scalar record conservatively; set is never invalidated (union only).
+// Sharing one RunSchedulerOwned call for both halves -- rather than a
+// second Owned call for the set -- halves the per-header token-validation
+// cost of persistHeaderLineageOwned's per-dispatch persistence loop
 // (parsercore_phase0_driver.go), its sole caller.
+//
+// setDirty lets that caller skip the set union outright: scalar dirtiness
+// cannot be inferred from set dirtiness (a rank flip on an already-recorded
+// lineage id changes rank without adding a member), so the scalar merge
+// always runs -- it is already cheap when nothing changed
+// (recordNodeLineage's own no-op guard) -- but the set union is both more
+// expensive per call and, empirically, redundant far more often (the same
+// (head, altSet) pair persisted again on a dispatch that never touched this
+// header), so the caller may prove that in advance and skip it entirely.
 func (c *Core) RecordHeadLineageOwned(
 	owner SchedulerTransactionToken,
 	head Head,
 	rank CleanPathRankSelection,
 	lineage uint16,
 	set AlternativeSet,
+	setDirty bool,
 ) error {
 	return c.RunSchedulerOwned(owner, func() error {
 		if rank != CleanPathRankSelected && rank != CleanPathRankUnselected || lineage == 0 {
@@ -62,6 +70,9 @@ func (c *Core) RecordHeadLineageOwned(
 		}
 		if err := c.recordNodeLineage(head, rank, lineage); err != nil {
 			return err
+		}
+		if !setDirty {
+			return nil
 		}
 		return c.recordNodeLineageSet(head, set)
 	})
@@ -181,6 +192,9 @@ func (c *Core) recordNodeLineageSet(head Head, set AlternativeSet) error {
 // runs alongside, and never changes the outcome of, recordNodeLineage's
 // existing scalar merge.
 func (c *Core) recordNodeLineageMember(head Head, member uint16) error {
+	if !alternativeSetRecordingEnabled() {
+		return nil
+	}
 	node, err := c.nodeLineage(head.Node)
 	if err != nil {
 		return err

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -30,25 +30,40 @@ func (c *Core) RecordReductionLineageOwned(owner SchedulerTransactionToken, outp
 			if err := c.recordNodeLineage(output.Head, output.CleanPathRank, lineage); err != nil {
 				return err
 			}
+			if err := c.recordNodeLineageMember(output.Head, lineage); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
 }
 
 // RecordHeadLineageOwned persists inherited scheduler lineage on one graph
-// version. Unknown lineage invalidates an earlier exact record conservatively.
+// version, and unions set into its recorded alternative set in the same
+// scheduler-owned operation. Unknown lineage invalidates an earlier exact
+// scalar record conservatively; set is never invalidated (union only), so
+// its update always runs, independent of the scalar outcome
+// (spec.b4b-alternative-set.v1 section 4). Sharing one RunSchedulerOwned
+// call for both halves -- rather than a second Owned call for the set --
+// halves the per-header token-validation cost of
+// persistHeaderLineageOwned's per-dispatch persistence loop
+// (parsercore_phase0_driver.go), its sole caller.
 func (c *Core) RecordHeadLineageOwned(
 	owner SchedulerTransactionToken,
 	head Head,
 	rank CleanPathRankSelection,
 	lineage uint16,
+	set AlternativeSet,
 ) error {
 	return c.RunSchedulerOwned(owner, func() error {
 		if rank != CleanPathRankSelected && rank != CleanPathRankUnselected || lineage == 0 {
 			rank = CleanPathRankUnknown
 			lineage = 0
 		}
-		return c.recordNodeLineage(head, rank, lineage)
+		if err := c.recordNodeLineage(head, rank, lineage); err != nil {
+			return err
+		}
+		return c.recordNodeLineageSet(head, set)
 	})
 }
 
@@ -88,7 +103,9 @@ func (c *Core) recordNodeLineage(head Head, rank CleanPathRankSelection, lineage
 	}
 	if len(c.transactions) != 0 {
 		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
-			node: head.Node, owner: node.owner, lineage: node.lineage, rank: node.rank, converged: node.converged,
+			node: head.Node, owner: node.owner,
+			setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
+			lineage: node.lineage, rank: node.rank, converged: node.converged,
 		})
 	}
 	node.rank = nextRank
@@ -115,12 +132,71 @@ func (c *Core) RecordHeadOwnerOwned(owner SchedulerTransactionToken, head Head, 
 		}
 		if len(c.transactions) != 0 {
 			c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
-				node: head.Node, owner: node.owner, lineage: node.lineage, rank: node.rank, converged: node.converged,
+				node: head.Node, owner: node.owner,
+				setCount: node.set.count, setFlags: node.set.flags, setSpillRef: node.set.spillRef,
+				lineage: node.lineage, rank: node.rank, converged: node.converged,
 			})
 		}
 		node.owner = lineage
 		return nil
 	})
+}
+
+// RecordHeadLineageSetOwned unions set into one compact head's node record.
+// Unlike the scalar clean-path pair, membership is never invalidated: this
+// is a pure union, never a poisoning overwrite (spec.b4b-alternative-set.v1
+// section 4).
+func (c *Core) RecordHeadLineageSetOwned(owner SchedulerTransactionToken, head Head, set AlternativeSet) error {
+	return c.RunSchedulerOwned(owner, func() error {
+		return c.recordNodeLineageSet(head, set)
+	})
+}
+
+func (c *Core) recordNodeLineageSet(head Head, set AlternativeSet) error {
+	if set.count == 0 {
+		return nil
+	}
+	node, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return err
+	}
+	before := node.set
+	if !c.alternativeSetUnion(&node.set, set) {
+		return nil
+	}
+	if len(c.transactions) != 0 {
+		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+			node: head.Node, owner: node.owner,
+			setCount: before.count, setFlags: before.flags, setSpillRef: before.spillRef,
+			lineage: node.lineage, rank: node.rank, converged: node.converged,
+		})
+	}
+	return nil
+}
+
+// recordNodeLineageMember inserts member into head's node's alternative set,
+// unconditionally: membership is a per-event ancestry fact established at
+// multi-pop reduction time, and it is never gated by clean-path rank or
+// invalidated once recorded (spec.b4b-alternative-set.v1 section 4). This
+// runs alongside, and never changes the outcome of, recordNodeLineage's
+// existing scalar merge.
+func (c *Core) recordNodeLineageMember(head Head, member uint16) error {
+	node, err := c.nodeLineage(head.Node)
+	if err != nil {
+		return err
+	}
+	before := node.set
+	if !c.alternativeSetInsert(&node.set, member) {
+		return nil
+	}
+	if len(c.transactions) != 0 {
+		c.nodeLineageJournal = append(c.nodeLineageJournal, nodeLineageMutation{
+			node: head.Node, owner: node.owner,
+			setCount: before.count, setFlags: before.flags, setSpillRef: before.spillRef,
+			lineage: node.lineage, rank: node.rank, converged: node.converged,
+		})
+	}
+	return nil
 }
 
 // enterLiveCondenseCandidates installs the live condense-candidate scope:
@@ -700,6 +776,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 		historicalForestDeterministic := previous.historicalForestDeterministic
 		historicalCleanPathRank := previous.historicalCleanPathRank
 		historicalLineage := previous.historicalLineage
+		historicalSet := previous.historicalSet
 		if outcome.historicalBoundarySplit {
 			switch {
 			case !previous.historicalBoundarySplit:
@@ -722,6 +799,18 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 				historicalForestDeterministic =
 					historicalForestDeterministic && outcome.historicalForestDeterministic
 			}
+			// Membership is never invalidated: where the scalar pair above may
+			// poison to Unknown/0 on disagreement between multiple historical
+			// versions landing on the same boundary, the alternative set instead
+			// unions every converged historical version's recorded set
+			// (spec.b4b-alternative-set.v1 section 4, "Dead-node historical
+			// import"). The dead node's lineage record persists for the rest of
+			// the parse.
+			if outcome.historicalConvergedSplit {
+				if dead, err := c.nodeLineage(outcome.historicalNode); err == nil {
+					c.alternativeSetUnion(&historicalSet, dead.set)
+				}
+			}
 		}
 		switch outcome.change {
 		case condenseUnchanged:
@@ -742,6 +831,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			historicalForestDeterministic: historicalForestDeterministic,
 			historicalCleanPathRank:       historicalCleanPathRank,
 			historicalLineage:             historicalLineage,
+			historicalSet:                 historicalSet,
 		})
 	}
 	for _, output := range scratch.boundaries {
@@ -762,6 +852,7 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 			HistoricalBoundaryProvenance: historicalProvenance,
 			HistoricalCleanPathRank:      output.historicalCleanPathRank,
 			HistoricalCleanPathLineage:   output.historicalLineage,
+			HistoricalAlternativeSet:     output.historicalSet,
 		})
 	}
 	phase0AFinishReductionConstruction(c)

--- a/parsercore_phase0_alternative_set_census.go
+++ b/parsercore_phase0_alternative_set_census.go
@@ -1,0 +1,244 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+)
+
+// The converged-alternative-set shadow proof and its census.
+//
+// A converged-split no-action drop is currently proved admissible by a
+// scalar (rank, lineage) pair recorded on each header
+// (diagnosticParserCoreSelectedLineageDrops). This file adds an alternative
+// proof: a drop is admissible when a surviving header's recorded
+// alternative-membership set contains every member of the dropped header's
+// set (diagnosticParserCoreConvergedCoverageDrops). The alternative-set
+// record (diagnosticParserCoreHeader.altSet and core.AlternativeSet) is
+// established and propagated everywhere the scalar pair already is, but the
+// new predicate runs only in shadow, next to the deciding scalar proof: it
+// never changes which drops dropGenericNoActionHeads allows. This file adds
+// that shadow predicate and an opt-in census that tallies how often the two
+// proofs agree.
+//
+// Mirrors admission_census.go's pattern: gated behind an env var, cached via
+// sync.Once, zero cost when off.
+
+// diagnosticParserCoreConvergedCoverageDrops shadow-proves converged-split
+// no-action drops by alternative-set containment
+// (spec.b4b-alternative-set.v1 section 5): a drop is admissible when one
+// surviving header's recorded set contains every recorded member of the
+// dropped header's set, and the dropped set is complete (non-empty, not
+// overflowed, with a resolvable spill reference). It never walks the
+// derivation DAG and never allocates once the shared spill arena has warmed.
+func (s *diagnosticParserCoreGenericScheduler) diagnosticParserCoreConvergedCoverageDrops(
+	indices []int,
+) (uint64, bool) {
+	var proved uint64
+	for _, index := range indices {
+		if index < 0 || index >= len(s.headers) {
+			return 0, false
+		}
+		dropped := s.headers[index]
+		if !dropped.convergedReductionSplit {
+			continue
+		}
+		droppedMembers, ok := s.compact.AlternativeSetMembers(dropped.altSet)
+		if !ok || len(droppedMembers) == 0 || dropped.altSet.Overflowed() {
+			return 0, false
+		}
+		matched := false
+		for survivorIndex, survivor := range s.headers {
+			dropIndex := sort.SearchInts(indices, survivorIndex)
+			if dropIndex < len(indices) && indices[dropIndex] == survivorIndex {
+				continue
+			}
+			survivorMembers, ok := s.compact.AlternativeSetMembers(survivor.altSet)
+			if !ok {
+				continue
+			}
+			if alternativeSetContainsAll(droppedMembers, survivorMembers) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return 0, false
+		}
+		proved++
+	}
+	return proved, true
+}
+
+// alternativeSetContainsAll reports whether every member of dropped is
+// present in survivor. Both slices are sorted ascending (core.AlternativeSet
+// section 3.2's invariant), so this is a single merge-scan, never
+// allocating: O(len(dropped)+len(survivor)), each side bounded by
+// alternativeSetHardCap.
+func alternativeSetContainsAll(dropped, survivor []uint16) bool {
+	if len(dropped) > len(survivor) {
+		return false
+	}
+	survivorIndex := 0
+	for _, member := range dropped {
+		for survivorIndex < len(survivor) && survivor[survivorIndex] < member {
+			survivorIndex++
+		}
+		if survivorIndex >= len(survivor) || survivor[survivorIndex] != member {
+			return false
+		}
+		survivorIndex++
+	}
+	return true
+}
+
+// DiagnosticParserCoreShadowCensusTotals tallies the comparison between the
+// scalar rank/lineage proof (diagnosticParserCoreSelectedLineageDrops) and
+// the alternative-set containment proof
+// (diagnosticParserCoreConvergedCoverageDrops) across every converged-split
+// no-action drop attempt observed while the census is enabled.
+type DiagnosticParserCoreShadowCensusTotals struct {
+	// Agree: both proofs reached the same verdict (both proved or both
+	// declined).
+	Agree uint64
+	// OldProvedNewUnproved is the design's stop rule
+	// (spec.b4b-alternative-set.v1 section 7): the scalar proof proved a drop
+	// the set proof could not. A non-zero count is a design falsifier, not
+	// an implementation bug to paper over.
+	OldProvedNewUnproved uint64
+	// NewProvedOldUnproved is the expected, desired direction: the set proof
+	// is strictly more capable (spec section 2, families F1-F3).
+	NewProvedOldUnproved uint64
+	// NeitherProved: both proofs declined (for example an F4 resurrection,
+	// out of B4b stage 1 scope).
+	NeitherProved uint64
+}
+
+// DiagnosticParserCoreShadowCensusFalsifier captures one old-proved/new-
+// unproved drop context for root-causing a stop-rule hit.
+type DiagnosticParserCoreShadowCensusFalsifier struct {
+	Detail string
+}
+
+var (
+	diagnosticParserCoreShadowCensusEnabledOnce sync.Once
+	diagnosticParserCoreShadowCensusEnabledVal  bool
+
+	diagnosticParserCoreShadowCensusMu    sync.Mutex
+	diagnosticParserCoreShadowCensusTotal DiagnosticParserCoreShadowCensusTotals
+	diagnosticParserCoreShadowFalsifiers  []DiagnosticParserCoreShadowCensusFalsifier
+)
+
+// diagnosticParserCoreShadowCensusEnabled reports whether
+// GTS_B4B_SHADOW_CENSUS requests the alternative-set shadow proof
+// comparison. The result is cached after the first read (sync.Once), so
+// every later drop attempt pays only one cached boolean read when the
+// census is off -- the same zero-cost-when-off shape as
+// admissionCensusEnabled (admission_census.go).
+func diagnosticParserCoreShadowCensusEnabled() bool {
+	diagnosticParserCoreShadowCensusEnabledOnce.Do(func() {
+		switch os.Getenv("GTS_B4B_SHADOW_CENSUS") {
+		case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
+			diagnosticParserCoreShadowCensusEnabledVal = true
+		}
+	})
+	return diagnosticParserCoreShadowCensusEnabledVal
+}
+
+// diagnosticParserCoreRunShadowCensus evaluates the alternative-set
+// containment proof next to the scalar decision dropGenericNoActionHeads
+// already computed, and tallies the comparison. Diagnostic-only: it never
+// influences dropGenericNoActionHeads' actual decision. Called only when
+// diagnosticParserCoreShadowCensusEnabled is true.
+func (s *diagnosticParserCoreGenericScheduler) diagnosticParserCoreRunShadowCensus(indices []int, oldProved bool) {
+	_, newProved := s.diagnosticParserCoreConvergedCoverageDrops(indices)
+	diagnosticParserCoreShadowCensusMu.Lock()
+	defer diagnosticParserCoreShadowCensusMu.Unlock()
+	switch {
+	case oldProved && newProved:
+		diagnosticParserCoreShadowCensusTotal.Agree++
+	case oldProved && !newProved:
+		diagnosticParserCoreShadowCensusTotal.OldProvedNewUnproved++
+		diagnosticParserCoreShadowFalsifiers = append(
+			diagnosticParserCoreShadowFalsifiers,
+			s.diagnosticParserCoreShadowCensusFalsifierDetail(indices),
+		)
+	case !oldProved && newProved:
+		diagnosticParserCoreShadowCensusTotal.NewProvedOldUnproved++
+	default:
+		diagnosticParserCoreShadowCensusTotal.NeitherProved++
+	}
+}
+
+// diagnosticParserCoreShadowCensusFalsifierDetail formats the exact dropped-
+// header and best-candidate-survivor context for a captured falsifier, so a
+// stop-rule hit can be root-caused without rerunning under a debugger.
+func (s *diagnosticParserCoreGenericScheduler) diagnosticParserCoreShadowCensusFalsifierDetail(indices []int) DiagnosticParserCoreShadowCensusFalsifier {
+	var b []byte
+	for _, index := range indices {
+		if index < 0 || index >= len(s.headers) {
+			continue
+		}
+		header := s.headers[index]
+		members, _ := s.compact.AlternativeSetMembers(header.altSet)
+		state, byteOffset, boundaryErr := s.compact.Boundary(header.head)
+		b = fmt.Appendf(b, "[drop idx=%d state=%d byte=%d boundaryErr=%v rank=%v lineage=%d converged=%t altSet=%v overflowed=%t] ",
+			index, state, byteOffset, boundaryErr, header.cleanPathRank, header.cleanPathLineage,
+			header.convergedReductionSplit, members, header.altSet.Overflowed())
+	}
+	for survivorIndex, survivor := range s.headers {
+		dropIndex := sort.SearchInts(indices, survivorIndex)
+		if dropIndex < len(indices) && indices[dropIndex] == survivorIndex {
+			continue
+		}
+		members, _ := s.compact.AlternativeSetMembers(survivor.altSet)
+		b = fmt.Appendf(b, "[survivor idx=%d rank=%v lineage=%d altSet=%v] ",
+			survivorIndex, survivor.cleanPathRank, survivor.cleanPathLineage, members)
+	}
+	return DiagnosticParserCoreShadowCensusFalsifier{Detail: string(b)}
+}
+
+// DiagnosticParserCoreShadowCensusSnapshotForTest returns the accumulated
+// shadow-census totals since the last reset. A harness resets around one
+// language's corpus run to attribute totals to that language.
+func DiagnosticParserCoreShadowCensusSnapshotForTest() DiagnosticParserCoreShadowCensusTotals {
+	diagnosticParserCoreShadowCensusMu.Lock()
+	defer diagnosticParserCoreShadowCensusMu.Unlock()
+	return diagnosticParserCoreShadowCensusTotal
+}
+
+// DiagnosticParserCoreShadowCensusResetForTest clears the accumulated
+// shadow-census totals and captured falsifiers.
+func DiagnosticParserCoreShadowCensusResetForTest() {
+	diagnosticParserCoreShadowCensusMu.Lock()
+	defer diagnosticParserCoreShadowCensusMu.Unlock()
+	diagnosticParserCoreShadowCensusTotal = DiagnosticParserCoreShadowCensusTotals{}
+	diagnosticParserCoreShadowFalsifiers = nil
+}
+
+// DiagnosticParserCoreShadowCensusFalsifiersForTest returns every captured
+// old-proved/new-unproved drop context observed since the last reset: the
+// design's stop rule (spec.b4b-alternative-set.v1 section 7). A non-empty
+// result means stop, root-cause, and re-spec -- not silently proceed.
+func DiagnosticParserCoreShadowCensusFalsifiersForTest() []DiagnosticParserCoreShadowCensusFalsifier {
+	diagnosticParserCoreShadowCensusMu.Lock()
+	defer diagnosticParserCoreShadowCensusMu.Unlock()
+	out := make([]DiagnosticParserCoreShadowCensusFalsifier, len(diagnosticParserCoreShadowFalsifiers))
+	copy(out, diagnosticParserCoreShadowFalsifiers)
+	return out
+}
+
+// SetDiagnosticParserCoreShadowCensusEnabledForTest overrides the
+// GTS_B4B_SHADOW_CENSUS gate for one test process, mirroring
+// setParserCoreReplayParseStatesForTest's override pattern
+// (parsestate_replay_compact.go). Restore the previous value (the returned
+// func) when done.
+func SetDiagnosticParserCoreShadowCensusEnabledForTest(on bool) func() {
+	diagnosticParserCoreShadowCensusEnabledOnce.Do(func() {})
+	previous := diagnosticParserCoreShadowCensusEnabledVal
+	diagnosticParserCoreShadowCensusEnabledVal = on
+	return func() { diagnosticParserCoreShadowCensusEnabledVal = previous }
+}

--- a/parsercore_phase0_b4b_shadow_census_internal_test.go
+++ b/parsercore_phase0_b4b_shadow_census_internal_test.go
@@ -18,14 +18,24 @@ package gotreesitter
 import (
 	"os"
 	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
 func TestDiagnosticParserCoreB4bShadowCensusCanonicalReport(t *testing.T) {
 	if os.Getenv("GTS_B4B_SHADOW_CENSUS_REPORT") != "1" {
 		t.Skip("set GTS_B4B_SHADOW_CENSUS_REPORT=1 to run the B4b stage 1 shadow census over the canonical fixtures")
 	}
+	// The census comparison switch and the recording switch are two
+	// independent cached reads of the same GTS_B4B_SHADOW_CENSUS
+	// environment variable (recording lives in parsercorephase0, which
+	// cannot depend back on this package's copy of the flag); a real
+	// process setting the env var enables both together, so the ForTest
+	// override here must enable both explicitly.
 	restore := SetDiagnosticParserCoreShadowCensusEnabledForTest(true)
 	defer restore()
+	restoreRecording := core.SetAlternativeSetRecordingEnabledForTest(true)
+	defer restoreRecording()
 
 	var grandTotal DiagnosticParserCoreShadowCensusTotals
 	var allFalsifiers []DiagnosticParserCoreShadowCensusFalsifier

--- a/parsercore_phase0_b4b_shadow_census_internal_test.go
+++ b/parsercore_phase0_b4b_shadow_census_internal_test.go
@@ -1,0 +1,66 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter
+
+// B4b stage 1 shadow census runner, canonical-fixtures half
+// (spec.b4b-alternative-set.v1 section 7, "Agreement census on ... the six
+// certified languages' real corpora"; the four canonical Go fixtures are the
+// available real-corpus-scale sources in this tree). Opt-in and diagnostic-
+// only, reusing the same canonical fixture loader and admission path as
+// TestDiagnosticParserCoreCanonicalAdmissions. The smoke-corpus half lives in
+// parsercore_phase0_b4b_shadow_census_test.go (package gotreesitter_test).
+//
+// Run with:
+//
+//	GTS_B4B_SHADOW_CENSUS_REPORT=1 go test -tags gts_parsercorephase0 \
+//	  -run TestDiagnosticParserCoreB4bShadowCensusCanonicalReport -v .
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDiagnosticParserCoreB4bShadowCensusCanonicalReport(t *testing.T) {
+	if os.Getenv("GTS_B4B_SHADOW_CENSUS_REPORT") != "1" {
+		t.Skip("set GTS_B4B_SHADOW_CENSUS_REPORT=1 to run the B4b stage 1 shadow census over the canonical fixtures")
+	}
+	restore := SetDiagnosticParserCoreShadowCensusEnabledForTest(true)
+	defer restore()
+
+	var grandTotal DiagnosticParserCoreShadowCensusTotals
+	var allFalsifiers []DiagnosticParserCoreShadowCensusFalsifier
+	for _, row := range diagnosticParserCoreCanonicalAdmissions {
+		row := row
+		DiagnosticParserCoreShadowCensusResetForTest()
+		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
+		requireDiagnosticParserCoreCanonicalFixtureIdentity(t, fixture, row)
+		_, routeErr := DiagnosticParseParserCorePrefix(
+			parserCoreWarmGoScanner, fixture.Source,
+			DiagnosticParserCorePrefixOptions{
+				ReceiptMode: DiagnosticParserCoreReceiptSummary,
+				MaxTokens:   300000, MaxDispatches: 600000,
+				Limits: diagnosticParserCoreCanonicalLimits(),
+			},
+		)
+		if routeErr != nil {
+			t.Fatalf("canonical fixture %s: compact admission declined: %v", row.id, routeErr)
+		}
+		total := DiagnosticParserCoreShadowCensusSnapshotForTest()
+		grandTotal.Agree += total.Agree
+		grandTotal.OldProvedNewUnproved += total.OldProvedNewUnproved
+		grandTotal.NewProvedOldUnproved += total.NewProvedOldUnproved
+		grandTotal.NeitherProved += total.NeitherProved
+		allFalsifiers = append(allFalsifiers, DiagnosticParserCoreShadowCensusFalsifiersForTest()...)
+		t.Logf("%-16s agree=%-6d old-proved/new-unproved=%-6d new-proved/old-unproved=%-6d neither=%-6d",
+			row.id, total.Agree, total.OldProvedNewUnproved, total.NewProvedOldUnproved, total.NeitherProved)
+	}
+	t.Logf("--- canonical totals: agree=%d old-proved/new-unproved=%d new-proved/old-unproved=%d neither=%d falsifiers=%d ---",
+		grandTotal.Agree, grandTotal.OldProvedNewUnproved, grandTotal.NewProvedOldUnproved, grandTotal.NeitherProved, len(allFalsifiers))
+
+	if len(allFalsifiers) > 0 {
+		for index, falsifier := range allFalsifiers {
+			t.Logf("FALSIFIER[%d]: %s", index, falsifier.Detail)
+		}
+		t.Fatalf("design falsifier: %d old-proved/new-unproved drop(s) on the canonical fixtures", len(allFalsifiers))
+	}
+}

--- a/parsercore_phase0_b4b_shadow_census_test.go
+++ b/parsercore_phase0_b4b_shadow_census_test.go
@@ -26,6 +26,7 @@ import (
 
 	gts "github.com/odvcencio/gotreesitter"
 	"github.com/odvcencio/gotreesitter/grammars"
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
 type b4bShadowCensusRow struct {
@@ -37,8 +38,14 @@ func TestDiagnosticParserCoreB4bShadowCensusSmokeCorpusReport(t *testing.T) {
 	if os.Getenv("GTS_B4B_SHADOW_CENSUS_REPORT") != "1" {
 		t.Skip("set GTS_B4B_SHADOW_CENSUS_REPORT=1 to run the B4b stage 1 shadow census over the smoke corpus")
 	}
+	// See parsercore_phase0_b4b_shadow_census_internal_test.go: the census
+	// comparison switch and the recording switch are independent cached
+	// reads of the same environment variable, so the ForTest override must
+	// enable both.
 	restore := gts.SetDiagnosticParserCoreShadowCensusEnabledForTest(true)
 	defer restore()
+	restoreRecording := core.SetAlternativeSetRecordingEnabledForTest(true)
+	defer restoreRecording()
 	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
 
 	var rows []b4bShadowCensusRow

--- a/parsercore_phase0_b4b_shadow_census_test.go
+++ b/parsercore_phase0_b4b_shadow_census_test.go
@@ -1,0 +1,103 @@
+//go:build gts_parsercorephase0
+
+package gotreesitter_test
+
+// B4b stage 1 shadow census runner, smoke-corpus half (spec.b4b-alternative-
+// set.v1 section 7, "Agreement census on the smoke corpus"). Opt-in and
+// diagnostic-only, mirroring TestAdmissionCandidateScorecard206's own gating:
+// it drives the compact candidate route across every registered language's
+// smoke fixture, resetting the shadow census
+// (parsercore_phase0_alternative_set_census.go) around each source so the
+// per-language agree/old-proved-new-unproved/new-proved-old-unproved counts
+// can be attributed and reported. The four-canonical-fixture half lives in
+// parsercore_phase0_b4b_shadow_census_internal_test.go (package
+// gotreesitter), which reuses the canonical fixture loader already wired for
+// TestDiagnosticParserCoreCanonicalAdmissions.
+//
+// Run with:
+//
+//	GTS_B4B_SHADOW_CENSUS_REPORT=1 go test -tags gts_parsercorephase0 \
+//	  -run TestDiagnosticParserCoreB4bShadowCensusSmokeCorpusReport -v .
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type b4bShadowCensusRow struct {
+	name   string
+	totals gts.DiagnosticParserCoreShadowCensusTotals
+}
+
+func TestDiagnosticParserCoreB4bShadowCensusSmokeCorpusReport(t *testing.T) {
+	if os.Getenv("GTS_B4B_SHADOW_CENSUS_REPORT") != "1" {
+		t.Skip("set GTS_B4B_SHADOW_CENSUS_REPORT=1 to run the B4b stage 1 shadow census over the smoke corpus")
+	}
+	restore := gts.SetDiagnosticParserCoreShadowCensusEnabledForTest(true)
+	defer restore()
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	var rows []b4bShadowCensusRow
+	var allFalsifiers []gts.DiagnosticParserCoreShadowCensusFalsifier
+
+	entries := grammars.AllLanguages()
+	for _, entry := range entries {
+		gts.DiagnosticParserCoreShadowCensusResetForTest()
+		func() {
+			defer func() { recover() }() // a candidate parse failure/panic must not lose the census so far
+			runB4bShadowCensusLanguageSmoke(entry)
+		}()
+		totals := gts.DiagnosticParserCoreShadowCensusSnapshotForTest()
+		rows = append(rows, b4bShadowCensusRow{name: entry.Name, totals: totals})
+		allFalsifiers = append(allFalsifiers, gts.DiagnosticParserCoreShadowCensusFalsifiersForTest()...)
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].name < rows[j].name })
+
+	var grandTotal gts.DiagnosticParserCoreShadowCensusTotals
+	t.Logf("=== B4b stage 1 shadow census: smoke corpus (%d languages) ===", len(rows))
+	for _, row := range rows {
+		total := row.totals
+		grandTotal.Agree += total.Agree
+		grandTotal.OldProvedNewUnproved += total.OldProvedNewUnproved
+		grandTotal.NewProvedOldUnproved += total.NewProvedOldUnproved
+		grandTotal.NeitherProved += total.NeitherProved
+		if total == (gts.DiagnosticParserCoreShadowCensusTotals{}) {
+			continue // no converged-split drop attempts observed for this source
+		}
+		t.Logf("%-20s agree=%-6d old-proved/new-unproved=%-6d new-proved/old-unproved=%-6d neither=%-6d",
+			row.name, total.Agree, total.OldProvedNewUnproved, total.NewProvedOldUnproved, total.NeitherProved)
+	}
+	t.Logf("--- totals: agree=%d old-proved/new-unproved=%d new-proved/old-unproved=%d neither=%d falsifiers=%d ---",
+		grandTotal.Agree, grandTotal.OldProvedNewUnproved, grandTotal.NewProvedOldUnproved, grandTotal.NeitherProved, len(allFalsifiers))
+
+	if len(allFalsifiers) > 0 {
+		for index, falsifier := range allFalsifiers {
+			t.Logf("FALSIFIER[%d]: %s", index, falsifier.Detail)
+		}
+		t.Fatalf("design falsifier: %d old-proved/new-unproved drop(s); the alternative-set containment predicate must be a superset of the scalar proof (spec.b4b-alternative-set.v1 section 7 stop rule)", len(allFalsifiers))
+	}
+}
+
+func runB4bShadowCensusLanguageSmoke(entry grammars.LangEntry) {
+	lang := entry.Language()
+	if lang == nil {
+		return
+	}
+	support := grammars.EvaluateParseSupport(entry, lang)
+	if support.Backend != grammars.ParseBackendDFA {
+		return
+	}
+	source := []byte(grammars.ParseSmokeSample(entry.Name))
+	candidate := gts.NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	tree, err := candidate.Parse(source)
+	if err != nil || tree == nil {
+		return
+	}
+	tree.Release()
+}

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -428,10 +428,12 @@ func TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64(t *testing.T) {
 	if runtime.GOARCH != "amd64" {
 		t.Skip("amd64 layout receipt")
 	}
-	// spec.b4b-alternative-set.v1 section 3.2: diagnosticParserCoreHeader
-	// grows by 16 bytes for the added altSet field.
-	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 40 {
-		t.Fatalf("scheduler header size=%d, want 40", got)
+	// diagnosticParserCoreHeader grows by 16 bytes for the added altSet
+	// field, then by another 24 bytes (lastPersistedHead core.Head +
+	// lastPersistedAltSet core.AlternativeSet) for the per-dispatch persist
+	// skip: 24 -> 40 -> 64.
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 64 {
+		t.Fatalf("scheduler header size=%d, want 64", got)
 	}
 	if got := unsafe.Sizeof(diagnosticParserCorePhaseHead{}); got != 12 {
 		t.Fatalf("canonical phase key size=%d, want 12", got)

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -428,8 +428,10 @@ func TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64(t *testing.T) {
 	if runtime.GOARCH != "amd64" {
 		t.Skip("amd64 layout receipt")
 	}
-	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 24 {
-		t.Fatalf("scheduler header size=%d, want 24", got)
+	// spec.b4b-alternative-set.v1 section 3.2: diagnosticParserCoreHeader
+	// grows by 16 bytes for the added altSet field.
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 40 {
+		t.Fatalf("scheduler header size=%d, want 40", got)
 	}
 	if got := unsafe.Sizeof(diagnosticParserCorePhaseHead{}); got != 12 {
 		t.Fatalf("canonical phase key size=%d, want 12", got)

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -879,6 +879,17 @@ type diagnosticParserCoreHeader struct {
 	// diagnosticParserCoreConvergedCoverageDrops and the shadow census; it
 	// never changes routing (spec.b4b-alternative-set.v1 section 7).
 	altSet core.AlternativeSet
+	// lastPersistedHead and lastPersistedAltSet record the (head, altSet)
+	// pair persistHeaderLineageOwned last actually wrote to a node. Both are
+	// plain comparable values, so persistHeaderLineageOwned can detect a
+	// no-op persist (same node, same set already recorded there) with two
+	// equality checks instead of re-entering the scheduler-owned set-union
+	// machinery every dispatch. A rolled-back dispatch reverts these fields
+	// along with the rest of the header (diagnosticParserCoreHeaderRollbackScratch
+	// snapshots the whole struct by value), so they never claim a persist
+	// that Core itself undid.
+	lastPersistedHead   core.Head
+	lastPersistedAltSet core.AlternativeSet
 }
 
 func nextDiagnosticParserCoreCleanPathLineage(next *uint16) (uint16, error) {
@@ -951,7 +962,8 @@ func markDiagnosticParserCoreExternalLineage(
 func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 	owner core.SchedulerTransactionToken,
 ) error {
-	for _, header := range s.headers {
+	for index := range s.headers {
+		header := &s.headers[index]
 		if header.creationSeq >= math.MaxUint32 {
 			return errors.New("parser-core phase zero: scheduler lineage overflow")
 		}
@@ -965,15 +977,28 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 		if !header.convergedReductionSplit {
 			continue
 		}
+		// The scalar pair is re-merged unconditionally: recordNodeLineage
+		// already no-ops cheaply when nothing changed, and rank can flip
+		// (Unselected -> Selected on the same lineage id) without altSet
+		// gaining a member, so scalar dirtiness can't be inferred from set
+		// dirtiness alone. The set union is the expensive, and far more
+		// often redundant, half (persistHeaderLineageOwned runs every
+		// dispatch for every still-active header, not only the one that
+		// dispatch actually touched): skip it when this exact (head, altSet)
+		// pair is already what was last persisted for this header.
+		setDirty := header.head != header.lastPersistedHead || header.altSet != header.lastPersistedAltSet
 		if err := s.compact.RecordHeadLineageOwned(
 			owner,
 			header.head,
 			header.cleanPathRank,
 			header.cleanPathLineage,
 			header.altSet,
+			setDirty,
 		); err != nil {
 			return err
 		}
+		header.lastPersistedHead = header.head
+		header.lastPersistedAltSet = header.altSet
 	}
 	return nil
 }

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -871,6 +871,14 @@ type diagnosticParserCoreHeader struct {
 	convergedReductionSplit bool
 	cleanPathRank           core.CleanPathRankSelection
 	cleanPathLineage        uint16
+	// altSet mirrors cleanPathRank/cleanPathLineage but by union rather than
+	// overwrite: it accumulates every converged-split event this derivation
+	// thread has passed through and is never invalidated (carried unchanged
+	// through an external shift that zeroes cleanPathLineage; see
+	// markDiagnosticParserCoreExternalLineage). Stage 1: shadow-only, read by
+	// diagnosticParserCoreConvergedCoverageDrops and the shadow census; it
+	// never changes routing (spec.b4b-alternative-set.v1 section 7).
+	altSet core.AlternativeSet
 }
 
 func nextDiagnosticParserCoreCleanPathLineage(next *uint16) (uint16, error) {
@@ -962,6 +970,7 @@ func (s *diagnosticParserCoreGenericScheduler) persistHeaderLineageOwned(
 			header.head,
 			header.cleanPathRank,
 			header.cleanPathLineage,
+			header.altSet,
 		); err != nil {
 			return err
 		}
@@ -1159,6 +1168,7 @@ type diagnosticParserCoreActionOutput struct {
 	freshness        core.ReductionFreshness
 	cleanPathRank    core.CleanPathRankSelection
 	cleanPathLineage uint16
+	cleanPathSet     core.AlternativeSet
 }
 
 func executeDiagnosticParserCoreGenericConflictDetailed(
@@ -1225,6 +1235,9 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 				secondary.freshness = output.freshness
 				secondary.convergedReductionSplit = secondary.convergedReductionSplit || output.cleanPathLineage != 0
 				applyDiagnosticParserCoreCleanPathOutput(&secondary, output.cleanPathRank, output.cleanPathLineage)
+				if output.cleanPathSet.Len() != 0 {
+					compact.UnionAlternativeSet(&secondary.altSet, output.cleanPathSet)
+				}
 				if action.Type == core.ActionShift {
 					markDiagnosticParserCoreExternalLineage(&secondary, token)
 				}
@@ -1255,6 +1268,9 @@ func executeDiagnosticParserCoreGenericConflictDetailed(
 			primary.freshness = output.freshness
 			primary.convergedReductionSplit = primary.convergedReductionSplit || output.cleanPathLineage != 0
 			applyDiagnosticParserCoreCleanPathOutput(&primary, output.cleanPathRank, output.cleanPathLineage)
+			if output.cleanPathSet.Len() != 0 {
+				compact.UnionAlternativeSet(&primary.altSet, output.cleanPathSet)
+			}
 			if primaryAction.Type == core.ActionShift {
 				markDiagnosticParserCoreExternalLineage(&primary, token)
 			}
@@ -1305,6 +1321,7 @@ type diagnosticParserCoreCanonicalGroup struct {
 	convergedReductionSplit bool
 	cleanPathRank           core.CleanPathRankSelection
 	cleanPathLineage        uint16
+	altSet                  core.AlternativeSet
 }
 
 const diagnosticParserCoreLinearCanonicalLimit = 8
@@ -1376,16 +1393,16 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalize(compact *core.Core, 
 	case len(normalized) == 0:
 		out = normalized
 	case len(normalized) <= diagnosticParserCoreLinearCanonicalLimit:
-		out = s.canonicalizeLinear(normalized)
+		out = s.canonicalizeLinear(compact, normalized)
 	default:
-		out = s.canonicalizeMapped(normalized)
+		out = s.canonicalizeMapped(compact, normalized)
 	}
 	s.headerBuffers[target] = out
 	s.nextBuffer = uint8(target ^ 1)
 	return out, nil
 }
 
-func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(compact *core.Core, normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
 	type linearGroup struct {
 		keyIndex int
 		diagnosticParserCoreCanonicalGroup
@@ -1407,6 +1424,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 					winner: index, runnable: !header.paused,
 					convergedReductionSplit: header.convergedReductionSplit,
 					cleanPathRank:           header.cleanPathRank, cleanPathLineage: header.cleanPathLineage,
+					altSet: header.altSet,
 				},
 			}
 			groupCount++
@@ -1421,6 +1439,13 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 			header.cleanPathRank,
 			header.cleanPathLineage,
 		)
+		// Union, never poison: the group's alternative set accumulates every
+		// member any header folding into this canonical group carries, even
+		// when the scalar pair above disagrees and resets to Unknown/0
+		// (spec.b4b-alternative-set.v1 section 4).
+		if header.altSet.Len() != 0 {
+			compact.UnionAlternativeSet(&group.altSet, header.altSet)
+		}
 		if diagnosticParserCoreCanonicalCandidateWins(normalized[group.winner], header) {
 			group.winner = index
 		}
@@ -1437,6 +1462,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 			header.convergedReductionSplit = group.convergedReductionSplit
 			header.cleanPathRank = group.cleanPathRank
 			header.cleanPathLineage = group.cleanPathLineage
+			header.altSet = group.altSet
 			normalized[write] = header
 			write++
 			break
@@ -1445,7 +1471,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeLinear(normalized []d
 	return normalized[:write]
 }
 
-func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
+func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(compact *core.Core, normalized []diagnosticParserCoreHeader) []diagnosticParserCoreHeader {
 	if s.groups == nil {
 		s.groups = make(map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup, len(normalized))
 	} else {
@@ -1467,6 +1493,9 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(normalized []d
 			header.cleanPathRank,
 			header.cleanPathLineage,
 		)
+		if header.altSet.Len() != 0 {
+			compact.UnionAlternativeSet(&group.altSet, header.altSet)
+		}
 		s.groups[key] = group
 	}
 	write := 0
@@ -1480,6 +1509,7 @@ func (s *diagnosticParserCoreCanonicalScratch) canonicalizeMapped(normalized []d
 		header.convergedReductionSplit = group.convergedReductionSplit
 		header.cleanPathRank = group.cleanPathRank
 		header.cleanPathLineage = group.cleanPathLineage
+		header.altSet = group.altSet
 		normalized[write] = header
 		write++
 	}
@@ -3517,6 +3547,13 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 		return errors.New("parser-core phase zero: sibling-backed no-action drop removed the complete frontier")
 	}
 	selectedLineageDrops, proved := diagnosticParserCoreSelectedLineageDrops(s.headers, indices)
+	if diagnosticParserCoreShadowCensusEnabled() {
+		// Stage 1 shadow proof: evaluates the alternative-set containment
+		// predicate and tallies the comparison against the scalar decision
+		// above. Never influences the decision below
+		// (spec.b4b-alternative-set.v1 section 7).
+		s.diagnosticParserCoreRunShadowCensus(indices, proved)
+	}
 	if !proved && !s.options.allowConvergedSplitDropArtifact {
 		return &diagnosticParserCoreDecline{
 			boundary: DiagnosticParserCoreNoAction,
@@ -3640,10 +3677,22 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryUnproved
 		rank := output.CleanPathRank
 		lineage := reductionLineage
+		var outputSet core.AlternativeSet
+		if output.MultiplePopPaths {
+			outputSet = core.NewAlternativeSetMember(reductionLineage)
+		}
 		if !output.MultiplePopPaths &&
 			output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged {
 			rank = output.HistoricalCleanPathRank
 			lineage = output.HistoricalCleanPathLineage
+		}
+		if output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged &&
+			output.HistoricalAlternativeSet.Len() != 0 {
+			// Union unconditionally, unlike the !MultiplePopPaths-gated scalar
+			// override above: historical ancestry is a fact regardless of
+			// whether this same reduction also established a fresh split on
+			// this output (spec.b4b-alternative-set.v1 section 4).
+			s.compact.UnionAlternativeSet(&outputSet, output.HistoricalAlternativeSet)
 		}
 		switch output.Freshness {
 		case core.ReductionUnchanged:
@@ -3653,6 +3702,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 					output.Head,
 					rank,
 					lineage,
+					outputSet,
 					true,
 				); err != nil {
 					return err
@@ -3670,6 +3720,7 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 				output.Head,
 				rank,
 				lineage,
+				outputSet,
 				convergedHistory,
 			)
 			if err != nil {
@@ -3685,6 +3736,9 @@ func (s *diagnosticParserCoreGenericScheduler) applyGenericReductionOwned(owner 
 		replacement.shifted = token.NoLookahead
 		replacement.convergedReductionSplit = replacement.convergedReductionSplit || convergedHistory
 		applyDiagnosticParserCoreCleanPathOutput(&replacement, rank, lineage)
+		if outputSet.Len() != 0 {
+			s.compact.UnionAlternativeSet(&replacement.altSet, outputSet)
+		}
 		if len(replacements) > 0 {
 			if s.nextSeq == math.MaxUint64 {
 				return errors.New("parser-core phase zero: reduction creation sequence overflow")
@@ -3769,6 +3823,7 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 	head core.Head,
 	rank core.CleanPathRankSelection,
 	lineage uint16,
+	set core.AlternativeSet,
 	convergedReductionSplit bool,
 ) (bool, error) {
 	for index := range s.headers {
@@ -3789,6 +3844,9 @@ func (s *diagnosticParserCoreGenericScheduler) adoptUpdatedReductionSibling(
 		s.headers[index].convergedReductionSplit =
 			s.headers[index].convergedReductionSplit || convergedReductionSplit
 		applyDiagnosticParserCoreCleanPathOutput(&s.headers[index], rank, lineage)
+		if set.Len() != 0 {
+			s.compact.UnionAlternativeSet(&s.headers[index].altSet, set)
+		}
 		return true, nil
 	}
 	return false, nil
@@ -3804,6 +3862,7 @@ func (s *diagnosticParserCoreGenericScheduler) reconcileGenericConflictOutputs(s
 				output.head,
 				output.cleanPathRank,
 				output.cleanPathLineage,
+				output.altSet,
 				output.cleanPathLineage != 0,
 			)
 			if err != nil {
@@ -4720,16 +4779,24 @@ func applyParserCoreConflictActionInto(
 		}
 	}
 	for _, output := range outputs {
+		var set core.AlternativeSet
+		if lineage != 0 {
+			set = core.NewAlternativeSetMember(lineage)
+		}
+		if output.HistoricalBoundaryProvenance == core.HistoricalBoundaryConverged &&
+			output.HistoricalAlternativeSet.Len() != 0 {
+			compact.UnionAlternativeSet(&set, output.HistoricalAlternativeSet)
+		}
 		switch output.Freshness {
 		case core.ReductionUnchanged:
 			dst = append(dst, diagnosticParserCoreActionOutput{
 				head: output.Head, freshness: output.Freshness,
-				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage,
+				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage, cleanPathSet: set,
 			})
 		case core.ReductionNew, core.ReductionUpdated:
 			dst = append(dst, diagnosticParserCoreActionOutput{
 				head: output.Head, freshness: output.Freshness,
-				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage,
+				cleanPathRank: output.CleanPathRank, cleanPathLineage: lineage, cleanPathSet: set,
 			})
 		default:
 			return nil, outputs, errors.New("parser-core phase zero: reduction returned invalid freshness")

--- a/parsercore_phase0_selected_lineage_internal_test.go
+++ b/parsercore_phase0_selected_lineage_internal_test.go
@@ -94,6 +94,7 @@ func TestDiagnosticParserCoreExternalShiftInvalidatesLineage(t *testing.T) {
 // with the carry assertion once the set becomes the live proof; this pin
 // documents the property from stage 1 on.
 func TestDiagnosticParserCoreExternalShiftCarriesAlternativeSet(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
 	header := diagnosticParserCoreHeader{
 		cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7,
 		altSet: core.NewAlternativeSetMember(7),
@@ -133,6 +134,7 @@ func newAlternativeSetPinScheduler(t *testing.T) *diagnosticParserCoreGenericSch
 }
 
 func TestDiagnosticParserCoreConvergedCoverageDropsProof(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
 	member := func(members ...uint16) core.AlternativeSet {
 		var set core.AlternativeSet
 		compact, err := core.New(alternativeSetPinCoverageTable{}, core.Limits{})
@@ -219,6 +221,7 @@ func TestDiagnosticParserCoreConvergedCoverageDropsProof(t *testing.T) {
 }
 
 func TestDiagnosticParserCoreConvergedCoverageDropsOverflowedDroppedFailsClosed(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
 	scheduler := newAlternativeSetPinScheduler(t)
 	dropped := core.NewAlternativeSetMember(1)
 	for member := uint16(2); member <= 40; member++ {
@@ -243,6 +246,7 @@ func TestDiagnosticParserCoreConvergedCoverageDropsOverflowedDroppedFailsClosed(
 // TestDiagnosticParserCoreSelectedLineageProofAllocations
 // (spec.b4b-alternative-set.v1 section 3.4's second new pin).
 func TestDiagnosticParserCoreConvergedCoverageDropsProofAllocations(t *testing.T) {
+	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
 	scheduler := newAlternativeSetPinScheduler(t)
 	survivorSet := core.NewAlternativeSetMember(7)
 	scheduler.compact.UnionAlternativeSet(&survivorSet, core.NewAlternativeSetMember(9))

--- a/parsercore_phase0_selected_lineage_internal_test.go
+++ b/parsercore_phase0_selected_lineage_internal_test.go
@@ -85,3 +85,178 @@ func TestDiagnosticParserCoreExternalShiftInvalidatesLineage(t *testing.T) {
 		t.Fatalf("external shift retained selected lineage: %+v", header)
 	}
 }
+
+// TestDiagnosticParserCoreExternalShiftCarriesAlternativeSet pins the
+// opposite property for the new record: unlike the scalar pair above, an
+// external shift must never erase altSet (spec.b4b-alternative-set.v1
+// section 4, "External shifts: carry, do not erase" -- the F1 fix). Stage 2
+// replaces TestDiagnosticParserCoreExternalShiftInvalidatesLineage itself
+// with the carry assertion once the set becomes the live proof; this pin
+// documents the property from stage 1 on.
+func TestDiagnosticParserCoreExternalShiftCarriesAlternativeSet(t *testing.T) {
+	header := diagnosticParserCoreHeader{
+		cleanPathRank: core.CleanPathRankSelected, cleanPathLineage: 7,
+		altSet: core.NewAlternativeSetMember(7),
+	}
+	before := header.altSet
+	markDiagnosticParserCoreExternalLineage(&header, Token{ExternalScannerToken: true})
+	if header.altSet != before {
+		t.Fatalf("external shift disturbed the carried alternative set: got %+v, want %+v", header.altSet, before)
+	}
+}
+
+// alternativeSetPinCoverageTable is a minimal core.TableView stub: the
+// converged-coverage predicate below never dispatches through a table, it
+// only resolves AlternativeSet membership, so every method is unreachable.
+type alternativeSetPinCoverageTable struct{}
+
+func (alternativeSetPinCoverageTable) Actions(core.StateID, core.Symbol) (core.ActionRow, error) {
+	return core.ActionRow{}, nil
+}
+func (alternativeSetPinCoverageTable) Goto(core.StateID, core.Symbol) (core.StateID, error) {
+	return 0, nil
+}
+func (alternativeSetPinCoverageTable) ProductionFields(uint16, int) ([]core.FieldMapEntry, error) {
+	return nil, nil
+}
+func (alternativeSetPinCoverageTable) ProductionAliases(uint16, int) ([]core.Symbol, error) {
+	return nil, nil
+}
+
+func newAlternativeSetPinScheduler(t *testing.T) *diagnosticParserCoreGenericScheduler {
+	t.Helper()
+	compact, err := core.New(alternativeSetPinCoverageTable{}, core.Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &diagnosticParserCoreGenericScheduler{compact: compact}
+}
+
+func TestDiagnosticParserCoreConvergedCoverageDropsProof(t *testing.T) {
+	member := func(members ...uint16) core.AlternativeSet {
+		var set core.AlternativeSet
+		compact, err := core.New(alternativeSetPinCoverageTable{}, core.Limits{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range members {
+			compact.UnionAlternativeSet(&set, core.NewAlternativeSetMember(m))
+		}
+		return set
+	}
+	tests := []struct {
+		name    string
+		headers []diagnosticParserCoreHeader
+		indices []int
+		count   uint64
+		proved  bool
+	}{
+		{
+			name: "single-member-containment",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, altSet: member(7)},
+				{convergedReductionSplit: true, altSet: member(7)},
+			},
+			indices: []int{1}, count: 1, proved: true,
+		},
+		{
+			name: "multi-member-superset-containment",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, altSet: member(2, 5, 9)},
+				{convergedReductionSplit: true, altSet: member(2, 5)},
+			},
+			indices: []int{1}, count: 1, proved: true,
+		},
+		{
+			name: "partial-containment-fails-closed",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, altSet: member(2, 9)},
+				{convergedReductionSplit: true, altSet: member(2, 5)},
+			},
+			indices: []int{1},
+		},
+		{
+			// F2 (spec section 2): an exact cross-path tie zeroes the scalar
+			// lineage (cleanPathRank stays Unknown) but never zeroes the set,
+			// so containment still proves the drop.
+			name: "unknown-rank-still-proves-by-set",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, altSet: member(7)},
+				{convergedReductionSplit: true, cleanPathRank: core.CleanPathRankUnknown, altSet: member(7)},
+			},
+			indices: []int{1}, count: 1, proved: true,
+		},
+		{
+			// F1 (spec section 2): an external shift erased cleanPathLineage
+			// to zero, but the set was carried, not erased.
+			name: "erased-scalar-lineage-still-proves-by-set",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, altSet: member(7)},
+				{convergedReductionSplit: true, cleanPathLineage: 0, altSet: member(7)},
+			},
+			indices: []int{1}, count: 1, proved: true,
+		},
+		{
+			name: "empty-dropped-set-fails-closed",
+			headers: []diagnosticParserCoreHeader{
+				{convergedReductionSplit: true, altSet: member(7)},
+				{convergedReductionSplit: true},
+			},
+			indices: []int{1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scheduler := newAlternativeSetPinScheduler(t)
+			scheduler.headers = test.headers
+			count, proved := scheduler.diagnosticParserCoreConvergedCoverageDrops(test.indices)
+			if count != test.count || proved != test.proved {
+				t.Fatalf("proof = %d/%t, want %d/%t", count, proved, test.count, test.proved)
+			}
+		})
+	}
+}
+
+func TestDiagnosticParserCoreConvergedCoverageDropsOverflowedDroppedFailsClosed(t *testing.T) {
+	scheduler := newAlternativeSetPinScheduler(t)
+	dropped := core.NewAlternativeSetMember(1)
+	for member := uint16(2); member <= 40; member++ {
+		scheduler.compact.UnionAlternativeSet(&dropped, core.NewAlternativeSetMember(member))
+	}
+	if !dropped.Overflowed() {
+		t.Fatal("setup did not overflow the dropped set")
+	}
+	survivor := dropped // recorded members are a subset either way; still must fail closed
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{convergedReductionSplit: true, altSet: survivor},
+		{convergedReductionSplit: true, altSet: dropped},
+	}
+	count, proved := scheduler.diagnosticParserCoreConvergedCoverageDrops([]int{1})
+	if count != 0 || proved {
+		t.Fatalf("proof = %d/%t, want 0/false (overflowed dropped set is incomplete)", count, proved)
+	}
+}
+
+// TestDiagnosticParserCoreConvergedCoverageDropsProofAllocations is the
+// converged-coverage counterpart to
+// TestDiagnosticParserCoreSelectedLineageProofAllocations
+// (spec.b4b-alternative-set.v1 section 3.4's second new pin).
+func TestDiagnosticParserCoreConvergedCoverageDropsProofAllocations(t *testing.T) {
+	scheduler := newAlternativeSetPinScheduler(t)
+	survivorSet := core.NewAlternativeSetMember(7)
+	scheduler.compact.UnionAlternativeSet(&survivorSet, core.NewAlternativeSetMember(9))
+	scheduler.headers = []diagnosticParserCoreHeader{
+		{convergedReductionSplit: true, altSet: survivorSet},
+		{convergedReductionSplit: true, altSet: core.NewAlternativeSetMember(7)},
+	}
+	indices := []int{1}
+	if allocations := testing.AllocsPerRun(1000, func() {
+		count, proved := scheduler.diagnosticParserCoreConvergedCoverageDrops(indices)
+		if count != 1 || !proved {
+			panic("converged-coverage proof failed")
+		}
+	}); allocations != 0 {
+		t.Fatalf("warm converged-coverage proof allocations = %g, want 0", allocations)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an alternative-set membership record alongside the existing scalar
(rank, lineage) clean-path pair used to prove converged-split no-action
drops admissible. The set records every converged-split event a derivation
descends from, established at multi-pop reduction time and propagated by
union everywhere the scalar pair already propagates. Unlike the scalar
pair, the set is never invalidated or erased (including across an external
shift). A shadow predicate proves a drop admissible by set containment and
runs next to the existing scalar proof for comparison only; it does not
change any routing or acceptance decision. No shipped parsing behavior
changes in this PR.

Recording and the shadow census share one gate, `GTS_B4B_SHADOW_CENSUS`,
**off by default**. With the gate off, no member is ever recorded and every
set in the system stays at its zero value for the life of the parse, so
default builds carry no added cost (measured below). Turning the gate on
records the full set and runs the census; that is the only configuration
that can currently observe a recorded set.

## Changes

- `AlternativeSet`: a sorted, deduplicated member set with 4-member inline
  storage, spilling into a shared arena beyond that, and a 32-member hard
  cap with overflow tracking. Insert and union are zero-alloc once the
  arena has warmed, with an O(1) amortized path for the common
  ascending-growth case and correct journal/rollback semantics.
- Wires the set into `nodeLineageRecord`, `ReductionOutput`,
  `diagnosticParserCoreHeader`, and `condenseOutcome`, and propagates it
  through multi-pop establishment, external shifts (carried, not erased),
  canonicalization, sibling adoption, and dead-node historical import.
- Adds `diagnosticParserCoreConvergedCoverageDrops`, a shadow predicate
  that proves a drop admissible when a surviving header's set contains the
  dropped header's set.
- Adds an opt-in shadow census (`GTS_B4B_SHADOW_CENSUS=1`) that tallies how
  often the new predicate agrees with the existing scalar proof, plus
  `ForTest` accessors for driving it from a corpus run.
- Per-header persist-skip: each header tracks the (node, set) pair it last
  wrote; the per-dispatch persist step re-unions a header's set into its
  node only when either changed since the last persist, instead of on
  every dispatch of every still-converged header regardless of whether
  anything about it moved.
- Recording gate: `GTS_B4B_SHADOW_CENSUS` (the same switch as the census)
  also gates the two points that ever put a member into a set
  (`NewAlternativeSetMember`, the multi-pop establishment insert); off by
  default, every set then stays empty for the whole parse and every
  downstream union/insert call no-ops through its own existing
  empty-source guard.
- Unit tests for set insert/union/spill/overflow/rollback, the persist-skip
  correctness (a rank flip without a new member still persists; a node
  change without a new member still persists), the recording gate
  (default-off leaves sets empty while the scalar mechanism is
  unaffected), and zero-allocation warm-path pins for the insert path and
  the new predicate.

## Testing

- `go build ./...` and `go vet ./...` clean under the default,
  `gts_parsercorephase0`, and `gts_no_parsercorephase0` build tags.
- `go test ./internal/parsercorephase0/...` (including `-race`): pass.
- `go test -tags gts_parsercorephase0 -run TestDiagnosticParserCoreCanonicalAdmissions .`:
  pass on all four canonical fixtures — deep-tree digests and the full
  work-count vector are byte-identical to the pinned values.
- `GTS_ADMISSION_SCORECARD=1 GTS_ADMISSION_SCORECARD_RATCHET=1 go test -tags gts_parsercorephase0 -run TestAdmissionCandidateScorecard206 .`:
  pass, 200/0/1/5/0 (pass/diverge/fallback/skip/error), unchanged.
- Shadow census (`GTS_B4B_SHADOW_CENSUS_REPORT=1`, which also turns on
  recording) over the four canonical fixtures and all 206 registered
  languages' smoke fixtures: 0 cases where the new predicate fails to
  prove a drop the existing proof already proves; 112 cases where the new
  predicate proves a drop the existing proof could not. Unchanged by the
  persist-skip and gating changes.
- `go test -tags gts_parsercorephase0 .` (full package, before and after
  this change): identical set of 14 pre-existing failures, unrelated to
  this change (confirmed by running the same suite against an unmodified
  checkout); no failures introduced.
- Zero-allocation pins: `TestDiagnosticParserCoreSelectedLineageProofAllocations`
  (existing, unchanged), and the pins for warm set insertion and the new
  predicate, all hold at 0 allocations.
- Performance: order-alternating A/B against unmodified `main` on
  `BenchmarkParserCoreFreshFullCanonical` (`benchstat`, n=12 rounds/side):

  | Fixture | Always-on (`GTS_B4B_SHADOW_CENSUS=1`) | **Default (gate off)** |
  |---|---|---|
  | rewrite | +7.50% (p=0.012) | +2.14% (p=0.160, not significant) |
  | query_compile | +5.54% (p=0.017) | +0.09% (p=0.799, not significant) |
  | language | +9.17% (p=0.000) | -0.53% (p=0.755, not significant) |
  | grammargen_lr | +7.92% (p=0.002) | +0.18% (p=0.319, not significant) |
  | geomean | +7.52% | **+0.49%** |

  Always-on recording (needed only to run the census) improved from an
  initial ~2x, through ordering-bias correction to ~1.1-1.2x, to +7.52%
  geomean after four profiling-guided fixes (amortized spill-segment
  extension, an O(n+m) containment fast path, an O(1) empty-destination
  alias, and a per-header dirty check that skips a redundant persist).
  That did not reach a "no measurable cost" bar on its own, so recording
  now sits behind the same gate as the census, off by default: in that
  (default) configuration the A/B shows no significant difference from
  unmodified `main` on any fixture. Always-on recording is deferred to the
  stage that retires the scalar mechanism's own per-reduction DAG walk
  (the predicate-flip stage), where removing that walk's cost gives this
  feature a negative net budget to land inside instead of a positive one
  to justify on its own.

Host caveat: this machine runs roughly two dozen concurrent, unrelated
agent processes; all A/B numbers above are order-alternated specifically
to cancel systematic bias from that load, and are reported with `benchstat`
confidence intervals rather than single-run deltas.

Not merged.
