### PR TITLE
update(parsercore): promote v2 alternative-set predicate to deciding proof

### DIFF
--- a/admission_switch_candidate_work_export_test.go
+++ b/admission_switch_candidate_work_export_test.go
@@ -6,10 +6,12 @@ package gotreesitter
 // converged-reduction-split-drop counters recorded by p's last candidate-route
 // parse attempt, whether that attempt routed or declined. ConvergedReduction
 // SplitDrops counts every no-action head dropped that descended from a
-// converged-path reduction split; SelectedLineageDrops counts the subset that
-// carried an exact unselected-to-selected lineage proof. A routed parse always
-// has drops == proved (the accept gate requires it); a mid-run decline can
-// leave the two unequal at the point of the last completed drop.
+// converged-path reduction split; ConvergedCoverageDrops counts the subset
+// whose dropped header's recorded alternative set was contained in one
+// surviving header's recorded set (spec.b4b-alternative-set.v2 section 5,
+// renamed from SelectedLineageDrops at stage 2b). A routed parse always has
+// drops == proved (the accept gate requires it); a mid-run decline can leave
+// the two unequal at the point of the last completed drop.
 //
 // ok is false when p never attempted the candidate route (no cached runner) or
 // the run never reached an acceptance receipt. The runner is per-Parser and
@@ -24,5 +26,5 @@ func AdmissionCandidateConvergedSplitWorkForTest(p *Parser) (drops, proved uint6
 		return 0, 0, false
 	}
 	work := runner.scheduler.receipt.Acceptance.Work
-	return work.ConvergedReductionSplitDrops, work.SelectedLineageDrops, true
+	return work.ConvergedReductionSplitDrops, work.ConvergedCoverageDrops, true
 }

--- a/admission_switch_erlang_converged_split_probe_test.go
+++ b/admission_switch_erlang_converged_split_probe_test.go
@@ -45,7 +45,7 @@ import (
 // has no matching selected survivor of the same lineage (an unprovable drop).
 // The paired control below proves the certificate is exactly what makes that
 // same source route WITH the certificate: it accepts via the artifact escape
-// with ConvergedReductionSplitDrops=1, SelectedLineageDrops=0 (an accepted,
+// with ConvergedReductionSplitDrops=1, ConvergedCoverageDrops=0 (an accepted,
 // unprovable drop). The trigger is any macro that expands to a top-level
 // function definition -- even a single clause with no guard; a plain,
 // non-macro function with the identical clauses routes cleanly. Macro-defined
@@ -405,7 +405,7 @@ func TestAdmissionCandidateErlangConvergedSplitAdversarialProbe(t *testing.T) {
 				t.Skipf(
 					"campaign-v7 B4d finding: erlang's CompactConvergedReductionSplitDropsCertified grant is load-bearing for this source. "+
 						"Without the certificate: declined (%s). "+
-						"With the certificate: routed only via the artifact escape with an unproved drop (ConvergedReductionSplitDrops=%d, SelectedLineageDrops=%d). "+
+						"With the certificate: routed only via the artifact escape with an unproved drop (ConvergedReductionSplitDrops=%d, ConvergedCoverageDrops=%d). "+
 						"Erlang's corpus-zero dependence finding (hypha spore b4-provenance-families) is incomplete for macro-expanded top-level function definitions. "+
 						"The grant in grammars/runtime_profiles.go is NOT retired; retirement is blocked pending a B4b converged-alternative-set proof.",
 					reason, certDrops, certProved,

--- a/cgo_harness/work_count_board_test.go
+++ b/cgo_harness/work_count_board_test.go
@@ -21,7 +21,7 @@ const (
 	workCountBoardGoBackendEnv            = "GTS_WORK_COUNT_GO_BACKEND"
 	workCountBoardGoProduction            = "production"
 	workCountBoardGoParserCore            = "parsercore_phase0"
-	workCountBoardParserCoreChildSchema   = "gts-work-count-parsercore-child/v3"
+	workCountBoardParserCoreChildSchema   = "gts-work-count-parsercore-child/v4"
 	workCountBoardParserCoreEngine        = "go-compact-parsercore-phase0-tagged-diagnostic"
 	workCountBoardSchema                  = "gts-work-count-board/v5"
 	workCountBoardContractSchema          = "gts-work-count-board-contract/v3"

--- a/internal/parsercorephase0/alternative_set_test.go
+++ b/internal/parsercorephase0/alternative_set_test.go
@@ -21,11 +21,14 @@ func TestNewAlternativeSetMember(t *testing.T) {
 	if got := NewAlternativeSetMember(0, 0); got != (AlternativeSet{}) {
 		t.Fatalf("NewAlternativeSetMember(0, 0) = %+v, want empty set", got)
 	}
-	// The recording gate defaults to off (GTS_B4B_SHADOW_CENSUS unset): a
-	// nonzero event still returns the empty set until recording is enabled.
-	if got := NewAlternativeSetMember(7, 0); got != (AlternativeSet{}) {
-		t.Fatalf("NewAlternativeSetMember(7, 0) with recording disabled = %+v, want empty set", got)
-	}
+	// Stage 2b made recording unconditional in production (the v2 deciding
+	// proof requires a populated set); the disabled path is test-only.
+	func() {
+		defer SetAlternativeSetRecordingEnabledForTest(false)()
+		if got := NewAlternativeSetMember(7, 0); got != (AlternativeSet{}) {
+			t.Fatalf("NewAlternativeSetMember(7, 0) with recording explicitly disabled = %+v, want empty set", got)
+		}
+	}()
 	defer SetAlternativeSetRecordingEnabledForTest(true)()
 	compact := &Core{}
 	set := NewAlternativeSetMember(7, 0)
@@ -303,6 +306,239 @@ func TestAlternativeSetUnionPropagatesOverflow(t *testing.T) {
 	}
 }
 
+// buildOverflowedAlternativeSetForTest inserts alternativeSetHardCap+1 real
+// members starting at start, so the returned set overflowed by genuine
+// natural growth (not by manual flag manipulation), for tests that need a
+// realistic overflowed source or destination.
+func buildOverflowedAlternativeSetForTest(t *testing.T, compact *Core, start uint32) AlternativeSet {
+	t.Helper()
+	var set AlternativeSet
+	for member := start; member < start+alternativeSetHardCap+1; member++ {
+		compact.alternativeSetInsert(&set, member)
+	}
+	if !set.Overflowed() {
+		t.Fatal("setup did not overflow the set")
+	}
+	return set
+}
+
+// TestAlternativeSetInsertFrozenOnceOverflowed pins the tightened invariant
+// the stage 2b fast path relies on: once alternativeSetFlagOverflowed is
+// set -- by any path, including propagation onto a set whose count never
+// itself reached alternativeSetHardCap -- the set is permanently frozen.
+// Manually marks a two-member set overflowed (the shape a union propagation
+// produces, spec.b4b-alternative-set.v2 section 3.2) to isolate
+// alternativeSetInsert's own short-circuit from alternativeSetUnion's.
+func TestAlternativeSetInsertFrozenOnceOverflowed(t *testing.T) {
+	compact := &Core{}
+	var set AlternativeSet
+	compact.alternativeSetInsert(&set, 5)
+	compact.alternativeSetInsert(&set, 9)
+	set.flags |= alternativeSetFlagOverflowed
+	before := set
+
+	if compact.alternativeSetInsert(&set, 7) {
+		t.Fatal("insert into an overflowed set reported a change")
+	}
+	if set != before {
+		t.Fatalf("overflowed set mutated by a declined insert: got %+v, want %+v", set, before)
+	}
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint32{5, 9}) {
+		t.Fatalf("overflowed set members = %v, want [5 9] (frozen at its pre-overflow content)", got)
+	}
+}
+
+// TestAlternativeSetUnionNoopWhenDestinationAlreadyOverflowed pins the
+// destination-side freeze: an already-overflowed dst can never change
+// again, regardless of what src offers, and the check runs before any
+// member resolution on either side.
+func TestAlternativeSetUnionNoopWhenDestinationAlreadyOverflowed(t *testing.T) {
+	compact := &Core{}
+	dst := buildOverflowedAlternativeSetForTest(t, compact, 1)
+	before := dst
+	beforeMembers := alternativeSetMembersForTest(t, compact, dst)
+
+	var src AlternativeSet
+	compact.alternativeSetInsert(&src, 9000)
+	if compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("union into an already-overflowed destination reported a change")
+	}
+	if dst != before {
+		t.Fatalf("already-overflowed destination mutated: got %+v, want %+v", dst, before)
+	}
+	if got := alternativeSetMembersForTest(t, compact, dst); !slices.Equal(got, beforeMembers) {
+		t.Fatalf("already-overflowed destination members = %v, want %v (unchanged)", got, beforeMembers)
+	}
+}
+
+// TestAlternativeSetUnionFreezesDestinationAtCurrentMembersWhenSourceOverflowed
+// pins the coordinator-specified semantics for the asymmetric case: an
+// overflowed source has incomplete true membership, so the sound
+// conclusion is that dst's own true union is unknowable beyond what dst
+// already recorded. dst becomes overflowed-and-done at exactly its
+// pre-union members -- it does not partially merge src's known members
+// first, unlike the pre-stage-2b behavior.
+func TestAlternativeSetUnionFreezesDestinationAtCurrentMembersWhenSourceOverflowed(t *testing.T) {
+	compact := &Core{}
+	var dst AlternativeSet
+	compact.alternativeSetInsert(&dst, 11)
+	compact.alternativeSetInsert(&dst, 22)
+	beforeMembers := alternativeSetMembersForTest(t, compact, dst)
+
+	src := buildOverflowedAlternativeSetForTest(t, compact, 1)
+
+	if !compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("union with an overflowed source reported no change")
+	}
+	if !dst.Overflowed() {
+		t.Fatal("destination did not become overflowed")
+	}
+	if got := alternativeSetMembersForTest(t, compact, dst); !slices.Equal(got, beforeMembers) {
+		t.Fatalf("destination members after overflow propagation = %v, want %v (frozen at pre-union content, not merged with src)", got, beforeMembers)
+	}
+}
+
+// TestAlternativeSetUnionBothOverflowedIsNoop pins the case where both
+// sides are already overflowed: the destination-side freeze check alone
+// must short-circuit before even inspecting src.
+func TestAlternativeSetUnionBothOverflowedIsNoop(t *testing.T) {
+	compact := &Core{}
+	dst := buildOverflowedAlternativeSetForTest(t, compact, 1)
+	src := buildOverflowedAlternativeSetForTest(t, compact, 1000)
+	before := dst
+
+	if compact.alternativeSetUnion(&dst, src) {
+		t.Fatal("union of two already-overflowed sets reported a change")
+	}
+	if dst != before {
+		t.Fatalf("already-overflowed destination mutated by a both-overflowed union: got %+v, want %+v", dst, before)
+	}
+}
+
+// TestAlternativeSetInsertOverflowFlagRestoredOnJournalRollback pins that a
+// transaction crossing the hard cap and then rolling back restores both the
+// overflow flag and the recorded count exactly, matching the generic
+// nodeLineageJournal mechanism (core.go's rollback loop restores
+// set.count/set.flags/set.spillRef from the pre-mutation snapshot
+// unconditionally, independent of what triggered the mutation).
+func TestAlternativeSetInsertOverflowFlagRestoredOnJournalRollback(t *testing.T) {
+	defer SetAlternativeSetRecordingEnabledForTest(true)()
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		for member := uint16(1); member <= alternativeSetHardCap; member++ {
+			if err := compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(member, 0), false); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.set.Overflowed() || before.set.Len() != alternativeSetHardCap {
+		t.Fatalf("setup did not reach exactly the hard cap unoverflowed: set=%+v", before.set)
+	}
+	beforeSet := before.set
+
+	sentinel := errors.New("rollback overflow insert")
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(alternativeSetHardCap+1, 0), false); err != nil {
+			return err
+		}
+		mid, err := compact.nodeLineage(head.Node)
+		if err != nil {
+			return err
+		}
+		if !mid.set.Overflowed() {
+			return errors.New("mid-transaction insert did not overflow")
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback err = %v, want %v", err, sentinel)
+	}
+	after, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.set != beforeSet {
+		t.Fatalf("rolled-back set = %+v, want %+v", after.set, beforeSet)
+	}
+	if after.set.Overflowed() {
+		t.Fatal("rollback left the overflow flag set")
+	}
+	if compact.alternativeSetInsert(&after.set, alternativeSetHardCap+2) == false {
+		t.Fatal("rolled-back set incorrectly still refuses new members as if overflowed")
+	}
+}
+
+// TestAlternativeSetUnionOverflowPropagationRestoredOnJournalRollback pins
+// the same rollback exactness for the propagation path: a transaction that
+// unions in an overflowed source (freezing the destination) and then rolls
+// back must restore the destination's pre-transaction flag and members,
+// not leave it overflowed.
+func TestAlternativeSetUnionOverflowPropagationRestoredOnJournalRollback(t *testing.T) {
+	defer SetAlternativeSetRecordingEnabledForTest(true)()
+	compact := newTinyCore(t, 4)
+	head, err := compact.Seed(1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		return compact.RecordHeadLineageSetOwned(owner, head, NewAlternativeSetMember(11, 0), false)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeSet := before.set
+	if beforeSet.Overflowed() {
+		t.Fatal("setup destination is already overflowed")
+	}
+
+	overflowedSource := buildOverflowedAlternativeSetForTest(t, compact, 1000)
+
+	sentinel := errors.New("rollback overflow union")
+	err = compact.ApplySchedulerAtomic(func(owner SchedulerTransactionToken) error {
+		if err := compact.RecordHeadLineageSetOwned(owner, head, overflowedSource, false); err != nil {
+			return err
+		}
+		mid, err := compact.nodeLineage(head.Node)
+		if err != nil {
+			return err
+		}
+		if !mid.set.Overflowed() {
+			return errors.New("mid-transaction union did not propagate overflow")
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("rollback err = %v, want %v", err, sentinel)
+	}
+	after, err := compact.nodeLineage(head.Node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.set != beforeSet {
+		t.Fatalf("rolled-back set = %+v, want %+v", after.set, beforeSet)
+	}
+	if after.set.Overflowed() {
+		t.Fatal("rollback left the propagated overflow flag set")
+	}
+	if got := alternativeSetMembersForTest(t, compact, after.set); !slices.Equal(got, []uint32{packAlternativeSetMember(11, 0)}) {
+		t.Fatalf("rolled-back members = %v, want [pack(11,0)]", got)
+	}
+}
+
 func TestAlternativeSetMembersRejectsUnresolvableSpill(t *testing.T) {
 	compact := &Core{}
 	bad := AlternativeSet{}
@@ -516,11 +752,14 @@ func TestAlternativeSetEstablishmentBranchOrdinalTracksOutputIndex(t *testing.T)
 	}
 }
 
-// TestAlternativeSetRecordingDisabledByDefaultLeavesSetEmptyButScalarIntact
-// pins the always-off-by-default recording gate (GTS_B4B_SHADOW_CENSUS):
-// with no override, establishment records no member at all, while the
+// TestAlternativeSetRecordingExplicitlyDisabledLeavesSetEmptyButScalarIntact
+// pins the recording gate's disabled path: stage 2b turned recording
+// unconditional in production (the v2 deciding proof requires a populated
+// set), so the only way to observe the gate off is the test-only override.
+// With it forced off, establishment records no member at all, while the
 // existing scalar rank/lineage mechanism is completely unaffected.
-func TestAlternativeSetRecordingDisabledByDefaultLeavesSetEmptyButScalarIntact(t *testing.T) {
+func TestAlternativeSetRecordingExplicitlyDisabledLeavesSetEmptyButScalarIntact(t *testing.T) {
+	defer SetAlternativeSetRecordingEnabledForTest(false)()
 	compact := newTinyCore(t, 4)
 	head, err := compact.Seed(1, 0)
 	if err != nil {

--- a/internal/parsercorephase0/clean_path_rank_test.go
+++ b/internal/parsercorephase0/clean_path_rank_test.go
@@ -155,6 +155,7 @@ func newAmbiguousPrefixRankFixture(tb testing.TB) (*Core, Head) {
 }
 
 func TestCleanPathRankUsesScoreBeforeDepth(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
 		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60},
 		{predecessor: 2, prefixScore: []int64{2, 2}, gotoState: 61},
@@ -174,6 +175,7 @@ func TestCleanPathRankUsesScoreBeforeDepth(t *testing.T) {
 }
 
 func TestCleanPathRankUsesDepthAfterEqualScore(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
 		{predecessor: 1, prefixScore: []int64{3}, gotoState: 60},
 		{predecessor: 2, prefixScore: []int64{1, 2}, gotoState: 61},
@@ -193,6 +195,7 @@ func TestCleanPathRankUsesDepthAfterEqualScore(t *testing.T) {
 }
 
 func TestCleanPathRankExactCrossPathTieIsUnknown(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
 		{predecessor: 1, prefixScore: []int64{3}, gotoState: 60},
 		{predecessor: 2, prefixScore: []int64{3}, gotoState: 61},
@@ -212,6 +215,7 @@ func TestCleanPathRankExactCrossPathTieIsUnknown(t *testing.T) {
 }
 
 func TestCleanPathRankAggregatesSelectedOccurrence(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
 		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60},
 		{predecessor: 2, prefixScore: []int64{4}, gotoState: 60},
@@ -226,6 +230,7 @@ func TestCleanPathRankAggregatesSelectedOccurrence(t *testing.T) {
 }
 
 func TestCleanPathRankKeepsSamePathPrefixTieKnown(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newAmbiguousPrefixRankFixture(t)
 	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
 	if err != nil {
@@ -242,6 +247,7 @@ func TestCleanPathRankKeepsSamePathPrefixTieKnown(t *testing.T) {
 }
 
 func TestCleanPathRankPrefixCapIsUnknown(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newAmbiguousPrefixRankFixture(t)
 	compact.limits.MaxDerivations = 1
 	outputs, err := compact.ReduceOutputs(head, 9, 0, ForkOrder{})
@@ -256,6 +262,7 @@ func TestCleanPathRankPrefixCapIsUnknown(t *testing.T) {
 }
 
 func TestCleanPathRankExternalPayloadIsUnknown(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
 		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60, external: true},
 		{predecessor: 2, prefixScore: []int64{2}, gotoState: 61},
@@ -303,6 +310,7 @@ func TestCleanPathRankSteadyStateDoesNotAllocate(t *testing.T) {
 }
 
 func TestCleanPathRankPanicRollsBackAndRetries(t *testing.T) {
+	defer SetCleanPathRankWalkEnabledForTest(true)()
 	compact, head := newCleanPathRankFixture(t, []cleanPathRankBranch{
 		{predecessor: 1, prefixScore: []int64{5}, gotoState: 60},
 		{predecessor: 2, prefixScore: []int64{1, 2}, gotoState: 61},

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -469,14 +469,15 @@ func AlternativeSetMemberEvent(member uint32) uint16 { return uint16(member >> 1
 func AlternativeSetMemberBranch(member uint32) uint16 { return uint16(member) }
 
 // alternativeSetRecordingEnabledOnce and alternativeSetRecordingEnabledVal
-// cache GTS_B4B_SHADOW_CENSUS, the same switch that gates the shadow census
-// itself. No production or stage-1 diagnostic decision reads a recorded
-// AlternativeSet except that census, so recording is off by default and
-// only turns on with it -- this package has no way to reach the census's
-// own copy of the flag (parsercorephase0 has no dependency on the higher
-// package that defines it), so it caches an independent read of the same
-// environment variable; both settle on the same cached value for the life
-// of a process.
+// cache the recording gate. Stage 1 kept recording shadow-only, off by
+// default, behind GTS_B4B_SHADOW_CENSUS. Stage 2b promotes the v2
+// containment predicate (diagnosticParserCoreConvergedCoverageDropsV2) to
+// the deciding proof for uncertified languages, so recording must be
+// unconditional: a header whose set was never populated fails closed on
+// every drop it is asked to prove, which would silently turn every
+// converged-split drop into a decline. Recording is allocation-free by
+// construction (spec.b4b-alternative-set.v2 section 3.4), so turning it on
+// always costs real CPU, never allocation.
 var (
 	alternativeSetRecordingEnabledOnce sync.Once
 	alternativeSetRecordingEnabledVal  bool
@@ -484,30 +485,74 @@ var (
 
 func alternativeSetRecordingEnabled() bool {
 	alternativeSetRecordingEnabledOnce.Do(func() {
-		switch os.Getenv("GTS_B4B_SHADOW_CENSUS") {
-		case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
-			alternativeSetRecordingEnabledVal = true
-		}
+		alternativeSetRecordingEnabledVal = true
 	})
 	return alternativeSetRecordingEnabledVal
 }
 
 // SetAlternativeSetRecordingEnabledForTest overrides the recording gate for
-// one test process, mirroring the census's own ForTest override. Restore
-// the previous value (the returned func) when done.
+// one test process. Restore the previous value (the returned func) when
+// done. Production never disables recording; this exists so a test can
+// exercise the disabled-gate code path in isolation. Reads through
+// alternativeSetRecordingEnabled first (rather than forcing the sync.Once
+// with an empty closure) so the captured "previous" is always the gate's
+// real value -- true on its first-ever call in a process -- never an
+// artifact of which caller happened to fire the Once first.
 func SetAlternativeSetRecordingEnabledForTest(on bool) func() {
-	alternativeSetRecordingEnabledOnce.Do(func() {})
-	previous := alternativeSetRecordingEnabledVal
+	previous := alternativeSetRecordingEnabled()
 	alternativeSetRecordingEnabledVal = on
 	return func() { alternativeSetRecordingEnabledVal = previous }
 }
 
+// cleanPathRankWalkEnabledOnce and cleanPathRankWalkEnabledVal cache
+// GTS_B4B_SHADOW_CENSUS, independently of the outer package's own copy of the
+// same switch (parsercorephase0 has no dependency on the package that
+// defines the census) -- the pattern alternativeSetRecordingEnabled used
+// before stage 2b made set recording unconditional. Once the converged-
+// coverage v2 predicate became the deciding proof, nothing on the routing
+// path reads markCleanProductionRank's scalar (rank, lineage) output except
+// the three-proof census's scalar comparison, so the DAG walk itself now
+// runs only when that census is requested. Off by default, multi-pop paths
+// are marked Unknown instead (markCleanPathRankUnknown): a single field
+// write per path, no derivation walk. Unknown still marks
+// nodeLineageRecord.converged=true exactly as Selected/Unselected would
+// (recordNodeLineage), so HistoricalBoundaryConverged classification and
+// alternative-set historical import (spec section 4, "Dead-node historical
+// import") are unaffected -- only the now-unread scalar rank/lineage values
+// degrade to Unknown/0.
+var (
+	cleanPathRankWalkEnabledOnce sync.Once
+	cleanPathRankWalkEnabledVal  bool
+)
+
+func cleanPathRankWalkEnabled() bool {
+	cleanPathRankWalkEnabledOnce.Do(func() {
+		switch os.Getenv("GTS_B4B_SHADOW_CENSUS") {
+		case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
+			cleanPathRankWalkEnabledVal = true
+		}
+	})
+	return cleanPathRankWalkEnabledVal
+}
+
+// SetCleanPathRankWalkEnabledForTest overrides the rank-walk gate for one
+// test process, mirroring SetAlternativeSetRecordingEnabledForTest's
+// override pattern. Restore the previous value (the returned func) when
+// done.
+func SetCleanPathRankWalkEnabledForTest(on bool) func() {
+	previous := cleanPathRankWalkEnabled()
+	cleanPathRankWalkEnabledVal = on
+	return func() { cleanPathRankWalkEnabledVal = previous }
+}
+
 // NewAlternativeSetMember returns the singleton set {pack(event, branch)},
 // or the empty set when event==0 (the reserved "no event" identity) or when
-// the recording gate is off. branch is the ReductionOutput's ordinal within
-// the establishing dispatch (spec.b4b-alternative-set.v2 section 3.1); it is
-// not independently reserved -- only event==0 makes the packed value zero,
-// since establishment always guards event!=0 first. Every driver-side
+// the recording gate is off (test-only; see
+// SetAlternativeSetRecordingEnabledForTest). branch is the ReductionOutput's
+// ordinal within the establishing dispatch (spec.b4b-alternative-set.v2
+// section 3.1); it is not independently reserved -- only event==0 makes the
+// packed value zero, since establishment always guards event!=0 first.
+// Every driver-side
 // alternative-set value not copied or unioned from an existing header/node
 // set originates here, so gating this one construction point -- together
 // with recordNodeLineageMember, the only other place a member is ever
@@ -4473,8 +4518,21 @@ func searchAlternativeSetMembers(members []uint32, member uint32) (int, bool) {
 // count/flags/spillRef alone (section 3.3); a superseded segment simply
 // leaks arena space until the next Reset, bounded by alternativeSetHardCap
 // per record.
+//
+// Overflowed is frozen, uniformly. Once alternativeSetFlagOverflowed is set
+// -- whether by this function's own count reaching alternativeSetHardCap,
+// or by alternativeSetUnion propagating an overflowed source's incomplete
+// knowledge onto set (below) -- no further insert can ever change set
+// again: the check runs first, before any member resolution or scan, so a
+// set that stays overflowed for the rest of a parse (the canonical corpus
+// census found this true for 98.7% of elections at (event, branch) member
+// width) costs one flag test per call instead of a spill-arena read and a
+// linear scan that would always end in the identical no-op.
 func (c *Core) alternativeSetInsert(set *AlternativeSet, member uint32) bool {
 	if member == 0 {
+		return false
+	}
+	if set.flags&alternativeSetFlagOverflowed != 0 {
 		return false
 	}
 	current, ok := c.alternativeSetMembers(*set)
@@ -4486,11 +4544,8 @@ func (c *Core) alternativeSetInsert(set *AlternativeSet, member uint32) bool {
 		return false
 	}
 	if int(set.count) >= alternativeSetHardCap {
-		if set.flags&alternativeSetFlagOverflowed == 0 {
-			set.flags |= alternativeSetFlagOverflowed
-			return true
-		}
-		return false
+		set.flags |= alternativeSetFlagOverflowed
+		return true
 	}
 	if position == len(current) {
 		switch {
@@ -4515,17 +4570,27 @@ func (c *Core) alternativeSetInsert(set *AlternativeSet, member uint32) bool {
 }
 
 // alternativeSetUnion unions src's recorded members into *dst in place and
-// reports whether dst changed. An overflowed source propagates its overflow
-// flag: a union whose source is overflowed marks the destination overflowed
-// (spec.b4b-alternative-set.v1 section 4, "Overflow propagation").
+// reports whether dst changed. Overflowed is frozen, uniformly (see
+// alternativeSetInsert's doc comment): this function never changes an
+// already-overflowed dst, and never partially merges an overflowed src's
+// known members before freezing dst -- an overflowed source's recorded
+// members are an incomplete view of its true membership (spec.b4b-
+// alternative-set.v1 section 3.2), so the only sound conclusion is that
+// dst's own true union is unknowable beyond what dst already has recorded.
+// dst becomes overflowed-and-done at exactly its pre-union state, rather
+// than spending a merge loop whose result is discarded the moment the flag
+// is set regardless. Checked first, in both directions, before any member
+// resolution: on the hot, already-saturated path (98.7% of canonical-corpus
+// elections touch an overflowed set), this turns a spill-arena read plus a
+// linear scan into one flag test.
 //
 // Header-to-node persistence (persistHeaderLineageOwned,
 // parsercore_phase0_driver.go) re-unions every convergedReductionSplit
 // header's accumulated set into its node on every dispatch, mirroring the
 // existing scalar RecordHeadLineageOwned call at the same frequency, and
 // header.head moves to a freshly allocated node on most dispatches -- so the
-// destination is empty far more often than it already equals src. Two fast
-// paths keep that pattern cheap:
+// destination is empty far more often than it already equals src. Two more
+// fast paths keep that pattern cheap once both sides are known unfrozen:
 //
 //  1. dst is empty: *dst = src, an O(1) value copy. This aliases src's spill
 //     segment (if any) rather than copying it, which is safe: every further
@@ -4537,8 +4602,15 @@ func (c *Core) alternativeSetInsert(set *AlternativeSet, member uint32) bool {
 //     (containsAll) instead of insert's O(len(src)) x O(len(dst))
 //     member-by-member scan.
 func (c *Core) alternativeSetUnion(dst *AlternativeSet, src AlternativeSet) bool {
+	if dst.flags&alternativeSetFlagOverflowed != 0 {
+		return false
+	}
+	if src.Overflowed() {
+		dst.flags |= alternativeSetFlagOverflowed
+		return true
+	}
 	if src.count == 0 {
-		return c.alternativeSetPropagateOverflow(dst, src)
+		return false
 	}
 	if dst.count == 0 {
 		*dst = src
@@ -4546,10 +4618,9 @@ func (c *Core) alternativeSetUnion(dst *AlternativeSet, src AlternativeSet) bool
 	}
 	srcMembers, ok := c.alternativeSetMembers(src)
 	if !ok {
-		return c.alternativeSetPropagateOverflow(dst, src)
+		return false
 	}
 	if dstMembers, dstOK := c.alternativeSetMembers(*dst); dstOK &&
-		(!src.Overflowed() || dst.Overflowed()) &&
 		alternativeSetSortedContainsAll(srcMembers, dstMembers) {
 		return false
 	}
@@ -4558,9 +4629,6 @@ func (c *Core) alternativeSetUnion(dst *AlternativeSet, src AlternativeSet) bool
 		if c.alternativeSetInsert(dst, member) {
 			changed = true
 		}
-	}
-	if c.alternativeSetPropagateOverflow(dst, src) {
-		changed = true
 	}
 	return changed
 }
@@ -4594,14 +4662,6 @@ func alternativeSetSortedContainsAll(needle, haystack []uint32) bool {
 		haystackIndex++
 	}
 	return true
-}
-
-func (c *Core) alternativeSetPropagateOverflow(dst *AlternativeSet, src AlternativeSet) bool {
-	if src.Overflowed() && dst.flags&alternativeSetFlagOverflowed == 0 {
-		dst.flags |= alternativeSetFlagOverflowed
-		return true
-	}
-	return false
 }
 
 // UnionAlternativeSet is the exported form of alternativeSetUnion for

--- a/internal/parsercorephase0/scheduler_owned.go
+++ b/internal/parsercorephase0/scheduler_owned.go
@@ -755,7 +755,21 @@ func (c *Core) reduceOutputsClassifiedIntoActive(frontier []ReductionOutput, bou
 	// case; see its doc comment.
 	multiPop := len(paths) > 1
 	if multiPop {
-		c.markCleanProductionRank(paths)
+		// Stage 2b (spec.b4b-alternative-set.v2 section 8): the v2
+		// containment predicate is the deciding proof and never reads
+		// cleanPathRank/cleanPathLineage on the routing path, so the
+		// prefix-DAG walk (markCleanProductionRank, the bisected dominant
+		// share of the recording-era compact-perf regression) runs only
+		// when the three-proof census asks for a meaningful scalar
+		// comparison. Otherwise every path is marked Unknown directly --
+		// cheap, and still marks nodeLineageRecord.converged=true, so
+		// historical-boundary classification and alternative-set import are
+		// unaffected (see cleanPathRankWalkEnabled's doc comment).
+		if cleanPathRankWalkEnabled() {
+			c.markCleanProductionRank(paths)
+		} else {
+			markCleanPathRankUnknown(paths)
+		}
 	}
 	for _, path := range paths {
 		prev, err := c.node(path.prev)

--- a/parsercore_phase0_alternative_set_census.go
+++ b/parsercore_phase0_alternative_set_census.go
@@ -11,29 +11,32 @@ import (
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
 )
 
-// The converged-alternative-set proofs and the stage 2a three-proof census.
+// The converged-alternative-set proofs and the stage 2 census.
 //
-// A converged-split no-action drop is proved admissible by a scalar (rank,
-// lineage) pair recorded on each header (diagnosticParserCoreSelectedLineageDrops).
-// That scalar proof remains the live decider throughout stage 2a
-// (spec.b4b-alternative-set.v2 section 7): the decider does not flip. This
-// file adds two alternative proofs, both diagnostic-only until their own
-// stage 2b gate passes:
+// Through stage 2a, a converged-split no-action drop was proved admissible
+// by a scalar (rank, lineage) pair recorded on each header
+// (diagnosticParserCoreSelectedLineageDrops). Stage 2b flips
+// dropGenericNoActionHeads to decide with the v2 predicate instead
+// (spec.b4b-alternative-set.v2 section 8), after the section 7 gate passed
+// (zero class-1 differing-tree cases; the Kotlin witness declines under v2;
+// stage 1's gates re-passed). This file carries three proofs:
 //
-//   - v1 (event-only): a drop is admissible when one surviving header's
-//     recorded set contains, for every recorded (event, branch) member of
-//     the dropped header's set, some member of that same event -- ignoring
-//     branch (spec.b4b-alternative-set.v1 section 5, superseded).
-//   - v2 ((event, branch), blended-witness veto): a drop is admissible when
-//     one surviving header's recorded set contains every recorded (event,
-//     branch) member of the dropped header's set exactly, and the
-//     surviving header is not blended (spec.b4b-alternative-set.v2 section
-//     5, the revised theorem).
+//   - v1 (event-only, superseded): a drop is admissible when one surviving
+//     header's recorded set contains, for every recorded (event, branch)
+//     member of the dropped header's set, some member of that same event --
+//     ignoring branch (spec.b4b-alternative-set.v1 section 5).
+//   - v2 ((event, branch), blended-witness veto, the decider): a drop is
+//     admissible when one surviving header's recorded set contains every
+//     recorded (event, branch) member of the dropped header's set exactly,
+//     and the surviving header is not blended (spec.b4b-alternative-set.v2
+//     section 5, the revised theorem).
+//   - scalar (rank, lineage), retired: the pre-B4b proof dropGenericNoActionHeads
+//     decided with through stage 2a. Evaluated only inside this file's
+//     census now, as an ongoing regression check while more languages
+//     decertify in stage 3.
 //
-// dropGenericNoActionHeads evaluates the scalar proof to decide, evaluates
-// v2 only when the differential-harness opt-in override is engaged
-// (alternativeSetV2OptInDeciderEnabled, test-only, never default), and
-// evaluates all three proofs together for the census whenever
+// dropGenericNoActionHeads decides with v2 unconditionally for uncertified
+// languages and evaluates all three proofs together for the census whenever
 // diagnosticParserCoreShadowCensusEnabled reports true. The census never
 // influences routing.
 //
@@ -212,13 +215,13 @@ func alternativeSetEventOnlyContainsAll(dropped, survivor []uint32) bool {
 }
 
 // DiagnosticParserCoreShadowCensusTotals tallies the comparison between the
-// scalar rank/lineage proof (diagnosticParserCoreSelectedLineageDrops, the
-// live decider) and the v2 alternative-set containment proof
-// (diagnosticParserCoreConvergedCoverageDropsV2) across every converged-split
-// no-action drop election observed while the census is enabled. Retained
-// under its stage 1 name for callers already reading it; see
-// DiagnosticParserCoreThreeProofCensusTotals for the full v1/v2/scalar
-// breakdown stage 2a adds.
+// retired scalar rank/lineage proof (diagnosticParserCoreSelectedLineageDrops)
+// and the v2 alternative-set containment proof
+// (diagnosticParserCoreConvergedCoverageDropsV2, the live decider since
+// stage 2b) across every converged-split no-action drop election observed
+// while the census is enabled. Retained under its stage 1 name for callers
+// already reading it; see DiagnosticParserCoreThreeProofCensusTotals for the
+// full v1/v2/scalar breakdown stage 2a adds.
 type DiagnosticParserCoreShadowCensusTotals struct {
 	// Agree: both proofs reached the same verdict (both proved or both
 	// declined).
@@ -251,17 +254,19 @@ type DiagnosticParserCoreThreeProofCensusTotals struct {
 	ScalarProved uint64
 	V1Proved     uint64
 	V2Proved     uint64
-	// Class1V2AdmitsScalarDeclines: v2 proves where the scalar (live)
-	// decider declines -- the class the stage 1 census structurally could
-	// not see, and the Kotlin class detector (spec section 7 class 1). The
-	// stage 2b gate requires this class to carry zero differing-tree cases
+	// Class1V2AdmitsScalarDeclines: v2 proves where the retired scalar proof
+	// declines -- the class the stage 1 census structurally could not see,
+	// and the Kotlin class detector (spec section 7 class 1). The stage 2b
+	// gate required this class to carry zero differing-tree cases
 	// (adjudicated against the C oracle, not raw production equality;
-	// campaign amendment 2026-08-02) across the corpora in scope.
+	// campaign amendment 2026-08-02) across the corpora in scope; it stays a
+	// live regression watch now that v2 is the decider.
 	Class1V2AdmitsScalarDeclines uint64
-	// Class2ScalarProvesV2Declines: the scalar (live) decider proves where
-	// v2 declines -- expected non-zero (rank-preference drops, the
-	// coincidental-premise class v1's own design indicted; spec section 7
-	// class 2). No gate.
+	// Class2ScalarProvesV2Declines: the retired scalar proof proves where v2
+	// (the live decider) declines -- expected non-zero (rank-preference
+	// drops, the coincidental-premise class v1's own design indicted; spec
+	// section 7 class 2). No gate; these are the newly-declined drops v2
+	// falls back on.
 	Class2ScalarProvesV2Declines uint64
 	// Class3V1ProvesV2Declines: v1 (event-only) proves where v2 declines --
 	// the branch-discrimination accepted capability cost (spec section 7
@@ -327,39 +332,6 @@ func diagnosticParserCoreShadowCensusEnabled() bool {
 		}
 	})
 	return diagnosticParserCoreShadowCensusEnabledVal
-}
-
-var (
-	alternativeSetV2OptInDeciderOnce sync.Once
-	alternativeSetV2OptInDeciderVal  bool
-)
-
-// alternativeSetV2OptInDeciderEnabled reports whether the differential
-// harness's v2-as-decider override is engaged (GTS_B4B_V2_OPT_IN_DECIDER).
-// This never affects default routing: it exists solely so a harness can
-// re-run a source with v2 substituted for the scalar proof as the deciding
-// predicate in dropGenericNoActionHeads and compare the resulting tree
-// against production (spec.b4b-alternative-set.v2 section 7 class 1's
-// differential harness). Off by default; cached the same zero-cost-when-off
-// way as diagnosticParserCoreShadowCensusEnabled.
-func alternativeSetV2OptInDeciderEnabled() bool {
-	alternativeSetV2OptInDeciderOnce.Do(func() {
-		switch os.Getenv("GTS_B4B_V2_OPT_IN_DECIDER") {
-		case "1", "true", "TRUE", "True", "on", "ON", "yes", "YES":
-			alternativeSetV2OptInDeciderVal = true
-		}
-	})
-	return alternativeSetV2OptInDeciderVal
-}
-
-// SetAlternativeSetV2OptInDeciderEnabledForTest overrides the v2 opt-in
-// decider gate for one test process. Restore the previous value (the
-// returned func) when done.
-func SetAlternativeSetV2OptInDeciderEnabledForTest(on bool) func() {
-	alternativeSetV2OptInDeciderOnce.Do(func() {})
-	previous := alternativeSetV2OptInDeciderVal
-	alternativeSetV2OptInDeciderVal = on
-	return func() { alternativeSetV2OptInDeciderVal = previous }
 }
 
 // diagnosticParserCoreRunThreeProofCensus evaluates the v1 and v2

--- a/parsercore_phase0_alternative_set_v2_differential_test.go
+++ b/parsercore_phase0_alternative_set_v2_differential_test.go
@@ -2,23 +2,27 @@
 
 package gotreesitter_test
 
-// The B4b stage 2a class-1 differential harness (spec.b4b-alternative-
-// set.v2 section 7 class 1, and the stage 2b gate). For each corpus source
-// this file re-parses the candidate route twice: once normally (the live
-// scalar decider, unchanged default), and once with v2 substituted as the
-// decider (SetAlternativeSetV2OptInDeciderEnabledForTest, test-only,
-// differential-harness-only). If v2 ever proves a converged-split drop that
-// the scalar decider alone would not have (spec section 7 class 1), forcing
-// it through this way is exactly "compact-if-forced": the v2-opt-in-decider
-// parse either declines somewhere else and falls back to production
-// trivially (nothing interesting -- the tree is production's by
-// construction), or it fully routes on v2's own proof alone, in which case
-// its resulting tree must equal production's. A mismatch there is a class-1
-// differing-tree case: per the campaign's C-oracle adjudication amendment
-// (2026-08-02), that is not automatically a v2 theorem falsifier -- the
-// cgo_harness C-oracle adjudication (b4b_alternative_set_v2_kotlin_adjudication_test.go)
-// determines whether production or the v2-admitted compact route is the
-// side that diverges from the locked C oracle.
+// The B4b stage 2b class-1 differential regression witness (spec.b4b-
+// alternative-set.v2 section 7 class 1, and the stage 2b gate). Stage 2a
+// built this harness around a test-only opt-in override
+// (SetAlternativeSetV2OptInDeciderEnabledForTest) that substituted v2 for
+// the then-live scalar decider; the section 7 gate passed and stage 2b
+// flipped dropGenericNoActionHeads to decide with v2 unconditionally for
+// uncertified languages, so that override was retired and this file now
+// exercises the plain candidate route. For each corpus source this file
+// re-parses twice: once with the candidate route disabled (production),
+// and once with it enabled (v2 decides). If v2 ever proves a converged-
+// split drop that the retired scalar decider alone would not have (spec
+// section 7 class 1), the candidate parse either declines somewhere else
+// and falls back to production trivially (nothing interesting -- the tree
+// is production's by construction), or it fully routes on v2's own proof
+// alone, in which case its resulting tree must equal production's. A
+// mismatch there is a class-1 differing-tree case: per the campaign's
+// C-oracle adjudication amendment (2026-08-02), that is not automatically a
+// v2 theorem falsifier -- the cgo_harness C-oracle adjudication
+// (b4b_alternative_set_v2_kotlin_adjudication_test.go) determines whether
+// production or the v2-admitted compact route is the side that diverges
+// from the locked C oracle.
 //
 // Run with:
 //
@@ -51,11 +55,13 @@ type v2DifferentialResult struct {
 }
 
 // runV2OptInDeciderDifferential parses source under production and under the
-// candidate route with v2 substituted as the deciding proof
-// (dropGenericNoActionHeads), and reports whether the resulting trees match.
-// Recording must be forced on: 2a's default-off recording gate would
-// otherwise leave every altSet empty, making v2 decline everything
-// trivially and defeating the harness's purpose.
+// candidate route, which decides converged-split drops with the v2 proof
+// unconditionally since the stage 2b flip (dropGenericNoActionHeads), and
+// reports whether the resulting trees match. Recording is forced on
+// explicitly (defense-in-depth): production has recorded it unconditional
+// since stage 2b, but an empty altSet would make v2 decline everything
+// trivially and silently defeat this harness's purpose, so the requirement
+// stays pinned here regardless of the current default.
 func runV2OptInDeciderDifferential(t testing.TB, name string, lang *gts.Language, source []byte) v2DifferentialResult {
 	t.Helper()
 	result := v2DifferentialResult{name: name}
@@ -75,8 +81,6 @@ func runV2OptInDeciderDifferential(t testing.TB, name string, lang *gts.Language
 	}
 	result.productionDigest = productionInspection.SHA256
 
-	restoreV2 := gts.SetAlternativeSetV2OptInDeciderEnabledForTest(true)
-	defer restoreV2()
 	restoreRecording := core.SetAlternativeSetRecordingEnabledForTest(true)
 	defer restoreRecording()
 
@@ -85,7 +89,7 @@ func runV2OptInDeciderDifferential(t testing.TB, name string, lang *gts.Language
 	candidate.SetAdmissionCandidateRoute(true)
 	candidateTree, err := candidate.Parse(source)
 	if err != nil {
-		result.err = fmt.Errorf("v2-opt-in-decider candidate parse: %w", err)
+		result.err = fmt.Errorf("v2-decider candidate parse: %w", err)
 		return result
 	}
 	defer candidateTree.Release()

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -156,22 +156,26 @@ type DiagnosticParserCoreGenericWork struct {
 	// ConvergedReductionSplitDrops counts no-action drops descended from a
 	// reduction that split multiple compact predecessor paths into live heads.
 	ConvergedReductionSplitDrops uint64
-	// SelectedLineageDrops counts converged split drops whose unselected rank
-	// matched one surviving selected header from the same reduction.
-	SelectedLineageDrops uint64
-	RepetitionFolds      uint64
-	Reductions           uint64
-	OrdinaryShifts       uint64
-	OrdinaryCohorts      uint64
-	ExtraShifts          uint64
-	ExtraCohorts         uint64
-	Accepts              uint64
-	ReductionPauses      uint64
-	NoActionDrops        uint64
-	Elections            uint64
-	Canonicalizations    uint64
-	PeakHeaders          uint64
-	Overflow             bool
+	// ConvergedCoverageDrops counts converged split drops whose dropped
+	// header's recorded alternative set was contained in one surviving,
+	// non-blended header's recorded set (spec.b4b-alternative-set.v2 section
+	// 5, the revised theorem). Renamed from SelectedLineageDrops at stage
+	// 2b, when the v2 containment predicate replaced the scalar (rank,
+	// lineage) proof as the deciding proof.
+	ConvergedCoverageDrops uint64
+	RepetitionFolds        uint64
+	Reductions             uint64
+	OrdinaryShifts         uint64
+	OrdinaryCohorts        uint64
+	ExtraShifts            uint64
+	ExtraCohorts           uint64
+	Accepts                uint64
+	ReductionPauses        uint64
+	NoActionDrops          uint64
+	Elections              uint64
+	Canonicalizations      uint64
+	PeakHeaders            uint64
+	Overflow               bool
 }
 
 func (w *DiagnosticParserCoreGenericWork) add(counter *uint64, delta uint64) {
@@ -3686,29 +3690,27 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 			}
 		}
 	}
-	// The scalar (rank, lineage) proof remains the live decider throughout
-	// stage 2a (spec.b4b-alternative-set.v2 section 7); the v2 predicate
-	// below only ever substitutes when the differential-harness opt-in
-	// override is engaged (test-only, never the default).
-	selectedLineageDrops, scalarProved := diagnosticParserCoreSelectedLineageDrops(s.headers, indices)
-	proved := scalarProved
-	if alternativeSetV2OptInDeciderEnabled() {
-		_, v2Proved := s.diagnosticParserCoreConvergedCoverageDropsV2(indices)
-		proved = v2Proved
-	}
+	// Stage 2b (spec.b4b-alternative-set.v2 section 8): the v2 containment
+	// predicate -- (event, branch) exact-member containment plus the
+	// blended-witness veto -- is the deciding proof for uncertified
+	// languages, replacing the scalar (rank, lineage) proof stage 2a kept
+	// live while the re-census ran. The section 7 gate passed (zero class-1
+	// differing-tree cases, the Kotlin witness declines under v2, stage 1's
+	// gates re-passed); erlang's own class-3 probe re-proof miss is scoped
+	// to its stage 3 certificate precondition, not this gate.
+	convergedCoverageDrops, proved := s.diagnosticParserCoreConvergedCoverageDropsV2(indices)
 	if diagnosticParserCoreShadowCensusEnabled() {
-		// Three-proof census: evaluates the v1 (event-only) and v2 ((event,
-		// branch) plus blended-witness veto) containment predicates next to
-		// the scalar decision above and tallies every pairwise comparison,
-		// including the declined-drop classes the stage 1 census could not
-		// see. Never influences the decision below
-		// (spec.b4b-alternative-set.v2 section 7).
+		// The retired scalar proof is evaluated only here, next to the v2
+		// decision above, for the ongoing three-proof regression check as
+		// more languages decertify in stage 3. Never influences the
+		// decision below.
+		_, scalarProved := diagnosticParserCoreSelectedLineageDrops(s.headers, indices)
 		s.diagnosticParserCoreRunThreeProofCensus(indices, scalarProved)
 	}
 	if !proved && !s.options.allowConvergedSplitDropArtifact {
 		return &diagnosticParserCoreDecline{
 			boundary: DiagnosticParserCoreNoAction,
-			detail:   "converged-path reduction split no-action drop lacks one exact unselected-to-selected lineage",
+			detail:   "converged-path reduction split no-action drop lacks alternative-set coverage by one non-blended survivor",
 		}
 	}
 	if s.fullReceipts() {
@@ -3750,7 +3752,7 @@ func (s *diagnosticParserCoreGenericScheduler) dropGenericNoActionHeads(indices 
 	s.headers = s.headers[:write]
 	s.work.NoActionDrops += uint64(len(indices))
 	s.work.add(&s.work.ConvergedReductionSplitDrops, convergedReductionSplitDrops)
-	s.work.add(&s.work.SelectedLineageDrops, selectedLineageDrops)
+	s.work.add(&s.work.ConvergedCoverageDrops, convergedCoverageDrops)
 	return nil
 }
 

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -143,13 +143,13 @@ func requireParserCoreFreshFullAcceptance(scheduler *diagnosticParserCoreGeneric
 			acceptance.Token, acceptance.Header.Header, acceptance.Accepts, acceptance.Work.Accepts)
 	}
 	if !allowConvergedReductionSplitDrops &&
-		acceptance.Work.ConvergedReductionSplitDrops != acceptance.Work.SelectedLineageDrops {
+		acceptance.Work.ConvergedReductionSplitDrops != acceptance.Work.ConvergedCoverageDrops {
 		return &diagnosticParserCoreDecline{
 			boundary: DiagnosticParserCoreAccept,
 			detail: fmt.Sprintf(
-				"accepted frontier followed %d converged-path reduction split drops with %d exact selected-lineage proofs",
+				"accepted frontier followed %d converged-path reduction split drops with %d alternative-set coverage proofs",
 				acceptance.Work.ConvergedReductionSplitDrops,
-				acceptance.Work.SelectedLineageDrops,
+				acceptance.Work.ConvergedCoverageDrops,
 			),
 		}
 	}

--- a/parsercore_phase0_generic_scheduler_test.go
+++ b/parsercore_phase0_generic_scheduler_test.go
@@ -402,7 +402,7 @@ func TestDiagnosticParserCoreGenericSchedulerAcceptsAndMaterializesExactRewrite(
 			ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 			Reductions: 1259, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 			ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-			ReductionPauses: 31, NoActionDrops: 166, ConvergedReductionSplitDrops: 164, SelectedLineageDrops: 1, Elections: 1036,
+			ReductionPauses: 31, NoActionDrops: 166, ConvergedReductionSplitDrops: 164, ConvergedCoverageDrops: 0, Elections: 1036,
 			Canonicalizations: 2446, PeakHeaders: 4,
 		}) || len(result.GenericScheduler.Elections) != 1036 || len(result.GenericScheduler.Rounds) != 2446 || len(result.GenericScheduler.NoActionDrops) != 166 || len(result.GenericScheduler.ExternalShifts) != 83 {
 		t.Fatalf("acceptance receipt drifted: result=%+v acceptance=%+v", result, acceptance)
@@ -501,7 +501,7 @@ func TestDiagnosticParserCoreSummaryReceiptPreservesExactRewrite(t *testing.T) {
 				ConflictActionArmsAdmitted: 328, CausalConflictForks: 168,
 				Reductions: 1259, OrdinaryShifts: 1238, OrdinaryCohorts: 215,
 				ExtraShifts: 27, ExtraCohorts: 1, Accepts: 1,
-				ReductionPauses: 31, NoActionDrops: 166, ConvergedReductionSplitDrops: 164, SelectedLineageDrops: 1, Elections: 1036,
+				ReductionPauses: 31, NoActionDrops: 166, ConvergedReductionSplitDrops: 164, ConvergedCoverageDrops: 0, Elections: 1036,
 				Canonicalizations: 2446, PeakHeaders: 4,
 			}) {
 			result.MaterializedTree.Release()

--- a/work_count_parsercore_child_internal_test.go
+++ b/work_count_parsercore_child_internal_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	parserCoreWorkCountChildSchema = "gts-work-count-parsercore-child/v3"
+	parserCoreWorkCountChildSchema = "gts-work-count-parsercore-child/v4"
 	parserCoreWorkCountEngine      = "go-compact-parsercore-phase0-tagged-diagnostic"
 	parserCoreWorkCountContract    = "gts-work-count/v2"
 	parserCoreWorkCountDigest      = "gts-deep-tree-v1"


### PR DESCRIPTION
## Summary

- Flip `dropGenericNoActionHeads` to decide converged-split drops with the
  v2 (event, branch) containment predicate for uncertified languages. The
  certified-language escape and the F4 resurrection veto stay unchanged.
- Retire the rank walk from the live routing path. `markCleanProductionRank`
  now runs only for census diagnostics; production marks multi-pop paths
  Unknown directly.
- Make alternative-set recording unconditional in production: the v2
  predicate needs a populated set to prove anything.
- Freeze overflowed alternative sets uniformly. Insert and union
  short-circuit on an already-overflowed set before any member resolution,
  closing the capacity gap stage 2a's census flagged (98.7% overflow on the
  canonical corpus).
- Rename the `SelectedLineageDrops` work counter to `ConvergedCoverageDrops`
  and bump the work-count schema to v4.

## Correctness (all gates green)

- Build and vet stay clean on every relevant tag combination.
- Internal package tests and the race detector pass.
- The full test suite passes. The `-tags gts_parsercorephase0` suite
  reproduces the identical pre-existing failure set from `main`, plus one
  net improvement.
- Canonical digests stay byte-identical across all four canonical fixtures.
- The 206-language admission scorecard stays unchanged:
  PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0.
- Work-count counters stay byte-identical except one documented, expected
  move: a converged-split drop the scalar proof used to claim, which v2
  correctly declines. The certified language still routes it through the
  artifact escape.
- Zero-alloc pins hold.
- New unit tests cover the overflow-freeze short-circuit, the union
  flag-propagation cases, and journal rollback of the overflow flag.

## Performance, host-caveated

Order-alternating 12-round interleave against `origin/main`, all four
canonical fixtures, taskset-pinned, benchstat n=12 (measured on a shared
development host, not a dedicated performance host):

| Fixture | sec/op | delta vs main |
|---|---|---|
| rewrite | 2.145m | ~ (p=0.590) |
| query_compile | 10.22m | ~ (p=0.443) |
| language | 10.39m | ~ (p=0.128) |
| grammargen_lr | 108.0m | ~ (p=0.630) |
| geomean | 12.53m | -0.47% |

The net is neutral, not a win: no fixture shows a statistically significant
change. This PR removes most of the tax an earlier, unoptimized version of
this flip carried. Isolated ablation on that earlier version found
recording alone cost +12.97% geomean; retiring the rank walk alone saved
-6.51% geomean; the two nearly canceled, netting a small regression. The
overflow fast path in this PR (`alternativeSetInsert`/`alternativeSetUnion`
short-circuit once a set is overflowed, instead of resolving members and
scanning first) closed most of that gap. A further win is deferred to
capacity work: the 98.7% overflow rate itself is a stage-2c-scoped
question, tracked separately.

## Notes

- The Kotlin witness declines under v2, matching the sealed regression the
  amendment fixes.
- Erlang's two probe witnesses stay class-3 (informational): their
  certificate-retirement precondition is unmet by this change, out of this
  PR's scope.

Do not merge without owner review (campaign coordination, post-talk merge
per the spec's stage ladder).
