### PR TITLE
add: inert recovery cost model over compact subtrees

### DIFF
--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -358,6 +358,22 @@ sealed or C0-authoritative epoch; it does not replace the receipt above or
 tranche that re-seals this board) will show `recovery` alongside the other
 eight components by construction, with no further classifier change needed.
 
+### B3 stage S2 addendum: the inert error-cost model
+
+Stage S2 added `internal/parsercorephase0/recovery_cost.go`: compact
+equivalents of `cNodeErrorCostLang`, `cSymbolVisibleLang`, and
+`cVersionStatus`, callable on demand but wired into nothing (no call site
+exists outside the file's own tests; a compile-time AST ratchet,
+`TestRecoveryCostNoOutsideCallSitesRatchet`, enforces this). A local
+reproduction of the documented command on stage S2's branch, with the file
+present, again confirmed `recovery` reads exactly 0.0% on every lane and
+fixture — diagnostic lane and shipped route alike. Every other component
+share stayed within this host's published noise floor of the stage-S1-era
+receipt above; the local noise floor measured on this run (8.2%-11.9% of
+median ns/op) is consistent with that same shared, uncontrolled-host
+variance, not a new finding. As with the S1 addendum, this is a
+verification check, not a new sealed epoch.
+
 ### Noise floor (interleaved A/A, identical binary, 12 pairs per fixture)
 
 | fixture | median ns/op | p95 \|delta\| | p95 \|delta\| as % of median |

--- a/internal/parsercorephase0/recovery_cost.go
+++ b/internal/parsercorephase0/recovery_cost.go
@@ -1,0 +1,407 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ---------------------------------------------------------------------------
+// recovery_cost.go -- campaign v7 tranche B3 stage S2: an inert error-cost
+// model over immutable compact subtree records.
+//
+// THE PRODUCTION GO PORT IS THE EXECUTABLE SPECIFICATION for this file
+// (spec.compact-recovery-ownership.v1, section 6): parser_recover_c.go's
+// cNodeErrorCostLang, cSymbolVisibleLang, and cVersionStatus, themselves
+// faithful ports of tree-sitter C's ts_subtree_error_cost /
+// ts_subtree_summarize_children (subtree.c) and
+// ts_parser__version_status / ts_parser__compare_versions (parser.c). Every
+// constant, branch, and evaluation order below mirrors those functions
+// exactly; a divergence gets a receipt, not a silent "improvement"
+// (decision 0007, hypha://m31labs/gotreesitter).
+//
+// Nothing in this package calls into this file. It is a pure, on-demand
+// library: no Core method, no scheduler path, and no driver file references
+// any declaration here. TestRecoveryCostNoOutsideCallSitesRatchet enforces
+// this as a compile-time property, in the style of
+// condense_outcome_provenance_ratchet_test.go. Stage S3 wires the ERROR-
+// region records this model reads over; stage S4 wires the recovery
+// election that reads RecoveryErrorStatus/RecoveryCompareVersions. Until
+// then this file is dead code by construction (gates G2/G3, design section
+// 8) -- reachable from nowhere except its own tests.
+//
+// Record shape note: RecoveryCostNode is a strict superset of the existing
+// SubtreeView (core.go): it adds Missing and two row fields (StartRow,
+// EndRow) that no compact subtree needs to populate today, because nothing
+// in the shipped compact core has ever produced a MISSING node or an ERROR
+// region -- compact has no error recovery yet. cNodeErrorCostLang only ever
+// reads a node's Missing flag or row span when that node either is itself
+// missing or is an ERROR node (parser_recover_c.go:1238,1249-1268); an
+// ordinary clean node's Missing is always false and its row span is never
+// read. So every real SubtreeView-backed RecoveryCostNode in service today
+// leaves Missing=false and StartRow==EndRow==0, and this cost model still
+// returns exactly 0 for it (see the parity corpus test in
+// recovery_cost_test.go and the root-package differential test). The two
+// added fields exist for the paused-header MISSING/ERROR records stage
+// S3/S5 construct (design section 4); this stage defines the shape those
+// stages populate, and does not approximate production *Node state -- it
+// defines a compact record able to carry all of it.
+// ---------------------------------------------------------------------------
+
+// Cost weights: a literal port of parser_recover_c.go:52-58's error_costs.h
+// constants (ERROR_COST_PER_RECOVERY=500, ERROR_COST_PER_MISSING_TREE=110,
+// ERROR_COST_PER_SKIPPED_TREE=100, ERROR_COST_PER_SKIPPED_LINE=30,
+// ERROR_COST_PER_SKIPPED_CHAR=1). Keep the production warning attached: an
+// older internal doc said the skipped-line cost was 2; the C header (and
+// this port) is 30.
+const (
+	RecoveryCostPerRecovery    = 500
+	RecoveryCostPerMissingTree = 110
+	RecoveryCostPerSkippedTree = 100
+	RecoveryCostPerSkippedLine = 30
+	RecoveryCostPerSkippedChar = 1
+)
+
+// recoveryMaxCostDifference mirrors cRecoverMaxCostDifference
+// (parser_recover_c.go:62-69): 18*RecoveryCostPerSkippedTree, matching
+// tree-sitter v0.25.0 (parser.c:83, the release the pinned oracle links).
+// Older tree-sitter releases used 16*ERROR_COST_PER_SKIPPED_TREE; do not
+// "correct" this back to 16 -- this port tracks the pinned oracle version.
+const recoveryMaxCostDifference = 18 * RecoveryCostPerSkippedTree
+
+// RecoveryErrorSymbol is tree-sitter's well-known builtin ERROR symbol id
+// (ts_builtin_sym_error). It is fixed across every grammar, not a
+// per-language table value, matching the root package's own errorSymbol
+// constant (parser_api.go:997).
+const RecoveryErrorSymbol Symbol = 65535
+
+// RecoveryCostNode is the immutable, per-subtree view the cost model reads.
+// See the file doc comment above for why it carries two fields SubtreeView
+// does not.
+type RecoveryCostNode struct {
+	Symbol    Symbol
+	Extra     bool
+	Missing   bool
+	StartByte uint32
+	EndByte   uint32
+	StartRow  uint32
+	EndRow    uint32
+	Children  []SubtreeID
+}
+
+// RecoveryCostSource resolves a SubtreeID to its cost-model view. Compact
+// subtree records are structurally immutable once published (core.go's
+// subtreeRecord doc comment); an implementation must return an equal
+// RecoveryCostNode for the same id for the lifetime of one parse. id is
+// never 0 (SubtreeIDs are one-based, core.go): callers in this file never
+// invoke RecoveryCostNode with id == 0, mirroring cNodeErrorCostLang's
+// `if n == nil { return 0 }` base case.
+type RecoveryCostSource interface {
+	RecoveryCostNode(id SubtreeID) (RecoveryCostNode, error)
+}
+
+// ErrRecoveryCostNodeMissing reports that a RecoveryCostSource has no record
+// for a referenced SubtreeID -- a malformed or foreign handle, never
+// expected from a well-formed compact tree.
+var ErrRecoveryCostNodeMissing = errors.New("parser-core phase zero: recovery cost source has no record for subtree id")
+
+// RecoverySymbolVisible is the compact equivalent of cSymbolVisibleLang
+// (parser_recover_c.go:1140-1148). symbols is the compact analogue of
+// Language.SymbolMetadata: SelectedStorePolicy.Symbols, sourced from the
+// identical Language.SymbolMetadata[...].Visible signal
+// (parsercore_phase0_driver.go:486-489), not an approximation of it.
+func RecoverySymbolVisible(symbols []SelectedSymbolPolicy, sym Symbol) bool {
+	if sym == RecoveryErrorSymbol {
+		return true
+	}
+	if int(sym) >= len(symbols) {
+		return false
+	}
+	return symbols[sym].Visible
+}
+
+// recoveryVisibleChildCount is the compact equivalent of
+// cNodeVisibleChildCountLang (parser_recover_c.go:1160-1176): direct
+// children that are visible, plus the visible children of invisible
+// internal children.
+func recoveryVisibleChildCount(symbols []SelectedSymbolPolicy, src RecoveryCostSource, id SubtreeID) (int, error) {
+	if id == 0 {
+		return 0, nil
+	}
+	node, err := src.RecoveryCostNode(id)
+	if err != nil {
+		return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", id, err)
+	}
+	count := 0
+	for _, childID := range node.Children {
+		if childID == 0 {
+			continue
+		}
+		child, err := src.RecoveryCostNode(childID)
+		if err != nil {
+			return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", childID, err)
+		}
+		if RecoverySymbolVisible(symbols, child.Symbol) {
+			count++
+		} else if len(child.Children) > 0 {
+			sub, err := recoveryVisibleChildCount(symbols, src, childID)
+			if err != nil {
+				return 0, err
+			}
+			count += sub
+		}
+	}
+	return count, nil
+}
+
+// RecoveryCostMemo memoizes RecoveryNodeErrorCostMemo results per SubtreeID.
+// Unlike production's cNodeMemoCacheEntry (parser_recover_c.go:1324-1349),
+// which pointer-hashes into a 2-way set-associative cache and carries an
+// equivVersion stamp because a live *Node mutates in place under GLR
+// forking, a published compact SubtreeID never changes once created -- the
+// open error region is the only mutable recovery state, and it lives on the
+// header, not the arena (design section 4, stage S2 scope). A memoized cost
+// is therefore valid for the rest of the parse with no version check, and
+// SubtreeID's dense, one-based arena numbering (core.go) lets the memo be a
+// flat, growable slice instead of a hash structure -- exact, no eviction, no
+// collision handling.
+//
+// The zero value is ready to use.
+type RecoveryCostMemo struct {
+	cost []uint32
+	has  []bool
+}
+
+func (m *RecoveryCostMemo) lookup(id SubtreeID) (uint32, bool) {
+	if m == nil {
+		return 0, false
+	}
+	idx := int(id)
+	if idx <= 0 || idx > len(m.has) || !m.has[idx-1] {
+		return 0, false
+	}
+	return m.cost[idx-1], true
+}
+
+func (m *RecoveryCostMemo) store(id SubtreeID, cost uint32) {
+	if m == nil {
+		return
+	}
+	idx := int(id)
+	if idx <= 0 {
+		return
+	}
+	if idx > len(m.has) {
+		grownHas := make([]bool, idx)
+		copy(grownHas, m.has)
+		m.has = grownHas
+		grownCost := make([]uint32, idx)
+		copy(grownCost, m.cost)
+		m.cost = grownCost
+	}
+	m.cost[idx-1] = cost
+	m.has[idx-1] = true
+}
+
+// Reset clears every memoized entry while retaining capacity, so one
+// RecoveryCostMemo can be reused across parses without reallocating,
+// mirroring Core.Reset's retained-capacity discipline (core.go).
+func (m *RecoveryCostMemo) Reset() {
+	if m == nil {
+		return
+	}
+	for i := range m.has {
+		m.has[i] = false
+	}
+}
+
+// Len reports the memo's current slot capacity (test/diagnostic use only).
+func (m *RecoveryCostMemo) Len() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.has)
+}
+
+// RecoveryNodeErrorCost is the compact equivalent of cNodeErrorCostLang
+// (parser_recover_c.go:1216-1271), unmemoized.
+func RecoveryNodeErrorCost(symbols []SelectedSymbolPolicy, src RecoveryCostSource, id SubtreeID) (uint32, error) {
+	return recoveryNodeErrorCost(symbols, src, nil, id)
+}
+
+// RecoveryNodeErrorCostMemo is RecoveryNodeErrorCost with memoization,
+// mirroring cNodeErrorCostLangWithScratch (parser_recover_c.go:1273-1322). A
+// nil memo falls back to the unmemoized walk, matching the production
+// function's `if scratch == nil` fallback.
+func RecoveryNodeErrorCostMemo(symbols []SelectedSymbolPolicy, src RecoveryCostSource, memo *RecoveryCostMemo, id SubtreeID) (uint32, error) {
+	return recoveryNodeErrorCost(symbols, src, memo, id)
+}
+
+func recoveryNodeErrorCost(symbols []SelectedSymbolPolicy, src RecoveryCostSource, memo *RecoveryCostMemo, id SubtreeID) (uint32, error) {
+	if id == 0 {
+		return 0, nil
+	}
+	if memo != nil {
+		if cost, ok := memo.lookup(id); ok {
+			return cost, nil
+		}
+	}
+	node, err := src.RecoveryCostNode(id)
+	if err != nil {
+		return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", id, err)
+	}
+	if node.Missing && len(node.Children) == 0 {
+		cost := uint32(RecoveryCostPerMissingTree + RecoveryCostPerRecovery)
+		if memo != nil {
+			memo.store(id, cost)
+		}
+		return cost, nil
+	}
+	var cost uint32
+	for _, childID := range node.Children {
+		if childID == 0 {
+			continue
+		}
+		child, err := src.RecoveryCostNode(childID)
+		if err != nil {
+			return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", childID, err)
+		}
+		if child.Symbol == RecoveryErrorSymbol && len(child.Children) == 0 {
+			// Compact mirror of the C ERROR-leaf rule: subtree error_cost is
+			// 0 for a childless ERROR node (parser_recover_c.go:1243-1246).
+			continue
+		}
+		childCost, err := recoveryNodeErrorCost(symbols, src, memo, childID)
+		if err != nil {
+			return 0, err
+		}
+		cost += childCost
+	}
+	if node.Symbol == RecoveryErrorSymbol {
+		for _, childID := range node.Children {
+			if childID == 0 {
+				continue
+			}
+			child, err := src.RecoveryCostNode(childID)
+			if err != nil {
+				return 0, fmt.Errorf("parser-core phase zero: recovery cost node %d: %w", childID, err)
+			}
+			if child.Extra {
+				continue
+			}
+			if RecoverySymbolVisible(symbols, child.Symbol) {
+				cost += RecoveryCostPerSkippedTree
+			} else if len(child.Children) > 0 {
+				vis, err := recoveryVisibleChildCount(symbols, src, childID)
+				if err != nil {
+					return 0, err
+				}
+				cost += RecoveryCostPerSkippedTree * uint32(vis)
+			}
+		}
+		spanBytes := uint32(0)
+		if node.EndByte > node.StartByte {
+			spanBytes = node.EndByte - node.StartByte
+		}
+		spanRows := uint32(0)
+		if node.EndRow > node.StartRow {
+			spanRows = node.EndRow - node.StartRow
+		}
+		cost += RecoveryCostPerRecovery + RecoveryCostPerSkippedChar*spanBytes + RecoveryCostPerSkippedLine*spanRows
+	}
+	if memo != nil {
+		memo.store(id, cost)
+	}
+	return cost, nil
+}
+
+// RecoveryErrorStatus is the compact equivalent of parser_recover_c.go's
+// cErrorStatus (:2172-2177): the four values ts_parser__compare_versions
+// competes on.
+type RecoveryErrorStatus struct {
+	Cost      uint32
+	NodeCount int
+	DynPrec   int
+	IsInError bool
+}
+
+// RecoveryVersionStatus is the compact equivalent of cVersionStatus
+// (parser_recover_c.go:2189-2201). Stage S2 owns no header type: the paused
+// flag, the node-count-since-error baseline, dynamic precedence, and
+// open-recovery existence all live on the paused header stage S3
+// introduces ("The open error region is the only mutable piece and lives
+// on the header, not in the arena", design section 4), so this function
+// takes them as explicit parameters instead of reading them off a header
+// that does not exist yet. subtreeCost is the caller-supplied result of
+// RecoveryNodeErrorCost(Memo) over the head's accumulated subtrees -- the
+// compact analogue of cStackErrorCost(s).
+//
+// cNodeVisibleSubtreeCount and cNodeCountSinceError
+// (parser_recover_c.go:1178-1214,2155-2166) are deliberately not ported
+// here: they accumulate a visible-node count across a live GLR stack since
+// an error baseline, which is per-head bookkeeping, not a property of one
+// compact subtree. That machinery belongs to the stage that owns paused
+// headers (S3/S4), not this inert stage; NodeCount stays an explicit input
+// for the same reason.
+func RecoveryVersionStatus(subtreeCost uint32, paused bool, nodeCount int, dynPrec int, hasOpenRecovery bool) RecoveryErrorStatus {
+	cost := subtreeCost
+	if paused {
+		cost += RecoveryCostPerSkippedTree
+	}
+	return RecoveryErrorStatus{
+		Cost:      cost,
+		NodeCount: nodeCount,
+		DynPrec:   dynPrec,
+		IsInError: paused || hasOpenRecovery,
+	}
+}
+
+// RecoveryComparison is the compact equivalent of cErrorComparison
+// (parser_recover_c.go:2179-2187).
+type RecoveryComparison int
+
+const (
+	RecoveryComparisonTakeLeft RecoveryComparison = iota
+	RecoveryComparisonPreferLeft
+	RecoveryComparisonNone
+	RecoveryComparisonPreferRight
+	RecoveryComparisonTakeRight
+)
+
+// RecoveryCompareVersions is a literal port of cCompareVersions
+// (parser_recover_c.go:2264-2297), itself a literal port of
+// ts_parser__compare_versions. This function carries exact-parity
+// obligation 3 (design section 6): in-error class first, then cost with the
+// node-count-scaled max-cost-difference band, then dynamic precedence.
+func RecoveryCompareVersions(a, b RecoveryErrorStatus) RecoveryComparison {
+	if !a.IsInError && b.IsInError {
+		if a.Cost < b.Cost {
+			return RecoveryComparisonTakeLeft
+		}
+		return RecoveryComparisonPreferLeft
+	}
+	if a.IsInError && !b.IsInError {
+		if b.Cost < a.Cost {
+			return RecoveryComparisonTakeRight
+		}
+		return RecoveryComparisonPreferRight
+	}
+	if a.Cost < b.Cost {
+		if (b.Cost-a.Cost)*uint32(1+a.NodeCount) > recoveryMaxCostDifference {
+			return RecoveryComparisonTakeLeft
+		}
+		return RecoveryComparisonPreferLeft
+	}
+	if b.Cost < a.Cost {
+		if (a.Cost-b.Cost)*uint32(1+b.NodeCount) > recoveryMaxCostDifference {
+			return RecoveryComparisonTakeRight
+		}
+		return RecoveryComparisonPreferRight
+	}
+	if a.DynPrec > b.DynPrec {
+		return RecoveryComparisonPreferLeft
+	}
+	if b.DynPrec > a.DynPrec {
+		return RecoveryComparisonPreferRight
+	}
+	return RecoveryComparisonNone
+}

--- a/internal/parsercorephase0/recovery_cost_ratchet_test.go
+++ b/internal/parsercorephase0/recovery_cost_ratchet_test.go
@@ -1,0 +1,101 @@
+package parsercorephase0
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRecoveryCostNoOutsideCallSitesRatchet is the compile-time,
+// clean-path-zero-cost guardrail for recovery_cost.go (campaign v7 tranche
+// B3 stage S2, design section 8 gates G2/G3): every symbol recovery_cost.go
+// declares at package scope must be referenced from nowhere else in this
+// package's non-test source, proving by construction that ordinary
+// condense, shift, reduce, and materialization code paths cannot reach the
+// cost model. This is the same pattern as
+// TestCondenseWithOutcomeAtomicProvenanceRatchet
+// (condense_outcome_provenance_ratchet_test.go), generalized from one
+// function name to a whole file's declared surface.
+//
+// Method names (Reset, Len, lookup, store, ...) are deliberately excluded
+// from the banned set: they are selected through a receiver, not referenced
+// as bare package-scope identifiers, and some are common enough (Core.Reset,
+// for one) that banning them by name would false-positive on unrelated
+// methods. What this ratchet protects is the set of package-scope
+// declarations recovery_cost.go introduces: its exported API plus its two
+// unexported helper functions/constant. A later stage that wires this file
+// in (S3 onward) will make this ratchet fail on purpose -- that failure is
+// the signal to update or retire it alongside the real call site landing.
+func TestRecoveryCostNoOutsideCallSitesRatchet(t *testing.T) {
+	const homeFile = "recovery_cost.go"
+
+	fset := token.NewFileSet()
+	home, err := parser.ParseFile(fset, homeFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", homeFile, err)
+	}
+
+	banned := map[string]bool{}
+	for _, decl := range home.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Recv != nil {
+				// A method: selected through a receiver, not a bare
+				// package-scope identifier. Excluded (see doc comment).
+				continue
+			}
+			banned[d.Name.Name] = true
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					banned[s.Name.Name] = true
+				case *ast.ValueSpec:
+					for _, name := range s.Names {
+						if name.Name != "_" {
+							banned[name.Name] = true
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(banned) == 0 {
+		t.Fatalf("collected zero package-scope identifiers from %s; the ratchet would vacuously pass", homeFile)
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == homeFile {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Clean(name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			ident, ok := node.(*ast.Ident)
+			if !ok || !banned[ident.Name] {
+				return true
+			}
+			violations++
+			t.Errorf("%s references %s, a recovery_cost.go (stage S2, inert) declaration -- "+
+				"the clean path must not call into the recovery cost model; if a later stage "+
+				"intentionally wires this in, update this ratchet in the same change",
+				fset.Position(ident.Pos()), ident.Name)
+			return true
+		})
+	}
+	if violations != 0 {
+		t.Fatalf("%d reference(s) to recovery_cost.go declarations found outside recovery_cost.go and its own tests", violations)
+	}
+}

--- a/internal/parsercorephase0/recovery_cost_test.go
+++ b/internal/parsercorephase0/recovery_cost_test.go
@@ -1,0 +1,495 @@
+package parsercorephase0
+
+import (
+	"errors"
+	"math/rand"
+	"testing"
+)
+
+// fakeRecoveryCostSource is a minimal, in-memory RecoveryCostSource backing
+// hand-built and generated fixtures. It never mutates published entries,
+// matching the immutability RecoveryCostSource documents.
+type fakeRecoveryCostSource map[SubtreeID]RecoveryCostNode
+
+func (s fakeRecoveryCostSource) RecoveryCostNode(id SubtreeID) (RecoveryCostNode, error) {
+	node, ok := s[id]
+	if !ok {
+		return RecoveryCostNode{}, ErrRecoveryCostNodeMissing
+	}
+	return node, nil
+}
+
+// recoveryCostSpec builds a fakeRecoveryCostSource fixture from a small tree
+// literal, assigning sequential one-based SubtreeIDs in publish order
+// (children before parents, matching compact's own append-only arena
+// discipline).
+type recoveryCostSpec struct {
+	symbol   Symbol
+	extra    bool
+	missing  bool
+	start    uint32
+	end      uint32
+	startRow uint32
+	endRow   uint32
+	children []*recoveryCostSpec
+}
+
+func publishRecoveryCostSpec(src fakeRecoveryCostSource, next *SubtreeID, spec *recoveryCostSpec) SubtreeID {
+	children := make([]SubtreeID, 0, len(spec.children))
+	for _, child := range spec.children {
+		children = append(children, publishRecoveryCostSpec(src, next, child))
+	}
+	*next++
+	id := *next
+	src[id] = RecoveryCostNode{
+		Symbol:    spec.symbol,
+		Extra:     spec.extra,
+		Missing:   spec.missing,
+		StartByte: spec.start,
+		EndByte:   spec.end,
+		StartRow:  spec.startRow,
+		EndRow:    spec.endRow,
+		Children:  children,
+	}
+	return id
+}
+
+func newRecoveryCostFixture(spec *recoveryCostSpec) (fakeRecoveryCostSource, SubtreeID) {
+	src := fakeRecoveryCostSource{}
+	var next SubtreeID
+	root := publishRecoveryCostSpec(src, &next, spec)
+	return src, root
+}
+
+const ordinarySymbol Symbol = 5
+
+func visibleSymbols() []SelectedSymbolPolicy {
+	symbols := make([]SelectedSymbolPolicy, 8)
+	symbols[ordinarySymbol] = SelectedSymbolPolicy{Visible: true, Named: true}
+	symbols[6] = SelectedSymbolPolicy{Visible: false, Named: false}
+	return symbols
+}
+
+func TestRecoveryNodeErrorCostCleanTreeIsZero(t *testing.T) {
+	spec := &recoveryCostSpec{
+		symbol: ordinarySymbol, start: 0, end: 10, endRow: 1,
+		children: []*recoveryCostSpec{
+			{symbol: ordinarySymbol, start: 0, end: 4},
+			{symbol: ordinarySymbol, start: 4, end: 10, endRow: 1},
+		},
+	}
+	src, root := newRecoveryCostFixture(spec)
+	got, err := RecoveryNodeErrorCost(visibleSymbols(), src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 0 {
+		t.Fatalf("clean tree cost = %d, want 0", got)
+	}
+}
+
+// TestRecoveryNodeErrorCostChildlessErrorLeafRule pins
+// parser_recover_c.go:1243-1246: a childless ERROR node contributes exactly
+// 0 to its PARENT's accumulated cost (its bytes are charged once via the
+// enclosing ERROR node's own span), but the same childless ERROR node
+// queried directly (as a root, not through a parent's child loop) still
+// charges its own RecoveryCostPerRecovery+bytes+rows -- matching the C
+// error_repeat wrapper around an invisible token
+// (parser_recover_c.go:1223-1233).
+func TestRecoveryNodeErrorCostChildlessErrorLeafRule(t *testing.T) {
+	leaf := &recoveryCostSpec{symbol: RecoveryErrorSymbol, start: 3, end: 7, startRow: 1, endRow: 2}
+
+	src, leafID := newRecoveryCostFixture(leaf)
+	directCost, err := RecoveryNodeErrorCost(visibleSymbols(), src, leafID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDirect := uint32(RecoveryCostPerRecovery + RecoveryCostPerSkippedChar*4 + RecoveryCostPerSkippedLine*1)
+	if directCost != wantDirect {
+		t.Fatalf("childless ERROR leaf queried directly = %d, want %d", directCost, wantDirect)
+	}
+
+	parent := &recoveryCostSpec{
+		symbol: ordinarySymbol, start: 0, end: 20, endRow: 3,
+		children: []*recoveryCostSpec{
+			{symbol: ordinarySymbol, start: 0, end: 3},
+			{symbol: RecoveryErrorSymbol, start: 3, end: 7, startRow: 1, endRow: 2},
+			{symbol: ordinarySymbol, start: 7, end: 20, startRow: 2, endRow: 3},
+		},
+	}
+	src2, root := newRecoveryCostFixture(parent)
+	parentCost, err := RecoveryNodeErrorCost(visibleSymbols(), src2, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parentCost != 0 {
+		t.Fatalf("parent cost through a childless ERROR child = %d, want 0 (leaf skipped)", parentCost)
+	}
+}
+
+func TestRecoveryNodeErrorCostMissingLeaf(t *testing.T) {
+	spec := &recoveryCostSpec{symbol: ordinarySymbol, missing: true, start: 5, end: 5, startRow: 1, endRow: 1}
+	src, root := newRecoveryCostFixture(spec)
+	got, err := RecoveryNodeErrorCost(visibleSymbols(), src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := uint32(RecoveryCostPerMissingTree + RecoveryCostPerRecovery)
+	if got != want {
+		t.Fatalf("missing leaf cost = %d, want %d", got, want)
+	}
+}
+
+// TestRecoveryNodeErrorCostErrorNodeSkippedChildren pins the
+// visible/invisible/extra child accounting inside the ERROR branch
+// (parser_recover_c.go:1249-1259).
+func TestRecoveryNodeErrorCostErrorNodeSkippedChildren(t *testing.T) {
+	symbols := visibleSymbols()
+	// One visible skipped child (+100), one extra child (skipped
+	// entirely, +0), one invisible child with two visible grandchildren
+	// (+100*2), spanning 6 bytes and 2 rows.
+	spec := &recoveryCostSpec{
+		symbol: RecoveryErrorSymbol, start: 0, end: 6, startRow: 0, endRow: 2,
+		children: []*recoveryCostSpec{
+			{symbol: ordinarySymbol, start: 0, end: 1},
+			{symbol: 6, extra: true, start: 1, end: 2},
+			{
+				symbol: 6, start: 2, end: 6, endRow: 2,
+				children: []*recoveryCostSpec{
+					{symbol: ordinarySymbol, start: 2, end: 4},
+					{symbol: ordinarySymbol, start: 4, end: 6, endRow: 2},
+				},
+			},
+		},
+	}
+	src, root := newRecoveryCostFixture(spec)
+	got, err := RecoveryNodeErrorCost(symbols, src, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := uint32(RecoveryCostPerSkippedTree /* visible child */ +
+		RecoveryCostPerSkippedTree*2 /* invisible wrapper's two visible grandchildren */ +
+		RecoveryCostPerRecovery + RecoveryCostPerSkippedChar*6 + RecoveryCostPerSkippedLine*2)
+	if got != want {
+		t.Fatalf("ERROR node cost = %d, want %d", got, want)
+	}
+}
+
+func TestRecoverySymbolVisible(t *testing.T) {
+	symbols := visibleSymbols()
+	if !RecoverySymbolVisible(symbols, RecoveryErrorSymbol) {
+		t.Fatal("RecoveryErrorSymbol must always be visible, even out of table range")
+	}
+	if !RecoverySymbolVisible(symbols, ordinarySymbol) {
+		t.Fatal("symbol marked Visible in the table must report visible")
+	}
+	if RecoverySymbolVisible(symbols, 6) {
+		t.Fatal("symbol marked not-Visible in the table must report not visible")
+	}
+	if RecoverySymbolVisible(symbols, Symbol(len(symbols)+50)) {
+		t.Fatal("out-of-range ordinary symbol must report not visible")
+	}
+}
+
+func TestRecoveryCostSourceMissingNodeErrors(t *testing.T) {
+	src := fakeRecoveryCostSource{}
+	_, err := RecoveryNodeErrorCost(nil, src, 1)
+	if !errors.Is(err, ErrRecoveryCostNodeMissing) {
+		t.Fatalf("err = %v, want wrapped ErrRecoveryCostNodeMissing", err)
+	}
+}
+
+// TestRecoveryNodeErrorCostMemoSkipsChildlessErrorLeaf pins the memo-shape
+// consequence of the childless-ERROR-leaf rule: a parent's skip-check reads
+// the leaf's Symbol/Children directly without recursing into it, so the leaf
+// itself is never memoized, even though it correctly contributes 0 to the
+// parent's memoized cost.
+func TestRecoveryNodeErrorCostMemoSkipsChildlessErrorLeaf(t *testing.T) {
+	leaf := &recoveryCostSpec{symbol: RecoveryErrorSymbol, start: 3, end: 7}
+	parent := &recoveryCostSpec{
+		symbol:   ordinarySymbol,
+		start:    0,
+		end:      7,
+		children: []*recoveryCostSpec{leaf},
+	}
+	src, root := newRecoveryCostFixture(parent)
+	leafID := SubtreeID(1) // published first, children-before-parent order.
+
+	var memo RecoveryCostMemo
+	cost, err := RecoveryNodeErrorCostMemo(visibleSymbols(), src, &memo, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cost != 0 {
+		t.Fatalf("parent cost = %d, want 0 (childless ERROR child skipped)", cost)
+	}
+	if _, ok := memo.lookup(leafID); ok {
+		t.Fatal("a childless ERROR leaf reached only via a parent's skip-check must not be memoized")
+	}
+	if _, ok := memo.lookup(root); !ok {
+		t.Fatal("the root itself must be memoized")
+	}
+}
+
+func TestRecoveryCostMemoGrowGetResetLen(t *testing.T) {
+	var memo RecoveryCostMemo
+	if memo.Len() != 0 {
+		t.Fatalf("zero value Len() = %d, want 0", memo.Len())
+	}
+	if _, ok := memo.lookup(3); ok {
+		t.Fatal("lookup on empty memo must miss")
+	}
+	memo.store(3, 42)
+	if got, ok := memo.lookup(3); !ok || got != 42 {
+		t.Fatalf("lookup(3) = (%d, %v), want (42, true)", got, ok)
+	}
+	if memo.Len() < 3 {
+		t.Fatalf("Len() = %d after storing id 3, want >= 3", memo.Len())
+	}
+	if _, ok := memo.lookup(1); ok {
+		t.Fatal("lookup on a never-stored id below the grown length must miss")
+	}
+	memo.Reset()
+	if _, ok := memo.lookup(3); ok {
+		t.Fatal("lookup after Reset must miss")
+	}
+	if memo.Len() < 3 {
+		t.Fatal("Reset must retain capacity")
+	}
+	// id == 0 (the compact nil-child sentinel) is a documented no-op.
+	memo.store(0, 99)
+	if _, ok := memo.lookup(0); ok {
+		t.Fatal("id 0 must never be stored")
+	}
+	// A nil *RecoveryCostMemo behaves like an always-miss, always-discard
+	// memo (RecoveryNodeErrorCost passes nil for the unmemoized entry
+	// point).
+	var nilMemo *RecoveryCostMemo
+	if _, ok := nilMemo.lookup(1); ok {
+		t.Fatal("nil memo lookup must miss")
+	}
+	nilMemo.store(1, 1)
+	nilMemo.Reset()
+	if nilMemo.Len() != 0 {
+		t.Fatal("nil memo Len() must be 0")
+	}
+}
+
+// TestRecoveryNodeErrorCostMemoMatchesUnmemoized runs a model-based property
+// check across many generated tree shapes: the memoized and unmemoized cost
+// entry points must return identical costs, and a warm memo (already
+// populated by an earlier full walk) must return the same cost as one primed
+// fresh, node for node.
+func TestRecoveryNodeErrorCostMemoMatchesUnmemoized(t *testing.T) {
+	symbols := visibleSymbols()
+	random := rand.New(rand.NewSource(0x7265_636f))
+	for trial := 0; trial < 500; trial++ {
+		src, root, ids := genRecoveryCostTree(random)
+
+		unmemoized, err := RecoveryNodeErrorCost(symbols, src, root)
+		if err != nil {
+			t.Fatalf("trial %d: unmemoized: %v", trial, err)
+		}
+
+		var freshMemo RecoveryCostMemo
+		memoized, err := RecoveryNodeErrorCostMemo(symbols, src, &freshMemo, root)
+		if err != nil {
+			t.Fatalf("trial %d: memoized: %v", trial, err)
+		}
+		if memoized != unmemoized {
+			t.Fatalf("trial %d: memoized root cost = %d, want %d (unmemoized)", trial, memoized, unmemoized)
+		}
+
+		// Every individual node's memoized cost must equal its own
+		// unmemoized cost too (node-for-node parity), not just the root.
+		//
+		// Not every id is necessarily present in freshMemo after the root
+		// walk: a childless ERROR leaf reached only through a parent's
+		// skip-check (the rule TestRecoveryNodeErrorCostChildlessErrorLeafRule
+		// pins) is never recursed into, so it is never memoized either --
+		// exactly mirroring cNodeErrorCostLangWithScratch, which also never
+		// calls itself (and so never populates scratch.cErrorCost) for a
+		// child it skips. When present, the memoized value must still match.
+		for _, id := range ids {
+			want, err := RecoveryNodeErrorCost(symbols, src, id)
+			if err != nil {
+				t.Fatalf("trial %d: unmemoized node %d: %v", trial, id, err)
+			}
+			if gotWarm, ok := freshMemo.lookup(id); ok && gotWarm != want {
+				t.Fatalf("trial %d: warm memo cost for node %d = %d, want %d", trial, id, gotWarm, want)
+			}
+			// A second, independent memoized call (cold memo) must agree too.
+			var coldMemo RecoveryCostMemo
+			gotCold, err := RecoveryNodeErrorCostMemo(symbols, src, &coldMemo, id)
+			if err != nil {
+				t.Fatalf("trial %d: cold memo node %d: %v", trial, id, err)
+			}
+			if gotCold != want {
+				t.Fatalf("trial %d: cold memo cost for node %d = %d, want %d", trial, id, gotCold, want)
+			}
+		}
+	}
+}
+
+// genRecoveryCostTree builds a small random compact subtree (bounded depth
+// and fan-out, a mix of ordinary/extra/missing/ERROR nodes and byte/row
+// spans) and returns its source, root id, and every published id in publish
+// (children-before-parents) order.
+func genRecoveryCostTree(random *rand.Rand) (fakeRecoveryCostSource, SubtreeID, []SubtreeID) {
+	src := fakeRecoveryCostSource{}
+	var next SubtreeID
+	var ids []SubtreeID
+	var build func(depth int) SubtreeID
+	build = func(depth int) SubtreeID {
+		childCount := 0
+		if depth < 4 {
+			switch {
+			case random.Intn(3) == 0:
+				childCount = 1 + random.Intn(3)
+			}
+		}
+		isError := depth > 0 && random.Intn(6) == 0
+		missing := childCount == 0 && !isError && random.Intn(8) == 0
+		sym := ordinarySymbol
+		switch {
+		case isError:
+			sym = RecoveryErrorSymbol
+		case random.Intn(4) == 0:
+			sym = Symbol(6) // invisible ordinary symbol
+		}
+		extra := childCount == 0 && random.Intn(5) == 0
+
+		startByte := uint32(random.Intn(30))
+		startRow := uint32(random.Intn(4))
+		children := make([]SubtreeID, 0, childCount)
+		endByte, endRow := startByte, startRow
+		for i := 0; i < childCount; i++ {
+			childID := build(depth + 1)
+			children = append(children, childID)
+			child := src[childID]
+			if child.EndByte > endByte {
+				endByte = child.EndByte
+			}
+			if child.EndRow > endRow {
+				endRow = child.EndRow
+			}
+		}
+		if childCount == 0 {
+			endByte = startByte + uint32(random.Intn(5))
+			endRow = startRow + uint32(random.Intn(2))
+		}
+
+		next++
+		id := next
+		src[id] = RecoveryCostNode{
+			Symbol: sym, Extra: extra, Missing: missing,
+			StartByte: startByte, EndByte: endByte, StartRow: startRow, EndRow: endRow,
+			Children: children,
+		}
+		ids = append(ids, id)
+		return id
+	}
+	root := build(0)
+	return src, root, ids
+}
+
+func TestRecoveryVersionStatusPausedAddsSkippedTreeCost(t *testing.T) {
+	clean := RecoveryVersionStatus(100, false, 3, 0, false)
+	if clean.Cost != 100 || clean.IsInError {
+		t.Fatalf("clean status = %+v", clean)
+	}
+	paused := RecoveryVersionStatus(100, true, 3, 0, false)
+	if paused.Cost != 100+RecoveryCostPerSkippedTree {
+		t.Fatalf("paused cost = %d, want %d", paused.Cost, 100+RecoveryCostPerSkippedTree)
+	}
+	if !paused.IsInError {
+		t.Fatal("a paused status must report IsInError")
+	}
+	openRecovery := RecoveryVersionStatus(0, false, 0, 0, true)
+	if !openRecovery.IsInError {
+		t.Fatal("hasOpenRecovery must set IsInError even when not paused")
+	}
+}
+
+func TestRecoveryCompareVersionsKnownCases(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b RecoveryErrorStatus
+		want RecoveryComparison
+	}{
+		{
+			name: "clean beats in-error regardless of cost when clean is cheaper",
+			a:    RecoveryErrorStatus{Cost: 10, IsInError: false},
+			b:    RecoveryErrorStatus{Cost: 999, IsInError: true},
+			want: RecoveryComparisonTakeLeft,
+		},
+		{
+			name: "clean but pricier than an in-error rival still only prefers left",
+			a:    RecoveryErrorStatus{Cost: 999, IsInError: false},
+			b:    RecoveryErrorStatus{Cost: 10, IsInError: true},
+			want: RecoveryComparisonPreferLeft,
+		},
+		{
+			name: "small cost gap within the band prefers the cheaper side",
+			a:    RecoveryErrorStatus{Cost: 100, NodeCount: 0, IsInError: true},
+			b:    RecoveryErrorStatus{Cost: 200, NodeCount: 0, IsInError: true},
+			want: RecoveryComparisonPreferLeft,
+		},
+		{
+			name: "large cost gap beyond the node-scaled band takes the cheaper side",
+			a:    RecoveryErrorStatus{Cost: 100, NodeCount: 0, IsInError: true},
+			b:    RecoveryErrorStatus{Cost: 100 + recoveryMaxCostDifference + 1, NodeCount: 0, IsInError: true},
+			want: RecoveryComparisonTakeLeft,
+		},
+		{
+			name: "equal cost falls through to dynamic precedence",
+			a:    RecoveryErrorStatus{Cost: 50, DynPrec: 2, IsInError: true},
+			b:    RecoveryErrorStatus{Cost: 50, DynPrec: 1, IsInError: true},
+			want: RecoveryComparisonPreferLeft,
+		},
+		{
+			name: "fully equal is None",
+			a:    RecoveryErrorStatus{Cost: 50, DynPrec: 1, NodeCount: 4, IsInError: true},
+			b:    RecoveryErrorStatus{Cost: 50, DynPrec: 1, NodeCount: 9, IsInError: true},
+			want: RecoveryComparisonNone,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RecoveryCompareVersions(tc.a, tc.b)
+			if got != tc.want {
+				t.Fatalf("RecoveryCompareVersions(%+v, %+v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecoveryCompareVersionsMirrorsOnSwap is a property test: swapping a and
+// b must mirror TakeLeft<->TakeRight and PreferLeft<->PreferRight, and leave
+// None fixed, for any generated pair.
+func TestRecoveryCompareVersionsMirrorsOnSwap(t *testing.T) {
+	random := rand.New(rand.NewSource(0x6d6972_726f72))
+	mirror := map[RecoveryComparison]RecoveryComparison{
+		RecoveryComparisonTakeLeft:    RecoveryComparisonTakeRight,
+		RecoveryComparisonPreferLeft:  RecoveryComparisonPreferRight,
+		RecoveryComparisonNone:        RecoveryComparisonNone,
+		RecoveryComparisonPreferRight: RecoveryComparisonPreferLeft,
+		RecoveryComparisonTakeRight:   RecoveryComparisonTakeLeft,
+	}
+	for trial := 0; trial < 2000; trial++ {
+		a := RecoveryErrorStatus{
+			Cost: uint32(random.Intn(3000)), NodeCount: random.Intn(20),
+			DynPrec: random.Intn(7) - 3, IsInError: random.Intn(2) == 0,
+		}
+		b := RecoveryErrorStatus{
+			Cost: uint32(random.Intn(3000)), NodeCount: random.Intn(20),
+			DynPrec: random.Intn(7) - 3, IsInError: random.Intn(2) == 0,
+		}
+		forward := RecoveryCompareVersions(a, b)
+		backward := RecoveryCompareVersions(b, a)
+		if backward != mirror[forward] {
+			t.Fatalf("trial %d: RecoveryCompareVersions(a,b)=%v but RecoveryCompareVersions(b,a)=%v, want %v",
+				trial, forward, backward, mirror[forward])
+		}
+	}
+}

--- a/parsercore_phase0_recovery_cost_internal_test.go
+++ b/parsercore_phase0_recovery_cost_internal_test.go
@@ -1,0 +1,264 @@
+package gotreesitter
+
+import (
+	"math/rand"
+	"testing"
+
+	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
+)
+
+// parsercore_phase0_recovery_cost_internal_test.go carries campaign v7
+// tranche B3 stage S2's differential parity obligation (design section 6,
+// obligations 1/3; section 4 stage S2 gate): "property tests proving
+// equality with the production cost model on a shared corpus." It parses
+// (here: hand-builds, to reach ERROR/MISSING shapes deterministically)
+// production *Node trees, computes production cost via cNodeErrorCostLang,
+// builds the compact RecoveryCostNode records for the identical trees, and
+// asserts cost equality node for node -- not just at the root.
+//
+// This differential test must live in package gotreesitter, not in
+// internal/parsercorephase0: it needs same-package access to production's
+// unexported cNodeErrorCostLang/cCompareVersions (parser_recover_c.go), and
+// internal/parsercorephase0 cannot import this package (it is the
+// dependency-neutral compact core; this package imports it, not the other
+// way around).
+
+// compactRecoveryCostFixture is a minimal core.RecoveryCostSource backed by
+// a plain map, built by compactifyRecoveryCostTree below.
+type compactRecoveryCostFixture map[core.SubtreeID]core.RecoveryCostNode
+
+func (f compactRecoveryCostFixture) RecoveryCostNode(id core.SubtreeID) (core.RecoveryCostNode, error) {
+	node, ok := f[id]
+	if !ok {
+		return core.RecoveryCostNode{}, core.ErrRecoveryCostNodeMissing
+	}
+	return node, nil
+}
+
+// compactifyRecoveryCostTree walks a production *Node tree (reading the same
+// unexported fields cNodeErrorCostLang itself reads: children, symbol,
+// isExtra, isMissing, startByte/endByte, startPoint/endPoint.Row) and
+// publishes an equivalent compact RecoveryCostNode fixture, children before
+// parents. It returns the fixture, the root's SubtreeID, and a *Node ->
+// SubtreeID map for the node-for-node walk.
+func compactifyRecoveryCostTree(root *Node) (compactRecoveryCostFixture, core.SubtreeID, map[*Node]core.SubtreeID) {
+	fixture := compactRecoveryCostFixture{}
+	ids := map[*Node]core.SubtreeID{}
+	var next core.SubtreeID
+	var walk func(n *Node) core.SubtreeID
+	walk = func(n *Node) core.SubtreeID {
+		if n == nil {
+			return 0
+		}
+		childIDs := make([]core.SubtreeID, 0, len(n.children))
+		for _, c := range n.children {
+			childIDs = append(childIDs, walk(c))
+		}
+		next++
+		id := next
+		fixture[id] = core.RecoveryCostNode{
+			Symbol:    core.Symbol(n.symbol),
+			Extra:     n.isExtra(),
+			Missing:   n.isMissing(),
+			StartByte: n.startByte,
+			EndByte:   n.endByte,
+			StartRow:  n.startPoint.Row,
+			EndRow:    n.endPoint.Row,
+			Children:  childIDs,
+		}
+		ids[n] = id
+		return id
+	}
+	rootID := walk(root)
+	return fixture, rootID, ids
+}
+
+// recoveryCostTreeCursor advances byte offsets and rows left to right so
+// generated leaves and their auto-spanned parents (NewParentNode derives a
+// parent's span from its first/last child, tree.go's populateParentNode)
+// stay monotonic, like a real parse.
+type recoveryCostTreeCursor struct {
+	byteOffset uint32
+	row        uint32
+}
+
+// genRecoveryCostProductionTree builds a small random *Node tree via the
+// same public constructors production tests use for hand-built cost fixtures
+// (NewLeafNode/NewParentNode, glr_test.go's TestCNodeErrorCostScratchTracksEquivVersion),
+// mixing ordinary, ERROR, MISSING, and extra nodes.
+func genRecoveryCostProductionTree(random *rand.Rand, cursor *recoveryCostTreeCursor, symbolCount int, depth int) *Node {
+	isError := random.Intn(6) == 0
+	childCount := 0
+	if depth < 4 && random.Intn(3) == 0 {
+		childCount = 1 + random.Intn(3)
+	}
+	sym := Symbol(random.Intn(symbolCount))
+	if isError {
+		sym = errorSymbol
+	}
+
+	if childCount == 0 {
+		missing := !isError && random.Intn(8) == 0
+		startByte := cursor.byteOffset
+		width := uint32(random.Intn(5))
+		startRow := cursor.row
+		rowBump := uint32(0)
+		if random.Intn(5) == 0 {
+			rowBump = uint32(1 + random.Intn(2))
+		}
+		endByte := startByte + width
+		endRow := startRow + rowBump
+		cursor.byteOffset = endByte
+		cursor.row = endRow
+		leaf := NewLeafNode(sym, true, startByte, endByte, Point{Row: startRow}, Point{Row: endRow})
+		if missing {
+			leaf.setMissing(true)
+		} else if random.Intn(5) == 0 {
+			leaf.setExtra(true)
+		}
+		if random.Intn(4) == 0 {
+			cursor.byteOffset++
+		}
+		return leaf
+	}
+
+	children := make([]*Node, 0, childCount)
+	for i := 0; i < childCount; i++ {
+		children = append(children, genRecoveryCostProductionTree(random, cursor, symbolCount, depth+1))
+		if random.Intn(4) == 0 {
+			cursor.byteOffset++
+		}
+	}
+	parent := NewParentNode(sym, true, children, nil, 0)
+	if random.Intn(6) == 0 {
+		parent.setExtra(true)
+	}
+	return parent
+}
+
+// assertRecoveryCostNodeForNode walks n and its compact translation in
+// lockstep, asserting the compact unmemoized, compact memoized (cold, one
+// memo per node -- the strongest independent check), and production costs
+// all agree, for every node in the tree, not only the root.
+func assertRecoveryCostNodeForNode(t *testing.T, trial int, lang *Language, symbols []core.SelectedSymbolPolicy, fixture compactRecoveryCostFixture, ids map[*Node]core.SubtreeID, n *Node) {
+	t.Helper()
+	if n == nil {
+		return
+	}
+	id, ok := ids[n]
+	if !ok {
+		t.Fatalf("trial %d: node has no compact id", trial)
+	}
+	want := cNodeErrorCostLang(lang, n)
+
+	got, err := core.RecoveryNodeErrorCost(symbols, fixture, id)
+	if err != nil {
+		t.Fatalf("trial %d: RecoveryNodeErrorCost(id=%d): %v", trial, id, err)
+	}
+	if got != want {
+		t.Fatalf("trial %d: compact unmemoized cost for id %d = %d, want %d (production)", trial, id, got, want)
+	}
+
+	var memo core.RecoveryCostMemo
+	gotMemo, err := core.RecoveryNodeErrorCostMemo(symbols, fixture, &memo, id)
+	if err != nil {
+		t.Fatalf("trial %d: RecoveryNodeErrorCostMemo(id=%d): %v", trial, id, err)
+	}
+	if gotMemo != want {
+		t.Fatalf("trial %d: compact memoized cost for id %d = %d, want %d (production)", trial, id, gotMemo, want)
+	}
+
+	for _, c := range n.children {
+		assertRecoveryCostNodeForNode(t, trial, lang, symbols, fixture, ids, c)
+	}
+}
+
+// TestRecoveryCostCompactMatchesProductionNodeForNode is stage S2's parity
+// gate (design section 4): differential unit/property parity against
+// cNodeErrorCostLang, including the childless-ERROR-leaf rule and the cost
+// constants, on a shared corpus of generated tree shapes.
+func TestRecoveryCostCompactMatchesProductionNodeForNode(t *testing.T) {
+	const symbolCount = 12
+	lang := &Language{SymbolMetadata: make([]SymbolMetadata, symbolCount)}
+	symbols := make([]core.SelectedSymbolPolicy, symbolCount)
+	for i := range lang.SymbolMetadata {
+		visible := i%2 == 0
+		lang.SymbolMetadata[i] = SymbolMetadata{Visible: visible, Named: true}
+		symbols[i] = core.SelectedSymbolPolicy{Visible: visible, Named: true}
+	}
+
+	random := rand.New(rand.NewSource(0x5332_6c6f))
+	for trial := 0; trial < 400; trial++ {
+		cursor := &recoveryCostTreeCursor{}
+		root := genRecoveryCostProductionTree(random, cursor, symbolCount, 0)
+
+		fixture, _, ids := compactifyRecoveryCostTree(root)
+		assertRecoveryCostNodeForNode(t, trial, lang, symbols, fixture, ids, root)
+	}
+}
+
+// TestRecoveryCostConstantsMatchProduction pins the five cost weights
+// (parser_recover_c.go:52-58) and the max-cost-difference band
+// (parser_recover_c.go:62-69) against the compact port's exported values, so
+// a transcription slip fails loudly and independently of the behavioral
+// walk above.
+func TestRecoveryCostConstantsMatchProduction(t *testing.T) {
+	cases := []struct {
+		name      string
+		got, want uint32
+	}{
+		{"RecoveryCostPerRecovery", core.RecoveryCostPerRecovery, cErrCostPerRecovery},
+		{"RecoveryCostPerMissingTree", core.RecoveryCostPerMissingTree, cErrCostPerMissingTree},
+		{"RecoveryCostPerSkippedTree", core.RecoveryCostPerSkippedTree, cErrCostPerSkippedTree},
+		{"RecoveryCostPerSkippedLine", core.RecoveryCostPerSkippedLine, cErrCostPerSkippedLine},
+		{"RecoveryCostPerSkippedChar", core.RecoveryCostPerSkippedChar, cErrCostPerSkippedChar},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d (production)", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestRecoveryCompareVersionsMatchesProduction is exact-parity obligation 3
+// (design section 6): cCompareVersions tie-breaking, differentially tested
+// against the compact port across generated (cost, nodeCount, dynPrec,
+// isInError) tuples.
+func TestRecoveryCompareVersionsMatchesProduction(t *testing.T) {
+	toProduction := map[core.RecoveryComparison]cErrorComparison{
+		core.RecoveryComparisonTakeLeft:    cErrorComparisonTakeLeft,
+		core.RecoveryComparisonPreferLeft:  cErrorComparisonPreferLeft,
+		core.RecoveryComparisonNone:        cErrorComparisonNone,
+		core.RecoveryComparisonPreferRight: cErrorComparisonPreferRight,
+		core.RecoveryComparisonTakeRight:   cErrorComparisonTakeRight,
+	}
+	random := rand.New(rand.NewSource(0x74696531))
+	for trial := 0; trial < 3000; trial++ {
+		// Bias cost toward the tie-break band around recoveryMaxCostDifference
+		// (1800) so both the "clearly worse" and "close enough" arms fire
+		// often, not just the isInError short-circuits.
+		aCost := uint32(random.Intn(4000))
+		bCost := aCost + uint32(random.Intn(3600)) - 1800
+		if int32(bCost) < 0 {
+			bCost = uint32(random.Intn(4000))
+		}
+		a := cErrorStatus{
+			cost: aCost, nodeCount: random.Intn(15), dynPrec: random.Intn(5) - 2,
+			isInError: random.Intn(2) == 0,
+		}
+		b := cErrorStatus{
+			cost: bCost, nodeCount: random.Intn(15), dynPrec: random.Intn(5) - 2,
+			isInError: random.Intn(2) == 0,
+		}
+
+		coreA := core.RecoveryErrorStatus{Cost: a.cost, NodeCount: a.nodeCount, DynPrec: a.dynPrec, IsInError: a.isInError}
+		coreB := core.RecoveryErrorStatus{Cost: b.cost, NodeCount: b.nodeCount, DynPrec: b.dynPrec, IsInError: b.isInError}
+
+		want := cCompareVersions(a, b)
+		got := core.RecoveryCompareVersions(coreA, coreB)
+		if toProduction[got] != want {
+			t.Fatalf("trial %d: a=%+v b=%+v: RecoveryCompareVersions=%v (-> %v), want production %v",
+				trial, a, b, got, toProduction[got], want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add an inert recovery cost model over compact subtrees, with parity
property tests. Not wired.

`internal/parsercorephase0/recovery_cost.go` ports `cNodeErrorCostLang`,
`cSymbolVisibleLang`, and `cVersionStatus`/`cCompareVersions`
(`parser_recover_c.go`) to compact subtree records. No file outside
`recovery_cost.go` and its own tests calls the new code. A compile-time
AST ratchet test enforces this.

## Changes

- `internal/parsercorephase0/recovery_cost.go`: the cost model, a
  `SubtreeID`-keyed memo cache, and `RecoveryCompareVersions` (the
  tie-break comparator).
- `internal/parsercorephase0/recovery_cost_test.go`: unit and property
  tests for the cost model, the memo cache, and version-status
  comparison.
- `internal/parsercorephase0/recovery_cost_ratchet_test.go`: an
  AST-based ratchet. It fails if any other non-test file in the package
  references a `recovery_cost.go` declaration.
- `parsercore_phase0_recovery_cost_internal_test.go`: a root-package
  differential test. It builds random production `*Node` trees,
  translates each tree into compact `RecoveryCostNode` records, and
  asserts cost equality against production's `cNodeErrorCostLang`, node
  for node.
- `docs/perf-attribution.md`: records a stage S2 addendum. The
  regenerated receipt confirms the `recovery` component reads 0.0% on
  every canonical fixture.

## Testing

- `go build ./...` and `go vet ./...`, across every build-tag
  combination in use: default, `gts_parsercorephase0`,
  `gts_no_parsercorephase0`, `gts_workcount`,
  `gts_parsercorephase0,gts_workcount`,
  `gts_parsercorephase0,gts_parsercorephase0a`, and
  `gts_parsercorephase0_selectedstore_onepass`.
- `go test ./internal/parsercorephase0/ -count=1`, and again with
  `-race`.
- `go test . -count=1` (full root package).
- The attribution tool (`cgo_harness/attribution`), regenerated locally:
  the `recovery` component reads 0.0% on every lane and fixture.
- `GTS_ADMISSION_SCORECARD=1 go test -tags gts_parsercorephase0 -run
  TestAdmissionCandidateScorecard206 -v .`: unaffected.

## Scope

This stage adds no driver behavior. Stage S3 wires the ERROR-region
records this model reads. Stage S4 wires the recovery election that
reads `RecoveryErrorStatus` and `RecoveryCompareVersions`.
