### PR TITLE
remove(kotlin): Remove dead Kotlin recovered source file root normalization

### DIFF
--- a/parser_result_kotlin.go
+++ b/parser_result_kotlin.go
@@ -3,7 +3,6 @@ package gotreesitter
 import "strings"
 
 func normalizeKotlinCompatibility(root *Node, source []byte, lang *Language) {
-	normalizeKotlinRecoveredSourceFileRoot(root, source, lang)
 	normalizeKotlinInterpolatedCallExpressions(root, lang)
 	normalizeKotlinGenericCallTypeArguments(root, source, lang)
 	normalizeKotlinPrefixComparisonExpressions(root, source, lang)
@@ -608,104 +607,6 @@ func normalizeKotlinRawStringTrailingContent(root *Node, source []byte, lang *La
 		n.startByte, n.endByte = startByte, endByte
 		n.startPoint, n.endPoint = startPoint, endPoint
 	})
-}
-
-func normalizeKotlinRecoveredSourceFileRoot(root *Node, source []byte, lang *Language) {
-	if root == nil || lang == nil || lang.Name != "kotlin" || root.Type(lang) != "ERROR" {
-		return
-	}
-	if !kotlinRootLooksRecoverableSourceFile(root, lang) {
-		return
-	}
-	normalizeKotlinTopLevelFunctionFragments(root, source, lang)
-	sym, ok := symbolByName(lang, "source_file")
-	if !ok {
-		return
-	}
-	retagResultRootAndRefreshError(root, sym, symbolIsNamed(lang, sym))
-}
-
-func kotlinRootLooksRecoverableSourceFile(root *Node, lang *Language) bool {
-	if root == nil || lang == nil || resultChildCount(root) == 0 {
-		return false
-	}
-	for i := 0; i < resultChildCount(root); i++ {
-		child := resultChildAt(root, i)
-		if child == nil {
-			continue
-		}
-		switch child.Type(lang) {
-		case "package_header",
-			"import_list",
-			"class_declaration",
-			"function_declaration",
-			"object_declaration",
-			"property_declaration",
-			"typealias_declaration",
-			"multiline_comment",
-			"line_comment":
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeKotlinTopLevelFunctionFragments(root *Node, source []byte, lang *Language) {
-	fnSym, ok := symbolByName(lang, "function_declaration")
-	if !ok {
-		return
-	}
-	funSym, ok := symbolByName(lang, "fun")
-	if !ok {
-		return
-	}
-	children := resultChildSliceForMutation(root)
-	if len(children) < 3 {
-		return
-	}
-	arena := root.ownerArena
-	if arena == nil {
-		return
-	}
-	rebuilt := make([]*Node, 0, len(children))
-	changed := false
-	for i := 0; i < len(children); i++ {
-		if fn, ok := kotlinRecoveredTopLevelFunction(arena, children, i, source, lang, fnSym, funSym); ok {
-			rebuilt = append(rebuilt, fn)
-			i += 2
-			changed = true
-			continue
-		}
-		rebuilt = append(rebuilt, children[i])
-	}
-	if !changed {
-		return
-	}
-	replaceNodeChildrenUnfielded(root, cloneNodeSliceInArena(arena, rebuilt))
-}
-
-func kotlinRecoveredTopLevelFunction(arena *nodeArena, children []*Node, idx int, source []byte, lang *Language, fnSym, funSym Symbol) (*Node, bool) {
-	if idx+2 >= len(children) {
-		return nil, false
-	}
-	funKeyword := children[idx]
-	name := children[idx+1]
-	params := children[idx+2]
-	if funKeyword == nil || name == nil || params == nil {
-		return nil, false
-	}
-	if funKeyword.Type(lang) != "ERROR" || strings.TrimSpace(funKeyword.Text(source)) != "fun" {
-		return nil, false
-	}
-	if name.Type(lang) != "simple_identifier" || params.Type(lang) != "function_value_parameters" {
-		return nil, false
-	}
-	retagResultRoot(funKeyword, funSym, symbolIsNamed(lang, funSym))
-	funKeyword.setHasError(false)
-	fnChildren := cloneNodeSliceInArena(funKeyword.ownerArena, []*Node{funKeyword, name, params})
-	fn := newParentNodeInArena(funKeyword.ownerArena, fnSym, symbolIsNamed(lang, fnSym), fnChildren, nil, 0)
-	fn.setHasError(true)
-	return fn, true
 }
 
 func normalizeKotlinInterpolatedCallExpressions(root *Node, lang *Language) {

--- a/testdata/result_compat_ownership_v1.json
+++ b/testdata/result_compat_ownership_v1.json
@@ -1607,10 +1607,11 @@
       "languages": [
         "kotlin"
       ],
-      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape.",
+      "purpose": "Reconcile Kotlin derivation selection and returned-tree shape. Retired member normalizeKotlinRecoveredSourceFileRoot as dead code on 2026-08-02: no route sets its ERROR-root guard on any tested witness, so the retag never fires. The remaining members, normalizeKotlinGenericCallTypeArguments and normalizeKotlinPrefixComparisonExpressions, stay load-bearing.",
       "authoritative_owner": "derivation_election_selection",
       "witnesses": [
-        "cgo_harness/parity_cgo_test.go"
+        "cgo_harness/parity_cgo_test.go",
+        "query_kotlin_regression_test.go"
       ],
       "retirement_condition": "Delete only after derivation_election_selection emits the same tree natively for every registered witness and production, compact, forest, incremental, and C-oracle route receipts are exact.",
       "route_coverage": {


### PR DESCRIPTION
## Summary

Removes `normalizeKotlinRecoveredSourceFileRoot` and its three helper
functions from `parser_result_kotlin.go`. This member retagged a Kotlin
parse's root node from `ERROR` to `source_file`. It fired only when
materialization left the root typed `ERROR`. No parsing route sets that
condition today, so the retag and its helpers never ran. The deletion does
not change parser output on any route.

## Why this is safe to remove

The member's only regression witness is
`TestKotlinRecoveredRootPreservesSourceFileQueries` in
`query_kotlin_regression_test.go`. Before deleting the code, this change
independently re-tested the member's guard condition
(`root.Type == "ERROR"` for a Kotlin parse) against 18 sources:

- The witness's own source, a package with a `new` Java-style constructor
  call (invalid Kotlin syntax that triggers error recovery).
- 17 adversarial Kotlin sources built to force an `ERROR`-typed root with a
  recognizable top-level child: unclosed braces, garbage tokens before
  valid declarations, broken generics, unterminated strings, and similar
  malformed inputs.

With the member's call site disabled, every one of these 18 sources still
produced a `source_file`-typed root. This held on both the default
(compact) parse route and the production-forced route
(`GTS_ADMISSION_CANDIDATE=0`). The guard condition never held on either
route. The regression test's own query assertions, import list and
function declaration matches under `source_file`, also passed unchanged
on both routes with the member disabled. The member is provably inert on
every tested route today.

## Changes

- Delete `normalizeKotlinRecoveredSourceFileRoot`,
  `kotlinRootLooksRecoverableSourceFile`,
  `normalizeKotlinTopLevelFunctionFragments`, and
  `kotlinRecoveredTopLevelFunction` from `parser_result_kotlin.go`.
- Remove the now-unused call site from `normalizeKotlinCompatibility`.
- Record the retirement in
  `testdata/result_compat_ownership_v1.json`'s `dispatch.kotlin` entry
  (`purpose` field) and add `query_kotlin_regression_test.go` as a
  registered witness.

The other two Kotlin result-normalization members,
`normalizeKotlinGenericCallTypeArguments` and
`normalizeKotlinPrefixComparisonExpressions`, are unchanged. They remain
load-bearing for six existing regression tests.

## Test plan

- [x] `go test . -count=1` (root package suite, full green)
- [x] `go test ./grammars` (full green)
- [x] Full `TestKotlin*` / `TestNormalizeKotlin*` suite, both admission
      routes
- [x] `TestResultCompatibilityOwnershipRegistry` (registry validation)
- [x] Kotlin C-oracle cgo parity subset (`GTS_PARITY_ALLOW_HOST=1`, tags
      `cgo treesitter_c_parity`); green, and matches known
      certification-withheld divergences that predate and are unrelated
      to this change
- [x] Admission scorecard across 206 languages: byte-identical to
      baseline, Kotlin's digest unchanged
- [x] Race detector on touched paths (root package and grammars package
      Kotlin tests)
