### PR TITLE
certify(A3): Certify compact-route acceptance for Perl, Python, Apex, and Ada

### DIFF
--- a/admission_switch_a3_arm_noop_confirmation_test.go
+++ b/admission_switch_a3_arm_noop_confirmation_test.go
@@ -1,0 +1,164 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// This file is the A3 certification-workstream (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) arm no-op confirmation receipt.
+//
+// Method (the finding's own method note): compare the compact route's raw
+// runner tree against its normal tailed tree. The compat tail runs inside
+// the compact route wrapper, so the probe must suppress it directly
+// (SetNoResultCompatibilityBenchmarkOnlyForTest) rather than through the
+// public ParseNoResultCompatibilityBenchmarkOnly wrapper, which also forces
+// production and can never serve as a compact-route probe. Equality between
+// the raw and tailed trees would prove the language's compat arm is a no-op
+// on compact-origin trees for that witness -- the retirement precondition
+// follow-up arm-deletion PRs need.
+//
+// RESULT, corrected from the finding: only Apex's witness confirms as a
+// no-op. Perl, Python, and Ada's compat arms still perform real,
+// load-bearing tree reshaping on compact-origin trees even after A3
+// certification lands, on their own tied-election witnesses. The finding's
+// "compact-raw equals compact-tailed on all six witnesses" claim does not
+// reproduce for four of those six (perl push-list; python tuple assignment;
+// both ada aggregates). It reproduces for the fifth, apex class-literal.
+//
+// This is consistent with the arm taxonomy (spec.campaign.v7): apex's arm
+// is a fixed derivation relabel that A3's primary-acceptance-derivation
+// certification already subsumes at the scheduler level, so there is
+// nothing left for the arm to do. Perl and Python's arms are
+// scheduler-action arms that perform source-text-scanning list regrouping
+// (ambiguous_function_call_expression / pattern_list-vs-expression_list) --
+// a materially stronger transformation than picking among tied derivations.
+// Ada's arms (materialization-owned) relabel one aggregate production into
+// another via a similar structural scan. None of these three
+// transformations are subsumed by the admission-time election flags this
+// workstream certifies.
+//
+// Follow-up arm-deletion PRs for perl, python, and ada must not treat this
+// finding's retirement precondition as met on this evidence; apex's
+// arm-deletion follow-on can cite this receipt directly.
+//
+// This does NOT affect A3's own certification landing. The certified
+// languages' full-corpus sweeps (cgo_harness a3_certification_sweep
+// pattern) compare the real shipped Parse() output, which always applies
+// the compat tail regardless of route, and found zero unadjudicated
+// divergence there. The no-op question is a separate, later concern: only
+// whether the arm itself can be deleted.
+
+func TestA3ArmNoOpConfirmationApexConfirms(t *testing.T) {
+	source := []byte("public class C {\n  void m() {\n    Object t = RecordPage.class;\n  }\n}\n")
+	lang := grammars.ApexLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("apex did not receive its A3 certification")
+	}
+	assertA3ArmNoOp(t, "apex/class_literal_alias", lang, source, true)
+}
+
+func TestA3ArmNoOpConfirmationPerlDoesNotConfirm(t *testing.T) {
+	lang := grammars.PerlLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified || !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("perl did not receive its A3 certification")
+	}
+	for _, tt := range []struct{ name, source string }{
+		{"push_two_args", "push @found, $_;\n"},
+		{"push_three_args", "push @found, $a, $b;\n"},
+	} {
+		assertA3ArmNoOp(t, "perl/"+tt.name, lang, []byte(tt.source), false)
+	}
+}
+
+func TestA3ArmNoOpConfirmationPythonDoesNotConfirm(t *testing.T) {
+	lang := grammars.PythonLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified || !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("python did not receive its A3 certification")
+	}
+	for _, tt := range []struct{ name, source string }{
+		{"assignment_bare_tuple", "x, y, z = 1, 2, 3\nxyz = x, y, z\n"},
+		{"assignment_bare_pair", "a = 1\nb = 2\npair = a, b\n"},
+	} {
+		assertA3ArmNoOp(t, "python/"+tt.name, lang, []byte(tt.source), false)
+	}
+}
+
+func TestA3ArmNoOpConfirmationAdaDoesNotConfirm(t *testing.T) {
+	lang := grammars.AdaLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified || !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("ada did not receive its A3 certification")
+	}
+	for _, tt := range []struct{ name, source string }{
+		{"locked_positional_array_aggregate", "package P is\n   type A is array (1 .. 3) of Boolean;\n   V : constant A := (1, 2, 3);\nend;\n"},
+		{"array_others_choice", "procedure P is\nbegin\n   A := (others => 0);\nend;\n"},
+	} {
+		assertA3ArmNoOp(t, "ada/"+tt.name, lang, []byte(tt.source), false)
+	}
+}
+
+// TestA3ArmNoOpConfirmationTrivialWitnessesAreVacuouslyNoOp documents the
+// baseline: on a source that never triggers a language's compat arm at
+// all, compact-raw trivially equals compact-tailed for every certified
+// language (there is nothing for the arm to rewrite). This is a different,
+// weaker property than the tied-election witnesses above and must not be
+// read as confirming the retirement precondition.
+func TestA3ArmNoOpConfirmationTrivialWitnessesAreVacuouslyNoOp(t *testing.T) {
+	tests := []struct {
+		name string
+		load func() *gts.Language
+	}{
+		{"perl", grammars.PerlLanguage},
+		{"python", grammars.PythonLanguage},
+		{"apex", grammars.ApexLanguage},
+		{"ada", grammars.AdaLanguage},
+	}
+	for _, tt := range tests {
+		lang := tt.load()
+		source := []byte(grammars.ParseSmokeSample(tt.name))
+		assertA3ArmNoOp(t, tt.name+"/smoke_sample", lang, source, true)
+	}
+}
+
+// assertA3ArmNoOp compares the compact route's raw (pre-compat-tail) tree
+// against its normal tailed tree for source, and asserts the observed
+// no-op status matches wantNoOp exactly (a Fatal either way -- a status
+// flip in either direction changes the campaign's retirement evidence and
+// must be investigated, not silently accepted).
+func assertA3ArmNoOp(t *testing.T, name string, lang *gts.Language, source []byte, wantNoOp bool) {
+	t.Helper()
+
+	tailed := gts.NewParser(lang)
+	tailed.SetAdmissionCandidateRoute(true)
+	tailedTree, err := tailed.Parse(source)
+	if err != nil {
+		t.Fatalf("%s: tailed parse: %v", name, err)
+	}
+	defer tailedTree.Release()
+
+	raw := gts.NewParser(lang)
+	raw.SetAdmissionCandidateRoute(true)
+	restore := gts.SetNoResultCompatibilityBenchmarkOnlyForTest(raw, true)
+	defer restore()
+	rawTree, err := raw.Parse(source)
+	if err != nil {
+		t.Fatalf("%s: raw parse: %v", name, err)
+	}
+	defer rawTree.Release()
+
+	tailedSExpr := tailedTree.RootNode().SExpr(lang)
+	rawSExpr := rawTree.RootNode().SExpr(lang)
+	gotNoOp := tailedSExpr == rawSExpr
+	if gotNoOp != wantNoOp {
+		t.Fatalf(
+			"%s: arm no-op status changed (compact-raw==compact-tailed is now %t, want %t) -- "+
+				"this flips the campaign's retirement evidence, re-verify before updating either "+
+				"the arm-deletion readiness or this receipt.\nraw   =%s\ntailed=%s",
+			name, gotNoOp, wantNoOp, rawSExpr, tailedSExpr,
+		)
+	}
+}

--- a/admission_switch_converged_path_test.go
+++ b/admission_switch_converged_path_test.go
@@ -53,6 +53,15 @@ func TestAdmissionCandidateCertifiedConvergedPathSplitsMatchProduction(t *testin
 			source: "def greet(name):\n    return f\"hello {name}\"\n\nprint(greet(\"world\"))\n",
 			load:   grammars.PythonLanguage,
 		},
+		{
+			// A3 certification workstream (spec.campaign.v7, finding
+			// tied-election-family-compact-retirement): the tied push-list
+			// election real-corpus witness
+			// (cgo_harness/corpus_real/perl/medium__unicode_ranges.pl).
+			name:   "perl",
+			source: "push @found, $_;\n",
+			load:   grammars.PerlLanguage,
+		},
 	}
 
 	for _, test := range tests {
@@ -131,7 +140,6 @@ func TestAdmissionCandidateSelectedLineageSplitsMatchProduction(t *testing.T) {
 	}{
 		{name: "dart", load: grammars.DartLanguage},
 		{name: "elixir", load: grammars.ElixirLanguage},
-		{name: "perl", load: grammars.PerlLanguage},
 		{name: "scala", load: grammars.ScalaLanguage},
 	}
 

--- a/admission_switch_kotlin_certification_withheld_test.go
+++ b/admission_switch_kotlin_certification_withheld_test.go
@@ -1,0 +1,144 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"strings"
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// This file is the A3 certification-workstream (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) withholding receipt for Kotlin.
+//
+// The finding's platform-modifier-recovery witness ("internal actual fun
+// f(): String = \"x\"") matches the C oracle once the compact route accepts
+// after a converged-path split drop
+// (cgo_harness/b4b_alternative_set_v2_kotlin_adjudication_test.go). Landing
+// CompactConvergedReductionSplitDropsCertified alone is safe:
+// TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe pins that.
+//
+// Combining CompactConvergedReductionSplitDropsCertified with
+// CompactPrimaryAcceptanceDerivationCertified -- the certification pair the
+// finding asks for -- regresses a distinct, pre-existing witness:
+// TestKotlinTopLevelObjectParsesAsDeclaration (issue #93,
+// query_kotlin_object_declaration_test.go). With both flags on, the compact
+// route accepts "object Singleton { fun work() = Unit }" as
+// infix_expression(object_literal, Singleton, lambda_literal) instead of
+// object_declaration. The C oracle sides with production's
+// object_declaration
+// (cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go).
+// This is a genuine divergence, not an adjudicated exception, so neither
+// certificate lands for Kotlin in grammars/runtime_profiles.go: the
+// "kotlin" map entry stays at its pre-A3 shape.
+//
+// This file pins both halves of the finding (the safe grant and the
+// regressing combination) so a future attempt to land Kotlin's
+// certification is checked against this exact counterexample.
+
+// TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe confirms
+// CompactConvergedReductionSplitDropsCertified alone (without
+// CompactPrimaryAcceptanceDerivationCertified) resolves the finding's
+// platform-modifier witness without introducing the object_declaration
+// regression.
+func TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe(t *testing.T) {
+	source := []byte("internal actual fun f(): String = \"x\"\n")
+	lang := grammars.KotlinLanguage()
+	if lang.CompactConvergedReductionSplitDropsCertified || lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("shared kotlin language unexpectedly carries a withheld A3 certificate")
+	}
+
+	lang.CompactConvergedReductionSplitDropsCertified = true
+	defer func() { lang.CompactConvergedReductionSplitDropsCertified = false }()
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidate := gts.NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	candidateTree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	defer candidateTree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf(
+			"split-drops-only candidate route counters = %d/%d, want 1/0; reason=%s",
+			routed, fallback, gts.AdmissionCandidateLastFallbackReason(),
+		)
+	}
+	want := "(source_file (function_declaration (modifiers (visibility_modifier) (platform_modifier)) " +
+		"(simple_identifier) (function_value_parameters) (user_type (type_identifier)) " +
+		"(function_body (string_literal (string_content)))))"
+	if got := candidateTree.RootNode().SExpr(lang); got != want {
+		t.Fatalf("split-drops-only candidate tree = %s, want %s", got, want)
+	}
+}
+
+// TestKotlinCompactCertificationObjectDeclarationRegressionWithheld
+// reproduces the counterexample that blocks Kotlin's A3 certification: with
+// both CompactConvergedReductionSplitDropsCertified and
+// CompactPrimaryAcceptanceDerivationCertified forced on, the compact route
+// accepts a tree that diverges from production's (C-oracle-matching, see
+// the cgo_harness companion receipt) object_declaration parse.
+func TestKotlinCompactCertificationObjectDeclarationRegressionWithheld(t *testing.T) {
+	source := []byte("package demo\n\nobject Singleton {\n    fun work() = Unit\n}\n")
+	lang := grammars.KotlinLanguage()
+	if lang.CompactConvergedReductionSplitDropsCertified || lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("shared kotlin language unexpectedly carries a withheld A3 certificate")
+	}
+
+	production := gts.NewParser(lang)
+	production.SetAdmissionCandidateRoute(false)
+	productionTree, err := production.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer productionTree.Release()
+	productionSExpr := productionTree.RootNode().SExpr(lang)
+	if !strings.Contains(productionSExpr, "object_declaration") {
+		t.Fatalf("production tree lost object_declaration (issue #93 regressed independently of this file): %s", productionSExpr)
+	}
+
+	lang.CompactConvergedReductionSplitDropsCertified = true
+	lang.CompactPrimaryAcceptanceDerivationCertified = true
+	defer func() {
+		lang.CompactConvergedReductionSplitDropsCertified = false
+		lang.CompactPrimaryAcceptanceDerivationCertified = false
+	}()
+
+	gts.ResetAdmissionCandidateCountersForTest()
+	candidate := gts.NewParser(lang)
+	candidate.SetAdmissionCandidateRoute(true)
+	candidateTree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("candidate parse: %v", err)
+	}
+	defer candidateTree.Release()
+
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 || fallback != 0 {
+		t.Fatalf(
+			"forced-both-certificates candidate route counters = %d/%d, want 1/0 "+
+				"(if this now declines instead of accepting a wrong tree, re-check whether "+
+				"the certification pair is safe to land); reason=%s",
+			routed, fallback, gts.AdmissionCandidateLastFallbackReason(),
+		)
+	}
+	candidateSExpr := candidateTree.RootNode().SExpr(lang)
+	if candidateSExpr == productionSExpr {
+		t.Fatalf(
+			"forced-both-certificates candidate tree now matches production (%s); the "+
+				"object_declaration regression may be fixed -- re-verify against the C oracle "+
+				"(cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go) "+
+				"before landing Kotlin's A3 certification",
+			candidateSExpr,
+		)
+	}
+	if !strings.Contains(candidateSExpr, "infix_expression") {
+		t.Fatalf("forced-both-certificates candidate tree changed shape unexpectedly: %s", candidateSExpr)
+	}
+	t.Logf("confirmed withheld: forced-both-certificates candidate tree diverges from production's object_declaration tree: %s", candidateSExpr)
+}

--- a/cgo_harness/a3_certification_sweep_helpers_test.go
+++ b/cgo_harness/a3_certification_sweep_helpers_test.go
@@ -1,0 +1,252 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+)
+
+// This file is the shared A3 certification-workstream (spec.campaign.v7,
+// finding tied-election-family-compact-retirement) full-corpus verification
+// harness. Each certified language (perl, python, apex, ada; kotlin is
+// withheld, see admission_switch_kotlin_certification_withheld_test.go and
+// kotlin_a3_certification_object_declaration_regression_test.go) has its own
+// sweep test file that calls runA3CertificationSweep with that language's
+// full real-corpus-or-constructed source set and its certification flags
+// already landed in grammars/runtime_profiles.go.
+//
+// Method (matches the admission_switch_converged_path_test.go flag-mutation
+// pattern): for every source, parse once on production (compat tail on,
+// route forced off) and once on the compact candidate route (route forced
+// on). A parse that declines the compact route is SAFE by construction (it
+// falls back to production automatically) and is only counted and
+// reason-classified. A parse that the compact route accepts must either
+// byte-match the production tree, or -- where the two differ -- match the
+// locked C oracle exactly (the adjudicated-exception rule: compact==C is
+// correct even when production diverges). Any accepted compact tree that
+// matches neither production nor the C oracle is a genuine, unadjudicated
+// divergence and fails the sweep.
+
+// a3CertificationSweepSource is one corpus file or constructed source fed
+// through the sweep.
+type a3CertificationSweepSource struct {
+	Name   string
+	Source []byte
+}
+
+// a3CertificationSweepResult is the scorecard one language's sweep produces.
+type a3CertificationSweepResult struct {
+	Language               string
+	Files                  int
+	Accepted               int
+	Declined               int
+	DeclineByReason        map[string]int
+	AdjudicatedExceptions  []string
+	Divergences            []string
+}
+
+// a3DeclineReasonClass buckets a compact-route decline reason string into a
+// coarse, stable class for the sweep's decline scorecard. Declines are safe
+// regardless of class (they fall back to production automatically); the
+// classification exists purely for the receipt.
+func a3DeclineReasonClass(reason string) string {
+	switch {
+	case reason == "":
+		return "unknown-empty-reason"
+	case strings.Contains(reason, "converged-path reduction split"):
+		return "converged-path-reduction-split"
+	case strings.Contains(reason, "did not accept EOF"):
+		return "no-eof-accept"
+	case strings.Contains(reason, "not sole exact EOF") || strings.Contains(reason, "acceptance is not sole exact EOF"):
+		return "not-sole-exact-eof"
+	case strings.Contains(reason, "runner unavailable"):
+		return "runner-unavailable"
+	case strings.Contains(reason, "recovery"):
+		return "recovery-entered"
+	default:
+		return "other:" + reason
+	}
+}
+
+// runA3CertificationSweep parses every source in sources on both routes for
+// lang (which must already carry the certification flags under test -- the
+// caller lands them in grammars/runtime_profiles.go, or forces them
+// temporarily for a withheld-language probe) and classifies every outcome.
+// cLangName resolves the locked C oracle used to adjudicate every compact
+// accept that diverges from production. It never mutates lang.
+func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *gotreesitter.Language, sources []a3CertificationSweepSource) a3CertificationSweepResult {
+	t.Helper()
+	result := a3CertificationSweepResult{Language: language, DeclineByReason: map[string]int{}}
+
+	cLang, err := COracleLanguage(cLangName)
+	if err != nil {
+		t.Fatalf("load %s C oracle: %v", cLangName, err)
+	}
+
+	for _, src := range sources {
+		result.Files++
+
+		production := gotreesitter.NewParser(lang)
+		production.SetAdmissionCandidateRoute(false)
+		productionTree, err := production.Parse(src.Source)
+		if err != nil {
+			t.Fatalf("%s: production parse: %v", src.Name, err)
+		}
+
+		routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+		candidate := gotreesitter.NewParser(lang)
+		candidate.SetAdmissionCandidateRoute(true)
+		candidateTree, err := candidate.Parse(src.Source)
+		if err != nil {
+			t.Fatalf("%s: candidate parse: %v", src.Name, err)
+		}
+		routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+
+		switch {
+		case routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore:
+			// Accepted via the compact route.
+			result.Accepted++
+			prodDivergences := a3GoTreeDivergences(candidateTree.RootNode(), lang, productionTree.RootNode())
+			if len(prodDivergences) == 0 {
+				break
+			}
+			// Compact disagrees with production: adjudicate against the locked
+			// C oracle. compact==C is the adjudicated exception (production is
+			// the divergent side); compact!=C is a genuine, unadjudicated
+			// divergence that blocks certification.
+			cTree := a3ParseCOracle(t, cLang, src.Source)
+			cDivergences := compactT3StructuralDivergences(candidateTree.RootNode(), lang, cTree.RootNode())
+			cTree.Close()
+			if len(cDivergences) == 0 {
+				result.AdjudicatedExceptions = append(result.AdjudicatedExceptions, src.Name)
+				t.Logf(
+					"%s: ADJUDICATED EXCEPTION -- compact diverges from production at %d point(s) but matches the C oracle exactly; first production divergence: %s",
+					src.Name, len(prodDivergences), prodDivergences[0],
+				)
+			} else {
+				detail := fmt.Sprintf(
+					"%s: UNADJUDICATED DIVERGENCE -- compact matches neither production (%d pt(s), first: %s) nor the C oracle (%d pt(s), first: %s)",
+					src.Name, len(prodDivergences), prodDivergences[0], len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
+				)
+				result.Divergences = append(result.Divergences, detail)
+				t.Log(detail)
+			}
+		case fallbackAfter == fallbackBefore+1 && routedAfter == routedBefore:
+			// Declined: safe by construction (production served the parse).
+			result.Declined++
+			class := a3DeclineReasonClass(gotreesitter.AdmissionCandidateLastFallbackReason())
+			result.DeclineByReason[class]++
+		default:
+			t.Fatalf(
+				"%s: ambiguous admission counters before=(%d,%d) after=(%d,%d) -- expected exactly one of routed/fallback to advance by one",
+				src.Name, routedBefore, fallbackBefore, routedAfter, fallbackAfter,
+			)
+		}
+
+		productionTree.Release()
+		candidateTree.Release()
+	}
+
+	return result
+}
+
+// a3ReportSweep logs the scorecard and fails the test if any unadjudicated
+// divergence was found. Declines and adjudicated exceptions never fail the
+// sweep.
+func a3ReportSweep(t *testing.T, result a3CertificationSweepResult) {
+	t.Helper()
+	t.Logf(
+		"%s A3 sweep: files=%d accepted=%d declined=%d adjudicated-exceptions=%d divergences=%d",
+		result.Language, result.Files, result.Accepted, result.Declined,
+		len(result.AdjudicatedExceptions), len(result.Divergences),
+	)
+	for class, count := range result.DeclineByReason {
+		t.Logf("%s decline reason class %q: %d", result.Language, class, count)
+	}
+	for _, name := range result.AdjudicatedExceptions {
+		t.Logf("%s adjudicated exception: %s", result.Language, name)
+	}
+	if len(result.Divergences) != 0 {
+		for _, d := range result.Divergences {
+			t.Error(d)
+		}
+		t.Fatalf("%s A3 sweep found %d unadjudicated divergence(s); certification withheld", result.Language, len(result.Divergences))
+	}
+}
+
+func a3ParseCOracle(t *testing.T, cLang *sitter.Language, source []byte) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set C oracle language: %v", err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil || tree.RootNode() == nil {
+		t.Fatal("C oracle parse returned no root")
+	}
+	return tree
+}
+
+// a3GoTreeDivergences walks two Go trees sharing the same Language in
+// lockstep and returns every structural divergence found (type, named,
+// missing, HasError, byte span, child count, and incoming field name). A nil
+// result means the two trees are structurally identical on every compared
+// axis.
+func a3GoTreeDivergences(a *gotreesitter.Node, lang *gotreesitter.Language, b *gotreesitter.Node) []string {
+	var out []string
+	a3WalkGoTreeDivergences(a, lang, b, "/root", &out)
+	return out
+}
+
+func a3WalkGoTreeDivergences(a *gotreesitter.Node, lang *gotreesitter.Language, b *gotreesitter.Node, path string, out *[]string) {
+	if a == nil || b == nil {
+		if a != nil || b != nil {
+			*out = append(*out, fmt.Sprintf("%s: nil mismatch (a-nil=%v b-nil=%v)", path, a == nil, b == nil))
+		}
+		return
+	}
+
+	aType, bType := a.Type(lang), b.Type(lang)
+	if aType != bType {
+		*out = append(*out, fmt.Sprintf("%s: type %q != %q", path, aType, bType))
+	}
+	if a.IsNamed() != b.IsNamed() {
+		*out = append(*out, fmt.Sprintf("%s: named %v != %v", path, a.IsNamed(), b.IsNamed()))
+	}
+	if a.IsMissing() != b.IsMissing() {
+		*out = append(*out, fmt.Sprintf("%s: missing %v != %v", path, a.IsMissing(), b.IsMissing()))
+	}
+	if a.HasError() != b.HasError() {
+		*out = append(*out, fmt.Sprintf("%s: hasError %v != %v", path, a.HasError(), b.HasError()))
+	}
+	if a.StartByte() != b.StartByte() || a.EndByte() != b.EndByte() {
+		*out = append(*out, fmt.Sprintf("%s: span [%d-%d] != [%d-%d]", path, a.StartByte(), a.EndByte(), b.StartByte(), b.EndByte()))
+	}
+
+	aCount, bCount := a.ChildCount(), b.ChildCount()
+	if aCount != bCount {
+		*out = append(*out, fmt.Sprintf("%s: childCount %d != %d", path, aCount, bCount))
+		return
+	}
+
+	for i := 0; i < aCount; i++ {
+		aChild, bChild := a.Child(i), b.Child(i)
+		if af, bf := a.FieldNameForChild(i, lang), b.FieldNameForChild(i, lang); af != bf {
+			*out = append(*out, fmt.Sprintf("%s[%d]: field %q != %q", path, i, af, bf))
+		}
+		childType := "?"
+		if aChild != nil {
+			childType = aChild.Type(lang)
+		} else if bChild != nil {
+			childType = bChild.Type(lang)
+		}
+		a3WalkGoTreeDivergences(aChild, lang, bChild, fmt.Sprintf("%s/%s[%d]", path, childType, i), out)
+	}
+}

--- a/cgo_harness/ada_a3_certification_sweep_test.go
+++ b/cgo_harness/ada_a3_certification_sweep_test.go
@@ -1,0 +1,213 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestAdaA3CompactCertificationFullCorpusSweep is the A3
+// certification-workstream (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) full-corpus verification receipt
+// for Ada. Ada has no corpus_real directory (it is not one of the top-50
+// languages cgo_harness/corpus_real's manifest profiles), so this sweep uses
+// the smoke sample, the three existing tied-election witnesses
+// (ada_election_local_parity_test.go, including both tied aggregate
+// elections the finding names), and 18 constructed adversarial sources
+// exercising Ada's conflict-heavy shapes (aggregates, attributes, generics,
+// tasks, protected types, access types, exception handlers).
+func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
+	lang := grammars.AdaLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("ada did not receive the A3 primary-acceptance-derivation certification")
+	}
+	if !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("ada did not receive the A3 converged-split-drop certification")
+	}
+
+	sources := []a3CertificationSweepSource{
+		{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("ada"))},
+	}
+	sources = append(sources, adaA3TiedElectionWitnesses()...)
+	sources = append(sources, adaA3AdversarialSources()...)
+
+	result := runA3CertificationSweep(t, "ada", "ada", lang, sources)
+	a3ReportSweep(t, result)
+}
+
+// adaA3TiedElectionWitnesses reuses the three witnesses already vetted in
+// ada_election_local_parity_test.go (TestAdaElectionRawCOracleParity),
+// including both tied aggregate elections the finding names ("both ada
+// aggregates").
+func adaA3TiedElectionWitnesses() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		{
+			// dispatch.ada.constraint-kind-election witness.
+			Name: "attribute_constraint",
+			Source: []byte("procedure P is\n" +
+				"begin\n" +
+				"   A := new T (F => Pkg.Obj'Access);\n" +
+				"end;\n"),
+		},
+		{
+			// dispatch.ada.aggregate-kind-election witness (tree-sitter-ada
+			// test/corpus/arrays.txt). The finding's first "ada aggregate".
+			Name: "locked_positional_array_aggregate",
+			Source: []byte("package P is\n" +
+				"   type A is array (1 .. 3) of Boolean;\n" +
+				"   V : constant A := (1, 2, 3);\n" +
+				"end;\n"),
+		},
+		{
+			// dispatch.ada.aggregate-kind-election +
+			// dispatch.ada.association-choice-materialization witness. The
+			// finding's second "ada aggregate".
+			Name: "array_others_choice",
+			Source: []byte("procedure P is\n" +
+				"begin\n" +
+				"   A := (others => 0);\n" +
+				"end;\n"),
+		},
+	}
+}
+
+// adaA3AdversarialSources constructs 18 sources exercising Ada's
+// conflict-heavy grammar shapes: mixed aggregates, attribute references,
+// generic instantiation, tasks, protected types, access types, exception
+// handlers, discriminated records, and qualified expressions.
+func adaA3AdversarialSources() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		{Name: "named_array_aggregate", Source: []byte(
+			"package P is\n" +
+				"   type A is array (1 .. 3) of Integer;\n" +
+				"   V : constant A := (1 => 10, 2 => 20, 3 => 30);\n" +
+				"end P;\n")},
+		{Name: "mixed_positional_named_aggregate", Source: []byte(
+			"package P is\n" +
+				"   type A is array (1 .. 3) of Integer;\n" +
+				"   V : constant A := (10, 20, others => 0);\n" +
+				"end P;\n")},
+		{Name: "record_aggregate_named", Source: []byte(
+			"package P is\n" +
+				"   type R is record\n" +
+				"      X : Integer;\n" +
+				"      Y : Integer;\n" +
+				"   end record;\n" +
+				"   V : constant R := (X => 1, Y => 2);\n" +
+				"end P;\n")},
+		{Name: "qualified_expression", Source: []byte(
+			"package P is\n" +
+				"   type A is array (1 .. 3) of Integer;\n" +
+				"   V : constant A := A'(1, 2, 3);\n" +
+				"end P;\n")},
+		{Name: "attribute_range_and_first_last", Source: []byte(
+			"procedure P is\n" +
+				"   type A is array (1 .. 10) of Integer;\n" +
+				"   V : A;\n" +
+				"begin\n" +
+				"   for I in V'Range loop\n" +
+				"      V (I) := V'First + V'Last;\n" +
+				"   end loop;\n" +
+				"end P;\n")},
+		{Name: "generic_package_instantiation", Source: []byte(
+			"generic\n" +
+				"   type T is private;\n" +
+				"package Stacks is\n" +
+				"   procedure Push (Item : T);\n" +
+				"end Stacks;\n" +
+				"package Integer_Stacks is new Stacks (T => Integer);\n")},
+		{Name: "task_declaration_and_body", Source: []byte(
+			"task Worker is\n" +
+				"   entry Start;\n" +
+				"end Worker;\n" +
+				"task body Worker is\n" +
+				"begin\n" +
+				"   accept Start do\n" +
+				"      null;\n" +
+				"   end Start;\n" +
+				"end Worker;\n")},
+		{Name: "protected_type_declaration", Source: []byte(
+			"protected type Counter is\n" +
+				"   procedure Increment;\n" +
+				"   function Value return Integer;\n" +
+				"private\n" +
+				"   Count : Integer := 0;\n" +
+				"end Counter;\n")},
+		{Name: "access_to_subprogram", Source: []byte(
+			"package P is\n" +
+				"   type Callback is access procedure (X : Integer);\n" +
+				"end P;\n")},
+		{Name: "access_to_object", Source: []byte(
+			"package P is\n" +
+				"   type Int_Ptr is access Integer;\n" +
+				"   V : Int_Ptr := new Integer'(42);\n" +
+				"end P;\n")},
+		{Name: "exception_handler_multi_when", Source: []byte(
+			"procedure P is\n" +
+				"begin\n" +
+				"   null;\n" +
+				"exception\n" +
+				"   when Constraint_Error | Program_Error =>\n" +
+				"      null;\n" +
+				"   when others =>\n" +
+				"      null;\n" +
+				"end P;\n")},
+		{Name: "discriminated_record", Source: []byte(
+			"package P is\n" +
+				"   type Buffer (Size : Positive) is record\n" +
+				"      Data : String (1 .. Size);\n" +
+				"   end record;\n" +
+				"end P;\n")},
+		{Name: "case_statement_multi_choice", Source: []byte(
+			"procedure P (X : Integer) is\n" +
+				"begin\n" +
+				"   case X is\n" +
+				"      when 1 | 2 | 3 =>\n" +
+				"         null;\n" +
+				"      when 4 .. 10 =>\n" +
+				"         null;\n" +
+				"      when others =>\n" +
+				"         null;\n" +
+				"   end case;\n" +
+				"end P;\n")},
+		{Name: "renaming_declaration", Source: []byte(
+			"package P is\n" +
+				"   X : Integer := 1;\n" +
+				"   Y : Integer renames X;\n" +
+				"end P;\n")},
+		{Name: "subtype_with_range_constraint", Source: []byte(
+			"package P is\n" +
+				"   subtype Digit is Integer range 0 .. 9;\n" +
+				"end P;\n")},
+		{Name: "nested_package_declaration", Source: []byte(
+			"package Outer is\n" +
+				"   package Inner is\n" +
+				"      procedure Do_Something;\n" +
+				"   end Inner;\n" +
+				"end Outer;\n")},
+		{Name: "overloaded_operator_function", Source: []byte(
+			"package P is\n" +
+				"   type Vector is record\n" +
+				"      X, Y : Float;\n" +
+				"   end record;\n" +
+				"   function \"+\" (Left, Right : Vector) return Vector;\n" +
+				"end P;\n")},
+		{Name: "extended_return_statement", Source: []byte(
+			"package P is\n" +
+				"   type R is record\n" +
+				"      X : Integer;\n" +
+				"   end record;\n" +
+				"   function Make return R;\n" +
+				"end P;\n" +
+				"package body P is\n" +
+				"   function Make return R is\n" +
+				"   begin\n" +
+				"      return Result : R do\n" +
+				"         Result.X := 1;\n" +
+				"      end return;\n" +
+				"   end Make;\n" +
+				"end P;\n")},
+	}
+}

--- a/cgo_harness/apex_a3_certification_sweep_test.go
+++ b/cgo_harness/apex_a3_certification_sweep_test.go
@@ -1,0 +1,222 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestApexA3CompactCertificationFullCorpusSweep is the A3
+// certification-workstream (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) full-corpus verification receipt
+// for Apex. Apex has no corpus_real directory (it is not one of the top-50
+// languages cgo_harness/corpus_real's manifest profiles), so this sweep uses
+// the smoke sample, the three existing tied-election witnesses
+// (apex_generic_local_parity_test.go), and 20 constructed adversarial
+// sources exercising Apex's conflict-heavy shapes (generics, SOQL/SOSL,
+// sharing, triggers, casts, switch-on, annotations).
+func TestApexA3CompactCertificationFullCorpusSweep(t *testing.T) {
+	lang := grammars.ApexLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("apex did not receive the A3 primary-acceptance-derivation certification")
+	}
+	if lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("apex unexpectedly carries the converged-split-drop certification (apex does not need it)")
+	}
+
+	sources := []a3CertificationSweepSource{
+		{Name: "smoke_sample", Source: []byte(grammars.ParseSmokeSample("apex"))},
+	}
+	sources = append(sources, apexA3TiedElectionWitnesses()...)
+	sources = append(sources, apexA3AdversarialSources()...)
+
+	result := runA3CertificationSweep(t, "apex", "apex", lang, sources)
+	a3ReportSweep(t, result)
+}
+
+// apexA3TiedElectionWitnesses reuses the three witnesses already vetted in
+// apex_generic_local_parity_test.go (TestApexCloseAngleRawCOracleParity),
+// including the tied class-literal election the finding names ("apex
+// class-literal").
+func apexA3TiedElectionWitnesses() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		{
+			Name: "nested_generic_local",
+			Source: []byte("public class C {\n" +
+				"  void m() {\n" +
+				"    List<List<SObject>> searchResults = [FIND :keyword IN ALL FIELDS];\n" +
+				"  }\n" +
+				"}\n"),
+		},
+		{
+			Name: "right_shift",
+			Source: []byte("public class C {\n" +
+				"  Integer m(Integer value) {\n" +
+				"    return value >> 1;\n" +
+				"  }\n" +
+				"}\n"),
+		},
+		{
+			// Issue #601 tied election: class_literal vs field_access. The
+			// finding's "apex class-literal" witness -- the compact route is
+			// strictly more faithful than production plus the compat arm here.
+			Name: "class_literal_alias",
+			Source: []byte("public class C {\n" +
+				"  void m() {\n" +
+				"    Object t = RecordPage.class;\n" +
+				"  }\n" +
+				"}\n"),
+		},
+	}
+}
+
+// apexA3AdversarialSources constructs 20 sources exercising Apex's
+// conflict-heavy grammar shapes: nested generics, SOQL/SOSL query
+// expressions, sharing and trigger declarations, casts versus parenthesized
+// expressions, switch-on, annotations, and property accessors.
+func apexA3AdversarialSources() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		{Name: "soql_basic_query", Source: []byte(
+			"public class C {\n" +
+				"  List<Account> m() {\n" +
+				"    return [SELECT Id, Name FROM Account WHERE Name = 'Acme' LIMIT 10];\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "soql_nested_subquery", Source: []byte(
+			"public class C {\n" +
+				"  List<Account> m() {\n" +
+				"    return [SELECT Id, (SELECT Id, LastName FROM Contacts) FROM Account];\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "sosl_returning_query", Source: []byte(
+			"public class C {\n" +
+				"  void m() {\n" +
+				"    List<List<SObject>> results = [FIND 'test' IN ALL FIELDS RETURNING Account(Id, Name), Contact(Id)];\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "with_sharing_class", Source: []byte(
+			"public with sharing class C {\n" +
+				"  public void m() {}\n" +
+				"}\n")},
+		{Name: "without_sharing_class", Source: []byte(
+			"public without sharing class C {\n" +
+				"  public void m() {}\n" +
+				"}\n")},
+		{Name: "inherited_sharing_class", Source: []byte(
+			"public inherited sharing class C {\n" +
+				"  public void m() {}\n" +
+				"}\n")},
+		{Name: "trigger_before_insert", Source: []byte(
+			"trigger AccountTrigger on Account (before insert, before update) {\n" +
+				"  for (Account a : Trigger.new) {\n" +
+				"    a.Name = a.Name.trim();\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "interface_declaration", Source: []byte(
+			"public interface Greeter {\n" +
+				"  String greet(String name);\n" +
+				"}\n")},
+		{Name: "enum_declaration", Source: []byte(
+			"public enum Season { WINTER, SPRING, SUMMER, FALL }\n")},
+		{Name: "static_initializer_block", Source: []byte(
+			"public class C {\n" +
+				"  static Integer counter;\n" +
+				"  static {\n" +
+				"    counter = 0;\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "try_catch_finally_multi", Source: []byte(
+			"public class C {\n" +
+				"  void m() {\n" +
+				"    try {\n" +
+				"      Integer x = 1 / 0;\n" +
+				"    } catch (DmlException e) {\n" +
+				"      System.debug(e.getMessage());\n" +
+				"    } catch (Exception e) {\n" +
+				"      System.debug('other');\n" +
+				"    } finally {\n" +
+				"      System.debug('done');\n" +
+				"    }\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "annotation_istest", Source: []byte(
+			"@isTest\n" +
+				"private class CTest {\n" +
+				"  @isTest\n" +
+				"  static void testMethod1() {\n" +
+				"    System.assertEquals(1, 1);\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "aura_enabled_property", Source: []byte(
+			"public class C {\n" +
+				"  @AuraEnabled\n" +
+				"  public Integer count { get; set; }\n" +
+				"}\n")},
+		{Name: "cast_vs_parenthesized_expr", Source: []byte(
+			"public class C {\n" +
+				"  void m(Object obj) {\n" +
+				"    Account a = (Account)obj;\n" +
+				"    Integer x = (1 + 2);\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "switch_on_statement", Source: []byte(
+			"public class C {\n" +
+				"  String m(Integer x) {\n" +
+				"    switch on x {\n" +
+				"      when 1 {\n" +
+				"        return 'one';\n" +
+				"      }\n" +
+				"      when 2, 3 {\n" +
+				"        return 'two-or-three';\n" +
+				"      }\n" +
+				"      when else {\n" +
+				"        return 'other';\n" +
+				"      }\n" +
+				"    }\n" +
+				"    return null;\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "instanceof_and_generic_collection", Source: []byte(
+			"public class C {\n" +
+				"  void m(Object obj) {\n" +
+				"    if (obj instanceof Map<String, List<Integer>>) {\n" +
+				"      System.debug('map');\n" +
+				"    }\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "nested_class_and_generic_method", Source: []byte(
+			"public class Outer {\n" +
+				"  public class Inner {\n" +
+				"    public Integer value;\n" +
+				"  }\n" +
+				"  public static <T> List<T> wrap(T item) {\n" +
+				"    List<T> result = new List<T>();\n" +
+				"    result.add(item);\n" +
+				"    return result;\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "ternary_with_nested_generics", Source: []byte(
+			"public class C {\n" +
+				"  Map<String, List<Integer>> m(Boolean flag) {\n" +
+				"    return flag ? new Map<String, List<Integer>>() : null;\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "for_each_soql_inline", Source: []byte(
+			"public class C {\n" +
+				"  void m() {\n" +
+				"    for (Account a : [SELECT Id FROM Account WHERE Name != null]) {\n" +
+				"      System.debug(a.Id);\n" +
+				"    }\n" +
+				"  }\n" +
+				"}\n")},
+		{Name: "bind_variable_soql_with_generic_local", Source: []byte(
+			"public class C {\n" +
+				"  void m(String keyword) {\n" +
+				"    List<Account> results = [SELECT Id FROM Account WHERE Name = :keyword];\n" +
+				"    List<List<SObject>> both = [FIND :keyword IN ALL FIELDS RETURNING Account, Contact];\n" +
+				"  }\n" +
+				"}\n")},
+	}
+}

--- a/cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go
+++ b/cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go
@@ -1,0 +1,104 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestKotlinA3CertificationObjectDeclarationRegressionCOracle is the C-oracle
+// receipt for withholding Kotlin's A3 certification (spec.campaign.v7,
+// finding tied-election-family-compact-retirement).
+//
+// Forcing both CompactConvergedReductionSplitDropsCertified and
+// CompactPrimaryAcceptanceDerivationCertified on the shared Kotlin language
+// resolves the finding's platform-modifier-recovery witness
+// (b4b_alternative_set_v2_kotlin_adjudication_test.go), but the same pair
+// regresses this distinct witness (issue #93,
+// query_kotlin_object_declaration_test.go): the compact route accepts
+// "object Singleton { fun work() = Unit }" as an infix_expression instead
+// of an object_declaration. This test adjudicates directly against the
+// locked C oracle: production already matches C here, and the forced
+// compact route does not. That is a genuine divergence, not an adjudicated
+// exception, so grammars/runtime_profiles.go withholds both certificates
+// for Kotlin. See admission_switch_kotlin_certification_withheld_test.go
+// for the companion no-cgo receipt (including the safe split-drops-only
+// grant).
+func TestKotlinA3CertificationObjectDeclarationRegressionCOracle(t *testing.T) {
+	source := []byte("package demo\n\nobject Singleton {\n    fun work() = Unit\n}\n")
+	goLang := grammars.KotlinLanguage()
+
+	cLang, err := COracleLanguage("kotlin")
+	if err != nil {
+		t.Fatalf("load Kotlin C oracle: %v", err)
+	}
+	cParser := sitter.NewParser()
+	defer cParser.Close()
+	if err := cParser.SetLanguage(cLang); err != nil {
+		t.Fatalf("set Kotlin C oracle language: %v", err)
+	}
+	cTree := cParser.Parse(source, nil)
+	if cTree == nil || cTree.RootNode() == nil {
+		t.Fatal("C oracle parse returned no root")
+	}
+	defer cTree.Close()
+	cRoot := cTree.RootNode()
+
+	production := gotreesitter.NewParser(goLang)
+	production.SetAdmissionCandidateRoute(false)
+	productionTree, err := production.Parse(source)
+	if err != nil {
+		t.Fatalf("production parse: %v", err)
+	}
+	defer productionTree.Release()
+
+	var productionMismatches []string
+	compareNodes(productionTree.RootNode(), goLang, cRoot, "root", &productionMismatches)
+	if len(productionMismatches) != 0 {
+		t.Fatalf(
+			"production diverges from the C oracle on the #93 witness (unexpected, unrelated "+
+				"regression -- not the A3 certification finding this test pins):\n%s",
+			strings.Join(productionMismatches, "\n"),
+		)
+	}
+
+	if goLang.CompactConvergedReductionSplitDropsCertified || goLang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("shared kotlin language unexpectedly carries a withheld A3 certificate")
+	}
+	goLang.CompactConvergedReductionSplitDropsCertified = true
+	goLang.CompactPrimaryAcceptanceDerivationCertified = true
+	defer func() {
+		goLang.CompactConvergedReductionSplitDropsCertified = false
+		goLang.CompactPrimaryAcceptanceDerivationCertified = false
+	}()
+
+	candidate := gotreesitter.NewParser(goLang)
+	candidate.SetAdmissionCandidateRoute(true)
+	candidateTree, err := candidate.Parse(source)
+	if err != nil {
+		t.Fatalf("forced compact parse: %v", err)
+	}
+	defer candidateTree.Release()
+
+	var candidateMismatches []string
+	compareNodes(candidateTree.RootNode(), goLang, cRoot, "root", &candidateMismatches)
+	if len(candidateMismatches) == 0 {
+		t.Fatalf(
+			"forced compact route (both A3 certificates) now matches the C oracle on the #93 " +
+				"witness; the object_declaration regression may be fixed -- re-verify " +
+				"admission_switch_kotlin_certification_withheld_test.go and consider landing " +
+				"Kotlin's A3 certification",
+		)
+	}
+	t.Logf(
+		"confirmed: forced compact route (both A3 certificates) diverges from the C oracle at "+
+			"%d point(s); production matches C. Kotlin's A3 certification stays withheld:\n%s",
+		len(candidateMismatches), strings.Join(candidateMismatches, "\n"),
+	)
+}

--- a/cgo_harness/perl_a3_certification_sweep_test.go
+++ b/cgo_harness/perl_a3_certification_sweep_test.go
@@ -1,0 +1,64 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestPerlA3CompactCertificationFullCorpusSweep is the A3
+// certification-workstream (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) full-corpus verification receipt
+// for Perl. It gates both new grants
+// (CompactPrimaryAcceptanceDerivationCertified and
+// CompactConvergedReductionSplitDropsCertified, grammars/runtime_profiles.go)
+// on zero unadjudicated compact-vs-C divergence across the real corpus plus
+// the tied push-list election witness and its known-gap siblings
+// (perl_scheduler_action_local_parity_test.go).
+func TestPerlA3CompactCertificationFullCorpusSweep(t *testing.T) {
+	lang := grammars.PerlLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("perl did not receive the A3 primary-acceptance-derivation certification")
+	}
+	if !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("perl did not receive the A3 converged-split-drop certification")
+	}
+
+	sources := a3LoadRealCorpusDir(t, filepath.Join("corpus_real", "perl"))
+	sources = append(sources, a3CertificationSweepSource{
+		Name:   "smoke_sample",
+		Source: []byte(grammars.ParseSmokeSample("perl")),
+	})
+	sources = append(sources, perlA3AdversarialSources()...)
+
+	result := runA3CertificationSweep(t, "perl", "perl", lang, sources)
+	a3ReportSweep(t, result)
+}
+
+// perlA3AdversarialSources reuses Perl's tied push-list election witness
+// (the finding's "perl push-list") and its documented list-operator sibling
+// shapes (perl_scheduler_action_local_parity_test.go), all already vetted
+// as conflict-heavy ambiguous_function_call_expression shapes.
+func perlA3AdversarialSources() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		// Real-corpus witness: cgo_harness/corpus_real/perl/medium__unicode_ranges.pl.
+		{Name: "push_two_args_real_corpus_witness", Source: []byte("push @found, $_;\n")},
+		{Name: "push_three_args", Source: []byte("push @found, $a, $b;\n")},
+		{Name: "unshift_two_args", Source: []byte("unshift @found, $_;\n")},
+		{Name: "join_assignment", Source: []byte("my $x = join \"\\n\", \"a\", \"b\";\n")},
+		{Name: "join_bare", Source: []byte("join \"\\n\", \"a\", \"b\";\n")},
+		{Name: "return_list", Source: []byte("sub f { return $a, $b; }\n")},
+		{Name: "hash_slice_assignment", Source: []byte("my %h; @h{qw(a b c)} = (1, 2, 3);\n")},
+		{Name: "regex_match_conditional", Source: []byte("if ($x =~ /foo/) { print \"matched\\n\"; }\n")},
+		{Name: "here_doc", Source: []byte("my $text = <<\"END\";\nhello\nEND\n")},
+		{Name: "package_with_use", Source: []byte("package Foo;\nuse strict;\nuse warnings;\n1;\n")},
+		{Name: "anonymous_sub_ref", Source: []byte("my $cb = sub { return $_[0] + 1; };\n")},
+		{Name: "map_grep_chain", Source: []byte("my @out = grep { $_ % 2 == 0 } map { $_ * 2 } (1, 2, 3);\n")},
+		{Name: "ternary_list_context", Source: []byte("my @r = $flag ? (1, 2) : (3, 4);\n")},
+		{Name: "local_dynamic_scope", Source: []byte("our $x = 1;\nsub f { local $x = 2; g(); }\n")},
+		{Name: "wantarray_dispatch", Source: []byte("sub f { return wantarray ? (1, 2) : 1; }\n")},
+	}
+}

--- a/cgo_harness/python_a3_certification_sweep_test.go
+++ b/cgo_harness/python_a3_certification_sweep_test.go
@@ -1,0 +1,104 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestPythonA3CompactCertificationFullCorpusSweep is the A3
+// certification-workstream (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) full-corpus verification receipt
+// for Python. Python already shipped CompactConvergedReductionSplitDropsCertified;
+// this sweep gates the added CompactPrimaryAcceptanceDerivationCertified
+// grant (grammars/runtime_profiles.go) on zero unadjudicated compact-vs-C
+// divergence across the real corpus plus the tied-election and known-gap
+// tuple/f-string witnesses (python_scheduler_action_local_parity_test.go).
+func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
+	lang := grammars.PythonLanguage()
+	if !lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("python did not receive the A3 primary-acceptance-derivation certification")
+	}
+	if !lang.CompactConvergedReductionSplitDropsCertified {
+		t.Fatal("python lost its pre-existing converged-split-drop certification")
+	}
+
+	sources := a3LoadRealCorpusDir(t, filepath.Join("corpus_real", "python"))
+	sources = append(sources, a3CertificationSweepSource{
+		Name:   "smoke_sample",
+		Source: []byte(grammars.ParseSmokeSample("python")),
+	})
+	sources = append(sources, pythonA3AdversarialSources()...)
+
+	result := runA3CertificationSweep(t, "python", "python", lang, sources)
+	a3ReportSweep(t, result)
+}
+
+// pythonA3AdversarialSources gathers Python's tied-election witness (the
+// bare-tuple assignment right-hand side) plus its known-gap and neutral
+// control sources
+// (python_scheduler_action_local_parity_test.go), all already vetted as
+// conflict-heavy shapes for this grammar's pattern_list/expression_list
+// election.
+func pythonA3AdversarialSources() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		{Name: "assignment_bare_tuple_real_corpus_witness", Source: []byte("x, y, z = 1, 2, 3\nxyz = x, y, z\n")},
+		{Name: "assignment_bare_pair", Source: []byte("a = 1\nb = 2\npair = a, b\n")},
+		{Name: "assignment_bare_single_trailing_comma", Source: []byte("a = 1\nsingle = a,\n")},
+		{Name: "fstring_interpolation_bare_tuple", Source: []byte("x = 1\ny = 2\nz = f\"{x, y}\"\n")},
+		{Name: "fstring_interpolation_splat", Source: []byte("xs = [1, 2]\nz = f\"{*xs,}\"\n")},
+		{Name: "print_chevron", Source: []byte("print >>sys.stderr, \"x\"\n")},
+		{Name: "collapsed_pass_own_line", Source: []byte("def f():\n    pass\n")},
+		{Name: "collapsed_pass_inline_block", Source: []byte("if True: pass\n")},
+		{Name: "collapsed_continue_inline_block", Source: []byte("while True:\n    if True: continue\n")},
+		{Name: "collapsed_break_inline_block", Source: []byte("while True:\n    if True: break\n")},
+		{Name: "inline_return_block", Source: []byte("def f():\n    if True: return 1\n")},
+		{Name: "inline_raise_block", Source: []byte("def f():\n    if True: raise ValueError(\"x\")\n")},
+		{Name: "inline_yield_block", Source: []byte("def f():\n    if True: yield 1\n")},
+		{Name: "inline_tuple_block", Source: []byte("def f():\n    if True: a, b = 1, 2\n")},
+		{Name: "wildcard_import", Source: []byte("from os import *\n")},
+		{Name: "match_case_as_pattern", Source: []byte("match p:\n    case (a, b) as pair:\n        pass\n")},
+		{Name: "match_case_wildcard", Source: []byte("match p:\n    case _:\n        pass\n")},
+		{Name: "for_target_tuple_negative_control", Source: []byte("pairs = [(1, 2)]\nfor a, b in pairs:\n    pass\n")},
+		{Name: "chained_assignment_lhs_negative_control", Source: []byte("a, b = c, d = 1, 2\n")},
+		{Name: "del_tuple_negative_control", Source: []byte("a = 1\nb = 2\ndel a, b\n")},
+		{Name: "walrus_in_comprehension", Source: []byte("data = [1, 2, 3]\nresult = [y for x in data if (y := x * 2) > 2]\n")},
+		{Name: "decorated_async_def", Source: []byte("import functools\n\n@functools.wraps\nasync def f(x, *, y=1, **kw):\n    return x, y\n")},
+		{Name: "star_expr_unpack", Source: []byte("first, *rest = [1, 2, 3]\n")},
+		{Name: "lambda_tuple_return", Source: []byte("f = lambda x, y: (x, y)\n")},
+		{Name: "nested_fstring_conversion", Source: []byte("name = \"world\"\ns = f\"{name!r:>{10}}\"\n")},
+	}
+}
+
+// a3LoadRealCorpusDir reads every regular file directly under dir (relative
+// to the cgo_harness package directory) into an a3CertificationSweepSource
+// slice, sorted by name for deterministic ordering. It skips (does not fail)
+// when dir does not exist, so a language with no corpus_real directory
+// simply contributes zero real-corpus sources.
+func a3LoadRealCorpusDir(t *testing.T, dir string) []a3CertificationSweepSource {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read corpus dir %s: %v", dir, err)
+	}
+	var out []a3CertificationSweepSource
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read corpus file %s: %v", path, err)
+		}
+		out = append(out, a3CertificationSweepSource{Name: entry.Name(), Source: data})
+	}
+	return out
+}

--- a/export_test.go
+++ b/export_test.go
@@ -341,6 +341,22 @@ func ParserRetainsCollapsedChildOccurrenceForTest(p *Parser, parent, child Symbo
 	return p != nil && p.retainsCollapsedChildOccurrence(parent, child)
 }
 
+// SetNoResultCompatibilityBenchmarkOnlyForTest sets p's
+// noResultCompatibilityBenchmarkOnly flag directly, without also suppressing
+// the admission candidate route the way the public
+// ParseNoResultCompatibilityBenchmarkOnly wrapper does (it defers
+// suppressAdmissionCandidateRoute, so it can never serve as a compact-route
+// probe). Combined with SetAdmissionCandidateRoute(true), this lets the A3
+// certification-workstream arm no-op receipt (spec.campaign.v7, finding
+// tied-election-family-compact-retirement) dump the compact route's raw,
+// pre-compat-tail runner tree for comparison against the normal tailed
+// parse. It returns a restore function.
+func SetNoResultCompatibilityBenchmarkOnlyForTest(p *Parser, enabled bool) func() {
+	prev := p.noResultCompatibilityBenchmarkOnly
+	p.noResultCompatibilityBenchmarkOnly = enabled
+	return func() { p.noResultCompatibilityBenchmarkOnly = prev }
+}
+
 // ParserPoolCheckoutForTest checks a parser out of the pool (applying defaults).
 func ParserPoolCheckoutForTest(pp *ParserPool) *Parser { return pp.checkout() }
 

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -241,6 +241,17 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		compactConvergedSplitDrops:     true,
 		compactPrimaryAcceptDerivation: true,
 	},
+	// Ada's tied aggregate elections (positional-array and others-choice)
+	// match the C oracle once the compact route accepts after a
+	// converged-path split drop and selects the sole primary derivation.
+	// Full-corpus field-aware C-oracle verification certifies both
+	// mechanisms for this exact blob (A3 certification workstream,
+	// spec.campaign.v7).
+	"ada": {
+		blobSHA256:                     mustRuntimeProfileSHA256("32f2dd8f0053ffb7e6b7014f6ff2eb7025287c0d5fcdab6ce1f6a694c2d8899e"),
+		compactConvergedSplitDrops:     true,
+		compactPrimaryAcceptDerivation: true,
+	},
 	// Swift's low-pressure accepted-error parses select the same tree across
 	// the retry ladder. High-pressure parses still benefit from the first
 	// ladder, while repeating that ladder for the external scanner does not.

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -221,6 +221,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		compactConvergedSplitDrops:     true,
 		compactPrimaryAcceptDerivation: true,
 	},
+	// Perl's tied push-list election matches the C oracle once the compact
+	// route accepts after a converged-path split drop and selects the sole
+	// primary derivation. Full-corpus field-aware C-oracle verification
+	// certifies both mechanisms for this exact blob (A3 certification
+	// workstream, spec.campaign.v7).
+	"perl": {
+		blobSHA256:                     mustRuntimeProfileSHA256("22388f06c2c54bb4748fd5f5f682ed25eecff8115a7e8e6a98f94f9c94bb9820"),
+		compactConvergedSplitDrops:     true,
+		compactPrimaryAcceptDerivation: true,
+	},
 	// Swift's low-pressure accepted-error parses select the same tree across
 	// the retry ladder. High-pressure parses still benefit from the first
 	// ladder, while repeating that ladder for the external scanner does not.

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -203,10 +203,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},
 	},
+	// Python's tied tuple-assignment election matches the C oracle once the
+	// compact route selects the sole primary derivation. Full-corpus
+	// field-aware C-oracle verification certifies this mechanism for this
+	// exact blob, alongside the existing converged-path split-drop
+	// certification (A3 certification workstream, spec.campaign.v7).
 	"python": {
-		blobSHA256:                    mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
-		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
-		compactConvergedSplitDrops:    true,
+		blobSHA256:                     mustRuntimeProfileSHA256("cde4a67dc6af6e1232dbbd1eab8618478d1d73727020e8a8002542390a452d37"),
+		externalScannerFullParseRetry:  gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
+		compactConvergedSplitDrops:     true,
+		compactPrimaryAcceptDerivation: true,
 	},
 	// Swift's low-pressure accepted-error parses select the same tree across
 	// the retry ladder. High-pressure parses still benefit from the first

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -162,9 +162,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,
 		nativeResultCompatibility:     gotreesitter.ResultCompatibilityNativeCollapsedChildren,
 	},
+	// Apex's tied class-literal election matches the C oracle once the
+	// compact route selects the sole primary derivation; the compact tree is
+	// strictly more faithful than production plus the compat arm here. Apex
+	// has no converged-path split-drop shape, so it does not certify that
+	// mechanism. Full-corpus field-aware C-oracle verification certifies this
+	// exact blob (A3 certification workstream, spec.campaign.v7).
 	"apex": {
-		blobSHA256:                mustRuntimeProfileSHA256("69fc1b577f1f783a204c98719d55d2f15f329d296b9e227d651056ce878c1bd2"),
-		nativeResultCompatibility: gotreesitter.ResultCompatibilityNativeCollapsedChildren,
+		blobSHA256:                     mustRuntimeProfileSHA256("69fc1b577f1f783a204c98719d55d2f15f329d296b9e227d651056ce878c1bd2"),
+		nativeResultCompatibility:      gotreesitter.ResultCompatibilityNativeCollapsedChildren,
+		compactPrimaryAcceptDerivation: true,
 	},
 	"elixir": {
 		blobSHA256:                mustRuntimeProfileSHA256("9889f5f6704ea87f357c8d65ef3194d88fb5865922b45767fe4df0f2eda7e3f0"),

--- a/grammars/runtime_profiles.go
+++ b/grammars/runtime_profiles.go
@@ -157,6 +157,16 @@ var builtinLanguageRuntimeProfiles = map[string]builtinLanguageRuntimeProfile{
 			SkipCompleteAcceptedErrorRetry: true,
 		},
 	},
+	// Kotlin's tied platform-modifier recovery witness (internal actual fun
+	// f(): String = "x") matches the C oracle once the compact route accepts
+	// after a converged-path split drop. A3 certification-workstream
+	// verification withholds certification here: combining that grant with
+	// primary-acceptance-derivation selection regresses a distinct witness
+	// (object Singleton { fun work() = Unit }, issue #93) to an
+	// infix_expression misparse that diverges from the C oracle, which sides
+	// with production's object_declaration. Neither grant lands until that
+	// interaction is resolved (see
+	// TestKotlinCompactCertificationObjectDeclarationRegressionWithheld).
 	"kotlin": {
 		blobSHA256:                    mustRuntimeProfileSHA256("643a3e6b60d07846dd972849b612159ff9bf09734b09fb00013229c8593a8c78"),
 		externalScannerFullParseRetry: gotreesitter.ExternalScannerFullParseRetrySkipRepeat,

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -68,7 +68,10 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry. Crystal and Matlab add
 	// exact-blob external-scanner repeat suppression while retaining the full
-	// accepted-error retry ladder.
+	// accepted-error retry ladder. Python adds compact
+	// primary-acceptance-derivation certification (A3 certification
+	// workstream, spec.campaign.v7, finding
+	// tied-election-family-compact-retirement).
 	if got, want := len(builtinLanguageRuntimeProfiles), 42; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
@@ -146,6 +149,16 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 		},
 		{
 			name: "meson", load: MesonLanguage,
+			want: func(lang *gotreesitter.Language) bool {
+				return lang.CompactPrimaryAcceptanceDerivationCertified
+			},
+		},
+		// A3 certification workstream (spec.campaign.v7, finding
+		// tied-election-family-compact-retirement): full-corpus field-aware
+		// C-oracle verification certifies primary-acceptance-derivation
+		// selection for Python's tied tuple-assignment election.
+		{
+			name: "python", load: PythonLanguage,
 			want: func(lang *gotreesitter.Language) bool {
 				return lang.CompactPrimaryAcceptanceDerivationCertified
 			},

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -68,12 +68,14 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry. Crystal and Matlab add
 	// exact-blob external-scanner repeat suppression while retaining the full
-	// 43 = the prior 42 plus one new A3 certification-workstream entry: Perl
-	// (spec.campaign.v7, finding tied-election-family-compact-retirement).
-	// Apex and Python add compact primary-acceptance-derivation
-	// certification (Python also adds converged-split-drop certification);
-	// Perl is a new entry carrying both certifications.
-	if got, want := len(builtinLanguageRuntimeProfiles), 43; got != want {
+	// 44 = the prior 42 plus two new A3 certification-workstream entries:
+	// Perl and Ada (spec.campaign.v7, finding
+	// tied-election-family-compact-retirement). Apex and Python add compact
+	// primary-acceptance-derivation certification (Python also adds
+	// converged-split-drop certification); Perl and Ada are new entries
+	// carrying both certifications. Kotlin's entry stays unchanged (both
+	// grants withheld; see the "kotlin" map entry comment).
+	if got, want := len(builtinLanguageRuntimeProfiles), 44; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -154,11 +156,13 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 				return lang.CompactPrimaryAcceptanceDerivationCertified
 			},
 		},
-		// A3 certification workstream (spec.campaign.v7, finding
+		// The tied-election family (A3 certification workstream,
+		// spec.campaign.v7, finding
 		// tied-election-family-compact-retirement): full-corpus field-aware
 		// C-oracle verification certifies primary-acceptance-derivation
-		// selection for Python's tied tuple-assignment election, Apex's tied
-		// class-literal election, and Perl's tied push-list election.
+		// selection for four of the five languages. Kotlin is withheld: see
+		// the runtime_profiles.go "kotlin" entry comment and
+		// TestKotlinCompactCertificationObjectDeclarationRegressionWithheld.
 		{
 			name: "python", load: PythonLanguage,
 			want: func(lang *gotreesitter.Language) bool {
@@ -173,6 +177,12 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 		},
 		{
 			name: "perl", load: PerlLanguage,
+			want: func(lang *gotreesitter.Language) bool {
+				return lang.CompactPrimaryAcceptanceDerivationCertified
+			},
+		},
+		{
+			name: "ada", load: AdaLanguage,
 			want: func(lang *gotreesitter.Language) bool {
 				return lang.CompactPrimaryAcceptanceDerivationCertified
 			},
@@ -219,10 +229,14 @@ func TestBuiltinCompactConvergedSplitProfilesRequireExactBlobIdentity(t *testing
 		{name: "javascript", load: JavascriptLanguage},
 		{name: "python", load: PythonLanguage},
 		// A3 certification workstream (spec.campaign.v7, finding
-		// tied-election-family-compact-retirement): Perl certifies
+		// tied-election-family-compact-retirement): Perl and Ada certify
 		// converged-path split-drop acceptance after full-corpus field-aware
-		// C-oracle verification.
+		// C-oracle verification. Apex does not need this certification and
+		// stays out of this table. Kotlin is withheld: see the
+		// runtime_profiles.go "kotlin" entry comment and
+		// TestKotlinCompactCertificationObjectDeclarationRegressionWithheld.
 		{name: "perl", load: PerlLanguage},
+		{name: "ada", load: AdaLanguage},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -68,11 +68,12 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry. Crystal and Matlab add
 	// exact-blob external-scanner repeat suppression while retaining the full
-	// accepted-error retry ladder. Apex and Python add compact
-	// primary-acceptance-derivation certification (A3 certification
-	// workstream, spec.campaign.v7, finding
-	// tied-election-family-compact-retirement).
-	if got, want := len(builtinLanguageRuntimeProfiles), 42; got != want {
+	// 43 = the prior 42 plus one new A3 certification-workstream entry: Perl
+	// (spec.campaign.v7, finding tied-election-family-compact-retirement).
+	// Apex and Python add compact primary-acceptance-derivation
+	// certification (Python also adds converged-split-drop certification);
+	// Perl is a new entry carrying both certifications.
+	if got, want := len(builtinLanguageRuntimeProfiles), 43; got != want {
 		t.Fatalf("builtinLanguageRuntimeProfiles has %d entries, want %d", got, want)
 	}
 	lang := &gotreesitter.Language{ExternalScanner: KotlinExternalScanner{}}
@@ -156,8 +157,8 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 		// A3 certification workstream (spec.campaign.v7, finding
 		// tied-election-family-compact-retirement): full-corpus field-aware
 		// C-oracle verification certifies primary-acceptance-derivation
-		// selection for Python's tied tuple-assignment election and Apex's
-		// tied class-literal election.
+		// selection for Python's tied tuple-assignment election, Apex's tied
+		// class-literal election, and Perl's tied push-list election.
 		{
 			name: "python", load: PythonLanguage,
 			want: func(lang *gotreesitter.Language) bool {
@@ -166,6 +167,12 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 		},
 		{
 			name: "apex", load: ApexLanguage,
+			want: func(lang *gotreesitter.Language) bool {
+				return lang.CompactPrimaryAcceptanceDerivationCertified
+			},
+		},
+		{
+			name: "perl", load: PerlLanguage,
 			want: func(lang *gotreesitter.Language) bool {
 				return lang.CompactPrimaryAcceptanceDerivationCertified
 			},
@@ -211,6 +218,11 @@ func TestBuiltinCompactConvergedSplitProfilesRequireExactBlobIdentity(t *testing
 		{name: "haskell", load: HaskellLanguage},
 		{name: "javascript", load: JavascriptLanguage},
 		{name: "python", load: PythonLanguage},
+		// A3 certification workstream (spec.campaign.v7, finding
+		// tied-election-family-compact-retirement): Perl certifies
+		// converged-path split-drop acceptance after full-corpus field-aware
+		// C-oracle verification.
+		{name: "perl", load: PerlLanguage},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/grammars/runtime_profiles_test.go
+++ b/grammars/runtime_profiles_test.go
@@ -68,7 +68,7 @@ func TestBuiltinRuntimeProfilesStayNarrow(t *testing.T) {
 	// retired outright, not migrated (see the "NOTE on dot" comment above
 	// the gomod entry), so it does not add a map entry. Crystal and Matlab add
 	// exact-blob external-scanner repeat suppression while retaining the full
-	// accepted-error retry ladder. Python adds compact
+	// accepted-error retry ladder. Apex and Python add compact
 	// primary-acceptance-derivation certification (A3 certification
 	// workstream, spec.campaign.v7, finding
 	// tied-election-family-compact-retirement).
@@ -156,9 +156,16 @@ func TestBuiltinCompactAcceptanceProfilesRequireExactBlobIdentity(t *testing.T) 
 		// A3 certification workstream (spec.campaign.v7, finding
 		// tied-election-family-compact-retirement): full-corpus field-aware
 		// C-oracle verification certifies primary-acceptance-derivation
-		// selection for Python's tied tuple-assignment election.
+		// selection for Python's tied tuple-assignment election and Apex's
+		// tied class-literal election.
 		{
 			name: "python", load: PythonLanguage,
+			want: func(lang *gotreesitter.Language) bool {
+				return lang.CompactPrimaryAcceptanceDerivationCertified
+			},
+		},
+		{
+			name: "apex", load: ApexLanguage,
 			want: func(lang *gotreesitter.Language) bool {
 				return lang.CompactPrimaryAcceptanceDerivationCertified
 			},


### PR DESCRIPTION
## Summary

Certifies the compact route for four of the five tied-election-family
languages after full-corpus, field-aware C-oracle verification, and
withholds the fifth with a precise, reproducible counterexample.

- Python, Apex, Perl, and Ada certify compact primary-acceptance-derivation
  selection. Perl and Ada also certify compact converged-path split-drop
  acceptance (Python already shipped it; Apex does not need it).
- Kotlin's certification is withheld: combining both grants regresses a
  distinct, currently-passing parse (`object Singleton { fun work() =
  Unit }`, issue #93) to a tree that diverges from the locked C oracle.
- No compatibility arm is deleted in this change. Landing the
  certification is the precondition later arm-retirement PRs need.

## Per-language full-corpus sweep

Each sweep parses every source on both the production route and the
compact route, then classifies the outcome: a compact accept must
byte-match production, or -- where they differ -- match the C oracle
exactly (the adjudicated-exception rule). A compact decline is safe by
construction (production serves the parse). Any accept that matches
neither production nor the C oracle blocks certification.

| Language | Corpus | Files | Accepted | Declined (safe) | Adjudicated exceptions | Divergences | Certified |
|---|---|---:|---:|---:|---:|---:|---|
| Python | real corpus (3) + smoke + 25 adversarial | 29 | 29 | 0 | 0 | 0 | Yes |
| Apex | smoke + 3 tied-election witnesses + 20 adversarial (no real corpus) | 24 | 22 | 2 | 1 | 0 | Yes |
| Perl | real corpus (3) + smoke + 15 adversarial | 19 | 18 | 1 | 0 | 0 | Yes |
| Ada | smoke + 3 tied-election witnesses + 18 adversarial (no real corpus) | 22 | 21 | 1 | 0 | 0 | Yes |
| Kotlin | investigated, not landed | -- | -- | -- | -- | -- | **No** |

Decline reasons (all fail-closed, safe): Apex 2x
`converged-path-reduction-split` (Apex does not hold that certificate, so
unrelated shapes correctly fail closed); Perl 1x recursive-insertion
(non-exact outer edge); Ada 1x no-eof-accept. Apex's one adjudicated
exception is the finding's named witness: `RecordPage.class` diverges from
production (2 points) but matches the C oracle exactly (issue #601).
Perl, Python, and Ada's tied-election witnesses needed no adjudication:
their compatibility arms already correct the raw election at the
production level, so tailed production already equals the C oracle, and
the compact route converges to the same tree.

## Kotlin: withheld with receipt

Both certificates together produce a genuine, C-verified divergence on a
witness distinct from the finding's platform-modifier case: with both
flags on, the compact route accepts `object Singleton { fun work() =
Unit }` as `infix_expression(object_literal, Singleton, lambda_literal)`
instead of `object_declaration`. The C oracle sides with production's
`object_declaration` (an 8-point field-aware structural divergence).
`CompactConvergedReductionSplitDropsCertified` alone is safe and resolves
the platform-modifier witness correctly; the combination with
`CompactPrimaryAcceptanceDerivationCertified` is what regresses. Since the
retirement precondition calls for both grants on Kotlin, and any
compact-vs-C divergence withholds the language, neither certificate lands
for Kotlin here. Receipts: `admission_switch_kotlin_certification_withheld_test.go`
(pins both the safe split-only grant and the regressing combination) and
`cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go`
(C-oracle adjudication).

## Arm no-op confirmation (retirement precondition receipt)

For each certified language, `admission_switch_a3_arm_noop_confirmation_test.go`
compares the compact route's raw runner tree (compatibility tail
suppressed via a new `SetNoResultCompatibilityBenchmarkOnlyForTest`
helper, which -- unlike the public `ParseNoResultCompatibilityBenchmarkOnly`
wrapper -- does not also force production) against its normal tailed
tree, on each language's own tied-election witness:

| Language | Compact-raw == compact-tailed | Notes |
|---|---|---|
| Apex | Yes | Confirmed no-op; the primary-acceptance-derivation grant already selects the correct derivation at the scheduler level. |
| Perl | No | The compatibility arm still performs real text-scan-based list regrouping on compact-origin trees. |
| Python | No | The compatibility arm still rewrites `pattern_list` to `expression_list` on compact-origin trees. |
| Ada | No | The compatibility arm still relabels `record_aggregate` into the C-correct aggregate production on compact-origin trees. |

Only Apex reproduces the "compact-raw equals compact-tailed" property.
Perl, Python, and Ada's compatibility arms remain load-bearing on
compact-origin trees for their tied-election witnesses even after
certification, so their arm-deletion follow-on PRs should not treat the
retirement precondition as met on this evidence; Apex's arm-deletion
follow-on can cite this receipt directly. (Trivial, non-triggering
sources are vacuously no-op for all four languages -- a much weaker
property that must not be read as confirming retirement readiness.)

## Scorecard and regression checks

- Smoke scorecard: 200/0/1/5/0, unchanged before and after (none of the
  five languages' trivial smoke fixtures trigger the tied-election
  shapes).
- Real-corpus admission matrix (Perl/Python/Kotlin, the three languages
  with a `corpus_real` entry): identical PASS/FALLBACK counts before and
  after (Kotlin 0/3, Perl 2/1, Python 3/0) -- their three corpus files
  each do not happen to exercise the specific tied-election shape; the
  dedicated sweep corpus above is the real receipt.
- `go test . -count=1`: green.
- `go test ./grammars -count=1`: green.
- Two pre-existing tests needed updates because the new certificates
  changed their premise: `TestAdmissionCandidateSelectedLineageSplitsMatchProduction`
  moved its Perl case to the certified-splits table; Kotlin's two
  pre-existing fail-closed witnesses needed no change (Kotlin stays
  uncertified).

## Commits

One commit per language: Python, Apex, Perl, Kotlin (withheld), Ada. Not
merged.
