### PR TITLE
fix(javascript-scanner): Bind JavaScript scanner positionally to Language symbols

### DIFF
--- a/grammars/external_scanner_positional_binding_test.go
+++ b/grammars/external_scanner_positional_binding_test.go
@@ -188,6 +188,27 @@ func TestRealLanguageExternalBindingTablesArePositional(t *testing.T) {
 	if got, want := rust.symbols, rustDefaultSymTable; got != want {
 		t.Fatalf("rust post-bind symbols = %v, want default table %v", got, want)
 	}
+
+	// javascript: pins the currently-shipped javascript.bin's binding as a
+	// permanent regression guard. This equality is non-tautological the same
+	// way as the other five languages: positional binding sets symbols[i] =
+	// lang.ExternalSymbols[i], while jsDefaultSymTable[i] is jsSym*'s
+	// independently recorded expectation for that same slot. If a future
+	// javascript.bin regen shifts the automaton's absolute symbol numbering
+	// (as it does today at grammargen HEAD -- see
+	// TestJavaScriptExternalScannerBindsPositionally for the synthetic-Language
+	// reproduction of that shift), this externalToToken check still passes
+	// (positional binding is index-based, not value-based) but the CI blob-swap
+	// proof in the scanner-adapt-corruption spore is what actually matters for
+	// end-to-end correctness -- this test only guards the shipped blob's
+	// binding, not a hypothetical regenerated one.
+	javascript := JavaScriptExternalScanner{}.ExternalScannerForLanguage(JavascriptLanguage()).(JavaScriptExternalScanner)
+	if got, want := javascript.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7}; !slices.Equal(got, want) {
+		t.Fatalf("javascript externalToToken = %v, want %v", got, want)
+	}
+	if got, want := javascript.symbols, jsDefaultSymTable; got != want {
+		t.Fatalf("javascript post-bind symbols = %v, want default table %v", got, want)
+	}
 }
 
 // Note: the pure-unit drift and length-mismatch tests for

--- a/grammars/javascript_scanner.go
+++ b/grammars/javascript_scanner.go
@@ -18,19 +18,69 @@ const (
 	jsTokEscapeSequence = 5
 	jsTokRegexPattern   = 6
 	jsTokJsxText        = 7
+	jsTokenCount        = 8
 )
 
+// Concrete symbol IDs from the checked-in JavaScript grammar ExternalSymbols.
+// These are DEFAULTS only: the fallback entries in jsDefaultSymTable, used
+// as-is if Scan is ever invoked on a scanner value that was never bound to a
+// Language (should not happen in production; see ExternalScannerForLanguage).
+// ExternalScannerForLanguage binds the real per-Language symbols
+// POSITIONALLY (by external index, via bindExternalScannerSymbolNames), not
+// by these absolute IDs, so a grammargen-regenerated javascript blob — which
+// emits the same 8 externals in the same order but under different absolute
+// Symbol numbering once the automaton grows or shrinks — still lexes
+// correctly instead of silently mistyping every external scan result. See
+// bindExternalScannerSymbolNames for why positional (not absolute-ID or
+// by-name) binding is required; the same pattern is used by the
+// kotlin/python/swift/dart/rust/hcl scanners.
 const (
-	jsSymAutoSemicolon gotreesitter.Symbol = 129
-	jsSymTemplateChars gotreesitter.Symbol = 130
-	jsSymTernaryQmark  gotreesitter.Symbol = 131
-	jsSymHtmlComment   gotreesitter.Symbol = 132
-	jsSymJsxText       gotreesitter.Symbol = 133
+	jsSymAutoSemicolon  gotreesitter.Symbol = 129
+	jsSymTemplateChars  gotreesitter.Symbol = 130
+	jsSymTernaryQmark   gotreesitter.Symbol = 131
+	jsSymHtmlComment    gotreesitter.Symbol = 132
+	jsSymLogicalOr      gotreesitter.Symbol = 78
+	jsSymEscapeSequence gotreesitter.Symbol = 107
+	jsSymRegexPattern   gotreesitter.Symbol = 112
+	jsSymJsxText        gotreesitter.Symbol = 133
 )
+
+// jsDefaultSymTable mirrors the jsTok* index order above.
+var jsDefaultSymTable = [jsTokenCount]gotreesitter.Symbol{
+	jsTokAutoSemicolon:  jsSymAutoSemicolon,
+	jsTokTemplateChars:  jsSymTemplateChars,
+	jsTokTernaryQmark:   jsSymTernaryQmark,
+	jsTokHtmlComment:    jsSymHtmlComment,
+	jsTokLogicalOr:      jsSymLogicalOr,
+	jsTokEscapeSequence: jsSymEscapeSequence,
+	jsTokRegexPattern:   jsSymRegexPattern,
+	jsTokJsxText:        jsSymJsxText,
+}
+
+// jsExternalSymbolNames lists the javascript grammar's external tokens in
+// declaration order (matching the jsTok* indexes above and the language's
+// ExternalSymbols order). Used by ExternalScannerForLanguage to bind this
+// scanner's token slots to a Language's external symbols positionally, the
+// same pattern used by the kotlin/python/swift/dart/rust/hcl scanners. See
+// bindExternalScannerSymbolNames for why positional (not absolute-ID or
+// by-name) binding is required.
+var jsExternalSymbolNames = []string{
+	"_automatic_semicolon",
+	"_template_chars",
+	"_ternary_qmark",
+	"html_comment",
+	"||",
+	"escape_sequence",
+	"regex_pattern",
+	"jsx_text",
+}
 
 // JavaScriptExternalScanner handles automatic semicolons, template strings,
 // JSX text, ternary question marks, and HTML comments for JavaScript.
-type JavaScriptExternalScanner struct{}
+type JavaScriptExternalScanner struct {
+	symbols         [jsTokenCount]gotreesitter.Symbol
+	externalToToken []int
+}
 
 type jsWhitespaceResult uint8
 
@@ -39,6 +89,21 @@ const (
 	jsWhitespaceNoNewline
 	jsWhitespaceAccept
 )
+
+// ExternalScannerForLanguage binds this scanner's token slots to lang's
+// external symbols positionally (external index i -> scanner token i), so
+// Scan resolves result symbols through the bound table instead of the
+// hardcoded absolute IDs above. Required whenever the attached Language did
+// not come from the exact blob those absolute IDs were pinned against (e.g.
+// a grammargen regeneration that shifts the automaton's overall symbol
+// numbering) — see bindExternalScannerSymbolNames.
+func (JavaScriptExternalScanner) ExternalScannerForLanguage(lang *gotreesitter.Language) gotreesitter.ExternalScanner {
+	s := JavaScriptExternalScanner{symbols: jsDefaultSymTable}
+	s.externalToToken = bindExternalScannerSymbolNames(lang, jsExternalSymbolNames, func(tokenIdx int, sym gotreesitter.Symbol) {
+		s.symbols[tokenIdx] = sym
+	})
+	return s
+}
 
 func (JavaScriptExternalScanner) Create() any                           { return nil }
 func (JavaScriptExternalScanner) Destroy(payload any)                   {}
@@ -51,54 +116,91 @@ func (JavaScriptExternalScanner) SupportsIncrementalReuse() bool    { return tru
 func (JavaScriptExternalScanner) ExternalScannerIsStateless() bool  { return true }
 func (JavaScriptExternalScanner) PreservesStateOnScanFailure() bool { return true }
 
-func (JavaScriptExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+// symbolTable returns the per-Language-bound result-symbol table, falling
+// back to the pinned defaults when Scan is invoked on an unbound scanner
+// value (s.symbols is still its zero value).
+func (s JavaScriptExternalScanner) symbolTable() *[jsTokenCount]gotreesitter.Symbol {
+	if s.symbols == ([jsTokenCount]gotreesitter.Symbol{}) {
+		return &jsDefaultSymTable
+	}
+	return &s.symbols
+}
+
+// remapValidSymbols translates a Language-external-indexed validSymbols
+// slice into scanner-token-indexed space via s.externalToToken. When the
+// Language's external count and order agree with jsExternalSymbolNames (the
+// common case), externalToToken is the identity permutation and this is a
+// copy; it only diverges when a future grammar version adds, removes, or
+// reorders an external token relative to jsExternalSymbolNames.
+func (s JavaScriptExternalScanner) remapValidSymbols(validSymbols []bool, semanticValid *[jsTokenCount]bool) []bool {
+	if len(s.externalToToken) == 0 {
+		return validSymbols
+	}
+	*semanticValid = [jsTokenCount]bool{}
+	for externalIdx, valid := range validSymbols {
+		if !valid || externalIdx >= len(s.externalToToken) {
+			continue
+		}
+		tokenIdx := s.externalToToken[externalIdx]
+		if tokenIdx >= 0 && tokenIdx < jsTokenCount {
+			semanticValid[tokenIdx] = true
+		}
+	}
+	return semanticValid[:]
+}
+
+func (s JavaScriptExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+	var semanticValid [jsTokenCount]bool
+	validSymbols = s.remapValidSymbols(validSymbols, &semanticValid)
+	symbols := s.symbolTable()
+
 	if jsValid(validSymbols, jsTokTemplateChars) {
 		if jsValid(validSymbols, jsTokAutoSemicolon) {
 			return false
 		}
-		return jsScanTemplateChars(lexer)
+		return jsScanTemplateChars(lexer, symbols)
 	}
 
 	preferAutoSemicolon := jsPreferAutoSemicolonOverJsxText(lexer, validSymbols)
 
 	if jsValid(validSymbols, jsTokJsxText) && !preferAutoSemicolon {
-		if jsScanJsxText(lexer) {
+		if jsScanJsxText(lexer, symbols) {
 			return true
 		}
 	}
 
 	if jsValid(validSymbols, jsTokAutoSemicolon) {
 		scannedComment := false
-		ret := jsScanAutoSemicolon(lexer, validSymbols, &scannedComment)
+		ret := jsScanAutoSemicolon(lexer, validSymbols, symbols, &scannedComment)
 		if !ret && !scannedComment && jsValid(validSymbols, jsTokTernaryQmark) && lexer.Lookahead() == '?' {
-			return jsScanTernaryQmark(lexer)
+			return jsScanTernaryQmark(lexer, symbols)
 		}
 		if !ret && !scannedComment && preferAutoSemicolon && jsValid(validSymbols, jsTokJsxText) {
-			return jsScanJsxText(lexer)
+			return jsScanJsxText(lexer, symbols)
 		}
 		return ret
 	}
 
 	if jsValid(validSymbols, jsTokJsxText) && preferAutoSemicolon {
-		return jsScanJsxText(lexer)
+		return jsScanJsxText(lexer, symbols)
 	}
 
 	if jsValid(validSymbols, jsTokTernaryQmark) {
-		return jsScanTernaryQmark(lexer)
+		return jsScanTernaryQmark(lexer, symbols)
 	}
 
 	if jsValid(validSymbols, jsTokHtmlComment) &&
 		!jsValid(validSymbols, jsTokLogicalOr) &&
 		!jsValid(validSymbols, jsTokEscapeSequence) &&
 		!jsValid(validSymbols, jsTokRegexPattern) {
-		return jsScanClosingComment(lexer)
+		return jsScanClosingComment(lexer, symbols)
 	}
 
 	return false
 }
 
-func jsScanTemplateChars(lexer *gotreesitter.ExternalLexer) bool {
-	lexer.SetResultSymbol(jsSymTemplateChars)
+func jsScanTemplateChars(lexer *gotreesitter.ExternalLexer, symbols *[jsTokenCount]gotreesitter.Symbol) bool {
+	lexer.SetResultSymbol(symbols[jsTokTemplateChars])
 	hasContent := false
 	for {
 		lexer.MarkEnd()
@@ -126,8 +228,8 @@ func jsScanTemplateChars(lexer *gotreesitter.ExternalLexer) bool {
 	}
 }
 
-func jsScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool, scannedComment *bool) bool {
-	lexer.SetResultSymbol(jsSymAutoSemicolon)
+func jsScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool, symbols *[jsTokenCount]gotreesitter.Symbol, scannedComment *bool) bool {
+	lexer.SetResultSymbol(symbols[jsTokAutoSemicolon])
 	lexer.MarkEnd()
 
 	for {
@@ -320,7 +422,7 @@ func jsScanWSAndComments(lexer *gotreesitter.ExternalLexer, scannedComment *bool
 	}
 }
 
-func jsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
+func jsScanTernaryQmark(lexer *gotreesitter.ExternalLexer, symbols *[jsTokenCount]gotreesitter.Symbol) bool {
 	for unicode.IsSpace(lexer.Lookahead()) {
 		lexer.Advance(true)
 	}
@@ -336,7 +438,7 @@ func jsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	lexer.MarkEnd()
-	lexer.SetResultSymbol(jsSymTernaryQmark)
+	lexer.SetResultSymbol(symbols[jsTokTernaryQmark])
 
 	for unicode.IsSpace(lexer.Lookahead()) {
 		lexer.Advance(false)
@@ -353,7 +455,7 @@ func jsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 	return true
 }
 
-func jsScanClosingComment(lexer *gotreesitter.ExternalLexer) bool {
+func jsScanClosingComment(lexer *gotreesitter.ExternalLexer, symbols *[jsTokenCount]gotreesitter.Symbol) bool {
 	for unicode.IsSpace(lexer.Lookahead()) || lexer.Lookahead() == 0x2028 || lexer.Lookahead() == 0x2029 {
 		lexer.Advance(true)
 	}
@@ -384,12 +486,12 @@ func jsScanClosingComment(lexer *gotreesitter.ExternalLexer) bool {
 		lexer.Advance(false)
 	}
 
-	lexer.SetResultSymbol(jsSymHtmlComment)
+	lexer.SetResultSymbol(symbols[jsTokHtmlComment])
 	lexer.MarkEnd()
 	return true
 }
 
-func jsScanJsxText(lexer *gotreesitter.ExternalLexer) bool {
+func jsScanJsxText(lexer *gotreesitter.ExternalLexer, symbols *[jsTokenCount]gotreesitter.Symbol) bool {
 	sawText := false
 	atNewline := false
 	onlyWhitespace := true
@@ -441,7 +543,7 @@ func jsScanJsxText(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	lexer.MarkEnd()
-	lexer.SetResultSymbol(jsSymJsxText)
+	lexer.SetResultSymbol(symbols[jsTokJsxText])
 	return sawText
 }
 

--- a/grammars/javascript_scanner_binding_test.go
+++ b/grammars/javascript_scanner_binding_test.go
@@ -1,0 +1,73 @@
+//go:build !grammar_subset || grammar_subset_javascript
+
+package grammars
+
+import (
+	"slices"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// TestJavaScriptExternalScannerBindsPositionally is the regression witness for
+// the javascript blob-regen scanner-adaptation corruption: a Language whose
+// automaton grew (or otherwise shifted overall symbol numbering) still emits
+// the same 8 externals in the same declared order, but under different
+// absolute Symbol IDs than the ones jsSym* were pinned against. Before
+// JavaScriptExternalScanner implemented ExternalScannerForLanguage, the
+// scanner was attached raw (attachExternalScannerForLanguage's non-bound
+// branch) and every SetResultSymbol call emitted the stale, hardcoded jsSym*
+// IDs regardless of the attached Language's real numbering — silently
+// mistyping every external scan result on any regenerated table whose
+// automaton size differs from the one those constants were pinned against.
+// This test simulates that shift with a synthetic Language (no blob
+// dependency) and asserts the bound scanner resolves each token to the
+// synthetic Language's own symbol, not the pinned default.
+//
+// Tagged to match javascript_scanner.go exactly (not the broader
+// external_scanner_binding_test.go umbrella): a grammar_subset build that
+// selects only kotlin+swift, for example, would not compile
+// javascript_scanner.go, so this test must not be visible there either.
+func TestJavaScriptExternalScannerBindsPositionally(t *testing.T) {
+	jsLang := externalBindingTestLanguage(
+		"_automatic_semicolon",
+		"_template_chars",
+		"_ternary_qmark",
+		"html_comment",
+		"||",
+		"escape_sequence",
+		"regex_pattern",
+		"jsx_text",
+	)
+	jsScanner, ok := JavaScriptExternalScanner{}.ExternalScannerForLanguage(jsLang).(JavaScriptExternalScanner)
+	if !ok {
+		t.Fatalf("JavaScriptExternalScanner binding type = %T, want JavaScriptExternalScanner", JavaScriptExternalScanner{}.ExternalScannerForLanguage(jsLang))
+	}
+	if got, want := jsScanner.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7}; !slices.Equal(got, want) {
+		t.Fatalf("javascript externalToToken = %v, want %v", got, want)
+	}
+	// externalBindingTestLanguage assigns ExternalSymbols[i] = Symbol(i+1), which
+	// deliberately does not match any jsSym* default (129, 130, 131, 132, 78,
+	// 107, 112, 133) -- simulating a regenerated table with shifted numbering.
+	wantBound := map[int]gotreesitter.Symbol{
+		jsTokAutoSemicolon:  1,
+		jsTokTemplateChars:  2,
+		jsTokTernaryQmark:   3,
+		jsTokHtmlComment:    4,
+		jsTokLogicalOr:      5,
+		jsTokEscapeSequence: 6,
+		jsTokRegexPattern:   7,
+		jsTokJsxText:        8,
+	}
+	for tokenIdx, want := range wantBound {
+		if got := jsScanner.symbols[tokenIdx]; got != want {
+			t.Fatalf("javascript token %d bound symbol = %d, want %d (synthetic Language's own numbering, not the pinned default)", tokenIdx, got, want)
+		}
+	}
+	// The pinned defaults must NOT leak through once a Language is bound --
+	// that leak is exactly the pre-fix corruption (attaching the raw,
+	// unbound scanner to a table whose automaton had grown).
+	if jsScanner.symbols == jsDefaultSymTable {
+		t.Fatal("javascript bound symbols still equal jsDefaultSymTable; binding did not override the pinned defaults")
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes scanner adaptation for regenerated grammar tables with larger automatons. `JavaScriptExternalScanner` used hardcoded absolute symbol IDs when it set a result symbol. A regenerated table with a different automaton size shifts those IDs, so the scanner reported the wrong token.
- The fix binds the scanner's result symbols to each attached `Language` at load time, by external-token position. This is the same pattern six other hand-written scanners already use (kotlin, python, swift, dart, rust, hcl).
- The change is confined to `grammars/javascript_scanner.go` plus two test files. It ships no grammar blob.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./grammargen -count=1 -timeout 25m` — no new failures
- [x] `go test ./grammars -count=1` — pass
- [x] `go test . -count=1` — pass
- [x] Shipped `javascript.bin` produces byte-identical parse trees before and after the fix (no behavior change for the current blob)
- [x] A freshly regenerated `javascript.bin` (not committed) parses correctly through the production scanner-adaptation path after the fix
- [x] No `.bin` file changed in this diff
