### PR TITLE
fix(grammars): Bind TypeScript and TSX scanners positionally to language symbols

### DIFF
--- a/grammars/external_scanner_positional_binding_test.go
+++ b/grammars/external_scanner_positional_binding_test.go
@@ -209,6 +209,30 @@ func TestRealLanguageExternalBindingTablesArePositional(t *testing.T) {
 	if got, want := javascript.symbols, jsDefaultSymTable; got != want {
 		t.Fatalf("javascript post-bind symbols = %v, want default table %v", got, want)
 	}
+
+	// typescript and tsx: pin the currently-shipped typescript.bin/tsx.bin
+	// bindings as permanent regression guards, the same way as javascript
+	// above. Both carry the same 10 externals (javascript's 8 plus
+	// _function_signature_automatic_semicolon and __error_recovery), so a
+	// future blob regen that shifts the automaton's absolute symbol
+	// numbering still passes this externalToToken check (index-based, not
+	// value-based) but would only pass the symbols equality below if the
+	// external declaration order is unchanged.
+	typescript := TypeScriptExternalScanner{}.ExternalScannerForLanguage(TypescriptLanguage()).(TypeScriptExternalScanner)
+	if got, want := typescript.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}; !slices.Equal(got, want) {
+		t.Fatalf("typescript externalToToken = %v, want %v", got, want)
+	}
+	if got, want := typescript.symbols, tsDefaultSymTable; got != want {
+		t.Fatalf("typescript post-bind symbols = %v, want default table %v", got, want)
+	}
+
+	tsx := TsxExternalScanner{}.ExternalScannerForLanguage(TsxLanguage()).(TsxExternalScanner)
+	if got, want := tsx.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}; !slices.Equal(got, want) {
+		t.Fatalf("tsx externalToToken = %v, want %v", got, want)
+	}
+	if got, want := tsx.symbols, tsxDefaultSymTable; got != want {
+		t.Fatalf("tsx post-bind symbols = %v, want default table %v", got, want)
+	}
 }
 
 // Note: the pure-unit drift and length-mismatch tests for

--- a/grammars/tsx_scanner.go
+++ b/grammars/tsx_scanner.go
@@ -20,20 +20,90 @@ const (
 	tsxTokJsxText         = 7
 	tsxTokFuncSigAutoSemi = 8
 	tsxTokErrorRecovery   = 9
+	tsxTokenCount         = 10
 )
 
+// Concrete symbol IDs from the checked-in TSX grammar ExternalSymbols. These
+// are DEFAULTS only: the fallback entries in tsxDefaultSymTable, used as-is
+// if Scan is ever invoked on a scanner value that was never bound to a
+// Language (should not happen in production; see ExternalScannerForLanguage).
+// ExternalScannerForLanguage binds the real per-Language symbols
+// POSITIONALLY (by external index, via bindExternalScannerSymbolNames), not
+// by these absolute IDs, so a grammargen-regenerated tsx blob -- which emits
+// the same 10 externals in the same order but under different absolute
+// Symbol numbering once the automaton grows or shrinks -- still lexes
+// correctly instead of silently mistyping every external scan result. See
+// bindExternalScannerSymbolNames for why positional (not absolute-ID or
+// by-name) binding is required; the same pattern is used by the
+// javascript/typescript/kotlin/python/swift/dart/rust/hcl scanners.
 const (
 	tsxSymAutoSemicolon   gotreesitter.Symbol = 166
 	tsxSymTemplateChars   gotreesitter.Symbol = 167
 	tsxSymTernaryQmark    gotreesitter.Symbol = 168
 	tsxSymHtmlComment     gotreesitter.Symbol = 169
+	tsxSymLogicalOr       gotreesitter.Symbol = 81
+	tsxSymEscapeSequence  gotreesitter.Symbol = 109
+	tsxSymRegexPattern    gotreesitter.Symbol = 114
 	tsxSymJsxText         gotreesitter.Symbol = 170
 	tsxSymFuncSigAutoSemi gotreesitter.Symbol = 171
+	tsxSymErrorRecovery   gotreesitter.Symbol = 172
 )
+
+// tsxDefaultSymTable mirrors the tsxTok* index order above.
+var tsxDefaultSymTable = [tsxTokenCount]gotreesitter.Symbol{
+	tsxTokAutoSemicolon:   tsxSymAutoSemicolon,
+	tsxTokTemplateChars:   tsxSymTemplateChars,
+	tsxTokTernaryQmark:    tsxSymTernaryQmark,
+	tsxTokHtmlComment:     tsxSymHtmlComment,
+	tsxTokLogicalOr:       tsxSymLogicalOr,
+	tsxTokEscapeSequence:  tsxSymEscapeSequence,
+	tsxTokRegexPattern:    tsxSymRegexPattern,
+	tsxTokJsxText:         tsxSymJsxText,
+	tsxTokFuncSigAutoSemi: tsxSymFuncSigAutoSemi,
+	tsxTokErrorRecovery:   tsxSymErrorRecovery,
+}
+
+// tsxExternalSymbolNames lists the tsx grammar's external tokens in
+// declaration order (matching the tsxTok* indexes above and the language's
+// ExternalSymbols order). Used by ExternalScannerForLanguage to bind this
+// scanner's token slots to a Language's external symbols positionally, the
+// same pattern used by the javascript/typescript/kotlin/python/swift/dart/
+// rust/hcl scanners. See bindExternalScannerSymbolNames for why positional
+// (not absolute-ID or by-name) binding is required.
+var tsxExternalSymbolNames = []string{
+	"_automatic_semicolon",
+	"_template_chars",
+	"_ternary_qmark",
+	"html_comment",
+	"||",
+	"escape_sequence",
+	"regex_pattern",
+	"jsx_text",
+	"_function_signature_automatic_semicolon",
+	"__error_recovery",
+}
 
 // TsxExternalScanner handles automatic semicolons, template strings,
 // JSX text, ternary question marks, and HTML comments for TSX.
-type TsxExternalScanner struct{}
+type TsxExternalScanner struct {
+	symbols         [tsxTokenCount]gotreesitter.Symbol
+	externalToToken []int
+}
+
+// ExternalScannerForLanguage binds this scanner's token slots to lang's
+// external symbols positionally (external index i -> scanner token i), so
+// Scan resolves result symbols through the bound table instead of the
+// hardcoded absolute IDs above. Required whenever the attached Language did
+// not come from the exact blob those absolute IDs were pinned against (e.g.
+// a grammargen regeneration that shifts the automaton's overall symbol
+// numbering) -- see bindExternalScannerSymbolNames.
+func (TsxExternalScanner) ExternalScannerForLanguage(lang *gotreesitter.Language) gotreesitter.ExternalScanner {
+	s := TsxExternalScanner{symbols: tsxDefaultSymTable}
+	s.externalToToken = bindExternalScannerSymbolNames(lang, tsxExternalSymbolNames, func(tokenIdx int, sym gotreesitter.Symbol) {
+		s.symbols[tokenIdx] = sym
+	})
+	return s
+}
 
 func (TsxExternalScanner) Create() any                           { return nil }
 func (TsxExternalScanner) Destroy(payload any)                   {}
@@ -41,54 +111,91 @@ func (TsxExternalScanner) Serialize(payload any, buf []byte) int { return 0 }
 func (TsxExternalScanner) Deserialize(payload any, buf []byte)   {}
 func (TsxExternalScanner) SupportsIncrementalReuse() bool        { return true }
 
-func (TsxExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+// symbolTable returns the per-Language-bound result-symbol table, falling
+// back to the pinned defaults when Scan is invoked on an unbound scanner
+// value (s.symbols is still its zero value).
+func (s TsxExternalScanner) symbolTable() *[tsxTokenCount]gotreesitter.Symbol {
+	if s.symbols == ([tsxTokenCount]gotreesitter.Symbol{}) {
+		return &tsxDefaultSymTable
+	}
+	return &s.symbols
+}
+
+// remapValidSymbols translates a Language-external-indexed validSymbols
+// slice into scanner-token-indexed space via s.externalToToken. When the
+// Language's external count and order agree with tsxExternalSymbolNames (the
+// common case), externalToToken is the identity permutation and this is a
+// copy; it only diverges when a future grammar version adds, removes, or
+// reorders an external token relative to tsxExternalSymbolNames.
+func (s TsxExternalScanner) remapValidSymbols(validSymbols []bool, semanticValid *[tsxTokenCount]bool) []bool {
+	if len(s.externalToToken) == 0 {
+		return validSymbols
+	}
+	*semanticValid = [tsxTokenCount]bool{}
+	for externalIdx, valid := range validSymbols {
+		if !valid || externalIdx >= len(s.externalToToken) {
+			continue
+		}
+		tokenIdx := s.externalToToken[externalIdx]
+		if tokenIdx >= 0 && tokenIdx < tsxTokenCount {
+			semanticValid[tokenIdx] = true
+		}
+	}
+	return semanticValid[:]
+}
+
+func (s TsxExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+	var semanticValid [tsxTokenCount]bool
+	validSymbols = s.remapValidSymbols(validSymbols, &semanticValid)
+	symbols := s.symbolTable()
+
 	if tsxValid(validSymbols, tsxTokTemplateChars) {
 		if tsxValid(validSymbols, tsxTokAutoSemicolon) {
 			return false
 		}
-		return tsxScanTemplateChars(lexer)
+		return tsxScanTemplateChars(lexer, symbols)
 	}
 
 	preferAutoSemicolon := tsxPreferAutoSemicolonOverJsxText(lexer, validSymbols)
 
 	if tsxValid(validSymbols, tsxTokJsxText) && !preferAutoSemicolon {
-		if tsxScanJsxText(lexer) {
+		if tsxScanJsxText(lexer, symbols) {
 			return true
 		}
 	}
 
 	if tsxValid(validSymbols, tsxTokAutoSemicolon) || tsxValid(validSymbols, tsxTokFuncSigAutoSemi) {
 		scannedComment := false
-		ret := tsxScanAutoSemicolon(lexer, validSymbols, &scannedComment)
+		ret := tsxScanAutoSemicolon(lexer, validSymbols, symbols, &scannedComment)
 		if !ret && !scannedComment && tsxValid(validSymbols, tsxTokTernaryQmark) && lexer.Lookahead() == '?' {
-			return tsxScanTernaryQmark(lexer)
+			return tsxScanTernaryQmark(lexer, symbols)
 		}
 		if !ret && !scannedComment && preferAutoSemicolon && tsxValid(validSymbols, tsxTokJsxText) {
-			return tsxScanJsxText(lexer)
+			return tsxScanJsxText(lexer, symbols)
 		}
 		return ret
 	}
 
 	if tsxValid(validSymbols, tsxTokJsxText) && preferAutoSemicolon {
-		return tsxScanJsxText(lexer)
+		return tsxScanJsxText(lexer, symbols)
 	}
 
 	if tsxValid(validSymbols, tsxTokTernaryQmark) {
-		return tsxScanTernaryQmark(lexer)
+		return tsxScanTernaryQmark(lexer, symbols)
 	}
 
 	if tsxValid(validSymbols, tsxTokHtmlComment) &&
 		!tsxValid(validSymbols, tsxTokLogicalOr) &&
 		!tsxValid(validSymbols, tsxTokEscapeSequence) &&
 		!tsxValid(validSymbols, tsxTokRegexPattern) {
-		return tsxScanClosingComment(lexer)
+		return tsxScanClosingComment(lexer, symbols)
 	}
 
 	return false
 }
 
-func tsxScanTemplateChars(lexer *gotreesitter.ExternalLexer) bool {
-	lexer.SetResultSymbol(tsxSymTemplateChars)
+func tsxScanTemplateChars(lexer *gotreesitter.ExternalLexer, symbols *[tsxTokenCount]gotreesitter.Symbol) bool {
+	lexer.SetResultSymbol(symbols[tsxTokTemplateChars])
 	hasContent := false
 	for {
 		lexer.MarkEnd()
@@ -116,8 +223,8 @@ func tsxScanTemplateChars(lexer *gotreesitter.ExternalLexer) bool {
 	}
 }
 
-func tsxScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool, scannedComment *bool) bool {
-	lexer.SetResultSymbol(tsxSymAutoSemicolon)
+func tsxScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool, symbols *[tsxTokenCount]gotreesitter.Symbol, scannedComment *bool) bool {
+	lexer.SetResultSymbol(symbols[tsxTokAutoSemicolon])
 	lexer.MarkEnd()
 
 	for {
@@ -247,7 +354,7 @@ func tsxScanWSAndComments(lexer *gotreesitter.ExternalLexer, scannedComment *boo
 	}
 }
 
-func tsxScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
+func tsxScanTernaryQmark(lexer *gotreesitter.ExternalLexer, symbols *[tsxTokenCount]gotreesitter.Symbol) bool {
 	for unicode.IsSpace(lexer.Lookahead()) {
 		lexer.Advance(true)
 	}
@@ -263,7 +370,7 @@ func tsxScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	lexer.MarkEnd()
-	lexer.SetResultSymbol(tsxSymTernaryQmark)
+	lexer.SetResultSymbol(symbols[tsxTokTernaryQmark])
 
 	for unicode.IsSpace(lexer.Lookahead()) {
 		lexer.Advance(false)
@@ -280,7 +387,7 @@ func tsxScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 	return true
 }
 
-func tsxScanClosingComment(lexer *gotreesitter.ExternalLexer) bool {
+func tsxScanClosingComment(lexer *gotreesitter.ExternalLexer, symbols *[tsxTokenCount]gotreesitter.Symbol) bool {
 	for unicode.IsSpace(lexer.Lookahead()) || lexer.Lookahead() == 0x2028 || lexer.Lookahead() == 0x2029 {
 		lexer.Advance(true)
 	}
@@ -311,12 +418,12 @@ func tsxScanClosingComment(lexer *gotreesitter.ExternalLexer) bool {
 		lexer.Advance(false)
 	}
 
-	lexer.SetResultSymbol(tsxSymHtmlComment)
+	lexer.SetResultSymbol(symbols[tsxTokHtmlComment])
 	lexer.MarkEnd()
 	return true
 }
 
-func tsxScanJsxText(lexer *gotreesitter.ExternalLexer) bool {
+func tsxScanJsxText(lexer *gotreesitter.ExternalLexer, symbols *[tsxTokenCount]gotreesitter.Symbol) bool {
 	sawText := false
 	atNewline := false
 	onlyWhitespace := true
@@ -368,7 +475,7 @@ func tsxScanJsxText(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	lexer.MarkEnd()
-	lexer.SetResultSymbol(tsxSymJsxText)
+	lexer.SetResultSymbol(symbols[tsxTokJsxText])
 	return sawText
 }
 

--- a/grammars/tsx_scanner_binding_test.go
+++ b/grammars/tsx_scanner_binding_test.go
@@ -1,0 +1,78 @@
+//go:build !grammar_subset || grammar_subset_tsx
+
+package grammars
+
+import (
+	"slices"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// TestTsxExternalScannerBindsPositionally is the regression witness for the
+// tsx blob-regen scanner-adaptation corruption: a Language whose automaton
+// grew (or otherwise shifted overall symbol numbering) still emits the same
+// 10 externals in the same declared order, but under different absolute
+// Symbol IDs than the ones tsxSym* were pinned against. Before
+// TsxExternalScanner implemented ExternalScannerForLanguage, the scanner was
+// attached raw (attachExternalScannerForLanguage's non-bound branch) and
+// every SetResultSymbol call emitted the stale, hardcoded tsxSym* IDs
+// regardless of the attached Language's real numbering -- silently
+// mistyping every external scan result on any regenerated table whose
+// automaton size differs from the one those constants were pinned against.
+// This test simulates that shift with a synthetic Language (no blob
+// dependency) and asserts the bound scanner resolves each token to the
+// synthetic Language's own symbol, not the pinned default.
+//
+// Tagged to match tsx_scanner.go exactly (not the broader
+// external_scanner_binding_test.go umbrella): a grammar_subset build that
+// selects only kotlin+swift, for example, would not compile tsx_scanner.go,
+// so this test must not be visible there either.
+func TestTsxExternalScannerBindsPositionally(t *testing.T) {
+	tsxLang := externalBindingTestLanguage(
+		"_automatic_semicolon",
+		"_template_chars",
+		"_ternary_qmark",
+		"html_comment",
+		"||",
+		"escape_sequence",
+		"regex_pattern",
+		"jsx_text",
+		"_function_signature_automatic_semicolon",
+		"__error_recovery",
+	)
+	tsxScanner, ok := TsxExternalScanner{}.ExternalScannerForLanguage(tsxLang).(TsxExternalScanner)
+	if !ok {
+		t.Fatalf("TsxExternalScanner binding type = %T, want TsxExternalScanner", TsxExternalScanner{}.ExternalScannerForLanguage(tsxLang))
+	}
+	if got, want := tsxScanner.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}; !slices.Equal(got, want) {
+		t.Fatalf("tsx externalToToken = %v, want %v", got, want)
+	}
+	// externalBindingTestLanguage assigns ExternalSymbols[i] = Symbol(i+1), which
+	// deliberately does not match any tsxSym* default (166, 167, 168, 169, 81,
+	// 109, 114, 170, 171, 172) -- simulating a regenerated table with shifted
+	// numbering.
+	wantBound := map[int]gotreesitter.Symbol{
+		tsxTokAutoSemicolon:   1,
+		tsxTokTemplateChars:   2,
+		tsxTokTernaryQmark:    3,
+		tsxTokHtmlComment:     4,
+		tsxTokLogicalOr:       5,
+		tsxTokEscapeSequence:  6,
+		tsxTokRegexPattern:    7,
+		tsxTokJsxText:         8,
+		tsxTokFuncSigAutoSemi: 9,
+		tsxTokErrorRecovery:   10,
+	}
+	for tokenIdx, want := range wantBound {
+		if got := tsxScanner.symbols[tokenIdx]; got != want {
+			t.Fatalf("tsx token %d bound symbol = %d, want %d (synthetic Language's own numbering, not the pinned default)", tokenIdx, got, want)
+		}
+	}
+	// The pinned defaults must NOT leak through once a Language is bound --
+	// that leak is exactly the pre-fix corruption (attaching the raw,
+	// unbound scanner to a table whose automaton had grown).
+	if tsxScanner.symbols == tsxDefaultSymTable {
+		t.Fatal("tsx bound symbols still equal tsxDefaultSymTable; binding did not override the pinned defaults")
+	}
+}

--- a/grammars/typescript_scanner.go
+++ b/grammars/typescript_scanner.go
@@ -20,20 +20,90 @@ const (
 	tsTokJsxText         = 7
 	tsTokFuncSigAutoSemi = 8
 	tsTokErrorRecovery   = 9
+	tsTokenCount         = 10
 )
 
+// Concrete symbol IDs from the checked-in TypeScript grammar ExternalSymbols.
+// These are DEFAULTS only: the fallback entries in tsDefaultSymTable, used
+// as-is if Scan is ever invoked on a scanner value that was never bound to a
+// Language (should not happen in production; see ExternalScannerForLanguage).
+// ExternalScannerForLanguage binds the real per-Language symbols
+// POSITIONALLY (by external index, via bindExternalScannerSymbolNames), not
+// by these absolute IDs, so a grammargen-regenerated typescript blob -- which
+// emits the same 10 externals in the same order but under different absolute
+// Symbol numbering once the automaton grows or shrinks -- still lexes
+// correctly instead of silently mistyping every external scan result. See
+// bindExternalScannerSymbolNames for why positional (not absolute-ID or
+// by-name) binding is required; the same pattern is used by the
+// javascript/kotlin/python/swift/dart/rust/hcl scanners.
 const (
 	tsSymAutoSemicolon   gotreesitter.Symbol = 160
 	tsSymTemplateChars   gotreesitter.Symbol = 161
 	tsSymTernaryQmark    gotreesitter.Symbol = 162
 	tsSymHtmlComment     gotreesitter.Symbol = 163
+	tsSymLogicalOr       gotreesitter.Symbol = 72
+	tsSymEscapeSequence  gotreesitter.Symbol = 103
+	tsSymRegexPattern    gotreesitter.Symbol = 108
 	tsSymJsxText         gotreesitter.Symbol = 164
 	tsSymFuncSigAutoSemi gotreesitter.Symbol = 165
+	tsSymErrorRecovery   gotreesitter.Symbol = 166
 )
+
+// tsDefaultSymTable mirrors the tsTok* index order above.
+var tsDefaultSymTable = [tsTokenCount]gotreesitter.Symbol{
+	tsTokAutoSemicolon:   tsSymAutoSemicolon,
+	tsTokTemplateChars:   tsSymTemplateChars,
+	tsTokTernaryQmark:    tsSymTernaryQmark,
+	tsTokHtmlComment:     tsSymHtmlComment,
+	tsTokLogicalOr:       tsSymLogicalOr,
+	tsTokEscapeSequence:  tsSymEscapeSequence,
+	tsTokRegexPattern:    tsSymRegexPattern,
+	tsTokJsxText:         tsSymJsxText,
+	tsTokFuncSigAutoSemi: tsSymFuncSigAutoSemi,
+	tsTokErrorRecovery:   tsSymErrorRecovery,
+}
+
+// tsExternalSymbolNames lists the typescript grammar's external tokens in
+// declaration order (matching the tsTok* indexes above and the language's
+// ExternalSymbols order). Used by ExternalScannerForLanguage to bind this
+// scanner's token slots to a Language's external symbols positionally, the
+// same pattern used by the javascript/kotlin/python/swift/dart/rust/hcl
+// scanners. See bindExternalScannerSymbolNames for why positional (not
+// absolute-ID or by-name) binding is required.
+var tsExternalSymbolNames = []string{
+	"_automatic_semicolon",
+	"_template_chars",
+	"_ternary_qmark",
+	"html_comment",
+	"||",
+	"escape_sequence",
+	"regex_pattern",
+	"jsx_text",
+	"_function_signature_automatic_semicolon",
+	"__error_recovery",
+}
 
 // TypeScriptExternalScanner handles automatic semicolons, template strings,
 // JSX text, ternary question marks, and HTML comments for TypeScript.
-type TypeScriptExternalScanner struct{}
+type TypeScriptExternalScanner struct {
+	symbols         [tsTokenCount]gotreesitter.Symbol
+	externalToToken []int
+}
+
+// ExternalScannerForLanguage binds this scanner's token slots to lang's
+// external symbols positionally (external index i -> scanner token i), so
+// Scan resolves result symbols through the bound table instead of the
+// hardcoded absolute IDs above. Required whenever the attached Language did
+// not come from the exact blob those absolute IDs were pinned against (e.g.
+// a grammargen regeneration that shifts the automaton's overall symbol
+// numbering) -- see bindExternalScannerSymbolNames.
+func (TypeScriptExternalScanner) ExternalScannerForLanguage(lang *gotreesitter.Language) gotreesitter.ExternalScanner {
+	s := TypeScriptExternalScanner{symbols: tsDefaultSymTable}
+	s.externalToToken = bindExternalScannerSymbolNames(lang, tsExternalSymbolNames, func(tokenIdx int, sym gotreesitter.Symbol) {
+		s.symbols[tokenIdx] = sym
+	})
+	return s
+}
 
 func (TypeScriptExternalScanner) Create() any                           { return nil }
 func (TypeScriptExternalScanner) Destroy(payload any)                   {}
@@ -41,54 +111,91 @@ func (TypeScriptExternalScanner) Serialize(payload any, buf []byte) int { return
 func (TypeScriptExternalScanner) Deserialize(payload any, buf []byte)   {}
 func (TypeScriptExternalScanner) SupportsIncrementalReuse() bool        { return true }
 
-func (TypeScriptExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+// symbolTable returns the per-Language-bound result-symbol table, falling
+// back to the pinned defaults when Scan is invoked on an unbound scanner
+// value (s.symbols is still its zero value).
+func (s TypeScriptExternalScanner) symbolTable() *[tsTokenCount]gotreesitter.Symbol {
+	if s.symbols == ([tsTokenCount]gotreesitter.Symbol{}) {
+		return &tsDefaultSymTable
+	}
+	return &s.symbols
+}
+
+// remapValidSymbols translates a Language-external-indexed validSymbols
+// slice into scanner-token-indexed space via s.externalToToken. When the
+// Language's external count and order agree with tsExternalSymbolNames (the
+// common case), externalToToken is the identity permutation and this is a
+// copy; it only diverges when a future grammar version adds, removes, or
+// reorders an external token relative to tsExternalSymbolNames.
+func (s TypeScriptExternalScanner) remapValidSymbols(validSymbols []bool, semanticValid *[tsTokenCount]bool) []bool {
+	if len(s.externalToToken) == 0 {
+		return validSymbols
+	}
+	*semanticValid = [tsTokenCount]bool{}
+	for externalIdx, valid := range validSymbols {
+		if !valid || externalIdx >= len(s.externalToToken) {
+			continue
+		}
+		tokenIdx := s.externalToToken[externalIdx]
+		if tokenIdx >= 0 && tokenIdx < tsTokenCount {
+			semanticValid[tokenIdx] = true
+		}
+	}
+	return semanticValid[:]
+}
+
+func (s TypeScriptExternalScanner) Scan(payload any, lexer *gotreesitter.ExternalLexer, validSymbols []bool) bool {
+	var semanticValid [tsTokenCount]bool
+	validSymbols = s.remapValidSymbols(validSymbols, &semanticValid)
+	symbols := s.symbolTable()
+
 	if tsValid(validSymbols, tsTokTemplateChars) {
 		if tsValid(validSymbols, tsTokAutoSemicolon) {
 			return false
 		}
-		return tsScanTemplateChars(lexer)
+		return tsScanTemplateChars(lexer, symbols)
 	}
 
 	preferAutoSemicolon := tsPreferAutoSemicolonOverJsxText(lexer, validSymbols)
 
 	if tsValid(validSymbols, tsTokJsxText) && !preferAutoSemicolon {
-		if tsScanJsxText(lexer) {
+		if tsScanJsxText(lexer, symbols) {
 			return true
 		}
 	}
 
 	if tsValid(validSymbols, tsTokAutoSemicolon) || tsValid(validSymbols, tsTokFuncSigAutoSemi) {
 		scannedComment := false
-		ret := tsScanAutoSemicolon(lexer, validSymbols, &scannedComment)
+		ret := tsScanAutoSemicolon(lexer, validSymbols, symbols, &scannedComment)
 		if !ret && !scannedComment && tsValid(validSymbols, tsTokTernaryQmark) && lexer.Lookahead() == '?' {
-			return tsScanTernaryQmark(lexer)
+			return tsScanTernaryQmark(lexer, symbols)
 		}
 		if !ret && !scannedComment && preferAutoSemicolon && tsValid(validSymbols, tsTokJsxText) {
-			return tsScanJsxText(lexer)
+			return tsScanJsxText(lexer, symbols)
 		}
 		return ret
 	}
 
 	if tsValid(validSymbols, tsTokJsxText) && preferAutoSemicolon {
-		return tsScanJsxText(lexer)
+		return tsScanJsxText(lexer, symbols)
 	}
 
 	if tsValid(validSymbols, tsTokTernaryQmark) {
-		return tsScanTernaryQmark(lexer)
+		return tsScanTernaryQmark(lexer, symbols)
 	}
 
 	if tsValid(validSymbols, tsTokHtmlComment) &&
 		!tsValid(validSymbols, tsTokLogicalOr) &&
 		!tsValid(validSymbols, tsTokEscapeSequence) &&
 		!tsValid(validSymbols, tsTokRegexPattern) {
-		return tsScanClosingComment(lexer)
+		return tsScanClosingComment(lexer, symbols)
 	}
 
 	return false
 }
 
-func tsScanTemplateChars(lexer *gotreesitter.ExternalLexer) bool {
-	lexer.SetResultSymbol(tsSymTemplateChars)
+func tsScanTemplateChars(lexer *gotreesitter.ExternalLexer, symbols *[tsTokenCount]gotreesitter.Symbol) bool {
+	lexer.SetResultSymbol(symbols[tsTokTemplateChars])
 	hasContent := false
 	for {
 		lexer.MarkEnd()
@@ -116,8 +223,8 @@ func tsScanTemplateChars(lexer *gotreesitter.ExternalLexer) bool {
 	}
 }
 
-func tsScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool, scannedComment *bool) bool {
-	lexer.SetResultSymbol(tsSymAutoSemicolon)
+func tsScanAutoSemicolon(lexer *gotreesitter.ExternalLexer, validSymbols []bool, symbols *[tsTokenCount]gotreesitter.Symbol, scannedComment *bool) bool {
+	lexer.SetResultSymbol(symbols[tsTokAutoSemicolon])
 	lexer.MarkEnd()
 
 	for {
@@ -247,7 +354,7 @@ func tsScanWSAndComments(lexer *gotreesitter.ExternalLexer, scannedComment *bool
 	}
 }
 
-func tsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
+func tsScanTernaryQmark(lexer *gotreesitter.ExternalLexer, symbols *[tsTokenCount]gotreesitter.Symbol) bool {
 	for unicode.IsSpace(lexer.Lookahead()) {
 		lexer.Advance(true)
 	}
@@ -263,7 +370,7 @@ func tsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	lexer.MarkEnd()
-	lexer.SetResultSymbol(tsSymTernaryQmark)
+	lexer.SetResultSymbol(symbols[tsTokTernaryQmark])
 
 	for unicode.IsSpace(lexer.Lookahead()) {
 		lexer.Advance(false)
@@ -280,7 +387,7 @@ func tsScanTernaryQmark(lexer *gotreesitter.ExternalLexer) bool {
 	return true
 }
 
-func tsScanClosingComment(lexer *gotreesitter.ExternalLexer) bool {
+func tsScanClosingComment(lexer *gotreesitter.ExternalLexer, symbols *[tsTokenCount]gotreesitter.Symbol) bool {
 	for unicode.IsSpace(lexer.Lookahead()) || lexer.Lookahead() == 0x2028 || lexer.Lookahead() == 0x2029 {
 		lexer.Advance(true)
 	}
@@ -311,12 +418,12 @@ func tsScanClosingComment(lexer *gotreesitter.ExternalLexer) bool {
 		lexer.Advance(false)
 	}
 
-	lexer.SetResultSymbol(tsSymHtmlComment)
+	lexer.SetResultSymbol(symbols[tsTokHtmlComment])
 	lexer.MarkEnd()
 	return true
 }
 
-func tsScanJsxText(lexer *gotreesitter.ExternalLexer) bool {
+func tsScanJsxText(lexer *gotreesitter.ExternalLexer, symbols *[tsTokenCount]gotreesitter.Symbol) bool {
 	sawText := false
 	atNewline := false
 	onlyWhitespace := true
@@ -368,7 +475,7 @@ func tsScanJsxText(lexer *gotreesitter.ExternalLexer) bool {
 	}
 
 	lexer.MarkEnd()
-	lexer.SetResultSymbol(tsSymJsxText)
+	lexer.SetResultSymbol(symbols[tsTokJsxText])
 	return sawText
 }
 

--- a/grammars/typescript_scanner_binding_test.go
+++ b/grammars/typescript_scanner_binding_test.go
@@ -1,0 +1,78 @@
+//go:build !grammar_subset || grammar_subset_typescript
+
+package grammars
+
+import (
+	"slices"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// TestTypeScriptExternalScannerBindsPositionally is the regression witness for
+// the typescript blob-regen scanner-adaptation corruption: a Language whose
+// automaton grew (or otherwise shifted overall symbol numbering) still emits
+// the same 10 externals in the same declared order, but under different
+// absolute Symbol IDs than the ones tsSym* were pinned against. Before
+// TypeScriptExternalScanner implemented ExternalScannerForLanguage, the
+// scanner was attached raw (attachExternalScannerForLanguage's non-bound
+// branch) and every SetResultSymbol call emitted the stale, hardcoded tsSym*
+// IDs regardless of the attached Language's real numbering -- silently
+// mistyping every external scan result on any regenerated table whose
+// automaton size differs from the one those constants were pinned against.
+// This test simulates that shift with a synthetic Language (no blob
+// dependency) and asserts the bound scanner resolves each token to the
+// synthetic Language's own symbol, not the pinned default.
+//
+// Tagged to match typescript_scanner.go exactly (not the broader
+// external_scanner_binding_test.go umbrella): a grammar_subset build that
+// selects only kotlin+swift, for example, would not compile
+// typescript_scanner.go, so this test must not be visible there either.
+func TestTypeScriptExternalScannerBindsPositionally(t *testing.T) {
+	tsLang := externalBindingTestLanguage(
+		"_automatic_semicolon",
+		"_template_chars",
+		"_ternary_qmark",
+		"html_comment",
+		"||",
+		"escape_sequence",
+		"regex_pattern",
+		"jsx_text",
+		"_function_signature_automatic_semicolon",
+		"__error_recovery",
+	)
+	tsScanner, ok := TypeScriptExternalScanner{}.ExternalScannerForLanguage(tsLang).(TypeScriptExternalScanner)
+	if !ok {
+		t.Fatalf("TypeScriptExternalScanner binding type = %T, want TypeScriptExternalScanner", TypeScriptExternalScanner{}.ExternalScannerForLanguage(tsLang))
+	}
+	if got, want := tsScanner.externalToToken, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}; !slices.Equal(got, want) {
+		t.Fatalf("typescript externalToToken = %v, want %v", got, want)
+	}
+	// externalBindingTestLanguage assigns ExternalSymbols[i] = Symbol(i+1), which
+	// deliberately does not match any tsSym* default (160, 161, 162, 163, 72,
+	// 103, 108, 164, 165, 166) -- simulating a regenerated table with shifted
+	// numbering.
+	wantBound := map[int]gotreesitter.Symbol{
+		tsTokAutoSemicolon:   1,
+		tsTokTemplateChars:   2,
+		tsTokTernaryQmark:    3,
+		tsTokHtmlComment:     4,
+		tsTokLogicalOr:       5,
+		tsTokEscapeSequence:  6,
+		tsTokRegexPattern:    7,
+		tsTokJsxText:         8,
+		tsTokFuncSigAutoSemi: 9,
+		tsTokErrorRecovery:   10,
+	}
+	for tokenIdx, want := range wantBound {
+		if got := tsScanner.symbols[tokenIdx]; got != want {
+			t.Fatalf("typescript token %d bound symbol = %d, want %d (synthetic Language's own numbering, not the pinned default)", tokenIdx, got, want)
+		}
+	}
+	// The pinned defaults must NOT leak through once a Language is bound --
+	// that leak is exactly the pre-fix corruption (attaching the raw,
+	// unbound scanner to a table whose automaton had grown).
+	if tsScanner.symbols == tsDefaultSymTable {
+		t.Fatal("typescript bound symbols still equal tsDefaultSymTable; binding did not override the pinned defaults")
+	}
+}


### PR DESCRIPTION
## Summary

Binds the TypeScript and TSX external scanners to their attached Language positionally, closing the same hardcoded-symbol-ID gap fixed for the JavaScript scanner in #618.

Both scanners previously called `SetResultSymbol` with hardcoded absolute `Symbol` constants pinned to the currently shipped `typescript.bin`/`tsx.bin`. That pin was silently correct only because no one had regenerated those blobs since the constants were written. Any future regen that shifts the automaton's absolute symbol numbering would mistype every external scan result with no compiler or test signal, because a fresh `typescript.bin` regen at HEAD (5930 -> 28993 states) reproduces the same corruption class the JavaScript fix addressed.

## Changes

- `TypeScriptExternalScanner` and `TsxExternalScanner` now implement `ExternalScannerForLanguage`, binding their token slots to the attached `Language`'s external symbols positionally via `bindExternalScannerSymbolNames` (the same helper used by javascript/kotlin/python/swift/dart/rust/hcl).
- Both scanners gain `symbols`/`externalToToken` state, a `symbolTable()` fallback to pinned defaults for an unbound scanner value, and `remapValidSymbols()` to translate the Language-external-indexed `validSymbols` into scanner-token-indexed space.
- `SetResultSymbol` calls in every scan helper (`tsScanTemplateChars`, `tsScanAutoSemicolon`, `tsScanTernaryQmark`, `tsScanClosingComment`, `tsScanJsxText`, and the `tsx` equivalents) now resolve through the bound table instead of the hardcoded constants.
- New `typescript_scanner_binding_test.go` / `tsx_scanner_binding_test.go`: regression witnesses that bind each scanner against a synthetic `Language` with shifted symbol numbering (mirroring `javascript_scanner_binding_test.go`) and assert the bound result differs from the pinned defaults.
- `external_scanner_positional_binding_test.go`: extended `TestRealLanguageExternalBindingTablesArePositional` with typescript/tsx blocks that pin the currently-shipped blobs' bindings as permanent regression guards.

Shipped-blob behavior is unaffected: the currently shipped `typescript.bin`/`tsx.bin` blobs' `ExternalSymbols` already match the previously-hardcoded constants at every index, so positional binding resolves to byte-identical `SetResultSymbol` values. `go test ./grammars -count=1` passes with no digest or fixture changes.

## Not included: javascript.bin resync

A companion change was planned to resync the stale `grammars/grammar_blobs/javascript.bin` (last generated 2026-03-02, predating the generator's declared-conflict retention fix from 2026-03-16) and flip the `corpus_real_small_functions` witness in `cgo_harness/javascript_election_local_parity_test.go`.

That resync is **not** included here. A fresh regen (`go run ./cmd/grammargen emit javascript -bin ...`, both with and without `-lr-split`) does fix the targeted witness, but C-oracle comparison against the real corpus found it introduces new divergences that do not exist on the currently shipped blob:

- `corpus_real/javascript/large__jquery.js`: 0 mismatches on the shipped blob -> 34 mismatches on the fresh blob (`update_expression`/`member_expression`/`.` token misclassification around byte ~46000).
- `corpus_real/javascript/large__text-editor-component.js`: 0 mismatches (clean parse) on the shipped blob -> the fresh blob's root collapses entirely into a single `ERROR` node (3 children instead of 44), diverging from C's clean `program` root.
- The `-lr-split` alternative regenerates a table that fails far worse (root `ERROR` at byte 472/57 on those same two files).

Both regressions were confirmed absent on the currently shipped blob via the same C-oracle comparison, so this is a new regression introduced by regenerating against the current grammargen generator, not a pre-existing gap. The `javascript.bin` resync needs grammargen-level investigation before it can ship; it is being tracked separately rather than shipped alongside this scanner-binding fix.

## Testing

- `go build ./...`
- `go test ./grammars -count=1`
- `go test ./grammars -tags 'grammar_subset,grammar_subset_typescript' ./grammars/...`, same for `tsx`, and for `kotlin+swift` (confirms build-tag isolation)
- `go vet ./...`
- `go test . -run '^TestW5JavaScriptFamilyTransientErrorGate$' -count=1`
