### PR TITLE
optimize(parsercore-phase0): shrink hot-path structs and pin benchmark to production route

### DIFF
--- a/benchmark_real_go_test.go
+++ b/benchmark_real_go_test.go
@@ -100,6 +100,18 @@ func benchmarkWarmRealGoDFA(b *testing.B, fixture benchfixtures.LoadedFixture, l
 	admitRealGoBenchmarkFixture(b, fixture, lang)
 	gotreesitter.DrainArenaPools()
 	parser := gotreesitter.NewParser(lang)
+	// Pin to production, mirroring admitRealGoBenchmarkFixture's own parser
+	// above: this benchmark reports and asserts on GLR-only runtime counters
+	// (max_stacks, peak_depth, nodes/op below), which the compact candidate
+	// route never populates. Phase-3 admission defaults the candidate route
+	// on, and every one of this benchmark's fixtures sits under the compact
+	// eligibility ceiling, so an unpinned parser here silently measures the
+	// compact route on both sides of an A/B comparison instead of production
+	// (b4b-width-repair audit, 2026-08; oak-b's v9 decomposition first
+	// caught this reproducing unmodified on origin/main). The guard
+	// assertion after the timed loop below fails loudly if this pin is ever
+	// lost again, instead of silently re-conflating the two routes.
+	parser.SetAdmissionCandidateRoute(false)
 	warmTree, err := parser.Parse(fixture.Source)
 	if err != nil {
 		releaseBenchmarkTree(warmTree)
@@ -110,6 +122,8 @@ func benchmarkWarmRealGoDFA(b *testing.B, fixture benchfixtures.LoadedFixture, l
 		b.Fatalf("%s warm parse: %v", fixture.Fixture.ID, err)
 	}
 	warmTree.Release()
+
+	routedBefore, _ := gotreesitter.AdmissionCandidateCounters()
 
 	b.ReportAllocs()
 	b.SetBytes(int64(len(fixture.Source)))
@@ -132,7 +146,30 @@ func benchmarkWarmRealGoDFA(b *testing.B, fixture benchfixtures.LoadedFixture, l
 		tree.Release()
 	}
 	b.StopTimer()
+	verifyRealGoBenchmarkMeasuredProduction(b, fixture.Fixture.ID, routedBefore, lastRuntime)
 	reportRealGoRuntime(b, lastRuntime)
+}
+
+// verifyRealGoBenchmarkMeasuredProduction guards against silently re-
+// conflating the compact candidate route into a benchmark that pins and
+// reports on the production route (b4b-width-repair audit, 2026-08; see
+// benchmarkWarmRealGoDFA's SetAdmissionCandidateRoute comment above). It
+// fails closed on either signal alone: the process-wide candidate-route
+// counter must not have moved across the timed loop (routedBefore is
+// sampled after the pinned warm parse, so this isolates the b.N loop), and
+// the final timed parse's GLR-only runtime counters -- which the compact
+// route never populates -- must be nonzero. A genuine production route parse
+// always seeds at least one GSS stack, so MaxStacksSeen/PeakStackDepth are
+// never legitimately zero on success.
+func verifyRealGoBenchmarkMeasuredProduction(b *testing.B, fixtureID string, routedBefore uint64, rt gotreesitter.ParseRuntime) {
+	b.Helper()
+	routedAfter, _ := gotreesitter.AdmissionCandidateCounters()
+	if routedAfter != routedBefore {
+		b.Fatalf("%s: compact candidate route counter moved (%d -> %d) during the pinned timed loop: this benchmark is measuring the compact route, not production", fixtureID, routedBefore, routedAfter)
+	}
+	if rt.MaxStacksSeen == 0 && rt.PeakStackDepth == 0 {
+		b.Fatalf("%s: timed parse reported MaxStacksSeen=0 and PeakStackDepth=0 -- GLR-only counters the compact route never populates; this benchmark is not measuring production", fixtureID)
+	}
 }
 
 func verifyRealGoBenchmarkGrammarIdentity() error {

--- a/internal/parsercorephase0/alternative_set_test.go
+++ b/internal/parsercorephase0/alternative_set_test.go
@@ -51,52 +51,69 @@ func TestNewAlternativeSetMember(t *testing.T) {
 	}
 }
 
+// TestAlternativeSetInsertAscendingStaysInline pins the inline/spill
+// boundary at alternativeSetInlineCapacity members (not a hardcoded literal:
+// the b4b-width-repair audit, 2026-08, tuned this constant down from 4 to 2,
+// and this test must track it rather than re-pin the old width).
 func TestAlternativeSetInsertAscendingStaysInline(t *testing.T) {
 	compact := &Core{}
 	var set AlternativeSet
-	for _, member := range []uint32{2, 5, 9, 20} {
+	members := make([]uint32, alternativeSetInlineCapacity)
+	for i := range members {
+		members[i] = uint32(2 + i*3)
+	}
+	for _, member := range members {
 		if !compact.alternativeSetInsert(&set, member) {
 			t.Fatalf("insert(%d) reported no change", member)
 		}
 	}
 	if set.spilled() {
-		t.Fatalf("four ascending inserts spilled: %+v", set)
+		t.Fatalf("%d ascending inserts (at capacity) spilled: %+v", alternativeSetInlineCapacity, set)
 	}
-	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint32{2, 5, 9, 20}) {
-		t.Fatalf("members = %v, want [2 5 9 20]", got)
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, members) {
+		t.Fatalf("members = %v, want %v", got, members)
 	}
 	// Duplicate and zero are no-ops.
-	if compact.alternativeSetInsert(&set, 9) {
+	if compact.alternativeSetInsert(&set, members[len(members)-1]) {
 		t.Fatal("duplicate insert reported a change")
 	}
 	if compact.alternativeSetInsert(&set, 0) {
 		t.Fatal("zero-member insert reported a change")
 	}
-	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint32{2, 5, 9, 20}) {
-		t.Fatalf("members after no-ops = %v, want [2 5 9 20]", got)
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, members) {
+		t.Fatalf("members after no-ops = %v, want %v", got, members)
 	}
 }
 
-func TestAlternativeSetFifthMemberSpills(t *testing.T) {
+// TestAlternativeSetOneBeyondCapacitySpills pins that the (capacity+1)th
+// ascending insert -- and only that one -- forces the spill, tracking
+// alternativeSetInlineCapacity rather than a hardcoded literal (see
+// TestAlternativeSetInsertAscendingStaysInline's doc comment).
+func TestAlternativeSetOneBeyondCapacitySpills(t *testing.T) {
 	compact := &Core{}
 	var set AlternativeSet
-	for _, member := range []uint32{1, 2, 3, 4} {
+	for member := uint32(1); member <= alternativeSetInlineCapacity; member++ {
 		compact.alternativeSetInsert(&set, member)
 	}
 	if set.spilled() {
-		t.Fatal("four members already spilled")
+		t.Fatalf("%d members already spilled", alternativeSetInlineCapacity)
 	}
-	if !compact.alternativeSetInsert(&set, 5) {
-		t.Fatal("fifth insert reported no change")
+	overflowMember := uint32(alternativeSetInlineCapacity + 1)
+	if !compact.alternativeSetInsert(&set, overflowMember) {
+		t.Fatal("capacity+1'th insert reported no change")
 	}
 	if !set.spilled() {
-		t.Fatal("fifth member did not spill")
+		t.Fatal("capacity+1'th member did not spill")
 	}
-	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, []uint32{1, 2, 3, 4, 5}) {
-		t.Fatalf("members after spill = %v, want [1 2 3 4 5]", got)
+	want := make([]uint32, alternativeSetInlineCapacity+1)
+	for i := range want {
+		want[i] = uint32(i + 1)
 	}
-	if len(compact.alternativeSpillArena) != 5 {
-		t.Fatalf("spill arena length = %d, want 5", len(compact.alternativeSpillArena))
+	if got := alternativeSetMembersForTest(t, compact, set); !slices.Equal(got, want) {
+		t.Fatalf("members after spill = %v, want %v", got, want)
+	}
+	if len(compact.alternativeSpillArena) != alternativeSetInlineCapacity+1 {
+		t.Fatalf("spill arena length = %d, want %d", len(compact.alternativeSpillArena), alternativeSetInlineCapacity+1)
 	}
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -414,12 +414,19 @@ type nodeLineageRecord struct {
 	blended bool
 }
 
+// Field order groups the two uint32 members (node, owner, setSpillRef)
+// before the trailing byte/uint16-sized fields: setSpillRef needs 4-byte
+// alignment, so declaring it after the 1-byte setCount/setFlags pair (as an
+// earlier revision did) forced 2 bytes of mid-struct padding that this order
+// avoids, matching journal-append-site field order 1:1 (every
+// nodeLineageJournal append already names every field, so this reorder is
+// layout-only and touches no call site).
 type nodeLineageMutation struct {
 	node        NodeID
 	owner       uint32
+	setSpillRef uint32
 	setCount    uint8
 	setFlags    uint8
-	setSpillRef uint32
 	lineage     uint16
 	rank        CleanPathRankSelection
 	converged   bool
@@ -431,8 +438,29 @@ type nodeLineageMutation struct {
 // alternativeSetHardCap is the total recorded-member ceiling; a set that
 // would exceed it stops recording new members and reports Overflowed.
 // spec.b4b-alternative-set.v1 section 3.2, open question 5.
+//
+// v2 widened one packed member from uint16 (event only) to uint32 (event,
+// branch), doubling AlternativeSet's inline array from 8 to 16 bytes and,
+// with it, every by-value container that embeds a set (nodeLineageRecord,
+// ReductionOutput, and diagnosticParserCoreHeader's two copies) -- paid on
+// every header canonicalize double-buffer copy, rollback scratch snapshot,
+// and reduction-output propagation, whether or not that particular set is
+// ever populated (b4b-width-repair audit, 2026-08). 4 was never a load-
+// bearing width: the canonical-fixture census (four fixtures, 8537 converged
+// -split elections) shows 8519/8537 (99.8%) already touch a spilled set by
+// election time and 8424/8537 (98.7%) are already Overflowed at the hard
+// cap, so the inline/spill boundary is nearly vestigial in steady state.
+// Lowering it to 2 -- matching "canonical reductions produce one output 95%
+// of the time and at most two observed" (packAlternativeSetMember's doc
+// comment; census maxBranch=1 on all four fixtures) so a fresh establishment
+// plus one sibling union still never spills -- restores AlternativeSet's
+// inline array to its pre-v2 8 bytes (2 members x 4 bytes, vs. the original
+// 4 members x 2 bytes) at the same total 16-byte struct size, with no change
+// to member encoding, hard cap, or any observable membership: spilled
+// storage is exact and zero-alloc once warm (alternativeSetInsert/
+// alternativeSetMembers already treat inline and spilled uniformly).
 const (
-	alternativeSetInlineCapacity = 4
+	alternativeSetInlineCapacity = 2
 	alternativeSetHardCap        = 32
 )
 
@@ -1797,22 +1825,27 @@ const (
 )
 
 // ReductionOutput is one final canonical boundary and its aggregate freshness
-// relative to the boundary map at entry to ReduceOutputs.
+// relative to the boundary map at entry to ReduceOutputs. Field order groups
+// Head with HistoricalAlternativeSet up front (both 4-byte aligned, so the
+// set immediately follows Head with no gap) and the byte/uint16-sized fields
+// after; every construction site uses keyed fields
+// (reduceOutputsClassifiedIntoActive, scheduler_owned.go), so this reorder
+// is layout-only (b4b-width-repair audit, 2026-08).
 type ReductionOutput struct {
-	Head                         Head
-	Freshness                    ReductionFreshness
-	CleanPathRank                CleanPathRankSelection
-	MultiplePopPaths             bool
-	HistoricalBoundaryProvenance HistoricalBoundaryProvenance
-	HistoricalCleanPathRank      CleanPathRankSelection
-	HistoricalCleanPathLineage   uint16
+	Head Head
 	// HistoricalAlternativeSet is the union of every dead predecessor's
 	// recorded alternative set discovered while producing this boundary
 	// (spec.b4b-alternative-set.v1 section 4, "Dead-node historical
 	// import"). Unlike HistoricalCleanPathRank/Lineage, multiple historical
 	// versions union here instead of poisoning to Unknown/0, because
 	// membership is never invalidated.
-	HistoricalAlternativeSet AlternativeSet
+	HistoricalAlternativeSet     AlternativeSet
+	HistoricalCleanPathLineage   uint16
+	Freshness                    ReductionFreshness
+	CleanPathRank                CleanPathRankSelection
+	MultiplePopPaths             bool
+	HistoricalBoundaryProvenance HistoricalBoundaryProvenance
+	HistoricalCleanPathRank      CleanPathRankSelection
 	// HistoricalBlended carries forward the blended mark accumulated while
 	// building HistoricalAlternativeSet: true when an imported dead record
 	// was itself blended, or when two dead sets unioned into this one
@@ -1823,17 +1856,21 @@ type ReductionOutput struct {
 
 const inlineReductionBoundaryOutputs = 2
 
+// Field order groups key (8-byte aligned), head and historicalSet (4-byte
+// aligned) up front, then the byte/uint16-sized fields; the sole
+// construction site (scratch.store, scheduler_owned.go) uses keyed fields,
+// so this reorder is layout-only (b4b-width-repair audit, 2026-08).
 type reductionBoundaryOutput struct {
 	key                           boundaryKey
 	head                          Head
+	historicalSet                 AlternativeSet
+	historicalLineage             uint16
 	freshness                     ReductionFreshness
 	cleanPathRank                 CleanPathRankSelection
 	historicalBoundarySplit       bool
 	historicalConvergedSplit      bool
 	historicalForestDeterministic bool
 	historicalCleanPathRank       CleanPathRankSelection
-	historicalLineage             uint16
-	historicalSet                 AlternativeSet
 	historicalBlended             bool
 }
 

--- a/internal/parsercorephase0/core_test.go
+++ b/internal/parsercorephase0/core_test.go
@@ -2677,25 +2677,34 @@ func TestCompactArenaRecordsRemainPointerFree(t *testing.T) {
 	// spec.b4b-alternative-set.v1 section 3.2: nodeLineageRecord grew from 8
 	// bytes to the transition size of 24 (owner uint32 + AlternativeSet's 16
 	// bytes + the still-present transition scalars lineage/rank/converged).
-	// spec.b4b-alternative-set.v2 section 3.2 widens AlternativeSet's inline
-	// members to uint32 (16 -> 24 bytes padded, +8) and adds the blended
-	// bool (+1, padded): 24 -> 36. Stage 3 deletes the transition scalars
-	// for a smaller final record. The grown field (AlternativeSet) stays
-	// pointer-free, checked above.
-	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 36 {
-		t.Fatalf("nodeLineageRecord size = %d, want 36", got)
+	// spec.b4b-alternative-set.v2 section 3.2 widened AlternativeSet's inline
+	// members to uint32 (16 -> 24 bytes padded, +8) and added the blended
+	// bool (+1, padded): 24 -> 36. The b4b-width-repair audit (2026-08) then
+	// lowered AlternativeSet's inline capacity from 4 to 2 members (still
+	// uint32-packed (event, branch); the canonical-fixture census shows
+	// 99.8% of elections already spill past 4 members by election time, so
+	// the threshold was not load-bearing) to restore the 16-byte set: 36 ->
+	// 28, 4 bytes over the pre-v2 24 for the still-present blended bool.
+	// Stage 3 deletes the transition scalars for a smaller final record. The
+	// grown field (AlternativeSet) stays pointer-free, checked above.
+	if got := unsafe.Sizeof(nodeLineageRecord{}); got != 28 {
+		t.Fatalf("nodeLineageRecord size = %d, want 28", got)
 	}
 	if got := unsafe.Sizeof(linkRecord{}); got != 32 {
 		t.Fatalf("linkRecord size = %d, want 32", got)
 	}
 	// spec.b4b-alternative-set.v1 section 4: ReductionOutput grew from 12
 	// bytes to 28 with the added HistoricalAlternativeSet field (dead-node
-	// historical import). spec.b4b-alternative-set.v2 section 3.2 widens
-	// AlternativeSet's inline members to uint32 (+8) and adds
-	// HistoricalBlended (+1, padded): 28 -> 40. Stays pointer-free, checked
-	// above.
-	if got := unsafe.Sizeof(ReductionOutput{}); got != 40 {
-		t.Fatalf("ReductionOutput size = %d, want 40", got)
+	// historical import). spec.b4b-alternative-set.v2 section 3.2 widened
+	// AlternativeSet's inline members to uint32 (+8) and added
+	// HistoricalBlended (+1, padded): 28 -> 40. The b4b-width-repair audit
+	// (2026-08) lowered AlternativeSet's inline capacity to 2 (see
+	// nodeLineageRecord's comment above) and reordered fields (Head and
+	// HistoricalAlternativeSet first, both 4-byte aligned) to fold
+	// HistoricalBlended into existing padding: 40 -> 28, exactly the pre-v2
+	// size despite the extra field. Stays pointer-free, checked above.
+	if got := unsafe.Sizeof(ReductionOutput{}); got != 28 {
+		t.Fatalf("ReductionOutput size = %d, want 28", got)
 	}
 	if got := unsafe.Sizeof(popPath{}); got != 88 {
 		t.Fatalf("popPath size = %d, want 88", got)

--- a/parsercore_phase0_alternative_set_census.go
+++ b/parsercore_phase0_alternative_set_census.go
@@ -415,10 +415,13 @@ func (s *diagnosticParserCoreGenericScheduler) diagnosticParserCoreRunThreeProof
 // influences any proof outcome.
 func (s *diagnosticParserCoreGenericScheduler) diagnosticParserCoreThreeProofSpillAndBranchSample(indices []int) (spilled bool, maxBranch uint16) {
 	// alternativeSetInlineSampleCapacity mirrors core.AlternativeSet's own
-	// inline capacity (parsercorephase0/core.go, unexported): a recorded set
-	// longer than this has spilled into the shared arena. Census-only proxy;
-	// never used for a proof decision.
-	const alternativeSetInlineSampleCapacity = 4
+	// inline capacity (internal/parsercorephase0/core.go's unexported
+	// alternativeSetInlineCapacity, currently 2 as of the b4b-width-repair
+	// audit, 2026-08): a recorded set longer than this has spilled into the
+	// shared arena. Census-only proxy; never used for a proof decision, so a
+	// stale value here cannot desync any drop decision -- only this rate
+	// counter (SpillObserved/SpillElections).
+	const alternativeSetInlineSampleCapacity = 2
 	for _, header := range s.headers {
 		members, ok := s.compact.AlternativeSetMembers(header.altSet)
 		if !ok {

--- a/parsercore_phase0_canonical_scratch_internal_test.go
+++ b/parsercore_phase0_canonical_scratch_internal_test.go
@@ -432,11 +432,24 @@ func TestDiagnosticParserCoreCheckpointCompactLayoutsAMD64(t *testing.T) {
 	// field, then by another 24 bytes (lastPersistedHead core.Head +
 	// lastPersistedAltSet core.AlternativeSet) for the per-dispatch persist
 	// skip: 24 -> 40 -> 64. spec.b4b-alternative-set.v2 section 3.2/3.4
-	// widens altSet and lastPersistedAltSet (uint32 members, +8 bytes each)
-	// and adds three bools (blended, resurrectionUnproved,
-	// lastPersistedBlended, +1 each): 64 -> 80 -> 83, padded to 88.
-	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 88 {
-		t.Fatalf("scheduler header size=%d, want 88", got)
+	// widened altSet and lastPersistedAltSet (uint32 members, +8 bytes each)
+	// and added three bools (blended, resurrectionUnproved,
+	// lastPersistedBlended, +1 each): 64 -> 80 -> 83, padded to 88. The
+	// b4b-width-repair audit (2026-08) lowered AlternativeSet's inline
+	// capacity from 4 to 2 members (core.go; the canonical-fixture census
+	// shows 99.8% of elections already spill past 4 members by election
+	// time, so 4 was not load-bearing), shrinking each embedded set back to
+	// 16 bytes, and reordered this struct's fields (both sets and both Head
+	// copies grouped up front, all 4-byte aligned, ahead of the
+	// byte/uint16-sized fields) so the three added bools fold into what
+	// would otherwise be trailing padding: 88 -> 64, exactly the pre-v2
+	// size despite carrying the full (event, branch) sets and all three
+	// bools. This struct is copied by value on every dispatch (the header
+	// canonicalize double-buffer and the rollback scratch snapshot), so the
+	// 24-byte-per-header reduction applies once per copy, twice per
+	// dispatch.
+	if got := unsafe.Sizeof(diagnosticParserCoreHeader{}); got != 64 {
+		t.Fatalf("scheduler header size=%d, want 64", got)
 	}
 	if got := unsafe.Sizeof(diagnosticParserCorePhaseHead{}); got != 12 {
 		t.Fatalf("canonical phase key size=%d, want 12", got)

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -864,10 +864,46 @@ func diagnosticParserCoreSelectedNodeCensus(root *Node) diagnosticParserCoreSele
 	return census
 }
 
+// Field order groups creationSeq (8-byte aligned), then every 4-byte-aligned
+// field (head, checkpoint, altSet, lastPersistedHead, lastPersistedAltSet),
+// then cleanPathLineage (2-byte aligned), then every remaining byte-sized
+// field. This is layout-only: every construction site across the package
+// and its tests uses keyed fields (grep-verified), so declaration order
+// changes memory footprint, never behavior. It restores this struct to its
+// pre-b4b-v2 64 bytes (unsafe.Sizeof-verified, parsercore_phase0_canonical_scratch_internal_test.go)
+// despite carrying two full (event, branch) alternative sets plus three
+// bools v1 never had (b4b-width-repair audit, 2026-08): the widened
+// AlternativeSet's own inline-capacity reduction (core.go) supplies most of
+// the recovered space, and this reorder folds the three new bools into
+// padding a naive append-at-the-end declaration order would otherwise pay
+// for separately.
 type diagnosticParserCoreHeader struct {
-	creationSeq             uint64
-	head                    core.Head
-	checkpoint              core.CheckpointID
+	creationSeq uint64
+	head        core.Head
+	checkpoint  core.CheckpointID
+	// altSet mirrors cleanPathRank/cleanPathLineage but by union rather than
+	// overwrite: it accumulates every converged-split (event, branch) member
+	// this derivation thread has passed through and is never invalidated
+	// (carried unchanged through an external shift that zeroes
+	// cleanPathLineage; see markDiagnosticParserCoreExternalLineage). The
+	// scalar (rank, lineage) pair remains the live decider
+	// (dropGenericNoActionHeads); altSet and blended are read by the v1/v2
+	// containment census only (spec.b4b-alternative-set.v2 section 7).
+	altSet core.AlternativeSet
+	// lastPersistedHead and lastPersistedAltSet record the (head, altSet)
+	// pair persistHeaderLineageOwned last actually wrote to a node. Both are
+	// plain comparable values, so persistHeaderLineageOwned can detect a
+	// no-op persist (same node, same set already recorded there) with two
+	// equality checks instead of re-entering the scheduler-owned set-union
+	// machinery every dispatch. A rolled-back dispatch reverts these fields
+	// along with the rest of the header (diagnosticParserCoreHeaderRollbackScratch
+	// snapshots the whole struct by value), so they never claim a persist
+	// that Core itself undid. lastPersistedBlended extends the same no-op
+	// detection to blended: persistHeaderLineageOwned must also re-persist
+	// when only blended changed (spec.b4b-alternative-set.v2 section 10).
+	lastPersistedHead       core.Head
+	lastPersistedAltSet     core.AlternativeSet
+	cleanPathLineage        uint16
 	freshness               core.ReductionFreshness
 	shifted                 bool
 	accepted                bool
@@ -882,34 +918,11 @@ type diagnosticParserCoreHeader struct {
 	// same certified-language artifact escape that waives the proof itself.
 	resurrectionUnproved bool
 	cleanPathRank        core.CleanPathRankSelection
-	cleanPathLineage     uint16
-	// altSet mirrors cleanPathRank/cleanPathLineage but by union rather than
-	// overwrite: it accumulates every converged-split (event, branch) member
-	// this derivation thread has passed through and is never invalidated
-	// (carried unchanged through an external shift that zeroes
-	// cleanPathLineage; see markDiagnosticParserCoreExternalLineage). The
-	// scalar (rank, lineage) pair remains the live decider
-	// (dropGenericNoActionHeads); altSet and blended are read by the v1/v2
-	// containment census only (spec.b4b-alternative-set.v2 section 7).
-	altSet core.AlternativeSet
 	// blended records whether altSet was ever produced by folding two
 	// incomparable recorded sets together (spec.b4b-alternative-set.v2
 	// section 3.4). A blended header can never serve as a v2 containment
 	// witness (section 5).
-	blended bool
-	// lastPersistedHead and lastPersistedAltSet record the (head, altSet)
-	// pair persistHeaderLineageOwned last actually wrote to a node. Both are
-	// plain comparable values, so persistHeaderLineageOwned can detect a
-	// no-op persist (same node, same set already recorded there) with two
-	// equality checks instead of re-entering the scheduler-owned set-union
-	// machinery every dispatch. A rolled-back dispatch reverts these fields
-	// along with the rest of the header (diagnosticParserCoreHeaderRollbackScratch
-	// snapshots the whole struct by value), so they never claim a persist
-	// that Core itself undid. lastPersistedBlended extends the same no-op
-	// detection to blended: persistHeaderLineageOwned must also re-persist
-	// when only blended changed (spec.b4b-alternative-set.v2 section 10).
-	lastPersistedHead    core.Head
-	lastPersistedAltSet  core.AlternativeSet
+	blended              bool
 	lastPersistedBlended bool
 }
 
@@ -1380,14 +1393,18 @@ type diagnosticParserCoreCanonicalScratch struct {
 	groups        map[diagnosticParserCorePhaseHead]diagnosticParserCoreCanonicalGroup
 }
 
+// Field order groups winner (8-byte aligned int) and altSet (4-byte
+// aligned) up front, then the byte/uint16-sized fields; the sole
+// construction site (canonicalizeLinear/canonicalizeMapped) uses keyed
+// fields, so this reorder is layout-only (b4b-width-repair audit, 2026-08).
 type diagnosticParserCoreCanonicalGroup struct {
 	winner                  int
+	altSet                  core.AlternativeSet
+	cleanPathLineage        uint16
 	runnable                bool
 	convergedReductionSplit bool
 	resurrectionUnproved    bool
 	cleanPathRank           core.CleanPathRankSelection
-	cleanPathLineage        uint16
-	altSet                  core.AlternativeSet
 	blended                 bool
 }
 

--- a/parsercore_phase0_selected_lineage_internal_test.go
+++ b/parsercore_phase0_selected_lineage_internal_test.go
@@ -134,14 +134,18 @@ func newAlternativeSetPinScheduler(t *testing.T) *diagnosticParserCoreGenericSch
 
 // alternativeSetPinMember builds a set from bare events, each on branch 0 --
 // the v1-equivalent shape (spec.b4b-alternative-set.v1 section 5) -- for
-// tests that exercise only event-only containment.
-func alternativeSetPinMember(t *testing.T, members ...uint16) core.AlternativeSet {
+// tests that exercise only event-only containment. compact must be the same
+// Core instance the caller will later read the set back through (typically
+// scheduler.compact): a spilled set's spillRef only resolves against the
+// arena that produced it (core.go's alternativeSetMembers doc comment), so
+// building with one Core and reading with another silently fails closed the
+// moment a set actually spills. This was previously masked at the pre-b4b-
+// width-repair inline capacity (4): every set literal in this file has at
+// most 3 members, which never spilled at capacity 4 but does at the audited
+// capacity of 2 (core.go), so the aliasing defect is load-bearing now.
+func alternativeSetPinMember(t *testing.T, compact *core.Core, members ...uint16) core.AlternativeSet {
 	t.Helper()
 	var set core.AlternativeSet
-	compact, err := core.New(alternativeSetPinCoverageTable{}, core.Limits{})
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, m := range members {
 		compact.UnionAlternativeSet(&set, core.NewAlternativeSetMember(m, 0))
 	}
@@ -149,14 +153,11 @@ func alternativeSetPinMember(t *testing.T, members ...uint16) core.AlternativeSe
 }
 
 // alternativeSetPinBranchMember builds a set from explicit (event, branch)
-// pairs, for v2-specific tests.
-func alternativeSetPinBranchMember(t *testing.T, pairs ...[2]uint16) core.AlternativeSet {
+// pairs, for v2-specific tests. See alternativeSetPinMember's doc comment
+// for why compact must be the same Core instance the caller reads through.
+func alternativeSetPinBranchMember(t *testing.T, compact *core.Core, pairs ...[2]uint16) core.AlternativeSet {
 	t.Helper()
 	var set core.AlternativeSet
-	compact, err := core.New(alternativeSetPinCoverageTable{}, core.Limits{})
-	if err != nil {
-		t.Fatal(err)
-	}
 	for _, pair := range pairs {
 		compact.UnionAlternativeSet(&set, core.NewAlternativeSetMember(pair[0], pair[1]))
 	}
@@ -165,7 +166,12 @@ func alternativeSetPinBranchMember(t *testing.T, pairs ...[2]uint16) core.Altern
 
 func TestDiagnosticParserCoreConvergedCoverageDropsV1Proof(t *testing.T) {
 	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
-	member := func(members ...uint16) core.AlternativeSet { return alternativeSetPinMember(t, members...) }
+	// One shared scheduler (and compact) builds every test-table set below
+	// and later reads each back: diagnosticParserCoreConvergedCoverageDropsV1
+	// only reads through scheduler.compact, so sharing it across subtests is
+	// safe, and it is required -- see alternativeSetPinMember's doc comment.
+	scheduler := newAlternativeSetPinScheduler(t)
+	member := func(members ...uint16) core.AlternativeSet { return alternativeSetPinMember(t, scheduler.compact, members...) }
 	tests := []struct {
 		name    string
 		headers []diagnosticParserCoreHeader
@@ -230,7 +236,6 @@ func TestDiagnosticParserCoreConvergedCoverageDropsV1Proof(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scheduler := newAlternativeSetPinScheduler(t)
 			scheduler.headers = test.headers
 			count, proved := scheduler.diagnosticParserCoreConvergedCoverageDropsV1(test.indices)
 			if count != test.count || proved != test.proved {
@@ -290,7 +295,12 @@ func TestDiagnosticParserCoreConvergedCoverageDropsV1ProofAllocations(t *testing
 // (spec.b4b-alternative-set.v2 section 5).
 func TestDiagnosticParserCoreConvergedCoverageDropsV2Proof(t *testing.T) {
 	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
-	branchMember := func(pairs ...[2]uint16) core.AlternativeSet { return alternativeSetPinBranchMember(t, pairs...) }
+	// One shared scheduler (and compact) builds every test-table set below
+	// and later reads each back -- see
+	// TestDiagnosticParserCoreConvergedCoverageDropsV1Proof's identical setup
+	// and alternativeSetPinMember's doc comment.
+	scheduler := newAlternativeSetPinScheduler(t)
+	branchMember := func(pairs ...[2]uint16) core.AlternativeSet { return alternativeSetPinBranchMember(t, scheduler.compact, pairs...) }
 	tests := []struct {
 		name    string
 		headers []diagnosticParserCoreHeader
@@ -349,7 +359,6 @@ func TestDiagnosticParserCoreConvergedCoverageDropsV2Proof(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			scheduler := newAlternativeSetPinScheduler(t)
 			scheduler.headers = test.headers
 			count, proved := scheduler.diagnosticParserCoreConvergedCoverageDropsV2(test.indices)
 			if count != test.count || proved != test.proved {
@@ -363,8 +372,8 @@ func TestDiagnosticParserCoreConvergedCoverageDropsV2BlendedVetoFiredDetail(t *t
 	defer core.SetAlternativeSetRecordingEnabledForTest(true)()
 	scheduler := newAlternativeSetPinScheduler(t)
 	scheduler.headers = []diagnosticParserCoreHeader{
-		{convergedReductionSplit: true, altSet: alternativeSetPinBranchMember(t, [2]uint16{5, 0}), blended: true},
-		{convergedReductionSplit: true, altSet: alternativeSetPinBranchMember(t, [2]uint16{5, 0})},
+		{convergedReductionSplit: true, altSet: alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{5, 0}), blended: true},
+		{convergedReductionSplit: true, altSet: alternativeSetPinBranchMember(t, scheduler.compact, [2]uint16{5, 0})},
 	}
 	blendedVetoFired, count, proved, overflowDeclined := scheduler.diagnosticParserCoreConvergedCoverageDropsV2Detail([]int{1})
 	if !blendedVetoFired {


### PR DESCRIPTION
## Summary

- Shrinks the b4b-v2 alternative-set widening's footprint back to its pre-widening size on every by-value container (`AlternativeSet`, `nodeLineageRecord`, `nodeLineageMutation`, `ReductionOutput`, `reductionBoundaryOutput`, `diagnosticParserCoreHeader`), by lowering the inline member capacity from 4 to 2 and reordering struct fields to fold the new bool flags into existing alignment padding.
- Pins `BenchmarkGoParseWarmRealDFA`'s hot-loop parser to the production route and adds a guard assertion, fixing a benchmark-harness bug that let it silently re-measure the compact route on both sides of an A/B comparison.

## Audit table (unsafe.Sizeof, bytes)

| Struct | pre-#616 | current (main) | this PR |
|---|---:|---:|---:|
| `AlternativeSet` | 16 | 24 | 16 |
| `nodeLineageRecord` | 24 | 36 | 28 |
| `nodeLineageMutation` | 20 | 24 | 20 |
| `ReductionOutput` | 28 | 40 | 28 |
| `reductionBoundaryOutput` | 56 | 64 | 56 |
| `condenseOutcome` | 16 | 16 | 16 (audited, unchanged by #616 -- no repair needed) |
| `diagnosticParserCoreHeader` | 64 | 88 | 64 |
| `diagnosticParserCoreHeaderRollbackScratch` | 544 | 736 | 544 |

`diagnosticParserCoreHeader` is copied by value twice per scheduler dispatch (the header canonicalize double-buffer and the rollback scratch snapshot), so the 24-byte-per-header reduction applies to both hot copy sites.

## Mechanism

Chose capacity reduction + field reordering (option (a), packing) over a side-table/handle indirection (option (b)): the canonical-fixture census shows 8519/8537 (99.8%) of converged-split elections already spill past 4 inline members by election time, so the inline/spill threshold was not load-bearing, and 8424/8537 (98.7%) are already `Overflowed`. Lowering the threshold to 2 (matching "at most two [reduction outputs] observed" and the census's own `maxBranch=1` on every fixture) restores the inline array to its pre-widening 8 bytes while leaving the `uint32` (event, branch) packed-member encoding, the hard cap, and every union/insert/containment code path completely untouched. Field reordering (grouping 4-byte-aligned fields before byte-sized ones) is layout-only; every non-empty struct literal in the tree uses keyed fields (grep-verified), so no call site changes.

## Census identity

Re-ran the `GTS_B4B_SHADOW_CENSUS_REPORT` canonical-fixture census before and after:

```
                  elections scalar v1 v2 class1 class2 class3 blendedVeto overflow maxBranch
before/after      identical on every field, every fixture, and the grand total
--- canonical totals: elections=8537 scalar=7 v1=93 v2=7 class1=0 class2=0 class3=86 blendedVeto=50 overflow=8424 maxBranch=1 ---
```

The only field that moved is the informational spill-rate proxy (`spill=8519/8537` -> `8528/8537`), which is expected and correct: it counts elections touching >2 (was >4) inline members, so it necessarily grows slightly with the lower threshold. That proxy constant was updated to track the new capacity.

Also re-ran the 206-language `TestAdmissionCandidateScorecard206` (`GTS_ADMISSION_SCORECARD=1`) before and after: `PASS=200 DIVERGE=0 FALLBACK=1 SKIP=5 ERROR=0`, and every individual language's status and tree digest is byte-identical between the two trees.

While reducing the capacity, found and fixed a latent (pre-existing, not introduced by this change) spill-arena aliasing defect in two `internal_test.go` helper functions that built an `AlternativeSet` through one throwaway `Core` and later read it back through a different `Core`. This was silently masked at the old inline capacity of 4 (nothing in the affected test tables exceeded 4 members) and surfaced as a single test failure once capacity dropped to 2. Fixed by threading the caller's actual `Core` instance through both helpers.

## Gates

- `go build` / `go vet` clean on all three tag combinations (default, `gts_parsercorephase0`, `gts_no_parsercorephase0`).
- `internal/parsercorephase0` full suite, including `-race`: pass.
- Root package full suite, tagged and untagged, `-count=1`: identical failure set to unmodified `origin/main` (14 pre-existing, environment-dependent failures reproduce byte-for-byte on both trees; zero new failures, zero newly-passing).
- `TestDiagnosticParserCoreCanonicalAdmissions` (all four fixtures' frozen digests): pass.
- All zero-alloc pins (`TestAlternativeSetWarmInsertAllocations`, `TestAlternativeSetIncomparableWarmAllocations`, `TestDiagnosticParserCoreSelectedLineageProofAllocations`, `TestDiagnosticParserCoreConvergedCoverageDropsV1/V2ProofAllocations`): pass, 0 allocs.
- Journal rollback tests, including `TestDiagnosticParserCoreHeaderRollbackScratchRestoresAndReuses` and the `AlternativeSet` journal/overflow-restore tests: pass.

## Clean-VM A/B (c2-standard-8 spot, us-central1-c, GOMAXPROCS=1, taskset -c 4, `-tags gts_parsercorephase0`, `-benchtime=750ms`, order-alternating, n=10/side, `BenchmarkParserCoreFreshFullCanonical`, all four canonical fixtures, vs `origin/main` at `74be0e11`)

Noise floor (`origin/main` vs itself, A/A): geomean -0.27%, pooled p95 |dev| from median 0.80% (grammargen_lr alone significant at -0.73%, p=0.004; the other three not significant).

This branch vs `origin/main`, sec/op:

| Fixture | vs base | p |
|---|---:|---:|
| rewrite | -2.71% | 0.000 |
| query_compile | -2.89% | 0.000 |
| language | -3.05% | 0.000 |
| grammargen_lr | -2.56% | 0.000 |
| **geomean** | **-2.80%** | all n=10 |

Every fixture significant at p=0.000, 3-4x the same-session noise floor. This reclaims essentially the entire measured +2.80% #616-widening regression (the largest single step in the v9 decomposition ladder this repair targets). B/s (throughput) moves the mirror +2.80% geomean. B/op and allocs/op are unchanged (±0%, all samples equal on both sides) -- no allocation regression.

Every reported work-count metric (`compact_reductions/op`, `compact_shifts/op`, `compact_pop_paths/op`, `compact_pop_payloads/op`, `compact_pop_requests/op`, `compact_leaf_constructions/op`, `compact_parent_constructions/op`, `compact_link_additions/op`, `candidate_fallback/op`) is exactly equal between `origin/main` and this branch on all four fixtures (benchstat: "all samples are equal", ±0.00% geomean) -- zero dispatch/reduction/shift-count drift, independent confirmation alongside the census-identity and scorecard-digest checks above.

## Harness fix

`benchmarkWarmRealGoDFA` built two parsers: `admitRealGoBenchmarkFixture`'s own admission parser correctly pinned `SetAdmissionCandidateRoute(false)`, but the separate parser driving the warm-up and timed `b.N` loop never did. Phase-3 admission defaults the compact candidate route on, and all four canonical fixtures sit under the compact eligibility ceiling, so an unpinned run silently measured the compact route on both sides of an A/B comparison instead of production -- reproducible unmodified on `origin/main`, first caught by a decomposition task that found GLR-only counters (`max_stacks`, `peak_depth`, `nodes/op`) reporting zero for 3/4 fixtures on both sides of a "production" comparison.

Pinned the hot-loop parser the same way, and added `verifyRealGoBenchmarkMeasuredProduction`, which fails the benchmark closed if the process-wide compact-route counter moves during the timed loop, or if the timed parse's GLR-only counters come back zero. Verified the guard actually catches the regression it targets: with the pin temporarily removed, it failed immediately with `compact candidate route counter moved (1 -> 2) during the pinned timed loop: this benchmark is measuring the compact route, not production`.

## Test plan

- [x] `go build` / `go vet`, all three tag combinations
- [x] `go test ./internal/parsercorephase0/... -race -count=1`
- [x] `go test . -count=1` (default and `-tags gts_parsercorephase0`), zero diff vs `origin/main`
- [x] `GTS_B4B_SHADOW_CENSUS_REPORT=1` canonical-fixture census: identical proof counts before/after
- [x] `GTS_ADMISSION_SCORECARD=1` 206-language scorecard: digest-identical before/after
- [x] Zero-alloc pins and journal rollback tests
- [x] Clean-VM order-alternating A/B, n=10, four canonical fixtures
- [x] Harness-fix guard verified to fire on the regression it targets
