### PR TITLE
fix: Drop oversized slabs on scratch reset

### DIFF
--- a/glr.go
+++ b/glr.go
@@ -5675,6 +5675,23 @@ func (s *glrEntryScratch) reset() {
 		// Keep the newest/largest slabs up to the retention budget.
 		keepFrom := len(s.slabs) - 1
 		retained := len(s.slabs[keepFrom].data)
+		if retained > maxRetainedStackEntryCap {
+			// Even the single most recent slab alone outgrew the retention
+			// budget: a pathological wide/deep GLR stack on one parse (a
+			// denser grammar table forking or reducing less eagerly can
+			// drive one stack's entries far past ordinary steady state).
+			// Drop every slab rather than pool an oversized backing array,
+			// which would otherwise sit in the process-wide sync.Pool and
+			// get billed, unshrunk, to every unrelated future parse that
+			// reuses this scratch object regardless of language or file
+			// size. The next parse that needs entries simply reallocates.
+			s.slabs = nil
+			s.slabCursor = 0
+			s.usedTotal = 0
+			s.peakUsed = 0
+			s.allocatedBytes = 0
+			return
+		}
 		for keepFrom > 0 {
 			next := retained + len(s.slabs[keepFrom-1].data)
 			if next > maxRetainedStackEntryCap {

--- a/glr_gss.go
+++ b/glr_gss.go
@@ -711,22 +711,35 @@ func (s *gssScratch) reset() {
 	if total > maxRetainedGSSNodes {
 		keepFrom := len(s.slabs) - 1
 		retained := len(s.slabs[keepFrom].data)
-		for keepFrom > 0 {
-			next := retained + len(s.slabs[keepFrom-1].data)
-			if next > maxRetainedGSSNodes {
-				break
+		if retained > maxRetainedGSSNodes {
+			// Even the single most recent slab alone outgrew the retention
+			// budget: a pathological wide GLR fork count on one parse (a
+			// denser grammar table forking more can drive one parse's GSS
+			// far past ordinary steady state). Drop every slab rather than
+			// pool an oversized backing array, which would otherwise sit in
+			// the process-wide sync.Pool and get billed, unshrunk, to every
+			// unrelated future parse that reuses this scratch object
+			// regardless of language or file size. The next parse that
+			// needs GSS nodes simply reallocates.
+			s.slabs = nil
+		} else {
+			for keepFrom > 0 {
+				next := retained + len(s.slabs[keepFrom-1].data)
+				if next > maxRetainedGSSNodes {
+					break
+				}
+				keepFrom--
+				retained = next
 			}
-			keepFrom--
-			retained = next
-		}
-		if keepFrom > 0 {
-			oldLen := len(s.slabs)
-			copy(s.slabs, s.slabs[keepFrom:])
-			newLen := oldLen - keepFrom
-			for i := newLen; i < oldLen; i++ {
-				s.slabs[i] = gssNodeSlab{}
+			if keepFrom > 0 {
+				oldLen := len(s.slabs)
+				copy(s.slabs, s.slabs[keepFrom:])
+				newLen := oldLen - keepFrom
+				for i := newLen; i < oldLen; i++ {
+					s.slabs[i] = gssNodeSlab{}
+				}
+				s.slabs = s.slabs[:newLen]
 			}
-			s.slabs = s.slabs[:newLen]
 		}
 	}
 	for i := range s.slabs {


### PR DESCRIPTION
## Summary

The GLR scratch pool reset paths always kept the newest slab, even when it alone exceeded the retention budget. A single wide or deep parse could pin a large slab in the process-wide `sync.Pool`. Every later parse then paid that memory cost, regardless of language or file size.

This fix drops oversized retained scratch slabs instead of pooling them. When the most recent slab alone exceeds the retention cap, reset now clears all slabs instead of keeping the oversized one. The next parse reallocates from a clean slate.

## Changes

- `glrEntryScratch.reset()` (glr.go): drop all slabs when the newest slab alone exceeds `maxRetainedStackEntryCap`.
- `gssScratch.reset()` (glr_gss.go): apply the same drop-oversized-slab guard for `maxRetainedGSSNodes`.

## Verification

- `go build ./...`: clean.
- `go test . -count=1` (root package, original shipped grammar blobs): green, full suite.
- `go test . -race` on the touched test files (`glr_gss_test.go`, `glr_test.go`, `parser_scratch_budget_test.go`, `parser_scratch_reset_test.go`): 185 tests, 0 failures, 0 data races.
- W5 editor-latency gate tests (`TestW5*`): green.
