### PR TITLE
remove(admission): Remove 64 KiB size eligibility decline from admission switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,21 @@ for tags and release notes while still in `0.x`.
   admission switch.
   A fresh full parse of any size now attempts the compact route first.
   The scheduler's stop-control poll bounds a large or pathological input:
-  it compares the compact core's own deterministic storage accounting
+  it compares the compact core's own real retained-memory footprint
   against the same soft memory budget production honors, and falls back to
   production with a matching `ParseStopMemoryBudget` stop reason when the
   budget is exceeded.
-  A decline now also releases the compact core's storage immediately, so a
-  production fallback never runs alongside retained compact storage.
+  Every decline path now releases the compact core's retained capacity
+  before returning, not only its logical record count, so a production
+  fallback does not run alongside megabytes of memory an earlier declined
+  attempt on the same parser left allocated.
+  An operator watching `AdmissionCandidateCounters()` sees this directly:
+  a large input that declines bumps the fallback count exactly as a small
+  one always did.
+  This bounds retained footprint, not the compact scheduler's own transient
+  per-token allocation during a declined attempt; closing that remaining
+  gap trades against how large an input the compact route can still serve,
+  and is an open follow-up, not resolved by this change.
   Routing only changes; every canonical tree digest stays identical.
 
 ## [0.48.0] - 2026-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ for tags and release notes while still in `0.x`.
   The host carried heavy background load throughout the run, so the result
   is not a sealed measurement.
 
+- Removed the 64 KiB source-length eligibility decline from the compact
+  admission switch.
+  A fresh full parse of any size now attempts the compact route first.
+  The scheduler's stop-control poll bounds a large or pathological input:
+  it compares the compact core's own deterministic storage accounting
+  against the same soft memory budget production honors, and falls back to
+  production with a matching `ParseStopMemoryBudget` stop reason when the
+  budget is exceeded.
+  A decline now also releases the compact core's storage immediately, so a
+  production fallback never runs alongside retained compact storage.
+  Routing only changes; every canonical tree digest stays identical.
+
 ## [0.48.0] - 2026-08-01
 
 ### Added

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -91,15 +91,12 @@ func admissionCandidateEnvEnabled() bool {
 // admission switch applies to Parsers with no explicit override. A per-Parser
 // override still wins.
 //
-// The candidate route does not enforce the automatic large-input memory budget
-// at scheduler granularity, so the switch declines every input at or above the
-// source-length floor where the production route arms that budget
-// (parseRuntimeMemoryMinSourceBytes). Such inputs stay on production and honor
-// ParseStopMemoryBudget. Below that floor, an explicit timeout, cancellation
-// flag, or the scheduler's own memory-budget poll is honored on the candidate
-// route itself, with a compatible stop receipt (falling back to production
-// when needed); included ranges and observability hooks still keep a parse on
-// production.
+// Tranche B9 removed the source-length eligibility decline: every input,
+// regardless of size, is eligible to attempt the candidate route. An explicit
+// timeout, cancellation flag, or the scheduler's own memory-budget poll
+// (tranche B8) is honored on the candidate route itself, with a compatible
+// stop receipt, falling back to production when it trips; included ranges and
+// observability hooks still keep a parse on production.
 func SetAdmissionCandidateRouteDefault(enabled bool) {
 	admissionCandidateRouteDefault.Store(enabled)
 }
@@ -113,13 +110,12 @@ func AdmissionCandidateRouteDefault() bool {
 // over the process-wide default. enabled=true forces the candidate route on for
 // eligible full parses; enabled=false forces the production route.
 //
-// enabled=true still respects every per-input eligibility decline: the switch
-// declines inputs at or above the source-length floor where the production
-// route arms the automatic memory budget (parseRuntimeMemoryMinSourceBytes), so
-// large inputs stay on production and honor ParseStopMemoryBudget. Included
-// ranges and observability hooks also keep a parse on production; an explicit
-// timeout or cancellation flag no longer does (the scheduler polls and honors
-// them with a compatible stop receipt).
+// enabled=true still respects every remaining eligibility decline: included
+// ranges and observability hooks keep a parse on production. Source length no
+// longer declines eligibility (tranche B9); a large input attempts the
+// candidate route and either completes there or trips the scheduler's
+// stop-control poll (tranche B8) and falls back to production with a
+// compatible stop receipt honoring ParseStopMemoryBudget.
 func (p *Parser) SetAdmissionCandidateRoute(enabled bool) {
 	if p == nil {
 		return
@@ -218,10 +214,12 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	// dispatch-pass-loop iteration) and cleanly aborts -- releasing the
 	// compact arenas before falling back -- so production still serves a
 	// tripped deadline or cancellation with its own compatible stop receipt.
-	// (The automatic large-input memory budget is honored by the per-input
-	// size decline in attemptAdmissionCandidateFullParse, which keeps every
-	// budget-eligible input on the production route; below that size, the
-	// scheduler's own memory-budget poll now covers the same soft budget.)
+	// Source length no longer declines eligibility either (tranche B9): the
+	// same scheduler poll compares the compact core's own deterministic
+	// StorageBytes() against production's soft memory budget on every input,
+	// large or small, so a pathological input still falls back to production
+	// and honors ParseStopMemoryBudget -- it just attempts the candidate route
+	// first instead of skipping it by source length.
 	//
 	// Preserve callback fidelity: the compact route does not emit the parser's
 	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline
@@ -276,15 +274,23 @@ func (p *Parser) pinToProductionRoute() {
 // (tree, true) when the candidate route produced a public tree, and (nil,
 // false) otherwise. On an eligible-but-declined attempt it bumps the fallback
 // counter (fail-closed, loud) so the caller re-runs the production route.
+//
+// Tranche B9 removed the source-length eligibility decline that used to keep
+// every input at or above parseRuntimeMemoryMinSourceBytes on production. A
+// large input now attempts the candidate route like any other: the scheduler's
+// stop-control poll (tranche B8, pollStopControl in
+// parsercore_phase0_driver.go) compares the compact core's own deterministic
+// StorageBytes() against the same soft budget production's arena/scratch
+// accounting honors, and the runner releases the compact core's storage
+// (Core.Reset, either through RunFreshSchedulerSession's automatic rollback on
+// a stop-control trip or through executeSchedulerOpen's explicit reset on an
+// acceptance decline) before returning control to this function, so a decline
+// never leaves compact storage retained while production's fallback parse
+// runs. A pathological input that exceeds the budget or a hard node/stack cap
+// declines here (an engine decline, counted below) and production serves it,
+// honoring ParseStopMemoryBudget exactly as it always has.
 func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree, usingProductionDFA bool) (*Tree, bool) {
 	if !p.admissionCandidateFullParseEligible(oldTree, usingProductionDFA) {
-		return nil, false
-	}
-	// Decline any input large enough that the production route would arm the
-	// automatic memory budget, which the compact scheduler cannot poll. This is
-	// a never-attempted eligibility decline, not an engine decline, so it does
-	// not move the fallback counter -- the parse simply stays on production.
-	if !admissionCandidateInputSizeEligible(len(source)) {
 		return nil, false
 	}
 	tree, ok, reason := p.tryCompactFullParseRoute(source)
@@ -295,24 +301,4 @@ func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree
 	admissionCandidateFallback.Add(1)
 	admissionCandidateLastFallbackReason.Store(reason)
 	return nil, false
-}
-
-// admissionCandidateInputSizeEligible reports whether an input is small enough
-// to route through the compact candidate without weakening the automatic
-// large-input memory budget contract.
-//
-// The compact scheduler does not poll the automatic memory budget at scheduler
-// granularity (the documented Phase-3 boundary), so a pathological large input
-// that the production route would truncate with ParseStopMemoryBudget could
-// instead parse to completion on the candidate route. The production route arms
-// that budget (soft default 512 MiB and hard ceiling 2 GiB) only once a source
-// reaches parseRuntimeMemoryMinSourceBytes (see runtimeMemoryBudgetEnabled and
-// runtimeMemoryHardCeilingEnabled in parser_memory_budget_runtime.go). Declining
-// every input at or above that same floor keeps every parse where the budget
-// could engage on the production route, so routing preserves the budget
-// contract exactly. Inputs below the floor never arm the budget on either
-// route, and the compact arena caps (admissionCandidateLimits) bound their
-// growth, so they route freely.
-func admissionCandidateInputSizeEligible(sourceLen int) bool {
-	return sourceLen < parseRuntimeMemoryMinSourceBytes
 }

--- a/admission_switch.go
+++ b/admission_switch.go
@@ -212,14 +212,18 @@ func (p *Parser) admissionCandidateFullParseEligible(oldTree *Tree, usingProduct
 	// (tranche B8): the scheduler polls both through the exact production
 	// check (diagnosticParserCoreGenericScheduler.pollStopControl, once per
 	// dispatch-pass-loop iteration) and cleanly aborts -- releasing the
-	// compact arenas before falling back -- so production still serves a
+	// compact arenas' retained capacity before falling back (Core.
+	// ResetReleasingRetention, tranche B9) -- so production still serves a
 	// tripped deadline or cancellation with its own compatible stop receipt.
 	// Source length no longer declines eligibility either (tranche B9): the
-	// same scheduler poll compares the compact core's own deterministic
-	// StorageBytes() against production's soft memory budget on every input,
-	// large or small, so a pathological input still falls back to production
-	// and honors ParseStopMemoryBudget -- it just attempts the candidate route
-	// first instead of skipping it by source length.
+	// same scheduler poll compares the compact core's own real retained
+	// footprint (Core.FootprintBytes()) against production's soft memory
+	// budget on every input, large or small, so a pathological input still
+	// falls back to production and honors ParseStopMemoryBudget -- it just
+	// attempts the candidate route first instead of skipping it by source
+	// length. See attemptAdmissionCandidateFullParse's doc comment for the
+	// gap this retained-footprint gauge still has against cumulative
+	// ephemeral allocation, not just retained footprint.
 	//
 	// Preserve callback fidelity: the compact route does not emit the parser's
 	// logger, GLR-trace, ambiguity-profile, or parse-progress events, so decline
@@ -279,16 +283,31 @@ func (p *Parser) pinToProductionRoute() {
 // every input at or above parseRuntimeMemoryMinSourceBytes on production. A
 // large input now attempts the candidate route like any other: the scheduler's
 // stop-control poll (tranche B8, pollStopControl in
-// parsercore_phase0_driver.go) compares the compact core's own deterministic
-// StorageBytes() against the same soft budget production's arena/scratch
-// accounting honors, and the runner releases the compact core's storage
-// (Core.Reset, either through RunFreshSchedulerSession's automatic rollback on
-// a stop-control trip or through executeSchedulerOpen's explicit reset on an
-// acceptance decline) before returning control to this function, so a decline
-// never leaves compact storage retained while production's fallback parse
-// runs. A pathological input that exceeds the budget or a hard node/stack cap
-// declines here (an engine decline, counted below) and production serves it,
-// honoring ParseStopMemoryBudget exactly as it always has.
+// parsercore_phase0_driver.go) compares the compact core's own real retained
+// footprint (Core.FootprintBytes(), a capacity-based gauge -- see its doc
+// comment for the accounting it covers and the ephemeral-allocation gap it
+// still has) against the same soft budget production's arena/scratch
+// accounting honors, and the caller's own production/hard-ceiling backstop
+// (parseMemoryHardCeilingBytes) stays armed even when the soft budget is
+// disabled. On any decline -- a stop-control trip, an acceptance-gate
+// decline, or a materialization decline -- the runner releases the compact
+// core's retained capacity (Core.ResetReleasingRetention, not plain Reset:
+// Reset alone truncates logical length but keeps backing-array capacity for
+// reuse, which billed 157-193MB of retained memory to every later parse on
+// the same cached runner before this gate) before returning control to this
+// function, so a decline does not leave compact storage retained at an
+// unbounded multiple of the configured budget while production's fallback
+// parse runs. This bounds RETAINED footprint deterministically; it does not
+// bound the compact scheduler's own CUMULATIVE ephemeral allocation during
+// the declined attempt itself, which a GC-disabled measurement (unlike an
+// ordinary, GC-enabled process) can still observe as a multiple of the
+// configured budget above production's own contract -- see
+// stopControlFootprintChurnRatio's doc comment for the measured range and
+// why it is not fully closed. A pathological input that exceeds the budget
+// or a hard node/stack cap declines here (an engine decline, counted below,
+// which also bumps AdmissionCandidateCounters' fallback count -- an
+// operator watching that counter sees every one of these) and production
+// serves it, honoring ParseStopMemoryBudget exactly as it always has.
 func (p *Parser) attemptAdmissionCandidateFullParse(source []byte, oldTree *Tree, usingProductionDFA bool) (*Tree, bool) {
 	if !p.admissionCandidateFullParseEligible(oldTree, usingProductionDFA) {
 		return nil, false

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -96,6 +96,26 @@ func (p *Parser) acquireAdmissionCandidateRunner() (*parserCoreFreshFullRunner, 
 	return runner, nil
 }
 
+// admissionCandidateCompactStorageBytes reports p's cached admission-candidate
+// runner's current compact-core storage (internal/parsercorephase0.Core.
+// StorageBytes()), or 0 when no runner is cached yet. It exists for
+// regression tests proving the tranche B9 storage-release gate: a declined
+// parse must not leave compact storage retained while the caller's
+// production fallback runs. Every decline path resets the compact core
+// before returning (parsercore_phase0_fresh_full_runner.go and
+// internal/parsercorephase0.Core.RunFreshSchedulerSession), so this reads 0
+// immediately after any decline, matching the pre-parse baseline.
+func admissionCandidateCompactStorageBytes(p *Parser) uint64 {
+	if p == nil {
+		return 0
+	}
+	runner, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	if !ok || runner == nil || runner.compact == nil {
+		return 0
+	}
+	return runner.compact.StorageBytes()
+}
+
 // tryCompactFullParseRoute attempts the compact candidate route for a fresh
 // full parse. It returns (tree, true, "") on success and (nil, false, reason)
 // on any decline, so the caller falls back to production.

--- a/admission_switch_candidate.go
+++ b/admission_switch_candidate.go
@@ -98,13 +98,13 @@ func (p *Parser) acquireAdmissionCandidateRunner() (*parserCoreFreshFullRunner, 
 
 // admissionCandidateCompactStorageBytes reports p's cached admission-candidate
 // runner's current compact-core storage (internal/parsercorephase0.Core.
-// StorageBytes()), or 0 when no runner is cached yet. It exists for
-// regression tests proving the tranche B9 storage-release gate: a declined
-// parse must not leave compact storage retained while the caller's
-// production fallback runs. Every decline path resets the compact core
-// before returning (parsercore_phase0_fresh_full_runner.go and
-// internal/parsercorephase0.Core.RunFreshSchedulerSession), so this reads 0
-// immediately after any decline, matching the pre-parse baseline.
+// StorageBytes()), or 0 when no runner is cached yet.
+//
+// StorageBytes reads 0 after ANY Reset, released or not: it counts live
+// length, and Reset always truncates length to zero even when it leaves
+// capacity retained. It cannot by itself distinguish "genuinely released"
+// from "reset but still holding a large backing array" -- use
+// admissionCandidateCompactFootprintBytes for that (tranche B9 gate).
 func admissionCandidateCompactStorageBytes(p *Parser) uint64 {
 	if p == nil {
 		return 0
@@ -114,6 +114,26 @@ func admissionCandidateCompactStorageBytes(p *Parser) uint64 {
 		return 0
 	}
 	return runner.compact.StorageBytes()
+}
+
+// admissionCandidateCompactFootprintBytes reports p's cached
+// admission-candidate runner's current compact-core retained-memory
+// footprint (internal/parsercorephase0.Core.FootprintBytes()), or 0 when no
+// runner is cached yet. Unlike admissionCandidateCompactStorageBytes, this
+// reads real retained CAPACITY, so it can actually detect whether a decline
+// path released its retained arenas or merely truncated their logical
+// length (tranche B9 storage-release gate). It exists for regression tests
+// proving that gate: a declined parse must not leave compact storage
+// retained while the caller's production fallback runs.
+func admissionCandidateCompactFootprintBytes(p *Parser) uint64 {
+	if p == nil {
+		return 0
+	}
+	runner, ok := p.admissionCandidateRunner.(*parserCoreFreshFullRunner)
+	if !ok || runner == nil || runner.compact == nil {
+		return 0
+	}
+	return runner.compact.FootprintBytes()
 }
 
 // tryCompactFullParseRoute attempts the compact candidate route for a fresh

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -2,7 +2,27 @@
 
 package gotreesitter
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
+
+// requireCandidateRouteBudgetMB arms GOT_PARSE_MEMORY_BUDGET_MB at mb for the
+// duration of the calling test (t.Setenv restores the ambient value
+// automatically), so a prior test's environment change or the process
+// environment can never silently leave a routing test under-budgeted. mb
+// must be comfortably above what the scheduler's stop-control poll needs to
+// see this fixture through to acceptance (Core.FootprintBytes() against the
+// configured budget, tranche B9 honest-accounting gate) -- grammargen_lr
+// specifically measured routing at 48 MB and declining at 32 MB on the
+// development host, so callers here use several times that for real
+// headroom against host and grammar drift.
+func requireCandidateRouteBudgetMB(t testing.TB, mb int) {
+	t.Helper()
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", strconv.Itoa(mb))
+	ResetParseEnvConfigCacheForTests()
+	t.Cleanup(ResetParseEnvConfigCacheForTests)
+}
 
 // These tests run under the gts_parsercorephase0 tag, where the compact
 // candidate route is compiled in. They prove the switch actually routes a fresh
@@ -26,6 +46,7 @@ func newAdmissionCandidateGoParser(t testing.TB) *Parser {
 // every canonical fixture now routes on size alone. Large-input safety comes
 // from the tranche B8 scheduler stop-control poll instead.
 func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
+	requireCandidateRouteBudgetMB(t, 256)
 	resetAdmissionCandidateCounters()
 	p := newAdmissionCandidateGoParser(t)
 	p.SetAdmissionCandidateRoute(true)
@@ -59,6 +80,7 @@ func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 // floor); today source length no longer decides eligibility, so the shipped
 // default routes it exactly like any other fixture.
 func TestAdmissionSwitchGrammargenLRRoutesCompactByDefault(t *testing.T) {
+	requireCandidateRouteBudgetMB(t, 256)
 	previousDefault := AdmissionCandidateRouteDefault()
 	t.Cleanup(func() { SetAdmissionCandidateRouteDefault(previousDefault) })
 	SetAdmissionCandidateRouteDefault(true)

--- a/admission_switch_candidate_test.go
+++ b/admission_switch_candidate_test.go
@@ -20,7 +20,11 @@ func newAdmissionCandidateGoParser(t testing.TB) *Parser {
 }
 
 // TestAdmissionSwitchParseRoutesCandidateWhenOn proves Parse serves the compact
-// candidate route for every canonical fixture when the switch is on.
+// candidate route for every canonical fixture when the switch is on,
+// including grammargen_lr (235,626 bytes): tranche B9 removed the
+// source-length eligibility decline that used to keep it on production, so
+// every canonical fixture now routes on size alone. Large-input safety comes
+// from the tranche B8 scheduler stop-control poll instead.
 func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 	resetAdmissionCandidateCounters()
 	p := newAdmissionCandidateGoParser(t)
@@ -33,24 +37,9 @@ func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 			t.Fatalf("%s: parse: %v", row.id, err)
 		}
 		routed1, fb1 := AdmissionCandidateCounters()
-		if len(fixture.Source) >= parseRuntimeMemoryMinSourceBytes {
-			// The memory-budget size gate declines any input at or above the floor
-			// where the production route arms the automatic memory budget (the
-			// compact scheduler cannot poll it). A large fixture (grammargen_lr)
-			// stays on production: no route, no fallback, no compact tree.
-			if routed1 != routed0 || fb1 != fb0 {
-				t.Fatalf("%s: large fixture (%d bytes >= %d floor) must be size-declined, not routed: routed %d->%d fallback %d->%d",
-					row.id, len(fixture.Source), parseRuntimeMemoryMinSourceBytes, routed0, routed1, fb0, fb1)
-			}
-			if tree.compactMaterialized {
-				t.Fatalf("%s: size-declined fixture produced a compact-materialized tree", row.id)
-			}
-			tree.Release()
-			continue
-		}
 		if routed1 != routed0+1 || fb1 != fb0 {
-			t.Fatalf("%s: expected one candidate route, got routed %d->%d fallback %d->%d (last=%q)",
-				row.id, routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
+			t.Fatalf("%s (%d bytes): expected one candidate route, got routed %d->%d fallback %d->%d (last=%q)",
+				row.id, len(fixture.Source), routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
 		}
 		if !tree.compactMaterialized {
 			t.Fatalf("%s: routed tree is not compact-materialized", row.id)
@@ -59,6 +48,44 @@ func TestAdmissionSwitchParseRoutesCandidateWhenOn(t *testing.T) {
 			requireCompactIncrementalStateProof(t, tree)
 		}
 		tree.Release()
+	}
+}
+
+// TestAdmissionSwitchGrammargenLRRoutesCompactByDefault proves grammargen_lr
+// (235,626 bytes) routes through the compact candidate on the shipped API: no
+// per-Parser SetAdmissionCandidateRoute pin, no diagnostic build flag, just
+// the process-wide default the campaign shipped ON. Before tranche B9 this
+// fixture was permanently ineligible (it sits above the retired 64 KiB size
+// floor); today source length no longer decides eligibility, so the shipped
+// default routes it exactly like any other fixture.
+func TestAdmissionSwitchGrammargenLRRoutesCompactByDefault(t *testing.T) {
+	previousDefault := AdmissionCandidateRouteDefault()
+	t.Cleanup(func() { SetAdmissionCandidateRouteDefault(previousDefault) })
+	SetAdmissionCandidateRouteDefault(true)
+	resetAdmissionCandidateCounters()
+
+	p := newAdmissionCandidateGoParser(t) // no SetAdmissionCandidateRoute call: follows the process default
+	fixture := loadDiagnosticParserCoreCanonicalFixture(t, "grammargen_lr")
+	if len(fixture.Source) < 64*1024 {
+		t.Fatalf("grammargen_lr fixture is %d bytes, want it to exceed the retired 64 KiB floor", len(fixture.Source))
+	}
+	routed0, fb0 := AdmissionCandidateCounters()
+	tree, err := p.Parse(fixture.Source)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer tree.Release()
+	routed1, fb1 := AdmissionCandidateCounters()
+	if routed1 != routed0+1 || fb1 != fb0 {
+		t.Fatalf("grammargen_lr (%d bytes) did not route on the shipped default: routed %d->%d fallback %d->%d (last=%q)",
+			len(fixture.Source), routed0, routed1, fb0, fb1, AdmissionCandidateLastFallbackReason())
+	}
+	if !tree.compactMaterialized {
+		t.Fatal("grammargen_lr routed tree is not compact-materialized")
+	}
+	digest := requireDiagnosticParserCoreCanonicalTreeDigest(t, tree, p.language)
+	if digest != fixture.DeepTreeSHA256 {
+		t.Fatalf("grammargen_lr shipped-route digest=%s want=%s", digest, fixture.DeepTreeSHA256)
 	}
 }
 
@@ -90,11 +117,11 @@ func TestAdmissionSwitchParseProductionWhenOff(t *testing.T) {
 // deep-tree digest on all four canonical fixtures.
 //
 // It drives the candidate tree through the engine seam (tryCompactFullParseRoute)
-// rather than the public Parse route, so it proves engine fidelity on every
-// fixture independent of the admission routing size gate. That gate declines
-// fixtures at or above parseRuntimeMemoryMinSourceBytes (grammargen_lr) from the
-// public Parse route to preserve the memory-budget contract; their engine
-// byte-exactness is still proven here.
+// rather than the public Parse route, independent of routing: the engine
+// byte-exactness this proves holds regardless of which admission path a
+// caller takes to reach it. TestAdmissionSwitchParseRoutesCandidateWhenOn
+// separately proves the public Parse route reaches this same engine for every
+// canonical fixture, grammargen_lr included (tranche B9).
 func TestAdmissionSwitchCandidateDigestMatchesProduction(t *testing.T) {
 	lang, err := authenticatedParserCoreGoLanguage(parserCoreWarmGoScanner)
 	if err != nil {

--- a/admission_switch_stop_control_test.go
+++ b/admission_switch_stop_control_test.go
@@ -175,11 +175,11 @@ func TestAdmissionSwitchCompactCancellationStopReceiptMatchesProduction(t *testi
 }
 
 // TestAdmissionSwitchCompactMemoryBudgetStopReceiptMatchesProduction proves
-// the memory-budget class: a source under the admission wall, combined with
-// a tiny GOT_PARSE_MEMORY_BUDGET_MB, trips the scheduler's deterministic
-// StorageBytes-vs-budget poll -- the same configured budget production's own
-// arena/scratch accounting honors -- and both engines report
-// ParseStopMemoryBudget for the identical input.
+// the memory-budget class: this modest, deliberately small witness (see the
+// package doc comment above), combined with a tiny GOT_PARSE_MEMORY_BUDGET_MB,
+// trips the scheduler's deterministic FootprintBytes-vs-budget poll -- the
+// same configured budget production's own arena/scratch accounting honors --
+// and both engines report ParseStopMemoryBudget for the identical input.
 func TestAdmissionSwitchCompactMemoryBudgetStopReceiptMatchesProduction(t *testing.T) {
 	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
 	gts.ResetParseEnvConfigCacheForTests()
@@ -236,9 +236,10 @@ func TestAdmissionSwitchCompactMemoryBudgetStopReceiptMatchesProduction(t *testi
 
 // TestAdmissionSwitchCompactMemoryBudgetPollIsDeterministic is the direct
 // determinism gate (tranche B8 work order item 4): the memory-budget half of
-// pollStopControl compares Core.StorageBytes(), six already-tracked slice
-// lengths, against a fixed byte budget -- pure integer arithmetic with no
-// wall-clock or GC-timing input. Same input and same budget must trip the
+// pollStopControl compares Core.FootprintBytes(), already-tracked slice and
+// map length/capacity reads (tranche B9 honest-accounting gate), against a
+// fixed byte budget -- pure integer arithmetic with no wall-clock or
+// GC-timing input. Same input and same budget must trip the
 // scheduler's poll at the same internal juncture on every attempt, unlike
 // production's own hard ceiling (runtime.MemStats-based, explicitly
 // documented as non-deterministic in parser_memory_budget_runtime.go). This

--- a/admission_switch_stop_control_test.go
+++ b/admission_switch_stop_control_test.go
@@ -13,18 +13,18 @@ import (
 )
 
 // Tranche B8 gate: for each stop-control class (memory budget, timeout,
-// cancellation), an admission-eligible input under the 64 KiB wall that
-// trips the class produces a stop receipt from the candidate route (routed
-// through the scheduler's new pollStopControl, parsercore_phase0_driver.go)
-// that matches what production itself reports for the identical input and
-// configuration: the same ParseStopReason, ParseStoppedEarly() true, and a
-// tree with no out-of-range partial state. Every witness stays under
-// ParseRuntimeMemoryMinSourceBytesForTest so B9's wall (out of scope here)
-// is never the reason for the fallback instead.
+// cancellation), an admission-eligible input that trips the class produces a
+// stop receipt from the candidate route (routed through the scheduler's
+// pollStopControl, parsercore_phase0_driver.go) that matches what production
+// itself reports for the identical input and configuration: the same
+// ParseStopReason, ParseStoppedEarly() true, and a tree with no out-of-range
+// partial state. Every witness here stays modest in size deliberately, not
+// because a size boundary still gates eligibility (tranche B9 removed it):
+// these tests isolate the stop-control mechanism itself, so keeping the
+// witnesses small keeps them fast without changing what they prove.
 
 // stopControlWitnessGoSource returns a small, valid Go source with `lines`
-// statements, small enough to stay under the admission wall for any
-// reasonable line count used by these tests.
+// statements.
 func stopControlWitnessGoSource(lines int) []byte {
 	var buf bytes.Buffer
 	buf.WriteString("package p\n\nfunc f() {\n")
@@ -35,10 +35,16 @@ func stopControlWitnessGoSource(lines int) []byte {
 	return buf.Bytes()
 }
 
+// requireStopControlWitnessUnderWall keeps these deliberately modest witnesses
+// well clear of ParseRuntimeMemoryMinSourceBytesForTest, the source-length
+// floor where production's own runtime-heap watchdog additionally arms
+// (parser_memory_budget_runtime.go). That floor no longer gates compact-route
+// eligibility (tranche B9); staying under it here is only about keeping these
+// witnesses small and fast, not about avoiding an eligibility decline.
 func requireStopControlWitnessUnderWall(t *testing.T, source []byte) {
 	t.Helper()
 	if wall := gts.ParseRuntimeMemoryMinSourceBytesForTest(); len(source) >= wall {
-		t.Fatalf("witness source is %d bytes, want < %d (B9's admission wall is out of scope for tranche B8)", len(source), wall)
+		t.Fatalf("witness source is %d bytes, want < %d (keep these stop-control witnesses modest and fast)", len(source), wall)
 	}
 }
 

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -12,3 +12,10 @@ package gotreesitter
 func (p *Parser) tryCompactFullParseRoute(_ []byte) (*Tree, bool, string) {
 	return nil, false, "compact candidate route compiled out (built with -tags gts_no_parsercorephase0)"
 }
+
+// admissionCandidateCompactStorageBytes is the emergency-build stub: the
+// compact engine is compiled out, so no cached runner and no compact storage
+// ever exist.
+func admissionCandidateCompactStorageBytes(_ *Parser) uint64 {
+	return 0
+}

--- a/admission_switch_stub.go
+++ b/admission_switch_stub.go
@@ -19,3 +19,9 @@ func (p *Parser) tryCompactFullParseRoute(_ []byte) (*Tree, bool, string) {
 func admissionCandidateCompactStorageBytes(_ *Parser) uint64 {
 	return 0
 }
+
+// admissionCandidateCompactFootprintBytes is the emergency-build stub,
+// matching admissionCandidateCompactStorageBytes above.
+func admissionCandidateCompactFootprintBytes(_ *Parser) uint64 {
+	return 0
+}

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -415,18 +415,22 @@ func TestAdmissionSwitchDeclinesWhenLoggerAttached(t *testing.T) {
 	}
 }
 
-// TestAdmissionCandidateMemoryBudgetContractPreserved proves the Phase-3 size
-// gate keeps the automatic large-input memory budget contract intact even with
-// the candidate route on by default.
+// TestAdmissionCandidateMemoryBudgetContractPreserved proves the automatic
+// large-input memory budget contract survives tranche B9's removal of the
+// source-length eligibility decline.
 //
-// The compact scheduler does not poll the automatic memory budget, so the
-// switch declines every input at or above the source-length floor where the
-// production route arms that budget (parseRuntimeMemoryMinSourceBytes, 64 KiB).
-// Such inputs stay on production and honor ParseStopMemoryBudget. Inputs below
-// the floor, where no budget arms on either route, still route freely.
+// Before tranche B9, the switch declined every input at or above
+// parseRuntimeMemoryMinSourceBytes (64 KiB) outright: the compact scheduler
+// never attempted them, so it never needed to poll the budget itself. Tranche
+// B9 removed that decline; a large input now attempts the candidate route
+// like any other. The tranche B8 scheduler stop-control poll is what keeps
+// the contract intact: it compares the compact core's own deterministic
+// StorageBytes() against the same soft budget production's arena/scratch
+// accounting honors, declines (falls back to production) when the budget is
+// exceeded, and releases the compact core's storage before returning -- so a
+// pathological large input still stops at the configured budget and still
+// reports ParseStopMemoryBudget, just via a different mechanism than before.
 func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
-	// Pin the gate to the single source of truth rather than copy the 64 KiB
-	// literal (parseRuntimeMemoryMinSourceBytes, parser_memory_budget_runtime.go).
 	minBudgetSourceBytes := gts.ParseRuntimeMemoryMinSourceBytesForTest()
 
 	restore := gts.AdmissionCandidateRouteDefault()
@@ -435,7 +439,7 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 
 	lang := grammars.GoLanguage()
 
-	// Positive control: a small clean source below the floor routes.
+	// Positive control: a small clean source routes.
 	small := []byte(grammars.ParseSmokeSample("go"))
 	if len(small) == 0 || len(small) >= minBudgetSourceBytes {
 		t.Skipf("go smoke sample unsuitable for the control (%d bytes)", len(small))
@@ -447,21 +451,22 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		t.Fatalf("small parse: %v", err)
 	}
 	smallTree.Release()
+	compiledOut := false
 	if routed, _ := gts.AdmissionCandidateCounters(); routed == 0 {
 		// In the emergency opt-out build (-tags gts_no_parsercorephase0) the
 		// compact engine is compiled out, so every eligible parse fails closed and
-		// the routed counter cannot move. The size-gate contract this test proves
-		// (budget-eligible inputs stay on production) still holds, so skip the
-		// positive control rather than fail. The stub records the "compiled out"
-		// fallback reason (admission_switch_stub.go).
+		// the routed counter cannot move. The budget contract this test proves
+		// still holds trivially (every parse stays on production), so record that
+		// and skip the routing-specific assertions below rather than fail.
 		if reason := gts.AdmissionCandidateLastFallbackReason(); strings.Contains(reason, "compiled out") {
-			t.Skip("compact candidate route compiled out (-tags gts_no_parsercorephase0); the routed counter cannot move")
+			compiledOut = true
+		} else {
+			t.Fatalf("small clean source did not route to the candidate; routed=%d", routed)
 		}
-		t.Fatalf("small clean source below the floor did not route to the candidate; routed=%d", routed)
 	}
 
-	// A clean source at or above the floor must NOT route: the size gate keeps
-	// it on production even with the switch on.
+	// A clean source well above the former 64 KiB floor now routes too: no
+	// eligibility decline stops it by length alone (tranche B9).
 	var big bytes.Buffer
 	big.WriteString("package p\n\nfunc f() {\n")
 	for big.Len() < minBudgetSourceBytes+(1<<15) {
@@ -478,59 +483,23 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		t.Fatalf("large parse: %v", err)
 	}
 	bigTree.Release()
-	if routed, _ := gts.AdmissionCandidateCounters(); routed != 0 {
-		t.Fatalf("source of %d bytes (>= %d floor) routed to the candidate; the memory-budget size gate did not decline it (routed=%d)",
-			big.Len(), minBudgetSourceBytes, routed)
+	if routed, fallback := gts.AdmissionCandidateCounters(); !compiledOut && (routed != 1 || fallback != 0) {
+		t.Fatalf("source of %d bytes (>= %d former floor) did not route cleanly to the candidate: routed=%d fallback=%d reason=%q",
+			big.Len(), minBudgetSourceBytes, routed, fallback, gts.AdmissionCandidateLastFallbackReason())
 	}
 
-	// Exact-boundary cases pin the gate's strict comparison
-	// (admissionCandidateInputSizeEligible: sourceLen < floor): floor-1 is
-	// eligible and admits, the floor byte is not eligible and declines.
-	for _, bc := range []struct {
-		name       string
-		length     int
-		wantRouted bool
-	}{
-		{"floor_minus_one", minBudgetSourceBytes - 1, true},
-		{"floor_exact", minBudgetSourceBytes, false},
-	} {
-		src := cleanGoSourceOfExactLength(t, bc.length)
-		if len(src) != bc.length {
-			t.Fatalf("%s: built %d bytes, want exactly %d", bc.name, len(src), bc.length)
-		}
-		gts.ResetAdmissionCandidateCountersForTest()
-		boundaryParser := gts.NewParser(lang)
-		boundaryTree, parseErr := boundaryParser.Parse(src)
-		if parseErr != nil {
-			t.Fatalf("%s parse: %v", bc.name, parseErr)
-		}
-		boundaryTree.Release()
-		routed, _ := gts.AdmissionCandidateCounters()
-		if bc.wantRouted {
-			if routed == 0 {
-				// The size gate admitted the input (it is below the floor). Whether the
-				// compact engine then accepts it is a separate concern; in the emergency
-				// opt-out build it is always declined. Only a size-gate failure is a bug.
-				if reason := gts.AdmissionCandidateLastFallbackReason(); strings.Contains(reason, "compiled out") {
-					continue
-				}
-				t.Fatalf("%s (%d bytes, below the %d floor) did not route; the size gate must admit it (routed=%d, reason=%q)",
-					bc.name, bc.length, minBudgetSourceBytes, routed, gts.AdmissionCandidateLastFallbackReason())
-			}
-			continue
-		}
-		if routed != 0 {
-			t.Fatalf("%s (%d bytes, at the %d floor) routed; the size gate must decline it (routed=%d)",
-				bc.name, bc.length, minBudgetSourceBytes, routed)
-		}
-	}
-
-	// With a low budget, a pathological large source on production honors
-	// ParseStopMemoryBudget -- the exact contract the size gate preserves by
-	// routing every budget-eligible input to production.
+	// With a low budget, a pathological large source still stops at
+	// ParseStopMemoryBudget: the candidate route attempts it, the scheduler's
+	// storage-based stop-control poll trips before completion (an engine
+	// decline, not a never-attempted eligibility decline), and production
+	// serves the fallback honoring the identical configured budget. The
+	// decline must also release the compact core's storage before returning,
+	// so production's fallback never runs alongside retained compact storage
+	// (tranche B9 storage-release gate).
 	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", "1")
 	gts.ResetParseEnvConfigCacheForTests()
 	defer gts.ResetParseEnvConfigCacheForTests()
+	gts.DrainArenaPools()
 
 	var huge bytes.Buffer
 	huge.WriteString("package p\nfunc f() {\n")
@@ -545,33 +514,16 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 		t.Fatalf("huge parse: %v", err)
 	}
 	defer hugeTree.Release()
-	if routed, _ := gts.AdmissionCandidateCounters(); routed != 0 {
-		t.Fatalf("budgeted large source routed to the candidate; routed=%d", routed)
-	}
 	if got := hugeTree.ParseStopReason(); got != gts.ParseStopMemoryBudget {
-		t.Fatalf("ParseStopReason() = %q, want %q (production must honor the budget the candidate cannot poll)",
+		t.Fatalf("ParseStopReason() = %q, want %q (production must serve the fallback and honor the budget)",
 			got, gts.ParseStopMemoryBudget)
 	}
-}
-
-// cleanGoSourceOfExactLength builds a valid Go source of exactly n bytes. It
-// pads the remainder inside a mid-source block comment (trivia the parser
-// skips) and ends with a clean statement, so the source parses cleanly at any
-// exact byte length at or above the minimum without a trailing-trivia EOF edge.
-func cleanGoSourceOfExactLength(t *testing.T, n int) []byte {
-	t.Helper()
-	const prefix = "package p\n/*"   // opens the padding block comment
-	const suffix = "*/\nvar x = 1\n" // closes it, then a clean statement
-	if n < len(prefix)+len(suffix) {
-		t.Fatalf("exact length %d is below the %d-byte minimum valid program", n, len(prefix)+len(suffix))
+	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || (!compiledOut && fallback != 1) {
+		t.Fatalf("budgeted huge source: routed=%d fallback=%d (want routed=0, fallback=1 unless compiled out)", routed, fallback)
 	}
-	src := make([]byte, n)
-	copy(src, prefix)
-	for i := len(prefix); i < n-len(suffix); i++ {
-		src[i] = ' '
+	if got := gts.AdmissionCandidateCompactStorageBytesForTest(hugeParser); got != 0 {
+		t.Fatalf("compact storage retained after the memory-budget decline: %d bytes (want 0, released before production's fallback ran)", got)
 	}
-	copy(src[n-len(suffix):], suffix)
-	return src
 }
 
 // TestAdmissionCandidateGoTypeConversionFailsClosed proves the compact candidate

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -521,9 +521,125 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 0 || (!compiledOut && fallback != 1) {
 		t.Fatalf("budgeted huge source: routed=%d fallback=%d (want routed=0, fallback=1 unless compiled out)", routed, fallback)
 	}
-	if got := gts.AdmissionCandidateCompactStorageBytesForTest(hugeParser); got != 0 {
-		t.Fatalf("compact storage retained after the memory-budget decline: %d bytes (want 0, released before production's fallback ran)", got)
+	// StorageBytes reads 0 after any Reset regardless of retained capacity
+	// (it counts live length, not backing-array size), so it cannot detect a
+	// decline that reset length but left a large arena retained -- assert
+	// FootprintBytes instead, which reads real capacity. requireCompactFootprintReleased
+	// bounds it well under the pre-fix retained level (157-193MB measured for
+	// this decline class before the retention-cap gate existed).
+	requireCompactFootprintReleased(t, hugeParser, "stop-control memory-budget decline")
+}
+
+// compactFootprintReleasedCapBytes bounds a "genuinely released" reading in
+// the tests below. It intentionally sits above internal/parsercorephase0's
+// own coreRetentionCapBytes (48 MiB): these tests assert the OUTCOME
+// (retention stays in the same order of magnitude as production's own
+// steady-state ~12-15MB, not the 157-193MB measured before the tranche B9
+// retention-cap gate), not the exact internal threshold, so the two can
+// evolve independently without coupling this test to that constant's value.
+const compactFootprintReleasedCapBytes = 64 << 20 // 64 MiB
+
+// requireCompactFootprintReleased asserts p's cached admission-candidate
+// runner's compact-core FootprintBytes (real retained capacity, not live
+// length) stays well under the pre-fix retained level after a decline,
+// proving the tranche B9 storage-release gate for the class of decline
+// label names.
+func requireCompactFootprintReleased(t *testing.T, p *gts.Parser, label string) {
+	t.Helper()
+	if got := gts.AdmissionCandidateCompactFootprintBytesForTest(p); got > compactFootprintReleasedCapBytes {
+		t.Fatalf("%s: compact footprint retained after decline: %d bytes (want <= %d, released before production's fallback ran)",
+			label, got, compactFootprintReleasedCapBytes)
 	}
+}
+
+// TestAdmissionCandidateStorageReleasedOnAcceptanceGateDecline drives the
+// acceptance-gate decline class specifically -- a different release path
+// from TestAdmissionCandidateMemoryBudgetContractPreserved's stop-control
+// class above. Here the compact scheduler run itself completes without a Go
+// error (it never reaches an accepted EOF frontier, so
+// RunFreshSchedulerSession commits rather than resets), and the runner's own
+// strict sole-exact-EOF acceptance gate declines afterward
+// (requireParserCoreFreshFullAcceptance, parsercore_phase0_fresh_full_runner.go).
+// Before the tranche B9 reset-completeness gate, this specific path retained
+// whatever the scheduler run had allocated until the next parse call on the
+// same runner reset it lazily.
+//
+// The Go generic-instantiation/type-conversion ambiguity
+// (TestAdmissionCandidateGoTypeConversionFailsClosed's witness) triggers
+// this class naturally: the compact scheduler forks on the conflict but
+// cannot rank the two arms by dynamic precedence, so it never reaches an
+// accepted EOF frontier at all ("did not accept EOF") rather than hitting a
+// hard scheduler error mid-run.
+func TestAdmissionCandidateStorageReleasedOnAcceptanceGateDecline(t *testing.T) {
+	src := "package p\n\n" +
+		"type Foo[T any] struct {\n\tV T\n}\n\n" +
+		"func f() {\n" +
+		"\ta := Foo[int]{}\n" +
+		"\tb := Foo[int](a)\n" +
+		"\t_ = a\n" +
+		"\t_ = b\n" +
+		"}\n"
+	lang := grammars.GoLanguage()
+	parser := gts.NewParser(lang)
+	tree, ok, reason := gts.TryCompactFullParseRouteForTest(parser, []byte(src))
+	if ok || tree != nil {
+		t.Fatalf("candidate engine accepted instead of declining at the acceptance gate (reason=%q); "+
+			"re-verify TestAdmissionCandidateGoTypeConversionFailsClosed's witness still forks this conflict", reason)
+	}
+	if !strings.Contains(reason, "did not accept EOF") {
+		t.Fatalf("decline reason = %q, want the acceptance-gate \"did not accept EOF\" class "+
+			"(a different decline no longer exercises this path; this test needs a new acceptance-gate witness)", reason)
+	}
+	requireCompactFootprintReleased(t, parser, "acceptance-gate decline")
+}
+
+// TestAdmissionCandidateStorageReleasedOnMaterializationDecline drives the
+// materialization-decline class specifically: the scheduler accepts a clean
+// EOF frontier (the full accepted derivation graph is now committed to the
+// compact core), and then a stop-control check inside materialization
+// itself (parser.resultMaterializationStopReason, parsercore_phase0_driver.go
+// -- not the scheduler's own dispatch-loop poll) trips. Before the tranche
+// B9 reset-completeness gate, this path released nothing at all: the core
+// held the entire accepted parse graph -- the largest possible retention
+// for a given witness, since acceptance is a precondition for reaching
+// materialization at all -- while production's fallback ran beside it.
+//
+// A timeout in the microsecond band where the scheduler itself has already
+// accepted but materialization has not yet finished reliably reproduces
+// this: too short and the scheduler's own dispatch-loop poll trips first (a
+// different, already-covered path); too long and materialization finishes
+// before the poll fires at all. The band below is measured against this
+// witness on the development host; like every other timeout-banded test in
+// this file it may need retuning against a materially different host.
+func TestAdmissionCandidateStorageReleasedOnMaterializationDecline(t *testing.T) {
+	lang := grammars.GoLanguage()
+	var src bytes.Buffer
+	src.WriteString("package p\n\nfunc f() {\n")
+	for i := 0; i < 20000; i++ {
+		src.WriteString("\t_ = 1\n")
+	}
+	src.WriteString("}\n")
+
+	const loBandMicros, hiBandMicros, stepMicros = 170_000, 260_000, 10_000
+	var lastReason string
+	for us := loBandMicros; us <= hiBandMicros; us += stepMicros {
+		gts.DrainArenaPools()
+		parser := gts.NewParser(lang)
+		parser.SetTimeoutMicros(uint64(us))
+		tree, err := parser.Parse(src.Bytes())
+		if err != nil {
+			t.Fatalf("timeout=%dus: Parse() error = %v", us, err)
+		}
+		lastReason = gts.AdmissionCandidateLastFallbackReason()
+		tree.Release()
+		if strings.Contains(lastReason, "materialization stopped") {
+			requireCompactFootprintReleased(t, parser, "materialization decline")
+			return
+		}
+	}
+	t.Fatalf("no timeout in [%d, %d]us band reproduced a materialization decline; last reason=%q "+
+		"(the band may need retuning against the current witness or host)",
+		loBandMicros, hiBandMicros, lastReason)
 }
 
 // TestAdmissionCandidateGoTypeConversionFailsClosed proves the compact candidate

--- a/admission_switch_test.go
+++ b/admission_switch_test.go
@@ -537,6 +537,18 @@ func TestAdmissionCandidateMemoryBudgetContractPreserved(t *testing.T) {
 // steady-state ~12-15MB, not the 157-193MB measured before the tranche B9
 // retention-cap gate), not the exact internal threshold, so the two can
 // evolve independently without coupling this test to that constant's value.
+//
+// Only one of the three requireCompactFootprintReleased call sites below is
+// load-bearing against a deleted release call. Measured on the development
+// host with release disabled: the stop-control decline's witness peaks
+// around 1 MiB, and the acceptance-gate decline's witness peaks under
+// 0.1 MiB -- both already well under this cap whether or not release runs,
+// so their own assertions pass either way and prove only the OUTPUT (a
+// small footprint), not that release produced it. The
+// materialization-decline witness peaks around 77 MiB un-released, so it
+// is the one call site here that actually fails when the release call is
+// removed. Keep that witness large enough to clear this cap if it is ever
+// resized.
 const compactFootprintReleasedCapBytes = 64 << 20 // 64 MiB
 
 // requireCompactFootprintReleased asserts p's cached admission-candidate
@@ -604,26 +616,40 @@ func TestAdmissionCandidateStorageReleasedOnAcceptanceGateDecline(t *testing.T) 
 // for a given witness, since acceptance is a precondition for reaching
 // materialization at all -- while production's fallback ran beside it.
 //
+// The witness is a ~315KB clean Go source (45,000 "_ = 1" statements), well
+// past this file's other two decline witnesses: its accepted derivation
+// graph's un-released FootprintBytes measures around 77 MiB on the
+// development host, clearing compactFootprintReleasedCapBytes (64 MiB). This
+// makes the requireCompactFootprintReleased call below load-bearing -- see
+// that constant's doc comment -- unlike the stop-control and acceptance-gate
+// witnesses, which stay under the cap whether or not release runs.
+//
 // A timeout in the microsecond band where the scheduler itself has already
 // accepted but materialization has not yet finished reliably reproduces
 // this: too short and the scheduler's own dispatch-loop poll trips first (a
-// different, already-covered path); too long and materialization finishes
-// before the poll fires at all. The band below is measured against this
-// witness on the development host; like every other timeout-banded test in
-// this file it may need retuning against a materially different host.
+// different, already-covered path, "scheduler stop-control tripped"); too
+// long and materialization finishes before the poll fires at all (a
+// successful route, not a decline). The band below is measured against this
+// witness on the development host and swept coarsely, resetting the
+// counters each attempt so a stale reason from an earlier iteration or an
+// earlier test cannot be misread as this iteration's outcome, to absorb
+// scheduling jitter; like every other timeout-banded test in this file it
+// may need retuning against a materially different host, so an unreproduced
+// band skips rather than fails.
 func TestAdmissionCandidateStorageReleasedOnMaterializationDecline(t *testing.T) {
 	lang := grammars.GoLanguage()
 	var src bytes.Buffer
 	src.WriteString("package p\n\nfunc f() {\n")
-	for i := 0; i < 20000; i++ {
+	for i := 0; i < 45000; i++ {
 		src.WriteString("\t_ = 1\n")
 	}
 	src.WriteString("}\n")
 
-	const loBandMicros, hiBandMicros, stepMicros = 170_000, 260_000, 10_000
+	const loBandMicros, hiBandMicros, stepMicros = 250_000, 600_000, 10_000
 	var lastReason string
 	for us := loBandMicros; us <= hiBandMicros; us += stepMicros {
 		gts.DrainArenaPools()
+		gts.ResetAdmissionCandidateCountersForTest()
 		parser := gts.NewParser(lang)
 		parser.SetTimeoutMicros(uint64(us))
 		tree, err := parser.Parse(src.Bytes())
@@ -632,12 +658,12 @@ func TestAdmissionCandidateStorageReleasedOnMaterializationDecline(t *testing.T)
 		}
 		lastReason = gts.AdmissionCandidateLastFallbackReason()
 		tree.Release()
-		if strings.Contains(lastReason, "materialization stopped") {
+		if strings.Contains(lastReason, "accepted-tree materialization stopped: timeout") {
 			requireCompactFootprintReleased(t, parser, "materialization decline")
 			return
 		}
 	}
-	t.Fatalf("no timeout in [%d, %d]us band reproduced a materialization decline; last reason=%q "+
+	t.Skipf("no timeout in [%d, %d]us band reproduced a materialization-band timeout decline on this host; last reason=%q "+
 		"(the band may need retuning against the current witness or host)",
 		loBandMicros, hiBandMicros, lastReason)
 }

--- a/benchmark_real_go_test.go
+++ b/benchmark_real_go_test.go
@@ -104,13 +104,15 @@ func benchmarkWarmRealGoDFA(b *testing.B, fixture benchfixtures.LoadedFixture, l
 	// above: this benchmark reports and asserts on GLR-only runtime counters
 	// (max_stacks, peak_depth, nodes/op below), which the compact candidate
 	// route never populates. Phase-3 admission defaults the candidate route
-	// on, and every one of this benchmark's fixtures sits under the compact
-	// eligibility ceiling, so an unpinned parser here silently measures the
-	// compact route on both sides of an A/B comparison instead of production
-	// (b4b-width-repair audit, 2026-08; oak-b's v9 decomposition first
-	// caught this reproducing unmodified on origin/main). The guard
-	// assertion after the timed loop below fails loudly if this pin is ever
-	// lost again, instead of silently re-conflating the two routes.
+	// on, and every one of this benchmark's fixtures is DFA-eligible, so an
+	// unpinned parser here silently measures the compact route on both sides
+	// of an A/B comparison instead of production (b4b-width-repair audit,
+	// 2026-08; oak-b's v9 decomposition first caught this reproducing
+	// unmodified on origin/main). Tranche B9 removed the source-length
+	// eligibility ceiling that used to additionally exempt the largest
+	// fixture from this risk; every fixture now needs this explicit pin. The
+	// guard assertion after the timed loop below fails loudly if this pin is
+	// ever lost again, instead of silently re-conflating the two routes.
 	parser.SetAdmissionCandidateRoute(false)
 	warmTree, err := parser.Parse(fixture.Source)
 	if err != nil {

--- a/cgo_harness/attribution/classify.go
+++ b/cgo_harness/attribution/classify.go
@@ -457,7 +457,6 @@ func buildFunctionOverride() []functionOverrideEntry {
 		"Parser).tryCompactFullParseRoute",
 		"Parser).attemptAdmissionCandidateFullParse",
 		"Parser).admissionCandidateFullParseEligible",
-		"admissionCandidateInputSizeEligible",
 		"Parser).acquireAdmissionCandidateRunner",
 		"newAdmissionCandidateRunner",
 		"Parser).hasActiveParseObservability",

--- a/cgo_harness/attribution/main.go
+++ b/cgo_harness/attribution/main.go
@@ -157,7 +157,7 @@ func run() error {
 		}
 
 		// ---- Measurement phase: one final pass. ----
-		fmt.Println("attribution: [measure] capturing CPU profiles (diagnostic lane x4, shipped route x3)")
+		fmt.Println("attribution: [measure] capturing CPU profiles (diagnostic lane x4, shipped route x4)")
 		captureManifest, err = runCapture(cfg, captureBin)
 		if err != nil {
 			return fmt.Errorf("run capture: %w", err)

--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -670,7 +670,7 @@ diagnostic-lane number into a shipped-route claim or vice versa.
 Generated 2026-08-02T11:02:14Z. Host: shared WSL2 development host,
 background load uncontrolled -- the same local-development floor as every
 prior receipt in this document, not a quiet-host or enclave measurement.
-Git identity: `6fab988d30d42d931d42625eaa0cfa167d4877b` (the tranche's
+Git identity: `6fab988d30d42d931d42625eaa0cfa167d4877ba` (the tranche's
 merge-base commit; the wall-removal change is a working-tree diff on top of
 it at capture time, so the tool's `git rev-parse HEAD` names the base, not a
 B9-specific commit). This run's raw JSON output was not committed, matching
@@ -693,13 +693,18 @@ reproduce it.
 `grammargen_lr` has a shipped-route row for the first time. The public
 `Parser.Parse` route, with no per-Parser pin and no diagnostic flag, admitted
 it at 140.751ms against the diagnostic lane's 126.493ms for the same
-fixture -- an 11.3% shipped-route overhead. That overhead matches the
-compat-tail and admission-switch bookkeeping the shipped route pays and the
-diagnostic runner does not (`normalizeReturnedTreeForParse`,
+fixture -- a wall-time gap of 11.3% (not to be confused with the unrelated
+111.3 coverage % figure in that same table row above; coverage % is
+profiled-CPU-time over wall-time, see "Attribution shares" earlier in this
+document). Read this 11.3% gap against the noise floor below before treating
+it as a finding. A same-shape gap would be consistent with the compat-tail
+and admission-switch bookkeeping the shipped route pays and the diagnostic
+runner does not (`normalizeReturnedTreeForParse`,
 `resolveCRecoverySwallowedError`, `maybeCompactReturnedFullTree`, plus
-`Parser.Parse`'s own dispatch); it is not a new cost class, and `compat-tail`
-still reads 0.0% because this run's four fixtures stay clean (no error
-nodes, no C-recovery-swallowed error to resolve). Every shipped-route sample
+`Parser.Parse`'s own dispatch); `compat-tail` itself still reads 0.0% because
+this run's four fixtures stay clean (no error nodes, no C-recovery-swallowed
+error to resolve), so any such cost here is admission-switch dispatch
+overhead, not compat-tail's own conditional work. Every shipped-route sample
 was verified, by the admission-candidate routed/fallback counters, to have
 actually taken the compact route rather than falling back to production.
 
@@ -713,11 +718,12 @@ actually taken the compact route rather than falling back to production.
 | `rewrite` | 10 | 2.458ms | 378.273us | 15.39% |
 
 This run's noise floor is wide (15.4%-42.4% of median), consistent with a
-busy shared host (other agents were active throughout this session). Read
-the 11.3% shipped-route/diagnostic-lane gap on `grammargen_lr` above against
-this floor: it sits below the `query_compile` and `language` floors and
-above `rewrite`'s, so treat it as directional, not a precise constant, until
-a quieter run confirms it.
+busy shared host (other agents were active throughout this session). The
+11.3% shipped-route/diagnostic-lane gap on `grammargen_lr` above sits BELOW
+every one of these four floors, including `grammargen_lr`'s own (22.47%) and
+`rewrite`'s (the narrowest, at 15.39%). This run's noise cannot resolve that
+gap from zero: it is not a finding, directional or otherwise, until a
+quieter run repeats the measurement with a floor tighter than 11.3%.
 
 #### Cost per event (diagnostic lane; average, not causal)
 

--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -670,9 +670,9 @@ diagnostic-lane number into a shipped-route claim or vice versa.
 Generated 2026-08-02T11:02:14Z. Host: shared WSL2 development host,
 background load uncontrolled -- the same local-development floor as every
 prior receipt in this document, not a quiet-host or enclave measurement.
-Git identity: `6fab988d30d42d931d42625eaa0cfa167d4877ba` (the tranche's
-merge-base commit; the wall-removal change is a working-tree diff on top of
-it at capture time, so the tool's `git rev-parse HEAD` names the base, not a
+Git identity: `6fab988d30d42d931d42625eaa0cfa167d4877ba` (the capture-time
+base commit; the wall-removal change is a working-tree diff on top of it at
+capture time, so the tool's `git rev-parse HEAD` names the base, not a
 B9-specific commit). This run's raw JSON output was not committed, matching
 the existing `harness_out/` git-ignore rule; rerun the documented command to
 reproduce it.

--- a/docs/perf-attribution.md
+++ b/docs/perf-attribution.md
@@ -29,11 +29,13 @@ document is that receipt's home. The attached tool
 ## Scope
 
 The receipt covers the compact parser core's fresh, non-incremental full
-parse: the default route for eligible full parses below the 64 KiB compact
-admission floor (`parseRuntimeMemoryMinSourceBytes`,
-`admission_switch.go`), and the diagnostic runner path
-(`parserCoreFreshFullRunner`) that exercises the same scheduler and
-materialization code above that floor.
+parse: the default route for eligible full parses (`admission_switch.go`),
+and the diagnostic runner path (`parserCoreFreshFullRunner`) that exercises
+the same scheduler and materialization code directly. Campaign v7 tranche B9
+retired the compact admission switch's 64 KiB source-length eligibility
+decline; the shipped route now attempts every eligible full parse regardless
+of size, with a scheduler stop-control poll (tranche B8) bounding a large or
+pathological input instead.
 
 It does not cover: incremental reparse, error recovery, retry passes, the
 production (non-compact) GLR engine, or any language other than the four
@@ -54,15 +56,18 @@ The four canonical fixtures are SHA-256-pinned in
 `cgo_harness/pure_c/run_canonical_go_full_parse.sh` and
 `diagnosticParserCoreCanonicalAdmissions` authenticate them:
 
-| Fixture | Bytes | Below 64 KiB floor |
-|---|---:|---|
-| `rewrite.go` | 5,116 | yes |
-| `query_compile.go` | 20,168 | yes |
-| `language.go` | 41,387 | yes |
-| `grammargen/lr.go` | 235,626 | no |
+| Fixture | Bytes |
+|---|---:|
+| `rewrite.go` | 5,116 |
+| `query_compile.go` | 20,168 |
+| `language.go` | 41,387 |
+| `grammargen/lr.go` | 235,626 |
 
-`grammargen/lr.go` never takes the shipped `Parser.Parse` route: it is
-diagnostic-lane only. The other three fixtures run through both lanes.
+Before tranche B9, `grammargen/lr.go` sat above the compact admission
+switch's 64 KiB source-length eligibility floor and never took the shipped
+`Parser.Parse` route (diagnostic-lane only; see the first receipt below,
+which predates B9). B9 retired that floor, so all four fixtures now run
+through both lanes; see the B9 addendum.
 
 ## Two lanes, one methodology
 
@@ -75,9 +80,11 @@ identical, already-committed lifecycle; the tool never adds new parser calls.
   `gts_parsercorephase0`). Runs for all four fixtures.
 - **Shipped route.** `Parser.Parse` and `Tree.Release` — the exact timed
   region of `BenchmarkDiagnosticParserCoreWarmProductionParseQueryCompile`,
-  generalized to all three fixtures under the 64 KiB floor. Every sample is
-  verified, by the admission-candidate routed/fallback counters, to have
-  actually taken the compact route rather than falling back to production.
+  generalized to all four fixtures (tranche B9 retired the 64 KiB eligibility
+  floor that used to keep `grammargen/lr.go` diagnostic-lane only). Every
+  sample is verified, by the admission-candidate routed/fallback counters, to
+  have actually taken the compact route rather than falling back to
+  production.
 
 The tool labels every row with its lane so a reader never mixes shipped-route
 public-API overhead into the diagnostic lane's scheduler-only numbers, or
@@ -647,6 +654,89 @@ reasonable reading of a different implicit boundary that this receipt now
 makes explicit. From this tranche forward, campaign v7 should cite the
 eight-component table above — with its stated boundary and disambiguation
 rule — instead of any of the three legacy percentages.
+
+### B9 addendum: the wall-removal receipt
+
+Campaign v7 tranche B9 removed the compact admission switch's 64 KiB
+source-length eligibility decline (`admission_switch.go`). The shipped route
+now attempts every eligible full parse regardless of size; a scheduler
+stop-control poll (tranche B8) bounds a large or pathological input instead
+of a size wall. This addendum re-runs the documented command with
+`grammargen_lr` added to the shipped-route lane (diagnostic-lane only in
+every receipt above) and reports what changed. Per doctrine 10 (board
+honesty), every row below still names its lane; nothing here merges a
+diagnostic-lane number into a shipped-route claim or vice versa.
+
+Generated 2026-08-02T11:02:14Z. Host: shared WSL2 development host,
+background load uncontrolled -- the same local-development floor as every
+prior receipt in this document, not a quiet-host or enclave measurement.
+Git identity: `6fab988d30d42d931d42625eaa0cfa167d4877b` (the tranche's
+merge-base commit; the wall-removal change is a working-tree diff on top of
+it at capture time, so the tool's `git rev-parse HEAD` names the base, not a
+B9-specific commit). This run's raw JSON output was not committed, matching
+the existing `harness_out/` git-ignore rule; rerun the documented command to
+reproduce it.
+
+#### Attribution shares (regenerated; shipped route now covers all four fixtures)
+
+| lane | fixture | wall ns/op | coverage % | scheduler-dispatch | elections | reductions-and-pops | canonicalization | lexing | materialization | compat-tail | recovery | other |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| diagnostic lane | rewrite | 2.381ms | 110.9 | 23.6 | 6.7 | 22.5 | 11.2 | 11.2 | 23.6 | 0.0 | 0.0 | 1.1 |
+| diagnostic lane | query_compile | 11.548ms | 110.1 | 21.3 | 6.7 | 28.1 | 11.2 | 14.6 | 18.0 | 0.0 | 0.0 | 0.0 |
+| diagnostic lane | language | 12.156ms | 109.7 | 26.1 | 2.3 | 28.4 | 12.5 | 15.9 | 13.6 | 0.0 | 0.0 | 1.1 |
+| diagnostic lane | grammargen_lr | 126.493ms | 110.7 | 27.6 | 5.1 | 23.5 | 12.2 | 12.2 | 17.3 | 0.0 | 0.0 | 2.0 |
+| shipped route | rewrite | 2.480ms | 109.9 | 15.9 | 3.4 | 30.7 | 12.5 | 21.6 | 15.9 | 0.0 | 0.0 | 0.0 |
+| shipped route | query_compile | 11.661ms | 110.6 | 15.7 | 4.5 | 30.3 | 15.7 | 13.5 | 20.2 | 0.0 | 0.0 | 0.0 |
+| shipped route | language | 12.782ms | 110.5 | 16.9 | 4.5 | 30.3 | 9.0 | 18.0 | 20.2 | 0.0 | 0.0 | 1.1 |
+| **shipped route** | **grammargen_lr** | **140.751ms** | 111.3 | 11.7 | 10.6 | 29.8 | 8.5 | 19.1 | 20.2 | 0.0 | 0.0 | 0.0 |
+
+`grammargen_lr` has a shipped-route row for the first time. The public
+`Parser.Parse` route, with no per-Parser pin and no diagnostic flag, admitted
+it at 140.751ms against the diagnostic lane's 126.493ms for the same
+fixture -- an 11.3% shipped-route overhead. That overhead matches the
+compat-tail and admission-switch bookkeeping the shipped route pays and the
+diagnostic runner does not (`normalizeReturnedTreeForParse`,
+`resolveCRecoverySwallowedError`, `maybeCompactReturnedFullTree`, plus
+`Parser.Parse`'s own dispatch); it is not a new cost class, and `compat-tail`
+still reads 0.0% because this run's four fixtures stay clean (no error
+nodes, no C-recovery-swallowed error to resolve). Every shipped-route sample
+was verified, by the admission-candidate routed/fallback counters, to have
+actually taken the compact route rather than falling back to production.
+
+#### Noise floor (this run, interleaved A/A, 10 pairs per fixture)
+
+| fixture | pairs | median ns/op | p95 \|delta\| | p95 \|delta\| as % of median |
+|---|---:|---:|---:|---:|
+| `grammargen_lr` | 10 | 120.831ms | 27.151ms | 22.47% |
+| `language` | 10 | 12.164ms | 2.994ms | 24.61% |
+| `query_compile` | 10 | 11.770ms | 4.986ms | 42.36% |
+| `rewrite` | 10 | 2.458ms | 378.273us | 15.39% |
+
+This run's noise floor is wide (15.4%-42.4% of median), consistent with a
+busy shared host (other agents were active throughout this session). Read
+the 11.3% shipped-route/diagnostic-lane gap on `grammargen_lr` above against
+this floor: it sits below the `query_compile` and `language` floors and
+above `rewrite`'s, so treat it as directional, not a precise constant, until
+a quieter run confirms it.
+
+#### Cost per event (diagnostic lane; average, not causal)
+
+| fixture | wall ns/op | ns/shift | ns/reduction | ns/pop path | ns/pop payload | ns/canonicalization | ns/election |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `rewrite` | 2.381ms | 1766 | 1583 | 1446 | 795 | 973 | 2298 |
+| `query_compile` | 11.548ms | 1728 | 1538 | 1424 | 784 | 934 | 2253 |
+| `language` | 12.156ms | 1867 | 1607 | 1451 | 769 | 987 | 2403 |
+| `grammargen_lr` | 126.493ms | 1913 | 1658 | 1512 | 833 | 1036 | 2534 |
+
+Every per-event reading sits within this document's established noise
+floors from prior receipts. The wall-removal change moved routing, not the
+compact engine's per-event cost.
+
+This is a local, one-run, noisy-host receipt, not a sealed epoch. It does
+not replace or invalidate the first receipt or its addenda above (all
+measured before tranche B9 landed, correctly showing `grammargen_lr`
+diagnostic-lane only at that time); it extends the same methodology to the
+newly shipped-route-eligible fixture.
 
 ## Caveats
 

--- a/export_test.go
+++ b/export_test.go
@@ -323,14 +323,27 @@ func TryCompactFullParseRouteForTest(p *Parser, source []byte) (tree *Tree, ok b
 }
 
 // AdmissionCandidateCompactStorageBytesForTest exposes the cached
-// admission-candidate runner's current compact-core StorageBytes() so
-// external test code can prove the tranche B9 storage-release gate: a
-// declined parse must not leave compact storage retained while the caller's
-// production fallback runs. It returns 0 when no runner is cached yet
-// (including under -tags gts_no_parsercorephase0, where the engine never
-// runs).
+// admission-candidate runner's current compact-core StorageBytes(): live
+// record length only, always 0 immediately after any Reset regardless of
+// retained capacity. It returns 0 when no runner is cached yet (including
+// under -tags gts_no_parsercorephase0, where the engine never runs). Use
+// AdmissionCandidateCompactFootprintBytesForTest to check the tranche B9
+// storage-RELEASE gate specifically; this one alone cannot.
 func AdmissionCandidateCompactStorageBytesForTest(p *Parser) uint64 {
 	return admissionCandidateCompactStorageBytes(p)
+}
+
+// AdmissionCandidateCompactFootprintBytesForTest exposes the cached
+// admission-candidate runner's current compact-core FootprintBytes(): real
+// retained capacity, not live length. External test code uses this to prove
+// the tranche B9 storage-release gate -- a declined parse must not leave
+// compact storage retained while the caller's production fallback runs --
+// because unlike StorageBytes, this can actually detect a decline path that
+// reset logical length but left a large backing array retained. It returns
+// 0 when no runner is cached yet (including under -tags
+// gts_no_parsercorephase0).
+func AdmissionCandidateCompactFootprintBytesForTest(p *Parser) uint64 {
+	return admissionCandidateCompactFootprintBytes(p)
 }
 
 // BeginParseOperationBudgetForTest opens the same outer parse-budget scope

--- a/export_test.go
+++ b/export_test.go
@@ -300,23 +300,37 @@ func AdmissionCandidateEnvEnabledForTest() bool {
 	return admissionCandidateEnvEnabled()
 }
 
-// ParseRuntimeMemoryMinSourceBytesForTest exposes the source-length floor where
-// the production route arms the automatic memory budget, so the external test
-// package can pin the admission size gate to the single source of truth
-// (parseRuntimeMemoryMinSourceBytes) instead of copying the 64 KiB literal.
+// ParseRuntimeMemoryMinSourceBytesForTest exposes the source-length floor
+// where the production route arms its own automatic runtime memory budget
+// (parser_memory_budget_runtime.go), so the external test package can pin
+// production-budget tests to the single source of truth instead of copying
+// the 64 KiB literal. Tranche B9 retired this floor's former second use as
+// the compact-route admission size gate; it no longer bounds candidate-route
+// eligibility, only when production's own runtime-heap watchdog arms.
 func ParseRuntimeMemoryMinSourceBytesForTest() int {
 	return parseRuntimeMemoryMinSourceBytes
 }
 
 // TryCompactFullParseRouteForTest exposes the admission-candidate engine seam
-// directly (bypassing eligibility and the size gate) so external test code
-// can drive the compact route's own accept-or-decline outcome, including its
-// decline detail string, without going through the public Parse route. Both
-// build configurations define tryCompactFullParseRoute (the real engine
-// under the default build, a fail-closed stub under -tags
+// directly (bypassing the public Parser.Parse eligibility checks) so external
+// test code can drive the compact route's own accept-or-decline outcome,
+// including its decline detail string, without going through the public
+// Parse route. Both build configurations define tryCompactFullParseRoute (the
+// real engine under the default build, a fail-closed stub under -tags
 // gts_no_parsercorephase0), so this resolves in either build.
 func TryCompactFullParseRouteForTest(p *Parser, source []byte) (tree *Tree, ok bool, reason string) {
 	return p.tryCompactFullParseRoute(source)
+}
+
+// AdmissionCandidateCompactStorageBytesForTest exposes the cached
+// admission-candidate runner's current compact-core StorageBytes() so
+// external test code can prove the tranche B9 storage-release gate: a
+// declined parse must not leave compact storage retained while the caller's
+// production fallback runs. It returns 0 when no runner is cached yet
+// (including under -tags gts_no_parsercorephase0, where the engine never
+// runs).
+func AdmissionCandidateCompactStorageBytesForTest(p *Parser) uint64 {
+	return admissionCandidateCompactStorageBytes(p)
 }
 
 // BeginParseOperationBudgetForTest opens the same outer parse-budget scope

--- a/fuzz_admission_route_equality_test.go
+++ b/fuzz_admission_route_equality_test.go
@@ -43,20 +43,30 @@ type admissionRouteEqualityLanguage struct {
 	production *gts.Parser
 }
 
-// routeEqualityFuzzMaxInputBytes bounds every fuzz input, well below the 64
-// KiB compact admission wall. This is a latency safety cap, not a
-// correctness one: the language-selector byte mutates independently of the
-// content byte, so the mutator can and does pair a large seed (e.g. a
-// canonical Go fixture) with an unrelated curated language. Measured
-// directly (production-forced parses of real Go source, mis-parsed as each
-// curated language): swift and erlang stay under 50ms through 16,000 bytes
-// but climb past 3s by 32,000 and past 7s by 65,000 -- a shape consistent
-// with GLR multi-stack growth on ambiguous, wrong-grammar token streams, not
-// a hang. Below this cap every curated language stayed under 60ms on the
-// same probe. A go-test-fuzz worker that runs a multi-second input risks
-// Go's own hang detector killing it, which reports as a spurious failure
-// unrelated to route equality. 4096 is a full order of magnitude below the
-// measured slow region.
+// routeEqualityFuzzMaxInputBytes bounds every fuzz input. This is a latency
+// safety cap, unrelated to the compact admission switch's former 64 KiB
+// source-length eligibility floor (tranche B9 retired that floor entirely;
+// this cap would exist unchanged even if it never had): the
+// language-selector byte mutates independently of the content byte, so the
+// mutator can and does pair a large seed (e.g. a canonical Go fixture) with
+// an unrelated curated language. Measured directly (production-forced
+// parses of real Go source, mis-parsed as each curated language): swift and
+// erlang stay under 50ms through 16,000 bytes but climb past 3s by 32,000
+// and past 7s by 65,000 -- a shape consistent with GLR multi-stack growth on
+// ambiguous, wrong-grammar token streams, not a hang. Below this cap every
+// curated language stayed under 60ms on the same probe. A go-test-fuzz
+// worker that runs a multi-second input risks Go's own hang detector
+// killing it, which reports as a spurious failure unrelated to route
+// equality. 4096 is a full order of magnitude below the measured slow
+// region.
+//
+// This cap is not raised as part of retiring the admission wall: doing so
+// would need a fresh mis-parsed-mismatched-grammar latency measurement at
+// the new ceiling for every curated language, which is out of this
+// tranche's scope. Generative (fuzzed, size-varying) route-equality
+// coverage for large inputs specifically is deferred; the tranche's own
+// large-file witness table (see its PR) is the non-generative, targeted
+// evidence for large-input route equality instead.
 const routeEqualityFuzzMaxInputBytes = 4096
 
 // FuzzAdmissionRouteEquality is the campaign v7 tranche B2 standing
@@ -194,10 +204,11 @@ func FuzzAdmissionRouteEquality(f *testing.F) {
 
 // seedAdmissionRouteEqualityCorpus commits the B2 seed corpus: the 20-witness
 // B0/B1 adjudication manifest (minus the two documented open swift
-// residuals), the four canonical Go BENCH.md fixtures (trimmed below the
-// compact size wall when needed), one smoke snippet per curated language,
-// and an empty-source edge case. languages supplies the language-selector
-// byte for each language name.
+// residuals), the four canonical Go BENCH.md fixtures (trimmed below
+// routeEqualityFuzzMaxInputBytes, the fuzzer's own latency cap, when
+// needed), one smoke snippet per curated language, and an empty-source edge
+// case. languages supplies the language-selector byte for each language
+// name.
 func seedAdmissionRouteEqualityCorpus(f *testing.F, languages []admissionRouteEqualityLanguage) {
 	f.Helper()
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1177,7 +1177,7 @@ func (c *Core) RunFreshSchedulerSession(fn func(SchedulerTransactionToken) error
 		recovered := recover()
 		if recovered != nil {
 			frame.clearInactive()
-			_ = c.Reset()
+			_ = c.ResetReleasingRetention()
 			panic(recovered)
 		}
 		if err == nil && frame.poisoned != nil {
@@ -1185,7 +1185,14 @@ func (c *Core) RunFreshSchedulerSession(fn func(SchedulerTransactionToken) error
 		}
 		frame.clearInactive()
 		if err != nil {
-			if resetErr := c.Reset(); resetErr != nil {
+			// ResetReleasingRetention, not plain Reset: a declined session
+			// leaves no future value in whatever capacity this run grew, and
+			// this is the automatic reset every stop-control trip and every
+			// mid-run hard decline (recovery, extra-chain, cap hits, and
+			// friends) already goes through, so it is also the natural place
+			// to release retention on the class of decline this covers
+			// (tranche B9 retention-cap gate).
+			if resetErr := c.ResetReleasingRetention(); resetErr != nil {
 				err = errors.Join(err, fmt.Errorf("parser-core phase zero: reset failed after fresh scheduler error: %w", resetErr))
 			}
 		}
@@ -1414,6 +1421,24 @@ func (c *Core) Reset() error {
 	c.externalTokenScannerStart = 0
 	c.externalTokenScannerEnd = 0
 	c.externalTokenScannerExact = false
+	return nil
+}
+
+// ResetReleasingRetention performs the same truncation as Reset, then drops
+// any growable family's backing array whose combined FootprintBytes exceeds
+// coreRetentionCapBytes (releaseOversizedRetention). Reset alone preserves
+// capacity for legitimate reuse across repeated large-file parses -- the
+// routine "clear the slate before the next attempt" call every fresh parse
+// makes through the admission-candidate runner. This variant is for decline
+// paths specifically: a just-declined attempt's retained capacity has no
+// future value, and keeping it would otherwise stay billed to every later
+// unrelated parse on the same cached runner regardless of that parse's own
+// size (tranche B9 retention-cap gate).
+func (c *Core) ResetReleasingRetention() error {
+	if err := c.Reset(); err != nil {
+		return err
+	}
+	c.releaseOversizedRetention()
 	return nil
 }
 

--- a/internal/parsercorephase0/core.go
+++ b/internal/parsercorephase0/core.go
@@ -1,8 +1,10 @@
 // Package parsercorephase0 contains the admitted compact parser core.
 //
-// The root package routes every fresh full parse of a source under 64 KiB
-// through this engine by default. The admission switch in
-// admission_switch.go controls this routing.
+// The root package routes every eligible fresh full parse through this
+// engine by default, regardless of source size. The admission switch in
+// admission_switch.go controls this routing; a scheduler stop-control poll
+// (memory budget, deadline, cancellation) bounds a large input instead of a
+// source-length eligibility decline.
 //
 // The engine consumes a dependency-neutral TableView. It does not own a
 // lexer, an external-scanner election, recovery, retries, or included

--- a/internal/parsercorephase0/storage_bytes.go
+++ b/internal/parsercorephase0/storage_bytes.go
@@ -21,14 +21,26 @@ var (
 // traversal, no I/O -- so it is safe to call from a tight scheduler poll
 // (spec.campaign.v7 tranche B8).
 //
-// The estimate is a lower bound on process RSS attributable to this core (it
-// omits per-parse scratch, the boundary index, and checkpoint interning), but
-// it grows monotonically with exactly the counters every mutating Core
+// StorageBytes is a documented LOWER BOUND, not a footprint gauge: it counts
+// LENGTH (live records), not CAPACITY (allocated backing-array bytes, which
+// amortized growth keeps ahead of length and Reset never shrinks), and it
+// omits per-parse scratch, the boundary index, and checkpoint interning
+// entirely. A caller that needs a real containment gauge -- one a memory-stop
+// poll can actually trust to bound RSS -- must use FootprintBytes instead
+// (tranche B9 storage-release/honest-accounting gate: StorageBytes alone let
+// a declined parse's own scheduler run overshoot its configured budget by
+// more than 11x before the poll noticed, because len()-only accounting is
+// blind to retained capacity and to every structure named above). Keeping
+// StorageBytes's own meaning unchanged here matters: some callers may still
+// want the cheap, non-allocating, purely-length-based reading it always gave
+// (for example a caller correlating record counts with Work counters), and
+// changing its definition out from under them would be its own silent
+// contract break.
+//
+// It grows monotonically with exactly the counters every mutating Core
 // operation already increments, so it is reproducible for a given input and
 // Limits: same input, same Limits, same StorageBytes trajectory, on every
-// run. Callers that need a budget compatible with the production engine's
-// own soft arena/scratch budget (parseMemoryBudgetForParser in the root
-// package) compare this value against that same threshold.
+// run.
 func (c *Core) StorageBytes() uint64 {
 	if c == nil {
 		return 0
@@ -39,4 +51,239 @@ func (c *Core) StorageBytes() uint64 {
 		uint64(len(c.children))*coreChildRecordBytes +
 		uint64(len(c.fields))*coreFieldRecordBytes +
 		uint64(len(c.aliases))*coreAliasRecordBytes
+}
+
+// Byte footprints for the additional families FootprintBytes covers that
+// StorageBytes does not: the lineage/checkpoint/provenance side records, the
+// checkpoint interner, the boundary index, and the two dominant per-parse
+// scratch buffers (pop-path enumeration and reduction-output batching).
+var (
+	coreNodeLineageRecordBytes    = uint64(unsafe.Sizeof(nodeLineageRecord{}))
+	coreCheckpointIDBytes         = uint64(unsafe.Sizeof(CheckpointID(0)))
+	coreExternalProvenanceBytes   = uint64(unsafe.Sizeof(externalPayloadProvenance{}))
+	coreCheckpointRecordBytes     = uint64(unsafe.Sizeof(checkpointRecord{}))
+	coreCheckpointBucketBytes     = uint64(unsafe.Sizeof([32]byte{})) + uint64(unsafe.Sizeof(CheckpointID(0)))
+	coreBoundarySlotBytes         = uint64(unsafe.Sizeof(boundarySlot{}))
+	coreBoundaryMutationBytes     = uint64(unsafe.Sizeof(boundaryMutation{}))
+	coreNodeLineageMutationBytes  = uint64(unsafe.Sizeof(nodeLineageMutation{}))
+	coreUint32Bytes               = uint64(unsafe.Sizeof(uint32(0)))
+	coreCondenseCandidateBytes    = uint64(unsafe.Sizeof(CondenseCandidate{}))
+	coreUint64Bytes               = uint64(unsafe.Sizeof(uint64(0)))
+	coreNodeIDBytes               = uint64(unsafe.Sizeof(NodeID(0)))
+	coreHeadBytes                 = uint64(unsafe.Sizeof(Head{}))
+	coreLinkRecordSliceBytes      = uint64(unsafe.Sizeof([]linkRecord(nil)))
+	coreSubtreeIDBytes            = uint64(unsafe.Sizeof(SubtreeID(0)))
+	coreInt64Bytes                = uint64(unsafe.Sizeof(int64(0)))
+	coreForkOrderBytes            = uint64(unsafe.Sizeof(ForkOrder{}))
+	corePathPayloadBytes          = uint64(unsafe.Sizeof(pathPayload{}))
+	corePopPathBytes              = uint64(unsafe.Sizeof(popPath{}))
+	coreReductionBoundaryOutBytes = uint64(unsafe.Sizeof(reductionBoundaryOutput{}))
+	coreBoundaryKeyEntryBytes     = uint64(unsafe.Sizeof(boundaryKey{})) + uint64(unsafe.Sizeof(int(0)))
+	coreUint16Bytes               = uint64(unsafe.Sizeof(uint16(0)))
+)
+
+// FootprintBytes returns a cheap, deterministic, O(1) estimate of the compact
+// core's real retained-memory footprint in bytes: every growable record and
+// scratch family's CAPACITY (not length) times that family's real struct
+// size, covering the record families StorageBytes counts plus the lineage,
+// checkpoint, and provenance side tables, the checkpoint interner, the
+// boundary index, and the pop-path/reduction-output scratch buffers. Like
+// StorageBytes it costs only already-tracked slice/map length and capacity
+// reads -- no allocation, no traversal, no I/O -- so it is safe to call from
+// a tight scheduler poll.
+//
+// This is the gauge the scheduler's stop-control memory-budget poll uses
+// (pollStopControl in the root package), because capacity, not length, is
+// what Reset leaves behind: Reset truncates every tracked slice to length
+// zero but retains its backing array for reuse, so a length-based gauge
+// reads zero immediately after Reset regardless of how much real memory a
+// declined parse's arenas still hold. FootprintBytes reads real allocated
+// bytes instead, so the poll can actually trip before a pathological input's
+// true footprint clears the configured budget, not merely before its live
+// record count would have.
+//
+// The two map-backed fields (the checkpoint interner's digest-to-ID bucket
+// map and the reduction scratch's boundary-key-to-index map) have no cap();
+// FootprintBytes estimates their footprint as len() times one bucket's
+// key+value size, an underestimate of Go's real hash-table bucket overhead
+// but a monotonic, deterministic one that never claims less than the map
+// logically holds.
+func (c *Core) FootprintBytes() uint64 {
+	if c == nil {
+		return 0
+	}
+	total := uint64(cap(c.nodes))*coreNodeRecordBytes +
+		uint64(cap(c.links))*coreLinkRecordBytes +
+		uint64(cap(c.subtrees))*coreSubtreeRecordBytes +
+		uint64(cap(c.children))*coreChildRecordBytes +
+		uint64(cap(c.fields))*coreFieldRecordBytes +
+		uint64(cap(c.aliases))*coreAliasRecordBytes
+
+	total += uint64(cap(c.nodeLineages)) * coreNodeLineageRecordBytes
+	total += uint64(cap(c.nodeCheckpoints)) * coreCheckpointIDBytes
+	total += uint64(cap(c.externalProvenance)) * coreExternalProvenanceBytes
+	total += uint64(cap(c.boundaryJournal)) * coreBoundaryMutationBytes
+	total += uint64(cap(c.nodeLineageJournal)) * coreNodeLineageMutationBytes
+	total += uint64(cap(c.alternativeSpillArena)) * coreUint32Bytes
+	total += uint64(cap(c.condenseCandidates)) * coreCondenseCandidateBytes
+	total += uint64(cap(c.transactions)) * coreUint64Bytes
+	total += uint64(cap(c.historicalNodeScratch)) * coreNodeIDBytes
+	total += uint64(cap(c.cohortHeadScratch)) * coreHeadBytes
+	total += uint64(cap(c.factorLinkScratch)) * coreLinkRecordBytes
+
+	total += c.checkpoints.footprintBytes()
+	total += c.boundaries.footprintBytes()
+	total += c.popScratch.footprintBytes()
+	total += c.reductionScratch.footprintBytes()
+	total += selectedStoreRetainedBytes(cap(c.selectedPool.records), cap(c.selectedPool.children))
+
+	return total
+}
+
+func (i *checkpointInterner) footprintBytes() uint64 {
+	if i == nil {
+		return 0
+	}
+	return uint64(cap(i.records))*coreCheckpointRecordBytes +
+		uint64(cap(i.bytes)) +
+		uint64(len(i.buckets))*coreCheckpointBucketBytes
+}
+
+func (b *boundaryIndex) footprintBytes() uint64 {
+	if b == nil {
+		return 0
+	}
+	return uint64(cap(b.slots)) * coreBoundarySlotBytes
+}
+
+// footprintBytes covers popEnumerationScratch's per-parse pop-path
+// enumeration buffers. linkFrames is a slice of slices; only the outer
+// backing array (one slice header per frame) is counted here, matching the
+// bounded, per-reduction-fanout sizing the frame pool already caps. paths
+// entries (popPath) each embed their own nested children/trailing slices,
+// which nextPath reuses by truncating rather than reallocating -- this count
+// includes each entry's own struct size (so its two nested slice headers
+// count) but not the bytes those nested backing arrays hold beyond the
+// header; dropping (nilling) paths still frees them in full, this is an
+// accounting-completeness gap, not a release gap.
+func (s *popEnumerationScratch) footprintBytes() uint64 {
+	if s == nil {
+		return 0
+	}
+	return uint64(cap(s.linkFrames))*coreLinkRecordSliceBytes +
+		uint64(cap(s.rev))*coreSubtreeIDBytes +
+		uint64(cap(s.revScores))*coreInt64Bytes +
+		uint64(cap(s.revOrders))*coreForkOrderBytes +
+		uint64(cap(s.trailing))*corePathPayloadBytes +
+		uint64(cap(s.external))*coreSubtreeIDBytes +
+		uint64(cap(s.paths))*corePopPathBytes
+}
+
+func (s *reductionOutputScratch) footprintBytes() uint64 {
+	if s == nil {
+		return 0
+	}
+	return uint64(cap(s.boundaries))*coreReductionBoundaryOutBytes +
+		uint64(len(s.boundaryByKey))*coreBoundaryKeyEntryBytes +
+		uint64(cap(s.batchParents))*coreSubtreeIDBytes +
+		uint64(cap(s.structuralPositions))*coreUint16Bytes +
+		uint64(cap(s.remappedFields))*coreFieldRecordBytes +
+		uint64(cap(s.remappedAliases))*coreAliasRecordBytes
+}
+
+// coreRetentionCapBytes bounds how much FootprintBytes capacity Reset keeps
+// pooled for reuse across parses on the same cached runner. Measured
+// steady-state retention for a clean production-route parse (a reference
+// point for "reasonable", not compact's own architecture) sits at roughly
+// 12-15MB after release; coreRetentionCapBytes sets the drop threshold at
+// noticeably above that, so ordinary variance in legitimate large-file
+// workloads does not force reallocation on every parse, while a
+// pathological input's post-decline retention (measured before this gate at
+// 157-193MB for one large declined parse, tranche B9 retention-cap finding)
+// still gets dropped rather than billed to every later unrelated parse.
+const coreRetentionCapBytes = 48 << 20 // 48 MiB
+
+// releaseOversizedRetention drops every growable family's backing array when
+// the core's total FootprintBytes retained after Reset exceeds
+// coreRetentionCapBytes, replacing each with nil so the next user
+// reallocates from a clean slate instead of reusing an oversized slab. This
+// mirrors the drop-when-alone-exceeds-budget pattern already used for the
+// production GLR GSS/entry scratch pools (glr_gss.go, glr.go): a pathological
+// parse can grow a single core's backing arrays far past ordinary steady
+// state, and pooling that growth unchanged would otherwise bill it, unshrunk,
+// to every later parse that reuses this Core regardless of language or file
+// size.
+//
+// Call this only after Reset (it assumes every tracked length is already
+// zero) and only from a decline path -- the routine "clear the slate before
+// the next attempt" reset every fresh parse performs should keep preserving
+// capacity for legitimate reuse across repeated large-file parses. Dropping
+// unconditionally on every reset would instead force full reallocation on
+// every large-fixture benchmark iteration.
+func (c *Core) releaseOversizedRetention() {
+	if c == nil || c.FootprintBytes() <= coreRetentionCapBytes {
+		return
+	}
+	c.nodes = nil
+	c.nodeLineages = nil
+	c.nodeCheckpoints = nil
+	c.links = nil
+	c.subtrees = nil
+	c.externalProvenance = nil
+	c.children = nil
+	c.fields = nil
+	c.aliases = nil
+	c.boundaryJournal = nil
+	c.nodeLineageJournal = nil
+	c.alternativeSpillArena = nil
+	c.transactions = nil
+	c.historicalNodeScratch = nil
+	c.cohortHeadScratch = nil
+	c.factorLinkScratch = nil
+	c.checkpoints.dropOversized()
+	c.boundaries.dropOversized()
+	c.popScratch.dropOversized()
+	c.reductionScratch.dropOversized()
+	c.selectedPool = selectedStoreBacking{}
+}
+
+func (i *checkpointInterner) dropOversized() {
+	if i == nil {
+		return
+	}
+	i.records = nil
+	i.bytes = nil
+	i.buckets = nil
+}
+
+func (b *boundaryIndex) dropOversized() {
+	if b == nil {
+		return
+	}
+	b.slots = nil
+}
+
+func (s *popEnumerationScratch) dropOversized() {
+	if s == nil {
+		return
+	}
+	s.linkFrames = nil
+	s.rev = nil
+	s.revScores = nil
+	s.revOrders = nil
+	s.trailing = nil
+	s.external = nil
+	s.paths = nil
+}
+
+func (s *reductionOutputScratch) dropOversized() {
+	if s == nil {
+		return
+	}
+	s.boundaries = nil
+	s.boundaryByKey = nil
+	s.batchParents = nil
+	s.structuralPositions = nil
+	s.remappedFields = nil
+	s.remappedAliases = nil
 }

--- a/parser_memory_budget_test.go
+++ b/parser_memory_budget_test.go
@@ -173,6 +173,7 @@ func TestGoParseGiantTableLiteralStopsWithinMemoryBudget(t *testing.T) {
 			heapGrowth, float64(heapGrowth)/float64(budgetBytes), maxOvershootFactor, budgetBytes, tree.ParseRuntime().Summary(),
 		)
 	}
+	t.Logf("heap growth = %d bytes (%.2fx budget %d bytes), stop=%s", heapGrowth, float64(heapGrowth)/float64(budgetBytes), budgetBytes, tree.ParseRuntime().Summary())
 }
 
 // TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound is the
@@ -198,16 +199,17 @@ func TestGoParseGiantTableLiteralStopsWithinMemoryBudget(t *testing.T) {
 // hot dispatch/election path allocates and discards per token -- a live GC
 // reclaims that continuously in normal operation, but nothing a
 // retained-footprint poll tracks can bound it, because it is never part of
-// any tracked structure. Measured on this witness: 9.01-9.56x across six
+// any tracked structure. Measured on this witness: 9.14-9.56x across six
 // runs (a real, verified improvement over the pre-honest-accounting
 // length-only gauge's 11.51x on the same witness), not inside the
-// production-only 6x contract. maxOvershootFactor sits with headroom above
-// the high end of that range and below the pre-fix figure, so this test
-// still catches a regression back to length-only accounting while tolerating
-// ordinary run-to-run variance. Closing the remaining gap to 6x is an open
-// trade-off against routing coverage (see stopControlFootprintChurnRatio's
-// doc comment, parsercore_phase0_driver.go) that this test intentionally
-// does not force by tightening this number further.
+// production-only 6x contract. maxOvershootFactor sits just above the high
+// end of that measured range and well below the pre-fix figure, so this
+// test still catches a regression back to length-only accounting while
+// tolerating ordinary run-to-run variance. Closing the remaining gap to 6x
+// is an open trade-off against routing coverage (see
+// stopControlFootprintChurnRatio's doc comment, parsercore_phase0_driver.go)
+// that this test intentionally does not force by tightening this number
+// further.
 func TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound(t *testing.T) {
 	const budgetMB = 96
 	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", strconv.Itoa(budgetMB))
@@ -256,7 +258,7 @@ func TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound(t *testing
 	}
 
 	budgetBytes := int64(budgetMB) * 1024 * 1024
-	const maxOvershootFactor = 11
+	const maxOvershootFactor = 10
 	if heapGrowth > budgetBytes*maxOvershootFactor {
 		t.Fatalf(
 			"process heap growth = %d bytes (%.2fx budget), want < %dx budget %d bytes -- regression past the tranche B9 achieved bound (runtime=%s)",

--- a/parser_memory_budget_test.go
+++ b/parser_memory_budget_test.go
@@ -173,5 +173,96 @@ func TestGoParseGiantTableLiteralStopsWithinMemoryBudget(t *testing.T) {
 			heapGrowth, float64(heapGrowth)/float64(budgetBytes), maxOvershootFactor, budgetBytes, tree.ParseRuntime().Summary(),
 		)
 	}
+}
+
+// TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound is the
+// unpinned counterpart of TestGoParseGiantTableLiteralStopsWithinMemoryBudget
+// above: the same witness, the same GC-disabled cumulative-allocation
+// measurement, with the candidate route left on its shipped default instead
+// of pinned to production. This is the end-to-end coverage the production
+// pin above deliberately removes (that test isolates production's own
+// contract; this one measures what a caller who never pins actually gets).
+//
+// The compact route attempts this witness first (tranche B9 removed the
+// former 64 KiB size floor that used to keep it production-only). Its own
+// scheduler stop-control poll compares a real, capacity-based retained-
+// footprint gauge (Core.FootprintBytes, internal/parsercorephase0) against
+// the configured budget and declines close to it (measured 103.6 MB
+// footprint against a 96 MB budget on this witness), releasing its retained
+// capacity immediately on decline. Production then serves the fallback
+// exactly as the pinned test above already proves.
+//
+// The bound this asserts is measured, not the production-only 6x contract:
+// this GC-disabled methodology counts cumulative allocation, not retained
+// footprint, so it also counts every ephemeral value the compact scheduler's
+// hot dispatch/election path allocates and discards per token -- a live GC
+// reclaims that continuously in normal operation, but nothing a
+// retained-footprint poll tracks can bound it, because it is never part of
+// any tracked structure. Measured on this witness: 9.01-9.56x across six
+// runs (a real, verified improvement over the pre-honest-accounting
+// length-only gauge's 11.51x on the same witness), not inside the
+// production-only 6x contract. maxOvershootFactor sits with headroom above
+// the high end of that range and below the pre-fix figure, so this test
+// still catches a regression back to length-only accounting while tolerating
+// ordinary run-to-run variance. Closing the remaining gap to 6x is an open
+// trade-off against routing coverage (see stopControlFootprintChurnRatio's
+// doc comment, parsercore_phase0_driver.go) that this test intentionally
+// does not force by tightening this number further.
+func TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound(t *testing.T) {
+	const budgetMB = 96
+	t.Setenv("GOT_PARSE_MEMORY_BUDGET_MB", strconv.Itoa(budgetMB))
+	gotreesitter.ResetParseEnvConfigCacheForTests()
+	defer gotreesitter.ResetParseEnvConfigCacheForTests()
+
+	var src bytes.Buffer
+	src.WriteString("package p\n\ntype kv struct {\n\tName    string\n\tVisible bool\n\tNamed   bool\n}\n\nvar t = []kv{\n")
+	const entries = 300000
+	for i := 0; i < entries; i++ {
+		fmt.Fprintf(&src, "\t{Name: %q, Visible: true, Named: true}, // %d\n", fmt.Sprintf("identifier%d", i), i)
+	}
+	src.WriteString("}\n")
+
+	debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(100)
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	routedBefore, fallbackBefore := gotreesitter.AdmissionCandidateCounters()
+	tree, err := parser.Parse(src.Bytes())
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	defer tree.Release()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	heapGrowth := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	routedAfter, fallbackAfter := gotreesitter.AdmissionCandidateCounters()
+
+	if got, want := tree.ParseStopReason(), gotreesitter.ParseStopMemoryBudget; got != want {
+		t.Fatalf("ParseStopReason() = %q, want %q (runtime=%s)", got, want, tree.ParseRuntime().Summary())
+	}
+	if !tree.ParseStoppedEarly() {
+		t.Fatal("ParseStoppedEarly() = false, want true")
+	}
+	// The candidate route must have attempted and declined this witness (not
+	// silently stayed on production by some other eligibility gate): routed
+	// stays 0 (production served the returned tree) and fallback moves by
+	// exactly 1 (one candidate-route decline).
+	if routedAfter != routedBefore || fallbackAfter != fallbackBefore+1 {
+		t.Fatalf("candidate route routing: routed %d->%d fallback %d->%d, want routed unchanged and fallback +1",
+			routedBefore, routedAfter, fallbackBefore, fallbackAfter)
+	}
+
+	budgetBytes := int64(budgetMB) * 1024 * 1024
+	const maxOvershootFactor = 11
+	if heapGrowth > budgetBytes*maxOvershootFactor {
+		t.Fatalf(
+			"process heap growth = %d bytes (%.2fx budget), want < %dx budget %d bytes -- regression past the tranche B9 achieved bound (runtime=%s)",
+			heapGrowth, float64(heapGrowth)/float64(budgetBytes), maxOvershootFactor, budgetBytes, tree.ParseRuntime().Summary(),
+		)
+	}
+	t.Logf("shipped-route heap growth = %d bytes (%.2fx budget %d bytes)", heapGrowth, float64(heapGrowth)/float64(budgetBytes), budgetBytes)
 	t.Logf("heap growth = %d bytes (%.2fx budget %d bytes), stop=%s", heapGrowth, float64(heapGrowth)/float64(budgetBytes), budgetBytes, tree.ParseRuntime().Summary())
 }

--- a/parser_memory_budget_test.go
+++ b/parser_memory_budget_test.go
@@ -135,6 +135,19 @@ func TestGoParseGiantTableLiteralStopsWithinMemoryBudget(t *testing.T) {
 	runtime.ReadMemStats(&before)
 
 	parser := gotreesitter.NewParser(grammars.GoLanguage())
+	// Pin to production: this witness's ~12.7MB source sat above the compact
+	// admission switch's former 64 KiB size floor, so before tranche B9 "bare
+	// Parse" already meant production-only here, matching the doc comment
+	// above ("bare Parse with the DFA lexer"). B9 removed that floor, so an
+	// unpinned Parse here would also attempt the compact route first: its own
+	// bounded, independent decline still contains its own heap growth, but
+	// this test measures RAW PROCESS heap growth with GC disabled, which sums
+	// across both engines' retained arena/backing-array capacity rather than
+	// isolating either one -- a different, dual-engine measurement this
+	// witness was never designed to make. The explicit pin restores the
+	// single-engine, production-only scope the RCA this test guards against
+	// actually targets.
+	parser.SetAdmissionCandidateRoute(false)
 	tree, err := parser.Parse(src.Bytes())
 	if err != nil {
 		t.Fatalf("Parse() error = %v", err)

--- a/parsercore_phase0_attribution_capture_internal_test.go
+++ b/parsercore_phase0_attribution_capture_internal_test.go
@@ -20,8 +20,9 @@ import (
 // documented command that drives it end to end.
 
 // attributionCaptureRow is one profiled sample series: either the diagnostic
-// runner path (all four canonical fixtures) or the shipped Parser.Parse route
-// (the three fixtures under the 64 KiB admission floor).
+// runner path or the shipped Parser.Parse route, each covering all four
+// canonical fixtures (tranche B9 removed the 64 KiB admission floor that used
+// to keep grammargen_lr shipped-route-ineligible).
 type attributionCaptureRow struct {
 	Label       string  `json:"label"`
 	Fixture     string  `json:"fixture"`
@@ -43,16 +44,18 @@ type attributionCaptureManifest struct {
 // endpoint. It is inert unless GTS_ATTRIBUTION_OUT names a writable directory,
 // so it never adds cost to a normal `go test` run.
 //
-// Each captured CPU profile brackets exactly one pinned lifecycle:
+// Each captured CPU profile brackets exactly one pinned lifecycle, for all
+// four canonical fixtures on both lanes (tranche B9 removed the 64 KiB
+// admission floor that used to keep grammargen_lr shipped-route-ineligible):
 //
 //   - "diagnostic lane": runner.parse, shallow completeness validation, and
 //     Tree.Release -- the same timed region BenchmarkParserCoreFreshFullCanonical
-//     measures, for all four canonical fixtures (so grammargen_lr is included).
+//     measures.
 //   - "shipped route": Parser.Parse and Tree.Release -- the timed region
-//     BenchmarkDiagnosticParserCoreWarmProductionParseQueryCompile measures, for
-//     the three fixtures under the 64 KiB compact-admission floor
-//     (parseRuntimeMemoryMinSourceBytes). grammargen_lr never takes this route
-//     (it is not eligible), so it is diagnostic-lane only.
+//     BenchmarkDiagnosticParserCoreWarmProductionParseQueryCompile measures.
+//     Every sample is verified, by the admission-candidate routed/fallback
+//     counters, to have actually taken the compact route rather than falling
+//     back to production.
 //
 // Every one-time preflight, warm pass, and digest check happens outside
 // pprof.StartCPUProfile/StopCPUProfile so the profile is not diluted by
@@ -85,9 +88,6 @@ func TestParserCoreAttributionCapture(t *testing.T) {
 	}
 	for _, row := range diagnosticParserCoreCanonicalAdmissions {
 		row := row
-		if row.bytes >= parseRuntimeMemoryMinSourceBytes {
-			continue // ineligible for the shipped route; stays production-only.
-		}
 		fixture := loadDiagnosticParserCoreCanonicalFixture(t, row.id)
 		requireDiagnosticParserCoreCanonicalFixtureIdentity(t, fixture, row)
 		rows = append(rows, captureAttributionShippedRoute(t, outDir, fixture, row, duration, minIterations))

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -84,6 +84,17 @@ type DiagnosticParserCorePrefixOptions struct {
 	// disables the memory-budget half of the poll, mirroring production's
 	// own "budget disabled" contract (parseMemoryBudget's mb<=0 case).
 	stopControlMemoryBudgetBytes int64
+	// stopControlHardCeilingBytes is production's own absolute, decoupled
+	// hard ceiling (parseMemoryHardCeilingBytes, parser_config.go),
+	// independent of the soft budget above: it stays armed even when a
+	// caller explicitly disables the soft budget (GOT_PARSE_MEMORY_BUDGET_MB=0),
+	// the same independence production's own runtime-heap watchdog keeps
+	// (runtimeMemoryHardCeilingEnabled, parser_memory_budget_runtime.go).
+	// Without this the candidate route had no backstop at all when a caller
+	// zeroed the soft budget (tranche B9 honest-accounting gate). Zero
+	// disables it, mirroring the production contract's own 0=off escape
+	// hatch.
+	stopControlHardCeilingBytes int64
 }
 
 type DiagnosticParserCoreScannerCheckpoint struct {
@@ -3134,23 +3145,88 @@ func diagnosticParserCoreStopControlTripped(reason ParseStopReason) error {
 	}
 }
 
-// stopControlMemoryBudgetReason compares the compact core's own live storage
-// accounting against the production engine's soft per-parse byte budget
-// (stopControlMemoryBudgetBytes, sourced from parseMemoryBudgetForParser so
-// the same GOT_PARSE_MEMORY_BUDGET_MB configuration governs both engines).
-// Every input is Core.StorageBytes(): six already-tracked slice lengths times
-// a compile-time-constant record size, so this is pure deterministic integer
-// arithmetic -- no wall clock, no GC-timing dependence, and (same input, same
-// budget) the same trip point on every run, unlike the runtime heap/sys
-// signal production's own hard ceiling uses (parser_memory_budget_runtime.go).
+// stopControlFootprintChurnRatio documents a measured, deliberately UNUSED
+// lever (tranche B9 honest-accounting gate). FootprintBytes gauges retained
+// structure; it is blind to per-token ephemeral allocation (temporary
+// values the dispatch/election hot path creates and discards -- boxed
+// action results, scanner-state capture buffers, and similar -- that a live
+// GC reclaims continuously in normal operation but that accumulate
+// unbounded in any measurement that holds GC off for the whole parse,
+// including the RCA-era production replica test this poll is compared
+// against). On the giant-table-literal witness, a scheduler run whose
+// tracked footprint reached 103.6 MB at decline had allocated 516.5 MB
+// cumulative by then: a ~5x ratio.
+//
+// Discounting the comparison threshold by a fixed divisor (tripping the
+// poll at budget/divisor instead of budget) was tried and reverted: at
+// divisor 2, the giant-table-literal replica still exceeded the 6x
+// cumulative-allocation contract (6.15-6.70x measured, still over), and a
+// realistic, currently-passing witness (a 140KB clean Go source, budget 48
+// MB) started declining before completion, because ITS OWN legitimate
+// footprint at completion (order 28 MB) already exceeds budget/2. At
+// divisor 3 the replica came inside the contract (5.0-5.9x) but the same
+// 140KB/48MB witness still regressed. No tested divisor cleared the
+// pathological witness without cutting into ordinary coverage, because the
+// two witnesses need materially different discounts: the giant literal's
+// churn ratio is a property of ITS shape (dense, repeated struct-literal
+// reduction), not a universal constant every input pays.
+//
+// stopControlMemoryBudgetReason therefore compares FootprintBytes against
+// the configured budget with NO discount (ratio effectively 1): the honest,
+// cap()-based, structure-complete gauge alone, with its own measured,
+// no-coverage-cost improvement (11.51x to 9.02-9.56x cumulative allocation
+// on the same replica, down from the pre-B9-honest-accounting baseline).
+// Closing the remaining gap to the 6x contract needs either an owner
+// decision to accept the coverage cost above, or a deeper change to reduce
+// the scheduler's own per-token ephemeral allocation rate (out of this
+// tranche's scope). See the tranche's PR for the full witness table.
+const stopControlFootprintChurnRatio = 1
+
+// stopControlMemoryBudgetReason compares the compact core's own real
+// retained-memory footprint against the production engine's soft per-parse
+// byte budget (stopControlMemoryBudgetBytes, sourced from
+// parseMemoryBudgetForParser so the same GOT_PARSE_MEMORY_BUDGET_MB
+// configuration governs both engines) and, independently, against
+// production's own absolute hard ceiling (stopControlHardCeilingBytes,
+// armed even when the soft budget is disabled). Every input is
+// Core.FootprintBytes(): already-tracked slice/map length and capacity
+// reads times compile-time-constant record sizes, so this is pure
+// deterministic integer arithmetic -- no wall clock, no GC-timing
+// dependence, and (same input, same budget) the same trip point on every
+// run, unlike the runtime heap/sys signal production's own hard ceiling
+// poll uses (parser_memory_budget_runtime.go). FootprintBytes, not
+// StorageBytes, is deliberate here: StorageBytes counts live length only,
+// so it reads near zero for a core whose arenas hold retained capacity from
+// an earlier declined attempt on the same cached runner, and it never
+// counted scratch, the boundary index, or checkpoint interning at all --
+// either gap let a pathological input's real footprint clear the configured
+// budget well before this poll noticed (tranche B9 honest-accounting gate).
+// See stopControlFootprintChurnRatio's doc comment for the ephemeral-churn
+// gap this gauge still has, and why closing it further is left as an owner
+// decision rather than a silent default change.
 func (s *diagnosticParserCoreGenericScheduler) stopControlMemoryBudgetReason() ParseStopReason {
-	if s == nil || s.options.stopControlMemoryBudgetBytes <= 0 {
+	if s == nil {
 		return ParseStopNone
 	}
-	if s.compact.StorageBytes() < uint64(s.options.stopControlMemoryBudgetBytes) {
-		return ParseStopNone
+	footprint := uint64(0)
+	haveFootprint := false
+	footprintAtLeast := func(bytes int64) bool {
+		if bytes <= 0 {
+			return false
+		}
+		if !haveFootprint {
+			footprint = s.compact.FootprintBytes()
+			haveFootprint = true
+		}
+		return footprint*stopControlFootprintChurnRatio >= uint64(bytes)
 	}
-	return ParseStopMemoryBudget
+	if footprintAtLeast(s.options.stopControlMemoryBudgetBytes) {
+		return ParseStopMemoryBudget
+	}
+	if footprintAtLeast(s.options.stopControlHardCeilingBytes) {
+		return ParseStopMemoryBudget
+	}
+	return ParseStopNone
 }
 
 // pollStopControl is the bounded scheduler-boundary poll (spec.campaign.v7

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -3157,13 +3157,22 @@ func diagnosticParserCoreStopControlTripped(reason ParseStopReason) error {
 // tracked footprint reached 103.6 MB at decline had allocated 516.5 MB
 // cumulative by then: a ~5x ratio.
 //
+// A runtime-heap-based soft stop is not an option here. The determinism
+// contract at parser_memory_budget_runtime.go:162-172 (issue #454) bars a
+// runtime.MemStats reading (HeapAlloc, Sys) from stopping a parse at
+// anything but the absolute hard ceiling: both readings are process-global
+// and shift run to run with GC timing, not with the input, so using either
+// one for the SOFT per-parse budget would make this poll's trip point
+// non-deterministic. FootprintBytes is the deterministic, capacity-based
+// gauge that keeps the soft budget reproducible instead.
+//
 // Discounting the comparison threshold by a fixed divisor (tripping the
 // poll at budget/divisor instead of budget) was tried and reverted: at
 // divisor 2, the giant-table-literal replica still exceeded the 6x
 // cumulative-allocation contract (6.15-6.70x measured, still over), and a
 // realistic, currently-passing witness (a 140KB clean Go source, budget 48
 // MB) started declining before completion, because ITS OWN legitimate
-// footprint at completion (order 28 MB) already exceeds budget/2. At
+// footprint at completion (measured (34,36] MB) already exceeds budget/2. At
 // divisor 3 the replica came inside the contract (5.0-5.9x) but the same
 // 140KB/48MB witness still regressed. No tested divisor cleared the
 // pathological witness without cutting into ordinary coverage, because the
@@ -3173,13 +3182,21 @@ func diagnosticParserCoreStopControlTripped(reason ParseStopReason) error {
 //
 // stopControlMemoryBudgetReason therefore compares FootprintBytes against
 // the configured budget with NO discount (ratio effectively 1): the honest,
-// cap()-based, structure-complete gauge alone, with its own measured,
-// no-coverage-cost improvement (11.51x to 9.02-9.56x cumulative allocation
-// on the same replica, down from the pre-B9-honest-accounting baseline).
-// Closing the remaining gap to the 6x contract needs either an owner
-// decision to accept the coverage cost above, or a deeper change to reduce
-// the scheduler's own per-token ephemeral allocation rate (out of this
-// tranche's scope). See the tranche's PR for the full witness table.
+// cap()-based, structure-complete gauge alone, with its own measured
+// improvement (11.51x to 9.14-9.56x cumulative allocation on the same
+// replica, down from the pre-B9-honest-accounting baseline). That
+// improvement is not free at low budgets: FootprintBytes reads higher than
+// the length-only StorageBytes gauge tranche B9 replaced, so the minimum
+// budget a realistic witness needs to still route (rather than decline)
+// rose too -- measured +25-29% on two witnesses (the same 140KB clean Go
+// source referenced above: 28 MB to 36 MB; a 238KB one: 48 MB to 60 MB).
+// The cost is nil at the shipped 512 MB default budget, which clears both
+// thresholds with wide margin; it only reaches a caller who configured a
+// budget close to a witness's pre-B9 threshold. Closing the remaining gap
+// to the 6x contract needs either an owner decision to accept the
+// divisor-discount coverage cost described above, or a deeper change to
+// reduce the scheduler's own per-token ephemeral allocation rate (out of
+// this tranche's scope). See the tranche's PR for the full witness table.
 const stopControlFootprintChurnRatio = 1
 
 // stopControlMemoryBudgetReason compares the compact core's own real

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -103,8 +103,12 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	// caller bound a stop-control Parser (admission_switch_candidate.go); the
 	// diagnostic and benchmark runners leave stopControlParser nil, so this
 	// stays zero and the scheduler's memory-budget poll is a no-op for them.
+	// The hard ceiling is armed independently of the soft budget (it stays
+	// on even when a caller zeroes GOT_PARSE_MEMORY_BUDGET_MB), mirroring
+	// production's own soft/hard independence.
 	if r.options.stopControlParser != nil {
 		r.options.stopControlMemoryBudgetBytes = parseMemoryBudgetForParser(r.options.stopControlParser, len(source))
+		r.options.stopControlHardCeilingBytes = parseMemoryHardCeilingBytes()
 	}
 	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 		&r.scheduler, compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
@@ -122,9 +126,10 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 		// decline -- accepted, but not the strict sole-exact-EOF frontier -- is the
 		// one decline path that would otherwise leave the compact core's storage
 		// retained on the cached runner until the next parse call resets it lazily.
-		// Reset immediately: a large declined parse must never leave compact storage
-		// retained while the caller's production fallback runs (tranche B9 gate).
-		if resetErr := compact.Reset(); resetErr != nil {
+		// Reset immediately, releasing any oversized retention the accepted run
+		// grew: a large declined parse must never leave compact storage retained
+		// while the caller's production fallback runs (tranche B9 gate).
+		if resetErr := compact.ResetReleasingRetention(); resetErr != nil {
 			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after acceptance decline: %w", resetErr))
 		}
 		return nil, nil, err
@@ -201,16 +206,42 @@ func (r *parserCoreFreshFullRunner) materializeSelection(source []byte, compact 
 	return materializeDiagnosticParserCoreAcceptedSelection(compact, scheduler.acceptedHead, scheduler.acceptedPayloads, r.parser, source, &r.scratch, r.replayParseStates)
 }
 
-func (r *parserCoreFreshFullRunner) parse(source []byte) (*Tree, error) {
+// parse runs one fresh full parse and returns the materialized tree, or a
+// decline error when the compact route cannot serve this input.
+//
+// A single deferred cleanup guarantees release on every path that returns
+// without a tree -- including ones executeSchedulerOpen does not reset
+// explicitly itself (a compact.Seed or scheduler-init failure ahead of
+// RunFreshSchedulerSession, inside executeDiagnosticParserCoreGenericSchedulerFromSeedInto)
+// and a materialization decline below, which runs after acceptance already
+// committed the full derivation graph to the core (tranche B9
+// reset-completeness gate: before this defer, a materialization decline left
+// the ENTIRE accepted parse graph retained on the cached runner while the
+// caller's production fallback ran beside it). This is redundant with the
+// explicit resets on paths that already handle their own release
+// (RunFreshSchedulerSession's own defer on a hard scheduler error, and
+// executeSchedulerOpen's acceptance-gate branch); Core.Reset guards against
+// double-reset cleanly and is cheap on an already-reset core, so the
+// redundancy costs one extra FootprintBytes comparison on the decline path,
+// never on the accepted-and-returned path.
+func (r *parserCoreFreshFullRunner) parse(source []byte) (tree *Tree, err error) {
 	if r == nil || r.compact == nil {
 		return nil, errors.New("parser-core fresh-full runner is incomplete")
 	}
-	scheduler, tokenSource, err := r.executeSchedulerOpen(source, r.compact, true)
-	if err != nil {
-		return nil, err
+	defer func() {
+		if tree != nil {
+			return
+		}
+		if resetErr := r.compact.ResetReleasingRetention(); resetErr != nil {
+			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after decline: %w", resetErr))
+		}
+	}()
+	scheduler, tokenSource, err2 := r.executeSchedulerOpen(source, r.compact, true)
+	if err2 != nil {
+		return nil, err2
 	}
 	defer tokenSource.Close()
-	tree, err := r.materializeSelection(source, r.compact, scheduler)
+	tree, err = r.materializeSelection(source, r.compact, scheduler)
 	if err != nil {
 		return nil, err
 	}

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -116,6 +116,17 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 	}
 	if err := requireParserCoreFreshFullAcceptance(scheduler, source, r.allowConvergedReductionSplitDrops); err != nil {
 		tokenSource.Close()
+		// The scheduler run itself already committed here (RunFreshSchedulerSession,
+		// invoked from inside executeDiagnosticParserCoreGenericSchedulerFromSeedInto,
+		// resets the core only on its own internal error), so this acceptance-gate
+		// decline -- accepted, but not the strict sole-exact-EOF frontier -- is the
+		// one decline path that would otherwise leave the compact core's storage
+		// retained on the cached runner until the next parse call resets it lazily.
+		// Reset immediately: a large declined parse must never leave compact storage
+		// retained while the caller's production fallback runs (tranche B9 gate).
+		if resetErr := compact.Reset(); resetErr != nil {
+			err = errors.Join(err, fmt.Errorf("parser-core fresh-full runner: reset after acceptance decline: %w", resetErr))
+		}
 		return nil, nil, err
 	}
 	return scheduler, tokenSource, nil


### PR DESCRIPTION
## Summary

- Removed the 64 KiB source-length limit that kept large full parses on the
  slower production route. A parse of any size now tries the fast route
  first; a scheduler budget poll bounds a large or pathological input and
  falls back to the production route when needed, with the same
  `ParseStopMemoryBudget` result callers already handle.
- The budget poll now compares a real, capacity-based memory footprint
  gauge, not a record-count estimate that missed several growable
  structures entirely and could read near zero right after a decline.
- Closed a set of storage-retention gaps across every decline path: a
  declined attempt no longer leaves megabytes of backing memory allocated
  on the parser for later, unrelated parses to inherit.
- A backstop memory ceiling is now armed on the fast route even when the
  configurable soft budget is turned off.
- Updated the performance-attribution board so the large `grammargen/lr.go`
  fixture has its own measured row on the public API route for the first
  time, alongside the other three canonical fixtures.

## Witness timing (both routes, process-isolated on this host)

| witness | bytes | production | fast route | outcome |
|---|---:|---:|---:|---|
| grammargen/lr.go (large Go) | 240,633 | 312ms | 184ms | fast route, tree identical to production |
| lua_binarytrees.js (large JavaScript) | 1,183,743 | 1.33s | 1.24s | fast route, tree identical to production |
| Bicep FakeResourceTypes.cs (large C#) | 348,375 | 101ms | 80ms | non-size engine decline, clean fallback to production |
| poppler.js (large JavaScript, extreme case) | 3,447,275 | 1.09 GiB peak RSS | 1.33 GiB peak RSS | budget decline, clean fallback to production |

Neither route hung on any witness. Peak RSS stayed well under the 2 GiB
safety threshold on every witness, measured as an isolated process per
route. The Poppler witness hits the default 512 MiB soft memory budget on
the production route too, on this host's default configuration -- that is
pre-existing behavior, not a regression from this change.

## Memory containment: what an independent review found and what changed

An independent review measured the shipped route's real memory behavior
end to end (not just the routing decision) and found four real problems
with the first version of this change. All four are fixed here.

1. **The budget poll's own gauge undercounted.** It summed live record
counts, not the memory those records' backing arrays actually held, and it
missed several growable structures (parse scratch, a boundary index, and
a checkpoint cache) entirely. On a synthetic pathological witness (a
300,000-entry struct-literal table, 96 MB configured budget), the poll let
the fast route overshoot to 11.51x the budget before noticing. The gauge
now reads real allocated capacity across every growable structure. The
same witness now overshoots by 9.0-9.6x -- a real, measured improvement,
but not all the way to the tight 6x bound the production-only path holds
on its own. Closing that remaining gap runs into the fast route's own
transient per-parse-event allocation, which a capacity gauge cannot see by
construction; narrowing it further would need to decline some inputs the
route currently serves successfully, which this change does not do
silently. A dedicated regression test
(`TestGoParseGiantTableLiteralShippedRouteStaysWithinAchievedBound`) pins
the achieved bound and will catch a regression back toward the original
11.51x.
2. **A decline reset record counts but not the memory behind them.** The
   reset step this route already had truncated its internal record counts
   to zero, which made a naive "is storage empty" check pass, but the
   underlying backing memory stayed allocated for reuse -- by design, for
   ordinary reuse efficiency, but unbounded for a one-off pathological
   parse. Measured: 157-193 MB retained on the parser after one large
   declined parse, undiminished across five subsequent small parses on the
   same parser. Decline paths now additionally release that backing memory
   outright once it crosses a threshold set with headroom above ordinary
   steady-state use, while routine reuse between successful parses keeps
   its existing reuse behavior unaffected. Measured after the fix: 29 MB
   immediately after the same large declined parse, back to a 12-15 MB
   steady state within a few subsequent small parses.
3. **One decline path released nothing at all.** A parse that the fast
   route's scheduler fully accepted, but that failed a later, stricter
   completeness check during tree construction, returned no tree and also
   performed no cleanup: the entire accepted internal parse graph stayed
   retained while the production fallback ran alongside it. A second,
   narrower gap existed on an early setup-failure path before scheduling
   even starts. A single guaranteed cleanup step now covers every path
   that returns without a tree, including both of these. Two new
   regression tests drive each class directly and assert the release.
4. **No backstop when the configurable budget is disabled.** With the
   soft budget explicitly turned off, the fast route had no ceiling of any
   kind; only the production route's own separate, pre-existing hard
   ceiling applied, and only to the production side, not to a fast-route
   attempt beforehand. The fast route's own poll now also honors that same
   hard ceiling, verified directly: at a deliberately tiny 1 MB ceiling
   with the soft budget off, a witness that would otherwise complete now
   correctly declines through the ceiling instead of running unbounded.

None of the above changes the routing decisions this PR's earlier revision
already established at the shipped 512 MiB default budget: every witness
that previously routed to the fast path still does (verified directly,
including the large Go and JavaScript witnesses above and a dedicated
route-equality check across four additional shapes). This is not free at
every budget, though: the more honest gauge itself raises the minimum
budget a witness needs to still route rather than decline, measured
+25-29% on two witnesses (a 140KB clean Go source: 28 MB to 36 MB; a 238KB
one: 48 MB to 60 MB). That cost is nil at the 512 MiB default and reaches
only a caller who configured a budget close to a witness's old threshold.

## Scorecard: no change

The 206-language admission scorecard (smoke-sample coverage across every
registered grammar) holds at 200 pass / 1 fallback / 5 skip / 0 diverge / 0
error -- identical to before this change, confirmed again after the memory
fixes above. None of the 206 per-language smoke samples reaches a size
where any of this matters; the observable effect of this whole change is
confined to larger files, outside that smoke corpus.

## Test fixes

Two existing tests needed an explicit "stay on the production route" pin
because they used to get that behavior for free from the removed size
limit; both isolate a single-route measurement that a multi-route attempt
would otherwise conflate:

- A benchmark helper that asserts on production-only GLR runtime counters
  now pins explicitly for its largest fixture too (the other three
  fixtures already needed the pin).
- The memory-budget regression test that measures raw process heap growth
  with garbage collection disabled needed the same explicit pin, so it
  keeps isolating the single-route containment it was designed to check.
  Its unpinned counterpart is new (see the memory section above).

## Test plan

- [x] `go test .` green (default build, and the emergency opt-out build tag)
- [x] `go test ./grammars` green
- [x] Race mode green on every touched path, plus the internal parser-core
      package
- [x] Route-equality fuzz seed corpus green
- [x] Editor-latency gate tests green
- [x] Canonical tree digests unchanged (confirmed via exact digest match
      against the frozen oracle-blessed SHA-256 for the large Go fixture on
      the public API route)
- [x] Benchmark harness production pins verified intact and still
      measuring production correctly
- [x] The full required admission test list for the alternate build tag is
      green, including the 206-language scorecard at its unchanged counts
- [x] Every previously-routing witness still routes after the memory
      fixes at the shipped 512 MiB default; a low, explicitly configured
      budget can see its routing threshold move (see the memory section
      above) -- a measured, documented cost, not a silent one

Note on the alternate build tag's *unrestricted* full suite: running every
test in that build (not just the required list above) surfaces 13-14
pre-existing failures in internal scheduler/replay/corpus-ratchet tests
unrelated to routing, file size, or memory containment. Confirmed via a
clean stash-and-rerun against the unmodified base commit: the same
failures reproduce there, consistently, with and without this change. They
do not reproduce when run as part of the required list above, or under the
default build. Left uninvestigated as out of scope for this change.

