### PR TITLE
fix(parsercore): decline material tied acceptance elections

### DIFF
--- a/admission_census.go
+++ b/admission_census.go
@@ -128,6 +128,14 @@ const (
 	// publish a clean tree while production and the locked C oracle both
 	// report an error for the same input.
 	censusMechanismAcceptedRootLeadingGap admissionCensusMechanism = "accepted-root-leading-gap"
+	// censusMechanismMaterialAcceptanceElection: the accepted head carried a
+	// tied compact acceptance election (selectCompactAcceptanceDerivation's
+	// score-tie guard, gated by compactAcceptanceElectionIsVacuous in
+	// parsercore_phase0_driver.go) with more than one live derivation, and
+	// materializing every one of them did not prove they all publish the
+	// same tree. The route declines instead of admitting the positional
+	// primary derivation; production still serves the input.
+	censusMechanismMaterialAcceptanceElection admissionCensusMechanism = "material-acceptance-election"
 	// censusMechanismOther is the catch-all for a decline this classifier
 	// does not yet recognize. The full original detail is always preserved
 	// alongside it.
@@ -195,6 +203,8 @@ func admissionCensusClassify(boundary DiagnosticParserCoreBoundaryKind, detail s
 			return censusMechanismAcceptedLeafTilingGap
 		case strings.Contains(detail, "accepted-root-leading-gap"):
 			return censusMechanismAcceptedRootLeadingGap
+		case strings.Contains(detail, "material-acceptance-election"):
+			return censusMechanismMaterialAcceptanceElection
 		default:
 			return censusMechanismSchedulerShape
 		}

--- a/admission_census_internal_test.go
+++ b/admission_census_internal_test.go
@@ -2,7 +2,10 @@
 
 package gotreesitter
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestAdmissionCensusSeparatesNoTableActionFromPausedFrontier(t *testing.T) {
 	if got := admissionCensusClassify(
@@ -17,4 +20,50 @@ func TestAdmissionCensusSeparatesNoTableActionFromPausedFrontier(t *testing.T) {
 	); got != censusMechanismSchedulerShape {
 		t.Fatalf("paused-frontier mechanism=%q", got)
 	}
+}
+
+// TestAdmissionCensusClassifiesMaterialAcceptanceElection pins the census
+// mechanism the R1 materiality gate's two decline reasons classify into
+// (compactAcceptanceElectionMaterialDetail and
+// compactAcceptanceElectionCandidateCapDetail, parsercore_phase0_driver.go):
+// both share the DiagnosticParserCoreAccept boundary and both contain the
+// "material-acceptance-election" substring, so both must classify the same
+// way, distinct from the pre-existing accepted-leaf-tiling-gap and
+// accepted-root-leading-gap cases on the same boundary.
+func TestAdmissionCensusClassifiesMaterialAcceptanceElection(t *testing.T) {
+	if got := admissionCensusClassify(
+		DiagnosticParserCoreAccept, compactAcceptanceElectionMaterialDetail,
+	); got != censusMechanismMaterialAcceptanceElection {
+		t.Fatalf("material-election mechanism=%q, want %q", got, censusMechanismMaterialAcceptanceElection)
+	}
+	if got := admissionCensusClassify(
+		DiagnosticParserCoreAccept, compactAcceptanceElectionCandidateCapDetail,
+	); got != censusMechanismMaterialAcceptanceElection {
+		t.Fatalf("candidate-cap mechanism=%q, want %q", got, censusMechanismMaterialAcceptanceElection)
+	}
+	// A soft decline wraps the recorded Stop detail as "did not accept EOF:
+	// <detail>" (admissionCensusStopDecline) before this classifier ever
+	// sees it; the substring match must still hit through that prefix.
+	if got := admissionCensusClassify(
+		DiagnosticParserCoreAccept, "did not accept EOF: "+compactAcceptanceElectionMaterialDetail,
+	); got != censusMechanismMaterialAcceptanceElection {
+		t.Fatalf("wrapped material-election mechanism=%q, want %q", got, censusMechanismMaterialAcceptanceElection)
+	}
+	if got := admissionCensusClassify(DiagnosticParserCoreAccept, "accepted-leaf-tiling-gap: unrelated"); got != censusMechanismAcceptedLeafTilingGap {
+		t.Fatalf("leaf-tiling-gap mechanism=%q, want %q (regression check: still distinct)", got, censusMechanismAcceptedLeafTilingGap)
+	}
+}
+
+// ResetAdmissionCensusEnabledForTest clears the cached GTS_ADMISSION_CENSUS
+// read (admissionCensusEnabled's sync.Once) so a test that sets the
+// environment variable with t.Setenv sees it take effect immediately,
+// regardless of whether an earlier test in the same binary already read and
+// cached a value. Call it again (for example via t.Cleanup) after restoring
+// the environment variable, so later tests re-read rather than inherit this
+// test's cached value. Never copies the sync.Once (which would trip
+// go vet's copylocks check); it only replaces the package-level variable
+// with a fresh zero value.
+func ResetAdmissionCensusEnabledForTest() {
+	admissionCensusEnabledOnce = sync.Once{}
+	admissionCensusEnabledVal = false
 }

--- a/admission_census_internal_test.go
+++ b/admission_census_internal_test.go
@@ -23,13 +23,15 @@ func TestAdmissionCensusSeparatesNoTableActionFromPausedFrontier(t *testing.T) {
 }
 
 // TestAdmissionCensusClassifiesMaterialAcceptanceElection pins the census
-// mechanism the R1 materiality gate's two decline reasons classify into
-// (compactAcceptanceElectionMaterialDetail and
-// compactAcceptanceElectionCandidateCapDetail, parsercore_phase0_driver.go):
-// both share the DiagnosticParserCoreAccept boundary and both contain the
-// "material-acceptance-election" substring, so both must classify the same
-// way, distinct from the pre-existing accepted-leaf-tiling-gap and
-// accepted-root-leading-gap cases on the same boundary.
+// mechanism the R1 materiality gate's three decline reasons classify into
+// (compactAcceptanceElectionMaterialDetail,
+// compactAcceptanceElectionCandidateCapDetail, and
+// compactAcceptanceElectionNoContextDetail, parsercore_phase0_driver.go):
+// all three share the DiagnosticParserCoreAccept boundary and all three
+// contain the "material-acceptance-election" substring, so all three must
+// classify the same way, distinct from the pre-existing
+// accepted-leaf-tiling-gap and accepted-root-leading-gap cases on the same
+// boundary.
 func TestAdmissionCensusClassifiesMaterialAcceptanceElection(t *testing.T) {
 	if got := admissionCensusClassify(
 		DiagnosticParserCoreAccept, compactAcceptanceElectionMaterialDetail,
@@ -40,6 +42,14 @@ func TestAdmissionCensusClassifiesMaterialAcceptanceElection(t *testing.T) {
 		DiagnosticParserCoreAccept, compactAcceptanceElectionCandidateCapDetail,
 	); got != censusMechanismMaterialAcceptanceElection {
 		t.Fatalf("candidate-cap mechanism=%q, want %q", got, censusMechanismMaterialAcceptanceElection)
+	}
+	if got := admissionCensusClassify(
+		DiagnosticParserCoreAccept, compactAcceptanceElectionNoContextDetail,
+	); got != censusMechanismMaterialAcceptanceElection {
+		t.Fatalf("no-context mechanism=%q, want %q", got, censusMechanismMaterialAcceptanceElection)
+	}
+	if compactAcceptanceElectionNoContextDetail == compactAcceptanceElectionMaterialDetail {
+		t.Fatalf("no-context detail must be distinct wording from the ran-a-comparison detail")
 	}
 	// A soft decline wraps the recorded Stop detail as "did not accept EOF:
 	// <detail>" (admissionCensusStopDecline) before this classifier ever

--- a/admission_scorecard_test.go
+++ b/admission_scorecard_test.go
@@ -81,7 +81,7 @@ var admissionScorecardRequiredCompactPasses = map[string]struct{}{
 	"hlsl": {}, "html": {}, "http": {}, "hurl": {}, "hyprlang": {}, "ini": {}, "janet": {}, "javascript": {}, "jinja2": {}, "jq": {}, "jsdoc": {},
 	"json5": {}, "jsonnet": {}, "julia": {}, "just": {}, "kconfig": {}, "kdl": {}, "kotlin": {},
 	"ledger": {}, "less": {}, "linkerscript": {}, "liquid": {}, "llvm": {}, "lua": {},
-	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "meson": {}, "mojo": {},
+	"luau": {}, "make": {}, "markdown": {}, "matlab": {}, "mermaid": {}, "mojo": {},
 	"move": {}, "nginx": {}, "nickel": {}, "nim": {}, "ninja": {}, "nix": {}, "norg": {}, "nushell": {},
 	"objc": {}, "ocaml": {}, "odin": {}, "org": {}, "pascal": {}, "pem": {}, "perl": {},
 	"php": {}, "pkl": {}, "powershell": {}, "prisma": {}, "prolog": {}, "promql": {},
@@ -146,10 +146,23 @@ func TestAdmissionCandidateScorecard206(t *testing.T) {
 		// welcome (more PASS, fewer FALLBACK); silent correctness failures,
 		// registry drift, or surrendered route coverage require an explicit
 		// review and ratchet update.
+		//
+		// minPass moved 200 -> 199 and maxFallback 1 -> 2 when
+		// selectCompactAcceptanceDerivation's materiality gate
+		// (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous)
+		// landed: meson's smoke sample ("message('hello')") has a genuine,
+		// score-tied grammar ambiguity between two distinct real symbols
+		// (variableunit and var_unit -- both present in the compiled
+		// language's SymbolNames). The old positional rule happened to pick
+		// the derivation that matches production; the gate cannot prove that
+		// pick correct without a C oracle, so it now declines instead of
+		// publishing an unproven tree, and the route falls back to
+		// production (still a PASS-safe FALLBACK, never a DIVERGE -- see
+		// counts[scorecardDiverge] below, unaffected at 0).
 		const (
 			wantTotal   = 206
-			minPass     = 200
-			maxFallback = 1
+			minPass     = 199
+			maxFallback = 2
 			wantSkip    = 5
 		)
 		if got := len(admissionScorecardRequiredCompactPasses); got != minPass {

--- a/admission_switch_a3_arm_noop_confirmation_test.go
+++ b/admission_switch_a3_arm_noop_confirmation_test.go
@@ -43,8 +43,19 @@ import (
 // workstream certifies.
 //
 // Follow-up arm-deletion PRs for perl, python, and ada must not treat this
-// finding's retirement precondition as met on this evidence; apex's
-// arm-deletion follow-on can cite this receipt directly.
+// finding's retirement precondition as met on this evidence.
+//
+// UPDATE: apex's witness no longer confirms. selectCompactAcceptanceDerivation's
+// materiality gate (parsercore_phase0_driver.go,
+// compactAcceptanceElectionIsVacuous) found the class_literal_alias witness's
+// two tied derivations are not byte-identical (one assigns the "object"
+// field, the other does not), so the compact route now declines it instead
+// of publishing an unproven pick. With the route no longer originating a
+// tree for this witness, the raw-vs-tailed comparison this file's method
+// depends on no longer applies -- see
+// TestA3ArmNoOpConfirmationApexClassLiteralDeclinesAsMaterialElection. Apex's
+// arm-deletion follow-on needs a different witness or a direct review before
+// it can still cite this receipt.
 //
 // This does NOT affect A3's own certification landing. The certified
 // languages' full-corpus sweeps (cgo_harness a3_certification_sweep
@@ -53,13 +64,62 @@ import (
 // divergence there. The no-op question is a separate, later concern: only
 // whether the arm itself can be deleted.
 
-func TestA3ArmNoOpConfirmationApexConfirms(t *testing.T) {
+// TestA3ArmNoOpConfirmationApexClassLiteralDeclinesAsMaterialElection
+// supersedes this file's original apex "confirms no-op" receipt for the
+// class_literal_alias witness. selectCompactAcceptanceDerivation's
+// materiality gate (parsercore_phase0_driver.go,
+// compactAcceptanceElectionIsVacuous) found this witness's two tied
+// derivations are not byte-identical -- one assigns the "object" field to
+// its first child, the other does not -- so the compact route now declines
+// this witness (fail-closed) instead of publishing the positional primary,
+// and falls back to production on both the raw and tailed probes.
+//
+// The route no longer originates a tree here at all, so the raw-vs-tailed
+// "arm no-op" comparison this file's method depends on no longer applies to
+// this witness: with neither side routed, any raw/tailed difference would
+// only be re-measuring production's own noResultCompatibilityBenchmarkOnly
+// behavior, not the compact route's. The apex arm's retirement evidence
+// (this file's original RESULT note) needs a different witness or a direct
+// review before it can still be cited; this test only pins the corrected
+// admission outcome, not an arm no-op finding.
+func TestA3ArmNoOpConfirmationApexClassLiteralDeclinesAsMaterialElection(t *testing.T) {
 	source := []byte("public class C {\n  void m() {\n    Object t = RecordPage.class;\n  }\n}\n")
 	lang := grammars.ApexLanguage()
 	if !lang.CompactPrimaryAcceptanceDerivationCertified {
 		t.Fatal("apex did not receive its A3 certification")
 	}
-	assertA3ArmNoOp(t, "apex/class_literal_alias", lang, source, true)
+
+	for _, tt := range []struct {
+		name                    string
+		noResultCompatOnlyProbe bool
+	}{
+		{"tailed", false},
+		{"raw", true},
+	} {
+		gts.ResetAdmissionCandidateCountersForTest()
+		p := gts.NewParser(lang)
+		p.SetAdmissionCandidateRoute(true)
+		var restore func()
+		if tt.noResultCompatOnlyProbe {
+			restore = gts.SetNoResultCompatibilityBenchmarkOnlyForTest(p, true)
+		}
+		tree, err := p.Parse(source)
+		if restore != nil {
+			restore()
+		}
+		if err != nil {
+			t.Fatalf("apex/class_literal_alias %s: parse: %v", tt.name, err)
+		}
+		tree.Release()
+		routed, fallback := gts.AdmissionCandidateCounters()
+		if routed != 0 || fallback != 1 {
+			t.Fatalf(
+				"apex/class_literal_alias %s: route counters routed=%d fallback=%d, want 0/1 "+
+					"(the materiality gate should decline this material election); reason=%s",
+				tt.name, routed, fallback, gts.AdmissionCandidateLastFallbackReason(),
+			)
+		}
+	}
 }
 
 func TestA3ArmNoOpConfirmationPerlDoesNotConfirm(t *testing.T) {
@@ -129,9 +189,26 @@ func TestA3ArmNoOpConfirmationTrivialWitnessesAreVacuouslyNoOp(t *testing.T) {
 // no-op status matches wantNoOp exactly (a Fatal either way -- a status
 // flip in either direction changes the campaign's retirement evidence and
 // must be investigated, not silently accepted).
+//
+// Tailed (normal) must route through the compact route: a tailed fallback
+// means the witness is a material election under
+// selectCompactAcceptanceDerivation's materiality gate
+// (compactAcceptanceElectionIsVacuous) and needs its own dedicated test (see
+// TestA3ArmNoOpConfirmationApexClassLiteralDeclinesAsMaterialElection), not
+// this shared no-op probe.
+//
+// Raw (SetNoResultCompatibilityBenchmarkOnlyForTest) suppresses the compat
+// arm entirely, including during the gate's own comparison (Node.RootNode
+// applies the compat finalizer, so the gate's tailed-mode comparison already
+// runs post-arm; suppressing the arm removes whatever convergence it
+// provided). If raw then declines while tailed still routes, the arm was
+// exactly what let the election resolve at all -- unambiguous evidence it is
+// not a no-op, so this counts as gotNoOp=false without attempting the SExpr
+// comparison (there is no raw compact-route tree to compare).
 func assertA3ArmNoOp(t *testing.T, name string, lang *gts.Language, source []byte, wantNoOp bool) {
 	t.Helper()
 
+	gts.ResetAdmissionCandidateCountersForTest()
 	tailed := gts.NewParser(lang)
 	tailed.SetAdmissionCandidateRoute(true)
 	tailedTree, err := tailed.Parse(source)
@@ -139,20 +216,39 @@ func assertA3ArmNoOp(t *testing.T, name string, lang *gts.Language, source []byt
 		t.Fatalf("%s: tailed parse: %v", name, err)
 	}
 	defer tailedTree.Release()
+	if routed, fallback := gts.AdmissionCandidateCounters(); routed != 1 || fallback != 0 {
+		t.Fatalf("%s: tailed parse did not route through the compact route (routed=%d fallback=%d reason=%q)",
+			name, routed, fallback, gts.AdmissionCandidateLastFallbackReason())
+	}
 
+	gts.ResetAdmissionCandidateCountersForTest()
 	raw := gts.NewParser(lang)
 	raw.SetAdmissionCandidateRoute(true)
 	restore := gts.SetNoResultCompatibilityBenchmarkOnlyForTest(raw, true)
-	defer restore()
 	rawTree, err := raw.Parse(source)
+	restore()
 	if err != nil {
 		t.Fatalf("%s: raw parse: %v", name, err)
 	}
 	defer rawTree.Release()
+	routed, fallback := gts.AdmissionCandidateCounters()
+	if routed != 1 && fallback != 1 {
+		t.Fatalf("%s: ambiguous raw route counters routed=%d fallback=%d", name, routed, fallback)
+	}
 
 	tailedSExpr := tailedTree.RootNode().SExpr(lang)
-	rawSExpr := rawTree.RootNode().SExpr(lang)
-	gotNoOp := tailedSExpr == rawSExpr
+	var gotNoOp bool
+	var rawSExpr string
+	if routed == 1 {
+		rawSExpr = rawTree.RootNode().SExpr(lang)
+		gotNoOp = tailedSExpr == rawSExpr
+	} else {
+		// Raw declined (the arm's absence made the election unresolvable):
+		// definitively not a no-op, and there is no raw compact-route tree
+		// to compare against tailed's.
+		rawSExpr = "<declined: " + gts.AdmissionCandidateLastFallbackReason() + ">"
+		gotNoOp = false
+	}
 	if gotNoOp != wantNoOp {
 		t.Fatalf(
 			"%s: arm no-op status changed (compact-raw==compact-tailed is now %t, want %t) -- "+

--- a/admission_switch_a3_arm_noop_confirmation_test.go
+++ b/admission_switch_a3_arm_noop_confirmation_test.go
@@ -61,7 +61,12 @@ import (
 // languages' full-corpus sweeps (cgo_harness a3_certification_sweep
 // pattern) compare the real shipped Parse() output, which always applies
 // the compat tail regardless of route, and found zero unadjudicated
-// divergence there. The no-op question is a separate, later concern: only
+// divergence there beyond the enumerated, tracked pre-existing
+// production-route defects each sweep file carries (perlA3KnownDivergences,
+// pythonA3KnownDivergences, adaA3KnownDivergences; apex carries none). Those
+// defects reproduce with the compact route disabled, so the compact route
+// contributes nothing to them; they are unrelated to this file's own arm
+// no-op question. The no-op question is a separate, later concern: only
 // whether the arm itself can be deleted.
 
 // TestA3ArmNoOpConfirmationApexClassLiteralDeclinesAsMaterialElection
@@ -232,8 +237,12 @@ func assertA3ArmNoOp(t *testing.T, name string, lang *gts.Language, source []byt
 	}
 	defer rawTree.Release()
 	routed, fallback := gts.AdmissionCandidateCounters()
-	if routed != 1 && fallback != 1 {
-		t.Fatalf("%s: ambiguous raw route counters routed=%d fallback=%d", name, routed, fallback)
+	// Exactly one of routed/fallback must be 1: (routed == 1) == (fallback
+	// == 1) is true both when neither fired (0, 0; no parse reached a
+	// terminal outcome) and when both did (1, 1; a double count), and false
+	// only in the two valid, mutually exclusive outcomes (1, 0) and (0, 1).
+	if (routed == 1) == (fallback == 1) {
+		t.Fatalf("%s: ambiguous raw route counters routed=%d fallback=%d, want exactly one to be 1", name, routed, fallback)
 	}
 
 	tailedSExpr := tailedTree.RootNode().SExpr(lang)

--- a/admission_switch_acceptance_frontier_test.go
+++ b/admission_switch_acceptance_frontier_test.go
@@ -11,7 +11,15 @@ import (
 )
 
 func TestAdmissionCandidateCertifiedAcceptanceFrontiers(t *testing.T) {
-	for _, name := range []string{"http", "robot", "meson"} {
+	// meson is not in this list: its smoke sample has a genuine, score-tied
+	// grammar ambiguity (variableunit vs var_unit) that
+	// selectCompactAcceptanceDerivation's materiality gate
+	// (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous) can
+	// no longer prove correct without a C oracle, so the route now declines
+	// and falls back to production instead of publishing an unproven pick.
+	// See admission_scorecard_test.go's admissionScorecardRequiredCompactPasses
+	// comment for the full account.
+	for _, name := range []string{"http", "robot"} {
 		t.Run(name, func(t *testing.T) {
 			entry := grammars.DetectLanguageByName(name)
 			if entry == nil {

--- a/admission_switch_kotlin_certification_withheld_test.go
+++ b/admission_switch_kotlin_certification_withheld_test.go
@@ -93,6 +93,15 @@ func TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe(t *testing.T)
 // declines the compact route instead of publishing the wrong one, and the
 // route falls back to production's (C-oracle-matching, see the cgo_harness
 // companion receipt) object_declaration parse.
+//
+// The route counters alone only prove "some soft decline happened" -- the
+// generic "did not accept EOF" fallback reason is shared by every soft
+// decline, not specific to this gate. GTS_ADMISSION_CENSUS=1
+// (ResetAdmissionCensusEnabledForTest clears the cached env read so setting
+// it here reliably takes effect) surfaces the classified mechanism tag, so
+// this asserts mechanism=material-acceptance-election specifically: proof
+// this decline came from the materiality gate, not some other soft-decline
+// path that also contains "did not accept EOF".
 func TestKotlinCompactCertificationObjectDeclarationRegressionWithheld(t *testing.T) {
 	source := []byte("package demo\n\nobject Singleton {\n    fun work() = Unit\n}\n")
 	lang := grammars.KotlinLanguage()
@@ -119,6 +128,10 @@ func TestKotlinCompactCertificationObjectDeclarationRegressionWithheld(t *testin
 		lang.CompactPrimaryAcceptanceDerivationCertified = false
 	}()
 
+	t.Setenv("GTS_ADMISSION_CENSUS", "1")
+	gts.ResetAdmissionCensusEnabledForTest()
+	t.Cleanup(gts.ResetAdmissionCensusEnabledForTest)
+
 	gts.ResetAdmissionCandidateCountersForTest()
 	candidate := gts.NewParser(lang)
 	candidate.SetAdmissionCandidateRoute(true)
@@ -137,15 +150,26 @@ func TestKotlinCompactCertificationObjectDeclarationRegressionWithheld(t *testin
 			routed, fallback, gts.AdmissionCandidateLastFallbackReason(),
 		)
 	}
-	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "did not accept EOF") {
-		t.Fatalf("forced-both-certificates fallback reason changed unexpectedly: %s", reason)
-	}
-	candidateSExpr := candidateTree.RootNode().SExpr(lang)
-	if candidateSExpr != productionSExpr {
+	reason := gts.AdmissionCandidateLastFallbackReason()
+	if !strings.Contains(reason, "mechanism=material-acceptance-election") {
 		t.Fatalf(
-			"forced-both-certificates candidate tree (fallback to production) = %s, want production's object_declaration tree %s",
-			candidateSExpr, productionSExpr,
+			"forced-both-certificates fallback reason does not classify as the materiality gate "+
+				"(want mechanism=material-acceptance-election): %s", reason,
 		)
 	}
-	t.Logf("confirmed: the materiality gate declines this material election (two derivations, two different trees) instead of publishing the positional primary; production's object_declaration tree is served: %s", candidateSExpr)
+	// Sanity check only, not a correctness proof: a decline falls back to
+	// production, so the served tree is production's own parse of the same
+	// source, computed identically above. This can only fail if production
+	// parsing itself is non-deterministic across two fresh parsers, a much
+	// larger and separately-tested property (TestW5DeterminismAcrossFreshParsers).
+	candidateSExpr := candidateTree.RootNode().SExpr(lang)
+	t.Logf(
+		"confirmed: the materiality gate declines this material election (two derivations, two "+
+			"different trees, reason=%s) instead of publishing the positional primary; production's "+
+			"object_declaration tree is served: %s",
+		reason, candidateSExpr,
+	)
+	if candidateSExpr != productionSExpr {
+		t.Fatalf("fallback tree = %s, want production's object_declaration tree %s (production parse non-determinism?)", candidateSExpr, productionSExpr)
+	}
 }

--- a/admission_switch_kotlin_certification_withheld_test.go
+++ b/admission_switch_kotlin_certification_withheld_test.go
@@ -21,21 +21,28 @@ import (
 // TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe pins that.
 //
 // Combining CompactConvergedReductionSplitDropsCertified with
-// CompactPrimaryAcceptanceDerivationCertified -- the certification pair the
-// finding asks for -- regresses a distinct, pre-existing witness:
-// TestKotlinTopLevelObjectParsesAsDeclaration (issue #93,
-// query_kotlin_object_declaration_test.go). With both flags on, the compact
-// route accepts "object Singleton { fun work() = Unit }" as
+// CompactPrimaryAcceptanceDerivationCertified used to regress a distinct,
+// pre-existing witness: TestKotlinTopLevelObjectParsesAsDeclaration (issue
+// #93, query_kotlin_object_declaration_test.go). With both flags on, the
+// compact route used to accept "object Singleton { fun work() = Unit }" as
 // infix_expression(object_literal, Singleton, lambda_literal) instead of
-// object_declaration. The C oracle sides with production's
+// object_declaration, even though the C oracle sides with production's
 // object_declaration
 // (cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go).
-// This is a genuine divergence, not an adjudicated exception, so neither
-// certificate lands for Kotlin in grammars/runtime_profiles.go: the
-// "kotlin" map entry stays at its pre-A3 shape.
+//
+// selectCompactAcceptanceDerivation's materiality gate
+// (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous) closes
+// this exact shape: the two derivations at this witness's accepted head
+// materialize to different trees, so the election is material and the
+// compact route now declines and falls back to production instead of
+// publishing the wrong one. TestKotlinCompactCertificationObjectDeclarationRegressionWithheld
+// below pins the corrected (declining) behavior. Kotlin's certification
+// still does not land in grammars/runtime_profiles.go: an unrelated
+// witness (annotated_declaration, a derivation-coverage gap rather than an
+// election error) remains open.
 //
 // This file pins both halves of the finding (the safe grant and the
-// regressing combination) so a future attempt to land Kotlin's
+// now-safely-declining combination) so a future attempt to land Kotlin's
 // certification is checked against this exact counterexample.
 
 // TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe confirms
@@ -77,12 +84,15 @@ func TestKotlinCompactCertificationPlatformModifierSplitOnlyIsSafe(t *testing.T)
 	}
 }
 
-// TestKotlinCompactCertificationObjectDeclarationRegressionWithheld
-// reproduces the counterexample that blocks Kotlin's A3 certification: with
-// both CompactConvergedReductionSplitDropsCertified and
-// CompactPrimaryAcceptanceDerivationCertified forced on, the compact route
-// accepts a tree that diverges from production's (C-oracle-matching, see
-// the cgo_harness companion receipt) object_declaration parse.
+// TestKotlinCompactCertificationObjectDeclarationRegressionWithheld pins the
+// corrected behavior on the counterexample that used to block Kotlin's A3
+// certification: with both CompactConvergedReductionSplitDropsCertified and
+// CompactPrimaryAcceptanceDerivationCertified forced on, the accepted head
+// carries two derivations that materialize to different trees (a material
+// election), so selectCompactAcceptanceDerivation's materiality gate now
+// declines the compact route instead of publishing the wrong one, and the
+// route falls back to production's (C-oracle-matching, see the cgo_harness
+// companion receipt) object_declaration parse.
 func TestKotlinCompactCertificationObjectDeclarationRegressionWithheld(t *testing.T) {
 	source := []byte("package demo\n\nobject Singleton {\n    fun work() = Unit\n}\n")
 	lang := grammars.KotlinLanguage()
@@ -119,26 +129,23 @@ func TestKotlinCompactCertificationObjectDeclarationRegressionWithheld(t *testin
 	defer candidateTree.Release()
 
 	routed, fallback := gts.AdmissionCandidateCounters()
-	if routed != 1 || fallback != 0 {
+	if routed != 0 || fallback != 1 {
 		t.Fatalf(
-			"forced-both-certificates candidate route counters = %d/%d, want 1/0 "+
-				"(if this now declines instead of accepting a wrong tree, re-check whether "+
-				"the certification pair is safe to land); reason=%s",
+			"forced-both-certificates candidate route counters = %d/%d, want 0/1 "+
+				"(the materiality gate should decline this material election and fall back "+
+				"to production); reason=%s",
 			routed, fallback, gts.AdmissionCandidateLastFallbackReason(),
 		)
 	}
+	if reason := gts.AdmissionCandidateLastFallbackReason(); !strings.Contains(reason, "did not accept EOF") {
+		t.Fatalf("forced-both-certificates fallback reason changed unexpectedly: %s", reason)
+	}
 	candidateSExpr := candidateTree.RootNode().SExpr(lang)
-	if candidateSExpr == productionSExpr {
+	if candidateSExpr != productionSExpr {
 		t.Fatalf(
-			"forced-both-certificates candidate tree now matches production (%s); the "+
-				"object_declaration regression may be fixed -- re-verify against the C oracle "+
-				"(cgo_harness/kotlin_a3_certification_object_declaration_regression_test.go) "+
-				"before landing Kotlin's A3 certification",
-			candidateSExpr,
+			"forced-both-certificates candidate tree (fallback to production) = %s, want production's object_declaration tree %s",
+			candidateSExpr, productionSExpr,
 		)
 	}
-	if !strings.Contains(candidateSExpr, "infix_expression") {
-		t.Fatalf("forced-both-certificates candidate tree changed shape unexpectedly: %s", candidateSExpr)
-	}
-	t.Logf("confirmed withheld: forced-both-certificates candidate tree diverges from production's object_declaration tree: %s", candidateSExpr)
+	t.Logf("confirmed: the materiality gate declines this material election (two derivations, two different trees) instead of publishing the positional primary; production's object_declaration tree is served: %s", candidateSExpr)
 }

--- a/cgo_harness/a3_certification_sweep_helpers_test.go
+++ b/cgo_harness/a3_certification_sweep_helpers_test.go
@@ -26,12 +26,14 @@ import (
 // route forced off) and once on the compact candidate route (route forced
 // on). A parse that declines the compact route is SAFE by construction (it
 // falls back to production automatically) and is only counted and
-// reason-classified. A parse that the compact route accepts must either
-// byte-match the production tree, or -- where the two differ -- match the
-// locked C oracle exactly (the adjudicated-exception rule: compact==C is
-// correct even when production diverges). Any accepted compact tree that
-// matches neither production nor the C oracle is a genuine, unadjudicated
-// divergence and fails the sweep.
+// reason-classified. A parse that the compact route accepts is adjudicated
+// against the locked C oracle directly and unconditionally: certification
+// means compact==C. Matching production is not itself sufficient and is
+// checked only to label the outcome -- a clean pass when compact, production,
+// and C all agree, or an adjudicated exception (the one sanctioned deviation)
+// when compact==C but production diverges. An accepted compact tree that does
+// not match the C oracle is a genuine, unadjudicated divergence and fails the
+// sweep, whether or not it happens to match production.
 
 // a3CertificationSweepSource is one corpus file or constructed source fed
 // through the sweep.
@@ -110,26 +112,43 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 
 		switch {
 		case routedAfter == routedBefore+1 && fallbackAfter == fallbackBefore:
-			// Accepted via the compact route.
+			// Accepted via the compact route. Certification means compact == the
+			// locked C oracle tree, checked directly and unconditionally: matching
+			// production alone is not sufficient, because production can itself
+			// carry an undetected divergence from C that an accepted compact tree
+			// would then inherit and pass silently. Every accepted source is
+			// therefore adjudicated against the C oracle here, not only the ones
+			// that already disagree with production. Production agreement is used
+			// only to label the outcome (a clean pass, or an adjudicated exception
+			// where compact is right and production is wrong); it never
+			// substitutes for the C comparison.
 			result.Accepted++
 			prodDivergences := a3GoTreeDivergences(candidateTree.RootNode(), lang, productionTree.RootNode())
-			if len(prodDivergences) == 0 {
-				break
-			}
-			// Compact disagrees with production: adjudicate against the locked
-			// C oracle. compact==C is the adjudicated exception (production is
-			// the divergent side); compact!=C is a genuine, unadjudicated
-			// divergence that blocks certification.
 			cTree := a3ParseCOracle(t, cLang, src.Source)
 			cDivergences := compactT3StructuralDivergences(candidateTree.RootNode(), lang, cTree.RootNode())
 			cTree.Close()
-			if len(cDivergences) == 0 {
-				result.AdjudicatedExceptions = append(result.AdjudicatedExceptions, src.Name)
-				t.Logf(
-					"%s: ADJUDICATED EXCEPTION -- compact diverges from production at %d point(s) but matches the C oracle exactly; first production divergence: %s",
-					src.Name, len(prodDivergences), prodDivergences[0],
+			switch {
+			case len(cDivergences) == 0:
+				// compact == C. A clean pass when production also agrees; an
+				// adjudicated exception (the existing sanctioned deviation) when
+				// production does not.
+				if len(prodDivergences) != 0 {
+					result.AdjudicatedExceptions = append(result.AdjudicatedExceptions, src.Name)
+					t.Logf(
+						"%s: ADJUDICATED EXCEPTION -- compact diverges from production at %d point(s) but matches the C oracle exactly; first production divergence: %s",
+						src.Name, len(prodDivergences), prodDivergences[0],
+					)
+				}
+			case len(prodDivergences) == 0:
+				// compact == production, but neither matches C: reproducing
+				// production is not a sanctioned deviation on its own.
+				detail := fmt.Sprintf(
+					"%s: UNADJUDICATED DIVERGENCE -- compact matches production but both diverge from the C oracle at %d point(s), first: %s",
+					src.Name, len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
 				)
-			} else {
+				result.Divergences = append(result.Divergences, detail)
+				t.Log(detail)
+			default:
 				detail := fmt.Sprintf(
 					"%s: UNADJUDICATED DIVERGENCE -- compact matches neither production (%d pt(s), first: %s) nor the C oracle (%d pt(s), first: %s)",
 					src.Name, len(prodDivergences), prodDivergences[0], len(cDivergences), compactT3FormatDivergence(cDivergences[0]),

--- a/cgo_harness/a3_certification_sweep_helpers_test.go
+++ b/cgo_harness/a3_certification_sweep_helpers_test.go
@@ -44,13 +44,50 @@ type a3CertificationSweepSource struct {
 
 // a3CertificationSweepResult is the scorecard one language's sweep produces.
 type a3CertificationSweepResult struct {
-	Language               string
-	Files                  int
-	Accepted               int
-	Declined               int
-	DeclineByReason        map[string]int
-	AdjudicatedExceptions  []string
-	Divergences            []string
+	Language              string
+	Files                 int
+	Accepted              int
+	Declined              int
+	DeclineByReason       map[string]int
+	AdjudicatedExceptions []string
+	Divergences           []string
+	TrackedDivergences    []string
+}
+
+// a3KnownDivergence is one already-triaged, pre-existing production-route
+// defect: the compact route only reproduces what production already
+// produces (verified by parsing the witness with the compact route
+// disabled), so this is not a tied-election defect and sits outside the
+// materiality gate's scope. Tracked here so the sweep's own pass/fail
+// signal stays honest without silently widening what counts as
+// certification-clean: an entry only suppresses the exact divergence it
+// names (witness, first divergent node path, and the Go/C values recorded
+// there). A witness whose divergence shape has moved -- a different path,
+// or the same path with different Go/C values -- is NOT a match and still
+// fails the sweep as a new, unadjudicated divergence.
+//
+// Family tags the mechanism: "M" (materialization inherited-field
+// over-projection), "S" (materialization aliased multi-token span), "D"
+// (GLR derivation selection at a declared conflict). Entries burn down as
+// each family's repair lands; they do not expire on their own.
+type a3KnownDivergence struct {
+	Witness   string
+	FirstPath string
+	GoValue   string
+	CValue    string
+	Family    string
+}
+
+// a3MatchesKnownDivergence reports whether first (the first entry in a
+// compactT3StructuralDivergences result) is exactly the divergence known
+// records for witness, and returns that entry if so.
+func a3MatchesKnownDivergence(known []a3KnownDivergence, witness string, first compactT3StructuralDivergence) (a3KnownDivergence, bool) {
+	for _, k := range known {
+		if k.Witness == witness && k.FirstPath == first.Path && k.GoValue == first.GoValue && k.CValue == first.CValue {
+			return k, true
+		}
+	}
+	return a3KnownDivergence{}, false
 }
 
 // a3DeclineReasonClass buckets a compact-route decline reason string into a
@@ -81,8 +118,11 @@ func a3DeclineReasonClass(reason string) string {
 // caller lands them in grammars/runtime_profiles.go, or forces them
 // temporarily for a withheld-language probe) and classifies every outcome.
 // cLangName resolves the locked C oracle used to adjudicate every compact
-// accept that diverges from production. It never mutates lang.
-func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *gotreesitter.Language, sources []a3CertificationSweepSource) a3CertificationSweepResult {
+// accept that diverges from production. known is this language's enumerated
+// list of already-triaged, pre-existing production-route divergences
+// (a3KnownDivergence); pass nil for a language with none. It never mutates
+// lang.
+func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *gotreesitter.Language, sources []a3CertificationSweepSource, known []a3KnownDivergence) a3CertificationSweepResult {
 	t.Helper()
 	result := a3CertificationSweepResult{Language: language, DeclineByReason: map[string]int{}}
 
@@ -141,7 +181,24 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 				}
 			case len(prodDivergences) == 0:
 				// compact == production, but neither matches C: reproducing
-				// production is not a sanctioned deviation on its own.
+				// production is not a sanctioned deviation on its own. If this
+				// exact divergence is already triaged and tracked as a
+				// pre-existing production-route defect (known), it is safe by
+				// the same construction as a decline -- the compact route
+				// contributes nothing here, it only inherits what production
+				// already produces -- so it is counted separately and does not
+				// fail the sweep. Any other divergence, or this witness's
+				// divergence at a different node or with different Go/C
+				// values, is not a match and still fails.
+				if k, ok := a3MatchesKnownDivergence(known, src.Name, cDivergences[0]); ok {
+					detail := fmt.Sprintf(
+						"%s: TRACKED DIVERGENCE (family %s, pre-existing production-route defect) -- compact matches production but both diverge from the C oracle at %d point(s), first: %s",
+						src.Name, k.Family, len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
+					)
+					result.TrackedDivergences = append(result.TrackedDivergences, detail)
+					t.Log(detail)
+					break
+				}
 				detail := fmt.Sprintf(
 					"%s: UNADJUDICATED DIVERGENCE -- compact matches production but both diverge from the C oracle at %d point(s), first: %s",
 					src.Name, len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
@@ -149,6 +206,15 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 				result.Divergences = append(result.Divergences, detail)
 				t.Log(detail)
 			default:
+				if k, ok := a3MatchesKnownDivergence(known, src.Name, cDivergences[0]); ok {
+					detail := fmt.Sprintf(
+						"%s: TRACKED DIVERGENCE (family %s, pre-existing production-route defect) -- compact matches neither production (%d pt(s), first: %s) nor the C oracle (%d pt(s), first: %s)",
+						src.Name, k.Family, len(prodDivergences), prodDivergences[0], len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
+					)
+					result.TrackedDivergences = append(result.TrackedDivergences, detail)
+					t.Log(detail)
+					break
+				}
 				detail := fmt.Sprintf(
 					"%s: UNADJUDICATED DIVERGENCE -- compact matches neither production (%d pt(s), first: %s) nor the C oracle (%d pt(s), first: %s)",
 					src.Name, len(prodDivergences), prodDivergences[0], len(cDivergences), compactT3FormatDivergence(cDivergences[0]),
@@ -176,20 +242,24 @@ func runA3CertificationSweep(t *testing.T, language, cLangName string, lang *got
 }
 
 // a3ReportSweep logs the scorecard and fails the test if any unadjudicated
-// divergence was found. Declines and adjudicated exceptions never fail the
-// sweep.
+// divergence was found. Declines, adjudicated exceptions, and tracked
+// (already-triaged, pre-existing production-route) divergences never fail
+// the sweep.
 func a3ReportSweep(t *testing.T, result a3CertificationSweepResult) {
 	t.Helper()
 	t.Logf(
-		"%s A3 sweep: files=%d accepted=%d declined=%d adjudicated-exceptions=%d divergences=%d",
+		"%s A3 sweep: files=%d accepted=%d declined=%d adjudicated-exceptions=%d tracked-divergences=%d divergences=%d",
 		result.Language, result.Files, result.Accepted, result.Declined,
-		len(result.AdjudicatedExceptions), len(result.Divergences),
+		len(result.AdjudicatedExceptions), len(result.TrackedDivergences), len(result.Divergences),
 	)
 	for class, count := range result.DeclineByReason {
 		t.Logf("%s decline reason class %q: %d", result.Language, class, count)
 	}
 	for _, name := range result.AdjudicatedExceptions {
 		t.Logf("%s adjudicated exception: %s", result.Language, name)
+	}
+	for _, d := range result.TrackedDivergences {
+		t.Logf("%s tracked divergence: %s", result.Language, d)
 	}
 	if len(result.Divergences) != 0 {
 		for _, d := range result.Divergences {

--- a/cgo_harness/ada_a3_certification_sweep_test.go
+++ b/cgo_harness/ada_a3_certification_sweep_test.go
@@ -39,8 +39,66 @@ func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	// is no missing-fixture condition to detect for this language.
 	t.Logf("ada A3 full-corpus sweep source denominator: real=0 (no corpus_real/ada on any host) constructed=%d total=%d", len(sources), len(sources))
 
-	result := runA3CertificationSweep(t, "ada", "ada", lang, sources)
+	result := runA3CertificationSweep(t, "ada", "ada", lang, sources, adaA3KnownDivergences)
 	a3ReportSweep(t, result)
+}
+
+// adaA3KnownDivergences are already-triaged, pre-existing production-route
+// defects the tightened sweep criterion surfaced: the compact route only
+// reproduces what production already produces (verified directly, with the
+// compact route disabled) on each of these witnesses.
+//
+// Six of the seven are family M (materialization: an inherited field-map
+// entry names a child Go's flattened-hidden-span heuristic should not; C's
+// node.c filters inherited entries and never does). Ada's grammar declares
+// "name"/"subtype_mark" as inherited fields on productions whose actual
+// child production (named_array_aggregate, range_g) never carries them
+// directly; Go's applyParentFieldToFlattenedHiddenSpan re-attaches the
+// inherited field anyway.
+//
+// attribute_constraint is family D: Ada's grammar declares
+// prec.dynamic(1, discriminant_constraint) over index_constraint with an
+// explicit grammar comment choosing it, and Go's reduceForkWindowPreference
+// still picks index_constraint.
+//
+// Not tied elections, not this gate's scope; repair lanes are tracked
+// separately.
+var adaA3KnownDivergences = []a3KnownDivergence{
+	{
+		Witness:   "attribute_constraint",
+		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/allocator[0]/index_constraint[2]",
+		GoValue:   "index_constraint", CValue: "discriminant_constraint", Family: "D",
+	},
+	{
+		Witness:   "locked_positional_array_aggregate",
+		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
+		GoValue:   "subtype_mark", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "array_others_choice",
+		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/handled_sequence_of_statements[3]/assignment_statement[0]/expression[2]/term[0]/named_array_aggregate[0]",
+		GoValue:   "name", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "named_array_aggregate",
+		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
+		GoValue:   "subtype_mark", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "mixed_positional_named_aggregate",
+		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
+		GoValue:   "subtype_mark", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "qualified_expression",
+		FirstPath: "/compilation/compilation_unit[0]/package_declaration[0]/full_type_declaration[3]/array_type_definition[3]/range_g[2]",
+		GoValue:   "subtype_mark", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "attribute_range_and_first_last",
+		FirstPath: "/compilation/compilation_unit[0]/subprogram_body[0]/non_empty_declarative_part[2]/full_type_declaration[0]/array_type_definition[3]/range_g[2]",
+		GoValue:   "subtype_mark", CValue: "", Family: "M",
+	},
 }
 
 // adaA3TiedElectionWitnesses reuses the three witnesses already vetted in

--- a/cgo_harness/ada_a3_certification_sweep_test.go
+++ b/cgo_harness/ada_a3_certification_sweep_test.go
@@ -32,6 +32,12 @@ func TestAdaA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	}
 	sources = append(sources, adaA3TiedElectionWitnesses()...)
 	sources = append(sources, adaA3AdversarialSources()...)
+	// Ada has no cgo_harness/corpus_real directory on any host (it is not
+	// one of the top-50 languages the real-corpus manifest profiles), so
+	// real=0 here is a documented, permanent property of this sweep, not a
+	// silent degradation -- unlike python/perl (a3LoadRealCorpusDir), there
+	// is no missing-fixture condition to detect for this language.
+	t.Logf("ada A3 full-corpus sweep source denominator: real=0 (no corpus_real/ada on any host) constructed=%d total=%d", len(sources), len(sources))
 
 	result := runA3CertificationSweep(t, "ada", "ada", lang, sources)
 	a3ReportSweep(t, result)
@@ -209,5 +215,20 @@ func adaA3AdversarialSources() []a3CertificationSweepSource {
 				"      end return;\n" +
 				"   end Make;\n" +
 				"end P;\n")},
+		// bare_aggregate_assignment_material_election is a permanent
+		// regression fixture: a genuinely material tied election outside
+		// this sweep's original corpus. The C oracle picks the derivation
+		// whose outer production is record_aggregate; the certified compact
+		// route's old positional primary picked the derivation whose outer
+		// production is named_array_aggregate instead (matching production,
+		// which also diverges from C here). Under the materiality gate
+		// (selectCompactAcceptanceDerivation, compactAcceptanceElectionIsVacuous)
+		// the two tied derivations are not byte-identical, so this now
+		// declines instead of accepting the C-divergent tree.
+		{Name: "bare_aggregate_assignment_material_election", Source: []byte(
+			"procedure P is\n" +
+				"begin\n" +
+				"   R := (F => 1, G => 2);\n" +
+				"end;\n")},
 	}
 }

--- a/cgo_harness/apex_a3_certification_sweep_test.go
+++ b/cgo_harness/apex_a3_certification_sweep_test.go
@@ -38,7 +38,9 @@ func TestApexA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	// is no missing-fixture condition to detect for this language.
 	t.Logf("apex A3 full-corpus sweep source denominator: real=0 (no corpus_real/apex on any host) constructed=%d total=%d", len(sources), len(sources))
 
-	result := runA3CertificationSweep(t, "apex", "apex", lang, sources)
+	// No known-divergence entries: apex's sweep has zero unadjudicated
+	// divergences at both the pre- and post-tightening criterion.
+	result := runA3CertificationSweep(t, "apex", "apex", lang, sources, nil)
 	a3ReportSweep(t, result)
 }
 

--- a/cgo_harness/apex_a3_certification_sweep_test.go
+++ b/cgo_harness/apex_a3_certification_sweep_test.go
@@ -31,6 +31,12 @@ func TestApexA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	}
 	sources = append(sources, apexA3TiedElectionWitnesses()...)
 	sources = append(sources, apexA3AdversarialSources()...)
+	// Apex has no cgo_harness/corpus_real directory on any host (it is not
+	// one of the top-50 languages the real-corpus manifest profiles), so
+	// real=0 here is a documented, permanent property of this sweep, not a
+	// silent degradation -- unlike python/perl (a3LoadRealCorpusDir), there
+	// is no missing-fixture condition to detect for this language.
+	t.Logf("apex A3 full-corpus sweep source denominator: real=0 (no corpus_real/apex on any host) constructed=%d total=%d", len(sources), len(sources))
 
 	result := runA3CertificationSweep(t, "apex", "apex", lang, sources)
 	a3ReportSweep(t, result)
@@ -216,6 +222,22 @@ func apexA3AdversarialSources() []a3CertificationSweepSource {
 				"  void m(String keyword) {\n" +
 				"    List<Account> results = [SELECT Id FROM Account WHERE Name = :keyword];\n" +
 				"    List<List<SObject>> both = [FIND :keyword IN ALL FIELDS RETURNING Account, Contact];\n" +
+				"  }\n" +
+				"}\n")},
+		// soql_local_declaration_material_election is a permanent regression
+		// fixture: a genuinely material tied election outside this sweep's
+		// original corpus. The C oracle picks the derivation whose outer
+		// production is local_variable_declaration; the certified compact
+		// route's old positional primary picked the derivation whose outer
+		// production is binary_expression instead (matching production,
+		// which also diverges from C here). Under the materiality gate
+		// (selectCompactAcceptanceDerivation, compactAcceptanceElectionIsVacuous)
+		// the two tied derivations are not byte-identical, so this now
+		// declines instead of accepting the C-divergent tree.
+		{Name: "soql_local_declaration_material_election", Source: []byte(
+			"public class C {\n" +
+				"  void m() {\n" +
+				"    List<Account> a = [SELECT Id FROM Account];\n" +
 				"  }\n" +
 				"}\n")},
 	}

--- a/cgo_harness/kotlin_a3_certification_sweep_test.go
+++ b/cgo_harness/kotlin_a3_certification_sweep_test.go
@@ -50,8 +50,25 @@ func TestKotlinA3CompactCertificationForcedSweep(t *testing.T) {
 	sources := append(append([]a3CertificationSweepSource{}, real...), constructed...)
 	t.Logf("kotlin A3 forced sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
-	result := runA3CertificationSweep(t, "kotlin", "kotlin", lang, sources)
+	result := runA3CertificationSweep(t, "kotlin", "kotlin", lang, sources, kotlinA3KnownDivergences)
 	a3ReportSweep(t, result)
+}
+
+// kotlinA3KnownDivergences is an already-triaged, pre-existing
+// production-route defect the tightened sweep criterion surfaced: the
+// compact route only reproduces what production already produces (verified
+// directly, with the compact route disabled). Family D: a declared GLR
+// conflict where Go's reduceForkWindowPreference disagrees with C's
+// ts_parser__select_tree on which branch to keep (assignment vs getter,
+// reachable only through the detached "get() = ..." that follows an
+// annotated extension-property declaration). Not a tied election, not this
+// gate's scope; repair lane is tracked separately.
+var kotlinA3KnownDivergences = []a3KnownDivergence{
+	{
+		Witness:   "large__DeprecatedInstant.kt",
+		FirstPath: "/source_file/assignment[14]",
+		GoValue:   "assignment", CValue: "getter", Family: "D",
+	},
 }
 
 // kotlinA3AdversarialSources gathers Kotlin's known tied-election and

--- a/cgo_harness/kotlin_a3_certification_sweep_test.go
+++ b/cgo_harness/kotlin_a3_certification_sweep_test.go
@@ -1,0 +1,78 @@
+//go:build cgo && treesitter_c_parity
+
+package cgoharness
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestKotlinA3CompactCertificationForcedSweep is the R1 verification receipt
+// for Kotlin: it runs the same shared sweep harness as the four landed
+// languages (runA3CertificationSweep), with both A3 certificates
+// (CompactConvergedReductionSplitDropsCertified and
+// CompactPrimaryAcceptanceDerivationCertified) forced on locally for the
+// duration of this test only. It does not touch
+// grammars/runtime_profiles.go and does not certify Kotlin -- see
+// admission_switch_kotlin_certification_withheld_test.go and
+// kotlin_a3_certification_object_declaration_regression_test.go for why
+// Kotlin's certification still does not land in this PR.
+//
+// Before selectCompactAcceptanceDerivation's materiality gate
+// (parsercore_phase0_driver.go, compactAcceptanceElectionIsVacuous), forcing
+// both certificates regressed the object_declaration witness (a C-divergent
+// accept). The gate closes that: the witness's two tied derivations are not
+// byte-identical, so it now declines and falls back to production instead.
+// The annotated_declaration witness is a separate, pre-existing derivation-
+// coverage gap (no election is involved; the C-correct derivation is not
+// reachable at the accepted head at all) and is expected to remain a
+// decline or a divergence -- this sweep records that outcome, it does not
+// chase a fix for it.
+func TestKotlinA3CompactCertificationForcedSweep(t *testing.T) {
+	lang := grammars.KotlinLanguage()
+	if lang.CompactConvergedReductionSplitDropsCertified || lang.CompactPrimaryAcceptanceDerivationCertified {
+		t.Fatal("shared kotlin language unexpectedly carries a withheld A3 certificate")
+	}
+	lang.CompactConvergedReductionSplitDropsCertified = true
+	lang.CompactPrimaryAcceptanceDerivationCertified = true
+	defer func() {
+		lang.CompactConvergedReductionSplitDropsCertified = false
+		lang.CompactPrimaryAcceptanceDerivationCertified = false
+	}()
+
+	real := a3LoadRealCorpusDir(t, "kotlin", filepath.Join("corpus_real", "kotlin"))
+	constructed := append([]a3CertificationSweepSource{{
+		Name:   "smoke_sample",
+		Source: []byte(grammars.ParseSmokeSample("kotlin")),
+	}}, kotlinA3AdversarialSources()...)
+	sources := append(append([]a3CertificationSweepSource{}, real...), constructed...)
+	t.Logf("kotlin A3 forced sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
+
+	result := runA3CertificationSweep(t, "kotlin", "kotlin", lang, sources)
+	a3ReportSweep(t, result)
+}
+
+// kotlinA3AdversarialSources gathers Kotlin's known tied-election and
+// derivation-coverage-gap witnesses: the platform-modifier-recovery witness
+// (b4b_alternative_set_v2_kotlin_adjudication_test.go), the object-
+// declaration witness at both the collapsing and non-collapsing spacing
+// (admission_switch_kotlin_certification_withheld_test.go,
+// kotlin_a3_certification_object_declaration_regression_test.go), the empty-
+// body object-declaration witness, and the annotated-declaration derivation-
+// coverage gap.
+func kotlinA3AdversarialSources() []a3CertificationSweepSource {
+	return []a3CertificationSweepSource{
+		{Name: "platform_modifier_recovery", Source: []byte("internal actual fun f(): String = \"x\"\n")},
+		{Name: "object_declaration_multiline", Source: []byte("package demo\n\nobject Singleton {\n    fun work() = Unit\n}\n")},
+		{Name: "object_declaration_no_body_members", Source: []byte("object S {}\n")},
+		{Name: "annotated_declaration", Source: []byte("@Suppress(\"UNUSED\")\nfun f() {}\n")},
+		{Name: "try_catch", Source: []byte("fun f() {\n    try {\n        g()\n    } catch (e: Exception) {\n        h()\n    }\n}\n")},
+		{Name: "class_with_constructor", Source: []byte("class Point(val x: Int, val y: Int)\n")},
+		{Name: "when_expression", Source: []byte("fun f(x: Int): String = when (x) {\n    1 -> \"one\"\n    else -> \"other\"\n}\n")},
+		{Name: "extension_function", Source: []byte("fun String.shout(): String = this.uppercase()\n")},
+		{Name: "data_class", Source: []byte("data class User(val name: String, val age: Int)\n")},
+		{Name: "lambda_trailing", Source: []byte("val xs = listOf(1, 2, 3).map { it * 2 }\n")},
+	}
+}

--- a/cgo_harness/perl_a3_certification_sweep_test.go
+++ b/cgo_harness/perl_a3_certification_sweep_test.go
@@ -27,12 +27,13 @@ func TestPerlA3CompactCertificationFullCorpusSweep(t *testing.T) {
 		t.Fatal("perl did not receive the A3 converged-split-drop certification")
 	}
 
-	sources := a3LoadRealCorpusDir(t, filepath.Join("corpus_real", "perl"))
-	sources = append(sources, a3CertificationSweepSource{
+	real := a3LoadRealCorpusDir(t, "perl", filepath.Join("corpus_real", "perl"))
+	constructed := append([]a3CertificationSweepSource{{
 		Name:   "smoke_sample",
 		Source: []byte(grammars.ParseSmokeSample("perl")),
-	})
-	sources = append(sources, perlA3AdversarialSources()...)
+	}}, perlA3AdversarialSources()...)
+	sources := append(append([]a3CertificationSweepSource{}, real...), constructed...)
+	t.Logf("perl A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
 	result := runA3CertificationSweep(t, "perl", "perl", lang, sources)
 	a3ReportSweep(t, result)
@@ -60,5 +61,16 @@ func perlA3AdversarialSources() []a3CertificationSweepSource {
 		{Name: "ternary_list_context", Source: []byte("my @r = $flag ? (1, 2) : (3, 4);\n")},
 		{Name: "local_dynamic_scope", Source: []byte("our $x = 1;\nsub f { local $x = 2; g(); }\n")},
 		{Name: "wantarray_dispatch", Source: []byte("sub f { return wantarray ? (1, 2) : 1; }\n")},
+		// print_filehandle_list_material_election is a permanent regression
+		// fixture: a genuinely material tied election outside this sweep's
+		// original corpus. The C oracle picks the derivation whose outer
+		// production is ambiguous_function_call_expression; the certified
+		// compact route's old positional primary picked the derivation whose
+		// outer production is list_expression instead (matching production,
+		// which also diverges from C here). Under the materiality gate
+		// (selectCompactAcceptanceDerivation, compactAcceptanceElectionIsVacuous)
+		// the two tied derivations are not byte-identical, so this now
+		// declines instead of accepting the C-divergent tree.
+		{Name: "print_filehandle_list_material_election", Source: []byte("print $fh, \"a\", \"b\";\n")},
 	}
 }

--- a/cgo_harness/perl_a3_certification_sweep_test.go
+++ b/cgo_harness/perl_a3_certification_sweep_test.go
@@ -35,8 +35,39 @@ func TestPerlA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	sources := append(append([]a3CertificationSweepSource{}, real...), constructed...)
 	t.Logf("perl A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
-	result := runA3CertificationSweep(t, "perl", "perl", lang, sources)
+	result := runA3CertificationSweep(t, "perl", "perl", lang, sources, perlA3KnownDivergences)
 	a3ReportSweep(t, result)
+}
+
+// perlA3KnownDivergences are already-triaged, pre-existing production-route
+// defects the tightened sweep criterion surfaced: the compact route only
+// reproduces what production already produces (verified directly, with the
+// compact route disabled) on each of these witnesses. All four are family D
+// (GLR derivation selection at a declared conflict: Go's
+// reduceForkWindowPreference disagrees with C's ts_parser__select_tree on
+// which branch of a real grammar-declared conflict to keep). Not tied
+// elections, not this gate's scope; repair lanes are tracked separately.
+var perlA3KnownDivergences = []a3KnownDivergence{
+	{
+		Witness:   "medium__statements.pm",
+		FirstPath: "/source_file/try_statement[69]/block[1]/expression_statement[1]/ambiguous_function_call_expression[0]",
+		GoValue:   "ambiguous_function_call_expression", CValue: "function_call_expression", Family: "D",
+	},
+	{
+		Witness:   "join_assignment",
+		FirstPath: "/source_file/expression_statement[0]/list_expression[0]",
+		GoValue:   "list_expression", CValue: "assignment_expression", Family: "D",
+	},
+	{
+		Witness:   "return_list",
+		FirstPath: "/source_file/subroutine_declaration_statement[0]/block[2]/expression_statement[1]/list_expression[0]",
+		GoValue:   "list_expression", CValue: "return_expression", Family: "D",
+	},
+	{
+		Witness:   "local_dynamic_scope",
+		FirstPath: "/source_file/subroutine_declaration_statement[2]/block[2]/expression_statement[3]/ambiguous_function_call_expression[0]",
+		GoValue:   "ambiguous_function_call_expression", CValue: "function_call_expression", Family: "D",
+	},
 }
 
 // perlA3AdversarialSources reuses Perl's tied push-list election witness

--- a/cgo_harness/python_a3_certification_sweep_test.go
+++ b/cgo_harness/python_a3_certification_sweep_test.go
@@ -35,8 +35,46 @@ func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
 	sources := append(append([]a3CertificationSweepSource{}, real...), constructed...)
 	t.Logf("python A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
-	result := runA3CertificationSweep(t, "python", "python", lang, sources)
+	result := runA3CertificationSweep(t, "python", "python", lang, sources, pythonA3KnownDivergences)
 	a3ReportSweep(t, result)
+}
+
+// pythonA3KnownDivergences are already-triaged, pre-existing production-route
+// defects the tightened sweep criterion surfaced: the compact route only
+// reproduces what production already produces (verified directly, with the
+// compact route disabled) on each of these witnesses. The two real-corpus
+// entries are family M (materialization: an inherited field-map entry names
+// a child Go's flattened-hidden-span heuristic should not; C's node.c filters
+// inherited entries and never does). large__python3.8_grammar.py's first
+// point is family M; it also carries a family S point further in (an
+// aliased "not in"/"is not" span that starts one byte early) not enumerated
+// as a separate entry here, since only the first divergence gates the match.
+// The two f-string entries are family D (a first-class declared
+// pattern_list/expression_list ambiguity; Go's reduceForkWindowPreference
+// disagrees with C's ts_parser__select_tree on which side to keep). Not
+// tied elections, not this gate's scope; repair lanes are tracked
+// separately.
+var pythonA3KnownDivergences = []a3KnownDivergence{
+	{
+		Witness:   "large__python3.8_grammar.py",
+		FirstPath: "/module/class_definition[25]/block[4]/function_definition[13]/block[6]/import_from_statement[0]/,[4]",
+		GoValue:   "name", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "medium__setup.py",
+		FirstPath: "/module/import_from_statement[2]/,[4]",
+		GoValue:   "name", CValue: "", Family: "M",
+	},
+	{
+		Witness:   "fstring_interpolation_bare_tuple",
+		FirstPath: "/module/assignment[2]/string[2]/interpolation[1]/pattern_list[1]",
+		GoValue:   "pattern_list", CValue: "expression_list", Family: "D",
+	},
+	{
+		Witness:   "fstring_interpolation_splat",
+		FirstPath: "/module/assignment[1]/string[2]/interpolation[1]/pattern_list[1]",
+		GoValue:   "pattern_list", CValue: "expression_list", Family: "D",
+	},
 }
 
 // pythonA3AdversarialSources gathers Python's tied-election witness (the

--- a/cgo_harness/python_a3_certification_sweep_test.go
+++ b/cgo_harness/python_a3_certification_sweep_test.go
@@ -27,12 +27,13 @@ func TestPythonA3CompactCertificationFullCorpusSweep(t *testing.T) {
 		t.Fatal("python lost its pre-existing converged-split-drop certification")
 	}
 
-	sources := a3LoadRealCorpusDir(t, filepath.Join("corpus_real", "python"))
-	sources = append(sources, a3CertificationSweepSource{
+	real := a3LoadRealCorpusDir(t, "python", filepath.Join("corpus_real", "python"))
+	constructed := append([]a3CertificationSweepSource{{
 		Name:   "smoke_sample",
 		Source: []byte(grammars.ParseSmokeSample("python")),
-	})
-	sources = append(sources, pythonA3AdversarialSources()...)
+	}}, pythonA3AdversarialSources()...)
+	sources := append(append([]a3CertificationSweepSource{}, real...), constructed...)
+	t.Logf("python A3 full-corpus sweep source denominator: real=%d constructed=%d total=%d", len(real), len(constructed), len(sources))
 
 	result := runA3CertificationSweep(t, "python", "python", lang, sources)
 	a3ReportSweep(t, result)
@@ -76,13 +77,28 @@ func pythonA3AdversarialSources() []a3CertificationSweepSource {
 
 // a3LoadRealCorpusDir reads every regular file directly under dir (relative
 // to the cgo_harness package directory) into an a3CertificationSweepSource
-// slice, sorted by name for deterministic ordering. It skips (does not fail)
-// when dir does not exist, so a language with no corpus_real directory
-// simply contributes zero real-corpus sources.
-func a3LoadRealCorpusDir(t *testing.T, dir string) []a3CertificationSweepSource {
+// slice, sorted by name for deterministic ordering.
+//
+// cgo_harness/corpus_real is a generated, gitignored fixture
+// (cgo_harness/cmd/build_real_corpus); it is not always present. The calling
+// test's name claims full-corpus scope, so it must not silently downgrade to
+// a constructed-only run when the real corpus is missing -- that used to be
+// exactly what this function did (returning nil on a missing directory with
+// no signal to the caller or the test log). It now skips the calling test
+// loudly instead, matching this package's existing convention for a
+// claimed-scope test that cannot honor its own claim on the current host
+// (parityRequireExhaustive, parity_cgo_test.go). lang names the calling
+// sweep in the skip/log messages.
+func a3LoadRealCorpusDir(t *testing.T, lang, dir string) []a3CertificationSweepSource {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
 	if os.IsNotExist(err) {
+		t.Skipf(
+			"%s A3 full-corpus sweep requires %s (a generated, gitignored real-corpus fixture; "+
+				"see cgo_harness/cmd/build_real_corpus) -- absent on this host, so this sweep cannot "+
+				"claim full-corpus scope",
+			lang, dir,
+		)
 		return nil
 	}
 	if err != nil {
@@ -99,6 +115,9 @@ func a3LoadRealCorpusDir(t *testing.T, dir string) []a3CertificationSweepSource 
 			t.Fatalf("read corpus file %s: %v", path, err)
 		}
 		out = append(out, a3CertificationSweepSource{Name: entry.Name(), Source: data})
+	}
+	if len(out) == 0 {
+		t.Skipf("%s A3 full-corpus sweep found %s but it contains no files -- this sweep cannot claim full-corpus scope", lang, dir)
 	}
 	return out
 }

--- a/parsercore_phase0_acceptance_election_materiality_test.go
+++ b/parsercore_phase0_acceptance_election_materiality_test.go
@@ -1,0 +1,103 @@
+//go:build !gts_no_parsercorephase0
+
+package gotreesitter_test
+
+import (
+	"testing"
+
+	gts "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestCompactAcceptanceDerivationTreesEqual covers the structural axes
+// compactAcceptanceDerivationTreesEqual (parsercore_phase0_driver.go)
+// compares directly: nil handling, reflexivity on a real parsed tree,
+// symbol/span divergence, and child-count divergence. Field-assignment
+// sensitivity -- the axis that is invisible in an SExpr dump and the reason
+// the comparator checks fields explicitly -- is covered at the integration
+// level by TestA3ArmNoOpConfirmationApexClassLiteralDeclinesAsMaterialElection
+// (admission_switch_a3_arm_noop_confirmation_test.go), which exercises the
+// real apex class_literal_alias witness where two tied derivations share a
+// symbol and shape and differ only in an "object" field assignment; a unit
+// test would need to hand-construct that exact ambiguity, which the real
+// witness already does more faithfully.
+func TestCompactAcceptanceDerivationTreesEqual(t *testing.T) {
+	lang := grammars.GoLanguage()
+
+	parse := func(t *testing.T, source string) *gts.Tree {
+		t.Helper()
+		p := gts.NewParser(lang)
+		tree, err := p.Parse([]byte(source))
+		if err != nil {
+			t.Fatalf("parse %q: %v", source, err)
+		}
+		t.Cleanup(tree.Release)
+		return tree
+	}
+
+	t.Run("nil-nil is equal", func(t *testing.T) {
+		if !gts.CompactAcceptanceDerivationTreesEqualForTest(lang, nil, nil) {
+			t.Fatal("nil, nil = false, want true")
+		}
+	})
+
+	t.Run("nil-vs-node is not equal", func(t *testing.T) {
+		tree := parse(t, "package main\n")
+		if gts.CompactAcceptanceDerivationTreesEqualForTest(lang, tree.RootNode(), nil) {
+			t.Fatal("node, nil = true, want false")
+		}
+		if gts.CompactAcceptanceDerivationTreesEqualForTest(lang, nil, tree.RootNode()) {
+			t.Fatal("nil, node = true, want false")
+		}
+	})
+
+	t.Run("two fresh parses of the same source are equal", func(t *testing.T) {
+		source := "package main\n\nfunc f(x int, y int) int {\n\treturn x + y\n}\n"
+		a := parse(t, source)
+		b := parse(t, source)
+		if !gts.CompactAcceptanceDerivationTreesEqualForTest(lang, a.RootNode(), b.RootNode()) {
+			t.Fatalf("two deterministic parses of the same source compared unequal:\na=%s\nb=%s",
+				a.RootNode().SExpr(lang), b.RootNode().SExpr(lang))
+		}
+	})
+
+	t.Run("different source is not equal (symbol/span divergence)", func(t *testing.T) {
+		a := parse(t, "package main\n\nfunc f() {}\n")
+		b := parse(t, "package main\n\nvar x = 1\n")
+		if gts.CompactAcceptanceDerivationTreesEqualForTest(lang, a.RootNode(), b.RootNode()) {
+			t.Fatalf("structurally different sources compared equal:\na=%s\nb=%s",
+				a.RootNode().SExpr(lang), b.RootNode().SExpr(lang))
+		}
+	})
+
+	t.Run("child count divergence is not equal", func(t *testing.T) {
+		// Same root symbol (source_file) and same start byte (0), but a
+		// different child count and a different second child, so this must
+		// fail on the child-count check specifically, not the root's own
+		// symbol/span/flags.
+		a := parse(t, "package main\n")
+		b := parse(t, "package main\n\nfunc f() {}\n")
+		if a.RootNode().Symbol() != b.RootNode().Symbol() {
+			t.Fatalf("test fixture invalid: root symbols differ (%d vs %d)", a.RootNode().Symbol(), b.RootNode().Symbol())
+		}
+		if a.RootNode().ChildCount() == b.RootNode().ChildCount() {
+			t.Fatalf("test fixture invalid: root child counts match (%d)", a.RootNode().ChildCount())
+		}
+		if gts.CompactAcceptanceDerivationTreesEqualForTest(lang, a.RootNode(), b.RootNode()) {
+			t.Fatalf("different child counts compared equal:\na=%s\nb=%s",
+				a.RootNode().SExpr(lang), b.RootNode().SExpr(lang))
+		}
+	})
+
+	t.Run("a subtree is not equal to its own parent", func(t *testing.T) {
+		tree := parse(t, "package main\n\nfunc f() {}\n")
+		root := tree.RootNode()
+		if root.ChildCount() == 0 {
+			t.Fatal("test fixture invalid: root has no children")
+		}
+		child := root.Child(0)
+		if gts.CompactAcceptanceDerivationTreesEqualForTest(lang, root, child) {
+			t.Fatalf("root compared equal to its own child:\nroot=%s\nchild=%s", root.SExpr(lang), child.SExpr(lang))
+		}
+	})
+}

--- a/parsercore_phase0_acceptance_selection_test.go
+++ b/parsercore_phase0_acceptance_selection_test.go
@@ -51,3 +51,12 @@ func TestSelectCompactAcceptanceDerivation(t *testing.T) {
 		})
 	}
 }
+
+// CompactAcceptanceDerivationTreesEqualForTest exposes
+// compactAcceptanceDerivationTreesEqual to the external gotreesitter_test
+// package, which can import grammars to build real parsed trees (an
+// internal test file in this package cannot: grammars imports gotreesitter,
+// so that would be an import cycle).
+func CompactAcceptanceDerivationTreesEqualForTest(lang *Language, a, b *Node) bool {
+	return compactAcceptanceDerivationTreesEqual(lang, a, b)
+}

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -4649,6 +4649,17 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 			// (admission_census.go), with a distinguishable detail string.
 			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionCandidateCapDetail, 0)
 		}
+		if !s.options.materializationContextSet {
+			// No caller in this parse set up a materialization context, so no
+			// comparison can run at all here -- distinct from the case below,
+			// where a comparison ran and found (or failed to prove) equality.
+			// Every real parse entry point sets the context before running
+			// the scheduler (parsercore_phase0_fresh_full_runner.go
+			// executeSchedulerOpen, diagnosticParseParserCoreGenericFromSeed),
+			// so this is a fail-closed guard for a caller shape not observed
+			// in the certified sweep corpora.
+			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionNoContextDetail, 0)
+		}
 		if !compactAcceptanceElectionIsVacuous(
 			s.compact, s.options.materializationParser, s.options.materializationSource,
 			s.options.materializationForceReplayParseStates, s.options.materializationContextSet,
@@ -4758,6 +4769,24 @@ func compactDerivationsForAcceptance(compact *core.Core, head core.Head) ([]core
 // counted mechanism class this detail is matched into.
 const compactAcceptanceElectionMaterialDetail = "material-acceptance-election: certified primary derivation is not proven byte-identical to every tied secondary derivation"
 
+// compactAcceptanceElectionNoContextDetail is the counted decline reason for
+// a tied election reached with no materialization context available: no
+// caller in this parse set DiagnosticParserCorePrefixOptions
+// .materializationContextSet, so compactAcceptanceElectionIsVacuous never
+// ran, and no comparison happened at all. This is deliberately distinct
+// wording from compactAcceptanceElectionMaterialDetail -- "not proven
+// byte-identical" would overstate what happened when no comparison ran.
+// completeAcceptance checks materializationContextSet itself and selects
+// this detail before ever calling compactAcceptanceElectionIsVacuous, so
+// that function's own internal contextSet check is a second, defensive
+// fail-closed guard for any other caller, not the source of this wording.
+// Classifies under the same material-acceptance-election census mechanism
+// (admissionCensusClassify, admission_census.go) as the other two decline
+// details in this family: the public contract is identical across all
+// three -- the route could not prove this election vacuous, so it declines
+// rather than guess.
+const compactAcceptanceElectionNoContextDetail = "material-acceptance-election: materialization context unavailable; election cannot be proven vacuous"
+
 // compactAcceptanceElectionMaxLiveDerivations bounds how many live
 // derivations compactAcceptanceElectionIsVacuous will materialize and
 // compare. Observed live-derivation counts at a tied accepted head top out
@@ -4804,7 +4833,12 @@ const compactAcceptanceElectionCandidateCapDetail = "material-acceptance-electio
 // function's contract is to compare what the published tree actually
 // carries, not some other configuration. contextSet distinguishes "no caller
 // provided a materialization context" (fail closed) from "the caller
-// provided one, and the source is legitimately empty".
+// provided one, and the source is legitimately empty". completeAcceptance
+// checks contextSet itself before calling this function and picks
+// compactAcceptanceElectionNoContextDetail instead of running a call that
+// can only fail closed, so the contextSet check inside this function is a
+// second, defensive guard for any other caller, not the source of the
+// no-context detail text.
 //
 // A materialization failure on any candidate (a cap, a tiling-gap decline,
 // or any other error) is treated as "not proven vacuous", matching the
@@ -4877,17 +4911,30 @@ func compactAcceptanceElectionIsVacuous(
 // equivalent of any of them. Adding any of the four to this comparator was
 // measured directly against the five R1 target languages' full sweep
 // corpora (perl, python, apex, ada, kotlin; certificates forced,
-// GTS_ADMISSION_CENSUS=1) and each one independently declines at least one
-// witness the pre-R1 election census had already proven vacuous (both
-// derivations publish byte-identical public trees): ParseState/PreGotoState
-// decline Perl push_two_args/push_three_args and Python assignment_bare_pair
-// (and 2-3 more per language); the fragile/external-scanner-token pair
-// declines Ada array_others_choice. In every measured case the two
-// derivations' PUBLIC trees remain identical; only the internal replay/
-// ambiguity bookkeeping differs. Comparing them would turn a correct,
-// C-exact accept into an unnecessary decline, so none of the four are
-// compared here. ParseState/PreGotoState trustworthiness for incremental
-// reuse is guarded separately and already, per materialized tree, by
+// GTS_ADMISSION_CENSUS=1). Only ParseState/PreGotoState decline a source
+// that was otherwise a clean, C-exact accept: Perl push_two_args_real_corpus_
+// witness, push_three_args, and Python assignment_bare_tuple_real_corpus_
+// witness, assignment_bare_pair, assignment_bare_single_trailing_comma (5
+// sources). In every one, the two derivations' PUBLIC trees are already
+// byte-identical, so adding either attribute declines a correct accept for
+// no benefit. That is the entire measured cost of this scope boundary.
+//
+// The other two measured effects are not an additional cost, because
+// neither source involved was a clean pass to begin with:
+//   - ParseState/PreGotoState also decline four already-tracked,
+//     C-divergent sources: Perl join_assignment, return_list, and Python
+//     fstring_interpolation_bare_tuple, fstring_interpolation_splat.
+//     Declining them buys nothing for parity -- production already carries
+//     the identical divergence -- but costs nothing new either.
+//   - The fragile/external-scanner-token pair declines exactly one source,
+//     Ada array_others_choice, which is itself a tracked Family M
+//     divergence (adaA3KnownDivergences), not a clean pass. This pair's
+//     measured effect is a wash: no fidelity change either way.
+//
+// None of the four are compared here; the measured, avoidable cost is
+// confined to the five ParseState/PreGotoState witnesses named above.
+// ParseState/PreGotoState trustworthiness for incremental reuse is guarded
+// separately and already, per materialized tree, by
 // incrementalReuseProven / Tree.incrementalReuseDisabled
 // (materializeDiagnosticParserCoreAcceptedSelection) -- that mechanism does
 // not depend on which of two shape-identical derivations was published, so

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -103,20 +103,39 @@ type DiagnosticParserCorePrefixOptions struct {
 	// disables it, mirroring the production contract's own 0=off escape
 	// hatch.
 	stopControlHardCeilingBytes int64
-	// materializationParser and materializationSource back the compact
-	// acceptance-election materiality gate (completeAcceptance ->
-	// compactAcceptanceElectionIsVacuous): when a certified primary
-	// derivation election has more than one live candidate, the gate
-	// re-materializes every candidate through the same public-tree pipeline
-	// the accepted parse itself uses, so it can require every candidate's
-	// tree to be byte-identical to the primary before admitting it. Both
-	// fields are set by the two production seed entry points
+	// materializationParser, materializationSource,
+	// materializationForceReplayParseStates, and materializationContextSet
+	// back the compact acceptance-election materiality gate
+	// (completeAcceptance -> compactAcceptanceElectionIsVacuous): when a
+	// certified primary derivation election has more than one live
+	// candidate, the gate re-materializes every candidate through the same
+	// public-tree pipeline the accepted parse itself uses, so it can require
+	// every candidate's tree to match the primary before admitting it.
+	//
+	// materializationForceReplayParseStates must match the value the
+	// caller's own post-acceptance materialization will use, not just be
+	// "some" value: it decides whether replayCompactDerivation stamps
+	// ParseState/PreGotoState on the materialized nodes at all, and the
+	// gate's comparator reads those stamps. A mismatched value would compare
+	// an attribute the published tree does not actually carry.
+	//
+	// All fields are set by the two production seed entry points
 	// (DiagnosticParseParserCorePrefix, parserCoreFreshFullRunner's
-	// executeSchedulerOpen) from the same Parser and source bytes those
-	// callers already hold. Nil/empty here (any other caller) makes the gate
-	// unable to prove vacuity, so it fails closed instead of guessing.
-	materializationParser *Parser
-	materializationSource []byte
+	// executeSchedulerOpen) from state those callers already hold:
+	// DiagnosticParseParserCorePrefix always forces false (its own
+	// materialization call does the same); executeSchedulerOpen forwards the
+	// runner's own replayParseStates field, which is true only for the
+	// admission-candidate route (admission_switch_candidate.go).
+	//
+	// materializationContextSet distinguishes "no caller has set this
+	// context" (fail closed: the gate cannot materialize at all) from "the
+	// caller set it, and the source legitimately empty" (a zero-length
+	// source is a normal, if degenerate, parse input) -- len(source) == 0
+	// alone cannot tell those apart.
+	materializationParser                 *Parser
+	materializationSource                 []byte
+	materializationForceReplayParseStates bool
+	materializationContextSet             bool
 }
 
 type DiagnosticParserCoreScannerCheckpoint struct {
@@ -801,6 +820,12 @@ func diagnosticParseParserCoreGenericFromSeed(
 ) (DiagnosticParserCorePrefixResult, error) {
 	options.materializationParser = parser
 	options.materializationSource = source
+	// The diagnostic prefix route's own post-acceptance materialization
+	// (below, and publishDiagnosticParserCoreGenericResult's callback) always
+	// forces false; match it so the gate compares the same ParseState/
+	// PreGotoState presence the published tree actually carries.
+	options.materializationForceReplayParseStates = false
+	options.materializationContextSet = true
 	scheduler, runErr := executeDiagnosticParserCoreGenericSchedulerFromSeed(
 		compact, tokenSource, scannerScratch, initialState, options, diagnosticParserCoreSeedObserver{},
 	)
@@ -4596,11 +4621,41 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 	// materializes to the identical tree (a vacuous election -- any pick is
 	// correct). len(paths) > 1 here means the tie guard, not the len(paths)
 	// == 1 fast path, selected primary, so every entry in paths is live.
-	if len(paths) > 1 && !compactAcceptanceElectionIsVacuous(
-		s.compact, s.options.materializationParser, s.options.materializationSource,
-		s.headers[0].head, paths, path,
-	) {
-		return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionMaterialDetail, 0)
+	//
+	// COST, stated plainly, not special-cased away: Apex's class_literal_alias
+	// witness ("Object t = RecordPage.class;", apexA3TiedElectionWitnesses,
+	// apex_a3_certification_sweep_test.go) was already in the certified sweep
+	// corpus before this gate existed, and on main its positional primary was
+	// the C-exact derivation while production diverged (a sanctioned
+	// adjudicated exception). This gate cannot tell that apart from a tied
+	// election where the primary is wrong: it declines class_literal_alias
+	// too, and the route now serves production's C-divergent tree instead of
+	// compact's C-exact one -- public output got worse on this one input.
+	// This is judged acceptable because it restores the pre-compact status
+	// quo (production already served every input before the compact route
+	// existed) and because the planned C-comparator port (R2) recovers it
+	// properly, by comparing error cost/dynamic precedence/structural order
+	// the way the C runtime does instead of requiring exact identity. It is
+	// not fixed by special-casing this witness.
+	if len(paths) > 1 {
+		if len(paths) > compactAcceptanceElectionMaxLiveDerivations {
+			// Observed live-derivation counts top out at 8 (bounded by
+			// MaxLinksPerBoundary); Limits.MaxDerivations itself allows up
+			// to 1<<16. Materializing and comparing every candidate up to
+			// that theoretical count is an unbounded-cost path with no
+			// observed witness anywhere near it, so decline outright above
+			// this cap rather than pay for a comparison this rare. Counted
+			// under the same material-acceptance-election census mechanism
+			// (admission_census.go), with a distinguishable detail string.
+			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionCandidateCapDetail, 0)
+		}
+		if !compactAcceptanceElectionIsVacuous(
+			s.compact, s.options.materializationParser, s.options.materializationSource,
+			s.options.materializationForceReplayParseStates, s.options.materializationContextSet,
+			s.headers[0].head, paths, path,
+		) {
+			return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionMaterialDetail, 0)
+		}
 	}
 	if core.Phase0AEnabled {
 		if err := core.RecordPhase0ADiagnosticAcceptedRoots(s.compact, path.Payloads); err != nil {
@@ -4703,16 +4758,58 @@ func compactDerivationsForAcceptance(compact *core.Core, head core.Head) ([]core
 // counted mechanism class this detail is matched into.
 const compactAcceptanceElectionMaterialDetail = "material-acceptance-election: certified primary derivation is not proven byte-identical to every tied secondary derivation"
 
+// compactAcceptanceElectionMaxLiveDerivations bounds how many live
+// derivations compactAcceptanceElectionIsVacuous will materialize and
+// compare. Observed live-derivation counts at a tied accepted head top out
+// at 8 (bounded in practice by MaxLinksPerBoundary); core.Limits.MaxDerivations
+// itself permits up to 1<<16 exact paths, so an adversarial or pathological
+// grammar/input combination could in principle present far more live
+// candidates than any witness measured so far. Materializing and comparing
+// every one of them is unbounded cost with no known witness anywhere near
+// this bound; completeAcceptance declines outright above it instead.
+const compactAcceptanceElectionMaxLiveDerivations = 8
+
+// compactAcceptanceElectionCandidateCapDetail is the counted decline reason
+// for a tied election whose live-derivation count exceeds
+// compactAcceptanceElectionMaxLiveDerivations. It is a distinct string from
+// compactAcceptanceElectionMaterialDetail (the gate never ran a comparison
+// here) but classifies under the same material-acceptance-election census
+// mechanism (admissionCensusClassify, admission_census.go), since both
+// outcomes share the same public contract: the route could not prove this
+// election vacuous, so it declines rather than guess.
+const compactAcceptanceElectionCandidateCapDetail = "material-acceptance-election: tied derivation count exceeds the materiality gate's comparison cap"
+
 // compactAcceptanceElectionIsVacuous decides whether every derivation in
 // paths materializes to the same public tree as the already-selected primary.
 // Called only when selectCompactAcceptanceDerivation has admitted primary
-// under its score-tie guard with more than one entry in paths, so every entry
-// is a live, score-tied-or-losing candidate -- exactly the shape the four A3
-// certified languages' own sweep corpora already satisfy on every witness
-// (every multi-derivation accept there is vacuous). A materialization failure
-// on any candidate (a cap, a tiling-gap decline, or any other error) is
-// treated as "not proven vacuous", matching the fail-closed contract every
-// other compact decline in this file uses: the route never guesses.
+// under its score-tie guard with 2 to compactAcceptanceElectionMaxLiveDerivations
+// entries in paths (completeAcceptance declines above the cap before ever
+// calling this function), so every entry is a live, score-tied-or-losing
+// candidate.
+//
+// This is NOT a property every multi-derivation accept in the certified
+// languages' own sweep corpora already had before this gate landed: Apex's
+// class_literal_alias witness (apexA3TiedElectionWitnesses,
+// apex_a3_certification_sweep_test.go) was already in that sweep corpus, and
+// its two derivations are not byte-identical -- one assigns an "object"
+// field the other does not. Before this gate, the route accepted it anyway
+// (the positional primary, which happened to be the byte-identical-to-C one
+// on this witness); this gate now declines it. See the cost note where
+// completeAcceptance calls this function for that specific regression.
+//
+// forceReplayParseStates must equal the value the caller's own
+// post-acceptance materialization will use (DiagnosticParserCorePrefixOptions
+// .materializationForceReplayParseStates): it decides whether the
+// materialized nodes carry ParseState/PreGotoState stamps at all, and this
+// function's contract is to compare what the published tree actually
+// carries, not some other configuration. contextSet distinguishes "no caller
+// provided a materialization context" (fail closed) from "the caller
+// provided one, and the source is legitimately empty".
+//
+// A materialization failure on any candidate (a cap, a tiling-gap decline,
+// or any other error) is treated as "not proven vacuous", matching the
+// fail-closed contract every other compact decline in this file uses: the
+// route never guesses.
 //
 // This redundantly re-materializes primary (once here for comparison, once
 // again by the caller's normal post-acceptance materialization). That cost
@@ -4720,12 +4817,13 @@ const compactAcceptanceElectionMaterialDetail = "material-acceptance-election: c
 // accept (the overwhelming majority) never reaches this function at all.
 func compactAcceptanceElectionIsVacuous(
 	compact *core.Core, parser *Parser, source []byte,
+	forceReplayParseStates bool, contextSet bool,
 	head core.Head, paths []core.Derivation, primary core.Derivation,
 ) bool {
 	if len(paths) < 2 {
 		return true
 	}
-	if compact == nil || parser == nil || len(source) == 0 {
+	if !contextSet || compact == nil || parser == nil {
 		return false
 	}
 	// allowErrorRoot is always false here (B3 stage S3, materializeDiagnosticParserCoreAcceptedSelection):
@@ -4733,8 +4831,10 @@ func compactAcceptanceElectionIsVacuous(
 	// candidate that needs allowErrorRoot=true to materialize is not
 	// something this gate is equipped to reason about -- it fails the trial
 	// materialization, which the fail-closed contract below already treats
-	// as "not proven vacuous".
-	primaryTree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, head, primary.Payloads, parser, source, nil, false, false)
+	// as "not proven vacuous". forceReplayParseStates is threaded through
+	// (not hardcoded) so the trial materialization matches the caller's own
+	// post-acceptance one -- see this function's doc comment.
+	primaryTree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, head, primary.Payloads, parser, source, nil, forceReplayParseStates, false)
 	if err != nil {
 		return false
 	}
@@ -4744,7 +4844,7 @@ func compactAcceptanceElectionIsVacuous(
 		if slices.Equal(candidate.Payloads, primary.Payloads) {
 			continue
 		}
-		candidateTree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, head, candidate.Payloads, parser, source, nil, false, false)
+		candidateTree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, head, candidate.Payloads, parser, source, nil, forceReplayParseStates, false)
 		if err != nil {
 			return false
 		}
@@ -4758,15 +4858,40 @@ func compactAcceptanceElectionIsVacuous(
 }
 
 // compactAcceptanceDerivationTreesEqual reports whether two materialized
-// derivation trees of the same accepted head are byte-identical: the same
-// node symbol, byte span, and named/extra/missing flags, the same field
-// assignment per child, and the same children, recursively. Field assignment
-// matters here even though it is invisible in an SExpr dump: a materiality
-// census that only compared SExpr text would miss a tied election where both
-// candidates share a symbol and shape but assign a field (for example
-// "object") on only one side. HasError is not compared separately -- it is a
-// pure function of the subtree below a node, so it is already implied once
-// every descendant symbol and shape matches.
+// derivation trees of the same accepted head publish the same PUBLIC tree
+// shape: the same node symbol, byte span, named/extra/missing flags, the
+// same field assignment per child, and the same children, recursively. This
+// is deliberately narrower than "identical in every internal attribute a
+// *Node carries" -- see the scope note below. Field assignment matters here
+// even though it is invisible in an SExpr dump: a materiality census that
+// only compared SExpr text would miss a tied election where both candidates
+// share a symbol and shape but assign a field (for example "object") on only
+// one side. HasError is not compared separately -- it is a pure function of
+// the subtree below a node, so it is already implied once every descendant
+// symbol and shape matches.
+//
+// Scope note (evaluated and rejected: ParseState, PreGotoState, the fragile
+// flag, and the external-scanner-token flag). All four are gotreesitter's
+// own internal construction bookkeeping, not part of the tree-sitter tree
+// shape the C oracle can be compared against -- the C runtime has no
+// equivalent of any of them. Adding any of the four to this comparator was
+// measured directly against the five R1 target languages' full sweep
+// corpora (perl, python, apex, ada, kotlin; certificates forced,
+// GTS_ADMISSION_CENSUS=1) and each one independently declines at least one
+// witness the pre-R1 election census had already proven vacuous (both
+// derivations publish byte-identical public trees): ParseState/PreGotoState
+// decline Perl push_two_args/push_three_args and Python assignment_bare_pair
+// (and 2-3 more per language); the fragile/external-scanner-token pair
+// declines Ada array_others_choice. In every measured case the two
+// derivations' PUBLIC trees remain identical; only the internal replay/
+// ambiguity bookkeeping differs. Comparing them would turn a correct,
+// C-exact accept into an unnecessary decline, so none of the four are
+// compared here. ParseState/PreGotoState trustworthiness for incremental
+// reuse is guarded separately and already, per materialized tree, by
+// incrementalReuseProven / Tree.incrementalReuseDisabled
+// (materializeDiagnosticParserCoreAcceptedSelection) -- that mechanism does
+// not depend on which of two shape-identical derivations was published, so
+// this gate does not need to duplicate it.
 func compactAcceptanceDerivationTreesEqual(lang *Language, a, b *Node) bool {
 	if a == nil || b == nil {
 		return a == b

--- a/parsercore_phase0_driver.go
+++ b/parsercore_phase0_driver.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"sort"
 
 	core "github.com/odvcencio/gotreesitter/internal/parsercorephase0"
@@ -102,6 +103,20 @@ type DiagnosticParserCorePrefixOptions struct {
 	// disables it, mirroring the production contract's own 0=off escape
 	// hatch.
 	stopControlHardCeilingBytes int64
+	// materializationParser and materializationSource back the compact
+	// acceptance-election materiality gate (completeAcceptance ->
+	// compactAcceptanceElectionIsVacuous): when a certified primary
+	// derivation election has more than one live candidate, the gate
+	// re-materializes every candidate through the same public-tree pipeline
+	// the accepted parse itself uses, so it can require every candidate's
+	// tree to be byte-identical to the primary before admitting it. Both
+	// fields are set by the two production seed entry points
+	// (DiagnosticParseParserCorePrefix, parserCoreFreshFullRunner's
+	// executeSchedulerOpen) from the same Parser and source bytes those
+	// callers already hold. Nil/empty here (any other caller) makes the gate
+	// unable to prove vacuity, so it fails closed instead of guessing.
+	materializationParser *Parser
+	materializationSource []byte
 }
 
 type DiagnosticParserCoreScannerCheckpoint struct {
@@ -784,6 +799,8 @@ func diagnosticParseParserCoreGenericFromSeed(
 	source []byte,
 	options DiagnosticParserCorePrefixOptions,
 ) (DiagnosticParserCorePrefixResult, error) {
+	options.materializationParser = parser
+	options.materializationSource = source
 	scheduler, runErr := executeDiagnosticParserCoreGenericSchedulerFromSeed(
 		compact, tokenSource, scannerScratch, initialState, options, diagnosticParserCoreSeedObserver{},
 	)
@@ -4573,6 +4590,18 @@ func (s *diagnosticParserCoreGenericScheduler) completeAcceptance() error {
 	if !selected {
 		return s.finish(DiagnosticParserCoreAccept, "generic scheduler requires one certified accepted derivation", 0)
 	}
+	// R1 materiality gate: selectCompactAcceptanceDerivation's tie guard has
+	// no C-faithful basis for choosing among score-tied derivations. It is
+	// only safe to admit the positional primary when every live derivation
+	// materializes to the identical tree (a vacuous election -- any pick is
+	// correct). len(paths) > 1 here means the tie guard, not the len(paths)
+	// == 1 fast path, selected primary, so every entry in paths is live.
+	if len(paths) > 1 && !compactAcceptanceElectionIsVacuous(
+		s.compact, s.options.materializationParser, s.options.materializationSource,
+		s.headers[0].head, paths, path,
+	) {
+		return s.finish(DiagnosticParserCoreAccept, compactAcceptanceElectionMaterialDetail, 0)
+	}
 	if core.Phase0AEnabled {
 		if err := core.RecordPhase0ADiagnosticAcceptedRoots(s.compact, path.Payloads); err != nil {
 			return err
@@ -4662,6 +4691,104 @@ func compactDerivationsForAcceptance(compact *core.Core, head core.Head) ([]core
 		return nil, &diagnosticParserCoreDecline{boundary: DiagnosticParserCoreAccept, detail: "accepted derivation enumeration cap"}
 	}
 	return paths, err
+}
+
+// compactAcceptanceElectionMaterialDetail is the counted decline reason FIX
+// R1 uses when a tied compact acceptance election is material: more than one
+// live derivation exists at the accepted head, and materializing every one of
+// them does not prove they all publish the same tree. The compact route has
+// no C-faithful tiebreak for this shape, so it declines instead of guessing
+// which derivation the locked C runtime would have picked; production still
+// serves the input. See admissionCensusClassify (admission_census.go) for the
+// counted mechanism class this detail is matched into.
+const compactAcceptanceElectionMaterialDetail = "material-acceptance-election: certified primary derivation is not proven byte-identical to every tied secondary derivation"
+
+// compactAcceptanceElectionIsVacuous decides whether every derivation in
+// paths materializes to the same public tree as the already-selected primary.
+// Called only when selectCompactAcceptanceDerivation has admitted primary
+// under its score-tie guard with more than one entry in paths, so every entry
+// is a live, score-tied-or-losing candidate -- exactly the shape the four A3
+// certified languages' own sweep corpora already satisfy on every witness
+// (every multi-derivation accept there is vacuous). A materialization failure
+// on any candidate (a cap, a tiling-gap decline, or any other error) is
+// treated as "not proven vacuous", matching the fail-closed contract every
+// other compact decline in this file uses: the route never guesses.
+//
+// This redundantly re-materializes primary (once here for comparison, once
+// again by the caller's normal post-acceptance materialization). That cost
+// lands only on multi-derivation accepts, which are rare; a sole-derivation
+// accept (the overwhelming majority) never reaches this function at all.
+func compactAcceptanceElectionIsVacuous(
+	compact *core.Core, parser *Parser, source []byte,
+	head core.Head, paths []core.Derivation, primary core.Derivation,
+) bool {
+	if len(paths) < 2 {
+		return true
+	}
+	if compact == nil || parser == nil || len(source) == 0 {
+		return false
+	}
+	// allowErrorRoot is always false here (B3 stage S3, materializeDiagnosticParserCoreAcceptedSelection):
+	// this gate only runs on a clean, non-recovery tied accept, and a
+	// candidate that needs allowErrorRoot=true to materialize is not
+	// something this gate is equipped to reason about -- it fails the trial
+	// materialization, which the fail-closed contract below already treats
+	// as "not proven vacuous".
+	primaryTree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, head, primary.Payloads, parser, source, nil, false, false)
+	if err != nil {
+		return false
+	}
+	defer primaryTree.Release()
+	primaryRoot := primaryTree.RootNode()
+	for _, candidate := range paths {
+		if slices.Equal(candidate.Payloads, primary.Payloads) {
+			continue
+		}
+		candidateTree, err := materializeDiagnosticParserCoreAcceptedSelection(compact, head, candidate.Payloads, parser, source, nil, false, false)
+		if err != nil {
+			return false
+		}
+		equal := compactAcceptanceDerivationTreesEqual(parser.language, primaryRoot, candidateTree.RootNode())
+		candidateTree.Release()
+		if !equal {
+			return false
+		}
+	}
+	return true
+}
+
+// compactAcceptanceDerivationTreesEqual reports whether two materialized
+// derivation trees of the same accepted head are byte-identical: the same
+// node symbol, byte span, and named/extra/missing flags, the same field
+// assignment per child, and the same children, recursively. Field assignment
+// matters here even though it is invisible in an SExpr dump: a materiality
+// census that only compared SExpr text would miss a tied election where both
+// candidates share a symbol and shape but assign a field (for example
+// "object") on only one side. HasError is not compared separately -- it is a
+// pure function of the subtree below a node, so it is already implied once
+// every descendant symbol and shape matches.
+func compactAcceptanceDerivationTreesEqual(lang *Language, a, b *Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Symbol() != b.Symbol() ||
+		a.StartByte() != b.StartByte() || a.EndByte() != b.EndByte() ||
+		a.IsNamed() != b.IsNamed() || a.IsExtra() != b.IsExtra() || a.IsMissing() != b.IsMissing() {
+		return false
+	}
+	childCount := a.ChildCount()
+	if childCount != b.ChildCount() {
+		return false
+	}
+	for i := 0; i < childCount; i++ {
+		if a.FieldNameForChild(i, lang) != b.FieldNameForChild(i, lang) {
+			return false
+		}
+		if !compactAcceptanceDerivationTreesEqual(lang, a.Child(i), b.Child(i)) {
+			return false
+		}
+	}
+	return true
 }
 
 // diagnosticParserCoreGenericNoActionDropEligible reports whether at least one

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -125,6 +125,11 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 		r.options.stopControlMemoryBudgetBytes = parseMemoryBudgetForParser(r.options.stopControlParser, len(source))
 		r.options.stopControlHardCeilingBytes = parseMemoryHardCeilingBytes()
 	}
+	// See DiagnosticParserCorePrefixOptions.materializationParser: this runner
+	// is reused across parses, so both fields are refreshed on every call
+	// rather than set once at construction.
+	r.options.materializationParser = r.parser
+	r.options.materializationSource = source
 	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 		&r.scheduler, compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
 		r.options, diagnosticParserCoreSeedObserver{},

--- a/parsercore_phase0_fresh_full_runner.go
+++ b/parsercore_phase0_fresh_full_runner.go
@@ -126,10 +126,32 @@ func (r *parserCoreFreshFullRunner) executeSchedulerOpen(source []byte, compact 
 		r.options.stopControlHardCeilingBytes = parseMemoryHardCeilingBytes()
 	}
 	// See DiagnosticParserCorePrefixOptions.materializationParser: this runner
-	// is reused across parses, so both fields are refreshed on every call
-	// rather than set once at construction.
+	// is reused across parses, so these fields are refreshed on every call
+	// rather than set once at construction. materializationForceReplayParseStates
+	// forwards r.replayParseStates itself (not a hardcoded value): it is true
+	// only for the admission-candidate route (newAdmissionCandidateRunner),
+	// so the gate's trial materializations carry the same ParseState/
+	// PreGotoState presence the caller's own post-acceptance materialization
+	// (materializeSelection, below) will publish.
 	r.options.materializationParser = r.parser
 	r.options.materializationSource = source
+	r.options.materializationForceReplayParseStates = r.replayParseStates
+	r.options.materializationContextSet = true
+	// The gate (completeAcceptance, run synchronously inside the call below)
+	// is the only reader of these fields, and it runs to completion before
+	// this function returns. Clear both this runner's own copy and the
+	// scheduler's copy (scheduler.options is a byte-for-byte struct copy
+	// taken inside the call, so it holds its own slice header aliasing the
+	// same backing array) on every exit path, so the cached, per-Parser
+	// runner does not pin the caller's source buffer between parses.
+	defer func() {
+		r.options.materializationParser = nil
+		r.options.materializationSource = nil
+		r.options.materializationContextSet = false
+		r.scheduler.options.materializationParser = nil
+		r.scheduler.options.materializationSource = nil
+		r.scheduler.options.materializationContextSet = false
+	}()
 	scheduler, err := executeDiagnosticParserCoreGenericSchedulerFromSeedInto(
 		&r.scheduler, compact, tokenSource, &r.scannerScratch, r.lang.InitialState,
 		r.options, diagnosticParserCoreSeedObserver{},


### PR DESCRIPTION
## Summary

The compact parser's acceptance-derivation election used a positional rule. When two derivations of an accepted parse tied on score, the rule published whichever derivation the parse table listed first.

That rule has no basis in the C runtime's own tie-break logic. It could publish a tree that diverges from the C oracle when the tied derivations differ from each other.

This PR gates multi-derivation acceptance elections on materialized-tree equality. When a tied election has more than one live derivation, the gate materializes every candidate through the same public-tree pipeline. It then compares the candidates on:

- node symbol
- byte span
- the named, extra, and missing flags
- the field name assigned to each child

The gate admits the primary derivation only when every candidate proves byte-identical to it on those axes. If any candidate differs, the compact route declines the parse and falls back to production.

This PR also tightens the certification-sweep acceptance criterion. The sweep now compares every accepted compact tree against the locked C oracle, with no exception. Before this change, the sweep checked the C oracle only when compact disagreed with production. A compact tree that reproduced a production-side C divergence used to pass the sweep uninspected.

This PR also makes missing-corpus degradation loud. A full-corpus sweep that cannot find its real-corpus fixture now skips with a stated reason. It no longer shrinks silently to a constructed-only run.

## Gate mechanism

- `compactAcceptanceElectionIsVacuous` (parsercore_phase0_driver.go): re-materializes the primary derivation and every other live candidate at a tied accepted head, up to a cap of 8 live derivations (see "Cost cap" below). It releases each trial tree after the comparison.
- `compactAcceptanceDerivationTreesEqual` (parsercore_phase0_driver.go): a recursive structural comparator over the public tree shape (symbol, byte span, the named/extra/missing flags, then each child's field name, then the children). It compares the PUBLIC tree shape specifically, not every internal attribute a node carries; see "Scope boundary" below for what it deliberately excludes and why.
- The comparator checks field assignment directly. Field assignment does not appear in an S-expression dump. One witness's two derivations both printed as `field_access(identifier, identifier)`; they differed only in an "object" field assigned on one side.
- `completeAcceptance` calls the gate right after `selectCompactAcceptanceDerivation`'s existing score-tie guard. A material (non-identical) election declines with a new counted reason, `material-acceptance-election`, classified in `admission_census.go`.
- Materialization context (`materializationParser`, `materializationSource`, `materializationForceReplayParseStates`, `materializationContextSet`) travels through `DiagnosticParserCorePrefixOptions`. Each production entry point sets it once per parse, then clears it on every exit path so the cached, per-Parser runner does not pin the caller's source buffer between parses.
- `materializationForceReplayParseStates` matches the value the caller's own post-acceptance materialization uses (true only for the admission-candidate route), so the gate's trial materializations carry the same ParseState/PreGotoState presence the published tree actually carries.
- `materializationContextSet` distinguishes "no caller provided a materialization context" from "the caller provided one, and the source is legitimately empty" -- an empty source alone cannot tell those two apart.
- A tied election reached with no materialization context set declines with its own detail string (`material-acceptance-election: materialization context unavailable; election cannot be proven vacuous`), distinct from the byte-identical-comparison-failed text, since no comparison actually ran in that case. Every real parse entry point sets the context before running the scheduler, so this is a fail-closed guard for a caller shape this PR's measurements never exercise, not an observed case in the certified sweep corpora.

### Cost cap

Observed live-derivation counts at a tied accepted head top out at 8 in every witness measured. `core.Limits.MaxDerivations` itself permits up to 65536 exact paths, so an adversarial or pathological input could in principle present far more live candidates than any witness seen so far. Materializing and comparing every one of them is unbounded cost with no known witness anywhere near this bound. `completeAcceptance` now declines outright above 8 live derivations, counted under the same `material-acceptance-election` mechanism with a distinguishable detail string.

### Scope boundary: what the comparator does not check, and why

Four additional node attributes were evaluated for inclusion and are not part of the comparator: `Node.ParseState()`, `Node.PreGotoState()`, the fragile flag, and the external-scanner-token flag. All four are gotreesitter's own internal construction bookkeeping; the C runtime has no equivalent of any of them, so comparing them does not serve this gate's purpose (proving the public tree shape is C-faithful).

Adding any of the four was measured directly against the five target languages' full sweep corpora (perl, python, apex, ada, kotlin; certificates forced, with the fine-grained decline classification enabled). Only ParseState/PreGotoState decline a source that was otherwise a clean, C-exact accept:

- ParseState/PreGotoState decline Perl's `push_two_args_real_corpus_witness`, `push_three_args`, and Python's `assignment_bare_tuple_real_corpus_witness`, `assignment_bare_pair`, `assignment_bare_single_trailing_comma` (5 sources). In every one, the two derivations' public trees are already byte-identical, so declining them is a pure, avoidable cost with no parity benefit. This is the entire measured cost of this scope boundary.

The other two measured effects are not an additional cost, because neither source involved was a clean pass to begin with:

- ParseState/PreGotoState also decline four sources that are already tracked, C-divergent accepts, not clean passes: Perl's `join_assignment`, `return_list`, and Python's `fstring_interpolation_bare_tuple`, `fstring_interpolation_splat`. Declining these buys nothing for parity -- production already carries the identical divergence -- but it is not an added cost either, since none of the four was C-exact to begin with.
- The fragile/external-scanner-token pair declines exactly one source, Ada's `array_others_choice` -- itself a tracked Family M divergence (see the known-divergence allowlist below), not a clean pass. This pair's measured effect is a wash: no fidelity change either way.

So the genuine, measured cost of adding any of the four attributes is confined to the five ParseState/PreGotoState witnesses named above; the other five affected sources cost nothing beyond what is already tracked. This PR does not add any of the four to the comparator. ParseState/PreGotoState trustworthiness for incremental reuse is guarded separately and already, per materialized tree, by the existing `incrementalReuseProven` / `Tree.incrementalReuseDisabled` mechanism, which does not depend on which of two shape-identical derivations was published.

**This was checked against the risk that aligning the replay-state setting alone could flip a currently-accepted vacuous election to material.** It does not: aligning `materializationForceReplayParseStates` by itself changes only whether ParseState/PreGotoState get computed on the trial materializations, not whether the comparator reads them. Verified directly: with the alignment fix applied and no comparator change, all five languages' sweep counts are unchanged from before the alignment fix. The regression appears only when the four attributes are added to the comparison, which this PR does not do.

### Known cost: Apex `class_literal_alias`

Before this gate existed, Apex's `class_literal_alias` witness (`Object t = RecordPage.class;`) was already in the certified sweep corpus. On `main`, its positional primary was the C-exact derivation while production diverged from C at two points (missing `object`/field-name assignments) -- a sanctioned adjudicated exception. This gate cannot tell that apart from a tied election where the primary is wrong: the witness's two derivations differ only in field assignment, so the gate declines it too, and the route now serves production's C-divergent tree instead of compact's C-exact one. Public output got worse on this one input.

This is judged acceptable because it restores the pre-compact-route status quo (production served every input before the compact route existed) and because a planned future change -- porting the full C acceptance comparator (error cost, then dynamic precedence, then structural tree order) instead of requiring exact identity -- recovers it properly. It is not fixed by special-casing this witness; the code comment at the gate call site states this cost directly.

## Sweep criterion finding

The old certification-sweep predicate accepted a source when compact matched production. It compared against the C oracle, and required an exact match, only when compact and production disagreed. A compact tree that reproduced production's own answer never touched the C oracle at all. A production-side C divergence that compact happened to inherit therefore passed the sweep silently.

The new predicate adjudicates every accepted compact tree against the C oracle, unconditionally. Production agreement now only labels the outcome: a clean pass when compact, production, and C all agree; an adjudicated exception (the existing sanctioned deviation) when compact matches C but production does not.

Running the tightened criterion surfaced 16 divergences that predate this PR and sit outside its scope. Each one reproduces with the compact route disabled entirely -- production alone produces the same divergence from the C oracle -- so the compact route only inherits what production already produces; it does not cause any of them. Verified directly: Perl's `join_assignment` diverges from the C oracle at the production level alone, checked with no compact route involved at all.

The 16 fall into two mechanism families of 8 sources each, both at the production route:

- **Field over-projection** (8 sources: 2 Python, 6 Ada): a materialization step re-attaches an inherited grammar field to a child that should not carry it in specific hidden-production shapes. The C runtime's own field-name resolution filters out exactly this case; production's heuristic over-applies it.
- **Conflict-derivation selection** (8 sources: 4 Perl, 2 Python, 1 Ada, 1 Kotlin): at a handful of grammar-declared ambiguous constructs (list-operator scope and bareword function calls in Perl, a `pattern_list`/`expression_list` choice in Python f-strings, a dynamic-precedence-decided constraint kind in Ada, a detached property getter in Kotlin), production's own conflict-resolution ladder picks a different branch than the C runtime's `ts_parser__select_tree` does.

Each of the 16 is enumerated explicitly in the sweep's own known-divergence list (see below), by witness name, the first divergent node's path, and the recorded Go/C values there -- not adjudicated away, tracked. None of the 16 is an election defect, and the materiality gate does not touch any of them (each of these sources has exactly one live derivation at its accepted head). These are flagged here for follow-up; this PR does not fix them.

## Known-divergence allowlist

Each of the four languages carrying a divergence now has an explicit, enumerated `<language>A3KnownDivergences` list in its sweep test file. Each entry names the witness, the exact first divergent node path, the recorded Go and C values there, and a mechanism-family tag. The sweep matches an observed divergence against this list by witness name AND exact first-divergence shape: a witness whose divergence has moved to a different node, or the same node with different values, is NOT a match and still fails the sweep as a new, unadjudicated divergence. A matched entry is counted separately (as a tracked divergence) and logged, but does not fail the sweep. Apex carries no entries: its sweep has zero divergences under the tightened criterion, both before and after this accounting change.

The stale claim in `admission_switch_a3_arm_noop_confirmation_test.go` ("found zero unadjudicated divergence") is corrected to state the true condition: zero divergences beyond the enumerated, tracked list.

## Corpus loud-fail convention

A missing `cgo_harness/corpus_real/<lang>` directory (a generated, gitignored fixture) used to make `a3LoadRealCorpusDir` return `nil` with no signal. A "full corpus" sweep would then run quietly on its constructed sources alone. Two sweeps, Python and Perl, call this loader. The other two, Apex and Ada, already document that they carry no real corpus and never call it.

The fix follows this package's existing convention for a claimed-scope test that cannot honor its claim on the current host (`parityRequireExhaustive`, `parity_cgo_test.go`): skip with a stated reason, rather than fail hard, since the real corpus is an optional, separately provisioned fixture. Every sweep, across all five languages, now logs its actual source denominator (`real=N constructed=M total=N+M`), whether or not the real corpus is present.

## Five-language sweep table

Run with certificates forced, `GTS_PARITY_ALLOW_HOST=1`, a local C-oracle build cache, `CGO_ENABLED=1`, tags `cgo treesitter_c_parity`:

| Language | Files | Accepted | Declined | Adjudicated | Tracked divergences | Unadjudicated divergences |
|---|---|---|---|---|---|---|
| Perl | 20 | 16 | 4 | 0 | 4 | 0 |
| Python | 29 | 29 | 0 | 0 | 4 | 0 |
| Apex | 25 | 21 | 4 | 0 | 0 | 0 |
| Ada | 23 | 20 | 3 | 0 | 7 | 0 |
| Kotlin (certificates forced, not landed) | 14 | 10 | 4 | 2 | 1 | 0 |

All five sweeps pass. Every material tied-election witness checked in this PR declines cleanly under the gate: Kotlin's `object_declaration` witness, Apex's `class_literal_alias` witness (with the cost noted above), and the three new off-corpus fixtures below. Kotlin's `platform_modifier_recovery` witness is an adjudicated exception: compact matches the C oracle and diverges from production. Kotlin's `annotated_declaration` derivation-coverage gap still declines, as expected -- it is a missing-derivation gap, not an election, and sits outside this PR's scope.

No accepted source in any language shows a compact tree that diverges from the C oracle for the election reason this PR addresses. Every tracked divergence listed above is a production-route defect the compact route only inherits, enumerated by witness and exact node, and does not fail the sweep. It needs its own follow-up per language; this PR does not fix it.

## Three new fixtures

Each fixture is now a permanent regression source in its language's constructed sweep corpus, with its C-oracle expectation documented in a code comment. All three decline under the gate -- a material election, not an accept-and-diverge:

- Perl `print $fh, "a", "b";` (`print_filehandle_list_material_election`). The C oracle picks the derivation with an `ambiguous_function_call_expression` at the top. The old positional primary picked the `list_expression`-topped derivation instead, matching production; both diverge from C. Declines under the gate.
- Apex `List<Account> a = [SELECT Id FROM Account];` (`soql_local_declaration_material_election`). The C oracle picks `local_variable_declaration`. The old positional primary picked `binary_expression`, matching production; both diverge from C. Declines (via a pre-existing, unrelated scheduler mechanism on this specific input; still a safe decline, not an accept).
- Ada `R := (F => 1, G => 2);` (`bare_aggregate_assignment_material_election`). The C oracle picks `record_aggregate`. The old positional primary picked `named_array_aggregate`, matching production; both diverge from C. Declines under the gate.

## Benchmark deltas

Benchmarks: `BenchmarkDiagnosticParserCoreWarmSchedulerOnlyQueryCompile`, `...MaterializationOnlyQueryCompile`, `...TotalQueryCompile`, and `BenchmarkAdmissionCandidateGoQueryCompileWarmRoute` (3 runs each, `-tags gts_parsercorephase0`).

Allocation counts and byte totals match exactly before and after this change: 208 B and 6 allocations for the scheduler-only path, 256-258 B and 7 allocations for the materialization-only path. Timing sits inside the same noise band as `main` on this host. The `query_compile` canonical fixture has no multi-derivation ties, so the gate's extra materialization never runs on it. The measured cost is zero, matching expectations, since the gate only runs on rare multi-derivation accepts.

## Gates

- `go test .`: green.
- `go test ./grammars`: green.
- Admission scorecard ratchet: green, with one intentional, documented update carried from the prior revision. Meson's smoke sample (`message('hello')`) carries a genuine, score-tied ambiguity between two distinct grammar symbols, `variableunit` and `var_unit`. The old rule published whichever one happened to match production; the gate now declines it, since it cannot prove either candidate correct. `minPass` moves from 200 to 199 and `maxFallback` moves from 1 to 2. The total count (206), the skip count (5), and the diverge count (0) do not change. No other language in the 206-language scorecard changes status.
- W5 editor-latency gates: green.
- Canonical tree digests: unchanged (`TestDiagnosticParserCoreCanonicalAdmissions`, all four fixtures).
- Race mode on touched paths: green. A broader race sweep across admission, compact, A3, Kotlin, and Apex tests, plus the struct-layout receipt test, surfaces three failures unrelated to this PR: a struct-size receipt test expecting a 64-byte scheduler header (a sibling, already-merged change added an 8-byte field, growing it to 72, and did not update the receipt), and the same two pre-existing corpus-order failures noted in the previous revision (`TestAdmissionCandidateExactExternalPayloadCorpus/kotlin`, `TestAdmissionCandidateBoundedRecursiveInsertionCorpus/elixir,scala`). All three reproduce identically with this branch's changes removed, on the current `main`.
- Compact canonical benchmarks: inside the noise band of `main` (see above).

## Other fixes in this revision

- Route-counter assertion in the arm no-op test fixed to reject both the (0, 0) and (1, 1) outcomes (it previously only rejected (0, 0), reading as a `&&`/`||` mix-up).
- The Kotlin certification-withheld test now asserts the specific classified decline mechanism (`material-acceptance-election`) instead of a decline-reason substring shared by every soft decline; a tautological tree self-comparison in the same test is now labeled as a non-load-bearing sanity check rather than a correctness assertion.
- Added a direct unit test for `compactAcceptanceDerivationTreesEqual` (nil handling, reflexivity, symbol/span divergence, child-count divergence) and one covering all three census-classified decline details this gate can produce (comparison-failed, candidate-cap, no-context).
- The no-context branch (no caller set a materialization context) now declines with its own detail string instead of reusing the comparison-failed one, since no comparison actually ran there.

## Scope note

This PR does not change any certification flag in `grammars/runtime_profiles.go`. Kotlin's certification does not land here. The forced-certificate sweep above is a verification-only receipt.

Rebased onto `main` at `c1806563` (includes the native HTML strategy-2 recovery, skipped-gap materialization, and 64 KiB admission-eligibility removal changes). All conflicts were additive (new struct fields and new trailing function parameters on both sides); resolved by keeping both sides' additions.

