### PR TITLE
Correct javascript declared-conflict witness diagnosis; pin the retention rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ for tags and release notes while still in `0.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the root-cause comment on the javascript declared-conflict
+  election witness test.
+  `grammargen/lr.go` already retains the `labeled_statement`/`_property_name`
+  GLR fork that the real tree-sitter-javascript grammar declares.
+  That fix landed 2026-03-16.
+  The shipped `javascript.bin` blob predates the fix by two weeks.
+  Nothing resynced the blob afterward, so the raw parse still diverges from
+  the C oracle today.
+  A new unit test pins the retention rule directly against the generator.
+  Regressions now surface without a blob rebuild.
+
 ### Changed
 
 - The condense-candidate dispatch path no longer passes a closure through

--- a/cgo_harness/javascript_election_local_parity_test.go
+++ b/cgo_harness/javascript_election_local_parity_test.go
@@ -53,11 +53,30 @@ func TestJavaScriptElectionRawCOracleParity(t *testing.T) {
 			// over cgo_harness/corpus_real/javascript): dispatch.javascript
 			// rewrites 7 positions in this exact file; the two dynamic-import
 			// witnesses above show no rewrites, so this is the live-firing shape.
-			// For `{ key: value }` at the start of a statement, the grammar
-			// table drops the action that would let the object-literal
-			// derivation survive as a live fork, keeping only the
-			// labeled-statement/block derivation, so the raw tree diverges
-			// from the C oracle here.
+			//
+			// For `{ key: value }` at the start of a statement, the C oracle
+			// forks between labeled_statement and an object-literal pair, then
+			// elects the object literal. The shipped javascript.bin blob still
+			// elects labeled_statement only, but the current generator source
+			// does not cause that: grammar.js declares
+			// [$.labeled_statement, $._property_name] in `conflicts`, and
+			// grammargen/lr.go's shiftReduceInConflictGroup already retains
+			// both actions for this exact shape (added 2026-03-16, commit
+			// bb6c8aa0; pinned by
+			// TestResolveShiftReduceKeepsLabeledStatementPropertyNameDeclaredConflict
+			// in grammargen/lr_conflict_resolution_test.go). The blob was last
+			// regenerated 2026-03-02, two weeks before that fix landed, and was
+			// never resynced afterward.
+			//
+			// Regenerating the blob is blocked by a separate, unrelated bug:
+			// grammars.AdaptScannerForLanguage corrupts the raw parse of a
+			// freshly regenerated javascript blob (early truncation, exposed
+			// supertype nodes) through the production loading path
+			// (grammars.JavascriptLanguage / grammars.LoadLanguage). This
+			// reproduces with no table-generation change at all. See
+			// hypha://m31labs/gotreesitter/object/spore.2026-08-02.pecan.javascript-blob-regen-scanner-corruption.
+			// wantDivergence stays true until both the blob resync and the
+			// scanner fix land.
 			name:           "corpus_real_small_functions",
 			source:         mustReadCorpusFile(t, "corpus_real/javascript/small__functions.js"),
 			wantDivergence: true,
@@ -96,7 +115,7 @@ func TestJavaScriptElectionRawCOracleParity(t *testing.T) {
 				if len(mismatches) == 0 {
 					t.Fatalf("expected %q to diverge from the C oracle, but the raw trees now match; the underlying table-generation fix landed -- flip wantDivergence to false and re-verify before shipping", test.name)
 				}
-				t.Skipf("known divergence from the C oracle, the grammar table drops the object-literal derivation before it can fork:\n%s", strings.Join(mismatches, "\n"))
+				t.Skipf("known divergence from the C oracle: the shipped javascript.bin blob predates the 2026-03-16 declared-conflict retention fix and was never resynced (see the witness comment above):\n%s", strings.Join(mismatches, "\n"))
 				return
 			}
 			if len(mismatches) != 0 {

--- a/grammargen/lr_conflict_resolution_test.go
+++ b/grammargen/lr_conflict_resolution_test.go
@@ -2955,3 +2955,49 @@ func TestResolveAuxToParentsUsesCachedReverseParents(t *testing.T) {
 		t.Fatalf("cached resolveAuxToParents(value_token1) = %v, want [0]", again)
 	}
 }
+
+// TestResolveShiftReduceKeepsLabeledStatementPropertyNameDeclaredConflict
+// pins the T1 election-table-parity witness (spec.a2-election-table-parity,
+// tranche T1): the real tree-sitter-javascript grammar.js declares
+//
+//	conflicts: $ => [ ..., [$.labeled_statement, $._property_name], ... ]
+//
+// because at statement position, `identifier ':'` right after `{` is
+// ambiguous between a labeled_statement (`label ':' body`) and an object
+// literal's pair (`_property_name ':' value`). On lookahead ':', the state
+// offers a SHIFT that continues labeled_statement's `label • ':' body` and a
+// REDUCE that completes `_property_name -> identifier`. Upstream's generator
+// keeps both actions (a GLR table entry) whenever precedence does not
+// resolve a declared-conflict pair; it never silently drops one side. This
+// test asserts resolveActionConflict does the same for the exact shape that
+// reaches it once shift/reduce metadata is separated (grammargen/lr.go
+// shiftReduceInConflictGroup, ~lr.go:3676-3709): shift LHS and reduce LHS
+// are different members of the same declared conflict group, so both
+// actions must survive so the runtime GLR engine (labeled_statement carries
+// prec.dynamic(-1); _property_name carries none) can elect the object
+// literal at merge time.
+func TestResolveShiftReduceKeepsLabeledStatementPropertyNameDeclaredConflict(t *testing.T) {
+	ng := &NormalizedGrammar{
+		Symbols: []SymbolInfo{
+			{Name: ":", Kind: SymbolTerminal},
+			{Name: "identifier", Kind: SymbolTerminal},
+			{Name: "labeled_statement", Kind: SymbolNonterminal, Visible: true, Named: true},
+			{Name: "_property_name", Kind: SymbolNonterminal},
+		},
+		Productions: []Production{
+			{LHS: 3, RHS: []int{1}}, // _property_name -> identifier
+		},
+		Conflicts: [][]int{{2, 3}}, // declared: [labeled_statement, _property_name]
+	}
+
+	got, err := resolveActionConflict(0, []lrAction{
+		{kind: lrShift, state: 10, lhsSym: 2}, // labeled_statement: label . ':' body
+		{kind: lrReduce, prodIdx: 0},          // _property_name -> identifier .
+	}, ng)
+	if err != nil {
+		t.Fatalf("resolveActionConflict: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("resolved actions = %+v, want both the labeled_statement shift and the _property_name reduce kept (declared conflict, GLR fork)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Corrects the root-cause comment on the javascript declared-conflict
  election witness test. The generator already retains the
  `labeled_statement`/`_property_name` GLR fork the real
  tree-sitter-javascript grammar declares (fixed 2026-03-16, commit
  bb6c8aa0). The shipped `javascript.bin` blob predates that fix and was
  never resynced, so the raw parse still diverges from the C oracle today.
- Adds `TestResolveShiftReduceKeepsLabeledStatementPropertyNameDeclaredConflict`,
  a fast generator-level unit test that pins the declared-conflict
  retention rule directly against `resolveActionConflict`, independent of
  any grammar blob.
- Ships no table-generation logic change and no grammar blob change.

## Test plan

- [x] `go build ./...`
- [x] `go test . -count=1`
- [x] `go test ./grammars -count=1`
- [x] `go test ./grammargen -run TestResolveShiftReduceKeepsLabeledStatementPropertyNameDeclaredConflict -v`
- [x] Local election parity (javascript, apex, ada) reproduces known,
      pre-existing skips with no regression
