### PR TITLE
fix(parser): Materialize skipped gaps as EXTRA errors; add forest regen guard

### DIFF
--- a/forest_regen_guard_test.go
+++ b/forest_regen_guard_test.go
@@ -108,17 +108,23 @@ var forestRegenGuardCorpus = map[string]func(n int) []byte{
 }
 
 // TestForestRegenGuardRepeatedTopLevelItems is the work-floor regen guard: for
-// every forest-default language, parsing N=1..20 repeated top-level items
-// must keep dispatching through the GSS-forest fast path (no eof_no_root /
-// any other decline), and gotreesitter.Parser.Parse's own resulting
-// MaxStacksSeen on the same corpus must stay 0. It runs against whatever
-// blobs are currently embedded (grammars/grammar_blobs), so it is a plain
-// default-on test today and automatically re-checks the new blob the next
-// time a table-resync PR swaps one in.
+// every forest-default language, parsing N=1..20 repeated top-level items via
+// Parser.Parse (the real dispatch entry point, not the diagnostic-only
+// ParseForestExperimental) must keep ROUTING through the GSS-forest fast path
+// -- Tree.UsedForestFastPath() true, not merely "the forest engine can handle
+// this input in isolation" -- and Parse's own resulting MaxStacksSeen on the
+// same corpus must stay 0. It runs against whatever blobs are currently
+// embedded (grammars/grammar_blobs), so it is a plain default-on test today
+// and automatically re-checks the new blob the next time a table-resync PR
+// swaps one in.
 //
 // A generator is validated (HasError=false at a small N) before the sweep
-// trusts it, so an author mistake in forestRegenGuardCorpus skips with a
-// clear reason instead of masquerading as a forest-engine regression.
+// trusts it, but an established generator's baseline going dirty is treated
+// as a hard failure, not a skip: once a language is in this map, silently
+// skipping on a broken baseline would disable the guard on exactly the
+// regression class it exists to catch (a table resync corrupting even the
+// trivial corpus). Missing an entry entirely (a forest-default language with
+// no generator yet) still skips, since no coverage claim is being made there.
 func TestForestRegenGuardRepeatedTopLevelItems(t *testing.T) {
 	const maxN = 20
 	for _, entry := range grammars.AllLanguages() {
@@ -137,31 +143,31 @@ func TestForestRegenGuardRepeatedTopLevelItems(t *testing.T) {
 			baselineParser := gotreesitter.NewParser(lang)
 			baselineTree, err := baselineParser.Parse(baseline)
 			if err != nil || baselineTree == nil || baselineTree.RootNode() == nil || baselineTree.RootNode().HasError() {
-				t.Skipf("forest-regen-guard: generator baseline for %q is not clean (err=%v); fixture needs authoring, not a forest regression", name, err)
+				t.Fatalf("forest-regen-guard: generator baseline for %q is not clean (err=%v); either the fixture needs authoring or a table regen broke the trivial corpus itself -- the exact regression this guard exists to catch", name, err)
 			}
 			baselineTree.Release()
 
 			for n := 1; n <= maxN; n++ {
 				src := gen(n)
 
-				forestParser := gotreesitter.NewParser(lang)
-				forestTree, forestOK := forestParser.ParseForestExperimental(src)
-				if !forestOK {
-					offset, sym, reason, states := forestParser.ForestDeclineInfo()
-					t.Fatalf("N=%d: forest fast path declined (offset=%d sym=%d reason=%q states=%v); a table regen regressed forest coverage on a trivial repeated-item corpus",
-						n, offset, sym, reason, states)
-				}
-				forestTree.Release()
-
-				prodParser := gotreesitter.NewParser(lang)
-				prodTree, err := prodParser.Parse(src)
+				routedParser := gotreesitter.NewParser(lang)
+				routedTree, err := routedParser.Parse(src)
 				if err != nil {
 					t.Fatalf("N=%d: Parse failed: %v", n, err)
 				}
-				if maxStacks := prodTree.ParseRuntime().MaxStacksSeen; maxStacks != 0 {
-					t.Fatalf("N=%d: MaxStacksSeen=%d, want 0 on this trivial repeated-item corpus (forest decline or genuine multi-stack fork)", n, maxStacks)
+				if !routedTree.UsedForestFastPath() {
+					diagParser := gotreesitter.NewParser(lang)
+					_, forestOK := diagParser.ParseForestExperimental(src)
+					offset, sym, reason, states := diagParser.ForestDeclineInfo()
+					routedTree.Release()
+					t.Fatalf("N=%d: Parse did not route through the forest fast path (forest engine standalone ok=%v; decline offset=%d sym=%d reason=%q states=%v); a table regen regressed forest coverage on a trivial repeated-item corpus",
+						n, forestOK, offset, sym, reason, states)
 				}
-				prodTree.Release()
+				if maxStacks := routedTree.ParseRuntime().MaxStacksSeen; maxStacks != 0 {
+					routedTree.Release()
+					t.Fatalf("N=%d: MaxStacksSeen=%d, want 0 on this trivial repeated-item corpus (genuine multi-stack fork even while forest-routed)", n, maxStacks)
+				}
+				routedTree.Release()
 			}
 		})
 	}

--- a/forest_regen_guard_test.go
+++ b/forest_regen_guard_test.go
@@ -1,0 +1,168 @@
+package gotreesitter_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// forestRegenGuardCorpus generates N syntactically valid, repeated top-level
+// items for a language known to dispatch to the GSS-forest GLR fast path by
+// default (gotreesitter.LanguageWantsForest). This is the work-floor
+// regression class found in the 2026-08-02 javascript table-fork regression
+// (hypha spore spore.2026-08-02.pine.table-fork-regression): a table regen
+// can change forest-engine coverage (not tree correctness -- production
+// silently absorbs the decline) without any parity gate noticing, because
+// parity floors compare trees, and forest and production converge on the
+// same tree once production runs. This corpus is deliberately trivial
+// (single-construct repetition, no internal ambiguity of its own) so a
+// decline here isolates a forest-coverage regression from any other cause.
+var forestRegenGuardCorpus = map[string]func(n int) []byte{
+	"javascript": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "let a%d = %d;\n", i, i)
+		}
+		return b.Bytes()
+	},
+	"json5": func(n int) []byte {
+		var b bytes.Buffer
+		b.WriteByte('[')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			fmt.Fprintf(&b, "%d", i)
+		}
+		b.WriteByte(']')
+		return b.Bytes()
+	},
+	"gitignore": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "file%d.o\n", i)
+		}
+		return b.Bytes()
+	},
+	"gitattributes": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "file%d.txt text\n", i)
+		}
+		return b.Bytes()
+	},
+	"nix": func(n int) []byte {
+		var b bytes.Buffer
+		b.WriteString("{\n")
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "  a%d = %d;\n", i, i)
+		}
+		b.WriteString("}\n")
+		return b.Bytes()
+	},
+	"squirrel": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "local a%d = %d;\n", i, i)
+		}
+		return b.Bytes()
+	},
+	"prisma": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "model M%d {\n  id Int @id\n}\n\n", i)
+		}
+		return b.Bytes()
+	},
+	"arduino": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "void f%d() {}\n", i)
+		}
+		return b.Bytes()
+	},
+	"awk": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "{ print %d }\n", i)
+		}
+		return b.Bytes()
+	},
+	"kdl": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "node%d %d\n", i, i)
+		}
+		return b.Bytes()
+	},
+	"uxntal": func(n int) []byte {
+		var b bytes.Buffer
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, "@label%d\n", i)
+		}
+		return b.Bytes()
+	},
+}
+
+// TestForestRegenGuardRepeatedTopLevelItems is the work-floor regen guard: for
+// every forest-default language, parsing N=1..20 repeated top-level items
+// must keep dispatching through the GSS-forest fast path (no eof_no_root /
+// any other decline), and gotreesitter.Parser.Parse's own resulting
+// MaxStacksSeen on the same corpus must stay 0. It runs against whatever
+// blobs are currently embedded (grammars/grammar_blobs), so it is a plain
+// default-on test today and automatically re-checks the new blob the next
+// time a table-resync PR swaps one in.
+//
+// A generator is validated (HasError=false at a small N) before the sweep
+// trusts it, so an author mistake in forestRegenGuardCorpus skips with a
+// clear reason instead of masquerading as a forest-engine regression.
+func TestForestRegenGuardRepeatedTopLevelItems(t *testing.T) {
+	const maxN = 20
+	for _, entry := range grammars.AllLanguages() {
+		lang := entry.Language()
+		if !gotreesitter.LanguageWantsForest(lang) {
+			continue
+		}
+		name := entry.Name
+		t.Run(name, func(t *testing.T) {
+			gen, ok := forestRegenGuardCorpus[name]
+			if !ok {
+				t.Skipf("forest-regen-guard: no repeated-top-level-item generator for forest-default language %q; add one to forestRegenGuardCorpus", name)
+			}
+
+			baseline := gen(2)
+			baselineParser := gotreesitter.NewParser(lang)
+			baselineTree, err := baselineParser.Parse(baseline)
+			if err != nil || baselineTree == nil || baselineTree.RootNode() == nil || baselineTree.RootNode().HasError() {
+				t.Skipf("forest-regen-guard: generator baseline for %q is not clean (err=%v); fixture needs authoring, not a forest regression", name, err)
+			}
+			baselineTree.Release()
+
+			for n := 1; n <= maxN; n++ {
+				src := gen(n)
+
+				forestParser := gotreesitter.NewParser(lang)
+				forestTree, forestOK := forestParser.ParseForestExperimental(src)
+				if !forestOK {
+					offset, sym, reason, states := forestParser.ForestDeclineInfo()
+					t.Fatalf("N=%d: forest fast path declined (offset=%d sym=%d reason=%q states=%v); a table regen regressed forest coverage on a trivial repeated-item corpus",
+						n, offset, sym, reason, states)
+				}
+				forestTree.Release()
+
+				prodParser := gotreesitter.NewParser(lang)
+				prodTree, err := prodParser.Parse(src)
+				if err != nil {
+					t.Fatalf("N=%d: Parse failed: %v", n, err)
+				}
+				if maxStacks := prodTree.ParseRuntime().MaxStacksSeen; maxStacks != 0 {
+					t.Fatalf("N=%d: MaxStacksSeen=%d, want 0 on this trivial repeated-item corpus (forest decline or genuine multi-stack fork)", n, maxStacks)
+				}
+				prodTree.Release()
+			}
+		})
+	}
+}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -570,6 +570,17 @@ func parserWantsForest(p *Parser) bool {
 		(p.language.WantsForest || p.language.AutomaticForestEnabledByDefault || builtinForestDefaults[p.language.Name])
 }
 
+// LanguageWantsForest reports whether lang dispatches to the GSS-forest GLR
+// fast path by default (Parser.Parse tries tryForestFastPath before the
+// production loop). Exported so regression gates outside this package (e.g.
+// the regen-guard sweep that reparses N repeated top-level items per
+// forest-default language) can enumerate the same set parserWantsForest uses,
+// without duplicating or drifting from builtinForestDefaults.
+func LanguageWantsForest(lang *Language) bool {
+	return lang != nil &&
+		(lang.WantsForest || lang.AutomaticForestEnabledByDefault || builtinForestDefaults[lang.Name])
+}
+
 func automaticForestMemoryBudget(p *Parser, operationBudget int64) int64 {
 	if p == nil || p.language == nil || operationBudget <= 0 {
 		return operationBudget

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -561,21 +561,24 @@ var builtinForestDefaults = map[string]bool{
 	"gitattributes": true,
 }
 
-// parserWantsForest reports whether p's language dispatches to the GSS-forest
-// GLR fast path: either the Language opted in directly (WantsForest, set by a
-// grammargen consumer), its exact artifact received a certified automatic
-// profile, or it is one of the older curated built-ins in builtinForestDefaults.
+// parserWantsForest reports whether p's language is in the forest-default set:
+// either the Language opted in directly (WantsForest, set by a grammargen
+// consumer), its exact artifact received a certified automatic profile, or it
+// is one of the older curated built-ins in builtinForestDefaults. This is
+// per-language eligibility only; tryForestFastPath separately gates on the
+// glrForestEnabled global switch (GOT_GLR_FOREST) before dispatching.
 func parserWantsForest(p *Parser) bool {
-	return p != nil && p.language != nil &&
-		(p.language.WantsForest || p.language.AutomaticForestEnabledByDefault || builtinForestDefaults[p.language.Name])
+	return p != nil && LanguageWantsForest(p.language)
 }
 
-// LanguageWantsForest reports whether lang dispatches to the GSS-forest GLR
-// fast path by default (Parser.Parse tries tryForestFastPath before the
-// production loop). Exported so regression gates outside this package (e.g.
-// the regen-guard sweep that reparses N repeated top-level items per
-// forest-default language) can enumerate the same set parserWantsForest uses,
-// without duplicating or drifting from builtinForestDefaults.
+// LanguageWantsForest reports whether lang is in the forest-default set (see
+// parserWantsForest). It does not account for the glrForestEnabled global
+// switch (GOT_GLR_FOREST), which can still disable dispatch even for a
+// language this reports true for. Exported so regression gates outside this
+// package (e.g. the regen-guard sweep that reparses N repeated top-level
+// items per forest-default language) can enumerate the same set
+// parserWantsForest uses, without duplicating or drifting from
+// builtinForestDefaults.
 func LanguageWantsForest(lang *Language) bool {
 	return lang != nil &&
 		(lang.WantsForest || lang.AutomaticForestEnabledByDefault || builtinForestDefaults[lang.Name])

--- a/parser.go
+++ b/parser.go
@@ -3873,31 +3873,69 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 	return actions[0].Type == ParseActionShift && !actions[0].Extra
 }
 
+// materializeSkippedGapAsExtraError covers a lexer-skipped mid-production gap
+// (a stray run of bytes immediately after an anonymous separator, where the
+// real lookahead continues the production via a single deterministic shift,
+// per skippedRealGapContinuesSeparatedList) with a transparent EXTRA ERROR
+// leaf spanning exactly the gap, then advances the stack's byte offset across
+// it. The leaf is pushed with parseState == state (the same state the caller
+// already resolved the deterministic shift against, not
+// schemeErrorRecoveryState's possibly-different recovery target), so the
+// following action lookup for tok is unaffected: this mirrors
+// pushLexErrorRunLeaf's "resume in the same state" contract. Because
+// reduceWindowFromGSS only counts non-extra stack entries toward a
+// production's ChildCount, the leaf is folded into whichever production
+// later reduces over it without perturbing arity, while populateParentNode's
+// unconditional HasError OR still lets the error bubble to ancestors.
+func (p *Parser) materializeSkippedGapAsExtraError(s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) {
+	if p != nil {
+		// See pushOrExtendErrorNode: error content makes costs relevant.
+		p.crecoveryCostCompetitionRelevant = true
+	}
+	startPoint := stackEntryNodeEndPoint(s.top())
+	leaf := newLeafNodeInArena(arena, errorSymbol, true, s.byteOffset, tok.StartByte, startPoint, tok.StartPoint)
+	leaf.setHasError(true)
+	leaf.setExtra(true)
+	leaf.parseState = state
+	p.pushStackNode(s, state, leaf, entryScratch, gssScratch)
+	if nodeCount != nil {
+		*nodeCount = *nodeCount + 1
+	}
+	if trackChildErrors != nil {
+		*trackChildErrors = true
+	}
+	s.byteOffset = tok.StartByte
+}
+
 func (p *Parser) tryMaterializeSkippedRealGap(source []byte, s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) bool {
 	if s == nil || tok.StartByte <= s.byteOffset || realTokenAttachmentGapIsParserPadding(source, s, tok) {
 		return false
 	}
 	// A stray token that the lexer skipped mid-production (immediately after an
 	// anonymous separator terminal, e.g. a comma in a separated list) must not be
-	// covered by a STRUCTURAL error node here: inserting one between the
-	// separator and the next element corrupts the pending reduction and collapses
-	// the enclosing construct into a flat ERROR. The parser has a concrete shift
-	// for the real lookahead that continues the production, so advance across the
-	// uncovered gap (restoring the pre-guard shift-across behavior) without
-	// materializing a node for the stray: the skipped bytes stay interior to the
-	// covering production's span, so total-span invariants hold, but they now sit
-	// in no leaf's span. Leaf-level parity with C tree-sitter's transparent
-	// EXTRA-error representation of such strays depends on a per-language
-	// post-parse normalizer re-materializing the stray afterward (today only
-	// normalizeJuliaTrailingCommaAssignmentTuple, dispatched from
-	// parser_result_compat.go's language switch); emitting the EXTRA error here
-	// at parse time instead, for every language, is the tracked follow-up.
+	// covered by a STRUCTURAL error node here: inserting one that changes the
+	// automaton state (pushOrExtendErrorNode's schemeErrorRecoveryState target)
+	// or that counts toward the enclosing production's ChildCount would corrupt
+	// the pending reduction and could collapse the enclosing construct into a
+	// flat ERROR. The parser has a concrete shift for the real lookahead that
+	// continues the production, so cover the gap with a transparent EXTRA ERROR
+	// leaf — pushed in the SAME state, so the following action lookup for tok is
+	// unaffected — and then advance across it exactly as a silent shift-across
+	// would (see materializeSkippedGapAsExtraError). reduceWindowFromGSS already
+	// treats EXTRA stack entries as free when counting a production's popped
+	// window, and populateParentNode ORs children's HasError regardless of
+	// Extra, so this leaf folds into whichever production reduces over it
+	// without perturbing arity, while still giving the skipped bytes their own
+	// span (parity with C tree-sitter's transparent EXTRA-error representation
+	// of such strays — see cmd/grammargen and the parser_shift_gap_test.go
+	// synthetic-language coverage of skippedRealGapContinuesSeparatedList's
+	// guard clauses for the shapes this must keep matching).
 	if p.skippedRealGapContinuesSeparatedList(s, state, tok) {
 		if p.glrTrace {
-			fmt.Printf("    SHIFT-ACROSS skipped real gap (mid-list separator): gap=%d..%d before tok=%d..%d\n",
+			fmt.Printf("    MATERIALIZE-EXTRA skipped real gap (mid-list separator): gap=%d..%d before tok=%d..%d\n",
 				s.byteOffset, tok.StartByte, tok.StartByte, tok.EndByte)
 		}
-		s.byteOffset = tok.StartByte
+		p.materializeSkippedGapAsExtraError(s, state, tok, nodeCount, arena, entryScratch, gssScratch, trackChildErrors)
 		return true
 	}
 	if p.tryExtendHiddenTrailingErrorAcrossSkippedRealGap(source, s, tok, nodeCount, arena, trackChildErrors) {

--- a/parser.go
+++ b/parser.go
@@ -3883,7 +3883,14 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 // reduceWindowFromGSS only counts non-extra stack entries toward a
 // production's ChildCount, the leaf is folded into whichever production
 // later reduces over it without perturbing arity, while populateParentNode's
-// unconditional HasError OR still lets the error bubble to ancestors.
+// HasError OR propagates the error through the reduce-built ancestors above
+// it. That propagation is not universal all the way to the tree root: python
+// specifically can still report a clean root over a genuinely erroring
+// subtree (parser_result_root_build.go's syntheticRootCanDropError /
+// pythonModuleChildrenLookComplete, a pre-existing, python-only root-level
+// convention this fix does not change and does not fully interact well
+// with -- see the PR discussion for the measured effect on root-level
+// HasError()).
 //
 // This is an ACCOUNTING fix, not a shape fix: the skipped bytes now have a
 // span and HasError=true, matching C tree-sitter's verdict that the

--- a/parser.go
+++ b/parser.go
@@ -3821,20 +3821,17 @@ func realShiftGapIsParserPadding(source []byte, s *glrStack, tok Token) bool {
 // skippedRealGapContinuesSeparatedList reports whether the sole active stack is
 // mid-production immediately after an anonymous separator terminal (e.g. a comma
 // in a separated list) and the real lookahead continues that production. In that
-// position, covering a lexer-skipped stray with a STRUCTURAL error node would
-// insert it between the separator and the next element and corrupt the pending
-// reduction; the correct behavior is to shift across the uncovered gap (as the
-// parser did before the shift-gap guard existed) without materializing any node
-// for the stray, so the skipped bytes stay interior to the covering
-// production's span and total-span invariants hold. That is parse-time
-// behavior only: the stray now lands in no leaf's span, so leaf-level parity
-// with C tree-sitter — which represents such a stray as an EXTRA error
-// transparent to the production — currently depends on a per-language
-// post-parse normalizer re-materializing it (today only
-// normalizeJuliaTrailingCommaAssignmentTuple, dispatched from
-// parser_result_compat.go's language switch). Emitting the EXTRA error
-// directly at parse time, so every language gets it without a bespoke
-// normalizer, is the tracked follow-up.
+// position, covering a lexer-skipped stray with a STRUCTURAL error node — one
+// that changes the automaton state (pushOrExtendErrorNode's
+// schemeErrorRecoveryState target) or counts toward the enclosing production's
+// ChildCount — would corrupt the pending reduction and could collapse the
+// enclosing construct into a flat ERROR. When this returns true,
+// tryMaterializeSkippedRealGap calls materializeSkippedGapAsExtraError instead:
+// it covers the gap with a transparent EXTRA ERROR leaf pushed in the SAME
+// state (not the older silent shift-across, which advanced past the gap with
+// no node at all and left it in no leaf's span, HasError unset). See
+// materializeSkippedGapAsExtraError's doc for the mechanism and its known
+// remaining shape gap versus C tree-sitter's representation of the same stray.
 func (p *Parser) skippedRealGapContinuesSeparatedList(s *glrStack, state StateID, tok Token) bool {
 	if p == nil || s == nil || tok.Symbol == 0 || tok.Symbol == errorSymbol || tok.Missing || tok.NoLookahead {
 		return false
@@ -3887,16 +3884,31 @@ func (p *Parser) stateDeterministicNonExtraShift(state StateID, sym Symbol) bool
 // production's ChildCount, the leaf is folded into whichever production
 // later reduces over it without perturbing arity, while populateParentNode's
 // unconditional HasError OR still lets the error bubble to ancestors.
+//
+// This is an ACCOUNTING fix, not a shape fix: the skipped bytes now have a
+// span and HasError=true, matching C tree-sitter's verdict that the
+// construct is erroneous. The leaf's own shape still diverges from C's for
+// the same stray in two ways that remain open follow-up work: the span
+// covers the whole lexer-skipped gap (which can include trivia C would not
+// attribute to the stray), and the leaf is childless where C typically wraps
+// the stray token as a child of its own ERROR/error_repeat node. Closing that
+// gap needs re-lexing the skipped bytes to find the stray token's true
+// bounds and giving the leaf that token as a child, which needs its own
+// verification pass and is out of scope here.
 func (p *Parser) materializeSkippedGapAsExtraError(s *glrStack, state StateID, tok Token, nodeCount *int, arena *nodeArena, entryScratch *glrEntryScratch, gssScratch *gssScratch, trackChildErrors *bool) {
-	if p != nil {
-		// See pushOrExtendErrorNode: error content makes costs relevant.
-		p.crecoveryCostCompetitionRelevant = true
-	}
+	// See pushOrExtendErrorNode: error content makes costs relevant. p is
+	// never nil here: the only caller (tryMaterializeSkippedRealGap) reaches
+	// this branch only after p.skippedRealGapContinuesSeparatedList already
+	// returned true, and that function itself returns false for a nil p.
+	p.crecoveryCostCompetitionRelevant = true
 	startPoint := stackEntryNodeEndPoint(s.top())
 	leaf := newLeafNodeInArena(arena, errorSymbol, true, s.byteOffset, tok.StartByte, startPoint, tok.StartPoint)
 	leaf.setHasError(true)
 	leaf.setExtra(true)
 	leaf.parseState = state
+	if perfCountersEnabled {
+		perfRecordErrorNode()
+	}
 	p.pushStackNode(s, state, leaf, entryScratch, gssScratch)
 	if nodeCount != nil {
 		*nodeCount = *nodeCount + 1
@@ -3911,25 +3923,16 @@ func (p *Parser) tryMaterializeSkippedRealGap(source []byte, s *glrStack, state 
 	if s == nil || tok.StartByte <= s.byteOffset || realTokenAttachmentGapIsParserPadding(source, s, tok) {
 		return false
 	}
-	// A stray token that the lexer skipped mid-production (immediately after an
-	// anonymous separator terminal, e.g. a comma in a separated list) must not be
-	// covered by a STRUCTURAL error node here: inserting one that changes the
-	// automaton state (pushOrExtendErrorNode's schemeErrorRecoveryState target)
-	// or that counts toward the enclosing production's ChildCount would corrupt
-	// the pending reduction and could collapse the enclosing construct into a
-	// flat ERROR. The parser has a concrete shift for the real lookahead that
-	// continues the production, so cover the gap with a transparent EXTRA ERROR
-	// leaf — pushed in the SAME state, so the following action lookup for tok is
-	// unaffected — and then advance across it exactly as a silent shift-across
-	// would (see materializeSkippedGapAsExtraError). reduceWindowFromGSS already
-	// treats EXTRA stack entries as free when counting a production's popped
-	// window, and populateParentNode ORs children's HasError regardless of
-	// Extra, so this leaf folds into whichever production reduces over it
-	// without perturbing arity, while still giving the skipped bytes their own
-	// span (parity with C tree-sitter's transparent EXTRA-error representation
-	// of such strays — see cmd/grammargen and the parser_shift_gap_test.go
-	// synthetic-language coverage of skippedRealGapContinuesSeparatedList's
-	// guard clauses for the shapes this must keep matching).
+	// A stray run of bytes that the lexer skipped mid-production, immediately
+	// after an anonymous separator terminal with a concrete deterministic
+	// shift for the real lookahead, is covered by materializeSkippedGapAsExtraError
+	// rather than by ordinary structural gap materialization below — see that
+	// function's doc and skippedRealGapContinuesSeparatedList's doc for why a
+	// structural node here would corrupt the pending reduction, and for the
+	// accounting-vs-shape distinction in what this branch actually fixes.
+	// parser_shift_gap_test.go's synthetic-language coverage of
+	// skippedRealGapContinuesSeparatedList's guard clauses pins the shapes
+	// this must keep matching.
 	if p.skippedRealGapContinuesSeparatedList(s, state, tok) {
 		if p.glrTrace {
 			fmt.Printf("    MATERIALIZE-EXTRA skipped real gap (mid-list separator): gap=%d..%d before tok=%d..%d\n",

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -1393,16 +1393,20 @@ func repairPythonKeywordErrorNode(node *Node, source []byte, arena *nodeArena, l
 		return node
 	}
 	childCount := resultChildCount(node)
-	// A childless ERROR leaf that is already EXTRA never came from a real
-	// shift the grammar directed (an EXTRA ERROR leaf only exists today from
-	// materializeSkippedGapAsExtraError, parser.go: a lexer-skipped gap that
-	// happens to spell an anonymous symbol's name). Relabeling it as that
-	// symbol would silently drop the error signal this repair itself must
-	// not launder away (setExtra below preserves Extra but never restores
-	// HasError on the replacement leaf) -- see parser.go's
-	// skippedRealGapContinuesSeparatedList doc for why that gap has no real
-	// token to begin with. Non-extra childless ERROR leaves (the case this
-	// repair exists for) are unaffected.
+	// Exclude a childless ERROR leaf that is already EXTRA: relabeling it as
+	// the matched keyword symbol would silently drop the error signal, since
+	// setExtra below preserves Extra but never restores HasError on the
+	// replacement leaf. This case is not unique to one call site --
+	// materializeSkippedGapAsExtraError (parser.go, a lexer-skipped gap that
+	// happens to spell an anonymous symbol's name) is one source, and
+	// tryRecoverPreviousShiftAsError (parser.go, a previously-shifted token
+	// reclassified as an EXTRA error during recovery) is a pre-existing one;
+	// there may be others. Measured on origin/main: the pre-existing sources
+	// already reach this childless-EXTRA-ERROR shape without ever matching
+	// pythonKeywordLeafSymbol, so this exclusion changes no tree at those
+	// sites -- it only changes outcomes for the new source. Non-extra
+	// childless ERROR leaves (the case this repair exists for) are
+	// unaffected regardless of source.
 	if node.Type(lang) == "ERROR" && childCount == 0 && !node.isExtra() {
 		if keyword, ok := pythonKeywordLeafSymbol(node, source, lang); ok {
 			named := symbolIsNamed(lang, keyword)

--- a/parser_result_python.go
+++ b/parser_result_python.go
@@ -1393,7 +1393,17 @@ func repairPythonKeywordErrorNode(node *Node, source []byte, arena *nodeArena, l
 		return node
 	}
 	childCount := resultChildCount(node)
-	if node.Type(lang) == "ERROR" && childCount == 0 {
+	// A childless ERROR leaf that is already EXTRA never came from a real
+	// shift the grammar directed (an EXTRA ERROR leaf only exists today from
+	// materializeSkippedGapAsExtraError, parser.go: a lexer-skipped gap that
+	// happens to spell an anonymous symbol's name). Relabeling it as that
+	// symbol would silently drop the error signal this repair itself must
+	// not launder away (setExtra below preserves Extra but never restores
+	// HasError on the replacement leaf) -- see parser.go's
+	// skippedRealGapContinuesSeparatedList doc for why that gap has no real
+	// token to begin with. Non-extra childless ERROR leaves (the case this
+	// repair exists for) are unaffected.
+	if node.Type(lang) == "ERROR" && childCount == 0 && !node.isExtra() {
 		if keyword, ok := pythonKeywordLeafSymbol(node, source, lang); ok {
 			named := symbolIsNamed(lang, keyword)
 			repl := newLeafNodeInArena(arena, keyword, named, node.startByte, node.endByte, node.startPoint, node.endPoint)

--- a/tree.go
+++ b/tree.go
@@ -2983,14 +2983,21 @@ func (t *Tree) RootNodeWithOffset(offsetBytes uint32, offsetExtent Point) *Node 
 // Source returns the original source text.
 func (t *Tree) Source() []byte { return t.source }
 
-// UsedForestFastPath reports whether this specific tree was produced by the
-// GSS-forest GLR fast path (Parser.Parse trying tryForestFastPath before the
-// production loop, or a direct ParseForestExperimental call) rather than the
-// production parser. Unlike LanguageWantsForest (which only reports whether a
-// language is eligible for the fast path), this reports what actually
-// happened for one parse: a forest-default language can still fall through to
-// production on any given input the forest declines. Exported so routing
-// regression gates can assert dispatch, not just engine capability.
+// UsedForestFastPath reports whether the node data behind this tree was
+// produced by the GSS-forest GLR fast path (Parser.Parse trying
+// tryForestFastPath before the production loop, or a direct
+// ParseForestExperimental call) rather than the production parser. Unlike
+// LanguageWantsForest (which only reports whether a language is eligible for
+// the fast path), this reports what actually produced the data for a FRESH
+// parse. It is provenance of the data, not necessarily of this exact call:
+// reuseTreeWithNewSource (incremental_leaf_fastpath.go) copies the field from
+// the old tree onto a new *Tree sharing the old root when reusing a tree
+// incrementally, so an incrementally-reused tree reports whichever route
+// produced the shared data, not whether this particular reuse call itself
+// dispatched to forest (it did not run parser dispatch at all). Regression
+// gates that always call Parser.Parse fresh (never ParseIncremental) are
+// unaffected by this distinction; callers mixing in incremental reuse should
+// not read this as "this call routed through forest."
 func (t *Tree) UsedForestFastPath() bool {
 	return t != nil && t.forestFastPath
 }

--- a/tree.go
+++ b/tree.go
@@ -2983,6 +2983,18 @@ func (t *Tree) RootNodeWithOffset(offsetBytes uint32, offsetExtent Point) *Node 
 // Source returns the original source text.
 func (t *Tree) Source() []byte { return t.source }
 
+// UsedForestFastPath reports whether this specific tree was produced by the
+// GSS-forest GLR fast path (Parser.Parse trying tryForestFastPath before the
+// production loop, or a direct ParseForestExperimental call) rather than the
+// production parser. Unlike LanguageWantsForest (which only reports whether a
+// language is eligible for the fast path), this reports what actually
+// happened for one parse: a forest-default language can still fall through to
+// production on any given input the forest declines. Exported so routing
+// regression gates can assert dispatch, not just engine capability.
+func (t *Tree) UsedForestFastPath() bool {
+	return t != nil && t.forestFastPath
+}
+
 // SourceEncoding returns the encoding used by the caller that produced this tree.
 //
 // For UTF-16 parses, Source still returns the parser's canonical UTF-8 copy.


### PR DESCRIPTION
## Summary

- Fix the false-clean byte-drop in `skippedRealGapContinuesSeparatedList`: a lexer-skipped gap now gets a transparent EXTRA `ERROR` leaf instead of a silent byte-offset bump. `HasError` now turns true and every byte gets a span.
- Fix a laundering defect this uncovered in `repairPythonKeywordErrorNode`: it was relabeling the new EXTRA `ERROR` leaves as fabricated clean tokens, erasing the error signal on python sources.
- Add `TestForestRegenGuardRepeatedTopLevelItems`, a default-on regen guard: for each forest-default language, N=1..20 repeated top-level items must keep **routing** through the GSS-forest fast path (`Tree.UsedForestFastPath()`, not just engine capability), and `Parse`'s own `MaxStacksSeen` must stay 0.
- The forest fast-path coverage regression itself (a table regen makes the forest engine decline earlier on long repeated-item lists) is diagnosed in full below but **not fixed** in this PR. See "Forest coverage regression" for why.

## Fix: gap materialization (parser.go)

`skippedRealGapContinuesSeparatedList` checked only "the just-shifted top is an anonymous childless leaf, and the real lookahead has exactly one non-extra shift" — not whether the position is actually inside a separated list. A lexer gap in that shape took the SHIFT-ACROSS branch: it advanced the byte offset with no node, leaving `HasError=false` and an unaccounted byte range.

The fix replaces the silent advance with `materializeSkippedGapAsExtraError`: it pushes a childless, EXTRA-flagged `ERROR` leaf spanning the gap, `parseState == state` (the caller's already-resolved deterministic-shift state, not a different recovery state), then advances exactly as before. Two existing, already-verified mechanisms make this safe:

- `reduceWindowFromGSS` already excludes EXTRA stack entries from a production's `ChildCount`, so the leaf never perturbs arity.
- `populateParentNode` already ORs children's `HasError` regardless of the Extra flag, so the error still bubbles to every ancestor.

Both mechanisms back `pushLexErrorRunLeaf`'s existing unlexable-run handling; this fix reuses their contract rather than inventing a new one. `skippedRealGapContinuesSeparatedList`'s own guard clauses are untouched; its synthetic-language unit tests pass unmodified. The function's own doc comment (previously describing the retired silent shift-across as current behavior) is corrected to describe `materializeSkippedGapAsExtraError`.

### Witness: `x = a..b;`

(Verified firing on both tables via `SetGLRTrace`; `const v0 == 1;`, used in an earlier revision of this PR, does not exercise this branch on the shipped table -- it hits a different, pre-existing recovery path there. Replaced.)

The "regenerated table" column below is evidence held **outside this branch**: no regenerated blob is committed here (per instructions, table-generation output is test-only, never a shipped artifact of this PR). To reproduce: from this branch's `cmd/grammargen`, run `go run ./cmd/grammargen emit javascript -bin /tmp/js-new.bin`, then point a parse at it via `GOTREESITTER_GRAMMARGEN_BLOB_DIR` (directory containing `javascript.bin`). The exact blob measured against for this table: 56994 bytes, sha256 `9dcc034feb4399b301531b77134d49d0366d543fc1e5cf89d94e8f8b3369ad19`, generated from this branch's HEAD.

| | shipped table, before | shipped table, after | regenerated table, before | regenerated table, after |
|---|---|---|---|---|
| `HasError` | **false** | **true** | **false** | **true** |
| the stray `.` at byte 6 | absorbed into `member_expression` with 3 children (C has 4 -- the byte is unaccounted for) | isolated `ERROR[6,7)`, EXTRA | same as shipped | same as shipped |

Identical behavior on both tables, before and after -- this construct does not depend on which table is loaded, only on this fix.

### C-oracle verdict (`cgo_harness`, `GTS_PARITY_ALLOW_HOST=1` + `GTS_PARITY_C_REF_BUILD_CACHE`)

Both tables, before this fix: `go_root HasError=false`, `c_root HasError=true` -- the false-clean hazard, node-for-node (`member_expression` ChildCount go=3 vs c=4).

Both tables, after this fix: `go_root HasError=true`, `c_root HasError=true` -- **verdict now matches C** on every table tested. Node shape still diverges: `ERROR` ChildCount go=0 vs c=1, same span `[6,7)` both sides.

### Honest framing: this is an accounting fix, not a shape fix

`HasError` now matches C's verdict, and the skipped bytes now have a span (no more "in no node's span" gap). The covering node's own shape does **not** match C's representation of the same stray:

- **Span**: this leaf's span is the whole lexer-skipped gap, which can include trivia C would not attribute to the stray. C's ERROR wraps only the stray token itself.
- **Children**: this leaf is childless. C typically wraps the stray as a child of its own `ERROR`/`error_repeat` node (confirmed on the witness above: ChildCount 0 vs 1, and separately on `const v0 == 1;`, same pattern).

Closing that gap needs re-lexing the skipped bytes to find the stray token's true bounds and giving the leaf that token as a child -- a real-corpus-plus-C-oracle verification pass of its own, filed as follow-up, not attempted here. Do not read this PR as delivering shape parity with C for these nodes; it delivers verdict parity (`HasError`) and byte-coverage.

### Changed-tree enumeration (real-corpus sites touched by this fix)

Instrumented the SHIFT-ACROSS branch across the full default `go test .` suite (2081 tests) to find every real-corpus site it fires on:

| source | sites | test | result |
|---|---|---|---|
| `testdata/incremental_gate/json_contract.json` | 315 | `TestIncrementalInvariantGateJSON` | pass, 0 new divergences |
| `testdata/incremental_gate/python_setup.py` | 70 | `TestIncrementalInvariantGatePython` | pass, 0 new divergences |
| `testdata/incremental_gate/javascript_grammar.js` | 10 | `TestIncrementalInvariantGateJavaScript` | pass, 0 new divergences |

395 sites total (corrected; an earlier revision of this PR mis-added this to 396). All now get an `ERROR` node instead of a silent skip. `TestIncrementalInvariantGate*`'s freshClean scope (by design) excludes any site where the fresh parse carries an `ERROR`/`MISSING` node from its strict structural-identity assertion, so these sites correctly move out of that assertion's scope rather than being compared incorrectly. Full suite: 2081/2081 pass, 0 failures, both before and after.

## Fix: python keyword-error laundering (parser_result_python.go)

`repairPythonKeywordErrorNode` relabels any **childless** `ERROR` node whose raw text matches an anonymous symbol's name (e.g. `.`) into a plain leaf of that symbol -- and does not restore `HasError` on the replacement, only `Extra`. The new EXTRA `ERROR` leaf from the fix above is exactly that shape, so on python sources it was being laundered into a clean-looking, fabricated token: the error signal this PR was built to preserve was erased downstream, on python specifically.

Repro: `testdata/incremental_gate/python_setup.py` with byte 834 deleted (`*.queries: [*.scm` region) produced a fabricated `.` leaf, `extra=true`, `hasError=false` -- C emits nothing of the sort at that position.

Fix: exclude EXTRA `ERROR` leaves from this repair (`!node.isExtra()` added to the existing childless-ERROR check). Non-extra childless `ERROR` leaves -- the shape this repair exists for -- are unaffected. Checked against the STOP RULE for this change (excluding EXTRA leaves must not break any existing python test, since the repair could be load-bearing for a real witness class): every python-named test in the repo (`TestRepairPython*`, `TestNormalizePython*`, `TestIncrementalInvariantGatePython`, plus the full default suite) passes unchanged. With the fix, the same repro now produces a correctly nested `ERROR` node, with `HasError` propagating through the reduce-built ancestors above it (`attribute` → `binary_operator` → `ERROR` → `dictionary` → `keyword_argument`) instead of the pre-fix flattened, fully error-erased shape.

That propagation does **not** reach the module/root node in this repro: `keyword_argument.HasError()` is true, `module.HasError()` (the parse root) is false. Root-cause: `parser_result_root_build.go`'s `syntheticRootCanDropError` / `pythonModuleChildrenLookComplete`, a pre-existing, python-only convention (unchanged by this PR, present on `origin/main`) that suppresses the root's `HasError` when the top-level module children structurally "look complete" -- and this fix's own correction (proper nesting instead of the flattened laundered shape) makes that precondition trigger *more* reliably than before, since the module now looks structurally complete more often.

Measured, cross-checked in review: (a) root-level `HasError()` accuracy against C across the reviewed corpus went `main` 45/94 correct -> this PR's first revision 83/94 -> this revision 80/94 -- a 3-site regression from the first revision, still a net +35 over `main`. (b) The underlying mechanism is not new: the same pre-existing python root-suppression convention has 746 witnesses on `origin/main` by itself, independent of this PR entirely. This PR's 3 sites join that pre-existing class rather than introducing a new one, and the class is filed as separate, tracked finding-level work, not fixed here. `TestIncrementalInvariantGate*` cannot see any of this: it deliberately scopes by `IsError()`/`IsMissing()` node-type checks, never `Node.HasError()` (see that file's own doc comment) -- it caught neither the pre-existing 746-witness class nor this revision's 3-site interaction with it.

## Fix: regen guard now asserts routing, not just engine capability

The guard called `ParseForestExperimental` directly, which never checks `glrForestEnabled` (`GOT_GLR_FOREST`) or per-language eligibility -- it is a diagnostic entry point that always tries the forest engine regardless of whether `Parser.Parse` would ever route there. Verified directly: with `GOT_GLR_FOREST=0` (forest disabled entirely), `MaxStacksSeen` still reads 0 for N=1..20 on this corpus via plain production -- so neither original assertion actually distinguished "forest is routing" from "forest never tried, but production alone happens to be cheap here."

Fix: added `Tree.UsedForestFastPath()` (a small exported accessor over the tree's existing `forestFastPath` bookkeeping, set identically by both `Parse`'s internal dispatch and `ParseForestExperimental`). The guard now calls `Parser.Parse` (the real dispatch entry point) and asserts `UsedForestFastPath()` is true, falling back to a `ParseForestExperimental` diagnostic call only to report a decline reason on failure. Verified the distinction is real: with `GOT_GLR_FOREST=0`, the revised guard now correctly fails at N=1 (`forest engine standalone ok=true` but `Parse` did not route) -- the exact case the old assertions missed.

Also fixed: the dirty-baseline path was a `t.Skipf`, which would silently disable the guard for a language whose established generator's own trivial 2-item baseline breaks -- exactly the "table resync corrupts the trivial corpus" scenario the guard exists to catch. Changed to `t.Fatalf`. A genuinely missing generator (a forest-default language with no entry yet) still skips, since no coverage claim is being made there.

Also fixed (cheap, same pass): `parserWantsForest` now delegates to the exported `LanguageWantsForest` instead of duplicating its expression; both doc comments now say "in the forest-default set" and note they do not account for the `glrForestEnabled` global switch; `perfRecordErrorNode()` added under `perfCountersEnabled` in the new leaf path for parity with `pushLexErrorRunLeaf`; a dead `p != nil` guard removed (the same function dereferences `p` unconditionally two lines later); the stray `cmd/grammargen` doc reference removed.

## Forest coverage regression: root-caused, not fixed

The regenerated javascript table's GSS-forest fast path declines earlier than the shipped table on long runs of repeated top-level items (shipped: clean through at least 500 items; regenerated: declines at item 11, `eof_no_root`), forcing the whole file through the slower production loop.

Root cause, confirmed by direct instrumentation of the forest reduce worklist (temporary, not included in this PR): tree-sitter's binary repeat auxiliary rule (`X_repeat1 -> X_repeat1 X_repeat1 | element`) is combinatorially associativity-ambiguous. The regenerated table's states let the forest's graph-structured stack retain every outermost split point of the item list as a tied alternative (same score, same error cost) at one coalesced node. That fan-out is capped at `forestMaxLinksPerNode` (8); once the list has more than 8 valid split points, the cap's eviction policy can drop the one alternative whose ancestor chain actually reaches the accept state. (An earlier suspect, a real reduce/reduce action conflict, was ruled out directly: zero such conflicts fire on a parens-free repeated-item corpus that still reproduces the decline.)

Raising the cap is tree-safe where it succeeds -- verified byte-for-byte identical to the production route across 827 fingerprinted nodes (N = 1, 5, 10, 11, 15, 20, 25, 30) -- but does not scale: a cap of 32 only survives to roughly 40 items, and the W5 137KB fixture (several thousand items) needs far more; an effectively unbounded cap crashes the process outright on that fixture. The shipped table never produces this fan-out at all (clean through 500 items at the current cap of 8), so no single constant serves both a small regression-gate corpus and a 137KB file.

A complete fix needs the forest coalescer's existing same-`(prev, symbol, span)` hidden-node dedup (added for the sibling `X_repeat1`-grouping case) generalized to match across *different* `prev` when `(symbol, span)` still ties -- the coalescer's own comment flags exactly that generalization as unproven. That needs the same real-corpus-plus-C-oracle verification its narrower predecessor used, which is out of scope here.

## Gate: `TestForestRegenGuardRepeatedTopLevelItems`

Default-on (no opt-in flag), runs against whatever blobs are currently embedded. For every language `LanguageWantsForest` reports as forest-default (11 today), it parses N=1..20 repeated top-level items and asserts:

- `Parser.Parse` (not just the forest engine in isolation) routes through the forest fast path, and
- `Parse`'s own `MaxStacksSeen` stays 0 on the same input.

Verified both directions:

| blob | result |
|---|---|
| shipped `javascript.bin` | green, all 11 languages |
| regenerated table (evidence witness; same blob as the witness section above -- `go run ./cmd/grammargen emit javascript -bin /tmp/js-new.bin`, sha256 `9dcc034feb4399b301531b77134d49d0366d543fc1e5cf89d94e8f8b3369ad19`, held outside this branch) | fails with `N=11: Parse did not route through the forest fast path (... reason="eof_no_root" ...)` |

Each language's generator self-validates against a small clean baseline before the sweep trusts it; a missing generator skips, but a broken baseline for an established one now fails the build (see above).

## Verification

- `go test . -count=1`: 2081/2081 pass (before and after every change in this PR, including this revision).
- `go test ./grammars -count=1`: pass.
- `go test -tags gts_parsercorephase0 -run TestDiagnosticParserCoreCanonicalAdmissions`: pass (canonical digests unchanged; this fix does not touch the compact/admission-candidate route).
- `go test -tags gts_parsercorephase0 -run 'TestAdmissionCandidateNoLookaheadSmokeRatchet|TestAdmissionCandidateCooklangSmokeRatchet|TestAdmissionSwitchRoutePrecedenceRatchet'`: pass.
- `go test -race` on every touched-path test (shift-gap and materialize unit tests, the FIDL recovery-shape test, every `TestRepairPython*`/`TestNormalizePython*`, the regen guard, `TestIncrementalInvariantGate{JavaScript,JSON,Python}`, `TestW5JavaScriptFamilyTransientErrorGate`): pass, no race reports.
- `TestW5JavaScriptFamilyTransientErrorGate`: green on the shipped blob (both size tiers). Against the regenerated table, the 137KB tier still exceeds its allocation ceiling -- this is the forest coverage regression described above, unresolved in this PR, unaffected by this revision.
- C-oracle parity (`cgo_harness`, `treesitter_c_parity`): see the witness table above.

## Not merged

Left open per instructions.

