### PR TITLE
fix(forest): pin span-maximal link at hidden forest cap tie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ for tags and release notes while still in `0.x`.
 
 ### Fixed
 
+- The GSS-forest link cap could silently drop the widest hidden-symbol
+  alternative when it tied a narrower one on score and error cost.
+  The cap kept the earlier arrival by default in every tie.
+  json5's flat-array grammar shape hits this tie constantly on ordinary
+  input.
+  Other forest-default languages hit it rarely or not at all on their
+  current tables.
+  The cap now keeps the wider alternative when two links tie on the same
+  symbol and the same end byte.
+  A narrower-tie or cross-symbol tie keeps the prior behavior unchanged.
+  `Parser.ForestCapTieStats()` is a new method.
+  It reports how often the tie fires and how often the fix changes the
+  outcome.
+  Set `GOT_FOREST_CAP_TIE_DUMP=1` to also record a bounded per-decision
+  receipt list.
+
 - Corrected the root-cause comment on the javascript declared-conflict
   election witness test.
   `grammargen/lr.go` already retains the `labeled_statement`/`_property_name`

--- a/forest_cap_pinning_json5_test.go
+++ b/forest_cap_pinning_json5_test.go
@@ -1,0 +1,137 @@
+package gotreesitter_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+// TestForestCapTiePinningJSON5FlatArrayTreeParity is the shipped-table
+// regression guard for span-maximal pinning (glr_forest.go,
+// forestCapReplacementIndex / forestCapTiePinsCandidate).
+//
+// json5 is a shipped, default-on forest language whose flat-array grammar
+// shape fires the hidden-symbol cap-tie arm constantly -- unlike the
+// javascript repeated-top-level-item repro this feature's evidence base
+// used, which never ties on the shipped table. A 7-item array already
+// fires it (`[0,1,2,3,4,5,6]`, 15 bytes), and a large flat array fires it
+// tens of thousands of times. This test asserts the pin never changes the
+// observable tree (a full node-by-node fingerprint against a
+// forced-production parse of the identical source) across a range of N,
+// and it records CandidatesPinned so a future table resync that moves the
+// count is visible in this test's own log output rather than silently.
+func TestForestCapTiePinningJSON5FlatArrayTreeParity(t *testing.T) {
+	build := func(n int) []byte {
+		var b bytes.Buffer
+		b.WriteByte('[')
+		for i := 0; i < n; i++ {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			fmt.Fprintf(&b, "%d", i)
+		}
+		b.WriteByte(']')
+		return b.Bytes()
+	}
+	lang := grammars.Json5Language()
+	totalHidden, totalPinned, totalNodes := 0, 0, 0
+	for _, n := range []int{1, 5, 7, 8, 10, 20, 50, 100, 200, 400} {
+		src := build(n)
+
+		forestParser := gotreesitter.NewParser(lang)
+		forestTree, err := forestParser.Parse(src)
+		if err != nil || forestTree == nil {
+			t.Fatalf("N=%d: forest-routed parse failed: %v", n, err)
+		}
+		if !forestTree.UsedForestFastPath() {
+			t.Fatalf("N=%d: expected forest routing on the shipped json5 table", n)
+		}
+		stats := forestParser.ForestCapTieStats()
+		totalHidden += stats.HiddenTieDecisions
+		totalPinned += stats.CandidatesPinned
+
+		gotreesitter.SetGLRForestEnabled(false)
+		prodParser := gotreesitter.NewParser(lang)
+		prodTree, err := prodParser.Parse(src)
+		gotreesitter.SetGLRForestEnabled(true)
+		if err != nil || prodTree == nil {
+			t.Fatalf("N=%d: production parse failed: %v", n, err)
+		}
+
+		totalNodes += forestCapPinningJSON5FingerprintDiff(t, n, forestTree.RootNode(), prodTree.RootNode())
+		forestTree.Release()
+		prodTree.Release()
+	}
+	t.Logf("json5 flat-array N sweep: nodes_compared=%d HiddenTieDecisions=%d CandidatesPinned=%d", totalNodes, totalHidden, totalPinned)
+	if totalPinned == 0 {
+		t.Fatal("span-maximal pinning never fired on the json5 flat-array sweep; the shipped-table regression this test exists to catch would be invisible")
+	}
+}
+
+// TestForestCapTiePinningJSON5LargeArrayTreeParity is the same guard at the
+// scale the reviewer measured (~108KB, ~20000 items): a single large parse
+// with tens of thousands of cap-tie decisions in one pass.
+func TestForestCapTiePinningJSON5LargeArrayTreeParity(t *testing.T) {
+	var b bytes.Buffer
+	b.WriteByte('[')
+	for i := 0; i < 20000; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%d", i)
+	}
+	b.WriteByte(']')
+	src := b.Bytes()
+
+	lang := grammars.Json5Language()
+	forestParser := gotreesitter.NewParser(lang)
+	forestTree, err := forestParser.Parse(src)
+	if err != nil || forestTree == nil {
+		t.Fatalf("forest-routed parse failed: %v", err)
+	}
+	if !forestTree.UsedForestFastPath() {
+		t.Fatal("expected forest routing on the shipped json5 table for the large array")
+	}
+	stats := forestParser.ForestCapTieStats()
+
+	gotreesitter.SetGLRForestEnabled(false)
+	prodParser := gotreesitter.NewParser(lang)
+	prodTree, err := prodParser.Parse(src)
+	gotreesitter.SetGLRForestEnabled(true)
+	if err != nil || prodTree == nil {
+		t.Fatalf("production parse failed: %v", err)
+	}
+
+	nodes := forestCapPinningJSON5FingerprintDiff(t, len(src), forestTree.RootNode(), prodTree.RootNode())
+	t.Logf("json5 large array (%d bytes): nodes_compared=%d HiddenTieDecisions=%d CandidatesPinned=%d", len(src), nodes, stats.HiddenTieDecisions, stats.CandidatesPinned)
+	if stats.CandidatesPinned == 0 {
+		t.Fatal("span-maximal pinning never fired on the large json5 array; the scale this test exists to cover would be invisible")
+	}
+	forestTree.Release()
+	prodTree.Release()
+}
+
+func forestCapPinningJSON5FingerprintDiff(t *testing.T, n int, a, b *gotreesitter.Node) int {
+	t.Helper()
+	if (a == nil) != (b == nil) {
+		t.Fatalf("N=%d: nil mismatch: forest=%v production=%v", n, a == nil, b == nil)
+	}
+	if a == nil {
+		return 0
+	}
+	if a.Symbol() != b.Symbol() || a.StartByte() != b.StartByte() || a.EndByte() != b.EndByte() ||
+		a.IsNamed() != b.IsNamed() || a.IsExtra() != b.IsExtra() || a.IsMissing() != b.IsMissing() ||
+		a.HasError() != b.HasError() || a.ChildCount() != b.ChildCount() {
+		t.Fatalf("N=%d: node fingerprint diverged: forest={sym=%d start=%d end=%d named=%v extra=%v missing=%v err=%v children=%d} production={sym=%d start=%d end=%d named=%v extra=%v missing=%v err=%v children=%d}",
+			n, a.Symbol(), a.StartByte(), a.EndByte(), a.IsNamed(), a.IsExtra(), a.IsMissing(), a.HasError(), a.ChildCount(),
+			b.Symbol(), b.StartByte(), b.EndByte(), b.IsNamed(), b.IsExtra(), b.IsMissing(), b.HasError(), b.ChildCount())
+	}
+	count := 1
+	for i := 0; i < a.ChildCount(); i++ {
+		count += forestCapPinningJSON5FingerprintDiff(t, n, a.Child(i), b.Child(i))
+	}
+	return count
+}

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -606,6 +606,13 @@ func automaticForestMemoryBudget(p *Parser, operationBudget int64) int64 {
 // off by default so the production path is unchanged until per-language corpus
 // parity is verified and the gate is lifted.
 func (p *Parser) tryForestFastPath(source []byte) *Tree {
+	// Reset first, before any early-return decline path below (included
+	// ranges, the decline memo, the unary-wrapper-profile decline, ...):
+	// several of those return nil without ever reaching parseForest, whose
+	// own reset would otherwise be skipped, leaving a *reused* Parser's
+	// ForestCapTieStats reporting an earlier, unrelated parse's counts (see
+	// resetForestCapTieStats's doc comment).
+	p.resetForestCapTieStats()
 	if !glrForestEnabled || !parserWantsForest(p) {
 		return nil
 	}
@@ -1567,12 +1574,21 @@ func forestCapReplacementIndex(p *Parser, arena *nodeArena, node *gssForestNode,
 	if p != nil && arena != nil {
 		if same, idx := forestWorstSameRawBucketLink(p, arena, node, candidate); same {
 			if hiddenSym && candidate.errorCost == node.links[idx].errorCost && candidate.score == node.links[idx].score {
-				// Raw-shape-exact-equal implies span-equal (both the shaped
-				// and unshaped arms of forestRawStackEntriesExactEqualRec
-				// check start/end), so span-maximal pinning is always a
-				// no-op in this bucket; still recorded so the instrument's
-				// counts cover every hidden-tie decision, not only the ones
-				// pinning can act on.
+				// This bucket's candidate is raw-shape-exact-equal to
+				// node.links[idx] (forestWorstSameRawBucketLink), which is a
+				// stronger match than span-maximal pinning needs to act on,
+				// but it does not by itself prove the two share a span: the
+				// unshaped arm of forestRawStackEntriesExactEqualRec compares
+				// the entry's own start/end directly, but the shaped arm
+				// (forestRawShapesExactEqualRec) only walks CHILDREN's
+				// absolute spans, never the root shape's own -- a
+				// zero-child (epsilon) shape has no child comparison to
+				// constrain it. That gap does not matter here: this branch
+				// never calls forestCapTiePinsCandidate, so it stays exactly
+				// the legacy stable-incumbent behavior regardless of span,
+				// unaffected by span-maximal pinning either way. Still
+				// recorded so the instrument's counts cover every
+				// hidden-tie decision, not only the ones pinning can act on.
 				p.recordForestCapTie(candidate, &node.links[idx], false)
 				return idx, false
 			}
@@ -1605,29 +1621,45 @@ func forestCapReplacementIndex(p *Parser, arena *nodeArena, node *gssForestNode,
 // when candidate must survive over incumbent at a hidden-symbol cap tie
 // because candidate is the wider (more span-maximal) member of the pair.
 // Both links were coalesced at the same node, so subtree.endByte is
-// identical for both; "wider span" therefore reduces to "smaller
-// startByte". Scoped to one symbol group by design (Section 5's "each
-// symbol group") — a cross-symbol tie is left to the existing
-// stable-incumbent policy untouched.
+// expected to be identical for both; "wider span" then reduces to "smaller
+// startByte". That expectation is a measured fact about every table
+// exercised so far (12.5M coalesce calls, zero end mismatches), not a
+// structural guarantee: coalescing keys on parser input position, not
+// necessarily the visible node span (see the reduce-span comment a few
+// hundred lines below, "Coalescing tracks parser input position, not
+// necessarily the visible node span" — trimmed trailing delimiters are the
+// documented case where a node's own endByte can trail the stack position).
+// So this is a checked precondition, not an assumption: candidateEnd ==
+// incumbentEnd is required before "smaller start" is trusted to mean
+// "wider span". A future table that violates it simply leaves the tie at
+// the existing stable-incumbent policy (fail closed) instead of silently
+// misordering by a stale premise. Scoped to one symbol group by design
+// (Section 5's "each symbol group") — a cross-symbol tie is left to the
+// existing stable-incumbent policy untouched either way.
 func forestCapTiePinsCandidate(candidate, incumbent *gssLink) bool {
 	if candidate == nil || incumbent == nil ||
 		candidate.subtree.kind != stackEntryKindNode || candidate.subtree.node == nil ||
 		incumbent.subtree.kind != stackEntryKindNode || incumbent.subtree.node == nil {
 		return false
 	}
-	candidateSym, candidateStart, _ := entrySymSpan(candidate.subtree)
-	incumbentSym, incumbentStart, _ := entrySymSpan(incumbent.subtree)
-	return candidateSym == incumbentSym && candidateStart < incumbentStart
+	candidateSym, candidateStart, candidateEnd := entrySymSpan(candidate.subtree)
+	incumbentSym, incumbentStart, incumbentEnd := entrySymSpan(incumbent.subtree)
+	return candidateSym == incumbentSym && candidateEnd == incumbentEnd && candidateStart < incumbentStart
 }
 
-// forestCapTieDumpEnabled gates the receipt half of Stage 0's cap-event
-// instrument (spec.forest-coalescer-dedup-generalization.v1 Section 5): set
-// GOT_FOREST_CAP_TIE_DUMP=1 to record a bounded per-decision receipt for
-// every hidden-symbol cap tie, alongside the summary counts that
-// Parser.ForestCapTieStats always maintains. Off by default so the
-// instrument costs nothing beyond the boolean check in the common case.
-// Read fresh on every call (like rawShapeDiagEnabled) rather than latched
-// once at package init, so tests can toggle it with t.Setenv.
+// forestCapTieDumpEnabled reads whether the receipt half of Stage 0's
+// cap-event instrument is requested (spec.forest-coalescer-dedup-
+// generalization.v1 Section 5): GOT_FOREST_CAP_TIE_DUMP=1 records a bounded
+// per-decision receipt for every hidden-symbol cap tie, alongside the
+// summary counts that Parser.ForestCapTieStats always maintains. Not
+// latched at package init (unlike most GOT_* flags in this file) so tests
+// can toggle it with t.Setenv; instead resetForestCapTieStats reads it once
+// per parse and caches the result on Parser.forestCapTieDumpActive --
+// recordForestCapTie itself never calls this, it just reads that field. A
+// hot corpus (a single large JSON5 array can hit tens of thousands of
+// hidden-symbol cap ties in one parse) made a per-tie os.Getenv call a real
+// cost: os.Getenv takes an internal lock on the process environment on
+// every call, not a free boolean check.
 func forestCapTieDumpEnabled() bool {
 	return os.Getenv("GOT_FOREST_CAP_TIE_DUMP") == "1"
 }
@@ -1636,6 +1668,25 @@ func forestCapTieDumpEnabled() bool {
 // long fixture (e.g. the W5 137KB corpus) cannot grow the dump without
 // bound; the summary counts on ForestCapTieStats stay exact regardless.
 const forestCapTieReceiptLimit = 512
+
+// resetForestCapTieStats clears the cap-tie instrument for a new parse
+// attempt and re-latches Parser.forestCapTieDumpActive from the
+// environment, reading it once per parse instead of once per tie decision
+// (see forestCapTieDumpEnabled's doc comment for why that matters).
+// Preserves the Receipts slice's backing array (append reuses capacity)
+// rather than reallocating every parse. Called at the top of every forest
+// entry point (tryForestFastPath and parseForest) so
+// Parser.ForestCapTieStats() never returns a stale result left over from an
+// earlier call on the same *Parser -- including the paths that decline
+// before parseForest ever runs, such as an included-ranges parse
+// immediately after a forest-routed one on a reused Parser.
+func (p *Parser) resetForestCapTieStats() {
+	if p == nil {
+		return
+	}
+	p.forestCapTieStats = ForestCapTieStats{Receipts: p.forestCapTieStats.Receipts[:0]}
+	p.forestCapTieDumpActive = forestCapTieDumpEnabled()
+}
 
 // ForestCapTieStats is Stage 0's cap-event instrument: how many hidden-
 // symbol ties were decided at the forest link cap, how many span-maximal
@@ -1670,12 +1721,21 @@ type ForestCapTieReceipt struct {
 }
 
 // ForestCapTieStats returns Stage 0's cap-event counts recorded during the
-// most recent forest parse on this Parser.
+// most recent forest parse on this Parser. The returned Receipts slice is a
+// copy: the next parse on this same *Parser reuses forestCapTieStats.
+// Receipts' backing array (resetForestCapTieStats truncates it with [:0]
+// rather than reallocating), so a caller that held the previous slice
+// without copying would see its own already-returned receipts silently
+// rewritten by the next parse's recordForestCapTie appends.
 func (p *Parser) ForestCapTieStats() ForestCapTieStats {
 	if p == nil {
 		return ForestCapTieStats{}
 	}
-	return p.forestCapTieStats
+	stats := p.forestCapTieStats
+	if len(stats.Receipts) > 0 {
+		stats.Receipts = append([]ForestCapTieReceipt(nil), stats.Receipts...)
+	}
+	return stats
 }
 
 // recordForestCapTie updates the cap-tie instrument for one hidden-symbol
@@ -1701,7 +1761,7 @@ func (p *Parser) recordForestCapTie(candidate, incumbent *gssLink, kept bool) {
 	if sameSpan {
 		p.forestCapTieStats.SameSpanTies++
 	}
-	if !forestCapTieDumpEnabled() || len(p.forestCapTieStats.Receipts) >= forestCapTieReceiptLimit {
+	if !p.forestCapTieDumpActive || len(p.forestCapTieStats.Receipts) >= forestCapTieReceiptLimit {
 		return
 	}
 	p.forestCapTieStats.Receipts = append(p.forestCapTieStats.Receipts, ForestCapTieReceipt{
@@ -3137,7 +3197,7 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 	p.forestDeclineReason = ""
 	p.forestDeclineByte, p.forestDeclineSym = 0, 0
 	p.forestDeclineStates = p.forestDeclineStates[:0]
-	p.forestCapTieStats = ForestCapTieStats{Receipts: p.forestCapTieStats.Receipts[:0]}
+	p.resetForestCapTieStats()
 	progress := newParseProgressTelemetry(p, len(source), uint32(len(source)), time.Now())
 	if progress.enabled {
 		progress.emit(time.Now(), "forest_parse_begin", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")

--- a/glr_forest.go
+++ b/glr_forest.go
@@ -1542,6 +1542,23 @@ func forestCapReplacementIndex(p *Parser, arena *nodeArena, node *gssForestNode,
 	// unrelated), narrow it to the exact bucket the caller already found via
 	// forestWorstSameRawBucketLink (same raw shape) rather than the plain
 	// same-symbol/tied-score condition used here.
+	//
+	// Stage 0 span-maximal pinning
+	// (spec.forest-coalescer-dedup-generalization.v1 Section 5). The
+	// "keep the incumbent" arm below is exactly the drop-on-arrival defect
+	// the spec's evidence base identified: a REGENERATED javascript table's
+	// binary-repeat lowering mints one hidden link per bracketing split of a
+	// run of top-level items, forestMaxLinksPerNode=8 fills with narrow
+	// splits before the sole full-coverage split arrives, and this tie-as-
+	// no-op policy silently discards it (cedar-d, N=11). Two links coalesced
+	// at the SAME node always share subtree.endByte (both were just produced
+	// at this node's byteOffset), so the full-coverage split is always the
+	// smallest-startByte (widest-span) member of its symbol group.
+	// forestCapTiePinsCandidate keeps that member over a same-symbol tied
+	// sibling regardless of arrival order; every other tie (different
+	// symbol, or an exact span tie the proxy cannot break) is untouched —
+	// the cap itself is not raised, only which side of an already-arbitrary
+	// tie survives.
 	hiddenSym := false
 	if p != nil && p.language != nil && candidate.subtree.kind == stackEntryKindNode && candidate.subtree.node != nil {
 		esym, _, _ := entrySymSpan(candidate.subtree)
@@ -1550,6 +1567,13 @@ func forestCapReplacementIndex(p *Parser, arena *nodeArena, node *gssForestNode,
 	if p != nil && arena != nil {
 		if same, idx := forestWorstSameRawBucketLink(p, arena, node, candidate); same {
 			if hiddenSym && candidate.errorCost == node.links[idx].errorCost && candidate.score == node.links[idx].score {
+				// Raw-shape-exact-equal implies span-equal (both the shaped
+				// and unshaped arms of forestRawStackEntriesExactEqualRec
+				// check start/end), so span-maximal pinning is always a
+				// no-op in this bucket; still recorded so the instrument's
+				// counts cover every hidden-tie decision, not only the ones
+				// pinning can act on.
+				p.recordForestCapTie(candidate, &node.links[idx], false)
 				return idx, false
 			}
 			return idx, forestResultLinkCompare(p, arena, node, candidate, candidateOrder, &node.links[idx], idx) > 0
@@ -1567,9 +1591,140 @@ func forestCapReplacementIndex(p *Parser, arena *nodeArena, node *gssForestNode,
 	// of candidate — cache it the same way (see cachedWorstResidentLink).
 	worst := node.cachedWorstResidentLink(p, arena)
 	if hiddenSym && candidate.errorCost == node.links[worst].errorCost && candidate.score == node.links[worst].score {
+		if forestCapTiePinsCandidate(candidate, &node.links[worst]) {
+			p.recordForestCapTie(candidate, &node.links[worst], true)
+			return worst, true
+		}
+		p.recordForestCapTie(candidate, &node.links[worst], false)
 		return worst, false
 	}
 	return worst, forestResultLinkCompare(p, arena, node, candidate, candidateOrder, &node.links[worst], worst) > 0
+}
+
+// forestCapTiePinsCandidate is Stage 0's span-maximal pinning predicate: true
+// when candidate must survive over incumbent at a hidden-symbol cap tie
+// because candidate is the wider (more span-maximal) member of the pair.
+// Both links were coalesced at the same node, so subtree.endByte is
+// identical for both; "wider span" therefore reduces to "smaller
+// startByte". Scoped to one symbol group by design (Section 5's "each
+// symbol group") — a cross-symbol tie is left to the existing
+// stable-incumbent policy untouched.
+func forestCapTiePinsCandidate(candidate, incumbent *gssLink) bool {
+	if candidate == nil || incumbent == nil ||
+		candidate.subtree.kind != stackEntryKindNode || candidate.subtree.node == nil ||
+		incumbent.subtree.kind != stackEntryKindNode || incumbent.subtree.node == nil {
+		return false
+	}
+	candidateSym, candidateStart, _ := entrySymSpan(candidate.subtree)
+	incumbentSym, incumbentStart, _ := entrySymSpan(incumbent.subtree)
+	return candidateSym == incumbentSym && candidateStart < incumbentStart
+}
+
+// forestCapTieDumpEnabled gates the receipt half of Stage 0's cap-event
+// instrument (spec.forest-coalescer-dedup-generalization.v1 Section 5): set
+// GOT_FOREST_CAP_TIE_DUMP=1 to record a bounded per-decision receipt for
+// every hidden-symbol cap tie, alongside the summary counts that
+// Parser.ForestCapTieStats always maintains. Off by default so the
+// instrument costs nothing beyond the boolean check in the common case.
+// Read fresh on every call (like rawShapeDiagEnabled) rather than latched
+// once at package init, so tests can toggle it with t.Setenv.
+func forestCapTieDumpEnabled() bool {
+	return os.Getenv("GOT_FOREST_CAP_TIE_DUMP") == "1"
+}
+
+// forestCapTieReceiptLimit bounds the receipt list so a saturated node in a
+// long fixture (e.g. the W5 137KB corpus) cannot grow the dump without
+// bound; the summary counts on ForestCapTieStats stay exact regardless.
+const forestCapTieReceiptLimit = 512
+
+// ForestCapTieStats is Stage 0's cap-event instrument: how many hidden-
+// symbol ties were decided at the forest link cap, how many span-maximal
+// pinning kept over the arrival-order default, how many were themselves an
+// exact-span tie (the case the span-maximal proxy cannot break -- see the
+// spec's Open Questions), and, only when GOT_FOREST_CAP_TIE_DUMP=1, a
+// bounded per-decision receipt list. Valid after any Parse or
+// ParseForestExperimental call.
+type ForestCapTieStats struct {
+	HiddenTieDecisions int
+	CandidatesPinned   int
+	SameSpanTies       int
+	Receipts           []ForestCapTieReceipt
+}
+
+// ForestCapTieReceipt is one hidden-symbol cap-tie decision: (symbol, span,
+// prev.state, prev.byteOffset) for the arriving candidate and the incumbent
+// it was compared against, matching the spec Section 5 instrumentation
+// shape.
+type ForestCapTieReceipt struct {
+	Symbol             Symbol
+	CandidateStart     uint32
+	CandidateEnd       uint32
+	CandidatePrevState StateID
+	CandidatePrevByte  uint32
+	IncumbentStart     uint32
+	IncumbentEnd       uint32
+	IncumbentPrevState StateID
+	IncumbentPrevByte  uint32
+	SameSpan           bool
+	CandidateKept      bool
+}
+
+// ForestCapTieStats returns Stage 0's cap-event counts recorded during the
+// most recent forest parse on this Parser.
+func (p *Parser) ForestCapTieStats() ForestCapTieStats {
+	if p == nil {
+		return ForestCapTieStats{}
+	}
+	return p.forestCapTieStats
+}
+
+// recordForestCapTie updates the cap-tie instrument for one hidden-symbol
+// cap decision. kept reports whether span-maximal pinning overrode the
+// stable-incumbent default to keep candidate instead of incumbent. Every
+// production forest link is stackEntryKindNode with a non-nil node (every
+// coalesceForestWithRawAndAlternatives call site builds one that way), but
+// this stays defensive like forestCapTiePinsCandidate: decline to record
+// rather than reinterpret a non-Node subtree as one.
+func (p *Parser) recordForestCapTie(candidate, incumbent *gssLink, kept bool) {
+	if p == nil || candidate == nil || incumbent == nil ||
+		candidate.subtree.kind != stackEntryKindNode || candidate.subtree.node == nil ||
+		incumbent.subtree.kind != stackEntryKindNode || incumbent.subtree.node == nil {
+		return
+	}
+	csym, cstart, cend := entrySymSpan(candidate.subtree)
+	_, istart, iend := entrySymSpan(incumbent.subtree)
+	p.forestCapTieStats.HiddenTieDecisions++
+	if kept {
+		p.forestCapTieStats.CandidatesPinned++
+	}
+	sameSpan := cstart == istart && cend == iend
+	if sameSpan {
+		p.forestCapTieStats.SameSpanTies++
+	}
+	if !forestCapTieDumpEnabled() || len(p.forestCapTieStats.Receipts) >= forestCapTieReceiptLimit {
+		return
+	}
+	p.forestCapTieStats.Receipts = append(p.forestCapTieStats.Receipts, ForestCapTieReceipt{
+		Symbol: csym, CandidateStart: cstart, CandidateEnd: cend,
+		CandidatePrevState: forestLinkPrevState(candidate), CandidatePrevByte: forestLinkPrevByteOffset(candidate),
+		IncumbentStart: istart, IncumbentEnd: iend,
+		IncumbentPrevState: forestLinkPrevState(incumbent), IncumbentPrevByte: forestLinkPrevByteOffset(incumbent),
+		SameSpan: sameSpan, CandidateKept: kept,
+	})
+}
+
+func forestLinkPrevState(link *gssLink) StateID {
+	if link == nil || link.prev == nil {
+		return 0
+	}
+	return link.prev.state
+}
+
+func forestLinkPrevByteOffset(link *gssLink) uint32 {
+	if link == nil || link.prev == nil {
+		return 0
+	}
+	return link.prev.byteOffset
 }
 
 func forestWorstSameRawBucketLink(p *Parser, arena *nodeArena, node *gssForestNode, candidate *gssLink) (bool, int) {
@@ -2982,6 +3137,7 @@ func (p *Parser) parseForest(arena *nodeArena, source []byte, captureExternalChe
 	p.forestDeclineReason = ""
 	p.forestDeclineByte, p.forestDeclineSym = 0, 0
 	p.forestDeclineStates = p.forestDeclineStates[:0]
+	p.forestCapTieStats = ForestCapTieStats{Receipts: p.forestCapTieStats.Receipts[:0]}
 	progress := newParseProgressTelemetry(p, len(source), uint32(len(source)), time.Now())
 	if progress.enabled {
 		progress.emit(time.Now(), "forest_parse_begin", 0, 0, Token{}, false, nil, 0, 0, 0, true, 0, 0, "")

--- a/glr_forest_cap_pinning_test.go
+++ b/glr_forest_cap_pinning_test.go
@@ -1,0 +1,138 @@
+package gotreesitter
+
+import "testing"
+
+// Stage 0 of spec.forest-coalescer-dedup-generalization.v1: span-maximal
+// pinning at the forest link cap, plus the cap-event instrument that backs
+// it. The evidence base (cedar-d, N=11 on a regenerated javascript table) is
+// exactly the scenario built here: forestMaxLinksPerNode fills a coalesced
+// node with hidden, score/errorCost-tied links from different bracketing
+// splits of a repeated construct, and the sole full-coverage (widest-span)
+// split arrives last and used to be silently dropped by the pre-existing
+// stable-incumbent tie policy.
+
+// forestCapPinTestLanguage marks symbols 100 and 200 hidden (Visible=false)
+// so hiddenSym computation in forestCapReplacementIndex has real metadata to
+// read, matching a real Language rather than the "unknown language reads as
+// visible" case.
+func forestCapPinTestLanguage() *Language {
+	meta := make([]SymbolMetadata, 201)
+	meta[100] = SymbolMetadata{Name: "_hidden_a", Visible: false}
+	meta[200] = SymbolMetadata{Name: "_hidden_b", Visible: false}
+	return &Language{SymbolMetadata: meta}
+}
+
+// forestCapPinTestLink builds a gssLink whose subtree is a bare materialized
+// Node carrying exactly the (symbol, start, end) entrySymSpan reads, with a
+// prev node at (prevState, prevByte). No arena or raw shape is needed:
+// forestCapReplacementIndex's hidden-tie arms (and forestCapTiePinsCandidate)
+// only ever read entrySymSpan and the score/errorCost/prev fields directly.
+func forestCapPinTestLink(sym Symbol, start, end uint32, prevState StateID, prevByte uint32, score, errorCost int) gssLink {
+	node := &Node{symbol: sym, startByte: start, endByte: end}
+	prev := &gssForestNode{state: prevState, byteOffset: prevByte}
+	return gssLink{prev: prev, subtree: newStackEntryNode(0, node), score: score, errorCost: errorCost}
+}
+
+func TestForestCapTiePinsWiderArrivingHiddenCandidate(t *testing.T) {
+	p := &Parser{language: forestCapPinTestLanguage()}
+	// One resident: symbol 100, covers only the last split [7,10).
+	incumbent := forestCapPinTestLink(100, 7, 10, 5, 7, 0, 0)
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+
+	// The full-coverage split arrives late: same symbol, same score/errorCost,
+	// but covers the whole run [0,10) -- exactly cedar-d's N=11 shape.
+	candidate := forestCapPinTestLink(100, 0, 10, 1, 0, 0, 0)
+
+	idx, replace := forestCapReplacementIndex(p, nil, node, &candidate, 1)
+	if !replace || idx != 0 {
+		t.Fatalf("forestCapReplacementIndex(wider candidate) = (%d, %v), want (0, true) -- pinning must keep the span-maximal arriving candidate", idx, replace)
+	}
+
+	stats := p.ForestCapTieStats()
+	if stats.HiddenTieDecisions != 1 || stats.CandidatesPinned != 1 || stats.SameSpanTies != 0 {
+		t.Fatalf("ForestCapTieStats after pin = %+v, want HiddenTieDecisions=1 CandidatesPinned=1 SameSpanTies=0", stats)
+	}
+}
+
+func TestForestCapTieKeepsWiderIncumbentOnHiddenTie(t *testing.T) {
+	p := &Parser{language: forestCapPinTestLanguage()}
+	// Resident already holds the full-coverage split.
+	incumbent := forestCapPinTestLink(100, 0, 10, 1, 0, 0, 0)
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+
+	// A narrower, tied candidate arrives after it -- today's stable-incumbent
+	// policy already protects the wider resident, and pinning must leave that
+	// direction untouched (zero-delta: this is not the N=11 defect).
+	candidate := forestCapPinTestLink(100, 7, 10, 5, 7, 0, 0)
+
+	idx, replace := forestCapReplacementIndex(p, nil, node, &candidate, 1)
+	if replace || idx != 0 {
+		t.Fatalf("forestCapReplacementIndex(narrower candidate) = (%d, %v), want (0, false) -- must not evict an already wider-span incumbent", idx, replace)
+	}
+
+	stats := p.ForestCapTieStats()
+	if stats.HiddenTieDecisions != 1 || stats.CandidatesPinned != 0 {
+		t.Fatalf("ForestCapTieStats after protective no-op = %+v, want HiddenTieDecisions=1 CandidatesPinned=0", stats)
+	}
+}
+
+func TestForestCapTieLeavesExactSpanTieUnpinned(t *testing.T) {
+	p := &Parser{language: forestCapPinTestLanguage()}
+	incumbent := forestCapPinTestLink(100, 3, 10, 5, 7, 0, 0)
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+
+	// Same symbol, same span, same score/errorCost: the span-maximal proxy
+	// cannot distinguish these (open question in the spec), so behavior must
+	// stay exactly the legacy stable-incumbent no-op.
+	candidate := forestCapPinTestLink(100, 3, 10, 55, 70, 0, 0)
+
+	idx, replace := forestCapReplacementIndex(p, nil, node, &candidate, 1)
+	if replace || idx != 0 {
+		t.Fatalf("forestCapReplacementIndex(exact span tie) = (%d, %v), want (0, false)", idx, replace)
+	}
+
+	stats := p.ForestCapTieStats()
+	if stats.HiddenTieDecisions != 1 || stats.CandidatesPinned != 0 || stats.SameSpanTies != 1 {
+		t.Fatalf("ForestCapTieStats after exact-span tie = %+v, want HiddenTieDecisions=1 CandidatesPinned=0 SameSpanTies=1", stats)
+	}
+}
+
+func TestForestCapTieLeavesCrossSymbolTieUnpinned(t *testing.T) {
+	p := &Parser{language: forestCapPinTestLanguage()}
+	// Resident is symbol 200, narrower than the arriving symbol-100 candidate.
+	incumbent := forestCapPinTestLink(200, 7, 10, 5, 7, 0, 0)
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+
+	candidate := forestCapPinTestLink(100, 0, 10, 1, 0, 0, 0)
+
+	idx, replace := forestCapReplacementIndex(p, nil, node, &candidate, 1)
+	if replace || idx != 0 {
+		t.Fatalf("forestCapReplacementIndex(cross-symbol tie) = (%d, %v), want (0, false) -- pinning is scoped to one symbol group", idx, replace)
+	}
+}
+
+func TestForestCapTieReceiptsGatedByEnv(t *testing.T) {
+	p := &Parser{language: forestCapPinTestLanguage()}
+	incumbent := forestCapPinTestLink(100, 7, 10, 5, 7, 0, 0)
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+	candidate := forestCapPinTestLink(100, 0, 10, 1, 0, 0, 0)
+
+	if _, _ = forestCapReplacementIndex(p, nil, node, &candidate, 1); len(p.ForestCapTieStats().Receipts) != 0 {
+		t.Fatalf("receipts populated with GOT_FOREST_CAP_TIE_DUMP unset: %+v", p.ForestCapTieStats().Receipts)
+	}
+
+	t.Setenv("GOT_FOREST_CAP_TIE_DUMP", "1")
+	p2 := &Parser{language: forestCapPinTestLanguage()}
+	node2 := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+	if _, _ = forestCapReplacementIndex(p2, nil, node2, &candidate, 1); len(p2.ForestCapTieStats().Receipts) != 1 {
+		t.Fatalf("receipts with GOT_FOREST_CAP_TIE_DUMP=1: got %d, want 1", len(p2.ForestCapTieStats().Receipts))
+	}
+	receipt := p2.ForestCapTieStats().Receipts[0]
+	if receipt.Symbol != 100 || receipt.CandidateStart != 0 || receipt.CandidateEnd != 10 ||
+		receipt.CandidatePrevState != 1 || receipt.CandidatePrevByte != 0 ||
+		receipt.IncumbentStart != 7 || receipt.IncumbentEnd != 10 ||
+		receipt.IncumbentPrevState != 5 || receipt.IncumbentPrevByte != 7 ||
+		receipt.SameSpan || !receipt.CandidateKept {
+		t.Fatalf("receipt shape = %+v, want the candidate/incumbent (symbol,span,prev.state,prev.byteOffset) tuples", receipt)
+	}
+}

--- a/glr_forest_cap_pinning_test.go
+++ b/glr_forest_cap_pinning_test.go
@@ -111,18 +111,30 @@ func TestForestCapTieLeavesCrossSymbolTieUnpinned(t *testing.T) {
 	}
 }
 
+// TestForestCapTieReceiptsGatedByEnv is hermetic against an ambient
+// GOT_FOREST_CAP_TIE_DUMP in the test process's environment: it clears the
+// variable itself before relying on "unset" rather than assuming a clean
+// shell. forestCapReplacementIndex reads Parser.forestCapTieDumpActive, a
+// field latched once per parse by resetForestCapTieStats (production calls
+// it at the top of tryForestFastPath/parseForest); calling
+// resetForestCapTieStats directly after each t.Setenv mirrors that latch
+// for this unit test, which calls forestCapReplacementIndex directly and so
+// never goes through either of those entry points itself.
 func TestForestCapTieReceiptsGatedByEnv(t *testing.T) {
-	p := &Parser{language: forestCapPinTestLanguage()}
 	incumbent := forestCapPinTestLink(100, 7, 10, 5, 7, 0, 0)
-	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
 	candidate := forestCapPinTestLink(100, 0, 10, 1, 0, 0, 0)
 
+	t.Setenv("GOT_FOREST_CAP_TIE_DUMP", "")
+	p := &Parser{language: forestCapPinTestLanguage()}
+	p.resetForestCapTieStats()
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
 	if _, _ = forestCapReplacementIndex(p, nil, node, &candidate, 1); len(p.ForestCapTieStats().Receipts) != 0 {
 		t.Fatalf("receipts populated with GOT_FOREST_CAP_TIE_DUMP unset: %+v", p.ForestCapTieStats().Receipts)
 	}
 
 	t.Setenv("GOT_FOREST_CAP_TIE_DUMP", "1")
 	p2 := &Parser{language: forestCapPinTestLanguage()}
+	p2.resetForestCapTieStats()
 	node2 := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
 	if _, _ = forestCapReplacementIndex(p2, nil, node2, &candidate, 1); len(p2.ForestCapTieStats().Receipts) != 1 {
 		t.Fatalf("receipts with GOT_FOREST_CAP_TIE_DUMP=1: got %d, want 1", len(p2.ForestCapTieStats().Receipts))
@@ -134,5 +146,95 @@ func TestForestCapTieReceiptsGatedByEnv(t *testing.T) {
 		receipt.IncumbentPrevState != 5 || receipt.IncumbentPrevByte != 7 ||
 		receipt.SameSpan || !receipt.CandidateKept {
 		t.Fatalf("receipt shape = %+v, want the candidate/incumbent (symbol,span,prev.state,prev.byteOffset) tuples", receipt)
+	}
+}
+
+// TestForestCapTieReceiptsAreCopiedNotAliased guards ForestCapTieStats'
+// copy-on-return contract: the caller must be able to hold a returned
+// Receipts slice across a later parse on the same *Parser without it being
+// silently rewritten (resetForestCapTieStats truncates and reuses the same
+// backing array with [:0], not a fresh allocation, every parse).
+func TestForestCapTieReceiptsAreCopiedNotAliased(t *testing.T) {
+	t.Setenv("GOT_FOREST_CAP_TIE_DUMP", "1")
+	p := &Parser{language: forestCapPinTestLanguage()}
+	p.resetForestCapTieStats()
+	incumbent := forestCapPinTestLink(100, 7, 10, 5, 7, 0, 0)
+	candidate := forestCapPinTestLink(100, 0, 10, 1, 0, 0, 0)
+	node := &gssForestNode{state: 9, byteOffset: 10, links: []gssLink{incumbent}}
+	if _, _ = forestCapReplacementIndex(p, nil, node, &candidate, 1); len(p.ForestCapTieStats().Receipts) != 1 {
+		t.Fatal("setup did not record a receipt")
+	}
+	held := p.ForestCapTieStats().Receipts
+	heldSymbol := held[0].Symbol
+
+	// A later parse-equivalent reset + a differently-shaped tie must not
+	// mutate the slice the caller already holds.
+	p.resetForestCapTieStats()
+	incumbent2 := forestCapPinTestLink(200, 70, 100, 5, 70, 0, 0)
+	candidate2 := forestCapPinTestLink(200, 0, 100, 1, 0, 0, 0)
+	node2 := &gssForestNode{state: 9, byteOffset: 100, links: []gssLink{incumbent2}}
+	if _, _ = forestCapReplacementIndex(p, nil, node2, &candidate2, 1); len(p.ForestCapTieStats().Receipts) != 1 {
+		t.Fatal("second setup did not record a receipt")
+	}
+
+	if held[0].Symbol != heldSymbol {
+		t.Fatalf("held receipts slice was rewritten by a later parse: got symbol %d, want unchanged %d", held[0].Symbol, heldSymbol)
+	}
+}
+
+// TestForestCapTiePinsWiderCandidateAtFullCapMultiResidentNode exercises the
+// cap-full, multi-resident path for real: forestMaxLinksPerNode (8)
+// raw-shape-distinct hidden links, all score/errorCost-tied, built up
+// through the real insertion path (coalesceForestWithRaw) so
+// cachedWorstResidentLink actually scans multiple residents instead of the
+// trivial single-link node the other unit tests in this file use. A
+// still-wider candidate must win regardless of which specific resident
+// cachedWorstResidentLink's raw-shape/order tiebreak happens to pick as
+// "worst" -- the candidate's span (smaller start, same end) is wider than
+// every resident's, not merely the one selected.
+func TestForestCapTiePinsWiderCandidateAtFullCapMultiResidentNode(t *testing.T) {
+	var idx gssForestIndex
+	idx.init(0)
+	slab := &gssForestNodeSlab{}
+	arena := acquireNodeArena(arenaClassFull)
+	defer arena.Release()
+
+	p := &Parser{language: forestCapPinTestLanguage()}
+	makeEntry := func(childSym Symbol, prod uint16, start, end uint32) stackEntry {
+		child := newLeafNodeInArena(arena, childSym, true, start, end, Point{}, Point{})
+		parent := newParentNodeInArena(arena, 100, true, []*Node{child}, nil, 0)
+		parent.rawShape = p.captureRawShape(nil, arena, 100, prod, []stackEntry{newStackEntryNode(StateID(childSym), child)}, 0, 1)
+		return newStackEntryNode(100, parent)
+	}
+
+	var node *gssForestNode
+	for i := 0; i < forestMaxLinksPerNode; i++ {
+		start := uint32(200 - 10*(i+1))
+		prev := &gssForestNode{state: StateID(i + 1), byteOffset: start}
+		entry := makeEntry(Symbol(300+i), uint16(i+1), start, 200)
+		node = coalesceForestWithRaw(p, arena, &idx, slab, 5, 200, prev, entry, 0, 0)
+	}
+	if len(node.links) != forestMaxLinksPerNode {
+		t.Fatalf("setup links = %d, want %d", len(node.links), forestMaxLinksPerNode)
+	}
+
+	widePrev := &gssForestNode{state: 99, byteOffset: 10}
+	wideEntry := makeEntry(999, 99, 10, 200)
+	node = coalesceForestWithRaw(p, arena, &idx, slab, 5, 200, widePrev, wideEntry, 0, 0)
+
+	if len(node.links) != forestMaxLinksPerNode {
+		t.Fatalf("links after cap = %d, want %d", len(node.links), forestMaxLinksPerNode)
+	}
+	found := false
+	for i := range node.links {
+		if node.links[i].subtree.node == wideEntry.node {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("span-maximal candidate was dropped at a full, multi-resident cap node instead of pinning")
+	}
+	if stats := p.ForestCapTieStats(); stats.CandidatesPinned == 0 {
+		t.Fatalf("ForestCapTieStats.CandidatesPinned = 0 after a full-cap multi-resident pin, want > 0 (stats=%+v)", stats)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -103,13 +103,23 @@ type Parser struct {
 	forestDeclineStates []StateID
 	// forestCapTieStats is Stage 0's cap-event instrument (see
 	// ForestCapTieStats and glr_forest.go's forestCapReplacementIndex):
-	// hidden-symbol cap-tie counts for the most recent forest parse, reset
-	// at the top of parseForest like the decline diagnostics above.
+	// hidden-symbol cap-tie counts for the most recent forest parse. Reset
+	// (along with forestCapTieDumpActive) by resetForestCapTieStats at the
+	// top of every forest entry point, not only the decline diagnostics'
+	// parseForest -- tryForestFastPath's early declines (included ranges,
+	// the decline memo, ...) never reach parseForest at all, and without
+	// their own reset a reused Parser would report a stale prior parse's
+	// counts for a call that did no forest work this time.
 	forestCapTieStats ForestCapTieStats
-	hasRecoverState   []bool
-	hasRecoverSymbol  []bool
-	recoverByState    [][]recoverSymbolAction
-	hasKeywordState   []bool
+	// forestCapTieDumpActive is GOT_FOREST_CAP_TIE_DUMP's value latched once
+	// per parse by resetForestCapTieStats; recordForestCapTie reads this
+	// field on every hidden-symbol cap tie instead of calling os.Getenv
+	// per-tie (see forestCapTieDumpEnabled's doc comment).
+	forestCapTieDumpActive bool
+	hasRecoverState        []bool
+	hasRecoverSymbol       []bool
+	recoverByState         [][]recoverSymbolAction
+	hasKeywordState        []bool
 	// lookupActionIndexFn caches the bound-method closure for
 	// lookupActionIndex. Passing p.lookupActionIndex directly at token-source
 	// construction sites allocates a fresh 16-byte closure per parse; the

--- a/parser.go
+++ b/parser.go
@@ -101,10 +101,15 @@ type Parser struct {
 	forestDeclineSym    Symbol
 	forestDeclineReason string
 	forestDeclineStates []StateID
-	hasRecoverState     []bool
-	hasRecoverSymbol    []bool
-	recoverByState      [][]recoverSymbolAction
-	hasKeywordState     []bool
+	// forestCapTieStats is Stage 0's cap-event instrument (see
+	// ForestCapTieStats and glr_forest.go's forestCapReplacementIndex):
+	// hidden-symbol cap-tie counts for the most recent forest parse, reset
+	// at the top of parseForest like the decline diagnostics above.
+	forestCapTieStats ForestCapTieStats
+	hasRecoverState   []bool
+	hasRecoverSymbol  []bool
+	recoverByState    [][]recoverSymbolAction
+	hasKeywordState   []bool
 	// lookupActionIndexFn caches the bound-method closure for
 	// lookupActionIndex. Passing p.lookupActionIndex directly at token-source
 	// construction sites allocates a fresh 16-byte closure per parse; the


### PR DESCRIPTION
## Summary

This change fixes a coverage cliff in the GSS-forest GLR fast path. The fast path builds one link per bracketing split of a repeated construct. A per-node link cap (`forestMaxLinksPerNode = 8`) can fill with narrow splits before the full-coverage split arrives. The prior tie policy then discards the late-arriving full-coverage split, and the parse falls back to the production engine for the whole file.

This change pins the wider (span-maximal) alternative at a hidden-symbol cap tie, so the full-coverage split survives regardless of arrival order. The cap does not change. Only the choice of which tied link survives changes.

json5 is a shipped, default-on forest language whose flat-array grammar shape fires this tie constantly on ordinary input (see Validation). The pin is tree-invariant everywhere it has been checked: it changes which internal hidden link a node keeps, never the observable tree.

## Mechanism

At a forest link cap decision, two hidden-symbol links can tie on score and error cost. The prior policy always kept the earlier arrival (a stable no-op). The new policy compares span width first. Both links are expected to end at the same byte offset, because the forest coalesces them at the same node; that expectation now is a checked precondition (`candidateEnd == incumbentEnd`), not an assumption, since a documented case elsewhere in the same file notes that coalescing keys on parser position, not always the visible node span. When the precondition holds, the link with the smaller start byte covers more of the input, and that link wins the tie.

A tie stays untouched in three cases:
- The two links carry different symbols.
- The two links do not share an end byte (the precondition above).
- The two links cover the exact same span.

All three keep the prior stable-incumbent behavior. This keeps the change scoped to the one drop pattern the evidence identifies, and it keeps every score-based (non-tied) decision exactly as it was.

The change also adds `Parser.ForestCapTieStats()`. It reports the count of hidden-symbol cap-tie decisions, how many pinning resolved in the candidate's favor, and how many were an exact-span tie the pinning heuristic cannot break. Set `GOT_FOREST_CAP_TIE_DUMP=1` to also collect a bounded per-decision receipt list: symbol, span, and predecessor state/byte offset for each side of the tie. The environment read happens once per parse, not once per tie; a large json5 array can hit tens of thousands of ties in a single parse.

## Validation

### json5 (shipped table, default-on)

json5's flat-array shape fires the tie arm from a 7-element array onward (`[0,1,2,3,4,5,6]`, 15 bytes). Two new tests parse a range of array sizes and a large (~109KB, ~20,000-element) array through the real `Parser.Parse` path, compare every node against a forced production-engine parse of the same source, and log the tie/pin counts:

| Corpus | Nodes compared | Hidden-symbol ties | Pins | Divergences |
|---|---|---|---|---|
| N sweep (1, 5, 7, 8, 10, 20, 50, 100, 200, 400 elements) | 1,632 | 762 | 715 | 0 |
| Large array (~109KB, 20,000 elements) | 40,003 | 19,996 | 19,989 | 0 |

Both tests fail if `CandidatesPinned` is ever zero, so a future table resync that stops exercising this path is caught, not silently invisible.

### javascript (regenerated table only; no blob in this PR)

Validation of the original N=11 defect used a freshly regenerated (unshipped) javascript grammar table that exhibits a wider fan-out on this specific corpus shape. No blob changed in this PR.

N-sweep, forest-fast-path routing by item count N (repeated top-level `let` statements):

| Table | Pinning | Result |
|---|---|---|
| Shipped (checked in) | n/a | Routes through the forest fast path for N=1-20; no cap tie ever fires on this corpus. |
| Regenerated | off (control) | Routes through N=1-10. Declines (`eof_no_root`) at N=11 and stays declined at every N checked through N=60. |
| Regenerated | on | Routes through N=1-20 and an extended sweep through N=400, with zero declines. Re-checked after the end-byte precondition landed: still zero declines. |

A node-by-node comparison of the forest-routed tree against a forced production-engine parse of the same source, N=1-30 on the regenerated table with pinning on, covered 3,285 nodes with zero differences.

### W5 137KB fixture, javascript

| Table | Pinning | Result |
|---|---|---|
| Shipped (checked in) | n/a | Gate passes (unaffected by this change). |
| Regenerated | off (control) | Gate fails: fresh-parse memory 153,270,136 bytes against a 72,941,568-byte ceiling; node count 92,506 against a 193,200 ceiling. |
| Regenerated | on | Gate fails identically: the same two numbers, unchanged. |

## What remains

The 137KB measurement shows this fix does not raise the effective cap; it only changes which link wins an existing tie. A grammar shape with a genuinely wide fan-out still exhausts the eight-link cap and declines, independent of pinning.

The tie javascript's regenerated table fires is an end-only tie, not a same-span tie (candidate and incumbent share an end byte but differ on start byte). A later same-span deduplication mechanism (a shared cap slot for links that cover the identical byte range) would not by itself resolve that pattern, since the two competing links there cover different byte ranges. The two mechanisms are independent and both stay useful. Raising the effective cap for a genuinely wide fan-out needs the follow-on family-accounting design, tracked separately.

## Gates

- `go test . -count=1`: pass
- `go test ./grammars -count=1`: pass
- `go test . -race` on the touched forest paths (including the new json5 tests) and on the W5 gate: pass, no races (run as separate invocations; W5's own memory-ceiling checks are noisy under `-race` when bundled with other heavy tests in one process, independent of this change)
- Forest regen guard, all 11 forest-default languages, shipped blobs: pass; also re-checked against the regenerated javascript table
- Admission scorecard: exact match against the prior baseline (200 pass, 0 diverge, 1 fallback, 5 skip, 0 error; javascript digest identical)
- `gofmt` / `go vet`: clean
- Diff is confined to `glr_forest.go`, `parser.go`, one new and one modified test file, and a CHANGELOG entry; no blob or generated file changed
