### PR TITLE
optimize(parsercore): add condense direct-append and dispatch cell-validation skip

### DIFF
--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -76,14 +76,32 @@ const (
 // repeatedly interpreting immutable action records without weakening the
 // existing ordering and authentication gates.
 type ActionRowDescriptor struct {
-	kind      ActionRowKind
-	hasShift  bool
-	hasReduce bool
+	kind              ActionRowKind
+	hasShift          bool
+	hasReduce         bool
+	dispatchSupported bool
 }
 
 func (d ActionRowDescriptor) Kind() ActionRowKind { return d.kind }
 func (d ActionRowDescriptor) HasShift() bool      { return d.hasShift }
 func (d ActionRowDescriptor) HasReduce() bool     { return d.hasReduce }
+
+// DispatchSupported reports whether the root package's generic scheduler
+// dispatch loop can prove this row is not an unsupported cell without
+// reading the current token. It holds exactly for ActionRowShift,
+// ActionRowReduce, and ActionRowConflict: parsercore_phase0_driver.go's
+// diagnosticParserCoreGenericUnsupportedCellDescriptor returns "supported"
+// (a nil decline) for those three kinds unconditionally, never consulting
+// its token argument, while ActionRowExtraShift and ActionRowAccept still
+// need the token's width/EOF shape and ActionRowEmpty/ActionRowUnsupported
+// are never supported. This is table-derived and immutable once the row is
+// decoded (describeActionRow computes it once per distinct action row, not
+// once per dispatch pass), so the dispatch loop's per-cell, per-pass
+// unsupported check can read this field instead of re-deriving the same
+// kind-only fact on every pass a cell with this shape is dispatched
+// (spec.campaign.v7 tranche C0 item 4, the "cell-array and descriptor
+// validation" L1 sub-item). Keep this in sync with that function's switch.
+func (d ActionRowDescriptor) DispatchSupported() bool { return d.dispatchSupported }
 
 type actionRowData struct {
 	actions    []Action
@@ -174,6 +192,7 @@ func describeActionRow(actions []Action) ActionRowDescriptor {
 	}
 	if len(actions) > 1 {
 		descriptor.kind = ActionRowConflict
+		descriptor.dispatchSupported = true
 		return descriptor
 	}
 	switch actions[0].Type {
@@ -182,9 +201,11 @@ func describeActionRow(actions []Action) ActionRowDescriptor {
 			descriptor.kind = ActionRowExtraShift
 		} else {
 			descriptor.kind = ActionRowShift
+			descriptor.dispatchSupported = true
 		}
 	case ActionReduce:
 		descriptor.kind = ActionRowReduce
+		descriptor.dispatchSupported = true
 	case ActionAccept:
 		descriptor.kind = ActionRowAccept
 	default:
@@ -2302,6 +2323,26 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		return condenseOutcome{}, err
 	}
 	probe, oldID := c.boundaries.probe(boundaryIdentityFromKey(key))
+	if !probe.found {
+		// No incumbent has ever published this boundary in the current
+		// frontier: exactly one candidate exists (the incoming link), so no
+		// fold comparison against another link is possible, and there is no
+		// historical predecessor to retire. This is the L1
+		// deterministic-frontier direct-append fast path (spec.campaign.v7
+		// tranche C0 item 4; ginkgo's open question 3, "can
+		// condenseWithOutcomeAtomic prove a single pop path and take a
+		// direct append"). condenseDirectAppend produces the exact bytes the
+		// general path below would: every historical* field stays zero,
+		// oldID stays 0, and the ~200-line fold-comparison block is
+		// unreachable for this shape either way. This is a restructuring of
+		// already-dead branches for a proven condition, not a behavior
+		// change. publishBoundary still gates journal writes on
+		// len(c.transactions) unchanged, so the rollback contract this
+		// function depends on is untouched -- this function still cannot
+		// prove a caller can never roll back past this append, so it does
+		// not weaken that contract.
+		return c.condenseDirectAppend(key, probe, prev.pathCount, in)
+	}
 	historicalBoundarySplit := false
 	var historicalCleanPathRank CleanPathRankSelection
 	var historicalLineage uint16
@@ -2569,6 +2610,49 @@ func (c *Core) condenseWithOutcomeAtomic(key boundaryKey, in linkInput) (condens
 		c.recordLinkUnionAlternateAppended()
 	}
 	return buildOutcome(Head{Node: id}, change), nil
+}
+
+// condenseDirectAppend is condenseWithOutcomeAtomic's single-candidate fast
+// path: probe.found is false, so this frontier has never published key
+// before, in is the sole candidate, and no fold comparison or historical
+// retirement applies. Every argument and every write below matches exactly
+// what the general path performs when oldID stays 0 throughout -- the same
+// arena-cap checks, the same unlinked (next: 0) single-link node, the same
+// publishBoundary call against the same probe, and the same zero-valued
+// condenseOutcome shape (change: condenseNew, every historical* field at its
+// zero value). publishBoundary keeps deciding journal writes from
+// len(c.transactions) unchanged; this helper does not touch that contract.
+func (c *Core) condenseDirectAppend(key boundaryKey, probe boundaryProbe, prevPathCount uint64, in linkInput) (condenseOutcome, error) {
+	if uint64(len(c.links))+1 > uint64(c.limits.MaxLinks) || uint64(len(c.links)) >= math.MaxUint32 {
+		return condenseOutcome{}, errors.New("parser-core phase zero: link arena cap")
+	}
+	if uint64(len(c.nodes))+1 > uint64(c.limits.MaxNodes) || uint64(len(c.nodes)) >= math.MaxUint32 {
+		return condenseOutcome{}, errors.New("parser-core phase zero: node arena cap")
+	}
+	linkID := LinkID(uint64(len(c.links)) + 1)
+	flags := uint32(0)
+	if in.order.Present {
+		flags |= linkFlagHasOrder
+	}
+	c.links = append(c.links, linkRecord{
+		prev: in.prev, payload: in.payload, scoreDelta: in.scoreDelta,
+		order: in.order.Value, flags: flags,
+	})
+	c.addWork(&c.work.GraphLinkAdditionsProxy, 1)
+	id, err := c.appendNodeAt(nodeRecord{
+		state: key.state, byteOffset: key.byteOffset,
+		firstLink: uint32(linkID), linkCount: 1, pathCount: prevPathCount,
+	}, key.checkpoint)
+	if err != nil {
+		return condenseOutcome{}, err
+	}
+	if err := c.publishBoundary(probe, id); err != nil {
+		return condenseOutcome{}, err
+	}
+	if phase0AEnabled {
+		phase0AObserveDirectPublication(c, key, in, linkID, id, 0)
+	}
+	return condenseOutcome{head: Head{Node: id}, change: condenseNew}, nil
 }
 
 func (c *Core) linkEqualInput(link linkRecord, in linkInput) (bool, error) {

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3282,7 +3282,20 @@ func (s *diagnosticParserCoreGenericScheduler) dispatchPassActive() (*diagnostic
 	for index := range cells {
 		cell := &cells[index]
 		descriptor := cell.descriptor()
-		if cell.selectedBy == diagnosticParserCoreCellSelectionNone {
+		// descriptor.DispatchSupported() is table-derived and immutable once
+		// this row was decoded (core.describeActionRow, once per distinct
+		// action row -- not once per dispatch pass): it is true exactly when
+		// diagnosticParserCoreGenericUnsupportedCellDescriptor's own kind
+		// switch below would already return a nil decline without reading
+		// its token argument (Shift, Reduce, and Conflict rows). Skipping
+		// the call for those rows avoids re-deriving that same kind-only
+		// fact, and the cell.dispatchToken(s.token) token-struct copy that
+		// building its argument would cost, on every pass that dispatches an
+		// already-proven-supported cell (spec.campaign.v7 tranche C0 item 4,
+		// the "cell-array and descriptor validation" L1 sub-item). Rows that
+		// still need the token (ExtraShift, Accept) or are never supported
+		// (Empty, Unsupported) keep paying the full per-pass call unchanged.
+		if cell.selectedBy == diagnosticParserCoreCellSelectionNone && !descriptor.DispatchSupported() {
 			if unsupported := diagnosticParserCoreGenericUnsupportedCellDescriptor(cell.headerIndex, cell.dispatchToken(s.token), cell.actions(), descriptor); unsupported != nil {
 				return unsupported, nil
 			}


### PR DESCRIPTION
## Summary

This change adds two evidence-selected fast paths from the L1
deterministic-frontier follow-on model (`docs/perf-attribution.md`, the
2026-08-02 addendum). It touches `internal/parsercorephase0/core.go` and
`parsercore_phase0_driver.go` only.

- It adds a single-path condense append in `condenseWithOutcomeAtomic`.
- It hoists an invariant cell-descriptor check out of the dispatch loop.

Work counts and trees stay unchanged. Timing measurement defers to the
sealed epoch, per the merged L1 precedent (PR #580).

## Changes

- `condenseDirectAppend`: when a boundary has never published in the
  current frontier (`probe.found` is false), exactly one candidate exists
  and no fold comparison can occur. The general path already treats this
  case as dead code (`oldID` stays 0 through the whole function). This adds
  an explicit fast path that reaches the same bytes without evaluating the
  dead branches. `publishBoundary` still decides journal writes from
  `len(c.transactions)`, unchanged, so the rollback contract stays intact.
  The open question ("can the transaction wrapper itself be skipped") stays
  open: this change does not touch it.
- `ActionRowDescriptor.DispatchSupported`: computed once per decoded action
  row, true for Shift, Reduce, and Conflict rows. The dispatch loop's
  per-pass unsupported-cell check
  (`diagnosticParserCoreGenericUnsupportedCellDescriptor`) already returns
  "supported" unconditionally for those three row kinds, without reading
  the token. The new field lets the dispatch loop skip that call, and the
  token-struct copy building its argument, for cells it has already proven
  supported from the table alone.

## Gates

- Build and vet pass on all six tag combinations in use
  (`gts_no_parsercorephase0`, `gts_parsercorephase0`,
  `gts_parsercorephase0,gts_parsercorephase0a`,
  `gts_parsercorephase0,gts_workcount`,
  `gts_parsercorephase0_selectedstore_onepass`, and default).
- `go test ./internal/parsercorephase0/...` passes, with `-race`.
- `go test .` passes, untagged and under `-tags gts_parsercorephase0`. The
  tagged full suite carries pre-existing, test-order-dependent failures on
  unmodified `main` too; every failing test name reproduces identically,
  isolated, on both revisions (verified with two independently built
  baseline binaries).
- `TestDiagnosticParserCoreCanonicalAdmissions`: all four canonical
  fixtures pass, with byte-identical digests.
- `TestParserCoreWorkCountChild`: all four canonical fixtures produce
  byte-identical JSON before and after (shifts, reductions,
  emitted-pop-paths, emitted-pop-payloads, canonicalizations, peak-headers,
  elections, conflicts, and forks all unchanged).
- `TestAdmissionCandidateScorecard206`: `PASS=200 DIVERGE=0 FALLBACK=1
  SKIP=5 ERROR=0 total=206`, matching the PR #580 and prior-worker
  precedent exactly.
- Zero-alloc pins hold. `AllocsPerRun`-based tests pass.
  `BenchmarkAdmissionCandidateGoQueryCompileWarmRoute` allocs/op stays at 8
  before and after, across repeated runs.

## Timing (host-caveated, not a timing claim)

12-round order-alternating A/B, `BenchmarkParserCoreFreshFullCanonical`,
`GOMAXPROCS=1`, compared with `benchstat`: no fixture reaches significance
(rewrite p=0.243, query_compile p=0.511, language p=0.801, grammargen_lr
p=0.979). This sits inside this session's stated 30-56% local noise floor.
Every work-count, allocation, and byte metric across all rounds and
fixtures matches exactly (p=1.000). The timing claim defers to the sealed
epoch, per the merged L1 precedent.

Do not merge.
