### PR TITLE
fix(admission): decline compact route on root leading gap

### DIFF
--- a/admission_census.go
+++ b/admission_census.go
@@ -113,6 +113,21 @@ const (
 	// locked C oracle both return an error tree for the same input
 	// (cgo_harness/testdata/compact_t3_oracle_witnesses_v2.json).
 	censusMechanismAcceptedLeafTilingGap admissionCensusMechanism = "accepted-leaf-tiling-gap"
+	// censusMechanismAcceptedRootLeadingGap: the accepted derivation's own
+	// root reduce declared a span starting after the source's first
+	// non-trivia byte (parsercore_phase0_driver.go,
+	// materializeDiagnosticParserCoreAcceptedSelection). The root reduce is
+	// exempt from censusMechanismAcceptedLeafTilingGap's own-children check
+	// (isDerivationRootReduce), so a dropped leading byte at the root symbol
+	// itself passes that gate by construction; the shared post-materialization
+	// normalizeRootSourceStart (parser_result_root_build.go) then pulls the
+	// public root span back over the gap on the assumption of a legitimately
+	// elided leading extra, publishing HasError()==false. This is the second,
+	// root-specific false-clean route-equality gate: without it, an accepted
+	// derivation that never represented one real byte at document start would
+	// publish a clean tree while production and the locked C oracle both
+	// report an error for the same input.
+	censusMechanismAcceptedRootLeadingGap admissionCensusMechanism = "accepted-root-leading-gap"
 	// censusMechanismOther is the catch-all for a decline this classifier
 	// does not yet recognize. The full original detail is always preserved
 	// alongside it.
@@ -175,10 +190,14 @@ func admissionCensusClassify(boundary DiagnosticParserCoreBoundaryKind, detail s
 		}
 		return censusMechanismSchedulerShape
 	case DiagnosticParserCoreAccept:
-		if strings.Contains(detail, "accepted-leaf-tiling-gap") {
+		switch {
+		case strings.Contains(detail, "accepted-leaf-tiling-gap"):
 			return censusMechanismAcceptedLeafTilingGap
+		case strings.Contains(detail, "accepted-root-leading-gap"):
+			return censusMechanismAcceptedRootLeadingGap
+		default:
+			return censusMechanismSchedulerShape
 		}
-		return censusMechanismSchedulerShape
 	case DiagnosticParserCoreGenericClosed:
 		return censusMechanismSchedulerShape
 	case censusBoundaryMultiDerivation:

--- a/admission_route_equality_root_leading_gap_test.go
+++ b/admission_route_equality_root_leading_gap_test.go
@@ -1,0 +1,169 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCompactRouteRootLeadingGapDeclines pins the eight fuzzer-found
+// reproductions of the root-start pull-back class: the accepted
+// derivation's own root reduce declared a span that starts after the
+// source's first non-trivia byte -- one real byte at document start that no
+// node in the derivation ever represented -- fully tiled within itself, so
+// diagnosticParserCoreReduceChildrenTilingGap's own-children check (exempt at
+// the root symbol, isDerivationRootReduce) never sees a gap. Before the
+// accepted-root-leading-gap decline, the shared post-materialization
+// normalizeRootSourceStart (parser_result_root_build.go) pulled the public
+// root span back over the dropped byte on the assumption of a legitimately
+// elided leading extra, publishing HasError()==false while production
+// correctly reports an error for the same bytes.
+func TestCompactRouteRootLeadingGapDeclines(t *testing.T) {
+	// html, erlang, and haskell are not otherwise loaded by the always-on
+	// (untagged) suite; purge the process-wide embedded cache afterward so
+	// this test does not inflate heap for later whole-process tests (matches
+	// admission_scorecard_test.go's convention).
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	cases := []struct {
+		name   string
+		lang   string
+		source string
+	}{
+		{"html_amp_digit", "html", "&0"},
+		{"html_amp_semicolon", "html", "&;"},
+		{"html_amp_hash", "html", "&#"},
+		{"html_close_angle_digit", "html", ">0"},
+		{"html_amp_zeros", "html", "&000"},
+		{"erlang_soh_digit", "erlang", "\x010"},
+		{"erlang_du_digit", "erlang", "\x100"},
+		{"haskell_unterminated_string", "haskell", "\"\n"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(c.lang)
+			if entry == nil {
+				t.Fatalf("language %q is not registered", c.lang)
+			}
+			lang := entry.Language()
+			source := []byte(c.source)
+
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+			if !productionTree.RootNode().HasError() {
+				t.Fatalf("production HasError=false, want true for %q", c.source)
+			}
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candidateTree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 0 || fallback != 1 {
+				t.Fatalf("route counters routed=%d fallback=%d, want routed=0 fallback=1 (compact must decline)", routed, fallback)
+			}
+			reason := gts.AdmissionCandidateLastFallbackReason()
+			if !strings.Contains(reason, "accepted-root-leading-gap") {
+				t.Fatalf("fallback reason=%q, want it to cite accepted-root-leading-gap", reason)
+			}
+
+			// The caller-visible tree is production-served (post-fallback
+			// within the same Parse call), so it must match production's own
+			// verdict exactly.
+			if got := candidateTree.RootNode().HasError(); got != productionTree.RootNode().HasError() {
+				t.Fatalf("production-served (post-fallback) HasError=%t, want %t (production's own verdict)",
+					got, productionTree.RootNode().HasError())
+			}
+			if got, want := candidateTree.RootNode().StartByte(), productionTree.RootNode().StartByte(); got != want {
+				t.Fatalf("production-served (post-fallback) root startByte=%d, want %d", got, want)
+			}
+			if got, want := candidateTree.RootNode().EndByte(), productionTree.RootNode().EndByte(); got != want {
+				t.Fatalf("production-served (post-fallback) root endByte=%d, want %d", got, want)
+			}
+		})
+	}
+}
+
+// TestCompactRouteLeadingCommentStillServes is the accepted-root-leading-gap
+// check's fail-open control: a source that begins with a comment (or other
+// leading extra) and then real code must NOT decline, because a legitimate
+// leading extra sits INSIDE the accepted derivation's own root span (the
+// root reduce's raw declared start already covers it), unlike the eight
+// dropped-byte reproductions above where no node covers the gap at all. This
+// pins the trivia-awareness the fix direction called for: the check
+// distinguishes "the derivation never represented this byte" from "a
+// retained extra owns this byte", using the same raw pre-normalization
+// span the decline above reads.
+//
+// Verified directly: all three cases route through the compact candidate
+// with no fallback both before and after this change lands, so the check
+// does not regress any of them.
+func TestCompactRouteLeadingCommentStillServes(t *testing.T) {
+	t.Cleanup(func() { grammars.PurgeEmbeddedLanguageCache() })
+
+	cases := []struct {
+		name   string
+		lang   string
+		source string
+	}{
+		{"go_leading_line_comment", "go", "// leading comment\npackage main\n\nfunc main() {}\n"},
+		{"html_leading_block_comment", "html", "<!-- leading comment --><a></a>"},
+		{"javascript_leading_line_comment", "javascript", "// leading comment\nconsole.log(1);\n"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			entry := grammars.DetectLanguageByName(c.lang)
+			if entry == nil {
+				t.Fatalf("language %q is not registered", c.lang)
+			}
+			lang := entry.Language()
+			source := []byte(c.source)
+
+			production := gts.NewParser(lang)
+			production.SetAdmissionCandidateRoute(false)
+			productionTree, err := production.Parse(source)
+			if err != nil {
+				t.Fatalf("production parse: %v", err)
+			}
+			defer productionTree.Release()
+
+			gts.ResetAdmissionCandidateCountersForTest()
+			candidate := gts.NewParser(lang)
+			candidate.SetAdmissionCandidateRoute(true)
+			candidateTree, err := candidate.Parse(source)
+			if err != nil {
+				t.Fatalf("candidate parse: %v", err)
+			}
+			defer candidateTree.Release()
+
+			routed, fallback := gts.AdmissionCandidateCounters()
+			if routed != 1 || fallback != 0 {
+				reason := gts.AdmissionCandidateLastFallbackReason()
+				t.Fatalf("route counters routed=%d fallback=%d reason=%q, want routed=1 fallback=0 (a leading comment sits inside the root span and must not trip the leading-gap decline)",
+					routed, fallback, reason)
+			}
+
+			if diff := routeEqualityFirstDivergence(candidateTree.RootNode(), productionTree.RootNode(), lang, "root"); diff != "" {
+				t.Fatalf("structural divergence: %s", diff)
+			}
+		})
+	}
+}

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -77,41 +77,43 @@ const routeEqualityFuzzMaxInputBytes = 4096
 // attribution harness's diagnostic lane (cgo_harness/attribution), which
 // bypasses Parse and the admission switch entirely and never ships.
 //
-// KNOWN OPEN FINDING (root-reduce leaf-tiling exemption; not fixed by this
-// tranche): live fuzzing reproducibly finds a false-clean divergence in
-// under 4 seconds from a cold cache, independent of which curated language
-// it lands on. Confirmed witnesses: html "&0", "&;", "&#", "&09", ">0";
-// erlang "\x010", "\x100"; haskell "\"\n" -- all two bytes, all the same
-// shape: one non-trivia byte at byte 0 (document start) that compact drops
-// silently (HasError()==false, no child covers it) while production
-// correctly reports HasError()==true. Root cause, verified by direct
-// read of parsercore_phase0_driver.go: materializeDiagnosticParserCoreAcceptedSelection's
-// reduce visitor calls diagnosticParserCoreReduceChildrenTilingGap (the B1
-// fix) for every reduce EXCEPT the derivation's own root symbol
-// (isDerivationRootReduce, ~line 2800) -- a deliberate exemption, but its own
-// comment justifies it only against finalizeDiagnosticParserCoreAcceptedRootSpan
-// pinning "an over-wide root span"; that function (~line 2420) verifies only
-// that the root's span bounds equal [expectedStart, sourceLen), never that
-// the root's own raw children actually tile it, so a LEADING (or interior)
-// gap at the root symbol specifically is unchecked by either function. The
-// exemption's one documented motivating case (jsdoc's unspaced "*/" comment
-// terminator) is a TRAILING-edge gap; every reproduction found here is a
-// LEADING-edge gap, a materially different shape the exemption's own
-// reasoning does not cover. A narrow fix -- keep the exemption only for a
-// gap that reaches the root's own endByte (trailing), not one that starts
-// at the root's own startByte or sits between two of its children -- was
-// identified but deliberately NOT implemented here: correctly scoping and
-// re-validating any change to this function needs the full B1 validation
-// surface (98-witness manifest, real-corpus matrix, 206-language scorecard,
-// cgo C-oracle parity), none of which a B2-scoped fuzzer change should touch
-// ad hoc. Filed as a campaign finding for a B1 follow-up tranche.
+// FIXED FINDING (root-start pull-back leading-byte drop): live fuzzing used
+// to reproduce a false-clean divergence in under 4 seconds from a cold
+// cache, independent of which curated language it landed on. Confirmed
+// witnesses: html "&0", "&;", "&#", ">0", "&000"; erlang "\x010", "\x100";
+// haskell "\"\n" -- all the same shape: one non-trivia byte at byte 0
+// (document start) that the accepted derivation's own root reduce never
+// represented (HasError()==false, no node anywhere in the derivation covers
+// the byte) while production correctly reported HasError()==true.
+// diagnosticParserCoreReduceChildrenTilingGap (the B1 fix) never saw this
+// gap because it is exempt at the derivation's own root symbol
+// (isDerivationRootReduce, parsercore_phase0_driver.go); the shared post-
+// materialization normalizeRootSourceStart (parser_result_root_build.go)
+// then pulled the public root span back over the missing byte on the
+// assumption of a legitimately elided leading extra, so
+// finalizeDiagnosticParserCoreAcceptedRootSpan's own start check saw an
+// already-laundered, tautologically-correct span. Fixed by a second,
+// root-specific decline in materializeDiagnosticParserCoreAcceptedSelection
+// (parsercore_phase0_driver.go) that reads the derivation's raw,
+// pre-normalization root span start -- the one value the pull-back
+// overwrites -- and declines fail-closed whenever it starts after the
+// source's first non-trivia byte. See
+// TestCompactRouteRootLeadingGapDeclines
+// (admission_route_equality_root_leading_gap_test.go) for the pinned
+// per-witness regression and TestCompactRouteLeadingCommentStillServes for
+// the fail-open control (a legitimate leading comment still routes through
+// the compact candidate).
 //
-// Because this reproduces from a cold cache in seconds regardless of which
-// curated language the mutator lands on, the bounded CI fuzz lane
-// (.github/workflows/ci.yml) runs this target as an ADVISORY step, not a
-// blocking one, until that follow-up lands; only the seed-corpus regression
-// step (this file's committed f.Add corpus, which excludes every witness
-// above) is required. See this tranche's spore for the full writeup.
+// The bounded CI fuzz lane (.github/workflows/ci.yml) still runs this
+// target's live-mutation step as ADVISORY, not blocking: a 90-second local
+// session with this finding fixed found zero occurrences of this class
+// across go, javascript, html, swift, python, bash, erlang, and rust, but
+// surfaced a separate, unrelated, pre-existing structural divergence on
+// haskell (matching HasError, differing child count -- a different
+// mechanism from this finding's HasError divergence). Promote the live-
+// mutation step once that residual is filed and resolved. The seed-corpus
+// regression step (this file's committed f.Add corpus) is unaffected and
+// stays required.
 func FuzzAdmissionRouteEquality(f *testing.F) {
 	// Several curated languages (html, javascript, swift, ...) are not
 	// otherwise loaded by the always-on suite; purge the process-wide

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -2869,6 +2869,23 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 		}
 		nodes[index] = nodesByID[payload]
 	}
+	// acceptedRootSpanStart is each top-level node's OWN declared startByte
+	// (view.StartByte, stamped verbatim at materializeVisit and never mutated
+	// since), captured before buildResultFromNodes runs. It must be read here:
+	// buildResultFromNodes's finalizeResultRoot calls normalizeRootSourceStart
+	// (parser_result_root_build.go), which unconditionally pulls a wider root
+	// back to source's first non-trivia byte on the assumption of a
+	// legitimately elided leading extra. That pull-back overwrites this exact
+	// field, so any check against the post-build root.startByte is tautological
+	// (it always reads back whatever normalizeRootSourceStart just wrote). See
+	// the leading-gap decline below, which compares this pre-normalization
+	// value instead.
+	acceptedRootSpanStart := nodes[0].startByte
+	for _, n := range nodes[1:] {
+		if n.startByte < acceptedRootSpanStart {
+			acceptedRootSpanStart = n.startByte
+		}
+	}
 	if err := poll(); err != nil {
 		return nil, err
 	}
@@ -2921,6 +2938,31 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	root := tree.root
 	if err := finalizeDiagnosticParserCoreAcceptedRootSpan(root, source, sourceLen); err != nil {
 		return rejectTree(err)
+	}
+	// accepted-root-leading-gap: the derivation's own root reduce is exempt
+	// from diagnosticParserCoreReduceChildrenTilingGap (isDerivationRootReduce,
+	// above), so a root whose declared span starts strictly after the source's
+	// first non-trivia byte passes that check by construction -- no child ever
+	// needed to cover the missing prefix because the root itself never claimed
+	// it. finalizeDiagnosticParserCoreAcceptedRootSpan does not catch this
+	// either: it runs after normalizeRootSourceStart has already pulled
+	// root.startByte back to expectedStart, so its equality check is
+	// tautological for this exact shape. acceptedRootSpanStart (captured
+	// before that pull-back) is the only place this information still exists.
+	// A raw start after the first real byte means at least one leading byte
+	// was never represented by any node in the accepted derivation; decline
+	// fail-closed rather than let normalizeRootSourceStart's legitimate-
+	// elision assumption launder it into a clean tree. Conservative by
+	// design: a genuine legitimately-elided leading extra also declines here
+	// and falls back to production, which still serves it correctly.
+	if expectedStart := firstNonTriviaByteStart(source); acceptedRootSpanStart > expectedStart {
+		return rejectTree(&diagnosticParserCoreDecline{
+			boundary: DiagnosticParserCoreAccept,
+			detail: fmt.Sprintf(
+				"accepted-root-leading-gap: accepted derivation's own root span started at byte %d, after source's first non-trivia byte %d",
+				acceptedRootSpanStart, expectedStart,
+			),
+		})
 	}
 	tree.incrementalReuseDisabled = !incrementalReuseProven
 	tree.compactMaterialized = true


### PR DESCRIPTION
## Summary

The compact parser route accepted derivations whose root span started
after the source's first non-trivia byte. A shared span normalizer
then pulled the root back over the gap and published a clean tree
with no error, while the production route correctly reported an
error for the same input.

Add a fail-closed acceptance check: decline the compact route when
the accepted derivation's own root span starts after the source's
first non-trivia byte. Read the raw, pre-normalization span, since
the normalizer overwrites it before any later check can see the true
value.

## Changes

- Add the accepted-root-leading-gap decline in
  `materializeDiagnosticParserCoreAcceptedSelection`
  (parsercore_phase0_driver.go).
- Add census class `censusMechanismAcceptedRootLeadingGap`
  (admission_census.go).
- Add `TestCompactRouteRootLeadingGapDeclines`: pins the 8 known
  reproductions (html, erlang, haskell).
- Add `TestCompactRouteLeadingCommentStillServes`: confirms a leading
  comment still routes through the compact candidate.
- Update the `FuzzAdmissionRouteEquality` doc comment to record the
  fix and a newly found, unrelated haskell divergence.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test . -count=1`
- [x] Admission scorecard (206 languages, ratchet mode): PASS=200
      DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0, unchanged from the pre-fix
      baseline; the one FALLBACK (markdown_inline) is pre-existing and
      unrelated
- [x] Per-language canonical digests: byte-identical before and after
- [x] Canonical fresh-full benchmark: zero allocs/op delta on all
      four fixtures
- [x] `go test . -race` on the affected admission/compact test surface
- [x] 90-second local fuzz session: zero occurrences of this class

## Fuzz lane

Left the live-mutation CI step advisory. The 90-second session found
zero occurrences of this class, but it also found a separate,
pre-existing, unrelated structural divergence on haskell (present on
unmodified main; matching HasError, differing child count). Promote
the step once that divergence has its own fix.
