### PR TITLE
Poll deadlines, cancellation, and memory budget in the compact parse route

### DIFF
--- a/admission_switch.go
+++ b/admission_switch.go
@@ -95,8 +95,11 @@ func admissionCandidateEnvEnabled() bool {
 // at scheduler granularity, so the switch declines every input at or above the
 // source-length floor where the production route arms that budget
 // (parseRuntimeMemoryMinSourceBytes). Such inputs stay on production and honor
-// ParseStopMemoryBudget. Explicit timeouts, cancellation flags, included ranges,
-// and observability hooks also keep a parse on production.
+// ParseStopMemoryBudget. Below that floor, an explicit timeout, cancellation
+// flag, or the scheduler's own memory-budget poll is honored on the candidate
+// route itself, with a compatible stop receipt (falling back to production
+// when needed); included ranges and observability hooks still keep a parse on
+// production.
 func SetAdmissionCandidateRouteDefault(enabled bool) {
 	admissionCandidateRouteDefault.Store(enabled)
 }
@@ -113,9 +116,10 @@ func AdmissionCandidateRouteDefault() bool {
 // enabled=true still respects every per-input eligibility decline: the switch
 // declines inputs at or above the source-length floor where the production
 // route arms the automatic memory budget (parseRuntimeMemoryMinSourceBytes), so
-// large inputs stay on production and honor ParseStopMemoryBudget. Explicit
-// timeouts, cancellation flags, included ranges, and observability hooks also
-// keep a parse on production.
+// large inputs stay on production and honor ParseStopMemoryBudget. Included
+// ranges and observability hooks also keep a parse on production; an explicit
+// timeout or cancellation flag no longer does (the scheduler polls and honors
+// them with a compatible stop receipt).
 func (p *Parser) SetAdmissionCandidateRoute(enabled bool) {
 	if p == nil {
 		return
@@ -208,14 +212,17 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	if len(p.included) > 0 {
 		return false
 	}
-	// Preserve liveness fidelity: the compact scheduler does not poll an explicit
-	// timeout or cancellation flag, so decline when a caller set one. Production
-	// then honors the deadline exactly. (The automatic large-input memory budget
-	// is honored by the per-input size decline in attemptAdmissionCandidateFullParse,
-	// which keeps every budget-eligible input on the production route.)
-	if p.timeoutMicros != 0 || p.cancellationFlag != nil {
-		return false
-	}
+	// An explicit timeout or cancellation flag no longer declines eligibility
+	// (tranche B8): the scheduler polls both through the exact production
+	// check (diagnosticParserCoreGenericScheduler.pollStopControl, once per
+	// dispatch-pass-loop iteration) and cleanly aborts -- releasing the
+	// compact arenas before falling back -- so production still serves a
+	// tripped deadline or cancellation with its own compatible stop receipt.
+	// (The automatic large-input memory budget is honored by the per-input
+	// size decline in attemptAdmissionCandidateFullParse, which keeps every
+	// budget-eligible input on the production route; below that size, the
+	// scheduler's own memory-budget poll now covers the same soft budget.)
+	//
 	// Preserve callback fidelity: the compact route does not emit the parser's
 	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline
 	// (fall back to production) whenever a consumer has attached one. Production

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -50,6 +50,13 @@ func newAdmissionCandidateRunner(p *Parser) (*parserCoreFreshFullRunner, error) 
 		allowConvergedSplitDropArtifact: p.language.CompactConvergedReductionSplitDropsCertified,
 		noLookaheadRootSymbol:           p.rootSymbol,
 		hasNoLookaheadRootSymbol:        p.hasRootSymbol,
+		// Tranche B8 scheduler stop-control: bind this Parser so the scheduler
+		// polls its deadline, cancellation flag, and (via
+		// stopControlMemoryBudgetBytes, recomputed per parse in
+		// executeSchedulerOpen) its production-compatible memory budget. This
+		// is the one runner constructor that arms the poll; the diagnostic and
+		// benchmark runner (newParserCoreFreshFullRunner) leaves it nil.
+		stopControlParser: p,
 	}
 	tables, err := newParserCoreRootTables(p)
 	if err != nil {

--- a/admission_switch_stop_control_test.go
+++ b/admission_switch_stop_control_test.go
@@ -1,0 +1,268 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// Tranche B8 gate: for each stop-control class (memory budget, timeout,
+// cancellation), an admission-eligible input under the 64 KiB wall that
+// trips the class produces a stop receipt from the candidate route (routed
+// through the scheduler's new pollStopControl, parsercore_phase0_driver.go)
+// that matches what production itself reports for the identical input and
+// configuration: the same ParseStopReason, ParseStoppedEarly() true, and a
+// tree with no out-of-range partial state. Every witness stays under
+// ParseRuntimeMemoryMinSourceBytesForTest so B9's wall (out of scope here)
+// is never the reason for the fallback instead.
+
+// stopControlWitnessGoSource returns a small, valid Go source with `lines`
+// statements, small enough to stay under the admission wall for any
+// reasonable line count used by these tests.
+func stopControlWitnessGoSource(lines int) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("package p\n\nfunc f() {\n")
+	for i := 0; i < lines; i++ {
+		buf.WriteString("\tvar x = 1\n")
+	}
+	buf.WriteString("}\n")
+	return buf.Bytes()
+}
+
+func requireStopControlWitnessUnderWall(t *testing.T, source []byte) {
+	t.Helper()
+	if wall := gts.ParseRuntimeMemoryMinSourceBytesForTest(); len(source) >= wall {
+		t.Fatalf("witness source is %d bytes, want < %d (B9's admission wall is out of scope for tranche B8)", len(source), wall)
+	}
+}
+
+// requireSaneStoppedTree checks the partial-state half of the gate: whatever
+// the stopped tree contains, it must not claim byte coverage past the source
+// it was built from.
+func requireSaneStoppedTree(t *testing.T, tree *gts.Tree, source []byte, label string) {
+	t.Helper()
+	if tree == nil {
+		t.Fatalf("%s: nil tree", label)
+	}
+	if !tree.ParseStoppedEarly() {
+		t.Fatalf("%s: ParseStoppedEarly() = false, want true", label)
+	}
+	if root := tree.RootNode(); root != nil && root.EndByte() > uint32(len(source)) {
+		t.Fatalf("%s: partial tree root end %d exceeds source length %d", label, root.EndByte(), len(source))
+	}
+}
+
+// TestAdmissionSwitchCompactTimeoutStopReceiptMatchesProduction proves the
+// timeout class: the candidate route is eligible (tranche B8 removed the
+// outright timeout decline), the scheduler's poll detects the deadline
+// already expired, cleanly aborts and falls back, and production's own
+// receipt for the identical input carries the same ParseStopReason.
+func TestAdmissionSwitchCompactTimeoutStopReceiptMatchesProduction(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+
+	source := stopControlWitnessGoSource(50)
+	requireStopControlWitnessUnderWall(t, source)
+
+	// Production reference: pin production, expire the deadline before Parse
+	// runs (the same technique TestParseWithSnippetParserInheritsExpiredParentDeadline
+	// uses internally): BeginParseOperationBudgetForTest opens the same outer
+	// budget scope Parse opens, computing the deadline now, then the sleep
+	// pushes it into the past before Parse's own nested scope reads it.
+	prod := gts.NewParser(grammars.GoLanguage())
+	prod.SetAdmissionCandidateRoute(false)
+	prod.SetTimeoutMicros(50)
+	endProdBudget := prod.BeginParseOperationBudgetForTest()
+	time.Sleep(2 * time.Millisecond)
+	prodTree, err := prod.Parse(source)
+	endProdBudget()
+	if err != nil {
+		t.Fatalf("production reference parse: %v", err)
+	}
+	defer prodTree.Release()
+	if got, want := prodTree.ParseStopReason(), gts.ParseStopTimeout; got != want {
+		t.Fatalf("production reference ParseStopReason() = %q, want %q", got, want)
+	}
+
+	// Candidate route: identical construction and expiry technique, default
+	// routing (compact eligible; nothing else declines this input).
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidate := gts.NewParser(grammars.GoLanguage())
+	candidate.SetTimeoutMicros(50)
+	endCandidateBudget := candidate.BeginParseOperationBudgetForTest()
+	time.Sleep(2 * time.Millisecond)
+	tree, err := candidate.Parse(source)
+	endCandidateBudget()
+	if err != nil {
+		t.Fatalf("candidate-route parse: %v", err)
+	}
+	defer tree.Release()
+
+	if got, want := tree.ParseStopReason(), gts.ParseStopTimeout; got != want {
+		t.Fatalf("candidate-route ParseStopReason() = %q, want %q (production reference agrees on %q)", got, want, prodTree.ParseStopReason())
+	}
+	requireSaneStoppedTree(t, tree, source, "timeout")
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if fallback != 1 || routed != 0 {
+		t.Fatalf("expected exactly one stop-control fallback and zero routed: routed=%d fallback=%d", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "stop-control tripped: timeout") {
+		t.Fatalf("fallback reason = %q, want it to name the scheduler's timeout trip", reason)
+	}
+}
+
+// TestAdmissionSwitchCompactCancellationStopReceiptMatchesProduction is the
+// cancellation counterpart: the flag is already tripped before Parse is
+// called, so the scheduler's very first poll (before its first election)
+// catches it deterministically -- no elapsed-time technique needed.
+func TestAdmissionSwitchCompactCancellationStopReceiptMatchesProduction(t *testing.T) {
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+
+	source := stopControlWitnessGoSource(50)
+	requireStopControlWitnessUnderWall(t, source)
+
+	prod := gts.NewParser(grammars.GoLanguage())
+	prod.SetAdmissionCandidateRoute(false)
+	var prodFlag uint32 = 1
+	prod.SetCancellationFlag(&prodFlag)
+	prodTree, err := prod.Parse(source)
+	if err != nil {
+		t.Fatalf("production reference parse: %v", err)
+	}
+	defer prodTree.Release()
+	if got, want := prodTree.ParseStopReason(), gts.ParseStopCancelled; got != want {
+		t.Fatalf("production reference ParseStopReason() = %q, want %q", got, want)
+	}
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidate := gts.NewParser(grammars.GoLanguage())
+	var flag uint32 = 1
+	candidate.SetCancellationFlag(&flag)
+	tree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate-route parse: %v", err)
+	}
+	defer tree.Release()
+
+	if got, want := tree.ParseStopReason(), gts.ParseStopCancelled; got != want {
+		t.Fatalf("candidate-route ParseStopReason() = %q, want %q (production reference agrees on %q)", got, want, prodTree.ParseStopReason())
+	}
+	requireSaneStoppedTree(t, tree, source, "cancellation")
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if fallback != 1 || routed != 0 {
+		t.Fatalf("expected exactly one stop-control fallback and zero routed: routed=%d fallback=%d", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "stop-control tripped: cancelled") {
+		t.Fatalf("fallback reason = %q, want it to name the scheduler's cancellation trip", reason)
+	}
+}
+
+// TestAdmissionSwitchCompactMemoryBudgetStopReceiptMatchesProduction proves
+// the memory-budget class: a source under the admission wall, combined with
+// a tiny GOT_PARSE_MEMORY_BUDGET_MB, trips the scheduler's deterministic
+// StorageBytes-vs-budget poll -- the same configured budget production's own
+// arena/scratch accounting honors -- and both engines report
+// ParseStopMemoryBudget for the identical input.
+func TestAdmissionSwitchCompactMemoryBudgetStopReceiptMatchesProduction(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
+	gts.ResetParseEnvConfigCacheForTests()
+	defer gts.ResetParseEnvConfigCacheForTests()
+
+	restore := gts.AdmissionCandidateRouteDefault()
+	defer gts.SetAdmissionCandidateRouteDefault(restore)
+	gts.SetAdmissionCandidateRouteDefault(true)
+
+	source := stopControlWitnessGoSource(5000)
+	requireStopControlWitnessUnderWall(t, source)
+
+	// Drain the shared arena pool before each parse: a warm, large-capacity
+	// retained arena needs fewer growth events to reach this witness's node
+	// count, and the deterministic arena budget check only runs at
+	// materialization-boundary call sites (not every allocation), so a warm
+	// pool can let a single large batch jump straight past the budget between
+	// polls. Draining forces every parse below to grow its arena from cold,
+	// matching the poll cadence this witness was sized against.
+	gts.DrainArenaPools()
+	prod := gts.NewParser(grammars.GoLanguage())
+	prod.SetAdmissionCandidateRoute(false)
+	prodTree, err := prod.Parse(source)
+	if err != nil {
+		t.Fatalf("production reference parse: %v", err)
+	}
+	defer prodTree.Release()
+	if got, want := prodTree.ParseStopReason(), gts.ParseStopMemoryBudget; got != want {
+		t.Fatalf("production reference ParseStopReason() = %q, want %q (runtime=%s)", got, want, prodTree.ParseRuntime().Summary())
+	}
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	gts.DrainArenaPools()
+	candidate := gts.NewParser(grammars.GoLanguage())
+	tree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate-route parse: %v", err)
+	}
+	defer tree.Release()
+
+	if got, want := tree.ParseStopReason(), gts.ParseStopMemoryBudget; got != want {
+		t.Fatalf("candidate-route ParseStopReason() = %q, want %q (production reference agrees on %q)", got, want, prodTree.ParseStopReason())
+	}
+	requireSaneStoppedTree(t, tree, source, "memory-budget")
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if fallback != 1 || routed != 0 {
+		t.Fatalf("expected exactly one stop-control fallback and zero routed: routed=%d fallback=%d", routed, fallback)
+	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "stop-control tripped: memory_budget") {
+		t.Fatalf("fallback reason = %q, want it to name the scheduler's memory-budget trip", reason)
+	}
+}
+
+// TestAdmissionSwitchCompactMemoryBudgetPollIsDeterministic is the direct
+// determinism gate (tranche B8 work order item 4): the memory-budget half of
+// pollStopControl compares Core.StorageBytes(), six already-tracked slice
+// lengths, against a fixed byte budget -- pure integer arithmetic with no
+// wall-clock or GC-timing input. Same input and same budget must trip the
+// scheduler's poll at the same internal juncture on every attempt, unlike
+// production's own hard ceiling (runtime.MemStats-based, explicitly
+// documented as non-deterministic in parser_memory_budget_runtime.go). This
+// drives the candidate engine seam directly (tryCompactFullParseRoute, not
+// the public Parse route), draining and re-arming the arena pool between
+// attempts, and requires the identical decline detail both times.
+func TestAdmissionSwitchCompactMemoryBudgetPollIsDeterministic(t *testing.T) {
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
+	gts.ResetParseEnvConfigCacheForTests()
+	defer gts.ResetParseEnvConfigCacheForTests()
+
+	source := stopControlWitnessGoSource(5000)
+	requireStopControlWitnessUnderWall(t, source)
+
+	var reasons [3]string
+	for i := range reasons {
+		gts.DrainArenaPools()
+		parser := gts.NewParser(grammars.GoLanguage())
+		_, ok, reason := gts.TryCompactFullParseRouteForTest(parser, source)
+		if ok {
+			t.Fatalf("attempt %d: candidate engine accepted instead of stopping on the memory budget", i)
+		}
+		if !strings.Contains(reason, "stop-control tripped: memory_budget") {
+			t.Fatalf("attempt %d: decline reason = %q, want the scheduler's memory-budget trip", i, reason)
+		}
+		reasons[i] = reason
+	}
+	for i := 1; i < len(reasons); i++ {
+		if reasons[i] != reasons[0] {
+			t.Fatalf("non-deterministic stop point: attempt 0 = %q, attempt %d = %q", reasons[0], i, reasons[i])
+		}
+	}
+}

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -251,10 +251,15 @@ func TestAdmissionSwitchDeclinesWhenIncludedRangesSet(t *testing.T) {
 	}
 }
 
-// TestAdmissionSwitchDeclinesWhenTimeoutSet proves the candidate route declines
-// when a caller set a timeout: the compact scheduler does not poll deadlines, so
-// the parse stays on production which honors it.
-func TestAdmissionSwitchDeclinesWhenTimeoutSet(t *testing.T) {
+// TestAdmissionSwitchConsultsCandidateWhenTimeoutSetButNotExpired proves
+// that, since tranche B8 wired the scheduler's own deadline poll, a live but
+// unexpired timeout no longer declines eligibility outright: the parse now
+// consults the candidate route (one routing event) and still returns a clean
+// tree. Like the rest of this file it asserts the routing EVENT, not which
+// engine served the parse, so it holds under every build (including
+// -tags gts_no_parsercorephase0, where the engine itself is a stub that
+// always declines: the event still fires, just as a fallback).
+func TestAdmissionSwitchConsultsCandidateWhenTimeoutSetButNotExpired(t *testing.T) {
 	restore := gts.AdmissionCandidateRouteDefault()
 	defer gts.SetAdmissionCandidateRouteDefault(restore)
 	gts.SetAdmissionCandidateRouteDefault(true)
@@ -268,14 +273,19 @@ func TestAdmissionSwitchDeclinesWhenTimeoutSet(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 	defer tree.Release()
-	if got := admissionRoutingEvents(t); got != before {
-		t.Fatalf("a timeout must keep the parse on production: %d -> %d", before, got)
+	requireCleanFullTree(t, tree, source, "timeout-armed-but-not-tripped")
+	if got := tree.ParseStopReason(); got == gts.ParseStopTimeout {
+		t.Fatalf("a generous timeout must not trip: ParseStopReason() = %q", got)
+	}
+	if got := admissionRoutingEvents(t); got != before+1 {
+		t.Fatalf("a live but unexpired timeout must be eligible (exactly one routing event): %d -> %d", before, got)
 	}
 }
 
-// TestAdmissionSwitchDeclinesWhenCancellationFlagSet proves the candidate route
-// declines when a caller set a cancellation flag.
-func TestAdmissionSwitchDeclinesWhenCancellationFlagSet(t *testing.T) {
+// TestAdmissionSwitchConsultsCandidateWhenCancellationFlagSetButNotTripped is
+// the cancellation-flag counterpart of
+// TestAdmissionSwitchConsultsCandidateWhenTimeoutSetButNotExpired.
+func TestAdmissionSwitchConsultsCandidateWhenCancellationFlagSetButNotTripped(t *testing.T) {
 	restore := gts.AdmissionCandidateRouteDefault()
 	defer gts.SetAdmissionCandidateRouteDefault(restore)
 	gts.SetAdmissionCandidateRouteDefault(true)
@@ -290,8 +300,12 @@ func TestAdmissionSwitchDeclinesWhenCancellationFlagSet(t *testing.T) {
 		t.Fatalf("parse: %v", err)
 	}
 	defer tree.Release()
-	if got := admissionRoutingEvents(t); got != before {
-		t.Fatalf("a cancellation flag must keep the parse on production: %d -> %d", before, got)
+	requireCleanFullTree(t, tree, source, "cancellation-armed-but-not-tripped")
+	if got := tree.ParseStopReason(); got == gts.ParseStopCancelled {
+		t.Fatalf("an unset cancellation flag must not trip: ParseStopReason() = %q", got)
+	}
+	if got := admissionRoutingEvents(t); got != before+1 {
+		t.Fatalf("a live but untripped cancellation flag must be eligible (exactly one routing event): %d -> %d", before, got)
 	}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -308,6 +308,30 @@ func ParseRuntimeMemoryMinSourceBytesForTest() int {
 	return parseRuntimeMemoryMinSourceBytes
 }
 
+// TryCompactFullParseRouteForTest exposes the admission-candidate engine seam
+// directly (bypassing eligibility and the size gate) so external test code
+// can drive the compact route's own accept-or-decline outcome, including its
+// decline detail string, without going through the public Parse route. Both
+// build configurations define tryCompactFullParseRoute (the real engine
+// under the default build, a fail-closed stub under -tags
+// gts_no_parsercorephase0), so this resolves in either build.
+func TryCompactFullParseRouteForTest(p *Parser, source []byte) (tree *Tree, ok bool, reason string) {
+	return p.tryCompactFullParseRoute(source)
+}
+
+// BeginParseOperationBudgetForTest opens the same outer parse-budget scope
+// Parse itself opens (beginParseOperationBudget), so external test code can
+// pin a deadline via SetTimeoutMicros, sleep past it, and then call Parse:
+// the nested budget scope Parse opens internally (including inside the
+// tranche B8 admission-candidate route) inherits this already-expired
+// deadline instead of computing a fresh one, giving a deterministic --
+// not call-overhead-dependent -- expired-timeout witness. Mirrors the
+// technique TestParseWithSnippetParserInheritsExpiredParentDeadline already
+// uses from inside the package.
+func (p *Parser) BeginParseOperationBudgetForTest() func() {
+	return p.beginParseOperationBudget()
+}
+
 // AdmissionSubParserProbe bundles internal sub-parser construction so the
 // external test package can prove recovery, snippet, and injection sub-parsers
 // are born pinned to the production route.

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -1,0 +1,42 @@
+package parsercorephase0
+
+import "unsafe"
+
+// Byte footprints of the compact core's growable record families, computed
+// once from each record type's real in-memory layout so StorageBytes stays
+// authoritative if a record ever gains or loses a field.
+var (
+	coreNodeRecordBytes    = uint64(unsafe.Sizeof(nodeRecord{}))
+	coreLinkRecordBytes    = uint64(unsafe.Sizeof(linkRecord{}))
+	coreSubtreeRecordBytes = uint64(unsafe.Sizeof(subtreeRecord{}))
+	coreChildRecordBytes   = uint64(unsafe.Sizeof(SubtreeID(0)))
+	coreFieldRecordBytes   = uint64(unsafe.Sizeof(FieldMapEntry{}))
+	coreAliasRecordBytes   = uint64(unsafe.Sizeof(Symbol(0)))
+)
+
+// StorageBytes returns a cheap, deterministic, O(1) estimate of the compact
+// core's current record storage in bytes: every growable record family's
+// live slice length times that family's real struct size. It costs six
+// multiply-adds over already-tracked slice lengths -- no allocation, no
+// traversal, no I/O -- so it is safe to call from a tight scheduler poll
+// (spec.campaign.v7 tranche B8).
+//
+// The estimate is a lower bound on process RSS attributable to this core (it
+// omits per-parse scratch, the boundary index, and checkpoint interning), but
+// it grows monotonically with exactly the counters every mutating Core
+// operation already increments, so it is reproducible for a given input and
+// Limits: same input, same Limits, same StorageBytes trajectory, on every
+// run. Callers that need a budget compatible with the production engine's
+// own soft arena/scratch budget (parseMemoryBudgetForParser in the root
+// package) compare this value against that same threshold.
+func (c *Core) StorageBytes() uint64 {
+	if c == nil {
+		return 0
+	}
+	return uint64(len(c.nodes))*coreNodeRecordBytes +
+		uint64(len(c.links))*coreLinkRecordBytes +
+		uint64(len(c.subtrees))*coreSubtreeRecordBytes +
+		uint64(len(c.children))*coreChildRecordBytes +
+		uint64(len(c.fields))*coreFieldRecordBytes +
+		uint64(len(c.aliases))*coreAliasRecordBytes
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -69,6 +69,21 @@ type DiagnosticParserCorePrefixOptions struct {
 	allowConvergedSplitDropArtifact bool
 	noLookaheadRootSymbol           Symbol
 	hasNoLookaheadRootSymbol        bool
+	// stopControlParser, when non-nil, arms the scheduler's stop-control poll
+	// (spec.campaign.v7 tranche B8): once per dispatch-pass-loop iteration,
+	// diagnosticParserCoreGenericScheduler.run checks this Parser's deadline
+	// (timeoutMicros) and cancellation flag through the exact production
+	// check (activeParseStopReason), plus the deterministic compact-arena
+	// memory budget below. Nil (the default for every diagnostic and
+	// benchmark caller) disables the whole poll, matching prior behavior
+	// byte-for-byte -- only the admission-candidate route sets this field.
+	stopControlParser *Parser
+	// stopControlMemoryBudgetBytes is the production engine's own soft
+	// per-parse byte budget (parseMemoryBudgetForParser), recomputed from the
+	// caller's source length immediately before each scheduler run. Zero
+	// disables the memory-budget half of the poll, mirroring production's
+	// own "budget disabled" contract (parseMemoryBudget's mb<=0 case).
+	stopControlMemoryBudgetBytes int64
 }
 
 type DiagnosticParserCoreScannerCheckpoint struct {
@@ -3086,7 +3101,70 @@ func materializeDiagnosticParserCoreAcceptedSelection(compact *core.Core, head c
 	return tree, nil
 }
 
+// diagnosticParserCoreStopControlTripped renders a poll-detected stop-control
+// trip (spec.campaign.v7 tranche B8: memory budget, deadline, or
+// cancellation) as the same kind of decline every other scheduler cap uses.
+// Returning a real error here -- not the graceful s.finish(...) receipt path
+// -- matters: run executes inside compact.RunFreshSchedulerSession for the
+// admission-candidate route (options.freshSchedulerSession), whose deferred
+// cleanup resets the whole core on any non-nil error. That is what releases
+// the compact arenas' accumulated storage before the caller's production
+// fallback engages, with no extra cleanup call needed here.
+func diagnosticParserCoreStopControlTripped(reason ParseStopReason) error {
+	return &diagnosticParserCoreDecline{
+		boundary: DiagnosticParserCoreCap,
+		detail:   "scheduler stop-control tripped: " + string(reason),
+	}
+}
+
+// stopControlMemoryBudgetReason compares the compact core's own live storage
+// accounting against the production engine's soft per-parse byte budget
+// (stopControlMemoryBudgetBytes, sourced from parseMemoryBudgetForParser so
+// the same GOT_PARSE_MEMORY_BUDGET_MB configuration governs both engines).
+// Every input is Core.StorageBytes(): six already-tracked slice lengths times
+// a compile-time-constant record size, so this is pure deterministic integer
+// arithmetic -- no wall clock, no GC-timing dependence, and (same input, same
+// budget) the same trip point on every run, unlike the runtime heap/sys
+// signal production's own hard ceiling uses (parser_memory_budget_runtime.go).
+func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() ParseStopReason {
+	if s == nil || s.options.stopControlMemoryBudgetBytes <= 0 {
+		return ParseStopNone
+	}
+	if s.compact.StorageBytes() < uint64(s.options.stopControlMemoryBudgetBytes) {
+		return ParseStopNone
+	}
+	return ParseStopMemoryBudget
+}
+
+// pollStopControl is the bounded scheduler-boundary poll (spec.campaign.v7
+// tranche B8): the memory-budget check above, then -- only when the caller
+// armed stop control by binding a Parser (stopControlParser, set only by the
+// admission-candidate route) -- the exact production deadline/cancellation
+// check (activeParseStopReason). It runs once before the scheduler's first
+// election and once per iteration of run's dispatch-pass loop: every loop
+// iteration is either one dispatch pass or one re-election round, so this
+// granularity bounds both a runaway dispatch grind and a runaway election
+// cycle. Nil stopControlParser and a zero budget make this two nil/zero
+// comparisons -- the diagnostic and benchmark runners, which never set
+// either, pay that and nothing else.
+func (s *diagnosticParserCoreGenericScheduler) pollStopControl() error {
+	if reason := s.stopControlMemoryBudgetReason(); reason != ParseStopNone {
+		return diagnosticParserCoreStopControlTripped(reason)
+	}
+	parser := s.options.stopControlParser
+	if parser == nil {
+		return nil
+	}
+	if reason := parser.activeParseStopReason(); parseStopReasonIsActive(reason) {
+		return diagnosticParserCoreStopControlTripped(reason)
+	}
+	return nil
+}
+
 func (s *diagnosticParserCoreGenericScheduler) run() error {
+	if err := s.pollStopControl(); err != nil {
+		return err
+	}
 	if err := s.elect(true); err != nil {
 		return err
 	}
@@ -3095,6 +3173,9 @@ func (s *diagnosticParserCoreGenericScheduler) run() error {
 		return nil
 	}
 	for {
+		if err := s.pollStopControl(); err != nil {
+			return err
+		}
 		if uint64(len(s.headers)) > s.work.PeakHeaders {
 			s.work.PeakHeaders = uint64(len(s.headers))
 		}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -97,6 +97,15 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	if tokenSource == nil {
 		return nil, nil, errors.New("parser-core fresh-full runner: production DFA unavailable")
 	}
+	// Recomputed fresh for every call: the production soft budget is a
+	// function of source length (parseMemoryBudgetForParser), and this
+	// runner is reused across parses of different sizes. Only armed when the
+	// caller bound a stop-control Parser (admission_switch_candidate.go); the
+	// diagnostic and benchmark runners leave stopControlParser nil, so this
+	// stays zero and the scheduler's memory-budget poll is a no-op for them.
+	if r.options.stopControlParser != nil {
+		r.options.stopControlMemoryBudgetBytes = parseMemoryBudgetForParser(r.options.stopControlParser, len(source))
+	}
 	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 		&r.scheduler, compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
 		r.options, diagnosticParserCoreSeedObserver{},


### PR DESCRIPTION
## Summary

The compact parse route now polls for three stop conditions during a parse: a deadline, a cancellation flag, and a memory budget. When one of these conditions trips, the route releases its internal storage and falls back to the production route. The production route then reports the same stop reason.

Before this change, the compact route declined any parse with a deadline or a cancellation flag before the parse started. It now attempts these parses and stops correctly when a limit trips.

## Changes

- Add a poll to the compact route scheduler. The poll runs once before the first token election and once per dispatch pass.
- Compare the deadline and the cancellation flag with the same check the production route uses.
- Track the compact route's own memory use with a cheap, deterministic byte count. Compare this count against the same memory budget the production route honors.
- Remove the eligibility check that declined every parse with a deadline or a cancellation flag. These parses now attempt the compact route.
- Release the compact route's internal storage before every fallback to the production route.
- Add tests that compare stop reasons between the compact route and the production route for the deadline, cancellation, and memory-budget cases.
- Add a test that confirms the memory-budget poll stops at the same point on repeated runs.

## Testing

- `go test .` (full package suite)
- `go test . -run 'TestAdmissionSwitch' -race -count=5`
- `go test . -tags gts_parsercorephase0 -run 'TestAdmissionSwitch' -race`
- `GTS_ADMISSION_SCORECARD=1 go test . -tags gts_parsercorephase0 -run TestAdmissionCandidateScorecard206` (200 pass, 1 fallback, 5 skip, 0 diverge; unchanged from baseline)
- `go test . -bench BenchmarkGoParseWarmRealDFA -run '^$'`, interleaved before/after comparison (no statistically significant timing change; allocation counts unchanged)
